### PR TITLE
fix: raise runtime error on integer division by zero

### DIFF
--- a/changelog.d/754-div-by-zero.md
+++ b/changelog.d/754-div-by-zero.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Integer division by zero (`1 / 0`) now raises a runtime error instead of returning `inf` (#754)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -916,6 +916,8 @@ public:
     FnTypeInfo parseFnTypeAnnotation(const std::string &typeStr);
     void emitRuntimeError(const std::string &message, const std::string &globalName,
                           llvm::ArrayRef<llvm::Value *> extraArgs = {});
+    void emitIntZeroDivGuard(llvm::Value *divisor, const std::string &bbPrefix,
+                             const std::string &errMsg);
     void emitBoundsError(llvm::Value *index, llvm::Value *size,
                          const std::string &fmtMsg, const std::string &globalName);
     llvm::Value *emitNegativeIndexWrap(llvm::Value *idx, llvm::Value *wrapBase,

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -609,6 +609,19 @@ void CodeGen::emitBoundsError(llvm::Value *index, llvm::Value *size,
     emitRuntimeError(fmtMsg, globalName, {index, size});
 }
 
+void CodeGen::emitIntZeroDivGuard(llvm::Value *divisor, const std::string &bbPrefix,
+                                   const std::string &errMsg) {
+    llvm::Value *isZero = builder_.CreateICmpEQ(
+        divisor, llvm::ConstantInt::get(i64Ty_, 0), bbPrefix + "_zero");
+    llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, bbPrefix + ".err", fn_);
+    llvm::BasicBlock *okBB  = llvm::BasicBlock::Create(*ctx_, bbPrefix + ".ok", fn_);
+    builder_.CreateCondBr(isZero, errBB, okBB);
+    builder_.SetInsertPoint(errBB);
+    emitRuntimeError(errMsg,
+                      "." + bbPrefix + "_err_" + std::to_string(arith_zero_err_counter_++));
+    builder_.SetInsertPoint(okBB);
+}
+
 llvm::Value *CodeGen::emitNegativeIndexWrap(llvm::Value *idx, llvm::Value *wrapBase,
                                               const std::string &prefix) {
     llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -612,7 +612,7 @@ void CodeGen::emitBoundsError(llvm::Value *index, llvm::Value *size,
 void CodeGen::emitIntZeroDivGuard(llvm::Value *divisor, const std::string &bbPrefix,
                                    const std::string &errMsg) {
     llvm::Value *isZero = builder_.CreateICmpEQ(
-        divisor, llvm::ConstantInt::get(i64Ty_, 0), bbPrefix + "_zero");
+        divisor, llvm::ConstantInt::get(divisor->getType(), 0), bbPrefix + "_zero");
     llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, bbPrefix + ".err", fn_);
     llvm::BasicBlock *okBB  = llvm::BasicBlock::Create(*ctx_, bbPrefix + ".ok", fn_);
     builder_.CreateCondBr(isZero, errBB, okBB);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -938,17 +938,7 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
             return builder_.CreateCall(floorFn, {div}, "floordiv");
         }
         // int: zero-division guard
-        {
-            llvm::Value *isZero = builder_.CreateICmpEQ(
-                rhs, llvm::ConstantInt::get(i64Ty_, 0), "div_zero");
-            llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, "floordiv.zero_err", fn_);
-            llvm::BasicBlock *okBB  = llvm::BasicBlock::Create(*ctx_, "floordiv.ok", fn_);
-            builder_.CreateCondBr(isZero, errBB, okBB);
-            builder_.SetInsertPoint(errBB);
-            emitRuntimeError("runtime error: division by zero\n",
-                              ".floordiv_zero_err_" + std::to_string(arith_zero_err_counter_++));
-            builder_.SetInsertPoint(okBB);
-        }
+        emitIntZeroDivGuard(rhs, "floordiv", "runtime error: division by zero\n");
         // int: sdiv + floor adjustment
         llvm::Value *q   = builder_.CreateSDiv(lhs, rhs, "q");
         llvm::Value *rem  = builder_.CreateSRem(lhs, rhs, "rem");
