### PR TITLE
fix: prefer repo stdlib for repo builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,7 @@
 
 ### 1. Ry 宣言ファイル作成
 
-`lib/std/<pkg>/<pkg>.ry` に `@native` 宣言を記述する。ディレクトリスキャンで自動認識されるため、`manifest.json` の更新は不要。
+`lib/std/<pkg>/<pkg>.ry` に `@native` 宣言を記述する。`manifest.json` の更新は不要だが、宣言ファイルの追加だけでは package は使えるようにならない。
 
 ```ry
 @native
@@ -88,32 +88,42 @@ llvm::Value *CodeGen::emitBuiltin<Pkg>(const CallExpr &e) {
 | `emitResultBranch(isErr, resTy, buildOk, buildErr)` | カスタム Result 構築 |
 | `buildErrorFromRuntime(errFn)` | ランタイムから Error struct を構築 |
 
-### 4. Dispatcher 登録
+### 4. Central registry 登録
 
-`src/codegen_call.cpp` の `stdlib_dispatchers` 配列に 1 行追加する。
+`include/ry/builtin_stdlib_registry.hpp` に package を 1 行追加する。dispatcher 配列と native constant registry はここから導出される。
 
 ```cpp
-static const StdlibDispatcher stdlib_dispatchers[] = {
-    ...
-    &CodeGen::emitBuiltin<Pkg>,  // ← 追加
-};
+X(crypto, "lib/std/crypto/crypto.ry", emitBuiltinCrypto)
 ```
 
 ### 5. ビルド設定
 
 `CMakeLists.txt` の `ry_lib` に `src/runtime_<pkg>.cpp` と `src/codegen_call_<pkg>.cpp` を追加する。
 
+### 6. テスト追加
+
+- package import テストを追加する
+- 代表的な native function の実行テストを追加する
+- 必要なら declaration file / native constant の registry 整合テストも追加する
+
 ### 定数の追加
 
-`src/codegen_call.cpp` の `native_constant_registry` に 1 行追加するだけでよい。`codegen_stmt.cpp` の変更は不要。
+`lib/std/<pkg>/<pkg>.ry` に `@native @const` 宣言を追加し、`include/ry/builtin_stdlib_registry.hpp` の constant 一覧にも 1 行追加する。`codegen_stmt.cpp` の変更は不要。
 
 ### 既存パッケージへの関数追加
 
-既存パッケージに関数を追加する場合は、以下の 3 箇所を変更する:
+既存パッケージに関数を追加する場合は、以下の 4 箇所を確認する:
 
 1. `lib/std/<pkg>/<pkg>.ry` — `@native fn` 宣言を追加
 2. `src/runtime_<pkg>.cpp` — C++ 実装を追加
 3. `src/codegen_call_<pkg>.cpp` — dispatch case を追加
+4. テスト — selective import と実行ケースを追加
+
+## repo build と stdlib 解決
+
+- repo 内でビルドした `./build/ry` / `./build-current/ry` は、この project の `package.toml` にある hidden 設定 `[paths]._dev_stdlib` を使って project local の `lib/std` を参照する
+- OS にインストールされた `ry` はこの hidden 設定を無視し、`~/.ry/lib/std` を参照する
+- `RY_ENV=internal` は追加の isolation 用であり、repo 開発時の通常動作に必須ではない
 
 ## Git ブランチ運用ルール
 
@@ -192,7 +202,7 @@ static const StdlibDispatcher stdlib_dispatchers[] = {
 全テストを実行して成功を確認する。
 
 ```bash
