### PR TITLE
fix: quote string elements in collection display

### DIFF
--- a/changelog.d/756-collection-string-display.md
+++ b/changelog.d/756-collection-string-display.md
@@ -1,0 +1,3 @@
+### Changed
+
+- String elements inside collections (`List`, `Set`, `Map`, `Array`, `Tuple`, record) are now wrapped in double quotes when displayed via `print()` or `to_str()`, following Rust's debug display convention. Empty strings are now visible: `[""]` instead of `[]` (#756)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -173,9 +173,9 @@ print(Err(Error("fail")))  # Err(Error: fail (code: 0))
 print(Some(1))     # Some(1)
 print(None)        # None
 print([1, 2, 3])   # [1, 2, 3]
-print({"a": 1})    # {a: 1}
+print({"a": 1})    # {"a": 1}
 print({1, 2, 3})   # {1, 2, 3}
-print((1, "hello"))  # (1, hello)
+print((1, "hello"))  # (1, "hello")
 
 # Multiple arguments (space-separated)
 print(1, 2, 3)             # 1 2 3

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -21,7 +21,7 @@
 | `receive(stream, max)` | Receives up to `max` bytes from `TcpStream` or `TlsStream` as `Result<List<u8>, Error>` |
 | `close(handle)` | Closes a `TcpStream`, `TlsStream`, or `TcpListener` |
 | `block_on(task)` | Blocks the current thread until a `Task<T>` completes and returns its result |
-| `to_str(value)` | Converts a value to its string representation (`int`, `float`, `bool`, `str`, record, enum, tuple, `List`, `Map`, `Set`, `Result`, `Option`) |
+| `to_str(value)` | Converts a value to its string representation (`int`, `float`, `bool`, `str`, record, enum, tuple, `List`, `Map`, `Set`, `Result`, `Option`). String elements inside collections are wrapped in double quotes (e.g., `["hello", "world"]`) |
 | `fail()` / `fail(message)` | Marks the current test as failed (only available in `ry test` mode) |
 
 ### Option

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -852,7 +852,7 @@ public:
     llvm::Value *emitExprVariant(const std::unique_ptr<ErrorPropagateExpr> &e);
     llvm::Value *emitExprVariant(const std::unique_ptr<AwaitExpr> &e);
     llvm::Value *emitExprVariant(const std::unique_ptr<WeakExpr> &e);
-    llvm::Value *valueToString(llvm::Value *val);
+    llvm::Value *valueToString(llvm::Value *val, bool inCollection = false);
     llvm::Value *structToString(llvm::Value *val);
     bool isTupleStructType(llvm::StructType *st);
     llvm::Value *tupleToString(llvm::Value *val, llvm::StructType *st);

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -3,7 +3,7 @@
 
 namespace ry {
 
-llvm::Value *CodeGen::valueToString(llvm::Value *val) {
+llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
     llvm::Type *ty = val->getType();
 
     if (ty == anyTy_)
@@ -111,7 +111,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
                                 builder_.CreateCall(spf, {commaFmt});
                             }
 
-                            llvm::Value *fieldStr = valueToString(fieldVal);
+                            llvm::Value *fieldStr = valueToString(fieldVal, true);
                             llvm::Constant *sfmt = cachedGlobalString("%s", ".vts_adt_s");
                             builder_.CreateCall(spf, {sfmt, fieldStr});
 
@@ -205,7 +205,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
                 if (isLowLevelTypeName(compName))
                     getOrCreateMeta(innerVal).low_level_type_name = compName;
 
-                llvm::Value *innerStr = valueToString(innerVal);
+                llvm::Value *innerStr = valueToString(innerVal, inCollection);
 
                 phi->addIncoming(innerStr, builder_.GetInsertBlock());
                 builder_.CreateBr(mergeBB);
@@ -234,7 +234,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
             llvm::Value *innerVal = builder_.CreateExtractValue(val, 1, "vts.opt.val");
             propagateMeta(val, innerVal);
             builder_.CreateCall(spf, {cachedGlobalString("Some(", ".vts_some_pre")});
-            llvm::Value *innerStr = valueToString(innerVal);
+            llvm::Value *innerStr = valueToString(innerVal, inCollection);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_opt_s"), innerStr});
             builder_.CreateCall(spf, {cachedGlobalString(")", ".vts_some_post")});
             builder_.CreateBr(endBB);
@@ -258,7 +258,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
             llvm::Value *okVal = builder_.CreateExtractValue(val, 1, "vts.res.ok_val");
             propagateMeta(val, okVal);
             builder_.CreateCall(spf, {cachedGlobalString("Ok(", ".vts_ok_pre")});
-            llvm::Value *okStr = valueToString(okVal);
+            llvm::Value *okStr = valueToString(okVal, inCollection);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_res_s"), okStr});
             builder_.CreateCall(spf, {cachedGlobalString(")", ".vts_ok_post")});
             builder_.CreateBr(endBB);
@@ -267,7 +267,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
             llvm::Value *errVal = builder_.CreateExtractValue(val, 2, "vts.res.err_val");
             propagateMeta(val, errVal);
             builder_.CreateCall(spf, {cachedGlobalString("Err(", ".vts_err_pre")});
-            llvm::Value *errStr = valueToString(errVal);
+            llvm::Value *errStr = valueToString(errVal, inCollection);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_res_e"), errStr});
             builder_.CreateCall(spf, {cachedGlobalString(")", ".vts_err_post")});
             builder_.CreateBr(endBB);
@@ -328,7 +328,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
                 {llvm::ConstantInt::get(i64Ty_, 0), iCur},
                 "vts_arr_ptr");
             llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "vts_arr_elem");
