### PR TITLE
feat: closure capture for nested named functions

### DIFF
--- a/changelog.d/661-nested-fn-closure-capture.md
+++ b/changelog.d/661-nested-fn-closure-capture.md
@@ -1,0 +1,3 @@
+### Added
+
+- Nested named functions can now capture variables from enclosing scopes, behaving as closures just like lambdas (#661)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -124,7 +124,27 @@ bar()   # 2
 
 Nested functions can be used as values and passed to higher-order functions. Mutual recursion between nested functions in the same scope also works (the compiler forward-declares them).
 
-> **Note:** Nested named functions do not yet capture variables from enclosing scopes. Use lambdas for closure capture.
+### Closure Capture
+
+Nested named functions can capture variables from enclosing scopes, just like lambdas. When a nested function references an outer variable, it becomes a closure:
+
+```python
+function make_adder(base: int) -> function(int) -> int:
+    function add(x: int) -> int:
+        return x + base
+    return add
+
+add10 = make_adder(10)
+add10(5)   # 15
+```
+
+Capture rules:
+
+- Captures are **by value** (same as lambdas). The value is copied at the point the closure is created.
+- Captured variables **cannot be reassigned** inside the nested function body.
+- ARC-managed values (strings, lists, etc.) are properly retained and released.
+- If a nested function has no captures, it remains a plain function pointer (no overhead).
+- Multi-level capture works: a deeply nested function can reference variables from any enclosing scope.
 
 ---
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -227,7 +227,22 @@ public:
     llvm::SmallPtrSet<llvm::AllocaInst*, 8> captured_vars_; // reject reassignment of captured vars inside closure body
     std::vector<std::vector<llvm::Value*>> iterator_malloc_stack_; // per-scope iterator malloc tracking
 
+    // ======== Closure Capture ARC Kinds ========
+    // Determines which destructor to use when releasing a captured value.
+    // Defined here (before OverloadEntry) so nested-function capture metadata
+    // can reference it.
+    enum class CapturedArcKind {
+        None,       // not ARC-managed
+        List,
+        Map,
+        Set,
+        Closure,
+        Resource,   // generic resource (destructor not tracked per-capture)
+        Generic,    // ARC-managed but no sub-destructor (e.g., f-strings)
+    };
+
     // ======== Function Overloads & Dispatch ========
+    struct FnTypeInfo;  // forward declaration for capturedClosureInfos
     struct OverloadEntry {
         llvm::Function *func;
         std::vector<llvm::Type*> paramTypes;
@@ -239,6 +254,12 @@ public:
         const std::vector<ExprPtr> *preconditions = nullptr;
         const std::vector<ExprPtr> *postconditions = nullptr;
         const std::vector<std::string> *ensureBindings = nullptr;
+        // Capture metadata for nested functions with closures (empty = no captures)
+        std::vector<std::string> capturedNames;
+        std::vector<llvm::Type*> capturedTypes;
+        std::vector<CapturedArcKind> capturedArcKinds;
+        std::vector<ResourceKind> capturedResourceKinds;
+        std::unique_ptr<std::unordered_map<size_t, FnTypeInfo>> capturedClosureInfos;
     };
     std::unordered_map<std::string, std::vector<OverloadEntry>> functions_;
     std::unordered_set<llvm::Function*> forward_declared_fns_;
@@ -344,17 +365,6 @@ public:
     std::string reverseResolveType(llvm::Value *val);
 
     // ======== Closure & Lambda Support ========
-    // Captured variable ARC kind — determines which destructor to use on release
-    enum class CapturedArcKind {
-        None,       // not ARC-managed
-        List,
-        Map,
-        Set,
-        Closure,
-        Resource,   // generic resource (destructor not tracked per-capture)
-        Generic,    // ARC-managed but no sub-destructor (e.g., f-strings)
-    };
-
     // Function type info for indirect calls (lambda / function pointers)
     struct FnTypeInfo {
         std::vector<llvm::Type*> paramTypes;
@@ -435,6 +445,30 @@ public:
     };
     std::map<ClosureDtorKey, llvm::FunctionCallee> closure_destructors_cache_;
     CapturedArcKind detectCapturedArcKind(llvm::AllocaInst *alloca) const;
+
+    // Free-variable analysis result — shared between lambda and nested named function codegen
+    struct CaptureAnalysisResult {
+        std::vector<std::string> capturedNames;
+        std::vector<llvm::Value*> capturedValues;
+        std::vector<llvm::Type*> capturedTypes;
+        std::vector<CapturedArcKind> capturedArcKinds;
+        std::vector<ResourceKind> capturedResourceKinds;
+        std::unordered_map<size_t, FnTypeInfo> capturedClosureInfos;
+        llvm::SmallVector<bool, 8> capturedIsConst;
+    };
+    CaptureAnalysisResult analyzeFreeVariables(
+        const std::vector<StmtNode> &body,
+        const ExprPtr &expr_body,
+        const std::unordered_set<std::string> &paramNames,
+        bool emitLoads = true);
+
+    // Build ARC-managed closure struct {fn_ptr, cap1, cap2, ...} and return the closure pointer.
+    // Returns the raw function pointer if capturedValues is empty.
+    llvm::Value *buildClosureStruct(
+        llvm::Function *func,
+        const FnTypeInfo &info,
+        const std::vector<llvm::Value*> &capturedValues);
+
     int lambda_counter_ = 0;
     bool test_mode_ = false;
     bool outline_mode_ = false;

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -212,6 +212,18 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         }
     }
 
