### PR TITLE
fix: sweep print/to_str layer bugs in collections, unions, and floats

### DIFF
--- a/.claude/skills/git-fix-pr-reviews/SKILL.md
+++ b/.claude/skills/git-fix-pr-reviews/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: git-fix-pr-reviews
-description: Fetch PR review comments, triage them, and apply fixes. Does not commit or push.
+description: Fetch PR review comments, triage them, apply fixes, and reply to every handled item so reviewers (e.g. CodeRabbit) can learn from the outcome. Does not commit or push.
 allowed-tools: Bash(gh:*), Bash(git branch:*), Read, Edit
 metadata:
-  short-description: Triage and fix PR review comments
+  short-description: Triage, fix, and reply to PR review comments
 ---
 
 # Git Fix PR Reviews
@@ -33,7 +33,7 @@ User input: $ARGUMENTS
 Get repository info with `gh repo view --json owner,name --jq '.owner.login + "/" + .name'` and call the following three APIs **in parallel**:
 
 1. `gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments` — inline comments (each has an `id` field needed for replies)
-2. `gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews` — review summaries (general comments)
+2. `gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews` — review summaries (general comments). Read each review `body` and extract any **nitpick / suggestion items embedded inside the summary** (e.g. CodeRabbit's `<summary>🧹 Nitpick comments</summary>` block) — these are NOT inline comments and do not have their own `id`, so they cannot receive inline replies. Treat them as separate triage items referenced by file/line in the summary body.
 3. Thread-to-comment mapping via GraphQL — fetch all review threads with their comment node IDs:
 
    ```shell
@@ -63,20 +63,50 @@ Display the classification results for all comments in a table:
 | 2 | Needs confirmation | ... | ... | ... | ... |
 | 3 | Skip | ... | ... | ... | ... |
 
-### Step 5: Apply fixes
+### Step 5: Apply fixes and reply to every handled item
 
-- **Auto-fix**: Read the target file with `Read` and apply the fix immediately with `Edit`
-- **Needs confirmation**: Ask the user which ones to apply, and only fix those that are approved
-- **Skip (inline comment)**: Reply with a brief reason (e.g. "Intentional design", "Already fixed", "Pre-existing issue — out of scope for this PR") using `gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body='<reason>'`. Use the comment `id` from Step 2.
-- **Skip (review summary)**: No reply needed — review summaries are general text (LGTM, etc.) and don't support inline replies.
+**Every handled item must receive a reply**, not just skipped ones. Reviewers like CodeRabbit use reply content to learn and improve future review precision — silently resolving threads wastes that signal. The reply should state **what was done and why** in 1-5 lines.
+
+For each category:
+
+- **Auto-fix**: Read the target file with `Read` and apply the fix with `Edit`. After the fix, reply to the inline comment describing the concrete change (which file/line, what the fix does, and the commit/approach if it's not obvious). If the auto-fix decision was non-trivial or the reviewer's suggestion was partially adjusted, say so.
+- **Needs confirmation — approved**: Apply the fix after user approval, then reply the same way as Auto-fix. If the user's instruction changed the approach from what the reviewer suggested, note that in the reply so the reviewer understands the deviation.
+- **Needs confirmation — rejected / deferred**: Do not fix. Reply with a clear reason (e.g. "Intentional design — see ...", "Out of scope for this PR, filed as issue #NNN", "Will address in a follow-up").
+- **Skip (inline comment)**: Reply with a brief reason (e.g. "Already fixed in commit abc1234", "Pre-existing — out of scope", "LGTM, no change needed").
+- **Skip (review summary — general text like LGTM)**: No reply needed.
+- **Review-summary nitpicks (embedded in the review body)**: These have no individual comment `id` and cannot receive inline replies. Instead, post **one consolidated issue comment** on the PR via `gh pr comment <number> --body '...'` that addresses each nitpick (one section per item, referencing the original file/line from the summary). Mention `@coderabbitai` at the top so the reviewer picks it up for learning.
+
+**Reply APIs**:
+
+- Inline-comment reply:
+
+  ```shell
+  gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body='<markdown body>'
+  ```
+
+  Use the REST `id` from Step 2 (not the GraphQL node id).
+
+- Consolidated PR issue comment (for review-summary nitpicks only):
+
+  ```shell
+  gh pr comment {number} --body '<markdown body>'
+  ```
+
+**Reply content guidance**:
+
+- Lead with the outcome (`Fixed in abc1234.` / `Skipping — reason: ...`), then the rationale.
+- Cite the commit SHA for fixes so the reviewer can verify.
+- For partial fixes, be explicit about what was and wasn't addressed.
+- Do not argue with the reviewer — if you disagree, briefly state why and move on.
+- Avoid emojis and filler (`Thanks for the review!` is fine at most once per batch).
 
 ### Step 6: Resolve handled threads
 
-After all fixes are applied and skip replies are posted, resolve **only the threads that were handled** in Step 5. Do NOT resolve threads that were not triaged or handled.
+After all fixes are applied and every handled item has received a reply (Step 5), resolve **only the threads that were handled**. Do NOT resolve threads that were not triaged or handled.
 
-1. During Step 5, collect the **comment IDs** of every handled inline/thread comment (auto-fixed, user-approved, or replied to with a skip reason).
+1. During Step 5, collect the **comment IDs** of every handled inline/thread comment (auto-fixed, user-approved, rejected with reason, or skipped with reason).
 2. Using the comment-to-thread mapping built in Step 2, look up the corresponding **thread ID** for each handled comment ID.
-3. If a handled comment ID has no mapped thread ID (e.g., review summary/general review text), skip it.
+3. If a handled item has no mapped thread ID (e.g., a review-summary nitpick that was addressed via a consolidated PR comment in Step 5), skip it — there is no thread to resolve.
 4. Resolve each mapped thread (skip threads that are already resolved):
 
    ```shell
@@ -87,12 +117,26 @@ This ensures only threads with a reply or fix are resolved. Unhandled threads (e
 
 ### Step 7: Report
 
-After all fixes are applied, display a summary including:
+After all fixes and replies are applied, display a summary including:
 
 - Number of auto-fixed items
 - Number of user-approved fixes
+- Number of user-rejected / deferred items
 - Number of skipped items
+- Number of inline replies posted
+- Number of consolidated PR comments posted (for review-summary nitpicks)
 - Number of threads resolved
 - List of modified files
 
 **Important**: Do NOT commit or push. The user will do so explicitly.
+
+### Rationale — why every handled item gets a reply
+
+Reviewers (especially AI reviewers like CodeRabbit) use reply content as training signal for future reviews on this repository. Silently resolving a thread — even for a correct auto-fix — tells the reviewer nothing about *what* changed or *why* a suggestion was or wasn't taken. A 2-3 line reply stating the fix (or the reason for not fixing) costs almost nothing and directly improves the next review.
+
+Rules of thumb:
+
+- Every triaged item (not just skipped ones) → reply.
+- Cite commit SHAs and file/line references when possible.
+- For rejected suggestions, state the reason once, clearly, without arguing.
+- For review-summary nitpicks that have no inline thread, a single consolidated PR comment is the correct channel.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -151,17 +151,24 @@ because both are `ptrTy_`, so a `Map` value gets wrapped with tag=0
 garbage output. This bug was invisible before #836 because the formatter
 rejected collection variants entirely.
 
-**Rule**: When matching a value to a union component, prefer variants
-that match by **value metadata kind** (List / Map / Set / function),
-falling back to LLVM type equality only if no kind-match is found. The
-value's `CodeGen::ValueMetadata` fields (`list_elem`, `map_key` /
-`map_value`, `set_elem`, `fn_type_info`) are the source of truth for
-collection / function variants.
+**Rule**: When matching a value to a union component, resolve in three
+passes: (1) reconstruct the full source-level type name from the value's
+metadata via `buildTypeNameFromMeta()` and match it against
+`componentNames` exactly — this handles same-kind variants like
+`List<int> | List<str>`; (2) fall back to coarse kind match
+(`isListTypeName` / `isMapTypeName` / `isSetTypeName` /
+`isFunctionTypeName`) against the same metadata fields — this handles
+cases where the canonical name couldn't be built (literals without
+annotations, aliases); (3) fall back to LLVM-type equality. The value's
+`CodeGen::ValueMetadata` fields (`list_elem`, `list_elem_type_name`,
+`map_key` / `map_value` / `map_value_type_name`, `set_elem` /
+`set_elem_type_name`, `fn_type_info`) are the source of truth.
 
 **How to apply**: Any future dispatch that uses LLVM type equality to
-route between ptr-backed Ry types must first consult the metadata. See
-the `preferredName` / `matchesPreferred` logic in
-`wrapInUnion()` as the canonical pattern.
+route between ptr-backed Ry types must first consult the metadata.
+`src/codegen_match.cpp::wrapInUnion()` and the
+`buildTypeNameFromMeta()` helper in `src/codegen_builtin.cpp` are the
+canonical pattern.
 
 ### %.17g roundtrip precision would break existing float tests
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -97,6 +97,94 @@ For each hit ask "what if the result is no longer a union/variadic/
 tuple?". If the caller indexes a map keyed on the original category,
 it needs a guard.
 
