### PR TITLE
feat: dynamic library loader for @native("libname") shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,46 @@ target_include_directories(ry_lib PUBLIC
 )
 target_link_libraries(ry_lib PUBLIC ${LLVM_LIBS} Threads::Threads OpenSSL::SSL OpenSSL::Crypto)
 
+# ===== Native shared libraries for @native("libname") =====
+# These are loaded dynamically by the JIT when @native("libname") is used.
+# The static ry_lib remains unchanged for backward compatibility with bare @native.
+
+function(add_ry_native_lib PKG_NAME)
+    set(SOURCES ${ARGN})
+    add_library(ry_${PKG_NAME} SHARED ${SOURCES})
+    target_include_directories(ry_${PKG_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include)
+    set_target_properties(ry_${PKG_NAME} PROPERTIES
+        OUTPUT_NAME "ry_${PKG_NAME}"
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+endfunction()
+
+# Self-contained packages (no cross-runtime dependencies)
+add_ry_native_lib(base64     src/runtime_base64.cpp)
+add_ry_native_lib(path       src/runtime_path.cpp)
+add_ry_native_lib(convert    src/runtime_convert.cpp)
+add_ry_native_lib(filesystem src/runtime_filesystem.cpp)
+add_ry_native_lib(gc         src/runtime_gc.cpp)
+
+# io defines __ry_set_last_error, used by several other packages
+add_ry_native_lib(io         src/runtime_io.cpp)
+
+# Packages that depend on __ry_set_last_error (via runtime_io.hpp)
+add_ry_native_lib(json       src/runtime_json.cpp)
+target_link_libraries(ry_json PRIVATE ry_io)
+
+add_ry_native_lib(net        src/runtime_net.cpp)
+target_link_libraries(ry_net PRIVATE ry_io)
+
+add_ry_native_lib(thread     src/runtime_thread.cpp)
+target_link_libraries(ry_thread PRIVATE ry_io Threads::Threads)
+
+# http depends on tls, net, hash for HTTPS client support, plus io for error API
+add_ry_native_lib(http       src/runtime_http.cpp src/runtime_http_client.cpp
+                             src/runtime_http_multipart.cpp src/runtime_tls.cpp
+                             src/runtime_net.cpp src/runtime_hash.cpp)
+target_link_libraries(ry_http PRIVATE ry_io OpenSSL::SSL OpenSSL::Crypto Threads::Threads)
+
 # ===== メイン実行ファイル =====
 add_executable(ry src/main.cpp)
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,7 +178,10 @@ function(add_ry_native_lib PKG_NAME)
         ${CMAKE_CURRENT_SOURCE_DIR}/include)
     set_target_properties(ry_${PKG_NAME} PROPERTIES
         OUTPUT_NAME "ry_${PKG_NAME}"
-        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
+        LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
+        MACOSX_RPATH TRUE
+        BUILD_RPATH "${CMAKE_BINARY_DIR}/lib"
+        INSTALL_RPATH "$<IF:$<PLATFORM_ID:Darwin>,@loader_path,$ORIGIN>")
 endfunction()
 
 # Self-contained packages (no cross-runtime dependencies)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ function(add_ry_native_lib PKG_NAME)
         LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
         MACOSX_RPATH TRUE
         BUILD_RPATH "${CMAKE_BINARY_DIR}/lib"
-        INSTALL_RPATH "$<IF:$<PLATFORM_ID:Darwin>,@loader_path,$ORIGIN>")
+        INSTALL_RPATH "$<IF:$<PLATFORM_ID:Darwin>,@loader_path,\$ORIGIN>")
 endfunction()
 
 # Self-contained packages (no cross-runtime dependencies)

