### PR TITLE
feat: add compound assignment operators, in/not in for list/map, and range() step

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@
 build/
 
 .DS_Store
+PLAN.md

--- a/docs/ja/reference/builtins.md
+++ b/docs/ja/reference/builtins.md
@@ -10,7 +10,7 @@
 |------|------|
 | `print(expr)` | 値を標準出力に表示 |
 | `len(x)` | リスト・マップ・セットの要素数、文字列の長さを返す |
-| `range(n)` / `range(start, end)` | 整数のリストを生成 |
+| `range(n)` / `range(start, end)` / `range(start, end, step)` | 整数のリストを生成 |
 
 ### Option
 
@@ -178,7 +178,7 @@ print(2 in s)     # false
 
 ## range
 
-**シグネチャ:** `range(n: int) -> List<int>` / `range(start: int, end: int) -> List<int>`
+**シグネチャ:** `range(n: int) -> List<int>` / `range(start: int, end: int) -> List<int>` / `range(start: int, end: int, step: int) -> List<int>`
 
 整数のリストを生成します。
 
@@ -186,10 +186,17 @@ print(2 in s)     # false
 |------|------------|
 | `range(n)` | `[0, 1, ..., n-1]` |
 | `range(start, end)` | `[start, start+1, ..., end-1]` |
+| `range(start, end, step)` | `[start, start+step, start+2*step, ...]` (`end` は含まない) |
+
+- `step > 0` の場合、`start` から昇順に `end` に向かって生成します。
+- `step < 0` の場合、`start` から降順に `end` に向かって生成します。
+- `step == 0` の場合、ランタイムエラーになります。
 
 ```python
-print(range(3))       # [0, 1, 2]
-print(range(2, 5))    # [2, 3, 4]
+print(range(3))           # [0, 1, 2]
+print(range(2, 5))        # [2, 3, 4]
+print(range(0, 10, 2))    # [0, 2, 4, 6, 8]
+print(range(10, 0, -3))   # [10, 7, 4, 1]
 
 for i in range(3):
     print(i)

--- a/docs/ja/reference/control-flow.md
+++ b/docs/ja/reference/control-flow.md
@@ -98,6 +98,10 @@ for i in range(n):
 # range（開始・終了指定）
 for i in range(start, end):
     # i = start, start+1, ..., end-1
+
+# range（ステップ指定）
+for i in range(start, end, step):
+    # i = start, start+step, start+2*step, ...
 ```
 
 ### 例
@@ -116,6 +120,12 @@ for i in range(5):
 
 for i in range(2, 6):
     print(i)     # 2 3 4 5
+
+for i in range(0, 10, 2):
+    print(i)     # 0 2 4 6 8
+
+for i in range(10, 0, -3):
+    print(i)     # 10 7 4 1
 ```
 
 ---

--- a/docs/ja/reference/operators.md
+++ b/docs/ja/reference/operators.md
@@ -59,8 +59,9 @@ let s = "foo" + "bar"  # "foobar"
 
 - 数値型（int / float）とbool に対して使用可能。
 - `str` 同士は辞書順（バイト順）で比較。
-- `in` 演算子はセットに対する所属チェックに使用（`x in s`）。
+- `in` 演算子はセット、リスト、マップに対する所属チェックに使用（`x in s`）。
 - `not in` 演算子は `in` の否定（`x not in s`）。
+- マップの場合、`in` はキーの存在を確認します。
 
 ```python
 let x = 3 < 5       # true
@@ -68,6 +69,10 @@ let y = "abc" < "abd"  # true（辞書順）
 let s = {1, 2, 3}
 let z = 2 in s      # true
 let w = 4 not in s  # true
