### PR TITLE
refactor: implement table-driven dispatch for Tier 1 packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ add_library(ry_lib STATIC
     src/runtime_tls.cpp
     src/runtime_base64.cpp
     src/codegen_call_base64.cpp
+    src/codegen_call_native.cpp
     src/runtime_path.cpp
     src/codegen_call_path.cpp
     src/runtime_filesystem.cpp

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -44,6 +44,25 @@ public:
         std::vector<std::string> directive_names; // e.g. {"native", "deprecated"}
     };
 
+    // --- Table-driven native call dispatch ---
+
+    enum class ReturnWrapping {
+        Direct,               // return as-is (ptr→ptr, void→Unit, i64→int)
+        ResultPtr,            // wrapPtrAsResult(ptr, errFn)
+        ResultStatus,         // wrapStatusAsResult(status, errFn)
+        ResultOutParam,       // alloca + out-param + emitResultBranch
+        BoolFromI64,          // i64 → trunc to i1
+        ResultPtrWithListMeta // ResultPtr + type_meta_[TM_ListElem] annotation
+    };
+
+    struct NativeDispatchEntry {
+        const char *fn_name;        // e.g. "encode", "collect"
+        const char *rt_suffix;      // runtime name suffix override (nullptr = use fn_name)
+        ReturnWrapping wrapping;
+        int arity;                  // -1 = variadic (e.g. path::join 2-4 args)
+        const char *out_param_type; // for ResultOutParam only (e.g. "int"); nullptr otherwise
+    };
+
     // Access the @native function signature registry.
     // Keyed by "package::name" for package functions, bare name for builtins.
     const std::unordered_map<std::string, std::vector<NativeFnSignature>>&
@@ -935,6 +954,10 @@ private:
     llvm::Value *emitBuiltinFilesystem(const CallExpr &e);
     llvm::Value *emitBuiltinThread(const CallExpr &e);
     llvm::Value *emitBuiltinGc(const CallExpr &e);
+    llvm::Value *emitTableDrivenNativeCall(const CallExpr &e,
+                                            const char *package,
+                                            const NativeDispatchEntry *table,
+                                            size_t table_size);
     bool isTcpListener(llvm::Value *val);
     bool isTcpStream(llvm::Value *val);
     bool isTlsStream(llvm::Value *val);

--- a/src/codegen_call_base64.cpp
+++ b/src/codegen_call_base64.cpp
@@ -8,5 +8,6 @@ static const CodeGen::NativeDispatchEntry base64_table[] = {
 };
 
 llvm::Value *CodeGen::emitBuiltinBase64(const CallExpr &e) {
-    return emitTableDrivenNativeCall(e, "base64", base64_table, std::size(base64_table));
+    return emitTableDrivenNativeCall(e, "base64", base64_table,
+                                     sizeof(base64_table) / sizeof(base64_table[0]));
 }

--- a/src/codegen_call_base64.cpp
+++ b/src/codegen_call_base64.cpp
@@ -1,39 +1,12 @@
 #include "ry/codegen.hpp"
 
+static const CodeGen::NativeDispatchEntry base64_table[] = {
+    {"encode",          nullptr, CodeGen::ReturnWrapping::Direct,    1, nullptr},
+    {"encode_url_safe", nullptr, CodeGen::ReturnWrapping::Direct,    1, nullptr},
+    {"decode",          nullptr, CodeGen::ReturnWrapping::ResultPtr, 1, nullptr},
+    {"decode_url_safe", nullptr, CodeGen::ReturnWrapping::ResultPtr, 1, nullptr},
+};
+
 llvm::Value *CodeGen::emitBuiltinBase64(const CallExpr &e) {
-    if (!native_fn_arg_counts_.count(e.callee))
-        return nullptr;
-
-    // Helper: call a __ry_base64_* function with 1 str arg, returning str
-    auto emitBase64Call = [&](const std::string &rtName) -> llvm::Value * {
-        requireArgs(e, 1);
-        llvm::Value *input = emitExpr(*e.args[0]);
-        if (input->getType() != ptrTy_)
-            codegenError(e.callee + "() requires str argument");
-        auto fnTy = fnTy_ptr_to_ptr_;
-        auto fn = mod_->getOrInsertFunction(rtName, fnTy);
-        return builder_.CreateCall(fn, {input}, e.callee);
-    };
-
-    // encode(str) -> str
-    if (e.callee == "encode")
-        return emitBase64Call("__ry_base64_encode");
-
-    // encode_url_safe(str) -> str
-    if (e.callee == "encode_url_safe")
-        return emitBase64Call("__ry_base64_encode_url_safe");
-
-    // decode(str) -> Result<str, Error>
-    if (e.callee == "decode") {
-        llvm::Value *ptr = emitBase64Call("__ry_base64_decode");
-        return wrapPtrAsResult(ptr, "__ry_base64_get_last_error");
-    }
-
-    // decode_url_safe(str) -> Result<str, Error>
-    if (e.callee == "decode_url_safe") {
-        llvm::Value *ptr = emitBase64Call("__ry_base64_decode_url_safe");
-        return wrapPtrAsResult(ptr, "__ry_base64_get_last_error");
-    }
-
-    return nullptr;
+    return emitTableDrivenNativeCall(e, "base64", base64_table, std::size(base64_table));
 }