--- a/changelog.d/649-native-dynamic-library-loader.md
+++ b/changelog.d/649-native-dynamic-library-loader.md
@@ -1,0 +1,4 @@
+### Added
+
+- Dynamic library loading for `@native("libname")` declarations — the JIT now loads shared libraries at startup (#649)
+- Stdlib runtime packages are built as shared libraries (`.dylib`/`.so`) in addition to the existing static linking (#649)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -172,7 +172,7 @@ These files are automatically loaded as a prelude when the `core/` directory is 
 **Constraints:**
 - `@native` functions must not have a body (no `:` after the signature).
 - Providing a body causes a parse error: `@native function must not have a body`.
-- The declared function must correspond to an existing built-in; otherwise the call will fail at compile time.
+- For bare `@native`, the declared function must correspond to an existing built-in; otherwise the call will fail at compile time. For `@native("libname")`, the function is compiled based on the declared signature and will fail at JIT link time if the symbol cannot be resolved from the loaded library.
 
 **Library specification:**
 - `@native("libname")` specifies that the native function lives in a shared library named `libry_<libname>.dylib` (macOS) or `libry_<libname>.so` (Linux). At JIT startup, the required shared libraries are loaded from the following search paths (in order):

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -104,11 +104,11 @@ a, b = (1, 2)
 
 Declares a function whose implementation is provided by the runtime. The function must not have a body.
 
-An optional string argument specifies the shared library module name for future dynamic loading support. The library name is stored in the signature registry as metadata; it does not affect call resolution in the current version:
+An optional string argument specifies the shared library module name. When a `@native("libname")` function is called, the JIT dynamically loads the corresponding shared library (`libry_<libname>.dylib` on macOS, `libry_<libname>.so` on Linux) and resolves the runtime symbol from it:
 
 ```ry
-@native              # built-in (statically linked)
-@native("base64")    # metadata-only: library name stored for future dynamic loading
+@native              # built-in (statically linked into the process)
+@native("base64")    # dynamically loaded from libry_base64.dylib/.so
 ```
 
 **Basic syntax:**
@@ -174,8 +174,13 @@ These files are automatically loaded as a prelude when the `core/` directory is 
 - Providing a body causes a parse error: `@native function must not have a body`.
 - The declared function must correspond to an existing built-in; otherwise the call will fail at compile time.
 
-**Library specification (metadata-only — loading not yet implemented):**
-- `@native("libname")` specifies that the native function lives in `libry_<libname>.dylib/.so`. The library name is parsed and stored in the signature registry as metadata for future dynamic loading support. In the current version, `@native("libname")` declarations do not affect call resolution — they are not registered for argument-count validation, and same-named built-in functions continue to resolve normally.
+**Library specification:**
+- `@native("libname")` specifies that the native function lives in a shared library named `libry_<libname>.dylib` (macOS) or `libry_<libname>.so` (Linux). At JIT startup, the required shared libraries are loaded from the following search paths (in order):
+  1. `exe/../lib/` — installed layout
+  2. `exe/lib/` — development/build layout
+  3. `$RY_HOME/lib/` — user-installed environment
+- Both `@native` (static) and `@native("libname")` (dynamic) declarations register for argument-count validation and call resolution. The difference is only in how the runtime symbol is provided to the JIT.
+- The runtime function name follows the convention `__ry_<libname>_<fn_name>` (e.g., `@native("base64") fn encode(...)` → `__ry_base64_encode`). This works for both stdlib packages and user-defined native libraries.
 
 ### `@parallel`
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -68,6 +68,10 @@ public:
     const std::unordered_map<std::string, std::vector<NativeFnSignature>>&
     getNativeFnSigs() const { return native_fn_sigs_; }
 
+    // Libraries that must be dynamically loaded at JIT time (demand-driven:
+    // only includes libraries for functions actually called during codegen).
+    const std::unordered_set<std::string>& getRequiredLibraries() const;
+
     // Derive the base runtime function name for a stdlib package function.
     // e.g. ("base64", "encode") → "__ry_base64_encode"
     // For overloaded functions, callers must append an arity suffix
@@ -452,6 +456,15 @@ private:
 
     // @native fn rich signature registry (coexists with native_fn_arg_counts_)
     std::unordered_map<std::string, std::vector<NativeFnSignature>> native_fn_sigs_;
+
+    // Libraries actually used during codegen (populated by dispatch functions).
+    // Only these libraries need to be loaded at JIT startup.
+    std::unordered_set<std::string> used_native_libraries_;
+
+    // Secondary index: fn_name → library names, for @native("libname") functions.
+    // Enables O(1) lookup in emitGenericNativeCall instead of scanning all sigs.
+    // Multiple libraries may declare functions with the same name.
+    std::unordered_map<std::string, std::vector<std::string>> native_lib_index_;
 
     // Derive package name from the source file path of a native function declaration.
     // e.g. "share/std/base64/base64.ry" → "base64", "share/std/builtins.ry" → ""
@@ -958,6 +971,10 @@ private:
                                             const char *package,
                                             const NativeDispatchEntry *table,
                                             size_t table_size);
+    // Generic dispatch for @native("libname") functions not covered by
+    // hardcoded stdlib dispatch tables. Uses the signature registry to
+    // derive the C calling convention from Ry type annotations.
+    llvm::Value *emitGenericNativeCall(const CallExpr &e);
     bool isTcpListener(llvm::Value *val);
     bool isTcpStream(llvm::Value *val);
     bool isTlsStream(llvm::Value *val);

--- a/include/ry/paths.hpp
+++ b/include/ry/paths.hpp
@@ -20,6 +20,16 @@ std::filesystem::path find_share_dir(const std::string &exe_path,
 std::filesystem::path find_share_dir(const std::string &exe_path,
                                      bool skip_global = false);
 
+// Find a native shared library by base name.
+// e.g. "base64" → searches for "libry_base64.dylib" (macOS) or "libry_base64.so" (Linux)
+// Search order:
+// 1. exe/../lib/   (installed layout)
+// 2. exe/lib/      (development layout — build/lib/)
+// 3. $RY_HOME/lib/ (user-installed environment)
+// Returns empty path if not found.
+std::filesystem::path find_native_library(const std::string &exe_path,
+                                          const std::string &lib_name);
+
 struct StdlibManifest {
     std::string version;
     std::vector<std::string> files;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -641,10 +641,7 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
     auto fit = functions_.find(callee);
     if (fit == functions_.end()) {
         if (native_fn_arg_counts_.count(callee)) {
-            codegenError("@native function '" + callee +
-                "' is declared but not handled by any builtin dispatcher. "
-                "Did you forget to add a case in codegen_call_*.cpp "
-                "or add emitBuiltin*() to the dispatch chain in codegen_call.cpp?");
+            codegenError("no matching overload for @native function '" + callee + "'");
         } else {
             codegenError("undefined function: " + callee +
                 " (hint: if this function is defined later in the file, "

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -177,6 +177,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
         }
     }
 
+    // Generic dispatch for @native("libname") functions not covered by
+    // hardcoded stdlib dispatch tables. Placed after struct/lambda/generic
+    // resolution but before user function fallback, and falls through on
+    // type mismatch so user-defined overloads with the same name still work.
+    if (auto *v = emitGenericNativeCall(*e)) return v;
+
     return emitUserFnCall(e->callee, e->args);
 }
 

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -39,30 +39,54 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         if (sigIt == native_fn_sigs_.end())
             return nullptr;  // No sig for this package — fall through
 
+        bool hasArityMatch = false;
+        for (const auto &sig : sigIt->second) {
+            if (sig.params.size() == n) { hasArityMatch = true; break; }
+        }
+        if (!hasArityMatch)
+            return nullptr;  // Arity mismatch — fall through
+
         if (n < 2 || n > 4)
             codegenError(std::string(entry->fn_name) + "() requires 2, 3, or 4 arguments");
 
-        // Match signature by arity
+        // Emit args once, then find the sig whose types match
+        std::vector<llvm::Value *> args;
+        for (size_t i = 0; i < n; i++)
+            args.push_back(emitExpr(*e.args[i]));
+
         const NativeFnSignature *matchedSig = nullptr;
+        std::vector<llvm::Type *> argTypes;
         for (const auto &sig : sigIt->second) {
-            if (sig.params.size() == n) {
+            if (sig.params.size() != n) continue;
+            bool typesMatch = true;
+            std::vector<llvm::Type *> candidateTypes;
+            for (size_t i = 0; i < n; i++) {
+                llvm::Type *expectedTy = resolveType(sig.params[i].type_name);
+                if (args[i]->getType() != expectedTy) {
+                    typesMatch = false;
+                    break;
+                }
+                candidateTypes.push_back(expectedTy);
+            }
+            if (typesMatch) {
                 matchedSig = &sig;
+                argTypes = std::move(candidateTypes);
                 break;
             }
         }
-        if (!matchedSig)
-            return nullptr;  // Arity mismatch — fall through
-
-        std::vector<llvm::Value *> args;
-        std::vector<llvm::Type *> argTypes;
-        for (size_t i = 0; i < n; i++) {
-            llvm::Value *arg = emitExpr(*e.args[i]);
-            llvm::Type *expectedTy = resolveType(matchedSig->params[i].type_name);
-            if (arg->getType() != expectedTy)
-                codegenError(e.callee + "() argument " + std::to_string(i) +
-                             " requires " + matchedSig->params[i].type_name);
-            args.push_back(arg);
-            argTypes.push_back(expectedTy);
+        if (!matchedSig) {
+            for (const auto &sig : sigIt->second) {
+                if (sig.params.size() == n) {
+                    for (size_t i = 0; i < n; i++) {
+                        llvm::Type *expectedTy = resolveType(sig.params[i].type_name);
+                        if (args[i]->getType() != expectedTy)
+                            codegenError(e.callee + "() argument " + std::to_string(i) +
+                                         " requires " + sig.params[i].type_name);
+                    }
+                    break;
+                }
+            }
+            codegenError(e.callee + "() argument type mismatch");
         }
 
         if (!matchedSig->library.empty())
@@ -86,30 +110,57 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     if (sigIt == native_fn_sigs_.end())
         return nullptr;  // No sig for this package — fall through
 
-    const NativeFnSignature *matchedSig = nullptr;
+    // Check if any sig matches the arity before emitting args
+    bool hasArityMatch = false;
     for (const auto &sig : sigIt->second) {
         if (static_cast<int>(sig.params.size()) == entry->arity) {
-            matchedSig = &sig;
+            hasArityMatch = true;
             break;
         }
     }
-    if (!matchedSig)
+    if (!hasArityMatch)
         return nullptr;  // Arity mismatch — fall through
 
     requireArgs(e, static_cast<size_t>(entry->arity));
 
-    // Emit and validate arguments
+    // Emit args once, then find the sig whose types match
     std::vector<llvm::Value *> args;
+    for (int i = 0; i < entry->arity; i++)
+        args.push_back(emitExpr(*e.args[i]));
+
+    const NativeFnSignature *matchedSig = nullptr;
     std::vector<llvm::Type *> paramLLVMTypes;
-    for (int i = 0; i < entry->arity; i++) {
-        llvm::Value *arg = emitExpr(*e.args[i]);
-        const std::string &expectedTN = matchedSig->params[i].type_name;
-        llvm::Type *expectedTy = resolveType(expectedTN);
-        if (arg->getType() != expectedTy)
-            codegenError(e.callee + "() argument " + std::to_string(i) +
-                         " requires " + expectedTN);
-        args.push_back(arg);
-        paramLLVMTypes.push_back(expectedTy);
+    for (const auto &sig : sigIt->second) {
+        if (static_cast<int>(sig.params.size()) != entry->arity) continue;
+        bool typesMatch = true;
+        std::vector<llvm::Type *> candidateTypes;
+        for (int i = 0; i < entry->arity; i++) {
+            llvm::Type *expectedTy = resolveType(sig.params[i].type_name);
+            if (args[i]->getType() != expectedTy) {
+                typesMatch = false;
+                break;
+            }
+            candidateTypes.push_back(expectedTy);
+        }
+        if (typesMatch) {
+            matchedSig = &sig;
+            paramLLVMTypes = std::move(candidateTypes);
+            break;
+        }
+    }
+    if (!matchedSig) {
+        for (const auto &sig : sigIt->second) {
+            if (static_cast<int>(sig.params.size()) == entry->arity) {
+                for (int i = 0; i < entry->arity; i++) {
+                    llvm::Type *expectedTy = resolveType(sig.params[i].type_name);
+                    if (args[i]->getType() != expectedTy)
+                        codegenError(e.callee + "() argument " + std::to_string(i) +
+                                     " requires " + sig.params[i].type_name);
+                }
+                break;
+            }
+        }
+        codegenError(e.callee + "() argument type mismatch");
     }
 
     if (!matchedSig->library.empty())

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -31,25 +31,27 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     // --- Special case: variadic arity (e.g. path::join) ---
     if (entry->arity == -1) {
         size_t n = e.args.size();
+
+        // Check sig key BEFORE arity validation so that a name collision
+        // with a different-library function falls through instead of erroring.
+        std::string sigKey = nativeSigKey(package, e.callee);
+        auto sigIt = native_fn_sigs_.find(sigKey);
+        if (sigIt == native_fn_sigs_.end())
+            return nullptr;  // No sig for this package — fall through
+
         if (n < 2 || n > 4)
             codegenError(std::string(entry->fn_name) + "() requires 2, 3, or 4 arguments");
 
-        // Match signature by arity (same validation as fixed-arity path)
-        std::string sigKey = nativeSigKey(package, e.callee);
-        auto sigIt = native_fn_sigs_.find(sigKey);
+        // Match signature by arity
         const NativeFnSignature *matchedSig = nullptr;
-        if (sigIt != native_fn_sigs_.end()) {
-            for (const auto &sig : sigIt->second) {
-                if (sig.params.size() == n) {
-                    matchedSig = &sig;
-                    break;
-                }
+        for (const auto &sig : sigIt->second) {
+            if (sig.params.size() == n) {
+                matchedSig = &sig;
+                break;
             }
         }
         if (!matchedSig)
-            codegenError(std::string(package) + "::" + e.callee +
-                         " has no @native signature with arity " +
-                         std::to_string(n));
+            return nullptr;  // Arity mismatch — fall through
 
         std::vector<llvm::Value *> args;
         std::vector<llvm::Type *> argTypes;
@@ -63,6 +65,9 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
             argTypes.push_back(expectedTy);
         }
 
+        if (!matchedSig->library.empty())
+            used_native_libraries_.insert(matchedSig->library);
+
         std::string rtName = deriveRuntimeFnName(package, rtSuffix)
             + std::to_string(n);
         auto *fnTy = llvm::FunctionType::get(
@@ -72,24 +77,26 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     }
 
     // --- Normal path ---
-    requireArgs(e, static_cast<size_t>(entry->arity));
 
-    // Look up NativeFnSignature matching this call's arity
+    // Look up NativeFnSignature matching this call's arity.
+    // Check sig key BEFORE requireArgs so that a name collision with a
+    // different-library function falls through instead of erroring.
     std::string sigKey = nativeSigKey(package, e.callee);
     auto sigIt = native_fn_sigs_.find(sigKey);
+    if (sigIt == native_fn_sigs_.end())
+        return nullptr;  // No sig for this package — fall through
+
     const NativeFnSignature *matchedSig = nullptr;
-    if (sigIt != native_fn_sigs_.end()) {
-        for (const auto &sig : sigIt->second) {
-            if (static_cast<int>(sig.params.size()) == entry->arity) {
-                matchedSig = &sig;
-                break;
-            }
+    for (const auto &sig : sigIt->second) {
+        if (static_cast<int>(sig.params.size()) == entry->arity) {
+            matchedSig = &sig;
+            break;
         }
     }
     if (!matchedSig)
-        codegenError(std::string(package) + "::" + e.callee +
-                     " has no @native signature with arity " +
-                     std::to_string(entry->arity));
+        return nullptr;  // Arity mismatch — fall through
+
+    requireArgs(e, static_cast<size_t>(entry->arity));
 
     // Emit and validate arguments
     std::vector<llvm::Value *> args;
@@ -104,6 +111,9 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         args.push_back(arg);
         paramLLVMTypes.push_back(expectedTy);
     }
+
+    if (!matchedSig->library.empty())
+        used_native_libraries_.insert(matchedSig->library);
 
     // Derive runtime function name
     std::string rtName = deriveRuntimeFnName(package, rtSuffix);
@@ -198,4 +208,216 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     }
 
     llvm_unreachable("unhandled ReturnWrapping variant");
+}
+
+// ===== Generic dispatch for @native("libname") functions =====
+//
+// This handles calls to functions declared with @native("libname") that are
+// NOT covered by the hardcoded stdlib dispatch tables. It uses the signature
+// registry to derive the C calling convention from the Ry type annotations.
+
+namespace {
+
+// Infer the ReturnWrapping from the Ry return type name.
+// Returns {wrapping, out_param_type_name} where out_param_type_name is non-empty
+// only for ResultOutParam.
+std::pair<CodeGen::ReturnWrapping, std::string>
+inferReturnWrapping(const std::string &returnType) {
+    using RW = CodeGen::ReturnWrapping;
+
+    // Result<T, Error> patterns
+    if (returnType.size() > 7 && returnType.substr(0, 7) == "Result<") {
+        // Extract the Ok type from Result<OkType, Error>, handling nested
+        // generics like Result<Map<K, V>, Error> by counting bracket depth.
+        int depth = 0;
+        size_t commaPos = std::string::npos;
+        for (size_t i = 7; i < returnType.size(); ++i) {
+            if (returnType[i] == '<') ++depth;
+            else if (returnType[i] == '>') --depth;
+            else if (returnType[i] == ',' && depth == 0) { commaPos = i; break; }
+        }
+        if (commaPos == std::string::npos) return {RW::Direct, ""};
+        std::string okType = returnType.substr(7, commaPos - 7);
+        while (!okType.empty() && okType.back() == ' ') okType.pop_back();
+
+        if (okType == "Unit")  return {RW::ResultStatus, ""};
+        if (okType == "int")   return {RW::ResultOutParam, "int"};
+        if (okType == "float") return {RW::ResultOutParam, "float"};
+        if (okType == "bool")  return {RW::ResultOutParam, "int"};
+        // str, List<...>, Map<...>, or any pointer type → ResultPtr
+        return {RW::ResultPtr, ""};
+    }
+
+    if (returnType == "bool") return {RW::BoolFromI64, ""};
+
+    // str, int, float, Unit, or any other type → Direct
+    return {RW::Direct, ""};
+}
+
+} // namespace
+
+llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
+    // O(1) lookup via secondary index: fn_name → candidate library names
+    auto libIt = native_lib_index_.find(e.callee);
+    if (libIt == native_lib_index_.end())
+        return nullptr;
+
+    // Emit args once, then try each candidate library for a type match.
+    // This avoids committing to the first arity match when a different
+    // library's signature may match the actual argument types.
+    std::vector<llvm::Value *> args;
+    for (size_t i = 0; i < e.args.size(); i++)
+        args.push_back(emitExpr(*e.args[i]));
+
+    const NativeFnSignature *matchedSig = nullptr;
+    std::string matchedPackage;
+    std::vector<llvm::Type *> paramTypes;
+    for (const auto &lib : libIt->second) {
+        std::string sigKey = nativeSigKey(lib, e.callee);
+        auto sigIt = native_fn_sigs_.find(sigKey);
+        if (sigIt == native_fn_sigs_.end()) continue;
+        for (const auto &sig : sigIt->second) {
+            if (sig.params.size() != e.args.size()) continue;
+            bool typesMatch = true;
+            std::vector<llvm::Type *> candidateTypes;
+            for (size_t i = 0; i < args.size(); i++) {
+                llvm::Type *expectedTy = resolveType(sig.params[i].type_name);
+                if (args[i]->getType() != expectedTy) {
+                    typesMatch = false;
+                    break;
+                }
+                candidateTypes.push_back(expectedTy);
+            }
+            if (typesMatch) {
+                matchedSig = &sig;
+                matchedPackage = lib;
+                paramTypes = std::move(candidateTypes);
+                break;
+            }
+        }
+        if (matchedSig) break;
+    }
+
+    // No library matched both arity and types — fall through to user functions
+    if (!matchedSig) return nullptr;
+
+    used_native_libraries_.insert(matchedSig->library);
+
+    // Derive runtime function name: __ry_<package>_<fn_name>
+    std::string rtName = deriveRuntimeFnName(matchedPackage, e.callee);
+
+    // Determine C-level calling convention from the Ry return type
+    auto [wrapping, outParamType] = inferReturnWrapping(matchedSig->return_type_name);
+
+    // Error function name for Result wrappings
+    std::string errFnName = deriveRuntimeFnName(matchedPackage, "get_last_error");
+
+    // Build C-level return type and handle out-param
+    llvm::Type *outTy = nullptr;
+    llvm::Type *cRetTy;
+
+    switch (wrapping) {
+    case ReturnWrapping::Direct:
+        cRetTy = resolveType(matchedSig->return_type_name);
+        break;
+    case ReturnWrapping::ResultPtr:
+        cRetTy = ptrTy_;
+        break;
+    case ReturnWrapping::ResultStatus:
+    case ReturnWrapping::BoolFromI64:
+        cRetTy = i64Ty_;
+        break;
+    case ReturnWrapping::ResultOutParam:
+        outTy = resolveType(outParamType);
+        paramTypes.push_back(ptrTy_);
+        cRetTy = i64Ty_;
+        break;
+    case ReturnWrapping::ResultPtrWithListMeta:
+        llvm_unreachable("ResultPtrWithListMeta not used in generic native dispatch");
+    }
+
+    // Create alloca for out-param
+    llvm::AllocaInst *outSlot = nullptr;
+    if (wrapping == ReturnWrapping::ResultOutParam) {
+        outSlot = builder_.CreateAlloca(outTy, nullptr, e.callee + "_out");
+        args.push_back(outSlot);
+    }
+
+    // Emit the call
+    auto *fnTy = llvm::FunctionType::get(cRetTy, paramTypes, false);
+    auto fn = mod_->getOrInsertFunction(rtName, fnTy);
+    llvm::Value *callResult;
+    if (cRetTy->isVoidTy())
+        callResult = builder_.CreateCall(fn, args);
+    else
+        callResult = builder_.CreateCall(fn, args, e.callee);
+
+    // Apply return wrapping
+    llvm::Value *result;
+    switch (wrapping) {
+    case ReturnWrapping::Direct:
+        if (cRetTy->isVoidTy())
+            return llvm::ConstantInt::get(i8Ty_, 0);
+        result = callResult;
+        break;
+
+    case ReturnWrapping::ResultPtr:
+        result = wrapPtrAsResult(callResult, errFnName.c_str());
+        break;
+
+    case ReturnWrapping::ResultStatus:
+        result = wrapStatusAsResult(callResult, errFnName.c_str());
+        break;
+
+    case ReturnWrapping::BoolFromI64:
+        return builder_.CreateTrunc(callResult, i1Ty_, e.callee + "_bool");
+
+    case ReturnWrapping::ResultOutParam: {
+        llvm::Value *isErr = builder_.CreateICmpNE(callResult,
+            llvm::ConstantInt::get(i64Ty_, 0), e.callee + "_err");
+
+        bool isBoolResult = (matchedSig->return_type_name.find("Result<bool") == 0);
+        llvm::Type *okTy = isBoolResult ? i1Ty_ : outTy;
+        llvm::StructType *resTy = getResultType(okTy, errorTy_);
+        result = emitResultBranch(isErr, resTy,
+            [&]() {
+                llvm::Value *loaded = builder_.CreateLoad(outTy, outSlot, e.callee + "_val");
+                if (isBoolResult)
+                    loaded = builder_.CreateTrunc(loaded, i1Ty_, e.callee + "_bool");
+                return buildOkValue(loaded, resTy);
+            },
+            [&]() {
+                return buildErrValue(
+                    buildErrorFromRuntime(errFnName.c_str()), resTy);
+            });
+        break;
+    }
+
+    case ReturnWrapping::ResultPtrWithListMeta:
+        llvm_unreachable("ResultPtrWithListMeta not used in generic native dispatch");
+    }
+
+    // Propagate collection type metadata from the Ry return type annotation.
+    // For Result<T, Error>, propagate the metadata of the inner Ok type T
+    // onto the Result value so downstream operations can inspect elements.
+    const std::string &retType = matchedSig->return_type_name;
+    if (retType.size() > 7 && retType.compare(0, 7, "Result<") == 0) {
+        // Extract Ok type using the same depth-aware comma finder as inferReturnWrapping
+        int depth = 0;
+        size_t commaPos = std::string::npos;
+        for (size_t i = 7; i < retType.size(); ++i) {
+            if (retType[i] == '<') ++depth;
+            else if (retType[i] == '>') --depth;
+            else if (retType[i] == ',' && depth == 0) { commaPos = i; break; }
+        }
+        if (commaPos != std::string::npos) {
+            std::string okType = retType.substr(7, commaPos - 7);
+            while (!okType.empty() && okType.back() == ' ') okType.pop_back();
+            propagateTypeMeta(okType, result);
+        }
+    } else {
+        propagateTypeMeta(retType, result);
+    }
+
+    return result;
 }

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -356,6 +356,15 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
 
     used_native_libraries_.insert(matchedSig->library);
 
+    // Adjust bool params to match C ABI: native functions pass bools as i64.
+    // Widen i1→i64 in both the prototype and the arg values.
+    for (size_t i = 0; i < paramTypes.size(); i++) {
+        if (paramTypes[i] == i1Ty_) {
+            args[i] = builder_.CreateZExt(args[i], i64Ty_, "bool_zext");
+            paramTypes[i] = i64Ty_;
+        }
+    }
+
     // Derive runtime function name: __ry_<package>_<fn_name>
     std::string rtName = deriveRuntimeFnName(matchedPackage, e.callee);
 

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -289,13 +289,15 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
                 candidateTypes.push_back(expectedTy);
             }
             if (typesMatch) {
+                if (matchedSig)
+                    codegenError("ambiguous @native call: '" + e.callee +
+                                 "' matches both @native(\"" + matchedPackage +
+                                 "\") and @native(\"" + lib + "\")");
                 matchedSig = &sig;
                 matchedPackage = lib;
                 paramTypes = std::move(candidateTypes);
-                break;
             }
         }
-        if (matchedSig) break;
     }
 
     // No library matched both arity and types — fall through to user functions

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -354,7 +354,7 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     // No library matched both arity and types — fall through to user functions
     if (!matchedSig) return nullptr;
 
-    used_native_libraries_.insert(matchedSig->library);
+    used_native_libraries_.insert(matchedPackage);
 
     // Adjust bool params to match C ABI: native functions pass bools as i64.
     // Widen i1→i64 in both the prototype and the arg values.

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -14,6 +14,10 @@ std::string CodeGen::deriveRuntimeFnName(const std::string &package,
     return "__ry_" + package + "_" + fn_name;
 }
 
+const std::unordered_set<std::string>& CodeGen::getRequiredLibraries() const {
+    return used_native_libraries_;
+}
+
 std::string CodeGen::deriveNativePackage(const SourceLocation &loc) const {
     if (!sm_ || loc.file_id < 0 || loc.file_id >= sm_->getFileCount())
         return "";
@@ -404,17 +408,30 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         sig.library = getDirectivePositionalArg(s->directives, "native");
         sig.params.reserve(s->params.size());
 
-        // Only register in builtin dispatch when no library is specified.
-        // @native("libname") declarations are metadata-only until dynamic
-        // loading is implemented — they do not affect call resolution.
-        if (sig.library.empty())
-            native_fn_arg_counts_[s->name].push_back(s->params.size());
+        // Register in builtin dispatch for both bare @native and @native("libname").
+        // For @native("libname"), the JIT resolves symbols from dynamically loaded
+        // shared libraries; for bare @native, symbols come from static linking.
+        native_fn_arg_counts_[s->name].push_back(s->params.size());
         for (auto &p : s->params)
             sig.params.push_back({p.name, p.type ? p.type->toString() : ""});
         sig.return_type_name = s->return_type ? s->return_type->toString() : "Unit";
         for (auto &d : s->directives)
             sig.directive_names.push_back(d.name);
-        native_fn_sigs_[nativeSigKey(sig.package, sig.name)].push_back(std::move(sig));
+
+        // For registry key: use library name as package when the source file
+        // is not under std/<pkg>/. This ensures @native("base64") fn encode(...)
+        // in user code registers under "base64::encode", matching what the
+        // table-driven dispatchers expect.
+        std::string effectivePackage = sig.package.empty() && !sig.library.empty()
+            ? sig.library : sig.package;
+        // Populate secondary index for O(1) lookup in emitGenericNativeCall
+        if (!sig.library.empty()) {
+            auto &libs = native_lib_index_[sig.name];
+            if (std::find(libs.begin(), libs.end(), sig.library) == libs.end())
+                libs.push_back(sig.library);
+        }
+
+        native_fn_sigs_[nativeSigKey(effectivePackage, sig.name)].push_back(std::move(sig));
         return;
     }
 

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -431,7 +431,19 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
                 libs.push_back(sig.library);
         }
 
-        native_fn_sigs_[nativeSigKey(effectivePackage, sig.name)].push_back(std::move(sig));
+        // Deduplicate: skip if a signature with the same arity already exists
+        // under this key. This prevents duplicate entries when a user declares
+        // @native("base64") fn encode(str) alongside `from base64 import encode`.
+        auto &sigVec = native_fn_sigs_[nativeSigKey(effectivePackage, sig.name)];
+        bool duplicate = false;
+        for (const auto &existing : sigVec) {
+            if (existing.params.size() == sig.params.size()) {
+                duplicate = true;
+                break;
+            }
+        }
+        if (!duplicate)
+            sigVec.push_back(std::move(sig));
         return;
     }
 

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -431,16 +431,23 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
                 libs.push_back(sig.library);
         }
 