@@ -965,6 +955,10 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
 
     // / 除算: 常にf64
     if (op == "/") {
+        // int / int: zero-division guard (fdiv doesn't trap, but Ry treats int/0 as error)
+        if (lhs->getType()->isIntegerTy() && rhs->getType()->isIntegerTy()) {
+            emitIntZeroDivGuard(promoteToInt(rhs), "div", "runtime error: division by zero\n");
+        }
         std::tie(lhs, rhs) = promoteToFloat(lhs, rhs);
         return builder_.CreateFDiv(lhs, rhs, "div");
     }
@@ -990,17 +984,7 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
             return builder_.CreateSelect(needsAdj, adjusted, frem, "ffloormod");
         }
         // int: zero-division guard
-        {
-            llvm::Value *isZero = builder_.CreateICmpEQ(
-                rhs, llvm::ConstantInt::get(i64Ty_, 0), "mod_zero");
-            llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, "mod.zero_err", fn_);
-            llvm::BasicBlock *okBB  = llvm::BasicBlock::Create(*ctx_, "mod.ok", fn_);
-            builder_.CreateCondBr(isZero, errBB, okBB);
-            builder_.SetInsertPoint(errBB);
-            emitRuntimeError("runtime error: modulo by zero\n",
-                              ".mod_zero_err_" + std::to_string(arith_zero_err_counter_++));
-            builder_.SetInsertPoint(okBB);
-        }
+        emitIntZeroDivGuard(rhs, "mod", "runtime error: modulo by zero\n");
         // Floor modulo: r = srem(a,b); if (r != 0 && sign(r) != sign(b)) r += b
         llvm::Value *rem = builder_.CreateSRem(lhs, rhs, "srem");
         llvm::Value *remNonZero = builder_.CreateICmpNE(

--- a/tests/spec/div_zero_guard.test.ry
+++ b/tests/spec/div_zero_guard.test.ry
@@ -1,0 +1,13 @@
+describe("division", ():
+  it("should divide integers correctly", ():
+    expect(6 / 3).to_eq(2.0)
+    expect(1 / 2).to_eq(0.5)
+    expect(-7 / 2).to_eq(-3.5)
+    expect(0 / 1).to_eq(0.0)
+  )
+
+  it("should divide floats correctly", ():
+    expect(6.0 / 3.0).to_eq(2.0)
+    expect(1.0 / 2.0).to_eq(0.5)
+  )
+)

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -372,6 +372,23 @@ TEST_F(CodeGenTest, NativeFunctionMissingDispatcher) {
 
 // ===== Zero division guard tests (death tests - individual) =====
 
+TEST_F(CodeGenTest, DivByZeroExits) {
+    EXPECT_EXIT(runSource("print(1 / 0)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: division by zero");
+}
+
+TEST_F(CodeGenTest, DivByZeroVariableExits) {
+    EXPECT_EXIT(runSource("x = 0\nprint(1 / x)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: division by zero");
+}
+
+TEST_F(CodeGenTest, DivFloatByZeroReturnsInf) {
+    EXPECT_EQ(runSource("print(1.0 / 0.0)"), "inf\n");
+    EXPECT_EQ(runSource("print(-1.0 / 0.0)"), "-inf\n");
+}
+
 TEST_F(CodeGenTest, FloorDivByZeroExits) {
     EXPECT_EXIT(runSource("print(7 // 0)"),
                 ::testing::ExitedWithCode(1),


### PR DESCRIPTION
## Summary

- Integer `/` operator (`1 / 0`) now raises a runtime error instead of silently returning `inf`
- Float division (`1.0 / 0.0`) still returns `inf` per IEEE 754
- Extracted `emitIntZeroDivGuard` helper to deduplicate zero-division guard logic across `/`, `//`, and `%` operators

## Test plan

- [x] C++ death tests: `DivByZeroExits`, `DivByZeroVariableExits` (literal and variable)
- [x] C++ positive test: `DivFloatByZeroReturnsInf` (float division still returns inf)
- [x] Ry self-test: `div_zero_guard.test.ry` (normal integer/float division)
- [x] All 1449 C++ tests pass
- [x] All 97 Ry self-test files pass (0 failures)
- [x] ASan build passes all tests

Closes #754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Integer division and modulo by zero now raise a runtime error with a descriptive message (including floor-division), instead of returning infinity. Float division by zero still returns IEEE infinities.
* **Tests**
  * Added tests verifying integer division/modulo-by-zero triggers errors and float division-by-zero yields infinities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->