### PR TITLE
feat: enforce bool return type for comparison/logical operator overloads

### DIFF
--- a/docs/ja/reference/functions.md
+++ b/docs/ja/reference/functions.md
@@ -293,6 +293,27 @@ fn operator<op>(a: 型) -> 戻り値型:
 | 論理（二項） | `and` `or` |
 | 単項 | `-` `~` `not` |
 
+### 戻り値型の制約
+
+比較演算子と論理演算子は `bool` を返す必要がある:
+
+| 種別 | 演算子 | 必須戻り値型 |
+|---|---|---|
+| 比較 | `==` `!=` `<` `<=` `>` `>=` | `bool` |
+| 論理 | `and` `or` `not` | `bool` |
+
+```python
+# OK
+fn operator==(a: Vec2, b: Vec2) -> bool:
+    return a.x == b.x and a.y == b.y
+
+# エラー: comparison operator '==' must return 'bool', but returns 'int'
+fn operator==(a: Vec2, b: Vec2) -> int:
+    return 42
+```
+
+算術演算子・ビット演算子には戻り値型の制約はない。
+
 ### 二項 / 単項の区別
 
 引数の個数で区別する。

--- a/docs/ja/reference/operators.md
+++ b/docs/ja/reference/operators.md
@@ -295,6 +295,27 @@ fn operator-(a: MyType) -> MyType:
 | 論理（二項） | `and` `or` |
 | 単項 | `-` `~` `not` |
 
+### 戻り値型の制約
+
+比較演算子と論理演算子は `bool` を返す必要があります:
+
+| 種別 | 演算子 | 必須戻り値型 |
+|---|---|---|
+| 比較 | `==` `!=` `<` `<=` `>` `>=` | `bool` |
+| 論理 | `and` `or` `not` | `bool` |
+
+```python
+# OK
+fn operator==(a: Vec2, b: Vec2) -> bool:
+    return a.x == b.x and a.y == b.y
+
+# エラー: comparison operator '==' must return 'bool', but returns 'int'
+fn operator==(a: Vec2, b: Vec2) -> int:
+    return 42
+```
+
+算術演算子・ビット演算子には戻り値型の制約はありません。
+
 ### 二項 / 単項の区別
 
 引数の個数で区別します。

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -355,6 +355,27 @@ fn operator<op>(a: type) -> return_type:
 | Logical (binary) | `and` `or` |
 | Unary | `-` `~` `not` |
 
+### Return Type Constraints
+
+Comparison and logical operators must return `bool`:
+
+| Category | Operators | Required Return Type |
+|---|---|---|
+| Comparison | `==` `!=` `<` `<=` `>` `>=` | `bool` |
+| Logical | `and` `or` `not` | `bool` |
+
+```python
+# OK
+fn operator==(a: Vec2, b: Vec2) -> bool:
+    return a.x == b.x and a.y == b.y
+
+# Error: comparison operator '==' must return 'bool', but returns 'int'
+fn operator==(a: Vec2, b: Vec2) -> int:
+    return 42
+```
+
+Arithmetic and bitwise operators have no return type constraint.
+
 ### Distinguishing Binary and Unary
 
 Distinguished by the number of parameters.

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -298,6 +298,27 @@ fn operator-(a: MyType) -> MyType:
 | Logical (binary) | `and` `or` |
 | Unary | `-` `~` `not` |
 
+### Return Type Constraints
+
+Comparison and logical operators must return `bool`:
+
+| Category | Operators | Required Return Type |
+|---|---|---|
+| Comparison | `==` `!=` `<` `<=` `>` `>=` | `bool` |
+| Logical | `and` `or` `not` | `bool` |
+
+```python
+# OK
+fn operator==(a: Vec2, b: Vec2) -> bool:
+    return a.x == b.x and a.y == b.y
+
+# Error: comparison operator '==' must return 'bool', but returns 'int'
+fn operator==(a: Vec2, b: Vec2) -> int:
+    return 42
+```
+
+Arithmetic and bitwise operators have no return type constraint.
+
 ### Distinguishing Binary and Unary
 
 Distinguished by the number of parameters.

--- a/docs/zh/reference/functions.md
+++ b/docs/zh/reference/functions.md
@@ -265,6 +265,27 @@ fn operator<op>(a: 型別) -> 回傳型別:
 | 邏輯（二元） | `and` `or` |
 | 一元 | `-` `~` `not` |
 
