### PR TITLE
fix: copy nested stdlib modules recursively during self-update

### DIFF
--- a/lib/std/manifest.json
+++ b/lib/std/manifest.json
@@ -1,7 +1,8 @@
 {
-  "version": "0.0.3",
+  "version": "0.0.5",
   "files": [
     "builtins.ry", "convert.ry", "higher_order.ry",
-    "list.ry", "map.ry", "set.ry", "str.ry", "regex.ry"
+    "list.ry", "map.ry", "set.ry", "str.ry", "regex.ry",
+    "http/http.ry", "io/io.ry", "math/math.ry", "net/net.ry"
   ]
 }

--- a/src/self_update.cpp
+++ b/src/self_update.cpp
@@ -344,30 +344,39 @@ bool install_stdlib(const std::string &tmp_dir_str, const std::string &new_versi
         return false;
     }
 
-    // Copy new files
+    // Copy new files (recursive)
     std::vector<std::string> new_files;
-    for (const auto &entry : fs::directory_iterator(src_std)) {
+    for (const auto &entry : fs::recursive_directory_iterator(src_std)) {
         if (!entry.is_regular_file()) continue;
-        auto filename = entry.path().filename().string();
-        fs::copy_file(entry.path(), dest_std / filename,
+        auto rel_path = fs::relative(entry.path(), src_std).string();
+        if (rel_path == "manifest.json") continue;
+
+        auto dest_path = dest_std / rel_path;
+        fs::create_directories(dest_path.parent_path(), ec);
+        fs::copy_file(entry.path(), dest_path,
                       fs::copy_options::overwrite_existing, ec);
-        if (!ec && filename != "manifest.json") {
-            new_files.push_back(filename);
+        if (!ec) {
+            new_files.push_back(rel_path);
         }
     }
 
-    // Delete files that were in old manifest but not in new
+    // Delete files that were in old manifest but not in new,
+    // then clean up empty parent directories
     std::sort(new_files.begin(), new_files.end());
     for (const auto &old_file : old_manifest.files) {
-        // Validate manifest entry is a simple filename (no path traversal)
-        if (old_file.empty() || old_file == "." || old_file == ".." ||
-            old_file.find('/') != std::string::npos ||
-            old_file.find('\\') != std::string::npos) {
+        if (old_file.empty() || old_file.find("..") != std::string::npos ||
+            old_file[0] == '/' || old_file[0] == '\\') {
             std::cerr << "Warning: Skipping invalid stdlib manifest entry: " << old_file << "\n";
             continue;
         }
         if (!std::binary_search(new_files.begin(), new_files.end(), old_file)) {
             fs::remove(dest_std / old_file, ec);
+            // Remove empty parent directories up to dest_std
+            auto parent = (dest_std / old_file).parent_path();
+            while (parent != dest_std && fs::is_directory(parent) && fs::is_empty(parent)) {
+                fs::remove(parent, ec);
+                parent = parent.parent_path();
+            }
         }
     }
 

--- a/tests/test_self_update.cpp
+++ b/tests/test_self_update.cpp
@@ -1,8 +1,13 @@
 #include <gtest/gtest.h>
 #include "ry/self_update.hpp"
+#include "ry/paths.hpp"
+#include <filesystem>
+#include <fstream>
+#include <cstdlib>
 
 using namespace ry::self_update;
 using namespace ry::self_update::detail;
+namespace fs = std::filesystem;
 
 TEST(SelfUpdate, IsPrereleaseStable) {
     EXPECT_FALSE(is_prerelease("v0.0.1"));
@@ -80,4 +85,126 @@ TEST(SelfUpdate, IsValidTag) {
     EXPECT_FALSE(is_valid_tag("v0.0.1' && echo pwned"));
     EXPECT_FALSE(is_valid_tag("$(whoami)"));
     EXPECT_FALSE(is_valid_tag(""));
+}
+
+// --- install_stdlib tests ---
+
+class InstallStdlibTest : public ::testing::Test {
+protected:
+    fs::path tmp_root;
+    fs::path src_dir;   // simulated archive extraction dir
+    fs::path dest_home; // simulated RY_HOME
+    std::string old_ry_home;
+
+    void SetUp() override {
+        tmp_root = fs::temp_directory_path() / "ry_test_install_stdlib";
+        fs::remove_all(tmp_root);
+
+        src_dir = tmp_root / "archive";
+        dest_home = tmp_root / "ry_home";
+        fs::create_directories(src_dir / "lib" / "std");
+        fs::create_directories(dest_home / "lib" / "std");
+
+        // Save and override RY_HOME
+        if (const char *env = std::getenv("RY_HOME")) {
+            old_ry_home = env;
+        }
+        setenv("RY_HOME", dest_home.c_str(), 1);
+    }
+
+    void TearDown() override {
+        if (old_ry_home.empty()) {
+            unsetenv("RY_HOME");
+        } else {
+            setenv("RY_HOME", old_ry_home.c_str(), 1);
+        }
+        fs::remove_all(tmp_root);
+    }
+
+    void write_file(const fs::path &path, const std::string &content) {
+        fs::create_directories(path.parent_path());
+        std::ofstream(path) << content;
+    }
+};
+
+TEST_F(InstallStdlibTest, CopiesNestedModules) {
+    auto src_std = src_dir / "lib" / "std";
+    write_file(src_std / "builtins.ry", "# builtins");
+    write_file(src_std / "http" / "http.ry", "# http module");
+    write_file(src_std / "net" / "net.ry", "# net module");
+
+    bool ok = install_stdlib(src_dir.string(), "0.1.0");
+    ASSERT_TRUE(ok);
+
+    auto dest_std = dest_home / "lib" / "std";
+    EXPECT_TRUE(fs::exists(dest_std / "builtins.ry"));
+    EXPECT_TRUE(fs::exists(dest_std / "http" / "http.ry"));
+    EXPECT_TRUE(fs::exists(dest_std / "net" / "net.ry"));
+}
+
+TEST_F(InstallStdlibTest, ManifestContainsRelativePaths) {
+    auto src_std = src_dir / "lib" / "std";
+    write_file(src_std / "builtins.ry", "# builtins");
+    write_file(src_std / "http" / "http.ry", "# http");
+
+    install_stdlib(src_dir.string(), "0.1.0");
+
+    auto manifest = ry::read_manifest(dest_home / "lib" / "std");
+    EXPECT_EQ(manifest.version, "0.1.0");
+
+    // Check that both top-level and nested files are in the manifest
+    auto &files = manifest.files;
+    EXPECT_NE(std::find(files.begin(), files.end(), "builtins.ry"), files.end());
+    EXPECT_NE(std::find(files.begin(), files.end(), "http/http.ry"), files.end());
+}
+
+TEST_F(InstallStdlibTest, CleansUpOldNestedFiles) {
+    auto dest_std = dest_home / "lib" / "std";
+
+    // Pre-populate dest with an old nested file and manifest
+    write_file(dest_std / "old_mod" / "old.ry", "# old");
+    ry::write_manifest(dest_std, "0.0.1", {"old_mod/old.ry"});
+
+    // New archive has only builtins.ry
+    auto src_std = src_dir / "lib" / "std";
+    write_file(src_std / "builtins.ry", "# builtins");
+
+    install_stdlib(src_dir.string(), "0.1.0");
+
+    EXPECT_TRUE(fs::exists(dest_std / "builtins.ry"));
+    EXPECT_FALSE(fs::exists(dest_std / "old_mod" / "old.ry"));
+}
+
+TEST_F(InstallStdlibTest, CleansUpEmptyDirectories) {
+    auto dest_std = dest_home / "lib" / "std";
+
+    // Pre-populate with a nested file
+    write_file(dest_std / "removed_mod" / "removed.ry", "# removed");
+    ry::write_manifest(dest_std, "0.0.1", {"removed_mod/removed.ry"});
+
+    // New archive has no removed_mod
+    auto src_std = src_dir / "lib" / "std";
+    write_file(src_std / "builtins.ry", "# builtins");
+
+    install_stdlib(src_dir.string(), "0.1.0");
+
+    EXPECT_FALSE(fs::exists(dest_std / "removed_mod"));
+}
+
+TEST_F(InstallStdlibTest, CleansUpDeeplyNestedEmptyDirectories) {
+    auto dest_std = dest_home / "lib" / "std";
+
+    // Pre-populate with a deeply nested file (a/b/c.ry)
+    write_file(dest_std / "a" / "b" / "c.ry", "# deep");
+    ry::write_manifest(dest_std, "0.0.1", {"a/b/c.ry"});
+
+    // New archive has no a/b/c.ry
+    auto src_std = src_dir / "lib" / "std";
+    write_file(src_std / "builtins.ry", "# builtins");
+
+    install_stdlib(src_dir.string(), "0.1.0");
+
+    // Both a/b/ and a/ should be removed
+    EXPECT_FALSE(fs::exists(dest_std / "a" / "b"));
+    EXPECT_FALSE(fs::exists(dest_std / "a"));
 }


### PR DESCRIPTION
## Summary

- `install_stdlib()` used `directory_iterator` which only copied top-level `.ry` files, causing nested modules (`http/`, `io/`, `math/`, `net/`) to be missing after `self-update`
- Switched to `recursive_directory_iterator` and track relative paths (e.g. `http/http.ry`) in the manifest
- Clean up empty parent directories recursively when removing old files

## Changes

- **`src/self_update.cpp`** — Recursive copy, relative path tracking, unified cleanup loop with deep directory removal
- **`lib/std/manifest.json`** — Added nested modules to manifest
- **`tests/test_self_update.cpp`** — 5 new tests: nested copy, manifest relative paths, old file cleanup, empty dir cleanup, deeply nested dir cleanup

## Test plan

- [x] `./build/ry_tests --gtest_filter="InstallStdlib*"` — 5 tests pass
- [x] `./build/ry_tests` — 1209 tests pass
- [x] `./build/ry test` — 21 tests pass, 0 failures

Closes #108