+let xs = [1, 2, 3]
+let a = 2 in xs     # true（リスト線形探索）
+let m = {"a": 1}
+let b = "a" in m    # true（マップキー検索）
 ```
 
 ## 論理演算子
@@ -115,9 +120,16 @@ let shifted = 1 << 8          # 256
 | `x *= y` | `x = x * y` |
 | `x /= y` | `x = x / y` |
 | `x %= y` | `x = x % y` |
+| `x //= y` | `x = x // y` |
+| `x **= y` | `x = x ** y` |
+| `x &= y` | `x = x & y` |
+| `x \|= y` | `x = x \| y` |
+| `x ^= y` | `x = x ^ y` |
+| `x <<= y` | `x = x << y` |
+| `x >>= y` | `x = x >> y` |
 
 ```python
-let x = 10
+var x = 10
 x += 5    # x = 15
 x -= 3    # x = 12
 x *= 2    # x = 24
@@ -138,8 +150,8 @@ x *= 2    # x = 24
 | `+` | str | str | str |
 | `== != < <= > >=` | 数値 / bool / str | 同型 | bool |
 | `*` | str | int | str |
-| `in` | 任意 | Set<T> | bool |
-| `not in` | 任意 | Set<T> | bool |
+| `in` | 任意 | Set<T> / List<T> / Map<K, V> | bool |
+| `not in` | 任意 | Set<T> / List<T> / Map<K, V> | bool |
 | `& \| ^ ~ << >> >>>` | int | int | int |
 | `and or not` | bool | bool | bool |
 

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -10,7 +10,7 @@
 |------|------|
 | `print(expr)` | Prints a value to standard output |
 | `len(x)` | Returns the number of elements in a list, map, or set, or the length of a string |
-| `range(n)` / `range(start, end)` | Generates a list of integers |
+| `range(n)` / `range(start, end)` / `range(start, end, step)` | Generates a list of integers |
 
 ### Option
 
@@ -178,7 +178,7 @@ print(2 in s)     # false
 
 ## range
 
-**Signature:** `range(n: int) -> List<int>` / `range(start: int, end: int) -> List<int>`
+**Signature:** `range(n: int) -> List<int>` / `range(start: int, end: int) -> List<int>` / `range(start: int, end: int, step: int) -> List<int>`
 
 Generates a list of integers.
 
@@ -186,10 +186,18 @@ Generates a list of integers.
 |------|------------|
 | `range(n)` | `[0, 1, ..., n-1]` |
 | `range(start, end)` | `[start, start+1, ..., end-1]` |
+| `range(start, end, step)` | `[start, start+step, start+2*step, ...]` (up to but not including `end`) |
+
+- When `step > 0`, generates values from `start` ascending toward `end`.
+- When `step < 0`, generates values from `start` descending toward `end`.
+- When `step == 0`, a runtime error occurs.
+- If the range is empty (e.g., `range(0, 10, -1)`), returns an empty list.
 
 ```python
-print(range(3))       # [0, 1, 2]
-print(range(2, 5))    # [2, 3, 4]
+print(range(3))           # [0, 1, 2]
+print(range(2, 5))        # [2, 3, 4]
+print(range(0, 10, 2))    # [0, 2, 4, 6, 8]
+print(range(10, 0, -3))   # [10, 7, 4, 1]
 
 for i in range(3):
     print(i)

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -98,6 +98,10 @@ for i in range(n):
 # range (with start and end)
 for i in range(start, end):
     # i = start, start+1, ..., end-1
+
+# range (with step)
+for i in range(start, end, step):
+    # i = start, start+step, start+2*step, ...
 ```
 
 ### Example
@@ -116,6 +120,12 @@ for i in range(5):
 
 for i in range(2, 6):
     print(i)     # 2 3 4 5
+
+for i in range(0, 10, 2):
+    print(i)     # 0 2 4 6 8
+
+for i in range(10, 0, -3):
+    print(i)     # 10 7 4 1
 ```
 
 ---

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -59,8 +59,9 @@ All return `bool`.
 
 - Can be used with numeric types (int / float) and bool.
 - `str` values are compared lexicographically (byte order).
-- The `in` operator is used for membership checks on sets (`x in s`).
+- The `in` operator is used for membership checks on sets, lists, and maps (`x in s`).
 - The `not in` operator is the negation of `in` (`x not in s`).
+- For maps, `in` checks whether the key exists.
 
 ```python
 let x = 3 < 5       # true
@@ -68,6 +69,10 @@ let y = "abc" < "abd"  # true (lexicographic)
 let s = {1, 2, 3}
 let z = 2 in s      # true
 let w = 4 not in s  # true
+let xs = [1, 2, 3]
+let a = 2 in xs     # true (list linear search)
+let m = {"a": 1}
+let b = "a" in m    # true (map key lookup)
 ```
 
 ## Logical Operators
@@ -115,12 +120,21 @@ Shorthand for updating a variable. `x op= y` is equivalent to `x = x op y`.
 | `x *= y` | `x = x * y` |
 | `x /= y` | `x = x / y` |
 | `x %= y` | `x = x % y` |
+| `x //= y` | `x = x // y` |
+| `x **= y` | `x = x ** y` |
+| `x &= y` | `x = x & y` |
+| `x \|= y` | `x = x \| y` |
+| `x ^= y` | `x = x ^ y` |
+| `x <<= y` | `x = x << y` |
+| `x >>= y` | `x = x >> y` |
 
 ```python
-let x = 10
+var x = 10
 x += 5    # x = 15
 x -= 3    # x = 12
 x *= 2    # x = 24
+x //= 3  # x = 8
+x &= 6   # x = 0
 ```
 
 ## Type Rules for Operations
@@ -138,8 +152,8 @@ x *= 2    # x = 24
 | `+` | str | str | str |
 | `== != < <= > >=` | numeric / bool / str | same type | bool |
 | `*` | str | int | str |
-| `in` | any | Set<T> | bool |
-| `not in` | any | Set<T> | bool |
+| `in` | any | Set<T> / List<T> / Map<K, V> | bool |
+| `not in` | any | Set<T> / List<T> / Map<K, V> | bool |
 | `& \| ^ ~ << >> >>>` | int | int | int |
 | `and or not` | bool | bool | bool |
 

