### PR TITLE
refactor: extract emitStringRepeat helper to unify str*n and repeat() codegen

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -486,6 +486,7 @@ private:
     llvm::Value *emitStrOp_trim_start(const CallExpr &e);
     llvm::Value *emitStrOp_trim_end(const CallExpr &e);
     llvm::Value *emitStrOp_repeat(const CallExpr &e);
+    llvm::Value *emitStringRepeat(llvm::Value *strVal, llvm::Value *n);
     llvm::Value *emitStrOp_reverse(const CallExpr &e);
     llvm::Value *emitStrOp_reverse_mut(const CallExpr &e);
     llvm::Value *emitStrOp_split(const CallExpr &e);

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -543,56 +543,7 @@ llvm::Value *CodeGen::emitStrOp_repeat(const CallExpr &e) {
     if (n->getType() != i64Ty_)
         codegenError("repeat() requires int as second argument");
 
-    llvm::Value *nPos = builder_.CreateICmpSGT(
-        n, llvm::ConstantInt::get(i64Ty_, 0), "repeat_npos");
-
-    llvm::BasicBlock *emptyBB = llvm::BasicBlock::Create(*ctx_, "repeat.empty", fn_);
-    llvm::BasicBlock *repeatBB = llvm::BasicBlock::Create(*ctx_, "repeat.do", fn_);
-    llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "repeat.merge", fn_);
-
-    builder_.CreateCondBr(nPos, repeatBB, emptyBB);
-
-    builder_.SetInsertPoint(emptyBB);
-    llvm::Value *emptyStr = builder_.CreateGlobalString("", ".repeat_empty");
-    builder_.CreateBr(mergeBB);
-
-    builder_.SetInsertPoint(repeatBB);
-    auto strlenFn = getStdlibStrlen();
-    auto mallocFn = getStdlibMalloc();
-    auto memcpyFn = getStdlibMemcpy();
-
-    llvm::Value *sLen = builder_.CreateCall(strlenFn, {s}, "repeat_slen");
-    llvm::Value *totalLen = builder_.CreateMul(sLen, n, "repeat_total");
-    llvm::Value *bufSize = builder_.CreateAdd(totalLen, llvm::ConstantInt::get(i64Ty_, 1), "repeat_bsize");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "repeat_buf");
-
-    llvm::BasicBlock *loopBB = llvm::BasicBlock::Create(*ctx_, "repeat.loop", fn_);
-    llvm::BasicBlock *doneBB = llvm::BasicBlock::Create(*ctx_, "repeat.done", fn_);
-
-    builder_.CreateBr(loopBB);
-    builder_.SetInsertPoint(loopBB);
-
-    llvm::PHINode *i = builder_.CreatePHI(i64Ty_, 2, "repeat_i");
-    i->addIncoming(llvm::ConstantInt::get(i64Ty_, 0), repeatBB);
-
-    llvm::Value *offset = builder_.CreateMul(i, sLen, "repeat_offset");
-    llvm::Value *dstPtr = builder_.CreateGEP(builder_.getInt8Ty(), buf, offset, "repeat_dst");
-    builder_.CreateCall(memcpyFn, {dstPtr, s, sLen});
-
-    llvm::Value *iNext = builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1), "repeat_next");
-    i->addIncoming(iNext, loopBB);
-    builder_.CreateCondBr(builder_.CreateICmpSLT(iNext, n, "repeat_cond"), loopBB, doneBB);
-
-    builder_.SetInsertPoint(doneBB);
-    llvm::Value *nullPtr = builder_.CreateGEP(builder_.getInt8Ty(), buf, totalLen, "repeat_null");
-    builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), nullPtr);
-    builder_.CreateBr(mergeBB);
-
-    builder_.SetInsertPoint(mergeBB);
-    llvm::PHINode *result = builder_.CreatePHI(ptrTy_, 2, "repeat_result");
-    result->addIncoming(emptyStr, emptyBB);
-    result->addIncoming(buf, doneBB);
-    return result;
+    return emitStringRepeat(s, n);
 }
 
 // reverse(list) → new reversed list, or reverse(str) → str

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -248,63 +248,7 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
                 intVal = builder_.CreateZExt(intVal, i64Ty_, "n_ext");
             else if (intVal->getType() == i8Ty_)
                 intVal = builder_.CreateZExt(intVal, i64Ty_, "n_ext");
