### PR TITLE
ci: add branch name validation for PRs targeting main

### DIFF
--- a/.github/workflows/enforce-branch-name.yml
+++ b/.github/workflows/enforce-branch-name.yml
@@ -1,0 +1,18 @@
+name: Enforce Branch Name
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-branch-name:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate source branch name
+        run: |
+          BRANCH="${{ github.head_ref }}"
+          if [[ ! "$BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Branch name '$BRANCH' does not match the required pattern vX.X.X (e.g., v0.0.3)"
+            exit 1
+          fi
+          echo "Branch name '$BRANCH' is valid."


### PR DESCRIPTION
## Summary

- `main` ブランチへのPRのソースブランチ名が `vX.X.X` 形式であることを検証する GitHub Actions ワークフローを追加
- パターンに一致しない場合は CI を失敗させ、リリースブランチ以外からの直接マージを防止

## Test plan

- [x] 正規表現が有効なブランチ名（`v0.0.3`, `v1.2.10`, `v10.20.30`）を許可することを確認
- [x] 正規表現が無効なブランチ名（`feat/something`, `main`, `v0.0.3-beta`, `v1.2`）を拒否することを確認