### PR TITLE
fix: apply test timeout per it-block instead of per file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 cmake --preset default                                  # Ninja + LLVM（CMakePresets.json）
 cmake --build build                                     # Ninja が自動並列ビルド
 ./build/ry_tests                                        # C++ テスト (GoogleTest)
-RY_ENV=internal ./build/ry test                         # Ry セルフテスト (全 *.test.ry)
+RY_ENV=internal ./build/ry test -p                       # Ry セルフテスト (全 *.test.ry)
 RY_ENV=internal ./build/ry test tests/spec/<file>.test.ry # 個別ファイル実行
 ```
 
@@ -174,7 +174,7 @@ static const StdlibDispatcher stdlib_dispatchers[] = {
 全テストを実行して成功を確認する。
 
 ```bash
-cmake --preset default && cmake --build build && ./build/ry_tests && RY_ENV=internal ./build/ry test
+cmake --preset default && cmake --build build && ./build/ry_tests && RY_ENV=internal ./build/ry test -p
 ```
 
 テストが失敗した場合は、原因を修正してから作業完了とすること。

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,7 +51,7 @@ using namespace llvm::orc;
 namespace fs = std::filesystem;
 
 static void test_timeout_handler(int) {
-    const char msg[] = "\nTest timed out (30s)\n";
+    const char msg[] = "\nTest timed out (60s)\n";
     (void)write(STDERR_FILENO, msg, sizeof(msg) - 1);
     _exit(124);
 }
@@ -236,11 +236,8 @@ static int runRySource(const std::string &src, const std::string &source_name,
 
     if (test_mode) {
         std::signal(SIGALRM, test_timeout_handler);
-        alarm(30);
     }
     int result = fn();
-    if (test_mode)
-        alarm(0);
 
     // Record filenames for coverage reporting (accumulates across calls).
     // Exclude stdlib files (those under lib_dir) from the report.

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <random>
 #include <string>
+#include <unistd.h>
 #include <unordered_map>
 
 static int g_passed = 0;
@@ -30,9 +31,11 @@ void __ry_test_describe_end() {
 void __ry_test_it_begin(const char *name) {
     g_current_it = name;
     g_current_it_failed = false;
+    alarm(60);
 }
 
 void __ry_test_it_end() {
+    alarm(0);
     __ry_mock_clear_all();
     if (g_current_it_failed) {
         std::printf("  \033[31m- %s\033[0m\n", g_current_it.c_str());


### PR DESCRIPTION
## Summary
- テストタイムアウトの粒度をファイル単位から `it` ブロック単位に変更
- タイムアウト時間を 30秒 → 60秒 に変更
- `__ry_test_it_begin()` / `__ry_test_it_end()` 内で `alarm(60)` / `alarm(0)` を呼び出し、全 it バリアント（`@each`, `@property` 含む）を自動的にカバー
- CLAUDE.md の全テスト実行コマンドに `-p` オプションを追記

## Test plan
- [x] C++ テスト (GoogleTest): 1020 tests passed
- [x] Ry セルフテスト: 38 test files, 0 failures