### PR TITLE
perf: reduce AST allocation and merge pre-pass traversals (#464)

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -61,7 +61,13 @@ private:
     // Cycle collector — static analysis & visit function generation
     std::unordered_set<std::string> potentially_cyclic_types_;
     std::unordered_map<std::string, llvm::Function*> gc_visit_functions_;
-    void computeCyclicTypes(Program &prog);
+    void collectTypeGraphFromStmt(
+        const StmtNode &stmt,
+        std::unordered_map<std::string, std::unordered_set<std::string>> &graph,
+        std::unordered_set<std::string> &all_types);
+    void runCyclicTypeAnalysis(
+        std::unordered_map<std::string, std::unordered_set<std::string>> &graph,
+        const std::unordered_set<std::string> &all_types);
     bool isPotentiallyCyclic(const std::string &typeName) const;
     llvm::Function *getOrCreateVisitFunction(const std::string &typeName);
     std::unordered_set<llvm::Value*> arc_atomic_values_;  // values requiring atomic refcount ops

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -319,55 +319,60 @@ bool CodeGen::isImmutable(const std::string &name) const {
     return false;
 }
 
-// Pre-pass: collect all function names targeted by mock() in the AST
-static void collectMockedFunctions(const std::vector<StmtNode> &stmts,
-                                    std::unordered_set<std::string> &out) {
-    for (const auto &stmt : stmts) {
-        std::visit([&](const auto &s) {
-            using T = std::decay_t<decltype(s)>;
-            if constexpr (std::is_same_v<T, CallStmt>) {
-                if (s.callee == "mock" && !s.args.empty()) {
-                    if (auto *str = std::get_if<StringExpr>(&s.args[0]->data))
-                        out.insert(str->value);
-                }
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) {
-                collectMockedFunctions(s->branch.body, out);
-                collectMockedFunctions(s->else_body, out);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhenCondStmt>>) {
-                for (auto &arm : s->arms)
-                    collectMockedFunctions(arm.body, out);
-                collectMockedFunctions(s->else_body, out);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) {
-                collectMockedFunctions(s->body, out);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) {
-                collectMockedFunctions(s->body, out);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
-                collectMockedFunctions(s->body, out);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
-                for (auto &arm : s->arms)
-                    collectMockedFunctions(arm.body, out);
+// Forward declaration for mutual recursion.
+static void collectMockedFunctionsFromStmts(const std::vector<StmtNode> &stmts,
+                                             std::unordered_set<std::string> &out);
+
+// Scan a single statement (and its nested bodies) for mock() call targets.
+static void collectMockedFunctionsFromStmt(const StmtNode &stmt,
+                                            std::unordered_set<std::string> &out) {
+    std::visit([&](const auto &s) {
+        using T = std::decay_t<decltype(s)>;
+        if constexpr (std::is_same_v<T, CallStmt>) {
+            if (s.callee == "mock" && !s.args.empty()) {
+                if (auto *str = std::get_if<StringExpr>(&s.args[0]->data))
+                    out.insert(str->value);
             }
-        }, stmt);
-        // Also scan lambda args (e.g., describe/it trailing blocks)
-        std::visit([&](const auto &s) {
-            using T = std::decay_t<decltype(s)>;
-            if constexpr (std::is_same_v<T, CallStmt>) {
-                for (auto &arg : s.args) {
-                    if (auto *lam = std::get_if<std::unique_ptr<LambdaExpr>>(&arg->data))
-                        collectMockedFunctions((*lam)->body, out);
-                }
+            for (auto &arg : s.args) {
+                if (auto *lam = std::get_if<std::unique_ptr<LambdaExpr>>(&arg->data))
+                    collectMockedFunctionsFromStmts((*lam)->body, out);
             }
-        }, stmt);
-    }
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) {
+            collectMockedFunctionsFromStmts(s->branch.body, out);
+            collectMockedFunctionsFromStmts(s->else_body, out);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<WhenCondStmt>>) {
+            for (auto &arm : s->arms)
+                collectMockedFunctionsFromStmts(arm.body, out);
+            collectMockedFunctionsFromStmts(s->else_body, out);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) {
+            collectMockedFunctionsFromStmts(s->body, out);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) {
+            collectMockedFunctionsFromStmts(s->body, out);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
+            collectMockedFunctionsFromStmts(s->body, out);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
+            for (auto &arm : s->arms)
+                collectMockedFunctionsFromStmts(arm.body, out);
+        }
+    }, stmt);
+}
+
+static void collectMockedFunctionsFromStmts(const std::vector<StmtNode> &stmts,
+                                             std::unordered_set<std::string> &out) {
+    for (const auto &stmt : stmts)
+        collectMockedFunctionsFromStmt(stmt, out);
 }
 
 llvm::orc::ThreadSafeModule CodeGen::compile(Program &prog) {
-    // Pre-pass: collect all mock targets before codegen
-    if (test_mode_)
-        collectMockedFunctions(prog, mocked_functions_);
-
-    // Pre-pass: compute potentially cyclic types for GC candidate tracking
-    computeCyclicTypes(prog);
+    // Single pre-pass: collect mock targets and build cyclic type graph together
+    std::unordered_map<std::string, std::unordered_set<std::string>> typeGraph;
+    std::unordered_set<std::string> allTypes;
+    for (auto &stmt : prog) {
+        collectTypeGraphFromStmt(stmt, typeGraph, allTypes);
+        if (test_mode_)
+            collectMockedFunctionsFromStmt(stmt, mocked_functions_);
+    }
+    runCyclicTypeAnalysis(typeGraph, allTypes);
 
     llvm::FunctionType *ft = llvm::FunctionType::get(i32Ty_, false);
     fn_ = llvm::Function::Create(ft, llvm::Function::ExternalLinkage, "__ry_main__", *mod_);

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -992,31 +992,31 @@ static void collectReferencedTypes(const TypeNodePtr &tn,
     // FnType, RangeType: skip (functions don't form ownership cycles)
 }
 
-void CodeGen::computeCyclicTypes(Program &prog) {
-    // Build type reference graph from AST declarations.
-    // type_name -> set of type names it references (via ARC pointer fields)
-    std::unordered_map<std::string, std::unordered_set<std::string>> graph;
-    std::unordered_set<std::string> all_types;
-
-    for (auto &stmt : prog) {
-        if (auto *es = std::get_if<EnumStmt>(&stmt)) {
-            if (!es->type_params.empty()) continue;  // skip generic templates
-            all_types.insert(es->name);
-            auto &refs = graph[es->name];
-            for (auto &v : es->variants) {
-                for (auto &ft : v.field_types) {
-                    collectReferencedTypes(ft, refs);
-                }
-            }
-        } else if (auto *rs = std::get_if<RecordStmt>(&stmt)) {
-            all_types.insert(rs->name);
-            auto &refs = graph[rs->name];
-            for (auto &f : rs->fields) {
-                collectReferencedTypes(f.type, refs);
+void CodeGen::collectTypeGraphFromStmt(
+    const StmtNode &stmt,
+    std::unordered_map<std::string, std::unordered_set<std::string>> &graph,
+    std::unordered_set<std::string> &all_types) {
+    if (auto *es = std::get_if<EnumStmt>(&stmt)) {
+        if (!es->type_params.empty()) return;  // skip generic templates
+        all_types.insert(es->name);
+        auto &refs = graph[es->name];
+        for (auto &v : es->variants) {
+            for (auto &ft : v.field_types) {
+                collectReferencedTypes(ft, refs);
             }
         }
+    } else if (auto *rs = std::get_if<RecordStmt>(&stmt)) {
+        all_types.insert(rs->name);
+        auto &refs = graph[rs->name];
+        for (auto &f : rs->fields) {
+            collectReferencedTypes(f.type, refs);
+        }
     }
+}
 
+void CodeGen::runCyclicTypeAnalysis(
+    std::unordered_map<std::string, std::unordered_set<std::string>> &graph,
+    const std::unordered_set<std::string> &all_types) {
     // Remove edges to types not in our type set (built-in types like int, str, etc.).
     for (auto &[name, refs] : graph) {
         std::unordered_set<std::string> filtered;

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -226,6 +226,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<InterpolatedStringExpr> &e) {
     // Convert each expression to string
     std::vector<llvm::Value*> strParts;
+    strParts.reserve(e->parts.size() + e->exprs.size());
     for (size_t i = 0; i < e->parts.size(); ++i) {
         if (!e->parts[i].empty())
             strParts.push_back(cachedGlobalString(e->parts[i], ".fstr_lit"));

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -119,7 +119,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e)
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<TupleExpr> &e) {
     std::vector<llvm::Type*> types;
+    types.reserve(e->elements.size());
     std::vector<llvm::Value*> vals;
+    vals.reserve(e->elements.size());
     for (auto &el : e->elements) {
         llvm::Value *v = emitExpr(*el);
         types.push_back(v->getType());

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -165,6 +165,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     }
 
     std::vector<llvm::Type*> paramTypes;
+    paramTypes.reserve(s->params.size());
     for (auto &p : s->params)
         paramTypes.push_back(resolveType(p.type->toString()));
 
@@ -218,6 +219,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     // Compute minArity and collect default values
     size_t newMinArity = 0;
     std::vector<ExprPtr> defaults;
+    defaults.reserve(s->params.size());
     for (size_t i = 0; i < s->params.size(); ++i) {
         if (!s->params[i].default_value) newMinArity = i + 1;
         defaults.push_back(std::move(s->params[i].default_value));
@@ -259,9 +261,11 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         ft, llvm::Function::ExternalLinkage, irName, *mod_);
 
     std::vector<std::string> paramNames;
+    paramNames.reserve(s->params.size());
     for (auto &p : s->params)
         paramNames.push_back(p.name);
     std::vector<std::string> paramTypeNames;
+    paramTypeNames.reserve(s->params.size());
     for (auto &p : s->params)
         paramTypeNames.push_back(p.type->toString());
     overloads.push_back({func, paramTypes, paramNames, paramTypeNames, exposedReturnTypeName,
@@ -457,6 +461,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
         llvm::Value *typedEnv = builder_.CreateBitCast(envRaw, ptrTy_, "async_env_typed");
         std::vector<llvm::Value*> thunkArgs;
+        thunkArgs.reserve(paramTypes.size());
         for (size_t i = 0; i < paramTypes.size(); ++i) {
             llvm::Value *argField = builder_.CreateStructGEP(
                 envTy, typedEnv, i, "async_arg_field." + std::to_string(i));
@@ -545,6 +550,7 @@ void CodeGen::emitInvariantCheck(const std::string &typeName, const StructInfo &
     if (info.invariants.empty() && info.parent_name.empty()) return;
 
     std::vector<std::pair<std::string, const ExprPtr*>> allInvariants;
+    allInvariants.reserve(8);
     for (auto &inv : info.invariants)
         allInvariants.push_back({typeName, &inv});
     const std::string *parent = &info.parent_name;
@@ -646,6 +652,7 @@ void CodeGen::instantiateGenericEnum(const std::string &fullName, const std::str
 
     bool hasADT = false;
     std::vector<llvm::Constant*> nameStrings;
+    nameStrings.reserve(tmpl.variants.size());
     for (size_t i = 0; i < tmpl.variants.size(); ++i) {
         auto &v = tmpl.variants[i];
         info.variants[v.name] = static_cast<int64_t>(i);
@@ -847,6 +854,7 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
 
     // Resolve parameter types and return type using type_param_scope_
     std::vector<llvm::Type*> paramTypes;
+    paramTypes.reserve(s.params.size());
     for (auto &p : s.params)
         paramTypes.push_back(resolveType(p.type->toString()));
     std::string sReturnType = s.return_type ? s.return_type->toString() : "";
@@ -866,9 +874,11 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
         ft, llvm::Function::InternalLinkage, irName, *mod_);
 
     std::vector<std::string> paramNames;
+    paramNames.reserve(s.params.size());
     for (auto &p : s.params)
         paramNames.push_back(p.name);
     std::vector<std::string> paramTypeNames;
+    paramTypeNames.reserve(s.params.size());
     for (auto &p : s.params) {
         // Substitute type params in param type names for FnTypeInfo
         std::string pTypeStr = p.type->toString();

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -740,6 +740,8 @@ void CodeGen::emitStmt(EnumStmt &s) {
 
     // Create global string array for variant names (for printing)
     std::vector<llvm::Constant*> nameStrings;
+    nameStrings.reserve(s.variants.size());
+    info.variantOrder.reserve(s.variants.size());
     std::unordered_set<int64_t> seenValues;
     for (size_t i = 0; i < s.variants.size(); ++i) {
         int64_t val = s.variants[i].explicit_value.value_or(static_cast<int64_t>(i));

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -118,6 +118,7 @@ ExprPtr Parser::parseBinaryLeft(ParseFn operand, std::initializer_list<TokenKind
 
 std::vector<ExprPtr> Parser::parseArgList() {
     std::vector<ExprPtr> args;
+    args.reserve(4);
     if (lex_.peek().kind != TokenKind::RParen) {
         args.push_back(parseConditional());
         while (lex_.peek().kind == TokenKind::Comma) {
@@ -135,6 +136,7 @@ std::vector<ExprPtr> Parser::parseArgList() {
 
 Program Parser::parseProgram() {
     Program prog;
+    prog.reserve(32);
     skipNewlines();
     while (lex_.peek().kind != TokenKind::Eof) {
         if (lex_.peek().kind == TokenKind::From) {
@@ -278,6 +280,7 @@ StmtNode Parser::parseImportStatement() {
     }
 
     std::vector<std::string> names;
+    names.reserve(4);
     if (lex_.peek().kind == TokenKind::Import) {
         lex_.next(); // consume 'import'
         Token name = lex_.peek();
@@ -596,6 +599,7 @@ std::vector<StmtNode> Parser::parseBlock() {
     lex_.next(); // consume Indent
 
     std::vector<StmtNode> stmts;
+    stmts.reserve(8);
     while (lex_.peek().kind != TokenKind::Dedent &&
            lex_.peek().kind != TokenKind::Eof) {
         stmts.push_back(parseStatement());

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -27,6 +27,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
     Token fnTok = lex_.next(); // consume 'function'
 
     auto fnStmt = std::make_unique<FnStmt>();
+    fnStmt->params.reserve(4);
     fnStmt->loc = locFromToken(fnTok);
     fnStmt->is_async = is_async;
 
@@ -109,6 +110,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         // Parse optional type parameters: function name<T, U>(...) or function name<T: Bound>(...)
         if (lex_.peek().kind == TokenKind::Less) {
             lex_.next(); // consume '<'
+            fnStmt->type_params.reserve(2);
             for (;;) {
                 fnStmt->type_params.push_back(parseOneTypeParam());
                 if (lex_.peek().kind != TokenKind::Comma)
@@ -343,6 +345,7 @@ StmtNode Parser::parseRecordStatement() {
     RecordStmt ts;
     ts.name = nameTok.value;
     ts.loc = locFromToken(recordTok);
+    ts.fields.reserve(8);
 
     // Optional parent type: record Child < Parent:
     if (lex_.peek().kind == TokenKind::Less) {
@@ -480,6 +483,7 @@ StmtNode Parser::parseEnumStatement() {
     es.name = nameTok.value;
     es.type_params = std::move(typeParams);
     es.loc = locFromToken(enumTok);
+    es.variants.reserve(4);
     std::unordered_set<std::string> seenVariants;
 
     while (lex_.peek().kind != TokenKind::Dedent &&
@@ -605,6 +609,7 @@ TypeNodePtr Parser::parseTypeName() {
         return node;
     // Union type
     std::vector<TypeNodePtr> components;
+    components.reserve(4);
     components.push_back(std::move(node));
     while (lex_.peek().kind == TokenKind::Pipe) {
         lex_.next(); // consume '|'
@@ -618,6 +623,7 @@ TypeNodePtr Parser::parseTypeNameSingle() {
     if (lex_.peek().kind == TokenKind::LParen) {
         lex_.next(); // consume '('
         std::vector<TypeNodePtr> elements;
+        elements.reserve(4);
         elements.push_back(parseTypeName());
         while (lex_.peek().kind == TokenKind::Comma) {
             lex_.next(); // consume ','
@@ -703,6 +709,7 @@ TypeNodePtr Parser::parseTypeNameSingle() {
     if (lex_.peek().kind == TokenKind::Less) {
         lex_.next(); // consume '<'
         std::vector<TypeNodePtr> typeArgs;
+        typeArgs.reserve(2);
         typeArgs.push_back(parseTypeName());
         if ((name == "Map" || name == "Result") && lex_.peek().kind == TokenKind::Comma) {
             // Two-parameter generic: Map<K, V> or Result<V, E>
@@ -746,6 +753,7 @@ TypeNodePtr Parser::parseFnType() {
         parseError("expected '(' after 'function' in function type");
     lex_.next(); // consume '('
     std::vector<TypeNodePtr> paramTypes;
+    paramTypes.reserve(4);
     if (lex_.peek().kind != TokenKind::RParen) {
         paramTypes.push_back(parseTypeName());
         while (lex_.peek().kind == TokenKind::Comma) {
@@ -870,6 +878,7 @@ Pattern Parser::parsePattern() {
             if (lex_.peek().kind == TokenKind::LParen) {
                 lex_.next(); // consume '('
                 std::vector<std::string> bindings;
+                bindings.reserve(4);
                 if (lex_.peek().kind != TokenKind::RParen) {
                     for (;;) {
                         Token binding = lex_.peek();
@@ -912,6 +921,7 @@ StmtNode Parser::parseWhenStatement() {
 
         auto whenStmt = std::make_unique<WhenCondStmt>();
         whenStmt->loc = locFromToken(whenTok);
+        whenStmt->arms.reserve(4);
 
         bool seenElse = false;
         while (lex_.peek().kind != TokenKind::Dedent &&
@@ -973,6 +983,7 @@ StmtNode Parser::parseMatchStatement() {
     auto matchStmt = std::make_unique<MatchStmt>();
     matchStmt->subject = std::move(subject);
     matchStmt->loc = locFromToken(matchTok);
+    matchStmt->arms.reserve(4);
 
     while (lex_.peek().kind != TokenKind::Dedent &&
            lex_.peek().kind != TokenKind::Eof) {

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -296,6 +296,8 @@ ExprPtr Parser::parsePrimary() {
     if (t.kind == TokenKind::FStringStart) {
         lex_.next(); // consume FStringStart
         auto interp = std::make_unique<InterpolatedStringExpr>();
+        interp->parts.reserve(4);
+        interp->exprs.reserve(4);
         interp->parts.push_back(t.value);
         interp->exprs.push_back(parseConditional());
         while (lex_.peek().kind == TokenKind::FStringMid) {
@@ -542,6 +544,8 @@ ExprPtr Parser::parsePrimary() {
             // Map literal: first expression was the key
             lex_.next(); // consume ':'
             auto map = std::make_unique<MapExpr>();
+            map->keys.reserve(4);
+            map->values.reserve(4);
             ExprPtr val = parseConditional();
             map->keys.push_back(std::move(first));
             map->values.push_back(std::move(val));
@@ -565,6 +569,7 @@ ExprPtr Parser::parsePrimary() {
         } else {
             // Set literal
             auto set = std::make_unique<SetExpr>();
+            set->elements.reserve(4);
             set->elements.push_back(std::move(first));
             while (lex_.peek().kind == TokenKind::Comma) {
                 lex_.next(); // consume ','
@@ -582,6 +587,7 @@ ExprPtr Parser::parsePrimary() {
     if (t.kind == TokenKind::LBracket) {
         lex_.next(); // consume '['
         auto list = std::make_unique<ListExpr>();
+        list->elements.reserve(4);
         skipStructuralTokens();
         if (lex_.peek().kind != TokenKind::RBracket) {
             list->elements.push_back(parseConditional());
@@ -621,6 +627,7 @@ ExprPtr Parser::parsePrimary() {
         if (lex_.peek().kind == TokenKind::Comma) {
             // Tuple literal: (expr, expr, ...)
             auto tuple = std::make_unique<TupleExpr>();
+            tuple->elements.reserve(4);
             tuple->elements.push_back(std::move(first));
             while (lex_.peek().kind == TokenKind::Comma) {
                 lex_.next(); // consume ','
@@ -671,6 +678,7 @@ ExprPtr Parser::parseParenLambdaExpr() {
     lex_.next(); // consume '('
 
     auto lambda = std::make_unique<LambdaExpr>();
+    lambda->params.reserve(4);
     if (lex_.peek().kind != TokenKind::RParen) {
         for (;;) {
             Token paramName = lex_.peek();
@@ -802,6 +810,7 @@ ExprPtr Parser::parsePostfix() {
         if (lex_.peek().kind == TokenKind::LBracket) {
             Token lbTok = lex_.next(); // consume '['
             std::vector<ExprPtr> indices;
+            indices.reserve(2);
             indices.push_back(parseConditional());
             while (lex_.peek().kind == TokenKind::Comma) {
                 lex_.next(); // consume ','


### PR DESCRIPTION
Closes #464

## Summary

- Add `reserve()` to 30+ vector hot paths across parser and codegen to eliminate reallocation overhead
- Merge two separate pre-pass traversals in `compile()` into a single loop over program statements
- Refactor `computeCyclicTypes` into per-stmt `collectTypeGraphFromStmt` + `runCyclicTypeAnalysis`
- Deduplicate mock collection logic: single-stmt visitor as canonical implementation

### Parser reserve() additions (22 locations)
- `parseArgList`, `parseProgram`, `parseBlock`, `parseImportStatement`
- Collection literals: list, map, set, tuple elements
- Function: params, type_params
- Record: fields; Enum: variants
- Type annotations: union components, tuple elements, generic typeArgs, fn paramTypes
- Pattern bindings, match/when arms, lambda params, index indices, f-string parts

### Codegen reserve() additions (14 locations)
- `codegen_fn.cpp`: paramTypes, paramNames, paramTypeNames, defaults, thunkArgs, nameStrings, allInvariants
- `codegen_expr_literal.cpp`: tuple types/vals
- `codegen_expr_cast.cpp`: interpolated string strParts
- `codegen_stmt.cpp`: nameStrings, variantOrder

### Pre-pass merge
- `compile()` now runs one loop instead of two separate passes
- `collectTypeGraphFromStmt` (shallow type extraction) + `collectMockedFunctionsFromStmt` (deep mock scan) execute per statement
- `runCyclicTypeAnalysis` runs DFS cycle detection after graph construction

## Test plan

- [x] All 1278 C++ tests pass (`./build/ry_tests`)
- [x] All 62 Ry self-test files pass (`./build/ry test -p`)
- [x] ASan build passes (1277 tests + 62 self-tests, 1 pre-existing disabled)