### PR TITLE
refactor: extend table-driven dispatch to Tier 2 (math, io, json)

### DIFF
--- a/changelog.d/650-table-driven-tier2.md
+++ b/changelog.d/650-table-driven-tier2.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Refactored math, io, json package dispatch to use table-driven native call dispatch (#650)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -64,11 +64,11 @@ public:
     enum class ListElemMeta : uint8_t { None, I8, Ptr };
 
     struct NativeDispatchEntry {
-        const char *fn_name;        // e.g. "encode", "collect"
-        const char *rt_suffix;      // runtime name suffix override (nullptr = use fn_name)
-        ReturnWrapping wrapping;
-        int arity;                  // -1 = variadic (e.g. path::join 2-4 args)
-        const char *out_param_type; // for ResultOutParam only (e.g. "int"); nullptr otherwise
+        const char *fn_name = nullptr;        // e.g. "encode", "collect"
+        const char *rt_suffix = nullptr;      // runtime name suffix override (nullptr = use fn_name)
+        ReturnWrapping wrapping = ReturnWrapping::Direct;
+        int arity = 0;                        // -1 = variadic (e.g. path::join 2-4 args)
+        const char *out_param_type = nullptr;  // for ResultOutParam only (e.g. "int"); nullptr otherwise
 
         // --- Tier 2 additions ---
         CustomEmitterFn custom_emitter = nullptr;  // escape hatch for complex logic

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -55,12 +55,26 @@ public:
         ResultPtrWithListMeta // ResultPtr + type_meta_[TM_ListElem] annotation
     };
 
+    struct NativeDispatchEntry;  // forward declaration for member-fn pointer
+
+    // Member function pointer for custom emitter escape hatch.
+    using CustomEmitterFn = llvm::Value *(CodeGen::*)(const CallExpr &);
+
+    // Post-call type metadata annotation for TM_ListElem.
+    enum class ListElemMeta : uint8_t { None, I8, Ptr };
+
     struct NativeDispatchEntry {
         const char *fn_name;        // e.g. "encode", "collect"
         const char *rt_suffix;      // runtime name suffix override (nullptr = use fn_name)
         ReturnWrapping wrapping;
         int arity;                  // -1 = variadic (e.g. path::join 2-4 args)
         const char *out_param_type; // for ResultOutParam only (e.g. "int"); nullptr otherwise
+
+        // --- Tier 2 additions ---
+        CustomEmitterFn custom_emitter = nullptr;  // escape hatch for complex logic
+        const char *rt_name_override = nullptr;     // full runtime name (e.g. "sin", "__ry_file_exists")
+        const char *err_fn_override = nullptr;      // error function override (nullptr = derive from package)
+        ListElemMeta list_elem_meta = ListElemMeta::None;  // post-call TM_ListElem annotation
     };
 
     // Access the @native function signature registry.
@@ -85,6 +99,26 @@ public:
                                     const std::string &name) {
         return package.empty() ? name : package + "::" + name;
     }
+
+    // Math custom emitters (table-driven Tier 2)
+    llvm::Value *emitMathAbs(const CallExpr &e);
+    llvm::Value *emitMathFloorCeilRound(const CallExpr &e);
+    llvm::Value *emitMathIsNan(const CallExpr &e);
+    llvm::Value *emitMathIsInf(const CallExpr &e);
+
+    // JSON custom emitters (table-driven Tier 2)
+    llvm::Value *emitJsonParse(const CallExpr &e);
+    llvm::Value *emitJsonStringify(const CallExpr &e);
+    llvm::Value *emitJsonKind(const CallExpr &e);
+    llvm::Value *emitJsonGet(const CallExpr &e);
+    llvm::Value *emitJsonAt(const CallExpr &e);
+    llvm::Value *emitJsonToStr(const CallExpr &e);
+    llvm::Value *emitJsonToInt(const CallExpr &e);
+    llvm::Value *emitJsonToFloat(const CallExpr &e);
+    llvm::Value *emitJsonToBool(const CallExpr &e);
+    llvm::Value *emitJsonLength(const CallExpr &e);
+    llvm::Value *emitJsonKeys(const CallExpr &e);
+    llvm::Value *emitJsonFree(const CallExpr &e);
 
 private:
     std::unique_ptr<llvm::LLVMContext> ctx_;
@@ -962,6 +996,7 @@ private:
     llvm::Value *emitBuiltinNet(const CallExpr &e);
     llvm::Value *emitBuiltinHttp(const CallExpr &e);
     llvm::Value *emitBuiltinJson(const CallExpr &e);
