### PR TITLE
fix: collection operations fail on List/Map/Set returned from user-defined functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- `append!` / `appended` and other collection operations now work correctly on `List`, `Map`, and `Set` values returned from user-defined functions (#509)
 - `operator as` codegen now supports generic target types (e.g., `int?`, `Result<int, Error>`), not just struct types (#501)
 - Self-update tar validation now uses a whitelist approach, rejecting all archive entries that are not regular files or directories (device nodes, FIFOs, sockets, etc.) (#471)
 - `print()` output inside `@parallel for` loops is no longer interleaved across threads — each `print()` call now produces atomic output via thread-local buffering (#473)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -809,6 +809,7 @@ private:
     void propagateResourceTracking(llvm::Value *src, llvm::Value *dst);
     void propagateResourceTrackingWide(llvm::Value *src, llvm::Value *dst);
     void propagateCollectionMetadata(llvm::Value *src, llvm::Value *dst);
+    void propagateReturnTypeMeta(const OverloadEntry *entry, llvm::Value *val);
     void propagateAllMetadata(llvm::Value *src, llvm::Value *dst);
     void propagateAllMetadataWide(llvm::Value *src, llvm::Value *dst);
     void registerResourceByTypeName(const std::string &typeName, llvm::Value *val);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -953,15 +953,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         llvm::PHINode *phi = builder_.CreatePHI(fn->getReturnType(), 2, "call_result");
         phi->addIncoming(mockResult, mockEndBB);
         phi->addIncoming(origResult, origEndBB);
-        if (matchedEntry && matchedEntry->returnTypeName.size() > 5 &&
-            matchedEntry->returnTypeName.compare(0, 5, "Task<") == 0 &&
-            matchedEntry->returnTypeName.back() == '>') {
-            std::string inner = matchedEntry->returnTypeName.substr(
-                5, matchedEntry->returnTypeName.size() - 6);
-            type_meta_[TM_TaskResult][phi] = resolveType(inner);
-        }
-        if (matchedEntry && isLowLevelTypeName(matchedEntry->returnTypeName))
-            low_level_type_names_[phi] = matchedEntry->returnTypeName;
+        propagateReturnTypeMeta(matchedEntry, phi);
         return phi;
     }
 
@@ -969,16 +961,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         return builder_.CreateCall(fn, argVals);
     llvm::Value *callResult = builder_.CreateCall(fn, argVals, "calltmp");
 
-    if (matchedEntry && matchedEntry->returnTypeName.size() > 5 &&
-        matchedEntry->returnTypeName.compare(0, 5, "Task<") == 0 &&
-        matchedEntry->returnTypeName.back() == '>') {
-        std::string inner = matchedEntry->returnTypeName.substr(5, matchedEntry->returnTypeName.size() - 6);
-        type_meta_[TM_TaskResult][callResult] = resolveType(inner);
-    }
-
-    // Propagate low-level type metadata from return type
-    if (matchedEntry && isLowLevelTypeName(matchedEntry->returnTypeName))
-        low_level_type_names_[callResult] = matchedEntry->returnTypeName;
+    propagateReturnTypeMeta(matchedEntry, callResult);
 
     return callResult;
 }

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -114,6 +114,27 @@ void CodeGen::propagateCollectionMetadata(llvm::Value *src, llvm::Value *dst) {
     }
 }
 
+void CodeGen::propagateReturnTypeMeta(const OverloadEntry *entry, llvm::Value *val) {
+    if (!entry) return;
+    const auto &rtn = entry->returnTypeName;
+    if (rtn.size() > 5 && rtn.compare(0, 5, "Task<") == 0 && rtn.back() == '>') {
+        std::string inner = rtn.substr(5, rtn.size() - 6);
+        type_meta_[TM_TaskResult][val] = resolveType(inner);
+    } else if (rtn.size() > 5 && rtn.compare(0, 5, "List<") == 0 && rtn.back() == '>') {
+        std::string inner = rtn.substr(5, rtn.size() - 6);
+        type_meta_[TM_ListElem][val] = resolveType(inner);
+    } else if (rtn.size() > 4 && rtn.compare(0, 4, "Map<") == 0 && rtn.back() == '>') {
+        auto [keyTy, valTy] = parseMapTypeAnnotation(rtn);
+        if (keyTy) type_meta_[TM_MapKey][val] = keyTy;
+        if (valTy) type_meta_[TM_MapValue][val] = valTy;
+    } else if (rtn.size() > 4 && rtn.compare(0, 4, "Set<") == 0 && rtn.back() == '>') {
+        std::string inner = rtn.substr(4, rtn.size() - 5);
+        type_meta_[TM_SetElem][val] = resolveType(inner);
+    } else if (isLowLevelTypeName(rtn)) {
+        low_level_type_names_[val] = rtn;
+    }
+}
+
 void CodeGen::propagateAllMetadata(llvm::Value *src, llvm::Value *dst) {
     propagateCollectionMetadata(src, dst);
     propagateResourceTracking(src, dst);

--- a/tests/spec/user_fn_collection_return.test.ry
+++ b/tests/spec/user_fn_collection_return.test.ry
@@ -1,0 +1,34 @@
+describe("List returned from user-defined function", ():
+  function get_list() -> List<int>:
+    return [1, 2, 3]
+
+  it("append! on returned list", ():
+    xs = get_list()
+    xs.append!(4)
+    expect(xs).to_have_length(4)
+    expect(xs[3]).to_eq(4)
+  )
+
+  it("appended on returned list", ():
+    xs = get_list()
+    ys = xs.appended(4)
+    expect(xs).to_have_length(3)
+    expect(ys).to_have_length(4)
+    expect(ys[3]).to_eq(4)
+  )
+
+  it("append on returned list", ():
+    xs = get_list()
+    append(xs, 4)
+    expect(xs).to_have_length(4)
+    expect(xs[3]).to_eq(4)
+  )
+
+  it("chained operations on returned list", ():
+    xs = get_list()
+    xs.append!(4)
+    xs.append!(5)
+    expect(xs).to_have_length(5)
+    expect(xs[4]).to_eq(5)
+  )
+)


### PR DESCRIPTION
## Summary

- Fix `append!` / `appended` and other collection operations failing with "not handled by any builtin dispatcher" when called on `List`, `Map`, or `Set` values returned from user-defined functions
- Extract `propagateReturnTypeMeta()` helper to propagate `TM_ListElem`, `TM_MapKey`, `TM_MapValue`, `TM_SetElem`, `TM_TaskResult`, and low-level type metadata from `OverloadEntry::returnTypeName` onto the call result `llvm::Value*`
- Use `else if` chain for short-circuit evaluation since return types are mutually exclusive

## Test plan

- [x] New test file `tests/spec/user_fn_collection_return.test.ry` with 4 cases (`append!`, `appended`, `append`, chained operations)
- [x] All 1290 C++ tests pass
- [x] All 63 Ry self-test files pass (0 failures)
- [x] ASan build passes with no errors

Closes #509