### PR TITLE
fix: quote Any-typed strings in collection display

### DIFF
--- a/changelog.d/771-any-string-collection-quote.md
+++ b/changelog.d/771-any-string-collection-quote.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `Any`-typed string values inside collections are now displayed with double quotes, consistent with statically-typed strings (#771)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1209,7 +1209,7 @@ public:
     bool canAnyHoldType(llvm::Type *ty) const;
     bool isNonStrPointer(llvm::Value *val);
     bool isStringValue(llvm::Value *val);
-    llvm::Value *emitAnyToString(llvm::Value *anyVal);
+    llvm::Value *emitAnyToString(llvm::Value *anyVal, bool inCollection = false);
     static bool isNoneLiteral(const ExprNode &expr);
 };
 

--- a/include/ry/runtime_any.hpp
+++ b/include/ry/runtime_any.hpp
@@ -26,6 +26,7 @@ void __ry_any_pow(RyAny *result, const RyAny *a, const RyAny *b);
 void __ry_any_neg(RyAny *result, const RyAny *a);
 
 const char *__ry_any_to_string(const RyAny *a);
+const char *__ry_any_to_string_in_collection(const RyAny *a);
 
 int64_t __ry_any_eq(const RyAny *a, const RyAny *b);
 int64_t __ry_any_ne(const RyAny *a, const RyAny *b);

--- a/src/codegen_any.cpp
+++ b/src/codegen_any.cpp
@@ -133,11 +133,13 @@ llvm::Value *CodeGen::unwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy) {
     return builder_.CreateLoad(targetTy, dataPtr, "any.unwrap.val");
 }
 
-llvm::Value *CodeGen::emitAnyToString(llvm::Value *anyVal) {
+llvm::Value *CodeGen::emitAnyToString(llvm::Value *anyVal, bool inCollection) {
     llvm::AllocaInst *tmp = builder_.CreateAlloca(anyTy_, nullptr, "any.ts");
     builder_.CreateStore(anyVal, tmp);
     llvm::FunctionType *fnTy = llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
-    llvm::FunctionCallee fn = mod_->getOrInsertFunction("__ry_any_to_string", fnTy);
+    const char *fnName = inCollection ? "__ry_any_to_string_in_collection"
+                                      : "__ry_any_to_string";
+    llvm::FunctionCallee fn = mod_->getOrInsertFunction(fnName, fnTy);
     return builder_.CreateCall(fn, {tmp}, "any.ts.str");
 }
 

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -7,7 +7,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
     llvm::Type *ty = val->getType();
 
     if (ty == anyTy_)
-        return emitAnyToString(val);
+        return emitAnyToString(val, inCollection);
 
     // Enum value → variant name string
     {

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -122,6 +122,20 @@ extern "C" const char *__ry_any_to_string(const RyAny *a) {
     }
 }
 
+extern "C" const char *__ry_any_to_string_in_collection(const RyAny *a) {
+    if (a->tag == static_cast<int64_t>(RyAnyTag::Str)) {
+        const char *raw = extractStr(a);
+        size_t len = strlen(raw);
+        char *buf = static_cast<char *>(checked_malloc(len + 3));
+        buf[0] = '"';
+        memcpy(buf + 1, raw, len);
+        buf[len + 1] = '"';
+        buf[len + 2] = '\0';
+        return buf;
+    }
+    return __ry_any_to_string(a);
+}
+
 // ===== Type error (#224) =====
 
 extern "C" void __ry_any_type_error(const char *op, int64_t tag_a, int64_t tag_b) {

--- a/tests/spec/collection_string_display.test.ry
+++ b/tests/spec/collection_string_display.test.ry
@@ -77,4 +77,22 @@ describe("collection string display", ():
     expected = "Ok((1, " + "\"a\"" + "))"
     expect(to_str(r)).to_eq(expected)
   )
+  it("should quote any-typed string in list", ():
+    x: any = "hello"
+    y: any = 42
+    xs = [x, y]
+    expected = "[" + "\"hello\"" + ", 42]"
+    expect(to_str(xs)).to_eq(expected)
+  )
+  it("should quote any-typed empty string in list", ():
+    x: any = ""
+    xs = [x]
+    expected = "[" + "\"\"" + "]"
+    expect(to_str(xs)).to_eq(expected)
+  )
+  it("should not quote any-typed int in list", ():
+    x: any = 42
+    xs = [x]
+    expect(to_str(xs)).to_eq("[42]")
+  )
 )

--- a/tests/test_runtime_any.cpp
+++ b/tests/test_runtime_any.cpp
@@ -623,3 +623,45 @@ TEST(RuntimeAnyToString, UnitToString) {
     EXPECT_STREQ(s, "Unit");
     // s points to a string literal — no free needed
 }
+
+// ===== __ry_any_to_string_in_collection =====
+
+TEST(RuntimeAnyToStringInCollection, StrQuoted) {
+    RyAny a = mkStr("hello");
+    const char *s = __ry_any_to_string_in_collection(&a);
+    EXPECT_STREQ(s, "\"hello\"");
+    free(const_cast<char*>(s));
+}
+
+TEST(RuntimeAnyToStringInCollection, EmptyStrQuoted) {
+    RyAny a = mkStr("");
+    const char *s = __ry_any_to_string_in_collection(&a);
+    EXPECT_STREQ(s, "\"\"");
+    free(const_cast<char*>(s));
+}
+
+TEST(RuntimeAnyToStringInCollection, IntUnchanged) {
+    RyAny a = mkInt(42);
+    const char *s = __ry_any_to_string_in_collection(&a);
+    EXPECT_STREQ(s, "42");
+    free(const_cast<char*>(s));
+}
+
+TEST(RuntimeAnyToStringInCollection, FloatUnchanged) {
+    RyAny a = mkFloat(3.14);
+    const char *s = __ry_any_to_string_in_collection(&a);
+    EXPECT_STREQ(s, "3.14");
+    free(const_cast<char*>(s));
+}
+
+TEST(RuntimeAnyToStringInCollection, BoolUnchanged) {
+    RyAny a = mkBool(true);
+    const char *s = __ry_any_to_string_in_collection(&a);
+    EXPECT_STREQ(s, "true");
+}
+
+TEST(RuntimeAnyToStringInCollection, UnitUnchanged) {
+    RyAny a = mkUnit();
+    const char *s = __ry_any_to_string_in_collection(&a);
+    EXPECT_STREQ(s, "Unit");
+}


### PR DESCRIPTION
## Summary

- Add `__ry_any_to_string_in_collection()` runtime function that wraps `Any`-typed strings in double quotes when displayed inside collections
- Thread `inCollection` flag through `emitAnyToString()` codegen path so the correct runtime function is called
- Add C++ unit tests and Ry self-tests for the new behavior

Closes #771

## Test plan

- [x] C++ unit tests: `RuntimeAnyToStringInCollection` (6 cases — Str quoted, empty Str quoted, Int/Float/Bool/Unit unchanged)
- [x] Ry self-tests: 3 new cases in `collection_string_display.test.ry`
- [x] All existing tests pass (`ry_tests`: 1446, `ry test -p`: 96 files, 0 failures)
- [x] ASan clean (`ry_tests` + `ry test -p` under ASan)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in how `Any`-typed string values are displayed in collections. String values now consistently render with surrounding double quotes, aligning them with the display of statically-typed strings. Non-string values such as numbers and booleans maintain their existing formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->