### PR TITLE
fix: compare inner values in Option equality, not just has_value flag (#726)

### DIFF
--- a/changelog.d/726-option-equality.md
+++ b/changelog.d/726-option-equality.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Option equality (`==` / `!=`) now correctly compares inner values when both operands are `Some`, instead of comparing only the `has_value` flag (#726)

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -301,12 +301,29 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
     bool lhsIsOpt = isOptionType(lhs->getType());
     bool rhsIsOpt = isOptionType(rhs->getType());
     if (lhsIsOpt && rhsIsOpt && (op == "==" || op == "!=")) {
-        // Only support comparison with none (has_value == false on one side)
-        // Extract has_value flags from both
         llvm::Value *lhsFlag = builder_.CreateExtractValue(lhs, 0, "lhs_has");
         llvm::Value *rhsFlag = builder_.CreateExtractValue(rhs, 0, "rhs_has");
-        if (op == "==") return builder_.CreateICmpEQ(lhsFlag, rhsFlag, "opt_eq");
-        return builder_.CreateICmpNE(lhsFlag, rhsFlag, "opt_ne");
+
+        // When inner types differ (e.g., Option<Error> vs none's Option<int>),
+        // only compare has_value flags (one side must be None)
+        if (lhs->getType() != rhs->getType()) {
+            if (op == "==") return builder_.CreateICmpEQ(lhsFlag, rhsFlag, "opt_eq");
+            return builder_.CreateICmpNE(lhsFlag, rhsFlag, "opt_ne");
+        }
+
+        // Same Option type: compare both flag and inner value
+        llvm::Value *bothNone = builder_.CreateAnd(
+            builder_.CreateNot(lhsFlag), builder_.CreateNot(rhsFlag), "both_none");
+        llvm::Value *bothSome = builder_.CreateAnd(lhsFlag, rhsFlag, "both_some");
+
+        llvm::Value *lhsInner = builder_.CreateExtractValue(lhs, 1, "opt_l_inner");
+        llvm::Value *rhsInner = builder_.CreateExtractValue(rhs, 1, "opt_r_inner");
+
+        llvm::Value *innerEq = emitComparisonOp("==", lhsInner, rhsInner, "", "");
+        llvm::Value *eqResult = builder_.CreateOr(
+            bothNone, builder_.CreateAnd(bothSome, innerEq), "opt_eq");
+        if (op == "!=") return builder_.CreateNot(eqResult, "opt_ne");
+        return eqResult;
     }
 
     // Record (struct) type comparison: field-by-field (only == and != supported)

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -34,6 +34,14 @@ describe("equality — Option", ():
     expect(Some("hello") == Some("hello")).to_be_true()
     expect(Some("a") != Some("b")).to_be_true()
   )
+  it("should consider typed Option equal to none when both are None", ():
+    e: Error? = none
+    expect(e == none).to_be_true()
+  )
+  it("should consider typed Option unequal to none when Some", ():
+    e: Error? = Some(Error("oops"))
+    expect(e != none).to_be_true()
+  )
 )
 
 function res_ok(v: int) -> Result<int, Error>:

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -29,8 +29,11 @@ describe("equality — Option", ():
     y: int? = none
     expect(x != y).to_be_true()
   )
-  # BUG #726: Some(1) == Some(2) returns true — Option equality ignores inner value
-  # it("should consider Some values with different inner values unequal", ():
-  #   expect(Some(1) != Some(2)).to_be_true()
-  # )
+  it("should consider Some values with different inner values unequal", ():
+    expect(Some(1) != Some(2)).to_be_true()
+  )
+  it("should compare Some string values by content", ():
+    expect(Some("hello") == Some("hello")).to_be_true()
+    expect(Some("a") != Some("b")).to_be_true()
+  )
 )

--- a/tests/spec/combinatorial/print_display.test.ry
+++ b/tests/spec/combinatorial/print_display.test.ry
@@ -1,4 +1,4 @@
-# BUG #728: print() and to_str() on closure values not supported
+# BUG #728: print() and to_str() on int | str union values not supported
 
 describe("print — union", ():
   it("should print int variant of union without crashing", ():


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- `Some(1) == Some(2)` was incorrectly returning `true` because the comparison only checked the `has_value` flag and ignored the inner value
- Fixed `emitComparisonOp` to compare inner values when both sides are `Some` of the same Option type
- When types differ (e.g. `Option<Error>` vs `none`'s `Option<int>`), falls back to flag-only comparison to avoid inner type mismatch

## Test plan

- [ ] `Some(1) != Some(2)` returns `true`
- [ ] `Some("hello") == Some("hello")` returns `true`
- [ ] `Some("a") != Some("b")` returns `true`
- [ ] `Some(42) == Some(42)` still returns `true`
- [ ] `Option<Error> == none` still works
- [ ] `./build/ry_tests` passes
- [ ] `./build/ry test -p` passes
- [ ] ASan build passes

Closes #726
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed option equality operators (`==` and `!=`) to correctly compare inner values when both operands are `Some`, instead of only comparing whether a value is present or absent. This correction ensures proper equality semantics for optional types and their contained values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->