### PR TITLE
refactor: split runtime_http headers, extract helpers, and decompose large functions

### DIFF
--- a/include/ry/runtime_http_internal.hpp
+++ b/include/ry/runtime_http_internal.hpp
@@ -1,15 +1,10 @@
 #pragma once
 
-// Internal shared header for runtime_http*.cpp files.
-// NOT part of the public API — do not include from codegen or other modules.
+// Internal shared header for runtime_http*.cpp files that need network transport.
+// Includes OpenSSL and HttpTransport. For code that only needs struct definitions
+// and helpers (e.g., multipart parsing), use runtime_http_types.hpp instead.
 
-#include <cstdint>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-#include <string>
-#include <strings.h>
-#include <vector>
+#include "ry/runtime_http_types.hpp"
 
 #include <sys/socket.h>
 #include <unistd.h>
@@ -19,96 +14,14 @@
 #include "ry/runtime_net.hpp"
 #include "ry/runtime_tls.hpp"
 
-// Forward declarations for runtime functions used by HTTP code
-extern "C" {
-int64_t __ry_http_parse_content_length(const char *value);
-int64_t *__ry_ht_rehash_str(const char **keys, int64_t count,
-                             int64_t newBucketCount);
-}
-
 // ---------------------------------------------------------------------------
-// Constants
+// Constants (transport-specific)
 // ---------------------------------------------------------------------------
-inline constexpr int64_t MAX_BODY_SIZE = 10 * 1024 * 1024; // 10 MB
 inline constexpr int MAX_REDIRECTS = 10;
-inline constexpr size_t kRecvBufSize = 4096;
-inline constexpr size_t kMaxHeaderSize = 8192;
 
 // ---------------------------------------------------------------------------
-// Struct definitions — layouts must match codegen expectations
+// Network transport abstraction
 // ---------------------------------------------------------------------------
-
-struct FormFieldEntry {
-    char *key;
-    char *value;
-};
-
-struct FormFileEntry {
-    char *name;
-    char *filename;
-    char *content_type;
-    char *data;
-    int64_t data_len;
-};
-
-struct HttpRequestHandle {
-    char *method;
-    char *path;
-    char **header_keys;
-    char **header_values;
-    int64_t header_count;
-    char *body;
-    int64_t body_len;
-    char **query_keys;
-    char **query_values;
-    int64_t query_count;
-    char **cookie_keys;
-    char **cookie_values;
-    int64_t cookie_count;
-    // Multipart form data (parsed lazily on first access)
-    bool form_parsed;
-    FormFieldEntry *form_fields;
-    int64_t form_field_count;
-    FormFileEntry *form_files;
-    int64_t form_file_count;
-};
-
-struct HttpResponseHandle {
-    int64_t status;
-    char **header_keys;
-    char **header_values;
-    int64_t header_count;
-    char *body;
-    int64_t body_len;
-};
-
-// MapHeader layout must match codegen: {len, cap, keys, vals, bucket_count, buckets}
-struct MapHeader {
-    int64_t len;
-    int64_t cap;
-    char **keys;
-    char **vals;
-    int64_t bucket_count;
-    void *buckets;
-};
-
-struct HeaderPair { char *key; char *val; };
-
-struct HttpClientResponseHandle {
-    int64_t status;
-    char **header_keys;
-    char **header_values;
-    int64_t header_count;
-    char *body;
-    int64_t body_len;
-};
-
-struct ParsedUrl {
-    char *host;
-    int64_t port;
-    char *path;
-    bool is_https;
-};
 
 struct HttpTransport {
     int fd;
@@ -145,89 +58,6 @@ struct HttpTransport {
         }
     }
 };
-
-// ---------------------------------------------------------------------------
-// OOM-safe allocation helpers
-// ---------------------------------------------------------------------------
-
-[[noreturn]] inline void oom_abort() {
-    fprintf(stderr, "ry: out of memory\n");
-    abort();
-}
-
-inline char *checked_strndup(const char *s, size_t n) {
-    char *r = strndup(s, n);
-    if (!r) oom_abort();
-    return r;
-}
-
-inline char *checked_strdup(const char *s) {
-    char *r = strdup(s);
-    if (!r) oom_abort();
-    return r;
-}
-
-inline char *checked_memdup(const void *src, size_t len) {
-    char *r = (char *)malloc(len + 1);
-    if (!r) oom_abort();
-    memcpy(r, src, len);
-    r[len] = '\0';  // NUL-terminate for str compatibility
-    return r;
-}
-
-inline void *checked_malloc(size_t n) {
-    void *r = malloc(n);
-    if (!r) oom_abort();
-    return r;
-}
-
-// ---------------------------------------------------------------------------
-// Header parsing helpers
-// ---------------------------------------------------------------------------
-
-std::vector<HeaderPair> parse_raw_headers(const std::string &raw,
-                                           size_t start, size_t end);
-
-inline void assign_headers(const std::vector<HeaderPair> &headers,
-                           char ***keys_out, char ***values_out,
-                           int64_t *count_out) {
-    int64_t count = (int64_t)headers.size();
-    *count_out = count;
-    if (count > 0) {
-        *keys_out = (char **)checked_malloc(sizeof(char *) * (size_t)count);
-        *values_out = (char **)checked_malloc(sizeof(char *) * (size_t)count);
-        for (int64_t i = 0; i < count; i++) {
-            (*keys_out)[i] = headers[(size_t)i].key;
-            (*values_out)[i] = headers[(size_t)i].val;
-        }
-    } else {
-        *keys_out = nullptr;
-        *values_out = nullptr;
-    }
-}
-
-// Assign parallel key/value arrays from a vector, using accessor lambdas.
-template <typename T, typename KeyFn, typename ValFn>
-inline void assign_kv_pairs(const std::vector<T> &items,
-                            char ***keys_out, char ***values_out,
-                            int64_t *count_out,
-                            KeyFn get_key, ValFn get_val) {
-    auto count = (int64_t)items.size();
-    *count_out = count;
-    if (count > 0) {
-        *keys_out = (char **)checked_malloc(sizeof(char *) * (size_t)count);
-        *values_out = (char **)checked_malloc(sizeof(char *) * (size_t)count);
-        for (size_t i = 0; i < items.size(); i++) {
-            (*keys_out)[i] = get_key(items[i]);
-            (*values_out)[i] = get_val(items[i]);
-        }
-    } else {
-        *keys_out = nullptr;
-        *values_out = nullptr;
-    }
-}
-
-void *build_str_map(char **keys, char **vals, int64_t count);
 
 // ---------------------------------------------------------------------------
 // Network I/O helpers

