### PR TITLE
fix: diagnose IR verify errors at the frontend (#805, #818, #821)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -192,6 +192,70 @@ changing the default `%g` precision.
 `__ry_fmt_float` (runtime_any.cpp) or elsewhere without also planning
 to update every float test assertion.
 
+### Diagnose type / control-flow mismatches at the frontend, never at LLVM verify
+
+**Source**: #805 / #818 / #821 sweep (2026-04-10)
+**Tags**: codegen, diagnostics, ir-verify, frontend
+
+**Context**: Three separate bugs all surfaced as cryptic LLVM IR verify
+errors (`icmp ne ptr, i0 0`, `Terminator found in the middle of a
+basic block`, `Call parameter type does not match function signature`)
+because codegen emitted invalid IR and relied on the LLVM verifier to
+flag it. Users saw LLVM internals instead of actionable messages:
+- #805: `Result<T, E>` routed to a `T`-expecting runtime call because
+  `isJsonValue()` trusted a metadata flag without checking `ptrTy_`.
+- #818: `toBool(ptr)` fell through to `ICmpNE(v, ConstantInt::get(ptrTy_,
+  0))` which LLVM printed as `icmp ne ptr, i0 0`.
+- #821: `emitExit()` created an `unreachable` terminator but did not
+  switch insertion blocks, so trailing statements emitted into a
+  terminated block.
+
+**Rule**: Whenever codegen is about to emit IR that depends on a type or
+control-flow invariant (argument type, terminator absence, block
+validity), check the invariant in C++ and call `codegenError(...)` with
+a user-facing message **before** the invalid IR is written. Never treat
+LLVM verification as a user-visible error surface.
+
+**How to verify**: grep for these smells in your change:
+
+```bash
+git diff origin/<base> -- 'src/**' \
+  | grep -nE 'ConstantInt::get\(.*->getType\(\)'
+git diff origin/<base> -- 'src/**' \
+  | grep -nE 'CreateUnreachable|CreateRet|CreateBr'
+```
+
+Every `ConstantInt::get(v->getType(), ...)` site must be guarded by an
+`isIntegerTy()` check. Every terminator-emitting call that is not the
+last thing in its basic block must either be followed by a new block
+creation + `SetInsertPoint`, or the caller loop must break on
+`GetInsertBlock()->getTerminator()`.
+
+### Dual-path builtins must share terminator / cleanup handling
+
+**Source**: #821 sweep (2026-04-10)
+**Tags**: codegen, builtins, exit, diverging-call
+
+**Context**: `exit()` had two dispatch paths: (1) as an expression via
+`emitBuiltinCore` in `src/codegen_call.cpp`, which explicitly created a
+fresh `exit.dead` block after emitting `unreachable`, and (2) as a
+statement via `builtins_["exit"]` lambda in `src/codegen.cpp`, which
+just called `emitExit()` and left the insertion point on the terminated
+block. The statement path (the most common usage) broke LLVM basic
+block invariants for any trailing code. Putting the dead-block switch
+inside `emitExit()` itself made both paths behave consistently.
+
+**Rule**: When a builtin or helper has post-emit fixup — dead block
+creation, ARC cleanup, metadata propagation, trace exit — put the
+fixup inside the core helper (`emitExit`, `emitReturn`, ...) so every
+dispatch path inherits it. If a fixup lives only in one caller, the
+other caller is a latent bug waiting to be triggered.
+
+**How to verify**: grep for all callers of the core helper and confirm
+each one either expects the helper's post-state or explicitly
+re-establishes its own. If any caller is silent about the post-state,
+the fixup belongs in the helper.
+
 ### New primitive types must be wired into every type-reflection site
 
 **Source**: #825 PR review (CodeRabbit, 4 comments)

--- a/changelog.d/805-818-821-ir-verify-sweep.md
+++ b/changelog.d/805-818-821-ir-verify-sweep.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- `Result<JsonValue, Error>` returned by `json.get` / `json.at` no longer
+  sneaks past JSON type checks via metadata alone. `isJsonValue()` now
+  also requires the underlying LLVM value to be a pointer, so passing a
+  `Result` to `kind` / `stringify` / `get` / `at` produces the existing
+  "requires a JsonValue argument" diagnostic instead of an LLVM IR verify
+  error. `to_str(result)` and `print(result)` still work and format as
+  `Ok(...)` / `Err(...)` via the generic `valueToString` path (#805).
+- Using `List` / `str` / `Map` / `Set` (or any other ptr-backed value) as
+  a boolean condition in `if` / `while` / `when` or under the unary `not`
+  operator now produces a clear compile-time error suggesting
+  `length(x) > 0` or `not is_empty(x)`, replacing the previous
+  `icmp ne ptr, i0 0` IR verify failure (#818).
+- `exit(0)` followed by more statements no longer triggers
+  `Terminator found in the middle of a basic block`. `emitExit()` now
+  switches to a fresh dead basic block so trailing IR lands on a valid
+  (unreachable) block and LLVM DCE removes it during optimization (#821).

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -314,12 +314,21 @@ for i in range(3):
 
 **Signature:** `exit(code: int)`
 
-Terminates the process immediately with the given exit code. Code after `exit()` is unreachable.
+Terminates the process immediately with the given exit code. Statements
+after `exit()` are compiled into an unreachable block that LLVM removes
+during optimization, so they never run:
 
 ```python
 exit(0)        # normal termination
 exit(1)        # error termination
