### PR TITLE
fix: harden SSRF filter and handle fcntl restore failure

### DIFF
--- a/changelog.d/667-harden-ssrf-filter.md
+++ b/changelog.d/667-harden-ssrf-filter.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Broadened SSRF private address filter to block carrier-grade NAT (`100.64.0.0/10`), benchmarking (`198.18.0.0/15`), multicast (`224.0.0.0/4`), reserved (`240.0.0.0/4`), IPv6 unspecified (`::`), and IPv6 multicast (`ff00::/8`) (#667)
+- Added error handling for `fcntl` failure when restoring blocking mode after non-blocking connect (#667)

--- a/include/ry/runtime_net.hpp
+++ b/include/ry/runtime_net.hpp
@@ -26,6 +26,9 @@ bool __ry_is_private_host(const char *host, int64_t port);
 // SSRF protection: check if any address in a pre-resolved addrinfo list is private
 bool __ry_is_private_addrinfo(const struct addrinfo *info);
 
+// SSRF protection: check if a single sockaddr is private/loopback
+bool __ry_is_private_addr(const struct sockaddr *sa);
+
 // Resolve hostname to addrinfo list. Caller must freeaddrinfo(*out).
 // Returns 0 on success, -1 on failure.
 int __ry_resolve(const char *host, int64_t port, struct addrinfo **out);

--- a/include/ry/runtime_net_utils.hpp
+++ b/include/ry/runtime_net_utils.hpp
@@ -46,6 +46,9 @@ static inline bool ry_net_is_private_ipv4_raw(uint32_t ip) {
     if ((ip >> 16) == 0xC0A8) return true; // 192.168.0.0/16
     if ((ip >> 16) == 0xA9FE) return true; // 169.254.0.0/16
     if ((ip >> 24) == 0) return true;      // 0.0.0.0/8
+    if ((ip >> 22) == 0x191) return true;  // 100.64.0.0/10 (CGNAT)
+    if ((ip >> 17) == 0x6309) return true; // 198.18.0.0/15 (benchmarking)
+    if ((ip >> 28) >= 0xE) return true;    // 224.0.0.0/4+ (multicast + reserved)
     return false;
 }
 
@@ -62,6 +65,8 @@ static inline bool ry_net_is_private_addr(const struct sockaddr *sa) {
             return ry_net_is_private_ipv4_raw(ntohl(ip_raw));
         }
         if (IN6_IS_ADDR_LOOPBACK(&sin6->sin6_addr)) return true;
+        if (IN6_IS_ADDR_UNSPECIFIED(&sin6->sin6_addr)) return true;
+        if (IN6_IS_ADDR_MULTICAST(&sin6->sin6_addr)) return true;
         if (IN6_IS_ADDR_LINKLOCAL(&sin6->sin6_addr)) return true;
         uint8_t first = sin6->sin6_addr.s6_addr[0];
         if ((first & 0xFE) == 0xFC) return true; // fc00::/7 (ULA)
@@ -119,7 +124,10 @@ static inline void *ry_net_connect_resolved(const struct addrinfo *info) {
         }
 
         // Restore blocking mode
-        ::fcntl(fd, F_SETFL, flags);
+        if (::fcntl(fd, F_SETFL, flags) < 0) {
+            ::close(fd);
+            continue;
+        }
 
         void *smem = arc_alloc(sizeof(TcpStreamHandle));
         if (!smem) {

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -137,6 +137,10 @@ bool __ry_is_private_addrinfo(const struct addrinfo *info) {
     return ry_net_is_private_addrinfo(info);
 }
 
+bool __ry_is_private_addr(const struct sockaddr *sa) {
+    return ry_net_is_private_addr(sa);
+}
+
 bool __ry_is_private_host(const char *host, int64_t port) {
     struct addrinfo *result = nullptr;
     if (ry_net_resolve(host, port, &result) != 0)

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -138,6 +138,7 @@ bool __ry_is_private_addrinfo(const struct addrinfo *info) {
 }
 
 bool __ry_is_private_addr(const struct sockaddr *sa) {
+    if (!sa) return false;
     return ry_net_is_private_addr(sa);
 }
 

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -1511,6 +1511,10 @@ TEST(HttpSSRF, PrivateAddrIPv6Multicast) {
     EXPECT_TRUE(__ry_is_private_addr((struct sockaddr *)&sin6));
 }
 
+TEST(HttpSSRF, PrivateAddrNullSockaddr) {
+    EXPECT_FALSE(__ry_is_private_addr(nullptr));
+}
+
 // --- Multipart form-data tests ---
 
 TEST(RuntimeHttp, FormFieldBasic) {

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -1452,6 +1452,10 @@ TEST(HttpSSRF, PrivateHostCarrierGradeNAT) {
     EXPECT_TRUE(__ry_is_private_host("100.64.0.1", 80));
 }
 
+TEST(HttpSSRF, PrivateHostCarrierGradeNATLowerEdge) {
+    EXPECT_TRUE(__ry_is_private_host("100.64.0.0", 80));
+}
+
 TEST(HttpSSRF, PrivateHostCarrierGradeNATUpper) {
     EXPECT_TRUE(__ry_is_private_host("100.127.255.255", 80));
 }
@@ -1482,6 +1486,10 @@ TEST(HttpSSRF, PrivateHostMulticastUpper) {
 
 TEST(HttpSSRF, PrivateHostReserved) {
     EXPECT_TRUE(__ry_is_private_host("240.0.0.1", 80));
+}
+
+TEST(HttpSSRF, PrivateHostReservedLowerEdge) {
+    EXPECT_TRUE(__ry_is_private_host("240.0.0.0", 80));
 }
 
 TEST(HttpSSRF, PrivateHostBroadcast) {

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -1499,7 +1499,6 @@ TEST(HttpSSRF, PublicHostBelowMulticast) {
 TEST(HttpSSRF, PrivateAddrIPv6Unspecified) {
     struct sockaddr_in6 sin6{};
     sin6.sin6_family = AF_INET6;
-    sin6.sin6_addr = IN6ADDR_ANY_INIT;
     EXPECT_TRUE(__ry_is_private_addr((struct sockaddr *)&sin6));
 }
 

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -1460,12 +1460,20 @@ TEST(HttpSSRF, PrivateHostBenchmarking) {
     EXPECT_TRUE(__ry_is_private_host("198.18.0.1", 80));
 }
 
+TEST(HttpSSRF, PrivateHostBenchmarkingLowerEdge) {
+    EXPECT_TRUE(__ry_is_private_host("198.18.0.0", 80));
+}
+
 TEST(HttpSSRF, PrivateHostBenchmarkingUpper) {
     EXPECT_TRUE(__ry_is_private_host("198.19.255.255", 80));
 }
 
 TEST(HttpSSRF, PrivateHostMulticast) {
     EXPECT_TRUE(__ry_is_private_host("224.0.0.1", 80));
+}
+
+TEST(HttpSSRF, PrivateHostMulticastLowerEdge) {
+    EXPECT_TRUE(__ry_is_private_host("224.0.0.0", 80));
 }
 
 TEST(HttpSSRF, PrivateHostMulticastUpper) {
@@ -1488,6 +1496,14 @@ TEST(HttpSSRF, PublicHostBelowCarrierGradeNAT) {
 
 TEST(HttpSSRF, PublicHostAboveCarrierGradeNAT) {
     EXPECT_FALSE(__ry_is_private_host("100.128.0.0", 80));
+}
+
+TEST(HttpSSRF, PublicHostBelowBenchmarking) {
+    EXPECT_FALSE(__ry_is_private_host("198.17.255.255", 80));
+}
+
+TEST(HttpSSRF, PublicHostAboveBenchmarking) {
+    EXPECT_FALSE(__ry_is_private_host("198.20.0.0", 80));
 }
 
 TEST(HttpSSRF, PublicHostBelowMulticast) {

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -1446,6 +1446,72 @@ TEST(HttpSSRF, PublicAddrInfoSynthetic) {
     EXPECT_FALSE(__ry_is_private_addrinfo(&ai));
 }
 
+// --- Additional SSRF range tests (IPv4) ---
+
+TEST(HttpSSRF, PrivateHostCarrierGradeNAT) {
+    EXPECT_TRUE(__ry_is_private_host("100.64.0.1", 80));
+}
+
+TEST(HttpSSRF, PrivateHostCarrierGradeNATUpper) {
+    EXPECT_TRUE(__ry_is_private_host("100.127.255.255", 80));
+}
+
+TEST(HttpSSRF, PrivateHostBenchmarking) {
+    EXPECT_TRUE(__ry_is_private_host("198.18.0.1", 80));
+}
+
+TEST(HttpSSRF, PrivateHostBenchmarkingUpper) {
+    EXPECT_TRUE(__ry_is_private_host("198.19.255.255", 80));
+}
+
+TEST(HttpSSRF, PrivateHostMulticast) {
+    EXPECT_TRUE(__ry_is_private_host("224.0.0.1", 80));
+}
+
+TEST(HttpSSRF, PrivateHostMulticastUpper) {
+    EXPECT_TRUE(__ry_is_private_host("239.255.255.255", 80));
+}
+
+TEST(HttpSSRF, PrivateHostReserved) {
+    EXPECT_TRUE(__ry_is_private_host("240.0.0.1", 80));
+}
+
+TEST(HttpSSRF, PrivateHostBroadcast) {
+    EXPECT_TRUE(__ry_is_private_host("255.255.255.255", 80));
+}
+
+// Boundary tests (should remain public / not blocked)
+
+TEST(HttpSSRF, PublicHostBelowCarrierGradeNAT) {
+    EXPECT_FALSE(__ry_is_private_host("100.63.255.255", 80));
+}
+
+TEST(HttpSSRF, PublicHostAboveCarrierGradeNAT) {
+    EXPECT_FALSE(__ry_is_private_host("100.128.0.0", 80));
+}
+
+TEST(HttpSSRF, PublicHostBelowMulticast) {
+    EXPECT_FALSE(__ry_is_private_host("223.255.255.255", 80));
+}
+
+// --- Additional SSRF range tests (IPv6 synthetic) ---
+
+TEST(HttpSSRF, PrivateAddrIPv6Unspecified) {
+    struct sockaddr_in6 sin6{};
+    sin6.sin6_family = AF_INET6;
+    sin6.sin6_addr = IN6ADDR_ANY_INIT;
+    EXPECT_TRUE(__ry_is_private_addr((struct sockaddr *)&sin6));
+}
+
+TEST(HttpSSRF, PrivateAddrIPv6Multicast) {
+    struct sockaddr_in6 sin6{};
+    sin6.sin6_family = AF_INET6;
+    sin6.sin6_addr.s6_addr[0] = 0xFF;
+    sin6.sin6_addr.s6_addr[1] = 0x02;
+    sin6.sin6_addr.s6_addr[15] = 0x01; // ff02::1
+    EXPECT_TRUE(__ry_is_private_addr((struct sockaddr *)&sin6));
+}
+
 // --- Multipart form-data tests ---
 
 TEST(RuntimeHttp, FormFieldBasic) {


### PR DESCRIPTION
## Summary

- Broadened SSRF private address filter to block CGNAT (`100.64.0.0/10`), benchmarking (`198.18.0.0/15`), multicast (`224.0.0.0/4`), reserved (`240.0.0.0/4`), IPv6 unspecified (`::`), and IPv6 multicast (`ff00::/8`)
- Added error handling for `fcntl` failure when restoring blocking mode after non-blocking connect
- Added null guard for `__ry_is_private_addr` wrapper
- Added 20 new tests (IPv4 range + boundary + edge + IPv6 synthetic + null sockaddr)

## Test plan

- [x] All 33 HttpSSRF tests pass (including 20 new)
- [x] Full C++ test suite: 1372+ tests pass
- [x] Ry self-tests: 77 files, 0 failures
- [x] ASan build: no memory errors

Closes #667