### PR TITLE
feat: support generic target types in operator as cast codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `operator as` codegen now supports generic target types (e.g., `int?`, `Result<int, Error>`), not just struct types (#501)
 - Self-update tar validation now uses a whitelist approach, rejecting all archive entries that are not regular files or directories (device nodes, FIFOs, sockets, etc.) (#471)
 - `print()` output inside `@parallel for` loops is no longer interleaved across threads — each `print()` call now produces atomic output via thread-local buffering (#473)
 - Mocked functions now still enforce the original function's `require` and `ensure` contracts, preventing tests from bypassing contract checks (#441)

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -482,4 +482,17 @@ c = Celsius(100)
 f = c as Fahrenheit   # Fahrenheit(212)
 ```
 
+The target type can be any type the compiler can resolve, including generic types:
+
+```python
+record Temperature:
+    value: int
+
+function operator as(t: Temperature) -> int?:
+    return Some(t.value)
+
+t = Temperature(42)
+result: int? = t as int?   # Some(42)
+```
+
 User-defined `as` operators are tried first; if no match is found, built-in casts (int, float, bool, str, etc.) are used as a fallback.

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -9,15 +9,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
     // Try user-defined operator as (matches by source type + return type)
     auto fit = functions_.find("operatoras");
     if (fit != functions_.end()) {
-        auto sit = struct_types_.find(target);
-        if (sit != struct_types_.end()) {
-            llvm::Type *targetTy = sit->second.llvmType;
-            for (auto &entry : fit->second) {
-                if (entry.paramTypes.size() == 1 &&
-                    entry.paramTypes[0] == srcTy &&
-                    entry.func->getReturnType() == targetTy) {
-                    return builder_.CreateCall(entry.func, {val}, "cast_op");
-                }
+        llvm::Type *targetTy = resolveType(target);
+        for (auto &entry : fit->second) {
+            if (entry.paramTypes.size() == 1 &&
+                entry.paramTypes[0] == srcTy &&
+                entry.func->getReturnType() == targetTy) {
+                return builder_.CreateCall(entry.func, {val}, "cast_op");
             }
         }
     }

--- a/tests/spec/operator_overload.test.ry
+++ b/tests/spec/operator_overload.test.ry
@@ -116,6 +116,16 @@ describe("operator as", ():
     expect(f.value).to_eq(212)
   )
 
+  it("cast to generic Option type", ():
+    record Temperature:
+      value: int
+    function operator as(t: Temperature) -> int?:
+      return Some(t.value)
+    t = Temperature(42)
+    result: int? = t as int?
+    expect(result ?? -1).to_eq(42)
+  )
+
   it("built-in cast still works", ():
     x: float = 42 as float
     expect(x + 0.5).to_eq(42.5)

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2310,6 +2310,18 @@ TEST_F(CodeGenTest, OperatorAsParamValidation) {
         "    return a\n"), std::runtime_error);
 }
 
+TEST_F(CodeGenTest, OperatorAsGenericOptionTarget) {
+    std::string src =
+        "record Celsius:\n"
+        "    value: int\n"
+        "function operator as(c: Celsius) -> int?:\n"
+        "    return Some(c.value)\n"
+        "c = Celsius(42)\n"
+        "result: int? = c as int?\n"
+        "print(result ?? -1)\n";
+    EXPECT_EQ(runSource(src), "42\n");
+}
+
 // ===== Bounds checking tests =====
 
 TEST_F(CodeGenTest, ListNegativeIndexWrapAll) {


### PR DESCRIPTION
## Summary

- Replace `struct_types_.find(target)` with `resolveType(target)` in `operator as` matching path so generic types (`Option<int>`, `Result<int, Error>`, etc.) can be cast targets
- Add C++ unit test and Ry spec test for `operator as` with `int?` target
- Document generic cast target support in `docs/reference/operators.md`

Closes #501

## Test plan

- [x] New `OperatorAsGenericOptionTarget` C++ test passes
- [x] New spec test "cast to generic Option type" passes
- [x] Existing `OperatorAs`, `OperatorAsFallbackBuiltin`, `OperatorAsParamValidation` tests still pass
- [x] Full C++ test suite: 1284 passed
- [x] Full Ry spec tests: 62 files, 0 failures
- [x] ASan build: 1283 passed (C++), 0 failures (Ry spec)