+
+print("a")
+exit(0)
+print("b")     # never prints — unreachable after exit
 ```
+
+The same treatment applies to `return`, `break`, and `continue` — code
+after any diverging control-flow statement is silently elided.
 
 ---
 

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -20,7 +20,27 @@ else:
 | `bool` | `false` | `true` |
 | `int` | `0` | non-zero |
 
-`float` and `str` cannot be used directly as conditions.
+Only `bool` and integer types may appear in a condition. `float`, `str`,
+`List`, `Map`, `Set`, iterators, closures, records, `Option`, and `Result`
+cannot be used directly as conditions. For collections and strings, write
+the length check explicitly:
+
+```python
+xs = [1, 2, 3]
+# ✗ error: value of this type cannot be used as a boolean condition
+# if xs:
+#     print("non-empty")
+# ✓ explicit length check
+if length(xs) > 0:
+    print("non-empty")
+# ✓ equivalent using is_empty
+if not is_empty(xs):
+    print("non-empty")
+```
+
+For `Option` and `Result`, pattern-match the variants explicitly with
+`match` / `when` instead of using them as conditions. These rules apply
+equally to `while`, `when` arms, and the unary `not` operator.
 
 ### Example
 

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -19,8 +19,9 @@ else:
 |---|---|---|
 | `bool` | `false` | `true` |
 | `int` | `0` | non-zero |
+| `float` | `0.0` | non-zero |
 
-Only `bool` and integer types may appear in a condition. `float`, `str`,
+Only `bool`, integer, and `float` types may appear in a condition. `str`,
 `List`, `Map`, `Set`, iterators, closures, records, `Option`, and `Result`
 cannot be used directly as conditions. For collections and strings, write
 the length check explicitly:

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -57,6 +57,31 @@ The `json` package provides functions to parse JSON text into an opaque `JsonVal
 |----------|-----------|-------------|
 | `json_free` | `(JsonValue) -> Unit` | Frees a JsonValue and all its children |
 
+## Unwrapping `Result<JsonValue, Error>`
+
+`parse`, `get`, and `at` return `Result<JsonValue, Error>`. You must
+unwrap the `Result` before passing the inner value to another json
+function — passing the `Result` directly is rejected at compile time:
+
+```python
+match parse(text):
+  case Ok(doc):
+    # ✗ error: kind() requires a JsonValue argument
+    # kind(get(doc, "name"))
+    # ✓ unwrap first
+    match get(doc, "name"):
+      case Ok(name_val):
+        print(kind(name_val))
+      case Err(e):
+        print("no name")
+  case Err(e):
+    print("parse error")
+```
+
+Generic stringification (`to_str(result)`, `print(result)`, f-string
+interpolation) still works on a `Result` and formats as `Ok(...)` /
+`Err(...)`, matching the behavior for any other `Result` value.
+
 ## Usage Examples
 
 ### Parsing and accessing fields

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -398,11 +398,11 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
 // ===== Builtin Core =====
 
 llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
