### PR TITLE
docs: fix tutorial accuracy — output examples, install method, record terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed float output examples in operator tutorial to match actual `%g` formatting (e.g. `1024` not `1024.0`)
+- Added curl one-liner installer to Getting Started tutorial
+- Fixed "struct" terminology to "record" across tutorial and reference docs
 - Improved error message when hyphens are used in import paths (e.g. `from my-pkg import foo` now suggests using underscores)
 - Binary operations between `str` and non-`str` types (e.g. `"abc" - 2`, `"abc" / 2`) now raise compile-time type errors instead of producing garbage output or LLVM IR verification errors (#396)
 - `ry version` now works as an alias for `ry --version` instead of trying to execute the VERSION file on case-insensitive filesystems (#381)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **Rich Type System** — `int`, `float`, `bool`, `str`, `Option<T>`, `Error`, tuples, `List<T>`, `Map<K,V>`, `Set<T>`, `enum`, function types, user-defined structs
 - **Operators** — Arithmetic, comparison, logical, bitwise (`>>>` logical right shift), compound assignment, `in` / `not in`, string repetition (`"ab" * 3`), `as` type cast, with operator overloading support
 - **F-String** — String interpolation with `f"Hello {name}"`
-- **Design by Contract** — `require` (preconditions), `ensure` (postconditions), `invariant` (struct invariants), `old()`, `result`
+- **Design by Contract** — `require` (preconditions), `ensure` (postconditions), `invariant` (record invariants), `old()`, `result`
 - **Directives** — `@deprecated` compile-time metadata annotations
 - **Functions** — `fn` definitions, recursion, overloading, lambdas (closures), higher-order functions, UFCS
 - **Control Flow** — `if`/`elif`/`else`, `while`, `for...in`, `break`/`continue`

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ If you are new to Ry, please read through these in order.
 | 03 | [Operators](tutorial/03-operators.md) | Arithmetic, comparison, logical, bitwise, compound assignment operators |
 | 04 | [Control Flow](tutorial/04-control-flow.md) | if/elif/else, while, for/range, break/continue |
 | 05 | [Functions](tutorial/05-functions.md) | fn definitions, recursion, overloading, lambdas, UFCS |
-| 06 | [Structs and Enums](tutorial/06-structs.md) | type definitions, field access, methods, enum |
+| 06 | [Records and Enums](tutorial/06-records.md) | type definitions, field access, methods, enum |
 | 07 | [Collections](tutorial/07-collections.md) | Tuples, lists, maps, sets |
 | 08 | [Advanced Features](tutorial/08-advanced.md) | Closures, operator overloading, Option type |
 | 09 | [Packages](tutorial/09-modules.md) | Packages, std library, directory packages |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -17,7 +17,7 @@ Ry を初めて使う方はこちらから順番に読み進めてください�
 | 03 | [演算子](tutorial/03-operators.md) | 算術・比較・論理・ビット・複合代入演算子 |
 | 04 | [制御構文](tutorial/04-control-flow.md) | if/elif/else・while・for/range・break/continue |
 | 05 | [関数定義](tutorial/05-functions.md) | fn 定義・再帰・オーバーロード・ラムダ・UFCS |
-| 06 | [構造体と列挙型](tutorial/06-structs.md) | type 定義・フィールドアクセス・メソッド・enum |
+| 06 | [Record と列挙型](tutorial/06-records.md) | type 定義・フィールドアクセス・メソッド・enum |
 | 07 | [コレクション](tutorial/07-collections.md) | タプル・リスト・マップ・セット |
 | 08 | [高度な機能](tutorial/08-advanced.md) | クロージャ・演算子オーバーロード・Option 型 |
 | 09 | [パッケージ](tutorial/09-modules.md) | パッケージ、std ライブラリ、ディレクトリパッケージ |

--- a/docs/ja/tutorial/01-getting-started.md
+++ b/docs/ja/tutorial/01-getting-started.md
@@ -6,26 +6,23 @@
 
 ---
 
-## 必要環境
+## インストール
 
-Ry をビルドして実行するには以下が必要です。
-
-- **LLVM 21**
-- **CMake 3.20 以上**
-- **C++17 対応コンパイラ**（GCC 7+ / Clang 5+ 等）
-
----
-
-## ビルド手順
-
-リポジトリのルートで以下のコマンドを実行します。
+### クイックインストール（macOS Apple Silicon）
 
 ```bash
-cmake -B build -DLLVM_DIR=/usr/local/llvm/lib/cmake/llvm
-cmake --build build
+curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh
 ```
 
-ビルドが成功すると `build/ry` という実行ファイルが生成されます。
+`ry` バイナリが `~/.local/bin` に、標準ライブラリが `~/.ry/lib/std/` にインストールされます。
+
+`~/.local/bin` が `PATH` に含まれていることを確認してください:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+ソースからビルドする場合や他のプラットフォームについては、[README のインストールセクション](../../../README.md#installation)を参照してください。
 
 ---
 
@@ -66,7 +63,7 @@ print("Hello, World!")
 次のコマンドで実行します。
 
 ```bash
-./build/ry hello.ry
+ry hello.ry
 ```
 
 出力:
@@ -78,9 +75,9 @@ Hello, World!
 パイプや Here-document を使って、標準入力からコードを実行することもできます。
 
 ```bash
-echo 'print("Hello, World!")' | ./build/ry
+echo 'print("Hello, World!")' | ry
 
-./build/ry <<'RY'
+ry <<'RY'
 print("Hello, World!")
 RY
 ```

--- a/docs/ja/tutorial/03-operators.md
+++ b/docs/ja/tutorial/03-operators.md
@@ -16,7 +16,7 @@
 | `/` | 除算（常に float） | `7 / 2` | `3.5` |
 | `//` | 整数除算（常に int） | `7 // 2` | `3` |
 | `%` | 剰余 | `7 % 3` | `1` |
-| `**` | 累乗（常に float） | `2 ** 10` | `1024.0` |
+| `**` | 累乗（常に float） | `2 ** 10` | `1024` |
 
 ```python
 a = 10
@@ -28,7 +28,7 @@ print(a * b)    # 30
 print(a / b)    # 3.3333...（float）
 print(a // b)   # 3（int）
 print(a % b)    # 1
-print(2 ** 8)   # 256.0（float）
+print(2 ** 8)   # 256（float）
 ```
 
 ---
@@ -133,7 +133,7 @@ x = 10
 x += 5    # x == 15
 x -= 3    # x == 12
 x *= 2    # x == 24
-x /= 4    # x == 6.0（float になる）
+x /= 4    # x == 6（float になる）
 ```
 
 ---
@@ -165,18 +165,18 @@ count--       # count == 1
 ```python
 # + - * は片方が float なら結果は float
 print(1 + 2)      # 3 (int)
-print(1 + 2.0)    # 3.0 (float)
-print(1.0 + 2)    # 3.0 (float)
+print(1 + 2.0)    # 3 (float)
+print(1.0 + 2)    # 3 (float)
 
 # / は常に float
-print(4 / 2)      # 2.0 (float)
+print(4 / 2)      # 2 (float)
 
 # // は常に int
 print(7 // 2)     # 3 (int)
 print(7.0 // 2)   # 3 (int)
 
 # ** は常に float
-print(2 ** 3)     # 8.0 (float)
+print(2 ** 3)     # 8 (float)
 
 # % は両辺 int なら int、片方 float なら float
 print(7 % 3)      # 1 (int)

--- a/docs/ja/tutorial/05-functions.md
+++ b/docs/ja/tutorial/05-functions.md
@@ -2,7 +2,7 @@
 
 # 関数
 
-[← 前: 制御構文](04-control-flow.md) | [次: 構造体 →](06-structs.md)
+[← 前: 制御構文](04-control-flow.md) | [次: Record →](06-records.md)
 
 ---
 
@@ -87,4 +87,4 @@ greet()   # 42
 
 ---
 
-[← 前: 制御構文](04-control-flow.md) | [次: 構造体 →](06-structs.md)
+[← 前: 制御構文](04-control-flow.md) | [次: Record →](06-records.md)

--- a/docs/ja/tutorial/06-records.md
+++ b/docs/ja/tutorial/06-records.md
@@ -1,14 +1,14 @@
-[English](../../tutorial/06-structs.md) | [日本語](06-structs.md) | [繁體中文](../../zh/tutorial/06-structs.md)
+[English](../../tutorial/06-records.md) | [日本語](06-records.md) | [繁體中文](../../zh/tutorial/06-records.md)
 
-# 構造体と列挙型
+# Record と列挙型
 
 [← 前: 関数](05-functions.md) | [次: コレクション →](07-collections.md)
 
 ---
 
-## record による構造体定義
+## Record の定義
 
-`record` キーワードで構造体を定義します。各フィールドは `name: type` の形式で記述します。
+`record` キーワードで record を定義します。各フィールドは `name: type` の形式で記述します。
 
 ```python
 record Point:
@@ -16,13 +16,13 @@ record Point:
     y: int
 ```
 
-構造体はスタック上の値型です。
+Record はスタック上の値型です。
 
 ---
 
-## コンストラクタの使い方
+## インスタンスの生成
 
-構造体名を関数のように呼び出してインスタンスを生成します。引数はフィールドの定義順に指定します。
+record 名を関数のように呼び出してインスタンスを生成します。引数はフィールドの定義順に指定します。
 
 ```python
 p = Point(10, 20)
@@ -40,7 +40,7 @@ print(p.x)   # 10
 print(p.y)   # 20
 ```
 
-> **注意**: `print` に構造体を直接渡すとエラーになります。フィールドを個別に渡してください。
+> **注意**: `print` に record を直接渡すとエラーになります。フィールドを個別に渡してください。
 
 ---
 
@@ -58,9 +58,9 @@ print(p.x)   # 100
 
 ---
 
-## 関数の引数としての構造体
+## 関数の引数としての Record
 
-構造体を関数の引数として渡せます。
+Record を関数の引数として渡せます。
 
 ```python
 record Point:
@@ -77,9 +77,9 @@ print(distance_x(p1, p2))   # 6
 
 ---
 
-## ネスト構造体
+## ネストした Record
 
-構造体のフィールドに別の構造体を使えます。
+Record のフィールドに別の record を使えます。
 
 ```python
 record Point:

--- a/docs/ja/tutorial/07-collections.md
+++ b/docs/ja/tutorial/07-collections.md
@@ -2,7 +2,7 @@
 
 # コレクション
 
-[← 前: 構造体](06-structs.md) | [次: 高度な機能 →](08-advanced.md)
+[← 前: Record](06-records.md) | [次: 高度な機能 →](08-advanced.md)
 
 Ry には4種類のコレクション型があります: **タプル**、**リスト**、**マップ**、**セット**。
 
@@ -399,4 +399,4 @@ for k, v in {"a": 1, "b": 2}.iter():
 
 ---
 
-[← 前: 構造体](06-structs.md) | [次: 高度な機能 →](08-advanced.md)
+[← 前: Record](06-records.md) | [次: 高度な機能 →](08-advanced.md)

--- a/docs/ja/tutorial/10-contracts.md
+++ b/docs/ja/tutorial/10-contracts.md
@@ -4,7 +4,7 @@
 
 [← 前: パッケージ](09-modules.md) | [次: テスト →](11-testing.md)
 
-Ry は Eiffel スタイルの契約による設計をサポートしています。事前条件（`require`）、事後条件（`ensure`）、構造体不変条件（`invariant`）を使ってコードの正しさを保証します。契約違反が発生するとプログラムは終了します。詳細な仕様は[契約による設計リファレンス](../reference/contracts.md)を参照してください。
+Ry は Eiffel スタイルの契約による設計をサポートしています。事前条件（`require`）、事後条件（`ensure`）、record 不変条件（`invariant`）を使ってコードの正しさを保証します。契約違反が発生するとプログラムは終了します。詳細な仕様は[契約による設計リファレンス](../reference/contracts.md)を参照してください。
 
 ---
 
@@ -81,9 +81,9 @@ fn deposit(amount: int, balance: int) -> int:
 
 ---
 
-## 構造体不変条件（`invariant`）
+## Record 不変条件（`invariant`）
 
-`invariant` を使って、構造体に対して常に成り立つ必要がある条件を指定します。不変条件はコンストラクタの実行後とフィールドへの代入後にチェックされます。
+`invariant` を使って、record に対して常に成り立つ必要がある条件を指定します。不変条件は生成後とフィールドへの代入後にチェックされます。
 
 ```python
 record BankAccount:

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -2,7 +2,7 @@
 
 # Design by Contract (DbC)
 
-Ry supports Eiffel-style Design by Contract with preconditions (`require`), postconditions (`ensure`), and struct invariants (`invariant`). Contract violations terminate the process with `exit(1)`.
+Ry supports Eiffel-style Design by Contract with preconditions (`require`), postconditions (`ensure`), and record invariants (`invariant`). Contract violations terminate the process with `exit(1)`.
 
 ---
 
@@ -84,9 +84,9 @@ fn deposit(amount: int, balance: int) -> int:
 
 ---
 
-## Struct Invariants (`invariant`)
+## Record Invariants (`invariant`)
 
-Invariants are conditions that must always hold for a struct instance. They are checked:
+Invariants are conditions that must always hold for a record instance. They are checked:
 - After construction
 - After every field assignment
 

--- a/docs/tutorial/01-getting-started.md
+++ b/docs/tutorial/01-getting-started.md
@@ -6,26 +6,23 @@ Next tutorial -> [02 - Variables and Types](02-variables-and-types.md)
 
 ---
 
-## Prerequisites
+## Installation
 
-To build and run Ry, you need the following:
-
-- **LLVM 21**
-- **CMake 3.20 or later**
-- **A C++17 compatible compiler** (GCC 7+ / Clang 5+, etc.)
-
----
-
-## Build Instructions
-
-Run the following commands from the repository root:
+### Quick Install (macOS Apple Silicon)
 
 ```bash
-cmake -B build -DLLVM_DIR=/usr/local/llvm/lib/cmake/llvm
-cmake --build build
+curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh
 ```
 
-On a successful build, an executable named `build/ry` will be generated.
+This installs the `ry` binary to `~/.local/bin` and the standard library to `~/.ry/lib/std/`.
+
+Make sure `~/.local/bin` is in your `PATH`:
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+To build from source or install on other platforms, see the [Installation section in README](../../../README.md#installation).
 
 ---
 
@@ -66,7 +63,7 @@ print("Hello, World!")
 Run it with the following command:
 
 ```bash
-./build/ry hello.ry
+ry hello.ry
 ```
 
 Output:
@@ -78,9 +75,9 @@ Hello, World!
 You can also run code from stdin using a pipe or here-document:
 
 ```bash
-echo 'print("Hello, World!")' | ./build/ry
+echo 'print("Hello, World!")' | ry
 
-./build/ry <<'RY'
+ry <<'RY'
 print("Hello, World!")
 RY
 ```

--- a/docs/tutorial/03-operators.md
+++ b/docs/tutorial/03-operators.md
@@ -16,7 +16,7 @@
 | `/` | Division (always float) | `7 / 2` | `3.5` |
 | `//` | Integer division (always int) | `7 // 2` | `3` |
 | `%` | Modulo | `7 % 3` | `1` |
-| `**` | Exponentiation (always float) | `2 ** 10` | `1024.0` |
+| `**` | Exponentiation (always float) | `2 ** 10` | `1024` |
 
 ```python
 a = 10
@@ -28,7 +28,7 @@ print(a * b)    # 30
 print(a / b)    # 3.3333... (float)
 print(a // b)   # 3 (int)
 print(a % b)    # 1
-print(2 ** 8)   # 256.0 (float)
+print(2 ** 8)   # 256 (float)
 ```
 
 ---
@@ -133,7 +133,7 @@ x = 10
 x += 5    # x == 15
 x -= 3    # x == 12
 x *= 2    # x == 24
-x /= 4    # x == 6.0 (becomes float)
+x /= 4    # x == 6 (becomes float)
 ```
 
 ---
@@ -165,18 +165,18 @@ The following describes the behavior when `int` and `float` are mixed in operati
 ```python
 # + - * produce float if either operand is float
 print(1 + 2)      # 3 (int)
-print(1 + 2.0)    # 3.0 (float)
-print(1.0 + 2)    # 3.0 (float)
+print(1 + 2.0)    # 3 (float)
+print(1.0 + 2)    # 3 (float)
 
 # / always produces float
-print(4 / 2)      # 2.0 (float)
+print(4 / 2)      # 2 (float)
 
 # // always produces int
 print(7 // 2)     # 3 (int)
 print(7.0 // 2)   # 3 (int)
 
 # ** always produces float
-print(2 ** 3)     # 8.0 (float)
+print(2 ** 3)     # 8 (float)
 
 # % produces int if both operands are int, float if either is float
 print(7 % 3)      # 1 (int)

--- a/docs/tutorial/05-functions.md
+++ b/docs/tutorial/05-functions.md
@@ -2,7 +2,7 @@
 
 # Functions
 
-[<- Prev: Control Flow](04-control-flow.md) | [Next: Structs ->](06-structs.md)
+[<- Prev: Control Flow](04-control-flow.md) | [Next: Records ->](06-records.md)
 
 ---
 
@@ -87,4 +87,4 @@ This is the simplest form of a function with no parameters and no return value.
 
 ---
 
-[<- Prev: Control Flow](04-control-flow.md) | [Next: Structs ->](06-structs.md)
+[<- Prev: Control Flow](04-control-flow.md) | [Next: Records ->](06-records.md)

--- a/docs/tutorial/06-records.md
+++ b/docs/tutorial/06-records.md
@@ -1,14 +1,14 @@
-[English](06-structs.md) | [日本語](../ja/tutorial/06-structs.md) | [繁體中文](../zh/tutorial/06-structs.md)
+[English](06-records.md) | [日本語](../ja/tutorial/06-records.md) | [繁體中文](../zh/tutorial/06-records.md)
 
-# Structs and Enums
+# Records and Enums
 
 [<- Prev: Functions](05-functions.md) | [Next: Collections ->](07-collections.md)
 
 ---
 
-## Defining Structs with record
+## Defining Records
 
-Structs are defined with the `record` keyword. Each field is described in the `name: type` format.
+Records are defined with the `record` keyword. Each field is described in the `name: type` format.
 
 ```python
 record Point:
@@ -16,13 +16,13 @@ record Point:
     y: int
 ```
 
-Structs are value types allocated on the stack.
+Records are value types allocated on the stack.
 
 ---
 
-## Using Constructors
+## Creating Instances
 
-Create an instance by calling the struct name as a function. Arguments are specified in the order the fields are defined.
+Create an instance by calling the record name as a function. Arguments are specified in the order the fields are defined.
 
 ```python
 p = Point(10, 20)
@@ -40,7 +40,7 @@ print(p.x)   # 10
 print(p.y)   # 20
 ```
 
-> **Note**: Passing a struct directly to `print` causes an error. Pass individual fields instead.
+> **Note**: Passing a record directly to `print` causes an error. Pass individual fields instead.
 
 ---
 
@@ -58,9 +58,9 @@ print(p.x)   # 100
 
 ---
 
-## Structs as Function Parameters
+## Records as Function Parameters
 
-Structs can be passed as function arguments.
+Records can be passed as function arguments.
 
 ```python
 record Point:
@@ -77,9 +77,9 @@ print(distance_x(p1, p2))   # 6
 
 ---
 
-## Nested Structs
+## Nested Records
 
-A struct's field can be another struct.
+A record's field can be another record.
 
 ```python
 record Point:

--- a/docs/tutorial/07-collections.md
+++ b/docs/tutorial/07-collections.md
@@ -2,7 +2,7 @@
 
 # Collections
 
-[<- Prev: Structs](06-structs.md) | [Next: Advanced Features ->](08-advanced.md)
+[<- Prev: Records](06-records.md) | [Next: Advanced Features ->](08-advanced.md)
 
 Ry has four collection types: **Tuples**, **Lists**, **Maps**, and **Sets**.
 
@@ -399,4 +399,4 @@ for k, v in {"a": 1, "b": 2}.iter():
 
 ---
 
-[<- Prev: Structs](06-structs.md) | [Next: Advanced Features ->](08-advanced.md)
+[<- Prev: Records](06-records.md) | [Next: Advanced Features ->](08-advanced.md)

--- a/docs/tutorial/10-contracts.md
+++ b/docs/tutorial/10-contracts.md
@@ -4,7 +4,7 @@
 
 [<- Prev: Packages](09-modules.md) | [Next: Testing ->](11-testing.md)
 
-Ry supports Eiffel-style Design by Contract with preconditions (`require`), postconditions (`ensure`), and struct invariants (`invariant`). Contract violations terminate the program. For the full specification, see [Design by Contract Reference](../reference/contracts.md).
+Ry supports Eiffel-style Design by Contract with preconditions (`require`), postconditions (`ensure`), and record invariants (`invariant`). Contract violations terminate the program. For the full specification, see [Design by Contract Reference](../reference/contracts.md).
 
 ---
 
@@ -81,9 +81,9 @@ fn deposit(amount: int, balance: int) -> int:
 
 ---
 
-## Struct Invariants (`invariant`)
+## Record Invariants (`invariant`)
 
-Use `invariant` to specify conditions that must always hold for a struct. Invariants are checked after construction and after every field assignment.
+Use `invariant` to specify conditions that must always hold for a record. Invariants are checked after construction and after every field assignment.
 
 ```python
 record BankAccount:

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -17,7 +17,7 @@ Ry 是一個基於 LLVM JIT 的簡潔程式語言。採用 Python 風格的縮�
 | 03 | [運算子](tutorial/03-operators.md) | 算術、比較、邏輯、位元、複合賦值運算子 |
 | 04 | [控制流程](tutorial/04-control-flow.md) | if/elif/else、while、for/range、break/continue |
 | 05 | [函式定義](tutorial/05-functions.md) | fn 定義、遞迴、多載、Lambda、UFCS |
-| 06 | [結構體與列舉型別](tutorial/06-structs.md) | type 定義、欄位存取、方法、enum |
+| 06 | [Record 與列舉型別](tutorial/06-records.md) | type 定義、欄位存取、方法、enum |
 | 07 | [集合型別](tutorial/07-collections.md) | 元組、串列、映射、集合 |
 | 08 | [進階功能](tutorial/08-advanced.md) | 閉包、運算子多載、Option 型別 |
 | 09 | [套件](tutorial/09-modules.md) | 套件、std 函式庫、目錄套件 |

--- a/docs/zh/tutorial/01-getting-started.md
+++ b/docs/zh/tutorial/01-getting-started.md
@@ -6,26 +6,23 @@
 
 ---
 
-## 前提条件
+## 安装
 
-要构建并运行 Ry，需要以下环境：
-
-- **LLVM 21**
-- **CMake 3.20 以上**
-- **支持 C++17 的编译器**（GCC 7+ / Clang 5+ 等）
-
----
-
-## 构建步骤
-
-在仓库根目录下执行以下命令：
+### 快速安装（macOS Apple Silicon）
 
 ```bash
-cmake -B build -DLLVM_DIR=/usr/local/llvm/lib/cmake/llvm
-cmake --build build
+curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh
 ```
 
-构建成功后，会生成 `build/ry` 可执行文件。
+`ry` 二进制文件将安装到 `~/.local/bin`，标准库将安装到 `~/.ry/lib/std/`。
+
+请确保 `~/.local/bin` 已添加到 `PATH`：
+
+```bash
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+如需从源代码构建或在其他平台安装，请参阅 [README 的安装部分](../../../README.md#installation)。
 
 ---
 
@@ -66,7 +63,7 @@ print("Hello, World!")
 使用以下命令运行：
 
 ```bash
-./build/ry hello.ry
+ry hello.ry
 ```
 
 输出：
@@ -78,9 +75,9 @@ Hello, World!
 也可以通过管道或 Here-document 从标准输入执行代码：
 
 ```bash
-echo 'print("Hello, World!")' | ./build/ry
+echo 'print("Hello, World!")' | ry
 
-./build/ry <<'RY'
+ry <<'RY'
 print("Hello, World!")
 RY
 ```

--- a/docs/zh/tutorial/03-operators.md
+++ b/docs/zh/tutorial/03-operators.md
@@ -16,7 +16,7 @@
 | `/` | 除法（始終為 float） | `7 / 2` | `3.5` |
 | `//` | 整數除法（始終為 int） | `7 // 2` | `3` |
 | `%` | 取餘 | `7 % 3` | `1` |
-| `**` | 次方（始終為 float） | `2 ** 10` | `1024.0` |
+| `**` | 次方（始終為 float） | `2 ** 10` | `1024` |
 
 ```python
 a = 10
@@ -28,7 +28,7 @@ print(a * b)    # 30
 print(a / b)    # 3.3333...（float）
 print(a // b)   # 3（int）
 print(a % b)    # 1
-print(2 ** 8)   # 256.0（float）
+print(2 ** 8)   # 256（float）
 ```
 
 ---
@@ -133,7 +133,7 @@ x = 10
 x += 5    # x == 15
 x -= 3    # x == 12
 x *= 2    # x == 24
-x /= 4    # x == 6.0（會變為 float）
+x /= 4    # x == 6（會變為 float）
 ```
 
 ---
@@ -165,18 +165,18 @@ count--       # count == 1
 ```python
 # + - * 當其中一方為 float 時結果為 float
 print(1 + 2)      # 3 (int)
-print(1 + 2.0)    # 3.0 (float)
-print(1.0 + 2)    # 3.0 (float)
+print(1 + 2.0)    # 3 (float)
+print(1.0 + 2)    # 3 (float)
 
 # / 始終為 float
-print(4 / 2)      # 2.0 (float)
+print(4 / 2)      # 2 (float)
 
 # // 始終為 int
 print(7 // 2)     # 3 (int)
 print(7.0 // 2)   # 3 (int)
 
 # ** 始終為 float
-print(2 ** 3)     # 8.0 (float)
+print(2 ** 3)     # 8 (float)
 
 # % 當兩邊皆為 int 時為 int，其中一方為 float 時為 float
 print(7 % 3)      # 1 (int)

--- a/docs/zh/tutorial/05-functions.md
+++ b/docs/zh/tutorial/05-functions.md
@@ -2,7 +2,7 @@
 
 # 函式
 
-[← 前一篇：控制流程](04-control-flow.md) | [下一篇：結構體 →](06-structs.md)
+[← 前一篇：控制流程](04-control-flow.md) | [下一篇：Record →](06-records.md)
 
 ---
 
@@ -87,4 +87,4 @@ greet()   # 42
 
 ---
 
-[← 前一篇：控制流程](04-control-flow.md) | [下一篇：結構體 →](06-structs.md)
+[← 前一篇：控制流程](04-control-flow.md) | [下一篇：Record →](06-records.md)

--- a/docs/zh/tutorial/06-records.md
+++ b/docs/zh/tutorial/06-records.md
@@ -1,14 +1,14 @@
-[English](../../tutorial/06-structs.md) | [日本語](../../ja/tutorial/06-structs.md) | [繁體中文](06-structs.md)
+[English](../../tutorial/06-records.md) | [日本語](../../ja/tutorial/06-records.md) | [繁體中文](06-records.md)
 
-# 結構體與列舉型別
+# Record 與列舉型別
 
 [← 前一篇：函式](05-functions.md) | [下一篇：集合 →](07-collections.md)
 
 ---
 
-## 使用 record 定義結構體
+## 定義 Record
 
-使用 `record` 關鍵字定義結構體。各欄位以 `name: type` 的格式描述。
+使用 `record` 關鍵字定義 record。各欄位以 `name: type` 的格式描述。
 
 ```python
 record Point:
@@ -16,13 +16,13 @@ record Point:
     y: int
 ```
 
-結構體是堆疊上的值型別。
+Record 是堆疊上的值型別。
 
 ---
 
-## 建構式的使用方式
+## 建立實例
 
-像呼叫函式一樣使用結構體名稱來產生實例。參數按照欄位的定義順序指定。
+像呼叫函式一樣使用 record 名稱來產生實例。參數按照欄位的定義順序指定。
 
 ```python
 p = Point(10, 20)
@@ -40,7 +40,7 @@ print(p.x)   # 10
 print(p.y)   # 20
 ```
 
-> **注意**：將結構體直接傳給 `print` 會產生錯誤。請個別傳遞欄位。
+> **注意**：將 record 直接傳給 `print` 會產生錯誤。請個別傳遞欄位。
 
 ---
 
@@ -58,9 +58,9 @@ print(p.x)   # 100
 
 ---
 
-## 結構體作為函式參數
+## Record 作為函式參數
 
-可以將結構體作為函式的參數傳遞。
+可以將 record 作為函式的參數傳遞。
 
 ```python
 record Point:
@@ -77,9 +77,9 @@ print(distance_x(p1, p2))   # 6
 
 ---
 
-## 巢狀結構體
+## 巢狀 Record
 
-結構體的欄位可以使用其他結構體。
+Record 的欄位可以使用其他 record。
 
 ```python
 record Point:

--- a/docs/zh/tutorial/07-collections.md
+++ b/docs/zh/tutorial/07-collections.md
@@ -2,7 +2,7 @@
 
 # 集合
 
-[<- 上一篇：结构体](06-structs.md) | [下一篇：高级特性 ->](08-advanced.md)
+[<- 上一篇：Record](06-records.md) | [下一篇：高级特性 ->](08-advanced.md)
 
 Ry 有四种集合类型：**元组**、**列表**、**映射**、**集合**。
 
@@ -399,4 +399,4 @@ for k, v in {"a": 1, "b": 2}.iter():
 
 ---
 
-[<- 上一篇：结构体](06-structs.md) | [下一篇：高级特性 ->](08-advanced.md)
+[<- 上一篇：Record](06-records.md) | [下一篇：高级特性 ->](08-advanced.md)

--- a/docs/zh/tutorial/10-contracts.md
+++ b/docs/zh/tutorial/10-contracts.md
@@ -4,7 +4,7 @@
 
 [<- 上一篇：包](09-modules.md) | [下一篇：测试 ->](11-testing.md)
 
-Ry 支持 Eiffel 风格的契约式设计，包含前置条件（`require`）、后置条件（`ensure`）以及结构体不变量（`invariant`）。当契约违反时，程序会终止。详细规格请参阅[契约式设计参考手册](../reference/contracts.md)。
+Ry 支持 Eiffel 风格的契约式设计，包含前置条件（`require`）、后置条件（`ensure`）以及 record 不变量（`invariant`）。当契约违反时，程序会终止。详细规格请参阅[契约式设计参考手册](../reference/contracts.md)。
 
 ---
 
@@ -81,9 +81,9 @@ fn deposit(amount: int, balance: int) -> int:
 
 ---
 
-## 结构体不变量（`invariant`）
+## Record 不变量（`invariant`）
 
-使用 `invariant` 指定结构体必须始终成立的条件。不变量会在构造后及每次字段赋值后检查。
+使用 `invariant` 指定 record 必须始终成立的条件。不变量会在建立后及每次字段赋值后检查。
 
 ```python
 record BankAccount:


### PR DESCRIPTION
## Summary

- **Fix float output examples**: `%g` formatting strips trailing zeros, so `1024.0` → `1024`, `256.0` → `256`, etc. Updated all affected examples in operator tutorial (en/ja/zh)
- **Add curl installer to Getting Started**: Replaced source build instructions with the curl one-liner; source build now links to README
- **Unify record terminology**: Renamed `06-structs.md` → `06-records.md`, replaced "Struct" → "Record", "Constructor" → "Creating Instances", "struct invariants" → "record invariants" across all tutorials, reference docs, and READMEs (en/ja/zh)

## Test plan

- [x] Verified actual output matches new docs (`print(2 ** 10)` → `1024`, etc.)
- [x] Verified no stale `06-structs` references remain (`grep` returns 0 matches)
- [x] All 1170 C++ tests passed
- [x] All 53 Ry test files passed (0 failures)
- [x] ASan build: all tests passed (no memory issues)