-            auto strlenFn = getStdlibStrlen();
-            auto mallocFn = getStdlibMalloc();
-            auto memcpyFn = getStdlibMemcpy();
-
-            llvm::Value *strLen = builder_.CreateCall(strlenFn, {strVal}, "str_len");
-
-            // If n <= 0, return empty string
-            llvm::Value *nPos = builder_.CreateICmpSGT(intVal, llvm::ConstantInt::get(i64Ty_, 0), "n_pos");
-
-            llvm::BasicBlock *emptyBB = llvm::BasicBlock::Create(*ctx_, "str_rep.empty", fn_);
-            llvm::BasicBlock *repeatBB = llvm::BasicBlock::Create(*ctx_, "str_rep.repeat", fn_);
-            llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "str_rep.merge", fn_);
-
-            builder_.CreateCondBr(nPos, repeatBB, emptyBB);
-
-            // Empty case: return ""
-            builder_.SetInsertPoint(emptyBB);
-            llvm::Value *emptyStr = builder_.CreateGlobalString("", ".empty_str");
-            builder_.CreateBr(mergeBB);
-
-            // Repeat case
-            builder_.SetInsertPoint(repeatBB);
-            llvm::Value *totalLen = builder_.CreateMul(strLen, intVal, "total_len");
-            llvm::Value *bufSize = builder_.CreateAdd(totalLen, llvm::ConstantInt::get(i64Ty_, 1), "buf_size");
-            llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "rep_buf");
-
-            // Loop: copy strVal into buf n times
-            llvm::BasicBlock *loopBB = llvm::BasicBlock::Create(*ctx_, "str_rep.loop", fn_);
-            llvm::BasicBlock *doneBB = llvm::BasicBlock::Create(*ctx_, "str_rep.done", fn_);
-
-            builder_.CreateBr(loopBB);
-            builder_.SetInsertPoint(loopBB);
-
-            llvm::PHINode *i = builder_.CreatePHI(i64Ty_, 2, "i");
-            i->addIncoming(llvm::ConstantInt::get(i64Ty_, 0), repeatBB);
-
-            llvm::Value *offset = builder_.CreateMul(i, strLen, "offset");
-            llvm::Value *dst = builder_.CreateGEP(builder_.getInt8Ty(), buf, {offset}, "dst");
-            builder_.CreateCall(memcpyFn, {dst, strVal, strLen});
-
-            llvm::Value *iNext = builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1), "i_next");
-            i->addIncoming(iNext, loopBB);
-            llvm::Value *cond = builder_.CreateICmpSLT(iNext, intVal, "loop_cond");
-            builder_.CreateCondBr(cond, loopBB, doneBB);
-
-            builder_.SetInsertPoint(doneBB);
-            // Null-terminate
-            llvm::Value *endPtr = builder_.CreateGEP(builder_.getInt8Ty(), buf, {totalLen}, "end_ptr");
-            builder_.CreateStore(llvm::ConstantInt::get(builder_.getInt8Ty(), 0), endPtr);
-            builder_.CreateBr(mergeBB);
-
-            // Merge
-            builder_.SetInsertPoint(mergeBB);
-            llvm::PHINode *result = builder_.CreatePHI(ptrTy_, 2, "str_rep_result");
-            result->addIncoming(emptyStr, emptyBB);
-            result->addIncoming(buf, doneBB);
-            return result;
+            return emitStringRepeat(strVal, intVal);
         }
     }
 