--- a/src/codegen_call_filesystem.cpp
+++ b/src/codegen_call_filesystem.cpp
@@ -1,101 +1,31 @@
 #include "ry/codegen.hpp"
 
+static const CodeGen::NativeDispatchEntry filesystem_table[] = {
+    // (str) -> Result<List<str>, Error>
+    {"list_dir",    nullptr, CodeGen::ReturnWrapping::ResultPtrWithListMeta, 1, nullptr},
+    {"walk",        nullptr, CodeGen::ReturnWrapping::ResultPtrWithListMeta, 1, nullptr},
+    {"glob_files",  nullptr, CodeGen::ReturnWrapping::ResultPtrWithListMeta, 1, nullptr},
+    // (str, str) -> Result<Unit, Error>
+    {"copy",        nullptr, CodeGen::ReturnWrapping::ResultStatus,  2, nullptr},
+    {"move",        nullptr, CodeGen::ReturnWrapping::ResultStatus,  2, nullptr},
+    {"symlink",     nullptr, CodeGen::ReturnWrapping::ResultStatus,  2, nullptr},
+    // (str) -> Result<Unit, Error>
+    {"remove",      nullptr, CodeGen::ReturnWrapping::ResultStatus,  1, nullptr},
+    {"remove_all",  nullptr, CodeGen::ReturnWrapping::ResultStatus,  1, nullptr},
+    {"make_dir",    nullptr, CodeGen::ReturnWrapping::ResultStatus,  1, nullptr},
+    {"make_dir_all",nullptr, CodeGen::ReturnWrapping::ResultStatus,  1, nullptr},
+    // (str) -> bool
+    {"is_file",     nullptr, CodeGen::ReturnWrapping::BoolFromI64,   1, nullptr},
+    {"is_dir",      nullptr, CodeGen::ReturnWrapping::BoolFromI64,   1, nullptr},
+    {"is_symlink",  nullptr, CodeGen::ReturnWrapping::BoolFromI64,   1, nullptr},
+    // (str) -> Result<str, Error>
+    {"read_link",   nullptr, CodeGen::ReturnWrapping::ResultPtr,     1, nullptr},
+    // (str) -> Result<int, Error>
+    {"file_size",   nullptr, CodeGen::ReturnWrapping::ResultOutParam,1, "int"},
+    // (str, int) -> Result<Unit, Error>
+    {"chmod",       nullptr, CodeGen::ReturnWrapping::ResultStatus,  2, nullptr},
+};
+
 llvm::Value *CodeGen::emitBuiltinFilesystem(const CallExpr &e) {
-    if (!native_fn_arg_counts_.count(e.callee))
-        return nullptr;
-
-    auto emitFS1 = [&](const std::string &name,
-                        llvm::Type *retTy) -> llvm::Value * {
-        requireArgs(e, 1);
-        llvm::Value *arg = emitExpr(*e.args[0]);
-        if (arg->getType() != ptrTy_)
-            codegenError(e.callee + "() requires str argument");
-        auto fnTy = llvm::FunctionType::get(retTy, {ptrTy_}, false);
-        auto fn = mod_->getOrInsertFunction("__ry_filesystem_" + name, fnTy);
-        return builder_.CreateCall(fn, {arg}, name);
-    };
-
-    auto emitFS2 = [&](const std::string &name,
-                        llvm::Type *retTy) -> llvm::Value * {
-        requireArgs(e, 2);
-        llvm::Value *a = emitExpr(*e.args[0]);
-        llvm::Value *b = emitExpr(*e.args[1]);
-        if (a->getType() != ptrTy_ || b->getType() != ptrTy_)
-            codegenError(e.callee + "() requires str arguments");
-        auto fnTy = llvm::FunctionType::get(retTy, {ptrTy_, ptrTy_}, false);
-        auto fn = mod_->getOrInsertFunction("__ry_filesystem_" + name, fnTy);
-        return builder_.CreateCall(fn, {a, b}, name);
-    };
-
-    // ---- Pattern 1: (str) -> Result<List<str>, Error> ----
-    if (e.callee == "list_dir" || e.callee == "walk" || e.callee == "glob_files") {
-        llvm::Value *ptr = emitFS1(e.callee, ptrTy_);
-        llvm::Value *result = wrapPtrAsResult(ptr, "__ry_filesystem_get_last_error");
-        type_meta_[TM_ListElem][result] = ptrTy_;
-        return result;
-    }
-
-    // ---- Pattern 2: (str, str) -> Result<Unit, Error> ----
-    if (e.callee == "copy" || e.callee == "move" || e.callee == "symlink") {
-        llvm::Value *status = emitFS2(e.callee, i64Ty_);
-        return wrapStatusAsResult(status, "__ry_filesystem_get_last_error");
-    }
-
-    // ---- Pattern 3: (str) -> Result<Unit, Error> ----
-    if (e.callee == "remove" || e.callee == "remove_all" ||
-        e.callee == "make_dir" || e.callee == "make_dir_all") {
-        llvm::Value *status = emitFS1(e.callee, i64Ty_);
-        return wrapStatusAsResult(status, "__ry_filesystem_get_last_error");
-    }
-
-    // ---- Pattern 4: (str) -> bool ----
-    if (e.callee == "is_file" || e.callee == "is_dir" || e.callee == "is_symlink") {
-        llvm::Value *result = emitFS1(e.callee, i64Ty_);
-        return builder_.CreateTrunc(result, i1Ty_, e.callee + "_bool");
-    }
-
-    // ---- Pattern 5: (str) -> Result<str, Error> ----
-    if (e.callee == "read_link") {
-        llvm::Value *ptr = emitFS1(e.callee, ptrTy_);
-        return wrapPtrAsResult(ptr, "__ry_filesystem_get_last_error");
-    }
-
-    // ---- Pattern 6: (str) -> Result<int, Error> ----
-    if (e.callee == "file_size") {
-        requireArgs(e, 1);
-        llvm::Value *arg = emitExpr(*e.args[0]);
-        if (arg->getType() != ptrTy_)
-            codegenError("file_size() requires str argument");
-        llvm::AllocaInst *outSlot = builder_.CreateAlloca(i64Ty_, nullptr, "file_size_out");
-        auto fnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, ptrTy_}, false);
-        auto fn = mod_->getOrInsertFunction("__ry_filesystem_file_size", fnTy);
-        llvm::Value *status = builder_.CreateCall(fn, {arg, outSlot}, "file_size_status");
-        llvm::Value *isErr = builder_.CreateICmpNE(status,
-            llvm::ConstantInt::get(i64Ty_, 0), "file_size_err");
-        llvm::StructType *resTy = getResultType(i64Ty_, errorTy_);
-        return emitResultBranch(isErr, resTy,
-            [&]() {
-                llvm::Value *loaded = builder_.CreateLoad(i64Ty_, outSlot, "file_size_val");
-                return buildOkValue(loaded, resTy);
-            },
-            [&]() { return buildErrValue(
-                buildErrorFromRuntime("__ry_filesystem_get_last_error"), resTy); });
-    }
-
-    // ---- Pattern 7: (str, int) -> Result<Unit, Error> ----
-    if (e.callee == "chmod") {
-        requireArgs(e, 2);
-        llvm::Value *path = emitExpr(*e.args[0]);
-        llvm::Value *mode = emitExpr(*e.args[1]);
-        if (path->getType() != ptrTy_)
-            codegenError("chmod() path must be str");
-        if (mode->getType() != i64Ty_)
-            codegenError("chmod() mode must be int");
-        auto fnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, i64Ty_}, false);
-        auto fn = mod_->getOrInsertFunction("__ry_filesystem_chmod", fnTy);
-        llvm::Value *status = builder_.CreateCall(fn, {path, mode}, "chmod_status");
-        return wrapStatusAsResult(status, "__ry_filesystem_get_last_error");
-    }
-
-    return nullptr;
+    return emitTableDrivenNativeCall(e, "filesystem", filesystem_table, std::size(filesystem_table));
 }

