### PR TITLE
stability: harden C runtime against memory corruption (#631)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,25 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for banned unsafe allocation functions
+        run: |
+          # Scan src/ and include/ for raw malloc/realloc/calloc/strdup/strndup.
+          # Exclude runtime_alloc.hpp (the wrapper implementation itself) and
+          # lines that are already using the checked_* wrappers.
+          if grep -rn --include='*.cpp' --include='*.hpp' \
+            -E '\b(std::)?(malloc|realloc|calloc|strdup|strndup)\s*\(' \
+            src/ include/ \
+            | grep -v 'runtime_alloc\.hpp' \
+            | grep -v 'checked_' \
+            | grep -v '//.*\b(malloc|realloc|calloc|strdup|strndup)\b'; then
+            echo "::error::Raw allocation functions detected. Use checked_* wrappers from include/ry/runtime_alloc.hpp instead."
+            exit 1
+          fi
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
             -E '\b(std::)?(malloc|realloc|calloc|strdup|strndup)\s*\(' \
             src/ include/ \
             | grep -v 'runtime_alloc\.hpp' \
-            | grep -v 'checked_' \
-            | grep -v '//.*\b(malloc|realloc|calloc|strdup|strndup)\b'; then
+            | grep -v 'checked_'; then
             echo "::error::Raw allocation functions detected. Use checked_* wrappers from include/ry/runtime_alloc.hpp instead."
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,24 @@ ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p    # Ry セル�
 
 ASan が検出した問題（メモリリーク、バッファオーバーフロー、use-after-free 等）は必ず解消すること。ASan エラーを残したままコミットしてはならない。
 
+## メモリ安全ルール（C++ ランタイム）
+
+`include/ry/runtime_alloc.hpp` の安全なラッパーを使用すること。以下の関数は新規コードで直接呼び出してはならない:
+
+| 禁止関数 | 代替 | 理由 |
+|---------|------|------|
+| `malloc` | `checked_malloc` | OOM 時の null 未チェック → segfault |
+| `realloc` | `checked_realloc` | OOM 時の null 未チェック |
+| `calloc` | `checked_malloc` + `memset` | OOM 時の null 未チェック |
+| `strdup` | `checked_strdup` | OOM 時の null 未チェック |
+| `strndup` | `checked_strndup` | OOM 時の null 未チェック |
+| `malloc(count * sizeof(T))` | `checked_array_malloc(count, sizeof(T))` | 整数オーバーフロー → ヒープバッファオーバーフロー |
+
+その他のルール:
+- OOM 時は `oom_abort()` で即座に中断する（nullptr を返すパターンは使わない）
+- 外部入力（HTTP リクエスト、JSON パース結果等）を `strcmp` / `strlen` に渡す前に NULL チェックを行う
+- CI の `lint` ジョブが禁止関数の直接呼び出しを検出し、新規コードが追加された場合は自動でブロックする
+
 ## ワークフロー全体像
 
 1. **issue 確認** — 対象 issue の内容を把握する

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ ASan が検出した問題（メモリリーク、バッファオーバーフロ
 | `malloc(count * sizeof(T))` | `checked_array_malloc(count, sizeof(T))` | 整数オーバーフロー → ヒープバッファオーバーフロー |
 
 その他のルール:
-- OOM 時は `oom_abort()` で即座に中断する（nullptr を返すパターンは使わない）
+- OOM 時は `oom_abort(n)` のように要求サイズを渡して即座に中断する（nullptr を返すパターンは使わない）
 - 外部入力（HTTP リクエスト、JSON パース結果等）を `strcmp` / `strlen` に渡す前に NULL チェックを行う
 - CI の `lint` ジョブが禁止関数の直接呼び出しを検出し、新規コードが追加された場合は自動でブロックする
 

--- a/changelog.d/631-harden-c-runtime.md
+++ b/changelog.d/631-harden-c-runtime.md
@@ -1,0 +1,5 @@
+### Changed
+
+- All C runtime memory allocations now use OOM-safe wrappers (`checked_malloc`, `checked_strdup`, etc.) that abort with a clear message instead of silently returning NULL (#631)
+- Integer overflow checks added to array-size calculations in hash table rehash, UTF-8 reverse, and JSON parser (#631)
+- CI now enforces a lint check that blocks raw `malloc`/`realloc`/`strdup` in new code (#631)

--- a/include/ry/runtime_alloc.hpp
+++ b/include/ry/runtime_alloc.hpp
@@ -12,6 +12,11 @@ namespace ry {
     abort();
 }
 
+[[noreturn]] inline void overflow_abort(size_t count, size_t elem_size) {
+    fprintf(stderr, "ry: allocation size overflow (%zu * %zu)\n", count, elem_size);
+    abort();
+}
+
 inline void *checked_malloc(size_t n) {
     void *p = malloc(n);
     if (!p && n > 0) oom_abort(n);
@@ -39,6 +44,7 @@ inline char *checked_strndup(const char *s, size_t n) {
 }
 
 inline char *checked_memdup(const void *src, size_t len) {
+    if (!src) return nullptr;
     char *p = (char *)checked_malloc(len + 1);
     memcpy(p, src, len);
     p[len] = '\0';
@@ -49,7 +55,7 @@ inline char *checked_memdup(const void *src, size_t len) {
 inline void *checked_array_malloc(size_t count, size_t elem_size) {
     size_t total;
     if (__builtin_mul_overflow(count, elem_size, &total)) {
-        oom_abort(SIZE_MAX);
+        overflow_abort(count, elem_size);
     }
     return checked_malloc(total);
 }
@@ -58,7 +64,7 @@ inline void *checked_array_malloc(size_t count, size_t elem_size) {
 inline void *checked_array_realloc(void *ptr, size_t count, size_t elem_size) {
     size_t total;
     if (__builtin_mul_overflow(count, elem_size, &total)) {
-        oom_abort(SIZE_MAX);
+        overflow_abort(count, elem_size);
     }
     return checked_realloc(ptr, total);
 }

--- a/include/ry/runtime_alloc.hpp
+++ b/include/ry/runtime_alloc.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+namespace ry {
+
+[[noreturn]] inline void oom_abort(size_t n) {
+    fprintf(stderr, "ry: out of memory (requested %zu bytes)\n", n);
+    abort();
+}
+
+inline void *checked_malloc(size_t n) {
+    void *p = malloc(n);
+    if (!p && n > 0) oom_abort(n);
+    return p;
+}
+
+inline void *checked_realloc(void *ptr, size_t n) {
+    void *p = realloc(ptr, n);
+    if (!p && n > 0) oom_abort(n);
+    return p;
+}
+
+inline char *checked_strdup(const char *s) {
+    if (!s) return nullptr;
+    char *p = strdup(s);
+    if (!p) oom_abort(strlen(s) + 1);
+    return p;
+}
+
+inline char *checked_strndup(const char *s, size_t n) {
+    if (!s) return nullptr;
+    char *p = strndup(s, n);
+    if (!p) oom_abort(n + 1);
+    return p;
+}
+
+inline char *checked_memdup(const void *src, size_t len) {
+    char *p = (char *)checked_malloc(len + 1);
+    memcpy(p, src, len);
+    p[len] = '\0';
+    return p;
+}
+
+// Overflow-safe array allocation: aborts if count * elem_size overflows.
+inline void *checked_array_malloc(size_t count, size_t elem_size) {
+    size_t total;
+    if (__builtin_mul_overflow(count, elem_size, &total)) {
+        oom_abort(SIZE_MAX);
+    }
+    return checked_malloc(total);
+}
+
+// Overflow-safe array reallocation: aborts if count * elem_size overflows.
+inline void *checked_array_realloc(void *ptr, size_t count, size_t elem_size) {
+    size_t total;
+    if (__builtin_mul_overflow(count, elem_size, &total)) {
+        oom_abort(SIZE_MAX);
+    }
+    return checked_realloc(ptr, total);
+}
+
+} // namespace ry

--- a/include/ry/runtime_alloc.hpp
+++ b/include/ry/runtime_alloc.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>

--- a/include/ry/runtime_alloc.hpp
+++ b/include/ry/runtime_alloc.hpp
@@ -45,6 +45,7 @@ inline char *checked_strndup(const char *s, size_t n) {
 
 inline char *checked_memdup(const void *src, size_t len) {
     if (!src) return nullptr;
+    if (len == SIZE_MAX) oom_abort(len);
     char *p = (char *)checked_malloc(len + 1);
     memcpy(p, src, len);
     p[len] = '\0';

--- a/include/ry/runtime_arc.hpp
+++ b/include/ry/runtime_arc.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "ry/ry_layout.hpp"
+#include "ry/runtime_alloc.hpp"
 #include <cstdlib>
 
 
@@ -9,8 +10,7 @@ namespace ry {
 // Returns a pointer to the data area (past ARC_HEADER_SIZE bytes).
 // Caller must placement-new or initialize the data area.
 inline void *arc_alloc(size_t data_size) {
-    void *block = std::malloc(ARC_HEADER_SIZE + data_size);
-    if (!block) return nullptr;
+    void *block = checked_malloc(ARC_HEADER_SIZE + data_size);
     auto *header = static_cast<int64_t *>(block);
     header[0] = 1; // strong_count
     header[1] = 0; // weak_count

--- a/include/ry/runtime_error.hpp
+++ b/include/ry/runtime_error.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ry/runtime_alloc.hpp"
+
 #include <cstdarg>
 #include <cstdio>
 #include <cstdlib>
@@ -31,7 +33,7 @@ namespace ry {
     }                                                                          \
                                                                                \
     extern "C" const char *__ry_##prefix##_get_last_error() {                  \
-        return strdup(last_error_buf);                                         \
+        return checked_strdup(last_error_buf);                                  \
     }
 
 } // namespace ry

--- a/include/ry/runtime_http_types.hpp
+++ b/include/ry/runtime_http_types.hpp
@@ -13,6 +13,8 @@
 #include <strings.h>
 #include <vector>
 
+#include "ry/runtime_alloc.hpp"
+
 
 namespace ry {
 
@@ -105,41 +107,6 @@ struct ParsedUrl {
     char *path;
     bool is_https;
 };
-
-// ---------------------------------------------------------------------------
-// OOM-safe allocation helpers
-// ---------------------------------------------------------------------------
-
-[[noreturn]] inline void oom_abort() {
-    fprintf(stderr, "ry: out of memory\n");
-    abort();
-}
-
-inline char *checked_strndup(const char *s, size_t n) {
-    char *r = strndup(s, n);
-    if (!r) oom_abort();
-    return r;
-}
-
-inline char *checked_strdup(const char *s) {
-    char *r = strdup(s);
-    if (!r) oom_abort();
-    return r;
-}
-
-inline char *checked_memdup(const void *src, size_t len) {
-    char *r = (char *)malloc(len + 1);
-    if (!r) oom_abort();
-    memcpy(r, src, len);
-    r[len] = '\0';  // NUL-terminate for str compatibility
-    return r;
-}
-
-inline void *checked_malloc(size_t n) {
-    void *r = malloc(n);
-    if (!r) oom_abort();
-    return r;
-}
 
 // ---------------------------------------------------------------------------
 // Parallel key/value array helpers

--- a/include/ry/runtime_io.hpp
+++ b/include/ry/runtime_io.hpp
@@ -4,6 +4,8 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "ry/runtime_alloc.hpp"
+
 
 namespace ry {
 
@@ -19,13 +21,11 @@ struct IOListHeader {
 // Build a heap-allocated IOListHeader from raw bytes.
 // Each byte is stored as an int8_t element.
 inline IOListHeader *makeByteList(const uint8_t *bytes, int64_t len) {
-    auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
-    if (!header) return nullptr;
+    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
     header->len = len;
     header->cap = len;
     if (len > 0) {
-        header->data = (int8_t *)malloc(len);
-        if (!header->data) { free(header); return nullptr; }
+        header->data = (int8_t *)checked_malloc(len);
         memcpy(header->data, bytes, len);
     } else {
         header->data = nullptr;

--- a/include/ry/runtime_list.hpp
+++ b/include/ry/runtime_list.hpp
@@ -6,6 +6,8 @@
 #include <string>
 #include <vector>
 
+#include "ry/runtime_alloc.hpp"
+
 
 namespace ry {
 
@@ -21,8 +23,7 @@ struct ListHeader {
 // Duplicate a string of known length into a heap-allocated null-terminated
 // buffer.
 inline char *dupString(const char *s, size_t n) {
-    char *buf = (char *)malloc(n + 1);
-    if (!buf) return nullptr;
+    char *buf = (char *)checked_malloc(n + 1);
     memcpy(buf, s, n);
     buf[n] = '\0';
     return buf;
@@ -31,24 +32,13 @@ inline char *dupString(const char *s, size_t n) {
 // Build a heap-allocated ListHeader from a vector of strings.
 // Each string is individually heap-allocated via dupString.
 inline ListHeader *makeStringList(const std::vector<std::string> &items) {
-    auto *header = (ListHeader *)malloc(sizeof(ListHeader));
-    if (!header) return nullptr;
+    auto *header = (ListHeader *)checked_malloc(sizeof(ListHeader));
     header->len = (int64_t)items.size();
     header->cap = (int64_t)items.size();
-    header->data =
-        (char **)malloc(sizeof(char *) * (items.empty() ? 1 : items.size()));
-    if (!header->data) {
-        free(header);
-        return nullptr;
-    }
+    header->data = (char **)checked_array_malloc(
+        items.empty() ? 1 : items.size(), sizeof(char *));
     for (size_t i = 0; i < items.size(); ++i) {
         header->data[i] = dupString(items[i].c_str(), items[i].size());
-        if (!header->data[i]) {
-            for (size_t j = 0; j < i; ++j) free(header->data[j]);
-            free(header->data);
-            free(header);
-            return nullptr;
-        }
     }
     return header;
 }

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -1,3 +1,4 @@
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_any.hpp"
 #include <cmath>
 #include <cstddef>
@@ -73,18 +74,9 @@ static bool hasNaN(const RyAny *a, const RyAny *b) {
     return false;
 }
 
-static char *checkedMalloc(size_t size) {
-    char *p = static_cast<char *>(malloc(size));
-    if (!p) {
-        fprintf(stderr, "runtime error: out of memory\n");
-        exit(1);
-    }
-    return p;
-}
-
 static void repeatStr(RyAny *result, const char *s, int64_t n) {
     if (n <= 0) {
-        char *buf = checkedMalloc(1);
+        char *buf = static_cast<char *>(checked_malloc(1));
         buf[0] = '\0';
         makeStr(result, buf);
         return;
@@ -95,7 +87,7 @@ static void repeatStr(RyAny *result, const char *s, int64_t n) {
         fprintf(stderr, "runtime error: string repeat overflow\n");
         exit(1);
     }
-    char *buf = checkedMalloc(len * n + 1);
+    char *buf = static_cast<char *>(checked_malloc(len * n + 1));
     for (int64_t i = 0; i < n; i++)
         memcpy(buf + i * len, s, len);
     buf[len * n] = '\0';
@@ -107,12 +99,12 @@ static void repeatStr(RyAny *result, const char *s, int64_t n) {
 extern "C" const char *__ry_any_to_string(const RyAny *a) {
     switch (a->tag) {
     case static_cast<int64_t>(RyAnyTag::Int): {
-        char *buf = checkedMalloc(32);
+        char *buf = static_cast<char *>(checked_malloc(32));
         snprintf(buf, 32, "%lld", (long long)extractInt(a));
         return buf;
     }
     case static_cast<int64_t>(RyAnyTag::Float): {
-        char *buf = checkedMalloc(64);
+        char *buf = static_cast<char *>(checked_malloc(64));
         snprintf(buf, 64, "%g", extractFloat(a));
         return buf;
     }
@@ -158,7 +150,7 @@ extern "C" void __ry_any_add(RyAny *result, const RyAny *a, const RyAny *b) {
         const char *sa = __ry_any_to_string(a);
         const char *sb = __ry_any_to_string(b);
         size_t la = strlen(sa), lb = strlen(sb);
-        char *buf = checkedMalloc(la + lb + 1);
+        char *buf = static_cast<char *>(checked_malloc(la + lb + 1));
         memcpy(buf, sa, la);
         memcpy(buf + la, sb, lb + 1);
         if (a_alloc) free(const_cast<char *>(sa));

--- a/src/runtime_base64.cpp
+++ b/src/runtime_base64.cpp
@@ -1,3 +1,4 @@
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_error.hpp"
 
 #include <cstdint>
@@ -45,7 +46,7 @@ static char *base64_encode_impl(const char *input, size_t len, const char *table
         if (rem == 1) out_len += 2;
         else if (rem == 2) out_len += 3;
     }
-    char *out = (char *)malloc(out_len + 1);
+    char *out = (char *)checked_malloc(out_len + 1);
 
     size_t j = 0;
     for (size_t i = 0; i < len; i += 3) {
@@ -75,7 +76,7 @@ static char *base64_decode_impl(const char *input, size_t len, const int8_t *dec
         len--;
 
     size_t out_cap = len * 3 / 4;
-    char *out = (char *)malloc(out_cap + 1);
+    char *out = (char *)checked_malloc(out_cap + 1);
     size_t j = 0;
 
     for (size_t i = 0; i < len; ) {
@@ -107,7 +108,7 @@ static char *base64_decode_impl(const char *input, size_t len, const int8_t *dec
 
 // Null/empty input guard shared by all public functions
 static const char *empty_guard(const char *input, size_t *len) {
-    if (!input || (*len = strlen(input)) == 0) return strdup("");
+    if (!input || (*len = strlen(input)) == 0) return checked_strdup("");
     return nullptr;
 }
 

--- a/src/runtime_error.cpp
+++ b/src/runtime_error.cpp
@@ -4,6 +4,8 @@
 // the process at runtime via -undefined dynamic_lookup (macOS) or
 // -rdynamic (Linux).
 
+#include "ry/runtime_alloc.hpp"
+
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -18,7 +20,7 @@ extern "C" void __ry_set_last_error(const char *msg) {
 
 extern "C" const char *__ry_get_last_error() {
     // Return a heap copy so it can be stored as a ry str
-    return strdup(last_error_buf);
+    return checked_strdup(last_error_buf);
 }
 
 } // namespace ry

--- a/src/runtime_filesystem.cpp
+++ b/src/runtime_filesystem.cpp
@@ -1,3 +1,4 @@
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_list.hpp"
 #include "ry/runtime_error.hpp"
 
@@ -362,7 +363,7 @@ const char *__ry_filesystem_read_link(const char *path) {
         return nullptr;
     }
     buf[len] = '\0';
-    return strdup(buf);
+    return checked_strdup(buf);
 }
 
 } // extern "C"

--- a/src/runtime_hash.cpp
+++ b/src/runtime_hash.cpp
@@ -2,6 +2,8 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "ry/runtime_alloc.hpp"
+
 namespace ry {
 
 static const int64_t EMPTY = -1;
@@ -87,7 +89,7 @@ void __ry_ht_insert(int64_t *buckets, int64_t bucketMask,
 
 // Rehash: rebuild bucket array from dense keys array
 int64_t *__ry_ht_rehash_i64(int64_t *keys, int64_t count, int64_t newBucketCount) {
-    int64_t *buckets = (int64_t *)malloc((size_t)newBucketCount * sizeof(int64_t));
+    int64_t *buckets = (int64_t *)checked_array_malloc((size_t)newBucketCount, sizeof(int64_t));
     memset(buckets, 0xFF, (size_t)newBucketCount * sizeof(int64_t)); // fill with -1 (EMPTY)
     int64_t mask = newBucketCount - 1;
     for (int64_t i = 0; i < count; ++i) {
@@ -97,7 +99,7 @@ int64_t *__ry_ht_rehash_i64(int64_t *keys, int64_t count, int64_t newBucketCount
 }
 
 int64_t *__ry_ht_rehash_f64(double *keys, int64_t count, int64_t newBucketCount) {
-    int64_t *buckets = (int64_t *)malloc((size_t)newBucketCount * sizeof(int64_t));
+    int64_t *buckets = (int64_t *)checked_array_malloc((size_t)newBucketCount, sizeof(int64_t));
     memset(buckets, 0xFF, (size_t)newBucketCount * sizeof(int64_t));
     int64_t mask = newBucketCount - 1;
     for (int64_t i = 0; i < count; ++i) {
@@ -107,7 +109,7 @@ int64_t *__ry_ht_rehash_f64(double *keys, int64_t count, int64_t newBucketCount)
 }
 
 int64_t *__ry_ht_rehash_str(const char **keys, int64_t count, int64_t newBucketCount) {
-    int64_t *buckets = (int64_t *)malloc((size_t)newBucketCount * sizeof(int64_t));
+    int64_t *buckets = (int64_t *)checked_array_malloc((size_t)newBucketCount, sizeof(int64_t));
     memset(buckets, 0xFF, (size_t)newBucketCount * sizeof(int64_t));
     int64_t mask = newBucketCount - 1;
     for (int64_t i = 0; i < count; ++i) {

--- a/src/runtime_http_multipart.cpp
+++ b/src/runtime_http_multipart.cpp
@@ -168,6 +168,7 @@ static void parse_multipart_form_data(HttpRequestHandle *req) {
 }
 
 extern "C" const char *__ry_http_form_field(void *r, const char *name) {
+    if (!name) return nullptr;
     auto *req = (HttpRequestHandle *)r;
     parse_multipart_form_data(req);
     for (int64_t i = 0; i < req->form_field_count; i++) {
@@ -178,6 +179,7 @@ extern "C" const char *__ry_http_form_field(void *r, const char *name) {
 }
 
 extern "C" void *__ry_http_form_file(void *r, const char *name) {
+    if (!name) return nullptr;
     auto *req = (HttpRequestHandle *)r;
     parse_multipart_form_data(req);
     for (int64_t i = 0; i < req->form_file_count; i++) {

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -50,7 +50,7 @@ extern "C" const char *__ry_read_line() {
     ssize_t nread = getline(&line, &len, stdin);
     if (nread == -1) {
         free(line);
-        return strdup("");
+        return checked_strdup("");
     }
     if (nread > 0 && line[nread - 1] == '\n')
         line[nread - 1] = '\0';
@@ -64,11 +64,9 @@ extern "C" const char *__ry_read_all() {
 
     for (;;) {
         if (len + 1 >= cap) {
-            if (cap > SIZE_MAX / 2) { free(buf); oom_abort(); }
+            if (cap > SIZE_MAX / 2) { free(buf); oom_abort(cap); }
             cap *= 2;
-            char *newBuf = (char *)realloc(buf, cap);
-            if (!newBuf) { free(buf); oom_abort(); }
-            buf = newBuf;
+            buf = (char *)checked_realloc(buf, cap);
         }
         size_t to_read = cap - len - 1;
         size_t n = fread(buf + len, 1, to_read, stdin);
@@ -107,7 +105,7 @@ extern "C" const char *__ry_read_text(const char *path) {
     }
     fseek(f, 0, SEEK_SET);
 
-    char *buf = (char *)malloc((size_t)size + 1);
+    char *buf = (char *)checked_malloc((size_t)size + 1);
     size_t nread = fread(buf, 1, (size_t)size, f);
     buf[nread] = '\0';
     fclose(f);
@@ -176,8 +174,8 @@ extern "C" void *__ry_read_bytes(const char *path) {
     }
     fseek(f, 0, SEEK_SET);
 
-    auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
-    header->data = (int8_t *)malloc(size);
+    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
+    header->data = (int8_t *)checked_malloc(size);
     size_t nread = fread(header->data, 1, size, f);
     header->len = (int64_t)nread;
     header->cap = (int64_t)nread;
@@ -216,7 +214,7 @@ extern "C" const char *__ry_bytes_to_str(void *list) {
             return nullptr;
         }
     }
-    char *buf = (char *)malloc(header->len + 1);
+    char *buf = (char *)checked_malloc(header->len + 1);
     memcpy(buf, header->data, header->len);
     buf[header->len] = '\0';
     return buf;

--- a/src/runtime_json.cpp
+++ b/src/runtime_json.cpp
@@ -127,8 +127,7 @@ struct Parser {
             }
             auto *v = new (mem) JsonValue;
             v->type = JsonType::String;
-            v->string_val = strndup(src + pos, scan - pos);
-            if (!v->string_val) { arc_free(v); error = "out of memory"; return nullptr; }
+            v->string_val = checked_strndup(src + pos, scan - pos);
             pos = scan + 1;
             return v;
         }
@@ -150,8 +149,7 @@ struct Parser {
                 }
                 auto *v = new (mem) JsonValue;
                 v->type = JsonType::String;
-                v->string_val = strdup(buf.c_str());
-                if (!v->string_val) { arc_free(v); error = "out of memory"; return nullptr; }
+                v->string_val = checked_strdup(buf.c_str());
                 return v;
             }
             if (c == '\\') {
@@ -339,8 +337,7 @@ struct Parser {
         }
 
         size_t cap = 8, len = 0;
-        JsonValue **items = (JsonValue**)malloc(sizeof(JsonValue*) * cap);
-        if (!items) { error = "out of memory"; return nullptr; }
+        JsonValue **items = (JsonValue**)checked_array_malloc(cap, sizeof(JsonValue*));
 
         while (true) {
             JsonValue *item = parse_value();
@@ -358,15 +355,7 @@ struct Parser {
                     return nullptr;
                 }
                 cap *= 2;
-                JsonValue **tmp = (JsonValue**)realloc(items, sizeof(JsonValue*) * cap);
-                if (!tmp) {
-                    json_free_recursive(item);
-                    for (size_t i = 0; i < len; i++) json_free_recursive(items[i]);
-                    free(items);
-                    error = "out of memory";
-                    return nullptr;
-                }
-                items = tmp;
+                items = (JsonValue**)checked_array_realloc(items, cap, sizeof(JsonValue*));
             }
             items[len++] = item;
             skip_ws();
@@ -416,9 +405,8 @@ struct Parser {
         }
 
         size_t cap = 8, len = 0;
-        char **keys = (char**)malloc(sizeof(char*) * cap);
-        JsonValue **vals = (JsonValue**)malloc(sizeof(JsonValue*) * cap);
-        if (!keys || !vals) { free(keys); free(vals); error = "out of memory"; return nullptr; }
+        char **keys = (char**)checked_array_malloc(cap, sizeof(char*));
+        JsonValue **vals = (JsonValue**)checked_array_malloc(cap, sizeof(JsonValue*));
 
         auto cleanup = [&]() {
             for (size_t i = 0; i < len; i++) { free(keys[i]); json_free_recursive(vals[i]); }
@@ -448,18 +436,8 @@ struct Parser {
                     error = "object too large"; cleanup(); return nullptr;
                 }
                 cap *= 2;
-                char **tmp_keys = (char**)realloc(keys, sizeof(char*) * cap);
-                if (!tmp_keys) {
-                    free(key); json_free_recursive(val);
-                    error = "out of memory"; cleanup(); return nullptr;
-                }
-                keys = tmp_keys;
-                JsonValue **tmp_vals = (JsonValue**)realloc(vals, sizeof(JsonValue*) * cap);
-                if (!tmp_vals) {
-                    free(key); json_free_recursive(val);
-                    error = "out of memory"; cleanup(); return nullptr;
-                }
-                vals = tmp_vals;
+                keys = (char**)checked_array_realloc(keys, cap, sizeof(char*));
+                vals = (JsonValue**)checked_array_realloc(vals, cap, sizeof(JsonValue*));
             }
             keys[len] = key;
             vals[len] = val;
@@ -577,13 +555,6 @@ static void stringify_value(const JsonValue *v, std::string &out,
     }
 }
 
-// Allocate a C string copy using known size (avoids strlen in strdup).
-static char *string_to_cstr(const std::string &s) {
-    size_t len = s.size();
-    char *r = (char *)malloc(len + 1);
-    if (r) { memcpy(r, s.data(), len); r[len] = '\0'; }
-    return r;
-}
 
 // ===== extern "C" implementations =====
 
@@ -614,7 +585,7 @@ const char *__ry_json_stringify(void *value) {
     auto *v = (JsonValue*)value;
     std::string out;
     stringify_value(v, out, 0, 0, false);
-    return string_to_cstr(out);
+    return checked_memdup(out.data(), out.size());
 }
 
 const char *__ry_json_stringify_pretty(void *value, int64_t indent) {
@@ -625,7 +596,7 @@ const char *__ry_json_stringify_pretty(void *value, int64_t indent) {
     } else {
         stringify_value(v, out, (int)indent, 0, true);
     }
-    return string_to_cstr(out);
+    return checked_memdup(out.data(), out.size());
 }
 
 const char *__ry_json_type(void *value) {
@@ -692,7 +663,7 @@ const char *__ry_json_str(void *value) {
         __ry_set_last_error("json_str: value is not a string");
         return nullptr;
     }
-    return strdup(v->string_val);
+    return checked_strdup(v->string_val);
 }
 
 int64_t __ry_json_int(void *value, int64_t *out) {

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -1,3 +1,4 @@
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_net.hpp"
 #include "ry/runtime_net_types.hpp"
 #include "ry/runtime_net_utils.hpp"
@@ -174,7 +175,7 @@ extern "C" int64_t __ry_tcp_send(void *stream, void *byte_list) {
 }
 
 static IOListHeader *makeEmptyIOList() {
-    auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
+    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
     header->len = 0;
     header->cap = 0;
     header->data = nullptr;
@@ -187,10 +188,8 @@ extern "C" void *__ry_tcp_receive(void *stream, int64_t max_bytes) {
     }
     auto *handle = (TcpStreamHandle *)stream;
     ry_net_apply_default_recv_timeout(handle->fd);
-    auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
-    if (!header) return nullptr;
-    header->data = (int8_t *)malloc((size_t)max_bytes);
-    if (!header->data) { free(header); return nullptr; }
+    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
+    header->data = (int8_t *)checked_malloc((size_t)max_bytes);
     ssize_t n = ::recv(handle->fd, header->data, (size_t)max_bytes, 0);
     if (n < 0) {
         // Error: free everything and return nullptr
@@ -207,8 +206,7 @@ extern "C" void *__ry_tcp_receive(void *stream, int64_t max_bytes) {
         return header;
     }
     if (n < (ssize_t)max_bytes) {
-        if (auto *shrunk = (int8_t *)realloc(header->data, (size_t)n))
-            header->data = shrunk;
+        header->data = (int8_t *)checked_realloc(header->data, (size_t)n);
     }
     header->len = (int64_t)n;
     header->cap = (int64_t)n;

--- a/src/runtime_path.cpp
+++ b/src/runtime_path.cpp
@@ -1,3 +1,4 @@
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_error.hpp"
 
 #include <cerrno>
@@ -30,22 +31,14 @@ static const char *find_base(const char *p, size_t len) {
     return s;
 }
 
-// Allocate and return a substring [start, start+n).
-static char *strndup_alloc(const char *start, size_t n) {
-    char *out = (char *)malloc(n + 1);
-    memcpy(out, start, n);
-    out[n] = '\0';
-    return out;
-}
-
 // ===== Internal =====
 
 // If b is absolute, returns a copy of b.
 // Otherwise concatenates a + "/" + b, normalizing double slashes.
 static char *join2_impl(const char *a, const char *b) {
-    if (!a || !*a) return strdup(b ? b : "");
-    if (!b || !*b) return strdup(a);
-    if (b[0] == '/') return strdup(b);
+    if (!a || !*a) return checked_strdup(b ? b : "");
+    if (!b || !*b) return checked_strdup(a);
+    if (b[0] == '/') return checked_strdup(b);
 
     size_t a_len = strip_trailing(a, strlen(a));
     size_t b_len = strlen(b);
@@ -53,7 +46,7 @@ static char *join2_impl(const char *a, const char *b) {
     // If a ends with '/' (root path), don't insert an extra separator
     bool need_sep = (a[a_len - 1] != '/');
     size_t out_len = a_len + (need_sep ? 1 : 0) + b_len;
-    char *out = (char *)malloc(out_len + 1);
+    char *out = (char *)checked_malloc(out_len + 1);
     memcpy(out, a, a_len);
     if (need_sep)
         out[a_len] = '/';
@@ -85,10 +78,10 @@ extern "C" const char *__ry_path_join4(const char *a, const char *b, const char 
 }
 
 extern "C" const char *__ry_path_basename(const char *p) {
-    if (!p || !*p) return strdup("");
+    if (!p || !*p) return checked_strdup("");
 
     size_t len = strip_trailing(p, strlen(p));
-    if (len == 1 && p[0] == '/') return strdup("");
+    if (len == 1 && p[0] == '/') return checked_strdup("");
 
     const char *end = p + len;
     const char *base = find_base(p, len);
@@ -96,11 +89,11 @@ extern "C" const char *__ry_path_basename(const char *p) {
     // If base points to a '/', skip it
     if (*base == '/') base++;
 
-    return strndup_alloc(base, (size_t)(end - base));
+    return checked_strndup(base, (size_t)(end - base));
 }
 
 extern "C" const char *__ry_path_dirname(const char *p) {
-    if (!p || !*p) return strdup(".");
+    if (!p || !*p) return checked_strdup(".");
 
     size_t len = strip_trailing(p, strlen(p));
 
@@ -110,7 +103,7 @@ extern "C" const char *__ry_path_dirname(const char *p) {
         slash--;
 
     if (slash == p) {
-        return strdup(*slash == '/' ? "/" : ".");
+        return checked_strdup(*slash == '/' ? "/" : ".");
     }
 
     // Strip trailing slashes from dirname portion
@@ -119,13 +112,13 @@ extern "C" const char *__ry_path_dirname(const char *p) {
         dir_end--;
 
     size_t dir_len = (size_t)(dir_end - p);
-    if (dir_len == 0) return strdup("/");
+    if (dir_len == 0) return checked_strdup("/");
 
-    return strndup_alloc(p, dir_len);
+    return checked_strndup(p, dir_len);
 }
 
 extern "C" const char *__ry_path_extension(const char *p) {
-    if (!p || !*p) return strdup("");
+    if (!p || !*p) return checked_strdup("");
 
     size_t len = strip_trailing(p, strlen(p));
     const char *end = p + len;
@@ -140,9 +133,9 @@ extern "C" const char *__ry_path_extension(const char *p) {
     }
 
     // No dot, or dot is the first character (hidden file like .gitignore)
-    if (!dot || dot == base) return strdup("");
+    if (!dot || dot == base) return checked_strdup("");
 
-    return strndup_alloc(dot, (size_t)(end - dot));
+    return checked_strndup(dot, (size_t)(end - dot));
 }
 
 extern "C" const char *__ry_path_resolve(const char *p) {

--- a/src/runtime_print.cpp
+++ b/src/runtime_print.cpp
@@ -39,8 +39,9 @@ static int append_vprintf(char *&buf, size_t &len, size_t &cap,
     }
 
     if (static_cast<size_t>(n) >= remaining) {
-        size_t newCap = len + static_cast<size_t>(n) + 1;
-        if (newCap < cap * 2) newCap = cap * 2;
+        size_t needed = len + static_cast<size_t>(n) + 1;
+        size_t doubled = (cap <= SIZE_MAX / 2) ? cap * 2 : SIZE_MAX;
+        size_t newCap = (needed > doubled) ? needed : doubled;
         buf = static_cast<char *>(checked_realloc(buf, newCap));
         cap = newCap;
         std::vsnprintf(buf + len, cap - len, fmt, args2);

--- a/src/runtime_print.cpp
+++ b/src/runtime_print.cpp
@@ -1,3 +1,4 @@
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_print.hpp"
 
 #include <cstdarg>
@@ -40,12 +41,7 @@ static int append_vprintf(char *&buf, size_t &len, size_t &cap,
     if (static_cast<size_t>(n) >= remaining) {
         size_t newCap = len + static_cast<size_t>(n) + 1;
         if (newCap < cap * 2) newCap = cap * 2;
-        char *newBuf = static_cast<char *>(std::realloc(buf, newCap));
-        if (!newBuf) {
-            va_end(args2);
-            return -1;
-        }
-        buf = newBuf;
+        buf = static_cast<char *>(checked_realloc(buf, newCap));
         cap = newCap;
         std::vsnprintf(buf + len, cap - len, fmt, args2);
     }
@@ -61,11 +57,7 @@ extern "C" void __ry_print_begin() {
         tl_len = 0;
         if (!tl_buf) {
             tl_cap = kInitialCap;
-            tl_buf = static_cast<char *>(std::malloc(tl_cap));
-            if (!tl_buf) {
-                tl_cap = 0;
-                --tl_depth;
-            }
+            tl_buf = static_cast<char *>(checked_malloc(tl_cap));
         }
     }
 }
@@ -112,9 +104,7 @@ extern "C" void __ry_sprint_begin() {
     ++tl_sprint_depth;
     if (!tl_sprint_buf) {
         tl_sprint_cap = kInitialCap;
-        tl_sprint_buf = static_cast<char *>(std::malloc(tl_sprint_cap));
-        if (!tl_sprint_buf)
-            tl_sprint_cap = 0;
+        tl_sprint_buf = static_cast<char *>(checked_malloc(tl_sprint_cap));
     }
 }
 
@@ -133,12 +123,10 @@ extern "C" char *__ry_sprint_end() {
     if (tl_sprint_depth < kMaxSprintDepth)
         start = tl_sprint_offsets[tl_sprint_depth];
     size_t len = tl_sprint_len - start;
-    char *result = static_cast<char *>(std::malloc(len + 1));
-    if (result) {
-        if (len > 0)
-            std::memcpy(result, tl_sprint_buf + start, len);
-        result[len] = '\0';
-    }
+    char *result = static_cast<char *>(checked_malloc(len + 1));
+    if (len > 0)
+        std::memcpy(result, tl_sprint_buf + start, len);
+    result[len] = '\0';
     tl_sprint_len = start;
     return result;
 }

--- a/src/runtime_print.cpp
+++ b/src/runtime_print.cpp
@@ -39,7 +39,9 @@ static int append_vprintf(char *&buf, size_t &len, size_t &cap,
     }
 
     if (static_cast<size_t>(n) >= remaining) {
-        size_t needed = len + static_cast<size_t>(n) + 1;
+        size_t sn = static_cast<size_t>(n);
+        if (len > SIZE_MAX - sn - 1) oom_abort(len);
+        size_t needed = len + sn + 1;
         size_t doubled = (cap <= SIZE_MAX / 2) ? cap * 2 : SIZE_MAX;
         size_t newCap = (needed > doubled) ? needed : doubled;
         buf = static_cast<char *>(checked_realloc(buf, newCap));

--- a/src/runtime_sort.cpp
+++ b/src/runtime_sort.cpp
@@ -205,8 +205,7 @@ void __ry_timsort(void *data, int64_t len, int64_t elemSize,
     }
 
     // Allocate temp buffer for merging (max half of array)
-    int64_t tmpSize = (len / 2 + 1) * elemSize;
-    void *tmpBuf = checked_malloc(tmpSize);
+    void *tmpBuf = checked_array_malloc((size_t)(len / 2 + 1), (size_t)elemSize);
 
     // Run stack (max 85 entries for 2^64 elements)
     RunEntry runStack[85];

--- a/src/runtime_sort.cpp
+++ b/src/runtime_sort.cpp
@@ -3,6 +3,8 @@
 #include <cstring>
 #include <algorithm>
 
+#include "ry/runtime_alloc.hpp"
+
 namespace ry {
 
 // TimSort implementation for the Ry language runtime.
@@ -32,7 +34,7 @@ static inline void *elemAt(void *data, int64_t index, int64_t elemSize) {
 
 static void reverseRange(void *data, int64_t lo, int64_t hi, int64_t elemSize) {
     char tmp[256];
-    void *tmpBuf = elemSize <= (int64_t)sizeof(tmp) ? tmp : malloc(elemSize);
+    void *tmpBuf = elemSize <= (int64_t)sizeof(tmp) ? tmp : checked_malloc(elemSize);
     int64_t left = lo, right = hi - 1;
     while (left < right) {
         elemCopy(tmpBuf, elemAt(data, left, elemSize), elemSize);
@@ -49,7 +51,7 @@ static void binaryInsertionSort(void *data, int64_t lo, int64_t hi,
                                  int64_t start, int64_t elemSize,
                                  CmpFn cmp, void *ctx) {
     char tmp[256];
-    void *tmpBuf = elemSize <= (int64_t)sizeof(tmp) ? tmp : malloc(elemSize);
+    void *tmpBuf = elemSize <= (int64_t)sizeof(tmp) ? tmp : checked_malloc(elemSize);
 
     for (int64_t i = start; i < hi; i++) {
         elemCopy(tmpBuf, elemAt(data, i, elemSize), elemSize);
@@ -204,7 +206,7 @@ void __ry_timsort(void *data, int64_t len, int64_t elemSize,
 
     // Allocate temp buffer for merging (max half of array)
     int64_t tmpSize = (len / 2 + 1) * elemSize;
-    void *tmpBuf = malloc(tmpSize);
+    void *tmpBuf = checked_malloc(tmpSize);
 
     // Run stack (max 85 entries for 2^64 elements)
     RunEntry runStack[85];

--- a/src/runtime_tls.cpp
+++ b/src/runtime_tls.cpp
@@ -1,3 +1,4 @@
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_tls.hpp"
 #include "ry/runtime_arc.hpp"
 #include "ry/runtime_net_utils.hpp"
@@ -153,7 +154,7 @@ extern "C" void *__ry_tls_receive(void *tls_stream, int64_t max_bytes) {
     auto *h = (TlsStreamHandle *)tls_stream;
     ry_net_apply_default_recv_timeout(h->fd);
     if (max_bytes <= 0) {
-        auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
+        auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
         header->len = 0;
         header->cap = 0;
         header->data = nullptr;
@@ -161,8 +162,8 @@ extern "C" void *__ry_tls_receive(void *tls_stream, int64_t max_bytes) {
     }
     auto *handle = (TlsStreamHandle *)tls_stream;
 
-    auto *header = (IOListHeader *)malloc(sizeof(IOListHeader));
-    header->data = (int8_t *)malloc((size_t)max_bytes);
+    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
+    header->data = (int8_t *)checked_malloc((size_t)max_bytes);
 
     int n = SSL_read(handle->ssl, header->data, (int)max_bytes);
     if (n < 0) {

--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -140,7 +140,6 @@ char *__ry_utf8_reverse(const char *s) {
     const char *p = s;
     while (*p) {
         if (count == capacity) {
-            if (capacity > SIZE_MAX / 2) oom_abort(capacity);
             capacity *= 2;
             cps = static_cast<CPInfo *>(checked_array_realloc(cps, capacity, sizeof(CPInfo)));
         }

--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -140,6 +140,7 @@ char *__ry_utf8_reverse(const char *s) {
     const char *p = s;
     while (*p) {
         if (count == capacity) {
+            if (capacity > SIZE_MAX / 2) oom_abort(capacity);
             capacity *= 2;
             cps = static_cast<CPInfo *>(checked_array_realloc(cps, capacity, sizeof(CPInfo)));
         }

--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_list.hpp"
 
 
@@ -39,7 +40,7 @@ char *__ry_utf8_char_at(const char *s, int64_t i) {
     for (int64_t idx = 0; *p; ++idx) {
         int len = utf8_char_len_nul(p);
         if (idx == i) {
-            char *buf = static_cast<char *>(malloc(len + 1));
+            char *buf = static_cast<char *>(checked_malloc(len + 1));
             memcpy(buf, p, len);
             buf[len] = '\0';
             return buf;
@@ -60,7 +61,7 @@ char *__ry_utf8_char_at_checked(const char *s, int64_t i) {
         while (*p) {
             int len = utf8_char_len_nul(p);
             if (idx == i) {
-                char *buf = static_cast<char *>(malloc(len + 1));
+                char *buf = static_cast<char *>(checked_malloc(len + 1));
                 memcpy(buf, p, len);
                 buf[len] = '\0';
                 return buf;
@@ -96,7 +97,7 @@ char *__ry_utf8_char_at_checked(const char *s, int64_t i) {
         p += utf8_char_len_nul(p);
 
     int len = utf8_char_len_nul(p);
-    char *buf = static_cast<char *>(malloc(len + 1));
+    char *buf = static_cast<char *>(checked_malloc(len + 1));
     memcpy(buf, p, len);
     buf[len] = '\0';
     return buf;
@@ -119,7 +120,7 @@ char *__ry_utf8_substring(const char *s, int64_t start, int64_t endIdx) {
     if (!startPtr) startPtr = endPtr;
 
     size_t byteLen = endPtr - startPtr;
-    char *buf = static_cast<char *>(malloc(byteLen + 1));
+    char *buf = static_cast<char *>(checked_malloc(byteLen + 1));
     memcpy(buf, startPtr, byteLen);
     buf[byteLen] = '\0';
     return buf;
@@ -128,19 +129,19 @@ char *__ry_utf8_substring(const char *s, int64_t start, int64_t endIdx) {
 char *__ry_utf8_reverse(const char *s) {
     // Collect character byte-offsets and lengths
     size_t totalBytes = strlen(s);
-    char *buf = static_cast<char *>(malloc(totalBytes + 1));
+    char *buf = static_cast<char *>(checked_malloc(totalBytes + 1));
 
     // First pass: collect codepoint boundaries
     struct CPInfo { const char *ptr; int len; };
     size_t capacity = 64;
     size_t count = 0;
-    CPInfo *cps = static_cast<CPInfo *>(malloc(capacity * sizeof(CPInfo)));
+    CPInfo *cps = static_cast<CPInfo *>(checked_array_malloc(capacity, sizeof(CPInfo)));
 
     const char *p = s;
     while (*p) {
         if (count == capacity) {
             capacity *= 2;
-            cps = static_cast<CPInfo *>(realloc(cps, capacity * sizeof(CPInfo)));
+            cps = static_cast<CPInfo *>(checked_array_realloc(cps, capacity, sizeof(CPInfo)));
         }
         int len = utf8_char_len_nul(p);
         cps[count++] = {p, len};
@@ -178,27 +179,16 @@ void *__ry_split_chars(const char *s) {
         ++count;
 
     // Build ListHeader directly (avoids intermediate vector + double-copy)
-    auto *header = (ListHeader *)malloc(sizeof(ListHeader));
-    if (!header) return nullptr;
+    auto *header = (ListHeader *)checked_malloc(sizeof(ListHeader));
     header->len = count;
     header->cap = count;
-    header->data = (char **)malloc(sizeof(char *) * (count ? count : 1));
-    if (!header->data) {
-        free(header);
-        return nullptr;
-    }
+    header->data = (char **)checked_array_malloc(count ? count : 1, sizeof(char *));
 
     // Second pass: populate string array
     const char *p = s;
     for (int64_t i = 0; i < count; ++i) {
         int len = utf8_char_len_nul(p);
         header->data[i] = dupString(p, len);
-        if (!header->data[i]) {
-            for (int64_t j = 0; j < i; ++j) free(header->data[j]);
-            free(header->data);
-            free(header);
-            return nullptr;
-        }
         p += len;
     }
     return header;

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -1,3 +1,4 @@
+#include "ry/runtime_alloc.hpp"
 #include "ry/test_runtime.hpp"
 #include <cstdio>
 #include <cstdint>
@@ -145,7 +146,7 @@ const char *__ry_test_rand_str() {
     std::uniform_int_distribution<int> charDist(32, 126); // printable ASCII
     auto &rng = getRng();
     int len = lenDist(rng);
-    char *buf = static_cast<char*>(std::malloc(len + 1));
+    char *buf = static_cast<char*>(checked_malloc(len + 1));
     for (int i = 0; i < len; ++i)
         buf[i] = static_cast<char>(charDist(rng));
     buf[len] = '\0';


### PR DESCRIPTION
## Summary

- Centralize OOM-safe allocation wrappers in `include/ry/runtime_alloc.hpp` (`checked_malloc`, `checked_realloc`, `checked_strdup`, `checked_strndup`, `checked_memdup`, `checked_array_malloc`, `checked_array_realloc`)
- Replace ~50 unchecked `malloc`/`realloc`/`strdup` calls across 15 runtime source files with safe wrappers that abort with clear diagnostics on OOM
- Fix integer overflow vulnerabilities in hash table rehash (`runtime_hash.cpp`) and UTF-8 reverse (`runtime_utf8.cpp`) via `checked_array_malloc`
- Add NULL guards to `__ry_http_form_field` / `__ry_http_form_file` for strcmp safety
- Add CI lint job that blocks raw allocation functions in new code
- Document memory safety rules in AGENTS.md

Closes #631

## Test plan

- [x] All C++ tests pass (1391 tests)
- [x] All Ry self-tests pass (77 files, 0 failures)
- [x] ASan build passes (1390 tests + 77 self-test files)
- [x] CI lint grep pattern returns clean (no banned functions detected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Safe allocation helpers added with overflow checks and OOM abort behavior.

* **Bug Fixes**
  * Added null-pointer guards to HTTP multipart accessors.

* **Documentation**
  * Contributor guidance and changelog updated with memory-safety rules and hardening notes.

* **Chores**
  * CI lint gate added to block direct use of unsafe allocation APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->