### PR TITLE
feat: support @native("libname") directive syntax

### DIFF
--- a/changelog.d/647-native-libname-directive.md
+++ b/changelog.d/647-native-libname-directive.md
@@ -1,0 +1,3 @@
+### Added
+
+- `@native("libname")` directive syntax for specifying shared library module names (#647)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -102,7 +102,14 @@ a, b = (1, 2)
 
 ### `@native`
 
-Declares a function whose implementation is provided by the runtime (built-in). The function must not have a body.
+Declares a function whose implementation is provided by the runtime. The function must not have a body.
+
+An optional string argument specifies the shared library module name for future dynamic loading support. The library name is stored in the signature registry as metadata; it does not affect call resolution in the current version:
+
+```
+@native              # built-in (statically linked)
+@native("base64")    # metadata-only: library name stored for future dynamic loading
+```
 
 **Basic syntax:**
 
@@ -167,8 +174,8 @@ These files are automatically loaded as a prelude when the `core/` directory is 
 - Providing a body causes a parse error: `@native function must not have a body`.
 - The declared function must correspond to an existing built-in; otherwise the call will fail at compile time.
 
-**Future extensions:**
-- `@native("libfoo.so")` — FFI binding to external shared libraries.
+**Library specification (metadata-only — loading not yet implemented):**
+- `@native("libname")` specifies that the native function lives in `libry_<libname>.dylib/.so`. The library name is parsed and stored in the signature registry as metadata for future dynamic loading support. In the current version, `@native("libname")` declarations do not affect call resolution — they are not registered for argument-count validation, and same-named built-in functions continue to resolve normally.
 
 ### `@parallel`
 

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -106,7 +106,7 @@ Declares a function whose implementation is provided by the runtime. The functio
 
 An optional string argument specifies the shared library module name for future dynamic loading support. The library name is stored in the signature registry as metadata; it does not affect call resolution in the current version:
 
-```
+```ry
 @native              # built-in (statically linked)
 @native("base64")    # metadata-only: library name stored for future dynamic loading
 ```

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -89,7 +89,7 @@ inline std::string getDirectivePositionalArg(const std::vector<Directive> &direc
     for (const auto &d : directives) {
         if (d.name == name) {
             for (const auto &p : d.params)
-                if (p.key.empty()) return p.value;
+                if (p.key.empty() && p.is_string) return p.value;
             return "";
         }
     }

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -60,6 +60,7 @@ struct TypeNode {
 struct DirectiveParam {
     std::string key;
     std::string value;
+    bool is_string = false;  // true when value was a string literal token
 };
 
 struct Directive {
@@ -79,6 +80,20 @@ inline bool hasDirective(const std::vector<Directive> &directives, std::string_v
     for (const auto &d : directives)
         if (d.name == name) return true;
     return false;
+}
+
+// Get the first positional (key-empty) string argument of a named directive.
+// Returns empty string if not found.
+inline std::string getDirectivePositionalArg(const std::vector<Directive> &directives,
+                                              std::string_view name) {
+    for (const auto &d : directives) {
+        if (d.name == name) {
+            for (const auto &p : d.params)
+                if (p.key.empty()) return p.value;
+            return "";
+        }
+    }
+    return "";
 }
 
 // Returns true for operator names whose return type must be bool.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -38,6 +38,7 @@ public:
     struct NativeFnSignature {
         std::string name;              // function name ("encode", "sin", etc.)
         std::string package;           // package name ("base64", "math", etc.; empty for builtins)
+        std::string library;           // @native("libname") argument; empty = built-in (static link)
         std::vector<NativeFnParam> params;
         std::string return_type_name;  // Ry return type name
         std::vector<std::string> directive_names; // e.g. {"native", "deprecated"}

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -397,14 +397,18 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             }
         }
 
-        // Register argument count for native function overload
-        native_fn_arg_counts_[s->name].push_back(s->params.size());
-
         // Build rich signature
         NativeFnSignature sig;
         sig.name = s->name;
         sig.package = deriveNativePackage(s->loc);
+        sig.library = getDirectivePositionalArg(s->directives, "native");
         sig.params.reserve(s->params.size());
+
+        // Only register in builtin dispatch when no library is specified.
+        // @native("libname") declarations are metadata-only until dynamic
+        // loading is implemented — they do not affect call resolution.
+        if (sig.library.empty())
+            native_fn_arg_counts_[s->name].push_back(s->params.size());
         for (auto &p : s->params)
             sig.params.push_back({p.name, p.type ? p.type->toString() : ""});
         sig.return_type_name = s->return_type ? s->return_type->toString() : "Unit";

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -444,7 +444,15 @@ void Formatter::formatDirectives(const std::vector<Directive> &directives) {
             emit("(");
             for (size_t i = 0; i < d.params.size(); ++i) {
                 if (i > 0) emit(", ");
-                emit(d.params[i].key + "=" + d.params[i].value);
+                const auto &p = d.params[i];
+                if (p.key.empty()) {
+                    // Positional string argument: @native("base64")
+                    emit("\"" + escapeString(p.value) + "\"");
+                } else if (p.is_string) {
+                    emit(p.key + "=\"" + escapeString(p.value) + "\"");
+                } else {
+                    emit(p.key + "=" + p.value);
+                }
             }
             emit(")");
         }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -194,11 +194,23 @@ std::vector<Directive> Parser::parseDirectives() {
                 if (lex_.peek().kind != TokenKind::RParen)
                     parseError("expected ')' after @each list");
                 lex_.next(); // consume ')'
+            } else if (nameTok.value == "native") {
+                // @native("libname") — exactly one positional string argument
+                if (lex_.peek().kind != TokenKind::String)
+                    parseError("@native(...) expects a string argument, e.g. @native(\"libname\")");
+                Token strTok = lex_.next(); // consume string
+                if (strTok.value.empty())
+                    parseError(strTok.line, "@native library name must not be empty");
+                d.params.push_back({"", strTok.value, /*is_string=*/true});
+                if (lex_.peek().kind != TokenKind::RParen)
+                    parseError("@native(\"...\") accepts exactly one argument");
+                lex_.next(); // consume ')'
             } else {
+                // key=value parameters: @inline(mode="always")
                 while (lex_.peek().kind != TokenKind::RParen) {
-                    Token keyTok2 = lex_.peek();
-                    if (keyTok2.kind != TokenKind::Ident)
-                        parseError(keyTok2.line, "expected parameter name in directive");
+                    Token keyTok = lex_.peek();
+                    if (keyTok.kind != TokenKind::Ident)
+                        parseError(keyTok.line, "expected parameter name in directive");
                     lex_.next(); // consume key
 
                     if (lex_.peek().kind != TokenKind::Equals)
@@ -215,7 +227,8 @@ std::vector<Directive> Parser::parseDirectives() {
                         parseError(valTok.line, "expected value after '=' in directive parameter");
                     lex_.next(); // consume value
 
-                    d.params.push_back({keyTok2.value, valTok.value});
+                    d.params.push_back({keyTok.value, valTok.value,
+                                        /*is_string=*/valTok.kind == TokenKind::String});
 
                     if (lex_.peek().kind == TokenKind::Comma)
                         lex_.next(); // consume ','

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -110,6 +110,63 @@ TEST(NativeFnSigs, DirectivesRecorded) {
               directives.end());
 }
 
+TEST(NativeFnSigs, LibraryFieldParsed) {
+    // @native("base64") parses correctly at AST level
+    std::string src =
+        "@native(\"base64\")\n"
+        "function encode(data: str) -> str\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    // Verify the directive parameter was parsed
+    ASSERT_FALSE(prog.empty());
+    auto *fn = std::get_if<std::unique_ptr<FnStmt>>(&prog[0]);
+    ASSERT_NE(fn, nullptr);
+    ASSERT_FALSE((*fn)->directives.empty());
+    auto &d = (*fn)->directives[0];
+    EXPECT_EQ(d.name, "native");
+    ASSERT_EQ(d.params.size(), 1u);
+    EXPECT_EQ(d.params[0].key, "");
+    EXPECT_EQ(d.params[0].value, "base64");
+}
+
+TEST(NativeFnSigs, LibraryFieldStoredAtCodegen) {
+    // @native("base64") stores library name in registry
+    std::string src =
+        "@native(\"base64\")\n"
+        "function encode(data: str) -> str\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    auto &sigs = cg.getNativeFnSigs();
+    ASSERT_TRUE(sigs.count("encode"));
+    EXPECT_EQ(sigs.at("encode")[0].library, "base64");
+}
+
+TEST(NativeFnSigs, LibraryFieldEmptyForBareNative) {
+    std::string src =
+        "@native\n"
+        "function contains(s: str, sub: str) -> bool\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    auto &sigs = cg.getNativeFnSigs();
+    ASSERT_TRUE(sigs.count("contains"));
+    EXPECT_EQ(sigs.at("contains")[0].library, "");
+}
+
 // 1. @deprecated function called -> warning, execution normal
 TEST_F(DirectiveTest, DeprecatedFunctionWarning) {
     auto [output, warnings] = runSourceWithWarnings(
@@ -238,6 +295,40 @@ TEST_F(DirectiveTest, UnknownDirectiveError) {
     }, std::runtime_error);
 }
 
+// 10b. Positional string argument on non-@native directive causes parse error
+TEST_F(DirectiveTest, PositionalArgOnNonNativeError) {
+    EXPECT_THROW({
+        runSource("@inline(\"always\")\nfunction add(a: int, b: int) -> int:\n    return a + b\n");
+    }, std::runtime_error);
+    EXPECT_THROW({
+        runSource("@deprecated(\"old\")\nfunction foo() -> int:\n    return 1\n");
+    }, std::runtime_error);
+}
+
+// 10c. @native("") with empty string causes parse error
+TEST_F(DirectiveTest, NativeEmptyLibraryNameError) {
+    EXPECT_THROW({
+        runSource("@native(\"\")\nfunction foo(x: int) -> int\n");
+    }, std::runtime_error);
+}
+
+// 10d. @native("a", "b") or @native("a", key=val) — extra arguments rejected
+TEST_F(DirectiveTest, NativeLibraryExtraArgsError) {
+    EXPECT_THROW({
+        runSource("@native(\"a\", \"b\")\nfunction foo(x: int) -> int\n");
+    }, std::runtime_error);
+    EXPECT_THROW({
+        runSource("@native(\"a\", key=val)\nfunction foo(x: int) -> int\n");
+    }, std::runtime_error);
+}
+
+// 10e. @native(key=value) — key-value params not allowed for @native
+TEST_F(DirectiveTest, NativeKeyValueParamsError) {
+    EXPECT_THROW({
+        runSource("@native(lib=base64)\nfunction foo(x: int) -> int\n");
+    }, std::runtime_error);
+}
+
 // 11. Directive on invalid target causes parse error
 TEST_F(DirectiveTest, DirectiveOnInvalidTarget) {
     EXPECT_THROW({
@@ -352,6 +443,30 @@ TEST_F(DirectiveTest, CoreStrDeclarationsWork) {
         "print(starts_with(\"hello\", \"hel\"))\n"
     );
     EXPECT_EQ(output, "HELLO\ntrue\ntrue\n");
+}
+
+// ===== @native("libname") directive syntax tests =====
+
+TEST_F(DirectiveTest, NativeFnLibraryDeclarationOnly) {
+    // @native("libname") declaration is accepted but does not register
+    // for builtin dispatch. The function is only in the signature registry.
+    std::string output = runSource(
+        "@native(\"base64\")\n"
+        "function encode(data: str) -> str\n"
+        "print(\"ok\")\n"
+    );
+    EXPECT_EQ(output, "ok\n");
+}
+
+TEST_F(DirectiveTest, NativeFnLibraryDoesNotAffectDispatch) {
+    // @native("libname") is metadata-only — it does not register for
+    // builtin arg-count validation, but same-named builtins still resolve.
+    std::string output = runSource(
+        "@native(\"base64\")\n"
+        "function contains(s: str, sub: str) -> bool\n"
+        "print(contains(\"hello\", \"ell\"))\n"
+    );
+    EXPECT_EQ(output, "true\n");
 }
 
 // ===== @inline tests =====

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -130,6 +130,7 @@ TEST(NativeFnSigs, LibraryFieldParsed) {
     ASSERT_EQ(d.params.size(), 1u);
     EXPECT_EQ(d.params[0].key, "");
     EXPECT_EQ(d.params[0].value, "base64");
+    EXPECT_TRUE(d.params[0].is_string);
 }
 
 TEST(NativeFnSigs, LibraryFieldStoredAtCodegen) {

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -346,6 +346,44 @@ TEST(Formatter, NativeDirectiveFormatting) {
     }
 }
 
+// ===== @native("libname") directive formatting =====
+
+TEST(Formatter, NativeLibraryDirectiveRoundTrip) {
+    // @native("base64") round-trips correctly
+    {
+        std::string src = "@native(\"base64\")\nfunction encode(data: str) -> str\n";
+        auto out = fmt(src);
+        EXPECT_NE(out.find("@native(\"base64\")"), std::string::npos)
+            << "Expected @native(\"base64\") in:\n" << out;
+        // Idempotent
+        EXPECT_EQ(out, fmt(out));
+    }
+    // @inline(mode="always") — value is a string literal, quotes preserved
+    {
+        std::string src = "@inline(mode=\"always\")\nfunction add(a: int, b: int) -> int:\n    return a + b\n";
+        auto out = fmt(src);
+        EXPECT_NE(out.find("@inline(mode=\"always\")"), std::string::npos)
+            << "Expected @inline(mode=\"always\") in:\n" << out;
+        EXPECT_EQ(out, fmt(out));
+    }
+    // @deprecated(reason="use new_func") — string value keeps quotes
+    {
+        std::string src = "@deprecated(reason=\"use new_func\")\nfunction old() -> int:\n    return 1\n";
+        auto out = fmt(src);
+        EXPECT_NE(out.find("@deprecated(reason=\"use new_func\")"), std::string::npos)
+            << "Expected quoted reason in:\n" << out;
+        EXPECT_EQ(out, fmt(out));
+    }
+    // String value with escape sequences round-trips correctly
+    {
+        std::string src = "@deprecated(reason=\"has \\\"quotes\\\" inside\")\nfunction old() -> int:\n    return 1\n";
+        auto out = fmt(src);
+        EXPECT_NE(out.find("@deprecated(reason=\"has \\\"quotes\\\" inside\")"), std::string::npos)
+            << "Expected escaped quotes in:\n" << out;
+        EXPECT_EQ(out, fmt(out));
+    }
+}
+
 // ===== Blank Line Tests =====
 
 TEST(Formatter, BlankLineBetweenDefs) {


### PR DESCRIPTION
## Summary

- Parse `@native("libname")` syntax with strict validation (exactly one non-empty string argument)
- Store library name in `NativeFnSignature.library` field for future dynamic loading
- Add `DirectiveParam.is_string` flag and `getDirectivePositionalArg()` helper
- Fix formatter to correctly quote/escape positional and string directive params
- Library-specified functions are metadata-only: excluded from `native_fn_arg_counts_` and do not affect call resolution

Closes #647

## Test plan

- [x] 1344 C++ tests pass (including 14 new tests for parsing, registry, error cases, and formatting)
- [x] 77 Ry self-test files pass
- [x] ASan build passes with no errors
- [x] `ry fmt` round-trips `@native("libname")` correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `@native("libname")` directive syntax; library-named natives record metadata and do not affect builtin dispatch/arg-count registration.
* **Documentation**
  * Expanded `@native` docs with examples, usage notes, library naming pattern, and clarified metadata-only behavior.
* **Style**
  * Formatter preserves and emits quoted string directive arguments correctly.
* **Tests**
  * Added parser, codegen, formatter, and behavior tests covering `@native("...")` handling and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->