### PR TITLE
refactor: extract applyParamTypeMeta helper for shared parameter type-metadata setup (#530)

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -825,6 +825,8 @@ private:
     void propagateAllMetadata(llvm::Value *src, llvm::Value *dst);
     void propagateAllMetadataWide(llvm::Value *src, llvm::Value *dst);
     void registerResourceByTypeName(const std::string &typeName, llvm::Value *val);
+    void applyParamTypeMeta(const std::string &ptype, llvm::AllocaInst *alloca,
+                            llvm::Type *paramLLVMType, const std::string &paramName);
     // Shared Result-wrapping helpers for stdlib dispatchers
     llvm::Value *emitResultBranch(llvm::Value *isErr, llvm::StructType *resTy,
                                    std::function<llvm::Value*()> buildOk,

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -29,6 +29,33 @@ void CodeGen::registerResourceByTypeName(const std::string &typeName, llvm::Valu
         if (typeName == name) { resource_sets_[rk].insert(val); return; }
 }
 
+void CodeGen::applyParamTypeMeta(const std::string &ptype,
+                                  llvm::AllocaInst *alloca,
+                                  llvm::Type *paramLLVMType,
+                                  const std::string &paramName) {
+    propagateTypeMeta(ptype, alloca);
+    if (enum_types_.count(ptype))
+        enum_value_types_[alloca] = ptype;
+    registerResourceByTypeName(ptype, alloca);
+    if (isCollectionTypeName(ptype))
+        markArcManaged(alloca);
+    {
+        std::string resolvedPtype = resolveTypeAlias(ptype);
+        if (resolvedPtype.size() > 9 && resolvedPtype.compare(0, 9, "function(") == 0)
+            fn_type_info_[alloca] = parseFnTypeAnnotation(resolvedPtype);
+        auto constraint = parseTypeConstraint(resolvedPtype);
+        if (constraint) {
+            type_constraints_[alloca] = *constraint;
+            llvm::Value *argVal = builder_.CreateLoad(
+                paramLLVMType, alloca, paramName + ".load");
+            emitConstraintCheck(argVal, *constraint, paramName);
+        } else {
+            if (isUnionType(ptype))
+                union_value_types_[alloca] = normalizeUnionType(ptype);
+        }
+    }
+}
+
 void CodeGen::emitStmt(AwaitStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
@@ -337,31 +364,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             builder_.CreateStore(&arg, alloca);
             scope_stack_.back()[s->params[idx].name] = alloca;
             const std::string &ptype = paramTypeNames[idx];
-            propagateTypeMeta(ptype, alloca);
-            if (enum_types_.count(ptype))
-                enum_value_types_[alloca] = ptype;
-            registerResourceByTypeName(ptype, alloca);
-            if (isCollectionTypeName(ptype)) {
-                markArcManaged(alloca);
-            }
-            // Track fn type info and constraint check (shared alias resolution)
-            {
-                std::string resolvedPtype = resolveTypeAlias(ptype);
-                if (resolvedPtype.size() > 9 && resolvedPtype.compare(0, 9, "function(") == 0) {
-                    fn_type_info_[alloca] = parseFnTypeAnnotation(resolvedPtype);
-                }
-                auto constraint = parseTypeConstraint(resolvedPtype);
-                if (constraint) {
-                    type_constraints_[alloca] = *constraint;
-                    llvm::Value *argVal = builder_.CreateLoad(
-                        paramTypes[idx], alloca, s->params[idx].name + ".load");
-                    emitConstraintCheck(argVal, *constraint, s->params[idx].name);
-                } else {
-                    // Track union type only for non-literal unions
-                    if (isUnionType(ptype))
-                        union_value_types_[alloca] = normalizeUnionType(ptype);
-                }
-            }
+            applyParamTypeMeta(ptype, alloca, paramTypes[idx], s->params[idx].name);
             ++idx;
         }
 
@@ -907,24 +910,8 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
             builder_.CreateStore(&arg, alloca);
             scope_stack_.back()[s.params[idx].name] = alloca;
 
-            // Resolve the actual param type name (with substitution)
             std::string ptype = paramTypeNames[idx];
-
-            propagateTypeMeta(ptype, alloca);
-            if (enum_types_.count(ptype))
-                enum_value_types_[alloca] = ptype;
-            registerResourceByTypeName(ptype, alloca);
-            // Mark ARC-managed for collection parameters
-            if (isCollectionTypeName(ptype)) {
-                markArcManaged(alloca);
-            }
-            {
-                std::string resolvedPtype = resolveTypeAlias(ptype);
-                if (resolvedPtype.size() > 9 && resolvedPtype.compare(0, 9, "function(") == 0)
-                    fn_type_info_[alloca] = parseFnTypeAnnotation(resolvedPtype);
-                if (isUnionType(ptype))
-                    union_value_types_[alloca] = normalizeUnionType(ptype);
-            }
+            applyParamTypeMeta(ptype, alloca, paramTypes[idx], s.params[idx].name);
             ++idx;
         }
 

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -197,13 +197,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
                     paramTypes[idx], nullptr, e->params[idx].name);
                 builder_.CreateStore(&arg, alloca);
                 scope_stack_.back()[e->params[idx].name] = alloca;
-                // Track fn type info for fn-typed parameters
                 const std::string ptype = e->params[idx].type->toString();
-                std::string resolvedPtype = resolveTypeAlias(ptype);
-                if (resolvedPtype.size() > 9 && resolvedPtype.substr(0, 9) == "function(") {
-                    fn_type_info_[alloca] = parseFnTypeAnnotation(resolvedPtype);
-                }
-                registerResourceByTypeName(ptype, alloca);
+                applyParamTypeMeta(ptype, alloca, paramTypes[idx], e->params[idx].name);
             } else {
                 // Captured variable
                 size_t capIdx = idx - e->params.size();


### PR DESCRIPTION
## Summary

- Extract a shared `applyParamTypeMeta()` helper that consolidates duplicated parameter type-metadata registration logic from `emitStmt(FnStmt)`, `instantiateGenericFn()`, and lambda parameter setup
- Fix missing type constraint checks (`parseTypeConstraint` / `emitConstraintCheck`) in `instantiateGenericFn()`
- Add `propagateTypeMeta`, enum tracking, ARC marking, constraint checks, and union tracking to lambda parameters

## Test plan

- [x] C++ tests (1294 passed)
- [x] Ry self tests (66 files, 0 failures)
- [x] ASan verification (no errors)

Closes #530