### PR TITLE
perf: eliminate dead IR in dispatch chain for take(list, n)

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -772,7 +772,7 @@ private:
 
     // Builtin dispatch helpers (Step 4)
     llvm::Value *emitBuiltinCore(const CallExpr &e);
-    llvm::Value *emitBuiltinCollection(const CallExpr &e);
+    llvm::Value *emitBuiltinCollection(const CallExpr &e, llvm::Value *preEmittedArg0 = nullptr);
 
     // Collection operation handlers
     llvm::Value *emitCollOp_add(const CallExpr &e);
@@ -785,6 +785,7 @@ private:
     llvm::Value *emitCollOp_pop(const CallExpr &e);
     llvm::Value *emitCollOp_slice(const CallExpr &e);
     llvm::Value *emitCollOp_take(const CallExpr &e);
+    llvm::Value *emitCollOp_take_impl(const CallExpr &e, llvm::Value *listPtr);
     llvm::Value *emitCollOp_insert(const CallExpr &e);
     llvm::Value *emitCollOp_remove_at(const CallExpr &e);
     llvm::Value *emitCollOp_distinct(const CallExpr &e);

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -4,7 +4,11 @@
 
 // ===== Builtin Collection =====
 
-llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e) {
+llvm::Value *CodeGen::emitBuiltinCollection(const CallExpr &e,
+                                              llvm::Value *preEmittedArg0) {
+    if (preEmittedArg0 && e.callee == "take")
+        return emitCollOp_take_impl(e, preEmittedArg0);
+
     using Handler = llvm::Value *(CodeGen::*)(const CallExpr &);
     static const std::unordered_map<std::string, Handler> dispatch = {
         {"add",       &CodeGen::emitCollOp_add},
@@ -526,8 +530,11 @@ llvm::Value *CodeGen::emitCollOp_slice(const CallExpr &e) {
 
 llvm::Value *CodeGen::emitCollOp_take(const CallExpr &e) {
     if (e.args.size() != 2) return nullptr;
-    // take(list, n) -> new list with first n elements
-    llvm::Value *listPtr = emitExpr(*e.args[0]);
+    return emitCollOp_take_impl(e, emitExpr(*e.args[0]));
+}
+
+llvm::Value *CodeGen::emitCollOp_take_impl(const CallExpr &e,
+                                            llvm::Value *listPtr) {
     llvm::Type *elemTy = getListElementType(listPtr);
     if (elemTy) {
         llvm::Value *nVal = emitExpr(*e.args[1]);

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -94,6 +94,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
         if (auto *v = emitBuiltinResult(*e, arg0))      return v;
         if (auto *v = emitBuiltinIterator(*e, arg0))    return v;
         if (auto *v = emitBuiltinHigherOrder(*e, arg0)) return v;
+    } else if (e->args.size() == 2 && e->callee == "take") {
+        llvm::Value *arg0 = emitExpr(*e->args[0]);
+        if (auto *v = emitBuiltinIterator(*e, arg0))    return v;
+        if (auto *v = emitBuiltinCollection(*e, arg0))  return v;
     } else {
         // Dispatch to language-builtin helpers (Pattern B: no @native registry)
         if (auto *v = emitBuiltinResult(*e))      return v;


### PR DESCRIPTION
## Summary

- Pre-emit `args[0]` once in the fast path for `take()` to prevent `emitBuiltinIterator` from emitting dead IR when `take(list, n)` is called
- Split `emitCollOp_take` into a dispatch-table-compatible wrapper and `emitCollOp_take_impl` to bypass the `Handler` type constraint
- Only route through `emitBuiltinIterator` and `emitBuiltinCollection` (skip `emitBuiltinResult` and `emitBuiltinHigherOrder` which always return `nullptr` for `take`)
- Use exact arity check (`args.size() == 2`) to prevent 3+ arg calls from being incorrectly intercepted

Closes #607

## Test plan

- [x] `./build/ry_tests` — 1314 tests passed
- [x] `./build/ry test -p` — 75 test files, 0 failures
- [x] ASan build — no memory errors detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized code generation dispatch and handling for collection operations, improving compilation efficiency through streamlined builtin dispatch logic and separation of implementation concerns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->