### PR TITLE
feat: add --outline option to ry test (#442)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- `--outline` option for `ry test`: prints the `describe`/`it` structure of test files without executing test bodies, useful for reviewing test organization at a glance (#442)
 - Cycle collector for ARC: CPython-style trial deletion algorithm detects and reclaims circular reference chains that ARC alone cannot free. Includes `gc` stdlib package with `collect()`, `enable()`, `disable()`, `set_threshold()` API. Static analysis identifies potentially cyclic types at compile time — non-cyclic types have zero GC overhead (#417)
 - ARC for closures: closures with captured variables are now ARC-managed — automatically freed when no longer referenced, with proper retain/release of captured ARC-typed variables (collections, resources, other closures) (#415)
 - Copy-on-Write (CoW) semantics for collection types (List, Map, Set): shared collections are automatically deep-copied before mutation, preserving value semantics while avoiding unnecessary copies when the collection has a single owner (#414)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -19,6 +19,7 @@ ry test -w -p        # Watch mode with parallel execution
 ry test -w tests/    # Watch a specific directory
 ry test --coverage   # Run all tests with line coverage summary
 ry test --cov        # Short alias for --coverage
+ry test --outline    # Print describe/it structure without running tests
 ```
 
 The exit code is 0 if all tests passed, 1 if any test failed.
@@ -260,6 +261,32 @@ Test Coverage Summary:
 
 - Only user code is reported; standard library files are excluded
 - `--coverage` with `--parallel` falls back to sequential execution
+
+---
+
+## Test Outline
+
+Use `--outline` to display the `describe`/`it` structure of test files without executing any test bodies:
+
+```bash
+ry test --outline tests/spec/mock.test.ry
+```
+
+Output:
+
+```
+describe mock
+  it replaces function
+  it auto-restores after it block
+  it with arguments
+describe verify
+  it counts calls
+  it zero calls
+```
+
+- Works with individual files, directories, and `-p` (all test files)
+- `@each` parameterized tests show the format template with an `(@each)` suffix
+- `@property` tests show the label with a `(@property)` suffix
 
 ---
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -18,7 +18,8 @@
 class CodeGen {
 public:
     explicit CodeGen(bool test_mode = false, const SourceManager *sm = nullptr,
-                     bool coverage_mode = false, int coverage_file_id_offset = 0);
+                     bool coverage_mode = false, int coverage_file_id_offset = 0,
+                     bool outline_mode = false);
     llvm::orc::ThreadSafeModule compile(Program &prog);
     const std::vector<std::string>& getWarnings() const { return warnings_; }
 
@@ -286,6 +287,8 @@ private:
     CapturedArcKind detectCapturedArcKind(llvm::AllocaInst *alloca) const;
     int lambda_counter_ = 0;
     bool test_mode_ = false;
+    bool outline_mode_ = false;
+    int outline_depth_ = 0;
     bool coverage_mode_ = false;
     int coverage_file_id_offset_ = 0;
     int test_fn_counter_ = 0;
@@ -420,6 +423,7 @@ private:
     void emitItCall(CallStmt &s);
     void emitEachItCall(CallStmt &s);
     void emitPropertyItCall(CallStmt &s);
+    void emitOutlinePrintf(const std::string &label, llvm::Value *nameVal = nullptr);
     std::pair<llvm::FunctionCallee, llvm::FunctionCallee> getTestItFunctions();
     llvm::Function *emitTestFunction(const std::string &namePrefix,
         const std::vector<llvm::Type*> &paramTypes, LambdaExpr &lam, const std::string &context);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -6,11 +6,12 @@
 #include <llvm/Support/raw_ostream.h>
 
 CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
-                 int coverage_file_id_offset)
+                 int coverage_file_id_offset, bool outline_mode)
     : ctx_(std::make_unique<llvm::LLVMContext>()),
       mod_(std::make_unique<llvm::Module>("ry", *ctx_)),
       builder_(*ctx_),
       test_mode_(test_mode),
+      outline_mode_(outline_mode),
       coverage_mode_(coverage_mode),
       coverage_file_id_offset_(coverage_file_id_offset),
       sm_(sm) {
@@ -282,7 +283,7 @@ llvm::orc::ThreadSafeModule CodeGen::compile(Program &prog) {
     }
 
     if (!builder_.GetInsertBlock()->getTerminator()) {
-        if (test_mode_) {
+        if (test_mode_ && !outline_mode_) {
             // Call __ry_test_summary() and return its result as exit code
             llvm::FunctionType *summaryTy = llvm::FunctionType::get(i32Ty_, false);
             llvm::FunctionCallee summaryFn = mod_->getOrInsertFunction("__ry_test_summary", summaryTy);

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -4,6 +4,18 @@
 #include <llvm/Support/raw_ostream.h>
 #include <stdexcept>
 
+// ===== Outline helper =====
+
+void CodeGen::emitOutlinePrintf(const std::string &label, llvm::Value *nameVal) {
+    auto printfFn = getStdlibPrintf();
+    std::string indent(outline_depth_ * 2, ' ');
+    llvm::Value *fmt = cachedGlobalString(indent + label, ".outline_fmt");
+    if (nameVal)
+        builder_.CreateCall(printfFn, {fmt, nameVal});
+    else
+        builder_.CreateCall(printfFn, {fmt});
+}
+
 // ===== Test: describe/it (lambda argument) =====
 
 static LambdaExpr &extractLambdaArg(CallStmt &s, const std::string &callee) {
@@ -21,6 +33,23 @@ void CodeGen::emitDescribeCall(CallStmt &s) {
 
     auto &lambda = extractLambdaArg(s, "describe");
 
+    llvm::Value *descName = emitExpr(*s.args[0]);
+    if (!descName->getType()->isPointerTy())
+        codegenError("describe() first argument must be a string");
+
+    if (outline_mode_) {
+        emitOutlinePrintf("describe %s\n", descName);
+        ++outline_depth_;
+        for (auto &stmt : lambda.body) {
+            if (auto *cs = std::get_if<CallStmt>(&stmt)) {
+                if (cs->callee == "describe" || cs->callee == "it")
+                    emitStmt(*cs);
+            }
+        }
+        --outline_depth_;
+        return;
+    }
+
     llvm::FunctionType *voidStrTy = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
     llvm::FunctionType *voidTy = llvm::FunctionType::get(
@@ -29,9 +58,6 @@ void CodeGen::emitDescribeCall(CallStmt &s) {
     llvm::FunctionCallee descBeginFn = mod_->getOrInsertFunction("__ry_test_describe_begin", voidStrTy);
     llvm::FunctionCallee descEndFn   = mod_->getOrInsertFunction("__ry_test_describe_end", voidTy);
 
-    llvm::Value *descName = emitExpr(*s.args[0]);
-    if (!descName->getType()->isPointerTy())
-        codegenError("describe() first argument must be a string");
     builder_.CreateCall(descBeginFn, {descName});
 
     for (auto &stmt : lambda.body)
@@ -127,6 +153,14 @@ void CodeGen::emitItCall(CallStmt &s) {
         return;
     }
 
+    if (outline_mode_) {
+        llvm::Value *itName = emitExpr(*s.args[0]);
+        if (!itName->getType()->isPointerTy())
+            codegenError("it() first argument must be a string");
+        emitOutlinePrintf("it %s\n", itName);
+        return;
+    }
+
     auto &lambda = extractLambdaArg(s, "it");
     auto [itBeginFn, itEndFn] = getTestItFunctions();
 
@@ -164,6 +198,11 @@ void CodeGen::emitEachItCall(CallStmt &s) {
     if (!descStr)
         codegenError("@each it() first argument must be a string literal");
     std::string fmtStr = descStr->value;
+
+    if (outline_mode_) {
+        emitOutlinePrintf("it " + fmtStr + " (@each)\n");
+        return;
+    }
 
     // Evaluate the list expression to get the list header
     llvm::Value *listPtr = emitExpr(*eachDir->expr);
@@ -259,6 +298,14 @@ void CodeGen::emitEachItCall(CallStmt &s) {
 // ===== Test: @property property-based test =====
 
 void CodeGen::emitPropertyItCall(CallStmt &s) {
+    if (outline_mode_) {
+        llvm::Value *itName = emitExpr(*s.args[0]);
+        if (!itName->getType()->isPointerTy())
+            codegenError("@property it() first argument must be a string");
+        emitOutlinePrintf("it %s (@property)\n", itName);
+        return;
+    }
+
     // Find @property directive and get count
     int64_t count = 100; // default
     for (auto &d : s.directives) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -84,7 +84,8 @@ static void emitCoverageReport() {
 // Compile and run Ry source code via JIT. Returns the JIT function's exit code.
 static int runRySource(const std::string &src, const std::string &source_name,
                        const std::string &referrer_dir, bool test_mode,
-                       const char *argv0, bool coverage_mode = false) {
+                       const char *argv0, bool coverage_mode = false,
+                       bool outline_mode = false) {
     std::string project_root;
     // Load .env from project root (once per root per process)
     {
@@ -138,7 +139,7 @@ static int runRySource(const std::string &src, const std::string &source_name,
     prog = loader.resolveImports(prog, referrer_dir);
 
     // CodeGen -> ThreadSafeModule
-    CodeGen cg(test_mode, &sm, coverage_mode, g_coverage_file_id_offset);
+    CodeGen cg(test_mode, &sm, coverage_mode, g_coverage_file_id_offset, outline_mode);
     ThreadSafeModule tsm = cg.compile(prog);
 
     // Build LLJIT
@@ -269,7 +270,8 @@ static int runRySource(const std::string &src, const std::string &source_name,
 
 // Compile and run a .ry file via JIT. Returns the JIT function's exit code.
 static int runRyFile(const std::string &filepath, bool test_mode,
-                     const char *argv0, bool coverage_mode = false) {
+                     const char *argv0, bool coverage_mode = false,
+                     bool outline_mode = false) {
     auto bufOrErr = MemoryBuffer::getFile(filepath);
     if (!bufOrErr) {
         errs() << "Error reading file: " << filepath << "\n";
@@ -277,7 +279,7 @@ static int runRyFile(const std::string &filepath, bool test_mode,
     }
     std::string src = (*bufOrErr)->getBuffer().str();
     std::string referrer_dir = fs::path(filepath).parent_path().string();
-    return runRySource(src, filepath, referrer_dir, test_mode, argv0, coverage_mode);
+    return runRySource(src, filepath, referrer_dir, test_mode, argv0, coverage_mode, outline_mode);
 }
 
 // Collect *.test.ry files recursively under root_dir
@@ -309,14 +311,15 @@ static std::vector<std::string> findTestFiles(const std::string &root_dir) {
 
 // Run multiple test files sequentially and report results
 static int runTestFilesSequential(const std::vector<std::string> &test_files,
-                                  const char *argv0, bool coverage = false) {
+                                  const char *argv0, bool coverage = false,
+                                  bool outline = false) {
     if (coverage) resetCoverageState();
     int total_failed = 0;
     int total_files = 0;
     for (const auto &tf : test_files) {
         ++total_files;
         try {
-            int failed = runRyFile(tf, /*test_mode=*/true, argv0, coverage);
+            int failed = runRyFile(tf, /*test_mode=*/true, argv0, coverage, outline);
             total_failed += failed;
         } catch (const DiagnosticError &e) {
             errs() << e.what();
@@ -326,7 +329,7 @@ static int runTestFilesSequential(const std::vector<std::string> &test_files,
             ++total_failed;
         }
     }
-    if (total_files > 1) {
+    if (!outline && total_files > 1) {
         std::printf("\n%d test files executed, %d total failures\n",
                     total_files, total_failed);
     }
@@ -469,9 +472,10 @@ static int runTestFilesParallel(const std::vector<std::string> &test_files,
 
 // Run multiple test files and report results
 static int runTestFiles(const std::vector<std::string> &test_files,
-                        const char *argv0, bool parallel, bool coverage = false) {
-    if (!parallel || test_files.size() <= 1) {
-        return runTestFilesSequential(test_files, argv0, coverage);
+                        const char *argv0, bool parallel, bool coverage = false,
+                        bool outline = false) {
+    if (outline || !parallel || test_files.size() <= 1) {
+        return runTestFilesSequential(test_files, argv0, coverage, outline);
     }
     std::string exe_path = ry::self_update::detail::get_executable_path();
     if (exe_path.empty()) {
@@ -486,13 +490,14 @@ static int runTestFiles(const std::vector<std::string> &test_files,
 
 // Discover *.test.ry files in a directory and run them
 static int discoverAndRunTests(const std::string &dir, const char *argv0,
-                               bool parallel, bool coverage = false) {
+                               bool parallel, bool coverage = false,
+                               bool outline = false) {
     auto test_files = findTestFiles(dir);
     if (test_files.empty()) {
         errs() << "No *.test.ry files found in " << dir << "\n";
         return 1;
     }
-    return runTestFiles(test_files, argv0, parallel, coverage);
+    return runTestFiles(test_files, argv0, parallel, coverage, outline);
 }
 
 static void applyRyEnv(const char *value) {
@@ -548,6 +553,7 @@ static void printTestHelp() {
     llvm::outs() << "  -p, --parallel       Run tests in parallel\n";
     llvm::outs() << "  -w, --watch          Watch for changes and re-run\n";
     llvm::outs() << "  --coverage, --cov    Collect coverage information\n";
+    llvm::outs() << "  --outline            Print describe/it structure without running tests\n";
     llvm::outs() << "  -h, --help           Show this help\n";
 }
 
@@ -652,6 +658,7 @@ int main(int argc, char *argv[]) {
 
     bool test_mode = false;
     bool coverage_mode = false;
+    bool outline_mode = false;
     const char *filename = nullptr;
 
     if (argc >= 2 && std::strcmp(argv[1], "test") != 0) {
@@ -670,6 +677,7 @@ int main(int argc, char *argv[]) {
         bool parallel = false;
         bool watch = false;
         bool coverage = false;
+        bool outline = false;
         const char *target = nullptr;
         for (int i = 2; i < argc; ++i) {
             if (std::strcmp(argv[i], "-p") == 0 ||
@@ -681,6 +689,8 @@ int main(int argc, char *argv[]) {
             } else if (std::strcmp(argv[i], "--coverage") == 0 ||
                        std::strcmp(argv[i], "--cov") == 0) {
                 coverage = true;
+            } else if (std::strcmp(argv[i], "--outline") == 0) {
+                outline = true;
             } else if (!target) {
                 target = argv[i];
             }
@@ -696,12 +706,12 @@ int main(int argc, char *argv[]) {
             if (fs::is_directory(target_str, ec)) {
                 if (watch) {
                     const char *a0 = argv[0];
-                    ry::watchAndRunTests(target_str, [target_str, a0, parallel, coverage]() {
-                        discoverAndRunTests(target_str, a0, parallel, coverage);
+                    ry::watchAndRunTests(target_str, [target_str, a0, parallel, coverage, outline]() {
+                        discoverAndRunTests(target_str, a0, parallel, coverage, outline);
                     });
                     return 0;
                 }
-                return discoverAndRunTests(target_str, argv[0], parallel, coverage);
+                return discoverAndRunTests(target_str, argv[0], parallel, coverage, outline);
             }
             if (ec) {
                 errs() << "Error: cannot access " << target_str << ": "
@@ -713,9 +723,9 @@ int main(int argc, char *argv[]) {
                 auto target_dir = fs::path(target_str).parent_path().string();
                 std::string watch_root = findProjectRoot(target_dir).value_or(target_dir);
                 const char *a0 = argv[0];
-                ry::watchAndRunTests(watch_root, [target_str, a0]() {
+                ry::watchAndRunTests(watch_root, [target_str, a0, outline]() {
                     try {
-                        runRyFile(target_str, true, a0);
+                        runRyFile(target_str, true, a0, false, outline);
                     } catch (const DiagnosticError &e) {
                         errs() << e.what();
                     } catch (const std::exception &e) {
@@ -727,6 +737,7 @@ int main(int argc, char *argv[]) {
             // ry test <file.ry> — single file test (parallel flag ignored)
             test_mode = true;
             coverage_mode = coverage;
+            outline_mode = outline;
             filename = target;
             __ry_args_init(0, nullptr);
         } else {
@@ -739,12 +750,12 @@ int main(int argc, char *argv[]) {
             if (watch) {
                 std::string root_dir = *root;
                 const char *a0 = argv[0];
-                ry::watchAndRunTests(root_dir, [root_dir, a0, parallel, coverage]() {
-                    discoverAndRunTests(root_dir, a0, parallel, coverage);
+                ry::watchAndRunTests(root_dir, [root_dir, a0, parallel, coverage, outline]() {
+                    discoverAndRunTests(root_dir, a0, parallel, coverage, outline);
                 });
                 return 0;
             }
-            return discoverAndRunTests(*root, argv[0], parallel, coverage);
+            return discoverAndRunTests(*root, argv[0], parallel, coverage, outline);
         }
     } else if (argc == 1 && !isatty(STDIN_FILENO)) {
         std::string src{std::istreambuf_iterator<char>(std::cin),
@@ -767,7 +778,7 @@ int main(int argc, char *argv[]) {
 
     try {
         if (coverage_mode) resetCoverageState();
-        int rc = runRyFile(filename, test_mode, argv[0], coverage_mode);
+        int rc = runRyFile(filename, test_mode, argv[0], coverage_mode, outline_mode);
         if (coverage_mode) emitCoverageReport();
         return rc;
     } catch (const DiagnosticError &e) {


### PR DESCRIPTION
## Summary

- Add `--outline` option to `ry test` that prints the `describe`/`it` structure without executing test bodies
- Implemented at the codegen level: outline mode emits only `printf` calls for labels, skipping test body generation entirely
- Works with individual files, directories, and `-p` (all test files); `@each` and `@property` tests show annotated labels

Closes #442

## Test plan

- [x] `./build/ry test --outline tests/spec/mock.test.ry` matches expected output from issue
- [x] `./build/ry test --outline tests/spec/parameterized.test.ry` shows `@each`/`@property` annotations
- [x] `./build/ry test --outline -p` runs all files sequentially and prints outlines
- [x] `./build/ry_tests` — 1222 C++ tests pass
- [x] `./build/ry test -p` — 61 test files, 0 failures
- [x] ASan build: `ry_tests` and `ry test -p` pass with no errors