+
     llvm::Value *emitBuiltinBase64(const CallExpr &e);
     llvm::Value *emitBuiltinPath(const CallExpr &e);
     llvm::Value *emitBuiltinFilesystem(const CallExpr &e);

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -788,115 +788,103 @@ void CodeGen::storeMapHeaderFields(llvm::Value *headerPtr, llvm::Value *len,
 
 // ===== Builtin Math =====
 
+// ===== Math custom emitters =====
+
+llvm::Value *CodeGen::emitMathAbs(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *x = emitExpr(*e.args[0]);
+    if (x->getType() == f64Ty_) {
+        auto fn = getRuntimeFn("fabs", f64Ty_, {f64Ty_});
+        return builder_.CreateCall(fn, {x}, "abs");
+    }
+    if (x->getType()->isIntegerTy(64)) {
+        llvm::Value *neg = builder_.CreateNeg(x, "neg");
+        llvm::Value *isNeg = builder_.CreateICmpSLT(x, llvm::ConstantInt::get(i64Ty_, 0), "is_neg");
+        return builder_.CreateSelect(isNeg, neg, x, "abs");
+    }
+    codegenError("abs() requires int or float argument");
+}
+
+llvm::Value *CodeGen::emitMathFloorCeilRound(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *x = emitExpr(*e.args[0]);
+    if (x->getType() != f64Ty_)
+        codegenError(e.callee + "() requires float argument");
+
+    auto fabsFn = getRuntimeFn("fabs", f64Ty_, {f64Ty_});
+
+    // Runtime check: reject NaN and values outside i64 range
+    llvm::Value *isNan = builder_.CreateFCmpUNO(x, x, "is_nan_chk");
+    llvm::Value *absVal = builder_.CreateCall(fabsFn, {x}, "abs_chk");
+    // 2^63 = 9.223372036854776e+18 — values >= this overflow i64
+    llvm::Value *limit = llvm::ConstantFP::get(f64Ty_, 9.223372036854776e+18);
+    llvm::Value *tooBig = builder_.CreateFCmpOGE(absVal, limit, "too_big_chk");
+    llvm::Value *invalid = builder_.CreateOr(isNan, tooBig, "invalid_chk");
+
+    llvm::BasicBlock *failBB = llvm::BasicBlock::Create(*ctx_, e.callee + ".fail", fn_);
+    llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, e.callee + ".ok", fn_);
+    builder_.CreateCondBr(invalid, failBB, okBB);
+
+    builder_.SetInsertPoint(failBB);
+    static int mathErrCounter = 0;
+    emitRuntimeError("runtime error: " + e.callee + "() argument out of int range\n",
+                      ".math_err_" + std::to_string(mathErrCounter++));
+
+    builder_.SetInsertPoint(okBB);
+    auto fnTy = llvm::FunctionType::get(f64Ty_, {f64Ty_}, false);
+    auto fn = mod_->getOrInsertFunction(e.callee, fnTy);
+    llvm::Value *result = builder_.CreateCall(fn, {x}, e.callee);
+    return builder_.CreateFPToSI(result, i64Ty_, e.callee + "_i");
+}
+
+llvm::Value *CodeGen::emitMathIsNan(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *x = emitExpr(*e.args[0]);
+    if (x->getType() != f64Ty_)
+        codegenError("is_nan() requires float argument");
+    return builder_.CreateFCmpUNO(x, x, "is_nan");
+}
+
+llvm::Value *CodeGen::emitMathIsInf(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *x = emitExpr(*e.args[0]);
+    if (x->getType() != f64Ty_)
+        codegenError("is_inf() requires float argument");
+    auto fabsFn = getRuntimeFn("fabs", f64Ty_, {f64Ty_});
+    llvm::Value *absVal = builder_.CreateCall(fabsFn, {x}, "abs_for_inf");
+    llvm::Value *posInf = llvm::ConstantFP::getInfinity(f64Ty_);
+    return builder_.CreateFCmpOEQ(absVal, posInf, "is_inf");
+}
+
+// ===== Math dispatch table =====
+
+static const CodeGen::NativeDispatchEntry math_table[] = {
+    // 1-arg float->float (bare C library names)
+    {"sqrt",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "sqrt"},
+    {"log",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "log"},
+    {"log2",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "log2"},
+    {"log10", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "log10"},
+    {"exp",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "exp"},
+    {"sin",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "sin"},
+    {"cos",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "cos"},
+    {"tan",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "tan"},
+    {"asin",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "asin"},
+    {"acos",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "acos"},
+    {"atan",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "atan"},
+    // 2-arg float->float
+    {"pow",   nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, nullptr, "pow"},
+    {"atan2", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, nullptr, "atan2"},
+    {"hypot", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, nullptr, "hypot"},
+    // Custom emitters
+    {"abs",    nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, &CodeGen::emitMathAbs},
+    {"floor",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, &CodeGen::emitMathFloorCeilRound},
+    {"ceil",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, &CodeGen::emitMathFloorCeilRound},
+    {"round",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, &CodeGen::emitMathFloorCeilRound},
+    {"is_nan", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, &CodeGen::emitMathIsNan},
+    {"is_inf", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, &CodeGen::emitMathIsInf},
+};
+
 llvm::Value *CodeGen::emitBuiltinMath(const CallExpr &e) {
-    // Only dispatch if the callee was declared via @native (i.e., explicitly imported)
-    if (!native_fn_arg_counts_.count(e.callee))
-        return nullptr;
-
-    // Helper: get fabs C function
-    auto getFabs = [&]() {
-        auto ty = llvm::FunctionType::get(f64Ty_, {f64Ty_}, false);
-        return mod_->getOrInsertFunction("fabs", ty);
-    };
-
-    // abs(int) -> int, abs(float) -> float
-    if (e.callee == "abs") {
-        requireArgs(e, 1);
-        llvm::Value *x = emitExpr(*e.args[0]);
-        if (x->getType() == f64Ty_)
-            return builder_.CreateCall(getFabs(), {x}, "abs");
-        if (x->getType()->isIntegerTy(64)) {
-            llvm::Value *neg = builder_.CreateNeg(x, "neg");
-            llvm::Value *isNeg = builder_.CreateICmpSLT(x, llvm::ConstantInt::get(i64Ty_, 0), "is_neg");
-            return builder_.CreateSelect(isNeg, neg, x, "abs");
-        }
-        codegenError("abs() requires int or float argument");
-    }
-
-    // floor/ceil/round(float) -> int
-    if (e.callee == "floor" || e.callee == "ceil" || e.callee == "round") {
-        requireArgs(e, 1);
-        llvm::Value *x = emitExpr(*e.args[0]);
-        if (x->getType() != f64Ty_)
-            codegenError(e.callee + "() requires float argument");
-
-        // Runtime check: reject NaN and values outside i64 range
-        llvm::Value *isNan = builder_.CreateFCmpUNO(x, x, "is_nan_chk");
-        llvm::Value *absVal = builder_.CreateCall(getFabs(), {x}, "abs_chk");
-        // 2^63 = 9.223372036854776e+18 — values >= this overflow i64
-        llvm::Value *limit = llvm::ConstantFP::get(f64Ty_, 9.223372036854776e+18);
-        llvm::Value *tooBig = builder_.CreateFCmpOGE(absVal, limit, "too_big_chk");
-        llvm::Value *invalid = builder_.CreateOr(isNan, tooBig, "invalid_chk");
-
-        llvm::BasicBlock *failBB = llvm::BasicBlock::Create(*ctx_, e.callee + ".fail", fn_);
-        llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, e.callee + ".ok", fn_);
-        builder_.CreateCondBr(invalid, failBB, okBB);
-
-        builder_.SetInsertPoint(failBB);
-        static int mathErrCounter = 0;
-        emitRuntimeError("runtime error: " + e.callee + "() argument out of int range\n",
-                          ".math_err_" + std::to_string(mathErrCounter++));
-
-        builder_.SetInsertPoint(okBB);
-        auto fnTy = llvm::FunctionType::get(f64Ty_, {f64Ty_}, false);
-        auto fn = mod_->getOrInsertFunction(e.callee, fnTy);
-        llvm::Value *result = builder_.CreateCall(fn, {x}, e.callee);
-        return builder_.CreateFPToSI(result, i64Ty_, e.callee + "_i");
-    }
-
-    // 1-arg float -> float: sqrt, log, log2, log10, exp, sin, cos, tan, asin, acos, atan
-    {
-        static const std::unordered_set<std::string> oneArgFloat = {
-            "sqrt", "log", "log2", "log10", "exp",
-            "sin", "cos", "tan", "asin", "acos", "atan"
-        };
-        if (oneArgFloat.count(e.callee)) {
-            requireArgs(e, 1);
-            llvm::Value *x = emitExpr(*e.args[0]);
-            if (x->getType() != f64Ty_)
-                codegenError(e.callee + "() requires float argument");
-            auto fnTy = llvm::FunctionType::get(f64Ty_, {f64Ty_}, false);
-            auto fn = mod_->getOrInsertFunction(e.callee, fnTy);
-            return builder_.CreateCall(fn, {x}, e.callee);
-        }
-    }
-
-    // 2-arg float -> float: pow, atan2, hypot
-    {
-        static const std::unordered_set<std::string> twoArgFloat = {
-            "pow", "atan2", "hypot"
-        };
-        if (twoArgFloat.count(e.callee)) {
-            requireArgs(e, 2);
-            llvm::Value *x = emitExpr(*e.args[0]);
-            llvm::Value *y = emitExpr(*e.args[1]);
-            if (x->getType() != f64Ty_ || y->getType() != f64Ty_)
-                codegenError(e.callee + "() requires float arguments");
-            auto fnTy = llvm::FunctionType::get(f64Ty_, {f64Ty_, f64Ty_}, false);
-            auto fn = mod_->getOrInsertFunction(e.callee, fnTy);
-            return builder_.CreateCall(fn, {x, y}, e.callee);
-        }
-    }
-
-    // is_nan(float) -> bool
-    if (e.callee == "is_nan") {
-        requireArgs(e, 1);
-        llvm::Value *x = emitExpr(*e.args[0]);
-        if (x->getType() != f64Ty_)
-            codegenError("is_nan() requires float argument");
-        return builder_.CreateFCmpUNO(x, x, "is_nan");
-    }
-
-    // is_inf(float) -> bool
-    if (e.callee == "is_inf") {
-        requireArgs(e, 1);
-        llvm::Value *x = emitExpr(*e.args[0]);
-        if (x->getType() != f64Ty_)
-            codegenError("is_inf() requires float argument");
-        llvm::Value *absVal = builder_.CreateCall(getFabs(), {x}, "abs_for_inf");
-        llvm::Value *posInf = llvm::ConstantFP::getInfinity(f64Ty_);
-        return builder_.CreateFCmpOEQ(absVal, posInf, "is_inf");
-    }
-
-    return nullptr;
+    return emitTableDrivenNativeCall(e, "math", math_table,
+                                     std::size(math_table));
 }

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -77,7 +77,7 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
 
 // ===== Builtin IO =====
 