-cmake --preset default && cmake --build build && ./build/ry_tests && RY_ENV=internal ./build/ry test -p
+cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p
 ```
 
 テストが失敗した場合は、原因を修正してから作業完了とすること。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Repo-built `ry` now prefers the checked-out stdlib over stale `~/.ry/lib/std`, restoring `base64`, `json`, and `net` timeout imports during language development (#367, #370)
 - Floor division (`//`) now uses correct floor semantics instead of truncation (#239)
 - Zero-division guards for integer `//` and `%` operators (#242)
 - NaN comparison aligned with compiler's ordered semantics (#240)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,8 +8,8 @@
 cmake --preset default                                  # Ninja + LLVM（CMakePresets.json）
 cmake --build build                                     # Ninja が自動並列ビルド
 ./build/ry_tests                                        # C++ テスト (GoogleTest)
-RY_ENV=internal ./build/ry test -p                       # Ry セルフテスト (全 *.test.ry)
-RY_ENV=internal ./build/ry test tests/spec/<file>.test.ry # 個別ファイル実行
+./build/ry test -p                                      # Ry セルフテスト (全 *.test.ry)
+./build/ry test tests/spec/<file>.test.ry               # 個別ファイル実行
 ```
 
-> **`RY_ENV=internal`**: グローバル (`~/.ry/lib`) をスキップし、プロジェクトローカルの `lib/std/` を使用する。言語開発時は常にこれを付けること。
+> repo 内でビルドした `./build/ry` は `package.toml` の hidden 設定 `[paths]._dev_stdlib` に従ってプロジェクトローカルの `lib/std/` を優先する。`RY_ENV=internal` は追加の isolation が必要な場合だけ使う。

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,7 @@ add_executable(ry_tests
     tests/test_self_update.cpp
     tests/test_diagnostic.cpp
     tests/test_paths.cpp
+    tests/test_builtin_stdlib_registry.cpp
     tests/test_regex_runtime.cpp
     tests/test_codegen_regex.cpp
     tests/test_codegen_mock.cpp

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -131,11 +131,11 @@ The `RY_ENV` environment variable controls the runtime environment mode. You can
 
 | Value | Alias | `.env` loading | Lib search |
 |-------|-------|---------------|------------|
-| `prod` | `production` | Disabled | `$RY_HOME/lib` → `exe/../lib` → `exe/lib` |
+| `prod` | `production` | Disabled | Project override for repo builds → `$RY_HOME/lib` → `exe/../lib` → `exe/lib` |
 | `dev` | `development` | `.env.dev` → `.env` | Same as `prod` |
 | `test` | — | `.env.test` → `.env` | Same as `prod` |
 | `staging` | — | `.env.staging` → `.env` | Same as `prod` |
-| `internal` | — | `.env.internal` → `.env` | `exe/../lib` → `exe/lib` only (`$RY_HOME` skipped) |
+| `internal` | — | `.env.internal` → `.env` | Project override for repo builds → `exe/../lib` → `exe/lib` (`$RY_HOME` skipped) |
 | (unset) (default) | — | `.env` only | Same as `prod` |
 
 Aliases are automatically resolved to their canonical form. For example, `RY_ENV=production` is normalized to `prod`.
@@ -157,18 +157,21 @@ RY_ENV=development ./build/ry app.ry
 # prod mode: .env is NOT loaded
 RY_ENV=prod ./build/ry app.ry
 
-# Use exe-relative stdlib only (for Ry language development)
+# Additional isolation when developing Ry itself
 RY_ENV=internal ./build/ry test
 ```
+
+When a `ry` executable is built inside the Ry source tree, it can use a repo-local stdlib override from the project's `package.toml`. This keeps repo builds aligned with the checked-out `lib/std` even if `~/.ry/lib/std` is older. Installed `ry` binaries ignore that override and continue to use `$RY_HOME/lib/std`.
 
 ---
 
 ## Search Path Priority
 
 1. The directory of the importing file
-2. `$RY_HOME/lib` (standard library location)
-3. Executable-relative `lib/` directories
-4. Paths specified in the `RY_PATH` environment variable (colon-separated)
+2. Repo-local stdlib override from the current Ry checkout, when using a repo-built `ry`
+3. `$RY_HOME/lib` (standard library location)
+4. Executable-relative `lib/` directories
+5. Paths specified in the `RY_PATH` environment variable (colon-separated)
 
 ---
 

--- a/include/ry/builtin_stdlib_registry.hpp
+++ b/include/ry/builtin_stdlib_registry.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#define RY_BUILTIN_STDLIB_PACKAGES(X) \
+    X(math,   "lib/std/math/math.ry",     emitBuiltinMath) \
+    X(io,     "lib/std/io/io.ry",         emitBuiltinIO) \
+    X(net,    "lib/std/net/net.ry",       emitBuiltinNet) \
+    X(http,   "lib/std/http/http.ry",     emitBuiltinHttp) \
+    X(json,   "lib/std/json/json.ry",     emitBuiltinJson) \
+    X(base64, "lib/std/base64/base64.ry", emitBuiltinBase64)
+
+#define RY_BUILTIN_STDLIB_CONSTANTS(X) \
+    X(math, PI,  Value,    3.141592653589793) \
+    X(math, E,   Value,    2.718281828459045) \
+    X(math, Inf, Infinity, 0.0) \
+    X(math, NaN, NaN,      0.0)

--- a/include/ry/paths.hpp
+++ b/include/ry/paths.hpp
@@ -9,8 +9,14 @@ namespace ry {
 std::filesystem::path get_ry_home();
 
 // Find the lib/ directory containing stdlib
-// Search order: $RY_HOME/lib -> exe/../lib -> exe/lib
-// When skip_global is true, $RY_HOME/lib is skipped (for RY_ENV=internal)
+// Search order:
+// 1. project-local override from package.toml (repo builds only)
+// 2. $RY_HOME/lib (skipped when skip_global is true)
+// 3. exe/../lib
+// 4. exe/lib
+std::filesystem::path find_lib_dir(const std::string &exe_path,
+                                   const std::string &project_root,
+                                   bool skip_global = false);
 std::filesystem::path find_lib_dir(const std::string &exe_path,
                                    bool skip_global = false);
 

--- a/include/ry/project_config.hpp
+++ b/include/ry/project_config.hpp
@@ -8,6 +8,7 @@ struct ProjectConfig {
     std::string version;
     std::string entry;
     std::string src_dir;
+    std::optional<std::string> dev_stdlib_dir;
 };
 
 class ProjectConfigParser {

--- a/package.toml
+++ b/package.toml
@@ -5,3 +5,4 @@ entry = "src/main.ry"
 
 [paths]
 src = "src"
+_dev_stdlib = "lib"

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -1,4 +1,5 @@
 #include "ry/codegen.hpp"
+#include "ry/builtin_stdlib_registry.hpp"
 #include "ry/diagnostic.hpp"
 
 // ===== CallExpr Dispatcher =====
@@ -108,15 +109,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
     if (auto *v = emitBuiltinRegex(*e))       return v;
 
     // Dispatch to stdlib package helpers (Pattern A: @native registry guard)
-    // To add a new stdlib package, add its emitBuiltin method here.
     using StdlibDispatcher = llvm::Value *(CodeGen::*)(const CallExpr &);
     static const StdlibDispatcher stdlib_dispatchers[] = {
-        &CodeGen::emitBuiltinMath,
-        &CodeGen::emitBuiltinIO,
-        &CodeGen::emitBuiltinNet,
-        &CodeGen::emitBuiltinHttp,
-        &CodeGen::emitBuiltinJson,
-        &CodeGen::emitBuiltinBase64,
+#define RY_STDLIB_DISPATCHER_ENTRY(pkg, decl, method) &CodeGen::method,
+        RY_BUILTIN_STDLIB_PACKAGES(RY_STDLIB_DISPATCHER_ENTRY)
+#undef RY_STDLIB_DISPATCHER_ENTRY
     };
     for (auto dispatcher : stdlib_dispatchers) {
         if (auto *v = (this->*dispatcher)(*e)) return v;
@@ -358,10 +355,9 @@ struct NativeConstantEntry {
 };
 
 static const std::unordered_map<std::string, NativeConstantEntry> native_constant_registry = {
-    {"PI",  {NativeConstantKind::Value,    3.141592653589793}},
-    {"E",   {NativeConstantKind::Value,    2.718281828459045}},
-    {"Inf", {NativeConstantKind::Infinity, 0.0}},
-    {"NaN", {NativeConstantKind::NaN,      0.0}},
+#define RY_NATIVE_CONSTANT_ENTRY(pkg, name, kind, value) {#name, {NativeConstantKind::kind, value}},
+    RY_BUILTIN_STDLIB_CONSTANTS(RY_NATIVE_CONSTANT_ENTRY)
+#undef RY_NATIVE_CONSTANT_ENTRY
 };
 
 bool CodeGen::isNativeConstant(const std::string &name) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,9 +85,11 @@ static void emitCoverageReport() {
 static int runRySource(const std::string &src, const std::string &source_name,
                        const std::string &referrer_dir, bool test_mode,
                        const char *argv0, bool coverage_mode = false) {
+    std::string project_root;
     // Load .env from project root (once per root per process)
     {
         if (auto root = findProjectRoot(referrer_dir)) {
+            project_root = *root;
             static std::string loaded_root;
             if (loaded_root != *root) {
                 const char *ry_env = std::getenv("RY_ENV");
@@ -108,7 +110,7 @@ static int runRySource(const std::string &src, const std::string &source_name,
 
     // Set up search paths with lib/ for stdlib
     std::vector<std::string> search_paths;
-    std::string lib_dir = ry::find_lib_dir(argv0, g_skip_global_lib).string();
+    std::string lib_dir = ry::find_lib_dir(argv0, project_root, g_skip_global_lib).string();
     if (!lib_dir.empty()) {
         search_paths.push_back(lib_dir);
         // Enable flattened imports: "from math" resolves to lib/std/math/

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -1,12 +1,61 @@
 #include "ry/paths.hpp"
+#include "ry/project_config.hpp"
 #include "ry/self_update.hpp"
 #include <cstdlib>
 #include <fstream>
 #include <sstream>
+#include <stdexcept>
 
 namespace fs = std::filesystem;
 
 namespace ry {
+
+namespace {
+
+bool is_within(const fs::path &child, const fs::path &parent) {
+    auto rel = child.lexically_relative(parent);
+    return !rel.empty() && rel.native().find("..") != 0;
+}
+
+std::optional<fs::path> find_project_override_lib_dir(const std::string &exe_path,
+                                                      const std::string &project_root) {
+    if (project_root.empty()) return std::nullopt;
+
+    std::error_code ec;
+    fs::path project = fs::weakly_canonical(fs::path(project_root), ec);
+    if (ec || project.empty()) return std::nullopt;
+
+    fs::path exe = fs::weakly_canonical(fs::absolute(fs::path(exe_path)), ec);
+    if (ec || exe.empty() || !is_within(exe, project)) return std::nullopt;
+
+    std::ifstream file(project / "package.toml");
+    if (!file.is_open()) return std::nullopt;
+    std::string toml((std::istreambuf_iterator<char>(file)),
+                     std::istreambuf_iterator<char>());
+    ProjectConfig config = ProjectConfigParser::load(toml);
+    if (!config.dev_stdlib_dir || config.dev_stdlib_dir->empty()) return std::nullopt;
+
+    fs::path rel(*config.dev_stdlib_dir);
+    if (rel.is_absolute()) {
+        throw std::runtime_error("package.toml [paths]._dev_stdlib must be a project-relative path");
+    }
+    for (const auto &part : rel) {
+        if (part == "..") {
+            throw std::runtime_error("package.toml [paths]._dev_stdlib must stay within the project root");
+        }
+    }
+
+    fs::path candidate = fs::weakly_canonical(project / rel, ec);
+    if (ec || candidate.empty() || !is_within(candidate, project)) {
+        throw std::runtime_error("package.toml [paths]._dev_stdlib resolves outside the project root");
+    }
+    if (!fs::is_directory(candidate / "std")) {
+        throw std::runtime_error("package.toml [paths]._dev_stdlib must point to a lib directory containing std/");
+    }
+    return candidate;
+}
+
+} // namespace
 
 fs::path get_ry_home() {
     if (const char *env = std::getenv("RY_HOME")) {
@@ -18,8 +67,15 @@ fs::path get_ry_home() {
     return fs::path(".ry");
 }
 
-fs::path find_lib_dir(const std::string &exe_path, bool skip_global) {
-    // 1. $RY_HOME/lib (skipped when skip_global is true)
+fs::path find_lib_dir(const std::string &exe_path,
+                      const std::string &project_root,
+                      bool skip_global) {
+    // 1. project-local override from package.toml (repo builds only)
+    if (auto project_lib = find_project_override_lib_dir(exe_path, project_root)) {
+        return *project_lib;
+    }
+
+    // 2. $RY_HOME/lib (skipped when skip_global is true)
     if (!skip_global) {
         fs::path ry_home_lib = get_ry_home() / "lib";
         if (fs::is_directory(ry_home_lib / "std")) {
@@ -27,7 +83,7 @@ fs::path find_lib_dir(const std::string &exe_path, bool skip_global) {
         }
     }
 
-    // 2. exe/../lib (installed layout)
+    // 3. exe/../lib (installed layout)
     std::error_code ec;
     fs::path exe_dir = fs::path(exe_path).parent_path();
     exe_dir = fs::canonical(exe_dir, ec);
@@ -37,7 +93,7 @@ fs::path find_lib_dir(const std::string &exe_path, bool skip_global) {
             return parent_lib;
         }
 
-        // 3. exe/lib (development layout)
+        // 4. exe/lib (development layout)
         fs::path sibling_lib = exe_dir / "lib";
         if (fs::is_directory(sibling_lib / "std")) {
             return sibling_lib;
@@ -45,6 +101,10 @@ fs::path find_lib_dir(const std::string &exe_path, bool skip_global) {
     }
 
     return {};
+}
+
+fs::path find_lib_dir(const std::string &exe_path, bool skip_global) {
+    return find_lib_dir(exe_path, "", skip_global);
 }
 
 StdlibManifest read_manifest(const fs::path &dir) {

--- a/src/project_config.cpp
+++ b/src/project_config.cpp
@@ -66,6 +66,13 @@ ProjectConfig ProjectConfigParser::load(const std::string &toml_content) {
     config.version  = sections["project"]["version"];
     config.entry    = sections["project"]["entry"];
     config.src_dir  = sections["paths"]["src"];
+    auto paths = sections.find("paths");
+    if (paths != sections.end()) {
+        auto it = paths->second.find("_dev_stdlib");
+        if (it != paths->second.end()) {
+            config.dev_stdlib_dir = it->second;
+        }
+    }
     return config;
 }
 

--- a/tests/test_builtin_stdlib_registry.cpp
+++ b/tests/test_builtin_stdlib_registry.cpp
@@ -1,0 +1,41 @@
+#include <gtest/gtest.h>
+#include "ry/builtin_stdlib_registry.hpp"
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+namespace fs = std::filesystem;
+
+namespace {
+
+fs::path repo_root() {
+    return fs::path(__FILE__).parent_path().parent_path();
+}
+
+std::string read_text(const fs::path &path) {
+    std::ifstream file(path);
+    std::ostringstream out;
+    out << file.rdbuf();
+    return out.str();
+}
+
+} // namespace
+
+TEST(BuiltinStdlibRegistry, DeclarationFilesExist) {
+#define RY_EXPECT_DECL_EXISTS(pkg, decl, method) \
+    EXPECT_TRUE(fs::exists(repo_root() / decl)) << decl;
+    RY_BUILTIN_STDLIB_PACKAGES(RY_EXPECT_DECL_EXISTS)
+#undef RY_EXPECT_DECL_EXISTS
+}
+
+TEST(BuiltinStdlibRegistry, NativeConstantsAreDeclaredInStdlib) {
+#define RY_EXPECT_CONST_DECL(pkg, name, kind, value)                                      \
+    do {                                                                                  \
+        const fs::path decl_path = repo_root() / "lib/std/" #pkg "/" #pkg ".ry";         \
+        const std::string content = read_text(decl_path);                                 \
+        EXPECT_NE(content.find("@const\n" #name ":"), std::string::npos) << decl_path;   \
+    } while (false);
+    RY_BUILTIN_STDLIB_CONSTANTS(RY_EXPECT_CONST_DECL)
+#undef RY_EXPECT_CONST_DECL
+}

--- a/tests/test_paths.cpp
+++ b/tests/test_paths.cpp
@@ -106,6 +106,98 @@ TEST(Paths, FindLibDirSkipGlobal) {
     fs::remove_all(exe);
 }
 
+TEST(Paths, FindLibDirPrefersProjectOverrideForRepoBuild) {
+    char home_dir[] = "/tmp/ry-home-override-XXXXXX";
+    ASSERT_NE(mkdtemp(home_dir), nullptr);
+    std::string home(home_dir);
+    fs::create_directories(home + "/lib/std");
+    std::ofstream(home + "/lib/std/builtins.ry") << "fn noop():\n    return\n";
+
+    char project_dir[] = "/tmp/ry-project-XXXXXX";
+    ASSERT_NE(mkdtemp(project_dir), nullptr);
+    std::string project(project_dir);
+    fs::create_directories(project + "/build");
+    fs::create_directories(project + "/lib/std");
+    std::ofstream(project + "/lib/std/builtins.ry") << "fn noop():\n    return\n";
+    std::ofstream(project + "/package.toml") << R"(
+[project]
+name = "ry"
+version = "0.1.0"
+entry = "src/main.ry"
+
+[paths]
+src = "src"
+_dev_stdlib = "lib"
+)";
+
+    ScopedEnv guard("RY_HOME", home_dir);
+
+    auto result = ry::find_lib_dir(project + "/build/ry", project, false);
+    EXPECT_EQ(result, fs::canonical(project + "/lib"));
+
+    fs::remove_all(home);
+    fs::remove_all(project);
+}
+
+TEST(Paths, FindLibDirIgnoresProjectOverrideForInstalledBinary) {
+    char home_dir[] = "/tmp/ry-home-installed-XXXXXX";
+    ASSERT_NE(mkdtemp(home_dir), nullptr);
+    std::string home(home_dir);
+    fs::create_directories(home + "/lib/std");
+    std::ofstream(home + "/lib/std/builtins.ry") << "fn noop():\n    return\n";
+
+    char project_dir[] = "/tmp/ry-project-installed-XXXXXX";
+    ASSERT_NE(mkdtemp(project_dir), nullptr);
+    std::string project(project_dir);
+    fs::create_directories(project + "/lib/std");
+    std::ofstream(project + "/lib/std/builtins.ry") << "fn noop():\n    return\n";
+    std::ofstream(project + "/package.toml") << R"(
+[project]
+name = "ry"
+version = "0.1.0"
+entry = "src/main.ry"
+
+[paths]
+src = "src"
+_dev_stdlib = "lib"
+)";
+
+    char install_dir[] = "/tmp/ry-install-XXXXXX";
+    ASSERT_NE(mkdtemp(install_dir), nullptr);
+    std::string install(install_dir);
+    fs::create_directories(install + "/bin");
+
+    ScopedEnv guard("RY_HOME", home_dir);
+
+    auto result = ry::find_lib_dir(install + "/bin/ry", project, false);
+    EXPECT_EQ(result, fs::path(home) / "lib");
+
+    fs::remove_all(home);
+    fs::remove_all(project);
+    fs::remove_all(install);
+}
+
+TEST(Paths, FindLibDirRejectsInvalidProjectOverride) {
+    char project_dir[] = "/tmp/ry-project-invalid-XXXXXX";
+    ASSERT_NE(mkdtemp(project_dir), nullptr);
+    std::string project(project_dir);
+    fs::create_directories(project + "/build");
+    std::ofstream(project + "/package.toml") << R"(
+[project]
+name = "ry"
+version = "0.1.0"
+entry = "src/main.ry"
+
+[paths]
+src = "src"
+_dev_stdlib = "../lib"
+)";
+
+    EXPECT_THROW(ry::find_lib_dir(project + "/build/ry", project, false), std::runtime_error);
+
+    fs::remove_all(project);
+}
+
 TEST(Paths, ManifestReadWrite) {
     char tmp_dir[] = "/tmp/ry-manifest-XXXXXX";
     ASSERT_NE(mkdtemp(tmp_dir), nullptr);

--- a/tests/test_project_config.cpp
+++ b/tests/test_project_config.cpp
@@ -53,6 +53,7 @@ TEST(ProjectConfigParser, SerializeRoundTrip) {
     original.version = "2.0.0";
     original.entry = "src/main.ry";
     original.src_dir = "src";
+    original.dev_stdlib_dir = "lib";
 
     std::string toml = ProjectConfigParser::serialize(original);
     auto loaded = ProjectConfigParser::load(toml);
@@ -61,6 +62,23 @@ TEST(ProjectConfigParser, SerializeRoundTrip) {
     EXPECT_EQ(loaded.version, original.version);
     EXPECT_EQ(loaded.entry, original.entry);
     EXPECT_EQ(loaded.src_dir, original.src_dir);
+    EXPECT_FALSE(loaded.dev_stdlib_dir.has_value());
+}
+
+TEST(ProjectConfigParser, LoadHiddenDevStdlibOverride) {
+    std::string toml = R"(
+[project]
+name = "ry"
+version = "0.1.0"
+entry = "src/main.ry"
+
+[paths]
+src = "src"
+_dev_stdlib = "lib"
+)";
+    auto config = ProjectConfigParser::load(toml);
+    ASSERT_TRUE(config.dev_stdlib_dir.has_value());
+    EXPECT_EQ(*config.dev_stdlib_dir, "lib");
 }
 
 TEST(ProjectConfigParser, LoadInvalidLine) {


### PR DESCRIPTION
## Summary

This changes stdlib resolution for repo-built `ry` binaries so they use the checked-out stdlib instead of accidentally picking up a stale `~/.ry/lib/std`.

It also centralizes built-in stdlib package and native constant registration and updates the developer guidance to match the new workflow.

## Root cause

Issues #367 and #370 were both caused by the same path resolution problem:

- repo-built binaries still preferred `$RY_HOME/lib`
- in a language-development environment, `$RY_HOME/lib/std` can be older than the checked-out source tree
- that made `base64`, `json`, and the `net` timeout APIs appear missing even though the current checkout already defined them

## What changed

- repo-built `ry` now checks the hidden `package.toml` setting `[paths]._dev_stdlib` and uses that repo-local stdlib first
- installed `ry` binaries continue to use `~/.ry/lib/std`
- invalid `_dev_stdlib` values fail fast instead of silently falling back
- built-in stdlib package and constant registration now come from a shared central registry
- AGENTS / CLAUDE / package docs now describe the repo-build vs install-build behavior

## Validation

Passed:
- `./build-current/ry_tests --gtest_filter='ProjectConfigParser.*:Paths.*:BuiltinStdlibRegistry.*'`
- `./build-current/ry test tests/spec/base64.test.ry`
- `./build-current/ry test tests/spec/json.test.ry`
- `./build-current/ry <<'RY' ... from net import bind, set_timeout, set_recv_timeout, set_send_timeout ... RY`
- `./build-current/ry test -p` no longer fails on `base64` / `json` / `set_timeout` import resolution

Known unrelated failures remain:
- TCP/HTTP runtime failures tracked separately in #369
