### PR TITLE
fix: implement == / != for List, Set, Map, Result, and union types (#725)

### DIFF
--- a/changelog.d/628-combinatorial-coverage.md
+++ b/changelog.d/628-combinatorial-coverage.md
@@ -1,0 +1,3 @@
+### Added
+
+- Systematic combinatorial test coverage in `tests/spec/combinatorial/` (#628): 113 tests across 9 files covering type×operation matrix (equality, fn argument/return, collection element, match, nested types, syntax combinations, print/display, stdlib boundary inputs)

--- a/changelog.d/725-collection-equality.md
+++ b/changelog.d/725-collection-equality.md
@@ -1,0 +1,8 @@
+### Added
+
+- `==` and `!=` operators now work for `List<T>`, `Set<T>`, `Map<K,V>`, `Result<T,E>`, and union types (#725)
+  - List: element-wise comparison (supports `int`, `float`, `str`, `bool` elements)
+  - Set: unordered equality — `{1,2,3} == {3,2,1}` is `true`
+  - Map: key/value equality — maps with the same key-value pairs are equal regardless of insertion order
+  - Result: compares `is_ok` flag and the inner `Ok` or `Err` value
+  - Union (`A|B`): compares tag (variant kind) first, then the inner value for matching tags

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -103,6 +103,16 @@ Both operands must have the same element type.
 
 `int`, `float`, `bool`, `str`
 
+### Equality
+
+Lists support `==` and `!=`. Two lists are equal when they have the same length and all corresponding elements are equal.
+
+```python
+[1, 2, 3] == [1, 2, 3]   # true
+[1, 2, 3] != [1, 2, 4]   # true
+[1, 2]    != [1, 2, 3]   # true (different lengths)
+```
+
 ### Index Access
 
 ```python
@@ -509,6 +519,16 @@ m = {"a": 1, "b": 2}
 m: Map<str, int> = {"a": 1, "b": 2}
 ```
 
+### Equality
+
+Maps support `==` and `!=`. Two maps are equal when they have the same number of entries and every key-value pair in one map exists with an equal value in the other.
+
+```python
+{"a": 1, "b": 2} == {"a": 1, "b": 2}   # true
+{"a": 1}         != {"a": 2}            # true (different values)
+{"a": 1}         != {"b": 1}            # true (different keys)
+```
+
 ### Key Access
 
 ```python
@@ -636,6 +656,15 @@ s: Set<int> = {1, 2, 3}
 ### Supported Element Types
 
 `int`, `float`, `bool`, `str`
+
+### Equality
+
+Sets support `==` and `!=`. Equality is order-independent — two sets are equal when they contain exactly the same elements.
+
+```python
+{1, 2, 3} == {3, 2, 1}   # true (order does not matter)
+{1, 2}    != {1, 2, 3}   # true (different sizes)
+```
 
 ### in Operator (Membership Check)
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -541,7 +541,7 @@ A union type is represented as `{ i64 tag, [N x i8] data }`. The `tag` indicates
 
 ### Equality
 
-Union types support `==` and `!=`. Two union values are equal when they hold the same variant (same tag) and the inner values are equal.
+Union types currently support `==` and `!=` for primitive variants (`int`, `float`, `str`, `bool`). Two union values are equal when they hold the same variant (same tag) and the inner values are equal.
 
 ```python
 x: int | str = 42

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -493,6 +493,16 @@ match save("/tmp/test.txt", "hello"):
 
 It is used with `match` for exhaustive error handling. Both `Ok` and `Err` cases must be covered (or use `_` wildcard).
 
+**Equality:**
+`Result<T, E>` supports `==` and `!=`. Two results are equal when both variants match (`Ok`/`Ok` or `Err`/`Err`) and the inner values are equal.
+
+```python
+function make_ok(v: int) -> Result<int, Error>: return Ok(v)
+make_ok(42) == make_ok(42)   # true
+make_ok(1)  == make_ok(2)    # false
+make_ok(1)  != Err(Error("e"))  # true
+```
+
 **Test matchers:**
 - `expect(x).to_be_ok()` — asserts the result is `Ok`
 - `expect(x).to_be_err()` — asserts the result is `Err`
@@ -529,11 +539,25 @@ function get_val(flag: bool) -> int | str:
 
 A union type is represented as `{ i64 tag, [N x i8] data }`. The `tag` indicates the index of each component type (sorted alphabetically), and `data` is a byte array sized to the largest component type.
 
+### Equality
+
+Union types support `==` and `!=`. Two union values are equal when they hold the same variant (same tag) and the inner values are equal.
+
+```python
+x: int | str = 42
+y: int | str = 42
+x == y   # true
+
+z: int | str = "42"
+x == z   # false (different tags: int vs str)
+```
+
 ### Constraints
 
 - Assigning a type not included in the union causes a compile error
 - `int | str` and `str | int` are the same type (normalized)
 - When printing a union value with `print()`, the value is displayed using the appropriate type based on the runtime tag
+- `==` and `!=` support primitive variants (`int`, `float`, `str`, `bool`); closure variants are not supported
 
 ## any Type
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -301,12 +301,29 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
     bool lhsIsOpt = isOptionType(lhs->getType());
     bool rhsIsOpt = isOptionType(rhs->getType());
     if (lhsIsOpt && rhsIsOpt && (op == "==" || op == "!=")) {
-        // Only support comparison with none (has_value == false on one side)
-        // Extract has_value flags from both
         llvm::Value *lhsFlag = builder_.CreateExtractValue(lhs, 0, "lhs_has");
         llvm::Value *rhsFlag = builder_.CreateExtractValue(rhs, 0, "rhs_has");
-        if (op == "==") return builder_.CreateICmpEQ(lhsFlag, rhsFlag, "opt_eq");
-        return builder_.CreateICmpNE(lhsFlag, rhsFlag, "opt_ne");
+
+        // When inner types differ (e.g., Option<Error> vs none's Option<int>),
+        // only compare has_value flags (one side must be None)
+        if (lhs->getType() != rhs->getType()) {
+            if (op == "==") return builder_.CreateICmpEQ(lhsFlag, rhsFlag, "opt_eq");
+            return builder_.CreateICmpNE(lhsFlag, rhsFlag, "opt_ne");
+        }
+
+        // Same Option type: compare both flag and inner value
+        llvm::Value *bothNone = builder_.CreateAnd(
+            builder_.CreateNot(lhsFlag), builder_.CreateNot(rhsFlag), "both_none");
+        llvm::Value *bothSome = builder_.CreateAnd(lhsFlag, rhsFlag, "both_some");
+
+        llvm::Value *lhsInner = builder_.CreateExtractValue(lhs, 1, "opt_l_inner");
+        llvm::Value *rhsInner = builder_.CreateExtractValue(rhs, 1, "opt_r_inner");
+
+        llvm::Value *innerEq = emitComparisonOp("==", lhsInner, rhsInner, "", "");
+        llvm::Value *eqResult = builder_.CreateOr(
+            bothNone, builder_.CreateAnd(bothSome, innerEq), "opt_eq");
+        if (op == "!=") return builder_.CreateNot(eqResult, "opt_ne");
+        return eqResult;
     }
 
     // Record (struct) type comparison: field-by-field (only == and != supported)

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -2,6 +2,7 @@
 #include "ry/stdlib_registry.hpp"
 #include "ry/diagnostic.hpp"
 #include <climits>
+#include <unordered_set>
 
 
 namespace ry {
@@ -311,38 +312,73 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             return builder_.CreateICmpNE(lhsFlag, rhsFlag, "opt_ne");
         }
 
-        // Same Option type: compare both flag and inner value
+        // Same Option type: only compare inner values when both are Some.
+        // Use control flow to avoid UB from comparison on undef inner values (None case).
         llvm::Value *bothNone = builder_.CreateAnd(
             builder_.CreateNot(lhsFlag), builder_.CreateNot(rhsFlag), "both_none");
         llvm::Value *bothSome = builder_.CreateAnd(lhsFlag, rhsFlag, "both_some");
 
+        llvm::BasicBlock *startBB    = builder_.GetInsertBlock();
+        llvm::Function   *curFn      = startBB->getParent();
+        llvm::BasicBlock *cmpInnerBB = llvm::BasicBlock::Create(*ctx_, "opt.cmp_inner", curFn);
+        llvm::BasicBlock *mergeBB    = llvm::BasicBlock::Create(*ctx_, "opt.merge",     curFn);
+
+        builder_.CreateCondBr(bothSome, cmpInnerBB, mergeBB);
+
+        builder_.SetInsertPoint(cmpInnerBB);
         llvm::Value *lhsInner = builder_.CreateExtractValue(lhs, 1, "opt_l_inner");
         llvm::Value *rhsInner = builder_.CreateExtractValue(rhs, 1, "opt_r_inner");
+        llvm::Value *innerEq  = emitComparisonOp("==", lhsInner, rhsInner, "", "");
+        llvm::BasicBlock *cmpDoneBB = builder_.GetInsertBlock();
+        builder_.CreateBr(mergeBB);
 
-        llvm::Value *innerEq = emitComparisonOp("==", lhsInner, rhsInner, "", "");
-        llvm::Value *eqResult = builder_.CreateOr(
-            bothNone, builder_.CreateAnd(bothSome, innerEq), "opt_eq");
+        builder_.SetInsertPoint(mergeBB);
+        llvm::PHINode *eqResult = builder_.CreatePHI(i1Ty_, 2, "opt_eq");
+        eqResult->addIncoming(bothNone, startBB);
+        eqResult->addIncoming(innerEq, cmpDoneBB);
         if (op == "!=") return builder_.CreateNot(eqResult, "opt_ne");
         return eqResult;
     }
 
-    // Result type equality: compare is_ok flag then inner Ok/Err value
+    // Result type equality: compare is_ok flag, then only the active variant's payload.
+    // Use control flow to avoid UB from comparison on inactive (garbage) variant data.
     if (isResultType(lhs->getType()) && isResultType(rhs->getType()) &&
         lhs->getType() == rhs->getType() && (op == "==" || op == "!=")) {
         llvm::Value *lhsOk   = builder_.CreateExtractValue(lhs, 0, "lhs_is_ok");
-        llvm::Value *flagsEq = builder_.CreateICmpEQ(lhsOk,
-            builder_.CreateExtractValue(rhs, 0, "rhs_is_ok"), "flags_eq");
-        llvm::Value *okEq  = emitComparisonOp("==",
-            builder_.CreateExtractValue(lhs, 1, "lhs_ok_val"),
-            builder_.CreateExtractValue(rhs, 1, "rhs_ok_val"), "", "");
+        llvm::Value *rhsOk   = builder_.CreateExtractValue(rhs, 0, "rhs_is_ok");
+        llvm::Value *flagsEq = builder_.CreateICmpEQ(lhsOk, rhsOk, "flags_eq");
+
+        llvm::Function   *curFn     = builder_.GetInsertBlock()->getParent();
+        llvm::BasicBlock *startBB   = builder_.GetInsertBlock();
+        llvm::BasicBlock *sameKindBB = llvm::BasicBlock::Create(*ctx_, "req.same",  curFn);
+        llvm::BasicBlock *isOkBB    = llvm::BasicBlock::Create(*ctx_, "req.ok",    curFn);
+        llvm::BasicBlock *isErrBB   = llvm::BasicBlock::Create(*ctx_, "req.err",   curFn);
+        llvm::BasicBlock *mergeBB   = llvm::BasicBlock::Create(*ctx_, "req.merge", curFn);
+
+        builder_.CreateCondBr(flagsEq, sameKindBB, mergeBB);
+
+        builder_.SetInsertPoint(sameKindBB);
+        builder_.CreateCondBr(lhsOk, isOkBB, isErrBB);
+
+        builder_.SetInsertPoint(isOkBB);
+        llvm::Value *okEq = emitComparisonOp("==",
+            builder_.CreateExtractValue(lhs, 1, "lhs_ok"),
+            builder_.CreateExtractValue(rhs, 1, "rhs_ok"), "", "");
+        llvm::BasicBlock *okDoneBB = builder_.GetInsertBlock();
+        builder_.CreateBr(mergeBB);
+
+        builder_.SetInsertPoint(isErrBB);
         llvm::Value *errEq = emitComparisonOp("==",
-            builder_.CreateExtractValue(lhs, 2, "lhs_err_val"),
-            builder_.CreateExtractValue(rhs, 2, "rhs_err_val"), "", "");
-        // flagsEq && ((lhsOk && okEq) || (!lhsOk && errEq))
-        llvm::Value *innerEq = builder_.CreateOr(
-            builder_.CreateAnd(lhsOk, okEq, "ok_match"),
-            builder_.CreateAnd(builder_.CreateNot(lhsOk), errEq, "err_match"), "inner_eq");
-        llvm::Value *eqResult = builder_.CreateAnd(flagsEq, innerEq, "res_eq");
+            builder_.CreateExtractValue(lhs, 2, "lhs_err"),
+            builder_.CreateExtractValue(rhs, 2, "rhs_err"), "", "");
+        llvm::BasicBlock *errDoneBB = builder_.GetInsertBlock();
+        builder_.CreateBr(mergeBB);
+
+        builder_.SetInsertPoint(mergeBB);
+        llvm::PHINode *eqResult = builder_.CreatePHI(i1Ty_, 3, "res_eq");
+        eqResult->addIncoming(llvm::ConstantInt::getFalse(*ctx_), startBB);
+        eqResult->addIncoming(okEq, okDoneBB);
+        eqResult->addIncoming(errEq, errDoneBB);
         if (op == "!=") return builder_.CreateNot(eqResult, "res_ne");
         return eqResult;
     }
@@ -378,6 +414,20 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             // Union type: compare tag then dispatch to per-variant inner comparison
             for (auto &[uname, uinfo] : union_type_info_) {
                 if (uinfo.llvmType != lhsST) continue;
+
+                // Union == / != only supports primitive component types.
+                // Non-primitive pointer variants (collections, closures) lose
+                // metadata when loaded from the union payload, causing them to
+                // be misclassified as strings by isStringValue().
+                {
+                    static const std::unordered_set<std::string> kUnionEqPrimitives = {
+                        "int", "float", "str", "bool"
+                    };
+                    for (const auto &cname : uinfo.componentNames) {
+                        if (!kUnionEqPrimitives.count(cname))
+                            codegenError("union == / != is not supported for non-primitive variant '" + cname + "'");
+                    }
+                }
 
                 llvm::Function *curFn = builder_.GetInsertBlock()->getParent();
                 llvm::BasicBlock *sameTagBB = llvm::BasicBlock::Create(*ctx_, "ueq.same",  curFn);
@@ -439,6 +489,12 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         if (lhsElemTy && rhsElemTy && (op == "==" || op == "!=")) {
             if (lhsElemTy != rhsElemTy)
                 codegenError("cannot compare List values with different element types");
+            // Reject equality for non-string pointer elements.
+            // Loaded list elements have no ValueMetadata; if lhsElemTy == ptrTy_
+            // but elements are not strings (e.g. List<List<T>>), isStringValue()
+            // would misclassify them and emit strcmp on arbitrary pointers.
+            if (lhsElemTy == ptrTy_ && getTypeMeta(TypeMeta::NestedListElem, lhs))
+                codegenError("list == / != is not supported for element type 'List<T>'");
             auto lf = loadListHeader(lhs, "leq_l");
             auto rf = loadListHeader(rhs, "leq_r");
             llvm::Function *curFn = builder_.GetInsertBlock()->getParent();
@@ -508,6 +564,16 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             llvm::Type *valTy = getMapValueType(lhs);
             if (!valTy || valTy != getMapValueType(rhs))
                 codegenError("cannot compare Map values with different value types");
+            // Reject equality for non-string pointer map values.
+            // map_value_type_name is non-empty when map values are non-string pointers
+            // (e.g. Map<str, List<int>>); loaded values lose metadata and would be
+            // misclassified as strings by isStringValue().
+            if (valTy == ptrTy_) {
+                auto *lhsMapMeta = getMeta(lhs);
+                if (lhsMapMeta && !lhsMapMeta->map_value_type_name.empty())
+                    codegenError("map == / != is not supported for non-string value type '" +
+                                 lhsMapMeta->map_value_type_name + "'");
+            }
             auto lf = loadMapHeader(lhs, "meq_l");
             auto rf = loadMapHeader(rhs, "meq_r");
             llvm::Function *curFn = builder_.GetInsertBlock()->getParent();

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -546,9 +546,26 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                 codegenError("cannot compare Set values with different element types");
             auto lf = loadSetHeader(lhs, "seq_l");
             auto rf = loadSetHeader(rhs, "seq_r");
-            llvm::Value *lenEq    = builder_.CreateICmpEQ(lf.len, rf.len, "seq_leneq");
+            llvm::Value *lenEq = builder_.CreateICmpEQ(lf.len, rf.len, "seq_leneq");
+
+            // Short-circuit: skip the subset-check loop when lengths differ.
+            llvm::Function   *curFn    = builder_.GetInsertBlock()->getParent();
+            llvm::BasicBlock *startBB  = builder_.GetInsertBlock();
+            llvm::BasicBlock *checkBB  = llvm::BasicBlock::Create(*ctx_, "seq.check", curFn);
+            llvm::BasicBlock *mergeBB  = llvm::BasicBlock::Create(*ctx_, "seq.merge",  curFn);
+
+            builder_.CreateCondBr(lenEq, checkBB, mergeBB);
+
+            builder_.SetInsertPoint(checkBB);
             llvm::Value *isSubset = emitSubsetCheck(lhs, rhs, "seq_sub");
-            llvm::Value *eqResult = builder_.CreateAnd(lenEq, isSubset, "seq_eq");
+            llvm::BasicBlock *checkDoneBB = builder_.GetInsertBlock();
+            builder_.CreateBr(mergeBB);
+
+            builder_.SetInsertPoint(mergeBB);
+            llvm::PHINode *eqResult = builder_.CreatePHI(i1Ty_, 2, "seq_eq");
+            eqResult->addIncoming(llvm::ConstantInt::getFalse(*ctx_), startBB);
+            eqResult->addIncoming(isSubset, checkDoneBB);
+
             if (op == "!=") return builder_.CreateNot(eqResult, "seq_ne");
             return eqResult;
         }

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -326,6 +326,27 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         return eqResult;
     }
 
+    // Result type equality: compare is_ok flag then inner Ok/Err value
+    if (isResultType(lhs->getType()) && isResultType(rhs->getType()) &&
+        lhs->getType() == rhs->getType() && (op == "==" || op == "!=")) {
+        llvm::Value *lhsOk   = builder_.CreateExtractValue(lhs, 0, "lhs_is_ok");
+        llvm::Value *flagsEq = builder_.CreateICmpEQ(lhsOk,
+            builder_.CreateExtractValue(rhs, 0, "rhs_is_ok"), "flags_eq");
+        llvm::Value *okEq  = emitComparisonOp("==",
+            builder_.CreateExtractValue(lhs, 1, "lhs_ok_val"),
+            builder_.CreateExtractValue(rhs, 1, "rhs_ok_val"), "", "");
+        llvm::Value *errEq = emitComparisonOp("==",
+            builder_.CreateExtractValue(lhs, 2, "lhs_err_val"),
+            builder_.CreateExtractValue(rhs, 2, "rhs_err_val"), "", "");
+        // flagsEq && ((lhsOk && okEq) || (!lhsOk && errEq))
+        llvm::Value *innerEq = builder_.CreateOr(
+            builder_.CreateAnd(lhsOk, okEq, "ok_match"),
+            builder_.CreateAnd(builder_.CreateNot(lhsOk), errEq, "err_match"), "inner_eq");
+        llvm::Value *eqResult = builder_.CreateAnd(flagsEq, innerEq, "res_eq");
+        if (op == "!=") return builder_.CreateNot(eqResult, "res_ne");
+        return eqResult;
+    }
+
     // Record (struct) type comparison: field-by-field (only == and != supported)
     if (op == "==" || op == "!=") {
         auto *lhsST = llvm::dyn_cast<llvm::StructType>(lhs->getType());
@@ -354,7 +375,195 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                 if (op == "==") return builder_.CreateICmpEQ(lhsTag, rhsTag, "enum_eq");
                 return builder_.CreateICmpNE(lhsTag, rhsTag, "enum_ne");
             }
+            // Union type: compare tag then dispatch to per-variant inner comparison
+            for (auto &[uname, uinfo] : union_type_info_) {
+                if (uinfo.llvmType != lhsST) continue;
+
+                llvm::Function *curFn = builder_.GetInsertBlock()->getParent();
+                llvm::BasicBlock *sameTagBB = llvm::BasicBlock::Create(*ctx_, "ueq.same",  curFn);
+                llvm::BasicBlock *invalidBB = llvm::BasicBlock::Create(*ctx_, "ueq.inv",   curFn);
+                llvm::BasicBlock *mergeBB   = llvm::BasicBlock::Create(*ctx_, "ueq.merge", curFn);
+
+                llvm::Value *lhsTag = builder_.CreateExtractValue(lhs, 0, "lhs.utag");
+                llvm::Value *rhsTag = builder_.CreateExtractValue(rhs, 0, "rhs.utag");
+                llvm::BasicBlock *entryBB = builder_.GetInsertBlock();
+                builder_.CreateCondBr(
+                    builder_.CreateICmpEQ(lhsTag, rhsTag, "utag_eq"), sameTagBB, mergeBB);
+
+                builder_.SetInsertPoint(sameTagBB);
+                auto *dataTy = uinfo.llvmType->getElementType(1);
+                llvm::AllocaInst *lhsTmp = builder_.CreateAlloca(dataTy, nullptr, "ueq.ld");
+                llvm::AllocaInst *rhsTmp = builder_.CreateAlloca(dataTy, nullptr, "ueq.rd");
+                lhsTmp->setAlignment(mod_->getDataLayout().getABITypeAlign(uinfo.llvmType));
+                rhsTmp->setAlignment(mod_->getDataLayout().getABITypeAlign(uinfo.llvmType));
+                builder_.CreateStore(builder_.CreateExtractValue(lhs, 1, "lhs.udata"), lhsTmp);
+                builder_.CreateStore(builder_.CreateExtractValue(rhs, 1, "rhs.udata"), rhsTmp);
+                llvm::SwitchInst *sw = builder_.CreateSwitch(
+                    lhsTag, invalidBB, uinfo.componentTypes.size());
+
+                builder_.SetInsertPoint(invalidBB);
+                builder_.CreateBr(mergeBB);
+
+                builder_.SetInsertPoint(mergeBB);
+                auto *phi = builder_.CreatePHI(
+                    i1Ty_, uinfo.componentTypes.size() + 2, "ueq.phi");
+                phi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), entryBB);
+                phi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), invalidBB);
+
+                for (size_t ci = 0; ci < uinfo.componentTypes.size(); ++ci) {
+                    llvm::BasicBlock *caseBB = llvm::BasicBlock::Create(
+                        *ctx_, "ueq.c" + std::to_string(ci), curFn);
+                    sw->addCase(
+                        llvm::ConstantInt::get(llvm::cast<llvm::IntegerType>(i64Ty_), ci),
+                        caseBB);
+                    builder_.SetInsertPoint(caseBB);
+                    llvm::Type *compTy = uinfo.componentTypes[ci];
+                    llvm::Value *li = builder_.CreateLoad(compTy, lhsTmp, "ueq.li");
+                    llvm::Value *ri = builder_.CreateLoad(compTy, rhsTmp, "ueq.ri");
+                    llvm::Value *caseEq = emitComparisonOp("==", li, ri, "", "");
+                    phi->addIncoming(caseEq, builder_.GetInsertBlock());
+                    builder_.CreateBr(mergeBB);
+                }
+
+                builder_.SetInsertPoint(mergeBB);
+                if (op == "!=") return builder_.CreateNot(phi, "ueq_ne");
+                return phi;
+            }
         }
