### PR TITLE
refactor: rename len to length and expand abbreviated parameter names

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,7 +40,7 @@ For detailed language specifications, see the reference pages below.
 | [Functions, Lambdas, UFCS, Operator Overloading](reference/functions.md) | All forms of function definitions |
 | [Structs and Enums](reference/structs.md) | Complete grammar for type and enum definitions |
 | [Tuples, Lists, Maps, Sets](reference/collections.md) | Collection type operations |
-| [Built-in Functions](reference/builtins.md) | print, len, Some, range, etc. |
+| [Built-in Functions](reference/builtins.md) | print, length, Some, range, etc. |
 | [String Functions](reference/builtins-string.md) | contains, find, replace, split, join, etc. |
 | [Regular Expressions](reference/regex.md) | regex_match, regex_search, regex_replace, regex_split, regex_find_all |
 | [Math Functions](reference/math.md) | PI, E, sqrt, sin, cos, abs, floor, ceil, round, etc. |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -40,7 +40,7 @@ Ry を初めて使う方はこちらから順番に読み進めてください�
 | [関数・ラムダ・UFCS・演算子オーバーロード](reference/functions.md) | 関数定義の全形式 |
 | [構造体・列挙型](reference/structs.md) | type 定義・enum 定義の完全な文法 |
 | [タプル・リスト・マップ・セット](reference/collections.md) | コレクション型の操作方法 |
-| [組み込み関数](reference/builtins.md) | print・len・Some 等 |
+| [組み込み関数](reference/builtins.md) | print・length・Some 等 |
 | [文字列操作関数](reference/builtins-string.md) | contains・find・replace・split・join 等 |
 | [正規表現](reference/regex.md) | regex_match・regex_search・regex_replace・regex_split・regex_find_all |
 | [数学関数](reference/math.md) | PI・E・sqrt・sin・cos・abs・floor・ceil・round 等 |

--- a/docs/ja/reference/builtins-string.md
+++ b/docs/ja/reference/builtins-string.md
@@ -4,7 +4,7 @@
 
 文字列（`str`）に対する操作関数の一覧です。すべての関数で UFCS 記法が使用可能です。
 
-> **注意:** すべての文字列操作は UTF-8 対応です。`len()`、`char_at()`、`substring()`、`find()`、`reverse()` は Unicode コードポイント単位で動作し、バイト単位ではありません。バイト長が必要な場合は `byte_len()` を使用してください。
+> **注意:** すべての文字列操作は UTF-8 対応です。`length()`、`char_at()`、`substring()`、`find()`、`reverse()` は Unicode コードポイント単位で動作し、バイト単位ではありません。バイト長が必要な場合は `byte_len()` を使用してください。
 
 ## 関数一覧
 
@@ -67,9 +67,9 @@
 
 ## contains
 
-**シグネチャ:** `contains(s: str, sub: str) -> bool`
+**シグネチャ:** `contains(string: str, substring: str) -> bool`
 
-文字列 `s` に部分文字列 `sub` が含まれるかを返します。
+文字列 `string` に部分文字列 `substring` が含まれるかを返します。
 
 ```python
 print(contains("hello", "ell"))   # true
@@ -80,9 +80,9 @@ print("hello".contains("xyz"))    # false (UFCS)
 
 ## starts_with
 
-**シグネチャ:** `starts_with(s: str, prefix: str) -> bool`
+**シグネチャ:** `starts_with(string: str, prefix: str) -> bool`
 
-文字列 `s` が `prefix` で始まるかを返します。
+文字列 `string` が `prefix` で始まるかを返します。
 
 ```python
 print(starts_with("hello", "hel"))   # true
@@ -93,9 +93,9 @@ print("hello".starts_with("world"))  # false (UFCS)
 
 ## ends_with
 
-**シグネチャ:** `ends_with(s: str, suffix: str) -> bool`
+**シグネチャ:** `ends_with(string: str, suffix: str) -> bool`
 
-文字列 `s` が `suffix` で終わるかを返します。
+文字列 `string` が `suffix` で終わるかを返します。
 
 ```python
 print(ends_with("hello", "llo"))   # true
@@ -106,9 +106,9 @@ print("hello".ends_with("world"))  # false (UFCS)
 
 ## find
 
-**シグネチャ:** `find(s: str, sub: str) -> Option<int>`
+**シグネチャ:** `find(string: str, substring: str) -> Option<int>`
 
-文字列 `s` 中の部分文字列 `sub` の最初の出現位置（文字位置）を返します。見つからない場合は `None` を返します。
+文字列 `string` 中の部分文字列 `substring` の最初の出現位置（文字位置）を返します。見つからない場合は `None` を返します。
 
 ```python
 print(find("hello world", "world"))   # Some(6)
@@ -120,9 +120,9 @@ print("abcdef".find("cd"))            # Some(2) (UFCS)
 
 ## substring
 
-**シグネチャ:** `substring(s: str, start: int, end: int) -> str`
+**シグネチャ:** `substring(string: str, start: int, end: int) -> str`
 
-文字列 `s` の `start` から `end`（排他）までの部分文字列を返します。インデックスは文字位置（UTF-8 対応）です。
+文字列 `string` の `start` から `end`（排他）までの部分文字列を返します。インデックスは文字位置（UTF-8 対応）です。
 
 ```python
 print(substring("hello world", 0, 5))   # hello
@@ -134,9 +134,9 @@ print("abcdef".substring(1, 4))         # bcd (UFCS)
 
 ## char_at
 
-**シグネチャ:** `char_at(s: str, i: int) -> str`
+**シグネチャ:** `char_at(string: str, i: int) -> str`
 
-文字列 `s` の `i` 番目の UTF-8 文字を文字列として返します。
+文字列 `string` の `i` 番目の UTF-8 文字を文字列として返します。
 
 ```python
 print(char_at("hello", 0))   # h
@@ -147,9 +147,9 @@ print("abc".char_at(2))       # c (UFCS)
 
 ## replace
 
-**シグネチャ:** `replace(s: str, old: str, new: str) -> str`
+**シグネチャ:** `replace(string: str, old: str, new: str) -> str`
 
-文字列 `s` 中の `old` をすべて `new` に置換した新しい文字列を返します。
+文字列 `string` 中の `old` をすべて `new` に置換した新しい文字列を返します。
 
 ```python
 print(replace("hello world", "world", "ry"))   # hello ry
@@ -161,7 +161,7 @@ print("foo bar foo".replace("foo", "baz"))      # baz bar baz (UFCS)
 
 ## to_upper
 
-**シグネチャ:** `to_upper(s: str) -> str`
+**シグネチャ:** `to_upper(string: str) -> str`
 
 ASCII 小文字（a-z）を大文字に変換した新しい文字列を返します。
 
@@ -174,7 +174,7 @@ print("Hello World".to_upper())  # HELLO WORLD (UFCS)
 
 ## to_lower
 
-**シグネチャ:** `to_lower(s: str) -> str`
+**シグネチャ:** `to_lower(string: str) -> str`
 
 ASCII 大文字（A-Z）を小文字に変換した新しい文字列を返します。
 
@@ -187,7 +187,7 @@ print("Hello World".to_lower())  # hello world (UFCS)
 
 ## trim
 
-**シグネチャ:** `trim(s: str) -> str`
+**シグネチャ:** `trim(string: str) -> str`
 
 文字列の前後の空白文字（スペース、タブ、改行、復帰）を除去した新しい文字列を返します。
 
@@ -200,7 +200,7 @@ print("  hi  ".trim())     # hi (UFCS)
 
 ## trim_start
 
-**シグネチャ:** `trim_start(s: str) -> str`
+**シグネチャ:** `trim_start(string: str) -> str`
 
 文字列の先頭の空白文字を除去した新しい文字列を返します。
 
@@ -213,7 +213,7 @@ print("  hi".trim_start())       # hi (UFCS)
 
 ## trim_end
 
-**シグネチャ:** `trim_end(s: str) -> str`
+**シグネチャ:** `trim_end(string: str) -> str`
 
 文字列の末尾の空白文字を除去した新しい文字列を返します。
 
@@ -226,9 +226,9 @@ print("hi  ".trim_end())       # hi (UFCS)
 
 ## repeat
 
-**シグネチャ:** `repeat(s: str, n: int) -> str`
+**シグネチャ:** `repeat(string: str, count: int) -> str`
 
-文字列 `s` を `n` 回繰り返した新しい文字列を返します。
+文字列 `string` を `count` 回繰り返した新しい文字列を返します。
 
 ```python
 print(repeat("ab", 3))     # ababab
@@ -239,7 +239,7 @@ print("ha".repeat(3))      # hahaha (UFCS)
 
 ## reverse
 
-**シグネチャ:** `reverse(s: str) -> str`
+**シグネチャ:** `reverse(string: str) -> str`
 
 文字列を逆順にした新しい文字列を返します（UTF-8 対応）。
 
@@ -252,23 +252,23 @@ print("abc".reverse())     # cba (UFCS)
 
 ## byte_len
 
-**シグネチャ:** `byte_len(s: str) -> int`
+**シグネチャ:** `byte_len(string: str) -> int`
 
-文字列 `s` のバイト長を返します。UTF-8 文字数を返す `len()` とは異なり、`byte_len()` はバイト数を返します。
+文字列 `string` のバイト長を返します。UTF-8 文字数を返す `length()` とは異なり、`byte_len()` はバイト数を返します。
 
 ```python
 print(byte_len("hello"))   # 5
 print(byte_len("あいう"))   # 9
-print(len("あいう"))        # 3 (文字数)
+print(length("あいう"))        # 3 (文字数)
 ```
 
 ---
 
 ## split
 
-**シグネチャ:** `split(s: str, delim: str) -> List<str>`
+**シグネチャ:** `split(string: str, delimiter: str) -> List<str>`
 
-文字列 `s` をデリミタ `delim` で分割し、`List<str>` を返します。
+文字列 `string` をデリミタ `delimiter` で分割し、`List<str>` を返します。
 
 ```python
 parts = split("a,b,c", ",")
@@ -286,7 +286,7 @@ for word in "hello world".split(" "):
 
 ## join
 
-**シグネチャ:** `join(xs: List<str>, sep: str) -> str`
+**シグネチャ:** `join(values: List<str>, sep: str) -> str`
 
 文字列リストの要素をセパレータ `sep` で結合した文字列を返します。
 
@@ -300,7 +300,7 @@ print(parts.join("-"))         # a-b-c (UFCS)
 
 ## to_int
 
-**シグネチャ:** `to_int(s: str) -> int`
+**シグネチャ:** `to_int(value: str) -> int`
 
 文字列を整数に変換します。
 
@@ -314,7 +314,7 @@ print("123".to_int())     # 123 (UFCS)
 
 ## to_float
 
-**シグネチャ:** `to_float(s: str) -> float`
+**シグネチャ:** `to_float(value: str) -> float`
 
 文字列を浮動小数点数に変換します。
 
@@ -327,7 +327,7 @@ print("2.5".to_float())   # 2.5 (UFCS)
 
 ## to_str
 
-**シグネチャ:** `to_str(v: int | float | bool | str) -> str`
+**シグネチャ:** `to_str(value: int | float | bool | str) -> str`
 
 値を文字列に変換します。
 

--- a/docs/ja/reference/builtins.md
+++ b/docs/ja/reference/builtins.md
@@ -9,8 +9,8 @@
 | 関数 | 説明 |
 |------|------|
 | `print(expr)` | 値を標準出力に表示 |
-| `len(x)` | リスト・マップ・セットの要素数、文字列の UTF-8 文字数を返す |
-| `range(n)` / `range(start, end)` / `range(start, end, step)` | 整数のリストを生成 |
+| `length(value)` | リスト・マップ・セットの要素数、文字列の UTF-8 文字数を返す |
+| `range(count)` / `range(start, end)` / `range(start, end, step)` | 整数のリストを生成 |
 | `exit(code)` | 指定した終了コードでプロセスを終了 |
 | `args()` | コマンドライン引数を `List<str>` として返す |
 | `available_parallelism()` | ランタイムの worker 数を `int` で返す |
@@ -47,9 +47,9 @@
 | `tap(list, fn)` | 各要素に fn を呼び出し、元のリストを返す |
 | `filter(list, pred)` | 述語を満たす要素だけの新しいリストを返す |
 | `map(list, fn)` | 各要素を変換した新しいリストを返す |
-| `sort(list)` / `sort(list, comp)` | ソート済みの新しいリストを返す（デフォルト昇順） |
-| `sort!(list)` / `sort!(list, comp)` | リストをその場でソートする（ミューテーション操作） |
-| `insert(list, i, val)` | インデックス i に要素を挿入 |
+| `sort(list)` / `sort(list, comparator)` | ソート済みの新しいリストを返す（デフォルト昇順） |
+| `sort!(list)` / `sort!(list, comparator)` | リストをその場でソートする（ミューテーション操作） |
+| `insert(list, i, value)` | インデックス i に要素を挿入 |
 | `remove_at(list, i)` | インデックス i の要素を削除して返す |
 | `items(map)` | (キー, 値) タプルのリストを返す |
 | `remove(map, key)` | 指定したキーのエントリを削除 |
@@ -66,21 +66,21 @@
 
 | 関数 | 説明 |
 |------|------|
-| `contains(s, sub)` | 部分文字列が含まれるか |
-| `starts_with(s, prefix)` | 接頭辞で始まるか |
-| `ends_with(s, suffix)` | 接尾辞で終わるか |
-| `find(s, sub)` | 部分文字列の文字位置（`Option<int>`） |
-| `byte_len(s)` | 文字列のバイト長を返す |
-| `substring(s, start, end)` | 部分文字列を取得 |
-| `char_at(s, i)` | 指定位置の文字を取得 |
-| `replace(s, old, new)` | 部分文字列を全置換 |
-| `to_upper(s)` / `to_lower(s)` | 大文字・小文字変換 |
-| `trim(s)` / `trim_start(s)` / `trim_end(s)` | 空白除去 |
-| `repeat(s, n)` | 文字列を n 回繰り返す |
-| `reverse(s)` | 文字列を逆順にする |
-| `split(s, delim)` | 文字列を分割してリストを返す |
+| `contains(string, substring)` | 部分文字列が含まれるか |
+| `starts_with(string, prefix)` | 接頭辞で始まるか |
+| `ends_with(string, suffix)` | 接尾辞で終わるか |
+| `find(string, substring)` | 部分文字列の文字位置（`Option<int>`） |
+| `byte_len(string)` | 文字列のバイト長を返す |
+| `substring(string, start, end)` | 部分文字列を取得 |
+| `char_at(string, i)` | 指定位置の文字を取得 |
+| `replace(string, old, new)` | 部分文字列を全置換 |
+| `to_upper(string)` / `to_lower(string)` | 大文字・小文字変換 |
+| `trim(string)` / `trim_start(string)` / `trim_end(string)` | 空白除去 |
+| `repeat(string, count)` | 文字列を n 回繰り返す |
+| `reverse(string)` | 文字列を逆順にする |
+| `split(string, delimiter)` | 文字列を分割してリストを返す |
 | `join(list, sep)` | リストの文字列をセパレータで結合 |
-| `to_int(s)` / `to_float(s)` / `to_str(v)` | 型変換 |
+| `to_int(string)` / `to_float(string)` / `to_str(v)` | 型変換 |
 
 → 詳細は **[文字列操作関数リファレンス](builtins-string.md)** を参照
 
@@ -134,25 +134,25 @@ print(x)   # Some(42)
 
 ---
 
-## len
+## length
 
-**シグネチャ:** `len(x: List<T> | Map<K, V> | Set<T> | str) -> int`
+**シグネチャ:** `length(value: List<T> | Map<K, V> | Set<T> | str) -> int`
 
 リスト・マップ・セットの要素数、または文字列の UTF-8 文字数を返します。バイト長が必要な場合は `byte_len()` を使用してください。
 
 ```python
