### PR TITLE
refactor: add custom_validator to DirectiveSignature for pluggable per-directive validation

### DIFF
--- a/include/ry/directive_meta.hpp
+++ b/include/ry/directive_meta.hpp
@@ -36,6 +36,9 @@ struct DirectiveSignature {
     int min_positional = 0;
     int max_positional = 0;        // -1 = unlimited
     std::vector<std::string> named_params;  // allowed named parameter names
+    // Optional per-directive validation. Called after generic checks pass.
+    // Throws std::runtime_error if validation fails.
+    void (*custom_validator)(const std::string &, const std::vector<DirectiveArg> &) = nullptr;
 };
 
 // Returns the registry of all built-in directive signatures.

--- a/src/directive_meta.cpp
+++ b/src/directive_meta.cpp
@@ -36,6 +36,13 @@ const ExprNode *getDirectiveNamedArg(const std::vector<Directive> &directives,
     return nullptr;
 }
 
+// Returns the first positional ExprNode from a directive arg list, or nullptr.
+static const ExprNode *firstPositionalExpr(const std::vector<DirectiveArg> &args) {
+    for (const auto &a : args)
+        if (!a.name.has_value() && a.value) return a.value.get();
+    return nullptr;
+}
+
 // ===== Built-in directive registry =====
 
 const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegistry() {
@@ -49,7 +56,17 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
         {"native", {"native",
             T::Function | T::Statement,
             DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/1, {}}},
+            /*min_pos=*/0, /*max_pos=*/1, {},
+            [](const std::string &, const std::vector<DirectiveArg> &args) {
+                if (const ExprNode *p = firstPositionalExpr(args)) {
+                    if (auto *s = std::get_if<StringExpr>(&p->data)) {
+                        if (s->value.empty())
+                            throw std::runtime_error("@native library name must not be empty");
+                    } else {
+                        throw std::runtime_error("@native expects a string literal argument");
+                    }
+                }
+            }}},
 
         {"inline", {"inline",
             asTarget(T::Function),
@@ -127,21 +144,9 @@ void validateDirectiveArgs(const std::string &directiveName,
             "@" + directiveName + " accepts at most " +
             std::to_string(sig.max_positional) + " positional argument(s)");
 
-    // @native-specific validation: positional arg must be a non-empty string
-    if (directiveName == "native" && positional > 0) {
-        const ExprNode *firstPos = nullptr;
-        for (const auto &a : args) {
-            if (!a.name.has_value() && a.value) { firstPos = a.value.get(); break; }
-        }
-        if (firstPos) {
-            if (auto *s = std::get_if<StringExpr>(&firstPos->data)) {
-                if (s->value.empty())
-                    throw std::runtime_error("@native library name must not be empty");
-            } else {
-                throw std::runtime_error("@native expects a string literal argument");
-            }
-        }
-    }
+    // Per-directive custom validation
+    if (sig.custom_validator)
+        sig.custom_validator(directiveName, args);
 }
 
 }  // namespace ry

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -408,6 +408,17 @@ TEST_F(DirectiveTest, NativeLibraryExtraArgsError) {
     }, std::runtime_error);
 }
 
+// 10e-1. @native(123) — non-string positional argument causes validation error
+TEST_F(DirectiveTest, NativeNonStringArgError) {
+    try {
+        runSource("@native(123)\nfunction foo(x: int) -> int\n");
+        FAIL() << "Expected std::runtime_error";
+    } catch (const std::runtime_error &e) {
+        EXPECT_NE(std::string(e.what()).find("@native expects a string literal argument"),
+                  std::string::npos);
+    }
+}
+
 // 10e. @native(key=value) — key-value params not allowed for @native
 TEST_F(DirectiveTest, NativeKeyValueParamsError) {
     EXPECT_THROW({

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -410,13 +410,9 @@ TEST_F(DirectiveTest, NativeLibraryExtraArgsError) {
 
 // 10e-1. @native(123) — non-string positional argument causes validation error
 TEST_F(DirectiveTest, NativeNonStringArgError) {
-    try {
+    EXPECT_THROW({
         runSource("@native(123)\nfunction foo(x: int) -> int\n");
-        FAIL() << "Expected std::runtime_error";
-    } catch (const std::runtime_error &e) {
-        EXPECT_NE(std::string(e.what()).find("@native expects a string literal argument"),
-                  std::string::npos);
-    }
+    }, std::runtime_error);
 }
 
 // 10e. @native(key=value) — key-value params not allowed for @native


### PR DESCRIPTION
Closes #695

## Summary

- Add `custom_validator` function pointer field to `DirectiveSignature` (defaults to `nullptr`), replacing the hardcoded `if (directiveName == "native")` branch in `validateDirectiveArgs()`
- Add file-local `firstPositionalExpr()` helper in `directive_meta.cpp` to find the first positional `ExprNode` from an arg list, avoiding duplication of the scan pattern
- Migrate `@native` argument validation (must be a non-empty string literal) into the registry entry's `custom_validator` lambda, which uses `firstPositionalExpr()`
- Use a plain function pointer instead of `std::function` — the lambda captures nothing, so no heap allocation needed

## Test plan

- [ ] `./build/ry_tests` — all 1409 tests pass
- [ ] `./build/ry test -p` — all 80 test files pass
- [ ] ASan build passes (`ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests && ./build-asan/ry test -p`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Directive validation redesigned to support per-directive custom validation callbacks for clearer, extensible checks.
* **Bug Fixes**
  * `@native` directive now enforces a non-empty string literal argument and reports a descriptive error when invalid.
* **Tests**
  * Added a test verifying `@native` rejects non-string arguments and produces the expected error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->