### PR TITLE
feat: tail call optimization for self-recursive functions (#214)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Membership operator overloading `operator in` for user-defined types (#202)
 - Call operator overloading `operator()` for callable records (#202)
 - Cast operator overloading `operator as` for user-defined type conversions (#202)
+- Tail call optimization (TCO) for self-recursive functions via LLVM `musttail` (#214)
 - Compound assignment operator overloading with in-place optimization (#204)
 - Enforce bool return type for comparison and logical operator overloads (#203)
 - N-element tuple destructuring in for loops (#302)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -102,6 +102,27 @@ fn factorial(n: int) -> int:
     return n * factorial(n - 1)
 ```
 
+### Tail Call Optimization
+
+The compiler automatically detects self-recursive tail calls — where the last action in a function is a call to itself — and applies LLVM's `musttail` optimization. This guarantees that tail-recursive functions use constant stack space, preventing stack overflow for deep recursion.
+
+```python
+fn sum_to(n: int, acc: int) -> int:
+    if n <= 0:
+        return acc
+    return sum_to(n - 1, acc + n)    # tail call → optimized
+
+sum_to(1000000, 0)    # works without stack overflow
+```
+
+**Conditions for TCO:**
+
+- The function calls itself directly in a `return` statement (`return f(args)`)
+- The call result is returned without any further computation (`return n * f(n-1)` is NOT a tail call)
+- The function has no `ensure` (postcondition) clauses
+
+Mutual recursion (A calls B, B calls A) is not currently optimized.
+
 ---
 
 ## Overloading

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -42,6 +42,20 @@ void CodeGen::emitStmt(ReturnStmt &s) {
         }
     } else {
         llvm::Value *val = emitExpr(*s.value);
+
+        // Tail call optimization: self-recursive tail call → musttail
+        if (!current_postconditions_) {
+            if (auto *ci = llvm::dyn_cast<llvm::CallInst>(val)) {
+                if (ci->getCalledFunction() == fn_) {
+                    ci->setTailCallKind(llvm::CallInst::TCK_MustTail);
+                    builder_.CreateRet(val);
+                    llvm::BasicBlock *dead = llvm::BasicBlock::Create(*ctx_, "dead", fn_);
+                    builder_.SetInsertPoint(dead);
+                    return;
+                }
+            }
+        }
+
         llvm::Type *retTy = fn_->getReturnType();
         if (retTy->isVoidTy())
             codegenError("cannot return a value from Unit function '" +

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -154,3 +154,14 @@ describe("operator overloading", fn():
     expect(v.y).to_eq(6.0)
   )
 )
+
+fn sum_to(n: int, acc: int) -> int:
+  if n <= 0:
+    return acc
+  return sum_to(n - 1, acc + n)
+
+describe("tail call optimization", fn():
+  it("self-recursive tail call does not overflow", fn():
+    expect(sum_to(1000000, 0)).to_eq(500000500000)
+  )
+)

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1259,3 +1259,35 @@ TEST_F(CodeGenTest, ErrorPropagateSubtypeCoercion) {
         "        print(v)";
     EXPECT_EQ(runSource(src), "fail\n");
 }
+
+// ===== Tail Call Optimization (#214) =====
+
+TEST_F(CodeGenTest, TailCallOptimization) {
+    // Deep self-recursive tail call should not stack overflow
+    EXPECT_EQ(runSource(
+        "fn sum_to(n: int, acc: int) -> int:\n"
+        "  if n <= 0:\n"
+        "    return acc\n"
+        "  return sum_to(n - 1, acc + n)\n"
+        "print(sum_to(1000000, 0))"), "500000500000\n");
+}
+
+TEST_F(CodeGenTest, TailCallFactorial) {
+    // Tail-recursive factorial with accumulator
+    EXPECT_EQ(runSource(
+        "fn factorial(n: int, acc: int) -> int:\n"
+        "  if n <= 1:\n"
+        "    return acc\n"
+        "  return factorial(n - 1, n * acc)\n"
+        "print(factorial(20, 1))"), "2432902008176640000\n");
+}
+
+TEST_F(CodeGenTest, NonTailRecursionStillWorks) {
+    // n * factorial(n-1) is NOT a tail call — should still work for small N
+    EXPECT_EQ(runSource(
+        "fn factorial(n: int) -> int:\n"
+        "  if n <= 1:\n"
+        "    return 1\n"
+        "  return n * factorial(n - 1)\n"
+        "print(factorial(10))"), "3628800\n");
+}


### PR DESCRIPTION
## Summary

- Detect self-recursive tail calls in `return f(args)` and apply LLVM `musttail` attribute to guarantee constant stack space
- Core change: ~8 lines in `emitStmt(ReturnStmt)` — after `emitExpr`, check if the result is a `CallInst` targeting the current function (`fn_`), and if no postconditions exist, mark it as `musttail`
- Enables deep recursion (e.g., `sum_to(1000000, 0)`) without stack overflow

## Test plan

- [x] C++ tests: `TailCallOptimization` (N=1M sum), `TailCallFactorial` (N=20), `NonTailRecursionStillWorks` (N=10)
- [x] Ry self-test: `functions.test.ry` — tail call with N=1M
- [x] All 1100 C++ tests pass
- [x] All 44 Ry self-test files pass