### PR TITLE
feat: restrict await to async fn, add block_on(), remove join(task) (#206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Self-update artifact checksum verification (#116)
 - Linux x86_64 (amd64) release build in CI (#154)
 - Linux ARM64 (aarch64) release build in CI (#155)
+- `block_on(task)` built-in function for synchronous Task waiting (#206)
 
 ### Changed
 
@@ -63,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Lambda expression syntax changed from `:` to `=>` (#301)
 - Flatten stdlib imports — `from std.x` to `from x` (#178)
 - Rename `ry.toml` to `package.toml` (#335)
+- Restrict `await` to `async fn` context only — use `block_on()` in synchronous code (#206)
 
 ### Fixed
 
@@ -98,6 +100,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Concurrency primitives: channels, spawn, select, task_group, cancel (#304)
 - `byte` type in favor of `u8` (#294)
+- `join(task)` built-in — replaced by `block_on(task)` (#206)
 
 ## [0.0.4] - 2026-03-22
 

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -20,7 +20,7 @@
 | `send(stream, data)` | Sends `List<u8>` through `TcpStream`, returns bytes sent |
 | `recv(stream, max)` | Receives up to `max` bytes from `TcpStream` as `List<u8>` |
 | `close(handle)` | Closes a `TcpStream` or `TcpListener` |
-| `join(task)` | Waits for a `Task<T>` to complete and returns its result |
+| `block_on(task)` | Blocks the current thread until a `Task<T>` completes and returns its result |
 
 ### Option
 

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -183,15 +183,21 @@ for i in 1 .. 3:
 
 ## async / await
 
-`async fn` declares a function that runs concurrently. Calling an `async fn` returns `Task<T>`. Use `await` or `join(task)` to wait for the result.
+`async fn` declares a function that runs concurrently. Calling an `async fn` returns `Task<T>`. Use `await` inside another `async fn` or `block_on()` from synchronous context to wait for the result.
 
 ```python
 async fn add(a: int, b: int) -> int:
     return a + b
 
+# From synchronous context, use block_on()
 t: Task<int> = add(20, 22)
-print(await t)          # 42
-print(join(add(1, 2)))  # 3
+print(block_on(t))                  # 42
+print(block_on(add(1, 2)))          # 3
+
+# Inside async fn, use await
+async fn double_add(a: int, b: int) -> int:
+    result = await add(a, b)
+    return result * 2
 ```
 
 ### Rules
@@ -199,8 +205,9 @@ print(join(add(1, 2)))  # 3
 - `async fn name(...) -> T:` is declared with the awaited result type `T`.
 - Calling an `async fn` immediately returns `Task<T>`.
 - `await expr` requires `expr` to be `Task<T>` and produces `T`.
-- `await` is allowed anywhere an expression is allowed, and `await expr` is also allowed as a statement.
-- `async fn ... -> Unit` is supported; `await task` is the primary way to wait when no value is produced.
+- `await` can only be used inside an `async fn`. Use `block_on(task)` from synchronous context.
+- `block_on(task)` blocks the current thread until the task completes and returns the result.
+- `async fn ... -> Unit` is supported; `block_on(task)` is the primary way to wait when no value is produced.
 - Tasks run on the runtime worker pool; they are not implemented as one OS thread per task.
 - `async` lambdas and `async @native fn` are not supported in v1.
 

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -207,16 +207,20 @@ fn log(msg: str) -> Unit:
 
 ## Tasks And Async Functions
 
-`Task<T>` is the built-in handle type for concurrent work. `async fn` returns `Task<T>`, `await` extracts `T`, and `join(task)` is the blocking function-form equivalent of `await task`.
+`Task<T>` is the built-in handle type for concurrent work. `async fn` returns `Task<T>`, `await` extracts `T` inside another `async fn`, and `block_on(task)` blocks from synchronous context until the task completes.
 
 ```python
 async fn add(a: int, b: int) -> int:
     return a + b
 
+# From synchronous context, use block_on()
 t: Task<int> = add(20, 22)
-print(await t)          # 42
-await add(1, 2)         # waits and discards the result
-print(join(add(1, 2)))  # 3
+print(block_on(t))                  # 42
+block_on(add(1, 2))                 # waits and discards the result
+
+# Inside async fn, use await
+async fn double_add(a: int, b: int) -> int:
+    return (await add(a, b)) * 2
 ```
 
 ### Rules
@@ -224,8 +228,9 @@ print(join(add(1, 2)))  # 3
 - `async fn name(...) -> T:` is declared with the awaited result type `T`.
 - Calling an `async fn` immediately returns `Task<T>`.
 - `await expr` requires `expr` to be `Task<T>` and produces `T`.
-- `await` is allowed anywhere an expression is allowed, and `await expr` is also allowed as a statement.
-- `async fn ... -> Unit` is supported; `await task` is the primary way to wait when no value is produced.
+- `await` can only be used inside an `async fn`. Use `block_on(task)` from synchronous context.
+- `block_on(task)` blocks the current thread until the task completes and returns the result.
+- `async fn ... -> Unit` is supported; `block_on(task)` is the primary way to wait when no value is produced.
 - Tasks run on the runtime worker pool; they are not implemented as one OS thread per task.
 - `async` lambdas and `async @native fn` are not supported in v1.
 

--- a/docs/tutorial/08-advanced.md
+++ b/docs/tutorial/08-advanced.md
@@ -188,16 +188,20 @@ match x:
 
 ## Concurrency Basics
 
-`Task<T>` is the runtime handle for concurrent work. Use `async fn` for task-returning functions and `await` or `join(task)` to wait for completion.
+`Task<T>` is the runtime handle for concurrent work. Use `async fn` for task-returning functions, `await` inside another `async fn`, and `block_on(task)` from synchronous context to wait for completion.
 
 ```python
 async fn add(a: int, b: int) -> int:
     return a + b
 
+# From synchronous context, use block_on()
 t: Task<int> = add(20, 22)
-print(await t)             # 42
-print(join(add(1, 2)))     # 3
-await add(1, 2)            # statement form also works
+print(block_on(t))                  # 42
+print(block_on(add(1, 2)))          # 3
+
+# Inside async fn, use await
+async fn double_add(a: int, b: int) -> int:
+    return (await add(a, b)) * 2
 ```
 
 `@parallel` can be applied to counted `for` loops over `range(...)` or integer `..` ranges:

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -430,6 +430,7 @@ private:
     llvm::Type *getNestedListElementType(llvm::Value *listVal);
     llvm::Value *emitSetElementLookup(llvm::Value *setPtr, llvm::Value *elem, llvm::Type *elemTy);
     llvm::Type *getTaskResultType(llvm::Value *taskVal);
+    llvm::Value *emitTaskWait(llvm::Value *taskVal, const char *runtimeFn, const char *label);
 
     // Hash function resolution helper (Step 1)
     struct HashFnInfo {

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -21,6 +21,7 @@ private:
     const SourceManager *sm_ = nullptr;
     int file_id_ = 0;
     int recursion_depth_ = 0;
+    bool in_async_fn_ = false;
     static constexpr int MAX_RECURSION_DEPTH = 256;
 
     struct RecursionGuard {

--- a/include/ry/runtime_parallel.hpp
+++ b/include/ry/runtime_parallel.hpp
@@ -9,6 +9,7 @@ using __ry_parallel_for_fn = void (*)(void *, int64_t, int64_t, int64_t);
 
 void *__ry_task_spawn(__ry_task_entry_fn entry, void *env, int64_t result_size);
 void __ry_task_join(void *task, void *out_buf);
+void __ry_block_on(void *task, void *out_buf);
 void __ry_parallel_for_i64(int64_t begin, int64_t end, int64_t step,
                            void *env, __ry_parallel_for_fn fn);
 int64_t __ry_available_parallelism();

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -751,6 +751,7 @@ void CodeGen::emitStmt(CallStmt &s) {
         s.callee == "listen" ||
         s.callee == "http_listen" ||
         s.callee == "sleep" ||
+        s.callee == "block_on" ||
         s.callee == "set_timeout" || s.callee == "set_recv_timeout" || s.callee == "set_send_timeout" ||
         s.callee == "shutdown" ||
         s.callee == "json_free") {

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -377,6 +377,12 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         return builder_.CreateCall(fn, {}, "available_parallelism");
     }
 
+    // block_on(task) -> T — block the current thread until the Task<T> completes
+    if (e.callee == "block_on") {
+        requireArgs(e, 1);
+        return emitTaskWait(emitExpr(*e.args[0]), "__ry_block_on", "block_on");
+    }
+
     // sleep(duration_ms) -> Unit
     if (e.callee == "sleep") {
         requireArgs(e, 1);

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -753,8 +753,7 @@ llvm::Value *CodeGen::emitStrOp_split(const CallExpr &e) {
 // join(list, sep) → str
 llvm::Value *CodeGen::emitStrOp_join(const CallExpr &e) {
     if (e.args.size() != 2) {
-        if (e.args.size() != 1)
-            codegenError("join() expects 1 argument (Task<T>) or 2 arguments (List<str>, str)");
+        codegenError("join() expects 2 arguments (List<str>, str)");
         return nullptr;
     }
     llvm::Value *listPtr = emitExpr(*e.args[0]);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -796,22 +796,25 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ErrorPropagateExpr> 
     return okVal;
 }
 
-llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<AwaitExpr> &e) {
-    llvm::Value *taskVal = emitExpr(*e->operand);
+llvm::Value *CodeGen::emitTaskWait(llvm::Value *taskVal, const char *runtimeFn, const char *label) {
     llvm::Type *resultTy = getTaskResultType(taskVal);
     if (!resultTy)
-        codegenError("await requires a Task value");
+        codegenError(std::string(label) + "() requires a Task value");
 
-    llvm::FunctionType *joinTy = llvm::FunctionType::get(
+    llvm::FunctionType *fnTy = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*ctx_), {ptrTy_, ptrTy_}, false);
-    llvm::FunctionCallee joinFn = mod_->getOrInsertFunction("__ry_task_join", joinTy);
+    llvm::FunctionCallee fn = mod_->getOrInsertFunction(runtimeFn, fnTy);
 
     if (resultTy->isVoidTy()) {
-        return builder_.CreateCall(joinFn, {taskVal, llvm::ConstantPointerNull::get(
+        return builder_.CreateCall(fn, {taskVal, llvm::ConstantPointerNull::get(
             llvm::cast<llvm::PointerType>(ptrTy_))});
     }
 
-    llvm::AllocaInst *resultSlot = builder_.CreateAlloca(resultTy, nullptr, "await_result");
-    builder_.CreateCall(joinFn, {taskVal, resultSlot});
-    return builder_.CreateLoad(resultTy, resultSlot, "awaited");
+    llvm::AllocaInst *resultSlot = builder_.CreateAlloca(resultTy, nullptr, std::string(label) + "_result");
+    builder_.CreateCall(fn, {taskVal, resultSlot});
+    return builder_.CreateLoad(resultTy, resultSlot, std::string(label) + "_val");
+}
+
+llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<AwaitExpr> &e) {
+    return emitTaskWait(emitExpr(*e->operand), "__ry_task_join", "await");
 }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -336,6 +336,8 @@ StmtNode Parser::parseStatement() {
 
     if (first.kind == TokenKind::Await) {
         Token awaitTok = lex_.next(); // consume 'await'
+        if (!in_async_fn_)
+            parseError(awaitTok.line, "'await' can only be used inside an 'async fn'; use 'block_on()' in synchronous context");
         AwaitStmt s;
         s.operand = parseLogicalNot();
         s.loc = locFromToken(awaitTok);

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -221,6 +221,10 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         parseEnsureClause(*fnStmt);
     }
 
+    // Track async context for await restriction
+    bool prev_in_async = in_async_fn_;
+    in_async_fn_ = is_async;
+
     // Parse body statements
     while (lex_.peek().kind != TokenKind::Dedent &&
            lex_.peek().kind != TokenKind::Eof) {
@@ -232,6 +236,9 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
 
     if (fnStmt->body.empty())
         parseError("empty function body is not allowed");
+
+    // Restore async context
+    in_async_fn_ = prev_in_async;
 
     if (lex_.peek().kind == TokenKind::Dedent)
         lex_.next(); // consume Dedent

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -176,6 +176,8 @@ ExprPtr Parser::parseLogicalNot() {
 
 ExprPtr Parser::parseAwaitExpr() {
     Token awaitTok = lex_.next(); // consume 'await'
+    if (!in_async_fn_)
+        parseError(awaitTok.line, "'await' can only be used inside an 'async fn'; use 'block_on()' in synchronous context");
     ExprPtr operand = parseLogicalNot();
     auto awaitExpr = std::make_unique<AwaitExpr>();
     awaitExpr->operand = std::move(operand);
@@ -623,6 +625,10 @@ ExprPtr Parser::parseLambdaExpr() {
         lambda->return_type = nullptr;  // inferred at codegen time
     }
 
+    // Lambda is not an async context — save and reset
+    bool prev_in_async = in_async_fn_;
+    in_async_fn_ = false;
+
     if (lex_.peek().kind == TokenKind::FatArrow) {
         // Single-expression lambda: fn(params) => expr
         lex_.next(); // consume '=>'
@@ -652,6 +658,8 @@ ExprPtr Parser::parseLambdaExpr() {
     } else {
         parseError("expected '=>' or ':' after lambda parameters");
     }
+
+    in_async_fn_ = prev_in_async;
 
     auto node = std::make_unique<ExprNode>();
     node->data = std::move(lambda);

--- a/src/runtime_parallel.cpp
+++ b/src/runtime_parallel.cpp
@@ -299,6 +299,12 @@ extern "C" void __ry_task_join(void *task_ptr, void *out_buf) {
         std::rethrow_exception(error);
 }
 
+// Separate entry point from __ry_task_join so block_on and await
+// can diverge when coroutine-based scheduling is added (#362).
+extern "C" void __ry_block_on(void *task_ptr, void *out_buf) {
+    __ry_task_join(task_ptr, out_buf);
+}
+
 extern "C" void __ry_parallel_for_i64(int64_t begin, int64_t end, int64_t step,
                                       void *env, __ry_parallel_for_fn fn) {
     if (step == 0)

--- a/tests/spec/concurrency.test.ry
+++ b/tests/spec/concurrency.test.ry
@@ -1,26 +1,26 @@
 describe("async and await", fn():
-  it("awaits direct async call", fn():
+  it("block_on awaits direct async call", fn():
     async fn async_add_direct(a: int, b: int) -> int:
       return a + b
-    expect(await async_add_direct(20, 22)).to_eq(42)
+    expect(block_on(async_add_direct(20, 22))).to_eq(42)
   )
-  it("awaits task variable", fn():
+  it("block_on awaits task variable", fn():
     async fn async_add_task(a: int, b: int) -> int:
       return a + b
     t: Task<int> = async_add_task(7, 8)
-    expect(await t).to_eq(15)
+    expect(block_on(t)).to_eq(15)
   )
-  it("chains async functions", fn():
+  it("chains async functions with await inside async fn", fn():
     async fn inner() -> int:
       return 21
     async fn outer() -> int:
       return (await inner()) * 2
-    expect(await outer()).to_eq(42)
+    expect(block_on(outer())).to_eq(42)
   )
-  it("supports Unit-returning async functions through await", fn():
+  it("supports Unit-returning async functions through block_on", fn():
     async fn bump() -> Unit:
       print("done")
-    await bump()
+    block_on(bump())
     expect(1).to_eq(1)
   )
 )

--- a/tests/spec/http.test.ry
+++ b/tests/spec/http.test.ry
@@ -47,7 +47,7 @@ describe("HTTP Server API", fn():
                 close(conn)
               case Err(e):
                 fail("unexpected error")
-            await t
+            block_on(t)
           case Err(e):
             fail("unexpected error")
       case Err(e):
@@ -97,7 +97,7 @@ describe("HTTP Server API", fn():
                 close(conn)
               case Err(e):
                 fail("unexpected error")
-            await t
+            block_on(t)
           case Err(e):
             fail("unexpected error")
       case Err(e):

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -65,7 +65,7 @@ describe("TCP socket API", fn():
                 close(conn)
               case Err(e):
                 fail("unexpected error")
-            await t
+            block_on(t)
           case Err(e):
             fail("unexpected error")
       case Err(e):
@@ -123,7 +123,7 @@ describe("TCP socket API", fn():
             t = run_server(server)
             resp_msg = run_client(port)
             expect(resp_msg).to_eq("echo:hello")
-            await t
+            block_on(t)
           case Err(e):
             fail("unexpected error")
       case Err(e):

--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -74,7 +74,7 @@ match bind("127.0.0.1", 0):
                         close(conn)
                     case Err(e):
                         print("connect failed")
-                await t
+                block_on(t)
             case Err(e):
                 ...
     case Err(e):
@@ -132,7 +132,7 @@ match bind("127.0.0.1", 0):
                         close(conn)
                     case Err(e):
                         print("false")
-                await t
+                block_on(t)
             case Err(e):
                 ...
     case Err(e):
@@ -190,7 +190,7 @@ match bind("127.0.0.1", 0):
                         close(conn)
                     case Err(e):
                         print("false")
-                await t
+                block_on(t)
             case Err(e):
                 ...
     case Err(e):
@@ -248,7 +248,7 @@ match bind("127.0.0.1", 0):
                         close(conn)
                     case Err(e):
                         print("false")
-                await t
+                block_on(t)
             case Err(e):
                 ...
     case Err(e):
@@ -258,7 +258,7 @@ match bind("127.0.0.1", 0):
 
 // ============================================================
 // http_listen with max_requests: server exits after N requests
-// Uses async fn + port_callback + await to verify server lifecycle.
+// Uses async fn + port_callback + block_on to verify server lifecycle.
 // ============================================================
 
 static const std::string HTTP_LISTEN_DECLS = HTTP_DECLS + R"(
@@ -309,7 +309,7 @@ match connect("127.0.0.1", 18932):
     case Err(e):
         print("false")
         print("false")
-result = await t
+result = block_on(t)
 print(result)
 )"), "true\ntrue\ndone\n");
 }
@@ -368,7 +368,7 @@ match connect("127.0.0.1", 18933):
     case Err(e):
         print("false")
 
-result = await t
+result = block_on(t)
 print(result)
 )"), "true\ntrue\ndone\n");
 }
@@ -432,7 +432,7 @@ match connect("127.0.0.1", 18934):
         print("false")
         print("false")
 
-result = await t
+result = block_on(t)
 print(result)
 )"), "true\ntrue\ntrue\ntrue\ndone\n");
 }
@@ -494,7 +494,7 @@ match connect("127.0.0.1", 18935):
     case Err(e):
         print("false")
 
-result = await t
+result = block_on(t)
 print(result)
 )"), "true\ntrue\ntrue\ndone\n");
 }
@@ -567,7 +567,7 @@ match connect("127.0.0.1", 18936):
         print("false")
         print("false")
 
-result = await t
+result = block_on(t)
 print(result)
 )"), "true\ntrue\ntrue\ndone\n");
 }

--- a/tests/test_codegen_net.cpp
+++ b/tests/test_codegen_net.cpp
@@ -144,7 +144,7 @@ match bind("127.0.0.1", 0):
                 t = run_server(server)
                 resp_msg = run_client(port)
                 print(resp_msg)
-                await t
+                block_on(t)
             case Err(e):
                 ...
     case Err(e):
@@ -358,7 +358,7 @@ match bind("127.0.0.1", 0):
                         close(conn)
                     case Err(e):
                         print("connect failed")
-                await t
+                block_on(t)
             case Err(e):
                 ...
     case Err(e):

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -939,47 +939,52 @@ TEST_F(CodeGenTest, RangeExprVariants) {
 // ===== Concurrency: async/await =====
 
 TEST_F(CodeGenTest, AsyncAwaitBasics) {
-    // AsyncAwaitDirectCall
+    // block_on awaits direct async call
     EXPECT_EQ(runSource(
         "async fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
-        "print(await add(20, 22))"), "42\n");
-    // AsyncAwaitTaskVariable
+        "print(block_on(add(20, 22)))"), "42\n");
+    // block_on awaits task variable
     EXPECT_EQ(runSource(
         "async fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "t: Task<int> = add(7, 8)\n"
-        "print(await t)"), "15\n");
-    // AsyncAwaitChain
+        "print(block_on(t))"), "15\n");
+    // await chains inside async fn, block_on at top level
     EXPECT_EQ(runSource(
         "async fn inner() -> int:\n"
         "    return 21\n"
         "async fn outer() -> int:\n"
         "    return (await inner()) * 2\n"
-        "print(await outer())"), "42\n");
+        "print(block_on(outer()))"), "42\n");
 }
 
 TEST_F(CodeGenTest, AsyncStatementForms) {
-    // AsyncUnitAwaitStatement
+    // block_on Unit-returning async
     EXPECT_EQ(runSource(
         "async fn bump() -> Unit:\n"
         "    print(\"done\")\n"
-        "await bump()\n"
+        "block_on(bump())\n"
         "print(\"after\")"), "done\nafter\n");
-    // AsyncAwaitStatementDiscardsValue
+    // block_on discards value
     EXPECT_EQ(runSource(
         "async fn add(a: int, b: int) -> int:\n"
         "    print(a + b)\n"
         "    return a + b\n"
-        "await add(20, 22)\n"
+        "block_on(add(20, 22))\n"
         "print(\"after\")"), "42\nafter\n");
 }
 
 TEST_F(CodeGenTest, AwaitErrors) {
-    // AwaitRequiresTask
-    EXPECT_THROW(runSource("x = await 123\nprint(x)"), std::runtime_error);
-    // AwaitStatementRequiresTask
-    EXPECT_THROW(runSource("await 123"), std::runtime_error);
+    // await outside async fn is a parse error
+    EXPECT_THROW(runSource("async fn add(a: int, b: int) -> int:\n"
+        "    return a + b\n"
+        "x = await add(1, 2)\nprint(x)"), std::runtime_error);
+    EXPECT_THROW(runSource("async fn bump() -> Unit:\n"
+        "    print(\"done\")\n"
+        "await bump()"), std::runtime_error);
+    // block_on requires Task
+    EXPECT_THROW(runSource("x = block_on(123)\nprint(x)"), std::runtime_error);
 }
 
 TEST_F(CodeGenTest, AvailableParallelismBuiltin) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1295,9 +1295,16 @@ TEST(ParserTest, AsyncFnParsing) {
 }
 
 TEST(ParserTest, AwaitExprParsing) {
-    Program prog = parseStr("x = await fetch()");
+    // await inside async fn should parse successfully
+    Program prog = parseStr(
+        "async fn do_fetch() -> int:\n"
+        "    x = await fetch()\n"
+        "    return x");
     ASSERT_EQ(prog.size(), 1u);
-    auto &let = std::get<AssignStmt>(prog[0]);
+    auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
+    ASSERT_TRUE(fn.is_async);
+    ASSERT_GE(fn.body.size(), 1u);
+    auto &let = std::get<AssignStmt>(fn.body[0]);
     auto *await = std::get_if<std::unique_ptr<AwaitExpr>>(&let.value->data);
     ASSERT_NE(await, nullptr);
     auto *call = std::get_if<std::unique_ptr<CallExpr>>(&(*await)->operand->data);
@@ -1306,13 +1313,30 @@ TEST(ParserTest, AwaitExprParsing) {
 }
 
 TEST(ParserTest, AwaitStatementParsing) {
-    Program prog = parseStr("await fetch()");
+    // await as statement inside async fn
+    Program prog = parseStr(
+        "async fn do_fetch() -> Unit:\n"
+        "    await fetch()");
     ASSERT_EQ(prog.size(), 1u);
-    ASSERT_TRUE(std::holds_alternative<AwaitStmt>(prog[0]));
-    auto &await = std::get<AwaitStmt>(prog[0]);
+    auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
+    ASSERT_TRUE(fn.is_async);
+    ASSERT_EQ(fn.body.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<AwaitStmt>(fn.body[0]));
+    auto &await = std::get<AwaitStmt>(fn.body[0]);
     auto *call = std::get_if<std::unique_ptr<CallExpr>>(&await.operand->data);
     ASSERT_NE(call, nullptr);
     EXPECT_EQ((*call)->callee, "fetch");
+}
+
+TEST(ParserTest, AwaitOutsideAsyncFnRejected) {
+    // await outside async fn should fail
+    EXPECT_THROW(parseStr("x = await fetch()"), std::runtime_error);
+    EXPECT_THROW(parseStr("await fetch()"), std::runtime_error);
+    // await inside lambda within async fn should also fail (lambda is not async)
+    EXPECT_THROW(parseStr(
+        "async fn foo() -> int:\n"
+        "    f = fn(x: int) => await bar()\n"
+        "    return 1"), std::runtime_error);
 }
 
 TEST(ParserTest, ParallelDirectiveRejectedOnWhile) {


### PR DESCRIPTION
## Summary

- Add `block_on(task)` builtin for blocking Task<T> waiting from synchronous context
- Restrict `await` to `async fn` context only — parser emits error with actionable message suggesting `block_on()`
- Remove `join(task)` builtin (was undocumented/broken for Task; replaced by `block_on`)
- Extract shared `emitTaskWait()` helper to deduplicate await/block_on codegen

## Test plan

- [x] C++ tests: 1078 passed (parser, codegen, net, http)
- [x] Ry self-tests: 43 files, 0 failures
- [x] New parser test: `await` inside lambda within async fn is rejected
- [x] New codegen test: `block_on(123)` on non-Task value errors correctly

Closes #206