### PR TITLE
feat: support named fields in ADT enum variants

### DIFF
--- a/docs/reference/structs.md
+++ b/docs/reference/structs.md
@@ -252,6 +252,22 @@ Rules:
 - Duplicate values are a compile error.
 - `print()` displays the variant name, not the integer value.
 
+### Named Fields in ADT Variants
+
+ADT variant fields can optionally include names for documentation purposes. Named fields make definitions self-describing without changing construction or pattern matching semantics.
+
+```python
+enum Shape:
+    Circle(radius: float)
+    Rect(width: float, height: float)
+    Point
+```
+
+- Construction is always positional: `Shape::Circle(3.14)`, not `Shape::Circle(radius: 3.14)`.
+- Pattern matching binds user-chosen variable names: `case Shape::Circle(r):`.
+- Field names must be `snake_case`. Mixing named and unnamed fields within a single variant is not allowed.
+- Unnamed syntax (`Circle(float)`) remains valid.
+
 ### Constraints and Errors
 
 | Constraint | Details |
@@ -259,3 +275,4 @@ Rules:
 | Variant access requires `EnumName::VariantName` | The `::` operator is required |
 | Variant values | Auto-assigned (0, 1, 2, ...) by default, or explicitly specified with `= value` |
 | Comparison uses integer comparison | `==`, `!=` can be used |
+| Named field names | Must be `snake_case`; no duplicates within a variant; no mixing named/unnamed |

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -282,9 +282,25 @@ enum Shape:
     Point
 ```
 
+### Named Fields
+
+Variants can optionally use named fields for documentation clarity. Named fields make variant definitions self-describing but do not change runtime behavior — construction and pattern matching remain positional.
+
+```python
+enum Shape:
+    Circle(radius: float)
+    Rectangle(width: float, height: float)
+    Point
+```
+
+Rules:
+- Field names must be `snake_case`.
+- Within a single variant, all fields must be either named or unnamed (no mixing).
+- Duplicate field names within a variant are a compile error.
+
 ### Constructor
 
-Use the `EnumName::Variant(value)` syntax to construct a variant with data.
+Use the `EnumName::Variant(value)` syntax to construct a variant with data. Arguments are always positional, even when fields are named.
 
 ```python
 c = Shape::Circle(3.14)
@@ -294,7 +310,7 @@ p = Shape::Point
 
 ### Pattern Matching with Binding
 
-Use `case EnumName::Variant(binding):` to extract the associated data.
+Use `case EnumName::Variant(binding):` to extract the associated data. Bindings use user-chosen variable names, not field names.
 
 ```python
 match c:

--- a/docs/tutorial/08-advanced.md
+++ b/docs/tutorial/08-advanced.md
@@ -296,16 +296,20 @@ b = true as int       # 1
 
 ## Enum with Associated Data (ADT)
 
-Enum variants can carry associated values. This lets a single enum represent a family of different shapes of data.
+Enum variants can carry associated values. This lets a single enum represent a family of different shapes of data. You can optionally name the fields for documentation clarity.
 
 ```python
 enum Shape:
-    Circle(float)
-    Rectangle(float, float)
+    Circle(radius: float)
+    Rectangle(width: float, height: float)
     Point
 ```
 
+Named fields are documentation-only — they make definitions self-describing. Unnamed syntax (`Circle(float)`) is also valid.
+
 ### Constructing ADT Variants
+
+Construction is always positional, regardless of whether fields are named.
 
 ```python
 c = Shape::Circle(3.14)
@@ -315,7 +319,7 @@ p = Shape::Point
 
 ### Matching ADT Variants
 
