### PR TITLE
fix: crash when passing capturing closure as function argument (#688)

### DIFF
--- a/changelog.d/688-closure-fn-param.md
+++ b/changelog.d/688-closure-fn-param.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Passing a capturing closure as a `function(...)` argument no longer crashes (#688)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -423,7 +423,7 @@ public:
     }
     llvm::StructType *getUniformClosureTy() {
         if (!uniformClosureTy_)
-            uniformClosureTy_ = llvm::StructType::get(*ctx_, {ptrTy_, ptrTy_});
+            uniformClosureTy_ = llvm::StructType::get(*ctx_, {ptrTy_, ptrTy_, ptrTy_});
         return uniformClosureTy_;
     }
     llvm::StructType *uniformClosureTy_ = nullptr;

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -376,6 +376,8 @@ public:
         std::vector<ResourceKind> capturedResourceKinds; // per-capture ResourceKind (RK_COUNT if N/A)
         // unique_ptr to break incomplete-type cycle (GCC 11 requires complete type for unordered_map value)
         std::unique_ptr<std::unordered_map<size_t, FnTypeInfo>> capturedClosureInfos;
+        bool isUniformClosure = false;  // true when value uses {thunk, env} layout
+        llvm::Function *sourceFn = nullptr;  // underlying LLVM function (for thunk generation)
 
         FnTypeInfo() = default;
         ~FnTypeInfo() = default;
@@ -388,7 +390,9 @@ public:
               capturedResourceKinds(o.capturedResourceKinds),
               capturedClosureInfos(o.capturedClosureInfos
                   ? std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(*o.capturedClosureInfos)
-                  : nullptr) {}
+                  : nullptr),
+              isUniformClosure(o.isUniformClosure),
+              sourceFn(o.sourceFn) {}
         FnTypeInfo& operator=(const FnTypeInfo &o) {
             if (this != &o) {
                 paramTypes = o.paramTypes;
@@ -401,6 +405,8 @@ public:
                 capturedClosureInfos = o.capturedClosureInfos
                     ? std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(*o.capturedClosureInfos)
                     : nullptr;
+                isUniformClosure = o.isUniformClosure;
+                sourceFn = o.sourceFn;
             }
             return *this;
         }
@@ -410,6 +416,28 @@ public:
     lookupFnTypeInfo(llvm::Value *val);
     std::unordered_map<llvm::Function*, FnTypeInfo> return_fn_type_info_;
     llvm::FunctionCallee getOrCreateClosureDestructor(const FnTypeInfo &info);
