### PR TITLE
feat: add unsigned integer types (u8, u16, u32, u64) and i8/i64

### DIFF
--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -26,8 +26,14 @@
 | Int literal | i64 | `42`, `0 \| 1` | Int literal type (value constraint) |
 | String literal | ptr | `"N" \| "S"` | String literal type (value constraint) |
 | Range | i64 | `1..12`, `-10..10` | Range type (inclusive integer range constraint) |
+| `i8` | i8 | `x: i8 = 42` | 8-bit signed integer (low-level, no implicit conversion) |
 | `i16` | i16 | `x: i16 = 100` | 16-bit signed integer (low-level, no implicit conversion) |
 | `i32` | i32 | `x: i32 = 42` | 32-bit signed integer (low-level, no implicit conversion) |
+| `i64` | i64 | `x: i64 = 100` | 64-bit signed integer (low-level, no implicit conversion) |
+| `u8` | i8 | `x: u8 = 200` | 8-bit unsigned integer (low-level, no implicit conversion) |
+| `u16` | i16 | `x: u16 = 60000` | 16-bit unsigned integer (low-level, no implicit conversion) |
+| `u32` | i32 | `x: u32 = 3000000000` | 32-bit unsigned integer (low-level, no implicit conversion) |
+| `u64` | i64 | `x: u64 = 100` | 64-bit unsigned integer (low-level, no implicit conversion) |
 | `f32` | float | `x: f32 = 3.14` | 32-bit floating-point (low-level, no implicit conversion) |
 
 ## Type Annotation Syntax
@@ -69,8 +75,14 @@ a: any = 42
 | `Error` | Built-in error type (`message: str`, `code: int`) |
 | `any` | Built-in type that can hold any primitive value (`int`, `float`, `bool`, `str`) or `Unit` (for value-less/implicit returns). Default return type for named functions when omitted. Supports implicit conversion: concrete values are automatically wrapped when assigned to `any`, and `any` values are automatically unwrapped (with runtime type check) when assigned to a concrete type. `any(int)` → `float` auto-promotion is supported |
 | `T1 \| T2 \| ...` | Union type (one of multiple types separated by `\|`) |
+| `i8` | Low-level 8-bit signed integer (no implicit conversion) |
 | `i16` | Low-level 16-bit signed integer (no implicit conversion) |
 | `i32` | Low-level 32-bit signed integer (no implicit conversion) |
+| `i64` | Low-level 64-bit signed integer (no implicit conversion) |
+| `u8` | Low-level 8-bit unsigned integer (no implicit conversion) |
+| `u16` | Low-level 16-bit unsigned integer (no implicit conversion) |
+| `u32` | Low-level 32-bit unsigned integer (no implicit conversion) |
+| `u64` | Low-level 64-bit unsigned integer (no implicit conversion) |
 | `f32` | Low-level 32-bit floating-point (no implicit conversion) |
 | User-defined type name | Type declared with the `record` or `enum` keyword |
 
@@ -241,16 +253,21 @@ b = 255 as byte       # byte value 255
 | `int` | `byte` | Truncation (lower 8 bits) |
 | `byte` | `int` | Zero extension |
 
-| `int` | `i32` / `i16` | Truncation |
-| `i32` / `i16` | `int` | Sign extension (`SExt`) |
-| `i32` | `i16` | Truncation |
-| `i16` | `i32` | Sign extension (`SExt`) |
-| `i32` / `i16` | `float` | `SIToFP` then `f64` |
-| `float` | `i32` / `i16` | `FPToSI` (truncation) |
+| `int` | `i8` / `i16` / `i32` / `i64` | Truncation (or identity for i64) |
+| `i8` / `i16` / `i32` / `i64` | `int` | Sign extension (`SExt`) |
+| `int` | `u8` / `u16` / `u32` / `u64` | Truncation (or identity for u64) |
+| `u8` / `u16` / `u32` / `u64` | `int` | Zero extension (`ZExt`) |
+| signed | signed (wider) | Sign extension (`SExt`) |
+| signed | signed (narrower) | Truncation |
+| unsigned | unsigned/signed (wider) | Zero extension (`ZExt`) |
+| unsigned | unsigned/signed (narrower) | Truncation |
+| signed / unsigned int | `float` | `SIToFP` / `UIToFP` then `f64` |
+| `float` | signed / unsigned int | `FPToSI` / `FPToUI` |
 | `float` | `f32` | `FPTrunc` |
 | `f32` | `float` | `FPExt` |
-| `i32` / `i16` | `f32` | `SIToFP` |
-| `f32` | `i32` / `i16` | `FPToSI` |
+| signed int | `f32` | `SIToFP` |
+| unsigned int | `f32` | `UIToFP` |
+| `f32` | signed / unsigned int | `FPToSI` / `FPToUI` |
 
 Unsupported casts (e.g. `str as int`) cause a compile error. Use `to_int()` / `to_float()` for string-to-number conversions.
 
@@ -435,12 +452,18 @@ A union type is represented as `{ i64 tag, [N x i8] data }`. The `tag` indicates
 | `in` | any | Set<T> | bool | Whether the element is in the set |
 | `&` `\|` `^` `~` `<<` `>>` | int | int | int | Error for float |
 | `+` `-` `*` | i32 | i32 | i32 | Low-level types: no implicit conversion, same type required |
-| `/` `//` | i32 | i32 | i32 | Integer division (Rust-style), NOT float |
-| `%` | i32 | i32 | i32 | |
+| `/` `//` | i32 | i32 | i32 | Signed integer division (`SDiv`) |
+| `/` `//` | u32 | u32 | u32 | Unsigned integer division (`UDiv`) |
+| `%` | i32 | i32 | i32 | Signed remainder (`SRem`) |
+| `%` | u32 | u32 | u32 | Unsigned remainder (`URem`) |
 | `+` `-` `*` `/` | f32 | f32 | f32 | |
-| `==` `!=` `<` `<=` `>` `>=` | i32 | i32 | bool | |
-| `**` | i32/i16/f32 | any | error | Power operator not supported for low-level types |
-| mixed | i32/i16/f32 | int/float | error | Mixing low-level and high-level types is a compile error |
+| `==` `!=` | i32/u32 | i32/u32 | bool | Sign-agnostic equality |
+| `<` `<=` `>` `>=` | i32 | i32 | bool | Signed comparison (`ICMP_SLT` etc.) |
+| `<` `<=` `>` `>=` | u32 | u32 | bool | Unsigned comparison (`ICMP_ULT` etc.) |
+| `>>` | i32 | i32 | i32 | Arithmetic right shift (sign-preserving) |
+| `>>` | u32 | u32 | u32 | Logical right shift (zero-fill) |
+| `**` | low-level | any | error | Power operator not supported for low-level types |
+| mixed | low-level | different | error | Mixing low-level and high-level types is a compile error |
 
 ### Escape Sequences (in str Literals)
 
@@ -459,5 +482,6 @@ A union type is represented as `{ i64 tag, [N x i8] data }`. The `tag` indicates
 - **Variable types are fixed at declaration** -- A variable declared as `int` cannot be reassigned a `float` value.
 - **Bitwise operations are for `int` only** -- Applying bitwise operations to `float` or `bool` causes a compile error.
 - **Non-`bool` types can be used in conditions** -- `if` conditions accept `int` (0 = false, non-zero = true) and other types besides `bool`.
