### PR TITLE
feat: @it and @describe directives on named functions (#634, #635)

### DIFF
--- a/changelog.d/634-it-describe-directive.md
+++ b/changelog.d/634-it-describe-directive.md
@@ -1,0 +1,5 @@
+### Added
+
+- `@it("description")` directive on named functions: test cases can now be defined as ordinary named functions decorated with `@it` (#634)
+- `@describe("group")` directive on named functions: test groups can now be defined as ordinary named functions decorated with `@describe` (#635)
+- `@each` and `@property` directives compose with `@it` on named functions for parameterized and property-based tests (#634)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -40,7 +40,7 @@ When `ry test` is run without arguments, it:
 
 Use the `@it` and `@describe` directives to define test cases as ordinary named functions:
 
-```
+```ry
 @it("test case name")
 function test_add():
     expect(1 + 2).to_eq(3)
@@ -48,7 +48,7 @@ function test_add():
 
 Group related tests using `@describe`:
 
-```
+```ry
 @describe("Arithmetic")
 function arithmetic_tests():
     @it("adds integers")

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -36,7 +36,36 @@ When `ry test` is run without arguments, it:
 
 ## Syntax
 
-### describe / it
+### Function-Based Syntax (recommended)
+
+Use the `@it` and `@describe` directives to define test cases as ordinary named functions:
+
+```
+@it("test case name")
+function test_add():
+    expect(1 + 2).to_eq(3)
+```
+
+Group related tests using `@describe`:
+
+```
+@describe("Arithmetic")
+function arithmetic_tests():
+    @it("adds integers")
+    function test_add():
+        expect(1 + 2).to_eq(3)
+
+    @it("subtracts integers")
+    function test_sub():
+        expect(5 - 3).to_eq(2)
+```
+
+- The function name is used for code navigation and symbol identity
+- The description string (in the directive) is used for test output and reporting
+- `@it` functions must have no parameters unless combined with `@each` or `@property`
+- Both `@it` and `@describe` are only available with `ry test`
+
+### Lambda Syntax (classic)
 
 ```
 describe("description", ():
@@ -202,7 +231,22 @@ describe("verify", ():
 
 ## Parameterized Tests (@each)
 
-`@each` runs the same test with multiple sets of parameters. Attach it to an `it` block with a list of tuples:
+`@each` runs the same test with multiple sets of parameters.
+
+**Function-based syntax (recommended):**
+
+```
+@each([
+    (1, 2, 3),
+    (0, 0, 0),
+    (-1, 1, 0)
+])
+@it("adds {0} + {1} = {2}")
+function test_add(a: int, b: int, expected: int):
+    expect(a + b).to_eq(expected)
+```
+
+**Lambda syntax:**
 
 ```
 @each([
@@ -215,7 +259,7 @@ it("adds {0} + {1} = {2}", (a: int, b: int, expected: int):
 )
 ```
 
-- The list must contain tuples whose arity matches the lambda parameter count
+- The list must contain tuples whose arity matches the parameter count
 - Placeholders `{0}`, `{1}`, ... in the description are replaced with the parameter values
 - Each tuple generates an independent test case
 - Supported parameter types: `int`, `float`, `bool`, `str`
@@ -224,7 +268,18 @@ it("adds {0} + {1} = {2}", (a: int, b: int, expected: int):
 
 ## Property-Based Tests (@property)
 
-`@property` generates random inputs and runs the test multiple times:
+`@property` generates random inputs and runs the test multiple times.
+
+**Function-based syntax (recommended):**
+
+```
+@property(count=100)
+@it("addition is commutative")
+function test_commutative(a: int, b: int):
+    expect(a + b).to_eq(b + a)
+```
+
+**Lambda syntax:**
 
 ```
 @property(count=100)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -348,5 +348,5 @@ describe verify
 
 ## Limitations
 
-- Nesting of `describe` is not supported
+- Nesting of `describe` (lambda syntax) is not supported; use the function-based `@describe` syntax for grouping within a describe block
 - `before_each` / `after_each` are not supported

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -83,6 +83,12 @@ inline bool hasDirective(const std::vector<Directive> &directives, std::string_v
     return false;
 }
 
+inline Directive *findDirective(std::vector<Directive> &directives, std::string_view name) {
+    for (auto &d : directives)
+        if (d.name == name) return &d;
+    return nullptr;
+}
+
 // Get the first positional string argument of a named directive.
 // Returns empty string if not found or not a StringExpr.
 std::string getDirectivePositionalArg(const std::vector<Directive> &directives,

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -746,8 +746,18 @@ public:
     void emitItCall(CallStmt &s);
     void emitEachItCall(CallStmt &s);
     void emitPropertyItCall(CallStmt &s);
+    void emitItDirective(std::unique_ptr<FnStmt> &s);
+    void emitEachItDirective(std::unique_ptr<FnStmt> &s);
+    void emitPropertyItDirective(std::unique_ptr<FnStmt> &s);
+    void emitDescribeDirective(std::unique_ptr<FnStmt> &s);
+    void emitEachItLoop(llvm::Value *listPtr, llvm::Type *elemTy, unsigned numFields,
+                        const std::string &fmtStr, llvm::Function *testFunc);
+    void emitPropertyItLoop(llvm::Function *testFunc, llvm::Value *descVal,
+                            const std::vector<llvm::Type*> &paramTypes,
+                            const std::vector<std::string> &paramNames, int64_t count);
     void emitOutlinePrintf(const std::string &label, llvm::Value *nameVal = nullptr);
     std::pair<llvm::FunctionCallee, llvm::FunctionCallee> getTestItFunctions();
+    std::pair<llvm::FunctionCallee, llvm::FunctionCallee> getTestDescribeFunctions();
     llvm::Function *emitTestFunction(const std::string &namePrefix,
         const std::vector<llvm::Type*> &paramTypes, LambdaExpr &lam, const std::string &context);
     void emitMockCall(CallStmt &s);

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -434,12 +434,12 @@ void CodeGen::validateDirectives(const std::vector<Directive> &directives) {
 
 void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     if (s->loc.isValid()) current_loc_ = s->loc;
-    emitCoverage(s->loc);
-    emitTraceSymbolDefine("function", s->name, s->loc);
 
     validateDirectives(s->directives);
 
-    // Directive-based test case: @it("description") on a named function
+    // Directive-based test case: @it("description") on a named function.
+    // Dispatch before coverage/trace so the inner emitStmt(s) call (after
+    // directive stripping) handles those for the actual function definition.
     if (hasDirective(s->directives, "it")) {
         emitItDirective(s);
         return;
@@ -449,6 +449,9 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         emitDescribeDirective(s);
         return;
     }
+
+    emitCoverage(s->loc);
+    emitTraceSymbolDefine("function", s->name, s->loc);
 
     // Generic function: save as template, don't instantiate yet
     if (!s->type_params.empty()) {

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -439,6 +439,17 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
     validateDirectives(s->directives);
 
+    // Directive-based test case: @it("description") on a named function
+    if (hasDirective(s->directives, "it")) {
+        emitItDirective(s);
+        return;
+    }
+    // Directive-based test group: @describe("group") on a named function
+    if (hasDirective(s->directives, "describe")) {
+        emitDescribeDirective(s);
+        return;
+    }
+
     // Generic function: save as template, don't instantiate yet
     if (!s->type_params.empty()) {
         for (auto &p : s->params) {

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -53,13 +53,7 @@ void CodeGen::emitDescribeCall(CallStmt &s) {
         return;
     }
 
-    llvm::FunctionType *voidStrTy = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
-    llvm::FunctionType *voidTy = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*ctx_), false);
-
-    llvm::FunctionCallee descBeginFn = mod_->getOrInsertFunction("__ry_test_describe_begin", voidStrTy);
-    llvm::FunctionCallee descEndFn   = mod_->getOrInsertFunction("__ry_test_describe_end", voidTy);
+    auto [descBeginFn, descEndFn] = getTestDescribeFunctions();
 
     builder_.CreateCall(descBeginFn, {descName});
 
@@ -69,7 +63,6 @@ void CodeGen::emitDescribeCall(CallStmt &s) {
     builder_.CreateCall(descEndFn);
 }
 
-// Helper: get it_begin/it_end function callees
 std::pair<llvm::FunctionCallee, llvm::FunctionCallee> CodeGen::getTestItFunctions() {
     llvm::FunctionType *voidStrTy = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
@@ -78,6 +71,17 @@ std::pair<llvm::FunctionCallee, llvm::FunctionCallee> CodeGen::getTestItFunction
     return {
         mod_->getOrInsertFunction("__ry_test_it_begin", voidStrTy),
         mod_->getOrInsertFunction("__ry_test_it_end", voidTy)
+    };
+}
+
+std::pair<llvm::FunctionCallee, llvm::FunctionCallee> CodeGen::getTestDescribeFunctions() {
+    llvm::FunctionType *voidStrTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    llvm::FunctionType *voidTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_), false);
+    return {
+        mod_->getOrInsertFunction("__ry_test_describe_begin", voidStrTy),
+        mod_->getOrInsertFunction("__ry_test_describe_end", voidTy)
     };
 }
 
@@ -229,7 +233,11 @@ void CodeGen::emitEachItCall(CallStmt &s) {
 
     llvm::Function *testFunc = emitTestFunction("__test_each_", paramTypes, lam, "@each test");
 
-    // Get list length and data
+    emitEachItLoop(listPtr, elemTy, numFields, fmtStr, testFunc);
+}
+
+void CodeGen::emitEachItLoop(llvm::Value *listPtr, llvm::Type *elemTy, unsigned numFields,
+                              const std::string &fmtStr, llvm::Function *testFunc) {
     llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, listPtr, 0, "each_len_ptr");
     llvm::Value *length = builder_.CreateLoad(i64Ty_, lenPtr, "each_len");
     llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, listPtr, 2, "each_data_ptr");
@@ -238,18 +246,16 @@ void CodeGen::emitEachItCall(CallStmt &s) {
     auto [itBeginFn, itEndFn] = getTestItFunctions();
     auto snprintfFn = getStdlibSnprintf();
 
-    // Parse format string placeholders in single pass
     std::string cFmt;
     std::vector<unsigned> fieldOrder;
     parseFormatPlaceholders(fmtStr, cFmt, fieldOrder);
 
-    // IR loop: for i in 0..length
     llvm::Value *iAlloca = builder_.CreateAlloca(i64Ty_, nullptr, "each_i");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iAlloca);
 
     llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "each.cond", fn_);
     llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, "each.body", fn_);
-    llvm::BasicBlock *endBB  = llvm::BasicBlock::Create(*ctx_, "each.end", fn_);
+    llvm::BasicBlock *endBB  = llvm::BasicBlock::Create(*ctx_, "each.end",  fn_);
 
     builder_.CreateBr(condBB);
     builder_.SetInsertPoint(condBB);
@@ -261,7 +267,6 @@ void CodeGen::emitEachItCall(CallStmt &s) {
     llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {iVal}, "each_elem_ptr");
     llvm::Value *tupleVal = builder_.CreateLoad(elemTy, elemPtr, "each_tuple");
 
-    // Extract fields and format name
     std::vector<llvm::Value*> fieldVals;
     std::vector<llvm::Value*> fieldStrs;
     for (unsigned i = 0; i < numFields; ++i) {
@@ -290,7 +295,6 @@ void CodeGen::emitEachItCall(CallStmt &s) {
     builder_.CreateCall(testFunc, fieldVals);
     builder_.CreateCall(itEndFn);
 
-    // Increment loop counter
     llvm::Value *nextI = builder_.CreateAdd(iVal, llvm::ConstantInt::get(i64Ty_, 1), "next_i");
     builder_.CreateStore(nextI, iAlloca);
     builder_.CreateBr(condBB);
@@ -339,40 +343,40 @@ void CodeGen::emitPropertyItCall(CallStmt &s) {
 
     llvm::Function *testFunc = emitTestFunction("__prop_test_", paramTypes, lam, "@property test");
 
+    std::vector<std::string> paramNames;
+    for (auto &p : lam.params)
+        paramNames.push_back(p.name);
+
+    emitPropertyItLoop(testFunc, itName, paramTypes, paramNames, count);
+}
+
+void CodeGen::emitPropertyItLoop(llvm::Function *testFunc, llvm::Value *descVal,
+                                  const std::vector<llvm::Type*> &paramTypes,
+                                  const std::vector<std::string> &paramNames, int64_t count) {
     auto [itBeginFn, itEndFn] = getTestItFunctions();
 
-    // Declare random generator functions
     llvm::FunctionType *initRngTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), false);
     llvm::FunctionCallee initRngFn = mod_->getOrInsertFunction("__ry_test_prop_init_rng", initRngTy);
-
     llvm::FunctionType *randIntTy = llvm::FunctionType::get(i64Ty_, false);
     llvm::FunctionCallee randIntFn = mod_->getOrInsertFunction("__ry_test_rand_int", randIntTy);
-
     llvm::FunctionType *randFloatTy = llvm::FunctionType::get(f64Ty_, false);
     llvm::FunctionCallee randFloatFn = mod_->getOrInsertFunction("__ry_test_rand_float", randFloatTy);
-
     llvm::FunctionType *randBoolTy = llvm::FunctionType::get(i64Ty_, false);
     llvm::FunctionCallee randBoolFn = mod_->getOrInsertFunction("__ry_test_rand_bool", randBoolTy);
-
     llvm::FunctionType *randStrTy = llvm::FunctionType::get(ptrTy_, false);
     llvm::FunctionCallee randStrFn = mod_->getOrInsertFunction("__ry_test_rand_str", randStrTy);
-
     llvm::FunctionType *isFailedTy = llvm::FunctionType::get(i64Ty_, false);
     llvm::FunctionCallee isFailedFn = mod_->getOrInsertFunction("__ry_test_it_is_failed", isFailedTy);
 
-    // Init RNG
     builder_.CreateCall(initRngFn);
+    builder_.CreateCall(itBeginFn, {descVal});
 
-    // Begin test
-    builder_.CreateCall(itBeginFn, {itName});
-
-    // IR loop: for i in 0..count
     llvm::Value *iAlloca = builder_.CreateAlloca(i64Ty_, nullptr, "prop_i");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iAlloca);
 
     llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "prop.cond", fn_);
     llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, "prop.body", fn_);
-    llvm::BasicBlock *endBB  = llvm::BasicBlock::Create(*ctx_, "prop.end", fn_);
+    llvm::BasicBlock *endBB  = llvm::BasicBlock::Create(*ctx_, "prop.end",  fn_);
 
     builder_.CreateBr(condBB);
     builder_.SetInsertPoint(condBB);
@@ -382,7 +386,6 @@ void CodeGen::emitPropertyItCall(CallStmt &s) {
 
     builder_.SetInsertPoint(bodyBB);
 
-    // Generate random values for each parameter
     std::vector<llvm::Value*> randVals;
     for (unsigned i = 0; i < paramTypes.size(); ++i) {
         llvm::Value *val;
@@ -396,15 +399,13 @@ void CodeGen::emitPropertyItCall(CallStmt &s) {
         } else if (paramTypes[i] == ptrTy_) {
             val = builder_.CreateCall(randStrFn, {}, "rand_str");
         } else {
-            codegenError("@property: unsupported parameter type for '" + lam.params[i].name + "'");
+            codegenError("@property: unsupported parameter type for '" + paramNames[i] + "'");
         }
         randVals.push_back(val);
     }
 
-    // Call test function
     builder_.CreateCall(testFunc, randVals);
 
-    // Check if failed → early exit
     llvm::Value *failed = builder_.CreateCall(isFailedFn, {}, "is_failed");
     llvm::Value *didFail = builder_.CreateICmpNE(failed, llvm::ConstantInt::get(i64Ty_, 0), "did_fail");
 
@@ -412,19 +413,15 @@ void CodeGen::emitPropertyItCall(CallStmt &s) {
     llvm::BasicBlock *contBB = llvm::BasicBlock::Create(*ctx_, "prop.cont", fn_);
     builder_.CreateCondBr(didFail, failBB, contBB);
 
-    // On failure: print counterexample
     builder_.SetInsertPoint(failBB);
     {
         auto printfFn = getStdlibPrintf();
-
-        // Build counterexample message
         std::string ceFmt = "    \033[31mCounterexample: (";
         for (unsigned i = 0; i < paramTypes.size(); ++i) {
             if (i > 0) ceFmt += ", ";
-            ceFmt += lam.params[i].name + " = %s";
+            ceFmt += paramNames[i] + " = %s";
         }
         ceFmt += ")\033[0m\n";
-
         llvm::Value *ceFmtStr = cachedGlobalString(ceFmt, ".prop_ce_fmt");
         std::vector<llvm::Value*> ceArgs = {ceFmtStr};
         for (unsigned i = 0; i < randVals.size(); ++i)
@@ -448,6 +445,178 @@ void CodeGen::emitPropertyItCall(CallStmt &s) {
 
     builder_.SetInsertPoint(endBB);
     builder_.CreateCall(itEndFn);
+}
+
+// ===== Test: @it / @describe directive on named functions =====
+
+// Helper: erase directives matching any of the given names
+static void stripDirectives(
+    std::vector<Directive> &directives,
+    std::initializer_list<const char*> names)
+{
+    directives.erase(
+        std::remove_if(directives.begin(), directives.end(), [&](const Directive &d) {
+            for (const char *n : names)
+                if (d.name == n) return true;
+            return false;
+        }),
+        directives.end());
+}
+
+void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
+    if (!test_mode_)
+        codegenError("@it is only allowed in test mode (use 'ry test')");
+
+    if (hasDirective(s->directives, "each")) {
+        emitEachItDirective(s);
+        return;
+    }
+    if (hasDirective(s->directives, "property")) {
+        emitPropertyItDirective(s);
+        return;
+    }
+
+    // Basic @it: function must have no parameters
+    if (!s->params.empty())
+        codegenError("@it: function '" + s->name + "' has parameters but no @each or @property directive");
+
+    std::string desc = getDirectivePositionalArg(s->directives, "it");
+
+    if (outline_mode_) {
+        llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+        emitOutlinePrintf("it %s\n", descVal);
+        return;
+    }
+
+    // Strip @it and emit the function normally, then emit it_begin/call/it_end
+    stripDirectives(s->directives, {"it"});
+    emitStmt(s);
+
+    auto *overloads = findFunction(s->name);
+    if (!overloads || overloads->empty())
+        codegenError("@it: internal error — function '" + s->name + "' not found after emit");
+    llvm::Function *testFunc = overloads->back().func;
+
+    auto [itBeginFn, itEndFn] = getTestItFunctions();
+    llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+    builder_.CreateCall(itBeginFn, {descVal});
+    builder_.CreateCall(testFunc);
+    builder_.CreateCall(itEndFn);
+}
+
+void CodeGen::emitEachItDirective(std::unique_ptr<FnStmt> &s) {
+    Directive *eachDir = findDirective(s->directives, "each");
+    if (!eachDir || eachDir->args.empty() || !eachDir->args[0].value || eachDir->args[0].name.has_value())
+        codegenError("@each directive requires a list expression");
+
+    std::string fmtStr = getDirectivePositionalArg(s->directives, "it");
+
+    if (outline_mode_) {
+        emitOutlinePrintf("it " + fmtStr + " (@each)\n");
+        return;
+    }
+
+    llvm::Value *listPtr = emitExpr(*eachDir->args[0].value);
+    llvm::Type *elemTy = getListElementType(listPtr);
+    if (!elemTy)
+        codegenError("@each requires a list of tuples");
+    auto *tupleTy = llvm::dyn_cast<llvm::StructType>(elemTy);
+    if (!tupleTy)
+        codegenError("@each requires a list of tuples");
+
+    unsigned numFields = tupleTy->getNumElements();
+    if (numFields != s->params.size())
+        codegenError("@each: tuple arity (" + std::to_string(numFields) +
+                     ") doesn't match function parameter count (" + std::to_string(s->params.size()) + ")");
+
+    stripDirectives(s->directives, {"it", "each"});
+    emitStmt(s);
+
+    auto *overloads = findFunction(s->name);
+    if (!overloads || overloads->empty())
+        codegenError("@each @it: internal error — function '" + s->name + "' not found after emit");
+    llvm::Function *testFunc = overloads->back().func;
+
+    emitEachItLoop(listPtr, elemTy, numFields, fmtStr, testFunc);
+}
+
+void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
+    std::string desc = getDirectivePositionalArg(s->directives, "it");
+
+    if (outline_mode_) {
+        llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+        emitOutlinePrintf("it %s (@property)\n", descVal);
+        return;
+    }
+
+    int64_t count = 100;
+    if (const ExprNode *countExpr = getDirectiveNamedArg(s->directives, "property", "count")) {
+        if (auto *n = std::get_if<NumberExpr>(&countExpr->data)) {
+            if (n->value <= 0)
+                codegenError("@property 'count' must be a positive integer");
+            count = static_cast<int64_t>(n->value);
+        } else {
+            codegenError("@property 'count' must be an integer literal");
+        }
+    }
+
+    std::vector<llvm::Type*> paramTypes;
+    std::vector<std::string> paramNames;
+    for (auto &p : s->params) {
+        if (!p.type)
+            codegenError("@property: parameter '" + p.name + "' must have an explicit type annotation");
+        paramTypes.push_back(resolveType(p.type->toString()));
+        paramNames.push_back(p.name);
+    }
+
+    stripDirectives(s->directives, {"it", "property"});
+    emitStmt(s);
+
+    auto *overloads = findFunction(s->name);
+    if (!overloads || overloads->empty())
+        codegenError("@property @it: internal error — function '" + s->name + "' not found after emit");
+    llvm::Function *testFunc = overloads->back().func;
+
+    llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+    emitPropertyItLoop(testFunc, descVal, paramTypes, paramNames, count);
+}
+
+void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
+    if (!test_mode_)
+        codegenError("@describe is only allowed in test mode (use 'ry test')");
+
+    std::string desc = getDirectivePositionalArg(s->directives, "describe");
+    llvm::Value *descVal = cachedGlobalString(desc, ".describe_desc");
+
+    if (outline_mode_) {
+        emitOutlinePrintf("describe %s\n", descVal);
+        ++outline_depth_;
+        for (auto &stmt : s->body) {
+            if (auto *fnPtr = std::get_if<std::unique_ptr<FnStmt>>(&stmt)) {
+                auto &fn = *fnPtr;
+                if (hasDirective(fn->directives, "it") || hasDirective(fn->directives, "describe"))
+                    std::visit([this](auto &st) { emitStmt(st); }, stmt);
+            } else if (auto *cs = std::get_if<CallStmt>(&stmt)) {
+                if (cs->callee == "describe" || cs->callee == "it")
+                    emitStmt(*cs);
+            }
+        }
+        --outline_depth_;
+        return;
+    }
+
+    stripDirectives(s->directives, {"describe"});
+    emitStmt(s);
+
+    auto *overloads = findFunction(s->name);
+    if (!overloads || overloads->empty())
+        codegenError("@describe: internal error — function '" + s->name + "' not found after emit");
+    llvm::Function *descFunc = overloads->back().func;
+
+    auto [descBeginFn, descEndFn] = getTestDescribeFunctions();
+    builder_.CreateCall(descBeginFn, {descVal});
+    builder_.CreateCall(descFunc);
+    builder_.CreateCall(descEndFn);
 }
 
 // ===== Test: mock(fn_name, replacement) =====

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -1,5 +1,7 @@
 #include "ry/codegen.hpp"
 #include "ry/diagnostic.hpp"
+#include <algorithm>
+#include <initializer_list>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
 #include <stdexcept>
@@ -207,7 +209,8 @@ void CodeGen::emitEachItCall(CallStmt &s) {
     std::string fmtStr = descStr->value;
 
     if (outline_mode_) {
-        emitOutlinePrintf("it " + fmtStr + " (@each)\n");
+        llvm::Value *fmtStrVal = cachedGlobalString(fmtStr, ".it_each_desc");
+        emitOutlinePrintf("it %s (@each)\n", fmtStrVal);
         return;
     }
 
@@ -466,6 +469,10 @@ static void stripDirectives(
 void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     if (!test_mode_)
         codegenError("@it is only allowed in test mode (use 'ry test')");
+    if (s->is_async)
+        codegenError("@it: function '" + s->name + "' cannot be async");
+    if (!s->type_params.empty())
+        codegenError("@it: function '" + s->name + "' cannot be generic");
 
     if (hasDirective(s->directives, "each")) {
         emitEachItDirective(s);
@@ -512,7 +519,8 @@ void CodeGen::emitEachItDirective(std::unique_ptr<FnStmt> &s) {
     std::string fmtStr = getDirectivePositionalArg(s->directives, "it");
 
     if (outline_mode_) {
-        emitOutlinePrintf("it " + fmtStr + " (@each)\n");
+        llvm::Value *fmtStrVal = cachedGlobalString(fmtStr, ".it_each_desc");
+        emitOutlinePrintf("it %s (@each)\n", fmtStrVal);
         return;
     }
 
@@ -584,6 +592,12 @@ void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
 void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
     if (!test_mode_)
         codegenError("@describe is only allowed in test mode (use 'ry test')");
+    if (s->is_async)
+        codegenError("@describe: function '" + s->name + "' cannot be async");
+    if (!s->type_params.empty())
+        codegenError("@describe: function '" + s->name + "' cannot be generic");
+    if (!s->params.empty())
+        codegenError("@describe: function '" + s->name + "' cannot have parameters");
 
     std::string desc = getDirectivePositionalArg(s->directives, "describe");
     llvm::Value *descVal = cachedGlobalString(desc, ".describe_desc");

--- a/src/directive_meta.cpp
+++ b/src/directive_meta.cpp
@@ -96,12 +96,24 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
         {"it", {"it",
             asTarget(T::Function),
             DirectiveStage::CompileTime,
-            /*min_pos=*/1, /*max_pos=*/1, {}}},
+            /*min_pos=*/1, /*max_pos=*/1, {},
+            [](const std::string &, const std::vector<DirectiveArg> &args) {
+                if (const ExprNode *p = firstPositionalExpr(args)) {
+                    if (!std::get_if<StringExpr>(&p->data))
+                        throw std::runtime_error("@it expects a string literal description");
+                }
+            }}},
 
         {"describe", {"describe",
             asTarget(T::Function),
             DirectiveStage::CompileTime,
-            /*min_pos=*/1, /*max_pos=*/1, {}}},
+            /*min_pos=*/1, /*max_pos=*/1, {},
+            [](const std::string &, const std::vector<DirectiveArg> &args) {
+                if (const ExprNode *p = firstPositionalExpr(args)) {
+                    if (!std::get_if<StringExpr>(&p->data))
+                        throw std::runtime_error("@describe expects a string literal description");
+                }
+            }}},
     };
     return registry;
 }

