### PR TITLE
feat: complete @describe directive — shared setup, nesting depth, deprecation (#635)

### DIFF
--- a/changelog.d/635-describe-directive-completion.md
+++ b/changelog.d/635-describe-directive-completion.md
@@ -1,0 +1,12 @@
+### Added
+
+- Shared setup in `@describe`: variables declared in a describe function body are automatically captured by inner `@it` functions (#635)
+- Nested `@describe` output indentation: test output is now indented proportionally to nesting depth (#635)
+
+### Fixed
+
+- `ExpectStmt` was not scanned during free-variable analysis, preventing closure capture of variables referenced in `expect(x).to_eq(...)` assertions inside nested `@it` functions (#635)
+
+### Deprecated
+
+- `describe()` and `it()` lambda call syntax: use `@describe("name")` and `@it("name")` directives on named functions instead (#635)

--- a/changelog.d/635-describe-directive-completion.md
+++ b/changelog.d/635-describe-directive-completion.md
@@ -7,6 +7,6 @@
 
 - `ExpectStmt` was not scanned during free-variable analysis, preventing closure capture of variables referenced in `expect(x).to_eq(...)` assertions inside nested `@it` functions (#635)
 
-### Deprecated
+### Changed
 
-- `describe()` and `it()` lambda call syntax: use `@describe("name")` and `@it("name")` directives on named functions instead (#635)
+- `describe()` and `it()` lambda call syntax is deprecated; use `@describe("name")` and `@it("name")` directives on named functions instead (#635)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -99,7 +99,8 @@ function api_tests():
 ```
 
 Output:
-```
+
+```text
 API
   GET /users
     + returns 200 OK
@@ -110,6 +111,7 @@ API
 > **Deprecated**: The `describe()` and `it()` lambda call syntax is deprecated. Use `@describe` and `@it` directives on named functions instead. The lambda syntax will be removed in a future release.
 >
 > Migration:
+>
 > | Lambda syntax | Directive syntax |
 > |---|---|
 > | `it("name", (): ...)` | `@it("name") function name(): ...` |

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -65,7 +65,55 @@ function arithmetic_tests():
 - `@it` functions must have no parameters unless combined with `@each` or `@property`
 - Both `@it` and `@describe` are only available with `ry test`
 
-### Lambda Syntax (classic)
+#### Shared Setup
+
+Variables declared in the `@describe` function body are automatically captured by inner `@it` functions:
+
+```ry
+@describe("User validation")
+function user_validation_tests():
+    min_length = 8
+    max_length = 64
+
+    @it("rejects short passwords")
+    function test_short():
+        expect(min_length).to_be_greater_than(0)
+
+    @it("accepts passwords within length limits")
+    function test_range():
+        expect(max_length).to_be_greater_than(min_length)
+```
+
+#### Nested `@describe`
+
+`@describe` functions can be nested to create multi-level groupings. Output is indented to reflect the nesting depth:
+
+```ry
+@describe("API")
+function api_tests():
+    @describe("GET /users")
+    function get_users_tests():
+        @it("returns 200 OK")
+        function test_ok():
+            expect(true).to_be_true()
+```
+
+Output:
+```
+API
+  GET /users
+    + returns 200 OK
+```
+
+### Lambda Syntax (deprecated)
+
+> **Deprecated**: The `describe()` and `it()` lambda call syntax is deprecated. Use `@describe` and `@it` directives on named functions instead. The lambda syntax will be removed in a future release.
+>
+> Migration:
+> | Lambda syntax | Directive syntax |
+> |---|---|
+> | `it("name", (): ...)` | `@it("name") function name(): ...` |
+> | `describe("name", (): ...)` | `@describe("name") function name(): ...` |
 
 ```
 describe("description", ():
@@ -348,5 +396,5 @@ describe verify
 
 ## Limitations
 
-- Nesting of `describe` (lambda syntax) is not supported; use the function-based `@describe` syntax for grouping within a describe block
+- Nesting of `describe` (lambda syntax) is not supported; use the function-based `@describe` directive syntax for nested grouping
 - `before_each` / `after_each` are not supported

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -528,6 +528,7 @@ public:
     std::unordered_set<std::string> deprecated_variables_;
     std::unordered_set<std::string> deprecated_fields_;  // "TypeName.fieldName"
     std::vector<std::string> warnings_;
+    std::unordered_set<std::string> warned_call_deprecations_;
 
     void emitDeprecationWarning(const std::string &name);
 
@@ -746,15 +747,18 @@ public:
     void emitItCall(CallStmt &s);
     void emitEachItCall(CallStmt &s);
     void emitPropertyItCall(CallStmt &s);
+    llvm::SmallVector<llvm::Value*, 4> loadCapturedArgs(const OverloadEntry &entry, const std::string &directive);
     void emitItDirective(std::unique_ptr<FnStmt> &s);
     void emitEachItDirective(std::unique_ptr<FnStmt> &s);
     void emitPropertyItDirective(std::unique_ptr<FnStmt> &s);
     void emitDescribeDirective(std::unique_ptr<FnStmt> &s);
     void emitEachItLoop(llvm::Value *listPtr, llvm::Type *elemTy, unsigned numFields,
-                        const std::string &fmtStr, llvm::Function *testFunc);
+                        const std::string &fmtStr, llvm::Function *testFunc,
+                        const std::vector<llvm::Value*> &capturedVals = {});
     void emitPropertyItLoop(llvm::Function *testFunc, llvm::Value *descVal,
                             const std::vector<llvm::Type*> &paramTypes,
-                            const std::vector<std::string> &paramNames, int64_t count);
+                            const std::vector<std::string> &paramNames, int64_t count,
+                            const std::vector<llvm::Value*> &capturedVals = {});
     void emitOutlinePrintf(const std::string &label, llvm::Value *nameVal = nullptr);
     std::pair<llvm::FunctionCallee, llvm::FunctionCallee> getTestItFunctions();
     std::pair<llvm::FunctionCallee, llvm::FunctionCallee> getTestDescribeFunctions();

--- a/include/ry/test_runtime.hpp
+++ b/include/ry/test_runtime.hpp
@@ -21,6 +21,9 @@ extern "C" {
     void    __ry_mock_increment_call(const char *name);
     void    __ry_mock_clear_all();
 
+    // Indent helpers
+    const char *__ry_test_indent(int extra);
+
     // Property-based test support
     void        __ry_test_prop_init_rng();
     int64_t     __ry_test_rand_int();

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -131,6 +131,9 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
                     if (arm.guard) scanExpr(*arm.guard);
                     for (auto &st : arm.body) scanStmt(st);
                 }
+            } else if constexpr (std::is_same_v<T, ExpectStmt>) {
+                scanExpr(*s.actual);
+                if (s.expected) scanExpr(*s.expected);
             }
         }, stmt);
     };

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -444,14 +444,22 @@ void CodeGen::emitPropertyItLoop(llvm::Function *testFunc, llvm::Value *descVal,
     builder_.SetInsertPoint(failBB);
     {
         auto printfFn = getStdlibPrintf();
-        std::string ceFmt = "    \033[31mCounterexample: (";
+        // Fetch the current describe-nesting indent at runtime so Counterexample:
+        // aligns with the surrounding test output regardless of nesting depth.
+        llvm::FunctionType *indentTy = llvm::FunctionType::get(
+            ptrTy_, {llvm::Type::getInt32Ty(*ctx_)}, false);
+        llvm::FunctionCallee indentFn = mod_->getOrInsertFunction("__ry_test_indent", indentTy);
+        llvm::Value *indentStr = builder_.CreateCall(
+            indentFn, {llvm::ConstantInt::get(llvm::Type::getInt32Ty(*ctx_), 2)}, "ce_indent");
+
+        std::string ceFmt = "%s\033[31mCounterexample: (";
         for (unsigned i = 0; i < paramTypes.size(); ++i) {
             if (i > 0) ceFmt += ", ";
             ceFmt += paramNames[i] + " = %s";
         }
         ceFmt += ")\033[0m\n";
         llvm::Value *ceFmtStr = cachedGlobalString(ceFmt, ".prop_ce_fmt");
-        std::vector<llvm::Value*> ceArgs = {ceFmtStr};
+        std::vector<llvm::Value*> ceArgs = {ceFmtStr, indentStr};
         for (unsigned i = 0; i < randVals.size(); ++i)
             ceArgs.push_back(valueToString(randVals[i]));
         builder_.CreateCall(printfFn, ceArgs);
@@ -572,7 +580,7 @@ void CodeGen::emitEachItDirective(std::unique_ptr<FnStmt> &s) {
     const auto &entry = overloads->back();
     auto capturedVals = loadCapturedArgs(entry, "@each @it");
     emitEachItLoop(listPtr, elemTy, numFields, fmtStr, entry.func,
-                   {capturedVals.begin(), capturedVals.end()});
+                   std::vector<llvm::Value*>(capturedVals.begin(), capturedVals.end()));
 }
 
 void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
@@ -614,7 +622,7 @@ void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
     auto capturedVals = loadCapturedArgs(entry, "@property @it");
     llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
     emitPropertyItLoop(entry.func, descVal, paramTypes, paramNames, count,
-                       {capturedVals.begin(), capturedVals.end()});
+                       std::vector<llvm::Value*>(capturedVals.begin(), capturedVals.end()));
 }
 
 void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -21,6 +21,19 @@ void CodeGen::emitOutlinePrintf(const std::string &label, llvm::Value *nameVal) 
         builder_.CreateCall(printfFn, {fmt});
 }
 
+// ===== Test helpers =====
+
+llvm::SmallVector<llvm::Value*, 4> CodeGen::loadCapturedArgs(const OverloadEntry &entry, const std::string &directive) {
+    llvm::SmallVector<llvm::Value*, 4> args;
+    for (const auto &capName : entry.capturedNames) {
+        llvm::AllocaInst *alloca = findVar(capName);
+        if (!alloca)
+            codegenError(directive + ": captured variable '" + capName + "' not found in scope");
+        args.push_back(builder_.CreateLoad(alloca->getAllocatedType(), alloca, capName + ".cap_pass"));
+    }
+    return args;
+}
+
 // ===== Test: describe/it (lambda argument) =====
 
 static LambdaExpr &extractLambdaArg(CallStmt &s, const std::string &callee) {
@@ -35,6 +48,9 @@ static LambdaExpr &extractLambdaArg(CallStmt &s, const std::string &callee) {
 void CodeGen::emitDescribeCall(CallStmt &s) {
     if (!test_mode_)
         codegenError("'describe' is only allowed in test mode (use 'ry test')");
+
+    if (warned_call_deprecations_.insert("describe").second)
+        warnings_.push_back("warning: describe() lambda syntax is deprecated; use @describe(\"...\") on a named function instead");
 
     auto &lambda = extractLambdaArg(s, "describe");
 
@@ -152,6 +168,9 @@ void CodeGen::emitItCall(CallStmt &s) {
     if (!test_mode_)
         codegenError("'it' is only allowed in test mode (use 'ry test')");
 
+    if (warned_call_deprecations_.insert("it").second)
+        warnings_.push_back("warning: it() lambda syntax is deprecated; use @it(\"...\") on a named function instead");
+
     // Check for @each / @property directives
     if (hasDirective(s.directives, "each")) {
         emitEachItCall(s);
@@ -240,7 +259,8 @@ void CodeGen::emitEachItCall(CallStmt &s) {
 }
 
 void CodeGen::emitEachItLoop(llvm::Value *listPtr, llvm::Type *elemTy, unsigned numFields,
-                              const std::string &fmtStr, llvm::Function *testFunc) {
+                              const std::string &fmtStr, llvm::Function *testFunc,
+                              const std::vector<llvm::Value*> &capturedVals) {
     llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, listPtr, 0, "each_len_ptr");
     llvm::Value *length = builder_.CreateLoad(i64Ty_, lenPtr, "each_len");
     llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, listPtr, 2, "each_data_ptr");
@@ -294,8 +314,10 @@ void CodeGen::emitEachItLoop(llvm::Value *listPtr, llvm::Type *elemTy, unsigned 
         snprintfArgs.push_back(fieldStrs[idx]);
     builder_.CreateCall(snprintfFn, snprintfArgs);
 
+    llvm::SmallVector<llvm::Value*, 8> callArgs(fieldVals.begin(), fieldVals.end());
+    callArgs.append(capturedVals.begin(), capturedVals.end());
     builder_.CreateCall(itBeginFn, {fmtBuf});
-    builder_.CreateCall(testFunc, fieldVals);
+    builder_.CreateCall(testFunc, callArgs);
     builder_.CreateCall(itEndFn);
 
     llvm::Value *nextI = builder_.CreateAdd(iVal, llvm::ConstantInt::get(i64Ty_, 1), "next_i");
@@ -355,7 +377,8 @@ void CodeGen::emitPropertyItCall(CallStmt &s) {
 
 void CodeGen::emitPropertyItLoop(llvm::Function *testFunc, llvm::Value *descVal,
                                   const std::vector<llvm::Type*> &paramTypes,
-                                  const std::vector<std::string> &paramNames, int64_t count) {
+                                  const std::vector<std::string> &paramNames, int64_t count,
+                                  const std::vector<llvm::Value*> &capturedVals) {
     auto [itBeginFn, itEndFn] = getTestItFunctions();
 
     llvm::FunctionType *initRngTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), false);
@@ -407,7 +430,9 @@ void CodeGen::emitPropertyItLoop(llvm::Function *testFunc, llvm::Value *descVal,
         randVals.push_back(val);
     }
 
-    builder_.CreateCall(testFunc, randVals);
+    llvm::SmallVector<llvm::Value*, 8> propCallArgs(randVals.begin(), randVals.end());
+    propCallArgs.append(capturedVals.begin(), capturedVals.end());
+    builder_.CreateCall(testFunc, propCallArgs);
 
     llvm::Value *failed = builder_.CreateCall(isFailedFn, {}, "is_failed");
     llvm::Value *didFail = builder_.CreateICmpNE(failed, llvm::ConstantInt::get(i64Ty_, 0), "did_fail");
@@ -502,12 +527,13 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
         codegenError("@it: internal error — function '" + s->name + "' not found after emit");
-    llvm::Function *testFunc = overloads->back().func;
+    const auto &entry = overloads->back();
+    auto capturedArgs = loadCapturedArgs(entry, "@it");
 
     auto [itBeginFn, itEndFn] = getTestItFunctions();
     llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
     builder_.CreateCall(itBeginFn, {descVal});
-    builder_.CreateCall(testFunc);
+    builder_.CreateCall(entry.func, capturedArgs);
     builder_.CreateCall(itEndFn);
 }
 
@@ -543,9 +569,10 @@ void CodeGen::emitEachItDirective(std::unique_ptr<FnStmt> &s) {
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
         codegenError("@each @it: internal error — function '" + s->name + "' not found after emit");
-    llvm::Function *testFunc = overloads->back().func;
-
-    emitEachItLoop(listPtr, elemTy, numFields, fmtStr, testFunc);
+    const auto &entry = overloads->back();
+    auto capturedVals = loadCapturedArgs(entry, "@each @it");
+    emitEachItLoop(listPtr, elemTy, numFields, fmtStr, entry.func,
+                   {capturedVals.begin(), capturedVals.end()});
 }
 
 void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
@@ -583,10 +610,11 @@ void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
         codegenError("@property @it: internal error — function '" + s->name + "' not found after emit");
-    llvm::Function *testFunc = overloads->back().func;
-
+    const auto &entry = overloads->back();
+    auto capturedVals = loadCapturedArgs(entry, "@property @it");
     llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
-    emitPropertyItLoop(testFunc, descVal, paramTypes, paramNames, count);
+    emitPropertyItLoop(entry.func, descVal, paramTypes, paramNames, count,
+                       {capturedVals.begin(), capturedVals.end()});
 }
 
 void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
@@ -625,11 +653,12 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
         codegenError("@describe: internal error — function '" + s->name + "' not found after emit");
-    llvm::Function *descFunc = overloads->back().func;
+    const auto &entry = overloads->back();
+    auto capturedArgs = loadCapturedArgs(entry, "@describe");
 
     auto [descBeginFn, descEndFn] = getTestDescribeFunctions();
     builder_.CreateCall(descBeginFn, {descVal});
-    builder_.CreateCall(descFunc);
+    builder_.CreateCall(entry.func, capturedArgs);
     builder_.CreateCall(descEndFn);
 }
 

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -13,9 +13,13 @@ namespace ry {
 
 static int g_passed = 0;
 static int g_failed = 0;
-static std::string g_current_describe;
+static int g_describe_depth = 0;
 static std::string g_current_it;
 static bool g_current_it_failed = false;
+
+static std::string currentIndent(int extra = 0) {
+    return std::string(static_cast<size_t>(g_describe_depth * 2 + extra), ' ');
+}
 
 // async-signal-safe buffer for the timeout handler in main.cpp
 static char g_current_it_buf[256];
@@ -28,12 +32,12 @@ static std::unordered_map<std::string, MockEntry> g_mock_registry;
 extern "C" {
 
 void __ry_test_describe_begin(const char *name) {
-    g_current_describe = name;
-    std::printf("%s\n", name);
+    std::printf("%s%s\n", currentIndent().c_str(), name);
+    ++g_describe_depth;
 }
 
 void __ry_test_describe_end() {
-    g_current_describe.clear();
+    --g_describe_depth;
 }
 
 // ASan slows synchronization primitives ~3-10x; extend timeout to avoid
@@ -55,11 +59,12 @@ void __ry_test_it_begin(const char *name) {
 void __ry_test_it_end() {
     alarm(0);
     __ry_mock_clear_all();
+    const auto indent = currentIndent();
     if (g_current_it_failed) {
-        std::printf("  \033[31m- %s\033[0m\n", g_current_it.c_str());
+        std::printf("%s\033[31m- %s\033[0m\n", indent.c_str(), g_current_it.c_str());
         ++g_failed;
     } else {
-        std::printf("  \033[32m+ %s\033[0m\n", g_current_it.c_str());
+        std::printf("%s\033[32m+ %s\033[0m\n", indent.c_str(), g_current_it.c_str());
         ++g_passed;
     }
     g_current_it.clear();
@@ -67,15 +72,16 @@ void __ry_test_it_end() {
 
 void __ry_test_expect_fail(int line, const char *actual, const char *expected) {
     g_current_it_failed = true;
-    std::printf("    \033[31mline %d: expected %s, got %s\033[0m\n", line, expected, actual);
+    std::printf("%s\033[31mline %d: expected %s, got %s\033[0m\n", currentIndent(2).c_str(), line, expected, actual);
 }
 
 void __ry_test_fail(int line, const char *msg) {
     g_current_it_failed = true;
+    const auto indent = currentIndent(2);
     if (msg && msg[0] != '\0') {
-        std::printf("    \033[31mline %d: %s\033[0m\n", line, msg);
+        std::printf("%s\033[31mline %d: %s\033[0m\n", indent.c_str(), line, msg);
     } else {
-        std::printf("    \033[31mline %d: test failed\033[0m\n", line);
+        std::printf("%s\033[31mline %d: test failed\033[0m\n", indent.c_str(), line);
     }
 }
 

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -37,7 +37,7 @@ void __ry_test_describe_begin(const char *name) {
 }
 
 void __ry_test_describe_end() {
-    --g_describe_depth;
+    if (g_describe_depth > 0) --g_describe_depth;
 }
 
 // ASan slows synchronization primitives ~3-10x; extend timeout to avoid
@@ -161,6 +161,16 @@ const char *__ry_test_rand_str() {
 
 int64_t __ry_test_it_is_failed() {
     return g_current_it_failed ? 1 : 0;
+}
+
+const char *__ry_test_indent(int extra) {
+    static char buf[256];
+    int len = g_describe_depth * 2 + extra;
+    if (len < 0) len = 0;
+    if (len >= static_cast<int>(sizeof(buf))) len = static_cast<int>(sizeof(buf)) - 1;
+    std::memset(buf, ' ', static_cast<size_t>(len));
+    buf[len] = '\0';
+    return buf;
 }
 
 } // extern "C"

--- a/tests/spec/directive_test.test.ry
+++ b/tests/spec/directive_test.test.ry
@@ -45,3 +45,26 @@ function test_add_commutative(a: int, b: int):
 @it("double is always even")
 function test_double_even(n: int):
   expect(n * 2 % 2).to_eq(0)
+
+# @describe with shared setup: variables declared in describe body captured by @it (#635)
+@describe("shared setup")
+function shared_setup_tests():
+  base = 100
+  offset = 5
+
+  @it("uses base value")
+  function test_base():
+    expect(base).to_eq(100)
+
+  @it("uses both base and offset")
+  function test_combined():
+    expect(base + offset).to_eq(105)
+
+# Nested @describe indentation (#635)
+@describe("outer group")
+function outer_group():
+  @describe("inner group")
+  function inner_group():
+    @it("deeply nested test")
+    function test_deep():
+      expect(1 + 1).to_eq(2)

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -118,4 +118,15 @@ protected:
         auto warnings = cg.getWarnings();
         return {runModule(std::move(tsm)), warnings};
     }
+
+    static std::pair<std::string, std::vector<std::string>> runTestSourceWithWarnings(const std::string &src) {
+        Lexer lex(src);
+        Parser parser(lex);
+        Program prog = parser.parseProgram();
+
+        CodeGen cg(true);  // test_mode = true
+        auto tsm = cg.compile(prog);
+        auto warnings = cg.getWarnings();
+        return {runModule(std::move(tsm)), warnings};
+    }
 };

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -917,7 +917,7 @@ TEST_F(DirectiveTest, ItDirectiveBasicCodegen) {
         "@it(\"adds 1 + 2 = 3\")\n"
         "function test_add():\n"
         "    expect(1 + 2).to_eq(3)\n"
-    ), "  \033[32m+ adds 1 + 2 = 3\033[0m\n\n1 passed, 0 failed\n");
+    ), "\033[32m+ adds 1 + 2 = 3\033[0m\n\n1 passed, 0 failed\n");
 }
 
 // @it requires test mode — should error outside test mode
@@ -972,9 +972,9 @@ TEST_F(DirectiveTest, ItDirectiveWithEach) {
         "@it(\"adds {0} + {1} = {2}\")\n"
         "function test_add(a: int, b: int, expected: int):\n"
         "    expect(a + b).to_eq(expected)\n"
-    ), "  \033[32m+ adds 1 + 2 = 3\033[0m\n"
-       "  \033[32m+ adds 0 + 0 = 0\033[0m\n"
-       "  \033[32m+ adds -1 + 1 = 0\033[0m\n"
+    ), "\033[32m+ adds 1 + 2 = 3\033[0m\n"
+       "\033[32m+ adds 0 + 0 = 0\033[0m\n"
+       "\033[32m+ adds -1 + 1 = 0\033[0m\n"
        "\n3 passed, 0 failed\n");
 }
 
