### PR TITLE
fix: add zero-division guard for low-level integer operators

### DIFF
--- a/changelog.d/783-ll-int-zero-div-guard.md
+++ b/changelog.d/783-ll-int-zero-div-guard.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Low-level integer types (`i32`, `u8`, etc.) now raise a runtime error on division/modulo by zero instead of causing undefined behavior (#783)

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -829,10 +829,12 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
         // Low-level integer
         bool isUnsigned = isUnsignedLowLevel(lhs) || isUnsignedLowLevelName(llNameHint);
         if (op == "/" || op == "//") {
+            emitIntZeroDivGuard(rhs, "div_ll", "runtime error: division by zero\n");
             if (isUnsigned) return propagate(builder_.CreateUDiv(lhs, rhs, "udiv_ll"));
             return propagate(builder_.CreateSDiv(lhs, rhs, "sdiv_ll"));
         }
         if (op == "%") {
+            emitIntZeroDivGuard(rhs, "mod_ll", "runtime error: modulo by zero\n");
             if (isUnsigned) return propagate(builder_.CreateURem(lhs, rhs, "urem_ll"));
             return propagate(builder_.CreateSRem(lhs, rhs, "srem_ll"));
         }

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -401,6 +401,38 @@ TEST_F(CodeGenTest, ModByZeroExits) {
                 "runtime error: modulo by zero");
 }
 
+// ===== Low-level integer zero division guard tests =====
+
+TEST_F(CodeGenTest, LowLevelDivByZeroExits) {
+    EXPECT_EXIT(runSource("a: i32 = 10\nb: i32 = 0\nc = a / b\nprint(c as int)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: division by zero");
+}
+
+TEST_F(CodeGenTest, LowLevelFloorDivByZeroExits) {
+    EXPECT_EXIT(runSource("a: i32 = 10\nb: i32 = 0\nc = a // b\nprint(c as int)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: division by zero");
+}
+
+TEST_F(CodeGenTest, LowLevelModByZeroExits) {
+    EXPECT_EXIT(runSource("a: i32 = 10\nb: i32 = 0\nc = a % b\nprint(c as int)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: modulo by zero");
+}
+
+TEST_F(CodeGenTest, LowLevelUnsignedDivByZeroExits) {
+    EXPECT_EXIT(runSource("a: u32 = 10\nb: u32 = 0\nc = a / b\nprint(c as int)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: division by zero");
+}
+
+TEST_F(CodeGenTest, LowLevelUnsignedModByZeroExits) {
+    EXPECT_EXIT(runSource("a: u32 = 10\nb: u32 = 0\nc = a % b\nprint(c as int)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: modulo by zero");
+}
+
 TEST_F(CodeGenTest, FloorDivModWorks) {
     EXPECT_EQ(runSource("print(7 // 2)"), "3\n");
     EXPECT_EQ(runSource("print(-7 // 2)"), "-4\n");


### PR DESCRIPTION
## Summary

- Add `emitIntZeroDivGuard` calls before low-level integer `/`, `//`, `%` operations in `codegen_expr.cpp`
- Low-level integer types (`i32`, `u8`, etc.) now raise a runtime error on division/modulo by zero instead of causing LLVM undefined behavior

## Test plan

- [x] 5 new death tests for low-level integer zero-division (signed `/`/`//`/`%`, unsigned `/`/`%`)
- [x] All C++ tests pass (1454 tests)
- [x] All Ry self-tests pass (97 files)
- [x] ASan clean (no memory errors)

Closes #783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Low-level integer types now detect division and modulo by zero at runtime, raising an error instead of triggering undefined behavior.

## Tests
* Added test coverage for low-level integer division and modulo by zero error handling across signed and unsigned types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->