### PR TITLE
fix: restore nightly build schedule with missing dependencies (#380)

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,13 +1,131 @@
 name: Dev Release
 on:
+  schedule:
+    - cron: '0 0 * * *'
   workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
+  # スケジュール実行: v* ブランチを自動検出
+  discover:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.find.outputs.branches }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: find
+        run: |
+          branches=$(git branch -r --list 'origin/v[0-9]*' \
+            | sed 's| *origin/||' \
+            | jq -Rsc 'split("\n") | map(select(. != ""))')
+          echo "branches=$branches" >> "$GITHUB_OUTPUT"
+
+  # アクティブブランチに対応しない古い nightly プレリリースを削除
+  cleanup-stale-nightlies:
+    needs: discover
+    if: github.event_name == 'schedule' && needs.discover.outputs.branches != '[]'
+    continue-on-error: true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Delete stale nightly releases
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ACTIVE_BRANCHES: ${{ needs.discover.outputs.branches }}
+        run: |
+          gh release list --limit 1000 --json tagName,isPrerelease -q \
+            '.[] | select(.isPrerelease and (.tagName | endswith("-nightly"))) | .tagName' \
+            | while read -r tag; do
+                branch="${tag%-nightly}"
+                if ! echo "$ACTIVE_BRANCHES" | jq -e --arg b "$branch" 'index($b) != null' > /dev/null 2>&1; then
+                  echo "Deleting stale nightly release: $tag"
+                  gh release delete "$tag" --yes --cleanup-tag || true
+                fi
+              done
+
+  nightly:
+    needs: [discover, cleanup-stale-nightlies]
+    if: github.event_name == 'schedule' && needs.discover.outputs.branches != '[]'
+    runs-on: macos-14
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        branch: ${{ fromJSON(needs.discover.outputs.branches) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Cache LLVM 21
+        id: cache-llvm
+        uses: actions/cache@v4
+        with:
+          path: |
+            /opt/homebrew/opt/llvm@21
+            /opt/homebrew/Cellar/llvm@21
+          key: llvm-21-macos-arm64
+      - name: Install LLVM 21
+        if: steps.cache-llvm.outputs.cache-hit != 'true'
+        run: brew install llvm@21
+      - name: Install dependencies
+        run: brew install openssl@3 ninja googletest
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: dev-release-macos-${{ matrix.branch }}
+          restore-keys: |
+            dev-release-macos-
+      - name: Set version
+        id: version
+        run: echo "version=${{ matrix.branch }}-nightly" >> "$GITHUB_OUTPUT"
+      - name: Build
+        run: |
+          cmake -B build -G Ninja \
+            -DLLVM_DIR="$(brew --prefix llvm@21)/lib/cmake/llvm" \
+            -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DRY_VERSION="${{ steps.version.outputs.version }}"
+          cmake --build build
+      - name: Test
+        run: ./build/ry_tests
+      - name: Package
+        run: |
+          mkdir -p dist
+          cp build/ry dist/ry
+          cd dist
+          tar czf ry-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz ry
+          shasum -a 256 ry-*.tar.gz > checksums.txt
+      - name: Cleanup old prereleases
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          BRANCH="${{ matrix.branch }}"
+          gh release list --json tagName,isPrerelease -q \
+            ".[] | select(.isPrerelease and (.tagName | startswith(\"${BRANCH}-\"))) | .tagName" \
+            | while read -r tag; do
+                echo "Deleting old release: $tag"
+                gh release delete "$tag" --yes --cleanup-tag || true
+              done
+      - name: Create Pre-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${{ steps.version.outputs.version }}" \
+            --title "${{ steps.version.outputs.version }}" \
+            --notes "Nightly build from branch ${{ matrix.branch }}" \
+            --prerelease \
+            dist/ry-*.tar.gz dist/checksums.txt
+
   # 手動実行: 現在のブランチでビルド
   manual:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: macos-14
     permissions:
       contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - `ry version` now works as an alias for `ry --version` instead of trying to execute the VERSION file on case-insensitive filesystems (#381)
+- Dev Release nightly build fails due to missing dependencies (`openssl@3`, `ninja`, `googletest`) and removed schedule trigger (#380)
 
 ## [0.0.5] - 2026-03-28
 


### PR DESCRIPTION
## Summary

- Re-add the `schedule` trigger (daily at UTC 0:00) and nightly jobs (`discover`, `cleanup-stale-nightlies`, `nightly`) removed in f8646c4
- Add missing dependency installation (`openssl@3`, `ninja`, `googletest`) to the `nightly` job
- Upgrade `nightly` job to match `manual` job optimizations: LLVM caching, ccache, Ninja build, OpenSSL root dir
- Add `if: github.event_name == 'workflow_dispatch'` guard to `manual` job

Closes #380

## Test plan

- [ ] Verify YAML syntax is valid
- [ ] Trigger a manual dev release via `workflow_dispatch` to confirm the `manual` job still works
- [ ] Wait for the next scheduled nightly run (or trigger manually) and confirm all `v*` branches build successfully