### PR TITLE
refactor: introduce structured TypeNode AST to replace string-based type representation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ add_library(ry_lib STATIC
     src/lexer.cpp
     src/parser.cpp
     src/parser_expr.cpp
+    src/type_node.cpp
     src/parser_decl.cpp
     src/codegen.cpp
     src/codegen_type.cpp

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -13,6 +13,44 @@
 struct ExprNode;
 using ExprPtr = std::unique_ptr<ExprNode>;
 
+// ===== Type AST nodes =====
+
+struct TypeNode;
+using TypeNodePtr = std::unique_ptr<TypeNode>;
+
+struct BasicType    { std::string name; };
+struct GenericType  { std::string name; std::vector<TypeNodePtr> type_args; };
+struct ArrayType    { TypeNodePtr element_type; uint64_t size; };
+struct TupleType    { std::vector<TypeNodePtr> elements; };
+struct FnType       { std::vector<TypeNodePtr> param_types; TypeNodePtr return_type; };
+struct UnionType    { std::vector<TypeNodePtr> components; };
+struct OptionalType { TypeNodePtr inner; };
+struct RangeType    { std::string start; std::string end; };
+
+struct TypeNode {
+    std::variant<
+        BasicType,
+        GenericType,
+        ArrayType,
+        TupleType,
+        FnType,
+        UnionType,
+        OptionalType,
+        RangeType
+    > data;
+
+    std::string toString() const;
+
+    static TypeNodePtr makeBasic(std::string name);
+    static TypeNodePtr makeGeneric(std::string name, std::vector<TypeNodePtr> args);
+    static TypeNodePtr makeArray(TypeNodePtr elem, uint64_t size);
+    static TypeNodePtr makeTuple(std::vector<TypeNodePtr> elems);
+    static TypeNodePtr makeFn(std::vector<TypeNodePtr> params, TypeNodePtr ret);
+    static TypeNodePtr makeUnion(std::vector<TypeNodePtr> comps);
+    static TypeNodePtr makeOptional(TypeNodePtr inner);
+    static TypeNodePtr makeRange(std::string start, std::string end);
+};
+
 // ===== Directive =====
 
 struct DirectiveParam {
@@ -158,11 +196,11 @@ struct SetExpr {
     std::vector<ExprPtr> elements;
 };
 
-struct AssignStmt { std::string name; std::optional<std::string> type_annotation; ExprPtr value; std::optional<std::string> compound_op; std::vector<Directive> directives; SourceLocation loc; };
+struct AssignStmt { std::string name; TypeNodePtr type_annotation; ExprPtr value; std::optional<std::string> compound_op; std::vector<Directive> directives; SourceLocation loc; };
 struct CallStmt   { std::string callee; std::vector<ExprPtr> args; std::vector<Directive> directives; SourceLocation loc; };
 
 struct ReturnStmt { ExprPtr value; SourceLocation loc; };
-struct FnParam { std::string name; std::string type; ExprPtr default_value; };
+struct FnParam { std::string name; TypeNodePtr type; ExprPtr default_value; };
 
 struct ImportStmt {
     std::string module_path;              // "utils/math" (resolved to dir or .ry file)
@@ -177,11 +215,11 @@ struct IndexAssignStmt {
     SourceLocation loc;
 };
 
-struct FieldDef { std::string name; std::string type; std::vector<Directive> directives; };
+struct FieldDef { std::string name; TypeNodePtr type; std::vector<Directive> directives; };
 
 struct RecordStmt { std::string name; std::vector<FieldDef> fields; std::vector<ExprPtr> invariants; std::vector<Directive> directives; SourceLocation loc; };
 
-struct TypeAliasStmt { std::string name; std::string target_type; SourceLocation loc; };
+struct TypeAliasStmt { std::string name; TypeNodePtr target_type; SourceLocation loc; };
 
 struct BreakStmt { SourceLocation loc; };
 struct ContinueStmt { SourceLocation loc; };
@@ -189,7 +227,7 @@ struct EllipsisStmt { SourceLocation loc; };
 
 struct EnumVariant {
     std::string name;
-    std::vector<std::string> field_types;  // empty = no associated data
+    std::vector<TypeNodePtr> field_types;  // empty = no associated data
     std::vector<std::string> field_names;  // parallel to field_types; empty when unnamed
     std::optional<int64_t> explicit_value;
 };
@@ -269,7 +307,7 @@ struct ForStmt {
 
 struct CastExpr {
     ExprPtr value;
-    std::string target_type;
+    TypeNodePtr target_type;
 };
 
 struct TernaryExpr {
@@ -305,7 +343,7 @@ struct FnStmt {
     std::string name;
     std::vector<std::string> type_params;  // for generics: <T, U>
     std::vector<FnParam> params;
-    std::string return_type;
+    TypeNodePtr return_type;
     std::vector<StmtNode> body;
     bool is_operator = false;
     bool is_async = false;
@@ -318,7 +356,7 @@ struct FnStmt {
 
 struct LambdaExpr {
     std::vector<FnParam> params;
-    std::string return_type;
+    TypeNodePtr return_type;
     std::vector<StmtNode> body;   // multi-line lambda
     ExprPtr expr_body;            // single-expression lambda (if non-null, use this)
 };

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -246,7 +246,7 @@ private:
 
     // Variable declaration (B3)
     void emitVarDecl(const std::string &name,
-                     const std::optional<std::string> &type_annotation,
+                     const TypeNodePtr &type_annotation,
                      ExprNode &value, bool is_immutable);
 
     void emitStmt(AssignStmt &s);

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -62,8 +62,9 @@ private:
     ExprPtr parseTrailingBlockAsLambda();
     StmtNode parseMatchStatement();
     Pattern parsePattern();
-    std::string parseTypeName();
-    std::string parseTypeNameSingle();
+    TypeNodePtr parseTypeName();
+    TypeNodePtr parseTypeNameSingle();
+    TypeNodePtr parseFnType();
     std::vector<StmtNode> parseBlock();
     std::vector<ExprPtr> parseArgList();
     void parseContractClause(const std::string &clauseName, std::vector<ExprPtr> &out);

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -4,7 +4,7 @@
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
     llvm::Value *val = emitExpr(*e->value);
     llvm::Type *srcTy = val->getType();
-    const std::string &target = e->target_type;
+    const std::string target = e->target_type->toString();
 
     if (target == "float") {
         if (srcTy->isDoubleTy()) return val;
@@ -264,7 +264,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<InterpolatedStringEx
 void CodeGen::emitStmt(TypeAliasStmt &s) {
     // Type aliases are resolved at compile time via resolveType()
     // Store the alias mapping for later lookup
-    type_aliases_[s.name] = s.target_type;
+    type_aliases_[s.name] = s.target_type->toString();
 }
 
 // ===== RangeExpr =====

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -7,7 +7,7 @@ void CodeGen::emitStmt(RecordStmt &s) {
 
     std::vector<llvm::Type*> fieldTypes;
     for (auto &f : s.fields)
-        fieldTypes.push_back(resolveType(f.type));
+        fieldTypes.push_back(resolveType(f.type->toString()));
 
     llvm::StructType *structTy = llvm::StructType::create(*ctx_, fieldTypes, s.name);
     if (hasDirective(s.directives, "deprecated"))

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -119,9 +119,10 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
         // Validate return type for comparison/logical operators
         if (s->is_operator && isBoolConstrainedOperator(s->name)) {
-            if (!s->return_type.empty() && s->return_type != "bool") {
+            std::string retStr = s->return_type ? s->return_type->toString() : "";
+            if (!retStr.empty() && retStr != "bool") {
                 codegenError("operator '" + operatorSymbol(s->name) + "' must return 'bool', but returns '" +
-                             s->return_type + "'");
+                             retStr + "'");
             }
         }
 
@@ -132,14 +133,14 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
     std::vector<llvm::Type*> paramTypes;
     for (auto &p : s->params)
-        paramTypes.push_back(resolveType(p.type));
+        paramTypes.push_back(resolveType(p.type->toString()));
 
     llvm::Type *bodyRetTy;
-    if (s->return_type.empty()) {
+    if (!s->return_type) {
         // Infer return type from body
         std::unordered_map<std::string, llvm::Type*> paramTypeMap;
         for (auto &p : s->params)
-            paramTypeMap[p.name] = resolveType(p.type);
+            paramTypeMap[p.name] = resolveType(p.type->toString());
         std::vector<llvm::Type*> retTypes;
         collectReturnTypes(s->body, paramTypeMap, retTypes);
         bodyRetTy = deduceReturnType(retTypes);
@@ -150,24 +151,24 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             if (std::find(unique.begin(), unique.end(), ty) == unique.end())
                 unique.push_back(ty);
         if (unique.size() <= 1) {
-            s->return_type = reverseResolveTypeName(bodyRetTy);
+            s->return_type = TypeNode::makeBasic(reverseResolveTypeName(bodyRetTy));
         } else {
-            std::string unionName;
-            for (size_t i = 0; i < unique.size(); ++i) {
-                if (i > 0) unionName += " | ";
-                unionName += reverseResolveTypeName(unique[i]);
-            }
-            s->return_type = unionName;
+            std::vector<TypeNodePtr> comps;
+            for (auto *ty : unique)
+                comps.push_back(TypeNode::makeBasic(reverseResolveTypeName(ty)));
+            s->return_type = TypeNode::makeUnion(std::move(comps));
         }
     } else {
-        bodyRetTy = resolveType(s->return_type);
+        bodyRetTy = resolveType(s->return_type->toString());
     }
+
+    std::string returnTypeStr = s->return_type->toString();
 
     // Validate return type for comparison/logical operators
     if (s->is_operator && isBoolConstrainedOperator(s->name)) {
         if (bodyRetTy != llvm::Type::getInt1Ty(*ctx_)) {
             codegenError("operator '" + operatorSymbol(s->name) + "' must return 'bool', but returns '" +
-                         s->return_type + "'");
+                         returnTypeStr + "'");
         }
     }
 
@@ -176,9 +177,9 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         && !hasDirective(s->directives, "native")) {
         if (!allPathsReturn(s->body))
             codegenError("function '" + s->name + "' with return type '" +
-                         s->return_type + "' does not return a value on all code paths");
+                         returnTypeStr + "' does not return a value on all code paths");
     }
-    std::string exposedReturnTypeName = s->is_async ? "Task<" + s->return_type + ">" : s->return_type;
+    std::string exposedReturnTypeName = s->is_async ? "Task<" + returnTypeStr + ">" : returnTypeStr;
     llvm::Type *exposedRetTy = s->is_async ? resolveType(exposedReturnTypeName) : bodyRetTy;
 
     // Compute minArity and collect default values
@@ -226,7 +227,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
     std::vector<std::string> paramTypeNames;
     for (auto &p : s->params)
-        paramTypeNames.push_back(p.type);
+        paramTypeNames.push_back(p.type->toString());
     overloads.push_back({func, paramTypes, paramTypeNames, exposedReturnTypeName,
                          newMinArity, std::move(defaults)});
 
@@ -271,7 +272,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             builder_.CreateStore(&arg, alloca);
             scope_stack_.back()[s->params[idx].name] = alloca;
             // Track list element type for list parameters
-            const std::string &ptype = s->params[idx].type;
+            const std::string &ptype = paramTypeNames[idx];
             if (ptype.size() > 5 && ptype.compare(0, 5, "List<") == 0 && ptype.back() == '>') {
                 std::string inner = ptype.substr(5, ptype.size() - 6);
                 type_meta_[TM_ListElem][alloca] = resolveType(inner);
@@ -370,14 +371,14 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     };
 
     if (!s->is_async) {
-        emitFunctionBody(func, bodyRetTy, s->return_type, s->name);
+        emitFunctionBody(func, bodyRetTy, returnTypeStr, s->name);
         return;
     }
 
     llvm::FunctionType *bodyFt = llvm::FunctionType::get(bodyRetTy, paramTypes, false);
     llvm::Function *bodyFunc = llvm::Function::Create(
         bodyFt, llvm::Function::InternalLinkage, irName + ".__async_body", *mod_);
-    emitFunctionBody(bodyFunc, bodyRetTy, s->return_type, s->name);
+    emitFunctionBody(bodyFunc, bodyRetTy, returnTypeStr, s->name);
 
     std::vector<llvm::Type*> envFields = paramTypes;
     if (envFields.empty())
@@ -574,8 +575,9 @@ void CodeGen::instantiateGenericEnum(const std::string &fullName, const std::str
             hasADT = true;
             VariantFieldInfo vfi;
             for (auto &ft : v.field_types) {
-                std::string resolved = ft;
-                auto mit = typeMap.find(ft);
+                std::string ftStr = ft->toString();
+                std::string resolved = ftStr;
+                auto mit = typeMap.find(ftStr);
                 if (mit != typeMap.end()) resolved = mit->second;
                 vfi.fieldTypes.push_back(resolveType(resolved));
                 vfi.fieldTypeNames.push_back(resolved);
@@ -686,7 +688,7 @@ std::vector<std::string> CodeGen::inferTypeArgs(
     // Use AST-based type inference to avoid emitting IR for arguments
     std::unordered_map<std::string, llvm::Type*> emptyParamMap;
     for (size_t i = 0; i < args.size(); ++i) {
-        const std::string &paramType = tmpl.params[i].type;
+        const std::string paramType = tmpl.params[i].type->toString();
         llvm::Type *argTy = inferExprType(*args[i], emptyParamMap);
 
         if (typeParamSet.count(paramType)) {
@@ -754,12 +756,13 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
     // Resolve parameter types and return type using type_param_scope_
     std::vector<llvm::Type*> paramTypes;
     for (auto &p : s.params)
-        paramTypes.push_back(resolveType(p.type));
-    llvm::Type *bodyRetTy = resolveType(s.return_type);
+        paramTypes.push_back(resolveType(p.type->toString()));
+    std::string sReturnType = s.return_type ? s.return_type->toString() : "";
+    llvm::Type *bodyRetTy = resolveType(sReturnType);
 
     // Substitute type params in return type name
-    std::string exposedReturnTypeName = s.return_type;
-    auto retTpit = type_param_scope_.find(s.return_type);
+    std::string exposedReturnTypeName = sReturnType;
+    auto retTpit = type_param_scope_.find(sReturnType);
     if (retTpit != type_param_scope_.end())
         exposedReturnTypeName = retTpit->second;
     llvm::Type *exposedRetTy = bodyRetTy;
@@ -773,8 +776,9 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
     std::vector<std::string> paramTypeNames;
     for (auto &p : s.params) {
         // Substitute type params in param type names for FnTypeInfo
-        std::string resolvedName = p.type;
-        auto tpit = type_param_scope_.find(p.type);
+        std::string pTypeStr = p.type->toString();
+        std::string resolvedName = pTypeStr;
+        auto tpit = type_param_scope_.find(pTypeStr);
         if (tpit != type_param_scope_.end())
             resolvedName = tpit->second;
         paramTypeNames.push_back(resolvedName);
@@ -786,7 +790,7 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
     {
         FnScope guard(*this);
         fn_ = func;
-        current_fn_return_type_ = s.return_type;
+        current_fn_return_type_ = sReturnType;
         pushScope();
 
         llvm::BasicBlock *entry = llvm::BasicBlock::Create(*ctx_, "entry", func);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -112,19 +112,20 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     // Build parameter types (user params + captured vars)
     std::vector<llvm::Type*> paramTypes;
     for (auto &p : e->params)
-        paramTypes.push_back(resolveType(p.type));
+        paramTypes.push_back(resolveType(p.type->toString()));
     std::vector<llvm::Type*> allParamTypes = paramTypes;
     for (auto *t : capturedTypes)
         allParamTypes.push_back(t);
 
     llvm::Type *retTy;
-    if (e->return_type == "any") {
+    std::string retTypeStr = e->return_type ? e->return_type->toString() : "";
+    if (retTypeStr == "any") {
         retTy = anyTy_;
-    } else if (e->return_type.empty()) {
+    } else if (!e->return_type) {
         // Infer return type when omitted
         std::unordered_map<std::string, llvm::Type*> paramTypeMap;
         for (auto &p : e->params)
-            paramTypeMap[p.name] = resolveType(p.type);
+            paramTypeMap[p.name] = resolveType(p.type->toString());
 
         if (e->expr_body) {
             retTy = inferExprType(*e->expr_body, paramTypeMap);
@@ -132,15 +133,15 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
             retTy = inferReturnType(e->body, paramTypeMap);
         }
     } else {
-        retTy = resolveType(e->return_type);
+        retTy = resolveType(retTypeStr);
     }
 
     // Check that block-bodied lambdas with explicit non-any/Unit return type
     // return on all paths
-    if (!e->expr_body && !e->return_type.empty()
+    if (!e->expr_body && e->return_type
         && !isAnyType(retTy) && !retTy->isVoidTy()) {
         if (!allPathsReturn(e->body))
-            codegenError("lambda with return type '" + e->return_type +
+            codegenError("lambda with return type '" + retTypeStr +
                          "' does not return a value on all code paths");
     }
 
@@ -153,7 +154,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     {
         FnScope guard(*this);
         fn_ = func;
-        current_fn_return_type_ = e->return_type;
+        current_fn_return_type_ = retTypeStr;
         pushScope();
 
         llvm::BasicBlock *entry = llvm::BasicBlock::Create(*ctx_, "entry", func);
@@ -169,7 +170,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
                 builder_.CreateStore(&arg, alloca);
                 scope_stack_.back()[e->params[idx].name] = alloca;
                 // Track fn type info for fn-typed parameters
-                const std::string &ptype = e->params[idx].type;
+                const std::string ptype = e->params[idx].type->toString();
                 std::string resolvedPtype = resolveTypeAlias(ptype);
                 if (resolvedPtype.size() > 3 && resolvedPtype.substr(0, 3) == "fn(") {
                     fn_type_info_[alloca] = parseFnTypeAnnotation(resolvedPtype);
@@ -224,7 +225,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     FnTypeInfo info;
     info.paramTypes = paramTypes;  // only the user-visible params
     for (auto &p : e->params)
-        info.paramTypeNames.push_back(p.type);
+        info.paramTypeNames.push_back(p.type->toString());
     info.returnType = retTy;
     info.capturedVars = capturedNames;
     info.capturedTypes = capturedTypes;

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -12,17 +12,22 @@ void CodeGen::emitDeprecationWarning(const std::string &name) {
 // ===== B3: emitVarDecl =====
 
 void CodeGen::emitVarDecl(const std::string &name,
-                           const std::optional<std::string> &type_annotation,
+                           const TypeNodePtr &type_annotation,
                            ExprNode &value, bool is_immutable) {
     if (scope_stack_.back().count(name))
         codegenError("redeclared variable: " + name);
 
+    // Convert TypeNodePtr to string for codegen (Phase 1 bridge)
+    std::optional<std::string> annot;
+    if (type_annotation)
+        annot = type_annotation->toString();
+
     // Handle empty set/map literal with type annotation
     if (auto *se = std::get_if<std::unique_ptr<SetExpr>>(&value.data); se && (*se)->elements.empty()) {
-        if (!type_annotation)
+        if (!annot)
             codegenError("empty {} literal requires type annotation");
-        if (type_annotation->size() > 4 && type_annotation->substr(0, 4) == "Set<") {
-            std::string inner = type_annotation->substr(4, type_annotation->size() - 5);
+        if (annot->size() > 4 && annot->substr(0, 4) == "Set<") {
+            std::string inner = annot->substr(4, annot->size() - 5);
             llvm::Type *elemTy = resolveType(inner);
 
             auto mallocFn = getStdlibMalloc();
@@ -52,10 +57,10 @@ void CodeGen::emitVarDecl(const std::string &name,
                 immutable_scope_stack_.back().insert(name);
             return;
         }
-        if (type_annotation->size() > 4 && type_annotation->substr(0, 4) == "Map<") {
-            auto [keyTy, valTy] = parseMapTypeAnnotation(*type_annotation);
+        if (annot->size() > 4 && annot->substr(0, 4) == "Map<") {
+            auto [keyTy, valTy] = parseMapTypeAnnotation(*annot);
             if (!keyTy || !valTy)
-                codegenError("invalid map type annotation: " + *type_annotation);
+                codegenError("invalid map type annotation: " + *annot);
 
             auto mallocFn = getStdlibMalloc();
             const llvm::DataLayout &dl = mod_->getDataLayout();
@@ -97,9 +102,9 @@ void CodeGen::emitVarDecl(const std::string &name,
                   (std::holds_alternative<VariableExpr>(value.data) &&
                    std::get<VariableExpr>(value.data).name == "None");
     if (isNone) {
-        if (!type_annotation)
+        if (!annot)
             codegenError("type annotation required for None");
-        llvm::Type *annotTy = resolveType(*type_annotation);
+        llvm::Type *annotTy = resolveType(*annot);
         if (!isOptionType(annotTy))
             codegenError("None can only be assigned to Option type");
         llvm::Value *val = buildNoneValue(annotTy);
@@ -113,8 +118,8 @@ void CodeGen::emitVarDecl(const std::string &name,
     // Resolve type alias and parse constraint once for the entire function
     std::string resolvedAnnot;
     std::optional<TypeConstraint> constraint;
-    if (type_annotation) {
-        resolvedAnnot = resolveTypeAlias(*type_annotation);
+    if (annot) {
+        resolvedAnnot = resolveTypeAlias(*annot);
         constraint = parseTypeConstraint(resolvedAnnot);
 
         // Pre-emit compile-time check for string literal constraints
@@ -139,18 +144,18 @@ void CodeGen::emitVarDecl(const std::string &name,
     }
 
     // Fixed-length array declaration: [T; N] = [elem, ...]
-    if (type_annotation && !type_annotation->empty() && type_annotation->front() == '[' &&
-        type_annotation->back() == ']' && type_annotation->find(';') != std::string::npos) {
-        llvm::Type *annotTy = resolveType(*type_annotation);
+    if (annot && !annot->empty() && annot->front() == '[' &&
+        annot->back() == ']' && annot->find(';') != std::string::npos) {
+        llvm::Type *annotTy = resolveType(*annot);
         auto *arrTy = llvm::dyn_cast<llvm::ArrayType>(annotTy);
-        if (!arrTy) codegenError("invalid array type: " + *type_annotation);
+        if (!arrTy) codegenError("invalid array type: " + *annot);
 
         llvm::Type *elemTy = arrTy->getElementType();
         uint64_t arrSize = arrTy->getNumElements();
 
         // Parse element type name from annotation "[elemType; N]"
-        size_t semiPos = type_annotation->find(';');
-        std::string elemTypeName = type_annotation->substr(1, semiPos - 1);
+        size_t semiPos = annot->find(';');
+        std::string elemTypeName = annot->substr(1, semiPos - 1);
         while (!elemTypeName.empty() && elemTypeName.back() == ' ') elemTypeName.pop_back();
 
         auto *le = std::get_if<std::unique_ptr<ListExpr>>(&value.data);
@@ -202,20 +207,20 @@ void CodeGen::emitVarDecl(const std::string &name,
     llvm::Value *val = emitExpr(value);
     llvm::Type *newTy = val->getType();
 
-    if (type_annotation) {
+    if (annot) {
         if (constraint) {
             // Literal/range type: resolve to base type and check constraint
             llvm::Type *annotTy = resolveType(resolvedAnnot);
             if (annotTy != newTy)
                 codegenError(
-                    "type error: annotation '" + *type_annotation +
+                    "type error: annotation '" + *annot +
                     "' does not match expression type for variable '" + name + "'");
             emitConstraintCheck(val, *constraint, name);
         } else {
-            llvm::Type *annotTy = resolveType(*type_annotation);
+            llvm::Type *annotTy = resolveType(*annot);
             if (annotTy != newTy) {
                 if (annotTy == i8Ty_ && newTy == i64Ty_) {
-                    const std::string &ann = *type_annotation;
+                    const std::string &ann = *annot;
                     if (ann == "i8") {
                         if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
                             int64_t v = ci->getSExtValue();
@@ -235,7 +240,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                     val = builder_.CreateTrunc(val, i8Ty_, "i8trunc");
                     newTy = i8Ty_;
                 } else if (annotTy == i32Ty_ && newTy == i64Ty_) {
-                    const std::string &ann = *type_annotation;
+                    const std::string &ann = *annot;
                     if (ann == "u32") {
                         if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
                             int64_t v = ci->getSExtValue();
@@ -254,7 +259,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                     val = builder_.CreateTrunc(val, i32Ty_, "i32trunc");
                     newTy = i32Ty_;
                 } else if (annotTy == i16Ty_ && newTy == i64Ty_) {
-                    const std::string &ann = *type_annotation;
+                    const std::string &ann = *annot;
                     if (ann == "u16") {
                         if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
                             int64_t v = ci->getSExtValue();
@@ -286,7 +291,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                     llvm::Type *innerTy = optTy->getElementType(1);
                     if (val->getType() != innerTy)
                         codegenError(
-                            "type error: annotation '" + *type_annotation +
+                            "type error: annotation '" + *annot +
                             "' does not match expression type for variable '" + name + "'");
                     val = buildSomeValue(val, annotTy);
                     newTy = annotTy;
@@ -296,12 +301,12 @@ void CodeGen::emitVarDecl(const std::string &name,
                 } else if (isAnyType(newTy) && canAnyHoldType(annotTy)) {
                     val = unwrapFromAny(val, annotTy);
                     newTy = annotTy;
-                } else if (isUnionType(*type_annotation)) {
-                    val = wrapInUnion(val, *type_annotation);
+                } else if (isUnionType(*annot)) {
+                    val = wrapInUnion(val, *annot);
                     newTy = val->getType();
                 } else {
                     codegenError(
-                        "type error: annotation '" + *type_annotation +
+                        "type error: annotation '" + *annot +
                         "' does not match expression type for variable '" + name + "'");
                 }
             }
@@ -312,8 +317,8 @@ void CodeGen::emitVarDecl(const std::string &name,
     builder_.CreateStore(val, ptr);
 
     // Track low-level type metadata
-    if (type_annotation) {
-        const std::string &ann = *type_annotation;
+    if (annot) {
+        const std::string &ann = *annot;
         if (isLowLevelTypeName(ann))
             low_level_type_names_[ptr] = ann;
     } else {
@@ -332,8 +337,8 @@ void CodeGen::emitVarDecl(const std::string &name,
         type_constraints_[ptr] = *constraint;
 
     // Track union value type (skip literal unions which use base types directly)
-    if (type_annotation && isUnionType(*type_annotation) && !constraint) {
-        union_value_types_[ptr] = normalizeUnionType(*type_annotation);
+    if (annot && isUnionType(*annot) && !constraint) {
+        union_value_types_[ptr] = normalizeUnionType(*annot);
     }
 
     // Track collection metadata for Option/Result wrapping a collection
@@ -341,8 +346,8 @@ void CodeGen::emitVarDecl(const std::string &name,
     if (isOptionType(newTy) || isResultType(newTy)) {
         propagateCollectionMetadata(val, ptr);
         // Extract inner collection type from Option<Map<K,V>> or Result<Map<K,V>, E>
-        if (type_annotation && type_meta_[TM_MapKey].find(ptr) == type_meta_[TM_MapKey].end()) {
-            std::string ann = *type_annotation;
+        if (annot && type_meta_[TM_MapKey].find(ptr) == type_meta_[TM_MapKey].end()) {
+            std::string ann = *annot;
             std::string inner;
             if (ann.size() > 7 && ann.substr(0, 7) == "Option<" && ann.back() == '>')
                 inner = ann.substr(7, ann.size() - 8);
@@ -381,9 +386,9 @@ void CodeGen::emitVarDecl(const std::string &name,
     if (newTy == ptrTy_) {
         // --- List tracking ---
         llvm::Type *elemTy = getListElementType(val);
-        if (!elemTy && type_annotation && type_annotation->size() > 5 &&
-            type_annotation->substr(0, 5) == "List<") {
-            std::string inner = type_annotation->substr(5, type_annotation->size() - 6);
+        if (!elemTy && annot && annot->size() > 5 &&
+            annot->substr(0, 5) == "List<") {
+            std::string inner = annot->substr(5, annot->size() - 6);
             elemTy = resolveType(inner);
         }
         if (elemTy)
@@ -419,9 +424,9 @@ void CodeGen::emitVarDecl(const std::string &name,
             }
         }
         // From type annotation: Map<K, V>
-        if (!keyTy && type_annotation && type_annotation->size() > 4 &&
-            type_annotation->substr(0, 4) == "Map<") {
-            std::tie(keyTy, valTy) = parseMapTypeAnnotation(*type_annotation);
+        if (!keyTy && annot && annot->size() > 4 &&
+            annot->substr(0, 4) == "Map<") {
+            std::tie(keyTy, valTy) = parseMapTypeAnnotation(*annot);
         }
         if (keyTy) type_meta_[TM_MapKey][ptr] = keyTy;
         if (valTy) type_meta_[TM_MapValue][ptr] = valTy;
@@ -433,9 +438,9 @@ void CodeGen::emitVarDecl(const std::string &name,
                 setElemTy = getSetElementType(load->getPointerOperand());
             }
         }
-        if (!setElemTy && type_annotation && type_annotation->size() > 4 &&
-            type_annotation->substr(0, 4) == "Set<") {
-            std::string inner = type_annotation->substr(4, type_annotation->size() - 5);
+        if (!setElemTy && annot && annot->size() > 4 &&
+            annot->substr(0, 4) == "Set<") {
+            std::string inner = annot->substr(4, annot->size() - 5);
             setElemTy = resolveType(inner);
         }
         if (setElemTy)
@@ -443,9 +448,9 @@ void CodeGen::emitVarDecl(const std::string &name,
 
         // --- Task tracking ---
         llvm::Type *taskTy = getTaskResultType(val);
-        if (!taskTy && type_annotation && type_annotation->size() > 5 &&
-            type_annotation->substr(0, 5) == "Task<" && type_annotation->back() == '>') {
-            std::string inner = type_annotation->substr(5, type_annotation->size() - 6);
+        if (!taskTy && annot && annot->size() > 5 &&
+            annot->substr(0, 5) == "Task<" && annot->back() == '>') {
+            std::string inner = annot->substr(5, annot->size() - 6);
             taskTy = resolveType(inner);
         }
         if (taskTy)
@@ -455,7 +460,7 @@ void CodeGen::emitVarDecl(const std::string &name,
         auto fnIt = fn_type_info_.find(val);
         if (fnIt != fn_type_info_.end()) {
             fn_type_info_[ptr] = fnIt->second;
-        } else if (type_annotation) {
+        } else if (annot) {
             if (resolvedAnnot.size() > 3 && resolvedAnnot.substr(0, 3) == "fn(") {
                 fn_type_info_[ptr] = parseFnTypeAnnotation(resolvedAnnot);
             }
@@ -477,16 +482,16 @@ void CodeGen::emitVarDecl(const std::string &name,
     // These must be outside the ptrTy_ guard because resources can be
     // wrapped in Result<T, Error> structs (e.g., http_get() returns a struct).
     propagateResourceTrackingWide(val, ptr);
-    if (type_annotation)
-        registerResourceByTypeName(*type_annotation, ptr);
+    if (annot)
+        registerResourceByTypeName(*annot, ptr);
 
     // --- Enum value tracking (works for i64 values, not just ptr) ---
     {
         auto evIt = enum_value_types_.find(val);
         if (evIt != enum_value_types_.end())
             enum_value_types_[ptr] = evIt->second;
-        else if (type_annotation && enum_types_.count(*type_annotation))
-            enum_value_types_[ptr] = *type_annotation;
+        else if (annot && enum_types_.count(*annot))
+            enum_value_types_[ptr] = *annot;
     }
 
     if (is_immutable)
@@ -689,7 +694,7 @@ void CodeGen::emitStmt(EnumStmt &s) {
         GenericEnumTemplate tmpl;
         tmpl.name = s.name;
         tmpl.typeParams = s.type_params;
-        tmpl.variants = s.variants;
+        tmpl.variants = std::move(s.variants);
         generic_enum_templates_[s.name] = std::move(tmpl);
         return;
     }
@@ -732,8 +737,9 @@ void CodeGen::emitStmt(EnumStmt &s) {
         if (!s.variants[i].field_types.empty()) {
             VariantFieldInfo vfi;
             for (auto &ft : s.variants[i].field_types) {
-                vfi.fieldTypes.push_back(resolveType(ft));
-                vfi.fieldTypeNames.push_back(ft);
+                std::string ftStr = ft->toString();
+                vfi.fieldTypes.push_back(resolveType(ftStr));
+                vfi.fieldTypeNames.push_back(ftStr);
             }
             info.variantFields[s.variants[i].name] = std::move(vfi);
         }

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -293,7 +293,7 @@ void CodeGen::emitPropertyItCall(CallStmt &s) {
     // Resolve parameter types
     std::vector<llvm::Type*> paramTypes;
     for (auto &p : lam.params)
-        paramTypes.push_back(resolveType(p.type));
+        paramTypes.push_back(resolveType(p.type->toString()));
 
     llvm::Function *testFunc = emitTestFunction("__prop_test_", paramTypes, lam, "@property test");
 

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -289,7 +289,7 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
             }
             return "{" + elems + "}";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CastExpr>>) {
-            return formatExpr(*v->value) + " as " + v->target_type;
+            return formatExpr(*v->value) + " as " + v->target_type->toString();
         } else if constexpr (std::is_same_v<T, std::unique_ptr<TernaryExpr>>) {
             return formatExpr(*v->condition) + " ? " + formatExpr(*v->true_expr) + " : " + formatExpr(*v->false_expr);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<RangeExpr>>) {
@@ -320,7 +320,7 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
             return result;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
             std::string result = "fn(" + formatParams(v->params) + ")";
-            if (!v->return_type.empty()) result += " -> " + v->return_type;
+            if (v->return_type) result += " -> " + v->return_type->toString();
             if (v->expr_body) {
                 result += " => " + formatExpr(*v->expr_body);
                 return result;
@@ -350,7 +350,7 @@ std::string Formatter::formatParams(const std::vector<FnParam> &params) {
     std::string result;
     for (size_t i = 0; i < params.size(); ++i) {
         if (i > 0) result += ", ";
-        result += params[i].name + ": " + params[i].type;
+        result += params[i].name + ": " + params[i].type->toString();
         if (params[i].default_value)
             result += " = " + formatExpr(*params[i].default_value);
     }

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -8,7 +8,7 @@ void Formatter::formatAssign(const AssignStmt &s) {
 
     emit(s.name);
     if (s.type_annotation) {
-        emit(": " + *s.type_annotation);
+        emit(": " + s.type_annotation->toString());
     }
     // @native @const declarations have no value
     if (!s.value) {
@@ -29,7 +29,7 @@ void Formatter::formatAssign(const AssignStmt &s) {
         const auto &lambda = **lambda_ptr;
         if (!lambda.expr_body && !lambda.body.empty()) {
             emit("fn(" + formatParams(lambda.params) + ")");
-            if (!lambda.return_type.empty()) emit(" -> " + lambda.return_type);
+            if (lambda.return_type) emit(" -> " + lambda.return_type->toString());
             emit(":");
             emitInlineComment(s.loc.line);
             emitNewline();
@@ -69,7 +69,7 @@ void Formatter::formatCall(const CallStmt &s) {
         if (has_trailing_lambda && i == lambda_idx) {
             const auto &lambda = *std::get<std::unique_ptr<LambdaExpr>>(s.args[i]->data);
             emit("fn(" + formatParams(lambda.params) + ")");
-            if (!lambda.return_type.empty()) emit(" -> " + lambda.return_type);
+            if (lambda.return_type) emit(" -> " + lambda.return_type->toString());
             emit(":");
             emitInlineComment(s.loc.line);
             emitNewline();
@@ -85,7 +85,7 @@ void Formatter::formatCall(const CallStmt &s) {
             if (lp && !(*lp)->expr_body && !(*lp)->body.empty()) {
                 const auto &lambda = **lp;
                 emit("fn(" + formatParams(lambda.params) + ")");
-                if (!lambda.return_type.empty()) emit(" -> " + lambda.return_type);
+                if (lambda.return_type) emit(" -> " + lambda.return_type->toString());
                 emit(":");
                 emitNewline();
                 last_emitted_line_ = s.loc.line;
@@ -141,7 +141,7 @@ void Formatter::formatRecord(const RecordStmt &s) {
     for (const auto &field : s.fields) {
         formatDirectives(field.directives);
         emitIndent();
-        emit(field.name + ": " + field.type);
+        emit(field.name + ": " + field.type->toString());
         emitNewline();
     }
     if (!s.invariants.empty()) {
@@ -181,7 +181,7 @@ void Formatter::formatEnum(const EnumStmt &s) {
             emit("(");
             for (size_t i = 0; i < variant.field_types.size(); ++i) {
                 if (i > 0) emit(", ");
-                emit(variant.field_types[i]);
+                emit(variant.field_types[i]->toString());
             }
             emit(")");
         }
@@ -191,7 +191,7 @@ void Formatter::formatEnum(const EnumStmt &s) {
 }
 
 void Formatter::formatTypeAlias(const TypeAliasStmt &s) {
-    emit("type " + s.name + " = " + s.target_type);
+    emit("type " + s.name + " = " + s.target_type->toString());
     emitInlineComment(s.loc.line);
     emitNewline();
     last_emitted_line_ = s.loc.line;
@@ -255,8 +255,8 @@ void Formatter::formatFn(const FnStmt &s) {
         emit(">");
     }
     emit("(" + formatParams(s.params) + ")");
-    if (!s.return_type.empty()) {
-        emit(" -> " + s.return_type);
+    if (s.return_type) {
+        emit(" -> " + s.return_type->toString());
     }
 
     // @native functions without body: no colon, no block

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -351,10 +351,10 @@ StmtNode Parser::parseStatement() {
     if (next.kind == TokenKind::Colon) {
         // Type-annotated declaration: x: int = 42 or @native @const PI: float
         lex_.next(); // consume ':'
-        std::string typeAnnotation = parseTypeName();
+        auto typeAnnotation = parseTypeName();
         AssignStmt s;
         s.name = first.value;
-        s.type_annotation = typeAnnotation;
+        s.type_annotation = std::move(typeAnnotation);
         s.directives = std::move(directives);
         s.loc = locFromToken(first);
         if (lex_.peek().kind == TokenKind::Equals) {

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -120,7 +120,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
                 parseError(paramName.line, "parameter name '" + paramName.value + "' must be snake_case");
             lex_.next(); // consume param name
 
-            std::string paramType = "any";  // default when type is omitted
+            TypeNodePtr paramType = TypeNode::makeBasic("any");  // default when type is omitted
             bool has_explicit_type = false;
             if (lex_.peek().kind == TokenKind::Colon) {
                 lex_.next(); // consume ':'
@@ -142,7 +142,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
                     "(all parameters after a default parameter must also have defaults)");
             }
 
-            fnStmt->params.push_back({paramName.value, paramType, std::move(default_value)});
+            fnStmt->params.push_back({paramName.value, std::move(paramType), std::move(default_value)});
 
             if (lex_.peek().kind != TokenKind::Comma)
                 break;
@@ -158,7 +158,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         lex_.next(); // consume '->'
         fnStmt->return_type = parseTypeName();
     } else {
-        fnStmt->return_type = "";
+        fnStmt->return_type = nullptr;
     }
 
     // Validate operator parameter count
@@ -178,11 +178,11 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
     }
 
     // Validate return type for comparison/logical operators
-    if (fnStmt->is_operator && !fnStmt->return_type.empty()) {
-        if (isBoolConstrainedOperator(fnStmt->name) && fnStmt->return_type != "bool") {
+    if (fnStmt->is_operator && fnStmt->return_type) {
+        if (isBoolConstrainedOperator(fnStmt->name) && fnStmt->return_type->toString() != "bool") {
             parseError(fnTok.line,
                 "operator '" + operatorSymbol(fnStmt->name) + "' must return 'bool', but returns '" +
-                fnStmt->return_type + "'");
+                fnStmt->return_type->toString() + "'");
         }
     }
 
@@ -215,7 +215,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
 
     // Parse optional ensure clause with variable binding
     if (lex_.peek().kind == TokenKind::Ensure) {
-        if (fnStmt->return_type == "Unit")
+        if (fnStmt->return_type && fnStmt->return_type->toString() == "Unit")
             parseError("'ensure' requires a non-Unit return type");
         lex_.next(); // consume 'ensure'
         parseEnsureClause(*fnStmt);
@@ -334,11 +334,11 @@ StmtNode Parser::parseRecordStatement() {
             parseError("expected ':' after field name");
         lex_.next(); // consume ':'
 
-        std::string fieldType = parseTypeName();
+        auto fieldType = parseTypeName();
 
         if (seenFields.count(fieldName.value))
             parseError(fieldName.line, "duplicate field name '" + fieldName.value + "'");
-        ts.fields.push_back({fieldName.value, fieldType, std::move(fieldDirectives)});
+        ts.fields.push_back({fieldName.value, std::move(fieldType), std::move(fieldDirectives)});
         seenFields.insert(fieldName.value);
 
         if (lex_.peek().kind == TokenKind::Newline)
@@ -376,11 +376,11 @@ StmtNode Parser::parseTypeAliasStatement() {
         parseError("expected '=' in type alias declaration");
     lex_.next(); // consume '='
 
-    std::string targetType = parseTypeName();
+    auto targetType = parseTypeName();
 
     TypeAliasStmt s;
     s.name = nameTok.value;
-    s.target_type = targetType;
+    s.target_type = std::move(targetType);
     s.loc = locFromToken(typeTok);
     return s;
 }
@@ -550,72 +550,57 @@ StmtNode Parser::parseEnumStatement() {
     return es;
 }
 
-std::string Parser::parseTypeName() {
-    std::string name = parseTypeNameSingle();
+TypeNodePtr Parser::parseTypeName() {
+    auto node = parseTypeNameSingle();
+    if (lex_.peek().kind != TokenKind::Pipe)
+        return node;
+    // Union type
+    std::vector<TypeNodePtr> components;
+    components.push_back(std::move(node));
     while (lex_.peek().kind == TokenKind::Pipe) {
         lex_.next(); // consume '|'
-        name += " | " + parseTypeNameSingle();
+        components.push_back(parseTypeNameSingle());
     }
-    return name;
+    return TypeNode::makeUnion(std::move(components));
 }
 
-std::string Parser::parseTypeNameSingle() {
+TypeNodePtr Parser::parseTypeNameSingle() {
     // Fixed-length array type: [T; N]
     if (lex_.peek().kind == TokenKind::LBracket) {
         lex_.next(); // consume '['
-        std::string elemType = parseTypeNameSingle();
+        auto elemType = parseTypeNameSingle();
         if (lex_.peek().kind != TokenKind::Semi)
             parseError("expected ';' in array type [T; N]");
         lex_.next(); // consume ';'
         if (lex_.peek().kind != TokenKind::Number)
             parseError("expected integer size in array type [T; N]");
-        std::string size = lex_.peek().value;
+        uint64_t size = std::stoull(lex_.peek().value);
         lex_.next(); // consume number
         if (lex_.peek().kind != TokenKind::RBracket)
             parseError("expected ']' in array type");
         lex_.next(); // consume ']'
-        return "[" + elemType + "; " + size + "]";
+        return TypeNode::makeArray(std::move(elemType), size);
     }
 
     // Tuple type: (int, float)
     if (lex_.peek().kind == TokenKind::LParen) {
         lex_.next(); // consume '('
-        std::string name = "(" + parseTypeName();
+        std::vector<TypeNodePtr> elements;
+        elements.push_back(parseTypeName());
         while (lex_.peek().kind == TokenKind::Comma) {
             lex_.next(); // consume ','
-            name += ", " + parseTypeName();
+            elements.push_back(parseTypeName());
         }
         if (lex_.peek().kind != TokenKind::RParen)
             parseError("expected ')' in tuple type");
         lex_.next(); // consume ')'
-        name += ")";
-        return name;
+        return TypeNode::makeTuple(std::move(elements));
     }
 
     // fn(int, int) -> int  function type
     if (lex_.peek().kind == TokenKind::Fn) {
         lex_.next(); // consume 'fn'
-        std::string name = "fn";
-        if (lex_.peek().kind != TokenKind::LParen)
-            parseError("expected '(' after 'fn' in function type");
-        lex_.next(); // consume '('
-        name += "(";
-        if (lex_.peek().kind != TokenKind::RParen) {
-            name += parseTypeName();
-            while (lex_.peek().kind == TokenKind::Comma) {
-                lex_.next(); // consume ','
-                name += ", " + parseTypeName();
-            }
-        }
-        if (lex_.peek().kind != TokenKind::RParen)
-            parseError("expected ')' in function type");
-        lex_.next(); // consume ')'
-        name += ")";
-        if (lex_.peek().kind == TokenKind::Arrow) {
-            lex_.next(); // consume '->'
-            name += " -> " + parseTypeName();
-        }
-        return name;
+        return parseFnType();
     }
 
     // Int literal type (42, -10) or range type (1..12, -10..10)
@@ -649,79 +634,87 @@ std::string Parser::parseTypeNameSingle() {
             }
             std::string endVal = (negEnd ? "-" : "") + endNum;
             lex_.next(); // consume end number
-            return name + ".." + endVal;
+            return TypeNode::makeRange(name, endVal);
         }
-        return name;
+        return TypeNode::makeBasic(name);
     }
 
     // String literal type: "N"
     if (lex_.peek().kind == TokenKind::String) {
         std::string name = "\"" + lex_.peek().value + "\"";
         lex_.next(); // consume string
-        return name;
+        return TypeNode::makeBasic(name);
     }
 
     Token t = lex_.peek();
     if (t.kind == TokenKind::ErrorKw) {
         lex_.next(); // consume 'Error'
-        std::string name = "Error";
         if (lex_.peek().kind == TokenKind::Question) {
             lex_.next(); // consume '?'
-            name += "?";
+            return TypeNode::makeOptional(TypeNode::makeBasic("Error"));
         }
-        return name;
+        return TypeNode::makeBasic("Error");
     }
     if (t.kind != TokenKind::Ident)
         parseError(t.line, "expected type name");
     std::string name = t.value;
     lex_.next(); // consume type name
 
-    // fn(int, int) -> int  function type (when fn comes as an ident, shouldn't happen normally)
+    // fn(int, int) -> int  function type (when fn comes as an ident)
     if (name == "fn" && lex_.peek().kind == TokenKind::LParen) {
-        lex_.next(); // consume '('
-        name += "(";
-        if (lex_.peek().kind != TokenKind::RParen) {
-            name += parseTypeName();
-            while (lex_.peek().kind == TokenKind::Comma) {
-                lex_.next(); // consume ','
-                name += ", " + parseTypeName();
-            }
-        }
-        if (lex_.peek().kind != TokenKind::RParen)
-            parseError("expected ')' in function type");
-        lex_.next(); // consume ')'
-        name += ")";
-        if (lex_.peek().kind == TokenKind::Arrow) {
-            lex_.next(); // consume '->'
-            name += " -> " + parseTypeName();
-        }
-        return name;
+        return parseFnType();
     }
 
+    TypeNodePtr result;
     if (lex_.peek().kind == TokenKind::Less) {
         lex_.next(); // consume '<'
-        std::string inner = parseTypeName();
+        std::vector<TypeNodePtr> typeArgs;
+        typeArgs.push_back(parseTypeName());
         if ((name == "Map" || name == "Result") && lex_.peek().kind == TokenKind::Comma) {
             // Two-parameter generic: Map<K, V> or Result<V, E>
             lex_.next(); // consume ','
-            std::string secondTy = parseTypeName();
+            typeArgs.push_back(parseTypeName());
             if (!lex_.consumeGreaterInTypeContext())
                 parseError("expected '>' in " + name + " type");
-            name += "<" + inner + ", " + secondTy + ">";
         } else {
             if (!lex_.consumeGreaterInTypeContext())
                 parseError("expected '>' after generic type parameter");
-            name += "<" + inner + ">";
         }
+        result = TypeNode::makeGeneric(name, std::move(typeArgs));
+    } else {
+        result = TypeNode::makeBasic(name);
     }
 
     // Optional type suffix: int? => wraps in Option<T>
     if (lex_.peek().kind == TokenKind::Question) {
         lex_.next(); // consume '?'
-        name = name + "?";
+        result = TypeNode::makeOptional(std::move(result));
     }
 
-    return name;
+    return result;
+}
+
+TypeNodePtr Parser::parseFnType() {
+    if (lex_.peek().kind != TokenKind::LParen)
+        parseError("expected '(' after 'fn' in function type");
+    lex_.next(); // consume '('
+    std::vector<TypeNodePtr> paramTypes;
+    if (lex_.peek().kind != TokenKind::RParen) {
+        paramTypes.push_back(parseTypeName());
+        while (lex_.peek().kind == TokenKind::Comma) {
+            lex_.next(); // consume ','
+            paramTypes.push_back(parseTypeName());
+        }
+    }
+    if (lex_.peek().kind != TokenKind::RParen)
+        parseError("expected ')' in function type");
+    lex_.next(); // consume ')'
+    TypeNodePtr retType;
+    if (lex_.peek().kind == TokenKind::Arrow) {
+        lex_.next(); // consume '->'
+        retType = parseTypeName();
+    }
+    return TypeNode::makeFn(std::move(paramTypes), std::move(retType));
 }
 
 Pattern Parser::parsePattern() {

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -147,7 +147,7 @@ ExprPtr Parser::parseCast() {
         std::string targetType = lex_.next().value;
         auto cast = std::make_unique<CastExpr>();
         cast->value = std::move(expr);
-        cast->target_type = targetType;
+        cast->target_type = TypeNode::makeBasic(targetType);
         auto node = std::make_unique<ExprNode>();
         node->data = std::move(cast);
         node->loc = locFromToken(asTok);
@@ -594,7 +594,7 @@ ExprPtr Parser::parseLambdaExpr() {
                 parseError(paramName.line, "expected parameter name in lambda");
             lex_.next(); // consume param name
 
-            std::string paramType = "any";  // default when type is omitted
+            TypeNodePtr paramType = TypeNode::makeBasic("any");  // default when type is omitted
             if (lex_.peek().kind == TokenKind::Colon) {
                 lex_.next(); // consume ':'
                 paramType = parseTypeName();
@@ -603,7 +603,7 @@ ExprPtr Parser::parseLambdaExpr() {
                 parseError(paramName.line,
                     "default arguments are not supported in lambda expressions");
 
-            lambda->params.push_back({paramName.value, paramType, nullptr});
+            lambda->params.push_back({paramName.value, std::move(paramType), nullptr});
 
             if (lex_.peek().kind != TokenKind::Comma)
                 break;
@@ -620,7 +620,7 @@ ExprPtr Parser::parseLambdaExpr() {
         lex_.next(); // consume '->'
         lambda->return_type = parseTypeName();
     } else {
-        lambda->return_type = "";  // inferred at codegen time
+        lambda->return_type = nullptr;  // inferred at codegen time
     }
 
     if (lex_.peek().kind == TokenKind::FatArrow) {
@@ -766,7 +766,7 @@ ExprPtr Parser::parseTrailingBlockAsLambda() {
     // ':' is already consumed. Parse the block and wrap it in a LambdaExpr.
     auto body = parseBlock();
     auto lambda = std::make_unique<LambdaExpr>();
-    lambda->return_type = "";  // inferred at codegen time
+    lambda->return_type = nullptr;  // inferred at codegen time
     lambda->body = std::move(body);
     auto node = std::make_unique<ExprNode>();
     node->data = std::move(lambda);

--- a/src/type_node.cpp
+++ b/src/type_node.cpp
@@ -1,0 +1,97 @@
+#include "ry/ast.hpp"
+
+std::string TypeNode::toString() const {
+    return std::visit([](const auto &v) -> std::string {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, BasicType>) {
+            return v.name;
+        } else if constexpr (std::is_same_v<T, GenericType>) {
+            std::string result = v.name + "<";
+            for (size_t i = 0; i < v.type_args.size(); ++i) {
+                if (i > 0) result += ", ";
+                result += v.type_args[i]->toString();
+            }
+            result += ">";
+            return result;
+        } else if constexpr (std::is_same_v<T, ArrayType>) {
+            return "[" + v.element_type->toString() + "; " + std::to_string(v.size) + "]";
+        } else if constexpr (std::is_same_v<T, TupleType>) {
+            std::string result = "(";
+            for (size_t i = 0; i < v.elements.size(); ++i) {
+                if (i > 0) result += ", ";
+                result += v.elements[i]->toString();
+            }
+            result += ")";
+            return result;
+        } else if constexpr (std::is_same_v<T, FnType>) {
+            std::string result = "fn(";
+            for (size_t i = 0; i < v.param_types.size(); ++i) {
+                if (i > 0) result += ", ";
+                result += v.param_types[i]->toString();
+            }
+            result += ")";
+            if (v.return_type)
+                result += " -> " + v.return_type->toString();
+            return result;
+        } else if constexpr (std::is_same_v<T, UnionType>) {
+            std::string result;
+            for (size_t i = 0; i < v.components.size(); ++i) {
+                if (i > 0) result += " | ";
+                result += v.components[i]->toString();
+            }
+            return result;
+        } else if constexpr (std::is_same_v<T, OptionalType>) {
+            return v.inner->toString() + "?";
+        } else if constexpr (std::is_same_v<T, RangeType>) {
+            return v.start + ".." + v.end;
+        }
+    }, data);
+}
+
+TypeNodePtr TypeNode::makeBasic(std::string name) {
+    auto node = std::make_unique<TypeNode>();
+    node->data = BasicType{std::move(name)};
+    return node;
+}
+
+TypeNodePtr TypeNode::makeGeneric(std::string name, std::vector<TypeNodePtr> args) {
+    auto node = std::make_unique<TypeNode>();
+    node->data = GenericType{std::move(name), std::move(args)};
+    return node;
+}
+
+TypeNodePtr TypeNode::makeArray(TypeNodePtr elem, uint64_t size) {
+    auto node = std::make_unique<TypeNode>();
+    node->data = ArrayType{std::move(elem), size};
+    return node;
+}
+
+TypeNodePtr TypeNode::makeTuple(std::vector<TypeNodePtr> elems) {
+    auto node = std::make_unique<TypeNode>();
+    node->data = TupleType{std::move(elems)};
+    return node;
+}
+
+TypeNodePtr TypeNode::makeFn(std::vector<TypeNodePtr> params, TypeNodePtr ret) {
+    auto node = std::make_unique<TypeNode>();
+    node->data = FnType{std::move(params), std::move(ret)};
+    return node;
+}
+
+TypeNodePtr TypeNode::makeUnion(std::vector<TypeNodePtr> comps) {
+    auto node = std::make_unique<TypeNode>();
+    node->data = UnionType{std::move(comps)};
+    return node;
+}
+
+TypeNodePtr TypeNode::makeOptional(TypeNodePtr inner) {
+    auto node = std::make_unique<TypeNode>();
+    node->data = OptionalType{std::move(inner)};
+    return node;
+}
+
+TypeNodePtr TypeNode::makeRange(std::string start, std::string end) {
+    auto node = std::make_unique<TypeNode>();
+    node->data = RangeType{std::move(start), std::move(end)};
+    return node;
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -14,7 +14,7 @@ TEST(ParserTest, LetSimpleInt) {
     ASSERT_TRUE(std::holds_alternative<AssignStmt>(prog[0]));
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "x");
-    EXPECT_FALSE(s.type_annotation.has_value());
+    EXPECT_EQ(s.type_annotation, nullptr);
     ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.value->data));
     EXPECT_EQ(std::get<NumberExpr>(s.value->data).value, 42);
 }
@@ -25,7 +25,7 @@ TEST(ParserTest, VarSimpleInt) {
     ASSERT_TRUE(std::holds_alternative<AssignStmt>(prog[0]));
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "x");
-    EXPECT_FALSE(s.type_annotation.has_value());
+    EXPECT_EQ(s.type_annotation, nullptr);
     ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.value->data));
     EXPECT_EQ(std::get<NumberExpr>(s.value->data).value, 42);
 }
@@ -35,8 +35,8 @@ TEST(ParserTest, LetWithTypeAnnotation) {
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "x");
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "int");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"int");
     ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.value->data));
     EXPECT_EQ(std::get<NumberExpr>(s.value->data).value, 42);
 }
@@ -45,8 +45,8 @@ TEST(ParserTest, VarWithTypeAnnotation) {
     Program prog = parseStr("y: float = 3.14");
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "y");
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "float");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"float");
     ASSERT_TRUE(std::holds_alternative<FloatExpr>(s.value->data));
 }
 
@@ -211,8 +211,8 @@ TEST(ParserTest, TypeAnnotationInt) {
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "x");
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "int");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"int");
     ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.value->data));
     EXPECT_EQ(std::get<NumberExpr>(s.value->data).value, 42);
 }
@@ -221,8 +221,8 @@ TEST(ParserTest, TypeAnnotationFloat) {
     Program prog = parseStr("y: float = 3.14");
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "y");
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "float");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"float");
     ASSERT_TRUE(std::holds_alternative<FloatExpr>(s.value->data));
 }
 
@@ -230,8 +230,8 @@ TEST(ParserTest, TypeAnnotationBool) {
     Program prog = parseStr("z: bool = true");
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "z");
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "bool");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"bool");
     ASSERT_TRUE(std::holds_alternative<BoolExpr>(s.value->data));
 }
 
@@ -239,8 +239,8 @@ TEST(ParserTest, TypeAnnotationAcceptsUserDefinedType) {
     Program prog = parseStr("x: Point = p");
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "Point");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"Point");
 }
 
 // ===== type パーサーテスト =====
@@ -253,9 +253,9 @@ TEST(ParserTest, TypeDefinition) {
     EXPECT_EQ(ts.name, "Point");
     ASSERT_EQ(ts.fields.size(), 2u);
     EXPECT_EQ(ts.fields[0].name, "x");
-    EXPECT_EQ(ts.fields[0].type, "int");
+    EXPECT_EQ(ts.fields[0].type->toString(), "int");
     EXPECT_EQ(ts.fields[1].name, "y");
-    EXPECT_EQ(ts.fields[1].type, "int");
+    EXPECT_EQ(ts.fields[1].type->toString(), "int");
 }
 
 TEST(ParserTest, FieldAccessSimple) {
@@ -298,8 +298,8 @@ TEST(ParserTest, LetStringWithTypeAnnotation) {
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "s");
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "str");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"str");
     ASSERT_TRUE(std::holds_alternative<StringExpr>(s.value->data));
     EXPECT_EQ(std::get<StringExpr>(s.value->data).value, "world");
 }
@@ -311,8 +311,8 @@ TEST(ParserTest, TypeAnnotationMissingEqualsThrows) {
 TEST(ParserTest, TypeAnnotationMixedWithInference) {
     Program prog = parseStr("a: int = 1\nb = 2");
     ASSERT_EQ(prog.size(), 2u);
-    EXPECT_TRUE(std::get<AssignStmt>(prog[0]).type_annotation.has_value());
-    EXPECT_FALSE(std::get<AssignStmt>(prog[1]).type_annotation.has_value());
+    EXPECT_TRUE(std::get<AssignStmt>(prog[0]).type_annotation != nullptr);
+    EXPECT_EQ(std::get<AssignStmt>(prog[1]).type_annotation, nullptr);
 }
 
 TEST(ParserTest, BareAssignmentWithoutDeclaration) {
@@ -329,8 +329,8 @@ TEST(ParserTest, TypeAnnotationWithoutValue) {
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "x");
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "int");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"int");
 }
 
 // ===== if/elif/else パーサーテスト =====
@@ -412,10 +412,10 @@ TEST(ParserTest, FnSimple) {
     EXPECT_EQ(fn.name, "add");
     ASSERT_EQ(fn.params.size(), 2u);
     EXPECT_EQ(fn.params[0].name, "a");
-    EXPECT_EQ(fn.params[0].type, "int");
+    EXPECT_EQ(fn.params[0].type->toString(), "int");
     EXPECT_EQ(fn.params[1].name, "b");
-    EXPECT_EQ(fn.params[1].type, "int");
-    EXPECT_EQ(fn.return_type, "int");
+    EXPECT_EQ(fn.params[1].type->toString(), "int");
+    EXPECT_EQ(fn.return_type->toString(), "int");
     ASSERT_EQ(fn.body.size(), 1u);
     EXPECT_TRUE(std::holds_alternative<ReturnStmt>(fn.body[0]));
 }
@@ -455,7 +455,7 @@ TEST(ParserTest, FnReturnTypeOmitted) {
     ASSERT_EQ(prog.size(), 1u);
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(fn.name, "f");
-    EXPECT_EQ(fn.return_type, "");
+    EXPECT_EQ(fn.return_type, nullptr);
     ASSERT_EQ(fn.body.size(), 1u);
     ASSERT_TRUE(std::holds_alternative<ReturnStmt>(fn.body[0]));
     const auto &ret = std::get<ReturnStmt>(fn.body[0]);
@@ -465,7 +465,7 @@ TEST(ParserTest, FnReturnTypeOmitted) {
 TEST(ParserTest, FnExplicitUnitReturn) {
     Program prog = parseStr("fn f() -> Unit:\n    return");
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
-    EXPECT_EQ(fn.return_type, "Unit");
+    EXPECT_EQ(fn.return_type->toString(), "Unit");
 }
 
 TEST(ParserTest, LambdaReturnTypeOmitted) {
@@ -474,7 +474,7 @@ TEST(ParserTest, LambdaReturnTypeOmitted) {
     ASSERT_EQ(prog.size(), 1u);
     const auto &assign = std::get<AssignStmt>(prog[0]);
     const auto &lambda = std::get<std::unique_ptr<LambdaExpr>>(assign.value->data);
-    EXPECT_EQ(lambda->return_type, "");
+    EXPECT_EQ(lambda->return_type, nullptr);
 }
 
 TEST(ParserTest, LambdaExplicitReturnType) {
@@ -483,28 +483,28 @@ TEST(ParserTest, LambdaExplicitReturnType) {
     ASSERT_EQ(prog.size(), 1u);
     const auto &assign = std::get<AssignStmt>(prog[0]);
     const auto &lambda = std::get<std::unique_ptr<LambdaExpr>>(assign.value->data);
-    EXPECT_EQ(lambda->return_type, "int");
+    EXPECT_EQ(lambda->return_type->toString(), "int");
 }
 
 TEST(ParserTest, TypeAnnotationOptionInt) {
     Program prog = parseStr("x: Option<int> = None");
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "Option<int>");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"Option<int>");
 }
 
 TEST(ParserTest, FnParamOptionType) {
     Program prog = parseStr("fn f(x: Option<int>) -> int:\n    return 0");
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(fn.params.size(), 1u);
-    EXPECT_EQ(fn.params[0].type, "Option<int>");
+    EXPECT_EQ(fn.params[0].type->toString(), "Option<int>");
 }
 
 TEST(ParserTest, FnReturnOptionType) {
     Program prog = parseStr("fn f() -> Option<int>:\n    return Some(1)");
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
-    EXPECT_EQ(fn.return_type, "Option<int>");
+    EXPECT_EQ(fn.return_type->toString(), "Option<int>");
 }
 
 // ===== import パーサーテスト =====
@@ -591,8 +591,8 @@ TEST(ParserTest, TupleThreeElements) {
 TEST(ParserTest, TupleTypeAnnotation) {
     Program prog = parseStr("t: (int, float) = (1, 3.14)");
     const auto &s = std::get<AssignStmt>(prog[0]);
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "(int, float)");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"(int, float)");
 }
 
 TEST(ParserTest, TupleIndexAccess) {
@@ -609,7 +609,7 @@ TEST(ParserTest, TupleIndexAccess) {
 TEST(ParserTest, FnReturnTupleType) {
     Program prog = parseStr("fn swap(a: int, b: int) -> (int, int):\n    return (b, a)");
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
-    EXPECT_EQ(fn.return_type, "(int, int)");
+    EXPECT_EQ(fn.return_type->toString(), "(int, int)");
 }
 
 TEST(ParserTest, ParenGroupingStillWorks) {
@@ -721,8 +721,8 @@ TEST(ParserTest, MapTypeAnnotation) {
     Program prog = parseStr("m: Map<str, int> = {\"a\": 1}");
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "Map<str, int>");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"Map<str, int>");
 }
 
 // ===== Operator overloading =====
@@ -739,10 +739,10 @@ TEST(ParserTest, OperatorFnBinaryPlus) {
     EXPECT_TRUE(fn->is_operator);
     ASSERT_EQ(fn->params.size(), 2u);
     EXPECT_EQ(fn->params[0].name, "a");
-    EXPECT_EQ(fn->params[0].type, "Vec2");
+    EXPECT_EQ(fn->params[0].type->toString(), "Vec2");
     EXPECT_EQ(fn->params[1].name, "b");
-    EXPECT_EQ(fn->params[1].type, "Vec2");
-    EXPECT_EQ(fn->return_type, "Vec2");
+    EXPECT_EQ(fn->params[1].type->toString(), "Vec2");
+    EXPECT_EQ(fn->return_type->toString(), "Vec2");
 }
 
 TEST(ParserTest, OperatorFnUnaryMinus) {
@@ -914,8 +914,8 @@ TEST(ParserTest, OperatorFnCompoundPlusEq) {
     EXPECT_TRUE(fn->is_operator);
     ASSERT_EQ(fn->params.size(), 2u);
     EXPECT_EQ(fn->params[0].name, "a");
-    EXPECT_EQ(fn->params[0].type, "Vec2");
-    EXPECT_EQ(fn->return_type, "Vec2");
+    EXPECT_EQ(fn->params[0].type->toString(), "Vec2");
+    EXPECT_EQ(fn->return_type->toString(), "Vec2");
 }
 
 TEST(ParserTest, OperatorFnCompoundAssignRequiresTwoParams) {
@@ -959,8 +959,8 @@ TEST(ParserTest, SetTypeAnnotation) {
     Program prog = parseStr("s: Set<int> = {1}");
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "Set<int>");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"Set<int>");
 }
 
 TEST(ParserTest, InOperator) {
@@ -1019,21 +1019,21 @@ TEST(ParserTest, LetUnionTypeAnnotation) {
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
     EXPECT_EQ(s.name, "x");
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "int | str");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"int | str");
 }
 
 TEST(ParserTest, FnUnionParam) {
     Program prog = parseStr("fn f(x: int | str) -> int:\n    return 0");
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(fn.params.size(), 1u);
-    EXPECT_EQ(fn.params[0].type, "int | str");
+    EXPECT_EQ(fn.params[0].type->toString(), "int | str");
 }
 
 TEST(ParserTest, FnUnionReturn) {
     Program prog = parseStr("fn f() -> int | str:\n    return 0");
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
-    EXPECT_EQ(fn.return_type, "int | str");
+    EXPECT_EQ(fn.return_type->toString(), "int | str");
 }
 
 // ===== >>> パーサーテスト =====
@@ -1075,8 +1075,8 @@ TEST(ParserTest, NotStillWorksAfterNotIn) {
 TEST(ParserTest, UnionThreeTypes) {
     Program prog = parseStr("x: int | float | str = 42");
     const auto &s = std::get<AssignStmt>(prog[0]);
-    ASSERT_TRUE(s.type_annotation.has_value());
-    EXPECT_EQ(*s.type_annotation, "int | float | str");
+    ASSERT_TRUE(s.type_annotation != nullptr);
+    EXPECT_EQ(s.type_annotation->toString(),"int | float | str");
 }
 
 // ===== Contract (Design by Contract) tests =====
@@ -1219,7 +1219,7 @@ TEST(ParserTest, TypeAlias) {
     ASSERT_TRUE(std::holds_alternative<TypeAliasStmt>(prog[0]));
     auto &ta = std::get<TypeAliasStmt>(prog[0]);
     EXPECT_EQ(ta.name, "MyInt");
-    EXPECT_EQ(ta.target_type, "int");
+    EXPECT_EQ(ta.target_type->toString(), "int");
 }
 
 // ===== for k, v in map =====
@@ -1268,7 +1268,7 @@ TEST(ParserTest, AsyncFnParsing) {
     auto &fn = std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_TRUE(fn->is_async);
     EXPECT_EQ(fn->name, "add");
-    EXPECT_EQ(fn->return_type, "int");
+    EXPECT_EQ(fn->return_type->toString(), "int");
 }
 
 TEST(ParserTest, AwaitExprParsing) {
@@ -1417,14 +1417,14 @@ TEST(ParserTest, EnumNamedFields) {
     // Circle
     EXPECT_EQ(es.variants[0].name, "Circle");
     ASSERT_EQ(es.variants[0].field_types.size(), 1u);
-    EXPECT_EQ(es.variants[0].field_types[0], "float");
+    EXPECT_EQ(es.variants[0].field_types[0]->toString(), "float");
     ASSERT_EQ(es.variants[0].field_names.size(), 1u);
     EXPECT_EQ(es.variants[0].field_names[0], "radius");
     // Rect
     EXPECT_EQ(es.variants[1].name, "Rect");
     ASSERT_EQ(es.variants[1].field_types.size(), 2u);
-    EXPECT_EQ(es.variants[1].field_types[0], "float");
-    EXPECT_EQ(es.variants[1].field_types[1], "float");
+    EXPECT_EQ(es.variants[1].field_types[0]->toString(), "float");
+    EXPECT_EQ(es.variants[1].field_types[1]->toString(), "float");
     ASSERT_EQ(es.variants[1].field_names.size(), 2u);
     EXPECT_EQ(es.variants[1].field_names[0], "width");
     EXPECT_EQ(es.variants[1].field_names[1], "height");
@@ -1461,7 +1461,7 @@ TEST(ParserTest, EnumNamedFieldsGeneric) {
     ASSERT_EQ(es.variants[0].field_names.size(), 1u);
     EXPECT_EQ(es.variants[0].field_names[0], "value");
     ASSERT_EQ(es.variants[0].field_types.size(), 1u);
-    EXPECT_EQ(es.variants[0].field_types[0], "T");
+    EXPECT_EQ(es.variants[0].field_types[0]->toString(), "T");
 }
 
 TEST(ParserTest, PascalCaseTypeAliasRequired) {
@@ -1472,7 +1472,7 @@ TEST(ParserTest, TypeAliasFnType) {
     Program prog = parseStr("type Callback = fn(int, int) -> int");
     auto &ta = std::get<TypeAliasStmt>(prog[0]);
     EXPECT_EQ(ta.name, "Callback");
-    EXPECT_EQ(ta.target_type, "fn(int, int) -> int");
+    EXPECT_EQ(ta.target_type->toString(), "fn(int, int) -> int");
 }
 
 TEST(ParserTest, SnakeCaseForLoopVariable) {
@@ -1565,7 +1565,7 @@ TEST(ParserTest, NativeFnDeclaration) {
     auto &fs = std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(fs->name, "contains");
     EXPECT_EQ(fs->params.size(), 2u);
-    EXPECT_EQ(fs->return_type, "bool");
+    EXPECT_EQ(fs->return_type->toString(), "bool");
     EXPECT_TRUE(fs->body.empty());
     ASSERT_EQ(fs->directives.size(), 1u);
     EXPECT_EQ(fs->directives[0].name, "native");


### PR DESCRIPTION
## Summary

- Introduce `TypeNode` variant type with 8 sub-types (BasicType, GenericType, ArrayType, TupleType, FnType, UnionType, OptionalType, RangeType) to structurally represent all type annotations in the AST
- Migrate parser's `parseTypeName()`/`parseTypeNameSingle()` to build `TypeNode` trees instead of concatenating strings
- Convert all AST type fields (`FnParam.type`, `AssignStmt.type_annotation`, `FnStmt.return_type`, `FieldDef.type`, `CastExpr.target_type`, `TypeAliasStmt.target_type`, `LambdaExpr.return_type`, `EnumVariant.field_types`) from `std::string` to `TypeNodePtr`
- Add `toString()` bridge so codegen continues using existing `resolveType(string)` logic (Phase 2 will migrate codegen to consume TypeNode directly)

Closes #343

## Test plan

- [x] All 1057 C++ tests pass
- [x] All 41 Ry self-test files pass with 0 failures
- [x] `toString()` round-trip produces identical strings to the previous parser output
- [x] No user-facing behavior changes (internal refactoring only)