### PR TITLE
refactor: semantic type classification and registry-driven CallStmt dispatch

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -832,5 +832,6 @@ private:
     bool isAnyType(llvm::Type *ty) const;
     bool canAnyHoldType(llvm::Type *ty) const;
     bool isNonStrPointer(llvm::Value *val);
+    bool isStringValue(llvm::Value *val);
     llvm::Value *emitAnyToString(llvm::Value *anyVal);
 };

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -911,25 +911,6 @@ void CodeGen::emitStmt(CallStmt &s) {
         emitStructConstructor(sit->second, s.callee, s.args);
         return;
     }
-    if (s.callee == "available_parallelism" || s.callee == "args" ||
-        s.callee == "range" || s.callee == "send" ||
-        s.callee == "recv" ||
-        s.callee == "close" ||
-        s.callee == "write_text" || s.callee == "append_text" ||
-        s.callee == "delete_file" || s.callee == "write_bytes" ||
-        s.callee == "listen" ||
-        s.callee == "http_listen" ||
-        s.callee == "sleep" ||
-        s.callee == "block_on" ||
-        s.callee == "set_timeout" || s.callee == "set_recv_timeout" || s.callee == "set_send_timeout" ||
-        s.callee == "shutdown" ||
-        s.callee == "json_free") {
-        auto ce = std::make_unique<CallExpr>();
-        ce->callee = s.callee;
-        ce->args = std::move(s.args);
-        emitExprVariant(ce);
-        return;
-    }
     // Intercept collection operations and route through CallExpr emitter
     if (!s.args.empty()) {
         bool intercept = false;
@@ -979,16 +960,13 @@ void CodeGen::emitStmt(CallStmt &s) {
     }
     if (tryCallOperator(s.callee, s.args))
         return;
-    // Route @native function calls through the full CallExpr dispatch chain
-    // so that stdlib dispatchers (emitBuiltinThread, etc.) can handle them.
-    if (native_fn_arg_counts_.count(s.callee)) {
-        auto ce = std::make_unique<CallExpr>();
-        ce->callee = s.callee;
-        ce->args = std::move(s.args);
-        emitExprVariant(ce);
-        return;
-    }
-    emitUserFnCall(s.callee, s.args);
+    // Route all remaining calls through the unified CallExpr dispatch chain.
+    // This covers @native stdlib functions, language builtins (close, range,
+    // sleep, etc.), and user-defined functions without a hardcoded whitelist.
+    auto ce = std::make_unique<CallExpr>();
+    ce->callee = s.callee;
+    ce->args = std::move(s.args);
+    emitExprVariant(ce);
 }
 
 llvm::Value *CodeGen::toBool(llvm::Value *v) {

--- a/src/codegen_any.cpp
+++ b/src/codegen_any.cpp
@@ -39,6 +39,10 @@ bool CodeGen::isNonStrPointer(llvm::Value *val) {
     return false;
 }
 
+bool CodeGen::isStringValue(llvm::Value *val) {
+    return val->getType() == ptrTy_ && !isNonStrPointer(val);
+}
+
 llvm::Value *CodeGen::wrapInAny(llvm::Value *val) {
     if (isNonStrPointer(val))
         codegenError("type error: 'any' can only hold int/float/bool/str; "

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -253,8 +253,11 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         }
     }
 
+    bool lhsIsStr = isStringValue(lhs);
+    bool rhsIsStr = isStringValue(rhs);
+
     // String comparison via strcmp
-    if (lhs->getType() == ptrTy_ && rhs->getType() == ptrTy_) {
+    if (lhsIsStr && rhsIsStr) {
         auto strcmpFn = getStdlibStrcmp();
         llvm::Value *cmp = builder_.CreateCall(strcmpFn, {lhs, rhs}, "strcmp");
         llvm::Value *zero = llvm::ConstantInt::get(i32Ty_, 0);
@@ -268,7 +271,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
     }
 
     // Reject str with non-str operands
-    if (lhs->getType() == ptrTy_ || rhs->getType() == ptrTy_)
+    if (lhsIsStr || rhsIsStr)
         codegenError("type error: operator '" + op + "' not supported between str and non-str types");
 
     // Low-level type mix check
@@ -344,7 +347,7 @@ llvm::Value *CodeGen::emitBitwiseOp(const std::string &op, llvm::Value *lhs, llv
         codegenError(
             "bitwise operator '" + op + "' requires integer operands, got float");
     // Reject str operands
-    if (lhs->getType() == ptrTy_ || rhs->getType() == ptrTy_)
+    if (isStringValue(lhs) || isStringValue(rhs))
         codegenError("type error: bitwise operator '" + op + "' not supported for str type");
     checkLowLevelTypeMix(lhs, rhs, op);
     // Low-level integer bitwise at native width
@@ -441,16 +444,21 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
     }
 
     // Auto-convert non-str to str for + operator (#393)
+    bool lhsIsStr = isStringValue(lhs);
+    bool rhsIsStr = isStringValue(rhs);
     auto isScalarTy = [&](llvm::Value *v) {
         return v->getType()->isIntegerTy() || v->getType()->isDoubleTy();
     };
-    if (op == "+" && lhs->getType() == ptrTy_ && isScalarTy(rhs))
+    if (op == "+" && lhsIsStr && isScalarTy(rhs)) {
         rhs = valueToString(rhs);
-    else if (op == "+" && rhs->getType() == ptrTy_ && isScalarTy(lhs))
+        rhsIsStr = true;
+    } else if (op == "+" && rhsIsStr && isScalarTy(lhs)) {
         lhs = valueToString(lhs);
+        lhsIsStr = true;
+    }
 
     // String concatenation
-    if (op == "+" && lhs->getType() == ptrTy_ && rhs->getType() == ptrTy_) {
+    if (op == "+" && lhsIsStr && rhsIsStr) {
         auto strlenFn = getStdlibStrlen();
         auto mallocFn = getStdlibMalloc();
         auto strcpyFn = getStdlibStrcpy();
@@ -470,9 +478,9 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
     if (op == "*") {
         llvm::Value *strVal = nullptr;
         llvm::Value *intVal = nullptr;
-        if (lhs->getType() == ptrTy_ && rhs->getType()->isIntegerTy()) {
+        if (lhsIsStr && rhs->getType()->isIntegerTy()) {
             strVal = lhs; intVal = rhs;
-        } else if (rhs->getType() == ptrTy_ && lhs->getType()->isIntegerTy()) {
+        } else if (rhsIsStr && lhs->getType()->isIntegerTy()) {
             strVal = rhs; intVal = lhs;
         }
         if (strVal) {
@@ -485,7 +493,7 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
     }
 
     // Reject str with non-str operands (must come after string concat/repeat checks)
-    if (lhs->getType() == ptrTy_ || rhs->getType() == ptrTy_)
+    if (lhsIsStr || rhsIsStr)
         codegenError("type error: operator '" + op + "' not supported between str and non-str types");
 
     // // floor division (toward -∞)
@@ -765,22 +773,23 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<WhenCondExpr> &e) {
             codegenError("when expression: all branches must have the same type");
 
         if (lhs->getType() == ptrTy_) {
+            // Classify pointer values by semantic kind using isStringValue and type_meta_
             enum class SemanticKind { Str, List, Map, Set, Other };
             auto classify = [&](llvm::Value *v) -> SemanticKind {
-                if (type_meta_[TM_ListElem].count(v)) return SemanticKind::List;
-                if (type_meta_[TM_MapKey].count(v)) return SemanticKind::Map;
-                if (type_meta_[TM_SetElem].count(v)) return SemanticKind::Set;
-                if (type_meta_[TM_TaskResult].count(v)) return SemanticKind::Other;
-                return SemanticKind::Str;
+                if (isStringValue(v)) return SemanticKind::Str;
+                if (lookupCollectionType(type_meta_[TM_ListElem], v)) return SemanticKind::List;
+                if (lookupCollectionType(type_meta_[TM_MapKey], v)) return SemanticKind::Map;
+                if (lookupCollectionType(type_meta_[TM_SetElem], v)) return SemanticKind::Set;
+                return SemanticKind::Other;
             };
             SemanticKind lhsKind = classify(lhs);
             SemanticKind rhsKind = classify(rhs);
             if (lhsKind != rhsKind)
                 codegenError("when expression: all branches must have the same type");
             if (lhsKind == SemanticKind::List) {
-                llvm::Type *lhsElem = type_meta_[TM_ListElem][lhs];
-                llvm::Type *rhsElem = type_meta_[TM_ListElem][rhs];
-                if (lhsElem != rhsElem)
+                llvm::Type *lhsElem = lookupCollectionType(type_meta_[TM_ListElem], lhs);
+                llvm::Type *rhsElem = lookupCollectionType(type_meta_[TM_ListElem], rhs);
+                if (lhsElem && rhsElem && lhsElem != rhsElem)
                     codegenError("when expression: all branches must have the same type");
             }
         }

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -198,6 +198,17 @@ TEST_F(CodeGenTest, StringAutoConcat) {
     EXPECT_EQ(runSource("print(false + \" is false\")"), "false is false\n");
 }
 
+// ===== Non-string pointer types must not hit string paths (#397) =====
+
+TEST_F(CodeGenTest, NonStrPointerNotTreatedAsStr) {
+    // Collections share LLVM ptrTy_ with str but must not activate str-specific operator paths
+    EXPECT_THROW(runSource("xs = [1, 2]\nprint(xs == \"abc\")"), std::runtime_error);
+    EXPECT_THROW(runSource("xs = [1, 2]\nprint(xs + \"abc\")"), std::runtime_error);
+    EXPECT_THROW(runSource("xs = [1, 2]\nprint(xs & 2)"), std::runtime_error);
+    EXPECT_THROW(runSource("m = {\"a\": 1}\nprint(m == \"abc\")"), std::runtime_error);
+    EXPECT_THROW(runSource("m = {\"a\": 1}\nprint(m + \"abc\")"), std::runtime_error);
+}
+
 // ===== Type change throws =====
 
 TEST_F(CodeGenTest, TypeChangeThrows) {


### PR DESCRIPTION
## Summary

- **#397**: Replace raw `ptrTy_` comparisons in binary op guards (`emitComparisonOp`, `emitArithmeticOp`, `emitBitwiseOp`) with `isStringValue()` helper that leverages existing `isNonStrPointer()` infrastructure to correctly distinguish `str` from other pointer-backed types (List, Map, Set, resources, closures)
- **#391**: Remove 18-function hardcoded CallStmt whitelist and route all unresolved statement calls through the unified CallExpr dispatch chain
- Cache `isStringValue` results per binary op to avoid redundant `isNonStrPointer` traversals
- Update `WhenCondExpr` classify lambda to use `isStringValue` + `lookupCollectionType` for consistent semantic classification

Closes #397
Closes #391

## Test plan

- [x] New `NonStrPointerNotTreatedAsStr` test: verifies List/Map don't trigger string operator paths
- [x] All 1232 C++ tests pass
- [x] All 61 Ry self-test files pass (0 failures)
- [x] ASan build: all tests pass with no memory errors