### PR TITLE
feat: operator overloading for call () and cast as (#202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Named fields in ADT enum variants (#308)
 - Subscript operator overloading `operator[]` / `operator[]=` with multi-index support (#202)
 - Membership operator overloading `operator in` for user-defined types (#202)
+- Call operator overloading `operator()` for callable records (#202)
+- Cast operator overloading `operator as` for user-defined type conversions (#202)
 - Compound assignment operator overloading with in-place optimization (#204)
 - Enforce bool return type for comparison and logical operator overloads (#203)
 - N-element tuple destructuring in for loops (#302)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -439,6 +439,8 @@ fn operator<op>(a: type) -> return_type:
 | Logical (binary) | `and` `or` |
 | Membership | `in` |
 | Subscript | `[]` (read), `[]=` (write) |
+| Call | `()` |
+| Cast | `as` |
 | Unary | `-` `~` `not` |
 
 ### Return Type Constraints
@@ -450,6 +452,7 @@ Comparison, logical, and membership operators must return `bool`:
 | Comparison | `==` `!=` `<` `<=` `>` `>=` | `bool` |
 | Logical | `and` `or` `not` | `bool` |
 | Membership | `in` | `bool` |
+| Cast | `as` | Required (target type) |
 
 ```python
 # OK

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -298,6 +298,8 @@ fn operator-(a: MyType) -> MyType:
 | Logical (binary) | `and` `or` |
 | Membership | `in` |
 | Subscript | `[]` (read), `[]=` (write) |
+| Call | `()` |
+| Cast | `as` |
 | Unary | `-` `~` `not` |
 | Compound assignment | `+=` `-=` `*=` `/=` `%=` `//=` `**=` `&=` `\|=` `^=` `<<=` `>>=` |
 
@@ -310,6 +312,7 @@ Comparison and logical operators must return `bool`:
 | Comparison | `==` `!=` `<` `<=` `>` `>=` | `bool` |
 | Logical | `and` `or` `not` | `bool` |
 | Membership | `in` | `bool` |
+| Cast | `as` | Required (target type) |
 
 ```python
 # OK
@@ -426,3 +429,40 @@ print(15 not in r)  # true
 ```
 
 User-defined `in` operators are tried first; if no match is found, built-in behavior (for sets, maps, and lists) is used as a fallback. `not in` is automatically supported when `in` is defined.
+
+### Call Operator Overloading
+
+The `()` operator enables records to behave as callable objects. Requires at least 2 parameters (object + arguments).
+
+```python
+record Adder:
+    base: int
+
+fn operator()(a: Adder, x: int) -> int:
+    return a.base + x
+
+add5 = Adder(5)
+print(add5(10))    # 15
+```
+
+When a variable holding a record value is called like a function, the compiler tries `operator()` overloads first. If no match is found, other call resolution strategies (functions, constructors, lambdas) take precedence.
+
+### Cast Operator Overloading
+
+The `as` operator can be overloaded to define custom type conversions. Takes exactly 1 parameter (the source value) and must specify a return type (the target type). Dispatch matches by source type and return type.
+
+```python
+record Celsius:
+    value: int
+
+record Fahrenheit:
+    value: int
+
+fn operator as(c: Celsius) -> Fahrenheit:
+    return Fahrenheit(c.value * 9 // 5 + 32)
+
+c = Celsius(100)
+f = c as Fahrenheit   # Fahrenheit(212)
+```
+
+User-defined `as` operators are tried first; if no match is found, built-in casts (int, float, bool, str, etc.) are used as a fallback.

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -103,10 +103,6 @@ inline bool isCompoundAssignOperator(const std::string &name) {
            name == "operator<<=" || name == "operator>>=";
 }
 
-inline bool isSubscriptOperator(const std::string &name) {
-    return name == "operator[]" || name == "operator[]=";
-}
-
 struct NumberExpr   { int64_t value; std::string suffix; };
 struct FloatExpr    { double value;  std::string suffix; };
 struct BoolExpr     { bool value; };

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -358,6 +358,8 @@ private:
                                       llvm::Value *operand);
     llvm::Value *trySubscriptOperatorCall(llvm::Value *object,
                                            llvm::ArrayRef<llvm::Value*> indices);
+    llvm::Value *tryCallOperator(const std::string &callee,
+                                 const std::vector<ExprPtr> &args);
     bool trySubscriptAssignOperatorCall(llvm::Value *object,
                                          llvm::ArrayRef<llvm::Value*> indices,
                                          llvm::Value *value);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -807,6 +807,8 @@ void CodeGen::emitStmt(CallStmt &s) {
             return;
         }
     }
+    if (tryCallOperator(s.callee, s.args))
+        return;
     emitUserFnCall(s.callee, s.args);
 }
 

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -142,6 +142,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
             llvm::Value *loaded = builder_.CreateLoad(ptrTy_, varPtr, e->callee + ".fn");
             return emitLambdaCall(loaded, info, argVals, "indirect_call");
         }
+
+        if (auto *result = tryCallOperator(e->callee, e->args))
+            return result;
     }
 
     // Generic function dispatch (explicit type args or type inference)

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -197,6 +197,20 @@ bool CodeGen::trySubscriptAssignOperatorCall(
     return findAndCallOverload("operator[]=", args, "subscr_assign") != nullptr;
 }
 
+llvm::Value *CodeGen::tryCallOperator(const std::string &callee,
+                                       const std::vector<ExprPtr> &args) {
+    llvm::AllocaInst *varPtr = findVar(callee);
+    if (!varPtr) return nullptr;
+    llvm::Type *allocTy = varPtr->getAllocatedType();
+    if (!allocTy->isStructTy()) return nullptr;
+    llvm::Value *obj = builder_.CreateLoad(allocTy, varPtr, callee + ".val");
+    llvm::SmallVector<llvm::Value*, 4> callArgs;
+    callArgs.push_back(obj);
+    for (auto &arg : args)
+        callArgs.push_back(emitExpr(*arg));
+    return findAndCallOverload("operator()", callArgs, "call_op");
+}
+
 // ===== B2: BinaryExpr sub-dispatchers =====
 
 llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -6,6 +6,22 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
     llvm::Type *srcTy = val->getType();
     const std::string target = e->target_type->toString();
 
+    // Try user-defined operator as (matches by source type + return type)
+    auto fit = functions_.find("operatoras");
+    if (fit != functions_.end()) {
+        auto sit = struct_types_.find(target);
+        if (sit != struct_types_.end()) {
+            llvm::Type *targetTy = sit->second.llvmType;
+            for (auto &entry : fit->second) {
+                if (entry.paramTypes.size() == 1 &&
+                    entry.paramTypes[0] == srcTy &&
+                    entry.func->getReturnType() == targetTy) {
+                    return builder_.CreateCall(entry.func, {val}, "cast_op");
+                }
+            }
+        }
+    }
+
     if (target == "float") {
         if (srcTy->isDoubleTy()) return val;
         if (srcTy == f32Ty_) return builder_.CreateFPExt(val, f64Ty_, "cast_f");

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -88,6 +88,18 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
                 opName = "in";
                 lex_.next(); // consume 'in'
                 break;
+            case TokenKind::LParen: {
+                lex_.next(); // consume '('
+                if (lex_.peek().kind != TokenKind::RParen)
+                    parseError("expected ')' after '(' in operator declaration");
+                lex_.next(); // consume ')'
+                opName = "()";
+                break;
+            }
+            case TokenKind::As:
+                opName = "as";
+                lex_.next(); // consume 'as'
+                break;
             default:
                 parseError(opTok.line, "expected operator symbol after 'operator'");
         }
@@ -198,6 +210,14 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         } else if (opName == "operatorin") {
             if (nParams != 2)
                 parseError("operator in requires exactly 2 parameters");
+        } else if (opName == "operator()") {
+            if (nParams < 2)
+                parseError("operator() requires at least 2 parameters (object + arguments)");
+        } else if (opName == "operatoras") {
+            if (nParams != 1)
+                parseError("operator as requires exactly 1 parameter");
+            if (!fnStmt->return_type)
+                parseError("operator as requires a return type");
         } else if (nParams != 1 && nParams != 2) {
             parseError("operator function requires 1 or 2 parameters");
         }

--- a/tests/spec/operator_overload.test.ry
+++ b/tests/spec/operator_overload.test.ry
@@ -82,3 +82,43 @@ describe("operator in", fn():
     expect("c" in m).to_be_false()
   )
 )
+
+describe("operator()", fn():
+  it("callable record", fn():
+    record Adder:
+      base: int
+    fn operator()(a: Adder, x: int) -> int:
+      return a.base + x
+    add5 = Adder(5)
+    expect(add5(10)).to_eq(15)
+  )
+
+  it("multi-arg callable", fn():
+    record Calc:
+      base: int
+    fn operator()(c: Calc, x: int, y: int) -> int:
+      return c.base + x * y
+    calc = Calc(10)
+    expect(calc(3, 4)).to_eq(22)
+  )
+)
+
+describe("operator as", fn():
+  it("custom cast", fn():
+    record Celsius:
+      value: int
+    record Fahrenheit:
+      value: int
+    fn operator as(c: Celsius) -> Fahrenheit:
+      return Fahrenheit(c.value * 9 // 5 + 32)
+    c = Celsius(100)
+    f = c as Fahrenheit
+    expect(f.value).to_eq(212)
+  )
+
+  it("built-in cast still works", fn():
+    x: float = 42 as float
+    expect(x + 0.5).to_eq(42.5)
+    expect(3.14 as int).to_eq(3)
+  )
+)

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2198,3 +2198,70 @@ TEST_F(CodeGenTest, BuiltinIndexStillWorks) {
     // Map index assignment
     EXPECT_EQ(runSource("m = {\"a\": 1}\nm[\"b\"] = 2\nprint(m[\"b\"])"), "2\n");
 }
+
+TEST_F(CodeGenTest, OperatorCallSingleArg) {
+    std::string src =
+        "record Adder:\n"
+        "    base: int\n"
+        "fn operator()(a: Adder, x: int) -> int:\n"
+        "    return a.base + x\n"
+        "add5 = Adder(5)\n"
+        "print(add5(10))";
+    EXPECT_EQ(runSource(src), "15\n");
+}
+
+TEST_F(CodeGenTest, OperatorCallMultiArg) {
+    std::string src =
+        "record Multiplier:\n"
+        "    factor: int\n"
+        "fn operator()(m: Multiplier, x: int, y: int) -> int:\n"
+        "    return m.factor * (x + y)\n"
+        "mul = Multiplier(3)\n"
+        "print(mul(4, 5))";
+    EXPECT_EQ(runSource(src), "27\n");
+}
+
+TEST_F(CodeGenTest, OperatorCallVoid) {
+    std::string src =
+        "record Printer:\n"
+        "    prefix: str\n"
+        "fn operator()(p: Printer, msg: str):\n"
+        "    print(p.prefix + msg)\n"
+        "p = Printer(\">> \")\n"
+        "p(\"hello\")";
+    EXPECT_EQ(runSource(src), ">> hello\n");
+}
+
+TEST_F(CodeGenTest, OperatorAs) {
+    std::string src =
+        "record Celsius:\n"
+        "    value: int\n"
+        "record Fahrenheit:\n"
+        "    value: int\n"
+        "fn operator as(c: Celsius) -> Fahrenheit:\n"
+        "    return Fahrenheit(c.value * 9 // 5 + 32)\n"
+        "c = Celsius(100)\n"
+        "f = c as Fahrenheit\n"
+        "print(f.value)";
+    EXPECT_EQ(runSource(src), "212\n");
+}
+
+TEST_F(CodeGenTest, OperatorAsFallbackBuiltin) {
+    EXPECT_EQ(runSource("x = 42\nprint(x as float)"), "42\n");
+}
+
+TEST_F(CodeGenTest, OperatorCallParamValidation) {
+    EXPECT_THROW(runSource(
+        "record Foo:\n"
+        "    x: int\n"
+        "fn operator()(f: Foo) -> int:\n"
+        "    return f.x\n"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, OperatorAsParamValidation) {
+    EXPECT_THROW(runSource(
+        "record Foo:\n"
+        "    x: int\n"
+        "fn operator as(a: int, b: int) -> int:\n"
+        "    return a\n"), std::runtime_error);
+}


### PR DESCRIPTION
## Summary
- Add `operator()` overloading for callable records (e.g., `add5(10)` where `add5` is a record with `operator()` defined)
- Add `operator as` overloading for user-defined type conversions (e.g., `c as Fahrenheit` with custom cast logic)
- Both dispatch user-defined operators first, falling back to built-in behavior
- Completes the remaining operators from #202 (`[]` and `in` were shipped in #358)

## Test plan
- [x] C++ tests: OperatorCallSingleArg, OperatorCallMultiArg, OperatorCallVoid, OperatorAs, OperatorAsFallbackBuiltin, OperatorCallParamValidation, OperatorAsParamValidation
- [x] Ry self-tests: operator_overload.test.ry (operator(), operator as sections)
- [x] All 1091 C++ tests pass
- [x] All 44 Ry self-test files pass
- [x] Built-in `as` casts and function calls unaffected