### PR TITLE
fix: floor modulo and boundary tests

### DIFF
--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -542,7 +542,17 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
         bool rf = rhs->getType()->isDoubleTy();
         if (lf || rf) {
             std::tie(lhs, rhs) = promoteToFloat(lhs, rhs);
-            return builder_.CreateFRem(lhs, rhs, "frem");
+            // Floor modulo for float: r = frem(a,b); if (r != 0 && sign(r) != sign(b)) r += b
+            llvm::Value *frem = builder_.CreateFRem(lhs, rhs, "frem");
+            llvm::Value *zero = llvm::ConstantFP::get(f64Ty_, 0.0);
+            llvm::Value *remNonZero = builder_.CreateFCmpONE(frem, zero, "frem_nz");
+            // XOR the sign bits: if frem and rhs have different signs, adjust
+            llvm::Value *fremNeg = builder_.CreateFCmpOLT(frem, zero, "frem_neg");
+            llvm::Value *rhsNeg  = builder_.CreateFCmpOLT(rhs, zero, "rhs_neg");
+            llvm::Value *signsDiffer = builder_.CreateXor(fremNeg, rhsNeg, "fsigns_differ");
+            llvm::Value *needsAdj = builder_.CreateAnd(remNonZero, signsDiffer, "fmod_adj");
+            llvm::Value *adjusted = builder_.CreateFAdd(frem, rhs, "fmod_adjusted");
+            return builder_.CreateSelect(needsAdj, adjusted, frem, "ffloormod");
         }
         // int: zero-division guard
         {
@@ -556,7 +566,16 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
                               ".mod_zero_err_" + std::to_string(arith_zero_err_counter_++));
             builder_.SetInsertPoint(okBB);
         }
-        return builder_.CreateSRem(lhs, rhs, "srem");
+        // Floor modulo: r = srem(a,b); if (r != 0 && sign(r) != sign(b)) r += b
+        llvm::Value *rem = builder_.CreateSRem(lhs, rhs, "srem");
+        llvm::Value *remNonZero = builder_.CreateICmpNE(
+            rem, llvm::ConstantInt::get(i64Ty_, 0), "rem_nz");
+        llvm::Value *xorV = builder_.CreateXor(rem, rhs, "rem_xor_rhs");
+        llvm::Value *signsDiffer = builder_.CreateICmpSLT(
+            xorV, llvm::ConstantInt::get(i64Ty_, 0), "signs_differ");
+        llvm::Value *needsAdj = builder_.CreateAnd(remNonZero, signsDiffer, "mod_adj");
+        llvm::Value *adjusted = builder_.CreateAdd(rem, rhs, "mod_adjusted");
+        return builder_.CreateSelect(needsAdj, adjusted, rem, "floormod");
     }
 
     // +/-/*: 片方f64なら浮動小数点命令

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -221,12 +221,21 @@ extern "C" void __ry_any_mod(RyAny *result, const RyAny *a, const RyAny *b) {
             fprintf(stderr, "runtime error: modulo by zero\n");
             exit(1);
         }
-        makeInt(result, extractInt(a) % bv);
+        // Floor modulo: r = a % b; if (r != 0 && sign(r) != sign(b)) r += b
+        int64_t av = extractInt(a);
+        int64_t r = av % bv;
+        if (r != 0 && ((r ^ bv) < 0)) r += bv;
+        makeInt(result, r);
     } else if (a->tag == TAG_FLOAT && b->tag == TAG_FLOAT) {
-        makeFloat(result, std::fmod(extractFloat(a), extractFloat(b)));
+        double r = std::fmod(extractFloat(a), extractFloat(b));
+        if (r != 0.0 && ((r < 0) != (extractFloat(b) < 0))) r += extractFloat(b);
+        makeFloat(result, r);
     } else if ((a->tag == TAG_INT && b->tag == TAG_FLOAT) ||
                (a->tag == TAG_FLOAT && b->tag == TAG_INT)) {
-        makeFloat(result, std::fmod(toFloat(a), toFloat(b)));
+        double fa = toFloat(a), fb = toFloat(b);
+        double r = std::fmod(fa, fb);
+        if (r != 0.0 && ((r < 0) != (fb < 0))) r += fb;
+        makeFloat(result, r);
     } else {
         __ry_any_type_error("%", a->tag, b->tag);
     }

