### PR TITLE
fix: prevent duplicate blank line before section comments in ry fmt

### DIFF
--- a/include/ry/formatter.hpp
+++ b/include/ry/formatter.hpp
@@ -39,6 +39,7 @@ private:
     void emit(const std::string &s);
     void emitIndent();
     void emitNewline();
+    bool endsWithBlankLine() const;
     void indent();
     void dedent();
 

--- a/lib/std/http/http.ry
+++ b/lib/std/http/http.ry
@@ -32,7 +32,6 @@ fn http_cookies(req: HttpRequest) -> Map<str, str>
 @native
 fn http_response(status: int, headers: Map<str, str>, body: str) -> HttpResponse
 
-
 # HTTP client operations
 @native
 fn http_get(url: str) -> Result<HttpClientResponse, Error>

--- a/lib/std/io/io.ry
+++ b/lib/std/io/io.ry
@@ -7,7 +7,6 @@ fn read_line() -> str
 @native
 fn read_all() -> str
 
-
 # File I/O
 @native
 fn read_text(path: str) -> str
@@ -29,7 +28,6 @@ fn read_bytes(path: str) -> List<byte>
 
 @native
 fn write_bytes(path: str, data: List<byte>) -> Unit
-
 
 # Byte conversions
 @native

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -83,6 +83,9 @@ void Formatter::emitIndent() {
 void Formatter::emitNewline() { out_ += '\n'; }
 void Formatter::indent() { ++indent_level_; }
 void Formatter::dedent() { --indent_level_; }
+bool Formatter::endsWithBlankLine() const {
+    return out_.size() >= 2 && out_[out_.size() - 1] == '\n' && out_[out_.size() - 2] == '\n';
+}
 
 // --- Comment emission ---
 
@@ -92,8 +95,8 @@ void Formatter::emitCommentsBefore(int line) {
         if (c.line >= line) break;
         if (c.is_inline) { ++next_comment_idx_; continue; }
 
-        // Preserve blank line before comment if there was one in source
-        if (last_emitted_line_ > 0 && c.line > last_emitted_line_ + 1) {
+        // Preserve blank line before comment if source had one and output doesn't already
+        if (last_emitted_line_ > 0 && c.line > last_emitted_line_ + 1 && !endsWithBlankLine()) {
             emitNewline();
         }
 
@@ -976,7 +979,7 @@ std::string Formatter::format(const Program &prog) {
     }
 
     // Remove trailing blank lines (keep single newline at end)
-    while (out_.size() > 1 && out_[out_.size() - 1] == '\n' && out_[out_.size() - 2] == '\n') {
+    while (endsWithBlankLine()) {
         out_.pop_back();
     }
 

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -401,3 +401,25 @@ TEST(Formatter, NativeConstMultipleDeclarations) {
     std::string src = "@native\n@const\nPI: float\n\n@native\n@const\nE: float\n";
     EXPECT_EQ(fmt(src), src);
 }
+
+// ===== Blank Line Before Section Comment After Definition =====
+
+static const char *kNativeDefWithSectionComment =
+    "@native\n"
+    "fn read_all() -> str\n"
+    "\n"
+    "# File I/O\n"
+    "@native\n"
+    "fn read_text(path: str) -> str\n";
+
+TEST(Formatter, NativeDefFollowedBySectionComment) {
+    std::string out = fmt(kNativeDefWithSectionComment);
+    EXPECT_EQ(out.find("\n\n\n"), std::string::npos) << "Found triple newline (double blank line) in:\n" << out;
+    EXPECT_NE(out.find("-> str\n\n# File I/O"), std::string::npos) << "Expected single blank line before comment in:\n" << out;
+}
+
+TEST(Formatter, NativeDefFollowedBySectionCommentIdempotent) {
+    std::string first = fmt(kNativeDefWithSectionComment);
+    std::string second = fmt(first);
+    EXPECT_EQ(first, second) << "Formatting is not idempotent:\nFirst:\n" << first << "\nSecond:\n" << second;
+}


### PR DESCRIPTION
## Summary

- `ry fmt` が定義の後にセクションコメント（例: `# File I/O`）が続く場合、コメント前に余計な空行を挿入するバグを修正
- `formatProgram` と `emitCommentsBefore` が独立に空行を出力し二重になっていた問題を、出力バッファの末尾チェックで防止
- `endsWithBlankLine()` ヘルパーを抽出し、`emitCommentsBefore` と `format()` の末尾クリーンアップで共有

## Test plan

- [x] 新規テスト2件追加（空行テスト + 冪等性テスト）
- [x] C++ テスト全1384件パス (`./build/ry_tests`)
- [x] Ry セルフテスト全27ファイル0失敗 (`./build/ry test`)
- [x] `./build/ry fmt --check lib/std/io/io.ry` がフォーマット済みで安定

Closes #157