-            llvm::Value *elemStr = valueToString(elem);
+            llvm::Value *elemStr = valueToString(elem, true);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_arr_s"), elemStr});
 
             builder_.CreateStore(
@@ -379,7 +379,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
             builder_.SetInsertPoint(elemBB);
             llvm::Value *elemPtr = builder_.CreateGEP(setElemTy, sf.elems, {iCur}, "vts_set_elem_ptr");
             llvm::Value *elem = builder_.CreateLoad(setElemTy, elemPtr, "vts_set_elem");
-            llvm::Value *elemStr = valueToString(elem);
+            llvm::Value *elemStr = valueToString(elem, true);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_set_s"), elemStr});
 
             builder_.CreateStore(
@@ -429,12 +429,12 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
             builder_.SetInsertPoint(kvBB);
             llvm::Value *keyPtr = builder_.CreateGEP(mapKeyTy, mf.keys, {iCur}, "vts_map_key_ptr");
             llvm::Value *keyVal = builder_.CreateLoad(mapKeyTy, keyPtr, "vts_map_key");
-            llvm::Value *keyStr = valueToString(keyVal);
+            llvm::Value *keyStr = valueToString(keyVal, true);
             builder_.CreateCall(spf, {cachedGlobalString("%s: ", ".vts_map_kv_fmt"), keyStr});
 
             llvm::Value *valPtr = builder_.CreateGEP(mapValTy, mf.vals, {iCur}, "vts_map_val_ptr");
             llvm::Value *valVal = builder_.CreateLoad(mapValTy, valPtr, "vts_map_val");
-            llvm::Value *valStr = valueToString(valVal);
+            llvm::Value *valStr = valueToString(valVal, true);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_map_v_s"), valStr});
 
             builder_.CreateStore(
@@ -499,7 +499,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
                 if (elemFnTypeInfo)
                     getOrCreateMeta(elem).fn_type_info = *elemFnTypeInfo;
             }
-            llvm::Value *elemStr = valueToString(elem);
+            llvm::Value *elemStr = valueToString(elem, true);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_list_s"), elemStr});
 
             builder_.CreateStore(
@@ -513,6 +513,18 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val) {
 
         if (auto *fnMeta = getMeta(val); fnMeta && fnMeta->fn_type_info)
             return cachedGlobalString("<closure>", ".vts_closure");
+        if (inCollection) {
+            auto strlenFn = getStdlibStrlen();
+            auto mallocFn = getStdlibMalloc();
+            auto snprintfFn = getStdlibSnprintf();
+            llvm::Value *len = builder_.CreateCall(strlenFn, {val}, "vts_str_len");
+            llvm::Value *bufSz = builder_.CreateAdd(
+                len, llvm::ConstantInt::get(i64Ty_, 3), "vts_str_bufsz");
+            llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSz}, "vts_str_buf");
+            builder_.CreateCall(snprintfFn,
+                {buf, bufSz, cachedGlobalString("\"%s\"", ".vts_str_quote"), val});
+            return buf;
+        }
         return val; // string pointer
     }
     auto mallocFn = getStdlibMalloc();
@@ -630,7 +642,7 @@ llvm::Value *CodeGen::structToString(llvm::Value *val) {
             addLiteral(", ", ".sts_sep");
         addLiteral(info.fields[i].name + ": ", ".sts_fname");
         llvm::Value *field = builder_.CreateExtractValue(val, i, info.fields[i].name);
-        llvm::Value *fieldStr = valueToString(field);
+        llvm::Value *fieldStr = valueToString(field, true);
         parts.push_back({fieldStr, builder_.CreateCall(strlenFn, {fieldStr}, "sts_len")});
     }
 