--- a/src/codegen_call_filesystem.cpp
+++ b/src/codegen_call_filesystem.cpp
@@ -27,5 +27,6 @@ static const CodeGen::NativeDispatchEntry filesystem_table[] = {
 };
 
 llvm::Value *CodeGen::emitBuiltinFilesystem(const CallExpr &e) {
-    return emitTableDrivenNativeCall(e, "filesystem", filesystem_table, std::size(filesystem_table));
+    return emitTableDrivenNativeCall(e, "filesystem", filesystem_table,
+                                     sizeof(filesystem_table) / sizeof(filesystem_table[0]));
 }

--- a/src/codegen_call_gc.cpp
+++ b/src/codegen_call_gc.cpp
@@ -8,5 +8,6 @@ static const CodeGen::NativeDispatchEntry gc_table[] = {
 };
 
 llvm::Value *CodeGen::emitBuiltinGc(const CallExpr &e) {
-    return emitTableDrivenNativeCall(e, "gc", gc_table, std::size(gc_table));
+    return emitTableDrivenNativeCall(e, "gc", gc_table,
+                                     sizeof(gc_table) / sizeof(gc_table[0]));
 }

--- a/src/codegen_call_gc.cpp
+++ b/src/codegen_call_gc.cpp
@@ -1,46 +1,12 @@
 #include "ry/codegen.hpp"
 