-print(len([1, 2, 3]))         # 3
-print(len({"a": 1, "b": 2})) # 2
-print(len({1, 2, 3}))         # 3
-print(len("hello"))           # 5
-print(len("あいう"))           # 3 (UTF-8 文字数)
+print(length([1, 2, 3]))         # 3
+print(length({"a": 1, "b": 2})) # 2
+print(length({1, 2, 3}))         # 3
+print(length("hello"))           # 5
+print(length("あいう"))           # 3 (UTF-8 文字数)
 ```
 
 ---
 
 ## has_key
 
-**シグネチャ:** `has_key(m: Map<K, V>, key: K) -> bool`
+**シグネチャ:** `has_key(map: Map<K, V>, key: K) -> bool`
 
 マップに指定したキーが存在するかを返します。UFCS記法も使用可能です。
 
@@ -166,7 +166,7 @@ print(m.has_key("z"))     # false (UFCS)
 
 ## add
 
-**シグネチャ:** `add(s: Set<T>, value: T)`
+**シグネチャ:** `add(set: Set<T>, value: T)`
 
 セットに要素を追加します。既に存在する要素を追加した場合は何もしません。UFCS記法も使用可能です。
 
@@ -175,14 +175,14 @@ s = {1, 2, 3}
 s.add(4)          # UFCS
 add(s, 5)         # 通常の呼び出し
 s.add(1)          # 既に存在するため無視
-print(len(s))     # 5
+print(length(s))     # 5
 ```
 
 ---
 
 ## remove
 
-**シグネチャ:** `remove(s: Set<T>, value: T)`
+**シグネチャ:** `remove(set: Set<T>, value: T)`
 
 セットから要素を削除します。UFCS記法も使用可能です。
 
@@ -196,13 +196,13 @@ print(2 in s)     # false
 
 ## range
 
-**シグネチャ:** `range(n: int) -> List<int>` / `range(start: int, end: int) -> List<int>` / `range(start: int, end: int, step: int) -> List<int>`
+**シグネチャ:** `range(count: int) -> List<int>` / `range(start: int, end: int) -> List<int>` / `range(start: int, end: int, step: int) -> List<int>`
 
 整数のリストを生成します。
 
 | 形式 | 生成される値 |
 |------|------------|
-| `range(n)` | `[0, 1, ..., n-1]` |
+| `range(count)` | `[0, 1, ..., count-1]` |
 | `range(start, end)` | `[start, start+1, ..., end-1]` |
 | `range(start, end, step)` | `[start, start+step, start+2*step, ...]` (`end` は含まない) |
 
@@ -247,7 +247,7 @@ exit(1)        # エラー終了
 ```python
 # 実行: ry script.ry hello world
 a = args()
-print(len(a))    # 2
+print(length(a))    # 2
 print(a[0])      # hello
 print(a[1])      # world
 
@@ -305,7 +305,7 @@ print(xs)   # [1, 2, 3]（変更なし）
 
 **シグネチャ:** `slice(list: List<T>, start: int, end: int) -> List<T>`
 
-`start`（含む）から `end`（含まない）までの新しい部分リストを返します。インデックスは有効範囲（`0` から `len(list)` まで）にクランプされます。UFCS記法も使用可能です。
+`start`（含む）から `end`（含まない）までの新しい部分リストを返します。インデックスは有効範囲（`0` から `length(list)` まで）にクランプされます。UFCS記法も使用可能です。
 
 ```python
 xs = [1, 2, 3, 4, 5]
@@ -317,9 +317,9 @@ print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5]（クランプされる）
 
 ## take
 
-**シグネチャ:** `take(list: List<T>, n: int) -> List<T>`
+**シグネチャ:** `take(list: List<T>, count: int) -> List<T>`
 
-先頭 `n` 要素の新しいリストを返します。`n` がリストの長さを超える場合はリスト全体のコピーを返します。`n <= 0` の場合は空リストを返します。元のリストは変更されません。UFCS記法も使用可能です。
+先頭 `count` 要素の新しいリストを返します。`count` がリストの長さを超える場合はリスト全体のコピーを返します。`count <= 0` の場合は空リストを返します。元のリストは変更されません。UFCS記法も使用可能です。
 
 ```python
 xs = [1, 2, 3, 4, 5]
@@ -376,7 +376,7 @@ print(ys)   # [2, 4, 6]
 
 ## sort
 
-**シグネチャ:** `sort(list: List<T>) -> List<T>` / `sort(list: List<T>, comp: fn(T, T) -> bool) -> List<T>`
+**シグネチャ:** `sort(list: List<T>) -> List<T>` / `sort(list: List<T>, comparator: fn(T, T) -> bool) -> List<T>`
 
 ソート済みの新しいリストを返します。デフォルトは昇順です。カスタム比較関数を指定できます（第一引数が第二引数の前に来るべき場合に `true` を返す）。元のリストは変更されません。ソートは**安定**です（等しい要素の元の順序が保持されます）。UFCS記法も使用可能です。
 
@@ -393,7 +393,7 @@ print(desc)   # [3, 2, 1]
 
 ## sort!
 
-**シグネチャ:** `sort!(list: List<T>)` / `sort!(list: List<T>, comp: fn(T, T) -> bool)`
+**シグネチャ:** `sort!(list: List<T>)` / `sort!(list: List<T>, comparator: fn(T, T) -> bool)`
 
 リストをその場でソートします。ソートアルゴリズムは `sort()` と同じですが、新しいリストを作成する代わりに元のリストを変更します。UFCS記法も使用可能です。
 
@@ -468,7 +468,7 @@ print(last([10, 20, 30]))   # Some(30)
 
 ## get (Map)
 
-**シグネチャ:** `get(map: Map<K, V>, key: K) -> Option<V>` / `get(map: Map<K, V>, key: K, default: V) -> V`
+**シグネチャ:** `get(map: Map<K, V>, key: K) -> Option<V>` / `get(map: Map<K, V>, key: K, default_value: V) -> V`
 
 2引数形式はキーの値を `Option<V>` として返します。3引数形式はキーの値またはデフォルト値を返します。
 

--- a/docs/ja/reference/collections.md
+++ b/docs/ja/reference/collections.md
@@ -85,11 +85,11 @@ xs[0] = 99
 print(xs[0])   # 99
 ```
 
-### len
+### length
 
 ```python
 xs = [1, 2, 3]
-print(len(xs))   # 3
+print(length(xs))   # 3
 ```
 
 ### print
@@ -405,7 +405,7 @@ print(xs)            # [[1, 2], [3, 4]]（変更なし）
 | `filter`, `map`, `reduce`, `fold` | O(n) |
 | `reverse` / `reverse!` | O(n) |
 | `distinct` | O(n) |
-| `len` | O(1) |
+| `length` | O(1) |
 
 ### 制約とエラー
 
@@ -445,11 +445,11 @@ m["b"] = 2     # 新規追加
 m["a"] = 99    # 更新
 ```
 
-### len
+### length
 
 ```python
 m = {"a": 1, "b": 2, "c": 3}
-print(len(m))   # 3
+print(length(m))   # 3
 ```
 
 ### print
@@ -566,11 +566,11 @@ print(2 in s)   # true
 print(5 in s)   # false
 ```
 
-### len
+### length
 
 ```python
 s = {1, 2, 3}
-print(len(s))   # 3
+print(length(s))   # 3
 ```
 
 ### print
@@ -588,7 +588,7 @@ print(s)   # {1, 2, 3}
 s = {1, 2, 3}
 s.add(4)         # 追加
 s.add(1)         # 既に存在するため無視
-print(len(s))    # 4
+print(length(s))    # 4
 ```
 
 ### remove（要素削除）

--- a/docs/ja/reference/directives.md
+++ b/docs/ja/reference/directives.md
@@ -108,7 +108,7 @@ a, b = (1, 2)
 
 ```
 @native
-fn contains(s: str, sub: str) -> bool
+fn contains(string: str, substring: str) -> bool
 
 print(contains("hello world", "world"))  # true
 ```
@@ -126,7 +126,7 @@ print("hello" + " world")  # hello world
 
 ```
 @native
-fn to_upper(s: str) -> str
+fn to_upper(string: str) -> str
 
 print("hello".to_upper())  # HELLO
 ```
@@ -141,7 +141,7 @@ print("hello".to_upper())  # HELLO
 
 | ファイル | 内容 |
 |---|---|
-| `core/builtins.ry` | `print`, `len`, `range`, `enumerate`, `zip`, `exit`, `args`, `available_parallelism` |
+| `core/builtins.ry` | `print`, `length`, `range`, `enumerate`, `zip`, `exit`, `args`, `available_parallelism` |
 | `core/str.ry` | `contains`, `starts_with`, `ends_with`, `find`, `substring`, `char_at`, `replace`, `to_upper`, `to_lower`, `trim`, `trim_start`, `trim_end`, `repeat`, `reverse`, `split`, `join` |
 | `core/convert.ry` | `to_int`, `to_float`, `to_str` |
 | `core/list.ry` | `append`, `pop`, `insert`, `remove_at`, `slice`, `distinct`, `flatten`, `sort`, `first`, `last`, `is_empty` |

--- a/docs/ja/reference/functions.md
+++ b/docs/ja/reference/functions.md
@@ -255,7 +255,7 @@ result = 5.double().add_one()   # double(5) → 10, add_one(10) → 11
 
 ```python
 p = Point(3, 4)
-len = p.x.to_float()   # フィールドアクセス + UFCS
+length = p.x.to_float()   # フィールドアクセス + UFCS
 ```
 
 ---

--- a/docs/ja/reference/io.md
+++ b/docs/ja/reference/io.md
@@ -63,7 +63,7 @@ print(file_exists("hello.txt"))   # false
 from std.io import str_to_bytes, bytes_to_str, write_bytes, read_bytes
 
 bs = str_to_bytes("ABC")
-print(len(bs))    # 3
+print(length(bs))    # 3
 
 write_bytes("data.bin", bs)
 rb = read_bytes("data.bin")
@@ -94,6 +94,6 @@ print(f"Hello, {name}!")
 
 ## 備考
 
-- `List<byte>` をバッファ型として使用します。標準的なリスト操作（`len()`、`append()`、`slice()`、インデックスアクセス）がすべてバイトリストで使えます。
+- `List<byte>` をバッファ型として使用します。標準的なリスト操作（`length()`、`append()`、`slice()`、インデックスアクセス）がすべてバイトリストで使えます。
 - ファイルパスは絶対パスを指定しない限り、カレントディレクトリからの相対パスとなります。
 - `write_text` と `write_bytes` は既存ファイルを上書きします。既存ファイルに追記するには `append_text` を使用してください。

--- a/docs/ja/reference/packages.md
+++ b/docs/ja/reference/packages.md
@@ -93,7 +93,7 @@ from mypackage import add   # add のみインポート
 ## 標準ライブラリ (`std`)
 
 `std` パッケージはすべてのプログラムに自動的にインポートされます。提供する機能:
-- 組み込み関数（`print`, `len`, `range` など）
+- 組み込み関数（`print`, `length`, `range` など）
 - 文字列関数（`contains`, `find`, `replace` など）
 - 型変換関数（`to_int`, `to_float`, `to_str`）
 - コレクション関数（`map`, `filter`, `sort` など）

--- a/docs/ja/reference/regex.md
+++ b/docs/ja/reference/regex.md
@@ -77,7 +77,7 @@ print(s)  # aXbXcX
 
 ```ry
 parts = regex_split("\\s+", "hello  world  foo")
-print(len(parts))  # 3
+print(length(parts))  # 3
 print(parts[0])    # hello
 ```
 
@@ -85,7 +85,7 @@ print(parts[0])    # hello
 
 ```ry
 matches = regex_find_all("[0-9]+", "a1b23c456")
-print(len(matches))  # 3
+print(length(matches))  # 3
 print(matches[0])    # 1
 print(matches[1])    # 23
 ```
@@ -111,7 +111,7 @@ print(l)  # X and X
 
 # 個別のHTMLタグを取得
 tags = regex_find_all("<.*?>", "<a> <bb> <ccc>")
-print(len(tags))  # 3
+print(length(tags))  # 3
 ```
 
 > **注意:** 非貪欲マッチはマッチ全体の長さを制御します。グループ（括弧で囲んだ部分式）がない場合、greedy/lazy の混在パターンは PCRE エンジンと異なる動作をする場合があります。
@@ -125,7 +125,7 @@ print(pos)  # 6
 
 # すべての単語を取得
 words = regex_find_all("\\b\\w+\\b", "hello world foo")
-print(len(words))  # 3
+print(length(words))  # 3
 
 # \B は非境界（単語の内部）にマッチ
 pos2 = regex_search("\\Bworld", "helloworld")

--- a/docs/ja/tutorial/02-variables-and-types.md
+++ b/docs/ja/tutorial/02-variables-and-types.md
@@ -86,7 +86,7 @@ print(a != b)   # true
 print(a < b)    # true（"H" < "W"）
 
 # 長さ
-print(len(a))   # 5
+print(length(a))   # 5
 
 # 部分文字列チェック
 s = "Hello, World!"

--- a/docs/ja/tutorial/07-collections.md
+++ b/docs/ja/tutorial/07-collections.md
@@ -85,10 +85,10 @@ print(xs[i])   # 2
 xs[0] = 99
 ```
 
-### len
+### length
 
 ```python
-print(len(xs))   # 3
+print(length(xs))   # 3
 ```
 
 ### print
@@ -240,10 +240,10 @@ m["c"] = 3    # 新規追加
 m["a"] = 99   # 更新
 ```
 