--- a/docs/zh/reference/builtins.md
+++ b/docs/zh/reference/builtins.md
@@ -10,7 +10,7 @@
 |------|------|
 | `print(expr)` | 將值輸出到標準輸出 |
 | `len(x)` | 回傳串列、映射、集合的元素數量，或字串的長度 |
-| `range(n)` / `range(start, end)` | 生成整數串列 |
+| `range(n)` / `range(start, end)` / `range(start, end, step)` | 生成整數串列 |
 
 ### Option
 
@@ -178,7 +178,7 @@ print(2 in s)     # false
 
 ## range
 
-**簽名：** `range(n: int) -> List<int>` / `range(start: int, end: int) -> List<int>`
+**簽名：** `range(n: int) -> List<int>` / `range(start: int, end: int) -> List<int>` / `range(start: int, end: int, step: int) -> List<int>`
 
 生成整數串列。
 
@@ -186,10 +186,17 @@ print(2 in s)     # false
 |------|------------|
 | `range(n)` | `[0, 1, ..., n-1]` |
 | `range(start, end)` | `[start, start+1, ..., end-1]` |
+| `range(start, end, step)` | `[start, start+step, start+2*step, ...]`（不包含 `end`） |
+
+- `step > 0` 時，從 `start` 向 `end` 遞增生成。
+- `step < 0` 時，從 `start` 向 `end` 遞減生成。
+- `step == 0` 時，會產生執行時錯誤。
 
 ```python
-print(range(3))       # [0, 1, 2]
-print(range(2, 5))    # [2, 3, 4]
+print(range(3))           # [0, 1, 2]
+print(range(2, 5))        # [2, 3, 4]
+print(range(0, 10, 2))    # [0, 2, 4, 6, 8]
+print(range(10, 0, -3))   # [10, 7, 4, 1]
 
 for i in range(3):
     print(i)

--- a/docs/zh/reference/control-flow.md
+++ b/docs/zh/reference/control-flow.md
@@ -98,6 +98,10 @@ for i in range(n):
 # range（指定起始與結束）
 for i in range(start, end):
     # i = start, start+1, ..., end-1
+
+# range（指定步長）
+for i in range(start, end, step):
+    # i = start, start+step, start+2*step, ...
 ```
 
 ### 範例
@@ -116,6 +120,12 @@ for i in range(5):
 
 for i in range(2, 6):
     print(i)     # 2 3 4 5
+
+for i in range(0, 10, 2):
+    print(i)     # 0 2 4 6 8
+
+for i in range(10, 0, -3):
+    print(i)     # 10 7 4 1
 ```
 
 ---

--- a/docs/zh/reference/operators.md
+++ b/docs/zh/reference/operators.md
@@ -59,8 +59,9 @@ let s = "foo" + "bar"  # "foobar"
 
 - 可用於數值型別（int / float）和 bool。
 - `str` 之間以字典序（位元組順序）比較。
-- `in` 運算子用於集合的歸屬檢查（`x in s`）。
+- `in` 運算子用於集合、串列、映射的歸屬檢查（`x in s`）。
 - `not in` 運算子為 `in` 的否定（`x not in s`）。
+- 對於映射，`in` 檢查鍵是否存在。
 
 ```python
 let x = 3 < 5       # true
@@ -68,6 +69,10 @@ let y = "abc" < "abd"  # true（字典序）
 let s = {1, 2, 3}
 let z = 2 in s      # true
 let w = 4 not in s  # true