-static const char *IO_ERR = "__ry_get_last_error";
+static constexpr const char *IO_ERR = "__ry_get_last_error";
 
 static const CodeGen::NativeDispatchEntry io_table[] = {
     // 0-arg -> str (stdin)

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -77,84 +77,43 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
 
 // ===== Builtin IO =====
 
+static const char *IO_ERR = "__ry_get_last_error";
+
+static const CodeGen::NativeDispatchEntry io_table[] = {
+    // 0-arg -> str (stdin)
+    {"read_line",   nullptr, CodeGen::ReturnWrapping::Direct,       0, nullptr,
+     nullptr, "__ry_read_line"},
+    {"read_all",    nullptr, CodeGen::ReturnWrapping::Direct,       0, nullptr,
+     nullptr, "__ry_read_all"},
+    // 1-arg -> Result<str, Error>
+    {"read_text",   nullptr, CodeGen::ReturnWrapping::ResultPtr,    1, nullptr,
+     nullptr, "__ry_read_text", IO_ERR},
+    {"bytes_to_str",nullptr, CodeGen::ReturnWrapping::ResultPtr,    1, nullptr,
+     nullptr, "__ry_bytes_to_str", IO_ERR},
+    // 2-arg -> Result<Unit, Error>
+    {"write_text",  nullptr, CodeGen::ReturnWrapping::ResultStatus, 2, nullptr,
+     nullptr, "__ry_write_text", IO_ERR},
+    {"append_text", nullptr, CodeGen::ReturnWrapping::ResultStatus, 2, nullptr,
+     nullptr, "__ry_append_text", IO_ERR},
+    {"write_bytes", nullptr, CodeGen::ReturnWrapping::ResultStatus, 2, nullptr,
+     nullptr, "__ry_write_bytes", IO_ERR},
+    // 1-arg -> Result<Unit, Error>
+    {"delete_file", nullptr, CodeGen::ReturnWrapping::ResultStatus, 1, nullptr,
+     nullptr, "__ry_delete_file", IO_ERR},
+    // exists -> BoolFromI64 with name remap
+    {"exists",      nullptr, CodeGen::ReturnWrapping::BoolFromI64,  1, nullptr,
+     nullptr, "__ry_file_exists"},
+    // read_bytes -> ResultPtr + list_elem=I8
+    {"read_bytes",  nullptr, CodeGen::ReturnWrapping::ResultPtr,    1, nullptr,
+     nullptr, "__ry_read_bytes", IO_ERR, CodeGen::ListElemMeta::I8},
+    // to_bytes -> Direct + list_elem=I8
+    {"to_bytes",    nullptr, CodeGen::ReturnWrapping::Direct,       1, nullptr,
+     nullptr, "__ry_str_to_bytes", nullptr, CodeGen::ListElemMeta::I8},
+};
+
 llvm::Value *CodeGen::emitBuiltinIO(const CallExpr &e) {
-    if (!native_fn_arg_counts_.count(e.callee))
-        return nullptr;
-
-    // Helper: emit a call to __ry_<name> with ptr args, validate count and types
-    auto emitIOCall = [&](const std::string &name, size_t nargs,
-                          llvm::Type *retTy) -> llvm::Value * {
-        if (e.args.size() != nargs)
-            codegenError(name + "() takes exactly " + std::to_string(nargs) + " argument(s)");
-        std::vector<llvm::Value *> args;
-        std::vector<llvm::Type *> argTys;
-        for (size_t i = 0; i < nargs; ++i) {
-            args.push_back(emitExpr(*e.args[i]));
-            if (args.back()->getType() != ptrTy_)
-                codegenError(name + "() requires str/ptr arguments");
-            argTys.push_back(ptrTy_);
-        }
-        auto fnTy = llvm::FunctionType::get(retTy, argTys, false);
-        auto fn = mod_->getOrInsertFunction("__ry_" + name, fnTy);
-        return builder_.CreateCall(fn, args, name);
-    };
-
-    // 0-arg -> str (stdin functions: no Result wrapping)
-    if (e.callee == "read_line" || e.callee == "read_all")
-        return emitIOCall(e.callee, 0, ptrTy_);
-
-    // read_text(path) -> Result<str, Error>
-    if (e.callee == "read_text") {
-        llvm::Value *ptr = emitIOCall(e.callee, 1, ptrTy_);
-        return wrapPtrAsResult(ptr);
-    }
-
-    // bytes_to_str(bytes) -> Result<str, Error>
-    if (e.callee == "bytes_to_str") {
-        llvm::Value *ptr = emitIOCall(e.callee, 1, ptrTy_);
-        return wrapPtrAsResult(ptr);
-    }
-
-    // write_text(path, content) -> Result<Unit, Error>
-    if (e.callee == "write_text" || e.callee == "append_text") {
-        llvm::Value *status = emitIOCall(e.callee, 2, i64Ty_);
-        return wrapStatusAsResult(status);
-    }
-
-    // write_bytes(path, bytes) -> Result<Unit, Error>
-    if (e.callee == "write_bytes") {
-        llvm::Value *status = emitIOCall(e.callee, 2, i64Ty_);
-        return wrapStatusAsResult(status);
-    }
-
-    // delete_file(path) -> Result<Unit, Error>
-    if (e.callee == "delete_file") {
-        llvm::Value *status = emitIOCall(e.callee, 1, i64Ty_);
-        return wrapStatusAsResult(status);
-    }
-
-    // exists(path) -> bool (i64 truncated to i1) — no Result wrapping
-    if (e.callee == "exists") {
-        llvm::Value *result = emitIOCall("file_exists", 1, i64Ty_);
-        return builder_.CreateTrunc(result, i1Ty_, "exists_bool");
-    }
-
-    // read_bytes(path) -> Result<List<u8>, Error>
-    if (e.callee == "read_bytes") {
-        llvm::Value *ptr = emitIOCall(e.callee, 1, ptrTy_);
-        llvm::Value *result = wrapPtrAsResult(ptr);
-        type_meta_[TM_ListElem][result] = i8Ty_;
-        return result;
-    }
-
-    // to_bytes(str) -> List<u8> — always succeeds, no Result wrapping
-    if (e.callee == "to_bytes") {
-        llvm::Value *result = emitIOCall("str_to_bytes", 1, ptrTy_);
-        type_meta_[TM_ListElem][result] = i8Ty_;
-        return result;
-    }
-
-    return nullptr;
+    return emitTableDrivenNativeCall(e, "io", io_table,
+                                     std::size(io_table));
 }
 
 // ===== Builtin Net =====

--- a/src/codegen_call_json.cpp
+++ b/src/codegen_call_json.cpp
@@ -14,202 +14,197 @@ bool CodeGen::isJsonValue(llvm::Value *val) {
            lookupJsonSet(json_type_only_, val);
 }
 
-llvm::Value *CodeGen::emitBuiltinJson(const CallExpr &e) {
-    if (!native_fn_arg_counts_.count(e.callee))
-        return nullptr;
+// ===== JSON custom emitters =====
 
-    // Helper: wrap ptr as Result.
-    // owned=true: independently allocated (parse) → ARC cleanup on scope exit
-    // owned=false: borrowed child pointer (get/at) → type dispatch only, no cleanup
-    auto wrapJsonPtrResult = [&](llvm::Value *ptr, bool owned = false) -> llvm::Value * {
-        llvm::Value *result = wrapPtrAsResult(ptr);
-        if (owned)
-            resource_sets_[RK_JsonValue].insert(result);
-        else
-            json_type_only_.insert(result);
-        return result;
-    };
+llvm::Value *CodeGen::emitJsonParse(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *text = emitExpr(*e.args[0]);
+    if (text->getType() != ptrTy_)
+        codegenError("parse() requires a str argument");
+    auto fnTy = fnTy_ptr_to_ptr_;
+    auto fn = mod_->getOrInsertFunction("__ry_json_parse", fnTy);
+    llvm::Value *ptr = builder_.CreateCall(fn, {text}, "json_parse");
+    llvm::Value *result = wrapPtrAsResult(ptr);
+    resource_sets_[RK_JsonValue].insert(result);
+    return result;
+}
 
-    // parse(text) -> Result<JsonValue, Error>
-    if (e.callee == "parse") {
-        requireArgs(e, 1);
-        llvm::Value *text = emitExpr(*e.args[0]);
-        if (text->getType() != ptrTy_)
-            codegenError("parse() requires a str argument");
+llvm::Value *CodeGen::emitJsonStringify(const CallExpr &e) {
+    if (e.args.size() == 1) {
+        llvm::Value *val = emitExpr(*e.args[0]);
+        if (!isJsonValue(val))
+            codegenError("stringify() requires a JsonValue argument");
         auto fnTy = fnTy_ptr_to_ptr_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_parse", fnTy);
-        llvm::Value *ptr = builder_.CreateCall(fn, {text}, "json_parse");
-        return wrapJsonPtrResult(ptr, true);
+        auto fn = mod_->getOrInsertFunction("__ry_json_stringify", fnTy);
+        return builder_.CreateCall(fn, {val}, "json_stringify");
     }
-
-    // stringify(value) -> str
-    // stringify(value, indent) -> str
-    if (e.callee == "stringify") {
-        if (e.args.size() == 1) {
-            llvm::Value *val = emitExpr(*e.args[0]);
-            if (!isJsonValue(val))
-                codegenError("stringify() requires a JsonValue argument");
-            auto fnTy = fnTy_ptr_to_ptr_;
-            auto fn = mod_->getOrInsertFunction("__ry_json_stringify", fnTy);
-            return builder_.CreateCall(fn, {val}, "json_stringify");
-        }
-        if (e.args.size() == 2) {
-            llvm::Value *val = emitExpr(*e.args[0]);
-            if (!isJsonValue(val))
-                codegenError("stringify() requires a JsonValue as first argument");
-            llvm::Value *indent = emitExpr(*e.args[1]);
-            auto fnTy = fnTy_ptr_i64_to_ptr_;
-            auto fn = mod_->getOrInsertFunction("__ry_json_stringify_pretty", fnTy);
-            return builder_.CreateCall(fn, {val, indent}, "json_stringify_pretty");
-        }
-        codegenError("stringify() takes 1 or 2 arguments");
-    }
-
-    // kind(value) -> str
-    if (e.callee == "kind") {
-        requireArgs(e, 1);
+    if (e.args.size() == 2) {
         llvm::Value *val = emitExpr(*e.args[0]);
         if (!isJsonValue(val))
-            codegenError("kind() requires a JsonValue argument");
-        auto fnTy = fnTy_ptr_to_ptr_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_type", fnTy);
-        return builder_.CreateCall(fn, {val}, "json_kind");
-    }
-
-    // get(value, key) -> Result<JsonValue, Error>
-    if (e.callee == "get") {
-        requireArgs(e, 2);
-        llvm::Value *val = emitExpr(*e.args[0]);
-        if (!isJsonValue(val))
-            codegenError("get() requires a JsonValue as first argument");
-        llvm::Value *key = emitExpr(*e.args[1]);
-        if (key->getType() != ptrTy_)
-            codegenError("get() requires a str key");
-        auto fnTy = fnTy_ptr_ptr_to_ptr_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_get", fnTy);
-        llvm::Value *ptr = builder_.CreateCall(fn, {val, key}, "json_get");
-        return wrapJsonPtrResult(ptr, false);
-    }
-
-    // at(value, index) -> Result<JsonValue, Error>
-    if (e.callee == "at") {
-        requireArgs(e, 2);
-        llvm::Value *val = emitExpr(*e.args[0]);
-        if (!isJsonValue(val))
-            codegenError("at() requires a JsonValue as first argument");
-        llvm::Value *idx = emitExpr(*e.args[1]);
+            codegenError("stringify() requires a JsonValue as first argument");
+        llvm::Value *indent = emitExpr(*e.args[1]);
         auto fnTy = fnTy_ptr_i64_to_ptr_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_at", fnTy);
-        llvm::Value *ptr = builder_.CreateCall(fn, {val, idx}, "json_at");
-        return wrapJsonPtrResult(ptr, false);
+        auto fn = mod_->getOrInsertFunction("__ry_json_stringify_pretty", fnTy);
+        return builder_.CreateCall(fn, {val, indent}, "json_stringify_pretty");
     }
+    codegenError("stringify() takes 1 or 2 arguments");
+}
 
-    // to_str(value) -> Result<str, Error> — for JsonValue
-    if (e.callee == "to_str") {
-        requireArgs(e, 1);
-        llvm::Value *val = emitExpr(*e.args[0]);
-        if (!isJsonValue(val)) return nullptr;
-        auto fnTy = fnTy_ptr_to_ptr_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_str", fnTy);
-        llvm::Value *ptr = builder_.CreateCall(fn, {val}, "json_str");
-        return wrapPtrAsResult(ptr);
-    }
+llvm::Value *CodeGen::emitJsonKind(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!isJsonValue(val))
+        codegenError("kind() requires a JsonValue argument");
+    auto fnTy = fnTy_ptr_to_ptr_;
+    auto fn = mod_->getOrInsertFunction("__ry_json_type", fnTy);
+    return builder_.CreateCall(fn, {val}, "json_kind");
+}
 
-    // to_int(value) -> Result<int, Error> — for JsonValue
-    if (e.callee == "to_int") {
-        requireArgs(e, 1);
-        llvm::Value *val = emitExpr(*e.args[0]);
-        if (!isJsonValue(val)) return nullptr;
-        llvm::AllocaInst *outSlot = builder_.CreateAlloca(i64Ty_, nullptr, "json_int_out");
-        auto fnTy = fnTy_ptr_ptr_to_i64_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_int", fnTy);
-        llvm::Value *status = builder_.CreateCall(fn, {val, outSlot}, "json_int_status");
-        llvm::Value *isErr = builder_.CreateICmpNE(status,
-            llvm::ConstantInt::get(i64Ty_, 0), "json_int_err");
-        llvm::StructType *resTy = getResultType(i64Ty_, errorTy_);
-        return emitResultBranch(isErr, resTy,
-            [&]() {
-                llvm::Value *loaded = builder_.CreateLoad(i64Ty_, outSlot, "json_int_val");
-                return buildOkValue(loaded, resTy);
-            },
-            [&]() { return buildErrValue(buildErrorFromRuntime(), resTy); });
-    }
+llvm::Value *CodeGen::emitJsonGet(const CallExpr &e) {
+    requireArgs(e, 2);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!isJsonValue(val))
+        codegenError("get() requires a JsonValue as first argument");
+    llvm::Value *key = emitExpr(*e.args[1]);
+    if (key->getType() != ptrTy_)
+        codegenError("get() requires a str key");
+    auto fnTy = fnTy_ptr_ptr_to_ptr_;
+    auto fn = mod_->getOrInsertFunction("__ry_json_get", fnTy);
+    llvm::Value *ptr = builder_.CreateCall(fn, {val, key}, "json_get");
+    llvm::Value *result = wrapPtrAsResult(ptr);
+    json_type_only_.insert(result);
+    return result;
+}
 
-    // to_float(value) -> Result<float, Error> — for JsonValue
-    if (e.callee == "to_float") {
-        requireArgs(e, 1);
-        llvm::Value *val = emitExpr(*e.args[0]);
-        if (!isJsonValue(val)) return nullptr;
-        llvm::AllocaInst *outSlot = builder_.CreateAlloca(f64Ty_, nullptr, "json_float_out");
-        auto fnTy = fnTy_ptr_ptr_to_i64_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_float", fnTy);
-        llvm::Value *status = builder_.CreateCall(fn, {val, outSlot}, "json_float_status");
-        llvm::Value *isErr = builder_.CreateICmpNE(status,
-            llvm::ConstantInt::get(i64Ty_, 0), "json_float_err");
-        llvm::StructType *resTy = getResultType(f64Ty_, errorTy_);
-        return emitResultBranch(isErr, resTy,
-            [&]() {
-                llvm::Value *loaded = builder_.CreateLoad(f64Ty_, outSlot, "json_float_val");
-                return buildOkValue(loaded, resTy);
-            },
-            [&]() { return buildErrValue(buildErrorFromRuntime(), resTy); });
-    }
+llvm::Value *CodeGen::emitJsonAt(const CallExpr &e) {
+    requireArgs(e, 2);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!isJsonValue(val))
+        codegenError("at() requires a JsonValue as first argument");
+    llvm::Value *idx = emitExpr(*e.args[1]);
+    auto fnTy = fnTy_ptr_i64_to_ptr_;
+    auto fn = mod_->getOrInsertFunction("__ry_json_at", fnTy);
+    llvm::Value *ptr = builder_.CreateCall(fn, {val, idx}, "json_at");
+    llvm::Value *result = wrapPtrAsResult(ptr);
+    json_type_only_.insert(result);
+    return result;
+}
 
-    // to_bool(value) -> Result<bool, Error>
-    if (e.callee == "to_bool") {
-        requireArgs(e, 1);
-        llvm::Value *val = emitExpr(*e.args[0]);
-        if (!isJsonValue(val))
-            codegenError("to_bool() requires a JsonValue argument");
-        llvm::AllocaInst *outSlot = builder_.CreateAlloca(i64Ty_, nullptr, "json_bool_out");
-        auto fnTy = fnTy_ptr_ptr_to_i64_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_bool", fnTy);
-        llvm::Value *status = builder_.CreateCall(fn, {val, outSlot}, "json_bool_status");
-        llvm::Value *isErr = builder_.CreateICmpNE(status,
-            llvm::ConstantInt::get(i64Ty_, 0), "json_bool_err");
-        llvm::StructType *resTy = getResultType(i1Ty_, errorTy_);
-        return emitResultBranch(isErr, resTy,
-            [&]() {
-                llvm::Value *loaded = builder_.CreateLoad(i64Ty_, outSlot, "json_bool_i64");
-                llvm::Value *boolVal = builder_.CreateTrunc(loaded, i1Ty_, "json_bool_val");
-                return buildOkValue(boolVal, resTy);
-            },
-            [&]() { return buildErrValue(buildErrorFromRuntime(), resTy); });
-    }
+llvm::Value *CodeGen::emitJsonToStr(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!isJsonValue(val)) return nullptr;
+    auto fnTy = fnTy_ptr_to_ptr_;
+    auto fn = mod_->getOrInsertFunction("__ry_json_str", fnTy);
+    llvm::Value *ptr = builder_.CreateCall(fn, {val}, "json_str");
+    return wrapPtrAsResult(ptr);
+}
 