-    // exit(code) as expression — emit exit, then create dead block for subsequent IR
+    // exit(code) as expression — emitExit() switches the insert point to a
+    // fresh dead block internally (see codegen_match.cpp), so any trailing
+    // statements still land on a valid (unreachable) block.
     if (e.callee == "exit") {
         emitExit(e.args);
-        llvm::BasicBlock *deadBB = llvm::BasicBlock::Create(*ctx_, "exit.dead", fn_);
-        builder_.SetInsertPoint(deadBB);
         return llvm::UndefValue::get(i64Ty_);
     }
 

--- a/src/codegen_call_json.cpp
+++ b/src/codegen_call_json.cpp
@@ -14,6 +14,15 @@ struct JsonResourceReg { JsonResourceReg() {
 }
 
 bool CodeGen::isJsonValue(llvm::Value *val) {
+    // JsonValue is always represented as a ptr at the LLVM level. Metadata
+    // like `json_type_only` can ride on wrappers (e.g. Result<JsonValue,
+    // Error>) to keep the inner type known, but those wrapper values are not
+    // themselves JsonValues — routing them through the JSON runtime would
+    // pass a struct to a function expecting `ptr` and fail IR verification
+    // (#805). Gate on the LLVM type so metadata alone cannot mislabel a
+    // non-ptr value as a JsonValue.
+    if (val->getType() != ptrTy_)
+        return false;
     if (hasResourceKind(val, rk_json_value))
         return true;
     auto *meta = getMeta(val);

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -483,6 +483,19 @@ llvm::Value *CodeGen::toBool(llvm::Value *v) {
     if (v->getType()->isDoubleTy())
         return builder_.CreateFCmpONE(
             v, llvm::ConstantFP::get(f64Ty_, 0.0), "ftobool");
+    // Anything else must be a plain integer. ARC-managed ptr-backed values
+    // (List, Map, Set, str, iterator, closure, record handle, ...) used to
+    // fall through to `icmp ne ptr, ConstantInt::get(ptrTy_, 0)`, which LLVM
+    // rendered as `icmp ne ptr, i0 0` and rejected in IR verification (#818).
+    // Reject at the frontend with a clearer, type-aware diagnostic.
+    if (!v->getType()->isIntegerTy()) {
+        if (v->getType() == ptrTy_)
+            codegenError(
+                "value of this type cannot be used as a boolean condition; "
+                "use `length(x) > 0` or `not is_empty(x)` for collections/strings, "
+                "or pattern-match Option/Result explicitly");
+        codegenError("value of this type cannot be used as a boolean condition");
+    }
     return builder_.CreateICmpNE(
         v, llvm::ConstantInt::get(v->getType(), 0), "itobool");
 }

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -680,6 +680,14 @@ void CodeGen::emitExit(const std::vector<ExprPtr> &args) {
     auto exitFn = getStdlibExit();
     builder_.CreateCall(exitFn, {code});
     builder_.CreateUnreachable();
+    // Callers may continue emitting statements after exit() — e.g. the body
+    // of `emitStmt(CallStmt)` routes `exit(0)` through `builtins_["exit"]`
+    // and then goes back to the statement-emission loop. Switch to a fresh
+    // dead block so trailing IR does not land on a terminated block and trip
+    // LLVM verification (#821). LLVM DCE removes the unreachable block.
+    llvm::BasicBlock *deadBB =
+        llvm::BasicBlock::Create(*ctx_, "exit.dead", fn_);
+    builder_.SetInsertPoint(deadBB);
 }
 
 } // namespace ry

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -203,6 +203,245 @@ TEST_F(CodeGenTest, StructInequalityStillWorks) {
 }
 
 // ============================================================
+// IR verify error sweep — #805, #818, #821
+//
+// These used to reach LLVM IR verification and crash with cryptic
+// "icmp ne ptr, i0 0" or "Terminator found in the middle of a basic
+// block" messages. After the sweep, each case is either handled
+// frontend-side with a clear diagnostic or silently accepted with a
+// trailing dead block that LLVM DCE removes.
+// ============================================================
+
+// ---- #818: pointer-backed collection/str types cannot be conditions ----
+
+TEST_F(CodeGenTest, ListInIfConditionRejected) {
+    EXPECT_THROW(runSource(
+        "xs: List<int> = [1, 2, 3]\n"
+        "if xs:\n"
+        "    print(\"non-empty\")\n"
+    ), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ListInWhileConditionRejected) {
+    EXPECT_THROW(runSource(
+        "xs: List<int> = [1, 2, 3]\n"
+        "while xs:\n"
+        "    break\n"
+    ), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, StrInIfConditionRejected) {
+    EXPECT_THROW(runSource(
+        "s: str = \"hello\"\n"
+        "if s:\n"
+        "    print(\"non-empty\")\n"
+    ), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, MapInIfConditionRejected) {
+    EXPECT_THROW(runSource(
+        "m: Map<str, int> = {\"a\": 1}\n"
+        "if m:\n"
+        "    print(\"non-empty\")\n"
+    ), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, SetInIfConditionRejected) {
+    EXPECT_THROW(runSource(
+        "s: Set<int> = {1, 2, 3}\n"
+        "if s:\n"
+        "    print(\"non-empty\")\n"
+    ), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, NotOnListRejected) {
+    EXPECT_THROW(runSource(
+        "xs: List<int> = [1, 2, 3]\n"
+        "print(not xs)\n"
+    ), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, RecordInIfConditionRejected) {
+    // Records land in the "not i1, not double, not ptr, not integer" branch
+    // of toBool() and must be rejected with the generic condition error
+    // rather than falling through to the integer compare path.
+    EXPECT_THROW(runSource(
+        "record Point:\n"
+        "    x: int\n"
+        "    y: int\n"
+        "p = Point(1, 2)\n"
+        "if p:\n"
+        "    print(\"has\")\n"
+    ), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, WhenCondCollectionRejected) {
+    EXPECT_THROW(runSource(
+        "xs: List<int> = [1]\n"
+        "when:\n"
+        "    xs:\n"
+        "        print(\"has\")\n"
+        "    else:\n"
+        "        print(\"none\")\n"
+    ), std::runtime_error);
+}
+
+// Regression: integer and bool conditions must still work.
+TEST_F(CodeGenTest, IntInIfConditionStillWorks) {
+    EXPECT_EQ(runSource(
+        "x = 1\n"
+        "if x:\n"
+        "    print(\"yes\")\n"
+    ), "yes\n");
+}
+
+TEST_F(CodeGenTest, LengthGreaterZeroIdiomWorks) {
+    EXPECT_EQ(runSource(
+        "xs: List<int> = [1, 2, 3]\n"
+        "if length(xs) > 0:\n"
+        "    print(\"non-empty\")\n"
+    ), "non-empty\n");
+}
+
+// ---- #821: code after exit() must not trigger IR verify error ----
+//
+// Using compileSource() here instead of runSource(): calling exit(0) from a
+// JIT-loaded module would terminate the test process itself. We only need to
+// verify that codegen produces valid IR (no "Terminator found in the middle
+// of a basic block" from LLVM verification), which compileSource() checks.
+
+TEST_F(CodeGenTest, ExitFollowedByPrintCompiles) {
+    // exit(0) is a diverging call. emitExit() switches to a fresh dead block
+    // so the trailing print() lands on a valid (unreachable) block and LLVM
+    // verification sees exactly one terminator per basic block.
+    EXPECT_NO_THROW(compileSource(
+        "print(\"before\")\n"
+        "exit(0)\n"
+        "print(\"after - should not print\")\n"
+    ));
+}
+
+TEST_F(CodeGenTest, ExitInsideIfFollowedByStmtCompiles) {
+    EXPECT_NO_THROW(compileSource(
+        "x = 1\n"
+        "if x == 1:\n"
+        "    print(\"first\")\n"
+        "    exit(0)\n"
+        "    print(\"dead\")\n"
+        "print(\"unreachable-after-if\")\n"
+    ));
+}
+
+TEST_F(CodeGenTest, ExitInFunctionBodyFollowedByStmtCompiles) {
+    // Function body emission loop should also tolerate a dead block after
+    // exit(). Covers the CallStmt path (emitStmt(CallStmt) routes exit
+    // through builtins_["exit"]).
+    EXPECT_NO_THROW(compileSource(
+        "function f():\n"
+        "    exit(1)\n"
+        "    print(\"dead\")\n"
+        "f()\n"
+    ));
+}
+
+// ---- #805: Result wrapper must not be mistaken for inner JsonValue ----
+//
+// These tests inline the @native("json") declarations so they do not rely
+// on the module loader (runSource goes through CodeGen::compile directly).
+// The declarations mirror share/std/json/json.ry.
+
+static const std::string JSON_DECLS = R"(
+@native("json")
+function parse(text: str) -> Result<JsonValue, Error>
+@native("json")
+function stringify(value: JsonValue) -> str
+@native("json")
+function kind(value: JsonValue) -> str
+@native("json")
+function get(value: JsonValue, key: str) -> Result<JsonValue, Error>
+@native("json")
+function to_str(value: JsonValue) -> Result<str, Error>
+@native("json")
+function json_free(value: JsonValue) -> Unit
+)";
+
+TEST_F(CodeGenTest, JsonKindOnResultRejected) {
+    // json.get() returns Result<JsonValue, Error>. Passing it to kind()
+    // without unwrapping used to sneak past isJsonValue() (metadata-only
+    // check) and reach __ry_json_type() with a Result struct, producing
+    // an IR verify error. After the fix, isJsonValue gates on ptrTy_, so
+    // the Result is rejected at the frontend with kind()'s existing
+    // "requires a JsonValue argument" diagnostic — not an LLVM verify
+    // failure.
+    std::string err;
+    try {
+        compileSource(JSON_DECLS + R"(
+match parse("{\"name\": \"ry\"}"):
+    case Ok(j):
+        v = get(j, "name")
+        print(kind(v))
+    case Err(e):
+        print(e)
+)");
+    } catch (const std::runtime_error &e) {
+        err = e.what();
+    }
+    EXPECT_NE(err.find("kind() requires a JsonValue argument"),
+              std::string::npos) << "error was: " << err;
+    // Guard: must NOT be an LLVM verify error — that would mean the
+    // isJsonValue fix regressed.
+    EXPECT_EQ(err.find("IR verify error"), std::string::npos)
+        << "error was: " << err;
+}
+
+TEST_F(CodeGenTest, JsonStringifyOnResultRejected) {
+    std::string err;
+    try {
+        compileSource(JSON_DECLS + R"(
+match parse("{\"name\": \"ry\"}"):
+    case Ok(j):
+        v = get(j, "name")
+        print(stringify(v))
+    case Err(e):
+        print(e)
+)");
+    } catch (const std::runtime_error &e) {
+        err = e.what();
+    }
+    EXPECT_NE(err.find("stringify() requires a JsonValue argument"),
+              std::string::npos) << "error was: " << err;
+    EXPECT_EQ(err.find("IR verify error"), std::string::npos)
+        << "error was: " << err;
+}
+
+TEST_F(CodeGenTest, ToStrOnJsonResultFallsThroughToGenericResult) {
+    // After the fix, to_str() on a Result<JsonValue, Error> does NOT route
+    // through the JSON-specific dispatcher (isJsonValue now returns false
+    // for non-ptr values). It falls through to the generic valueToString()
+    // Result branch, which formats as "Ok(...)" just like any other Result.
+    // This matches the baseline behavior of print() on Result values.
+    std::string out = runSource(JSON_DECLS + R"(
+match parse("{\"name\": \"ry\"}"):
+    case Ok(j):
+        v = get(j, "name")
+        print(to_str(v))
+    case Err(e):
+        print("err")
+)");
+    // The inner JsonValue formatting is a separate concern; we assert only
+    // that the Result wrapper is preserved and no IR verify error occurs.
+    EXPECT_NE(out.find("Ok("), std::string::npos) << "output was: " << out;
+}
+
+// Regression: generic Result stringification still works for non-JSON cases.
+TEST_F(CodeGenTest, GenericResultToStrStillWorks) {
+    EXPECT_EQ(runSource(
+        "r: Result<int, Error> = Ok(42)\n"
+        "print(to_str(r))\n"
+    ), "Ok(42)\n");
+}
+
+// ============================================================
 // findMatchingCloseParen — depth-tracking paren matcher (#768)
 // ============================================================
 


### PR DESCRIPTION
## Summary

Three bugs (#805, #818, #821) all surfaced as cryptic LLVM IR verify errors instead of user-friendly diagnostics because codegen emitted invalid IR and let the LLVM verifier reject it. This PR pushes diagnosis back to the frontend in each case.

### #805 — `Result<JsonValue, Error>` routed to JSON runtime functions

`isJsonValue()` trusted the `json_type_only` metadata flag without checking the underlying LLVM type, so a `Result<JsonValue, Error>` returned by `json.get()` reached `__ry_json_str(ptr)` with a struct argument and failed verification. `isJsonValue()` now gates on `ptrTy_` so wrappers fall through to `valueToString()`'s generic Result branch, and JSON-specific helpers like `kind`/`stringify` report their existing "requires a JsonValue argument" diagnostic.

### #818 — `List` / `str` / `Map` / `Set` used as a condition

`toBool()` fell through to `ICmpNE(v, ConstantInt::get(ptrTy_, 0))` for pointer-backed values, which LLVM printed as `icmp ne ptr, i0 0`. Reject non-integer / non-double / non-i1 values at the frontend with a clear message suggesting `length(x) > 0` or `not is_empty(x)`.

### #821 — Code after `exit()`

`exit()` as a statement (via the `builtins_["exit"]` lambda) only emitted `call + unreachable` without switching insertion blocks, so the statement-emission loop kept writing into a terminated block (\`Terminator found in the middle of a basic block\`). Move the dead-block switch inside \`emitExit()\` itself and drop the duplicate logic from \`emitBuiltinCore\` — both dispatch paths now inherit correct terminator handling.

## Changes

- \`src/codegen_call_json.cpp\` — \`isJsonValue()\` requires \`ptrTy_\`
- \`src/codegen_call_user.cpp\` — \`toBool()\` rejects non-integer ptr / struct values with a type-aware diagnostic
- \`src/codegen_match.cpp\` — \`emitExit()\` creates a fresh dead block after \`CreateUnreachable\`
- \`src/codegen_call.cpp\` — drop duplicated dead-block logic from \`emitBuiltinCore\`
- \`tests/test_codegen_type_safety.cpp\` — 17 new regression tests covering each rejection branch + fast-path guards
- \`docs/reference/control-flow.md\` / \`builtins.md\` / \`json.md\` — document the new behaviors
- \`KNOWLEDGE.md\` — two new entries (frontend diagnosis rule, dual-path builtin rule)
- \`changelog.d/805-818-821-ir-verify-sweep.md\` — changelog fragment

## Test plan

- [x] \`./build/ry_tests\` — 1507 PASSED
- [x] \`./build/ry test -p\` — 102 test files, 0 failures
- [x] ASan: \`./build-asan/ry_tests\` — 1506 PASSED
- [x] ASan: \`./build-asan/ry test -p\` — 102 test files, 0 failures
- [x] Manual reproduction of each bug now produces the expected diagnostic or succeeds without IR verify error

Closes #805
Closes #818
Closes #821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded condition rules: allow bool, integer, and float; explicitly exclude strings/collections/iterators/closures/records/Option/Result and show length/emptiness checks
  * Clarified JSON APIs require unwrapping Result<JsonValue, Error>
  * Documented that exit/return/break/continue make following code unreachable

* **Bug Fixes**
  * Pointer-backed collections/strings now emit clear compile-time errors as conditions
  * JSON value checks now require pointer-backed JsonValue to avoid misclassification
  * Diverging calls (e.g., exit) no longer cause IR verification failures for trailing code

* **Tests**
  * Added regression tests covering condition type-safety, JSON Result handling, and post-exit codegen behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->