### PR TITLE
refactor: extract CI signing step into a composite action

### DIFF
--- a/.github/actions/sign-checksums/action.yml
+++ b/.github/actions/sign-checksums/action.yml
@@ -1,0 +1,22 @@
+name: Sign checksums
+description: Sign checksums.txt using OpenSSL with RY_SIGNING_PRIVATE_KEY
+
+inputs:
+  checksums_dir:
+    description: Directory containing checksums.txt
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Sign checksums
+      shell: bash
+      run: |
+        echo "$RY_SIGNING_PRIVATE_KEY" > /tmp/signing_key.pem
+        openssl pkeyutl -sign \
+          -inkey /tmp/signing_key.pem \
+          -rawin \
+          -in ${{ inputs.checksums_dir }}/checksums.txt \
+          -out /tmp/checksums.txt.sig.raw
+        openssl base64 -A -in /tmp/checksums.txt.sig.raw -out ${{ inputs.checksums_dir }}/checksums.txt.sig
+        rm -f /tmp/signing_key.pem /tmp/checksums.txt.sig.raw

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -104,17 +104,11 @@ jobs:
           shasum -a 256 ry-*.tar.gz > checksums.txt
       - name: Sign checksums
         if: env.RY_SIGNING_PRIVATE_KEY != ''
+        uses: ./.github/actions/sign-checksums
+        with:
+          checksums_dir: dist
         env:
           RY_SIGNING_PRIVATE_KEY: ${{ secrets.RY_SIGNING_PRIVATE_KEY }}
-        run: |
-          echo "$RY_SIGNING_PRIVATE_KEY" > /tmp/signing_key.pem
-          openssl pkeyutl -sign \
-            -inkey /tmp/signing_key.pem \
-            -rawin \
-            -in dist/checksums.txt \
-            -out /tmp/checksums.txt.sig.raw
-          openssl base64 -A -in /tmp/checksums.txt.sig.raw -out dist/checksums.txt.sig
-          rm -f /tmp/signing_key.pem /tmp/checksums.txt.sig.raw
       - name: Cleanup old prereleases
         env:
           GH_TOKEN: ${{ github.token }}
@@ -195,17 +189,11 @@ jobs:
           shasum -a 256 ry-*.tar.gz > checksums.txt
       - name: Sign checksums
         if: env.RY_SIGNING_PRIVATE_KEY != ''
+        uses: ./.github/actions/sign-checksums
+        with:
+          checksums_dir: dist
         env:
           RY_SIGNING_PRIVATE_KEY: ${{ secrets.RY_SIGNING_PRIVATE_KEY }}
-        run: |
-          echo "$RY_SIGNING_PRIVATE_KEY" > /tmp/signing_key.pem
-          openssl pkeyutl -sign \
-            -inkey /tmp/signing_key.pem \
-            -rawin \
-            -in dist/checksums.txt \
-            -out /tmp/checksums.txt.sig.raw
-          openssl base64 -A -in /tmp/checksums.txt.sig.raw -out dist/checksums.txt.sig
-          rm -f /tmp/signing_key.pem /tmp/checksums.txt.sig.raw
       - name: Cleanup old prereleases
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,17 +137,11 @@ jobs:
 
       - name: Sign checksums
         if: env.SKIP != 'true' && env.RY_SIGNING_PRIVATE_KEY != ''
+        uses: ./.github/actions/sign-checksums
+        with:
+          checksums_dir: artifacts
         env:
           RY_SIGNING_PRIVATE_KEY: ${{ secrets.RY_SIGNING_PRIVATE_KEY }}
-        run: |
-          echo "$RY_SIGNING_PRIVATE_KEY" > /tmp/signing_key.pem
-          openssl pkeyutl -sign \
-            -inkey /tmp/signing_key.pem \
-            -rawin \
-            -in artifacts/checksums.txt \
-            -out /tmp/checksums.txt.sig.raw
-          openssl base64 -A -in /tmp/checksums.txt.sig.raw -out artifacts/checksums.txt.sig
-          rm -f /tmp/signing_key.pem /tmp/checksums.txt.sig.raw
 
       - name: Extract changelog
         if: env.SKIP != 'true'


### PR DESCRIPTION
## Summary

- Create `.github/actions/sign-checksums/action.yml` composite action with a single `checksums_dir` input
- Replace 3 duplicated "Sign checksums" shell blocks across `release.yml` and `dev-release.yml` (nightly + manual jobs)
- No behavioral change — signing logic, conditions, and secret handling remain identical

## Test plan

- [ ] Verify YAML syntax is valid (done locally)
- [ ] Trigger a dev-release workflow run to confirm signing step executes correctly
- [ ] Verify stable release workflow still references the composite action correctly

Closes #388