### PR TITLE
fix: prevent low_level_type_names_ corruption from LLVM ConstantInt sharing

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -274,6 +274,7 @@ private:
     bool isUnsignedLowLevel(llvm::Value *val) const;
     static bool isUnsignedLowLevelName(const std::string &name);
     static bool isLowLevelTypeName(const std::string &name);
+    static std::string getExprLowLevelSuffix(const ExprNode &node);
     bool isLowLevelIntTy(llvm::Type *ty) const;
     bool isLowLevelIntTy(llvm::Value *val) const;
     bool isLowLevelFloatTy(llvm::Type *ty) const;
@@ -319,9 +320,12 @@ private:
                                       llvm::Value *operand);
 
     // BinaryExpr sub-dispatchers (B2)
-    llvm::Value *emitComparisonOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs);
-    llvm::Value *emitBitwiseOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs);
-    llvm::Value *emitArithmeticOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs);
+    llvm::Value *emitComparisonOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
+                                   const std::string &llNameHint = "");
+    llvm::Value *emitBitwiseOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
+                                const std::string &llNameHint = "");
+    llvm::Value *emitArithmeticOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
+                                   const std::string &llNameHint = "");
     llvm::Value *emitAnyBinaryOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs);
     llvm::Value *emitAnyUnaryNeg(llvm::Value *operand);
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -248,6 +248,16 @@ bool CodeGen::isLowLevelTypeName(const std::string &name) {
            name == "u8" || name == "u16" || name == "u32" || name == "u64" || name == "f32";
 }
 
+std::string CodeGen::getExprLowLevelSuffix(const ExprNode &node) {
+    if (auto *ne = std::get_if<NumberExpr>(&node.data)) {
+        if (isLowLevelTypeName(ne->suffix)) return ne->suffix;
+    }
+    if (auto *fe = std::get_if<FloatExpr>(&node.data)) {
+        if (isLowLevelTypeName(fe->suffix)) return fe->suffix;
+    }
+    return "";
+}
+
 bool CodeGen::isLowLevelIntTy(llvm::Type *ty) const {
     return ty == i16Ty_ || ty == i32Ty_;
 }

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -48,7 +48,10 @@ llvm::Value *CodeGen::emitExprVariant(const NumberExpr &e) {
     llvm::Type *ty = resolveType(e.suffix);
     bool isSigned = !isUnsignedLowLevelName(e.suffix);
     auto *result = llvm::ConstantInt::get(ty, static_cast<uint64_t>(e.value), isSigned);
-    low_level_type_names_[result] = e.suffix;
+    // Do NOT set low_level_type_names_ on ConstantInt: LLVM's constant uniquing
+    // shares the same pointer for identical (type, value) pairs, causing metadata
+    // corruption when different suffixes map to the same constant (#311).
+    // Suffix info is propagated via AST (getExprLowLevelSuffix) instead.
     return result;
 }
 
@@ -57,7 +60,7 @@ llvm::Value *CodeGen::emitExprVariant(const FloatExpr &e) {
         return llvm::ConstantFP::get(f64Ty_, e.value);
     // suffix == "f32"
     auto *result = llvm::ConstantFP::get(f32Ty_, e.value);
-    low_level_type_names_[result] = "f32";
+    // Do NOT set low_level_type_names_ on ConstantFP (same reason as NumberExpr, #311).
     return result;
 }
 
@@ -182,7 +185,8 @@ llvm::Value *CodeGen::tryUnaryOperatorCall(const std::string &opFnName,
 
 // ===== B2: BinaryExpr sub-dispatchers =====
 
-llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs) {
+llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
+                                        const std::string &llNameHint) {
     // Option type comparison with none: check has_value flag only
     // Only allowed when at least one side is Option and both sides are Option
     // (none is also an Option value with has_value=false)
@@ -226,7 +230,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             else                 pred = llvm::CmpInst::FCMP_OGE;
             return builder_.CreateFCmp(pred, lhs, rhs, "fcmp_ll");
         }
-        bool isUnsigned = isUnsignedLowLevel(lhs);
+        bool isUnsigned = isUnsignedLowLevel(lhs) || isUnsignedLowLevelName(llNameHint);
         llvm::CmpInst::Predicate pred;
         if      (op == "==") pred = llvm::CmpInst::ICMP_EQ;
         else if (op == "!=") pred = llvm::CmpInst::ICMP_NE;
