### PR TITLE
feat: add numeric literal suffixes (42i32, 3.14f32)

### DIFF
--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -26,15 +26,15 @@
 | Int literal | i64 | `42`, `0 \| 1` | Int literal type (value constraint) |
 | String literal | ptr | `"N" \| "S"` | String literal type (value constraint) |
 | Range | i64 | `1..12`, `-10..10` | Range type (inclusive integer range constraint) |
-| `i8` | i8 | `x: i8 = 42` | 8-bit signed integer (low-level, no implicit conversion) |
-| `i16` | i16 | `x: i16 = 100` | 16-bit signed integer (low-level, no implicit conversion) |
-| `i32` | i32 | `x: i32 = 42` | 32-bit signed integer (low-level, no implicit conversion) |
-| `i64` | i64 | `x: i64 = 100` | 64-bit signed integer (low-level, no implicit conversion) |
-| `u8` | i8 | `x: u8 = 200` | 8-bit unsigned integer (low-level, no implicit conversion) |
-| `u16` | i16 | `x: u16 = 60000` | 16-bit unsigned integer (low-level, no implicit conversion) |
-| `u32` | i32 | `x: u32 = 3000000000` | 32-bit unsigned integer (low-level, no implicit conversion) |
-| `u64` | i64 | `x: u64 = 100` | 64-bit unsigned integer (low-level, no implicit conversion) |
-| `f32` | float | `x: f32 = 3.14` | 32-bit floating-point (low-level, no implicit conversion) |
+| `i8` | i8 | `x: i8 = 42`, `x = 42i8` | 8-bit signed integer (low-level, no implicit conversion) |
+| `i16` | i16 | `x: i16 = 100`, `x = 100i16` | 16-bit signed integer (low-level, no implicit conversion) |
+| `i32` | i32 | `x: i32 = 42`, `x = 42i32` | 32-bit signed integer (low-level, no implicit conversion) |
+| `i64` | i64 | `x: i64 = 100`, `x = 100i64` | 64-bit signed integer (low-level, no implicit conversion) |
+| `u8` | i8 | `x: u8 = 200`, `x = 200u8` | 8-bit unsigned integer (low-level, no implicit conversion) |
+| `u16` | i16 | `x: u16 = 60000`, `x = 60000u16` | 16-bit unsigned integer (low-level, no implicit conversion) |
+| `u32` | i32 | `x: u32 = 3000000000`, `x = 100u32` | 32-bit unsigned integer (low-level, no implicit conversion) |
+| `u64` | i64 | `x: u64 = 100`, `x = 100u64` | 64-bit unsigned integer (low-level, no implicit conversion) |
+| `f32` | float | `x: f32 = 3.14`, `x = 3.14f32` | 32-bit floating-point (low-level, no implicit conversion) |
 
 ## Type Annotation Syntax
 
@@ -482,6 +482,7 @@ A union type is represented as `{ i64 tag, [N x i8] data }`. The `tag` indicates
 - **Variable types are fixed at declaration** -- A variable declared as `int` cannot be reassigned a `float` value.
 - **Bitwise operations are for `int` only** -- Applying bitwise operations to `float` or `bool` causes a compile error.
 - **Non-`bool` types can be used in conditions** -- `if` conditions accept `int` (0 = false, non-zero = true) and other types besides `bool`.