-### len
+### length
 
 ```python
-print(len(m))   # 3
+print(length(m))   # 3
 ```
 
 ### print
@@ -318,10 +318,10 @@ s.remove(1)    # 要素削除
 s.add(2)       # 既に存在するため無視
 ```
 
-### len / print
+### length / print
 
 ```python
-print(len(s))  # 3
+print(length(s))  # 3
 print(s)       # {2, 3, 4}
 ```
 

--- a/docs/ja/tutorial/09-modules.md
+++ b/docs/ja/tutorial/09-modules.md
@@ -59,7 +59,7 @@ from mypackage import add   # add のみインポート
 ```python
 # これらの関数はインポートなしで利用可能
 print("hello")
-n = len("world")
+n = length("world")
 xs = range(5)
 ```
 

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -4,7 +4,7 @@
 
 A list of operation functions for strings (`str`). All functions support UFCS notation.
 
-> **Note:** All string operations are UTF-8 aware. `len()`, `char_at()`, `substring()`, `find()`, and `reverse()` operate on Unicode code points, not bytes. Use `byte_len()` if you need the byte length.
+> **Note:** All string operations are UTF-8 aware. `length()`, `char_at()`, `substring()`, `find()`, and `reverse()` operate on Unicode code points, not bytes. Use `byte_len()` if you need the byte length.
 
 ## Function List
 
@@ -67,9 +67,9 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 
 ## contains
 
-**Signature:** `contains(s: str, sub: str) -> bool`
+**Signature:** `contains(string: str, substring: str) -> bool`
 
-Returns whether string `s` contains the substring `sub`.
+Returns whether string `string` contains the substring `substring`.
 
 ```python
 print(contains("hello", "ell"))   # true
@@ -80,9 +80,9 @@ print("hello".contains("xyz"))    # false (UFCS)
 
 ## starts_with
 
-**Signature:** `starts_with(s: str, prefix: str) -> bool`
+**Signature:** `starts_with(string: str, prefix: str) -> bool`
 
-Returns whether string `s` starts with `prefix`.
+Returns whether string `string` starts with `prefix`.
 
 ```python
 print(starts_with("hello", "hel"))   # true
@@ -93,9 +93,9 @@ print("hello".starts_with("world"))  # false (UFCS)
 
 ## ends_with
 
-**Signature:** `ends_with(s: str, suffix: str) -> bool`
+**Signature:** `ends_with(string: str, suffix: str) -> bool`
 
-Returns whether string `s` ends with `suffix`.
+Returns whether string `string` ends with `suffix`.
 
 ```python
 print(ends_with("hello", "llo"))   # true
@@ -106,9 +106,9 @@ print("hello".ends_with("world"))  # false (UFCS)
 
 ## find
 
-**Signature:** `find(s: str, sub: str) -> Option<int>`
+**Signature:** `find(string: str, substring: str) -> Option<int>`
 
-Returns the character position of the first occurrence of substring `sub` in string `s`. Returns `None` if not found.
+Returns the character position of the first occurrence of substring `substring` in string `string`. Returns `None` if not found.
 
 ```python
 print(find("hello world", "world"))   # Some(6)
@@ -120,9 +120,9 @@ print("abcdef".find("cd"))            # Some(2) (UFCS)
 
 ## substring
 
-**Signature:** `substring(s: str, start: int, end: int) -> str`
+**Signature:** `substring(string: str, start: int, end: int) -> str`
 
-Returns the substring of `s` from `start` to `end` (exclusive). Indices are character positions (UTF-8 aware).
+Returns the substring of `string` from `start` to `end` (exclusive). Indices are character positions (UTF-8 aware).
 
 ```python
 print(substring("hello world", 0, 5))   # hello
@@ -134,9 +134,9 @@ print("abcdef".substring(1, 4))         # bcd (UFCS)
 
 ## char_at
 
-**Signature:** `char_at(s: str, i: int) -> str`
+**Signature:** `char_at(string: str, i: int) -> str`
 
-Returns the UTF-8 character at position `i` in string `s` as a string.
+Returns the UTF-8 character at position `i` in string `string` as a string.
 
 ```python
 print(char_at("hello", 0))   # h
@@ -147,9 +147,9 @@ print("abc".char_at(2))       # c (UFCS)
 
 ## replace
 
-**Signature:** `replace(s: str, old: str, new: str) -> str`
+**Signature:** `replace(string: str, old: str, new: str) -> str`
 
-Returns a new string with all occurrences of `old` in `s` replaced with `new`.
+Returns a new string with all occurrences of `old` in `string` replaced with `new`.
 
 ```python
 print(replace("hello world", "world", "ry"))   # hello ry
@@ -161,7 +161,7 @@ print("foo bar foo".replace("foo", "baz"))      # baz bar baz (UFCS)
 
 ## to_upper
 
-**Signature:** `to_upper(s: str) -> str`
+**Signature:** `to_upper(string: str) -> str`
 
 Returns a new string with ASCII lowercase letters (a-z) converted to uppercase.
 
@@ -174,7 +174,7 @@ print("Hello World".to_upper())  # HELLO WORLD (UFCS)
 
 ## to_lower
 
-**Signature:** `to_lower(s: str) -> str`
+**Signature:** `to_lower(string: str) -> str`
 
 Returns a new string with ASCII uppercase letters (A-Z) converted to lowercase.
 
@@ -187,7 +187,7 @@ print("Hello World".to_lower())  # hello world (UFCS)
 
 ## trim
 
-**Signature:** `trim(s: str) -> str`
+**Signature:** `trim(string: str) -> str`
 
 Returns a new string with leading and trailing whitespace characters (spaces, tabs, newlines, carriage returns) removed.
 
@@ -200,7 +200,7 @@ print("  hi  ".trim())     # hi (UFCS)
 
 ## trim_start
 
-**Signature:** `trim_start(s: str) -> str`
+**Signature:** `trim_start(string: str) -> str`
 
 Returns a new string with leading whitespace characters removed.
 
@@ -213,7 +213,7 @@ print("  hi".trim_start())       # hi (UFCS)
 
 ## trim_end
 
-**Signature:** `trim_end(s: str) -> str`
+**Signature:** `trim_end(string: str) -> str`
 
 Returns a new string with trailing whitespace characters removed.
 
@@ -226,9 +226,9 @@ print("hi  ".trim_end())       # hi (UFCS)
 
 ## repeat
 
-**Signature:** `repeat(s: str, n: int) -> str`
+**Signature:** `repeat(string: str, count: int) -> str`
 
-Returns a new string with `s` repeated `n` times.
+Returns a new string with `string` repeated `count` times.
 
 ```python
 print(repeat("ab", 3))     # ababab
@@ -239,7 +239,7 @@ print("ha".repeat(3))      # hahaha (UFCS)
 
 ## reverse
 
-**Signature:** `reverse(s: str) -> str`
+**Signature:** `reverse(string: str) -> str`
 
 Returns a new string with the characters reversed (UTF-8 aware).
 
@@ -252,23 +252,23 @@ print("abc".reverse())     # cba (UFCS)
 
 ## byte_len
 
-**Signature:** `byte_len(s: str) -> int`
+**Signature:** `byte_len(string: str) -> int`
 
-Returns the byte length of string `s`. Unlike `len()`, which returns the number of UTF-8 characters, `byte_len()` returns the number of bytes.
+Returns the byte length of string `string`. Unlike `length()`, which returns the number of UTF-8 characters, `byte_len()` returns the number of bytes.
 
 ```python
 print(byte_len("hello"))   # 5
 print(byte_len("あいう"))   # 9
-print(len("あいう"))        # 3 (characters)
+print(length("あいう"))        # 3 (characters)
 ```
 
 ---
 
 ## split
 
-**Signature:** `split(s: str, delim: str) -> List<str>`
+**Signature:** `split(string: str, delimiter: str) -> List<str>`
 
-Splits string `s` by delimiter `delim` and returns a `List<str>`.
+Splits string `string` by delimiter `delimiter` and returns a `List<str>`.
 
 ```python
 parts = split("a,b,c", ",")
@@ -286,7 +286,7 @@ for word in "hello world".split(" "):
 
 ## join
 
-**Signature:** `join(xs: List<str>, sep: str) -> str`
+**Signature:** `join(values: List<str>, sep: str) -> str`
 
 Joins the elements of a string list with separator `sep` and returns a string.
 
@@ -300,7 +300,7 @@ print(parts.join("-"))         # a-b-c (UFCS)
 
 ## to_int
 
-**Signature:** `to_int(s: str) -> int`
+**Signature:** `to_int(string: str) -> int`
 
 Converts a string to an integer.
 
@@ -314,7 +314,7 @@ print("123".to_int())     # 123 (UFCS)
 
 ## to_float
 
-**Signature:** `to_float(s: str) -> float`
+**Signature:** `to_float(string: str) -> float`
 
 Converts a string to a floating-point number.
 

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -9,7 +9,7 @@
 | Function | Description |
 |------|------|
 | `print(expr)` | Prints a value to standard output |
-| `len(x)` | Returns the number of elements in a list, map, or set, or the number of UTF-8 characters in a string |
+| `length(value)` | Returns the number of elements in a list, map, or set, or the number of UTF-8 characters in a string |
 | `range(n)` / `range(start, end)` / `range(start, end, step)` | Generates a list of integers |
 | `exit(code)` | Terminates the process with the given exit code |
 | `args()` | Returns command-line arguments as `List<str>` |
@@ -80,19 +80,19 @@
 
 | Function | Description |
 |------|------|
-| `contains(s, sub)` | Whether a substring is contained |
-| `starts_with(s, prefix)` | Whether it starts with a prefix |
-| `ends_with(s, suffix)` | Whether it ends with a suffix |
-| `find(s, sub)` | Character position of a substring (`Option<int>`) |
-| `byte_len(s)` | Returns the byte length of a string |
-| `substring(s, start, end)` | Extract a substring |
-| `char_at(s, i)` | Get the character at a specified position |
-| `replace(s, old, new)` | Replace all occurrences of a substring |
-| `to_upper(s)` / `to_lower(s)` | Uppercase / lowercase conversion |
-| `trim(s)` / `trim_start(s)` / `trim_end(s)` | Whitespace removal |
-| `repeat(s, n)` | Repeat a string n times |
-| `reverse(s)` | Reverse a string |
-| `split(s, delim)` | Split a string into a list |
+| `contains(string, substring)` | Whether a substring is contained |
+| `starts_with(string, prefix)` | Whether it starts with a prefix |
+| `ends_with(string, suffix)` | Whether it ends with a suffix |
+| `find(string, substring)` | Character position of a substring (`Option<int>`) |
+| `byte_len(string)` | Returns the byte length of a string |
+| `substring(string, start, end)` | Extract a substring |
+| `char_at(string, i)` | Get the character at a specified position |
+| `replace(string, old, new)` | Replace all occurrences of a substring |
+| `to_upper(string)` / `to_lower(string)` | Uppercase / lowercase conversion |
+| `trim(string)` / `trim_start(string)` / `trim_end(string)` | Whitespace removal |
+| `repeat(string, count)` | Repeat a string n times |
+| `reverse(string)` | Reverse a string |
+| `split(string, delimiter)` | Split a string into a list |
 | `join(list, sep)` | Join list elements with a separator |
 | `to_int(s)` / `to_float(s)` / `to_str(v)` | Type conversion |
 
@@ -148,18 +148,18 @@ print(x)   # Some(42)
 
 ---
 
-## len
+## length
 
-**Signature:** `len(x: List<T> | Map<K, V> | Set<T> | str) -> int`
+**Signature:** `length(x: List<T> | Map<K, V> | Set<T> | str) -> int`
 
 Returns the number of elements in a list, map, or set, or the number of UTF-8 characters in a string. Use `byte_len()` for the byte length.
 
 ```python
-print(len([1, 2, 3]))         # 3
-print(len({"a": 1, "b": 2})) # 2
-print(len({1, 2, 3}))         # 3
-print(len("hello"))           # 5
-print(len("あいう"))           # 3 (UTF-8 characters)
+print(length([1, 2, 3]))         # 3
+print(length({"a": 1, "b": 2})) # 2
+print(length({1, 2, 3}))         # 3
+print(length("hello"))           # 5
+print(length("あいう"))           # 3 (UTF-8 characters)
 ```
 
 ---
@@ -189,7 +189,7 @@ s = {1, 2, 3}
 s.add(4)          # UFCS
 add(s, 5)         # Normal call
 s.add(1)          # Ignored because it already exists
-print(len(s))     # 5
+print(length(s))     # 5
 ```
 
 ---
@@ -262,7 +262,7 @@ Returns the command-line arguments passed to the script as a list of strings. Do
 ```python
 # Run: ry script.ry hello world
 a = args()
-print(len(a))    # 2
+print(length(a))    # 2
 print(a[0])      # hello
 print(a[1])      # world
 
@@ -320,7 +320,7 @@ print(xs)   # [1, 2, 3] (unchanged)
 
 **Signature:** `slice(list: List<T>, start: int, end: int) -> List<T>`
 
-Returns a new sub-list from `start` (inclusive) to `end` (exclusive). Indices are clamped to the valid range (`0` to `len(list)`). UFCS notation is also available.
+Returns a new sub-list from `start` (inclusive) to `end` (exclusive). Indices are clamped to the valid range (`0` to `length(list)`). UFCS notation is also available.
 
 ```python
 xs = [1, 2, 3, 4, 5]

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -85,11 +85,11 @@ xs[0] = 99
 print(xs[0])   # 99
 ```
 
-### len
+### length
 
 ```python
 xs = [1, 2, 3]
-print(len(xs))   # 3
+print(length(xs))   # 3
 ```
 
 ### print
@@ -406,7 +406,7 @@ print(xs)            # [[1, 2], [3, 4]] (unchanged)
 | `filter`, `map`, `reduce`, `fold` | O(n) |
 | `reverse` / `reverse!` | O(n) |
 | `distinct` | O(n) |
-| `len` | O(1) |
+| `length` | O(1) |
 
 ### Constraints and Errors
 
@@ -446,11 +446,11 @@ m["b"] = 2     # Insert new entry
 m["a"] = 99    # Update existing entry
 ```
 
-### len
+### length
 
 ```python
 m = {"a": 1, "b": 2, "c": 3}
-print(len(m))   # 3
+print(length(m))   # 3
 ```
 
 ### print
@@ -567,11 +567,11 @@ print(2 in s)   # true
 print(5 in s)   # false
 ```
 
-### len
+### length
 
 ```python
 s = {1, 2, 3}
-print(len(s))   # 3
+print(length(s))   # 3
 ```
 
 ### print
@@ -589,7 +589,7 @@ Duplicate elements are ignored when added.
 s = {1, 2, 3}
 s.add(4)         # Add
 s.add(1)         # Ignored because it already exists