+    // Append captured variable values for nested functions with closures
+    if (matchedEntry && !matchedEntry->capturedNames.empty()) {
+        for (auto &capName : matchedEntry->capturedNames) {
+            llvm::AllocaInst *capAlloca = findVar(capName);
+            if (!capAlloca)
+                codegenError("captured variable '" + capName + "' not found in calling scope");
+            llvm::Value *capVal = builder_.CreateLoad(
+                capAlloca->getAllocatedType(), capAlloca, capName + ".cap_pass");
+            argVals.push_back(capVal);
+        }
+    }
+
     // ARC: retain arguments that are ARC-managed before passing to callee
     for (auto *argVal : argVals)
         tryRetainArcSource(argVal);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -125,11 +125,35 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
     if (fnOverloads && fnOverloads->size() == 1) {
         if (deprecated_functions_.count(e.name))
             emitDeprecationWarning(e.name);
-        llvm::Function *func = (*fnOverloads)[0].func;
+        auto &entry = (*fnOverloads)[0];
+        llvm::Function *func = entry.func;
         FnTypeInfo info;
-        info.paramTypes = (*fnOverloads)[0].paramTypes;
-        info.paramTypeNames = (*fnOverloads)[0].paramTypeNames;
+        info.paramTypes = entry.paramTypes;
+        info.paramTypeNames = entry.paramTypeNames;
         info.returnType = func->getReturnType();
+
+        // If this nested function has captures, materialize as a closure struct
+        if (!entry.capturedNames.empty()) {
+            info.capturedVars = entry.capturedNames;
+            info.capturedTypes = entry.capturedTypes;
+            info.capturedArcKinds = entry.capturedArcKinds;
+            info.capturedResourceKinds = entry.capturedResourceKinds;
+            if (entry.capturedClosureInfos)
+                info.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(*entry.capturedClosureInfos);
+            fn_type_info_[func] = info;
+
+            // Load captured values from the current scope
+            std::vector<llvm::Value*> capturedValues;
+            for (auto &capName : entry.capturedNames) {
+                llvm::AllocaInst *capAlloca = findVar(capName);
+                if (!capAlloca)
+                    codegenError("captured variable '" + capName + "' not found when materializing function '" + e.name + "'");
+                capturedValues.push_back(builder_.CreateLoad(
+                    capAlloca->getAllocatedType(), capAlloca, capName + ".cap_mat"));
+            }
+            return buildClosureStruct(func, info, capturedValues);
+        }
+
         fn_type_info_[func] = info;
         return func;
     }

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -617,6 +617,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
                 // Update the OverloadEntry
                 bool isNestedScope = fn_nesting_depth_ > 0 && !fn_scope_stack_.empty();
                 auto &overloads = isNestedScope ? fn_scope_stack_.back()[s->name] : functions_[s->name];
+                bool entryUpdated = false;
                 for (auto &entry : overloads) {
                     if (entry.paramTypes == paramTypes) {
                         entry.func = extFunc;
@@ -626,9 +627,12 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
                         entry.capturedResourceKinds = captures.capturedResourceKinds;
                         if (!captures.capturedClosureInfos.empty())
                             entry.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(std::move(captures.capturedClosureInfos));
+                        entryUpdated = true;
                         break;
                     }
                 }
+                if (!entryUpdated)
+                    codegenError("internal error: no matching OverloadEntry for nested function '" + s->name + "'");
                 func = extFunc;
             }
         }

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -569,7 +569,6 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     llvm::Type *exposedRetTy = s->is_async ? resolveType(exposedReturnTypeName) : bodyRetTy;
 
     // If not forward-declared, do the full declaration now
