### PR TITLE
feat: inherit parent invariants and auto-slice Error subtypes in Err()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Record auto-generated `operator==` and `operator!=` (#305)
 - Record auto-generated `to_str` (#306)
 - Record subtyping with `<` syntax for field inheritance and subtype coercion (#307)
+- Record invariant inheritance: parent `invariant:` clauses are checked on child construction (#355)
+- Auto-slice Error subtypes in `Err()` for Result return type coercion (#354)
 - `@inline` directive for function inlining hints (#299)
 - Explicit value assignment for simple enum variants (#309)
 - Named fields in ADT enum variants (#308)

--- a/docs/reference/structs.md
+++ b/docs/reference/structs.md
@@ -190,6 +190,7 @@ handle(derr)  # OK — coerced to Error (grandparent)
 | Deep inheritance | `record C < B:` where `record B < A:` — allowed |
 | Name collision | Child field with same name as parent field → compile error |
 | Auto `==` / `to_str` | Includes all inherited fields |
+| Invariant inheritance | Parent `invariant:` clauses are checked when constructing or modifying child records |
 | `@const` | Applies to all fields including inherited |
 
 ---

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -650,13 +650,15 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
     if (e.callee == "Err") {
         requireArgs(e, 1);
         llvm::Value *inner = emitExpr(*e.args[0]);
-        // Determine the ok type from the enclosing function's return type
         llvm::Type *okTy = i8Ty_; // default: Unit (i8 dummy)
         if (fn_) {
             llvm::Type *retTy = fn_->getReturnType();
             if (isResultType(retTy)) {
                 auto *retStructTy = llvm::cast<llvm::StructType>(retTy);
                 okTy = retStructTy->getElementType(1);
+                llvm::Type *expectedErrTy = retStructTy->getElementType(2);
+                if (auto *sliced = tryEmitSubtypeCoerce(inner, expectedErrTy))
+                    inner = sliced;
             }
         }
         llvm::StructType *resTy = getResultType(okTy, inner->getType());

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -68,9 +68,7 @@ llvm::Value *CodeGen::emitStructConstructor(const StructInfo &info,
         result = builder_.CreateInsertValue(result, val, i);
     }
 
-    // Check invariants after construction
-    if (!info.invariants.empty())
-        emitInvariantCheck(name, info, result);
+    emitInvariantCheck(name, info, result);
 
     return result;
 }

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -51,6 +51,8 @@ void CodeGen::emitStmt(ReturnStmt &s) {
                 val = wrapInAny(val);
             } else if (isUnionType(current_fn_return_type_)) {
                 val = wrapInUnion(val, current_fn_return_type_);
+            } else if (auto *sliced = tryEmitSubtypeCoerce(val, retTy)) {
+                val = sliced;
             } else {
                 // Try tuple element coercion (e.g., Option<int> none → Option<Error>)
                 auto *retST = llvm::dyn_cast<llvm::StructType>(retTy);
@@ -493,7 +495,20 @@ void CodeGen::emitContractCheck(const std::string &kind, const std::string &fn_n
 
 void CodeGen::emitInvariantCheck(const std::string &typeName, const StructInfo &info,
                                   llvm::Value *structVal) {
-    if (info.invariants.empty()) return;
+    if (info.invariants.empty() && info.parent_name.empty()) return;
+
+    std::vector<std::pair<std::string, const ExprPtr*>> allInvariants;
+    for (auto &inv : info.invariants)
+        allInvariants.push_back({typeName, &inv});
+    const std::string *parent = &info.parent_name;
+    while (!parent->empty()) {
+        auto pit = struct_types_.find(*parent);
+        if (pit == struct_types_.end()) break;
+        for (auto &inv : pit->second.invariants)
+            allInvariants.push_back({*parent, &inv});
+        parent = &pit->second.parent_name;
+    }
+    if (allInvariants.empty()) return;
 
     pushScope();
     for (unsigned f = 0; f < info.fields.size(); ++f) {
@@ -503,8 +518,8 @@ void CodeGen::emitInvariantCheck(const std::string &typeName, const StructInfo &
         builder_.CreateStore(fieldVal, fieldAlloca);
         scope_stack_.back()[info.fields[f].name] = fieldAlloca;
     }
-    for (int i = 0; i < static_cast<int>(info.invariants.size()); ++i)
-        emitContractCheck("invariant", typeName, info.invariants[i]);
+    for (auto &[name, inv] : allInvariants)
+        emitContractCheck("invariant", name, *inv);
     popScope();
 }
 

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -597,9 +597,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
     llvm::Value *updated = builder_.CreateInsertValue(current, newVal, fieldIdx, "struct_upd");
     builder_.CreateStore(updated, ptr);
 
-    // Check invariants after field assignment
-    if (!info.invariants.empty())
-        emitInvariantCheck(typeName, info, updated);
+    emitInvariantCheck(typeName, info, updated);
 }
 
 void CodeGen::emitStmt(EnumStmt &s) {

--- a/tests/spec/record_subtyping.test.ry
+++ b/tests/spec/record_subtyping.test.ry
@@ -45,6 +45,54 @@ describe("deep inheritance", fn():
   )
 )
 
+# --- #355: Invariant inheritance ---
+record Positive:
+  value: int
+  invariant:
+    value > 0
+
+record NamedPositive < Positive:
+  name: str
+
+describe("invariant inheritance", fn():
+  it("child with valid parent fields succeeds", fn():
+    np = NamedPositive(42, "good")
+    expect(np.value).to_eq(42)
+    expect(np.name).to_eq("good")
+  )
+)
+
+# --- #354: Err() auto-slicing ---
+record ApiError < Error:
+  endpoint: str
+
+fn fetch_data(url: str) -> Result<int, Error>:
+  return Err(ApiError("not found", 404, url))
+
+describe("Err auto-slicing", fn():
+  it("Err(subtype) auto-slices to Error in Result", fn():
+    result = fetch_data("/api")
+    match result:
+      case Err(e):
+        expect(e.message).to_eq("not found")
+        expect(e.code).to_eq(404)
+      case Ok(_):
+        expect(false).to_be_true()
+  )
+)
+
+# --- return subtype coercion ---
+fn to_error(msg: str) -> Error:
+  return ApiError(msg, 500, "/internal")
+
+describe("return subtype coercion", fn():
+  it("return subtype auto-slices to parent return type", fn():
+    e = to_error("fail")
+    expect(e.message).to_eq("fail")
+    expect(e.code).to_eq(500)
+  )
+)
+
 record Animal:
   name: str
   legs: int

--- a/tests/test_codegen_contract.cpp
+++ b/tests/test_codegen_contract.cpp
@@ -155,6 +155,63 @@ TEST_F(CodeGenTest, InvariantViolatedAfterFieldAssign) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
+// ===== Inherited invariant tests =====
+
+TEST_F(CodeGenTest, InheritedInvariantSatisfied) {
+    std::string src =
+        "record Positive:\n"
+        "    value: int\n"
+        "    invariant:\n"
+        "        value > 0\n"
+        "record NamedPositive < Positive:\n"
+        "    name: str\n"
+        "np = NamedPositive(42, \"good\")\n"
+        "print(np.value)";
+    EXPECT_EQ(runSource(src), "42\n");
+}
+
+TEST_F(CodeGenTest, InheritedInvariantViolated) {
+    std::string src =
+        "record Positive:\n"
+        "    value: int\n"
+        "    invariant:\n"
+        "        value > 0\n"
+        "record NamedPositive < Positive:\n"
+        "    name: str\n"
+        "np = NamedPositive(-1, \"bad\")\n"
+        "print(np.value)";
+    EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
+}
+
+TEST_F(CodeGenTest, InheritedInvariantViolatedAfterFieldAssign) {
+    std::string src =
+        "record Positive:\n"
+        "    value: int\n"
+        "    invariant:\n"
+        "        value > 0\n"
+        "record NamedPositive < Positive:\n"
+        "    name: str\n"
+        "np = NamedPositive(42, \"good\")\n"
+        "np.value = -1\n"
+        "print(np.value)";
+    EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
+}
+
+TEST_F(CodeGenTest, DeepInheritedInvariantViolated) {
+    std::string src =
+        "record Positive:\n"
+        "    value: int\n"
+        "    invariant:\n"
+        "        value > 0\n"
+        "record NamedPositive < Positive:\n"
+        "    name: str\n"
+        "record TaggedPositive < NamedPositive:\n"
+        "    tag: int\n"
+        "tp = TaggedPositive(-1, \"bad\", 0)\n"
+        "print(tp.value)";
+    EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
+}
+
 // ===== Nested function with contract: FnScope protects contract state =====
 
 TEST_F(CodeGenTest, NestedFnWithEnsurePreservesOuterContract) {


### PR DESCRIPTION
## Summary

- **#355**: Parent record `invariant:` clauses are now checked when constructing or modifying child records. Walks the parent chain at codegen time — no `ExprNode::clone()` needed.
- **#354**: `Err(HttpError(...))` in a function returning `Result<V, Error>` now auto-slices `HttpError` to `Error`. Also adds subtype coercion to return statements.

## Changes

- `emitInvariantCheck` walks ancestor chain to collect and enforce all inherited invariants
- `Err()` handler applies `tryEmitSubtypeCoerce` to match expected error type
- Return statements support subtype coercion (`return HttpError(...)` in `-> Error` function)
- Fast-path guard: skip invariant collection for records with no invariants and no parent

Closes #355
Closes #354

## Test plan

- [x] C++ tests: 4 new invariant inheritance tests (satisfied, violated on construction, violated on field assign, deep inheritance)
- [x] Ry self-tests: invariant inheritance, Err auto-slicing, return subtype coercion
- [x] All 1081 C++ tests pass
- [x] All 43 Ry test files pass