### PR TITLE
fix: exclude match/when pattern bindings from closure capture analysis

### DIFF
--- a/changelog.d/779-match-pattern-closure-capture.md
+++ b/changelog.d/779-match-pattern-closure-capture.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Match/when pattern bindings are now correctly excluded from closure capture analysis, preventing incorrect capture of outer variables with the same name (#779)

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -55,6 +55,24 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
             result.capturedClosureInfos[result.capturedNames.size() - 1] = *fnMeta->fn_type_info;
     };
 
+    auto excludePatternBindings = [&](const Pattern &pat) {
+        std::visit([&](const auto &p) {
+            using P = std::decay_t<decltype(p)>;
+            if constexpr (std::is_same_v<P, VariablePattern>) {
+                excludedNames.insert(p.name);
+            } else if constexpr (std::is_same_v<P, SomePattern>) {
+                if (p.binding != "_") excludedNames.insert(p.binding);
+            } else if constexpr (std::is_same_v<P, OkPattern>) {
+                if (p.binding != "_") excludedNames.insert(p.binding);
+            } else if constexpr (std::is_same_v<P, ErrPattern>) {
+                if (p.binding != "_") excludedNames.insert(p.binding);
+            } else if constexpr (std::is_same_v<P, EnumConstructorPattern>) {
+                for (auto &b : p.bindings)
+                    if (b != "_") excludedNames.insert(b);
+            }
+        }, pat);
+    };
+
     scanExpr = [&](const ExprNode &node) {
         std::visit([&](const auto &v) {
             using T = std::decay_t<decltype(v)>;
@@ -96,8 +114,11 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
             } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchExpr>>) {
                 scanExpr(*v->subject);
                 for (auto &arm : v->arms) {
+                    auto savedExcluded = excludedNames;
+                    excludePatternBindings(arm.pattern);
                     if (arm.guard) scanExpr(*arm.guard);
                     scanExpr(*arm.value);
+                    excludedNames = std::move(savedExcluded);
                 }
             } else if constexpr (std::is_same_v<T, std::unique_ptr<RangeExpr>>) {
                 if (v->start) scanExpr(*v->start);
@@ -155,8 +176,11 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
             } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
                 scanExpr(*s->subject);
                 for (auto &arm : s->arms) {
+                    auto savedExcluded = excludedNames;
+                    excludePatternBindings(arm.pattern);
                     if (arm.guard) scanExpr(*arm.guard);
                     for (auto &st : arm.body) scanStmt(st);
+                    excludedNames = std::move(savedExcluded);
                 }
             } else if constexpr (std::is_same_v<T, ExpectStmt>) {
                 scanExpr(*s.actual);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -55,11 +55,12 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
             result.capturedClosureInfos[result.capturedNames.size() - 1] = *fnMeta->fn_type_info;
     };
 
-    auto excludePatternBindings = [&](const Pattern &pat) {
+    std::function<void(const Pattern &)> excludePatternBindings =
+        [&](const Pattern &pat) {
         std::visit([&](const auto &p) {
             using P = std::decay_t<decltype(p)>;
             if constexpr (std::is_same_v<P, VariablePattern>) {
-                excludedNames.insert(p.name);
+                if (p.name != "_") excludedNames.insert(p.name);
             } else if constexpr (std::is_same_v<P, SomePattern>) {
                 if (p.binding != "_") excludedNames.insert(p.binding);
             } else if constexpr (std::is_same_v<P, OkPattern>) {
@@ -69,6 +70,11 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
             } else if constexpr (std::is_same_v<P, EnumConstructorPattern>) {
                 for (auto &b : p.bindings)
                     if (b != "_") excludedNames.insert(b);
+            } else if constexpr (std::is_same_v<P, std::unique_ptr<OrPattern>>) {
+                if (p) {
+                    for (const auto &alt : p->alternatives)
+                        excludePatternBindings(alt);
+                }
             }
         }, pat);
     };

--- a/tests/spec/closure_match_pattern_capture.test.ry
+++ b/tests/spec/closure_match_pattern_capture.test.ry
@@ -1,0 +1,61 @@
+describe("match pattern capture", ():
+  it("match expr pattern binding excluded from closure capture", ():
+    n = 999
+    function make_matcher(limit: int) -> function(int) -> str:
+      function do_match(x: int) -> str:
+        return match x:
+          case n if n > limit => "above"
+          case _ => "below"
+      return do_match
+
+    f = make_matcher(5)
+    expect(f(10)).to_eq("above")
+    expect(f(3)).to_eq("below")
+  )
+
+  it("match stmt pattern binding excluded from closure capture", ():
+    n = 999
+    function make_classifier(limit: int) -> function(int) -> str:
+      function classify(x: int) -> str:
+        result = ""
+        match x:
+          case n if n > limit:
+            result = "above"
+          case _:
+            result = "below"
+        return result
+      return classify
+
+    f = make_classifier(5)
+    expect(f(10)).to_eq("above")
+    expect(f(3)).to_eq("below")
+  )
+
+  it("captures outer variable but not pattern binding with same name", ():
+    suffix = "!"
+    function make_matcher(limit: int) -> function(int) -> str:
+      function do_match(x: int) -> str:
+        return match x:
+          case n if n > limit => f"above{suffix}"
+          case _ => f"below{suffix}"
+      return do_match
+
+    f = make_matcher(5)
+    expect(f(10)).to_eq("above!")
+    expect(f(3)).to_eq("below!")
+  )
+
+  it("str outer not captured when pattern binds int with same name", ():
+    n = "outer_string"
+    function make_matcher(limit: int) -> function(int) -> str:
+      function do_match(x: int) -> str:
+        return match x:
+          case n if n > limit => "above"
+          case _ => "below"
+      return do_match
+
+    f = make_matcher(5)
+    expect(f(10)).to_eq("above")
+    expect(f(3)).to_eq("below")
+  )
+)


### PR DESCRIPTION
## Summary

- Add `excludePatternBindings` helper to `analyzeFreeVariables()` that extracts binding names from all pattern types (Variable, Some, Ok, Err, EnumConstructor)
- Apply save/restore scoping for `excludedNames` in both `MatchExpr` and `MatchStmt` handlers, matching the existing `FnStmt` pattern
- Add regression tests for match expr, match stmt, f-string capture coexistence, and type-mismatch shadowing

Closes #779

## Test plan

- [x] New tests in `tests/spec/closure_match_pattern_capture.test.ry` (4 cases)
- [x] `./build/ry_tests` — 1440 passed
- [x] `./build/ry test -p` — 96 files, 0 failures
- [x] ASan build — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Match/case pattern bindings no longer cause unintended closure capture of outer variables with the same name; pattern-bound names are excluded from capture analysis.
* **Tests**
  * Added tests verifying closure capture behavior for match expressions and statements, including name-collision cases.
* **Documentation**
  * Added a changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->