-    bool wasForwardDeclared = (func != nullptr);
     if (!func) {
         func = declareFunction(
             s->name, paramTypes, s->params, exposedRetTy,

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -292,7 +292,8 @@ llvm::Function *CodeGen::declareFunction(
         paramTypeNames.push_back(p.type->toString());
     overloads.push_back({func, paramTypes, paramNames, paramTypeNames, exposedReturnTypeName,
                          newMinArity, std::move(defaults),
-                         preconditions, postconditions, ensureBindings});
+                         preconditions, postconditions, ensureBindings,
+                         {}, {}, {}, {}, {}});
 
     if (hasDirective(directives, "deprecated"))
         deprecated_functions_.insert(name);
@@ -361,6 +362,48 @@ void CodeGen::forwardDeclareFunctionsInBody(std::vector<StmtNode> &stmts, bool v
             exposedReturnTypeName, s->directives,
             &s->preconditions, &s->postconditions, &s->ensure_bindings);
         applyInlineDirective(func, s->directives);
+
+        // For nested functions, run capture analysis and extend the LLVM function
+        // signature with capture parameters. This must happen at forward-declaration
+        // time so that sibling functions that call this function pass capture args.
+        if (fn_nesting_depth_ > 0) {
+            std::unordered_set<std::string> paramNameSet;
+            for (auto &p : s->params)
+                paramNameSet.insert(p.name);
+            auto captures = analyzeFreeVariables(s->body, nullptr, paramNameSet, /*emitLoads=*/false);
+
+            if (!captures.capturedNames.empty()) {
+                // Build extended param types (user params + captured vars)
+                std::vector<llvm::Type*> extParamTypes = paramTypes;
+                for (auto *capTy : captures.capturedTypes)
+                    extParamTypes.push_back(capTy);
+
+                // Create new function with extended signature
+                llvm::FunctionType *extFt = llvm::FunctionType::get(
+                    func->getReturnType(), extParamTypes, false);
+                llvm::Function *extFunc = llvm::Function::Create(
+                    extFt, func->getLinkage(), func->getName().str(), *mod_);
+                applyInlineDirective(extFunc, s->directives);
+
+                // Safe to erase: no users exist at forward-declaration time
+                func->eraseFromParent();
+
+                // Update the OverloadEntry that declareFunction just created
+                bool isNestedScope = fn_nesting_depth_ > 0 && !fn_scope_stack_.empty();
+                auto &overloads = isNestedScope ? fn_scope_stack_.back()[s->name] : functions_[s->name];
+                auto &entry = overloads.back();
+                entry.func = extFunc;
+                entry.capturedNames = std::move(captures.capturedNames);
+                entry.capturedTypes = std::move(captures.capturedTypes);
+                entry.capturedArcKinds = std::move(captures.capturedArcKinds);
+                entry.capturedResourceKinds = std::move(captures.capturedResourceKinds);
+                if (!captures.capturedClosureInfos.empty())
+                    entry.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(std::move(captures.capturedClosureInfos));
+
+                func = extFunc;
+            }
+        }
+
         forward_declared_fns_.insert(func);
     }
 }
@@ -526,6 +569,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     llvm::Type *exposedRetTy = s->is_async ? resolveType(exposedReturnTypeName) : bodyRetTy;
 
     // If not forward-declared, do the full declaration now
