### PR TITLE
fix: free iterator malloc'd headers and states at scope exit

### DIFF
--- a/changelog.d/577-iterator-memory-leak.md
+++ b/changelog.d/577-iterator-memory-leak.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Heap corruption after Iterator tests caused by leaked iterator headers and states; iterator memory is now freed at scope exit (#577)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -146,6 +146,7 @@ private:
     static constexpr int64_t TAG_UNIT  = 4; // reserved for future use
     std::vector<std::unordered_map<std::string, llvm::AllocaInst*>> scope_stack_;
     std::vector<std::unordered_set<std::string>> immutable_scope_stack_;
+    std::vector<std::vector<llvm::Value*>> iterator_malloc_stack_; // per-scope iterator malloc tracking
     struct OverloadEntry {
         llvm::Function *func;
         std::vector<llvm::Type*> paramTypes;
@@ -409,6 +410,7 @@ private:
         std::unordered_map<llvm::AllocaInst*, std::string> savedWeakInnerTypeNames_;
         std::unordered_map<llvm::AllocaInst*, ResourceKind> savedResourceManaged_;
         std::unordered_set<llvm::AllocaInst*> savedClosureManaged_;
+        std::vector<std::vector<llvm::Value*>> savedIteratorMallocs_;
         llvm::BasicBlock *savedBlock_;
         llvm::BasicBlock::iterator savedPoint_;
         std::vector<ExprPtr> *savedPostconditions_;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -111,6 +111,7 @@ CodeGen::FnScope::FnScope(CodeGen &cg) : cg_(cg) {
     savedWeakInnerTypeNames_ = std::move(cg_.weak_inner_type_names_);
     savedResourceManaged_ = std::move(cg_.resource_managed_vars_);
     savedClosureManaged_ = std::move(cg_.closure_managed_vars_);
+    savedIteratorMallocs_ = std::move(cg_.iterator_malloc_stack_);
     savedBlock_ = cg_.builder_.GetInsertBlock();
     savedPoint_ = cg_.builder_.GetInsertPoint();
     savedPostconditions_ = cg_.current_postconditions_;
@@ -126,6 +127,7 @@ CodeGen::FnScope::FnScope(CodeGen &cg) : cg_(cg) {
     cg_.weak_inner_type_names_.clear();
     cg_.resource_managed_vars_.clear();
     cg_.closure_managed_vars_.clear();
+    cg_.iterator_malloc_stack_.clear();
     cg_.current_postconditions_ = nullptr;
     cg_.ensure_bindings_ = nullptr;
     cg_.in_ensure_context_ = false;
@@ -143,6 +145,7 @@ CodeGen::FnScope::~FnScope() {
     cg_.weak_inner_type_names_ = std::move(savedWeakInnerTypeNames_);
     cg_.resource_managed_vars_ = std::move(savedResourceManaged_);
     cg_.closure_managed_vars_ = std::move(savedClosureManaged_);
+    cg_.iterator_malloc_stack_ = std::move(savedIteratorMallocs_);
     cg_.builder_.SetInsertPoint(savedBlock_, savedPoint_);
     cg_.current_postconditions_ = savedPostconditions_;
     cg_.ensure_bindings_ = savedEnsureBindings_;
@@ -272,12 +275,14 @@ void CodeGen::emitTraceWhenBranch(int armIndex, const SourceLocation &loc) {
 void CodeGen::pushScope() {
     scope_stack_.emplace_back();
     immutable_scope_stack_.emplace_back();
+    iterator_malloc_stack_.emplace_back();
 }
 
 void CodeGen::popScope() {
     emitScopeCleanup();
     scope_stack_.pop_back();
     immutable_scope_stack_.pop_back();
+    iterator_malloc_stack_.pop_back();
 }
 
 void CodeGen::emitScopeCleanup() {
@@ -298,6 +303,13 @@ void CodeGen::emitScopeCleanupToDepth(size_t targetDepth) {
             if (!arc_managed_vars_.count(alloca)) continue;
             emitArcReleaseVar(name, alloca);
             arc_managed_vars_.erase(alloca);
+        }
+        auto &iterMallocs = iterator_malloc_stack_[i - 1];
+        if (!iterMallocs.empty()) {
+            auto freeFn = getStdlibFree();
+            for (auto *ptr : iterMallocs) {
+                builder_.CreateCall(freeFn, {ptr});
+            }
         }
     }
 }

--- a/src/codegen_call_iterator.cpp
+++ b/src/codegen_call_iterator.cpp
@@ -10,6 +10,7 @@ static llvm::Value *emitIteratorHeaderAlloc(
     llvm::FunctionCallee mallocFn,
     llvm::Function *nextFn, llvm::Value *stateAlloc, llvm::Type *elemTy,
     std::unordered_map<llvm::Value*, llvm::Type*> &elemTypes,
+    std::vector<llvm::Value*> &iterMallocs,
     const std::string &name) {
     uint64_t headerSize = mod.getDataLayout().getTypeAllocSize(iterHeaderTy);
     llvm::Value *header = builder.CreateCall(
@@ -17,6 +18,7 @@ static llvm::Value *emitIteratorHeaderAlloc(
     builder.CreateStore(nextFn, builder.CreateStructGEP(iterHeaderTy, header, 0));
     builder.CreateStore(stateAlloc, builder.CreateStructGEP(iterHeaderTy, header, 1));
     elemTypes[header] = elemTy;
+    iterMallocs.push_back(header);
     return header;
 }
 
@@ -89,6 +91,7 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
             // Allocate and fill state
             llvm::Value *stateAlloc = builder_.CreateCall(
                 mallocFn, {llvm::ConstantInt::get(i64Ty_, stateSize)}, "iter_state");
+            iterator_malloc_stack_.back().push_back(stateAlloc);
             llvm::Value *srcData = builder_.CreateLoad(ptrTy_,
                 builder_.CreateStructGEP(collHeaderTy, collVal, dataPtrIdx), "src_data");
             llvm::Value *srcLen = builder_.CreateLoad(i64Ty_,
@@ -99,7 +102,8 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
                 builder_.CreateStructGEP(stateTy, stateAlloc, 2));
 
             return emitIteratorHeaderAlloc(builder_, *mod_, iteratorHeaderTy_,
-                i64Ty_, mallocFn, nextFn, stateAlloc, elemTy, type_meta_[TM_IteratorElem], "iter_header");
+                i64Ty_, mallocFn, nextFn, stateAlloc, elemTy, type_meta_[TM_IteratorElem],
+                iterator_malloc_stack_.back(), "iter_header");
         };
 
         // Try List (data at index 2, len at index 0)
@@ -164,6 +168,7 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
 
             llvm::Value *stateAlloc = builder_.CreateCall(
                 mallocFn, {llvm::ConstantInt::get(i64Ty_, stateSize)}, "iter_state");
+            iterator_malloc_stack_.back().push_back(stateAlloc);
             builder_.CreateStore(
                 builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, collVal, 2)),
                 builder_.CreateStructGEP(stateTy, stateAlloc, 0));
@@ -177,7 +182,8 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
                 builder_.CreateStructGEP(stateTy, stateAlloc, 3));
 
             return emitIteratorHeaderAlloc(builder_, *mod_, iteratorHeaderTy_,
-                i64Ty_, mallocFn, nextFn, stateAlloc, tupleTy, type_meta_[TM_IteratorElem], "iter_header");
+                i64Ty_, mallocFn, nextFn, stateAlloc, tupleTy, type_meta_[TM_IteratorElem],
+                iterator_malloc_stack_.back(), "iter_header");
         }
 
         codegenError("iter() argument must be a List, Set, or Map");
