### PR TITLE
refactor: extract C stdlib helpers, deduplicate codegen patterns

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -286,6 +286,24 @@ private:
     llvm::Type *getMapKeyType(llvm::Value *mapVal);
     llvm::Type *getMapValueType(llvm::Value *mapVal);
     llvm::Value *emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, llvm::Type *keyTy);
+    llvm::Value *emitIsWhitespace(llvm::Value *ch);
+
+    // C stdlib function helpers
+    llvm::FunctionCallee getStdlibMalloc();
+    llvm::FunctionCallee getStdlibRealloc();
+    llvm::FunctionCallee getStdlibFree();
+    llvm::FunctionCallee getStdlibStrlen();
+    llvm::FunctionCallee getStdlibMemcpy();
+    llvm::FunctionCallee getStdlibMemmove();
+    llvm::FunctionCallee getStdlibMemset();
+    llvm::FunctionCallee getStdlibStrcmp();
+    llvm::FunctionCallee getStdlibStrncmp();
+    llvm::FunctionCallee getStdlibStrstr();
+    llvm::FunctionCallee getStdlibStrcpy();
+    llvm::FunctionCallee getStdlibStrcat();
+    llvm::FunctionCallee getStdlibSnprintf();
+    llvm::FunctionCallee getStdlibPrintf();
+    llvm::FunctionCallee getStdlibExit();
     llvm::Type *getSetElementType(llvm::Value *setVal);
     llvm::Type *getNestedListElementType(llvm::Value *listVal);
     llvm::Value *emitSetElementLookup(llvm::Value *setPtr, llvm::Value *elem, llvm::Type *elemTy);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -2,7 +2,6 @@
 #include "ry/diagnostic.hpp"
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
-#include <stdexcept>
 
 CodeGen::CodeGen(bool test_mode, const SourceManager *sm) : ctx_(std::make_unique<llvm::LLVMContext>()),
                      mod_(std::make_unique<llvm::Module>("ry", *ctx_)),
@@ -682,14 +681,88 @@ llvm::Value *CodeGen::buildSomeValue(llvm::Value *inner, llvm::Type *optionTy) {
     return val;
 }
 
