### PR TITLE
fix: SEGFAULT on two-level nested function return (#752)

### DIFF
--- a/changelog.d/752-nested-fn-return-segfault.md
+++ b/changelog.d/752-nested-fn-return-segfault.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed SEGFAULT when calling a two-level nested function return with type annotation (#752)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -373,6 +373,7 @@ public:
         std::vector<ResourceKind> capturedResourceKinds; // per-capture ResourceKind (RK_COUNT if N/A)
         // unique_ptr to break incomplete-type cycle (GCC 11 requires complete type for unordered_map value)
         std::unique_ptr<std::unordered_map<size_t, FnTypeInfo>> capturedClosureInfos;
+        std::unique_ptr<FnTypeInfo> returnFnTypeInfo;  // nested function return type info
         bool isUniformClosure = false;  // true when value uses {thunk, env} layout
         llvm::Function *sourceFn = nullptr;  // underlying LLVM function (for thunk generation)
 
@@ -388,6 +389,9 @@ public:
               capturedClosureInfos(o.capturedClosureInfos
                   ? std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(*o.capturedClosureInfos)
                   : nullptr),
+              returnFnTypeInfo(o.returnFnTypeInfo
+                  ? std::make_unique<FnTypeInfo>(*o.returnFnTypeInfo)
+                  : nullptr),
               isUniformClosure(o.isUniformClosure),
               sourceFn(o.sourceFn) {}
         FnTypeInfo& operator=(const FnTypeInfo &o) {
@@ -401,6 +405,9 @@ public:
                 capturedResourceKinds = o.capturedResourceKinds;
                 capturedClosureInfos = o.capturedClosureInfos
                     ? std::make_unique<std::unordered_map<size_t, FnTypeInfo>>(*o.capturedClosureInfos)
+                    : nullptr;
+                returnFnTypeInfo = o.returnFnTypeInfo
+                    ? std::make_unique<FnTypeInfo>(*o.returnFnTypeInfo)
                     : nullptr;
                 isUniformClosure = o.isUniformClosure;
                 sourceFn = o.sourceFn;

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -143,6 +143,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
             llvm::Value *loaded = builder_.CreateLoad(ptrTy_, varPtr, e->callee + ".fn");
             llvm::Value *result = emitLambdaCall(loaded, info, argVals, "indirect_call");
 
+            if (info.returnFnTypeInfo)
+                getOrCreateMeta(result).fn_type_info = *info.returnFnTypeInfo;
+
             releaseUniformClosureTemps(ucTemps);
             return result;
         }

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -131,6 +131,11 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
         info.paramTypes = entry.paramTypes;
         info.paramTypeNames = entry.paramTypeNames;
         info.returnType = func->getReturnType();
+        {
+            std::string resolved = resolveTypeAlias(entry.returnTypeName);
+            if (isFunctionTypeName(resolved))
+                info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(resolved));
+        }
 
         // If this nested function has captures, materialize as a closure struct
         if (!entry.capturedNames.empty()) {

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -129,11 +129,18 @@ void CodeGen::emitStmt(ReturnStmt &s) {
         } else {
             val = emitExpr(*s.value);
 
-            // Propagate fn_type_info for function-type return values
+            // Propagate fn_type_info for function-type return values;
+            // wrap raw function pointers as uniform closures so callers
+            // can always treat function-typed returns uniformly.
             {
                 auto *fnInfo = lookupFnTypeInfo(val);
-                if (fnInfo)
+                if (fnInfo) {
+                    if (!fnInfo->isUniformClosure) {
+                        val = wrapAsUniformClosure(val, *fnInfo);
+                        fnInfo = lookupFnTypeInfo(val);
+                    }
                     return_fn_type_info_[fn_] = *fnInfo;
+                }
             }
 
             // Tail call optimization: self-recursive tail call → musttail

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -330,6 +330,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     for (auto &p : e->params)
         info.paramTypeNames.push_back(p.type->toString());
     info.returnType = retTy;
+    if (!retTypeStr.empty()) {
+        std::string resolvedRetType = resolveTypeAlias(retTypeStr);
+        if (isFunctionTypeName(resolvedRetType))
+            info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(resolvedRetType));
+    }
     info.capturedVars = captures.capturedNames;
     info.capturedTypes = captures.capturedTypes;
     info.capturedArcKinds = captures.capturedArcKinds;

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -735,6 +735,8 @@ llvm::Value *CodeGen::wrapAsUniformClosure(llvm::Value *val, const FnTypeInfo &i
     ucInfo.paramTypes = info.paramTypes;
     ucInfo.paramTypeNames = info.paramTypeNames;
     ucInfo.returnType = info.returnType;
+    if (info.returnFnTypeInfo)
+        ucInfo.returnFnTypeInfo = std::make_unique<FnTypeInfo>(*info.returnFnTypeInfo);
     ucInfo.isUniformClosure = true;
     getOrCreateMeta(ucPtr).fn_type_info = ucInfo;
 

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -387,6 +387,8 @@ CodeGen::FnTypeInfo CodeGen::parseFnTypeAnnotation(const std::string &typeStr) {
         if (s != std::string::npos)
             retStr = retStr.substr(s);
         info.returnType = resolveType(retStr);
+        if (isFunctionTypeName(retStr))
+            info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(retStr));
     } else {
         info.returnType = llvm::Type::getVoidTy(*ctx_);
     }

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -387,8 +387,15 @@ CodeGen::FnTypeInfo CodeGen::parseFnTypeAnnotation(const std::string &typeStr) {
         if (s != std::string::npos)
             retStr = retStr.substr(s);
         info.returnType = resolveType(retStr);
-        if (isFunctionTypeName(retStr))
-            info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(retStr));
+        std::string resolvedRetStr = resolveTypeAlias(retStr);
+        {
+            size_t rs = resolvedRetStr.find_first_not_of(' ');
+            size_t re = resolvedRetStr.find_last_not_of(' ');
+            if (rs != std::string::npos)
+                resolvedRetStr = resolvedRetStr.substr(rs, re - rs + 1);
+        }
+        if (isFunctionTypeName(resolvedRetStr))
+            info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(resolvedRetStr));
     } else {
         info.returnType = llvm::Type::getVoidTy(*ctx_);
     }

