### PR TITLE
perf: cache module resolution and parsed imports (#465)

### DIFF
--- a/include/ry/module_loader.hpp
+++ b/include/ry/module_loader.hpp
@@ -29,13 +29,18 @@ private:
     // Cache: abs_path -> set of exported names defined in that package/file
     std::unordered_map<std::string, std::unordered_set<std::string>> fn_cache_;
 
-    // Cache: raw path string -> canonical path (empty on failure)
-    std::unordered_map<std::string, std::string> canonical_cache_;
+    // Cache: raw path string -> (canonical path, error_code)
+    struct CanonicalEntry {
+        std::string path;
+        std::error_code ec;
+    };
+    std::unordered_map<std::string, CanonicalEntry> canonical_cache_;
     // Cache: "package_path\0referrer_dir" -> resolved path + is_directory flag
     std::unordered_map<std::string, ResolvedPath> resolve_cache_;
 
-    // Cached fs::canonical — core implementation keyed by raw string
+    // Cached fs::canonical — populates ec with original error on failure
     std::string cachedCanonical(const std::string &raw, std::error_code &ec);
+    // Cached fs::canonical — throws filesystem_error on failure (like fs::canonical)
     std::string cachedCanonical(const std::string &raw);
     // Convenience overloads accepting fs::path
     std::string cachedCanonical(const std::filesystem::path &p, std::error_code &ec);

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -113,21 +113,21 @@ ModuleLoader::ModuleLoader(const std::vector<std::string> &search_paths,
 std::string ModuleLoader::cachedCanonical(const std::string &raw, std::error_code &ec) {
     auto it = canonical_cache_.find(raw);
     if (it != canonical_cache_.end()) {
-        if (it->second.empty())
-            ec = std::make_error_code(std::errc::no_such_file_or_directory);
-        else
-            ec.clear();
-        return it->second;
+        ec = it->second.ec;
+        return it->second.path;
     }
     std::string result = fs::canonical(fs::path(raw), ec).string();
     if (ec) result.clear();
-    canonical_cache_[raw] = result;
+    canonical_cache_[raw] = {result, ec};
     return result;
 }
 
 std::string ModuleLoader::cachedCanonical(const std::string &raw) {
     std::error_code ec;
-    return cachedCanonical(raw, ec);
+    std::string result = cachedCanonical(raw, ec);
+    if (ec)
+        throw fs::filesystem_error("cachedCanonical", fs::path(raw), ec);
+    return result;
 }
 
 std::string ModuleLoader::cachedCanonical(const fs::path &p, std::error_code &ec) {
@@ -135,8 +135,7 @@ std::string ModuleLoader::cachedCanonical(const fs::path &p, std::error_code &ec
 }
 
 std::string ModuleLoader::cachedCanonical(const fs::path &p) {
-    std::error_code ec;
-    return cachedCanonical(p.string(), ec);
+    return cachedCanonical(p.string());
 }
 
 ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &package_path,


### PR DESCRIPTION
## Summary

- Add `canonical_cache_` to eliminate redundant `fs::canonical()` syscalls (3-4 per import resolution)
- Add `resolve_cache_` to skip re-resolution of identical `(package_path, referrer_dir)` pairs
- Inline exported name collection into `extractDefinitions` via `out_names` parameter, removing separate `collectExportedNames` traversal
- Cache `is_directory` flag in `ResolvedPath` to avoid re-probing filesystem in `resolveImports`

Closes #465

## Test plan

- [x] All 1278 C++ tests pass (`ry_tests`)
- [x] All 62 Ry spec test files pass (`ry test -p`)
- [x] ASan build passes with no memory errors
- [x] No change in observable import resolution semantics or diagnostics