### PR TITLE
ci: remove PR trigger from CodeQL, keep push/schedule/manual

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,6 +12,8 @@
 name: "CodeQL Advanced"
 
 on:
+  push:
+    branches: [ "main", "v*.*.*" ]
   schedule:
     - cron: '40 14 * * *'
   workflow_dispatch:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,17 +12,12 @@
 name: "CodeQL Advanced"
 
 on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main", "v*.*.*" ]
-    types: [opened, synchronize, reopened, ready_for_review]
   schedule:
-    - cron: '40 14 * * 6'
+    - cron: '40 14 * * *'
+  workflow_dispatch:
 
 jobs:
   analyze:
-    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     name: Analyze (${{ matrix.language }})
     # Runner size impacts CodeQL analysis time. To learn more, please see:
     #   - https://gh.io/recommended-hardware-resources-for-running-codeql


### PR DESCRIPTION
## Summary

- Remove `pull_request` trigger from CodeQL workflow (no longer runs on PRs)
- Keep `push` trigger for `main` and `v*.*.*` branches (release branch coverage)
- Change schedule from weekly (Saturday) to daily (UTC 14:40)
- Add `workflow_dispatch` for manual execution
- Remove PR-specific draft skip condition (no longer needed)

## Test plan

- [ ] Verify workflow syntax is valid by checking Actions tab
- [ ] Confirm CodeQL no longer triggers on PR events
- [ ] Test manual trigger via Actions > CodeQL Advanced > Run workflow