### PR TITLE
refactor: consolidate shared ARC/tag constants into ry_layout.hpp

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ry/ry_layout.hpp"
 #include "ry/ast.hpp"
 #include "ry/sema_return.hpp"
 #include "ry/source_location.hpp"
@@ -137,8 +138,6 @@ public:
 
     // ARC infrastructure
     llvm::StructType *arcHeaderTy_;                       // { i64 strong_count, i64 weak_count }
-    static constexpr uint64_t ARC_HEADER_SIZE = 16;
-    static constexpr int64_t ARC_IMMORTAL = INT64_MAX;    // sentinel: never retain/release
 
     // Cycle collector — static analysis & visit function generation
     std::unordered_set<std::string> potentially_cyclic_types_;
@@ -221,11 +220,6 @@ public:
     llvm::Constant *buildArcGlobal(const std::string &str, const llvm::Twine &name,
                                     std::unordered_map<std::string, llvm::Constant*> &cache);
     llvm::Constant *cachedGlobalString(const std::string &str, const llvm::Twine &name = "");
-    static constexpr int64_t TAG_INT   = 0;
-    static constexpr int64_t TAG_FLOAT = 1;
-    static constexpr int64_t TAG_BOOL  = 2;
-    static constexpr int64_t TAG_STR   = 3;
-    static constexpr int64_t TAG_UNIT  = 4; // reserved for future use
     std::vector<std::unordered_map<std::string, llvm::AllocaInst*>> scope_stack_;
     std::vector<std::unordered_set<std::string>> immutable_scope_stack_;
     llvm::SmallPtrSet<llvm::AllocaInst*, 8> captured_vars_; // reject reassignment of captured vars inside closure body

--- a/include/ry/runtime_any.hpp
+++ b/include/ry/runtime_any.hpp
@@ -1,18 +1,10 @@
 #pragma once
 
-#include <cstdint>
+#include "ry/ry_layout.hpp"
 
 struct RyAny {
     int64_t tag;
     alignas(8) char data[8];
-};
-
-enum RyAnyTag {
-    TAG_INT   = 0,
-    TAG_FLOAT = 1,
-    TAG_BOOL  = 2,
-    TAG_STR   = 3,
-    TAG_UNIT  = 4,
 };
 
 #ifdef __cplusplus

--- a/include/ry/runtime_arc.hpp
+++ b/include/ry/runtime_arc.hpp
@@ -3,7 +3,7 @@
 #include <cstdlib>
 
 // Allocate a block with an ARC header prepended.