+static const CodeGen::NativeDispatchEntry gc_table[] = {
+    {"collect",       nullptr, CodeGen::ReturnWrapping::Direct, 0, nullptr},
+    {"enable",        nullptr, CodeGen::ReturnWrapping::Direct, 0, nullptr},
+    {"disable",       nullptr, CodeGen::ReturnWrapping::Direct, 0, nullptr},
+    {"set_threshold", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr},
+};
+
 llvm::Value *CodeGen::emitBuiltinGc(const CallExpr &e) {
-    if (!native_fn_arg_counts_.count(e.callee))
-        return nullptr;
-
-    // collect() -> int
-    if (e.callee == "collect") {
-        requireArgs(e, 0);
-        auto *fnTy = llvm::FunctionType::get(i64Ty_, {}, false);
-        auto fn = mod_->getOrInsertFunction("__ry_gc_collect", fnTy);
-        return builder_.CreateCall(fn, {}, "gc_collected");
-    }
-
-    // enable() -> Unit
-    if (e.callee == "enable") {
-        requireArgs(e, 0);
-        auto *fnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {}, false);
-        auto fn = mod_->getOrInsertFunction("__ry_gc_enable", fnTy);
-        builder_.CreateCall(fn, {});
-        return llvm::ConstantInt::get(i8Ty_, 0);  // Unit
-    }
-
-    // disable() -> Unit
-    if (e.callee == "disable") {
-        requireArgs(e, 0);
-        auto *fnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {}, false);
-        auto fn = mod_->getOrInsertFunction("__ry_gc_disable", fnTy);
-        builder_.CreateCall(fn, {});
-        return llvm::ConstantInt::get(i8Ty_, 0);  // Unit
-    }
-
-    // set_threshold(n: int) -> Unit
-    if (e.callee == "set_threshold") {
-        requireArgs(e, 1);
-        llvm::Value *n = emitExpr(*e.args[0]);
-        if (n->getType() != i64Ty_)
-            codegenError("set_threshold() requires int argument");
-        auto *fnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {i64Ty_}, false);
-        auto fn = mod_->getOrInsertFunction("__ry_gc_set_threshold", fnTy);
-        builder_.CreateCall(fn, {n});
-        return llvm::ConstantInt::get(i8Ty_, 0);  // Unit
-    }
-
-    return nullptr;
+    return emitTableDrivenNativeCall(e, "gc", gc_table, std::size(gc_table));
 }

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -54,9 +54,18 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     // --- Normal path ---
     requireArgs(e, static_cast<size_t>(entry->arity));
 
-    // Look up NativeFnSignature for type info
+    // Look up NativeFnSignature matching this call's arity
     std::string sigKey = nativeSigKey(package, e.callee);
     auto sigIt = native_fn_sigs_.find(sigKey);
+    const NativeFnSignature *matchedSig = nullptr;
+    if (sigIt != native_fn_sigs_.end()) {
+        for (const auto &sig : sigIt->second) {
+            if (static_cast<int>(sig.params.size()) == entry->arity) {
+                matchedSig = &sig;
+                break;
+            }
+        }
+    }
 
     // Emit and validate arguments
     std::vector<llvm::Value *> args;
@@ -65,12 +74,9 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         llvm::Value *arg = emitExpr(*e.args[i]);
         llvm::Type *expectedTy = ptrTy_; // default
         std::string expectedTN = "str";
