### PR TITLE
feat: add body_bytes() for binary-safe HTTP body access (#284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Regex literal syntax (`/pattern/`) that produces a `Regex` type, enabling type-based overload resolution and UFCS-compatible function calls (e.g., `"hello".is_match(/[a-z]+/)`, `"a1b2".split(/[0-9]/)`) (#458)
 - New text-first regex functions: `is_match`, `search`, `replace`, `split`, `find_all` — overloaded to accept `Regex` type patterns alongside existing string functions
 - `print()` now accepts multiple arguments with space-separated output (e.g., `print(1, "hello", true)` → `1 hello true`), and calling `print()` with no arguments now prints only a newline
+- `body_bytes()` function for `HttpRequest` and `HttpClientResponse` that returns `List<u8>`, enabling binary-safe HTTP body access without NUL-byte truncation (#284)
 
 ### Fixed
 

--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -17,7 +17,7 @@
 These functions require explicit import:
 
 ```python
-from http import listen, method, path, header, body, query, query_all, cookie, cookies, form_field, form_file, form_fields, response
+from http import listen, method, path, header, body, body_bytes, query, query_all, cookie, cookies, form_field, form_file, form_fields, response
 ```
 
 ### Server
@@ -35,7 +35,8 @@ from http import listen, method, path, header, body, query, query_all, cookie, c
 | `method` | `(req: HttpRequest) -> str` | Returns the HTTP method (e.g., `"GET"`, `"POST"`). |
 | `path` | `(req: HttpRequest) -> str` | Returns the request path without the query string (e.g., `"/search"` for `"/search?q=hello"`). |
 | `header` | `(req: HttpRequest, key: str) -> Option<str>` | Returns the value of a request header (case-insensitive lookup). Returns `None` if not found. |
-| `body` | `(req: HttpRequest) -> str` | Returns the request body as a string. |
+| `body` | `(req: HttpRequest) -> str` | Returns the request body as a string. Truncated at the first NUL byte; use `body_bytes` for binary data. |
+| `body_bytes` | `(req: HttpRequest) -> List<u8>` | Returns the request body as a byte list. Binary-safe — preserves all bytes including NUL. |
 | `query` | `(req: HttpRequest, key: str) -> Option<str>` | Returns the value of a query parameter. Returns `None` if not found. Values are automatically URL-decoded. |
 | `query_all` | `(req: HttpRequest) -> Map<str, str>` | Returns all query parameters as a map. Keys and values are automatically URL-decoded. |
 | `cookie` | `(req: HttpRequest, name: str) -> Option<str>` | Returns the value of a cookie by name. Returns `None` if not found. |
@@ -269,7 +270,8 @@ Other status codes use `"Unknown"` as the reason phrase.
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `status` | `(resp: HttpClientResponse) -> int` | Returns the HTTP status code. |
-| `body` | `(resp: HttpClientResponse) -> str` | Returns the response body as a string. |
+| `body` | `(resp: HttpClientResponse) -> str` | Returns the response body as a string. Truncated at the first NUL byte; use `body_bytes` for binary data. |
+| `body_bytes` | `(resp: HttpClientResponse) -> List<u8>` | Returns the response body as a byte list. Binary-safe — preserves all bytes including NUL. |
 | `header` | `(resp: HttpClientResponse, key: str) -> Option<str>` | Returns the value of a response header (case-insensitive). Returns `None` if not found. |
 | `http_client_response_free` | `(resp: HttpClientResponse) -> Unit` | Frees the response and its associated memory. Call when done with the response. |
 

--- a/include/ry/runtime_http.hpp
+++ b/include/ry/runtime_http.hpp
@@ -9,6 +9,7 @@ const char *__ry_http_method(void *req);
 const char *__ry_http_path(void *req);
 const char *__ry_http_header(void *req, const char *key);
 const char *__ry_http_body(void *req);
+void       *__ry_http_body_bytes(void *req);
 void       *__ry_http_response_create(int64_t status, void *headers_map, const char *body);
 void        __ry_http_send_response(void *stream, void *response, int64_t keep_alive);
 int64_t     __ry_http_should_keep_alive(void *req);
@@ -39,6 +40,7 @@ void       *__ry_http_get(const char *url);
 void       *__ry_http_post(const char *url, const char *body, void *headers_map);
 int64_t     __ry_http_client_status(void *resp);
 const char *__ry_http_client_body(void *resp);
+void       *__ry_http_client_body_bytes(void *resp);
 const char *__ry_http_client_header(void *resp, const char *key);
 void        __ry_http_client_response_free(void *resp);
 

--- a/include/ry/runtime_io.hpp
+++ b/include/ry/runtime_io.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
+#include <cstring>
 
 // ListHeader layout: {i64 len, i64 cap, ptr data}
 // Matches the generic list ABI used by codegen.
@@ -10,6 +12,23 @@ struct IOListHeader {
     int64_t cap;
     int8_t *data;
 };
+
+// Build a heap-allocated IOListHeader from raw bytes.
+// Each byte is stored as an int8_t element.
+inline IOListHeader *makeByteList(const uint8_t *bytes, int64_t len) {
+    auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
+    if (!header) return nullptr;
+    header->len = len;
+    header->cap = len;
+    if (len > 0) {
+        header->data = (int8_t *)malloc(len);
+        if (!header->data) { free(header); return nullptr; }
+        memcpy(header->data, bytes, len);
+    } else {
+        header->data = nullptr;
+    }
+    return header;
+}
 
 extern "C" {
 

--- a/lib/std/http/http.ry
+++ b/lib/std/http/http.ry
@@ -21,6 +21,9 @@ function header(req: HttpRequest, key: str) -> Option<str>
 function body(req: HttpRequest) -> str
 
 @native
+function body_bytes(req: HttpRequest) -> List<u8>
+
+@native
 function query(req: HttpRequest, key: str) -> Option<str>
 
 @native
@@ -59,6 +62,9 @@ function status(response: HttpClientResponse) -> int
 
 @native
 function body(response: HttpClientResponse) -> str
+
+@native
+function body_bytes(response: HttpClientResponse) -> List<u8>
 
 @native
 function header(response: HttpClientResponse, key: str) -> Option<str>

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -327,6 +327,25 @@ llvm::Value *CodeGen::emitBuiltinHttp(const CallExpr &e) {
         codegenError("body() requires HttpRequest or HttpClientResponse argument");
     }
 
+    // body_bytes(req_or_resp) -> List<u8> — binary-safe body access
+    if (e.callee == "body_bytes") {
+        requireArgs(e, 1);
+        llvm::Value *arg = emitExpr(*e.args[0]);
+        if (isHttpRequest(arg)) {
+            auto fn = mod_->getOrInsertFunction("__ry_http_body_bytes", fnTy_ptr_to_ptr_);
+            llvm::Value *result = builder_.CreateCall(fn, {arg}, "body_bytes");
+            type_meta_[TM_ListElem][result] = i8Ty_;
+            return result;
+        }
+        if (isHttpClientResponse(arg)) {
+            auto fn = mod_->getOrInsertFunction("__ry_http_client_body_bytes", fnTy_ptr_to_ptr_);
+            llvm::Value *result = builder_.CreateCall(fn, {arg}, "body_bytes");
+            type_meta_[TM_ListElem][result] = i8Ty_;
+            return result;
+        }
+        codegenError("body_bytes() requires HttpRequest or HttpClientResponse argument");
+    }
+
     // header(req_or_resp, key) -> Option<str> — overloaded for HttpRequest and HttpClientResponse
     if (e.callee == "header") {
         requireArgs(e, 2);

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -1,5 +1,6 @@
 #include "ry/runtime_http_internal.hpp"
 #include "ry/runtime_http.hpp"
+#include "ry/runtime_io.hpp"
 #include "ry/runtime_net_types.hpp"
 #include "ry/runtime_arc.hpp"
 
@@ -549,6 +550,11 @@ extern "C" const char *__ry_http_header(void *r, const char *key) {
 extern "C" const char *__ry_http_body(void *r) {
     auto *req = (HttpRequestHandle *)r;
     return req->body;
+}
+
+extern "C" void *__ry_http_body_bytes(void *r) {
+    auto *req = (HttpRequestHandle *)r;
+    return makeByteList((const uint8_t *)req->body, req->body_len);
 }
 
 extern "C" const char *__ry_http_query(void *r, const char *key) {

--- a/src/runtime_http_client.cpp
+++ b/src/runtime_http_client.cpp
@@ -1,5 +1,6 @@
 #include "ry/runtime_http_internal.hpp"
 #include "ry/runtime_http.hpp"
+#include "ry/runtime_io.hpp"
 #include "ry/runtime_net_types.hpp"
 #include "ry/runtime_arc.hpp"
 
@@ -516,6 +517,12 @@ extern "C" int64_t __ry_http_client_status(void *r) {
 extern "C" const char *__ry_http_client_body(void *r) {
     if (!r) return "";
     return ((HttpClientResponseHandle *)r)->body;
+}
+
+extern "C" void *__ry_http_client_body_bytes(void *r) {
+    if (!r) return makeByteList(nullptr, 0);
+    auto *resp = (HttpClientResponseHandle *)r;
+    return makeByteList((const uint8_t *)resp->body, resp->body_len);
 }
 
 extern "C" const char *__ry_http_client_header(void *r, const char *key) {

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -44,16 +44,7 @@ extern "C" const char *__ry_get_last_error() {
     return strdup(last_error_buf);
 }
 
-// IOListHeader is defined in runtime_io.hpp (shared with runtime_net.cpp)
-
-static IOListHeader *makeByteList(const uint8_t *bytes, int64_t len) {
-    auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
-    header->len = len;
-    header->cap = len;
-    header->data = (int8_t *)malloc(len);
-    memcpy(header->data, bytes, len);
-    return header;
-}
+// IOListHeader and makeByteList are defined in runtime_io.hpp
 
 // ===== Standard input =====
 

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include "ry/runtime_net.hpp"
 #include "ry/runtime_http_types.hpp"
+#include "ry/runtime_io.hpp"
 
 extern "C" {
 const char *__ry_http_reason_phrase(int64_t status);
@@ -16,6 +17,7 @@ void *__ry_http_read_request(void *stream);
 const char *__ry_http_method(void *req);
 const char *__ry_http_path(void *req);
 const char *__ry_http_body(void *req);
+void *__ry_http_body_bytes(void *req);
 const char *__ry_http_query(void *req, const char *key);
 void *__ry_http_query_all(void *req);
 const char *__ry_http_cookie(void *req, const char *name);
@@ -37,6 +39,7 @@ void *__ry_http_get(const char *url);
 void *__ry_http_post(const char *url, const char *body, void *headers_map);
 int64_t __ry_http_client_status(void *resp);
 const char *__ry_http_client_body(void *resp);
+void *__ry_http_client_body_bytes(void *resp);
 const char *__ry_http_client_header(void *resp, const char *key);
 void __ry_http_client_response_free(void *resp);
 }
@@ -1760,6 +1763,19 @@ TEST(RuntimeHttp, ReadRequestBodyWithNulByte) {
     const char *body = __ry_http_body(result);
     EXPECT_STREQ(body, "ab");
 
+    // body_bytes preserves the full binary content including NUL
+    void *bytes = __ry_http_body_bytes(result);
+    ASSERT_NE(bytes, nullptr);
+    auto *bheader = (IOListHeader *)bytes;
+    EXPECT_EQ(bheader->len, 5);
+    EXPECT_EQ(bheader->data[0], 'a');
+    EXPECT_EQ(bheader->data[1], 'b');
+    EXPECT_EQ(bheader->data[2], '\0');
+    EXPECT_EQ(bheader->data[3], 'c');
+    EXPECT_EQ(bheader->data[4], 'd');
+    free(bheader->data);
+    free(bheader);
+
     __ry_http_request_free(result);
     ::close(fds[0]);
     free(handle);
@@ -1900,6 +1916,55 @@ TEST_F(RuntimeHttpClientTest, ClientResponseBodyWithNulByte) {
 
     const char *body = __ry_http_client_body(resp);
     EXPECT_STREQ(body, "he");  // C-string truncation at NUL
+
+    // body_bytes preserves the full binary content including NUL
+    void *bytes = __ry_http_client_body_bytes(resp);
+    ASSERT_NE(bytes, nullptr);
+    auto *header = (IOListHeader *)bytes;
+    EXPECT_EQ(header->len, 5);
+    EXPECT_EQ(header->data[0], 'h');
+    EXPECT_EQ(header->data[1], 'e');
+    EXPECT_EQ(header->data[2], '\0');
+    EXPECT_EQ(header->data[3], 'l');
+    EXPECT_EQ(header->data[4], 'o');
+    free(header->data);
+    free(header);
+
+    __ry_http_client_response_free(resp);
+    ::close(srv);
+}
+
+TEST_F(RuntimeHttpClientTest, ClientBodyBytesEmptyBody) {
+    // Server sends response with empty body.
+    std::string response =
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 0\r\n"
+        "\r\n";
+
+    int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
+    int port = get_server_port(srv);
+
+    std::thread server_thread([&]() {
+        struct sockaddr_in client_addr{};
+        socklen_t client_len = sizeof(client_addr);
+        int conn = ::accept(srv, (struct sockaddr *)&client_addr, &client_len);
+        ::write(conn, response.data(), response.size());
+        ::close(conn);
+    });
+    JoinGuard jg(server_thread);
+
+    std::string url = "http://127.0.0.1:" + std::to_string(port) + "/";
+    void *resp = __ry_http_get(url.c_str());
+    ASSERT_NE(resp, nullptr);
+
+    void *bytes = __ry_http_client_body_bytes(resp);
+    ASSERT_NE(bytes, nullptr);
+    auto *header = (IOListHeader *)bytes;
+    EXPECT_EQ(header->len, 0);
+    free(header->data);
+    free(header);
+
     __ry_http_client_response_free(resp);
     ::close(srv);
 }


### PR DESCRIPTION
## Summary

- Add `body_bytes()` function overloaded for `HttpRequest` and `HttpClientResponse`, returning `List<u8>` for binary-safe HTTP body access
- Existing `body()` returns `str` which truncates at the first NUL byte — `body_bytes()` preserves all bytes using the `body_len` infrastructure from #281
- Move `makeByteList` helper from `runtime_io.cpp` (static) to `runtime_io.hpp` (inline) for cross-module reuse

Closes #284

## Test plan

- [x] C++ tests: NUL-byte preservation for server request body (`ReadRequestBodyWithNulByte`)
- [x] C++ tests: NUL-byte preservation for client response body (`ClientResponseBodyWithNulByte`)
- [x] C++ tests: empty body returns `List<u8>` with len=0 (`ClientBodyBytesEmptyBody`)
- [x] All 1286 C++ tests pass
- [x] All 62 Ry test files pass (0 failures)
- [x] ASan build: all tests pass with no memory errors