### PR TITLE
fix: guard utf8_char_len_safe() against truncated UTF-8 buffer overread

### DIFF
--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -9,8 +9,8 @@ static int utf8_char_len_safe(const char *s) {
     unsigned char c = static_cast<unsigned char>(s[0]);
     if (c < 0x80) return 1;
     if ((c & 0xE0) == 0xC0 && is_cont(s[1])) return 2;
-    if ((c & 0xF0) == 0xE0 && is_cont(s[1]) && is_cont(s[2])) return 3;
-    if ((c & 0xF8) == 0xF0 && is_cont(s[1]) && is_cont(s[2]) && is_cont(s[3])) return 4;
+    if ((c & 0xF0) == 0xE0 && is_cont(s[1]) && s[2] && is_cont(s[2])) return 3;
+    if ((c & 0xF8) == 0xF0 && is_cont(s[1]) && s[2] && is_cont(s[2]) && s[3] && is_cont(s[3])) return 4;
     return 1; // invalid/truncated byte treated as 1
 }
 

--- a/tests/test_runtime_utf8.cpp
+++ b/tests/test_runtime_utf8.cpp
@@ -35,6 +35,31 @@ TEST(RuntimeUtf8, Len4Byte) {
     EXPECT_EQ(__ry_utf8_len("\xF0\x9F\x98\x80\xF0\x9F\x98\x81"), 2);
 }
 
+TEST(RuntimeUtf8, LenTruncated2Byte) {
+    // Truncated 2-byte sequence: lead byte 0xC3 followed by '\0'
+    // Should treat the lead byte as 1 char
+    EXPECT_EQ(__ry_utf8_len("\xC3"), 1);
+}
+
+TEST(RuntimeUtf8, LenTruncated3Byte) {
+    // Truncated 3-byte: lead byte + 1 continuation, missing 2nd continuation
+    // 0xE3 0x81 → 2 invalid bytes, each counted as 1 char
+    EXPECT_EQ(__ry_utf8_len("\xE3\x81"), 2);
+    // Lead byte only: 0xE3 → 1 char
+    EXPECT_EQ(__ry_utf8_len("\xE3"), 1);
+}
+
+TEST(RuntimeUtf8, LenTruncated4Byte) {
+    // Truncated 4-byte: lead + 1 continuation
+    // 0xF0 0x9F → 2 invalid bytes
+    EXPECT_EQ(__ry_utf8_len("\xF0\x9F"), 2);
+    // Truncated 4-byte: lead + 2 continuations
+    // 0xF0 0x9F 0x98 → 3 invalid bytes
+    EXPECT_EQ(__ry_utf8_len("\xF0\x9F\x98"), 3);
+    // Lead byte only: 0xF0 → 1 char
+    EXPECT_EQ(__ry_utf8_len("\xF0"), 1);
+}
+
 TEST(RuntimeUtf8, CharAtAscii) {
     expectStr(__ry_utf8_char_at("hello", 0), "h");
     expectStr(__ry_utf8_char_at("hello", 4), "o");


### PR DESCRIPTION
## Summary

- `utf8_char_len_safe()` の3バイト・4バイトケースで、`s[2]` / `s[3]` にアクセスする前に明示的な `'\0'` チェックを追加
- 切り詰められた UTF-8 シーケンスが文字列末尾にある場合のバッファ外アクセス（未定義動作）を防止
- 切り詰められた UTF-8 シーケンスのテストを3件追加（2バイト・3バイト・4バイト各パターン）

Closes #91

## Test plan

- [x] `LenTruncated2Byte` — 切り詰められた2バイトシーケンスで長さ1を返す
- [x] `LenTruncated3Byte` — 切り詰められた3バイトシーケンスで各バイトを長さ1として扱う
- [x] `LenTruncated4Byte` — 切り詰められた4バイトシーケンスで各バイトを長さ1として扱う
- [x] 既存の全テスト（C++ 1200件、Ry セルフテスト 23ファイル）がパス