-        if (sigIt != native_fn_sigs_.end() && !sigIt->second.empty()) {
-            const auto &sig = sigIt->second[0];
-            if (static_cast<size_t>(i) < sig.params.size()) {
-                expectedTN = sig.params[i].type_name;
-                expectedTy = resolveType(expectedTN);
-            }
+        if (matchedSig && static_cast<size_t>(i) < matchedSig->params.size()) {
+            expectedTN = matchedSig->params[i].type_name;
+            expectedTy = resolveType(expectedTN);
         }
         if (arg->getType() != expectedTy)
             codegenError(e.callee + "() argument " + std::to_string(i) +
@@ -91,9 +97,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     llvm::Type *cRetTy;
     switch (entry->wrapping) {
     case ReturnWrapping::Direct: {
-        std::string retTN = "Unit";
-        if (sigIt != native_fn_sigs_.end() && !sigIt->second.empty())
-            retTN = sigIt->second[0].return_type_name;
+        std::string retTN = matchedSig ? matchedSig->return_type_name : "Unit";
         cRetTy = resolveType(retTN);
         break;
     }

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -1,0 +1,174 @@
+#include "ry/codegen.hpp"
+
+llvm::Value *CodeGen::emitTableDrivenNativeCall(
+    const CallExpr &e,
+    const char *package,
+    const NativeDispatchEntry *table,
+    size_t table_size) {
+
+    if (!native_fn_arg_counts_.count(e.callee))
+        return nullptr;
+
+    // Lookup entry in dispatch table
+    const NativeDispatchEntry *entry = nullptr;
+    for (size_t i = 0; i < table_size; i++) {
+        if (e.callee == table[i].fn_name) {
+            entry = &table[i];
+            break;
+        }
+    }
+    if (!entry)
+        return nullptr;
+
+    // Lazily build error function name (only for wrappings that need it)
+    auto getErrFnName = [&]() {
+        return deriveRuntimeFnName(package, "get_last_error");
+    };
+
+    // Resolve the effective runtime suffix
+    const char *rtSuffix = entry->rt_suffix ? entry->rt_suffix : entry->fn_name;
+
+    // --- Special case: variadic arity (e.g. path::join) ---
+    if (entry->arity == -1) {
+        size_t n = e.args.size();
+        if (n < 2 || n > 4)
+            codegenError(std::string(entry->fn_name) + "() requires 2, 3, or 4 arguments");
+
+        std::vector<llvm::Value *> args;
+        std::vector<llvm::Type *> argTypes;
+        for (size_t i = 0; i < n; i++) {
+            llvm::Value *arg = emitExpr(*e.args[i]);
+            if (arg->getType() != ptrTy_)
+                codegenError(std::string(entry->fn_name) + "() requires str arguments");
+            args.push_back(arg);
+            argTypes.push_back(ptrTy_);
+        }
+
+        std::string rtName = deriveRuntimeFnName(package, rtSuffix)
+            + std::to_string(n);
+        auto *fnTy = llvm::FunctionType::get(ptrTy_, argTypes, false);
+        auto fn = mod_->getOrInsertFunction(rtName, fnTy);
+        return builder_.CreateCall(fn, args, entry->fn_name);
+    }
+
+    // --- Normal path ---
+    requireArgs(e, static_cast<size_t>(entry->arity));
+
+    // Look up NativeFnSignature for type info
+    std::string sigKey = nativeSigKey(package, e.callee);
+    auto sigIt = native_fn_sigs_.find(sigKey);
+
+    // Emit and validate arguments
+    std::vector<llvm::Value *> args;
+    std::vector<llvm::Type *> paramLLVMTypes;
+    for (int i = 0; i < entry->arity; i++) {
+        llvm::Value *arg = emitExpr(*e.args[i]);
+        llvm::Type *expectedTy = ptrTy_; // default
+        if (sigIt != native_fn_sigs_.end() && !sigIt->second.empty()) {
+            const auto &sig = sigIt->second[0];
+            if (static_cast<size_t>(i) < sig.params.size())
+                expectedTy = resolveType(sig.params[i].type_name);
+        }
+        if (arg->getType() != expectedTy)
+            codegenError(e.callee + "() argument type mismatch");
+        args.push_back(arg);
+        paramLLVMTypes.push_back(expectedTy);
+    }
+
+    // Derive runtime function name
+    std::string rtName = deriveRuntimeFnName(package, rtSuffix);
+
+    // Pre-compute out-param type for ResultOutParam (used in two places)
+    llvm::Type *outTy = nullptr;
+    if (entry->wrapping == ReturnWrapping::ResultOutParam)
+        outTy = entry->out_param_type ? resolveType(entry->out_param_type) : i64Ty_;
+
+    // Determine C-level return type and build function type
+    llvm::Type *cRetTy;
+    switch (entry->wrapping) {
+    case ReturnWrapping::Direct: {
+        std::string retTN = "Unit";
+        if (sigIt != native_fn_sigs_.end() && !sigIt->second.empty())
+            retTN = sigIt->second[0].return_type_name;
+        cRetTy = resolveType(retTN);
+        break;
+    }
+    case ReturnWrapping::ResultPtr:
+    case ReturnWrapping::ResultPtrWithListMeta:
+        cRetTy = ptrTy_;
+        break;
+    case ReturnWrapping::ResultStatus:
+    case ReturnWrapping::BoolFromI64:
+        cRetTy = i64Ty_;
+        break;
+    case ReturnWrapping::ResultOutParam:
+        paramLLVMTypes.push_back(ptrTy_);
+        cRetTy = i64Ty_;
+        break;
+    }
+
+    // For ResultOutParam, create alloca and add to args
+    llvm::AllocaInst *outSlot = nullptr;
+    if (entry->wrapping == ReturnWrapping::ResultOutParam) {
+        outSlot = builder_.CreateAlloca(outTy, nullptr,
+            std::string(entry->fn_name) + "_out");
+        args.push_back(outSlot);
+    }
+
+    auto *fnTy = llvm::FunctionType::get(cRetTy, paramLLVMTypes, false);
+    auto fn = mod_->getOrInsertFunction(rtName, fnTy);
+    llvm::Value *callResult;
+    if (cRetTy->isVoidTy())
+        callResult = builder_.CreateCall(fn, args);
+    else
+        callResult = builder_.CreateCall(fn, args, entry->fn_name);
+
+    // Apply return wrapping
+    switch (entry->wrapping) {
+    case ReturnWrapping::Direct:
+        if (cRetTy->isVoidTy())
+            return llvm::ConstantInt::get(i8Ty_, 0); // Unit
+        return callResult;
+
+    case ReturnWrapping::ResultPtr: {
+        std::string errFn = getErrFnName();
+        return wrapPtrAsResult(callResult, errFn.c_str());
+    }
+
+    case ReturnWrapping::ResultPtrWithListMeta: {
+        std::string errFn = getErrFnName();
+        llvm::Value *result = wrapPtrAsResult(callResult, errFn.c_str());
+        type_meta_[TM_ListElem][result] = ptrTy_;
+        return result;
+    }
+
+    case ReturnWrapping::ResultStatus: {
+        std::string errFn = getErrFnName();
+        return wrapStatusAsResult(callResult, errFn.c_str());
+    }
+
+    case ReturnWrapping::BoolFromI64:
+        return builder_.CreateTrunc(callResult, i1Ty_,
+            std::string(entry->fn_name) + "_bool");
+
+    case ReturnWrapping::ResultOutParam: {
+        std::string errFn = getErrFnName();
+        llvm::Value *isErr = builder_.CreateICmpNE(callResult,
+            llvm::ConstantInt::get(i64Ty_, 0),
+            std::string(entry->fn_name) + "_err");
+        llvm::StructType *resTy = getResultType(outTy, errorTy_);
+        return emitResultBranch(isErr, resTy,
+            [&]() {
+                llvm::Value *loaded = builder_.CreateLoad(outTy, outSlot,
+                    std::string(entry->fn_name) + "_val");
+                return buildOkValue(loaded, resTy);
+            },
+            [&]() {
+                return buildErrValue(
+                    buildErrorFromRuntime(errFn.c_str()), resTy);
+            });
+    }
+    }
+
+    return nullptr; // unreachable
+}

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -66,18 +66,18 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
             }
         }
     }
