### PR TITLE
fix: invoke validateDirectiveArgs on all directive-bearing AST nodes

### DIFF
--- a/changelog.d/696-validate-directives-all-nodes.md
+++ b/changelog.d/696-validate-directives-all-nodes.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Unknown or invalid directive arguments on `record`, record fields, variable assignments, and `for` loops now produce a compile-time error, consistent with how function directives are validated (#696)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -731,6 +731,7 @@ public:
         const std::vector<ExprPtr> *postconditions,
         const std::vector<std::string> *ensureBindings);
     void applyInlineDirective(llvm::Function *func, const std::vector<Directive> &directives);
+    void validateDirectives(const std::vector<Directive> &directives);
     llvm::Type *tryResolveType(const std::string &typeName);
     void emitStmt(std::unique_ptr<MatchStmt> &s);
     llvm::Value *emitPatternTest(const Pattern &pattern, llvm::Value *subjectVal,

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -391,6 +391,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
 
 void CodeGen::emitStmt(CallStmt &s) {
     emitCoverage(s.loc);
+    validateDirectives(s.directives);
     if (s.callee == "describe") {
         emitDescribeCall(s);
         return;

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -390,6 +390,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
 }
 
 void CodeGen::emitStmt(CallStmt &s) {
+    if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
     validateDirectives(s.directives);
     if (s.callee == "describe") {

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -4,6 +4,7 @@
 namespace ry {
 
 void CodeGen::emitStmt(RecordStmt &s) {
+    if (s.loc.isValid()) current_loc_ = s.loc;
     validateDirectives(s.directives);
     for (const auto &f : s.fields)
         validateDirectives(f.directives);

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -4,6 +4,9 @@
 namespace ry {
 
 void CodeGen::emitStmt(RecordStmt &s) {
+    validateDirectives(s.directives);
+    for (const auto &f : s.fields)
+        validateDirectives(f.directives);
     emitTraceSymbolDefine("record", s.name, s.loc);
     if (struct_types_.count(s.name))
         codegenError("redefined type: " + s.name);

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -415,15 +415,10 @@ void CodeGen::forwardDeclareNestedFunctions(std::vector<StmtNode> &body) {
     forwardDeclareFunctionsInBody(body, /*validateOperatorReturn=*/true);
 }
 
-// ===== B5: FnStmt using FnScope RAII =====
+// ===== Directive validation helper =====
 
-void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
-    if (s->loc.isValid()) current_loc_ = s->loc;
-    emitCoverage(s->loc);
-    emitTraceSymbolDefine("function", s->name, s->loc);
-
-    // Validate directives against their signatures (set location for diagnostics)
-    for (const auto &d : s->directives) {
+void CodeGen::validateDirectives(const std::vector<Directive> &directives) {
+    for (const auto &d : directives) {
         if (d.loc.isValid()) current_loc_ = d.loc;
         try {
             validateDirectiveArgs(d.name, d.args);
@@ -431,6 +426,16 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             codegenError(e.what());
         }
     }
+}
+
+// ===== B5: FnStmt using FnScope RAII =====
+
+void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
+    if (s->loc.isValid()) current_loc_ = s->loc;
+    emitCoverage(s->loc);
+    emitTraceSymbolDefine("function", s->name, s->loc);
+
+    validateDirectives(s->directives);
 
     // Generic function: save as template, don't instantiate yet
     if (!s->type_params.empty()) {

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -418,6 +418,7 @@ void CodeGen::forwardDeclareNestedFunctions(std::vector<StmtNode> &body) {
 // ===== Directive validation helper =====
 
 void CodeGen::validateDirectives(const std::vector<Directive> &directives) {
+    SourceLocation saved_loc = current_loc_;
     for (const auto &d : directives) {
         if (d.loc.isValid()) current_loc_ = d.loc;
         try {
@@ -426,6 +427,7 @@ void CodeGen::validateDirectives(const std::vector<Directive> &directives) {
             codegenError(e.what());
         }
     }
+    current_loc_ = saved_loc;
 }
 
 // ===== B5: FnStmt using FnScope RAII =====

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -527,6 +527,7 @@ void CodeGen::emitStmt(ExprStmt &s) {
 void CodeGen::emitStmt(AssignStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
+    validateDirectives(s.directives);
     bool is_const = hasDirective(s.directives, "const");
     bool is_native = hasDirective(s.directives, "native");
 

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -32,6 +32,7 @@ void CodeGen::emitStmt(std::unique_ptr<WhileStmt> &s) {
 
 void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
     emitCoverage(s->loc);
+    current_loc_ = s->loc;
     validateDirectives(s->directives);
     if (hasDirective(s->directives, "parallel")) {
         if (s->var_names.size() > 1)

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -32,6 +32,7 @@ void CodeGen::emitStmt(std::unique_ptr<WhileStmt> &s) {
 
 void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
     emitCoverage(s->loc);
+    validateDirectives(s->directives);
     if (hasDirective(s->directives, "parallel")) {
         if (s->var_names.size() > 1)
             codegenError(s->loc, "@parallel for does not support destructuring iteration");

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -148,6 +148,7 @@ void CodeGen::emitStmt(EnumStmt &s) {
 }
 
 void CodeGen::emitStmt(TupleDestructStmt &s) {
+    if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
     validateDirectives(s.directives);
     llvm::Value *tupleVal = emitExpr(*s.value);

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -149,6 +149,7 @@ void CodeGen::emitStmt(EnumStmt &s) {
 
 void CodeGen::emitStmt(TupleDestructStmt &s) {
     emitCoverage(s.loc);
+    validateDirectives(s.directives);
     llvm::Value *tupleVal = emitExpr(*s.value);
     llvm::StructType *structTy = llvm::dyn_cast<llvm::StructType>(tupleVal->getType());
     if (!structTy)

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -450,6 +450,20 @@ TEST_F(DirectiveTest, DeprecatedPositionalArgOnRecordError) {
     }, std::runtime_error);
 }
 
+// 10k. Unknown directive on TupleDestructStmt causes codegen error
+TEST_F(DirectiveTest, UnknownDirectiveOnTupleDestructError) {
+    EXPECT_THROW({
+        runSource("@unknown\na, b = (1, 2)\n");
+    }, std::runtime_error);
+}
+
+// 10l. Unknown directive on CallStmt causes codegen error
+TEST_F(DirectiveTest, UnknownDirectiveOnCallStmtError) {
+    EXPECT_THROW({
+        runSource("@unknown\nprint(1)\n");
+    }, std::runtime_error);
+}
+
 // 11. Directive on invalid target causes parse error
 TEST_F(DirectiveTest, DirectiveOnInvalidTarget) {
     EXPECT_THROW({

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -415,6 +415,41 @@ TEST_F(DirectiveTest, NativeKeyValueParamsError) {
     }, std::runtime_error);
 }
 
+// 10f. Unknown directive on RecordStmt causes codegen error
+TEST_F(DirectiveTest, UnknownDirectiveOnRecordError) {
+    EXPECT_THROW({
+        runSource("@unknown\nrecord Foo:\n    x: int\n");
+    }, std::runtime_error);
+}
+
+// 10g. Unknown directive on a record field causes codegen error
+TEST_F(DirectiveTest, UnknownDirectiveOnFieldError) {
+    EXPECT_THROW({
+        runSource("record Foo:\n    @unknown\n    x: int\n");
+    }, std::runtime_error);
+}
+
+// 10h. Unknown directive on AssignStmt causes codegen error
+TEST_F(DirectiveTest, UnknownDirectiveOnAssignError) {
+    EXPECT_THROW({
+        runSource("@unknown\nx = 42\n");
+    }, std::runtime_error);
+}
+
+// 10i. Unknown directive on ForStmt causes codegen error
+TEST_F(DirectiveTest, UnknownDirectiveOnForError) {
+    EXPECT_THROW({
+        runSource("@unknown\nfor i in range(10):\n    print(i)\n");
+    }, std::runtime_error);
+}
+
+// 10j. @deprecated with positional arg on record causes codegen error
+TEST_F(DirectiveTest, DeprecatedPositionalArgOnRecordError) {
+    EXPECT_THROW({
+        runSource("@deprecated(\"old\")\nrecord Foo:\n    x: int\n");
+    }, std::runtime_error);
+}
+
 // 11. Directive on invalid target causes parse error
 TEST_F(DirectiveTest, DirectiveOnInvalidTarget) {
     EXPECT_THROW({


### PR DESCRIPTION
Closes #696

## Summary

- Add `CodeGen::validateDirectives()` helper that wraps the try/catch → `codegenError` pattern around `validateDirectiveArgs`
- Call it at codegen entry points for `RecordStmt` (record-level and field-level directives), `AssignStmt`, and `ForStmt`
- Refactor existing `FnStmt` validation to use the same helper, eliminating 4 copies of the same loop
- Add 5 new tests covering unknown/invalid directives on each affected node type

## Test plan

- [ ] `UnknownDirectiveOnRecordError` — `@unknown` on record → compile error
- [ ] `UnknownDirectiveOnFieldError` — `@unknown` on record field → compile error
- [ ] `UnknownDirectiveOnAssignError` — `@unknown` on assignment → compile error
- [ ] `UnknownDirectiveOnForError` — `@unknown` on for loop → compile error
- [ ] `DeprecatedPositionalArgOnRecordError` — `@deprecated("old")` on record → compile error
- [ ] All 1403 existing tests pass
- [ ] ASan build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unknown or invalid directives on records, record fields, assignments, for-loops, tuple destructuring, and calls are now reported at compile time for consistent validation.

* **Tests**
  * Added tests asserting compile-time errors for unknown or invalid directive usages across multiple statement types.

* **Documentation**
  * Changelog updated to note these directive validation fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->