### PR TITLE
test: add systematic combinatorial cross-feature test coverage (#628)

### DIFF
--- a/changelog.d/727-list-element-type.md
+++ b/changelog.d/727-list-element-type.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Element type metadata is now preserved when accessing elements of `List<Map<K,V>>`, `List<Set<T>>`, and `List<closure>` by index or in a `for` loop (#727)
+  - `xs[0]["key"]` on `List<Map<str, int>>` now works correctly
+  - `for m in xs: m["key"]` on `List<Map<str, int>>` now works correctly
+  - `xs[0]` on `List<Set<int>>` supports the `in` operator
+  - Closures stored in a list (`fns[0](arg)`) are now callable after retrieval

--- a/changelog.d/728-closure-print.md
+++ b/changelog.d/728-closure-print.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `print()`, `to_str()`, and f-string interpolation now work with closure values — they produce `"<closure>"` instead of a compile-time error (#728)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -454,6 +454,19 @@ function apply(func: function(int) -> int, x: int) -> int:
 result = apply(f, 5)   # 10
 ```
 
+### String Representation
+
+`print()`, `to_str()`, and f-string interpolation all produce `"<closure>"` for function values:
+
+```python
+f = (x: int) => x + 1
+print(f)              # <closure>
+s = to_str(f)         # "<closure>"
+msg = f"fn={f}"       # "fn=<closure>"
+```
+
+> **Note**: Equality comparison (`==` / `!=`) between closures is not supported and produces a compile-time error.
+
 ---
 
 ## Higher-Order Functions

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -578,9 +578,13 @@ public:
 
         // String-typed metadata
         std::string low_level_type_name;
-        std::string map_value_type_name;   // Ry type name for map values
-        std::string union_value_type;      // normalized union type name
-        std::string enum_value_type;       // enum type name
+        std::string map_value_type_name;    // Ry type name for map values
+        std::string list_elem_type_name;    // Ry type name for list elements (e.g. "Map<str, int>")
+        std::string union_value_type;       // normalized union type name
+        std::string enum_value_type;        // enum type name
+
+        // Closure/function type info for list elements
+        std::optional<FnTypeInfo> list_elem_fn_type_info;
 
         // Closure/function type info
         std::optional<FnTypeInfo> fn_type_info;

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -202,6 +202,13 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
             if (allMatch)
                 setTypeMeta(TypeMeta::NestedListElem, headerPtr, innerElemTy);
         }
+
+        // Track Map/Set/closure element type name for metadata propagation on index access
+        std::string elemTypeName = inferCollectionTypeName(vals[0]);
+        if (!elemTypeName.empty())
+            getOrCreateMeta(headerPtr).list_elem_type_name = elemTypeName;
+        else if (auto *elemMeta = getMeta(vals[0]); elemMeta && elemMeta->fn_type_info)
+            getOrCreateMeta(headerPtr).list_elem_fn_type_info = elemMeta->fn_type_info;
     }
 
     return headerPtr;
@@ -513,6 +520,13 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     llvm::Type *nestedElemTy = getNestedListElementType(objPtr);
     if (nestedElemTy)
         setTypeMeta(TypeMeta::ListElem, elem, nestedElemTy);
+
+    // Propagate Map/Set/closure element metadata (e.g. List<Map<str,int>>, List<closure>)
+    auto *listMeta = getMeta(objPtr);
+    if (listMeta && !listMeta->list_elem_type_name.empty())
+        propagateTypeMeta(listMeta->list_elem_type_name, elem);
+    if (listMeta && listMeta->list_elem_fn_type_info)
+        getOrCreateMeta(elem).fn_type_info = *listMeta->list_elem_fn_type_info;
 
     return elem;
 }

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -203,9 +203,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
                 setTypeMeta(TypeMeta::NestedListElem, headerPtr, innerElemTy);
         }
 
-        // Track Map/Set/closure element type name for metadata propagation on index access.
-        // Snapshot getMeta(vals[0]) fields before any getOrCreateMeta call that may rehash
-        // value_metadata_ and invalidate the pointer.
+        // Track inferred collection/type names (Map, Set, List, etc.) for metadata
+        // propagation on index access. If no named type is inferred, preserve closure
+        // function type metadata instead. Snapshot getMeta(vals[0]) fields before any
+        // getOrCreateMeta call that may rehash value_metadata_ and invalidate the pointer.
         std::string elemTypeName = inferCollectionTypeName(vals[0]);
         std::optional<FnTypeInfo> elemFnTypeInfo;
         if (elemTypeName.empty()) {

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -203,12 +203,19 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
                 setTypeMeta(TypeMeta::NestedListElem, headerPtr, innerElemTy);
         }
 
-        // Track Map/Set/closure element type name for metadata propagation on index access
+        // Track Map/Set/closure element type name for metadata propagation on index access.
+        // Snapshot getMeta(vals[0]) fields before any getOrCreateMeta call that may rehash
+        // value_metadata_ and invalidate the pointer.
         std::string elemTypeName = inferCollectionTypeName(vals[0]);
+        std::optional<FnTypeInfo> elemFnTypeInfo;
+        if (elemTypeName.empty()) {
+            if (auto *elemMeta = getMeta(vals[0]))
+                elemFnTypeInfo = elemMeta->fn_type_info;
+        }
         if (!elemTypeName.empty())
             getOrCreateMeta(headerPtr).list_elem_type_name = elemTypeName;
-        else if (auto *elemMeta = getMeta(vals[0]); elemMeta && elemMeta->fn_type_info)
-            getOrCreateMeta(headerPtr).list_elem_fn_type_info = elemMeta->fn_type_info;
+        else if (elemFnTypeInfo)
+            getOrCreateMeta(headerPtr).list_elem_fn_type_info = elemFnTypeInfo;
     }
 
     return headerPtr;

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -522,11 +522,20 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
         setTypeMeta(TypeMeta::ListElem, elem, nestedElemTy);
 
     // Propagate Map/Set/closure element metadata (e.g. List<Map<str,int>>, List<closure>)
-    auto *listMeta = getMeta(objPtr);
-    if (listMeta && !listMeta->list_elem_type_name.empty())
-        propagateTypeMeta(listMeta->list_elem_type_name, elem);
-    if (listMeta && listMeta->list_elem_fn_type_info)
-        getOrCreateMeta(elem).fn_type_info = *listMeta->list_elem_fn_type_info;
+    // Copy metadata fields before any call that may rehash value_metadata_ and invalidate
+    // the pointer returned by getMeta().
+    {
+        std::string elemTypeName;
+        std::optional<FnTypeInfo> elemFnTypeInfo;
+        if (auto *listMeta = getMeta(objPtr)) {
+            elemTypeName   = listMeta->list_elem_type_name;
+            elemFnTypeInfo = listMeta->list_elem_fn_type_info;
+        }
+        if (!elemTypeName.empty())
+            propagateTypeMeta(elemTypeName, elem);
+        if (elemFnTypeInfo)
+            getOrCreateMeta(elem).fn_type_info = *elemFnTypeInfo;
+    }
 
     return elem;
 }

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -22,7 +22,9 @@ bool CodeGen::ValueMetadata::hasAnyMeta() const {
            !low_level_type_name.empty() ||
            !map_value_type_name.empty() ||
            !union_value_type.empty() ||
-           !enum_value_type.empty();
+           !enum_value_type.empty() ||
+           !list_elem_type_name.empty() ||
+           list_elem_fn_type_info.has_value();
 }
 
 llvm::Type *CodeGen::ValueMetadata::getCollectionType(TypeMeta kind) const {

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -96,12 +96,14 @@ llvm::Type *CodeGen::getTypeMeta(TypeMeta kind, llvm::Value *val) const {
 // ======== Unified propagation ========
 
 void CodeGen::propagateMeta(llvm::Value *src, llvm::Value *dst) {
-    const ValueMetadata *srcMetaPtr = getMeta(src);
-    if (!srcMetaPtr) return;
-    // Copy srcMeta before calling getOrCreateMeta(dst), which can rehash
-    // value_metadata_ and invalidate the pointer.
-    ValueMetadata srcMeta = *srcMetaPtr;
+    if (!getMeta(src)) return;
+    // Call getOrCreateMeta(dst) first so any rehash of value_metadata_ happens
+    // before we take a pointer to src's metadata.  Then re-fetch src metadata
+    // to avoid the deep-copy overhead of copying the full ValueMetadata struct.
     ValueMetadata &dstMeta = getOrCreateMeta(dst);
+    const ValueMetadata *srcMetaPtr = getMeta(src);
+    if (!srcMetaPtr) return;  // src == dst edge case: dst was just created, nothing to copy
+    const ValueMetadata &srcMeta = *srcMetaPtr;
 
     // Collection types
     if (srcMeta.list_elem)       dstMeta.list_elem = srcMeta.list_elem;

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -96,41 +96,44 @@ llvm::Type *CodeGen::getTypeMeta(TypeMeta kind, llvm::Value *val) const {
 // ======== Unified propagation ========
 
 void CodeGen::propagateMeta(llvm::Value *src, llvm::Value *dst) {
-    const ValueMetadata *srcMeta = getMeta(src);
-    if (!srcMeta) return;
+    const ValueMetadata *srcMetaPtr = getMeta(src);
+    if (!srcMetaPtr) return;
+    // Copy srcMeta before calling getOrCreateMeta(dst), which can rehash
+    // value_metadata_ and invalidate the pointer.
+    ValueMetadata srcMeta = *srcMetaPtr;
     ValueMetadata &dstMeta = getOrCreateMeta(dst);
 
     // Collection types
-    if (srcMeta->list_elem)       dstMeta.list_elem = srcMeta->list_elem;
-    if (srcMeta->map_key)         dstMeta.map_key = srcMeta->map_key;
-    if (srcMeta->map_value)       dstMeta.map_value = srcMeta->map_value;
-    if (srcMeta->set_elem)        dstMeta.set_elem = srcMeta->set_elem;
-    if (srcMeta->nested_list_elem) dstMeta.nested_list_elem = srcMeta->nested_list_elem;
-    if (srcMeta->task_result)     dstMeta.task_result = srcMeta->task_result;
-    if (srcMeta->iterator_elem)   dstMeta.iterator_elem = srcMeta->iterator_elem;
+    if (srcMeta.list_elem)       dstMeta.list_elem = srcMeta.list_elem;
+    if (srcMeta.map_key)         dstMeta.map_key = srcMeta.map_key;
+    if (srcMeta.map_value)       dstMeta.map_value = srcMeta.map_value;
+    if (srcMeta.set_elem)        dstMeta.set_elem = srcMeta.set_elem;
+    if (srcMeta.nested_list_elem) dstMeta.nested_list_elem = srcMeta.nested_list_elem;
+    if (srcMeta.task_result)     dstMeta.task_result = srcMeta.task_result;
+    if (srcMeta.iterator_elem)   dstMeta.iterator_elem = srcMeta.iterator_elem;
 
     // String metadata
-    if (!srcMeta->low_level_type_name.empty())
-        dstMeta.low_level_type_name = srcMeta->low_level_type_name;
-    if (!srcMeta->map_value_type_name.empty())
-        dstMeta.map_value_type_name = srcMeta->map_value_type_name;
-    if (!srcMeta->list_elem_type_name.empty())
-        dstMeta.list_elem_type_name = srcMeta->list_elem_type_name;
-    if (srcMeta->list_elem_fn_type_info)
-        dstMeta.list_elem_fn_type_info = srcMeta->list_elem_fn_type_info;
-    if (!srcMeta->union_value_type.empty())
-        dstMeta.union_value_type = srcMeta->union_value_type;
-    if (!srcMeta->enum_value_type.empty())
-        dstMeta.enum_value_type = srcMeta->enum_value_type;
+    if (!srcMeta.low_level_type_name.empty())
+        dstMeta.low_level_type_name = srcMeta.low_level_type_name;
+    if (!srcMeta.map_value_type_name.empty())
+        dstMeta.map_value_type_name = srcMeta.map_value_type_name;
+    if (!srcMeta.list_elem_type_name.empty())
+        dstMeta.list_elem_type_name = srcMeta.list_elem_type_name;
+    if (srcMeta.list_elem_fn_type_info)
+        dstMeta.list_elem_fn_type_info = srcMeta.list_elem_fn_type_info;
+    if (!srcMeta.union_value_type.empty())
+        dstMeta.union_value_type = srcMeta.union_value_type;
+    if (!srcMeta.enum_value_type.empty())
+        dstMeta.enum_value_type = srcMeta.enum_value_type;
 
     // FnTypeInfo
-    if (srcMeta->fn_type_info)
-        dstMeta.fn_type_info = srcMeta->fn_type_info;
+    if (srcMeta.fn_type_info)
+        dstMeta.fn_type_info = srcMeta.fn_type_info;
 
     // Resource kinds
-    for (int rk : srcMeta->resource_kinds)
+    for (int rk : srcMeta.resource_kinds)
         dstMeta.addResourceKind(rk);
-    if (srcMeta->json_type_only)
+    if (srcMeta.json_type_only)
         dstMeta.json_type_only = true;
 
     // ARC managed status propagation

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -112,6 +112,10 @@ void CodeGen::propagateMeta(llvm::Value *src, llvm::Value *dst) {
         dstMeta.low_level_type_name = srcMeta->low_level_type_name;
     if (!srcMeta->map_value_type_name.empty())
         dstMeta.map_value_type_name = srcMeta->map_value_type_name;
+    if (!srcMeta->list_elem_type_name.empty())
+        dstMeta.list_elem_type_name = srcMeta->list_elem_type_name;
+    if (srcMeta->list_elem_fn_type_info)
+        dstMeta.list_elem_fn_type_info = srcMeta->list_elem_fn_type_info;
     if (!srcMeta->union_value_type.empty())
         dstMeta.union_value_type = srcMeta->union_value_type;
     if (!srcMeta->enum_value_type.empty())

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -352,24 +352,31 @@ void CodeGen::emitVarDecl(const std::string &name,
             auto *valMeta = getMeta(val);
             std::string letn;
             std::optional<FnTypeInfo> lefti;
-            if (valMeta && !valMeta->list_elem_type_name.empty()) {
-                letn = valMeta->list_elem_type_name;
-                lefti = valMeta->list_elem_fn_type_info;
+            if (valMeta) {
+                if (!valMeta->list_elem_type_name.empty())
+                    letn = valMeta->list_elem_type_name;
+                if (valMeta->list_elem_fn_type_info)
+                    lefti = valMeta->list_elem_fn_type_info;
             } else if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val)) {
                 auto *loadMeta = getMeta(load->getPointerOperand());
-                if (loadMeta && !loadMeta->list_elem_type_name.empty()) {
-                    letn = loadMeta->list_elem_type_name;
-                    lefti = loadMeta->list_elem_fn_type_info;
+                if (loadMeta) {
+                    if (!loadMeta->list_elem_type_name.empty())
+                        letn = loadMeta->list_elem_type_name;
+                    if (loadMeta->list_elem_fn_type_info)
+                        lefti = loadMeta->list_elem_fn_type_info;
                 }
             }
             // Also derive from annotation: List<Map<str, int>> → inner = "Map<str, int>"
-            if (letn.empty() && annot && isListTypeName(*annot)) {
-                std::string inner = annot->substr(5, annot->size() - 6);
-                while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
-                if (isMapTypeName(inner) || isSetTypeName(inner))
-                    letn = inner;
-                else if (inner.size() > 9 && inner.substr(0, 9) == "function(")
-                    lefti = parseFnTypeAnnotation(inner);
+            if (letn.empty() && !lefti && annot) {
+                std::string resolved = resolveTypeAlias(*annot);
+                if (isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
+                    std::string inner = resolved.substr(5, resolved.size() - 6);
+                    while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
+                    if (isMapTypeName(inner) || isSetTypeName(inner))
+                        letn = inner;
+                    else if (inner.size() > 9 && inner.substr(0, 9) == "function(")
+                        lefti = parseFnTypeAnnotation(inner);
+                }
             }
             if (!letn.empty())
                 getOrCreateMeta(ptr).list_elem_type_name = letn;

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -347,6 +347,36 @@ void CodeGen::emitVarDecl(const std::string &name,
         if (elemTy)
             setTypeMeta(TypeMeta::ListElem, ptr, elemTy);
 
+        // --- List element type name tracking (for List<Map>, List<Set>, List<closure>) ---
+        {
+            auto *valMeta = getMeta(val);
+            std::string letn;
+            std::optional<FnTypeInfo> lefti;
+            if (valMeta && !valMeta->list_elem_type_name.empty()) {
+                letn = valMeta->list_elem_type_name;
+                lefti = valMeta->list_elem_fn_type_info;
+            } else if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val)) {
+                auto *loadMeta = getMeta(load->getPointerOperand());
+                if (loadMeta && !loadMeta->list_elem_type_name.empty()) {
+                    letn = loadMeta->list_elem_type_name;
+                    lefti = loadMeta->list_elem_fn_type_info;
+                }
+            }
+            // Also derive from annotation: List<Map<str, int>> → inner = "Map<str, int>"
+            if (letn.empty() && annot && isListTypeName(*annot)) {
+                std::string inner = annot->substr(5, annot->size() - 6);
+                while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
+                if (isMapTypeName(inner) || isSetTypeName(inner))
+                    letn = inner;
+                else if (inner.size() > 9 && inner.substr(0, 9) == "function(")
+                    lefti = parseFnTypeAnnotation(inner);
+            }
+            if (!letn.empty())
+                getOrCreateMeta(ptr).list_elem_type_name = letn;
+            if (lefti)
+                getOrCreateMeta(ptr).list_elem_fn_type_info = lefti;
+        }
+
         // --- Nested list tracking (for flatten) ---
         {
             llvm::Type *nestedTy = getTypeMeta(TypeMeta::NestedListElem, val);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -131,6 +131,12 @@ void CodeGen::emitVarDecl(const std::string &name,
                 setTypeMeta(TypeMeta::NestedListElem, ptr, nestedElemTy);
         }
 
+        // Set list element type metadata for List<Map>, List<Set>, List<closure> annotations
+        if (isMapTypeName(inner) || isSetTypeName(inner))
+            getOrCreateMeta(ptr).list_elem_type_name = inner;
+        else if (inner.size() > 9 && inner.substr(0, 9) == "function(")
+            getOrCreateMeta(ptr).list_elem_fn_type_info = parseFnTypeAnnotation(inner);
+
         if (is_immutable)
             immutable_scope_stack_.back().insert(name);
         return;

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -363,14 +363,6 @@ void CodeGen::emitVarDecl(const std::string &name,
                     letn = valMeta->list_elem_type_name;
                 if (valMeta->list_elem_fn_type_info)
                     lefti = valMeta->list_elem_fn_type_info;
-            } else if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val)) {
-                auto *loadMeta = getMeta(load->getPointerOperand());
-                if (loadMeta) {
-                    if (!loadMeta->list_elem_type_name.empty())
-                        letn = loadMeta->list_elem_type_name;
-                    if (loadMeta->list_elem_fn_type_info)
-                        lefti = loadMeta->list_elem_fn_type_info;
-                }
             }
             // Also derive from annotation: List<Map<str, int>> → inner = "Map<str, int>"
             if (letn.empty() && !lefti && annot) {

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -192,11 +192,17 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
     llvm::Value *dataPtrField = builder_.CreateStructGEP(headerTy, iterable, 2, "for_data_ptr");
     llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "for_data");
 
+    auto *iterMeta = getMeta(iterable);
     emitIndexedForLoop(length, s->body, [&](llvm::Value *iCur) {
         llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {iCur}, "for_elem_ptr");
         llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "for_elem");
         llvm::AllocaInst *loopVar = getOrCreateVar(s->var_names[0], elemTy);
         builder_.CreateStore(elem, loopVar);
+        // Propagate Map/Set/closure element metadata for List<Map>, List<Set>, List<closure>
+        if (iterMeta && !iterMeta->list_elem_type_name.empty())
+            propagateTypeMeta(iterMeta->list_elem_type_name, loopVar);
+        if (iterMeta && iterMeta->list_elem_fn_type_info)
+            getOrCreateMeta(loopVar).fn_type_info = *iterMeta->list_elem_fn_type_info;
     });
 }
 

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -192,17 +192,24 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
     llvm::Value *dataPtrField = builder_.CreateStructGEP(headerTy, iterable, 2, "for_data_ptr");
     llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "for_data");
 
-    auto *iterMeta = getMeta(iterable);
+    // Copy list element metadata before entering the loop body to avoid
+    // pointer invalidation from unordered_map rehash inside propagateTypeMeta/getOrCreateMeta.
+    std::string elemTypeName;
+    std::optional<FnTypeInfo> elemFnTypeInfo;
+    if (auto *iterMeta = getMeta(iterable)) {
+        elemTypeName    = iterMeta->list_elem_type_name;
+        elemFnTypeInfo  = iterMeta->list_elem_fn_type_info;
+    }
     emitIndexedForLoop(length, s->body, [&](llvm::Value *iCur) {
         llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {iCur}, "for_elem_ptr");
         llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "for_elem");
         llvm::AllocaInst *loopVar = getOrCreateVar(s->var_names[0], elemTy);
         builder_.CreateStore(elem, loopVar);
         // Propagate Map/Set/closure element metadata for List<Map>, List<Set>, List<closure>
-        if (iterMeta && !iterMeta->list_elem_type_name.empty())
-            propagateTypeMeta(iterMeta->list_elem_type_name, loopVar);
-        if (iterMeta && iterMeta->list_elem_fn_type_info)
-            getOrCreateMeta(loopVar).fn_type_info = *iterMeta->list_elem_fn_type_info;
+        if (!elemTypeName.empty())
+            propagateTypeMeta(elemTypeName, loopVar);
+        if (elemFnTypeInfo)
+            getOrCreateMeta(loopVar).fn_type_info = *elemFnTypeInfo;
     });
 }
 

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -482,6 +482,11 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
             builder_.SetInsertPoint(elemBB);
             llvm::Value *elemPtr = builder_.CreateGEP(listElemTy, lf.data, {iCur}, "vts_list_elem_ptr");
             llvm::Value *elem = builder_.CreateLoad(listElemTy, elemPtr, "vts_list_elem");
+            // Propagate list element function metadata so valueToString(elem) can
+            // detect closure elements and return "<closure>" instead of falling
+            // through to the raw string-pointer path.
+            if (auto *listMeta = getMeta(val); listMeta && listMeta->list_elem_fn_type_info)
+                getOrCreateMeta(elem).fn_type_info = listMeta->list_elem_fn_type_info;
             llvm::Value *elemStr = valueToString(elem);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_list_s"), elemStr});
 

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -485,8 +485,10 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
             // Propagate list element function metadata so valueToString(elem) can
             // detect closure elements and return "<closure>" instead of falling
             // through to the raw string-pointer path.
-            if (auto *listMeta = getMeta(val); listMeta && listMeta->list_elem_fn_type_info)
-                getOrCreateMeta(elem).fn_type_info = listMeta->list_elem_fn_type_info;
+            if (auto *listMeta = getMeta(val); listMeta && listMeta->list_elem_fn_type_info) {
+                auto fnTypeInfo = listMeta->list_elem_fn_type_info;  // snapshot before potential rehash
+                getOrCreateMeta(elem).fn_type_info = fnTypeInfo;
+            }
             llvm::Value *elemStr = valueToString(elem);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_list_s"), elemStr});
 

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -485,7 +485,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
         }
 
         if (auto *fnMeta = getMeta(val); fnMeta && fnMeta->fn_type_info)
-            codegenError("cannot convert function to string");
+            return cachedGlobalString("<closure>", ".vts_closure");
         return val; // string pointer
     }
     auto mallocFn = getStdlibMalloc();

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -482,12 +482,22 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
             builder_.SetInsertPoint(elemBB);
             llvm::Value *elemPtr = builder_.CreateGEP(listElemTy, lf.data, {iCur}, "vts_list_elem_ptr");
             llvm::Value *elem = builder_.CreateLoad(listElemTy, elemPtr, "vts_list_elem");
-            // Propagate list element function metadata so valueToString(elem) can
-            // detect closure elements and return "<closure>" instead of falling
-            // through to the raw string-pointer path.
-            if (auto *listMeta = getMeta(val); listMeta && listMeta->list_elem_fn_type_info) {
-                auto fnTypeInfo = listMeta->list_elem_fn_type_info;  // snapshot before potential rehash
-                getOrCreateMeta(elem).fn_type_info = fnTypeInfo;
+            // Propagate list element metadata so valueToString(elem) can detect
+            // Map/Set elements (via list_elem_type_name) and closure elements
+            // (via fn_type_info) instead of falling through to the raw string-
+            // pointer path.  Snapshot both fields before getOrCreateMeta() to
+            // avoid pointer invalidation if value_metadata_ is rehashed.
+            {
+                std::string elemTypeName;
+                std::optional<FnTypeInfo> elemFnTypeInfo;
+                if (auto *listMeta = getMeta(val)) {
+                    elemTypeName   = listMeta->list_elem_type_name;
+                    elemFnTypeInfo = listMeta->list_elem_fn_type_info;
+                }
+                if (!elemTypeName.empty())
+                    propagateTypeMeta(elemTypeName, elem);
+                if (elemFnTypeInfo)
+                    getOrCreateMeta(elem).fn_type_info = *elemFnTypeInfo;
             }
             llvm::Value *elemStr = valueToString(elem);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_list_s"), elemStr});

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -182,7 +182,15 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
 
                 const auto &compName = uinfo.componentNames[i];
 
-                // Reject non-stringifiable pointer-backed variants
+                // Closure/function variants: return "<closure>" directly
+                if (uinfo.componentTypes[i]->isPointerTy() && compName == "closure") {
+                    phi->addIncoming(cachedGlobalString("<closure>", ".vts_closure"),
+                                     builder_.GetInsertBlock());
+                    builder_.CreateBr(mergeBB);
+                    continue;
+                }
+
+                // Reject other non-stringifiable pointer-backed variants
                 if (uinfo.componentTypes[i]->isPointerTy() && compName != "str") {
                     codegenError("cannot convert " + compName +
                                  " variant of union to string");

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -182,8 +182,10 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
 
                 const auto &compName = uinfo.componentNames[i];
 
-                // Closure/function variants: return "<closure>" directly
-                if (uinfo.componentTypes[i]->isPointerTy() && compName == "closure") {
+                // Closure/function variants: return "<closure>" directly.
+                // Union component names are normalized type strings like "function(int) -> int",
+                // so use isFunctionTypeName() rather than comparing against the literal "closure".
+                if (uinfo.componentTypes[i]->isPointerTy() && isFunctionTypeName(compName)) {
                     phi->addIncoming(cachedGlobalString("<closure>", ".vts_closure"),
                                      builder_.GetInsertBlock());
                     builder_.CreateBr(mergeBB);

--- a/tests/spec/combinatorial/list_element_types.test.ry
+++ b/tests/spec/combinatorial/list_element_types.test.ry
@@ -1,0 +1,53 @@
+describe("List<Map> — element access", ():
+  it("should access map element by key after list index", ():
+    xs: List<Map<str, int>> = [{"a": 1}, {"b": 2}]
+    m = xs[0]
+    expect(m["a"]).to_eq(1)
+  )
+  it("should access map element in for loop", ():
+    xs: List<Map<str, int>> = [{"a": 10}, {"b": 20}]
+    total = 0
+    for m in xs:
+      total = total + m.length()
+    expect(total).to_eq(2)
+  )
+  it("should access map from second element", ():
+    xs: List<Map<str, int>> = [{"x": 1}, {"y": 99}]
+    m = xs[1]
+    expect(m["y"]).to_eq(99)
+  )
+)
+
+describe("List<Set> — element access", ():
+  it("should test membership after list index", ():
+    ss: List<Set<int>> = [{1, 2, 3}, {4, 5}]
+    s = ss[0]
+    expect(1 in s).to_be_true()
+    expect(4 in s).to_be_false()
+  )
+  it("should test membership in for loop", ():
+    ss: List<Set<int>> = [{1, 2}, {3, 4}]
+    count = 0
+    for s in ss:
+      if 1 in s:
+        count = count + 1
+    expect(count).to_eq(1)
+  )
+)
+
+describe("List<closure> — element access", ():
+  it("should call closure retrieved from list by index", ():
+    add2 = (x: int) => x + 2
+    add5 = (x: int) => x + 5
+    fns = [add2, add5]
+    f = fns[0]
+    expect(f(10)).to_eq(12)
+  )
+  it("should call second closure from list", ():
+    add2 = (x: int) => x + 2
+    add5 = (x: int) => x + 5
+    fns = [add2, add5]
+    g = fns[1]
+    expect(g(10)).to_eq(15)
+  )
+)

--- a/tests/spec/combinatorial/list_element_types.test.ry
+++ b/tests/spec/combinatorial/list_element_types.test.ry
@@ -50,4 +50,14 @@ describe("List<closure> — element access", ():
     g = fns[1]
     expect(g(10)).to_eq(15)
   )
+  it("should call closures from annotated List<closure> in for loop", ():
+    add2 = (x: int) => x + 2
+    add5 = (x: int) => x + 5
+    fns: List<function(int) -> int> = [add2, add5]
+    results: List<int> = []
+    for f in fns:
+      results.append!(f(10))
+    expect(results[0]).to_eq(12)
+    expect(results[1]).to_eq(15)
+  )
 )

--- a/tests/spec/combinatorial/list_element_types.test.ry
+++ b/tests/spec/combinatorial/list_element_types.test.ry
@@ -5,11 +5,11 @@ describe("List<Map> — element access", ():
     expect(m["a"]).to_eq(1)
   )
   it("should access map element in for loop", ():
-    xs: List<Map<str, int>> = [{"a": 10}, {"b": 20}]
+    xs: List<Map<str, int>> = [{"a": 10}, {"a": 20}]
     total = 0
     for m in xs:
-      total = total + m.length()
-    expect(total).to_eq(2)
+      total = total + m["a"]
+    expect(total).to_eq(30)
   )
   it("should access map from second element", ():
     xs: List<Map<str, int>> = [{"x": 1}, {"y": 99}]

--- a/tests/spec/combinatorial/print_display.test.ry
+++ b/tests/spec/combinatorial/print_display.test.ry
@@ -1,5 +1,3 @@
-# BUG #728: print() and to_str() on closure values not supported
-
 describe("print — union", ():
   it("should print int variant of union without crashing", ():
     x: int | str = 42
@@ -18,5 +16,21 @@ describe("print — union", ():
   it("should use f-string interpolation with union value", ():
     x: int | str = "world"
     expect(f"value={x}").to_eq("value=world")
+  )
+)
+
+describe("print — closure", ():
+  it("should print closure as <closure>", ():
+    f = (x: int) => x + 1
+    print(f)
+    # expect-output: <closure>
+  )
+  it("should convert closure to string with to_str", ():
+    f = (x: int) => x * 2
+    expect(to_str(f)).to_eq("<closure>")
+  )
+  it("should interpolate closure in f-string", ():
+    f = (x: int) => x
+    expect(f"fn={f}").to_eq("fn=<closure>")
   )
 )

--- a/tests/spec/combinatorial/print_display.test.ry
+++ b/tests/spec/combinatorial/print_display.test.ry
@@ -1,4 +1,4 @@
-# BUG #728: print() and to_str() on int | str union values not supported
+# BUG #728: print()/to_str() coverage for union values and closure stringification
 
 
 describe("print — union", ():


### PR DESCRIPTION
## Summary

- Adds systematic combinatorial test coverage for cross-feature interactions
- Includes fixes discovered during testing:
  - #727: Preserve type metadata for `List<Map>`, `List<Set>`, `List<closure>` element access
  - #728: Support `print()` and `to_str()` for closure/function values

## Test plan

- CI passes (lint, test, asan)
- All combinatorial spec tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve list element type behavior so indexing and iteration work for List<Map<...>>, List<Set<...>>, and List<closure> (e.g., xs[0]["key"], membership checks, and callable closures via fns[0](...)).
  * print(), to_str(), and f-string interpolation now render closures as "<closure>" instead of failing.

* **Documentation**
  * Added guidance on closure string rendering and noted closure equality comparisons are unsupported.

* **Tests**
  * Added and expanded tests validating these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->