### PR TITLE
feat: support print() and to_str() for closure/function values (#728)

### DIFF
--- a/changelog.d/728-closure-print.md
+++ b/changelog.d/728-closure-print.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `print()`, `to_str()`, and f-string interpolation now work with closure values — they produce `"<closure>"` instead of a compile-time error (#728)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -454,6 +454,19 @@ function apply(func: function(int) -> int, x: int) -> int:
 result = apply(f, 5)   # 10
 ```
 
+### String Representation
+
+`print()`, `to_str()`, and f-string interpolation all produce `"<closure>"` for function values:
+
+```python
+f = (x: int) => x + 1
+print(f)              # <closure>
+s = to_str(f)         # "<closure>"
+msg = f"fn={f}"       # "fn=<closure>"
+```
+
+> **Note**: Equality comparison (`==` / `!=`) between closures is not supported and produces a compile-time error.
+
 ---
 
 ## Higher-Order Functions

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -485,7 +485,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
         }
 
         if (auto *fnMeta = getMeta(val); fnMeta && fnMeta->fn_type_info)
-            codegenError("cannot convert function to string");
+            return cachedGlobalString("<closure>", ".vts_closure");
         return val; // string pointer
     }
     auto mallocFn = getStdlibMalloc();

--- a/tests/spec/combinatorial/print_display.test.ry
+++ b/tests/spec/combinatorial/print_display.test.ry
@@ -1,5 +1,3 @@
-# BUG #728: print() and to_str() on closure values not supported
-
 describe("print — union", ():
   it("should print int variant of union without crashing", ():
     x: int | str = 42
@@ -18,5 +16,21 @@ describe("print — union", ():
   it("should use f-string interpolation with union value", ():
     x: int | str = "world"
     expect(f"value={x}").to_eq("value=world")
+  )
+)
+
+describe("print — closure", ():
+  it("should print closure as <closure>", ():
+    f = (x: int) => x + 1
+    print(f)
+    # expect-output: <closure>
+  )
+  it("should convert closure to string with to_str", ():
+    f = (x: int) => x * 2
+    expect(to_str(f)).to_eq("<closure>")
+  )
+  it("should interpolate closure in f-string", ():
+    f = (x: int) => x
+    expect(f"fn={f}").to_eq("fn=<closure>")
   )
 )

--- a/tests/spec/combinatorial/print_display.test.ry
+++ b/tests/spec/combinatorial/print_display.test.ry
@@ -1,4 +1,4 @@
-# BUG #728: print() and to_str() on int | str union values not supported
+# BUG #728: print()/to_str() coverage for union values and closure stringification
 
 
 describe("print — union", ():


### PR DESCRIPTION
Closes #728

## Summary

クロージャ/関数値に `print()` / `to_str()` を呼ぶと `cannot convert function to string` エラーになるのを修正し、`<function>` などの表現を返す。

## Unblock

マージ後に `print_display.test.ry` に closure の print/to_str テストを追加できる。