@@ -358,12 +364,14 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
         uint64_t stateSize = dl.getTypeAllocSize(stateTy);
         llvm::Value *stateAlloc = builder_.CreateCall(
             mallocFn, {llvm::ConstantInt::get(i64Ty_, stateSize)}, "filter_state");
+        iterator_malloc_stack_.back().push_back(stateAlloc);
         builder_.CreateStore(srcNf, builder_.CreateStructGEP(stateTy, stateAlloc, 0));
         builder_.CreateStore(srcSt, builder_.CreateStructGEP(stateTy, stateAlloc, 1));
         builder_.CreateStore(lambdaVal, builder_.CreateStructGEP(stateTy, stateAlloc, 2));
 
         return emitIteratorHeaderAlloc(builder_, *mod_, iteratorHeaderTy_,
-            i64Ty_, mallocFn, filterNextFn, stateAlloc, elemTy, type_meta_[TM_IteratorElem], "filter_iter");
+            i64Ty_, mallocFn, filterNextFn, stateAlloc, elemTy, type_meta_[TM_IteratorElem],
+            iterator_malloc_stack_.back(), "filter_iter");
     }
 
     // map(iter, transform) → new Iterator with transformed element type
@@ -432,12 +440,14 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
         uint64_t stateSize = dl.getTypeAllocSize(stateTy);
         llvm::Value *stateAlloc = builder_.CreateCall(
             mallocFn, {llvm::ConstantInt::get(i64Ty_, stateSize)}, "map_state");