-- **Low-level numeric types (`i16`, `i32`, `f32`) have no implicit conversions** -- Mixing low-level types with each other or with high-level types (`int`, `float`) causes a compile error. Use explicit `as` casts. The `/` operator on low-level integers performs integer division (like Rust), not float division.
-- **Low-level integer overflow wraps around** -- Arithmetic on low-level integer types (`i16`, `i32`) uses two's complement wrapping on overflow. For example, `i32` max value `2147483647 + 1` wraps to `-2147483648`. This matches C behavior. Use the high-level `int` type (64-bit) if overflow is a concern.
+- **Low-level numeric types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `f32`) have no implicit conversions** -- Mixing low-level types with each other or with high-level types (`int`, `float`) causes a compile error. Use explicit `as` casts. The `/` operator on low-level integers performs integer division (like Rust), not float division. Signed types use `SDiv`/`SRem`, unsigned types use `UDiv`/`URem`.
+- **Signed vs unsigned** -- Signed types (`i8`, `i16`, `i32`, `i64`) use signed comparison (`ICMP_SLT` etc.) and arithmetic right shift (`AShr`). Unsigned types (`u8`, `u16`, `u32`, `u64`) use unsigned comparison (`ICMP_ULT` etc.) and logical right shift (`LShr`). The `>>>` operator always performs logical shift regardless of signedness.
+- **Low-level integer overflow wraps around** -- Arithmetic on low-level integer types uses two's complement wrapping on overflow (signed) or modular arithmetic (unsigned). For example, `i32` max value `2147483647 + 1` wraps to `-2147483648`. This matches C behavior. Use the high-level `int` type (64-bit) if overflow is a concern.

--- a/docs/tutorial/02-variables-and-types.md
+++ b/docs/tutorial/02-variables-and-types.md
@@ -73,8 +73,14 @@ Ry also provides low-level numeric types for precise control over memory layout.
 
 | Type | Description | Example |
 |------|-------------|---------|
+| `i8` | 8-bit signed integer | `x: i8 = 42` |
 | `i16` | 16-bit signed integer | `x: i16 = 100` |
 | `i32` | 32-bit signed integer | `x: i32 = 42` |
+| `i64` | 64-bit signed integer | `x: i64 = 100` |
+| `u8` | 8-bit unsigned integer | `x: u8 = 200` |
+| `u16` | 16-bit unsigned integer | `x: u16 = 60000` |
+| `u32` | 32-bit unsigned integer | `x: u32 = 3000000000` |
+| `u64` | 64-bit unsigned integer | `x: u64 = 100` |
 | `f32` | 32-bit floating-point | `x: f32 = 3.14` |
 
 ```python
@@ -87,11 +93,16 @@ d = 42
 
 y = a as int       # Explicit cast to int
 z = d as i32       # Explicit cast to i32
+
+# Unsigned types use unsigned operations
+x: u32 = 3000000000
+y: u32 = 7
+q = x / y          # Unsigned division (UDiv)
 ```
 
-> **Note**: `/` on low-level integers performs integer division (like Rust), not float division.
+> **Note**: `/` on low-level integers performs integer division (like Rust), not float division. Signed types use `SDiv`, unsigned types use `UDiv`.
 >
