### PR TITLE
refactor: extract shared bounds-check and type-coercion helpers for index operations

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -295,6 +295,10 @@ private:
     bool isLowLevelTy(llvm::Type *ty) const;
     bool isLowLevelTy(llvm::Value *val) const;
     void checkLowLevelTypeMix(llvm::Value *lhs, llvm::Value *rhs, const std::string &op);
+    llvm::Value *coerceToLowLevelType(llvm::Value *val, llvm::Type *targetTy,
+                                       const std::string &typeName,
+                                       const std::string &context,
+                                       const std::string &truncName);
 
     // Checked/Saturating/Wrapping arithmetic helpers
     void validateCheckedArithArgs(llvm::Value *lhs, llvm::Value *rhs, const std::string &callee);
@@ -380,6 +384,9 @@ private:
     std::pair<llvm::Type*, llvm::Type*> parseMapTypeAnnotation(const std::string &typeStr);
     FnTypeInfo parseFnTypeAnnotation(const std::string &typeStr);
     void emitRuntimeError(const std::string &message, const std::string &globalName);
+    void emitBoundsCheck(llvm::Value *&index, llvm::Value *size,
+                         const std::string &errMsg, const std::string &globalName,
+                         const std::string &bbPrefix);
     void emitContractCheck(const std::string &kind, const std::string &fn_name,
                            const ExprPtr &cond);
     void emitEnsureChecks(llvm::Value *retVal);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1,6 +1,7 @@
 #include "ry/codegen.hpp"
 #include "ry/coverage_runtime.hpp"
 #include "ry/diagnostic.hpp"
+#include <climits>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -853,6 +854,63 @@ void CodeGen::emitRuntimeError(const std::string &message, const std::string &gl
     auto exitFn = getStdlibExit();
     builder_.CreateCall(exitFn, {llvm::ConstantInt::get(i32Ty_, 1)});
     builder_.CreateUnreachable();
