### PR TITLE
feat: compound assignment operator overloading with in-place optimization

### DIFF
--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -297,6 +297,7 @@ fn operator-(a: MyType) -> MyType:
 | Bitwise (binary) | `&` `\|` `^` `<<` `>>` `>>>` |
 | Logical (binary) | `and` `or` |
 | Unary | `-` `~` `not` |
+| Compound assignment | `+=` `-=` `*=` `/=` `%=` `//=` `**=` `&=` `\|=` `^=` `<<=` `>>=` |
 
 ### Return Type Constraints
 
@@ -332,3 +333,42 @@ fn operator-(a: Vec2, b: Vec2) -> Vec2:
 fn operator-(v: Vec2) -> Vec2:
     return Vec2(-v.x, -v.y)
 ```
+
+### Compound Assignment Operator Overloading
+
+Compound assignment operators (`+=`, `-=`, etc.) can be independently overloaded. This enables in-place optimization for large data structures.
+
+```python
+record Matrix:
+    data: List
+    rows: int
+    cols: int
+
+fn operator+=(a: Matrix, b: Matrix) -> Matrix:
+    for i in range(len(a.data)):
+        a.data[i] = a.data[i] + b.data[i]
+    return a
+```
+
+#### Resolution Priority
+
+When `x += y` is evaluated:
+
+1. If `operator+=` is defined for the types → call it directly
+2. If `operator+=` is not defined but `operator+` is → fall back to `x = x + y`
+3. If neither is defined (for non-builtin types) → compile error
+
+```python
+record Vec2:
+    x: float
+    y: float
+
+fn operator+=(a: Vec2, b: Vec2) -> Vec2:
+    return Vec2(a.x + b.x, a.y + b.y)
+
+v = Vec2(1.0, 2.0)
+v += Vec2(3.0, 4.0)  # calls operator+= directly
+# v.x == 4.0, v.y == 6.0
+```
+
+Compound assignment operators require exactly 2 parameters and have no return type constraint.

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -52,6 +52,17 @@ inline std::string operatorSymbol(const std::string &name) {
     return name.substr(8);
 }
 
+// Returns true for compound assignment operator names (operator+=, operator-=, etc.).
+inline bool isCompoundAssignOperator(const std::string &name) {
+    return name == "operator+=" || name == "operator-=" ||
+           name == "operator*=" || name == "operator/=" ||
+           name == "operator%=" || name == "operator//=" ||
+           name == "operator**=" ||
+           name == "operator&=" || name == "operator|=" ||
+           name == "operator^=" ||
+           name == "operator<<=" || name == "operator>>=";
+}
+
 struct NumberExpr   { int64_t value; std::string suffix; };
 struct FloatExpr    { double value;  std::string suffix; };
 struct BoolExpr     { bool value; };
@@ -147,7 +158,7 @@ struct SetExpr {
     std::vector<ExprPtr> elements;
 };
 
-struct AssignStmt { std::string name; std::optional<std::string> type_annotation; ExprPtr value; std::vector<Directive> directives; SourceLocation loc; };
+struct AssignStmt { std::string name; std::optional<std::string> type_annotation; ExprPtr value; std::optional<std::string> compound_op; std::vector<Directive> directives; SourceLocation loc; };
 struct CallStmt   { std::string callee; std::vector<ExprPtr> args; std::vector<Directive> directives; SourceLocation loc; };
 
 struct ReturnStmt { ExprPtr value; SourceLocation loc; };

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -326,6 +326,10 @@ private:
     llvm::Value *tryUnaryOperatorCall(const std::string &opFnName,
                                       llvm::Value *operand);
 
+    // Binary operation dispatch (user-defined → any → built-in)
+    llvm::Value *emitBinaryOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
+                               const std::string &llNameHint = "");
+
     // BinaryExpr sub-dispatchers (B2)
     llvm::Value *emitComparisonOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
                                    const std::string &llNameHint = "");

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -69,8 +69,8 @@ private:
     void parseContractClause(const std::string &clauseName, std::vector<ExprPtr> &out);
     void parseEnsureClause(FnStmt &fn);
 
-    // Desugar helper: x = x op rhs
-    AssignStmt makeDesugarAssign(const Token &nameTok, const Token &opTok, const std::string &op, ExprPtr rhs);
+    // Compound assignment helper: x op= rhs
+    AssignStmt makeCompoundAssign(const Token &nameTok, const std::string &op, ExprPtr rhs);
 
     // Binary expression helper (left-associative)
     using ParseFn = ExprPtr (Parser::*)();

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -658,6 +658,15 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
     llvm::Value *rhs = emitExpr(*e->rhs);
     const std::string &op = e->op;
 
+    // Compute low-level type name hint from AST suffixes for constant operands (#311).
+    std::string llHint = getExprLowLevelSuffix(*e->lhs);
+    if (llHint.empty()) llHint = getExprLowLevelSuffix(*e->rhs);
+
+    return emitBinaryOp(op, lhs, rhs, llHint);
+}
+
+llvm::Value *CodeGen::emitBinaryOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
+                                    const std::string &llNameHint) {
     // Try user-defined binary operator first
     std::string opFnName = "operator" + op;
     if (auto *result = tryOperatorCall(opFnName, lhs, rhs))
@@ -670,19 +679,15 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
         return emitAnyBinaryOp(op, lhs, rhs);
     }
 
-    // Compute low-level type name hint from AST suffixes for constant operands (#311).
-    std::string llHint = getExprLowLevelSuffix(*e->lhs);
-    if (llHint.empty()) llHint = getExprLowLevelSuffix(*e->rhs);
-
     if (op == "==" || op == "!=" || op == "<" ||
         op == "<=" || op == ">"  || op == ">=")
-        return emitComparisonOp(op, lhs, rhs, llHint);
+        return emitComparisonOp(op, lhs, rhs, llNameHint);
 
     if (op == "&" || op == "|" || op == "^" ||
         op == "<<" || op == ">>" || op == ">>>")
-        return emitBitwiseOp(op, lhs, rhs, llHint);
+        return emitBitwiseOp(op, lhs, rhs, llNameHint);
 
-    return emitArithmeticOp(op, lhs, rhs, llHint);
+    return emitArithmeticOp(op, lhs, rhs, llNameHint);
 }
 
 void CodeGen::emitStmt(RecordStmt &s) {

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -467,6 +467,37 @@ void CodeGen::emitStmt(AssignStmt &s) {
     if (isImmutable(s.name))
         codegenError("cannot reassign @const variable: " + s.name);
 
+    // Compound assignment resolution: operator+= → operator+ → built-in
+    if (s.compound_op) {
+        llvm::Value *currentVal = builder_.CreateLoad(ptr->getAllocatedType(), ptr, s.name);
+        llvm::Value *rhs = emitExpr(*s.value);
+
+        // Priority 1: user-defined compound assignment operator (e.g., operator+=)
+        std::string compoundOpName = "operator" + *s.compound_op + "=";
+        llvm::Value *result = tryOperatorCall(compoundOpName, currentVal, rhs);
+
+        if (!result) {
+            // Priority 2: user-defined binary operator or built-in (e.g., operator+)
+            result = emitBinaryOp(*s.compound_op, currentVal, rhs);
+        }
+
+        // Type compatibility check (same as plain assignment path)
+        llvm::Type *varTy = ptr->getAllocatedType();
+        if (result->getType() != varTy) {
+            if (varTy == i8Ty_ && result->getType() == i64Ty_) {
+                result = builder_.CreateTrunc(result, i8Ty_, "bytetrunc");
+            } else if (isAnyType(varTy)) {
+                result = wrapInAny(result);
+            } else {
+                codegenError("type error: compound assignment on '" + s.name +
+                    "' produces incompatible type");
+            }
+        }
+
+        builder_.CreateStore(result, ptr);
+        return;
+    }
+
     // Handle None literal in assignment
     if (auto *ve = std::get_if<VariableExpr>(&s.value->data); ve && ve->name == "None") {
         llvm::Type *varTy = ptr->getAllocatedType();

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -544,7 +544,11 @@ void Formatter::formatAssign(const AssignStmt &s) {
         return;
     }
 
-    emit(" = ");
+    if (s.compound_op) {
+        emit(" " + *s.compound_op + "= ");
+    } else {
+        emit(" = ");
+    }
 
     // Check if value is a multi-line lambda
     if (auto *lambda_ptr = std::get_if<std::unique_ptr<LambdaExpr>>(&s.value->data)) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -34,22 +34,13 @@ static bool isSnakeCase(const std::string &name) {
     parseError(lex_.peek().line, msg);
 }
 
-// ===== Desugar helper: x = x op rhs =====
+// ===== Compound assignment helper: x op= rhs =====
 
-AssignStmt Parser::makeDesugarAssign(const Token &nameTok, const Token &opTok, const std::string &op, ExprPtr rhs) {
-    auto varRef = std::make_unique<ExprNode>();
-    varRef->data = VariableExpr{nameTok.value};
-    varRef->loc = locFromToken(nameTok);
-    auto bin = std::make_unique<BinaryExpr>();
-    bin->op = op;
-    bin->lhs = std::move(varRef);
-    bin->rhs = std::move(rhs);
-    auto binNode = std::make_unique<ExprNode>();
-    binNode->data = std::move(bin);
-    binNode->loc = locFromToken(opTok);
+AssignStmt Parser::makeCompoundAssign(const Token &nameTok, const std::string &op, ExprPtr rhs) {
     AssignStmt s;
     s.name = nameTok.value;
-    s.value = std::move(binNode);
+    s.value = std::move(rhs);
+    s.compound_op = op;
     s.loc = locFromToken(nameTok);
     return s;
 }
@@ -477,17 +468,17 @@ StmtNode Parser::parseStatement() {
                next.kind == TokenKind::LessLessEq || next.kind == TokenKind::GreaterGreaterEq) {
         if (!directives.empty())
             parseError(first.line, "directives are not supported on compound assignment");
-        // Compound assignment: desugar x += e → x = x + e
+        // Compound assignment: preserve compound_op for codegen resolution
         Token opTok = lex_.next(); // consume +=, -=, //=, **=, etc.
         std::string op = opTok.value.substr(0, opTok.value.size() - 1); // extract "//" from "//="
-        return makeDesugarAssign(first, opTok, op, parseTernary());
+        return makeCompoundAssign(first, op, parseTernary());
     } else if (next.kind == TokenKind::PlusPlus || next.kind == TokenKind::MinusMinus) {
         Token opTok = lex_.next(); // consume ++ or --
         std::string op = (opTok.kind == TokenKind::PlusPlus) ? "+" : "-";
         auto one = std::make_unique<ExprNode>();
         one->data = NumberExpr{1, ""};
         one->loc = locFromToken(first);
-        return makeDesugarAssign(first, opTok, op, std::move(one));
+        return makeCompoundAssign(first, op, std::move(one));
     } else if (next.kind == TokenKind::LParen) {
         if (!directives.empty())
             parseError(first.line, "directives are not supported on function calls");

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -60,6 +60,14 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
             case TokenKind::GreaterGreaterGreater:
             case TokenKind::And: case TokenKind::Or:
             case TokenKind::Not:
+            // Compound assignment operators
+            case TokenKind::PlusEq: case TokenKind::MinusEq:
+            case TokenKind::StarEq: case TokenKind::SlashEq:
+            case TokenKind::PercentEq: case TokenKind::SlashSlashEq:
+            case TokenKind::StarStarEq:
+            case TokenKind::AmpEq: case TokenKind::PipeEq:
+            case TokenKind::CaretEq:
+            case TokenKind::LessLessEq: case TokenKind::GreaterGreaterEq:
                 opName = opTok.value;
                 lex_.next(); // consume operator
                 break;
@@ -144,6 +152,9 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         if (opName == "operator~" || opName == "operatornot") {
             if (nParams != 1)
                 parseError("unary operator requires exactly 1 parameter");
+        } else if (isCompoundAssignOperator(opName)) {
+            if (nParams != 2)
+                parseError("compound assignment operator requires exactly 2 parameters");
         } else if (nParams != 1 && nParams != 2) {
             parseError("operator function requires 1 or 2 parameters");
         }

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -31,6 +31,9 @@ fn operator+(a: Vec2, b: Vec2) -> Vec2:
 fn operator==(a: Vec2, b: Vec2) -> bool:
   return a.x == b.x and a.y == b.y
 
+fn operator+=(a: Vec2, b: Vec2) -> Vec2:
+  return Vec2(a.x + b.x, a.y + b.y)
+
 describe("basic function", fn():
   it("call", fn():
     expect(add(1, 2)).to_eq(3)
@@ -143,5 +146,11 @@ describe("operator overloading", fn():
     v1 = Vec2(1.0, 2.0)
     v2 = Vec2(1.0, 2.0)
     expect(v1 == v2).to_be_true()
+  )
+  it("compound += calls operator+=", fn():
+    v = Vec2(1.0, 2.0)
+    v += Vec2(3.0, 4.0)
+    expect(v.x).to_eq(4.0)
+    expect(v.y).to_eq(6.0)
   )
 )

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -806,6 +806,95 @@ TEST_F(CodeGenTest, OperatorOverloadStruct) {
     }
 }
 
+// ===== Compound assignment operator overloading =====
+
+TEST_F(CodeGenTest, CompoundAssignWithOperatorPlusEq) {
+    // operator+= defined → called directly
+    std::string src =
+        "record Vec2:\n"
+        "    x: int\n"
+        "    y: int\n"
+        "fn operator+=(a: Vec2, b: Vec2) -> Vec2:\n"
+        "    return Vec2(a.x + b.x, a.y + b.y)\n"
+        "v = Vec2(1, 2)\n"
+        "v += Vec2(3, 4)\n"
+        "print(v.x)\n"
+        "print(v.y)";
+    EXPECT_EQ(runSource(src), "4\n6\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignFallbackToOperatorPlus) {
+    // operator+= NOT defined, operator+ defined → fallback
+    std::string src =
+        "record Vec2:\n"
+        "    x: int\n"
+        "    y: int\n"
+        "fn operator+(a: Vec2, b: Vec2) -> Vec2:\n"
+        "    return Vec2(a.x + b.x, a.y + b.y)\n"
+        "v = Vec2(1, 2)\n"
+        "v += Vec2(3, 4)\n"
+        "print(v.x)\n"
+        "print(v.y)";
+    EXPECT_EQ(runSource(src), "4\n6\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignBuiltinStillWorks) {
+    // Built-in int compound assignment
+    std::string src =
+        "x = 10\n"
+        "x += 5\n"
+        "x -= 3\n"
+        "x *= 2\n"
+        "print(x)";
+    EXPECT_EQ(runSource(src), "24\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignPriorityOverPlus) {
+    // operator+= takes priority over operator+ when both are defined
+    std::string src =
+        "record Counter:\n"
+        "    val: int\n"
+        "fn operator+(a: Counter, b: Counter) -> Counter:\n"
+        "    return Counter(a.val + b.val + 100)\n"
+        "fn operator+=(a: Counter, b: Counter) -> Counter:\n"
+        "    return Counter(a.val + b.val)\n"
+        "c = Counter(1)\n"
+        "c += Counter(2)\n"
+        "print(c.val)";
+    EXPECT_EQ(runSource(src), "3\n");
+}
+
+TEST_F(CodeGenTest, CompoundAssignAllBuiltinOps) {
+    std::string src =
+        "x = 100\n"
+        "x += 10\n"   // 110
+        "x -= 10\n"   // 100
+        "x *= 3\n"    // 300
+        "x //= 7\n"   // 42
+        "x %= 10\n"   // 2
+        "print(x)\n"
+        "z = 0b1100\n"
+        "z &= 0b1010\n"  // 0b1000 = 8
+        "z |= 0b0011\n"  // 0b1011 = 11
+        "z ^= 0b0001\n"  // 0b1010 = 10
+        "print(z)\n"
+        "w = 1\n"
+        "w <<= 3\n"   // 8
+        "w >>= 1\n"   // 4
+        "print(w)";
+    EXPECT_EQ(runSource(src), "2\n10\n4\n");
+}
+
+TEST_F(CodeGenTest, IncrementDecrementStillWorks) {
+    std::string src =
+        "x = 5\n"
+        "x++\n"
+        "x++\n"
+        "x--\n"
+        "print(x)";
+    EXPECT_EQ(runSource(src), "6\n");
+}
+
 // ===== List element assignment =====
 
 TEST_F(CodeGenTest, ListIndexAssignTypes) {

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -183,19 +183,19 @@ TEST(Formatter, ControlFlow) {
     // For loop
     {
         auto src = "for i in range(5):\n    sum += i\n";
-        auto expected = "for i in range(5):\n  sum = sum + i\n";
+        auto expected = "for i in range(5):\n  sum += i\n";
         EXPECT_EQ(fmt(src), expected);
     }
     // For loop with two vars
     {
         auto src = "for k, v in m:\n    total += v\n";
-        auto expected = "for k, v in m:\n  total = total + v\n";
+        auto expected = "for k, v in m:\n  total += v\n";
         EXPECT_EQ(fmt(src), expected);
     }
     // While loop
     {
         auto src = "while i < 5:\n    i += 1\n";
-        auto expected = "while i < 5:\n  i = i + 1\n";
+        auto expected = "while i < 5:\n  i += 1\n";
         EXPECT_EQ(fmt(src), expected);
     }
     // Match statement

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -853,6 +853,84 @@ TEST(ParserTest, OperatorPlusReturnsNonBoolOk) {
     EXPECT_EQ(prog.size(), 1u);
 }
 
+// ===== Compound assignment operator tests =====
+
+TEST(ParserTest, CompoundAssignPreservesOp) {
+    Program prog = parseStr("x += 1\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    EXPECT_EQ(s.name, "x");
+    ASSERT_TRUE(s.compound_op.has_value());
+    EXPECT_EQ(*s.compound_op, "+");
+    ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.value->data));
+    EXPECT_EQ(std::get<NumberExpr>(s.value->data).value, 1);
+}
+
+TEST(ParserTest, CompoundAssignAllOperators) {
+    std::vector<std::pair<std::string, std::string>> cases = {
+        {"x += 1\n", "+"}, {"x -= 1\n", "-"}, {"x *= 1\n", "*"},
+        {"x /= 1\n", "/"}, {"x %= 1\n", "%"}, {"x //= 1\n", "//"},
+        {"x **= 1\n", "**"}, {"x &= 1\n", "&"}, {"x |= 1\n", "|"},
+        {"x ^= 1\n", "^"}, {"x <<= 1\n", "<<"}, {"x >>= 1\n", ">>"},
+    };
+    for (auto &[src, expected_op] : cases) {
+        Program prog = parseStr(src);
+        ASSERT_EQ(prog.size(), 1u) << "Failed for: " << src;
+        const auto &s = std::get<AssignStmt>(prog[0]);
+        ASSERT_TRUE(s.compound_op.has_value()) << "Failed for: " << src;
+        EXPECT_EQ(*s.compound_op, expected_op) << "Failed for: " << src;
+    }
+}
+
+TEST(ParserTest, IncrementPreservesCompoundOp) {
+    Program prog = parseStr("x++\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    EXPECT_EQ(s.name, "x");
+    ASSERT_TRUE(s.compound_op.has_value());
+    EXPECT_EQ(*s.compound_op, "+");
+    ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.value->data));
+    EXPECT_EQ(std::get<NumberExpr>(s.value->data).value, 1);
+}
+
+TEST(ParserTest, DecrementPreservesCompoundOp) {
+    Program prog = parseStr("x--\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    EXPECT_EQ(s.name, "x");
+    ASSERT_TRUE(s.compound_op.has_value());
+    EXPECT_EQ(*s.compound_op, "-");
+}
+
+TEST(ParserTest, OperatorFnCompoundPlusEq) {
+    std::string src =
+        "fn operator+=(a: Vec2, b: Vec2) -> Vec2:\n"
+        "    return a\n";
+    Program prog = parseStr(src);
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FnStmt>>(prog[0]));
+    const auto &fn = std::get<std::unique_ptr<FnStmt>>(prog[0]);
+    EXPECT_EQ(fn->name, "operator+=");
+    EXPECT_TRUE(fn->is_operator);
+    ASSERT_EQ(fn->params.size(), 2u);
+    EXPECT_EQ(fn->params[0].name, "a");
+    EXPECT_EQ(fn->params[0].type, "Vec2");
+    EXPECT_EQ(fn->return_type, "Vec2");
+}
+
+TEST(ParserTest, OperatorFnCompoundAssignRequiresTwoParams) {
+    EXPECT_THROW(
+        parseStr("fn operator+=(a: Vec2) -> Vec2:\n    return a\n"),
+        std::runtime_error);
+}
+
+TEST(ParserTest, PlainAssignHasNoCompoundOp) {
+    Program prog = parseStr("x = 1\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    EXPECT_FALSE(s.compound_op.has_value());
+}
+
 // ===== Set パーサーテスト =====
 
 TEST(ParserTest, SetLiteral) {


### PR DESCRIPTION
## Summary

Closes #204

- `fn operator+=` 等の複合代入演算子を独立してオーバーロード可能にした
- 未定義時は `operator+` → built-in の順でフォールバック
- パーサーでのデシュガリングを廃止し、AST に `compound_op` フィールドを保持する方式に変更
- `emitBinaryOp` ヘルパーを抽出し、BinaryExpr と複合代入の codegen で再利用

### Resolution Priority

1. `operator+=` が定義されている → 直接呼び出し（in-place）
2. `operator+=` 未定義、`operator+` 定義あり → `x = x + y` にフォールバック
3. どちらも未定義（非組み込み型） → コンパイルエラー

### Supported Compound Assignment Operators

`+=` `-=` `*=` `/=` `%=` `//=` `**=` `&=` `|=` `^=` `<<=` `>>=`

## Test plan

- [x] パーサーテスト 7 件追加（compound_op 保持、operator+= 宣言、バリデーション）
- [x] コード生成テスト 6 件追加（operator+= 直接呼出、フォールバック、優先度、built-in、++/--）
- [x] Ry spec テスト追加（operator+= オーバーロード on Vec2）
- [x] 全 C++ テスト 1010/1010 通過
- [x] 全 Ry spec テスト 38 ファイル 0 failures