-> **Note**: Arithmetic on low-level integers wraps on overflow (two's complement). Use `int` if overflow is a concern.
+> **Note**: Arithmetic on low-level integers wraps on overflow. Signed types use two's complement, unsigned types use modular arithmetic. Use the high-level `int` type (64-bit) if overflow is a concern.
 
 ---
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -69,6 +69,7 @@ private:
     std::vector<llvm::Value*> task_group_stack_;
     std::unordered_map<llvm::Value*, llvm::Type*> channel_element_types_;
     std::unordered_map<llvm::Value*, llvm::Type*> iterator_element_types_;
+    std::unordered_map<llvm::Value*, std::string> low_level_type_names_;
     int iterator_fn_counter_ = 0;
 
     struct UnionTypeInfo {
@@ -269,10 +270,16 @@ private:
     llvm::Value *toBool(llvm::Value *v);
 
     // Low-level type helpers
+    const std::string &getLowLevelTypeName(llvm::Value *val) const;
+    bool isUnsignedLowLevel(llvm::Value *val) const;
+    static bool isUnsignedLowLevelName(const std::string &name);
+    static bool isLowLevelTypeName(const std::string &name);
     bool isLowLevelIntTy(llvm::Type *ty) const;
+    bool isLowLevelIntTy(llvm::Value *val) const;
     bool isLowLevelFloatTy(llvm::Type *ty) const;
     bool isLowLevelTy(llvm::Type *ty) const;
-    void checkLowLevelTypeMix(llvm::Type *lhsTy, llvm::Type *rhsTy, const std::string &op);
+    bool isLowLevelTy(llvm::Value *val) const;
+    void checkLowLevelTypeMix(llvm::Value *lhs, llvm::Value *rhs, const std::string &op);
 
     // Type promotion helpers (B1)
     llvm::Value *promoteToInt(llvm::Value *v);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -223,8 +223,39 @@ llvm::AllocaInst *CodeGen::getOrCreateVar(const std::string &name, llvm::Type *t
 
 // ===== Low-level type helpers =====
 
+const std::string &CodeGen::getLowLevelTypeName(llvm::Value *val) const {
+    static const std::string empty;
+    auto it = low_level_type_names_.find(val);
+    if (it != low_level_type_names_.end()) return it->second;
+    if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val)) {
+        auto it2 = low_level_type_names_.find(load->getPointerOperand());
+        if (it2 != low_level_type_names_.end()) return it2->second;
+    }
+    return empty;
+}
+
+bool CodeGen::isUnsignedLowLevel(llvm::Value *val) const {
+    std::string name = getLowLevelTypeName(val);
+    return isUnsignedLowLevelName(name);
+}
+
+bool CodeGen::isUnsignedLowLevelName(const std::string &name) {
+    return !name.empty() && name[0] == 'u';
+}
+
+bool CodeGen::isLowLevelTypeName(const std::string &name) {
+    return name == "i8" || name == "i16" || name == "i32" || name == "i64" ||
+           name == "u8" || name == "u16" || name == "u32" || name == "u64" || name == "f32";
+}
+
 bool CodeGen::isLowLevelIntTy(llvm::Type *ty) const {
     return ty == i16Ty_ || ty == i32Ty_;
+}
+
+bool CodeGen::isLowLevelIntTy(llvm::Value *val) const {
+    const std::string &name = getLowLevelTypeName(val);
+    if (!name.empty()) return name != "f32";
+    return isLowLevelIntTy(val->getType());
 }
 
 bool CodeGen::isLowLevelFloatTy(llvm::Type *ty) const {
@@ -235,13 +266,25 @@ bool CodeGen::isLowLevelTy(llvm::Type *ty) const {
     return isLowLevelIntTy(ty) || isLowLevelFloatTy(ty);
 }
 
-void CodeGen::checkLowLevelTypeMix(llvm::Type *lhsTy, llvm::Type *rhsTy, const std::string &op) {
-    bool lhsLL = isLowLevelTy(lhsTy);
-    bool rhsLL = isLowLevelTy(rhsTy);
+bool CodeGen::isLowLevelTy(llvm::Value *val) const {
+    return isLowLevelIntTy(val) || isLowLevelFloatTy(val->getType());
+}
+
+void CodeGen::checkLowLevelTypeMix(llvm::Value *lhs, llvm::Value *rhs, const std::string &op) {
+    std::string lhsName = getLowLevelTypeName(lhs);
+    std::string rhsName = getLowLevelTypeName(rhs);
+    bool lhsLL = !lhsName.empty() || isLowLevelTy(lhs->getType());
+    bool rhsLL = !rhsName.empty() || isLowLevelTy(rhs->getType());
     if (lhsLL || rhsLL) {
-        if (lhsTy != rhsTy)
+        if (lhs->getType() != rhs->getType()) {
             codegenError("type error: cannot mix types in operator '" + op +
                          "'; low-level numeric types require explicit 'as' cast");
+        }
+        // Both have metadata: must match (e.g., u32 vs i32 is an error)
+        if (!lhsName.empty() && !rhsName.empty() && lhsName != rhsName) {
+            codegenError("type error: cannot mix types in operator '" + op +
+                         "'; low-level numeric types require explicit 'as' cast");
+        }
     }
 }
 
@@ -250,19 +293,19 @@ void CodeGen::checkLowLevelTypeMix(llvm::Type *lhsTy, llvm::Type *rhsTy, const s
 llvm::Value *CodeGen::promoteToInt(llvm::Value *v) {
     if (v->getType() == i1Ty_)
         return builder_.CreateZExt(v, i64Ty_, "boolext");
-    if (v->getType() == i8Ty_)
+    if (v->getType() == i8Ty_ && !isLowLevelIntTy(v))
         return builder_.CreateZExt(v, i64Ty_, "byteext");
     return v;
 }
 
 std::pair<llvm::Value*, llvm::Value*> CodeGen::promoteToFloat(llvm::Value *lhs, llvm::Value *rhs) {
-    if (!lhs->getType()->isDoubleTy()) {
+    if (!lhs->getType()->isDoubleTy() && !isLowLevelTy(lhs)) {
         if (lhs->getType() == i8Ty_)
             lhs = builder_.CreateUIToFP(lhs, f64Ty_, "lhs_f");
         else
             lhs = builder_.CreateSIToFP(lhs, f64Ty_, "lhs_f");
     }
-    if (!rhs->getType()->isDoubleTy()) {
+    if (!rhs->getType()->isDoubleTy() && !isLowLevelTy(rhs)) {
         if (rhs->getType() == i8Ty_)
             rhs = builder_.CreateUIToFP(rhs, f64Ty_, "rhs_f");
         else
@@ -510,6 +553,10 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         channel_element_types_[callResult] = resolveType(inner);
     }
 
+    // Propagate low-level type metadata from return type
+    if (matchedEntry && isLowLevelTypeName(matchedEntry->returnTypeName))
+        low_level_type_names_[callResult] = matchedEntry->returnTypeName;
+
     return callResult;
 }
 
@@ -671,8 +718,14 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
     if (typeName == "any")   return anyTy_;
     if (typeName == "Unit")  return llvm::Type::getVoidTy(*ctx_);
     // Low-level numeric types
+    if (typeName == "i8")    return i8Ty_;
     if (typeName == "i16")   return i16Ty_;
     if (typeName == "i32")   return i32Ty_;
+    if (typeName == "i64")   return i64Ty_;
+    if (typeName == "u8")    return i8Ty_;
+    if (typeName == "u16")   return i16Ty_;
+    if (typeName == "u32")   return i32Ty_;
+    if (typeName == "u64")   return i64Ty_;
     if (typeName == "f32")   return f32Ty_;
 
     // Optional type suffix: "int?" -> Option<int>
@@ -1096,16 +1149,40 @@ void CodeGen::emitPrintValue(llvm::Value *val, llvm::Type *ty,
         llvm::Constant *fmt = builder_.CreateGlobalString("%s", ".fmt_s" + suffix);
         builder_.CreateCall(printfFn, {fmt, val});
     } else if (ty == i8Ty_) {
-        llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "byte_print");
-        llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".fmt_b" + suffix);
-        builder_.CreateCall(printfFn, {fmt, ext});
+        std::string llName = getLowLevelTypeName(val);
+        if (llName == "i8") {
+            llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i8_print");
+            llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".fmt_i8" + suffix);
+            builder_.CreateCall(printfFn, {fmt, ext});
+        } else if (llName == "u8") {
+            llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "u8_print");
+            llvm::Constant *fmt = builder_.CreateGlobalString("%u", ".fmt_u8" + suffix);
+            builder_.CreateCall(printfFn, {fmt, ext});
+        } else {
+            llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "byte_print");
+            llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".fmt_b" + suffix);
+            builder_.CreateCall(printfFn, {fmt, ext});
+        }
     } else if (ty == i16Ty_) {
-        llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i16_print");
-        llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".fmt_i16" + suffix);
-        builder_.CreateCall(printfFn, {fmt, ext});
+        std::string llName = getLowLevelTypeName(val);
+        if (llName == "u16") {
+            llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "u16_print");
+            llvm::Constant *fmt = builder_.CreateGlobalString("%u", ".fmt_u16" + suffix);
+            builder_.CreateCall(printfFn, {fmt, ext});
+        } else {
+            llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i16_print");
+            llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".fmt_i16" + suffix);
+            builder_.CreateCall(printfFn, {fmt, ext});
+        }
     } else if (ty == i32Ty_) {
-        llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".fmt_i32" + suffix);
-        builder_.CreateCall(printfFn, {fmt, val});
+        std::string llName = getLowLevelTypeName(val);
+        if (llName == "u32") {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%u", ".fmt_u32" + suffix);
+            builder_.CreateCall(printfFn, {fmt, val});
+        } else {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".fmt_i32" + suffix);
+            builder_.CreateCall(printfFn, {fmt, val});
+        }
     } else if (ty == f32Ty_) {
         llvm::Value *ext = builder_.CreateFPExt(val, f64Ty_, "f32_print");
         llvm::Constant *fmt = builder_.CreateGlobalString("%g", ".fmt_f32" + suffix);
@@ -1123,8 +1200,14 @@ void CodeGen::emitPrintValue(llvm::Value *val, llvm::Type *ty,
         llvm::Constant *fmt = builder_.CreateGlobalString("Error: %s (code: %ld)", ".fmt_err" + suffix);
         builder_.CreateCall(printfFn, {fmt, msg, code});
     } else {
-        llvm::Constant *fmt = builder_.CreateGlobalString("%ld", ".fmt_i" + suffix);
-        builder_.CreateCall(printfFn, {fmt, val});
+        std::string llName = getLowLevelTypeName(val);
+        if (llName == "u64") {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%lu", ".fmt_u64" + suffix);
+            builder_.CreateCall(printfFn, {fmt, val});
+        } else {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%ld", ".fmt_i" + suffix);
+            builder_.CreateCall(printfFn, {fmt, val});
+        }
     }
 }
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -161,10 +161,10 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
     }
 
     // Low-level type mix check
