### PR TITLE
fix: address re-verification issues #91, #92, #94, #130, #133

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -382,6 +382,9 @@ private:
     bool isHttpClientResponse(llvm::Value *val);
     void propagateResourceTracking(llvm::Value *src, llvm::Value *dst);
     void propagateResourceTrackingWide(llvm::Value *src, llvm::Value *dst);
+    void propagateCollectionMetadata(llvm::Value *src, llvm::Value *dst);
+    void propagateAllMetadata(llvm::Value *src, llvm::Value *dst);
+    void propagateAllMetadataWide(llvm::Value *src, llvm::Value *dst);
     void registerResourceByTypeName(const std::string &typeName, llvm::Value *val);
     llvm::Value *emitPtrToResult(llvm::Value *ptr, const std::string &name,
                                  const std::string &errMsg,

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -108,6 +108,41 @@ void CodeGen::propagateResourceTrackingWide(llvm::Value *src, llvm::Value *dst) 
     if (lookupValueSetWide(http_client_response_values_, src)) http_client_response_values_.insert(dst);
 }
 
+void CodeGen::propagateCollectionMetadata(llvm::Value *src, llvm::Value *dst) {
+    if (auto it = list_element_types_.find(src); it != list_element_types_.end())
+        list_element_types_[dst] = it->second;
+    if (auto it = nested_list_element_types_.find(src); it != nested_list_element_types_.end())
+        nested_list_element_types_[dst] = it->second;
+    if (auto it = map_key_types_.find(src); it != map_key_types_.end())
+        map_key_types_[dst] = it->second;
+    if (auto it = map_value_types_.find(src); it != map_value_types_.end())
+        map_value_types_[dst] = it->second;
+    if (auto it = set_element_types_.find(src); it != set_element_types_.end())
+        set_element_types_[dst] = it->second;
+    if (auto it = fn_type_info_.find(src); it != fn_type_info_.end())
+        fn_type_info_[dst] = it->second;
+    if (auto it = task_result_types_.find(src); it != task_result_types_.end())
+        task_result_types_[dst] = it->second;
+    if (auto it = union_value_types_.find(src); it != union_value_types_.end())
+        union_value_types_[dst] = it->second;
+    if (auto it = enum_value_types_.find(src); it != enum_value_types_.end())
+        enum_value_types_[dst] = it->second;
+    if (auto it = channel_element_types_.find(src); it != channel_element_types_.end())
+        channel_element_types_[dst] = it->second;
+    if (auto it = iterator_element_types_.find(src); it != iterator_element_types_.end())
+        iterator_element_types_[dst] = it->second;
+}
+
+void CodeGen::propagateAllMetadata(llvm::Value *src, llvm::Value *dst) {
+    propagateCollectionMetadata(src, dst);
+    propagateResourceTracking(src, dst);
+}
+
+void CodeGen::propagateAllMetadataWide(llvm::Value *src, llvm::Value *dst) {
+    propagateCollectionMetadata(src, dst);
+    propagateResourceTrackingWide(src, dst);
+}
+
 // Step 1: Hash function resolution helper
 CodeGen::HashFnInfo CodeGen::resolveHashFn(llvm::Type *keyTy) {
     if (keyTy == ptrTy_)
@@ -870,15 +905,7 @@ void CodeGen::emitStmt(std::unique_ptr<MatchStmt> &s) {
 
     // Track resource types for subject alloca.
     // Uses wide variant to resolve through Result<T, Error> struct loads.
-    propagateResourceTrackingWide(subject, subjectAlloca);
-
-    // Propagate collection metadata to subject alloca
-    if (auto it = list_element_types_.find(subject); it != list_element_types_.end())
-        list_element_types_[subjectAlloca] = it->second;
-    if (auto it = map_key_types_.find(subject); it != map_key_types_.end())
-        map_key_types_[subjectAlloca] = it->second;
-    if (auto it = map_value_types_.find(subject); it != map_value_types_.end())
-        map_value_types_[subjectAlloca] = it->second;
+    propagateAllMetadataWide(subject, subjectAlloca);
 
     for (size_t i = 0; i < s->arms.size(); ++i) {
         auto &arm = s->arms[i];
@@ -1060,13 +1087,7 @@ void CodeGen::emitStmt(std::unique_ptr<MatchStmt> &s) {
                         llvm::Value *okVal = builder_.CreateExtractValue(sv, 1, "ok_val");
                         llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, okVal->getType());
                         builder_.CreateStore(okVal, varAlloca);
-                        if (auto it = list_element_types_.find(subjectAlloca); it != list_element_types_.end())
-                            list_element_types_[varAlloca] = it->second;
-                        if (auto it = map_key_types_.find(subjectAlloca); it != map_key_types_.end())
-                            map_key_types_[varAlloca] = it->second;
-                        if (auto it = map_value_types_.find(subjectAlloca); it != map_value_types_.end())
-                            map_value_types_[varAlloca] = it->second;
-                        propagateResourceTracking(subjectAlloca, varAlloca);
+                        propagateAllMetadata(subjectAlloca, varAlloca);
                     }
                 } else if constexpr (std::is_same_v<T, ErrPattern>) {
                     if (pat.binding != "_") {
@@ -1113,14 +1134,7 @@ void CodeGen::emitStmt(std::unique_ptr<MatchStmt> &s) {
                     llvm::Value *okVal = builder_.CreateExtractValue(sv, 1, "ok_val");
                     llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, okVal->getType());
                     builder_.CreateStore(okVal, varAlloca);
-                    // Propagate collection metadata from subject to extracted ok value
-                    if (auto it = list_element_types_.find(subjectAlloca); it != list_element_types_.end())
-                        list_element_types_[varAlloca] = it->second;
-                    if (auto it = map_key_types_.find(subjectAlloca); it != map_key_types_.end())
-                        map_key_types_[varAlloca] = it->second;
-                    if (auto it = map_value_types_.find(subjectAlloca); it != map_value_types_.end())
-                        map_value_types_[varAlloca] = it->second;
-                    propagateResourceTracking(subjectAlloca, varAlloca);
+                    propagateAllMetadata(subjectAlloca, varAlloca);
                 }
             } else if constexpr (std::is_same_v<T, ErrPattern>) {
                 if (pat.binding != "_") {

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1168,22 +1168,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<TernaryExpr> &e) {
     phi->addIncoming(trueVal, trueEndBB);
     phi->addIncoming(falseVal, falseEndBB);
 
-    // Propagate semantic type metadata to the PHI result
-    if (list_element_types_.count(trueVal))
-        list_element_types_[phi] = list_element_types_[trueVal];
-    if (map_key_types_.count(trueVal)) {
-        map_key_types_[phi] = map_key_types_[trueVal];
-        map_value_types_[phi] = map_value_types_[trueVal];
-    }
-    if (set_element_types_.count(trueVal))
-        set_element_types_[phi] = set_element_types_[trueVal];
-    if (task_result_types_.count(trueVal))
-        task_result_types_[phi] = task_result_types_[trueVal];
-    if (channel_element_types_.count(trueVal))
-        channel_element_types_[phi] = channel_element_types_[trueVal];
-    if (iterator_element_types_.count(trueVal))
-        iterator_element_types_[phi] = iterator_element_types_[trueVal];
-    propagateResourceTracking(trueVal, phi);
+    propagateAllMetadata(trueVal, phi);
 
     return phi;
 }

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -1089,27 +1089,7 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
                 builder_.CreateStore(builder_.CreateLoad(capTy, fieldPtr, name + ".cap"), dst);
                 scope_stack_.back()[name] = dst;
 
-                if (auto it = list_element_types_.find(src); it != list_element_types_.end())
-                    list_element_types_[dst] = it->second;
-                if (auto it = nested_list_element_types_.find(src); it != nested_list_element_types_.end())
-                    nested_list_element_types_[dst] = it->second;
-                if (auto it = map_key_types_.find(src); it != map_key_types_.end())
-                    map_key_types_[dst] = it->second;
-                if (auto it = map_value_types_.find(src); it != map_value_types_.end())
-                    map_value_types_[dst] = it->second;
-                if (auto it = set_element_types_.find(src); it != set_element_types_.end())
-                    set_element_types_[dst] = it->second;
-                if (auto it = fn_type_info_.find(src); it != fn_type_info_.end())
-                    fn_type_info_[dst] = it->second;
-                if (auto it = task_result_types_.find(src); it != task_result_types_.end())
-                    task_result_types_[dst] = it->second;
-                if (auto it = union_value_types_.find(src); it != union_value_types_.end())
-                    union_value_types_[dst] = it->second;
-                if (auto it = enum_value_types_.find(src); it != enum_value_types_.end())
-                    enum_value_types_[dst] = it->second;
-                if (auto it = channel_element_types_.find(src); it != channel_element_types_.end())
-                    channel_element_types_[dst] = it->second;
-                propagateResourceTracking(src, dst);
+                propagateAllMetadata(src, dst);
             }
         }
 

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -248,8 +248,12 @@ extern "C" void *__ry_tcp_recv(void *stream, int64_t max_bytes) {
         header->cap = 0;
         return header;
     }