-    // length(value) -> int — for JsonValue
-    if (e.callee == "length") {
-        requireArgs(e, 1);
-        llvm::Value *val = emitExpr(*e.args[0]);
-        if (!isJsonValue(val)) return nullptr;
-        auto fnTy = fnTy_ptr_to_i64_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_len", fnTy);
-        return builder_.CreateCall(fn, {val}, "json_len");
-    }
+llvm::Value *CodeGen::emitJsonToInt(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!isJsonValue(val)) return nullptr;
+    llvm::AllocaInst *outSlot = builder_.CreateAlloca(i64Ty_, nullptr, "json_int_out");
+    auto fn = mod_->getOrInsertFunction("__ry_json_int", fnTy_ptr_ptr_to_i64_);
+    llvm::Value *status = builder_.CreateCall(fn, {val, outSlot}, "json_int_status");
+    llvm::Value *isErr = builder_.CreateICmpNE(status,
+        llvm::ConstantInt::get(i64Ty_, 0), "json_int_err");
+    llvm::StructType *resTy = getResultType(i64Ty_, errorTy_);
+    return emitResultBranch(isErr, resTy,
+        [&]() {
+            llvm::Value *loaded = builder_.CreateLoad(i64Ty_, outSlot, "json_int_val");
+            return buildOkValue(loaded, resTy);
+        },
+        [&]() { return buildErrValue(buildErrorFromRuntime(), resTy); });
+}
 
