### PR TITLE
feat: add comprehensive HTTP status code reason phrases

### DIFF
--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -101,22 +101,50 @@ http_listen("127.0.0.1", 8080, fn(req: HttpRequest) -> HttpResponse:
 
 ## Supported Status Codes
 
-The following status codes have standard reason phrases:
+The following status codes have standard reason phrases (RFC 9110):
 
 | Code | Reason |
 |------|--------|
+| 100 | Continue |
+| 101 | Switching Protocols |
 | 200 | OK |
 | 201 | Created |
+| 202 | Accepted |
+| 203 | Non-Authoritative Information |
 | 204 | No Content |
+| 205 | Reset Content |
+| 206 | Partial Content |
+| 300 | Multiple Choices |
 | 301 | Moved Permanently |
 | 302 | Found |
+| 303 | See Other |
 | 304 | Not Modified |
+| 307 | Temporary Redirect |
+| 308 | Permanent Redirect |
 | 400 | Bad Request |
 | 401 | Unauthorized |
 | 403 | Forbidden |
 | 404 | Not Found |
 | 405 | Method Not Allowed |
+| 406 | Not Acceptable |
+| 408 | Request Timeout |
+| 409 | Conflict |
+| 410 | Gone |
+| 411 | Length Required |
+| 413 | Content Too Large |
+| 414 | URI Too Long |
+| 415 | Unsupported Media Type |
+| 416 | Range Not Satisfiable |
+| 417 | Expectation Failed |
+| 422 | Unprocessable Content |
+| 426 | Upgrade Required |
+| 429 | Too Many Requests |
 | 500 | Internal Server Error |
+| 501 | Not Implemented |
+| 502 | Bad Gateway |
+| 503 | Service Unavailable |
+| 504 | Gateway Timeout |
+| 505 | HTTP Version Not Supported |
 
 Other status codes use `"Unknown"` as the reason phrase.
 

--- a/include/ry/runtime_http.hpp
+++ b/include/ry/runtime_http.hpp
@@ -18,4 +18,8 @@ void        __ry_http_response_free(void *resp);
 // Returns >= 0 on success, -1 if null (no header), -2 if invalid, -3 if exceeds max.
 int64_t     __ry_http_parse_content_length(const char *value);
 
+// Map an HTTP status code to its RFC 9110 reason phrase.
+// Returns "Unknown" for unrecognized codes.
+const char *__ry_http_reason_phrase(int64_t status);
+
 }

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -264,27 +264,57 @@ extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, co
     return resp;
 }
 
