### PR TITLE
docs: add missing CLI overview, !! operator, and Result matchers

### DIFF
--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -8,7 +8,7 @@ Lower numbers indicate higher precedence (evaluated first).
 
 | Precedence | Operator | Description | Associativity |
 |---|---|---|---|
-| 0 | `?` | Error propagation (postfix) | Left |
+| 0 | `?` `!!` | Error propagation (postfix) | Left |
 | 1 | `()` | Grouping | -- |
 | 2 | `+x` `-x` `~x` | Unary plus, unary minus, bitwise NOT | Right |
 | 3 | `**` | Exponentiation | Right |
@@ -113,9 +113,11 @@ masked = flags & 0b0011   # 3
 shifted = 1 << 8          # 256
 ```
 
-## Error Propagation Operator (`?`)
+## Error Propagation Operator (`?` / `!!`)
 
 The postfix `?` operator unwraps a `Result` value. If the value is `Ok(v)`, it evaluates to `v`. If the value is `Err(e)`, the enclosing function immediately returns `Err(e)`.
+
+The `!!` operator is an alias for `?` with identical semantics. Both can be used interchangeably.
 
 The enclosing function must have a `Result` return type.
 
@@ -127,7 +129,7 @@ fn safe_divide(a: int, b: int) -> Result<int, Error>:
 
 fn compute(a: int, b: int, c: int) -> Result<int, Error>:
     x = safe_divide(a, b)?    # returns Err early if b == 0
-    y = safe_divide(x, c)?    # returns Err early if c == 0
+    y = safe_divide(x, c)!!
     return Ok(y + 1)
 ```
 

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -2,6 +2,36 @@
 
 # Project Management
 
+## CLI Overview
+
+```bash
+ry <file.ry> [args...]              # Run a Ry script
+echo '<code>' | ry                  # Run code from stdin
+ry test [options] [<file> | <dir>]  # Run tests
+ry init                             # Initialize a project
+ry new <project-name>               # Create a new project
+ry fmt [options] [<file> | <dir>]   # Format source files
+ry self-update [options]            # Update ry itself
+```
+
+### Global Options
+
+| Option | Description |
+|---|---|
+| `-h`, `--help` | Show help |
+| `-v`, `--version` | Show version |
+| `--env=<env>` | Set environment (`production`\|`development`\|`internal`). Overrides the `RY_ENV` environment variable. |
+
+### Stdin Execution
+
+When no file argument is given and stdin is not a terminal, `ry` reads source code from stdin and executes it:
+
+```bash
+echo 'print("hello")' | ry
+```
+
+---
+
 ## `ry init` - Project Initialization
 
 Initializes the current directory as a Ry project.
@@ -88,6 +118,36 @@ ry fmt --check src/        # Check specific directory
 - Does not require LLVM initialization (fast startup)
 - Compound assignment operators (`+=`, `-=`, etc.) are represented in their desugared form (`x = x + expr`) after formatting, because the parser desugars them during parsing
 - Hex (`0xFF`) and binary (`0b1010`) number literals are converted to decimal notation
+
+---
+
+## `ry test` - Run Tests
+
+Discovers and runs test files (`*.test.ry`). See [Testing](testing.md) for full test syntax documentation.
+
+```bash
+ry test                        # Auto-discover and run all *.test.ry files
+ry test tests/spec             # Run all tests under a directory
+ry test test_file.ry           # Run a specific test file
+ry test -p                     # Run tests in parallel
+ry test -w                     # Watch mode: re-run on file change
+ry test --coverage             # Collect line coverage information
+```
+
+### Options
+
+| Option | Description |
+|---|---|
+| `-p`, `--parallel` | Run tests in parallel |
+| `-w`, `--watch` | Watch for changes and re-run |
+| `--coverage`, `--cov` | Collect coverage information |
+| `-h`, `--help` | Show help |
+
+### Behavior
+
+1. Without arguments, searches for `package.toml` to find the project root and recursively discovers `*.test.ry` files (skipping `.git`, `build`, `node_modules`)
+2. Exit code is 0 if all tests passed, 1 if any failed
+3. `--coverage` with `--parallel` falls back to sequential execution
 
 ---
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -75,6 +75,8 @@ foo("arg", fn():
 | `to_be_false()` | Asserts `false` | bool |
 | `to_be_none()` | Asserts `None` | Option |
 | `to_be_some()` | Asserts Option is `Some` | Option |
+| `to_be_ok()` | Asserts Result is `Ok` | Result |
+| `to_be_err()` | Asserts Result is `Err` | Result |
 | `to_contain(val)` | Asserts container includes value | List, Set, Map, str |
 | `to_not_contain(val)` | Asserts container does not include value | List, Set, Map, str |
 | `to_be_greater_than(v)` | Asserts `actual > v` | int, float |


### PR DESCRIPTION
## Summary
- **project.md**: Add CLI Overview section with global options (`--env=<env>`, `-h`, `-v`), stdin execution (`echo '<code>' | ry`), and `ry test` command reference with all options (`-p`, `-w`, `--coverage`)
- **operators.md**: Document `!!` as an alias for the `?` error propagation operator in both the precedence table and detailed section
- **testing.md**: Add `to_be_ok()` and `to_be_err()` matchers to the expect matcher table

## Test plan
- [ ] Verify CLI Overview matches `ry --help` output
- [ ] Verify `ry test` options match `ry test --help` output
- [ ] Verify `!!` operator documentation matches parser implementation
- [ ] Verify `to_be_ok()`/`to_be_err()` matchers match codegen implementation