### PR TITLE
fix: add InterpolatedStringExpr to closure capture analysis

### DIFF
--- a/changelog.d/753-fstring-closure-capture.md
+++ b/changelog.d/753-fstring-closure-capture.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- f-string interpolation inside closures now correctly captures outer variables (#753)

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -81,6 +81,8 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
             } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
                 if (v->expr_body) scanExpr(*v->expr_body);
                 for (auto &st : v->body) scanStmt(st);
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<InterpolatedStringExpr>>) {
+                for (auto &expr : v->exprs) scanExpr(*expr);
             }
         }, node.data);
     };

--- a/tests/spec/fstring_closure_capture.test.ry
+++ b/tests/spec/fstring_closure_capture.test.ry
@@ -40,3 +40,13 @@ describe("f-string closure capture — nested named function", ():
   )
 )
 
+describe("f-string closure capture — lambda", ():
+  it("should capture outer variable via f-string in lambda", ():
+    function str_len(s: str) -> int:
+      return s.length()
+    name = "world"
+    f = () => str_len(f"hello {name}")
+    expect(f()).to_eq(11)
+  )
+)
+

--- a/tests/spec/fstring_closure_capture.test.ry
+++ b/tests/spec/fstring_closure_capture.test.ry
@@ -1,0 +1,42 @@
+describe("f-string closure capture — nested named function", ():
+  it("should capture outer variable in f-string inside nested function", ():
+    function make_greeter(greeting: str) -> function(str) -> str:
+      function greet(name: str) -> str:
+        return f"{greeting} {name}"
+      return greet
+
+    g = make_greeter("hi")
+    expect(g("ry")).to_eq("hi ry")
+  )
+
+  it("should capture int variable in f-string inside nested function", ():
+    function make_formatter(prefix: str) -> function(int) -> str:
+      function fmt(x: int) -> str:
+        return f"{prefix}_{x}"
+      return fmt
+
+    f = make_formatter("item")
+    expect(f(42)).to_eq("item_42")
+  )
+
+  it("should capture variable used in expression inside f-string", ():
+    function make_calc(base: int) -> function(int) -> str:
+      function calc(x: int) -> str:
+        return f"result={base + x}"
+      return calc
+
+    f = make_calc(10)
+    expect(f(5)).to_eq("result=15")
+  )
+
+  it("should capture multiple outer variables in f-string", ():
+    function make_pair_fmt(a: str, b: str) -> function() -> str:
+      function fmt() -> str:
+        return f"{a} {b}"
+      return fmt
+
+    f = make_pair_fmt("hello", "world")
+    expect(f()).to_eq("hello world")
+  )
+)
+


### PR DESCRIPTION
## Summary

- Add missing `InterpolatedStringExpr` case to `scanExpr` in `analyzeFreeVariables()`, fixing f-string interpolation variables not being captured in closures
- Add tests for f-string closure capture in nested named functions

Closes #753

## Test plan

- [x] New test `fstring_closure_capture.test.ry` — 4 cases covering str/int capture, expressions, multiple variables
- [x] All C++ tests pass (1440/1440)
- [x] All Ry self-tests pass (94 files, 0 failures)
- [x] ASan clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * f-string interpolation inside closures now correctly captures and uses outer-scope variables and expressions.

* **Tests**
  * Added tests validating f-string closure capture for nested functions and lambdas, covering single/multiple variables and expression interpolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->