### PR TITLE
fix: remove dyld crash on installed binary, make native libs independent

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -99,10 +99,12 @@ jobs:
         run: ./build/ry_tests
       - name: Package
         run: |
-          mkdir -p dist
+          mkdir -p dist/lib dist/share
           cp build/ry dist/ry
+          cp build/lib/libry_*.* dist/lib/
+          cp -r share/std dist/share/std
           cd dist
-          tar czf ry-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz ry
+          tar czf ry-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz ry lib/ share/
           shasum -a 256 ry-*.tar.gz > checksums.txt
       - name: Sign checksums
         if: env.RY_SIGNING_PRIVATE_KEY != ''
@@ -187,10 +189,12 @@ jobs:
         run: ./build/ry_tests
       - name: Package
         run: |
-          mkdir -p dist
+          mkdir -p dist/lib dist/share
           cp build/ry dist/ry
+          cp build/lib/libry_*.* dist/lib/
+          cp -r share/std dist/share/std
           cd dist
-          tar czf ry-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz ry
+          tar czf ry-${{ steps.version.outputs.version }}-darwin-arm64.tar.gz ry lib/ share/
           shasum -a 256 ry-*.tar.gz > checksums.txt
       - name: Sign checksums
         if: env.RY_SIGNING_PRIVATE_KEY != ''

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,11 +89,12 @@ jobs:
 
       - name: Package
         run: |
-          mkdir -p dist/share
+          mkdir -p dist/lib dist/share
           cp build/ry dist/ry
+          cp build/lib/libry_*.* dist/lib/
           cp -r share/std dist/share/std
           cd dist
-          tar czf ry-${{ steps.version.outputs.version }}-${{ matrix.target }}.tar.gz ry share/
+          tar czf ry-${{ steps.version.outputs.version }}-${{ matrix.target }}.tar.gz ry lib/ share/
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,11 @@ add_ry_native_lib(json       src/runtime_json.cpp)
 add_ry_native_lib(net        src/runtime_net.cpp)
 
 add_ry_native_lib(thread     src/runtime_thread.cpp)
-target_link_libraries(ry_thread PRIVATE Threads::Threads)
+if(APPLE)
+    target_link_libraries(ry_thread PRIVATE Threads::Threads)
+else()
+    target_link_libraries(ry_thread PRIVATE Threads::Threads atomic)
+endif()
 
 # runtime_hash.cpp is compiled here (not in a separate shared lib) because ry_http
 # needs hash symbols at link time for HTTP header map construction.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,7 +216,10 @@ add_dependencies(ry ${RY_NATIVE_LIBS})
 if(APPLE)
     target_link_libraries(ry PRIVATE -Wl,-force_load,$<TARGET_FILE:ry_lib> ry_lib)
 else()
-    target_link_libraries(ry PRIVATE -Wl,--whole-archive ry_lib -Wl,--no-whole-archive atomic)
+    # --no-as-needed for atomic: JIT-generated code may reference __atomic_load
+    # (from LLVM atomicrmw lowering), so libatomic must stay linked even though
+    # ry_lib has no direct references to it.
+    target_link_libraries(ry PRIVATE -Wl,--whole-archive ry_lib -Wl,--no-whole-archive -Wl,--no-as-needed atomic -Wl,--as-needed)
     # -rdynamic: export process symbols so JIT DynamicLibrarySearchGenerator and
     # dlopen'd native libs can find __ry_set_last_error etc. from the process
     target_link_options(ry PRIVATE -rdynamic)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,7 @@ add_library(ry_lib STATIC
     src/codegen_any.cpp
     src/runtime_any.cpp
     src/codegen_arc.cpp
+    src/runtime_error.cpp
 )
 target_precompile_headers(ry_lib PRIVATE
     <algorithm>
@@ -168,6 +169,11 @@ function(add_ry_native_lib PKG_NAME)
         MACOSX_RPATH TRUE
         BUILD_RPATH "${CMAKE_BINARY_DIR}/lib"
         INSTALL_RPATH "$<IF:$<PLATFORM_ID:Darwin>,@loader_path,\$ORIGIN>")
+    # Native libs resolve infrastructure symbols (__ry_set_last_error etc.)
+    # from the main process at runtime, not via link-time dependency.
+    if(APPLE)
+        target_link_options(ry_${PKG_NAME} PRIVATE -undefined dynamic_lookup)
+    endif()
 endfunction()
 
 # Self-contained packages (no cross-runtime dependencies)
@@ -177,40 +183,38 @@ add_ry_native_lib(convert    src/runtime_convert.cpp)
 add_ry_native_lib(filesystem src/runtime_filesystem.cpp)
 add_ry_native_lib(gc         src/runtime_gc.cpp)
 
-# io defines __ry_set_last_error, used by several other packages
+# All native libs are independent — no inter-library link dependencies.
+# __ry_set_last_error / __ry_get_last_error live in ry_lib (the main executable)
+# and are resolved from the process at runtime via -undefined dynamic_lookup
+# (macOS) or -rdynamic (Linux).
 add_ry_native_lib(io         src/runtime_io.cpp)
-
-# Packages that depend on __ry_set_last_error (via runtime_io.hpp)
 add_ry_native_lib(json       src/runtime_json.cpp)
-target_link_libraries(ry_json PRIVATE ry_io)
-
 add_ry_native_lib(net        src/runtime_net.cpp)
-target_link_libraries(ry_net PRIVATE ry_io)
 
 add_ry_native_lib(thread     src/runtime_thread.cpp)
-target_link_libraries(ry_thread PRIVATE ry_io Threads::Threads)
+target_link_libraries(ry_thread PRIVATE Threads::Threads)
 
-# http depends on tls for HTTPS client support, plus io/net for error & socket APIs.
 # runtime_hash.cpp is compiled here (not in a separate shared lib) because ry_http
 # needs hash symbols at link time for HTTP header map construction.
+# Shared TCP utilities are compiled directly into ry_http via runtime_net_utils.hpp.
 add_ry_native_lib(http       src/runtime_http.cpp src/runtime_http_client.cpp
                              src/runtime_http_multipart.cpp src/runtime_tls.cpp
                              src/runtime_hash.cpp)
