### PR TITLE
feat: add type_of builtin and Type primitive (#793)

### DIFF
--- a/changelog.d/793-type-of-builtin.md
+++ b/changelog.d/793-type-of-builtin.md
@@ -1,0 +1,4 @@
+### Added
+
+- `type_of(expr)` built-in function that returns a `Type` value representing the compile-time type identity of its argument. Supports `==` / `!=` for identity-based comparison and is printable via `print` / `to_str`. Covers primitives, low-level numeric types, collections (`List`, `Map`, `Set`), records, enums, `Option`, `Result`, functions/closures, `None`, and `Type` itself (reflective) (#793)
+- `Type` primitive type representing the compile-time identity of a Ry type. Each distinct type definition receives a unique identity, so different records (or a record and an enum sharing a name) are always distinguishable by `==` (#793)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -667,6 +667,7 @@ Returns the type of an expression as a [`Type`](types.md#type) value. Every dist
 - The argument is evaluated for side effects but only its static type is used.
 - Printing a `Type` value via `print` or `to_str` yields the human-readable name (for example, `"int"`, `"List"`, `"Point"`).
 - Two expressions with the same canonical type return equal `Type` values; different records (or a record and an enum that happen to share a name) are always distinguishable.
+- The bare `none` literal reports as `"None"`. A typed `Option<T>` value (whether constructed via `Some(...)` or assigned from `none`) reports as `"Option"`.
 
 ```ry
 record Point:
@@ -716,10 +717,14 @@ print(to_str(type_of(type_of(42)))) # Type
 | `[1, 2]` | `List` |
 | `{"a": 1}` | `Map` |
 | `{1, 2}` | `Set` |
-| `val x: i32 = 1` | `i32` (and similarly for `u8`, `i16`, …, `f32`) |
+| `x: i32 = 1` | `i32` (and similarly for `u8`, `i16`, …, `f32`) |
 | record value | record name (e.g. `Point`) |
 | enum value | enum name (e.g. `Color`) |
-| `Some(1)` / `None` (typed) | `Option` |
+| `none` literal | `None` |
+| `Some(1)` | `Option` |
+| `x: Option<int> = none` | `Option` |
 | `Ok(1)` / `Err(e)` | `Result` |
 | lambda / closure | `function` |
 | `type_of(x)` | `Type` |
+
+> The bare `none` literal is reported as `"None"` to distinguish it from a typed `Option` value. Any `Option<T>` container — whether constructed via `Some(...)` or assigned from `none` to an `Option<T>`-typed binding — reports as `"Option"`.

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -22,6 +22,7 @@
 | `close(handle)` | Closes a `TcpStream`, `TlsStream`, or `TcpListener` |
 | `block_on(task)` | Blocks the current thread until a `Task<T>` completes and returns its result |
 | `to_str(value)` | Converts a value to its string representation (`int`, `float`, `bool`, `str`, record, enum, tuple, `List`, `Map`, `Set`, `Result`, `Option`). String elements inside collections are wrapped in double quotes (e.g., `["hello", "world"]`) |
+| `type_of(expr)` | Returns the type of `expr` as a `Type` value. See [type_of](#type_of) |
 | `fail()` / `fail(message)` | Marks the current test as failed (only available in `ry test` mode) |
 
 ### Option
@@ -654,3 +655,71 @@ xs = [1, 2, 3, 4, 5]
 ys = xs.iter().filter((x: int) => x > 2).to_list()
 print(ys)   # [3, 4, 5]
 ```
+
+---
+
+## type_of
+
+**Signature:** `type_of(expr: T) -> Type`
+
+Returns the type of an expression as a [`Type`](types.md#type) value. Every distinct type definition (primitive, collection, record, enum, `Option`, `Result`, function, etc.) receives a unique identity at compile time, so `type_of` values can be compared by `==` to check whether two expressions share the same type.
+
+- The argument is evaluated for side effects but only its static type is used.
+- Printing a `Type` value via `print` or `to_str` yields the human-readable name (for example, `"int"`, `"List"`, `"Point"`).
+- Two expressions with the same canonical type return equal `Type` values; different records (or a record and an enum that happen to share a name) are always distinguishable.
+
+```ry
+record Point:
+  x: int
+  y: int
+
+enum Color:
+  Red
+  Green
+  Blue
+
+print(to_str(type_of(42)))          # int
+print(to_str(type_of(3.14)))        # float
+print(to_str(type_of("hello")))     # str
+print(to_str(type_of([1, 2, 3])))   # List
+print(to_str(type_of({"a": 1})))    # Map
+print(to_str(type_of({1, 2})))      # Set
+
+p = Point(1, 2)
+print(to_str(type_of(p)))           # Point
+
+c = Color::Red
+print(to_str(type_of(c)))           # Color
+
+# identity comparison
+print(type_of(42) == type_of(100))  # true
+print(type_of(42) == type_of(3.14)) # false
+print(type_of(p) != type_of(c))     # true
+
+# low-level numeric types are distinguished from `int`
+x: i32 = 1
+print(to_str(type_of(x)))           # i32
+print(type_of(x) == type_of(42))    # false
+
+# type_of is reflective: the type of a Type value is Type
+print(to_str(type_of(type_of(42)))) # Type
+```
+
+### Type categories returned by `type_of`
+
+| Input | `to_str(type_of(...))` |
+|---|---|
+| `42` | `int` |
+| `3.14` | `float` |
+| `true` / `false` | `bool` |
+| `"hello"` | `str` |
+| `[1, 2]` | `List` |
+| `{"a": 1}` | `Map` |
+| `{1, 2}` | `Set` |
+| `val x: i32 = 1` | `i32` (and similarly for `u8`, `i16`, …, `f32`) |
+| record value | record name (e.g. `Point`) |
+| enum value | enum name (e.g. `Color`) |
+| `Some(1)` / `None` (typed) | `Option` |
+| `Ok(1)` / `Err(e)` | `Result` |
+| lambda / closure | `function` |
+| `type_of(x)` | `Type` |

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -21,6 +21,7 @@
 | User-defined type | LLVM StructType (named) | `record Point: ...` | Struct defined with the `record` keyword |
 | `enum` | i64 / tagged union | `Color::Red`, `Shape::Circle(3.14)` | Enumeration defined with the `enum` keyword (supports associated data) |
 | `Error` | `{ ptr, i64 }` | `Error("msg")`, `Error("msg", 404)` | Built-in error type |
+| `Type` | `{ i64, ptr }` | `type_of(42)` | Compile-time type identity returned by `type_of`. See [Type](#type) |
 | `any` | `{ i64, [8 x i8] }` | `x: any = 42` | Tagged union that can hold any primitive value |
 | `T1 \| T2` | `{ i64, [N x i8] }` | `int \| str` | Union type (holds one of multiple types) |
 | Int literal | i64 | `42`, `0 \| 1` | Int literal type (value constraint) |
@@ -511,6 +512,31 @@ make_ok(1)  != Err(Error("e"))  # true
 
 `Error` is represented as `{ ptr message, i64 code }`.
 `Result<V, E>` is represented as `{ i1 isOk, V okValue, E errValue }`.
+
+## Type
+
+`Type` is the value returned by the built-in [`type_of`](builtins.md#type_of) function. It represents the compile-time identity of a type and allows reflective comparison at run time.
+
+```ry
+print(to_str(type_of(42)))          # int
+print(to_str(type_of([1, 2, 3])))   # List
+
+print(type_of(42) == type_of(100))  # true
+print(type_of(42) == type_of(3.14)) # false
+```
+
+Key properties:
+
+- Each distinct type definition (primitive, collection, record, enum, `Option`, `Result`, `function`, `Type` itself, etc.) receives a unique identity at compile time.
+- `==` / `!=` on `Type` values compare identities, not display names. Two different records (or a record and an enum with the same name) are always distinguishable.
+- `print` and `to_str` display the human-readable type name (for example, `"int"`, `"List"`, `"Point"`, `"i32"`).
+- Low-level numeric types (`i8`, `i16`, …, `f32`) are distinguished from `int` / `float`.
+- Collection generics collapse to their base name: `type_of([1, 2])` returns `"List"`, not `"List<int>"`.
+- `Type` is reflective: `type_of(type_of(x))` returns the `Type` value that represents `Type` itself.
+
+### Internal Representation
+
+`Type` is represented as `{ i64 id, ptr name }`. The `id` field is used for equality and the `name` field is used for display. Both fields are populated at compile time by `type_of`.
 
 ## Union Type
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -137,6 +137,7 @@ public:
     llvm::StructType *iteratorHeaderTy_;
     llvm::StructType *errorTy_;
     llvm::StructType *anyTy_;
+    llvm::StructType *typeTy_;            // { i64 id, ptr name } — returned by type_of
 
     // ======== ARC Infrastructure ========
     // Resource kind IDs are assigned dynamically by ResourceKindRegistry.
@@ -281,8 +282,16 @@ public:
         std::vector<FieldDef> fields;
         std::vector<ExprPtr> invariants;
         std::string parentName;
+        int64_t type_id = -1;   // unique identity for type_of
     };
     std::unordered_map<std::string, StructInfo> struct_types_;
+
+    // Type ID registry for type_of builtin.
+    // Each distinct type definition gets a unique id, allowing identity-based
+    // equality on values returned by type_of (rather than name-based comparison).
+    int64_t next_type_id_ = 0;
+    std::unordered_map<std::string, int64_t> canonical_type_ids_;
+    int64_t getOrAllocateCanonicalTypeId(const std::string &canonicalName);
     std::unordered_map<std::string, std::string> type_aliases_;
     std::unordered_map<llvm::Type*, llvm::StructType*> option_types_;
     std::map<std::pair<llvm::Type*, llvm::Type*>, llvm::StructType*> result_types_;
@@ -321,6 +330,7 @@ public:
         llvm::StructType *adtType = nullptr;   // { i64 tag, [N x i8] payload }
         size_t maxPayloadSize = 0;
         std::unordered_map<std::string, VariantFieldInfo> variantFields;
+        int64_t type_id = -1;   // unique identity for type_of
     };
     std::unordered_map<std::string, EnumInfo> enum_types_;
     EnumVariantRegistry buildEnumVariantRegistry() const;
@@ -1119,6 +1129,9 @@ public:
     llvm::Value *emitBuiltinHigherOrder(const CallExpr &e, llvm::Value *preEmittedArg0 = nullptr);
     llvm::Value *emitSortCore(llvm::Value *listVal, const std::vector<ExprPtr> &args, const std::string &callee);
     llvm::Value *emitBuiltinQuery(const CallExpr &e);
+    llvm::Value *emitTypeOf(const CallExpr &e);
+    std::pair<int64_t, std::string> resolveTypeOfKey(llvm::Value *val);
+    llvm::Value *buildTypeValue(int64_t id, const std::string &name);
     llvm::Value *emitBuiltinSetOps(const CallExpr &e);
     llvm::Value *emitSubsetCheck(llvm::Value *iterSet, llvm::Value *lookupSet,
                                   const std::string &prefix);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -34,7 +34,7 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
         std::vector<FieldDef> errorFields;
         errorFields.push_back({"message", TypeNode::makeBasic("str"), {}});
         errorFields.push_back({"code", TypeNode::makeBasic("int"), {}});
-        struct_types_["Error"] = {errorTy_, std::move(errorFields), {}, ""};
+        struct_types_["Error"] = {errorTy_, std::move(errorFields), {}, "", next_type_id_++};
     }
 
     listHeaderTy_ = llvm::StructType::create(*ctx_, {i64Ty_, i64Ty_, ptrTy_}, "ListHeader");
@@ -45,6 +45,20 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
 
     anyTy_ = llvm::StructType::create(
         *ctx_, {i64Ty_, llvm::ArrayType::get(i8Ty_, 8)}, "Any");
+
+    typeTy_ = llvm::StructType::create(*ctx_, {i64Ty_, ptrTy_}, "Type");
+
+    // Pre-allocate canonical type IDs for primitives, collections, and other
+    // built-in types so that type_of returns stable identities across a compile.
+    for (const char *name : {
+             "int", "float", "bool", "str", "any", "Unit",
+             "i8", "i16", "i32", "i64",
+             "u8", "u16", "u32", "u64", "f32",
+             "List", "Map", "Set",
+             "Option", "Result",
+             "None", "function", "Type"}) {
+        canonical_type_ids_[name] = next_type_id_++;
+    }
 
     fnTy_ptr_to_ptr_       = llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
     fnTy_ptr_to_i64_       = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
@@ -60,6 +74,12 @@ llvm::FunctionCallee CodeGen::getRuntimeFn(const char *name, llvm::Type *retTy,
                                             llvm::ArrayRef<llvm::Type*> argTys) {
     auto *fnTy = llvm::FunctionType::get(retTy, argTys, false);
     return mod_->getOrInsertFunction(name, fnTy);
+}
+
+int64_t CodeGen::getOrAllocateCanonicalTypeId(const std::string &canonicalName) {
+    auto [it, inserted] = canonical_type_ids_.try_emplace(canonicalName, next_type_id_);
+    if (inserted) ++next_type_id_;
+    return it->second;
 }
 
 llvm::Constant *CodeGen::buildArcGlobal(

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -54,9 +54,87 @@ llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
     return nullptr;
 }
 
+// ===== type_of builtin =====
+
+llvm::Value *CodeGen::buildTypeValue(int64_t id, const std::string &name) {
+    llvm::Constant *nameStr = cachedGlobalString(name, ".type_of_name");
+    return llvm::ConstantStruct::get(
+        typeTy_,
+        {llvm::ConstantInt::get(i64Ty_, id), nameStr});
+}
+
+std::pair<int64_t, std::string> CodeGen::resolveTypeOfKey(llvm::Value *val) {
+    const std::string &llName = getLowLevelTypeName(val);
+    if (!llName.empty())
+        return {getOrAllocateCanonicalTypeId(llName), llName};
+
+    // Metadata probes are type-guarded: LLVM interns ConstantInt across the
+    // module, so metadata attached to one constant site can alias to unrelated
+    // sites that share the same bit pattern.
+    if (auto *meta = getMeta(val)) {
+        llvm::Type *vt = val->getType();
+        if (!meta->enum_value_type.empty() && vt == i64Ty_) {
+            auto eit = enum_types_.find(meta->enum_value_type);
+            if (eit != enum_types_.end())
+                return {eit->second.type_id, meta->enum_value_type};
+        }
+        if (!meta->union_value_type.empty() && vt != i64Ty_) {
+            return {getOrAllocateCanonicalTypeId(meta->union_value_type),
+                    meta->union_value_type};
+        }
+        if (meta->fn_type_info.has_value() && vt == ptrTy_)
+            return {getOrAllocateCanonicalTypeId("function"), "function"};
+    }
+
+    // Collection kinds collapse to their base name without constructing the
+    // fully-qualified generic form that inferCollectionTypeName would build.
+    if (getMapKeyType(val))      return {getOrAllocateCanonicalTypeId("Map"), "Map"};
+    if (getListElementType(val)) return {getOrAllocateCanonicalTypeId("List"), "List"};
+    if (getSetElementType(val))  return {getOrAllocateCanonicalTypeId("Set"), "Set"};
+
+    llvm::Type *ty = val->getType();
+    if (ty == typeTy_)    return {getOrAllocateCanonicalTypeId("Type"), "Type"};
+    if (isOptionType(ty)) return {getOrAllocateCanonicalTypeId("Option"), "Option"};
+    if (isResultType(ty)) return {getOrAllocateCanonicalTypeId("Result"), "Result"};
+
+    if (auto *st = llvm::dyn_cast<llvm::StructType>(ty)) {
+        std::string adtName = findAdtEnumName(st);
+        if (!adtName.empty()) {
+            auto eit = enum_types_.find(adtName);
+            if (eit != enum_types_.end())
+                return {eit->second.type_id, adtName};
+        }
+        std::string name = findStructTypeName(st);
+        if (!name.empty()) {
+            auto sit = struct_types_.find(name);
+            if (sit != struct_types_.end())
+                return {sit->second.type_id, name};
+        }
+    }
+
+    std::string name = reverseResolveTypeName(ty);
+    return {getOrAllocateCanonicalTypeId(name), name};
+}
+
+llvm::Value *CodeGen::emitTypeOf(const CallExpr &e) {
+    requireArgs(e, 1);
+
+    // None literal is special — reported as "None" instead of "Option"
+    if (std::holds_alternative<NoneExpr>(e.args[0]->data)) {
+        return buildTypeValue(getOrAllocateCanonicalTypeId("None"), "None");
+    }
+
+    llvm::Value *val = emitExpr(*e.args[0]);
+    auto [id, name] = resolveTypeOfKey(val);
+    return buildTypeValue(id, name);
+}
+
 // ===== Builtin Query =====
 
 llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
+    if (e.callee == "type_of") {
+        return emitTypeOf(e);
+    }
     // ===== keys(map) — fall through for JsonValue =====
     if (e.callee == "keys") {
         requireArgs(e, 1);

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -118,13 +118,34 @@ std::pair<int64_t, std::string> CodeGen::resolveTypeOfKey(llvm::Value *val) {
 
 llvm::Value *CodeGen::emitTypeOf(const CallExpr &e) {
     requireArgs(e, 1);
+    const ExprNode &arg = *e.args[0];
 
-    // None literal is special — reported as "None" instead of "Option"
-    if (std::holds_alternative<NoneExpr>(e.args[0]->data)) {
+    // AST-level fast paths — these handle cases where running emitExpr would
+    // either destroy type information (low-level literal suffixes are dropped
+    // onto interned ConstantInt/ConstantFP values) or attach metadata to
+    // interned constants that then leaks to unrelated sites.
+
+    if (std::holds_alternative<NoneExpr>(arg.data))
         return buildTypeValue(getOrAllocateCanonicalTypeId("None"), "None");
+
+    // Literal numeric suffix (e.g. 1u16, 3.14f32) — read from the AST node
+    // directly because constant uniquing prevents metadata from surviving on
+    // the emitted Value.
+    {
+        std::string suffix = getExprLowLevelSuffix(arg);
+        if (!suffix.empty())
+            return buildTypeValue(getOrAllocateCanonicalTypeId(suffix), suffix);
     }
 
-    llvm::Value *val = emitExpr(*e.args[0]);
+    // Enum variant access (e.g. Color::Red) — decide the type from the AST so
+    // we never rely on metadata attached to interned i64 constants.
+    if (auto *ea = std::get_if<EnumAccessExpr>(&arg.data)) {
+        auto eit = enum_types_.find(ea->enum_name);
+        if (eit != enum_types_.end())
+            return buildTypeValue(eit->second.type_id, ea->enum_name);
+    }
+
+    llvm::Value *val = emitExpr(arg);
     auto [id, name] = resolveTypeOfKey(val);
     return buildTypeValue(id, name);
 }

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -301,6 +301,16 @@ llvm::Value *CodeGen::tryCallOperator(const std::string &callee,
 llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
                                         const std::string &lhsHint, const std::string &rhsHint) {
     const std::string &llNameHint = !lhsHint.empty() ? lhsHint : rhsHint;
+
+    // Type (from type_of) comparison: identity by id field only (ignore name)
+    if (lhs->getType() == typeTy_ && rhs->getType() == typeTy_ &&
+        (op == "==" || op == "!=")) {
+        llvm::Value *lid = builder_.CreateExtractValue(lhs, 0, "type_lhs_id");
+        llvm::Value *rid = builder_.CreateExtractValue(rhs, 0, "type_rhs_id");
+        if (op == "==") return builder_.CreateICmpEQ(lid, rid, "type_eq");
+        return builder_.CreateICmpNE(lid, rid, "type_ne");
+    }
+
     // Option type comparison with none: check has_value flag only
     // Only allowed when at least one side is Option and both sides are Option
     // (none is also an Option value with has_value=false)

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -425,7 +425,13 @@ llvm::Value *CodeGen::emitExprVariant(const EnumAccessExpr &e) {
         return adtVal;
     }
 
-    llvm::Value *val = llvm::ConstantInt::get(i64Ty_, vit->second);
+    // Wrap the interned ConstantInt in a Freeze instruction so that the
+    // enum_value_type metadata attaches to a unique Value. Attaching metadata
+    // directly to the interned constant would leak to unrelated int literals
+    // with the same bit pattern (see type_of enum misidentification test).
+    llvm::Value *val = builder_.CreateFreeze(
+        llvm::ConstantInt::get(i64Ty_, vit->second),
+        "enum." + e.enum_name + "." + e.variant_name);
     getOrCreateMeta(val).enum_value_type = e.enum_name;
     return val;
 }

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -52,8 +52,8 @@ void CodeGen::emitStmt(RecordStmt &s) {
             deprecated_fields_.insert(s.name + "." + f.name);
     }
 
-    struct_types_[s.name] = {structTy, std::move(allFields), std::move(s.invariants),
-                             parentName};
+    StructInfo info{structTy, std::move(allFields), std::move(s.invariants), parentName, next_type_id_++};
+    struct_types_[s.name] = std::move(info);
 }
 
 llvm::Value *CodeGen::emitStructConstructor(const StructInfo &info,

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -204,6 +204,7 @@ std::string CodeGen::reverseResolveType(llvm::Value *val) {
     if (ty == i16Ty_) return "i16";
     if (ty == i32Ty_) return "i32";
     if (ty == f32Ty_) return "f32";
+    if (ty == typeTy_) return "Type";
     if (isAnyType(ty)) return "any";
 
     if (ty == ptrTy_) {
@@ -268,6 +269,7 @@ std::vector<std::string> CodeGen::inferTypeArgs(
             else if (argTy == i1Ty_)  resolved = "bool";
             else if (argTy == i8Ty_)  resolved = "u8";
             else if (argTy == ptrTy_) resolved = "str";
+            else if (argTy == typeTy_) resolved = "Type";
             else if (isAnyType(argTy)) resolved = "any";
             else if (auto *st = llvm::dyn_cast<llvm::StructType>(argTy)) {
                 std::string sname = st->getName().str();

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -132,6 +132,7 @@ void CodeGen::instantiateGenericEnum(const std::string &fullName, const std::str
     EnumInfo info;
     info.name = fullName;
     info.variantCount = tmpl.variants.size();
+    info.type_id = next_type_id_++;
 
     bool hasADT = false;
     std::vector<llvm::Constant*> nameStrings;

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -540,6 +540,8 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 return sit->second.llvmType;
             // Known builtin return types
             const std::string &c = v->callee;
+            if (c == "type_of")
+                return typeTy_;
             if (c == "length" || c == "to_int" || c == "find")
                 return i64Ty_;
             // sum/min/max/first/last return the element type of the list argument
@@ -624,6 +626,7 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             if (elem.empty()) return "";
             return "Set<" + elem + ">";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CallExpr>>) {
+            if (v->callee == "type_of") return "Type";
             auto *overloads = findFunction(v->callee);
             if (overloads && !overloads->empty() && !(*overloads)[0].returnTypeName.empty())
                 return (*overloads)[0].returnTypeName;

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -706,6 +706,7 @@ std::string CodeGen::reverseResolveTypeName(llvm::Type *ty) {
     if (ty == f32Ty_) return "f32";
     if (ty == ptrTy_) return "str";
     if (isAnyType(ty)) return "any";
+    if (ty == typeTy_) return "Type";
     if (ty->isVoidTy()) return "Unit";
     if (auto *st = llvm::dyn_cast<llvm::StructType>(ty)) {
         std::string n = findStructTypeName(st);

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -74,6 +74,7 @@ void CodeGen::emitStmt(EnumStmt &s) {
     EnumInfo info;
     info.name = s.name;
     info.variantCount = s.variants.size();
+    info.type_id = next_type_id_++;
 
     // Check if any variant has associated data
     bool hasADT = false;

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -9,6 +9,11 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
     if (ty == anyTy_)
         return emitAnyToString(val, inCollection);
 
+    // Type value (from type_of): extract and return the name ptr directly
+    if (ty == typeTy_) {
+        return builder_.CreateExtractValue(val, 1, "type_name");
+    }
+
     // Enum value → variant name string
     {
         auto *evMeta = getMeta(val);

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -21,6 +21,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
     if (typeName == "str")   return ptrTy_;
     if (typeName == "Error") return errorTy_;
     if (typeName == "any")   return anyTy_;
+    if (typeName == "Type")  return typeTy_;
     if (typeName == "Unit")  return llvm::Type::getVoidTy(*ctx_);
     // Low-level numeric types
     if (typeName == "i8")    return i8Ty_;

--- a/tests/spec/type_of.test.ry
+++ b/tests/spec/type_of.test.ry
@@ -55,6 +55,22 @@ describe("type_of low-level numeric types", ():
     b: i32 = 1
     expect(type_of(a) != type_of(b)).to_be_true()
   )
+
+  it("should identify literal suffix u16 directly", ():
+    expect(to_str(type_of(1u16))).to_eq("u16")
+  )
+
+  it("should distinguish literal suffixes u16 and i16", ():
+    expect(type_of(1u16) != type_of(1i16)).to_be_true()
+  )
+
+  it("should distinguish literal suffixes u32 and u64", ():
+    expect(type_of(1u32) != type_of(1u64)).to_be_true()
+  )
+
+  it("should identify literal suffix f32", ():
+    expect(to_str(type_of(1.0f32))).to_eq("f32")
+  )
 )
 
 describe("type_of collections", ():
@@ -111,6 +127,15 @@ describe("type_of enums", ():
     c = TypeOfColor::Red
     expect(type_of(p) != type_of(c)).to_be_true()
   )
+
+  it("should not misidentify int literal sharing an enum variant value", ():
+    # Regression: LLVM interns ConstantInt, so an int literal that happens to
+    # equal an enum variant tag previously inherited the enum metadata.
+    c = TypeOfColor::Red
+    n = 0
+    expect(to_str(type_of(n))).to_eq("int")
+    expect(type_of(n) != type_of(c)).to_be_true()
+  )
 )
 
 describe("type_of Option", ():
@@ -124,6 +149,61 @@ describe("type_of Option", ():
     a = Some(1)
     expect(type_of(a) != type_of(42)).to_be_true()
   )
+
+  it("should report bare none literal as None", ():
+    expect(to_str(type_of(none))).to_eq("None")
+  )
+
+  it("should distinguish none literal from Some", ():
+    expect(type_of(none) != type_of(Some(1))).to_be_true()
+  )
+
+  it("should report a typed Option<int> binding as Option", ():
+    x: Option<int> = none
+    expect(to_str(type_of(x))).to_eq("Option")
+  )
+)
+
+describe("type_of Result", ():
+  it("should identify Ok", ():
+    function make_ok() -> Result<int, Error>:
+      return Ok(1)
+    r = make_ok()
+    expect(to_str(type_of(r))).to_eq("Result")
+  )
+
+  it("should identify Err", ():
+    function make_err() -> Result<int, Error>:
+      return Err(Error("oops"))
+    r = make_err()
+    expect(to_str(type_of(r))).to_eq("Result")
+  )
+
+  it("should identify Ok and Err as the same Result type", ():
+    function ok() -> Result<int, Error>:
+      return Ok(1)
+    function err() -> Result<int, Error>:
+      return Err(Error("oops"))
+    expect(type_of(ok()) == type_of(err())).to_be_true()
+  )
+)
+
+describe("type_of function/lambda", ():
+  it("should identify a lambda as function", ():
+    f = (x: int) => x + 1
+    expect(to_str(type_of(f))).to_eq("function")
+  )
+
+  it("should identify two different lambdas as the same function type", ():
+    f = (x: int) => x + 1
+    g = (x: int) => x * 2
+    expect(type_of(f) == type_of(g)).to_be_true()
+  )
+
+  it("should infer Type as the return type of an unannotated lambda body", ():
+    get_type = (x: int) => type_of(x)
+    expect(to_str(get_type(42))).to_eq("int")
+  )
 )
 
 describe("type_of is reflective", ():
@@ -131,6 +211,14 @@ describe("type_of is reflective", ():
     t1 = type_of(42)
     t2 = type_of("hello")
     expect(type_of(t1) == type_of(t2)).to_be_true()
+  )
+
+  it("should round-trip Type through a generic identity function", ():
+    function identity<T>(x: T) -> T:
+      return x
+    t = identity(type_of(1))
+    expect(to_str(t)).to_eq("int")
+    expect(type_of(t) == type_of(type_of(1))).to_be_true()
   )
 )
 

--- a/tests/spec/type_of.test.ry
+++ b/tests/spec/type_of.test.ry
@@ -1,0 +1,170 @@
+record TypeOfPoint:
+  x: int
+  y: int
+
+record TypeOfCircle:
+  radius: float
+
+enum TypeOfColor:
+  Red
+  Green
+  Blue
+
+enum TypeOfDirection:
+  North
+  South
+  East
+  West
+
+describe("type_of primitives", ():
+  it("should identify int", ():
+    expect(type_of(42) == type_of(100)).to_be_true()
+    expect(type_of(42) != type_of(3.14)).to_be_true()
+  )
+
+  it("should identify float", ():
+    expect(type_of(3.14) == type_of(2.71)).to_be_true()
+    expect(type_of(3.14) != type_of(42)).to_be_true()
+  )
+
+  it("should identify bool", ():
+    expect(type_of(true) == type_of(false)).to_be_true()
+    expect(type_of(true) != type_of(42)).to_be_true()
+  )
+
+  it("should identify str", ():
+    expect(type_of("hello") == type_of("world")).to_be_true()
+    expect(type_of("hello") != type_of(42)).to_be_true()
+  )
+)
+
+describe("type_of low-level numeric types", ():
+  it("should identify i32", ():
+    x: i32 = 1
+    y: i32 = 2
+    expect(type_of(x) == type_of(y)).to_be_true()
+  )
+
+  it("should distinguish i32 from int", ():
+    x: i32 = 1
+    expect(type_of(x) != type_of(42)).to_be_true()
+  )
+
+  it("should distinguish u8 from i32", ():
+    a: u8 = 1
+    b: i32 = 1
+    expect(type_of(a) != type_of(b)).to_be_true()
+  )
+)
+
+describe("type_of collections", ():
+  it("should identify List", ():
+    expect(type_of([1, 2]) == type_of([3, 4, 5])).to_be_true()
+  )
+
+  it("should identify Map", ():
+    expect(type_of({"a": 1}) == type_of({"b": 2})).to_be_true()
+  )
+
+  it("should identify Set", ():
+    expect(type_of({1, 2}) == type_of({3, 4})).to_be_true()
+  )
+
+  it("should distinguish List from Set", ():
+    expect(type_of([1, 2]) != type_of({1, 2})).to_be_true()
+  )
+
+  it("should distinguish List from Map", ():
+    expect(type_of([1, 2]) != type_of({"a": 1})).to_be_true()
+  )
+)
+
+describe("type_of records", ():
+  it("should identify same record type", ():
+    p1 = TypeOfPoint(1, 2)
+    p2 = TypeOfPoint(3, 4)
+    expect(type_of(p1) == type_of(p2)).to_be_true()
+  )
+
+  it("should distinguish different record types", ():
+    p = TypeOfPoint(1, 2)
+    c = TypeOfCircle(1.0)
+    expect(type_of(p) != type_of(c)).to_be_true()
+  )
+)
+
+describe("type_of enums", ():
+  it("should identify same enum type", ():
+    a = TypeOfColor::Red
+    b = TypeOfColor::Blue
+    expect(type_of(a) == type_of(b)).to_be_true()
+  )
+
+  it("should distinguish different enum types", ():
+    c = TypeOfColor::Red
+    d = TypeOfDirection::North
+    expect(type_of(c) != type_of(d)).to_be_true()
+  )
+
+  it("should distinguish enum from record", ():
+    p = TypeOfPoint(1, 2)
+    c = TypeOfColor::Red
+    expect(type_of(p) != type_of(c)).to_be_true()
+  )
+)
+
+describe("type_of Option", ():
+  it("should identify Some", ():
+    a = Some(1)
+    b = Some(2)
+    expect(type_of(a) == type_of(b)).to_be_true()
+  )
+
+  it("should distinguish Some from int", ():
+    a = Some(1)
+    expect(type_of(a) != type_of(42)).to_be_true()
+  )
+)
+
+describe("type_of is reflective", ():
+  it("type_of(type_of(x)) should be Type", ():
+    t1 = type_of(42)
+    t2 = type_of("hello")
+    expect(type_of(t1) == type_of(t2)).to_be_true()
+  )
+)
+
+describe("type_of to_str", ():
+  it("should stringify primitives", ():
+    expect(to_str(type_of(42))).to_eq("int")
+    expect(to_str(type_of(3.14))).to_eq("float")
+    expect(to_str(type_of(true))).to_eq("bool")
+    expect(to_str(type_of("hi"))).to_eq("str")
+  )
+
+  it("should stringify low-level numeric", ():
+    x: i32 = 1
+    expect(to_str(type_of(x))).to_eq("i32")
+  )
+
+  it("should stringify collections", ():
+    expect(to_str(type_of([1, 2]))).to_eq("List")
+    expect(to_str(type_of({"a": 1}))).to_eq("Map")
+    expect(to_str(type_of({1, 2}))).to_eq("Set")
+  )
+
+  it("should stringify records", ():
+    p = TypeOfPoint(1, 2)
+    expect(to_str(type_of(p))).to_eq("TypeOfPoint")
+  )
+
+  it("should stringify enums", ():
+    c = TypeOfColor::Red
+    expect(to_str(type_of(c))).to_eq("TypeOfColor")
+  )
+
+  it("should stringify Type itself", ():
+    t = type_of(42)
+    expect(to_str(type_of(t))).to_eq("Type")
+  )
+)


### PR DESCRIPTION
## Summary

Adds a `type_of(expr)` built-in function that returns a new `Type` primitive value representing the compile-time identity of its argument. Closes #793.

- `Type` is a new primitive backed by `{ i64 id, ptr name }`
- Each distinct type definition (record, enum, primitive, collection, `Option`, `Result`, `function`, `Type` itself) receives a unique compile-time id
- `==` / `!=` on `Type` values compare identity (id field only), not display name
- `print` / `to_str` on a `Type` value displays the human-readable type name
- Collection kinds collapse to their base name (`List`, `Map`, `Set`) without constructing the fully-qualified generic form
- Low-level numeric types (`i8`..`u64`, `f32`) are distinguished from `int` / `float`
- `None` literal reports as `"None"` rather than `"Option"`

## Design rationale

The original issue proposed returning a `str`, but string-based identity cannot distinguish two type definitions that share a name (e.g. a record and an enum both named `Foo`, which the compiler currently allows — tracked separately in #815). A dedicated `Type` primitive with monotonic compile-time ids provides Python-like identity comparison without the fragility.

## Test plan

- [x] New `tests/spec/type_of.test.ry` — 26 cases covering primitives, low-level numerics, collections, records, enums, `Option`, `Some` vs `int`, reflection (`type_of(type_of(x)) == Type`), and `to_str` output
- [x] Full C++ test suite (`./build/ry_tests`): 1460 passed
- [x] Full Ry self-test suite (`./build/ry test -p`): 101 files, 0 failures
- [x] ASan build + tests: both suites pass, no memory issues
- [x] Manual verification of `print(type_of(...))` output formats

## Documentation

- `docs/reference/builtins.md` — new `type_of` section with semantics, examples, and type-category table
- `docs/reference/types.md` — new `Type` primitive section covering identity semantics and internal representation
- `changelog.d/793-type-of-builtin.md` — CHANGELOG fragment

## Spun-out issues

Discovered while working on this feature:

- #815 — allow same-name record and enum to coexist (missing cross-validation)
- #816 — refactor: rename legacy `struct` terminology in codegen to `record`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added type_of(expr) builtin returning a Type value encoding compile-time type identity
  * Added Type primitive with identity-based ==/!= and printable representation; reflective queries (type_of(type_of(x))) supported
  * Covers primitives, low-level numeric variants, collections, records, enums, Option/Result, functions, None

* **Documentation**
  * Added reference docs for type_of() and Type behavior

* **Tests**
  * Added comprehensive tests validating type_of across supported categories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->