### PR TITLE
fix: sanitize HTTP response headers to prevent response splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Variable reassignment now uses the full destructor resolver (covering resources and closures) instead of only resolving collection destructors
 - Parser error message for unexpected tokens in statement position now says `unexpected token 'X'` instead of listing all valid keywords — also removes `expect` from keyword listing since it is a function, not a keyword (#404)
 - Eliminated DNS rebinding TOCTOU gap in HTTP client SSRF protection — DNS is now resolved once and the same result is used for both the private-host check and the connection, preventing attackers from bypassing SSRF guards via DNS rebinding; also added IPv4-mapped IPv6 address detection (#470)
+- HTTP response headers containing CR or LF characters are now silently skipped to prevent response splitting attacks (#472)
 
 ### Changed
 

--- a/include/ry/runtime_http_types.hpp
+++ b/include/ry/runtime_http_types.hpp
@@ -172,6 +172,19 @@ inline const char *find_in_kv_pairs(char **keys, char **vals, int64_t count,
 }
 
 // ---------------------------------------------------------------------------
+// CRLF validation — used by both client and server paths to prevent
+// HTTP request/response splitting via injected CR/LF in headers.
+// ---------------------------------------------------------------------------
+
+inline bool has_crlf(const char *s) {
+    if (!s) return false;
+    for (; *s; s++) {
+        if (*s == '\r' || *s == '\n') return true;
+    }
+    return false;
+}
+
+// ---------------------------------------------------------------------------
 // Header parsing helpers
 // ---------------------------------------------------------------------------
 

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -561,14 +561,17 @@ extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, co
     resp->body = checked_memdup(b, (size_t)resp->body_len);
 
     auto *map = (MapHeader *)headers_map;
-    resp->header_count = map->len;
     if (map->len > 0) {
         resp->header_keys = (char **)checked_malloc(sizeof(char *) * (size_t)map->len);
         resp->header_values = (char **)checked_malloc(sizeof(char *) * (size_t)map->len);
+        int64_t actual = 0;
         for (int64_t i = 0; i < map->len; i++) {
-            resp->header_keys[i] = checked_strdup(map->keys[i]);
-            resp->header_values[i] = checked_strdup(map->vals[i]);
+            if (has_crlf(map->keys[i]) || has_crlf(map->vals[i])) continue;
+            resp->header_keys[actual] = checked_strdup(map->keys[i]);
+            resp->header_values[actual] = checked_strdup(map->vals[i]);
+            actual++;
         }
+        resp->header_count = actual;
     } else {
         resp->header_keys = nullptr;
         resp->header_values = nullptr;

--- a/src/runtime_http_client.cpp
+++ b/src/runtime_http_client.cpp
@@ -309,15 +309,6 @@ static bool is_redirect_status(int status) {
            status == 307 || status == 308;
 }
 
-// Reject strings containing CR or LF to prevent HTTP request splitting
-static bool has_crlf(const char *s) {
-    if (!s) return false;
-    for (; *s; s++) {
-        if (*s == '\r' || *s == '\n') return true;
-    }
-    return false;
-}
-
 // RAII guard for freeaddrinfo
 struct AddrInfoGuard {
     struct addrinfo *info;

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -8,9 +8,9 @@
 #include <arpa/inet.h>
 #include <unistd.h>
 #include "ry/runtime_net.hpp"
+#include "ry/runtime_http_types.hpp"
 
 extern "C" {
-int64_t __ry_http_parse_content_length(const char *value);
 const char *__ry_http_reason_phrase(int64_t status);
 void *__ry_http_read_request(void *stream);
 const char *__ry_http_method(void *req);
@@ -448,16 +448,6 @@ TEST(RuntimeHttp, QueryParamsDuplicateFirstWins) {
     free(handle);
 }
 
-// MapHeader layout must match codegen
-struct MapHeader {
-    int64_t len;
-    int64_t cap;
-    char **keys;
-    char **vals;
-    int64_t bucket_count;
-    void *buckets;
-};
-
 TEST(RuntimeHttp, QueryAllBasic) {
     int fds[2];
     ASSERT_EQ(socketpair(AF_UNIX, SOCK_STREAM, 0, fds), 0);
@@ -556,9 +546,6 @@ TEST(RuntimeHttp, QueryAllDuplicateFirstWins) {
     ::close(fds[0]);
     free(handle);
 }
-
-// --- ParsedUrl struct for tests (must match runtime_http.cpp layout) ---
-struct ParsedUrl { char *host; int64_t port; char *path; bool is_https; };
 
 // --- Merged URL parsing tests ---
 
@@ -1961,4 +1948,115 @@ TEST(RuntimeHttp, FormFileDefaultContentType) {
     __ry_http_request_free(result);
     ::close(fds[0]);
     free(handle);
+}
+
+// --- Response header CRLF injection tests ---
+
+// Helper to build a MapHeader for response CRLF tests
+static MapHeader *build_response_headers(
+    std::initializer_list<std::pair<const char *, const char *>> entries) {
+    auto *map = (MapHeader *)malloc(sizeof(MapHeader));
+    auto count = (int64_t)entries.size();
+    map->len = count;
+    map->cap = count;
+    map->keys = count > 0 ? (char **)malloc(sizeof(char *) * (size_t)count) : nullptr;
+    map->vals = count > 0 ? (char **)malloc(sizeof(char *) * (size_t)count) : nullptr;
+    map->bucket_count = 4;
+    map->buckets = calloc(4, sizeof(int64_t));
+    int64_t i = 0;
+    for (auto &[k, v] : entries) {
+        map->keys[i] = strdup(k);
+        map->vals[i] = strdup(v);
+        i++;
+    }
+    return map;
+}
+
+static void free_response_headers(MapHeader *map) {
+    for (int64_t i = 0; i < map->len; i++) {
+        free(map->keys[i]);
+        free(map->vals[i]);
+    }
+    free(map->keys);
+    free(map->vals);
+    free(map->buckets);
+    free(map);
+}
+
+TEST(RuntimeHttp, ResponseHeaderCRLFInKeyIsSkipped) {
+    auto *map = build_response_headers({
+        {"X-Safe", "ok"},
+        {"X-Evil\r\nInjected: bad", "value"},
+        {"X-Also-Safe", "fine"},
+    });
+
+    void *resp_ptr = __ry_http_response_create(200, map, "body");
+    auto *resp = (HttpResponseHandle *)resp_ptr;
+
+    ASSERT_EQ(resp->header_count, 2);
+    EXPECT_STREQ(resp->header_keys[0], "X-Safe");
+    EXPECT_STREQ(resp->header_values[0], "ok");
+    EXPECT_STREQ(resp->header_keys[1], "X-Also-Safe");
+    EXPECT_STREQ(resp->header_values[1], "fine");
+
+    __ry_http_response_free(resp_ptr);
+    free_response_headers(map);
+}
+
+TEST(RuntimeHttp, ResponseHeaderCRLFInValueIsSkipped) {
+    auto *map = build_response_headers({
+        {"X-Safe", "ok"},
+        {"X-Inject", "val\r\nEvil-Header: injected"},
+        {"X-Also-Safe", "fine"},
+    });
+
+    void *resp_ptr = __ry_http_response_create(200, map, "body");
+    auto *resp = (HttpResponseHandle *)resp_ptr;
+
+    ASSERT_EQ(resp->header_count, 2);
+    EXPECT_STREQ(resp->header_keys[0], "X-Safe");
+    EXPECT_STREQ(resp->header_keys[1], "X-Also-Safe");
+
+    __ry_http_response_free(resp_ptr);
+    free_response_headers(map);
+}
+
+TEST(RuntimeHttp, ResponseHeaderLFOnlyIsSkipped) {
+    auto *map = build_response_headers({
+        {"X-LF-Key\n", "val"},
+        {"X-Normal", "good\ninjection"},
+        {"X-Clean", "safe"},
+    });
+
+    void *resp_ptr = __ry_http_response_create(200, map, "body");
+    auto *resp = (HttpResponseHandle *)resp_ptr;
+
+    ASSERT_EQ(resp->header_count, 1);
+    EXPECT_STREQ(resp->header_keys[0], "X-Clean");
+    EXPECT_STREQ(resp->header_values[0], "safe");
+
+    __ry_http_response_free(resp_ptr);
+    free_response_headers(map);
+}
+
+TEST(RuntimeHttp, ResponseHeaderSafeHeadersUnaffected) {
+    auto *map = build_response_headers({
+        {"Content-Type", "text/html"},
+        {"X-Custom", "value123"},
+        {"Cache-Control", "no-cache"},
+    });
+
+    void *resp_ptr = __ry_http_response_create(200, map, "body");
+    auto *resp = (HttpResponseHandle *)resp_ptr;
+
+    ASSERT_EQ(resp->header_count, 3);
+    EXPECT_STREQ(resp->header_keys[0], "Content-Type");
+    EXPECT_STREQ(resp->header_values[0], "text/html");
+    EXPECT_STREQ(resp->header_keys[1], "X-Custom");
+    EXPECT_STREQ(resp->header_values[1], "value123");
+    EXPECT_STREQ(resp->header_keys[2], "Cache-Control");
+    EXPECT_STREQ(resp->header_values[2], "no-cache");
+
+    __ry_http_response_free(resp_ptr);
+    free_response_headers(map);
 }


### PR DESCRIPTION
## Summary

- Skip response headers containing CR or LF characters in `__ry_http_response_create()` to prevent HTTP response splitting attacks, consistent with the existing client-side request header hardening
- Consolidate the shared `has_crlf()` helper into `runtime_http_types.hpp` (was duplicated as `static` in both `runtime_http.cpp` and `runtime_http_client.cpp`)
- Remove duplicate struct definitions (`MapHeader`, `HttpResponseHandle`, `ParsedUrl`) from test file, replaced with `#include "ry/runtime_http_types.hpp"`

Closes #472

## Test plan

- [x] 4 new tests added: CRLF in key, CRLF in value, LF-only, safe headers unaffected
- [x] All 1247 C++ tests pass
- [x] All 61 Ry self-test files pass
- [x] ASan build passes with no errors