### PR TITLE
fix: include version tag in self-update download URL

### DIFF
--- a/src/self_update.cpp
+++ b/src/self_update.cpp
@@ -231,7 +231,7 @@ static std::string build_release_asset_url(const std::string &tag, const std::st
 }
 
 std::string build_download_url(const std::string &tag, const PlatformInfo &platform) {
-    return build_release_asset_url(tag, "ry-" + platform.os + "-" + platform.arch + ".tar.gz");
+    return build_release_asset_url(tag, "ry-" + tag + "-" + platform.os + "-" + platform.arch + ".tar.gz");
 }
 
 UpdateTarget resolve_update_target(const std::string &mode, const PlatformInfo &platform) {

--- a/tests/test_self_update.cpp
+++ b/tests/test_self_update.cpp
@@ -29,10 +29,10 @@ TEST(SelfUpdate, BuildDownloadUrl) {
     PlatformInfo linux_amd64{"linux", "amd64"};
 
     auto url1 = build_download_url("v0.0.1", darwin_arm64);
-    EXPECT_EQ(url1, "https://github.com/t0k0sh1/ry/releases/download/v0.0.1/ry-darwin-arm64.tar.gz");
+    EXPECT_EQ(url1, "https://github.com/t0k0sh1/ry/releases/download/v0.0.1/ry-v0.0.1-darwin-arm64.tar.gz");
 
     auto url2 = build_download_url("v0.0.2-dev.20250101", linux_amd64);
-    EXPECT_EQ(url2, "https://github.com/t0k0sh1/ry/releases/download/v0.0.2-dev.20250101/ry-linux-amd64.tar.gz");
+    EXPECT_EQ(url2, "https://github.com/t0k0sh1/ry/releases/download/v0.0.2-dev.20250101/ry-v0.0.2-dev.20250101-linux-amd64.tar.gz");
 }
 
 TEST(SelfUpdate, ExtractJsonString) {


### PR DESCRIPTION
## Summary

- `ry self-update` was always failing because `build_download_url` generated an incorrect asset filename (e.g., `ry-darwin-arm64.tar.gz`) that didn't match the actual release asset name (e.g., `ry-v0.0.5-darwin-arm64.tar.gz`)
- Added the version tag to the download URL filename to match the naming convention used by `release.yml` and `install.sh`

## Test plan

- [x] `BuildDownloadUrl` unit test updated and passing
- [x] All 1190 C++ tests passing
- [x] All 57 Ry self-tests passing
- [x] ASan build passing with no errors