-    checkLowLevelTypeMix(lhs->getType(), rhs->getType(), op);
+    checkLowLevelTypeMix(lhs, rhs, op);
 
     // Low-level type native-width comparison
-    if (isLowLevelTy(lhs->getType()) && lhs->getType() == rhs->getType()) {
+    if (isLowLevelTy(lhs) && lhs->getType() == rhs->getType()) {
         if (isLowLevelFloatTy(lhs->getType())) {
             llvm::CmpInst::Predicate pred;
             if      (op == "==") pred = llvm::CmpInst::FCMP_OEQ;
@@ -175,13 +175,14 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             else                 pred = llvm::CmpInst::FCMP_OGE;
             return builder_.CreateFCmp(pred, lhs, rhs, "fcmp_ll");
         }
+        bool isUnsigned = isUnsignedLowLevel(lhs);
         llvm::CmpInst::Predicate pred;
         if      (op == "==") pred = llvm::CmpInst::ICMP_EQ;
         else if (op == "!=") pred = llvm::CmpInst::ICMP_NE;
-        else if (op == "<")  pred = llvm::CmpInst::ICMP_SLT;
-        else if (op == "<=") pred = llvm::CmpInst::ICMP_SLE;
-        else if (op == ">")  pred = llvm::CmpInst::ICMP_SGT;
-        else                 pred = llvm::CmpInst::ICMP_SGE;
+        else if (op == "<")  pred = isUnsigned ? llvm::CmpInst::ICMP_ULT : llvm::CmpInst::ICMP_SLT;
+        else if (op == "<=") pred = isUnsigned ? llvm::CmpInst::ICMP_ULE : llvm::CmpInst::ICMP_SLE;
+        else if (op == ">")  pred = isUnsigned ? llvm::CmpInst::ICMP_UGT : llvm::CmpInst::ICMP_SGT;
+        else                 pred = isUnsigned ? llvm::CmpInst::ICMP_UGE : llvm::CmpInst::ICMP_SGE;
         return builder_.CreateICmp(pred, lhs, rhs, "icmp_ll");
     }
 
@@ -216,15 +217,25 @@ llvm::Value *CodeGen::emitBitwiseOp(const std::string &op, llvm::Value *lhs, llv
         isLowLevelFloatTy(lhs->getType()) || isLowLevelFloatTy(rhs->getType()))
         codegenError(
             "bitwise operator '" + op + "' requires integer operands, got float");
-    checkLowLevelTypeMix(lhs->getType(), rhs->getType(), op);
+    checkLowLevelTypeMix(lhs, rhs, op);
     // Low-level integer bitwise at native width
-    if (isLowLevelIntTy(lhs->getType()) && lhs->getType() == rhs->getType()) {
-        if (op == "&")  return builder_.CreateAnd(lhs, rhs,  "band_ll");
-        if (op == "|")  return builder_.CreateOr(lhs,  rhs,  "bor_ll");
-        if (op == "^")  return builder_.CreateXor(lhs, rhs,  "bxor_ll");
-        if (op == "<<") return builder_.CreateShl(lhs,  rhs, "shl_ll");
-        if (op == ">>") return builder_.CreateAShr(lhs, rhs, "ashr_ll");
-        if (op == ">>>") return builder_.CreateLShr(lhs, rhs, "lshr_ll");
+    if (isLowLevelIntTy(lhs) && lhs->getType() == rhs->getType()) {
+        std::string llName = getLowLevelTypeName(lhs);
+        if (llName.empty()) llName = getLowLevelTypeName(rhs);
+        auto propagate = [&](llvm::Value *result) -> llvm::Value* {
+            if (!llName.empty()) low_level_type_names_[result] = llName;
+            return result;
+        };
+        if (op == "&")  return propagate(builder_.CreateAnd(lhs, rhs,  "band_ll"));
+        if (op == "|")  return propagate(builder_.CreateOr(lhs,  rhs,  "bor_ll"));
+        if (op == "^")  return propagate(builder_.CreateXor(lhs, rhs,  "bxor_ll"));
+        if (op == "<<") return propagate(builder_.CreateShl(lhs,  rhs, "shl_ll"));
+        if (op == ">>") {
+            if (isUnsignedLowLevel(lhs))
+                return propagate(builder_.CreateLShr(lhs, rhs, "lshr_ll"));
+            return propagate(builder_.CreateAShr(lhs, rhs, "ashr_ll"));
+        }
+        if (op == ">>>") return propagate(builder_.CreateLShr(lhs, rhs, "lshr_ll"));
         codegenError("unknown bitwise operator: " + op);
     }
     lhs = promoteToInt(lhs);
@@ -240,29 +251,43 @@ llvm::Value *CodeGen::emitBitwiseOp(const std::string &op, llvm::Value *lhs, llv
 
 llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs) {
     // Low-level type mix check (must come first)
-    checkLowLevelTypeMix(lhs->getType(), rhs->getType(), op);
+    checkLowLevelTypeMix(lhs, rhs, op);
 
     // Low-level type native-width arithmetic
-    if (isLowLevelTy(lhs->getType()) && lhs->getType() == rhs->getType()) {
+    if (isLowLevelTy(lhs) && lhs->getType() == rhs->getType()) {
         llvm::Type *ty = lhs->getType();
         if (op == "**")
             codegenError("operator '**' is not supported for low-level numeric types");
+        // Propagate low-level type metadata to result
+        std::string llName = getLowLevelTypeName(lhs);
+        if (llName.empty()) llName = getLowLevelTypeName(rhs);
+        auto propagate = [&](llvm::Value *result) -> llvm::Value* {
+            if (!llName.empty()) low_level_type_names_[result] = llName;
+            return result;
+        };
         if (isLowLevelFloatTy(ty)) {
             if (op == "//")
                 codegenError("operator '//' is not supported for f32");
-            if (op == "%")  return builder_.CreateFRem(lhs, rhs, "frem32");
-            if (op == "/")  return builder_.CreateFDiv(lhs, rhs, "fdiv32");
-            if (op == "+")  return builder_.CreateFAdd(lhs, rhs, "fadd32");
-            if (op == "-")  return builder_.CreateFSub(lhs, rhs, "fsub32");
-            if (op == "*")  return builder_.CreateFMul(lhs, rhs, "fmul32");
+            if (op == "%")  return propagate(builder_.CreateFRem(lhs, rhs, "frem32"));
+            if (op == "/")  return propagate(builder_.CreateFDiv(lhs, rhs, "fdiv32"));
+            if (op == "+")  return propagate(builder_.CreateFAdd(lhs, rhs, "fadd32"));
+            if (op == "-")  return propagate(builder_.CreateFSub(lhs, rhs, "fsub32"));
+            if (op == "*")  return propagate(builder_.CreateFMul(lhs, rhs, "fmul32"));
             codegenError("unknown operator: " + op);
         }
-        // Low-level integer (i16, i32)
-        if (op == "/" || op == "//") return builder_.CreateSDiv(lhs, rhs, "sdiv_ll");
-        if (op == "%")  return builder_.CreateSRem(lhs, rhs, "srem_ll");
-        if (op == "+")  return builder_.CreateAdd(lhs, rhs, "add_ll");
-        if (op == "-")  return builder_.CreateSub(lhs, rhs, "sub_ll");
-        if (op == "*")  return builder_.CreateMul(lhs, rhs, "mul_ll");
+        // Low-level integer
+        bool isUnsigned = isUnsignedLowLevel(lhs);
+        if (op == "/" || op == "//") {
+            if (isUnsigned) return propagate(builder_.CreateUDiv(lhs, rhs, "udiv_ll"));
+            return propagate(builder_.CreateSDiv(lhs, rhs, "sdiv_ll"));
+        }
+        if (op == "%") {
+            if (isUnsigned) return propagate(builder_.CreateURem(lhs, rhs, "urem_ll"));
+            return propagate(builder_.CreateSRem(lhs, rhs, "srem_ll"));
+        }
+        if (op == "+")  return propagate(builder_.CreateAdd(lhs, rhs, "add_ll"));
+        if (op == "-")  return propagate(builder_.CreateSub(lhs, rhs, "sub_ll"));
+        if (op == "*")  return propagate(builder_.CreateMul(lhs, rhs, "mul_ll"));
         codegenError("unknown operator: " + op);
     }
 
@@ -1079,24 +1104,49 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
         builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 64), fmt, val});
         return buf;
     }
