### PR TITLE
ci: unify Linux CI compiler to Clang 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 21
-          sudo apt-get install -y libllvm21 llvm-21-dev
+          sudo apt-get install -y libllvm21 llvm-21-dev clang-21
       - name: Install dependencies
         run: sudo apt-get install -y libssl-dev ninja-build libgtest-dev libgmock-dev
       - name: Setup ccache
@@ -66,7 +66,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 21
-          sudo apt-get install -y libllvm21 llvm-21-dev
+          sudo apt-get install -y libllvm21 llvm-21-dev clang-21
       - name: Install dependencies
         run: sudo apt-get install -y libssl-dev ninja-build libgtest-dev libgmock-dev
       - name: Setup ccache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,10 @@ jobs:
             ci-ubuntu-
       - name: Build
         run: |
-          cmake -B build -G Ninja -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm
+          cmake -B build -G Ninja \
+            -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm \
+            -DCMAKE_C_COMPILER=clang-21 \
+            -DCMAKE_CXX_COMPILER=clang++-21
           cmake --build build
       - name: Test (C++)
         run: ./build/ry_tests
@@ -76,6 +79,8 @@ jobs:
         run: |
           cmake -B build-asan -G Ninja \
             -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm \
+            -DCMAKE_C_COMPILER=clang-21 \
+            -DCMAKE_CXX_COMPILER=clang++-21 \
             -DCMAKE_BUILD_TYPE=Debug \
             -DENABLE_ASAN=ON
           cmake --build build-asan

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -98,7 +98,10 @@ jobs:
       if: matrix.build-mode == 'manual'
       shell: bash
       run: |
-        cmake -B build -G Ninja -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm
+        cmake -B build -G Ninja \
+          -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm \
+          -DCMAKE_C_COMPILER=clang-21 \
+          -DCMAKE_CXX_COMPILER=clang++-21
         cmake --build build
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -90,7 +90,7 @@ jobs:
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh 21
-        sudo apt-get install -y libllvm21 llvm-21-dev
+        sudo apt-get install -y libllvm21 llvm-21-dev clang-21
     - name: Install dependencies
       if: matrix.language == 'c-cpp'
       run: sudo apt-get install -y libssl-dev ninja-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
           sudo ./llvm.sh 21
-          sudo apt-get install -y libllvm21 llvm-21-dev
+          sudo apt-get install -y libllvm21 llvm-21-dev clang-21
       - name: Install dependencies (apt)
         if: matrix.llvm_install == 'apt'
         run: sudo apt-get install -y libssl-dev ninja-build libgtest-dev libgmock-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,6 +81,8 @@ jobs:
         run: |
           cmake -B build -G Ninja \
             -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm \
+            -DCMAKE_C_COMPILER=clang-21 \
+            -DCMAKE_CXX_COMPILER=clang++-21 \
             -DCMAKE_BUILD_TYPE=Release
           cmake --build build
 


### PR DESCRIPTION
## Summary

- Set `-DCMAKE_C_COMPILER=clang-21 -DCMAKE_CXX_COMPILER=clang++-21` in all Linux cmake invocations across CI, Release, and CodeQL workflows
- Eliminates GCC/Clang divergence that caused the v0.0.6 release build failure (#623)
- LLVM 21 (and thus `clang-21`) is already installed in CI, so no additional setup is needed

## Changed files

- `.github/workflows/ci.yml` — test and asan jobs
- `.github/workflows/release.yml` — Linux build step
- `.github/workflows/codeql.yml` — manual build step

Closes #627