### PR TITLE
fix: use depth-tracking for nested parens in parseFnTypeAnnotation

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -915,6 +915,7 @@ public:
     llvm::Value *buildErrValue(llvm::Value *inner, llvm::StructType *resultTy);
     llvm::Value *buildStaticError(const std::string &msg, const std::string &globalName);
     static std::vector<std::string> splitTypeArgs(const std::string &argsStr);
+    static size_t findMatchingCloseParen(const std::string &s, size_t openParen);
     std::pair<llvm::Type*, llvm::Type*> parseMapTypeAnnotation(const std::string &typeStr);
     FnTypeInfo parseFnTypeAnnotation(const std::string &typeStr);
     void emitRuntimeError(const std::string &message, const std::string &globalName,

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -349,8 +349,10 @@ llvm::Type *CodeGen::getTaskResultType(llvm::Value *taskVal) {
 }
 
 size_t CodeGen::findMatchingCloseParen(const std::string &s, size_t openParen) {
-    int depth = 0;
-    for (size_t i = openParen; i < s.size(); ++i) {
+    if (openParen >= s.size() || s[openParen] != '(')
+        return std::string::npos;
+    int depth = 1;
+    for (size_t i = openParen + 1; i < s.size(); ++i) {
         if (s[i] == '(') ++depth;
         else if (s[i] == ')' && --depth == 0)
             return i;

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -348,13 +348,25 @@ llvm::Type *CodeGen::getTaskResultType(llvm::Value *taskVal) {
     return getTypeMeta(TypeMeta::TaskResult, taskVal);
 }
 
+size_t CodeGen::findMatchingCloseParen(const std::string &s, size_t openParen) {
+    int depth = 0;
+    for (size_t i = openParen; i < s.size(); ++i) {
+        if (s[i] == '(') ++depth;
+        else if (s[i] == ')' && --depth == 0)
+            return i;
+    }
+    return std::string::npos;
+}
+
 CodeGen::FnTypeInfo CodeGen::parseFnTypeAnnotation(const std::string &typeStr) {
     // Parse "function(int, float) -> int"
     FnTypeInfo info;
     // Find the opening paren
     size_t openParen = typeStr.find('(');
-    size_t closeParen = typeStr.find(')');
-    if (openParen == std::string::npos || closeParen == std::string::npos)
+    if (openParen == std::string::npos)
+        codegenError("invalid function type: " + typeStr);
+    size_t closeParen = findMatchingCloseParen(typeStr, openParen);
+    if (closeParen == std::string::npos)
         codegenError("invalid function type: " + typeStr);
 
     std::string paramStr = typeStr.substr(openParen + 1, closeParen - openParen - 1);

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -201,3 +201,42 @@ TEST_F(CodeGenTest, StructInequalityStillWorks) {
         "print(p != q)\n"
     ), "true\n");
 }
+
+// ============================================================
+// findMatchingCloseParen — depth-tracking paren matcher (#768)
+// ============================================================
+
+TEST(FindMatchingCloseParen, Simple) {
+    // function(int) -> int
+    //         ^   ^
+    //         8   12
+    std::string s = "function(int) -> int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), 12u);
+}
+
+TEST(FindMatchingCloseParen, Nested) {
+    // function(function() -> int) -> int
+    //         ^                 ^
+    //         8                 26
+    std::string s = "function(function() -> int) -> int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), 26u);
+}
+
+TEST(FindMatchingCloseParen, DeeplyNested) {
+    // function(function(function() -> int) -> int) -> int
+    //         ^                                  ^
+    std::string s = "function(function(function() -> int) -> int) -> int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), 43u);
+}
+
+TEST(FindMatchingCloseParen, MultipleParamsWithNested) {
+    // function(int, function() -> int) -> int
+    //         ^                      ^
+    std::string s = "function(int, function() -> int) -> int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), 31u);
+}
+
+TEST(FindMatchingCloseParen, NoMatch) {
+    std::string s = "function(int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), std::string::npos);
+}


### PR DESCRIPTION
## Summary

- Replace `typeStr.find(')')` with depth-tracking `findMatchingCloseParen()` in `parseFnTypeAnnotation` to correctly handle nested function types like `function(function() -> int) -> int`
- Extract paren-matching logic as a reusable `static` method on `CodeGen`
- Add 5 C++ unit tests covering simple, nested, deeply nested, multi-param, and no-match cases

Closes #768

## Test plan

- [x] All 5 `FindMatchingCloseParen` tests pass
- [x] Full C++ test suite passes (1460 tests)
- [x] Full Ry self-test suite passes (100 files)
- [x] ASan build passes with no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type/function signature parsing so nested parentheses are handled correctly, preventing incorrect parsing and spurious errors for complex type annotations.
  * Error reporting refined to only trigger when a matching closing parenthesis truly cannot be found.

* **Tests**
  * Added unit tests covering simple, nested, deep-nested, multi-parameter with nested parentheses, and missing-closing-parenthesis cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->