### PR TITLE
fix: auto-detect nightly channel in self-update

### DIFF
--- a/src/self_update.cpp
+++ b/src/self_update.cpp
@@ -743,7 +743,7 @@ int cmd_self_update(int argc, char *argv[]) {
             std::cerr << "Usage: ry self-update [--nightly | <version>]\n";
             std::cerr << "\n";
             std::cerr << "Options:\n";
-            std::cerr << "  (no args)    Update to latest stable release\n";
+            std::cerr << "  (no args)    Update to latest release (nightly if current version is prerelease)\n";
             std::cerr << "  --nightly    Update to latest nightly/prerelease\n";
             std::cerr << "  <version>    Update to a specific version (e.g. v0.0.1)\n";
             std::cerr << "\nEnvironment:\n";


### PR DESCRIPTION
## Summary

- Prerelease版（例: v0.0.6-nightly）で `ry self-update` を引数なしで実行すると、安定版（v0.0.5）へダウングレードしようとする問題を修正
- 現在のバージョンが prerelease の場合、デフォルトのアップデートチャネルを `nightly` に自動切り替え

## Test plan

- [x] `ry_tests` 全テスト通過
- [x] `ry test -p` 全テスト通過
- [x] ASan ビルドでのテスト通過
- [ ] v0.0.6-nightly インストール状態で `ry self-update` を実行し、ダウングレードが発生しないことを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Self-update command now chooses its default update stream based on your current app version: prerelease installs default to nightly updates, while stable installs default to stable updates. Help text for the no-argument case has been updated to reflect this prerelease-aware default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->