+// ===== C stdlib function helpers =====
+
+llvm::FunctionCallee CodeGen::getStdlibMalloc() {
+    auto ty = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    return mod_->getOrInsertFunction("malloc", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibRealloc() {
+    auto ty = llvm::FunctionType::get(ptrTy_, {ptrTy_, i64Ty_}, false);
+    return mod_->getOrInsertFunction("realloc", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibFree() {
+    auto ty = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    return mod_->getOrInsertFunction("free", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibStrlen() {
+    auto ty = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
+    return mod_->getOrInsertFunction("strlen", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibMemcpy() {
+    auto ty = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
+    return mod_->getOrInsertFunction("memcpy", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibMemmove() {
+    auto ty = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
+    return mod_->getOrInsertFunction("memmove", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibMemset() {
+    auto ty = llvm::FunctionType::get(ptrTy_, {ptrTy_, i32Ty_, i64Ty_}, false);
+    return mod_->getOrInsertFunction("memset", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibStrcmp() {
+    auto ty = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
+    return mod_->getOrInsertFunction("strcmp", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibStrncmp() {
+    auto ty = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_, i64Ty_}, false);
+    return mod_->getOrInsertFunction("strncmp", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibStrstr() {
+    auto ty = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
+    return mod_->getOrInsertFunction("strstr", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibStrcpy() {
+    auto ty = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
+    return mod_->getOrInsertFunction("strcpy", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibStrcat() {
+    auto ty = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
+    return mod_->getOrInsertFunction("strcat", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibSnprintf() {
+    auto ty = llvm::FunctionType::get(i32Ty_, {ptrTy_, i64Ty_, ptrTy_}, true);
+    return mod_->getOrInsertFunction("snprintf", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibPrintf() {
+    auto ty = llvm::FunctionType::get(i32Ty_, {ptrTy_}, true);
+    return mod_->getOrInsertFunction("printf", ty);
+}
+
+llvm::FunctionCallee CodeGen::getStdlibExit() {
+    auto ty = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {i32Ty_}, false);
+    return mod_->getOrInsertFunction("exit", ty);
+}
+
 void CodeGen::emitRuntimeError(const std::string &message, const std::string &globalName) {
-    llvm::FunctionType *printfTy = llvm::FunctionType::get(i32Ty_, {ptrTy_}, true);
-    llvm::FunctionCallee printfFn = mod_->getOrInsertFunction("printf", printfTy);
+    auto printfFn = getStdlibPrintf();
     llvm::Constant *errMsg = builder_.CreateGlobalString(message, globalName);
     builder_.CreateCall(printfFn, {errMsg});
-    llvm::FunctionType *exitTy = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*ctx_), {i32Ty_}, false);
-    llvm::FunctionCallee exitFn = mod_->getOrInsertFunction("exit", exitTy);
+    auto exitFn = getStdlibExit();
     builder_.CreateCall(exitFn, {llvm::ConstantInt::get(i32Ty_, 1)});
     builder_.CreateUnreachable();
 }
@@ -918,9 +991,7 @@ void CodeGen::emitConstraintCheck(llvm::Value *val, const TypeConstraint &constr
             // Can't easily extract string from ConstantExpr, fall through to runtime
         }
         // For string literals, we need runtime strcmp checks
-        llvm::FunctionType *strcmpTy = llvm::FunctionType::get(
-            i32Ty_, {ptrTy_, ptrTy_}, false);
-        llvm::FunctionCallee strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+        auto strcmpFn = getStdlibStrcmp();
 
         llvm::Value *anyMatch = llvm::ConstantInt::get(i1Ty_, 0);
         for (const auto &allowed : constraint.str_values) {

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -102,10 +102,8 @@ llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, ll
 void CodeGen::emitBucketInit(llvm::Value *headerPtr, llvm::StructType *headerTy,
                               unsigned bucketCountIdx, unsigned bucketsPtrIdx,
                               int64_t initialBucketCount) {
-    llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-    llvm::FunctionType *memsetTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, i32Ty_, i64Ty_}, false);
-    llvm::FunctionCallee memsetFn = mod_->getOrInsertFunction("memset", memsetTy);
+    auto mallocFn = getStdlibMalloc();
+    auto memsetFn = getStdlibMemset();
 
     int64_t bucketBytes = initialBucketCount * 8; // sizeof(int64_t)
     llvm::Value *bucketsPtr = builder_.CreateCall(
@@ -175,8 +173,7 @@ void CodeGen::emitBucketInsertAndRehashCheck(llvm::Value *headerPtr, llvm::Struc
     llvm::Value *newBuckets = builder_.CreateCall(rehashFn, {keysPtr, lenForRehash, newBc}, "new_buckets");
 
     // Free old buckets
-    llvm::FunctionType *freeTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
-    llvm::FunctionCallee freeFn = mod_->getOrInsertFunction("free", freeTy);
+    auto freeFn = getStdlibFree();
     llvm::Value *oldBuckets = builder_.CreateLoad(ptrTy_, bucketsField, "old_buckets");
     builder_.CreateCall(freeFn, {oldBuckets});
 
@@ -194,9 +191,7 @@ void CodeGen::emitPrint(const std::vector<ExprPtr> &args) {
     if (args.size() != 1)
         codegenError("print() takes exactly 1 argument");
 
-    llvm::FunctionType *printfTy = llvm::FunctionType::get(
-        i32Ty_, {llvm::PointerType::getUnqual(*ctx_)}, /*isVarArg=*/true);
-    llvm::FunctionCallee printfFn = mod_->getOrInsertFunction("printf", printfTy);
+    auto printfFn = getStdlibPrintf();
 
     llvm::Value *val = emitExpr(*args[0]);
 
@@ -795,8 +790,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         } else if (actualTy == i1Ty_ && expectedTy == i1Ty_) {
             eqResult = builder_.CreateICmpEQ(actualVal, expectedVal, "eq");
         } else if (actualTy == ptrTy_ && expectedTy == ptrTy_) {
-            llvm::FunctionType *strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-            llvm::FunctionCallee strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+            auto strcmpFn = getStdlibStrcmp();
             llvm::Value *result = builder_.CreateCall(strcmpFn, {actualVal, expectedVal}, "strcmp");
             eqResult = builder_.CreateICmpEQ(result, llvm::ConstantInt::get(i32Ty_, 0), "eq");
         } else if ((actualTy == i64Ty_ && expectedTy == f64Ty_) ||
@@ -823,8 +817,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
             else if (innerTy == i1Ty_)
                 innerEq = builder_.CreateICmpEQ(aInner, bInner, "opt_inner_eq");
             else if (innerTy == ptrTy_) {
-                llvm::FunctionType *strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-                llvm::FunctionCallee strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+                auto strcmpFn = getStdlibStrcmp();
                 llvm::Value *r = builder_.CreateCall(strcmpFn, {aInner, bInner}, "strcmp");
                 innerEq = builder_.CreateICmpEQ(r, llvm::ConstantInt::get(i32Ty_, 0), "opt_inner_eq");
             } else {
@@ -914,8 +907,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
             if (elemTy == i64Ty_)
                 eq = builder_.CreateICmpEQ(elem, expectedVal, "eq");
             else if (elemTy == ptrTy_) {
-                llvm::FunctionType *strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-                llvm::FunctionCallee strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+                auto strcmpFn = getStdlibStrcmp();
                 llvm::Value *cmp = builder_.CreateCall(strcmpFn, {elem, expectedVal}, "strcmp");
                 eq = builder_.CreateICmpEQ(cmp, llvm::ConstantInt::get(i32Ty_, 0), "eq");
             } else
@@ -937,8 +929,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
             containResult = builder_.CreateLoad(i1Ty_, foundVar, "contain_result");
         } else if (actualTy == ptrTy_ && expectedVal->getType() == ptrTy_) {
             // String contains: use strstr
-            llvm::FunctionType *strstrTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
-            llvm::FunctionCallee strstrFn = mod_->getOrInsertFunction("strstr", strstrTy);
+            auto strstrFn = getStdlibStrstr();
             llvm::Value *result = builder_.CreateCall(strstrFn, {actualVal, expectedVal}, "strstr");
             containResult = builder_.CreateICmpNE(result, llvm::ConstantPointerNull::get(
                 llvm::PointerType::getUnqual(*ctx_)), "contains");
@@ -1013,10 +1004,8 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         if (actualTy != ptrTy_ || expectedVal->getType() != ptrTy_)
             codegenError("line " + std::to_string(s.loc.line) +
                 ": to_start_with: requires str operands");
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto strncmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto strncmpFn = mod_->getOrInsertFunction("strncmp", strncmpTy);
+        auto strlenFn = getStdlibStrlen();
+        auto strncmpFn = getStdlibStrncmp();
         llvm::Value *prefixLen = builder_.CreateCall(strlenFn, {expectedVal}, "prefix_len");
         llvm::Value *cmp = builder_.CreateCall(strncmpFn, {actualVal, expectedVal, prefixLen}, "strncmp");
         cmpResult = builder_.CreateICmpEQ(cmp, llvm::ConstantInt::get(i32Ty_, 0), "starts_with");
@@ -1026,10 +1015,8 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         if (actualTy != ptrTy_ || expectedVal->getType() != ptrTy_)
             codegenError("line " + std::to_string(s.loc.line) +
                 ": to_end_with: requires str operands");
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto strncmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto strncmpFn = mod_->getOrInsertFunction("strncmp", strncmpTy);
+        auto strlenFn = getStdlibStrlen();
+        auto strncmpFn = getStdlibStrncmp();
         llvm::Value *sLen = builder_.CreateCall(strlenFn, {actualVal}, "s_len");
         llvm::Value *suffixLen = builder_.CreateCall(strlenFn, {expectedVal}, "suffix_len");
 
@@ -1072,8 +1059,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
 
     // For now, format actual and expected as string representations
     // Use snprintf to format values at runtime
-    llvm::FunctionType *snprintfTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, i64Ty_, ptrTy_}, true);
-    llvm::FunctionCallee snprintfFn = mod_->getOrInsertFunction("snprintf", snprintfTy);
+    auto snprintfFn = getStdlibSnprintf();
 
     auto formatValue = [&](llvm::Value *val, llvm::Type *ty, const std::string &bufName) -> llvm::Value* {
         llvm::Value *buf = builder_.CreateAlloca(
@@ -1401,8 +1387,7 @@ void CodeGen::emitStmt(std::unique_ptr<MatchStmt> &s) {
                 } else if (subjectTy == i1Ty_ && litVal->getType() == i1Ty_) {
                     testResult = builder_.CreateICmpEQ(subjectVal, litVal, "match.beq");
                 } else if (subjectTy == ptrTy_ && litVal->getType() == ptrTy_) {
-                    auto strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-                    auto strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+                    auto strcmpFn = getStdlibStrcmp();
                     llvm::Value *cmp = builder_.CreateCall(strcmpFn, {subjectVal, litVal}, "strcmp");
                     testResult = builder_.CreateICmpEQ(cmp, llvm::ConstantInt::get(i32Ty_, 0), "match.streq");
                 } else {
@@ -1478,8 +1463,7 @@ void CodeGen::emitStmt(std::unique_ptr<MatchStmt> &s) {
                             else if (subjectTy == i1Ty_ && litVal->getType() == i1Ty_)
                                 altResult = builder_.CreateICmpEQ(subjectVal, litVal, "or.beq");
                             else if (subjectTy == ptrTy_ && litVal->getType() == ptrTy_) {
-                                auto strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-                                auto strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+                                auto strcmpFn = getStdlibStrcmp();
                                 llvm::Value *cmp = builder_.CreateCall(strcmpFn, {subjectVal, litVal}, "strcmp");
                                 altResult = builder_.CreateICmpEQ(cmp, llvm::ConstantInt::get(i32Ty_, 0), "or.streq");
                             } else {
@@ -1688,9 +1672,7 @@ void CodeGen::emitExit(const std::vector<ExprPtr> &args) {
         codegenError("exit() argument must be an integer");
     if (code->getType() != i32Ty_)
         code = builder_.CreateIntCast(code, i32Ty_, true, "exit_code");
-    llvm::FunctionType *exitTy = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*ctx_), {i32Ty_}, false);
-    llvm::FunctionCallee exitFn = mod_->getOrInsertFunction("exit", exitTy);
+    auto exitFn = getStdlibExit();
     builder_.CreateCall(exitFn, {code});
     builder_.CreateUnreachable();
 }

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -1,6 +1,25 @@
 #include "ry/codegen.hpp"
 #include "ry/diagnostic.hpp"
-#include <stdexcept>
+
+namespace {
+// RAII guard to restore moved-out args after proxy CallExpr delegation
+struct ArgsRestoreGuard {
+    std::vector<ExprPtr> &dst;
+    std::vector<ExprPtr> &src;
+    ~ArgsRestoreGuard() { dst = std::move(src); }
+};
+} // namespace
+
+// ===== Whitespace helper =====
+
+llvm::Value *CodeGen::emitIsWhitespace(llvm::Value *ch) {
+    llvm::Value *isSp  = builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, ' '));
+    llvm::Value *isTab = builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, '\t'));
+    llvm::Value *isNl  = builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, '\n'));
+    llvm::Value *isCr  = builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, '\r'));
+    return builder_.CreateOr(builder_.CreateOr(isSp, isTab),
+                             builder_.CreateOr(isNl, isCr));
+}
 
 // ===== Builtin String =====
 
@@ -13,8 +32,7 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *sub = emitExpr(*e.args[1]);
         if (s->getType() != ptrTy_ || sub->getType() != ptrTy_)
             codegenError("contains() requires str arguments");
-        auto strstrTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
-        auto strstrFn = mod_->getOrInsertFunction("strstr", strstrTy);
+        auto strstrFn = getStdlibStrstr();
         llvm::Value *result = builder_.CreateCall(strstrFn, {s, sub}, "strstr");
         llvm::Value *null = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
         return builder_.CreateICmpNE(result, null, "contains");
@@ -28,10 +46,8 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *prefix = emitExpr(*e.args[1]);
         if (s->getType() != ptrTy_ || prefix->getType() != ptrTy_)
             codegenError("starts_with() requires str arguments");
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto strncmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto strncmpFn = mod_->getOrInsertFunction("strncmp", strncmpTy);
+        auto strlenFn = getStdlibStrlen();
+        auto strncmpFn = getStdlibStrncmp();
         llvm::Value *prefixLen = builder_.CreateCall(strlenFn, {prefix}, "prefix_len");
         llvm::Value *cmp = builder_.CreateCall(strncmpFn, {s, prefix, prefixLen}, "strncmp");
         return builder_.CreateICmpEQ(cmp, llvm::ConstantInt::get(i32Ty_, 0), "starts_with");
@@ -45,10 +61,8 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *suffix = emitExpr(*e.args[1]);
         if (s->getType() != ptrTy_ || suffix->getType() != ptrTy_)
             codegenError("ends_with() requires str arguments");
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto strncmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto strncmpFn = mod_->getOrInsertFunction("strncmp", strncmpTy);
+        auto strlenFn = getStdlibStrlen();
+        auto strncmpFn = getStdlibStrncmp();
         llvm::Value *sLen = builder_.CreateCall(strlenFn, {s}, "s_len");
         llvm::Value *suffixLen = builder_.CreateCall(strlenFn, {suffix}, "suffix_len");
 
@@ -84,9 +98,7 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
             codegenError("find() requires str arguments");
 
         llvm::StructType *optTy = getOptionType(i64Ty_);
-
-        auto strstrTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
-        auto strstrFn = mod_->getOrInsertFunction("strstr", strstrTy);
+        auto strstrFn = getStdlibStrstr();
         llvm::Value *result = builder_.CreateCall(strstrFn, {s, sub}, "find_ptr");
         llvm::Value *null = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
         llvm::Value *isNull = builder_.CreateICmpEQ(result, null, "find_null");
@@ -158,15 +170,10 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *newStr = emitExpr(*e.args[2]);
         if (s->getType() != ptrTy_ || oldStr->getType() != ptrTy_ || newStr->getType() != ptrTy_)
             codegenError("replace() requires str arguments");
-
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto strstrTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
-        auto strstrFn = mod_->getOrInsertFunction("strstr", strstrTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto strlenFn = getStdlibStrlen();
+        auto strstrFn = getStdlibStrstr();
+        auto mallocFn = getStdlibMalloc();
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *sLen = builder_.CreateCall(strlenFn, {s}, "repl_s_len");
         llvm::Value *oldLen = builder_.CreateCall(strlenFn, {oldStr}, "repl_old_len");
@@ -255,11 +262,8 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *s = emitExpr(*e.args[0]);
         if (s->getType() != ptrTy_)
             codegenError("to_upper() requires str argument");
-
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto strlenFn = getStdlibStrlen();
+        auto mallocFn = getStdlibMalloc();
 
         llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "upper_len");
         llvm::Value *bufSize = builder_.CreateAdd(len, llvm::ConstantInt::get(i64Ty_, 1), "upper_buf_size");
@@ -304,11 +308,8 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *s = emitExpr(*e.args[0]);
         if (s->getType() != ptrTy_)
             codegenError("to_lower() requires str argument");
-
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto strlenFn = getStdlibStrlen();
+        auto mallocFn = getStdlibMalloc();
 
         llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "lower_len");
         llvm::Value *bufSize = builder_.CreateAdd(len, llvm::ConstantInt::get(i64Ty_, 1), "lower_buf_size");
@@ -353,13 +354,9 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *s = emitExpr(*e.args[0]);
         if (s->getType() != ptrTy_)
             codegenError("trim() requires str argument");
-
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto strlenFn = getStdlibStrlen();
+        auto mallocFn = getStdlibMalloc();
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "trim_len");
 
@@ -381,11 +378,7 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         builder_.SetInsertPoint(startCheckBB);
         llvm::Value *startPtr = builder_.CreateGEP(builder_.getInt8Ty(), s, startIdx, "start_ptr");
         llvm::Value *startCh = builder_.CreateLoad(i8Ty_, startPtr, "start_ch");
-        llvm::Value *isSp = builder_.CreateICmpEQ(startCh, llvm::ConstantInt::get(i8Ty_, ' '), "is_sp");
-        llvm::Value *isTab = builder_.CreateICmpEQ(startCh, llvm::ConstantInt::get(i8Ty_, '\t'), "is_tab");
-        llvm::Value *isNl = builder_.CreateICmpEQ(startCh, llvm::ConstantInt::get(i8Ty_, '\n'), "is_nl");
-        llvm::Value *isCr = builder_.CreateICmpEQ(startCh, llvm::ConstantInt::get(i8Ty_, '\r'), "is_cr");
-        llvm::Value *isWs = builder_.CreateOr(builder_.CreateOr(isSp, isTab), builder_.CreateOr(isNl, isCr), "is_ws");
+        llvm::Value *isWs = emitIsWhitespace(startCh);
         builder_.CreateCondBr(isWs, startBodyBB, startEndBB);
 
         builder_.SetInsertPoint(startBodyBB);
@@ -415,11 +408,7 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *endPrev = builder_.CreateSub(endIdx, llvm::ConstantInt::get(i64Ty_, 1), "end_prev");
         llvm::Value *endPtr = builder_.CreateGEP(builder_.getInt8Ty(), s, endPrev, "end_ptr");
         llvm::Value *endCh = builder_.CreateLoad(i8Ty_, endPtr, "end_ch");
-        llvm::Value *isSp2 = builder_.CreateICmpEQ(endCh, llvm::ConstantInt::get(i8Ty_, ' '), "is_sp2");
-        llvm::Value *isTab2 = builder_.CreateICmpEQ(endCh, llvm::ConstantInt::get(i8Ty_, '\t'), "is_tab2");
-        llvm::Value *isNl2 = builder_.CreateICmpEQ(endCh, llvm::ConstantInt::get(i8Ty_, '\n'), "is_nl2");
-        llvm::Value *isCr2 = builder_.CreateICmpEQ(endCh, llvm::ConstantInt::get(i8Ty_, '\r'), "is_cr2");
-        llvm::Value *isWs2 = builder_.CreateOr(builder_.CreateOr(isSp2, isTab2), builder_.CreateOr(isNl2, isCr2), "is_ws2");
+        llvm::Value *isWs2 = emitIsWhitespace(endCh);
         builder_.CreateCondBr(isWs2, endBodyBB, endEndBB);
 
         builder_.SetInsertPoint(endBodyBB);
@@ -449,13 +438,9 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *s = emitExpr(*e.args[0]);
         if (s->getType() != ptrTy_)
             codegenError("trim_start() requires str argument");
-
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto strlenFn = getStdlibStrlen();
+        auto mallocFn = getStdlibMalloc();
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "tstart_len");
 
@@ -475,14 +460,7 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         builder_.SetInsertPoint(checkBB);
         llvm::Value *ptr = builder_.CreateGEP(builder_.getInt8Ty(), s, idx, "tstart_ptr");
         llvm::Value *ch = builder_.CreateLoad(i8Ty_, ptr, "tstart_ch");
-        llvm::Value *isWs = builder_.CreateOr(
-            builder_.CreateOr(
-                builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, ' ')),
-                builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, '\t'))),
-            builder_.CreateOr(
-                builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, '\n')),
-                builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, '\r'))),
-            "tstart_ws");
+        llvm::Value *isWs = emitIsWhitespace(ch);
         builder_.CreateCondBr(isWs, bodyBB, endBB);
 
         builder_.SetInsertPoint(bodyBB);
@@ -508,13 +486,9 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *s = emitExpr(*e.args[0]);
         if (s->getType() != ptrTy_)
             codegenError("trim_end() requires str argument");
-
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto strlenFn = getStdlibStrlen();
+        auto mallocFn = getStdlibMalloc();
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "tend_len");
 
@@ -536,14 +510,7 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *prevIdx = builder_.CreateSub(endIdx, llvm::ConstantInt::get(i64Ty_, 1), "tend_prev");
         llvm::Value *ptr = builder_.CreateGEP(builder_.getInt8Ty(), s, prevIdx, "tend_ptr");
         llvm::Value *ch = builder_.CreateLoad(i8Ty_, ptr, "tend_ch");
-        llvm::Value *isWs = builder_.CreateOr(
-            builder_.CreateOr(
-                builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, ' ')),
-                builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, '\t'))),
-            builder_.CreateOr(
-                builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, '\n')),
-                builder_.CreateICmpEQ(ch, llvm::ConstantInt::get(i8Ty_, '\r'))),
-            "tend_ws");
+        llvm::Value *isWs = emitIsWhitespace(ch);
         builder_.CreateCondBr(isWs, bodyBB, endBB);
 
         builder_.SetInsertPoint(bodyBB);
