### PR TITLE
fix: use FetchContent for GoogleTest to fix nightly CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,8 +40,15 @@ llvm_map_components_to_libnames(LLVM_LIBS
     ${RY_ARCH_COMPONENTS} targetparser
 )
 
-# ===== GoogleTest =====
-find_package(GTest REQUIRED)
+# ===== GoogleTest (FetchContent) =====
+include(FetchContent)
+FetchContent_Declare(
+    googletest
+    URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.tar.gz
+    DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
 
 # ===== 共有ライブラリ =====
 add_library(ry_lib STATIC


### PR DESCRIPTION
## Summary

- Dev Release nightly CI が 3/27, 3/28 と連続で失敗していた
- 原因: `v0.0.5` の `CMakeLists.txt` が `find_package(GTest REQUIRED)` を使っているが、`main` の nightly ジョブは `brew install googletest` をしていない
- `FetchContent` 方式に変更し、`main` ブランチと統一

## Test plan

- [x] `cmake --preset default && cmake --build build` ビルド成功
- [x] `./build/ry_tests` — 1001 tests passed
- [x] `RY_ENV=internal ./build/ry test` — 38 test files, 0 failures