@@ -1044,8 +1044,8 @@ TEST_F(DirectiveTest, DescribeDirectiveNestedDescribe) {
         "            expect(2 * 3).to_eq(6)\n"
     ), "outer\n"
        "  \033[32m+ direct child\033[0m\n"
-       "inner\n"
-       "  \033[32m+ nested child\033[0m\n"
+       "  inner\n"
+       "    \033[32m+ nested child\033[0m\n"
        "\n2 passed, 0 failed\n");
 }
 
@@ -1136,6 +1136,106 @@ TEST(DirectiveSyntax, NamedArgWithCallValue) {
     EXPECT_EQ(*d.args[0].name, "data");
     auto *call = std::get_if<std::unique_ptr<CallExpr>>(&d.args[0].value->data);
     ASSERT_NE(call, nullptr);
+}
+
+// @describe with shared setup: variables declared in the describe body are captured by inner @it
+TEST_F(DirectiveTest, DescribeDirectiveSharedSetup) {
+    EXPECT_EQ(runTestSource(
+        "@describe(\"shared setup\")\n"
+        "function shared_tests():\n"
+        "    x = 10\n"
+        "    y = 20\n"
+        "    @it(\"uses x\")\n"
+        "    function test_x():\n"
+        "        expect(x).to_eq(10)\n"
+        "    @it(\"uses x and y\")\n"
+        "    function test_xy():\n"
+        "        expect(x + y).to_eq(30)\n"
+    ), "shared setup\n"
+       "  \033[32m+ uses x\033[0m\n"
+       "  \033[32m+ uses x and y\033[0m\n"
+       "\n2 passed, 0 failed\n");
+}
+
+// @describe three levels deep: indentation tracks nesting depth
+TEST_F(DirectiveTest, DescribeDirectiveThreeLevelNesting) {
+    EXPECT_EQ(runTestSource(
+        "@describe(\"level 1\")\n"
+        "function l1():\n"
+        "    @describe(\"level 2\")\n"
+        "    function l2():\n"
+        "        @describe(\"level 3\")\n"
+        "        function l3():\n"
+        "            @it(\"deep test\")\n"
+        "            function test_deep():\n"
+        "                expect(true).to_be_true()\n"
+    ), "level 1\n"
+       "  level 2\n"
+       "    level 3\n"
+       "      \033[32m+ deep test\033[0m\n"
+       "\n1 passed, 0 failed\n");
+}
+
+// @each + @it inside @describe: parameterized tests inside a group
+TEST_F(DirectiveTest, DescribeDirectiveWithEach) {
+    EXPECT_EQ(runTestSource(
+        "@describe(\"parameterized\")\n"
+        "function param_tests():\n"
+        "    @each([(1, 2, 3), (4, 5, 9)])\n"
+        "    @it(\"{0} + {1} = {2}\")\n"
+        "    function test_add(a: int, b: int, expected: int):\n"
+        "        expect(a + b).to_eq(expected)\n"
+    ), "parameterized\n"
+       "  \033[32m+ 1 + 2 = 3\033[0m\n"
+       "  \033[32m+ 4 + 5 = 9\033[0m\n"
+       "\n2 passed, 0 failed\n");
+}
+
+// @property + @it inside @describe: property tests inside a group
+TEST_F(DirectiveTest, DescribeDirectiveWithProperty) {
+    std::string out = runTestSource(
+        "@describe(\"property group\")\n"
+        "function prop_tests():\n"
+        "    @property(count=5)\n"
+        "    @it(\"int identity\")\n"
+        "    function test_id(a: int):\n"
+        "        expect(a).to_eq(a)\n"
+    );
+    EXPECT_NE(out.find("property group"), std::string::npos);
+    EXPECT_NE(out.find("+ int identity"), std::string::npos);
+    EXPECT_NE(out.find("1 passed, 0 failed"), std::string::npos);
+}
+
+// Old describe() lambda syntax emits a deprecation warning
+TEST_F(DirectiveTest, DescribeCallEmitsDeprecationWarning) {
+    auto [output, warnings] = runTestSourceWithWarnings(
+        "describe(\"old style\", ():\n"
+        "    it(\"test\", ():\n"
+        "        expect(1).to_eq(1)\n"
+        "    )\n"
+        ")\n"
+    );
+    bool found = false;
+    for (const auto &w : warnings)
+        if (w.find("describe") != std::string::npos && w.find("deprecated") != std::string::npos)
+            found = true;
+    EXPECT_TRUE(found) << "Expected deprecation warning for describe() call syntax";
+}
+
+// Old it() lambda syntax emits a deprecation warning
+TEST_F(DirectiveTest, ItCallEmitsDeprecationWarning) {
+    auto [output, warnings] = runTestSourceWithWarnings(
+        "describe(\"g\", ():\n"
+        "    it(\"old it\", ():\n"
+        "        expect(1).to_eq(1)\n"
+        "    )\n"
+        ")\n"
+    );
+    bool found = false;
+    for (const auto &w : warnings)
+        if (w.find("it") != std::string::npos && w.find("deprecated") != std::string::npos)
+            found = true;
+    EXPECT_TRUE(found) << "Expected deprecation warning for it() call syntax";
 }
 
 // Unknown directive name: parser now accepts any name (validation deferred to codegen).

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1215,11 +1215,14 @@ TEST_F(DirectiveTest, DescribeCallEmitsDeprecationWarning) {
         "    )\n"
         ")\n"
     );
