### PR TITLE
fix: track local variable types in return type inference

### DIFF
--- a/changelog.d/770-return-type-inference-locals.md
+++ b/changelog.d/770-return-type-inference-locals.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Return type inference now correctly handles local variables instead of falling back to `int` (#770)
+- "return type mismatch" errors now show expected and actual types

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1185,6 +1185,8 @@ public:
                                 std::vector<llvm::Value*> args, const std::string &name);
 
     // Return type inference
+    void buildLocalTypeMap(const std::vector<StmtNode> &body,
+        std::unordered_map<std::string, llvm::Type*> &typeMap);
     llvm::Type *inferExprType(const ExprNode &expr,
         const std::unordered_map<std::string, llvm::Type*> &paramTypeMap);
     llvm::Type *inferReturnType(const std::vector<StmtNode> &body,

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -173,8 +173,12 @@ void CodeGen::emitStmt(ReturnStmt &s) {
                     // Try tuple element coercion (e.g., Option<int> none → Option<Error>)
                     auto *retST = llvm::dyn_cast<llvm::StructType>(retTy);
                     auto *valST = llvm::dyn_cast<llvm::StructType>(val->getType());
+                    const std::string mismatchMsg =
+                        "return type mismatch: expected '" +
+                        reverseResolveTypeName(retTy) + "', found '" +
+                        reverseResolveTypeName(val->getType()) + "'";
                     if (!retST || !valST || retST->getNumElements() != valST->getNumElements())
-                        codegenError("return type mismatch");
+                        codegenError(mismatchMsg);
 
                     // Find which elements need coercion
                     bool needsCoercion = false;
@@ -182,7 +186,7 @@ void CodeGen::emitStmt(ReturnStmt &s) {
                         if (valST->getElementType(i) != retST->getElementType(i)) {
                             if (!(isOptionType(valST->getElementType(i)) &&
                                   isOptionType(retST->getElementType(i))))
-                                codegenError("return type mismatch");
+                                codegenError(mismatchMsg);
                             needsCoercion = true;
                         }
                     }
@@ -564,6 +568,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         std::unordered_map<std::string, llvm::Type*> paramTypeMap;
         for (auto &p : s->params)
             paramTypeMap[p.name] = resolveType(p.type->toString());
+        buildLocalTypeMap(s->body, paramTypeMap);
         std::vector<llvm::Type*> retTypes;
         collectReturnTypes(s->body, paramTypeMap, retTypes);
         bodyRetTy = deduceReturnType(retTypes);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -282,6 +282,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
         if (e->expr_body) {
             retTy = inferExprType(*e->expr_body, paramTypeMap);
         } else {
+            buildLocalTypeMap(e->body, paramTypeMap);
             retTy = inferReturnType(e->body, paramTypeMap);
         }
     } else {
@@ -405,6 +406,40 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
 }
 
 // ===== Lambda return type inference =====
+
+void CodeGen::buildLocalTypeMap(const std::vector<StmtNode> &body,
+    std::unordered_map<std::string, llvm::Type*> &typeMap) {
+    for (auto &stmt : body) {
+        std::visit([&](const auto &s) {
+            using T = std::decay_t<decltype(s)>;
+            if constexpr (std::is_same_v<T, AssignStmt>) {
+                if (s.value && !s.compound_op &&
+                    typeMap.find(s.name) == typeMap.end()) {
+                    if (s.type_annotation) {
+                        if (auto *ty = tryResolveType(s.type_annotation->toString()))
+                            typeMap[s.name] = ty;
+                    } else {
+                        typeMap[s.name] = inferExprType(*s.value, typeMap);
+                    }
+                }
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) {
+                buildLocalTypeMap(s->branch.body, typeMap);
+                buildLocalTypeMap(s->else_body, typeMap);
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) {
+                buildLocalTypeMap(s->body, typeMap);
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) {
+                buildLocalTypeMap(s->body, typeMap);
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhenCondStmt>>) {
+                for (auto &arm : s->arms)
+                    buildLocalTypeMap(arm.body, typeMap);
+                buildLocalTypeMap(s->else_body, typeMap);
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
+                for (auto &arm : s->arms)
+                    buildLocalTypeMap(arm.body, typeMap);
+            }
+        }, stmt);
+    }
+}
 
 llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
     const std::unordered_map<std::string, llvm::Type*> &paramTypeMap) {

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -227,4 +227,10 @@ describe("return type inference for local variables", ():
   it("should infer float return type from local", ():
     expect(local_float(2.5)).to_eq(3.5)
   )
+  it("should infer return type for block-bodied lambda local", ():
+    f = (x: int):
+      y = x + 1
+      return y
+    expect(f(2)).to_eq(3)
+  )
 )

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -201,3 +201,30 @@ describe("tail call optimization", ():
     expect(sum_to(1000000, 0)).to_eq(500000500000)
   )
 )
+
+# --- Return type inference for local variables (#770) ---
+
+function compute_and_return(r: float):
+  v = 4.0 * 3.14 * r * r * r / 3.0
+  return v
+
+function transitive_local(x: int):
+  a = x * 2
+  b = a + 1
+  return b
+
+function local_float(x: float):
+  result = x + 1.0
+  return result
+
+describe("return type inference for local variables", ():
+  it("should infer return type from local variable", ():
+    expect(compute_and_return(1.0)).to_eq(4.0 * 3.14 / 3.0)
+  )
+  it("should infer return type through transitive locals", ():
+    expect(transitive_local(5)).to_eq(11)
+  )
+  it("should infer float return type from local", ():
+    expect(local_float(2.5)).to_eq(3.5)
+  )
+)


### PR DESCRIPTION
## Summary

- Add `buildLocalTypeMap` to pre-scan function/lambda bodies for local variable assignments before return type inference, fixing spurious "return type mismatch" errors when returning local variables
- Improve "return type mismatch" error messages to show expected vs actual types

Closes #770

## Test plan

- [x] Reproduction case (`function f(r): v = expr; return v`) now works
- [x] C++ tests pass (1454 tests)
- [x] Ry self-tests pass (97 files, 0 failures)
- [x] ASan clean (no memory errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Return type inference now respects local variables (including transitive assignments and float arithmetic) and works for block-bodied lambdas.
  * "Return type mismatch" errors now show both expected and actual types for clearer diagnostics.

* **Tests**
  * Added tests validating return type inference for locals, transitive assignments, and block-bodied lambdas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->