+### valueToString element loads must propagate metadata via propagateTypeMeta
+
+**Source**: #811/#836/#810 sweep (2026-04-10, implementation)
+**Tags**: codegen, formatter, metadata, collection, nested
+
+**Context**: The formatter in `src/codegen_tostring.cpp` iterates over
+`List` / `Map` / `Set` elements by loading them from the container's
+data array. Each load yields a fresh SSA `Value*` with no metadata. If
+the element type is itself a collection (e.g. `Map<str, List<int>>`),
+calling `valueToString(elem)` without propagating the inner type name
+falls through to the raw string-pointer path and prints empty strings or
+garbage bytes. The `List` branch already had this propagation
+(`list_elem_type_name` + `list_elem_fn_type_info` snapshot), but the
+`Map` and `Set` branches did not — which is why #811 / #810 went
+undetected until this sweep.
+
+**Rule**: Whenever you add a new outer container type to
+`valueToString()`, the element-load block MUST:
+
+1. Snapshot both the element type name and any `*_fn_type_info` field
+   from the outer container's metadata **before** calling
+   `getOrCreateMeta()` (which may rehash `value_metadata_` and
+   invalidate pointers).
+2. Call `propagateTypeMeta(elemTypeName, elem)` to rebuild the element's
+   collection metadata (`list_elem`, `map_value_type_name`, etc.).
+3. If the snapshot had `*_fn_type_info`, store it on the element's
+   metadata so closures format as `<closure>`.
+
+The union-variant branch needs the same pattern — see the post-#836
+code in `codegen_tostring.cpp:200-230`.
+
+**How to verify before opening a PR**:
+
+```bash
+grep -nE 'CreateLoad.*elem|CreateLoad.*valVal' src/codegen_tostring.cpp
+```
+
+For each hit, confirm that a metadata snapshot + `propagateTypeMeta`
+call follows within ~5 lines, or that the outer container has no
+corresponding `*_type_name` metadata slot (e.g. fixed-length arrays).
+
+### wrapInUnion must disambiguate same-LLVM-type variants by metadata
+
+**Source**: #836 sweep (discovered while fixing union collection variants)
+**Tags**: codegen, union, variant-dispatch, collection, metadata
+
+**Context**: `src/codegen_match.cpp::wrapInUnion` originally picked the
+first variant whose LLVM type matched the value's LLVM type. For unions
+like `List<int> | Map<str, int>` this always picks the first variant
+because both are `ptrTy_`, so a `Map` value gets wrapped with tag=0
+(List) and is then interpreted as a List at dispatch time, producing
+garbage output. This bug was invisible before #836 because the formatter
+rejected collection variants entirely.
+
+**Rule**: When matching a value to a union component, prefer variants
+that match by **value metadata kind** (List / Map / Set / function),
+falling back to LLVM type equality only if no kind-match is found. The
+value's `CodeGen::ValueMetadata` fields (`list_elem`, `map_key` /
+`map_value`, `set_elem`, `fn_type_info`) are the source of truth for
+collection / function variants.
+
+**How to apply**: Any future dispatch that uses LLVM type equality to
+route between ptr-backed Ry types must first consult the metadata. See
+the `preferredName` / `matchesPreferred` logic in
+`wrapInUnion()` as the canonical pattern.
+
+### %.17g roundtrip precision would break existing float tests
+
+**Source**: #808 sweep (Plan phase, 2026-04-10)
+**Tags**: formatter, float, precision, tests
+
+**Context**: A natural fix for #808 ("`print(3.0)` should print `3.0`")
+is to switch the `float` formatter to `%.17g` (IEEE 754 roundtrip-safe
+precision, same as Python). But IEEE 754 stores `3.14` as
+`3.1400000000000001…`, so `%.17g` produces `"3.1400000000000001"`,
+breaking every existing test that asserts `to_str(3.14) == "3.14"`
+(several in `tests/spec/*.test.ry` and `tests/test_codegen*.cpp`).
+
+**Rule**: The float formatter uses `%g` (= `%.6g`) and appends `".0"`
+only when the result has no decimal point, no exponent, and is not
+`nan`/`inf`. Roundtrip-safe display is a separate concern and should
+be introduced as an explicit opt-in (e.g. `to_str_exact(x)`), not by
+changing the default `%g` precision.
+
+**How to apply**: Do not change `%g` → `%.17g` in
+`__ry_fmt_float` (runtime_any.cpp) or elsewhere without also planning
+to update every float test assertion.
+
 ### New primitive types must be wired into every type-reflection site
 
 **Source**: #825 PR review (CodeRabbit, 4 comments)