-    bool found = false;
-    for (const auto &w : warnings)
-        if (w.find("describe") != std::string::npos && w.find("deprecated") != std::string::npos)
-            found = true;
-    EXPECT_TRUE(found) << "Expected deprecation warning for describe() call syntax";
+    const auto describe_warn_count = std::count_if(
+        warnings.begin(), warnings.end(),
+        [](const std::string &w) {
+            return w.find("describe(") != std::string::npos &&
+                   w.find("deprecated") != std::string::npos;
+        });
+    EXPECT_EQ(describe_warn_count, 1u)
+        << "Expected exactly one deprecation warning for describe() call syntax";
 }
 
 // Old it() lambda syntax emits a deprecation warning
@@ -1231,11 +1234,14 @@ TEST_F(DirectiveTest, ItCallEmitsDeprecationWarning) {
         "    )\n"
         ")\n"
     );
-    bool found = false;
-    for (const auto &w : warnings)
-        if (w.find("it") != std::string::npos && w.find("deprecated") != std::string::npos)
-            found = true;
-    EXPECT_TRUE(found) << "Expected deprecation warning for it() call syntax";
+    const auto it_warn_count = std::count_if(
+        warnings.begin(), warnings.end(),
+        [](const std::string &w) {
+            return w.find("it(") != std::string::npos &&
+                   w.find("deprecated") != std::string::npos;
+        });
+    EXPECT_EQ(it_warn_count, 1u)
+        << "Expected exactly one deprecation warning for it() call syntax";
 }
 
 // Unknown directive name: parser now accepts any name (validation deferred to codegen).


