### PR TITLE
feat: add RY_ENV environment variable and --env CLI flag

### DIFF
--- a/docs/ja/reference/packages.md
+++ b/docs/ja/reference/packages.md
@@ -125,6 +125,26 @@ from std.str import contains
 export RY_HOME="$HOME/.ry"   # デフォルト
 ```
 
+### RY_ENV
+
+`RY_ENV` 環境変数でランタイム環境モードを制御します。`--env=<value>` CLI フラグでも指定可能です。
+
+| 値 | 説明 | lib 探索 |
+|---|------|---------|
+| `production`（デフォルト） | 本番モード | `$RY_HOME/lib` → `exe/../lib` → `exe/lib` |
+| `development` | プロジェクト開発 | production と同じ（将来の拡張用） |
+| `internal` | Ry 言語自体の開発 | `exe/../lib` → `exe/lib` のみ（`$RY_HOME` スキップ） |
+
+カスタム値（`staging`、`testing` など）も設定可能で、`production` と同じ動作になります。
+
+```bash
+# 実行ファイル相対の stdlib のみ使用（Ry 言語開発用）
+RY_ENV=internal ./build/ry test
+
+# CLI フラグでも指定可能
+./build/ry --env=internal test
+```
+
 ---
 
 ## 検索パスの優先順位

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -125,6 +125,26 @@ The standard library is installed at `$RY_HOME/lib/std/`. The default value of `
 export RY_HOME="$HOME/.ry"   # default
 ```
 
+### RY_ENV
+
+The `RY_ENV` environment variable controls the runtime environment mode. You can also use the `--env=<value>` CLI flag.
+
+| Value | Description | Lib search |
+|-------|-------------|------------|
+| `production` (default) | Production mode | `$RY_HOME/lib` → `exe/../lib` → `exe/lib` |
+| `development` | Project development | Same as production (reserved for future extensions) |
+| `internal` | Ry language development | `exe/../lib` → `exe/lib` only (`$RY_HOME` skipped) |
+
+Custom values (e.g., `staging`, `testing`) are also accepted and behave like `production`.
+
+```bash
+# Use exe-relative stdlib only (for Ry language development)
+RY_ENV=internal ./build/ry test
+
+# Or use CLI flag
+./build/ry --env=internal test
+```
+
 ---
 
 ## Search Path Priority

--- a/docs/zh/reference/packages.md
+++ b/docs/zh/reference/packages.md
@@ -125,6 +125,26 @@ from std.str import contains
 export RY_HOME="$HOME/.ry"   # 預設值
 ```
 
+### RY_ENV
+
+`RY_ENV` 環境變數控制執行時環境模式。也可以使用 `--env=<value>` CLI 旗標。
+
+| 值 | 說明 | lib 搜尋 |
+|---|------|---------|
+| `production`（預設） | 正式環境模式 | `$RY_HOME/lib` → `exe/../lib` → `exe/lib` |
+| `development` | 專案開發 | 與 production 相同（保留供未來擴充） |
+| `internal` | Ry 語言本身的開發 | 僅 `exe/../lib` → `exe/lib`（跳過 `$RY_HOME`） |
+
+也接受自定義值（如 `staging`、`testing`），行為與 `production` 相同。
+
+```bash
+# 僅使用執行檔相對的 stdlib（用於 Ry 語言開發）
+RY_ENV=internal ./build/ry test
+
+# 也可以使用 CLI 旗標
+./build/ry --env=internal test
+```
+
 ---
 
 ## 搜尋路徑的優先順序

--- a/include/ry/paths.hpp
+++ b/include/ry/paths.hpp
@@ -10,7 +10,9 @@ std::filesystem::path get_ry_home();
 
 // Find the lib/ directory containing stdlib
 // Search order: $RY_HOME/lib -> exe/../lib -> exe/lib