+    if (n < (ssize_t)max_bytes) {
+        if (auto *shrunk = (int8_t *)realloc(header->data, (size_t)n))
+            header->data = shrunk;
+    }
     header->len = (int64_t)n;
-    header->cap = max_bytes;
+    header->cap = (int64_t)n;
     return header;
 }
 

--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -5,30 +5,33 @@
 // UTF-8 lead byte → validated byte count (clamps to remaining bytes)
 static inline bool is_cont(unsigned char c) { return (c & 0xC0) == 0x80; }
 
-static int utf8_char_len_safe(const char *s) {
+static int utf8_char_len_safe(const char *s, size_t remaining) {
+    if (remaining == 0) return 0;
     unsigned char c = static_cast<unsigned char>(s[0]);
     if (c < 0x80) return 1;
-    if ((c & 0xE0) == 0xC0 && is_cont(s[1])) return 2;
-    if ((c & 0xF0) == 0xE0 && is_cont(s[1]) && s[2] && is_cont(s[2])) return 3;
-    if ((c & 0xF8) == 0xF0 && is_cont(s[1]) && s[2] && is_cont(s[2]) && s[3] && is_cont(s[3])) return 4;
+    if ((c & 0xE0) == 0xC0 && remaining >= 2 && is_cont(s[1])) return 2;
+    if ((c & 0xF0) == 0xE0 && remaining >= 3 && is_cont(s[1]) && is_cont(s[2])) return 3;
+    if ((c & 0xF8) == 0xF0 && remaining >= 4 && is_cont(s[1]) && is_cont(s[2]) && is_cont(s[3])) return 4;
     return 1; // invalid/truncated byte treated as 1
 }
 
 extern "C" {
 
 int64_t __ry_utf8_len(const char *s) {
+    const char *end = s + strlen(s);
     int64_t count = 0;
     while (*s) {
-        s += utf8_char_len_safe(s);
+        s += utf8_char_len_safe(s, (size_t)(end - s));
         ++count;
     }
     return count;
 }
 
 char *__ry_utf8_char_at(const char *s, int64_t i) {
+    const char *end = s + strlen(s);
     const char *p = s;
     for (int64_t idx = 0; *p; ++idx) {
-        int len = utf8_char_len_safe(p);
+        int len = utf8_char_len_safe(p, (size_t)(end - p));
         if (idx == i) {
             char *buf = static_cast<char *>(malloc(len + 1));
             memcpy(buf, p, len);
@@ -43,7 +46,8 @@ char *__ry_utf8_char_at(const char *s, int64_t i) {
     return buf;
 }
 
-char *__ry_utf8_substring(const char *s, int64_t start, int64_t end) {
+char *__ry_utf8_substring(const char *s, int64_t start, int64_t endIdx) {
+    const char *strEnd = s + strlen(s);
     const char *p = s;
     const char *startPtr = nullptr;
     const char *endPtr = nullptr;
@@ -51,8 +55,8 @@ char *__ry_utf8_substring(const char *s, int64_t start, int64_t end) {
 
     while (*p) {
         if (idx == start) startPtr = p;
-        if (idx == end) { endPtr = p; break; }
-        p += utf8_char_len_safe(p);
+        if (idx == endIdx) { endPtr = p; break; }
+        p += utf8_char_len_safe(p, (size_t)(strEnd - p));
         ++idx;
     }
     if (idx == start) startPtr = p;
@@ -77,13 +81,14 @@ char *__ry_utf8_reverse(const char *s) {
     size_t count = 0;
     CPInfo *cps = static_cast<CPInfo *>(malloc(capacity * sizeof(CPInfo)));
 
+    const char *end = s + totalBytes;
     const char *p = s;
     while (*p) {
         if (count == capacity) {
             capacity *= 2;
             cps = static_cast<CPInfo *>(realloc(cps, capacity * sizeof(CPInfo)));
         }
-        int len = utf8_char_len_safe(p);
+        int len = utf8_char_len_safe(p, (size_t)(end - p));
         cps[count++] = {p, len};
         p += len;
     }
@@ -101,11 +106,12 @@ char *__ry_utf8_reverse(const char *s) {
 }
 
 int64_t __ry_utf8_char_index(const char *s, int64_t byte_offset) {
+    const char *end = s + strlen(s);
     const char *p = s;
     int64_t charIdx = 0;
     int64_t byteIdx = 0;
     while (*p && byteIdx < byte_offset) {
-        p += utf8_char_len_safe(p);
+        p += utf8_char_len_safe(p, (size_t)(end - p));
         byteIdx = p - s;
         ++charIdx;
     }

--- a/tests/spec/parameterized.test.ry
+++ b/tests/spec/parameterized.test.ry
@@ -22,4 +22,8 @@ describe("@property tests", fn():
   it("bool identity", fn(x: bool):
     expect(x == x).to_be_true()
   )
+  @property(count=20)
+  it("str length is non-negative", fn(s: str):
+    expect(length(s) >= 0).to_be_true()
+  )
 )

--- a/tests/test_codegen_net.cpp
+++ b/tests/test_codegen_net.cpp
@@ -36,7 +36,7 @@ fn set_send_timeout(stream: TcpStream, ms: int) -> Unit
 
 TEST_F(CodeGenTest, NetBindReturnsResult) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-match bind("127.0.0.1", 18080):
+match bind("127.0.0.1", 0):
     case Ok(server):
         print("ok")
         close(server)
@@ -66,7 +66,7 @@ match connect("127.0.0.1", 19999):
 
 TEST_F(CodeGenTest, NetListenReturnsResult) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-match bind("127.0.0.1", 18082):
+match bind("127.0.0.1", 0):
     case Ok(server):
         match listen(server, 1):
             case Ok(_):

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -724,6 +724,7 @@ struct JoinGuard {
 TEST(RuntimeHttpClient, HttpGetBasic) {
     std::string response = "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nX-Custom: test-value\r\n\r\nhello";
     int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
     int port = get_server_port(srv);
 
     std::thread server_thread([&]() {
@@ -749,6 +750,7 @@ TEST(RuntimeHttpClient, HttpGetBasic) {
 TEST(RuntimeHttpClient, HttpPostWithBody) {
     std::string response = "HTTP/1.1 201 Created\r\nContent-Length: 2\r\n\r\nok";
     int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
     int port = get_server_port(srv);
 
     std::string captured_request;
@@ -782,6 +784,7 @@ TEST(RuntimeHttpClient, HttpGetConnectionRefused) {
 TEST(RuntimeHttpClient, HttpGetNoContentLength) {
     std::string response = "HTTP/1.1 200 OK\r\nConnection: close\r\n\r\nno content length body";
     int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
     int port = get_server_port(srv);
 
     std::thread server_thread([&]() {
@@ -805,6 +808,7 @@ TEST(RuntimeHttpClient, HttpGetNoContentLength) {
 TEST(RuntimeHttpClient, HttpRequestCustomMethod) {
     std::string response = "HTTP/1.1 204 No Content\r\nContent-Length: 0\r\n\r\n";
     int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
     int port = get_server_port(srv);
 
     std::string captured_request;
@@ -831,6 +835,7 @@ TEST(RuntimeHttpClient, HttpRequestCustomMethod) {
 TEST(RuntimeHttpClient, HttpClientHeaderCaseInsensitive) {
     std::string response = "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nContent-Length: 2\r\n\r\n{}";
     int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
     int port = get_server_port(srv);
 
     std::thread server_thread([&]() {
@@ -1226,6 +1231,7 @@ TEST(RuntimeHttpClient, ChunkedClientResponse) {
         "6\r\n world\r\n"
         "0\r\n\r\n";
     int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
     int port = get_server_port(srv);
 
     std::thread server_thread([&]() {
@@ -1256,6 +1262,7 @@ TEST(RuntimeHttpClient, ChunkedClientResponseMultipleChunks) {
         "e\r\n in\r\n\r\nchunks.\r\n"
         "0\r\n\r\n";
     int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
     int port = get_server_port(srv);
 
     std::thread server_thread([&]() {


### PR DESCRIPTION
## Summary

再検証で未完了と判定された5件のissueをまとめて修正。

- **#91**: `utf8_char_len_safe()` に `remaining` パラメータを追加し、非null終端バッファでのバッファ外アクセスを防止
- **#92**: `@property` テストに `str` パラメータを追加し、codegen の free パスが正しく動作することを検証
- **#94**: `__ry_tcp_recv` で recv 後にバッファを実受信サイズに縮小（`realloc` + NULL安全ガード）
- **#130**: `propagateCollectionMetadata()` / `propagateAllMetadata()` / `propagateAllMetadataWide()` ヘルパーを抽出し、5箇所の型追跡伝播の重複コードを統合
- **#133**: HTTP client テスト7件に `GTEST_SKIP` ガードを追加、codegen net テストのハードコードポートを動的ポート割当に変更

## Test plan

- [x] `./build/ry_tests` — 1434 tests passed
- [x] `./build/ry test` — 30 files, 29 passed (1 pre-existing failure in net.test.ry)
- [x] `/simplify` code review applied — realloc NULL check, utf8 remaining==0 return value fix, propagateAllMetadata combined helpers