### PR TITLE
chore: sync stdlib declaration files with implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Synced stdlib declaration files (`.ry`) with implementations: added missing `remove`, `take`, `tap` to `list.ry`, `remove` to `map.ry`, and corrected IO function return types to `Result` in `io.ry` (#454)
 - **Breaking:** Stdin execution now requires explicit `-c` flag (`echo 'code' | ry -c`). Bare `ry` without arguments runs the `entry` file from `package.toml` instead of reading stdin (#443)
 
 ### Added

--- a/lib/std/io/io.ry
+++ b/lib/std/io/io.ry
@@ -9,29 +9,29 @@ fn read_all() -> str
 
 # File I/O
 @native
-fn read_text(path: str) -> str
+fn read_text(path: str) -> Result<str, Error>
 
 @native
-fn write_text(path: str, content: str) -> Unit
+fn write_text(path: str, content: str) -> Result<Unit, Error>
 
 @native
-fn append_text(path: str, content: str) -> Unit
+fn append_text(path: str, content: str) -> Result<Unit, Error>
 
 @native
 fn file_exists(path: str) -> bool
 
 @native
-fn delete_file(path: str) -> Unit
+fn delete_file(path: str) -> Result<Unit, Error>
 
 @native
-fn read_bytes(path: str) -> List<u8>
+fn read_bytes(path: str) -> Result<List<u8>, Error>
 
 @native
-fn write_bytes(path: str, data: List<u8>) -> Unit
+fn write_bytes(path: str, data: List<u8>) -> Result<Unit, Error>
 
 # Byte conversions
 @native
 fn str_to_bytes(string: str) -> List<u8>
 
 @native
-fn bytes_to_str(bytes: List<u8>) -> str
+fn bytes_to_str(bytes: List<u8>) -> Result<str, Error>

--- a/lib/std/list.ry
+++ b/lib/std/list.ry
@@ -49,3 +49,12 @@ fn append!(values: List<int>, value: int) -> Unit
 
 @native
 fn is_empty(values: List<int>) -> bool
+
+@native
+fn remove(values: List<int>, value: int) -> Unit
+
+@native
+fn take(values: List<int>, n: int) -> List<int>
+
+@native
+fn tap(values: List<int>, f: fn(int) -> int) -> List<int>

--- a/lib/std/map.ry
+++ b/lib/std/map.ry
@@ -19,3 +19,6 @@ fn get(map: Map<str, int>, key: str, default: int) -> int
 
 @native
 fn merge(first_map: Map<str, int>, second_map: Map<str, int>) -> Map<str, int>
+
+@native
+fn remove(map: Map<str, int>, key: str) -> Unit


### PR DESCRIPTION
## Summary

- Added missing `@native fn` declarations to stdlib `.ry` files: `remove`, `take`, `tap` in `list.ry` and `remove` in `map.ry`
- Corrected IO function return types in `io.ry` from plain types to `Result<T, Error>` to match the C++ runtime/codegen implementations

Closes #454

## Test plan

- [x] All C++ tests pass (1232 tests)
- [x] All Ry self-tests pass (61 test files)
- [x] ASan build passes with no errors