### PR TITLE
feat: operator overloading for subscript [] and membership in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - `@inline` directive for function inlining hints (#299)
 - Explicit value assignment for simple enum variants (#309)
 - Named fields in ADT enum variants (#308)
+- Subscript operator overloading `operator[]` / `operator[]=` with multi-index support (#202)
+- Membership operator overloading `operator in` for user-defined types (#202)
 - Compound assignment operator overloading with in-place optimization (#204)
 - Enforce bool return type for comparison and logical operator overloads (#203)
 - N-element tuple destructuring in for loops (#302)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -437,16 +437,19 @@ fn operator<op>(a: type) -> return_type:
 | Comparison (binary) | `==` `!=` `<` `<=` `>` `>=` |
 | Bitwise (binary) | `&` `\|` `^` `<<` `>>` |
 | Logical (binary) | `and` `or` |
+| Membership | `in` |
+| Subscript | `[]` (read), `[]=` (write) |
 | Unary | `-` `~` `not` |
 
 ### Return Type Constraints
 
-Comparison and logical operators must return `bool`:
+Comparison, logical, and membership operators must return `bool`:
 
 | Category | Operators | Required Return Type |
 |---|---|---|
 | Comparison | `==` `!=` `<` `<=` `>` `>=` | `bool` |
 | Logical | `and` `or` `not` | `bool` |
+| Membership | `in` | `bool` |
 
 ```python
 # OK

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -296,6 +296,8 @@ fn operator-(a: MyType) -> MyType:
 | Comparison (binary) | `==` `!=` `<` `<=` `>` `>=` |
 | Bitwise (binary) | `&` `\|` `^` `<<` `>>` `>>>` |
 | Logical (binary) | `and` `or` |
+| Membership | `in` |
+| Subscript | `[]` (read), `[]=` (write) |
 | Unary | `-` `~` `not` |
 | Compound assignment | `+=` `-=` `*=` `/=` `%=` `//=` `**=` `&=` `\|=` `^=` `<<=` `>>=` |
 
@@ -307,6 +309,7 @@ Comparison and logical operators must return `bool`:
 |---|---|---|
 | Comparison | `==` `!=` `<` `<=` `>` `>=` | `bool` |
 | Logical | `and` `or` `not` | `bool` |
+| Membership | `in` | `bool` |
 
 ```python
 # OK
@@ -372,3 +375,54 @@ v += Vec2(3.0, 4.0)  # calls operator+= directly
 ```
 
 Compound assignment operators require exactly 2 parameters and have no return type constraint.
+
+### Subscript Operator Overloading
+
+The `[]` (read) and `[]=` (write) operators enable custom subscript behavior for user-defined types. Multi-index access (e.g., `m[row, col]`) is supported.
+
+```python
+record Grid:
+    a: int
+    b: int
+    c: int
+    d: int
+
+# Read: requires 2+ parameters (object + indices)
+fn operator[](g: Grid, row: int, col: int) -> int:
+    if row == 0 and col == 0:
+        return g.a
+    if row == 0 and col == 1:
+        return g.b
+    if row == 1 and col == 0:
+        return g.c
+    return g.d
+
+# Write: requires 3+ parameters (object + indices + value)
+fn operator[]=(g: Grid, row: int, col: int, value: int):
+    ...
+
+g = Grid(1, 2, 3, 4)
+print(g[0, 1])    # 2
+g[1, 0] = 99
+```
+
+User-defined subscript operators are tried first; if no match is found, built-in subscript behavior (for lists, maps, and arrays) is used as a fallback.
+
+### Membership Operator Overloading
+
+The `in` operator can be overloaded to define custom membership tests. Must return `bool`.
+
+```python
+record Range:
+    lo: int
+    hi: int
+
+fn operator in(value: int, r: Range) -> bool:
+    return value >= r.lo and value < r.hi
+
+r = Range(1, 10)
+print(5 in r)       # true
+print(15 not in r)  # true
+```
+
+User-defined `in` operators are tried first; if no match is found, built-in behavior (for sets, maps, and lists) is used as a fallback. `not in` is automatically supported when `in` is defined.

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -82,7 +82,8 @@ inline bool isBoolConstrainedOperator(const std::string &name) {
     return name == "operator==" || name == "operator!=" ||
            name == "operator<"  || name == "operator<=" ||
            name == "operator>"  || name == "operator>=" ||
-           name == "operatornot" || name == "operatorand" || name == "operatoror";
+           name == "operatornot" || name == "operatorand" || name == "operatoror" ||
+           name == "operatorin";
 }
 
 // Strips the "operator" prefix from an operator function name.
@@ -99,6 +100,10 @@ inline bool isCompoundAssignOperator(const std::string &name) {
            name == "operator&=" || name == "operator|=" ||
            name == "operator^=" ||
            name == "operator<<=" || name == "operator>>=";
+}
+
+inline bool isSubscriptOperator(const std::string &name) {
+    return name == "operator[]" || name == "operator[]=";
 }
 
 struct NumberExpr   { int64_t value; std::string suffix; };
@@ -184,7 +189,7 @@ struct ListExpr {
 
 struct IndexExpr {
     ExprPtr object;
-    ExprPtr index;
+    std::vector<ExprPtr> indices;
 };
 
 struct MapExpr {
@@ -210,7 +215,7 @@ struct ImportStmt {
 
 struct IndexAssignStmt {
     ExprPtr object;
-    ExprPtr index;
+    std::vector<ExprPtr> indices;
     ExprPtr value;
     SourceLocation loc;
 };

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -343,10 +343,18 @@ private:
     llvm::Value *structToString(llvm::Value *val);
 
     // Operator overload helpers
+    llvm::Value *findAndCallOverload(const std::string &opFnName,
+                                      llvm::ArrayRef<llvm::Value*> args,
+                                      const char *callName = "opcall");
     llvm::Value *tryOperatorCall(const std::string &opFnName,
                                  llvm::Value *lhs, llvm::Value *rhs);
     llvm::Value *tryUnaryOperatorCall(const std::string &opFnName,
                                       llvm::Value *operand);
+    llvm::Value *trySubscriptOperatorCall(llvm::Value *object,
+                                           llvm::ArrayRef<llvm::Value*> indices);
+    bool trySubscriptAssignOperatorCall(llvm::Value *object,
+                                         llvm::ArrayRef<llvm::Value*> indices,
+                                         llvm::Value *value);
 
     // Binary operation dispatch (user-defined → any → built-in)
     llvm::Value *emitBinaryOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -148,44 +148,53 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<UnaryExpr> &e) {
 
 // ===== Operator overload helpers =====
 
-llvm::Value *CodeGen::tryOperatorCall(const std::string &opFnName,
-                                       llvm::Value *lhs, llvm::Value *rhs) {
+llvm::Value *CodeGen::findAndCallOverload(const std::string &opFnName,
+                                           llvm::ArrayRef<llvm::Value*> args,
+                                           const char *callName) {
     auto fit = functions_.find(opFnName);
-    if (fit == functions_.end())
-        return nullptr;
-
-    llvm::Type *lhsTy = lhs->getType();
-    llvm::Type *rhsTy = rhs->getType();
+    if (fit == functions_.end()) return nullptr;
 
     for (auto &entry : fit->second) {
-        if (entry.paramTypes.size() == 2 &&
-            entry.paramTypes[0] == lhsTy &&
-            entry.paramTypes[1] == rhsTy) {
-            if (entry.func->getReturnType()->isVoidTy())
-                return builder_.CreateCall(entry.func, {lhs, rhs});
-            return builder_.CreateCall(entry.func, {lhs, rhs}, "opcall");
+        if (entry.paramTypes.size() != args.size()) continue;
+        bool match = true;
+        for (size_t i = 0; i < args.size(); ++i) {
+            if (entry.paramTypes[i] != args[i]->getType()) {
+                match = false; break;
+            }
         }
+        if (!match) continue;
+        if (entry.func->getReturnType()->isVoidTy())
+            return builder_.CreateCall(entry.func, args);
+        return builder_.CreateCall(entry.func, args, callName);
     }
     return nullptr;
 }
 
+llvm::Value *CodeGen::tryOperatorCall(const std::string &opFnName,
+                                       llvm::Value *lhs, llvm::Value *rhs) {
+    return findAndCallOverload(opFnName, {lhs, rhs}, "opcall");
+}
+
 llvm::Value *CodeGen::tryUnaryOperatorCall(const std::string &opFnName,
                                             llvm::Value *operand) {
-    auto fit = functions_.find(opFnName);
-    if (fit == functions_.end())
-        return nullptr;
+    return findAndCallOverload(opFnName, {operand}, "opcall");
+}
 
-    llvm::Type *opTy = operand->getType();
+llvm::Value *CodeGen::trySubscriptOperatorCall(
+    llvm::Value *object, llvm::ArrayRef<llvm::Value*> indices) {
+    llvm::SmallVector<llvm::Value*, 4> args;
+    args.push_back(object);
+    args.append(indices.begin(), indices.end());
+    return findAndCallOverload("operator[]", args, "subscript");
+}
 
-    for (auto &entry : fit->second) {
-        if (entry.paramTypes.size() == 1 &&
-            entry.paramTypes[0] == opTy) {
-            if (entry.func->getReturnType()->isVoidTy())
-                return builder_.CreateCall(entry.func, {operand});
-            return builder_.CreateCall(entry.func, {operand}, "opcall");
-        }
-    }
-    return nullptr;
+bool CodeGen::trySubscriptAssignOperatorCall(
+    llvm::Value *object, llvm::ArrayRef<llvm::Value*> indices, llvm::Value *value) {
+    llvm::SmallVector<llvm::Value*, 4> args;
+    args.push_back(object);
+    args.append(indices.begin(), indices.end());
+    args.push_back(value);
+    return findAndCallOverload("operator[]=", args, "subscr_assign") != nullptr;
 }
 
 // ===== B2: BinaryExpr sub-dispatchers =====
@@ -525,6 +534,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
     if (e->op == "in" || e->op == "not in") {
         llvm::Value *elem = emitExpr(*e->lhs);
         llvm::Value *container = emitExpr(*e->rhs);
+
+        if (auto *result = tryOperatorCall("operatorin", elem, container)) {
+            if (e->op == "not in")
+                result = builder_.CreateNot(result, "user_not_in");
+            return result;
+        }
 
         // Try set
         llvm::Type *setElemTy = getSetElementType(container);

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -414,7 +414,17 @@ llvm::Value *CodeGen::emitExprVariant(const EnumAccessExpr &e) {
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     llvm::Value *objPtr = emitExpr(*e->object);
-    llvm::Value *index = emitExpr(*e->index);
+
+    llvm::SmallVector<llvm::Value*, 2> indexValues;
+    for (auto &idx : e->indices)
+        indexValues.push_back(emitExpr(*idx));
+
+    if (llvm::Value *result = trySubscriptOperatorCall(objPtr, indexValues))
+        return result;
+    if (indexValues.size() > 1)
+        codegenError("multi-index requires operator[] overload");
+
+    llvm::Value *index = indexValues[0];
 
     // Fixed-length array index access
     if (auto *ai = llvm::dyn_cast<llvm::AllocaInst>(objPtr)) {

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -51,7 +51,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
             } else if constexpr (std::is_same_v<T, std::unique_ptr<ListExpr>>) {
                 for (auto &el : v->elements) scanExpr(*el);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<IndexExpr>>) {
-                scanExpr(*v->object); scanExpr(*v->index);
+                scanExpr(*v->object); for (auto &idx : v->indices) scanExpr(*idx);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<MapExpr>>) {
                 for (auto &k : v->keys) scanExpr(*k);
                 for (auto &val : v->values) scanExpr(*val);
@@ -72,7 +72,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
             } else if constexpr (std::is_same_v<T, ReturnStmt>) {
                 if (s.value) scanExpr(*s.value);
             } else if constexpr (std::is_same_v<T, IndexAssignStmt>) {
-                scanExpr(*s.object); scanExpr(*s.index); scanExpr(*s.value);
+                scanExpr(*s.object); for (auto &idx : s.indices) scanExpr(*idx); scanExpr(*s.value);
             } else if constexpr (std::is_same_v<T, FieldAssignStmt>) {
                 scanExpr(*s.object); scanExpr(*s.value);
             } else if constexpr (std::is_same_v<T, TupleDestructStmt>) {

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -761,8 +761,18 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
     llvm::Value *objPtr = emitExpr(*s.object);
-    llvm::Value *key = emitExpr(*s.index);
+
+    llvm::SmallVector<llvm::Value*, 2> indexValues;
+    for (auto &idx : s.indices)
+        indexValues.push_back(emitExpr(*idx));
     llvm::Value *val = emitExpr(*s.value);
+
+    if (trySubscriptAssignOperatorCall(objPtr, indexValues, val))
+        return;
+    if (indexValues.size() > 1)
+        codegenError("multi-index requires operator[]= overload");
+
+    llvm::Value *key = indexValues[0];
 
     // Fixed-length array index assignment
     if (auto *ai = llvm::dyn_cast<llvm::AllocaInst>(objPtr)) {

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -273,7 +273,12 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
             }
             return "[" + elems + "]";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IndexExpr>>) {
-            return formatExpr(*v->object) + "[" + formatExpr(*v->index) + "]";
+            std::string idxStr;
+            for (size_t i = 0; i < v->indices.size(); ++i) {
+                if (i > 0) idxStr += ", ";
+                idxStr += formatExpr(*v->indices[i]);
+            }
+            return formatExpr(*v->object) + "[" + idxStr + "]";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<MapExpr>>) {
             std::string pairs;
             for (size_t i = 0; i < v->keys.size(); ++i) {

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -330,7 +330,12 @@ void Formatter::formatMatch(const MatchStmt &s) {
 }
 
 void Formatter::formatIndexAssign(const IndexAssignStmt &s) {
-    emit(formatExpr(*s.object) + "[" + formatExpr(*s.index) + "] = " + formatExpr(*s.value));
+    std::string idxStr;
+    for (size_t i = 0; i < s.indices.size(); ++i) {
+        if (i > 0) idxStr += ", ";
+        idxStr += formatExpr(*s.indices[i]);
+    }
+    emit(formatExpr(*s.object) + "[" + idxStr + "] = " + formatExpr(*s.value));
     emitInlineComment(s.loc.line);
     emitNewline();
     last_emitted_line_ = s.loc.line;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -369,9 +369,14 @@ StmtNode Parser::parseStatement() {
     } else if (next.kind == TokenKind::LBracket) {
         if (!directives.empty())
             parseError(first.line, "directives are not supported on index assignment");
-        // index assignment: ident[expr] = value
+        // index assignment: ident[expr, ...] = value
         lex_.next(); // consume '['
-        ExprPtr index = parseTernary();
+        std::vector<ExprPtr> indices;
+        indices.push_back(parseTernary());
+        while (lex_.peek().kind == TokenKind::Comma) {
+            lex_.next(); // consume ','
+            indices.push_back(parseTernary());
+        }
         if (lex_.peek().kind != TokenKind::RBracket)
             parseError("expected ']'");
         lex_.next(); // consume ']'
@@ -384,7 +389,7 @@ StmtNode Parser::parseStatement() {
         obj->data = VariableExpr{first.value};
         obj->loc = locFromToken(first);
         s.object = std::move(obj);
-        s.index = std::move(index);
+        s.indices = std::move(indices);
         s.value = std::move(val);
         s.loc = locFromToken(first);
         return s;

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -71,6 +71,23 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
                 opName = opTok.value;
                 lex_.next(); // consume operator
                 break;
+            case TokenKind::LBracket: {
+                lex_.next(); // consume '['
+                if (lex_.peek().kind != TokenKind::RBracket)
+                    parseError("expected ']' after '[' in operator declaration");
+                lex_.next(); // consume ']'
+                if (lex_.peek().kind == TokenKind::Equals) {
+                    lex_.next(); // consume '='
+                    opName = "[]=";
+                } else {
+                    opName = "[]";
+                }
+                break;
+            }
+            case TokenKind::In:
+                opName = "in";
+                lex_.next(); // consume 'in'
+                break;
             default:
                 parseError(opTok.line, "expected operator symbol after 'operator'");
         }
@@ -172,6 +189,15 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         } else if (isCompoundAssignOperator(opName)) {
             if (nParams != 2)
                 parseError("compound assignment operator requires exactly 2 parameters");
+        } else if (opName == "operator[]") {
+            if (nParams < 2)
+                parseError("operator[] requires at least 2 parameters (object + index)");
+        } else if (opName == "operator[]=") {
+            if (nParams < 3)
+                parseError("operator[]= requires at least 3 parameters (object + index + value)");
+        } else if (opName == "operatorin") {
+            if (nParams != 2)
+                parseError("operator in requires exactly 2 parameters");
         } else if (nParams != 1 && nParams != 2) {
             parseError("operator function requires 1 or 2 parameters");
         }

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -709,13 +709,18 @@ ExprPtr Parser::parsePostfix() {
         }
         if (lex_.peek().kind == TokenKind::LBracket) {
             Token lbTok = lex_.next(); // consume '['
-            ExprPtr index = parseTernary();
+            std::vector<ExprPtr> indices;
+            indices.push_back(parseTernary());
+            while (lex_.peek().kind == TokenKind::Comma) {
+                lex_.next(); // consume ','
+                indices.push_back(parseTernary());
+            }
             if (lex_.peek().kind != TokenKind::RBracket)
                 parseError("expected ']'");
             lex_.next(); // consume ']'
             auto idx = std::make_unique<IndexExpr>();
             idx->object = std::move(expr);
-            idx->index = std::move(index);
+            idx->indices = std::move(indices);
             auto node = std::make_unique<ExprNode>();
             node->data = std::move(idx);
             node->loc = locFromToken(lbTok);

--- a/tests/spec/operator_overload.test.ry
+++ b/tests/spec/operator_overload.test.ry
@@ -1,0 +1,84 @@
+describe("operator[]", fn():
+  it("read with single index", fn():
+    record Point:
+      x: int
+      y: int
+      z: int
+    fn operator[](p: Point, i: int) -> int:
+      if i == 0:
+        return p.x
+      if i == 1:
+        return p.y
+      return p.z
+    p = Point(10, 20, 30)
+    expect(p[0]).to_eq(10)
+    expect(p[1]).to_eq(20)
+    expect(p[2]).to_eq(30)
+  )
+
+  it("read with multi-index", fn():
+    record Grid:
+      a: int
+      b: int
+      c: int
+      d: int
+    fn operator[](g: Grid, row: int, col: int) -> int:
+      if row == 0 and col == 0:
+        return g.a
+      if row == 0 and col == 1:
+        return g.b
+      if row == 1 and col == 0:
+        return g.c
+      return g.d
+    g = Grid(1, 2, 3, 4)
+    expect(g[0, 0]).to_eq(1)
+    expect(g[0, 1]).to_eq(2)
+    expect(g[1, 0]).to_eq(3)
+    expect(g[1, 1]).to_eq(4)
+  )
+
+  it("write dispatches operator[]=", fn():
+    record Sink:
+      last_key: int
+      last_val: int
+    fn operator[]=(s: Sink, key: int, value: int):
+      s.last_key = key
+      s.last_val = value
+    s = Sink(0, 0)
+    s[5] = 42
+  )
+)
+
+describe("operator in", fn():
+  it("custom in", fn():
+    record Range:
+      lo: int
+      hi: int
+    fn operator in(v: int, r: Range) -> bool:
+      return v >= r.lo and v < r.hi
+    r = Range(1, 10)
+    expect(5 in r).to_be_true()
+    expect(0 in r).to_be_false()
+    expect(10 in r).to_be_false()
+  )
+
+  it("not in", fn():
+    record Span:
+      lo: int
+      hi: int
+    fn operator in(v: int, s: Span) -> bool:
+      return v >= s.lo and v < s.hi
+    s = Span(1, 10)
+    expect(15 not in s).to_be_true()
+    expect(5 not in s).to_be_false()
+  )
+
+  it("built-in in still works", fn():
+    xs = [1, 2, 3]
+    expect(2 in xs).to_be_true()
+    expect(5 in xs).to_be_false()
+    m = {"a": 1, "b": 2}
+    expect("a" in m).to_be_true()
+    expect("c" in m).to_be_false()
+  )
+)

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2085,3 +2085,116 @@ TEST_F(CodeGenTest, ForThreeVarCountMismatch) {
         "    print(a)";
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
+
+// ===== operator[] / operator[]= / operator in =====
+
+TEST_F(CodeGenTest, OperatorSubscriptReadSingleIndex) {
+    std::string src =
+        "record Point:\n"
+        "    x: int\n"
+        "    y: int\n"
+        "    z: int\n"
+        "fn operator[](p: Point, i: int) -> int:\n"
+        "    if i == 0:\n"
+        "        return p.x\n"
+        "    if i == 1:\n"
+        "        return p.y\n"
+        "    return p.z\n"
+        "p = Point(10, 20, 30)\n"
+        "print(p[0])\n"
+        "print(p[2])";
+    EXPECT_EQ(runSource(src), "10\n30\n");
+}
+
+TEST_F(CodeGenTest, OperatorSubscriptReadMultiIndex) {
+    std::string src =
+        "record Grid:\n"
+        "    a: int\n"
+        "    b: int\n"
+        "    c: int\n"
+        "    d: int\n"
+        "fn operator[](g: Grid, row: int, col: int) -> int:\n"
+        "    if row == 0 and col == 0:\n"
+        "        return g.a\n"
+        "    if row == 0 and col == 1:\n"
+        "        return g.b\n"
+        "    if row == 1 and col == 0:\n"
+        "        return g.c\n"
+        "    return g.d\n"
+        "g = Grid(1, 2, 3, 4)\n"
+        "print(g[0, 1])\n"
+        "print(g[1, 0])";
+    EXPECT_EQ(runSource(src), "2\n3\n");
+}
+
+TEST_F(CodeGenTest, OperatorSubscriptWrite) {
+    // operator[]= dispatches correctly (uses side effect to verify)
+    std::string src =
+        "record Counter:\n"
+        "    count: int\n"
+        "fn operator[]=(c: Counter, key: int, value: int):\n"
+        "    print(key)\n"
+        "    print(value)\n"
+        "c = Counter(0)\n"
+        "c[3] = 42";
+    EXPECT_EQ(runSource(src), "3\n42\n");
+}
+
+TEST_F(CodeGenTest, OperatorIn) {
+    std::string src =
+        "record Range:\n"
+        "    start: int\n"
+        "    end_val: int\n"
+        "fn operator in(value: int, r: Range) -> bool:\n"
+        "    return value >= r.start and value < r.end_val\n"
+        "r = Range(1, 10)\n"
+        "print(5 in r)\n"
+        "print(15 in r)\n"
+        "print(5 not in r)";
+    EXPECT_EQ(runSource(src), "true\nfalse\nfalse\n");
+}
+
+TEST_F(CodeGenTest, OperatorInFallbackBuiltin) {
+    // Built-in in should still work for lists/maps/sets
+    EXPECT_EQ(runSource("print(2 in [1, 2, 3])"), "true\n");
+    EXPECT_EQ(runSource("print(\"a\" in {\"a\": 1})"), "true\n");
+    EXPECT_EQ(runSource("print(5 in [1, 2, 3])"), "false\n");
+}
+
+TEST_F(CodeGenTest, OperatorSubscriptParamValidation) {
+    // operator[] with < 2 params should fail
+    EXPECT_THROW(runSource(
+        "record Foo:\n"
+        "    x: int\n"
+        "fn operator[](f: Foo) -> int:\n"
+        "    return f.x\n"), std::runtime_error);
+    // operator[]= with < 3 params should fail
+    EXPECT_THROW(runSource(
+        "record Foo:\n"
+        "    x: int\n"
+        "fn operator[]=(f: Foo, v: int):\n"
+        "    f.x = v\n"), std::runtime_error);
+    // operator in with != 2 params should fail
+    EXPECT_THROW(runSource(
+        "record Foo:\n"
+        "    x: int\n"
+        "fn operator in(a: int) -> bool:\n"
+        "    return true\n"), std::runtime_error);
+    // operator in must return bool
+    EXPECT_THROW(runSource(
+        "record Foo:\n"
+        "    x: int\n"
+        "fn operator in(a: int, f: Foo) -> int:\n"
+        "    return 1\n"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, BuiltinIndexStillWorks) {
+    // List indexing
+    EXPECT_EQ(runSource("xs = [10, 20, 30]\nprint(xs[1])"), "20\n");
+    // Map indexing
+    EXPECT_EQ(runSource("m = {\"a\": 1, \"b\": 2}\nprint(m[\"b\"])"), "2\n");
+    // List index assignment
+    EXPECT_EQ(runSource("xs = [1, 2, 3]\nxs[0] = 99\nprint(xs[0])"), "99\n");
+    // Map index assignment
+    EXPECT_EQ(runSource("m = {\"a\": 1}\nm[\"b\"] = 2\nprint(m[\"b\"])"), "2\n");
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -711,8 +711,8 @@ TEST(ParserTest, IndexAssignStmt) {
     const auto &s = std::get<IndexAssignStmt>(prog[1]);
     ASSERT_TRUE(std::holds_alternative<VariableExpr>(s.object->data));
     EXPECT_EQ(std::get<VariableExpr>(s.object->data).name, "m");
-    ASSERT_TRUE(std::holds_alternative<StringExpr>(s.index->data));
-    EXPECT_EQ(std::get<StringExpr>(s.index->data).value, "b");
+    ASSERT_TRUE(std::holds_alternative<StringExpr>(s.indices[0]->data));
+    EXPECT_EQ(std::get<StringExpr>(s.indices[0]->data).value, "b");
     ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.value->data));
     EXPECT_EQ(std::get<NumberExpr>(s.value->data).value, 2);
 }


### PR DESCRIPTION
## Summary

- Add `operator[]` (read) and `operator[]=` (write) overloading with multi-index support (e.g., `m[row, col]`)
- Add `operator in` overloading for user-defined membership tests (`not in` automatically supported)
- User-defined operators are tried first; built-in list/map/array/set behavior is used as fallback
- Unify all operator dispatch logic through a generic `findAndCallOverload` helper using `llvm::ArrayRef`/`SmallVector`
- Update docs (operators.md, functions.md) and CHANGELOG

Closes #202 (partial — `[]` and `in` only; `as` and `()` deferred to separate PRs)

## Test plan

- [ ] C++ tests: 7 new tests covering single-index, multi-index, write, `in`, `not in`, fallback, param validation, bool return constraint
- [ ] Ry self-tests: `operator_overload.test.ry` with 6 test cases
- [ ] All 1082 existing C++ tests pass
- [ ] All 43 Ry self-test files pass (0 failures)