### PR TITLE
docs: fix checked arithmetic return types and record print documentation

### DIFF
--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -43,9 +43,9 @@
 
 | Function | Description |
 |------|------|
-| `checked_add(a, b)` | Returns `Some(a + b)` if no overflow, otherwise `None` |
-| `checked_sub(a, b)` | Returns `Some(a - b)` if no overflow, otherwise `None` |
-| `checked_mul(a, b)` | Returns `Some(a * b)` if no overflow, otherwise `None` |
+| `checked_add(a, b)` | Returns `Ok(a + b)` if no overflow, otherwise `Err(Error("arithmetic overflow"))` |
+| `checked_sub(a, b)` | Returns `Ok(a - b)` if no overflow, otherwise `Err(Error("arithmetic overflow"))` |
+| `checked_mul(a, b)` | Returns `Ok(a * b)` if no overflow, otherwise `Err(Error("arithmetic overflow"))` |
 | `saturating_add(a, b)` | Returns `a + b`, clamped to `int` range on overflow |
 | `saturating_sub(a, b)` | Returns `a - b`, clamped to `int` range on overflow |
 | `saturating_mul(a, b)` | Returns `a * b`, clamped to `int` range on overflow |
@@ -156,6 +156,7 @@ Prints one or more values to standard output, separated by spaces. A newline is 
 | `map` | `{key1: val1, key2: val2, ...}` |
 | `set` | `{elem1, elem2, ...}` |
 | `enum` | Variant name (e.g., `Red`) |
+| `record` | `RecordName(field: val, ...)` |
 
 ```python
 print(42)          # 42
@@ -175,7 +176,7 @@ print(1, "hello", true)   # 1 hello true
 print()                    # (empty line)
 ```
 
-**Error condition:** Passing a struct or tuple directly causes a compile error.
+**Error condition:** Passing a tuple directly causes a compile error.
 
 ---
 

--- a/docs/tutorial/06-records.md
+++ b/docs/tutorial/06-records.md
@@ -40,7 +40,12 @@ print(p.x)   # 10
 print(p.y)   # 20
 ```
 
-> **Note**: Passing a record directly to `print` causes an error. Pass individual fields instead.
+Records can be printed directly:
+
+```python
+p = Point(10, 20)
+print(p)   # Point(x: 10, y: 20)
+```
 
 ---
 


### PR DESCRIPTION
## Summary

- Fix `checked_add/sub/mul` descriptions in `builtins.md` to correctly show `Result<T, Error>` return type instead of `Option<T>` (`Some/None`)
- Add `record` type to `print()` output format table in `builtins.md`
- Remove incorrect "struct" from `print()` error condition — records can now be printed directly
- Replace incorrect tutorial note in `06-records.md` about records not being printable with a working code example

## Test plan

- [ ] Verify `checked_add` overflow returns `Err(Error(...))`, not `None`
- [ ] Verify `print(RecordInstance)` outputs `RecordName(field: val, ...)`
- [ ] Verify `print(tuple)` still causes a compile error