-print(len(s))    # 4
+print(length(s))    # 4
 ```
 
 ### remove (Remove Element)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -108,7 +108,7 @@ Declares a function whose implementation is provided by the runtime (built-in). 
 
 ```
 @native
-fn contains(s: str, sub: str) -> bool
+fn contains(string: str, substring: str) -> bool
 
 print(contains("hello world", "world"))  # true
 ```
@@ -126,7 +126,7 @@ print("hello" + " world")  # hello world
 
 ```
 @native
-fn to_upper(s: str) -> str
+fn to_upper(string: str) -> str
 
 print("hello".to_upper())  # HELLO
 ```
@@ -141,9 +141,9 @@ fn range(n: int) -> List<int>
 @native
 fn range(start: int, end: int) -> List<int>
 
-print(len(range(5)))       # OK: matches 1-arg overload
-print(len(range(1, 10)))   # OK: matches 2-arg overload
-print(len(range()))        # Error: expects 1 or 2 argument(s), but got 0
+print(length(range(5)))       # OK: matches 1-arg overload
+print(length(range(1, 10)))   # OK: matches 2-arg overload
+print(length(range()))        # Error: expects 1 or 2 argument(s), but got 0
 ```
 
 **Standard library declarations (`core/`):**
@@ -152,7 +152,7 @@ The `core/` directory contains `@native` declarations for all built-in functions
 
 | File | Contents |
 |---|---|
-| `core/builtins.ry` | `print`, `len`, `range`, `enumerate`, `zip`, `exit`, `args`, `available_parallelism` |
+| `core/builtins.ry` | `print`, `length`, `range`, `enumerate`, `zip`, `exit`, `args`, `available_parallelism` |
 | `core/str.ry` | `contains`, `starts_with`, `ends_with`, `find`, `substring`, `char_at`, `replace`, `to_upper`, `to_lower`, `trim`, `trim_start`, `trim_end`, `repeat`, `reverse`, `split`, `join` |
 | `core/convert.ry` | `to_int`, `to_float`, `to_str` |
 | `core/list.ry` | `append`, `pop`, `insert`, `remove_at`, `slice`, `distinct`, `flatten`, `sort`, `first`, `last`, `is_empty` |

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -255,7 +255,7 @@ Field access (`.field`) and UFCS (`.method()`) use the same dot notation but are
 
 ```python
 p = Point(3, 4)
-len = p.x.to_float()   # Field access + UFCS
+length = p.x.to_float()   # Field access + UFCS
 ```
 
 ---

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -68,7 +68,7 @@ match delete_file("hello.txt"):
 from std.io import str_to_bytes, bytes_to_str, write_bytes, read_bytes
 
 bs = str_to_bytes("ABC")
-print(len(bs))    # 3
+print(length(bs))    # 3
 
 match write_bytes("data.bin", bs):
     case Ok(_):
@@ -115,6 +115,6 @@ match read_text("missing.txt"):
 
 ## Notes
 
-- `List<byte>` is used as the buffer type. Standard list operations (`len()`, `append()`, `slice()`, index access) all work with byte lists.
+- `List<byte>` is used as the buffer type. Standard list operations (`length()`, `append()`, `slice()`, index access) all work with byte lists.
 - File paths are relative to the current working directory unless absolute paths are specified.
 - `write_text` and `write_bytes` overwrite existing files. Use `append_text` to add content to existing files.

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -93,7 +93,7 @@ from mypackage import add   # imports only add
 ## Standard Library (`std`)
 
 The `std` package is automatically imported into every program. It provides:
-- Built-in functions (`print`, `len`, `range`, etc.)
+- Built-in functions (`print`, `length`, `range`, etc.)
 - String functions (`contains`, `find`, `replace`, etc.)
 - Type conversion functions (`to_int`, `to_float`, `to_str`)
 - Collection functions (`map`, `filter`, `sort`, etc.)

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -78,7 +78,7 @@ print(s)  # aXbXcX
 
 ```ry
 parts = regex_split("\\s+", "hello  world  foo")
-print(len(parts))  # 3
+print(length(parts))  # 3
 print(parts[0])    # hello
 ```
 
@@ -86,7 +86,7 @@ print(parts[0])    # hello
 
 ```ry
 matches = regex_find_all("[0-9]+", "a1b23c456")
-print(len(matches))  # 3
+print(length(matches))  # 3
 print(matches[0])    # 1
 print(matches[1])    # 23
 print(matches[2])    # 456
@@ -113,7 +113,7 @@ print(l)  # X and X
 
 # Find individual HTML-like tags
 tags = regex_find_all("<.*?>", "<a> <bb> <ccc>")
-print(len(tags))  # 3
+print(length(tags))  # 3
 ```
 
 > **Note:** Non-greedy matching controls the overall match length. Without support for extracting parenthesized groups, mixed greedy/lazy patterns may behave differently from PCRE-style engines.
@@ -127,7 +127,7 @@ print(pos)  # 6
 
 # Find all words
 words = regex_find_all("\\b\\w+\\b", "hello world foo")
-print(len(words))  # 3
+print(length(words))  # 3
 
 # \B matches non-boundary (inside a word)
 pos2 = regex_search("\\Bworld", "helloworld")

--- a/docs/tutorial/02-variables-and-types.md
+++ b/docs/tutorial/02-variables-and-types.md
@@ -86,7 +86,7 @@ print(a != b)   # true
 print(a < b)    # true ("H" < "W")
 
 # Length
-print(len(a))   # 5
+print(length(a))   # 5
 
 # Substring checks
 s = "Hello, World!"

--- a/docs/tutorial/07-collections.md
+++ b/docs/tutorial/07-collections.md
@@ -85,10 +85,10 @@ print(xs[i])   # 2
 xs[0] = 99
 ```
 
-### len
+### length
 
 ```python
-print(len(xs))   # 3
+print(length(xs))   # 3
 ```
 
 ### print
@@ -240,10 +240,10 @@ m["c"] = 3    # Insert new entry
 m["a"] = 99   # Update existing entry
 ```
 
-### len
+### length
 
 ```python
-print(len(m))   # 3
+print(length(m))   # 3
 ```
 
 ### print
@@ -318,10 +318,10 @@ s.remove(1)    # Remove element
 s.add(2)       # Ignored since it already exists
 ```
 
-### len / print
+### length / print
 
 ```python
-print(len(s))  # 3
+print(length(s))  # 3
 print(s)       # {2, 3, 4}
 ```
 

--- a/docs/tutorial/09-modules.md
+++ b/docs/tutorial/09-modules.md
@@ -59,7 +59,7 @@ The `std` package is automatically imported into every program. You don't need t
 ```python
 # These functions are available without any import
 print("hello")
-n = len("world")
+n = length("world")
 xs = range(5)
 ```
 

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -40,7 +40,7 @@ Ry 是一個基於 LLVM JIT 的簡潔程式語言。採用 Python 風格的縮�
 | [函式、Lambda、UFCS、運算子多載](reference/functions.md) | 函式定義的所有形式 |
 | [結構體與列舉型別](reference/structs.md) | type 定義、enum 定義的完整文法 |
 | [元組、串列、映射、集合](reference/collections.md) | 集合型別的操作方法 |
-| [內建函式](reference/builtins.md) | print、len、Some 等 |
+| [內建函式](reference/builtins.md) | print、length、Some 等 |
 | [字串操作函式](reference/builtins-string.md) | contains、find、replace、split、join 等 |
 | [正規表達式](reference/regex.md) | regex_match、regex_search、regex_replace、regex_split、regex_find_all |
 | [數學函式](reference/math.md) | PI、E、sqrt、sin、cos、abs、floor、ceil、round 等 |

--- a/docs/zh/reference/builtins-string.md
+++ b/docs/zh/reference/builtins-string.md
@@ -4,7 +4,7 @@
 
 針對字串（`str`）的操作函式一覽。所有函式皆可使用 UFCS 記法。
 
-> **注意：** 所有字串操作皆支援 UTF-8。`len()`、`char_at()`、`substring()`、`find()` 和 `reverse()` 以 Unicode 碼位為單位操作，而非位元組。如需取得位元組長度，請使用 `byte_len()`。
+> **注意：** 所有字串操作皆支援 UTF-8。`length()`、`char_at()`、`substring()`、`find()` 和 `reverse()` 以 Unicode 碼位為單位操作，而非位元組。如需取得位元組長度，請使用 `byte_len()`。
 
 ## 函式一覽
 
@@ -67,9 +67,9 @@
 
 ## contains
 
-**簽名：** `contains(s: str, sub: str) -> bool`
+**簽名：** `contains(string: str, substring: str) -> bool`
 
-回傳字串 `s` 中是否包含子字串 `sub`。
+回傳字串 `string` 中是否包含子字串 `substring`。
 
 ```python
 print(contains("hello", "ell"))   # true
@@ -80,9 +80,9 @@ print("hello".contains("xyz"))    # false (UFCS)
 
 ## starts_with
 
-**簽名：** `starts_with(s: str, prefix: str) -> bool`
+**簽名：** `starts_with(string: str, prefix: str) -> bool`
 
-回傳字串 `s` 是否以 `prefix` 開頭。
+回傳字串 `string` 是否以 `prefix` 開頭。
 
 ```python
 print(starts_with("hello", "hel"))   # true
@@ -93,9 +93,9 @@ print("hello".starts_with("world"))  # false (UFCS)
 
 ## ends_with
 
-**簽名：** `ends_with(s: str, suffix: str) -> bool`
+**簽名：** `ends_with(string: str, suffix: str) -> bool`
 
-回傳字串 `s` 是否以 `suffix` 結尾。
+回傳字串 `string` 是否以 `suffix` 結尾。
 
 ```python
 print(ends_with("hello", "llo"))   # true
@@ -106,9 +106,9 @@ print("hello".ends_with("world"))  # false (UFCS)
 
 ## find
 
-**簽名：** `find(s: str, sub: str) -> Option<int>`
+**簽名：** `find(string: str, substring: str) -> Option<int>`
 
-回傳字串 `s` 中子字串 `sub` 首次出現的字元位置。未找到時回傳 `None`。
+回傳字串 `string` 中子字串 `substring` 首次出現的字元位置。未找到時回傳 `None`。
 
 ```python
 print(find("hello world", "world"))   # Some(6)
@@ -120,9 +120,9 @@ print("abcdef".find("cd"))            # Some(2) (UFCS)
 
 ## substring
 
-**簽名：** `substring(s: str, start: int, end: int) -> str`
+**簽名：** `substring(string: str, start: int, end: int) -> str`
 
-回傳字串 `s` 從 `start` 到 `end`（不含）的子字串。索引為字元位置（UTF-8 感知）。
+回傳字串 `string` 從 `start` 到 `end`（不含）的子字串。索引為字元位置（UTF-8 感知）。
 
 ```python
 print(substring("hello world", 0, 5))   # hello
@@ -134,9 +134,9 @@ print("abcdef".substring(1, 4))         # bcd (UFCS)
 
 ## char_at
 
-**簽名：** `char_at(s: str, i: int) -> str`
+**簽名：** `char_at(string: str, i: int) -> str`
 
-回傳字串 `s` 第 `i` 個位置的 UTF-8 字元作為字串。
+回傳字串 `string` 第 `i` 個位置的 UTF-8 字元作為字串。
 
 ```python
 print(char_at("hello", 0))   # h
@@ -147,9 +147,9 @@ print("abc".char_at(2))       # c (UFCS)
 
 ## replace
 
-**簽名：** `replace(s: str, old: str, new: str) -> str`
+**簽名：** `replace(string: str, old: str, new: str) -> str`
 
-回傳將字串 `s` 中所有 `old` 替換為 `new` 後的新字串。
+回傳將字串 `string` 中所有 `old` 替換為 `new` 後的新字串。
 
 ```python
 print(replace("hello world", "world", "ry"))   # hello ry
@@ -161,7 +161,7 @@ print("foo bar foo".replace("foo", "baz"))      # baz bar baz (UFCS)
 
 ## to_upper
 
-**簽名：** `to_upper(s: str) -> str`
+**簽名：** `to_upper(string: str) -> str`
 
 回傳將 ASCII 小寫字母（a-z）轉換為大寫後的新字串。
 
@@ -174,7 +174,7 @@ print("Hello World".to_upper())  # HELLO WORLD (UFCS)
 
 ## to_lower
 
-**簽名：** `to_lower(s: str) -> str`
+**簽名：** `to_lower(string: str) -> str`
 
 回傳將 ASCII 大寫字母（A-Z）轉換為小寫後的新字串。
 
@@ -187,7 +187,7 @@ print("Hello World".to_lower())  # hello world (UFCS)
 
 ## trim
 
-**簽名：** `trim(s: str) -> str`
+**簽名：** `trim(string: str) -> str`
 
 回傳去除字串前後空白字元（空格、定位字元、換行、回車）後的新字串。
 
@@ -200,7 +200,7 @@ print("  hi  ".trim())     # hi (UFCS)
 
 ## trim_start
 
-**簽名：** `trim_start(s: str) -> str`
+**簽名：** `trim_start(string: str) -> str`
 
 回傳去除字串開頭空白字元後的新字串。
 
@@ -213,7 +213,7 @@ print("  hi".trim_start())       # hi (UFCS)
 
 ## trim_end
 
-**簽名：** `trim_end(s: str) -> str`
+**簽名：** `trim_end(string: str) -> str`
 
 回傳去除字串結尾空白字元後的新字串。
 
@@ -226,9 +226,9 @@ print("hi  ".trim_end())       # hi (UFCS)
 
 ## repeat
 
-**簽名：** `repeat(s: str, n: int) -> str`
+**簽名：** `repeat(string: str, count: int) -> str`
 
-回傳將字串 `s` 重複 `n` 次後的新字串。
+回傳將字串 `string` 重複 `count` 次後的新字串。
 
 ```python
 print(repeat("ab", 3))     # ababab
@@ -239,7 +239,7 @@ print("ha".repeat(3))      # hahaha (UFCS)
 
 ## reverse
 
-**簽名：** `reverse(s: str) -> str`
+**簽名：** `reverse(string: str) -> str`
 
 回傳字元順序反轉後的新字串（UTF-8 感知）。
 
@@ -252,23 +252,23 @@ print("abc".reverse())     # cba (UFCS)
 
 ## byte_len
 
-**簽名：** `byte_len(s: str) -> int`
+**簽名：** `byte_len(string: str) -> int`
 
-回傳字串 `s` 的位元組長度。與回傳 UTF-8 字元數的 `len()` 不同，`byte_len()` 回傳的是位元組數。
+回傳字串 `string` 的位元組長度。與回傳 UTF-8 字元數的 `length()` 不同，`byte_len()` 回傳的是位元組數。
 
 ```python
 print(byte_len("hello"))   # 5
 print(byte_len("あいう"))   # 9
