### PR TITLE
fix: unify TCP error handling to return Result instead of exit(1)

### DIFF
--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -22,7 +22,7 @@ from std.net import bind, listen, accept, connect
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `bind` | `(host: str, port: int) -> Result<TcpListener, Error>` | Creates a TCP server socket bound to the given address. Returns `Err` on failure. |
-| `listen` | `(listener: TcpListener, backlog: int) -> Unit` | Starts listening for incoming connections. Runtime error on failure. |
+| `listen` | `(listener: TcpListener, backlog: int) -> Result<Unit, Error>` | Starts listening for incoming connections. Returns `Err` on failure. |
 | `accept` | `(listener: TcpListener) -> Result<TcpStream, Error>` | Accepts a new connection. Waits up to 1 second for a client to connect. Returns `Err` on timeout or failure. |
 | `connect` | `(host: str, port: int) -> Result<TcpStream, Error>` | Connects to a remote TCP server. Times out after 5 seconds. Returns `Err` on timeout or failure. |
 
@@ -32,8 +32,8 @@ These functions are built-in and work with both `Channel<T>` and TCP socket type
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `send` | `(stream: TcpStream, data: List<byte>) -> int` | Sends bytes through a TCP connection. Returns the number of bytes sent. Runtime error on failure. |
-| `recv` | `(stream: TcpStream, max: int) -> List<byte>` | Receives up to `max` bytes from a TCP connection. Returns an empty list on connection close. |
+| `send` | `(stream: TcpStream, data: List<byte>) -> Result<int, Error>` | Sends bytes through a TCP connection. Returns `Ok` with the number of bytes sent, or `Err` on failure. |
+| `recv` | `(stream: TcpStream, max: int) -> Result<List<byte>, Error>` | Receives up to `max` bytes from a TCP connection. Returns `Ok` with an empty list on connection close, or `Err` on error. |
 | `close` | `(handle: TcpStream) -> Unit` | Closes a TCP stream. |
 | `close` | `(handle: TcpListener) -> Unit` | Closes a TCP listener. |
 
@@ -48,14 +48,24 @@ from std.io import str_to_bytes, bytes_to_str
 # Server
 match bind("127.0.0.1", 8080):
     case Ok(server):
-        listen(server, 128)
-        match accept(server):
-            case Ok(conn):
-                data: List<byte> = recv(conn, 4096)
-                send(conn, data)
-                close(conn)
+        match listen(server, 128):
+            case Ok(_):
+                match accept(server):
+                    case Ok(conn):
+                        match recv(conn, 4096):
+                            case Ok(data):
+                                match send(conn, data):
+                                    case Ok(_):
+                                        ...
+                                    case Err(e):
+                                        print(e.message)
+                            case Err(e):
+                                print(e.message)
+                        close(conn)
+                    case Err(e):
+                        ...
             case Err(e):
-                ...
+                print("listen failed")
         close(server)
     case Err(e):
         print("bind failed")