@@ -568,13 +535,9 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *n = emitExpr(*e.args[1]);
         if (s->getType() != ptrTy_)
             codegenError("repeat() requires str as first argument");
-
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto strlenFn = getStdlibStrlen();
+        auto mallocFn = getStdlibMalloc();
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *sLen = builder_.CreateCall(strlenFn, {s}, "repeat_slen");
         llvm::Value *totalLen = builder_.CreateMul(sLen, n, "repeat_total");
@@ -616,8 +579,7 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         // List reverse
         llvm::Type *elemTy = getListElementType(arg);
         if (elemTy) {
-            auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+            auto mallocFn = getStdlibMalloc();
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
@@ -724,15 +686,10 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         llvm::Value *delim = emitExpr(*e.args[1]);
         if (s->getType() != ptrTy_ || delim->getType() != ptrTy_)
             codegenError("split() requires str arguments");
-
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto strstrTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
-        auto strstrFn = mod_->getOrInsertFunction("strstr", strstrTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto strlenFn = getStdlibStrlen();
+        auto strstrFn = getStdlibStrstr();
+        auto mallocFn = getStdlibMalloc();
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *delimLen = builder_.CreateCall(strlenFn, {delim}, "split_dlen");
         llvm::Value *null = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
@@ -835,13 +792,9 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
             codegenError("join() requires List<str> and str arguments");
         if (getListElementType(listPtr) != ptrTy_)
             codegenError("join() requires List<str> as first argument");
-
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto strlenFn = getStdlibStrlen();
+        auto mallocFn = getStdlibMalloc();
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *listLen = builder_.CreateLoad(i64Ty_,
             builder_.CreateStructGEP(listHeaderTy_, listPtr, 0, "join_len_ptr"), "join_len");
@@ -984,17 +937,14 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *mapLen = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(mapHeaderTy_, mapVal, 0), "keys_len");
         llvm::Value *keysData = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, mapVal, 2), "keys_data");
 
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         llvm::Value *newHeader = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, headerSize)}, "keys_header");
         uint64_t elemSize = dl.getTypeAllocSize(keyTy);
         llvm::Value *dataSize = builder_.CreateMul(mapLen, llvm::ConstantInt::get(i64Ty_, elemSize), "keys_ds");
         llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "keys_nd");
