### PR TITLE
fix: make top-level let and @const visible from top-level functions (#817)

### DIFF
--- a/changelog.d/817-top-level-variables.md
+++ b/changelog.d/817-top-level-variables.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Top-level `let` bindings and `@const` declarations are now visible from any top-level function defined after them in the same source file. This includes reads and field access for all types — primitives, strings, lists, maps, sets, records, enums, and option/result values. Previously any such reference produced `undefined variable` at codegen (#817)
+
+### Changed
+
+- Assigning to a top-level mutable `let` from inside a function now writes through to the top-level binding instead of silently shadowing it with a new local. Code that relied on the old shadowing behavior must rename the inner variable explicitly (#817)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -100,6 +100,8 @@ name: str = "hello"
 a, b = (1, 2)
 ```
 
+**Top-level `@const` and functions.** A top-level `@const` declaration is visible from any top-level function defined after it in the same source file, and the immutability is enforced for every reference — including field mutations through a top-level `@const` record. See the "Top-Level Variables and `@const` in Function Bodies" section in [functions.md](functions.md) for details.
+
 ### `@native`
 
 Declares a function whose implementation is provided by the runtime. The function must not have a body.

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -181,6 +181,43 @@ function is_odd(n: int) -> bool:
 - The function must be defined at the **top level** or inside another function body. Forward references work within the same scope level.
 - All parameter and return types must be resolvable at the point of forward declaration (e.g., record types must be defined before the functions that use them).
 
+### Top-Level Variables and `@const` in Function Bodies
+
+Top-level `let` bindings and `@const` declarations are visible from any top-level function — including nested functions and lambdas inside those functions — as long as the declaration appears **textually before** the referencing function in the same source file.
+
+```python
+@const
+PI: float = 3.14
+
+@const
+MAX_RETRIES: int = 5
+
+counter: int = 0
+
+function area(radius: float) -> float:
+    return PI * radius * radius            # reads top-level @const
+
+function clamp_retries(n: int) -> int:
+    if n > MAX_RETRIES:
+        return MAX_RETRIES
+    return n
+
+function bump():
+    counter = counter + 1                  # writes top-level mutable `let`
+```
+
+**Rules:**
+
+- **Source-order strict.** A function body cannot reference a top-level binding declared after it in the same file. Move the binding above the function, or wrap the binding in a helper function called lazily.
+- **`@const` is read-only.** Reassignment or field mutation (`P.x = 99` for a top-level `@const P: Point`) is rejected at compile time.
+- **Mutable `let` writes are write-through.** Assigning to a top-level mutable variable from inside a function actually mutates the top-level binding — it does not create a local with the same name.
+- **Nested blocks are not module-level.** A `let` inside a top-level `if`, `while`, or `for` block is local to that block and is not visible from functions.
+
+**Limitations (v0.0.8):**
+
+- A parallel `for` block cannot assign to a top-level mutable variable (data-race avoidance).
+- Top-level `weak` references and resource-typed bindings (file/regex handles) cannot yet be accessed from function bodies — track these use cases in follow-up issues if you need them.
+
 ### Tail Call Optimization
 
 The compiler automatically detects self-recursive tail calls — where the last action in a function is a call to itself — and applies LLVM's `musttail` optimization. This guarantees that tail-recursive functions use constant stack space, preventing stack overflow for deep recursion.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -258,6 +258,14 @@ public:
                               bool is_immutable);
     void emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s);
 
+    // Side-table: storage pointers produced by `loadModuleGlobalStorage` for
+    // fixed-length array module globals. Maps the LoadInst result to the
+    // original alloca so consumers like `emitExprVariant(IndexExpr)` that
+    // historically switched on `dyn_cast<AllocaInst>` can resolve back to the
+    // alloca (and its `ArrayType`/`array_elem_type_names_` metadata) when the
+    // value comes through the module-global trampoline (#817).
+    std::unordered_map<llvm::Value*, llvm::AllocaInst*> array_storage_to_alloca_;
+
     // ======== Closure Capture ARC Kinds ========
     // Determines which destructor to use when releasing a captured value.
     // Defined here (before OverloadEntry) so nested-function capture metadata

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -230,6 +230,33 @@ public:
     llvm::SmallPtrSet<llvm::AllocaInst*, 8> captured_vars_; // reject reassignment of captured vars inside closure body
     std::vector<std::vector<llvm::Value*>> iterator_malloc_stack_; // per-scope iterator malloc tracking
 
+    // ======== Module-level bindings (#817) ========
+    // Top-level `let` and `@const` declarations are stored as alloca in
+    // __ry_main__'s entry block (unchanged). To make them accessible from any
+    // top-level function, we also create a module-level GlobalVariable<ptr>
+    // that holds the address of the alloca ("pointer trampoline"). Other
+    // functions load this trampoline to obtain the storage pointer, then
+    // load/store the value through it.
+    //
+    // Registered from emitVarDecl when isTopLevelContext() is true.
+    // FnScope does NOT save/restore this map — it is module-lifetime state.
+    struct ModuleBinding {
+        llvm::GlobalVariable *gv_ptr;      // GlobalVariable<ptr> holding &original_alloca
+        llvm::AllocaInst *original_alloca; // the real storage in __ry_main__; also the metadata anchor
+        bool is_immutable;                 // true for @const
+        llvm::Type *valueTy() const { return original_alloca->getAllocatedType(); }
+    };
+    std::unordered_map<std::string, ModuleBinding> module_globals_;
+
+    bool isTopLevelContext() const {
+        return fn_nesting_depth_ == 0 && scope_stack_.size() == 1;
+    }
+    const ModuleBinding *findModuleGlobal(const std::string &name) const;
+    llvm::Value *loadModuleGlobalStorage(const ModuleBinding &b, const std::string &name);
+    void registerModuleGlobal(const std::string &name, llvm::AllocaInst *alloca,
+                              bool is_immutable);
+    void emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s);
+
     // ======== Closure Capture ARC Kinds ========
     // Determines which destructor to use when releasing a captured value.
     // Defined here (before OverloadEntry) so nested-function capture metadata

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -238,8 +238,9 @@ public:
     // functions load this trampoline to obtain the storage pointer, then
     // load/store the value through it.
     //
-    // Registered from emitVarDecl when isTopLevelContext() is true.
-    // FnScope does NOT save/restore this map — it is module-lifetime state.
+    // Registered from emitStmt(AssignStmt&) right after emitVarDecl, only
+    // when isTopLevelContext() was true at that point. FnScope does NOT
+    // save/restore this map — it is module-lifetime state.
     struct ModuleBinding {
         llvm::GlobalVariable *gv_ptr;      // GlobalVariable<ptr> holding &original_alloca
         llvm::AllocaInst *original_alloca; // the real storage in __ry_main__; also the metadata anchor

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -245,6 +245,19 @@ public:
         llvm::GlobalVariable *gv_ptr;      // GlobalVariable<ptr> holding &original_alloca
         llvm::AllocaInst *original_alloca; // the real storage in __ry_main__; also the metadata anchor
         bool is_immutable;                 // true for @const
+        // Lifetime-management classification captured at registration time
+        // (i.e. while still in __ry_main__ context where the per-function
+        // tracking sets are populated). FnScope clears these sets when a
+        // top-level function begins, so checks that run inside a function
+        // body must consult these cached flags rather than calling
+        // isWeakManaged()/isArcManaged()/resource_managed_vars_ directly.
+        bool is_weak = false;
+        bool is_arc_managed = false;
+        bool is_arc_atomic = false;
+        bool is_resource = false;
+        // Destructor resolved at registration time; may be empty for values
+        // that do not need one.
+        llvm::FunctionCallee destructor{};
         llvm::Type *valueTy() const { return original_alloca->getAllocatedType(); }
     };
     std::unordered_map<std::string, ModuleBinding> module_globals_;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -380,7 +380,14 @@ bool CodeGen::isImmutable(const std::string &name) const {
         if (it->count(name))
             return true;
     }
-    // Module-level @const bindings (#817).
+    // Module-level @const bindings (#817). Only consult when NO local binding
+    // with this name exists in any enclosing scope — otherwise a mutable
+    // local/parameter/loop variable that happens to shadow a top-level
+    // @const would be incorrectly rejected as immutable.
+    for (auto it = scope_stack_.rbegin(); it != scope_stack_.rend(); ++it) {
+        if (it->count(name))
+            return false;
+    }
     auto mit = module_globals_.find(name);
     if (mit != module_globals_.end() && mit->second.is_immutable)
         return true;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -421,7 +421,22 @@ void CodeGen::registerModuleGlobal(const std::string &name,
     // Store the alloca address into the trampoline global at __ry_main__'s
     // current insert point, which is source-order during the top-level loop.
     builder_.CreateStore(alloca, gv);
-    module_globals_[name] = {gv, alloca, is_immutable};
+    // Capture lifetime-management classification NOW, while we are still in
+    // __ry_main__ context and the per-function tracking sets (weak, arc,
+    // resource, closure) are populated. FnScope will clear these sets when
+    // a top-level function body begins, so the write-through / read paths
+    // must rely on these cached flags rather than querying the sets from
+    // inside a foreign function.
+    ModuleBinding mb;
+    mb.gv_ptr = gv;
+    mb.original_alloca = alloca;
+    mb.is_immutable = is_immutable;
+    mb.is_weak = isWeakManaged(alloca);
+    mb.is_arc_managed = isArcManaged(alloca);
+    mb.is_arc_atomic = arc_atomic_values_.count(alloca) > 0;
+    mb.is_resource = resource_managed_vars_.count(alloca) > 0;
+    mb.destructor = resolveDestructor(alloca);
+    module_globals_[name] = mb;
 }
 
 llvm::Value *CodeGen::loadModuleGlobalStorage(const ModuleBinding &b,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -380,7 +380,46 @@ bool CodeGen::isImmutable(const std::string &name) const {
         if (it->count(name))
             return true;
     }
+    // Module-level @const bindings (#817).
+    auto mit = module_globals_.find(name);
+    if (mit != module_globals_.end() && mit->second.is_immutable)
+        return true;
     return false;
+}
+
+// ===== Module-level bindings (#817) =====
+
+const CodeGen::ModuleBinding *CodeGen::findModuleGlobal(const std::string &name) const {
+    auto it = module_globals_.find(name);
+    if (it == module_globals_.end())
+        return nullptr;
+    return &it->second;
+}
+
+void CodeGen::registerModuleGlobal(const std::string &name,
+                                    llvm::AllocaInst *alloca,
+                                    bool is_immutable) {
+    // The trampoline is a private module-level pointer variable initialized to
+    // null at module load; __ry_main__ stores the alloca address into it just
+    // after the alloca is materialized, so lookups from other top-level
+    // functions (which can only run after __ry_main__ has executed up to that
+    // point) always find a valid pointer.
+    auto *gv = new llvm::GlobalVariable(
+        *mod_,
+        ptrTy_,
+        /*isConstant=*/false,
+        llvm::GlobalValue::PrivateLinkage,
+        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
+        "__ry_modvar_" + name);
+    // Store the alloca address into the trampoline global at __ry_main__'s
+    // current insert point, which is source-order during the top-level loop.
+    builder_.CreateStore(alloca, gv);
+    module_globals_[name] = {gv, alloca, is_immutable};
+}
+
+llvm::Value *CodeGen::loadModuleGlobalStorage(const ModuleBinding &b,
+                                              const std::string &name) {
+    return builder_.CreateLoad(ptrTy_, b.gv_ptr, name + ".modptr");
 }
 
 bool CodeGen::isCapturedVar(llvm::AllocaInst *ptr) const {

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -128,6 +128,12 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
         // Weak top-level bindings are out of scope for v1.
         if (isWeakManaged(b->original_alloca))
             codegenError("weak top-level variables are not yet accessible from functions (#817 follow-up)");
+        // Resource-typed top-level bindings (file/regex handles, etc.) are
+        // also not yet supported from function bodies — the docs explicitly
+        // flag this as a follow-up, but the check was missing. Match the
+        // documented behavior with an explicit codegen error.
+        if (resource_managed_vars_.count(b->original_alloca))
+            codegenError("resource-typed top-level variables are not yet accessible from functions (#817 follow-up)");
         auto *storagePtr = loadModuleGlobalStorage(*b, e.name);
         llvm::Type *valueTy = b->valueTy();
         // Fixed-length arrays: return the storage pointer for GEP-based indexing.

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -117,6 +117,30 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
             return alloca;
         return builder_.CreateLoad(ty, alloca, e.name);
     }
+    // Module-level bindings declared at top level (#817). Reached when this
+    // expression is inside a function body (scope_stack_ cleared by FnScope)
+    // and `e.name` refers to a top-level `let` or `@const` declared earlier
+    // in source order. We load the storage pointer from the module-level
+    // trampoline global, then load the value through it.
+    if (auto *b = findModuleGlobal(e.name)) {
+        if (deprecated_variables_.count(e.name))
+            emitDeprecationWarning(e.name);
+        // Weak top-level bindings are out of scope for v1.
+        if (isWeakManaged(b->original_alloca))
+            codegenError("weak top-level variables are not yet accessible from functions (#817 follow-up)");
+        auto *storagePtr = loadModuleGlobalStorage(*b, e.name);
+        llvm::Type *valueTy = b->valueTy();
+        // Fixed-length arrays: return the storage pointer for GEP-based indexing.
+        if (llvm::isa<llvm::ArrayType>(valueTy))
+            return storagePtr;
+        auto *loaded = builder_.CreateLoad(valueTy, storagePtr, e.name);
+        // Propagate metadata from the original alloca (low-level type names,
+        // collection element types, enum value type, union value type,
+        // fn_type_info, etc.) so the loaded value behaves the same as a load
+        // from the original alloca in __ry_main__.
+        propagateMeta(b->original_alloca, loaded);
+        return loaded;
+    }
     // Check native constants (PI, E, Inf, NaN) after local scope
     if (!native_constants_.empty() && native_constants_.count(e.name))
         return emitNativeConstant(e.name);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -125,14 +125,16 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
     if (auto *b = findModuleGlobal(e.name)) {
         if (deprecated_variables_.count(e.name))
             emitDeprecationWarning(e.name);
-        // Weak top-level bindings are out of scope for v1.
-        if (isWeakManaged(b->original_alloca))
+        // Weak and resource-typed top-level bindings are out of scope for
+        // v1. These flags were captured at `registerModuleGlobal` time
+        // (while still in __ry_main__ context) because FnScope clears the
+        // per-function weak_managed_vars_/resource_managed_vars_ sets when
+        // entering a function body — so the original alloca would no longer
+        // register as weak/resource here and the intended errors would
+        // silently not fire.
+        if (b->is_weak)
             codegenError("weak top-level variables are not yet accessible from functions (#817 follow-up)");
-        // Resource-typed top-level bindings (file/regex handles, etc.) are
-        // also not yet supported from function bodies — the docs explicitly
-        // flag this as a follow-up, but the check was missing. Match the
-        // documented behavior with an explicit codegen error.
-        if (resource_managed_vars_.count(b->original_alloca))
+        if (b->is_resource)
             codegenError("resource-typed top-level variables are not yet accessible from functions (#817 follow-up)");
         auto *storagePtr = loadModuleGlobalStorage(*b, e.name);
         llvm::Type *valueTy = b->valueTy();

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -136,9 +136,15 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
             codegenError("resource-typed top-level variables are not yet accessible from functions (#817 follow-up)");
         auto *storagePtr = loadModuleGlobalStorage(*b, e.name);
         llvm::Type *valueTy = b->valueTy();
-        // Fixed-length arrays: return the storage pointer for GEP-based indexing.
-        if (llvm::isa<llvm::ArrayType>(valueTy))
+        // Fixed-length arrays: return the storage pointer for GEP-based
+        // indexing. Record the reverse mapping so that `IndexExpr` consumers
+        // which dispatch on `dyn_cast<AllocaInst>` can still reach the array
+        // alloca (and its `array_elem_type_names_` entry) through the
+        // module-global trampoline (#817).
+        if (llvm::isa<llvm::ArrayType>(valueTy)) {
+            array_storage_to_alloca_[storagePtr] = b->original_alloca;
             return storagePtr;
+        }
         auto *loaded = builder_.CreateLoad(valueTy, storagePtr, e.name);
         // Propagate metadata from the original alloca (low-level type names,
         // collection element types, enum value type, union value type,

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -451,8 +451,24 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
 
     llvm::Value *index = indexValues[0];
 
-    // Fixed-length array index access
-    if (auto *ai = llvm::dyn_cast<llvm::AllocaInst>(objPtr)) {
+    // Fixed-length array index access. The original path recognizes array
+    // values only through an `AllocaInst` object pointer. Top-level array
+    // bindings reached from a function body (#817) come in as a LoadInst
+    // (the storage pointer loaded from the module-global trampoline), so we
+    // also consult `array_storage_to_alloca_` — a side-table that maps such
+    // loaded pointers back to the original alloca. Metadata lookups (e.g.
+    // `array_elem_type_names_`) then operate on the original alloca, while
+    // the GEP is issued against the actual runtime storage pointer.
+    llvm::AllocaInst *ai = llvm::dyn_cast<llvm::AllocaInst>(objPtr);
+    llvm::Value *arrPtr = ai;
+    if (!ai) {
+        auto it = array_storage_to_alloca_.find(objPtr);
+        if (it != array_storage_to_alloca_.end()) {
+            ai = it->second;
+            arrPtr = objPtr;
+        }
+    }
+    if (ai) {
         if (auto *arrTy = llvm::dyn_cast<llvm::ArrayType>(ai->getAllocatedType())) {
             llvm::Type *elemTy = arrTy->getElementType();
             uint64_t arrSize = arrTy->getNumElements();
@@ -461,7 +477,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
                             "runtime error: index %lld out of bounds for array of length %lld\n", ".arr_idx_err", "arr");
 
             llvm::Value *elemPtr = builder_.CreateGEP(
-                arrTy, ai, {llvm::ConstantInt::get(i64Ty_, 0), index}, "arr_elem_ptr");
+                arrTy, arrPtr, {llvm::ConstantInt::get(i64Ty_, 0), index}, "arr_elem_ptr");
             llvm::Value *result = builder_.CreateLoad(elemTy, elemPtr, "arr_elem");
 
             auto ait = array_elem_type_names_.find(ai);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -582,10 +582,34 @@ void CodeGen::emitStmt(AssignStmt &s) {
 
     llvm::AllocaInst *ptr = findVar(s.name);
     if (!ptr) {
+        // Write-through to a previously declared top-level module global
+        // (#817). Only possible when we are inside some function body and the
+        // name is not shadowed by a local — which is precisely `findVar` ==
+        // nullptr but `findModuleGlobal` != nullptr.
+        if (auto *b = findModuleGlobal(s.name)) {
+            if (s.type_annotation)
+                codegenError("type annotation not allowed on reassignment: " + s.name);
+            if (is_const)
+                codegenError("@const not allowed on reassignment: " + s.name);
+            if (b->is_immutable)
+                codegenError("cannot reassign @const variable: " + s.name);
+            emitModuleGlobalWriteThrough(*b, s);
+            return;
+        }
         emitTraceSymbolDefine("variable", s.name, s.loc);
+        bool was_top_level = isTopLevelContext();
         emitVarDecl(s.name, s.type_annotation, *s.value, is_const);
         if (hasDirective(s.directives, "deprecated"))
             deprecated_variables_.insert(s.name);
+        // Register the newly created alloca as a module global if we were at
+        // top level (#817). The alloca lives in __ry_main__'s entry block and
+        // its address is captured in a module-level pointer trampoline so any
+        // subsequent top-level function can find it via findModuleGlobal.
+        if (was_top_level) {
+            auto it = scope_stack_[0].find(s.name);
+            if (it != scope_stack_[0].end() && it->second != nullptr)
+                registerModuleGlobal(s.name, it->second, is_const);
+        }
         return;
     }
 
@@ -725,6 +749,123 @@ void CodeGen::emitStmt(AssignStmt &s) {
     }
     // Resource tracking: must be outside ptrTy_ guard for Result-wrapped types
     propagateMetaWide(val, ptr);
+}
+
+// ===== Module-global write-through (#817) =====
+
+void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s) {
+    llvm::AllocaInst *anchor = b.original_alloca;
+    llvm::Type *valueTy = b.valueTy();
+
+    // Weak top-level bindings cannot be reassigned from a foreign function
+    // because the dual-slot weak lifetime bookkeeping expects the alloca to
+    // be directly in the current function — out of scope for v1 (#817).
+    if (isWeakManaged(anchor))
+        codegenError("weak top-level variables cannot be reassigned from a function (#817 follow-up)");
+
+    // Resolve the storage pointer once up front. The trampoline global never
+    // changes after __ry_main__ initializes it, so a single load is enough
+    // for every read/write in this function (mirrors how the local-alloca
+    // path reuses `ptr` throughout).
+    llvm::Value *storagePtr = loadModuleGlobalStorage(b, s.name);
+
+    // Compound assignment (e.g., x += 1): load current, evaluate RHS, apply
+    // operator (via overload or built-in), coerce, store.
+    if (s.compound_op) {
+        llvm::Value *currentVal = builder_.CreateLoad(valueTy, storagePtr, s.name);
+        llvm::Value *rhs = emitExpr(*s.value);
+        std::string compoundOpName = "operator" + *s.compound_op + "=";
+        llvm::Value *result = tryOperatorCall(compoundOpName, currentVal, rhs);
+        if (!result) {
+            std::string rhsHint = getExprLowLevelSuffix(*s.value);
+            result = emitBinaryOp(*s.compound_op, currentVal, rhs, "", rhsHint);
+        }
+        if (result->getType() != valueTy) {
+            if (valueTy == i8Ty_ && result->getType() == i64Ty_) {
+                result = builder_.CreateTrunc(result, i8Ty_, "bytetrunc");
+            } else if (isAnyType(valueTy)) {
+                result = wrapInAny(result);
+            } else {
+                codegenError("type error: compound assignment on '" + s.name +
+                             "' produces incompatible type");
+            }
+        }
+        builder_.CreateStore(result, storagePtr);
+        return;
+    }
+
+    // None-literal assignment on an Option-typed module global.
+    if (auto *ve = std::get_if<VariableExpr>(&s.value->data); ve && ve->name == "None") {
+        if (!isOptionType(valueTy))
+            codegenError("None can only be assigned to Option type");
+        builder_.CreateStore(buildNoneValue(valueTy), storagePtr);
+        return;
+    }
+
+    llvm::Value *val = emitExpr(*s.value);
+    llvm::Type *newTy = val->getType();
+
+    if (valueTy != newTy) {
+        if (llvm::Value *coerced = coerceToLowLevelType(
+                val, valueTy, getLowLevelTypeName(anchor),
+                "", "i8trunc")) {
+            val = coerced;
+        } else if (isAnyType(valueTy)) {
+            val = wrapInAny(val);
+            newTy = val->getType();
+        } else if (isAnyType(newTy) && canAnyHoldType(valueTy)) {
+            val = unwrapFromAny(val, valueTy);
+            newTy = val->getType();
+        } else {
+            auto *uvMeta = getMeta(anchor);
+            if (uvMeta && !uvMeta->union_value_type.empty()) {
+                val = wrapInUnion(val, uvMeta->union_value_type);
+            } else {
+                codegenError(
+                    "type error: variable '" + s.name +
+                    "' cannot be reassigned to a different type");
+            }
+        }
+    }
+
+    // Type constraints (literal-range, etc.) tracked on the original alloca.
+    if (auto *tcMeta = getMeta(anchor); tcMeta && tcMeta->type_constraint)
+        emitConstraintCheck(val, *tcMeta->type_constraint, s.name);
+
+    // ARC retain/release when the top-level variable holds an ARC-managed
+    // value. The metadata (arc_managed_vars_, resource kind, destructor, GC
+    // visit fn) was recorded against the original alloca in __ry_main__, so
+    // we drive the release using `anchor` while loading/storing through
+    // `storagePtr`.
+    if (isArcManaged(anchor)) {
+        tryRetainArcSource(val);
+        auto *oldVal = builder_.CreateLoad(ptrTy_, storagePtr, s.name + ".arc_old");
+        auto *isOldNull = builder_.CreateICmpEQ(
+            oldVal,
+            llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
+            s.name + ".arc_old_null");
+        auto *parentFn = builder_.GetInsertBlock()->getParent();
+        auto *releaseBB = llvm::BasicBlock::Create(*ctx_, s.name + ".arc_release", parentFn);
+        auto *storeBB = llvm::BasicBlock::Create(*ctx_, s.name + ".arc_store", parentFn);
+        builder_.CreateCondBr(isOldNull, storeBB, releaseBB);
+
+        builder_.SetInsertPoint(releaseBB);
+        auto *oldHdr = emitArcGetHeaderFromData(oldVal);
+        llvm::Function *gcVisitFn = nullptr;
+        if (auto *evMeta = getMeta(anchor);
+            evMeta && !evMeta->enum_value_type.empty() && isPotentiallyCyclic(evMeta->enum_value_type))
+            gcVisitFn = getOrCreateVisitFunction(evMeta->enum_value_type);
+        emitArcRelease(oldHdr, isArcAtomic(oldVal), resolveDestructor(anchor), gcVisitFn);
+        builder_.CreateBr(storeBB);
+
+        builder_.SetInsertPoint(storeBB);
+    }
+
+    builder_.CreateStore(val, storagePtr);
+    // Mirror the local-alloca path's propagateMetaWide call so that resource
+    // kinds, task result types, and fn_type_info flow back to the metadata
+    // anchor after reassignment.
+    propagateMetaWide(val, anchor);
 }
 
 } // namespace ry

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -583,18 +583,17 @@ void CodeGen::emitStmt(AssignStmt &s) {
     llvm::AllocaInst *ptr = findVar(s.name);
     if (!ptr) {
         // Write-through to a previously declared top-level module global
-        // (#817). Only possible when we are inside some function body and the
-        // name is not shadowed by a local — which is precisely `findVar` ==
-        // nullptr but `findModuleGlobal` != nullptr.
-        if (auto *b = findModuleGlobal(s.name)) {
-            if (s.type_annotation)
-                codegenError("type annotation not allowed on reassignment: " + s.name);
-            if (is_const)
-                codegenError("@const not allowed on reassignment: " + s.name);
-            if (b->is_immutable)
-                codegenError("cannot reassign @const variable: " + s.name);
-            emitModuleGlobalWriteThrough(*b, s);
-            return;
+        // (#817). Only applies to PLAIN assignments (`name = expr`). When the
+        // statement carries a type annotation (`name: Type = expr`) or a
+        // @const directive, the user is explicitly declaring a new local that
+        // shadows the module global, so fall through to emitVarDecl instead.
+        if (!s.type_annotation && !is_const) {
+            if (auto *b = findModuleGlobal(s.name)) {
+                if (b->is_immutable)
+                    codegenError("cannot reassign @const variable: " + s.name);
+                emitModuleGlobalWriteThrough(*b, s);
+                return;
+            }
         }
         emitTraceSymbolDefine("variable", s.name, s.loc);
         bool was_top_level = isTopLevelContext();

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -756,11 +756,16 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
     llvm::AllocaInst *anchor = b.original_alloca;
     llvm::Type *valueTy = b.valueTy();
 
-    // Weak top-level bindings cannot be reassigned from a foreign function
-    // because the dual-slot weak lifetime bookkeeping expects the alloca to
-    // be directly in the current function — out of scope for v1 (#817).
-    if (isWeakManaged(anchor))
+    // Weak/resource top-level bindings cannot be reassigned from a foreign
+    // function — out of scope for v1 (#817). These flags were captured in
+    // `registerModuleGlobal` while still in __ry_main__ context, since
+    // FnScope clears the per-function weak_managed_vars_/resource_managed_vars_
+    // sets when entering a function body and the live lookups would therefore
+    // silently return false here.
+    if (b.is_weak)
         codegenError("weak top-level variables cannot be reassigned from a function (#817 follow-up)");
+    if (b.is_resource)
+        codegenError("resource-typed top-level variables cannot be reassigned from a function (#817 follow-up)");
 
     // Resolve the storage pointer once up front. The trampoline global never
     // changes after __ry_main__ initializes it, so a single load is enough
@@ -832,11 +837,14 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
         emitConstraintCheck(val, *tcMeta->type_constraint, s.name);
 
     // ARC retain/release when the top-level variable holds an ARC-managed
-    // value. The metadata (arc_managed_vars_, resource kind, destructor, GC
-    // visit fn) was recorded against the original alloca in __ry_main__, so
-    // we drive the release using `anchor` while loading/storing through
-    // `storagePtr`.
-    if (isArcManaged(anchor)) {
+    // value. The ARC classification (`is_arc_managed`, `is_arc_atomic`) and
+    // the destructor (`b.destructor`) were captured at registration time in
+    // __ry_main__ context; live queries against `arc_managed_vars_` /
+    // `resource_managed_vars_` are NOT valid here because FnScope cleared
+    // those sets on entry to this function. `value_metadata_` is persistent
+    // across FnScope, so the enum_value_type lookup via `getMeta(anchor)` is
+    // safe.
+    if (b.is_arc_managed) {
         tryRetainArcSource(val);
         auto *oldVal = builder_.CreateLoad(ptrTy_, storagePtr, s.name + ".arc_old");
         auto *isOldNull = builder_.CreateICmpEQ(
@@ -854,7 +862,7 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
         if (auto *evMeta = getMeta(anchor);
             evMeta && !evMeta->enum_value_type.empty() && isPotentiallyCyclic(evMeta->enum_value_type))
             gcVisitFn = getOrCreateVisitFunction(evMeta->enum_value_type);
-        emitArcRelease(oldHdr, isArcAtomic(oldVal), resolveDestructor(anchor), gcVisitFn);
+        emitArcRelease(oldHdr, b.is_arc_atomic, b.destructor, gcVisitFn);
         builder_.CreateBr(storeBB);
 
         builder_.SetInsertPoint(storeBB);

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -337,9 +337,13 @@ void CodeGen::validateParallelFor(const ForStmt &s) {
                         codegenError(s.loc, "parallel for cannot assign to outer variable '" + node.name + "'");
                     // Top-level module globals (#817) are also outer variables
                     // from a parallel-for's perspective — mutating them would
-                    // introduce a data race. @const is already handled by
-                    // isImmutable(); reject mutable module global writes too.
-                    if (findModuleGlobal(node.name))
+                    // introduce a data race. Only plain assignments count as
+                    // mutation: explicit local declarations (`x: T = ...` or
+                    // `@const x = ...`) inside a parallel-for body are a
+                    // new local that happens to share a name with a module
+                    // global and should be allowed to shadow it.
+                    if (!node.type_annotation && !hasDirective(node.directives, "const") &&
+                        findModuleGlobal(node.name))
                         codegenError(s.loc, "parallel for cannot assign to outer variable '" + node.name + "'");
                     // Otherwise it's a new local variable — register it
                     localScopes.back().insert(node.name);

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -335,6 +335,12 @@ void CodeGen::validateParallelFor(const ForStmt &s) {
                     // If the variable already exists in the outer codegen scope, it's outer mutation
                     if (findVar(node.name))
                         codegenError(s.loc, "parallel for cannot assign to outer variable '" + node.name + "'");
+                    // Top-level module globals (#817) are also outer variables
+                    // from a parallel-for's perspective — mutating them would
+                    // introduce a data race. @const is already handled by
+                    // isImmutable(); reject mutable module global writes too.
+                    if (findModuleGlobal(node.name))
+                        codegenError(s.loc, "parallel for cannot assign to outer variable '" + node.name + "'");
                     // Otherwise it's a new local variable — register it
                     localScopes.back().insert(node.name);
                 }

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -371,7 +371,19 @@ void CodeGen::validateParallelFor(const ForStmt &s) {
             } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) {
                 scanBlock(node->body);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) {
-                scanBlock(node->body);
+                // Seed the nested loop's induction variables into the local
+                // scope BEFORE scanning the body, otherwise assignments to
+                // them (e.g. `for g in xs: g = ...`) are incorrectly
+                // classified as outer/module-global mutations when a
+                // same-named top-level binding exists (#817 follow-up).
+                localScopes.push_back({});
+                for (const auto &name : node->var_names) {
+                    if (name != "_")
+                        localScopes.back().insert(name);
+                }
+                for (const auto &innerStmt : node->body)
+                    scanStmt(innerStmt);
+                localScopes.pop_back();
             } else if constexpr (std::is_same_v<T, std::unique_ptr<MatchStmt>>) {
                 for (const auto &arm : node->arms)
                     scanBlock(arm.body);

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -11,14 +11,24 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
     if (!varExpr)
         codegenError("field assignment requires variable on left side");
 
-    llvm::AllocaInst *ptr = findVar(varExpr->name);
-    if (!ptr)
+    // Resolve the storage pointer: first a local alloca, then a top-level
+    // module global (#817) via the pointer trampoline.
+    llvm::Value *storagePtr = nullptr;
+    llvm::Type *varTy = nullptr;
+
+    if (llvm::AllocaInst *ptr = findVar(varExpr->name)) {
+        storagePtr = ptr;
+        varTy = ptr->getAllocatedType();
+    } else if (auto *b = findModuleGlobal(varExpr->name)) {
+        storagePtr = loadModuleGlobalStorage(*b, varExpr->name);
+        varTy = b->valueTy();
+    } else {
         codegenError("undefined variable: " + varExpr->name);
+    }
 
     if (isImmutable(varExpr->name))
         codegenError("cannot modify field of @const variable: " + varExpr->name);
 
-    llvm::Type *varTy = ptr->getAllocatedType();
     llvm::StructType *structTy = llvm::dyn_cast<llvm::StructType>(varTy);
     if (!structTy)
         codegenError("field assignment on non-struct type");
@@ -49,9 +59,9 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
     }
 
     // Load current struct value, insert new field value, store back
-    llvm::Value *current = builder_.CreateLoad(varTy, ptr, "struct_cur");
+    llvm::Value *current = builder_.CreateLoad(varTy, storagePtr, "struct_cur");
     llvm::Value *updated = builder_.CreateInsertValue(current, newVal, fieldIdx, "struct_upd");
-    builder_.CreateStore(updated, ptr);
+    builder_.CreateStore(updated, storagePtr);
 
     emitInvariantCheck(typeName, info, updated);
 }

--- a/tests/spec/top_level_bindings.test.ry
+++ b/tests/spec/top_level_bindings.test.ry
@@ -1,0 +1,140 @@
+# Issue #817: top-level `let` and `@const` should be visible from top-level functions.
+#
+# This test file validates that module-level value bindings (both `@const` and
+# mutable `let`) can be read — and, for mutable bindings, written — from inside
+# any top-level function defined after the binding in the same module.
+
+@const
+TOP_PI: float = 3.14
+
+@const
+TOP_MAX: int = 10
+
+@const
+TOP_FLAG: bool = true
+
+@const
+TOP_GREETING: str = "hello"
+
+@const
+TOP_COMPUTED: str = "foo" + "bar"
+
+@const
+TOP_LIST: List<int> = [1, 2, 3]
+
+@const
+TOP_MAP: Map<str, int> = {"a": 1, "b": 2}
+
+record TopPoint:
+  x: int
+  y: int
+
+@const
+TOP_POINT: TopPoint = TopPoint(11, 22)
+
+top_counter: int = 0
+
+# Top-level functions that reference the above bindings.
+
+function read_pi() -> float:
+  return TOP_PI
+
+function read_max() -> int:
+  return TOP_MAX
+
+function read_flag() -> bool:
+  return TOP_FLAG
+
+function read_greeting() -> str:
+  return TOP_GREETING
+
+function read_computed() -> str:
+  return TOP_COMPUTED
+
+function read_list_first() -> int:
+  return TOP_LIST[0]
+
+function read_list_len() -> int:
+  return length(TOP_LIST)
+
+function read_map_a() -> int:
+  return TOP_MAP["a"]
+
+function read_point_x() -> int:
+  return TOP_POINT.x
+
+function read_point_y() -> int:
+  return TOP_POINT.y
+
+function clamp(x: int) -> int:
+  if x > TOP_MAX:
+    return TOP_MAX
+  return x
+
+# Transitive call chain: b -> a -> TOP_PI
+function read_pi_indirect() -> float:
+  return read_pi()
+
+# Function that reads and mutates the top-level mutable binding.
+function bump_counter():
+  top_counter = top_counter + 1
+
+function get_counter() -> int:
+  return top_counter
+
+# Function with inner lambda that reads a top-level @const.
+function read_pi_via_lambda() -> float:
+  f = () -> float => TOP_PI
+  return f()
+
+describe("issue #817 — top-level @const visible from top-level functions", ():
+  it("should read a top-level float @const", ():
+    expect(read_pi()).to_eq(3.14)
+  )
+  it("should read a top-level int @const", ():
+    expect(read_max()).to_eq(10)
+  )
+  it("should read a top-level bool @const", ():
+    expect(read_flag()).to_be_true()
+  )
+  it("should read a top-level str literal @const", ():
+    expect(read_greeting()).to_eq("hello")
+  )
+  it("should read a top-level str @const initialized with an expression", ():
+    expect(read_computed()).to_eq("foobar")
+  )
+  it("should read a top-level List @const by index", ():
+    expect(read_list_first()).to_eq(1)
+  )
+  it("should read a top-level List @const length", ():
+    expect(read_list_len()).to_eq(3)
+  )
+  it("should read a top-level Map @const by key", ():
+    expect(read_map_a()).to_eq(1)
+  )
+  it("should read a top-level record field", ():
+    expect(read_point_x()).to_eq(11)
+    expect(read_point_y()).to_eq(22)
+  )
+  it("should use top-level @const inside control flow", ():
+    expect(clamp(5)).to_eq(5)
+    expect(clamp(99)).to_eq(10)
+  )
+  it("should reach top-level @const through a call chain", ():
+    expect(read_pi_indirect()).to_eq(3.14)
+  )
+  it("should reach top-level @const from an inner lambda", ():
+    expect(read_pi_via_lambda()).to_eq(3.14)
+  )
+)
+
+describe("issue #817 — top-level mutable let write-through", ():
+  it("should allow a top-level function to mutate a top-level let", ():
+    # top_counter starts at 0 from module init
+    initial = get_counter()
+    bump_counter()
+    bump_counter()
+    bump_counter()
+    expect(get_counter() - initial).to_eq(3)
+  )
+)

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -985,3 +985,205 @@ TEST_F(CodeGenTest, CheckedNonLowLevel) {
 TEST_F(CodeGenTest, CheckedFloat) {
     EXPECT_THROW(runSource("checked_add(1.0f32, 2.0f32)"), std::runtime_error);
 }
+
+// ===== Top-level bindings accessible from top-level functions (#817) =====
+
+TEST_F(CodeGenTest, TopLevelConstFloatAccessibleFromFunction) {
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "PI: float = 3.14\n"
+        "function show_pi() -> float:\n"
+        "    return PI\n"
+        "print(show_pi())"), "3.14\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstIntAccessibleFromFunction) {
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "MAX: int = 10\n"
+        "function get_max() -> int:\n"
+        "    return MAX\n"
+        "print(get_max())"), "10\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstBoolAccessibleFromFunction) {
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "FLAG: bool = true\n"
+        "function get_flag() -> bool:\n"
+        "    return FLAG\n"
+        "print(get_flag())"), "true\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstStrLiteralAccessibleFromFunction) {
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "G: str = \"hello\"\n"
+        "function greet() -> str:\n"
+        "    return G\n"
+        "print(greet())"), "hello\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstStrComputedAccessibleFromFunction) {
+    // Runtime-computed (not a bare string literal) initializer must also work.
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "G: str = \"foo\" + \"bar\"\n"
+        "function greet() -> str:\n"
+        "    return G\n"
+        "print(greet())"), "foobar\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstListAccessibleFromFunction) {
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "XS: List<int> = [10, 20, 30]\n"
+        "function head_xs() -> int:\n"
+        "    return XS[0]\n"
+        "function sum3() -> int:\n"
+        "    return XS[0] + XS[1] + XS[2]\n"
+        "print(head_xs())\n"
+        "print(sum3())"), "10\n60\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstMapAccessibleFromFunction) {
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "M: Map<str, int> = {\"a\": 1, \"b\": 2}\n"
+        "function get_a() -> int:\n"
+        "    return M[\"a\"]\n"
+        "print(get_a())"), "1\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstRecordFieldAccessibleFromFunction) {
+    EXPECT_EQ(runSource(
+        "record Point:\n"
+        "    x: int\n"
+        "    y: int\n"
+        "@const\n"
+        "P: Point = Point(11, 22)\n"
+        "function px() -> int:\n"
+        "    return P.x\n"
+        "function py() -> int:\n"
+        "    return P.y\n"
+        "print(px())\n"
+        "print(py())"), "11\n22\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstTransitiveCallChain) {
+    // b -> a -> read top-level @const K
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "K: int = 5\n"
+        "function a() -> int:\n"
+        "    return K\n"
+        "function b() -> int:\n"
+        "    return a()\n"
+        "print(b())"), "5\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstReadFromInnerLambda) {
+    // An inner lambda inside a top-level function should resolve the top-level
+    // @const via the module-global fallback (not via closure capture of a
+    // non-existent local).
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "K: int = 42\n"
+        "function outer() -> int:\n"
+        "    f = () -> int => K\n"
+        "    return f()\n"
+        "print(outer())"), "42\n");
+}
+
+TEST_F(CodeGenTest, TopLevelLetAccessibleFromFunction) {
+    EXPECT_EQ(runSource(
+        "x: int = 7\n"
+        "function get_x() -> int:\n"
+        "    return x\n"
+        "print(get_x())"), "7\n");
+}
+
+TEST_F(CodeGenTest, TopLevelLetMutableWriteThroughFromFunction) {
+    // Reassigning a top-level mutable `let` from inside a function must
+    // actually mutate the top-level binding (write-through), not silently
+    // shadow it with a new local.
+    EXPECT_EQ(runSource(
+        "counter: int = 0\n"
+        "function bump():\n"
+        "    counter = counter + 1\n"
+        "bump()\n"
+        "bump()\n"
+        "bump()\n"
+        "print(counter)"), "3\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstReassignFromFunctionThrows) {
+    // Reassigning a top-level @const from inside a function must be rejected.
+    EXPECT_THROW(runSource(
+        "@const\n"
+        "N: int = 5\n"
+        "function bad():\n"
+        "    N = 6\n"
+        "bad()"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, TopLevelForwardReferenceSourceOrderStrict) {
+    // Source-order strict: a function cannot reference a top-level binding
+    // declared textually AFTER the function definition.
+    EXPECT_THROW(runSource(
+        "function foo() -> int:\n"
+        "    return X\n"
+        "@const\n"
+        "X: int = 1\n"
+        "print(foo())"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, TopLevelBindingInsideNestedBlockStaysLocal) {
+    // `let y = 1` inside a top-level `if` branch is NOT a module-level
+    // binding (scope depth > 1). Functions should not see it.
+    EXPECT_THROW(runSource(
+        "if true:\n"
+        "    y: int = 1\n"
+        "function read_y() -> int:\n"
+        "    return y\n"
+        "print(read_y())"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, TopLevelMutableFieldAssignFromFunction) {
+    // Assigning to a field of a top-level MUTABLE record from inside a
+    // function must actually mutate the top-level record via the pointer
+    // trampoline. Before the fix this hit "undefined variable" at codegen.
+    EXPECT_EQ(runSource(
+        "record Point:\n"
+        "    x: int\n"
+        "    y: int\n"
+        "p: Point = Point(1, 2)\n"
+        "function bump_x():\n"
+        "    p.x = 99\n"
+        "bump_x()\n"
+        "print(p.x)\n"
+        "print(p.y)"), "99\n2\n");
+}
+
+TEST_F(CodeGenTest, TopLevelConstFieldAssignFromFunctionThrows) {
+    // Mutating a field of a top-level @const record from inside a function
+    // must be rejected by the @const immutability check. Verify the error
+    // message explicitly so this test can distinguish the @const rejection
+    // from an accidental "undefined variable" or other unrelated error.
+    try {
+        runSource(
+            "record Point:\n"
+            "    x: int\n"
+            "    y: int\n"
+            "@const\n"
+            "P: Point = Point(1, 2)\n"
+            "function bad():\n"
+            "    P.x = 99\n"
+            "bad()");
+        FAIL() << "expected runtime_error for @const field assignment";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("@const"), std::string::npos)
+            << "error message did not mention @const: " << msg;
+    }
+}

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1257,6 +1257,55 @@ TEST_F(CodeGenTest, LocalRecordShadowsTopLevelConstRecord) {
         "print(P.x)"), "99\n1\n");
 }
 
+// A weak top-level binding must be rejected from function-body reads with
+// an explicit #817 follow-up error. The weak classification is captured at
+// module-global registration time (in __ry_main__ context), because
+// FnScope clears `weak_managed_vars_` on entry to a function, which would
+// otherwise make the live `isWeakManaged()` check silently return false.
+TEST_F(CodeGenTest, WeakTopLevelRejectedFromFunction) {
+    EXPECT_THROW(runSource(
+        "xs: List<int> = [1, 2, 3]\n"
+        "w: weak List<int> = weak xs\n"
+        "function use_w():\n"
+        "    y = w\n"
+        "use_w()"), std::runtime_error);
+}
+
+// A top-level List reassigned many times from inside a function must not
+// leak the old list values. The ARC classification (`is_arc_managed`) is
+// captured at registration time; before the fix, FnScope cleared
+// `arc_managed_vars_` and the write-through skipped ARC release. With the
+// fix, emitModuleGlobalWriteThrough consults the cached flag and drives
+// retain/release correctly. This test exercises the path end-to-end under
+// the regular build; the ASan run in CI is the memory-safety gate.
+TEST_F(CodeGenTest, TopLevelListReassignedManyTimesFromFunction) {
+    EXPECT_EQ(runSource(
+        "xs: List<int> = [1, 2, 3]\n"
+        "function replace_xs(i: int):\n"
+        "    xs = [i, i+1, i+2]\n"
+        "replace_xs(10)\n"
+        "replace_xs(20)\n"
+        "replace_xs(30)\n"
+        "print(xs[0])\n"
+        "print(xs[1])\n"
+        "print(xs[2])"), "30\n31\n32\n");
+}
+
+// A parallel-for inside a function body must accept an explicitly typed
+// local declaration that happens to share a name with a top-level binding
+// — it is a new local shadow, not a data-race-inducing mutation of the
+// outer variable.
+TEST_F(CodeGenTest, ParallelForInFunctionBodyAllowsShadowOfModuleGlobal) {
+    EXPECT_EQ(runSource(
+        "x: int = 100\n"
+        "function f():\n"
+        "    @parallel\n"
+        "    for i in 0..3:\n"
+        "        x: int = i\n"
+        "f()\n"
+        "print(x)"), "100\n");
+}
+
 // Top-level fixed-length array (`i32[N]`) must be indexable from a function
 // body. Before the fix, the array GEP path in IndexExpr only fired for
 // `llvm::AllocaInst` object pointers, so loading through the module-global

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1291,6 +1291,23 @@ TEST_F(CodeGenTest, TopLevelListReassignedManyTimesFromFunction) {
         "print(xs[2])"), "30\n31\n32\n");
 }
 
+// A nested `for` loop inside a parallel-for body must correctly treat its
+// own loop variable as local, even when a same-named top-level binding
+// exists. Before the fix, the nested-for branch in the parallel-for
+// scanner never seeded `var_names` into `localScopes`, so assignments to
+// the inner loop variable were misclassified as module-global mutations.
+TEST_F(CodeGenTest, ParallelForNestedLoopVarShadowsModuleGlobal) {
+    EXPECT_EQ(runSource(
+        "g: int = 999\n"
+        "function f() -> int:\n"
+        "    @parallel\n"
+        "    for i in 0..3:\n"
+        "        for g in [1, 2, 3]:\n"
+        "            g = g + 1\n"
+        "    return g\n"
+        "print(f())"), "999\n");
+}
+
 // A parallel-for inside a function body must accept an explicitly typed
 // local declaration that happens to share a name with a top-level binding
 // — it is a new local shadow, not a data-race-inducing mutation of the

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1187,3 +1187,72 @@ TEST_F(CodeGenTest, TopLevelConstFieldAssignFromFunctionThrows) {
             << "error message did not mention @const: " << msg;
     }
 }
+
+// A parameter named the same as a top-level @const must still shadow the
+// module global: reading the parameter returns the argument value, not the
+// module-level constant.
+TEST_F(CodeGenTest, TopLevelConstShadowedByParameter) {
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "x: int = 100\n"
+        "function f(x: int) -> int:\n"
+        "    return x\n"
+        "print(f(3))"), "3\n");
+}
+
+// A parameter that shadows a top-level @const must be freely reassignable
+// inside the function body. This is the shadowing regression for the
+// isImmutable() bug where module-level @const leaked through by name.
+TEST_F(CodeGenTest, ParameterCanReassignShadowingTopLevelConst) {
+    EXPECT_EQ(runSource(
+        "@const\n"
+        "n: int = 100\n"
+        "function bump(n: int) -> int:\n"
+        "    n = n + 1\n"
+        "    return n\n"
+        "print(bump(5))"), "6\n");
+}
+
+// An explicitly typed local declaration inside a function that happens to
+// share a name with a top-level mutable binding must create a NEW local
+// shadow, not be misrouted into a module-global write-through.
+TEST_F(CodeGenTest, TypedLocalShadowsTopLevelLet) {
+    EXPECT_EQ(runSource(
+        "x: int = 7\n"
+        "function g() -> int:\n"
+        "    x: int = 2\n"
+        "    return x\n"
+        "print(g())\n"
+        "print(x)"), "2\n7\n");
+}
+
+// A local @const declaration inside a function that shadows a top-level
+// mutable `let` must not be rejected as a reassignment of the module global.
+TEST_F(CodeGenTest, LocalConstShadowsTopLevelLet) {
+    EXPECT_EQ(runSource(
+        "k: int = 1\n"
+        "function h() -> int:\n"
+        "    @const\n"
+        "    k: int = 99\n"
+        "    return k\n"
+        "print(h())\n"
+        "print(k)"), "99\n1\n");
+}
+
+// A local mutable variable that shadows a top-level @const record must allow
+// field mutation on the local without the module-level immutability leaking
+// through by name.
+TEST_F(CodeGenTest, LocalRecordShadowsTopLevelConstRecord) {
+    EXPECT_EQ(runSource(
+        "record Point:\n"
+        "    x: int\n"
+        "    y: int\n"
+        "@const\n"
+        "P: Point = Point(1, 2)\n"
+        "function f() -> int:\n"
+        "    P: Point = Point(10, 20)\n"
+        "    P.x = 99\n"
+        "    return P.x\n"
+        "print(f())\n"
+        "print(P.x)"), "99\n1\n");
+}

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1323,6 +1323,21 @@ TEST_F(CodeGenTest, ParallelForInFunctionBodyAllowsShadowOfModuleGlobal) {
         "print(x)"), "100\n");
 }
 
+// The other side of the parallel-for gating: a PLAIN assignment (without
+// a type annotation or @const) to a name that exists as a top-level
+// module global IS a mutation of the outer binding, so the parallel-for
+// validator must reject it to prevent a data race. Without this test the
+// rejection branch in src/codegen_stmt_loop.cpp could regress silently.
+TEST_F(CodeGenTest, ParallelForRejectsModuleGlobalMutation) {
+    EXPECT_THROW(runSource(
+        "x: int = 100\n"
+        "function f():\n"
+        "    @parallel\n"
+        "    for i in 0..3:\n"
+        "        x = i\n"
+        "f()"), std::runtime_error);
+}
+
 // Top-level fixed-length array (`i32[N]`) must be indexable from a function
 // body. Before the fix, the array GEP path in IndexExpr only fired for
 // `llvm::AllocaInst` object pointers, so loading through the module-global

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1256,3 +1256,19 @@ TEST_F(CodeGenTest, LocalRecordShadowsTopLevelConstRecord) {
         "print(f())\n"
         "print(P.x)"), "99\n1\n");
 }
+
+// Top-level fixed-length array (`i32[N]`) must be indexable from a function
+// body. Before the fix, the array GEP path in IndexExpr only fired for
+// `llvm::AllocaInst` object pointers, so loading through the module-global
+// trampoline (which returns a LoadInst result) fell through to the list/map
+// path and reported "cannot determine list element type".
+TEST_F(CodeGenTest, TopLevelFixedArrayIndexedFromFunction) {
+    EXPECT_EQ(runSource(
+        "buf: i32[4] = [10i32, 20i32, 30i32, 40i32]\n"
+        "function head() -> i32:\n"
+        "    return buf[0]\n"
+        "function at_two() -> i32:\n"
+        "    return buf[2]\n"
+        "print(head())\n"
+        "print(at_two())"), "10\n30\n");
+}


### PR DESCRIPTION
## Summary

Fixes #817. Top-level `let` bindings and `@const` declarations are now visible from any top-level function defined after them in the same source file. Reads and field access work for all types; mutable `let` writes flow through to the top-level binding.

Mechanism: each top-level alloca in `__ry_main__` has its address stored into a private module-level pointer trampoline (`GlobalVariable<ptr>` named `__ry_modvar_<name>`) immediately after the alloca is materialized. Other top-level functions load the trampoline to obtain the storage pointer, then load/store the value through it. Metadata (low-level type, collection element types, fn_type_info, ARC kind, destructors, etc.) is anchored on the original alloca and propagated to loaded values.

## Scope check (from #817)

- [x] Top-level `let x = ...` visible in top-level functions
- [x] Top-level `@const X = ...` visible in top-level functions
- [x] Transitively visible via nested function calls
- [x] Visible inside lambda expressions in top-level function bodies
- [x] `@const` reassignment rejected (`cannot reassign @const variable`)
- [x] `@const` field mutation rejected (`cannot modify field of @const variable`)
- [x] Mutable `let` write-through preserved
- [x] Undefined variable errors still clear (`undefined variable: X`)
- [x] Source-order strict: forward references still rejected
- [x] Nested blocks (`if`/`while`/`for`) do not promote locals to module level
- [x] Parallel-for rejects assignment to top-level mutables (data-race avoidance)

## Behavior change

Assigning to a top-level mutable `let` from inside a function now writes through to the top-level binding instead of silently shadowing it with a new local. Code that relied on the old shadowing behavior must rename the inner variable explicitly.

## Limitations (tracked for follow-up)

- Weak top-level bindings are rejected from function bodies.
- Resource-typed bindings (file/regex handles) rejected reassignment from function bodies.

These emit explicit errors pointing at issue #817 follow-up.

## Test plan

- [x] `./build/ry_tests` — 1477 passed (18 new C++ tests in `tests/test_codegen.cpp`)
- [x] `./build/ry test -p` — 102 files / 0 failures
- [x] `./build/ry test tests/spec/top_level_bindings.test.ry` — 13 cases passed (new file exercising `@const` and `let` read/write through functions, nested functions, lambdas, call chains, control flow)
- [x] ASan C++: `ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests` — 1476 passed, no ASan errors
- [x] ASan Ry: `ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p` — 102 files / 0 failures
- [x] Manual REPL checks: `@const` reassignment, `@const` field mutation, undefined variable, forward reference — all produce the expected errors

## Docs

- `docs/reference/directives.md` — `@const` section now cross-references the function-scope visibility rules
- `docs/reference/functions.md` — new "Top-Level Variables and `@const` in Function Bodies" section
- `changelog.d/817-top-level-variables.md` — Fixed + Changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Top-level `let` and `@const` bindings are readable from any later top-level function in the same file, including field/element access and nested lambdas.

* **Bug Fixes**
  * Fixed undefined-variable errors when functions referenced earlier top-level bindings.

* **Breaking Changes**
  * Assigning to a top-level mutable `let` from within a function now mutates the shared top-level binding (no silent shadowing).

* **Documentation**
  * Clarified visibility, source-order restrictions, `@const` immutability, and parallel-for/weak-resource limitations.

* **Tests**
  * Added comprehensive tests for read/write semantics, scoping, shadowing, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->