+- **Numeric literal suffixes** -- Low-level types can be specified via literal suffixes: `42i32`, `255u8`, `3.14f32`, `0xFFu8`, `0b1010u8`. An integer literal with a float suffix (`42f32`) produces a float value. A float literal with an integer suffix (`3.14i32`) is a compile error. Out-of-range values (e.g., `256u8`, `129i8`) are also compile errors.
 - **Low-level numeric types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `f32`) have no implicit conversions** -- Mixing low-level types with each other or with high-level types (`int`, `float`) causes a compile error. Use explicit `as` casts. The `/` operator on low-level integers performs integer division (like Rust), not float division. Signed types use `SDiv`/`SRem`, unsigned types use `UDiv`/`URem`.
 - **Signed vs unsigned** -- Signed types (`i8`, `i16`, `i32`, `i64`) use signed comparison (`ICMP_SLT` etc.) and arithmetic right shift (`AShr`). Unsigned types (`u8`, `u16`, `u32`, `u64`) use unsigned comparison (`ICMP_ULT` etc.) and logical right shift (`LShr`). The `>>>` operator always performs logical shift regardless of signedness.
 - **Low-level integer overflow wraps around** -- Arithmetic on low-level integer types uses two's complement wrapping on overflow (signed) or modular arithmetic (unsigned). For example, `i32` max value `2147483647 + 1` wraps to `-2147483648`. This matches C behavior. Use the high-level `int` type (64-bit) if overflow is a concern.

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -39,8 +39,8 @@ inline bool hasDirective(const std::vector<Directive> &directives, std::string_v
     return false;
 }
 
-struct NumberExpr   { int64_t value; };
-struct FloatExpr    { double value; };
+struct NumberExpr   { int64_t value; std::string suffix; };
+struct FloatExpr    { double value;  std::string suffix; };
 struct BoolExpr     { bool value; };
 struct StringExpr   { std::string value; };
 struct VariableExpr { std::string name; };

--- a/include/ry/lexer.hpp
+++ b/include/ry/lexer.hpp
@@ -159,4 +159,5 @@ private:
 
     Token readToken();
     Token readFStringSegment(bool isStart);
+    void tryConsumeNumericSuffix(TokenKind &kind);
 };

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -4,7 +4,10 @@
 #include "ry/ast.hpp"
 #include "ry/source_manager.hpp"
 
+#include <cctype>
+#include <cstring>
 #include <initializer_list>
+#include <utility>
 
 class Parser {
 public:
@@ -96,3 +99,31 @@ private:
     ExprPtr parseSpawnExpr();
     ExprPtr parseAwaitExpr();
 };
+
+// --- Shared numeric literal helpers ---
+
+inline constexpr const char *kNumericSuffixes[] = {
+    "i8", "i16", "i32", "i64",
+    "u8", "u16", "u32", "u64",
+    "f32", "f64"
+};
+
+inline std::pair<std::string, std::string> splitNumericSuffix(const std::string &s) {
+    for (const char *suf : kNumericSuffixes) {
+        size_t len = std::strlen(suf);
+        if (s.size() > len && s.compare(s.size() - len, len, suf) == 0) {
+            char before = s[s.size() - len - 1];
+            if (std::isdigit(before))
+                return {s.substr(0, s.size() - len), suf};
+        }
+    }
+    return {s, ""};
+}
+
+inline int64_t parseIntLiteral(const std::string &s) {
+    if (s.size() > 2 && s[0] == '0') {
+        if (s[1] == 'x' || s[1] == 'X') return std::stoll(s, nullptr, 16);
+        if (s[1] == 'b' || s[1] == 'B') return std::stoll(s.substr(2), nullptr, 2);
+    }
+    return std::stoll(s);
+}

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1,5 +1,36 @@
 #include "ry/codegen.hpp"
 #include "ry/diagnostic.hpp"