-print(len("あいう"))        # 3 (字元數)
+print(length("あいう"))        # 3 (字元數)
 ```
 
 ---
 
 ## split
 
-**簽名：** `split(s: str, delim: str) -> List<str>`
+**簽名：** `split(string: str, delimiter: str) -> List<str>`
 
-以分隔符號 `delim` 分割字串 `s`，回傳 `List<str>`。
+以分隔符號 `delimiter` 分割字串 `string`，回傳 `List<str>`。
 
 ```python
 parts = split("a,b,c", ",")
@@ -286,7 +286,7 @@ for word in "hello world".split(" "):
 
 ## join
 
-**簽名：** `join(xs: List<str>, sep: str) -> str`
+**簽名：** `join(values: List<str>, sep: str) -> str`
 
 以分隔符號 `sep` 連接字串串列的元素，回傳結合後的字串。
 
@@ -300,7 +300,7 @@ print(parts.join("-"))         # a-b-c (UFCS)
 
 ## to_int
 
-**簽名：** `to_int(s: str) -> int`
+**簽名：** `to_int(string: str) -> int`
 
 將字串轉換為整數。
 
@@ -314,7 +314,7 @@ print("123".to_int())     # 123 (UFCS)
 
 ## to_float
 
-**簽名：** `to_float(s: str) -> float`
+**簽名：** `to_float(string: str) -> float`
 
 將字串轉換為浮點數。
 

--- a/docs/zh/reference/builtins.md
+++ b/docs/zh/reference/builtins.md
@@ -9,8 +9,8 @@
 | 函式 | 說明 |
 |------|------|
 | `print(expr)` | 將值輸出到標準輸出 |
-| `len(x)` | 回傳串列、映射、集合的元素數量，或字串的 UTF-8 字元數 |
-| `range(n)` / `range(start, end)` / `range(start, end, step)` | 生成整數串列 |
+| `length(value)` | 回傳串列、映射、集合的元素數量，或字串的 UTF-8 字元數 |
+| `range(count)` / `range(start, end)` / `range(start, end, step)` | 生成整數串列 |
 | `exit(code)` | 以指定的結束碼終止程序 |
 | `args()` | 以 `List<str>` 回傳命令列引數 |
 
@@ -39,7 +39,7 @@
 | `map(list, fn)` | 傳回將每個元素轉換後的新串列 |
 | `sort(list)` / `sort(list, comp)` | 傳回排序後的新串列（預設升序） |
 | `sort!(list)` / `sort!(list, comp)` | 就地排序串列（破壞性） |
-| `insert(list, i, val)` | 在索引 i 處插入元素 |
+| `insert(list, i, value)` | 在索引 i 處插入元素 |
 | `remove_at(list, i)` | 移除並回傳索引 i 處的元素 |
 | `items(map)` | 回傳 (鍵, 值) 元組的串列 |
 | `remove(map, key)` | 刪除指定鍵的條目 |
@@ -56,21 +56,21 @@
 
 | 函式 | 說明 |
 |------|------|
-| `contains(s, sub)` | 是否包含子字串 |
-| `starts_with(s, prefix)` | 是否以前綴開頭 |
-| `ends_with(s, suffix)` | 是否以後綴結尾 |
-| `find(s, sub)` | 子字串的字元位置（`Option<int>`） |
-| `byte_len(s)` | 回傳字串的位元組長度 |
-| `substring(s, start, end)` | 取得子字串 |
-| `char_at(s, i)` | 取得指定位置的字元 |
-| `replace(s, old, new)` | 全部取代子字串 |
-| `to_upper(s)` / `to_lower(s)` | 大小寫轉換 |
-| `trim(s)` / `trim_start(s)` / `trim_end(s)` | 去除空白 |
-| `repeat(s, n)` | 將字串重複 n 次 |
-| `reverse(s)` | 反轉字串 |
-| `split(s, delim)` | 分割字串並回傳串列 |
-| `join(list, sep)` | 以分隔符號連接串列中的字串 |
-| `to_int(s)` / `to_float(s)` / `to_str(v)` | 型別轉換 |
+| `contains(string, substring)` | 是否包含子字串 |
+| `starts_with(string, prefix)` | 是否以前綴開頭 |
+| `ends_with(string, suffix)` | 是否以後綴結尾 |
+| `find(string, substring)` | 子字串的字元位置（`Option<int>`） |
+| `byte_len(string)` | 回傳字串的位元組長度 |
+| `substring(string, start, end)` | 取得子字串 |
+| `char_at(string, i)` | 取得指定位置的字元 |
+| `replace(string, old, new)` | 全部取代子字串 |
+| `to_upper(string)` / `to_lower(string)` | 大小寫轉換 |
+| `trim(string)` / `trim_start(string)` / `trim_end(string)` | 去除空白 |
+| `repeat(string, count)` | 將字串重複 n 次 |
+| `reverse(string)` | 反轉字串 |
+| `split(string, delimiter)` | 分割字串並回傳串列 |
+| `join(values, sep)` | 以分隔符號連接串列中的字串 |
+| `to_int(string)` / `to_float(string)` / `to_str(v)` | 型別轉換 |
 
 → 詳細請參閱 **[字串操作函式參考](builtins-string.md)**
 
@@ -124,25 +124,25 @@ print(x)   # Some(42)
 
 ---
 
-## len
+## length
 
-**簽名：** `len(x: List<T> | Map<K, V> | Set<T> | str) -> int`
+**簽名：** `length(value: List<T> | Map<K, V> | Set<T> | str) -> int`
 
 回傳串列、映射、集合的元素數量，或字串的 UTF-8 字元數。如需取得位元組長度，請使用 `byte_len()`。
 
 ```python
-print(len([1, 2, 3]))         # 3
-print(len({"a": 1, "b": 2})) # 2
-print(len({1, 2, 3}))         # 3
-print(len("hello"))           # 5
-print(len("あいう"))           # 3 (UTF-8 字元數)
+print(length([1, 2, 3]))         # 3
+print(length({"a": 1, "b": 2})) # 2
+print(length({1, 2, 3}))         # 3
+print(length("hello"))           # 5
+print(length("あいう"))           # 3 (UTF-8 字元數)
 ```
 
 ---
 
 ## has_key
 
-**簽名：** `has_key(m: Map<K, V>, key: K) -> bool`
+**簽名：** `has_key(map: Map<K, V>, key: K) -> bool`
 
 回傳映射中是否存在指定的鍵。也可使用 UFCS 記法。
 
@@ -156,7 +156,7 @@ print(m.has_key("z"))     # false (UFCS)
 
 ## add
 
-**簽名：** `add(s: Set<T>, value: T)`
+**簽名：** `add(set: Set<T>, value: T)`
 
 向集合新增元素。若元素已存在則不做任何操作。也可使用 UFCS 記法。
 
@@ -165,14 +165,14 @@ s = {1, 2, 3}
 s.add(4)          # UFCS
 add(s, 5)         # 一般呼叫
 s.add(1)          # 已存在，因此忽略
-print(len(s))     # 5
+print(length(s))     # 5
 ```
 
 ---
 
 ## remove
 
-**簽名：** `remove(s: Set<T>, value: T)`
+**簽名：** `remove(set: Set<T>, value: T)`
 
 從集合刪除元素。也可使用 UFCS 記法。
 
@@ -186,13 +186,13 @@ print(2 in s)     # false
 
 ## range
 
-**簽名：** `range(n: int) -> List<int>` / `range(start: int, end: int) -> List<int>` / `range(start: int, end: int, step: int) -> List<int>`
+**簽名：** `range(count: int) -> List<int>` / `range(start: int, end: int) -> List<int>` / `range(start: int, end: int, step: int) -> List<int>`
 
 生成整數串列。
 
 | 形式 | 生成的值 |
 |------|------------|
-| `range(n)` | `[0, 1, ..., n-1]` |
+| `range(count)` | `[0, 1, ..., count-1]` |
 | `range(start, end)` | `[start, start+1, ..., end-1]` |
 | `range(start, end, step)` | `[start, start+step, start+2*step, ...]`（不包含 `end`） |
 
@@ -237,7 +237,7 @@ exit(1)        # 錯誤終止
 ```python
 # 執行: ry script.ry hello world
 a = args()
-print(len(a))    # 2
+print(length(a))    # 2
 print(a[0])      # hello
 print(a[1])      # world
 
@@ -295,7 +295,7 @@ print(xs)   # [1, 2, 3]（未修改）
 
 **簽名：** `slice(list: List<T>, start: int, end: int) -> List<T>`
 
-傳回從 `start`（含）到 `end`（不含）的新子串列。索引會被鉗制在有效範圍內（`0` 到 `len(list)`）。也可使用 UFCS 記法。
+傳回從 `start`（含）到 `end`（不含）的新子串列。索引會被鉗制在有效範圍內（`0` 到 `length(list)`）。也可使用 UFCS 記法。
 
 ```python
 xs = [1, 2, 3, 4, 5]
@@ -307,9 +307,9 @@ print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5]（鉗制）
 
 ## take
 
-**簽名：** `take(list: List<T>, n: int) -> List<T>`
+**簽名：** `take(list: List<T>, count: int) -> List<T>`
 
-傳回包含前 `n` 個元素的新串列。若 `n` 超過串列長度，傳回整個串列的副本。若 `n <= 0`，傳回空串列。原始串列不會被修改。也可使用 UFCS 記法。
+傳回包含前 `count` 個元素的新串列。若 `count` 超過串列長度，傳回整個串列的副本。若 `count <= 0`，傳回空串列。原始串列不會被修改。也可使用 UFCS 記法。
 
 ```python
 xs = [1, 2, 3, 4, 5]
@@ -366,7 +366,7 @@ print(ys)   # [2, 4, 6]
 
 ## sort
 
-**簽名:** `sort(list: List<T>) -> List<T>` / `sort(list: List<T>, comp: fn(T, T) -> bool) -> List<T>`
+**簽名:** `sort(list: List<T>) -> List<T>` / `sort(list: List<T>, comparator: fn(T, T) -> bool) -> List<T>`
 
 傳回排序後的新串列。預設為升序。可提供自訂比較函式（第一引數應排在第二引數之前時回傳 `true`）。原始串列不會被修改。排序是**穩定的**（相等元素保持原始順序）。也可使用 UFCS 記法。
 
@@ -383,7 +383,7 @@ print(desc)   # [3, 2, 1]
 
 ## sort!
 
-**簽名:** `sort!(list: List<T>)` / `sort!(list: List<T>, comp: fn(T, T) -> bool)`
+**簽名:** `sort!(list: List<T>)` / `sort!(list: List<T>, comparator: fn(T, T) -> bool)`
 
 就地排序串列。排序演算法與 `sort()` 相同，但修改原始串列而非建立新串列。也可使用 UFCS 記法。
 

--- a/docs/zh/reference/collections.md
+++ b/docs/zh/reference/collections.md
@@ -85,11 +85,11 @@ xs[0] = 99
 print(xs[0])   # 99
 ```
 
-### len
+### length
 
 ```python
 xs = [1, 2, 3]
-print(len(xs))   # 3
+print(length(xs))   # 3
 ```
 
 ### print
@@ -153,7 +153,7 @@ print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5]（鉗制）
 
 ### take
 
-傳回包含前 `n` 個元素的新串列。若 `n` 超過串列長度，傳回整個串列的副本。若 `n <= 0`，傳回空串列。原始串列不會被修改。
+傳回包含前 `count` 個元素的新串列。若 `count` 超過串列長度，傳回整個串列的副本。若 `count <= 0`，傳回空串列。原始串列不會被修改。
 
 ```python
 xs = [1, 2, 3, 4, 5]
@@ -405,7 +405,7 @@ print(xs)            # [[1, 2], [3, 4]]（未變更）
 | `filter`、`map`、`reduce`、`fold` | O(n) |
 | `reverse` / `reverse!` | O(n) |
 | `distinct` | O(n) |
-| `len` | O(1) |
+| `length` | O(1) |
 
 ### 限制與錯誤
 
@@ -445,11 +445,11 @@ m["b"] = 2     # 新增
 m["a"] = 99    # 更新
 ```
 
-### len
+### length
 
 ```python
 m = {"a": 1, "b": 2, "c": 3}
-print(len(m))   # 3
+print(length(m))   # 3
 ```
 
 ### print
@@ -566,11 +566,11 @@ print(2 in s)   # true
 print(5 in s)   # false
 ```
 
-### len
+### length
 
 ```python
 s = {1, 2, 3}
-print(len(s))   # 3
+print(length(s))   # 3
 ```
 
 ### print
@@ -588,7 +588,7 @@ print(s)   # {1, 2, 3}
 s = {1, 2, 3}
 s.add(4)         # 新增
 s.add(1)         # 已存在，因此忽略
-print(len(s))    # 4
+print(length(s))    # 4
 ```
 
 ### remove（刪除元素）

--- a/docs/zh/reference/directives.md
+++ b/docs/zh/reference/directives.md
@@ -107,7 +107,7 @@ a, b = (1, 2)
 
 ```
 @native
-fn contains(s: str, sub: str) -> bool
+fn contains(string: str, substring: str) -> bool
 
 print(contains("hello world", "world"))  # true
 ```
@@ -125,7 +125,7 @@ print("hello" + " world")  # hello world
 
 ```
 @native
-fn to_upper(s: str) -> str
+fn to_upper(string: str) -> str
 
 print("hello".to_upper())  # HELLO
 ```
@@ -140,7 +140,7 @@ print("hello".to_upper())  # HELLO
 
 | 檔案 | 內容 |
 |---|---|
-| `core/builtins.ry` | `print`, `len`, `range`, `enumerate`, `zip`, `exit`, `args` |
+| `core/builtins.ry` | `print`, `length`, `range`, `enumerate`, `zip`, `exit`, `args` |
 | `core/str.ry` | `contains`, `starts_with`, `ends_with`, `find`, `substring`, `char_at`, `replace`, `to_upper`, `to_lower`, `trim`, `trim_start`, `trim_end`, `repeat`, `reverse`, `split`, `join` |
 | `core/convert.ry` | `to_int`, `to_float`, `to_str` |
 | `core/list.ry` | `append`, `pop`, `insert`, `remove_at`, `slice`, `distinct`, `flatten`, `sort`, `first`, `last`, `is_empty` |

--- a/docs/zh/reference/functions.md
+++ b/docs/zh/reference/functions.md
@@ -227,7 +227,7 @@ result = 5.double().add_one()   # double(5) → 10, add_one(10) → 11
 
 ```python
 p = Point(3, 4)