+
+    // Uniform closure support: {thunk_ptr, env_ptr} for function-type boundaries
+    static bool isFunctionTypeName(const std::string &s) {
+        return s.size() > 9 && s.compare(0, 9, "function(") == 0;
+    }
+    llvm::StructType *getUniformClosureTy() {
+        if (!uniformClosureTy_)
+            uniformClosureTy_ = llvm::StructType::get(*ctx_, {ptrTy_, ptrTy_});
+        return uniformClosureTy_;
+    }
+    llvm::StructType *uniformClosureTy_ = nullptr;
+    std::unordered_map<llvm::Function*, llvm::Function*> forwarding_thunk_cache_;
+    std::unordered_map<llvm::Function*, llvm::Function*> capturing_thunk_cache_;
+    llvm::Function *uniform_closure_dtor_ = nullptr;
+    llvm::Function *getOrCreateForwardingThunk(llvm::Function *realFn, const FnTypeInfo &info);
+    llvm::Function *getOrCreateCapturingThunk(llvm::Function *realFn, const FnTypeInfo &info);
+    llvm::Value *wrapAsUniformClosure(llvm::Value *val, const FnTypeInfo &info);
+    llvm::Function *getOrCreateUniformClosureDestructor();
+    std::vector<llvm::Value*> wrapFnTypedArgs(
+        std::vector<llvm::Value*> &argVals,
+        const std::vector<std::string> &paramTypeNames);
+    void releaseUniformClosureTemps(const std::vector<llvm::Value*> &temps);
     // Nested closure shape for cache key differentiation
     struct NestedClosureShape {
         size_t index;

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -190,8 +190,14 @@ llvm::FunctionCallee CodeGen::resolveDestructor(llvm::AllocaInst *alloca) {
         return getOrCreateResourceDestructor(it->second);
     if (closure_managed_vars_.count(alloca)) {
         auto fnIt = fn_type_info_.find(alloca);
-        if (fnIt != fn_type_info_.end() && !fnIt->second.capturedArcKinds.empty())
-            return getOrCreateClosureDestructor(fnIt->second);
+        if (fnIt != fn_type_info_.end()) {
+            if (fnIt->second.isUniformClosure) {
+                auto *dtorFn = getOrCreateUniformClosureDestructor();
+                return llvm::FunctionCallee(dtorFn->getFunctionType(), dtorFn);
+            }
+            if (!fnIt->second.capturedArcKinds.empty())
+                return getOrCreateClosureDestructor(fnIt->second);
+        }
     }
     return {};
 }

--- a/src/codegen_arc_cow.cpp
+++ b/src/codegen_arc_cow.cpp
@@ -248,6 +248,12 @@ CodeGen::CapturedArcKind CodeGen::detectCapturedArcKind(llvm::AllocaInst *alloca
         return CapturedArcKind::Set;
     if (closure_managed_vars_.count(alloca))
         return CapturedArcKind::Closure;
+    // Uniform closures stored in function-type params are ARC-managed
+    {
+        auto fnIt = fn_type_info_.find(alloca);
+        if (fnIt != fn_type_info_.end() && fnIt->second.isUniformClosure)
+            return CapturedArcKind::Closure;
+    }
     if (resource_managed_vars_.count(alloca))
         return CapturedArcKind::Resource;
     if (isArcManaged(alloca))
@@ -340,9 +346,14 @@ llvm::FunctionCallee CodeGen::getOrCreateClosureDestructor(const FnTypeInfo &inf
         case CapturedArcKind::Closure: {
             if (info.capturedClosureInfos) {
                 auto cit = info.capturedClosureInfos->find(i);
-                if (cit != info.capturedClosureInfos->end() &&
-                    !cit->second.capturedArcKinds.empty())
-                    subDtor = getOrCreateClosureDestructor(cit->second);
+                if (cit != info.capturedClosureInfos->end()) {
+                    if (cit->second.isUniformClosure) {
+                        auto *ucDtor = getOrCreateUniformClosureDestructor();
+                        subDtor = llvm::FunctionCallee(ucDtor->getFunctionType(), ucDtor);
+                    } else if (!cit->second.capturedArcKinds.empty()) {
+                        subDtor = getOrCreateClosureDestructor(cit->second);
+                    }
+                }
             }
             break;
         }

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -137,8 +137,14 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
             std::vector<llvm::Value*> argVals;
             for (auto &arg : e->args)
                 argVals.push_back(emitExpr(*arg));
+
+            auto ucTemps = wrapFnTypedArgs(argVals, info.paramTypeNames);
+
             llvm::Value *loaded = builder_.CreateLoad(ptrTy_, varPtr, e->callee + ".fn");
-            return emitLambdaCall(loaded, info, argVals, "indirect_call");
+            llvm::Value *result = emitLambdaCall(loaded, info, argVals, "indirect_call");
+
+            releaseUniformClosureTemps(ucTemps);
+            return result;
         }
 
         if (auto *result = tryCallOperator(e->callee, e->args))
@@ -227,6 +233,27 @@ std::vector<llvm::Value*> CodeGen::coerceCallArgs(const FnTypeInfo &info,
 llvm::Value *CodeGen::emitLambdaCall(llvm::Value *lambdaVal, const FnTypeInfo &info,
                                       std::vector<llvm::Value*> args, const std::string &name) {
     args = coerceCallArgs(info, std::move(args), "lambda call");
+
+    if (info.isUniformClosure) {
+        // Uniform closure: {thunk_ptr, env_ptr}
+        auto *ucTy = getUniformClosureTy();
+        auto *thunkField = builder_.CreateStructGEP(
+            ucTy, lambdaVal, 0, "uc.thunk_field");
+        auto *thunkPtr = builder_.CreateLoad(ptrTy_, thunkField, "uc.thunk");
+        auto *envField = builder_.CreateStructGEP(
+            ucTy, lambdaVal, 1, "uc.env_field");
+        auto *envPtr = builder_.CreateLoad(ptrTy_, envField, "uc.env");
+
+        std::vector<llvm::Value*> callArgs = args;
+        callArgs.push_back(envPtr);
+        std::vector<llvm::Type*> callTypes = info.paramTypes;
+        callTypes.push_back(ptrTy_);
+
+        auto *ft = llvm::FunctionType::get(info.returnType, callTypes, false);
+        if (info.returnType->isVoidTy())
+            return builder_.CreateCall(ft, thunkPtr, callArgs);
+        return builder_.CreateCall(ft, thunkPtr, callArgs, name);
+    }
 
     if (info.capturedVars.empty()) {
         llvm::FunctionType *ft = llvm::FunctionType::get(

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -224,6 +224,11 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         }
     }
 
+    // Wrap function-typed arguments as uniform closures for function(...) params
+    std::vector<llvm::Value*> uniformClosureTemps;
+    if (matchedEntry)
+        uniformClosureTemps = wrapFnTypedArgs(argVals, matchedEntry->paramTypeNames);
+
     // ARC: retain arguments that are ARC-managed before passing to callee
     for (auto *argVal : argVals)
         tryRetainArcSource(argVal);
@@ -367,9 +372,13 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         return phi;
     }
 
-    if (fn->getReturnType()->isVoidTy())
-        return builder_.CreateCall(fn, argVals);
+    if (fn->getReturnType()->isVoidTy()) {
+        builder_.CreateCall(fn, argVals);
+        releaseUniformClosureTemps(uniformClosureTemps);
+        return nullptr;
+    }
     llvm::Value *callResult = builder_.CreateCall(fn, argVals, "calltmp");
+    releaseUniformClosureTemps(uniformClosureTemps);
 
     propagateReturnTypeMeta(matchedEntry, callResult);
 

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -348,6 +348,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
             builder_.CreateBr(mergeBB);
 
             builder_.SetInsertPoint(mergeBB);
+            releaseUniformClosureTemps(uniformClosureTemps);
             return nullptr;
         }
 
@@ -369,6 +370,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         phi->addIncoming(origResult, origEndBB);
         propagateReturnTypeMeta(matchedEntry, phi);
         propagateReturnFnTypeMeta(matchedEntry, fn, phi);
+        releaseUniformClosureTemps(uniformClosureTemps);
         return phi;
     }
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -140,6 +140,7 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
             info.capturedResourceKinds = entry.capturedResourceKinds;
             if (entry.capturedClosureInfos)
                 info.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(*entry.capturedClosureInfos);
+            info.sourceFn = func;
             fn_type_info_[func] = info;
 
             // Load captured values from the current scope
@@ -154,6 +155,7 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
             return buildClosureStruct(func, info, capturedValues);
         }
 
