### PR TITLE
fix: treat `version` as alias for `--version` in CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `ry version` now works as an alias for `ry --version` instead of trying to execute the VERSION file on case-insensitive filesystems (#381)
+
 ## [0.0.5] - 2026-03-28
 
 ### Added

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -615,7 +615,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
-    if (argc == 2 && (std::strcmp(argv[1], "--version") == 0 || std::strcmp(argv[1], "-v") == 0)) {
+    if (argc == 2 && (std::strcmp(argv[1], "--version") == 0 || std::strcmp(argv[1], "-v") == 0 || std::strcmp(argv[1], "version") == 0)) {
         llvm::outs() << "ry " << RY_VERSION << "\n";
         return 0;
     }


### PR DESCRIPTION
## Summary

- Add `"version"` as an alias for `--version`/`-v` in CLI argument handling
- Fixes case-insensitive filesystem issue where `ry version` matched the `VERSION` file and tried to execute it as a Ry script

Closes #381

## Test plan

- [x] `ry version` outputs version string (verified: `ry 0.0.5`)
- [x] `ry --version` and `ry -v` still work as before
- [x] C++ tests pass (1113 tests)
- [x] Ry self-tests pass (45 test files)