+    // Check low-level type metadata for ambiguous LLVM types
+    std::string llName = getLowLevelTypeName(val);
+
     if (ty == i8Ty_) {
         llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");
-        llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".vts_byte_fmt");
-        llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "byte_ext");
-        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
+        if (llName == "i8") {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".vts_i8_fmt");
+            llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i8_ext");
+            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
+        } else if (llName == "u8") {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%u", ".vts_u8_fmt");
+            llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "u8_ext");
+            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
+        } else {
+            // byte (default)
+            llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".vts_byte_fmt");
+            llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "byte_ext");
+            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
+        }
         return buf;
     }
     if (ty == i16Ty_) {
         llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");
-        llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".vts_i16_fmt");
-        llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i16_ext");
-        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
+        if (llName == "u16") {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%u", ".vts_u16_fmt");
+            llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "u16_ext");
+            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
+        } else {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".vts_i16_fmt");
+            llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i16_ext");
+            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
+        }
         return buf;
     }
     if (ty == i32Ty_) {
         llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");
-        llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".vts_i32_fmt");
-        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
+        if (llName == "u32") {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%u", ".vts_u32_fmt");
+            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
+        } else {
+            llvm::Constant *fmt = builder_.CreateGlobalString("%d", ".vts_i32_fmt");
+            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
+        }
         return buf;
     }
     if (ty == f32Ty_) {
@@ -1106,10 +1156,15 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
         builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 64), fmt, ext});
         return buf;
     }
-    // default: int (i64)
+    // default: int (i64) or i64/u64
     llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");
-    llvm::Constant *fmt = builder_.CreateGlobalString("%ld", ".vts_int_fmt");
-    builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
+    if (llName == "u64") {
+        llvm::Constant *fmt = builder_.CreateGlobalString("%lu", ".vts_u64_fmt");
+        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
+    } else {
+        llvm::Constant *fmt = builder_.CreateGlobalString("%ld", ".vts_int_fmt");
+        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
+    }
     return buf;
 }
 
@@ -1122,9 +1177,28 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         if (srcTy->isDoubleTy()) return val;
         if (srcTy == f32Ty_) return builder_.CreateFPExt(val, f64Ty_, "cast_f");
         if (srcTy == i1Ty_) val = builder_.CreateZExt(val, i64Ty_, "bool_ext");
-        else if (srcTy == i8Ty_) val = builder_.CreateZExt(val, i64Ty_, "byte_ext");
-        else if (srcTy == i16Ty_) val = builder_.CreateSExt(val, i64Ty_, "i16_ext");
-        else if (srcTy == i32Ty_) val = builder_.CreateSExt(val, i64Ty_, "i32_ext");
+        else if (srcTy == i8Ty_) {
+            if (isUnsignedLowLevel(val))
+                return builder_.CreateUIToFP(val, f64Ty_, "cast_f");
+            std::string name = getLowLevelTypeName(val);
+            if (name == "i8") {
+                val = builder_.CreateSExt(val, i64Ty_, "i8_ext");
+            } else {
+                val = builder_.CreateZExt(val, i64Ty_, "byte_ext");
+            }
+        }
+        else if (srcTy == i16Ty_) {
+            if (isUnsignedLowLevel(val))
+                return builder_.CreateUIToFP(val, f64Ty_, "cast_f");
+            val = builder_.CreateSExt(val, i64Ty_, "i16_ext");
+        }
+        else if (srcTy == i32Ty_) {
+            if (isUnsignedLowLevel(val))
+                return builder_.CreateUIToFP(val, f64Ty_, "cast_f");
+            val = builder_.CreateSExt(val, i64Ty_, "i32_ext");
+        }
+        else if (srcTy == i64Ty_ && isUnsignedLowLevel(val))
+            return builder_.CreateUIToFP(val, f64Ty_, "cast_f");
         if (val->getType()->isIntegerTy())
             return builder_.CreateSIToFP(val, f64Ty_, "cast_f");
         codegenError("cannot cast to float");
@@ -1133,9 +1207,19 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         if (srcTy == i64Ty_) return val;
         if (srcTy->isDoubleTy()) return builder_.CreateFPToSI(val, i64Ty_, "cast_i");
         if (srcTy == i1Ty_) return builder_.CreateZExt(val, i64Ty_, "cast_i");
-        if (srcTy == i8Ty_) return builder_.CreateZExt(val, i64Ty_, "cast_i");
-        if (srcTy == i32Ty_) return builder_.CreateSExt(val, i64Ty_, "cast_i");
-        if (srcTy == i16Ty_) return builder_.CreateSExt(val, i64Ty_, "cast_i");
+        if (srcTy == i8Ty_) {
+            std::string name = getLowLevelTypeName(val);
+            if (name == "i8") return builder_.CreateSExt(val, i64Ty_, "cast_i");
+            return builder_.CreateZExt(val, i64Ty_, "cast_i");
+        }
+        if (srcTy == i32Ty_) {
+            if (isUnsignedLowLevel(val)) return builder_.CreateZExt(val, i64Ty_, "cast_i");
+            return builder_.CreateSExt(val, i64Ty_, "cast_i");
+        }
+        if (srcTy == i16Ty_) {
+            if (isUnsignedLowLevel(val)) return builder_.CreateZExt(val, i64Ty_, "cast_i");
+            return builder_.CreateSExt(val, i64Ty_, "cast_i");
+        }
         if (srcTy == f32Ty_) return builder_.CreateFPToSI(val, i64Ty_, "cast_i");
         codegenError("cannot cast to int");
     }