-    // keys(value) -> Result<List<str>, Error> — for JsonValue
-    if (e.callee == "keys") {
-        requireArgs(e, 1);
-        llvm::Value *val = emitExpr(*e.args[0]);
-        if (!isJsonValue(val)) return nullptr;
-        auto fnTy = fnTy_ptr_to_ptr_;
-        auto fn = mod_->getOrInsertFunction("__ry_json_keys", fnTy);
-        llvm::Value *ptr = builder_.CreateCall(fn, {val}, "json_keys");
-        llvm::Value *result = wrapPtrAsResult(ptr);
-        type_meta_[TM_ListElem][result] = ptrTy_;
-        return result;
-    }
+llvm::Value *CodeGen::emitJsonToFloat(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!isJsonValue(val)) return nullptr;
+    llvm::AllocaInst *outSlot = builder_.CreateAlloca(f64Ty_, nullptr, "json_float_out");
+    auto fn = mod_->getOrInsertFunction("__ry_json_float", fnTy_ptr_ptr_to_i64_);
+    llvm::Value *status = builder_.CreateCall(fn, {val, outSlot}, "json_float_status");
+    llvm::Value *isErr = builder_.CreateICmpNE(status,
+        llvm::ConstantInt::get(i64Ty_, 0), "json_float_err");
+    llvm::StructType *resTy = getResultType(f64Ty_, errorTy_);
+    return emitResultBranch(isErr, resTy,
+        [&]() {
+            llvm::Value *loaded = builder_.CreateLoad(f64Ty_, outSlot, "json_float_val");
+            return buildOkValue(loaded, resTy);
+        },
+        [&]() { return buildErrValue(buildErrorFromRuntime(), resTy); });
+}
 
