### PR TITLE
docs: align README and reference examples with v0.0.5 language surface (#368)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ c = Color::Red
 print(c)               # Red
 
 # Package import
-from math import add
-print(add(1, 2))
+from math import sqrt, PI
+print(sqrt(PI))
 ```
 
 ## Installation

--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -25,7 +25,7 @@ from http import http_listen, http_method, http_path, http_header, http_body, ht
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `http_listen` | `(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse) -> Unit` | Starts an HTTP server on the given address. Blocks in an accept loop, calling `handler` for each request. |
-| `http_listen` | `(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse, max_requests: int) -> Unit` | Starts an HTTP server that stops after processing `max_requests` requests. Enables `spawn` + `join` lifecycle management. |
+| `http_listen` | `(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse, max_requests: int) -> Unit` | Starts an HTTP server that stops after processing `max_requests` requests. Enables `async fn` + `block_on()` lifecycle management. |
 | `http_listen` | `(host: str, port: int, handler: fn(HttpRequest) -> HttpResponse, max_requests: int, port_callback: fn(int) -> Unit) -> Unit` | Same as above, but calls `port_callback` with the actual bound port after `bind` + `listen` succeeds. Use with port `0` for OS-assigned ephemeral ports. |
 
 ### Request Accessors
@@ -112,7 +112,7 @@ match http_get("http://127.0.0.1:" + to_str(port) + "/"):
     case Err(e):
         print("error")
 
-result = join(t)  # Server exits after 1 request; join completes
+result = block_on(t)  # Server exits after 1 request; block_on completes
 ```
 
 ### Reading Query Parameters
@@ -183,7 +183,7 @@ http_listen("127.0.0.1", 8080, fn(req: HttpRequest) -> HttpResponse:
 
 - `http_listen()` binds to the address, starts listening, and enters an accept loop.
 - When called with 3 arguments, the accept loop runs indefinitely.
-- When called with 4 arguments (`max_requests`), the server stops after processing the specified number of requests. `max_requests` must be a positive integer. This enables `spawn` + `join` lifecycle management. Malformed requests (silently skipped) do not count toward the limit.
+- When called with 4 arguments (`max_requests`), the server stops after processing the specified number of requests. `max_requests` must be a positive integer. This enables `async fn` + `block_on()` lifecycle management. Malformed requests (silently skipped) do not count toward the limit.
 - When called with 5 arguments (`max_requests`, `port_callback`), `port_callback` is called synchronously with the actual bound port after `bind` + `listen` succeeds. This allows safe use of port `0` (OS-assigned ephemeral port) to avoid port conflicts in parallel tests.
 - The server supports HTTP/1.1 keep-alive by default. Multiple requests can be processed on a single connection. The server checks the `Connection` header on each request: if `Connection: close` is sent, the connection is closed after the response; otherwise the connection stays open for subsequent requests. Idle connections are closed after a 5-second timeout.
 - `Content-Length` is automatically added to the response if not provided in the headers map.

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -102,38 +102,42 @@ match connect("127.0.0.1", 8080):
         print("connect failed")
 ```
 
-### Concurrent Echo Server with `spawn`
+### Concurrent Echo Server with `async fn`
 
 ```python
-fn echo_server(port: int) -> str:
-    match bind("127.0.0.1", port):
-        case Ok(server):
-            match listen(server, 1):
-                case Ok(_):
-                    match accept(server):
-                        case Ok(conn):
-                            match recv(conn, 4096):
-                                case Ok(data):
-                                    match send(conn, data):
-                                        case Ok(_):
-                                            ...
-                                        case Err(e):
-                                            ...
-                                case Err(e):
-                                    ...
-                            close(conn)
+from net import bind, listen, accept, connect, listener_port
+from io import str_to_bytes, bytes_to_str
+
+async fn echo_server(server: TcpListener) -> str:
+    match accept(server):
+        case Ok(conn):
+            match recv(conn, 4096):
+                case Ok(data):
+                    match send(conn, data):
+                        case Ok(_):
+                            ...
                         case Err(e):
                             ...
                 case Err(e):
                     ...
-            close(server)
+            close(conn)
         case Err(e):
             ...
+    close(server)
     return "done"
 
-t: Task<str> = spawn echo_server(8080)
-# ... client code ...
-join(t)
+match bind("127.0.0.1", 0):
+    case Ok(server):
+        match listen(server, 1):
+            case Ok(_):
+                port = listener_port(server)
+                t = echo_server(server)
+                # ... client code using port ...
+                block_on(t)
+            case Err(e):
+                ...
+    case Err(e):
+        ...
 ```
 
 ## Timeout Configuration

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -23,7 +23,7 @@ Imports all functions and types from the package.
 ### Selective Import
 
 ```python
-from math import add
+from math import sqrt
 ```
 
 Imports only the specified definition.
@@ -31,7 +31,7 @@ Imports only the specified definition.
 ### Multiple Selective Import
 
 ```python
-from math import add, sub
+from math import sqrt, PI
 ```
 
 Imports multiple definitions separated by commas.
@@ -79,7 +79,7 @@ fn public_api() -> int:  # public — importable
 
 ```
 mypackage/
-  math.ry      # fn add(), fn sub()
+  calc.ry      # fn add(), fn sub()
   string.ry    # fn concat()
 ```
 
@@ -207,7 +207,7 @@ from math   # Skipped
 ### Single File Package
 
 ```python
-# math.ry
+# calc.ry
 fn add(a: int, b: int) -> int:
     return a + b
 
@@ -217,7 +217,7 @@ fn sub(a: int, b: int) -> int:
 
 ```python
 # main.ry
-from math import add, sub
+from calc import add, sub
 
 print(add(1, 2))   # 3
 print(sub(5, 3))   # 2
@@ -227,7 +227,7 @@ print(sub(5, 3))   # 2
 
 ```
 mylib/
-  math.ry
+  calc.ry
   string.ry
 ```
 

--- a/docs/tutorial/08-advanced.md
+++ b/docs/tutorial/08-advanced.md
@@ -218,40 +218,60 @@ for i in range(8):
 
 ## Networking (TCP Sockets)
 
-Ry provides TCP socket support through the `net` module. The `send`, `recv`, and `close` functions work with TCP sockets.
+Ry provides TCP socket support through the `net` module. The `send`, `recv`, and `close` functions work with TCP sockets. All network operations return `Result` types.
 
 ```python
-from net import bind, listen, accept, connect
+from net import bind, listen, accept, connect, listener_port
 from io import str_to_bytes, bytes_to_str
 
-fn echo_server(port: int) -> str:
-    match bind("127.0.0.1", port):
-        case Some(server):
-            listen(server, 1)
-            match accept(server):
-                case Some(conn):
-                    data: List<u8> = recv(conn, 4096)
-                    send(conn, data)
-                    close(conn)
-                case None:
+async fn echo_server(server: TcpListener) -> str:
+    match accept(server):
+        case Ok(conn):
+            match recv(conn, 4096):
+                case Ok(data):
+                    match send(conn, data):
+                        case Ok(_):
+                            ...
+                        case Err(e):
+                            ...
+                case Err(e):
                     ...
-            close(server)
-        case None:
+            close(conn)
+        case Err(e):
             ...
+    close(server)
     return "done"
 
-t: Task<str> = spawn echo_server(8080)
-
-match connect("127.0.0.1", 8080):
-    case Some(conn):
-        send(conn, str_to_bytes("hello"))
-        resp: List<u8> = recv(conn, 4096)
-        print(bytes_to_str(resp))   # hello
-        close(conn)
-    case None:
-        print("connect failed")
-
-join(t)
+match bind("127.0.0.1", 0):
+    case Ok(server):
+        match listen(server, 1):
+            case Ok(_):
+                port = listener_port(server)
+                t = echo_server(server)
+                match connect("127.0.0.1", port):
+                    case Ok(conn):
+                        match send(conn, str_to_bytes("hello")):
+                            case Ok(_):
+                                ...
+                            case Err(e):
+                                ...
+                        match recv(conn, 4096):
+                            case Ok(resp):
+                                match bytes_to_str(resp):
+                                    case Ok(s):
+                                        print(s)   # hello
+                                    case Err(e):
+                                        ...
+                            case Err(e):
+                                ...
+                        close(conn)
+                    case Err(e):
+                        print("connect failed")
+                block_on(t)
+            case Err(e):
+                ...
+    case Err(e):
+        print("bind failed")
 ```
 
 See [Network Reference](../reference/net.md) for the full API.

--- a/docs/tutorial/09-modules.md
+++ b/docs/tutorial/09-modules.md
@@ -13,7 +13,7 @@ Ry uses a package system to organize code across files and directories. For the 
 Use the `from` syntax to import functions from another file.
 
 ```python
-from math import add, sub   # Selective import
+from math import sqrt, PI   # Selective import
 from math                    # Full import (all definitions)
 ```
 
@@ -26,7 +26,7 @@ This makes functions defined in `math.ry` available for use.
 Use dot-separated paths to specify packages in subdirectories.
 
 ```python
-from utils.math import add   # Import from utils/math.ry
+from utils.calc import add   # Import from utils/calc.ry
 ```
 
 Each dot corresponds to a directory separator.
@@ -39,7 +39,7 @@ A package can be either a single `.ry` file or a directory containing multiple `
 
 ```
 mypackage/
-  math.ry      # fn add(), fn sub()
+  calc.ry      # fn add(), fn sub()
   string.ry    # fn concat()
 ```
 


### PR DESCRIPTION
## Summary

- Replace removed `spawn`/`join(task)` with `async fn`/`block_on()` in net.md, http.md, 08-advanced.md
- Replace nonexistent `math.add`/`math.sub` with real stdlib functions (`sqrt`, `PI`) in README.md, packages.md, 09-modules.md
- Rename user-defined package examples from `math.ry` to `calc.ry` to avoid confusion with stdlib
- Update TCP networking tutorial to use Result types (`Ok`/`Err`) instead of obsolete `Some`/`None`

Closes #368

## Test plan

- [x] All 1098 C++ tests pass
- [x] All 44 Ry self-test files pass
- [x] `grep` confirms no remaining `spawn`/`join(t)`/`from math import add` in English docs