-std::filesystem::path find_lib_dir(const std::string &exe_path);
+// When skip_global is true, $RY_HOME/lib is skipped (for RY_ENV=internal)
+std::filesystem::path find_lib_dir(const std::string &exe_path,
+                                   bool skip_global = false);
 
 struct StdlibManifest {
     std::string version;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -54,6 +54,9 @@ static void test_timeout_handler(int) {
     _exit(124);
 }
 
+// RY_ENV: skip $RY_HOME/lib when running in "internal" mode
+static bool g_skip_global_lib = false;
+
 // Coverage: accumulated filenames across multiple runRyFile calls.
 // Maps global file_id to filename for user files (excluding stdlib).
 static std::vector<std::string> g_coverage_filenames;
@@ -97,7 +100,7 @@ static int runRyFile(const std::string &filepath, bool test_mode,
 
     // Set up search paths with lib/ for stdlib
     std::vector<std::string> search_paths;
-    std::string lib_dir = ry::find_lib_dir(argv0).string();
+    std::string lib_dir = ry::find_lib_dir(argv0, g_skip_global_lib).string();
     if (!lib_dir.empty()) search_paths.push_back(lib_dir);
 
     std::string referrer_dir = fs::path(filepath).parent_path().string();
@@ -469,7 +472,28 @@ static int discoverAndRunTests(const std::string &dir, const char *argv0,
     return runTestFiles(test_files, argv0, parallel, coverage);
 }
 
+static void applyRyEnv(const char *value) {
+    setenv("RY_ENV", value, 1);
+    if (std::strcmp(value, "internal") == 0)
+        g_skip_global_lib = true;
+}
+
+static void parseRyEnv(int &argc, char **&argv) {
+    // --env=<value> CLI flag takes precedence over RY_ENV env var
+    if (argc >= 2 && std::strncmp(argv[1], "--env=", 6) == 0) {
+        applyRyEnv(argv[1] + 6);
+        // Remove --env flag from argv, preserving argv[0] (program name)
+        argv[1] = argv[0];
+        ++argv;
+        --argc;
+    } else if (const char *env = std::getenv("RY_ENV")) {
+        applyRyEnv(env);
+    }
+}
+
 int main(int argc, char *argv[]) {
+    parseRyEnv(argc, argv);
+
     if (argc == 2 && (std::strcmp(argv[1], "--version") == 0 || std::strcmp(argv[1], "-v") == 0)) {
         llvm::outs() << "ry " << RY_VERSION << "\n";
         return 0;
@@ -583,13 +607,15 @@ int main(int argc, char *argv[]) {
             return discoverAndRunTests(*root, argv[0], parallel, coverage);
         }
     } else {
-        errs() << "Usage: ry <file.ry> [args...]\n";
-        errs() << "       ry test [-p | --parallel] [-w | --watch] [--coverage | --cov] [<file.ry> | <dir>]\n";
+        errs() << "Usage: ry [--env=<env>] <file.ry> [args...]\n";
+        errs() << "       ry [--env=<env>] test [-p | --parallel] [-w | --watch] [--coverage | --cov] [<file.ry> | <dir>]\n";
         errs() << "       ry init\n";
         errs() << "       ry fmt [--check] [<file|dir>]\n";
         errs() << "       ry new <project-name>\n";
         errs() << "       ry self-update [--nightly | <version>]\n";
         errs() << "       ry --version\n";
+        errs() << "\n";
+        errs() << "Environment: RY_ENV=production|development|internal (default: production)\n";
         return 1;
     }
 

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -18,11 +18,13 @@ fs::path get_ry_home() {
     return fs::path(".ry");
 }
 
-fs::path find_lib_dir(const std::string &exe_path) {
-    // 1. $RY_HOME/lib
-    fs::path ry_home_lib = get_ry_home() / "lib";
-    if (fs::is_directory(ry_home_lib / "std")) {
-        return ry_home_lib;
+fs::path find_lib_dir(const std::string &exe_path, bool skip_global) {
+    // 1. $RY_HOME/lib (skipped when skip_global is true)
+    if (!skip_global) {
+        fs::path ry_home_lib = get_ry_home() / "lib";
+        if (fs::is_directory(ry_home_lib / "std")) {
+            return ry_home_lib;
+        }
     }
 
     // 2. exe/../lib (installed layout)

--- a/tests/test_paths.cpp
+++ b/tests/test_paths.cpp
@@ -76,6 +76,36 @@ TEST(Paths, FindLibDirNotFound) {
     EXPECT_TRUE(result.empty());
 }
 
+TEST(Paths, FindLibDirSkipGlobal) {
+    // Set up RY_HOME with a valid std/ directory
+    char home_dir[] = "/tmp/ry-home-XXXXXX";
+    ASSERT_NE(mkdtemp(home_dir), nullptr);
+    std::string home(home_dir);
+    fs::create_directories(home + "/lib/std");
+    std::ofstream(home + "/lib/std/builtins.ry") << "fn noop():\n    return\n";
+
+    // Set up exe-relative lib/ directory
+    char exe_dir[] = "/tmp/ry-exe-XXXXXX";
+    ASSERT_NE(mkdtemp(exe_dir), nullptr);
+    std::string exe(exe_dir);
+    fs::create_directories(exe + "/bin");
+    fs::create_directories(exe + "/lib/std");
+    std::ofstream(exe + "/lib/std/builtins.ry") << "fn noop():\n    return\n";
+
+    ScopedEnv guard("RY_HOME", home_dir);
+
+    // Without skip_global: should find RY_HOME/lib
+    auto result_normal = ry::find_lib_dir(exe + "/bin/ry", false);
+    EXPECT_EQ(result_normal, fs::path(home) / "lib");
+
+    // With skip_global: should skip RY_HOME/lib and find exe/../lib
+    auto result_skip = ry::find_lib_dir(exe + "/bin/ry", true);
+    EXPECT_EQ(result_skip, fs::canonical(exe + "/lib"));
+
+    fs::remove_all(home);
+    fs::remove_all(exe);
+}
+
 TEST(Paths, ManifestReadWrite) {
     char tmp_dir[] = "/tmp/ry-manifest-XXXXXX";
     ASSERT_NE(mkdtemp(tmp_dir), nullptr);


### PR DESCRIPTION
## Summary

- Add `RY_ENV` environment variable and `--env=<value>` CLI flag to control runtime environment mode
- Three standard modes: `production` (default), `development` (future extensions), `internal` (skip `$RY_HOME/lib`)
- `RY_ENV=internal` enables Ry language developers to use exe-relative stdlib only, avoiding interference from installed `~/.ry`
- Custom values (e.g., `staging`) are accepted and behave like `production`

## Test plan

- [x] `FindLibDirSkipGlobal` C++ test verifies `$RY_HOME/lib` is skipped when `skip_global=true`
- [x] All 1394 C++ tests pass
- [x] All 27 Ry self-test files pass (0 failures)
- [x] `RY_ENV=internal ./build/ry test` works correctly
- [x] `./build/ry --env=internal test` works correctly

Closes #159