+        info.sourceFn = func;
         fn_type_info_[func] = info;
         return func;
     }

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -333,6 +333,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     info.capturedResourceKinds = captures.capturedResourceKinds;
     if (!captures.capturedClosureInfos.empty())
         info.capturedClosureInfos = std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(std::move(captures.capturedClosureInfos));
+    info.sourceFn = func;
     fn_type_info_[func] = info;
 
     return buildClosureStruct(func, info, captures.capturedValues);
@@ -499,6 +500,234 @@ std::string CodeGen::reverseResolveTypeName(llvm::Type *ty) {
         if (!n.empty()) return n;
     }
     return "any"; // fallback
+}
+
+// ===== Uniform Closure Support =====
+
+llvm::Function *CodeGen::getOrCreateForwardingThunk(llvm::Function *realFn, const FnTypeInfo &info) {
+    auto it = forwarding_thunk_cache_.find(realFn);
+    if (it != forwarding_thunk_cache_.end())
+        return it->second;
+
+    // Thunk signature: (user_params..., ptr env) -> ret
+    std::vector<llvm::Type*> thunkParams = info.paramTypes;
+    thunkParams.push_back(ptrTy_); // env (ignored)
+    auto *thunkTy = llvm::FunctionType::get(info.returnType, thunkParams, false);
+
+    std::string name = "__ry_uc_fwd_" + realFn->getName().str();
+    auto *thunk = llvm::Function::Create(
+        thunkTy, llvm::Function::InternalLinkage, name, mod_.get());
+    thunk->addFnAttr(llvm::Attribute::AlwaysInline);
+    thunk->addFnAttr(llvm::Attribute::NoUnwind);
+
+    auto *savedBB = builder_.GetInsertBlock();
+    auto savedPt = builder_.GetInsertPoint();
+
+    auto *entry = llvm::BasicBlock::Create(*ctx_, "entry", thunk);
+    builder_.SetInsertPoint(entry);
+
+    // Forward user args to realFn
+    std::vector<llvm::Value*> args;
+    for (size_t i = 0; i < info.paramTypes.size(); ++i)
+        args.push_back(thunk->getArg(i));
+
+    llvm::Value *result = builder_.CreateCall(realFn, args, info.returnType->isVoidTy() ? "" : "fwd_result");
+    if (info.returnType->isVoidTy())
+        builder_.CreateRetVoid();
+    else
+        builder_.CreateRet(result);
+
+    if (savedBB)
+        builder_.SetInsertPoint(savedBB, savedPt);
+
+    forwarding_thunk_cache_[realFn] = thunk;
+    return thunk;
+}
+
+llvm::Function *CodeGen::getOrCreateCapturingThunk(llvm::Function *realFn, const FnTypeInfo &info) {
+    auto it = capturing_thunk_cache_.find(realFn);
+    if (it != capturing_thunk_cache_.end())
+        return it->second;
+
+    // Thunk signature: (user_params..., ptr env) -> ret
+    std::vector<llvm::Type*> thunkParams = info.paramTypes;
+    thunkParams.push_back(ptrTy_); // env = original closure struct pointer
+    auto *thunkTy = llvm::FunctionType::get(info.returnType, thunkParams, false);
+
+    std::string name = "__ry_uc_cap_" + realFn->getName().str();
+    auto *thunk = llvm::Function::Create(
+        thunkTy, llvm::Function::InternalLinkage, name, mod_.get());
+    thunk->addFnAttr(llvm::Attribute::NoUnwind);
+
+    auto *savedBB = builder_.GetInsertBlock();
+    auto savedPt = builder_.GetInsertPoint();
+
+    auto *entry = llvm::BasicBlock::Create(*ctx_, "entry", thunk);
+    builder_.SetInsertPoint(entry);
+
+    // env is the last argument
+    llvm::Value *envPtr = thunk->getArg(info.paramTypes.size());
+
+    // Reconstruct the original closure struct type: {fn_ptr, cap1, cap2, ...}
+    std::vector<llvm::Type*> closureFields;
+    closureFields.push_back(ptrTy_); // fn_ptr
+    for (auto *ct : info.capturedTypes)
+        closureFields.push_back(ct);
+    auto *closureTy = llvm::StructType::get(*ctx_, closureFields);
+
+    // Build full args: user_params + captured values loaded from env
+    std::vector<llvm::Value*> fullArgs;
+    for (size_t i = 0; i < info.paramTypes.size(); ++i)
+        fullArgs.push_back(thunk->getArg(i));
+
+    for (size_t i = 0; i < info.capturedTypes.size(); ++i) {
+        auto *capField = builder_.CreateStructGEP(
+            closureTy, envPtr, i + 1, "thunk.cap." + std::to_string(i));
+        auto *capVal = builder_.CreateLoad(
+            info.capturedTypes[i], capField, "thunk.cap_val." + std::to_string(i));
+        fullArgs.push_back(capVal);
+    }
+
+    llvm::Value *result = builder_.CreateCall(realFn, fullArgs,
+        info.returnType->isVoidTy() ? "" : "cap_result");
+    if (info.returnType->isVoidTy())
+        builder_.CreateRetVoid();
+    else
+        builder_.CreateRet(result);
+
+    if (savedBB)
+        builder_.SetInsertPoint(savedBB, savedPt);
+
+    capturing_thunk_cache_[realFn] = thunk;
+    return thunk;
+}
+
+llvm::Function *CodeGen::getOrCreateUniformClosureDestructor() {
+    if (uniform_closure_dtor_)
+        return uniform_closure_dtor_;
+
+    auto *ucTy = getUniformClosureTy();
+
+    auto *dtorTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    auto *dtorFn = llvm::Function::Create(
+        dtorTy, llvm::Function::InternalLinkage, "__ry_arc_dtor_uniform_closure", mod_.get());
+    dtorFn->addFnAttr(llvm::Attribute::NoUnwind);
+
+    auto *savedBB = builder_.GetInsertBlock();
+    auto savedPt = builder_.GetInsertPoint();
+
+    auto *entryBB = llvm::BasicBlock::Create(*ctx_, "entry", dtorFn);
+    builder_.SetInsertPoint(entryBB);
+
+    auto *dataPtr = dtorFn->getArg(0); // points to {thunk, env}
+    auto *envField = builder_.CreateStructGEP(ucTy, dataPtr, 1, "uc_dtor.env_field");
+    auto *envVal = builder_.CreateLoad(ptrTy_, envField, "uc_dtor.env");
+
+    // If env is non-null, it's an ARC-managed closure struct — release it
+    auto *isNull = builder_.CreateICmpEQ(envVal,
+        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)), "uc_dtor.null");
+    auto *releaseBB = llvm::BasicBlock::Create(*ctx_, "uc_dtor.release", dtorFn);
+    auto *doneBB = llvm::BasicBlock::Create(*ctx_, "uc_dtor.done", dtorFn);
+    builder_.CreateCondBr(isNull, doneBB, releaseBB);
+
+    builder_.SetInsertPoint(releaseBB);
+    auto *hdr = emitArcGetHeaderFromData(envVal);
+    emitArcRelease(hdr, false);
+    builder_.CreateBr(doneBB);
+
+    builder_.SetInsertPoint(doneBB);
+    builder_.CreateRetVoid();
+
+    if (savedBB)
+        builder_.SetInsertPoint(savedBB, savedPt);
+
+    uniform_closure_dtor_ = dtorFn;
+    return dtorFn;
+}
+
+llvm::Value *CodeGen::wrapAsUniformClosure(llvm::Value *val, const FnTypeInfo &info) {
+    // Already a uniform closure — pass through
+    if (info.isUniformClosure)
+        return val;
+
+    auto *ucTy = getUniformClosureTy();
+
+    llvm::Function *thunk = nullptr;
+    llvm::Value *envVal = nullptr;
+
+    if (info.capturedVars.empty()) {
+        // Non-capturing: env = null, per-function forwarding thunk
+        llvm::Function *realFn = info.sourceFn;
+        if (!realFn)
+            realFn = llvm::dyn_cast<llvm::Function>(val);
+        if (!realFn)
+            codegenError("cannot wrap non-capturing function: sourceFn unknown");
+        thunk = getOrCreateForwardingThunk(realFn, info);
+        envVal = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
+    } else {
+        // Capturing: env = original closure struct pointer, unpacking thunk
+        llvm::Function *realFn = info.sourceFn;
+        if (!realFn)
+            codegenError("cannot wrap capturing closure: sourceFn unknown");
+        thunk = getOrCreateCapturingThunk(realFn, info);
+        envVal = val; // original closure struct pointer
+    }
+
+    // Allocate ARC-managed uniform closure struct {thunk, env}
+    const llvm::DataLayout &dl = mod_->getDataLayout();
+    uint64_t ucSize = dl.getTypeAllocSize(ucTy);
+    auto *arcHeader = emitArcAlloc(llvm::ConstantInt::get(i64Ty_, ucSize));
+    llvm::Value *ucPtr = emitArcGetDataPtr(arcHeader);
+
+    // Store thunk and env
+    auto *thunkField = builder_.CreateStructGEP(ucTy, ucPtr, 0, "uc.thunk_store");
+    builder_.CreateStore(thunk, thunkField);
+    auto *envField = builder_.CreateStructGEP(ucTy, ucPtr, 1, "uc.env_store");
+    builder_.CreateStore(envVal, envField);
+
+    // If env is an ARC-managed closure, retain it
+    if (!info.capturedVars.empty()) {
+        auto *envHdr = emitArcGetHeaderFromData(envVal);
+        emitArcRetain(envHdr, false);
+    }
+
+    // Register as uniform closure in fn_type_info_
+    // (ucPtr is already in arc_owned_values_ via emitArcGetDataPtr)
+    FnTypeInfo ucInfo;
+    ucInfo.paramTypes = info.paramTypes;
+    ucInfo.paramTypeNames = info.paramTypeNames;
+    ucInfo.returnType = info.returnType;
+    ucInfo.isUniformClosure = true;
+    fn_type_info_[ucPtr] = ucInfo;
+
+    return ucPtr;
+}
+
+std::vector<llvm::Value*> CodeGen::wrapFnTypedArgs(
+    std::vector<llvm::Value*> &argVals,
+    const std::vector<std::string> &paramTypeNames) {
+    std::vector<llvm::Value*> temps;
+    for (size_t i = 0; i < argVals.size() && i < paramTypeNames.size(); ++i) {
+        std::string resolved = resolveTypeAlias(paramTypeNames[i]);
+        if (isFunctionTypeName(resolved)) {
+            auto fnIt = lookupFnTypeInfo(argVals[i]);
+            if (fnIt != fn_type_info_.end() && !fnIt->second.isUniformClosure) {
+                argVals[i] = wrapAsUniformClosure(argVals[i], fnIt->second);
+                temps.push_back(argVals[i]);
+            }
+        }
+    }
+    return temps;
+}
+
+void CodeGen::releaseUniformClosureTemps(const std::vector<llvm::Value*> &temps) {
+    if (temps.empty()) return;
+    auto *dtorFn = getOrCreateUniformClosureDestructor();
+    llvm::FunctionCallee dtor(dtorFn->getFunctionType(), dtorFn);
+    for (auto *uc : temps) {
+        auto *hdr = emitArcGetHeaderFromData(uc);
+        emitArcRelease(hdr, false, dtor);
+    }
 }
 
 } // namespace ry

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -619,20 +619,48 @@ llvm::Function *CodeGen::getOrCreateUniformClosureDestructor() {
     auto *entryBB = llvm::BasicBlock::Create(*ctx_, "entry", dtorFn);
     builder_.SetInsertPoint(entryBB);
 
-    auto *dataPtr = dtorFn->getArg(0); // points to {thunk, env}
+    auto *dataPtr = dtorFn->getArg(0); // points to {thunk, env, env_dtor}
     auto *envField = builder_.CreateStructGEP(ucTy, dataPtr, 1, "uc_dtor.env_field");
     auto *envVal = builder_.CreateLoad(ptrTy_, envField, "uc_dtor.env");
+    auto *envDtorField = builder_.CreateStructGEP(ucTy, dataPtr, 2, "uc_dtor.env_dtor_field");
+    auto *envDtorVal = builder_.CreateLoad(ptrTy_, envDtorField, "uc_dtor.env_dtor");
 
-    // If env is non-null, it's an ARC-managed closure struct — release it
-    auto *isNull = builder_.CreateICmpEQ(envVal,
-        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)), "uc_dtor.null");
+    // If env is non-null, release it with its destructor
+    auto *nullPtr = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
+    auto *isEnvNull = builder_.CreateICmpEQ(envVal, nullPtr, "uc_dtor.env_null");
     auto *releaseBB = llvm::BasicBlock::Create(*ctx_, "uc_dtor.release", dtorFn);
     auto *doneBB = llvm::BasicBlock::Create(*ctx_, "uc_dtor.done", dtorFn);
