### PR TITLE
feat: add @inline directive for function inlining hints (#299)

### DIFF
--- a/docs/ja/reference/directives.md
+++ b/docs/ja/reference/directives.md
@@ -245,6 +245,46 @@ fn old_api() -> int:
 
 現時点では、パラメータはパースされますが `@deprecated` ディレクティブでは使用されません。
 
+### `@inline`
+
+LLVM オプティマイザにインライン化のヒントを与えます。デフォルトでは、関数を常にインライン化するよう指示します。
+
+**基本的な使い方（常にインライン化）：**
+
+```
+@inline
+fn add(a: int, b: int) -> int:
+    return a + b
+```
+
+**mode パラメータ付き：**
+
+```
+@inline(mode="always")
+fn hot_path(x: int) -> int:
+    return x * 2 + 1
+
+@inline(mode="hint")
+fn medium_path(x: int) -> int:
+    return x + 1
+
+@inline(mode="never")
+fn cold_error_handler(msg: str):
+    print("ERROR: " + msg)
+```
+
+**モード：**
+
+| モード | LLVM 属性 | 説明 |
+|--------|----------|------|
+| `always`（デフォルト） | `AlwaysInline` | 常にインライン化する |
+| `hint` | `InlineHint` | オプティマイザにインライン化を提案する |
+| `never` | `NoInline` | インライン化を禁止する |
+
+**制約：**
+- `@inline` は `@native` と併用できません（native 関数にはインライン化するボディがありません）。
+- 不明な mode 値はコンパイルエラーになります。
+
 ## 注意事項
 
 - 非推奨のエンティティは正常に動作します。警告が出力されるだけです。

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -244,6 +244,46 @@ it("property name", fn(a: int, b: int):
 
 On failure, the counterexample (parameter values that caused the failure) is printed.
 
+### `@inline`
+
+Provides inlining hints to the LLVM optimizer. By default, marks the function for aggressive inlining.
+
+**Basic usage (always inline):**
+
+```
+@inline
+fn add(a: int, b: int) -> int:
+    return a + b
+```
+
+**With mode parameter:**
+
+```
+@inline(mode="always")
+fn hot_path(x: int) -> int:
+    return x * 2 + 1
+
+@inline(mode="hint")
+fn medium_path(x: int) -> int:
+    return x + 1
+
+@inline(mode="never")
+fn cold_error_handler(msg: str):
+    print("ERROR: " + msg)
+```
+
+**Modes:**
+
+| Mode | LLVM Attribute | Description |
+|------|---------------|-------------|
+| `always` (default) | `AlwaysInline` | Always inline this function |
+| `hint` | `InlineHint` | Suggest inlining to the optimizer |
+| `never` | `NoInline` | Never inline this function |
+
+**Constraints:**
+- `@inline` cannot be used with `@native` (native functions have no body to inline).
+- An unknown mode value causes a compile error.
+
 ### Parameters (future extension)
 
 Directives support an optional parameter syntax for future extensions:

--- a/docs/zh/reference/directives.md
+++ b/docs/zh/reference/directives.md
@@ -222,6 +222,46 @@ fn old_api() -> int:
 
 目前，參數會被解析但不會被 `@deprecated` 指令使用。
 
+### `@inline`
+
+為 LLVM 優化器提供內聯提示。預設情況下，標記函數進行積極內聯。
+
+**基本用法（始終內聯）：**
+
+```
+@inline
+fn add(a: int, b: int) -> int:
+    return a + b
+```
+
+**帶 mode 參數：**
+
+```
+@inline(mode="always")
+fn hot_path(x: int) -> int:
+    return x * 2 + 1
+
+@inline(mode="hint")
+fn medium_path(x: int) -> int:
+    return x + 1
+
+@inline(mode="never")
+fn cold_error_handler(msg: str):
+    print("ERROR: " + msg)
+```
+
+**模式：**
+
+| 模式 | LLVM 屬性 | 說明 |
+|------|----------|------|
+| `always`（預設） | `AlwaysInline` | 始終內聯此函數 |
+| `hint` | `InlineHint` | 向優化器建議內聯 |
+| `never` | `NoInline` | 禁止內聯此函數 |
+
+**限制：**
+- `@inline` 不能與 `@native` 一起使用（native 函數沒有可內聯的函數體）。
+- 未知的 mode 值會導致編譯錯誤。
+
 ## 注意事項
 
 - 已棄用的實體仍然正常運作，僅會發出警告。

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -299,6 +299,8 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     if (hasDirective(s->directives, "native")) {
         if (s->is_async)
             codegenError("async native functions are not supported");
+        if (hasDirective(s->directives, "inline"))
+            codegenError("@inline cannot be used with @native functions");
         if (hasDirective(s->directives, "deprecated"))
             deprecated_functions_.insert(s->name);
 
@@ -379,6 +381,26 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
     if (hasDirective(s->directives, "deprecated"))
         deprecated_functions_.insert(s->name);
+
+    if (hasDirective(s->directives, "inline")) {
+        std::string mode = "always";
+        for (auto &d : s->directives) {
+            if (d.name == "inline") {
+                for (auto &p : d.params) {
+                    if (p.key == "mode") mode = p.value;
+                }
+            }
+        }
+        if (mode == "always")
+            func->addFnAttr(llvm::Attribute::AlwaysInline);
+        else if (mode == "never")
+            func->addFnAttr(llvm::Attribute::NoInline);
+        else if (mode == "hint")
+            func->addFnAttr(llvm::Attribute::InlineHint);
+        else
+            codegenError("unknown @inline mode: '" + mode +
+                         "' (expected 'always', 'never', or 'hint')");
+    }
 
     auto emitFunctionBody = [&](llvm::Function *targetFunc, llvm::Type *retTy,
                                 const std::string &returnTypeName, const std::string &fnNameForErrors) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -127,7 +127,7 @@ void Parser::skipStructuralTokens() {
 
 // ===== Directive parsing =====
 
-static const std::unordered_set<std::string> known_directives = {"deprecated", "native", "parallel", "each", "property", "const"};
+static const std::unordered_set<std::string> known_directives = {"deprecated", "native", "parallel", "each", "property", "const", "inline"};
 
 std::vector<Directive> Parser::parseDirectives() {
     std::vector<Directive> directives;

--- a/tests/spec/inline.test.ry
+++ b/tests/spec/inline.test.ry
@@ -1,0 +1,39 @@
+@inline
+fn add(a: int, b: int) -> int:
+  return a + b
+
+@inline(mode="always")
+fn mul(a: int, b: int) -> int:
+  return a * b
+
+@inline(mode="hint")
+fn sub(a: int, b: int) -> int:
+  return a - b
+
+@inline(mode="never")
+fn negate(a: int) -> int:
+  return -a
+
+@inline
+fn fact(n: int) -> int:
+  if n <= 1:
+    return 1
+  return n * fact(n - 1)
+
+describe("@inline directive", fn():
+  it("default (always)", fn():
+    expect(add(3, 4)).to_eq(7)
+  )
+  it("mode=always", fn():
+    expect(mul(5, 6)).to_eq(30)
+  )
+  it("mode=hint", fn():
+    expect(sub(10, 3)).to_eq(7)
+  )
+  it("mode=never", fn():
+    expect(negate(-5)).to_eq(5)
+  )
+  it("recursive", fn():
+    expect(fact(5)).to_eq(120)
+  )
+)

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -245,3 +245,88 @@ TEST_F(DirectiveTest, CoreStrDeclarationsWork) {
     );
     EXPECT_EQ(output, "HELLO\ntrue\ntrue\n");
 }
+
+// ===== @inline tests =====
+
+TEST_F(DirectiveTest, InlineDefault) {
+    std::string output = runSource(
+        "@inline\n"
+        "fn add(a: int, b: int) -> int:\n"
+        "    return a + b\n"
+        "print(add(3, 4))\n"
+    );
+    EXPECT_EQ(output, "7\n");
+}
+
+TEST_F(DirectiveTest, InlineModeAlways) {
+    std::string output = runSource(
+        "@inline(mode=\"always\")\n"
+        "fn mul(a: int, b: int) -> int:\n"
+        "    return a * b\n"
+        "print(mul(5, 6))\n"
+    );
+    EXPECT_EQ(output, "30\n");
+}
+
+TEST_F(DirectiveTest, InlineModeHint) {
+    std::string output = runSource(
+        "@inline(mode=\"hint\")\n"
+        "fn sub(a: int, b: int) -> int:\n"
+        "    return a - b\n"
+        "print(sub(10, 3))\n"
+    );
+    EXPECT_EQ(output, "7\n");
+}
+
+TEST_F(DirectiveTest, InlineModeNever) {
+    std::string output = runSource(
+        "@inline(mode=\"never\")\n"
+        "fn negate(a: int) -> int:\n"
+        "    return -a\n"
+        "print(negate(-5))\n"
+    );
+    EXPECT_EQ(output, "5\n");
+}
+
+TEST_F(DirectiveTest, InlineInvalidMode) {
+    EXPECT_THROW(runSource(
+        "@inline(mode=\"aggressive\")\n"
+        "fn bad() -> int:\n"
+        "    return 1\n"
+        "print(bad())\n"
+    ), std::runtime_error);
+}
+
+TEST_F(DirectiveTest, InlineWithNativeError) {
+    EXPECT_THROW(runSource(
+        "@inline\n"
+        "@native\n"
+        "fn contains(s: str, sub: str) -> bool\n"
+        "print(contains(\"hello\", \"ell\"))\n"
+    ), std::runtime_error);
+}
+
+TEST_F(DirectiveTest, InlineWithDeprecated) {
+    auto [output, warnings] = runSourceWithWarnings(
+        "@inline\n"
+        "@deprecated\n"
+        "fn old_add(a: int, b: int) -> int:\n"
+        "    return a + b\n"
+        "print(old_add(1, 2))\n"
+    );
+    EXPECT_EQ(output, "3\n");
+    ASSERT_EQ(warnings.size(), 1);
+    EXPECT_EQ(warnings[0], "warning: 'old_add' is deprecated");
+}
+
+TEST_F(DirectiveTest, InlineRecursive) {
+    std::string output = runSource(
+        "@inline\n"
+        "fn fact(n: int) -> int:\n"
+        "    if n <= 1:\n"
+        "        return 1\n"
+        "    return n * fact(n - 1)\n"
+        "print(fact(5))\n"
+    );
+    EXPECT_EQ(output, "120\n");
+}


### PR DESCRIPTION
## Summary

- `@inline` ディレクティブを追加し、LLVM の関数インライン化属性にマッピング
- デフォルト (`@inline`) は `AlwaysInline`、`@inline(mode="hint")` は `InlineHint`、`@inline(mode="never")` は `NoInline`
- `@inline` + `@native` の組み合わせをコンパイルエラーとして拒否
- 不明な mode 値はコンパイルエラー

## Changes

| File | Change |
|------|--------|
| `src/parser.cpp` | `known_directives` に `"inline"` 追加 |
| `src/codegen_fn.cpp` | `@inline` の LLVM 属性付与ロジック + `@native` 排他チェック |
| `tests/test_codegen_directive.cpp` | C++ テスト 8 件追加 |
| `tests/spec/inline.test.ry` | Ry セルフテスト 5 件追加 |
| `docs/reference/directives.md` | `@inline` セクション追加 (EN) |
| `docs/ja/reference/directives.md` | `@inline` セクション追加 (JA) |
| `docs/zh/reference/directives.md` | `@inline` セクション追加 (ZH) |

## Test plan

- [x] C++ テスト 993 件全合格 (`@inline` 関連 8 件含む)
- [x] Ry セルフテスト `inline.test.ry` 5 件全合格

Closes #299