### PR TITLE
build: switch from Make to Ninja for faster parallel builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 21
-          sudo apt-get install -y libllvm21 llvm-21-dev libssl-dev
+          sudo apt-get install -y libllvm21 llvm-21-dev libssl-dev ninja-build
       - name: Build
         run: |
-          cmake -B build -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm
+          cmake -B build -G Ninja -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm
           cmake --build build
       - name: Test (C++)
         run: ./build/ry_tests

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -20,13 +20,13 @@ jobs:
           fi
       - uses: actions/checkout@v4
       - name: Install LLVM 21 and OpenSSL
-        run: brew install llvm@21 openssl@3
+        run: brew install llvm@21 openssl@3 ninja
       - name: Set version
         id: version
         run: echo "version=${GITHUB_REF_NAME}-nightly" >> "$GITHUB_OUTPUT"
       - name: Build
         run: |
-          cmake -B build \
+          cmake -B build -G Ninja \
             -DLLVM_DIR="$(brew --prefix llvm@21)/lib/cmake/llvm" \
             -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
             -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install LLVM 21 and OpenSSL
         run: |
-          brew install llvm@21 openssl@3
+          brew install llvm@21 openssl@3 ninja
       - name: Read version
         id: version
         run: echo "version=v$(cat VERSION | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
@@ -30,7 +30,7 @@ jobs:
       - name: Build
         if: env.SKIP != 'true'
         run: |
-          cmake -B build \
+          cmake -B build -G Ninja \
             -DLLVM_DIR="$(brew --prefix llvm@21)/lib/cmake/llvm" \
             -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
             -DCMAKE_BUILD_TYPE=Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,8 +3,8 @@
 ## ビルド & テスト
 
 ```bash
-cmake -B build -DLLVM_DIR=/usr/local/llvm/lib/cmake/llvm
-cmake --build build
+cmake --preset default                                  # Ninja + LLVM（CMakePresets.json）
+cmake --build build                                     # Ninja が自動並列ビルド
 ./build/ry_tests                                        # C++ テスト (GoogleTest)
 RY_ENV=internal ./build/ry test                         # Ry セルフテスト (全 *.test.ry)
 RY_ENV=internal ./build/ry test tests/spec/<file>.test.ry # 個別ファイル実行
@@ -173,7 +173,7 @@ static const StdlibDispatcher stdlib_dispatchers[] = {
 全テストを実行して成功を確認する。
 
 ```bash
-cmake -B build -DLLVM_DIR=/usr/local/llvm/lib/cmake/llvm && cmake --build build && ./build/ry_tests && RY_ENV=internal ./build/ry test
+cmake --preset default && cmake --build build && ./build/ry_tests && RY_ENV=internal ./build/ry test
 ```
 
 テストが失敗した場合は、原因を修正してから作業完了とすること。

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,31 @@
+{
+  "version": 6,
+  "configurePresets": [
+    {
+      "name": "default",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build",
+      "cacheVariables": {
+        "LLVM_DIR": "/usr/local/llvm/lib/cmake/llvm",
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "debug",
+      "inherits": "default",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `CMakePresets.json` with Ninja generator as default (`cmake --preset default`)
- Update CI workflows (`ci.yml`, `dev-release.yml`, `release.yml`) to install and use Ninja
- Update `CLAUDE.md` build commands to use preset-based configuration

Ninja automatically parallelizes builds based on CPU core count, requiring no `-j` flag.

## Test plan
- [x] Local build with `cmake --preset default && cmake --build build` succeeds
- [x] C++ tests pass (926 tests)
- [x] Ry self tests pass (35 test files, 0 failures)
- [ ] CI workflow runs successfully with Ninja on Ubuntu
- [ ] Release/dev-release workflows run successfully with Ninja on macOS