@@ -263,7 +267,8 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
     return builder_.CreateICmp(pred, lhs, rhs, "icmp");
 }
 
-llvm::Value *CodeGen::emitBitwiseOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs) {
+llvm::Value *CodeGen::emitBitwiseOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
+                                     const std::string &llNameHint) {
     if (lhs->getType()->isDoubleTy() || rhs->getType()->isDoubleTy() ||
         isLowLevelFloatTy(lhs->getType()) || isLowLevelFloatTy(rhs->getType()))
         codegenError(
@@ -273,6 +278,7 @@ llvm::Value *CodeGen::emitBitwiseOp(const std::string &op, llvm::Value *lhs, llv
     if (isLowLevelIntTy(lhs) && lhs->getType() == rhs->getType()) {
         std::string llName = getLowLevelTypeName(lhs);
         if (llName.empty()) llName = getLowLevelTypeName(rhs);
+        if (llName.empty()) llName = llNameHint;
         auto propagate = [&](llvm::Value *result) -> llvm::Value* {
             if (!llName.empty()) low_level_type_names_[result] = llName;
             return result;
@@ -282,7 +288,7 @@ llvm::Value *CodeGen::emitBitwiseOp(const std::string &op, llvm::Value *lhs, llv
         if (op == "^")  return propagate(builder_.CreateXor(lhs, rhs,  "bxor_ll"));
         if (op == "<<") return propagate(builder_.CreateShl(lhs,  rhs, "shl_ll"));
         if (op == ">>") {
-            if (isUnsignedLowLevel(lhs))
+            if (isUnsignedLowLevel(lhs) || isUnsignedLowLevelName(llNameHint))
                 return propagate(builder_.CreateLShr(lhs, rhs, "lshr_ll"));
             return propagate(builder_.CreateAShr(lhs, rhs, "ashr_ll"));
         }
@@ -300,7 +306,8 @@ llvm::Value *CodeGen::emitBitwiseOp(const std::string &op, llvm::Value *lhs, llv
     codegenError("unknown bitwise operator: " + op);
 }
 
-llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs) {
+llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
+                                        const std::string &llNameHint) {
     // Low-level type mix check (must come first)
     checkLowLevelTypeMix(lhs, rhs, op);
 
@@ -312,6 +319,7 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
         // Propagate low-level type metadata to result
         std::string llName = getLowLevelTypeName(lhs);
         if (llName.empty()) llName = getLowLevelTypeName(rhs);
+        if (llName.empty()) llName = llNameHint;
         auto propagate = [&](llvm::Value *result) -> llvm::Value* {
             if (!llName.empty()) low_level_type_names_[result] = llName;
             return result;
@@ -327,7 +335,7 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
             codegenError("unknown operator: " + op);
         }
         // Low-level integer
-        bool isUnsigned = isUnsignedLowLevel(lhs);
+        bool isUnsigned = isUnsignedLowLevel(lhs) || isUnsignedLowLevelName(llNameHint);
         if (op == "/" || op == "//") {
             if (isUnsigned) return propagate(builder_.CreateUDiv(lhs, rhs, "udiv_ll"));
             return propagate(builder_.CreateSDiv(lhs, rhs, "sdiv_ll"));
@@ -634,15 +642,19 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
         return emitAnyBinaryOp(op, lhs, rhs);
     }
 
+    // Compute low-level type name hint from AST suffixes for constant operands (#311).
+    std::string llHint = getExprLowLevelSuffix(*e->lhs);
+    if (llHint.empty()) llHint = getExprLowLevelSuffix(*e->rhs);
+
     if (op == "==" || op == "!=" || op == "<" ||
         op == "<=" || op == ">"  || op == ">=")
-        return emitComparisonOp(op, lhs, rhs);
+        return emitComparisonOp(op, lhs, rhs, llHint);
 
     if (op == "&" || op == "|" || op == "^" ||
         op == "<<" || op == ">>" || op == ">>>")
-        return emitBitwiseOp(op, lhs, rhs);
+        return emitBitwiseOp(op, lhs, rhs, llHint);
 
-    return emitArithmeticOp(op, lhs, rhs);
+    return emitArithmeticOp(op, lhs, rhs, llHint);
 }
 
 void CodeGen::emitStmt(RecordStmt &s) {
@@ -1291,8 +1303,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         codegenError("cannot cast to byte");
     }
     // Low-level type casts — helper lambda for metadata
+    // Skip metadata for Constant values to avoid ConstantInt sharing corruption (#311).
     auto withMeta = [&](llvm::Value *result, const std::string &name) -> llvm::Value* {
-        low_level_type_names_[result] = name;
+        if (!llvm::isa<llvm::Constant>(result))
+            low_level_type_names_[result] = name;
         return result;
     };
 

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -258,6 +258,10 @@ void CodeGen::emitVarDecl(const std::string &name,
     } else {
         // Propagate metadata from initializer expression (e.g., y = x as u32)
         std::string valName = getLowLevelTypeName(val);
+        // Fall back to AST suffix for literal constants, since ConstantInt/ConstantFP
+        // pointers are shared by LLVM and cannot carry per-use metadata (#311).
+        if (valName.empty())
+            valName = getExprLowLevelSuffix(value);
         if (!valName.empty())
             low_level_type_names_[ptr] = valName;
     }

--- a/tests/spec/constantint_sharing.test.ry
+++ b/tests/spec/constantint_sharing.test.ry
@@ -1,0 +1,54 @@
+describe("ConstantInt sharing fix (#311)", fn():
+  it("same value with u64 suffix and plain int", fn():
+    x = 100u64
+    y = 100
+    expect(y).to_eq(100)
+    expect(y + 1).to_eq(101)
+  )
+
+  it("same value with u32 and i32 suffix", fn():
+    a = 100u32
+    b = 100i32
+    expect(a as int).to_eq(100)
+    expect(b as int).to_eq(100)
+  )
+
+  it("plain int not tainted by prior u64 literal", fn():
+    x = 50u64
+    y = 50
+    z = y * 2
+    expect(z).to_eq(100)
+  )
+
+  it("annotated u32 variable still works", fn():
+    x: u32 = 100
+    expect(x as int).to_eq(100)
+  )
+
+  it("u32 unsigned division via suffix", fn():
+    x: u32 = 10
+    y: u32 = 3
+    expect((x / y) as int).to_eq(3)
+  )
+
+  it("suffix literal direct arithmetic", fn():
+    x = 100i32 + 200i32
+    expect(x as int).to_eq(300)
+  )
+
+  it("suffix literal direct comparison", fn():
+    expect(100u32 < 200u32).to_eq(true)
+  )
+
+  it("mixed: variable and suffix literal", fn():
+    x: u32 = 10
+    y = x + 5u32
+    expect(y as int).to_eq(15)
+  )
+
+  it("f32 constant sharing", fn():
+    a = 1.5f32
+    b = 1.5
+    expect(b).to_eq(1.5)
+  )
+)


### PR DESCRIPTION
## Summary

Fixes #311

`low_level_type_names_` マップが `llvm::Value*` をキーにしているが、LLVM の `ConstantInt::get()` は同じ `(型, 値)` に対して同一ポインタを返す（constant uniquing）。そのため、`100u64` と `100`（plain int）が同じ `ConstantInt*` を共有し、suffix メタデータが汚染されていた。

### Changes

- `ConstantInt`/`ConstantFP` に対する `low_level_type_names_` 書き込みを削除
- AST ノードから suffix を取得する `getExprLowLevelSuffix()` ヘルパーを追加
- 二項演算ディスパッチャに `llNameHint` パラメータを追加し、定数オペランドの型情報を伝播
- CastExpr の `withMeta` に `Constant` ガードを追加
- `emitVarDecl` の no-annotation ケースで AST fallback を追加

## Test plan

- [x] 新規テスト `constantint_sharing.test.ry`（9テスト）が全て通過
- [x] 既存テスト `low_level_types.test.ry`（81テスト）が全て通過
- [x] 既存テスト `numeric_literal_suffix.test.ry`（24テスト）が全て通過
- [x] C++ テスト（980テスト）が全て通過