### PR TITLE
refactor: extract isCollectionTypeName helper for List/Map/Set prefix checks

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -98,6 +98,12 @@ private:
     void emitArcReleaseVar(const std::string &name, llvm::AllocaInst *alloca);
     bool tryRetainArcSource(llvm::Value *val);
 
+    // Collection type name helpers
+    static bool isListTypeName(const std::string &typeName);
+    static bool isMapTypeName(const std::string &typeName);
+    static bool isSetTypeName(const std::string &typeName);
+    static bool isCollectionTypeName(const std::string &typeName);
+
     // Weak reference operations
     static bool isWeakTypeName(const std::string &typeName);
     static std::string weakInnerTypeName(const std::string &typeName);

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -335,6 +335,24 @@ void CodeGen::emitArcReleaseVar(const std::string &name, llvm::AllocaInst *alloc
     builder_.SetInsertPoint(skipBB);
 }
 
+// ===== Collection type name helpers =====
+
+bool CodeGen::isListTypeName(const std::string &typeName) {
+    return typeName.size() > 5 && typeName.compare(0, 5, "List<") == 0;
+}
+
+bool CodeGen::isMapTypeName(const std::string &typeName) {
+    return typeName.size() > 4 && typeName.compare(0, 4, "Map<") == 0;
+}
+
+bool CodeGen::isSetTypeName(const std::string &typeName) {
+    return typeName.size() > 4 && typeName.compare(0, 4, "Set<") == 0;
+}
+
+bool CodeGen::isCollectionTypeName(const std::string &typeName) {
+    return isListTypeName(typeName) || isMapTypeName(typeName) || isSetTypeName(typeName);
+}
+
 // ===== Weak reference operations =====
 
 bool CodeGen::isWeakTypeName(const std::string &typeName) {
@@ -1097,7 +1115,7 @@ bool CodeGen::isPotentiallyCyclic(const std::string &typeName) const {
     if (typeName.size() > 1 && typeName.back() == '?')
         return isPotentiallyCyclic(typeName.substr(0, typeName.size() - 1));
     // Map<K,V> — check both K and V
-    if (typeName.size() > 5 && typeName.compare(0, 4, "Map<") == 0 && typeName.back() == '>') {
+    if (isMapTypeName(typeName) && typeName.back() == '>') {
         std::string inner = typeName.substr(4, typeName.size() - 5);
         // Find the comma separating K and V (handle nested generics)
         int depth = 0;

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -118,18 +118,18 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
     if (typeName.size() > 5 && typeName.compare(0, 5, "Task<") == 0 && typeName.back() == '>') {
         std::string inner = typeName.substr(5, typeName.size() - 6);
         type_meta_[TM_TaskResult][val] = resolveType(inner);
-    } else if (typeName.size() > 5 && typeName.compare(0, 5, "List<") == 0 && typeName.back() == '>') {
+    } else if (isListTypeName(typeName) && typeName.back() == '>') {
         std::string inner = typeName.substr(5, typeName.size() - 6);
         type_meta_[TM_ListElem][val] = resolveType(inner);
-        if (inner.size() > 5 && inner.compare(0, 5, "List<") == 0 && inner.back() == '>') {
+        if (isListTypeName(inner) && inner.back() == '>') {
             std::string nested = inner.substr(5, inner.size() - 6);
             type_meta_[TM_NestedListElem][val] = resolveType(nested);
         }
-    } else if (typeName.size() > 4 && typeName.compare(0, 4, "Map<") == 0 && typeName.back() == '>') {
+    } else if (isMapTypeName(typeName) && typeName.back() == '>') {
         auto [keyTy, valTy] = parseMapTypeAnnotation(typeName);
         if (keyTy) type_meta_[TM_MapKey][val] = keyTy;
         if (valTy) type_meta_[TM_MapValue][val] = valTy;
-    } else if (typeName.size() > 4 && typeName.compare(0, 4, "Set<") == 0 && typeName.back() == '>') {
+    } else if (isSetTypeName(typeName) && typeName.back() == '>') {
         std::string inner = typeName.substr(4, typeName.size() - 5);
         type_meta_[TM_SetElem][val] = resolveType(inner);
     } else if (isLowLevelTypeName(typeName)) {

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -341,9 +341,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             if (enum_types_.count(ptype))
                 enum_value_types_[alloca] = ptype;
             registerResourceByTypeName(ptype, alloca);
-            if ((ptype.size() > 5 && ptype.compare(0, 5, "List<") == 0) ||
-                (ptype.size() > 4 && ptype.compare(0, 4, "Map<") == 0) ||
-                (ptype.size() > 4 && ptype.compare(0, 4, "Set<") == 0)) {
+            if (isCollectionTypeName(ptype)) {
                 markArcManaged(alloca);
             }
             // Track fn type info and constraint check (shared alias resolution)
@@ -917,9 +915,7 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
                 enum_value_types_[alloca] = ptype;
             registerResourceByTypeName(ptype, alloca);
             // Mark ARC-managed for collection parameters
-            if ((ptype.size() > 5 && ptype.compare(0, 5, "List<") == 0) ||
-                (ptype.size() > 4 && ptype.compare(0, 4, "Map<") == 0) ||
-                (ptype.size() > 4 && ptype.compare(0, 4, "Set<") == 0)) {
+            if (isCollectionTypeName(ptype)) {
                 markArcManaged(alloca);
             }
             {

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -26,7 +26,7 @@ void CodeGen::emitVarDecl(const std::string &name,
     if (auto *se = std::get_if<std::unique_ptr<SetExpr>>(&value.data); se && (*se)->elements.empty()) {
         if (!annot)
             codegenError("empty {} literal requires type annotation");
-        if (annot->size() > 4 && annot->substr(0, 4) == "Set<") {
+        if (isSetTypeName(*annot)) {
             std::string inner = annot->substr(4, annot->size() - 5);
             llvm::Type *elemTy = resolveType(inner);
 
@@ -59,7 +59,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                 immutable_scope_stack_.back().insert(name);
             return;
         }
-        if (annot->size() > 4 && annot->substr(0, 4) == "Map<") {
+        if (isMapTypeName(*annot)) {
             auto [keyTy, valTy] = parseMapTypeAnnotation(*annot);
             if (!keyTy || !valTy)
                 codegenError("invalid map type annotation: " + *annot);
@@ -309,8 +309,7 @@ void CodeGen::emitVarDecl(const std::string &name,
     if (newTy == ptrTy_) {
         // --- List tracking ---
         llvm::Type *elemTy = getListElementType(val);
-        if (!elemTy && annot && annot->size() > 5 &&
-            annot->substr(0, 5) == "List<") {
+        if (!elemTy && annot && isListTypeName(*annot)) {
             std::string inner = annot->substr(5, annot->size() - 6);
             elemTy = resolveType(inner);
         }
@@ -347,8 +346,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             }
         }
         // From type annotation: Map<K, V>
-        if (!keyTy && annot && annot->size() > 4 &&
-            annot->substr(0, 4) == "Map<") {
+        if (!keyTy && annot && isMapTypeName(*annot)) {
             std::tie(keyTy, valTy) = parseMapTypeAnnotation(*annot);
         }
         if (keyTy) type_meta_[TM_MapKey][ptr] = keyTy;
@@ -361,8 +359,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                 setElemTy = getSetElementType(load->getPointerOperand());
             }
         }
-        if (!setElemTy && annot && annot->size() > 4 &&
-            annot->substr(0, 4) == "Set<") {
+        if (!setElemTy && annot && isSetTypeName(*annot)) {
             std::string inner = annot->substr(4, annot->size() - 5);
             setElemTy = resolveType(inner);
         }

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -148,18 +148,8 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
         return ptrTy_;
     }
 
-    // List<T> parsing
-    if (typeName.size() > 5 && typeName.compare(0, 5, "List<") == 0 && typeName.back() == '>') {
-        return ptrTy_;
-    }
-
-    // Map<K, V> parsing
-    if (typeName.size() > 4 && typeName.compare(0, 4, "Map<") == 0 && typeName.back() == '>') {
-        return ptrTy_;
-    }
-
-    // Set<T> parsing
-    if (typeName.size() > 4 && typeName.compare(0, 4, "Set<") == 0 && typeName.back() == '>') {
+    // Collection type parsing (List<T>, Map<K, V>, Set<T>)
+    if (isCollectionTypeName(typeName) && typeName.back() == '>') {
         return ptrTy_;
     }
 


### PR DESCRIPTION
## Summary

- Extract `isListTypeName`, `isMapTypeName`, `isSetTypeName`, and `isCollectionTypeName` static helpers into `CodeGen` class to eliminate duplicated collection type name prefix checks across the codebase
- Replace 15 inline occurrences across 5 files (`codegen_fn.cpp`, `codegen_type.cpp`, `codegen_builtin.cpp`, `codegen_stmt.cpp`, `codegen_arc.cpp`)
- Consolidate both `compare()` and `substr()` style checks into a single consistent pattern

Closes #523

## Test plan

- [x] `./build/ry_tests` — 1294 tests passed
- [x] `./build/ry test -p` — 66 test files, 0 failures
- [x] ASan build: `./build-asan/ry_tests` — 1293 tests passed
- [x] ASan build: `./build-asan/ry test -p` — 66 test files, 0 failures