+    }
+
+    // List equality: element-wise comparison (only == and != supported)
+    {
+        llvm::Type *lhsElemTy = getListElementType(lhs);
+        llvm::Type *rhsElemTy = getListElementType(rhs);
+        if (lhsElemTy && rhsElemTy && (op == "==" || op == "!=")) {
+            if (lhsElemTy != rhsElemTy)
+                codegenError("cannot compare List values with different element types");
+            auto lf = loadListHeader(lhs, "leq_l");
+            auto rf = loadListHeader(rhs, "leq_r");
+            llvm::Function *curFn = builder_.GetInsertBlock()->getParent();
+            llvm::BasicBlock *entryBB   = builder_.GetInsertBlock();
+            llvm::BasicBlock *sameLenBB = llvm::BasicBlock::Create(*ctx_, "leq.slen",  curFn);
+            llvm::BasicBlock *condBB    = llvm::BasicBlock::Create(*ctx_, "leq.cond",  curFn);
+            llvm::BasicBlock *bodyBB    = llvm::BasicBlock::Create(*ctx_, "leq.body",  curFn);
+            llvm::BasicBlock *nextBB    = llvm::BasicBlock::Create(*ctx_, "leq.next",  curFn);
+            llvm::BasicBlock *failBB    = llvm::BasicBlock::Create(*ctx_, "leq.fail",  curFn);
+            llvm::BasicBlock *mergeBB   = llvm::BasicBlock::Create(*ctx_, "leq.merge", curFn);
+            builder_.CreateCondBr(
+                builder_.CreateICmpEQ(lf.len, rf.len, "leq_leneq"), sameLenBB, mergeBB);
+            builder_.SetInsertPoint(sameLenBB);
+            llvm::AllocaInst *leqI = builder_.CreateAlloca(i64Ty_, nullptr, "leq_i");
+            builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), leqI);
+            builder_.CreateBr(condBB);
+            builder_.SetInsertPoint(condBB);
+            llvm::Value *leqIv = builder_.CreateLoad(i64Ty_, leqI, "leq_iv");
+            builder_.CreateCondBr(builder_.CreateICmpSLT(leqIv, lf.len), bodyBB, mergeBB);
+            builder_.SetInsertPoint(bodyBB);
+            llvm::Value *leqIc = builder_.CreateLoad(i64Ty_, leqI, "leq_ic");
+            llvm::Value *le = builder_.CreateLoad(lhsElemTy,
+                builder_.CreateGEP(lhsElemTy, lf.data, {leqIc}, "leq_lep"), "leq_le");
+            llvm::Value *re = builder_.CreateLoad(lhsElemTy,
+                builder_.CreateGEP(lhsElemTy, rf.data, {leqIc}, "leq_rep"), "leq_re");
+            builder_.CreateCondBr(emitComparisonOp("==", le, re, "", ""), nextBB, failBB);
+            builder_.SetInsertPoint(nextBB);
+            builder_.CreateStore(
+                builder_.CreateAdd(leqIc, llvm::ConstantInt::get(i64Ty_, 1), "leq_in"), leqI);
+            builder_.CreateBr(condBB);
+            builder_.SetInsertPoint(failBB);
+            builder_.CreateBr(mergeBB);
+            builder_.SetInsertPoint(mergeBB);
+            auto *leqPhi = builder_.CreatePHI(i1Ty_, 3, "leq.phi");
+            leqPhi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), entryBB);
+            leqPhi->addIncoming(llvm::ConstantInt::getTrue(*ctx_),  condBB);
+            leqPhi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), failBB);
+            if (op == "!=") return builder_.CreateNot(leqPhi, "leq_ne");
+            return leqPhi;
+        }
+    }
+
+    // Set equality: same length + lhs is a subset of rhs
+    {
+        llvm::Type *lhsSetElemTy = getSetElementType(lhs);
+        llvm::Type *rhsSetElemTy = getSetElementType(rhs);
+        if (lhsSetElemTy && rhsSetElemTy && (op == "==" || op == "!=")) {
+            if (lhsSetElemTy != rhsSetElemTy)
+                codegenError("cannot compare Set values with different element types");
+            auto lf = loadSetHeader(lhs, "seq_l");
+            auto rf = loadSetHeader(rhs, "seq_r");
+            llvm::Value *lenEq    = builder_.CreateICmpEQ(lf.len, rf.len, "seq_leneq");
+            llvm::Value *isSubset = emitSubsetCheck(lhs, rhs, "seq_sub");
+            llvm::Value *eqResult = builder_.CreateAnd(lenEq, isSubset, "seq_eq");
+            if (op == "!=") return builder_.CreateNot(eqResult, "seq_ne");
+            return eqResult;
+        }
+    }
+
+    // Map equality: same length + all keys/values from lhs exist with equal values in rhs
+    {
+        llvm::Type *lhsKeyTy = getMapKeyType(lhs);
+        llvm::Type *rhsKeyTy = getMapKeyType(rhs);
+        if (lhsKeyTy && rhsKeyTy && (op == "==" || op == "!=")) {
+            if (lhsKeyTy != rhsKeyTy)
+                codegenError("cannot compare Map values with different key types");
+            llvm::Type *valTy = getMapValueType(lhs);
+            if (!valTy || valTy != getMapValueType(rhs))
+                codegenError("cannot compare Map values with different value types");
+            auto lf = loadMapHeader(lhs, "meq_l");
+            auto rf = loadMapHeader(rhs, "meq_r");
+            llvm::Function *curFn = builder_.GetInsertBlock()->getParent();
+            llvm::BasicBlock *entryBB   = builder_.GetInsertBlock();
+            llvm::BasicBlock *sameLenBB = llvm::BasicBlock::Create(*ctx_, "meq.slen",  curFn);
+            llvm::BasicBlock *condBB    = llvm::BasicBlock::Create(*ctx_, "meq.cond",  curFn);
+            llvm::BasicBlock *bodyBB    = llvm::BasicBlock::Create(*ctx_, "meq.body",  curFn);
+            llvm::BasicBlock *valBB     = llvm::BasicBlock::Create(*ctx_, "meq.val",   curFn);
+            llvm::BasicBlock *nextBB    = llvm::BasicBlock::Create(*ctx_, "meq.next",  curFn);
+            llvm::BasicBlock *failBB    = llvm::BasicBlock::Create(*ctx_, "meq.fail",  curFn);
+            llvm::BasicBlock *mergeBB   = llvm::BasicBlock::Create(*ctx_, "meq.merge", curFn);
+            builder_.CreateCondBr(
+                builder_.CreateICmpEQ(lf.len, rf.len, "meq_leneq"), sameLenBB, mergeBB);
+            builder_.SetInsertPoint(sameLenBB);
+            llvm::AllocaInst *meqI = builder_.CreateAlloca(i64Ty_, nullptr, "meq_i");
+            builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), meqI);
+            builder_.CreateBr(condBB);
+            builder_.SetInsertPoint(condBB);
+            llvm::Value *meqIv = builder_.CreateLoad(i64Ty_, meqI, "meq_iv");
+            builder_.CreateCondBr(builder_.CreateICmpSLT(meqIv, lf.len), bodyBB, mergeBB);
+            builder_.SetInsertPoint(bodyBB);
+            llvm::Value *meqIc = builder_.CreateLoad(i64Ty_, meqI, "meq_ic");
+            llvm::Value *key = builder_.CreateLoad(lhsKeyTy,
+                builder_.CreateGEP(lhsKeyTy, lf.keys, {meqIc}, "meq_kep"), "meq_k");
+            llvm::Value *rhsIdx = emitMapKeyLookup(rhs, key, lhsKeyTy);
+            builder_.CreateCondBr(
+                builder_.CreateICmpSGE(rhsIdx, llvm::ConstantInt::get(i64Ty_, 0), "meq_found"),
+                valBB, failBB);
+            builder_.SetInsertPoint(valBB);
+            llvm::Value *lv = builder_.CreateLoad(valTy,
+                builder_.CreateGEP(valTy, lf.vals, {meqIc}, "meq_lvep"), "meq_lv");
+            llvm::Value *rv = builder_.CreateLoad(valTy,
+                builder_.CreateGEP(valTy, rf.vals, {rhsIdx}, "meq_rvep"), "meq_rv");
+            builder_.CreateCondBr(emitComparisonOp("==", lv, rv, "", ""), nextBB, failBB);
+            builder_.SetInsertPoint(nextBB);
+            builder_.CreateStore(
+                builder_.CreateAdd(meqIc, llvm::ConstantInt::get(i64Ty_, 1), "meq_in"), meqI);
+            builder_.CreateBr(condBB);
+            builder_.SetInsertPoint(failBB);
+            builder_.CreateBr(mergeBB);
+            builder_.SetInsertPoint(mergeBB);
+            auto *meqPhi = builder_.CreatePHI(i1Ty_, 3, "meq.phi");
+            meqPhi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), entryBB);
+            meqPhi->addIncoming(llvm::ConstantInt::getTrue(*ctx_),  condBB);
+            meqPhi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), failBB);
+            if (op == "!=") return builder_.CreateNot(meqPhi, "meq_ne");
+            return meqPhi;
+        }
+    }
+
+    // Closure: equality comparison is not supported
+    {
+        auto *lhsMeta = getMeta(lhs);
+        auto *rhsMeta = getMeta(rhs);
+        if ((lhsMeta && lhsMeta->fn_type_info) || (rhsMeta && rhsMeta->fn_type_info))
+            codegenError("operator '" + op + "' is not supported for closure values");
     }
 
     bool lhsIsStr = isStringValue(lhs);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -305,8 +305,11 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         llvm::Value *lhsFlag = builder_.CreateExtractValue(lhs, 0, "lhs_has");
         llvm::Value *rhsFlag = builder_.CreateExtractValue(rhs, 0, "rhs_has");
 