@@ -1509,4 +1453,66 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<AwaitExpr> &e) {
     llvm::AllocaInst *resultSlot = builder_.CreateAlloca(resultTy, nullptr, "await_result");
     builder_.CreateCall(joinFn, {taskVal, resultSlot});
     return builder_.CreateLoad(resultTy, resultSlot, "awaited");
+}
+
+// Common helper: emit IR for string repetition.
+// strVal must be ptr (i8*), n must be i64.
+llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
+    auto strlenFn = getStdlibStrlen();
+    auto mallocFn = getStdlibMalloc();
+    auto memcpyFn = getStdlibMemcpy();
+
+    llvm::Value *strLen = builder_.CreateCall(strlenFn, {strVal}, "str_len");
+
+    // If n <= 0, return empty string
+    llvm::Value *nPos = builder_.CreateICmpSGT(n, llvm::ConstantInt::get(i64Ty_, 0), "n_pos");
+
+    llvm::BasicBlock *emptyBB = llvm::BasicBlock::Create(*ctx_, "str_rep.empty", fn_);
+    llvm::BasicBlock *repeatBB = llvm::BasicBlock::Create(*ctx_, "str_rep.repeat", fn_);
+    llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "str_rep.merge", fn_);
+
+    builder_.CreateCondBr(nPos, repeatBB, emptyBB);
+
+    // Empty case: return ""
+    builder_.SetInsertPoint(emptyBB);
+    llvm::Value *emptyStr = builder_.CreateGlobalString("", ".empty_str");
+    builder_.CreateBr(mergeBB);
+
+    // Repeat case
+    builder_.SetInsertPoint(repeatBB);
+    llvm::Value *totalLen = builder_.CreateMul(strLen, n, "total_len");
+    llvm::Value *bufSize = builder_.CreateAdd(totalLen, llvm::ConstantInt::get(i64Ty_, 1), "buf_size");
+    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "rep_buf");
+
+    // Loop: copy strVal into buf n times
+    llvm::BasicBlock *loopBB = llvm::BasicBlock::Create(*ctx_, "str_rep.loop", fn_);
+    llvm::BasicBlock *doneBB = llvm::BasicBlock::Create(*ctx_, "str_rep.done", fn_);
+
+    builder_.CreateBr(loopBB);
+    builder_.SetInsertPoint(loopBB);
+
+    llvm::PHINode *i = builder_.CreatePHI(i64Ty_, 2, "i");
+    i->addIncoming(llvm::ConstantInt::get(i64Ty_, 0), repeatBB);
+
+    llvm::Value *offset = builder_.CreateMul(i, strLen, "offset");
+    llvm::Value *dst = builder_.CreateGEP(builder_.getInt8Ty(), buf, {offset}, "dst");
+    builder_.CreateCall(memcpyFn, {dst, strVal, strLen});
+
+    llvm::Value *iNext = builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1), "i_next");
+    i->addIncoming(iNext, loopBB);
+    llvm::Value *cond = builder_.CreateICmpSLT(iNext, n, "loop_cond");
+    builder_.CreateCondBr(cond, loopBB, doneBB);
+
+    builder_.SetInsertPoint(doneBB);
+    // Null-terminate
+    llvm::Value *endPtr = builder_.CreateGEP(builder_.getInt8Ty(), buf, {totalLen}, "end_ptr");
+    builder_.CreateStore(llvm::ConstantInt::get(builder_.getInt8Ty(), 0), endPtr);
+    builder_.CreateBr(mergeBB);
+
+    // Merge
+    builder_.SetInsertPoint(mergeBB);
+    llvm::PHINode *result = builder_.CreatePHI(ptrTy_, 2, "str_rep_result");
+    result->addIncoming(emptyStr, emptyBB);
+    result->addIncoming(buf, doneBB);
+    return result;
 }


### PR DESCRIPTION
## Summary

- `str * n` 演算子と `repeat()` 関数で重複していた文字列繰り返し IR 生成ロジック（各 ~50 行）を、共通ヘルパー `emitStringRepeat(strVal, n)` に抽出
- 両方の呼び出し元はバリデーション/型変換のみ行い、繰り返しロジックをヘルパーに委譲

## Changes

- `include/ry/codegen.hpp` — `emitStringRepeat` 宣言追加
- `src/codegen_expr.cpp` — ヘルパー実装 + `str * n` 演算子の簡素化
- `src/codegen_call_string.cpp` — `emitStrOp_repeat` の簡素化

## Test plan

- [x] C++ テスト全 955 パス (`./build/ry_tests`)
- [x] `operators.test.ry` 全 64 パス（`str * n` repetition テスト含む）
- [x] `strings.test.ry` 全 24 パス（`repeat()` テスト含む）

Closes #282