### PR TITLE
security: verify self-update artifacts before install

### DIFF
--- a/include/ry/self_update.hpp
+++ b/include/ry/self_update.hpp
@@ -27,7 +27,12 @@ bool is_prerelease(const std::string &version);
 std::string build_download_url(const std::string &tag, const PlatformInfo &platform);
 UpdateTarget resolve_update_target(const std::string &mode, const PlatformInfo &platform);
 bool download_file(const std::string &url, const std::string &dest_path);
-std::string download_and_extract(const std::string &download_url);
+std::string build_checksums_url(const std::string &tag);
+std::string parse_checksum_for_file(const std::string &checksums_content, const std::string &filename);
+std::string compute_sha256(const std::string &file_path);
+bool verify_checksum(const std::string &archive_path, const std::string &expected_hash);
+bool validate_tar_entries(const std::string &archive_path);
+std::string download_and_extract(const std::string &download_url, const std::string &tag);
 bool replace_binary(const std::string &tmp_dir, const std::string &binary_path);
 bool install_stdlib(const std::string &tmp_dir, const std::string &new_version);
 

--- a/src/self_update.cpp
+++ b/src/self_update.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <sstream>
 #include <algorithm>
 #include <vector>
 #include <regex>
@@ -269,7 +270,119 @@ bool download_file(const std::string &url, const std::string &dest_path) {
     return run_command({"curl", "-sfL", "-o", dest_path, url}) == 0;
 }
 