+    bool wasForwardDeclared = (func != nullptr);
     if (!func) {
         func = declareFunction(
             s->name, paramTypes, s->params, exposedRetTy,
@@ -539,6 +583,58 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     for (auto &p : s->params)
         paramTypeNames.push_back(p.type->toString());
 
+    // Capture analysis for nested functions.
+    // Re-run analysis (without emitting loads) to get metadata for body emission.
+    // If the LLVM function doesn't yet have capture params (e.g. forward-declared
+    // before local vars were in scope), extend the signature now.
+    CaptureAnalysisResult captures;
+    if (fn_nesting_depth_ > 0) {
+        std::unordered_set<std::string> paramNameSet;
+        for (auto &p : s->params)
+            paramNameSet.insert(p.name);
+        captures = analyzeFreeVariables(s->body, nullptr, paramNameSet, /*emitLoads=*/false);
+
+        if (!captures.capturedNames.empty()) {
+            size_t expectedArgCount = s->params.size() + captures.capturedNames.size();
+            if (func->arg_size() != expectedArgCount) {
+                // Function signature needs extension (captures not yet in signature).
+                if (!func->use_empty())
+                    codegenError("nested function '" + s->name +
+                        "' captures variables from the enclosing scope but is called "
+                        "from a sibling function before its definition; move '" +
+                        s->name + "' before the calling function, or restructure the code");
+
+                std::vector<llvm::Type*> extParamTypes = paramTypes;
+                for (auto *capTy : captures.capturedTypes)
+                    extParamTypes.push_back(capTy);
+
+                llvm::FunctionType *extFt = llvm::FunctionType::get(
+                    func->getReturnType(), extParamTypes, false);
+                llvm::Function *extFunc = llvm::Function::Create(
+                    extFt, func->getLinkage(), func->getName().str(), *mod_);
+                applyInlineDirective(extFunc, s->directives);
+                func->eraseFromParent();
+
+                // Update the OverloadEntry
+                bool isNestedScope = fn_nesting_depth_ > 0 && !fn_scope_stack_.empty();
+                auto &overloads = isNestedScope ? fn_scope_stack_.back()[s->name] : functions_[s->name];
+                for (auto &entry : overloads) {
+                    if (entry.paramTypes == paramTypes) {
+                        entry.func = extFunc;
+                        entry.capturedNames = captures.capturedNames;
+                        entry.capturedTypes = captures.capturedTypes;
+                        entry.capturedArcKinds = captures.capturedArcKinds;
+                        entry.capturedResourceKinds = captures.capturedResourceKinds;
+                        if (!captures.capturedClosureInfos.empty())
+                            entry.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(std::move(captures.capturedClosureInfos));
+                        break;
+                    }
+                }
+                func = extFunc;
+            }
+        }
+    }
+
     auto emitFunctionBody = [&](llvm::Function *targetFunc, llvm::Type *retTy,
                                 const std::string &returnTypeName, const std::string &fnNameForErrors) {
         FnScope guard(*this);
@@ -547,24 +643,44 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         current_function_name_ = s->name;
         pushScope();
 
-        // Forward-declare nested functions for mutual recursion within this body
-        forwardDeclareNestedFunctions(s->body);
-
         llvm::BasicBlock *entry = llvm::BasicBlock::Create(*ctx_, "entry", targetFunc);
         builder_.SetInsertPoint(entry);
         emitTraceFunctionEnter(s->name, s->loc);
 
+        // Set up user parameters BEFORE forward-declaring nested functions,
+        // so that capture analysis during forward declaration can find outer params.
         unsigned idx = 0;
         for (auto &arg : targetFunc->args()) {
-            arg.setName(s->params[idx].name);
-            llvm::AllocaInst *alloca = builder_.CreateAlloca(
-                paramTypes[idx], nullptr, s->params[idx].name);
-            builder_.CreateStore(&arg, alloca);
-            scope_stack_.back()[s->params[idx].name] = alloca;
-            const std::string &ptype = paramTypeNames[idx];
-            applyParamTypeMeta(ptype, alloca, paramTypes[idx], s->params[idx].name);
+            if (idx < s->params.size()) {
+                arg.setName(s->params[idx].name);
+                llvm::AllocaInst *alloca = builder_.CreateAlloca(
+                    paramTypes[idx], nullptr, s->params[idx].name);
+                builder_.CreateStore(&arg, alloca);
+                scope_stack_.back()[s->params[idx].name] = alloca;
+                const std::string &ptype = paramTypeNames[idx];
+                applyParamTypeMeta(ptype, alloca, paramTypes[idx], s->params[idx].name);
+            } else {
+                // Captured variable injected as extra parameter
+                size_t capIdx = idx - s->params.size();
+                arg.setName(captures.capturedNames[capIdx] + ".cap");
+                llvm::AllocaInst *alloca = builder_.CreateAlloca(
+                    captures.capturedTypes[capIdx], nullptr, captures.capturedNames[capIdx]);
+                builder_.CreateStore(&arg, alloca);
+                scope_stack_.back()[captures.capturedNames[capIdx]] = alloca;
+                captured_vars_.insert(alloca);
+                if (captures.capturedIsConst[capIdx])
+                    immutable_scope_stack_.back().insert(captures.capturedNames[capIdx]);
+                // Propagate fn_type_info for captured function-type variables
+                auto closureIt = captures.capturedClosureInfos.find(capIdx);
+                if (closureIt != captures.capturedClosureInfos.end())
+                    fn_type_info_[alloca] = closureIt->second;
+            }
             ++idx;
         }
+
+        // Forward-declare nested functions for mutual recursion within this body.
+        // Must come after user params are in scope so capture analysis can find them.
+        forwardDeclareNestedFunctions(s->body);
 
         // Emit require checks (preconditions)
         for (int i = 0; i < static_cast<int>(s->preconditions.size()); ++i)

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -594,6 +594,10 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         captures = analyzeFreeVariables(s->body, nullptr, paramNameSet, /*emitLoads=*/false);
 
         if (!captures.capturedNames.empty()) {
+            if (s->is_async)
+                codegenError("captured nested async functions are not yet supported (function '" +
+                    s->name + "' captures variables from the enclosing scope)");
+
             size_t expectedArgCount = s->params.size() + captures.capturedNames.size();
             if (func->arg_size() != expectedArgCount) {
                 // Function signature needs extension (captures not yet in signature).
@@ -626,7 +630,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
                         entry.capturedArcKinds = captures.capturedArcKinds;
                         entry.capturedResourceKinds = captures.capturedResourceKinds;
                         if (!captures.capturedClosureInfos.empty())
-                            entry.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(std::move(captures.capturedClosureInfos));
+                            entry.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(captures.capturedClosureInfos);
                         entryUpdated = true;
                         break;
                     }

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -9,54 +9,50 @@
 
 namespace ry {
 
-// ===== LambdaExpr =====
+// ===== Free-variable analysis (shared between lambda and nested named functions) =====
 
-llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
-    // Collect free variables (captured from outer scope)
-    std::vector<std::string> capturedNames;
-    std::vector<llvm::Value*> capturedValues;
-    std::vector<llvm::Type*> capturedTypes;
-    std::vector<CapturedArcKind> capturedArcKinds;
-    std::vector<ResourceKind> capturedResourceKinds;
-    std::unordered_map<size_t, FnTypeInfo> capturedClosureInfosLocal;
+CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
+    const std::vector<StmtNode> &body,
+    const ExprPtr &expr_body,
+    const std::unordered_set<std::string> &paramNames,
+    bool emitLoads) {
 
-    // Build a set of parameter names
-    std::unordered_set<std::string> paramNames;
-    for (auto &p : e->params)
-        paramNames.insert(p.name);
+    CaptureAnalysisResult result;
+    std::unordered_set<std::string> found;
+    // Mutable copy so nested FnStmt params can be temporarily added
+    std::unordered_set<std::string> excludedNames = paramNames;
 
-    // Simple free variable analysis: scan for VariableExpr in the body
-    // We use a lambda to recursively walk the AST
     std::function<void(const ExprNode&)> scanExpr;
     std::function<void(const StmtNode&)> scanStmt;
-    std::unordered_set<std::string> found;
 
-    // Try to capture a variable by name (used for both VariableExpr and CallExpr callee)
     auto tryCaptureVar = [&](const std::string &varName) {
-        if (paramNames.count(varName) || found.count(varName))
+        if (excludedNames.count(varName) || found.count(varName))
             return;
         llvm::AllocaInst *alloca = findVar(varName);
         if (!alloca)
             return;
         found.insert(varName);
-        capturedNames.push_back(varName);
-        llvm::Value *val = builder_.CreateLoad(
-            alloca->getAllocatedType(), alloca, varName + ".cap");
-        capturedValues.push_back(val);
-        capturedTypes.push_back(val->getType());
+        result.capturedNames.push_back(varName);
+        llvm::Type *capType = alloca->getAllocatedType();
+        if (emitLoads) {
+            llvm::Value *val = builder_.CreateLoad(capType, alloca, varName + ".cap");
+            result.capturedValues.push_back(val);
+        } else {
+            result.capturedValues.push_back(nullptr);
+        }
+        result.capturedTypes.push_back(capType);
         auto cak = detectCapturedArcKind(alloca);
-        capturedArcKinds.push_back(cak);
+        result.capturedArcKinds.push_back(cak);
         if (cak == CapturedArcKind::Resource) {
             auto rmIt = resource_managed_vars_.find(alloca);
-            capturedResourceKinds.push_back(
+            result.capturedResourceKinds.push_back(
                 rmIt != resource_managed_vars_.end() ? rmIt->second : ResourceKindRegistry::NONE);
         } else {
-            capturedResourceKinds.push_back(ResourceKindRegistry::NONE);
+            result.capturedResourceKinds.push_back(ResourceKindRegistry::NONE);
         }
-        // Store fn_type_info for any function-typed capture (closure or plain fn pointer)
         auto fnIt = fn_type_info_.find(alloca);
         if (fnIt != fn_type_info_.end())
-            capturedClosureInfosLocal[capturedNames.size() - 1] = fnIt->second;
+            result.capturedClosureInfos[result.capturedNames.size() - 1] = fnIt->second;
     };
 
     scanExpr = [&](const ExprNode &node) {
@@ -125,7 +121,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
                 scanExpr(*s->iterable);
                 for (auto &st : s->body) scanStmt(st);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
+                auto savedExcluded = excludedNames;
+                for (auto &p : s->params) excludedNames.insert(p.name);
                 for (auto &st : s->body) scanStmt(st);
+                excludedNames = std::move(savedExcluded);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
                 scanExpr(*s->subject);
                 for (auto &arm : s->arms) {
@@ -136,26 +135,78 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
         }, stmt);
     };
 
-    // Scan the lambda body for free variables
-    if (e->expr_body) {
-        scanExpr(*e->expr_body);
+    if (expr_body) {
+        scanExpr(*expr_body);
     } else {
-        for (auto &stmt : e->body)
+        for (auto &stmt : body)
             scanStmt(stmt);
     }
 
     // Snapshot @const status before FnScope clears immutable_scope_stack_
-    llvm::SmallVector<bool, 8> capturedIsConst;
-    capturedIsConst.reserve(capturedNames.size());
-    for (auto &name : capturedNames)
-        capturedIsConst.push_back(isImmutable(name));
+    result.capturedIsConst.reserve(result.capturedNames.size());
+    for (auto &name : result.capturedNames)
+        result.capturedIsConst.push_back(isImmutable(name));
+
+    return result;
+}
+
+// ===== Closure struct builder (shared between lambda and nested named functions) =====
+
+llvm::Value *CodeGen::buildClosureStruct(
+    llvm::Function *func,
+    const FnTypeInfo &info,
+    const std::vector<llvm::Value*> &capturedValues) {
+
+    if (capturedValues.empty())
+        return func;
+
+    std::vector<llvm::Type*> closureFields;
+    closureFields.push_back(ptrTy_);  // function pointer
+    for (auto *t : info.capturedTypes)
+        closureFields.push_back(t);
+    llvm::StructType *closureTy = llvm::StructType::get(*ctx_, closureFields);
+
+    const llvm::DataLayout &dl = mod_->getDataLayout();
+    uint64_t closureSize = dl.getTypeAllocSize(closureTy);
+    auto *arcHeader = emitArcAlloc(llvm::ConstantInt::get(i64Ty_, closureSize));
+    llvm::Value *closurePtr = emitArcGetDataPtr(arcHeader);
+
+    // Store function pointer
+    llvm::Value *fnField = builder_.CreateStructGEP(closureTy, closurePtr, 0, "closure.fn");
+    builder_.CreateStore(func, fnField);
+
+    // Store captured values and retain ARC-managed ones
+    for (size_t i = 0; i < capturedValues.size(); ++i) {
+        llvm::Value *capField = builder_.CreateStructGEP(
+            closureTy, closurePtr, i + 1, "closure.cap." + std::to_string(i));
+        builder_.CreateStore(capturedValues[i], capField);
+        if (info.capturedArcKinds[i] != CapturedArcKind::None) {
+            auto *hdr = emitArcGetHeaderFromData(capturedValues[i]);
+            emitArcRetain(hdr, false);
+        }
+    }
+
+    fn_type_info_[closurePtr] = info;
+    return closurePtr;
+}
+
+// ===== LambdaExpr =====
+
+llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
+    // Build a set of parameter names
+    std::unordered_set<std::string> paramNames;
+    for (auto &p : e->params)
+        paramNames.insert(p.name);
+
+    // Run free-variable analysis
+    auto captures = analyzeFreeVariables(e->body, e->expr_body, paramNames);
 
     // Build parameter types (user params + captured vars)
     std::vector<llvm::Type*> paramTypes;
     for (auto &p : e->params)
         paramTypes.push_back(resolveType(p.type->toString()));
     std::vector<llvm::Type*> allParamTypes = paramTypes;
-    for (auto *t : capturedTypes)
+    for (auto *t : captures.capturedTypes)
         allParamTypes.push_back(t);
 
     llvm::Type *retTy;
@@ -215,17 +266,17 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
             } else {
                 // Captured variable
                 size_t capIdx = idx - e->params.size();
-                arg.setName(capturedNames[capIdx] + ".cap");
+                arg.setName(captures.capturedNames[capIdx] + ".cap");
                 llvm::AllocaInst *alloca = builder_.CreateAlloca(
-                    capturedTypes[capIdx], nullptr, capturedNames[capIdx]);
+                    captures.capturedTypes[capIdx], nullptr, captures.capturedNames[capIdx]);
                 builder_.CreateStore(&arg, alloca);
-                scope_stack_.back()[capturedNames[capIdx]] = alloca;
+                scope_stack_.back()[captures.capturedNames[capIdx]] = alloca;
                 captured_vars_.insert(alloca);
-                if (capturedIsConst[capIdx])
-                    immutable_scope_stack_.back().insert(capturedNames[capIdx]);
+                if (captures.capturedIsConst[capIdx])
+                    immutable_scope_stack_.back().insert(captures.capturedNames[capIdx]);
                 // Propagate fn_type_info for captured function-type variables
-                auto closureIt = capturedClosureInfosLocal.find(capIdx);
-                if (closureIt != capturedClosureInfosLocal.end())
+                auto closureIt = captures.capturedClosureInfos.find(capIdx);
+                if (closureIt != captures.capturedClosureInfos.end())
                     fn_type_info_[alloca] = closureIt->second;
             }
             ++idx;
@@ -276,49 +327,15 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     for (auto &p : e->params)
         info.paramTypeNames.push_back(p.type->toString());
     info.returnType = retTy;
-    info.capturedVars = capturedNames;
-    info.capturedTypes = capturedTypes;
-    info.capturedArcKinds = capturedArcKinds;
-    info.capturedResourceKinds = capturedResourceKinds;
-    if (!capturedClosureInfosLocal.empty())
-        info.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(std::move(capturedClosureInfosLocal));
+    info.capturedVars = captures.capturedNames;
+    info.capturedTypes = captures.capturedTypes;
+    info.capturedArcKinds = captures.capturedArcKinds;
+    info.capturedResourceKinds = captures.capturedResourceKinds;
+    if (!captures.capturedClosureInfos.empty())
+        info.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(std::move(captures.capturedClosureInfos));
     fn_type_info_[func] = info;
 
-    // If no captures, just return the function pointer
-    if (capturedNames.empty())
-        return func;
-
-    // With captures: pack {fn_ptr, cap1, cap2, ...} into a struct
-    std::vector<llvm::Type*> closureFields;
-    closureFields.push_back(ptrTy_);  // function pointer
-    for (auto *t : capturedTypes)
-        closureFields.push_back(t);
-    llvm::StructType *closureTy = llvm::StructType::get(*ctx_, closureFields);
-
-    const llvm::DataLayout &dl = mod_->getDataLayout();
-    uint64_t closureSize = dl.getTypeAllocSize(closureTy);
-    auto *arcHeader = emitArcAlloc(llvm::ConstantInt::get(i64Ty_, closureSize));
-    llvm::Value *closurePtr = emitArcGetDataPtr(arcHeader);
-
-    // Store function pointer
-    llvm::Value *fnField = builder_.CreateStructGEP(closureTy, closurePtr, 0, "closure.fn");
-    builder_.CreateStore(func, fnField);
-
-    // Store captured values and retain ARC-managed ones
-    for (size_t i = 0; i < capturedValues.size(); ++i) {
-        llvm::Value *capField = builder_.CreateStructGEP(
-            closureTy, closurePtr, i + 1, "closure.cap." + std::to_string(i));
-        builder_.CreateStore(capturedValues[i], capField);
-        if (capturedArcKinds[i] != CapturedArcKind::None) {
-            auto *hdr = emitArcGetHeaderFromData(capturedValues[i]);
-            emitArcRetain(hdr, false);
-        }
-    }
-
-    // Register the closure pointer with fn_type_info
-    fn_type_info_[closurePtr] = info;
-
-    return closurePtr;
+    return buildClosureStruct(func, info, captures.capturedValues);
 }
 
 // ===== Lambda return type inference =====

--- a/tests/spec/nested_fn_closure.test.ry
+++ b/tests/spec/nested_fn_closure.test.ry
@@ -1,0 +1,160 @@
+function apply(f: function(int) -> int, x: int) -> int:
+  return f(x)
+
+describe("nested named function — capture basics", ():
+  it("captures int from enclosing scope", ():
+    function make_adder(base: int) -> function(int) -> int:
+      function add(x: int) -> int:
+        return x + base
+      return add
+
+    add10 = make_adder(10)
+    expect(add10(5)).to_eq(15)
+  )
+
+  it("captures str from enclosing scope (ARC-managed)", ():
+    function choose_prefix(prefix: str) -> function(str) -> str:
+      function decorate(name: str) -> str:
+        return prefix + name
+      return decorate
+
+    f = choose_prefix("hi ")
+    expect(f("ry")).to_eq("hi ry")
+  )
+
+  it("captures multiple variables", ():
+    function make_linear(a: int, b: int) -> function(int) -> int:
+      function linear(x: int) -> int:
+        return a * x + b
+      return linear
+
+    f = make_linear(3, 10)
+    expect(f(5)).to_eq(25)
+  )
+)
+
+describe("nested named function — direct call with captures", ():
+  it("calls capturing nested function directly in defining scope", ():
+    function outer(n: int) -> int:
+      function add_n(x: int) -> int:
+        return x + n
+      return add_n(100)
+
+    expect(outer(7)).to_eq(107)
+  )
+
+  it("multiple capturing nested functions in same scope", ():
+    function outer(base: int) -> int:
+      function inc(x: int) -> int:
+        return x + base
+      function dec(x: int) -> int:
+        return x - base
+      return inc(10) + dec(10)
+
+    expect(outer(3)).to_eq(20)
+  )
+
+  it("sibling param shadowing does not prevent capture", ():
+    function outer() -> int:
+      x = 10
+      function a(x: int) -> int:
+        return x + 1
+      function b() -> int:
+        return x
+      return a(5) + b()
+
+    expect(outer()).to_eq(16)
+  )
+)
+
+describe("nested named function — higher-order interop", ():
+  it("passes no-capture nested function to higher-order function", ():
+    function outer() -> int:
+      function double_it(n: int) -> int:
+        return n * 2
+      return apply(double_it, 5)
+
+    expect(outer()).to_eq(10)
+  )
+
+  it("returned capturing nested function called twice", ():
+    function make_step(n: int) -> function(int) -> int:
+      function step(x: int) -> int:
+        return x + n
+      return step
+
+    step3 = make_step(3)
+    expect(step3(step3(1))).to_eq(7)
+  )
+)
+
+describe("nested named function — variable assignment and indirect call", ():
+  it("assigns capturing nested function to variable and calls it", ():
+    function outer(offset: int) -> int:
+      function add_offset(x: int) -> int:
+        return x + offset
+      f = add_offset
+      return f(10)
+
+    expect(outer(5)).to_eq(15)
+  )
+)
+
+describe("nested named function — multi-level capture", ():
+  it("captures variable from two levels up", ():
+    function outer(x: int) -> function(int) -> int:
+      function mid() -> function(int) -> int:
+        function inner(y: int) -> int:
+          return x + y
+        return inner
+      return mid()
+
+    f = outer(100)
+    expect(f(23)).to_eq(123)
+  )
+)
+
+describe("nested named function — no-capture remains plain function", ():
+  it("no-capture nested function works as before", ():
+    function outer() -> int:
+      function helper(x: int) -> int:
+        return x * 2
+      return helper(21)
+
+    expect(outer()).to_eq(42)
+  )
+
+  it("no-capture nested function passed as value", ():
+    function outer() -> int:
+      function double_it(n: int) -> int:
+        return n * 2
+      return apply(double_it, 5)
+
+    expect(outer()).to_eq(10)
+  )
+)
+
+describe("nested named function — ARC capture correctness", ():
+  it("captured string survives after outer function returns", ():
+    function make_greeter(greeting: str) -> function(str) -> str:
+      function greet(name: str) -> str:
+        return greeting + " " + name
+      return greet
+
+    g = make_greeter("hello")
+    expect(g("world")).to_eq("hello world")
+    expect(g("ry")).to_eq("hello ry")
+  )
+
+  it("multiple closures from same factory are independent", ():
+    function make_adder(base: int) -> function(int) -> int:
+      function add(x: int) -> int:
+        return x + base
+      return add
+
+    add3 = make_adder(3)
+    add7 = make_adder(7)
+    expect(add3(10)).to_eq(13)
+    expect(add7(10)).to_eq(17)
+  )
+)

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -53,3 +53,19 @@ TEST_F(CodeGenTest, NestedFunctionNotVisibleOutsideScope) {
         "inner()\n"
     ), std::runtime_error);
 }
