### PR TITLE
fix: simplify parser error message for unexpected tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Explicit resource free/close functions (`lock_free`, `close`, `json_free`, etc.) now decrement the ARC reference count instead of immediately freeing — aliased resources no longer cause use-after-free (#427)
 - Closure destructors now recursively release captured resources and nested closures, preventing memory/resource leaks when closures are freed (#429)
 - Variable reassignment now uses the full destructor resolver (covering resources and closures) instead of only resolving collection destructors
+- Parser error message for unexpected tokens in statement position now says `unexpected token 'X'` instead of listing all valid keywords — also removes `expect` from keyword listing since it is a function, not a keyword (#404)
 
 ### Added
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -376,7 +376,7 @@ StmtNode Parser::parseStatement() {
 
     // identifier-leading statements: assignment, index assignment, or function call
     if (first.kind != TokenKind::Ident)
-        parseError(first.line, "expected 'if', 'while', 'for', 'fn', 'async fn', 'return', 'break', 'continue', 'await', '...', 'enum', 'match', 'expect', 'record', 'type', or identifier, got '" + first.value + "'");
+        parseError(first.line, "unexpected token '" + first.value + "'");
     lex_.next(); // consume ident
 
     Token next = lex_.peek();

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -225,6 +225,18 @@ TEST(ParserTest, InvalidSyntaxThrows) {
     EXPECT_THROW(parseStr("42 = x"), std::runtime_error);
 }
 
+TEST(ParserTest, UnexpectedTokenMessage) {
+    try {
+        parseStr("- 1");
+        FAIL() << "expected exception";
+    } catch (const DiagnosticError &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("unexpected token '-'"), std::string::npos);
+        // 'expect' should not be listed as a keyword
+        EXPECT_EQ(msg.find("'expect'"), std::string::npos);
+    }
+}
+
 TEST(ParserTest, TypeAnnotationInt) {
     Program prog = parseStr("x: int = 42");
     ASSERT_EQ(prog.size(), 1u);


### PR DESCRIPTION
## Summary

- Replace verbose keyword listing in `parseStatement()` fallback error with concise `"unexpected token 'X'"` message, consistent with `parser_expr.cpp`
- Remove `expect` from keyword listing since it is a function, not a keyword
- Add test verifying the new message format and absence of `expect` in error output

Closes #404