### PR TITLE
feat: implicit widening conversion in overload resolution

### DIFF
--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -130,10 +130,13 @@ b = area(3, 4)    # 12
 When multiple overloads match a call, the compiler selects the most specific one using the following priority (highest first):
 
 1. **Exact type match** — argument type matches parameter type exactly
-2. **Union type match** — argument type is a member of a union parameter type
-3. **`any` type match** — parameter type is `any` (accepts anything)
+2. **Implicit widening** — safe widening conversion (`byte` → `int`, `byte` → `float`, `int` → `float`)
+3. **Union type match** — argument type is a member of a union parameter type
+4. **`any` type match** — parameter type is `any` (accepts anything)
 
 The overload with the most exact matches wins. If two or more overloads have equal specificity, the compiler reports an ambiguity error.
+
+Low-level numeric types (`i8`, `i16`, `i32`, `i64`, `u8`–`u64`, `f32`) do **not** participate in implicit widening — they require explicit `as` casts.
 
 ```python
 fn process(x: int) -> str:
@@ -144,6 +147,13 @@ fn process(x) -> str:          # x: any
 
 process(42)       # "int" — exact match (int) beats any
 process("hello")  # "any" — no exact match for str, falls back to any
+```
+
+```python
+fn double(x: float) -> float:
+    return x * 2.0
+
+double(5)         # OK — int is implicitly widened to float, returns 10.0
 ```
 
 ---

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -624,7 +624,7 @@ result = add_one(v)   # any(int) is unwrapped to int; result is 43
 
 ## Type Safety Constraints
 
-- **No implicit type conversions** -- Mixing `int` and `float` triggers float promotion, but no other implicit conversions exist. `byte` is automatically promoted to `int` during operations (ZExt). Narrowing conversion from an `int` literal to `byte` is only allowed with a type annotation `b: byte = 42`.
+- **Implicit widening conversions** -- Safe widening conversions are supported in function calls: `byte` → `int`, `byte` → `float`, `int` → `float`. For binary operators, mixing `int` and `float` triggers float promotion, and `byte` is automatically promoted to `int` (ZExt). Narrowing conversions (e.g., `float` → `int`) are not allowed implicitly. Narrowing conversion from an `int` literal to `byte` is only allowed with a type annotation `b: byte = 42`.
 - **Variable types are fixed at declaration** -- A variable declared as `int` cannot be reassigned a `float` value.
 - **Bitwise operations are for `int` only** -- Applying bitwise operations to `float` or `bool` causes a compile error.
 - **Non-`bool` types can be used in conditions** -- `if` conditions accept `int` (0 = false, non-zero = true) and other types besides `bool`.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -293,6 +293,11 @@ private:
     llvm::Value *promoteToInt(llvm::Value *v);
     std::pair<llvm::Value*, llvm::Value*> promoteToFloat(llvm::Value *lhs, llvm::Value *rhs);
 
+    // Implicit widening conversion helpers
+    bool isWideningConversion(llvm::Value *argVal, llvm::Type *paramTy,
+                              const std::string &paramTypeName) const;
+    llvm::Value *emitWideningConversion(llvm::Value *argVal, llvm::Type *paramTy);
+
     llvm::Value *emitExpr(const ExprNode &node);
     llvm::Value *emitExprVariant(const NumberExpr &e);
     llvm::Value *emitExprVariant(const FloatExpr &e);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -340,6 +340,29 @@ std::pair<llvm::Value*, llvm::Value*> CodeGen::promoteToFloat(llvm::Value *lhs, 
 }
 
 