+        iterator_malloc_stack_.back().push_back(stateAlloc);
         builder_.CreateStore(srcNf, builder_.CreateStructGEP(stateTy, stateAlloc, 0));
         builder_.CreateStore(srcSt, builder_.CreateStructGEP(stateTy, stateAlloc, 1));
         builder_.CreateStore(lambdaVal, builder_.CreateStructGEP(stateTy, stateAlloc, 2));
 
         return emitIteratorHeaderAlloc(builder_, *mod_, iteratorHeaderTy_,
-            i64Ty_, mallocFn, mapNextFn, stateAlloc, outElemTy, type_meta_[TM_IteratorElem], "map_iter");
+            i64Ty_, mallocFn, mapNextFn, stateAlloc, outElemTy, type_meta_[TM_IteratorElem],
+            iterator_malloc_stack_.back(), "map_iter");
     }
 
     // take(iter, n) → new Iterator that yields at most n elements
@@ -496,12 +506,14 @@ llvm::Value *CodeGen::emitBuiltinIterator(const CallExpr &e) {
         uint64_t stateSize = dl.getTypeAllocSize(stateTy);
         llvm::Value *stateAlloc = builder_.CreateCall(
             mallocFn, {llvm::ConstantInt::get(i64Ty_, stateSize)}, "take_state");
+        iterator_malloc_stack_.back().push_back(stateAlloc);
         builder_.CreateStore(srcNf, builder_.CreateStructGEP(stateTy, stateAlloc, 0));
         builder_.CreateStore(srcSt, builder_.CreateStructGEP(stateTy, stateAlloc, 1));
         builder_.CreateStore(n, builder_.CreateStructGEP(stateTy, stateAlloc, 2));
 
         return emitIteratorHeaderAlloc(builder_, *mod_, iteratorHeaderTy_,
-            i64Ty_, mallocFn, takeNextFn, stateAlloc, elemTy, type_meta_[TM_IteratorElem], "take_iter");
+            i64Ty_, mallocFn, takeNextFn, stateAlloc, elemTy, type_meta_[TM_IteratorElem],
+            iterator_malloc_stack_.back(), "take_iter");
     }
 
     return nullptr;


### PR DESCRIPTION
## Summary

- Iterator chains (`iter`, `filter`, `map`, `take`) allocated headers and states via `malloc` but never freed them, causing heap corruption (`corrupted size vs. prev_size`) in CI after Iterator tests
- Add per-scope tracking of iterator-related mallocs via `iterator_malloc_stack_`, integrated into `pushScope`/`popScope` and `FnScope` save/restore
- All tracked pointers are freed in `emitScopeCleanupToDepth`, covering normal scope exit, `break`, and `continue` paths

Closes #577

## Test plan

- [x] `./build/ry_tests` — 1299 tests passed
- [x] `./build/ry test -p` — 69 test files, 0 failures
- [x] ASan build (`cmake --preset asan`) — 1298 tests passed, 69 test files 0 failures
- [ ] CI passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed heap corruption bug affecting iterator operations. Iterator memory allocations are now properly tracked and automatically freed when scopes exit, preventing memory leaks and corruption during iterator evaluation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->