### PR TITLE
refactor: build NativeFnSignature registry for @native functions

### DIFF
--- a/changelog.d/646-native-fn-signature-registry.md
+++ b/changelog.d/646-native-fn-signature-registry.md
@@ -1,0 +1,4 @@
+### Added
+
+- `NativeFnSignature` registry that captures full type information (parameter names/types, return type, package) from `@native` function declarations (#646)
+- Documented the `__ry_<pkg>_<name>` native function naming convention (#646)

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -268,3 +268,34 @@ mylib/
 # main.ry
 from mylib import add, concat
 ```
+
+---
+
+## Native Function Naming Convention
+
+Stdlib package functions that are implemented as C runtime functions follow the `__ry_<package>_<function_name>` convention.
+
+> **Note**: This convention applies to stdlib package functions (e.g., `base64`, `filesystem`, `path`). Built-in functions (e.g., `print`, `length`) and math functions use varied implementations (inline LLVM IR, libc calls) and do not follow this naming pattern.
+
+### Format
+
+```
+__ry_<package>_<function_name>
+```
+
+### Rules
+
+1. **Prefix**: `__ry_`
+2. **Package**: The package name from `import <pkg>`
+3. **Function name**: The snake_case function name as declared in Ry
+4. **Overloads**: When a function has multiple overloads with different arities, append the argument count as a suffix (e.g., `__ry_path_join2`, `__ry_path_join3`)
+5. **Error getter**: Each package that returns `Result` types provides `__ry_<pkg>_get_last_error`
+
+### Examples
+
+| Ry declaration | C runtime function name |
+|---------------|------------------------|
+| `base64::encode(data: str) -> str` | `__ry_base64_encode` |
+| `filesystem::list_dir(path: str) -> Result<List<str>, Error>` | `__ry_filesystem_list_dir` |
+| `path::join(a: str, b: str) -> str` | `__ry_path_join2` |
+| `path::join(a: str, b: str, c: str) -> str` | `__ry_path_join3` |

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -279,14 +279,14 @@ Stdlib package functions that are implemented as C runtime functions follow the 
 
 ### Format
 
-```
+```text
 __ry_<package>_<function_name>
 ```
 
 ### Rules
 
 1. **Prefix**: `__ry_`
-2. **Package**: The package name from `import <pkg>`
+2. **Package**: The package name (e.g., `base64` from `from base64 import encode`)
 3. **Function name**: The snake_case function name as declared in Ry
 4. **Overloads**: When a function has multiple overloads with different arities, append the argument count as a suffix (e.g., `__ry_path_join2`, `__ry_path_join3`)
 5. **Error getter**: Each package that returns `Result` types provides `__ry_<pkg>_get_last_error`

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -18,6 +18,7 @@
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 class CodeGen {
 public:

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -27,6 +27,40 @@ public:
     llvm::orc::ThreadSafeModule compile(Program &prog);
     const std::vector<std::string>& getWarnings() const { return warnings_; }
 
+    // --- @native function signature types ---
+
+    struct NativeFnParam {
+        std::string name;
+        std::string type_name;   // Ry type name ("str", "int", "List<int>", etc.)
+    };
+
+    struct NativeFnSignature {
+        std::string name;              // function name ("encode", "sin", etc.)
+        std::string package;           // package name ("base64", "math", etc.; empty for builtins)
+        std::vector<NativeFnParam> params;
+        std::string return_type_name;  // Ry return type name
+        std::vector<std::string> directive_names; // e.g. {"native", "deprecated"}
+    };
+
+    // Access the @native function signature registry.
+    // Keyed by "package::name" for package functions, bare name for builtins.
+    const std::unordered_map<std::string, std::vector<NativeFnSignature>>&
+    getNativeFnSigs() const { return native_fn_sigs_; }
+
+    // Derive the base runtime function name for a stdlib package function.
+    // e.g. ("base64", "encode") → "__ry_base64_encode"
+    // For overloaded functions, callers must append an arity suffix
+    // (e.g. "__ry_path_join2", "__ry_path_join3") as needed.
+    // Only meaningful for package functions; builtins use varied naming.
+    static std::string deriveRuntimeFnName(const std::string &package,
+                                           const std::string &fn_name);
+
+    // Build the registry key for native_fn_sigs_.
+    static std::string nativeSigKey(const std::string &package,
+                                    const std::string &name) {
+        return package.empty() ? name : package + "::" + name;
+    }
+
 private:
     std::unique_ptr<llvm::LLVMContext> ctx_;
     std::unique_ptr<llvm::Module> mod_;
@@ -151,6 +185,7 @@ private:
     std::vector<std::unordered_set<std::string>> immutable_scope_stack_;
     llvm::SmallPtrSet<llvm::AllocaInst*, 8> captured_vars_; // reject reassignment of captured vars inside closure body
     std::vector<std::vector<llvm::Value*>> iterator_malloc_stack_; // per-scope iterator malloc tracking
+
     struct OverloadEntry {
         llvm::Function *func;
         std::vector<llvm::Type*> paramTypes;
@@ -393,6 +428,13 @@ private:
 
     // @native fn signature registry (argument count per overload)
     std::unordered_map<std::string, std::vector<size_t>> native_fn_arg_counts_;
+
+    // @native fn rich signature registry (coexists with native_fn_arg_counts_)
+    std::unordered_map<std::string, std::vector<NativeFnSignature>> native_fn_sigs_;
+
+    // Derive package name from the source file path of a native function declaration.
+    // e.g. "share/std/base64/base64.ry" → "base64", "share/std/builtins.ry" → ""
+    std::string deriveNativePackage(const SourceLocation &loc) const;
 
     // Literal/range type constraints
     struct TypeConstraint {

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -1,8 +1,39 @@
 #include "ry/codegen.hpp"
 #include "ry/diagnostic.hpp"
 #include "ry/sema_return.hpp"
+#include <filesystem>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
+
+// --- JNI-like naming convention helpers ---
+
+std::string CodeGen::deriveRuntimeFnName(const std::string &package,
+                                         const std::string &fn_name) {
+    if (package.empty())
+        return "__ry_" + fn_name;
+    return "__ry_" + package + "_" + fn_name;
+}
+
+std::string CodeGen::deriveNativePackage(const SourceLocation &loc) const {
+    if (!sm_ || loc.file_id < 0 || loc.file_id >= sm_->getFileCount())
+        return "";
+    const std::string &fname = sm_->getFilename(loc.file_id);
+
+    namespace fs = std::filesystem;
+    fs::path p(fname);
+    fs::path stem = p.stem();
+    fs::path parent = p.parent_path();
+
+    // /std/<pkg>/<pkg>.ry (directory package)
+    if (parent.filename() == stem && parent.parent_path().filename() == "std")
+        return stem.string();
+
+    // /std/<pkg>.ry (single-file package, excluding builtins.ry)
+    if (parent.filename() == "std" && stem != "builtins")
+        return stem.string();
+
+    return "";
+}
 
 EnumVariantRegistry CodeGen::buildEnumVariantRegistry() const {
     EnumVariantRegistry reg;
@@ -368,6 +399,18 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
         // Register argument count for native function overload
         native_fn_arg_counts_[s->name].push_back(s->params.size());
+
+        // Build rich signature
+        NativeFnSignature sig;
+        sig.name = s->name;
+        sig.package = deriveNativePackage(s->loc);
+        sig.params.reserve(s->params.size());
+        for (auto &p : s->params)
+            sig.params.push_back({p.name, p.type ? p.type->toString() : ""});
+        sig.return_type_name = s->return_type ? s->return_type->toString() : "Unit";
+        for (auto &d : s->directives)
+            sig.directive_names.push_back(d.name);
+        native_fn_sigs_[nativeSigKey(sig.package, sig.name)].push_back(std::move(sig));
         return;
     }
 

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -2,6 +2,114 @@
 
 class DirectiveTest : public CodeGenTest {};
 
+// --- deriveRuntimeFnName tests ---
+
+TEST(NativeFnNaming, PackageFunction) {
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("base64", "encode"), "__ry_base64_encode");
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("base64", "decode"), "__ry_base64_decode");
+}
+
+TEST(NativeFnNaming, MathFunctions) {
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("math", "sin"), "__ry_math_sin");
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("math", "cos"), "__ry_math_cos");
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("math", "floor"), "__ry_math_floor");
+}
+
+TEST(NativeFnNaming, EmptyPackage) {
+    // Empty package still produces a name, but callers should not use it
+    // for builtins since they use varied naming (libc, inline IR, etc.)
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("", "print"), "__ry_print");
+}
+
+TEST(NativeFnNaming, MultiWordFunctionName) {
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("filesystem", "list_dir"), "__ry_filesystem_list_dir");
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("path", "get_extension"), "__ry_path_get_extension");
+}
+
+TEST(NativeFnNaming, ErrorGetter) {
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("base64", "get_last_error"), "__ry_base64_get_last_error");
+    EXPECT_EQ(CodeGen::deriveRuntimeFnName("io", "get_last_error"), "__ry_io_get_last_error");
+}
+
+// --- NativeFnSignature registry tests ---
+
+TEST(NativeFnSigs, RegistryPopulatedAndKeyed) {
+    // Compile source with @native declarations and verify the registry
+    std::string src =
+        "@native\n"
+        "function print(value: str) -> Unit\n"
+        "@native\n"
+        "function contains(s: str, sub: str) -> bool\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    auto &sigs = cg.getNativeFnSigs();
+
+    // Builtins (no package) are keyed by bare name
+    ASSERT_TRUE(sigs.count("print"));
+    ASSERT_EQ(sigs.at("print").size(), 1u);
+    EXPECT_EQ(sigs.at("print")[0].name, "print");
+    EXPECT_EQ(sigs.at("print")[0].package, "");
+    EXPECT_EQ(sigs.at("print")[0].return_type_name, "Unit");
+    ASSERT_EQ(sigs.at("print")[0].params.size(), 1u);
+    EXPECT_EQ(sigs.at("print")[0].params[0].name, "value");
+    EXPECT_EQ(sigs.at("print")[0].params[0].type_name, "str");
+
+    ASSERT_TRUE(sigs.count("contains"));
+    ASSERT_EQ(sigs.at("contains").size(), 1u);
+    EXPECT_EQ(sigs.at("contains")[0].name, "contains");
+    EXPECT_EQ(sigs.at("contains")[0].return_type_name, "bool");
+    ASSERT_EQ(sigs.at("contains")[0].params.size(), 2u);
+}
+
+TEST(NativeFnSigs, OverloadsGrouped) {
+    std::string src =
+        "@native\n"
+        "function range(n: int) -> List<int>\n"
+        "@native\n"
+        "function range(start: int, end_val: int) -> List<int>\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    auto &sigs = cg.getNativeFnSigs();
+    ASSERT_TRUE(sigs.count("range"));
+    ASSERT_EQ(sigs.at("range").size(), 2u);
+    EXPECT_EQ(sigs.at("range")[0].params.size(), 1u);
+    EXPECT_EQ(sigs.at("range")[1].params.size(), 2u);
+}
+
+TEST(NativeFnSigs, DirectivesRecorded) {
+    std::string src =
+        "@native\n"
+        "@deprecated\n"
+        "function old_fn(x: int) -> int\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    auto &sigs = cg.getNativeFnSigs();
+    ASSERT_TRUE(sigs.count("old_fn"));
+    auto &directives = sigs.at("old_fn")[0].directive_names;
+    EXPECT_NE(std::find(directives.begin(), directives.end(), "native"),
+              directives.end());
+    EXPECT_NE(std::find(directives.begin(), directives.end(), "deprecated"),
+              directives.end());
+}
+
 // 1. @deprecated function called -> warning, execution normal
 TEST_F(DirectiveTest, DeprecatedFunctionWarning) {
     auto [output, warnings] = runSourceWithWarnings(


### PR DESCRIPTION
## Summary

- Add `NativeFnSignature` registry (`native_fn_sigs_`) that captures full type information from `@native` function declarations (parameter names/types, return type, package name, directives)
- Add `deriveNativePackage()` to extract package names from source file paths (supports both directory packages like `share/std/base64/base64.ry` and single-file packages like `share/std/str.ry`)
- Add `deriveRuntimeFnName()` to derive `__ry_<pkg>_<name>` convention names
- Add `nativeSigKey()` for package-qualified registry keys preventing cross-package name collisions
- Document the `__ry_<pkg>_<name>` naming convention in `docs/reference/packages.md`
- Registry coexists with existing `native_fn_arg_counts_` — no behavioral change

## Test plan

- [x] 5 `NativeFnNaming` tests verify `deriveRuntimeFnName` output
- [x] 3 `NativeFnSigs` tests verify registry population, overload grouping, and directive recording via `getNativeFnSigs()` accessor
- [x] All 1334 C++ tests pass
- [x] All 77 Ry self-test files pass
- [x] ASan build passes with no errors

Closes #646

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Native Function Naming Convention section documenting runtime symbol format, example mappings, and exclusions.

* **New Features**
  * Introduced a native function signature registry that records full signature info (package, parameter names/types, return types, directives) and groups overloads.

* **Tests**
  * Added unit tests validating naming rules and registry population for native functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->