-    builder_.CreateCondBr(isNull, doneBB, releaseBB);
+    builder_.CreateCondBr(isEnvNull, doneBB, releaseBB);
 
     builder_.SetInsertPoint(releaseBB);
     auto *hdr = emitArcGetHeaderFromData(envVal);
-    emitArcRelease(hdr, false);
+
+    // Decrement strong count; if zero, call env_dtor (if non-null) and free
+    auto *strongPtr = builder_.CreateStructGEP(arcHeaderTy_, hdr, 0, "uc_dtor.strong_ptr");
+    auto *cur = builder_.CreateLoad(i64Ty_, strongPtr, "uc_dtor.strong");
+    auto *dec = builder_.CreateSub(cur, llvm::ConstantInt::get(i64Ty_, 1), "uc_dtor.dec");
+    builder_.CreateStore(dec, strongPtr);
+    auto *isDead = builder_.CreateICmpEQ(dec, llvm::ConstantInt::get(i64Ty_, 0), "uc_dtor.dead");
+
+    auto *freeBB = llvm::BasicBlock::Create(*ctx_, "uc_dtor.free", dtorFn);
+    builder_.CreateCondBr(isDead, freeBB, doneBB);
+
+    builder_.SetInsertPoint(freeBB);
+    // Call env_dtor(envVal) if non-null to release captured ARC values
+    auto *isDtorNull = builder_.CreateICmpEQ(envDtorVal, nullPtr, "uc_dtor.dtor_null");
+    auto *callDtorBB = llvm::BasicBlock::Create(*ctx_, "uc_dtor.call_dtor", dtorFn);
+    auto *afterDtorBB = llvm::BasicBlock::Create(*ctx_, "uc_dtor.after_dtor", dtorFn);
+    builder_.CreateCondBr(isDtorNull, afterDtorBB, callDtorBB);
+
+    builder_.SetInsertPoint(callDtorBB);
+    auto *envDtorFnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    builder_.CreateCall(envDtorFnTy, envDtorVal, {envVal});
+    builder_.CreateBr(afterDtorBB);
+
+    builder_.SetInsertPoint(afterDtorBB);
+    auto freeFn = mod_->getOrInsertFunction("free",
+        llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false));
+    builder_.CreateCall(freeFn, {hdr});
     builder_.CreateBr(doneBB);
 
     builder_.SetInsertPoint(doneBB);