+    if (!matchedSig)
+        codegenError(std::string(package) + "::" + e.callee +
+                     " has no @native signature with arity " +
+                     std::to_string(entry->arity));
 
     // Emit and validate arguments
     std::vector<llvm::Value *> args;
     std::vector<llvm::Type *> paramLLVMTypes;
     for (int i = 0; i < entry->arity; i++) {
         llvm::Value *arg = emitExpr(*e.args[i]);
-        llvm::Type *expectedTy = ptrTy_; // default
-        std::string expectedTN = "str";
-        if (matchedSig && static_cast<size_t>(i) < matchedSig->params.size()) {
-            expectedTN = matchedSig->params[i].type_name;
-            expectedTy = resolveType(expectedTN);
-        }
+        const std::string &expectedTN = matchedSig->params[i].type_name;
+        llvm::Type *expectedTy = resolveType(expectedTN);
         if (arg->getType() != expectedTy)
             codegenError(e.callee + "() argument " + std::to_string(i) +
                          " requires " + expectedTN);
@@ -97,8 +97,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     llvm::Type *cRetTy;
     switch (entry->wrapping) {
     case ReturnWrapping::Direct: {
-        std::string retTN = matchedSig ? matchedSig->return_type_name : "Unit";
-        cRetTy = resolveType(retTN);
+        cRetTy = resolveType(matchedSig->return_type_name);
         break;
     }
     case ReturnWrapping::ResultPtr:

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -178,5 +178,5 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     }
     }
 
-    return nullptr; // unreachable
+    llvm_unreachable("unhandled ReturnWrapping variant");
 }

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -34,19 +34,39 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         if (n < 2 || n > 4)
             codegenError(std::string(entry->fn_name) + "() requires 2, 3, or 4 arguments");
 
