### PR TITLE
feat: rename pattern matching from `when value:` to `match value:`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Breaking**: Pattern matching syntax renamed from `when value:` to `match value:`; conditional `when:` (without subject) is unchanged (#482)
 - **Breaking**: Self-update now requires Ed25519 signature verification by default; set `RY_SKIP_SIGNATURE=1` to opt out (#469)
 
 ### Added
 
-- Regex literal syntax (`/pattern/`) that produces a `Regex` type, enabling type-based overload resolution and UFCS-compatible function calls (e.g., `"hello".match(/[a-z]+/)`, `"a1b2".split(/[0-9]/)`) (#458)
-- New text-first regex functions: `match`, `search`, `replace`, `split`, `find_all` — overloaded to accept `Regex` type patterns alongside existing string functions
+- Regex literal syntax (`/pattern/`) that produces a `Regex` type, enabling type-based overload resolution and UFCS-compatible function calls (e.g., `"hello".is_match(/[a-z]+/)`, `"a1b2".split(/[0-9]/)`) (#458)
+- New text-first regex functions: `is_match`, `search`, `replace`, `split`, `find_all` — overloaded to accept `Regex` type patterns alongside existing string functions
 - `print()` now accepts multiple arguments with space-separated output (e.g., `print(1, "hello", true)` → `1 hello true`), and calling `print()` with no arguments now prints only a newline
 
 ### Fixed

--- a/docs/reference/base64.md
+++ b/docs/reference/base64.md
@@ -27,7 +27,7 @@ from base64 import encode, decode
 encoded = encode("Hello, World!")
 print(encoded)  # SGVsbG8sIFdvcmxkIQ==
 
-when decode(encoded):
+match decode(encoded):
     case Ok(s):
         print(s)  # Hello, World!
     case Err(e):
@@ -44,7 +44,7 @@ from base64 import encode_url_safe, decode_url_safe
 encoded = encode_url_safe("data with special chars: ?&=")
 # No + / or = in the output
 
-when decode_url_safe(encoded):
+match decode_url_safe(encoded):
     case Ok(s):
         print(s)
     case Err(e):
@@ -68,7 +68,7 @@ encoded = encode(bytes_to_str(bytes)?)
 `decode` and `decode_url_safe` return `Result<str, Error>`. Decoding fails if the input contains invalid base64 characters.
 
 ```python
-when decode("!!!not-valid!!!"):
+match decode("!!!not-valid!!!"):
     case Ok(s):
         print(s)
     case Err(e):

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -299,7 +299,7 @@ If a `.env` file exists in the project root (the directory containing `package.t
 ```python
 # One-argument form: returns Option<str>
 path = env("PATH")
-when path:
+match path:
     case Some(v):
         print(v)
     case None:

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -269,7 +269,7 @@ for i in range(5):
 ## `...` (Ellipsis)
 
 - A no-op statement that does nothing. Used as a placeholder for empty blocks.
-- Can be used in any block: function body, `if`/`else`, `while`, `for`, `when` arm, etc.
+- Can be used in any block: function body, `if`/`else`, `while`, `for`, `match` arm, etc.
 
 ```python
 function not_yet():
@@ -288,7 +288,7 @@ else:
 `when` has two statement forms:
 
 - `when:` for multi-branch conditional flow
-- `when value:` for pattern matching on a subject value
+- `match value:` for pattern matching on a subject value
 
 ### Conditional `when:`
 
@@ -322,12 +322,12 @@ The conditional `when:` statement evaluates arms from top to bottom and executes
 
 For the expression form of `when:`, see [Operator Reference](operators.md#when-conditional-expression).
 
-### Pattern `when value:`
+### Pattern `match value:`
 
 #### Syntax
 
 ```python
-when expression:
+match expression:
     case pattern:
         # body
     case pattern if guard_condition:
@@ -360,14 +360,14 @@ A guard condition can be specified in the form `case pattern if condition:`. The
 Multiple patterns can be combined with `|` to match any of them. Variable bindings (`n`, `Some(x)`, `Ok(v)`, `Err(e)`) are not allowed in OR patterns.
 
 ```python
-when x:
+match x:
     case 1 | 2 | 3:
         print("small")
     case _:
         print("other")
 
 # Enum OR pattern
-when color:
+match color:
     case Color::Red | Color::Blue:
         print("warm or cool")
     case Color::Green:
@@ -385,13 +385,13 @@ when color:
 #### Example
 
 ```python
-# enum pattern when
+# enum pattern match
 enum Color:
     Red
     Green
     Blue
 
-when color:
+match color:
     case Color::Red:
         print("red")
     case Color::Green:
@@ -399,28 +399,28 @@ when color:
     case Color::Blue:
         print("blue")
 
-# Option pattern when
+# Option pattern match
 x: Option<int> = Some(42)
-when x:
+match x:
     case Some(v):
         print(v)
     case None:
         print("nothing")
 
-# Result pattern when
+# Result pattern match
 function divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
         return Err(Error("division by zero"))
     return Ok(a // b)
 
-when divide(10, 2):
+match divide(10, 2):
     case Ok(v):
         print(v)         # 5
     case Err(e):
         print(e.message)
 
-# Literal pattern when
-when x:
+# Literal pattern match
+match x:
     case 0:
         print("zero")
     case 1:
@@ -429,7 +429,7 @@ when x:
         print("other")
 
 # Guard clause
-when x:
+match x:
     case n if n > 0:
         print("positive")
     case n if n < 0:
@@ -449,7 +449,7 @@ enum Shape:
     Point
 
 s = Shape::Circle(3.14)
-when s:
+match s:
     case Shape::Circle(r):
         print(r)        # 3.14
     case Shape::Rectangle(w, h):

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -39,7 +39,7 @@ Each error message includes:
 | Module import inside block | Used `from` statement inside a function or conditional block | `from math` inside a function |
 | Circular import | Modules import each other | `a.ry` imports `b.ry` and `b.ry` imports `a.ry` |
 | Duplicate field name | Defined the same field name twice in a struct | Defining `x` twice in `type T: x: int` |
-| Non-exhaustive when | `when` does not cover all patterns | Some enum variants uncovered, missing `None` for Option, missing `Ok`/`Err` for Result, no `_` for literals |
+| Non-exhaustive match | `match` does not cover all patterns | Some enum variants uncovered, missing `None` for Option, missing `Ok`/`Err` for Result, no `_` for literals |
 | `?` on non-Result type | Applied `?` to an expression that is not a `Result` type | `x = 42` -> `x?` |
 | `?` in non-Result function | Used `?` in a function that does not return `Result` | `function foo() -> int:` -> `bar()?` |
 

--- a/docs/reference/filesystem.md
+++ b/docs/reference/filesystem.md
@@ -41,7 +41,7 @@ from filesystem import chmod, symlink, read_link
 from filesystem import make_dir, make_dir_all, list_dir, remove_all
 
 # Create a single directory
-when make_dir("/tmp/myapp"):
+match make_dir("/tmp/myapp"):
   case Ok(_):
     print("created")
   case Err(e):
@@ -51,7 +51,7 @@ when make_dir("/tmp/myapp"):
 make_dir_all("/tmp/myapp/data/logs")
 
 # List directory contents
-when list_dir("/tmp/myapp"):
+match list_dir("/tmp/myapp"):
   case Ok(entries):
     for entry in entries:
       print(entry)
@@ -74,7 +74,7 @@ write_text("/tmp/hello.txt", "Hello, World!")
 copy("/tmp/hello.txt", "/tmp/hello_copy.txt")
 
 # Get file size
-when file_size("/tmp/hello.txt"):
+match file_size("/tmp/hello.txt"):
   case Ok(sz):
     print("size: " + to_string(sz))
   case Err(e):
@@ -93,7 +93,7 @@ remove("/tmp/renamed.txt")
 from filesystem import walk, glob_files
 
 # Walk a directory tree (like find)
-when walk("/var/log"):
+match walk("/var/log"):
   case Ok(files):
     for f in files:
       print(f)
@@ -101,7 +101,7 @@ when walk("/var/log"):
     print("error: " + e.message)
 
 # Glob pattern matching
-when glob_files("/var/log/*.log"):
+match glob_files("/var/log/*.log"):
   case Ok(matches):
     for m in matches:
       print(m)
@@ -134,7 +134,7 @@ symlink("/usr/local/bin/ry", "/tmp/ry_link")
 
 # Check and read symlink
 if is_symlink("/tmp/ry_link"):
-  when read_link("/tmp/ry_link"):
+  match read_link("/tmp/ry_link"):
     case Ok(target):
       print("points to: " + target)
     case Err(e):

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -564,9 +564,9 @@ Built-in functions for explicit overflow control on low-level integer types (`i8
 | `wrapping_mul(a, b)` | `T` | Explicit wrapping (same as `*`) |
 
 ```python
-# Checked: returns Result, use when or ? to handle
+# Checked: returns Result, use match or ? to handle
 r = checked_add(2147483647i32, 1i32)
-when r:
+match r:
   case Ok(v):
     print(v)
   case Err(e):

--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -106,7 +106,7 @@ t = start_server()
 sleep(100)  # Wait for server to start
 port = port_holder[0]
 
-when http_get("http://127.0.0.1:" + to_str(port) + "/"):
+match http_get("http://127.0.0.1:" + to_str(port) + "/"):
     case Ok(resp):
         print(body(resp))  # "Hello!"
     case Err(e):
@@ -123,7 +123,7 @@ from http import listen, path, query, query_all, response
 listen("127.0.0.1", 8080, function(req: HttpRequest) -> HttpResponse:
     p = path(req)
     if p == "/search":
-        when query(req, "q"):
+        match query(req, "q"):
             case Some(q):
                 return response(200, {"Content-Type": "text/plain"}, "Search: " + q)
             case None:
@@ -138,7 +138,7 @@ listen("127.0.0.1", 8080, function(req: HttpRequest) -> HttpResponse:
 from http import listen, header, response
 
 listen("127.0.0.1", 8080, function(req: HttpRequest) -> HttpResponse:
-    when header(req, "Authorization"):
+    match header(req, "Authorization"):
         case Some(token):
             return response(200, {"Content-Type": "text/plain"}, "Authenticated: " + token)
         case None:
@@ -152,9 +152,9 @@ listen("127.0.0.1", 8080, function(req: HttpRequest) -> HttpResponse:
 from http import listen, form_field, form_file, response
 
 listen("127.0.0.1", 8080, function(req: HttpRequest) -> HttpResponse:
-    when form_field(req, "username"):
+    match form_field(req, "username"):
         case Some(name):
-            when form_file(req, "avatar"):
+            match form_file(req, "avatar"):
                 case Some(file_info):
                     filename = file_info["filename"]
                     return response(200, {"Content-Type": "text/plain"}, "Hello " + name + ", file: " + filename)
@@ -171,7 +171,7 @@ listen("127.0.0.1", 8080, function(req: HttpRequest) -> HttpResponse:
 from http import listen, cookie, cookies, response
 
 listen("127.0.0.1", 8080, function(req: HttpRequest) -> HttpResponse:
-    when cookie(req, "session_id"):
+    match cookie(req, "session_id"):
         case Some(sid):
             return response(200, {"Content-Type": "text/plain"}, "Session: " + sid)
         case None:
@@ -279,7 +279,7 @@ Other status codes use `"Unknown"` as the reason phrase.
 from http import http_get, http_post, status, body, header
 
 # Simple GET request
-when http_get("http://example.com/api/data"):
+match http_get("http://example.com/api/data"):
     case Ok(resp):
         s = status(resp)
         b = body(resp)
@@ -289,7 +289,7 @@ when http_get("http://example.com/api/data"):
 
 # POST request with body and headers
 headers: Map<str, str> = {"Content-Type": "application/json"}
-when http_post("http://example.com/api/data", "{\"key\": \"value\"}", headers):
+match http_post("http://example.com/api/data", "{\"key\": \"value\"}", headers):
     case Ok(resp):
         print(body(resp))
     case Err(e):
@@ -328,4 +328,4 @@ HTTP client functions automatically follow redirect responses (3xx with `Locatio
 - `listen()` raises a runtime error if `bind()` fails (e.g., port already in use).
 - Malformed requests or idle timeouts on a keep-alive connection cause the connection to be closed. The server then resumes accepting new connections.
 - The handler function must always return an `HttpResponse` — there is no default response.
-- Client functions return `Result<HttpClientResponse, Error>` — use `when` to handle success and failure.
+- Client functions return `Result<HttpClientResponse, Error>` — use `match` to handle success and failure.

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -43,9 +43,9 @@ from io import read_text, write_text, exists
 ```python
 from io import read_text, write_text, append_text, exists, delete_file
 
-when write_text("hello.txt", "Hello, World!"):
+match write_text("hello.txt", "Hello, World!"):
     case Ok(_):
-        when read_text("hello.txt"):
+        match read_text("hello.txt"):
             case Ok(content):
                 print(content)   # Hello, World!
             case Err(e):
@@ -55,7 +55,7 @@ when write_text("hello.txt", "Hello, World!"):
 
 print(exists("hello.txt"))   # true
 
-when delete_file("hello.txt"):
+match delete_file("hello.txt"):
     case Ok(_):
         print(exists("hello.txt"))   # false
     case Err(e):
@@ -70,11 +70,11 @@ from io import to_bytes, bytes_to_str, write_bytes, read_bytes
 bs = to_bytes("ABC")
 print(length(bs))    # 3
 
-when write_bytes("data.bin", bs):
+match write_bytes("data.bin", bs):
     case Ok(_):
-        when read_bytes("data.bin"):
+        match read_bytes("data.bin"):
             case Ok(rb):
-                when bytes_to_str(rb):
+                match bytes_to_str(rb):
                     case Ok(s):
                         print(s)          # ABC
                     case Err(e):
@@ -96,10 +96,10 @@ print(f"Hello, {name}!")
 
 ## Error Handling
 
-File operations return `Result<T, Error>` instead of terminating on failure. Use `when` with `Ok`/`Err` patterns to handle errors:
+File operations return `Result<T, Error>` instead of terminating on failure. Use `match` with `Ok`/`Err` patterns to handle errors:
 
 ```python
-when read_text("missing.txt"):
+match read_text("missing.txt"):
     case Ok(content):
         print(content)
     case Err(e):

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -64,11 +64,11 @@ The `json` package provides functions to parse JSON text into an opaque `JsonVal
 ```python
 from json import parse, get, to_str, to_int, json_free
 
-when parse("{\"name\": \"Alice\", \"age\": 30}"):
+match parse("{\"name\": \"Alice\", \"age\": 30}"):
   case Ok(data):
-    when get(data, "name"):
+    match get(data, "name"):
       case Ok(val):
-        when to_str(val):
+        match to_str(val):
           case Ok(name):
             print(name)   # "Alice"
           case Err(e):
@@ -85,12 +85,12 @@ when parse("{\"name\": \"Alice\", \"age\": 30}"):
 ```python
 from json import parse, at, to_int, length, json_free
 
-when parse("[10, 20, 30]"):
+match parse("[10, 20, 30]"):
   case Ok(data):
     print(to_str(length(data)))   # 3
-    when at(data, 0):
+    match at(data, 0):
       case Ok(elem):
-        when to_int(elem):
+        match to_int(elem):
           case Ok(n):
             print(to_str(n))   # 10
           case Err(e):
@@ -107,7 +107,7 @@ when parse("[10, 20, 30]"):
 ```python
 from json import parse, stringify, json_free
 
-when parse("{\"key\":\"value\",\"count\":42}"):
+match parse("{\"key\":\"value\",\"count\":42}"):
   case Ok(data):
     print(stringify(data, 2))
     # {

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -53,15 +53,15 @@ from net import bind, listen, accept, connect
 from io import to_bytes, bytes_to_str
 
 # Server
-when bind("127.0.0.1", 8080):
+match bind("127.0.0.1", 8080):
     case Ok(server):
-        when listen(server, 128):
+        match listen(server, 128):
             case Ok(_):
-                when accept(server):
+                match accept(server):
                     case Ok(conn):
-                        when receive(conn, 4096):
+                        match receive(conn, 4096):
                             case Ok(data):
-                                when send(conn, data):
+                                match send(conn, data):
                                     case Ok(_):
                                         ...
                                     case Err(e):
@@ -81,16 +81,16 @@ when bind("127.0.0.1", 8080):
 ### Client
 
 ```python
-when connect("127.0.0.1", 8080):
+match connect("127.0.0.1", 8080):
     case Ok(conn):
-        when send(conn, to_bytes("hello")):
+        match send(conn, to_bytes("hello")):
             case Ok(_):
                 ...
             case Err(e):
                 print(e.message)
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(s):
                         print(s)
                     case Err(e):
@@ -109,11 +109,11 @@ from net import bind, listen, accept, connect, listener_port
 from io import to_bytes, bytes_to_str
 
 async function echo_server(server: TcpListener) -> str:
-    when accept(server):
+    match accept(server):
         case Ok(conn):
-            when receive(conn, 4096):
+            match receive(conn, 4096):
                 case Ok(data):
-                    when send(conn, data):
+                    match send(conn, data):
                         case Ok(_):
                             ...
                         case Err(e):
@@ -126,9 +126,9 @@ async function echo_server(server: TcpListener) -> str:
     close(server)
     return "done"
 
-when bind("127.0.0.1", 0):
+match bind("127.0.0.1", 0):
     case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
             case Ok(_):
                 port = listener_port(server)
                 t = echo_server(server)
@@ -147,10 +147,10 @@ By default, `receive()` uses a 30-second timeout if no custom timeout is set. Us
 ```python
 from net import connect, set_receive_timeout
 
-when connect("127.0.0.1", 8080):
+match connect("127.0.0.1", 8080):
     case Ok(conn):
         set_receive_timeout(conn, 5000)  # 5-second timeout
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(data):
                 ...
             case Err(e):
@@ -164,7 +164,7 @@ Pass `0` to disable the timeout (wait indefinitely).
 
 ## Error Handling
 
-- All TCP functions except `close()` return `Result<T, Error>` — use `when` with `Ok`/`Err` to handle failure.
+- All TCP functions except `close()` return `Result<T, Error>` — use `match` with `Ok`/`Err` to handle failure.
 - `receive()` returns `Ok` with an empty `List<u8>` when the connection is closed by the peer, and `Err` on actual errors (timeout, socket error).
 - `close()` closes the socket and frees the handle. Using a handle after close is undefined behavior.
 

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -136,13 +136,13 @@ function compute(a: int, b: int, c: int) -> Result<int, Error>:
     return Ok(y + 1)
 ```
 
-This is equivalent to the following `when` pattern, but much more concise:
+This is equivalent to the following `match` pattern, but much more concise:
 
 ```python
 function compute(a: int, b: int, c: int) -> Result<int, Error>:
-    when safe_divide(a, b):
+    match safe_divide(a, b):
         case Ok(x):
-            when safe_divide(x, c):
+            match safe_divide(x, c):
                 case Ok(y):
                     return Ok(y + 1)
                 case Err(e):

--- a/docs/reference/path.md
+++ b/docs/reference/path.md
@@ -72,13 +72,13 @@ print(is_absolute("src/main.ry")) # false
 ```python
 from path import resolve
 
-when resolve("/tmp"):
+match resolve("/tmp"):
   case Ok(p):
     print(p)  # /private/tmp (on macOS) or /tmp
   case Err(e):
     print(e.message)
 
-when resolve("/nonexistent"):
+match resolve("/nonexistent"):
   case Ok(p):
     print(p)
   case Err(e):

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -7,10 +7,10 @@
 Regex literals use the `/pattern/` syntax and produce a `Regex` type value:
 
 ```ry
-from regex import match, split, replace
+from regex import is_match, split, replace
 
 # Regex literals enable type-based overloading
-"hello".match(/[a-z]+/)        # true
+"hello".is_match(/[a-z]+/)        # true
 "a1b2c".split(/[0-9]/)         # ["a", "b", "c"]
 "abc123".replace(/[0-9]+/, "X") # "abcX"
 ```
@@ -19,13 +19,13 @@ Regex literals can be stored in variables:
 
 ```ry
 pat = /[a-z]+/
-"hello".match(pat)  # true
+"hello".is_match(pat)  # true
 ```
 
 The `/` inside a regex literal can be escaped with `\/`:
 
 ```ry
-"a/b".match(/a\/b/)  # true
+"a/b".is_match(/a\/b/)  # true
 ```
 
 ### Division vs Regex
@@ -37,7 +37,7 @@ The lexer uses context to distinguish regex literals from division:
 
 ```ry
 x = 10 / 2         # division: 5
-y = match("a", /a/) # regex literal
+y = is_match("a", /a/) # regex literal
 ```
 
 ## Function List
@@ -48,17 +48,17 @@ These functions take a `Regex` type pattern and use text-first argument order fo
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `match` | `(str, Regex) -> bool` | Returns whether the entire text matches the pattern |
+| `is_match` | `(str, Regex) -> bool` | Returns whether the entire text matches the pattern |
 | `search` | `(str, Regex) -> int` | Returns the start position of the first match (-1 if not found) |
 | `replace` | `(str, Regex, str) -> str` | Replaces all matches with a replacement string |
 | `split` | `(str, Regex) -> List<str>` | Splits text by pattern matches |
 | `find_all` | `(str, Regex) -> List<str>` | Returns all non-overlapping matches |
 
 ```ry
-from regex import match, search, replace, split, find_all
+from regex import is_match, search, replace, split, find_all
 
 # Direct call
-print(match("hello", /[a-z]+/))          # true
+print(is_match("hello", /[a-z]+/))       # true
 
 # UFCS (text.function(pattern))
 print("abc123".search(/[0-9]+/))          # 3

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -230,7 +230,7 @@ Accessing a weak variable automatically performs an **upgrade** — an atomic ch
 ```python
 s = "alive"
 w: weak str = weak s
-when w:
+match w:
   case Some(v):
     print(v)           # "alive"
   case None:
@@ -378,7 +378,7 @@ p = Shape::Point
 Use `case EnumName::Variant(binding):` to extract the associated data. Bindings use user-chosen variable names, not field names.
 
 ```python
-when c:
+match c:
     case Shape::Circle(r):
         print(r)            # 3.14
     case Shape::Rectangle(w, h):
@@ -412,7 +412,7 @@ Instantiate by providing a concrete type argument. The type argument is required
 a = MyOption<int>::MySome(42)
 b = MyOption<int>::MyNone
 
-when a:
+match a:
     case MyOption::MySome(v):
         print(v)      # 42
     case MyOption::MyNone:
@@ -444,7 +444,7 @@ function divide(a: int, b: int) -> Result<int, Error>:
         return Err(Error("division by zero"))
     return Ok(a // b)
 
-when divide(10, 2):
+match divide(10, 2):
     case Ok(v):
         print(v)            # 5
     case Err(e):
@@ -457,7 +457,7 @@ When the return value is not meaningful, use `Result<Unit, Error>`:
 function save(path: str, data: str) -> Result<Unit, Error>:
     return Ok(0 as u8)   # Unit placeholder
 
-when save("/tmp/test.txt", "hello"):
+match save("/tmp/test.txt", "hello"):
     case Ok(_):
         print("saved")
     case Err(e):
@@ -471,7 +471,7 @@ when save("/tmp/test.txt", "hello"):
 - `Ok(value)` — success variant
 - `Err(error)` — error variant
 
-It is used with `when` for exhaustive error handling. Both `Ok` and `Err` cases must be covered (or use `_` wildcard).
+It is used with `match` for exhaustive error handling. Both `Ok` and `Err` cases must be covered (or use `_` wildcard).
 
 **Test matchers:**
 - `expect(x).to_be_ok()` — asserts the result is `Ok`

--- a/docs/tutorial/04-control-flow.md
+++ b/docs/tutorial/04-control-flow.md
@@ -36,7 +36,7 @@ if a > 0:
 
 ## when
 
-Use `when:` for multi-branch conditionals, or `when value:` for pattern matching.
+Use `when:` for multi-branch conditionals, or `match value:` for pattern matching.
 
 ### Conditional `when:`
 
@@ -54,7 +54,7 @@ when:
 
 This is the preferred form when you would otherwise chain multiple branches.
 
-### Pattern `when value:`
+### Pattern `match value:`
 
 ```python
 enum Color:
@@ -63,7 +63,7 @@ enum Color:
     Blue
 
 c = Color::Green
-when c:
+match c:
     case Color::Red:
         print("red")
     case Color::Green:
@@ -257,7 +257,7 @@ print(x)       # 99
 
 ## Pattern Matching
 
-`when value:` safely branches on enums, `Option`, `Result`, and literals.
+`match value:` safely branches on enums, `Option`, `Result`, and literals.
 
 ```python
 enum Color:
@@ -266,7 +266,7 @@ enum Color:
     Blue
 
 c = Color::Green
-when c:
+match c:
     case Color::Red:
         print("red")
     case Color::Green:
@@ -278,11 +278,11 @@ when c:
 
 ### Option Matching
 
-Use `when value:` to safely handle both the `Some` and `None` cases.
+Use `match value:` to safely handle both the `Some` and `None` cases.
 
 ```python
 x: Option<int> = Some(42)
-when x:
+match x:
     case Some(v):
         print(v)
     case None:
@@ -296,7 +296,7 @@ when x:
 
 ```python
 n = 5
-when n:
+match n:
     case 0:
         print("zero")
     case 1:
@@ -311,7 +311,7 @@ when n:
 You can add guard conditions with `if`.
 
 ```python
-when n:
+match n:
     case x if x > 0:
         print("positive")
     case x if x < 0:
@@ -320,7 +320,7 @@ when n:
         print("zero")
 ```
 
-> **Note**: `when value:` must be exhaustive. For enums, all variants must be covered. For Options, both `Some` and `None` are required. For literals, a `_` wildcard is needed.
+> **Note**: `match value:` must be exhaustive. For enums, all variants must be covered. For Options, both `Some` and `None` are required. For literals, a `_` wildcard is needed.
 
 ---
 

--- a/docs/tutorial/06-records.md
+++ b/docs/tutorial/06-records.md
@@ -173,11 +173,11 @@ p = Shape::Point
 
 ### Matching ADT Variants
 
-Use `when` with `case` to extract the associated data. Bindings use your chosen variable names, not the field names. This connects directly with the pattern matching you learned in [Control Flow](04-control-flow.md).
+Use `match` with `case` to extract the associated data. Bindings use your chosen variable names, not the field names. This connects directly with the pattern matching you learned in [Control Flow](04-control-flow.md).
 
 ```python
 function describe(s: Shape) -> str:
-    when s:
+    match s:
         case Shape::Circle(r):
             return f"circle with radius {r}"
         case Shape::Rectangle(w, h):
@@ -209,7 +209,7 @@ enum MyOption<T>:
 a = MyOption<int>::MySome(42)
 b: MyOption<int> = MyOption<int>::MyNone
 
-when a:
+match a:
     case MyOption::MySome(v):
         print(v)      # 42
     case MyOption::MyNone:
@@ -270,7 +270,7 @@ function operator-(v: Vec2) -> Vec2:
 
 ## Exercises
 
-1. **ADT**: Define an `Animal` enum with variants `Dog(name: str)`, `Cat(name: str, indoor: bool)`, and `Fish`. Write a `describe(a: Animal) -> str` function that uses `when` to return a description for each variant.
+1. **ADT**: Define an `Animal` enum with variants `Dog(name: str)`, `Cat(name: str, indoor: bool)`, and `Fish`. Write a `describe(a: Animal) -> str` function that uses `match` to return a description for each variant.
 
 2. **Operator overloading**: Define a `Money` record with `amount: int` and `currency: str`. Overload `+` so that adding two `Money` values with the same currency returns a new `Money` with the summed amount.
 

--- a/docs/tutorial/08-error-handling.md
+++ b/docs/tutorial/08-error-handling.md
@@ -22,10 +22,10 @@ print(y)   # None
 
 ### Extracting the Value
 
-Use `when` to safely extract the inner value and handle the `None` case. This uses the pattern matching you learned in [Control Flow](04-control-flow.md):
+Use `match` to safely extract the inner value and handle the `None` case. This uses the pattern matching you learned in [Control Flow](04-control-flow.md):
 
 ```python
-when x:
+match x:
     case Some(v):
         print(v)    # 42
     case None:
@@ -51,11 +51,11 @@ function divide(a: int, b: int) -> Result<int, str>:
     return Ok(a // b)
 ```
 
-### Handling Results with when
+### Handling Results with match
 
 ```python
 r = divide(10, 0)
-when r:
+match r:
     case Ok(v):
         print(v)
     case Err(e):
@@ -81,7 +81,7 @@ This is equivalent to writing:
 
 ```python
 function divide_and_add(a: int, b: int) -> Result<int, Error>:
-    when safe_divide(a, b):
+    match safe_divide(a, b):
         case Ok(v):
             return Ok(v + 1)
         case Err(e):

--- a/docs/tutorial/10-concurrency.md
+++ b/docs/tutorial/10-concurrency.md
@@ -183,11 +183,11 @@ from net import bind, listen, accept, connect, listener_port
 from io import to_bytes, bytes_to_str
 
 async function echo_server(server: TcpListener) -> str:
-    when accept(server):
+    match accept(server):
         case Ok(conn):
-            when receive(conn, 4096):
+            match receive(conn, 4096):
                 case Ok(data):
-                    when send(conn, data):
+                    match send(conn, data):
                         case Ok(_):
                             ...
                         case Err(e):

--- a/docs/tutorial/12-building-a-project.md
+++ b/docs/tutorial/12-building-a-project.md
@@ -85,7 +85,7 @@ function find_task(tasks: List<Task>, id: int) -> Option<Task>:
     return None
 
 function complete_task(tasks: List<Task>, id: int) -> Result<List<Task>, Error>:
-    when find_task(tasks, id):
+    match find_task(tasks, id):
         case Some(t):
             t.status = Status::Done
             return Ok(tasks)
@@ -114,7 +114,7 @@ Add a display function to `src/model.ry`:
 ```python
 function format_task(t: Task) -> str:
     marker = "[ ]"
-    when t.status:
+    match t.status:
         case Status::Todo:
             marker = "[ ]"
         case Status::InProgress:
@@ -151,7 +151,7 @@ print("All tasks:")
 print_tasks(tasks)
 
 # Complete a task
-when complete_task(tasks, 1):
+match complete_task(tasks, 1):
     case Ok(updated):
         tasks = updated
     case Err(e):
@@ -205,7 +205,7 @@ describe("Task model", function():
     it("finds a task by id", function():
         tasks: List<Task> = []
         tasks = add_task(tasks, "Target")
-        when find_task(tasks, 1):
+        match find_task(tasks, 1):
             case Some(t):
                 expect(t.title).to_eq("Target")
             case None:
@@ -220,7 +220,7 @@ describe("Task model", function():
     it("completes a task", function():
         tasks: List<Task> = []
         tasks = add_task(tasks, "Do it")
-        when complete_task(tasks, 1):
+        match complete_task(tasks, 1):
             case Ok(updated):
                 remaining = pending_tasks(updated)
                 expect(is_empty(remaining)).to_be_true()
@@ -230,7 +230,7 @@ describe("Task model", function():
 
     it("returns error for invalid id", function():
         tasks: List<Task> = []
-        when complete_task(tasks, 999):
+        match complete_task(tasks, 999):
             case Ok(_):
                 fail("expected error")
             case Err(e):

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -270,7 +270,7 @@ struct IfStmt;
 struct WhileStmt;
 struct ForStmt;
 struct FnStmt;
-struct WhenMatchStmt;
+struct MatchStmt;
 struct WhenCondStmt;
 struct AwaitStmt;
 
@@ -291,7 +291,7 @@ using StmtNode = std::variant<AssignStmt, CallStmt,
                               std::unique_ptr<WhileStmt>,
                               std::unique_ptr<ForStmt>,
                               std::unique_ptr<FnStmt>,
-                              std::unique_ptr<WhenMatchStmt>>;
+                              std::unique_ptr<MatchStmt>>;
 using Program  = std::vector<StmtNode>;
 
 struct IfBranch {
@@ -428,7 +428,7 @@ struct MatchArm {
     std::vector<StmtNode> body;
 };
 
-struct WhenMatchStmt {
+struct MatchStmt {
     ExprPtr subject;
     std::vector<MatchArm> arms;
     SourceLocation loc;

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -438,7 +438,7 @@ private:
     void emitStmt(std::unique_ptr<WhileStmt> &s);
     void emitStmt(std::unique_ptr<ForStmt> &s);
     void emitStmt(std::unique_ptr<FnStmt> &s);
-    void emitStmt(std::unique_ptr<WhenMatchStmt> &s);
+    void emitStmt(std::unique_ptr<MatchStmt> &s);
     void emitDescribeCall(CallStmt &s);
     void emitItCall(CallStmt &s);
     void emitEachItCall(CallStmt &s);

--- a/include/ry/formatter.hpp
+++ b/include/ry/formatter.hpp
@@ -59,7 +59,7 @@ private:
     void formatWhile(const WhileStmt &s);
     void formatFor(const ForStmt &s);
     void formatFn(const FnStmt &s);
-    void formatWhenMatch(const WhenMatchStmt &s);
+    void formatMatch(const MatchStmt &s);
     void formatIndexAssign(const IndexAssignStmt &s);
     void formatFieldAssign(const FieldAssignStmt &s);
     void formatBreak(const BreakStmt &s);

--- a/include/ry/lexer.hpp
+++ b/include/ry/lexer.hpp
@@ -38,6 +38,7 @@ enum class TokenKind {
     If,             // if
     Else,           // else
     When,           // when
+    Match,          // match
     While,          // while
     // --- 関数定義 ---
     Fn,             // fn

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -60,6 +60,7 @@ private:
     StmtNode parseReturnStatement();
     StmtNode parseExpectStatement();
     StmtNode parseWhenStatement();
+    StmtNode parseMatchStatement();
     void tryParseTrailingBlock(CallStmt &s);
     ExprPtr parseTrailingBlockAsLambda();
     ExprPtr parseWhenExpr();

--- a/lib/std/regex.ry
+++ b/lib/std/regex.ry
@@ -16,7 +16,7 @@ function regex_find_all(pattern: str, text: str) -> List<str>
 
 # Regex literal overloads (text-first for UFCS)
 @native
-function match(text: str, pattern: Regex) -> bool
+function is_match(text: str, pattern: Regex) -> bool
 
 @native
 function search(text: str, pattern: Regex) -> int

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -343,7 +343,7 @@ static void collectMockedFunctions(const std::vector<StmtNode> &stmts,
                 collectMockedFunctions(s->body, out);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
                 collectMockedFunctions(s->body, out);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhenMatchStmt>>) {
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
                 for (auto &arm : s->arms)
                     collectMockedFunctions(arm.body, out);
             }

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -53,7 +53,7 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
         return builder_.CreateCall(fn, {pattern, text}, rtName);
     };
 
-    if (e.callee == "match" && e.args.size() == 2) {
+    if (e.callee == "is_match" && e.args.size() == 2) {
         if (auto *r = emitUfcsRegex("regex_match", fnTy_ptr_ptr_to_i64_))
             return builder_.CreateTrunc(r, i1Ty_, "regex_match_bool");
     }

--- a/src/codegen_call_thread.cpp
+++ b/src/codegen_call_thread.cpp
@@ -71,7 +71,7 @@ static std::unordered_set<std::string> collectReferencedVars(const LambdaExpr &l
                 for (auto &st : s->body) scanStmt(st);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
                 for (auto &st : s->body) scanStmt(st);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhenMatchStmt>>) {
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
                 scanExpr(*s->subject);
                 for (auto &arm : s->arms) {
                     if (arm.guard) scanExpr(*arm.guard);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -113,7 +113,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
                 for (auto &st : s->body) scanStmt(st);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
                 for (auto &st : s->body) scanStmt(st);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhenMatchStmt>>) {
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
                 scanExpr(*s->subject);
                 for (auto &arm : s->arms) {
                     if (arm.guard) scanExpr(*arm.guard);
@@ -403,7 +403,7 @@ void CodeGen::collectReturnTypes(const std::vector<StmtNode> &body,
                 for (auto &arm : s->arms)
                     collectReturnTypes(arm.body, paramTypeMap, out);
                 collectReturnTypes(s->else_body, paramTypeMap, out);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhenMatchStmt>>) {
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
                 for (auto &arm : s->arms)
                     collectReturnTypes(arm.body, paramTypeMap, out);
             }

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -1,9 +1,9 @@
 #include "ry/codegen.hpp"
 #include "ry/diagnostic.hpp"
 
-// ===== WhenMatchStmt =====
+// ===== MatchStmt =====
 
-void CodeGen::emitStmt(std::unique_ptr<WhenMatchStmt> &s) {
+void CodeGen::emitStmt(std::unique_ptr<MatchStmt> &s) {
     emitCoverage(s->loc);
     llvm::Value *subject = emitExpr(*s->subject);
     llvm::Type *subjectTy = subject->getType();
@@ -101,7 +101,7 @@ void CodeGen::emitStmt(std::unique_ptr<WhenMatchStmt> &s) {
                 }
                 for (auto &[vname, _] : it->second.variants) {
                     if (!covered.count(vname))
-                        codegenError("non-exhaustive when: missing variant '" +
+                        codegenError("non-exhaustive match: missing variant '" +
                             enumName + "::" + vname + "'");
                 }
             }
@@ -123,7 +123,7 @@ void CodeGen::emitStmt(std::unique_ptr<WhenMatchStmt> &s) {
             }
         }
         if ((hasSome && !hasNone) || (!hasSome && hasNone))
-            codegenError("non-exhaustive when: Option requires both Some and None cases (or use '_')");
+            codegenError("non-exhaustive match: Option requires both Some and None cases (or use '_')");
 
         // Check Result exhaustiveness
         bool hasOk = false, hasErr = false;
@@ -141,7 +141,7 @@ void CodeGen::emitStmt(std::unique_ptr<WhenMatchStmt> &s) {
             }
         }
         if ((hasOk && !hasErr) || (!hasOk && hasErr))
-            codegenError("non-exhaustive when: Result requires both Ok and Err cases (or use '_')");
+            codegenError("non-exhaustive match: Result requires both Ok and Err cases (or use '_')");
 
         // Check bool exhaustiveness
         bool hasTrue = false, hasFalse = false;
@@ -163,11 +163,11 @@ void CodeGen::emitStmt(std::unique_ptr<WhenMatchStmt> &s) {
             }
         }
         if (subjectTy == i1Ty_ && !(hasTrue && hasFalse) && !hasWildcardOrVar)
-            codegenError("non-exhaustive when: bool requires both true and false cases (or use '_')");
+            codegenError("non-exhaustive match: bool requires both true and false cases (or use '_')");
 
         // For int/float/string literals without wildcard
         if (enumName.empty() && !hasSome && !hasNone && !hasOk && !hasErr && !hasTrue && !hasFalse)
-            codegenError("non-exhaustive when: literal patterns require a wildcard '_' case");
+            codegenError("non-exhaustive match: literal patterns require a wildcard '_' case");
     }
 
     // --- Code generation: chain of conditional branches ---
@@ -224,7 +224,7 @@ void CodeGen::emitStmt(std::unique_ptr<WhenMatchStmt> &s) {
                     llvm::Value *cmp = builder_.CreateCall(strcmpFn, {subjectVal, litVal}, "strcmp");
                     testResult = builder_.CreateICmpEQ(cmp, llvm::ConstantInt::get(i32Ty_, 0), "match.streq");
                 } else {
-                    codegenError("when: incompatible types in literal pattern");
+                    codegenError("match: incompatible types in literal pattern");
                 }
             } else if constexpr (std::is_same_v<T, VariablePattern>) {
                 testResult = llvm::ConstantInt::get(i1Ty_, 1);
@@ -240,10 +240,10 @@ void CodeGen::emitStmt(std::unique_ptr<WhenMatchStmt> &s) {
                     }
                 }
                 if (enumIt == enum_types_.end())
-                    codegenError("when: unknown enum '" + pat.enum_name + "'");
+                    codegenError("match: unknown enum '" + pat.enum_name + "'");
                 auto varIt = enumIt->second.variants.find(pat.variant_name);
                 if (varIt == enumIt->second.variants.end())
-                    codegenError("when: unknown variant '" + pat.enum_name + "::" + pat.variant_name + "'");
+                    codegenError("match: unknown variant '" + pat.enum_name + "::" + pat.variant_name + "'");
                 if (enumIt->second.isADT) {
                     llvm::Value *subjectTag = builder_.CreateExtractValue(subjectVal, 0, "adt.tag");
                     testResult = builder_.CreateICmpEQ(subjectTag, llvm::ConstantInt::get(i64Ty_, varIt->second), "match.adt_eq");
@@ -262,32 +262,32 @@ void CodeGen::emitStmt(std::unique_ptr<WhenMatchStmt> &s) {
                     }
                 }
                 if (enumIt == enum_types_.end())
-                    codegenError("when: unknown enum '" + pat.enum_name + "'");
+                    codegenError("match: unknown enum '" + pat.enum_name + "'");
                 if (!enumIt->second.isADT)
-                    codegenError("when: constructor pattern requires ADT enum, but '" + pat.enum_name + "' is not ADT");
+                    codegenError("match: constructor pattern requires ADT enum, but '" + pat.enum_name + "' is not ADT");
                 auto varIt = enumIt->second.variants.find(pat.variant_name);
                 if (varIt == enumIt->second.variants.end())
-                    codegenError("when: unknown variant '" + pat.enum_name + "::" + pat.variant_name + "'");
+                    codegenError("match: unknown variant '" + pat.enum_name + "::" + pat.variant_name + "'");
                 llvm::Value *subjectTag = builder_.CreateExtractValue(subjectVal, 0, "adt.tag");
                 testResult = builder_.CreateICmpEQ(subjectTag, llvm::ConstantInt::get(i64Ty_, varIt->second), "match.adt_eq");
             } else if constexpr (std::is_same_v<T, SomePattern>) {
                 if (!isOptionType(subjectTy))
-                    codegenError("when: Some pattern requires Option type");
+                    codegenError("match: Some pattern requires Option type");
                 llvm::Value *hasValue = builder_.CreateExtractValue(subjectVal, 0, "has_value");
                 testResult = hasValue;
             } else if constexpr (std::is_same_v<T, NonePattern>) {
                 if (!isOptionType(subjectTy))
-                    codegenError("when: None pattern requires Option type");
+                    codegenError("match: None pattern requires Option type");
                 llvm::Value *hasValue = builder_.CreateExtractValue(subjectVal, 0, "has_value");
                 testResult = builder_.CreateNot(hasValue, "is_none");
             } else if constexpr (std::is_same_v<T, OkPattern>) {
                 if (!isResultType(subjectTy))
-                    codegenError("when: Ok pattern requires Result type");
+                    codegenError("match: Ok pattern requires Result type");
                 llvm::Value *isOk = builder_.CreateExtractValue(subjectVal, 0, "is_ok");
                 testResult = isOk;
             } else if constexpr (std::is_same_v<T, ErrPattern>) {
                 if (!isResultType(subjectTy))
-                    codegenError("when: Err pattern requires Result type");
+                    codegenError("match: Err pattern requires Result type");
                 llvm::Value *isOk = builder_.CreateExtractValue(subjectVal, 0, "is_ok");
                 testResult = builder_.CreateNot(isOk, "is_err");
             } else if constexpr (std::is_same_v<T, std::unique_ptr<OrPattern>>) {
@@ -310,35 +310,35 @@ void CodeGen::emitStmt(std::unique_ptr<WhenMatchStmt> &s) {
                                 llvm::Value *cmp = builder_.CreateCall(strcmpFn, {subjectVal, litVal}, "strcmp");
                                 altResult = builder_.CreateICmpEQ(cmp, llvm::ConstantInt::get(i32Ty_, 0), "or.streq");
                             } else {
-                                codegenError("when: incompatible types in OR literal pattern");
+                                codegenError("match: incompatible types in OR literal pattern");
                             }
                         } else if constexpr (std::is_same_v<U, EnumPattern>) {
                             auto enumIt = enum_types_.find(altPat.enum_name);
                             if (enumIt == enum_types_.end())
-                                codegenError("when: unknown enum '" + altPat.enum_name + "'");
+                                codegenError("match: unknown enum '" + altPat.enum_name + "'");
                             auto varIt = enumIt->second.variants.find(altPat.variant_name);
                             if (varIt == enumIt->second.variants.end())
-                                codegenError("when: unknown variant '" + altPat.enum_name + "::" + altPat.variant_name + "'");
+                                codegenError("match: unknown variant '" + altPat.enum_name + "::" + altPat.variant_name + "'");
                             llvm::Value *tag = llvm::ConstantInt::get(i64Ty_, varIt->second);
                             altResult = builder_.CreateICmpEQ(subjectVal, tag, "or.enum_eq");
                         } else if constexpr (std::is_same_v<U, WildcardPattern>) {
                             altResult = llvm::ConstantInt::get(i1Ty_, 1);
                         } else if constexpr (std::is_same_v<U, NonePattern>) {
                             if (!isOptionType(subjectTy))
-                                codegenError("when: None pattern requires Option type");
+                                codegenError("match: None pattern requires Option type");
                             llvm::Value *hasValue = builder_.CreateExtractValue(subjectVal, 0, "has_value");
                             altResult = builder_.CreateNot(hasValue, "is_none");
                         } else if constexpr (std::is_same_v<U, OkPattern>) {
                             if (!isResultType(subjectTy))
-                                codegenError("when: Ok pattern requires Result type");
+                                codegenError("match: Ok pattern requires Result type");
                             altResult = builder_.CreateExtractValue(subjectVal, 0, "or.is_ok");
                         } else if constexpr (std::is_same_v<U, ErrPattern>) {
                             if (!isResultType(subjectTy))
-                                codegenError("when: Err pattern requires Result type");
+                                codegenError("match: Err pattern requires Result type");
                             llvm::Value *isOk = builder_.CreateExtractValue(subjectVal, 0, "is_ok");
                             altResult = builder_.CreateNot(isOk, "or.is_err");
                         } else {
-                            codegenError("when: unsupported pattern type in OR pattern");
+                            codegenError("match: unsupported pattern type in OR pattern");
                         }
                     }, alt);
                     testResult = builder_.CreateOr(testResult, altResult, "or.comb");

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -344,7 +344,7 @@ void CodeGen::validateParallelFor(const ForStmt &s) {
                 scanBlock(node->body);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) {
                 scanBlock(node->body);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhenMatchStmt>>) {
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
                 for (const auto &arm : node->arms)
                     scanBlock(arm.body);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -484,7 +484,7 @@ int Formatter::getStmtLine(const StmtNode &stmt) const {
             if (!v->directives.empty()) return v->directives.front().loc.line;
             return v->loc.line;
         }
-        else if constexpr (std::is_same_v<T, std::unique_ptr<WhenMatchStmt>>) return v->loc.line;
+        else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) return v->loc.line;
         else if constexpr (std::is_same_v<T, AssignStmt>) {
             if (!v.directives.empty()) return v.directives.front().loc.line;
             return v.loc.line;
@@ -541,7 +541,7 @@ void Formatter::formatStmt(const StmtNode &stmt) {
         else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) formatWhile(*v);
         else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) formatFor(*v);
         else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) formatFn(*v);
-        else if constexpr (std::is_same_v<T, std::unique_ptr<WhenMatchStmt>>) formatWhenMatch(*v);
+        else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) formatMatch(*v);
     }, stmt);
 }
 

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -338,8 +338,8 @@ void Formatter::formatFn(const FnStmt &s) {
     formatBlock(s.body);
 }
 
-void Formatter::formatWhenMatch(const WhenMatchStmt &s) {
-    emit("when " + formatExpr(*s.subject) + ":");
+void Formatter::formatMatch(const MatchStmt &s) {
+    emit("match " + formatExpr(*s.subject) + ":");
     emitNewline();
     last_emitted_line_ = s.loc.line;
     indent();

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -38,6 +38,7 @@ static const std::unordered_map<std::string, TokenKind> keyword_map = {
     {"if",        TokenKind::If},
     {"else",      TokenKind::Else},
     {"when",      TokenKind::When},
+    {"match",     TokenKind::Match},
     {"while",     TokenKind::While},
     {"for",       TokenKind::For},
     {"in",        TokenKind::In},

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -340,6 +340,9 @@ StmtNode Parser::parseStatement() {
     if (first.kind == TokenKind::When)
         return parseWhenStatement();
 
+    if (first.kind == TokenKind::Match)
+        return parseMatchStatement();
+
     if (first.kind == TokenKind::If)
         return parseIfStatement();
 

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -3,6 +3,7 @@
 #include <regex>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 
 TypeParam Parser::parseOneTypeParam() {
     Token tp = lex_.peek();
@@ -21,7 +22,6 @@ TypeParam Parser::parseOneTypeParam() {
     }
     return param;
 }
-#include <unordered_set>
 
 static bool isSnakeCase(const std::string &name) {
     if (name.empty()) return false;
@@ -973,10 +973,16 @@ StmtNode Parser::parseWhenStatement() {
         return whenStmt;
     }
 
+    parseError("expected ':' after 'when'; use 'match value:' for pattern matching");
+}
+
+StmtNode Parser::parseMatchStatement() {
+    Token matchTok = lex_.next(); // consume 'match'
+
     ExprPtr subject = parseConditional();
 
     if (lex_.peek().kind != TokenKind::Colon)
-        parseError("single-condition when statements are not supported; use 'if' or 'when:'");
+        parseError("expected ':' after match subject");
     lex_.next(); // consume ':'
 
     if (lex_.peek().kind != TokenKind::Newline)
@@ -989,16 +995,16 @@ StmtNode Parser::parseWhenStatement() {
     lex_.next(); // consume Indent
 
     if (lex_.peek().kind != TokenKind::Case)
-        parseError("subject 'when value:' blocks must start with 'case'");
+        parseError("'match' blocks must start with 'case'");
 
-    auto whenStmt = std::make_unique<WhenMatchStmt>();
-    whenStmt->subject = std::move(subject);
-    whenStmt->loc = locFromToken(whenTok);
+    auto matchStmt = std::make_unique<MatchStmt>();
+    matchStmt->subject = std::move(subject);
+    matchStmt->loc = locFromToken(matchTok);
 
     while (lex_.peek().kind != TokenKind::Dedent &&
            lex_.peek().kind != TokenKind::Eof) {
         if (lex_.peek().kind != TokenKind::Case)
-            parseError(lex_.peek().line, "expected 'case' in when block");
+            parseError(lex_.peek().line, "expected 'case' in match block");
         lex_.next(); // consume 'case'
 
         MatchArm arm;
@@ -1046,15 +1052,15 @@ StmtNode Parser::parseWhenStatement() {
         lex_.next();
 
         arm.body = parseBlock();
-        whenStmt->arms.push_back(std::move(arm));
+        matchStmt->arms.push_back(std::move(arm));
         skipNewlines();
     }
 
-    if (whenStmt->arms.empty())
-        parseError("when block must have at least one case");
+    if (matchStmt->arms.empty())
+        parseError("match block must have at least one case");
 
     if (lex_.peek().kind == TokenKind::Dedent)
         lex_.next();
 
-    return whenStmt;
+    return matchStmt;
 }

--- a/src/sema_return.cpp
+++ b/src/sema_return.cpp
@@ -53,7 +53,7 @@ bool stmtReturnsOnAllPaths(const StmtNode &stmt) {
                 if (!allPathsReturn(arm.body)) return false;
             }
             return allPathsReturn(s->else_body);
-        } else if constexpr (std::is_same_v<T, std::unique_ptr<WhenMatchStmt>>) {
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
             if (!isExhaustiveMatch(s->arms)) return false;
             for (auto &arm : s->arms) {
                 if (!allPathsReturn(arm.body)) return false;

--- a/tests/spec/base64.test.ry
+++ b/tests/spec/base64.test.ry
@@ -21,28 +21,28 @@ describe("base64", function():
 
   describe("decode", function():
     it("basic string", function():
-      when decode("SGVsbG8sIFdvcmxkIQ=="):
+      match decode("SGVsbG8sIFdvcmxkIQ=="):
         case Ok(s):
           expect(s).to_eq("Hello, World!")
         case Err(e):
           fail("unexpected error: " + e.message)
     )
     it("empty string", function():
-      when decode(""):
+      match decode(""):
         case Ok(s):
           expect(s).to_eq("")
         case Err(e):
           fail("unexpected error: " + e.message)
     )
     it("no padding", function():
-      when decode("QUJD"):
+      match decode("QUJD"):
         case Ok(s):
           expect(s).to_eq("ABC")
         case Err(e):
           fail("unexpected error: " + e.message)
     )
     it("invalid base64", function():
-      when decode("!!!invalid!!!"):
+      match decode("!!!invalid!!!"):
         case Ok(s):
           fail("expected error but got Ok")
         case Err(e):
@@ -68,14 +68,14 @@ describe("base64", function():
     it("roundtrip", function():
       original = "Hello, World! subjects?_d>>"
       encoded = encode_url_safe(original)
-      when decode_url_safe(encoded):
+      match decode_url_safe(encoded):
         case Ok(s):
           expect(s).to_eq(original)
         case Err(e):
           fail("unexpected error: " + e.message)
     )
     it("invalid input", function():
-      when decode_url_safe("!!!"):
+      match decode_url_safe("!!!"):
         case Ok(s):
           fail("expected error but got Ok")
         case Err(e):
@@ -86,7 +86,7 @@ describe("base64", function():
   describe("roundtrip", function():
     it("standard base64", function():
       original = "The quick brown fox jumps over the lazy dog"
-      when decode(encode(original)):
+      match decode(encode(original)):
         case Ok(s):
           expect(s).to_eq(original)
         case Err(e):
@@ -94,7 +94,7 @@ describe("base64", function():
     )
     it("longer string", function():
       original = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-      when decode(encode(original)):
+      match decode(encode(original)):
         case Ok(s):
           expect(s).to_eq(original)
         case Err(e):

--- a/tests/spec/checked_arith.test.ry
+++ b/tests/spec/checked_arith.test.ry
@@ -1,7 +1,7 @@
 describe("checked arithmetic", function():
   it("checked_add ok", function():
     r = checked_add(10i32, 20i32)
-    when r:
+    match r:
       case Ok(v):
         expect(v as int).to_eq(30)
       case Err(e):
@@ -9,7 +9,7 @@ describe("checked arithmetic", function():
   )
   it("checked_add overflow", function():
     r = checked_add(2147483647i32, 1i32)
-    when r:
+    match r:
       case Ok(v):
         expect(true).to_eq(false)
       case Err(e):
@@ -17,7 +17,7 @@ describe("checked arithmetic", function():
   )
   it("checked_sub ok", function():
     r = checked_sub(100i32, 50i32)
-    when r:
+    match r:
       case Ok(v):
         expect(v as int).to_eq(50)
       case Err(e):
@@ -25,7 +25,7 @@ describe("checked arithmetic", function():
   )
   it("checked_mul ok", function():
     r = checked_mul(6i32, 7i32)
-    when r:
+    match r:
       case Ok(v):
         expect(v as int).to_eq(42)
       case Err(e):
@@ -53,7 +53,7 @@ describe("checked arithmetic", function():
   )
   it("checked_sub overflow", function():
     r = checked_sub(-2147483648i32, 1i32)
-    when r:
+    match r:
       case Ok(v):
         expect(true).to_eq(false)
       case Err(e):
@@ -61,7 +61,7 @@ describe("checked arithmetic", function():
   )
   it("checked_mul overflow", function():
     r = checked_mul(100000i32, 100000i32)
-    when r:
+    match r:
       case Ok(v):
         expect(true).to_eq(false)
       case Err(e):
@@ -69,7 +69,7 @@ describe("checked arithmetic", function():
   )
   it("checked_add zero boundary", function():
     r = checked_add(0i32, 0i32)
-    when r:
+    match r:
       case Ok(v):
         expect(v as int).to_eq(0)
       case Err(e):

--- a/tests/spec/control_flow.test.ry
+++ b/tests/spec/control_flow.test.ry
@@ -193,7 +193,7 @@ describe("when", function():
   it("literal pattern", function():
     res = 0
     x = 2
-    when x:
+    match x:
       case 1:
         res = 10
       case 2:
@@ -205,7 +205,7 @@ describe("when", function():
   it("variable binding", function():
     res = 0
     x = 42
-    when x:
+    match x:
       case n if n > 0:
         res = n
       case _:
@@ -215,7 +215,7 @@ describe("when", function():
   it("guard", function():
     res = ""
     x = -5
-    when x:
+    match x:
       case n if n > 0:
         res = "positive"
       case n if n < 0:
@@ -227,7 +227,7 @@ describe("when", function():
   it("OR pattern", function():
     res = ""
     x = 2
-    when x:
+    match x:
       case 1 | 2 | 3:
         res = "small"
       case _:
@@ -237,7 +237,7 @@ describe("when", function():
   it("wildcard", function():
     res = ""
     x = 999
-    when x:
+    match x:
       case 0:
         res = "zero"
       case _:
@@ -247,7 +247,7 @@ describe("when", function():
   it("string literal pattern", function():
     res = ""
     s = "hello"
-    when s:
+    match s:
       case "hello":
         res = "matched"
       case _:
@@ -257,7 +257,7 @@ describe("when", function():
   it("negative literal pattern", function():
     res = ""
     x = -1
-    when x:
+    match x:
       case -1:
         res = "minus one"
       case 0:
@@ -269,7 +269,7 @@ describe("when", function():
   it("guard fallback to wildcard", function():
     res = ""
     x = 5
-    when x:
+    match x:
       case n if n > 100:
         res = "big"
       case n if n > 50:
@@ -281,7 +281,7 @@ describe("when", function():
   it("OR pattern with many alternatives", function():
     res = ""
     x = 4
-    when x:
+    match x:
       case 1 | 2 | 3 | 4:
         res = "small"
       case _:
@@ -294,7 +294,7 @@ describe("when Option", function():
   it("Some", function():
     res = 0
     x: Option<int> = Some(42)
-    when x:
+    match x:
       case Some(v):
         res = v
       case None:
@@ -304,7 +304,7 @@ describe("when Option", function():
   it("None", function():
     res = 0
     x: Option<int> = None
-    when x:
+    match x:
       case Some(v):
         res = v
       case None:
@@ -323,7 +323,7 @@ describe("when enum", function():
   it("simple enum", function():
     res = ""
     d = Direction::North
-    when d:
+    match d:
       case Direction::North:
         res = "north"
       case Direction::South:
@@ -337,7 +337,7 @@ describe("when enum", function():
   it("last enum variant matches", function():
     res = ""
     d = Direction::West
-    when d:
+    match d:
       case Direction::North:
         res = "north"
       case Direction::South:
@@ -359,7 +359,7 @@ describe("when ADT enum", function():
   it("with associated data", function():
     res = 0.0
     s = Shape::Circle(3.14)
-    when s:
+    match s:
       case Shape::Circle(r):
         res = r
       case Shape::Rect(w, h):
@@ -371,7 +371,7 @@ describe("when ADT enum", function():
   it("multi-field variant", function():
     res = 0.0
     s = Shape::Rect(4.0, 5.0)
-    when s:
+    match s:
       case Shape::Circle(r):
         res = r
       case Shape::Rect(w, h):
@@ -387,11 +387,11 @@ describe("nested when", function():
     res = ""
     x = 2
     y = 10
-    when x:
+    match x:
       case 1:
         res = "one"
       case 2:
-        when y:
+        match y:
           case 10:
             res = "two-ten"
           case _:
@@ -406,7 +406,7 @@ describe("when ADT no-data variant", function():
   it("matches Point variant", function():
     res = 0.0
     s = Shape::Point
-    when s:
+    match s:
       case Shape::Circle(r):
         res = r
       case Shape::Rect(w, h):

--- a/tests/spec/env.test.ry
+++ b/tests/spec/env.test.ry
@@ -21,7 +21,7 @@ describe("env", function():
 
   it("RY_ENV is canonicalized when set", function():
     ry_env = env("RY_ENV")
-    when ry_env:
+    match ry_env:
       case Some(v):
         expect(v).to_not_eq("production")
         expect(v).to_not_eq("development")

--- a/tests/spec/filesystem.test.ry
+++ b/tests/spec/filesystem.test.ry
@@ -8,7 +8,7 @@ describe("make_dir / make_dir_all", function():
     if is_dir(d):
       remove_all(d)
     make_dir_all("/tmp/ry_fs_test")
-    when make_dir(d):
+    match make_dir(d):
       case Ok(_):
         expect(is_dir(d)).to_be_true()
       case Err(e):
@@ -23,7 +23,7 @@ describe("make_dir / make_dir_all", function():
 
   it("creates nested directories", function():
     d = "/tmp/ry_fs_test/a/b/c"
-    when make_dir_all(d):
+    match make_dir_all(d):
       case Ok(_):
         expect(is_dir(d)).to_be_true()
       case Err(e):
@@ -34,7 +34,7 @@ describe("make_dir / make_dir_all", function():
 describe("is_file / is_dir / is_symlink", function():
   it("detects a regular file", function():
     f = "/tmp/ry_fs_test/test_file.txt"
-    when write_text(f, "hello"):
+    match write_text(f, "hello"):
       case Ok(_):
         expect(is_file(f)).to_be_true()
         expect(is_dir(f)).to_be_false()
@@ -64,7 +64,7 @@ describe("list_dir", function():
     write_text(join(d, "a.txt"), "a")
     write_text(join(d, "b.txt"), "b")
     make_dir(join(d, "subdir"))
-    when list_dir(d):
+    match list_dir(d):
       case Ok(entries):
         expect(entries).to_have_length(3)
       case Err(e):
@@ -86,7 +86,7 @@ describe("walk", function():
     write_text(join(d, "root.txt"), "r")
     write_text(join(d, "sub1", "mid.txt"), "m")
     write_text(join(d, "sub1", "sub2", "deep.txt"), "d")
-    when walk(d):
+    match walk(d):
       case Ok(entries):
         expect(length(entries) >= 5).to_be_true()
       case Err(e):
@@ -108,7 +108,7 @@ describe("glob_files", function():
     write_text(join(d, "file1.log"), "1")
     write_text(join(d, "file2.log"), "2")
     write_text(join(d, "file3.txt"), "3")
-    when glob_files(join(d, "*.log")):
+    match glob_files(join(d, "*.log")):
       case Ok(matches):
         expect(matches).to_have_length(2)
       case Err(e):
@@ -116,7 +116,7 @@ describe("glob_files", function():
   )
 
   it("returns empty list when nothing matches", function():
-    when glob_files("/tmp/ry_fs_test_nomatch_*.zzz"):
+    match glob_files("/tmp/ry_fs_test_nomatch_*.zzz"):
       case Ok(matches):
         expect(matches).to_have_length(0)
       case Err(e):
@@ -129,9 +129,9 @@ describe("copy", function():
     src = "/tmp/ry_fs_test/copy_src.txt"
     dst = "/tmp/ry_fs_test/copy_dst.txt"
     write_text(src, "copy me")
-    when copy(src, dst):
+    match copy(src, dst):
       case Ok(_):
-        when read_text(dst):
+        match read_text(dst):
           case Ok(content):
             expect(content).to_eq("copy me")
           case Err(e):
@@ -151,10 +151,10 @@ describe("move", function():
     src = "/tmp/ry_fs_test/move_src.txt"
     dst = "/tmp/ry_fs_test/move_dst.txt"
     write_text(src, "move me")
-    when move(src, dst):
+    match move(src, dst):
       case Ok(_):
         expect(exists(src)).to_be_false()
-        when read_text(dst):
+        match read_text(dst):
           case Ok(content):
             expect(content).to_eq("move me")
           case Err(e):
@@ -168,7 +168,7 @@ describe("remove / remove_all", function():
   it("removes a file", function():
     f = "/tmp/ry_fs_test/remove_me.txt"
     write_text(f, "bye")
-    when remove(f):
+    match remove(f):
       case Ok(_):
         expect(exists(f)).to_be_false()
       case Err(e):
@@ -188,7 +188,7 @@ describe("remove / remove_all", function():
     d = "/tmp/ry_fs_test/tree_to_remove"
     make_dir_all(join(d, "a", "b"))
     write_text(join(d, "a", "b", "file.txt"), "x")
-    when remove_all(d):
+    match remove_all(d):
       case Ok(_):
         expect(is_dir(d)).to_be_false()
       case Err(e):
@@ -200,7 +200,7 @@ describe("file_size", function():
   it("returns correct size", function():
     f = "/tmp/ry_fs_test/size_test.txt"
     write_text(f, "12345")
-    when file_size(f):
+    match file_size(f):
       case Ok(sz):
         expect(sz).to_eq(5)
       case Err(e):
@@ -217,7 +217,7 @@ describe("chmod", function():
   it("changes file permissions", function():
     f = "/tmp/ry_fs_test/chmod_test.txt"
     write_text(f, "x")
-    when chmod(f, 420):
+    match chmod(f, 420):
       case Ok(_):
         expect(is_file(f)).to_be_true()
       case Err(e):
@@ -232,11 +232,11 @@ describe("symlink / read_link / is_symlink", function():
     if is_symlink(link):
       remove(link)
     write_text(target, "target content")
-    when symlink(target, link):
+    match symlink(target, link):
       case Ok(_):
         expect(is_symlink(link)).to_be_true()
         expect(is_file(link)).to_be_true()
-        when read_link(link):
+        match read_link(link):
           case Ok(t):
             expect(t).to_eq(target)
           case Err(e):

--- a/tests/spec/http.test.ry
+++ b/tests/spec/http.test.ry
@@ -4,12 +4,12 @@ from io import to_bytes, bytes_to_str
 describe("HTTP Server API", function():
   it("responds with 200 OK for matching path", function():
     async function server_200(server: TcpListener) -> str:
-      when accept(server):
+      match accept(server):
         case Ok(conn):
-          when receive(conn, 4096):
+          match receive(conn, 4096):
             case Ok(data):
               response_str = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 6\r\n\r\nHello!"
-              when send(conn, to_bytes(response_str)):
+              match send(conn, to_bytes(response_str)):
                 case Ok(_):
                   ...
                 case Err(e):
@@ -21,22 +21,22 @@ describe("HTTP Server API", function():
           ...
       close(server)
       return "done"
-    when bind("127.0.0.1", 0):
+    match bind("127.0.0.1", 0):
       case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
           case Ok(_):
             port = listener_port(server)
             t = server_200(server)
-            when connect("127.0.0.1", port):
+            match connect("127.0.0.1", port):
               case Ok(conn):
-                when send(conn, to_bytes("GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+                match send(conn, to_bytes("GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n")):
                   case Ok(_):
                     ...
                   case Err(e):
                     ...
-                when receive(conn, 4096):
+                match receive(conn, 4096):
                   case Ok(resp):
-                    when bytes_to_str(resp):
+                    match bytes_to_str(resp):
                       case Ok(msg):
                         expect(contains(msg, "200 OK")).to_eq(true)
                         expect(contains(msg, "Hello!")).to_eq(true)
@@ -55,12 +55,12 @@ describe("HTTP Server API", function():
   )
   it("responds with 404 Not Found", function():
     async function server_404(server: TcpListener) -> str:
-      when accept(server):
+      match accept(server):
         case Ok(conn):
-          when receive(conn, 4096):
+          match receive(conn, 4096):
             case Ok(data):
               response_str = "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 9\r\n\r\nNot Found"
-              when send(conn, to_bytes(response_str)):
+              match send(conn, to_bytes(response_str)):
                 case Ok(_):
                   ...
                 case Err(e):
@@ -72,22 +72,22 @@ describe("HTTP Server API", function():
           ...
       close(server)
       return "done"
-    when bind("127.0.0.1", 0):
+    match bind("127.0.0.1", 0):
       case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
           case Ok(_):
             port = listener_port(server)
             t = server_404(server)
-            when connect("127.0.0.1", port):
+            match connect("127.0.0.1", port):
               case Ok(conn):
-                when send(conn, to_bytes("GET /missing HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+                match send(conn, to_bytes("GET /missing HTTP/1.1\r\nHost: localhost\r\n\r\n")):
                   case Ok(_):
                     ...
                   case Err(e):
                     ...
-                when receive(conn, 4096):
+                match receive(conn, 4096):
                   case Ok(resp):
-                    when bytes_to_str(resp):
+                    match bytes_to_str(resp):
                       case Ok(msg):
                         expect(contains(msg, "404 Not Found")).to_eq(true)
                       case Err(e):

--- a/tests/spec/http_client.test.ry
+++ b/tests/spec/http_client.test.ry
@@ -21,7 +21,7 @@ describe("HTTP Client", function():
   # - redirect limit exceeded returns Err
   # - http_get decodes chunked transfer encoding
   it("http_get returns Err on connection refused", function():
-    when http_get("http://127.0.0.1:1/nonexistent"):
+    match http_get("http://127.0.0.1:1/nonexistent"):
       case Ok(resp):
         fail("expected Err but got Ok")
       case Err(e):

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -2,51 +2,51 @@ from io import read_text, write_text, append_text, exists, delete_file, read_byt
 
 describe("file I/O", function():
   it("write and read text", function():
-    when write_text("/tmp/ry_selftest_io.txt", "hello world"):
+    match write_text("/tmp/ry_selftest_io.txt", "hello world"):
       case Ok(_):
-        when read_text("/tmp/ry_selftest_io.txt"):
+        match read_text("/tmp/ry_selftest_io.txt"):
           case Ok(s):
             expect(s).to_eq("hello world")
           case Err(e):
             fail("unexpected error")
       case Err(e):
         fail("unexpected error")
-    when delete_file("/tmp/ry_selftest_io.txt"):
+    match delete_file("/tmp/ry_selftest_io.txt"):
       case Ok(_):
         expect(true).to_eq(true)
       case Err(e):
         fail("unexpected error")
   )
   it("append text", function():
-    when write_text("/tmp/ry_selftest_io_append.txt", "hello"):
+    match write_text("/tmp/ry_selftest_io_append.txt", "hello"):
       case Ok(_):
         expect(true).to_eq(true)
       case Err(e):
         fail("unexpected error")
-    when append_text("/tmp/ry_selftest_io_append.txt", " world"):
+    match append_text("/tmp/ry_selftest_io_append.txt", " world"):
       case Ok(_):
         expect(true).to_eq(true)
       case Err(e):
         fail("unexpected error")
-    when read_text("/tmp/ry_selftest_io_append.txt"):
+    match read_text("/tmp/ry_selftest_io_append.txt"):
       case Ok(s):
         expect(s).to_eq("hello world")
       case Err(e):
         fail("unexpected error")
-    when delete_file("/tmp/ry_selftest_io_append.txt"):
+    match delete_file("/tmp/ry_selftest_io_append.txt"):
       case Ok(_):
         expect(true).to_eq(true)
       case Err(e):
         fail("unexpected error")
   )
   it("exists", function():
-    when write_text("/tmp/ry_selftest_io_exists.txt", "test"):
+    match write_text("/tmp/ry_selftest_io_exists.txt", "test"):
       case Ok(_):
         expect(true).to_eq(true)
       case Err(e):
         fail("unexpected error")
     expect(exists("/tmp/ry_selftest_io_exists.txt")).to_eq(true)
-    when delete_file("/tmp/ry_selftest_io_exists.txt"):
+    match delete_file("/tmp/ry_selftest_io_exists.txt"):
       case Ok(_):
         expect(true).to_eq(true)
       case Err(e):
@@ -56,7 +56,7 @@ describe("file I/O", function():
   it("byte conversions", function():
     bs = to_bytes("ABC")
     expect(length(bs)).to_eq(3)
-    when bytes_to_str(bs):
+    match bytes_to_str(bs):
       case Ok(s):
         expect(s).to_eq("ABC")
       case Err(e):
@@ -64,22 +64,22 @@ describe("file I/O", function():
   )
   it("read/write bytes", function():
     data = to_bytes("binary test")
-    when write_bytes("/tmp/ry_selftest_io_bytes.bin", data):
+    match write_bytes("/tmp/ry_selftest_io_bytes.bin", data):
       case Ok(_):
         expect(true).to_eq(true)
       case Err(e):
         fail("unexpected error")
-    when read_bytes("/tmp/ry_selftest_io_bytes.bin"):
+    match read_bytes("/tmp/ry_selftest_io_bytes.bin"):
       case Ok(rb):
         expect(length(rb)).to_eq(11)
-        when bytes_to_str(rb):
+        match bytes_to_str(rb):
           case Ok(s):
             expect(s).to_eq("binary test")
           case Err(e):
             fail("unexpected error")
       case Err(e):
         fail("unexpected error")
-    when delete_file("/tmp/ry_selftest_io_bytes.bin"):
+    match delete_file("/tmp/ry_selftest_io_bytes.bin"):
       case Ok(_):
         expect(true).to_eq(true)
       case Err(e):
@@ -95,9 +95,9 @@ describe("file I/O", function():
     expect(delete_file("/tmp/ry_selftest_nonexistent_delete.txt")).to_be_err()
   )
   it("write and read empty file", function():
-    when write_text("/tmp/ry_selftest_io_empty.txt", ""):
+    match write_text("/tmp/ry_selftest_io_empty.txt", ""):
       case Ok(_):
-        when read_text("/tmp/ry_selftest_io_empty.txt"):
+        match read_text("/tmp/ry_selftest_io_empty.txt"):
           case Ok(s):
             expect(s).to_eq("")
           case Err(e):
@@ -108,9 +108,9 @@ describe("file I/O", function():
   )
   it("write and read empty bytes", function():
     data = to_bytes("")
-    when write_bytes("/tmp/ry_selftest_io_empty.bin", data):
+    match write_bytes("/tmp/ry_selftest_io_empty.bin", data):
       case Ok(_):
-        when read_bytes("/tmp/ry_selftest_io_empty.bin"):
+        match read_bytes("/tmp/ry_selftest_io_empty.bin"):
           case Ok(rb):
             expect(length(rb)).to_eq(0)
           case Err(e):
@@ -125,7 +125,7 @@ describe("file I/O", function():
   it("overwrite existing file", function():
     write_text("/tmp/ry_selftest_io_overwrite.txt", "first")
     write_text("/tmp/ry_selftest_io_overwrite.txt", "second")
-    when read_text("/tmp/ry_selftest_io_overwrite.txt"):
+    match read_text("/tmp/ry_selftest_io_overwrite.txt"):
       case Ok(s):
         expect(s).to_eq("second")
       case Err(e):

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -3,7 +3,7 @@ from str import contains
 
 describe("json parse", function():
   it("parses an object", function():
-    when parse("{\"name\": \"Alice\", \"age\": 30}"):
+    match parse("{\"name\": \"Alice\", \"age\": 30}"):
       case Ok(data):
         expect(kind(data)).to_eq("object")
         json_free(data)
@@ -12,7 +12,7 @@ describe("json parse", function():
   )
 
   it("parses an array", function():
-    when parse("[1, 2, 3]"):
+    match parse("[1, 2, 3]"):
       case Ok(data):
         expect(kind(data)).to_eq("array")
         expect(length(data)).to_eq(3)
@@ -32,11 +32,11 @@ describe("json parse", function():
 
 describe("json access", function():
   it("gets string field", function():
-    when parse("{\"name\": \"Alice\"}"):
+    match parse("{\"name\": \"Alice\"}"):
       case Ok(data):
-        when get(data, "name"):
+        match get(data, "name"):
           case Ok(val):
-            when to_str(val):
+            match to_str(val):
               case Ok(name):
                 expect(name).to_eq("Alice")
               case Err(e):
@@ -49,11 +49,11 @@ describe("json access", function():
   )
 
   it("gets int field", function():
-    when parse("{\"age\": 30}"):
+    match parse("{\"age\": 30}"):
       case Ok(data):
-        when get(data, "age"):
+        match get(data, "age"):
           case Ok(val):
-            when to_int(val):
+            match to_int(val):
               case Ok(age):
                 expect(age).to_eq(30)
               case Err(e):
@@ -66,11 +66,11 @@ describe("json access", function():
   )
 
   it("gets float field", function():
-    when parse("{\"pi\": 3.14}"):
+    match parse("{\"pi\": 3.14}"):
       case Ok(data):
-        when get(data, "pi"):
+        match get(data, "pi"):
           case Ok(val):
-            when to_float(val):
+            match to_float(val):
               case Ok(pi):
                 expect(pi > 3.13).to_be_true()
                 expect(pi < 3.15).to_be_true()
@@ -84,11 +84,11 @@ describe("json access", function():
   )
 
   it("gets bool field", function():
-    when parse("{\"active\": true}"):
+    match parse("{\"active\": true}"):
       case Ok(data):
-        when get(data, "active"):
+        match get(data, "active"):
           case Ok(val):
-            when to_bool(val):
+            match to_bool(val):
               case Ok(b):
                 expect(b).to_be_true()
               case Err(e):
@@ -101,9 +101,9 @@ describe("json access", function():
   )
 
   it("gets null type", function():
-    when parse("{\"value\": null}"):
+    match parse("{\"value\": null}"):
       case Ok(data):
-        when get(data, "value"):
+        match get(data, "value"):
           case Ok(val):
             expect(kind(val)).to_eq("null")
           case Err(e):
@@ -114,20 +114,20 @@ describe("json access", function():
   )
 
   it("accesses array by index", function():
-    when parse("[10, 20, 30]"):
+    match parse("[10, 20, 30]"):
       case Ok(data):
-        when at(data, 0):
+        match at(data, 0):
           case Ok(first):
-            when to_int(first):
+            match to_int(first):
               case Ok(n):
                 expect(n).to_eq(10)
               case Err(e):
                 fail("json_int failed")
           case Err(e):
             fail("json_at failed")
-        when at(data, 2):
+        match at(data, 2):
           case Ok(last):
-            when to_int(last):
+            match to_int(last):
               case Ok(n):
                 expect(n).to_eq(30)
               case Err(e):
@@ -140,7 +140,7 @@ describe("json access", function():
   )
 
   it("returns Err for missing key", function():
-    when parse("{\"a\": 1}"):
+    match parse("{\"a\": 1}"):
       case Ok(data):
         expect(get(data, "missing")).to_be_err()
         json_free(data)
@@ -149,7 +149,7 @@ describe("json access", function():
   )
 
   it("returns Err for out-of-bounds index", function():
-    when parse("[1, 2]"):
+    match parse("[1, 2]"):
       case Ok(data):
         expect(at(data, 5)).to_be_err()
         json_free(data)
@@ -158,9 +158,9 @@ describe("json access", function():
   )
 
   it("returns Err for type mismatch", function():
-    when parse("{\"name\": \"Alice\"}"):
+    match parse("{\"name\": \"Alice\"}"):
       case Ok(data):
-        when get(data, "name"):
+        match get(data, "name"):
           case Ok(val):
             expect(to_int(val)).to_be_err()
           case Err(e):
@@ -173,22 +173,22 @@ describe("json access", function():
 
 describe("json nested", function():
   it("accesses nested objects", function():
-    when parse("{\"user\": {\"name\": \"Bob\", \"age\": 25}}"):
+    match parse("{\"user\": {\"name\": \"Bob\", \"age\": 25}}"):
       case Ok(data):
-        when get(data, "user"):
+        match get(data, "user"):
           case Ok(user):
-            when get(user, "name"):
+            match get(user, "name"):
               case Ok(name_val):
-                when to_str(name_val):
+                match to_str(name_val):
                   case Ok(name):
                     expect(name).to_eq("Bob")
                   case Err(e):
                     fail("json_str failed")
               case Err(e):
                 fail("json_get name failed")
-            when get(user, "age"):
+            match get(user, "age"):
               case Ok(age_val):
-                when to_int(age_val):
+                match to_int(age_val):
                   case Ok(age):
                     expect(age).to_eq(25)
                   case Err(e):
@@ -203,13 +203,13 @@ describe("json nested", function():
   )
 
   it("accesses array of objects", function():
-    when parse("[{\"id\": 1}, {\"id\": 2}]"):
+    match parse("[{\"id\": 1}, {\"id\": 2}]"):
       case Ok(data):
-        when at(data, 1):
+        match at(data, 1):
           case Ok(second):
-            when get(second, "id"):
+            match get(second, "id"):
               case Ok(id_val):
-                when to_int(id_val):
+                match to_int(id_val):
                   case Ok(id):
                     expect(id).to_eq(2)
                   case Err(e):
@@ -226,7 +226,7 @@ describe("json nested", function():
 
 describe("json keys and len", function():
   it("gets object keys", function():
-    when parse("{\"a\": 1, \"b\": 2}"):
+    match parse("{\"a\": 1, \"b\": 2}"):
       case Ok(data):
         ks = keys(data)
         expect(length(ks)).to_eq(2)
@@ -236,7 +236,7 @@ describe("json keys and len", function():
   )
 
   it("gets object len", function():
-    when parse("{\"x\": 1, \"y\": 2, \"z\": 3}"):
+    match parse("{\"x\": 1, \"y\": 2, \"z\": 3}"):
       case Ok(data):
         expect(length(data)).to_eq(3)
         json_free(data)
@@ -247,14 +247,14 @@ describe("json keys and len", function():
 
 describe("json stringify", function():
   it("round-trips an object", function():
-    when parse("{\"name\":\"Alice\",\"age\":30}"):
+    match parse("{\"name\":\"Alice\",\"age\":30}"):
       case Ok(data):
         text = stringify(data)
-        when parse(text):
+        match parse(text):
           case Ok(data2):
-            when get(data2, "name"):
+            match get(data2, "name"):
               case Ok(name_val):
-                when to_str(name_val):
+                match to_str(name_val):
                   case Ok(name):
                     expect(name).to_eq("Alice")
                   case Err(e):
@@ -270,7 +270,7 @@ describe("json stringify", function():
   )
 
   it("pretty prints with indent", function():
-    when parse("{\"a\":1}"):
+    match parse("{\"a\":1}"):
       case Ok(data):
         text = stringify(data, 2)
         expect(contains(text, "\n")).to_be_true()
@@ -282,7 +282,7 @@ describe("json stringify", function():
 
 describe("json type checks", function():
   it("identifies string type", function():
-    when parse("\"hello\""):
+    match parse("\"hello\""):
       case Ok(data):
         expect(kind(data)).to_eq("string")
         json_free(data)
@@ -291,7 +291,7 @@ describe("json type checks", function():
   )
 
   it("identifies number type", function():
-    when parse("42"):
+    match parse("42"):
       case Ok(data):
         expect(kind(data)).to_eq("number")
         json_free(data)
@@ -300,7 +300,7 @@ describe("json type checks", function():
   )
 
   it("identifies boolean type", function():
-    when parse("true"):
+    match parse("true"):
       case Ok(data):
         expect(kind(data)).to_eq("boolean")
         json_free(data)
@@ -309,7 +309,7 @@ describe("json type checks", function():
   )
 
   it("identifies null type", function():
-    when parse("null"):
+    match parse("null"):
       case Ok(data):
         expect(kind(data)).to_eq("null")
         json_free(data)

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -3,7 +3,7 @@ from io import to_bytes, bytes_to_str
 
 describe("TCP socket API", function():
   it("bind returns Ok on valid address", function():
-    when bind("127.0.0.1", 0):
+    match bind("127.0.0.1", 0):
       case Ok(server):
         close(server)
         expect(true).to_eq(true)
@@ -11,9 +11,9 @@ describe("TCP socket API", function():
         fail("unexpected error")
   )
   it("listen returns Ok on valid listener", function():
-    when bind("127.0.0.1", 0):
+    match bind("127.0.0.1", 0):
       case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
           case Ok(_):
             expect(true).to_eq(true)
           case Err(e):
@@ -23,7 +23,7 @@ describe("TCP socket API", function():
         fail("unexpected error")
   )
   it("tls_connect to closed port returns Err", function():
-    when tls_connect("127.0.0.1", 19991):
+    match tls_connect("127.0.0.1", 19991):
       case Ok(conn):
         close(conn)
         fail("expected Err but got Ok")
@@ -31,7 +31,7 @@ describe("TCP socket API", function():
         expect(true).to_eq(true)
   )
   it("connect to closed port returns Err", function():
-    when connect("127.0.0.1", 19998):
+    match connect("127.0.0.1", 19998):
       case Ok(conn):
         close(conn)
         fail("expected Err but got Ok")
@@ -40,7 +40,7 @@ describe("TCP socket API", function():
   )
   it("set_receive_timeout causes receive to return Err on timeout", function():
     async function timeout_server(server: TcpListener) -> str:
-      when accept(server):
+      match accept(server):
         case Ok(conn):
           sleep(500)
           close(conn)
@@ -48,16 +48,16 @@ describe("TCP socket API", function():
           ...
       close(server)
       return "done"
-    when bind("127.0.0.1", 0):
+    match bind("127.0.0.1", 0):
       case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
           case Ok(_):
             port = listener_port(server)
             t = timeout_server(server)
-            when connect("127.0.0.1", port):
+            match connect("127.0.0.1", port):
               case Ok(conn):
                 set_receive_timeout(conn, 100)
-                when receive(conn, 4096):
+                match receive(conn, 4096):
                   case Ok(data):
                     fail("expected Err but got Ok")
                   case Err(e):
@@ -73,13 +73,13 @@ describe("TCP socket API", function():
   )
   it("echo round-trip with async function", function():
     async function run_server(server: TcpListener) -> str:
-      when accept(server):
+      match accept(server):
         case Ok(conn):
-          when receive(conn, 4096):
+          match receive(conn, 4096):
             case Ok(data):
-              when bytes_to_str(data):
+              match bytes_to_str(data):
                 case Ok(msg):
-                  when send(conn, to_bytes("echo:" + msg)):
+                  match send(conn, to_bytes("echo:" + msg)):
                     case Ok(_):
                       ...
                     case Err(e):
@@ -94,16 +94,16 @@ describe("TCP socket API", function():
       close(server)
       return "done"
     function run_client(port: int) -> str:
-      when connect("127.0.0.1", port):
+      match connect("127.0.0.1", port):
         case Ok(conn):
-          when send(conn, to_bytes("hello")):
+          match send(conn, to_bytes("hello")):
             case Ok(_):
               ...
             case Err(e):
               ...
-          when receive(conn, 4096):
+          match receive(conn, 4096):
             case Ok(resp):
-              when bytes_to_str(resp):
+              match bytes_to_str(resp):
                 case Ok(msg):
                   close(conn)
                   return msg
@@ -115,9 +115,9 @@ describe("TCP socket API", function():
           return "fail"
         case Err(e):
           return "fail"
-    when bind("127.0.0.1", 0):
+    match bind("127.0.0.1", 0):
       case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
           case Ok(_):
             port = listener_port(server)
             t = run_server(server)

--- a/tests/spec/path.test.ry
+++ b/tests/spec/path.test.ry
@@ -102,14 +102,14 @@ describe("path", function():
 
   describe("resolve", function():
     it("resolves existing path", function():
-      when resolve("/tmp"):
+      match resolve("/tmp"):
         case Ok(s):
           expect(is_absolute(s)).to_eq(true)
         case Err(e):
           fail("unexpected error: " + e.message)
     )
     it("fails for non-existent path", function():
-      when resolve("/nonexistent_path_xyz_12345"):
+      match resolve("/nonexistent_path_xyz_12345"):
         case Ok(s):
           fail("expected error but got Ok")
         case Err(e):

--- a/tests/spec/record_subtyping.test.ry
+++ b/tests/spec/record_subtyping.test.ry
@@ -72,7 +72,7 @@ function fetch_data(url: str) -> Result<int, Error>:
 describe("Err auto-slicing", function():
   it("Err(subtype) auto-slices to Error in Result", function():
     result = fetch_data("/api")
-    when result:
+    match result:
       case Err(e):
         expect(e.message).to_eq("not found")
         expect(e.code).to_eq(404)
@@ -140,7 +140,7 @@ function process_data(url: str) -> Result<int, Error>:
 describe("? operator subtype coercion", function():
   it("propagates subtype error through ?", function():
     result = process_data("/api")
-    when result:
+    match result:
       case Err(e):
         expect(e.message).to_eq("fail")
         expect(e.code).to_eq(500)

--- a/tests/spec/regex_literal.test.ry
+++ b/tests/spec/regex_literal.test.ry
@@ -1,14 +1,14 @@
-from regex import match, search, replace, split, find_all
+from regex import is_match, search, replace, split, find_all
 
 describe("regex literal match", function():
   it("full match", function():
-    expect(match("hello", /[a-z]+/)).to_eq(true)
-    expect(match("123", /[a-z]+/)).to_eq(false)
-    expect(match("123", /[0-9]+/)).to_eq(true)
+    expect(is_match("hello", /[a-z]+/)).to_eq(true)
+    expect(is_match("123", /[a-z]+/)).to_eq(false)
+    expect(is_match("123", /[0-9]+/)).to_eq(true)
   )
   it("UFCS", function():
-    expect("hello".match(/[a-z]+/)).to_eq(true)
-    expect("123".match(/[a-z]+/)).to_eq(false)
+    expect("hello".is_match(/[a-z]+/)).to_eq(true)
+    expect("123".is_match(/[a-z]+/)).to_eq(false)
   )
 )
 
@@ -65,8 +65,8 @@ describe("regex literal find_all", function():
 describe("regex literal variable", function():
   it("works via variable", function():
     pat = /[a-z]+/
-    expect(match("hello", pat)).to_eq(true)
-    expect("world".match(pat)).to_eq(true)
+    expect(is_match("hello", pat)).to_eq(true)
+    expect("world".is_match(pat)).to_eq(true)
   )
 )
 
@@ -79,7 +79,7 @@ describe("regex literal division coexistence", function():
 
 describe("regex literal escaped slash", function():
   it("handles escaped /", function():
-    expect(match("a/b", /a\/b/)).to_eq(true)
+    expect(is_match("a/b", /a\/b/)).to_eq(true)
   )
 )
 

--- a/tests/spec/result.test.ry
+++ b/tests/spec/result.test.ry
@@ -25,49 +25,49 @@ describe("Result type", function():
     expect(res).to_be_err()
   )
   it("when Ok extracts value", function():
-    when safe_divide(10, 2):
+    match safe_divide(10, 2):
       case Ok(v):
         expect(v).to_eq(5)
       case Err(e):
         fail("unexpected error")
   )
   it("when Err extracts error", function():
-    when safe_divide(10, 0):
+    match safe_divide(10, 0):
       case Ok(v):
         fail("expected Err but got Ok")
       case Err(e):
         expect(e.message).to_eq("division by zero")
   )
   it("? unwraps Ok value", function():
-    when divide_and_add(10, 2):
+    match divide_and_add(10, 2):
       case Ok(v):
         expect(v).to_eq(6)
       case Err(e):
         fail("unexpected error")
   )
   it("? propagates Err", function():
-    when divide_and_add(10, 0):
+    match divide_and_add(10, 0):
       case Ok(v):
         fail("expected Err but got Ok")
       case Err(e):
         expect(e.message).to_eq("division by zero")
   )
   it("chained ? propagation", function():
-    when chained(100, 10, 2):
+    match chained(100, 10, 2):
       case Ok(v):
         expect(v).to_eq(5)
       case Err(e):
         fail("unexpected error")
   )
   it("chained ? propagates from second call", function():
-    when chained(100, 10, 0):
+    match chained(100, 10, 0):
       case Ok(v):
         fail("expected Err but got Ok")
       case Err(e):
         expect(e.message).to_eq("division by zero")
   )
   it("? in expression position with arithmetic", function():
-    when inline_expr(10, 2):
+    match inline_expr(10, 2):
       case Ok(v):
         expect(v).to_eq(6)
       case Err(e):
@@ -88,7 +88,7 @@ describe("Result type", function():
   it("when Ok with wildcard for Unit result", function():
     function unit_ok() -> Result<Unit, Error>:
       return Ok(0 as u8)
-    when unit_ok():
+    match unit_ok():
       case Ok(_):
         expect(true).to_eq(true)
       case Err(e):

--- a/tests/spec/return_check.test.ry
+++ b/tests/spec/return_check.test.ry
@@ -23,7 +23,7 @@ describe("return check - all paths return", function():
   )
   it("when with wildcard returns on all paths", function():
     function describe(x: int) -> str:
-      when x:
+      match x:
         case 1:
           return "one"
         case 2:
@@ -48,7 +48,7 @@ describe("return check - all paths return", function():
   )
   it("when with Ok/Err returns on all paths", function():
     function check(r: Result<int, Error>) -> str:
-      when r:
+      match r:
         case Ok(v):
           return "ok"
         case Err(e):
@@ -57,7 +57,7 @@ describe("return check - all paths return", function():
   )
   it("when with Some/None returns on all paths", function():
     function check(o: Option<int>) -> str:
-      when o:
+      match o:
         case Some(v):
           return "some"
         case None:

--- a/tests/spec/structs.test.ry
+++ b/tests/spec/structs.test.ry
@@ -116,7 +116,7 @@ describe("simple enum", function():
   it("when", function():
     res = ""
     c = Color::Blue
-    when c:
+    match c:
       case Color::Red:
         res = "red"
       case Color::Green:
@@ -141,7 +141,7 @@ describe("ADT enum", function():
   it("associated data", function():
     s = Shape::CircleS(3.14)
     res = 0.0
-    when s:
+    match s:
       case Shape::CircleS(r):
         res = r
       case Shape::RectS(w, h):
@@ -153,7 +153,7 @@ describe("ADT enum", function():
   it("multi-field pattern when", function():
     s = Shape::RectS(4.0, 5.0)
     res = 0.0
-    when s:
+    match s:
       case Shape::CircleS(r):
         res = r
       case Shape::RectS(w, h):
@@ -173,7 +173,7 @@ describe("ADT enum with named fields", function():
   it("construction is positional", function():
     s = NamedShape::Circle(3.14)
     res = 0.0
-    when s:
+    match s:
       case NamedShape::Circle(r):
         res = r
       case NamedShape::Rect(w, h):
@@ -185,7 +185,7 @@ describe("ADT enum with named fields", function():
   it("multi-field named variant", function():
     s = NamedShape::Rect(4.0, 5.0)
     res = 0.0
-    when s:
+    match s:
       case NamedShape::Circle(r):
         res = r
       case NamedShape::Rect(w, h):
@@ -218,7 +218,7 @@ describe("explicit enum values", function():
   it("when with explicit values", function():
     res = ""
     s = HttpStatus::NotFound
-    when s:
+    match s:
       case HttpStatus::Ok:
         res = "ok"
       case HttpStatus::NotFound:
@@ -246,7 +246,7 @@ describe("generic enum", function():
   it("with type parameter", function():
     a = MyOption<int>::MySome(42)
     res = 0
-    when a:
+    match a:
       case MyOption::MySome(v):
         res = v
       case MyOption::MyNone:
@@ -256,7 +256,7 @@ describe("generic enum", function():
   it("none variant", function():
     b = MyOption<int>::MyNone
     res = 0
-    when b:
+    match b:
       case MyOption::MySome(v):
         res = v
       case MyOption::MyNone:

--- a/tests/spec/thread.test.ry
+++ b/tests/spec/thread.test.ry
@@ -75,7 +75,7 @@ describe("Semaphore", function():
   it("limits concurrent access", function():
     sem_result = semaphore_new(2)
     expect(sem_result).to_be_ok()
-    when sem_result:
+    match sem_result:
       case Ok(sem):
         counter = atomic_int_new(0)
 
@@ -102,7 +102,7 @@ describe("Barrier", function():
   it("synchronizes threads", function():
     barrier_result = barrier_new(2)
     expect(barrier_result).to_be_ok()
-    when barrier_result:
+    match barrier_result:
       case Ok(barrier):
         counter = atomic_int_new(0)
 

--- a/tests/spec/type_advanced.test.ry
+++ b/tests/spec/type_advanced.test.ry
@@ -103,7 +103,7 @@ describe("Result type", function():
     return Ok(a // b)
   it("returns Ok on success", function():
     res = safe_divide(10, 2)
-    when res:
+    match res:
       case Ok(v):
         expect(v).to_eq(5)
       case Err(e):
@@ -111,7 +111,7 @@ describe("Result type", function():
   )
   it("returns Err on failure", function():
     res = safe_divide(10, 0)
-    when res:
+    match res:
       case Ok(v):
         fail("expected Err but got Ok")
       case Err(e):

--- a/tests/spec/types.test.ry
+++ b/tests/spec/types.test.ry
@@ -95,7 +95,7 @@ describe("nested generic type", function():
   it("Option<Option<int>> Some(Some)", function():
     inner: Option<int> = Some(42)
     x: Option<Option<int>> = Some(inner)
-    when x:
+    match x:
       case Some(v):
         expect(v).to_be_some()
       case None:

--- a/tests/spec/weak_ref.test.ry
+++ b/tests/spec/weak_ref.test.ry
@@ -5,7 +5,7 @@ describe("Weak references", function():
   it("weak ref upgrade returns Some when strong ref is alive", function():
     xs = [1, 2, 3]
     w: weak List<int> = weak xs
-    when w:
+    match w:
       case Some(v):
         expect(v.length()).to_eq(3)
       case None:
@@ -16,7 +16,7 @@ describe("Weak references", function():
     w: weak List<int> = weak make_list()
     # The temporary return value is still alive within this expression scope,
     # so the weak ref can still be upgraded to Some.
-    when w:
+    match w:
       case Some(v):
         expect(v.length()).to_eq(3)
       case None:
@@ -27,7 +27,7 @@ describe("Weak references", function():
     data = [42, 99]
     ref: weak List<int> = weak data
     result = 0
-    when ref:
+    match ref:
       case Some(v):
         result = v.length()
       case None:
@@ -46,13 +46,13 @@ describe("Weak references", function():
     a = [1, 2]
     b = [3, 4, 5]
     w: weak List<int> = weak a
-    when w:
+    match w:
       case Some(v):
         expect(v.length()).to_eq(2)
       case None:
         fail("expected Some")
     w = weak b
-    when w:
+    match w:
       case Some(v):
         expect(v.length()).to_eq(3)
       case None:

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -733,7 +733,7 @@ TEST_F(CodeGenTest, ArrayAssignRangeCheck) {
 TEST_F(CodeGenTest, CheckedAddOk) {
     EXPECT_EQ(runSource(
         "r = checked_add(1i32, 2i32)\n"
-        "when r:\n"
+        "match r:\n"
         "  case Ok(v):\n"
         "    print(v as int)\n"
         "  case Err(e):\n"
@@ -743,7 +743,7 @@ TEST_F(CodeGenTest, CheckedAddOk) {
 TEST_F(CodeGenTest, CheckedAddOverflow) {
     EXPECT_EQ(runSource(
         "r = checked_add(2147483647i32, 1i32)\n"
-        "when r:\n"
+        "match r:\n"
         "  case Ok(v):\n"
         "    print(\"ok\")\n"
         "  case Err(e):\n"
@@ -753,7 +753,7 @@ TEST_F(CodeGenTest, CheckedAddOverflow) {
 TEST_F(CodeGenTest, CheckedSubOverflow) {
     EXPECT_EQ(runSource(
         "r = checked_sub(-2147483648i32, 1i32)\n"
-        "when r:\n"
+        "match r:\n"
         "  case Ok(v):\n"
         "    print(\"ok\")\n"
         "  case Err(e):\n"
@@ -763,7 +763,7 @@ TEST_F(CodeGenTest, CheckedSubOverflow) {
 TEST_F(CodeGenTest, CheckedMulOverflow) {
     EXPECT_EQ(runSource(
         "r = checked_mul(100000i32, 100000i32)\n"
-        "when r:\n"
+        "match r:\n"
         "  case Ok(v):\n"
         "    print(\"ok\")\n"
         "  case Err(e):\n"
@@ -773,7 +773,7 @@ TEST_F(CodeGenTest, CheckedMulOverflow) {
 TEST_F(CodeGenTest, CheckedUnsignedOverflow) {
     EXPECT_EQ(runSource(
         "r = checked_add(255u8, 1u8)\n"
-        "when r:\n"
+        "match r:\n"
         "  case Ok(v):\n"
         "    print(\"ok\")\n"
         "  case Err(e):\n"
@@ -783,7 +783,7 @@ TEST_F(CodeGenTest, CheckedUnsignedOverflow) {
 TEST_F(CodeGenTest, CheckedI64Overflow) {
     EXPECT_EQ(runSource(
         "r = checked_add(9223372036854775807i64, 1i64)\n"
-        "when r:\n"
+        "match r:\n"
         "  case Ok(v):\n"
         "    print(\"ok\")\n"
         "  case Err(e):\n"

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -431,7 +431,7 @@ TEST_F(CodeGenTest, MatchEnumAllVariants) {
         "    Green\n"
         "    Blue\n"
         "c = Color::Green\n"
-        "when c:\n"
+        "match c:\n"
         "    case Color::Red:\n"
         "        print(\"red\")\n"
         "    case Color::Green:\n"
@@ -448,7 +448,7 @@ TEST_F(CodeGenTest, MatchEnumWithWildcard) {
         "    Green\n"
         "    Blue\n"
         "c = Color::Blue\n"
-        "when c:\n"
+        "match c:\n"
         "    case Color::Red:\n"
         "        print(\"red\")\n"
         "    case _:\n"
@@ -459,13 +459,13 @@ TEST_F(CodeGenTest, MatchEnumWithWildcard) {
 TEST_F(CodeGenTest, MatchOptionSomeNone) {
     std::string src =
         "x: Option<int> = Some(42)\n"
-        "when x:\n"
+        "match x:\n"
         "    case Some(v):\n"
         "        print(v)\n"
         "    case None:\n"
         "        print(\"nothing\")\n"
         "y: Option<int> = None\n"
-        "when y:\n"
+        "match y:\n"
         "    case Some(v):\n"
         "        print(v)\n"
         "    case None:\n"
@@ -476,7 +476,7 @@ TEST_F(CodeGenTest, MatchOptionSomeNone) {
 TEST_F(CodeGenTest, MatchIntLiteral) {
     std::string src =
         "x = 2\n"
-        "when x:\n"
+        "match x:\n"
         "    case 0:\n"
         "        print(\"zero\")\n"
         "    case 1:\n"
@@ -491,7 +491,7 @@ TEST_F(CodeGenTest, MatchIntLiteral) {
 TEST_F(CodeGenTest, MatchStringLiteral) {
     std::string src =
         "s = \"hello\"\n"
-        "when s:\n"
+        "match s:\n"
         "    case \"world\":\n"
         "        print(\"world\")\n"
         "    case \"hello\":\n"
@@ -504,7 +504,7 @@ TEST_F(CodeGenTest, MatchStringLiteral) {
 TEST_F(CodeGenTest, MatchBoolLiteral) {
     std::string src =
         "b = true\n"
-        "when b:\n"
+        "match b:\n"
         "    case true:\n"
         "        print(\"yes\")\n"
         "    case false:\n"
@@ -515,7 +515,7 @@ TEST_F(CodeGenTest, MatchBoolLiteral) {
 TEST_F(CodeGenTest, MatchVariableBinding) {
     std::string src =
         "x = 42\n"
-        "when x:\n"
+        "match x:\n"
         "    case n:\n"
         "        print(n)\n";
     EXPECT_EQ(runSource(src), "42\n");
@@ -524,7 +524,7 @@ TEST_F(CodeGenTest, MatchVariableBinding) {
 TEST_F(CodeGenTest, MatchGuard) {
     std::string src =
         "x = 5\n"
-        "when x:\n"
+        "match x:\n"
         "    case n if n > 0:\n"
         "        print(\"positive\")\n"
         "    case n if n < 0:\n"
@@ -537,7 +537,7 @@ TEST_F(CodeGenTest, MatchGuard) {
 TEST_F(CodeGenTest, MatchGuardZero) {
     std::string src =
         "x = 0\n"
-        "when x:\n"
+        "match x:\n"
         "    case n if n > 0:\n"
         "        print(\"positive\")\n"
         "    case n if n < 0:\n"
@@ -554,7 +554,7 @@ TEST_F(CodeGenTest, MatchNonExhaustiveEnum) {
         "    Green\n"
         "    Blue\n"
         "c = Color::Red\n"
-        "when c:\n"
+        "match c:\n"
         "    case Color::Red:\n"
         "        print(\"red\")\n"
         "    case Color::Green:\n"
@@ -565,7 +565,7 @@ TEST_F(CodeGenTest, MatchNonExhaustiveEnum) {
 TEST_F(CodeGenTest, MatchNonExhaustiveOption) {
     std::string src =
         "x: Option<int> = Some(1)\n"
-        "when x:\n"
+        "match x:\n"
         "    case Some(v):\n"
         "        print(v)\n";
     EXPECT_THROW(runSource(src), std::runtime_error);
@@ -574,7 +574,7 @@ TEST_F(CodeGenTest, MatchNonExhaustiveOption) {
 TEST_F(CodeGenTest, MatchNonExhaustiveBool) {
     std::string src =
         "b = true\n"
-        "when b:\n"
+        "match b:\n"
         "    case true:\n"
         "        print(\"yes\")\n";
     EXPECT_THROW(runSource(src), std::runtime_error);
@@ -583,7 +583,7 @@ TEST_F(CodeGenTest, MatchNonExhaustiveBool) {
 TEST_F(CodeGenTest, MatchNonExhaustiveLiteral) {
     std::string src =
         "x = 1\n"
-        "when x:\n"
+        "match x:\n"
         "    case 0:\n"
         "        print(\"zero\")\n"
         "    case 1:\n"
@@ -598,7 +598,7 @@ TEST_F(CodeGenTest, MatchNested) {
         "    Down\n"
         "d = Dir::Up\n"
         "if true:\n"
-        "    when d:\n"
+        "    match d:\n"
         "        case Dir::Up:\n"
         "            print(\"up\")\n"
         "        case Dir::Down:\n"
@@ -609,7 +609,7 @@ TEST_F(CodeGenTest, MatchNested) {
 TEST_F(CodeGenTest, MatchNegativeLiteral) {
     std::string src =
         "x = -1\n"
-        "when x:\n"
+        "match x:\n"
         "    case -1:\n"
         "        print(\"neg one\")\n"
         "    case 0:\n"
@@ -842,7 +842,7 @@ function read_file(path: str) -> Result<str, Error>:
     return Ok("content")
 
 res = read_file("test.txt")
-when res:
+match res:
     case Ok(data):
         print(data)
     case Err(e):
@@ -859,7 +859,7 @@ function read_file(path: str) -> Result<str, Error>:
     return Ok("content")
 
 res = read_file("")
-when res:
+match res:
     case Ok(data):
         print(data)
     case Err(e):
@@ -875,7 +875,7 @@ function divide(a: int, b: int) -> Result<int, Error>:
         return Err(Error("division by zero"))
     return Ok(a // b)
 
-when divide(10, 2):
+match divide(10, 2):
     case Ok(v):
         print(v)
     case Err(e):
@@ -891,7 +891,7 @@ function divide(a: int, b: int) -> Result<int, Error>:
         return Err(Error("division by zero"))
     return Ok(a // b)
 
-when divide(10, 0):
+match divide(10, 0):
     case Ok(v):
         print(v)
     case Err(e):
@@ -905,7 +905,7 @@ when divide(10, 0):
 TEST_F(CodeGenTest, MatchOrPatternInt) {
     std::string src =
         "x = 2\n"
-        "when x:\n"
+        "match x:\n"
         "    case 1 | 2 | 3:\n"
         "        print(\"small\")\n"
         "    case _:\n"
@@ -916,7 +916,7 @@ TEST_F(CodeGenTest, MatchOrPatternInt) {
 TEST_F(CodeGenTest, MatchOrPatternIntNoMatch) {
     std::string src =
         "x = 5\n"
-        "when x:\n"
+        "match x:\n"
         "    case 1 | 2 | 3:\n"
         "        print(\"small\")\n"
         "    case _:\n"
@@ -931,7 +931,7 @@ TEST_F(CodeGenTest, MatchOrPatternEnum) {
         "    Green\n"
         "    Blue\n"
         "c = Color::Red\n"
-        "when c:\n"
+        "match c:\n"
         "    case Color::Red | Color::Blue:\n"
         "        print(\"rb\")\n"
         "    case Color::Green:\n"
@@ -946,7 +946,7 @@ TEST_F(CodeGenTest, MatchOrPatternExhaustive) {
         "    Green\n"
         "    Blue\n"
         "c = Color::Green\n"
-        "when c:\n"
+        "match c:\n"
         "    case Color::Red | Color::Blue:\n"
         "        print(\"rb\")\n"
         "    case Color::Green:\n"
@@ -957,7 +957,7 @@ TEST_F(CodeGenTest, MatchOrPatternExhaustive) {
 TEST_F(CodeGenTest, MatchOrPatternVariableError) {
     std::string src =
         "x = 1\n"
-        "when x:\n"
+        "match x:\n"
         "    case a | b:\n"
         "        print(a)\n"
         "    case _:\n"
@@ -985,7 +985,7 @@ TEST_F(CodeGenTest, EnumADTMatchBinding) {
         "    Rectangle(float, float)\n"
         "    Point\n"
         "s = Shape::Circle(3.14)\n"
-        "when s:\n"
+        "match s:\n"
         "    case Shape::Circle(r):\n"
         "        print(r)\n"
         "    case Shape::Rectangle(w, h):\n"
@@ -1002,7 +1002,7 @@ TEST_F(CodeGenTest, EnumADTMatchRect) {
         "    Rectangle(float, float)\n"
         "    Point\n"
         "s = Shape::Rectangle(3.0, 4.0)\n"
-        "when s:\n"
+        "match s:\n"
         "    case Shape::Circle(r):\n"
         "        print(r)\n"
         "    case Shape::Rectangle(w, h):\n"
@@ -1019,7 +1019,7 @@ TEST_F(CodeGenTest, EnumADTMixed) {
         "    Rectangle(float, float)\n"
         "    Point\n"
         "s = Shape::Point\n"
-        "when s:\n"
+        "match s:\n"
         "    case Shape::Circle(r):\n"
         "        print(r)\n"
         "    case Shape::Rectangle(w, h):\n"
@@ -1035,7 +1035,7 @@ TEST_F(CodeGenTest, EnumADTSingleField) {
         "    IntVal(int)\n"
         "    StrVal(str)\n"
         "w = Wrapper::IntVal(42)\n"
-        "when w:\n"
+        "match w:\n"
         "    case Wrapper::IntVal(v):\n"
         "        print(v)\n"
         "    case Wrapper::StrVal(s):\n"
@@ -1051,7 +1051,7 @@ TEST_F(CodeGenTest, GenericEnumBasic) {
         "    MySome(T)\n"
         "    MyNone\n"
         "x = MyOption<int>::MySome(42)\n"
-        "when x:\n"
+        "match x:\n"
         "    case MyOption::MySome(v):\n"
         "        print(v)\n"
         "    case MyOption::MyNone:\n"
@@ -1065,7 +1065,7 @@ TEST_F(CodeGenTest, GenericEnumNone) {
         "    MySome(T)\n"
         "    MyNone\n"
         "x = MyOption<int>::MyNone\n"
-        "when x:\n"
+        "match x:\n"
         "    case MyOption::MySome(v):\n"
         "        print(v)\n"
         "    case MyOption::MyNone:\n"
@@ -1079,7 +1079,7 @@ TEST_F(CodeGenTest, GenericEnumFloat) {
         "    MySome(T)\n"
         "    MyNone\n"
         "x = MyOption<float>::MySome(3.14)\n"
-        "when x:\n"
+        "match x:\n"
         "    case MyOption::MySome(v):\n"
         "        print(v)\n"
         "    case MyOption::MyNone:\n"
@@ -1119,7 +1119,7 @@ TEST_F(CodeGenTest, EnumExplicitValueMatch) {
         "    NotFound = 404\n"
         "    InternalError = 500\n"
         "s = HttpStatus::InternalError\n"
-        "when s:\n"
+        "match s:\n"
         "    case HttpStatus::Ok:\n"
         "        print(\"ok\")\n"
         "    case HttpStatus::NotFound:\n"
@@ -1252,7 +1252,7 @@ TEST_F(CodeGenTest, ErrorPropagateSubtypeCoercion) {
         "    val = fetch(url)?\n"
         "    return Ok(val)\n"
         "result = process(\"/api\")\n"
-        "when result:\n"
+        "match result:\n"
         "    case Err(e):\n"
         "        print(e.message)\n"
         "    case Ok(v):\n"

--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -28,12 +28,12 @@ function sleep(ms: int) -> Unit
 TEST_F(CodeGenTest, ManualHttpServer200) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
 async function manual_server(server: TcpListener) -> str:
-    when accept(server):
+    match accept(server):
         case Ok(conn):
-            when receive(conn, 4096):
+            match receive(conn, 4096):
                 case Ok(data):
                     response_str = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 6\r\n\r\nHello!"
-                    when send(conn, to_bytes(response_str)):
+                    match send(conn, to_bytes(response_str)):
                         case Ok(_):
                             ...
                         case Err(e):
@@ -46,22 +46,22 @@ async function manual_server(server: TcpListener) -> str:
     close(server)
     return "done"
 
-when bind("127.0.0.1", 0):
+match bind("127.0.0.1", 0):
     case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
             case Ok(_):
                 port = listener_port(server)
                 t = manual_server(server)
-                when connect("127.0.0.1", port):
+                match connect("127.0.0.1", port):
                     case Ok(conn):
-                        when send(conn, to_bytes("GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+                        match send(conn, to_bytes("GET /hello HTTP/1.1\r\nHost: localhost\r\n\r\n")):
                             case Ok(_):
                                 ...
                             case Err(e):
                                 ...
-                        when receive(conn, 4096):
+                        match receive(conn, 4096):
                             case Ok(resp):
-                                when bytes_to_str(resp):
+                                match bytes_to_str(resp):
                                     case Ok(msg):
                                         print(contains(msg, "200 OK"))
                                         print(contains(msg, "Hello!"))
@@ -89,12 +89,12 @@ when bind("127.0.0.1", 0):
 TEST_F(CodeGenTest, ManualHttpServerEcho) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
 async function run_server(server: TcpListener) -> str:
-    when accept(server):
+    match accept(server):
         case Ok(conn):
-            when receive(conn, 4096):
+            match receive(conn, 4096):
                 case Ok(data):
                     response_str = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 14\r\n\r\nPOST:/api/data"
-                    when send(conn, to_bytes(response_str)):
+                    match send(conn, to_bytes(response_str)):
                         case Ok(_):
                             ...
                         case Err(e):
@@ -107,22 +107,22 @@ async function run_server(server: TcpListener) -> str:
     close(server)
     return "done"
 
-when bind("127.0.0.1", 0):
+match bind("127.0.0.1", 0):
     case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
             case Ok(_):
                 port = listener_port(server)
                 t = run_server(server)
-                when connect("127.0.0.1", port):
+                match connect("127.0.0.1", port):
                     case Ok(conn):
-                        when send(conn, to_bytes("POST /api/data HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+                        match send(conn, to_bytes("POST /api/data HTTP/1.1\r\nHost: localhost\r\n\r\n")):
                             case Ok(_):
                                 ...
                             case Err(e):
                                 ...
-                        when receive(conn, 4096):
+                        match receive(conn, 4096):
                             case Ok(resp):
-                                when bytes_to_str(resp):
+                                match bytes_to_str(resp):
                                     case Ok(response_msg):
                                         print(contains(response_msg, "POST:/api/data"))
                                     case Err(e):
@@ -147,12 +147,12 @@ when bind("127.0.0.1", 0):
 TEST_F(CodeGenTest, HttpResponse404) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
 async function manual_server(server: TcpListener) -> str:
-    when accept(server):
+    match accept(server):
         case Ok(conn):
-            when receive(conn, 4096):
+            match receive(conn, 4096):
                 case Ok(data):
                     response_str = "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 9\r\n\r\nNot Found"
-                    when send(conn, to_bytes(response_str)):
+                    match send(conn, to_bytes(response_str)):
                         case Ok(_):
                             ...
                         case Err(e):
@@ -165,22 +165,22 @@ async function manual_server(server: TcpListener) -> str:
     close(server)
     return "done"
 
-when bind("127.0.0.1", 0):
+match bind("127.0.0.1", 0):
     case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
             case Ok(_):
                 port = listener_port(server)
                 t = manual_server(server)
-                when connect("127.0.0.1", port):
+                match connect("127.0.0.1", port):
                     case Ok(conn):
-                        when send(conn, to_bytes("GET /missing HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+                        match send(conn, to_bytes("GET /missing HTTP/1.1\r\nHost: localhost\r\n\r\n")):
                             case Ok(_):
                                 ...
                             case Err(e):
                                 ...
-                        when receive(conn, 4096):
+                        match receive(conn, 4096):
                             case Ok(resp):
-                                when bytes_to_str(resp):
+                                match bytes_to_str(resp):
                                     case Ok(response_msg):
                                         print(contains(response_msg, "404 Not Found"))
                                     case Err(e):
@@ -205,12 +205,12 @@ when bind("127.0.0.1", 0):
 TEST_F(CodeGenTest, ManualHttpServerHeader) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
 async function manual_server(server: TcpListener) -> str:
-    when accept(server):
+    match accept(server):
         case Ok(conn):
-            when receive(conn, 4096):
+            match receive(conn, 4096):
                 case Ok(data):
                     response_str = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 17\r\n\r\nheader:test-value"
-                    when send(conn, to_bytes(response_str)):
+                    match send(conn, to_bytes(response_str)):
                         case Ok(_):
                             ...
                         case Err(e):
@@ -223,22 +223,22 @@ async function manual_server(server: TcpListener) -> str:
     close(server)
     return "done"
 
-when bind("127.0.0.1", 0):
+match bind("127.0.0.1", 0):
     case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
             case Ok(_):
                 port = listener_port(server)
                 t = manual_server(server)
-                when connect("127.0.0.1", port):
+                match connect("127.0.0.1", port):
                     case Ok(conn):
-                        when send(conn, to_bytes("GET / HTTP/1.1\r\nHost: localhost\r\nX-Custom: test-value\r\n\r\n")):
+                        match send(conn, to_bytes("GET / HTTP/1.1\r\nHost: localhost\r\nX-Custom: test-value\r\n\r\n")):
                             case Ok(_):
                                 ...
                             case Err(e):
                                 ...
-                        when receive(conn, 4096):
+                        match receive(conn, 4096):
                             case Ok(resp):
-                                when bytes_to_str(resp):
+                                match bytes_to_str(resp):
                                     case Ok(msg):
                                         print(contains(msg, "header:test-value"))
                                     case Err(e):
@@ -286,16 +286,16 @@ async function server() -> str:
 
 t = server()
 sleep(200)
-when connect("127.0.0.1", 18932):
+match connect("127.0.0.1", 18932):
     case Ok(conn):
-        when send(conn, to_bytes("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+        match send(conn, to_bytes("GET /test HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "200 OK"))
                         print(contains(msg, "ok"))
@@ -327,16 +327,16 @@ t = server()
 sleep(200)
 
 # First request
-when connect("127.0.0.1", 18933):
+match connect("127.0.0.1", 18933):
     case Ok(conn):
-        when send(conn, to_bytes("GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+        match send(conn, to_bytes("GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "/first"))
                     case Err(e):
@@ -348,16 +348,16 @@ when connect("127.0.0.1", 18933):
         print("false")
 
 # Second request
-when connect("127.0.0.1", 18933):
+match connect("127.0.0.1", 18933):
     case Ok(conn):
-        when send(conn, to_bytes("GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+        match send(conn, to_bytes("GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "/second"))
                     case Err(e):
@@ -386,17 +386,17 @@ t = server()
 sleep(200)
 
 # Send two requests on the same connection (keep-alive)
-when connect("127.0.0.1", 18934):
+match connect("127.0.0.1", 18934):
     case Ok(conn):
         # First request
-        when send(conn, to_bytes("GET /first HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")):
+        match send(conn, to_bytes("GET /first HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "/first"))
                         print(contains(msg, "Connection: keep-alive"))
@@ -408,14 +408,14 @@ when connect("127.0.0.1", 18934):
                 print("false")
 
         # Second request on same connection
-        when send(conn, to_bytes("GET /second HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")):
+        match send(conn, to_bytes("GET /second HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "/second"))
                         print(contains(msg, "Connection: close"))
@@ -449,16 +449,16 @@ t = server()
 sleep(200)
 
 # Send request with Connection: close
-when connect("127.0.0.1", 18935):
+match connect("127.0.0.1", 18935):
     case Ok(conn):
-        when send(conn, to_bytes("GET /test HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")):
+        match send(conn, to_bytes("GET /test HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "200 OK"))
                         print(contains(msg, "Connection: close"))
@@ -474,16 +474,16 @@ when connect("127.0.0.1", 18935):
         print("false")
 
 # Second request on new connection to reach max_requests
-when connect("127.0.0.1", 18935):
+match connect("127.0.0.1", 18935):
     case Ok(conn):
-        when send(conn, to_bytes("GET /test2 HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+        match send(conn, to_bytes("GET /test2 HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "200 OK"))
                     case Err(e):
@@ -512,17 +512,17 @@ t = server()
 sleep(200)
 
 # Send 3 requests on the same keep-alive connection
-when connect("127.0.0.1", 18936):
+match connect("127.0.0.1", 18936):
     case Ok(conn):
         # Request 1
-        when send(conn, to_bytes("GET /a HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+        match send(conn, to_bytes("GET /a HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "/a"))
                     case Err(e):
@@ -531,14 +531,14 @@ when connect("127.0.0.1", 18936):
                 print("false")
 
         # Request 2
-        when send(conn, to_bytes("GET /b HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+        match send(conn, to_bytes("GET /b HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "/b"))
                     case Err(e):
@@ -547,14 +547,14 @@ when connect("127.0.0.1", 18936):
                 print("false")
 
         # Request 3 (triggers shutdown)
-        when send(conn, to_bytes("GET /c HTTP/1.1\r\nHost: localhost\r\n\r\n")):
+        match send(conn, to_bytes("GET /c HTTP/1.1\r\nHost: localhost\r\n\r\n")):
             case Ok(_):
                 ...
             case Err(e):
                 ...
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(resp):
-                when bytes_to_str(resp):
+                match bytes_to_str(resp):
                     case Ok(msg):
                         print(contains(msg, "/c"))
                     case Err(e):

--- a/tests/test_codegen_io.cpp
+++ b/tests/test_codegen_io.cpp
@@ -43,9 +43,9 @@ TEST_F(CodeGenTest, IOWriteReadText) {
     std::string path = tmpPath("write_read");
     removeIfExists(path);
     EXPECT_EQ(runSource(IO_DECLS + R"(
-when write_text(")" + path + R"(", "hello world"):
+match write_text(")" + path + R"(", "hello world"):
     case Ok(_):
-        when read_text(")" + path + R"("):
+        match read_text(")" + path + R"("):
             case Ok(s):
                 print(s)
             case Err(e):
@@ -64,11 +64,11 @@ TEST_F(CodeGenTest, IOAppendText) {
     std::string path = tmpPath("append");
     removeIfExists(path);
     EXPECT_EQ(runSource(IO_DECLS + R"(
-when write_text(")" + path + R"(", "hello"):
+match write_text(")" + path + R"(", "hello"):
     case Ok(_):
-        when append_text(")" + path + R"(", " world"):
+        match append_text(")" + path + R"(", " world"):
             case Ok(_):
-                when read_text(")" + path + R"("):
+                match read_text(")" + path + R"("):
                     case Ok(s):
                         print(s)
                     case Err(e):
@@ -89,7 +89,7 @@ TEST_F(CodeGenTest, IOFileExistsTrue) {
     std::string path = tmpPath("exists");
     removeIfExists(path);
     EXPECT_EQ(runSource(IO_DECLS + R"(
-when write_text(")" + path + R"(", "test"):
+match write_text(")" + path + R"(", "test"):
     case Ok(_):
         print(exists(")" + path + R"("))
     case Err(e):
@@ -114,9 +114,9 @@ TEST_F(CodeGenTest, IODeleteFile) {
     std::string path = tmpPath("delete");
     removeIfExists(path);
     EXPECT_EQ(runSource(IO_DECLS + R"(
-when write_text(")" + path + R"(", "temp"):
+match write_text(")" + path + R"(", "temp"):
     case Ok(_):
-        when delete_file(")" + path + R"("):
+        match delete_file(")" + path + R"("):
             case Ok(_):
                 print(exists(")" + path + R"("))
             case Err(e):
@@ -143,7 +143,7 @@ print(bs[2])
 TEST_F(CodeGenTest, IOBytesToStr) {
     EXPECT_EQ(runSource(IO_DECLS + R"(
 bs = to_bytes("hello")
-when bytes_to_str(bs):
+match bytes_to_str(bs):
     case Ok(s):
         print(s)
     case Err(e):
@@ -160,11 +160,11 @@ TEST_F(CodeGenTest, IOWriteReadBytes) {
     removeIfExists(path);
     EXPECT_EQ(runSource(IO_DECLS + R"(
 bs = to_bytes("binary data")
-when write_bytes(")" + path + R"(", bs):
+match write_bytes(")" + path + R"(", bs):
     case Ok(_):
-        when read_bytes(")" + path + R"("):
+        match read_bytes(")" + path + R"("):
             case Ok(rb):
-                when bytes_to_str(rb):
+                match bytes_to_str(rb):
                     case Ok(s):
                         print(s)
                         print(length(rb))
@@ -184,7 +184,7 @@ when write_bytes(")" + path + R"(", bs):
 
 TEST_F(CodeGenTest, IOReadTextNotFound) {
     EXPECT_EQ(runSource(IO_DECLS + R"(
-when read_text("/tmp/ry_io_test_no_such_file_ever.txt"):
+match read_text("/tmp/ry_io_test_no_such_file_ever.txt"):
     case Ok(s):
         print("unexpected success")
     case Err(e):

--- a/tests/test_codegen_net.cpp
+++ b/tests/test_codegen_net.cpp
@@ -38,7 +38,7 @@ function sleep(ms: int) -> Unit
 
 TEST_F(CodeGenTest, NetBindReturnsResult) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-when bind("127.0.0.1", 0):
+match bind("127.0.0.1", 0):
     case Ok(server):
         print("ok")
         close(server)
@@ -53,7 +53,7 @@ when bind("127.0.0.1", 0):
 
 TEST_F(CodeGenTest, NetConnectInvalidReturnsErr) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-when connect("127.0.0.1", 19999):
+match connect("127.0.0.1", 19999):
     case Ok(conn):
         print("connected")
         close(conn)
@@ -68,9 +68,9 @@ when connect("127.0.0.1", 19999):
 
 TEST_F(CodeGenTest, NetListenReturnsResult) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-when bind("127.0.0.1", 0):
+match bind("127.0.0.1", 0):
     case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
             case Ok(_):
                 print("ok")
             case Err(e):
@@ -92,13 +92,13 @@ TEST_F(CodeGenTest, NetEchoRoundTrip) {
 function listener_port(listener: TcpListener) -> int
 
 async function run_server(server: TcpListener) -> str:
-    when accept(server):
+    match accept(server):
         case Ok(conn):
-            when receive(conn, 4096):
+            match receive(conn, 4096):
                 case Ok(data):
-                    when bytes_to_str(data):
+                    match bytes_to_str(data):
                         case Ok(msg):
-                            when send(conn, to_bytes("echo:" + msg)):
+                            match send(conn, to_bytes("echo:" + msg)):
                                 case Ok(_):
                                     ...
                                 case Err(e):
@@ -114,16 +114,16 @@ async function run_server(server: TcpListener) -> str:
     return "done"
 
 function run_client(port: int) -> str:
-    when connect("127.0.0.1", port):
+    match connect("127.0.0.1", port):
         case Ok(conn):
-            when send(conn, to_bytes("hello")):
+            match send(conn, to_bytes("hello")):
                 case Ok(_):
                     ...
                 case Err(e):
                     ...
-            when receive(conn, 4096):
+            match receive(conn, 4096):
                 case Ok(resp):
-                    when bytes_to_str(resp):
+                    match bytes_to_str(resp):
                         case Ok(msg):
                             close(conn)
                             return msg
@@ -136,9 +136,9 @@ function run_client(port: int) -> str:
         case Err(e):
             return "fail"
 
-when bind("127.0.0.1", 0):
+match bind("127.0.0.1", 0):
     case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
             case Ok(_):
                 port = listener_port(server)
                 t = run_server(server)
@@ -291,7 +291,7 @@ TEST(TcpRecv, ErrorReturnsNull) {
 
 TEST_F(CodeGenTest, NetSetTimeoutCompiles) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-when connect("127.0.0.1", 19997):
+match connect("127.0.0.1", 19997):
     case Ok(conn):
         set_timeout(conn, 500)
         print("ok")
@@ -303,7 +303,7 @@ when connect("127.0.0.1", 19997):
 
 TEST_F(CodeGenTest, NetSetRecvTimeoutCompiles) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-when connect("127.0.0.1", 19996):
+match connect("127.0.0.1", 19996):
     case Ok(conn):
         set_receive_timeout(conn, 500)
         print("ok")
@@ -315,7 +315,7 @@ when connect("127.0.0.1", 19996):
 
 TEST_F(CodeGenTest, NetSetSendTimeoutCompiles) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-when connect("127.0.0.1", 19995):
+match connect("127.0.0.1", 19995):
     case Ok(conn):
         set_send_timeout(conn, 500)
         print("ok")
@@ -331,7 +331,7 @@ TEST_F(CodeGenTest, NetRecvTimesOutWithShortTimeout) {
 function listener_port(listener: TcpListener) -> int
 
 async function server_task(server: TcpListener) -> str:
-    when accept(server):
+    match accept(server):
         case Ok(conn):
             # Don't send anything - let client timeout
             sleep(500)
@@ -341,16 +341,16 @@ async function server_task(server: TcpListener) -> str:
     close(server)
     return "done"
 
-when bind("127.0.0.1", 0):
+match bind("127.0.0.1", 0):
     case Ok(server):
-        when listen(server, 1):
+        match listen(server, 1):
             case Ok(_):
                 port = listener_port(server)
                 t = server_task(server)
-                when connect("127.0.0.1", port):
+                match connect("127.0.0.1", port):
                     case Ok(conn):
                         set_receive_timeout(conn, 100)
-                        when receive(conn, 4096):
+                        match receive(conn, 4096):
                             case Ok(data):
                                 print("got data")
                             case Err(e):
@@ -398,7 +398,7 @@ TEST(TcpTimeout, SetTimeoutSetsSocketOptions) {
 
 TEST_F(CodeGenTest, TlsConnectInvalidReturnsErr) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-when tls_connect("127.0.0.1", 19993):
+match tls_connect("127.0.0.1", 19993):
     case Ok(conn):
         print("connected")
         close(conn)
@@ -413,14 +413,14 @@ when tls_connect("127.0.0.1", 19993):
 
 TEST_F(CodeGenTest, TlsStreamOverloadsCompile) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-when tls_connect("127.0.0.1", 19992):
+match tls_connect("127.0.0.1", 19992):
     case Ok(conn):
-        when send(conn, to_bytes("hello")):
+        match send(conn, to_bytes("hello")):
             case Ok(n):
                 print("sent")
             case Err(e):
                 print("send err")
-        when receive(conn, 4096):
+        match receive(conn, 4096):
             case Ok(data):
                 print("recv ok")
             case Err(e):

--- a/tests/test_codegen_regex.cpp
+++ b/tests/test_codegen_regex.cpp
@@ -170,8 +170,8 @@ print(tags[1])
 
 TEST_F(CodeGenTest, RegexLiteralMatch) {
     EXPECT_EQ(runSource(R"(
-print(match("hello", /[a-z]+/))
-print(match("123", /[a-z]+/))
+print(is_match("hello", /[a-z]+/))
+print(is_match("123", /[a-z]+/))
 )"), "true\nfalse\n");
 }
 
@@ -209,7 +209,7 @@ print(nums[2])
 
 TEST_F(CodeGenTest, RegexLiteralUFCS) {
     EXPECT_EQ(runSource(R"(
-print("hello".match(/[a-z]+/))
+print("hello".is_match(/[a-z]+/))
 print("abc123".search(/[0-9]+/))
 nums = "a1b2c3".find_all(/[0-9]/)
 print(length(nums))
@@ -233,8 +233,8 @@ print("abc123".replace(/[0-9]+/, "X"))
 TEST_F(CodeGenTest, RegexLiteralVariable) {
     EXPECT_EQ(runSource(R"(
 pat = /[a-z]+/
-print(match("hello", pat))
-print("world".match(pat))
+print(is_match("hello", pat))
+print("world".is_match(pat))
 )"), "true\ntrue\n");
 }
 
@@ -249,7 +249,7 @@ print(y)
 
 TEST_F(CodeGenTest, RegexLiteralEscapedSlash) {
     EXPECT_EQ(runSource(R"(
-print(match("a/b", /a\/b/))
+print(is_match("a/b", /a\/b/))
 )"), "true\n");
 }
 

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -211,13 +211,13 @@ TEST(Formatter, ControlFlow) {
     // Match statement
     {
         auto src =
-            "when x:\n"
+            "match x:\n"
             "    case 1:\n"
             "        res = 10\n"
             "    case _:\n"
             "        res = 0\n";
         auto expected =
-            "when x:\n"
+            "match x:\n"
             "  case 1:\n"
             "    res = 10\n"
             "  case _:\n"

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1806,59 +1806,59 @@ TEST(ParserTest, NativeFnWithColonError) {
 
 TEST(ParserTest, OrPatternRejectsVariableBinding) {
     EXPECT_THROW({
-        parseStr("when x:\n    case a | b:\n        print(a)\n");
+        parseStr("match x:\n    case a | b:\n        print(a)\n");
     }, std::runtime_error);
 }
 
 TEST(ParserTest, OrPatternRejectsSomeBinding) {
     EXPECT_THROW({
-        parseStr("when x:\n    case Some(a) | Some(b):\n        print(a)\n");
+        parseStr("match x:\n    case Some(a) | Some(b):\n        print(a)\n");
     }, std::runtime_error);
 }
 
 TEST(ParserTest, OrPatternRejectsOkBinding) {
     EXPECT_THROW({
-        parseStr("when x:\n    case Ok(a) | Ok(b):\n        print(a)\n");
+        parseStr("match x:\n    case Ok(a) | Ok(b):\n        print(a)\n");
     }, std::runtime_error);
 }
 
 TEST(ParserTest, OrPatternRejectsErrBinding) {
     EXPECT_THROW({
-        parseStr("when x:\n    case Err(a) | Err(b):\n        print(a)\n");
+        parseStr("match x:\n    case Err(a) | Err(b):\n        print(a)\n");
     }, std::runtime_error);
 }
 
 TEST(ParserTest, OrPatternRejectsOkAsAlternative) {
     EXPECT_THROW({
-        parseStr("when x:\n    case 1 | Ok(a):\n        print(a)\n");
+        parseStr("match x:\n    case 1 | Ok(a):\n        print(a)\n");
     }, std::runtime_error);
 }
 
 TEST(ParserTest, OrPatternRejectsErrAsAlternative) {
     EXPECT_THROW({
-        parseStr("when x:\n    case 1 | Err(e):\n        print(e)\n");
+        parseStr("match x:\n    case 1 | Err(e):\n        print(e)\n");
     }, std::runtime_error);
 }
 
 TEST(ParserTest, OrPatternRejectsEnumConstructorBinding) {
     EXPECT_THROW({
-        parseStr("when x:\n    case Foo::Bar(a) | Foo::Baz(b):\n        print(a)\n");
+        parseStr("match x:\n    case Foo::Bar(a) | Foo::Baz(b):\n        print(a)\n");
     }, std::runtime_error);
 }
 
 TEST(ParserTest, OrPatternAllowsWildcardBindings) {
     EXPECT_NO_THROW({
-        parseStr("when x:\n"
+        parseStr("match x:\n"
                  "    case Ok(_) | Err(_):\n"
                  "        print(\"done\")\n");
     });
     EXPECT_NO_THROW({
-        parseStr("when x:\n"
+        parseStr("match x:\n"
                  "    case Some(_) | None:\n"
                  "        print(\"done\")\n");
     });
     EXPECT_NO_THROW({
-        parseStr("when x:\n"
+        parseStr("match x:\n"
                  "    case Foo::Bar(_) | Foo::Baz(_):\n"
                  "        print(\"done\")\n");
     });

--- a/tests/test_sema_return.cpp
+++ b/tests/test_sema_return.cpp
@@ -96,7 +96,7 @@ TEST_F(CodeGenTest, AllPathsReturnWhenMultiBranch) {
 TEST_F(CodeGenTest, AllPathsReturnMatchWildcard) {
     EXPECT_EQ(runSource(
         "function describe(x: int) -> str:\n"
-        "    when x:\n"
+        "    match x:\n"
         "        case 1:\n"
         "            return \"one\"\n"
         "        case _:\n"
@@ -109,7 +109,7 @@ TEST_F(CodeGenTest, AllPathsReturnMatchOkErr) {
     EXPECT_EQ(runSource(
         "function check(x: int) -> str:\n"
         "    r: Result<int, Error> = Ok(x)\n"
-        "    when r:\n"
+        "    match r:\n"
         "        case Ok(v):\n"
         "            return \"ok\"\n"
         "        case Err(e):\n"
@@ -121,7 +121,7 @@ TEST_F(CodeGenTest, AllPathsReturnMatchOkErr) {
 TEST_F(CodeGenTest, AllPathsReturnMatchSomeNone) {
     EXPECT_EQ(runSource(
         "function check(x: Option<int>) -> str:\n"
-        "    when x:\n"
+        "    match x:\n"
         "        case Some(v):\n"
         "            return \"some\"\n"
         "        case None:\n"
@@ -157,7 +157,7 @@ TEST_F(CodeGenTest, OmittedReturnTypeNoReturnOk) {
 TEST_F(CodeGenTest, AllPathsReturnMatchVariable) {
     EXPECT_EQ(runSource(
         "function describe(x: int) -> str:\n"
-        "    when x:\n"
+        "    match x:\n"
         "        case 1:\n"
         "            return \"one\"\n"
         "        case n:\n"


### PR DESCRIPTION
## Summary

- Rename pattern matching syntax from `when value:` to `match value:` (#482)
- `match` is now a reserved keyword (`TokenKind::Match`); conditional `when:` (without subject) is unchanged
- AST struct `WhenMatchStmt` renamed to `MatchStmt`; parser split into `parseWhenStatement()` (conditional) and `parseMatchStatement()` (pattern matching)
- Regex builtin function `match` renamed to `is_match` to avoid keyword conflict
- All codegen error messages updated (`"when:"` → `"match:"`, `"non-exhaustive when:"` → `"non-exhaustive match:"`)
- Fix: misplaced `#include <unordered_set>` in `parser_decl.cpp` moved to include block

## Test plan

- [x] All 1274 C++ tests pass
- [x] All 62 Ry spec test files pass (0 failures)
- [x] ASan build: 1273 C++ tests pass + 62 spec files pass, no memory errors
- [x] `match value:` + `case` works correctly
- [x] `when:` conditional (without subject) unchanged
- [x] `is_match()` regex function works (direct call and UFCS)
- [x] Formatter outputs `match` for pattern matching

Closes #482