--- a/changelog.d/811-836-808-810-print-sweep.md
+++ b/changelog.d/811-836-808-810-print-sweep.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `print()` / `to_str()` on `Map<K, List|Map|Set<...>>` now shows the actual nested container contents instead of empty strings for the values (#811)
+- `print()` / `to_str()` on union types with `List`, `Map`, or `Set` variants now works instead of failing at compile time with "cannot convert ... variant of union to string" (#836)
+- Whole-number `float` values now print with a trailing `.0` (e.g. `3.0`, `0.0`) instead of being indistinguishable from `int`, matching Python behavior (#808)
+- `print()` / `to_str()` on a `Map` whose value type is a function now outputs `<closure>` instead of garbage bytes (#810)
+- `wrapInUnion` now disambiguates same-LLVM-type variants (e.g. `List<int> | Map<str, int>`) by the value's collection metadata instead of always picking the first pointer-typed variant, fixing runtime miscategorization for collection/function unions

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -366,17 +366,21 @@ Converts a value to a string.
 | Type | Conversion Format |
 |----|---------|
 | `int` | `%ld` |
-| `float` | `%g` |
+| `float` | `%g`, with trailing `.0` for whole-number values (e.g. `"3.0"`, `"0.0"`) |
 | `bool` | `"true"` / `"false"` |
 | `str` | Returned as-is |
 | enum | Variant name (e.g. `"Red"`) |
 | record | `TypeName(field1: val1, field2: val2)` |
+| `List` / `Map` / `Set` | Recursively formatted, nested containers (e.g. `Map<str, List<int>>`) are supported |
+| union | Formatted as the active variant; `List`, `Map`, `Set`, and function variants are all supported |
+| function value (closure / lambda) | `"<closure>"` |
 
-Record types automatically generate a `to_str` representation. If a user-defined `function to_str(v: MyRecord) -> str` is provided, it takes precedence over the auto-generated version. This also works with `print()` and f-string interpolation.
+Whole-number `float` values are formatted with a trailing `.0` (e.g. `to_str(3.0) == "3.0"`) so they are visually distinguishable from `int`. Record types automatically generate a `to_str` representation. If a user-defined `function to_str(v: MyRecord) -> str` is provided, it takes precedence over the auto-generated version. This also works with `print()` and f-string interpolation.
 
 ```python
 print(to_str(42))         # 42
 print(to_str(3.14))       # 3.14
+print(to_str(3.0))        # 3.0          (whole-number float keeps .0)
 print(to_str(true))       # true
 print(99.to_str())        # 99 (UFCS)
 

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -21,7 +21,7 @@
 | `receive(stream, max)` | Receives up to `max` bytes from `TcpStream` or `TlsStream` as `Result<List<u8>, Error>` |
 | `close(handle)` | Closes a `TcpStream`, `TlsStream`, or `TcpListener` |
 | `block_on(task)` | Blocks the current thread until a `Task<T>` completes and returns its result |
-| `to_str(value)` | Converts a value to its string representation (`int`, `float`, `bool`, `str`, record, enum, tuple, `List`, `Map`, `Set`, `Result`, `Option`). String elements inside collections are wrapped in double quotes (e.g., `["hello", "world"]`) |
+| `to_str(value)` | Converts a value to its string representation. Supports `int`, `float` (whole numbers print with trailing `.0`), `bool`, `str`, record, enum, tuple, `List`, `Map`, `Set` (nested containers like `Map<str, List<int>>` are recursively formatted), `Result`, `Option`, union types (formatted as the active variant), and function values (printed as `<closure>`). String elements inside collections are wrapped in double quotes (e.g., `["hello", "world"]`) |
 | `type_of(expr)` | Returns the type of `expr` as a `Type` value. See [type_of](#type_of) |
 | `fail()` / `fail(message)` | Marks the current test as failed (only available in `ry test` mode) |
 

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -150,7 +150,7 @@ Prints one or more values to standard output, separated by spaces. A newline is 
 | Type | Output Format |
 |----|---------|
 | `int` | `%ld` |
-| `float` | `%g` |
+| `float` | `%g`, with trailing `.0` for whole-number values (e.g. `3.0`, `0.0`) |
 | `bool` | `true` / `false` |
 | `str` | `%s` |
 | `Result` (Ok) | `Ok(value)` |
@@ -163,10 +163,16 @@ Prints one or more values to standard output, separated by spaces. A newline is 
 | `tuple` | `(elem1, elem2, ...)` |
 | `enum` | Variant name (e.g., `Red`) |
 | `record` | `RecordName(field: val, ...)` |
+| function value (closure / lambda) | `<closure>` |
+| union | Formatted as the active variant's type |
+
+Whole-number `float` values always print with a trailing `.0` so they are visually distinguishable from `int`. Nested collections (e.g. `Map<str, List<int>>`) are recursively formatted using the inner element's formatter. Union variants whose underlying type is `List`, `Map`, or `Set` format as that collection; variants whose underlying type is a function value format as `<closure>`.
 
 ```python
 print(42)          # 42
 print(3.14)        # 3.14
+print(3.0)         # 3.0         (whole-number float keeps .0)
+print(0.0)         # 0.0
 print(true)        # true
 print("hello")     # hello
 print(Ok(42))      # Ok(42)
@@ -177,6 +183,18 @@ print([1, 2, 3])   # [1, 2, 3]
 print({"a": 1})    # {"a": 1}
 print({1, 2, 3})   # {1, 2, 3}
 print((1, "hello"))  # (1, "hello")
+
+# Nested collections
+m: Map<str, List<int>> = {"a": [1, 2, 3]}
+print(m)           # {"a": [1, 2, 3]}
+
+# Collection-typed union variant
+x: int | List<int> = [1, 2, 3]
+print(x)           # [1, 2, 3]
+
+# Function value
+f = (x: int) => x * 2
+print(f)           # <closure>
 
 # Multiple arguments (space-separated)
 print(1, 2, 3)             # 1 2 3

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1268,6 +1268,7 @@ public:
     llvm::Type *deduceReturnType(const std::vector<llvm::Type*> &types);
     std::string reverseResolveTypeName(llvm::Type *ty);
     std::string inferCollectionTypeName(llvm::Value *val);
+    std::string buildTypeNameFromMeta(llvm::Value *val);
     std::string extractMapValueTypeName(const std::string &mapTypeName);
 
     // ======== Union & Any Type Helpers ========

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -649,11 +649,14 @@ public:
         std::string low_level_type_name;
         std::string map_value_type_name;    // Ry type name for map values
         std::string list_elem_type_name;    // Ry type name for list elements (e.g. "Map<str, int>")
+        std::string set_elem_type_name;     // Ry type name for set elements (e.g. "List<int>")
         std::string union_value_type;       // normalized union type name
         std::string enum_value_type;        // enum type name
 
-        // Closure/function type info for list elements
+        // Closure/function type info for collection elements
         std::optional<FnTypeInfo> list_elem_fn_type_info;
+        std::optional<FnTypeInfo> map_value_fn_type_info;
+        std::optional<FnTypeInfo> set_elem_fn_type_info;
 
         // Closure/function type info
         std::optional<FnTypeInfo> fn_type_info;

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -140,6 +140,58 @@ std::string CodeGen::inferCollectionTypeName(llvm::Value *val) {
     return "";
 }
 
+// Reconstruct a canonical source-level type name (e.g. "List<int>",
+// "Map<str, bool>", "function(int) -> str") from a value's collection /
+// function metadata.  Used by wrapInUnion() to disambiguate same-LLVM-type
+// variants like `List<int> | List<str>` by comparing the reconstructed name
+// against each component name.  Returns "" if the value has no collection /
+// function metadata.
+std::string CodeGen::buildTypeNameFromMeta(llvm::Value *val) {
+    auto *meta = getMeta(val);
+    if (!meta) return "";
+
+    // Prefer the stored source-level type name (populated via
+    // propagateTypeMeta / emitVarDecl from annotations or literals).  Fall
+    // back to reverseResolveTypeName on the llvm::Type when unavailable — this
+    // only happens for primitive inner types, which reverseResolveTypeName
+    // handles correctly.
+    if (meta->list_elem) {
+        std::string elemName = !meta->list_elem_type_name.empty()
+            ? meta->list_elem_type_name
+            : reverseResolveTypeName(meta->list_elem);
+        return "List<" + elemName + ">";
+    }
+    if (meta->map_key || meta->map_value) {
+        std::string keyName = meta->map_key
+            ? reverseResolveTypeName(meta->map_key) : "";
+        std::string valName;
+        if (!meta->map_value_type_name.empty())
+            valName = meta->map_value_type_name;
+        else if (meta->map_value)
+            valName = reverseResolveTypeName(meta->map_value);
+        if (keyName.empty() || valName.empty()) return "";
+        return "Map<" + keyName + ", " + valName + ">";
+    }
+    if (meta->set_elem) {
+        std::string elemName = !meta->set_elem_type_name.empty()
+            ? meta->set_elem_type_name
+            : reverseResolveTypeName(meta->set_elem);
+        return "Set<" + elemName + ">";
+    }
+    if (meta->fn_type_info) {
+        const auto &info = *meta->fn_type_info;
+        std::string result = "function(";
+        for (size_t i = 0; i < info.paramTypes.size(); ++i) {
+            if (i > 0) result += ", ";
+            result += reverseResolveTypeName(info.paramTypes[i]);
+        }
+        result += ") -> ";
+        result += reverseResolveTypeName(info.returnType);
+        return result;
+    }
+    return "";
+}
+
 
 // Step 1: Hash function resolution helper
 CodeGen::HashFnInfo CodeGen::resolveHashFn(llvm::Type *keyTy) {

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -71,6 +71,9 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
     } else if (isListTypeName(typeName) && typeName.back() == '>') {
         std::string inner = typeName.substr(5, typeName.size() - 6);
         setTypeMeta(TypeMeta::ListElem, val, resolveType(inner));
+        getOrCreateMeta(val).list_elem_type_name = inner;
+        if (isFunctionTypeName(inner))
+            getOrCreateMeta(val).list_elem_fn_type_info = parseFnTypeAnnotation(inner);
         if (isListTypeName(inner) && inner.back() == '>') {
             std::string nested = inner.substr(5, inner.size() - 6);
             setTypeMeta(TypeMeta::NestedListElem, val, resolveType(nested));
@@ -80,10 +83,17 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         if (keyTy) setTypeMeta(TypeMeta::MapKey, val, keyTy);
         if (valTy) setTypeMeta(TypeMeta::MapValue, val, valTy);
         std::string vtn = extractMapValueTypeName(typeName);
-        if (!vtn.empty()) getOrCreateMeta(val).map_value_type_name = vtn;
+        if (!vtn.empty()) {
+            getOrCreateMeta(val).map_value_type_name = vtn;
+            if (isFunctionTypeName(vtn))
+                getOrCreateMeta(val).map_value_fn_type_info = parseFnTypeAnnotation(vtn);
+        }
     } else if (isSetTypeName(typeName) && typeName.back() == '>') {
         std::string inner = typeName.substr(4, typeName.size() - 5);
         setTypeMeta(TypeMeta::SetElem, val, resolveType(inner));
+        getOrCreateMeta(val).set_elem_type_name = inner;
+        if (isFunctionTypeName(inner))
+            getOrCreateMeta(val).set_elem_fn_type_info = parseFnTypeAnnotation(inner);
     } else if (isLowLevelTypeName(typeName)) {
         getOrCreateMeta(val).low_level_type_name = typeName;
     }

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -617,14 +617,30 @@ llvm::Value *CodeGen::wrapInUnion(llvm::Value *val, const std::string &unionType
     }
     auto &info = infoIt->second;
     int tagIdx = -1;
-    // First pass: when multiple ptr-backed variants share the same LLVM type
-    // (e.g. List<int> and Map<str, int> are both ptr), pick the one whose
-    // component-name kind matches the value's collection/function metadata.
-    // Without this, ptr values always bind to the first ptr variant and are
-    // later mis-dispatched at runtime.
+    // When multiple ptr-backed variants share the same LLVM type (e.g.
+    // `List<int> | Map<str, int>` — both `ptr`, or `List<int> | List<str>` —
+    // both `ptr` with the same kind), we must disambiguate by the value's
+    // collection/function metadata.  Otherwise ptr values always bind to the
+    // first ptr variant and are mis-dispatched at runtime.
     const ValueMetadata *meta =
         (val->getType() == ptrTy_) ? getMeta(val) : nullptr;
+    // Pass 1: exact canonical type-name match (handles same-kind variants like
+    // `List<int> | List<str>`).
     if (meta) {
+        std::string canonical = buildTypeNameFromMeta(val);
+        if (!canonical.empty()) {
+            for (size_t i = 0; i < info.componentTypes.size(); ++i) {
+                if (info.componentTypes[i] == val->getType() &&
+                    info.componentNames[i] == canonical) {
+                    tagIdx = i;
+                    break;
+                }
+            }
+        }
+    }
+    // Pass 2: coarse kind match (handles `List<int> | Map<str, int>` when the
+    // canonical name couldn't be built — e.g. literals without annotations).
+    if (tagIdx < 0 && meta) {
         for (size_t i = 0; i < info.componentTypes.size(); ++i) {
             if (info.componentTypes[i] != val->getType()) continue;
             const auto &compName = info.componentNames[i];

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -617,8 +617,28 @@ llvm::Value *CodeGen::wrapInUnion(llvm::Value *val, const std::string &unionType
     }
     auto &info = infoIt->second;
     int tagIdx = -1;
-    for (size_t i = 0; i < info.componentTypes.size(); ++i) {
-        if (info.componentTypes[i] == val->getType()) { tagIdx = i; break; }
+    // First pass: when multiple ptr-backed variants share the same LLVM type
+    // (e.g. List<int> and Map<str, int> are both ptr), pick the one whose
+    // component-name kind matches the value's collection/function metadata.
+    // Without this, ptr values always bind to the first ptr variant and are
+    // later mis-dispatched at runtime.
+    const ValueMetadata *meta =
+        (val->getType() == ptrTy_) ? getMeta(val) : nullptr;
+    if (meta) {
+        for (size_t i = 0; i < info.componentTypes.size(); ++i) {
+            if (info.componentTypes[i] != val->getType()) continue;
+            const auto &compName = info.componentNames[i];
+            if ((meta->map_key || meta->map_value) && isMapTypeName(compName)) { tagIdx = i; break; }
+            if (meta->set_elem && isSetTypeName(compName))                     { tagIdx = i; break; }
+            if (meta->list_elem && isListTypeName(compName))                   { tagIdx = i; break; }
+            if (meta->fn_type_info && isFunctionTypeName(compName))            { tagIdx = i; break; }
+        }
+    }
+    // Fallback: first variant with matching LLVM type.
+    if (tagIdx < 0) {
+        for (size_t i = 0; i < info.componentTypes.size(); ++i) {
+            if (info.componentTypes[i] == val->getType()) { tagIdx = i; break; }
+        }
     }
     if (tagIdx < 0)
         codegenError("type is not in union " + norm);

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -24,7 +24,10 @@ bool CodeGen::ValueMetadata::hasAnyMeta() const {
            !union_value_type.empty() ||
            !enum_value_type.empty() ||
            !list_elem_type_name.empty() ||
-           list_elem_fn_type_info.has_value();
+           !set_elem_type_name.empty() ||
+           list_elem_fn_type_info.has_value() ||
+           map_value_fn_type_info.has_value() ||
+           set_elem_fn_type_info.has_value();
 }
 
 llvm::Type *CodeGen::ValueMetadata::getCollectionType(TypeMeta kind) const {
@@ -121,8 +124,14 @@ void CodeGen::propagateMeta(llvm::Value *src, llvm::Value *dst) {
         dstMeta.map_value_type_name = srcMeta.map_value_type_name;
     if (!srcMeta.list_elem_type_name.empty())
         dstMeta.list_elem_type_name = srcMeta.list_elem_type_name;
+    if (!srcMeta.set_elem_type_name.empty())
+        dstMeta.set_elem_type_name = srcMeta.set_elem_type_name;
     if (srcMeta.list_elem_fn_type_info)
         dstMeta.list_elem_fn_type_info = srcMeta.list_elem_fn_type_info;
+    if (srcMeta.map_value_fn_type_info)
+        dstMeta.map_value_fn_type_info = srcMeta.map_value_fn_type_info;
+    if (srcMeta.set_elem_fn_type_info)
+        dstMeta.set_elem_fn_type_info = srcMeta.set_elem_fn_type_info;
     if (!srcMeta.union_value_type.empty())
         dstMeta.union_value_type = srcMeta.union_value_type;
     if (!srcMeta.enum_value_type.empty())

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -85,7 +85,11 @@ void CodeGen::emitVarDecl(const std::string &name,
             setTypeMeta(TypeMeta::MapValue, ptr, valTy);
             {
                 std::string vtn = extractMapValueTypeName(*annot);
-                if (!vtn.empty()) getOrCreateMeta(ptr).map_value_type_name = vtn;
+                if (!vtn.empty()) {
+                    getOrCreateMeta(ptr).map_value_type_name = vtn;
+                    if (isFunctionTypeName(vtn))
+                        getOrCreateMeta(ptr).map_value_fn_type_info = parseFnTypeAnnotation(vtn);
+                }
             }
             markArcManaged(ptr);
             if (is_immutable)
@@ -412,15 +416,37 @@ void CodeGen::emitVarDecl(const std::string &name,
         {
             auto *valMeta = getMeta(val);
             std::string mvtn;
-            if (valMeta && !valMeta->map_value_type_name.empty()) {
-                mvtn = valMeta->map_value_type_name;
-            } else if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val)) {
-                auto *loadMeta = getMeta(load->getPointerOperand());
-                if (loadMeta && !loadMeta->map_value_type_name.empty())
-                    mvtn = loadMeta->map_value_type_name;
+            std::optional<FnTypeInfo> mvfti;
+            if (valMeta) {
+                if (!valMeta->map_value_type_name.empty())
+                    mvtn = valMeta->map_value_type_name;
+                if (valMeta->map_value_fn_type_info)
+                    mvfti = valMeta->map_value_fn_type_info;
             }
-            if (!mvtn.empty())
+            if (mvtn.empty()) {
+                if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val)) {
+                    auto *loadMeta = getMeta(load->getPointerOperand());
+                    if (loadMeta) {
+                        if (!loadMeta->map_value_type_name.empty())
+                            mvtn = loadMeta->map_value_type_name;
+                        if (!mvfti && loadMeta->map_value_fn_type_info)
+                            mvfti = loadMeta->map_value_fn_type_info;
+                    }
+                }
+            }
+            // Also derive from annotation: Map<K, function(int) -> int> → mvtn = "function(int) -> int"
+            if (mvtn.empty() && annot && isMapTypeName(resolvedAnnot)) {
+                std::string vtn = extractMapValueTypeName(resolvedAnnot);
+                if (!vtn.empty())
+                    mvtn = vtn;
+            }
+            if (!mvtn.empty()) {
                 getOrCreateMeta(ptr).map_value_type_name = mvtn;
+                if (!mvfti && isFunctionTypeName(mvtn))
+                    mvfti = parseFnTypeAnnotation(mvtn);
+            }
+            if (mvfti)
+                getOrCreateMeta(ptr).map_value_fn_type_info = mvfti;
         }
 
         // --- Set tracking ---
@@ -436,6 +462,46 @@ void CodeGen::emitVarDecl(const std::string &name,
         }
         if (setElemTy)
             setTypeMeta(TypeMeta::SetElem, ptr, setElemTy);
+
+        // --- Set element type name tracking (for Set<List>, Set<Map>, Set<closure>) ---
+        {
+            auto *valMeta = getMeta(val);
+            std::string setn;
+            std::optional<FnTypeInfo> sefti;
+            if (valMeta) {
+                if (!valMeta->set_elem_type_name.empty())
+                    setn = valMeta->set_elem_type_name;
+                if (valMeta->set_elem_fn_type_info)
+                    sefti = valMeta->set_elem_fn_type_info;
+            }
+            if (setn.empty()) {
+                if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val)) {
+                    auto *loadMeta = getMeta(load->getPointerOperand());
+                    if (loadMeta) {
+                        if (!loadMeta->set_elem_type_name.empty())
+                            setn = loadMeta->set_elem_type_name;
+                        if (!sefti && loadMeta->set_elem_fn_type_info)
+                            sefti = loadMeta->set_elem_fn_type_info;
+                    }
+                }
+            }
+            if (setn.empty() && annot &&
+                isSetTypeName(resolvedAnnot) && resolvedAnnot.size() > 4 && resolvedAnnot.back() == '>') {
+                std::string inner = resolvedAnnot.substr(4, resolvedAnnot.size() - 5);
+                while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
+                if (isListTypeName(inner) || isMapTypeName(inner) || isSetTypeName(inner))
+                    setn = inner;
+                else if (isFunctionTypeName(inner))
+                    sefti = parseFnTypeAnnotation(inner);
+            }
+            if (!setn.empty()) {
+                getOrCreateMeta(ptr).set_elem_type_name = setn;
+                if (!sefti && isFunctionTypeName(setn))
+                    sefti = parseFnTypeAnnotation(setn);
+            }
+            if (sefti)
+                getOrCreateMeta(ptr).set_elem_fn_type_info = sefti;
+        }
 
         // --- Task tracking ---
         llvm::Type *taskTy = getTaskResultType(val);

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -197,8 +197,15 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
                     continue;
                 }
 
-                // Reject other non-stringifiable pointer-backed variants
-                if (uinfo.componentTypes[i]->isPointerTy() && compName != "str") {
+                // Reject non-stringifiable pointer-backed variants (str/collection/function are OK).
+                // This rejection branch is kept so that future additions of ARC-managed
+                // ptr-backed types without a formatter handler fail fast at compile time
+                // rather than producing garbage output.
+                if (uinfo.componentTypes[i]->isPointerTy() &&
+                    compName != "str" &&
+                    !isListTypeName(compName) &&
+                    !isMapTypeName(compName) &&
+                    !isSetTypeName(compName)) {
                     codegenError("cannot convert " + compName +
                                  " variant of union to string");
                 }
@@ -209,6 +216,11 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
                 // Propagate low-level type metadata for correct signedness formatting
                 if (isLowLevelTypeName(compName))
                     getOrCreateMeta(innerVal).low_level_type_name = compName;
+
+                // Propagate collection type metadata so List/Map/Set variants format
+                // their element types correctly (matches List/Map/Set branches below).
+                if (isListTypeName(compName) || isMapTypeName(compName) || isSetTypeName(compName))
+                    propagateTypeMeta(compName, innerVal);
 
                 llvm::Value *innerStr = valueToString(innerVal, inCollection);
 
@@ -348,6 +360,27 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
     }
 
     if (ty->isPointerTy()) {
+        // Propagate element-type metadata onto a freshly-loaded collection
+        // element so valueToString(elem) can detect nested collections / closures
+        // instead of falling through to the raw string-pointer path.  Snapshots
+        // are taken before any getOrCreateMeta() call because an insert into
+        // value_metadata_ may rehash and invalidate pointers from getMeta().
+        auto propagateElemMeta = [this](
+                llvm::Value *outer, llvm::Value *elem,
+                std::string ValueMetadata::*typeNameField,
+                std::optional<FnTypeInfo> ValueMetadata::*fnInfoField) {
+            std::string typeName;
+            std::optional<FnTypeInfo> fnInfo;
+            if (auto *outerMeta = getMeta(outer)) {
+                typeName = outerMeta->*typeNameField;
+                fnInfo   = outerMeta->*fnInfoField;
+            }
+            if (!typeName.empty())
+                propagateTypeMeta(typeName, elem);
+            if (fnInfo)
+                getOrCreateMeta(elem).fn_type_info = *fnInfo;
+        };
+
         // Set: sprint buffer + IR loop → {elem, elem, ...}
         if (llvm::Type *setElemTy = getSetElementType(val)) {
             auto spf = getSprintPrintf();
@@ -384,6 +417,9 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
             builder_.SetInsertPoint(elemBB);
             llvm::Value *elemPtr = builder_.CreateGEP(setElemTy, sf.elems, {iCur}, "vts_set_elem_ptr");
             llvm::Value *elem = builder_.CreateLoad(setElemTy, elemPtr, "vts_set_elem");
+            propagateElemMeta(val, elem,
+                              &ValueMetadata::set_elem_type_name,
+                              &ValueMetadata::set_elem_fn_type_info);
             llvm::Value *elemStr = valueToString(elem, true);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_set_s"), elemStr});
 
@@ -439,6 +475,9 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
 
             llvm::Value *valPtr = builder_.CreateGEP(mapValTy, mf.vals, {iCur}, "vts_map_val_ptr");
             llvm::Value *valVal = builder_.CreateLoad(mapValTy, valPtr, "vts_map_val");
+            propagateElemMeta(val, valVal,
+                              &ValueMetadata::map_value_type_name,
+                              &ValueMetadata::map_value_fn_type_info);
             llvm::Value *valStr = valueToString(valVal, true);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_map_v_s"), valStr});
 
@@ -487,23 +526,9 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
             builder_.SetInsertPoint(elemBB);
             llvm::Value *elemPtr = builder_.CreateGEP(listElemTy, lf.data, {iCur}, "vts_list_elem_ptr");
             llvm::Value *elem = builder_.CreateLoad(listElemTy, elemPtr, "vts_list_elem");
-            // Propagate list element metadata so valueToString(elem) can detect
-            // Map/Set elements (via list_elem_type_name) and closure elements
-            // (via fn_type_info) instead of falling through to the raw string-
-            // pointer path.  Snapshot both fields before getOrCreateMeta() to
-            // avoid pointer invalidation if value_metadata_ is rehashed.
-            {
-                std::string elemTypeName;
-                std::optional<FnTypeInfo> elemFnTypeInfo;
-                if (auto *listMeta = getMeta(val)) {
-                    elemTypeName   = listMeta->list_elem_type_name;
-                    elemFnTypeInfo = listMeta->list_elem_fn_type_info;
-                }
-                if (!elemTypeName.empty())
-                    propagateTypeMeta(elemTypeName, elem);
-                if (elemFnTypeInfo)
-                    getOrCreateMeta(elem).fn_type_info = *elemFnTypeInfo;
-            }
+            propagateElemMeta(val, elem,
+                              &ValueMetadata::list_elem_type_name,
+                              &ValueMetadata::list_elem_fn_type_info);
             llvm::Value *elemStr = valueToString(elem, true);
             builder_.CreateCall(spf, {cachedGlobalString("%s", ".vts_list_s"), elemStr});
 
@@ -534,10 +559,10 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
         return builder_.CreateSelect(val, trueStr, falseStr, "vts_bool");
     }
     if (ty->isDoubleTy()) {
-        llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 64)}, "vts_buf");
-        llvm::Constant *fmt = cachedGlobalString("%g", ".vts_float_fmt");
-        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 64), fmt, val});
-        return buf;
+        // Delegate to runtime helper so Python-style ".0" suffix is added
+        // for whole-number floats (see __ry_fmt_float in runtime_any.cpp, #808).
+        llvm::FunctionCallee fmtFn = getRuntimeFn("__ry_fmt_float", ptrTy_, {f64Ty_});
+        return builder_.CreateCall(fmtFn, {val}, "vts_f64_str");
     }
     // Check low-level type metadata for ambiguous LLVM types
     std::string llName = getLowLevelTypeName(val);
@@ -585,11 +610,10 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
         return buf;
     }
     if (ty == f32Ty_) {
-        llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 64)}, "vts_buf");
-        llvm::Constant *fmt = cachedGlobalString("%g", ".vts_f32_fmt");
+        // Promote to f64 and call the shared float formatter helper (#808).
         llvm::Value *ext = builder_.CreateFPExt(val, f64Ty_, "f32_ext");