@@ -66,11 +76,18 @@ match bind("127.0.0.1", 8080):
 ```python
 match connect("127.0.0.1", 8080):
     case Ok(conn):
-        send(conn, str_to_bytes("hello"))
-        resp: List<byte> = recv(conn, 4096)
-        match bytes_to_str(resp):
-            case Ok(s):
-                print(s)
+        match send(conn, str_to_bytes("hello")):
+            case Ok(_):
+                ...
+            case Err(e):
+                print(e.message)
+        match recv(conn, 4096):
+            case Ok(resp):
+                match bytes_to_str(resp):
+                    case Ok(s):
+                        print(s)
+                    case Err(e):
+                        print(e.message)
             case Err(e):
                 print(e.message)
         close(conn)
@@ -84,12 +101,22 @@ match connect("127.0.0.1", 8080):
 fn echo_server(port: int) -> str:
     match bind("127.0.0.1", port):
         case Ok(server):
-            listen(server, 1)
-            match accept(server):
-                case Ok(conn):
-                    data: List<byte> = recv(conn, 4096)
-                    send(conn, data)
-                    close(conn)
+            match listen(server, 1):
+                case Ok(_):
+                    match accept(server):
+                        case Ok(conn):
+                            match recv(conn, 4096):
+                                case Ok(data):
+                                    match send(conn, data):
+                                        case Ok(_):
+                                            ...
+                                        case Err(e):
+                                            ...
+                                case Err(e):
+                                    ...
+                            close(conn)
+                        case Err(e):
+                            ...
                 case Err(e):
                     ...
             close(server)
@@ -104,10 +131,8 @@ join(t)
 
 ## Error Handling
 
-- `bind()` and `connect()` return `Result<T, Error>` — use `match` with `Ok`/`Err` to handle failure.
-- `listen()` raises a runtime error on failure.
-- `send()` raises a runtime error on failure.
-- `recv()` returns an empty `List<byte>` when the connection is closed or when a receive error occurs; unlike `listen()`/`send()`, it does not raise on failure.
+- All TCP functions except `close()` return `Result<T, Error>` — use `match` with `Ok`/`Err` to handle failure.
+- `recv()` returns `Ok` with an empty `List<byte>` when the connection is closed by the peer, and `Err` on actual errors (timeout, socket error).
 - `close()` closes the socket and frees the handle. Using a handle after close is undefined behavior.
 
 ## Byte Conversion

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -290,6 +290,7 @@ private:
     bool isResultType(llvm::Type *ty);
     llvm::Value *buildOkValue(llvm::Value *inner, llvm::StructType *resultTy);
     llvm::Value *buildErrValue(llvm::Value *inner, llvm::StructType *resultTy);
+    llvm::Value *buildStaticError(const std::string &msg, const std::string &globalName);
     std::pair<llvm::Type*, llvm::Type*> parseMapTypeAnnotation(const std::string &typeStr);
     FnTypeInfo parseFnTypeAnnotation(const std::string &typeStr);
     void emitRuntimeError(const std::string &message, const std::string &globalName);

--- a/include/ry/runtime_net.hpp
+++ b/include/ry/runtime_net.hpp
@@ -11,7 +11,7 @@ ssize_t __ry_send_all(int fd, const void *buf, size_t len);
 extern "C" {
 
 void *__ry_bind(const char *host, int64_t port);
-void  __ry_listen(void *listener, int64_t backlog);
+int64_t __ry_listen(void *listener, int64_t backlog);
 void *__ry_accept(void *listener);
 void *__ry_connect(const char *host, int64_t port);
 int64_t __ry_tcp_send(void *stream, void *byte_list);

--- a/lib/std/net/net.ry
+++ b/lib/std/net/net.ry
@@ -4,7 +4,7 @@
 fn bind(host: str, port: int) -> Option<TcpListener>
 
 @native
-fn listen(listener: TcpListener, backlog: int) -> Unit
+fn listen(listener: TcpListener, backlog: int) -> Result<Unit, Error>
 
 @native
 fn accept(listener: TcpListener) -> Option<TcpStream>

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -716,6 +716,14 @@ llvm::Value *CodeGen::buildErrValue(llvm::Value *inner, llvm::StructType *result
     return val;
 }
 
+llvm::Value *CodeGen::buildStaticError(const std::string &msg, const std::string &globalName) {
+    llvm::Value *errMsgStr = builder_.CreateGlobalString(msg, globalName);
+    llvm::Value *errStruct = llvm::UndefValue::get(errorTy_);
+    errStruct = builder_.CreateInsertValue(errStruct, errMsgStr, 0, "err.msg");
+    errStruct = builder_.CreateInsertValue(errStruct, llvm::ConstantInt::get(i64Ty_, 0), 1, "err.code");
+    return errStruct;
+}
+
 std::pair<llvm::Type*, llvm::Type*> CodeGen::parseMapTypeAnnotation(const std::string &typeStr) {
     std::string inner = typeStr.substr(4, typeStr.size() - 5);
     size_t depth = 0;

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -1320,7 +1320,14 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
                 codegenError("send() with TcpStream requires List<byte> as second argument");
             auto fnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, ptrTy_}, false);
             auto fn = mod_->getOrInsertFunction("__ry_tcp_send", fnTy);
-            return builder_.CreateCall(fn, {firstArg, data}, "tcp_send");
+            llvm::Value *sent = builder_.CreateCall(fn, {firstArg, data}, "tcp_send");
+            // Wrap in Result<int, Error>
+            llvm::Value *isErr = builder_.CreateICmpSLT(sent,
+                llvm::ConstantInt::get(i64Ty_, 0), "send_err");
+            llvm::StructType *resTy = getResultType(i64Ty_, errorTy_);
+            llvm::Value *okVal = buildOkValue(sent, resTy);
+            llvm::Value *errVal = buildErrValue(buildStaticError("tcp send failed", ".send_err_msg"), resTy);
+            return builder_.CreateSelect(isErr, errVal, okVal, "send_result");
         }
         llvm::Value *channelVal = firstArg;
         llvm::Type *elemTy = getChannelElementType(channelVal);
@@ -1368,14 +1375,21 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
 
     if (e.callee == "recv") {
         if (e.args.size() == 2) {
-            // TCP recv(stream, max_bytes)
+            // TCP recv(stream, max_bytes) -> Result<List<byte>, Error>
             llvm::Value *streamVal = emitExpr(*e.args[0]);
             if (!isTcpStream(streamVal))
                 codegenError("recv() with 2 arguments requires TcpStream as first argument");
             llvm::Value *maxBytes = emitExpr(*e.args[1]);
             auto fnTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, i64Ty_}, false);
             auto fn = mod_->getOrInsertFunction("__ry_tcp_recv", fnTy);
-            llvm::Value *result = builder_.CreateCall(fn, {streamVal, maxBytes}, "tcp_recv");
+            llvm::Value *ptr = builder_.CreateCall(fn, {streamVal, maxBytes}, "tcp_recv");
+            // Wrap in Result<List<byte>, Error>: nullptr = Err, non-null = Ok
+            llvm::Value *isNull = builder_.CreateICmpEQ(ptr,
+                llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)), "recv_null");
+            llvm::StructType *resTy = getResultType(ptrTy_, errorTy_);
+            llvm::Value *okVal = buildOkValue(ptr, resTy);
+            llvm::Value *errVal = buildErrValue(buildStaticError("tcp recv failed", ".recv_err_msg"), resTy);
+            llvm::Value *result = builder_.CreateSelect(isNull, errVal, okVal, "recv_result");
             list_element_types_[result] = i8Ty_;
             return result;
         }
@@ -4455,12 +4469,7 @@ llvm::Value *CodeGen::emitBuiltinNet(const CallExpr &e) {
             llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)), name + "_null");
         llvm::StructType *resTy = getResultType(ptrTy_, errorTy_);
         llvm::Value *okVal = buildOkValue(ptr, resTy);
-        // Build Error from static message
-        llvm::Value *errMsgStr = builder_.CreateGlobalString(errMsg, "." + name + "_err_msg");
-        llvm::Value *errStruct = llvm::UndefValue::get(errorTy_);
-        errStruct = builder_.CreateInsertValue(errStruct, errMsgStr, 0, "err.msg");
-        errStruct = builder_.CreateInsertValue(errStruct, llvm::ConstantInt::get(i64Ty_, 0), 1, "err.code");
-        llvm::Value *errVal = buildErrValue(errStruct, resTy);
+        llvm::Value *errVal = buildErrValue(buildStaticError(errMsg, "." + name + "_err_msg"), resTy);
         llvm::Value *res = builder_.CreateSelect(isNull, errVal, okVal, name + "_result");
         trackingSet.insert(res);
         return res;
@@ -4478,7 +4487,7 @@ llvm::Value *CodeGen::emitBuiltinNet(const CallExpr &e) {
         return emitPtrToResult(result, "bind", "bind failed", tcp_listener_values_);
     }
 
-    // listen(listener, backlog) -> Unit
+    // listen(listener, backlog) -> Result<Unit, Error>
     if (e.callee == "listen") {
         if (e.args.size() != 2)
             codegenError("listen() takes exactly 2 arguments");
@@ -4486,10 +4495,16 @@ llvm::Value *CodeGen::emitBuiltinNet(const CallExpr &e) {
         if (!isTcpListener(listener))
             codegenError("listen() requires TcpListener as first argument");
         llvm::Value *backlog = emitExpr(*e.args[1]);
-        auto fnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_, i64Ty_}, false);
+        auto fnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, i64Ty_}, false);
         auto fn = mod_->getOrInsertFunction("__ry_listen", fnTy);
-        builder_.CreateCall(fn, {listener, backlog});
-        return llvm::ConstantInt::get(i64Ty_, 0);
+        llvm::Value *status = builder_.CreateCall(fn, {listener, backlog}, "listen_status");
+        // Wrap in Result<Unit, Error>
+        llvm::Value *isErr = builder_.CreateICmpNE(status,
+            llvm::ConstantInt::get(i64Ty_, 0), "listen_err");
+        llvm::StructType *resTy = getResultType(i8Ty_, errorTy_);
+        llvm::Value *okVal = buildOkValue(llvm::ConstantInt::get(i8Ty_, 0), resTy);
+        llvm::Value *errVal = buildErrValue(buildStaticError("listen failed", ".listen_err_msg"), resTy);
+        return builder_.CreateSelect(isErr, errVal, okVal, "listen_result");
     }
 
     // accept(listener) -> Result<TcpStream, Error>
@@ -4640,9 +4655,20 @@ llvm::Value *CodeGen::emitBuiltinHttp(const CallExpr &e) {
 
         // 2. listen(listener, 128)
         builder_.SetInsertPoint(bindOkBB);
-        auto listenFnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_, i64Ty_}, false);
+        auto listenFnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, i64Ty_}, false);
         auto listenFn = mod_->getOrInsertFunction("__ry_listen", listenFnTy);
-        builder_.CreateCall(listenFn, {listener, llvm::ConstantInt::get(i64Ty_, 128)});
+        llvm::Value *listenStatus = builder_.CreateCall(listenFn, {listener, llvm::ConstantInt::get(i64Ty_, 128)}, "listen_status");
+        // Check listen result — fatal for http_listen
+        llvm::Value *listenFailed = builder_.CreateICmpNE(listenStatus,
+            llvm::ConstantInt::get(i64Ty_, 0), "listen_failed");
+        llvm::BasicBlock *listenFailBB = llvm::BasicBlock::Create(*ctx_, "http.listen_fail", fn_);
+        llvm::BasicBlock *listenOkBB = llvm::BasicBlock::Create(*ctx_, "http.listen_ok", fn_);
+        builder_.CreateCondBr(listenFailed, listenFailBB, listenOkBB);
+        builder_.SetInsertPoint(listenFailBB);
+        static int httpListenErrCounter = 0;
+        emitRuntimeError("runtime error: http_listen() listen failed\n",
+                          ".http_listen_err_" + std::to_string(httpListenErrCounter++));
+        builder_.SetInsertPoint(listenOkBB);
 
         // 3. accept loop
         llvm::BasicBlock *loopBB = llvm::BasicBlock::Create(*ctx_, "http.loop", fn_);

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -63,12 +63,12 @@ extern "C" void *__ry_bind(const char *host, int64_t port) {
     return handle;
 }
 
-extern "C" void __ry_listen(void *listener, int64_t backlog) {
+extern "C" int64_t __ry_listen(void *listener, int64_t backlog) {
     auto *handle = (TcpListenerHandle *)listener;
     if (::listen(handle->fd, (int)backlog) < 0) {
-        fprintf(stderr, "runtime error: listen() failed\n");
-        exit(1);
+        return -1;
     }
+    return 0;
 }
 
 extern "C" void *__ry_accept(void *listener) {
@@ -177,10 +177,6 @@ extern "C" int64_t __ry_tcp_send(void *stream, void *byte_list) {
     auto *handle = (TcpStreamHandle *)stream;
     auto *header = (IOListHeader *)byte_list;
     ssize_t sent = __ry_send_all(handle->fd, header->data, (size_t)header->len);
-    if (sent < 0) {
-        fprintf(stderr, "runtime error: tcp send() failed\n");
-        exit(1);
-    }
     return (int64_t)sent;
 }
 
@@ -202,7 +198,14 @@ extern "C" void *__ry_tcp_recv(void *stream, int64_t max_bytes) {
     auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
     header->data = (int8_t *)malloc((size_t)max_bytes);
     ssize_t n = ::recv(handle->fd, header->data, (size_t)max_bytes, 0);
-    if (n <= 0) {
+    if (n < 0) {
+        // Error: free everything and return nullptr
+        free(header->data);
+        free(header);
+        return nullptr;
+    }
+    if (n == 0) {
+        // Connection closed: return empty list (non-null)
         free(header->data);
         header->data = nullptr;
         header->len = 0;

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -11,6 +11,19 @@ describe("TCP socket API", fn():
                 expect(true).to_eq(false)
 
     )
+    it("listen returns Ok on valid listener", fn():
+        match bind("127.0.0.1", 18091):
+            case Ok(server):
+                match listen(server, 1):
+                    case Ok(_):
+                        expect(true).to_eq(true)
+                    case Err(e):
+                        expect(true).to_eq(false)
+                close(server)
+            case Err(e):
+                expect(true).to_eq(false)
+
+    )
     it("connect to closed port returns Err", fn():
         match connect("127.0.0.1", 19998):
             case Ok(conn):

--- a/tests/test_codegen_net.cpp
+++ b/tests/test_codegen_net.cpp
@@ -11,7 +11,7 @@ static const std::string NET_DECLS = R"(
 @native
 fn bind(host: str, port: int) -> Result<TcpListener, Error>
 @native
-fn listen(listener: TcpListener, backlog: int) -> Unit
+fn listen(listener: TcpListener, backlog: int) -> Result<Unit, Error>
 @native
 fn accept(listener: TcpListener) -> Result<TcpStream, Error>
 @native
@@ -53,6 +53,25 @@ match connect("127.0.0.1", 19999):
 }
 
 // ============================================================
+// listen returns Result<Unit, Error>
+// ============================================================
+
+TEST_F(CodeGenTest, NetListenReturnsResult) {
+    EXPECT_EQ(runSource(NET_DECLS + R"(
+match bind("127.0.0.1", 18082):
+    case Ok(server):
+        match listen(server, 1):
+            case Ok(_):
+                print("ok")
+            case Err(e):
+                print("listen err")
+        close(server)
+    case Err(e):
+        print("bind err")
+)"), "ok\n");
+}
+
+// ============================================================
 // Echo round-trip: server and client via spawn
 // TODO: re-enable once network test hang on CI (macos-14) is resolved
 // See: https://github.com/t0k0sh1/ry/issues/96
@@ -63,16 +82,29 @@ match connect("127.0.0.1", 19999):
 // fn run_server(port: int, ready: Channel<int>) -> str:
 //     match bind("127.0.0.1", port):
 //         case Ok(server):
-//             listen(server, 1)
-//             send(ready, 1)
-//             match accept(server):
-//                 case Ok(conn):
-//                     data: List<byte> = recv(conn, 4096)
-//                     msg = bytes_to_str(data)
-//                     send(conn, str_to_bytes("echo:" + msg))
-//                     close(conn)
+//             match listen(server, 1):
+//                 case Ok(_):
+//                     send(ready, 1)
+//                     match accept(server):
+//                         case Ok(conn):
+//                             match recv(conn, 4096):
+//                                 case Ok(data):
+//                                     match bytes_to_str(data):
+//                                         case Ok(msg):
+//                                             match send(conn, str_to_bytes("echo:" + msg)):
+//                                                 case Ok(_):
+//                                                     ...
+//                                                 case Err(e):
+//                                                     ...
+//                                         case Err(e):
+//                                             ...
+//                                 case Err(e):
+//                                     ...
+//                             close(conn)
+//                         case Err(e):
+//                             ...
 //                 case Err(e):
-//                     ...
+//                     send(ready, 0)
 //             close(server)
 //         case Err(e):
 //             send(ready, 0)
@@ -81,11 +113,23 @@ match connect("127.0.0.1", 19999):
 // fn run_client(port: int) -> str:
 //     match connect("127.0.0.1", port):
 //         case Ok(conn):
-//             send(conn, str_to_bytes("hello"))
-//             resp: List<byte> = recv(conn, 4096)
-//             msg = bytes_to_str(resp)
+//             match send(conn, str_to_bytes("hello")):
+//                 case Ok(_):
+//                     ...
+//                 case Err(e):
+//                     ...
+//             match recv(conn, 4096):
+//                 case Ok(resp):
+//                     match bytes_to_str(resp):
+//                         case Ok(msg):
+//                             close(conn)
+//                             return msg
+//                         case Err(e):
+//                             ...
+//                 case Err(e):
+//                     ...
 //             close(conn)
-//             return msg
+//             return "fail"
 //         case Err(e):
 //             return "fail"
 //
@@ -115,6 +159,27 @@ print(val)
 close(ch)
 join(t)
 )"), "42\n");
+}
+
+// ============================================================
+// __ry_tcp_send: closed fd returns -1 (no exit)
+// ============================================================
+
+TEST(TcpSend, ClosedFdReturnsNegative) {
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    ::close(fds[0]);
+    ::close(fds[1]);
+
+    // Build a minimal IOListHeader
+    IOListHeader header;
+    int8_t data[] = {'x'};
+    header.data = data;
+    header.len = 1;
+    header.cap = 1;
+
+    int64_t result = __ry_tcp_send(&fds[0], &header);
+    EXPECT_EQ(result, -1);
 }
 
 // ============================================================
@@ -215,6 +280,18 @@ TEST(TcpRecv, PeerCloseReturnsEmptyList) {
 
     free(result);
     ::close(fds[0]);
+}
+
+TEST(TcpRecv, ErrorReturnsNull) {
+    int fds[2];
+    ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
+    // Close both ends so recv() gets an error (not just EOF)
+    ::close(fds[1]);
+    ::close(fds[0]);
+
+    // recv on closed fd returns nullptr (error)
+    auto *result = (IOListHeader *)__ry_tcp_recv(&fds[0], 4096);
+    EXPECT_EQ(result, nullptr);
 }
 
 TEST(TcpRecv, ZeroMaxBytesReturnsEmptyList) {


### PR DESCRIPTION
## Summary

- **listen**: `Unit` + `exit(1)` → `Result<Unit, Error>` with `-1`/`0` return from C runtime
- **send**: `int` + `exit(1)` → `Result<int, Error>`, removed `exit(1)` from `__ry_tcp_send`
- **recv**: `List<byte>` (error/close indistinguishable) → `Result<List<byte>, Error>` with `nullptr` on error, empty list on connection close
- Extracted `buildStaticError()` helper to deduplicate error-wrapping codegen across listen/send/recv/bind/accept/connect
- Updated `http_listen` codegen to handle new `__ry_listen` return type
- Updated docs, stdlib declarations, and tests

Closes #78

## Test plan

- [x] `NetListenReturnsResult` — listen returns `Ok` on valid listener
- [x] `TcpSend.ClosedFdReturnsNegative` — `__ry_tcp_send` returns `-1` on closed fd (no exit)
- [x] `TcpRecv.ErrorReturnsNull` — `__ry_tcp_recv` returns `nullptr` on error
- [x] `TcpRecv.PeerCloseReturnsEmptyList` — connection close returns non-null empty list
- [x] `NetSendRecvCloseOverloadWithChannel` — Channel overloads unaffected
- [x] All 1218 C++ tests pass
- [x] All 24 Ry self-test files pass (0 failures)