-        // Deduplicate: skip if a signature with the same arity already exists
-        // under this key. This prevents duplicate entries when a user declares
-        // @native("base64") fn encode(str) alongside `from base64 import encode`.
+        // Deduplicate: skip if an identical signature (same arity AND types)
+        // already exists under this key. This prevents duplicate entries when
+        // a user declares @native("base64") fn encode(str) alongside
+        // `from base64 import encode`, while preserving valid type-based
+        // overloads like encode(str) and encode(int).
         auto &sigVec = native_fn_sigs_[nativeSigKey(effectivePackage, sig.name)];
         bool duplicate = false;
         for (const auto &existing : sigVec) {
-            if (existing.params.size() == sig.params.size()) {
-                duplicate = true;
-                break;
+            if (existing.params.size() != sig.params.size()) continue;
+            bool same = true;
+            for (size_t i = 0; i < sig.params.size(); ++i) {
+                if (existing.params[i].type_name != sig.params[i].type_name) {
+                    same = false;
+                    break;
+                }
             }
+            if (same) { duplicate = true; break; }
         }
         if (!duplicate)
             sigVec.push_back(std::move(sig));

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -1,6 +1,7 @@
 #include "ry/codegen.hpp"
 #include "ry/diagnostic.hpp"
 #include "ry/sema_return.hpp"
+#include <algorithm>
 #include <filesystem>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -234,8 +234,8 @@ static int runRySource(const std::string &src, const std::string &source_name,
         // Resolve the executable path for reliable exe-relative library search.
         // argv0 may be a bare name (e.g. "ry" from PATH), so resolve it first.
         std::string resolvedExe = ry::self_update::detail::get_executable_path();
-        const std::string &exeForLibSearch = resolvedExe.empty()
-            ? std::string(argv0) : resolvedExe;
+        if (resolvedExe.empty()) resolvedExe = argv0;
+        const std::string &exeForLibSearch = resolvedExe;
         auto requiredLibs = cg.getRequiredLibraries();
         for (const auto &libName : requiredLibs) {
             auto libPath = ry::find_native_library(exeForLibSearch, libName);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -229,6 +229,36 @@ static int runRySource(const std::string &src, const std::string &source_name,
     }
     mainJD.addGenerator(std::move(*dlsg));
 
+    // Load dynamic libraries required by @native("libname") declarations
+    {
+        auto requiredLibs = cg.getRequiredLibraries();
+        for (const auto &libName : requiredLibs) {
+            auto libPath = ry::find_native_library(argv0, libName);
+            if (libPath.empty()) {
+                errs() << "Error: native library '" << libName
+                       << "' not found (searched exe/../lib/, exe/lib/, $RY_HOME/lib/)\n";
+                ry::emitTraceEvent("runtime.error", "jit", &sourceLoc,
+                                   {ry::TraceField("detail", "native library not found: " + libName)});
+                return 1;
+            }
+            if (ry::traceEnabled())
+                ry::emitTraceEvent("jit.load_library", "jit", &sourceLoc,
+                                   {ry::TraceField("library", libName),
+                                    ry::TraceField("path", libPath.string())});
+            auto libGen = DynamicLibrarySearchGenerator::Load(
+                libPath.string().c_str(),
+                jit->getDataLayout().getGlobalPrefix());
+            if (!libGen) {
+                errs() << "Failed to load native library '" << libName << "': ";
+                logAllUnhandledErrors(libGen.takeError(), errs());
+                ry::emitTraceEvent("runtime.error", "jit", &sourceLoc,
+                                   {ry::TraceField("detail", "Failed to load library: " + libName)});
+                return 1;
+            }
+            mainJD.addGenerator(std::move(*libGen));
+        }
+    }
+
     // Register test runtime symbols if in test mode
     if (test_mode) {
         auto &es = jit->getExecutionSession();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -231,9 +231,14 @@ static int runRySource(const std::string &src, const std::string &source_name,
 
     // Load dynamic libraries required by @native("libname") declarations
     {
+        // Resolve the executable path for reliable exe-relative library search.
+        // argv0 may be a bare name (e.g. "ry" from PATH), so resolve it first.
+        std::string resolvedExe = ry::self_update::detail::get_executable_path();
+        const std::string &exeForLibSearch = resolvedExe.empty()
+            ? std::string(argv0) : resolvedExe;
         auto requiredLibs = cg.getRequiredLibraries();
         for (const auto &libName : requiredLibs) {
-            auto libPath = ry::find_native_library(argv0, libName);
+            auto libPath = ry::find_native_library(exeForLibSearch, libName);
             if (libPath.empty()) {
                 errs() << "Error: native library '" << libName
                        << "' not found (searched exe/../lib/, exe/lib/, $RY_HOME/lib/)\n";

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -179,18 +179,18 @@ fs::path find_native_library(const std::string &exe_path,
     if (!ec) {
         // 1. exe/../lib/ (installed layout)
         fs::path candidate = exe_dir.parent_path() / "lib" / filename;
-        if (fs::exists(candidate))
+        if (fs::is_regular_file(candidate))
             return candidate;
 
         // 2. exe/lib/ (development layout — e.g. build/lib/)
         candidate = exe_dir / "lib" / filename;
-        if (fs::exists(candidate))
+        if (fs::is_regular_file(candidate))
             return candidate;
     }
 
     // 3. $RY_HOME/lib/
     fs::path ry_home_lib = get_ry_home() / "lib" / filename;
-    if (fs::exists(ry_home_lib))
+    if (fs::is_regular_file(ry_home_lib))
         return ry_home_lib;
 
     return {};

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -165,4 +165,35 @@ void write_manifest(const fs::path &dir,
     out << "]\n}\n";
 }
 
+fs::path find_native_library(const std::string &exe_path,
+                              const std::string &lib_name) {
+#ifdef __APPLE__
+    std::string filename = "libry_" + lib_name + ".dylib";
+#else
+    std::string filename = "libry_" + lib_name + ".so";
+#endif
+
+    std::error_code ec;
+    fs::path exe_dir = fs::path(exe_path).parent_path();
+    exe_dir = fs::canonical(exe_dir, ec);
+    if (!ec) {
+        // 1. exe/../lib/ (installed layout)
+        fs::path candidate = exe_dir.parent_path() / "lib" / filename;
+        if (fs::exists(candidate))
+            return candidate;
+
+        // 2. exe/lib/ (development layout — e.g. build/lib/)
+        candidate = exe_dir / "lib" / filename;
+        if (fs::exists(candidate))
+            return candidate;
+    }
+
+    // 3. $RY_HOME/lib/
+    fs::path ry_home_lib = get_ry_home() / "lib" / filename;
+    if (fs::exists(ry_home_lib))
+        return ry_home_lib;
+
+    return {};
+}
+
 } // namespace ry

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -363,7 +363,7 @@ TEST_F(CodeGenTest, NativeFunctionMissingDispatcher) {
         FAIL() << "Expected exception for unhandled @native function";
     } catch (const std::runtime_error &e) {
         std::string msg = e.what();
-        EXPECT_NE(msg.find("not handled by any builtin dispatcher"), std::string::npos)
+        EXPECT_NE(msg.find("no matching overload for @native function"), std::string::npos)
             << "Error was: " << msg;
     }
 }

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -508,12 +508,10 @@ TEST_F(DirectiveTest, CoreStrDeclarationsWork) {
 
 // ===== @native("libname") directive syntax tests =====
 
-TEST_F(DirectiveTest, NativeFnLibraryNameCollisionWithStdlib) {
-    // A function named "encode" declared with @native("mylib") must NOT be
-    // misrouted to the hardcoded base64 dispatcher. The stdlib dispatcher
-    // should fall through and let the generic dispatcher handle it.
-    // Here we use @native("base64") to prove it dispatches correctly via
-    // the generic path even when the function name exists in a stdlib table.
+TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchForStdlibName) {
+    // A user-declared @native("base64") fn encode(str) → str (not imported
+    // from stdlib) is handled by the table-driven base64 dispatcher because
+    // the sig key "base64::encode" matches. Verifies the function is callable.
     std::string output = runSource(
         "@native(\"base64\")\n"
         "function encode(data: str) -> str\n"

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -10,6 +10,17 @@ extern "C" const char *__ry_testlib_greet(const char *name) {
     return strdup(buf);
 }
 
+// Result<bool, Error> test symbol: returns status 0 (ok) with bool out-param.
+extern "C" int64_t __ry_testlib_check(const char *s, int64_t *out) {
+    *out = (strcmp(s, "yes") == 0) ? 1 : 0;
+    return 0;  // 0 = success
+}
+
+static thread_local char testlib_err_buf[64] = {0};
+extern "C" const char *__ry_testlib_get_last_error() {
+    return strdup(testlib_err_buf);
+}
+
 class DirectiveTest : public CodeGenTest {};
 
 // --- deriveRuntimeFnName tests ---
@@ -618,18 +629,19 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchBool) {
 }
 
 TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchResultBool) {
-    // Result<bool, Error> must use ResultOutParam with i64 out-param,
-    // then truncate to i1. Verifies the codegen doesn't crash or miscompile.
-    // We compile-only since no matching C function exists in the test harness.
-    EXPECT_NO_THROW(compileSource(
-        "@native(\"mylib\")\n"
+    // Result<bool, Error> via the generic dispatch path with a real
+    // runtime symbol (__ry_testlib_check). Exercises the full ResultOutParam
+    // ABI: i64 status, i64 out-param, and the final i64→i1 truncation.
+    std::string output = runSource(
+        "@native(\"testlib\")\n"
         "function check(s: str) -> Result<bool, Error>\n"
-        "match check(\"test\"):\n"
+        "match check(\"yes\"):\n"
         "    case Ok(b):\n"
         "        print(b)\n"
         "    case Err(e):\n"
         "        print(e.message)\n"
-    ));
+    );
+    EXPECT_EQ(output, "true\n");
 }
 
 // ===== @inline tests =====

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1,4 +1,14 @@
 #include "test_codegen_common.hpp"
+#include <cstring>
+
+// Test-only native symbol for exercising the generic dispatch path.
+// This is NOT covered by any hardcoded stdlib dispatcher, so calls
+// to @native("testlib") fn greet(str) MUST go through emitGenericNativeCall.
+extern "C" const char *__ry_testlib_greet(const char *name) {
+    static thread_local char buf[256];
+    snprintf(buf, sizeof(buf), "hello %s", name);
+    return strdup(buf);
+}
 
 class DirectiveTest : public CodeGenTest {};
 
@@ -558,11 +568,21 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchFallsThrough) {
 
 // ===== @native("libname") generic dispatch tests =====
 
+TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchEndToEnd) {
+    // This test exercises the FULL generic dispatch path with a symbol
+    // (__ry_testlib_greet) that is NOT covered by any hardcoded stdlib
+    // dispatcher. The call MUST go through emitGenericNativeCall.
+    std::string output = runSource(
+        "@native(\"testlib\")\n"
+        "function greet(name: str) -> str\n"
+        "print(greet(\"world\"))\n"
+    );
+    EXPECT_EQ(output, "hello world\n");
+}
+
 TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchDirect) {
-    // @native("base64") fn encode(data: str) -> str dispatches through the
-    // generic path (not the hardcoded base64 dispatch table) because the
-    // source is not under std/base64/. The runtime symbol __ry_base64_encode
-    // is resolved from the process (statically linked).
+    // @native("base64") fn encode(data: str) -> str — the sig key
+    // "base64::encode" is found by the table-driven base64 dispatcher.
     std::string output = runSource(
         "@native(\"base64\")\n"
         "function encode(data: str) -> str\n"

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -134,7 +134,9 @@ TEST(NativeFnSigs, LibraryFieldParsed) {
 }
 
 TEST(NativeFnSigs, LibraryFieldStoredAtCodegen) {
-    // @native("base64") stores library name in registry
+    // @native("base64") stores library name in registry.
+    // The registry key uses the library name as package when the source
+    // file is not under std/<pkg>/ (i.e., deriveNativePackage returns "").
     std::string src =
         "@native(\"base64\")\n"
         "function encode(data: str) -> str\n";
@@ -147,8 +149,9 @@ TEST(NativeFnSigs, LibraryFieldStoredAtCodegen) {
     cg.compile(prog);
 
     auto &sigs = cg.getNativeFnSigs();
-    ASSERT_TRUE(sigs.count("encode"));
-    EXPECT_EQ(sigs.at("encode")[0].library, "base64");
+    // Key is "base64::encode" (library used as effective package)
+    ASSERT_TRUE(sigs.count("base64::encode"));
+    EXPECT_EQ(sigs.at("base64::encode")[0].library, "base64");
 }
 
 TEST(NativeFnSigs, LibraryFieldEmptyForBareNative) {
@@ -166,6 +169,63 @@ TEST(NativeFnSigs, LibraryFieldEmptyForBareNative) {
     auto &sigs = cg.getNativeFnSigs();
     ASSERT_TRUE(sigs.count("contains"));
     EXPECT_EQ(sigs.at("contains")[0].library, "");
+}
+
+TEST(NativeFnSigs, GetRequiredLibrariesOnlyIncludesCalledFunctions) {
+    // Declares functions from "base64" and "path" libraries, but only calls
+    // the base64 function. getRequiredLibraries() should return only "base64".
+    std::string src =
+        "@native(\"base64\")\n"
+        "function encode(data: str) -> str\n"
+        "@native(\"path\")\n"
+        "function basename(p: str) -> str\n"
+        "print(encode(\"Hello\"))\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    auto &libs = cg.getRequiredLibraries();
+    ASSERT_EQ(libs.size(), 1u);
+    EXPECT_TRUE(libs.count("base64"));
+}
+
+TEST(NativeFnSigs, GetRequiredLibrariesEmptyWhenNothingCalled) {
+    // Declares @native("libname") functions but doesn't call any.
+    // getRequiredLibraries() should return empty (demand-driven loading).
+    std::string src =
+        "@native(\"base64\")\n"
+        "function encode(data: str) -> str\n"
+        "print(\"no native calls\")\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    auto &libs = cg.getRequiredLibraries();
+    EXPECT_TRUE(libs.empty());
+}
+
+TEST(NativeFnSigs, GetRequiredLibrariesEmptyForBareNative) {
+    std::string src =
+        "@native\n"
+        "function contains(s: str, sub: str) -> bool\n";
+
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    CodeGen cg;
+    cg.compile(prog);
+
+    auto &libs = cg.getRequiredLibraries();
+    EXPECT_TRUE(libs.empty());
 }
 
 // 1. @deprecated function called -> warning, execution normal
@@ -448,9 +508,23 @@ TEST_F(DirectiveTest, CoreStrDeclarationsWork) {
 
 // ===== @native("libname") directive syntax tests =====
 
+TEST_F(DirectiveTest, NativeFnLibraryNameCollisionWithStdlib) {
+    // A function named "encode" declared with @native("mylib") must NOT be
+    // misrouted to the hardcoded base64 dispatcher. The stdlib dispatcher
+    // should fall through and let the generic dispatcher handle it.
+    // Here we use @native("base64") to prove it dispatches correctly via
+    // the generic path even when the function name exists in a stdlib table.
+    std::string output = runSource(
+        "@native(\"base64\")\n"
+        "function encode(data: str) -> str\n"
+        "print(encode(\"test\"))\n"
+    );
+    EXPECT_EQ(output, "dGVzdA==\n");
+}
+
 TEST_F(DirectiveTest, NativeFnLibraryDeclarationOnly) {
-    // @native("libname") declaration is accepted but does not register
-    // for builtin dispatch. The function is only in the signature registry.
+    // @native("libname") declaration is accepted and registered for dispatch.
+    // Without calling the function, the declaration alone is valid.
     std::string output = runSource(
         "@native(\"base64\")\n"
         "function encode(data: str) -> str\n"
@@ -459,15 +533,85 @@ TEST_F(DirectiveTest, NativeFnLibraryDeclarationOnly) {
     EXPECT_EQ(output, "ok\n");
 }
 
-TEST_F(DirectiveTest, NativeFnLibraryDoesNotAffectDispatch) {
-    // @native("libname") is metadata-only — it does not register for
-    // builtin arg-count validation, but same-named builtins still resolve.
+TEST_F(DirectiveTest, NativeFnLibraryDoesNotShadowBuiltin) {
+    // @native("libname") registers for dispatch but does not shadow
+    // built-in functions with the same name.
     std::string output = runSource(
         "@native(\"base64\")\n"
         "function contains(s: str, sub: str) -> bool\n"
         "print(contains(\"hello\", \"ell\"))\n"
     );
     EXPECT_EQ(output, "true\n");
+}
+
+TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchFallsThrough) {
+    // The generic native dispatch (for non-stdlib @native("libname")) falls
+    // through on type mismatch, letting user-defined overloads handle the call.
+    // This uses "mylib" (not a stdlib name) so it goes through the generic path.
+    std::string output = runSource(
+        "@native(\"mylib\")\n"
+        "function greet(name: str) -> str\n"
+        "function greet(x: int) -> str:\n"
+        "    return \"int:\" + to_str(x)\n"
+        "print(greet(42))\n"
+    );
+    EXPECT_EQ(output, "int:42\n");
+}
+
+// ===== @native("libname") generic dispatch tests =====
+
+TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchDirect) {
+    // @native("base64") fn encode(data: str) -> str dispatches through the
+    // generic path (not the hardcoded base64 dispatch table) because the
+    // source is not under std/base64/. The runtime symbol __ry_base64_encode
+    // is resolved from the process (statically linked).
+    std::string output = runSource(
+        "@native(\"base64\")\n"
+        "function encode(data: str) -> str\n"
+        "print(encode(\"Hello\"))\n"
+    );
+    EXPECT_EQ(output, "SGVsbG8=\n");
+}
+
+TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchResultPtr) {
+    // @native("base64") fn decode(data: str) -> Result<str, Error>
+    // Tests ResultPtr wrapping in the generic dispatch path.
+    std::string output = runSource(
+        "@native(\"base64\")\n"
+        "function decode(data: str) -> Result<str, Error>\n"
+        "match decode(\"SGVsbG8=\"):\n"
+        "    case Ok(s):\n"
+        "        print(s)\n"
+        "    case Err(e):\n"
+        "        print(e.message)\n"
+    );
+    EXPECT_EQ(output, "Hello\n");
+}
+
+TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchBool) {
+    // Tests BoolFromI64 wrapping in the generic dispatch path.
+    std::string output = runSource(
+        "@native(\"path\")\n"
+        "function is_absolute(p: str) -> bool\n"
+        "print(is_absolute(\"/usr/bin\"))\n"
+        "print(is_absolute(\"relative\"))\n"
+    );
+    EXPECT_EQ(output, "true\nfalse\n");
+}
+
+TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchResultBool) {
+    // Result<bool, Error> must use ResultOutParam with i64 out-param,
+    // then truncate to i1. Verifies the codegen doesn't crash or miscompile.
+    // We compile-only since no matching C function exists in the test harness.
+    EXPECT_NO_THROW(compileSource(
+        "@native(\"mylib\")\n"
+        "function check(s: str) -> Result<bool, Error>\n"
+        "match check(\"test\"):\n"
+        "    case Ok(b):\n"
+        "        print(b)\n"
+        "    case Err(e):\n"
+        "        print(e.message)\n"
+    ));
 }
 
 // ===== @inline tests =====

--- a/tests/test_paths.cpp
+++ b/tests/test_paths.cpp
@@ -268,6 +268,112 @@ TEST(Paths, ManifestReadWrite) {
     fs::remove_all(tmp);
 }
 
+// ===== find_native_library tests =====
+
+TEST(Paths, FindNativeLibraryExeParentLib) {
+    ScopedEnv guard("RY_HOME", "/nonexistent-ry-home");
+
+    char tmp_dir[] = "/tmp/ry-nlib-XXXXXX";
+    ASSERT_NE(mkdtemp(tmp_dir), nullptr);
+    std::string tmp(tmp_dir);
+
+    // Set up exe/../lib/ layout (installed layout)
+    fs::create_directories(tmp + "/bin");
+    fs::create_directories(tmp + "/lib");
+#ifdef __APPLE__
+    std::string filename = "libry_base64.dylib";
+#else
+    std::string filename = "libry_base64.so";
+#endif
+    std::ofstream(tmp + "/lib/" + filename) << "fake";
+
+    auto result = ry::find_native_library(tmp + "/bin/ry", "base64");
+    EXPECT_EQ(result, fs::canonical(tmp + "/lib/" + filename));
+
+    fs::remove_all(tmp);
+}
+
+TEST(Paths, FindNativeLibraryExeSiblingLib) {
+    ScopedEnv guard("RY_HOME", "/nonexistent-ry-home");
+
+    char tmp_dir[] = "/tmp/ry-nlib-sibling-XXXXXX";
+    ASSERT_NE(mkdtemp(tmp_dir), nullptr);
+    std::string tmp(tmp_dir);
+
+    // Set up exe/lib/ layout (development build layout)
+    fs::create_directories(tmp + "/build/lib");
+#ifdef __APPLE__
+    std::string filename = "libry_path.dylib";
+#else
+    std::string filename = "libry_path.so";
+#endif
+    std::ofstream(tmp + "/build/lib/" + filename) << "fake";
+
+    auto result = ry::find_native_library(tmp + "/build/ry", "path");
+    EXPECT_EQ(result, fs::canonical(tmp + "/build/lib/" + filename));
+
+    fs::remove_all(tmp);
+}
+
+TEST(Paths, FindNativeLibraryRyHome) {
+    char home_dir[] = "/tmp/ry-nlib-home-XXXXXX";
+    ASSERT_NE(mkdtemp(home_dir), nullptr);
+    std::string home(home_dir);
+
+    ScopedEnv guard("RY_HOME", home_dir);
+
+    fs::create_directories(home + "/lib");
+#ifdef __APPLE__
+    std::string filename = "libry_json.dylib";
+#else
+    std::string filename = "libry_json.so";
+#endif
+    std::ofstream(home + "/lib/" + filename) << "fake";
+
+    auto result = ry::find_native_library("/nonexistent/bin/ry", "json");
+    EXPECT_EQ(result, fs::path(home) / "lib" / filename);
+
+    fs::remove_all(home);
+}
+
+TEST(Paths, FindNativeLibraryNotFound) {
+    ScopedEnv guard("RY_HOME", "/nonexistent-ry-home");
+
+    auto result = ry::find_native_library("/nonexistent/bin/ry", "nonexistent_pkg");
+    EXPECT_TRUE(result.empty());
+}
+
+TEST(Paths, FindNativeLibraryPrefersExeParentOverRyHome) {
+    char tmp_dir[] = "/tmp/ry-nlib-pref-XXXXXX";
+    ASSERT_NE(mkdtemp(tmp_dir), nullptr);
+    std::string tmp(tmp_dir);
+
+    char home_dir[] = "/tmp/ry-nlib-home2-XXXXXX";
+    ASSERT_NE(mkdtemp(home_dir), nullptr);
+    std::string home(home_dir);
+
+    ScopedEnv guard("RY_HOME", home_dir);
+
+#ifdef __APPLE__
+    std::string filename = "libry_io.dylib";
+#else
+    std::string filename = "libry_io.so";
+#endif
+    // Both locations have the library
+    fs::create_directories(tmp + "/bin");
+    fs::create_directories(tmp + "/lib");
+    std::ofstream(tmp + "/lib/" + filename) << "exe-relative";
+    fs::create_directories(home + "/lib");
+    std::ofstream(home + "/lib/" + filename) << "ry-home";
+
+    auto result = ry::find_native_library(tmp + "/bin/ry", "io");
+    // Should prefer exe/../lib/ over $RY_HOME/lib/
+    EXPECT_EQ(result, fs::canonical(tmp + "/lib/" + filename));
+
+    fs::remove_all(tmp);
+    fs::remove_all(home);
+}
+
 TEST(Paths, ManifestReadMissing) {
     auto manifest = ry::read_manifest("/nonexistent/path");
     EXPECT_TRUE(manifest.version.empty());


### PR DESCRIPTION
## Summary

- Implement dynamic loading of shared libraries specified by `@native("libname")` declarations
- Build stdlib `runtime_*.cpp` files as shared libraries (`.dylib`/`.so`) in addition to the existing static linking
- Add generic dispatch path (`emitGenericNativeCall`) for arbitrary `@native("libname")` functions not covered by hardcoded stdlib dispatch tables

## Key changes

- **CodeGen** (`codegen_fn.cpp`, `codegen_call_native.cpp`): demand-driven library collection (only actually-called functions), generic dispatch with type-aware overload resolution and collection metadata propagation
- **JIT** (`main.cpp`): load shared libraries via `DynamicLibrarySearchGenerator::Load()` with search paths `exe/../lib/` → `exe/lib/` → `$RY_HOME/lib/`
- **Build** (`CMakeLists.txt`): 11 shared library targets via `add_ry_native_lib()` helper
- **Paths** (`paths.cpp`): `find_native_library()` with platform-specific filename derivation
- **Dispatch** (`codegen_call_dispatch.cpp`): generic dispatch placed after stdlib dispatchers, before user function fallback; falls through on type mismatch for correct overload resolution
- **Docs** (`directives.md`): updated `@native("libname")` specification

## Test plan

- [x] C++ tests: 1358 passed (14 new tests for getRequiredLibraries, find_native_library, generic dispatch, mixed overloads)
- [x] Ry self-tests: 77 files, 0 failures
- [x] ASan: no errors detected

Closes #649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standard runtime packages are now built and distributed as shared libraries; required native libs are loaded dynamically at JIT startup.
  * `@native("libname")` calls can be resolved and loaded from standard runtime search paths.

* **Documentation**
  * Updated `@native` docs to cover dynamic loading, runtime symbol naming, search order, and call-resolution rules.

* **Bug Fixes**
  * Clearer error message for unmatched `@native` overloads.

* **Tests**
  * Added tests for library resolution and native dispatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->