-Use `case` with a binding pattern to extract the associated data.
+Use `case` with a binding pattern to extract the associated data. Bindings use your chosen variable names, not the field names.
 
 ```python
 fn describe(s: Shape) -> str:

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -168,6 +168,7 @@ struct EllipsisStmt { SourceLocation loc; };
 struct EnumVariant {
     std::string name;
     std::vector<std::string> field_types;  // empty = no associated data
+    std::vector<std::string> field_names;  // parallel to field_types; empty when unnamed
     std::optional<int64_t> explicit_value;
 };
 

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -412,15 +412,55 @@ StmtNode Parser::parseEnumStatement() {
         EnumVariant variant;
         variant.name = variantName.value;
 
-        // Associated data: Variant(type1, type2, ...)
+        // Associated data: Variant(type1, type2, ...) or Variant(name: type, ...)
         if (lex_.peek().kind == TokenKind::LParen) {
             lex_.next(); // consume '('
             if (lex_.peek().kind != TokenKind::RParen) {
+                bool hasNames = false;
+                bool firstField = true;
                 for (;;) {
+                    // Try to detect named field: name: type
+                    bool isNamed = false;
+                    if (lex_.peek().kind == TokenKind::Ident) {
+                        auto saved = lex_.saveState();
+                        lex_.next(); // consume potential field name
+                        if (lex_.peek().kind == TokenKind::Colon) {
+                            isNamed = true;
+                        }
+                        lex_.restoreState(saved);
+                    }
+
+                    if (firstField) {
+                        hasNames = isNamed;
+                        firstField = false;
+                    } else if (isNamed != hasNames) {
+                        parseError(lex_.peek().line,
+                            "cannot mix named and unnamed fields in enum variant");
+                    }
+
+                    if (isNamed) {
+                        Token fieldName = lex_.peek();
+                        lex_.next(); // consume field name
+                        if (!isSnakeCase(fieldName.value))
+                            parseError(fieldName.line,
+                                "enum variant field name '" + fieldName.value + "' must be snake_case");
+                        lex_.next(); // consume ':'
+                        variant.field_names.push_back(fieldName.value);
+                    }
+
                     variant.field_types.push_back(parseTypeName());
                     if (lex_.peek().kind != TokenKind::Comma)
                         break;
                     lex_.next(); // consume ','
+                }
+                // Check for duplicate field names
+                if (hasNames) {
+                    std::unordered_set<std::string> seen;
+                    for (auto &fn : variant.field_names) {
+                        if (!seen.insert(fn).second)
+                            parseError(variantName.line,
+                                "duplicate field name '" + fn + "' in enum variant '" + variantName.value + "'");
+                    }
                 }
             }
             if (lex_.peek().kind != TokenKind::RParen)

--- a/tests/spec/structs.test.ry
+++ b/tests/spec/structs.test.ry
@@ -156,6 +156,38 @@ describe("ADT enum", fn():
   )
 )
 
+enum NamedShape:
+  Circle(radius: float)
+  Rect(width: float, height: float)
+  Point
+
+describe("ADT enum with named fields", fn():
+  it("construction is positional", fn():
+    s = NamedShape::Circle(3.14)
+    res = 0.0
+    match s:
+      case NamedShape::Circle(r):
+        res = r
+      case NamedShape::Rect(w, h):
+        res = w * h
+      case NamedShape::Point:
+        res = 0.0
+    expect(res).to_eq(3.14)
+  )
+  it("multi-field named variant", fn():
+    s = NamedShape::Rect(4.0, 5.0)
+    res = 0.0
+    match s:
+      case NamedShape::Circle(r):
+        res = r
+      case NamedShape::Rect(w, h):
+        res = w * h
+      case NamedShape::Point:
+        res = 0.0
+    expect(res).to_eq(20.0)
+  )
+)
+
 enum HttpStatus:
   Ok = 200
   NotFound = 404

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1338,6 +1338,64 @@ TEST(ParserTest, EnumExplicitValueOnADTError) {
     EXPECT_THROW(parseStr("enum Bad:\n    A(int) = 1\n    B = 2"), std::runtime_error);
 }
 
+// ===== Named fields in ADT enum variants =====
+
+TEST(ParserTest, EnumNamedFields) {
+    Program prog = parseStr("enum Shape:\n    Circle(radius: float)\n    Rect(width: float, height: float)\n    Point");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &es = std::get<EnumStmt>(prog[0]);
+    EXPECT_EQ(es.name, "Shape");
+    ASSERT_EQ(es.variants.size(), 3u);
+    // Circle
+    EXPECT_EQ(es.variants[0].name, "Circle");
+    ASSERT_EQ(es.variants[0].field_types.size(), 1u);
+    EXPECT_EQ(es.variants[0].field_types[0], "float");
+    ASSERT_EQ(es.variants[0].field_names.size(), 1u);
+    EXPECT_EQ(es.variants[0].field_names[0], "radius");
+    // Rect
+    EXPECT_EQ(es.variants[1].name, "Rect");
+    ASSERT_EQ(es.variants[1].field_types.size(), 2u);
+    EXPECT_EQ(es.variants[1].field_types[0], "float");
+    EXPECT_EQ(es.variants[1].field_types[1], "float");
+    ASSERT_EQ(es.variants[1].field_names.size(), 2u);
+    EXPECT_EQ(es.variants[1].field_names[0], "width");
+    EXPECT_EQ(es.variants[1].field_names[1], "height");
+    // Point (no fields)
+    EXPECT_TRUE(es.variants[2].field_types.empty());
+    EXPECT_TRUE(es.variants[2].field_names.empty());
+}
+
+TEST(ParserTest, EnumUnnamedFieldsRegression) {
+    Program prog = parseStr("enum Shape:\n    Circle(float)\n    Rect(float, float)");
+    const auto &es = std::get<EnumStmt>(prog[0]);
+    ASSERT_EQ(es.variants[0].field_types.size(), 1u);
+    EXPECT_TRUE(es.variants[0].field_names.empty());
+    ASSERT_EQ(es.variants[1].field_types.size(), 2u);
+    EXPECT_TRUE(es.variants[1].field_names.empty());
+}
+
+TEST(ParserTest, EnumMixedFieldsError) {
+    EXPECT_THROW(parseStr("enum Bad:\n    Bar(x: int, float)"), std::runtime_error);
+}
+
+TEST(ParserTest, EnumDuplicateFieldNameError) {
+    EXPECT_THROW(parseStr("enum Bad:\n    Bar(x: int, x: float)"), std::runtime_error);
+}
+
+TEST(ParserTest, EnumNonSnakeCaseFieldError) {
+    EXPECT_THROW(parseStr("enum Bad:\n    Bar(Radius: float)"), std::runtime_error);
+}
+
+TEST(ParserTest, EnumNamedFieldsGeneric) {
+    Program prog = parseStr("enum Option<T>:\n    Some(value: T)\n    None");
+    const auto &es = std::get<EnumStmt>(prog[0]);
+    EXPECT_EQ(es.variants[0].name, "Some");
+    ASSERT_EQ(es.variants[0].field_names.size(), 1u);
+    EXPECT_EQ(es.variants[0].field_names[0], "value");
+    ASSERT_EQ(es.variants[0].field_types.size(), 1u);
+    EXPECT_EQ(es.variants[0].field_types[0], "T");
+}
+
 TEST(ParserTest, PascalCaseTypeAliasRequired) {
     EXPECT_THROW(parseStr("type my_int = int"), std::runtime_error);
 }


### PR DESCRIPTION
## Summary

Closes #308

- ADT enum variants now support optional named fields: `Circle(radius: float)`
- Named fields are documentation-only — construction and pattern matching remain positional
- Parser validates: `snake_case` field names, no duplicates within a variant, no mixing named/unnamed fields

## Test plan

- [x] C++ parser tests: named fields parse, unnamed regression, mixed error, duplicate error, non-snake_case error, generic enum
- [x] Ry integration tests: positional construction and pattern matching with named-field ADT
- [x] All 1015 C++ tests pass
- [x] All 42 Ry test files pass (0 failures)