-        // When inner types differ (e.g., Option<Error> vs none's Option<int>),
-        // only compare has_value flags (one side must be None)
+        // When Option types differ, one operand must be a 'none' literal whose
+        // LLVM type was not widened to match the other side (e.g. Error? == none).
+        // In this case only the has_value flag matters: Some(...) vs none always differ.
+        // The type checker ensures that Some(a)==Some(b) with incompatible inner
+        // types is rejected before codegen is reached.
         if (lhs->getType() != rhs->getType()) {
             if (op == "==") return builder_.CreateICmpEQ(lhsFlag, rhsFlag, "opt_eq");
             return builder_.CreateICmpNE(lhsFlag, rhsFlag, "opt_ne");
@@ -444,8 +447,8 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                 auto *dataTy = uinfo.llvmType->getElementType(1);
                 llvm::AllocaInst *lhsTmp = builder_.CreateAlloca(dataTy, nullptr, "ueq.ld");
                 llvm::AllocaInst *rhsTmp = builder_.CreateAlloca(dataTy, nullptr, "ueq.rd");
-                lhsTmp->setAlignment(mod_->getDataLayout().getABITypeAlign(uinfo.llvmType));
-                rhsTmp->setAlignment(mod_->getDataLayout().getABITypeAlign(uinfo.llvmType));
+                lhsTmp->setAlignment(mod_->getDataLayout().getABITypeAlign(dataTy));
+                rhsTmp->setAlignment(mod_->getDataLayout().getABITypeAlign(dataTy));
                 builder_.CreateStore(builder_.CreateExtractValue(lhs, 1, "lhs.udata"), lhsTmp);
                 builder_.CreateStore(builder_.CreateExtractValue(rhs, 1, "rhs.udata"), rhsTmp);
                 llvm::SwitchInst *sw = builder_.CreateSwitch(

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -295,8 +295,12 @@ int runRySource(const std::string &src, const std::string &source_name,
         }
     }
 
-    // Add module
-    if (auto err = jit->addIRModule(std::move(tsm))) {
+    // Add module via ResourceTracker so we can explicitly remove it before
+    // ~LLJIT() runs — avoids a heap-corruption crash on Linux ELF teardown
+    // (observed during ~LLJIT() → endSession() when the module contains
+    // ConstantExpr GEP relocations for ARC-managed globals).
+    auto RT = jit->getMainJITDylib().createResourceTracker();
+    if (auto err = jit->addIRModule(RT, std::move(tsm))) {
         errs() << "Failed to add IR module: ";
         logAllUnhandledErrors(std::move(err), errs());
         ry::emitTraceEvent("runtime.error", "jit", &sourceLoc,
@@ -354,6 +358,11 @@ int runRySource(const std::string &src, const std::string &source_name,
         }
         cs->file_id_offset += fc;
     }
+
+    // Explicitly remove JIT resources before ~LLJIT() to avoid Linux ELF
+    // teardown crash.  Errors here are non-fatal (program already ran).
+    if (auto err = RT->remove())
+        llvm::consumeError(std::move(err));
 
     return result > 0 ? 1 : 0;
 }

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -370,7 +370,7 @@ int runRySource(const std::string &src, const std::string &source_name,
     // LLVM-internal heap structures (SymbolStringPool) that are corrupted by
     // JIT relocation side-effects specific to ELF+JITLink.  For a short-lived
     // CLI subprocess this leak is acceptable; the OS reclaims memory on exit.
-    // TODO(#741): Investigate root cause; fix or file upstream LLVM bug.
+    // TODO(#742): Investigate root cause; fix or file upstream LLVM bug.
     jit.release();
 
     return result > 0 ? 1 : 0;

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -23,6 +23,7 @@
 #include <llvm/Support/MemoryBuffer.h>
 #include <llvm/Support/TargetSelect.h>
 #include <llvm/Support/raw_ostream.h>
+#include <llvm/ADT/ScopeExit.h>
 
 using namespace llvm;
 using namespace llvm::orc;
@@ -307,6 +308,13 @@ int runRySource(const std::string &src, const std::string &source_name,
                            {ry::TraceField("detail", "Failed to add IR module")});
         return 1;
     }
+
+    // RAII guard: always remove JIT resources on function exit (normal or early return).
+    auto rtCleanup = llvm::make_scope_exit([&RT]() {
+        if (auto err = RT->remove())
+            llvm::consumeError(std::move(err));
+    });
+
     if (ry::traceEnabled())
         ry::emitTraceEvent("jit.ready", "jit", &sourceLoc,
                            {ry::TraceField("file", source_name)});
@@ -359,19 +367,16 @@ int runRySource(const std::string &src, const std::string &source_name,
         cs->file_id_offset += fc;
     }
 
-    // Explicitly remove JIT resources before LLJIT teardown to avoid a Linux
-    // ELF crash in ~ExecutorProcessControl() → __libc_free.  Errors here are
-    // non-fatal (program already ran).
-    if (auto err = RT->remove())
-        llvm::consumeError(std::move(err));
-
-    // Intentionally leak the LLJIT object to prevent a crash in ~LLJIT() on
-    // Linux ELF.  The crash occurs in ~ExecutorProcessControl() when freeing
-    // LLVM-internal heap structures (SymbolStringPool) that are corrupted by
-    // JIT relocation side-effects specific to ELF+JITLink.  For a short-lived
-    // CLI subprocess this leak is acceptable; the OS reclaims memory on exit.
+#ifndef __APPLE__
+    // Intentionally leak the LLJIT on Linux to prevent a crash in ~LLJIT()
+    // (~ExecutorProcessControl() → __libc_free) caused by JIT relocation
+    // side-effects on ELF+JITLink.  The OS reclaims memory on process exit.
+    // Affects both subprocess (ry test -p) and sequential (ry test) modes;
+    // since ry always exits after the run/test command completes, the
+    // per-invocation leak is bounded by the process lifetime.
     // TODO(#742): Investigate root cause; fix or file upstream LLVM bug.
     jit.release();
+#endif
 
     return result > 0 ? 1 : 0;
 }

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -367,7 +367,7 @@ int runRySource(const std::string &src, const std::string &source_name,
         cs->file_id_offset += fc;
     }
 
-#ifndef __APPLE__
+#ifdef __linux__
     // Intentionally leak the LLJIT on Linux to prevent a crash in ~LLJIT()
     // (~ExecutorProcessControl() → __libc_free) caused by JIT relocation
     // side-effects on ELF+JITLink.  The OS reclaims memory on process exit.

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -359,10 +359,19 @@ int runRySource(const std::string &src, const std::string &source_name,
         cs->file_id_offset += fc;
     }
 
-    // Explicitly remove JIT resources before ~LLJIT() to avoid Linux ELF
-    // teardown crash.  Errors here are non-fatal (program already ran).
+    // Explicitly remove JIT resources before LLJIT teardown to avoid a Linux
+    // ELF crash in ~ExecutorProcessControl() → __libc_free.  Errors here are
+    // non-fatal (program already ran).
     if (auto err = RT->remove())
         llvm::consumeError(std::move(err));
+
+    // Intentionally leak the LLJIT object to prevent a crash in ~LLJIT() on
+    // Linux ELF.  The crash occurs in ~ExecutorProcessControl() when freeing
+    // LLVM-internal heap structures (SymbolStringPool) that are corrupted by
+    // JIT relocation side-effects specific to ELF+JITLink.  For a short-lived
+    // CLI subprocess this leak is acceptable; the OS reclaims memory on exit.
+    // TODO(#741): Investigate root cause; fix or file upstream LLVM bug.
+    jit.release();
 
     return result > 0 ? 1 : 0;
 }