-    // json_free(value) -> Unit
-    if (e.callee == "json_free") {
-        requireArgs(e, 1);
-        llvm::Value *val = emitExpr(*e.args[0]);
-        if (!lookupJsonSet(resource_sets_[RK_JsonValue], val))
-            codegenError("json_free() requires a JsonValue argument");
-        if (lookupJsonSet(json_type_only_, val))
-            codegenError("json_free() cannot free borrowed child values from get()/at()");
-        return emitResourceFree(val, RK_JsonValue, *e.args[0]);
-    }
+llvm::Value *CodeGen::emitJsonToBool(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!isJsonValue(val))
+        codegenError("to_bool() requires a JsonValue argument");
+    llvm::AllocaInst *outSlot = builder_.CreateAlloca(i64Ty_, nullptr, "json_bool_out");
+    auto fn = mod_->getOrInsertFunction("__ry_json_bool", fnTy_ptr_ptr_to_i64_);
+    llvm::Value *status = builder_.CreateCall(fn, {val, outSlot}, "json_bool_status");
+    llvm::Value *isErr = builder_.CreateICmpNE(status,
+        llvm::ConstantInt::get(i64Ty_, 0), "json_bool_err");
+    llvm::StructType *resTy = getResultType(i1Ty_, errorTy_);
+    return emitResultBranch(isErr, resTy,
+        [&]() {
+            llvm::Value *loaded = builder_.CreateLoad(i64Ty_, outSlot, "json_bool_i64");
+            llvm::Value *boolVal = builder_.CreateTrunc(loaded, i1Ty_, "json_bool_val");
+            return buildOkValue(boolVal, resTy);
+        },
+        [&]() { return buildErrValue(buildErrorFromRuntime(), resTy); });
+}
 