### PR DESCRIPTION
## Summary

- **Shared setup (closure capture)**: Variables declared in a `@describe` function body are now automatically captured by inner `@it` functions. Root cause was `ExpectStmt` not being scanned during free-variable analysis in `analyzeFreeVariables` — variables referenced inside `expect(x).to_eq(...)` were never found as free variables.
- **Nesting depth tracking**: `g_describe_depth` counter added to test runtime; describe output and it pass/fail lines are now indented proportionally to nesting depth (2 spaces per level).
- **Deprecation warnings**: `describe()` and `it()` lambda call syntax now emit a compile-time warning. Uses `warned_call_deprecations_` (unordered_set) for warn-once-per-form behavior.
- **Cleanup (via /simplify)**: Extracted `loadCapturedArgs()` helper (eliminates 4× repeated loop), `currentIndent()` helper in test_runtime, replaced two bool flags with a single set.

## Test plan

- [x] `DescribeDirectiveSharedSetup` — `@describe` body vars captured by inner `@it`
- [x] `DescribeDirectiveThreeLevelNesting` — 3-level nested `@describe` indentation
- [x] `DescribeDirectiveWithEach` — `@each @it` inside `@describe`
- [x] `DescribeDirectiveWithProperty` — `@property @it` inside `@describe`
- [x] `DescribeCallEmitsDeprecationWarning` — old `describe()` warns once
- [x] `ItCallEmitsDeprecationWarning` — old `it()` warns once
- [x] Ry spec tests in `tests/spec/directive_test.test.ry` (shared setup + nested describe)
- [x] All 1425 C++ tests pass (`./build/ry_tests`)
- [x] All 81 Ry test files pass (`./build/ry test -p`)
- [x] ASan clean (`ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests && ./build-asan/ry test -p`)

Closes #635

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Variables declared in `@describe` blocks are automatically captured for nested `@it` tests.
  * Test output now indents nested `@describe` blocks to reflect nesting depth.

* **Deprecations**
  * Lambda-based `describe()`/`it()` syntax deprecated; migrate to `@describe`/`@it` on named functions.

* **Documentation**
  * Testing docs updated with shared-setup and nested-`@describe` examples and deprecation guidance.

* **Tests**
  * Added directive tests validating capture, nesting indentation, parameterized and property cases, and deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->