--- a/tests/spec/combinatorial/collection_element.test.ry
+++ b/tests/spec/combinatorial/collection_element.test.ry
@@ -1,0 +1,170 @@
+# BUG #727: List<Map>, List<Set>, List<closure> lose type info on element access
+# BUG #727: List<int|str> is unsupported (list elements must all have the same type)
+
+record ColElemItem:
+  name: str
+  qty: int
+
+enum ColElemStatus:
+  Active
+  Inactive
+
+function make_ok_int(v: int) -> Result<int, Error>:
+  return Ok(v)
+
+function make_err_int() -> Result<int, Error>:
+  return Err(Error("fail"))
+
+describe("collection element — bool in List", ():
+  it("should store and retrieve bool from list", ():
+    xs: List<bool> = [true, false, true]
+    expect(xs[0]).to_be_true()
+    expect(xs[1]).to_be_false()
+  )
+  it("should iterate list of bools", ():
+    xs: List<bool> = [true, true, false]
+    count = 0
+    for v in xs:
+      if v:
+        count = count + 1
+    expect(count).to_eq(2)
+  )
+)
+
+describe("collection element — List<List<int>>", ():
+  it("should store nested lists and access inner elements", ():
+    xs: List<List<int>> = [[1, 2, 3], [4, 5, 6]]
+    expect(xs[0][1]).to_eq(2)
+    expect(xs[1][0]).to_eq(4)
+  )
+  it("should access multiple nested list elements", ():
+    xs: List<List<int>> = [[10, 20], [30, 40]]
+    inner0 = xs[0]
+    inner1 = xs[1]
+    expect(inner0[0]).to_eq(10)
+    expect(inner0[1]).to_eq(20)
+    expect(inner1[0]).to_eq(30)
+  )
+)
+
+describe("collection element — tuple in List", ():
+  it("should store tuples in list and access elements", ():
+    xs: List<(int, str)> = [(1, "a"), (2, "b"), (3, "c")]
+    t = xs[1]
+    expect(t.0).to_eq(2)
+    expect(t.1).to_eq("b")
+  )
+  it("should iterate list of tuples and access fields", ():
+    xs: List<(int, str)> = [(10, "x"), (20, "y")]
+    sum = 0
+    for t in xs:
+      sum = sum + t.0
+    expect(sum).to_eq(30)
+  )
+)
+
+describe("collection element — Option in List", ():
+  it("should store Some and None values in list", ():
+    xs: List<Option<int>> = [Some(1), none, Some(3)]
+    expect(xs[0]).to_be_some()
+    expect(xs[1]).to_be_none()
+    expect(xs[2]).to_be_some()
+  )
+  it("should iterate list of options and count Some values", ():
+    xs: List<Option<int>> = [Some(1), none, Some(3), none, Some(5)]
+    count = 0
+    for v in xs:
+      match v:
+        case Some(_):
+          count = count + 1
+        case _:
+          count = count
+    expect(count).to_eq(3)
+  )
+)
+
+describe("collection element — Result in List", ():
+  it("should store Ok and Err in list", ():
+    xs = [make_ok_int(1), make_err_int(), make_ok_int(3)]
+    expect(xs[0]).to_be_ok()
+    expect(xs[1]).to_be_err()
+  )
+  it("should iterate list of results and count Ok values", ():
+    xs = [make_ok_int(1), make_err_int(), make_ok_int(3)]
+    ok_count = 0
+    for r in xs:
+      match r:
+        case Ok(_):
+          ok_count = ok_count + 1
+        case Err(_):
+          ok_count = ok_count
+    expect(ok_count).to_eq(2)
+  )
+)
+
+describe("collection element — record in List", ():
+  it("should store records in list and access fields", ():
+    xs = [ColElemItem("apple", 3), ColElemItem("banana", 5)]
+    expect(xs[0].name).to_eq("apple")
+    expect(xs[0].qty).to_eq(3)
+    expect(xs[1].name).to_eq("banana")
+  )
+  it("should iterate list of records and sum fields", ():
+    xs = [ColElemItem("a", 10), ColElemItem("b", 20), ColElemItem("c", 30)]
+    total = 0
+    for item in xs:
+      total = total + item.qty
+    expect(total).to_eq(60)
+  )
+)
+
+describe("collection element — enum in List", ():
+  it("should store enum variants in list and check equality", ():
+    xs = [ColElemStatus::Active, ColElemStatus::Inactive, ColElemStatus::Active]
+    expect(xs[0] == ColElemStatus::Active).to_be_true()
+    expect(xs[1] == ColElemStatus::Inactive).to_be_true()
+  )
+  it("should filter list of enums by variant", ():
+    xs = [ColElemStatus::Active, ColElemStatus::Inactive, ColElemStatus::Active]
+    active_count = 0
+    for s in xs:
+      if s == ColElemStatus::Active:
+        active_count = active_count + 1
+    expect(active_count).to_eq(2)
+  )
+)
+
+# BUG #727: List<Map<str,int>> element access loses type info — commented out
+# describe("collection element — Map in List", ():
+#   it("should store maps in list and access by key", ():
+#     xs: List<Map<str,int>> = [{"a": 1}, {"b": 2}]
+#     m = xs[0]
+#     expect(m["a"]).to_eq(1)
+#   )
+# )
+
+# BUG #727: List<Set<int>> element access loses Set type — commented out
+# describe("collection element — Set in List", ():
+#   it("should store sets in list and check membership", ():
+#     xs: List<Set<int>> = [{1, 2, 3}, {4, 5}]
+#     s = xs[0]
+#     expect(1 in s).to_be_true()
+#   )
+# )
+
+# BUG #727: List<int|str> unsupported — list elements must all have the same type
+# describe("collection element — union in List", ():
+#   it("should store union values in list", ():
+#     xs: List<int|str> = [1, "hello", 2]
+#     ...
+#   )
+# )
+
+# BUG #727: List<closure> — calling retrieved closure fails
+# describe("collection element — closure in List", ():
+#   it("should store closures in list and call them", ():
+#     xs = [(x: int) => x * 2, (x: int) => x + 10]
+#     f = xs[0]
+#     expect(f(5)).to_eq(10)
+#   )
+# )

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -29,8 +29,11 @@ describe("equality — Option", ():
     y: int? = none
     expect(x != y).to_be_true()
   )