-    return nullptr;
+llvm::Value *CodeGen::emitJsonLength(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!isJsonValue(val)) return nullptr;
+    auto fnTy = fnTy_ptr_to_i64_;
+    auto fn = mod_->getOrInsertFunction("__ry_json_len", fnTy);
+    return builder_.CreateCall(fn, {val}, "json_len");
+}
+
+llvm::Value *CodeGen::emitJsonKeys(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!isJsonValue(val)) return nullptr;
+    auto fnTy = fnTy_ptr_to_ptr_;
+    auto fn = mod_->getOrInsertFunction("__ry_json_keys", fnTy);
+    llvm::Value *ptr = builder_.CreateCall(fn, {val}, "json_keys");
+    llvm::Value *result = wrapPtrAsResult(ptr);
+    type_meta_[TM_ListElem][result] = ptrTy_;
+    return result;
+}
+
+llvm::Value *CodeGen::emitJsonFree(const CallExpr &e) {
+    requireArgs(e, 1);
+    llvm::Value *val = emitExpr(*e.args[0]);
+    if (!lookupJsonSet(resource_sets_[RK_JsonValue], val))
+        codegenError("json_free() requires a JsonValue argument");
+    if (lookupJsonSet(json_type_only_, val))
+        codegenError("json_free() cannot free borrowed child values from get()/at()");
+    return emitResourceFree(val, RK_JsonValue, *e.args[0]);
+}
+
+// ===== JSON dispatch table =====
+
+static const CodeGen::NativeDispatchEntry json_table[] = {
+    {"parse",     nullptr, CodeGen::ReturnWrapping::ResultPtr,     1, nullptr, &CodeGen::emitJsonParse},
+    {"stringify", nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr, &CodeGen::emitJsonStringify},
+    {"kind",      nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr, &CodeGen::emitJsonKind},
+    {"get",       nullptr, CodeGen::ReturnWrapping::ResultPtr,     2, nullptr, &CodeGen::emitJsonGet},
+    {"at",        nullptr, CodeGen::ReturnWrapping::ResultPtr,     2, nullptr, &CodeGen::emitJsonAt},
+    {"to_str",    nullptr, CodeGen::ReturnWrapping::ResultPtr,     1, nullptr, &CodeGen::emitJsonToStr},
+    {"to_int",    nullptr, CodeGen::ReturnWrapping::ResultOutParam,1, "int",   &CodeGen::emitJsonToInt},
+    {"to_float",  nullptr, CodeGen::ReturnWrapping::ResultOutParam,1, "float", &CodeGen::emitJsonToFloat},
+    {"to_bool",   nullptr, CodeGen::ReturnWrapping::ResultOutParam,1, "int",   &CodeGen::emitJsonToBool},
+    {"length",    nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr, &CodeGen::emitJsonLength},
+    {"keys",      nullptr, CodeGen::ReturnWrapping::ResultPtr,     1, nullptr, &CodeGen::emitJsonKeys},
+    {"json_free", nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr, &CodeGen::emitJsonFree},
+};
+
+llvm::Value *CodeGen::emitBuiltinJson(const CallExpr &e) {
+    return emitTableDrivenNativeCall(e, "json", json_table,
+                                     std::size(json_table));
 }

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -21,7 +21,9 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         return nullptr;
 
     // Lazily build error function name (only for wrappings that need it)