-
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto memcpyFn = getStdlibMemcpy();
         builder_.CreateCall(memcpyFn, {newData, keysData, dataSize});
 
         builder_.CreateStore(mapLen, builder_.CreateStructGEP(listHeaderTy_, newHeader, 0));
@@ -1015,17 +965,14 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *mapLen = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(mapHeaderTy_, mapVal, 0), "vals_len");
         llvm::Value *valsData = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, mapVal, 3), "vals_data");
 
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         llvm::Value *newHeader = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, headerSize)}, "vals_header");
         uint64_t elemSize = dl.getTypeAllocSize(valTy);
         llvm::Value *dataSize = builder_.CreateMul(mapLen, llvm::ConstantInt::get(i64Ty_, elemSize), "vals_ds");
         llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "vals_nd");
-
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto memcpyFn = getStdlibMemcpy();
         builder_.CreateCall(memcpyFn, {newData, valsData, dataSize});
 
         builder_.CreateStore(mapLen, builder_.CreateStructGEP(listHeaderTy_, newHeader, 0));
@@ -1134,8 +1081,7 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *srcData = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(listHeaderTy_, listVal, 2), "enum_data");
 
         llvm::StructType *tupleTy = llvm::StructType::get(*ctx_, {i64Ty_, elemTy});
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         llvm::Value *newHeader = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, headerSize)}, "enum_header");
@@ -1189,8 +1135,7 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *minLen = builder_.CreateSelect(builder_.CreateICmpSLT(len1, len2), len1, len2, "zip_minlen");
 
         llvm::StructType *tupleTy = llvm::StructType::get(*ctx_, {elemTy1, elemTy2});
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         llvm::Value *newHeader = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, headerSize)}, "zip_header");
@@ -1254,8 +1199,7 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         llvm::Value *count = builder_.CreateSExt(count32, i64Ty_, "argc64");
 
         // Allocate list header
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         llvm::Value *headerPtr = builder_.CreateCall(
@@ -1368,8 +1312,7 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         llvm::Value *count = builder_.CreateSelect(stepPos, countPosClamped, countNegClamped, "range_count");
 
         // Allocate list header
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         llvm::Value *headerPtr = builder_.CreateCall(
@@ -1455,8 +1398,7 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         llvm::Value *ptr = emitExpr(*e.args[0]);
         if (ptr->getType() != ptrTy_)
             codegenError("byte_len() requires str argument");
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
+        auto strlenFn = getStdlibStrlen();
         return builder_.CreateCall(strlenFn, {ptr}, "byte_len");
     }
 
@@ -1551,8 +1493,7 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e) {
         llvm::Value *srcData = builder_.CreateLoad(ptrTy_, srcDataPtr, "filter_src_data");
 
         // Allocate new list header + data (capacity = source length)
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         llvm::Value *newHeader = builder_.CreateCall(
@@ -1655,8 +1596,7 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e) {
         llvm::Value *srcData = builder_.CreateLoad(ptrTy_, srcDataPtr, "map_src_data");
 
         // Allocate new list
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         llvm::Value *newHeader = builder_.CreateCall(
@@ -1739,8 +1679,7 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e) {
         llvm::Value *srcData = builder_.CreateLoad(ptrTy_, srcDataPtr, "sort_src_data");
 
         // Allocate new list and copy data
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         llvm::Value *newHeader = builder_.CreateCall(
@@ -1751,8 +1690,7 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e) {
         llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "sort_data");
 
         // memcpy source data to new data
-        llvm::FunctionType *memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        llvm::FunctionCallee memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto memcpyFn = getStdlibMemcpy();
         builder_.CreateCall(memcpyFn, {newData, srcData, dataSize});
 
         // Set header
@@ -1797,8 +1735,7 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e) {
             } else if (elemTy == f64Ty_) {
                 result = builder_.CreateFCmpOLT(valA, valB, "sort_lt");
             } else if (elemTy == ptrTy_) {
-                auto strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-                auto strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+                auto strcmpFn = getStdlibStrcmp();
                 llvm::Value *cmpResult = builder_.CreateCall(strcmpFn, {valA, valB}, "sort_strcmp");
                 result = builder_.CreateICmpSLT(cmpResult, llvm::ConstantInt::get(i32Ty_, 0), "sort_lt");
             } else {
@@ -1834,12 +1771,13 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e) {
         llvm::Type *elemTy = getListElementType(listPtr);
         if (!elemTy) codegenError("sort!() requires a list");
 
-        // Reuse sort() via a proxy CallExpr (avoid const_cast mutation)
+        // Reuse sort() via a proxy CallExpr with scope guard for exception safety
+        auto &mutArgs = const_cast<CallExpr &>(e).args;
         CallExpr sortProxy;
         sortProxy.callee = "sort";
-        sortProxy.args = std::move(const_cast<CallExpr &>(e).args);
+        sortProxy.args = std::move(mutArgs);
+        ArgsRestoreGuard guard{mutArgs, sortProxy.args};
         llvm::Value *sorted = emitBuiltinHigherOrder(sortProxy);
-        const_cast<CallExpr &>(e).args = std::move(sortProxy.args); // restore
 
         if (!sorted)
             codegenError("sort!() internal error");
@@ -1847,9 +1785,7 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e) {
         // Copy sorted data back into original list
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-
-        auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *srcLen = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(listHeaderTy_, listPtr, 0), "sortm_len");
         llvm::Value *srcData = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(listHeaderTy_, listPtr, 2), "sortm_data");
@@ -1858,8 +1794,7 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e) {
         builder_.CreateCall(memcpyFn, {srcData, sortedData, copySize});
 
         // Free the temporary sorted list
-        auto freeTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
-        auto freeFn = mod_->getOrInsertFunction("free", freeTy);
+        auto freeFn = getStdlibFree();
         builder_.CreateCall(freeFn, {sortedData});
         builder_.CreateCall(freeFn, {sorted});
 
@@ -2267,20 +2202,17 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
             llvm::Value *newCap = builder_.CreateMul(cap, llvm::ConstantInt::get(i64Ty_, 2), "new_cap");
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+            auto mallocFn = getStdlibMalloc();
             llvm::Value *newSize = builder_.CreateMul(newCap, llvm::ConstantInt::get(i64Ty_, elemSize), "new_size");
             llvm::Value *newElemsPtr = builder_.CreateCall(mallocFn, {newSize}, "new_elems");
 
-            llvm::FunctionType *memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            llvm::FunctionCallee memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+            auto memcpyFn = getStdlibMemcpy();
             llvm::Value *elemsPtrField = builder_.CreateStructGEP(setHeaderTy_, setPtr, 2, "elems_field");
             llvm::Value *oldElemsPtr = builder_.CreateLoad(ptrTy_, elemsPtrField, "old_elems");
             llvm::Value *oldSize = builder_.CreateMul(length, llvm::ConstantInt::get(i64Ty_, elemSize), "old_size");
             builder_.CreateCall(memcpyFn, {newElemsPtr, oldElemsPtr, oldSize});
 
-            llvm::FunctionType *freeTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
-            llvm::FunctionCallee freeFn = mod_->getOrInsertFunction("free", freeTy);
+            auto freeFn = getStdlibFree();
             builder_.CreateCall(freeFn, {oldElemsPtr});
 
             builder_.CreateStore(newElemsPtr, elemsPtrField);
@@ -2442,8 +2374,7 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             if (listElemTy == ptrTy_) {
                 if (getNestedListElementType(containerPtr))
                     codegenError("remove() is not supported for lists of non-string pointer elements");
-                auto strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-                auto strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+                auto strcmpFn = getStdlibStrcmp();
                 llvm::Value *cmpResult = builder_.CreateCall(strcmpFn, {val, listElem}, "lrem_strcmp");
                 match = builder_.CreateICmpEQ(cmpResult, llvm::ConstantInt::get(i32Ty_, 0), "lrem_match");
             } else if (listElemTy->isDoubleTy()) {
@@ -2475,8 +2406,7 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             builder_.CreateCondBr(wasFound, removeBB, doneBB);
 
             builder_.SetInsertPoint(removeBB);
-            llvm::FunctionType *memmoveTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            llvm::FunctionCallee memmoveFn = mod_->getOrInsertFunction("memmove", memmoveTy);
+            auto memmoveFn = getStdlibMemmove();
             llvm::Value *dstPtr = builder_.CreateGEP(listElemTy, dataPtr, {idx}, "lrem_dst");
             llvm::Value *srcPtr = builder_.CreateGEP(listElemTy, dataPtr,
                 {builder_.CreateAdd(idx, llvm::ConstantInt::get(i64Ty_, 1))}, "lrem_src");
@@ -2584,13 +2514,9 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
 
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-
-            auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-            auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
-            auto freeTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
-            auto freeFn = mod_->getOrInsertFunction("free", freeTy);
+            auto mallocFn = getStdlibMalloc();
+            auto memcpyFn = getStdlibMemcpy();
+            auto freeFn = getStdlibFree();
 
             llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, listPtr, 0, "app_len_ptr");
             llvm::Value *capPtr = builder_.CreateStructGEP(listHeaderTy_, listPtr, 1, "app_cap_ptr");
@@ -2646,11 +2572,8 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-
-            auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-            auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+            auto mallocFn = getStdlibMalloc();
+            auto memcpyFn = getStdlibMemcpy();
 
             llvm::Value *srcLen = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(listHeaderTy_, listPtr, 0), "apd_len");
             llvm::Value *srcData = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(listHeaderTy_, listPtr, 2), "apd_data");
