### PR TITLE
test: add unit tests for install_native_libs and install_stdlib edge cases

### DIFF
--- a/tests/test_self_update.cpp
+++ b/tests/test_self_update.cpp
@@ -89,25 +89,22 @@ TEST(SelfUpdate, IsValidTag) {
     EXPECT_FALSE(is_valid_tag(""));
 }
 
-// --- install_stdlib tests ---
-
-class InstallStdlibTest : public ::testing::Test {
+// Shared base for install_stdlib / install_native_libs tests.
+// Provides tmp dir lifecycle, RY_HOME save/restore, and write_file helper.
+class RyInstallTestBase : public ::testing::Test {
 protected:
     fs::path tmp_root;
-    fs::path src_dir;   // simulated archive extraction dir
-    fs::path dest_home; // simulated RY_HOME
+    fs::path src_dir;
+    fs::path dest_home;
     std::string old_ry_home;
 
-    void SetUp() override {
-        tmp_root = fs::temp_directory_path() / "ry_test_install_stdlib";
+    void SetUpDirs(const char *tmp_name) {
+        tmp_root = fs::temp_directory_path() / tmp_name;
         fs::remove_all(tmp_root);
-
         src_dir = tmp_root / "archive";
         dest_home = tmp_root / "ry_home";
-        fs::create_directories(src_dir / "share" / "std");
-        fs::create_directories(dest_home / "share" / "std");
-
-        // Save and override RY_HOME
+        fs::create_directories(src_dir);
+        fs::create_directories(dest_home);
         if (const char *env = std::getenv("RY_HOME")) {
             old_ry_home = env;
         }
@@ -126,6 +123,15 @@ protected:
     void write_file(const fs::path &path, const std::string &content) {
         fs::create_directories(path.parent_path());
         std::ofstream(path) << content;
+    }
+};
+
+class InstallStdlibTest : public RyInstallTestBase {
+protected:
+    void SetUp() override {
+        SetUpDirs("ry_test_install_stdlib");
+        fs::create_directories(src_dir / "share" / "std");
+        fs::create_directories(dest_home / "share" / "std");
     }
 };
 
@@ -224,6 +230,86 @@ TEST_F(InstallStdlibTest, OldLayoutArchiveInstallsToLibStd) {
     // Old layout archive → install to lib/std (matching old binary expectation)
     auto dest_std = dest_home / "lib" / "std";
     EXPECT_TRUE(fs::exists(dest_std / "builtins.ry"));
+}
+
+TEST_F(InstallStdlibTest, ReturnsFalseWhenNoStdlibInArchive) {
+    fs::remove_all(src_dir / "share" / "std");
+
+    bool ok = install_stdlib(src_dir.string(), "0.1.0");
+    EXPECT_FALSE(ok);
+}
+
+TEST_F(InstallStdlibTest, HandlesEmptyStdlibDirectory) {
+    bool ok = install_stdlib(src_dir.string(), "0.1.0");
+    EXPECT_TRUE(ok);
+}
+
+class InstallNativeLibsTest : public RyInstallTestBase {
+protected:
+    void SetUp() override {
+        SetUpDirs("ry_test_install_native_libs");
+    }
+};
+
+TEST_F(InstallNativeLibsTest, ReturnsFalseWhenNoLibDirectory) {
+    bool ok = install_native_libs(src_dir.string());
+    EXPECT_FALSE(ok);
+    EXPECT_FALSE(fs::exists(dest_home / "lib"));
+}
+
+TEST_F(InstallNativeLibsTest, CopiesLibryPrefixedFiles) {
+    write_file(src_dir / "lib" / "libry_parser.dylib", "parser lib");
+    write_file(src_dir / "lib" / "libry_runtime.so", "runtime lib");
+
+    bool ok = install_native_libs(src_dir.string());
+    ASSERT_TRUE(ok);
+
+    EXPECT_TRUE(fs::exists(dest_home / "lib" / "libry_parser.dylib"));
+    EXPECT_TRUE(fs::exists(dest_home / "lib" / "libry_runtime.so"));
+}
+
+TEST_F(InstallNativeLibsTest, SkipsNonLibryFiles) {
+    write_file(src_dir / "lib" / "libry_parser.dylib", "parser lib");
+    write_file(src_dir / "lib" / "libother.so", "other lib");
+    write_file(src_dir / "lib" / "readme.txt", "readme");
+
+    bool ok = install_native_libs(src_dir.string());
+    ASSERT_TRUE(ok);
+
+    EXPECT_TRUE(fs::exists(dest_home / "lib" / "libry_parser.dylib"));
+    EXPECT_FALSE(fs::exists(dest_home / "lib" / "libother.so"));
+    EXPECT_FALSE(fs::exists(dest_home / "lib" / "readme.txt"));
+}
+
+TEST_F(InstallNativeLibsTest, OverwritesExistingFiles) {
+    write_file(dest_home / "lib" / "libry_parser.dylib", "old version");
+    write_file(src_dir / "lib" / "libry_parser.dylib", "new version");
+
+    bool ok = install_native_libs(src_dir.string());
+    ASSERT_TRUE(ok);
+
+    std::ifstream ifs(dest_home / "lib" / "libry_parser.dylib");
+    std::string content((std::istreambuf_iterator<char>(ifs)),
+                         std::istreambuf_iterator<char>());
+    EXPECT_EQ(content, "new version");
+}
+
+TEST_F(InstallNativeLibsTest, ReturnsFalseWhenNoLibryFiles) {
+    write_file(src_dir / "lib" / "libother.so", "other lib");
+
+    bool ok = install_native_libs(src_dir.string());
+    EXPECT_FALSE(ok);
+}
+
+TEST_F(InstallNativeLibsTest, SkipsSubdirectories) {
+    write_file(src_dir / "lib" / "libry_parser.dylib", "parser lib");
+    write_file(src_dir / "lib" / "subdir" / "libry_nested.so", "nested lib");
+
+    bool ok = install_native_libs(src_dir.string());
+    ASSERT_TRUE(ok);
+
+    EXPECT_TRUE(fs::exists(dest_home / "lib" / "libry_parser.dylib"));
+    EXPECT_FALSE(fs::exists(dest_home / "lib" / "subdir"));
 }
 
 // --- Checksum verification tests ---

--- a/tests/test_self_update.cpp
+++ b/tests/test_self_update.cpp
@@ -3,6 +3,7 @@
 #include "ry/paths.hpp"
 #include <filesystem>
 #include <fstream>
+#include <iterator>
 #include <cstdlib>
 #include <cstdio>
 #include <string>
@@ -310,6 +311,22 @@ TEST_F(InstallNativeLibsTest, SkipsSubdirectories) {
 
     EXPECT_TRUE(fs::exists(dest_home / "lib" / "libry_parser.dylib"));
     EXPECT_FALSE(fs::exists(dest_home / "lib" / "subdir"));
+}
+
+TEST_F(InstallNativeLibsTest, ReturnsFalseWhenDestLibPathIsAFile) {
+    write_file(dest_home / "lib", "not a directory");
+    write_file(src_dir / "lib" / "libry_parser.dylib", "parser lib");
+
+    bool ok = install_native_libs(src_dir.string());
+    EXPECT_FALSE(ok);
+}
+
+TEST_F(InstallNativeLibsTest, ReturnsFalseWhenCopyFails) {
+    fs::create_directories(dest_home / "lib" / "libry_parser.dylib");
+    write_file(src_dir / "lib" / "libry_parser.dylib", "parser lib");
+
+    bool ok = install_native_libs(src_dir.string());
+    EXPECT_FALSE(ok);
 }
 
 // --- Checksum verification tests ---

--- a/tests/test_self_update.cpp
+++ b/tests/test_self_update.cpp
@@ -234,10 +234,13 @@ TEST_F(InstallStdlibTest, OldLayoutArchiveInstallsToLibStd) {
 }
 
 TEST_F(InstallStdlibTest, ReturnsFalseWhenNoStdlibInArchive) {
+    auto dest_std = dest_home / "share" / "std";
+    EXPECT_TRUE(fs::is_empty(dest_std));
     fs::remove_all(src_dir / "share" / "std");
 
     bool ok = install_stdlib(src_dir.string(), "0.1.0");
     EXPECT_FALSE(ok);
+    EXPECT_TRUE(fs::is_empty(dest_std));
 }
 
 TEST_F(InstallStdlibTest, HandlesEmptyStdlibDirectory) {
@@ -317,16 +320,22 @@ TEST_F(InstallNativeLibsTest, ReturnsFalseWhenDestLibPathIsAFile) {
     write_file(dest_home / "lib", "not a directory");
     write_file(src_dir / "lib" / "libry_parser.dylib", "parser lib");
 
+    testing::internal::CaptureStderr();
     bool ok = install_native_libs(src_dir.string());
+    std::string err = testing::internal::GetCapturedStderr();
     EXPECT_FALSE(ok);
+    EXPECT_NE(err.find("Warning: Failed to create lib directory"), std::string::npos);
 }
 
 TEST_F(InstallNativeLibsTest, ReturnsFalseWhenCopyFails) {
     fs::create_directories(dest_home / "lib" / "libry_parser.dylib");
     write_file(src_dir / "lib" / "libry_parser.dylib", "parser lib");
 
+    testing::internal::CaptureStderr();
     bool ok = install_native_libs(src_dir.string());
+    std::string err = testing::internal::GetCapturedStderr();
     EXPECT_FALSE(ok);
+    EXPECT_NE(err.find("Warning: Failed to copy"), std::string::npos);
 }
 
 // --- Checksum verification tests ---


### PR DESCRIPTION
## Summary

Closes #666

- Add `InstallNativeLibsTest` fixture with 6 tests covering all code paths in `install_native_libs()`: no lib directory, `libry_` prefix filtering, non-`libry_` file skipping, overwrite behavior, no matching files, and subdirectory skipping
- Add 2 edge case tests for `install_stdlib()`: no stdlib in archive and empty stdlib directory
- Extract `RyInstallTestBase` shared base fixture to eliminate duplication between `InstallStdlibTest` and `InstallNativeLibsTest`

## Test plan

- [x] All 14 install tests pass (`InstallStdlibTest` + `InstallNativeLibsTest`)
- [x] Full C++ test suite passes (1389 tests)
- [x] Full Ry self-test suite passes (77 files, 0 failures)
- [x] ASan build passes with no memory errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Centralized test setup/teardown into a shared base for temp-dir and environment handling; added a SetUpDirs helper.
  * Updated stdlib tests to verify behavior when the std directory is missing and when it exists but is empty.
  * New native-library tests covering missing lib directory, missing lib files, successful copying of libry* files, skipping unrelated entries and nested dirs, overwriting, and failure cases when destination is invalid or copy fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->