+
+// ============================================================
+// Captured variable cannot be modified inside nested named function
+// ============================================================
+
+TEST_F(CodeGenTest, NestedFunctionCannotModifyCapturedVariable) {
+    EXPECT_THROW(runSource(
+        "function outer() -> int:\n"
+        "    x = 10\n"
+        "    function helper() -> int:\n"
+        "        x = 20\n"
+        "        return x\n"
+        "    return helper()\n"
+        "print(outer())\n"
+    ), std::runtime_error);
+}


### PR DESCRIPTION
## Summary

Closes #661

- Enable nested named functions to capture variables from enclosing scopes, reusing the existing lambda closure pipeline
- Extract `analyzeFreeVariables()` and `buildClosureStruct()` as shared methods between lambda and nested function codegen
- Run capture analysis at forward-declaration time (outer params) and emit time (local vars), extending LLVM function signatures as needed
- Store capture metadata in `OverloadEntry` (including `capturedClosureInfos`) for correct call-site arg injection, closure materialization, and ARC destructor generation

## Test plan

- [x] 14 new Ry self-tests: int/str/multi capture, direct calls, higher-order interop, variable assignment, multi-level capture, ARC correctness, no-capture regression
- [x] 1 new C++ negative test: captured variable reassignment error
- [x] All 1393 C++ tests pass
- [x] All 79 Ry test files pass (0 failures)
- [x] ASan clean (1392 C++ tests + 79 Ry test files, 0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nested named functions now capture variables from enclosing scopes, providing closure behavior like lambdas.

* **Documentation**
  * Added a "Closure Capture" section describing by-value capture timing, immutability of captured vars in nested bodies, ARC handling, and multi-level captures with examples.

* **Tests**
  * Added comprehensive closure tests (captures, shadowing, multi-level, ARC-managed values) and a failing test preventing reassignment of captured variables.

* **Changelog**
  * Added entry documenting nested-function closure capture.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->