@@ -2677,12 +2600,12 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
 
     // append!(list, elem) → alias for append
     if (e.callee == "append!" && e.args.size() == 2) {
+        auto &mutArgs = const_cast<CallExpr &>(e).args;
         CallExpr appendProxy;
         appendProxy.callee = "append";
-        appendProxy.args = std::move(const_cast<CallExpr &>(e).args);
-        llvm::Value *result = emitBuiltinCollection(appendProxy);
-        const_cast<CallExpr &>(e).args = std::move(appendProxy.args);
-        return result;
+        appendProxy.args = std::move(mutArgs);
+        ArgsRestoreGuard guard{mutArgs, appendProxy.args};
+        return emitBuiltinCollection(appendProxy);
     }
 
     // pop(list) → Option<T>: remove and return last element
@@ -2735,11 +2658,8 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-
-            auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-            auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+            auto mallocFn = getStdlibMalloc();
+            auto memcpyFn = getStdlibMemcpy();
 
             llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, listPtr, 0, "sl_len_ptr");
             llvm::Value *len = builder_.CreateLoad(i64Ty_, lenPtr, "sl_len");
@@ -2794,11 +2714,8 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-
-            auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-            auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+            auto mallocFn = getStdlibMalloc();
+            auto memcpyFn = getStdlibMemcpy();
 
             llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, listPtr, 0, "tk_len_ptr");
             llvm::Value *len = builder_.CreateLoad(i64Ty_, lenPtr, "tk_len");
