### PR TITLE
feat: add cleanup job for stale nightly prereleases

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -28,7 +28,8 @@ jobs:
   # アクティブブランチに対応しない古い nightly プレリリースを削除
   cleanup-stale-nightlies:
     needs: discover
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' && needs.discover.outputs.branches != '[]'
+    continue-on-error: true
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -39,7 +40,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ACTIVE_BRANCHES: ${{ needs.discover.outputs.branches }}
         run: |
-          gh release list --json tagName,isPrerelease -q \
+          gh release list --limit 1000 --json tagName,isPrerelease -q \
             '.[] | select(.isPrerelease and (.tagName | endswith("-nightly"))) | .tagName' \
             | while read -r tag; do
                 branch="${tag%-nightly}"


### PR DESCRIPTION
## Summary

- nightlyビルド時に、既にマージ済みで不要になった古いバージョンのnightlyプレリリース（例: `v0.0.3-nightly`）を自動削除する `cleanup-stale-nightlies` ジョブを追加
- `discover` ジョブで取得したアクティブブランチリストと照合し、対応するブランチが存在しないnightlyプレリリースを削除
- ジョブ依存関係: `discover` → `cleanup-stale-nightlies` → `nightly`

## Test plan

- [ ] `cleanup-stale-nightlies` ジョブが `schedule` イベント時のみ実行されることを確認
- [ ] `workflow_dispatch`（手動実行）時には `cleanup-stale-nightlies` が実行されないことを確認
- [ ] アクティブブランチのnightlyは削除されず、非アクティブブランチのnightlyのみ削除されることを確認