### PR TITLE
fix: check all collection metadata keys in Option/Result type-meta guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Option/Result type-meta guard now checks all collection metadata keys (`TM_ListElem`, `TM_SetElem`, `TM_TaskResult`), not just `TM_MapKey`, preventing potential metadata overwrites when wrapping collection types (#525)
 - Generic function parameters with collection types (`List<T>`, `Map<K, V>`, `Set<T>`) are now properly marked as ARC-managed during instantiation, preventing potential memory leaks (#524)
 - Return type inference now correctly resolves user-defined struct types in functions and lambdas without explicit type annotations (#515)
 - Return-path analysis now recognizes exhaustive `match` statements on custom enums and `bool`, removing false "does not return a value on all code paths" errors when all variants are covered (#513)

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -277,8 +277,12 @@ void CodeGen::emitVarDecl(const std::string &name,
     // (e.g., Option<Map<str, str>>, Result<List<int>, Error>)
     if (isOptionType(newTy) || isResultType(newTy)) {
         propagateCollectionMetadata(val, ptr);
-        // Extract inner collection type from Option<Map<K,V>> or Result<Map<K,V>, E>
-        if (annot && type_meta_[TM_MapKey].find(ptr) == type_meta_[TM_MapKey].end()) {
+        // Extract inner collection type from Option/Result wrapping a collection
+        if (annot &&
+            !type_meta_[TM_MapKey].count(ptr) &&
+            !type_meta_[TM_ListElem].count(ptr) &&
+            !type_meta_[TM_SetElem].count(ptr) &&
+            !type_meta_[TM_TaskResult].count(ptr)) {
             std::string ann = *annot;
             std::string inner;
             if (ann.size() > 7 && ann.substr(0, 7) == "Option<" && ann.back() == '>')

--- a/tests/spec/builtins.test.ry
+++ b/tests/spec/builtins.test.ry
@@ -51,4 +51,31 @@ describe("Some / Option", ():
     x: Option<int> = None
     expect(x).to_be_none()
   )
+  it("Option<List<int>> preserves collection metadata", ():
+    x: Option<List<int>> = Some([1, 2, 3])
+    match x:
+      case Some(v):
+        expect(v).to_have_length(3)
+        expect(v[0]).to_eq(1)
+      case None:
+        fail("expected Some")
+  )
+  it("Option<Map<str, int>> preserves collection metadata", ():
+    x: Option<Map<str, int>> = Some({"a": 1, "b": 2})
+    match x:
+      case Some(v):
+        expect(v).to_have_length(2)
+        expect(get(v, "a")).to_eq(Some(1))
+      case None:
+        fail("expected Some")
+  )
+  it("Option<Set<int>> preserves collection metadata", ():
+    x: Option<Set<int>> = Some({1, 2, 3})
+    match x:
+      case Some(v):
+        expect(v).to_have_length(3)
+        expect(v).to_contain(2)
+      case None:
+        fail("expected Some")
+  )
 )


### PR DESCRIPTION
## Summary

- Option/Result の type-meta ガードが `TM_MapKey` のみチェックしていたのを、`TM_ListElem`、`TM_SetElem`、`TM_TaskResult` も含めた4条件に拡張
- `propagateCollectionMetadata()` が先に設定したメタデータを `propagateTypeMeta()` が上書きするのを防止
- `.find() == .end()` を `.count()` に統一（コードベース内の他の type_meta_ チェックとの一貫性）

Closes #525

## Test plan

- [x] `Option<List<int>>`, `Option<Map<str, int>>`, `Option<Set<int>>` のコレクションメタデータ保持テストを追加
- [x] 全 C++ テスト (`ry_tests`) パス: 1294 tests
- [x] 全 Ry セルフテスト (`ry test -p`) パス: 66 files, 0 failures
- [x] ASan ビルドでメモリ安全性エラーなし