--- a/include/ry/runtime_http_types.hpp
+++ b/include/ry/runtime_http_types.hpp
@@ -1,0 +1,221 @@
+#pragma once
+
+// Lightweight internal header for runtime_http*.cpp files.
+// Contains struct definitions, OOM helpers, and header parsing utilities.
+// Does NOT include OpenSSL or network transport — use runtime_http_internal.hpp
+// for code that needs HttpTransport or SSL.
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <strings.h>
+#include <vector>
+
+// Forward declarations for runtime functions used by HTTP code
+extern "C" {
+int64_t __ry_http_parse_content_length(const char *value);
+int64_t *__ry_ht_rehash_str(const char **keys, int64_t count,
+                             int64_t newBucketCount);
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+inline constexpr int64_t MAX_BODY_SIZE = 10 * 1024 * 1024; // 10 MB
+inline constexpr size_t kRecvBufSize = 4096;
+inline constexpr size_t kMaxHeaderSize = 8192;
+
+// ---------------------------------------------------------------------------
+// Struct definitions — layouts must match codegen expectations
+// ---------------------------------------------------------------------------
+
+struct FormFieldEntry {
+    char *key;
+    char *value;
+};
+
+struct FormFileEntry {
+    char *name;
+    char *filename;
+    char *content_type;
+    char *data;
+    int64_t data_len;
+};
+
+struct HttpRequestHandle {
+    char *method;
+    char *path;
+    char **header_keys;
+    char **header_values;
+    int64_t header_count;
+    char *body;
+    int64_t body_len;
+    char **query_keys;
+    char **query_values;
+    int64_t query_count;
+    char **cookie_keys;
+    char **cookie_values;
+    int64_t cookie_count;
+    // Multipart form data (parsed lazily on first access)
+    bool form_parsed;
+    FormFieldEntry *form_fields;
+    int64_t form_field_count;
+    FormFileEntry *form_files;
+    int64_t form_file_count;
+};
+
+struct HttpResponseHandle {
+    int64_t status;
+    char **header_keys;
+    char **header_values;
+    int64_t header_count;
+    char *body;
+    int64_t body_len;
+};
+
+// MapHeader layout must match codegen: {len, cap, keys, vals, bucket_count, buckets}
+struct MapHeader {
+    int64_t len;
+    int64_t cap;
+    char **keys;
+    char **vals;
+    int64_t bucket_count;
+    void *buckets;
+};
+
+struct HeaderPair { char *key; char *val; };
+
+struct HttpClientResponseHandle {
+    int64_t status;
+    char **header_keys;
+    char **header_values;
+    int64_t header_count;
+    char *body;
+    int64_t body_len;
+};
+
+struct ParsedUrl {
+    char *host;
+    int64_t port;
+    char *path;
+    bool is_https;
+};
+
+// ---------------------------------------------------------------------------
+// OOM-safe allocation helpers
+// ---------------------------------------------------------------------------
+
+[[noreturn]] inline void oom_abort() {
+    fprintf(stderr, "ry: out of memory\n");
+    abort();
+}
+
+inline char *checked_strndup(const char *s, size_t n) {
+    char *r = strndup(s, n);
+    if (!r) oom_abort();
+    return r;
+}
+
+inline char *checked_strdup(const char *s) {
+    char *r = strdup(s);
+    if (!r) oom_abort();
+    return r;
+}
+
+inline char *checked_memdup(const void *src, size_t len) {
+    char *r = (char *)malloc(len + 1);
+    if (!r) oom_abort();
+    memcpy(r, src, len);
+    r[len] = '\0';  // NUL-terminate for str compatibility
+    return r;
+}
+
+inline void *checked_malloc(size_t n) {
+    void *r = malloc(n);
+    if (!r) oom_abort();
+    return r;
+}
+
+// ---------------------------------------------------------------------------
+// Parallel key/value array helpers
+// ---------------------------------------------------------------------------
+
+inline void free_kv_pairs(char **keys, char **vals, int64_t count) {
+    for (int64_t i = 0; i < count; i++) {
+        free(keys[i]);
+        free(vals[i]);
+    }
+    free(keys);
+    free(vals);
+}
+
+// Case-insensitive search in parallel key/value arrays
+inline const char *find_in_kv_pairs_ci(char **keys, char **vals, int64_t count,
+                                        const char *target) {
+    for (int64_t i = 0; i < count; i++) {
+        if (strcasecmp(keys[i], target) == 0)
+            return vals[i];
+    }
+    return nullptr;
+}
+
+// Case-sensitive search in parallel key/value arrays
+inline const char *find_in_kv_pairs(char **keys, char **vals, int64_t count,
+                                     const char *target) {
+    for (int64_t i = 0; i < count; i++) {
+        if (strcmp(keys[i], target) == 0)
+            return vals[i];
+    }
+    return nullptr;
+}
+
+// ---------------------------------------------------------------------------
+// Header parsing helpers
+// ---------------------------------------------------------------------------
+
+std::vector<HeaderPair> parse_raw_headers(const std::string &raw,
+                                           size_t start, size_t end);
+
+inline void assign_headers(const std::vector<HeaderPair> &headers,
+                           char ***keys_out, char ***values_out,
+                           int64_t *count_out) {
+    int64_t count = (int64_t)headers.size();
+    *count_out = count;
+    if (count > 0) {
+        *keys_out = (char **)checked_malloc(sizeof(char *) * (size_t)count);
+        *values_out = (char **)checked_malloc(sizeof(char *) * (size_t)count);
+        for (int64_t i = 0; i < count; i++) {
+            (*keys_out)[i] = headers[(size_t)i].key;
+            (*values_out)[i] = headers[(size_t)i].val;
+        }
+    } else {
+        *keys_out = nullptr;
+        *values_out = nullptr;
+    }
+}
+
+// Assign parallel key/value arrays from a vector, using accessor lambdas.
+template <typename T, typename KeyFn, typename ValFn>
+inline void assign_kv_pairs(const std::vector<T> &items,
+                            char ***keys_out, char ***values_out,
+                            int64_t *count_out,
+                            KeyFn get_key, ValFn get_val) {
+    auto count = (int64_t)items.size();
+    *count_out = count;
+    if (count > 0) {
+        *keys_out = (char **)checked_malloc(sizeof(char *) * (size_t)count);
+        *values_out = (char **)checked_malloc(sizeof(char *) * (size_t)count);
+        for (size_t i = 0; i < items.size(); i++) {
+            (*keys_out)[i] = get_key(items[i]);
+            (*values_out)[i] = get_val(items[i]);
+        }
+    } else {
+        *keys_out = nullptr;
+        *values_out = nullptr;
+    }
+}
+
+void *build_str_map(char **keys, char **vals, int64_t count);
+void *build_str_map_copy(char **keys, char **vals, int64_t count);

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -55,6 +55,20 @@ void *build_str_map(char **keys, char **vals, int64_t count) {
     return map;
 }
 
+void *build_str_map_copy(char **keys, char **vals, int64_t count) {
+    char **dup_keys = nullptr;
+    char **dup_vals = nullptr;
+    if (count > 0) {
+        dup_keys = (char **)checked_malloc(sizeof(char *) * (size_t)count);
+        dup_vals = (char **)checked_malloc(sizeof(char *) * (size_t)count);
+        for (int64_t i = 0; i < count; i++) {
+            dup_keys[i] = checked_strdup(keys[i]);
+            dup_vals[i] = checked_strdup(vals[i]);
+        }
+    }
+    return build_str_map(dup_keys, dup_vals, count);
+}
+
 static int hex_digit(char c) {
     if (c >= '0' && c <= '9') return c - '0';
     if (c >= 'A' && c <= 'F') return c - 'A' + 10;
@@ -373,34 +387,20 @@ std::string read_chunked_body(HttpTransport &t, std::string &buf, size_t pos, bo
     return body;
 }
 
-extern "C" void *__ry_http_read_request(void *stream) {
-    auto *handle = (TcpStreamHandle *)stream;
-    struct timeval tv = {5, 0};
-    ::setsockopt(handle->fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-    std::string raw = recv_all(handle->fd, kMaxHeaderSize);
-    if (raw.empty()) return nullptr;
-
-    auto *req = (HttpRequestHandle *)checked_malloc(sizeof(HttpRequestHandle));
-    memset(req, 0, sizeof(HttpRequestHandle));
-
-    // Parse request line: METHOD PATH HTTP/x.x\r\n
+// Parse "METHOD PATH HTTP/x.x" request line and populate req->method, path, query.
+// On success, sets line_end_out to the position of the first \r\n.
+static bool parse_request_line(const std::string &raw, HttpRequestHandle *req,
+                                 size_t &line_end_out) {
     size_t line_end = raw.find("\r\n");
-    if (line_end == std::string::npos) {
-        free(req);
-        return nullptr;
-    }
+    if (line_end == std::string::npos) return false;
+
     std::string request_line = raw.substr(0, line_end);
 
-    // Parse method
     size_t sp1 = request_line.find(' ');
-    if (sp1 == std::string::npos) {
-        free(req);
-        return nullptr;
-    }
-    std::string method = request_line.substr(0, sp1);
-    req->method = checked_strdup(method.c_str());
+    if (sp1 == std::string::npos) return false;
 
-    // Parse path and query string
+    req->method = checked_strdup(request_line.substr(0, sp1).c_str());
+
     size_t sp2 = request_line.find(' ', sp1 + 1);
     std::string full_path;
     if (sp2 != std::string::npos)
@@ -416,65 +416,35 @@ extern "C" void *__ry_http_read_request(void *stream) {
         req->path = checked_strdup(full_path.c_str());
         parse_query_string("", req);
     }
+    line_end_out = line_end;
+    return true;
+}
 
-    // Parse headers
-    size_t headers_start = line_end + 2;
-    size_t headers_end = raw.find("\r\n\r\n", headers_start);
-    if (headers_end == std::string::npos) {
-        __ry_http_request_free(req);
-        return nullptr;
-    }
-
-    // Parse headers using shared helper
-    auto parsed_headers = parse_raw_headers(raw, headers_start, headers_end);
-    assign_headers(parsed_headers, &req->header_keys, &req->header_values, &req->header_count);
-
-    // Pre-parse Cookie header into req->cookie_keys/values/count
-    parse_cookie_header(req);
-
-    size_t body_start = headers_end + 4;
-    const char *cl_value = nullptr;
-    for (int64_t i = 0; i < req->header_count; i++) {
-        if (strcasecmp(req->header_keys[i], "Content-Length") == 0) {
-            cl_value = req->header_values[i];
-            break;
-        }
-    }
+// Read request body based on Content-Length or chunked Transfer-Encoding.
+static bool read_request_body(int fd, std::string &raw, size_t body_start,
+                                HttpRequestHandle *req) {
+    const char *cl_value = find_in_kv_pairs_ci(
+        req->header_keys, req->header_values, req->header_count, "Content-Length");
     bool has_te = has_transfer_encoding(req->header_keys, req->header_count);
     bool is_chunked = has_te && has_chunked_encoding(
         req->header_keys, req->header_values, req->header_count);
 
     // RFC 9112 §6.1: reject if both Transfer-Encoding and Content-Length are present
-    if (is_chunked && cl_value != nullptr) {
-        __ry_http_request_free(req);
-        return nullptr;
-    }
-
+    if (is_chunked && cl_value != nullptr) return false;
     // Reject unsupported transfer codings (e.g. gzip without chunked)
-    if (has_te && !is_chunked) {
-        __ry_http_request_free(req);
-        return nullptr;
-    }
+    if (has_te && !is_chunked) return false;
 
     if (is_chunked) {
-        // Chunked transfer encoding
         bool ok;
-        std::string body_data = read_chunked_body(handle->fd, raw, body_start, ok);
-        if (!ok) {
-            __ry_http_request_free(req);
-            return nullptr;
-        }
+        std::string body_data = read_chunked_body(fd, raw, body_start, ok);
+        if (!ok) return false;
         req->body_len = (int64_t)body_data.size();
         req->body = checked_memdup(body_data.data(), body_data.size());
-        return req;
+        return true;
     }
 
-    // Content-Length based body parsing
     int64_t content_length = __ry_http_parse_content_length(cl_value);
-    if (content_length == -2 || content_length == -3) {
-        __ry_http_request_free(req);
-        return nullptr;
-    }
+    if (content_length == -2 || content_length == -3) return false;
 
     std::string body_data;
     if (body_start < raw.size())
@@ -485,17 +455,14 @@ extern "C" void *__ry_http_read_request(void *stream) {
         char *extra = (char *)checked_malloc(remaining);
         size_t got = 0;
         while (got < remaining) {
-            ssize_t n = ::recv(handle->fd, extra + got, remaining - got, 0);
+            ssize_t n = ::recv(fd, extra + got, remaining - got, 0);
             if (n <= 0) break;
             got += (size_t)n;
         }
         body_data.append(extra, got);
         free(extra);
 
-        if ((int64_t)body_data.size() < content_length) {
-            __ry_http_request_free(req);
-            return nullptr;
-        }
+        if ((int64_t)body_data.size() < content_length) return false;
     }
 
     if (content_length >= 0 && (int64_t)body_data.size() > content_length)
@@ -503,6 +470,41 @@ extern "C" void *__ry_http_read_request(void *stream) {
 
     req->body_len = (int64_t)body_data.size();
     req->body = checked_memdup(body_data.data(), body_data.size());
+    return true;
+}
+
+extern "C" void *__ry_http_read_request(void *stream) {
+    auto *handle = (TcpStreamHandle *)stream;
+    struct timeval tv = {5, 0};
+    ::setsockopt(handle->fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    std::string raw = recv_all(handle->fd, kMaxHeaderSize);
+    if (raw.empty()) return nullptr;
+
+    auto *req = (HttpRequestHandle *)checked_malloc(sizeof(HttpRequestHandle));
+    memset(req, 0, sizeof(HttpRequestHandle));
+
+    size_t line_end;
+    if (!parse_request_line(raw, req, line_end)) {
+        free(req);
+        return nullptr;
+    }
+
+    size_t headers_start = line_end + 2;
+    size_t headers_end = raw.find("\r\n\r\n", headers_start);
+    if (headers_end == std::string::npos) {
+        __ry_http_request_free(req);
+        return nullptr;
+    }
+
+    auto parsed_headers = parse_raw_headers(raw, headers_start, headers_end);
+    assign_headers(parsed_headers, &req->header_keys, &req->header_values, &req->header_count);
+    parse_cookie_header(req);
+
+    size_t body_start = headers_end + 4;
+    if (!read_request_body(handle->fd, raw, body_start, req)) {
+        __ry_http_request_free(req);
+        return nullptr;
+    }
 
     return req;
 }
@@ -519,11 +521,7 @@ extern "C" const char *__ry_http_path(void *r) {
 
 extern "C" const char *__ry_http_header(void *r, const char *key) {
     auto *req = (HttpRequestHandle *)r;
-    for (int64_t i = 0; i < req->header_count; i++) {
-        if (strcasecmp(req->header_keys[i], key) == 0)
-            return req->header_values[i];
-    }
-    return nullptr;
+    return find_in_kv_pairs_ci(req->header_keys, req->header_values, req->header_count, key);
 }
 
 extern "C" const char *__ry_http_body(void *r) {
@@ -533,50 +531,22 @@ extern "C" const char *__ry_http_body(void *r) {
 
 extern "C" const char *__ry_http_query(void *r, const char *key) {
     auto *req = (HttpRequestHandle *)r;
-    for (int64_t i = 0; i < req->query_count; i++) {
-        if (strcmp(req->query_keys[i], key) == 0)
-            return req->query_values[i];
-    }
-    return nullptr;
+    return find_in_kv_pairs(req->query_keys, req->query_values, req->query_count, key);
 }
 
 extern "C" void *__ry_http_query_all(void *r) {
     auto *req = (HttpRequestHandle *)r;
-    char **dup_keys = nullptr;
-    char **dup_vals = nullptr;
-    if (req->query_count > 0) {
-        dup_keys = (char **)checked_malloc(sizeof(char *) * (size_t)req->query_count);
-        dup_vals = (char **)checked_malloc(sizeof(char *) * (size_t)req->query_count);
-        for (int64_t i = 0; i < req->query_count; i++) {
-            dup_keys[i] = checked_strdup(req->query_keys[i]);
-            dup_vals[i] = checked_strdup(req->query_values[i]);
-        }
-    }
-    return build_str_map(dup_keys, dup_vals, req->query_count);
+    return build_str_map_copy(req->query_keys, req->query_values, req->query_count);
 }
 
 extern "C" const char *__ry_http_cookie(void *r, const char *name) {
     auto *req = (HttpRequestHandle *)r;
-    for (int64_t i = 0; i < req->cookie_count; i++) {
-        if (strcmp(req->cookie_keys[i], name) == 0)
-            return req->cookie_values[i];
-    }
-    return nullptr;
+    return find_in_kv_pairs(req->cookie_keys, req->cookie_values, req->cookie_count, name);
 }
 
 extern "C" void *__ry_http_cookies(void *r) {
     auto *req = (HttpRequestHandle *)r;
-    char **dup_keys = nullptr;
-    char **dup_vals = nullptr;
-    if (req->cookie_count > 0) {
-        dup_keys = (char **)checked_malloc(sizeof(char *) * (size_t)req->cookie_count);
-        dup_vals = (char **)checked_malloc(sizeof(char *) * (size_t)req->cookie_count);
-        for (int64_t i = 0; i < req->cookie_count; i++) {
-            dup_keys[i] = checked_strdup(req->cookie_keys[i]);
-            dup_vals[i] = checked_strdup(req->cookie_values[i]);
-        }
-    }
-    return build_str_map(dup_keys, dup_vals, req->cookie_count);
+    return build_str_map_copy(req->cookie_keys, req->cookie_values, req->cookie_count);
 }
 
 extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, const char *body) {
@@ -726,24 +696,9 @@ extern "C" void __ry_http_request_free(void *r) {
     auto *req = (HttpRequestHandle *)r;
     free(req->method);
     free(req->path);
-    for (int64_t i = 0; i < req->header_count; i++) {
-        free(req->header_keys[i]);
-        free(req->header_values[i]);
-    }
-    free(req->header_keys);
-    free(req->header_values);
-    for (int64_t i = 0; i < req->query_count; i++) {
-        free(req->query_keys[i]);
-        free(req->query_values[i]);
-    }
-    free(req->query_keys);
-    free(req->query_values);
-    for (int64_t i = 0; i < req->cookie_count; i++) {
-        free(req->cookie_keys[i]);
-        free(req->cookie_values[i]);
-    }
-    free(req->cookie_keys);
-    free(req->cookie_values);
+    free_kv_pairs(req->header_keys, req->header_values, req->header_count);
+    free_kv_pairs(req->query_keys, req->query_values, req->query_count);
+    free_kv_pairs(req->cookie_keys, req->cookie_values, req->cookie_count);
     for (int64_t i = 0; i < req->form_field_count; i++) {
         free(req->form_fields[i].key);
         free(req->form_fields[i].value);
@@ -763,12 +718,7 @@ extern "C" void __ry_http_request_free(void *r) {
 extern "C" void __ry_http_response_free(void *r) {
     if (!r) return;
     auto *resp = (HttpResponseHandle *)r;
-    for (int64_t i = 0; i < resp->header_count; i++) {
-        free(resp->header_keys[i]);
-        free(resp->header_values[i]);
-    }
-    free(resp->header_keys);
-    free(resp->header_values);
+    free_kv_pairs(resp->header_keys, resp->header_values, resp->header_count);
     free(resp->body);
     free(resp);
 }

--- a/src/runtime_http_client.cpp
+++ b/src/runtime_http_client.cpp
@@ -78,27 +78,17 @@ extern "C" void __ry_http_parsed_url_free(void *parsed) {
     free(u);
 }
 
-static HttpClientResponseHandle *read_http_response(HttpTransport &t) {
-    __ry_apply_default_recv_timeout(t.fd);
-
-    // Read headers
-    std::string raw = recv_all(t, kMaxHeaderSize);
-    if (raw.empty()) return nullptr;
-
-    // Find header/body boundary
-    size_t hdr_end = raw.find("\r\n\r\n");
-    if (hdr_end == std::string::npos) return nullptr;
-
-    // Parse status line: HTTP/1.x STATUS REASON\r\n
+// Parse "HTTP/1.x STATUS REASON" and return status code, or -1 on failure.
+// Sets headers_start to the position after the status line.
+static int64_t parse_status_line(const std::string &raw, size_t &headers_start) {
     size_t line_end = raw.find("\r\n");
-    if (line_end == std::string::npos) return nullptr;
+    if (line_end == std::string::npos) return -1;
 
     std::string status_line = raw.substr(0, line_end);
-    // Must start with "HTTP/"
-    if (status_line.size() < 12 || status_line.substr(0, 5) != "HTTP/") return nullptr;
+    if (status_line.size() < 12 || status_line.substr(0, 5) != "HTTP/") return -1;
 
     size_t sp1 = status_line.find(' ');
-    if (sp1 == std::string::npos) return nullptr;
+    if (sp1 == std::string::npos) return -1;
     size_t sp2 = status_line.find(' ', sp1 + 1);
 
     std::string status_str;
@@ -110,86 +100,100 @@ static HttpClientResponseHandle *read_http_response(HttpTransport &t) {
     char *endptr = nullptr;
     long long status_code = strtoll(status_str.c_str(), &endptr, 10);
     if (!endptr || endptr == status_str.c_str() || status_code < 100 || status_code > 599)
-        return nullptr;
+        return -1;
 
-    // Parse headers using shared helper
-    size_t headers_start = line_end + 2;
-    auto parsed_headers = parse_raw_headers(raw, headers_start, hdr_end);
+    headers_start = line_end + 2;
+    return (int64_t)status_code;
+}
+
+// Read response body based on Transfer-Encoding or Content-Length.
+static bool read_response_body(HttpTransport &t, std::string &raw, size_t body_start,
+                                 const std::vector<HeaderPair> &headers,
+                                 std::string &body_out) {
+    bool has_te = has_transfer_encoding(headers);
+    bool is_chunked = has_te && has_chunked_encoding(headers);
+
+    // Reject unsupported transfer codings (e.g. gzip without chunked)
+    if (has_te && !is_chunked) return false;
+
+    if (is_chunked) {
+        bool ok;
+        body_out = read_chunked_body(t, raw, body_start, ok);
+        return ok;
+    }
+
+    if (body_start < raw.size())
+        body_out = raw.substr(body_start);
 
     const char *cl_value = nullptr;
-    for (auto &h : parsed_headers) {
+    for (auto &h : headers) {
         if (strcasecmp(h.key, "Content-Length") == 0) {
             cl_value = h.val;
             break;
         }
     }
-    bool has_te = has_transfer_encoding(parsed_headers);
-    bool is_chunked = has_te && has_chunked_encoding(parsed_headers);
 
-    // Reject unsupported transfer codings (e.g. gzip without chunked)
-    if (has_te && !is_chunked) {
+    int64_t content_length = __ry_http_parse_content_length(cl_value);
+    if (content_length == -2 || content_length == -3) return false;
+
+    if (content_length >= 0) {
+        if ((int64_t)body_out.size() < content_length) {
+            size_t remaining = (size_t)content_length - body_out.size();
+            char *extra = (char *)checked_malloc(remaining);
+            size_t got = 0;
+            while (got < remaining) {
+                ssize_t n = t.do_recv(extra + got, remaining - got);
+                if (n <= 0) break;
+                got += (size_t)n;
+            }
+            body_out.append(extra, got);
+            free(extra);
+        }
+        if ((int64_t)body_out.size() < content_length) return false;
+        if ((int64_t)body_out.size() > content_length)
+            body_out.resize((size_t)content_length);
+    } else {
+        char buf[kRecvBufSize];
+        while (true) {
+            ssize_t n = t.do_recv(buf, sizeof(buf));
+            if (n <= 0) break;
+            body_out.append(buf, (size_t)n);
+            if ((int64_t)body_out.size() > MAX_BODY_SIZE) {
+                body_out.resize((size_t)MAX_BODY_SIZE);
+                break;
+            }
+        }
+    }
+
+    return true;
+}
+
+static HttpClientResponseHandle *read_http_response(HttpTransport &t) {
+    __ry_apply_default_recv_timeout(t.fd);
+
+    std::string raw = recv_all(t, kMaxHeaderSize);
+    if (raw.empty()) return nullptr;
+
+    size_t hdr_end = raw.find("\r\n\r\n");
+    if (hdr_end == std::string::npos) return nullptr;
+
+    size_t headers_start;
+    int64_t status_code = parse_status_line(raw, headers_start);
+    if (status_code < 0) return nullptr;
+
+    auto parsed_headers = parse_raw_headers(raw, headers_start, hdr_end);
+
+    size_t body_start = hdr_end + 4;
+    std::string body_data;
+    if (!read_response_body(t, raw, body_start, parsed_headers, body_data)) {
         for (auto &h : parsed_headers) { free(h.key); free(h.val); }
         return nullptr;
     }
 
-    size_t body_start = hdr_end + 4;
-    std::string body_data;
-
-    if (is_chunked) {
-        bool ok;
-        body_data = read_chunked_body(t, raw, body_start, ok);
-        if (!ok) {
-            for (auto &h : parsed_headers) { free(h.key); free(h.val); }
-            return nullptr;
-        }
-    } else {
-        if (body_start < raw.size())
-            body_data = raw.substr(body_start);
-
-        int64_t content_length = __ry_http_parse_content_length(cl_value);
-        if (content_length == -2 || content_length == -3) {
-            for (auto &h : parsed_headers) { free(h.key); free(h.val); }
-            return nullptr;
-        }
-        if (content_length >= 0) {
-            if ((int64_t)body_data.size() < content_length) {
-                size_t remaining = (size_t)content_length - body_data.size();
-                char *extra = (char *)checked_malloc(remaining);
-                size_t got = 0;
-                while (got < remaining) {
-                    ssize_t n = t.do_recv(extra + got, remaining - got);
-                    if (n <= 0) break;
-                    got += (size_t)n;
-                }
-                body_data.append(extra, got);
-                free(extra);
-            }
-            if ((int64_t)body_data.size() < content_length) {
-                for (auto &h : parsed_headers) { free(h.key); free(h.val); }
-                return nullptr;
-            }
-            if ((int64_t)body_data.size() > content_length)
-                body_data.resize((size_t)content_length);
-        } else {
-            char buf[kRecvBufSize];
-            while (true) {
-                ssize_t n = t.do_recv(buf, sizeof(buf));
-                if (n <= 0) break;
-                body_data.append(buf, (size_t)n);
-                if ((int64_t)body_data.size() > MAX_BODY_SIZE) {
-                    body_data.resize((size_t)MAX_BODY_SIZE);
-                    break;
-                }
-            }
-        }
-    }
-
-    // Build response handle
     auto *resp = (HttpClientResponseHandle *)checked_malloc(sizeof(HttpClientResponseHandle));
-    resp->status = (int64_t)status_code;
+    resp->status = status_code;
     resp->body_len = (int64_t)body_data.size();
     resp->body = checked_memdup(body_data.data(), body_data.size());
-
     assign_headers(parsed_headers, &resp->header_keys, &resp->header_values, &resp->header_count);
 
     return resp;
@@ -308,11 +312,71 @@ static bool has_crlf(const char *s) {
     return false;
 }
 
+// Establish a TCP or TLS connection based on the parsed URL.
+static bool establish_connection(const ParsedUrl *parsed, HttpTransport &transport) {
+    if (parsed->is_https) {
+        void *tls = __ry_tls_connect(parsed->host, parsed->port);
+        if (!tls) return false;
+        __ry_tls_take_ownership(tls, &transport.fd, &transport.ssl);
+    } else {
+        void *stream = __ry_connect(parsed->host, parsed->port);
+        if (!stream) return false;
+        transport.fd = __ry_tcp_take_fd(stream);
+    }
+    return true;
+}
+
+// Build an HTTP/1.1 request string with Host header, user headers, and body.
+static std::string build_http_request(const char *method, const ParsedUrl *parsed,
+                                       void *headers_map, const char *body,
+                                       bool strip_sensitive) {
+    std::string request;
+    request.reserve(256);
+    request += method;
+    request += ' ';
+    request += parsed->path;
+    request += " HTTP/1.1\r\n";
+
+    request += "Host: ";
+    request += parsed->host;
+    int64_t default_port = parsed->is_https ? 443 : 80;
+    if (parsed->port != default_port) {
+        request += ':';
+        request += std::to_string(parsed->port);
+    }
+    request += "\r\n";
+
+    if (headers_map) {
+        auto *map = (MapHeader *)headers_map;
+        for (int64_t i = 0; i < map->len; i++) {
+            if (has_crlf(map->keys[i]) || has_crlf(map->vals[i])) continue;
+            if (strcasecmp(map->keys[i], "Content-Length") == 0) continue;
+            if (is_hop_by_hop_header(map->keys[i])) continue;
+            if (strip_sensitive && is_sensitive_header(map->keys[i])) continue;
+            request += map->keys[i];
+            request += ": ";
+            request += map->vals[i];
+            request += "\r\n";
+        }
+    }
+
+    size_t body_len = (body && *body) ? strlen(body) : 0;
+    request += "Content-Length: ";
+    request += std::to_string(body_len);
+    request += "\r\n";
+    request += "Connection: close\r\n";
+    request += "\r\n";
+
+    if (body_len > 0)
+        request.append(body, body_len);
+
+    return request;
+}
+
 extern "C" void *__ry_http_client_request(const char *method, const char *url,
                                            void *headers_map, const char *body) {
     if (has_crlf(method)) return nullptr;
 
-    // Owned copies — only allocated when redirects occur.
     char *owned_url = nullptr;
     char *owned_method = nullptr;
     const char *current_url = url;
@@ -338,68 +402,14 @@ extern "C" void *__ry_http_client_request(const char *method, const char *url,
             break;
         }
 
-        // Establish connection (plain TCP or TLS)
         HttpTransport transport{-1, nullptr};
-        if (parsed->is_https) {
-            void *tls = __ry_tls_connect(parsed->host, parsed->port);
-            if (!tls) {
-                __ry_http_parsed_url_free(parsed);
-                break;
-            }
-            __ry_tls_take_ownership(tls, &transport.fd, &transport.ssl);
-        } else {
-            void *stream = __ry_connect(parsed->host, parsed->port);
-            if (!stream) {
-                __ry_http_parsed_url_free(parsed);
-                break;
-            }
-            transport.fd = __ry_tcp_take_fd(stream);
+        if (!establish_connection(parsed, transport)) {
+            __ry_http_parsed_url_free(parsed);
+            break;
         }
 
-        // Build HTTP/1.1 request
-        std::string request;
-        request.reserve(256);
-        request += current_method;
-        request += ' ';
-        request += parsed->path;
-        request += " HTTP/1.1\r\n";
-
-        // Host header
-        request += "Host: ";
-        request += parsed->host;
-        int64_t default_port = parsed->is_https ? 443 : 80;
-        if (parsed->port != default_port) {
-            request += ':';
-            request += std::to_string(parsed->port);
-        }
-        request += "\r\n";
-
-        // User-provided headers
-        if (headers_map) {
-            auto *map = (MapHeader *)headers_map;
-            for (int64_t i = 0; i < map->len; i++) {
-                if (has_crlf(map->keys[i]) || has_crlf(map->vals[i])) continue;
-                if (strcasecmp(map->keys[i], "Content-Length") == 0) continue;
-                if (is_hop_by_hop_header(map->keys[i])) continue;
-                if (strip_sensitive && is_sensitive_header(map->keys[i])) continue;
-                request += map->keys[i];
-                request += ": ";
-                request += map->vals[i];
-                request += "\r\n";
-            }
-        }
-
-        size_t body_len = (current_body && *current_body) ? strlen(current_body) : 0;
-        request += "Content-Length: ";
-        request += std::to_string(body_len);
-        request += "\r\n";
-
-        request += "Connection: close\r\n";
-        request += "\r\n";
-
-        if (body_len > 0) {
-            request.append(current_body, body_len);
-        }
+        std::string request = build_http_request(current_method, parsed, headers_map,
+                                                  current_body, strip_sensitive);
 
         ssize_t sent = transport.do_send(request.c_str(), request.size());
         if (sent < 0) {
@@ -415,7 +425,6 @@ extern "C" void *__ry_http_client_request(const char *method, const char *url,
 
         if (!resp) break;
 
-        // Check for redirect
         if (is_redirect_status((int)resp->status)) {
             const char *location = __ry_http_client_header(resp, "Location");
 
@@ -438,9 +447,8 @@ extern "C" void *__ry_http_client_request(const char *method, const char *url,
                     current_body = "";
                 }
 
-                if (!strip_sensitive && is_cross_origin(current_url, new_url)) {
+                if (!strip_sensitive && is_cross_origin(current_url, new_url))
                     strip_sensitive = true;
-                }
 
                 __ry_http_client_response_free(resp);
                 free(owned_url);
@@ -481,22 +489,13 @@ extern "C" const char *__ry_http_client_body(void *r) {
 extern "C" const char *__ry_http_client_header(void *r, const char *key) {
     if (!r) return nullptr;
     auto *resp = (HttpClientResponseHandle *)r;
-    for (int64_t i = 0; i < resp->header_count; i++) {
-        if (strcasecmp(resp->header_keys[i], key) == 0)
-            return resp->header_values[i];
-    }
-    return nullptr;
+    return find_in_kv_pairs_ci(resp->header_keys, resp->header_values, resp->header_count, key);
 }
 
 extern "C" void __ry_http_client_response_free(void *r) {
     if (!r) return;
     auto *resp = (HttpClientResponseHandle *)r;
-    for (int64_t i = 0; i < resp->header_count; i++) {
-        free(resp->header_keys[i]);
-        free(resp->header_values[i]);
-    }
-    free(resp->header_keys);
-    free(resp->header_values);
+    free_kv_pairs(resp->header_keys, resp->header_values, resp->header_count);
     free(resp->body);
     free(resp);
 }

--- a/src/runtime_http_multipart.cpp
+++ b/src/runtime_http_multipart.cpp
@@ -1,17 +1,8 @@
-#include "ry/runtime_http_internal.hpp"
+#include "ry/runtime_http_types.hpp"
 
 #include <unordered_set>
 
 // ===== Multipart form-data parsing =====
-
-// Looks up a header value by name (case-insensitive) in the request's header arrays.
-static const char *find_request_header(HttpRequestHandle *req, const char *name) {
-    for (int64_t i = 0; i < req->header_count; i++) {
-        if (strcasecmp(req->header_keys[i], name) == 0)
-            return req->header_values[i];
-    }
-    return nullptr;
-}
 
 // Extract a parameter value from a header value string, working directly on C strings.
 // e.g., extract_param("form-data; name=\"field1\"", "name") -> "field1"
@@ -53,6 +44,48 @@ static void free_header_pairs(std::vector<HeaderPair> &headers) {
     for (auto &h : headers) { free(h.key); free(h.val); }
 }
 
+// Process a single multipart part: extract Content-Disposition, categorize as
+// field or file, and append to the appropriate vector with deduplication.
+static void process_multipart_part(const char *body, size_t data_start, size_t data_end,
+                                     const std::vector<HeaderPair> &part_headers,
+                                     std::vector<FormFieldEntry> &fields,
+                                     std::vector<FormFileEntry> &files,
+                                     std::unordered_set<std::string> &seen_field_names,
+                                     std::unordered_set<std::string> &seen_file_names) {
+    const char *disposition = nullptr;
+    const char *part_content_type = nullptr;
+    for (auto &h : part_headers) {
+        if (strcasecmp(h.key, "Content-Disposition") == 0)
+            disposition = h.val;
+        else if (strcasecmp(h.key, "Content-Type") == 0)
+            part_content_type = h.val;
+    }
+    if (!disposition) return;
+
+    std::string name = extract_param(disposition, "name");
+    if (name.empty()) return;
+
+    std::string filename = extract_param(disposition, "filename");
+    if (!filename.empty()) {
+        if (seen_file_names.insert(name).second) {
+            files.push_back({
+                checked_strdup(name.c_str()),
+                checked_strdup(filename.c_str()),
+                checked_strdup(part_content_type ? part_content_type : "application/octet-stream"),
+                checked_memdup(body + data_start, data_end - data_start),
+                (int64_t)(data_end - data_start)
+            });
+        }
+    } else {
+        if (seen_field_names.insert(name).second) {
+            fields.push_back({
+                checked_strdup(name.c_str()),
+                checked_strndup(body + data_start, data_end - data_start)
+            });
+        }
+    }
+}
+
 static void parse_multipart_form_data(HttpRequestHandle *req) {
     if (req->form_parsed) return;
     req->form_parsed = true;
@@ -63,7 +96,8 @@ static void parse_multipart_form_data(HttpRequestHandle *req) {
 
     if (!req->body || !req->body[0]) return;
 
-    const char *content_type = find_request_header(req, "Content-Type");
+    const char *content_type = find_in_kv_pairs_ci(
+        req->header_keys, req->header_values, req->header_count, "Content-Type");
     if (!content_type) return;
     if (strncasecmp(content_type, "multipart/form-data", 19) != 0) return;
     char next = content_type[19];
@@ -73,7 +107,6 @@ static void parse_multipart_form_data(HttpRequestHandle *req) {
     if (boundary.empty()) return;
 
     std::string delimiter = "--" + boundary;
-    // Line-boundary-aware delimiter for subsequent parts (RFC 2046: CRLF before delimiter)
     std::string crlf_delimiter = "\r\n" + delimiter;
     size_t body_len = (size_t)req->body_len;
 
@@ -81,7 +114,6 @@ static void parse_multipart_form_data(HttpRequestHandle *req) {
     std::vector<FormFileEntry> files;
     std::unordered_set<std::string> seen_field_names, seen_file_names;
 
-    // First delimiter appears at start of body (no preceding CRLF required)
     const char *delim_ptr = (const char *)memmem(req->body, body_len,
                                                   delimiter.c_str(), delimiter.size());
     if (!delim_ptr) return;
@@ -103,51 +135,14 @@ static void parse_multipart_form_data(HttpRequestHandle *req) {
 
         size_t data_start = headers_end + 4;
 
-        // Search for CRLF + delimiter to avoid false matches inside part data
         const char *next_ptr = (const char *)memmem(req->body + data_start, body_len - data_start,
                                                      crlf_delimiter.c_str(), crlf_delimiter.size());
         if (!next_ptr) { free_header_pairs(part_headers); break; }
-        // next_delim points to the "--boundary" part (skip the leading CRLF)
         size_t next_delim = (size_t)(next_ptr - req->body) + 2;
-
-        // Part data ends at the CRLF that precedes the delimiter
         size_t data_end = (size_t)(next_ptr - req->body);
 
-        const char *disposition = nullptr;
-        const char *part_content_type = nullptr;
-        for (auto &h : part_headers) {
-            if (strcasecmp(h.key, "Content-Disposition") == 0)
-                disposition = h.val;
-            else if (strcasecmp(h.key, "Content-Type") == 0)
-                part_content_type = h.val;
-        }
-
-        if (disposition) {
-            std::string name = extract_param(disposition, "name");
-            std::string filename = extract_param(disposition, "filename");
-
-            if (!name.empty()) {
-                if (!filename.empty()) {
-                    // First-value-wins deduplication
-                    if (seen_file_names.insert(name).second) {
-                        files.push_back({
-                            checked_strdup(name.c_str()),
-                            checked_strdup(filename.c_str()),
-                            checked_strdup(part_content_type ? part_content_type : "application/octet-stream"),
-                            checked_memdup(req->body + data_start, data_end - data_start),
-                            (int64_t)(data_end - data_start)
-                        });
-                    }
-                } else {
-                    if (seen_field_names.insert(name).second) {
-                        fields.push_back({
-                            checked_strdup(name.c_str()),
-                            checked_strndup(req->body + data_start, data_end - data_start)
-                        });
-                    }
-                }
-            }
-        }
+        process_multipart_part(req->body, data_start, data_end, part_headers,
+                                fields, files, seen_field_names, seen_file_names);
 
         free_header_pairs(part_headers);
 


### PR DESCRIPTION
## Summary

- **#276**: Split `runtime_http_internal.hpp` into lightweight `runtime_http_types.hpp` (structs, OOM helpers, KV utilities) and transport-specific `runtime_http_internal.hpp`, removing OpenSSL dependency from `runtime_http_multipart.cpp`
- **#279**: Extract `free_kv_pairs`, `find_in_kv_pairs_ci`/`find_in_kv_pairs`, and `build_str_map_copy` helpers to eliminate 3 categories of duplicated patterns across server/client/multipart code
- **#278**: Decompose 5 large functions into focused sub-functions:
  - `__ry_http_read_request` → `parse_request_line` + `read_request_body`
  - `read_http_response` → `parse_status_line` + `read_response_body`
  - `__ry_http_client_request` → `establish_connection` + `build_http_request`
  - `parse_multipart_form_data` → `process_multipart_part`

Closes #276, closes #278, closes #279

## Test plan

- [x] All 1072 C++ tests pass (`./build/ry_tests`)
- [x] All 42 Ry self-test files pass (`RY_ENV=internal ./build/ry test -p`)
- [x] HTTP-specific tests pass (57 tests in RuntimeHttp/RuntimeHttpClient/HttpSSRF suites)
- [x] Pure refactoring — no functional changes, no new tests needed