### PR TITLE
fix: wrap FnTypeInfo::capturedClosureInfos in unique_ptr for GCC 11

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -275,7 +275,36 @@ private:
         std::vector<llvm::Type*> capturedTypes;  // types of captured variables
         std::vector<CapturedArcKind> capturedArcKinds; // ARC kind per captured variable
         std::vector<ResourceKind> capturedResourceKinds; // per-capture ResourceKind (RK_COUNT if N/A)
-        std::unordered_map<size_t, FnTypeInfo> capturedClosureInfos; // sparse: index → FnTypeInfo for function-typed captures
+        // unique_ptr to break incomplete-type cycle (GCC 11 requires complete type for unordered_map value)
+        std::unique_ptr<std::unordered_map<size_t, FnTypeInfo>> capturedClosureInfos;
+
+        FnTypeInfo() = default;
+        ~FnTypeInfo() = default;
+        FnTypeInfo(FnTypeInfo&&) = default;
+        FnTypeInfo& operator=(FnTypeInfo&&) = default;
+        FnTypeInfo(const FnTypeInfo &o)
+            : paramTypes(o.paramTypes), paramTypeNames(o.paramTypeNames),
+              returnType(o.returnType), capturedVars(o.capturedVars),
+              capturedTypes(o.capturedTypes), capturedArcKinds(o.capturedArcKinds),
+              capturedResourceKinds(o.capturedResourceKinds),
+              capturedClosureInfos(o.capturedClosureInfos
+                  ? std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(*o.capturedClosureInfos)
+                  : nullptr) {}
+        FnTypeInfo& operator=(const FnTypeInfo &o) {
+            if (this != &o) {
+                paramTypes = o.paramTypes;
+                paramTypeNames = o.paramTypeNames;
+                returnType = o.returnType;
+                capturedVars = o.capturedVars;
+                capturedTypes = o.capturedTypes;
+                capturedArcKinds = o.capturedArcKinds;
+                capturedResourceKinds = o.capturedResourceKinds;
+                capturedClosureInfos = o.capturedClosureInfos
+                    ? std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(*o.capturedClosureInfos)
+                    : nullptr;
+            }
+            return *this;
+        }
     };
     std::unordered_map<llvm::Value*, FnTypeInfo> fn_type_info_;
     std::unordered_map<llvm::Value*, FnTypeInfo>::iterator

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -882,9 +882,10 @@ llvm::FunctionCallee CodeGen::getOrCreateClosureDestructor(const FnTypeInfo &inf
 
     // Cache key: capturedArcKinds + capturedTypes + capturedResourceKinds + nested closure shapes
     std::vector<NestedClosureShape> nestedShapes;
-    for (auto &[idx, ci] : info.capturedClosureInfos)
-        nestedShapes.push_back({idx, ci.capturedArcKinds, ci.capturedTypes,
-                                ci.capturedResourceKinds});
+    if (info.capturedClosureInfos)
+        for (auto &[idx, ci] : *info.capturedClosureInfos)
+            nestedShapes.push_back({idx, ci.capturedArcKinds, ci.capturedTypes,
+                                    ci.capturedResourceKinds});
     std::sort(nestedShapes.begin(), nestedShapes.end());
     ClosureDtorKey cacheKey{info.capturedArcKinds, info.capturedTypes,
                             info.capturedResourceKinds, std::move(nestedShapes)};
@@ -954,10 +955,12 @@ llvm::FunctionCallee CodeGen::getOrCreateClosureDestructor(const FnTypeInfo &inf
             break;
         }
         case CAK_Closure: {
-            auto cit = info.capturedClosureInfos.find(i);
-            if (cit != info.capturedClosureInfos.end() &&
-                !cit->second.capturedArcKinds.empty())
-                subDtor = getOrCreateClosureDestructor(cit->second);
+            if (info.capturedClosureInfos) {
+                auto cit = info.capturedClosureInfos->find(i);
+                if (cit != info.capturedClosureInfos->end() &&
+                    !cit->second.capturedArcKinds.empty())
+                    subDtor = getOrCreateClosureDestructor(cit->second);
+            }
             break;
         }
         case CAK_Generic:

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -14,7 +14,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     std::vector<llvm::Type*> capturedTypes;
     std::vector<CapturedArcKind> capturedArcKinds;
     std::vector<ResourceKind> capturedResourceKinds;
-    std::unordered_map<size_t, FnTypeInfo> capturedClosureInfos;
+    std::unordered_map<size_t, FnTypeInfo> capturedClosureInfosLocal;
 
     // Build a set of parameter names
     std::unordered_set<std::string> paramNames;
@@ -52,7 +52,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
         // Store fn_type_info for any function-typed capture (closure or plain fn pointer)
         auto fnIt = fn_type_info_.find(alloca);
         if (fnIt != fn_type_info_.end())
-            capturedClosureInfos[capturedNames.size() - 1] = fnIt->second;
+            capturedClosureInfosLocal[capturedNames.size() - 1] = fnIt->second;
     };
 
     scanExpr = [&](const ExprNode &node) {
@@ -210,8 +210,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
                 builder_.CreateStore(&arg, alloca);
                 scope_stack_.back()[capturedNames[capIdx]] = alloca;
                 // Propagate fn_type_info for captured function-type variables
-                auto closureIt = capturedClosureInfos.find(capIdx);
-                if (closureIt != capturedClosureInfos.end())
+                auto closureIt = capturedClosureInfosLocal.find(capIdx);
+                if (closureIt != capturedClosureInfosLocal.end())
                     fn_type_info_[alloca] = closureIt->second;
             }
             ++idx;
@@ -262,7 +262,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     info.capturedTypes = capturedTypes;
     info.capturedArcKinds = capturedArcKinds;
     info.capturedResourceKinds = capturedResourceKinds;
-    info.capturedClosureInfos = capturedClosureInfos;
+    if (!capturedClosureInfosLocal.empty())
+        info.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(std::move(capturedClosureInfosLocal));
     fn_type_info_[func] = info;
 
     // If no captures, just return the function pointer


### PR DESCRIPTION
## Summary

- v0.0.6 リリースの Linux ビルド（GCC 11）で `FnTypeInfo` の自己参照による incomplete type エラーが発生していた
- `capturedClosureInfos` を `std::unique_ptr<std::unordered_map<size_t, FnTypeInfo>>` でラップし、GCC 11 互換性を確保
- カスタムコピー/ムーブセマンティクスで deep copy を維持

## Test plan

- [x] ローカルビルド成功
- [x] C++ テスト全通過 (1315 tests)
- [x] Ry セルフテスト全通過 (76 files, 0 failures)
- [x] ASan ビルド・テスト全通過
- [ ] CI (Linux amd64/arm64) でのビルド成功を確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal memory management for closure handling in code generation, improving efficiency and maintainability of capture metadata processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->