-    auto getErrFnName = [&]() {
+    auto getErrFnName = [&]() -> std::string {
+        if (entry->err_fn_override)
+            return entry->err_fn_override;
         return deriveRuntimeFnName(package, "get_last_error");
     };
 
@@ -36,8 +38,12 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         // with a different-library function falls through instead of erroring.
         std::string sigKey = nativeSigKey(package, e.callee);
         auto sigIt = native_fn_sigs_.find(sigKey);
-        if (sigIt == native_fn_sigs_.end())
-            return nullptr;  // No sig for this package — fall through
+        if (sigIt == native_fn_sigs_.end()) {
+            // Fallback: try bare name for inline @native declarations without package
+            sigIt = native_fn_sigs_.find(e.callee);
+            if (sigIt == native_fn_sigs_.end())
+                return nullptr;  // No sig for this package — fall through
+        }
 
         bool hasArityMatch = false;
         for (const auto &sig : sigIt->second) {
@@ -92,7 +98,9 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         if (!matchedSig->library.empty())
             used_native_libraries_.insert(matchedSig->library);
 
-        std::string rtName = deriveRuntimeFnName(package, rtSuffix)
+        std::string rtName = (entry->rt_name_override
+            ? std::string(entry->rt_name_override)
+            : deriveRuntimeFnName(package, rtSuffix))
             + std::to_string(n);
         auto *fnTy = llvm::FunctionType::get(
             resolveType(matchedSig->return_type_name), argTypes, false);
@@ -107,8 +115,30 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     // different-library function falls through instead of erroring.
     std::string sigKey = nativeSigKey(package, e.callee);
     auto sigIt = native_fn_sigs_.find(sigKey);
-    if (sigIt == native_fn_sigs_.end())
-        return nullptr;  // No sig for this package — fall through
+    if (sigIt == native_fn_sigs_.end()) {
+        // Fallback: try bare name for inline @native declarations without package
+        sigIt = native_fn_sigs_.find(e.callee);
+        if (sigIt == native_fn_sigs_.end())
+            return nullptr;  // No sig for this package — fall through
+    }
+
+    // Custom emitter escape hatch: runs only after sig key AND call-arity
+    // validation.  The arity check uses the CALL's actual arg count against
+    // registered signatures so that same-package overloads with different
+    // arities are not hijacked (e.g. a 2-arg overload won't be grabbed by
+    // a 1-arg custom emitter entry).
+    if (entry->custom_emitter) {
+        bool hasCallArityMatch = false;
+        for (const auto &sig : sigIt->second) {
+            if (sig.params.size() == e.args.size()) {
+                hasCallArityMatch = true;
+                break;
+            }
+        }
+        if (!hasCallArityMatch)
+            return nullptr;  // No sig with this arity — fall through
+        return (this->*(entry->custom_emitter))(e);
+    }
 
     // Check if any sig matches the arity before emitting args
     bool hasArityMatch = false;
@@ -167,7 +197,9 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         used_native_libraries_.insert(matchedSig->library);
 
     // Derive runtime function name
-    std::string rtName = deriveRuntimeFnName(package, rtSuffix);
+    std::string rtName = entry->rt_name_override
+        ? entry->rt_name_override
+        : deriveRuntimeFnName(package, rtSuffix);
 
     // Pre-compute out-param type for ResultOutParam (used in two places)
     llvm::Type *outTy = nullptr;
@@ -216,11 +248,20 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     case ReturnWrapping::Direct:
         if (cRetTy->isVoidTy())
             return llvm::ConstantInt::get(i8Ty_, 0); // Unit
+        if (entry->list_elem_meta == ListElemMeta::I8)
+            type_meta_[TM_ListElem][callResult] = i8Ty_;
+        else if (entry->list_elem_meta == ListElemMeta::Ptr)
+            type_meta_[TM_ListElem][callResult] = ptrTy_;
         return callResult;
 
     case ReturnWrapping::ResultPtr: {
         std::string errFn = getErrFnName();
-        return wrapPtrAsResult(callResult, errFn.c_str());
+        llvm::Value *result = wrapPtrAsResult(callResult, errFn.c_str());
+        if (entry->list_elem_meta == ListElemMeta::I8)
+            type_meta_[TM_ListElem][result] = i8Ty_;
+        else if (entry->list_elem_meta == ListElemMeta::Ptr)
+            type_meta_[TM_ListElem][result] = ptrTy_;
+        return result;
     }
 
     case ReturnWrapping::ResultPtrWithListMeta: {


### PR DESCRIPTION
## Summary

- Extended `NativeDispatchEntry` with `custom_emitter`, `rt_name_override`, `err_fn_override`, and `list_elem_meta` fields to handle Tier 2 dispatch patterns
- Migrated **math** package: 14 simple C-library entries + 6 custom emitters (abs, floor/ceil/round, is_nan, is_inf)
- Migrated **io** package: 11 table entries with runtime name overrides and global error function
- Migrated **json** package: 12 custom emitter entries for receiver guards and resource tracking
- Custom emitter dispatch is guarded by sig-key + call-arity checks to prevent hijacking same-name functions from other packages

## Test plan

- [x] `./build/ry_tests` — 1359 passed
- [x] `./build/ry test -p` — 77 files, 0 failures
- [x] ASan build + tests — all passed

Closes #650

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Math, IO, and JSON builtins moved to a unified table-driven dispatch with dedicated emitters, simplifying and standardizing runtime handling.
* **Documentation**
  * Added changelog entry documenting the table-driven dispatch update for math, io, and json packages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->