+        // Match signature by arity (same validation as fixed-arity path)
+        std::string sigKey = nativeSigKey(package, e.callee);
+        auto sigIt = native_fn_sigs_.find(sigKey);
+        const NativeFnSignature *matchedSig = nullptr;
+        if (sigIt != native_fn_sigs_.end()) {
+            for (const auto &sig : sigIt->second) {
+                if (sig.params.size() == n) {
+                    matchedSig = &sig;
+                    break;
+                }
+            }
+        }
+        if (!matchedSig)
+            codegenError(std::string(package) + "::" + e.callee +
+                         " has no @native signature with arity " +
+                         std::to_string(n));
+
         std::vector<llvm::Value *> args;
         std::vector<llvm::Type *> argTypes;
         for (size_t i = 0; i < n; i++) {
             llvm::Value *arg = emitExpr(*e.args[i]);
-            if (arg->getType() != ptrTy_)
-                codegenError(std::string(entry->fn_name) + "() requires str arguments");
+            llvm::Type *expectedTy = resolveType(matchedSig->params[i].type_name);
+            if (arg->getType() != expectedTy)
+                codegenError(e.callee + "() argument " + std::to_string(i) +
+                             " requires " + matchedSig->params[i].type_name);
             args.push_back(arg);
-            argTypes.push_back(ptrTy_);
+            argTypes.push_back(expectedTy);
         }
 
         std::string rtName = deriveRuntimeFnName(package, rtSuffix)
             + std::to_string(n);
-        auto *fnTy = llvm::FunctionType::get(ptrTy_, argTypes, false);
+        auto *fnTy = llvm::FunctionType::get(
+            resolveType(matchedSig->return_type_name), argTypes, false);
         auto fn = mod_->getOrInsertFunction(rtName, fnTy);
         return builder_.CreateCall(fn, args, entry->fn_name);
     }

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -64,13 +64,17 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     for (int i = 0; i < entry->arity; i++) {
         llvm::Value *arg = emitExpr(*e.args[i]);
         llvm::Type *expectedTy = ptrTy_; // default
+        std::string expectedTN = "str";
         if (sigIt != native_fn_sigs_.end() && !sigIt->second.empty()) {
             const auto &sig = sigIt->second[0];
-            if (static_cast<size_t>(i) < sig.params.size())
-                expectedTy = resolveType(sig.params[i].type_name);
+            if (static_cast<size_t>(i) < sig.params.size()) {
+                expectedTN = sig.params[i].type_name;
+                expectedTy = resolveType(expectedTN);
+            }
         }
         if (arg->getType() != expectedTy)
-            codegenError(e.callee + "() argument type mismatch");
+            codegenError(e.callee + "() argument " + std::to_string(i) +
+                         " requires " + expectedTN);
         args.push_back(arg);
         paramLLVMTypes.push_back(expectedTy);
     }

--- a/src/codegen_call_path.cpp
+++ b/src/codegen_call_path.cpp
@@ -10,5 +10,6 @@ static const CodeGen::NativeDispatchEntry path_table[] = {
 };
 
 llvm::Value *CodeGen::emitBuiltinPath(const CallExpr &e) {
-    return emitTableDrivenNativeCall(e, "path", path_table, std::size(path_table));
+    return emitTableDrivenNativeCall(e, "path", path_table,
+                                     sizeof(path_table) / sizeof(path_table[0]));
 }

--- a/src/codegen_call_path.cpp
+++ b/src/codegen_call_path.cpp
@@ -1,77 +1,14 @@
 #include "ry/codegen.hpp"
 