+### 回傳型別限制
+
+比較運算子和邏輯運算子必須回傳 `bool`：
+
+| 種類 | 運算子 | 必要回傳型別 |
+|---|---|---|
+| 比較 | `==` `!=` `<` `<=` `>` `>=` | `bool` |
+| 邏輯 | `and` `or` `not` | `bool` |
+
+```python
+# OK
+fn operator==(a: Vec2, b: Vec2) -> bool:
+    return a.x == b.x and a.y == b.y
+
+# 錯誤: comparison operator '==' must return 'bool', but returns 'int'
+fn operator==(a: Vec2, b: Vec2) -> int:
+    return 42
+```
+
+算術運算子和位元運算子沒有回傳型別限制。
+
 ### 二元 / 一元的區別
 
 依引數個數區分。

--- a/docs/zh/reference/operators.md
+++ b/docs/zh/reference/operators.md
@@ -297,6 +297,27 @@ fn operator-(a: MyType) -> MyType:
 | 邏輯（二元） | `and` `or` |
 | 一元 | `-` `~` `not` |
 
+### 回傳型別限制
+
+比較運算子和邏輯運算子必須回傳 `bool`：
+
+| 種類 | 運算子 | 必要回傳型別 |
+|---|---|---|
+| 比較 | `==` `!=` `<` `<=` `>` `>=` | `bool` |
+| 邏輯 | `and` `or` `not` | `bool` |
+
+```python
+# OK
+fn operator==(a: Vec2, b: Vec2) -> bool:
+    return a.x == b.x and a.y == b.y
+
+# 錯誤: comparison operator '==' must return 'bool', but returns 'int'
+fn operator==(a: Vec2, b: Vec2) -> int:
+    return 42
+```
+
+算術運算子和位元運算子沒有回傳型別限制。
+
 ### 二元 / 一元的區別
 
 依引數個數區分。

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -39,6 +39,19 @@ inline bool hasDirective(const std::vector<Directive> &directives, std::string_v
     return false;
 }
 
+// Returns true for operator names whose return type must be bool.
+inline bool isBoolConstrainedOperator(const std::string &name) {
+    return name == "operator==" || name == "operator!=" ||
+           name == "operator<"  || name == "operator<=" ||
+           name == "operator>"  || name == "operator>=" ||
+           name == "operatornot" || name == "operatorand" || name == "operatoror";
+}
+
+// Strips the "operator" prefix from an operator function name.
+inline std::string operatorSymbol(const std::string &name) {
+    return name.substr(8);
+}
+
 struct NumberExpr   { int64_t value; std::string suffix; };
 struct FloatExpr    { double value;  std::string suffix; };
 struct BoolExpr     { bool value; };

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -304,6 +304,14 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         if (hasDirective(s->directives, "deprecated"))
             deprecated_functions_.insert(s->name);
 
+        // Validate return type for comparison/logical operators
+        if (s->is_operator && isBoolConstrainedOperator(s->name)) {
+            if (!s->return_type.empty() && s->return_type != "bool") {
+                codegenError("operator '" + operatorSymbol(s->name) + "' must return 'bool', but returns '" +
+                             s->return_type + "'");
+            }
+        }
+
         // Register argument count for native function overload
         native_fn_arg_counts_[s->name].push_back(s->params.size());
         return;
@@ -340,6 +348,14 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         }
     } else {
         bodyRetTy = resolveType(s->return_type);
+    }
+
+    // Validate return type for comparison/logical operators
+    if (s->is_operator && isBoolConstrainedOperator(s->name)) {
+        if (bodyRetTy != llvm::Type::getInt1Ty(*ctx_)) {
+            codegenError("operator '" + operatorSymbol(s->name) + "' must return 'bool', but returns '" +
+                         s->return_type + "'");
+        }
     }
 
     // Check that non-Unit, non-any functions return on all paths

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -149,6 +149,15 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         }
     }
 