@@ -654,26 +682,31 @@ llvm::Value *CodeGen::wrapAsUniformClosure(llvm::Value *val, const FnTypeInfo &i
 
     llvm::Function *thunk = nullptr;
     llvm::Value *envVal = nullptr;
+    llvm::Value *envDtorVal = nullptr;
+    auto *nullPtr = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
 
     if (info.capturedVars.empty()) {
-        // Non-capturing: env = null, per-function forwarding thunk
+        // Non-capturing: env = null, env_dtor = null
         llvm::Function *realFn = info.sourceFn;
         if (!realFn)
             realFn = llvm::dyn_cast<llvm::Function>(val);
         if (!realFn)
             codegenError("cannot wrap non-capturing function: sourceFn unknown");
         thunk = getOrCreateForwardingThunk(realFn, info);
-        envVal = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
+        envVal = nullPtr;
+        envDtorVal = nullPtr;
     } else {
-        // Capturing: env = original closure struct pointer, unpacking thunk
+        // Capturing: env = original closure struct pointer, env_dtor = closure destructor
         llvm::Function *realFn = info.sourceFn;
         if (!realFn)
             codegenError("cannot wrap capturing closure: sourceFn unknown");
         thunk = getOrCreateCapturingThunk(realFn, info);
-        envVal = val; // original closure struct pointer
+        envVal = val;
+        auto envDtor = getOrCreateClosureDestructor(info);
+        envDtorVal = envDtor ? llvm::cast<llvm::Value>(envDtor.getCallee()) : nullPtr;
     }
 
-    // Allocate ARC-managed uniform closure struct {thunk, env}
+    // Allocate ARC-managed uniform closure struct {thunk, env, env_dtor}
     const llvm::DataLayout &dl = mod_->getDataLayout();
     uint64_t ucSize = dl.getTypeAllocSize(ucTy);
     auto *arcHeader = emitArcAlloc(llvm::ConstantInt::get(i64Ty_, ucSize));
@@ -684,6 +717,8 @@ llvm::Value *CodeGen::wrapAsUniformClosure(llvm::Value *val, const FnTypeInfo &i
     builder_.CreateStore(thunk, thunkField);
     auto *envField = builder_.CreateStructGEP(ucTy, ucPtr, 1, "uc.env_store");
     builder_.CreateStore(envVal, envField);
+    auto *envDtorField = builder_.CreateStructGEP(ucTy, ucPtr, 2, "uc.env_dtor_store");
+    builder_.CreateStore(envDtorVal, envDtorField);
 
     // If env is an ARC-managed closure, retain it
     if (!info.capturedVars.empty()) {

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -461,7 +461,8 @@ void CodeGen::emitVarDecl(const std::string &name,
         bool isClosure = false;
         {
             auto fnIt = lookupFnTypeInfo(val);
-            if (fnIt != fn_type_info_.end() && !fnIt->second.capturedVars.empty()) {
+            if (fnIt != fn_type_info_.end() &&
+                (!fnIt->second.capturedVars.empty() || fnIt->second.isUniformClosure)) {
                 isClosure = true;
                 fn_type_info_[ptr] = fnIt->second; // propagate FnTypeInfo to alloca
             }

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -391,6 +391,7 @@ CodeGen::FnTypeInfo CodeGen::parseFnTypeAnnotation(const std::string &typeStr) {
         info.returnType = llvm::Type::getVoidTy(*ctx_);
     }
 
+    info.isUniformClosure = true;
     return info;
 }
 

--- a/tests/spec/closure_fn_param.test.ry
+++ b/tests/spec/closure_fn_param.test.ry
@@ -1,0 +1,48 @@
+describe("closure fn param", ():
+  function apply(f: function(int) -> int, x: int) -> int:
+    return f(x)
+
+  it("capturing lambda passed to function param", ():
+    factor = 7
+    mul = (x: int) => x * factor
+    expect(apply(mul, 6)).to_eq(42)
+  )
+
+  it("nested named function with capture passed to function param", ():
+    function outer(factor: int) -> int:
+      function mul(x: int) -> int:
+        return x * factor
+      return apply(mul, 6)
+
+    expect(outer(7)).to_eq(42)
+  )
+
+  it("non-capturing lambda passed to function param", ():
+    expect(apply((x: int) => x * 2, 5)).to_eq(10)
+  )
+
+  it("top-level function passed to function param", ():
+    function double(x: int) -> int:
+      return x * 2
+
+    expect(apply(double, 5)).to_eq(10)
+  )
+
+  it("multi-hop: closure passed through two function boundaries", ():
+    function apply2(f: function(int) -> int, x: int) -> int:
+      return apply(f, x)
+
+    factor = 7
+    mul = (x: int) => x * factor
+    expect(apply2(mul, 6)).to_eq(42)
+  )
+
+  it("ARC: string capture survives through function param", ():
+    function apply_str(f: function(str) -> str, x: str) -> str:
+      return f(x)
+
+    prefix = "hello "
+    greet = (name: str) => prefix + name
+    expect(apply_str(greet, "ry")).to_eq("hello ry")
+  )
+)


### PR DESCRIPTION
## Summary

- Fix SIGSEGV when passing a capturing closure as a `function(...)` argument to another function
- Introduce a uniform closure calling convention `{thunk_ptr, env_ptr}` for all values crossing `function(...)` type boundaries
- Generate per-function thunks: forwarding (non-capturing) and unpacking (capturing), cached by `llvm::Function*`
- Wrap function-typed arguments at both named-function (`emitUserFnCall`) and indirect call sites (`emitCallExpr`)
- Add uniform closure ARC destructor and correct capture-time ARC retain for uniform closures in function-type parameters

Closes #688

## Test plan

- [x] 6 new Ry self-tests (`closure_fn_param.test.ry`): capturing lambda, nested fn capture, non-capturing, top-level fn, multi-hop, ARC string capture
- [x] All 1393 C++ tests pass
- [x] All 80 Ry test files pass (0 failures)
- [x] ASan clean (1392 C++ tests + 80 Ry test files, 0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when passing capturing closures as function arguments, restoring reliable function-parameter behavior.

* **New Features**
  * Consistent support for passing both capturing and non-capturing callables through function parameters across call sites.

* **Tests**
  * Added tests covering closure function parameters, nested captures, multi-boundary passing, and reference-counted capture behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->