### PR TITLE
feat: subtype coercion for field assignment and `?` error propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Record subtyping with `<` syntax for field inheritance and subtype coercion (#307)
 - Record invariant inheritance: parent `invariant:` clauses are checked on child construction (#355)
 - Auto-slice Error subtypes in `Err()` for Result return type coercion (#354)
+- Subtype coercion for field assignment (#359)
+- Subtype coercion for `?` error propagation operator (#360)
 - `@inline` directive for function inlining hints (#299)
 - Explicit value assignment for simple enum variants (#309)
 - Named fields in ADT enum variants (#308)

--- a/docs/reference/structs.md
+++ b/docs/reference/structs.md
@@ -191,6 +191,7 @@ handle(derr)  # OK — coerced to Error (grandparent)
 | Name collision | Child field with same name as parent field → compile error |
 | Auto `==` / `to_str` | Includes all inherited fields |
 | Invariant inheritance | Parent `invariant:` clauses are checked when constructing or modifying child records |
+| Subtype coercion | Applies to: function args, return, `Err()`, field assignment, `?` operator |
 | `@const` | Applies to all fields including inherited |
 
 ---

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -789,8 +789,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ErrorPropagateExpr> 
 
     llvm::StructType *operandResultTy = llvm::cast<llvm::StructType>(operandTy);
     llvm::StructType *retResultTy = llvm::cast<llvm::StructType>(fnRetTy);
-    if (operandResultTy->getElementType(2) != retResultTy->getElementType(2))
-        codegenError("'?' operator error type mismatch: operand and function return different error types");
+    llvm::Type *operandErrTy = operandResultTy->getElementType(2);
+    llvm::Type *retErrTy = retResultTy->getElementType(2);
 
     llvm::Value *isOk = builder_.CreateExtractValue(operandVal, 0, "is_ok");
     llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "try.ok", fn_);
@@ -800,6 +800,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ErrorPropagateExpr> 
     // Err path: extract error, wrap in function return type, return
     builder_.SetInsertPoint(errBB);
     llvm::Value *errVal = builder_.CreateExtractValue(operandVal, 2, "err_val");
+    if (operandErrTy != retErrTy) {
+        if (auto *sliced = tryEmitSubtypeCoerce(errVal, retErrTy))
+            errVal = sliced;
+        else
+            codegenError("'?' operator error type mismatch: operand and function return different error types");
+    }
     llvm::Value *retErr = buildErrValue(errVal, retResultTy);
     emitEnsureChecks(retErr);
     builder_.CreateRet(retErr);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -589,8 +589,12 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
 
     llvm::Value *newVal = emitExpr(*s.value);
     llvm::Type *expectedTy = structTy->getElementType(fieldIdx);
-    if (newVal->getType() != expectedTy)
-        codegenError("field '" + s.field + "' type mismatch");
+    if (newVal->getType() != expectedTy) {
+        if (auto *sliced = tryEmitSubtypeCoerce(newVal, expectedTy))
+            newVal = sliced;
+        else
+            codegenError("field '" + s.field + "' type mismatch");
+    }
 
     // Load current struct value, insert new field value, store back
     llvm::Value *current = builder_.CreateLoad(varTy, ptr, "struct_cur");

--- a/tests/spec/record_subtyping.test.ry
+++ b/tests/spec/record_subtyping.test.ry
@@ -115,3 +115,36 @@ describe("non-Error subtyping", fn():
     expect(describe_animal(d)).to_eq("Rex has 4 legs")
   )
 )
+
+# --- #359: Field assignment subtype coercion ---
+record Owner:
+  pet: Animal
+
+describe("field assignment subtype coercion", fn():
+  it("assigns child type to parent-type field", fn():
+    o = Owner(Animal("cat", 4))
+    o.pet = Dog("Rex", 4, "Labrador")
+    expect(o.pet.name).to_eq("Rex")
+    expect(o.pet.legs).to_eq(4)
+  )
+)
+
+# --- #360: ? operator subtype coercion ---
+fn fetch_typed(url: str) -> Result<int, ApiError>:
+  return Err(ApiError("fail", 500, url))
+
+fn process_data(url: str) -> Result<int, Error>:
+  val = fetch_typed(url)?
+  return Ok(val)
+
+describe("? operator subtype coercion", fn():
+  it("propagates subtype error through ?", fn():
+    result = process_data("/api")
+    match result:
+      case Err(e):
+        expect(e.message).to_eq("fail")
+        expect(e.code).to_eq(500)
+      case Ok(_):
+        expect(false).to_be_true()
+  )
+)

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1221,3 +1221,41 @@ TEST_F(CodeGenTest, LambdaArgDescribeIt) {
         ")";
     EXPECT_NO_THROW(runTestSource(src));
 }
+
+// ===== Field assignment subtype coercion (#359) =====
+
+TEST_F(CodeGenTest, FieldAssignSubtypeCoercion) {
+    std::string src =
+        "record Animal:\n"
+        "    name: str\n"
+        "    legs: int\n"
+        "record Dog < Animal:\n"
+        "    breed: str\n"
+        "record Owner:\n"
+        "    pet: Animal\n"
+        "o = Owner(Animal(\"cat\", 4))\n"
+        "o.pet = Dog(\"Rex\", 4, \"Lab\")\n"
+        "print(o.pet.name)\n"
+        "print(o.pet.legs)";
+    EXPECT_EQ(runSource(src), "Rex\n4\n");
+}
+
+// ===== ? operator subtype coercion (#360) =====
+
+TEST_F(CodeGenTest, ErrorPropagateSubtypeCoercion) {
+    std::string src =
+        "record ApiError < Error:\n"
+        "    endpoint: str\n"
+        "fn fetch(url: str) -> Result<int, ApiError>:\n"
+        "    return Err(ApiError(\"fail\", 500, url))\n"
+        "fn process(url: str) -> Result<int, Error>:\n"
+        "    val = fetch(url)?\n"
+        "    return Ok(val)\n"
+        "result = process(\"/api\")\n"
+        "match result:\n"
+        "    case Err(e):\n"
+        "        print(e.message)\n"
+        "    case Ok(v):\n"
+        "        print(v)";
+    EXPECT_EQ(runSource(src), "fail\n");
+}


### PR DESCRIPTION
## Summary
- Add subtype coercion for field assignment: assigning a child-type value to a parent-type field now auto-slices (#359)
- Add subtype coercion for `?` error propagation operator: error subtypes are auto-sliced when propagating through `?` (#360)

## Changes
- `src/codegen_stmt.cpp`: Add `tryEmitSubtypeCoerce` fallback in `FieldAssignStmt` type check
- `src/codegen_expr.cpp`: Replace strict error type equality in `?` operator with `tryEmitSubtypeCoerce`-based coercion
- C++ tests and Ry self-tests for both features
- Docs and CHANGELOG updated

## Test plan
- [x] `./build/ry_tests` — 1090 C++ tests pass
- [x] `RY_ENV=internal ./build/ry test -p` — 44 Ry test files pass
- [x] New tests: `FieldAssignSubtypeCoercion`, `ErrorPropagateSubtypeCoercion`
- [x] New Ry tests: field assignment and `?` operator subtype coercion in `record_subtyping.test.ry`