### PR TITLE
refactor: consolidate duplicate type-meta parsing into propagateTypeMeta

### DIFF
--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -336,41 +336,16 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
                 paramTypes[idx], nullptr, s->params[idx].name);
             builder_.CreateStore(&arg, alloca);
             scope_stack_.back()[s->params[idx].name] = alloca;
-            // Track list element type for list parameters
             const std::string &ptype = paramTypeNames[idx];
-            if (ptype.size() > 5 && ptype.compare(0, 5, "List<") == 0 && ptype.back() == '>') {
-                std::string inner = ptype.substr(5, ptype.size() - 6);
-                type_meta_[TM_ListElem][alloca] = resolveType(inner);
-            }
-            // Track set element type for set parameters
-            if (ptype.size() > 4 && ptype.compare(0, 4, "Set<") == 0 && ptype.back() == '>') {
-                std::string inner = ptype.substr(4, ptype.size() - 5);
-                type_meta_[TM_SetElem][alloca] = resolveType(inner);
-            }
-            // Track enum type for enum parameters
-            if (enum_types_.count(ptype)) {
+            propagateTypeMeta(ptype, alloca);
+            if (enum_types_.count(ptype))
                 enum_value_types_[alloca] = ptype;
-            }
-            // Track map key/value types for map parameters
-            if (ptype.size() > 4 && ptype.compare(0, 4, "Map<") == 0 && ptype.back() == '>') {
-                auto [kTy, vTy] = parseMapTypeAnnotation(ptype);
-                if (kTy) type_meta_[TM_MapKey][alloca] = kTy;
-                if (vTy) type_meta_[TM_MapValue][alloca] = vTy;
-            }
-            if (ptype.size() > 5 && ptype.compare(0, 5, "Task<") == 0 && ptype.back() == '>') {
-                std::string inner = ptype.substr(5, ptype.size() - 6);
-                type_meta_[TM_TaskResult][alloca] = resolveType(inner);
-            }
             registerResourceByTypeName(ptype, alloca);
-            // Mark ARC-managed for collection parameters
             if ((ptype.size() > 5 && ptype.compare(0, 5, "List<") == 0) ||
                 (ptype.size() > 4 && ptype.compare(0, 4, "Map<") == 0) ||
                 (ptype.size() > 4 && ptype.compare(0, 4, "Set<") == 0)) {
                 markArcManaged(alloca);
             }
-            // Track low-level type metadata for parameters
-            if (isLowLevelTypeName(ptype))
-                low_level_type_names_[alloca] = ptype;
             // Track fn type info and constraint check (shared alias resolution)
             {
                 std::string resolvedPtype = resolveTypeAlias(ptype);
@@ -937,26 +912,10 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
             // Resolve the actual param type name (with substitution)
             std::string ptype = paramTypeNames[idx];
 
-            // Track collection element types
-            if (ptype.size() > 5 && ptype.compare(0, 5, "List<") == 0 && ptype.back() == '>') {
-                std::string inner = ptype.substr(5, ptype.size() - 6);
-                type_meta_[TM_ListElem][alloca] = resolveType(inner);
-            }
-            if (ptype.size() > 4 && ptype.compare(0, 4, "Set<") == 0 && ptype.back() == '>') {
-                std::string inner = ptype.substr(4, ptype.size() - 5);
-                type_meta_[TM_SetElem][alloca] = resolveType(inner);
-            }
+            propagateTypeMeta(ptype, alloca);
             if (enum_types_.count(ptype))
                 enum_value_types_[alloca] = ptype;
-            if (ptype.size() > 4 && ptype.compare(0, 4, "Map<") == 0 && ptype.back() == '>') {
-                auto [kTy, vTy] = parseMapTypeAnnotation(ptype);
-                if (kTy) type_meta_[TM_MapKey][alloca] = kTy;
-                if (vTy) type_meta_[TM_MapValue][alloca] = vTy;
-            }
             registerResourceByTypeName(ptype, alloca);
-            // Track low-level type metadata for parameters
-            if (isLowLevelTypeName(ptype))
-                low_level_type_names_[alloca] = ptype;
             {
                 std::string resolvedPtype = resolveTypeAlias(ptype);
                 if (resolvedPtype.size() > 9 && resolvedPtype.compare(0, 9, "function(") == 0)

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -296,21 +296,8 @@ void CodeGen::emitVarDecl(const std::string &name,
                     }
                 }
             }
-            if (inner.size() > 4 && inner.substr(0, 4) == "Map<") {
-                auto [k, v] = parseMapTypeAnnotation(inner);
-                if (k) type_meta_[TM_MapKey][ptr] = k;
-                if (v) type_meta_[TM_MapValue][ptr] = v;
-            } else if (inner.size() > 5 && inner.substr(0, 5) == "List<") {
-                std::string elemName = inner.substr(5, inner.size() - 6);
-                llvm::Type *elemTy = resolveType(elemName);
-                if (elemTy)
-                    type_meta_[TM_ListElem][ptr] = elemTy;
-            } else if (inner.size() > 4 && inner.substr(0, 4) == "Set<") {
-                std::string elemName = inner.substr(4, inner.size() - 5);
-                llvm::Type *elemTy = resolveType(elemName);
-                if (elemTy)
-                    type_meta_[TM_SetElem][ptr] = elemTy;
-            }
+            if (!inner.empty())
+                propagateTypeMeta(inner, ptr);
         }
     }
 
@@ -418,22 +405,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             std::string innerName = weakInnerTypeName(*annot);
             weak_inner_type_names_[ptr] = innerName;
             // Set collection metadata on weak alloca so it propagates through upgrade
-            auto ltPos = innerName.find('<');
-            if (ltPos != std::string::npos) {
-                std::string baseName = innerName.substr(0, ltPos);
-                std::string args = innerName.substr(ltPos + 1, innerName.size() - ltPos - 2);
-                if (baseName == "List")
-                    type_meta_[TM_ListElem][ptr] = resolveType(args);
-                else if (baseName == "Set")
-                    type_meta_[TM_SetElem][ptr] = resolveType(args);
-                else if (baseName == "Map") {
-                    auto commaPos = args.find(", ");
-                    if (commaPos != std::string::npos) {
-                        type_meta_[TM_MapKey][ptr] = resolveType(args.substr(0, commaPos));
-                        type_meta_[TM_MapValue][ptr] = resolveType(args.substr(commaPos + 2));
-                    }
-                }
-            }
+            propagateTypeMeta(innerName, ptr);
         }
         // --- ARC tracking ---
         else {


### PR DESCRIPTION
## Summary

- Replace manual type-name-to-metadata parsing at 4 call sites with `propagateTypeMeta()` calls, eliminating ~50 lines of duplicated string parsing logic
- Sites consolidated: `emitStmt(FnStmt)` params, `instantiateGenericFn()` params, weak reference inner types, Option/Result inner types
- Generic function params now also get Task<T> and NestedList metadata (previously missing)
- Weak reference Map parsing now uses `parseMapTypeAnnotation` (handles nested angle brackets correctly)

Closes #519

## Test plan

- [x] All C++ tests pass (1290 tests)
- [x] All Ry self-tests pass (65 test files)
- [x] ASan build + tests pass (no memory errors)