+}
+
+void CodeGen::emitBoundsCheck(llvm::Value *&index, llvm::Value *size,
+                               const std::string &errMsg, const std::string &globalName,
+                               const std::string &bbPrefix) {
+    if (index->getType() == i1Ty_)
+        index = builder_.CreateZExt(index, i64Ty_, "idx_ext");
+
+    if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(index)) {
+        if (auto *cs = llvm::dyn_cast<llvm::ConstantInt>(size)) {
+            int64_t idx = ci->getSExtValue();
+            uint64_t sz = cs->getZExtValue();
+            if (idx < 0 || (uint64_t)idx >= sz)
+                codegenError("index " + std::to_string(idx) +
+                             " out of bounds (size " + std::to_string(sz) + ")");
+            return;
+        }
+    }
+
+    llvm::Value *negCheck = builder_.CreateICmpSLT(
+        index, llvm::ConstantInt::get(i64Ty_, 0), bbPrefix + "_neg");
+    llvm::Value *overCheck = builder_.CreateICmpSGE(index, size, bbPrefix + "_over");
+    llvm::Value *oob = builder_.CreateOr(negCheck, overCheck, bbPrefix + "_oob");
+    llvm::BasicBlock *oobBB = llvm::BasicBlock::Create(*ctx_, bbPrefix + ".oob", fn_);
+    llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, bbPrefix + ".ok", fn_);
+    builder_.CreateCondBr(oob, oobBB, okBB);
+    builder_.SetInsertPoint(oobBB);
+    emitRuntimeError(errMsg, globalName);
+    builder_.SetInsertPoint(okBB);
+}
+
+llvm::Value *CodeGen::coerceToLowLevelType(llvm::Value *val, llvm::Type *targetTy,
+                                            const std::string &typeName,
+                                            const std::string &context,
+                                            const std::string &truncName) {
+    if (val->getType() == f64Ty_ && targetTy == f32Ty_)
+        return builder_.CreateFPTrunc(val, f32Ty_, truncName);
+
+    if (val->getType() == i64Ty_ && (targetTy == i8Ty_ || targetTy == i16Ty_ || targetTy == i32Ty_)) {
+        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
+            int64_t v = ci->getSExtValue();
+            bool isUnsigned = (!typeName.empty() && typeName[0] == 'u');
+            bool outOfRange = false;
+            if (targetTy == i8Ty_) {
+                outOfRange = isUnsigned ? (v < 0 || v > 255) : (v < INT8_MIN || v > INT8_MAX);
+            } else if (targetTy == i16Ty_) {
+                outOfRange = isUnsigned ? (v < 0 || v > (int64_t)UINT16_MAX) : (v < INT16_MIN || v > INT16_MAX);
+            } else {
+                outOfRange = isUnsigned ? (v < 0 || v > (int64_t)UINT32_MAX) : (v < INT32_MIN || v > INT32_MAX);
+            }
+            if (outOfRange)
+                codegenError(typeName + " value out of range" + context + ": " + std::to_string(v));
+        }
+        return builder_.CreateTrunc(val, targetTy, truncName);
+    }
+
+    return nullptr;
 }
 
 void CodeGen::emitPrintValue(llvm::Value *val, llvm::Type *ty,

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -422,29 +422,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
             llvm::Type *elemTy = arrTy->getElementType();
             uint64_t arrSize = arrTy->getNumElements();
 
-            if (index->getType() == i1Ty_)
-                index = builder_.CreateZExt(index, i64Ty_, "idx_ext");
-
-            // Bounds check
-            if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(index)) {
-                int64_t idx = ci->getSExtValue();
-                if (idx < 0 || (uint64_t)idx >= arrSize)
-                    codegenError("array index " + std::to_string(idx) +
-                                 " out of bounds (size " + std::to_string(arrSize) + ")");
-            } else {
-                // Runtime bounds check
-                llvm::Value *negCheck = builder_.CreateICmpSLT(
-                    index, llvm::ConstantInt::get(i64Ty_, 0), "arr_neg");
-                llvm::Value *overCheck = builder_.CreateICmpSGE(
-                    index, llvm::ConstantInt::get(i64Ty_, arrSize), "arr_over");
-                llvm::Value *oob = builder_.CreateOr(negCheck, overCheck, "arr_oob");
-                llvm::BasicBlock *oobBB = llvm::BasicBlock::Create(*ctx_, "arr.oob", fn_);
-                llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "arr.ok", fn_);
-                builder_.CreateCondBr(oob, oobBB, okBB);
-                builder_.SetInsertPoint(oobBB);
-                emitRuntimeError("runtime error: array index out of range\n", ".arr_idx_err");
-                builder_.SetInsertPoint(okBB);
-            }
+            emitBoundsCheck(index, llvm::ConstantInt::get(i64Ty_, arrSize),
+                            "runtime error: array index out of range\n", ".arr_idx_err", "arr");
 
             llvm::Value *elemPtr = builder_.CreateGEP(
                 arrTy, ai, {llvm::ConstantInt::get(i64Ty_, 0), index}, "arr_elem_ptr");
@@ -500,25 +479,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     if (!elemTy)
         codegenError("cannot determine list element type for index access");
 
-    if (index->getType() == i1Ty_)
-        index = builder_.CreateZExt(index, i64Ty_, "idx_ext");
-
     llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, objPtr, 0, "len_ptr");
     llvm::Value *length = builder_.CreateLoad(i64Ty_, lenPtr, "length");
 