-// Returns a pointer to the data area (header + 16).
+// Returns a pointer to the data area (past ARC_HEADER_SIZE bytes).
 // Caller must placement-new or initialize the data area.
 inline void *arc_alloc(size_t data_size) {
     void *block = std::malloc(ARC_HEADER_SIZE + data_size);

--- a/include/ry/runtime_arc.hpp
+++ b/include/ry/runtime_arc.hpp
@@ -1,14 +1,6 @@
 #pragma once
-#include <cstdint>
+#include "ry/ry_layout.hpp"
 #include <cstdlib>
-#include <climits>
-
-// ARC header layout: { int64_t strong_count, int64_t weak_count }
-// This must match the layout in codegen (ARC_HEADER_SIZE = 16).
-// ARC is used for: strings, collection headers (List/Set/Map), closures,
-// resources (TCP, HTTP, JSON, etc.), and enum/record payloads.
-static constexpr size_t ARC_HEADER_SIZE = 16;
-static constexpr int64_t ARC_IMMORTAL = INT64_MAX;
 
 // Allocate a block with an ARC header prepended.
 // Returns a pointer to the data area (header + 16).

--- a/include/ry/ry_layout.hpp
+++ b/include/ry/ry_layout.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+// ── ARC header layout ──────────────────────────────────
+// { int64_t strong_count, int64_t weak_count }
+inline constexpr size_t  ARC_HEADER_SIZE = 16;
+inline constexpr int64_t ARC_IMMORTAL    = INT64_MAX;
+
+// ── RyAny type tag ─────────────────────────────────────
+enum RyAnyTag : int64_t {
+    TAG_INT   = 0,
+    TAG_FLOAT = 1,
+    TAG_BOOL  = 2,
+    TAG_STR   = 3,
+    TAG_UNIT  = 4,
+};

--- a/tests/test_codegen_arc.cpp
+++ b/tests/test_codegen_arc.cpp
@@ -20,18 +20,18 @@ static_assert(sizeof(ArcHeader) == 16, "ARC header must be 16 bytes");
 static_assert(offsetof(ArcHeader, strong_count) == 0, "strong_count at offset 0");
 static_assert(offsetof(ArcHeader, weak_count) == 8, "weak_count at offset 8");
 
-// Simulate arc_alloc: malloc(16 + dataSize), init counts
+// Simulate arc_alloc: malloc(ARC_HEADER_SIZE + dataSize), init counts
 void *arcAlloc(int64_t dataSize) {
-    void *p = std::malloc(static_cast<size_t>(16 + dataSize));
+    void *p = std::malloc(static_cast<size_t>(ARC_HEADER_SIZE + dataSize));
     auto *hdr = static_cast<ArcHeader *>(p);
     hdr->strong_count = 1;
     hdr->weak_count = 0;
     return p;
 }
 
-// Simulate arc_get_data_ptr: header + 16
+// Simulate arc_get_data_ptr: header + ARC_HEADER_SIZE
 void *arcGetDataPtr(void *header) {
-    return static_cast<char *>(header) + 16;
+    return static_cast<char *>(header) + ARC_HEADER_SIZE;
 }
 
 

--- a/tests/test_codegen_arc.cpp
+++ b/tests/test_codegen_arc.cpp
@@ -1,5 +1,5 @@
 #include "test_codegen_common.hpp"
-#include <cstdint>
+#include "ry/ry_layout.hpp"
 #include <cstdlib>
 #include <cstddef>
 #include <cstring>
@@ -34,19 +34,18 @@ void *arcGetDataPtr(void *header) {
     return static_cast<char *>(header) + 16;
 }
 
-static constexpr int64_t ARC_IMMORTAL_VAL = INT64_MAX;
 
 // Simulate arc_retain (non-atomic, with immortal check)
 void arcRetain(void *header) {
     auto *hdr = static_cast<ArcHeader *>(header);
-    if (hdr->strong_count == ARC_IMMORTAL_VAL) return;
+    if (hdr->strong_count == ARC_IMMORTAL) return;
     hdr->strong_count += 1;
 }
 
 // Simulate arc_release (non-atomic, with immortal check); returns true if freed
 bool arcRelease(void *header) {
     auto *hdr = static_cast<ArcHeader *>(header);
-    if (hdr->strong_count == ARC_IMMORTAL_VAL) return false;
+    if (hdr->strong_count == ARC_IMMORTAL) return false;
     hdr->strong_count -= 1;
     if (hdr->strong_count == 0) {
         std::free(header);
@@ -156,10 +155,10 @@ TEST(ArcInfraTest, DataIntegrityThroughHeader) {
 TEST(ArcInfraTest, ImmortalSentinelSkipsRetain) {
     void *p = arcAlloc(16);
     auto *hdr = static_cast<ArcHeader *>(p);
-    hdr->strong_count = ARC_IMMORTAL_VAL;
+    hdr->strong_count = ARC_IMMORTAL;
 
     arcRetain(p);
-    EXPECT_EQ(hdr->strong_count, ARC_IMMORTAL_VAL);
+    EXPECT_EQ(hdr->strong_count, ARC_IMMORTAL);
 
     std::free(p);
 }
@@ -167,10 +166,10 @@ TEST(ArcInfraTest, ImmortalSentinelSkipsRetain) {
 TEST(ArcInfraTest, ImmortalSentinelSkipsRelease) {
     void *p = arcAlloc(16);
     auto *hdr = static_cast<ArcHeader *>(p);
-    hdr->strong_count = ARC_IMMORTAL_VAL;
+    hdr->strong_count = ARC_IMMORTAL;
 
     EXPECT_FALSE(arcRelease(p));
-    EXPECT_EQ(hdr->strong_count, ARC_IMMORTAL_VAL);
+    EXPECT_EQ(hdr->strong_count, ARC_IMMORTAL);
 
     std::free(p);
 }

--- a/tests/test_runtime_gc.cpp
+++ b/tests/test_runtime_gc.cpp
@@ -316,7 +316,7 @@ TEST(GcTest, ImmortalObjectSkipped) {
     __ry_gc_set_threshold(10000);
 
     void *hdrA = gcAllocObj(sizeof(NodeData));
-    getHeader(hdrA)->strong_count = INT64_MAX;  // immortal
+    getHeader(hdrA)->strong_count = ARC_IMMORTAL;  // immortal
 
     __ry_gc_track(hdrA, visitNode, dtorNode);
 

--- a/tests/test_runtime_gc.cpp
+++ b/tests/test_runtime_gc.cpp
@@ -1,6 +1,6 @@
 #include "test_codegen_common.hpp"
 #include "ry/runtime_gc.hpp"
-#include <cstdint>
+#include "ry/ry_layout.hpp"
 #include <cstdlib>
 #include <cstring>
 #include <vector>
@@ -12,7 +12,6 @@
 
 namespace {
 
-static constexpr size_t ARC_HDR_SIZE = 16;
 
 struct ArcHeader {
     int64_t strong_count;
@@ -21,16 +20,16 @@ struct ArcHeader {
 
 // Allocate an ARC object with the given data size.
 void *gcAllocObj(size_t dataSize) {
-    void *block = std::malloc(ARC_HDR_SIZE + dataSize);
+    void *block = std::malloc(ARC_HEADER_SIZE + dataSize);
     auto *hdr = static_cast<ArcHeader *>(block);
     hdr->strong_count = 1;
     hdr->weak_count = 0;
-    std::memset(static_cast<char *>(block) + ARC_HDR_SIZE, 0, dataSize);
+    std::memset(static_cast<char *>(block) + ARC_HEADER_SIZE, 0, dataSize);
     return block;  // returns header pointer
 }
 
 void *headerToData(void *hdr) {
-    return static_cast<char *>(hdr) + ARC_HDR_SIZE;
+    return static_cast<char *>(hdr) + ARC_HEADER_SIZE;
 }
 
 ArcHeader *getHeader(void *hdr) {


### PR DESCRIPTION
## Summary

- `ARC_HEADER_SIZE`, `ARC_IMMORTAL`, `RyAnyTag` enum が `runtime_arc.hpp`, `runtime_any.hpp`, `codegen.hpp` に手動で二重定義されていた問題を解消
- 新規共通ヘッダ `include/ry/ry_layout.hpp` に集約し、既存ヘッダとテストファイルから重複定義を削除
- `inline constexpr`（C++17）を使用し、partial rebuild 時の値ドリフトリスクを排除
- テストファイル内のローカル再定義（`ARC_IMMORTAL_VAL`, `ARC_HDR_SIZE`）も統一

Closes #675 (Phase 1)

## Test plan

- [x] `./build/ry_tests` — 1381 tests passed
- [x] `./build/ry test -p` — 77 test files, 0 failures
- [x] ASan build (`cmake --preset asan`) — 1380 tests passed, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated internal layout and tagging constants into a shared definition for consistency; removed duplicate private constants. No changes to public APIs or runtime behavior.
* **Tests**
  * Updated tests to use the consolidated layout constants. No functional test logic altered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->