+// ===== B3.5: Implicit widening conversion helpers =====
+
+bool CodeGen::isWideningConversion(llvm::Value *argVal, llvm::Type *paramTy,
+                                   const std::string &paramTypeName) const {
+    if (isLowLevelTy(argVal)) return false;
+    if (isLowLevelTypeName(paramTypeName)) return false;
+    auto *argTy = argVal->getType();
+    return (argTy == i8Ty_  && paramTy == i64Ty_) ||   // byte -> int
+           (argTy == i8Ty_  && paramTy == f64Ty_) ||   // byte -> float
+           (argTy == i64Ty_ && paramTy == f64Ty_);     // int  -> float
+}
+
+llvm::Value *CodeGen::emitWideningConversion(llvm::Value *argVal, llvm::Type *paramTy) {
+    auto *argTy = argVal->getType();
+    if (argTy == i8Ty_ && paramTy == i64Ty_)
+        return promoteToInt(argVal);
+    if (argTy == i8Ty_ && paramTy == f64Ty_)
+        return builder_.CreateUIToFP(argVal, f64Ty_, "byte_to_float");
+    if (argTy == i64Ty_ && paramTy == f64Ty_)
+        return builder_.CreateSIToFP(argVal, f64Ty_, "int_to_float");
+    llvm_unreachable("invalid widening conversion");
+}
+
 // ===== B4: emitUserFnCall =====
 
 llvm::Function *CodeGen::resolveOverload(const std::string &callee,
@@ -376,6 +399,7 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
     struct RankedCandidate {
         OverloadEntry *entry;
         int exactMatches = 0;
+        int wideningMatches = 0;
         int unionMatches = 0;
         int anyMatches = 0;
     };
@@ -383,6 +407,8 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
     auto isBetterCandidate = [](const RankedCandidate &lhs, const RankedCandidate &rhs) {
         if (lhs.exactMatches != rhs.exactMatches)
             return lhs.exactMatches > rhs.exactMatches;
+        if (lhs.wideningMatches != rhs.wideningMatches)
+            return lhs.wideningMatches > rhs.wideningMatches;
         if (lhs.unionMatches != rhs.unionMatches)
             return lhs.unionMatches > rhs.unionMatches;
         if (lhs.anyMatches != rhs.anyMatches)
@@ -396,7 +422,7 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
         if (entry.paramTypes.size() != args.size())
             continue;
         bool match = true;
-        RankedCandidate candidate{&entry, 0, 0, 0};
+        RankedCandidate candidate{&entry, 0, 0, 0, 0};
         for (size_t i = 0; i < args.size(); ++i) {
             std::string resolvedParamTypeName =
                 i < entry.paramTypeNames.size() ? resolveTypeAlias(entry.paramTypeNames[i]) : "";
@@ -407,6 +433,11 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
 
             if (emittedArgs[i]->getType() == entry.paramTypes[i]) {
                 candidate.exactMatches++;
+                continue;
+            }
+
+            if (isWideningConversion(emittedArgs[i], entry.paramTypes[i], resolvedParamTypeName)) {
+                candidate.wideningMatches++;
                 continue;
             }
 
@@ -461,6 +492,9 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
             i < chosen->paramTypeNames.size() ? resolveTypeAlias(chosen->paramTypeNames[i]) : "";
         if (isNone[i]) {
             outArgVals.push_back(buildNoneValue(chosen->paramTypes[i]));
+        } else if (emittedArgs[i]->getType() != chosen->paramTypes[i] &&
+                   isWideningConversion(emittedArgs[i], chosen->paramTypes[i], resolvedParamTypeName)) {
+            outArgVals.push_back(emitWideningConversion(emittedArgs[i], chosen->paramTypes[i]));
         } else if (emittedArgs[i]->getType() != chosen->paramTypes[i] &&
                    isAnyType(chosen->paramTypes[i])) {
             outArgVals.push_back(wrapInAny(emittedArgs[i]));

--- a/tests/spec/implicit_widening.test.ry
+++ b/tests/spec/implicit_widening.test.ry
@@ -1,0 +1,84 @@
+# --- helper functions ---
+
+fn double_float(x: float) -> float:
+  return x * 2.0
+
+fn accept_int(x: int) -> int:
+  return x
+
+fn accept_float(x: float) -> float:
+  return x
+
+fn add_floats(x: float, y: float) -> float:
+  return x + y
+
+# overload: exact match should win
+fn typed(x: int) -> str:
+  return "int"
+
+fn typed(x: float) -> str:
+  return "float"
+
+# overload: widening should win over any
+fn prefer_widening(x: float) -> str:
+  return "float"
+
+fn prefer_widening(x) -> str:
+  return "any"
+
+# --- tests ---
+
+describe("basic implicit widening", fn():
+  it("int to float", fn():
+    result = double_float(5)
+    expect(result).to_eq(10.0)
+  )
+
+  it("byte to int", fn():
+    b: byte = 200
+    result = accept_int(b)
+    expect(result).to_eq(200)
+  )
+
+  it("byte to float", fn():
+    b: byte = 42
+    result = accept_float(b)
+    expect(result).to_eq(42.0)
+  )
+)
+
+describe("return value correctness", fn():
+  it("int widened to float returns float", fn():
+    result = double_float(5)
+    expect(result).to_eq(10.0)
+  )
+
+  it("byte widened to int preserves unsigned value", fn():
+    b: byte = 255
+    result = accept_int(b)
+    expect(result).to_eq(255)
+  )
+)
+
+describe("overload resolution priority", fn():
+  it("exact match wins over widening", fn():
+    expect(typed(5)).to_eq("int")
+    expect(typed(5.0)).to_eq("float")
+  )
+
+  it("widening wins over any", fn():
+    expect(prefer_widening(5)).to_eq("float")
+  )
+)
+
+describe("multi-arg widening", fn():
+  it("both args widened", fn():
+    result = add_floats(1, 2)
+    expect(result).to_eq(3.0)
+  )
+
+  it("mixed: one exact, one widened", fn():
+    result = add_floats(1, 2.0)
+    expect(result).to_eq(3.0)
+  )
+)


### PR DESCRIPTION
## Summary

- オーバーロード解決に安全な暗黙的拡大変換（widening conversion）を導入
  - `byte` → `int`、`byte` → `float`、`int` → `float` の3パターン
  - `fn double(x: float) -> float` を `double(5)` で呼べるようになる
- 解決優先順位: `exact > widening > union > any`
- 低レベル型（`i8`〜`i64`, `u8`〜`u64`, `f32`）は対象外（明示的 `as` キャスト必須）

Closes #212

## Test plan

- [x] 基本変換テスト（int→float, byte→int, byte→float）
- [x] 戻り値の正確性（unsigned byte の値保持、float 型の戻り値）
- [x] オーバーロード優先度（exact > widening, widening > any）
- [x] 複数引数の widening
- [x] C++ テスト 1020 件全合格
- [x] Ry セルフテスト 39 ファイル全合格