--- a/tests/spec/nested_fn_return_fn.test.ry
+++ b/tests/spec/nested_fn_return_fn.test.ry
@@ -1,0 +1,53 @@
+describe("two-level nested function return (#752)", ():
+  it("should return and call a two-level nested function with type annotations", ():
+    function outer() -> function() -> function() -> int:
+      function middle() -> function() -> int:
+        function inner() -> int:
+          return 42
+        return inner
+      return middle
+
+    f: function() -> function() -> int = outer()
+    g: function() -> int = f()
+    expect(g()).to_eq(42)
+  )
+
+  it("should return and call a two-level nested function without type annotations", ():
+    function outer() -> function() -> function() -> int:
+      function middle() -> function() -> int:
+        function inner() -> int:
+          return 42
+        return inner
+      return middle
+
+    f = outer()
+    g = f()
+    expect(g()).to_eq(42)
+  )
+
+  it("should support chained calls via intermediate variables", ():
+    function make() -> function() -> function() -> int:
+      function mid() -> function() -> int:
+        function leaf() -> int:
+          return 99
+        return leaf
+      return mid
+
+    a = make()
+    b = a()
+    expect(b()).to_eq(99)
+  )
+
+  it("should work with parameters at each level", ():
+    function outer(a: int) -> function(int) -> function(int) -> int:
+      function middle(b: int) -> function(int) -> int:
+        function inner(c: int) -> int:
+          return a + b + c
+        return inner
+      return middle
+
+    f = outer(10)
+    g = f(20)
+    expect(g(30)).to_eq(60)
+  )
+)

--- a/tests/spec/nested_fn_return_fn.test.ry
+++ b/tests/spec/nested_fn_return_fn.test.ry
@@ -38,6 +38,19 @@ describe("two-level nested function return (#752)", ():
     expect(b()).to_eq(99)
   )
 
+  it("should work with lambdas returning nested functions", ():
+    make = () -> function() -> function() -> int:
+      mid = () -> function() -> int:
+        leaf = () -> int:
+          return 42
+        return leaf
+      return mid
+
+    f = make()
+    g = f()
+    expect(g()).to_eq(42)
+  )
+
   it("should work with parameters at each level", ():
     function outer(a: int) -> function(int) -> function(int) -> int:
       function middle(b: int) -> function(int) -> int:


### PR DESCRIPTION
## Summary

- Fixed SEGFAULT when calling a two-level nested function return (e.g., `function() -> function() -> function() -> int`)
- Root cause: `FnTypeInfo` lost nested function type metadata, and raw function pointers were not wrapped as uniform closures at return sites
- Added `returnFnTypeInfo` field to `FnTypeInfo` for recursive function type tracking
- Wrapped raw function pointers as uniform closures in return statements for consistent call dispatch

Closes #752

## Test plan

- [x] Reproduction case from issue outputs `42`
- [x] Type-annotated and non-annotated variants both work
- [x] Parameters at each nesting level work correctly
- [x] All C++ tests pass (1438 tests)
- [x] All Ry self-tests pass (92 files)
- [x] ASan build passes with no memory errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash when returning and invoking two-level nested functions with annotated return types by properly preserving nested function-type information across returns and closures.

* **Tests**
  * Added comprehensive tests for two-level nested function returns covering typed and untyped declarations, lambdas, chained intermediate calls, and parameter-passing across nesting levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->