-target_link_libraries(ry_http PRIVATE ry_io ry_net OpenSSL::SSL OpenSSL::Crypto Threads::Threads)
+target_link_libraries(ry_http PRIVATE OpenSSL::SSL OpenSSL::Crypto Threads::Threads)
 
-# All native shared libraries — linked into ry and ry_tests so the JIT can
-# resolve runtime symbols via DynamicLibrarySearchGenerator.
 set(RY_NATIVE_LIBS ry_base64 ry_path ry_convert ry_filesystem ry_gc ry_io ry_json ry_net ry_thread ry_http)
 
 # ===== メイン実行ファイル =====
+# Native shared libraries are NOT linked here — the JIT loads them on-demand
+# via find_native_library() + DynamicLibrarySearchGenerator::Load() (see main.cpp).
 add_executable(ry src/main.cpp)
+add_dependencies(ry ${RY_NATIVE_LIBS})
 if(APPLE)
-    target_link_libraries(ry PRIVATE -Wl,-force_load,$<TARGET_FILE:ry_lib> ry_lib ${RY_NATIVE_LIBS})
+    target_link_libraries(ry PRIVATE -Wl,-force_load,$<TARGET_FILE:ry_lib> ry_lib)
 else()
-    # --no-as-needed: force-link native libs (JIT resolves their symbols at runtime,
-    # so the static linker sees no direct references and would drop them otherwise)
-    target_link_libraries(ry PRIVATE -Wl,--whole-archive ry_lib -Wl,--no-whole-archive -Wl,--no-as-needed ${RY_NATIVE_LIBS} atomic -Wl,--as-needed)
-    # -rdynamic: export process symbols so JIT DynamicLibrarySearchGenerator can find them
+    target_link_libraries(ry PRIVATE -Wl,--whole-archive ry_lib -Wl,--no-whole-archive atomic)
+    # -rdynamic: export process symbols so JIT DynamicLibrarySearchGenerator and
+    # dlopen'd native libs can find __ry_set_last_error etc. from the process
     target_link_options(ry PRIVATE -rdynamic)
 endif()
 

--- a/changelog.d/659-native-lib-dyld-fix.md
+++ b/changelog.d/659-native-lib-dyld-fix.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Installed `ry` binary no longer crashes with `dyld: Library not loaded` when using native packages (#659)
+- Native shared libraries are now included in release and nightly distribution tarballs (#659)
+- `self-update` now installs native shared libraries alongside the binary and stdlib (#659)

--- a/include/ry/runtime_net_utils.hpp
+++ b/include/ry/runtime_net_utils.hpp
@@ -1,0 +1,198 @@
+// Shared TCP utility functions used by both ry_net and ry_http.
+// All functions have static linkage so each native lib gets its own copy,
+// ensuring no inter-library link dependencies.
+#pragma once
+
+#include "ry/runtime_net_types.hpp"
+#include "ry/runtime_arc.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <errno.h>
+#include <sys/time.h>
+#include <new>
+
+// ===== DNS resolution =====
+
+static inline int ry_net_resolve(const char *host, int64_t port,
+                                 struct addrinfo **out) {
+    struct addrinfo hints{};
+    hints.ai_family = AF_UNSPEC;
+    hints.ai_socktype = SOCK_STREAM;
+
+    char port_str[16];
+    snprintf(port_str, sizeof(port_str), "%lld", (long long)port);
+
+    *out = nullptr;
+    if (::getaddrinfo(host, port_str, &hints, out) != 0)
+        return -1;
+    return 0;
+}
+
+// ===== SSRF protection =====
+
+static inline bool ry_net_is_private_ipv4_raw(uint32_t ip) {
+    if ((ip >> 24) == 127) return true;    // 127.0.0.0/8
+    if ((ip >> 24) == 10) return true;     // 10.0.0.0/8
+    if ((ip >> 20) == 0xAC1) return true;  // 172.16.0.0/12
+    if ((ip >> 16) == 0xC0A8) return true; // 192.168.0.0/16
+    if ((ip >> 16) == 0xA9FE) return true; // 169.254.0.0/16
+    if ((ip >> 24) == 0) return true;      // 0.0.0.0/8
+    return false;
+}
+
+static inline bool ry_net_is_private_addr(const struct sockaddr *sa) {
+    if (sa->sa_family == AF_INET) {
+        auto *sin = (const struct sockaddr_in *)sa;
+        return ry_net_is_private_ipv4_raw(ntohl(sin->sin_addr.s_addr));
+    }
+    if (sa->sa_family == AF_INET6) {
+        auto *sin6 = (const struct sockaddr_in6 *)sa;
+        if (IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
+            uint32_t ip_raw;
+            std::memcpy(&ip_raw, &sin6->sin6_addr.s6_addr[12], sizeof(ip_raw));
+            return ry_net_is_private_ipv4_raw(ntohl(ip_raw));
+        }
+        if (IN6_IS_ADDR_LOOPBACK(&sin6->sin6_addr)) return true;
+        if (IN6_IS_ADDR_LINKLOCAL(&sin6->sin6_addr)) return true;
+        uint8_t first = sin6->sin6_addr.s6_addr[0];
+        if ((first & 0xFE) == 0xFC) return true; // fc00::/7 (ULA)
+        return false;
+    }
+    return false;
+}
+
+static inline bool ry_net_is_private_addrinfo(const struct addrinfo *info) {
+    for (const struct addrinfo *rp = info; rp; rp = rp->ai_next) {
+        if (ry_net_is_private_addr(rp->ai_addr))
+            return true;
+    }
+    return false;
+}
+
+// ===== Connection =====
+
+static inline void *ry_net_connect_resolved(const struct addrinfo *info) {
+    for (const struct addrinfo *rp = info; rp; rp = rp->ai_next) {
+        int fd = ::socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
+        if (fd < 0) continue;
+#ifdef SO_NOSIGPIPE
+        {
+            int nosig = 1;
+            ::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &nosig, sizeof(nosig));
+        }
+#endif
+        // Non-blocking connect with timeout
+        int flags = ::fcntl(fd, F_GETFL, 0);
+        if (flags < 0 || ::fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+            ::close(fd);
+            continue;
+        }
+
+        int conn_ret = ::connect(fd, rp->ai_addr, rp->ai_addrlen);
+        if (conn_ret < 0 && errno != EINPROGRESS) {
+            ::close(fd);
+            continue;
+        }
+        if (conn_ret < 0) {
+            struct pollfd pfd = {fd, POLLOUT, 0};
+            int poll_ret = ::poll(&pfd, 1, 1000);
+            if (poll_ret <= 0) {
+                ::close(fd);
+                continue;
+            }
+            int so_error = 0;
+            socklen_t len = sizeof(so_error);
+            if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &len) < 0 ||
+                so_error != 0) {
+                ::close(fd);
+                continue;
+            }
+        }
+
+        // Restore blocking mode
+        ::fcntl(fd, F_SETFL, flags);
+
+        void *smem = arc_alloc(sizeof(TcpStreamHandle));
+        if (!smem) {
+            ::close(fd);
+            return nullptr;
+        }
+        auto *stream = new (smem) TcpStreamHandle;
+        stream->fd = fd;
+        return stream;
+    }
+    return nullptr;
+}
+
+static inline void *ry_net_connect(const char *host, int64_t port) {
+    struct addrinfo *result = nullptr;
+    if (ry_net_resolve(host, port, &result) != 0)
+        return nullptr;
+    void *stream = ry_net_connect_resolved(result);
+    ::freeaddrinfo(result);
+    return stream;
+}
+
+// ===== Data transfer =====
+
+static inline ssize_t ry_net_send_all(int fd, const void *buf, size_t len) {
+    auto *data = static_cast<const char *>(buf);
+    size_t remaining = len;
+    int flags = 0;
+#ifdef MSG_NOSIGNAL
+    flags = MSG_NOSIGNAL;
+#endif
+    while (remaining > 0) {
+        ssize_t n = ::send(fd, data, remaining, flags);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return -1;
+        }
+        if (n == 0) return -1;
+        data += n;
+        remaining -= static_cast<size_t>(n);
+    }
+    return static_cast<ssize_t>(len);
+}
+
+// ===== Timeout configuration =====
+
+static inline void ry_net_set_socket_timeval(int fd, int option, int64_t ms) {
+    struct timeval tv;
+    if (ms <= 0) {
+        tv.tv_sec = 0;
+        tv.tv_usec = 0;
+    } else {
+        tv.tv_sec = ms / 1000;
+        tv.tv_usec = (ms % 1000) * 1000;
+    }
+    ::setsockopt(fd, SOL_SOCKET, option, &tv, sizeof(tv));
+}
+
+static inline void ry_net_apply_default_recv_timeout(int fd) {
+    struct timeval current_tv{};
+    socklen_t tv_len = sizeof(current_tv);
+    if (::getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &current_tv, &tv_len) == 0 &&
+        current_tv.tv_sec == 0 && current_tv.tv_usec == 0) {
+        struct timeval tv = {30, 0};
+        ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    }
+}
+
+// ===== Handle management =====
+
+static inline int ry_net_tcp_take_fd(void *stream) {
+    auto *handle = (TcpStreamHandle *)stream;
+    int fd = handle->fd;
+    arc_free(stream);
+    return fd;
+}

