### PR TITLE
fix: resolve struct types in reverseResolveTypeName and lambda dead-block fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Return type inference now correctly resolves user-defined struct types in functions and lambdas without explicit type annotations (#515)
 - Return-path analysis now recognizes exhaustive `match` statements on custom enums and `bool`, removing false "does not return a value on all code paths" errors when all variants are covered (#513)
 - Indexing into `List`, `Map`, or `Set` fields of a record (e.g., `record.field[idx]`) no longer fails with "cannot determine list element type" (#511)
 - `join()` now works correctly with UFCS string receiver (e.g., `",".join(parts)`) (#508)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -207,6 +207,7 @@ private:
     std::unordered_map<std::string, EnumInfo> enum_types_;
     EnumVariantRegistry buildEnumVariantRegistry() const;
     std::string findAdtEnumName(llvm::StructType *st) const;
+    std::string findStructTypeName(llvm::StructType *st) const;
     std::unordered_map<llvm::Value*, std::string> enum_value_types_;
     llvm::Function *createAdtVisitFunction(const std::string &typeName, const EnumInfo &info);
     llvm::Function *createStructVisitFunction(const std::string &typeName, const StructInfo &info);

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -776,9 +776,7 @@ std::string CodeGen::reverseResolveType(llvm::Value *val) {
     }
 
     if (auto *st = llvm::dyn_cast<llvm::StructType>(ty)) {
-        for (auto &[name, info] : struct_types_)
-            if (info.llvmType == st) return name;
-        std::string n = findAdtEnumName(st);
+        std::string n = findStructTypeName(st);
         if (!n.empty()) return n;
     }
 

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -244,6 +244,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
                 else if (retTy == ptrTy_)
                     builder_.CreateRet(llvm::ConstantPointerNull::get(
                         llvm::cast<llvm::PointerType>(ptrTy_)));
+                else
+                    builder_.CreateRet(llvm::UndefValue::get(retTy));
             }
         }
 
@@ -460,7 +462,7 @@ std::string CodeGen::reverseResolveTypeName(llvm::Type *ty) {
     if (isAnyType(ty)) return "any";
     if (ty->isVoidTy()) return "Unit";
     if (auto *st = llvm::dyn_cast<llvm::StructType>(ty)) {
-        std::string n = findAdtEnumName(st);
+        std::string n = findStructTypeName(st);
         if (!n.empty()) return n;
     }
     return "any"; // fallback

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -241,6 +241,12 @@ std::string CodeGen::findAdtEnumName(llvm::StructType *st) const {
     return {};
 }
 
+std::string CodeGen::findStructTypeName(llvm::StructType *st) const {
+    for (auto &[name, info] : struct_types_)
+        if (info.llvmType == st) return name;
+    return findAdtEnumName(st);
+}
+
 llvm::StructType *CodeGen::getOptionType(llvm::Type *innerTy) {
     auto it = option_types_.find(innerTy);
     if (it != option_types_.end()) return it->second;

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -122,6 +122,13 @@ function infer_union(flag: bool):
     return 42
   return 3.14
 
+record InferPoint:
+  x: int
+  y: int
+
+function infer_struct():
+  return InferPoint(3, 4)
+
 describe("return type inference", ():
   it("infers int", ():
     expect(infer_int()).to_eq(42)
@@ -139,6 +146,18 @@ describe("return type inference", ():
     x = infer_union(true)
     y = infer_union(false)
     expect(true).to_be_true()
+  )
+  it("infers struct type", ():
+    p = infer_struct()
+    expect(p.x).to_eq(3)
+    expect(p.y).to_eq(4)
+  )
+  it("infers struct type from lambda", ():
+    make_point = (a: int, b: int):
+      return InferPoint(a, b)
+    p = make_point(5, 6)
+    expect(p.x).to_eq(5)
+    expect(p.y).to_eq(6)
   )
 )
 


### PR DESCRIPTION
## Summary

Closes #515

- `reverseResolveTypeName` only handled primitives and ADT enums, causing user-defined struct types to silently resolve to `"any"` during return type inference
- Lambda dead-block fallback lacked handling for struct return types, causing IR verification errors (`Basic Block does not have terminator`)
- Extracted `findStructTypeName` helper to unify struct type name resolution across `reverseResolveTypeName` and `reverseResolveType`

## Changes

- **`src/codegen_type.cpp`**: Add `findStructTypeName()` — scans `struct_types_` then delegates to `findAdtEnumName()`
- **`src/codegen_lambda.cpp`**: Use `findStructTypeName` in `reverseResolveTypeName`; add catch-all `else` branch in lambda dead-block fallback
- **`src/codegen_fn.cpp`**: Use `findStructTypeName` in `reverseResolveType`
- **`include/ry/codegen.hpp`**: Declare `findStructTypeName`
- **`tests/spec/functions.test.ry`**: Add struct return type inference tests (function + lambda)
- **`CHANGELOG.md`**: Add Fixed entry

## Test plan

- [x] `./build/ry_tests` — 1294 passed
- [x] `./build/ry test -p` — 65 test files, 0 failures
- [x] ASan build — clean (no errors)