-len = p.x.to_float()   # 欄位存取 + UFCS
+length = p.x.to_float()   # 欄位存取 + UFCS
 ```
 
 ---

--- a/docs/zh/reference/io.md
+++ b/docs/zh/reference/io.md
@@ -63,7 +63,7 @@ print(file_exists("hello.txt"))   # false
 from std.io import str_to_bytes, bytes_to_str, write_bytes, read_bytes
 
 bs = str_to_bytes("ABC")
-print(len(bs))    # 3
+print(length(bs))    # 3
 
 write_bytes("data.bin", bs)
 rb = read_bytes("data.bin")
@@ -94,6 +94,6 @@ print(f"Hello, {name}!")
 
 ## 備註
 
-- 使用 `List<byte>` 作為緩衝區型別。標準串列操作（`len()`、`append()`、`slice()`、索引存取）均可用於位元組串列。
+- 使用 `List<byte>` 作為緩衝區型別。標準串列操作（`length()`、`append()`、`slice()`、索引存取）均可用於位元組串列。
 - 檔案路徑若未指定絕對路徑，則為相對於當前工作目錄的相對路徑。
 - `write_text` 與 `write_bytes` 會覆蓋既有檔案。若要追加內容，請使用 `append_text`。

--- a/docs/zh/reference/packages.md
+++ b/docs/zh/reference/packages.md
@@ -93,7 +93,7 @@ from mypackage import add   # 僅匯入 add
 ## 標準函式庫 (`std`)
 
 `std` 套件會自動匯入到每個程式中。提供的功能：
-- 內建函式（`print`, `len`, `range` 等）
+- 內建函式（`print`, `length`, `range` 等）
 - 字串函式（`contains`, `find`, `replace` 等）
 - 型別轉換函式（`to_int`, `to_float`, `to_str`）
 - 集合函式（`map`, `filter`, `sort` 等）

--- a/docs/zh/reference/regex.md
+++ b/docs/zh/reference/regex.md
@@ -77,7 +77,7 @@ print(s)  # aXbXcX
 
 ```ry
 parts = regex_split("\\s+", "hello  world  foo")
-print(len(parts))  # 3
+print(length(parts))  # 3
 print(parts[0])    # hello
 ```
 
@@ -85,7 +85,7 @@ print(parts[0])    # hello
 
 ```ry
 matches = regex_find_all("[0-9]+", "a1b23c456")
-print(len(matches))  # 3
+print(length(matches))  # 3
 print(matches[0])    # 1
 print(matches[1])    # 23
 ```
@@ -111,7 +111,7 @@ print(l)  # X and X
 
 # 取得個別 HTML 標籤
 tags = regex_find_all("<.*?>", "<a> <bb> <ccc>")
-print(len(tags))  # 3
+print(length(tags))  # 3
 ```
 
 > **注意：** 非貪婪匹配控制整體匹配長度。沒有使用括號分組時，greedy/lazy 混合模式可能與 PCRE 引擎行為不同。
@@ -125,7 +125,7 @@ print(pos)  # 6
 
 # 取得所有單字
 words = regex_find_all("\\b\\w+\\b", "hello world foo")
-print(len(words))  # 3
+print(length(words))  # 3
 
 # \B 匹配非邊界（單字內部）
 pos2 = regex_search("\\Bworld", "helloworld")

--- a/docs/zh/tutorial/02-variables-and-types.md
+++ b/docs/zh/tutorial/02-variables-and-types.md
@@ -86,7 +86,7 @@ print(a != b)   # true
 print(a < b)    # true（"H" < "W"）
 
 # 長度
-print(len(a))   # 5
+print(length(a))   # 5
 
 # 子字串檢查
 s = "Hello, World!"

--- a/docs/zh/tutorial/07-collections.md
+++ b/docs/zh/tutorial/07-collections.md
@@ -85,10 +85,10 @@ print(xs[i])   # 2
 xs[0] = 99
 ```
 
-### len
+### length
 
 ```python
-print(len(xs))   # 3
+print(length(xs))   # 3
 ```
 
 ### print
@@ -240,10 +240,10 @@ m["c"] = 3    # 新增
 m["a"] = 99   # 更新
 ```
 
-### len
+### length
 
 ```python
-print(len(m))   # 3
+print(length(m))   # 3
 ```
 
 ### print
@@ -318,10 +318,10 @@ s.remove(1)    # 移除元素
 s.add(2)       # 已存在，因此忽略
 ```
 
-### len / print
+### length / print
 
 ```python
-print(len(s))  # 3
+print(length(s))  # 3
 print(s)       # {2, 3, 4}
 ```
 

--- a/docs/zh/tutorial/09-modules.md
+++ b/docs/zh/tutorial/09-modules.md
@@ -59,7 +59,7 @@ from mypackage import add   # 僅匯入 add
 ```python
 # 這些函式無需匯入即可使用
 print("hello")
