### PR TITLE
fix: eliminate TOCTOU race conditions in filesystem runtime

### DIFF
--- a/src/runtime_filesystem.cpp
+++ b/src/runtime_filesystem.cpp
@@ -190,8 +190,13 @@ int64_t __ry_filesystem_copy(const char *src, const char *dst) {
         return 1;
     }
     struct stat dst_st;
-    if (fstat(dst_fd, &dst_st) == 0 &&
-        src_st.st_dev == dst_st.st_dev && src_st.st_ino == dst_st.st_ino) {
+    if (fstat(dst_fd, &dst_st) != 0) {
+        setLastError("copy: cannot stat destination '%s': %s", dst, strerror(errno));
+        close(src_fd);
+        close(dst_fd);
+        return 1;
+    }
+    if (src_st.st_dev == dst_st.st_dev && src_st.st_ino == dst_st.st_ino) {
         setLastError("copy: source and destination are the same file '%s'", src);
         close(src_fd);
         close(dst_fd);


### PR DESCRIPTION
## Summary

- **copy**: Replace `stat()` + `fopen()` + `chmod()` with fd-based `open()` + `fstat()` + `fchmod()` to prevent race between check and use
- **remove_all**: Replace `lstat()` + conditional `remove()` with `unlink()` first, falling back to `nftw()` on `EISDIR`/`EPERM`

Fixes 3 CodeQL `cpp/toctou-race-condition` high-severity alerts that are blocking #619.

## Test plan

- [x] `./build/ry_tests` — 1315 tests passed
- [x] `./build/ry test -p` — 76 test files, 0 failures
- [x] ASan build — 1314 tests passed, 76 Ry test files passed, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked file copying to a more robust, descriptor-based streaming flow that better handles interrupted I/O, partial writes, and deferred write errors while preserving permissions when possible.
  * Optimized file removal to try a quick unlink first and only recurse into directories when necessary, reducing work and improving error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->