### PR TITLE
fix: prevent duplicate CI runs on PR pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: ['**']
+    branches: [main, 'v[0-9]*']
     tags-ignore: ['**']
 
 jobs:


### PR DESCRIPTION
## Summary
- `push` トリガーのブランチを `branches: ['**']` から `branches: [main, 'v[0-9]*']` に限定
- PRブランチへのプッシュ時に `pull_request` と `push` の両方が発火して CI が2回実行される問題を修正

## 動作確認

| シナリオ | トリガー | 実行回数 |
|---|---|---|
| PR作成 | `pull_request` (opened) | 1回 |
| PR指摘修正プッシュ | `pull_request` (synchronize) | 1回 |
| mainへのマージ | `push` | 1回 |
| `v*` ブランチへの直接プッシュ | `push` | 1回 |