-std::string download_and_extract(const std::string &download_url) {
+std::string build_checksums_url(const std::string &tag) {
+    return "https://github.com/" + std::string(REPO) +
+           "/releases/download/" + tag + "/checksums.txt";
+}
+
+std::string parse_checksum_for_file(const std::string &checksums_content, const std::string &filename) {
+    std::istringstream stream(checksums_content);
+    std::string line;
+
+    // Extract platform suffix for fallback matching (e.g., "darwin-arm64.tar.gz")
+    std::string suffix;
+    auto dash_pos = filename.rfind('-');
+    if (dash_pos != std::string::npos) {
+        // Look for the os-arch part: find second-to-last dash
+        auto prev_dash = filename.rfind('-', dash_pos - 1);
+        if (prev_dash != std::string::npos) {
+            suffix = filename.substr(prev_dash + 1);
+        }
+    }
+
+    std::string fallback_hash;
+
+    while (std::getline(stream, line)) {
+        if (line.empty()) continue;
+
+        // Format: "<hash>  <filename>" (two spaces) or "<hash> <filename>" (one space)
+        auto sep = line.find(' ');
+        if (sep == std::string::npos) continue;
+
+        std::string hash = line.substr(0, sep);
+        // Skip spaces
+        auto name_start = line.find_first_not_of(' ', sep);
+        if (name_start == std::string::npos) continue;
+        std::string entry_name = line.substr(name_start);
+
+        // Exact match
+        if (entry_name == filename) {
+            return hash;
+        }
+
+        // Fallback: match by platform suffix
+        if (!suffix.empty() && entry_name.size() >= suffix.size() &&
+            entry_name.substr(entry_name.size() - suffix.size()) == suffix) {
+            fallback_hash = hash;
+        }
+    }
+
+    return fallback_hash;
+}
+
+std::string compute_sha256(const std::string &file_path) {
+    std::string output;
+    if (run_command({"shasum", "-a", "256", file_path}, &output) != 0 || output.empty()) {
+        return "";
+    }
+    // Output format: "<hash>  <filename>"
+    auto sep = output.find(' ');
+    if (sep == std::string::npos) return "";
+    return output.substr(0, sep);
+}
+
+bool verify_checksum(const std::string &archive_path, const std::string &expected_hash) {
+    std::string actual_hash = compute_sha256(archive_path);
+    if (actual_hash.empty()) {
+        std::cerr << "Error: Failed to compute SHA-256 checksum.\n";
+        return false;
+    }
+    return actual_hash == expected_hash;
+}
+
+bool validate_tar_entries(const std::string &archive_path) {
+    std::string verbose_listing;
+    if (run_command({"tar", "-tvzf", archive_path}, &verbose_listing) != 0) {
+        std::cerr << "Error: Failed to list archive entries.\n";
+        return false;
+    }
+
+    std::istringstream stream(verbose_listing);
+    std::string line;
+    while (std::getline(stream, line)) {
+        if (line.empty()) continue;
+
+        // Symlink detection: verbose tar output starts with 'l' for symlinks
+        if (line[0] == 'l') {
+            std::cerr << "Error: Archive contains symlink entry: " << line << "\n";
+            return false;
+        }
+
+        // Extract the entry path (last whitespace-delimited field)
+        auto last_space = line.rfind(' ');
+        if (last_space == std::string::npos) continue;
+        std::string entry = line.substr(last_space + 1);
+        if (entry.empty()) continue;
+
+        // Reject absolute paths
+        if (entry[0] == '/') {
+            std::cerr << "Error: Archive contains absolute path: " << entry << "\n";
+            return false;
+        }
+
+        // Reject path traversal
+        if (entry == ".." || entry.find("../") != std::string::npos ||
+            entry.find("/../") != std::string::npos ||
+            (entry.size() >= 3 && entry.substr(entry.size() - 3) == "/..")) {
+            std::cerr << "Error: Archive contains path traversal: " << entry << "\n";
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::string download_and_extract(const std::string &download_url, const std::string &tag) {
     char tmp_dir[] = "/tmp/ry-update-XXXXXX";
     if (mkdtemp(tmp_dir) == nullptr) {
         std::cerr << "Error: Failed to create temporary directory.\n";
@@ -287,6 +400,45 @@ std::string download_and_extract(const std::string &download_url) {
         return "";
     }
     std::cerr << " done.\n";
+
+    // Checksum verification
+    std::string checksums_url = build_checksums_url(tag);
+    std::string checksums_path = tmp_dir_str + "/checksums.txt";
+    if (download_file(checksums_url, checksums_path)) {
+        std::ifstream ifs(checksums_path);
+        std::string checksums_content((std::istreambuf_iterator<char>(ifs)),
+                                       std::istreambuf_iterator<char>());
+
+        // Extract filename from download URL
+        std::string expected_filename;
+        auto slash_pos = download_url.rfind('/');
+        if (slash_pos != std::string::npos) {
+            expected_filename = download_url.substr(slash_pos + 1);
+        }
+
+        std::string expected_hash = parse_checksum_for_file(checksums_content, expected_filename);
+        if (expected_hash.empty()) {
+            std::cerr << "Warning: Could not find checksum for " << expected_filename << " in checksums.txt. Skipping verification.\n";
+        } else {
+            std::cerr << "Verifying checksum..." << std::flush;
+            if (!verify_checksum(archive_path, expected_hash)) {
+                std::cerr << " failed.\n";
+                std::cerr << "Error: Checksum verification failed. The downloaded file may be corrupted or tampered with.\n";
+                run_command({"rm", "-rf", tmp_dir_str});
+                return "";
+            }
+            std::cerr << " ok.\n";
+        }
+    } else {
+        std::cerr << "Warning: checksums.txt not available. Skipping checksum verification.\n";
+    }
+
+    // Validate tar entries before extraction
+    if (!validate_tar_entries(archive_path)) {
+        std::cerr << "Error: Archive contains unsafe entries. Aborting update.\n";
+        run_command({"rm", "-rf", tmp_dir_str});
+        return "";
+    }
 
     if (run_command({"tar", "xzf", archive_path, "-C", tmp_dir_str}) != 0) {
         std::cerr << "Error: Failed to extract archive.\n";
@@ -437,7 +589,7 @@ int cmd_self_update(int argc, char *argv[]) {
         return 1;
     }
 
-    std::string tmp_dir = detail::download_and_extract(target.download_url);
+    std::string tmp_dir = detail::download_and_extract(target.download_url, target.tag);
     if (tmp_dir.empty()) {
         return 1;
     }

--- a/tests/test_self_update.cpp
+++ b/tests/test_self_update.cpp
@@ -4,6 +4,7 @@
 #include <filesystem>
 #include <fstream>
 #include <cstdlib>
+#include <cstdio>
 
 using namespace ry::self_update;
 using namespace ry::self_update::detail;
@@ -207,4 +208,148 @@ TEST_F(InstallStdlibTest, CleansUpDeeplyNestedEmptyDirectories) {
     // Both a/b/ and a/ should be removed
     EXPECT_FALSE(fs::exists(dest_std / "a" / "b"));
     EXPECT_FALSE(fs::exists(dest_std / "a"));
+}
+
+// --- Checksum verification tests ---
+
+TEST(SelfUpdate, BuildChecksumsUrl) {
+    auto url = build_checksums_url("v0.0.5");
+    EXPECT_EQ(url, "https://github.com/t0k0sh1/ry/releases/download/v0.0.5/checksums.txt");
+}
+
+TEST(SelfUpdate, ParseChecksumForFileExactMatch) {
+    std::string content =
+        "abc123def456  ry-darwin-arm64.tar.gz\n"
+        "789012fed345  ry-linux-amd64.tar.gz\n";
+
+    EXPECT_EQ(parse_checksum_for_file(content, "ry-darwin-arm64.tar.gz"), "abc123def456");
+    EXPECT_EQ(parse_checksum_for_file(content, "ry-linux-amd64.tar.gz"), "789012fed345");
+}
+
+TEST(SelfUpdate, ParseChecksumForFileFallback) {
+    // CI produces "ry-v0.0.5-darwin-arm64.tar.gz" but download URL uses "ry-darwin-arm64.tar.gz"
+    std::string content =
+        "abc123def456  ry-v0.0.5-darwin-arm64.tar.gz\n"
+        "789012fed345  ry-v0.0.5-linux-amd64.tar.gz\n";
+
+    // Exact match fails, but fallback by platform suffix should work
+    EXPECT_EQ(parse_checksum_for_file(content, "ry-darwin-arm64.tar.gz"), "abc123def456");
+    EXPECT_EQ(parse_checksum_for_file(content, "ry-linux-amd64.tar.gz"), "789012fed345");
+}
+
+TEST(SelfUpdate, ParseChecksumForFileNotFound) {
+    std::string content = "abc123  ry-darwin-arm64.tar.gz\n";
+    EXPECT_EQ(parse_checksum_for_file(content, "ry-windows-amd64.tar.gz"), "");
+}
+
+TEST(SelfUpdate, ParseChecksumForFileEmpty) {
+    EXPECT_EQ(parse_checksum_for_file("", "ry-darwin-arm64.tar.gz"), "");
+}
+
+TEST(SelfUpdate, ParseChecksumForFileMalformed) {
+    // Lines without proper separator
+    std::string content = "nospacehere\n";
+    EXPECT_EQ(parse_checksum_for_file(content, "nospacehere"), "");
+}
+
+TEST(SelfUpdate, ComputeSha256KnownContent) {
+    auto tmp = fs::temp_directory_path() / "ry_test_sha256";
+    {
+        std::ofstream ofs(tmp);
+        ofs << "hello world\n";
+    }
+    std::string hash = compute_sha256(tmp.string());
+    EXPECT_FALSE(hash.empty());
+    // sha256 of "hello world\n" is well-known
+    EXPECT_EQ(hash, "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447");
+    fs::remove(tmp);
+}
+
+TEST(SelfUpdate, VerifyChecksumCorrect) {
+    auto tmp = fs::temp_directory_path() / "ry_test_verify";
+    {
+        std::ofstream ofs(tmp);
+        ofs << "hello world\n";
+    }
+    EXPECT_TRUE(verify_checksum(tmp.string(), "a948904f2f0f479b8f8197694b30184b0d2ed1c1cd2a1ec0fb85d299a192a447"));
+    fs::remove(tmp);
+}
+
+TEST(SelfUpdate, VerifyChecksumWrong) {
+    auto tmp = fs::temp_directory_path() / "ry_test_verify_bad";
+    {
+        std::ofstream ofs(tmp);
+        ofs << "hello world\n";
+    }
+    EXPECT_FALSE(verify_checksum(tmp.string(), "0000000000000000000000000000000000000000000000000000000000000000"));
+    fs::remove(tmp);
+}
+
+// --- Tar validation tests ---
+
+class TarValidationTest : public ::testing::Test {
+protected:
+    fs::path tmp_root;
+
+    void SetUp() override {
+        tmp_root = fs::temp_directory_path() / "ry_test_tar_validation";
+        fs::remove_all(tmp_root);
+        fs::create_directories(tmp_root);
+    }
+
+    void TearDown() override {
+        fs::remove_all(tmp_root);
+    }
+};
+
+TEST_F(TarValidationTest, SafeArchive) {
+    // Create a safe tar archive
+    auto content_dir = tmp_root / "content";
+    fs::create_directories(content_dir / "lib" / "std");
+    { std::ofstream(content_dir / "ry") << "binary"; }
+    { std::ofstream(content_dir / "lib" / "std" / "builtins.ry") << "# builtins"; }
+
+    auto archive = tmp_root / "safe.tar.gz";
+    run_command({"tar", "-czf", archive.string(), "-C", content_dir.string(), "ry", "lib"});
+
+    EXPECT_TRUE(validate_tar_entries(archive.string()));
+}
+
+TEST_F(TarValidationTest, PathTraversal) {
+    auto archive = tmp_root / "traversal.tar.gz";
+    // Use python to create a tar with path traversal entry (portable across macOS/Linux)
+    std::string script =
+        "import tarfile, io\n"
+        "with tarfile.open('" + archive.string() + "', 'w:gz') as t:\n"
+        "    info = tarfile.TarInfo(name='../etc/passwd')\n"
+        "    info.size = 4\n"
+        "    t.addfile(info, io.BytesIO(b'evil'))\n";
+    run_command({"python3", "-c", script});
+
+    EXPECT_FALSE(validate_tar_entries(archive.string()));
+}
+
+TEST_F(TarValidationTest, AbsolutePath) {
+    auto archive = tmp_root / "absolute.tar.gz";
+    std::string script =
+        "import tarfile, io\n"
+        "with tarfile.open('" + archive.string() + "', 'w:gz') as t:\n"
+        "    info = tarfile.TarInfo(name='/etc/passwd')\n"
+        "    info.size = 4\n"
+        "    t.addfile(info, io.BytesIO(b'evil'))\n";
+    run_command({"python3", "-c", script});
+
+    EXPECT_FALSE(validate_tar_entries(archive.string()));
+}
+
+TEST_F(TarValidationTest, Symlink) {
+    // Create a tar archive containing a symlink
+    auto content_dir = tmp_root / "content";
+    fs::create_directories(content_dir);
+    fs::create_symlink("/etc/passwd", content_dir / "link");
+
+    auto archive = tmp_root / "symlink.tar.gz";
+    run_command({"tar", "-czf", archive.string(), "-C", content_dir.string(), "link"});
+
+    EXPECT_FALSE(validate_tar_entries(archive.string()));
 }


### PR DESCRIPTION
## Summary

- self-update でダウンロードした tarball を SHA-256 チェックサムで検証するようにした
- tar 展開前に path traversal、絶対パス、symlink を含む危険なエントリを検出・拒否するようにした
- 検証失敗時は既存のバイナリ・stdlib を一切変更せずに中断する

## Changes

- `build_checksums_url()` — リリースの checksums.txt URL を構築
- `parse_checksum_for_file()` — checksums.txt をパースし、プラットフォーム suffix によるフォールバックマッチに対応
- `compute_sha256()` / `verify_checksum()` — `shasum -a 256` によるハッシュ計算・照合
- `validate_tar_entries()` — `tar -tvzf` の出力から symlink、path traversal、絶対パスを検出
- `download_and_extract()` をリファクタリングし、ダウンロード後に検証ステップを挿入

## Test plan

- [x] `BuildChecksumsUrl` — URL 構築テスト
- [x] `ParseChecksumForFileExactMatch` / `Fallback` / `NotFound` / `Empty` / `Malformed` — checksums.txt パーステスト
- [x] `ComputeSha256KnownContent` — 既知コンテンツの SHA-256 検証
- [x] `VerifyChecksumCorrect` / `VerifyChecksumWrong` — チェックサム照合テスト
- [x] `ValidateTarEntries` (Safe / PathTraversal / AbsolutePath / Symlink) — tar 安全性検証テスト
- [x] 全 C++ テスト (1226 passed)
- [x] 全 Ry セルフテスト (24 files, 0 failures)

Closes #110