+    // Validate return type for comparison/logical operators
+    if (fnStmt->is_operator && !fnStmt->return_type.empty()) {
+        if (isBoolConstrainedOperator(fnStmt->name) && fnStmt->return_type != "bool") {
+            parseError(fnTok.line,
+                "operator '" + operatorSymbol(fnStmt->name) + "' must return 'bool', but returns '" +
+                fnStmt->return_type + "'");
+        }
+    }
+
     // @native fn: body-less declaration
     if (hasDirective(directives, "native")) {
         if (lex_.peek().kind == TokenKind::Colon)

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -90,6 +90,32 @@ TEST_F(CodeGenTest, UnknownFunctionThrows) {
     EXPECT_THROW(runSource("foo(42)"), std::runtime_error);
 }
 
+// ===== Operator return type constraint =====
+
+TEST_F(CodeGenTest, OperatorEqInferredNonBoolThrows) {
+    EXPECT_THROW(runSource(
+        "record Pt:\n"
+        "    x: int\n"
+        "fn operator==(a: Pt, b: Pt):\n"
+        "    return 42\n"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, OperatorAndExplicitNonBoolThrows) {
+    EXPECT_THROW(runSource(
+        "record Pt:\n"
+        "    x: int\n"
+        "fn operator and(a: Pt, b: Pt) -> int:\n"
+        "    return 1\n"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, OperatorOrExplicitNonBoolThrows) {
+    EXPECT_THROW(runSource(
+        "record Pt:\n"
+        "    x: int\n"
+        "fn operator or(a: Pt, b: Pt) -> int:\n"
+        "    return 1\n"), std::runtime_error);
+}
+
 // ===== Bitwise operators =====
 
 TEST_F(CodeGenTest, BitwiseOperators) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -783,6 +783,76 @@ TEST(ParserTest, OperatorFnInvalidParamCount) {
     EXPECT_THROW(parseStr(src), std::runtime_error);
 }
 
+// ===== Operator return type constraint =====
+
+TEST(ParserTest, OperatorEqMustReturnBool) {
+    EXPECT_THROW(parseStr(
+        "fn operator==(a: int, b: int) -> int:\n"
+        "    return 42\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorNeqMustReturnBool) {
+    EXPECT_THROW(parseStr(
+        "fn operator!=(a: int, b: int) -> str:\n"
+        "    return \"no\"\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorLessMustReturnBool) {
+    EXPECT_THROW(parseStr(
+        "fn operator<(a: int, b: int) -> int:\n"
+        "    return 0\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorLessEqMustReturnBool) {
+    EXPECT_THROW(parseStr(
+        "fn operator<=(a: int, b: int) -> int:\n"
+        "    return 0\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorGreaterMustReturnBool) {
+    EXPECT_THROW(parseStr(
+        "fn operator>(a: int, b: int) -> int:\n"
+        "    return 0\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorGreaterEqMustReturnBool) {
+    EXPECT_THROW(parseStr(
+        "fn operator>=(a: int, b: int) -> int:\n"
+        "    return 0\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorNotMustReturnBool) {
+    EXPECT_THROW(parseStr(
+        "fn operator not(a: int) -> int:\n"
+        "    return 0\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorAndMustReturnBool) {
+    EXPECT_THROW(parseStr(
+        "fn operator and(a: int, b: int) -> int:\n"
+        "    return 0\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorOrMustReturnBool) {
+    EXPECT_THROW(parseStr(
+        "fn operator or(a: int, b: int) -> int:\n"
+        "    return 0\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorEqReturnBoolOk) {
+    Program prog = parseStr(
+        "fn operator==(a: int, b: int) -> bool:\n"
+        "    return true\n");
+    EXPECT_EQ(prog.size(), 1u);
+}
+
+TEST(ParserTest, OperatorPlusReturnsNonBoolOk) {
+    Program prog = parseStr(
+        "fn operator+(a: int, b: int) -> int:\n"
+        "    return a + b\n");
+    EXPECT_EQ(prog.size(), 1u);
+}
+
 // ===== Set パーサーテスト =====
 
 TEST(ParserTest, SetLiteral) {


### PR DESCRIPTION
## Summary

Closes #203

- Comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`) and logical operators (`and`, `or`, `not`) must now return `bool` when overloaded
- Non-bool return types are rejected at parse time (explicit annotations) and codegen time (inferred return types)
- Shared helpers `isBoolConstrainedOperator` and `operatorSymbol` added to `include/ry/ast.hpp`

## Test plan

- [x] 11 parser tests (9 negative + 2 positive) in `test_parser.cpp`
- [x] 3 codegen tests (inferred/explicit non-bool) in `test_codegen.cpp`
- [x] All 1023 C++ tests pass
- [x] All 42 Ry self-test files pass