--- a/include/ry/self_update.hpp
+++ b/include/ry/self_update.hpp
@@ -50,6 +50,7 @@ SignatureAction evaluate_signature_policy(
 std::string download_and_extract(const std::string &download_url, const std::string &tag);
 bool replace_binary(const std::string &tmp_dir, const std::string &binary_path);
 bool install_stdlib(const std::string &tmp_dir, const std::string &new_version);
+bool install_native_libs(const std::string &tmp_dir_str);
 
 } // namespace detail
 } // namespace ry::self_update

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,15 @@ curl -fsSL "$DOWNLOAD_URL" -o "$TMPDIR/ry.tar.gz"
 tar xzf "$TMPDIR/ry.tar.gz" -C "$TMPDIR"
 install -m 755 "$TMPDIR/ry" "$INSTALL_DIR/ry"
 
+# Install native shared libraries
+if [ -d "$TMPDIR/lib" ]; then
+    mkdir -p "$RY_HOME/lib"
+    for f in "$TMPDIR"/lib/libry_*.*; do
+        [ -f "$f" ] && install -m 755 "$f" "$RY_HOME/lib/"
+    done
+    echo "Native libraries installed to $RY_HOME/lib"
+fi
+
 # Install standard library (clean replace)
 # Detect archive layout and install to the matching destination so the
 # corresponding binary can find stdlib at the path it expects.

--- a/install.sh
+++ b/install.sh
@@ -30,11 +30,17 @@ install -m 755 "$TMPDIR/ry" "$INSTALL_DIR/ry"
 
 # Install native shared libraries
 if [ -d "$TMPDIR/lib" ]; then
+    NATIVE_LIBS_INSTALLED=0
     mkdir -p "$RY_HOME/lib"
     for f in "$TMPDIR"/lib/libry_*.*; do
-        [ -f "$f" ] && install -m 755 "$f" "$RY_HOME/lib/"
+        if [ -f "$f" ]; then
+            install -m 755 "$f" "$RY_HOME/lib/"
+            NATIVE_LIBS_INSTALLED=1
+        fi
     done
-    echo "Native libraries installed to $RY_HOME/lib"
+    if [ "$NATIVE_LIBS_INSTALLED" = 1 ]; then
+        echo "Native libraries installed to $RY_HOME/lib"
+    fi
 fi
 
 # Install standard library (clean replace)

--- a/install.sh
+++ b/install.sh
@@ -63,6 +63,8 @@ if [ -n "$SRC_STD" ] && [ -d "$SRC_STD" ]; then
     # Clean up old lib/std layout only after successful install (migration)
     if [ "$NEW_LAYOUT" = 1 ]; then
         rm -rf "$RY_HOME/lib/std"
+        # rmdir only removes empty directories — safe when native libs
+        # (libry_*) are installed in $RY_HOME/lib (no-op in that case).
         rmdir "$RY_HOME/lib" 2>/dev/null || true
     fi
 fi

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -108,6 +108,7 @@ void CodeGen::emitArcRelease(llvm::Value *headerPtr, bool atomic,
             llvm::Type::getVoidTy(*ctx_),
             {ptrTy_, ptrTy_, ptrTy_}, false);
         auto gcTrackFn = mod_->getOrInsertFunction("__ry_gc_track", gcTrackFnTy);