--- a/tests/spec/directive_test.test.ry
+++ b/tests/spec/directive_test.test.ry
@@ -1,0 +1,47 @@
+# Tests for @it and @describe directive syntax on named functions (#634)
+
+# Basic @it on a named function
+@it("adds 1 + 2 = 3")
+function test_add():
+  expect(1 + 2).to_eq(3)
+
+@it("string concatenation")
+function test_str_concat():
+  expect("hello" + " " + "world").to_eq("hello world")
+
+@it("boolean logic")
+function test_bool():
+  expect(true and false).to_be_false()
+
+# @describe wrapping named functions with nested @it
+@describe("arithmetic")
+function arithmetic_tests():
+  @it("subtraction")
+  function test_sub():
+    expect(10 - 3).to_eq(7)
+
+  @it("multiplication")
+  function test_mul():
+    expect(4 * 5).to_eq(20)
+
+# @each with @it on a named function
+@each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
+@it("adds {0} + {1} = {2}")
+function test_add_each(a: int, b: int, expected: int):
+  expect(a + b).to_eq(expected)
+
+@each([("hello", 5), ("", 0), ("ry", 2)])
+@it("length of \"{0}\" is {1}")
+function test_length_each(s: str, expected: int):
+  expect(length(s)).to_eq(expected)
+
+# @property with @it on a named function
+@property(count=100)
+@it("addition is commutative")
+function test_add_commutative(a: int, b: int):
+  expect(a + b).to_eq(b + a)
+
+@property(count=50)
+@it("double is always even")
+function test_double_even(n: int):
+  expect(n * 2 % 2).to_eq(0)

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -909,6 +909,87 @@ TEST(DirectiveSyntax, MixedPositionalAndNamedArgsInOneDirective) {
     EXPECT_EQ(numExpr->value, 50);
 }
 
