### PR TITLE
refactor: extract ZExt coercion into coerceHashKey helper

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -374,6 +374,8 @@ private:
         llvm::Type *hashArgTy;
     };
     HashFnInfo resolveHashFn(llvm::Type *keyTy);
+    llvm::Value *coerceHashKey(llvm::Value *key, llvm::Type *keyTy,
+                               llvm::Type *hashArgTy, const llvm::Twine &prefix);
 
     // Collection type lookup helper (Step 2)
     static llvm::Type *lookupCollectionType(

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -155,6 +155,13 @@ CodeGen::HashFnInfo CodeGen::resolveHashFn(llvm::Type *keyTy) {
     return {"__ry_hash_i64", "__ry_ht_rehash_i64", i64Ty_};
 }
 
+llvm::Value *CodeGen::coerceHashKey(llvm::Value *key, llvm::Type *keyTy,
+                                     llvm::Type *hashArgTy, const llvm::Twine &prefix) {
+    if (keyTy != hashArgTy && keyTy->isIntegerTy() && hashArgTy->isIntegerTy())
+        return builder_.CreateZExt(key, hashArgTy, prefix + "_hash_zext");
+    return key;
+}
+
 // Step 3: Unified hash table lookup
 llvm::Value *CodeGen::emitHashTableLookup(llvm::Value *containerPtr, llvm::StructType *headerTy,
                                             const HashTableLayout &layout,
@@ -230,9 +237,7 @@ void CodeGen::emitBucketInsertAndRehashCheck(llvm::Value *headerPtr, llvm::Struc
     auto hfi = resolveHashFn(keyTy);
 
     // Coerce key to match hash function argument type (e.g. i1 → i64)
-    llvm::Value *hashKey = key;
-    if (keyTy != hfi.hashArgTy && keyTy->isIntegerTy() && hfi.hashArgTy->isIntegerTy())
-        hashKey = builder_.CreateZExt(key, hfi.hashArgTy, "hash_key_zext");
+    llvm::Value *hashKey = coerceHashKey(key, keyTy, hfi.hashArgTy, "hash_key");
 
     // Compute hash
     llvm::FunctionType *hashTy = llvm::FunctionType::get(i64Ty_, {hfi.hashArgTy}, false);

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -106,9 +106,7 @@ CodeGen::BucketContext CodeGen::emitHashTableRemoveBucket(
     const std::string &prefix) {
     llvm::Twine p(prefix);
     auto hfi = resolveHashFn(keyTy);
-    llvm::Value *hashKey = key;
-    if (keyTy != hfi.hashArgTy && keyTy->isIntegerTy() && hfi.hashArgTy->isIntegerTy())
-        hashKey = builder_.CreateZExt(key, hfi.hashArgTy, p + "_hash_zext");
+    llvm::Value *hashKey = coerceHashKey(key, keyTy, hfi.hashArgTy, p);
     llvm::FunctionType *hashTy = llvm::FunctionType::get(i64Ty_, {hfi.hashArgTy}, false);
     llvm::FunctionCallee hashFn = mod_->getOrInsertFunction(hfi.hashFnName, hashTy);
     llvm::Value *hashVal = builder_.CreateCall(hashFn, {hashKey}, p + "_hash");
@@ -133,9 +131,7 @@ void CodeGen::emitHashTableUpdateIndex(
     llvm::Value *oldIndex, llvm::Value *newIndex,
     const std::string &prefix) {
     llvm::Twine p(prefix);
-    llvm::Value *hashValue = value;
-    if (valueTy != bc.hashArgTy && valueTy->isIntegerTy() && bc.hashArgTy->isIntegerTy())
-        hashValue = builder_.CreateZExt(value, bc.hashArgTy, p + "_hash_zext");
+    llvm::Value *hashValue = coerceHashKey(value, valueTy, bc.hashArgTy, p);
     llvm::Value *hashVal = builder_.CreateCall(bc.hashFn, {hashValue}, p + "_hash");
 
     llvm::FunctionType *updateTy = llvm::FunctionType::get(


### PR DESCRIPTION
## Summary

- ハッシュテーブル操作で3箇所に重複していた ZExt coercion パターンを `CodeGen::coerceHashKey()` ヘルパーに抽出
- `emitBucketInsertAndRehashCheck`, `emitHashTableRemoveBucket`, `emitHashTableUpdateIndex` の各呼び出し箇所を置換

## Test plan

- [x] C++ テスト全件 (955 tests) パス
- [x] Ry セルフテスト（コレクション関連: Map/Set remove 含む）パス

Closes #274