### PR TITLE
test: add edge case and error path tests (Phase 1) (#200)

### DIFF
--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -125,10 +125,28 @@ describe("List", fn():
     expect(pairs[0].0).to_eq(0)
     expect(pairs[0].1).to_eq(10)
   )
+  it("enumerate empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    pairs = enumerate(ys)
+    expect(pairs).to_have_length(0)
+  )
   it("zip", fn():
     pairs = zip([1, 2], [10, 20])
     expect(pairs[0].0).to_eq(1)
     expect(pairs[0].1).to_eq(10)
+  )
+  it("zip unequal lengths truncates to shorter", fn():
+    pairs = zip([1, 2, 3], [10, 20])
+    expect(pairs).to_have_length(2)
+    expect(pairs[0].0).to_eq(1)
+    expect(pairs[1].1).to_eq(20)
+  )
+  it("zip empty with non-empty", fn():
+    xs = [1]
+    ys = filter(xs, fn(x: int) => x > 10)
+    pairs = zip(ys, [10, 20])
+    expect(pairs).to_have_length(0)
   )
   it("insert", fn():
     xs = [1, 2, 3]
@@ -335,6 +353,14 @@ describe("List", fn():
     expect(ys).to_have_length(1)
     expect(ys[0]).to_eq(42)
   )
+  it("flatten with single-element inner lists", fn():
+    xs = [[1], [2], [3]]
+    ys = flatten(xs)
+    expect(ys).to_have_length(3)
+    expect(ys[0]).to_eq(1)
+    expect(ys[1]).to_eq(2)
+    expect(ys[2]).to_eq(3)
+  )
   it("take empty", fn():
     xs = [1]
     ys = filter(xs, fn(x: int) => x > 10)
@@ -440,6 +466,32 @@ describe("Map", fn():
     m = {"a": 1}
     expect(get(m, "zzz")).to_be_none()
   )
+  it("empty map keys", fn():
+    m = {"a": 1}
+    remove(m, "a")
+    ks = keys(m)
+    expect(ks).to_have_length(0)
+  )
+  it("empty map values", fn():
+    m = {"a": 1}
+    remove(m, "a")
+    vs = values(m)
+    expect(vs).to_have_length(0)
+  )
+  it("empty map items", fn():
+    m = {"a": 1}
+    remove(m, "a")
+    ps = items(m)
+    expect(ps).to_have_length(0)
+  )
+  it("merge with empty map", fn():
+    m1 = {"a": 1}
+    m2 = {"a": 2}
+    remove(m2, "a")
+    m3 = merge(m1, m2)
+    expect(m3["a"]).to_eq(1)
+    expect(m3).to_have_length(1)
+  )
 )
 
 describe("Set", fn():
@@ -526,6 +578,39 @@ describe("Set", fn():
     expect(s).to_have_length(2)
     expect(s).to_contain("a")
     expect(s).to_contain("b")
+  )
+  it("union with empty set", fn():
+    a = {1, 2, 3}
+    b = {1}
+    remove(b, 1)
+    c = union(a, b)
+    expect(c).to_have_length(3)
+  )
+  it("intersection with empty set", fn():
+    a = {1, 2, 3}
+    b = {1}
+    remove(b, 1)
+    c = intersection(a, b)
+    expect(c).to_have_length(0)
+  )
+  it("difference with empty set", fn():
+    a = {1, 2, 3}
+    b = {1}
+    remove(b, 1)
+    c = difference(a, b)
+    expect(c).to_have_length(3)
+  )
+  it("is_subset empty is subset of any", fn():
+    a = {1}
+    remove(a, 1)
+    b = {1, 2, 3}
+    expect(is_subset(a, b)).to_be_true()
+  )
+  it("is_superset of empty set", fn():
+    a = {1, 2, 3}
+    b = {1}
+    remove(b, 1)
+    expect(is_superset(a, b)).to_be_true()
   )
 )
 

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -88,4 +88,48 @@ describe("file I/O", fn():
   it("read_text returns Err for missing file", fn():
     expect(read_text("/tmp/ry_selftest_nonexistent_file.txt")).to_be_err()
   )
+  it("read_bytes returns Err for missing file", fn():
+    expect(read_bytes("/tmp/ry_selftest_nonexistent_bytes.bin")).to_be_err()
+  )
+  it("delete_file returns Err for missing file", fn():
+    expect(delete_file("/tmp/ry_selftest_nonexistent_delete.txt")).to_be_err()
+  )
+  it("write and read empty file", fn():
+    when write_text("/tmp/ry_selftest_io_empty.txt", ""):
+      case Ok(_):
+        when read_text("/tmp/ry_selftest_io_empty.txt"):
+          case Ok(s):
+            expect(s).to_eq("")
+          case Err(e):
+            fail("unexpected read error")
+      case Err(e):
+        fail("unexpected write error")
+    delete_file("/tmp/ry_selftest_io_empty.txt")
+  )
+  it("write and read empty bytes", fn():
+    data = str_to_bytes("")
+    when write_bytes("/tmp/ry_selftest_io_empty.bin", data):
+      case Ok(_):
+        when read_bytes("/tmp/ry_selftest_io_empty.bin"):
+          case Ok(rb):
+            expect(length(rb)).to_eq(0)
+          case Err(e):
+            fail("unexpected read error")
+      case Err(e):
+        fail("unexpected write error")
+    delete_file("/tmp/ry_selftest_io_empty.bin")
+  )
+  it("file_exists returns false for missing file", fn():
+    expect(file_exists("/tmp/ry_selftest_nonexistent_exists.txt")).to_eq(false)
+  )
+  it("overwrite existing file", fn():
+    write_text("/tmp/ry_selftest_io_overwrite.txt", "first")
+    write_text("/tmp/ry_selftest_io_overwrite.txt", "second")
+    when read_text("/tmp/ry_selftest_io_overwrite.txt"):
+      case Ok(s):
+        expect(s).to_eq("second")
+      case Err(e):
+        fail("unexpected error")
+    delete_file("/tmp/ry_selftest_io_overwrite.txt")
+  )
 )

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -73,16 +73,36 @@ describe("math pow/sqrt", fn():
   it("sqrt", fn():
     expect(sqrt(4.0)).to_eq(2.0)
     expect(sqrt(9.0)).to_eq(3.0)
+    expect(sqrt(0.0)).to_eq(0.0)
+  )
+  it("sqrt negative returns NaN", fn():
+    expect(is_nan(sqrt(-1.0))).to_be_true()
   )
   it("pow", fn():
     expect(pow(2.0, 3.0)).to_eq(8.0)
     expect(pow(3.0, 2.0)).to_eq(9.0)
+  )
+  it("pow zero exponent", fn():
+    expect(pow(5.0, 0.0)).to_eq(1.0)
+    expect(pow(0.0, 0.0)).to_eq(1.0)
+  )
+  it("pow negative exponent", fn():
+    expect(pow(2.0, -1.0)).to_eq(0.5)
+  )
+  it("pow large exponent returns Inf", fn():
+    expect(is_inf(pow(2.0, 10000.0))).to_be_true()
   )
 )
 
 describe("math log", fn():
   it("log", fn():
     expect(log(1.0)).to_eq(0.0)
+  )
+  it("log zero returns -Inf", fn():
+    expect(is_inf(log(0.0))).to_be_true()
+  )
+  it("log negative returns NaN", fn():
+    expect(is_nan(log(-1.0))).to_be_true()
   )
   it("log2", fn():
     expect(log2(8.0)).to_eq(3.0)
@@ -95,6 +115,9 @@ describe("math log", fn():
 describe("math exp", fn():
   it("exp(0)", fn():
     expect(exp(0.0)).to_eq(1.0)
+  )
+  it("exp large returns Inf", fn():
+    expect(is_inf(exp(1000.0))).to_be_true()
   )
 )
 
@@ -114,8 +137,15 @@ describe("math inverse trig", fn():
   it("asin(0)", fn():
     expect(asin(0.0)).to_eq(0.0)
   )
+  it("asin out of domain returns NaN", fn():
+    expect(is_nan(asin(2.0))).to_be_true()
+    expect(is_nan(asin(-2.0))).to_be_true()
+  )
   it("acos(1)", fn():
     expect(acos(1.0)).to_eq(0.0)
+  )
+  it("acos out of domain returns NaN", fn():
+    expect(is_nan(acos(2.0))).to_be_true()
   )
   it("atan(0)", fn():
     expect(atan(0.0)).to_eq(0.0)
@@ -126,8 +156,14 @@ describe("math two-arg", fn():
   it("atan2", fn():
     expect(atan2(0.0, 1.0)).to_eq(0.0)
   )
+  it("atan2(0, 0)", fn():
+    expect(atan2(0.0, 0.0)).to_eq(0.0)
+  )
   it("hypot", fn():
     expect(hypot(3.0, 4.0)).to_eq(5.0)
+  )
+  it("hypot(0, 0)", fn():
+    expect(hypot(0.0, 0.0)).to_eq(0.0)
   )
 )
 
@@ -135,9 +171,24 @@ describe("math predicates", fn():
   it("is_nan", fn():
     expect(is_nan(NaN)).to_eq(true)
     expect(is_nan(1.0)).to_eq(false)
+    expect(is_nan(0.0)).to_eq(false)
+    expect(is_nan(Inf)).to_eq(false)
   )
   it("is_inf", fn():
     expect(is_inf(Inf)).to_eq(true)
     expect(is_inf(1.0)).to_eq(false)
+    expect(is_inf(0.0)).to_eq(false)
+    expect(is_inf(NaN)).to_eq(false)
+  )
+  it("NaN arithmetic propagation", fn():
+    expect(is_nan(NaN + 1.0)).to_be_true()
+    expect(is_nan(NaN * 2.0)).to_be_true()
+    expect(is_nan(NaN - NaN)).to_be_true()
+  )
+  it("Inf arithmetic", fn():
+    expect(is_inf(Inf + 1.0)).to_be_true()
+    expect(is_inf(Inf + Inf)).to_be_true()
+    expect(is_nan(Inf - Inf)).to_be_true()
+    expect(is_nan(Inf * 0.0)).to_be_true()
   )
 )

--- a/tests/spec/regex_phase2.test.ry
+++ b/tests/spec/regex_phase2.test.ry
@@ -19,6 +19,33 @@ describe("range quantifiers", fn():
   )
 )
 
+describe("empty and edge patterns", fn():
+  it("empty pattern matches empty string", fn():
+    expect(regex_match("", "")).to_eq(true)
+  )
+  it("dot matches any character", fn():
+    expect(regex_match(".", "a")).to_eq(true)
+    expect(regex_match(".", " ")).to_eq(true)
+  )
+  it("dot does not match empty", fn():
+    expect(regex_match(".", "")).to_eq(false)
+  )
+  it("match entire string only", fn():
+    expect(regex_match("abc", "abc")).to_eq(true)
+    expect(regex_match("abc", "xabcx")).to_eq(false)
+  )
+  it("search in empty string", fn():
+    expect(regex_search("a", "")).to_eq(-1)
+  )
+  it("find_all no matches", fn():
+    matches = regex_find_all("xyz", "hello world")
+    expect(length(matches)).to_eq(0)
+  )
+  it("replace no matches", fn():
+    expect(regex_replace("xyz", "hello", "X")).to_eq("hello")
+  )
+)
+
 describe("non-greedy when", fn():
   it("lazy star replace", fn():
     expect(regex_replace("\".*?\"", "\"a\" and \"b\"", "X")).to_eq("X and X")

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -55,6 +55,13 @@ describe("extraction and transformation", fn():
     expect(substring("hello world", 0, 5)).to_eq("hello")
     expect(substring("abcdef", 1, 4)).to_eq("bcd")
   )
+  it("substring out of bounds clamps", fn():
+    expect(substring("abc", 0, 100)).to_eq("abc")
+    expect(substring("abc", 5, 10)).to_eq("")
+  )
+  it("substring negative clamps to zero", fn():
+    expect(substring("abc", -1, 2)).to_eq("ab")
+  )
   it("char_at", fn():
     expect(char_at("hello", 0)).to_eq("h")
     expect(char_at("abc", 2)).to_eq("c")
@@ -62,6 +69,9 @@ describe("extraction and transformation", fn():
   it("replace", fn():
     expect(replace("hello world", "world", "ry")).to_eq("hello ry")
     expect(replace("foo bar foo", "foo", "baz")).to_eq("baz bar baz")
+  )
+  it("replace not found", fn():
+    expect(replace("hello", "xyz", "abc")).to_eq("hello")
   )
 )
 
@@ -135,6 +145,16 @@ describe("split and join", fn():
     expect(parts[1]).to_eq("b")
     expect(parts[2]).to_eq("c")
   )
+  it("split empty string", fn():
+    parts = split("", ",")
+    expect(parts).to_have_length(1)
+    expect(parts[0]).to_eq("")
+  )
+  it("split no delimiter found", fn():
+    parts = split("hello", ",")
+    expect(parts).to_have_length(1)
+    expect(parts[0]).to_eq("hello")
+  )
   it("join", fn():
     parts = ["a", "b", "c"]
     expect(join(parts, ",")).to_eq("a,b,c")
@@ -183,9 +203,17 @@ describe("type conversion", fn():
     expect(to_int("-7")).to_eq(-7)
     expect(to_int("123")).to_eq(123)
   )
+  it("to_int non-numeric returns 0", fn():
+    expect(to_int("abc")).to_eq(0)
+    expect(to_int("")).to_eq(0)
+  )
   it("to_float", fn():
     expect(to_float("3.14")).to_eq(3.14)
     expect(to_float("2.5")).to_eq(2.5)
+  )
+  it("to_float non-numeric returns 0", fn():
+    expect(to_float("xyz")).to_eq(0.0)
+    expect(to_float("")).to_eq(0.0)
   )
   it("to_str", fn():
     expect(to_str(42)).to_eq("42")


### PR DESCRIPTION
## Summary

- Add ~50 new edge case / error path tests across 5 test files as Phase 1 of #200
- **math.test.ry**: NaN/Inf propagation (`sqrt(-1)`, `log(0)`, `pow(2,10000)`), domain errors (`asin(2)`, `acos(2)`), zero-arg edge cases (`atan2(0,0)`, `hypot(0,0)`)
- **collections.test.ry**: `zip` with unequal/empty lists, `flatten` with single-element inners, `enumerate` empty, empty Map `keys()`/`values()`/`items()`/`merge()`, empty Set `union`/`intersection`/`difference`/`is_subset`/`is_superset`
- **strings.test.ry**: `to_int`/`to_float` with non-numeric input, `substring` out-of-bounds clamping, `split` edge cases, `replace` not-found
- **io.test.ry**: `read_bytes`/`delete_file` on missing files → Err, empty file read/write, file overwrite
- **regex_phase2.test.ry**: empty pattern, dot behavior, search/find_all/replace with no matches

## Test plan

- [x] `cmake --preset default && cmake --build build && ./build/ry_tests` — 1232 passed
- [x] `./build/ry test -p` — 61 files, 0 failures
- [x] ASan build: `cmake --preset asan && cmake --build build-asan`
- [x] `ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests` — 1232 passed
- [x] `ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p` — 61 files, 0 failures

Closes #200