### PR TITLE
fix: add ARC retain and scope cleanup to lambda return paths

### DIFF
--- a/changelog.d/789-lambda-arc-return.md
+++ b/changelog.d/789-lambda-arc-return.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Expression-bodied lambdas now correctly retain ARC references and clean up scope before returning, preventing potential use-after-free when returning captured ARC-managed values (#789)

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -393,12 +393,17 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
                 codegenError("lambda expression return type mismatch: expected '" +
                     reverseResolveTypeName(retTy) + "', found '" +
                     reverseResolveTypeName(val->getType()) + "'");
+            // Retain return value before scope cleanup to prevent dangling pointer
+            // when returning a value loaded from an ARC-managed captured variable
+            tryRetainArcSource(val);
+            emitScopeCleanupToDepth(0);
             builder_.CreateRet(val);
         } else {
             for (auto &stmt : e->body)
                 std::visit([this](auto &st) { emitStmt(st); }, stmt);
 
             if (!builder_.GetInsertBlock()->getTerminator()) {
+                emitScopeCleanupToDepth(0);
                 if (retTy->isVoidTy())
                     builder_.CreateRetVoid();
                 else if (isAnyType(retTy))

--- a/tests/spec/lambda_arc_return.test.ry
+++ b/tests/spec/lambda_arc_return.test.ry
@@ -1,0 +1,34 @@
+describe("expression-bodied lambda ARC retain on return (#789)", ():
+  it("should return captured string without use-after-free", ():
+    s = "hello"
+    f = () => s
+    expect(f()).to_eq("hello")
+    expect(f()).to_eq("hello")
+  )
+
+  it("should return captured list without use-after-free", ():
+    xs = [1, 2, 3]
+    f = () -> List<int> => xs
+    result = f()
+    expect(result.length()).to_eq(3)
+    expect(result[0]).to_eq(1)
+    expect(result[2]).to_eq(3)
+  )
+
+  it("should return captured string after multiple calls", ():
+    msg = "world"
+    f = () => msg
+    a = f()
+    b = f()
+    expect(a).to_eq("world")
+    expect(b).to_eq("world")
+  )
+
+  it("should return captured list used by multiple lambdas", ():
+    xs = [10, 20]
+    f = () -> List<int> => xs
+    g = () -> List<int> => xs
+    expect(f()[0]).to_eq(10)
+    expect(g()[1]).to_eq(20)
+  )
+)


### PR DESCRIPTION
## Summary

- Add `tryRetainArcSource(val)` and `emitScopeCleanupToDepth(0)` before `CreateRet` in expression-bodied lambda return path, mirroring the named function return pattern
- Add `emitScopeCleanupToDepth(0)` to statement-bodied lambda default return path
- Prevents ARC-managed captured variable leaks and potential use-after-free

Closes #789

## Test plan

- [x] New test: `tests/spec/lambda_arc_return.test.ry` — captured string/list return from expression-bodied lambdas
- [x] All C++ tests pass (1454 tests)
- [x] All Ry self-tests pass (100 files, 0 failures)
- [x] ASan verification clean (no memory errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed expression-bodied lambdas to correctly retain and clean up captured values on return, preventing potential use-after-free errors.

* **Tests**
  * Added comprehensive test coverage validating correct behavior when returning captured values from lambdas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->