### PR TITLE
feat: add lefthook branch protection

### DIFF
--- a/.lefthook/pre-commit/protect-branch.sh
+++ b/.lefthook/pre-commit/protect-branch.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+branch=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$branch" = "main" ] || echo "$branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "❌ Commit blocked: '$branch' は保護ブランチです。"
+  echo "   フィーチャーブランチを作成してからコミットしてください。"
+  echo "   例: git checkout -b feat/your-feature"
+  exit 1
+fi

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,4 @@
+pre-commit:
+  scripts:
+    "protect-branch.sh":
+      runner: bash


### PR DESCRIPTION
## Summary

- Add lefthook pre-commit hook to prevent direct commits on protected branches (`main`, `vX.X.X`)
- Forces feature branch workflow by blocking commits and showing guidance message

## Test plan

- [x] Commit on `v0.0.3` → blocked
- [x] Commit on `v0.0.4` → blocked
- [x] Commit on `feat/*` → allowed