### PR TITLE
fix: remove ineffective LLVM cache from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache LLVM 21
-        id: cache-llvm
-        uses: actions/cache@v4
-        with:
-          path: /usr/lib/llvm-21
-          key: llvm-21-ubuntu-${{ runner.os }}
       - name: Install LLVM 21
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -45,14 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache LLVM 21
-        id: cache-llvm
-        uses: actions/cache@v4
-        with:
-          path: /usr/lib/llvm-21
-          key: llvm-21-ubuntu-${{ runner.os }}
       - name: Install LLVM 21
-        if: steps.cache-llvm.outputs.cache-hit != 'true'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -85,15 +85,8 @@ jobs:
     # to build your code.
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Cache LLVM 21
-      if: matrix.language == 'c-cpp'
-      id: cache-llvm
-      uses: actions/cache@v4
-      with:
-        path: /usr/lib/llvm-21
-        key: llvm-21-ubuntu-${{ runner.os }}
     - name: Install LLVM 21
-      if: matrix.language == 'c-cpp' && steps.cache-llvm.outputs.cache-hit != 'true'
+      if: matrix.language == 'c-cpp'
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,15 +45,8 @@ jobs:
         run: brew install openssl@3 ninja googletest
 
       # --- LLVM 21: Linux (APT) ---
-      - name: Cache LLVM 21 (apt)
-        if: matrix.llvm_install == 'apt'
-        id: cache-llvm-apt
-        uses: actions/cache@v4
-        with:
-          path: /usr/lib/llvm-21
-          key: llvm-21-${{ matrix.target }}
       - name: Install LLVM 21 (apt)
-        if: matrix.llvm_install == 'apt' && steps.cache-llvm-apt.outputs.cache-hit != 'true'
+        if: matrix.llvm_install == 'apt'
         run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh


### PR DESCRIPTION
## Summary

- Remove `actions/cache` steps for `/usr/lib/llvm-21` from `ci.yml`, `codeql.yml`, and `release.yml`
- The cached directory is root-owned on GitHub-hosted runners, so cache restore/save silently failed
- LLVM is now always installed via apt; macOS (brew) cache is unaffected (user-owned directory)

Closes #403

## Test plan

- [ ] CI `test` job passes without LLVM cache
- [ ] CI `asan` job passes without LLVM cache