@@ -2847,14 +2764,10 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
 
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-            llvm::FunctionType *memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            llvm::FunctionCallee memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
-            llvm::FunctionType *freeTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
-            llvm::FunctionCallee freeFn = mod_->getOrInsertFunction("free", freeTy);
-            llvm::FunctionType *memmoveTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            llvm::FunctionCallee memmoveFn = mod_->getOrInsertFunction("memmove", memmoveTy);
+            auto mallocFn = getStdlibMalloc();
+            auto memcpyFn = getStdlibMemcpy();
+            auto freeFn = getStdlibFree();
+            auto memmoveFn = getStdlibMemmove();
 
             llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, listPtr, 0, "ins_len_ptr");
             llvm::Value *capPtr = builder_.CreateStructGEP(listHeaderTy_, listPtr, 1, "ins_cap_ptr");
@@ -2926,8 +2839,7 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
 
-            llvm::FunctionType *memmoveTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            llvm::FunctionCallee memmoveFn = mod_->getOrInsertFunction("memmove", memmoveTy);
+            auto memmoveFn = getStdlibMemmove();
 
             llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, listPtr, 0, "rmat_len_ptr");
             llvm::Value *dataField = builder_.CreateStructGEP(listHeaderTy_, listPtr, 2, "rmat_data_field");
@@ -2980,8 +2892,7 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
         llvm::Value *srcData = builder_.CreateLoad(ptrTy_, srcDataPtr, "dist_src_data");
 
         // Allocate new list (capacity = source length)
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         uint64_t elemSize = dl.getTypeAllocSize(elemTy);
@@ -3042,8 +2953,7 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
 
         llvm::Value *match;
         if (elemTy == ptrTy_) {
-            auto strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-            auto strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+            auto strcmpFn = getStdlibStrcmp();
             llvm::Value *cmpResult = builder_.CreateCall(strcmpFn, {srcElem, outElem}, "dist_strcmp");
             match = builder_.CreateICmpEQ(cmpResult, llvm::ConstantInt::get(i32Ty_, 0), "dist_match");
         } else if (elemTy->isDoubleTy()) {
@@ -3108,10 +3018,8 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
         uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
         uint64_t innerElemSize = dl.getTypeAllocSize(innerElemTy);
 
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        llvm::FunctionType *memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        llvm::FunctionCallee memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto mallocFn = getStdlibMalloc();
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *outerLenPtr = builder_.CreateStructGEP(listHeaderTy_, listVal, 0, "flat_olen_ptr");
         llvm::Value *outerLen = builder_.CreateLoad(i64Ty_, outerLenPtr, "flat_olen");
@@ -3207,8 +3115,7 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
             uint64_t tupleSize = dl.getTypeAllocSize(tupleTy);
 
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+            auto mallocFn = getStdlibMalloc();
 
             llvm::Value *newHeader = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, headerSize)}, "items_hdr");
             llvm::Value *dataSize = builder_.CreateMul(len, llvm::ConstantInt::get(i64Ty_, tupleSize), "items_ds");
@@ -3345,10 +3252,8 @@ llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
             uint64_t keySize = dl.getTypeAllocSize(keyTy);
             uint64_t valSize = dl.getTypeAllocSize(valTy);
 
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-            llvm::FunctionType *memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            llvm::FunctionCallee memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+            auto mallocFn = getStdlibMalloc();
+            auto memcpyFn = getStdlibMemcpy();
 
             llvm::Value *len1 = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(mapHeaderTy_, map1, 0), "mg_len1");
             llvm::Value *len2 = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(mapHeaderTy_, map2, 0), "mg_len2");
@@ -3488,8 +3393,7 @@ llvm::Value *CodeGen::emitBuiltinSetOps(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t headerSize = dl.getTypeAllocSize(setHeaderTy_);
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+            auto mallocFn = getStdlibMalloc();
 
             // Allocate max possible size (len1 + len2)
             llvm::Value *maxLen = builder_.CreateAdd(len1, len2, "u_max_len");
@@ -3498,8 +3402,7 @@ llvm::Value *CodeGen::emitBuiltinSetOps(const CallExpr &e) {
             llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "u_data");
 
             // Copy all of set1
-            llvm::FunctionType *memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            llvm::FunctionCallee memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+            auto memcpyFn = getStdlibMemcpy();
             llvm::Value *copy1Size = builder_.CreateMul(len1, llvm::ConstantInt::get(i64Ty_, elemSize), "u_copy1_size");
             builder_.CreateCall(memcpyFn, {newData, data1, copy1Size});
 
@@ -3588,8 +3491,7 @@ llvm::Value *CodeGen::emitBuiltinSetOps(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t headerSize = dl.getTypeAllocSize(setHeaderTy_);
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+            auto mallocFn = getStdlibMalloc();
 
             llvm::Value *newHeader = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, headerSize)}, "is_hdr");
             llvm::Value *dataSize = builder_.CreateMul(len1, llvm::ConstantInt::get(i64Ty_, elemSize), "is_ds");
