### PR TITLE
fix: abort on sprint buffer depth overflow instead of silent corruption

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,7 @@ add_executable(ry_tests
     tests/test_dotenv.cpp
     tests/test_runtime_json.cpp
     tests/test_runtime_any.cpp
+    tests/test_runtime_print.cpp
     tests/test_stdin.cpp
     tests/test_entry_point.cpp
     tests/test_help.cpp

--- a/changelog.d/773-sprint-depth-overflow.md
+++ b/changelog.d/773-sprint-depth-overflow.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Sprint buffer depth overflow now aborts with a clear error message instead of silently corrupting output (#773)

--- a/include/ry/runtime_alloc.hpp
+++ b/include/ry/runtime_alloc.hpp
@@ -17,6 +17,11 @@ namespace ry {
     abort();
 }
 
+[[noreturn]] inline void depth_limit_abort(const char *what, int limit) {
+    fprintf(stderr, "ry: %s nesting depth exceeded (max %d)\n", what, limit);
+    abort();
+}
+
 inline void *checked_malloc(size_t n) {
     void *p = malloc(n);
     if (!p && n > 0) oom_abort(n);

--- a/include/ry/runtime_alloc.hpp
+++ b/include/ry/runtime_alloc.hpp
@@ -17,8 +17,8 @@ namespace ry {
     abort();
 }
 
-[[noreturn]] inline void depth_limit_abort(const char *what, int limit) {
-    fprintf(stderr, "ry: %s nesting depth exceeded (max %d)\n", what, limit);
+[[noreturn]] inline void depth_limit_abort(const char *what, size_t limit) {
+    fprintf(stderr, "ry: %s nesting depth exceeded (max %zu)\n", what, limit);
     abort();
 }
 

--- a/src/runtime_print.cpp
+++ b/src/runtime_print.cpp
@@ -102,8 +102,9 @@ static thread_local size_t tl_sprint_offsets[kMaxSprintDepth];
 static thread_local int tl_sprint_depth = 0;
 
 extern "C" void __ry_sprint_begin() {
-    if (tl_sprint_depth < kMaxSprintDepth)
-        tl_sprint_offsets[tl_sprint_depth] = tl_sprint_len;
+    if (tl_sprint_depth >= kMaxSprintDepth)
+        depth_limit_abort("sprint", kMaxSprintDepth);
+    tl_sprint_offsets[tl_sprint_depth] = tl_sprint_len;
     ++tl_sprint_depth;
     if (!tl_sprint_buf) {
         tl_sprint_cap = kInitialCap;

--- a/tests/test_runtime_print.cpp
+++ b/tests/test_runtime_print.cpp
@@ -1,0 +1,36 @@
+#include "ry/runtime_print.hpp"
+#include <gtest/gtest.h>
+#include <cstdlib>
+
+using namespace ry;
+
+// Death tests use "threadsafe" style to avoid fork issues with LLVM state
+class RuntimePrintDeathTest : public ::testing::Test {
+protected:
+    static void SetUpTestSuite() {
+        GTEST_FLAG_SET(death_test_style, "threadsafe");
+    }
+};
+
+TEST_F(RuntimePrintDeathTest, SprintDepthOverflowAborts) {
+    EXPECT_DEATH(
+        {
+            for (int i = 0; i <= 64; ++i)
+                __ry_sprint_begin();
+        },
+        "sprint nesting depth exceeded");
+}
+
+TEST(RuntimePrintTest, SprintNestingWorks) {
+    __ry_sprint_begin();
+    __ry_sprint_printf("outer");
+    __ry_sprint_begin();
+    __ry_sprint_printf("inner");
+    char *inner = __ry_sprint_end();
+    __ry_sprint_printf(" + done");
+    char *outer = __ry_sprint_end();
+    EXPECT_STREQ(inner, "inner");
+    EXPECT_STREQ(outer, "outer + done");
+    free(inner);
+    free(outer);
+}


### PR DESCRIPTION
## Summary

- Fix `__ry_sprint_begin()` to abort with a clear error message when sprint nesting depth exceeds 64, instead of silently skipping the offset save and corrupting output
- Add `depth_limit_abort()` utility to `runtime_alloc.hpp` following existing `oom_abort`/`overflow_abort` pattern
- Add death test and positive nesting test for sprint buffer

Closes #773

## Test plan

- [x] Death test verifies abort with "sprint nesting depth exceeded" message at depth 65
- [x] Positive test verifies 2-level nesting produces correct output
- [x] All C++ tests pass (1440/1440)
- [x] All Ry self-tests pass (93 files, 0 failures)
- [x] ASan build: all tests pass, no memory errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sprint buffer depth overflow now terminates with a clear error message instead of silently corrupting output.

* **Tests**
  * Added test coverage for runtime print functionality and depth limit enforcement, including a death-test for overflow and checks for nested sprint behavior.

* **Chores**
  * Test build updated to include the new runtime print test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->