### PR TITLE
fix: escape double quotes and backslashes in collection string display

### DIFF
--- a/changelog.d/772-escape-quotes-in-collection-display.md
+++ b/changelog.d/772-escape-quotes-in-collection-display.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Double quotes and backslashes inside strings are now escaped when displayed in collections (#772)

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -515,7 +515,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
             return cachedGlobalString("<closure>", ".vts_closure");
         if (inCollection) {
             llvm::FunctionCallee escapeFn =
-                getRuntimeFn("__ry_str_quote_escape", ptrTy_, {ptrTy_});
+                getRuntimeFn("__ry_print_str_quote_escape", ptrTy_, {ptrTy_});
             return builder_.CreateCall(escapeFn, {val}, "vts_str_escaped");
         }
         return val; // string pointer

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -514,16 +514,9 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
         if (auto *fnMeta = getMeta(val); fnMeta && fnMeta->fn_type_info)
             return cachedGlobalString("<closure>", ".vts_closure");
         if (inCollection) {
-            auto strlenFn = getStdlibStrlen();
-            auto mallocFn = getStdlibMalloc();
-            auto snprintfFn = getStdlibSnprintf();
-            llvm::Value *len = builder_.CreateCall(strlenFn, {val}, "vts_str_len");
-            llvm::Value *bufSz = builder_.CreateAdd(
-                len, llvm::ConstantInt::get(i64Ty_, 3), "vts_str_bufsz");
-            llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSz}, "vts_str_buf");
-            builder_.CreateCall(snprintfFn,
-                {buf, bufSz, cachedGlobalString("\"%s\"", ".vts_str_quote"), val});
-            return buf;
+            llvm::FunctionCallee escapeFn =
+                getRuntimeFn("__ry_str_quote_escape", ptrTy_, {ptrTy_});
+            return builder_.CreateCall(escapeFn, {val}, "vts_str_escaped");
         }
         return val; // string pointer
     }

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -122,16 +122,11 @@ extern "C" const char *__ry_any_to_string(const RyAny *a) {
     }
 }
 
+extern "C" const char *__ry_str_quote_escape(const char *raw);
+
 extern "C" const char *__ry_any_to_string_in_collection(const RyAny *a) {
     if (a->tag == static_cast<int64_t>(RyAnyTag::Str)) {
-        const char *raw = extractStr(a);
-        size_t len = strlen(raw);
-        char *buf = static_cast<char *>(checked_malloc(len + 3));
-        buf[0] = '"';
-        memcpy(buf + 1, raw, len);
-        buf[len + 1] = '"';
-        buf[len + 2] = '\0';
-        return buf;
+        return __ry_str_quote_escape(extractStr(a));
     }
     return __ry_any_to_string(a);
 }

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -122,11 +122,11 @@ extern "C" const char *__ry_any_to_string(const RyAny *a) {
     }
 }
 
-extern "C" const char *__ry_str_quote_escape(const char *raw);
+extern "C" const char *__ry_print_str_quote_escape(const char *raw);
 
 extern "C" const char *__ry_any_to_string_in_collection(const RyAny *a) {
     if (a->tag == static_cast<int64_t>(RyAnyTag::Str)) {
-        return __ry_str_quote_escape(extractStr(a));
+        return __ry_print_str_quote_escape(extractStr(a));
     }
     return __ry_any_to_string(a);
 }

--- a/src/runtime_print.cpp
+++ b/src/runtime_print.cpp
@@ -136,3 +136,23 @@ extern "C" char *__ry_sprint_end() {
 }
 
 } // namespace ry
+
+extern "C" const char *__ry_str_quote_escape(const char *raw) {
+    size_t len = std::strlen(raw);
+    size_t extra = 0;
+    for (size_t i = 0; i < len; ++i) {
+        if (raw[i] == '"' || raw[i] == '\\')
+            ++extra;
+    }
+    char *buf = static_cast<char *>(ry::checked_malloc(len + extra + 3));
+    char *p = buf;
+    *p++ = '"';
+    for (size_t i = 0; i < len; ++i) {
+        if (raw[i] == '"' || raw[i] == '\\')
+            *p++ = '\\';
+        *p++ = raw[i];
+    }
+    *p++ = '"';
+    *p = '\0';
+    return buf;
+}

--- a/src/runtime_print.cpp
+++ b/src/runtime_print.cpp
@@ -137,7 +137,7 @@ extern "C" char *__ry_sprint_end() {
 
 } // namespace ry
 
-extern "C" const char *__ry_str_quote_escape(const char *raw) {
+extern "C" const char *__ry_print_str_quote_escape(const char *raw) {
     size_t len = std::strlen(raw);
     size_t extra = 0;
     for (size_t i = 0; i < len; ++i) {

--- a/tests/spec/collection_string_display.test.ry
+++ b/tests/spec/collection_string_display.test.ry
@@ -110,6 +110,11 @@ describe("collection string display", ():
     expected = "[\"say \\\\\\\"hi\\\\\\\"\"]"
     expect(to_str(xs)).to_eq(expected)
   )
+  it("should escape double quotes in map key and value", ():
+    xs = {"he said \"hi\"": "a\"b"}
+    expected = "{\"he said \\\"hi\\\"\": \"a\\\"b\"}"
+    expect(to_str(xs)).to_eq(expected)
+  )
   it("should escape double quotes in any-typed list string", ():
     x: any = "he said \"hi\""
     xs = [x]

--- a/tests/spec/collection_string_display.test.ry
+++ b/tests/spec/collection_string_display.test.ry
@@ -95,4 +95,25 @@ describe("collection string display", ():
     xs = [x]
     expect(to_str(xs)).to_eq("[42]")
   )
+  it("should escape double quotes in list string", ():
+    xs = ["he said \"hi\""]
+    expected = "[\"he said \\\"hi\\\"\"]"
+    expect(to_str(xs)).to_eq(expected)
+  )
+  it("should escape backslash in list string", ():
+    xs = ["a\\b"]
+    expected = "[\"a\\\\b\"]"
+    expect(to_str(xs)).to_eq(expected)
+  )
+  it("should escape both quotes and backslash in list string", ():
+    xs = ["say \\\"hi\\\""]
+    expected = "[\"say \\\\\\\"hi\\\\\\\"\"]"
+    expect(to_str(xs)).to_eq(expected)
+  )
+  it("should escape double quotes in any-typed list string", ():
+    x: any = "he said \"hi\""
+    xs = [x]
+    expected = "[\"he said \\\"hi\\\"\"]"
+    expect(to_str(xs)).to_eq(expected)
+  )
 )


### PR DESCRIPTION
## Summary

- Introduce shared runtime helper `__ry_str_quote_escape` that wraps a string in double quotes with proper escaping of `"` and `\`
- Replace inline codegen path (`codegen_tostring.cpp`) and runtime path (`runtime_any.cpp`) with calls to the shared helper
- Add 4 test cases covering strings with quotes, backslashes, and any-typed variants

Closes #772

## Test plan

- [x] New tests for `"`, `\`, and combined escaping in collection display
- [x] All 24 collection_string_display tests pass
- [x] C++ tests: 1454 passed
- [x] Ry self-tests: 97 files, 0 failures
- [x] ASan build: all tests pass, no memory issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed string rendering inside collections so double quotes and backslashes are escaped correctly in displayed output.

* **Tests**
  * Added coverage verifying quotes and backslashes are properly escaped in lists, maps, and any-typed elements.

* **Changelog**
  * Added an entry describing the collection string-escaping fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->