@@ -656,7 +668,7 @@ llvm::Value *CodeGen::tupleToString(llvm::Value *val, llvm::StructType *st) {
         if (i > 0)
             addLiteral(", ", ".tts_sep");
         llvm::Value *elem = builder_.CreateExtractValue(val, i, "tts_elem");
-        llvm::Value *elemStr = valueToString(elem);
+        llvm::Value *elemStr = valueToString(elem, true);
         parts.push_back({elemStr, builder_.CreateCall(strlenFn, {elemStr}, "tts_len")});
     }
     if (n == 1)

--- a/tests/spec/collection_string_display.test.ry
+++ b/tests/spec/collection_string_display.test.ry
@@ -1,0 +1,80 @@
+describe("collection string display", ():
+  it("should not quote top-level string", ():
+    expect(to_str("hello")).to_eq("hello")
+  )
+  it("should not quote string in print", ():
+    print("hello")
+    # expect-output: hello
+  )
+  it("should show empty strings in list", ():
+    xs = ["", "a", ""]
+    expected = "[" + "\"\"" + ", " + "\"a\"" + ", " + "\"\"" + "]"
+    expect(to_str(xs)).to_eq(expected)
+  )
+  it("should show single empty string in list", ():
+    xs = [""]
+    expected = "[" + "\"\"" + "]"
+    expect(to_str(xs)).to_eq(expected)
+  )
+  it("should show empty string in set", ():
+    s = {""}
+    expected = "{" + "\"\"" + "}"
+    expect(to_str(s)).to_eq(expected)
+  )
+  it("should show empty string in map value", ():
+    m = {"a": ""}
+    expected = "{" + "\"a\"" + ": " + "\"\"" + "}"
+    expect(to_str(m)).to_eq(expected)
+  )
+  it("should show empty string in map key", ():
+    m = {"": 1}
+    expected = "{" + "\"\"" + ": 1}"
+    expect(to_str(m)).to_eq(expected)
+  )
+  it("should show empty string in tuple", ():
+    t = (1, "")
+    expected = "(1, " + "\"\"" + ")"
+    expect(to_str(t)).to_eq(expected)
+  )
+  it("should quote strings in list", ():
+    xs = ["hello", "world"]
+    expected = "[" + "\"hello\"" + ", " + "\"world\"" + "]"
+    expect(to_str(xs)).to_eq(expected)
+  )
+  it("should quote string keys in map", ():
+    m = {"x": 1}
+    expected = "{" + "\"x\"" + ": 1}"
+    expect(to_str(m)).to_eq(expected)
+  )
+  it("should quote string values in map", ():
+    m = {1: "a"}
+    expected = "{1: " + "\"a\"" + "}"
+    expect(to_str(m)).to_eq(expected)
+  )
+  it("should quote strings in set", ():
+    s = {"a", "b"}
+    expected = "{" + "\"a\"" + ", " + "\"b\"" + "}"
+    expect(to_str(s)).to_eq(expected)
+  )
+  it("should quote strings in tuple", ():
+    t = (1, "hello", 3.14)
+    expected = "(1, " + "\"hello\"" + ", 3.14)"
+    expect(to_str(t)).to_eq(expected)
+  )
+  it("should quote strings in nested collections", ():
+    xs = [["a", "b"], ["c"]]
+    expected = "[[" + "\"a\"" + ", " + "\"b\"" + "], [" + "\"c\"" + "]]"
+    expect(to_str(xs)).to_eq(expected)
+  )
+  it("should not quote string in Ok at top level", ():
+    expect(to_str(Ok("hello"))).to_eq("Ok(hello)")
+  )
+  it("should not quote string in Some at top level", ():
+    expect(to_str(Some("hi"))).to_eq("Some(hi)")
+  )
+  it("should quote string in tuple inside Ok", ():
+    r = Ok((1, "a"))
+    expected = "Ok((1, " + "\"a\"" + "))"
+    expect(to_str(r)).to_eq(expected)
+  )
+)

--- a/tests/spec/print_result_option.test.ry
+++ b/tests/spec/print_result_option.test.ry
@@ -27,7 +27,7 @@ describe("print Result", ():
 
   it("should print Ok(map)", ():
     print(Ok({"a": 1}))
-    # expect-output: Ok({a: 1})
+    # expect-output: Ok({"a": 1})
   )
 )
 