--- a/tests/spec/bounds_check.test.ry
+++ b/tests/spec/bounds_check.test.ry
@@ -1,4 +1,15 @@
 describe("bounds checking", fn():
+  describe("single element list", fn():
+    it("access index 0", fn():
+      xs = [42]
+      expect(xs[0]).to_eq(42)
+    )
+    it("negative index on single element", fn():
+      xs = [42]
+      expect(xs[-1]).to_eq(42)
+    )
+  )
+
   describe("list negative index", fn():
     it("wraps -1 to last element", fn():
       xs = [10, 20, 30]

--- a/tests/spec/checked_arith.test.ry
+++ b/tests/spec/checked_arith.test.ry
@@ -51,4 +51,28 @@ describe("checked arithmetic", fn():
     v = wrapping_sub(0u8, 1u8)
     expect(v as int).to_eq(255)
   )
+  it("checked_sub overflow", fn():
+    r = checked_sub(-2147483648i32, 1i32)
+    when r:
+      case Ok(v):
+        expect(true).to_eq(false)
+      case Err(e):
+        expect(true).to_eq(true)
+  )
+  it("checked_mul overflow", fn():
+    r = checked_mul(100000i32, 100000i32)
+    when r:
+      case Ok(v):
+        expect(true).to_eq(false)
+      case Err(e):
+        expect(true).to_eq(true)
+  )
+  it("checked_add zero boundary", fn():
+    r = checked_add(0i32, 0i32)
+    when r:
+      case Ok(v):
+        expect(v as int).to_eq(0)
+      case Err(e):
+        expect(true).to_eq(false)
+  )
 )

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -241,6 +241,106 @@ describe("List", fn():
     expect(res[2]).to_eq(40)
     expect(res[3]).to_eq(50)
   )
+  it("sort empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    zs = sort(ys)
+    expect(zs).to_have_length(0)
+  )
+  it("sort single element", fn():
+    xs = [42]
+    ys = sort(xs)
+    expect(ys[0]).to_eq(42)
+  )
+  it("reverse empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    zs = reverse(ys)
+    expect(zs).to_have_length(0)
+  )
+  it("reverse single element", fn():
+    xs = [42]
+    ys = reverse(xs)
+    expect(ys[0]).to_eq(42)
+  )
+  it("map empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    zs = map(ys, fn(x: int) => x * 2)
+    expect(zs).to_have_length(0)
+  )
+  it("filter empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    zs = filter(ys, fn(x: int) => true)
+    expect(zs).to_have_length(0)
+  )
+  it("sum empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    expect(sum(ys)).to_eq(0)
+  )
+  it("fold empty returns initial", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    expect(fold(ys, 42, fn(a: int, b: int) => a + b)).to_eq(42)
+  )
+  it("any empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    expect(any(ys, fn(x: int) => true)).to_be_false()
+  )
+  it("all empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    expect(all(ys, fn(x: int) => false)).to_be_true()
+  )
+  it("is_empty true", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    expect(is_empty(ys)).to_be_true()
+  )
+  it("slice empty range", fn():
+    xs = [1, 2, 3, 4, 5]
+    ys = slice(xs, 0, 0)
+    expect(ys).to_have_length(0)
+  )
+  it("slice same start and end", fn():
+    xs = [1, 2, 3, 4, 5]
+    ys = slice(xs, 2, 2)
+    expect(ys).to_have_length(0)
+  )
+  it("insert at front", fn():
+    xs = [2, 3]
+    insert(xs, 0, 1)
+    expect(xs[0]).to_eq(1)
+    expect(xs[1]).to_eq(2)
+    expect(xs).to_have_length(3)
+  )
+  it("distinct empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    zs = distinct(ys)
+    expect(zs).to_have_length(0)
+  )
+  it("distinct single", fn():
+    xs = [1]
+    ys = distinct(xs)
+    expect(ys).to_have_length(1)
+    expect(ys[0]).to_eq(1)
+  )
+  it("flatten single inner", fn():
+    xs = [[42]]
+    ys = flatten(xs)
+    expect(ys).to_have_length(1)
+    expect(ys[0]).to_eq(42)
+  )
+  it("take empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    zs = take(ys, 5)
+    expect(zs).to_have_length(0)
+  )
   it("sort 32 elements (MIN_MERGE threshold)", fn():
     xs = [32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ys = sort(xs)
@@ -331,6 +431,15 @@ describe("Map", fn():
     expect(m).to_contain("a")
     expect(m).to_not_contain("z")
   )
+  it("remove non-existent key", fn():
+    m = {"a": 1, "b": 2}
+    remove(m, "zzz")
+    expect(m).to_have_length(2)
+  )
+  it("get non-existent optional", fn():
+    m = {"a": 1}
+    expect(get(m, "zzz")).to_be_none()
+  )
 )
 
 describe("Set", fn():
@@ -395,6 +504,11 @@ describe("Set", fn():
     expect(is_superset(a, b)).to_be_true()
     expect(is_superset(b, a)).to_be_false()
   )
+  it("remove non-existent element", fn():
+    s = {1, 2, 3}
+    remove(s, 999)
+    expect(s).to_have_length(3)
+  )
   it("literal dedup int", fn():
     s = {1, 2, 3, 2, 1}
     expect(s).to_have_length(3)
@@ -427,5 +541,11 @@ describe("Tuple", fn():
     res = swap(1, 2)
     expect(res.0).to_eq(2)
     expect(res.1).to_eq(1)
+  )
+  it("three element tuple", fn():
+    t = (1, "a", true)
+    expect(t.0).to_eq(1)
+    expect(t.1).to_eq("a")
+    expect(t.2).to_be_true()
   )
 )

--- a/tests/spec/control_flow.test.ry
+++ b/tests/spec/control_flow.test.ry
@@ -25,6 +25,30 @@ describe("if / when", fn():
         res = 3
     expect(res).to_eq(2)
   )
+  it("when all false falls to else", fn():
+    res = 0
+    x = 99
+    when:
+      x == 1:
+        res = 1
+      x == 2:
+        res = 2
+      else:
+        res = 3
+    expect(res).to_eq(3)
+  )
+  it("when first false second true", fn():
+    res = 0
+    x = 5
+    when:
+      x > 100:
+        res = 1
+      x > 3:
+        res = 2
+      else:
+        res = 3
+    expect(res).to_eq(2)
+  )
 )
 
 describe("while", fn():
@@ -137,6 +161,32 @@ describe("for", fn():
       sum = sum + a + c
     expect(sum).to_eq(14)
   )
+  it("empty list iteration", fn():
+    sum = 0
+    xs = [1]
+    empty = filter(xs, fn(x: int) => x > 10)
+    for x in empty:
+      sum = sum + x
+    expect(sum).to_eq(0)
+  )
+  it("range(0) is empty", fn():
+    sum = 0
+    for i in range(0):
+      sum = sum + 1
+    expect(sum).to_eq(0)
+  )
+  it("range with equal start and end", fn():
+    sum = 0
+    for i in range(5, 5):
+      sum = sum + 1
+    expect(sum).to_eq(0)
+  )
+  it("range reverse without step", fn():
+    sum = 0
+    for i in range(5, 3):
+      sum = sum + 1
+    expect(sum).to_eq(0)
+  )
 )
 
 describe("when", fn():
@@ -194,6 +244,50 @@ describe("when", fn():
         res = "other"
     expect(res).to_eq("other")
   )
+  it("string literal pattern", fn():
+    res = ""
+    s = "hello"
+    when s:
+      case "hello":
+        res = "matched"
+      case _:
+        res = "other"
+    expect(res).to_eq("matched")
+  )
+  it("negative literal pattern", fn():
+    res = ""
+    x = -1
+    when x:
+      case -1:
+        res = "minus one"
+      case 0:
+        res = "zero"
+      case _:
+        res = "other"
+    expect(res).to_eq("minus one")
+  )
+  it("guard fallback to wildcard", fn():
+    res = ""
+    x = 5
+    when x:
+      case n if n > 100:
+        res = "big"
+      case n if n > 50:
+        res = "medium"
+      case _:
+        res = "small"
+    expect(res).to_eq("small")
+  )
+  it("OR pattern with many alternatives", fn():
+    res = ""
+    x = 4
+    when x:
+      case 1 | 2 | 3 | 4:
+        res = "small"
+      case _:
+        res = "other"
+    expect(res).to_eq("small")
+  )
 )
 
 describe("when Option", fn():
@@ -240,6 +334,20 @@ describe("when enum", fn():
         res = "west"
     expect(res).to_eq("north")
   )
+  it("last enum variant matches", fn():
+    res = ""
+    d = Direction::West
+    when d:
+      case Direction::North:
+        res = "north"
+      case Direction::South:
+        res = "south"
+      case Direction::East:
+        res = "east"
+      case Direction::West:
+        res = "west"
+    expect(res).to_eq("west")
+  )
 )
 
 enum Shape:
@@ -271,6 +379,41 @@ describe("when ADT enum", fn():
       case Shape::Point:
         res = 0.0
     expect(res).to_eq(20.0)
+  )
+)
+
+describe("nested when", fn():
+  it("when inside when", fn():
+    res = ""
+    x = 2
+    y = 10
+    when x:
+      case 1:
+        res = "one"
+      case 2:
+        when y:
+          case 10:
+            res = "two-ten"
+          case _:
+            res = "two-other"
+      case _:
+        res = "other"
+    expect(res).to_eq("two-ten")
+  )
+)
+
+describe("when ADT no-data variant", fn():
+  it("matches Point variant", fn():
+    res = 0.0
+    s = Shape::Point
+    when s:
+      case Shape::Circle(r):
+        res = r
+      case Shape::Rect(w, h):
+        res = w * h
+      case Shape::Point:
+        res = -1.0
+    expect(res).to_eq(-1.0)
   )
 )
 

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -76,12 +76,20 @@ describe("closure", fn():
     base = 99
     expect(add_base(5)).to_eq(15)
   )
+  it("captures bool", fn():
+    flag = true
+    check = fn() => flag
+    expect(check()).to_be_true()
+  )
 )
 
 describe("higher-order function", fn():
   it("function as argument", fn():
     res = apply(fn(x: int) => x * 3, 5)
     expect(res).to_eq(15)
+  )
+  it("named function as argument", fn():
+    expect(apply(double, 5)).to_eq(10)
   )
 )
 
@@ -159,6 +167,15 @@ fn sum_to(n: int, acc: int) -> int:
   if n <= 0:
     return acc
   return sum_to(n - 1, acc + n)
+
+fn get_value() -> int:
+  return 42
+
+describe("zero arg function", fn():
+  it("returns value", fn():
+    expect(get_value()).to_eq(42)
+  )
+)
 
 describe("tail call optimization", fn():
   it("self-recursive tail call does not overflow", fn():

--- a/tests/spec/generics.test.ry
+++ b/tests/spec/generics.test.ry
@@ -30,4 +30,10 @@ describe("generic function", fn():
     expect(identity(10)).to_eq(10)
     expect(identity(20)).to_eq(20)
   )
+  it("explicit type arg float", fn():
+    expect(identity[float](3.14)).to_eq(3.14)
+  )
+  it("type inference bool", fn():
+    expect(identity(true)).to_be_true()
+  )
 )

--- a/tests/spec/iterator.test.ry
+++ b/tests/spec/iterator.test.ry
@@ -98,4 +98,16 @@ describe("Iterator", fn():
     expect(ys).to_have_length(3)
     expect(ys[0]).to_eq(1)
   )
+  it("filter empty iterator", fn():
+    xs = [1]
+    empty = filter(xs, fn(x: int) => x > 10)
+    ys = to_list(filter(iter(empty), fn(x: int) => true))
+    expect(ys).to_have_length(0)
+  )
+  it("map empty iterator", fn():
+    xs = [1]
+    empty = filter(xs, fn(x: int) => x > 10)
+    ys = to_list(map(iter(empty), fn(x: int) => x * 2))
+    expect(ys).to_have_length(0)
+  )
 )

--- a/tests/spec/operators.test.ry
+++ b/tests/spec/operators.test.ry
@@ -36,8 +36,46 @@ describe("arithmetic", fn():
   it("modulo", fn():
     expect(7 % 3).to_eq(1)
   )
+  it("modulo negative dividend", fn():
+    expect(-7 % 3).to_eq(2)
+  )
+  it("modulo negative divisor", fn():
+    expect(7 % -3).to_eq(-2)
+  )
+  it("modulo both negative", fn():
+    expect(-7 % -3).to_eq(-1)
+  )
+  it("modulo zero dividend", fn():
+    expect(0 % 5).to_eq(0)
+  )
+  it("floor div and modulo identity", fn():
+    expect((-7 // 3) * 3 + (-7 % 3)).to_eq(-7)
+    expect((7 // -3) * -3 + (7 % -3)).to_eq(7)
+    expect((-7 // -3) * -3 + (-7 % -3)).to_eq(-7)
+  )
+  it("float modulo", fn():
+    expect(7.5 % 2.5).to_eq(0.0)
+  )
+  it("float modulo negative", fn():
+    expect(-7.0 % 2.0).to_eq(1.0)
+  )
+  it("float floor div", fn():
+    expect(7.5 // 2.0).to_eq(3.0)
+  )
   it("exponentiation", fn():
     expect(2 ** 10).to_eq(1024.0)
+  )
+  it("exponentiation zero", fn():
+    expect(1 ** 0).to_eq(1.0)
+  )
+  it("exponentiation negative", fn():
+    expect(2 ** -1).to_eq(0.5)
+  )
+  it("zero times zero", fn():
+    expect(0 * 0).to_eq(0)
+  )
+  it("zero plus zero", fn():
+    expect(0 + 0).to_eq(0)
   )
 )
 
@@ -102,6 +140,16 @@ describe("comparison", fn():
   it("string comparison", fn():
     expect("abc" < "abd").to_be_true()
   )
+  it("string equality", fn():
+    expect("abc" == "abc").to_be_true()
+    expect("" == "").to_be_true()
+  )
+  it("empty string less than non-empty", fn():
+    expect("" < "a").to_be_true()
+  )
+  it("float equality", fn():
+    expect(3.14 == 3.14).to_be_true()
+  )
 )
 
 describe("logical", fn():
@@ -117,8 +165,11 @@ describe("logical", fn():
   it("or false", fn():
     expect(false or false).to_be_false()
   )
-  it("not", fn():
+  it("not true", fn():
     expect(not true).to_be_false()
+  )
+  it("not false", fn():
+    expect(not false).to_be_true()
   )
 )
 
@@ -162,6 +213,14 @@ describe("bitwise", fn():
   it("logical right shift", fn():
     expect(-1 >>> 1).to_eq(9223372036854775807)
   )
+  it("shift by zero", fn():
+    expect(0 << 0).to_eq(0)
+    expect(0 >> 0).to_eq(0)
+    expect(42 << 0).to_eq(42)
+  )
+  it("NOT of minus one", fn():
+    expect(~(-1)).to_eq(0)
+  )
 )
 
 describe("when expression", fn():
@@ -177,6 +236,31 @@ describe("when expression", fn():
       else => 20
     ).to_eq(20)
   )
+  it("multi-branch", fn():
+    x = 2
+    r = when:
+      x == 1 => "one"
+      x == 2 => "two"
+      x == 3 => "three"
+      else => "other"
+    expect(r).to_eq("two")
+  )
+  it("all false falls to else", fn():
+    x = 99
+    r = when:
+      x == 1 => "one"
+      x == 2 => "two"
+      else => "none"
+    expect(r).to_eq("none")
+  )
+  it("first false second true", fn():
+    x = 5
+    r = when:
+      x > 10 => "big"
+      x > 3 => "medium"
+      else => "small"
+    expect(r).to_eq("medium")
+  )
 )
 
 describe("null coalescing", fn():
@@ -187,6 +271,10 @@ describe("null coalescing", fn():
   it("None value", fn():
     b: int? = none
     expect(b ?? 0).to_eq(0)
+  )
+  it("Some(0) is not None", fn():
+    c: int? = Some(0)
+    expect(c ?? 99).to_eq(0)
   )
 )
 
@@ -312,5 +400,10 @@ describe("range operator", fn():
     expect(xs).to_have_length(5)
     expect(xs[0]).to_eq(1)
     expect(xs[4]).to_eq(5)
+  )
+  it("same start and end", fn():
+    xs = 5..5
+    expect(xs).to_have_length(1)
+    expect(xs[0]).to_eq(5)
   )
 )

--- a/tests/spec/result.test.ry
+++ b/tests/spec/result.test.ry
@@ -73,6 +73,18 @@ describe("Result type", fn():
       case Err(e):
         fail("unexpected error")
   )
+  it("Ok(0) is still Ok", fn():
+    res = Ok(0)
+    expect(res).to_be_ok()
+  )
+  it("Ok empty string is still Ok", fn():
+    res: Result<str, Error> = Ok("")
+    expect(res).to_be_ok()
+  )
+  it("Err with empty message", fn():
+    res = Err(Error(""))
+    expect(res).to_be_err()
+  )
   it("when Ok with wildcard for Unit result", fn():
     fn unit_ok() -> Result<Unit, Error>:
       return Ok(0 as u8)

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -36,6 +36,18 @@ describe("search and check", fn():
     expect(find("hello", "xyz")).to_be_none()
     expect(find("abcdef", "cd")).to_eq(Some(2))
   )
+  it("find in empty string", fn():
+    expect(find("", "x")).to_be_none()
+  )
+  it("find empty needle", fn():
+    expect(find("hello", "")).to_eq(Some(0))
+  )
+  it("contains empty needle", fn():
+    expect(contains("hello", "")).to_be_true()
+  )
+  it("contains empty haystack and needle", fn():
+    expect(contains("", "")).to_be_true()
+  )
 )
 
 describe("extraction and transformation", fn():
@@ -58,9 +70,15 @@ describe("case conversion", fn():
     expect(to_upper("hello")).to_eq("HELLO")
     expect(to_upper("Hello World")).to_eq("HELLO WORLD")
   )
+  it("to_upper empty", fn():
+    expect(to_upper("")).to_eq("")
+  )
   it("to_lower", fn():
     expect(to_lower("HELLO")).to_eq("hello")
     expect(to_lower("Hello World")).to_eq("hello world")
+  )
+  it("to_lower empty", fn():
+    expect(to_lower("")).to_eq("")
   )
 )
 
@@ -69,13 +87,22 @@ describe("whitespace", fn():
     expect(trim("  hello  ")).to_eq("hello")
     expect(trim("  hi  ")).to_eq("hi")
   )
+  it("trim empty", fn():
+    expect(trim("")).to_eq("")
+  )
   it("trim_start", fn():
     expect(trim_start("  hello  ")).to_eq("hello  ")
     expect(trim_start("  hi")).to_eq("hi")
   )
+  it("trim_start empty", fn():
+    expect(trim_start("")).to_eq("")
+  )
   it("trim_end", fn():
     expect(trim_end("  hello  ")).to_eq("  hello")
     expect(trim_end("hi  ")).to_eq("hi")
+  )
+  it("trim_end empty", fn():
+    expect(trim_end("")).to_eq("")
   )
 )
 
@@ -88,9 +115,15 @@ describe("generation", fn():
     expect(repeat("abc", -100)).to_eq("")
     expect(repeat("hello", 1)).to_eq("hello")
   )
+  it("repeat empty string", fn():
+    expect(repeat("", 5)).to_eq("")
+  )
   it("reverse", fn():
     expect(reverse("hello")).to_eq("olleh")
     expect(reverse("abc")).to_eq("cba")
+  )
+  it("reverse empty", fn():
+    expect(reverse("")).to_eq("")
   )
 )
 
@@ -107,6 +140,15 @@ describe("split and join", fn():
     expect(join(parts, ",")).to_eq("a,b,c")
     expect(join(parts, "-")).to_eq("a-b-c")
   )
+  it("join empty list", fn():
+    parts: List<str> = ["x"]
+    empty = filter(parts, fn(s: str) => false)
+    expect(join(empty, ",")).to_eq("")
+  )
+  it("join single element", fn():
+    parts = ["only"]
+    expect(join(parts, ",")).to_eq("only")
+  )
 )
 
 describe("UTF-8 support", fn():
@@ -117,6 +159,12 @@ describe("UTF-8 support", fn():
   it("byte_len counts bytes", fn():
     expect(byte_len("hello")).to_eq(5)
     expect(byte_len("あいう")).to_eq(9)
+  )
+  it("length empty", fn():
+    expect("").to_have_length(0)
+  )
+  it("byte_len empty", fn():
+    expect(byte_len("")).to_eq(0)
   )
   it("char_at UTF-8", fn():
     expect(char_at("あいう", 1)).to_eq("い")

--- a/tests/spec/structs.test.ry
+++ b/tests/spec/structs.test.ry
@@ -66,6 +66,9 @@ fn operator==(a: AlwaysEqual, b: AlwaysEqual) -> bool:
   return true
 
 describe("record equality", fn():
+  it("zero fields equal", fn():
+    expect(Point(0, 0) == Point(0, 0)).to_be_true()
+  )
   it("equal records", fn():
     expect(Point(1, 2) == Point(1, 2)).to_be_true()
   )
@@ -121,6 +124,11 @@ describe("simple enum", fn():
       case Color::Blue:
         res = "blue"
     expect(res).to_eq("blue")
+  )
+  it("to_str shows variant name", fn():
+    expect(to_str(Color::Red)).to_eq("Red")
+    expect(to_str(Color::Green)).to_eq("Green")
+    expect(to_str(Color::Blue)).to_eq("Blue")
   )
 )
 

--- a/tests/spec/type_advanced.test.ry
+++ b/tests/spec/type_advanced.test.ry
@@ -21,6 +21,18 @@ describe("f-string", fn():
   )
 )
 
+describe("string auto concat edge cases", fn():
+  it("empty string + int", fn():
+    expect("" + 0).to_eq("0")
+  )
+  it("empty string + bool", fn():
+    expect("" + true).to_eq("true")
+  )
+  it("empty string + float", fn():
+    expect("" + 3.14).to_eq("3.14")
+  )
+)
+
 describe("type cast as", fn():
   it("int to float", fn():
     expect(42 as float).to_eq(42.0)
@@ -42,6 +54,24 @@ describe("type cast as", fn():
   it("int to u8 to int", fn():
     b = 255 as u8
     expect(b as int).to_eq(255)
+  )
+  it("negative float to int truncates toward zero", fn():
+    expect(-3.7 as int).to_eq(-3)
+  )
+  it("negative half to int", fn():
+    expect(-0.5 as int).to_eq(0)
+  )
+  it("zero float to int", fn():
+    expect(0.0 as int).to_eq(0)
+  )
+  it("one float to int", fn():
+    expect(1.0 as int).to_eq(1)
+  )
+  it("bool to int true", fn():
+    expect(true as int).to_eq(1)
+  )
+  it("bool to int false", fn():
+    expect(false as int).to_eq(0)
   )
 )
 

--- a/tests/spec/types.test.ry
+++ b/tests/spec/types.test.ry
@@ -77,6 +77,18 @@ describe("Option", fn():
     x: int? = 42
     expect(x).to_be_some()
   )
+  it("Some(0) is Some not None", fn():
+    x: int? = Some(0)
+    expect(x).to_be_some()
+  )
+  it("Some(false) is Some not None", fn():
+    x: bool? = Some(false)
+    expect(x).to_be_some()
+  )
+  it("Some empty string is Some", fn():
+    x: str? = Some("")
+    expect(x).to_be_some()
+  )
 )
 
 describe("nested generic type", fn():

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -360,6 +360,14 @@ TEST_F(CodeGenTest, FloorDivModWorks) {
     EXPECT_EQ(runSource("print(7 // 2)"), "3\n");
     EXPECT_EQ(runSource("print(-7 // 2)"), "-4\n");
     EXPECT_EQ(runSource("print(7 % 3)"), "1\n");
+    // Floor modulo: sign follows divisor (Python semantics)
+    EXPECT_EQ(runSource("print(-7 % 3)"), "2\n");
+    EXPECT_EQ(runSource("print(7 % -3)"), "-2\n");
+    EXPECT_EQ(runSource("print(-7 % -3)"), "-1\n");
+    EXPECT_EQ(runSource("print(0 % 5)"), "0\n");
+    // Identity: a == (a // b) * b + (a % b)
+    EXPECT_EQ(runSource("print((-7 // 3) * 3 + (-7 % 3))"), "-7\n");
+    EXPECT_EQ(runSource("print((7 // -3) * -3 + (7 % -3))"), "7\n");
 }
 
 // ===== any type rejection =====


### PR DESCRIPTION
## Summary

- **Bug fix**: Changed `%` operator from C-style `SRem` to floor modulo (Python semantics), fixing inconsistency with `//` (floor division). The identity `a == (a // b) * b + (a % b)` now holds for all operands including negatives.
- **Boundary tests**: Added ~100 test cases across 13 `.test.ry` files covering empty collections, string edge cases, when pattern matching boundaries, type cast edge cases, and more.

### Files changed
- `src/codegen_expr.cpp` — Floor modulo for both int and float
- `src/runtime_any.cpp` — Floor modulo for `any` type operations
- `tests/test_codegen.cpp` — C++ tests for negative modulo and identity
- 13 `.test.ry` spec files — Boundary and edge case tests

## Test plan
- [x] `./build/ry_tests` — 1231 C++ tests passed
- [x] `./build/ry test -p` — All 61 spec files passed (0 failures)
- [x] ASan build: `./build-asan/ry_tests` — 1231 tests passed
- [x] ASan Ry tests: `./build-asan/ry test -p` — All passed