### PR TITLE
feat: add Linux x86_64 and ARM64 release builds to CI (#154, #155)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,35 +6,120 @@ on:
     branches: [main]
 
 jobs:
-  release:
-    runs-on: macos-14
+  build:
     if: github.event.workflow_run.conclusion == 'success'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-14
+            target: darwin-arm64
+            llvm_install: brew
+          - os: ubuntu-22.04
+            target: linux-amd64
+            llvm_install: apt
+          - os: ubuntu-22.04-arm
+            target: linux-arm64
+            llvm_install: apt
+    runs-on: ${{ matrix.os }}
     permissions:
-      contents: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
-      - name: Cache LLVM 21
-        id: cache-llvm
+
+      # --- LLVM 21: macOS (Homebrew) ---
+      - name: Cache LLVM 21 (brew)
+        if: matrix.llvm_install == 'brew'
+        id: cache-llvm-brew
         uses: actions/cache@v4
         with:
           path: |
             /opt/homebrew/opt/llvm@21
             /opt/homebrew/Cellar/llvm@21
-          key: llvm-21-macos-arm64
-      - name: Install LLVM 21
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
+          key: llvm-21-${{ matrix.target }}
+      - name: Install LLVM 21 (brew)
+        if: matrix.llvm_install == 'brew' && steps.cache-llvm-brew.outputs.cache-hit != 'true'
         run: brew install llvm@21
-      - name: Install dependencies
+      - name: Install dependencies (brew)
+        if: matrix.llvm_install == 'brew'
         run: brew install openssl@3 ninja googletest
+
+      # --- LLVM 21: Linux (APT) ---
+      - name: Cache LLVM 21 (apt)
+        if: matrix.llvm_install == 'apt'
+        id: cache-llvm-apt
+        uses: actions/cache@v4
+        with:
+          path: /usr/lib/llvm-21
+          key: llvm-21-${{ matrix.target }}
+      - name: Install LLVM 21 (apt)
+        if: matrix.llvm_install == 'apt' && steps.cache-llvm-apt.outputs.cache-hit != 'true'
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 21
+          sudo apt-get install -y libllvm21 llvm-21-dev
+      - name: Install dependencies (apt)
+        if: matrix.llvm_install == 'apt'
+        run: sudo apt-get install -y libssl-dev ninja-build libgtest-dev libgmock-dev
+
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1
         with:
-          key: release-macos
+          key: release-${{ matrix.target }}
           restore-keys: |
-            release-macos-
+            release-${{ matrix.target }}-
+
       - name: Read version
         id: version
         run: echo "version=v$(cat VERSION | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Build (macOS)
+        if: matrix.llvm_install == 'brew'
+        run: |
+          cmake -B build -G Ninja \
+            -DLLVM_DIR="$(brew --prefix llvm@21)/lib/cmake/llvm" \
+            -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build
+
+      - name: Build (Linux)
+        if: matrix.llvm_install == 'apt'
+        run: |
+          cmake -B build -G Ninja \
+            -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build build
+
+      - name: Test
+        run: ./build/ry_tests
+
+      - name: Package
+        run: |
+          mkdir -p dist/lib
+          cp build/ry dist/ry
+          cp -r lib/std dist/lib/std
+          cd dist
+          tar czf ry-${{ steps.version.outputs.version }}-${{ matrix.target }}.tar.gz ry lib/
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ry-${{ matrix.target }}
+          path: dist/ry-*.tar.gz
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read version
+        id: version
+        run: echo "version=v$(cat VERSION | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
       - name: Check if release exists
         env:
           GH_TOKEN: ${{ github.token }}
@@ -43,28 +128,20 @@ jobs:
             echo "Release ${{ steps.version.outputs.version }} already exists. Skipping."
             echo "SKIP=true" >> "$GITHUB_ENV"
           fi
-      - name: Build
+
+      - name: Download all artifacts
+        if: env.SKIP != 'true'
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Generate checksums
         if: env.SKIP != 'true'
         run: |
-          cmake -B build -G Ninja \
-            -DLLVM_DIR="$(brew --prefix llvm@21)/lib/cmake/llvm" \
-            -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
-            -DCMAKE_BUILD_TYPE=Release
-          cmake --build build
-      - name: Test
-        if: env.SKIP != 'true'
-        run: ./build/ry_tests
-      - name: Package
-        if: env.SKIP != 'true'
-        run: |
-          mkdir -p dist/lib/std
-          cp build/ry dist/ry
-          cp lib/std/*.ry dist/lib/std/
-          VERSION=$(cat VERSION | tr -d '[:space:]')
-          echo "{\"version\":\"$VERSION\",\"files\":[$(cd lib/std && ls *.ry | sed 's/.*/"&"/' | paste -sd, -)]}" > dist/lib/std/manifest.json
-          cd dist
-          tar czf ry-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz ry lib/
+          cd artifacts
           shasum -a 256 ry-*.tar.gz > checksums.txt
+
       - name: Extract changelog
         if: env.SKIP != 'true'
         run: |
@@ -74,6 +151,7 @@ jobs:
           if [ ! -s release_notes.txt ]; then
             echo "No changelog entries for $VERSION." > release_notes.txt
           fi
+
       - name: Create Release
         if: env.SKIP != 'true'
         env:
@@ -83,4 +161,4 @@ jobs:
             --title "${{ steps.version.outputs.version }}" \
             --notes-file release_notes.txt \
             --latest \
-            dist/ry-*.tar.gz dist/checksums.txt
+            artifacts/ry-*.tar.gz artifacts/checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `fail()` helper in test framework (#177)
 - HTTP automatic redirect following for client requests (#148)
 - Self-update artifact checksum verification (#116)
+- Linux x86_64 (amd64) release build in CI (#154)
+- Linux ARM64 (aarch64) release build in CI (#155)
 
 ### Changed
 

--- a/install.sh
+++ b/install.sh
@@ -27,11 +27,12 @@ curl -fsSL "$DOWNLOAD_URL" -o "$TMPDIR/ry.tar.gz"
 tar xzf "$TMPDIR/ry.tar.gz" -C "$TMPDIR"
 install -m 755 "$TMPDIR/ry" "$INSTALL_DIR/ry"
 
-# Install standard library
+# Install standard library (clean replace)
 STD_DIR="$RY_HOME/lib/std"
-mkdir -p "$STD_DIR"
 if [ -d "$TMPDIR/lib/std" ]; then
-    cp "$TMPDIR/lib/std/"* "$STD_DIR/"
+    rm -rf "$STD_DIR"
+    mkdir -p "$STD_DIR"
+    cp -r "$TMPDIR/lib/std/." "$STD_DIR/"
     echo "Standard library installed to $STD_DIR"
 fi
 


### PR DESCRIPTION
## Summary

- Add matrix strategy to `release.yml` for multi-platform builds: darwin-arm64, linux-amd64 (`ubuntu-22.04`), linux-arm64 (`ubuntu-22.04-arm`)
- Split workflow into `build` (per-platform) + `release` (collect artifacts, create GitHub Release) jobs
- Fix stdlib packaging bug: use `cp -r` to include subdirectories (`base64/`, `http/`, `io/`, `json/`, `math/`, `net/`) and use repo `manifest.json` instead of dynamically generating an incomplete one
- Fix `install.sh` to clean-replace stdlib on update (`rm -rf` + `cp -r`) to prevent stale files from previous versions

Closes #154
Closes #155

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Verify matrix variables are correctly referenced across all steps
- [ ] Verify artifact upload/download flow between build and release jobs
- [ ] Verify checksums.txt includes all platform archives
- [ ] Verify `install.sh` correctly handles subdirectories and clean replacement