-    llvm::Value *negCheck = builder_.CreateICmpSLT(index, llvm::ConstantInt::get(i64Ty_, 0), "neg_check");
-    llvm::Value *overCheck = builder_.CreateICmpSGE(index, length, "over_check");
-    llvm::Value *outOfBounds = builder_.CreateOr(negCheck, overCheck, "oob");
-
-    llvm::BasicBlock *oobBB = llvm::BasicBlock::Create(*ctx_, "index.oob", fn_);
-    llvm::BasicBlock *okBB2 = llvm::BasicBlock::Create(*ctx_, "index.ok", fn_);
-
-    builder_.CreateCondBr(outOfBounds, oobBB, okBB2);
-
-    builder_.SetInsertPoint(oobBB);
-    emitRuntimeError("runtime error: list index out of range\n", ".idx_err");
-
-    builder_.SetInsertPoint(okBB2);
+    emitBoundsCheck(index, length,
+                    "runtime error: list index out of range\n", ".idx_err", "index");
     llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, objPtr, 2, "data_ptr");
     llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "data");
     llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {index}, "elem_ptr");

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -170,25 +170,11 @@ void CodeGen::emitVarDecl(const std::string &name,
         for (uint64_t i = 0; i < arrSize; ++i) {
             llvm::Value *elemVal = emitExpr(*(*le)->elements[i]);
             if (elemVal->getType() != elemTy) {
-                if (elemVal->getType() == i64Ty_ && (elemTy == i8Ty_ || elemTy == i16Ty_ || elemTy == i32Ty_)) {
-                    // Range check for constant int literals
-                    if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(elemVal)) {
-                        int64_t v = ci->getSExtValue();
-                        bool isUnsigned = (elemTypeName[0] == 'u');
-                        if (elemTy == i8Ty_) {
-                            if (isUnsigned) { if (v < 0 || v > 255) codegenError(elemTypeName + " value out of range at index " + std::to_string(i) + ": " + std::to_string(v)); }
-                            else { if (v < INT8_MIN || v > INT8_MAX) codegenError(elemTypeName + " value out of range at index " + std::to_string(i) + ": " + std::to_string(v)); }
-                        } else if (elemTy == i16Ty_) {
-                            if (isUnsigned) { if (v < 0 || v > (int64_t)UINT16_MAX) codegenError(elemTypeName + " value out of range at index " + std::to_string(i) + ": " + std::to_string(v)); }
-                            else { if (v < INT16_MIN || v > INT16_MAX) codegenError(elemTypeName + " value out of range at index " + std::to_string(i) + ": " + std::to_string(v)); }
-                        } else if (elemTy == i32Ty_) {
-                            if (isUnsigned) { if (v < 0 || v > (int64_t)UINT32_MAX) codegenError(elemTypeName + " value out of range at index " + std::to_string(i) + ": " + std::to_string(v)); }
-                            else { if (v < INT32_MIN || v > INT32_MAX) codegenError(elemTypeName + " value out of range at index " + std::to_string(i) + ": " + std::to_string(v)); }
-                        }
-                    }
-                    elemVal = builder_.CreateTrunc(elemVal, elemTy, "arr_trunc");
-                } else if (elemVal->getType() == f64Ty_ && elemTy == f32Ty_) {
-                    elemVal = builder_.CreateFPTrunc(elemVal, f32Ty_, "arr_ftrunc");
+                llvm::Value *coerced = coerceToLowLevelType(
+                    elemVal, elemTy, elemTypeName,
+                    " at index " + std::to_string(i), "arr_trunc");
+                if (coerced) {
+                    elemVal = coerced;
                 } else {
                     codegenError("array element type mismatch at index " + std::to_string(i));
                 }
@@ -219,67 +205,10 @@ void CodeGen::emitVarDecl(const std::string &name,
         } else {
             llvm::Type *annotTy = resolveType(*annot);
             if (annotTy != newTy) {
-                if (annotTy == i8Ty_ && newTy == i64Ty_) {
-                    const std::string &ann = *annot;
-                    if (ann == "i8") {
-                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                            int64_t v = ci->getSExtValue();
-                            if (v < INT8_MIN || v > INT8_MAX)
-                                codegenError(
-                                    "i8 value out of range: " + std::to_string(v));
-                        }
-                    } else {
-                        // u8: unsigned 0-255 range
-                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                            int64_t v = ci->getSExtValue();
-                            if (v < 0 || v > 255)
-                                codegenError(
-                                    ann + " value out of range (0-255): " + std::to_string(v));
-                        }
-                    }
-                    val = builder_.CreateTrunc(val, i8Ty_, "i8trunc");
-                    newTy = i8Ty_;
-                } else if (annotTy == i32Ty_ && newTy == i64Ty_) {
-                    const std::string &ann = *annot;
-                    if (ann == "u32") {
-                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                            int64_t v = ci->getSExtValue();
-                            if (v < 0 || v > (int64_t)UINT32_MAX)
-                                codegenError(
-                                    "u32 value out of range: " + std::to_string(v));
-                        }
-                    } else {
-                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                            int64_t v = ci->getSExtValue();
-                            if (v < INT32_MIN || v > INT32_MAX)
-                                codegenError(
-                                    ann + " value out of range: " + std::to_string(v));
-                        }
-                    }
-                    val = builder_.CreateTrunc(val, i32Ty_, "i32trunc");
-                    newTy = i32Ty_;
-                } else if (annotTy == i16Ty_ && newTy == i64Ty_) {
-                    const std::string &ann = *annot;
-                    if (ann == "u16") {
-                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                            int64_t v = ci->getSExtValue();
-                            if (v < 0 || v > (int64_t)UINT16_MAX)
-                                codegenError(
-                                    "u16 value out of range: " + std::to_string(v));
-                        }
-                    } else {
-                        if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                            int64_t v = ci->getSExtValue();
-                            if (v < INT16_MIN || v > INT16_MAX)
-                                codegenError(
-                                    ann + " value out of range: " + std::to_string(v));
-                        }
-                    }
-                    val = builder_.CreateTrunc(val, i16Ty_, "i16trunc");
-                    newTy = i16Ty_;
-                } else if (annotTy == f32Ty_ && newTy == f64Ty_) {
-                    val = builder_.CreateFPTrunc(val, f32Ty_, "f32trunc");
-                    newTy = f32Ty_;
+                if (llvm::Value *coerced = coerceToLowLevelType(
+                        val, annotTy, *annot, "", *annot + "trunc")) {
+                    val = coerced;
+                    newTy = annotTy;
                 } else if (isOptionType(annotTy) && isOptionType(newTy) &&
                            std::holds_alternative<NoneExpr>(value.data)) {
                     // Allow none coercion to target Option type
@@ -578,25 +507,10 @@ void CodeGen::emitStmt(AssignStmt &s) {
     llvm::Type *newTy = val->getType();
 
     if (ptr->getAllocatedType() != newTy) {
-        // i8/u8 variable assigned from int expression
-        if (ptr->getAllocatedType() == i8Ty_ && newTy == i64Ty_) {
-            std::string tname = getLowLevelTypeName(ptr);
-            if (tname == "i8") {
-                if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                    int64_t v = ci->getSExtValue();
-                    if (v < INT8_MIN || v > INT8_MAX)
-                        codegenError(
-                            "i8 value out of range: " + std::to_string(v));
-                }
-            } else {
-                if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                    int64_t v = ci->getSExtValue();
-                    if (v < 0 || v > 255)
-                        codegenError(
-                            "u8 value out of range (0-255): " + std::to_string(v));
-                }
-            }
-            val = builder_.CreateTrunc(val, i8Ty_, "i8trunc");
+        if (llvm::Value *coerced = coerceToLowLevelType(
+                val, ptr->getAllocatedType(), getLowLevelTypeName(ptr),
+                "", "i8trunc")) {
+            val = coerced;
         } else if (isAnyType(ptr->getAllocatedType())) {
             val = wrapInAny(val);
             newTy = val->getType();
@@ -856,50 +770,16 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
             llvm::Type *elemTy = arrTy->getElementType();
             uint64_t arrSize = arrTy->getNumElements();
 
-            if (key->getType() == i1Ty_)
-                key = builder_.CreateZExt(key, i64Ty_, "idx_ext");
-
-            // Bounds check
-            if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(key)) {
-                int64_t idx = ci->getSExtValue();
-                if (idx < 0 || (uint64_t)idx >= arrSize)
-                    codegenError("array index " + std::to_string(idx) +
-                                 " out of bounds (size " + std::to_string(arrSize) + ")");
-            } else {
-                llvm::Value *negCheck = builder_.CreateICmpSLT(
-                    key, llvm::ConstantInt::get(i64Ty_, 0), "arr_neg");
-                llvm::Value *overCheck = builder_.CreateICmpSGE(
-                    key, llvm::ConstantInt::get(i64Ty_, arrSize), "arr_over");
-                llvm::Value *oob = builder_.CreateOr(negCheck, overCheck, "arr_oob");
-                llvm::BasicBlock *oobBB = llvm::BasicBlock::Create(*ctx_, "arr_assign.oob", fn_);
-                llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "arr_assign.ok", fn_);
-                builder_.CreateCondBr(oob, oobBB, okBB);
-                builder_.SetInsertPoint(oobBB);
-                emitRuntimeError("runtime error: array index out of range\n", ".arr_assign_err");
-                builder_.SetInsertPoint(okBB);
-            }
+            emitBoundsCheck(key, llvm::ConstantInt::get(i64Ty_, arrSize),
+                            "runtime error: array index out of range\n", ".arr_assign_err", "arr_assign");
 
             if (val->getType() != elemTy) {
-                if (val->getType() == i64Ty_ && (elemTy == i8Ty_ || elemTy == i16Ty_ || elemTy == i32Ty_)) {
-                    if (auto *ci = llvm::dyn_cast<llvm::ConstantInt>(val)) {
-                        int64_t v = ci->getSExtValue();
-                        auto nit = array_elem_type_names_.find(ai);
-                        std::string tn = (nit != array_elem_type_names_.end()) ? nit->second : "i32";
-                        bool isUnsigned = (tn[0] == 'u');
-                        if (elemTy == i8Ty_) {
-                            if (isUnsigned) { if (v < 0 || v > 255) codegenError(tn + " value out of range: " + std::to_string(v)); }
-                            else { if (v < INT8_MIN || v > INT8_MAX) codegenError(tn + " value out of range: " + std::to_string(v)); }
-                        } else if (elemTy == i16Ty_) {
-                            if (isUnsigned) { if (v < 0 || v > (int64_t)UINT16_MAX) codegenError(tn + " value out of range: " + std::to_string(v)); }
-                            else { if (v < INT16_MIN || v > INT16_MAX) codegenError(tn + " value out of range: " + std::to_string(v)); }
-                        } else if (elemTy == i32Ty_) {
-                            if (isUnsigned) { if (v < 0 || v > (int64_t)UINT32_MAX) codegenError(tn + " value out of range: " + std::to_string(v)); }
-                            else { if (v < INT32_MIN || v > INT32_MAX) codegenError(tn + " value out of range: " + std::to_string(v)); }
-                        }
-                    }
-                    val = builder_.CreateTrunc(val, elemTy, "arr_assign_trunc");
-                } else if (val->getType() == f64Ty_ && elemTy == f32Ty_) {
-                    val = builder_.CreateFPTrunc(val, f32Ty_, "arr_assign_ftrunc");
+                auto nit = array_elem_type_names_.find(ai);
+                std::string tn = (nit != array_elem_type_names_.end()) ? nit->second : "i32";
+                llvm::Value *coerced = coerceToLowLevelType(
+                    val, elemTy, tn, "", "arr_assign_trunc");
+                if (coerced) {
+                    val = coerced;
                 } else {
                     codegenError("array element type mismatch in index assignment");
                 }
@@ -1031,24 +911,11 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     if (!elemTy)
         codegenError("cannot determine list element type for index assignment");
 
-    if (key->getType() == i1Ty_)
-        key = builder_.CreateZExt(key, i64Ty_, "idx_ext");
-
-    // Bounds check
     llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, objPtr, 0, "len_ptr");
     llvm::Value *length = builder_.CreateLoad(i64Ty_, lenPtr, "length");
-    llvm::Value *negCheck = builder_.CreateICmpSLT(key, llvm::ConstantInt::get(i64Ty_, 0), "neg_check");
-    llvm::Value *overCheck = builder_.CreateICmpSGE(key, length, "over_check");
-    llvm::Value *outOfBounds = builder_.CreateOr(negCheck, overCheck, "oob");
 
-    llvm::BasicBlock *oobBB = llvm::BasicBlock::Create(*ctx_, "idx_assign.oob", fn_);
-    llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "idx_assign.ok", fn_);
-    builder_.CreateCondBr(outOfBounds, oobBB, okBB);
-
-    builder_.SetInsertPoint(oobBB);
-    emitRuntimeError("runtime error: list index out of range\n", ".idx_assign_err");
-
-    builder_.SetInsertPoint(okBB);
+    emitBoundsCheck(key, length,
+                    "runtime error: list index out of range\n", ".idx_assign_err", "idx_assign");
     llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, objPtr, 2, "data_ptr");
     llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "data");
     llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {key}, "elem_ptr");


### PR DESCRIPTION
## Summary

- Extract `emitBoundsCheck()` helper to unify 4 duplicated bounds-check patterns (array read/assign, list read/assign)
- Extract `coerceToLowLevelType()` helper to unify 4 duplicated type-coercion patterns (scalar var decl, array init, array assign, plain assign)
- Net reduction of ~100 lines with improved maintainability

Closes #342

## Test plan

- [x] All 1072 C++ tests pass
- [x] All 42 Ry self-test files pass
- [x] /simplify code review completed — no reuse, efficiency, or quality issues remaining