### PR TITLE
perf: fuse `not in` into a single lexer token (#486)

### DIFF
--- a/include/ry/lexer.hpp
+++ b/include/ry/lexer.hpp
@@ -19,6 +19,7 @@ enum class TokenKind {
     And,         // and
     Or,          // or
     Not,         // not
+    NotIn,       // not in
     True,        // true
     False,       // false
     // --- ビット演算子 ---

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -574,8 +574,25 @@ Token Lexer::readToken() {
         }
         std::string id(src_, start, pos_ - start);
         auto kit = keyword_map.find(id);
-        if (kit != keyword_map.end())
+        if (kit != keyword_map.end()) {
+            if (kit->second == TokenKind::Not) {
+                size_t savedPos = pos_;
+                int savedCol = col_;
+                while (pos_ < src_.size() && (src_[pos_] == ' ' || src_[pos_] == '\t')) {
+                    ++pos_; ++col_;
+                }
+                if (pos_ + 2 <= src_.size() &&
+                    src_[pos_] == 'i' && src_[pos_ + 1] == 'n' &&
+                    (pos_ + 2 >= src_.size() ||
+                     (!std::isalnum(static_cast<unsigned char>(src_[pos_ + 2])) && src_[pos_ + 2] != '_'))) {
+                    pos_ += 2; col_ += 2;
+                    return {TokenKind::NotIn, "not in", line_, startCol};
+                }
+                pos_ = savedPos;
+                col_ = savedCol;
+            }
             return {kit->second, std::move(id), line_, startCol};
+        }
         return {TokenKind::Ident, std::move(id), line_, startCol};
     }
 

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -108,30 +108,10 @@ ExprPtr Parser::parseComparison() {
     ExprPtr lhs = parseRange();
     for (;;) {
         TokenKind k = lex_.peek().kind;
-        // Handle "not in" as a two-token operator
-        if (k == TokenKind::Not) {
-            auto saved = lex_.saveState();
-            Token notTok = lex_.next(); // consume 'not'
-            if (lex_.peek().kind == TokenKind::In) {
-                lex_.next(); // consume 'in'
-                ExprPtr rhs = parseBitwiseOr();
-                auto bin = std::make_unique<BinaryExpr>();
-                bin->op = "not in";
-                bin->lhs = std::move(lhs);
-                bin->rhs = std::move(rhs);
-                auto node = std::make_unique<ExprNode>();
-                node->data = std::move(bin);
-                node->loc = locFromToken(notTok);
-                lhs = std::move(node);
-                continue;
-            }
-            lex_.restoreState(saved);
-            break;
-        }
         if (k == TokenKind::EqEq || k == TokenKind::BangEq ||
             k == TokenKind::Less || k == TokenKind::LessEq ||
             k == TokenKind::Greater || k == TokenKind::GreaterEq ||
-            k == TokenKind::In) {
+            k == TokenKind::In || k == TokenKind::NotIn) {
             Token opTok = lex_.next();
             ExprPtr rhs = parseBitwiseOr();
             auto bin = std::make_unique<BinaryExpr>();

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -61,6 +61,36 @@ TEST(LexerTest, KeywordRecognition) {
         ASSERT_EQ(toks.size(), 2u);
         EXPECT_EQ(toks[0].kind, TokenKind::Not);
     }
+    // not in (fused token)
+    {
+        auto toks = tokenize("x not in s");
+        ASSERT_EQ(toks.size(), 4u);
+        EXPECT_EQ(toks[0].kind, TokenKind::Ident);
+        EXPECT_EQ(toks[1].kind, TokenKind::NotIn);
+        EXPECT_EQ(toks[1].value, "not in");
+        EXPECT_EQ(toks[2].kind, TokenKind::Ident);
+    }
+    // not in with multiple spaces
+    {
+        auto toks = tokenize("x not  in s");
+        ASSERT_EQ(toks.size(), 4u);
+        EXPECT_EQ(toks[1].kind, TokenKind::NotIn);
+    }
+    // not followed by non-in identifier
+    {
+        auto toks = tokenize("not inside");
+        ASSERT_EQ(toks.size(), 3u);
+        EXPECT_EQ(toks[0].kind, TokenKind::Not);
+        EXPECT_EQ(toks[1].kind, TokenKind::Ident);
+        EXPECT_EQ(toks[1].value, "inside");
+    }
+    // standalone not (unary)
+    {
+        auto toks = tokenize("not x");
+        ASSERT_EQ(toks.size(), 3u);
+        EXPECT_EQ(toks[0].kind, TokenKind::Not);
+        EXPECT_EQ(toks[1].kind, TokenKind::Ident);
+    }
     // true
     {
         auto toks = tokenize("true");


### PR DESCRIPTION
## Summary

- Introduce `TokenKind::NotIn` so the lexer emits a single token for `not in` instead of two separate `Not` + `In` tokens
- Remove `saveState()`/`restoreState()` backtracking in `parseComparison()`, simplifying the parser logic
- Add lexer tests for token fusion, edge cases (`not inside`, `not x`, multi-space `not  in`)

Closes #486

## Test plan

- [x] All 1278 C++ tests pass (`./build/ry_tests`)
- [x] All 62 Ry self-test files pass (`./build/ry test -p`)
- [x] ASan build passes with no errors
- [x] `not in` operator works correctly in sets, lists, maps
- [x] Unary `not` still works as expected
- [x] `not inside` (non-`in` identifier) is not incorrectly fused