@@ -3653,8 +3555,7 @@ llvm::Value *CodeGen::emitBuiltinSetOps(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t headerSize = dl.getTypeAllocSize(setHeaderTy_);
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+            auto mallocFn = getStdlibMalloc();
 
             llvm::Value *newHeader = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, headerSize)}, "df_hdr");
             llvm::Value *dataSize = builder_.CreateMul(len1, llvm::ConstantInt::get(i64Ty_, elemSize), "df_ds");
@@ -3720,8 +3621,7 @@ llvm::Value *CodeGen::emitBuiltinSetOps(const CallExpr &e) {
             const llvm::DataLayout &dl = mod_->getDataLayout();
             uint64_t headerSize = dl.getTypeAllocSize(setHeaderTy_);
             uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+            auto mallocFn = getStdlibMalloc();
 
             llvm::Value *maxLen = builder_.CreateAdd(len1, len2, "sd_max_len");
             llvm::Value *newHeader = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, headerSize)}, "sd_hdr");
@@ -4194,8 +4094,7 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
         if (collVal->getType() != ptrTy_)
             return nullptr;
 
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
 
         // Helper lambda: generate a dense-array next function for List/Set
@@ -4346,10 +4245,8 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
         llvm::Type *elemTy = getIteratorElementType(iterVal);
         if (!elemTy) return nullptr;
 
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        llvm::FunctionType *reallocTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, i64Ty_}, false);
-        llvm::FunctionCallee reallocFn = mod_->getOrInsertFunction("realloc", reallocTy);
+        auto mallocFn = getStdlibMalloc();
+        auto reallocFn = getStdlibRealloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t elemSize = dl.getTypeAllocSize(elemTy);
 
@@ -4460,8 +4357,7 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
             codegenError("filter() on iterator requires a predicate function");
         auto &info = fnIt->second;
 
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
 
         // State: { ptr src_next_fn, ptr src_state, ptr predicate }
@@ -4543,8 +4439,7 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
         auto &info = fnIt->second;
         llvm::Type *outElemTy = info.returnType;
 
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
 
         llvm::StructType *stateTy = llvm::StructType::get(*ctx_, {ptrTy_, ptrTy_, ptrTy_});
@@ -4609,8 +4504,7 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
 
         llvm::Value *n = emitExpr(*e.args[1]);
 
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
 
         llvm::StructType *stateTy = llvm::StructType::get(*ctx_, {ptrTy_, ptrTy_, i64Ty_});

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1,6 +1,5 @@
 #include "ry/codegen.hpp"
 #include "ry/diagnostic.hpp"
-#include <stdexcept>
 
 llvm::Value *CodeGen::emitExpr(const ExprNode &node) {
     if (node.loc.isValid()) current_loc_ = node.loc;
@@ -138,8 +137,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
 
     // String comparison via strcmp
     if (lhs->getType() == ptrTy_ && rhs->getType() == ptrTy_) {
-        auto strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-        auto strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+        auto strcmpFn = getStdlibStrcmp();
         llvm::Value *cmp = builder_.CreateCall(strcmpFn, {lhs, rhs}, "strcmp");
         llvm::Value *zero = llvm::ConstantInt::get(i32Ty_, 0);
         if (op == "==") return builder_.CreateICmpEQ(cmp, zero, "str_eq");
@@ -210,14 +208,10 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
 
     // String concatenation
     if (op == "+" && lhs->getType() == ptrTy_ && rhs->getType() == ptrTy_) {
-        auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-        auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-        auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-        auto strcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
-        auto strcpyFn = mod_->getOrInsertFunction("strcpy", strcpyTy);
-        auto strcatTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_}, false);
-        auto strcatFn = mod_->getOrInsertFunction("strcat", strcatTy);
+        auto strlenFn = getStdlibStrlen();
+        auto mallocFn = getStdlibMalloc();
+        auto strcpyFn = getStdlibStrcpy();
+        auto strcatFn = getStdlibStrcat();
 
         llvm::Value *lenL = builder_.CreateCall(strlenFn, {lhs}, "len_l");
         llvm::Value *lenR = builder_.CreateCall(strlenFn, {rhs}, "len_r");
@@ -243,13 +237,9 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
                 intVal = builder_.CreateZExt(intVal, i64Ty_, "n_ext");
             else if (intVal->getType() == i8Ty_)
                 intVal = builder_.CreateZExt(intVal, i64Ty_, "n_ext");
-
-            auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-            auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-            auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-            auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-            auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+            auto strlenFn = getStdlibStrlen();
+            auto mallocFn = getStdlibMalloc();
+            auto memcpyFn = getStdlibMemcpy();
 
             llvm::Value *strLen = builder_.CreateCall(strlenFn, {strVal}, "str_len");
 
@@ -418,8 +408,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
             llvm::Value *match;
             if (listElemTy == ptrTy_) {
                 // String comparison
-                auto strcmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
-                auto strcmpFn = mod_->getOrInsertFunction("strcmp", strcmpTy);
+                auto strcmpFn = getStdlibStrcmp();
                 llvm::Value *cmpResult = builder_.CreateCall(strcmpFn, {elem, listElem}, "in_strcmp");
                 match = builder_.CreateICmpEQ(cmpResult, llvm::ConstantInt::get(i32Ty_, 0), "in_match");
             } else if (listElemTy->isDoubleTy()) {
@@ -633,8 +622,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
     int64_t count = static_cast<int64_t>(vals.size());
 
     // Allocate list header: { i64 length, i64 capacity, ptr data }
-    llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+    auto mallocFn = getStdlibMalloc();
 
     // Allocate header
     const llvm::DataLayout &dl = mod_->getDataLayout();
@@ -713,8 +701,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
 
     int64_t count = static_cast<int64_t>(keyVals.size());
 
-    llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+    auto mallocFn = getStdlibMalloc();
     const llvm::DataLayout &dl = mod_->getDataLayout();
 
     // Allocate MapHeader
@@ -810,8 +797,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<SetExpr> &e) {
 
     int64_t count = static_cast<int64_t>(vals.size());
 
-    llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+    auto mallocFn = getStdlibMalloc();
     const llvm::DataLayout &dl = mod_->getDataLayout();
 
     // Allocate SetHeader
@@ -1028,11 +1014,8 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
             codegenError("cannot convert function to string");
         return val; // string pointer
     }
-
-    auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-    auto snprintfTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, i64Ty_, ptrTy_}, true);
-    auto snprintfFn = mod_->getOrInsertFunction("snprintf", snprintfTy);
+    auto mallocFn = getStdlibMalloc();
+    auto snprintfFn = getStdlibSnprintf();
 
     if (ty == i1Ty_) {
         llvm::Constant *trueStr = builder_.CreateGlobalString("true", ".vts_true");
@@ -1113,12 +1096,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<InterpolatedStringEx
     }
 
     // Compute total length
