### PR TITLE
fix: enforce move-only semantics on Directive to prevent silent expr loss

### DIFF
--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -29,12 +29,8 @@ struct Directive {
     Directive() = default;
     Directive(Directive &&) = default;
     Directive &operator=(Directive &&) = default;
-    Directive(const Directive &o)
-        : name(o.name), params(o.params), expr(nullptr), loc(o.loc) {}
-    Directive &operator=(const Directive &o) {
-        if (this != &o) { name = o.name; params = o.params; expr = nullptr; loc = o.loc; }
-        return *this;
-    }
+    Directive(const Directive &) = delete;
+    Directive &operator=(const Directive &) = delete;
 };
 
 inline bool hasDirective(const std::vector<Directive> &directives, std::string_view name) {

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -512,14 +512,14 @@ void CodeGen::emitStmt(RecordStmt &s) {
         fieldTypes.push_back(resolveType(f.type));
 
     llvm::StructType *structTy = llvm::StructType::create(*ctx_, fieldTypes, s.name);
-    struct_types_[s.name] = {structTy, s.fields, std::move(s.invariants)};
-
     if (hasDirective(s.directives, "deprecated"))
         deprecated_types_.insert(s.name);
     for (auto &f : s.fields) {
         if (hasDirective(f.directives, "deprecated"))
             deprecated_fields_.insert(s.name + "." + f.name);
     }
+
+    struct_types_[s.name] = {structTy, std::move(s.fields), std::move(s.invariants)};
 }
 
 llvm::Value *CodeGen::emitStructConstructor(const StructInfo &info,


### PR DESCRIPTION
## Summary

- `Directive` のコピーコンストラクタ/代入演算子が `expr` を `nullptr` に設定しており、`@each` のデータが vector 再割り当て時にサイレントに失われるバグを修正
- コピー操作を `= delete` にして move-only セマンティクスを強制
- `emitStmt(RecordStmt&)` で `s.fields` の move を deprecated チェックの後に移動し use-after-move を回避

## Test plan

- [x] `cmake --build build` でコンパイル成功（コピー箇所がすべて解消されていることを確認）
- [x] `./build/ry_tests` — 1200 tests passed
- [x] `./build/ry test` — 23 test files, 0 failures

Closes #93