### PR TITLE
chore: migrate test descriptions to should-style wording (#664)

### DIFF
--- a/changelog.d/664-should-style-test-descriptions.md
+++ b/changelog.d/664-should-style-test-descriptions.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Migrated all test descriptions (`it()` / `@it()`) to "should-style" wording for natural "it should ..." readability in test output and `--outline` mode (#664)
+- Added test description style guideline to `docs/reference/testing.md` (#664)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -212,7 +212,7 @@ Enables parameterized testing by running an `it` block multiple times with diffe
 
 ```
 @each([(arg1, arg2, ...), ...])
-it("description with {0} and {1}", (param1: type, param2: type):
+it("should handle {0} and {1}", (param1: type, param2: type):
     # test body
 )
 ```
@@ -221,7 +221,7 @@ The argument can be any expression that evaluates to a list of tuples, including
 
 ```ry
 @each(make_inputs())
-it("test with {0}", (x: int):
+it("should handle {0}", (x: int):
     # test body
 )
 ```
@@ -241,7 +241,7 @@ Enables property-based testing by generating random inputs for an `it` block.
 
 ```
 @property(count=100)
-it("property name", (a: int, b: int):
+it("should verify property name", (a: int, b: int):
     # test body with random values
 )
 ```

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -384,10 +384,10 @@ Output:
 describe mock
   it should replace function
   it should auto-restore after it block
-  it should pass with arguments
+  it should mock with arguments
 describe verify
   it should count calls
-  it should return zero calls
+  it should count zero calls
 ```
 
 - Works with individual files, directories, and `-p` (all test files)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -51,11 +51,11 @@ Group related tests using `@describe`:
 ```ry
 @describe("Arithmetic")
 function arithmetic_tests():
-    @it("adds integers")
+    @it("should add integers")
     function test_add():
         expect(1 + 2).to_eq(3)
 
-    @it("subtracts integers")
+    @it("should subtract integers")
     function test_sub():
         expect(5 - 3).to_eq(2)
 ```
@@ -75,11 +75,11 @@ function user_validation_tests():
     min_length = 8
     max_length = 64
 
-    @it("rejects short passwords")
+    @it("should reject short passwords")
     function test_short():
         expect(min_length).to_be_greater_than(0)
 
-    @it("accepts passwords within length limits")
+    @it("should accept passwords within length limits")
     function test_range():
         expect(max_length).to_be_greater_than(min_length)
 ```
@@ -93,7 +93,7 @@ function user_validation_tests():
 function api_tests():
     @describe("GET /users")
     function get_users_tests():
-        @it("returns 200 OK")
+        @it("should return 200 OK")
         function test_ok():
             expect(true).to_be_true()
 ```
@@ -103,7 +103,7 @@ Output:
 ```text
 API
   GET /users
-    + returns 200 OK
+    + should return 200 OK
 ```
 
 ### Lambda Syntax (deprecated)
@@ -189,9 +189,9 @@ it("should not reach here", ():
 
 ```
 Calculator
-  + adds numbers
-  + subtracts
-  - fails test (red)
+  + should add numbers
+  + should subtract
+  - should pass test (red)
     line 10: expected 3, got 2
 
 2 passed, 1 failed
@@ -206,21 +206,21 @@ Calculator
 
 ```
 describe("Arithmetic", ():
-    it("adds integers", ():
+    it("should add integers", ():
         expect(1 + 2).to_eq(3)
 
     )
-    it("compares strings", ():
+    it("should compare strings", ():
         expect("hello").to_eq("hello")
 
     )
-    it("checks booleans", ():
+    it("should check booleans", ():
         expect(3 > 1).to_be_true()
 
     )
 )
 describe("Booleans", ():
-    it("false check", ():
+    it("should return false", ():
         expect(1 > 2).to_be_false()
     )
 )
@@ -239,12 +239,12 @@ function fetch_data() -> str:
     return "real data"
 
 describe("mocking", ():
-    it("replaces function", ():
+    it("should replace function", ():
         mock(fetch_data, () => "fake")
         expect(fetch_data()).to_eq("fake")
 
     )
-    it("auto-restores", ():
+    it("should auto-restore after it block", ():
         expect(fetch_data()).to_eq("real data")
     )
 )
@@ -262,7 +262,7 @@ Returns the number of times a mocked function was called (as `int`).
 
 ```
 describe("verify", ():
-    it("counts calls", ():
+    it("should count calls", ():
         mock(fetch_data, () => "fake")
         fetch_data()
         fetch_data()
@@ -291,7 +291,7 @@ describe("verify", ():
     (0, 0, 0),
     (-1, 1, 0)
 ])
-@it("adds {0} + {1} = {2}")
+@it("should add {0} + {1} = {2}")
 function test_add(a: int, b: int, expected: int):
     expect(a + b).to_eq(expected)
 ```
@@ -304,7 +304,7 @@ function test_add(a: int, b: int, expected: int):
     (0, 0, 0),
     (-1, 1, 0)
 ])
-it("adds {0} + {1} = {2}", (a: int, b: int, expected: int):
+it("should add {0} + {1} = {2}", (a: int, b: int, expected: int):
     expect(a + b).to_eq(expected)
 )
 ```
@@ -324,7 +324,7 @@ it("adds {0} + {1} = {2}", (a: int, b: int, expected: int):
 
 ```
 @property(count=100)
-@it("addition is commutative")
+@it("should verify addition is commutative")
 function test_commutative(a: int, b: int):
     expect(a + b).to_eq(b + a)
 ```
@@ -333,7 +333,7 @@ function test_commutative(a: int, b: int):
 
 ```
 @property(count=100)
-it("addition is commutative", (a: int, b: int):
+it("should verify addition is commutative", (a: int, b: int):
     expect(a + b).to_eq(b + a)
 )
 ```
@@ -382,17 +382,49 @@ Output:
 
 ```
 describe mock
-  it replaces function
-  it auto-restores after it block
-  it with arguments
+  it should replace function
+  it should auto-restore after it block
+  it should pass with arguments
 describe verify
-  it counts calls
-  it zero calls
+  it should count calls
+  it should return zero calls
 ```
 
 - Works with individual files, directories, and `-p` (all test files)
 - `@each` parameterized tests show the format template with an `(@each)` suffix
 - `@property` tests show the label with a `(@property)` suffix
+
+---
+
+## Test Description Style
+
+`it` descriptions should start with `should` so they read naturally as complete sentences in test output:
+
+```
+it should add integers
+it should reject invalid input
+it should return error when file is missing
+```
+
+**Preferred:**
+
+| Description | Notes |
+|-------------|-------|
+| `"should add integers"` | verb in base form |
+| `"should reject short passwords"` | verb in base form |
+| `"should return error for missing file"` | verb in base form |
+| `"should add {0} + {1} = {2}"` | parameterized: verb in base form |
+| `"should verify addition is commutative"` | property-based |
+
+**Avoid:**
+
+| Description | Reason |
+|-------------|--------|
+| `"adds integers"` | third-person verb, reads awkwardly as "it adds" |
+| `"integer addition"` | noun phrase, not a sentence |
+| `"handles error"` | third-person verb |
+
+`describe` blocks use noun or topic phrases (e.g., `"Arithmetic"`, `"List"`, `"GET /users"`) — they do not need `should`.
 
 ---
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -191,7 +191,7 @@ it("should not reach here", ():
 Calculator
   + should add numbers
   + should subtract
-  - should pass test (red)
+  - should fail
     line 10: expected 3, got 2
 
 2 passed, 1 failed

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -400,7 +400,7 @@ describe verify
 
 `it` descriptions should start with `should` so they read naturally as complete sentences in test output:
 
-```
+```text
 it should add integers
 it should reject invalid input
 it should return error when file is missing

--- a/docs/tutorial/11-testing.md
+++ b/docs/tutorial/11-testing.md
@@ -29,15 +29,15 @@ Use `describe` to group related tests and `it` to define individual test cases.
 
 ```python
 describe("Calculator", ():
-    it("adds integers", ():
+    it("should add integers", ():
         expect(1 + 2).to_eq(3)
 
     )
-    it("subtracts integers", ():
+    it("should subtract integers", ():
         expect(5 - 3).to_eq(2)
 
     )
-    it("checks booleans", ():
+    it("should check booleans", ():
         expect(3 > 1).to_be_true()
     )
 )
@@ -95,9 +95,9 @@ it("should handle error", ():
 
 ```
 Calculator
-  + adds integers
-  + subtracts integers
-  - checks booleans
+  + should add integers
+  + should subtract integers
+  - should check booleans
     line 10: expected true, got false
 
 2 passed, 1 failed
@@ -119,12 +119,12 @@ function fetch_data() -> str:
     return "real data"
 
 describe("mocking", ():
-    it("replaces function", ():
+    it("should replace function", ():
         mock(fetch_data, () => "fake")
         expect(fetch_data()).to_eq("fake")
 
     )
-    it("auto-restores", ():
+    it("should auto-restore after it block", ():
         expect(fetch_data()).to_eq("real data")
     )
 )
@@ -136,7 +136,7 @@ Returns the number of times a mocked function was called.
 
 ```python
 describe("verify", ():
-    it("counts calls", ():
+    it("should count calls", ():
         mock(fetch_data, () => "fake")
         fetch_data()
         fetch_data()
@@ -153,7 +153,7 @@ Use `@each` to run the same test with multiple inputs:
 
 ```python
 @each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
-it("adds {0} + {1} = {2}", (a: int, b: int, expected: int):
+it("should add {0} + {1} = {2}", (a: int, b: int, expected: int):
     expect(a + b).to_eq(expected)
 )
 ```
@@ -168,7 +168,7 @@ Use `@property` to test with randomly generated inputs:
 
 ```python
 @property(count=100)
-it("addition is commutative", (a: int, b: int):
+it("should verify addition is commutative", (a: int, b: int):
     expect(a + b).to_eq(b + a)
 )
 ```
@@ -190,7 +190,7 @@ function deposit(amount: int, balance: int) -> int:
     return balance + amount
 
 describe("deposit", ():
-    it("mocked version still checks contracts", ():
+    it("should enforce contracts even when mocked", ():
         mock(deposit, (amount: int, balance: int) => balance + amount)
         expect(deposit(10, 100)).to_eq(110)
         # deposit(-1, 100) would terminate with "require failed"

--- a/tests/spec/any.test.ry
+++ b/tests/spec/any.test.ry
@@ -230,7 +230,7 @@ describe("any unwrap in function call", ():
 )
 
 describe("overload resolution: concrete preferred over any", ():
-  it("should prefer concrete when over any when", ():
+  it("should prefer concrete overload over any", ():
     function dispatch(x: int) -> str:
       return "int"
     function dispatch(x) -> str:

--- a/tests/spec/any.test.ry
+++ b/tests/spec/any.test.ry
@@ -1,58 +1,58 @@
 describe("any type", ():
-  it("wrap int", ():
+  it("should wrap int", ():
     x: any = 42
     expect(true).to_eq(true)
   )
-  it("wrap float", ():
+  it("should wrap float", ():
     x: any = 3.14
     expect(true).to_eq(true)
   )
-  it("wrap str", ():
+  it("should wrap str", ():
     x: any = "hello"
     expect(true).to_eq(true)
   )
-  it("wrap bool", ():
+  it("should wrap bool", ():
     x: any = true
     expect(true).to_eq(true)
   )
 )
 
 describe("optional param type", ():
-  it("single param without type annotation", ():
+  it("should accept single param without type annotation", ():
     function add_one(x) -> int:
       return 1
     expect(add_one(42)).to_eq(1)
   )
-  it("multiple params without type annotation", ():
+  it("should accept multiple params without type annotation", ():
     function both_any(x, y) -> bool:
       return true
     expect(both_any(1, "hello")).to_eq(true)
   )
-  it("mixed: some typed, some untyped", ():
+  it("should accept mixed typed and untyped params", ():
     function mixed(x: int, y) -> int:
       return x
     expect(mixed(10, "hello")).to_eq(10)
   )
-  it("lambda without type annotation", ():
+  it("should accept lambda without type annotation", ():
     f = (x) -> bool => true
     expect(f(42)).to_eq(true)
   )
-  it("param accepts int", ():
+  it("should accept int as param", ():
     function accept(v) -> bool:
       return true
     expect(accept(42)).to_eq(true)
   )
-  it("param accepts float", ():
+  it("should accept float as param", ():
     function accept_f(v) -> bool:
       return true
     expect(accept_f(3.14)).to_eq(true)
   )
-  it("param accepts str", ():
+  it("should accept str as param", ():
     function accept_s(v) -> bool:
       return true
     expect(accept_s("hello")).to_eq(true)
   )
-  it("param accepts bool", ():
+  it("should accept bool as param", ():
     function accept_b(v) -> bool:
       return true
     expect(accept_b(false)).to_eq(true)
@@ -60,17 +60,17 @@ describe("optional param type", ():
 )
 
 describe("any reassignment", ():
-  it("reassign int to float", ():
+  it("should reassign int to float", ():
     x: any = 42
     x = 3.14
     expect(true).to_eq(true)
   )
-  it("reassign str to int", ():
+  it("should reassign str to int", ():
     x: any = "hello"
     x = 42
     expect(true).to_eq(true)
   )
-  it("reassign bool to str", ():
+  it("should reassign bool to str", ():
     x: any = true
     x = "world"
     expect(true).to_eq(true)
@@ -78,72 +78,72 @@ describe("any reassignment", ():
 )
 
 describe("any arithmetic operators", ():
-  it("int + int", ():
+  it("should support int + int", ():
     x: any = 10
     y: any = 20
     z: any = x + y
     expect(z == 30).to_eq(true)
   )
-  it("int - int", ():
+  it("should support int - int", ():
     x: any = 30
     y: any = 10
     z: any = x - y
     expect(z == 20).to_eq(true)
   )
-  it("int * int", ():
+  it("should support int * int", ():
     x: any = 5
     y: any = 6
     z: any = x * y
     expect(z == 30).to_eq(true)
   )
-  it("int / int", ():
+  it("should support int / int", ():
     x: any = 10
     y: any = 2
     z: any = x / y
     expect(z == 5.0).to_eq(true)
   )
-  it("int % int", ():
+  it("should support int % int", ():
     x: any = 10
     y: any = 3
     z: any = x % y
     expect(z == 1).to_eq(true)
   )
-  it("int // int", ():
+  it("should support int // int", ():
     x: any = 7
     y: any = 2
     z: any = x // y
     expect(z == 3).to_eq(true)
   )
-  it("int ** int", ():
+  it("should support int ** int", ():
     x: any = 2
     y: any = 10
     z: any = x ** y
     expect(z == 1024.0).to_eq(true)
   )
-  it("float + float", ():
+  it("should support float + float", ():
     x: any = 1.5
     y: any = 2.5
     z: any = x + y
     expect(z == 4.0).to_eq(true)
   )
-  it("int + float (mixed)", ():
+  it("should support int + float (mixed)", ():
     x: any = 10
     y: any = 3.14
     z: any = x + y
     expect(z == 13.14).to_eq(true)
   )
-  it("str + str (concat)", ():
+  it("should support str + str (concat)", ():
     x: any = "hello"
     y: any = " world"
     z: any = x + y
     expect(z == "hello world").to_eq(true)
   )
-  it("concrete + any (auto-wrap lhs)", ():
+  it("should support concrete + any (auto-wrap lhs)", ():
     y: any = 20
     z: any = 10 + y
     expect(z == 30).to_eq(true)
   )
-  it("any + concrete (auto-wrap rhs)", ():
+  it("should support any + concrete (auto-wrap rhs)", ():
     x: any = 10
     z: any = x + 20
     expect(z == 30).to_eq(true)
@@ -151,77 +151,77 @@ describe("any arithmetic operators", ():
 )
 
 describe("any comparison operators", ():
-  it("int == int (true)", ():
+  it("should compare int == int (true)", ():
     x: any = 42
     y: any = 42
     expect(x == y).to_eq(true)
   )
-  it("int == int (false)", ():
+  it("should compare int == int (false)", ():
     x: any = 42
     y: any = 99
     expect(x == y).to_eq(false)
   )
-  it("int != int", ():
+  it("should support int != int", ():
     x: any = 1
     y: any = 2
     expect(x != y).to_eq(true)
   )
-  it("int < int", ():
+  it("should support int < int", ():
     x: any = 1
     y: any = 2
     expect(x < y).to_eq(true)
   )
-  it("int <= int", ():
+  it("should support int <= int", ():
     x: any = 2
     y: any = 2
     expect(x <= y).to_eq(true)
   )
-  it("int > int", ():
+  it("should support int > int", ():
     x: any = 3
     y: any = 2
     expect(x > y).to_eq(true)
   )
-  it("int >= int", ():
+  it("should support int >= int", ():
     x: any = 2
     y: any = 2
     expect(x >= y).to_eq(true)
   )
-  it("str == str", ():
+  it("should compare str == str", ():
     x: any = "hello"
     y: any = "hello"
     expect(x == y).to_eq(true)
   )
-  it("mixed int/float comparison", ():
+  it("should handle mixed int/float comparison", ():
     x: any = 3
     y: any = 3.0
     expect(x == y).to_eq(true)
   )
-  it("concrete == any (auto-wrap)", ():
+  it("should support concrete == any (auto-wrap)", ():
     y: any = 42
     expect(42 == y).to_eq(true)
   )
 )
 
 describe("any unwrap in function call", ():
-  it("pass any(int) to int param", ():
+  it("should pass any(int) to int param", ():
     function typed_int(x: int) -> int:
       return x + 1
     v: any = 42
     expect(typed_int(v)).to_eq(43)
   )
-  it("pass any(float) to float param", ():
+  it("should pass any(float) to float param", ():
     function typed_float(x: float) -> float:
       return x + 1.0
     v: any = 2.5
     expect(typed_float(v)).to_eq(3.5)
   )
-  it("pass any(str) to str param", ():
+  it("should pass any(str) to str param", ():
     function typed_str(x: str) -> str:
       return x
     v: any = "hello"
     expect(typed_str(v)).to_eq("hello")
   )
-  it("pass any(bool) to bool param", ():
+  it("should pass any(bool) to bool param", ():
     function typed_bool(x: bool) -> bool:
       return x
     v: any = true
@@ -230,7 +230,7 @@ describe("any unwrap in function call", ():
 )
 
 describe("overload resolution: concrete preferred over any", ():
-  it("concrete when wins over any when", ():
+  it("should prefer concrete when over any when", ():
     function dispatch(x: int) -> str:
       return "int"
     function dispatch(x) -> str:
@@ -240,22 +240,22 @@ describe("overload resolution: concrete preferred over any", ():
 )
 
 describe("any print", ():
-  it("print int", ():
+  it("should print int", ():
     x: any = 42
     print(x)
     expect(true).to_eq(true)
   )
-  it("print float", ():
+  it("should print float", ():
     x: any = 3.14
     print(x)
     expect(true).to_eq(true)
   )
-  it("print bool", ():
+  it("should print bool", ():
     x: any = true
     print(x)
     expect(true).to_eq(true)
   )
-  it("print str", ():
+  it("should print str", ():
     x: any = "hello"
     print(x)
     expect(true).to_eq(true)
@@ -263,27 +263,27 @@ describe("any print", ():
 )
 
 describe("any to_str / f-string", ():
-  it("int to_str", ():
+  it("should convert int to str", ():
     x: any = 42
     expect(f"{x}").to_eq("42")
   )
-  it("float to_str", ():
+  it("should convert float to str", ():
     x: any = 3.14
     expect(f"{x}").to_eq("3.14")
   )
-  it("bool to_str", ():
+  it("should convert bool to str", ():
     x: any = true
     expect(f"{x}").to_eq("true")
   )
-  it("str to_str", ():
+  it("should convert str to str", ():
     x: any = "hello"
     expect(f"{x}").to_eq("hello")
   )
-  it("f-string with any", ():
+  it("should interpolate any in f-string", ():
     x: any = 42
     expect(f"value is {x}").to_eq("value is 42")
   )
-  it("unit to_str", ():
+  it("should convert unit to str", ():
     function unit_fn() -> any:
       return
     x: any = unit_fn()
@@ -292,12 +292,12 @@ describe("any to_str / f-string", ():
 )
 
 describe("any unary negation", ():
-  it("negate int", ():
+  it("should negate int", ():
     x: any = 42
     y: any = -x
     expect(y == -42).to_eq(true)
   )
-  it("negate float", ():
+  it("should negate float", ():
     x: any = 3.14
     y: any = -x
     expect(y == -3.14).to_eq(true)
@@ -305,22 +305,22 @@ describe("any unary negation", ():
 )
 
 describe("any parameter computation", ():
-  it("int addition via any params", ():
+  it("should compute int addition via any params", ():
     function add(a, b):
       return a + b
     expect(add(1, 2)).to_eq(3)
   )
-  it("string concatenation via any params", ():
+  it("should concatenate strings via any params", ():
     function concat(a, b):
       return a + b
     expect(concat("hello", " world")).to_eq("hello world")
   )
-  it("mixed int/float multiplication", ():
+  it("should multiply mixed int/float", ():
     function mul(a, b):
       return a * b
     expect(mul(3, 2.0)).to_eq(6.0)
   )
-  it("comparison via any params", ():
+  it("should compare via any params", ():
     function greater(a, b):
       return a > b
     expect(greater(5, 3)).to_eq(true)
@@ -328,22 +328,22 @@ describe("any parameter computation", ():
 )
 
 describe("any identity / round-trip", ():
-  it("identity preserves int", ():
+  it("should preserve int through identity", ():
     function identity(x: any) -> any:
       return x
     expect(identity(42)).to_eq(42)
   )
-  it("identity preserves str", ():
+  it("should preserve str through identity", ():
     function identity_s(x: any) -> any:
       return x
     expect(identity_s("hi")).to_eq("hi")
   )
-  it("identity preserves float", ():
+  it("should preserve float through identity", ():
     function identity_f(x: any) -> any:
       return x
     expect(identity_f(3.14)).to_eq(3.14)
   )
-  it("identity preserves bool", ():
+  it("should preserve bool through identity", ():
     function identity_b(x: any) -> any:
       return x
     expect(identity_b(true)).to_eq(true)
@@ -351,12 +351,12 @@ describe("any identity / round-trip", ():
 )
 
 describe("any lambda computation", ():
-  it("lambda with implicit any param and return", ():
+  it("should support lambda with implicit any param and return", ():
     f = (x):
       return x + 1
     expect(f(10)).to_eq(11)
   )
-  it("lambda returning any from computation", ():
+  it("should return any from lambda computation", ():
     f = (a, b):
       return a * b
     expect(f(3, 4)).to_eq(12)
@@ -364,7 +364,7 @@ describe("any lambda computation", ():
 )
 
 describe("any default return type", ():
-  it("function with omitted return type returns computed value", ():
+  it("should return computed value from function with omitted return type", ():
     function double_val(x: int):
       return x * 2
     expect(double_val(5)).to_eq(10)
@@ -372,37 +372,37 @@ describe("any default return type", ():
 )
 
 describe("any to concrete conversion", ():
-  it("unwrap any(int) to int variable", ():
+  it("should unwrap any(int) to int variable", ():
     function get_int() -> any:
       return 42
     x: int = get_int()
     expect(x).to_eq(42)
   )
-  it("unwrap any(str) to str variable", ():
+  it("should unwrap any(str) to str variable", ():
     function get_str() -> any:
       return "hello"
     x: str = get_str()
     expect(x).to_eq("hello")
   )
-  it("unwrap any(float) to float variable", ():
+  it("should unwrap any(float) to float variable", ():
     function get_float() -> any:
       return 3.14
     x: float = get_float()
     expect(x).to_eq(3.14)
   )
-  it("unwrap any(bool) to bool variable", ():
+  it("should unwrap any(bool) to bool variable", ():
     function get_bool() -> any:
       return true
     x: bool = get_bool()
     expect(x).to_eq(true)
   )
-  it("int to float auto-promotion in unwrap", ():
+  it("should auto-promote int to float in unwrap", ():
     function get_int_any() -> any:
       return 42
     x: float = get_int_any()
     expect(x).to_eq(42.0)
   )
-  it("reassign concrete variable from any value", ():
+  it("should reassign concrete variable from any value", ():
     function get_any() -> any:
       return 99
     x: int = 0

--- a/tests/spec/any_fn_return.test.ry
+++ b/tests/spec/any_fn_return.test.ry
@@ -1,35 +1,35 @@
 describe("any return from function", ():
-  it("return int from any-returning function", ():
+  it("should return int from any-returning function", ():
     function get_int() -> any:
       return 42
     x: any = get_int()
     expect(true).to_eq(true)
   )
-  it("return float from any-returning function", ():
+  it("should return float from any-returning function", ():
     function get_float() -> any:
       return 3.14
     x: any = get_float()
     expect(true).to_eq(true)
   )
-  it("return str from any-returning function", ():
+  it("should return str from any-returning function", ():
     function get_str() -> any:
       return "hello"
     x: any = get_str()
     expect(true).to_eq(true)
   )
-  it("return bool from any-returning function", ():
+  it("should return bool from any-returning function", ():
     function get_bool() -> any:
       return true
     x: any = get_bool()
     expect(true).to_eq(true)
   )
-  it("return without value from any-returning function", ():
+  it("should return without value from any-returning function", ():
     function no_val() -> any:
       return
     x: any = no_val()
     expect(true).to_eq(true)
   )
-  it("implicit return from any-returning function", ():
+  it("should support implicit return from any-returning function", ():
     function implicit_any() -> any:
       y = 1
     x: any = implicit_any()
@@ -38,18 +38,18 @@ describe("any return from function", ():
 )
 
 describe("any return from lambda", ():
-  it("lambda expr body returns any", ():
+  it("should return any from lambda expr body", ():
     f = () -> any => 42
     x: any = f()
     expect(true).to_eq(true)
   )
-  it("lambda block body returns any", ():
+  it("should return any from lambda block body", ():
     f = () -> any:
       return "hello"
     x: any = f()
     expect(true).to_eq(true)
   )
-  it("lambda implicit return is unit any", ():
+  it("should return unit any from lambda implicit return", ():
     f = () -> any:
       y = 1
     x: any = f()
@@ -58,12 +58,12 @@ describe("any return from lambda", ():
 )
 
 describe("omitted return type function (inferred)", ():
-  it("function with omitted return type infers int", ():
+  it("should infer int for function with omitted return type", ():
     function get_val():
       return 42
     expect(get_val()).to_eq(42)
   )
-  it("function with omitted return type infers Unit", ():
+  it("should infer Unit for function with omitted return type", ():
     function do_nothing():
       y = 1
     do_nothing()

--- a/tests/spec/arc_resource_alias_free.test.ry
+++ b/tests/spec/arc_resource_alias_free.test.ry
@@ -1,7 +1,7 @@
 from thread import lock_new, lock_acquire, lock_release, lock_free, rwlock_new, rwlock_read_lock, rwlock_unlock, rwlock_free, atomic_int_new, atomic_int_load, atomic_int_free
 
 describe("ARC resource alias — explicit free should decrement refcount (#427)", ():
-  it("lock alias: free original, alias still usable", ():
+  it("should keep alias usable after freeing original lock", ():
     a = lock_new()
     b = a
     lock_free(a)
@@ -10,7 +10,7 @@ describe("ARC resource alias — explicit free should decrement refcount (#427)"
     lock_release(b)
   )
 
-  it("lock alias: free alias, original still usable", ():
+  it("should keep original usable after freeing lock alias", ():
     a = lock_new()
     b = a
     lock_free(b)
@@ -19,7 +19,7 @@ describe("ARC resource alias — explicit free should decrement refcount (#427)"
     lock_release(a)
   )
 
-  it("rwlock alias: free original, alias still usable", ():
+  it("should keep rwlock alias usable after freeing original", ():
     a = rwlock_new()
     b = a
     rwlock_free(a)
@@ -28,14 +28,14 @@ describe("ARC resource alias — explicit free should decrement refcount (#427)"
     expect(true).to_be_true()
   )
 
-  it("atomic_int alias: free original, alias still usable", ():
+  it("should keep atomic_int alias usable after freeing original", ():
     a = atomic_int_new(42)
     b = a
     atomic_int_free(a)
     expect(atomic_int_load(b)).to_eq(42)
   )
 
-  it("lock multiple aliases: free first two, third still usable", ():
+  it("should keep third lock alias usable after freeing first two", ():
     a = lock_new()
     b = a
     c = a
@@ -46,7 +46,7 @@ describe("ARC resource alias — explicit free should decrement refcount (#427)"
     lock_release(c)
   )
 
-  it("lock: double free same variable is safe (no-op after null)", ():
+  it("should handle double free of same lock as safe no-op", ():
     a = lock_new()
     lock_free(a)
     lock_free(a)

--- a/tests/spec/array.test.ry
+++ b/tests/spec/array.test.ry
@@ -1,30 +1,30 @@
 describe("fixed-length array", ():
-  it("declaration and index read", ():
+  it("should support declaration and index read", ():
     buf: i32[4] = [1, 2, 3, 4]
     expect(buf[0] as int).to_eq(1)
     expect(buf[1] as int).to_eq(2)
     expect(buf[3] as int).to_eq(4)
   )
-  it("index write", ():
+  it("should support index write", ():
     buf: i32[3] = [0, 0, 0]
     buf[1] = 42
     expect(buf[1] as int).to_eq(42)
   )
-  it("length", ():
+  it("should return length", ():
     buf: u8[8] = [1, 2, 3, 4, 5, 6, 7, 8]
     expect(length(buf)).to_eq(8)
   )
-  it("u8 array", ():
+  it("should support u8 array", ():
     buf: u8[3] = [65, 66, 67]
     expect(buf[0] as int).to_eq(65)
     expect(buf[2] as int).to_eq(67)
   )
-  it("f32 array", ():
+  it("should support f32 array", ():
     buf: f32[2] = [1.5, 2.5]
     expect(buf[0] as float).to_eq(1.5)
     expect(buf[1] as float).to_eq(2.5)
   )
-  it("i16 array", ():
+  it("should support i16 array", ():
     buf: i16[2] = [100, 200]
     expect(buf[0] as int).to_eq(100)
     expect(buf[1] as int).to_eq(200)

--- a/tests/spec/base64.test.ry
+++ b/tests/spec/base64.test.ry
@@ -2,46 +2,46 @@ from base64 import encode, decode, encode_url_safe, decode_url_safe
 
 describe("base64", ():
   describe("encode", ():
-    it("basic string", ():
+    it("should encode basic string", ():
       expect(encode("Hello, World!")).to_eq("SGVsbG8sIFdvcmxkIQ==")
     )
-    it("empty string", ():
+    it("should encode empty string", ():
       expect(encode("")).to_eq("")
     )
-    it("single character", ():
+    it("should encode single character", ():
       expect(encode("A")).to_eq("QQ==")
     )
-    it("two characters", ():
+    it("should encode two characters", ():
       expect(encode("AB")).to_eq("QUI=")
     )
-    it("three characters", ():
+    it("should encode three characters", ():
       expect(encode("ABC")).to_eq("QUJD")
     )
   )
 
   describe("decode", ():
-    it("basic string", ():
+    it("should decode basic string", ():
       match decode("SGVsbG8sIFdvcmxkIQ=="):
         case Ok(s):
           expect(s).to_eq("Hello, World!")
         case Err(e):
           fail("unexpected error: " + e.message)
     )
-    it("empty string", ():
+    it("should decode empty string", ():
       match decode(""):
         case Ok(s):
           expect(s).to_eq("")
         case Err(e):
           fail("unexpected error: " + e.message)
     )
-    it("no padding", ():
+    it("should decode with no padding", ():
       match decode("QUJD"):
         case Ok(s):
           expect(s).to_eq("ABC")
         case Err(e):
           fail("unexpected error: " + e.message)
     )
-    it("invalid base64", ():
+    it("should return error for invalid base64", ():
       match decode("!!!invalid!!!"):
         case Ok(s):
           fail("expected error but got Ok")
@@ -51,10 +51,10 @@ describe("base64", ():
   )
 
   describe("encode_url_safe", ():
-    it("basic string", ():
+    it("should encode basic string", ():
       expect(encode_url_safe("Hello, World!")).to_eq("SGVsbG8sIFdvcmxkIQ")
     )
-    it("uses - and _ instead of + and /", ():
+    it("should use - and _ instead of + and /", ():
       # "?>>" encodes to "Pz4+" in standard, "Pz4-" in URL-safe
       std_encoded = encode("?>>")
       url_encoded = encode_url_safe("?>>")
@@ -65,7 +65,7 @@ describe("base64", ():
   )
 
   describe("decode_url_safe", ():
-    it("roundtrip", ():
+    it("should roundtrip encode/decode url safe", ():
       original = "Hello, World! subjects?_d>>"
       encoded = encode_url_safe(original)
       match decode_url_safe(encoded):
@@ -74,7 +74,7 @@ describe("base64", ():
         case Err(e):
           fail("unexpected error: " + e.message)
     )
-    it("invalid input", ():
+    it("should return error for invalid input", ():
       match decode_url_safe("!!!"):
         case Ok(s):
           fail("expected error but got Ok")
@@ -84,7 +84,7 @@ describe("base64", ():
   )
 
   describe("roundtrip", ():
-    it("standard base64", ():
+    it("should roundtrip standard base64", ():
       original = "The quick brown fox jumps over the lazy dog"
       match decode(encode(original)):
         case Ok(s):
@@ -92,7 +92,7 @@ describe("base64", ():
         case Err(e):
           fail("unexpected error: " + e.message)
     )
-    it("longer string", ():
+    it("should roundtrip longer string", ():
       original = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
       match decode(encode(original)):
         case Ok(s):

--- a/tests/spec/bounds_check.test.ry
+++ b/tests/spec/bounds_check.test.ry
@@ -1,37 +1,37 @@
 describe("bounds checking", ():
   describe("single element list", ():
-    it("access index 0", ():
+    it("should access index 0", ():
       xs = [42]
       expect(xs[0]).to_eq(42)
     )
-    it("negative index on single element", ():
+    it("should support negative index on single element", ():
       xs = [42]
       expect(xs[-1]).to_eq(42)
     )
   )
 
   describe("list negative index", ():
-    it("wraps -1 to last element", ():
+    it("should wrap -1 to last element", ():
       xs = [10, 20, 30]
       expect(xs[-1]).to_eq(30)
     )
-    it("wraps -2 to second-to-last", ():
+    it("should wrap -2 to second-to-last", ():
       xs = [10, 20, 30]
       expect(xs[-2]).to_eq(20)
     )
-    it("wraps -N to first element", ():
+    it("should wrap -N to first element", ():
       xs = [10, 20, 30]
       expect(xs[-3]).to_eq(10)
     )
   )
 
   describe("list negative index assignment", ():
-    it("assigns via negative index", ():
+    it("should assign via negative index", ():
       xs = [1, 2, 3]
       xs[-1] = 99
       expect(xs[2]).to_eq(99)
     )
-    it("assigns via -2", ():
+    it("should assign via -2", ():
       xs = [1, 2, 3]
       xs[-2] = 42
       expect(xs[1]).to_eq(42)
@@ -39,54 +39,54 @@ describe("bounds checking", ():
   )
 
   describe("char_at bounds", ():
-    it("normal index", ():
+    it("should support normal index for char_at", ():
       expect(char_at("hello", 0)).to_eq("h")
       expect(char_at("hello", 4)).to_eq("o")
     )
-    it("negative index wraps", ():
+    it("should wrap negative index for char_at", ():
       expect(char_at("hello", -1)).to_eq("o")
       expect(char_at("hello", -5)).to_eq("h")
     )
-    it("UTF-8 negative index", ():
+    it("should wrap UTF-8 negative index for char_at", ():
       expect(char_at("あいう", -1)).to_eq("う")
       expect(char_at("あいう", 0)).to_eq("あ")
     )
   )
 
   describe("substring clamping", ():
-    it("clamps negative start to 0", ():
+    it("should clamp negative start to 0", ():
       expect(substring("hello", -1, 3)).to_eq("hel")
     )
-    it("clamps end beyond length", ():
+    it("should clamp end beyond length", ():
       expect(substring("hello", 0, 100)).to_eq("hello")
     )
-    it("returns empty when end < start after clamping", ():
+    it("should return empty when end < start after clamping", ():
       expect(substring("hello", 3, 1)).to_eq("")
     )
-    it("normal substring", ():
+    it("should return normal substring", ():
       expect(substring("hello", 1, 4)).to_eq("ell")
     )
   )
 
   describe("array negative index", ():
-    it("wraps -1 to last element", ():
+    it("should wrap -1 to last element", ():
       buf: i32[3] = [10, 20, 30]
       expect(buf[-1] as int).to_eq(30)
     )
-    it("wraps -3 to first element", ():
+    it("should wrap -3 to first element", ():
       buf: i32[3] = [10, 20, 30]
       expect(buf[-3] as int).to_eq(10)
     )
   )
 
   describe("insert negative index", ():
-    it("insert at -1 appends (wraps to len)", ():
+    it("should insert at -1 by appending (wraps to len)", ():
       xs = [1, 2, 3]
       insert(xs, -1, 99)
       expect(xs).to_have_length(4)
       expect(xs[3]).to_eq(99)
     )
-    it("insert at -(len+1) inserts at front", ():
+    it("should insert at -(len+1) at front", ():
       xs = [1, 2, 3]
       insert(xs, -4, 99)
       expect(xs[0]).to_eq(99)
@@ -95,13 +95,13 @@ describe("bounds checking", ():
   )
 
   describe("remove_at negative index", ():
-    it("remove_at -1 removes last element", ():
+    it("should remove last element with remove_at -1", ():
       xs = [1, 2, 3]
       v = remove_at(xs, -1)
       expect(v).to_eq(3)
       expect(xs).to_have_length(2)
     )
-    it("remove_at -2 removes second-to-last", ():
+    it("should remove second-to-last element with remove_at -2", ():
       xs = [10, 20, 30]
       v = remove_at(xs, -2)
       expect(v).to_eq(20)

--- a/tests/spec/builtins.test.ry
+++ b/tests/spec/builtins.test.ry
@@ -1,38 +1,38 @@
 describe("length", ():
-  it("List", ():
+  it("should return length of List", ():
     expect([1, 2, 3]).to_have_length(3)
   )
-  it("Map", ():
+  it("should return length of Map", ():
     expect({"a": 1, "b": 2}).to_have_length(2)
   )
-  it("Set", ():
+  it("should return length of Set", ():
     expect({1, 2, 3}).to_have_length(3)
   )
-  it("str", ():
+  it("should return length of str", ():
     expect("hello").to_have_length(5)
   )
 )
 
 describe("range", ():
-  it("1 arg", ():
+  it("should work with 1 arg", ():
     xs = range(3)
     expect(xs).to_have_length(3)
     expect(xs[0]).to_eq(0)
     expect(xs[2]).to_eq(2)
   )
-  it("2 args", ():
+  it("should work with 2 args", ():
     xs = range(2, 5)
     expect(xs).to_have_length(3)
     expect(xs[0]).to_eq(2)
     expect(xs[2]).to_eq(4)
   )
-  it("3 args", ():
+  it("should work with 3 args", ():
     xs = range(0, 10, 2)
     expect(xs).to_have_length(5)
     expect(xs[0]).to_eq(0)
     expect(xs[4]).to_eq(8)
   )
-  it("negative step", ():
+  it("should work with negative step", ():
     xs = range(10, 0, -3)
     expect(xs).to_have_length(4)
     expect(xs[0]).to_eq(10)
@@ -43,15 +43,15 @@ describe("range", ():
 )
 
 describe("Some / Option", ():
-  it("Some wraps value", ():
+  it("should wrap value with Some", ():
     x = Some(42)
     expect(x).to_be_some()
   )
-  it("None is none", ():
+  it("should recognize None as none", ():
     x: Option<int> = None
     expect(x).to_be_none()
   )
-  it("Option<List<int>> preserves collection metadata", ():
+  it("should preserve collection metadata for Option<List<int>>", ():
     x: Option<List<int>> = Some([1, 2, 3])
     match x:
       case Some(v):
@@ -60,7 +60,7 @@ describe("Some / Option", ():
       case None:
         fail("expected Some")
   )
-  it("Option<Map<str, int>> preserves collection metadata", ():
+  it("should preserve collection metadata for Option<Map<str, int>>", ():
     x: Option<Map<str, int>> = Some({"a": 1, "b": 2})
     match x:
       case Some(v):
@@ -69,7 +69,7 @@ describe("Some / Option", ():
       case None:
         fail("expected Some")
   )
-  it("Option<Set<int>> preserves collection metadata", ():
+  it("should preserve collection metadata for Option<Set<int>>", ():
     x: Option<Set<int>> = Some({1, 2, 3})
     match x:
       case Some(v):

--- a/tests/spec/checked_arith.test.ry
+++ b/tests/spec/checked_arith.test.ry
@@ -1,5 +1,5 @@
 describe("checked arithmetic", ():
-  it("checked_add ok", ():
+  it("should return ok for checked_add", ():
     r = checked_add(10i32, 20i32)
     match r:
       case Ok(v):
@@ -7,7 +7,7 @@ describe("checked arithmetic", ():
       case Err(e):
         expect(true).to_eq(false)
   )
-  it("checked_add overflow", ():
+  it("should return error for checked_add overflow", ():
     r = checked_add(2147483647i32, 1i32)
     match r:
       case Ok(v):
@@ -15,7 +15,7 @@ describe("checked arithmetic", ():
       case Err(e):
         expect(true).to_eq(true)
   )
-  it("checked_sub ok", ():
+  it("should return ok for checked_sub", ():
     r = checked_sub(100i32, 50i32)
     match r:
       case Ok(v):
@@ -23,7 +23,7 @@ describe("checked arithmetic", ():
       case Err(e):
         expect(true).to_eq(false)
   )
-  it("checked_mul ok", ():
+  it("should return ok for checked_mul", ():
     r = checked_mul(6i32, 7i32)
     match r:
       case Ok(v):
@@ -31,27 +31,27 @@ describe("checked arithmetic", ():
       case Err(e):
         expect(true).to_eq(false)
   )
-  it("saturating_add clamps to max", ():
+  it("should clamp saturating_add to max", ():
     v = saturating_add(2147483647i32, 100i32)
     expect(v as int).to_eq(2147483647)
   )
-  it("saturating_sub clamps to min", ():
+  it("should clamp saturating_sub to min", ():
     v = saturating_sub(-2147483648i32, 1i32)
     expect(v as int).to_eq(-2147483648)
   )
-  it("saturating_mul clamps to max", ():
+  it("should clamp saturating_mul to max", ():
     v = saturating_mul(100000i32, 100000i32)
     expect(v as int).to_eq(2147483647)
   )
-  it("wrapping_add wraps", ():
+  it("should wrap on wrapping_add overflow", ():
     v = wrapping_add(2147483647i32, 1i32)
     expect(v as int).to_eq(-2147483648)
   )
-  it("wrapping_sub unsigned wraps", ():
+  it("should wrap unsigned on wrapping_sub underflow", ():
     v = wrapping_sub(0u8, 1u8)
     expect(v as int).to_eq(255)
   )
-  it("checked_sub overflow", ():
+  it("should return error for checked_sub overflow", ():
     r = checked_sub(-2147483648i32, 1i32)
     match r:
       case Ok(v):
@@ -59,7 +59,7 @@ describe("checked arithmetic", ():
       case Err(e):
         expect(true).to_eq(true)
   )
-  it("checked_mul overflow", ():
+  it("should return error for checked_mul overflow", ():
     r = checked_mul(100000i32, 100000i32)
     match r:
       case Ok(v):
@@ -67,7 +67,7 @@ describe("checked arithmetic", ():
       case Err(e):
         expect(true).to_eq(true)
   )
-  it("checked_add zero boundary", ():
+  it("should handle checked_add zero boundary", ():
     r = checked_add(0i32, 0i32)
     match r:
       case Ok(v):

--- a/tests/spec/closure_arc.test.ry
+++ b/tests/spec/closure_arc.test.ry
@@ -1,11 +1,11 @@
 describe("closure ARC — basic lifecycle", ():
-  it("closure with captured int", ():
+  it("should support closure with captured int", ():
     base = 10
     add_base = (x: int) => x + base
     expect(add_base(5)).to_eq(15)
   )
 
-  it("closure copy (g = f)", ():
+  it("should support closure copy (g = f)", ():
     base = 100
     f = (x: int) => x + base
     g = f
@@ -13,19 +13,19 @@ describe("closure ARC — basic lifecycle", ():
     expect(g(2)).to_eq(102)
   )
 
-  it("no-capture lambda", ():
+  it("should support no-capture lambda", ():
     f = (x: int) => x * 2
     expect(f(5)).to_eq(10)
   )
 
-  it("multiple captures", ():
+  it("should support multiple captures", ():
     a = 10
     b = 20
     f = (x: int) => x + a + b
     expect(f(5)).to_eq(35)
   )
 
-  it("capture string", ():
+  it("should capture string", ():
     prefix = "hello "
     greet = (name: str) => prefix + name
     expect(greet("world")).to_eq("hello world")
@@ -33,14 +33,14 @@ describe("closure ARC — basic lifecycle", ():
 )
 
 describe("closure ARC — escaping closures", ():
-  it("closure escapes defining scope via higher-order", ():
+  it("should escape defining scope via higher-order function", ():
     xs = [10, 20, 30]
     f = (x: int) => x > 15
     ys = filter(xs, f)
     expect(ys).to_have_length(2)
   )
 
-  it("closure captures dynamic string", ():
+  it("should capture dynamic string", ():
     name = "Alice"
     greeting = "Hello, " + name
     f = (suffix: str) => greeting + suffix
@@ -49,21 +49,21 @@ describe("closure ARC — escaping closures", ():
 )
 
 describe("closure ARC — higher-order patterns", ():
-  it("filter with closure", ():
+  it("should filter with closure", ():
     threshold = 3
     xs = [1, 2, 3, 4, 5]
     ys = filter(xs, (x: int) => x > threshold)
     expect(ys).to_have_length(2)
   )
 
-  it("map with closure", ():
+  it("should map with closure", ():
     factor = 10
     xs = [1, 2, 3]
     ys = map(xs, (x: int) => x * factor)
     expect(ys).to_eq([10, 20, 30])
   )
 
-  it("closure as named variable to higher-order", ():
+  it("should pass closure as named variable to higher-order function", ():
     base = 7
     f = (x: int) => x * base
     xs = [1, 2, 3]
@@ -71,7 +71,7 @@ describe("closure ARC — higher-order patterns", ():
     expect(ys).to_eq([7, 14, 21])
   )
 
-  it("reduce with closure", ():
+  it("should reduce with closure", ():
     init = 100
     xs = [1, 2, 3]
     result = reduce(xs, (acc: int, x: int) => acc + x + init)

--- a/tests/spec/closure_capture_arc.test.ry
+++ b/tests/spec/closure_capture_arc.test.ry
@@ -1,19 +1,19 @@
 describe("closure capturing ARC values — destructor should release captures (#429)", ():
-  it("closure captures string, alias is valid", ():
+  it("should capture string and keep alias valid", ():
     prefix = "hello"
     f = (x: str) => prefix + " " + x
     g = f
     expect(g("world")).to_eq("hello world")
   )
 
-  it("closure captures multiple strings", ():
+  it("should capture multiple strings", ():
     a = "foo"
     b = "bar"
     f = () => a + " " + b
     expect(f()).to_eq("foo bar")
   )
 
-  it("multiple closures capture same string", ():
+  it("should allow multiple closures to capture same string", ():
     greeting = "hi"
     f = (x: str) => greeting + " " + x
     g = (x: str) => greeting + "! " + x
@@ -21,7 +21,7 @@ describe("closure capturing ARC values — destructor should release captures (#
     expect(g("b")).to_eq("hi! b")
   )
 
-  it("closure copy retains captures", ():
+  it("should retain captures after closure copy", ():
     prefix = "test"
     f = (x: str) => prefix + x
     g = f

--- a/tests/spec/closure_fn_param.test.ry
+++ b/tests/spec/closure_fn_param.test.ry
@@ -2,13 +2,13 @@ describe("closure fn param", ():
   function apply(f: function(int) -> int, x: int) -> int:
     return f(x)
 
-  it("capturing lambda passed to function param", ():
+  it("should pass capturing lambda to function param", ():
     factor = 7
     mul = (x: int) => x * factor
     expect(apply(mul, 6)).to_eq(42)
   )
 
-  it("nested named function with capture passed to function param", ():
+  it("should pass nested named function with capture to function param", ():
     function outer(factor: int) -> int:
       function mul(x: int) -> int:
         return x * factor
@@ -17,18 +17,18 @@ describe("closure fn param", ():
     expect(outer(7)).to_eq(42)
   )
 
-  it("non-capturing lambda passed to function param", ():
+  it("should pass non-capturing lambda to function param", ():
     expect(apply((x: int) => x * 2, 5)).to_eq(10)
   )
 
-  it("top-level function passed to function param", ():
+  it("should pass top-level function to function param", ():
     function double(x: int) -> int:
       return x * 2
 
     expect(apply(double, 5)).to_eq(10)
   )
 
-  it("multi-hop: closure passed through two function boundaries", ():
+  it("should pass closure through two function boundaries", ():
     function apply2(f: function(int) -> int, x: int) -> int:
       return apply(f, x)
 
@@ -37,7 +37,7 @@ describe("closure fn param", ():
     expect(apply2(mul, 6)).to_eq(42)
   )
 
-  it("ARC: string capture survives through function param", ():
+  it("should survive string capture through function param (ARC)", ():
     function apply_str(f: function(str) -> str, x: str) -> str:
       return f(x)
 

--- a/tests/spec/closure_higher_order.test.ry
+++ b/tests/spec/closure_higher_order.test.ry
@@ -1,5 +1,5 @@
 describe("closure — returned from function", ():
-  it("make_adder returns callable closure", ():
+  it("should return callable closure from make_adder", ():
     function make_adder(base: int) -> function(int) -> int:
       return (x: int) => x + base
 
@@ -7,7 +7,7 @@ describe("closure — returned from function", ():
     expect(add5(3)).to_eq(8)
   )
 
-  it("returned closure with multiple captures", ():
+  it("should support returned closure with multiple captures", ():
     function make_linear(a: int, b: int) -> function(int) -> int:
       return (x: int) => a * x + b
 
@@ -15,7 +15,7 @@ describe("closure — returned from function", ():
     expect(f(5)).to_eq(25)
   )
 
-  it("returned no-capture lambda", ():
+  it("should support returned no-capture lambda", ():
     function make_doubler() -> function(int) -> int:
       return (x: int) => x * 2
 
@@ -25,7 +25,7 @@ describe("closure — returned from function", ():
 )
 
 describe("closure — function-type parameter capture", ():
-  it("compose captures two function params", ():
+  it("should compose two captured function params", ():
     function compose(f: function(int) -> int, g: function(int) -> int) -> function(int) -> int:
       return (x: int) => f(g(x))
 
@@ -35,7 +35,7 @@ describe("closure — function-type parameter capture", ():
     expect(double_then_inc(5)).to_eq(11)
   )
 
-  it("apply_twice captures function param", ():
+  it("should capture function param in apply_twice", ():
     function apply_twice(f: function(int) -> int, x: int) -> int:
       g = (v: int) => f(f(v))
       return g(x)

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -1,241 +1,241 @@
 describe("List", ():
-  it("indexing", ():
+  it("should support indexing", ():
     xs = [1, 2, 3]
     expect(xs[0]).to_eq(1)
     expect(xs[2]).to_eq(3)
   )
-  it("index assignment", ():
+  it("should support index assignment", ():
     xs = [1, 2, 3]
     xs[0] = 99
     expect(xs[0]).to_eq(99)
   )
-  it("length", ():
+  it("should return length", ():
     expect([1, 2, 3]).to_have_length(3)
   )
-  it("append", ():
+  it("should append", ():
     xs = [1, 2]
     append(xs, 3)
     expect(xs).to_have_length(3)
     expect(xs[2]).to_eq(3)
   )
-  it("pop", ():
+  it("should pop", ():
     xs = [1, 2, 3]
     v = pop(xs)
     expect(v).to_eq(Some(3))
     expect(xs).to_have_length(2)
   )
-  it("pop empty", ():
+  it("should return none when popping empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     v = pop(ys)
     expect(v).to_be_none()
   )
-  it("reverse", ():
+  it("should reverse", ():
     xs = [1, 2, 3]
     ys = reverse(xs)
     expect(ys[0]).to_eq(3)
     expect(ys[2]).to_eq(1)
     expect(xs[0]).to_eq(1)
   )
-  it("slice", ():
+  it("should slice", ():
     xs = [1, 2, 3, 4, 5]
     ys = slice(xs, 1, 3)
     expect(ys).to_have_length(2)
     expect(ys[0]).to_eq(2)
     expect(ys[1]).to_eq(3)
   )
-  it("filter", ():
+  it("should filter", ():
     xs = [1, 2, 3, 4, 5]
     ys = filter(xs, (x: int) => x > 3)
     expect(ys).to_have_length(2)
     expect(ys[0]).to_eq(4)
   )
-  it("map", ():
+  it("should map", ():
     xs = [1, 2, 3]
     ys = map(xs, (x: int) => x * 2)
     expect(ys[0]).to_eq(2)
     expect(ys[1]).to_eq(4)
     expect(ys[2]).to_eq(6)
   )
-  it("sort default", ():
+  it("should sort with default comparator", ():
     xs = [3, 1, 2]
     ys = sort(xs)
     expect(ys[0]).to_eq(1)
     expect(ys[1]).to_eq(2)
     expect(ys[2]).to_eq(3)
   )
-  it("sort custom comparator", ():
+  it("should sort with custom comparator", ():
     xs = [3, 1, 2]
     ys = sort(xs, (a: int, b: int) => a > b)
     expect(ys[0]).to_eq(3)
     expect(ys[1]).to_eq(2)
     expect(ys[2]).to_eq(1)
   )
-  it("reduce", ():
+  it("should reduce", ():
     xs = [1, 2, 3, 4, 5]
     total = reduce(xs, (a: int, b: int) => a + b)
     expect(total).to_eq(15)
   )
-  it("fold", ():
+  it("should fold", ():
     xs = [1, 2, 3, 4, 5]
     total = fold(xs, 0, (a: int, b: int) => a + b)
     expect(total).to_eq(15)
   )
-  it("any", ():
+  it("should support any predicate", ():
     xs = [1, 2, 3, 4, 5]
     expect(any(xs, (x: int) => x > 4)).to_be_true()
     expect(any(xs, (x: int) => x > 9)).to_be_false()
   )
-  it("all", ():
+  it("should support all predicate", ():
     xs = [2, 4, 6]
     expect(all(xs, (x: int) => x > 0)).to_be_true()
     expect(all(xs, (x: int) => x > 3)).to_be_false()
   )
-  it("sum", ():
+  it("should sum", ():
     expect(sum([1, 2, 3, 4, 5])).to_eq(15)
   )
-  it("min", ():
+  it("should find min", ():
     expect(min([3, 1, 4, 1, 5])).to_eq(1)
   )
-  it("max", ():
+  it("should find max", ():
     expect(max([3, 1, 4, 1, 5])).to_eq(5)
   )
-  it("first", ():
+  it("should return first element", ():
     expect(first([10, 20, 30])).to_eq(Some(10))
   )
-  it("first empty", ():
+  it("should return none for first of empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     expect(first(ys)).to_be_none()
   )
-  it("last", ():
+  it("should return last element", ():
     expect(last([10, 20, 30])).to_eq(Some(30))
   )
-  it("last empty", ():
+  it("should return none for last of empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     expect(last(ys)).to_be_none()
   )
-  it("is_empty", ():
+  it("should report is_empty correctly", ():
     expect(is_empty([1, 2])).to_be_false()
   )
-  it("enumerate", ():
+  it("should enumerate", ():
     xs = [10, 20, 30]
     pairs = enumerate(xs)
     expect(pairs[0].0).to_eq(0)
     expect(pairs[0].1).to_eq(10)
   )
-  it("enumerate empty", ():
+  it("should enumerate empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     pairs = enumerate(ys)
     expect(pairs).to_have_length(0)
   )
-  it("zip", ():
+  it("should zip", ():
     pairs = zip([1, 2], [10, 20])
     expect(pairs[0].0).to_eq(1)
     expect(pairs[0].1).to_eq(10)
   )
-  it("zip unequal lengths truncates to shorter", ():
+  it("should truncate zip to shorter list when lengths differ", ():
     pairs = zip([1, 2, 3], [10, 20])
     expect(pairs).to_have_length(2)
     expect(pairs[0].0).to_eq(1)
     expect(pairs[1].1).to_eq(20)
   )
-  it("zip empty with non-empty", ():
+  it("should return empty when zipping empty with non-empty", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     pairs = zip(ys, [10, 20])
     expect(pairs).to_have_length(0)
   )
-  it("insert", ():
+  it("should insert", ():
     xs = [1, 2, 3]
     insert(xs, 1, 99)
     expect(xs[1]).to_eq(99)
     expect(xs).to_have_length(4)
   )
-  it("remove_at", ():
+  it("should remove_at", ():
     xs = [1, 2, 3, 4]
     v = remove_at(xs, 1)
     expect(v).to_eq(2)
     expect(xs).to_have_length(3)
   )
-  it("remove", ():
+  it("should remove", ():
     xs = [1, 2, 3, 2, 4]
     remove(xs, 2)
     expect(xs[0]).to_eq(1)
     expect(xs[1]).to_eq(3)
   )
-  it("distinct", ():
+  it("should distinct", ():
     xs = [1, 2, 3, 2, 1, 4]
     ys = distinct(xs)
     expect(ys).to_have_length(4)
     expect(ys[0]).to_eq(1)
     expect(ys[3]).to_eq(4)
   )
-  it("flatten", ():
+  it("should flatten", ():
     xs = [[1, 2], [3, 4]]
     ys = flatten(xs)
     expect(ys).to_have_length(4)
     expect(ys[0]).to_eq(1)
     expect(ys[3]).to_eq(4)
   )
-  it("sort!", ():
+  it("should sort! in place", ():
     xs = [3, 1, 2]
     sort!(xs)
     expect(xs[0]).to_eq(1)
     expect(xs[1]).to_eq(2)
     expect(xs[2]).to_eq(3)
   )
-  it("reverse!", ():
+  it("should reverse! in place", ():
     xs = [1, 2, 3]
     reverse!(xs)
     expect(xs[0]).to_eq(3)
     expect(xs[1]).to_eq(2)
     expect(xs[2]).to_eq(1)
   )
-  it("appended", ():
+  it("should return appended list", ():
     xs = [1, 2]
     ys = appended(xs, 3)
     expect(xs).to_have_length(2)
     expect(ys).to_have_length(3)
     expect(ys[2]).to_eq(3)
   )
-  it("append!", ():
+  it("should append! in place", ():
     xs = [1, 2]
     append!(xs, 3)
     expect(xs).to_have_length(3)
     expect(xs[2]).to_eq(3)
   )
-  it("take", ():
+  it("should take", ():
     xs = [1, 2, 3, 4, 5]
     ys = take(xs, 3)
     expect(ys).to_have_length(3)
     expect(ys[0]).to_eq(1)
     expect(ys[2]).to_eq(3)
   )
-  it("take exceeds length", ():
+  it("should take all when n exceeds length", ():
     xs = [1, 2, 3]
     ys = take(xs, 10)
     expect(ys).to_have_length(3)
   )
-  it("take zero", ():
+  it("should take zero elements", ():
     xs = [1, 2, 3]
     ys = take(xs, 0)
     expect(ys).to_have_length(0)
   )
-  it("take non-mutating", ():
+  it("should take without mutating original", ():
     xs = [1, 2, 3, 4, 5]
     ys = take(xs, 2)
     expect(xs).to_have_length(5)
     expect(ys).to_have_length(2)
   )
-  it("take negative", ():
+  it("should return empty for take with negative n", ():
     xs = [1, 2, 3]
     ys = take(xs, -1)
     expect(ys).to_have_length(0)
   )
-  it("tap returns original list", ():
+  it("should return original list from tap", ():
     xs = [1, 2, 3]
     ys = tap(xs, (x: int) => x * 2)
     expect(ys).to_have_length(3)
@@ -243,7 +243,7 @@ describe("List", ():
     expect(ys[1]).to_eq(2)
     expect(ys[2]).to_eq(3)
   )
-  it("tap in chain", ():
+  it("should support tap in chain", ():
     xs = [5, 3, 1, 4, 2]
     res = sort(tap(filter(xs, (x: int) => x > 2), (x: int) => x + 1))
     expect(res).to_have_length(3)
@@ -251,7 +251,7 @@ describe("List", ():
     expect(res[1]).to_eq(4)
     expect(res[2]).to_eq(5)
   )
-  it("chain filter-map-sort", ():
+  it("should chain filter-map-sort", ():
     xs = [5, 3, 1, 4, 2]
     res = sort(map(filter(xs, (x: int) => x > 1), (x: int) => x * 10))
     expect(res[0]).to_eq(20)
@@ -259,101 +259,101 @@ describe("List", ():
     expect(res[2]).to_eq(40)
     expect(res[3]).to_eq(50)
   )
-  it("sort empty", ():
+  it("should sort empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     zs = sort(ys)
     expect(zs).to_have_length(0)
   )
-  it("sort single element", ():
+  it("should sort single element list", ():
     xs = [42]
     ys = sort(xs)
     expect(ys[0]).to_eq(42)
   )
-  it("reverse empty", ():
+  it("should reverse empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     zs = reverse(ys)
     expect(zs).to_have_length(0)
   )
-  it("reverse single element", ():
+  it("should reverse single element list", ():
     xs = [42]
     ys = reverse(xs)
     expect(ys[0]).to_eq(42)
   )
-  it("map empty", ():
+  it("should map empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     zs = map(ys, (x: int) => x * 2)
     expect(zs).to_have_length(0)
   )
-  it("filter empty", ():
+  it("should filter empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     zs = filter(ys, (x: int) => true)
     expect(zs).to_have_length(0)
   )
-  it("sum empty", ():
+  it("should sum empty list as zero", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     expect(sum(ys)).to_eq(0)
   )
-  it("fold empty returns initial", ():
+  it("should return initial for fold of empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     expect(fold(ys, 42, (a: int, b: int) => a + b)).to_eq(42)
   )
-  it("any empty", ():
+  it("should return false for any on empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     expect(any(ys, (x: int) => true)).to_be_false()
   )
-  it("all empty", ():
+  it("should return true for all on empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     expect(all(ys, (x: int) => false)).to_be_true()
   )
-  it("is_empty true", ():
+  it("should report is_empty true for empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     expect(is_empty(ys)).to_be_true()
   )
-  it("slice empty range", ():
+  it("should return empty for slice with empty range", ():
     xs = [1, 2, 3, 4, 5]
     ys = slice(xs, 0, 0)
     expect(ys).to_have_length(0)
   )
-  it("slice same start and end", ():
+  it("should return empty for slice with same start and end", ():
     xs = [1, 2, 3, 4, 5]
     ys = slice(xs, 2, 2)
     expect(ys).to_have_length(0)
   )
-  it("insert at front", ():
+  it("should insert at front", ():
     xs = [2, 3]
     insert(xs, 0, 1)
     expect(xs[0]).to_eq(1)
     expect(xs[1]).to_eq(2)
     expect(xs).to_have_length(3)
   )
-  it("distinct empty", ():
+  it("should distinct empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     zs = distinct(ys)
     expect(zs).to_have_length(0)
   )
-  it("distinct single", ():
+  it("should distinct single element list", ():
     xs = [1]
     ys = distinct(xs)
     expect(ys).to_have_length(1)
     expect(ys[0]).to_eq(1)
   )
-  it("flatten single inner", ():
+  it("should flatten single inner list", ():
     xs = [[42]]
     ys = flatten(xs)
     expect(ys).to_have_length(1)
     expect(ys[0]).to_eq(42)
   )
-  it("flatten with single-element inner lists", ():
+  it("should flatten with single-element inner lists", ():
     xs = [[1], [2], [3]]
     ys = flatten(xs)
     expect(ys).to_have_length(3)
@@ -361,25 +361,25 @@ describe("List", ():
     expect(ys[1]).to_eq(2)
     expect(ys[2]).to_eq(3)
   )
-  it("take empty", ():
+  it("should take from empty list", ():
     xs = [1]
     ys = filter(xs, (x: int) => x > 10)
     zs = take(ys, 5)
     expect(zs).to_have_length(0)
   )
-  it("sort 32 elements (MIN_MERGE threshold)", ():
+  it("should sort 32 elements (MIN_MERGE threshold)", ():
     xs = [32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ys = sort(xs)
     expect(ys[0]).to_eq(1)
     expect(ys[31]).to_eq(32)
   )
-  it("sort 33 elements (TimSort merge path)", ():
+  it("should sort 33 elements (TimSort merge path)", ():
     xs = [33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
     ys = sort(xs)
     expect(ys[0]).to_eq(1)
     expect(ys[32]).to_eq(33)
   )
-  it("sort stability", ():
+  it("should maintain sort stability", ():
     xs = [201, 102, 303, 104, 205]
     ys = sort(xs, (a: int, b: int) => a / 100 < b / 100)
     expect(ys[0]).to_eq(102)
@@ -388,21 +388,21 @@ describe("List", ():
     expect(ys[3]).to_eq(205)
     expect(ys[4]).to_eq(303)
   )
-  it("empty list literal with type annotation int", ():
+  it("should support empty list literal with int type annotation", ():
     xs: List<int> = []
     expect(xs).to_have_length(0)
     append(xs, 42)
     expect(xs).to_have_length(1)
     expect(xs[0]).to_eq(42)
   )
-  it("empty list literal with type annotation str", ():
+  it("should support empty list literal with str type annotation", ():
     xs: List<str> = []
     expect(xs).to_have_length(0)
     append(xs, "hello")
     expect(xs).to_have_length(1)
     expect(xs[0]).to_eq("hello")
   )
-  it("concatenation with +", ():
+  it("should concatenate with +", ():
     a = [1, 2, 3]
     b = [4, 5, 6]
     c = a + b
@@ -411,7 +411,7 @@ describe("List", ():
     expect(c[3]).to_eq(4)
     expect(c[5]).to_eq(6)
   )
-  it("concatenation with +=", ():
+  it("should concatenate with +=", ():
     a = [1, 2, 3]
     a += [4, 5]
     expect(a).to_have_length(5)
@@ -419,14 +419,14 @@ describe("List", ():
     expect(a[3]).to_eq(4)
     expect(a[4]).to_eq(5)
   )
-  it("concatenation with empty list", ():
+  it("should concatenate with empty list", ():
     a: List<int> = []
     b = [1, 2]
     c = a + b
     expect(c).to_have_length(2)
     expect(c[0]).to_eq(1)
   )
-  it("concatenation string lists", ():
+  it("should concatenate string lists", ():
     a = ["a", "b"]
     b = ["c"]
     c = a + b
@@ -436,60 +436,60 @@ describe("List", ():
 )
 
 describe("Map", ():
-  it("key access", ():
+  it("should access by key", ():
     m = {"a": 1, "b": 2}
     expect(m["a"]).to_eq(1)
   )
-  it("insert and update", ():
+  it("should insert and update", ():
     m = {"a": 1}
     m["b"] = 2
     m["a"] = 99
     expect(m["a"]).to_eq(99)
     expect(m["b"]).to_eq(2)
   )
-  it("length", ():
+  it("should return length", ():
     m = {"a": 1, "b": 2, "c": 3}
     expect(m).to_have_length(3)
   )
-  it("has_key", ():
+  it("should check has_key", ():
     m = {"a": 1, "b": 2}
     expect(m).to_contain("a")
     expect(m).to_not_contain("z")
   )
-  it("keys", ():
+  it("should return keys", ():
     m = {"x": 1}
     ks = keys(m)
     expect(ks).to_have_length(1)
     expect(ks[0]).to_eq("x")
   )
-  it("values", ():
+  it("should return values", ():
     m = {"x": 10}
     vs = values(m)
     expect(vs).to_have_length(1)
     expect(vs).to_contain(10)
   )
-  it("items", ():
+  it("should return items", ():
     m = {"a": 1}
     pairs = items(m)
     expect(pairs).to_have_length(1)
   )
-  it("remove", ():
+  it("should remove", ():
     m = {"a": 1, "b": 2}
     remove(m, "a")
     expect(m).to_not_contain("a")
     expect(m).to_have_length(1)
   )
-  it("get with default", ():
+  it("should get with default", ():
     m = {"a": 1, "b": 2}
     expect(get(m, "a", 0)).to_eq(1)
     expect(get(m, "z", 0)).to_eq(0)
   )
-  it("get optional", ():
+  it("should get optional", ():
     m = {"a": 1, "b": 2}
     expect(get(m, "a")).to_eq(Some(1))
     expect(get(m, "z")).to_be_none()
   )
-  it("merge", ():
+  it("should merge", ():
     m1 = {"a": 1, "b": 2}
     m2 = {"b": 99, "c": 3}
     m3 = merge(m1, m2)
@@ -497,39 +497,39 @@ describe("Map", ():
     expect(m3["b"]).to_eq(99)
     expect(m3["c"]).to_eq(3)
   )
-  it("in operator", ():
+  it("should support in operator", ():
     m = {"a": 1}
     expect(m).to_contain("a")
     expect(m).to_not_contain("z")
   )
-  it("remove non-existent key", ():
+  it("should handle remove of non-existent key", ():
     m = {"a": 1, "b": 2}
     remove(m, "zzz")
     expect(m).to_have_length(2)
   )
-  it("get non-existent optional", ():
+  it("should return none for get of non-existent key", ():
     m = {"a": 1}
     expect(get(m, "zzz")).to_be_none()
   )
-  it("empty map keys", ():
+  it("should return empty keys for empty map", ():
     m = {"a": 1}
     remove(m, "a")
     ks = keys(m)
     expect(ks).to_have_length(0)
   )
-  it("empty map values", ():
+  it("should return empty values for empty map", ():
     m = {"a": 1}
     remove(m, "a")
     vs = values(m)
     expect(vs).to_have_length(0)
   )
-  it("empty map items", ():
+  it("should return empty items for empty map", ():
     m = {"a": 1}
     remove(m, "a")
     ps = items(m)
     expect(ps).to_have_length(0)
   )
-  it("merge with empty map", ():
+  it("should merge with empty map", ():
     m1 = {"a": 1}
     m2 = {"a": 2}
     remove(m2, "a")
@@ -540,33 +540,33 @@ describe("Map", ():
 )
 
 describe("Set", ():
-  it("in", ():
+  it("should support in operator", ():
     s = {1, 2, 3}
     expect(s).to_contain(2)
     expect(s).to_not_contain(5)
   )
-  it("length", ():
+  it("should return length", ():
     s = {1, 2, 3}
     expect(s).to_have_length(3)
   )
-  it("add", ():
+  it("should add elements", ():
     s = {1, 2, 3}
     add(s, 4)
     add(s, 1)
     expect(s).to_have_length(4)
   )
-  it("remove", ():
+  it("should remove elements", ():
     s = {1, 2, 3}
     remove(s, 2)
     expect(s).to_not_contain(2)
   )
-  it("union", ():
+  it("should compute union", ():
     a = {1, 2, 3}
     b = {3, 4, 5}
     c = union(a, b)
     expect(c).to_have_length(5)
   )
-  it("intersection", ():
+  it("should compute intersection", ():
     a = {1, 2, 3}
     b = {2, 3, 4}
     c = intersection(a, b)
@@ -574,14 +574,14 @@ describe("Set", ():
     expect(c).to_contain(2)
     expect(c).to_contain(3)
   )
-  it("difference", ():
+  it("should compute difference", ():
     a = {1, 2, 3}
     b = {2, 3, 4}
     c = difference(a, b)
     expect(c).to_have_length(1)
     expect(c).to_contain(1)
   )
-  it("symmetric_difference", ():
+  it("should compute symmetric_difference", ():
     a = {1, 2, 3}
     b = {2, 3, 4}
     c = symmetric_difference(a, b)
@@ -589,69 +589,69 @@ describe("Set", ():
     expect(c).to_contain(1)
     expect(c).to_contain(4)
   )
-  it("is_subset", ():
+  it("should check is_subset", ():
     a = {1, 2}
     b = {1, 2, 3}
     expect(is_subset(a, b)).to_be_true()
     expect(is_subset(b, a)).to_be_false()
   )
-  it("is_superset", ():
+  it("should check is_superset", ():
     a = {1, 2, 3}
     b = {1, 2}
     expect(is_superset(a, b)).to_be_true()
     expect(is_superset(b, a)).to_be_false()
   )
-  it("remove non-existent element", ():
+  it("should handle remove of non-existent element", ():
     s = {1, 2, 3}
     remove(s, 999)
     expect(s).to_have_length(3)
   )
-  it("literal dedup int", ():
+  it("should dedup int in literal", ():
     s = {1, 2, 3, 2, 1}
     expect(s).to_have_length(3)
     expect(s).to_contain(1)
     expect(s).to_contain(2)
     expect(s).to_contain(3)
   )
-  it("literal dedup all same", ():
+  it("should dedup all-same literal to single element", ():
     s = {1, 1, 1}
     expect(s).to_have_length(1)
     expect(s).to_contain(1)
   )
-  it("literal dedup string", ():
+  it("should dedup string in literal", ():
     s = {"a", "b", "a"}
     expect(s).to_have_length(2)
     expect(s).to_contain("a")
     expect(s).to_contain("b")
   )
-  it("union with empty set", ():
+  it("should compute union with empty set", ():
     a = {1, 2, 3}
     b = {1}
     remove(b, 1)
     c = union(a, b)
     expect(c).to_have_length(3)
   )
-  it("intersection with empty set", ():
+  it("should compute intersection with empty set", ():
     a = {1, 2, 3}
     b = {1}
     remove(b, 1)
     c = intersection(a, b)
     expect(c).to_have_length(0)
   )
-  it("difference with empty set", ():
+  it("should compute difference with empty set", ():
     a = {1, 2, 3}
     b = {1}
     remove(b, 1)
     c = difference(a, b)
     expect(c).to_have_length(3)
   )
-  it("is_subset empty is subset of any", ():
+  it("should verify empty set is subset of any set", ():
     a = {1}
     remove(a, 1)
     b = {1, 2, 3}
     expect(is_subset(a, b)).to_be_true()
   )
-  it("is_superset of empty set", ():
+  it("should verify is_superset of empty set", ():
     a = {1, 2, 3}
     b = {1}
     remove(b, 1)
@@ -660,37 +660,37 @@ describe("Set", ():
 )
 
 describe("Tuple", ():
-  it("element access", ():
+  it("should access tuple elements", ():
     t = (10, "hello")
     expect(t.0).to_eq(10)
     expect(t.1).to_eq("hello")
   )
-  it("function return", ():
+  it("should return tuple from function", ():
     function swap(a: int, b: int) -> (int, int):
       return (b, a)
     res = swap(1, 2)
     expect(res.0).to_eq(2)
     expect(res.1).to_eq(1)
   )
-  it("three element tuple", ():
+  it("should support three element tuple", ():
     t = (1, "a", true)
     expect(t.0).to_eq(1)
     expect(t.1).to_eq("a")
     expect(t.2).to_be_true()
   )
-  it("equality", ():
+  it("should support tuple equality", ():
     expect((1, 2) == (1, 2)).to_be_true()
     expect((1, 2) == (1, 3)).to_be_false()
   )
-  it("inequality", ():
+  it("should support tuple inequality", ():
     expect((1, 2) != (3, 4)).to_be_true()
     expect((1, 2) != (1, 2)).to_be_false()
   )
-  it("equality with mixed types", ():
+  it("should support tuple equality with mixed types", ():
     expect(("a", 1) == ("a", 1)).to_be_true()
     expect(("a", 1) == ("b", 1)).to_be_false()
   )
-  it("equality via variables", ():
+  it("should support tuple equality via variables", ():
     t1 = (1, 2)
     t2 = (1, 2)
     expect(t1 == t2).to_be_true()

--- a/tests/spec/concurrency.test.ry
+++ b/tests/spec/concurrency.test.ry
@@ -1,23 +1,23 @@
 describe("async and await", ():
-  it("block_on awaits direct async call", ():
+  it("should await direct async call with block_on", ():
     async function async_add_direct(a: int, b: int) -> int:
       return a + b
     expect(block_on(async_add_direct(20, 22))).to_eq(42)
   )
-  it("block_on awaits task variable", ():
+  it("should await task variable with block_on", ():
     async function async_add_task(a: int, b: int) -> int:
       return a + b
     t: Task<int> = async_add_task(7, 8)
     expect(block_on(t)).to_eq(15)
   )
-  it("chains async functions with await inside async function", ():
+  it("should chain async functions with await inside async function", ():
     async function inner() -> int:
       return 21
     async function outer() -> int:
       return (await inner()) * 2
     expect(block_on(outer())).to_eq(42)
   )
-  it("supports Unit-returning async functions through block_on", ():
+  it("should support Unit-returning async functions through block_on", ():
     async function bump() -> Unit:
       print("done")
     block_on(bump())
@@ -26,7 +26,7 @@ describe("async and await", ():
 )
 
 describe("parallel for", ():
-  it("executes counted loops", ():
+  it("should execute counted loops in parallel", ():
     function consume(x: int) -> int:
       return x + 1
     expect(available_parallelism() > 0).to_be_true()

--- a/tests/spec/constantint_sharing.test.ry
+++ b/tests/spec/constantint_sharing.test.ry
@@ -1,52 +1,52 @@
 describe("ConstantInt sharing fix (#311)", ():
-  it("same value with u64 suffix and plain int", ():
+  it("should not conflict with same value using u64 suffix and plain int", ():
     x = 100u64
     y = 100
     expect(y).to_eq(100)
     expect(y + 1).to_eq(101)
   )
 
-  it("same value with u32 and i32 suffix", ():
+  it("should not conflict with same value using u32 and i32 suffix", ():
     a = 100u32
     b = 100i32
     expect(a as int).to_eq(100)
     expect(b as int).to_eq(100)
   )
 
-  it("plain int not tainted by prior u64 literal", ():
+  it("should not taint plain int by prior u64 literal", ():
     x = 50u64
     y = 50
     z = y * 2
     expect(z).to_eq(100)
   )
 
-  it("annotated u32 variable still works", ():
+  it("should work with annotated u32 variable", ():
     x: u32 = 100
     expect(x as int).to_eq(100)
   )
 
-  it("u32 unsigned division via suffix", ():
+  it("should perform u32 unsigned division via suffix", ():
     x: u32 = 10
     y: u32 = 3
     expect((x / y) as int).to_eq(3)
   )
 
-  it("suffix literal direct arithmetic", ():
+  it("should compute direct arithmetic with suffix literals", ():
     x = 100i32 + 200i32
     expect(x as int).to_eq(300)
   )
 
-  it("suffix literal direct comparison", ():
+  it("should compare suffix literals directly", ():
     expect(100u32 < 200u32).to_eq(true)
   )
 
-  it("mixed: variable and suffix literal", ():
+  it("should mix variable and suffix literal", ():
     x: u32 = 10
     y = x + 5u32
     expect(y as int).to_eq(15)
   )
 
-  it("f32 constant sharing", ():
+  it("should not conflict with f32 constant sharing", ():
     a = 1.5f32
     b = 1.5
     expect(b).to_eq(1.5)

--- a/tests/spec/contracts.test.ry
+++ b/tests/spec/contracts.test.ry
@@ -23,28 +23,28 @@ record BankAccount:
     balance >= min_balance
 
 describe("require", ():
-  it("passes when precondition met", ():
+  it("should pass when precondition met", ():
     res = deposit(100, 50)
     expect(res).to_eq(150)
   )
 )
 
 describe("ensure", ():
-  it("passes when postcondition met", ():
+  it("should pass when postcondition met", ():
     expect(abs_val(-5)).to_eq(5)
     expect(abs_val(3)).to_eq(3)
   )
 )
 
 describe("ensure with arg reference", ():
-  it("captures value correctly", ():
+  it("should capture value correctly", ():
     expect(increment(10)).to_eq(11)
     expect(increment(0)).to_eq(1)
   )
 )
 
 describe("struct invariant", ():
-  it("passes when invariant holds", ():
+  it("should pass when struct invariant holds", ():
     a = BankAccount(100, 0)
     expect(a.balance).to_eq(100)
     expect(a.min_balance).to_eq(0)
@@ -52,7 +52,7 @@ describe("struct invariant", ():
 )
 
 describe("result as identifier", ():
-  it("can be used as a variable name", ():
+  it("should allow result to be used as a variable name", ():
     result: int = 42
     expect(result).to_eq(42)
   )

--- a/tests/spec/control_flow.test.ry
+++ b/tests/spec/control_flow.test.ry
@@ -1,11 +1,11 @@
 describe("if / when", ():
-  it("if true", ():
+  it("should execute if true", ():
     res = 0
     if true:
       res = 1
     expect(res).to_eq(1)
   )
-  it("if false goes to else", ():
+  it("should go to else when if is false", ():
     res = 0
     if false:
       res = 1
@@ -13,7 +13,7 @@ describe("if / when", ():
       res = 2
     expect(res).to_eq(2)
   )
-  it("when multi-branch", ():
+  it("should evaluate when multi-branch", ():
     res = 0
     x = 5
     when:
@@ -25,7 +25,7 @@ describe("if / when", ():
         res = 3
     expect(res).to_eq(2)
   )
-  it("when all false falls to else", ():
+  it("should fall to else when all when branches are false", ():
     res = 0
     x = 99
     when:
@@ -37,7 +37,7 @@ describe("if / when", ():
         res = 3
     expect(res).to_eq(3)
   )
-  it("when first false second true", ():
+  it("should evaluate second when branch when first is false", ():
     res = 0
     x = 5
     when:
@@ -52,7 +52,7 @@ describe("if / when", ():
 )
 
 describe("while", ():
-  it("basic loop", ():
+  it("should run basic while loop", ():
     i = 0
     sum = 0
     while i < 5:
@@ -60,7 +60,7 @@ describe("while", ():
       i = i + 1
     expect(sum).to_eq(10)
   )
-  it("break", ():
+  it("should break out of loop", ():
     i = 0
     while true:
       if i >= 3:
@@ -68,7 +68,7 @@ describe("while", ():
       i = i + 1
     expect(i).to_eq(3)
   )
-  it("continue", ():
+  it("should continue to next iteration", ():
     sum = 0
     i = 0
     while i < 5:
@@ -81,51 +81,51 @@ describe("while", ():
 )
 
 describe("for", ():
-  it("list iteration", ():
+  it("should iterate over list", ():
     sum = 0
     xs = [10, 20, 30]
     for x in xs:
       sum = sum + x
     expect(sum).to_eq(60)
   )
-  it("range 1 arg", ():
+  it("should iterate range with 1 arg", ():
     sum = 0
     for i in range(5):
       sum = sum + i
     expect(sum).to_eq(10)
   )
-  it("range 2 args", ():
+  it("should iterate range with 2 args", ():
     sum = 0
     for i in range(2, 5):
       sum = sum + i
     expect(sum).to_eq(9)
   )
-  it("range 3 args", ():
+  it("should iterate range with 3 args", ():
     sum = 0
     for i in range(0, 10, 3):
       sum = sum + i
     expect(sum).to_eq(18)
   )
-  it("range negative step", ():
+  it("should iterate range with negative step", ():
     sum = 0
     for i in range(10, 0, -3):
       sum = sum + i
     expect(sum).to_eq(22)
   )
-  it(".. range", ():
+  it("should iterate .. range", ():
     sum = 0
     for i in 1..3:
       sum = sum + i
     expect(sum).to_eq(6)
   )
-  it("map key-value", ():
+  it("should iterate map key-value pairs", ():
     m = {"a": 1, "b": 2}
     total = 0
     for k, v in m:
       total = total + v
     expect(total).to_eq(3)
   )
-  it("enumerate destructuring", ():
+  it("should support enumerate destructuring", ():
     xs = [10, 20, 30]
     idx_sum = 0
     val_sum = 0
@@ -135,13 +135,13 @@ describe("for", ():
     expect(idx_sum).to_eq(3)
     expect(val_sum).to_eq(60)
   )
-  it("zip destructuring", ():
+  it("should support zip destructuring", ():
     sum = 0
     for a, b in zip([1, 2], [10, 20]):
       sum = sum + (a + b)
     expect(sum).to_eq(33)
   )
-  it("3-element tuple destructuring", ():
+  it("should support 3-element tuple destructuring", ():
     triples = [(1, 2, 3), (4, 5, 6)]
     sum_a = 0
     sum_b = 0
@@ -154,14 +154,14 @@ describe("for", ():
     expect(sum_b).to_eq(7)
     expect(sum_c).to_eq(9)
   )
-  it("3-element destructuring with wildcard", ():
+  it("should support 3-element destructuring with wildcard", ():
     triples = [(1, 2, 3), (4, 5, 6)]
     sum = 0
     for a, _, c in triples:
       sum = sum + a + c
     expect(sum).to_eq(14)
   )
-  it("empty list iteration", ():
+  it("should iterate empty list without executing body", ():
     sum = 0
     xs = [1]
     empty = filter(xs, (x: int) => x > 10)
@@ -169,19 +169,19 @@ describe("for", ():
       sum = sum + x
     expect(sum).to_eq(0)
   )
-  it("range(0) is empty", ():
+  it("should treat range(0) as empty", ():
     sum = 0
     for i in range(0):
       sum = sum + 1
     expect(sum).to_eq(0)
   )
-  it("range with equal start and end", ():
+  it("should treat range with equal start and end as empty", ():
     sum = 0
     for i in range(5, 5):
       sum = sum + 1
     expect(sum).to_eq(0)
   )
-  it("range reverse without step", ():
+  it("should treat range reverse without step as empty", ():
     sum = 0
     for i in range(5, 3):
       sum = sum + 1
@@ -190,7 +190,7 @@ describe("for", ():
 )
 
 describe("when", ():
-  it("literal pattern", ():
+  it("should match literal pattern", ():
     res = 0
     x = 2
     match x:
@@ -202,7 +202,7 @@ describe("when", ():
         res = 30
     expect(res).to_eq(20)
   )
-  it("variable binding", ():
+  it("should match with variable binding", ():
     res = 0
     x = 42
     match x:
@@ -212,7 +212,7 @@ describe("when", ():
         res = 0
     expect(res).to_eq(42)
   )
-  it("guard", ():
+  it("should match with guard", ():
     res = ""
     x = -5
     match x:
@@ -224,7 +224,7 @@ describe("when", ():
         res = "zero"
     expect(res).to_eq("negative")
   )
-  it("OR pattern", ():
+  it("should match OR pattern", ():
     res = ""
     x = 2
     match x:
@@ -234,7 +234,7 @@ describe("when", ():
         res = "other"
     expect(res).to_eq("small")
   )
-  it("wildcard", ():
+  it("should match wildcard", ():
     res = ""
     x = 999
     match x:
@@ -244,7 +244,7 @@ describe("when", ():
         res = "other"
     expect(res).to_eq("other")
   )
-  it("string literal pattern", ():
+  it("should match string literal pattern", ():
     res = ""
     s = "hello"
     match s:
@@ -254,7 +254,7 @@ describe("when", ():
         res = "other"
     expect(res).to_eq("matched")
   )
-  it("negative literal pattern", ():
+  it("should match negative literal pattern", ():
     res = ""
     x = -1
     match x:
@@ -266,7 +266,7 @@ describe("when", ():
         res = "other"
     expect(res).to_eq("minus one")
   )
-  it("guard fallback to wildcard", ():
+  it("should fall back to wildcard when guard fails", ():
     res = ""
     x = 5
     match x:
@@ -278,7 +278,7 @@ describe("when", ():
         res = "small"
     expect(res).to_eq("small")
   )
-  it("OR pattern with many alternatives", ():
+  it("should match OR pattern with many alternatives", ():
     res = ""
     x = 4
     match x:
@@ -291,7 +291,7 @@ describe("when", ():
 )
 
 describe("when Option", ():
-  it("Some", ():
+  it("should match Some", ():
     res = 0
     x: Option<int> = Some(42)
     match x:
@@ -301,7 +301,7 @@ describe("when Option", ():
         res = -1
     expect(res).to_eq(42)
   )
-  it("None", ():
+  it("should match None", ():
     res = 0
     x: Option<int> = None
     match x:
@@ -320,7 +320,7 @@ enum Direction:
   West
 
 describe("when enum", ():
-  it("simple enum", ():
+  it("should match simple enum", ():
     res = ""
     d = Direction::North
     match d:
@@ -334,7 +334,7 @@ describe("when enum", ():
         res = "west"
     expect(res).to_eq("north")
   )
-  it("last enum variant matches", ():
+  it("should match last enum variant", ():
     res = ""
     d = Direction::West
     match d:
@@ -356,7 +356,7 @@ enum Shape:
   Point
 
 describe("when ADT enum", ():
-  it("with associated data", ():
+  it("should match ADT enum with associated data", ():
     res = 0.0
     s = Shape::Circle(3.14)
     match s:
@@ -368,7 +368,7 @@ describe("when ADT enum", ():
         res = 0.0
     expect(res).to_eq(3.14)
   )
-  it("multi-field variant", ():
+  it("should match ADT enum multi-field variant", ():
     res = 0.0
     s = Shape::Rect(4.0, 5.0)
     match s:
@@ -383,7 +383,7 @@ describe("when ADT enum", ():
 )
 
 describe("nested when", ():
-  it("when inside when", ():
+  it("should support when inside when", ():
     res = ""
     x = 2
     y = 10
@@ -403,7 +403,7 @@ describe("nested when", ():
 )
 
 describe("when ADT no-data variant", ():
-  it("matches Point variant", ():
+  it("should match Point variant", ():
     res = 0.0
     s = Shape::Point
     match s:
@@ -418,7 +418,7 @@ describe("when ADT no-data variant", ():
 )
 
 describe("inline case body", ():
-  it("basic inline case", ():
+  it("should support basic inline case", ():
     res = 0
     x = 2
     match x:
@@ -427,7 +427,7 @@ describe("inline case body", ():
       case _: res = 30
     expect(res).to_eq(20)
   )
-  it("inline and block case mixed", ():
+  it("should support inline and block case mixed", ():
     res = 0
     x = 3
     match x:
@@ -437,7 +437,7 @@ describe("inline case body", ():
       case _: res = 99
     expect(res).to_eq(30)
   )
-  it("inline case with guard", ():
+  it("should support inline case with guard", ():
     res = ""
     x = -5
     match x:
@@ -446,7 +446,7 @@ describe("inline case body", ():
       case _: res = "zero"
     expect(res).to_eq("negative")
   )
-  it("inline case with destructuring", ():
+  it("should support inline case with destructuring", ():
     res = 0
     x: Option<int> = Some(42)
     match x:
@@ -457,7 +457,7 @@ describe("inline case body", ():
 )
 
 describe("inline when body", ():
-  it("inline when arm and inline else", ():
+  it("should support inline when arm and inline else", ():
     res = 0
     x = 5
     when:
@@ -466,7 +466,7 @@ describe("inline when body", ():
       else: res = 3
     expect(res).to_eq(2)
   )
-  it("inline when else fallback", ():
+  it("should support inline when else fallback", ():
     res = 0
     x = 1
     when:
@@ -477,7 +477,7 @@ describe("inline when body", ():
 )
 
 describe("scope and shadowing", ():
-  it("block scope", ():
+  it("should support block scope", ():
     x = 10
     res = 0
     if true:
@@ -489,7 +489,7 @@ describe("scope and shadowing", ():
 )
 
 describe("match expression", ():
-  it("literal pattern", ():
+  it("should match literal pattern as expression", ():
     x = 2
     res = match x:
       case 1 => "one"
@@ -497,14 +497,14 @@ describe("match expression", ():
       case _ => "other"
     expect(res).to_eq("two")
   )
-  it("wildcard fallback", ():
+  it("should fall back to wildcard in match expression", ():
     x = 999
     res = match x:
       case 0 => "zero"
       case _ => "other"
     expect(res).to_eq("other")
   )
-  it("variable binding with guard", ():
+  it("should match with variable binding and guard in expression", ():
     score = 85
     grade = match score:
       case n if n >= 90 => "A"
@@ -513,7 +513,7 @@ describe("match expression", ():
       case _ => "F"
     expect(grade).to_eq("B")
   )
-  it("OR pattern", ():
+  it("should match OR pattern in expression", ():
     x = 3
     kind = match x:
       case 1 | 2 | 3 => "small"
@@ -521,7 +521,7 @@ describe("match expression", ():
       case _ => "large"
     expect(kind).to_eq("small")
   )
-  it("string literal", ():
+  it("should match string literal in expression", ():
     s = "hello"
     res = match s:
       case "hello" => "greeting"
@@ -529,7 +529,7 @@ describe("match expression", ():
       case _ => "unknown"
     expect(res).to_eq("greeting")
   )
-  it("negative literal", ():
+  it("should match negative literal in expression", ():
     x = -1
     res = match x:
       case -1 => "minus one"
@@ -537,7 +537,7 @@ describe("match expression", ():
       case _ => "other"
     expect(res).to_eq("minus one")
   )
-  it("guard fallback to wildcard", ():
+  it("should fall back to wildcard when guard fails in expression", ():
     x = 5
     res = match x:
       case n if n > 100 => "big"
@@ -548,14 +548,14 @@ describe("match expression", ():
 )
 
 describe("match expression Option", ():
-  it("Some", ():
+  it("should match Some in expression", ():
     x: Option<int> = Some(42)
     res = match x:
       case Some(v) => v
       case None => -1
     expect(res).to_eq(42)
   )
-  it("None", ():
+  it("should match None in expression", ():
     x: Option<int> = None
     res = match x:
       case Some(v) => v
@@ -565,7 +565,7 @@ describe("match expression Option", ():
 )
 
 describe("match expression enum", ():
-  it("simple enum", ():
+  it("should match simple enum in expression", ():
     d = Direction::North
     res = match d:
       case Direction::North => "N"
@@ -574,7 +574,7 @@ describe("match expression enum", ():
       case Direction::West => "W"
     expect(res).to_eq("N")
   )
-  it("ADT enum", ():
+  it("should match ADT enum in expression", ():
     s = Shape::Rect(4.0, 5.0)
     area = match s:
       case Shape::Circle(r) => r * r
@@ -582,7 +582,7 @@ describe("match expression enum", ():
       case Shape::Point => 0.0
     expect(area).to_eq(20.0)
   )
-  it("ADT no-data variant", ():
+  it("should match ADT no-data variant in expression", ():
     s = Shape::Point
     area = match s:
       case Shape::Circle(r) => r * r
@@ -593,7 +593,7 @@ describe("match expression enum", ():
 )
 
 describe("match expression in function argument", ():
-  it("inline match expr", ():
+  it("should support inline match expr as function argument", ():
     x = 1
     expect(match x:
       case 1 => 100
@@ -624,12 +624,12 @@ function make_shape(kind: int) -> Shape:
   return Shape::Point
 
 describe("ADT enum as function parameter (#507)", ():
-  it("match on ADT enum parameter", ():
+  it("should match on ADT enum parameter", ():
     expect(shape_area(Shape::Circle(1.0))).to_eq(3.14)
     expect(shape_area(Shape::Rect(4.0, 5.0))).to_eq(20.0)
     expect(shape_area(Shape::Point)).to_eq(0.0)
   )
-  it("multiple functions matching same ADT enum parameter", ():
+  it("should support multiple functions matching same ADT enum parameter", ():
     c = Shape::Circle(2.0)
     expect(shape_area(c)).to_eq(12.56)
     expect(shape_name(c)).to_eq("circle")
@@ -637,13 +637,13 @@ describe("ADT enum as function parameter (#507)", ():
     expect(shape_area(r)).to_eq(12.0)
     expect(shape_name(r)).to_eq("rect")
   )
-  it("ADT enum as return type", ():
+  it("should support ADT enum as return type", ():
     s = make_shape(0)
     expect(shape_name(s)).to_eq("circle")
     s2 = make_shape(2)
     expect(shape_name(s2)).to_eq("point")
   )
-  it("ADT enum equality", ():
+  it("should support ADT enum equality", ():
     expect(Shape::Point == Shape::Point).to_eq(true)
     expect(Shape::Point != Shape::Circle(1.0)).to_eq(true)
     expect(Shape::Circle(1.0) == Shape::Circle(2.0)).to_eq(true)

--- a/tests/spec/cow.test.ry
+++ b/tests/spec/cow.test.ry
@@ -1,6 +1,6 @@
 describe("Copy-on-Write", ():
   describe("List", ():
-    it("append preserves original when shared", ():
+    it("should preserve original when appending to shared list", ():
       a = [1, 2, 3]
       b = a
       append(b, 4)
@@ -8,27 +8,27 @@ describe("Copy-on-Write", ():
       expect(b).to_have_length(4)
       expect(b[3]).to_eq(4)
     )
-    it("append mutates in-place when unique", ():
+    it("should mutate in-place when appending to unique list", ():
       a = [1, 2, 3]
       append(a, 4)
       expect(a).to_have_length(4)
       expect(a[3]).to_eq(4)
     )
-    it("index assignment preserves original when shared", ():
+    it("should preserve original when index-assigning shared list", ():
       a = [1, 2, 3]
       b = a
       b[0] = 99
       expect(a[0]).to_eq(1)
       expect(b[0]).to_eq(99)
     )
-    it("remove preserves original when shared", ():
+    it("should preserve original when removing from shared list", ():
       a = [1, 2, 3]
       b = a
       remove(b, 2)
       expect(a).to_have_length(3)
       expect(b).to_have_length(2)
     )
-    it("pop preserves original when shared", ():
+    it("should preserve original when popping from shared list", ():
       a = [1, 2, 3]
       b = a
       v = pop(b)
@@ -36,7 +36,7 @@ describe("Copy-on-Write", ():
       expect(a).to_have_length(3)
       expect(b).to_have_length(2)
     )
-    it("insert preserves original when shared", ():
+    it("should preserve original when inserting into shared list", ():
       a = [1, 3]
       b = a
       insert(b, 1, 2)
@@ -44,7 +44,7 @@ describe("Copy-on-Write", ():
       expect(b).to_have_length(3)
       expect(b[1]).to_eq(2)
     )
-    it("remove_at preserves original when shared", ():
+    it("should preserve original when remove_at on shared list", ():
       a = [1, 2, 3]
       b = a
       remove_at(b, 1)
@@ -52,7 +52,7 @@ describe("Copy-on-Write", ():
       expect(b).to_have_length(2)
       expect(b[1]).to_eq(3)
     )
-    it("sort! preserves original when shared", ():
+    it("should preserve original when sort! on shared list", ():
       a = [3, 1, 2]
       b = a
       sort!(b)
@@ -63,7 +63,7 @@ describe("Copy-on-Write", ():
       expect(b[1]).to_eq(2)
       expect(b[2]).to_eq(3)
     )
-    it("reverse! preserves original when shared", ():
+    it("should preserve original when reverse! on shared list", ():
       a = [1, 2, 3]
       b = a
       reverse!(b)
@@ -76,14 +76,14 @@ describe("Copy-on-Write", ():
     )
   )
   describe("Map", ():
-    it("index assignment preserves original when shared", ():
+    it("should preserve original when index-assigning shared map", ():
       a = {"x": 1}
       b = a
       b["y"] = 2
       expect(a).to_have_length(1)
       expect(b).to_have_length(2)
     )
-    it("remove preserves original when shared", ():
+    it("should preserve original when removing from shared map", ():
       a = {"x": 1, "y": 2}
       b = a
       remove(b, "x")
@@ -92,14 +92,14 @@ describe("Copy-on-Write", ():
     )
   )
   describe("Set", ():
-    it("add preserves original when shared", ():
+    it("should preserve original when adding to shared set", ():
       a = {1, 2}
       b = a
       add(b, 3)
       expect(a).to_have_length(2)
       expect(b).to_have_length(3)
     )
-    it("remove preserves original when shared", ():
+    it("should preserve original when removing from shared set", ():
       a = {1, 2, 3}
       b = a
       remove(b, 2)

--- a/tests/spec/default_args.test.ry
+++ b/tests/spec/default_args.test.ry
@@ -31,54 +31,54 @@ function calc(x: float, precision: int = 6) -> float:
 # --- tests ---
 
 describe("basic default arguments", ():
-  it("uses default when arg omitted", ():
+  it("should use default when arg is omitted", ():
     expect(greet("Alice")).to_eq("Hello, Alice")
   )
 
-  it("overrides default when arg provided", ():
+  it("should override default when arg is provided", ():
     expect(greet("Alice", "Hi")).to_eq("Hi, Alice")
   )
 )
 
 describe("multiple default arguments", ():
-  it("all defaults used", ():
+  it("should use all defaults when args are omitted", ():
     expect(connect("localhost")).to_eq("localhost:8080:30")
   )
 
-  it("first default overridden", ():
+  it("should override first default", ():
     expect(connect("localhost", 3000)).to_eq("localhost:3000:30")
   )
 
-  it("all args provided", ():
+  it("should work when all args are provided", ():
     expect(connect("localhost", 3000, 10000)).to_eq("localhost:3000:10000")
   )
 )
 
 describe("default value types", ():
-  it("float default", ():
+  it("should use float default", ():
     expect(with_float(5.0)).to_eq(5.0)
     expect(with_float(5.0, 2.0)).to_eq(10.0)
   )
 
-  it("bool default", ():
+  it("should use bool default", ():
     expect(with_bool("hello")).to_eq("hello")
     expect(with_bool("hello", true)).to_eq("hello!")
   )
 
-  it("None default for optional", ():
+  it("should use None as default for optional param", ():
     expect(with_none("Alice")).to_eq("Alice:none")
   )
 )
 
 describe("coexistence with overloading", ():
-  it("different arity overloads still work", ():
+  it("should support different arity overloads alongside defaults", ():
     expect(area(5)).to_eq(25)
     expect(area(3, 4)).to_eq(12)
   )
 )
 
 describe("widening with default args", ():
-  it("int widened to float with default", ():
+  it("should widen int to float with default arg", ():
     expect(calc(3)).to_eq(3.0)
   )
 )

--- a/tests/spec/directive_test.test.ry
+++ b/tests/spec/directive_test.test.ry
@@ -1,48 +1,48 @@
 # Tests for @it and @describe directive syntax on named functions (#634)
 
 # Basic @it on a named function
-@it("adds 1 + 2 = 3")
+@it("should add 1 + 2 = 3")
 function test_add():
   expect(1 + 2).to_eq(3)
 
-@it("string concatenation")
+@it("should concatenate strings")
 function test_str_concat():
   expect("hello" + " " + "world").to_eq("hello world")
 
-@it("boolean logic")
+@it("should evaluate boolean logic")
 function test_bool():
   expect(true and false).to_be_false()
 
 # @describe wrapping named functions with nested @it
 @describe("arithmetic")
 function arithmetic_tests():
-  @it("subtraction")
+  @it("should subtract")
   function test_sub():
     expect(10 - 3).to_eq(7)
 
-  @it("multiplication")
+  @it("should multiply")
   function test_mul():
     expect(4 * 5).to_eq(20)
 
 # @each with @it on a named function
 @each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
-@it("adds {0} + {1} = {2}")
+@it("should add {0} + {1} = {2}")
 function test_add_each(a: int, b: int, expected: int):
   expect(a + b).to_eq(expected)
 
 @each([("hello", 5), ("", 0), ("ry", 2)])
-@it("length of \"{0}\" is {1}")
+@it("should have length of \"{0}\" equal to {1}")
 function test_length_each(s: str, expected: int):
   expect(length(s)).to_eq(expected)
 
 # @property with @it on a named function
 @property(count=100)
-@it("addition is commutative")
+@it("should verify addition is commutative")
 function test_add_commutative(a: int, b: int):
   expect(a + b).to_eq(b + a)
 
 @property(count=50)
-@it("double is always even")
+@it("should verify double is always even")
 function test_double_even(n: int):
   expect(n * 2 % 2).to_eq(0)
 
@@ -52,11 +52,11 @@ function shared_setup_tests():
   base = 100
   offset = 5
 
-  @it("uses base value")
+  @it("should use base value")
   function test_base():
     expect(base).to_eq(100)
 
-  @it("uses both base and offset")
+  @it("should use both base and offset")
   function test_combined():
     expect(base + offset).to_eq(105)
 
@@ -65,6 +65,6 @@ function shared_setup_tests():
 function outer_group():
   @describe("inner group")
   function inner_group():
-    @it("deeply nested test")
+    @it("should pass deeply nested test")
     function test_deep():
       expect(1 + 1).to_eq(2)

--- a/tests/spec/env.test.ry
+++ b/tests/spec/env.test.ry
@@ -1,25 +1,25 @@
 describe("env", ():
-  it("returns some for existing var", ():
+  it("should return some for existing var", ():
     result = env("PATH")
     expect(result).to_be_some()
   )
 
-  it("returns none for non-existent var", ():
+  it("should return none for non-existent var", ():
     result = env("RY_TEST_NONEXISTENT_VAR_XYZ")
     expect(result).to_be_none()
   )
 
-  it("returns default for non-existent var", ():
+  it("should return default for non-existent var", ():
     result = env("RY_TEST_NONEXISTENT_VAR_XYZ", "fallback")
     expect(result).to_eq("fallback")
   )
 
-  it("returns value over default for existing var", ():
+  it("should return value over default for existing var", ():
     result = env("PATH", "fallback")
     expect(result).to_not_eq("fallback")
   )
 
-  it("RY_ENV is canonicalized when set", ():
+  it("should canonicalize RY_ENV when set", ():
     ry_env = env("RY_ENV")
     match ry_env:
       case Some(v):

--- a/tests/spec/expr_stmt.test.ry
+++ b/tests/spec/expr_stmt.test.ry
@@ -1,13 +1,13 @@
 describe("expression statement", ():
-  it("UFCS on list literal", ():
+  it("should support UFCS on list literal", ():
     result = [1, 2, 3].map((x: int) => x * 2)
     expect(result).to_eq([2, 4, 6])
   )
-  it("chained UFCS on list literal", ():
+  it("should support chained UFCS on list literal", ():
     result = [1, 2, 3, 4].filter((x: int) => x > 2).map((x: int) => x * 10)
     expect(result).to_eq([30, 40])
   )
-  it("standalone UFCS on list literal", ():
+  it("should support standalone UFCS on list literal", ():
     [1, 2, 3].map((x: int) => x * 2)
   )
 )

--- a/tests/spec/filesystem.test.ry
+++ b/tests/spec/filesystem.test.ry
@@ -3,7 +3,7 @@ from io import write_text, read_text, exists
 from path import join
 
 describe("make_dir / make_dir_all", ():
-  it("creates a single directory", ():
+  it("should create a single directory", ():
     d = "/tmp/ry_fs_test/single_dir"
     if is_dir(d):
       remove_all(d)
@@ -15,13 +15,13 @@ describe("make_dir / make_dir_all", ():
         fail("make_dir failed: " + e.message)
   )
 
-  it("fails on existing directory", ():
+  it("should fail on existing directory", ():
     d = "/tmp/ry_fs_test/single_dir"
     result = make_dir(d)
     expect(result).to_be_err()
   )
 
-  it("creates nested directories", ():
+  it("should create nested directories", ():
     d = "/tmp/ry_fs_test/a/b/c"
     match make_dir_all(d):
       case Ok(_):
@@ -32,7 +32,7 @@ describe("make_dir / make_dir_all", ():
 )
 
 describe("is_file / is_dir / is_symlink", ():
-  it("detects a regular file", ():
+  it("should detect a regular file", ():
     f = "/tmp/ry_fs_test/test_file.txt"
     match write_text(f, "hello"):
       case Ok(_):
@@ -43,12 +43,12 @@ describe("is_file / is_dir / is_symlink", ():
         fail("write_text failed: " + e.message)
   )
 
-  it("detects a directory", ():
+  it("should detect a directory", ():
     expect(is_dir("/tmp/ry_fs_test")).to_be_true()
     expect(is_file("/tmp/ry_fs_test")).to_be_false()
   )
 
-  it("returns false for non-existent path", ():
+  it("should return false for non-existent path", ():
     expect(is_file("/tmp/ry_fs_test_nonexistent_xyz")).to_be_false()
     expect(is_dir("/tmp/ry_fs_test_nonexistent_xyz")).to_be_false()
     expect(is_symlink("/tmp/ry_fs_test_nonexistent_xyz")).to_be_false()
@@ -56,7 +56,7 @@ describe("is_file / is_dir / is_symlink", ():
 )
 
 describe("list_dir", ():
-  it("lists directory entries", ():
+  it("should list directory entries", ():
     d = "/tmp/ry_fs_test/listdir_test"
     if is_dir(d):
       remove_all(d)
@@ -71,14 +71,14 @@ describe("list_dir", ():
         fail("list_dir failed: " + e.message)
   )
 
-  it("returns error for non-existent dir", ():
+  it("should return error for non-existent dir", ():
     result = list_dir("/tmp/ry_fs_test_no_such_dir")
     expect(result).to_be_err()
   )
 )
 
 describe("walk", ():
-  it("recursively lists files and directories", ():
+  it("should recursively list files and directories", ():
     d = "/tmp/ry_fs_test/walk_test"
     if is_dir(d):
       remove_all(d)
@@ -93,14 +93,14 @@ describe("walk", ():
         fail("walk failed: " + e.message)
   )
 
-  it("returns error for non-existent dir", ():
+  it("should return error for non-existent dir in walk", ():
     result = walk("/tmp/ry_fs_test_no_such_dir")
     expect(result).to_be_err()
   )
 )
 
 describe("glob_files", ():
-  it("matches files by pattern", ():
+  it("should match files by pattern", ():
     d = "/tmp/ry_fs_test/glob_test"
     if is_dir(d):
       remove_all(d)
@@ -115,7 +115,7 @@ describe("glob_files", ():
         fail("glob_files failed: " + e.message)
   )
 
-  it("returns empty list when nothing matches", ():
+  it("should return empty list when nothing matches", ():
     match glob_files("/tmp/ry_fs_test_nomatch_*.zzz"):
       case Ok(matches):
         expect(matches).to_have_length(0)
@@ -125,7 +125,7 @@ describe("glob_files", ():
 )
 
 describe("copy", ():
-  it("copies file content", ():
+  it("should copy file content", ():
     src = "/tmp/ry_fs_test/copy_src.txt"
     dst = "/tmp/ry_fs_test/copy_dst.txt"
     write_text(src, "copy me")
@@ -140,14 +140,14 @@ describe("copy", ():
         fail("copy failed: " + e.message)
   )
 
-  it("returns error for non-existent source", ():
+  it("should return error for non-existent source", ():
     result = copy("/tmp/ry_fs_test_nosrc.txt", "/tmp/ry_fs_test_nodst.txt")
     expect(result).to_be_err()
   )
 )
 
 describe("move", ():
-  it("moves a file", ():
+  it("should move a file", ():
     src = "/tmp/ry_fs_test/move_src.txt"
     dst = "/tmp/ry_fs_test/move_dst.txt"
     write_text(src, "move me")
@@ -165,7 +165,7 @@ describe("move", ():
 )
 
 describe("remove / remove_all", ():
-  it("removes a file", ():
+  it("should remove a file", ():
     f = "/tmp/ry_fs_test/remove_me.txt"
     write_text(f, "bye")
     match remove(f):
@@ -175,7 +175,7 @@ describe("remove / remove_all", ():
         fail("remove failed: " + e.message)
   )
 
-  it("remove fails on non-empty directory", ():
+  it("should fail to remove non-empty directory", ():
     d = "/tmp/ry_fs_test/nonempty_dir"
     make_dir(d)
     write_text(join(d, "child.txt"), "x")
@@ -184,7 +184,7 @@ describe("remove / remove_all", ():
     remove_all(d)
   )
 
-  it("remove_all removes directory tree", ():
+  it("should remove directory tree with remove_all", ():
     d = "/tmp/ry_fs_test/tree_to_remove"
     make_dir_all(join(d, "a", "b"))
     write_text(join(d, "a", "b", "file.txt"), "x")
@@ -197,7 +197,7 @@ describe("remove / remove_all", ():
 )
 
 describe("file_size", ():
-  it("returns correct size", ():
+  it("should return correct file size", ():
     f = "/tmp/ry_fs_test/size_test.txt"
     write_text(f, "12345")
     match file_size(f):
@@ -207,14 +207,14 @@ describe("file_size", ():
         fail("file_size failed: " + e.message)
   )
 
-  it("returns error for non-existent file", ():
+  it("should return error for non-existent file", ():
     result = file_size("/tmp/ry_fs_test_no_file.txt")
     expect(result).to_be_err()
   )
 )
 
 describe("chmod", ():
-  it("changes file permissions", ():
+  it("should change file permissions", ():
     f = "/tmp/ry_fs_test/chmod_test.txt"
     write_text(f, "x")
     match chmod(f, 420):
@@ -226,7 +226,7 @@ describe("chmod", ():
 )
 
 describe("symlink / read_link / is_symlink", ():
-  it("creates and reads a symbolic link", ():
+  it("should create and read a symbolic link", ():
     target = "/tmp/ry_fs_test/symlink_target.txt"
     link = "/tmp/ry_fs_test/symlink_link.txt"
     if is_symlink(link):
@@ -245,7 +245,7 @@ describe("symlink / read_link / is_symlink", ():
         fail("symlink failed: " + e.message)
   )
 
-  it("read_link fails on non-symlink", ():
+  it("should fail read_link on non-symlink", ():
     f = "/tmp/ry_fs_test/not_a_link.txt"
     write_text(f, "x")
     result = read_link(f)

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -35,32 +35,32 @@ function operator+=(a: Vec2, b: Vec2) -> Vec2:
   return Vec2(a.x + b.x, a.y + b.y)
 
 describe("basic function", ():
-  it("call", ():
+  it("should call function", ():
     expect(add(1, 2)).to_eq(3)
   )
 )
 
 describe("recursion", ():
-  it("factorial", ():
+  it("should compute factorial recursively", ():
     expect(factorial(5)).to_eq(120)
   )
 )
 
 describe("overloading", ():
-  it("1 arg", ():
+  it("should work with 1 arg", ():
     expect(area(5)).to_eq(25)
   )
-  it("2 args", ():
+  it("should work with 2 args", ():
     expect(area(3, 4)).to_eq(12)
   )
 )
 
 describe("lambda", ():
-  it("single expression", ():
+  it("should support single expression lambda", ():
     double = (x: int) => x * 2
     expect(double(5)).to_eq(10)
   )
-  it("multi-line", ():
+  it("should support multi-line lambda", ():
     abs_val = (x: int):
       if x < 0:
         return -x
@@ -70,13 +70,13 @@ describe("lambda", ():
 )
 
 describe("closure", ():
-  it("captures by value", ():
+  it("should capture by value", ():
     base = 10
     add_base = (x: int) => x + base
     base = 99
     expect(add_base(5)).to_eq(15)
   )
-  it("captures bool", ():
+  it("should capture bool", ():
     flag = true
     check = () => flag
     expect(check()).to_be_true()
@@ -84,20 +84,20 @@ describe("closure", ():
 )
 
 describe("higher-order function", ():
-  it("function as argument", ():
+  it("should pass function as argument", ():
     res = apply((x: int) => x * 3, 5)
     expect(res).to_eq(15)
   )
-  it("named function as argument", ():
+  it("should pass named function as argument", ():
     expect(apply(double, 5)).to_eq(10)
   )
 )
 
 describe("UFCS", ():
-  it("method-style call", ():
+  it("should support method-style call", ():
     expect(double(5)).to_eq(10)
   )
-  it("chaining", ():
+  it("should support UFCS chaining", ():
     expect(add_one(double(5))).to_eq(11)
   )
 )
@@ -130,29 +130,29 @@ function infer_struct():
   return InferPoint(3, 4)
 
 describe("return type inference", ():
-  it("infers int", ():
+  it("should infer int return type", ():
     expect(infer_int()).to_eq(42)
   )
-  it("infers float", ():
+  it("should infer float return type", ():
     expect(infer_float()).to_eq(3.14)
   )
-  it("infers str", ():
+  it("should infer str return type", ():
     expect(infer_str()).to_eq("hello")
   )
-  it("infers bool", ():
+  it("should infer bool return type", ():
     expect(infer_bool()).to_be_true()
   )
-  it("infers union type from mixed returns", ():
+  it("should infer union type from mixed returns", ():
     x = infer_union(true)
     y = infer_union(false)
     expect(true).to_be_true()
   )
-  it("infers struct type", ():
+  it("should infer struct return type", ():
     p = infer_struct()
     expect(p.x).to_eq(3)
     expect(p.y).to_eq(4)
   )
-  it("infers struct type from lambda", ():
+  it("should infer struct return type from lambda", ():
     make_point = (a: int, b: int):
       return InferPoint(a, b)
     p = make_point(5, 6)
@@ -162,19 +162,19 @@ describe("return type inference", ():
 )
 
 describe("operator overloading", ():
-  it("binary +", ():
+  it("should overload binary +", ():
     v1 = Vec2(1.0, 2.0)
     v2 = Vec2(3.0, 4.0)
     v3 = v1 + v2
     expect(v3.x).to_eq(4.0)
     expect(v3.y).to_eq(6.0)
   )
-  it("== comparison", ():
+  it("should overload == comparison", ():
     v1 = Vec2(1.0, 2.0)
     v2 = Vec2(1.0, 2.0)
     expect(v1 == v2).to_be_true()
   )
-  it("compound += calls operator+=", ():
+  it("should call operator+= for compound +=", ():
     v = Vec2(1.0, 2.0)
     v += Vec2(3.0, 4.0)
     expect(v.x).to_eq(4.0)
@@ -191,13 +191,13 @@ function get_value() -> int:
   return 42
 
 describe("zero arg function", ():
-  it("returns value", ():
+  it("should return value from zero arg function", ():
     expect(get_value()).to_eq(42)
   )
 )
 
 describe("tail call optimization", ():
-  it("self-recursive tail call does not overflow", ():
+  it("should not overflow with self-recursive tail call", ():
     expect(sum_to(1000000, 0)).to_eq(500000500000)
   )
 )

--- a/tests/spec/gc.test.ry
+++ b/tests/spec/gc.test.ry
@@ -1,24 +1,24 @@
 from gc import collect, enable, disable, set_threshold
 
 describe("Cycle Collector", ():
-  it("gc.collect returns 0 when no cycles exist", ():
+  it("should return 0 when no cycles exist", ():
     n = collect()
     expect(n).to_eq(0)
   )
 
-  it("gc.enable and gc.disable do not crash", ():
+  it("should not crash when calling gc.enable and gc.disable", ():
     disable()
     enable()
     n = collect()
     expect(n).to_eq(0)
   )
 
-  it("gc.set_threshold does not crash", ():
+  it("should not crash when calling gc.set_threshold", ():
     set_threshold(1000)
     set_threshold(700)
   )
 
-  it("gc.collect returns int", ():
+  it("should return int from gc.collect", ():
     result = collect()
     expect(result >= 0).to_eq(true)
   )

--- a/tests/spec/gc_struct_smoke.test.ry
+++ b/tests/spec/gc_struct_smoke.test.ry
@@ -12,7 +12,7 @@ enum Shape:
     Tagged(Payload)
 
 describe("Cycle Collector - Struct Visit Functions (smoke)", ():
-  it("ADT enum with record payload compiles and runs", ():
+  it("should compile and run ADT enum with record payload", ():
     p = Payload(42, "hello")
     s = Shape::Tagged(p)
     c = Shape::Circle(3.14)
@@ -21,7 +21,7 @@ describe("Cycle Collector - Struct Visit Functions (smoke)", ():
     expect(p.name).to_eq("hello")
   )
 
-  it("gc.collect does not crash with record-in-ADT types", ():
+  it("should not crash gc.collect with record-in-ADT types", ():
     enable()
     set_threshold(10000)
     n = collect()

--- a/tests/spec/generic_bounds.test.ry
+++ b/tests/spec/generic_bounds.test.ry
@@ -15,23 +15,23 @@ function count_legs<T: Animal>(a: T) -> int:
   return a.legs
 
 describe("generic record bounds", ():
-  it("accepts subtype", ():
+  it("should accept subtype", ():
     d = Dog("Rex", 4, "Lab")
     expect(get_name(d)).to_eq("Rex")
     expect(count_legs(d)).to_eq(4)
   )
-  it("accepts exact type", ():
+  it("should accept exact type", ():
     a = Animal("Cat", 4)
     expect(get_name(a)).to_eq("Cat")
   )
-  it("accepts deep subtype", ():
+  it("should accept deep subtype", ():
     g = GuideDog("Rex", 4, "Lab", "John")
     expect(get_name(g)).to_eq("Rex")
   )
-  it("works with explicit type arg", ():
+  it("should work with explicit type arg", ():
     expect(get_name[Dog](Dog("Rex", 4, "Lab"))).to_eq("Rex")
   )
-  it("mixed bounded and unbounded params", ():
+  it("should handle mixed bounded and unbounded params", ():
     function pair_name<T: Animal, U>(a: T, x: U) -> str:
       return a.name
     expect(pair_name(Dog("Rex", 4, "Lab"), 42)).to_eq("Rex")

--- a/tests/spec/generic_collection_param.test.ry
+++ b/tests/spec/generic_collection_param.test.ry
@@ -11,19 +11,19 @@ function set_count<T>(s: Set<T>) -> int:
     return 1
 
 describe("generic function with collection params", ():
-  it("List int first item", ():
+  it("should return List int first item", ():
     expect(first_item[int]([10, 20, 30])).to_eq(10)
   )
-  it("List int second item", ():
+  it("should return List int second item", ():
     expect(second_item[int]([10, 20, 30])).to_eq(20)
   )
-  it("List str first item", ():
+  it("should return List str first item", ():
     expect(first_item[str](["hello", "world"])).to_eq("hello")
   )
-  it("List str second item", ():
+  it("should return List str second item", ():
     expect(second_item[str](["hello", "world"])).to_eq("world")
   )
-  it("Set int parameter", ():
+  it("should support Set int parameter", ():
     expect(set_count[int]({1, 2, 3})).to_eq(1)
   )
 )

--- a/tests/spec/generics.test.ry
+++ b/tests/spec/generics.test.ry
@@ -5,35 +5,35 @@ function pick_first<T, U>(a: T, b: U) -> T:
     return a
 
 describe("generic function", ():
-  it("explicit type arg int", ():
+  it("should support explicit type arg int", ():
     expect(identity[int](42)).to_eq(42)
   )
-  it("explicit type arg str", ():
+  it("should support explicit type arg str", ():
     expect(identity[str]("hello")).to_eq("hello")
   )
-  it("explicit type arg bool", ():
+  it("should support explicit type arg bool", ():
     expect(identity[bool](true)).to_be_true()
   )
-  it("type inference int", ():
+  it("should infer type int", ():
     expect(identity(99)).to_eq(99)
   )
-  it("type inference str", ():
+  it("should infer type str", ():
     expect(identity("world")).to_eq("world")
   )
-  it("multiple type params", ():
+  it("should support multiple type params", ():
     expect(pick_first(1, "x")).to_eq(1)
   )
-  it("multiple type params reversed", ():
+  it("should support multiple type params reversed", ():
     expect(pick_first("hello", 42)).to_eq("hello")
   )
-  it("same instantiation reused", ():
+  it("should reuse same instantiation", ():
     expect(identity(10)).to_eq(10)
     expect(identity(20)).to_eq(20)
   )
-  it("explicit type arg float", ():
+  it("should support explicit type arg float", ():
     expect(identity[float](3.14)).to_eq(3.14)
   )
-  it("type inference bool", ():
+  it("should infer type bool", ():
     expect(identity(true)).to_be_true()
   )
 )
@@ -44,27 +44,27 @@ function maybe_none<T>(x: T, flag: bool) -> T?:
     return Some(x)
 
 describe("generic function with optional return", ():
-  it("return none with T=int", ():
+  it("should return none with T=int", ():
     r = maybe_none[int](42, true)
     expect(r).to_be_none()
   )
-  it("return Some with T=int", ():
+  it("should return Some with T=int", ():
     r = maybe_none[int](42, false)
     expect(r).to_be_some()
   )
-  it("return none with T=str", ():
+  it("should return none with T=str", ():
     r = maybe_none[str]("hello", true)
     expect(r).to_be_none()
   )
-  it("return Some with T=str", ():
+  it("should return Some with T=str", ():
     r = maybe_none[str]("hello", false)
     expect(r).to_be_some()
   )
-  it("return none with T=float", ():
+  it("should return none with T=float", ():
     r = maybe_none[float](3.14, true)
     expect(r).to_be_none()
   )
-  it("return none with T=bool", ():
+  it("should return none with T=bool", ():
     r = maybe_none[bool](true, true)
     expect(r).to_be_none()
   )

--- a/tests/spec/http.test.ry
+++ b/tests/spec/http.test.ry
@@ -2,7 +2,7 @@ from net import bind, listen, accept, connect, listener_port
 from io import to_bytes, bytes_to_str
 
 describe("HTTP Server API", ():
-  it("responds with 200 OK for matching path", ():
+  it("should respond with 200 OK for matching path", ():
     async function server_200(server: TcpListener) -> str:
       match accept(server):
         case Ok(conn):
@@ -53,7 +53,7 @@ describe("HTTP Server API", ():
       case Err(e):
         fail("unexpected error")
   )
-  it("responds with 404 Not Found", ():
+  it("should respond with 404 Not Found", ():
     async function server_404(server: TcpListener) -> str:
       match accept(server):
         case Ok(conn):

--- a/tests/spec/http_client.test.ry
+++ b/tests/spec/http_client.test.ry
@@ -20,7 +20,7 @@ describe("HTTP Client", ():
   # - redirect with relative Location path
   # - redirect limit exceeded returns Err
   # - http_get decodes chunked transfer encoding
-  it("http_get returns Err on connection refused", ():
+  it("should return Err on connection refused", ():
     match http_get("http://127.0.0.1:1/nonexistent"):
       case Ok(resp):
         fail("expected Err but got Ok")

--- a/tests/spec/implicit_widening.test.ry
+++ b/tests/spec/implicit_widening.test.ry
@@ -29,18 +29,18 @@ function prefer_widening(x) -> str:
 # --- tests ---
 
 describe("basic implicit widening", ():
-  it("int to float", ():
+  it("should widen int to float", ():
     result = double_float(5)
     expect(result).to_eq(10.0)
   )
 
-  it("u8 to int", ():
+  it("should widen u8 to int", ():
     b: u8 = 200
     result = accept_int(b)
     expect(result).to_eq(200)
   )
 
-  it("u8 to float", ():
+  it("should widen u8 to float", ():
     b: u8 = 42
     result = accept_float(b)
     expect(result).to_eq(42.0)
@@ -48,12 +48,12 @@ describe("basic implicit widening", ():
 )
 
 describe("return value correctness", ():
-  it("int widened to float returns float", ():
+  it("should return float when int widened to float", ():
     result = double_float(5)
     expect(result).to_eq(10.0)
   )
 
-  it("u8 widened to int preserves unsigned value", ():
+  it("should preserve unsigned value when u8 widened to int", ():
     b: u8 = 255
     result = accept_int(b)
     expect(result).to_eq(255)
@@ -61,23 +61,23 @@ describe("return value correctness", ():
 )
 
 describe("overload resolution priority", ():
-  it("exact when wins over widening", ():
+  it("should prefer exact when over widening", ():
     expect(typed(5)).to_eq("int")
     expect(typed(5.0)).to_eq("float")
   )
 
-  it("widening wins over any", ():
+  it("should prefer widening over any", ():
     expect(prefer_widening(5)).to_eq("float")
   )
 )
 
 describe("multi-arg widening", ():
-  it("both args widened", ():
+  it("should widen both args", ():
     result = add_floats(1, 2)
     expect(result).to_eq(3.0)
   )
 
-  it("mixed: one exact, one widened", ():
+  it("should handle mixed: one exact, one widened", ():
     result = add_floats(1, 2.0)
     expect(result).to_eq(3.0)
   )

--- a/tests/spec/inline.test.ry
+++ b/tests/spec/inline.test.ry
@@ -21,19 +21,19 @@ function fact(n: int) -> int:
   return n * fact(n - 1)
 
 describe("@inline directive", ():
-  it("default (always)", ():
+  it("should inline with default (always)", ():
     expect(add(3, 4)).to_eq(7)
   )
-  it("mode=always", ():
+  it("should inline with mode=always", ():
     expect(mul(5, 6)).to_eq(30)
   )
-  it("mode=hint", ():
+  it("should inline with mode=hint", ():
     expect(sub(10, 3)).to_eq(7)
   )
-  it("mode=never", ():
+  it("should respect mode=never", ():
     expect(negate(-5)).to_eq(5)
   )
-  it("recursive", ():
+  it("should inline recursive function", ():
     expect(fact(5)).to_eq(120)
   )
 )

--- a/tests/spec/int_overflow.test.ry
+++ b/tests/spec/int_overflow.test.ry
@@ -1,37 +1,37 @@
 describe("int overflow safety", ():
-  it("normal addition", ():
+  it("should handle normal addition", ():
     expect(100 + 200).to_eq(300)
     expect(-50 + 50).to_eq(0)
     expect(0 + 0).to_eq(0)
   )
-  it("normal subtraction", ():
+  it("should handle normal subtraction", ():
     expect(200 - 100).to_eq(100)
     expect(50 - 100).to_eq(-50)
     expect(0 - 0).to_eq(0)
   )
-  it("normal multiplication", ():
+  it("should handle normal multiplication", ():
     expect(1000000 * 1000000).to_eq(1000000000000)
     expect(-5 * 7).to_eq(-35)
     expect(0 * 9223372036854775807).to_eq(0)
   )
-  it("normal negation", ():
+  it("should handle normal negation", ():
     expect(-42).to_eq(-42)
     expect(-(-42)).to_eq(42)
     expect(-0).to_eq(0)
   )
-  it("large values within range", ():
+  it("should handle large values within range", ():
     max = 9223372036854775807
     expect(max + 0).to_eq(9223372036854775807)
     expect(max - max).to_eq(0)
     expect(max * 1).to_eq(9223372036854775807)
   )
-  it("INT64_MIN via subtraction", ():
+  it("should handle INT64_MIN via subtraction", ():
     min = -9223372036854775807 - 1
     expect(min + 0).to_eq(-9223372036854775807 - 1)
     expect(min * 1).to_eq(-9223372036854775807 - 1)
     expect(min - 0).to_eq(-9223372036854775807 - 1)
   )
-  it("compound assignment no overflow", ():
+  it("should handle compound assignment without overflow", ():
     x = 100
     x += 200
     expect(x).to_eq(300)

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -1,7 +1,7 @@
 from io import read_text, write_text, append_text, exists, delete_file, read_bytes, write_bytes, to_bytes, bytes_to_str
 
 describe("file I/O", ():
-  it("write and read text", ():
+  it("should write and read text", ():
     match write_text("/tmp/ry_selftest_io.txt", "hello world"):
       case Ok(_):
         match read_text("/tmp/ry_selftest_io.txt"):
@@ -17,7 +17,7 @@ describe("file I/O", ():
       case Err(e):
         fail("unexpected error")
   )
-  it("append text", ():
+  it("should append text", ():
     match write_text("/tmp/ry_selftest_io_append.txt", "hello"):
       case Ok(_):
         expect(true).to_eq(true)
@@ -39,7 +39,7 @@ describe("file I/O", ():
       case Err(e):
         fail("unexpected error")
   )
-  it("exists", ():
+  it("should check exists", ():
     match write_text("/tmp/ry_selftest_io_exists.txt", "test"):
       case Ok(_):
         expect(true).to_eq(true)
@@ -53,7 +53,7 @@ describe("file I/O", ():
         fail("unexpected error")
     expect(exists("/tmp/ry_selftest_io_exists.txt")).to_eq(false)
   )
-  it("byte conversions", ():
+  it("should handle byte conversions", ():
     bs = to_bytes("ABC")
     expect(length(bs)).to_eq(3)
     match bytes_to_str(bs):
@@ -62,7 +62,7 @@ describe("file I/O", ():
       case Err(e):
         fail("unexpected error")
   )
-  it("read/write bytes", ():
+  it("should read/write bytes", ():
     data = to_bytes("binary test")
     match write_bytes("/tmp/ry_selftest_io_bytes.bin", data):
       case Ok(_):
@@ -85,16 +85,16 @@ describe("file I/O", ():
       case Err(e):
         fail("unexpected error")
   )
-  it("read_text returns Err for missing file", ():
+  it("should return Err from read_text for missing file", ():
     expect(read_text("/tmp/ry_selftest_nonexistent_file.txt")).to_be_err()
   )
-  it("read_bytes returns Err for missing file", ():
+  it("should return Err from read_bytes for missing file", ():
     expect(read_bytes("/tmp/ry_selftest_nonexistent_bytes.bin")).to_be_err()
   )
-  it("delete_file returns Err for missing file", ():
+  it("should return Err from delete_file for missing file", ():
     expect(delete_file("/tmp/ry_selftest_nonexistent_delete.txt")).to_be_err()
   )
-  it("write and read empty file", ():
+  it("should write and read empty file", ():
     match write_text("/tmp/ry_selftest_io_empty.txt", ""):
       case Ok(_):
         match read_text("/tmp/ry_selftest_io_empty.txt"):
@@ -106,7 +106,7 @@ describe("file I/O", ():
         fail("unexpected write error")
     delete_file("/tmp/ry_selftest_io_empty.txt")
   )
-  it("write and read empty bytes", ():
+  it("should write and read empty bytes", ():
     data = to_bytes("")
     match write_bytes("/tmp/ry_selftest_io_empty.bin", data):
       case Ok(_):
@@ -119,10 +119,10 @@ describe("file I/O", ():
         fail("unexpected write error")
     delete_file("/tmp/ry_selftest_io_empty.bin")
   )
-  it("exists returns false for missing file", ():
+  it("should return false from exists for missing file", ():
     expect(exists("/tmp/ry_selftest_nonexistent_exists.txt")).to_eq(false)
   )
-  it("overwrite existing file", ():
+  it("should overwrite existing file", ():
     write_text("/tmp/ry_selftest_io_overwrite.txt", "first")
     write_text("/tmp/ry_selftest_io_overwrite.txt", "second")
     match read_text("/tmp/ry_selftest_io_overwrite.txt"):

--- a/tests/spec/iterator.test.ry
+++ b/tests/spec/iterator.test.ry
@@ -1,5 +1,5 @@
 describe("Iterator", ():
-  it("iter and to_list on list", ():
+  it("should iter and to_list on list", ():
     xs = [1, 2, 3]
     ys = to_list(iter(xs))
     expect(ys).to_have_length(3)
@@ -7,13 +7,13 @@ describe("Iterator", ():
     expect(ys[1]).to_eq(2)
     expect(ys[2]).to_eq(3)
   )
-  it("iter on empty list", ():
+  it("should iter on empty list", ():
     xs = [1]
     empty = filter(xs, (x: int) => x > 10)
     ys = to_list(iter(empty))
     expect(ys).to_have_length(0)
   )
-  it("lazy filter", ():
+  it("should support lazy filter", ():
     xs = [1, 2, 3, 4, 5]
     ys = to_list(filter(iter(xs), (x: int) => x > 2))
     expect(ys).to_have_length(3)
@@ -21,7 +21,7 @@ describe("Iterator", ():
     expect(ys[1]).to_eq(4)
     expect(ys[2]).to_eq(5)
   )
-  it("lazy map", ():
+  it("should support lazy map", ():
     xs = [1, 2, 3]
     ys = to_list(map(iter(xs), (x: int) => x * 10))
     expect(ys).to_have_length(3)
@@ -29,7 +29,7 @@ describe("Iterator", ():
     expect(ys[1]).to_eq(20)
     expect(ys[2]).to_eq(30)
   )
-  it("lazy take", ():
+  it("should support lazy take", ():
     xs = [1, 2, 3, 4, 5]
     ys = to_list(take(iter(xs), 3))
     expect(ys).to_have_length(3)
@@ -37,40 +37,40 @@ describe("Iterator", ():
     expect(ys[1]).to_eq(2)
     expect(ys[2]).to_eq(3)
   )
-  it("chained filter map take", ():
+  it("should support chained filter map take", ():
     xs = [1, 2, 3, 4, 5]
     ys = to_list(take(map(filter(iter(xs), (x: int) => x > 2), (x: int) => x * 2), 2))
     expect(ys).to_have_length(2)
     expect(ys[0]).to_eq(6)
     expect(ys[1]).to_eq(8)
   )
-  it("take 0", ():
+  it("should take 0 elements", ():
     xs = [1, 2, 3]
     ys = to_list(take(iter(xs), 0))
     expect(ys).to_have_length(0)
   )
-  it("take more than length", ():
+  it("should take up to available length when take exceeds length", ():
     xs = [1, 2, 3]
     ys = to_list(take(iter(xs), 10))
     expect(ys).to_have_length(3)
     expect(ys[0]).to_eq(1)
     expect(ys[2]).to_eq(3)
   )
-  it("for loop over iterator", ():
+  it("should support for loop over iterator", ():
     xs = [10, 20, 30]
     sum = 0
     for x in iter(xs):
       sum = sum + x
     expect(sum).to_eq(60)
   )
-  it("for loop with filter", ():
+  it("should support for loop with filter", ():
     xs = [1, 2, 3, 4, 5]
     sum = 0
     for x in filter(iter(xs), (x: int) => x > 3):
       sum = sum + x
     expect(sum).to_eq(9)
   )
-  it("next returns Option", ():
+  it("should return Option from next", ():
     xs = [10, 20]
     it = iter(xs)
     a = next(it)
@@ -80,31 +80,31 @@ describe("Iterator", ():
     c = next(it)
     expect(c).to_be_none()
   )
-  it("iter on set", ():
+  it("should iter on set", ():
     s = {1, 2, 3}
     ys = to_list(iter(s))
     expect(ys).to_have_length(3)
   )
-  it("iter on map", ():
+  it("should iter on map", ():
     m = {"a": 1, "b": 2}
     count = 0
     for k, v in iter(m):
       count = count + 1
     expect(count).to_eq(2)
   )
-  it("UFCS iter", ():
+  it("should support UFCS iter", ():
     xs = [1, 2, 3]
     ys = to_list(iter(xs))
     expect(ys).to_have_length(3)
     expect(ys[0]).to_eq(1)
   )
-  it("filter empty iterator", ():
+  it("should filter empty iterator", ():
     xs = [1]
     empty = filter(xs, (x: int) => x > 10)
     ys = to_list(filter(iter(empty), (x: int) => true))
     expect(ys).to_have_length(0)
   )
-  it("map empty iterator", ():
+  it("should map empty iterator", ():
     xs = [1]
     empty = filter(xs, (x: int) => x > 10)
     ys = to_list(map(iter(empty), (x: int) => x * 2))

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -2,7 +2,7 @@ from json import parse, stringify, kind, get, at, to_str, to_int, to_float, to_b
 from str import contains
 
 describe("json parse", ():
-  it("parses an object", ():
+  it("should parse an object", ():
     match parse("{\"name\": \"Alice\", \"age\": 30}"):
       case Ok(data):
         expect(kind(data)).to_eq("object")
@@ -11,7 +11,7 @@ describe("json parse", ():
         fail("parse failed: " + e.message)
   )
 
-  it("parses an array", ():
+  it("should parse an array", ():
     match parse("[1, 2, 3]"):
       case Ok(data):
         expect(kind(data)).to_eq("array")
@@ -21,17 +21,17 @@ describe("json parse", ():
         fail("parse failed: " + e.message)
   )
 
-  it("returns Err for invalid JSON", ():
+  it("should return Err for invalid JSON", ():
     expect(parse("{invalid}")).to_be_err()
   )
 
-  it("returns Err for trailing content", ():
+  it("should return Err for trailing content", ():
     expect(parse("123 456")).to_be_err()
   )
 )
 
 describe("json access", ():
-  it("gets string field", ():
+  it("should get string field", ():
     match parse("{\"name\": \"Alice\"}"):
       case Ok(data):
         match get(data, "name"):
@@ -48,7 +48,7 @@ describe("json access", ():
         fail("parse failed")
   )
 
-  it("gets int field", ():
+  it("should get int field", ():
     match parse("{\"age\": 30}"):
       case Ok(data):
         match get(data, "age"):
@@ -65,7 +65,7 @@ describe("json access", ():
         fail("parse failed")
   )
 
-  it("gets float field", ():
+  it("should get float field", ():
     match parse("{\"pi\": 3.14}"):
       case Ok(data):
         match get(data, "pi"):
@@ -83,7 +83,7 @@ describe("json access", ():
         fail("parse failed")
   )
 
-  it("gets bool field", ():
+  it("should get bool field", ():
     match parse("{\"active\": true}"):
       case Ok(data):
         match get(data, "active"):
@@ -100,7 +100,7 @@ describe("json access", ():
         fail("parse failed")
   )
 
-  it("gets null type", ():
+  it("should get null type", ():
     match parse("{\"value\": null}"):
       case Ok(data):
         match get(data, "value"):
@@ -113,7 +113,7 @@ describe("json access", ():
         fail("parse failed")
   )
 
-  it("accesses array by index", ():
+  it("should access array by index", ():
     match parse("[10, 20, 30]"):
       case Ok(data):
         match at(data, 0):
@@ -139,7 +139,7 @@ describe("json access", ():
         fail("parse failed")
   )
 
-  it("returns Err for missing key", ():
+  it("should return Err for missing key", ():
     match parse("{\"a\": 1}"):
       case Ok(data):
         expect(get(data, "missing")).to_be_err()
@@ -148,7 +148,7 @@ describe("json access", ():
         fail("parse failed")
   )
 
-  it("returns Err for out-of-bounds index", ():
+  it("should return Err for out-of-bounds index", ():
     match parse("[1, 2]"):
       case Ok(data):
         expect(at(data, 5)).to_be_err()
@@ -157,7 +157,7 @@ describe("json access", ():
         fail("parse failed")
   )
 
-  it("returns Err for type mismatch", ():
+  it("should return Err for type mismatch", ():
     match parse("{\"name\": \"Alice\"}"):
       case Ok(data):
         match get(data, "name"):
@@ -172,7 +172,7 @@ describe("json access", ():
 )
 
 describe("json nested", ():
-  it("accesses nested objects", ():
+  it("should access nested objects", ():
     match parse("{\"user\": {\"name\": \"Bob\", \"age\": 25}}"):
       case Ok(data):
         match get(data, "user"):
@@ -202,7 +202,7 @@ describe("json nested", ():
         fail("parse failed")
   )
 
-  it("accesses array of objects", ():
+  it("should access array of objects", ():
     match parse("[{\"id\": 1}, {\"id\": 2}]"):
       case Ok(data):
         match at(data, 1):
@@ -225,7 +225,7 @@ describe("json nested", ():
 )
 
 describe("json keys and len", ():
-  it("gets object keys", ():
+  it("should get object keys", ():
     match parse("{\"a\": 1, \"b\": 2}"):
       case Ok(data):
         match keys(data):
@@ -240,7 +240,7 @@ describe("json keys and len", ():
         fail("parse failed")
   )
 
-  it("returns Err for non-object keys", ():
+  it("should return Err for non-object keys", ():
     match parse("[1, 2, 3]"):
       case Ok(data):
         match keys(data):
@@ -253,7 +253,7 @@ describe("json keys and len", ():
         fail("parse failed")
   )
 
-  it("gets object len", ():
+  it("should get object len", ():
     match parse("{\"x\": 1, \"y\": 2, \"z\": 3}"):
       case Ok(data):
         expect(length(data)).to_eq(3)
@@ -264,7 +264,7 @@ describe("json keys and len", ():
 )
 
 describe("json stringify", ():
-  it("round-trips an object", ():
+  it("should round-trip an object", ():
     match parse("{\"name\":\"Alice\",\"age\":30}"):
       case Ok(data):
         text = stringify(data)
@@ -287,7 +287,7 @@ describe("json stringify", ():
         fail("parse failed")
   )
 
-  it("pretty prints with indent", ():
+  it("should pretty print with indent", ():
     match parse("{\"a\":1}"):
       case Ok(data):
         text = stringify(data, 2)
@@ -299,7 +299,7 @@ describe("json stringify", ():
 )
 
 describe("json child value ownership", ():
-  it("get() child does not cause double-free on scope exit", ():
+  it("should not cause double-free on scope exit for get() child", ():
     match parse("{\"name\": \"Alice\", \"age\": 30}"):
       case Ok(data):
         match get(data, "name"):
@@ -316,7 +316,7 @@ describe("json child value ownership", ():
         fail("parse failed")
   )
 
-  it("at() child does not cause double-free on scope exit", ():
+  it("should not cause double-free on scope exit for at() child", ():
     match parse("[\"hello\", \"world\"]"):
       case Ok(data):
         match at(data, 0):
@@ -333,7 +333,7 @@ describe("json child value ownership", ():
         fail("parse failed")
   )
 
-  it("nested get() children do not cause double-free on scope exit", ():
+  it("should not cause double-free on scope exit for nested get() children", ():
     match parse("{\"user\": {\"name\": \"Bob\"}}"):
       case Ok(data):
         match get(data, "user"):
@@ -356,7 +356,7 @@ describe("json child value ownership", ():
 )
 
 describe("json type checks", ():
-  it("identifies string type", ():
+  it("should identify string type", ():
     match parse("\"hello\""):
       case Ok(data):
         expect(kind(data)).to_eq("string")
@@ -365,7 +365,7 @@ describe("json type checks", ():
         fail("parse failed")
   )
 
-  it("identifies number type", ():
+  it("should identify number type", ():
     match parse("42"):
       case Ok(data):
         expect(kind(data)).to_eq("number")
@@ -374,7 +374,7 @@ describe("json type checks", ():
         fail("parse failed")
   )
 
-  it("identifies boolean type", ():
+  it("should identify boolean type", ():
     match parse("true"):
       case Ok(data):
         expect(kind(data)).to_eq("boolean")
@@ -383,7 +383,7 @@ describe("json type checks", ():
         fail("parse failed")
   )
 
-  it("identifies null type", ():
+  it("should identify null type", ():
     match parse("null"):
       case Ok(data):
         expect(kind(data)).to_eq("null")

--- a/tests/spec/leading_dot_float.test.ry
+++ b/tests/spec/leading_dot_float.test.ry
@@ -1,13 +1,13 @@
 describe("leading-dot float literals", ():
-  it(".5 equals 0.5", ():
+  it("should treat .5 as 0.5", ():
     x = .5
     expect(x).to_eq(0.5)
   )
-  it(".01 equals 0.01", ():
+  it("should treat .01 as 0.01", ():
     x = .01
     expect(x).to_eq(0.01)
   )
-  it("arithmetic with leading-dot floats", ():
+  it("should compute arithmetic with leading-dot floats", ():
     x = .5 + .25
     expect(x).to_eq(0.75)
   )

--- a/tests/spec/low_level_types.test.ry
+++ b/tests/spec/low_level_types.test.ry
@@ -1,63 +1,63 @@
 describe("i32 type", ():
-  it("declaration with annotation", ():
+  it("should support declaration with annotation", ():
     x: i32 = 42
     expect(x as int).to_eq(42)
   )
-  it("negative value", ():
+  it("should handle negative value", ():
     x: i32 = -10
     expect(x as int).to_eq(-10)
   )
-  it("zero", ():
+  it("should handle zero", ():
     x: i32 = 0
     expect(x as int).to_eq(0)
   )
-  it("addition", ():
+  it("should add", ():
     a: i32 = 10
     b: i32 = 20
     c = a + b
     expect(c as int).to_eq(30)
   )
-  it("subtraction", ():
+  it("should subtract", ():
     a: i32 = 50
     b: i32 = 20
     c = a - b
     expect(c as int).to_eq(30)
   )
-  it("multiplication", ():
+  it("should multiply", ():
     a: i32 = 3
     b: i32 = 4
     c = a * b
     expect(c as int).to_eq(12)
   )
-  it("integer division", ():
+  it("should perform integer division", ():
     a: i32 = 7
     b: i32 = 2
     c = a / b
     expect(c as int).to_eq(3)
   )
-  it("floor division", ():
+  it("should perform floor division", ():
     a: i32 = 7
     b: i32 = 2
     c = a // b
     expect(c as int).to_eq(3)
   )
-  it("modulo", ():
+  it("should compute modulo", ():
     a: i32 = 10
     b: i32 = 3
     c = a % b
     expect(c as int).to_eq(1)
   )
-  it("comparison equal", ():
+  it("should check comparison equal", ():
     a: i32 = 10
     b: i32 = 10
     expect(a == b).to_be_true()
   )
-  it("comparison less than", ():
+  it("should check comparison less than", ():
     a: i32 = 5
     b: i32 = 10
     expect(a < b).to_be_true()
   )
-  it("comparison greater than", ():
+  it("should check comparison greater than", ():
     a: i32 = 10
     b: i32 = 5
     expect(a > b).to_be_true()
@@ -65,21 +65,21 @@ describe("i32 type", ():
 )
 
 describe("i16 type", ():
-  it("declaration with annotation", ():
+  it("should support declaration with annotation", ():
     x: i16 = 100
     expect(x as int).to_eq(100)
   )
-  it("negative value", ():
+  it("should handle negative value", ():
     x: i16 = -100
     expect(x as int).to_eq(-100)
   )
-  it("addition", ():
+  it("should add", ():
     a: i16 = 10
     b: i16 = 20
     c = a + b
     expect(c as int).to_eq(30)
   )
-  it("comparison", ():
+  it("should check comparison", ():
     a: i16 = 5
     b: i16 = 10
     expect(a < b).to_be_true()
@@ -87,36 +87,36 @@ describe("i16 type", ():
 )
 
 describe("f32 type", ():
-  it("declaration with annotation", ():
+  it("should support declaration with annotation", ():
     x: f32 = 3.14
     expect(x as float > 3.13).to_be_true()
     expect(x as float < 3.15).to_be_true()
   )
-  it("addition", ():
+  it("should add", ():
     a: f32 = 1.5
     b: f32 = 2.5
     c = a + b
     expect(c as float).to_eq(4.0)
   )
-  it("subtraction", ():
+  it("should subtract", ():
     a: f32 = 5.0
     b: f32 = 2.0
     c = a - b
     expect(c as float).to_eq(3.0)
   )
-  it("multiplication", ():
+  it("should multiply", ():
     a: f32 = 3.0
     b: f32 = 4.0
     c = a * b
     expect(c as float).to_eq(12.0)
   )
-  it("division", ():
+  it("should divide", ():
     a: f32 = 7.0
     b: f32 = 2.0
     c = a / b
     expect(c as float).to_eq(3.5)
   )
-  it("comparison", ():
+  it("should check comparison", ():
     a: f32 = 1.0
     b: f32 = 2.0
     expect(a < b).to_be_true()
@@ -124,44 +124,44 @@ describe("f32 type", ():
 )
 
 describe("as cast with low-level types", ():
-  it("i32 to int", ():
+  it("should cast i32 to int", ():
     x: i32 = 42
     expect(x as int).to_eq(42)
   )
-  it("int to i32", ():
+  it("should cast int to i32", ():
     x = 42
     y = x as i32
     expect(y as int).to_eq(42)
   )
-  it("i32 to i16", ():
+  it("should cast i32 to i16", ():
     x: i32 = 100
     y = x as i16
     expect(y as int).to_eq(100)
   )
-  it("i16 to i32", ():
+  it("should cast i16 to i32", ():
     x: i16 = 100
     y = x as i32
     expect(y as int).to_eq(100)
   )
-  it("i32 to float", ():
+  it("should cast i32 to float", ():
     x: i32 = 42
     expect(x as float).to_eq(42.0)
   )
-  it("float to f32", ():
+  it("should cast float to f32", ():
     x = 3.14
     y = x as f32
     expect(y as float > 3.13).to_be_true()
   )
-  it("f32 to float", ():
+  it("should cast f32 to float", ():
     x: f32 = 2.5
     expect(x as float).to_eq(2.5)
   )
-  it("i32 to f32", ():
+  it("should cast i32 to f32", ():
     x: i32 = 42
     y = x as f32
     expect(y as float).to_eq(42.0)
   )
-  it("f32 to i32", ():
+  it("should cast f32 to i32", ():
     x: f32 = 3.14
     y = x as i32
     expect(y as int).to_eq(3)
@@ -169,32 +169,32 @@ describe("as cast with low-level types", ():
 )
 
 describe("low-level type inference and propagation", ():
-  it("i32 arithmetic result infers as i32", ():
+  it("should infer i32 for i32 arithmetic result", ():
     a: i32 = 10
     b: i32 = 20
     c = a + b
     expect(c as int).to_eq(30)
   )
-  it("inferred i32 can be reassigned with i32 expression", ():
+  it("should allow inferred i32 to be reassigned with i32 expression", ():
     a: i32 = 10
     b: i32 = 20
     c = a + b
     c = a * b
     expect(c as int).to_eq(200)
   )
-  it("i16 arithmetic result infers as i16", ():
+  it("should infer i16 for i16 arithmetic result", ():
     a: i16 = 3
     b: i16 = 7
     c = a + b
     expect(c as int).to_eq(10)
   )
-  it("f32 arithmetic result infers as f32", ():
+  it("should infer f32 for f32 arithmetic result", ():
     a: f32 = 1.5
     b: f32 = 2.5
     c = a + b
     expect(c as float).to_eq(4.0)
   )
-  it("chained i32 operations preserve type", ():
+  it("should preserve type for chained i32 operations", ():
     a: i32 = 2
     b: i32 = 3
     c = a + b
@@ -204,17 +204,17 @@ describe("low-level type inference and propagation", ():
 )
 
 describe("low-level type print", ():
-  it("print i32", ():
+  it("should print i32", ():
     x: i32 = 42
     s = x as str
     expect(s).to_eq("42")
   )
-  it("print i16", ():
+  it("should print i16", ():
     x: i16 = 100
     s = x as str
     expect(s).to_eq("100")
   )
-  it("print f32", ():
+  it("should print f32", ():
     x: f32 = 2.5
     s = x as str
     expect(s).to_eq("2.5")
@@ -224,32 +224,32 @@ describe("low-level type print", ():
 # ===== Phase 2: i8, i64, u8, u16, u32, u64 =====
 
 describe("i8 type", ():
-  it("declaration with annotation", ():
+  it("should support declaration with annotation", ():
     x: i8 = 42
     expect(x as int).to_eq(42)
   )
-  it("negative value", ():
+  it("should handle negative value", ():
     x: i8 = -10
     expect(x as int).to_eq(-10)
   )
-  it("addition", ():
+  it("should add", ():
     a: i8 = 10
     b: i8 = 20
     c = a + b
     expect(c as int).to_eq(30)
   )
-  it("signed division", ():
+  it("should perform signed division", ():
     a: i8 = -7
     b: i8 = 2
     c = a / b
     expect(c as int).to_eq(-3)
   )
-  it("signed comparison", ():
+  it("should perform signed comparison", ():
     a: i8 = -1
     b: i8 = 1
     expect(a < b).to_be_true()
   )
-  it("string conversion", ():
+  it("should convert to string", ():
     x: i8 = -5
     s = x as str
     expect(s).to_eq("-5")
@@ -257,27 +257,27 @@ describe("i8 type", ():
 )
 
 describe("i64 type", ():
-  it("declaration with annotation", ():
+  it("should support declaration with annotation", ():
     x: i64 = 100000
     expect(x as int).to_eq(100000)
   )
-  it("negative value", ():
+  it("should handle negative value", ():
     x: i64 = -100000
     expect(x as int).to_eq(-100000)
   )
-  it("addition", ():
+  it("should add", ():
     a: i64 = 1000
     b: i64 = 2000
     c = a + b
     expect(c as int).to_eq(3000)
   )
-  it("signed division", ():
+  it("should perform signed division", ():
     a: i64 = -7
     b: i64 = 2
     c = a / b
     expect(c as int).to_eq(-3)
   )
-  it("string conversion", ():
+  it("should convert to string", ():
     x: i64 = -999
     s = x as str
     expect(s).to_eq("-999")
@@ -285,28 +285,28 @@ describe("i64 type", ():
 )
 
 describe("u8 type", ():
-  it("declaration with annotation", ():
+  it("should support declaration with annotation", ():
     x: u8 = 200
     expect(x as int).to_eq(200)
   )
-  it("addition", ():
+  it("should add", ():
     a: u8 = 100
     b: u8 = 50
     c = a + b
     expect(c as int).to_eq(150)
   )
-  it("unsigned division", ():
+  it("should perform unsigned division", ():
     a: u8 = 200
     b: u8 = 3
     c = a / b
     expect(c as int).to_eq(66)
   )
-  it("unsigned comparison", ():
+  it("should perform unsigned comparison", ():
     a: u8 = 200
     b: u8 = 100
     expect(a > b).to_be_true()
   )
-  it("string conversion", ():
+  it("should convert to string", ():
     x: u8 = 255
     s = x as str
     expect(s).to_eq("255")
@@ -314,28 +314,28 @@ describe("u8 type", ():
 )
 
 describe("u16 type", ():
-  it("declaration with annotation", ():
+  it("should support declaration with annotation", ():
     x: u16 = 60000
     expect(x as int).to_eq(60000)
   )
-  it("addition", ():
+  it("should add", ():
     a: u16 = 10000
     b: u16 = 20000
     c = a + b
     expect(c as int).to_eq(30000)
   )
-  it("unsigned division", ():
+  it("should perform unsigned division", ():
     a: u16 = 50000
     b: u16 = 3
     c = a / b
     expect(c as int).to_eq(16666)
   )
-  it("unsigned comparison", ():
+  it("should perform unsigned comparison", ():
     a: u16 = 60000
     b: u16 = 30000
     expect(a > b).to_be_true()
   )
-  it("string conversion", ():
+  it("should convert to string", ():
     x: u16 = 65535
     s = x as str
     expect(s).to_eq("65535")
@@ -343,28 +343,28 @@ describe("u16 type", ():
 )
 
 describe("u32 type", ():
-  it("declaration with annotation", ():
+  it("should support declaration with annotation", ():
     x: u32 = 3000000000
     expect(x as int).to_eq(3000000000)
   )
-  it("addition", ():
+  it("should add", ():
     a: u32 = 1000000
     b: u32 = 2000000
     c = a + b
     expect(c as int).to_eq(3000000)
   )
-  it("unsigned division", ():
+  it("should perform unsigned division", ():
     a: u32 = 3000000000
     b: u32 = 7
     c = a / b
     expect(c as int).to_eq(428571428)
   )
-  it("unsigned comparison", ():
+  it("should perform unsigned comparison", ():
     a: u32 = 3000000000
     b: u32 = 1000000000
     expect(a > b).to_be_true()
   )
-  it("string conversion", ():
+  it("should convert to string", ():
     x: u32 = 4000000000
     s = x as str
     expect(s).to_eq("4000000000")
@@ -372,23 +372,23 @@ describe("u32 type", ():
 )
 
 describe("u64 type", ():
-  it("declaration with annotation", ():
+  it("should support declaration with annotation", ():
     x: u64 = 1000000
     expect(x as int).to_eq(1000000)
   )
-  it("addition", ():
+  it("should add", ():
     a: u64 = 100000
     b: u64 = 200000
     c = a + b
     expect(c as int).to_eq(300000)
   )
-  it("unsigned division", ():
+  it("should perform unsigned division", ():
     a: u64 = 1000000
     b: u64 = 3
     c = a / b
     expect(c as int).to_eq(333333)
   )
-  it("string conversion", ():
+  it("should convert to string", ():
     x: u64 = 999999
     s = x as str
     expect(s).to_eq("999999")
@@ -396,51 +396,51 @@ describe("u64 type", ():
 )
 
 describe("Phase 2 casts", ():
-  it("int to i8", ():
+  it("should cast int to i8", ():
     x = 42
     y = x as i8
     expect(y as int).to_eq(42)
   )
-  it("int to i64", ():
+  it("should cast int to i64", ():
     x = 42
     y = x as i64
     expect(y as int).to_eq(42)
   )
-  it("int to u8", ():
+  it("should cast int to u8", ():
     x = 200
     y = x as u8
     expect(y as int).to_eq(200)
   )
-  it("int to u16", ():
+  it("should cast int to u16", ():
     x = 60000
     y = x as u16
     expect(y as int).to_eq(60000)
   )
-  it("int to u32", ():
+  it("should cast int to u32", ():
     x = 3000000000
     y = x as u32
     expect(y as int).to_eq(3000000000)
   )
-  it("int to u64", ():
+  it("should cast int to u64", ():
     x = 42
     y = x as u64
     expect(y as int).to_eq(42)
   )
-  it("u32 to float", ():
+  it("should cast u32 to float", ():
     x: u32 = 42
     expect(x as float).to_eq(42.0)
   )
-  it("u8 to u32", ():
+  it("should cast u8 to u32", ():
     x: u8 = 200
     y = x as u32
     expect(y as int).to_eq(200)
   )
-  it("u32 to u8 (truncation)", ():
+  it("should truncate u32 to u8", ():
     x: u32 = 300
     y = x as u8
     expect(y as int).to_eq(44)
   )
-  it("i32 to u32", ():
+  it("should cast i32 to u32", ():
     x: i32 = 42
     y = x as u32
     expect(y as int).to_eq(42)
@@ -451,7 +451,7 @@ describe("Phase 2 function with low-level params", ():
   function add_u32(a: u32, b: u32) -> u32:
     return a + b
 
-  it("function with u32 params and return", ():
+  it("should work with function with u32 params and return", ():
     x: u32 = 100
     y: u32 = 200
     z = add_u32(x, y)
@@ -462,7 +462,7 @@ describe("Phase 2 function with low-level params", ():
     zero: i8 = 0
     return zero - x
 
-  it("function with i8 params and return", ():
+  it("should work with function with i8 params and return", ():
     x: i8 = 5
     y = negate_i8(x)
     expect(y as int).to_eq(-5)

--- a/tests/spec/map_chained_index.test.ry
+++ b/tests/spec/map_chained_index.test.ry
@@ -1,28 +1,28 @@
 describe("chained Map index access", ():
-  it("nested map with annotation", ():
+  it("should support nested map with annotation", ():
     m: Map<str, Map<str, int>> = {"a": {"b": 42}}
     expect(m["a"]["b"]).to_eq(42)
   )
 
-  it("intermediate variable", ():
+  it("should support intermediate variable", ():
     m: Map<str, Map<str, int>> = {"x": {"y": 99}}
     inner = m["x"]
     expect(inner["y"]).to_eq(99)
   )
 
-  it("nested map literal without annotation", ():
+  it("should support nested map literal without annotation", ():
     m = {"a": {"b": 7}}
     expect(m["a"]["b"]).to_eq(7)
   )
 
-  it("three-level nesting", ():
+  it("should support three-level nesting", ():
     m: Map<str, Map<str, Map<str, int>>> = {"a": {"b": {"c": 5}}}
     expect(m["a"]["b"]["c"]).to_eq(5)
   )
 )
 
 describe("Map with collection values", ():
-  it("Map<str, List<int>> chained access", ():
+  it("should support Map<str, List<int>> chained access", ():
     m: Map<str, List<int>> = {"nums": [10, 20, 30]}
     expect(m["nums"][1]).to_eq(20)
   )

--- a/tests/spec/matchers.test.ry
+++ b/tests/spec/matchers.test.ry
@@ -1,108 +1,108 @@
 describe("Numeric comparison matchers", ():
-  it("to_be_greater_than with int", ():
+  it("should pass to_be_greater_than with int", ():
     expect(5).to_be_greater_than(3)
     expect(10).to_be_greater_than(0)
   )
-  it("to_be_less_than with int", ():
+  it("should pass to_be_less_than with int", ():
     expect(3).to_be_less_than(5)
     expect(-1).to_be_less_than(0)
   )
-  it("to_be_greater_than_or_eq with int", ():
+  it("should pass to_be_greater_than_or_eq with int", ():
     expect(5).to_be_greater_than_or_eq(5)
     expect(6).to_be_greater_than_or_eq(5)
   )
-  it("to_be_less_than_or_eq with int", ():
+  it("should pass to_be_less_than_or_eq with int", ():
     expect(5).to_be_less_than_or_eq(5)
     expect(4).to_be_less_than_or_eq(5)
   )
-  it("to_be_greater_than with float", ():
+  it("should pass to_be_greater_than with float", ():
     expect(3.14).to_be_greater_than(2.71)
   )
-  it("to_be_less_than with float", ():
+  it("should pass to_be_less_than with float", ():
     expect(2.71).to_be_less_than(3.14)
   )
-  it("to_be_greater_than_or_eq with float", ():
+  it("should pass to_be_greater_than_or_eq with float", ():
     expect(3.14).to_be_greater_than_or_eq(3.14)
     expect(3.15).to_be_greater_than_or_eq(3.14)
   )
-  it("to_be_less_than_or_eq with float", ():
+  it("should pass to_be_less_than_or_eq with float", ():
     expect(3.14).to_be_less_than_or_eq(3.14)
     expect(3.13).to_be_less_than_or_eq(3.14)
   )
-  it("mixed int/float comparison", ():
+  it("should handle mixed int/float comparison", ():
     expect(5).to_be_greater_than(3.5)
     expect(2.5).to_be_less_than(3)
   )
 )
 
 describe("Length and empty matchers", ():
-  it("to_have_length with list", ():
+  it("should pass to_have_length with list", ():
     xs = [1, 2, 3]
     expect(xs).to_have_length(3)
   )
-  it("to_have_length with set", ():
+  it("should pass to_have_length with set", ():
     s = {1, 2, 3}
     expect(s).to_have_length(3)
   )
-  it("to_have_length with map", ():
+  it("should pass to_have_length with map", ():
     m = {"a": 1, "b": 2}
     expect(m).to_have_length(2)
   )
-  it("to_have_length with str", ():
+  it("should pass to_have_length with str", ():
     expect("hello").to_have_length(5)
   )
-  it("to_be_empty with empty list", ():
+  it("should pass to_be_empty with empty list", ():
     xs: List<int> = [1]
     ys = filter(xs, (x: int) => x > 10)
     expect(ys).to_be_empty()
   )
-  it("to_be_empty with empty string", ():
+  it("should pass to_be_empty with empty string", ():
     expect("").to_be_empty()
   )
 )
 
 describe("Containment matchers", ():
-  it("to_not_contain with list", ():
+  it("should pass to_not_contain with list", ():
     xs = [1, 2, 3]
     expect(xs).to_not_contain(4)
   )
-  it("to_not_contain with set", ():
+  it("should pass to_not_contain with set", ():
     s = {1, 2, 3}
     expect(s).to_not_contain(4)
   )
-  it("to_not_contain with string", ():
+  it("should pass to_not_contain with string", ():
     expect("hello").to_not_contain("xyz")
   )
-  it("to_contain with map key", ():
+  it("should pass to_contain with map key", ():
     m = {"a": 1, "b": 2}
     expect(m).to_contain("a")
     expect(m).to_contain("b")
   )
-  it("to_not_contain with map key", ():
+  it("should pass to_not_contain with map key", ():
     m = {"a": 1, "b": 2}
     expect(m).to_not_contain("c")
   )
 )
 
 describe("String matchers", ():
-  it("to_start_with", ():
+  it("should pass to_start_with", ():
     expect("hello world").to_start_with("hello")
     expect("abc").to_start_with("a")
   )
-  it("to_end_with", ():
+  it("should pass to_end_with", ():
     expect("hello world").to_end_with("world")
     expect("abc").to_end_with("c")
   )
-  it("to_start_with with empty prefix", ():
+  it("should pass to_start_with with empty prefix", ():
     expect("hello").to_start_with("")
   )
-  it("to_end_with with empty suffix", ():
+  it("should pass to_end_with with empty suffix", ():
     expect("hello").to_end_with("")
   )
-  it("to_start_with with full string", ():
+  it("should pass to_start_with with full string", ():
     expect("hello").to_start_with("hello")
   )
-  it("to_end_with with full string", ():
+  it("should pass to_end_with with full string", ():
     expect("hello").to_end_with("hello")
   )
 )

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -1,191 +1,191 @@
 from math import PI, E, Inf, NaN, abs, floor, ceil, round, sqrt, pow, log, log2, log10, exp, sin, cos, tan, asin, acos, atan, atan2, hypot, is_nan, is_inf
 
 describe("math constants", ():
-  it("PI", ():
+  it("should define PI", ():
     expect(PI > 3.14).to_eq(true)
     expect(PI < 3.15).to_eq(true)
   )
-  it("E", ():
+  it("should define E", ():
     expect(E > 2.71).to_eq(true)
     expect(E < 2.72).to_eq(true)
   )
 )
 
 describe("math special values", ():
-  it("Inf", ():
+  it("should define Inf", ():
     expect(is_inf(Inf)).to_eq(true)
     expect(Inf > 1000000.0).to_eq(true)
   )
-  it("NaN", ():
+  it("should define NaN", ():
     expect(is_nan(NaN)).to_eq(true)
   )
 )
 
 describe("NaN comparisons", ():
-  it("NaN == NaN is false", ():
+  it("should verify NaN == NaN is false", ():
     expect(NaN == NaN).to_eq(false)
   )
-  it("NaN != NaN is false (ordered)", ():
+  it("should verify NaN != NaN is false (ordered)", ():
     expect(NaN != NaN).to_eq(false)
   )
-  it("NaN < 1.0 is false", ():
+  it("should verify NaN < 1.0 is false", ():
     expect(NaN < 1.0).to_eq(false)
   )
-  it("NaN <= 1.0 is false", ():
+  it("should verify NaN <= 1.0 is false", ():
     expect(NaN <= 1.0).to_eq(false)
   )
-  it("NaN > 1.0 is false", ():
+  it("should verify NaN > 1.0 is false", ():
     expect(NaN > 1.0).to_eq(false)
   )
-  it("NaN >= 1.0 is false", ():
+  it("should verify NaN >= 1.0 is false", ():
     expect(NaN >= 1.0).to_eq(false)
   )
 )
 
 describe("math abs", ():
-  it("int", ():
+  it("should compute abs for int", ():
     expect(abs(-5)).to_eq(5)
     expect(abs(3)).to_eq(3)
     expect(abs(0)).to_eq(0)
   )
-  it("float", ():
+  it("should compute abs for float", ():
     expect(abs(-3.14)).to_eq(3.14)
     expect(abs(2.5)).to_eq(2.5)
   )
 )
 
 describe("math rounding", ():
-  it("floor", ():
+  it("should compute floor", ():
     expect(floor(3.7)).to_eq(3)
     expect(floor(-2.3)).to_eq(-3)
   )
-  it("ceil", ():
+  it("should compute ceil", ():
     expect(ceil(3.2)).to_eq(4)
     expect(ceil(-2.7)).to_eq(-2)
   )
-  it("round", ():
+  it("should compute round", ():
     expect(round(3.5)).to_eq(4)
     expect(round(2.3)).to_eq(2)
   )
 )
 
 describe("math pow/sqrt", ():
-  it("sqrt", ():
+  it("should compute sqrt", ():
     expect(sqrt(4.0)).to_eq(2.0)
     expect(sqrt(9.0)).to_eq(3.0)
     expect(sqrt(0.0)).to_eq(0.0)
   )
-  it("sqrt negative returns NaN", ():
+  it("should return NaN for sqrt of negative", ():
     expect(is_nan(sqrt(-1.0))).to_be_true()
   )
-  it("pow", ():
+  it("should compute pow", ():
     expect(pow(2.0, 3.0)).to_eq(8.0)
     expect(pow(3.0, 2.0)).to_eq(9.0)
   )
-  it("pow zero exponent", ():
+  it("should compute pow with zero exponent", ():
     expect(pow(5.0, 0.0)).to_eq(1.0)
     expect(pow(0.0, 0.0)).to_eq(1.0)
   )
-  it("pow negative exponent", ():
+  it("should compute pow with negative exponent", ():
     expect(pow(2.0, -1.0)).to_eq(0.5)
   )
-  it("pow large exponent returns Inf", ():
+  it("should return Inf for pow with large exponent", ():
     expect(is_inf(pow(2.0, 10000.0))).to_be_true()
   )
 )
 
 describe("math log", ():
-  it("log", ():
+  it("should compute log", ():
     expect(log(1.0)).to_eq(0.0)
   )
-  it("log zero returns -Inf", ():
+  it("should return -Inf for log of zero", ():
     expect(is_inf(log(0.0))).to_be_true()
   )
-  it("log negative returns NaN", ():
+  it("should return NaN for log of negative", ():
     expect(is_nan(log(-1.0))).to_be_true()
   )
-  it("log2", ():
+  it("should compute log2", ():
     expect(log2(8.0)).to_eq(3.0)
   )
-  it("log10", ():
+  it("should compute log10", ():
     expect(log10(100.0)).to_eq(2.0)
   )
 )
 
 describe("math exp", ():
-  it("exp(0)", ():
+  it("should compute exp(0)", ():
     expect(exp(0.0)).to_eq(1.0)
   )
-  it("exp large returns Inf", ():
+  it("should return Inf for large exp", ():
     expect(is_inf(exp(1000.0))).to_be_true()
   )
 )
 
 describe("math trigonometric", ():
-  it("sin(0)", ():
+  it("should compute sin(0)", ():
     expect(sin(0.0)).to_eq(0.0)
   )
-  it("cos(0)", ():
+  it("should compute cos(0)", ():
     expect(cos(0.0)).to_eq(1.0)
   )
-  it("tan(0)", ():
+  it("should compute tan(0)", ():
     expect(tan(0.0)).to_eq(0.0)
   )
 )
 
 describe("math inverse trig", ():
-  it("asin(0)", ():
+  it("should compute asin(0)", ():
     expect(asin(0.0)).to_eq(0.0)
   )
-  it("asin out of domain returns NaN", ():
+  it("should return NaN for asin out of domain", ():
     expect(is_nan(asin(2.0))).to_be_true()
     expect(is_nan(asin(-2.0))).to_be_true()
   )
-  it("acos(1)", ():
+  it("should compute acos(1)", ():
     expect(acos(1.0)).to_eq(0.0)
   )
-  it("acos out of domain returns NaN", ():
+  it("should return NaN for acos out of domain", ():
     expect(is_nan(acos(2.0))).to_be_true()
   )
-  it("atan(0)", ():
+  it("should compute atan(0)", ():
     expect(atan(0.0)).to_eq(0.0)
   )
 )
 
 describe("math two-arg", ():
-  it("atan2", ():
+  it("should compute atan2", ():
     expect(atan2(0.0, 1.0)).to_eq(0.0)
   )
-  it("atan2(0, 0)", ():
+  it("should compute atan2(0, 0)", ():
     expect(atan2(0.0, 0.0)).to_eq(0.0)
   )
-  it("hypot", ():
+  it("should compute hypot", ():
     expect(hypot(3.0, 4.0)).to_eq(5.0)
   )
-  it("hypot(0, 0)", ():
+  it("should compute hypot(0, 0)", ():
     expect(hypot(0.0, 0.0)).to_eq(0.0)
   )
 )
 
 describe("math predicates", ():
-  it("is_nan", ():
+  it("should check is_nan", ():
     expect(is_nan(NaN)).to_eq(true)
     expect(is_nan(1.0)).to_eq(false)
     expect(is_nan(0.0)).to_eq(false)
     expect(is_nan(Inf)).to_eq(false)
   )
-  it("is_inf", ():
+  it("should check is_inf", ():
     expect(is_inf(Inf)).to_eq(true)
     expect(is_inf(1.0)).to_eq(false)
     expect(is_inf(0.0)).to_eq(false)
     expect(is_inf(NaN)).to_eq(false)
   )
-  it("NaN arithmetic propagation", ():
+  it("should propagate NaN in arithmetic", ():
     expect(is_nan(NaN + 1.0)).to_be_true()
     expect(is_nan(NaN * 2.0)).to_be_true()
     expect(is_nan(NaN - NaN)).to_be_true()
   )
-  it("Inf arithmetic", ():
+  it("should handle Inf arithmetic", ():
     expect(is_inf(Inf + 1.0)).to_be_true()
     expect(is_inf(Inf + Inf)).to_be_true()
     expect(is_nan(Inf - Inf)).to_be_true()

--- a/tests/spec/mock.test.ry
+++ b/tests/spec/mock.test.ry
@@ -5,27 +5,27 @@ function compute(x: int) -> int:
   return x * 2
 
 describe("mock", ():
-  it("replaces function", ():
+  it("should replace function", ():
     mock("fetch_data", () => "fake")
     expect(fetch_data()).to_eq("fake")
   )
-  it("auto-restores after it block", ():
+  it("should auto-restore after it block", ():
     expect(fetch_data()).to_eq("real data")
   )
-  it("with arguments", ():
+  it("should mock with arguments", ():
     mock("compute", (x: int) => x + 100)
     expect(compute(5)).to_eq(105)
   )
 )
 
 describe("verify", ():
-  it("counts calls", ():
+  it("should count calls", ():
     mock("fetch_data", () => "fake")
     fetch_data()
     fetch_data()
     expect(verify("fetch_data")).to_eq(2)
   )
-  it("zero calls", ():
+  it("should count zero calls", ():
     mock("fetch_data", () => "fake")
     expect(verify("fetch_data")).to_eq(0)
   )

--- a/tests/spec/mutual_recursion.test.ry
+++ b/tests/spec/mutual_recursion.test.ry
@@ -63,12 +63,12 @@ function pong(n: int, prefix: str = "pong") -> str:
   return ping(n - 1)
 
 describe("mutual recursion", ():
-  it("is_even", ():
+  it("should compute is_even", ():
     expect(is_even(0)).to_be_true()
     expect(is_even(4)).to_be_true()
     expect(is_even(3)).to_be_false()
   )
-  it("is_odd", ():
+  it("should compute is_odd", ():
     expect(is_odd(0)).to_be_false()
     expect(is_odd(3)).to_be_true()
     expect(is_odd(4)).to_be_false()
@@ -76,7 +76,7 @@ describe("mutual recursion", ():
 )
 
 describe("three-way mutual recursion", ():
-  it("cycles through A -> B -> C -> A", ():
+  it("should cycle through A -> B -> C -> A", ():
     expect(phase_a(0)).to_eq("a")
     expect(phase_a(1)).to_eq("b")
     expect(phase_a(2)).to_eq("c")
@@ -86,21 +86,21 @@ describe("three-way mutual recursion", ():
 )
 
 describe("forward reference", ():
-  it("caller references callee defined later", ():
+  it("should resolve caller that references callee defined later", ():
     expect(caller(5)).to_eq(11)
     expect(caller(0)).to_eq(1)
   )
 )
 
 describe("mutual recursion with mixed return types", ():
-  it("count_down with bounce and check_zero", ():
+  it("should compute count_down with bounce and check_zero", ():
     expect(count_down(0)).to_eq(0)
     expect(count_down(5)).to_eq(0)
   )
 )
 
 describe("mutual recursion with default arguments", ():
-  it("ping-pong", ():
+  it("should compute ping-pong", ():
     expect(ping(0)).to_eq("ping")
     expect(ping(1)).to_eq("pong")
     expect(ping(2)).to_eq("ping")

--- a/tests/spec/nested_fn_closure.test.ry
+++ b/tests/spec/nested_fn_closure.test.ry
@@ -2,7 +2,7 @@ function apply(f: function(int) -> int, x: int) -> int:
   return f(x)
 
 describe("nested named function — capture basics", ():
-  it("captures int from enclosing scope", ():
+  it("should capture int from enclosing scope", ():
     function make_adder(base: int) -> function(int) -> int:
       function add(x: int) -> int:
         return x + base
@@ -12,7 +12,7 @@ describe("nested named function — capture basics", ():
     expect(add10(5)).to_eq(15)
   )
 
-  it("captures str from enclosing scope (ARC-managed)", ():
+  it("should capture str from enclosing scope (ARC-managed)", ():
     function choose_prefix(prefix: str) -> function(str) -> str:
       function decorate(name: str) -> str:
         return prefix + name
@@ -22,7 +22,7 @@ describe("nested named function — capture basics", ():
     expect(f("ry")).to_eq("hi ry")
   )
 
-  it("captures multiple variables", ():
+  it("should capture multiple variables", ():
     function make_linear(a: int, b: int) -> function(int) -> int:
       function linear(x: int) -> int:
         return a * x + b
@@ -34,7 +34,7 @@ describe("nested named function — capture basics", ():
 )
 
 describe("nested named function — direct call with captures", ():
-  it("calls capturing nested function directly in defining scope", ():
+  it("should call capturing nested function directly in defining scope", ():
     function outer(n: int) -> int:
       function add_n(x: int) -> int:
         return x + n
@@ -43,7 +43,7 @@ describe("nested named function — direct call with captures", ():
     expect(outer(7)).to_eq(107)
   )
 
-  it("multiple capturing nested functions in same scope", ():
+  it("should handle multiple capturing nested functions in same scope", ():
     function outer(base: int) -> int:
       function inc(x: int) -> int:
         return x + base
@@ -54,7 +54,7 @@ describe("nested named function — direct call with captures", ():
     expect(outer(3)).to_eq(20)
   )
 
-  it("sibling param shadowing does not prevent capture", ():
+  it("should not prevent capture when sibling param shadows outer", ():
     function outer() -> int:
       x = 10
       function a(x: int) -> int:
@@ -68,7 +68,7 @@ describe("nested named function — direct call with captures", ():
 )
 
 describe("nested named function — higher-order interop", ():
-  it("passes no-capture nested function to higher-order function", ():
+  it("should pass no-capture nested function to higher-order function", ():
     function outer() -> int:
       function double_it(n: int) -> int:
         return n * 2
@@ -77,7 +77,7 @@ describe("nested named function — higher-order interop", ():
     expect(outer()).to_eq(10)
   )
 
-  it("returned capturing nested function called twice", ():
+  it("should support returned capturing nested function called twice", ():
     function make_step(n: int) -> function(int) -> int:
       function step(x: int) -> int:
         return x + n
@@ -89,7 +89,7 @@ describe("nested named function — higher-order interop", ():
 )
 
 describe("nested named function — variable assignment and indirect call", ():
-  it("assigns capturing nested function to variable and calls it", ():
+  it("should assign capturing nested function to variable and call it", ():
     function outer(offset: int) -> int:
       function add_offset(x: int) -> int:
         return x + offset
@@ -101,7 +101,7 @@ describe("nested named function — variable assignment and indirect call", ():
 )
 
 describe("nested named function — multi-level capture", ():
-  it("captures variable from two levels up", ():
+  it("should capture variable from two levels up", ():
     function outer(x: int) -> function(int) -> int:
       function mid() -> function(int) -> int:
         function inner(y: int) -> int:
@@ -115,7 +115,7 @@ describe("nested named function — multi-level capture", ():
 )
 
 describe("nested named function — no-capture remains plain function", ():
-  it("no-capture nested function works as before", ():
+  it("should have no-capture nested function work as before", ():
     function outer() -> int:
       function helper(x: int) -> int:
         return x * 2
@@ -124,7 +124,7 @@ describe("nested named function — no-capture remains plain function", ():
     expect(outer()).to_eq(42)
   )
 
-  it("no-capture nested function passed as value", ():
+  it("should pass no-capture nested function as value", ():
     function outer() -> int:
       function double_it(n: int) -> int:
         return n * 2
@@ -135,7 +135,7 @@ describe("nested named function — no-capture remains plain function", ():
 )
 
 describe("nested named function — ARC capture correctness", ():
-  it("captured string survives after outer function returns", ():
+  it("should keep captured string alive after outer function returns", ():
     function make_greeter(greeting: str) -> function(str) -> str:
       function greet(name: str) -> str:
         return greeting + " " + name
@@ -146,7 +146,7 @@ describe("nested named function — ARC capture correctness", ():
     expect(g("ry")).to_eq("hello ry")
   )
 
-  it("multiple closures from same factory are independent", ():
+  it("should have multiple closures from same factory be independent", ():
     function make_adder(base: int) -> function(int) -> int:
       function add(x: int) -> int:
         return x + base

--- a/tests/spec/nested_fn_closure.test.ry
+++ b/tests/spec/nested_fn_closure.test.ry
@@ -115,7 +115,7 @@ describe("nested named function — multi-level capture", ():
 )
 
 describe("nested named function — no-capture remains plain function", ():
-  it("should have no-capture nested function work as before", ():
+  it("should keep no-capture nested function behavior unchanged", ():
     function outer() -> int:
       function helper(x: int) -> int:
         return x * 2
@@ -146,7 +146,7 @@ describe("nested named function — ARC capture correctness", ():
     expect(g("ry")).to_eq("hello ry")
   )
 
-  it("should have multiple closures from same factory be independent", ():
+  it("should keep closures from the same factory independent", ():
     function make_adder(base: int) -> function(int) -> int:
       function add(x: int) -> int:
         return x + base

--- a/tests/spec/nested_functions.test.ry
+++ b/tests/spec/nested_functions.test.ry
@@ -2,7 +2,7 @@ function apply(f: function(int) -> int, x: int) -> int:
   return f(x)
 
 describe("nested function basics", ():
-  it("defines and calls a nested function", ():
+  it("should define and call a nested function", ():
     function outer() -> int:
       function helper() -> int:
         return 42
@@ -10,7 +10,7 @@ describe("nested function basics", ():
     expect(outer()).to_eq(42)
   )
 
-  it("nested function is not visible outside enclosing function", ():
+  it("should not expose nested function outside enclosing function", ():
     function outer() -> int:
       function inner() -> int:
         return 1
@@ -21,7 +21,7 @@ describe("nested function basics", ():
 )
 
 describe("sibling scope isolation", ():
-  it("same-named nested functions in sibling scopes do not collide", ():
+  it("should not collide same-named nested functions in sibling scopes", ():
     function foo() -> int:
       function helper() -> int:
         return 1
@@ -38,7 +38,7 @@ describe("sibling scope isolation", ():
 )
 
 describe("multi-level nesting", ():
-  it("resolves names across three levels of nesting", ():
+  it("should resolve names across three levels of nesting", ():
     function outer() -> int:
       function mid() -> int:
         function inner() -> int:
@@ -48,7 +48,7 @@ describe("multi-level nesting", ():
     expect(outer()).to_eq(3)
   )
 
-  it("inner function can call sibling at same level", ():
+  it("should allow inner function to call sibling at same level", ():
     function outer() -> int:
       function a() -> int:
         return 10
@@ -60,7 +60,7 @@ describe("multi-level nesting", ():
 )
 
 describe("nested function recursion", ():
-  it("self-recursive nested function", ():
+  it("should support self-recursive nested function", ():
     function outer() -> int:
       function factorial(n: int) -> int:
         if n <= 1:
@@ -70,7 +70,7 @@ describe("nested function recursion", ():
     expect(outer()).to_eq(120)
   )
 
-  it("mutual recursion between nested functions", ():
+  it("should support mutual recursion between nested functions", ():
     function outer() -> bool:
       function is_even(n: int) -> bool:
         if n == 0:
@@ -86,7 +86,7 @@ describe("nested function recursion", ():
 )
 
 describe("nested function as value", ():
-  it("passes nested function to higher-order function", ():
+  it("should pass nested function to higher-order function", ():
     function outer() -> int:
       function double_it(n: int) -> int:
         return n * 2

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -2,7 +2,7 @@ from net import bind, listen, accept, connect, listener_port, set_timeout, set_r
 from io import to_bytes, bytes_to_str
 
 describe("TCP socket API", ():
-  it("bind returns Ok on valid address", ():
+  it("should return Ok on valid address for bind", ():
     match bind("127.0.0.1", 0):
       case Ok(server):
         close(server)
@@ -10,7 +10,7 @@ describe("TCP socket API", ():
       case Err(e):
         fail("unexpected error")
   )
-  it("listen returns Ok on valid listener", ():
+  it("should return Ok on valid listener for listen", ():
     match bind("127.0.0.1", 0):
       case Ok(server):
         match listen(server, 1):
@@ -22,7 +22,7 @@ describe("TCP socket API", ():
       case Err(e):
         fail("unexpected error")
   )
-  it("tls_connect to closed port returns Err", ():
+  it("should return Err when tls_connect to closed port", ():
     match tls_connect("127.0.0.1", 19991):
       case Ok(conn):
         close(conn)
@@ -30,7 +30,7 @@ describe("TCP socket API", ():
       case Err(e):
         expect(true).to_eq(true)
   )
-  it("connect to closed port returns Err", ():
+  it("should return Err when connect to closed port", ():
     match connect("127.0.0.1", 19998):
       case Ok(conn):
         close(conn)
@@ -38,7 +38,7 @@ describe("TCP socket API", ():
       case Err(e):
         expect(true).to_eq(true)
   )
-  it("set_receive_timeout causes receive to return Err on timeout", ():
+  it("should cause receive to return Err on timeout via set_receive_timeout", ():
     async function timeout_server(server: TcpListener) -> str:
       match accept(server):
         case Ok(conn):
@@ -71,7 +71,7 @@ describe("TCP socket API", ():
       case Err(e):
         fail("unexpected error")
   )
-  it("echo round-trip with async function", ():
+  it("should complete echo round-trip with async function", ():
     async function run_server(server: TcpListener) -> str:
       match accept(server):
         case Ok(conn):

--- a/tests/spec/numeric_literal_suffix.test.ry
+++ b/tests/spec/numeric_literal_suffix.test.ry
@@ -1,112 +1,112 @@
 describe("integer literal suffix", ():
-  it("i32 suffix", ():
+  it("should support i32 suffix", ():
     x = 42i32
     expect(x as int).to_eq(42)
   )
-  it("i16 suffix", ():
+  it("should support i16 suffix", ():
     x = 100i16
     expect(x as int).to_eq(100)
   )
-  it("i8 suffix", ():
+  it("should support i8 suffix", ():
     x = 127i8
     expect(x as int).to_eq(127)
   )
-  it("i64 suffix", ():
+  it("should support i64 suffix", ():
     x = 1000i64
     expect(x).to_eq(1000)
   )
-  it("u8 suffix", ():
+  it("should support u8 suffix", ():
     x = 255u8
     expect(x as int).to_eq(255)
   )
-  it("u16 suffix", ():
+  it("should support u16 suffix", ():
     x = 1000u16
     expect(x as int).to_eq(1000)
   )
-  it("u32 suffix", ():
+  it("should support u32 suffix", ():
     x = 100u32
     expect(x as int).to_eq(100)
   )
-  it("u64 suffix", ():
+  it("should support u64 suffix", ():
     x = 100u64
     expect(x as int).to_eq(100)
   )
-  it("zero with suffix", ():
+  it("should parse zero with suffix", ():
     x = 0i32
     expect(x as int).to_eq(0)
   )
 )
 
 describe("float literal suffix", ():
-  it("f32 suffix on float", ():
+  it("should support f32 suffix on float", ():
     x = 3.14f32
     expect(x as float > 3.0).to_eq(true)
   )
-  it("f64 suffix on float", ():
+  it("should support f64 suffix on float", ():
     x = 3.14f64
     expect(x > 3.0).to_eq(true)
   )
-  it("integer with f32 suffix becomes float", ():
+  it("should make integer with f32 suffix become float", ():
     x = 42f32
     expect(x as float > 41.0).to_eq(true)
   )
 )
 
 describe("hex and binary with suffix", ():
-  it("hex with u8 suffix", ():
+  it("should support hex with u8 suffix", ():
     x = 0xFFu8
     expect(x as int).to_eq(255)
   )
-  it("hex with i32 suffix", ():
+  it("should support hex with i32 suffix", ():
     x = 0x1Fi32
     expect(x as int).to_eq(31)
   )
-  it("binary with u8 suffix", ():
+  it("should support binary with u8 suffix", ():
     x = 0b1010u8
     expect(x as int).to_eq(10)
   )
 )
 
 describe("negative suffixed literals", ():
-  it("negative i32", ():
+  it("should support negative i32", ():
     x = -1i32
     expect(x as int).to_eq(-1)
   )
-  it("negative i8", ():
+  it("should support negative i8", ():
     x = -128i8
     expect(x as int).to_eq(-128)
   )
-  it("negative i16", ():
+  it("should support negative i16", ():
     x = -100i16
     expect(x as int).to_eq(-100)
   )
 )
 
 describe("suffixed literal arithmetic", ():
-  it("i32 addition", ():
+  it("should add i32", ():
     c = 10i32 + 20i32
     expect(c as int).to_eq(30)
   )
-  it("u8 addition", ():
+  it("should add u8", ():
     c = 100u8 + 50u8
     expect(c as int).to_eq(150)
   )
-  it("f32 addition", ():
+  it("should add f32", ():
     c = 1.5f32 + 2.5f32
     expect(c as float > 3.9).to_eq(true)
   )
 )
 
 describe("suffixed literal with annotation", ():
-  it("matching annotation i32", ():
+  it("should support matching annotation i32", ():
     x: i32 = 42i32
     expect(x as int).to_eq(42)
   )
-  it("matching annotation u8", ():
+  it("should support matching annotation u8", ():
     x: u8 = 200u8
     expect(x as int).to_eq(200)
   )
-  it("matching annotation f32", ():
+  it("should support matching annotation f32", ():
     x: f32 = 1.5f32
     expect(x as float > 1.0).to_eq(true)
   )

--- a/tests/spec/numeric_underscore_separator.test.ry
+++ b/tests/spec/numeric_underscore_separator.test.ry
@@ -1,27 +1,27 @@
 describe("numeric underscore separators", ():
-  it("decimal integer with underscores", ():
+  it("should parse decimal integer with underscores", ():
     expect(100_000).to_eq(100000)
     expect(1_000_000).to_eq(1000000)
   )
-  it("hex with underscores", ():
+  it("should parse hex with underscores", ():
     expect(0xFF_FF).to_eq(0xFFFF)
   )
-  it("binary with underscores", ():
+  it("should parse binary with underscores", ():
     expect(0b1010_0101).to_eq(0b10100101)
   )
-  it("float with underscores", ():
+  it("should parse float with underscores", ():
     expect(3.14_159).to_eq(3.14159)
   )
-  it("leading dot float with underscores", ():
+  it("should parse leading dot float with underscores", ():
     expect(.5_0).to_eq(0.50)
   )
-  it("with suffix", ():
+  it("should parse with suffix", ():
     x: i32 = 100_000i32
     expect(x as int).to_eq(100000)
     y = 1.5_0f64
     expect(y as float).to_eq(1.50)
   )
-  it("arithmetic with underscored literals", ():
+  it("should compute arithmetic with underscored literals", ():
     expect(1_000 + 2_000).to_eq(3000)
     expect(1_000_000 / 1_000).to_eq(1000)
   )

--- a/tests/spec/operator_overload.test.ry
+++ b/tests/spec/operator_overload.test.ry
@@ -1,5 +1,5 @@
 describe("operator[]", ():
-  it("read with single index", ():
+  it("should read with single index", ():
     record Point:
       x: int
       y: int
@@ -16,7 +16,7 @@ describe("operator[]", ():
     expect(p[2]).to_eq(30)
   )
 
-  it("read with multi-index", ():
+  it("should read with multi-index", ():
     record Grid:
       a: int
       b: int
@@ -37,7 +37,7 @@ describe("operator[]", ():
     expect(g[1, 1]).to_eq(4)
   )
 
-  it("write dispatches operator[]=", ():
+  it("should dispatch write to operator[]=", ():
     record Sink:
       last_key: int
       last_val: int
@@ -50,7 +50,7 @@ describe("operator[]", ():
 )
 
 describe("operator[] returning collection", ():
-  it("subscript returning List<int> preserves type info and supports chaining", ():
+  it("should preserve type info and support chaining for subscript returning List<int>", ():
     record Matrix:
       rows: List<List<int>>
     function operator[](m: Matrix, i: int) -> List<int>:
@@ -68,7 +68,7 @@ describe("operator[] returning collection", ():
 )
 
 describe("operator in", ():
-  it("custom in", ():
+  it("should support custom in", ():
     record Range:
       lo: int
       hi: int
@@ -80,7 +80,7 @@ describe("operator in", ():
     expect(10 in r).to_be_false()
   )
 
-  it("not in", ():
+  it("should support not in", ():
     record Span:
       lo: int
       hi: int
@@ -91,7 +91,7 @@ describe("operator in", ():
     expect(5 not in s).to_be_false()
   )
 
-  it("built-in in still works", ():
+  it("should still work with built-in in", ():
     xs = [1, 2, 3]
     expect(2 in xs).to_be_true()
     expect(5 in xs).to_be_false()
@@ -102,7 +102,7 @@ describe("operator in", ():
 )
 
 describe("operator()", ():
-  it("callable record", ():
+  it("should support callable record", ():
     record Adder:
       base: int
     function operator()(a: Adder, x: int) -> int:
@@ -111,7 +111,7 @@ describe("operator()", ():
     expect(add5(10)).to_eq(15)
   )
 
-  it("multi-arg callable", ():
+  it("should support multi-arg callable", ():
     record Calc:
       base: int
     function operator()(c: Calc, x: int, y: int) -> int:
@@ -122,7 +122,7 @@ describe("operator()", ():
 )
 
 describe("operator as", ():
-  it("custom cast", ():
+  it("should support custom cast", ():
     record Celsius:
       value: int
     record Fahrenheit:
@@ -134,7 +134,7 @@ describe("operator as", ():
     expect(f.value).to_eq(212)
   )
 
-  it("cast to generic Option type", ():
+  it("should support cast to generic Option type", ():
     record Temperature:
       value: int
     function operator as(t: Temperature) -> int?:
@@ -144,7 +144,7 @@ describe("operator as", ():
     expect(result ?? -1).to_eq(42)
   )
 
-  it("cast returning collection preserves type info", ():
+  it("should preserve type info for cast returning collection", ():
     record Row:
       items: List<int>
     function operator as(r: Row) -> List<int>:
@@ -155,7 +155,7 @@ describe("operator as", ():
     expect(xs[2]).to_eq(30)
   )
 
-  it("built-in cast still works", ():
+  it("should still work with built-in cast", ():
     x: float = 42 as float
     expect(x + 0.5).to_eq(42.5)
     expect(3.14 as int).to_eq(3)

--- a/tests/spec/operator_overload_fn_type.test.ry
+++ b/tests/spec/operator_overload_fn_type.test.ry
@@ -1,5 +1,5 @@
 describe("operator[] returning function type", ():
-  it("subscript returns a callable and can be invoked", ():
+  it("should return a callable from subscript and allow invocation", ():
     record FnMap:
       base: int
     function operator[](m: FnMap, key: int) -> function(int) -> int:
@@ -9,7 +9,7 @@ describe("operator[] returning function type", ():
     expect(f(100)).to_eq(111)
   )
 
-  it("subscript return called via variable", ():
+  it("should call subscript return via variable", ():
     record Dispatch:
       offset: int
     function operator[](d: Dispatch, idx: int) -> function(int) -> int:
@@ -21,7 +21,7 @@ describe("operator[] returning function type", ():
 )
 
 describe("operator as returning function type", ():
-  it("cast returns a callable and can be invoked", ():
+  it("should return a callable from cast and allow invocation", ():
     record Multiplier:
       factor: int
     function operator as(m: Multiplier) -> function(int) -> int:

--- a/tests/spec/operators.test.ry
+++ b/tests/spec/operators.test.ry
@@ -1,174 +1,174 @@
 describe("arithmetic", ():
-  it("addition", ():
+  it("should add integers", ():
     expect(1 + 2).to_eq(3)
   )
-  it("subtraction", ():
+  it("should subtract integers", ():
     expect(5 - 3).to_eq(2)
   )
-  it("multiplication", ():
+  it("should multiply integers", ():
     expect(4 * 3).to_eq(12)
   )
-  it("division returns float", ():
+  it("should return float on division", ():
     expect(7 / 2).to_eq(3.5)
   )
-  it("integer division", ():
+  it("should perform integer division", ():
     expect(7 // 2).to_eq(3)
   )
-  it("floor division with negative dividend", ():
+  it("should floor divide with negative dividend", ():
     expect(-7 // 2).to_eq(-4)
   )
-  it("floor division with negative divisor", ():
+  it("should floor divide with negative divisor", ():
     expect(7 // -2).to_eq(-4)
   )
-  it("floor division with both negative", ():
+  it("should floor divide with both negative", ():
     expect(-7 // -2).to_eq(3)
   )
-  it("floor division with float operands", ():
+  it("should floor divide with float operands", ():
     expect(7.0 // 2.0).to_eq(3.0)
     expect(-7.0 // 2.0).to_eq(-4.0)
   )
-  it("floor division with mixed operands", ():
+  it("should floor divide with mixed operands", ():
     expect(7.0 // 2).to_eq(3.0)
     expect(7 // 2.0).to_eq(3.0)
     expect(-7.0 // 2).to_eq(-4.0)
     expect(7 // -2.0).to_eq(-4.0)
   )
-  it("modulo", ():
+  it("should compute modulo", ():
     expect(7 % 3).to_eq(1)
   )
-  it("modulo negative dividend", ():
+  it("should compute modulo with negative dividend", ():
     expect(-7 % 3).to_eq(2)
   )
-  it("modulo negative divisor", ():
+  it("should compute modulo with negative divisor", ():
     expect(7 % -3).to_eq(-2)
   )
-  it("modulo both negative", ():
+  it("should compute modulo with both negative", ():
     expect(-7 % -3).to_eq(-1)
   )
-  it("modulo zero dividend", ():
+  it("should compute modulo with zero dividend", ():
     expect(0 % 5).to_eq(0)
   )
-  it("floor div and modulo identity", ():
+  it("should satisfy floor div and modulo identity", ():
     expect((-7 // 3) * 3 + (-7 % 3)).to_eq(-7)
     expect((7 // -3) * -3 + (7 % -3)).to_eq(7)
     expect((-7 // -3) * -3 + (-7 % -3)).to_eq(-7)
   )
-  it("float modulo", ():
+  it("should compute float modulo", ():
     expect(7.5 % 2.5).to_eq(0.0)
   )
-  it("float modulo negative", ():
+  it("should compute float modulo with negative", ():
     expect(-7.0 % 2.0).to_eq(1.0)
   )
-  it("float floor div", ():
+  it("should compute float floor div", ():
     expect(7.5 // 2.0).to_eq(3.0)
   )
-  it("exponentiation", ():
+  it("should compute exponentiation", ():
     expect(2 ** 10).to_eq(1024.0)
   )
-  it("exponentiation zero", ():
+  it("should compute exponentiation to zero", ():
     expect(1 ** 0).to_eq(1.0)
   )
-  it("exponentiation negative", ():
+  it("should compute negative exponentiation", ():
     expect(2 ** -1).to_eq(0.5)
   )
-  it("zero times zero", ():
+  it("should compute zero times zero", ():
     expect(0 * 0).to_eq(0)
   )
-  it("zero plus zero", ():
+  it("should compute zero plus zero", ():
     expect(0 + 0).to_eq(0)
   )
 )
 
 describe("unary", ():
-  it("unary minus", ():
+  it("should negate with unary minus", ():
     expect(-5).to_eq(-5)
   )
-  it("unary plus", ():
+  it("should apply unary plus", ():
     expect(+5).to_eq(5)
   )
 )
 
 describe("string operators", ():
-  it("concatenation", ():
+  it("should concatenate strings", ():
     expect("foo" + "bar").to_eq("foobar")
   )
-  it("repetition", ():
+  it("should repeat strings", ():
     expect("ab" * 3).to_eq("ababab")
   )
 )
 
 describe("string auto concatenation", ():
-  it("str + int", ():
+  it("should support str + int", ():
     expect("abc" + 2).to_eq("abc2")
   )
-  it("int + str", ():
+  it("should support int + str", ():
     expect(1 + "abc").to_eq("1abc")
   )
-  it("str + float", ():
+  it("should support str + float", ():
     expect("pi=" + 3.14).to_eq("pi=3.14")
   )
-  it("str + bool", ():
+  it("should support str + bool", ():
     expect("ok=" + true).to_eq("ok=true")
   )
-  it("bool + str", ():
+  it("should support bool + str", ():
     expect(false + " is false").to_eq("false is false")
   )
-  it("float + str", ():
+  it("should support float + str", ():
     expect(3.14 + " is pi").to_eq("3.14 is pi")
   )
 )
 
 describe("comparison", ():
-  it("equal", ():
+  it("should test equality", ():
     expect(1 == 1).to_be_true()
   )
-  it("not equal", ():
+  it("should test not equal", ():
     expect(1 != 2).to_be_true()
   )
-  it("less than", ():
+  it("should test less than", ():
     expect(1).to_be_less_than(2)
   )
-  it("less than or equal", ():
+  it("should test less than or equal", ():
     expect(2).to_be_less_than_or_eq(2)
   )
-  it("greater than", ():
+  it("should test greater than", ():
     expect(3).to_be_greater_than(2)
   )
-  it("greater than or equal", ():
+  it("should test greater than or equal", ():
     expect(3).to_be_greater_than_or_eq(3)
   )
-  it("string comparison", ():
+  it("should compare strings", ():
     expect("abc" < "abd").to_be_true()
   )
-  it("string equality", ():
+  it("should test string equality", ():
     expect("abc" == "abc").to_be_true()
     expect("" == "").to_be_true()
   )
-  it("empty string less than non-empty", ():
+  it("should recognize empty string as less than non-empty", ():
     expect("" < "a").to_be_true()
   )
-  it("float equality", ():
+  it("should test float equality", ():
     expect(3.14 == 3.14).to_be_true()
   )
 )
 
 describe("logical", ():
-  it("and true", ():
+  it("should evaluate and as true", ():
     expect(true and true).to_be_true()
   )
-  it("and false", ():
+  it("should evaluate and as false", ():
     expect(true and false).to_be_false()
   )
-  it("or true", ():
+  it("should evaluate or as true", ():
     expect(false or true).to_be_true()
   )
-  it("or false", ():
+  it("should evaluate or as false", ():
     expect(false or false).to_be_false()
   )
-  it("not true", ():
+  it("should negate true with not", ():
     expect(not true).to_be_false()
   )
-  it("not false", ():
+  it("should negate false with not", ():
     expect(not false).to_be_true()
   )
 )
@@ -177,13 +177,13 @@ function side_effect_flag() -> bool:
   return true
 
 describe("short-circuit evaluation", ():
-  it("and short-circuits on false", ():
+  it("should short-circuit and on false", ():
     mock("side_effect_flag", () => true)
     r = false and side_effect_flag()
     expect(r).to_be_false()
     expect(verify("side_effect_flag")).to_eq(0)
   )
-  it("or short-circuits on true", ():
+  it("should short-circuit or on true", ():
     mock("side_effect_flag", () => false)
     r = true or side_effect_flag()
     expect(r).to_be_true()
@@ -192,51 +192,51 @@ describe("short-circuit evaluation", ():
 )
 
 describe("bitwise", ():
-  it("AND", ():
+  it("should compute bitwise AND", ():
     expect(12 & 10).to_eq(8)
   )
-  it("OR", ():
+  it("should compute bitwise OR", ():
     expect(12 | 10).to_eq(14)
   )
-  it("XOR", ():
+  it("should compute bitwise XOR", ():
     expect(12 ^ 10).to_eq(6)
   )
-  it("NOT", ():
+  it("should compute bitwise NOT", ():
     expect(~0).to_eq(-1)
   )
-  it("left shift", ():
+  it("should left shift", ():
     expect(1 << 4).to_eq(16)
   )
-  it("arithmetic right shift", ():
+  it("should arithmetic right shift", ():
     expect(16 >> 2).to_eq(4)
   )
-  it("logical right shift", ():
+  it("should logical right shift", ():
     expect(-1 >>> 1).to_eq(9223372036854775807)
   )
-  it("shift by zero", ():
+  it("should shift by zero", ():
     expect(0 << 0).to_eq(0)
     expect(0 >> 0).to_eq(0)
     expect(42 << 0).to_eq(42)
   )
-  it("NOT of minus one", ():
+  it("should compute NOT of minus one", ():
     expect(~(-1)).to_eq(0)
   )
 )
 
 describe("when expression", ():
-  it("true branch", ():
+  it("should take true branch", ():
     expect(when:
       true => 10
       else => 20
     ).to_eq(10)
   )
-  it("false branch", ():
+  it("should take false branch", ():
     expect(when:
       false => 10
       else => 20
     ).to_eq(20)
   )
-  it("multi-branch", ():
+  it("should select correct branch in multi-branch when", ():
     x = 2
     r = when:
       x == 1 => "one"
@@ -245,7 +245,7 @@ describe("when expression", ():
       else => "other"
     expect(r).to_eq("two")
   )
-  it("all false falls to else", ():
+  it("should fall to else when all branches are false", ():
     x = 99
     r = when:
       x == 1 => "one"
@@ -253,7 +253,7 @@ describe("when expression", ():
       else => "none"
     expect(r).to_eq("none")
   )
-  it("first false second true", ():
+  it("should select second branch when first is false and second is true", ():
     x = 5
     r = when:
       x > 10 => "big"
@@ -264,67 +264,67 @@ describe("when expression", ():
 )
 
 describe("null coalescing", ():
-  it("Some value", ():
+  it("should return Some value with ??", ():
     a: int? = Some(10)
     expect(a ?? 0).to_eq(10)
   )
-  it("None value", ():
+  it("should return default for None with ??", ():
     b: int? = none
     expect(b ?? 0).to_eq(0)
   )
-  it("Some(0) is not None", ():
+  it("should recognize Some(0) as not None", ():
     c: int? = Some(0)
     expect(c ?? 99).to_eq(0)
   )
 )
 
 describe("compound assignment", ():
-  it("+=", ():
+  it("should support +=", ():
     x = 10
     x = x + 5
     expect(x).to_eq(15)
   )
-  it("-=", ():
+  it("should support -=", ():
     x = 10
     x = x - 3
     expect(x).to_eq(7)
   )
-  it("*=", ():
+  it("should support *=", ():
     x = 4
     x = x * 3
     expect(x).to_eq(12)
   )
-  it("//=", ():
+  it("should support //=", ():
     x = 10
     x = x // 3
     expect(x).to_eq(3)
   )
-  it("%=", ():
+  it("should support %=", ():
     x = 10
     x = x % 3
     expect(x).to_eq(1)
   )
-  it("&=", ():
+  it("should support &=", ():
     x = 12
     x = x & 10
     expect(x).to_eq(8)
   )
-  it("|=", ():
+  it("should support |=", ():
     x = 12
     x = x | 3
     expect(x).to_eq(15)
   )
-  it("^=", ():
+  it("should support ^=", ():
     x = 12
     x = x ^ 10
     expect(x).to_eq(6)
   )
-  it("<<=", ():
+  it("should support <<=", ():
     x = 1
     x = x << 4
     expect(x).to_eq(16)
   )
-  it(">>=", ():
+  it("should support >>=", ():
     x = 16
     x = x >> 2
     expect(x).to_eq(4)
@@ -332,62 +332,62 @@ describe("compound assignment", ():
 )
 
 describe("membership", ():
-  it("in Set", ():
+  it("should test membership in Set", ():
     s = {1, 2, 3}
     expect(s).to_contain(2)
   )
-  it("not in Set", ():
+  it("should test non-membership in Set", ():
     s = {1, 2, 3}
     expect(s).to_not_contain(4)
   )
-  it("in List", ():
+  it("should test membership in List", ():
     xs = [1, 2, 3]
     expect(xs).to_contain(2)
   )
-  it("not in List", ():
+  it("should test non-membership in List", ():
     xs = [1, 2, 3]
     expect(xs).to_not_contain(4)
   )
-  it("in Map", ():
+  it("should test membership in Map", ():
     m = {"a": 1}
     expect(m).to_contain("a")
   )
-  it("not in Map", ():
+  it("should test non-membership in Map", ():
     m = {"a": 1}
     expect(m).to_not_contain("b")
   )
 )
 
 describe("increment/decrement", ():
-  it("x++ increments int", ():
+  it("should increment int with x++", ():
     x = 10
     x = x + 1
     expect(x).to_eq(11)
   )
-  it("x-- decrements int", ():
+  it("should decrement int with x--", ():
     x = 10
     x = x - 1
     expect(x).to_eq(9)
   )
-  it("multiple increments", ():
+  it("should support multiple increments", ():
     x = 0
     x = x + 1
     x = x + 1
     x = x + 1
     expect(x).to_eq(3)
   )
-  it("decrement to negative", ():
+  it("should decrement to negative", ():
     x = 1
     x = x - 1
     x = x - 1
     expect(x).to_eq(-1)
   )
-  it("f++ increments float", ():
+  it("should increment float with f++", ():
     f = 1.5
     f = f + 1
     expect(f).to_eq(2.5)
   )
-  it("f-- decrements float", ():
+  it("should decrement float with f--", ():
     f = 3.5
     f = f - 1
     expect(f).to_eq(2.5)
@@ -395,13 +395,13 @@ describe("increment/decrement", ():
 )
 
 describe("range operator", ():
-  it("creates inclusive range", ():
+  it("should create inclusive range", ():
     xs = 1..5
     expect(xs).to_have_length(5)
     expect(xs[0]).to_eq(1)
     expect(xs[4]).to_eq(5)
   )
-  it("same start and end", ():
+  it("should create range with same start and end", ():
     xs = 5..5
     expect(xs).to_have_length(1)
     expect(xs[0]).to_eq(5)

--- a/tests/spec/parameterized.test.ry
+++ b/tests/spec/parameterized.test.ry
@@ -1,29 +1,29 @@
 describe("@each parameterized tests", ():
   @each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
-  it("adds {0} + {1} = {2}", (a: int, b: int, expected: int):
+  it("should add {0} + {1} = {2}", (a: int, b: int, expected: int):
     expect(a + b).to_eq(expected)
   )
   @each([("hello", 5), ("", 0), ("ry", 2)])
-  it("length of \"{0}\" is {1}", (s: str, expected: int):
+  it("should compute length of \"{0}\" as {1}", (s: str, expected: int):
     expect(length(s)).to_eq(expected)
   )
 )
 
 describe("@property tests", ():
   @property(count=100)
-  it("addition is commutative", (a: int, b: int):
+  it("should verify addition is commutative", (a: int, b: int):
     expect(a + b).to_eq(b + a)
   )
   @property(count=50)
-  it("double is always even", (n: int):
+  it("should verify double is always even", (n: int):
     expect(n * 2 % 2).to_eq(0)
   )
   @property(count=20)
-  it("bool identity", (x: bool):
+  it("should verify bool identity", (x: bool):
     expect(x == x).to_be_true()
   )
   @property(count=20)
-  it("str length is non-negative", (s: str):
+  it("should verify str length is non-negative", (s: str):
     expect(length(s) >= 0).to_be_true()
   )
 )

--- a/tests/spec/path.test.ry
+++ b/tests/spec/path.test.ry
@@ -2,113 +2,113 @@ from path import join, basename, dirname, extension, resolve, is_absolute
 
 describe("path", ():
   describe("join", ():
-    it("joins two parts", ():
+    it("should join two parts", ():
       expect(join("/tmp", "file.txt")).to_eq("/tmp/file.txt")
     )
-    it("joins three parts", ():
+    it("should join three parts", ():
       expect(join("/tmp", "data", "file.txt")).to_eq("/tmp/data/file.txt")
     )
-    it("joins four parts", ():
+    it("should join four parts", ():
       expect(join("/tmp", "a", "b", "file.txt")).to_eq("/tmp/a/b/file.txt")
     )
-    it("absolute second arg replaces first", ():
+    it("should replace first arg when second is absolute", ():
       expect(join("/tmp", "/usr")).to_eq("/usr")
     )
-    it("handles trailing slash", ():
+    it("should handle trailing slash", ():
       expect(join("/tmp/", "file.txt")).to_eq("/tmp/file.txt")
     )
-    it("join from root", ():
+    it("should join from root", ():
       expect(join("/", "tmp")).to_eq("/tmp")
     )
-    it("empty first arg", ():
+    it("should handle empty first arg", ():
       expect(join("", "file.txt")).to_eq("file.txt")
     )
-    it("empty second arg", ():
+    it("should handle empty second arg", ():
       expect(join("/tmp", "")).to_eq("/tmp")
     )
   )
 
   describe("basename", ():
-    it("extracts filename", ():
+    it("should extract filename", ():
       expect(basename("/tmp/data/file.txt")).to_eq("file.txt")
     )
-    it("root path", ():
+    it("should return empty string for root path", ():
       expect(basename("/")).to_eq("")
     )
-    it("no directory", ():
+    it("should return filename when no directory", ():
       expect(basename("file.txt")).to_eq("file.txt")
     )
-    it("trailing slash", ():
+    it("should handle trailing slash", ():
       expect(basename("/tmp/data/")).to_eq("data")
     )
-    it("empty string", ():
+    it("should handle empty string", ():
       expect(basename("")).to_eq("")
     )
   )
 
   describe("dirname", ():
-    it("extracts directory", ():
+    it("should extract directory", ():
       expect(dirname("/tmp/data/file.txt")).to_eq("/tmp/data")
     )
-    it("root file", ():
+    it("should return root for file at root", ():
       expect(dirname("/file.txt")).to_eq("/")
     )
-    it("no directory", ():
+    it("should return dot when no directory", ():
       expect(dirname("file.txt")).to_eq(".")
     )
-    it("root path", ():
+    it("should return root for root path", ():
       expect(dirname("/")).to_eq("/")
     )
-    it("empty string", ():
+    it("should return dot for empty string", ():
       expect(dirname("")).to_eq(".")
     )
   )
 
   describe("extension", ():
-    it("extracts extension", ():
+    it("should extract extension", ():
       expect(extension("/tmp/file.txt")).to_eq(".txt")
     )
-    it("no extension", ():
+    it("should return empty string when no extension", ():
       expect(extension("/tmp/file")).to_eq("")
     )
-    it("hidden file no ext", ():
+    it("should return empty string for hidden file with no ext", ():
       expect(extension(".gitignore")).to_eq("")
     )
-    it("hidden file with ext", ():
+    it("should extract extension from hidden file", ():
       expect(extension(".config.json")).to_eq(".json")
     )
-    it("multiple dots", ():
+    it("should return last extension with multiple dots", ():
       expect(extension("archive.tar.gz")).to_eq(".gz")
     )
-    it("empty string", ():
+    it("should return empty string for empty string", ():
       expect(extension("")).to_eq("")
     )
-    it("dot in directory", ():
+    it("should return empty string for dot in directory", ():
       expect(extension("/usr/local.d/file")).to_eq("")
     )
   )
 
   describe("is_absolute", ():
-    it("absolute path", ():
+    it("should detect absolute path", ():
       expect(is_absolute("/tmp")).to_eq(true)
     )
-    it("relative path", ():
+    it("should detect relative path", ():
       expect(is_absolute("tmp/file")).to_eq(false)
     )
-    it("empty string", ():
+    it("should return false for empty string", ():
       expect(is_absolute("")).to_eq(false)
     )
   )
 
   describe("resolve", ():
-    it("resolves existing path", ():
+    it("should resolve existing path", ():
       match resolve("/tmp"):
         case Ok(s):
           expect(is_absolute(s)).to_eq(true)
         case Err(e):
           fail("unexpected error: " + e.message)
     )
-    it("fails for non-existent path", ():
+    it("should fail for non-existent path", ():
       match resolve("/nonexistent_path_xyz_12345"):
         case Ok(s):
           fail("expected error but got Ok")

--- a/tests/spec/print_result_option.test.ry
+++ b/tests/spec/print_result_option.test.ry
@@ -1,93 +1,93 @@
 describe("print Result", ():
-  it("prints Ok(int)", ():
+  it("should print Ok(int)", ():
     print(Ok(42))
     # expect-output: Ok(42)
   )
 
-  it("prints Ok(str)", ():
+  it("should print Ok(str)", ():
     print(Ok("hello"))
     # expect-output: Ok(hello)
   )
 
-  it("prints Result from to_int()", ():
+  it("should print Result from to_int()", ():
     r = "42".to_int()
     print(r)
     # expect-output: Ok(42)
   )
 
-  it("prints Err", ():
+  it("should print Err", ():
     print(Err(Error("fail")))
     # expect-output: Err(Error: fail (code: 0))
   )
 
-  it("prints Ok(list)", ():
+  it("should print Ok(list)", ():
     print(Ok([1, 2, 3]))
     # expect-output: Ok([1, 2, 3])
   )
 
-  it("prints Ok(map)", ():
+  it("should print Ok(map)", ():
     print(Ok({"a": 1}))
     # expect-output: Ok({a: 1})
   )
 )
 
 describe("print Option", ():
-  it("prints Some(int)", ():
+  it("should print Some(int)", ():
     print(Some(1))
     # expect-output: Some(1)
   )
 
-  it("prints Some(str)", ():
+  it("should print Some(str)", ():
     print(Some("hi"))
     # expect-output: Some(hi)
   )
 
-  it("prints none", ():
+  it("should print none", ():
     x: int? = none
     print(x)
     # expect-output: None
   )
 
-  it("prints Some(list)", ():
+  it("should print Some(list)", ():
     print(Some([1, 2, 3]))
     # expect-output: Some([1, 2, 3])
   )
 )
 
 describe("to_str Result", ():
-  it("converts Ok(int) to string", ():
+  it("should convert Ok(int) to string", ():
     expect(to_str(Ok(42))).to_eq("Ok(42)")
   )
 
-  it("converts Ok(str) to string", ():
+  it("should convert Ok(str) to string", ():
     expect(to_str(Ok("hello"))).to_eq("Ok(hello)")
   )
 
-  it("converts Err to string", ():
+  it("should convert Err to string", ():
     expect(to_str(Err(Error("fail")))).to_eq("Err(Error: fail (code: 0))")
   )
 
-  it("works in f-string", ():
+  it("should work in f-string", ():
     r = Ok(99)
     expect(f"result: {r}").to_eq("result: Ok(99)")
   )
 
-  it("converts Ok(list) to string", ():
+  it("should convert Ok(list) to string", ():
     expect(to_str(Ok([1, 2, 3]))).to_eq("Ok([1, 2, 3])")
   )
 )
 
 describe("to_str Option", ():
-  it("converts Some(int) to string", ():
+  it("should convert Some(int) to string", ():
     expect(to_str(Some(1))).to_eq("Some(1)")
   )
 
-  it("converts none to string", ():
+  it("should convert none to string", ():
     x: int? = none
     expect(to_str(x)).to_eq("None")
   )
 
-  it("works in f-string", ():
+  it("should work in f-string", ():
     x = Some(42)
     expect(f"opt: {x}").to_eq("opt: Some(42)")
   )

--- a/tests/spec/print_result_option.test.ry
+++ b/tests/spec/print_result_option.test.ry
@@ -42,7 +42,7 @@ describe("print Option", ():
     # expect-output: Some(hi)
   )
 
-  it("should print none", ():
+  it("should print None", ():
     x: int? = none
     print(x)
     # expect-output: None

--- a/tests/spec/print_to_str_consistency.test.ry
+++ b/tests/spec/print_to_str_consistency.test.ry
@@ -13,102 +13,102 @@ enum Packet:
   Empty
 
 describe("print and to_str consistency", ():
-  it("int", ():
+  it("should be consistent for int", ():
     expect(to_str(42)).to_eq("42")
     print(42)
     # expect-output: 42
   )
 
-  it("float", ():
+  it("should be consistent for float", ():
     expect(to_str(3.14)).to_eq("3.14")
     print(3.14)
     # expect-output: 3.14
   )
 
-  it("bool", ():
+  it("should be consistent for bool", ():
     expect(to_str(true)).to_eq("true")
     expect(to_str(false)).to_eq("false")
     print(true)
     # expect-output: true
   )
 
-  it("string", ():
+  it("should be consistent for string", ():
     expect(to_str("hello")).to_eq("hello")
     print("hello")
     # expect-output: hello
   )
 
-  it("list of ints", ():
+  it("should be consistent for list of ints", ():
     xs = [10, 20, 30]
     expect(to_str(xs)).to_eq("[10, 20, 30]")
     print(xs)
     # expect-output: [10, 20, 30]
   )
 
-  it("map", ():
+  it("should be consistent for map", ():
     m = {"x": 1}
     expect(to_str(m)).to_eq("{x: 1}")
     print(m)
     # expect-output: {x: 1}
   )
 
-  it("set", ():
+  it("should be consistent for set", ():
     s = {5}
     expect(to_str(s)).to_eq("{5}")
     print(s)
     # expect-output: {5}
   )
 
-  it("tuple", ():
+  it("should be consistent for tuple", ():
     t = (1, "a")
     expect(to_str(t)).to_eq("(1, a)")
     print(t)
     # expect-output: (1, a)
   )
 
-  it("Option Some", ():
+  it("should be consistent for Option Some", ():
     x = Some(99)
     expect(to_str(x)).to_eq("Some(99)")
     print(x)
     # expect-output: Some(99)
   )
 
-  it("Option None", ():
+  it("should be consistent for Option None", ():
     x: int? = none
     expect(to_str(x)).to_eq("None")
     print(x)
     # expect-output: None
   )
 
-  it("Result Ok", ():
+  it("should be consistent for Result Ok", ():
     r = Ok(7)
     expect(to_str(r)).to_eq("Ok(7)")
     print(r)
     # expect-output: Ok(7)
   )
 
-  it("Result Err", ():
+  it("should be consistent for Result Err", ():
     r = Err(Error("oops"))
     expect(to_str(r)).to_eq("Err(Error: oops (code: 0))")
     print(r)
     # expect-output: Err(Error: oops (code: 0))
   )
 
-  it("Option wrapping list (recursive non-scalar)", ():
+  it("should be consistent for Option wrapping list (recursive non-scalar)", ():
     x = Some([10, 20])
     expect(to_str(x)).to_eq("Some([10, 20])")
     print(x)
     # expect-output: Some([10, 20])
   )
 
-  it("Result wrapping tuple (recursive non-scalar)", ():
+  it("should be consistent for Result wrapping tuple (recursive non-scalar)", ():
     r = Ok((1, "a"))
     expect(to_str(r)).to_eq("Ok((1, a))")
     print(r)
     # expect-output: Ok((1, a))
   )
 
-  it("record with user-defined to_str", ():
+  it("should use record with user-defined to_str", ():
     record Person:
       name: str
       age: int
@@ -120,7 +120,7 @@ describe("print and to_str consistency", ():
     # expect-output: Alice (age 30)
   )
 
-  it("sequential enum", ():
+  it("should be consistent for sequential enum", ():
     expect(to_str(Color::Red)).to_eq("Red")
     print(Color::Green)
     # expect-output: Green
@@ -128,29 +128,29 @@ describe("print and to_str consistency", ():
 )
 
 describe("to_str on ADT enum", ():
-  it("variant with single field", ():
+  it("should convert variant with single field to string", ():
     expect(to_str(Shape::Circle(3.14))).to_eq("Circle(3.14)")
   )
 
-  it("variant with multiple fields", ():
+  it("should convert variant with multiple fields to string", ():
     expect(to_str(Shape::Rectangle(10, 20))).to_eq("Rectangle(10, 20)")
   )
 
-  it("variant without fields", ():
+  it("should convert variant without fields to string", ():
     expect(to_str(Shape::Point)).to_eq("Point")
   )
 
-  it("print ADT enum with fields", ():
+  it("should print ADT enum with fields", ():
     print(Shape::Circle(2.5))
     # expect-output: Circle(2.5)
   )
 
-  it("f-string with ADT enum", ():
+  it("should interpolate ADT enum in f-string", ():
     s = Shape::Rectangle(3, 4)
     expect(f"shape: {s}").to_eq("shape: Rectangle(3, 4)")
   )
 
-  it("ADT enum field preserves unsigned type metadata", ():
+  it("should preserve unsigned type metadata in ADT enum field", ():
     p = Packet::Data(200 as u8)
     expect(to_str(p)).to_eq("Data(200)")
     print(p)
@@ -159,35 +159,35 @@ describe("to_str on ADT enum", ():
 )
 
 describe("to_str on Error", ():
-  it("basic error", ():
+  it("should convert basic error to string", ():
     e = Error("something went wrong")
     expect(to_str(e)).to_eq("Error: something went wrong (code: 0)")
   )
 
-  it("error with code", ():
+  it("should convert error with code to string", ():
     e = Error("not found", 404)
     expect(to_str(e)).to_eq("Error: not found (code: 404)")
   )
 
-  it("f-string with error", ():
+  it("should interpolate error in f-string", ():
     e = Error("fail")
     expect(f"got: {e}").to_eq("got: Error: fail (code: 0)")
   )
 )
 
 describe("to_str on fixed-length array", ():
-  it("i32 array", ():
+  it("should convert i32 array to string", ():
     arr: i32[3] = [1, 2, 3]
     expect(to_str(arr)).to_eq("[1, 2, 3]")
   )
 
-  it("print fixed-length array", ():
+  it("should print fixed-length array", ():
     arr: i32[2] = [10, 20]
     print(arr)
     # expect-output: [10, 20]
   )
 
-  it("f-string with fixed-length array", ():
+  it("should interpolate fixed-length array in f-string", ():
     arr: i32[3] = [7, 8, 9]
     expect(f"arr: {arr}").to_eq("arr: [7, 8, 9]")
   )

--- a/tests/spec/print_tuple_collection.test.ry
+++ b/tests/spec/print_tuple_collection.test.ry
@@ -1,39 +1,39 @@
 describe("tuple display", ():
-  it("simple tuple to_str", ():
+  it("should convert simple tuple to string", ():
     t = (1, 2)
     expect(to_str(t)).to_eq("(1, 2)")
   )
-  it("mixed-type tuple to_str", ():
+  it("should convert mixed-type tuple to string", ():
     t = (1, "hello", 3.14)
     expect(to_str(t)).to_eq("(1, hello, 3.14)")
   )
-  it("nested tuple to_str", ():
+  it("should convert nested tuple to string", ():
     t = ((1, 2), (3, 4))
     expect(to_str(t)).to_eq("((1, 2), (3, 4))")
   )
 )
 
 describe("list of tuples display", ():
-  it("zip result to_str", ():
+  it("should convert zip result to string", ():
     result = zip([1, 2, 3], ["a", "b", "c"])
     expect(to_str(result)).to_eq("[(1, a), (2, b), (3, c)]")
   )
 )
 
 describe("f-string with collections", ():
-  it("f-string with list", ():
+  it("should interpolate list in f-string", ():
     xs = [1, 2, 3]
     expect(f"items: {xs}").to_eq("items: [1, 2, 3]")
   )
-  it("f-string with map", ():
+  it("should interpolate map in f-string", ():
     m = {"a": 1}
     expect(f"map: {m}").to_eq("map: {a: 1}")
   )
-  it("f-string with set", ():
+  it("should interpolate set in f-string", ():
     s = {10, 20}
     expect(f"set: {s}").to_eq("set: {10, 20}")
   )
-  it("f-string with tuple", ():
+  it("should interpolate tuple in f-string", ():
     t = (1, 2)
     expect(f"t: {t}").to_eq("t: (1, 2)")
   )

--- a/tests/spec/record_field_index.test.ry
+++ b/tests/spec/record_field_index.test.ry
@@ -1,6 +1,6 @@
 describe("record_field_index", ():
 
-  it("list field index access", ():
+  it("should access list field by index", ():
     record Container:
       items: List<int>
 
@@ -10,7 +10,7 @@ describe("record_field_index", ():
     expect(c.items[2]).to_eq(30)
   )
 
-  it("list field assigned to variable then indexed", ():
+  it("should index list field after assignment to variable", ():
     record Holder:
       data: List<int>
 
@@ -20,7 +20,7 @@ describe("record_field_index", ():
     expect(xs[2]).to_eq(300)
   )
 
-  it("map field index access", ():
+  it("should access map field by index", ():
     record Config:
       settings: Map<str, str>
 
@@ -29,7 +29,7 @@ describe("record_field_index", ():
     expect(cfg.settings["port"]).to_eq("8080")
   )
 
-  it("list field index in function", ():
+  it("should access list field by index in function", ():
     record Matrix:
       data: List<int>
 
@@ -41,7 +41,7 @@ describe("record_field_index", ():
     expect(get_element(mat, 3)).to_eq(20)
   )
 
-  it("nested list field index access", ():
+  it("should access nested list field by index", ():
     record Grid:
       rows: List<List<int>>
 
@@ -51,7 +51,7 @@ describe("record_field_index", ():
     expect(row[1]).to_eq(2)
   )
 
-  it("list field with negative index", ():
+  it("should access list field with negative index", ():
     record Bag:
       items: List<int>
 
@@ -60,7 +60,7 @@ describe("record_field_index", ():
     expect(b.items[-3]).to_eq(10)
   )
 
-  it("operator overload using record list field", ():
+  it("should support operator overload using record list field", ():
     record Vec:
       elems: List<int>
 

--- a/tests/spec/record_subtyping.test.ry
+++ b/tests/spec/record_subtyping.test.ry
@@ -6,22 +6,22 @@ function handle_error(e: Error) -> str:
   return e.message
 
 describe("record subtyping", ():
-  it("constructor with inherited fields", ():
+  it("should construct with inherited fields", ():
     err = HttpError("not found", 404, 404, "/api")
     expect(err.message).to_eq("not found")
     expect(err.code).to_eq(404)
     expect(err.status).to_eq(404)
     expect(err.url).to_eq("/api")
   )
-  it("subtype coercion in function call", ():
+  it("should coerce subtype in function call", ():
     err = HttpError("fail", 500, 500, "/x")
     expect(handle_error(err)).to_eq("fail")
   )
-  it("auto == includes inherited fields", ():
+  it("should include inherited fields in auto ==", ():
     expect(HttpError("a", 1, 200, "/x") == HttpError("a", 1, 200, "/x")).to_be_true()
     expect(HttpError("a", 1, 200, "/x") == HttpError("b", 1, 200, "/x")).to_be_false()
   )
-  it("auto to_str includes inherited fields", ():
+  it("should include inherited fields in auto to_str", ():
     err = HttpError("err", 1, 404, "/api")
     expect(to_str(err)).to_eq("HttpError(message: err, code: 1, status: 404, url: /api)")
   )
@@ -31,7 +31,7 @@ record DetailedHttpError < HttpError:
   detail: str
 
 describe("deep inheritance", ():
-  it("constructor with all ancestor fields", ():
+  it("should construct with all ancestor fields", ():
     derr = DetailedHttpError("fail", 500, 500, "/x", "server crash")
     expect(derr.message).to_eq("fail")
     expect(derr.code).to_eq(500)
@@ -39,7 +39,7 @@ describe("deep inheritance", ():
     expect(derr.url).to_eq("/x")
     expect(derr.detail).to_eq("server crash")
   )
-  it("deep coercion to grandparent", ():
+  it("should coerce deeply to grandparent", ():
     derr = DetailedHttpError("fail", 500, 500, "/x", "crash")
     expect(handle_error(derr)).to_eq("fail")
   )
@@ -55,7 +55,7 @@ record NamedPositive < Positive:
   name: str
 
 describe("invariant inheritance", ():
-  it("child with valid parent fields succeeds", ():
+  it("should succeed when child has valid parent fields", ():
     np = NamedPositive(42, "good")
     expect(np.value).to_eq(42)
     expect(np.name).to_eq("good")
@@ -70,7 +70,7 @@ function fetch_data(url: str) -> Result<int, Error>:
   return Err(ApiError("not found", 404, url))
 
 describe("Err auto-slicing", ():
-  it("Err(subtype) auto-slices to Error in Result", ():
+  it("should auto-slice Err(subtype) to Error in Result", ():
     result = fetch_data("/api")
     match result:
       case Err(e):
@@ -86,7 +86,7 @@ function to_error(msg: str) -> Error:
   return ApiError(msg, 500, "/internal")
 
 describe("return subtype coercion", ():
-  it("return subtype auto-slices to parent return type", ():
+  it("should auto-slice return subtype to parent return type", ():
     e = to_error("fail")
     expect(e.message).to_eq("fail")
     expect(e.code).to_eq(500)
@@ -104,13 +104,13 @@ function describe_animal(a: Animal) -> str:
   return f"{a.name} has {a.legs} legs"
 
 describe("non-Error subtyping", ():
-  it("basic field inheritance", ():
+  it("should inherit basic fields", ():
     d = Dog("Rex", 4, "Labrador")
     expect(d.name).to_eq("Rex")
     expect(d.legs).to_eq(4)
     expect(d.breed).to_eq("Labrador")
   )
-  it("coercion to parent type", ():
+  it("should coerce to parent type", ():
     d = Dog("Rex", 4, "Labrador")
     expect(describe_animal(d)).to_eq("Rex has 4 legs")
   )
@@ -121,7 +121,7 @@ record Owner:
   pet: Animal
 
 describe("field assignment subtype coercion", ():
-  it("assigns child type to parent-type field", ():
+  it("should assign child type to parent-type field", ():
     o = Owner(Animal("cat", 4))
     o.pet = Dog("Rex", 4, "Labrador")
     expect(o.pet.name).to_eq("Rex")
@@ -138,7 +138,7 @@ function process_data(url: str) -> Result<int, Error>:
   return Ok(val)
 
 describe("? operator subtype coercion", ():
-  it("propagates subtype error through ?", ():
+  it("should propagate subtype error through ?", ():
     result = process_data("/api")
     match result:
       case Err(e):

--- a/tests/spec/regex_literal.test.ry
+++ b/tests/spec/regex_literal.test.ry
@@ -1,47 +1,47 @@
 from regex import is_match, search, replace, split, find_all
 
 describe("regex literal match", ():
-  it("full match", ():
+  it("should perform full match", ():
     expect(is_match("hello", /[a-z]+/)).to_eq(true)
     expect(is_match("123", /[a-z]+/)).to_eq(false)
     expect(is_match("123", /[0-9]+/)).to_eq(true)
   )
-  it("UFCS", ():
+  it("should support UFCS for match", ():
     expect("hello".is_match(/[a-z]+/)).to_eq(true)
     expect("123".is_match(/[a-z]+/)).to_eq(false)
   )
 )
 
 describe("regex literal search", ():
-  it("returns position", ():
+  it("should return position of match", ():
     expect(search("abc123", /[0-9]+/)).to_eq(3)
     expect(search("hello", /[0-9]+/)).to_eq(-1)
   )
-  it("UFCS", ():
+  it("should support UFCS for search", ():
     expect("abc123".search(/[0-9]+/)).to_eq(3)
   )
 )
 
 describe("regex literal replace", ():
-  it("replaces all matches", ():
+  it("should replace all matches", ():
     expect(replace("a1b2c3", /[0-9]+/, "X")).to_eq("aXbXcX")
   )
-  it("UFCS replaces all matches", ():
+  it("should replace all matches via UFCS", ():
     expect("a1b2c3".replace(/[0-9]+/, "X")).to_eq("aXbXcX")
   )
-  it("no match returns original", ():
+  it("should return original when no match", ():
     expect(replace("hello", /[0-9]+/, "X")).to_eq("hello")
   )
 )
 
 describe("regex literal split", ():
-  it("splits by pattern", ():
+  it("should split by pattern", ():
     parts = split("a1b2c", /[0-9]/)
     expect(parts[0]).to_eq("a")
     expect(parts[1]).to_eq("b")
     expect(parts[2]).to_eq("c")
   )
-  it("UFCS", ():
+  it("should support UFCS for split", ():
     parts = "hello world".split(/\s+/)
     expect(parts[0]).to_eq("hello")
     expect(parts[1]).to_eq("world")
@@ -49,21 +49,21 @@ describe("regex literal split", ():
 )
 
 describe("regex literal find_all", ():
-  it("finds all matches", ():
+  it("should find all matches", ():
     nums = find_all("a1b2c3", /[0-9]/)
     expect(length(nums)).to_eq(3)
     expect(nums[0]).to_eq("1")
     expect(nums[1]).to_eq("2")
     expect(nums[2]).to_eq("3")
   )
-  it("UFCS", ():
+  it("should support UFCS for find_all", ():
     nums = "a1b2c3".find_all(/[0-9]/)
     expect(length(nums)).to_eq(3)
   )
 )
 
 describe("regex literal variable", ():
-  it("works via variable", ():
+  it("should work via variable", ():
     pat = /[a-z]+/
     expect(is_match("hello", pat)).to_eq(true)
     expect("world".is_match(pat)).to_eq(true)
@@ -71,46 +71,46 @@ describe("regex literal variable", ():
 )
 
 describe("regex literal division coexistence", ():
-  it("division still works", ():
+  it("should still support division", ():
     expect(10 / 2).to_eq(5)
     expect(100 // 3).to_eq(33)
   )
 )
 
 describe("regex literal escaped slash", ():
-  it("handles escaped /", ():
+  it("should handle escaped /", ():
     expect(is_match("a/b", /a\/b/)).to_eq(true)
   )
 )
 
 describe("string split/replace still work", ():
-  it("string split", ():
+  it("should support string split", ():
     parts = split("a,b,c", ",")
     expect(parts[0]).to_eq("a")
     expect(parts[1]).to_eq("b")
     expect(parts[2]).to_eq("c")
   )
-  it("string replace", ():
+  it("should support string replace", ():
     expect(replace("hello world", "world", "ry")).to_eq("hello ry")
   )
 )
 
 describe("backward compatibility", ():
-  it("regex_match still works", ():
+  it("should support regex_match", ():
     expect(regex_match("hello", "[a-z]+")).to_eq(true)
   )
-  it("regex_search still works", ():
+  it("should support regex_search", ():
     expect(regex_search("abc123", "[0-9]+")).to_eq(3)
   )
-  it("regex_replace still works", ():
+  it("should support regex_replace", ():
     expect(regex_replace("abc123", "[0-9]+", "X")).to_eq("abcX")
   )
-  it("regex_split still works", ():
+  it("should support regex_split", ():
     parts = regex_split("a1b2c", "[0-9]")
     expect(parts[0]).to_eq("a")
     expect(parts[1]).to_eq("b")
   )
-  it("regex_find_all still works", ():
+  it("should support regex_find_all", ():
     nums = regex_find_all("a1b2c3", "[0-9]")
     expect(length(nums)).to_eq(3)
   )

--- a/tests/spec/regex_phase2.test.ry
+++ b/tests/spec/regex_phase2.test.ry
@@ -1,62 +1,62 @@
 describe("range quantifiers", ():
-  it("{n} exact", ():
+  it("should match {n} exact", ():
     expect(regex_match("aaa", "a{3}")).to_eq(true)
     expect(regex_match("aa", "a{3}")).to_eq(false)
   )
-  it("{n,m} range", ():
+  it("should match {n,m} range", ():
     expect(regex_match("aaa", "a{2,4}")).to_eq(true)
     expect(regex_match("a", "a{2,4}")).to_eq(false)
     expect(regex_match("aaaaa", "a{2,4}")).to_eq(false)
   )
-  it("{n,} min only", ():
+  it("should match {n,} min only", ():
     expect(regex_match("aa", "a{2,}")).to_eq(true)
     expect(regex_match("aaaa", "a{2,}")).to_eq(true)
     expect(regex_match("a", "a{2,}")).to_eq(false)
   )
-  it("digit pattern", ():
+  it("should match digit pattern", ():
     expect(regex_match("123-4567", "\\d{3}-\\d{4}")).to_eq(true)
     expect(regex_match("12-4567", "\\d{3}-\\d{4}")).to_eq(false)
   )
 )
 
 describe("empty and edge patterns", ():
-  it("empty pattern matches empty string", ():
+  it("should match empty pattern against empty string", ():
     expect(regex_match("", "")).to_eq(true)
   )
-  it("dot matches any character", ():
+  it("should match dot against any character", ():
     expect(regex_match("a", ".")).to_eq(true)
     expect(regex_match(" ", ".")).to_eq(true)
   )
-  it("dot does not match empty", ():
+  it("should not match dot against empty string", ():
     expect(regex_match("", ".")).to_eq(false)
   )
-  it("match entire string only", ():
+  it("should match entire string only", ():
     expect(regex_match("abc", "abc")).to_eq(true)
     expect(regex_match("xabcx", "abc")).to_eq(false)
   )
-  it("search in empty string", ():
+  it("should return -1 when searching in empty string", ():
     expect(regex_search("", "a")).to_eq(-1)
   )
-  it("find_all no matches", ():
+  it("should return empty list when find_all has no matches", ():
     matches = regex_find_all("hello world", "xyz")
     expect(length(matches)).to_eq(0)
   )
-  it("replace no matches", ():
+  it("should return original when replace has no matches", ():
     expect(regex_replace("hello", "xyz", "X")).to_eq("hello")
   )
 )
 
 describe("non-greedy when", ():
-  it("lazy star replace", ():
+  it("should replace with lazy star", ():
     expect(regex_replace("\"a\" and \"b\"", "\".*?\"", "X")).to_eq("X and X")
   )
-  it("lazy plus replace", ():
+  it("should replace with lazy plus", ():
     expect(regex_replace("aaa", "a+?", "X")).to_eq("XXX")
   )
-  it("lazy full when", ():
+  it("should match with lazy full pattern", ():
     expect(regex_match("aaa", "a+?")).to_eq(true)
   )
-  it("lazy find_all", ():
+  it("should find all matches with lazy quantifier", ():
     tags = regex_find_all("<x> <yy> <zzz>", "<.*?>")
     expect(length(tags)).to_eq(3)
     expect(tags[0]).to_eq("<x>")

--- a/tests/spec/regex_phase3.test.ry
+++ b/tests/spec/regex_phase3.test.ry
@@ -1,21 +1,21 @@
 describe("word boundary \\b / \\B", ():
-  it("\\b matches word boundary", ():
+  it("should match \\b at word boundary", ():
     expect(regex_search("hello world", "\\bworld\\b")).to_eq(6)
     expect(regex_search("helloworld", "\\bword\\b")).to_eq(-1)
   )
-  it("\\B matches non-boundary", ():
+  it("should match \\B at non-boundary", ():
     expect(regex_search("helloworld", "\\Bworld")).to_eq(5)
     expect(regex_search("world test", "\\Bworld")).to_eq(-1)
   )
-  it("\\b at start and end", ():
+  it("should match \\b at start and end", ():
     expect(regex_search("hello world", "\\bhello")).to_eq(0)
     expect(regex_search("hello world", "world\\b")).to_eq(6)
   )
-  it("\\b with digits and underscores", ():
+  it("should match \\b with digits and underscores", ():
     expect(regex_match("hello_123", "\\b\\w+\\b")).to_eq(true)
     expect(regex_search("abc 123 def", "\\b123\\b")).to_eq(4)
   )
-  it("\\b find_all", ():
+  it("should find all words with \\b", ():
     words = regex_find_all("hello world foo", "\\b\\w+\\b")
     expect(length(words)).to_eq(3)
     expect(words[0]).to_eq("hello")
@@ -25,32 +25,32 @@ describe("word boundary \\b / \\B", ():
 )
 
 describe("case-insensitive (?i)", ():
-  it("basic when", ():
+  it("should match case-insensitively with (?i)", ():
     expect(regex_match("HELLO", "(?i)hello")).to_eq(true)
     expect(regex_match("Hello", "(?i)hello")).to_eq(true)
     expect(regex_match("hello", "(?i)hello")).to_eq(true)
   )
-  it("char class", ():
+  it("should match char class case-insensitively", ():
     expect(regex_match("ABC", "(?i)[a-z]+")).to_eq(true)
     expect(regex_match("ABCDEF", "(?i)[a-f]+")).to_eq(true)
   )
-  it("case-sensitive by default", ():
+  it("should be case-sensitive by default", ():
     expect(regex_match("HELLO", "hello")).to_eq(false)
   )
-  it("search", ():
+  it("should search case-insensitively", ():
     expect(regex_search("Hello WORLD", "(?i)world")).to_eq(6)
   )
-  it("replace", ():
+  it("should replace case-insensitively", ():
     expect(regex_replace("Hello HELLO hello", "(?i)hello", "X")).to_eq("X X X")
   )
-  it("find_all", ():
+  it("should find all matches case-insensitively", ():
     matches = regex_find_all("Hello HELLO hello", "(?i)hello")
     expect(length(matches)).to_eq(3)
     expect(matches[0]).to_eq("Hello")
     expect(matches[1]).to_eq("HELLO")
     expect(matches[2]).to_eq("hello")
   )
-  it("combined with \\b", ():
+  it("should combine (?i) with \\b", ():
     expect(regex_search("Hello WORLD", "(?i)\\bworld\\b")).to_eq(6)
   )
 )

--- a/tests/spec/relative_import/mymath/mymath.test.ry
+++ b/tests/spec/relative_import/mymath/mymath.test.ry
@@ -1,7 +1,7 @@
 from . import add, sub
 
 describe("relative import from current directory", ():
-    it("imports symbols from multiple files in same directory", ():
+    it("should import symbols from multiple files in same directory", ():
         expect(add(2, 3)).to_eq(5)
         expect(sub(10, 4)).to_eq(6)
     )

--- a/tests/spec/relative_import/relative_import.test.ry
+++ b/tests/spec/relative_import/relative_import.test.ry
@@ -2,10 +2,10 @@ from .helper import greet
 from .mymath import add, sub
 
 describe("relative import", ():
-    it("import from sibling module", ():
+    it("should import from sibling module", ():
         expect(greet()).to_eq("hello")
     )
-    it("import from subdirectory package (multiple files)", ():
+    it("should import from subdirectory package (multiple files)", ():
         expect(add(2, 3)).to_eq(5)
         expect(sub(10, 4)).to_eq(6)
     )

--- a/tests/spec/resource_arc.test.ry
+++ b/tests/spec/resource_arc.test.ry
@@ -1,7 +1,7 @@
 from thread import lock_new, lock_acquire, lock_release, lock_free, atomic_int_new, atomic_int_load, atomic_int_store, atomic_int_free, thread_spawn, thread_join
 
 describe("ARC resource cleanup", ():
-  it("Lock is usable after creation", ():
+  it("should be usable after Lock creation", ():
     lock = lock_new()
     result = lock_acquire(lock)
     expect(result).to_be_ok()
@@ -9,7 +9,7 @@ describe("ARC resource cleanup", ():
     expect(result2).to_be_ok()
   )
 
-  it("Lock explicit free then scope exit is safe", ():
+  it("should be safe to explicitly free Lock then exit scope", ():
     lock = lock_new()
     result = lock_acquire(lock)
     expect(result).to_be_ok()
@@ -19,21 +19,21 @@ describe("ARC resource cleanup", ():
     expect(true).to_be_true()
   )
 
-  it("AtomicInt is usable after creation", ():
+  it("should be usable after AtomicInt creation", ():
     counter = atomic_int_new(0)
     atomic_int_store(counter, 42)
     val = atomic_int_load(counter)
     expect(val).to_eq(42)
   )
 
-  it("AtomicInt explicit free then scope exit is safe", ():
+  it("should be safe to explicitly free AtomicInt then exit scope", ():
     counter = atomic_int_new(10)
     val = atomic_int_load(counter)
     atomic_int_free(counter)
     expect(val).to_eq(10)
   )
 
-  it("Thread join and scope exit", ():
+  it("should handle Thread join and scope exit", ():
     result = atomic_int_new(0)
     t = thread_spawn(():
       atomic_int_store(result, 99)

--- a/tests/spec/result.test.ry
+++ b/tests/spec/result.test.ry
@@ -16,76 +16,76 @@ function inline_expr(a: int, b: int) -> Result<int, Error>:
   return Ok(safe_divide(a, b)? + 1)
 
 describe("Result type", ():
-  it("Ok wraps value", ():
+  it("should wrap value in Ok", ():
     res = Ok(42)
     expect(res).to_be_ok()
   )
-  it("Err wraps error", ():
+  it("should wrap error in Err", ():
     res = Err(Error("fail"))
     expect(res).to_be_err()
   )
-  it("when Ok extracts value", ():
+  it("should extract value when Ok", ():
     match safe_divide(10, 2):
       case Ok(v):
         expect(v).to_eq(5)
       case Err(e):
         fail("unexpected error")
   )
-  it("when Err extracts error", ():
+  it("should extract error when Err", ():
     match safe_divide(10, 0):
       case Ok(v):
         fail("expected Err but got Ok")
       case Err(e):
         expect(e.message).to_eq("division by zero")
   )
-  it("? unwraps Ok value", ():
+  it("should unwrap Ok value with ?", ():
     match divide_and_add(10, 2):
       case Ok(v):
         expect(v).to_eq(6)
       case Err(e):
         fail("unexpected error")
   )
-  it("? propagates Err", ():
+  it("should propagate Err with ?", ():
     match divide_and_add(10, 0):
       case Ok(v):
         fail("expected Err but got Ok")
       case Err(e):
         expect(e.message).to_eq("division by zero")
   )
-  it("chained ? propagation", ():
+  it("should propagate chained ?", ():
     match chained(100, 10, 2):
       case Ok(v):
         expect(v).to_eq(5)
       case Err(e):
         fail("unexpected error")
   )
-  it("chained ? propagates from second call", ():
+  it("should propagate chained ? from second call", ():
     match chained(100, 10, 0):
       case Ok(v):
         fail("expected Err but got Ok")
       case Err(e):
         expect(e.message).to_eq("division by zero")
   )
-  it("? in expression position with arithmetic", ():
+  it("should support ? in expression position with arithmetic", ():
     match inline_expr(10, 2):
       case Ok(v):
         expect(v).to_eq(6)
       case Err(e):
         fail("unexpected error")
   )
-  it("Ok(0) is still Ok", ():
+  it("should recognize Ok(0) as Ok", ():
     res = Ok(0)
     expect(res).to_be_ok()
   )
-  it("Ok empty string is still Ok", ():
+  it("should recognize Ok with empty string as Ok", ():
     res: Result<str, Error> = Ok("")
     expect(res).to_be_ok()
   )
-  it("Err with empty message", ():
+  it("should recognize Err with empty message as Err", ():
     res = Err(Error(""))
     expect(res).to_be_err()
   )
-  it("when Ok with wildcard for Unit result", ():
+  it("should match Ok with wildcard for Unit result", ():
     function unit_ok() -> Result<Unit, Error>:
       return Ok(0 as u8)
     match unit_ok():

--- a/tests/spec/result_chain.test.ry
+++ b/tests/spec/result_chain.test.ry
@@ -4,28 +4,28 @@ function safe_divide(a: int, b: int) -> Result<int, Error>:
   return Ok(a // b)
 
 describe("Result and_then", ():
-  it("chains Ok values", ():
+  it("should chain Ok values", ():
     res = safe_divide(10, 2).and_then((v: int) => safe_divide(v, 1))
     match res:
       case Ok(v): expect(v).to_eq(5)
       case Err(e): fail("unexpected error: " + e.message)
   )
 
-  it("short-circuits on first Err", ():
+  it("should short-circuit on first Err", ():
     res = safe_divide(10, 0).and_then((v: int) => safe_divide(v, 1))
     match res:
       case Ok(v): fail("expected Err but got Ok")
       case Err(e): expect(e.message).to_eq("division by zero")
   )
 
-  it("short-circuits on second Err", ():
+  it("should short-circuit on second Err", ():
     res = safe_divide(10, 2).and_then((v: int) => safe_divide(v, 0))
     match res:
       case Ok(v): fail("expected Err but got Ok")
       case Err(e): expect(e.message).to_eq("division by zero")
   )
 
-  it("chains multiple and_then", ():
+  it("should chain multiple and_then", ():
     res = safe_divide(100, 2).and_then((v: int) => safe_divide(v, 5)).and_then((v: int) => safe_divide(v, 2))
     match res:
       case Ok(v): expect(v).to_eq(5)
@@ -34,21 +34,21 @@ describe("Result and_then", ():
 )
 
 describe("Result map", ():
-  it("maps Ok value", ():
+  it("should map Ok value", ():
     res = safe_divide(10, 2).map((v: int) => v * 10)
     match res:
       case Ok(v): expect(v).to_eq(50)
       case Err(e): fail("unexpected error: " + e.message)
   )
 
-  it("preserves Err on map", ():
+  it("should preserve Err on map", ():
     res = safe_divide(10, 0).map((v: int) => v * 10)
     match res:
       case Ok(v): fail("expected Err but got Ok")
       case Err(e): expect(e.message).to_eq("division by zero")
   )
 
-  it("map with arithmetic", ():
+  it("should map with arithmetic", ():
     res = safe_divide(10, 2).map((v: int) => v + 1)
     match res:
       case Ok(v): expect(v).to_eq(6)
@@ -57,21 +57,21 @@ describe("Result map", ():
 )
 
 describe("Result chaining (mixed)", ():
-  it("and_then followed by map", ():
+  it("should support and_then followed by map", ():
     res = safe_divide(100, 10).and_then((v: int) => safe_divide(v, 2)).map((v: int) => v + 100)
     match res:
       case Ok(v): expect(v).to_eq(105)
       case Err(e): fail("unexpected error: " + e.message)
   )
 
-  it("map followed by and_then", ():
+  it("should support map followed by and_then", ():
     res = safe_divide(10, 2).map((v: int) => v * 4).and_then((v: int) => safe_divide(v, 5))
     match res:
       case Ok(v): expect(v).to_eq(4)
       case Err(e): fail("unexpected error: " + e.message)
   )
 
-  it("error propagates through mixed chain", ():
+  it("should propagate error through mixed chain", ():
     res = safe_divide(10, 0).map((v: int) => v * 10).and_then((v: int) => safe_divide(v, 2))
     match res:
       case Ok(v): fail("expected Err but got Ok")

--- a/tests/spec/return_check.test.ry
+++ b/tests/spec/return_check.test.ry
@@ -1,5 +1,5 @@
 describe("return check - all paths return", ():
-  it("if/else returns on all paths", ():
+  it("should return on all paths with if/else", ():
     function abs(x: int) -> int:
       if x < 0:
         return -x
@@ -8,7 +8,7 @@ describe("return check - all paths return", ():
     expect(abs(-3)).to_eq(3)
     expect(abs(5)).to_eq(5)
   )
-  it("when returns on all paths", ():
+  it("should return on all paths with when", ():
     function sign(x: int) -> int:
       when:
         x > 0:
@@ -21,7 +21,7 @@ describe("return check - all paths return", ():
     expect(sign(-5)).to_eq(-1)
     expect(sign(0)).to_eq(0)
   )
-  it("when with wildcard returns on all paths", ():
+  it("should return on all paths with when and wildcard", ():
     function describe(x: int) -> str:
       match x:
         case 1:
@@ -33,7 +33,7 @@ describe("return check - all paths return", ():
     expect(describe(1)).to_eq("one")
     expect(describe(99)).to_eq("other")
   )
-  it("nested if/else returns on all paths", ():
+  it("should return on all paths with nested if/else", ():
     function classify(x: int) -> str:
       if x > 0:
         if x > 100:
@@ -46,7 +46,7 @@ describe("return check - all paths return", ():
     expect(classify(50)).to_eq("small")
     expect(classify(-1)).to_eq("non-positive")
   )
-  it("when with Ok/Err returns on all paths", ():
+  it("should return on all paths with Ok/Err match", ():
     function check(r: Result<int, Error>) -> str:
       match r:
         case Ok(v):
@@ -55,7 +55,7 @@ describe("return check - all paths return", ():
           return "err"
     expect(check(Ok(1))).to_eq("ok")
   )
-  it("when with Some/None returns on all paths", ():
+  it("should return on all paths with Some/None match", ():
     function check(o: Option<int>) -> str:
       match o:
         case Some(v):
@@ -65,7 +65,7 @@ describe("return check - all paths return", ():
     expect(check(Some(1))).to_eq("some")
     expect(check(None)).to_eq("none")
   )
-  it("match on ADT enum with all variants returns on all paths (#513)", ():
+  it("should return on all paths when matching ADT enum with all variants (#513)", ():
     enum Shape:
       Circle(float)
       Rect(float, float)
@@ -79,7 +79,7 @@ describe("return check - all paths return", ():
     expect(area(Shape::Circle(5.0))).to_eq(78.5)
     expect(area(Shape::Rect(3.0, 4.0))).to_eq(12.0)
   )
-  it("match on simple enum with all variants returns on all paths (#513)", ():
+  it("should return on all paths when matching simple enum with all variants (#513)", ():
     enum Color:
       Red
       Green
@@ -97,7 +97,7 @@ describe("return check - all paths return", ():
     expect(name(Color::Green)).to_eq("green")
     expect(name(Color::Blue)).to_eq("blue")
   )
-  it("match on bool with true/false returns on all paths (#513)", ():
+  it("should return on all paths when matching bool with true/false (#513)", ():
     function describe(b: bool) -> str:
       match b:
         case true:

--- a/tests/spec/sleep.test.ry
+++ b/tests/spec/sleep.test.ry
@@ -1,13 +1,13 @@
 describe("sleep", ():
-  it("completes with zero duration", ():
+  it("should complete with zero duration", ():
     sleep(0)
     expect(true).to_eq(true)
   )
-  it("completes with positive duration", ():
+  it("should complete with positive duration", ():
     sleep(5)
     expect(true).to_eq(true)
   )
-  it("completes with negative duration", ():
+  it("should complete with negative duration", ():
     sleep(-1)
     expect(true).to_eq(true)
   )

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -1,123 +1,123 @@
 describe("search and check", ():
-  it("contains", ():
+  it("should check contains", ():
     expect("hello").to_contain("ell")
     expect(contains("hello", "xyz")).to_be_false()
   )
-  it("starts_with", ():
+  it("should check starts_with", ():
     expect("hello").to_start_with("hel")
     expect(starts_with("hello", "world")).to_be_false()
   )
-  it("ends_with", ():
+  it("should check ends_with", ():
     expect("hello").to_end_with("llo")
     expect(ends_with("hello", "world")).to_be_false()
   )
-  it("contains ignore_case", ():
+  it("should check contains case-insensitively", ():
     expect(contains("Hello World", "hello", true)).to_be_true()
     expect(contains("Hello World", "WORLD", true)).to_be_true()
     expect(contains("Hello World", "xyz", true)).to_be_false()
     expect(contains("Hello", "hello", false)).to_be_false()
     expect("Hello".contains("hello", true)).to_be_true()
   )
-  it("starts_with ignore_case", ():
+  it("should check starts_with case-insensitively", ():
     expect(starts_with("Hello World", "hello", true)).to_be_true()
     expect(starts_with("Hello World", "HELLO", true)).to_be_true()
     expect(starts_with("Hello World", "world", true)).to_be_false()
     expect("Hello".starts_with("hel", true)).to_be_true()
   )
-  it("ends_with ignore_case", ():
+  it("should check ends_with case-insensitively", ():
     expect(ends_with("Hello World", "world", true)).to_be_true()
     expect(ends_with("Hello World", "WORLD", true)).to_be_true()
     expect(ends_with("Hello World", "hello", true)).to_be_false()
     expect(ends_with("hi", "HELLO", true)).to_be_false()
     expect("Hello".ends_with("llo", true)).to_be_true()
   )
-  it("find", ():
+  it("should find substring", ():
     expect(find("hello world", "world")).to_eq(Some(6))
     expect(find("hello", "xyz")).to_be_none()
     expect(find("abcdef", "cd")).to_eq(Some(2))
   )
-  it("find in empty string", ():
+  it("should return none when finding in empty string", ():
     expect(find("", "x")).to_be_none()
   )
-  it("find empty needle", ():
+  it("should find empty needle at position 0", ():
     expect(find("hello", "")).to_eq(Some(0))
   )
-  it("contains empty needle", ():
+  it("should return true when contains empty needle", ():
     expect(contains("hello", "")).to_be_true()
   )
-  it("contains empty haystack and needle", ():
+  it("should return true when contains empty haystack and needle", ():
     expect(contains("", "")).to_be_true()
   )
 )
 
 describe("extraction and transformation", ():
-  it("substring", ():
+  it("should extract substring", ():
     expect(substring("hello world", 0, 5)).to_eq("hello")
     expect(substring("abcdef", 1, 4)).to_eq("bcd")
   )
-  it("substring out of bounds clamps", ():
+  it("should clamp out-of-bounds substring", ():
     expect(substring("abc", 0, 100)).to_eq("abc")
     expect(substring("abc", 5, 10)).to_eq("")
   )
-  it("substring negative clamps to zero", ():
+  it("should clamp negative substring index to zero", ():
     expect(substring("abc", -1, 2)).to_eq("ab")
   )
-  it("char_at", ():
+  it("should get char_at position", ():
     expect(char_at("hello", 0)).to_eq("h")
     expect(char_at("abc", 2)).to_eq("c")
   )
-  it("replace", ():
+  it("should replace substring", ():
     expect(replace("hello world", "world", "ry")).to_eq("hello ry")
     expect(replace("foo bar foo", "foo", "baz")).to_eq("baz bar baz")
   )
-  it("replace not found", ():
+  it("should return original when replace target not found", ():
     expect(replace("hello", "xyz", "abc")).to_eq("hello")
   )
 )
 
 describe("case conversion", ():
-  it("to_upper", ():
+  it("should convert to uppercase", ():
     expect(to_upper("hello")).to_eq("HELLO")
     expect(to_upper("Hello World")).to_eq("HELLO WORLD")
   )
-  it("to_upper empty", ():
+  it("should handle empty string in to_upper", ():
     expect(to_upper("")).to_eq("")
   )
-  it("to_lower", ():
+  it("should convert to lowercase", ():
     expect(to_lower("HELLO")).to_eq("hello")
     expect(to_lower("Hello World")).to_eq("hello world")
   )
-  it("to_lower empty", ():
+  it("should handle empty string in to_lower", ():
     expect(to_lower("")).to_eq("")
   )
 )
 
 describe("whitespace", ():
-  it("trim", ():
+  it("should trim whitespace", ():
     expect(trim("  hello  ")).to_eq("hello")
     expect(trim("  hi  ")).to_eq("hi")
   )
-  it("trim empty", ():
+  it("should trim empty string", ():
     expect(trim("")).to_eq("")
   )
-  it("trim_start", ():
+  it("should trim start whitespace", ():
     expect(trim_start("  hello  ")).to_eq("hello  ")
     expect(trim_start("  hi")).to_eq("hi")
   )
-  it("trim_start empty", ():
+  it("should trim start of empty string", ():
     expect(trim_start("")).to_eq("")
   )
-  it("trim_end", ():
+  it("should trim end whitespace", ():
     expect(trim_end("  hello  ")).to_eq("  hello")
     expect(trim_end("hi  ")).to_eq("hi")
   )
-  it("trim_end empty", ():
+  it("should trim end of empty string", ():
     expect(trim_end("")).to_eq("")
   )
 )
 
 describe("generation", ():
-  it("repeat", ():
+  it("should repeat string", ():
     expect(repeat("ab", 3)).to_eq("ababab")
     expect(repeat("ha", 3)).to_eq("hahaha")
     expect(repeat("a", 0)).to_eq("")
@@ -125,37 +125,37 @@ describe("generation", ():
     expect(repeat("abc", -100)).to_eq("")
     expect(repeat("hello", 1)).to_eq("hello")
   )
-  it("repeat empty string", ():
+  it("should repeat empty string", ():
     expect(repeat("", 5)).to_eq("")
   )
-  it("reverse", ():
+  it("should reverse string", ():
     expect(reverse("hello")).to_eq("olleh")
     expect(reverse("abc")).to_eq("cba")
   )
-  it("reverse empty", ():
+  it("should reverse empty string", ():
     expect(reverse("")).to_eq("")
   )
 )
 
 describe("split and join", ():
-  it("split", ():
+  it("should split string by delimiter", ():
     parts = split("a,b,c", ",")
     expect(parts).to_have_length(3)
     expect(parts[0]).to_eq("a")
     expect(parts[1]).to_eq("b")
     expect(parts[2]).to_eq("c")
   )
-  it("split empty string", ():
+  it("should split empty string", ():
     parts = split("", ",")
     expect(parts).to_have_length(1)
     expect(parts[0]).to_eq("")
   )
-  it("split no delimiter found", ():
+  it("should return whole string when delimiter not found", ():
     parts = split("hello", ",")
     expect(parts).to_have_length(1)
     expect(parts[0]).to_eq("hello")
   )
-  it("split empty delimiter", ():
+  it("should split by empty delimiter into characters", ():
     parts = split("hello", "")
     expect(parts).to_have_length(5)
     expect(parts[0]).to_eq("h")
@@ -164,37 +164,37 @@ describe("split and join", ():
     expect(parts[3]).to_eq("l")
     expect(parts[4]).to_eq("o")
   )
-  it("split empty delimiter single char", ():
+  it("should split single char by empty delimiter", ():
     parts = split("x", "")
     expect(parts).to_have_length(1)
     expect(parts[0]).to_eq("x")
   )
-  it("split empty string empty delimiter", ():
+  it("should return empty list when splitting empty string with empty delimiter", ():
     parts = split("", "")
     expect(parts).to_have_length(0)
   )
-  it("split empty delimiter unicode", ():
+  it("should split unicode string by empty delimiter", ():
     parts = split("あいう", "")
     expect(parts).to_have_length(3)
     expect(parts[0]).to_eq("あ")
     expect(parts[1]).to_eq("い")
     expect(parts[2]).to_eq("う")
   )
-  it("join", ():
+  it("should join list with delimiter", ():
     parts = ["a", "b", "c"]
     expect(join(parts, ",")).to_eq("a,b,c")
     expect(join(parts, "-")).to_eq("a-b-c")
   )
-  it("join empty list", ():
+  it("should join empty list", ():
     parts: List<str> = ["x"]
     empty = filter(parts, (s: str) => false)
     expect(join(empty, ",")).to_eq("")
   )
-  it("join single element", ():
+  it("should join single element", ():
     parts = ["only"]
     expect(join(parts, ",")).to_eq("only")
   )
-  it("join UFCS string receiver", ():
+  it("should join via UFCS string receiver", ():
     parts = ["a", "b", "c"]
     expect(",".join(parts)).to_eq("a,b,c")
     expect("-".join(parts)).to_eq("a-b-c")
@@ -203,33 +203,33 @@ describe("split and join", ():
 )
 
 describe("UTF-8 support", ():
-  it("length counts characters", ():
+  it("should count characters with length", ():
     expect("hello").to_have_length(5)
     expect("あいう").to_have_length(3)
   )
-  it("byte_len counts bytes", ():
+  it("should count bytes with byte_len", ():
     expect(byte_len("hello")).to_eq(5)
     expect(byte_len("あいう")).to_eq(9)
   )
-  it("length empty", ():
+  it("should report length 0 for empty string", ():
     expect("").to_have_length(0)
   )
-  it("byte_len empty", ():
+  it("should report byte_len 0 for empty string", ():
     expect(byte_len("")).to_eq(0)
   )
-  it("char_at UTF-8", ():
+  it("should get char_at for UTF-8 string", ():
     expect(char_at("あいう", 1)).to_eq("い")
   )
-  it("substring UTF-8", ():
+  it("should extract UTF-8 substring", ():
     expect(substring("あいう", 0, 2)).to_eq("あい")
   )
-  it("reverse UTF-8", ():
+  it("should reverse UTF-8 string", ():
     expect(reverse("あいう")).to_eq("ういあ")
   )
 )
 
 describe("type conversion", ():
-  it("to_int valid input returns Ok", ():
+  it("should return Ok for valid to_int input", ():
     match to_int("42"):
       case Ok(v):
         expect(v).to_eq(42)
@@ -243,29 +243,29 @@ describe("type conversion", ():
     expect(to_int("123")).to_be_ok()
     expect(to_int("0")).to_be_ok()
   )
-  it("to_int invalid input returns Err", ():
+  it("should return Err for invalid to_int input", ():
     expect(to_int("abc")).to_be_err()
     expect(to_int("")).to_be_err()
     expect(to_int("12abc")).to_be_err()
     expect(to_int("9223372036854775808")).to_be_err()
     expect(to_int("-9223372036854775809")).to_be_err()
   )
-  it("to_int UFCS returns Result", ():
+  it("should return Result from to_int via UFCS", ():
     match "99".to_int():
       case Ok(v):
         expect(v).to_eq(99)
       case Err(_):
         expect(false).to_eq(true)
   )
-  it("to_float", ():
+  it("should convert string to float with to_float", ():
     expect(to_float("3.14")).to_eq(3.14)
     expect(to_float("2.5")).to_eq(2.5)
   )
-  it("to_float non-numeric returns 0", ():
+  it("should return 0 for non-numeric to_float input", ():
     expect(to_float("xyz")).to_eq(0.0)
     expect(to_float("")).to_eq(0.0)
   )
-  it("to_str", ():
+  it("should convert value to string with to_str", ():
     expect(to_str(42)).to_eq("42")
     expect(to_str(true)).to_eq("true")
     expect(to_str(99)).to_eq("99")

--- a/tests/spec/structs.test.ry
+++ b/tests/spec/structs.test.ry
@@ -7,17 +7,17 @@ record Circle:
   radius: float
 
 describe("record", ():
-  it("constructor and field access", ():
+  it("should construct and access fields", ():
     p = Point(10, 20)
     expect(p.x).to_eq(10)
     expect(p.y).to_eq(20)
   )
-  it("var field assignment", ():
+  it("should assign to var field", ():
     p = Point(10, 20)
     p.x = 100
     expect(p.x).to_eq(100)
   )
-  it("nested record", ():
+  it("should support nested record", ():
     c = Circle(Point(0, 0), 1.0)
     expect(c.center.x).to_eq(0)
     expect(c.center.y).to_eq(0)
@@ -26,25 +26,25 @@ describe("record", ():
 )
 
 describe("record to_str", ():
-  it("auto-generated to_str", ():
+  it("should generate auto to_str", ():
     p = Point(10, 20)
     expect(to_str(p)).to_eq("Point(x: 10, y: 20)")
   )
-  it("f-string interpolation", ():
+  it("should interpolate record in f-string", ():
     p = Point(3, 4)
     expect(f"{p}").to_eq("Point(x: 3, y: 4)")
   )
-  it("nested record to_str", ():
+  it("should convert nested record to string", ():
     c = Circle(Point(1, 2), 3.14)
     expect(to_str(c)).to_eq("Circle(center: Point(x: 1, y: 2), radius: 3.14)")
   )
-  it("user-defined to_str overrides auto-generated", ():
+  it("should override auto-generated to_str with user-defined", ():
     function to_str(p: Point) -> str:
       return f"({p.x}, {p.y})"
     p = Point(5, 6)
     expect(to_str(p)).to_eq("(5, 6)")
   )
-  it("string field", ():
+  it("should convert string field to string", ():
     record Person:
       name: str
       age: int
@@ -66,34 +66,34 @@ function operator==(a: AlwaysEqual, b: AlwaysEqual) -> bool:
   return true
 
 describe("record equality", ():
-  it("zero fields equal", ():
+  it("should be equal with zero fields", ():
     expect(Point(0, 0) == Point(0, 0)).to_be_true()
   )
-  it("equal records", ():
+  it("should be equal when fields match", ():
     expect(Point(1, 2) == Point(1, 2)).to_be_true()
   )
-  it("unequal records", ():
+  it("should be unequal when fields differ", ():
     expect(Point(1, 2) == Point(3, 4)).to_be_false()
   )
-  it("!= operator", ():
+  it("should support != operator", ():
     expect(Point(1, 2) != Point(3, 4)).to_be_true()
     expect(Point(1, 2) != Point(1, 2)).to_be_false()
   )
-  it("mixed field types", ():
+  it("should compare records with mixed field types", ():
     a = Mixed("hello", 42, 3.14, true)
     b = Mixed("hello", 42, 3.14, true)
     c = Mixed("world", 42, 3.14, true)
     expect(a == b).to_be_true()
     expect(a != c).to_be_true()
   )
-  it("nested record equality", ():
+  it("should compare nested records for equality", ():
     c1 = Circle(Point(0, 0), 1.0)
     c2 = Circle(Point(0, 0), 1.0)
     c3 = Circle(Point(1, 0), 1.0)
     expect(c1 == c2).to_be_true()
     expect(c1 != c3).to_be_true()
   )
-  it("user-defined operator== takes precedence", ():
+  it("should use user-defined operator== over auto-generated", ():
     # AlwaysEqual always returns true regardless of field values
     expect(AlwaysEqual(1) == AlwaysEqual(2)).to_be_true()
   )
@@ -105,15 +105,15 @@ enum Color:
   Blue
 
 describe("simple enum", ():
-  it("variant access", ():
+  it("should access variant", ():
     c = Color::Red
     expect(c == Color::Red).to_be_true()
   )
-  it("comparison", ():
+  it("should compare variants", ():
     expect(Color::Red == Color::Red).to_be_true()
     expect(Color::Red != Color::Green).to_be_true()
   )
-  it("when", ():
+  it("should match variant with when", ():
     res = ""
     c = Color::Blue
     match c:
@@ -125,7 +125,7 @@ describe("simple enum", ():
         res = "blue"
     expect(res).to_eq("blue")
   )
-  it("to_str shows variant name", ():
+  it("should show variant name in to_str", ():
     expect(to_str(Color::Red)).to_eq("Red")
     expect(to_str(Color::Green)).to_eq("Green")
     expect(to_str(Color::Blue)).to_eq("Blue")
@@ -138,7 +138,7 @@ enum Shape:
   PointS
 
 describe("ADT enum", ():
-  it("associated data", ():
+  it("should support associated data", ():
     s = Shape::CircleS(3.14)
     res = 0.0
     match s:
@@ -150,7 +150,7 @@ describe("ADT enum", ():
         res = 0.0
     expect(res).to_eq(3.14)
   )
-  it("multi-field pattern when", ():
+  it("should support multi-field pattern match", ():
     s = Shape::RectS(4.0, 5.0)
     res = 0.0
     match s:
@@ -170,7 +170,7 @@ enum NamedShape:
   Point
 
 describe("ADT enum with named fields", ():
-  it("construction is positional", ():
+  it("should construct positionally with named fields", ():
     s = NamedShape::Circle(3.14)
     res = 0.0
     match s:
@@ -182,7 +182,7 @@ describe("ADT enum with named fields", ():
         res = 0.0
     expect(res).to_eq(3.14)
   )
-  it("multi-field named variant", ():
+  it("should support multi-field named variant", ():
     s = NamedShape::Rect(4.0, 5.0)
     res = 0.0
     match s:
@@ -207,15 +207,15 @@ enum Permission:
   Execute = 4
 
 describe("explicit enum values", ():
-  it("variant access with explicit value", ():
+  it("should access variant with explicit value", ():
     s = HttpStatus::Ok
     expect(s == HttpStatus::Ok).to_be_true()
   )
-  it("comparison with explicit values", ():
+  it("should compare variants with explicit values", ():
     expect(HttpStatus::Ok == HttpStatus::Ok).to_be_true()
     expect(HttpStatus::Ok != HttpStatus::NotFound).to_be_true()
   )
-  it("when with explicit values", ():
+  it("should match with explicit values in when", ():
     res = ""
     s = HttpStatus::NotFound
     match s:
@@ -227,11 +227,11 @@ describe("explicit enum values", ():
         res = "error"
     expect(res).to_eq("not found")
   )
-  it("print shows variant name", ():
+  it("should show variant name when printing", ():
     s = HttpStatus::Ok
     expect(to_str(s)).to_eq("Ok")
   )
-  it("bitmask-style values", ():
+  it("should support bitmask-style values", ():
     p = Permission::Execute
     expect(p == Permission::Execute).to_be_true()
     expect(p != Permission::Read).to_be_true()
@@ -243,7 +243,7 @@ enum MyOption<T>:
   MyNone
 
 describe("generic enum", ():
-  it("with type parameter", ():
+  it("should support generic enum with type parameter", ():
     a = MyOption<int>::MySome(42)
     res = 0
     match a:
@@ -253,7 +253,7 @@ describe("generic enum", ():
         res = -1
     expect(res).to_eq(42)
   )
-  it("none variant", ():
+  it("should support none variant in generic enum", ():
     b = MyOption<int>::MyNone
     res = 0
     match b:

--- a/tests/spec/thread.test.ry
+++ b/tests/spec/thread.test.ry
@@ -1,7 +1,7 @@
 from thread import thread_spawn, thread_join, lock_new, lock_acquire, lock_release, rwlock_new, rwlock_read_lock, rwlock_write_lock, rwlock_unlock, semaphore_new, semaphore_acquire, semaphore_release, barrier_new, barrier_wait, atomic_int_new, atomic_int_load, atomic_int_store, atomic_int_add, atomic_int_sub, atomic_int_cas, atomic_bool_new, atomic_bool_load, atomic_bool_store
 
 describe("thread_spawn and thread_join", ():
-  it("spawns a thread and joins it", ():
+  it("should spawn a thread and join it", ():
     counter = atomic_int_new(0)
     t = thread_spawn(():
       atomic_int_add(counter, 1)
@@ -11,7 +11,7 @@ describe("thread_spawn and thread_join", ():
     expect(atomic_int_load(counter)).to_eq(1)
   )
 
-  it("spawns multiple threads", ():
+  it("should spawn multiple threads", ():
     counter = atomic_int_new(0)
     t1 = thread_spawn(():
       atomic_int_add(counter, 10)
@@ -26,7 +26,7 @@ describe("thread_spawn and thread_join", ():
 )
 
 describe("Lock", ():
-  it("provides mutual exclusion", ():
+  it("should provide mutual exclusion", ():
     lock = lock_new()
     counter = atomic_int_new(0)
 
@@ -50,7 +50,7 @@ describe("Lock", ():
 )
 
 describe("RWLock", ():
-  it("allows concurrent reads and exclusive writes", ():
+  it("should allow concurrent reads and exclusive writes", ():
     rwlock = rwlock_new()
     counter = atomic_int_new(0)
 
@@ -72,7 +72,7 @@ describe("RWLock", ():
 )
 
 describe("Semaphore", ():
-  it("limits concurrent access", ():
+  it("should limit concurrent access", ():
     sem_result = semaphore_new(2)
     expect(sem_result).to_be_ok()
     match sem_result:
@@ -99,7 +99,7 @@ describe("Semaphore", ():
 )
 
 describe("Barrier", ():
-  it("synchronizes threads", ():
+  it("should synchronize threads", ():
     barrier_result = barrier_new(2)
     expect(barrier_result).to_be_ok()
     match barrier_result:
@@ -124,14 +124,14 @@ describe("Barrier", ():
 )
 
 describe("AtomicInt", ():
-  it("supports load and store", ():
+  it("should support load and store", ():
     a = atomic_int_new(42)
     expect(atomic_int_load(a)).to_eq(42)
     atomic_int_store(a, 100)
     expect(atomic_int_load(a)).to_eq(100)
   )
 
-  it("supports add and sub", ():
+  it("should support add and sub", ():
     a = atomic_int_new(10)
     old = atomic_int_add(a, 5)
     expect(old).to_eq(10)
@@ -141,7 +141,7 @@ describe("AtomicInt", ():
     expect(atomic_int_load(a)).to_eq(12)
   )
 
-  it("supports compare-and-swap", ():
+  it("should support compare-and-swap", ():
     a = atomic_int_new(10)
     ok = atomic_int_cas(a, 10, 20)
     expect(ok).to_be_true()
@@ -151,7 +151,7 @@ describe("AtomicInt", ():
     expect(atomic_int_load(a)).to_eq(20)
   )
 
-  it("concurrent increment", ():
+  it("should support concurrent increment", ():
     counter = atomic_int_new(0)
     t1 = thread_spawn(():
       for i in range(1000):
@@ -168,14 +168,14 @@ describe("AtomicInt", ():
 )
 
 describe("AtomicBool", ():
-  it("supports load and store", ():
+  it("should support bool load and store", ():
     b = atomic_bool_new(false)
     expect(atomic_bool_load(b)).to_be_false()
     atomic_bool_store(b, true)
     expect(atomic_bool_load(b)).to_be_true()
   )
 
-  it("works across threads", ():
+  it("should work across threads", ():
     flag = atomic_bool_new(false)
     t = thread_spawn(():
       atomic_bool_store(flag, true)

--- a/tests/spec/to_str_union.test.ry
+++ b/tests/spec/to_str_union.test.ry
@@ -8,42 +8,42 @@ function show_with_bool(x: bool | str) -> str:
   return to_str(x)
 
 describe("to_str union", ():
-  it("converts int variant", ():
+  it("should convert int variant to string", ():
     x: int | str = 42
     expect(to_str(x)).to_eq("42")
   )
 
-  it("converts str variant", ():
+  it("should convert str variant to string", ():
     x: int | str = "hello"
     expect(to_str(x)).to_eq("hello")
   )
 
-  it("converts float variant", ():
+  it("should convert float variant to string", ():
     x: int | float = 3.14
     expect(to_str(x)).to_eq("3.14")
   )
 
-  it("converts bool variant", ():
+  it("should convert bool variant to string", ():
     x: bool | str = true
     expect(to_str(x)).to_eq("true")
   )
 
-  it("works via function return", ():
+  it("should work via function return", ():
     expect(show(42)).to_eq("42")
     expect(show("hello")).to_eq("hello")
   )
 
-  it("works with float via function return", ():
+  it("should work with float via function return", ():
     expect(show_with_float(100)).to_eq("100")
     expect(show_with_float(2.5)).to_eq("2.5")
   )
 
-  it("works with bool via function return", ():
+  it("should work with bool via function return", ():
     expect(show_with_bool(false)).to_eq("false")
     expect(show_with_bool("world")).to_eq("world")
   )
 
-  it("preserves low-level type signedness", ():
+  it("should preserve low-level type signedness", ():
     x: u8 | str = 200 as u8
     expect(to_str(x)).to_eq("200")
   )

--- a/tests/spec/tuple_single_element.test.ry
+++ b/tests/spec/tuple_single_element.test.ry
@@ -1,36 +1,36 @@
 describe("single-element tuple", ():
-  it("creates with trailing comma", ():
+  it("should create single-element tuple with trailing comma", ():
     t = (42,)
     expect(t.0).to_eq(42)
   )
-  it("string element", ():
+  it("should support string element", ():
     t = ("hello",)
     expect(t.0).to_eq("hello")
   )
-  it("trailing comma in multi-element", ():
+  it("should support trailing comma in multi-element tuple", ():
     t = (1, 2,)
     expect(t.0).to_eq(1)
     expect(t.1).to_eq(2)
   )
-  it("print single-element tuple", ():
+  it("should print single-element tuple", ():
     t = (42,)
     expect(to_str(t)).to_eq("(42,)")
   )
-  it("grouping still works", ():
+  it("should still support grouping with parentheses", ():
     x = (1 + 2) * 3
     expect(x).to_eq(9)
   )
-  it("type annotation (int,)", ():
+  it("should support type annotation (int,)", ():
     t: (int,) = (42,)
     expect(t.0).to_eq(42)
   )
-  it("type annotation in function", ():
+  it("should support type annotation in function", ():
     function wrap(x: int) -> (int,):
       return (x,)
     t = wrap(99)
     expect(t.0).to_eq(99)
   )
-  it("type annotation (str,)", ():
+  it("should support type annotation (str,)", ():
     t: (str,) = ("hello",)
     expect(t.0).to_eq("hello")
   )

--- a/tests/spec/type_advanced.test.ry
+++ b/tests/spec/type_advanced.test.ry
@@ -1,82 +1,82 @@
 describe("f-string", ():
-  it("int interpolation", ():
+  it("should interpolate int in f-string", ():
     x = 42
     expect(f"value: {x}").to_eq("value: 42")
   )
-  it("float interpolation", ():
+  it("should interpolate float in f-string", ():
     x = 3.14
     expect(f"pi: {x}").to_eq("pi: 3.14")
   )
-  it("bool interpolation", ():
+  it("should interpolate bool in f-string", ():
     x = true
     expect(f"flag: {x}").to_eq("flag: true")
   )
-  it("expression interpolation", ():
+  it("should interpolate expression in f-string", ():
     a = 1
     b = 2
     expect(f"{a} + {b} = {a + b}").to_eq("1 + 2 = 3")
   )
-  it("escaped braces", ():
+  it("should support escaped braces", ():
     expect("{braces}").to_eq("{braces}")
   )
 )
 
 describe("string auto concat edge cases", ():
-  it("empty string + int", ():
+  it("should concatenate empty string with int", ():
     expect("" + 0).to_eq("0")
   )
-  it("empty string + bool", ():
+  it("should concatenate empty string with bool", ():
     expect("" + true).to_eq("true")
   )
-  it("empty string + float", ():
+  it("should concatenate empty string with float", ():
     expect("" + 3.14).to_eq("3.14")
   )
 )
 
 describe("type cast as", ():
-  it("int to float", ():
+  it("should cast int to float", ():
     expect(42 as float).to_eq(42.0)
   )
-  it("float to int", ():
+  it("should cast float to int", ():
     expect(3.14 as int).to_eq(3)
   )
-  it("int to bool", ():
+  it("should cast int to bool", ():
     expect(1 as bool).to_be_true()
     expect(0 as bool).to_be_false()
   )
-  it("int to str", ():
+  it("should cast int to str", ():
     expect(42 as str).to_eq("42")
   )
-  it("u8 to int", ():
+  it("should cast u8 to int", ():
     b: u8 = 200
     expect(b as int).to_eq(200)
   )
-  it("int to u8 to int", ():
+  it("should cast int to u8 and back to int", ():
     b = 255 as u8
     expect(b as int).to_eq(255)
   )
-  it("negative float to int truncates toward zero", ():
+  it("should truncate negative float to int toward zero", ():
     expect(-3.7 as int).to_eq(-3)
   )
-  it("negative half to int", ():
+  it("should cast negative half to int", ():
     expect(-0.5 as int).to_eq(0)
   )
-  it("zero float to int", ():
+  it("should cast zero float to int", ():
     expect(0.0 as int).to_eq(0)
   )
-  it("one float to int", ():
+  it("should cast one float to int", ():
     expect(1.0 as int).to_eq(1)
   )
-  it("bool to int true", ():
+  it("should cast true bool to int", ():
     expect(true as int).to_eq(1)
   )
-  it("bool to int false", ():
+  it("should cast false bool to int", ():
     expect(false as int).to_eq(0)
   )
 )
 
 describe("type alias", ():
-  it("basic alias", ():
+  it("should support basic alias", ():
     type Meters = float
     d: Meters = 3.14
     expect(d).to_eq(3.14)
@@ -84,12 +84,12 @@ describe("type alias", ():
 )
 
 describe("Error type", ():
-  it("constructor with message", ():
+  it("should construct Error with message", ():
     e = Error("something went wrong")
     expect(e.message).to_eq("something went wrong")
     expect(e.code).to_eq(0)
   )
-  it("constructor with code", ():
+  it("should construct Error with code", ():
     e = Error("not found", 404)
     expect(e.message).to_eq("not found")
     expect(e.code).to_eq(404)
@@ -101,7 +101,7 @@ describe("Result type", ():
     if b == 0:
       return Err(Error("division by zero"))
     return Ok(a // b)
-  it("returns Ok on success", ():
+  it("should return Ok on success", ():
     res = safe_divide(10, 2)
     match res:
       case Ok(v):
@@ -109,7 +109,7 @@ describe("Result type", ():
       case Err(e):
         fail("unexpected error")
   )
-  it("returns Err on failure", ():
+  it("should return Err on failure", ():
     res = safe_divide(10, 0)
     match res:
       case Ok(v):
@@ -123,10 +123,10 @@ function accept_union(x: int | str) -> bool:
   return true
 
 describe("union type", ():
-  it("accepts int", ():
+  it("should accept int", ():
     expect(accept_union(42)).to_be_true()
   )
-  it("accepts str", ():
+  it("should accept str", ():
     expect(accept_union("hello")).to_be_true()
   )
 )

--- a/tests/spec/types.test.ry
+++ b/tests/spec/types.test.ry
@@ -1,98 +1,98 @@
 describe("int", ():
-  it("decimal literal", ():
+  it("should support decimal literal", ():
     expect(42).to_eq(42)
   )
-  it("negative", ():
+  it("should support negative literal", ():
     expect(-7).to_eq(-7)
   )
-  it("hex literal", ():
+  it("should support hex literal", ():
     expect(255).to_eq(255)
   )
-  it("binary literal", ():
+  it("should support binary literal", ():
     expect(10).to_eq(10)
   )
 )
 
 describe("float", ():
-  it("basic", ():
+  it("should support basic float literal", ():
     expect(3.14).to_eq(3.14)
   )
-  it("zero point five", ():
+  it("should support zero point five float literal", ():
     expect(0.5).to_eq(0.5)
   )
 )
 
 describe("bool", ():
-  it("true", ():
+  it("should support true literal", ():
     expect(true).to_eq(true)
   )
-  it("false", ():
+  it("should support false literal", ():
     expect(false).to_eq(false)
   )
 )
 
 describe("str", ():
-  it("basic", ():
+  it("should support basic string literal", ():
     expect("hello").to_eq("hello")
   )
-  it("empty", ():
+  it("should support empty string literal", ():
     expect("").to_eq("")
   )
-  it("escape newline", ():
+  it("should support newline escape", ():
     expect("a\nb").to_have_length(3)
   )
-  it("escape tab", ():
+  it("should support tab escape", ():
     expect("a\tb").to_have_length(3)
   )
-  it("escape backslash", ():
+  it("should support backslash escape", ():
     expect("a\\b").to_have_length(3)
   )
 )
 
 describe("u8", ():
-  it("as int", ():
+  it("should cast u8 as int", ():
     b: u8 = 42
     expect(b as int).to_eq(42)
   )
-  it("max value", ():
+  it("should support max value of u8", ():
     b: u8 = 255
     expect(b as int).to_eq(255)
   )
 )
 
 describe("Option", ():
-  it("Some", ():
+  it("should wrap value in Some", ():
     x: Option<int> = Some(42)
     expect(x).to_be_some()
   )
-  it("None", ():
+  it("should represent None", ():
     x: Option<int> = None
     expect(x).to_be_none()
   )
-  it("none keyword", ():
+  it("should support none keyword", ():
     x: int? = none
     expect(x).to_be_none()
   )
-  it("shorthand syntax", ():
+  it("should support shorthand syntax", ():
     x: int? = 42
     expect(x).to_be_some()
   )
-  it("Some(0) is Some not None", ():
+  it("should recognize Some(0) as Some not None", ():
     x: int? = Some(0)
     expect(x).to_be_some()
   )
-  it("Some(false) is Some not None", ():
+  it("should recognize Some(false) as Some not None", ():
     x: bool? = Some(false)
     expect(x).to_be_some()
   )
-  it("Some empty string is Some", ():
+  it("should recognize Some empty string as Some", ():
     x: str? = Some("")
     expect(x).to_be_some()
   )
 )
 
 describe("nested generic type", ():
-  it("Option<Option<int>> Some(Some)", ():
+  it("should support Option<Option<int>> Some(Some)", ():
     inner: Option<int> = Some(42)
     x: Option<Option<int>> = Some(inner)
     match x:
@@ -101,18 +101,18 @@ describe("nested generic type", ():
       case None:
         expect(false).to_eq(true)
   )
-  it("Option<Option<int>> None", ():
+  it("should support Option<Option<int>> None", ():
     x: Option<Option<int>> = None
     expect(x).to_be_none()
   )
 )
 
 describe("Tuple", ():
-  it("element access", ():
+  it("should access first tuple element", ():
     t = (10, 3.14)
     expect(t.0).to_eq(10)
   )
-  it("second element", ():
+  it("should access second tuple element", ():
     t = (10, 3.14)
     expect(t.1).to_eq(3.14)
   )

--- a/tests/spec/unsigned_negation.test.ry
+++ b/tests/spec/unsigned_negation.test.ry
@@ -1,15 +1,15 @@
 describe("signed variable negation (regression)", ():
-  it("negate i32 variable", ():
+  it("should negate i32 variable", ():
     x: i32 = 5
     y = -x
     expect(y as int).to_eq(-5)
   )
-  it("negate i16 variable", ():
+  it("should negate i16 variable", ():
     x: i16 = 10
     y = -x
     expect(y as int).to_eq(-10)
   )
-  it("negate plain int variable", ():
+  it("should negate plain int variable", ():
     x = 42
     y = -x
     expect(y).to_eq(-42)

--- a/tests/spec/user_fn_collection_return.test.ry
+++ b/tests/spec/user_fn_collection_return.test.ry
@@ -2,14 +2,14 @@ describe("List returned from user-defined function", ():
   function get_list() -> List<int>:
     return [1, 2, 3]
 
-  it("append! on returned list", ():
+  it("should append! on returned list", ():
     xs = get_list()
     xs.append!(4)
     expect(xs).to_have_length(4)
     expect(xs[3]).to_eq(4)
   )
 
-  it("appended on returned list", ():
+  it("should use appended on returned list", ():
     xs = get_list()
     ys = xs.appended(4)
     expect(xs).to_have_length(3)
@@ -17,14 +17,14 @@ describe("List returned from user-defined function", ():
     expect(ys[3]).to_eq(4)
   )
 
-  it("append on returned list", ():
+  it("should append on returned list", ():
     xs = get_list()
     append(xs, 4)
     expect(xs).to_have_length(4)
     expect(xs[3]).to_eq(4)
   )
 
-  it("chained operations on returned list", ():
+  it("should chain operations on returned list", ():
     xs = get_list()
     xs.append!(4)
     xs.append!(5)

--- a/tests/spec/weak_ref.test.ry
+++ b/tests/spec/weak_ref.test.ry
@@ -2,7 +2,7 @@ function make_list() -> List<int>:
   return [10, 20, 30]
 
 describe("Weak references", ():
-  it("weak ref upgrade returns Some when strong ref is alive", ():
+  it("should upgrade weak ref to Some when strong ref is alive", ():
     xs = [1, 2, 3]
     w: weak List<int> = weak xs
     match w:
@@ -12,7 +12,7 @@ describe("Weak references", ():
         fail("expected Some but got None")
   )
 
-  it("weak ref upgrade returns Some for temporary (strong ref still alive in scope)", ():
+  it("should upgrade weak ref to Some for temporary (strong ref still alive in scope)", ():
     w: weak List<int> = weak make_list()
     # The temporary return value is still alive within this expression scope,
     # so the weak ref can still be upgraded to Some.
@@ -23,7 +23,7 @@ describe("Weak references", ():
         fail("expected Some — temporary should still be alive in scope")
   )
 
-  it("weak ref pattern matching with Some", ():
+  it("should match weak ref pattern with Some", ():
     data = [42, 99]
     ref: weak List<int> = weak data
     result = 0
@@ -35,14 +35,14 @@ describe("Weak references", ():
     expect(result).to_eq(2)
   )
 
-  it("weak ref with coalesce operator on string", ():
+  it("should use coalesce operator on weak ref to string", ():
     s = "coalesce"
     w: weak str = weak s
     val = w ?? "default"
     expect(val).to_eq("coalesce")
   )
 
-  it("weak ref reassignment", ():
+  it("should support weak ref reassignment", ():
     a = [1, 2]
     b = [3, 4, 5]
     w: weak List<int> = weak a

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -914,10 +914,10 @@ TEST(DirectiveSyntax, MixedPositionalAndNamedArgsInOneDirective) {
 // Basic @it on a named function compiles and runs as a test case
 TEST_F(DirectiveTest, ItDirectiveBasicCodegen) {
     EXPECT_EQ(runTestSource(
-        "@it(\"adds 1 + 2 = 3\")\n"
+        "@it(\"should add 1 + 2 = 3\")\n"
         "function test_add():\n"
         "    expect(1 + 2).to_eq(3)\n"
-    ), "\033[32m+ adds 1 + 2 = 3\033[0m\n\n1 passed, 0 failed\n");
+    ), "\033[32m+ should add 1 + 2 = 3\033[0m\n\n1 passed, 0 failed\n");
 }
 
 // @it requires test mode — should error outside test mode
@@ -955,26 +955,26 @@ TEST_F(DirectiveTest, DescribeDirectiveBasicCodegen) {
     EXPECT_EQ(runTestSource(
         "@describe(\"math\")\n"
         "function math_tests():\n"
-        "    @it(\"subtraction\")\n"
+        "    @it(\"should subtract\")\n"
         "    function test_sub():\n"
         "        expect(10 - 3).to_eq(7)\n"
         "\n"
-        "    @it(\"multiplication\")\n"
+        "    @it(\"should multiply\")\n"
         "    function test_mul():\n"
         "        expect(4 * 5).to_eq(20)\n"
-    ), "math\n  \033[32m+ subtraction\033[0m\n  \033[32m+ multiplication\033[0m\n\n2 passed, 0 failed\n");
+    ), "math\n  \033[32m+ should subtract\033[0m\n  \033[32m+ should multiply\033[0m\n\n2 passed, 0 failed\n");
 }
 
 // @each + @it on a named function: parameterized tests
 TEST_F(DirectiveTest, ItDirectiveWithEach) {
     EXPECT_EQ(runTestSource(
         "@each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])\n"
-        "@it(\"adds {0} + {1} = {2}\")\n"
+        "@it(\"should add {0} + {1} = {2}\")\n"
         "function test_add(a: int, b: int, expected: int):\n"
         "    expect(a + b).to_eq(expected)\n"
-    ), "\033[32m+ adds 1 + 2 = 3\033[0m\n"
-       "\033[32m+ adds 0 + 0 = 0\033[0m\n"
-       "\033[32m+ adds -1 + 1 = 0\033[0m\n"
+    ), "\033[32m+ should add 1 + 2 = 3\033[0m\n"
+       "\033[32m+ should add 0 + 0 = 0\033[0m\n"
+       "\033[32m+ should add -1 + 1 = 0\033[0m\n"
        "\n3 passed, 0 failed\n");
 }
 
@@ -982,11 +982,11 @@ TEST_F(DirectiveTest, ItDirectiveWithEach) {
 TEST_F(DirectiveTest, ItDirectiveWithProperty) {
     std::string out = runTestSource(
         "@property(count=10)\n"
-        "@it(\"addition is commutative\")\n"
+        "@it(\"should verify addition is commutative\")\n"
         "function test_commutative(a: int, b: int):\n"
         "    expect(a + b).to_eq(b + a)\n"
     );
-    EXPECT_NE(out.find("+ addition is commutative"), std::string::npos);
+    EXPECT_NE(out.find("+ should verify addition is commutative"), std::string::npos);
     EXPECT_NE(out.find("1 passed, 0 failed"), std::string::npos);
 }
 
@@ -1033,19 +1033,19 @@ TEST_F(DirectiveTest, DescribeDirectiveNestedDescribe) {
     EXPECT_EQ(runTestSource(
         "@describe(\"outer\")\n"
         "function outer_tests():\n"
-        "    @it(\"direct child\")\n"
+        "    @it(\"should pass as direct child\")\n"
         "    function test_direct():\n"
         "        expect(1 + 1).to_eq(2)\n"
         "\n"
         "    @describe(\"inner\")\n"
         "    function inner_tests():\n"
-        "        @it(\"nested child\")\n"
+        "        @it(\"should pass as nested child\")\n"
         "        function test_nested():\n"
         "            expect(2 * 3).to_eq(6)\n"
     ), "outer\n"
-       "  \033[32m+ direct child\033[0m\n"
+       "  \033[32m+ should pass as direct child\033[0m\n"
        "  inner\n"
-       "    \033[32m+ nested child\033[0m\n"
+       "    \033[32m+ should pass as nested child\033[0m\n"
        "\n2 passed, 0 failed\n");
 }
 
@@ -1145,15 +1145,15 @@ TEST_F(DirectiveTest, DescribeDirectiveSharedSetup) {
         "function shared_tests():\n"
         "    x = 10\n"
         "    y = 20\n"
-        "    @it(\"uses x\")\n"
+        "    @it(\"should use x\")\n"
         "    function test_x():\n"
         "        expect(x).to_eq(10)\n"
-        "    @it(\"uses x and y\")\n"
+        "    @it(\"should use x and y\")\n"
         "    function test_xy():\n"
         "        expect(x + y).to_eq(30)\n"
     ), "shared setup\n"
-       "  \033[32m+ uses x\033[0m\n"
-       "  \033[32m+ uses x and y\033[0m\n"
+       "  \033[32m+ should use x\033[0m\n"
+       "  \033[32m+ should use x and y\033[0m\n"
        "\n2 passed, 0 failed\n");
 }
 
@@ -1166,13 +1166,13 @@ TEST_F(DirectiveTest, DescribeDirectiveThreeLevelNesting) {
         "    function l2():\n"
         "        @describe(\"level 3\")\n"
         "        function l3():\n"
-        "            @it(\"deep test\")\n"
+        "            @it(\"should pass at deep nesting\")\n"
         "            function test_deep():\n"
         "                expect(true).to_be_true()\n"
     ), "level 1\n"
        "  level 2\n"
        "    level 3\n"
-       "      \033[32m+ deep test\033[0m\n"
+       "      \033[32m+ should pass at deep nesting\033[0m\n"
        "\n1 passed, 0 failed\n");
 }
 
@@ -1182,12 +1182,12 @@ TEST_F(DirectiveTest, DescribeDirectiveWithEach) {
         "@describe(\"parameterized\")\n"
         "function param_tests():\n"
         "    @each([(1, 2, 3), (4, 5, 9)])\n"
-        "    @it(\"{0} + {1} = {2}\")\n"
+        "    @it(\"should add {0} + {1} = {2}\")\n"
         "    function test_add(a: int, b: int, expected: int):\n"
         "        expect(a + b).to_eq(expected)\n"
     ), "parameterized\n"
-       "  \033[32m+ 1 + 2 = 3\033[0m\n"
-       "  \033[32m+ 4 + 5 = 9\033[0m\n"
+       "  \033[32m+ should add 1 + 2 = 3\033[0m\n"
+       "  \033[32m+ should add 4 + 5 = 9\033[0m\n"
        "\n2 passed, 0 failed\n");
 }
 
@@ -1197,12 +1197,12 @@ TEST_F(DirectiveTest, DescribeDirectiveWithProperty) {
         "@describe(\"property group\")\n"
         "function prop_tests():\n"
         "    @property(count=5)\n"
-        "    @it(\"int identity\")\n"
+        "    @it(\"should hold int identity\")\n"
         "    function test_id(a: int):\n"
         "        expect(a).to_eq(a)\n"
     );
     EXPECT_NE(out.find("property group"), std::string::npos);
-    EXPECT_NE(out.find("+ int identity"), std::string::npos);
+    EXPECT_NE(out.find("+ should hold int identity"), std::string::npos);
     EXPECT_NE(out.find("1 passed, 0 failed"), std::string::npos);
 }
 


### PR DESCRIPTION
## Summary

- Migrate all `it()` / `@it()` test descriptions (1310+) to `"should ..."` style across 79 Ry test files, so they read naturally as `it should ...` in test output and `--outline` mode
- Update `tests/test_codegen_directive.cpp` embedded test descriptions and expected output string assertions in lockstep
- Update English documentation examples (`docs/reference/testing.md`, `docs/tutorial/11-testing.md`, `docs/reference/directives.md`)
- Add **Test Description Style** guideline section to `docs/reference/testing.md`
- `describe()` / `@describe()` blocks left unchanged (noun/topic phrases are correct as-is)

Closes #664

## Test plan

- [x] `./build/ry_tests` — 1425 C++ tests passed
- [x] `./build/ry test -p` — 81 test files, 0 failures
- [x] `grep -rn '^\s*it("' tests/spec/ | grep -v 'should'` — no remaining non-should descriptions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Test Description Style” guideline recommending sentence-like descriptions prefixed with “should”
  * Updated documentation examples to use the new “should‑style” phrasing and show preferred vs. avoid patterns

* **Tests**
  * Standardized test case descriptions across the entire test suite to the new “should‑style” for clearer, more consistent output (including outline/failure labels)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->