@@ -1155,33 +1239,138 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         if (srcTy == i1Ty_) return builder_.CreateZExt(val, i8Ty_, "cast_byte");
         codegenError("cannot cast to byte");
     }
-    // Low-level type casts
+    // Low-level type casts — helper lambda for metadata
+    auto withMeta = [&](llvm::Value *result, const std::string &name) -> llvm::Value* {
+        low_level_type_names_[result] = name;
+        return result;
+    };
+
     if (target == "i32") {
-        if (srcTy == i32Ty_) return val;
-        if (srcTy == i64Ty_) return builder_.CreateTrunc(val, i32Ty_, "cast_i32");
-        if (srcTy == i16Ty_) return builder_.CreateSExt(val, i32Ty_, "cast_i32");
-        if (srcTy == i8Ty_)  return builder_.CreateSExt(val, i32Ty_, "cast_i32");
-        if (srcTy == i1Ty_)  return builder_.CreateZExt(val, i32Ty_, "cast_i32");
-        if (srcTy->isDoubleTy()) return builder_.CreateFPToSI(val, i32Ty_, "cast_i32");
-        if (srcTy == f32Ty_) return builder_.CreateFPToSI(val, i32Ty_, "cast_i32");
-        codegenError("cannot cast to i32");
+        llvm::Value *r;
+        if (srcTy == i32Ty_) r = val;
+        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i32Ty_, "cast_i32");
+        else if (srcTy == i16Ty_) r = builder_.CreateSExt(val, i32Ty_, "cast_i32");
+        else if (srcTy == i8Ty_) {
+            r = isUnsignedLowLevel(val) ? builder_.CreateZExt(val, i32Ty_, "cast_i32")
+                                        : builder_.CreateSExt(val, i32Ty_, "cast_i32");
+        }
+        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_i32");
+        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToSI(val, i32Ty_, "cast_i32");
+        else if (srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i32Ty_, "cast_i32");
+        else codegenError("cannot cast to i32");
+        return withMeta(r, "i32");
     }
     if (target == "i16") {
-        if (srcTy == i16Ty_) return val;
-        if (srcTy == i64Ty_) return builder_.CreateTrunc(val, i16Ty_, "cast_i16");
-        if (srcTy == i32Ty_) return builder_.CreateTrunc(val, i16Ty_, "cast_i16");
-        if (srcTy == i8Ty_)  return builder_.CreateSExt(val, i16Ty_, "cast_i16");
-        if (srcTy == i1Ty_)  return builder_.CreateZExt(val, i16Ty_, "cast_i16");
-        if (srcTy->isDoubleTy()) return builder_.CreateFPToSI(val, i16Ty_, "cast_i16");
-        if (srcTy == f32Ty_) return builder_.CreateFPToSI(val, i16Ty_, "cast_i16");
-        codegenError("cannot cast to i16");
+        llvm::Value *r;
+        if (srcTy == i16Ty_) r = val;
+        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_i16");
+        else if (srcTy == i32Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_i16");
+        else if (srcTy == i8Ty_) {
+            r = isUnsignedLowLevel(val) ? builder_.CreateZExt(val, i16Ty_, "cast_i16")
+                                        : builder_.CreateSExt(val, i16Ty_, "cast_i16");
+        }
+        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i16Ty_, "cast_i16");
+        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToSI(val, i16Ty_, "cast_i16");
+        else if (srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i16Ty_, "cast_i16");
+        else codegenError("cannot cast to i16");
+        return withMeta(r, "i16");
+    }
+    if (target == "i8") {
+        llvm::Value *r;
+        if (srcTy == i8Ty_) r = val;
+        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_i8");
+        else if (srcTy == i32Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_i8");
+        else if (srcTy == i16Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_i8");
+        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i8Ty_, "cast_i8");
+        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToSI(val, i8Ty_, "cast_i8");
+        else if (srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i8Ty_, "cast_i8");
+        else codegenError("cannot cast to i8");
+        return withMeta(r, "i8");
+    }
+    if (target == "i64") {
+        llvm::Value *r;
+        if (srcTy == i64Ty_) r = val;
+        else if (srcTy == i32Ty_) {
+            r = isUnsignedLowLevel(val) ? builder_.CreateZExt(val, i64Ty_, "cast_i64")
+                                        : builder_.CreateSExt(val, i64Ty_, "cast_i64");
+        }
+        else if (srcTy == i16Ty_) {
+            r = isUnsignedLowLevel(val) ? builder_.CreateZExt(val, i64Ty_, "cast_i64")
+                                        : builder_.CreateSExt(val, i64Ty_, "cast_i64");
+        }
+        else if (srcTy == i8Ty_) {
+            r = isUnsignedLowLevel(val) ? builder_.CreateZExt(val, i64Ty_, "cast_i64")
+                                        : builder_.CreateSExt(val, i64Ty_, "cast_i64");
+        }
+        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_i64");
+        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToSI(val, i64Ty_, "cast_i64");
+        else if (srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i64Ty_, "cast_i64");
+        else codegenError("cannot cast to i64");
+        return withMeta(r, "i64");
+    }
+    if (target == "u8") {
+        llvm::Value *r;
+        if (srcTy == i8Ty_) r = val;
+        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_u8");
+        else if (srcTy == i32Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_u8");
+        else if (srcTy == i16Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_u8");
+        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i8Ty_, "cast_u8");
+        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToUI(val, i8Ty_, "cast_u8");
+        else if (srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i8Ty_, "cast_u8");
+        else codegenError("cannot cast to u8");
+        return withMeta(r, "u8");
+    }
+    if (target == "u16") {
+        llvm::Value *r;
+        if (srcTy == i16Ty_) r = val;
+        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_u16");
+        else if (srcTy == i32Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_u16");
+        else if (srcTy == i8Ty_) r = builder_.CreateZExt(val, i16Ty_, "cast_u16");
+        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i16Ty_, "cast_u16");
+        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToUI(val, i16Ty_, "cast_u16");
+        else if (srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i16Ty_, "cast_u16");
+        else codegenError("cannot cast to u16");
+        return withMeta(r, "u16");
+    }
+    if (target == "u32") {
+        llvm::Value *r;
+        if (srcTy == i32Ty_) r = val;
+        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i32Ty_, "cast_u32");
+        else if (srcTy == i16Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_u32");
+        else if (srcTy == i8Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_u32");
+        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_u32");
+        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToUI(val, i32Ty_, "cast_u32");
+        else if (srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i32Ty_, "cast_u32");
+        else codegenError("cannot cast to u32");
+        return withMeta(r, "u32");
+    }
+    if (target == "u64") {
+        llvm::Value *r;
+        if (srcTy == i64Ty_) r = val;
+        else if (srcTy == i32Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
+        else if (srcTy == i16Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
+        else if (srcTy == i8Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
+        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
+        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToUI(val, i64Ty_, "cast_u64");
+        else if (srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i64Ty_, "cast_u64");
+        else codegenError("cannot cast to u64");
+        return withMeta(r, "u64");
     }
     if (target == "f32") {
         if (srcTy == f32Ty_) return val;
         if (srcTy->isDoubleTy()) return builder_.CreateFPTrunc(val, f32Ty_, "cast_f32");
-        if (srcTy == i64Ty_) return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
-        if (srcTy == i32Ty_) return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
-        if (srcTy == i16Ty_) return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
+        if (srcTy == i64Ty_) {
+            if (isUnsignedLowLevel(val)) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
+            return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
+        }
+        if (srcTy == i32Ty_) {
+            if (isUnsignedLowLevel(val)) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
+            return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
+        }
+        if (srcTy == i16Ty_) {
+            if (isUnsignedLowLevel(val)) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
+            return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
+        }
         if (srcTy == i8Ty_)  return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
         if (srcTy == i1Ty_)  return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
         codegenError("cannot cast to f32");

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -427,6 +427,9 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
                 channel_element_types_[alloca] = resolveType(inner);
             }
             registerResourceByTypeName(ptype, alloca);
+            // Track low-level type metadata for parameters
+            if (isLowLevelTypeName(ptype))
+                low_level_type_names_[alloca] = ptype;
             // Track fn type info and constraint check (shared alias resolution)
             {
                 std::string resolvedPtype = resolveTypeAlias(ptype);
@@ -745,6 +748,10 @@ void CodeGen::instantiateGenericEnum(const std::string &fullName, const std::str
 // ===== Generic function type inference =====
 
 std::string CodeGen::reverseResolveType(llvm::Value *val) {
+    // Check low-level type metadata first (resolves ambiguous LLVM types)
+    std::string llName = getLowLevelTypeName(val);
+    if (!llName.empty()) return llName;
+
     llvm::Type *ty = val->getType();
     if (ty == i64Ty_) return "int";
     if (ty == f64Ty_) return "float";
@@ -944,6 +951,9 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
                 if (vTy) map_value_types_[alloca] = vTy;
             }
             registerResourceByTypeName(ptype, alloca);
+            // Track low-level type metadata for parameters
+            if (isLowLevelTypeName(ptype))
+                low_level_type_names_[alloca] = ptype;
             {
                 std::string resolvedPtype = resolveTypeAlias(ptype);
                 if (resolvedPtype.size() > 3 && resolvedPtype.substr(0, 3) == "fn(")

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -154,29 +154,60 @@ void CodeGen::emitVarDecl(const std::string &name,
             llvm::Type *annotTy = resolveType(*type_annotation);
             if (annotTy != newTy) {
                 if (annotTy == i8Ty_ && newTy == i64Ty_) {
-                    if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                        int64_t v = ci->getSExtValue();
-                        if (v < 0 || v > 255)
-                            codegenError(
-                                "byte value out of range (0-255): " + std::to_string(v));
+                    const std::string &ann = *type_annotation;
+                    if (ann == "i8") {
+                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
+                            int64_t v = ci->getSExtValue();
+                            if (v < INT8_MIN || v > INT8_MAX)
+                                codegenError(
+                                    "i8 value out of range: " + std::to_string(v));
+                        }
+                    } else {
+                        // byte or u8: unsigned 0-255 range
+                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
+                            int64_t v = ci->getSExtValue();
+                            if (v < 0 || v > 255)
+                                codegenError(
+                                    ann + " value out of range (0-255): " + std::to_string(v));
+                        }
                     }
-                    val = builder_.CreateTrunc(val, i8Ty_, "bytetrunc");
+                    val = builder_.CreateTrunc(val, i8Ty_, "i8trunc");
                     newTy = i8Ty_;
                 } else if (annotTy == i32Ty_ && newTy == i64Ty_) {
-                    if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                        int64_t v = ci->getSExtValue();
-                        if (v < INT32_MIN || v > INT32_MAX)
-                            codegenError(
-                                "i32 value out of range: " + std::to_string(v));
+                    const std::string &ann = *type_annotation;
+                    if (ann == "u32") {
+                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
+                            int64_t v = ci->getSExtValue();
+                            if (v < 0 || v > (int64_t)UINT32_MAX)
+                                codegenError(
+                                    "u32 value out of range: " + std::to_string(v));
+                        }
+                    } else {
+                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
+                            int64_t v = ci->getSExtValue();
+                            if (v < INT32_MIN || v > INT32_MAX)
+                                codegenError(
+                                    ann + " value out of range: " + std::to_string(v));
+                        }
                     }
                     val = builder_.CreateTrunc(val, i32Ty_, "i32trunc");
                     newTy = i32Ty_;
                 } else if (annotTy == i16Ty_ && newTy == i64Ty_) {
-                    if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                        int64_t v = ci->getSExtValue();
-                        if (v < INT16_MIN || v > INT16_MAX)
-                            codegenError(
-                                "i16 value out of range: " + std::to_string(v));
+                    const std::string &ann = *type_annotation;
+                    if (ann == "u16") {
+                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
+                            int64_t v = ci->getSExtValue();
+                            if (v < 0 || v > (int64_t)UINT16_MAX)
+                                codegenError(
+                                    "u16 value out of range: " + std::to_string(v));
+                        }
+                    } else {
+                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
+                            int64_t v = ci->getSExtValue();
+                            if (v < INT16_MIN || v > INT16_MAX)
+                                codegenError(
+                                    ann + " value out of range: " + std::to_string(v));
+                        }
                     }
                     val = builder_.CreateTrunc(val, i16Ty_, "i16trunc");
                     newTy = i16Ty_;
@@ -218,6 +249,18 @@ void CodeGen::emitVarDecl(const std::string &name,
 
     llvm::AllocaInst *ptr = getOrCreateVar(name, newTy);
     builder_.CreateStore(val, ptr);
+
+    // Track low-level type metadata
+    if (type_annotation) {
+        const std::string &ann = *type_annotation;
+        if (isLowLevelTypeName(ann))
+            low_level_type_names_[ptr] = ann;
+    } else {
+        // Propagate metadata from initializer expression (e.g., y = x as u32)
+        std::string valName = getLowLevelTypeName(val);
+        if (!valName.empty())
+            low_level_type_names_[ptr] = valName;
+    }
 
     // Track type constraint for reassignment checks
     if (constraint)

--- a/tests/spec/low_level_types.test.ry
+++ b/tests/spec/low_level_types.test.ry
@@ -220,3 +220,251 @@ describe("low-level type print", fn():
     expect(s).to_eq("2.5")
   )
 )
+
+# ===== Phase 2: i8, i64, u8, u16, u32, u64 =====
+
+describe("i8 type", fn():
+  it("declaration with annotation", fn():
+    x: i8 = 42
+    expect(x as int).to_eq(42)
+  )
+  it("negative value", fn():
+    x: i8 = -10
+    expect(x as int).to_eq(-10)
+  )
+  it("addition", fn():
+    a: i8 = 10
+    b: i8 = 20
+    c = a + b
+    expect(c as int).to_eq(30)
+  )
+  it("signed division", fn():
+    a: i8 = -7
+    b: i8 = 2
+    c = a / b
+    expect(c as int).to_eq(-3)
+  )
+  it("signed comparison", fn():
+    a: i8 = -1
+    b: i8 = 1
+    expect(a < b).to_be_true()
+  )
+  it("string conversion", fn():
+    x: i8 = -5
+    s = x as str
+    expect(s).to_eq("-5")
+  )
+)
+
+describe("i64 type", fn():
+  it("declaration with annotation", fn():
+    x: i64 = 100000
+    expect(x as int).to_eq(100000)
+  )
+  it("negative value", fn():
+    x: i64 = -100000
+    expect(x as int).to_eq(-100000)
+  )
+  it("addition", fn():
+    a: i64 = 1000
+    b: i64 = 2000
+    c = a + b
+    expect(c as int).to_eq(3000)
+  )
+  it("signed division", fn():
+    a: i64 = -7
+    b: i64 = 2
+    c = a / b
+    expect(c as int).to_eq(-3)
+  )
+  it("string conversion", fn():
+    x: i64 = -999
+    s = x as str
+    expect(s).to_eq("-999")
+  )
+)
+
+describe("u8 type", fn():
+  it("declaration with annotation", fn():
+    x: u8 = 200
+    expect(x as int).to_eq(200)
+  )
+  it("addition", fn():
+    a: u8 = 100
+    b: u8 = 50
+    c = a + b
+    expect(c as int).to_eq(150)
+  )
+  it("unsigned division", fn():
+    a: u8 = 200
+    b: u8 = 3
+    c = a / b
+    expect(c as int).to_eq(66)
+  )
+  it("unsigned comparison", fn():
+    a: u8 = 200
+    b: u8 = 100
+    expect(a > b).to_be_true()
+  )
+  it("string conversion", fn():
+    x: u8 = 255
+    s = x as str
+    expect(s).to_eq("255")
+  )
+)
+
+describe("u16 type", fn():
+  it("declaration with annotation", fn():
+    x: u16 = 60000
+    expect(x as int).to_eq(60000)
+  )
+  it("addition", fn():
+    a: u16 = 10000
+    b: u16 = 20000
+    c = a + b
+    expect(c as int).to_eq(30000)
+  )
+  it("unsigned division", fn():
+    a: u16 = 50000
+    b: u16 = 3
+    c = a / b
+    expect(c as int).to_eq(16666)
+  )
+  it("unsigned comparison", fn():
+    a: u16 = 60000
+    b: u16 = 30000
+    expect(a > b).to_be_true()
+  )
+  it("string conversion", fn():
+    x: u16 = 65535
+    s = x as str
+    expect(s).to_eq("65535")
+  )
+)
+
+describe("u32 type", fn():
+  it("declaration with annotation", fn():
+    x: u32 = 3000000000
+    expect(x as int).to_eq(3000000000)
+  )
+  it("addition", fn():
+    a: u32 = 1000000
+    b: u32 = 2000000
+    c = a + b
+    expect(c as int).to_eq(3000000)
+  )
+  it("unsigned division", fn():
+    a: u32 = 3000000000
+    b: u32 = 7
+    c = a / b
+    expect(c as int).to_eq(428571428)
+  )
+  it("unsigned comparison", fn():
+    a: u32 = 3000000000
+    b: u32 = 1000000000
+    expect(a > b).to_be_true()
+  )
+  it("string conversion", fn():
+    x: u32 = 4000000000
+    s = x as str
+    expect(s).to_eq("4000000000")
+  )
+)
+
+describe("u64 type", fn():
+  it("declaration with annotation", fn():
+    x: u64 = 1000000
+    expect(x as int).to_eq(1000000)
+  )
+  it("addition", fn():
+    a: u64 = 100000
+    b: u64 = 200000
+    c = a + b
+    expect(c as int).to_eq(300000)
+  )
+  it("unsigned division", fn():
+    a: u64 = 1000000
+    b: u64 = 3
+    c = a / b
+    expect(c as int).to_eq(333333)
+  )
+  it("string conversion", fn():
+    x: u64 = 999999
+    s = x as str
+    expect(s).to_eq("999999")
+  )
+)
+
+describe("Phase 2 casts", fn():
+  it("int to i8", fn():
+    x = 42
+    y = x as i8
+    expect(y as int).to_eq(42)
+  )
+  it("int to i64", fn():
+    x = 42
+    y = x as i64
+    expect(y as int).to_eq(42)
+  )
+  it("int to u8", fn():
+    x = 200
+    y = x as u8
+    expect(y as int).to_eq(200)
+  )
+  it("int to u16", fn():
+    x = 60000
+    y = x as u16
+    expect(y as int).to_eq(60000)
+  )
+  it("int to u32", fn():
+    x = 3000000000
+    y = x as u32
+    expect(y as int).to_eq(3000000000)
+  )
+  it("int to u64", fn():
+    x = 42
+    y = x as u64
+    expect(y as int).to_eq(42)
+  )
+  it("u32 to float", fn():
+    x: u32 = 42
+    expect(x as float).to_eq(42.0)
+  )
+  it("u8 to u32", fn():
+    x: u8 = 200
+    y = x as u32
+    expect(y as int).to_eq(200)
+  )
+  it("u32 to u8 (truncation)", fn():
+    x: u32 = 300
+    y = x as u8
+    expect(y as int).to_eq(44)
+  )
+  it("i32 to u32", fn():
+    x: i32 = 42
+    y = x as u32
+    expect(y as int).to_eq(42)
+  )
+)
+
+describe("Phase 2 function with low-level params", fn():
+  fn add_u32(a: u32, b: u32) -> u32:
+    return a + b
+
+  it("function with u32 params and return", fn():
+    x: u32 = 100
+    y: u32 = 200
+    z = add_u32(x, y)
+    expect(z as int).to_eq(300)
+  )
+
+  fn negate_i8(x: i8) -> i8:
+    zero: i8 = 0
+    return zero - x
+
+  it("function with i8 params and return", fn():
+    x: i8 = 5
+    y = negate_i8(x)
+    expect(y as int).to_eq(-5)
+  )
+)


### PR DESCRIPTION
## Summary

- Add 6 new low-level numeric types: `u8`, `u16`, `u32`, `u64` (unsigned) and `i8`, `i64` (signed)
- Introduce `low_level_type_names_` metadata map (`Value* → string`) to distinguish types sharing the same LLVM IR representation (`byte`/`i8`/`u8` all map to LLVM `i8`; `int`/`i64`/`u64` all map to LLVM `i64`)
- Unsigned types use correct LLVM instructions: `UDiv`/`URem` for division, `ICMP_ULT`/`ULE`/`UGT`/`UGE` for comparison, `LShr` for `>>`
- Signed types retain: `SDiv`/`SRem`, `ICMP_SLT`/`SLE`/`SGT`/`SGE`, `AShr` for `>>`
- Add cast support for all new types with correct `SExt`/`ZExt`/`FPToSI`/`FPToUI` selection
- Propagate type metadata through arithmetic results, casts, variable declarations, function parameters, and return values
- Update docs (`types.md`, tutorial) with new type tables, cast rules, and signed/unsigned behavior

## Test plan

- [x] 42 new Ry tests added to `tests/spec/low_level_types.test.ry` (81 total, all pass)
- [x] All 972 C++ tests pass
- [x] All existing Ry spec tests pass (verified individually)

Closes #288