--- a/tests/spec/print_to_str_consistency.test.ry
+++ b/tests/spec/print_to_str_consistency.test.ry
@@ -47,9 +47,9 @@ describe("print and to_str consistency", ():
 
   it("should be consistent for map", ():
     m = {"x": 1}
-    expect(to_str(m)).to_eq("{x: 1}")
+    expect(to_str(m)).to_eq("{" + "\"x\"" + ": 1}")
     print(m)
-    # expect-output: {x: 1}
+    # expect-output: {"x": 1}
   )
 
   it("should be consistent for set", ():
@@ -61,9 +61,9 @@ describe("print and to_str consistency", ():
 
   it("should be consistent for tuple", ():
     t = (1, "a")
-    expect(to_str(t)).to_eq("(1, a)")
+    expect(to_str(t)).to_eq("(1, " + "\"a\"" + ")")
     print(t)
-    # expect-output: (1, a)
+    # expect-output: (1, "a")
   )
 
   it("should be consistent for Option Some", ():
@@ -103,9 +103,9 @@ describe("print and to_str consistency", ():
 
   it("should be consistent for Result wrapping tuple (recursive non-scalar)", ():
     r = Ok((1, "a"))
-    expect(to_str(r)).to_eq("Ok((1, a))")
+    expect(to_str(r)).to_eq("Ok((1, " + "\"a\"" + "))")
     print(r)
-    # expect-output: Ok((1, a))
+    # expect-output: Ok((1, "a"))
   )
 
   it("should use record with user-defined to_str", ():

--- a/tests/spec/print_tuple_collection.test.ry
+++ b/tests/spec/print_tuple_collection.test.ry
@@ -5,7 +5,7 @@ describe("tuple display", ():
   )
   it("should convert mixed-type tuple to string", ():
     t = (1, "hello", 3.14)
-    expect(to_str(t)).to_eq("(1, hello, 3.14)")
+    expect(to_str(t)).to_eq("(1, " + "\"hello\"" + ", 3.14)")
   )
   it("should convert nested tuple to string", ():
     t = ((1, 2), (3, 4))
@@ -16,7 +16,7 @@ describe("tuple display", ():
 describe("list of tuples display", ():
   it("should convert zip result to string", ():
     result = zip([1, 2, 3], ["a", "b", "c"])
-    expect(to_str(result)).to_eq("[(1, a), (2, b), (3, c)]")
+    expect(to_str(result)).to_eq("[(1, " + "\"a\"" + "), (2, " + "\"b\"" + "), (3, " + "\"c\"" + ")]")
   )
 )
 
@@ -27,7 +27,7 @@ describe("f-string with collections", ():
   )
   it("should interpolate map in f-string", ():
     m = {"a": 1}
-    expect(f"map: {m}").to_eq("map: {a: 1}")
+    expect(f"map: {m}").to_eq("map: {" + "\"a\"" + ": 1}")
   )
   it("should interpolate set in f-string", ():
     s = {10, 20}

--- a/tests/spec/record_subtyping.test.ry
+++ b/tests/spec/record_subtyping.test.ry
@@ -23,7 +23,8 @@ describe("record subtyping", ():
   )
   it("should include inherited fields in auto to_str", ():
     err = HttpError("err", 1, 404, "/api")
-    expect(to_str(err)).to_eq("HttpError(message: err, code: 1, status: 404, url: /api)")
+    expected = "HttpError(message: " + "\"err\"" + ", code: 1, status: 404, url: " + "\"/api\"" + ")"
+    expect(to_str(err)).to_eq(expected)
   )
 )
 

--- a/tests/spec/structs.test.ry
+++ b/tests/spec/structs.test.ry
@@ -49,7 +49,8 @@ describe("record to_str", ():
       name: str
       age: int
     p = Person("Alice", 30)
-    expect(to_str(p)).to_eq("Person(name: Alice, age: 30)")
+    expected = "Person(name: " + "\"Alice\"" + ", age: 30)"
+    expect(to_str(p)).to_eq(expected)
   )
 )
 

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -129,7 +129,7 @@ TEST_F(CodeGenTest, MapBasicOperations) {
     // MapLen
     EXPECT_EQ(runSource("m = {\"a\": 1, \"b\": 2}\nprint(length(m))"), "2\n");
     // MapPrint
-    EXPECT_EQ(runSource("m = {\"a\": 1, \"b\": 2}\nprint(m)"), "{a: 1, b: 2}\n");
+    EXPECT_EQ(runSource("m = {\"a\": 1, \"b\": 2}\nprint(m)"), "{\"a\": 1, \"b\": 2}\n");
     // MapWithTypeAnnotation
     EXPECT_EQ(runSource("m: Map<str, int> = {\"x\": 42}\nprint(m[\"x\"])"), "42\n");
     // MapIntKeys
@@ -1163,7 +1163,7 @@ TEST_F(CodeGenTest, ListAppendVariants) {
             "xs = [\"a\"]\n"
             "xs.append(\"b\")\n"
             "print(xs)";
-        EXPECT_EQ(runSource(src), "[a, b]\n");
+        EXPECT_EQ(runSource(src), "[\"a\", \"b\"]\n");
     }
 }
 
@@ -1911,7 +1911,7 @@ TEST_F(CodeGenTest, ListRemoveByType) {
             "xs = [\"a\", \"b\", \"c\"]\n"
             "remove(xs, \"b\")\n"
             "print(xs)";
-        EXPECT_EQ(runSource(src), "[a, c]\n");
+        EXPECT_EQ(runSource(src), "[\"a\", \"c\"]\n");
     }
     // ListRemoveFloat
     {
@@ -1972,7 +1972,7 @@ TEST_F(CodeGenTest, DistinctVariants) {
     // DistinctInt
     EXPECT_EQ(runSource("xs = [1, 2, 3, 2, 1, 4]\nprint(distinct(xs))"), "[1, 2, 3, 4]\n");
     // DistinctStr
-    EXPECT_EQ(runSource("xs = [\"a\", \"b\", \"a\", \"c\", \"b\"]\nprint(distinct(xs))"), "[a, b, c]\n");
+    EXPECT_EQ(runSource("xs = [\"a\", \"b\", \"a\", \"c\", \"b\"]\nprint(distinct(xs))"), "[\"a\", \"b\", \"c\"]\n");
     // DistinctFloat
     EXPECT_EQ(runSource("xs = [1.0, 2.0, 1.0, 3.0]\nprint(distinct(xs))"), "[1, 2, 3]\n");
     // DistinctAlreadyUnique
@@ -2051,7 +2051,7 @@ TEST_F(CodeGenTest, FlattenVariants) {
     // FlattenIntLists
     EXPECT_EQ(runSource("xs = [[1, 2], [3, 4]]\nprint(flatten(xs))"), "[1, 2, 3, 4]\n");
     // FlattenStrLists
-    EXPECT_EQ(runSource("xs = [[\"a\", \"b\"], [\"c\", \"d\"]]\nprint(flatten(xs))"), "[a, b, c, d]\n");
+    EXPECT_EQ(runSource("xs = [[\"a\", \"b\"], [\"c\", \"d\"]]\nprint(flatten(xs))"), "[\"a\", \"b\", \"c\", \"d\"]\n");
     // FlattenUnevenInner
     {
         std::string src =

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -408,7 +408,7 @@ TEST_F(CodeGenTest, StructStrField) {
         "    name: str\n"
         "    age: int\n"
         "p = Person(\"Alice\", 30)\n"
-        "print(p)"), "Person(name: Alice, age: 30)\n");
+        "print(p)"), "Person(name: \"Alice\", age: 30)\n");
 }
 
 TEST_F(CodeGenTest, UnknownTypeAnnotationThrows) {


### PR DESCRIPTION
## Summary

- String elements inside collections (List, Set, Map, Array, Tuple, record, ADT) are now wrapped in double quotes when displayed via `print()` or `to_str()`, following Rust's debug display convention
- Empty strings are now visible: `[""]` instead of `[]`, `["", "a", ""]` instead of `[, a, ]`
- Wrapper types (Option, Result, Union) propagate the quoting context, so `Ok("hello")` stays `Ok(hello)` but `Ok({"a": 1})` becomes `Ok({"a": 1})`

## Test plan

- [x] New test file `collection_string_display.test.ry` with 17 test cases covering empty strings, string quoting in all collection types, nested collections, and Option/Result behavior
- [x] Updated existing test expectations in 7 test files (Ry + C++)
- [x] All 1438 C++ tests pass
- [x] All 93 Ry self-test files pass (0 failures)
- [x] ASan build passes with no memory errors

Closes #756

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * String elements in collections now display with double quotes (e.g., ["hello"]); empty strings are shown (e.g., [""]).
  * Applies to print() and to_str() for lists, sets, maps, tuples, records, and nested collections.

* **Documentation**
  * Updated to_str() and print() examples to reflect quoted string elements in collections.

* **Tests**
  * Updated and added tests to validate the new string-quoting behavior across cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->