+#include <climits>
+
+// Range check for suffixed integer literals.
+// Since `-128i8` is parsed as UnaryExpr("-", NumberExpr{128, "i8"}),
+// we allow positive values up to 2^(N-1) for signed types (= |MIN|).
+template<typename ErrorFn>
+static void validateIntRange(int64_t value, const std::string &suffix,
+                             ErrorFn error) {
+    if (suffix == "i8") {
+        if (value < INT8_MIN || value > (int64_t)(-((int64_t)INT8_MIN)))
+            error("i8 literal out of range: " + std::to_string(value));
+    } else if (suffix == "i16") {
+        if (value < INT16_MIN || value > (int64_t)(-((int64_t)INT16_MIN)))
+            error("i16 literal out of range: " + std::to_string(value));
+    } else if (suffix == "i32") {
+        if (value < INT32_MIN || value > (int64_t)(-((int64_t)INT32_MIN)))
+            error("i32 literal out of range: " + std::to_string(value));
+    } else if (suffix == "u8") {
+        if (value < 0 || value > UINT8_MAX)
+            error("u8 literal out of range: " + std::to_string(value));
+    } else if (suffix == "u16") {
+        if (value < 0 || value > UINT16_MAX)
+            error("u16 literal out of range: " + std::to_string(value));
+    } else if (suffix == "u32") {
+        if (value < 0 || value > (int64_t)UINT32_MAX)
+            error("u32 literal out of range: " + std::to_string(value));
+    } else if (suffix == "u64") {
+        if (value < 0)
+            error("u64 literal out of range: " + std::to_string(value));
+    }
+}
 
 llvm::Value *CodeGen::emitExpr(const ExprNode &node) {
     if (node.loc.isValid()) current_loc_ = node.loc;
@@ -8,11 +39,26 @@ llvm::Value *CodeGen::emitExpr(const ExprNode &node) {
 }
 
 llvm::Value *CodeGen::emitExprVariant(const NumberExpr &e) {
-    return llvm::ConstantInt::get(i64Ty_, e.value, true);
+    if (e.suffix.empty())
+        return llvm::ConstantInt::get(i64Ty_, e.value, true);
+
+    validateIntRange(e.value, e.suffix,
+        [this](const std::string &msg) { codegenError(msg); });
+
+    llvm::Type *ty = resolveType(e.suffix);
+    bool isSigned = !isUnsignedLowLevelName(e.suffix);
+    auto *result = llvm::ConstantInt::get(ty, static_cast<uint64_t>(e.value), isSigned);
+    low_level_type_names_[result] = e.suffix;
+    return result;
 }
 
 llvm::Value *CodeGen::emitExprVariant(const FloatExpr &e) {
-    return llvm::ConstantFP::get(f64Ty_, e.value);
+    if (e.suffix.empty() || e.suffix == "f64")
+        return llvm::ConstantFP::get(f64Ty_, e.value);
+    // suffix == "f32"
+    auto *result = llvm::ConstantFP::get(f32Ty_, e.value);
+    low_level_type_names_[result] = "f32";
+    return result;
 }
 
 llvm::Value *CodeGen::emitExprVariant(const BoolExpr &e) {
@@ -69,8 +115,13 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<UnaryExpr> &e) {
         return val;
     }
     if (e->op == "-") {
-        if (val->getType()->isDoubleTy())
+        if (val->getType()->isDoubleTy() || val->getType()->isFloatTy())
             return builder_.CreateFNeg(val, "fneg");
+        // Check for unsigned suffix on the operand AST node
+        if (auto *ne = std::get_if<NumberExpr>(&e->operand->data)) {
+            if (isUnsignedLowLevelName(ne->suffix))
+                codegenError("cannot negate unsigned type '" + ne->suffix + "'");
+        }
         val = promoteToInt(val);
         return builder_.CreateNeg(val, "neg");
     }

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -271,9 +271,9 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
     return std::visit([&](const auto &v) -> llvm::Type* {
         using T = std::decay_t<decltype(v)>;
         if constexpr (std::is_same_v<T, NumberExpr>) {
-            return i64Ty_;
+            return v.suffix.empty() ? i64Ty_ : resolveType(v.suffix);
         } else if constexpr (std::is_same_v<T, FloatExpr>) {
-            return f64Ty_;
+            return v.suffix.empty() ? f64Ty_ : resolveType(v.suffix);
         } else if constexpr (std::is_same_v<T, BoolExpr>) {
             return i1Ty_;
         } else if constexpr (std::is_same_v<T, StringExpr>) {

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -214,9 +214,9 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
         using T = std::decay_t<decltype(v)>;
 
         if constexpr (std::is_same_v<T, NumberExpr>) {
-            return std::to_string(v.value);
+            return std::to_string(v.value) + v.suffix;
         } else if constexpr (std::is_same_v<T, FloatExpr>) {
-            return formatFloat(v.value);
+            return formatFloat(v.value) + v.suffix;
         } else if constexpr (std::is_same_v<T, BoolExpr>) {
             return v.value ? "true" : "false";
         } else if constexpr (std::is_same_v<T, StringExpr>) {

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -1,5 +1,6 @@
 #include "ry/lexer.hpp"
 #include <cctype>
+#include <cstring>
 #include <stdexcept>
 
 Token Lexer::next() {
@@ -37,6 +38,33 @@ void Lexer::restoreState(State s) {
     pending_ = std::move(s.pending);
     current_ = std::move(s.current);
     fstring_brace_depth_ = s.fstring_brace_depth;
+}
+
+void Lexer::tryConsumeNumericSuffix(TokenKind &kind) {
+    if (pos_ >= src_.size()) return;
+    char ch = src_[pos_];
+    if (ch != 'i' && ch != 'u' && ch != 'f') return;
+
+    static const char *suffixes[] = {
+        "i8", "i16", "i32", "i64",
+        "u8", "u16", "u32", "u64",
+        "f32", "f64"
+    };
+    for (const char *suf : suffixes) {
+        size_t len = std::strlen(suf);
+        if (pos_ + len > src_.size()) continue;
+        if (src_.compare(pos_, len, suf) != 0) continue;
+        // Avoid matching partial identifiers like `42i32x`
+        if (pos_ + len < src_.size()) {
+            char after = src_[pos_ + len];
+            if (std::isalnum(after) || after == '_') continue;
+        }
+        pos_ += len;
+        col_ += static_cast<int>(len);
+        if (suf[0] == 'f' && kind == TokenKind::Number)
+            kind = TokenKind::Float;
+        return;
+    }
 }
 
 Token Lexer::readToken() {
@@ -391,6 +419,7 @@ Token Lexer::readToken() {
 
     if (std::isdigit(c)) {
         size_t start = pos_;
+        TokenKind numKind = TokenKind::Number;
         if (c == '0' && pos_ + 1 < src_.size()) {
             char next = src_[pos_ + 1];
             if (next == 'x' || next == 'X') {
@@ -398,14 +427,16 @@ Token Lexer::readToken() {
                 if (pos_ >= src_.size() || !std::isxdigit(src_[pos_]))
                     throw std::runtime_error("line " + std::to_string(line_) + ": invalid hex literal");
                 while (pos_ < src_.size() && std::isxdigit(src_[pos_])) { ++pos_; ++col_; }
-                return {TokenKind::Number, std::string(src_, start, pos_ - start), line_, startCol};
+                tryConsumeNumericSuffix(numKind);
+                return {numKind, std::string(src_, start, pos_ - start), line_, startCol};
             }
             if (next == 'b' || next == 'B') {
                 pos_ += 2; col_ += 2;
                 if (pos_ >= src_.size() || (src_[pos_] != '0' && src_[pos_] != '1'))
                     throw std::runtime_error("line " + std::to_string(line_) + ": invalid binary literal");
                 while (pos_ < src_.size() && (src_[pos_] == '0' || src_[pos_] == '1')) { ++pos_; ++col_; }
-                return {TokenKind::Number, std::string(src_, start, pos_ - start), line_, startCol};
+                tryConsumeNumericSuffix(numKind);
+                return {numKind, std::string(src_, start, pos_ - start), line_, startCol};
             }
         }
         while (pos_ < src_.size() && std::isdigit(src_[pos_])) { ++pos_; ++col_; }
@@ -413,9 +444,12 @@ Token Lexer::readToken() {
             pos_ + 1 < src_.size() && std::isdigit(src_[pos_ + 1])) {
             ++pos_; ++col_;
             while (pos_ < src_.size() && std::isdigit(src_[pos_])) { ++pos_; ++col_; }
-            return {TokenKind::Float, std::string(src_, start, pos_ - start), line_, startCol};
+            numKind = TokenKind::Float;
+            tryConsumeNumericSuffix(numKind);
+            return {numKind, std::string(src_, start, pos_ - start), line_, startCol};
         }
-        return {TokenKind::Number, std::string(src_, start, pos_ - start), line_, startCol};
+        tryConsumeNumericSuffix(numKind);
+        return {numKind, std::string(src_, start, pos_ - start), line_, startCol};
     }
 
     if (std::isalpha(c) || c == '_') {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -488,7 +488,7 @@ StmtNode Parser::parseStatement() {
         Token opTok = lex_.next(); // consume ++ or --
         std::string op = (opTok.kind == TokenKind::PlusPlus) ? "+" : "-";
         auto one = std::make_unique<ExprNode>();
-        one->data = NumberExpr{1};
+        one->data = NumberExpr{1, ""};
         one->loc = locFromToken(first);
         return makeDesugarAssign(first, opTok, op, std::move(one));
     } else if (next.kind == TokenKind::LParen) {

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -31,13 +31,6 @@ static bool isPascalCase(const std::string &name) {
     return std::regex_match(name, pattern);
 }
 
-static int64_t parseIntLiteral(const std::string& s) {
-    if (s.size() > 2 && s[0] == '0') {
-        if (s[1] == 'x' || s[1] == 'X') return std::stoll(s, nullptr, 16);
-        if (s[1] == 'b' || s[1] == 'B') return std::stoll(s.substr(2), nullptr, 2);
-    }
-    return std::stoll(s);
-}
 
 StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool is_async) {
     Token fnTok = lex_.next(); // consume 'fn'
@@ -650,14 +643,19 @@ Pattern Parser::parsePattern() {
     // Literal patterns: number, float, string, true, false
     if (t.kind == TokenKind::Number) {
         lex_.next();
+        auto [numStr, suffix] = splitNumericSuffix(t.value);
         auto node = std::make_unique<ExprNode>();
-        node->data = NumberExpr{parseIntLiteral(t.value)};
+        if (suffix == "f32" || suffix == "f64")
+            node->data = FloatExpr{std::stod(numStr), suffix};
+        else
+            node->data = NumberExpr{parseIntLiteral(numStr), suffix};
         return LiteralPattern{std::move(node)};
     }
     if (t.kind == TokenKind::Float) {
         lex_.next();
+        auto [numStr, suffix] = splitNumericSuffix(t.value);
         auto node = std::make_unique<ExprNode>();
-        node->data = FloatExpr{std::stod(t.value)};
+        node->data = FloatExpr{std::stod(numStr), suffix};
         return LiteralPattern{std::move(node)};
     }
     if (t.kind == TokenKind::String) {
@@ -679,14 +677,19 @@ Pattern Parser::parsePattern() {
         Token num = lex_.peek();
         if (num.kind == TokenKind::Number) {
             lex_.next();
+            auto [numStr, suffix] = splitNumericSuffix(num.value);
             auto node = std::make_unique<ExprNode>();
-            node->data = NumberExpr{-parseIntLiteral(num.value)};
+            if (suffix == "f32" || suffix == "f64")
+                node->data = FloatExpr{-std::stod(numStr), suffix};
+            else
+                node->data = NumberExpr{-parseIntLiteral(numStr), suffix};
             return LiteralPattern{std::move(node)};
         }
         if (num.kind == TokenKind::Float) {
             lex_.next();
+            auto [numStr, suffix] = splitNumericSuffix(num.value);
             auto node = std::make_unique<ExprNode>();
-            node->data = FloatExpr{-std::stod(num.value)};
+            node->data = FloatExpr{-std::stod(numStr), suffix};
             return LiteralPattern{std::move(node)};
         }
         parseError(num.line, "expected number after '-' in pattern");

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -11,14 +11,6 @@ static void coerceFirstArgToString(std::vector<ExprPtr> &args) {
     }
 }
 
-static int64_t parseIntLiteral(const std::string& s) {
-    if (s.size() > 2 && s[0] == '0') {
-        if (s[1] == 'x' || s[1] == 'X') return std::stoll(s, nullptr, 16);
-        if (s[1] == 'b' || s[1] == 'B') return std::stoll(s.substr(2), nullptr, 2);
-    }
-    return std::stoll(s);
-}
-
 ExprPtr Parser::parseLogicalOr()  { return parseBinaryLeft(&Parser::parseLogicalAnd, {TokenKind::Or}); }
 
 ExprPtr Parser::parseTernary() {
@@ -225,15 +217,22 @@ ExprPtr Parser::parsePrimary() {
     }
     if (t.kind == TokenKind::Number) {
         lex_.next();
+        auto [numStr, suffix] = splitNumericSuffix(t.value);
         auto node = std::make_unique<ExprNode>();
-        node->data = NumberExpr{parseIntLiteral(t.value)};
+        if (suffix == "f32" || suffix == "f64")
+            node->data = FloatExpr{std::stod(numStr), suffix};
+        else
+            node->data = NumberExpr{parseIntLiteral(numStr), suffix};
         node->loc = locFromToken(t);
         return node;
     }
     if (t.kind == TokenKind::Float) {
         lex_.next();
+        auto [numStr, suffix] = splitNumericSuffix(t.value);
+        if (!suffix.empty() && suffix[0] != 'f')
+            parseError("cannot use integer suffix '" + suffix + "' on float literal");
         auto node = std::make_unique<ExprNode>();
-        node->data = FloatExpr{std::stod(t.value)};
+        node->data = FloatExpr{std::stod(numStr), suffix};
         node->loc = locFromToken(t);
         return node;
     }

--- a/tests/spec/numeric_literal_suffix.test.ry
+++ b/tests/spec/numeric_literal_suffix.test.ry
@@ -1,0 +1,113 @@
+describe("integer literal suffix", fn():
+  it("i32 suffix", fn():
+    x = 42i32
+    expect(x as int).to_eq(42)
+  )
+  it("i16 suffix", fn():
+    x = 100i16
+    expect(x as int).to_eq(100)
+  )
+  it("i8 suffix", fn():
+    x = 127i8
+    expect(x as int).to_eq(127)
+  )
+  it("i64 suffix", fn():
+    x = 1000i64
+    expect(x).to_eq(1000)
+  )
+  it("u8 suffix", fn():
+    x = 255u8
+    expect(x as int).to_eq(255)
+  )
+  it("u16 suffix", fn():
+    x = 1000u16
+    expect(x as int).to_eq(1000)
+  )
+  it("u32 suffix", fn():
+    x = 100u32
+    expect(x as int).to_eq(100)
+  )
+  it("u64 suffix", fn():
+    x = 100u64
+    expect(x as int).to_eq(100)
+  )
+  it("zero with suffix", fn():
+    x = 0i32
+    expect(x as int).to_eq(0)
+  )
+)
+
+describe("float literal suffix", fn():
+  it("f32 suffix on float", fn():
+    x = 3.14f32
+    expect(x as float > 3.0).to_eq(true)
+  )
+  it("f64 suffix on float", fn():
+    x = 3.14f64
+    expect(x > 3.0).to_eq(true)
+  )
+  it("integer with f32 suffix becomes float", fn():
+    x = 42f32
+    expect(x as float > 41.0).to_eq(true)
+  )
+)
+
+describe("hex and binary with suffix", fn():
+  it("hex with u8 suffix", fn():
+    x = 0xFFu8
+    expect(x as int).to_eq(255)
+  )
+  it("hex with i32 suffix", fn():
+    x = 0x1Fi32
+    expect(x as int).to_eq(31)
+  )
+  it("binary with u8 suffix", fn():
+    x = 0b1010u8
+    expect(x as int).to_eq(10)
+  )
+)
+
+describe("negative suffixed literals", fn():
+  it("negative i32", fn():
+    x = -1i32
+    expect(x as int).to_eq(-1)
+  )
+  it("negative i8", fn():
+    x = -128i8
+    expect(x as int).to_eq(-128)
+  )
+  it("negative i16", fn():
+    x = -100i16
+    expect(x as int).to_eq(-100)
+  )
+)
+
+describe("suffixed literal arithmetic", fn():
+  it("i32 addition", fn():
+    c = 10i32 + 20i32
+    expect(c as int).to_eq(30)
+  )
+  it("u8 addition", fn():
+    c = 100u8 + 50u8
+    expect(c as int).to_eq(150)
+  )
+  it("f32 addition", fn():
+    c = 1.5f32 + 2.5f32
+    expect(c as float > 3.9).to_eq(true)
+  )
+)
+
+describe("suffixed literal with annotation", fn():
+  it("matching annotation i32", fn():
+    x: i32 = 42i32
+    expect(x as int).to_eq(42)
+  )
+  it("matching annotation u8", fn():
+    x: u8 = 200u8
+    expect(x as int).to_eq(200)
+  )
+  it("matching annotation f32", fn():
+    x: f32 = 1.5f32
+    expect(x as float > 1.0).to_eq(true)
+  )
+)

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -412,6 +412,45 @@ TEST_F(CodeGenTest, LowLevelMixedTypeError) {
     EXPECT_THROW(runSource("a: i32 = 2\nb: i32 = 3\nc = a ** b"), std::runtime_error);
 }
 
+// ===== Numeric literal suffix =====
+
+TEST_F(CodeGenTest, NumericLiteralSuffix_i32) {
+    EXPECT_EQ(runSource("x = 42i32\nprint(x)"), "42\n");
+}
+
+TEST_F(CodeGenTest, NumericLiteralSuffix_u8) {
+    EXPECT_EQ(runSource("x = 255u8\nprint(x)"), "255\n");
+}
+
+TEST_F(CodeGenTest, NumericLiteralSuffix_f32) {
+    EXPECT_EQ(runSource("x = 3.14f32\nprint(x)"), "3.14\n");
+}
+
+TEST_F(CodeGenTest, NumericLiteralSuffix_IntWithF32) {
+    // Integer literal with f32 suffix becomes float
+    EXPECT_EQ(runSource("x = 42f32\nprint(x)"), "42\n");
+}
+
+TEST_F(CodeGenTest, NumericLiteralSuffix_Hex) {
+    EXPECT_EQ(runSource("x = 0xFFu8\nprint(x)"), "255\n");
+}
+
+TEST_F(CodeGenTest, NumericLiteralSuffix_Binary) {
+    EXPECT_EQ(runSource("x = 0b1010u8\nprint(x)"), "10\n");
+}
+
+TEST_F(CodeGenTest, NumericLiteralSuffix_Arithmetic) {
+    EXPECT_EQ(runSource("c = 10i32 + 20i32\nprint(c)"), "30\n");
+}
+
+TEST_F(CodeGenTest, NumericLiteralSuffix_OutOfRange) {
+    EXPECT_THROW(runSource("x = 256u8"), std::runtime_error);
+    EXPECT_THROW(runSource("x = -1u8"), std::runtime_error);
+    EXPECT_THROW(runSource("x = 129i8"), std::runtime_error);
+    EXPECT_THROW(runSource("x = -129i8"), std::runtime_error);
+    EXPECT_THROW(runSource("x = -1u32"), std::runtime_error);
+}
+
 // ===== Return type inference for named functions =====
 
 TEST_F(CodeGenTest, ReturnTypeInference_Int) {


### PR DESCRIPTION
## Summary

- 数値リテラルサフィックスを導入し、低レベル型を簡潔に指定可能にした
- 対応サフィックス: `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `f32`, `f64`
- レキサー・パーサー・AST・コード生成・フォーマッター全体を対応
- コンパイル時レンジチェック、unsigned リテラル negation エラー、f32 FNeg 対応
- 共通ヘルパーを `parser.hpp` に集約しコード重複を排除

## Examples

```python
x = 42i32         # i32 リテラル
y = 3.14f32       # f32 リテラル
z = 0xFFu8        # hex + u8 サフィックス
w = 0b1010u8      # binary + u8 サフィックス
n = 42f32         # int + f32 サフィックス → float
```

## Test plan

- [x] C++ テスト 980 passed (8 件の新規サフィックステスト含む)
- [x] Ry spec テスト 24 passed (`tests/spec/numeric_literal_suffix.test.ry`)
- [x] 既存 low-level types テスト 81 passed (リグレッションなし)
- [x] エラーケース: 範囲外 (`256u8`, `129i8`), unsigned negation (`-1u8`), float に integer suffix (`3.14i32`)

Closes #289