-        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 64), fmt, ext});
-        return buf;
+        llvm::FunctionCallee fmtFn = getRuntimeFn("__ry_fmt_float", ptrTy_, {f64Ty_});
+        return builder_.CreateCall(fmtFn, {ext}, "vts_f32_str");
     }
     // default: int (i64) or i64/u64
     llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -560,8 +560,8 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
     }
     if (ty->isDoubleTy()) {
         // Delegate to runtime helper so Python-style ".0" suffix is added
-        // for whole-number floats (see __ry_fmt_float in runtime_any.cpp, #808).
-        llvm::FunctionCallee fmtFn = getRuntimeFn("__ry_fmt_float", ptrTy_, {f64Ty_});
+        // for whole-number floats (see __ry_any_fmt_float in runtime_any.cpp, #808).
+        llvm::FunctionCallee fmtFn = getRuntimeFn("__ry_any_fmt_float", ptrTy_, {f64Ty_});
         return builder_.CreateCall(fmtFn, {val}, "vts_f64_str");
     }
     // Check low-level type metadata for ambiguous LLVM types
@@ -612,7 +612,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
     if (ty == f32Ty_) {
         // Promote to f64 and call the shared float formatter helper (#808).
         llvm::Value *ext = builder_.CreateFPExt(val, f64Ty_, "f32_ext");
-        llvm::FunctionCallee fmtFn = getRuntimeFn("__ry_fmt_float", ptrTy_, {f64Ty_});
+        llvm::FunctionCallee fmtFn = getRuntimeFn("__ry_any_fmt_float", ptrTy_, {f64Ty_});
         return builder_.CreateCall(fmtFn, {ext}, "vts_f32_str");
     }
     // default: int (i64) or i64/u64

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -96,6 +96,34 @@ static void repeatStr(RyAny *result, const char *s, int64_t n) {
 
 // ===== String conversion (#225) =====
 
+// Format a double using %g precision but append ".0" for whole-number values
+// so that `3.0` prints as "3.0" instead of "3" (Python-compatible, #808).
+// Precision stays at %g (~6 digits) to match existing test expectations like
+// `to_str(3.14) == "3.14"`.
+extern "C" const char *__ry_fmt_float(double x) {
+    char *buf = static_cast<char *>(checked_malloc(64));
+    snprintf(buf, 64, "%g", x);
+    // Skip ".0" correction for NaN/Inf ("nan", "inf", "-nan", "-inf") and for
+    // values already containing a decimal point or exponent.
+    bool needsDotZero = true;
+    for (char *p = buf; *p; ++p) {
+        if (*p == '.' || *p == 'e' || *p == 'E' ||
+            *p == 'n' || *p == 'N' || *p == 'i' || *p == 'I') {
+            needsDotZero = false;
+            break;
+        }
+    }
+    if (needsDotZero) {
+        size_t len = strlen(buf);
+        if (len + 3 < 64) {
+            buf[len] = '.';
+            buf[len + 1] = '0';
+            buf[len + 2] = '\0';
+        }
+    }
+    return buf;
+}
+
 extern "C" const char *__ry_any_to_string(const RyAny *a) {
     switch (a->tag) {
     case static_cast<int64_t>(RyAnyTag::Int): {
@@ -103,11 +131,8 @@ extern "C" const char *__ry_any_to_string(const RyAny *a) {
         snprintf(buf, 32, "%lld", (long long)extractInt(a));
         return buf;
     }
-    case static_cast<int64_t>(RyAnyTag::Float): {
-        char *buf = static_cast<char *>(checked_malloc(64));
-        snprintf(buf, 64, "%g", extractFloat(a));
-        return buf;
-    }
+    case static_cast<int64_t>(RyAnyTag::Float):
+        return __ry_fmt_float(extractFloat(a));
     case static_cast<int64_t>(RyAnyTag::Bool):
         return extractInt(a) ? "true" : "false";
     case static_cast<int64_t>(RyAnyTag::Str):

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -100,7 +100,7 @@ static void repeatStr(RyAny *result, const char *s, int64_t n) {
 // so that `3.0` prints as "3.0" instead of "3" (Python-compatible, #808).
 // Precision stays at %g (~6 digits) to match existing test expectations like
 // `to_str(3.14) == "3.14"`.
-extern "C" const char *__ry_fmt_float(double x) {
+extern "C" const char *__ry_any_fmt_float(double x) {
     char *buf = static_cast<char *>(checked_malloc(64));
     snprintf(buf, 64, "%g", x);
     // Skip ".0" correction for NaN/Inf ("nan", "inf", "-nan", "-inf") and for
@@ -132,7 +132,7 @@ extern "C" const char *__ry_any_to_string(const RyAny *a) {
         return buf;
     }
     case static_cast<int64_t>(RyAnyTag::Float):
-        return __ry_fmt_float(extractFloat(a));
+        return __ry_any_fmt_float(extractFloat(a));
     case static_cast<int64_t>(RyAnyTag::Bool):
         return extractInt(a) ? "true" : "false";
     case static_cast<int64_t>(RyAnyTag::Str):

--- a/tests/spec/collection_string_display.test.ry
+++ b/tests/spec/collection_string_display.test.ry
@@ -121,4 +121,44 @@ describe("collection string display", ():
     expected = "[\"he said \\\"hi\\\"\"]"
     expect(to_str(xs)).to_eq(expected)
   )
+
+  # --- #811: nested-container Map values / Set elements ---
+
+  it("should show List value inside Map (#811)", ():
+    m: Map<str, List<int>> = {"a": [1, 2, 3]}
+    expected = "{" + "\"a\"" + ": [1, 2, 3]}"
+    expect(to_str(m)).to_eq(expected)
+  )
+  it("should show two List values inside Map (#811)", ():
+    m: Map<str, List<int>> = {"a": [1, 2], "b": [3, 4]}
+    s = to_str(m)
+    # Map iteration order is insertion order
+    expected = "{" + "\"a\"" + ": [1, 2], " + "\"b\"" + ": [3, 4]}"
+    expect(s).to_eq(expected)
+  )
+  it("should show Map value inside Map (#811)", ():
+    m: Map<str, Map<str, int>> = {"outer": {"inner": 42}}
+    expected = "{" + "\"outer\"" + ": {" + "\"inner\"" + ": 42}}"
+    expect(to_str(m)).to_eq(expected)
+  )
+  it("should show Set value inside Map (#811)", ():
+    m: Map<str, Set<int>> = {"a": {1}}
+    expected = "{" + "\"a\"" + ": {1}}"
+    expect(to_str(m)).to_eq(expected)
+  )
+  it("should show List value inside Map with int keys (#811)", ():
+    m: Map<int, List<int>> = {1: [10, 20], 2: [30]}
+    expect(to_str(m)).to_eq("{1: [10, 20], 2: [30]}")
+  )
+
+  # Regression guards: List outer already worked, keep them
+  it("should show nested List of List (regression)", ():
+    xs: List<List<int>> = [[1, 2], [3, 4]]
+    expect(to_str(xs)).to_eq("[[1, 2], [3, 4]]")
+  )
+  it("should show nested List of Map (regression)", ():
+    xs: List<Map<str, int>> = [{"a": 1}, {"b": 2}]
+    expected = "[{" + "\"a\"" + ": 1}, {" + "\"b\"" + ": 2}]"
+    expect(to_str(xs)).to_eq(expected)
+  )
 )

--- a/tests/spec/print_to_str_consistency.test.ry
+++ b/tests/spec/print_to_str_consistency.test.ry
@@ -152,17 +152,23 @@ describe("print and to_str consistency", ():
   it("should print function value directly as <closure> (regression)", ():
     f = (x: int) => x * 2
     expect(to_str(f)).to_eq("<closure>")
+    print(f)
+    # expect-output: <closure>
   )
 
   it("should print function value inside Map as <closure> (#810)", ():
     fs: Map<str, function(int) -> int> = {"double": (x: int) => x * 2}
     expected = "{" + "\"double\"" + ": <closure>}"
     expect(to_str(fs)).to_eq(expected)
+    print(fs)
+    # expect-output: {"double": <closure>}
   )
 
   it("should print function value inside List as <closure> (regression)", ():
     fs: List<function(int) -> int> = [(x: int) => x + 1]
     expect(to_str(fs)).to_eq("[<closure>]")
+    print(fs)
+    # expect-output: [<closure>]
   )
 )
 

--- a/tests/spec/print_to_str_consistency.test.ry
+++ b/tests/spec/print_to_str_consistency.test.ry
@@ -25,6 +25,27 @@ describe("print and to_str consistency", ():
     # expect-output: 3.14
   )
 
+  it("should display whole-number float with .0 (#808)", ():
+    expect(to_str(3.0)).to_eq("3.0")
+    expect(to_str(1.0)).to_eq("1.0")
+    expect(to_str(0.0)).to_eq("0.0")
+    print(3.0)
+    # expect-output: 3.0
+  )
+
+  it("should display negative whole-number float with .0 (#808)", ():
+    expect(to_str(-2.0)).to_eq("-2.0")
+  )
+
+  it("should display whole-number float via variable with .0 (#808)", ():
+    x: float = 5.0
+    expect(to_str(x)).to_eq("5.0")
+  )
+
+  it("should preserve .0 in f-string interpolation (#808)", ():
+    expect(f"{3.0}").to_eq("3.0")
+  )
+
   it("should be consistent for bool", ():
     expect(to_str(true)).to_eq("true")
     expect(to_str(false)).to_eq("false")
@@ -124,6 +145,24 @@ describe("print and to_str consistency", ():
     expect(to_str(Color::Red)).to_eq("Red")
     print(Color::Green)
     # expect-output: Green
+  )
+
+  # --- #810: function values in Map (direct case already fixed by #728) ---
+
+  it("should print function value directly as <closure> (regression)", ():
+    f = (x: int) => x * 2
+    expect(to_str(f)).to_eq("<closure>")
+  )
+
+  it("should print function value inside Map as <closure> (#810)", ():
+    fs: Map<str, function(int) -> int> = {"double": (x: int) => x * 2}
+    expected = "{" + "\"double\"" + ": <closure>}"
+    expect(to_str(fs)).to_eq(expected)
+  )
+
+  it("should print function value inside List as <closure> (regression)", ():
+    fs: List<function(int) -> int> = [(x: int) => x + 1]
+    expect(to_str(fs)).to_eq("[<closure>]")
   )
 )
 

--- a/tests/spec/to_str_union.test.ry
+++ b/tests/spec/to_str_union.test.ry
@@ -47,4 +47,35 @@ describe("to_str union", ():
     x: u8 | str = 200 as u8
     expect(to_str(x)).to_eq("200")
   )
+
+  # --- #836: collection-typed union variants ---
+
+  it("should convert List variant of union to string (#836)", ():
+    x: int | List<int> = [1, 2, 3]
+    expect(to_str(x)).to_eq("[1, 2, 3]")
+  )
+  it("should keep int variant of union with List (#836)", ():
+    x: int | List<int> = 42
+    expect(to_str(x)).to_eq("42")
+  )
+  it("should convert Map variant of union to string (#836)", ():
+    x: str | Map<str, int> = {"a": 1}
+    expect(to_str(x)).to_eq("{" + "\"a\"" + ": 1}")
+  )
+  it("should convert Set variant of union to string (#836)", ():
+    x: int | Set<int> = {1, 2}
+    expect(to_str(x)).to_eq("{1, 2}")
+  )
+  it("should convert List | Map union where variant is List", ():
+    x: List<int> | Map<str, int> = [10, 20]
+    expect(to_str(x)).to_eq("[10, 20]")
+  )
+  it("should convert List | Map union where variant is Map", ():
+    x: List<int> | Map<str, int> = {"k": 5}
+    expect(to_str(x)).to_eq("{" + "\"k\"" + ": 5}")
+  )
+  it("should convert nested collection in union variant (#836)", ():
+    x: int | List<List<int>> = [[1, 2], [3]]
+    expect(to_str(x)).to_eq("[[1, 2], [3]]")
+  )
 )

--- a/tests/spec/to_str_union.test.ry
+++ b/tests/spec/to_str_union.test.ry
@@ -78,4 +78,24 @@ describe("to_str union", ():
     x: int | List<List<int>> = [[1, 2], [3]]
     expect(to_str(x)).to_eq("[[1, 2], [3]]")
   )
+
+  # Same-kind ptr-backed variants must disambiguate by reconstructed type name.
+  it("should disambiguate List<int> | List<str> via element type", ():
+    a: List<int> | List<str> = [1, 2, 3]
+    b: List<int> | List<str> = ["a", "b"]
+    expect(to_str(a)).to_eq("[1, 2, 3]")
+    expect(to_str(b)).to_eq("[" + "\"a\"" + ", " + "\"b\"" + "]")
+  )
+  it("should disambiguate Map<str, int> | Map<str, bool> via value type", ():
+    m1: Map<str, int> | Map<str, bool> = {"k": 42}
+    m2: Map<str, int> | Map<str, bool> = {"k": true}
+    expect(to_str(m1)).to_eq("{" + "\"k\"" + ": 42}")
+    expect(to_str(m2)).to_eq("{" + "\"k\"" + ": true}")
+  )
+  it("should disambiguate Set<int> | Set<str> via element type", ():
+    s1: Set<int> | Set<str> = {1}
+    s2: Set<int> | Set<str> = {"a"}
+    expect(to_str(s1)).to_eq("{1}")
+    expect(to_str(s2)).to_eq("{" + "\"a\"" + "}")
+  )
 )

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -8,8 +8,8 @@ TEST_F(CodeGenTest, PrintLiterals) {
     EXPECT_EQ(runSource("print(42)"), "42\n");
     EXPECT_EQ(runSource("x = -10\nprint(x)"), "-10\n");
     EXPECT_EQ(runSource("print(3.14)"), "3.14\n");
-    // %g 形式: 1.0 → "1"
-    EXPECT_EQ(runSource("print(1.0)"), "1\n");
+    // %g + ".0" correction: whole-number floats print as "1.0" (#808)
+    EXPECT_EQ(runSource("print(1.0)"), "1.0\n");
     EXPECT_EQ(runSource("print(true)"), "true\n");
     EXPECT_EQ(runSource("print(false)"), "false\n");
     EXPECT_EQ(runSource("print(\"hello\")"), "hello\n");
@@ -40,17 +40,17 @@ TEST_F(CodeGenTest, ArithmeticInt) {
     EXPECT_EQ(runSource("x = +5\nprint(x)"), "5\n");
     EXPECT_EQ(runSource("x = 10 % 3\nprint(x)"), "1\n");
     EXPECT_EQ(runSource("x = 7 // 2\nprint(x)"), "3\n");
-    // 2 ** 10 = 1024 (f64 → %g → "1024")
-    EXPECT_EQ(runSource("x = 2 ** 10\nprint(x)"), "1024\n");
+    // 2 ** 10 = 1024 (f64 with ".0" correction, #808)
+    EXPECT_EQ(runSource("x = 2 ** 10\nprint(x)"), "1024.0\n");
     // 2 ** 3 ** 2 = 2 ** (3 ** 2) = 2 ** 9 = 512
-    EXPECT_EQ(runSource("x = 2 ** 3 ** 2\nprint(x)"), "512\n");
+    EXPECT_EQ(runSource("x = 2 ** 3 ** 2\nprint(x)"), "512.0\n");
 }
 
 // ===== Arithmetic (float) =====
 
 TEST_F(CodeGenTest, ArithmeticFloat) {
     EXPECT_EQ(runSource("x = 7 / 2\nprint(x)"), "3.5\n");
-    EXPECT_EQ(runSource("x = 1.5 + 2.5\nprint(x)"), "4\n");
+    EXPECT_EQ(runSource("x = 1.5 + 2.5\nprint(x)"), "4.0\n");
     EXPECT_EQ(runSource("x = 1 + 2.5\nprint(x)"), "3.5\n");
     EXPECT_EQ(runSource("x = 5.5 % 2.0\nprint(x)"), "1.5\n");
 }
@@ -546,7 +546,7 @@ TEST_F(CodeGenTest, LowLevelI16Basics) {
 
 TEST_F(CodeGenTest, LowLevelF32Basics) {
     EXPECT_EQ(runSource("x: f32 = 2.5\nprint(x)"), "2.5\n");
-    EXPECT_EQ(runSource("x: f32 = 0.0\nprint(x)"), "0\n");
+    EXPECT_EQ(runSource("x: f32 = 0.0\nprint(x)"), "0.0\n");
 }
 
 TEST_F(CodeGenTest, LowLevelI32Arithmetic) {
@@ -560,9 +560,9 @@ TEST_F(CodeGenTest, LowLevelI32Arithmetic) {
 }
 
 TEST_F(CodeGenTest, LowLevelF32Arithmetic) {
-    EXPECT_EQ(runSource("a: f32 = 1.5\nb: f32 = 2.5\nc = a + b\nprint(c)"), "4\n");
-    EXPECT_EQ(runSource("a: f32 = 5.0\nb: f32 = 2.0\nc = a - b\nprint(c)"), "3\n");
-    EXPECT_EQ(runSource("a: f32 = 3.0\nb: f32 = 4.0\nc = a * b\nprint(c)"), "12\n");
+    EXPECT_EQ(runSource("a: f32 = 1.5\nb: f32 = 2.5\nc = a + b\nprint(c)"), "4.0\n");
+    EXPECT_EQ(runSource("a: f32 = 5.0\nb: f32 = 2.0\nc = a - b\nprint(c)"), "3.0\n");
+    EXPECT_EQ(runSource("a: f32 = 3.0\nb: f32 = 4.0\nc = a * b\nprint(c)"), "12.0\n");
     EXPECT_EQ(runSource("a: f32 = 7.0\nb: f32 = 2.0\nc = a / b\nprint(c)"), "3.5\n");
 }
 
@@ -581,13 +581,13 @@ TEST_F(CodeGenTest, LowLevelCast) {
     EXPECT_EQ(runSource("x: i32 = 100\ny = x as i16\nprint(y)"), "100\n");
     EXPECT_EQ(runSource("x: i16 = 100\ny = x as i32\nprint(y)"), "100\n");
     // i32 <-> float
-    EXPECT_EQ(runSource("x: i32 = 42\ny = x as float\nprint(y)"), "42\n");
+    EXPECT_EQ(runSource("x: i32 = 42\ny = x as float\nprint(y)"), "42.0\n");
     EXPECT_EQ(runSource("x = 3.14\ny = x as i32\nprint(y)"), "3\n");
     // f32 <-> float
     EXPECT_EQ(runSource("x: f32 = 2.5\ny = x as float\nprint(y)"), "2.5\n");
     EXPECT_EQ(runSource("x = 2.5\ny = x as f32\ny2 = y as float\nprint(y2)"), "2.5\n");
     // i32 <-> f32
-    EXPECT_EQ(runSource("x: i32 = 42\ny = x as f32\ny2 = y as float\nprint(y2)"), "42\n");
+    EXPECT_EQ(runSource("x: i32 = 42\ny = x as f32\ny2 = y as float\nprint(y2)"), "42.0\n");
     EXPECT_EQ(runSource("x: f32 = 3.14\ny = x as i32\nprint(y)"), "3\n");
 }
 
@@ -601,7 +601,7 @@ TEST_F(CodeGenTest, LowLevelTypeInference) {
     // i16 inference propagation
     EXPECT_EQ(runSource("a: i16 = 3\nb: i16 = 7\nc = a + b\nprint(c)"), "10\n");
     // f32 inference propagation
-    EXPECT_EQ(runSource("a: f32 = 1.5\nb: f32 = 2.5\nc = a + b\nprint(c)"), "4\n");
+    EXPECT_EQ(runSource("a: f32 = 1.5\nb: f32 = 2.5\nc = a + b\nprint(c)"), "4.0\n");
     // Inferred f32 variable cannot be mixed with float
     EXPECT_THROW(runSource("a: f32 = 1.0\nb: f32 = 2.0\nc = a + b\nd = 3.0\ne = c + d"), std::runtime_error);
 }
@@ -669,7 +669,7 @@ TEST_F(CodeGenTest, NumericLiteralSuffix_f32) {
 
 TEST_F(CodeGenTest, NumericLiteralSuffix_IntWithF32) {
     // Integer literal with f32 suffix becomes float
-    EXPECT_EQ(runSource("x = 42f32\nprint(x)"), "42\n");
+    EXPECT_EQ(runSource("x = 42f32\nprint(x)"), "42.0\n");
 }
 
 TEST_F(CodeGenTest, NumericLiteralSuffix_Hex) {

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -847,7 +847,7 @@ TEST_F(CodeGenTest, FStringBoolValue) {
 // ===== as cast tests =====
 
 TEST_F(CodeGenTest, AsCastIntToFloat) {
-    EXPECT_EQ(runSource("x = 42 as float\nprint(x)"), "42\n");
+    EXPECT_EQ(runSource("x = 42 as float\nprint(x)"), "42.0\n");
 }
 
 TEST_F(CodeGenTest, AsCastFloatToInt) {
@@ -1096,7 +1096,7 @@ TEST_F(CodeGenTest, EnumADTMatchRect) {
         "        print(w + h)\n"
         "    case Shape::Point:\n"
         "        print(\"point\")";
-    EXPECT_EQ(runSource(src), "7\n");
+    EXPECT_EQ(runSource(src), "7.0\n");
 }
 
 TEST_F(CodeGenTest, EnumADTMixed) {

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -361,7 +361,7 @@ TEST_F(CodeGenTest, StringToFloat) {
     // ToFloatBasic
     EXPECT_EQ(runSource("print(to_float(\"3.14\"))"), "3.14\n");
     // ToFloatInteger
-    EXPECT_EQ(runSource("print(to_float(\"42\"))"), "42\n");
+    EXPECT_EQ(runSource("print(to_float(\"42\"))"), "42.0\n");
     // ToFloatUFCS
     EXPECT_EQ(runSource("s = \"2.5\"\nprint(s.to_float())"), "2.5\n");
 }
@@ -644,7 +644,7 @@ TEST_F(CodeGenTest, OverloadBasicResolution) {
             "    return x * 3.0\n"
             "print(f(5))\n"
             "print(f(2.0))";
-        EXPECT_EQ(runSource(src), "10\n6\n");
+        EXPECT_EQ(runSource(src), "10\n6.0\n");
     }
     // OverloadDifferentReturn
     {
@@ -1114,7 +1114,7 @@ TEST_F(CodeGenTest, CompoundAssignExtended) {
     // CompoundAssignFloorDiv
     EXPECT_EQ(runSource("x = 7\nx //= 2\nprint(x)"), "3\n");
     // CompoundAssignPower
-    EXPECT_EQ(runSource("x = 2.0\nx **= 3.0\nprint(x)"), "8\n");
+    EXPECT_EQ(runSource("x = 2.0\nx **= 3.0\nprint(x)"), "8.0\n");
     // CompoundAssignBitAnd
     EXPECT_EQ(runSource("x = 12\nx &= 10\nprint(x)"), "8\n");
     // CompoundAssignBitOr
@@ -1310,7 +1310,7 @@ TEST_F(CodeGenTest, MapBasics) {
             "xs = [1, 2, 3]\n"
             "ys = map(xs, (x: int) => x * 1.5)\n"
             "print(ys)";
-        EXPECT_EQ(runSource(src), "[1.5, 3, 4.5]\n");
+        EXPECT_EQ(runSource(src), "[1.5, 3.0, 4.5]\n");
     }
     // MapStrToInt
     {
@@ -1405,7 +1405,7 @@ TEST_F(CodeGenTest, SortBasics) {
             "xs = [3.0, 1.0, 2.0]\n"
             "ys = sort(xs)\n"
             "print(ys)";
-        EXPECT_EQ(runSource(src), "[1, 2, 3]\n");
+        EXPECT_EQ(runSource(src), "[1.0, 2.0, 3.0]\n");
     }
     // SortStrAsc
     {
@@ -1919,7 +1919,7 @@ TEST_F(CodeGenTest, ListRemoveByType) {
             "xs = [1.0, 2.5, 3.0]\n"
             "remove(xs, 2.5)\n"
             "print(xs)";
-        EXPECT_EQ(runSource(src), "[1, 3]\n");
+        EXPECT_EQ(runSource(src), "[1.0, 3.0]\n");
     }
 }
 
@@ -1974,7 +1974,7 @@ TEST_F(CodeGenTest, DistinctVariants) {
     // DistinctStr
     EXPECT_EQ(runSource("xs = [\"a\", \"b\", \"a\", \"c\", \"b\"]\nprint(distinct(xs))"), "[\"a\", \"b\", \"c\"]\n");
     // DistinctFloat
-    EXPECT_EQ(runSource("xs = [1.0, 2.0, 1.0, 3.0]\nprint(distinct(xs))"), "[1, 2, 3]\n");
+    EXPECT_EQ(runSource("xs = [1.0, 2.0, 1.0, 3.0]\nprint(distinct(xs))"), "[1.0, 2.0, 3.0]\n");
     // DistinctAlreadyUnique
     EXPECT_EQ(runSource("xs = [1, 2, 3]\nprint(distinct(xs))"), "[1, 2, 3]\n");
     // DistinctAllSame
@@ -2330,7 +2330,7 @@ TEST_F(CodeGenTest, OperatorAs) {
 }
 
 TEST_F(CodeGenTest, OperatorAsFallbackBuiltin) {
-    EXPECT_EQ(runSource("x = 42\nprint(x as float)"), "42\n");
+    EXPECT_EQ(runSource("x = 42\nprint(x as float)"), "42.0\n");
 }
 
 TEST_F(CodeGenTest, OperatorCallParamValidation) {

--- a/tests/test_codegen_regex.cpp
+++ b/tests/test_codegen_regex.cpp
@@ -246,7 +246,7 @@ x = 10 / 2
 print(x)
 y = 100 // 3
 print(y)
-)"), "5\n33\n");
+)"), "5.0\n33\n");
 }
 
 TEST_F(CodeGenTest, RegexLiteralEscapedSlash) {

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1299,7 +1299,7 @@ TEST_F(CodeGenTest, DefaultArgWithWidening) {
     EXPECT_EQ(runSource(
         "function calc(x: float, precision: int = 6) -> float:\n"
         "    return x\n"
-        "print(calc(3))"), "3\n");
+        "print(calc(3))"), "3.0\n");
 }
 
 TEST_F(CodeGenTest, DefaultArgGenericError) {


### PR DESCRIPTION
## Summary

Fixes four print/to_str bugs discovered in v0.0.8, all stemming from missing metadata propagation / format specifiers in the formatter layer. The #811 issue body explicitly asks for a sweep of the entire `print()` / `to_str()` / f-string layer rather than a point fix, so this PR addresses the related bugs together.

Closes #811, closes #836, closes #808, closes #810.

## Bugs fixed

| # | Issue | Before | After |
|---|---|---|---|
| #811 | `Map<str, List<int>> = {\"a\": [1,2,3]}` | `{\"a\": \"\\003\"}` (garbage) | `{\"a\": [1, 2, 3]}` |
| #836 | `int \| List<int> = [1,2,3]` | **compile error** `cannot convert List<int> variant of union to string` | `[1, 2, 3]` |
| #808 | `print(3.0)` / `print(0.0)` | `3` / `0` (indistinguishable from int) | `3.0` / `0.0` (Python-compatible) |
| #810 | `Map<str, function(int) -> int> = {\"k\": lambda}` | `{\"k\": \"\\b\"}` (garbage) | `{\"k\": <closure>}` |

As a side fix required by #836, `wrapInUnion` now disambiguates same-LLVM-type variants (e.g. `List<int> | Map<str, int>` — both are `ptr`) using the value's collection / function metadata instead of always picking the first pointer-typed component.

## Implementation

- **`ValueMetadata`**: add `set_elem_type_name`, `map_value_fn_type_info`, `set_elem_fn_type_info` to mirror the existing `list_elem_*` pattern, and propagate them through `propagateTypeMeta` / `propagateMeta` / `emitVarDecl`.
- **`valueToString`**: extract a `propagateElemMeta` lambda (using pointer-to-member) shared by List / Map / Set element loads so the snapshot-and-propagate pattern is written once. Accept collection variants in the union branch and call `propagateTypeMeta(compName, innerVal)`. Keep the rejection branch so future additions of non-stringifiable ptr-backed variants still fail fast.
- **`__ry_fmt_float`** (runtime_any.cpp): new helper that calls `snprintf(\"%g\", x)` and appends \".0\" when the buffer has no decimal point, exponent, nan, or inf. Wire it from `valueToString` (f64 / f32) and `__ry_any_to_string`. Precision stays at `%g` to keep existing `to_str(3.14) == \"3.14\"` assertions green; `%.17g` was considered but rejected because it breaks IEEE 754 round-trip assertions (see KNOWLEDGE.md).
- **`wrapInUnion`**: first pass tries to match the value's metadata kind against each component's type name (`isListTypeName` / `isMapTypeName` / `isSetTypeName` / `isFunctionTypeName`); falls back to the existing LLVM-type-only match if no kind-match is found.

## Docs

- `docs/reference/builtins.md` and `docs/reference/builtins-string.md`: document the `.0` suffix for whole-number floats, nested-container formatting, union collection variants, and `<closure>` display for function values.
- `KNOWLEDGE.md`: record three lessons learned during the sweep (metadata propagation at element loads, wrapInUnion disambiguation, and why `%.17g` precision was rejected).
- `changelog.d/811-836-808-810-print-sweep.md`: user-facing changelog fragment.

## Test plan

- [x] Add new failing tests for all four bugs to `tests/spec/collection_string_display.test.ry`, `tests/spec/to_str_union.test.ry`, and `tests/spec/print_to_str_consistency.test.ry` (including regression guards for the List-outer case that already worked).
- [x] Update 20 existing C++ test assertions in `tests/test_codegen*.cpp` that depended on the old whole-number float output (e.g. `\"1\\n\"` → `\"1.0\\n\"`).
- [x] `cmake --build build && ./build/ry_tests` — **1490 tests passed**.
- [x] `./build/ry test -p` — **102 test files, 0 failures**.
- [x] ASan: `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests && ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p` — all green, no leaks.
- [x] Manual verification of all four issue reproductions via `./build/ry -c` snippets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * print()/to_str() now correctly serializes nested Map/List/Set and collection-typed union variants
  * Unions with same-underlying representation are disambiguated so collection/function variants stringify correctly
  * Whole-number floats now render with a trailing `.0`
  * Closures/functions in collections and unions display as `<closure>` instead of garbled output

* **Documentation**
  * Updated print()/to_str() docs and examples to reflect expanded type support and float `.0` behavior

* **Tests**
  * Added/updated tests covering nested collections, unions, closures, and float formatting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->