### PR TITLE
ci: cache LLVM 21 binaries to speed up CI builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cache LLVM 21
+        id: cache-llvm
+        uses: actions/cache@v4
+        with:
+          path: /usr/lib/llvm-21
+          key: llvm-21-ubuntu-${{ runner.os }}
       - name: Install LLVM 21
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 21
-          sudo apt-get install -y libllvm21 llvm-21-dev libssl-dev ninja-build libgtest-dev libgmock-dev
+          sudo apt-get install -y libllvm21 llvm-21-dev
+      - name: Install dependencies
+        run: sudo apt-get install -y libssl-dev ninja-build libgtest-dev libgmock-dev
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -19,8 +19,19 @@ jobs:
             exit 1
           fi
       - uses: actions/checkout@v4
-      - name: Install LLVM 21 and OpenSSL
-        run: brew install llvm@21 openssl@3 ninja googletest
+      - name: Cache LLVM 21
+        id: cache-llvm
+        uses: actions/cache@v4
+        with:
+          path: |
+            /opt/homebrew/opt/llvm@21
+            /opt/homebrew/Cellar/llvm@21
+          key: llvm-21-macos-arm64
+      - name: Install LLVM 21
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: brew install llvm@21
+      - name: Install dependencies
+        run: brew install openssl@3 ninja googletest
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,19 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - name: Install LLVM 21 and OpenSSL
-        run: |
-          brew install llvm@21 openssl@3 ninja googletest
+      - name: Cache LLVM 21
+        id: cache-llvm
+        uses: actions/cache@v4
+        with:
+          path: |
+            /opt/homebrew/opt/llvm@21
+            /opt/homebrew/Cellar/llvm@21
+          key: llvm-21-macos-arm64
+      - name: Install LLVM 21
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: brew install llvm@21
+      - name: Install dependencies
+        run: brew install openssl@3 ninja googletest
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:


### PR DESCRIPTION
## Summary

- CI/Dev Release/Release の全ワークフローで `actions/cache@v4` を使い LLVM 21 のインストールディレクトリをキャッシュ
- キャッシュヒット時は LLVM インストールをスキップし、ビルド時間を短縮
- 軽量な依存（openssl, ninja, googletest, libssl-dev 等）は毎回インストール

## Test plan

- [ ] CI ワークフローが正常に通ることを確認（初回はキャッシュミス）
- [ ] 2回目以降のCIでキャッシュヒットによりLLVMインストールがスキップされることを確認