### PR TITLE
fix: unify legacy regex API argument order to (text, pattern) (#512)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Indexing into `List`, `Map`, or `Set` fields of a record (e.g., `record.field[idx]`) no longer fails with "cannot determine list element type" (#511)
 - `join()` now works correctly with UFCS string receiver (e.g., `",".join(parts)`) (#508)
 - Closures returned from functions can now be called, and function-type parameters can be captured in closures — enabling higher-order patterns like `make_adder`, `compose`, and currying (#510)
+- **Breaking**: Legacy regex functions (`regex_match`, `regex_search`, `regex_replace`, `regex_split`, `regex_find_all`) now use text-first argument order `(text, pattern)` consistent with the regex literal API; previously `(pattern, text)` which caused silent incorrect results (#512)
 - SEGFAULT when multiple functions use `match` on ADT enum parameters — `resolveType()` now correctly returns the ADT struct type instead of `i64` for enums with variant data (#507)
 - `append!` / `appended` and other collection operations now work correctly on `List`, `Map`, and `Set` values returned from user-defined functions (#509)
 - `operator as` codegen now supports generic target types (e.g., `int?`, `Result<int, Error>`), not just struct types (#501)

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -67,21 +67,21 @@ parts = "hello world".split(/\s+/)
 nums = "a1b2c3".find_all(/[0-9]/)
 ```
 
-### Legacy Functions (pattern-first)
+### Legacy Functions (text-first)
 
-The original `regex_*` functions remain available for backward compatibility. They take pattern strings (not regex literals) with pattern-first argument order:
+The original `regex_*` functions remain available for backward compatibility. They take pattern strings (not regex literals) with text-first argument order, consistent with the regex literal API:
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `regex_match` | `(str, str) -> bool` | Returns whether the entire text matches the pattern |
-| `regex_search` | `(str, str) -> int` | Returns the start position of the first match (-1 if not found) |
-| `regex_replace` | `(str, str, str) -> str` | Replaces all matches with a replacement string |
-| `regex_split` | `(str, str) -> List<str>` | Splits text by pattern matches |
-| `regex_find_all` | `(str, str) -> List<str>` | Returns all non-overlapping matches |
+| `regex_match` | `(text: str, pattern: str) -> bool` | Returns whether the entire text matches the pattern |
+| `regex_search` | `(text: str, pattern: str) -> int` | Returns the start position of the first match (-1 if not found) |
+| `regex_replace` | `(text: str, pattern: str, replacement: str) -> str` | Replaces all matches with a replacement string |
+| `regex_split` | `(text: str, pattern: str) -> List<str>` | Splits text by pattern matches |
+| `regex_find_all` | `(text: str, pattern: str) -> List<str>` | Returns all non-overlapping matches |
 
 ```ry
-print(regex_match("[a-z]+", "hello"))   # true
-pos = regex_search("[0-9]+", "abc123")  # 3
+print(regex_match("hello", "[a-z]+"))   # true
+pos = regex_search("abc123", "[0-9]+")  # 3
 ```
 
 ## Supported Pattern Syntax
@@ -123,24 +123,24 @@ pos = regex_search("[0-9]+", "abc123")  # 3
 ### Range Quantifiers
 
 ```ry
-print(regex_match("\\d{3}-\\d{4}", "123-4567"))  # true
-print(regex_match("a{2,4}", "aaa"))               # true
-print(regex_match("(ab){2,}", "ababab"))           # true
+print(regex_match("123-4567", "\\d{3}-\\d{4}"))  # true
+print(regex_match("aaa", "a{2,4}"))               # true
+print(regex_match("ababab", "(ab){2,}"))           # true
 ```
 
 ### Non-Greedy (Lazy) Match
 
 ```ry
 # Greedy: matches longest
-g = regex_replace("\".*\"", "\"a\" and \"b\"", "X")
+g = regex_replace("\"a\" and \"b\"", "\".*\"", "X")
 print(g)  # X
 
 # Non-greedy: matches shortest
-l = regex_replace("\".*?\"", "\"a\" and \"b\"", "X")
+l = regex_replace("\"a\" and \"b\"", "\".*?\"", "X")
 print(l)  # X and X
 
 # Find individual HTML-like tags
-tags = regex_find_all("<.*?>", "<a> <bb> <ccc>")
+tags = regex_find_all("<a> <bb> <ccc>", "<.*?>")
 print(length(tags))  # 3
 ```
 
@@ -150,11 +150,11 @@ print(length(tags))  # 3
 
 ```ry
 # Match whole words only
-pos = regex_search("\\bworld\\b", "hello world")
+pos = regex_search("hello world", "\\bworld\\b")
 print(pos)  # 6
 
 # Find all words
-words = regex_find_all("\\b\\w+\\b", "hello world foo")
+words = regex_find_all("hello world foo", "\\b\\w+\\b")
 print(length(words))  # 3
 ```
 
@@ -162,8 +162,8 @@ print(length(words))  # 3
 
 ```ry
 # (?i) at the start of pattern enables case-insensitive matching
-print(regex_match("(?i)hello", "HELLO"))  # true
-print(regex_match("(?i)hello", "Hello"))  # true
+print(regex_match("HELLO", "(?i)hello"))  # true
+print(regex_match("Hello", "(?i)hello"))  # true
 ```
 
 > **Note:** `(?i)` must appear at the beginning of the pattern and applies to the entire pattern. Partial case-insensitive matching (e.g., `(?i:sub)pattern`) is not supported.

--- a/lib/std/regex.ry
+++ b/lib/std/regex.ry
@@ -1,18 +1,18 @@
 # Regular expression operations
 @native
-function regex_match(pattern: str, text: str) -> bool
+function regex_match(text: str, pattern: str) -> bool
 
 @native
-function regex_search(pattern: str, text: str) -> int
+function regex_search(text: str, pattern: str) -> int
 
 @native
-function regex_replace(pattern: str, text: str, replacement: str) -> str
+function regex_replace(text: str, pattern: str, replacement: str) -> str
 
 @native
-function regex_split(pattern: str, text: str) -> List<str>
+function regex_split(text: str, pattern: str) -> List<str>
 
 @native
-function regex_find_all(pattern: str, text: str) -> List<str>
+function regex_find_all(text: str, pattern: str) -> List<str>
 
 # Regex literal overloads (text-first for UFCS)
 @native

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -13,28 +13,31 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
             if (!isStringValue(args.back()))
                 codegenError(name + "() requires str arguments");
         }
+        // Legacy API accepts (text, pattern, ...) but runtime expects
+        // (pattern, text, ...) — swap the first two arguments.
+        if (nargs >= 2) std::swap(args[0], args[1]);
         auto fn = mod_->getOrInsertFunction("__ry_" + name, fnTy);
         return builder_.CreateCall(fn, args, name);
     };
 
-    // regex_match(pattern, text) -> bool
+    // regex_match(text, pattern) -> bool
     if (e.callee == "regex_match") {
         llvm::Value *r = emitRegexCall("regex_match", 2, fnTy_ptr_ptr_to_i64_);
         return builder_.CreateTrunc(r, i1Ty_, "regex_match_bool");
     }
-    // regex_search(pattern, text) -> int
+    // regex_search(text, pattern) -> int
     if (e.callee == "regex_search")
         return emitRegexCall("regex_search", 2, fnTy_ptr_ptr_to_i64_);
-    // regex_replace(pattern, text, replacement) -> str
+    // regex_replace(text, pattern, replacement) -> str
     if (e.callee == "regex_replace")
         return emitRegexCall("regex_replace", 3, fnTy_ptr_ptr_ptr_to_ptr_);
-    // regex_split(pattern, text) -> List<str>
+    // regex_split(text, pattern) -> List<str>
     if (e.callee == "regex_split") {
         llvm::Value *r = emitRegexCall("regex_split", 2, fnTy_ptr_ptr_to_ptr_);
         type_meta_[TM_ListElem][r] = ptrTy_;
         return r;
     }
-    // regex_find_all(pattern, text) -> List<str>
+    // regex_find_all(text, pattern) -> List<str>
     if (e.callee == "regex_find_all") {
         llvm::Value *r = emitRegexCall("regex_find_all", 2, fnTy_ptr_ptr_to_ptr_);
         type_meta_[TM_ListElem][r] = ptrTy_;
@@ -50,6 +53,7 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
         llvm::Value *pattern = emitExpr(*e.args[1]);
         if (!isRegex(pattern) || !isStringValue(text)) return nullptr;
         auto fn = mod_->getOrInsertFunction("__ry_" + rtName, fnTy);
+        // Runtime expects (pattern, text) — pass in that order.
         return builder_.CreateCall(fn, {pattern, text}, rtName);
     };
 

--- a/tests/spec/regex_literal.test.ry
+++ b/tests/spec/regex_literal.test.ry
@@ -97,21 +97,21 @@ describe("string split/replace still work", ():
 
 describe("backward compatibility", ():
   it("regex_match still works", ():
-    expect(regex_match("[a-z]+", "hello")).to_eq(true)
+    expect(regex_match("hello", "[a-z]+")).to_eq(true)
   )
   it("regex_search still works", ():
-    expect(regex_search("[0-9]+", "abc123")).to_eq(3)
+    expect(regex_search("abc123", "[0-9]+")).to_eq(3)
   )
   it("regex_replace still works", ():
-    expect(regex_replace("[0-9]+", "abc123", "X")).to_eq("abcX")
+    expect(regex_replace("abc123", "[0-9]+", "X")).to_eq("abcX")
   )
   it("regex_split still works", ():
-    parts = regex_split("[0-9]", "a1b2c")
+    parts = regex_split("a1b2c", "[0-9]")
     expect(parts[0]).to_eq("a")
     expect(parts[1]).to_eq("b")
   )
   it("regex_find_all still works", ():
-    nums = regex_find_all("[0-9]", "a1b2c3")
+    nums = regex_find_all("a1b2c3", "[0-9]")
     expect(length(nums)).to_eq(3)
   )
 )

--- a/tests/spec/regex_phase2.test.ry
+++ b/tests/spec/regex_phase2.test.ry
@@ -1,21 +1,21 @@
 describe("range quantifiers", ():
   it("{n} exact", ():
-    expect(regex_match("a{3}", "aaa")).to_eq(true)
-    expect(regex_match("a{3}", "aa")).to_eq(false)
+    expect(regex_match("aaa", "a{3}")).to_eq(true)
+    expect(regex_match("aa", "a{3}")).to_eq(false)
   )
   it("{n,m} range", ():
-    expect(regex_match("a{2,4}", "aaa")).to_eq(true)
-    expect(regex_match("a{2,4}", "a")).to_eq(false)
-    expect(regex_match("a{2,4}", "aaaaa")).to_eq(false)
+    expect(regex_match("aaa", "a{2,4}")).to_eq(true)
+    expect(regex_match("a", "a{2,4}")).to_eq(false)
+    expect(regex_match("aaaaa", "a{2,4}")).to_eq(false)
   )
   it("{n,} min only", ():
-    expect(regex_match("a{2,}", "aa")).to_eq(true)
-    expect(regex_match("a{2,}", "aaaa")).to_eq(true)
-    expect(regex_match("a{2,}", "a")).to_eq(false)
+    expect(regex_match("aa", "a{2,}")).to_eq(true)
+    expect(regex_match("aaaa", "a{2,}")).to_eq(true)
+    expect(regex_match("a", "a{2,}")).to_eq(false)
   )
   it("digit pattern", ():
-    expect(regex_match("\\d{3}-\\d{4}", "123-4567")).to_eq(true)
-    expect(regex_match("\\d{3}-\\d{4}", "12-4567")).to_eq(false)
+    expect(regex_match("123-4567", "\\d{3}-\\d{4}")).to_eq(true)
+    expect(regex_match("12-4567", "\\d{3}-\\d{4}")).to_eq(false)
   )
 )
 
@@ -24,40 +24,40 @@ describe("empty and edge patterns", ():
     expect(regex_match("", "")).to_eq(true)
   )
   it("dot matches any character", ():
-    expect(regex_match(".", "a")).to_eq(true)
-    expect(regex_match(".", " ")).to_eq(true)
+    expect(regex_match("a", ".")).to_eq(true)
+    expect(regex_match(" ", ".")).to_eq(true)
   )
   it("dot does not match empty", ():
-    expect(regex_match(".", "")).to_eq(false)
+    expect(regex_match("", ".")).to_eq(false)
   )
   it("match entire string only", ():
     expect(regex_match("abc", "abc")).to_eq(true)
-    expect(regex_match("abc", "xabcx")).to_eq(false)
+    expect(regex_match("xabcx", "abc")).to_eq(false)
   )
   it("search in empty string", ():
-    expect(regex_search("a", "")).to_eq(-1)
+    expect(regex_search("", "a")).to_eq(-1)
   )
   it("find_all no matches", ():
-    matches = regex_find_all("xyz", "hello world")
+    matches = regex_find_all("hello world", "xyz")
     expect(length(matches)).to_eq(0)
   )
   it("replace no matches", ():
-    expect(regex_replace("xyz", "hello", "X")).to_eq("hello")
+    expect(regex_replace("hello", "xyz", "X")).to_eq("hello")
   )
 )
 
 describe("non-greedy when", ():
   it("lazy star replace", ():
-    expect(regex_replace("\".*?\"", "\"a\" and \"b\"", "X")).to_eq("X and X")
+    expect(regex_replace("\"a\" and \"b\"", "\".*?\"", "X")).to_eq("X and X")
   )
   it("lazy plus replace", ():
-    expect(regex_replace("a+?", "aaa", "X")).to_eq("XXX")
+    expect(regex_replace("aaa", "a+?", "X")).to_eq("XXX")
   )
   it("lazy full when", ():
-    expect(regex_match("a+?", "aaa")).to_eq(true)
+    expect(regex_match("aaa", "a+?")).to_eq(true)
   )
   it("lazy find_all", ():
-    tags = regex_find_all("<.*?>", "<x> <yy> <zzz>")
+    tags = regex_find_all("<x> <yy> <zzz>", "<.*?>")
     expect(length(tags)).to_eq(3)
     expect(tags[0]).to_eq("<x>")
     expect(tags[1]).to_eq("<yy>")

--- a/tests/spec/regex_phase3.test.ry
+++ b/tests/spec/regex_phase3.test.ry
@@ -1,22 +1,22 @@
 describe("word boundary \\b / \\B", ():
   it("\\b matches word boundary", ():
-    expect(regex_search("\\bworld\\b", "hello world")).to_eq(6)
-    expect(regex_search("\\bword\\b", "helloworld")).to_eq(-1)
+    expect(regex_search("hello world", "\\bworld\\b")).to_eq(6)
+    expect(regex_search("helloworld", "\\bword\\b")).to_eq(-1)
   )
   it("\\B matches non-boundary", ():
-    expect(regex_search("\\Bworld", "helloworld")).to_eq(5)
-    expect(regex_search("\\Bworld", "world test")).to_eq(-1)
+    expect(regex_search("helloworld", "\\Bworld")).to_eq(5)
+    expect(regex_search("world test", "\\Bworld")).to_eq(-1)
   )
   it("\\b at start and end", ():
-    expect(regex_search("\\bhello", "hello world")).to_eq(0)
-    expect(regex_search("world\\b", "hello world")).to_eq(6)
+    expect(regex_search("hello world", "\\bhello")).to_eq(0)
+    expect(regex_search("hello world", "world\\b")).to_eq(6)
   )
   it("\\b with digits and underscores", ():
-    expect(regex_match("\\b\\w+\\b", "hello_123")).to_eq(true)
-    expect(regex_search("\\b123\\b", "abc 123 def")).to_eq(4)
+    expect(regex_match("hello_123", "\\b\\w+\\b")).to_eq(true)
+    expect(regex_search("abc 123 def", "\\b123\\b")).to_eq(4)
   )
   it("\\b find_all", ():
-    words = regex_find_all("\\b\\w+\\b", "hello world foo")
+    words = regex_find_all("hello world foo", "\\b\\w+\\b")
     expect(length(words)).to_eq(3)
     expect(words[0]).to_eq("hello")
     expect(words[1]).to_eq("world")
@@ -26,31 +26,31 @@ describe("word boundary \\b / \\B", ():
 
 describe("case-insensitive (?i)", ():
   it("basic when", ():
-    expect(regex_match("(?i)hello", "HELLO")).to_eq(true)
-    expect(regex_match("(?i)hello", "Hello")).to_eq(true)
-    expect(regex_match("(?i)hello", "hello")).to_eq(true)
+    expect(regex_match("HELLO", "(?i)hello")).to_eq(true)
+    expect(regex_match("Hello", "(?i)hello")).to_eq(true)
+    expect(regex_match("hello", "(?i)hello")).to_eq(true)
   )
   it("char class", ():
-    expect(regex_match("(?i)[a-z]+", "ABC")).to_eq(true)
-    expect(regex_match("(?i)[a-f]+", "ABCDEF")).to_eq(true)
+    expect(regex_match("ABC", "(?i)[a-z]+")).to_eq(true)
+    expect(regex_match("ABCDEF", "(?i)[a-f]+")).to_eq(true)
   )
   it("case-sensitive by default", ():
-    expect(regex_match("hello", "HELLO")).to_eq(false)
+    expect(regex_match("HELLO", "hello")).to_eq(false)
   )
   it("search", ():
-    expect(regex_search("(?i)world", "Hello WORLD")).to_eq(6)
+    expect(regex_search("Hello WORLD", "(?i)world")).to_eq(6)
   )
   it("replace", ():
-    expect(regex_replace("(?i)hello", "Hello HELLO hello", "X")).to_eq("X X X")
+    expect(regex_replace("Hello HELLO hello", "(?i)hello", "X")).to_eq("X X X")
   )
   it("find_all", ():
-    matches = regex_find_all("(?i)hello", "Hello HELLO hello")
+    matches = regex_find_all("Hello HELLO hello", "(?i)hello")
     expect(length(matches)).to_eq(3)
     expect(matches[0]).to_eq("Hello")
     expect(matches[1]).to_eq("HELLO")
     expect(matches[2]).to_eq("hello")
   )
   it("combined with \\b", ():
-    expect(regex_search("(?i)\\bworld\\b", "Hello WORLD")).to_eq(6)
+    expect(regex_search("Hello WORLD", "(?i)\\bworld\\b")).to_eq(6)
   )
 )

--- a/tests/test_codegen_regex.cpp
+++ b/tests/test_codegen_regex.cpp
@@ -6,21 +6,21 @@
 
 TEST_F(CodeGenTest, RegexMatchTrue) {
     EXPECT_EQ(runSource(R"(
-m = regex_match("[a-z]+", "hello")
+m = regex_match("hello", "[a-z]+")
 print(m)
 )"), "true\n");
 }
 
 TEST_F(CodeGenTest, RegexMatchFalse) {
     EXPECT_EQ(runSource(R"(
-m = regex_match("[0-9]+", "hello")
+m = regex_match("hello", "[0-9]+")
 print(m)
 )"), "false\n");
 }
 
 TEST_F(CodeGenTest, RegexMatchInIf) {
     EXPECT_EQ(runSource(R"(
-if regex_match("[a-z]+", "hello"):
+if regex_match("hello", "[a-z]+"):
     print("yes")
 else:
     print("no")
@@ -33,14 +33,14 @@ else:
 
 TEST_F(CodeGenTest, RegexSearchFound) {
     EXPECT_EQ(runSource(R"(
-pos = regex_search("[0-9]+", "abc123def")
+pos = regex_search("abc123def", "[0-9]+")
 print(pos)
 )"), "3\n");
 }
 
 TEST_F(CodeGenTest, RegexSearchNotFound) {
     EXPECT_EQ(runSource(R"(
-pos = regex_search("[0-9]+", "hello")
+pos = regex_search("hello", "[0-9]+")
 print(pos)
 )"), "-1\n");
 }
@@ -51,14 +51,14 @@ print(pos)
 
 TEST_F(CodeGenTest, RegexReplaceBasic) {
     EXPECT_EQ(runSource(R"(
-s = regex_replace("[0-9]+", "a1b2c3", "X")
+s = regex_replace("a1b2c3", "[0-9]+", "X")
 print(s)
 )"), "aXbXcX\n");
 }
 
 TEST_F(CodeGenTest, RegexReplaceNoMatch) {
     EXPECT_EQ(runSource(R"(
-s = regex_replace("[0-9]+", "hello", "X")
+s = regex_replace("hello", "[0-9]+", "X")
 print(s)
 )"), "hello\n");
 }
@@ -69,7 +69,7 @@ print(s)
 
 TEST_F(CodeGenTest, RegexSplitBasic) {
     EXPECT_EQ(runSource(R"(
-parts = regex_split(",", "a,b,c")
+parts = regex_split("a,b,c", ",")
 print(length(parts))
 print(parts[0])
 print(parts[1])
@@ -79,7 +79,7 @@ print(parts[2])
 
 TEST_F(CodeGenTest, RegexSplitPattern) {
     EXPECT_EQ(runSource(R"(
-parts = regex_split("\\s+", "hello  world")
+parts = regex_split("hello  world", "\\s+")
 print(length(parts))
 print(parts[0])
 print(parts[1])
@@ -92,7 +92,7 @@ print(parts[1])
 
 TEST_F(CodeGenTest, RegexFindAllBasic) {
     EXPECT_EQ(runSource(R"(
-matches = regex_find_all("[0-9]+", "a1b23c456")
+matches = regex_find_all("a1b23c456", "[0-9]+")
 print(length(matches))
 print(matches[0])
 print(matches[1])
@@ -102,32 +102,32 @@ print(matches[2])
 
 TEST_F(CodeGenTest, RegexFindAllNoMatch) {
     EXPECT_EQ(runSource(R"(
-matches = regex_find_all("[0-9]+", "hello")
+matches = regex_find_all("hello", "[0-9]+")
 print(length(matches))
 )"), "0\n");
 }
 
 // ============================================================
-// UFCS: pattern.regex_match(text)
+// UFCS: text.regex_match(pattern)
 // ============================================================
 
 TEST_F(CodeGenTest, RegexMatchUFCS) {
     EXPECT_EQ(runSource(R"(
-m = "[a-z]+".regex_match("hello")
+m = "hello".regex_match("[a-z]+")
 print(m)
 )"), "true\n");
 }
 
 TEST_F(CodeGenTest, RegexSearchUFCS) {
     EXPECT_EQ(runSource(R"(
-pos = "[0-9]+".regex_search("abc123")
+pos = "abc123".regex_search("[0-9]+")
 print(pos)
 )"), "3\n");
 }
 
 TEST_F(CodeGenTest, RegexReplaceUFCS) {
     EXPECT_EQ(runSource(R"(
-s = "[0-9]+".regex_replace("a1b2c3", "X")
+s = "a1b2c3".regex_replace("[0-9]+", "X")
 print(s)
 )"), "aXbXcX\n");
 }
@@ -138,9 +138,9 @@ print(s)
 
 TEST_F(CodeGenTest, RegexQuantifierExact) {
     EXPECT_EQ(runSource(R"(
-print(regex_match("\\d{3}", "123"))
-print(regex_match("\\d{3}", "12"))
-print(regex_match("\\d{3}", "1234"))
+print(regex_match("123", "\\d{3}"))
+print(regex_match("12", "\\d{3}"))
+print(regex_match("1234", "\\d{3}"))
 )"), "true\nfalse\nfalse\n");
 }
 
@@ -150,14 +150,14 @@ print(regex_match("\\d{3}", "1234"))
 
 TEST_F(CodeGenTest, RegexLazyReplace) {
     EXPECT_EQ(runSource(R"(
-s = regex_replace("\".*?\"", "\"a\" and \"b\"", "X")
+s = regex_replace("\"a\" and \"b\"", "\".*?\"", "X")
 print(s)
 )"), "X and X\n");
 }
 
 TEST_F(CodeGenTest, RegexLazyFindAll) {
     EXPECT_EQ(runSource(R"(
-tags = regex_find_all("<.*?>", "<x> <yy>")
+tags = regex_find_all("<x> <yy>", "<.*?>")
 print(length(tags))
 print(tags[0])
 print(tags[1])
@@ -255,8 +255,8 @@ print(is_match("a/b", /a\/b/))
 
 TEST_F(CodeGenTest, RegexLiteralWithPrefixedFunctions) {
     EXPECT_EQ(runSource(R"(
-print(regex_match("[a-z]+", "hello"))
-print(regex_search("[0-9]+", "abc123"))
+print(regex_match("hello", "[a-z]+"))
+print(regex_search("abc123", "[0-9]+"))
 )"), "true\n3\n");
 }
 


### PR DESCRIPTION
## Summary

- Legacy regex functions (`regex_match`, `regex_search`, `regex_replace`, `regex_split`, `regex_find_all`) now use text-first argument order `(text, pattern)`, consistent with the regex literal API
- Codegen swaps `args[0]` and `args[1]` before calling the runtime C API (which retains `(pattern, text)` order internally)
- Updated declarations, docs, CHANGELOG, and all tests

Closes #512

## Test plan

- [x] C++ tests pass (1290 tests)
- [x] Ry self tests pass (63 test files, 0 failures)
- [x] ASan build passes with no errors