### PR TITLE
refactor: reduce union unwrap alloca to data-only allocation

### DIFF
--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -651,10 +651,12 @@ void CodeGen::emitPrint(const std::vector<ExprPtr> &args) {
             auto &info = union_type_info_[unionName];
             llvm::Value *tag = builder_.CreateExtractValue(val, 0, "union.tag");
 
-            // Store the union value in memory so we can extract data via GEP
-            llvm::AllocaInst *unionTmp = builder_.CreateAlloca(info.llvmType, nullptr, "union.print.tmp");
-            builder_.CreateStore(val, unionTmp);
-            auto *dataPtr = builder_.CreateStructGEP(info.llvmType, unionTmp, 1, "union.data.ptr");
+            // Alloca only the data part (not the full union struct) for type punning
+            llvm::Value *dataBytes = builder_.CreateExtractValue(val, 1, "union.data");
+            auto *dataTy = info.llvmType->getElementType(1);
+            llvm::AllocaInst *dataTmp = builder_.CreateAlloca(dataTy, nullptr, "union.data.tmp");
+            dataTmp->setAlignment(mod_->getDataLayout().getABITypeAlign(info.llvmType));
+            builder_.CreateStore(dataBytes, dataTmp);
 
             llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "union.print.end", fn_);
             llvm::SwitchInst *sw = builder_.CreateSwitch(tag, endBB, info.componentTypes.size());
@@ -666,7 +668,7 @@ void CodeGen::emitPrint(const std::vector<ExprPtr> &args) {
                 builder_.SetInsertPoint(caseBB);
 
                 llvm::Value *innerVal = builder_.CreateLoad(
-                    info.componentTypes[i], dataPtr, "union.inner");
+                    info.componentTypes[i], dataTmp, "union.inner");
 
                 emitPrintValue(innerVal, info.componentTypes[i], printfFn, "_union" + std::to_string(i));
 


### PR DESCRIPTION
## Summary

- Union print の unwrap 処理で、full struct alloca (`{ i64, [N x i8] }`) を data-only alloca (`[N x i8]`) に置き換え
- `ExtractValue` で data bytes を取り出し、`StructGEP` を排除
- 明示的なアライメント設定により型安全な type-punning を保証

## Test plan

- [x] C++ テスト 926 tests PASSED
- [x] Ry セルフテスト 35 files, 0 failures

Closes #230