+        used_native_libraries_.insert("gc");
         llvm::Value *dtorPtr = destructor
             ? llvm::cast<llvm::Value>(destructor.getCallee())
             : llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -124,6 +124,7 @@ void CodeGen::emitArcRelease(llvm::Value *headerPtr, bool atomic,
         llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
     auto gcUntrackFn = mod_->getOrInsertFunction("__ry_gc_untrack", gcUntrackFnTy);
     builder_.CreateCall(gcUntrackFn, {headerPtr});
+    used_native_libraries_.insert("gc");
     if (destructor) {
         auto *dataPtr = emitArcGetDataPtr(headerPtr);
         builder_.CreateCall(destructor, {dataPtr});
@@ -251,21 +252,22 @@ llvm::FunctionCallee CodeGen::getOrCreateResourceDestructor(ResourceKind rk) {
         ResourceKind kind;
         const char *dtorName;
         const char *cleanupFnName;
+        const char *library;
     } table[] = {
-        {RK_TcpListener,        "__ry_arc_dtor_tcp_listener",          "__ry_tcp_listener_cleanup"},
-        {RK_TcpStream,           "__ry_arc_dtor_tcp_stream",            "__ry_tcp_cleanup"},
-        {RK_TlsStream,           "__ry_arc_dtor_tls_stream",            "__ry_tls_cleanup"},
-        {RK_HttpRequest,         "__ry_arc_dtor_http_request",          "__ry_http_request_cleanup"},
-        {RK_HttpResponse,        "__ry_arc_dtor_http_response",         "__ry_http_response_cleanup"},
-        {RK_HttpClientResponse,  "__ry_arc_dtor_http_client_response",  "__ry_http_client_response_cleanup"},
-        {RK_JsonValue,           "__ry_arc_dtor_json_value",            "__ry_json_cleanup"},
-        {RK_Thread,              "__ry_arc_dtor_thread",                "__ry_thread_cleanup"},
-        {RK_Lock,                "__ry_arc_dtor_lock",                  "__ry_lock_cleanup"},
-        {RK_RWLock,              "__ry_arc_dtor_rwlock",                "__ry_rwlock_cleanup"},
-        {RK_Semaphore,           "__ry_arc_dtor_semaphore",             "__ry_semaphore_cleanup"},
-        {RK_Barrier,             "__ry_arc_dtor_barrier",               "__ry_barrier_cleanup"},
-        {RK_AtomicInt,           "__ry_arc_dtor_atomic_int",            "__ry_atomic_int_cleanup"},
-        {RK_AtomicBool,          "__ry_arc_dtor_atomic_bool",           "__ry_atomic_bool_cleanup"},
+        {RK_TcpListener,        "__ry_arc_dtor_tcp_listener",          "__ry_tcp_listener_cleanup",         "net"},
+        {RK_TcpStream,           "__ry_arc_dtor_tcp_stream",            "__ry_tcp_cleanup",                 "net"},
+        {RK_TlsStream,           "__ry_arc_dtor_tls_stream",            "__ry_tls_cleanup",                 "http"},
+        {RK_HttpRequest,         "__ry_arc_dtor_http_request",          "__ry_http_request_cleanup",        "http"},
+        {RK_HttpResponse,        "__ry_arc_dtor_http_response",         "__ry_http_response_cleanup",       "http"},
+        {RK_HttpClientResponse,  "__ry_arc_dtor_http_client_response",  "__ry_http_client_response_cleanup","http"},
+        {RK_JsonValue,           "__ry_arc_dtor_json_value",            "__ry_json_cleanup",                "json"},
+        {RK_Thread,              "__ry_arc_dtor_thread",                "__ry_thread_cleanup",              "thread"},
+        {RK_Lock,                "__ry_arc_dtor_lock",                  "__ry_lock_cleanup",                "thread"},
+        {RK_RWLock,              "__ry_arc_dtor_rwlock",                "__ry_rwlock_cleanup",              "thread"},
+        {RK_Semaphore,           "__ry_arc_dtor_semaphore",             "__ry_semaphore_cleanup",           "thread"},
+        {RK_Barrier,             "__ry_arc_dtor_barrier",               "__ry_barrier_cleanup",             "thread"},
+        {RK_AtomicInt,           "__ry_arc_dtor_atomic_int",            "__ry_atomic_int_cleanup",          "thread"},
+        {RK_AtomicBool,          "__ry_arc_dtor_atomic_bool",           "__ry_atomic_bool_cleanup",         "thread"},
     };
 
     const char *dtorName = nullptr;
@@ -274,6 +276,7 @@ llvm::FunctionCallee CodeGen::getOrCreateResourceDestructor(ResourceKind rk) {
         if (entry.kind == rk) {
             dtorName = entry.dtorName;
             cleanupFnName = entry.cleanupFnName;
+            used_native_libraries_.insert(entry.library);
             break;
         }
     }

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -14,6 +14,7 @@ llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
         llvm::AllocaInst *outSlot = builder_.CreateAlloca(i64Ty_, nullptr, "to_int_out");
         auto fnTy = fnTy_ptr_ptr_to_i64_;
         auto fn = mod_->getOrInsertFunction("__ry_str_to_int", fnTy);
+        used_native_libraries_.insert("convert");
         llvm::Value *status = builder_.CreateCall(fn, {s, outSlot}, "to_int_status");
         llvm::Value *isErr = builder_.CreateICmpNE(status,
             llvm::ConstantInt::get(i64Ty_, 0), "to_int_err");

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -208,7 +208,9 @@ llvm::Value *CodeGen::emitNetTimeout(const CallExpr &e) {
         codegenError(e.callee + "() requires TcpStream or TlsStream as first argument");
     auto *voidTy = llvm::Type::getVoidTy(*ctx_);
     auto fnTy = llvm::FunctionType::get(voidTy, {ptrTy_, i64Ty_}, false);
-    std::string prefix = isTlsStream(stream) ? "__ry_tls_" : "__ry_tcp_";
+    bool isTls = isTlsStream(stream);
+    std::string prefix = isTls ? "__ry_tls_" : "__ry_tcp_";
+    used_native_libraries_.insert(isTls ? "http" : "net");
     std::string rtName = e.callee;
     if (rtName == "set_receive_timeout") rtName = "set_recv_timeout";
     auto fn = mod_->getOrInsertFunction(prefix + rtName, fnTy);

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -190,10 +190,12 @@ llvm::Value *CodeGen::emitNetConnect(const CallExpr &e) {
     requireArgs(e, 2);
     llvm::Value *host = emitExpr(*e.args[0]);
     llvm::Value *port = emitExpr(*e.args[1]);
+    bool isTls = e.callee == "tls_connect";
     auto fn = mod_->getOrInsertFunction(
-        e.callee == "tls_connect" ? "__ry_tls_connect" : "__ry_connect", fnTy_ptr_i64_to_ptr_);
+        isTls ? "__ry_tls_connect" : "__ry_connect", fnTy_ptr_i64_to_ptr_);
+    used_native_libraries_.insert(isTls ? "http" : "net");
     llvm::Value *result = builder_.CreateCall(fn, {host, port}, e.callee + "_result");
-    if (e.callee == "tls_connect")
+    if (isTls)
         return emitPtrToResult(result, "tls_connect", "TLS connection failed", RK_TlsStream);
     return emitPtrToResult(result, "connect", "connection failed", RK_TcpStream);
 }

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -133,6 +133,10 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         bool hasCallArityMatch = false;
         for (const auto &sig : sigIt->second) {
             if (sig.params.size() == e.args.size()) {
+                // Track native library for the JIT — custom emitters return
+                // before the normal matchedSig tracking below.
+                if (!sig.library.empty())
+                    used_native_libraries_.insert(sig.library);
                 hasCallArityMatch = true;
                 break;
             }

--- a/src/runtime_error.cpp
+++ b/src/runtime_error.cpp
@@ -1,0 +1,20 @@
+// Thread-local error message buffer for Result-based error reporting.
+// This is infrastructure shared by all native libs, so it lives in ry_lib
+// (the main executable). Native shared libraries resolve these symbols from
+// the process at runtime via -undefined dynamic_lookup (macOS) or
+// -rdynamic (Linux).
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+static thread_local char last_error_buf[512] = {0};
+
+extern "C" void __ry_set_last_error(const char *msg) {
+    snprintf(last_error_buf, sizeof(last_error_buf), "%s", msg);
+}
+
+extern "C" const char *__ry_get_last_error() {
+    // Return a heap copy so it can be stored as a ry str
+    return strdup(last_error_buf);
+}

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -1,7 +1,7 @@
 #include "ry/runtime_http_internal.hpp"
 #include "ry/runtime_http.hpp"
 #include "ry/runtime_io.hpp"
-#include "ry/runtime_net_types.hpp"
+#include "ry/runtime_net_utils.hpp"
 #include "ry/runtime_arc.hpp"
 
 #include <openssl/err.h>
@@ -738,7 +738,7 @@ extern "C" void __ry_http_send_response(void *stream, void *response, int64_t ke
     }
 
     // Send full response
-    __ry_send_all(handle->fd, out.c_str(), out.size());
+    ry_net_send_all(handle->fd, out.c_str(), out.size());
 }
 
 // Free internal fields of an HttpRequestHandle but NOT the handle memory itself.

--- a/src/runtime_http_client.cpp
+++ b/src/runtime_http_client.cpp
@@ -1,7 +1,7 @@
 #include "ry/runtime_http_internal.hpp"
 #include "ry/runtime_http.hpp"
 #include "ry/runtime_io.hpp"
-#include "ry/runtime_net_types.hpp"
+#include "ry/runtime_net_utils.hpp"
 #include "ry/runtime_arc.hpp"
 
 // =====================================================================
@@ -186,7 +186,7 @@ static bool read_response_body(HttpTransport &t, std::string &raw, size_t body_s
 }
 
 static HttpClientResponseHandle *read_http_response(HttpTransport &t) {
-    __ry_apply_default_recv_timeout(t.fd);
+    ry_net_apply_default_recv_timeout(t.fd);
 
     std::string raw = recv_all(t, kMaxHeaderSize);
     if (raw.empty()) return nullptr;
@@ -344,9 +344,9 @@ static bool establish_connection(const ParsedUrl *parsed,
         if (!tls) return false;
         __ry_tls_take_ownership(tls, &transport.fd, &transport.ssl);
     } else {
-        void *stream = __ry_connect_resolved(resolved);
+        void *stream = ry_net_connect_resolved(resolved);
         if (!stream) return false;
-        transport.fd = __ry_tcp_take_fd(stream);
+        transport.fd = ry_net_tcp_take_fd(stream);
     }
     return true;
 }
@@ -424,13 +424,13 @@ extern "C" void *__ry_http_client_request(const char *method, const char *url,
 
         // Resolve DNS once and use the result for both SSRF check and connection
         struct addrinfo *resolved = nullptr;
-        if (__ry_resolve(parsed->host, parsed->port, &resolved) != 0) {
+        if (ry_net_resolve(parsed->host, parsed->port, &resolved) != 0) {
             __ry_http_parsed_url_free(parsed);
             break;
         }
         AddrInfoGuard guard{resolved};
 
-        if (ssrf_check && __ry_is_private_addrinfo(resolved)) {
+        if (ssrf_check && ry_net_is_private_addrinfo(resolved)) {
             __ry_http_parsed_url_free(parsed);
             break;
         }

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -25,23 +25,16 @@ static FILE *fopen_nofollow(const char *path, const char *mode) {
     return f;
 }
 
-// Thread-local error message buffer for Result-based error reporting
-static thread_local char last_error_buf[512] = {0};
+// __ry_set_last_error / __ry_get_last_error are defined in runtime_error.cpp
+// (part of ry_lib). Native libs resolve them from the process at runtime.
 
 static void setLastError(const char *fmt, ...) {
+    char buf[512];
     va_list args;
     va_start(args, fmt);
-    vsnprintf(last_error_buf, sizeof(last_error_buf), fmt, args);
+    vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
-}
-
-extern "C" void __ry_set_last_error(const char *msg) {
-    snprintf(last_error_buf, sizeof(last_error_buf), "%s", msg);
-}
-
-extern "C" const char *__ry_get_last_error() {
-    // Return a heap copy so it can be stored as a ry str
-    return strdup(last_error_buf);
+    __ry_set_last_error(buf);
 }
 
 // IOListHeader and makeByteList are defined in runtime_io.hpp

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -1,5 +1,6 @@
 #include "ry/runtime_net.hpp"
 #include "ry/runtime_net_types.hpp"
+#include "ry/runtime_net_utils.hpp"
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_arc.hpp"
 
@@ -125,157 +126,42 @@ extern "C" void *__ry_accept(void *listener) {
     return stream;
 }
 
-static bool is_private_ipv4_raw(uint32_t ip) {
-    if ((ip >> 24) == 127) return true;   // 127.0.0.0/8
-    if ((ip >> 24) == 10) return true;    // 10.0.0.0/8
-    if ((ip >> 20) == 0xAC1) return true; // 172.16.0.0/12
-    if ((ip >> 16) == 0xC0A8) return true; // 192.168.0.0/16
-    if ((ip >> 16) == 0xA9FE) return true; // 169.254.0.0/16
-    if ((ip >> 24) == 0) return true;     // 0.0.0.0/8
-    return false;
-}
-
-static bool is_private_addr(const struct sockaddr *sa) {
-    if (sa->sa_family == AF_INET) {
-        auto *sin = (const struct sockaddr_in *)sa;
-        return is_private_ipv4_raw(ntohl(sin->sin_addr.s_addr));
-    }
-    if (sa->sa_family == AF_INET6) {
-        auto *sin6 = (const struct sockaddr_in6 *)sa;
-        if (IN6_IS_ADDR_V4MAPPED(&sin6->sin6_addr)) {
-            uint32_t ip_raw;
-            std::memcpy(&ip_raw, &sin6->sin6_addr.s6_addr[12], sizeof(ip_raw));
-            return is_private_ipv4_raw(ntohl(ip_raw));
-        }
-        if (IN6_IS_ADDR_LOOPBACK(&sin6->sin6_addr)) return true;
-        if (IN6_IS_ADDR_LINKLOCAL(&sin6->sin6_addr)) return true;
-        uint8_t first = sin6->sin6_addr.s6_addr[0];
-        if ((first & 0xFE) == 0xFC) return true; // fc00::/7 (ULA)
-        return false;
-    }
-    return false;
-}
+// Utility functions are implemented in runtime_net_utils.hpp (static inline).
+// The extern "C" wrappers below export them for JIT / Ry code to call.
 
 int __ry_resolve(const char *host, int64_t port, struct addrinfo **out) {
-    struct addrinfo hints{};
-    hints.ai_family = AF_UNSPEC;
-    hints.ai_socktype = SOCK_STREAM;
-
-    char port_str[16];
-    snprintf(port_str, sizeof(port_str), "%lld", (long long)port);
-
-    *out = nullptr;
-    if (::getaddrinfo(host, port_str, &hints, out) != 0)
-        return -1;
-    return 0;
+    return ry_net_resolve(host, port, out);
 }
 
 bool __ry_is_private_addrinfo(const struct addrinfo *info) {
-    for (const struct addrinfo *rp = info; rp; rp = rp->ai_next) {
-        if (is_private_addr(rp->ai_addr))
-            return true;
-    }
-    return false;
+    return ry_net_is_private_addrinfo(info);
 }
 
 bool __ry_is_private_host(const char *host, int64_t port) {
     struct addrinfo *result = nullptr;
-    if (__ry_resolve(host, port, &result) != 0)
+    if (ry_net_resolve(host, port, &result) != 0)
         return false;
-    bool priv = __ry_is_private_addrinfo(result);
+    bool priv = ry_net_is_private_addrinfo(result);
     ::freeaddrinfo(result);
     return priv;
 }
 
 extern "C" void *__ry_connect_resolved(const struct addrinfo *info) {
-    for (const struct addrinfo *rp = info; rp; rp = rp->ai_next) {
-        int fd = ::socket(rp->ai_family, rp->ai_socktype, rp->ai_protocol);
-        if (fd < 0) continue;
-#ifdef SO_NOSIGPIPE
-        {
-            int nosig = 1;
-            ::setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &nosig, sizeof(nosig));
-        }
-#endif
-
-        // Non-blocking connect with 5-second timeout
-        int flags = ::fcntl(fd, F_GETFL, 0);
-        if (flags < 0 || ::fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
-            ::close(fd);
-            continue;
-        }
-
-        int conn_ret = ::connect(fd, rp->ai_addr, rp->ai_addrlen);
-
-        if (conn_ret < 0 && errno != EINPROGRESS) {
-            ::close(fd);
-            continue;
-        }
-
-        if (conn_ret < 0) {
-            struct pollfd pfd = {fd, POLLOUT, 0};
-            int poll_ret = ::poll(&pfd, 1, 1000);
-            if (poll_ret <= 0) {
-                ::close(fd);
-                continue;
-            }
-            int so_error = 0;
-            socklen_t len = sizeof(so_error);
-            if (::getsockopt(fd, SOL_SOCKET, SO_ERROR, &so_error, &len) < 0 || so_error != 0) {
-                ::close(fd);
-                continue;
-            }
-        }
-
-        // Restore blocking mode
-        ::fcntl(fd, F_SETFL, flags);
-
-        void *smem = arc_alloc(sizeof(TcpStreamHandle));
-        if (!smem) {
-            ::close(fd);
-            return nullptr;
-        }
-        auto *stream = new (smem) TcpStreamHandle;
-        stream->fd = fd;
-        return stream;
-    }
-    return nullptr;
+    return ry_net_connect_resolved(info);
 }
 
 extern "C" void *__ry_connect(const char *host, int64_t port) {
-    struct addrinfo *result = nullptr;
-    if (__ry_resolve(host, port, &result) != 0)
-        return nullptr;
-    void *stream = __ry_connect_resolved(result);
-    ::freeaddrinfo(result);
-    return stream;
+    return ry_net_connect(host, port);
 }
 
 ssize_t __ry_send_all(int fd, const void *buf, size_t len) {
-    auto *data = static_cast<const char *>(buf);
-    size_t remaining = len;
-    // Use MSG_NOSIGNAL on Linux to suppress SIGPIPE (macOS uses SO_NOSIGPIPE instead)
-    int flags = 0;
-#ifdef MSG_NOSIGNAL
-    flags = MSG_NOSIGNAL;
-#endif
-    while (remaining > 0) {
-        ssize_t n = ::send(fd, data, remaining, flags);
-        if (n < 0) {
-            if (errno == EINTR) continue;
-            return -1;
-        }
-        if (n == 0) return -1;  // defensive: should not happen with remaining > 0
-        data += n;
-        remaining -= static_cast<size_t>(n);
-    }
-    return static_cast<ssize_t>(len);
+    return ry_net_send_all(fd, buf, len);
 }
 
 extern "C" int64_t __ry_tcp_send(void *stream, void *byte_list) {
     auto *handle = (TcpStreamHandle *)stream;
     auto *header = (IOListHeader *)byte_list;
-    ssize_t sent = __ry_send_all(handle->fd, header->data, (size_t)header->len);
+    ssize_t sent = ry_net_send_all(handle->fd, header->data, (size_t)header->len);
     return (int64_t)sent;
 }
 
@@ -292,7 +178,7 @@ extern "C" void *__ry_tcp_receive(void *stream, int64_t max_bytes) {
         return makeEmptyIOList();
     }
     auto *handle = (TcpStreamHandle *)stream;
-    __ry_apply_default_recv_timeout(handle->fd);
+    ry_net_apply_default_recv_timeout(handle->fd);
     auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
     if (!header) return nullptr;
     header->data = (int8_t *)malloc((size_t)max_bytes);
@@ -343,55 +229,38 @@ extern "C" void __ry_tcp_listener_shutdown(void *listener) {
 }
 
 // ============================================================
-// Timeout configuration
+// Timeout configuration — delegate to shared utils
 // ============================================================
 
 void __ry_set_socket_timeval(int fd, int option, int64_t ms) {
-    struct timeval tv;
-    if (ms <= 0) {
-        tv.tv_sec = 0;
-        tv.tv_usec = 0;
-    } else {
-        tv.tv_sec = ms / 1000;
-        tv.tv_usec = (ms % 1000) * 1000;
-    }
-    ::setsockopt(fd, SOL_SOCKET, option, &tv, sizeof(tv));
+    ry_net_set_socket_timeval(fd, option, ms);
 }
 
 int __ry_tcp_take_fd(void *stream) {
-    auto *handle = (TcpStreamHandle *)stream;
-    int fd = handle->fd;
-    arc_free(stream);
-    return fd;
+    return ry_net_tcp_take_fd(stream);
 }
 
 void __ry_apply_default_recv_timeout(int fd) {
-    struct timeval current_tv{};
-    socklen_t tv_len = sizeof(current_tv);
-    if (::getsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &current_tv, &tv_len) == 0 &&
-        current_tv.tv_sec == 0 && current_tv.tv_usec == 0) {
-        struct timeval tv = {30, 0};
-        ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
-    }
+    ry_net_apply_default_recv_timeout(fd);
 }
 
 extern "C" void __ry_tcp_set_timeout(void *stream, int64_t ms) {
     if (!stream) return;
     auto *handle = (TcpStreamHandle *)stream;
-    __ry_set_socket_timeval(handle->fd, SO_RCVTIMEO, ms);
-    __ry_set_socket_timeval(handle->fd, SO_SNDTIMEO, ms);
+    ry_net_set_socket_timeval(handle->fd, SO_RCVTIMEO, ms);
+    ry_net_set_socket_timeval(handle->fd, SO_SNDTIMEO, ms);
 }
 
 extern "C" void __ry_tcp_set_recv_timeout(void *stream, int64_t ms) {
     if (!stream) return;
     auto *handle = (TcpStreamHandle *)stream;
-    __ry_set_socket_timeval(handle->fd, SO_RCVTIMEO, ms);
+    ry_net_set_socket_timeval(handle->fd, SO_RCVTIMEO, ms);
 }
 
 extern "C" void __ry_tcp_set_send_timeout(void *stream, int64_t ms) {
     if (!stream) return;
     auto *handle = (TcpStreamHandle *)stream;
-    __ry_set_socket_timeval(handle->fd, SO_SNDTIMEO, ms);
+    ry_net_set_socket_timeval(handle->fd, SO_SNDTIMEO, ms);
 }
 
 extern "C" void __ry_tcp_cleanup(void *handle) {

--- a/src/runtime_tls.cpp
+++ b/src/runtime_tls.cpp
@@ -1,6 +1,6 @@
 #include "ry/runtime_tls.hpp"
 #include "ry/runtime_arc.hpp"
-#include "ry/runtime_net.hpp"
+#include "ry/runtime_net_utils.hpp"
 #include "ry/runtime_io.hpp"
 
 #include <openssl/ssl.h>
@@ -118,16 +118,16 @@ static void *tls_handshake(const char *host, int fd) {
 }
 
 extern "C" void *__ry_tls_connect_resolved(const char *host, const struct addrinfo *info) {
-    void *tcp = __ry_connect_resolved(info);
+    void *tcp = ry_net_connect_resolved(info);
     if (!tcp) return nullptr;
-    int fd = __ry_tcp_take_fd(tcp);
+    int fd = ry_net_tcp_take_fd(tcp);
     return tls_handshake(host, fd);
 }
 
 extern "C" void *__ry_tls_connect(const char *host, int64_t port) {
-    void *tcp = __ry_connect(host, port);
+    void *tcp = ry_net_connect(host, port);
     if (!tcp) return nullptr;
-    int fd = __ry_tcp_take_fd(tcp);
+    int fd = ry_net_tcp_take_fd(tcp);
     return tls_handshake(host, fd);
 }
 
@@ -148,7 +148,7 @@ extern "C" int64_t __ry_tls_send(void *tls_stream, void *byte_list) {
 
 extern "C" void *__ry_tls_receive(void *tls_stream, int64_t max_bytes) {
     auto *h = (TlsStreamHandle *)tls_stream;
-    __ry_apply_default_recv_timeout(h->fd);
+    ry_net_apply_default_recv_timeout(h->fd);
     if (max_bytes <= 0) {
         auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
         header->len = 0;
@@ -224,18 +224,18 @@ void __ry_tls_take_ownership(void *tls_stream, int *out_fd, SSL **out_ssl) {
 extern "C" void __ry_tls_set_timeout(void *tls_stream, int64_t ms) {
     if (!tls_stream) return;
     auto *handle = (TlsStreamHandle *)tls_stream;
-    __ry_set_socket_timeval(handle->fd, SO_RCVTIMEO, ms);
-    __ry_set_socket_timeval(handle->fd, SO_SNDTIMEO, ms);
+    ry_net_set_socket_timeval(handle->fd, SO_RCVTIMEO, ms);
+    ry_net_set_socket_timeval(handle->fd, SO_SNDTIMEO, ms);
 }
 
 extern "C" void __ry_tls_set_recv_timeout(void *tls_stream, int64_t ms) {
     if (!tls_stream) return;
     auto *handle = (TlsStreamHandle *)tls_stream;
-    __ry_set_socket_timeval(handle->fd, SO_RCVTIMEO, ms);
+    ry_net_set_socket_timeval(handle->fd, SO_RCVTIMEO, ms);
 }
 
 extern "C" void __ry_tls_set_send_timeout(void *tls_stream, int64_t ms) {
     if (!tls_stream) return;
     auto *handle = (TlsStreamHandle *)tls_stream;
-    __ry_set_socket_timeval(handle->fd, SO_SNDTIMEO, ms);
+    ry_net_set_socket_timeval(handle->fd, SO_SNDTIMEO, ms);
 }

--- a/src/self_update.cpp
+++ b/src/self_update.cpp
@@ -749,6 +749,37 @@ bool install_stdlib(const std::string &tmp_dir_str, const std::string &new_versi
     return true;
 }
 
+bool install_native_libs(const std::string &tmp_dir_str) {
+    namespace fs = std::filesystem;
+    fs::path src_lib = fs::path(tmp_dir_str) / "lib";
+    if (!fs::is_directory(src_lib))
+        return false;
+
+    const fs::path dest_lib = ry::get_ry_home() / "lib";
+    std::error_code ec;
+    fs::create_directories(dest_lib, ec);
+    if (ec) {
+        std::cerr << "Warning: Failed to create lib directory: " << ec.message() << "\n";
+        return false;
+    }
+
+    bool any_installed = false;
+    for (const auto &entry : fs::directory_iterator(src_lib)) {
+        if (!entry.is_regular_file()) continue;
+        auto filename = entry.path().filename().string();
+        if (filename.find("libry_") != 0) continue;
+        auto dest_path = dest_lib / filename;
+        fs::copy_file(entry.path(), dest_path,
+                      fs::copy_options::overwrite_existing, ec);
+        if (ec) {
+            std::cerr << "Warning: Failed to copy " << filename << ": " << ec.message() << "\n";
+        } else {
+            any_installed = true;
+        }
+    }
+    return any_installed;
+}
+
 } // namespace detail
 } // namespace ry::self_update
 
@@ -817,6 +848,11 @@ int cmd_self_update(int argc, char *argv[]) {
     if (!version.empty() && version[0] == 'v') version = version.substr(1);
     if (detail::install_stdlib(tmp_dir, version)) {
         std::cerr << "Standard library updated.\n";
+    }
+
+    // Install/update native shared libraries
+    if (detail::install_native_libs(tmp_dir)) {
+        std::cerr << "Native libraries updated.\n";
     }
 
     detail::run_command({RM_PATH, "-rf", tmp_dir});


### PR DESCRIPTION
## Summary

- Installed `ry` binary no longer crashes with `dyld: Library not loaded` when using native packages
- Native shared libraries are now fully independent (no inter-library link dependencies)
- Dylibs are packaged in distribution tarballs and installed via `install.sh` and `self-update`

## Root Cause

The `ry` executable linked all native shared libraries at build time, causing dyld to load them at startup from the CI build path (`/Users/runner/work/ry/ry/build/lib/`). The JIT already had on-demand loading via `find_native_library()` + `DynamicLibrarySearchGenerator::Load()`, making the link-time dependency unnecessary.

## Changes

- **CMakeLists.txt**: Remove `${RY_NATIVE_LIBS}` from `ry` executable linking; remove all inter-library `target_link_libraries`; add `-undefined dynamic_lookup` (macOS)
- **runtime_error.cpp** (new): Move `__ry_set_last_error`/`__ry_get_last_error` from `runtime_io.cpp` to `ry_lib`
- **runtime_net_utils.hpp** (new): Extract shared TCP utilities as `static inline` for independent compilation
- **codegen_call_native.cpp**: Fix library tracking for table-driven dispatch (custom_emitter path was missing it)
- **codegen_arc.cpp**: Add library tracking for gc track/untrack and resource destructors
- **codegen_call.cpp/codegen_call_io.cpp**: Add library tracking for `to_int`, `connect`, `tls_connect`
- **Workflows**: Package `lib/libry_*.*` in release and dev-release tarballs
- **install.sh**: Install dylibs to `$RY_HOME/lib/`
- **self_update.cpp**: Add `install_native_libs()` for self-update

## Test plan

- [x] `./build/ry_tests` — 1359 tests PASSED
- [x] `./build/ry test -p` — 77 test files, 0 failures
- [x] ASan build — `ry_tests` 1358 PASSED, `ry test -p` 0 failures
- [x] `otool -L ./build/ry | grep libry_` — no native lib dependencies
- [x] `otool -L ./build/lib/libry_json.dylib | grep libry_` — no inter-lib deps

Closes #659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crash on macOS caused by missing native libraries during runtime.

* **New Features**
  * Distribution archives now include native shared libraries.
  * Installer and self-update now install native shared libraries alongside the binary and standard library.

* **Documentation**
  * Added changelog entry documenting native-library packaging and install behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->