-    auto strlenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-    auto strlenFn = mod_->getOrInsertFunction("strlen", strlenTy);
-    auto mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    auto mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
-    auto memcpyTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-    auto memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+    auto strlenFn = getStdlibStrlen();
+    auto mallocFn = getStdlibMalloc();
+    auto memcpyFn = getStdlibMemcpy();
 
     llvm::Value *totalLen = llvm::ConstantInt::get(i64Ty_, 0);
     std::vector<llvm::Value*> lengths;
@@ -1249,8 +1229,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<RangeExpr> &e) {
     uint64_t headerSize = dl.getTypeAllocSize(listHeaderTy_);
     uint64_t elemSize = dl.getTypeAllocSize(i64Ty_);
 
-    llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+    auto mallocFn = getStdlibMalloc();
 
     llvm::Value *headerPtr = builder_.CreateCall(
         mallocFn, {llvm::ConstantInt::get(i64Ty_, headerSize)}, "range_hdr");

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -3,7 +3,6 @@
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
 #include <functional>
-#include <stdexcept>
 
 // ===== LambdaExpr =====
 
@@ -226,8 +225,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
         closureFields.push_back(t);
     llvm::StructType *closureTy = llvm::StructType::get(*ctx_, closureFields);
 
-    llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+    auto mallocFn = getStdlibMalloc();
     const llvm::DataLayout &dl = mod_->getDataLayout();
     uint64_t closureSize = dl.getTypeAllocSize(closureTy);
     llvm::Value *closurePtr = builder_.CreateCall(

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -2,7 +2,6 @@
 #include "ry/diagnostic.hpp"
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
-#include <stdexcept>
 
 // ===== Directive helpers =====
 
@@ -26,8 +25,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             std::string inner = type_annotation->substr(4, type_annotation->size() - 5);
             llvm::Type *elemTy = resolveType(inner);
 
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+            auto mallocFn = getStdlibMalloc();
             const llvm::DataLayout &dl = mod_->getDataLayout();
 
             uint64_t headerSize = dl.getTypeAllocSize(setHeaderTy_);
@@ -59,8 +57,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             if (!keyTy || !valTy)
                 codegenError("invalid map type annotation: " + *type_annotation);
 
-            llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-            llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+            auto mallocFn = getStdlibMalloc();
             const llvm::DataLayout &dl = mod_->getDataLayout();
 
             uint64_t headerSize = dl.getTypeAllocSize(mapHeaderTy_);
@@ -95,28 +92,16 @@ void CodeGen::emitVarDecl(const std::string &name,
         codegenError("empty {} requires Set<T> or Map<K, V> type annotation");
     }
 
-    // Handle None literal
-    if (auto *ve = std::get_if<VariableExpr>(&value.data); ve && ve->name == "None") {
+    // Handle None literal (VariableExpr("None") or NoneExpr)
+    bool isNone = std::holds_alternative<NoneExpr>(value.data) ||
+                  (std::holds_alternative<VariableExpr>(value.data) &&
+                   std::get<VariableExpr>(value.data).name == "None");
+    if (isNone) {
         if (!type_annotation)
             codegenError("type annotation required for None");
         llvm::Type *annotTy = resolveType(*type_annotation);
         if (!isOptionType(annotTy))
             codegenError("None can only be assigned to Option type");
-        llvm::Value *val = buildNoneValue(annotTy);
-        llvm::AllocaInst *ptr = getOrCreateVar(name, annotTy);
-        builder_.CreateStore(val, ptr);
-        if (is_immutable)
-            immutable_scope_stack_.back().insert(name);
-        return;
-    }
-
-    // Handle none keyword
-    if (std::holds_alternative<NoneExpr>(value.data)) {
-        if (!type_annotation)
-            codegenError("type annotation required for none");
-        llvm::Type *annotTy = resolveType(*type_annotation);
-        if (!isOptionType(annotTy))
-            codegenError("none can only be assigned to Option type");
         llvm::Value *val = buildNoneValue(annotTy);
         llvm::AllocaInst *ptr = getOrCreateVar(name, annotTy);
         builder_.CreateStore(val, ptr);
@@ -873,8 +858,7 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
 
         llvm::Value *newCap = builder_.CreateMul(cap, llvm::ConstantInt::get(i64Ty_, 2), "new_cap");
 
-        llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-        llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
+        auto mallocFn = getStdlibMalloc();
 
         // New keys array
         llvm::Value *newKeySize = builder_.CreateMul(newCap, llvm::ConstantInt::get(i64Ty_, keySize), "new_key_size");
@@ -885,9 +869,7 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         llvm::Value *newValsPtr = builder_.CreateCall(mallocFn, {newValSize}, "new_vals");
 
         // memcpy old data
-        llvm::FunctionType *memcpyTy = llvm::FunctionType::get(
-            ptrTy_, {ptrTy_, ptrTy_, i64Ty_}, false);
-        llvm::FunctionCallee memcpyFn = mod_->getOrInsertFunction("memcpy", memcpyTy);
+        auto memcpyFn = getStdlibMemcpy();
 
         llvm::Value *keysPtrField2 = builder_.CreateStructGEP(mapHeaderTy_, objPtr, 2, "keys_field");
         llvm::Value *oldKeysPtr = builder_.CreateLoad(ptrTy_, keysPtrField2, "old_keys");
@@ -900,9 +882,7 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         builder_.CreateCall(memcpyFn, {newValsPtr, oldValsPtr, oldValSize});
 
         // Free old arrays
-        llvm::FunctionType *freeTy = llvm::FunctionType::get(
-            llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
-        llvm::FunctionCallee freeFn = mod_->getOrInsertFunction("free", freeTy);
+        auto freeFn = getStdlibFree();
         builder_.CreateCall(freeFn, {oldKeysPtr});
         builder_.CreateCall(freeFn, {oldValsPtr});
 


### PR DESCRIPTION
## Summary

- Extract 15 `getStdlib*` helper methods (`malloc`, `realloc`, `free`, `strlen`, `memcpy`, `memmove`, `memset`, `strcmp`, `strncmp`, `strstr`, `strcpy`, `strcat`, `snprintf`, `printf`, `exit`) replacing ~130 inline `FunctionType::get` + `getOrInsertFunction` patterns across all codegen files
- Extract `emitIsWhitespace()` helper from 4 duplicated inline whitespace checks in `trim`/`trim_start`/`trim_end`
- Unify duplicate `None`/`NoneExpr` handling into a single conditional in `emitVarDecl`
- Replace `const_cast` hack in `sort!`/`append!` with `ArgsRestoreGuard` RAII scope guard for exception safety
- Remove unused `#include <stdexcept>` from 5 codegen files

Net effect: -78 lines, no behavioral changes.

## Test plan

- [x] All 1106 C++ tests pass (`./build/ry_tests`)
- [x] All 15 Ry self-test files pass (`./build/ry test`)
- [x] Zero compiler warnings
- [x] Internal refactoring only — no docs/README changes needed