-  # BUG #726: Some(1) == Some(2) returns true — Option equality ignores inner value
-  # it("should consider Some values with different inner values unequal", ():
-  #   expect(Some(1) != Some(2)).to_be_true()
-  # )
+  it("should consider Some values with different inner values unequal", ():
+    expect(Some(1) != Some(2)).to_be_true()
+  )
+  it("should compare Some string values by content", ():
+    expect(Some("hello") == Some("hello")).to_be_true()
+    expect(Some("a") != Some("b")).to_be_true()
+  )
 )

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -1,0 +1,36 @@
+# UNSUPPORTED: List/Map/Set/Result/union/closure == not yet implemented — see #725
+
+describe("equality — tuple", ():
+  it("should consider equal int tuples equal", ():
+    expect((1, 2) == (1, 2)).to_be_true()
+  )
+  it("should consider different int tuples unequal", ():
+    expect((1, 2) != (1, 3)).to_be_true()
+  )
+  it("should consider mixed-type tuples equal", ():
+    expect((1, "a", true) == (1, "a", true)).to_be_true()
+  )
+  it("should consider mixed-type tuples with different values unequal", ():
+    expect((1, "a") != (1, "b")).to_be_true()
+  )
+)
+
+describe("equality — Option", ():
+  it("should consider Some values equal when inner values are equal", ():
+    expect(Some(42) == Some(42)).to_be_true()
+  )
+  it("should consider None equal to None", ():
+    x: int? = none
+    y: int? = none
+    expect(x == y).to_be_true()
+  )
+  it("should consider Some unequal to None", ():
+    x: int? = Some(1)
+    y: int? = none
+    expect(x != y).to_be_true()
+  )
+  # BUG #726: Some(1) == Some(2) returns true — Option equality ignores inner value
+  # it("should consider Some values with different inner values unequal", ():
+  #   expect(Some(1) != Some(2)).to_be_true()
+  # )
+)

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -1,5 +1,3 @@
-# UNSUPPORTED: List/Map/Set/Result/union/closure == not yet implemented — see #725
-
 describe("equality — tuple", ():
   it("should consider equal int tuples equal", ():
     expect((1, 2) == (1, 2)).to_be_true()
@@ -37,3 +35,130 @@ describe("equality — Option", ():
     expect(Some("a") != Some("b")).to_be_true()
   )
 )
+
+function res_ok(v: int) -> Result<int, Error>:
+  return Ok(v)
+function res_err(msg: str) -> Result<int, Error>:
+  return Err(Error(msg))
+
+describe("equality — Result", ():
+  it("should consider Ok values equal when inner values are equal", ():
+    expect(res_ok(42) == res_ok(42)).to_be_true()
+  )
+  it("should consider Ok values unequal when inner values differ", ():
+    expect(res_ok(1) != res_ok(2)).to_be_true()
+  )
+  it("should consider Err values equal when messages are equal", ():
+    expect(res_err("oops") == res_err("oops")).to_be_true()
+  )
+  it("should consider Err values unequal when messages differ", ():
+    expect(res_err("foo") != res_err("bar")).to_be_true()
+  )
+  it("should consider Ok unequal to Err", ():
+    expect(res_ok(1) != res_err("e")).to_be_true()
+  )
+)
+
+describe("equality — union", ():
+  it("should consider equal int variants equal", ():
+    x: int|str = 42
+    y: int|str = 42
+    expect(x == y).to_be_true()
+  )
+  it("should consider different int variants unequal", ():
+    x: int|str = 1
+    y: int|str = 2
+    expect(x != y).to_be_true()
+  )
+  it("should consider equal str variants equal", ():
+    x: int|str = "hello"
+    y: int|str = "hello"
+    expect(x == y).to_be_true()
+  )
+  it("should consider different str variants unequal", ():
+    x: int|str = "a"
+    y: int|str = "b"
+    expect(x != y).to_be_true()
+  )
+  it("should consider different tag variants unequal", ():
+    x: int|str = 1
+    y: int|str = "1"
+    expect(x != y).to_be_true()
+  )
+)
+
+describe("equality — List", ():
+  it("should consider equal int lists equal", ():
+    expect([1, 2, 3] == [1, 2, 3]).to_be_true()
+  )
+  it("should consider int lists with different values unequal", ():
+    expect([1, 2, 3] != [1, 2, 4]).to_be_true()
+  )
+  it("should consider int lists of different lengths unequal", ():
+    expect([1, 2] != [1, 2, 3]).to_be_true()
+  )
+  it("should consider empty lists equal", ():
+    a: List<int> = []
+    b: List<int> = []
+    expect(a == b).to_be_true()
+  )
+  it("should consider equal str lists equal", ():
+    expect(["a", "b"] == ["a", "b"]).to_be_true()
+  )
+  it("should consider str lists with different values unequal", ():
+    expect(["a", "b"] != ["a", "c"]).to_be_true()
+  )
+)
+
+describe("equality — Set", ():
+  it("should consider equal int sets equal regardless of insertion order", ():
+    a: Set<int> = {1, 2, 3}
+    b: Set<int> = {3, 2, 1}
+    expect(a == b).to_be_true()
+  )
+  it("should consider int sets with different elements unequal", ():
+    a: Set<int> = {1, 2}
+    b: Set<int> = {1, 3}
+    expect(a != b).to_be_true()
+  )
+  it("should consider int sets of different sizes unequal", ():
+    a: Set<int> = {1, 2}
+    b: Set<int> = {1, 2, 3}
+    expect(a != b).to_be_true()
+  )
+  it("should consider empty sets equal", ():
+    a: Set<int> = {}
+    b: Set<int> = {}
+    expect(a == b).to_be_true()
+  )
+)
+
+describe("equality — Map", ():
+  it("should consider equal str->int maps equal", ():
+    a: Map<str, int> = {"x": 1, "y": 2}
+    b: Map<str, int> = {"x": 1, "y": 2}
+    expect(a == b).to_be_true()
+  )
+  it("should consider maps with different values unequal", ():
+    a: Map<str, int> = {"x": 1}
+    b: Map<str, int> = {"x": 2}
+    expect(a != b).to_be_true()
+  )
+  it("should consider maps with different keys unequal", ():
+    a: Map<str, int> = {"x": 1}
+    b: Map<str, int> = {"y": 1}
+    expect(a != b).to_be_true()
+  )
+  it("should consider empty maps equal", ():
+    a: Map<str, int> = {}
+    b: Map<str, int> = {}
+    expect(a == b).to_be_true()
+  )
+)
+# Closure equality is intentionally unsupported (compile-time error).
+# Uncomment to verify the compiler rejects it:
+# it("should reject closure equality at compile time", ():
+#   f = (x: int) => x + 1
+#   g = (x: int) => x + 1
+#   _ = f == g
+# )

--- a/tests/spec/combinatorial/fn_argument.test.ry
+++ b/tests/spec/combinatorial/fn_argument.test.ry
@@ -1,0 +1,77 @@
+record FnArgPoint:
+  x: int
+  y: int
+
+enum FnArgSuit:
+  Hearts
+  Diamonds
+  Clubs
+  Spades
+
+function take_set(s: Set<int>) -> bool:
+  return 10 in s
+
+function take_tuple(t: (int, str)) -> int:
+  return t.0
+
+function take_result_ok(r: Result<int, Error>) -> bool:
+  return match r:
+    case Ok(_) => true
+    case Err(_) => false
+
+function make_ok_result(v: int) -> Result<int, Error>:
+  return Ok(v)
+
+function make_err_result(msg: str) -> Result<int, Error>:
+  return Err(Error(msg))
+
+function take_record(p: FnArgPoint) -> int:
+  return p.x + p.y
+
+function take_enum(s: FnArgSuit) -> bool:
+  return s == FnArgSuit::Hearts
+
+describe("fn argument — Set", ():
+  it("should pass set as function argument and check membership", ():
+    s = {10, 20, 30}
+    expect(take_set(s)).to_be_true()
+  )
+  it("should pass set without target element as function argument", ():
+    s = {1, 2, 3}
+    expect(take_set(s)).to_be_false()
+  )
+)
+
+describe("fn argument — tuple", ():
+  it("should pass tuple as function argument and access element", ():
+    t = (42, "hello")
+    expect(take_tuple(t)).to_eq(42)
+  )
+)
+
+describe("fn argument — Result", ():
+  it("should pass Ok result as function argument", ():
+    r = make_ok_result(99)
+    expect(take_result_ok(r)).to_be_true()
+  )
+  it("should pass Err result as function argument", ():
+    r = make_err_result("fail")
+    expect(take_result_ok(r)).to_be_false()
+  )
+)
+
+describe("fn argument — record", ():
+  it("should pass record as function argument and compute from fields", ():
+    p = FnArgPoint(3, 7)
+    expect(take_record(p)).to_eq(10)
+  )
+)
+
+describe("fn argument — enum (simple)", ():
+  it("should pass matching enum variant as function argument", ():
+    expect(take_enum(FnArgSuit::Hearts)).to_be_true()
+  )
+  it("should pass non-matching enum variant as function argument", ():
+    expect(take_enum(FnArgSuit::Clubs)).to_be_false()
+  )
+)

--- a/tests/spec/combinatorial/fn_return.test.ry
+++ b/tests/spec/combinatorial/fn_return.test.ry
@@ -1,0 +1,95 @@
+record FnReturnPoint:
+  x: int
+  y: int
+
+enum FnReturnDir:
+  North
+  South
+  East
+  West
+
+function make_map() -> Map<str, int>:
+  m: Map<str, int> = {"a": 1, "b": 2, "c": 3}
+  return m
+
+function make_set() -> Set<int>:
+  return {10, 20, 30}
+
+function make_pair() -> (int, str):
+  return (42, "hello")
+
+function flexible(flag: bool) -> int | str:
+  if flag:
+    return 42
+  return "hello"
+
+function make_point(a: int, b: int) -> FnReturnPoint:
+  return FnReturnPoint(a, b)
+
+function pick_dir(n: int) -> FnReturnDir:
+  if n == 0:
+    return FnReturnDir::North
+  return FnReturnDir::South
+
+describe("fn return — Map", ():
+  it("should return map from function and access by key", ():
+    m = make_map()
+    expect(m["a"]).to_eq(1)
+    expect(m["b"]).to_eq(2)
+  )
+  it("should return map from function and check missing key", ():
+    m = make_map()
+    expect(m.get("z")).to_be_none()
+  )
+)
+
+describe("fn return — Set", ():
+  it("should return set from function and check membership", ():
+    s = make_set()
+    expect(10 in s).to_be_true()
+    expect(99 in s).to_be_false()
+  )
+)
+
+describe("fn return — tuple", ():
+  it("should return tuple from function and access elements", ():
+    t = make_pair()
+    expect(t.0).to_eq(42)
+    expect(t.1).to_eq("hello")
+  )
+)
+
+describe("fn return — union", ():
+  it("should return int variant from union function", ():
+    v = flexible(true)
+    expect(to_str(v)).to_eq("42")
+  )
+  it("should return str variant from union function", ():
+    v = flexible(false)
+    expect(to_str(v)).to_eq("hello")
+  )
+)
+
+describe("fn return — record", ():
+  it("should return record from function and access fields", ():
+    p = make_point(3, 7)
+    expect(p.x).to_eq(3)
+    expect(p.y).to_eq(7)
+  )
+  it("should mutate fields of returned record", ():
+    p = make_point(1, 2)
+    p.x = 99
+    expect(p.x).to_eq(99)
+  )
+)
+
+describe("fn return — enum (simple)", ():
+  it("should return North enum variant from function", ():
+    d = pick_dir(0)
+    expect(d == FnReturnDir::North).to_be_true()
+  )
+  it("should return South enum variant from function", ():
+    d = pick_dir(1)
+    expect(d == FnReturnDir::South).to_be_true()
+  )
+)

--- a/tests/spec/combinatorial/match_types.test.ry
+++ b/tests/spec/combinatorial/match_types.test.ry
@@ -1,0 +1,163 @@
+record MatchCoord:
+  x: int
+  y: int
+
+describe("match — float", ():
+  it("should match float literal", ():
+    x = 3.14
+    res = match x:
+      case 3.14 => "pi"
+      case _ => "other"
+    expect(res).to_eq("pi")
+  )
+  it("should match float with guard", ():
+    x = 2.71
+    res = match x:
+      case v if v > 3.0 => "big"
+      case v if v > 2.0 => "medium"
+      case _ => "small"
+    expect(res).to_eq("medium")
+  )
+  it("should fall through to wildcard for unmatched float", ():
+    x = 0.5
+    res = match x:
+      case 3.14 => "pi"
+      case _ => "other"
+    expect(res).to_eq("other")
+  )
+)
+
+describe("match — str (additional cases)", ():
+  it("should match empty string literal", ():
+    s = ""
+    res = match s:
+      case "" => "empty"
+      case _ => "non-empty"
+    expect(res).to_eq("empty")
+  )
+  it("should match multiple string alternatives with OR", ():
+    s = "yes"
+    res = match s:
+      case "yes" | "y" | "true" => "affirmative"
+      case _ => "other"
+    expect(res).to_eq("affirmative")
+  )
+)
+
+describe("match — bool", ():
+  it("should match true literal", ():
+    x = true
+    res = match x:
+      case true => "yes"
+      case false => "no"
+    expect(res).to_eq("yes")
+  )
+  it("should match false literal", ():
+    x = false
+    res = match x:
+      case true => "yes"
+      case false => "no"
+    expect(res).to_eq("no")
+  )
+  it("should use match expression on bool as return value", ():
+    flag = true
+    label = match flag:
+      case true => "on"
+      case false => "off"
+    expect(label).to_eq("on")
+  )
+)
+
+describe("match — List", ():
+  it("should match non-empty list using guard", ():
+    xs = [1, 2, 3]
+    res = match xs:
+      case _ if xs.is_empty() => "empty"
+      case _ => "non-empty"
+    expect(res).to_eq("non-empty")
+  )
+  it("should match empty list using guard", ():
+    xs: List<int> = []
+    res = match xs:
+      case _ if xs.is_empty() => "empty"
+      case _ => "non-empty"
+    expect(res).to_eq("empty")
+  )
+)
+
+describe("match — Map", ():
+  it("should match map by key presence using guard", ():
+    m: Map<str, int> = {"a": 1, "b": 2}
+    res = match m:
+      case _ if m.get("a") != none => "has a"
+      case _ => "no a"
+    expect(res).to_eq("has a")
+  )
+  it("should match empty map using guard", ():
+    m: Map<str, int> = {}
+    res = match m:
+      case _ if m.get("x") != none => "has x"
+      case _ => "no x"
+    expect(res).to_eq("no x")
+  )
+)
+
+describe("match — Set", ():
+  it("should match set by membership using guard", ():
+    s = {1, 2, 3}
+    res = match s:
+      case _ if 1 in s => "has 1"
+      case _ => "no 1"
+    expect(res).to_eq("has 1")
+  )
+  it("should match set without target element using guard", ():
+    s = {4, 5, 6}
+    res = match s:
+      case _ if 1 in s => "has 1"
+      case _ => "no 1"
+    expect(res).to_eq("no 1")
+  )
+)
+
+describe("match — tuple", ():
+  it("should match tuple with guard on first element", ():
+    t = (5, "hello")
+    res = match t:
+      case v if v.0 > 0 => "positive"
+      case _ => "non-positive"
+    expect(res).to_eq("positive")
+  )
+  it("should use match expression with tuple", ():
+    t = (0, "zero")
+    label = match t:
+      case v if v.0 == 0 => "zero"
+      case _ => "non-zero"
+    expect(label).to_eq("zero")
+  )
+)
+
+describe("match — record", ():
+  it("should match record with guard on field", ():
+    p = MatchCoord(10, 20)
+    res = match p:
+      case v if v.x > 0 => "positive x"
+      case _ => "non-positive x"
+    expect(res).to_eq("positive x")
+  )
+  it("should use match expression with record guard", ():
+    p = MatchCoord(0, 5)
+    label = match p:
+      case v if v.x == 0 and v.y > 0 => "on y-axis"
+      case _ => "other"
+    expect(label).to_eq("on y-axis")
+  )
+)
+
+describe("match — closure", ():
+  it("should match closure with wildcard", ():
+    f = (x: int) => x * 2
+    res = match f:
+      case _ => "got closure"
+    expect(res).to_eq("got closure")
+  )
+)

--- a/tests/spec/combinatorial/nested_types.test.ry
+++ b/tests/spec/combinatorial/nested_types.test.ry
@@ -1,0 +1,142 @@
+function divide(a: int, b: int) -> Result<int, Error>:
+  if b == 0:
+    return Err(Error("division by zero"))
+  return Ok(a // b)
+
+function try_parse(s: str) -> Result<int, Error>:
+  v = s.to_int()
+  return match v:
+    case Ok(n) => Ok(n)
+    case Err(e) => Err(e)
+
+describe("nested — Option<List<int>>", ():
+  it("should wrap list in Some and unwrap it", ():
+    xs = [1, 2, 3]
+    opt: Option<List<int>> = Some(xs)
+    match opt:
+      case Some(inner):
+        expect(inner[0]).to_eq(1)
+        expect(inner[2]).to_eq(3)
+      case None:
+        fail("expected Some")
+  )
+  it("should handle None option of list", ():
+    opt: Option<List<int>> = none
+    expect(opt).to_be_none()
+  )
+)
+
+describe("nested — List<Option<int>>", ():
+  it("should store mixed Some/None in list and filter Some values", ():
+    xs: List<Option<int>> = [Some(10), none, Some(30)]
+    result = 0
+    for v in xs:
+      match v:
+        case Some(n):
+          result = result + n
+        case _:
+          result = result
+    expect(result).to_eq(40)
+  )
+)
+
+describe("nested — Result<int, Error>", ():
+  # BUG #727: Result<Map>/Result<List> lose inner pointer-type content
+  # Using scalar inner type instead
+  it("should return Ok and match inner value", ():
+    r = divide(10, 2)
+    match r:
+      case Ok(n):
+        expect(n).to_eq(5)
+      case Err(e):
+        fail("unexpected error")
+  )
+  it("should propagate Err from nested result", ():
+    r = divide(10, 0)
+    expect(r).to_be_err()
+  )
+)
+
+describe("nested — Map<str, List<int>>", ():
+  it("should store lists as map values and access inner elements", ():
+    m: Map<str, List<int>> = {"evens": [2, 4, 6], "odds": [1, 3, 5]}
+    evens = m["evens"]
+    expect(evens[0]).to_eq(2)
+    expect(evens[2]).to_eq(6)
+  )
+  it("should access nested list from map value variable", ():
+    m: Map<str, List<int>> = {"nums": [10, 20, 30]}
+    nums = m["nums"]
+    expect(nums[1]).to_eq(20)
+  )
+)
+
+describe("nested — List<(int, str)>", ():
+  it("should store tuples in list and access fields", ():
+    xs: List<(int, str)> = [(1, "one"), (2, "two"), (3, "three")]
+    t = xs[1]
+    expect(t.0).to_eq(2)
+    expect(t.1).to_eq("two")
+  )
+  it("should iterate list of tuples and destructure", ():
+    xs: List<(int, str)> = [(10, "a"), (20, "b")]
+    total = 0
+    for t in xs:
+      total = total + t.0
+    expect(total).to_eq(30)
+  )
+)
+
+describe("nested — Option<(int, str)>", ():
+  it("should wrap tuple in Some and unwrap it", ():
+    opt: Option<(int, str)> = Some((42, "hello"))
+    match opt:
+      case Some(t):
+        expect(t.0).to_eq(42)
+        expect(t.1).to_eq("hello")
+      case None:
+        fail("expected Some")
+  )
+)
+
+function make_greeting(name: str) -> Result<str, Error>:
+  if name == "":
+    return Err(Error("name required"))
+  return Ok(f"hello, {name}")
+
+describe("nested — Result<str, Error>", ():
+  # BUG #727: Result<List<str>> loses inner list content
+  # Using scalar inner type instead
+  it("should return Ok with string and match it", ():
+    r = make_greeting("world")
+    match r:
+      case Ok(s):
+        expect(s).to_eq("hello, world")
+      case Err(e):
+        fail("unexpected error")
+  )
+  it("should return Err when input is invalid", ():
+    r = make_greeting("")
+    expect(r).to_be_err()
+  )
+)
+
+describe("nested — List<Result<int, Error>>", ():
+  it("should store mixed Ok/Err in list and check variants", ():
+    xs = [divide(10, 2), divide(5, 0), divide(8, 4)]
+    expect(xs[0]).to_be_ok()
+    expect(xs[1]).to_be_err()
+    expect(xs[2]).to_be_ok()
+  )
+  it("should iterate list of results and extract Ok values", ():
+    xs = [divide(10, 2), divide(5, 0), divide(20, 4)]
+    sum = 0
+    for r in xs:
+      match r:
+        case Ok(n):
+          sum = sum + n
+        case Err(_):
+          sum = sum
+    expect(sum).to_eq(10)
+  )
+)

--- a/tests/spec/combinatorial/print_display.test.ry
+++ b/tests/spec/combinatorial/print_display.test.ry
@@ -1,0 +1,22 @@
+# BUG #728: print() and to_str() on closure values not supported
+
+describe("print — union", ():
+  it("should print int variant of union without crashing", ():
+    x: int | str = 42
+    print(x)
+    # expect-output: 42
+  )
+  it("should print str variant of union without crashing", ():
+    y: int | str = "hello"
+    print(y)
+    # expect-output: hello
+  )
+  it("should use to_str on union value", ():
+    x: int | str = 99
+    expect(to_str(x)).to_eq("99")
+  )
+  it("should use f-string interpolation with union value", ():
+    x: int | str = "world"
+    expect(f"value={x}").to_eq("value=world")
+  )
+)

--- a/tests/spec/combinatorial/stdlib_boundary.test.ry
+++ b/tests/spec/combinatorial/stdlib_boundary.test.ry
@@ -1,0 +1,111 @@
+# BUG #729: int literal 9223372036854775807 (INT64_MAX) crashes the parser
+
+describe("stdlib boundary — large collection", ():
+  it("should handle list with 1000 elements", ():
+    xs: List<int> = []
+    for i in range(0, 1000):
+      append(xs, i)
+    expect(xs[0]).to_eq(0)
+    expect(xs[999]).to_eq(999)
+  )
+  it("should sort large list correctly", ():
+    xs: List<int> = []
+    for i in range(9, -1, -1):
+      append(xs, i)
+    sorted = sort(xs)
+    expect(sorted[0]).to_eq(0)
+    expect(sorted[9]).to_eq(9)
+  )
+)
+
+describe("stdlib boundary — unicode strings", ():
+  it("should split unicode string into chars", ():
+    parts = "あいう".split("")
+    expect(parts[0]).to_eq("あ")
+    expect(parts[1]).to_eq("い")
+    expect(parts[2]).to_eq("う")
+  )
+  it("should get char_at for unicode string with negative index", ():
+    expect(char_at("あいう", -1)).to_eq("う")
+    expect(char_at("あいう", -3)).to_eq("あ")
+  )
+  it("should compute substring for unicode string", ():
+    s = "abcdef"
+    expect(substring(s, 1, 4)).to_eq("bcd")
+  )
+)
+
+describe("stdlib boundary — negative indices", ():
+  it("should access list with negative index", ():
+    xs = [10, 20, 30, 40, 50]
+    expect(xs[-1]).to_eq(50)
+    expect(xs[-2]).to_eq(40)
+    expect(xs[-5]).to_eq(10)
+  )
+  it("should access string char with negative index", ():
+    expect(char_at("hello", -1)).to_eq("o")
+    expect(char_at("hello", -5)).to_eq("h")
+  )
+  it("should use substring with bounds clamping", ():
+    expect(substring("abc", 0, 100)).to_eq("abc")
+    expect(substring("abc", 5, 10)).to_eq("")
+  )
+)
+
+describe("stdlib boundary — type boundaries", ():
+  it("should handle small int boundary values", ():
+    expect(0).to_eq(0)
+    expect(-1).to_eq(-1)
+    expect(1000000000).to_eq(1000000000)
+    expect(-1000000000).to_eq(-1000000000)
+  )
+  it("should handle float infinity from division", ():
+    inf = 1.0 / 0.0
+    expect(inf > 1000000.0).to_be_true()
+  )
+  it("should handle float zero", ():
+    x = 0.0
+    expect(x == 0.0).to_be_true()
+    expect(-x == 0.0).to_be_true()
+  )
+)
+
+describe("stdlib boundary — empty inputs", ():
+  it("should split empty string by delimiter", ():
+    parts = "".split(",")
+    expect(parts).to_have_length(1)
+    expect(parts[0]).to_eq("")
+  )
+  it("should join empty list", ():
+    parts: List<str> = []
+    result = ",".join(parts)
+    expect(result).to_eq("")
+  )
+  it("should map empty list", ():
+    xs: List<int> = []
+    ys = xs.map((x: int) => x * 2)
+    expect(ys).to_have_length(0)
+  )
+  it("should return empty keys for empty map", ():
+    m: Map<str, int> = {}
+    expect(m.keys()).to_have_length(0)
+  )
+)
+
+describe("stdlib boundary — single element", ():
+  it("should sort single-element list", ():
+    xs = [42]
+    ys = sort(xs)
+    expect(ys[0]).to_eq(42)
+  )
+  it("should reverse single-element list", ():
+    xs = [99]
+    ys = reverse(xs)
+    expect(ys[0]).to_eq(99)
+  )
+  it("should split single char by empty delimiter", ():
+    parts = "a".split("")
+    expect(parts).to_have_length(1)
+    expect(parts[0]).to_eq("a")
+  )
+)

--- a/tests/spec/combinatorial/stdlib_boundary.test.ry
+++ b/tests/spec/combinatorial/stdlib_boundary.test.ry
@@ -30,8 +30,8 @@ describe("stdlib boundary — unicode strings", ():
     expect(char_at("あいう", -3)).to_eq("あ")
   )
   it("should compute substring for unicode string", ():
-    s = "abcdef"
-    expect(substring(s, 1, 4)).to_eq("bcd")
+    s = "あいうえお"
+    expect(substring(s, 1, 4)).to_eq("いうえ")
   )
 )
 

--- a/tests/spec/combinatorial/syntax_combinations.test.ry
+++ b/tests/spec/combinatorial/syntax_combinations.test.ry
@@ -1,0 +1,157 @@
+enum SyntaxShape:
+  Circle
+  Rect
+  Triangle
+
+function describe_shape_a(s: SyntaxShape) -> str:
+  return match s:
+    case SyntaxShape::Circle => "circle"
+    case SyntaxShape::Rect => "rect"
+    case SyntaxShape::Triangle => "triangle"
+
+function describe_shape_b(s: SyntaxShape) -> str:
+  return match s:
+    case SyntaxShape::Circle => "round"
+    case SyntaxShape::Rect => "angular"
+    case SyntaxShape::Triangle => "pointed"
+
+function make_multiplier(factor: int) -> function(int) -> int:
+  return (x: int) => x * factor
+
+describe("syntax combo — lambda with local var, if, return", ():
+  it("should execute multiline lambda with conditional and local variable", ():
+    transform = (n: int):
+      doubled = n * 2
+      if doubled > 10:
+        return doubled
+      return doubled + 1
+    expect(transform(6)).to_eq(12)
+    expect(transform(3)).to_eq(7)
+  )
+)
+
+describe("syntax combo — UFCS on literal", ():
+  it("should chain UFCS map on list literal", ():
+    result = [1, 2, 3].map((x: int) => x * 2)
+    expect(result[0]).to_eq(2)
+    expect(result[2]).to_eq(6)
+  )
+  it("should chain UFCS filter and map on list literal", ():
+    result = [1, 2, 3, 4, 5].filter((x: int) => x > 2).map((x: int) => x * 10)
+    expect(result[0]).to_eq(30)
+    expect(result[2]).to_eq(50)
+  )
+  it("should use UFCS split on string literal", ():
+    parts = "a,b,c".split(",")
+    expect(parts[0]).to_eq("a")
+    expect(parts[2]).to_eq("c")
+  )
+)
+
+describe("syntax combo — match + exhaustive enum + return value", ():
+  it("should use match expression on exhaustive enum as return value", ():
+    expect(describe_shape_a(SyntaxShape::Circle)).to_eq("circle")
+    expect(describe_shape_a(SyntaxShape::Rect)).to_eq("rect")
+    expect(describe_shape_a(SyntaxShape::Triangle)).to_eq("triangle")
+  )
+)
+
+describe("syntax combo — when expression (inline case) in expression position", ():
+  it("should use when expression to select label", ():
+    x = 3
+    label = when:
+      x == 1 => "one"
+      x == 3 => "three"
+      else => "other"
+    expect(label).to_eq("three")
+  )
+  it("should use when expression in function argument", ():
+    n = 5
+    result = (when:
+      n > 10 => n * 2
+      n > 3 => n + 10
+      else => n
+    )
+    expect(result).to_eq(15)
+  )
+)
+
+describe("syntax combo — type annotation with generics in parameter", ():
+  it("should pass Map<str, List<int>> as function argument", ():
+    function get_first_item(data: Map<str, List<int>>, key: str) -> int:
+      xs = data[key]
+      return xs[0]
+
+    m: Map<str, List<int>> = {"nums": [10, 20, 30]}
+    expect(get_first_item(m, "nums")).to_eq(10)
+  )
+)
+
+describe("syntax combo — string literal containing keywords", ():
+  it("should store and print string with keyword 'print'", ():
+    s = "print this"
+    expect(s).to_eq("print this")
+  )
+  it("should store string with 'if then else'", ():
+    s = "if then else"
+    expect(s).to_eq("if then else")
+  )
+  it("should use f-string with keyword-containing value", ():
+    keyword = "match"
+    result = f"the keyword is {keyword}"
+    expect(result).to_eq("the keyword is match")
+  )
+)
+
+describe("syntax combo — single-element tuple", ():
+  it("should create and access single-element tuple", ():
+    t = (42,)
+    expect(t.0).to_eq(42)
+  )
+  it("should pass single-element tuple as function argument", ():
+    function first_of_one(t: (int,)) -> int:
+      return t.0
+
+    expect(first_of_one((99,))).to_eq(99)
+  )
+)
+
+describe("syntax combo — chained index/method access", ():
+  it("should chain map index and list index access", ():
+    m: Map<str, List<int>> = {"nums": [10, 20, 30]}
+    xs = m["nums"]
+    expect(xs[1]).to_eq(20)
+  )
+  it("should chain UFCS method on indexed value", ():
+    data: List<str> = ["hello world", "foo bar"]
+    parts = data[0].split(" ")
+    expect(parts[0]).to_eq("hello")
+    expect(parts[1]).to_eq("world")
+  )
+)
+
+describe("syntax combo — closure returned from function", ():
+  it("should call closure returned from function", ():
+    triple = make_multiplier(3)
+    expect(triple(7)).to_eq(21)
+  )
+  it("should use multiple closures from same factory function", ():
+    double = make_multiplier(2)
+    times10 = make_multiplier(10)
+    expect(double(5)).to_eq(10)
+    expect(times10(5)).to_eq(50)
+  )
+)
+
+describe("syntax combo — multiple match on same ADT in different functions", ():
+  it("should independently match same ADT enum in separate functions", ():
+    expect(describe_shape_a(SyntaxShape::Circle)).to_eq("circle")
+    expect(describe_shape_b(SyntaxShape::Circle)).to_eq("round")
+  )
+  it("should handle all variants consistently across functions", ():
+    expect(describe_shape_a(SyntaxShape::Rect)).to_eq("rect")
+    expect(describe_shape_b(SyntaxShape::Rect)).to_eq("angular")
+    expect(describe_shape_a(SyntaxShape::Triangle)).to_eq("triangle")
+    expect(describe_shape_b(SyntaxShape::Triangle)).to_eq("pointed")
+  )
+)


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Implements `==` and `!=` for all previously unsupported composite types.

| Type | Approach |
|------|----------|
| `Result<T,E>` | Inline IR: compare `is_ok` flag, then inner `Ok`/`Err` value |
| `union A\|B` | `SwitchInst` per variant: compare tag, then inner value |
| `List<T>` | Inline IR loop: length check + element-wise comparison |
| `Set<T>` | Length check + `emitSubsetCheck` (order-independent) |
| `Map<K,V>` | Inline IR loop: length check + key lookup + value comparison |
| Closure | Compile-time error |

Supported element/value types for collections: `int`, `float`, `str`, `bool`.  
Complex element types (`List<record>`, nested collections) are tracked in #736.

Also includes the `#726` cherry-pick (Option inner value comparison) as a prerequisite.

## Test plan

- [ ] 33 new tests in `tests/spec/combinatorial/equality.test.ry` all pass
- [ ] `./build/ry_tests` passes (1425 tests)
- [ ] `./build/ry test -p` passes (90 files)
- [ ] ASan build passes
- [ ] `docs/reference/collections.md` and `docs/reference/types.md` updated

Closes #725
EOF
)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added == / != support for List, Set, Map, Result, Option, tuples and union variants (closure equality remains unsupported).

* **Documentation**
  * Updated reference docs with explicit equality semantics and examples for collections, Result/Option, and union variants.

* **Tests**
  * Added ~113 combinatorial tests covering collections, equality, function arguments/returns, match behavior, nested types, syntax combinations, print/display, and stdlib boundary cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->