### PR TITLE
fix: use dynamic ports in HTTP tests to eliminate parallel flakiness

### DIFF
--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -26,6 +26,7 @@ from http import http_listen, http_method, http_path, http_header, http_body, ht
 |----------|-----------|-------------|
 | `http_listen` | `(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse) -> Unit` | Starts an HTTP server on the given address. Blocks in an accept loop, calling `handler` for each request. |
 | `http_listen` | `(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse, max_requests: int) -> Unit` | Starts an HTTP server that stops after processing `max_requests` requests. Enables `spawn` + `join` lifecycle management. |
+| `http_listen` | `(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse, max_requests: int, port_channel: Channel<int>) -> Unit` | Same as above, but sends the actual bound port to `port_channel` after `bind` + `listen` succeeds. Use with port `0` for OS-assigned ephemeral ports. |
 
 ### Request Accessors
 
@@ -91,19 +92,17 @@ t: Task<str> = spawn start_server(8080)
 ```python
 from http import http_listen, http_path, http_response, http_get, http_client_status, http_client_body
 
-fn start_server(ready: Channel<int>) -> str:
-    send(ready, 1)
-    http_listen("127.0.0.1", 8080, fn(req: HttpRequest) -> HttpResponse:
+fn start_server(port_ch: Channel<int>) -> str:
+    http_listen("127.0.0.1", 0, fn(req: HttpRequest) -> HttpResponse:
         return http_response(200, {"Content-Type": "text/plain"}, "Hello!")
-    , 1)  # Stop after 1 request
+    , 1, port_ch)  # Stop after 1 request; send bound port to channel
     return "done"
 
-ready: Channel<int> = channel[int]()
-t: Task<str> = spawn start_server(ready)
-recv(ready)
-sleep(100)
+port_ch: Channel<int> = channel[int]()
+t: Task<str> = spawn start_server(port_ch)
+port = recv(port_ch)  # Blocks until server is ready
 
-match http_get("http://127.0.0.1:8080/"):
+match http_get("http://127.0.0.1:" + to_str(port) + "/"):
     case Ok(resp):
         print(http_client_body(resp))  # "Hello!"
     case Err(e):
@@ -181,6 +180,7 @@ http_listen("127.0.0.1", 8080, fn(req: HttpRequest) -> HttpResponse:
 - `http_listen()` binds to the address, starts listening, and enters an accept loop.
 - When called with 3 arguments, the accept loop runs indefinitely.
 - When called with 4 arguments (`max_requests`), the server stops after processing the specified number of requests. `max_requests` must be a positive integer. This enables `spawn` + `join` lifecycle management. Malformed requests (silently skipped) do not count toward the limit.
+- When called with 5 arguments (`max_requests`, `port_channel`), the actual bound port is sent to the channel after `bind` + `listen` succeeds. This eliminates the need for `sleep()` after `send(ready, 1)` and allows safe use of port `0` (OS-assigned ephemeral port) to avoid port conflicts in parallel tests.
 - Each accepted connection reads one HTTP/1.1 request, calls the handler, sends the response, and closes the connection.
 - `Content-Length` is automatically added to the response if not provided in the headers map.
 - The server supports HTTP/1.1 with `Content-Length`-based body reading and `Transfer-Encoding: chunked` decoding.

--- a/lib/std/http/http.ry
+++ b/lib/std/http/http.ry
@@ -6,6 +6,9 @@ fn http_listen(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse) -
 fn http_listen(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse, max_requests: int) -> Unit
 
 @native
+fn http_listen(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse, max_requests: int, port_channel: Channel<int>) -> Unit
+
+@native
 fn http_method(req: HttpRequest) -> str
 
 @native

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -409,10 +409,10 @@ llvm::Value *CodeGen::emitBuiltinHttp(const CallExpr &e) {
         return result;
     }
 
-    // http_listen(host, port, handler[, max_requests]) -> Unit
+    // http_listen(host, port, handler[, max_requests[, port_channel]]) -> Unit
     if (e.callee == "http_listen") {
-        if (e.args.size() < 3 || e.args.size() > 4)
-            codegenError("http_listen() takes 3 or 4 arguments");
+        if (e.args.size() < 3 || e.args.size() > 5)
+            codegenError("http_listen() takes 3 to 5 arguments");
         llvm::Value *host = emitExpr(*e.args[0]);
         llvm::Value *port = emitExpr(*e.args[1]);
         llvm::Value *handler = emitExpr(*e.args[2]);
@@ -452,7 +452,7 @@ llvm::Value *CodeGen::emitBuiltinHttp(const CallExpr &e) {
 
         // Optional 4th argument: max_requests (must be > 0)
         llvm::Value *maxReqs = llvm::ConstantInt::get(i64Ty_, 0);
-        if (e.args.size() == 4) {
+        if (e.args.size() >= 4) {
             maxReqs = emitExpr(*e.args[3]);
             if (maxReqs->getType() != i64Ty_)
                 codegenError("http_listen() max_requests must be int");
@@ -460,6 +460,15 @@ llvm::Value *CodeGen::emitBuiltinHttp(const CallExpr &e) {
                 if (maxConst->getSExtValue() <= 0)
                     codegenError("http_listen() max_requests must be a positive integer");
             }
+        }
+
+        // Optional 5th argument: port_channel (Channel<int>)
+        llvm::Value *portChannel = nullptr;
+        if (e.args.size() == 5) {
+            portChannel = emitExpr(*e.args[4]);
+            llvm::Type *elemTy = getChannelElementType(portChannel);
+            if (!elemTy || elemTy != i64Ty_)
+                codegenError("http_listen() port_channel must be Channel<int>");
         }
 
         // 1. bind(host, port)
@@ -496,9 +505,26 @@ llvm::Value *CodeGen::emitBuiltinHttp(const CallExpr &e) {
                           ".http_listen_err_" + std::to_string(httpListenErrCounter++));
         builder_.SetInsertPoint(listenOkBB);
 
-        bool hasLimit = (e.args.size() == 4);
+        // If port_channel provided, send the actual bound port after bind+listen
+        if (portChannel) {
+            auto portFnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
+            auto portFn = mod_->getOrInsertFunction("__ry_listener_port", portFnTy);
+            llvm::Value *actualPort = builder_.CreateCall(portFn, {listener}, "actual_port");
+
+            llvm::IRBuilder<> entryBuilder(&fn_->getEntryBlock(),
+                                            fn_->getEntryBlock().begin());
+            llvm::AllocaInst *portSlot = entryBuilder.CreateAlloca(i64Ty_, nullptr, "port_slot");
+            builder_.CreateStore(actualPort, portSlot);
+
+            auto chanSendFnTy = llvm::FunctionType::get(
+                llvm::Type::getVoidTy(*ctx_), {ptrTy_, ptrTy_}, false);
+            auto chanSendFn = mod_->getOrInsertFunction("__ry_channel_send", chanSendFnTy);
+            builder_.CreateCall(chanSendFn, {portChannel, portSlot});
+        }
+
+        bool hasMaxRequests = (e.args.size() >= 4);
         llvm::Value *counterAlloca = nullptr;
-        if (hasLimit) {
+        if (hasMaxRequests) {
             counterAlloca = builder_.CreateAlloca(i64Ty_, nullptr, "req_counter");
             builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), counterAlloca);
         }
@@ -564,7 +590,7 @@ llvm::Value *CodeGen::emitBuiltinHttp(const CallExpr &e) {
         builder_.CreateCall(freeRespFn, {resp});
         builder_.CreateCall(closeFn, {conn});
 
-        if (hasLimit) {
+        if (hasMaxRequests) {
             llvm::Value *oldCount = builder_.CreateLoad(i64Ty_, counterAlloca, "old_count");
             llvm::Value *newCount = builder_.CreateAdd(oldCount,
                 llvm::ConstantInt::get(i64Ty_, 1), "new_count");

--- a/tests/spec/http_form.test.ry
+++ b/tests/spec/http_form.test.ry
@@ -2,27 +2,26 @@ from http import http_listen, http_form_field, http_form_file, http_form_fields,
 
 describe("http_form_field", fn():
   it("parses text fields from multipart/form-data", fn():
-    fn server(ready: Channel<int>) -> str:
-      send(ready, 1)
-      http_listen("127.0.0.1", 18960, fn(req: HttpRequest) -> HttpResponse:
+    fn server(port_ch: Channel<int>) -> str:
+      http_listen("127.0.0.1", 0, fn(req: HttpRequest) -> HttpResponse:
         username = http_form_field(req, "username")
         match username:
           case Some(val):
             return http_response(200, {"Content-Type": "text/plain"}, val)
           case None:
             return http_response(400, {"Content-Type": "text/plain"}, "missing")
-      , 1)
+      , 1, port_ch)
       return "done"
 
-    ready: Channel<int> = channel[int]()
-    t: Task<str> = spawn server(ready)
-    recv(ready)
-    sleep(100)
+    port_ch: Channel<int> = channel[int]()
+    t: Task<str> = spawn server(port_ch)
+    port = recv(port_ch)
 
     body = "--boundary\r\nContent-Disposition: form-data; name=\"username\"\r\n\r\nalice\r\n--boundary--\r\n"
     headers = {"Content-Type": "multipart/form-data; boundary=boundary"}
 
-    match http_request("POST", "http://127.0.0.1:18960/submit", headers, body):
+    url = "http://127.0.0.1:" + to_str(port) + "/submit"
+    match http_request("POST", url, headers, body):
       case Ok(resp):
         expect(http_client_status(resp)).to_eq(200)
         expect(http_client_body(resp)).to_eq("alice")
@@ -36,25 +35,24 @@ describe("http_form_field", fn():
 
 describe("http_form_fields", fn():
   it("returns all text fields as a map", fn():
-    fn server_fields(ready: Channel<int>) -> str:
-      send(ready, 1)
-      http_listen("127.0.0.1", 18961, fn(req: HttpRequest) -> HttpResponse:
+    fn server_fields(port_ch: Channel<int>) -> str:
+      http_listen("127.0.0.1", 0, fn(req: HttpRequest) -> HttpResponse:
         fields = http_form_fields(req)
         a = fields["a"]
         b = fields["b"]
         return http_response(200, {"Content-Type": "text/plain"}, a + "," + b)
-      , 1)
+      , 1, port_ch)
       return "done"
 
-    ready: Channel<int> = channel[int]()
-    t: Task<str> = spawn server_fields(ready)
-    recv(ready)
-    sleep(100)
+    port_ch: Channel<int> = channel[int]()
+    t: Task<str> = spawn server_fields(port_ch)
+    port = recv(port_ch)
 
     body = "--bnd\r\nContent-Disposition: form-data; name=\"a\"\r\n\r\n1\r\n--bnd\r\nContent-Disposition: form-data; name=\"b\"\r\n\r\n2\r\n--bnd--\r\n"
     headers = {"Content-Type": "multipart/form-data; boundary=bnd"}
 
-    match http_request("POST", "http://127.0.0.1:18961/form", headers, body):
+    url = "http://127.0.0.1:" + to_str(port) + "/form"
+    match http_request("POST", url, headers, body):
       case Ok(resp):
         expect(http_client_status(resp)).to_eq(200)
         expect(http_client_body(resp)).to_eq("1,2")
@@ -68,27 +66,26 @@ describe("http_form_fields", fn():
 
 describe("http_form_file", fn():
   it("returns Some with file info for uploaded file", fn():
-    fn server_file(ready: Channel<int>) -> str:
-      send(ready, 1)
-      http_listen("127.0.0.1", 18962, fn(req: HttpRequest) -> HttpResponse:
+    fn server_file(port_ch: Channel<int>) -> str:
+      http_listen("127.0.0.1", 0, fn(req: HttpRequest) -> HttpResponse:
         file = http_form_file(req, "avatar")
         match file:
           case Some(info):
             return http_response(200, {"Content-Type": "text/plain"}, info["filename"])
           case None:
             return http_response(404, {"Content-Type": "text/plain"}, "not found")
-      , 1)
+      , 1, port_ch)
       return "done"
 
-    ready: Channel<int> = channel[int]()
-    t: Task<str> = spawn server_file(ready)
-    recv(ready)
-    sleep(100)
+    port_ch: Channel<int> = channel[int]()
+    t: Task<str> = spawn server_file(port_ch)
+    port = recv(port_ch)
 
     body = "--fbnd\r\nContent-Disposition: form-data; name=\"avatar\"; filename=\"photo.png\"\r\nContent-Type: image/png\r\n\r\nFAKE\r\n--fbnd--\r\n"
     headers = {"Content-Type": "multipart/form-data; boundary=fbnd"}
 
-    match http_request("POST", "http://127.0.0.1:18962/upload", headers, body):
+    url = "http://127.0.0.1:" + to_str(port) + "/upload"
+    match http_request("POST", url, headers, body):
       case Ok(resp):
         expect(http_client_status(resp)).to_eq(200)
         expect(http_client_body(resp)).to_eq("photo.png")
@@ -100,27 +97,26 @@ describe("http_form_file", fn():
   )
 
   it("returns None for missing file", fn():
-    fn server_no_file(ready: Channel<int>) -> str:
-      send(ready, 1)
-      http_listen("127.0.0.1", 18963, fn(req: HttpRequest) -> HttpResponse:
+    fn server_no_file(port_ch: Channel<int>) -> str:
+      http_listen("127.0.0.1", 0, fn(req: HttpRequest) -> HttpResponse:
         file = http_form_file(req, "missing")
         match file:
           case Some(info):
             return http_response(200, {"Content-Type": "text/plain"}, "found")
           case None:
             return http_response(404, {"Content-Type": "text/plain"}, "none")
-      , 1)
+      , 1, port_ch)
       return "done"
 
-    ready: Channel<int> = channel[int]()
-    t: Task<str> = spawn server_no_file(ready)
-    recv(ready)
-    sleep(100)
+    port_ch: Channel<int> = channel[int]()
+    t: Task<str> = spawn server_no_file(port_ch)
+    port = recv(port_ch)
 
     body = "--nbnd\r\nContent-Disposition: form-data; name=\"title\"\r\n\r\nhello\r\n--nbnd--\r\n"
     headers = {"Content-Type": "multipart/form-data; boundary=nbnd"}
 
-    match http_request("POST", "http://127.0.0.1:18963/upload", headers, body):
+    url = "http://127.0.0.1:" + to_str(port) + "/upload"
+    match http_request("POST", url, headers, body):
       case Ok(resp):
         expect(http_client_status(resp)).to_eq(404)
         expect(http_client_body(resp)).to_eq("none")

--- a/tests/spec/http_listen.test.ry
+++ b/tests/spec/http_listen.test.ry
@@ -2,18 +2,17 @@ from http import http_listen, http_path, http_response, http_get, http_client_st
 
 describe("http_listen with max_requests", fn():
   it("stops after 1 request with max_requests=1", fn():
-    fn server(ready: Channel<int>) -> str:
-      send(ready, 1)
-      http_listen("127.0.0.1", 18940, fn(req: HttpRequest) -> HttpResponse:
+    fn server(port_ch: Channel<int>) -> str:
+      http_listen("127.0.0.1", 0, fn(req: HttpRequest) -> HttpResponse:
         return http_response(200, {"Content-Type": "text/plain"}, "hello")
-      , 1)
+      , 1, port_ch)
       return "done"
 
-    ready: Channel<int> = channel[int]()
-    t: Task<str> = spawn server(ready)
-    recv(ready)
-    sleep(100)
-    match http_get("http://127.0.0.1:18940/test"):
+    port_ch: Channel<int> = channel[int]()
+    t: Task<str> = spawn server(port_ch)
+    port = recv(port_ch)
+    url = "http://127.0.0.1:" + to_str(port) + "/test"
+    match http_get(url):
       case Ok(resp):
         expect(http_client_status(resp)).to_eq(200)
         expect(http_client_body(resp)).to_eq("hello")
@@ -25,20 +24,19 @@ describe("http_listen with max_requests", fn():
   )
 
   it("stops after 2 requests with max_requests=2", fn():
-    fn server2(ready: Channel<int>) -> str:
-      send(ready, 1)
-      http_listen("127.0.0.1", 18941, fn(req: HttpRequest) -> HttpResponse:
+    fn server2(port_ch: Channel<int>) -> str:
+      http_listen("127.0.0.1", 0, fn(req: HttpRequest) -> HttpResponse:
         path = http_path(req)
         return http_response(200, {"Content-Type": "text/plain"}, path)
-      , 2)
+      , 2, port_ch)
       return "done"
 
-    ready: Channel<int> = channel[int]()
-    t: Task<str> = spawn server2(ready)
-    recv(ready)
-    sleep(100)
+    port_ch: Channel<int> = channel[int]()
+    t: Task<str> = spawn server2(port_ch)
+    port = recv(port_ch)
 
-    match http_get("http://127.0.0.1:18941/first"):
+    url1 = "http://127.0.0.1:" + to_str(port) + "/first"
+    match http_get(url1):
       case Ok(resp):
         expect(http_client_status(resp)).to_eq(200)
         expect(http_client_body(resp)).to_eq("/first")
@@ -46,7 +44,8 @@ describe("http_listen with max_requests", fn():
       case Err(e):
         fail("unexpected error")
 
-    match http_get("http://127.0.0.1:18941/second"):
+    url2 = "http://127.0.0.1:" + to_str(port) + "/second"
+    match http_get(url2):
       case Ok(resp):
         expect(http_client_status(resp)).to_eq(200)
         expect(http_client_body(resp)).to_eq("/second")


### PR DESCRIPTION
## Summary

- Add 5-arg `http_listen(host, port, handler, max_requests, port_channel)` overload that sends the actual bound port to a channel after `bind` + `listen` succeeds
- Migrate `http_listen.test.ry` and `http_form.test.ry` from fixed ports (18940-18963) with `sleep(100)` to dynamic ports (port 0) with `port_channel`
- Update `docs/reference/http.md` with new overload documentation and updated examples

## Test plan

- [x] C++ tests pass (955 tests)
- [x] Ry self-tests pass (37 files, 0 failures)
- [x] Parallel execution (`ry test -p`) passes 3 consecutive runs with no flakiness (1.2s, 8 workers)

Closes #273