### PR TITLE
feat: record subtyping with `<` syntax for field inheritance and subtype coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Nested type parameter parsing (`>>`) (#263)
 - Record auto-generated `operator==` and `operator!=` (#305)
 - Record auto-generated `to_str` (#306)
+- Record subtyping with `<` syntax for field inheritance and subtype coercion (#307)
 - `@inline` directive for function inlining hints (#299)
 - Explicit value assignment for simple enum variants (#309)
 - Named fields in ADT enum variants (#308)

--- a/docs/reference/structs.md
+++ b/docs/reference/structs.md
@@ -127,6 +127,73 @@ print(p1 != p3)  # true
 
 ---
 
+## Record Subtyping (Inheritance)
+
+Records support single inheritance using the `<` syntax. A child record inherits all fields from its parent.
+
+### Syntax
+
+```python
+record ChildName < ParentName:
+    child_field: type
+```
+
+### Example
+
+```python
+record HttpError < Error:
+    status: int
+    url: str
+```
+
+### Field Inheritance
+
+- The child record inherits all parent fields at the beginning of its layout.
+- The constructor takes parent fields first, then child-specific fields.
+
+```python
+err = HttpError("not found", 404, 404, "/api")
+print(err.message)  # "not found" (inherited from Error)
+print(err.status)   # 404 (own field)
+```
+
+### Subtype Coercion
+
+A child value can be passed where the parent type is expected. The child is automatically sliced to extract the parent-prefix fields (value-type slicing).
+
+```python
+fn handle(e: Error) -> str:
+    return e.message
+
+err = HttpError("fail", 500, 500, "/api")
+handle(err)  # OK — HttpError coerced to Error
+```
+
+### Deep Inheritance
+
+Records can form inheritance chains. Each level inherits all ancestor fields.
+
+```python
+record DetailedHttpError < HttpError:
+    detail: str
+
+# Constructor: Error fields + HttpError fields + own fields
+derr = DetailedHttpError("fail", 500, 500, "/x", "server crash")
+handle(derr)  # OK — coerced to Error (grandparent)
+```
+
+### Rules
+
+| Rule | Details |
+|------|------|
+| Single inheritance only | `record A < B:` — one parent only |
+| Deep inheritance | `record C < B:` where `record B < A:` — allowed |
+| Name collision | Child field with same name as parent field → compile error |
+| Auto `==` / `to_str` | Includes all inherited fields |
+| `@const` | Applies to all fields including inherited |
+
+---
+
 ## Constraints and Errors
 
 | Constraint | Details |

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -49,6 +49,7 @@ struct TypeNode {
     static TypeNodePtr makeUnion(std::vector<TypeNodePtr> comps);
     static TypeNodePtr makeOptional(TypeNodePtr inner);
     static TypeNodePtr makeRange(std::string start, std::string end);
+    static TypeNodePtr clone(const TypeNodePtr &src);
 };
 
 // ===== Directive =====
@@ -217,7 +218,7 @@ struct IndexAssignStmt {
 
 struct FieldDef { std::string name; TypeNodePtr type; std::vector<Directive> directives; };
 
-struct RecordStmt { std::string name; std::vector<FieldDef> fields; std::vector<ExprPtr> invariants; std::vector<Directive> directives; SourceLocation loc; };
+struct RecordStmt { std::string name; std::optional<std::string> parent_name; std::vector<FieldDef> fields; std::vector<ExprPtr> invariants; std::vector<Directive> directives; SourceLocation loc; };
 
 struct TypeAliasStmt { std::string name; TypeNodePtr target_type; SourceLocation loc; };
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -67,6 +67,7 @@ private:
         llvm::StructType *llvmType;
         std::vector<FieldDef> fields;
         std::vector<ExprPtr> invariants;
+        std::string parent_name;
     };
     std::unordered_map<std::string, StructInfo> struct_types_;
     std::unordered_map<std::string, std::string> type_aliases_;
@@ -314,6 +315,11 @@ private:
     bool isWideningConversion(llvm::Value *argVal, llvm::Type *paramTy,
                               const std::string &paramTypeName) const;
     llvm::Value *emitWideningConversion(llvm::Value *argVal, llvm::Type *paramTy);
+    bool isSubtypeOf(const std::string &childType, const std::string &parentType) const;
+    llvm::Value *emitSubtypeSlice(llvm::Value *childVal,
+                                   const std::string &childTypeName,
+                                   const std::string &parentTypeName);
+    llvm::Value *tryEmitSubtypeCoerce(llvm::Value *val, llvm::Type *targetTy);
 
     llvm::Value *emitExpr(const ExprNode &node);
     llvm::Value *emitExprVariant(const NumberExpr &e);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -27,6 +27,12 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
     builtins_["exit"] = [this](const std::vector<ExprPtr> &args) { emitExit(args); };
 
     errorTy_ = llvm::StructType::create(*ctx_, {ptrTy_, i64Ty_}, "Error");
+    {
+        std::vector<FieldDef> errorFields;
+        errorFields.push_back({"message", TypeNode::makeBasic("str"), {}});
+        errorFields.push_back({"code", TypeNode::makeBasic("int"), {}});
+        struct_types_["Error"] = {errorTy_, std::move(errorFields), {}, ""};
+    }
 
     listHeaderTy_ = llvm::StructType::create(*ctx_, {i64Ty_, i64Ty_, ptrTy_}, "ListHeader");
     mapHeaderTy_ = llvm::StructType::create(*ctx_, {i64Ty_, i64Ty_, ptrTy_, ptrTy_, i64Ty_, ptrTy_}, "MapHeader");
@@ -341,6 +347,43 @@ std::pair<llvm::Value*, llvm::Value*> CodeGen::promoteToFloat(llvm::Value *lhs, 
 }
 
 
+// ===== B3.4: Record subtype helpers =====
+
+bool CodeGen::isSubtypeOf(const std::string &childType, const std::string &parentType) const {
+    std::string current = childType;
+    while (!current.empty()) {
+        auto it = struct_types_.find(current);
+        if (it == struct_types_.end()) return false;
+        if (it->second.parent_name == parentType) return true;
+        current = it->second.parent_name;
+    }
+    return false;
+}
+
+llvm::Value *CodeGen::emitSubtypeSlice(llvm::Value *childVal,
+                                         const std::string &childTypeName,
+                                         const std::string &parentTypeName) {
+    auto pit = struct_types_.find(parentTypeName);
+    if (pit == struct_types_.end())
+        codegenError("unknown parent type: " + parentTypeName);
+    llvm::Value *result = llvm::UndefValue::get(pit->second.llvmType);
+    for (unsigned i = 0; i < pit->second.fields.size(); ++i) {
+        llvm::Value *field = builder_.CreateExtractValue(childVal, i, "slice." + std::to_string(i));
+        result = builder_.CreateInsertValue(result, field, i);
+    }
+    return result;
+}
+
+llvm::Value *CodeGen::tryEmitSubtypeCoerce(llvm::Value *val, llvm::Type *targetTy) {
+    auto *argST = llvm::dyn_cast<llvm::StructType>(val->getType());
+    auto *paramST = llvm::dyn_cast<llvm::StructType>(targetTy);
+    if (!argST || !paramST) return nullptr;
+    std::string argName = argST->getName().str();
+    std::string paramName = paramST->getName().str();
+    if (!isSubtypeOf(argName, paramName)) return nullptr;
+    return emitSubtypeSlice(val, argName, paramName);
+}
+
 // ===== B3.5: Implicit widening conversion helpers =====
 
 bool CodeGen::isWideningConversion(llvm::Value *argVal, llvm::Type *paramTy,
@@ -409,6 +452,7 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
     struct RankedCandidate {
         OverloadEntry *entry;
         int exactMatches = 0;
+        int subtypeMatches = 0;
         int wideningMatches = 0;
         int unionMatches = 0;
         int anyMatches = 0;
@@ -418,6 +462,8 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
     auto isBetterCandidate = [](const RankedCandidate &lhs, const RankedCandidate &rhs) {
         if (lhs.exactMatches != rhs.exactMatches)
             return lhs.exactMatches > rhs.exactMatches;
+        if (lhs.subtypeMatches != rhs.subtypeMatches)
+            return lhs.subtypeMatches > rhs.subtypeMatches;
         if (lhs.wideningMatches != rhs.wideningMatches)
             return lhs.wideningMatches > rhs.wideningMatches;
         if (lhs.unionMatches != rhs.unionMatches)
@@ -435,7 +481,7 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
         if (args.size() < entry.minArity || args.size() > entry.paramTypes.size())
             continue;
         bool match = true;
-        RankedCandidate candidate{&entry, 0, 0, 0, 0,
+        RankedCandidate candidate{&entry, 0, 0, 0, 0, 0,
                                   static_cast<int>(entry.paramTypes.size() - args.size())};
         for (size_t i = 0; i < args.size(); ++i) {
             std::string resolvedParamTypeName =
@@ -448,6 +494,15 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
             if (emittedArgs[i]->getType() == entry.paramTypes[i]) {
                 candidate.exactMatches++;
                 continue;
+            }
+
+            if (auto *argST = llvm::dyn_cast<llvm::StructType>(emittedArgs[i]->getType())) {
+                if (auto *paramST = llvm::dyn_cast<llvm::StructType>(entry.paramTypes[i])) {
+                    if (isSubtypeOf(argST->getName().str(), paramST->getName().str())) {
+                        candidate.subtypeMatches++;
+                        continue;
+                    }
+                }
             }
 
             if (isWideningConversion(emittedArgs[i], entry.paramTypes[i], resolvedParamTypeName)) {
@@ -509,6 +564,8 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
         } else if (emittedArgs[i]->getType() != chosen->paramTypes[i] &&
                    isWideningConversion(emittedArgs[i], chosen->paramTypes[i], resolvedParamTypeName)) {
             outArgVals.push_back(emitWideningConversion(emittedArgs[i], chosen->paramTypes[i]));
+        } else if (auto *sliced = tryEmitSubtypeCoerce(emittedArgs[i], chosen->paramTypes[i])) {
+            outArgVals.push_back(sliced);
         } else if (emittedArgs[i]->getType() != chosen->paramTypes[i] &&
                    isAnyType(chosen->paramTypes[i])) {
             outArgVals.push_back(wrapInAny(emittedArgs[i]));
@@ -538,6 +595,8 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
         if (defVal->getType() != chosen->paramTypes[i] &&
             isWideningConversion(defVal, chosen->paramTypes[i], resolvedParamTypeName)) {
             outArgVals.push_back(emitWideningConversion(defVal, chosen->paramTypes[i]));
+        } else if (auto *sliced = tryEmitSubtypeCoerce(defVal, chosen->paramTypes[i])) {
+            outArgVals.push_back(sliced);
         } else if (defVal->getType() != chosen->paramTypes[i] &&
                    isAnyType(chosen->paramTypes[i])) {
             outArgVals.push_back(wrapInAny(defVal));

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -203,6 +203,11 @@ std::vector<llvm::Value*> CodeGen::coerceCallArgs(const FnTypeInfo &info,
         if (args[i]->getType() == info.paramTypes[i])
             continue;
 
+        if (auto *sliced = tryEmitSubtypeCoerce(args[i], info.paramTypes[i])) {
+            args[i] = sliced;
+            continue;
+        }
+
         if (isAnyType(info.paramTypes[i])) {
             args[i] = wrapInAny(args[i]);
             continue;

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -5,19 +5,48 @@ void CodeGen::emitStmt(RecordStmt &s) {
     if (struct_types_.count(s.name))
         codegenError("redefined type: " + s.name);
 
-    std::vector<llvm::Type*> fieldTypes;
+    std::string parentName;
+    std::vector<FieldDef> allFields;
+
+    if (s.parent_name) {
+        parentName = *s.parent_name;
+        auto pit = struct_types_.find(parentName);
+        if (pit == struct_types_.end())
+            codegenError("parent record '" + parentName + "' not defined");
+
+        const auto &parentInfo = pit->second;
+
+        // Parent fields are pre-flattened (include all ancestors), so no recursion needed
+        for (auto &pf : parentInfo.fields)
+            allFields.push_back({pf.name, TypeNode::clone(pf.type), {}});
+
+        std::unordered_set<std::string> parentFieldNames;
+        for (auto &pf : parentInfo.fields)
+            parentFieldNames.insert(pf.name);
+        for (auto &cf : s.fields) {
+            if (parentFieldNames.count(cf.name))
+                codegenError("field '" + cf.name + "' in '" + s.name +
+                             "' conflicts with inherited field from '" + parentName + "'");
+        }
+    }
+
     for (auto &f : s.fields)
+        allFields.push_back({f.name, TypeNode::clone(f.type), std::move(f.directives)});
+
+    std::vector<llvm::Type*> fieldTypes;
+    for (auto &f : allFields)
         fieldTypes.push_back(resolveType(f.type->toString()));
 
     llvm::StructType *structTy = llvm::StructType::create(*ctx_, fieldTypes, s.name);
     if (hasDirective(s.directives, "deprecated"))
         deprecated_types_.insert(s.name);
-    for (auto &f : s.fields) {
+    for (auto &f : allFields) {
         if (hasDirective(f.directives, "deprecated"))
             deprecated_fields_.insert(s.name + "." + f.name);
     }
 
-    struct_types_[s.name] = {structTy, std::move(s.fields), std::move(s.invariants)};
+    struct_types_[s.name] = {structTy, std::move(allFields), std::move(s.invariants),
+                             parentName};
 }
 
 llvm::Value *CodeGen::emitStructConstructor(const StructInfo &info,

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -133,7 +133,10 @@ void Formatter::formatRecord(const RecordStmt &s) {
     formatDirectives(s.directives);
     if (!s.directives.empty()) emitIndent();
 
-    emit("record " + s.name + ":");
+    emit("record " + s.name);
+    if (s.parent_name)
+        emit(" < " + *s.parent_name);
+    emit(":");
     emitInlineComment(s.loc.line);
     emitNewline();
     last_emitted_line_ = s.loc.line;

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -300,6 +300,22 @@ StmtNode Parser::parseRecordStatement() {
         parseError(nameTok.line, "record name '" + nameTok.value + "' must be PascalCase");
     lex_.next(); // consume name
 
+    RecordStmt ts;
+    ts.name = nameTok.value;
+    ts.loc = locFromToken(recordTok);
+
+    // Optional parent type: record Child < Parent:
+    if (lex_.peek().kind == TokenKind::Less) {
+        lex_.next(); // consume '<'
+        Token parentTok = lex_.peek();
+        if (parentTok.kind != TokenKind::Ident && parentTok.kind != TokenKind::ErrorKw)
+            parseError(parentTok.line, "expected parent record name after '<'");
+        if (parentTok.kind == TokenKind::Ident && !isPascalCase(parentTok.value))
+            parseError(parentTok.line, "parent record name '" + parentTok.value + "' must be PascalCase");
+        lex_.next(); // consume parent name
+        ts.parent_name = parentTok.value;
+    }
+
     if (lex_.peek().kind != TokenKind::Colon)
         parseError("expected ':' after record name");
     lex_.next(); // consume ':'
@@ -313,9 +329,6 @@ StmtNode Parser::parseRecordStatement() {
         parseError("expected indented block");
     lex_.next(); // consume Indent
 
-    RecordStmt ts;
-    ts.name = nameTok.value;
-    ts.loc = locFromToken(recordTok);
     std::unordered_set<std::string> seenFields;
 
     while (lex_.peek().kind != TokenKind::Dedent &&

--- a/src/type_node.cpp
+++ b/src/type_node.cpp
@@ -95,3 +95,35 @@ TypeNodePtr TypeNode::makeRange(std::string start, std::string end) {
     node->data = RangeType{std::move(start), std::move(end)};
     return node;
 }
+
+TypeNodePtr TypeNode::clone(const TypeNodePtr &src) {
+    if (!src) return nullptr;
+    return std::visit([](const auto &v) -> TypeNodePtr {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, BasicType>) {
+            return makeBasic(v.name);
+        } else if constexpr (std::is_same_v<T, GenericType>) {
+            std::vector<TypeNodePtr> args;
+            for (auto &a : v.type_args) args.push_back(clone(a));
+            return makeGeneric(v.name, std::move(args));
+        } else if constexpr (std::is_same_v<T, ArrayType>) {
+            return makeArray(clone(v.element_type), v.size);
+        } else if constexpr (std::is_same_v<T, TupleType>) {
+            std::vector<TypeNodePtr> elems;
+            for (auto &e : v.elements) elems.push_back(clone(e));
+            return makeTuple(std::move(elems));
+        } else if constexpr (std::is_same_v<T, FnType>) {
+            std::vector<TypeNodePtr> params;
+            for (auto &p : v.param_types) params.push_back(clone(p));
+            return makeFn(std::move(params), clone(v.return_type));
+        } else if constexpr (std::is_same_v<T, UnionType>) {
+            std::vector<TypeNodePtr> comps;
+            for (auto &c : v.components) comps.push_back(clone(c));
+            return makeUnion(std::move(comps));
+        } else if constexpr (std::is_same_v<T, OptionalType>) {
+            return makeOptional(clone(v.inner));
+        } else if constexpr (std::is_same_v<T, RangeType>) {
+            return makeRange(v.start, v.end);
+        }
+    }, src->data);
+}

--- a/tests/spec/record_subtyping.test.ry
+++ b/tests/spec/record_subtyping.test.ry
@@ -1,0 +1,69 @@
+record HttpError < Error:
+  status: int
+  url: str
+
+fn handle_error(e: Error) -> str:
+  return e.message
+
+describe("record subtyping", fn():
+  it("constructor with inherited fields", fn():
+    err = HttpError("not found", 404, 404, "/api")
+    expect(err.message).to_eq("not found")
+    expect(err.code).to_eq(404)
+    expect(err.status).to_eq(404)
+    expect(err.url).to_eq("/api")
+  )
+  it("subtype coercion in function call", fn():
+    err = HttpError("fail", 500, 500, "/x")
+    expect(handle_error(err)).to_eq("fail")
+  )
+  it("auto == includes inherited fields", fn():
+    expect(HttpError("a", 1, 200, "/x") == HttpError("a", 1, 200, "/x")).to_be_true()
+    expect(HttpError("a", 1, 200, "/x") == HttpError("b", 1, 200, "/x")).to_be_false()
+  )
+  it("auto to_str includes inherited fields", fn():
+    err = HttpError("err", 1, 404, "/api")
+    expect(to_str(err)).to_eq("HttpError(message: err, code: 1, status: 404, url: /api)")
+  )
+)
+
+record DetailedHttpError < HttpError:
+  detail: str
+
+describe("deep inheritance", fn():
+  it("constructor with all ancestor fields", fn():
+    derr = DetailedHttpError("fail", 500, 500, "/x", "server crash")
+    expect(derr.message).to_eq("fail")
+    expect(derr.code).to_eq(500)
+    expect(derr.status).to_eq(500)
+    expect(derr.url).to_eq("/x")
+    expect(derr.detail).to_eq("server crash")
+  )
+  it("deep coercion to grandparent", fn():
+    derr = DetailedHttpError("fail", 500, 500, "/x", "crash")
+    expect(handle_error(derr)).to_eq("fail")
+  )
+)
+
+record Animal:
+  name: str
+  legs: int
+
+record Dog < Animal:
+  breed: str
+
+fn describe_animal(a: Animal) -> str:
+  return f"{a.name} has {a.legs} legs"
+
+describe("non-Error subtyping", fn():
+  it("basic field inheritance", fn():
+    d = Dog("Rex", 4, "Labrador")
+    expect(d.name).to_eq("Rex")
+    expect(d.legs).to_eq(4)
+    expect(d.breed).to_eq("Labrador")
+  )
+  it("coercion to parent type", fn():
+    d = Dog("Rex", 4, "Labrador")
+    expect(describe_animal(d)).to_eq("Rex has 4 legs")
+  )
+)

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -258,6 +258,29 @@ TEST(ParserTest, TypeDefinition) {
     EXPECT_EQ(ts.fields[1].type->toString(), "int");
 }
 
+TEST(ParserTest, RecordSubtyping) {
+    Program prog = parseStr("record HttpError < Error:\n    status: int\n    url: str");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<RecordStmt>(prog[0]));
+    const auto &ts = std::get<RecordStmt>(prog[0]);
+    EXPECT_EQ(ts.name, "HttpError");
+    ASSERT_TRUE(ts.parent_name.has_value());
+    EXPECT_EQ(*ts.parent_name, "Error");
+    ASSERT_EQ(ts.fields.size(), 2u);
+    EXPECT_EQ(ts.fields[0].name, "status");
+    EXPECT_EQ(ts.fields[0].type->toString(), "int");
+    EXPECT_EQ(ts.fields[1].name, "url");
+    EXPECT_EQ(ts.fields[1].type->toString(), "str");
+}
+
+TEST(ParserTest, RecordWithoutParent) {
+    Program prog = parseStr("record Point:\n    x: int\n    y: int");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &ts = std::get<RecordStmt>(prog[0]);
+    EXPECT_EQ(ts.name, "Point");
+    EXPECT_FALSE(ts.parent_name.has_value());
+}
+
 TEST(ParserTest, FieldAccessSimple) {
     Program prog = parseStr("x = p.x");
     ASSERT_EQ(prog.size(), 1u);


### PR DESCRIPTION
## Summary

Closes #307

- Introduce `record Child < Parent:` syntax for single-inheritance record subtyping
- Child records inherit all parent fields (prepended to layout) and support implicit coercion to parent type via value-type slicing
- Register built-in `Error` type in `struct_types_` to enable custom Error subtypes (`HttpError < Error`)
- Support deep inheritance chains (`C < B < A`)
- Integrate subtype coercion into overload resolution (`resolveOverload`) and lambda call args (`coerceCallArgs`)
- Auto `==` and `to_str` naturally cover inherited fields

## Test plan

- [x] C++ parser tests: `RecordSubtyping`, `RecordWithoutParent`
- [x] Ry self-tests: `tests/spec/record_subtyping.test.ry` (8 tests covering constructor, field access, coercion, deep inheritance, auto ==, auto to_str)
- [x] All 1074 C++ tests pass
- [x] All 43 Ry test files pass (0 failures)

## Related issues

- #354: Result + subtype Error auto-slicing (out of scope, created as follow-up)
- #355: Parent invariant inheritance (out of scope, created as follow-up)