-n = len("world")
+n = length("world")
 xs = range(5)
 ```
 

--- a/lib/std/builtins.ry
+++ b/lib/std/builtins.ry
@@ -1,22 +1,22 @@
 # Core built-in functions
 
 @native
-fn print(x: str) -> Unit
+fn print(value: str) -> Unit
 
 @native
-fn len(x: str) -> int
+fn length(value: str) -> int
 
 @native
-fn len(x: List<int>) -> int
+fn length(value: List<int>) -> int
 
 @native
-fn len(x: Map<str, int>) -> int
+fn length(value: Map<str, int>) -> int
 
 @native
-fn len(x: Set<int>) -> int
+fn length(value: Set<int>) -> int
 
 @native
-fn range(n: int) -> List<int>
+fn range(count: int) -> List<int>
 
 @native
 fn range(start: int, end: int) -> List<int>
@@ -25,10 +25,10 @@ fn range(start: int, end: int) -> List<int>
 fn range(start: int, end: int, step: int) -> List<int>
 
 @native
-fn enumerate(xs: List<int>) -> List<int>
+fn enumerate(values: List<int>) -> List<int>
 
 @native
-fn zip(xs: List<int>, ys: List<int>) -> List<int>
+fn zip(values: List<int>, other_values: List<int>) -> List<int>
 
 @native
 fn exit(code: int) -> Unit

--- a/lib/std/convert.ry
+++ b/lib/std/convert.ry
@@ -1,16 +1,16 @@
 # Type conversion functions
 
 @native
-fn to_int(x: str) -> int
+fn to_int(value: str) -> int
 
 @native
-fn to_float(x: str) -> float
+fn to_float(value: str) -> float
 
 @native
-fn to_str(x: int) -> str
+fn to_str(value: int) -> str
 
 @native
-fn to_str(x: float) -> str
+fn to_str(value: float) -> str
 
 @native
-fn to_str(x: bool) -> str
+fn to_str(value: bool) -> str

--- a/lib/std/higher_order.ry
+++ b/lib/std/higher_order.ry
@@ -1,28 +1,28 @@
 # Higher-order functions
 
 @native
-fn filter(xs: List<int>, f: fn(int) -> bool) -> List<int>
+fn filter(values: List<int>, predicate: fn(int) -> bool) -> List<int>
 
 @native
-fn map(xs: List<int>, f: fn(int) -> int) -> List<int>
+fn map(values: List<int>, transform: fn(int) -> int) -> List<int>
 
 @native
-fn reduce(xs: List<int>, f: fn(int, int) -> int) -> int
+fn reduce(values: List<int>, reducer: fn(int, int) -> int) -> int
 
 @native
-fn fold(xs: List<int>, init: int, f: fn(int, int) -> int) -> int
+fn fold(values: List<int>, init: int, reducer: fn(int, int) -> int) -> int
 
 @native
-fn any(xs: List<int>, f: fn(int) -> bool) -> bool
+fn any(values: List<int>, predicate: fn(int) -> bool) -> bool
 
 @native
-fn all(xs: List<int>, f: fn(int) -> bool) -> bool
+fn all(values: List<int>, predicate: fn(int) -> bool) -> bool
 
 @native
-fn sum(xs: List<int>) -> int
+fn sum(values: List<int>) -> int
 
 @native
-fn min(xs: List<int>) -> int
+fn min(values: List<int>) -> int
 
 @native
-fn max(xs: List<int>) -> int
+fn max(values: List<int>) -> int

--- a/lib/std/io/io.ry
+++ b/lib/std/io/io.ry
@@ -31,7 +31,7 @@ fn write_bytes(path: str, data: List<byte>) -> Unit
 
 # Byte conversions
 @native
-fn str_to_bytes(s: str) -> List<byte>
+fn str_to_bytes(string: str) -> List<byte>
 
 @native
-fn bytes_to_str(bs: List<byte>) -> str
+fn bytes_to_str(bytes: List<byte>) -> str

--- a/lib/std/list.ry
+++ b/lib/std/list.ry
@@ -1,52 +1,52 @@
 # List operations
 
 @native
-fn append(xs: List<int>, val: int) -> Unit
+fn append(values: List<int>, value: int) -> Unit
 
 @native
-fn pop(xs: List<int>) -> Option<int>
+fn pop(values: List<int>) -> Option<int>
 
 @native
-fn insert(xs: List<int>, index: int, val: int) -> Unit
+fn insert(values: List<int>, index: int, value: int) -> Unit
 
 @native
-fn remove_at(xs: List<int>, index: int) -> Unit
+fn remove_at(values: List<int>, index: int) -> Unit
 
 @native
-fn slice(xs: List<int>, start: int, end: int) -> List<int>
+fn slice(values: List<int>, start: int, end: int) -> List<int>
 
 @native
-fn distinct(xs: List<int>) -> List<int>
+fn distinct(values: List<int>) -> List<int>
 
 @native
-fn flatten(xs: List<int>) -> List<int>
+fn flatten(values: List<int>) -> List<int>
 
 @native
-fn sort(xs: List<int>) -> List<int>
+fn sort(values: List<int>) -> List<int>
 
 @native
-fn sort(xs: List<int>, comp: fn(int, int) -> bool) -> List<int>
+fn sort(values: List<int>, comparator: fn(int, int) -> bool) -> List<int>
 
 @native
-fn first(xs: List<int>) -> Option<int>
+fn first(values: List<int>) -> Option<int>
 
 @native
-fn last(xs: List<int>) -> Option<int>
+fn last(values: List<int>) -> Option<int>
 
 @native
-fn sort!(xs: List<int>) -> Unit
+fn sort!(values: List<int>) -> Unit
 
 @native
-fn sort!(xs: List<int>, comp: fn(int, int) -> bool) -> Unit
+fn sort!(values: List<int>, comparator: fn(int, int) -> bool) -> Unit
 
 @native
-fn reverse!(xs: List<int>) -> Unit
+fn reverse!(values: List<int>) -> Unit
 
 @native
-fn appended(xs: List<int>, val: int) -> List<int>
+fn appended(values: List<int>, value: int) -> List<int>
 
 @native
-fn append!(xs: List<int>, val: int) -> Unit
+fn append!(values: List<int>, value: int) -> Unit
 
 @native
-fn is_empty(xs: List<int>) -> bool
+fn is_empty(values: List<int>) -> bool

--- a/lib/std/map.ry
+++ b/lib/std/map.ry
@@ -1,22 +1,22 @@
 # Map operations
 
 @native
-fn keys(m: Map<str, int>) -> List<str>
+fn keys(map: Map<str, int>) -> List<str>
 
 @native
-fn values(m: Map<str, int>) -> List<int>
+fn values(map: Map<str, int>) -> List<int>
 
 @native
-fn items(m: Map<str, int>) -> List<int>
+fn items(map: Map<str, int>) -> List<int>
 
 @native
-fn has_key(m: Map<str, int>, key: str) -> bool
+fn has_key(map: Map<str, int>, key: str) -> bool
 
 @native
-fn get(m: Map<str, int>, key: str) -> Option<int>
+fn get(map: Map<str, int>, key: str) -> Option<int>
 
 @native
-fn get(m: Map<str, int>, key: str, default: int) -> int
+fn get(map: Map<str, int>, key: str, default: int) -> int
 
 @native
-fn merge(m1: Map<str, int>, m2: Map<str, int>) -> Map<str, int>
+fn merge(first_map: Map<str, int>, second_map: Map<str, int>) -> Map<str, int>

--- a/lib/std/set.ry
+++ b/lib/std/set.ry
@@ -1,25 +1,25 @@
 # Set operations
 
 @native
-fn add(s: Set<int>, val: int) -> Unit
+fn add(set: Set<int>, value: int) -> Unit
 
 @native
-fn remove(s: Set<int>, val: int) -> Unit
+fn remove(set: Set<int>, value: int) -> Unit
 
 @native
-fn union(s1: Set<int>, s2: Set<int>) -> Set<int>
+fn union(first_set: Set<int>, second_set: Set<int>) -> Set<int>
 
 @native
-fn intersection(s1: Set<int>, s2: Set<int>) -> Set<int>
+fn intersection(first_set: Set<int>, second_set: Set<int>) -> Set<int>
 
 @native
-fn difference(s1: Set<int>, s2: Set<int>) -> Set<int>
+fn difference(first_set: Set<int>, second_set: Set<int>) -> Set<int>
 
 @native
-fn symmetric_difference(s1: Set<int>, s2: Set<int>) -> Set<int>
+fn symmetric_difference(first_set: Set<int>, second_set: Set<int>) -> Set<int>
 
 @native
-fn is_subset(s1: Set<int>, s2: Set<int>) -> bool
+fn is_subset(first_set: Set<int>, second_set: Set<int>) -> bool
 
 @native
-fn is_superset(s1: Set<int>, s2: Set<int>) -> bool
+fn is_superset(first_set: Set<int>, second_set: Set<int>) -> bool

--- a/lib/std/str.ry
+++ b/lib/std/str.ry
@@ -1,52 +1,52 @@
 # String operations
 
 @native
-fn contains(s: str, sub: str) -> bool
+fn contains(string: str, substring: str) -> bool
 
 @native
-fn starts_with(s: str, prefix: str) -> bool
+fn starts_with(string: str, prefix: str) -> bool
 
 @native
-fn ends_with(s: str, suffix: str) -> bool
+fn ends_with(string: str, suffix: str) -> bool
 
 @native
-fn find(s: str, sub: str) -> Option<int>
+fn find(string: str, substring: str) -> Option<int>
 
 @native
-fn byte_len(s: str) -> int
+fn byte_len(string: str) -> int
 
 @native
-fn substring(s: str, start: int, end: int) -> str
+fn substring(string: str, start: int, end: int) -> str
 
 @native
-fn char_at(s: str, index: int) -> str
+fn char_at(string: str, index: int) -> str
 
 @native
-fn replace(s: str, target: str, replacement: str) -> str
+fn replace(string: str, target: str, replacement: str) -> str
 
 @native
-fn to_upper(s: str) -> str
+fn to_upper(string: str) -> str
 
 @native
-fn to_lower(s: str) -> str
+fn to_lower(string: str) -> str
 
 @native
-fn trim(s: str) -> str
+fn trim(string: str) -> str
 
 @native
-fn trim_start(s: str) -> str
+fn trim_start(string: str) -> str
 
 @native
-fn trim_end(s: str) -> str
+fn trim_end(string: str) -> str
 
 @native
-fn repeat(s: str, n: int) -> str
+fn repeat(string: str, count: int) -> str
 
 @native
-fn reverse(s: str) -> str
+fn reverse(string: str) -> str
 
 @native
-fn split(s: str, delim: str) -> List<str>
+fn split(string: str, delimiter: str) -> List<str>
 
 @native
-fn join(xs: List<str>, delim: str) -> str
+fn join(values: List<str>, delimiter: str) -> str

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -1589,13 +1589,13 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         return headerPtr;
     }
 
-    // len(xs) → list/map length
-    if (e.callee == "len") {
+    // length(xs) → list/map length
+    if (e.callee == "length") {
         if (e.args.size() != 1)
-            codegenError("len() takes exactly 1 argument");
+            codegenError("length() takes exactly 1 argument");
         llvm::Value *ptr = emitExpr(*e.args[0]);
         if (ptr->getType() != ptrTy_)
-            codegenError("len() requires list, map, or str argument");
+            codegenError("length() requires list, map, or str argument");
         // Check if it's a set
         if (getSetElementType(ptr)) {
             llvm::Value *lenPtr = builder_.CreateStructGEP(setHeaderTy_, ptr, 0, "set_len_ptr");

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -295,7 +295,7 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 return it->second[0].func->getReturnType();
             // Known builtin return types
             const std::string &c = v->callee;
-            if (c == "len" || c == "to_int" || c == "find")
+            if (c == "length" || c == "to_int" || c == "find")
                 return i64Ty_;
             // sum/min/max/first/last return the element type of the list argument
             if (c == "sum" || c == "min" || c == "max" || c == "first" || c == "last") {

--- a/tests/spec/builtins.test.ry
+++ b/tests/spec/builtins.test.ry
@@ -1,4 +1,4 @@
-describe("len", fn():
+describe("length", fn():
     it("List", fn():
         expect([1, 2, 3]).to_have_length(3)
 

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -11,7 +11,7 @@ describe("List", fn():
         expect(xs[0]).to_eq(99)
 
     )
-    it("len", fn():
+    it("length", fn():
         expect([1, 2, 3]).to_have_length(3)
 
     )
@@ -323,7 +323,7 @@ describe("Map", fn():
         expect(m["b"]).to_eq(2)
 
     )
-    it("len", fn():
+    it("length", fn():
         m = {"a": 1, "b": 2, "c": 3}
         expect(m).to_have_length(3)
 
@@ -396,7 +396,7 @@ describe("Set", fn():
         expect(s).to_not_contain(5)
 
     )
-    it("len", fn():
+    it("length", fn():
         s = {1, 2, 3}
         expect(s).to_have_length(3)
 

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -58,7 +58,7 @@ describe("file I/O", fn():
 
     it("byte conversions", fn():
         bs = str_to_bytes("ABC")
-        expect(len(bs)).to_eq(3)
+        expect(length(bs)).to_eq(3)
         match bytes_to_str(bs):
             case Ok(s):
                 expect(s).to_eq("ABC")
@@ -75,7 +75,7 @@ describe("file I/O", fn():
                 expect(true).to_eq(false)
         match read_bytes("/tmp/ry_selftest_io_bytes.bin"):
             case Ok(rb):
-                expect(len(rb)).to_eq(11)
+                expect(length(rb)).to_eq(11)
                 match bytes_to_str(rb):
                     case Ok(s):
                         expect(s).to_eq("binary test")

--- a/tests/spec/parameterized.test.ry
+++ b/tests/spec/parameterized.test.ry
@@ -14,7 +14,7 @@ describe("@each parameterized tests", fn():
         ("ry", 2)
     ])
     it("length of \"{0}\" is {1}", fn(s: str, expected: int):
-        expect(len(s)).to_eq(expected)
+        expect(length(s)).to_eq(expected)
     )
 )
 

--- a/tests/spec/regex_phase2.test.ry
+++ b/tests/spec/regex_phase2.test.ry
@@ -37,7 +37,7 @@ describe("non-greedy match", fn():
     )
     it("lazy find_all", fn():
         tags = regex_find_all("<.*?>", "<x> <yy> <zzz>")
-        expect(len(tags)).to_eq(3)
+        expect(length(tags)).to_eq(3)
         expect(tags[0]).to_eq("<x>")
         expect(tags[1]).to_eq("<yy>")
         expect(tags[2]).to_eq("<zzz>")

--- a/tests/spec/regex_phase3.test.ry
+++ b/tests/spec/regex_phase3.test.ry
@@ -21,7 +21,7 @@ describe("word boundary \\b / \\B", fn():
     )
     it("\\b find_all", fn():
         words = regex_find_all("\\b\\w+\\b", "hello world foo")
-        expect(len(words)).to_eq(3)
+        expect(length(words)).to_eq(3)
         expect(words[0]).to_eq("hello")
         expect(words[1]).to_eq("world")
         expect(words[2]).to_eq("foo")
@@ -54,7 +54,7 @@ describe("case-insensitive (?i)", fn():
     )
     it("find_all", fn():
         matches = regex_find_all("(?i)hello", "Hello HELLO hello")
-        expect(len(matches)).to_eq(3)
+        expect(length(matches)).to_eq(3)
         expect(matches[0]).to_eq("Hello")
         expect(matches[1]).to_eq("HELLO")
         expect(matches[2]).to_eq("hello")

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -96,7 +96,7 @@ describe("split and join", fn():
     )
 )
 describe("UTF-8 support", fn():
-    it("len counts characters", fn():
+    it("length counts characters", fn():
         expect("hello").to_have_length(5)
         expect("あいう").to_have_length(3)
 

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -498,12 +498,12 @@ TEST_F(CodeGenTest, ExitTooManyArgsThrows) {
 // ===== args() テスト =====
 
 TEST_F(CodeGenTest, ArgsEmpty) {
-    EXPECT_EQ(runSourceWithArgs("a = args()\nprint(len(a))", {}), "0\n");
+    EXPECT_EQ(runSourceWithArgs("a = args()\nprint(length(a))", {}), "0\n");
 }
 
 TEST_F(CodeGenTest, ArgsWithValues) {
     EXPECT_EQ(runSourceWithArgs(
-        "a = args()\nprint(len(a))\nprint(a[0])\nprint(a[1])",
+        "a = args()\nprint(length(a))\nprint(a[0])\nprint(a[1])",
         {"hello", "world"}), "2\nhello\nworld\n");
 }
 

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -137,7 +137,7 @@ TEST_F(CodeGenTest, EscapeQuote) {
 TEST_F(CodeGenTest, RangeEmptyList) {
     std::string src =
         "xs = range(0)\n"
-        "print(len(xs))";
+        "print(length(xs))";
     EXPECT_EQ(runSource(src), "0\n");
 }
 
@@ -147,7 +147,7 @@ TEST_F(CodeGenTest, RangeUsedAsList) {
         "print(xs[0])\n"
         "print(xs[1])\n"
         "print(xs[2])\n"
-        "print(len(xs))";
+        "print(length(xs))";
     EXPECT_EQ(runSource(src), "0\n1\n2\n3\n");
 }
 
@@ -270,7 +270,7 @@ TEST_F(CodeGenTest, SetNotIn) {
 TEST_F(CodeGenTest, SetLen) {
     std::string src =
         "s = {1, 2, 3}\n"
-        "print(len(s))";
+        "print(length(s))";
     EXPECT_EQ(runSource(src), "3\n");
 }
 
@@ -286,7 +286,7 @@ TEST_F(CodeGenTest, SetAddDuplicate) {
     std::string src =
         "s = {1, 2, 3}\n"
         "s.add(1)\n"
-        "print(len(s))";
+        "print(length(s))";
     EXPECT_EQ(runSource(src), "3\n");
 }
 
@@ -316,7 +316,7 @@ TEST_F(CodeGenTest, SetStringElements) {
 TEST_F(CodeGenTest, SetEmptyWithAnnotation) {
     std::string src =
         "s: Set<int> = {}\n"
-        "print(len(s))\n"
+        "print(length(s))\n"
         "s.add(42)\n"
         "print(42 in s)";
     EXPECT_EQ(runSource(src), "0\ntrue\n");

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -12,7 +12,7 @@ TEST_F(CodeGenTest, ListCreateAndAccess) {
 TEST_F(CodeGenTest, ListLen) {
     std::string src =
         "xs = [10, 20, 30]\n"
-        "print(len(xs))";
+        "print(length(xs))";
     EXPECT_EQ(runSource(src), "3\n");
 }
 
@@ -29,7 +29,7 @@ TEST_F(CodeGenTest, ListWithTypeAnnotation) {
     std::string src =
         "xs: List<int> = [1, 2, 3]\n"
         "print(xs[0])\n"
-        "print(len(xs))";
+        "print(length(xs))";
     EXPECT_EQ(runSource(src), "1\n3\n");
 }
 
@@ -67,7 +67,7 @@ TEST_F(CodeGenTest, ListInFunction) {
 TEST_F(CodeGenTest, ListLenInFunction) {
     std::string src =
         "fn size(xs: List<int>) -> int:\n"
-        "    return len(xs)\n"
+        "    return length(xs)\n"
         "xs = [1, 2, 3, 4, 5]\n"
         "print(size(xs))";
     EXPECT_EQ(runSource(src), "5\n");
@@ -171,7 +171,7 @@ TEST_F(CodeGenTest, MapAccessSecondKey) {
 TEST_F(CodeGenTest, MapLen) {
     std::string src =
         "m = {\"a\": 1, \"b\": 2}\n"
-        "print(len(m))";
+        "print(length(m))";
     EXPECT_EQ(runSource(src), "2\n");
 }
 
@@ -187,7 +187,7 @@ TEST_F(CodeGenTest, MapKeyAssign) {
         "m = {\"a\": 1, \"b\": 2}\n"
         "m[\"c\"] = 3\n"
         "print(m[\"c\"])\n"
-        "print(len(m))";
+        "print(length(m))";
     EXPECT_EQ(runSource(src), "3\n3\n");
 }
 
@@ -240,15 +240,15 @@ TEST_F(CodeGenTest, MapHasKey) {
 // ===== 文字列メソッドテスト =====
 
 TEST_F(CodeGenTest, StringLen) {
-    EXPECT_EQ(runSource("print(len(\"hello\"))"), "5\n");
+    EXPECT_EQ(runSource("print(length(\"hello\"))"), "5\n");
 }
 
 TEST_F(CodeGenTest, StringLenEmpty) {
-    EXPECT_EQ(runSource("print(len(\"\"))"), "0\n");
+    EXPECT_EQ(runSource("print(length(\"\"))"), "0\n");
 }
 
 TEST_F(CodeGenTest, StringLenUFCS) {
-    EXPECT_EQ(runSource("s = \"hello\"\nprint(s.len())"), "5\n");
+    EXPECT_EQ(runSource("s = \"hello\"\nprint(s.length())"), "5\n");
 }
 
 TEST_F(CodeGenTest, StringEqual) {
@@ -989,7 +989,7 @@ TEST_F(CodeGenTest, SplitBasic) {
 TEST_F(CodeGenTest, SplitNoDelimiter) {
     std::string src =
         "parts = split(\"hello\", \",\")\n"
-        "print(len(parts))\n"
+        "print(length(parts))\n"
         "print(parts[0])";
     EXPECT_EQ(runSource(src), "1\nhello\n");
 }
@@ -1004,7 +1004,7 @@ TEST_F(CodeGenTest, SplitMultiCharDelim) {
 }
 
 TEST_F(CodeGenTest, SplitLen) {
-    EXPECT_EQ(runSource("print(len(split(\"a,b,c,d\", \",\")))"), "4\n");
+    EXPECT_EQ(runSource("print(length(split(\"a,b,c,d\", \",\")))"), "4\n");
 }
 
 TEST_F(CodeGenTest, SplitUFCS) {
@@ -1072,7 +1072,7 @@ TEST_F(CodeGenTest, FilterIntEmpty) {
     std::string src =
         "xs = [1, 2, 3]\n"
         "ys = filter(xs, fn(x: int): x > 10)\n"
-        "print(len(ys))";
+        "print(length(ys))";
     EXPECT_EQ(runSource(src), "0\n");
 }
 
@@ -1096,7 +1096,7 @@ TEST_F(CodeGenTest, FilterString) {
     std::string src =
         "xs = [\"hello\", \"hi\", \"hey\"]\n"
         "ys = filter(xs, fn(s: str): s.starts_with(\"he\"))\n"
-        "print(len(ys))";
+        "print(length(ys))";
     EXPECT_EQ(runSource(src), "2\n");
 }
 
@@ -1138,7 +1138,7 @@ TEST_F(CodeGenTest, MapIntToFloat) {
 TEST_F(CodeGenTest, MapStrToInt) {
     std::string src =
         "xs = [\"hello\", \"hi\"]\n"
-        "ys = map(xs, fn(s: str): len(s))\n"
+        "ys = map(xs, fn(s: str): length(s))\n"
         "print(ys)";
     EXPECT_EQ(runSource(src), "[5, 2]\n");
 }
@@ -1519,7 +1519,7 @@ TEST_F(CodeGenTest, RangeStepEmpty) {
 TEST_F(CodeGenTest, RangeStepList) {
     std::string src =
         "xs = range(0, 10, 3)\n"
-        "print(len(xs))";
+        "print(length(xs))";
     EXPECT_EQ(runSource(src), "4\n");
 }
 
@@ -1561,7 +1561,7 @@ TEST_F(CodeGenTest, MapKeys) {
     std::string src =
         "m = {\"a\": 1, \"b\": 2}\n"
         "ks = keys(m)\n"
-        "print(len(ks))";
+        "print(length(ks))";
     EXPECT_EQ(runSource(src), "2\n");
 }
 
@@ -1569,7 +1569,7 @@ TEST_F(CodeGenTest, MapValues) {
     std::string src =
         "m = {\"a\": 1, \"b\": 2}\n"
         "vs = values(m)\n"
-        "print(len(vs))";
+        "print(length(vs))";
     EXPECT_EQ(runSource(src), "2\n");
 }
 
@@ -1632,7 +1632,7 @@ TEST_F(CodeGenTest, EnumerateBasic) {
     std::string src =
         "xs = [10, 20, 30]\n"
         "es = enumerate(xs)\n"
-        "print(len(es))";
+        "print(length(es))";
     EXPECT_EQ(runSource(src), "3\n");
 }
 
@@ -1641,7 +1641,7 @@ TEST_F(CodeGenTest, ZipBasic) {
         "xs = [1, 2, 3]\n"
         "ys = [\"a\", \"b\", \"c\"]\n"
         "zs = zip(xs, ys)\n"
-        "print(len(zs))";
+        "print(length(zs))";
     EXPECT_EQ(runSource(src), "3\n");
 }
 
@@ -1676,7 +1676,7 @@ TEST_F(CodeGenTest, ListInsert) {
         "print(xs[0])\n"
         "print(xs[1])\n"
         "print(xs[2])\n"
-        "print(len(xs))";
+        "print(length(xs))";
     EXPECT_EQ(runSource(src), "1\n2\n3\n4\n");
 }
 
@@ -1687,7 +1687,7 @@ TEST_F(CodeGenTest, ListRemoveAt) {
         "xs = [10, 20, 30]\n"
         "removed = remove_at(xs, 1)\n"
         "print(removed)\n"
-        "print(len(xs))\n"
+        "print(length(xs))\n"
         "print(xs[0])\n"
         "print(xs[1])";
     EXPECT_EQ(runSource(src), "20\n2\n10\n30\n");
@@ -1699,7 +1699,7 @@ TEST_F(CodeGenTest, MapItems) {
     std::string src =
         "m = {\"a\": 1}\n"
         "pairs = items(m)\n"
-        "print(len(pairs))";
+        "print(length(pairs))";
     EXPECT_EQ(runSource(src), "1\n");
 }
 
@@ -1719,7 +1719,7 @@ TEST_F(CodeGenTest, MapRemove) {
     std::string src =
         "m = {\"a\": 1, \"b\": 2}\n"
         "remove(m, \"a\")\n"
-        "print(len(m))";
+        "print(length(m))";
     EXPECT_EQ(runSource(src), "1\n");
 }
 
@@ -1730,7 +1730,7 @@ TEST_F(CodeGenTest, SetUnion) {
         "a: Set<int> = {1, 2, 3}\n"
         "b: Set<int> = {3, 4, 5}\n"
         "c = union(a, b)\n"
-        "print(len(c))";
+        "print(length(c))";
     EXPECT_EQ(runSource(src), "5\n");
 }
 
@@ -1739,7 +1739,7 @@ TEST_F(CodeGenTest, SetIntersection) {
         "a: Set<int> = {1, 2, 3}\n"
         "b: Set<int> = {2, 3, 4}\n"
         "c = intersection(a, b)\n"
-        "print(len(c))";
+        "print(length(c))";
     EXPECT_EQ(runSource(src), "2\n");
 }
 
@@ -1748,7 +1748,7 @@ TEST_F(CodeGenTest, SetDifference) {
         "a: Set<int> = {1, 2, 3}\n"
         "b: Set<int> = {2, 3, 4}\n"
         "c = difference(a, b)\n"
-        "print(len(c))";
+        "print(length(c))";
     EXPECT_EQ(runSource(src), "1\n");
 }
 
@@ -1757,7 +1757,7 @@ TEST_F(CodeGenTest, SetSymmetricDifference) {
         "a: Set<int> = {1, 2, 3}\n"
         "b: Set<int> = {2, 3, 4}\n"
         "c = symmetric_difference(a, b)\n"
-        "print(len(c))";
+        "print(length(c))";
     EXPECT_EQ(runSource(src), "2\n");
 }
 
@@ -1905,7 +1905,7 @@ TEST_F(CodeGenTest, MergeNoOverlap) {
         "m1 = {\"a\": 1, \"b\": 2}\n"
         "m2 = {\"c\": 3, \"d\": 4}\n"
         "m3 = merge(m1, m2)\n"
-        "print(len(m3))\n"
+        "print(length(m3))\n"
         "print(m3[\"a\"])\n"
         "print(m3[\"b\"])\n"
         "print(m3[\"c\"])\n"
@@ -1918,7 +1918,7 @@ TEST_F(CodeGenTest, MergeOverlap) {
         "m1 = {\"a\": 1, \"b\": 2}\n"
         "m2 = {\"b\": 99, \"c\": 3}\n"
         "m3 = merge(m1, m2)\n"
-        "print(len(m3))\n"
+        "print(length(m3))\n"
         "print(m3[\"a\"])\n"
         "print(m3[\"b\"])\n"
         "print(m3[\"c\"])";
@@ -1930,7 +1930,7 @@ TEST_F(CodeGenTest, MergeIntKeys) {
         "m1 = {1: \"a\", 2: \"b\"}\n"
         "m2 = {2: \"x\", 3: \"c\"}\n"
         "m3 = merge(m1, m2)\n"
-        "print(len(m3))\n"
+        "print(length(m3))\n"
         "print(m3[1])\n"
         "print(m3[2])\n"
         "print(m3[3])";
@@ -1942,9 +1942,9 @@ TEST_F(CodeGenTest, MergeNonDestructive) {
         "m1 = {\"a\": 1}\n"
         "m2 = {\"b\": 2}\n"
         "m3 = merge(m1, m2)\n"
-        "print(len(m1))\n"
-        "print(len(m2))\n"
-        "print(len(m3))";
+        "print(length(m1))\n"
+        "print(length(m2))\n"
+        "print(length(m3))";
     EXPECT_EQ(runSource(src), "1\n1\n2\n");
 }
 
@@ -1983,7 +1983,7 @@ TEST_F(CodeGenTest, FlattenNonDestructive) {
     std::string src =
         "xs = [[1, 2], [3, 4]]\n"
         "ys = flatten(xs)\n"
-        "print(len(xs))\n"
+        "print(length(xs))\n"
         "print(ys)";
     EXPECT_EQ(runSource(src), "2\n[1, 2, 3, 4]\n");
 }
@@ -2085,7 +2085,7 @@ TEST_F(CodeGenTest, SortLargeListWithDuplicates) {
         "5, 3, 8, 1, 9, 2, 7, 4, 6, 10, "
         "5, 3, 8, 1, 9, 2, 7, 4, 6, 10]\n"
         "ys = sort(xs)\n"
-        "print(len(ys))\n"
+        "print(length(ys))\n"
         "print(ys[0])\n"
         "print(ys[49])";
     EXPECT_EQ(runSource(src), "50\n1\n10\n");

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -216,9 +216,9 @@ TEST_F(DirectiveTest, NativeFnOverloadResolution) {
         "fn range(start: int, end_val: int) -> List<int>\n"
         "@native\n"
         "fn range(start: int, end_val: int, step: int) -> List<int>\n"
-        "print(len(range(5)))\n"
-        "print(len(range(1, 4)))\n"
-        "print(len(range(0, 10, 2)))\n"
+        "print(length(range(5)))\n"
+        "print(length(range(1, 4)))\n"
+        "print(length(range(0, 10, 2)))\n"
     );
     EXPECT_EQ(output, "5\n3\n5\n");
 }

--- a/tests/test_codegen_io.cpp
+++ b/tests/test_codegen_io.cpp
@@ -133,7 +133,7 @@ match write_text(")" + path + R"(", "temp"):
 TEST_F(CodeGenTest, IOStrToBytes) {
     EXPECT_EQ(runSource(IO_DECLS + R"(
 bs = str_to_bytes("ABC")
-print(len(bs))
+print(length(bs))
 print(bs[0])
 print(bs[1])
 print(bs[2])
@@ -167,7 +167,7 @@ match write_bytes(")" + path + R"(", bs):
                 match bytes_to_str(rb):
                     case Ok(s):
                         print(s)
-                        print(len(rb))
+                        print(length(rb))
                     case Err(e):
                         print(e.message)
             case Err(e):

--- a/tests/test_codegen_iterator.cpp
+++ b/tests/test_codegen_iterator.cpp
@@ -9,7 +9,7 @@ TEST_F(CodeGenTest, IteratorBasicToList) {
         "print(ys[0])\n"
         "print(ys[1])\n"
         "print(ys[2])\n"
-        "print(len(ys))";
+        "print(length(ys))";
     EXPECT_EQ(runSource(src), "1\n2\n3\n3\n");
 }
 
@@ -17,7 +17,7 @@ TEST_F(CodeGenTest, IteratorLazyFilter) {
     std::string src =
         "xs = [1, 2, 3, 4, 5]\n"
         "ys = xs.iter().filter(fn(x: int): x > 2).to_list()\n"
-        "print(len(ys))\n"
+        "print(length(ys))\n"
         "print(ys[0])\n"
         "print(ys[1])\n"
         "print(ys[2])";
@@ -38,7 +38,7 @@ TEST_F(CodeGenTest, IteratorLazyTake) {
     std::string src =
         "xs = [1, 2, 3, 4, 5]\n"
         "ys = xs.iter().take(3).to_list()\n"
-        "print(len(ys))\n"
+        "print(length(ys))\n"
         "print(ys[0])\n"
         "print(ys[2])";
     EXPECT_EQ(runSource(src), "3\n1\n3\n");
@@ -48,7 +48,7 @@ TEST_F(CodeGenTest, IteratorChained) {
     std::string src =
         "xs = [1, 2, 3, 4, 5]\n"
         "ys = xs.iter().filter(fn(x: int): x > 2).map(fn(x: int): x * 2).take(2).to_list()\n"
-        "print(len(ys))\n"
+        "print(length(ys))\n"
         "print(ys[0])\n"
         "print(ys[1])";
     EXPECT_EQ(runSource(src), "2\n6\n8\n");
@@ -91,7 +91,7 @@ TEST_F(CodeGenTest, IteratorTakeZero) {
     std::string src =
         "xs = [1, 2, 3]\n"
         "ys = xs.iter().take(0).to_list()\n"
-        "print(len(ys))";
+        "print(length(ys))";
     EXPECT_EQ(runSource(src), "0\n");
 }
 
@@ -99,7 +99,7 @@ TEST_F(CodeGenTest, IteratorTakeMoreThanLength) {
     std::string src =
         "xs = [1, 2, 3]\n"
         "ys = xs.iter().take(10).to_list()\n"
-        "print(len(ys))";
+        "print(length(ys))";
     EXPECT_EQ(runSource(src), "3\n");
 }
 
@@ -107,7 +107,7 @@ TEST_F(CodeGenTest, IteratorSetToList) {
     std::string src =
         "s = {1, 2, 3}\n"
         "ys = s.iter().to_list()\n"
-        "print(len(ys))";
+        "print(length(ys))";
     EXPECT_EQ(runSource(src), "3\n");
 }
 
@@ -125,7 +125,7 @@ TEST_F(CodeGenTest, IteratorUFCS) {
     std::string src =
         "xs = [1, 2, 3]\n"
         "ys = iter(xs).to_list()\n"
-        "print(len(ys))\n"
+        "print(length(ys))\n"
         "print(ys[0])";
     EXPECT_EQ(runSource(src), "3\n1\n");
 }

--- a/tests/test_codegen_parameterized.cpp
+++ b/tests/test_codegen_parameterized.cpp
@@ -27,7 +27,7 @@ TEST_F(CodeGenTest, EachStringParam) {
         "describe(\"each str\", fn():\n"
         "    @each([(\"hi\", 2), (\"\", 0)])\n"
         "    it(\"len of {0} is {1}\", fn(s: str, expected: int):\n"
-        "        expect(len(s)).to_eq(expected)\n"
+        "        expect(length(s)).to_eq(expected)\n"
         "    )\n"
         ")\n"
     );

--- a/tests/test_codegen_regex.cpp
+++ b/tests/test_codegen_regex.cpp
@@ -70,7 +70,7 @@ print(s)
 TEST_F(CodeGenTest, RegexSplitBasic) {
     EXPECT_EQ(runSource(R"(
 parts = regex_split(",", "a,b,c")
-print(len(parts))
+print(length(parts))
 print(parts[0])
 print(parts[1])
 print(parts[2])
@@ -80,7 +80,7 @@ print(parts[2])
 TEST_F(CodeGenTest, RegexSplitPattern) {
     EXPECT_EQ(runSource(R"(
 parts = regex_split("\\s+", "hello  world")
-print(len(parts))
+print(length(parts))
 print(parts[0])
 print(parts[1])
 )"), "2\nhello\nworld\n");
@@ -93,7 +93,7 @@ print(parts[1])
 TEST_F(CodeGenTest, RegexFindAllBasic) {
     EXPECT_EQ(runSource(R"(
 matches = regex_find_all("[0-9]+", "a1b23c456")
-print(len(matches))
+print(length(matches))
 print(matches[0])
 print(matches[1])
 print(matches[2])
@@ -103,7 +103,7 @@ print(matches[2])
 TEST_F(CodeGenTest, RegexFindAllNoMatch) {
     EXPECT_EQ(runSource(R"(
 matches = regex_find_all("[0-9]+", "hello")
-print(len(matches))
+print(length(matches))
 )"), "0\n");
 }
 
@@ -158,7 +158,7 @@ print(s)
 TEST_F(CodeGenTest, RegexLazyFindAll) {
     EXPECT_EQ(runSource(R"(
 tags = regex_find_all("<.*?>", "<x> <yy>")
-print(len(tags))
+print(length(tags))
 print(tags[0])
 print(tags[1])
 )"), "2\n<x>\n<yy>\n");

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1050,7 +1050,7 @@ TEST_F(CodeGenTest, ForKVInMap) {
 TEST_F(CodeGenTest, RangeExpr) {
     std::string src =
         "xs = 1 .. 5\n"
-        "print(len(xs))";
+        "print(length(xs))";
     EXPECT_EQ(runSource(src), "5\n");
 }
 


### PR DESCRIPTION
## Summary

Addresses #111 — Ry naming convention review for reserved words and standard library.

- Rename built-in function `len` → `length` in codegen dispatch (`codegen_call.cpp`, `codegen_lambda.cpp`) and stdlib declarations (`builtins.ry`)
- Expand abbreviated parameter names across all `lib/std/*.ry` files:
  - `s` → `string`, `sub` → `substring`, `delim` → `delimiter`, `n` → `count`
  - `xs` → `values`, `val` → `value`, `comp` → `comparator`
  - `m` → `map`, `m1` → `first_map`, `m2` → `second_map`
  - `s` → `set`, `s1` → `first_set`, `s2` → `second_set`
  - `f` → `predicate`/`transform`/`reducer`, `x` → `value`, `bs` → `bytes`
  - Math `x`/`y` kept unchanged (domain convention)
- TCP/HTTP naming unchanged (out of scope)
- Update all spec tests, C++ tests, and docs (en/ja/zh)

## Test plan

- [x] `cmake --build build` — compiles successfully
- [x] `./build/ry_tests` — 1228 tests passed
- [x] `./build/ry test` — 24 test files, 0 failures