### PR TITLE
feat: support compound expressions in directive arguments

### DIFF
--- a/changelog.d/694-compound-directive-args.md
+++ b/changelog.d/694-compound-directive-args.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Directive arguments now support compound expressions such as function calls and binary operators (`@each(make_inputs())`, `@foo(x + 1)`) (#694)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -219,7 +219,7 @@ it("description with {0} and {1}", (param1: type, param2: type):
 
 The argument can be any expression that evaluates to a list of tuples, including a function call:
 
-```
+```ry
 @each(make_inputs())
 it("test with {0}", (x: int):
     # test body

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -217,10 +217,19 @@ it("description with {0} and {1}", (param1: type, param2: type):
 )
 ```
 
+The argument can be any expression that evaluates to a list of tuples, including a function call:
+
+```
+@each(make_inputs())
+it("test with {0}", (x: int):
+    # test body
+)
+```
+
 **Supported target:** `it` calls only
 
 **Constraints:**
-- The argument must be a list of tuples
+- The argument must evaluate to a list of tuples
 - Tuple arity must match the lambda parameter count
 - Placeholders `{0}`, `{1}`, ... in the description string are replaced with stringified values
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -184,34 +184,20 @@ std::vector<Directive> Parser::parseDirectives() {
             lex_.next(); // consume '('
 
             while (lex_.peek().kind != TokenKind::RParen) {
-                // Look ahead two tokens: if Ident + '=' it's a named argument,
-                // otherwise it's positional. The lexer has no multi-peek so we consume
-                // the ident speculatively and reconstruct a VariableExpr if needed.
-                Token t1 = lex_.peek();
-                if (t1.kind == TokenKind::Ident) {
-                    lex_.next(); // consume ident
-                    if (lex_.peek().kind == TokenKind::Equals) {
-                        // Named argument: key=expr
-                        lex_.next(); // consume '='
-                        DirectiveArg arg;
-                        arg.name = t1.value;
-                        arg.value = parsePrimary();
-                        d.args.push_back(std::move(arg));
-                    } else {
-                        // Positional ident: reconstruct as VariableExpr (no putBack on lexer).
-                        auto identExpr = std::make_unique<ExprNode>();
-                        identExpr->data = VariableExpr{t1.value};
-                        identExpr->loc = {t1.line, t1.col, file_id_};
-                        DirectiveArg arg;
-                        arg.name = std::nullopt;
-                        arg.value = std::move(identExpr);
-                        d.args.push_back(std::move(arg));
-                    }
+                // Parse a full expression. If it turns out to be a bare
+                // VariableExpr followed by '=', treat it as a named argument.
+                ExprPtr expr = parseConditional();
+                auto *var = std::get_if<VariableExpr>(&expr->data);
+                if (var != nullptr && lex_.peek().kind == TokenKind::Equals) {
+                    lex_.next(); // consume '='
+                    DirectiveArg arg;
+                    arg.name = var->name;
+                    arg.value = parseConditional();
+                    d.args.push_back(std::move(arg));
                 } else {
-                    // Positional argument: arbitrary expression (list, string, number, …)
                     DirectiveArg arg;
                     arg.name = std::nullopt;
-                    arg.value = parsePrimary();
+                    arg.value = std::move(expr);
                     d.args.push_back(std::move(arg));
                 }
 

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -902,6 +902,95 @@ TEST(DirectiveSyntax, MixedPositionalAndNamedArgsInOneDirective) {
     EXPECT_EQ(numExpr->value, 50);
 }
 
+// Positional argument that is a function call expression.
+// Verifies @custom(make_inputs()) is parsed as a CallExpr, not a bare VariableExpr.
+TEST(DirectiveSyntax, CompoundExprCallAsPositionalArg) {
+    std::string src =
+        "@custom(make_inputs())\n"
+        "function foo():\n"
+        "    expect(1).to_eq(1)\n";
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    ASSERT_FALSE(prog.empty());
+    auto *fn = std::get_if<std::unique_ptr<FnStmt>>(&prog[0]);
+    ASSERT_NE(fn, nullptr);
+    ASSERT_EQ((*fn)->directives.size(), 1u);
+    auto &d = (*fn)->directives[0];
+    EXPECT_EQ(d.name, "custom");
+    ASSERT_EQ(d.args.size(), 1u);
+    EXPECT_FALSE(d.args[0].name.has_value());
+    auto *call = std::get_if<std::unique_ptr<CallExpr>>(&d.args[0].value->data);
+    ASSERT_NE(call, nullptr);
+}
+
+// Positional argument that is a binary expression.
+// Verifies @custom(x + 1) is parsed as a BinaryExpr, not a bare VariableExpr.
+TEST(DirectiveSyntax, CompoundExprBinaryAsPositionalArg) {
+    std::string src =
+        "@custom(x + 1)\n"
+        "function foo():\n"
+        "    expect(1).to_eq(1)\n";
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    ASSERT_FALSE(prog.empty());
+    auto *fn = std::get_if<std::unique_ptr<FnStmt>>(&prog[0]);
+    ASSERT_NE(fn, nullptr);
+    ASSERT_EQ((*fn)->directives.size(), 1u);
+    auto &d = (*fn)->directives[0];
+    ASSERT_EQ(d.args.size(), 1u);
+    EXPECT_FALSE(d.args[0].name.has_value());
+    ASSERT_NE(std::get_if<std::unique_ptr<BinaryExpr>>(&d.args[0].value->data), nullptr);
+}
+
+// Named argument whose value is a binary expression.
+// Verifies @custom(count=2 + 3) is parsed as named arg "count" with a BinaryExpr value.
+TEST(DirectiveSyntax, NamedArgWithCompoundValue) {
+    std::string src =
+        "@custom(count=2 + 3)\n"
+        "function foo():\n"
+        "    expect(1).to_eq(1)\n";
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    ASSERT_FALSE(prog.empty());
+    auto *fn = std::get_if<std::unique_ptr<FnStmt>>(&prog[0]);
+    ASSERT_NE(fn, nullptr);
+    ASSERT_EQ((*fn)->directives.size(), 1u);
+    auto &d = (*fn)->directives[0];
+    ASSERT_EQ(d.args.size(), 1u);
+    ASSERT_TRUE(d.args[0].name.has_value());
+    EXPECT_EQ(*d.args[0].name, "count");
+    ASSERT_NE(std::get_if<std::unique_ptr<BinaryExpr>>(&d.args[0].value->data), nullptr);
+}
+
+// Named argument whose value is a function call expression.
+// Verifies @custom(data=make_data()) is parsed as named arg "data" with a CallExpr value.
+TEST(DirectiveSyntax, NamedArgWithCallValue) {
+    std::string src =
+        "@custom(data=make_data())\n"
+        "function foo():\n"
+        "    expect(1).to_eq(1)\n";
+    Lexer lex(src);
+    Parser parser(lex);
+    Program prog = parser.parseProgram();
+
+    ASSERT_FALSE(prog.empty());
+    auto *fn = std::get_if<std::unique_ptr<FnStmt>>(&prog[0]);
+    ASSERT_NE(fn, nullptr);
+    ASSERT_EQ((*fn)->directives.size(), 1u);
+    auto &d = (*fn)->directives[0];
+    ASSERT_EQ(d.args.size(), 1u);
+    ASSERT_TRUE(d.args[0].name.has_value());
+    EXPECT_EQ(*d.args[0].name, "data");
+    auto *call = std::get_if<std::unique_ptr<CallExpr>>(&d.args[0].value->data);
+    ASSERT_NE(call, nullptr);
+}
+
 // Unknown directive name: parser now accepts any name (validation deferred to codegen).
 // This test verifies the AST is correctly populated; codegen will reject at emit time.
 TEST(DirectiveSyntax, UnknownDirectiveParseSucceeds) {


### PR DESCRIPTION
Closes #694

## Summary

- Replace the speculative identifier consumption in `parseDirectives()` with a parse-then-reclassify approach
- `parseConditional()` parses the full expression; the result is treated as a named arg only when it is a bare `VariableExpr` followed by `=`
- Enables `@each(make_inputs())` and `@foo(x + 1)` to parse correctly

## Changes

- `src/parser.cpp`: Replace 3-branch speculative-ident logic (~27 lines) with 2-branch `get_if`-based approach (~14 lines)
- `tests/test_codegen_directive.cpp`: Add 4 parse-level tests (`CompoundExprCallAsPositionalArg`, `CompoundExprBinaryAsPositionalArg`, `NamedArgWithCompoundValue`, `NamedArgWithCallValue`)
- `docs/reference/directives.md`: Document that `@each` accepts any expression evaluating to a list of tuples, including function calls
- `changelog.d/694-compound-directive-args.md`: CHANGELOG fragment

## Test plan

- [x] All 1409 C++ tests pass (`./build/ry_tests`)
- [x] All 80 Ry spec test files pass (`./build/ry test -p`)
- [x] ASan build passes with no memory errors
- [x] 4 new `DirectiveSyntax` tests cover the fixed cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Directive arguments now accept compound expressions, including function calls and binary operators (e.g., @each(make_inputs()), @foo(x + 1)).

* **Documentation**
  * Updated directive reference to reflect support for expressions that evaluate to lists/tuples.

* **Tests**
  * Added unit tests covering call- and binary-expression directive arguments.

* **Changelog**
  * Added entry noting the fix for compound directive arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->