### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/enforce-branch-name.yml
+++ b/.github/workflows/enforce-branch-name.yml
@@ -1,4 +1,6 @@
 name: Enforce Branch Name
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/t0k0sh1/ry/security/code-scanning/5](https://github.com/t0k0sh1/ry/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block and restrict the `GITHUB_TOKEN` to the minimal required access. Since this workflow only reads context information (`github.head_ref`) and runs a local shell check, it does not need any write access and can safely use `contents: read` as a minimal, standard baseline.

The best way to fix this without changing functionality is to add a `permissions` block at the workflow root (so it applies to all jobs) directly under the `name:` line and before `on:`. For example, set:

```yaml
permissions:
  contents: read
```

This will ensure that the `GITHUB_TOKEN` has read‑only access to repository contents and no unnecessary write scopes, while preserving the current behavior of the job.

Concretely, in `.github/workflows/enforce-branch-name.yml`, add the `permissions` section after line 1 (`name: Enforce Branch Name`). No additional imports, methods, or other definitions are needed; this is purely a YAML configuration change to the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