+// ===== @it / @describe directive codegen tests (#634) =====
+
+// Basic @it on a named function compiles and runs as a test case
+TEST_F(DirectiveTest, ItDirectiveBasicCodegen) {
+    EXPECT_EQ(runTestSource(
+        "@it(\"adds 1 + 2 = 3\")\n"
+        "function test_add():\n"
+        "    expect(1 + 2).to_eq(3)\n"
+    ), "  \033[32m+ adds 1 + 2 = 3\033[0m\n\n1 passed, 0 failed\n");
+}
+
+// @it requires test mode — should error outside test mode
+TEST_F(DirectiveTest, ItDirectiveRequiresTestMode) {
+    EXPECT_THROW(
+        compileSource(
+            "@it(\"should fail\")\n"
+            "function test_x():\n"
+            "    expect(1).to_eq(1)\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// @it on a function with params (without @each/@property) should error
+TEST_F(DirectiveTest, ItDirectiveRejectsParamsWithoutEachOrProperty) {
+    EXPECT_THROW(
+        []() {
+            Lexer lex(
+                "@it(\"bad\")\n"
+                "function test_bad(x: int):\n"
+                "    expect(x).to_eq(1)\n"
+            );
+            Parser parser(lex);
+            Program prog = parser.parseProgram();
+            CodeGen cg(true);
+            cg.compile(prog);
+        }(),
+        std::runtime_error
+    );
+}
+
+// @describe on a named function wraps nested @it functions in a describe group
+TEST_F(DirectiveTest, DescribeDirectiveBasicCodegen) {
+    EXPECT_EQ(runTestSource(
+        "@describe(\"math\")\n"
+        "function math_tests():\n"
+        "    @it(\"subtraction\")\n"
+        "    function test_sub():\n"
+        "        expect(10 - 3).to_eq(7)\n"
+        "\n"
+        "    @it(\"multiplication\")\n"
+        "    function test_mul():\n"
+        "        expect(4 * 5).to_eq(20)\n"
+    ), "math\n  \033[32m+ subtraction\033[0m\n  \033[32m+ multiplication\033[0m\n\n2 passed, 0 failed\n");
+}
+
+// @each + @it on a named function: parameterized tests
+TEST_F(DirectiveTest, ItDirectiveWithEach) {
+    EXPECT_EQ(runTestSource(
+        "@each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])\n"
+        "@it(\"adds {0} + {1} = {2}\")\n"
+        "function test_add(a: int, b: int, expected: int):\n"
+        "    expect(a + b).to_eq(expected)\n"
+    ), "  \033[32m+ adds 1 + 2 = 3\033[0m\n"
+       "  \033[32m+ adds 0 + 0 = 0\033[0m\n"
+       "  \033[32m+ adds -1 + 1 = 0\033[0m\n"
+       "\n3 passed, 0 failed\n");
+}
+
+// @property + @it on a named function: property-based tests
+TEST_F(DirectiveTest, ItDirectiveWithProperty) {
+    std::string out = runTestSource(
+        "@property(count=10)\n"
+        "@it(\"addition is commutative\")\n"
+        "function test_commutative(a: int, b: int):\n"
+        "    expect(a + b).to_eq(b + a)\n"
+    );
+    EXPECT_NE(out.find("+ addition is commutative"), std::string::npos);
+    EXPECT_NE(out.find("1 passed, 0 failed"), std::string::npos);
+}
+
 // Positional argument that is a function call expression.
 // Verifies @custom(make_inputs()) is parsed as a CallExpr, not a bare VariableExpr.
 TEST(DirectiveSyntax, CompoundExprCallAsPositionalArg) {

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -990,6 +990,65 @@ TEST_F(DirectiveTest, ItDirectiveWithProperty) {
     EXPECT_NE(out.find("1 passed, 0 failed"), std::string::npos);
 }
 
+// @it on an async function should error
+TEST_F(DirectiveTest, ItDirectiveRejectsAsyncFunction) {
+    EXPECT_THROW(
+        []() {
+            Lexer lex(
+                "@it(\"bad\")\n"
+                "async function test_async():\n"
+                "    expect(1).to_eq(1)\n"
+            );
+            Parser parser(lex);
+            Program prog = parser.parseProgram();
+            CodeGen cg(true);
+            cg.compile(prog);
+        }(),
+        std::runtime_error
+    );
+}
+
+// @describe on a function with parameters should error
+TEST_F(DirectiveTest, DescribeDirectiveRejectsParams) {
+    EXPECT_THROW(
+        []() {
+            Lexer lex(
+                "@describe(\"group\")\n"
+                "function grp(x: int):\n"
+                "    @it(\"sub\")\n"
+                "    function t():\n"
+                "        expect(x).to_eq(1)\n"
+            );
+            Parser parser(lex);
+            Program prog = parser.parseProgram();
+            CodeGen cg(true);
+            cg.compile(prog);
+        }(),
+        std::runtime_error
+    );
+}
+
+// @describe nested inside @describe: inner @it functions run under the outer group header
+TEST_F(DirectiveTest, DescribeDirectiveNestedDescribe) {
+    EXPECT_EQ(runTestSource(
+        "@describe(\"outer\")\n"
+        "function outer_tests():\n"
+        "    @it(\"direct child\")\n"
+        "    function test_direct():\n"
+        "        expect(1 + 1).to_eq(2)\n"
+        "\n"
+        "    @describe(\"inner\")\n"
+        "    function inner_tests():\n"
+        "        @it(\"nested child\")\n"
+        "        function test_nested():\n"
+        "            expect(2 * 3).to_eq(6)\n"
+    ), "outer\n"
+       "  \033[32m+ direct child\033[0m\n"
+       "inner\n"
+       "  \033[32m+ nested child\033[0m\n"
+       "\n2 passed, 0 failed\n");
+}
+
 // Positional argument that is a function call expression.
 // Verifies @custom(make_inputs()) is parsed as a CallExpr, not a bare VariableExpr.
 TEST(DirectiveSyntax, CompoundExprCallAsPositionalArg) {


### PR DESCRIPTION
## Summary

- Adds `@it("description")` directive on named functions: test cases can now be defined as ordinary named functions instead of lambdas
- Adds `@describe("group")` directive on named functions: test groups can now be defined as named functions
- `@each` and `@property` compose with `@it` on named functions for parameterized and property-based tests
- Extracted `emitEachItLoop()` and `emitPropertyItLoop()` as shared helpers to eliminate ~200 lines of duplicate LLVM IR generation between call-based and directive-based paths

Closes #634
Closes #635

## Test plan

- [ ] New C++ tests in `tests/test_codegen_directive.cpp`: `ItDirectiveBasicCodegen`, `ItDirectiveRequiresTestMode`, `ItDirectiveRejectsParamsWithoutEachOrProperty`, `DescribeDirectiveBasicCodegen`, `ItDirectiveWithEach`, `ItDirectiveWithProperty`
- [ ] New Ry self-test file `tests/spec/directive_test.test.ry` covering all four variants (basic `@it`, `@describe` + nested `@it`, `@each + @it`, `@property + @it`)
- [ ] All 1416 C++ tests pass, 81 Ry test files pass (0 failures)
- [ ] ASan clean: no memory errors detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Function-based test directives: `@it` and `@describe` can be applied to named functions; `@each` and `@property` compose with `@it` for parameterized and property-based tests.

* **Documentation**
  * Testing reference updated with recommended function-based syntax, constraints, examples for `@each`/`@property`, and guidance on grouping via `@describe`.

* **Tests**
  * Added end-to-end coverage for named-function `@it`/`@describe`, parameterized `@each` runs, and `@property` executions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->