+static const CodeGen::NativeDispatchEntry path_table[] = {
+    {"join",        nullptr, CodeGen::ReturnWrapping::Direct,      -1, nullptr},
+    {"basename",    nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr},
+    {"dirname",     nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr},
+    {"extension",   nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr},
+    {"resolve",     nullptr, CodeGen::ReturnWrapping::ResultPtr,     1, nullptr},
+    {"is_absolute", nullptr, CodeGen::ReturnWrapping::BoolFromI64,   1, nullptr},
+};
+
 llvm::Value *CodeGen::emitBuiltinPath(const CallExpr &e) {
-    if (!native_fn_arg_counts_.count(e.callee))
-        return nullptr;
-
-    // Helper: call a __ry_path_* function with 1 str arg, returning str
-    auto emitPathCall1 = [&](const std::string &rtName) -> llvm::Value * {
-        requireArgs(e, 1);
-        llvm::Value *arg = emitExpr(*e.args[0]);
-        if (arg->getType() != ptrTy_)
-            codegenError(e.callee + "() requires str argument");
-        auto fn = mod_->getOrInsertFunction(rtName, fnTy_ptr_to_ptr_);
-        return builder_.CreateCall(fn, {arg}, e.callee);
-    };
-
-    // join(str, str) -> str | join(str, str, str) -> str | join(str, str, str, str) -> str
-    if (e.callee == "join") {
-        size_t n = e.args.size();
-        if (n < 2 || n > 4)
-            codegenError("join() requires 2, 3, or 4 arguments");
-
-        std::vector<llvm::Value *> args;
-        for (size_t i = 0; i < n; i++) {
-            llvm::Value *arg = emitExpr(*e.args[i]);
-            if (arg->getType() != ptrTy_)
-                codegenError("join() requires str arguments");
-            args.push_back(arg);
-        }
-
-        std::string rtName;
-        llvm::FunctionType *fnTy;
-        if (n == 2) {
-            rtName = "__ry_path_join2";
-            fnTy = fnTy_ptr_ptr_to_ptr_;
-        } else if (n == 3) {
-            rtName = "__ry_path_join3";
-            fnTy = fnTy_ptr_ptr_ptr_to_ptr_;
-        } else {
-            rtName = "__ry_path_join4";
-            fnTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, ptrTy_, ptrTy_, ptrTy_}, false);
-        }
-        auto fn = mod_->getOrInsertFunction(rtName, fnTy);
-        return builder_.CreateCall(fn, args, "join");
-    }
-
-    // basename(str) -> str
-    if (e.callee == "basename")
-        return emitPathCall1("__ry_path_basename");
-
-    // dirname(str) -> str
-    if (e.callee == "dirname")
-        return emitPathCall1("__ry_path_dirname");
-
-    // extension(str) -> str
-    if (e.callee == "extension")
-        return emitPathCall1("__ry_path_extension");
-
-    // resolve(str) -> Result<str, Error>
-    if (e.callee == "resolve") {
-        llvm::Value *ptr = emitPathCall1("__ry_path_resolve");
-        return wrapPtrAsResult(ptr, "__ry_path_get_last_error");
-    }
-
-    // is_absolute(str) -> bool
-    if (e.callee == "is_absolute") {
-        requireArgs(e, 1);
-        llvm::Value *arg = emitExpr(*e.args[0]);
-        if (arg->getType() != ptrTy_)
-            codegenError("is_absolute() requires str argument");
-        auto fn = mod_->getOrInsertFunction("__ry_path_is_absolute", fnTy_ptr_to_i64_);
-        llvm::Value *result = builder_.CreateCall(fn, {arg}, "is_abs");
-        return builder_.CreateTrunc(result, i1Ty_, "is_abs_bool");
-    }
-
-    return nullptr;
+    return emitTableDrivenNativeCall(e, "path", path_table, std::size(path_table));
 }


### PR DESCRIPTION
## Summary

- Implement `emitTableDrivenNativeCall` that mechanically dispatches native function calls using `NativeDispatchEntry` metadata tables
- Migrate 4 Tier 1 stdlib packages (base64, gc, path, filesystem) from hand-written if-chains to static dispatch tables with 1-line wrapper methods
- Support 6 return-wrapping patterns: `Direct`, `ResultPtr`, `ResultStatus`, `ResultOutParam`, `BoolFromI64`, `ResultPtrWithListMeta`

## Key changes

| File | Change |
|------|--------|
| `include/ry/codegen.hpp` | Add `ReturnWrapping` enum, `NativeDispatchEntry` struct, `emitTableDrivenNativeCall` declaration |
| `src/codegen_call_native.cpp` | New file: shared table-driven emitter (~160 lines) |
| `src/codegen_call_{base64,gc,path,filesystem}.cpp` | Replace if-chains with static tables + 1-line wrappers |
| `CMakeLists.txt` | Register new source file |

## Special cases handled

- `path::join`: variadic arity (2-4 args) with runtime name suffix (`join2/3/4`)
- `filesystem::file_size`: `ResultOutParam` pattern with alloca out-slot
- `filesystem::list_dir/walk/glob_files`: `ResultPtrWithListMeta` with `type_meta_` annotation

## Test plan

- [x] C++ tests: 1344 passed
- [x] Ry self-tests: 77 files, 0 failures
- [x] ASan: clean (1343 passed + 1 pre-existing disabled)

Closes #648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated native-call handling into a single table-driven dispatch, standardizing argument validation, runtime selection, and return wrapping across built-ins.
  * Converted many bespoke per-call branches into uniform table entries for base64, filesystem, GC, path, and related native operations.

* **New Features**
  * Added table-driven support for expanded filesystem and variadic native-call variants, improving consistency of results and error wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->