### PR TITLE
test: verify ArcHeader LLVM type structure

### DIFF
--- a/tests/test_codegen_arc.cpp
+++ b/tests/test_codegen_arc.cpp
@@ -120,9 +120,12 @@ TEST(ArcInfraTest, SingleOwnerRelease) {
 // by compiling a trivial program and inspecting the CodeGen state.
 
 TEST_F(CodeGenTest, ArcHeaderTypeExists) {
-    // Compile a trivial program — this exercises the CodeGen constructor
-    // which creates arcHeaderTy_
-    EXPECT_NO_THROW(runSource("print(1)"));
+    auto tsm = compileSource("print(1)");
+    tsm.withModuleDo([](Module &mod) {
+        auto *arcHeaderTy = StructType::getTypeByName(mod.getContext(), "ArcHeader");
+        ASSERT_NE(arcHeaderTy, nullptr);
+        EXPECT_EQ(arcHeaderTy->getNumElements(), 2u);  // { i64, i64 }
+    });
 }
 
 // ===== Data integrity through ARC header =====

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -67,14 +67,17 @@ protected:
         }
     }
 
-    static std::string runSource(const std::string &src) {
+    static ThreadSafeModule compileSource(const std::string &src) {
         Lexer lex(src);
         Parser parser(lex);
         Program prog = parser.parseProgram();
 
         CodeGen cg;
-        auto tsm = cg.compile(prog);
-        return runModule(std::move(tsm));
+        return cg.compile(prog);
+    }
+
+    static std::string runSource(const std::string &src) {
+        return runModule(compileSource(src));
     }
 
     static std::string runTestSource(const std::string &src) {


### PR DESCRIPTION
## Summary

- Add `compileSource()` helper to `CodeGenTest` harness that returns `ThreadSafeModule` without JIT execution, enabling direct LLVM module inspection
- Update `ArcHeaderTypeExists` test to verify the `ArcHeader` named struct type exists with correct element count (`{ i64, i64 }`)
- Refactor `runSource()` to delegate to `compileSource()`, eliminating duplicated lex/parse/compile code

## Test plan

- [x] `ArcHeaderTypeExists` test passes with structural assertions
- [x] All 1203 C++ tests pass
- [x] All 61 Ry self-test files pass
- [x] ASan build passes with no errors

Closes #421