+extern "C" const char *__ry_http_reason_phrase(int64_t status) {
+    switch (status) {
+        case 100: return "Continue";
+        case 101: return "Switching Protocols";
+        case 200: return "OK";
+        case 201: return "Created";
+        case 202: return "Accepted";
+        case 203: return "Non-Authoritative Information";
+        case 204: return "No Content";
+        case 205: return "Reset Content";
+        case 206: return "Partial Content";
+        case 300: return "Multiple Choices";
+        case 301: return "Moved Permanently";
+        case 302: return "Found";
+        case 303: return "See Other";
+        case 304: return "Not Modified";
+        case 307: return "Temporary Redirect";
+        case 308: return "Permanent Redirect";
+        case 400: return "Bad Request";
+        case 401: return "Unauthorized";
+        case 403: return "Forbidden";
+        case 404: return "Not Found";
+        case 405: return "Method Not Allowed";
+        case 406: return "Not Acceptable";
+        case 408: return "Request Timeout";
+        case 409: return "Conflict";
+        case 410: return "Gone";
+        case 411: return "Length Required";
+        case 413: return "Content Too Large";
+        case 414: return "URI Too Long";
+        case 415: return "Unsupported Media Type";
+        case 416: return "Range Not Satisfiable";
+        case 417: return "Expectation Failed";
+        case 422: return "Unprocessable Content";
+        case 426: return "Upgrade Required";
+        case 429: return "Too Many Requests";
+        case 500: return "Internal Server Error";
+        case 501: return "Not Implemented";
+        case 502: return "Bad Gateway";
+        case 503: return "Service Unavailable";
+        case 504: return "Gateway Timeout";
+        case 505: return "HTTP Version Not Supported";
+        default: return "Unknown";
+    }
+}
+
 extern "C" void __ry_http_send_response(void *stream, void *response) {
     auto *handle = (TcpStreamHandle *)stream;
     auto *resp = (HttpResponseHandle *)response;
 
-    // Map status code to reason phrase
-    const char *reason = "OK";
-    switch (resp->status) {
-        case 200: reason = "OK"; break;
-        case 201: reason = "Created"; break;
-        case 204: reason = "No Content"; break;
-        case 301: reason = "Moved Permanently"; break;
-        case 302: reason = "Found"; break;
-        case 304: reason = "Not Modified"; break;
-        case 400: reason = "Bad Request"; break;
-        case 401: reason = "Unauthorized"; break;
-        case 403: reason = "Forbidden"; break;
-        case 404: reason = "Not Found"; break;
-        case 405: reason = "Method Not Allowed"; break;
-        case 500: reason = "Internal Server Error"; break;
-        default: reason = "Unknown"; break;
-    }
+    const char *reason = __ry_http_reason_phrase(resp->status);
 
     // Estimate response size to avoid repeated reallocations
     size_t body_len = strlen(resp->body);

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -7,6 +7,7 @@
 
 extern "C" {
 int64_t __ry_http_parse_content_length(const char *value);
+const char *__ry_http_reason_phrase(int64_t status);
 void *__ry_http_read_request(void *stream);
 const char *__ry_http_method(void *req);
 const char *__ry_http_path(void *req);
@@ -18,6 +19,69 @@ void __ry_http_request_free(void *req);
 struct TcpStreamHandle {
     int fd;
 };
+
+// --- Unit tests for __ry_http_reason_phrase ---
+
+TEST(RuntimeHttp, ReasonPhrase1xx) {
+    EXPECT_STREQ(__ry_http_reason_phrase(100), "Continue");
+    EXPECT_STREQ(__ry_http_reason_phrase(101), "Switching Protocols");
+}
+
+TEST(RuntimeHttp, ReasonPhrase2xx) {
+    EXPECT_STREQ(__ry_http_reason_phrase(200), "OK");
+    EXPECT_STREQ(__ry_http_reason_phrase(201), "Created");
+    EXPECT_STREQ(__ry_http_reason_phrase(202), "Accepted");
+    EXPECT_STREQ(__ry_http_reason_phrase(203), "Non-Authoritative Information");
+    EXPECT_STREQ(__ry_http_reason_phrase(204), "No Content");
+    EXPECT_STREQ(__ry_http_reason_phrase(205), "Reset Content");
+    EXPECT_STREQ(__ry_http_reason_phrase(206), "Partial Content");
+}
+
+TEST(RuntimeHttp, ReasonPhrase3xx) {
+    EXPECT_STREQ(__ry_http_reason_phrase(300), "Multiple Choices");
+    EXPECT_STREQ(__ry_http_reason_phrase(301), "Moved Permanently");
+    EXPECT_STREQ(__ry_http_reason_phrase(302), "Found");
+    EXPECT_STREQ(__ry_http_reason_phrase(303), "See Other");
+    EXPECT_STREQ(__ry_http_reason_phrase(304), "Not Modified");
+    EXPECT_STREQ(__ry_http_reason_phrase(307), "Temporary Redirect");
+    EXPECT_STREQ(__ry_http_reason_phrase(308), "Permanent Redirect");
+}
+
+TEST(RuntimeHttp, ReasonPhrase4xx) {
+    EXPECT_STREQ(__ry_http_reason_phrase(400), "Bad Request");
+    EXPECT_STREQ(__ry_http_reason_phrase(401), "Unauthorized");
+    EXPECT_STREQ(__ry_http_reason_phrase(403), "Forbidden");
+    EXPECT_STREQ(__ry_http_reason_phrase(404), "Not Found");
+    EXPECT_STREQ(__ry_http_reason_phrase(405), "Method Not Allowed");
+    EXPECT_STREQ(__ry_http_reason_phrase(406), "Not Acceptable");
+    EXPECT_STREQ(__ry_http_reason_phrase(408), "Request Timeout");
+    EXPECT_STREQ(__ry_http_reason_phrase(409), "Conflict");
+    EXPECT_STREQ(__ry_http_reason_phrase(410), "Gone");
+    EXPECT_STREQ(__ry_http_reason_phrase(411), "Length Required");
+    EXPECT_STREQ(__ry_http_reason_phrase(413), "Content Too Large");
+    EXPECT_STREQ(__ry_http_reason_phrase(414), "URI Too Long");
+    EXPECT_STREQ(__ry_http_reason_phrase(415), "Unsupported Media Type");
+    EXPECT_STREQ(__ry_http_reason_phrase(416), "Range Not Satisfiable");
+    EXPECT_STREQ(__ry_http_reason_phrase(417), "Expectation Failed");
+    EXPECT_STREQ(__ry_http_reason_phrase(422), "Unprocessable Content");
+    EXPECT_STREQ(__ry_http_reason_phrase(426), "Upgrade Required");
+    EXPECT_STREQ(__ry_http_reason_phrase(429), "Too Many Requests");
+}
+
+TEST(RuntimeHttp, ReasonPhrase5xx) {
+    EXPECT_STREQ(__ry_http_reason_phrase(500), "Internal Server Error");
+    EXPECT_STREQ(__ry_http_reason_phrase(501), "Not Implemented");
+    EXPECT_STREQ(__ry_http_reason_phrase(502), "Bad Gateway");
+    EXPECT_STREQ(__ry_http_reason_phrase(503), "Service Unavailable");
+    EXPECT_STREQ(__ry_http_reason_phrase(504), "Gateway Timeout");
+    EXPECT_STREQ(__ry_http_reason_phrase(505), "HTTP Version Not Supported");
+}
+
+TEST(RuntimeHttp, ReasonPhraseUnknown) {
+    EXPECT_STREQ(__ry_http_reason_phrase(0), "Unknown");
+    EXPECT_STREQ(__ry_http_reason_phrase(999), "Unknown");
+    EXPECT_STREQ(__ry_http_reason_phrase(299), "Unknown");
+}
 
 // --- Unit tests for __ry_http_parse_content_length ---
 


### PR DESCRIPTION
## Summary

- Extract inline status-to-reason switch into a standalone `__ry_http_reason_phrase()` function for testability and reuse
- Expand supported HTTP status codes from 11 to 39 (RFC 9110 coverage across 1xx–5xx)
- Add 6 unit test cases covering every supported code and unknown-code fallback
- Update `docs/reference/http.md` with the full status code table

Closes #84

## Test plan

- [x] `./build/ry_tests --gtest_filter='RuntimeHttp.ReasonPhrase*'` — 6 tests pass
- [x] `./build/ry_tests` — 1253 tests pass
- [x] `./build/ry test` — 21 tests pass, 0 failures