### PR TITLE
feat: reject unary negation on unsigned type variables and expressions (#312)

### DIFF
--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -125,6 +125,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<UnaryExpr> &e) {
             if (isUnsignedLowLevelName(ne->suffix))
                 codegenError("cannot negate unsigned type '" + ne->suffix + "'");
         }
+        if (isUnsignedLowLevel(val))
+            codegenError("cannot negate unsigned type '" + getLowLevelTypeName(val) + "'");
         val = promoteToInt(val);
         return builder_.CreateNeg(val, "neg");
     }

--- a/tests/spec/unsigned_negation.test.ry
+++ b/tests/spec/unsigned_negation.test.ry
@@ -1,0 +1,17 @@
+describe("signed variable negation (regression)", fn():
+  it("negate i32 variable", fn():
+    x: i32 = 5
+    y = -x
+    expect(y as int).to_eq(-5)
+  )
+  it("negate i16 variable", fn():
+    x: i16 = 10
+    y = -x
+    expect(y as int).to_eq(-10)
+  )
+  it("negate plain int variable", fn():
+    x = 42
+    y = -x
+    expect(y).to_eq(-42)
+  )
+)

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -451,6 +451,31 @@ TEST_F(CodeGenTest, NumericLiteralSuffix_OutOfRange) {
     EXPECT_THROW(runSource("x = -1u32"), std::runtime_error);
 }
 
+// ===== Unsigned variable negation error (#312) =====
+
+TEST_F(CodeGenTest, UnsignedVariableNegation_u8) {
+    EXPECT_THROW(runSource("x: u8 = 5\ny = -x"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, UnsignedVariableNegation_u16) {
+    EXPECT_THROW(runSource("x: u16 = 100\ny = -x"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, UnsignedVariableNegation_u32) {
+    EXPECT_THROW(runSource("x: u32 = 42\ny = -x"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, UnsignedVariableNegation_u64) {
+    EXPECT_THROW(runSource("x: u64 = 999\ny = -x"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, UnsignedFunctionReturnNegation) {
+    EXPECT_THROW(runSource(
+        "fn get_u32() -> u32:\n"
+        "    return 42u32\n"
+        "y = -get_u32()"), std::runtime_error);
+}
+
 // ===== Return type inference for named functions =====
 
 TEST_F(CodeGenTest, ReturnTypeInference_Int) {


### PR DESCRIPTION
## Summary

- unsigned 型（`u8`, `u16`, `u32`, `u64`）の変数や関数戻り値に対する単項マイナス (`-`) をコンパイルエラーにする
- 既存の AST レベルチェック（サフィックス付きリテラル `-5u8`）に加え、emit 済み `llvm::Value*` に対して `isUnsignedLowLevel(val)` チェックを追加
- #311 の ConstantInt 共有問題の修正が前提（修正済み）

## Changes

- `src/codegen_expr.cpp`: `emitExprVariant(UnaryExpr)` の `-` ブロックに value レベルの unsigned チェック追加（2行）
- `tests/test_codegen.cpp`: C++ テスト 5 件追加（u8/u16/u32/u64 変数、関数戻り値）
- `tests/spec/unsigned_negation.test.ry`: signed 型の negation 回帰テスト 3 件

## Test plan

- [x] C++ テスト 985 件全パス
- [x] Ry セルフテスト（関連テスト全パス）
- [x] 既存の unsigned リテラルチェック（`-1u8` 等）に影響なし

Closes #312