### PR TITLE
fix: flatten nested type alias unions recursively (#835)

### DIFF
--- a/changelog.d/835-nested-union-alias-flatten.md
+++ b/changelog.d/835-nested-union-alias-flatten.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Nested type aliases over union types are now fully flattened. Previously, given `type A = int | str; type B = A | bool`, declaring `x: B = 42` failed with *"type is not in union"* because the alias `A` inside the union was not expanded. `B` is now equivalent to `int | str | bool`, and overlapping members are deduplicated — so `type C = A | int` collapses to `int | str`, and `type D = B | A` (where `B` already transitively includes `A`) flattens to `bool | int | str` (#835)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -141,6 +141,18 @@ function describe(v: Simple) -> str:
   return to_str(v)
 ```
 
+Nested aliases whose union components are themselves aliases are flattened transparently, and duplicate members are deduplicated. The following three forms are equivalent:
+
+```python
+type A = int | str
+type B = A | bool          # same as `int | str | bool`
+type C = B | int           # same as `int | str | bool` (int is deduplicated)
+
+x: B = 42
+y: B = "hello"
+z: B = true
+```
+
 ---
 
 ## Literal Types

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1225,6 +1225,11 @@ public:
     // recursively expands alias components and deduplicates members,
     // returning the canonical sorted form (e.g. "bool | int | str").
     std::string flattenUnionWithAliases(const std::string &typeName);
+    // Flattens `typeName` and, if the result is still a union after dedupe,
+    // stores it as `union_value_type` metadata on `target`. Skips the write
+    // when the flattened form collapses to a single leaf (which would make
+    // downstream wrapInUnion lookups crash).
+    void storeFlattenedUnionMeta(llvm::Value *target, const std::string &typeName);
     bool isUnionType(const std::string &typeName);
     llvm::Value *wrapInUnion(llvm::Value *val, const std::string &unionTypeName);
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1221,6 +1221,10 @@ public:
     // ======== Union & Any Type Helpers ========
     std::vector<std::string> parseUnionComponents(const std::string &typeName);
     std::string normalizeUnionType(const std::string &typeName);
+    // Resolves typeName through type aliases and, for non-literal unions,
+    // recursively expands alias components and deduplicates members,
+    // returning the canonical sorted form (e.g. "bool | int | str").
+    std::string flattenUnionWithAliases(const std::string &typeName);
     bool isUnionType(const std::string &typeName);
     llvm::Value *wrapInUnion(llvm::Value *val, const std::string &unionTypeName);
 

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -261,13 +261,8 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         auto constraint = parseTypeConstraint(resolvedType);
         if (constraint)
             getOrCreateMeta(alloca).type_constraint = *constraint;
-        else if (isUnionType(resolvedType)) {
-            // Only store when the flattened form is still a union; dedupe
-            // collapse to a single leaf would break downstream wrapInUnion.
-            std::string flattened = flattenUnionWithAliases(*typeName);
-            if (isUnionType(flattened))
-                getOrCreateMeta(alloca).union_value_type = std::move(flattened);
-        }
+        else if (isUnionType(resolvedType))
+            storeFlattenedUnionMeta(alloca, *typeName);
     };
 
     auto bindMockContractParams = [&]() {

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -261,8 +261,13 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         auto constraint = parseTypeConstraint(resolvedType);
         if (constraint)
             getOrCreateMeta(alloca).type_constraint = *constraint;
-        else if (isUnionType(resolvedType))
-            getOrCreateMeta(alloca).union_value_type = flattenUnionWithAliases(*typeName);
+        else if (isUnionType(resolvedType)) {
+            // Only store when the flattened form is still a union; dedupe
+            // collapse to a single leaf would break downstream wrapInUnion.
+            std::string flattened = flattenUnionWithAliases(*typeName);
+            if (isUnionType(flattened))
+                getOrCreateMeta(alloca).union_value_type = std::move(flattened);
+        }
     };
 
     auto bindMockContractParams = [&]() {

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -100,7 +100,7 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
                 // Match: any type accepts all primitives; wrapping deferred to arg building
                 candidate.anyMatches++;
             } else if (isUnionType(resolvedParamTypeName)) {
-                std::string norm = normalizeUnionType(resolvedParamTypeName);
+                std::string norm = flattenUnionWithAliases(entry.paramTypeNames[i]);
                 auto uIt = union_type_info_.find(norm);
                 if (uIt != union_type_info_.end()) {
                     bool found = false;
@@ -262,7 +262,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         if (constraint)
             getOrCreateMeta(alloca).type_constraint = *constraint;
         else if (isUnionType(resolvedType))
-            getOrCreateMeta(alloca).union_value_type = normalizeUnionType(resolvedType);
+            getOrCreateMeta(alloca).union_value_type = flattenUnionWithAliases(*typeName);
     };
 
     auto bindMockContractParams = [&]() {

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -84,8 +84,14 @@ void CodeGen::applyParamTypeMeta(const std::string &ptype,
                 paramLLVMType, alloca, paramName + ".load");
             emitConstraintCheck(argVal, *constraint, paramName);
         } else {
-            if (isUnionType(resolvedPtype))
-                getOrCreateMeta(alloca).union_value_type = flattenUnionWithAliases(ptype);
+            // Only store when the flattened form is still a union — dedupe
+            // may collapse to a single leaf, which is unsafe for downstream
+            // wrapInUnion lookups that assume a union key.
+            if (isUnionType(resolvedPtype)) {
+                std::string flattened = flattenUnionWithAliases(ptype);
+                if (isUnionType(flattened))
+                    getOrCreateMeta(alloca).union_value_type = std::move(flattened);
+            }
         }
     }
 }

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -84,14 +84,8 @@ void CodeGen::applyParamTypeMeta(const std::string &ptype,
                 paramLLVMType, alloca, paramName + ".load");
             emitConstraintCheck(argVal, *constraint, paramName);
         } else {
-            // Only store when the flattened form is still a union — dedupe
-            // may collapse to a single leaf, which is unsafe for downstream
-            // wrapInUnion lookups that assume a union key.
-            if (isUnionType(resolvedPtype)) {
-                std::string flattened = flattenUnionWithAliases(ptype);
-                if (isUnionType(flattened))
-                    getOrCreateMeta(alloca).union_value_type = std::move(flattened);
-            }
+            if (isUnionType(resolvedPtype))
+                storeFlattenedUnionMeta(alloca, ptype);
         }
     }
 }

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -85,7 +85,7 @@ void CodeGen::applyParamTypeMeta(const std::string &ptype,
             emitConstraintCheck(argVal, *constraint, paramName);
         } else {
             if (isUnionType(resolvedPtype))
-                getOrCreateMeta(alloca).union_value_type = normalizeUnionType(resolvedPtype);
+                getOrCreateMeta(alloca).union_value_type = flattenUnionWithAliases(ptype);
         }
     }
 }

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -587,6 +587,12 @@ std::string CodeGen::flattenUnionWithAliases(const std::string &typeName) {
         }
     }
 
+    // Every expansion path cycled back into an already-visited union and
+    // no concrete leaf was ever found (e.g. `type A = B | C; type B = A;
+    // type C = A`). Reject instead of returning an empty type name.
+    if (out.empty())
+        codegenError("Circular type alias: " + typeName);
+
     return joinSortedUnion(out);
 }
 

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -596,6 +596,13 @@ std::string CodeGen::flattenUnionWithAliases(const std::string &typeName) {
     return joinSortedUnion(out);
 }
 
+void CodeGen::storeFlattenedUnionMeta(llvm::Value *target,
+                                      const std::string &typeName) {
+    std::string flattened = flattenUnionWithAliases(typeName);
+    if (isUnionType(flattened))
+        getOrCreateMeta(target).union_value_type = std::move(flattened);
+}
+
 llvm::Value *CodeGen::wrapInUnion(llvm::Value *val, const std::string &unionTypeName) {
     std::string norm = flattenUnionWithAliases(unionTypeName);
     auto infoIt = union_type_info_.find(norm);

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -599,8 +599,13 @@ std::string CodeGen::flattenUnionWithAliases(const std::string &typeName) {
 void CodeGen::storeFlattenedUnionMeta(llvm::Value *target,
                                       const std::string &typeName) {
     std::string flattened = flattenUnionWithAliases(typeName);
-    if (isUnionType(flattened))
-        getOrCreateMeta(target).union_value_type = std::move(flattened);
+    // Skip if dedupe collapsed to a single leaf, or if the canonical form
+    // is a literal union (e.g. `"N" | "S"`). Neither produces a
+    // union_type_info_ entry, so storing them would crash downstream
+    // wrapInUnion lookups.
+    if (!isUnionType(flattened) || isLiteralUnionType(flattened))
+        return;
+    getOrCreateMeta(target).union_value_type = std::move(flattened);
 }
 
 llvm::Value *CodeGen::wrapInUnion(llvm::Value *val, const std::string &unionTypeName) {

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -534,8 +534,7 @@ std::vector<std::string> CodeGen::parseUnionComponents(const std::string &typeNa
     return components;
 }
 
-std::string CodeGen::normalizeUnionType(const std::string &typeName) {
-    auto components = parseUnionComponents(typeName);
+static std::string joinSortedUnion(std::vector<std::string> &components) {
     std::sort(components.begin(), components.end());
     std::string result;
     for (size_t i = 0; i < components.size(); ++i) {
@@ -545,12 +544,54 @@ std::string CodeGen::normalizeUnionType(const std::string &typeName) {
     return result;
 }
 
+std::string CodeGen::normalizeUnionType(const std::string &typeName) {
+    auto components = parseUnionComponents(typeName);
+    return joinSortedUnion(components);
+}
+
 bool CodeGen::isUnionType(const std::string &typeName) {
     return typeName.find(" | ") != std::string::npos;
 }
 
+std::string CodeGen::flattenUnionWithAliases(const std::string &typeName) {
+    std::string resolved = resolveTypeAlias(typeName);
+    if (!isUnionType(resolved))
+        return resolved;
+    // Literal unions take a separate codepath in resolveType and never
+    // contain alias components.
+    if (isLiteralUnionType(resolved))
+        return normalizeUnionType(resolved);
+
+    std::vector<std::string> out;
+    std::unordered_set<std::string> seenLeaves;
+    // Tracks union strings whose expansion has already started, so we
+    // terminate on both genuine cycles (`type A = B | int; type B = A | str`)
+    // and redundant references (`type C = B | A` where B already expands A).
+    std::unordered_set<std::string> visitedUnions;
+
+    std::vector<std::string> worklist;
+    worklist.push_back(resolved);
+    visitedUnions.insert(resolved);
+
+    while (!worklist.empty()) {
+        std::string current = std::move(worklist.back());
+        worklist.pop_back();
+        for (auto &c : parseUnionComponents(current)) {
+            std::string r = resolveTypeAlias(c);
+            if (!isUnionType(r) || isLiteralUnionType(r)) {
+                if (seenLeaves.insert(r).second)
+                    out.push_back(r);
+            } else if (visitedUnions.insert(r).second) {
+                worklist.push_back(std::move(r));
+            }
+        }
+    }
+
+    return joinSortedUnion(out);
+}
+
 llvm::Value *CodeGen::wrapInUnion(llvm::Value *val, const std::string &unionTypeName) {
-    std::string norm = normalizeUnionType(unionTypeName);
+    std::string norm = flattenUnionWithAliases(unionTypeName);
     auto infoIt = union_type_info_.find(norm);
     if (infoIt == union_type_info_.end()) {
         resolveType(norm);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -306,13 +306,8 @@ void CodeGen::emitVarDecl(const std::string &name,
         getOrCreateMeta(ptr).type_constraint = *constraint;
 
     // Track union value type (skip literal unions which use base types directly).
-    // Only store when the flattened form is still a union — dedupe may
-    // collapse `type A = int | int` to a single leaf, and downstream
-    // `wrapInUnion` reassignment paths would crash on a non-union name.
     if (annot && isUnionType(resolvedAnnot) && !constraint) {
-        std::string flattened = flattenUnionWithAliases(*annot);
-        if (isUnionType(flattened))
-            getOrCreateMeta(ptr).union_value_type = std::move(flattened);
+        storeFlattenedUnionMeta(ptr, *annot);
     }
 
     // Track collection metadata for Option/Result wrapping a collection

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -306,8 +306,13 @@ void CodeGen::emitVarDecl(const std::string &name,
         getOrCreateMeta(ptr).type_constraint = *constraint;
 
     // Track union value type (skip literal unions which use base types directly).
+    // Only store when the flattened form is still a union — dedupe may
+    // collapse `type A = int | int` to a single leaf, and downstream
+    // `wrapInUnion` reassignment paths would crash on a non-union name.
     if (annot && isUnionType(resolvedAnnot) && !constraint) {
-        getOrCreateMeta(ptr).union_value_type = flattenUnionWithAliases(*annot);
+        std::string flattened = flattenUnionWithAliases(*annot);
+        if (isUnionType(flattened))
+            getOrCreateMeta(ptr).union_value_type = std::move(flattened);
     }
 
     // Track collection metadata for Option/Result wrapping a collection

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -305,9 +305,9 @@ void CodeGen::emitVarDecl(const std::string &name,
     if (constraint)
         getOrCreateMeta(ptr).type_constraint = *constraint;
 
-    // Track union value type (skip literal unions which use base types directly)
+    // Track union value type (skip literal unions which use base types directly).
     if (annot && isUnionType(resolvedAnnot) && !constraint) {
-        getOrCreateMeta(ptr).union_value_type = normalizeUnionType(resolvedAnnot);
+        getOrCreateMeta(ptr).union_value_type = flattenUnionWithAliases(*annot);
     }
 
     // Track collection metadata for Option/Result wrapping a collection

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -83,11 +83,17 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
 
     // Union type: "int | str"
     if (typeName.find(" | ") != std::string::npos) {
-        std::string normalized = normalizeUnionType(typeName);
-        auto it = union_type_info_.find(normalized);
+        std::string flattened = flattenUnionWithAliases(typeName);
+        // Flattening may dedupe down to a single leaf (e.g. `type A = int | str;
+        // type B = A | int` collapses to `int`), in which case fall back to
+        // the non-union path.
+        if (!isUnionType(flattened) || isLiteralUnionType(flattened))
+            return resolveType(flattened);
+
+        auto it = union_type_info_.find(flattened);
         if (it != union_type_info_.end()) return it->second.llvmType;
 
-        auto components = parseUnionComponents(normalized);
+        auto components = parseUnionComponents(flattened);
         std::vector<llvm::Type*> compTypes;
         uint64_t maxSize = 0;
         const auto &dl = mod_->getDataLayout();
@@ -99,9 +105,9 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
         auto *dataTy = llvm::ArrayType::get(
             llvm::Type::getInt8Ty(*ctx_), maxSize);
         auto *unionTy = llvm::StructType::create(
-            *ctx_, {i64Ty_, dataTy}, "union." + normalized);
+            *ctx_, {i64Ty_, dataTy}, "union." + flattened);
 
-        union_type_info_[normalized] = {unionTy, components, compTypes};
+        union_type_info_[flattened] = {unionTy, components, compTypes};
         return unionTy;
     }
 

--- a/tests/spec/type_advanced.test.ry
+++ b/tests/spec/type_advanced.test.ry
@@ -155,6 +155,15 @@ describe("nested type alias unions", ():
     z: NC4 = true
     expect(to_str(z)).to_eq("true")
   )
+
+  it("should terminate on mutually-cyclic union aliases and flatten reachable leaves", ():
+    type NCycA = NCycB | int
+    type NCycB = NCycA | str
+    x: NCycA = 1
+    expect(to_str(x)).to_eq("1")
+    y: NCycA = "ok"
+    expect(to_str(y)).to_eq("ok")
+  )
 )
 
 type TAVal = int | str

--- a/tests/spec/type_advanced.test.ry
+++ b/tests/spec/type_advanced.test.ry
@@ -109,6 +109,54 @@ describe("type alias", ():
   )
 )
 
+describe("nested type alias unions", ():
+  it("should flatten a one-level nested alias (A | bool where A = int | str)", ():
+    type NA1 = int | str
+    type NB1 = NA1 | bool
+    x: NB1 = 42
+    expect(to_str(x)).to_eq("42")
+    y: NB1 = "hello"
+    expect(to_str(y)).to_eq("hello")
+    z: NB1 = true
+    expect(to_str(z)).to_eq("true")
+  )
+
+  it("should flatten a two-level nested alias (C = B | float where B = A | bool)", ():
+    type NA2 = int | str
+    type NB2 = NA2 | bool
+    type NC2 = NB2 | float
+    a: NC2 = 1
+    expect(to_str(a)).to_eq("1")
+    b: NC2 = "x"
+    expect(to_str(b)).to_eq("x")
+    c: NC2 = false
+    expect(to_str(c)).to_eq("false")
+    d: NC2 = 3.5
+    expect(to_str(d)).to_eq("3.5")
+  )
+
+  it("should dedupe overlapping members when nesting", ():
+    type NA3 = int | str
+    type NB3 = NA3 | int
+    x: NB3 = 7
+    expect(to_str(x)).to_eq("7")
+    y: NB3 = "dup"
+    expect(to_str(y)).to_eq("dup")
+  )
+
+  it("should dedupe a member reached via multiple alias paths", ():
+    type NA4 = int | str
+    type NB4 = NA4 | bool
+    type NC4 = NB4 | NA4
+    x: NC4 = 42
+    expect(to_str(x)).to_eq("42")
+    y: NC4 = "hi"
+    expect(to_str(y)).to_eq("hi")
+    z: NC4 = true
+    expect(to_str(z)).to_eq("true")
+  )
+)
+
 type TAVal = int | str
 
 function ta_show(v: TAVal) -> str:
@@ -146,6 +194,56 @@ describe("type alias union of records", ():
     expect(to_str(a)).to_eq("TAPoint(x: 1, y: 2)")
     b: TAShape = TAName("hello")
     expect(to_str(b)).to_eq("TAName(value: \"hello\")")
+  )
+)
+
+type NTAInner = int | str
+type NTAOuter = NTAInner | bool
+
+function nta_show(v: NTAOuter) -> str:
+  return to_str(v)
+
+function nta_choose(k: int) -> NTAOuter:
+  if k == 0:
+    return 42
+  if k == 1:
+    return "hi"
+  return true
+
+describe("nested type alias union in functions", ():
+  it("should support nested union alias in function parameter", ():
+    expect(nta_show(7)).to_eq("7")
+    expect(nta_show("abc")).to_eq("abc")
+    expect(nta_show(false)).to_eq("false")
+  )
+
+  it("should support nested union alias in function return", ():
+    expect(to_str(nta_choose(0))).to_eq("42")
+    expect(to_str(nta_choose(1))).to_eq("hi")
+    expect(to_str(nta_choose(2))).to_eq("true")
+  )
+)
+
+record NTRecA:
+  x: int
+
+record NTRecB:
+  y: str
+
+record NTRecC:
+  z: float
+
+type NTRInner = NTRecA | NTRecB
+type NTROuter = NTRInner | NTRecC
+
+describe("nested type alias union of records", ():
+  it("should flatten nested record union alias", ():
+    a: NTROuter = NTRecA(1)
+    expect(to_str(a)).to_eq("NTRecA(x: 1)")
+    b: NTROuter = NTRecB("yo")
+    expect(to_str(b)).to_eq("NTRecB(y: \"yo\")")
+    c: NTROuter = NTRecC(2.5)
+    expect(to_str(c)).to_eq("NTRecC(z: 2.5)")
   )
 )
 

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -903,6 +903,19 @@ TEST_F(CodeGenTest, TypeAlias) {
     EXPECT_EQ(runSource(src), "7\n");
 }
 
+TEST_F(CodeGenTest, TypeAliasLeaflessCycleRejected) {
+    // `type A = B | C; type B = A; type C = A` — every expansion path
+    // cycles back into A with no concrete leaf ever reached. Must reject
+    // with a "Circular type alias" error instead of returning an empty
+    // flattened name (#835 follow-up).
+    std::string src =
+        "type A = B | C\n"
+        "type B = A\n"
+        "type C = A\n"
+        "x: A = 42\n";
+    EXPECT_THROW(runSource(src), std::runtime_error);
+}
+
 // ===== for k, v in map / range =====
 
 TEST_F(CodeGenTest, ForKVInMap) {

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -916,6 +916,21 @@ TEST_F(CodeGenTest, TypeAliasLeaflessCycleRejected) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
+TEST_F(CodeGenTest, TypeAliasLiteralUnionMetaDoesNotCrashOnReassignment) {
+    // Reassigning through an alias whose flattened canonical form is a
+    // literal union (`"N" | "S"`) must not crash wrapInUnion. Literal
+    // unions do not produce union_type_info_ entries, so the metadata
+    // write is skipped and reassignment to a mismatched type should
+    // surface the normal "cannot be reassigned" diagnostic (#835
+    // follow-up).
+    std::string src =
+        "type LitDir = \"N\" | \"S\"\n"
+        "type Alias = LitDir | \"N\"\n"
+        "x: Alias = \"N\"\n"
+        "x = 42\n";
+    EXPECT_THROW(runSource(src), std::runtime_error);
+}
+
 // ===== for k, v in map / range =====
 
 TEST_F(CodeGenTest, ForKVInMap) {


### PR DESCRIPTION
## Summary

- Fixes #835: `type A = int | str; type B = A | bool; x: B = 42` failed with *"type is not in union"* because alias components inside a union were not recursively expanded.
- Adds `flattenUnionWithAliases` and uses it as the canonical key at every site that creates, looks up, or records a union: `resolveType`, `wrapInUnion`, `emitVarDecl` metadata, `applyParamTypeMeta`, and both metadata/lookup sites in `codegen_call_user.cpp`.
- Handles both genuine cycles (`type A = B | int; type B = A | str` → `int | str`) and redundant references reachable via multiple alias paths (`type C = B | A` where B already transitively contains A → `bool | int | str`) via silent skip on re-visit — no false-positive "circular alias" errors.
- Extracts the shared sort-and-join tail into `joinSortedUnion` so `normalizeUnionType` and `flattenUnionWithAliases` stop duplicating that logic.
- Follow-up to #833 — same 4 codegen sites plus one additional overload-resolution lookup site in `codegen_call_user.cpp:103` that had the same underlying issue.

## Test plan

- [x] `./build/ry test tests/spec/type_advanced.test.ry` — 40 passed (7 new `nested type alias unions` / `nested type alias union in functions` / `nested type alias union of records` cases)
- [x] `./build/ry_tests` — 1460 passed
- [x] `./build/ry test -p` — 101 files, 0 failures (verified 3 consecutive clean runs)
- [x] ASan build: `./build-asan/ry_tests` 1459 passed, `./build-asan/ry test -p` 0 failures
- [x] Manual repro of the issue body snippet prints `42 / hi / true`
- [x] Multi-path dedupe (`type C = B | A`) verified — now flattens instead of erroring
- [x] Cycle cases (`type A = B | int; type B = A | str`, `type A = A | int`) terminate and produce the correct flattened leaf set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Nested type aliases in unions are now transitively flattened and deduplicated, fixing "type is not in union" assignment/matching failures.
  * Pure-alias cycles with no concrete member are rejected with an error instead of creating invalid/empty unions.
  * Reassignment through literal-collapsed alias cases now yields proper diagnostics instead of crashes.

* **Documentation**
  * Clarified alias-flattening and deduplication with examples.

* **Tests**
  * Added tests for nested/cyclic alias flattening, deduplication, function/return usage, record-union cases, and negative cycle/error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->