+let xs = [1, 2, 3]
+let a = 2 in xs     # true（串列線性搜尋）
+let m = {"a": 1}
+let b = "a" in m    # true（映射鍵搜尋）
 ```
 
 ## 邏輯運算子
@@ -115,6 +120,13 @@ let shifted = 1 << 8          # 256
 | `x *= y` | `x = x * y` |
 | `x /= y` | `x = x / y` |
 | `x %= y` | `x = x % y` |
+| `x //= y` | `x = x // y` |
+| `x **= y` | `x = x ** y` |
+| `x &= y` | `x = x & y` |
+| `x \|= y` | `x = x \| y` |
+| `x ^= y` | `x = x ^ y` |
+| `x <<= y` | `x = x << y` |
+| `x >>= y` | `x = x >> y` |
 
 ```python
 let x = 10
@@ -138,8 +150,8 @@ x *= 2    # x = 24
 | `+` | str | str | str |
 | `== != < <= > >=` | 數值 / bool / str | 同型別 | bool |
 | `*` | str | int | str |
-| `in` | 任意 | Set<T> | bool |
-| `not in` | 任意 | Set<T> | bool |
+| `in` | 任意 | Set<T> / List<T> / Map<K, V> | bool |
+| `not in` | 任意 | Set<T> / List<T> / Map<K, V> | bool |
 | `& \| ^ ~ << >> >>>` | int | int | int |
 | `and or not` | bool | bool | bool |
 

--- a/include/ry/lexer.hpp
+++ b/include/ry/lexer.hpp
@@ -69,6 +69,13 @@ enum class TokenKind {
     StarEq,         // *=
     SlashEq,        // /=
     PercentEq,      // %=
+    SlashSlashEq,   // //=
+    StarStarEq,     // **=
+    AmpEq,          // &=
+    PipeEq,         // |=
+    CaretEq,        // ^=
+    LessLessEq,     // <<=
+    GreaterGreaterEq, // >>=
     // --- enum ---
     Enum,           // enum
     ColonColon,     // ::

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -4,25 +4,61 @@
 // ===== CallExpr =====
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
-    // range(n) or range(start, end) → List<int>
+    // range(n), range(start, end), or range(start, end, step) → List<int>
     if (e->callee == "range") {
-        if (e->args.size() < 1 || e->args.size() > 2)
-            throw std::runtime_error("range() takes 1 or 2 arguments");
+        if (e->args.size() < 1 || e->args.size() > 3)
+            throw std::runtime_error("range() takes 1, 2, or 3 arguments");
 
-        llvm::Value *start, *end;
+        llvm::Value *start, *end, *step;
+        llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
+        llvm::Value *one = llvm::ConstantInt::get(i64Ty_, 1);
+
         if (e->args.size() == 1) {
-            start = llvm::ConstantInt::get(i64Ty_, 0);
+            start = zero;
             end = emitExpr(*e->args[0]);
+            step = one;
+        } else if (e->args.size() == 2) {
+            start = emitExpr(*e->args[0]);
+            end = emitExpr(*e->args[1]);
+            step = one;
         } else {
             start = emitExpr(*e->args[0]);
             end = emitExpr(*e->args[1]);
+            step = emitExpr(*e->args[2]);
         }
 
-        // count = max(0, end - start)
-        llvm::Value *diff = builder_.CreateSub(end, start, "range_diff");
-        llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
-        llvm::Value *isPos = builder_.CreateICmpSGT(diff, zero, "is_pos");
-        llvm::Value *count = builder_.CreateSelect(isPos, diff, zero, "range_count");
+        // Runtime check: step == 0 → error
+        if (e->args.size() == 3) {
+            llvm::Value *stepZero = builder_.CreateICmpEQ(step, zero, "step_zero");
+            llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, "range.step_err", fn_);
+            llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "range.step_ok", fn_);
+            builder_.CreateCondBr(stepZero, errBB, okBB);
+            builder_.SetInsertPoint(errBB);
+            emitRuntimeError("runtime error: range() step must not be zero\n", ".range_step_err");
+            builder_.SetInsertPoint(okBB);
+        }
+
+        // Compute count based on step sign
+        // step > 0: count = max(0, (end - start + step - 1) / step)
+        // step < 0: count = max(0, (start - end + (-step) - 1) / (-step))
+        llvm::Value *stepPos = builder_.CreateICmpSGT(step, zero, "step_pos");
+
+        // Positive step case
+        llvm::Value *diffPos = builder_.CreateSub(end, start, "diff_pos");
+        llvm::Value *numPos = builder_.CreateAdd(diffPos, builder_.CreateSub(step, one, "step_m1"), "num_pos");
+        llvm::Value *countPos = builder_.CreateSDiv(numPos, step, "count_pos");
+        llvm::Value *countPosClamped = builder_.CreateSelect(
+            builder_.CreateICmpSGT(countPos, zero, "pos_gt0"), countPos, zero, "count_pos_c");
+
+        // Negative step case
+        llvm::Value *negStep = builder_.CreateNeg(step, "neg_step");
+        llvm::Value *diffNeg = builder_.CreateSub(start, end, "diff_neg");
+        llvm::Value *numNeg = builder_.CreateAdd(diffNeg, builder_.CreateSub(negStep, one, "negstep_m1"), "num_neg");
+        llvm::Value *countNeg = builder_.CreateSDiv(numNeg, negStep, "count_neg");
+        llvm::Value *countNegClamped = builder_.CreateSelect(
+            builder_.CreateICmpSGT(countNeg, zero, "neg_gt0"), countNeg, zero, "count_neg_c");
+
+        llvm::Value *count = builder_.CreateSelect(stepPos, countPosClamped, countNegClamped, "range_count");
 
         // Allocate list header
         llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
@@ -37,7 +73,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
         llvm::Value *dataSize = builder_.CreateMul(count, llvm::ConstantInt::get(i64Ty_, elemSize), "range_data_size");
         llvm::Value *dataPtr = builder_.CreateCall(mallocFn, {dataSize}, "range_data");
 
-        // Fill data with start..end using a loop
+        // Fill data with start, start+step, start+2*step, ... using a loop
         llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "range_i");
         builder_.CreateStore(zero, iVar);
 
@@ -54,10 +90,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
 
         builder_.SetInsertPoint(bodyBB);
         llvm::Value *iCur = builder_.CreateLoad(i64Ty_, iVar, "ri_cur");
-        llvm::Value *val = builder_.CreateAdd(start, iCur, "range_val");
+        llvm::Value *offset = builder_.CreateMul(iCur, step, "range_offset");
+        llvm::Value *val = builder_.CreateAdd(start, offset, "range_val");
         llvm::Value *elemPtr = builder_.CreateGEP(i64Ty_, dataPtr, {iCur}, "range_elem_ptr");
         builder_.CreateStore(val, elemPtr);
-        llvm::Value *iNext = builder_.CreateAdd(iCur, llvm::ConstantInt::get(i64Ty_, 1), "ri_next");
+        llvm::Value *iNext = builder_.CreateAdd(iCur, one, "ri_next");
         builder_.CreateStore(iNext, iVar);
         builder_.CreateBr(condBB);
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -346,20 +346,101 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
 }
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
-    // Handle 'in' / 'not in' operator: lhs in rhs (rhs is set)
+    // Handle 'in' / 'not in' operator: lhs in rhs (set, list, or map)
     if (e->op == "in" || e->op == "not in") {
         llvm::Value *elem = emitExpr(*e->lhs);
-        llvm::Value *setVal = emitExpr(*e->rhs);
-        llvm::Type *elemTy = getSetElementType(setVal);
-        if (!elemTy)
-            throw std::runtime_error("'" + e->op + "' operator requires a set on the right side");
-        if (elem->getType() != elemTy)
-            throw std::runtime_error("'" + e->op + "' operator: element type mismatch");
-        llvm::Value *idx = emitSetElementLookup(setVal, elem, elemTy);
-        llvm::Value *result = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "set_in");
-        if (e->op == "not in")
-            result = builder_.CreateNot(result, "set_not_in");
-        return result;
+        llvm::Value *container = emitExpr(*e->rhs);
+
+        // Try set
+        llvm::Type *setElemTy = getSetElementType(container);
+        if (setElemTy) {
+            if (elem->getType() != setElemTy)
+                throw std::runtime_error("'" + e->op + "' operator: element type mismatch");
+            llvm::Value *idx = emitSetElementLookup(container, elem, setElemTy);
+            llvm::Value *result = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "set_in");
+            if (e->op == "not in")
+                result = builder_.CreateNot(result, "set_not_in");
+            return result;
+        }
+
+        // Try map (key lookup)
+        llvm::Type *mapKeyTy = getMapKeyType(container);
+        if (mapKeyTy) {
+            if (elem->getType() != mapKeyTy)
+                throw std::runtime_error("'" + e->op + "' operator: key type mismatch");
+            llvm::Value *idx = emitMapKeyLookup(container, elem, mapKeyTy);
+            llvm::Value *result = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "map_in");
+            if (e->op == "not in")
+                result = builder_.CreateNot(result, "map_not_in");
+            return result;
+        }
+
+        // Try list (linear search)
+        llvm::Type *listElemTy = getListElementType(container);
+        if (listElemTy) {
+            if (elem->getType() != listElemTy)
+                throw std::runtime_error("'" + e->op + "' operator: element type mismatch");
+
+            // Linear search loop
+            llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, container, 0, "in_len_ptr");
+            llvm::Value *length = builder_.CreateLoad(i64Ty_, lenPtr, "in_length");
+            llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, container, 2, "in_data_ptr");
+            llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "in_data");
+
+            llvm::AllocaInst *foundVar = builder_.CreateAlloca(i1Ty_, nullptr, "in_found");
+            builder_.CreateStore(llvm::ConstantInt::get(i1Ty_, 0), foundVar);
+            llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "in_i");
+            builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+
+            llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "in.cond", fn_);
+            llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, "in.body", fn_);
+            llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "in.end", fn_);
+
+            builder_.CreateBr(condBB);
+            builder_.SetInsertPoint(condBB);
+            llvm::Value *iVal = builder_.CreateLoad(i64Ty_, iVar, "in_iv");
+            llvm::Value *cond = builder_.CreateICmpSLT(iVal, length, "in_cond");
+            builder_.CreateCondBr(cond, bodyBB, endBB);
+
+            builder_.SetInsertPoint(bodyBB);
+            llvm::Value *iCur = builder_.CreateLoad(i64Ty_, iVar, "in_ic");
+            llvm::Value *elemPtr = builder_.CreateGEP(listElemTy, dataPtr, {iCur}, "in_elem_ptr");
+            llvm::Value *listElem = builder_.CreateLoad(listElemTy, elemPtr, "in_elem");
+
+            llvm::Value *match;
+            if (listElemTy == ptrTy_) {
+                // String comparison
+                auto strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
+                auto strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+                llvm::Value *cmpResult = builder_.CreateCall(strcmpFn, {elem, listElem}, "in_strcmp");
+                match = builder_.CreateICmpEQ(cmpResult, llvm::ConstantInt::get(i32Ty_, 0), "in_match");
+            } else if (listElemTy->isDoubleTy()) {
+                match = builder_.CreateFCmpOEQ(elem, listElem, "in_match");
+            } else {
+                match = builder_.CreateICmpEQ(elem, listElem, "in_match");
+            }
+
+            llvm::BasicBlock *foundBB = llvm::BasicBlock::Create(*ctx_, "in.found", fn_);
+            llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, "in.next", fn_);
+            builder_.CreateCondBr(match, foundBB, nextBB);
+
+            builder_.SetInsertPoint(foundBB);
+            builder_.CreateStore(llvm::ConstantInt::get(i1Ty_, 1), foundVar);
+            builder_.CreateBr(endBB);
+
+            builder_.SetInsertPoint(nextBB);
+            llvm::Value *iNext = builder_.CreateAdd(iCur, llvm::ConstantInt::get(i64Ty_, 1), "in_next");
+            builder_.CreateStore(iNext, iVar);
+            builder_.CreateBr(condBB);
+
+            builder_.SetInsertPoint(endBB);
+            llvm::Value *result = builder_.CreateLoad(i1Ty_, foundVar, "in_result");
+            if (e->op == "not in")
+                result = builder_.CreateNot(result, "list_not_in");
+            return result;
+        }
+
+        throw std::runtime_error("'" + e->op + "' operator requires a set, list, or map on the right side");
     }
 
     llvm::Value *lhs = emitExpr(*e->lhs);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -128,7 +128,11 @@ Token Lexer::readToken() {
     if (c == '*') {
         ++pos_;
         if (pos_ < src_.size() && src_[pos_] == '*') {
-            ++pos_; return {TokenKind::StarStar, "**", line_};
+            ++pos_;
+            if (pos_ < src_.size() && src_[pos_] == '=') {
+                ++pos_; return {TokenKind::StarStarEq, "**=", line_};
+            }
+            return {TokenKind::StarStar, "**", line_};
         }
         if (pos_ < src_.size() && src_[pos_] == '=') {
             ++pos_; return {TokenKind::StarEq, "*=", line_};
@@ -138,7 +142,11 @@ Token Lexer::readToken() {
     if (c == '/') {
         ++pos_;
         if (pos_ < src_.size() && src_[pos_] == '/') {
-            ++pos_; return {TokenKind::SlashSlash, "//", line_};
+            ++pos_;
+            if (pos_ < src_.size() && src_[pos_] == '=') {
+                ++pos_; return {TokenKind::SlashSlashEq, "//=", line_};
+            }
+            return {TokenKind::SlashSlash, "//", line_};
         }
         if (pos_ < src_.size() && src_[pos_] == '=') {
             ++pos_; return {TokenKind::SlashEq, "/=", line_};
@@ -165,7 +173,11 @@ Token Lexer::readToken() {
     if (c == '<') {
         ++pos_;
         if (pos_ < src_.size() && src_[pos_] == '<') {
-            ++pos_; return {TokenKind::LessLess, "<<", line_};
+            ++pos_;
+            if (pos_ < src_.size() && src_[pos_] == '=') {
+                ++pos_; return {TokenKind::LessLessEq, "<<=", line_};
+            }
+            return {TokenKind::LessLess, "<<", line_};
         }
         if (pos_ < src_.size() && src_[pos_] == '=') {
             ++pos_; return {TokenKind::LessEq, "<=", line_};
@@ -179,6 +191,9 @@ Token Lexer::readToken() {
             if (pos_ < src_.size() && src_[pos_] == '>') {
                 ++pos_; return {TokenKind::GreaterGreaterGreater, ">>>", line_};
             }
+            if (pos_ < src_.size() && src_[pos_] == '=') {
+                ++pos_; return {TokenKind::GreaterGreaterEq, ">>=", line_};
+            }
             return {TokenKind::GreaterGreater, ">>", line_};
         }
         if (pos_ < src_.size() && src_[pos_] == '=') {
@@ -186,9 +201,27 @@ Token Lexer::readToken() {
         }
         return {TokenKind::Greater, ">", line_};
     }
-    if (c == '&') { ++pos_; return {TokenKind::Amp,   "&", line_}; }
-    if (c == '|') { ++pos_; return {TokenKind::Pipe,  "|", line_}; }
-    if (c == '^') { ++pos_; return {TokenKind::Caret, "^", line_}; }
+    if (c == '&') {
+        ++pos_;
+        if (pos_ < src_.size() && src_[pos_] == '=') {
+            ++pos_; return {TokenKind::AmpEq, "&=", line_};
+        }
+        return {TokenKind::Amp, "&", line_};
+    }
+    if (c == '|') {
+        ++pos_;
+        if (pos_ < src_.size() && src_[pos_] == '=') {
+            ++pos_; return {TokenKind::PipeEq, "|=", line_};
+        }
+        return {TokenKind::Pipe, "|", line_};
+    }
+    if (c == '^') {
+        ++pos_;
+        if (pos_ < src_.size() && src_[pos_] == '=') {
+            ++pos_; return {TokenKind::CaretEq, "^=", line_};
+        }
+        return {TokenKind::Caret, "^", line_};
+    }
     if (c == '~') { ++pos_; return {TokenKind::Tilde, "~", line_}; }
     if (c == ':') {
         ++pos_;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -322,10 +322,14 @@ StmtNode Parser::parseStatement() {
         return s;
     } else if (next.kind == TokenKind::PlusEq  || next.kind == TokenKind::MinusEq ||
                next.kind == TokenKind::StarEq  || next.kind == TokenKind::SlashEq ||
-               next.kind == TokenKind::PercentEq) {
+               next.kind == TokenKind::PercentEq ||
+               next.kind == TokenKind::SlashSlashEq || next.kind == TokenKind::StarStarEq ||
+               next.kind == TokenKind::AmpEq  || next.kind == TokenKind::PipeEq ||
+               next.kind == TokenKind::CaretEq ||
+               next.kind == TokenKind::LessLessEq || next.kind == TokenKind::GreaterGreaterEq) {
         // Compound assignment: desugar x += e → x = x + e
-        Token opTok = lex_.next(); // consume +=, -=, etc.
-        std::string op(1, opTok.value[0]); // extract "+" from "+="
+        Token opTok = lex_.next(); // consume +=, -=, //=, **=, etc.
+        std::string op = opTok.value.substr(0, opTok.value.size() - 1); // extract "//" from "//="
         ExprPtr rhs = parseLogicalOr();
         auto varRef = std::make_unique<ExprNode>();
         varRef->data = VariableExpr{first.value};
@@ -346,7 +350,7 @@ StmtNode Parser::parseStatement() {
         s.args = parseArgList();
         return s;
     }
-    parseError(next.line, "expected '=', '+=', '-=', '*=', '/=', '%=', '.', '[', or '(' after identifier");
+    parseError(next.line, "expected '=', '+=', '-=', '*=', '/=', '%=', '//=', '**=', '&=', '|=', '^=', '<<=', '>>=', '.', '[', or '(' after identifier");
 }
 
 // ===== A4: parseLetOrVar =====

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -1309,3 +1309,128 @@ TEST_F(CodeGenTest, SortLargerList) {
         "print(sort(xs))";
     EXPECT_EQ(runSource(src), "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]\n");
 }
+
+// ===== 複合代入演算子 (追加分) =====
+
+TEST_F(CodeGenTest, CompoundAssignFloorDiv) {
+    std::string src =
+        "var x = 7\n"
+        "x //= 2\n"
+        "print(x)";
+    EXPECT_EQ(runSource(src), "3\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignPower) {
+    std::string src =
+        "var x = 2.0\n"
+        "x **= 3.0\n"
+        "print(x)";
+    EXPECT_EQ(runSource(src), "8\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignBitAnd) {
+    std::string src =
+        "var x = 12\n"
+        "x &= 10\n"
+        "print(x)";
+    EXPECT_EQ(runSource(src), "8\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignBitOr) {
+    std::string src =
+        "var x = 12\n"
+        "x |= 3\n"
+        "print(x)";
+    EXPECT_EQ(runSource(src), "15\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignBitXor) {
+    std::string src =
+        "var x = 12\n"
+        "x ^= 10\n"
+        "print(x)";
+    EXPECT_EQ(runSource(src), "6\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignLeftShift) {
+    std::string src =
+        "var x = 1\n"
+        "x <<= 3\n"
+        "print(x)";
+    EXPECT_EQ(runSource(src), "8\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignRightShift) {
+    std::string src =
+        "var x = 16\n"
+        "x >>= 2\n"
+        "print(x)";
+    EXPECT_EQ(runSource(src), "4\n");
+}
+
+// ===== in / not in: List・Map対応 =====
+
+TEST_F(CodeGenTest, InListInt) {
+    EXPECT_EQ(runSource("print(2 in [1, 2, 3])"), "true\n");
+}
+
+TEST_F(CodeGenTest, InListIntFalse) {
+    EXPECT_EQ(runSource("print(4 in [1, 2, 3])"), "false\n");
+}
+
+TEST_F(CodeGenTest, InListStr) {
+    EXPECT_EQ(runSource("print(\"a\" in [\"a\", \"b\"])"), "true\n");
+}
+
+TEST_F(CodeGenTest, NotInList) {
+    EXPECT_EQ(runSource("print(4 not in [1, 2, 3])"), "true\n");
+}
+
+TEST_F(CodeGenTest, InMapKey) {
+    EXPECT_EQ(runSource("print(\"a\" in {\"a\": 1})"), "true\n");
+}
+
+TEST_F(CodeGenTest, InMapKeyFalse) {
+    EXPECT_EQ(runSource("print(\"c\" in {\"a\": 1})"), "false\n");
+}
+
+TEST_F(CodeGenTest, NotInMapKey) {
+    EXPECT_EQ(runSource("print(\"b\" not in {\"a\": 1})"), "true\n");
+}
+
+// ===== range() ステップ対応 =====
+
+TEST_F(CodeGenTest, RangeStep) {
+    std::string src =
+        "for i in range(0, 10, 2):\n"
+        "    print(i)";
+    EXPECT_EQ(runSource(src), "0\n2\n4\n6\n8\n");
+}
+
+TEST_F(CodeGenTest, RangeStepNegative) {
+    std::string src =
+        "for i in range(10, 0, -1):\n"
+        "    print(i)";
+    EXPECT_EQ(runSource(src), "10\n9\n8\n7\n6\n5\n4\n3\n2\n1\n");
+}
+
+TEST_F(CodeGenTest, RangeStepNegative3) {
+    std::string src =
+        "for i in range(10, 0, -3):\n"
+        "    print(i)";
+    EXPECT_EQ(runSource(src), "10\n7\n4\n1\n");
+}
+
+TEST_F(CodeGenTest, RangeStepEmpty) {
+    std::string src =
+        "for i in range(0, 10, -1):\n"
+        "    print(i)";
+    EXPECT_EQ(runSource(src), "");
+}
+
+TEST_F(CodeGenTest, RangeStepList) {
+    std::string src =
+        "let xs = range(0, 10, 3)\n"
+        "print(len(xs))";
+    EXPECT_EQ(runSource(src), "4\n");
+}

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -769,6 +769,86 @@ TEST(LexerTest, FStringEscapedBraces) {
 
 // ===== as / Ok / Err keywords =====
 
+// ===== Compound assignment tokens =====
+
+TEST(LexerTest, SlashSlashEqToken) {
+    auto toks = tokenize("//=");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::SlashSlashEq);
+    EXPECT_EQ(toks[0].value, "//=");
+}
+
+TEST(LexerTest, StarStarEqToken) {
+    auto toks = tokenize("**=");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::StarStarEq);
+    EXPECT_EQ(toks[0].value, "**=");
+}
+
+TEST(LexerTest, AmpEqToken) {
+    auto toks = tokenize("&=");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::AmpEq);
+    EXPECT_EQ(toks[0].value, "&=");
+}
+
+TEST(LexerTest, PipeEqToken) {
+    auto toks = tokenize("|=");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::PipeEq);
+    EXPECT_EQ(toks[0].value, "|=");
+}
+
+TEST(LexerTest, CaretEqToken) {
+    auto toks = tokenize("^=");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::CaretEq);
+    EXPECT_EQ(toks[0].value, "^=");
+}
+
+TEST(LexerTest, LessLessEqToken) {
+    auto toks = tokenize("<<=");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::LessLessEq);
+    EXPECT_EQ(toks[0].value, "<<=");
+}
+
+TEST(LexerTest, GreaterGreaterEqToken) {
+    auto toks = tokenize(">>=");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::GreaterGreaterEq);
+    EXPECT_EQ(toks[0].value, ">>=");
+}
+
+TEST(LexerTest, CompoundAssignDoesNotBreakExisting) {
+    // // is still //
+    auto toks1 = tokenize("//");
+    EXPECT_EQ(toks1[0].kind, TokenKind::SlashSlash);
+    // ** is still **
+    auto toks2 = tokenize("**");
+    EXPECT_EQ(toks2[0].kind, TokenKind::StarStar);
+    // & is still &
+    auto toks3 = tokenize("&");
+    EXPECT_EQ(toks3[0].kind, TokenKind::Amp);
+    // | is still |
+    auto toks4 = tokenize("|");
+    EXPECT_EQ(toks4[0].kind, TokenKind::Pipe);
+    // ^ is still ^
+    auto toks5 = tokenize("^");
+    EXPECT_EQ(toks5[0].kind, TokenKind::Caret);
+    // << is still <<
+    auto toks6 = tokenize("<<");
+    EXPECT_EQ(toks6[0].kind, TokenKind::LessLess);
+    // >> is still >>
+    auto toks7 = tokenize(">>");
+    EXPECT_EQ(toks7[0].kind, TokenKind::GreaterGreater);
+    // >>> is still >>>
+    auto toks8 = tokenize(">>>");
+    EXPECT_EQ(toks8[0].kind, TokenKind::GreaterGreaterGreater);
+}
+
+// ===== as / Ok / Err keywords =====
+
 TEST(LexerTest, KeywordAs) {
     auto toks = tokenize("as");
     ASSERT_EQ(toks.size(), 2u);


### PR DESCRIPTION
## Summary

- **Compound assignment operators**: Add `//=`, `**=`, `&=`, `|=`, `^=`, `<<=`, `>>=` (Lexer → Parser desugaring, same pattern as existing `+=` etc.)
- **`in`/`not in` for List and Map**: Extend membership operator from Set-only to also support List (linear search) and Map (key lookup)
- **`range(start, end, step)`**: Add 3-argument form with positive/negative step support, including step==0 runtime error check

## Test plan

- [x] 7 Lexer tests for new compound assignment tokens + regression test for existing tokens
- [x] 7 codegen tests for compound assignment (`//=`, `**=`, `&=`, `|=`, `^=`, `<<=`, `>>=`)
- [x] 7 codegen tests for `in`/`not in` on List and Map
- [x] 5 codegen tests for `range()` with step (positive, negative, empty, list)
- [x] All 732 existing + new tests pass
- [x] Docs updated (en/ja/zh) for operators, builtins, and control-flow