### PR TITLE
chore: add gmock to test dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,11 +131,13 @@ if(APPLE)
         -Wl,-force_load,$<TARGET_FILE:ry_lib>
         ry_lib
         GTest::gtest_main
+        GTest::gmock
     )
 else()
     target_link_libraries(ry_tests PRIVATE
         -Wl,--whole-archive ry_lib -Wl,--no-whole-archive
         GTest::gtest_main
+        GTest::gmock
     )
     # Linux: JIT の DynamicLibrarySearchGenerator がプロセスシンボルを参照できるようにする
     target_link_options(ry_tests PRIVATE -rdynamic)


### PR DESCRIPTION
## Summary
- `GTest::gmock` を `ry_tests` のリンクライブラリに追加（Apple / Linux 両方）
- googletest v1.17.0 に同梱の gmock がそのまま利用可能になる

## Test plan
- [x] `cmake --build build` でビルド成功を確認
- [x] `./build/ry_tests` で全 1301 テスト PASSED を確認