### PR TITLE
fix: accept u64 max literals and scientific notation (#807, #819)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -302,6 +302,54 @@ decrements on the closing. Never use `string::find(')')` or similar.
 Reuse `CodeGen::findMatchingCloseParen()` in `src/codegen_type.cpp`
 as the canonical helper.
 
+### NumberExpr.value holds a non-negative bit pattern, not a signed magnitude
+
+**Source**: #807 + #819 sweep (2026-04-10)
+**Tags**: parser, codegen, numeric-literal, u64, bit-pattern
+
+**Context**: The parser accepts integer literals up to `UINT64_MAX`
+via `strtoull`, but `NumberExpr.value` is declared as `int64_t`. To
+support `u64` max literals (`18446744073709551615` = bit pattern
+`0xFFFFFFFFFFFFFFFF` = `int64_t(-1)`) without changing the AST type,
+the field is documented to store the non-negative magnitude as a bit
+pattern. The invariant breaks only if a parser site tries to be
+clever and stores a pre-negated value (e.g., the old pattern-literal
+path in `parser_decl.cpp` built `NumberExpr{-val, ""}` for `case -1:`).
+Codegen's empty-suffix emit path then cannot distinguish "legitimate
+negative from unary minus" from "overflow bit pattern >= 2^63".
+
+**Rule**: `NumberExpr.value` is always the unsigned bit pattern of a
+non-negative magnitude. Negation is expressed as
+`UnaryExpr("-", NumberExpr{magnitude, suffix})`, the same as
+`parser_expr.cpp`. Any new parser site that creates a NumberExpr
+from a literal that may be negative MUST wrap the node in a UnaryExpr
+instead of storing a pre-negated `int64_t`. In codegen, interpret
+`static_cast<uint64_t>(value)` when the target type is unsigned, and
+for the empty-suffix path treat `value < 0` as "literal exceeds
+`INT64_MAX`" → emit a "integer literal out of range for int" error.
+
+**How to apply**: Never write `NumberExpr{-val, ...}`. Always wrap in
+UnaryExpr. The empty-suffix `value < 0` check in
+`src/codegen_expr.cpp::emitExprVariant(const NumberExpr &)` depends
+on this invariant — a regression would either silently accept
+`x = 18446744073709551615` (wrong i64 emit) or reject `case -1:`
+(false positive).
+
+### Use strtod, not std::stod, for float literal parsing
+
+**Source**: #819 sweep (2026-04-10)
+**Tags**: parser, float, scientific-notation, exception-safety
+
+**Context**: `std::stod` throws `std::out_of_range` on overflow
+(e.g., `1e400`), which crashes the frontend before diagnostics can
+be produced. #819's scope check explicitly allows overflow to
+surface as `+Inf`, matching the runtime `to_float` converter.
+
+**Rule**: Use `std::strtod` + `errno` for parsing float literals in
+the frontend. Accept `HUGE_VAL` / `-HUGE_VAL` as valid `Inf` results
+and only treat non-zero trailing characters as errors. See
+`include/ry/parser.hpp::parseFloatLiteral`.
+
 ---
 
 ## Runtime / Memory

--- a/changelog.d/807-819-numeric-literal.md
+++ b/changelog.d/807-819-numeric-literal.md
@@ -1,0 +1,7 @@
+### Added
+
+- Scientific notation float literals (`1e10`, `1.5e-3`, `2.5E+2`, `1_000e3`). Overflowing exponents (`1e400`) produce `+Inf` to match the runtime `to_float` converter (#819)
+
+### Fixed
+
+- `u64` maximum value (`18446744073709551615`) now parses successfully when written with a `u64` suffix or under a `u64` / unsigned type annotation. Hex and binary forms (`0xFFFFFFFFFFFFFFFFu64`, `0b11...1u64`) are accepted too; range checking for `int` / `i64` / `u8`-`u32` happens in codegen against the target type (#807)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -180,7 +180,7 @@ word:    u32 = 4294967295               # 2^32 - 1
 
 ### Float Literals
 
-```
+```text
 FloatLiteral := DecDigits '.' DecDigits Exponent? FloatSuffix?
              |  DecDigits Exponent FloatSuffix?
 Exponent     := ('e' | 'E') ('+' | '-')? DecDigits

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | `int` | i64 | `42`, `-7`, `0xFF`, `0b1010`, `100_000` | 64-bit signed integer |
 | `u8` | i8 | (no dedicated literal) | Unsigned 8-bit integer (0-255). Used with type annotation `b: u8 = 42` |
-| `float` | f64 | `3.14`, `0.5`, `.5`, `3.14_159` | 64-bit floating-point number |
+| `float` | f64 | `3.14`, `0.5`, `3.14_159`, `1e10`, `1.5e-3`, `2.5E+2` | 64-bit floating-point number (scientific notation supported) |
 | `bool` | i1 | `true`, `false` | Boolean value |
 | `str` | ptr | `"hello"`, `""`, `"a\nb"` | String (immutable byte sequence on the heap) |
 | `Unit` | void | (no return value) | Return type for functions with no return value. Must be specified explicitly with `-> Unit` |
@@ -33,9 +33,9 @@
 | `i64` | i64 | `x: i64 = 100`, `x = 100i64` | 64-bit signed integer (low-level, no implicit conversion) |
 | `u8` | i8 | `x: u8 = 200`, `x = 200u8` | 8-bit unsigned integer (low-level, no implicit conversion) |
 | `u16` | i16 | `x: u16 = 60000`, `x = 60000u16` | 16-bit unsigned integer (low-level, no implicit conversion) |
-| `u32` | i32 | `x: u32 = 3000000000`, `x = 100u32` | 32-bit unsigned integer (low-level, no implicit conversion) |
-| `u64` | i64 | `x: u64 = 100`, `x = 100u64` | 64-bit unsigned integer (low-level, no implicit conversion) |
-| `f32` | float | `x: f32 = 3.14`, `x = 3.14f32` | 32-bit floating-point (low-level, no implicit conversion) |
+| `u32` | i32 | `x: u32 = 4294967295`, `x = 100u32` | 32-bit unsigned integer (low-level, no implicit conversion) |
+| `u64` | i64 | `x: u64 = 18446744073709551615`, `x = 0xFFFFFFFFFFFFFFFFu64` | 64-bit unsigned integer up to 2^64 − 1 (low-level, no implicit conversion) |
+| `f32` | float | `x: f32 = 3.14`, `x = 1e10f32` | 32-bit floating-point (low-level, no implicit conversion) |
 | `weak T` | ptr (header) | `weak s` | Weak reference to an ARC-managed value (does not prevent deallocation) |
 | `Regex` | ptr | `/[a-z]+/`, `/\d{3}/` | Regular expression pattern (created via regex literal syntax) |
 | `Result<T, E>` | `{ i1, T/E }` | `Ok(42)`, `Err(Error("fail"))` | A type representing success (`Ok`) or failure (`Err`) |
@@ -152,6 +152,51 @@ x: B = 42
 y: B = "hello"
 z: B = true
 ```
+
+---
+
+## Numeric Literals
+
+### Integer Literals
+
+Decimal, hexadecimal (`0x`/`0X`), and binary (`0b`/`0B`) forms are accepted. Underscores are allowed between digits as a visual separator (`1_000_000`, `0xFFFF_FFFF`).
+
+The accepted magnitude is determined by the target type:
+
+| Target | Range |
+|---|---|
+| bare `int` / `i64` | `-9_223_372_036_854_775_808 .. 9_223_372_036_854_775_807` (i64) |
+| `i8` / `i16` / `i32` | corresponding signed range |
+| `u8` / `u16` / `u32` | `0 .. 2^N - 1` |
+| `u64` | `0 .. 18_446_744_073_709_551_615` (2^64 − 1) |
+
+Large unsigned literals require either a suffix (`18446744073709551615u64`) or a type annotation on the receiving variable (`x: u64 = 18446744073709551615`). Negative literals arrive as a unary minus on a non-negative magnitude, so `-1i8` is accepted while `-1u8` is rejected.
+
+```python
+max_u64: u64 = 18446744073709551615     # 2^64 - 1
+mask:    u64 = 0xFFFF_FFFF_FFFF_FFFF    # same value via hex
+word:    u32 = 4294967295               # 2^32 - 1
+```
+
+### Float Literals
+
+```
+FloatLiteral := DecDigits '.' DecDigits Exponent? FloatSuffix?
+             |  DecDigits Exponent FloatSuffix?
+Exponent     := ('e' | 'E') ('+' | '-')? DecDigits
+FloatSuffix  := 'f32' | 'f64'
+```
+
+Scientific notation is supported anywhere a float is expected:
+
+```python
+avogadro  = 6.022e23
+planck    = 6.626e-34
+light_spd = 2.998E8
+big       = 1e10f32
+```
+
+Overflowing exponents produce `+Inf`/`-Inf` (not a compile error), matching the runtime `to_float` converter.
 
 ---
 

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -472,4 +472,32 @@ struct MatchExpr {
     std::vector<MatchExprArm> arms;
 };
 
+// True if `name` is a low-level integer type that can be injected as a
+// NumberExpr suffix. Excludes `f32` (the only non-integer low-level type).
+inline bool isLowLevelIntTypeName(const std::string &name) {
+    return name == "i8" || name == "i16" || name == "i32" || name == "i64" ||
+           name == "u8" || name == "u16" || name == "u32" || name == "u64";
+}
+
+// If `value` is a bare integer literal (optionally wrapped in UnaryExpr(+/-)),
+// propagate `annot` onto the inner NumberExpr so downstream consumers see the
+// literal typed against its target annotation. Used by codegen (for range
+// checks) and by the formatter (for correct unsigned rendering). Does not
+// touch already-suffixed literals or non-trivial initializer expressions.
+inline void injectLowLevelSuffix(ExprNode &value, const std::string &annot) {
+    if (!isLowLevelIntTypeName(annot)) return;
+    if (auto *ne = std::get_if<NumberExpr>(&value.data)) {
+        if (ne->suffix.empty())
+            ne->suffix = annot;
+        return;
+    }
+    if (auto *ue = std::get_if<std::unique_ptr<UnaryExpr>>(&value.data)) {
+        if ((*ue)->op != "-" && (*ue)->op != "+") return;
+        if (auto *inner = std::get_if<NumberExpr>(&(*ue)->operand->data)) {
+            if (inner->suffix.empty())
+                inner->suffix = annot;
+        }
+    }
+}
+
 } // namespace ry

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -129,6 +129,11 @@ struct TypeParam {
     std::string name;
     std::optional<std::string> bound;    // record name constraint; validated at instantiation
 };
+// `value` is the unsigned bit pattern of a non-negative magnitude stored in
+// int64_t (so UINT64_MAX arrives as int64_t(-1)). Negative literals are
+// represented as `UnaryExpr("-", NumberExpr{...})`, so every NumberExpr
+// node is logically non-negative. Codegen re-interprets the bit pattern
+// according to `suffix` (or an injected annotation suffix in emitVarDecl).
 struct NumberExpr   { int64_t value; std::string suffix; };
 struct FloatExpr    { double value;  std::string suffix; };
 struct BoolExpr     { bool value; };

--- a/include/ry/lexer.hpp
+++ b/include/ry/lexer.hpp
@@ -167,6 +167,10 @@ private:
     Token readToken();
     Token readFStringSegment(bool isStart);
     void tryConsumeNumericSuffix(TokenKind &kind);
+    // Consume a scientific-notation exponent (`e`/`E` [+-]? digits) if one
+    // is present at the current position. No-op otherwise. Caller is
+    // responsible for setting the token kind to Float on success.
+    bool consumeExponentIfPresent();
     void checkNoTrailingIdentStart() const;
 };
 

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -154,7 +154,12 @@ inline std::string stripUnderscores(const std::string &s) {
     return r;
 }
 
-// Returns true if s is a valid in-range int64_t literal; sets *out on success.
+// Parses a non-negative integer literal in the range [0, UINT64_MAX].
+// The value is stored in `*out` as a bit pattern reinterpreted into int64_t
+// (e.g. UINT64_MAX is stored as int64_t(-1)); codegen re-interprets the bit
+// pattern according to the literal's suffix or surrounding annotation type.
+// Negative literals arrive as UnaryExpr(-, NumberExpr{...}), so this function
+// only sees the unsigned magnitude.
 inline bool tryParseIntLiteral(const std::string &s, int64_t *out) {
     std::string clean = stripUnderscores(s);
     errno = 0;
@@ -165,9 +170,9 @@ inline bool tryParseIntLiteral(const std::string &s, int64_t *out) {
         if (clean[1] == 'x' || clean[1] == 'X') base = 16;
         else if (clean[1] == 'b' || clean[1] == 'B') { base = 2; p += 2; }
     }
-    long long val = std::strtoll(p, &end, base);
+    unsigned long long val = std::strtoull(p, &end, base);
     if (errno == ERANGE || (end && *end != '\0')) return false;
-    *out = static_cast<int64_t>(val);
+    *out = static_cast<int64_t>(static_cast<uint64_t>(val));
     return true;
 }
 
@@ -179,7 +184,17 @@ inline int64_t parseIntLiteral(const std::string &s) {
 }
 
 inline double parseFloatLiteral(const std::string &s) {
-    return std::stod(stripUnderscores(s));
+    // Use strtod (not stod) so overflow yields +/-HUGE_VAL instead of
+    // throwing out_of_range — this matches C99 and lets `1e400` surface as
+    // +Inf consistent with the runtime `to_float`.
+    std::string clean = stripUnderscores(s);
+    errno = 0;
+    char *end = nullptr;
+    double val = std::strtod(clean.c_str(), &end);
+    // Any trailing garbage indicates a malformed literal (a lexer bug).
+    if (end == clean.c_str() || (end && *end != '\0'))
+        throw std::out_of_range("invalid float literal: " + s);
+    return val;
 }
 
 } // namespace ry

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -16,33 +16,50 @@ struct RegexResourceReg { RegexResourceReg() {
 }
 
 // Range check for suffixed integer literals.
-// Since `-128i8` is parsed as UnaryExpr("-", NumberExpr{128, "i8"}),
-// we allow positive values up to 2^(N-1) for signed types (= |MIN|).
+//
+// NumberExpr.value holds the unsigned bit pattern of a non-negative magnitude
+// (see ast.hpp: negation is expressed as UnaryExpr). Signed suffixes accept
+// magnitudes up to 2^(N-1) — `-INT{N}_MIN` for `-INT{N}_MIN` itself via
+// UnaryExpr. Unsigned suffixes compare the bit pattern as uint64_t because
+// `u64` max is stored as `int64_t(-1)`.
 template<typename ErrorFn>
 static void validateIntRange(int64_t value, const std::string &suffix,
                              ErrorFn error) {
+    uint64_t uval = static_cast<uint64_t>(value);
+    auto fmtValue = [&]() {
+        // Unsigned suffixes: show the bit pattern as unsigned so large u64
+        // literals don't render as negative numbers.
+        if (!suffix.empty() && suffix[0] == 'u')
+            return std::to_string(uval);
+        return std::to_string(value);
+    };
     if (suffix == "i8") {
-        if (value < INT8_MIN || value > (int64_t)(-((int64_t)INT8_MIN)))
-            error("i8 literal out of range: " + std::to_string(value));
+        if (uval > static_cast<uint64_t>(-static_cast<int64_t>(INT8_MIN)))
+            error("i8 literal out of range: " + fmtValue());
     } else if (suffix == "i16") {
-        if (value < INT16_MIN || value > (int64_t)(-((int64_t)INT16_MIN)))
-            error("i16 literal out of range: " + std::to_string(value));
+        if (uval > static_cast<uint64_t>(-static_cast<int64_t>(INT16_MIN)))
+            error("i16 literal out of range: " + fmtValue());
     } else if (suffix == "i32") {
-        if (value < INT32_MIN || value > (int64_t)(-((int64_t)INT32_MIN)))
-            error("i32 literal out of range: " + std::to_string(value));
-    } else if (suffix == "u8") {
-        if (value < 0 || value > UINT8_MAX)
-            error("u8 literal out of range: " + std::to_string(value));
-    } else if (suffix == "u16") {
-        if (value < 0 || value > UINT16_MAX)
-            error("u16 literal out of range: " + std::to_string(value));
-    } else if (suffix == "u32") {
-        if (value < 0 || value > (int64_t)UINT32_MAX)
-            error("u32 literal out of range: " + std::to_string(value));
-    } else if (suffix == "u64") {
+        if (uval > static_cast<uint64_t>(-static_cast<int64_t>(INT32_MIN)))
+            error("i32 literal out of range: " + fmtValue());
+    } else if (suffix == "i64") {
+        // A negative bit pattern here means magnitude > INT64_MAX, which
+        // cannot fit in a signed i64 even after unary minus.
         if (value < 0)
-            error("u64 literal out of range: " + std::to_string(value));
+            error("i64 literal out of range: " + fmtValue());
+    } else if (suffix == "u8") {
+        if (uval > UINT8_MAX)
+            error("u8 literal out of range: " + fmtValue());
+    } else if (suffix == "u16") {
+        if (uval > UINT16_MAX)
+            error("u16 literal out of range: " + fmtValue());
+    } else if (suffix == "u32") {
+        if (uval > UINT32_MAX)
+            error("u32 literal out of range: " + fmtValue());
     }
+    // suffix == "u64": any 64-bit bit pattern is valid; unary minus on a
+    // u64 is rejected earlier by isUnsignedLowLevelName in the UnaryExpr
+    // path, so no negative magnitude can reach this site.
 }
 
 llvm::Value *CodeGen::emitExpr(const ExprNode &node) {
@@ -52,8 +69,17 @@ llvm::Value *CodeGen::emitExpr(const ExprNode &node) {
 }
 
 llvm::Value *CodeGen::emitExprVariant(const NumberExpr &e) {
-    if (e.suffix.empty())
+    if (e.suffix.empty()) {
+        // Bare `int` is i64. With the strtoull-based parser a negative bit
+        // pattern means the literal exceeds INT64_MAX (negative literals
+        // arrive as UnaryExpr, so NumberExpr.value is always a non-negative
+        // magnitude). Reject so users must either add a `u64` suffix or a
+        // u-type annotation (handled by emitVarDecl suffix injection).
+        if (e.value < 0)
+            codegenError("integer literal out of range for int: " +
+                         std::to_string(static_cast<uint64_t>(e.value)));
         return llvm::ConstantInt::get(i64Ty_, e.value, true);
+    }
 
     validateIntRange(e.value, e.suffix,
         [this](const std::string &msg) { codegenError(msg); });

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -33,18 +33,23 @@ static void validateIntRange(int64_t value, const std::string &suffix,
             return std::to_string(uval);
         return std::to_string(value);
     };
+    // Signed suffixes: positive literals must fit in INT{N}_MAX. The extra
+    // value `abs(INT{N}_MIN)` is only legal via a unary-minus wrapper, which
+    // is handled by a constant-fold fast-path in emitExprVariant(UnaryExpr)
+    // before this check runs.
     if (suffix == "i8") {
-        if (uval > static_cast<uint64_t>(-static_cast<int64_t>(INT8_MIN)))
+        if (uval > static_cast<uint64_t>(INT8_MAX))
             error("i8 literal out of range: " + fmtValue());
     } else if (suffix == "i16") {
-        if (uval > static_cast<uint64_t>(-static_cast<int64_t>(INT16_MIN)))
+        if (uval > static_cast<uint64_t>(INT16_MAX))
             error("i16 literal out of range: " + fmtValue());
     } else if (suffix == "i32") {
-        if (uval > static_cast<uint64_t>(-static_cast<int64_t>(INT32_MIN)))
+        if (uval > static_cast<uint64_t>(INT32_MAX))
             error("i32 literal out of range: " + fmtValue());
     } else if (suffix == "i64") {
-        // A negative bit pattern here means magnitude > INT64_MAX, which
-        // cannot fit in a signed i64 even after unary minus.
+        // Magnitude > INT64_MAX cannot fit in a signed i64 even via unary
+        // minus (except the INT64_MIN edge case, which is caught by the
+        // same UnaryExpr fast-path).
         if (value < 0)
             error("i64 literal out of range: " + fmtValue());
     } else if (suffix == "u8") {
@@ -232,6 +237,28 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
 }
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<UnaryExpr> &e) {
+    // Constant-fold `-<signed low-level int literal>` before recursing into
+    // emitExpr, so that magnitudes up to `|INT{N}_MIN|` are accepted (e.g.
+    // `-128i8`, `-9223372036854775808i64`). validateIntRange limits a bare
+    // NumberExpr to INT{N}_MAX; the unary-minus wrapper is the only way to
+    // reach the signed MIN edge.
+    if (e->op == "-") {
+        if (auto *ne = std::get_if<NumberExpr>(&e->operand->data)) {
+            if (!ne->suffix.empty() && isLowLevelTypeName(ne->suffix) &&
+                !isUnsignedLowLevelName(ne->suffix) && ne->suffix != "f32") {
+                llvm::Type *ty = resolveType(ne->suffix);
+                unsigned bits = ty->getIntegerBitWidth();
+                uint64_t absMin = static_cast<uint64_t>(1) << (bits - 1);
+                uint64_t mag = static_cast<uint64_t>(ne->value);
+                if (mag > absMin)
+                    codegenError(ne->suffix + " literal out of range: -" +
+                                 std::to_string(mag));
+                uint64_t negBits = static_cast<uint64_t>(-static_cast<int64_t>(mag));
+                return llvm::ConstantInt::get(ty, negBits, /*isSigned=*/false);
+            }
+        }
+    }
+
     llvm::Value *val = emitExpr(*e->operand);
 
     // Try user-defined unary operator first

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -13,6 +13,30 @@ void CodeGen::emitDeprecationWarning(const std::string &name) {
     warnings_.push_back("warning: '" + name + "' is deprecated");
 }
 
+namespace {
+// If `value` is a bare integer literal (optionally wrapped in UnaryExpr(+/-)),
+// propagate `annot` onto the inner NumberExpr so that codegen's range check
+// runs against the target type instead of bare `int`. Does not touch
+// already-suffixed literals or non-trivial initializer expressions.
+void injectLowLevelSuffix(ExprNode &value, const std::string &annot) {
+    // `isLowLevelTypeName` also admits "f32"; exclude it because NumberExpr
+    // never carries a float suffix.
+    if (!CodeGen::isLowLevelTypeName(annot) || annot == "f32") return;
+    if (auto *ne = std::get_if<NumberExpr>(&value.data)) {
+        if (ne->suffix.empty())
+            ne->suffix = annot;
+        return;
+    }
+    if (auto *ue = std::get_if<std::unique_ptr<UnaryExpr>>(&value.data)) {
+        if ((*ue)->op != "-" && (*ue)->op != "+") return;
+        if (auto *inner = std::get_if<NumberExpr>(&(*ue)->operand->data)) {
+            if (inner->suffix.empty())
+                inner->suffix = annot;
+        }
+    }
+}
+} // namespace
+
 // ===== B3: emitVarDecl =====
 
 void CodeGen::emitVarDecl(const std::string &name,
@@ -233,6 +257,12 @@ void CodeGen::emitVarDecl(const std::string &name,
             return;
         }
     }
+
+    // Propagate a low-level integer annotation onto bare integer literals
+    // in the initializer so the codegen range check runs against the target
+    // type (required for u64 max literals that don't fit in bare i64).
+    if (annot)
+        injectLowLevelSuffix(value, *annot);
 
     llvm::Value *val = emitExpr(value);
     llvm::Type *newTy = val->getType();
@@ -729,6 +759,14 @@ void CodeGen::emitStmt(AssignStmt &s) {
         return;
     }
 
+    // Mirror the decl-time suffix injection so `x = 18446744073709551615`
+    // works on a `u64` variable, not just on the initial declaration.
+    {
+        const std::string &varLL = getLowLevelTypeName(ptr);
+        if (!varLL.empty())
+            injectLowLevelSuffix(*s.value, varLL);
+    }
+
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();
 
@@ -870,6 +908,14 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
             codegenError("None can only be assigned to Option type");
         builder_.CreateStore(buildNoneValue(valueTy), storagePtr);
         return;
+    }
+
+    // Same suffix injection as the local-variable assign path, so
+    // module-global u64 reassignment honours the target type.
+    {
+        const std::string &anchorLL = getLowLevelTypeName(anchor);
+        if (!anchorLL.empty())
+            injectLowLevelSuffix(*s.value, anchorLL);
     }
 
     llvm::Value *val = emitExpr(*s.value);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -13,30 +13,6 @@ void CodeGen::emitDeprecationWarning(const std::string &name) {
     warnings_.push_back("warning: '" + name + "' is deprecated");
 }
 
-namespace {
-// If `value` is a bare integer literal (optionally wrapped in UnaryExpr(+/-)),
-// propagate `annot` onto the inner NumberExpr so that codegen's range check
-// runs against the target type instead of bare `int`. Does not touch
-// already-suffixed literals or non-trivial initializer expressions.
-void injectLowLevelSuffix(ExprNode &value, const std::string &annot) {
-    // `isLowLevelTypeName` also admits "f32"; exclude it because NumberExpr
-    // never carries a float suffix.
-    if (!CodeGen::isLowLevelTypeName(annot) || annot == "f32") return;
-    if (auto *ne = std::get_if<NumberExpr>(&value.data)) {
-        if (ne->suffix.empty())
-            ne->suffix = annot;
-        return;
-    }
-    if (auto *ue = std::get_if<std::unique_ptr<UnaryExpr>>(&value.data)) {
-        if ((*ue)->op != "-" && (*ue)->op != "+") return;
-        if (auto *inner = std::get_if<NumberExpr>(&(*ue)->operand->data)) {
-            if (inner->suffix.empty())
-                inner->suffix = annot;
-        }
-    }
-}
-} // namespace
-
 // ===== B3: emitVarDecl =====
 
 void CodeGen::emitVarDecl(const std::string &name,
@@ -235,6 +211,10 @@ void CodeGen::emitVarDecl(const std::string &name,
             llvm::AllocaInst *ptr = getOrCreateVar(name, arrTy);
 
             for (uint64_t i = 0; i < arrSize; ++i) {
+                // Inject the element's low-level suffix so `buf: u64[1] =
+                // [18446744073709551615]` is validated against u64 instead
+                // of bare int (mirrors the scalar emitVarDecl path).
+                injectLowLevelSuffix(*(*le)->elements[i], elemTypeName);
                 llvm::Value *elemVal = emitExpr(*(*le)->elements[i]);
                 if (elemVal->getType() != elemTy) {
                     llvm::Value *coerced = coerceToLowLevelType(

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -218,6 +218,11 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
         using T = std::decay_t<decltype(v)>;
 
         if constexpr (std::is_same_v<T, NumberExpr>) {
+            // Unsigned suffixes store a bit pattern in int64_t; cast to
+            // uint64_t so that u64 max renders as 18446744073709551615
+            // instead of -1.
+            if (!v.suffix.empty() && v.suffix[0] == 'u')
+                return std::to_string(static_cast<uint64_t>(v.value)) + v.suffix;
             return std::to_string(v.value) + v.suffix;
         } else if constexpr (std::is_same_v<T, FloatExpr>) {
             return formatFloat(v.value) + v.suffix;

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -13,6 +13,12 @@ void Formatter::formatAssign(const AssignStmt &s) {
     if (s.type_annotation) {
         emit(": " + s.type_annotation->toString());
     }
+
+    // Propagate the annotation type onto a bare integer literal initializer
+    // so a u64 max value like `h: u64 = 18446744073709551615` renders as the
+    // unsigned form instead of `-1` (mirrors codegen's suffix injection).
+    if (s.type_annotation && s.value)
+        injectLowLevelSuffix(*s.value, s.type_annotation->toString());
     // @native @const declarations have no value
     if (!s.value) {
         emitInlineComment(s.loc.line);

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -143,6 +143,25 @@ void Lexer::checkNoTrailingIdentStart() const {
     }
 }
 
+bool Lexer::consumeExponentIfPresent() {
+    if (pos_ >= src_.size()) return false;
+    if (src_[pos_] != 'e' && src_[pos_] != 'E') return false;
+    // One-char lookahead over an optional sign so `1exp` and `1e` fall
+    // through to checkNoTrailingIdentStart (treating `e` as an identifier
+    // start) instead of being stolen as a malformed exponent.
+    size_t look = pos_ + 1;
+    if (look < src_.size() && (src_[look] == '+' || src_[look] == '-'))
+        ++look;
+    if (look >= src_.size() || !std::isdigit(static_cast<unsigned char>(src_[look])))
+        return false;
+    ++pos_; ++col_; // consume 'e' / 'E'
+    if (pos_ < src_.size() && (src_[pos_] == '+' || src_[pos_] == '-')) {
+        ++pos_; ++col_;
+    }
+    consumeDigitsWithSeparators(src_, pos_, col_, line_, isDecDigit);
+    return true;
+}
+
 Token Lexer::readToken() {
     // 1. Return pending tokens (multiple DEDENTs)
     if (!pending_.empty()) {
@@ -432,6 +451,7 @@ Token Lexer::readToken() {
             consumeDigitsWithSeparators(src_, pos_, col_, line_,
                 isDecDigit);
             TokenKind numKind = TokenKind::Float;
+            consumeExponentIfPresent();
             tryConsumeNumericSuffix(numKind);
             checkNoTrailingIdentStart();
             return {numKind, std::string(src_, start, pos_ - start), line_, startCol};
@@ -574,25 +594,9 @@ Token Lexer::readToken() {
                 isDecDigit);
             numKind = TokenKind::Float;
         }
-        // Exponent part (e.g., 1e10, 1.5e-3, 2E+8). Uses a 1-char lookahead
-        // over the optional sign to avoid stealing `e` when it starts an
-        // identifier (e.g., `1exp` keeps the existing invalid-numeric error).
-        if (pos_ < src_.size() && (src_[pos_] == 'e' || src_[pos_] == 'E')) {
-            size_t look = pos_ + 1;
-            if (look < src_.size() && (src_[look] == '+' || src_[look] == '-'))
-                ++look;
-            if (look < src_.size() && std::isdigit(static_cast<unsigned char>(src_[look]))) {
-                ++pos_; ++col_; // consume 'e' or 'E'
-                if (pos_ < src_.size() && (src_[pos_] == '+' || src_[pos_] == '-')) {
-                    ++pos_; ++col_;
-                }
-                consumeDigitsWithSeparators(src_, pos_, col_, line_,
-                    isDecDigit);
-                numKind = TokenKind::Float;
-            }
-            // else: `e` is the start of an identifier; leave it for
-            // checkNoTrailingIdentStart() below to report.
-        }
+        // Exponent part (e.g. `1e10`, `1.5e-3`, `2E+8`).
+        if (consumeExponentIfPresent())
+            numKind = TokenKind::Float;
         tryConsumeNumericSuffix(numKind);
         checkNoTrailingIdentStart();
         return {numKind, std::string(src_, start, pos_ - start), line_, startCol};

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -566,15 +566,32 @@ Token Lexer::readToken() {
         }
         consumeDigitsWithSeparators(src_, pos_, col_, line_,
             isDecDigit);
+        // Fraction part (e.g., 3.14).
         if (pos_ < src_.size() && src_[pos_] == '.' &&
             pos_ + 1 < src_.size() && std::isdigit(static_cast<unsigned char>(src_[pos_ + 1]))) {
             ++pos_; ++col_;
             consumeDigitsWithSeparators(src_, pos_, col_, line_,
                 isDecDigit);
             numKind = TokenKind::Float;
-            tryConsumeNumericSuffix(numKind);
-            checkNoTrailingIdentStart();
-            return {numKind, std::string(src_, start, pos_ - start), line_, startCol};
+        }
+        // Exponent part (e.g., 1e10, 1.5e-3, 2E+8). Uses a 1-char lookahead
+        // over the optional sign to avoid stealing `e` when it starts an
+        // identifier (e.g., `1exp` keeps the existing invalid-numeric error).
+        if (pos_ < src_.size() && (src_[pos_] == 'e' || src_[pos_] == 'E')) {
+            size_t look = pos_ + 1;
+            if (look < src_.size() && (src_[look] == '+' || src_[look] == '-'))
+                ++look;
+            if (look < src_.size() && std::isdigit(static_cast<unsigned char>(src_[look]))) {
+                ++pos_; ++col_; // consume 'e' or 'E'
+                if (pos_ < src_.size() && (src_[pos_] == '+' || src_[pos_] == '-')) {
+                    ++pos_; ++col_;
+                }
+                consumeDigitsWithSeparators(src_, pos_, col_, line_,
+                    isDecDigit);
+                numKind = TokenKind::Float;
+            }
+            // else: `e` is the start of an identifier; leave it for
+            // checkNoTrailingIdentStart() below to report.
         }
         tryConsumeNumericSuffix(numKind);
         checkNoTrailingIdentStart();

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -7,6 +7,19 @@
 
 namespace ry {
 
+namespace {
+// True if `mag` fits in the signed int64 range when interpreted as the
+// magnitude of a literal. `negative` allows one extra value (|INT64_MIN|)
+// because two's complement lets `-INT64_MIN` land back on INT64_MIN.
+// NumberExpr.value stores the unsigned bit pattern of a non-negative
+// magnitude, so negation sites (enum values, pattern literals) must reject
+// magnitudes beyond this range before applying the sign.
+bool isSignedInt64Magnitude(uint64_t mag, bool negative) {
+    uint64_t cap = static_cast<uint64_t>(INT64_MAX) + (negative ? 1u : 0u);
+    return mag <= cap;
+}
+} // namespace
+
 TypeParam Parser::parseOneTypeParam() {
     Token tp = lex_.peek();
     if (tp.kind != TokenKind::Ident)
@@ -578,7 +591,15 @@ StmtNode Parser::parseEnumStatement() {
             int64_t val;
             if (!tryParseIntLiteral(valTok.value, &val))
                 parseError(valTok.line, "integer literal out of range for int: " + valTok.value);
-            if (negative) val = -val;
+            // Enum explicit values are i64-only; tryParseIntLiteral accepts
+            // up to UINT64_MAX (for u64 literals elsewhere), so reject
+            // anything that doesn't fit the signed range here.
+            if (!isSignedInt64Magnitude(static_cast<uint64_t>(val), negative))
+                parseError(valTok.line,
+                           "integer literal out of range for int: " +
+                           std::string(negative ? "-" : "") + valTok.value);
+            if (negative)
+                val = static_cast<int64_t>(-static_cast<uint64_t>(val));
             variant.explicit_value = val;
         }
 
@@ -902,8 +923,19 @@ Pattern Parser::parsePattern() {
                 int64_t val;
                 if (!tryParseIntLiteral(numStr, &val))
                     parseError("integer literal out of range for int: -" + numStr);
+                if (!isSignedInt64Magnitude(static_cast<uint64_t>(val), /*negative=*/true))
+                    parseError("integer literal out of range for int: -" + numStr);
                 lex_.next();
-                node->data = NumberExpr{-val, suffix};
+                // Wrap the positive magnitude in UnaryExpr("-") instead of
+                // pre-negating: NumberExpr.value must stay a non-negative
+                // magnitude (see the struct comment in ast.hpp). Codegen
+                // applies the negation through its unary-minus path.
+                auto inner = std::make_unique<ExprNode>();
+                inner->data = NumberExpr{val, suffix};
+                auto unary = std::make_unique<UnaryExpr>();
+                unary->op = "-";
+                unary->operand = std::move(inner);
+                node->data = std::move(unary);
             }
             return LiteralPattern{std::move(node)};
         }

--- a/tests/spec/numeric_literal_u64_scientific.test.ry
+++ b/tests/spec/numeric_literal_u64_scientific.test.ry
@@ -1,0 +1,71 @@
+describe("u64 max value literal (#807)", ():
+  it("accepts u64 max via annotation", ():
+    x: u64 = 18446744073709551615
+    expect(x == 18446744073709551615u64).to_eq(true)
+  )
+  it("accepts u64 max via u64 suffix", ():
+    x = 18446744073709551615u64
+    expect(x == 18446744073709551615u64).to_eq(true)
+  )
+  it("accepts u64 max via hex annotation", ():
+    x: u64 = 0xFFFFFFFFFFFFFFFF
+    expect(x == 18446744073709551615u64).to_eq(true)
+  )
+  it("accepts u32 max via annotation", ():
+    x: u32 = 4294967295
+    expect(x as int).to_eq(4294967295)
+  )
+  it("accepts u16 max via annotation", ():
+    x: u16 = 65535
+    expect(x as int).to_eq(65535)
+  )
+  it("accepts u8 max via annotation", ():
+    x: u8 = 255
+    expect(x as int).to_eq(255)
+  )
+  it("allows reassignment of u64 max to a u64 variable", ():
+    x: u64 = 0u64
+    x = 18446744073709551615
+    expect(x == 18446744073709551615u64).to_eq(true)
+  )
+)
+
+describe("scientific notation literals (#819)", ():
+  it("parses 1e10 as float", ():
+    x = 1e10
+    expect(x).to_eq(10000000000.0)
+  )
+  it("parses uppercase E exponent", ():
+    x = 2E3
+    expect(x).to_eq(2000.0)
+  )
+  it("parses explicit positive exponent sign", ():
+    x = 2.5e+2
+    expect(x).to_eq(250.0)
+  )
+  it("parses negative exponent for small values", ():
+    x = 1.5e-2
+    expect(x > 0.014 and x < 0.016).to_eq(true)
+  )
+  it("parses fraction with exponent", ():
+    x = 3.14e2
+    expect(x > 313.9 and x < 314.1).to_eq(true)
+  )
+  it("allows underscore separator in mantissa", ():
+    x = 1_000e3
+    expect(x).to_eq(1000000.0)
+  )
+  it("allows underscore separator in exponent", ():
+    x = 1e1_000
+    # overflows to +Inf; just assert it is huge
+    expect(x > 1e300).to_eq(true)
+  )
+  it("supports scientific notation with f32 suffix", ():
+    x = 1e5f32
+    expect(x as float > 99999.0).to_eq(true)
+  )
+  it("does not steal e from identifiers (regression)", ():
+    e10 = 42
+    expect(e10).to_eq(42)
+  )
+)

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1353,3 +1353,69 @@ TEST_F(CodeGenTest, TopLevelFixedArrayIndexedFromFunction) {
         "print(head())\n"
         "print(at_two())"), "10\n30\n");
 }
+
+// ===== #807 u64 max literals =====
+
+TEST_F(CodeGenTest, U64MaxViaAnnotation) {
+    EXPECT_EQ(runSource("h: u64 = 18446744073709551615\nprint(h)"),
+              "18446744073709551615\n");
+}
+
+TEST_F(CodeGenTest, U64MaxViaSuffix) {
+    EXPECT_EQ(runSource("x = 18446744073709551615u64\nprint(x)"),
+              "18446744073709551615\n");
+}
+
+TEST_F(CodeGenTest, U64MaxViaHexAnnotation) {
+    EXPECT_EQ(runSource("x: u64 = 0xFFFFFFFFFFFFFFFF\nprint(x)"),
+              "18446744073709551615\n");
+}
+
+TEST_F(CodeGenTest, U64MaxReassignment) {
+    // AssignStmt path must accept bare u64 max when variable is u64.
+    EXPECT_EQ(runSource(
+        "x: u64 = 0u64\n"
+        "x = 18446744073709551615\n"
+        "print(x)"),
+        "18446744073709551615\n");
+}
+
+TEST_F(CodeGenTest, I64MaxPlus1BareIntRejected) {
+    // After #807, INT64_MAX+1 passes the parser (bit-pattern stored), but
+    // codegen must reject it when the target is bare `int` (= i64).
+    EXPECT_THROW(runSource("x = 9223372036854775808\nprint(x)"),
+                 std::runtime_error);
+}
+
+TEST_F(CodeGenTest, U64OverflowInCodegenRejected) {
+    EXPECT_THROW(runSource("x: u64 = 18446744073709551616\nprint(x)"),
+                 std::runtime_error);
+}
+
+TEST_F(CodeGenTest, U32MaxLiteralAccepted) {
+    EXPECT_EQ(runSource("x: u32 = 4294967295\nprint(x as int)"),
+              "4294967295\n");
+}
+
+TEST_F(CodeGenTest, U32OverflowRejected) {
+    EXPECT_THROW(runSource("x: u32 = 4294967296\nprint(x)"),
+                 std::runtime_error);
+}
+
+// ===== #819 scientific notation =====
+
+TEST_F(CodeGenTest, ScientificBasic) {
+    EXPECT_EQ(runSource("print(1e10)"), "1e+10\n");
+}
+
+TEST_F(CodeGenTest, ScientificNegativeExponent) {
+    EXPECT_EQ(runSource("print(1.5e-3)"), "0.0015\n");
+}
+
+TEST_F(CodeGenTest, ScientificPositiveSign) {
+    EXPECT_EQ(runSource("print(2.5E+2)"), "250.0\n");
+}
+
+TEST_F(CodeGenTest, ScientificIntegerSuffixRejected) {
+    EXPECT_THROW(runSource("print(1e10i32)"), std::runtime_error);
+}

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1419,3 +1419,39 @@ TEST_F(CodeGenTest, ScientificPositiveSign) {
 TEST_F(CodeGenTest, ScientificIntegerSuffixRejected) {
     EXPECT_THROW(runSource("print(1e10i32)"), std::runtime_error);
 }
+
+TEST_F(CodeGenTest, ScientificLeadingDot) {
+    EXPECT_EQ(runSource("print(.5e2)"), "50.0\n");
+}
+
+// `128i8` (positive overflow) must be rejected; `-128i8` (INT8_MIN via
+// unary-minus fast-path) must be accepted.
+TEST_F(CodeGenTest, SignedSuffixPositiveMaxPlus1Rejected) {
+    EXPECT_THROW(runSource("x = 128i8\nprint(x)"), std::runtime_error);
+    EXPECT_THROW(runSource("x = 32768i16\nprint(x)"), std::runtime_error);
+    EXPECT_THROW(runSource("x = 2147483648i32\nprint(x)"), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, SignedSuffixMinAcceptedViaUnaryMinus) {
+    EXPECT_EQ(runSource("x = -128i8\nprint(x as int)"), "-128\n");
+    EXPECT_EQ(runSource("x = -32768i16\nprint(x as int)"), "-32768\n");
+    EXPECT_EQ(runSource("x = -2147483648i32\nprint(x as int)"), "-2147483648\n");
+}
+
+TEST_F(CodeGenTest, U64ArrayInitializerMax) {
+    // Fixed-length array initializer must inject the element suffix so
+    // u64 max literals pass the codegen range check.
+    EXPECT_EQ(runSource(
+        "buf: u64[1] = [18446744073709551615]\n"
+        "print(buf[0])"),
+        "18446744073709551615\n");
+}
+
+TEST_F(CodeGenTest, U64AnnotationFormatterRoundtrip) {
+    // Annotation-driven u64 max must format correctly (#807 formatter fix).
+    // The formatter injects the suffix and renders the unsigned form.
+    EXPECT_EQ(runSource(
+        "h: u64 = 18446744073709551615\n"
+        "print(h)"),
+        "18446744073709551615\n");
+}

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -1407,3 +1407,11 @@ TEST(LexerTest, NumericLiteralHexELettersUnchanged) {
     EXPECT_EQ(toks[0].kind, TokenKind::Number);
     EXPECT_EQ(toks[0].value, "0xFE");
 }
+
+TEST(LexerTest, NumericLiteralLeadingDotScientific) {
+    // `.5e10` must be tokenized as a single Float, matching `0.5e10`.
+    auto toks = tokenize(".5e10");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Float);
+    EXPECT_EQ(toks[0].value, ".5e10");
+}

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -1328,3 +1328,82 @@ TEST(LexerTest, InvalidTrailingAlphaAfterNumeric) {
         EXPECT_EQ(toks[0].value, "3.14f64");
     }
 }
+
+// ===== #819 scientific notation =====
+
+TEST(LexerTest, NumericLiteralScientificBasic) {
+    auto toks = tokenize("1e10");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Float);
+    EXPECT_EQ(toks[0].value, "1e10");
+}
+
+TEST(LexerTest, NumericLiteralScientificUppercaseE) {
+    auto toks = tokenize("1E10");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Float);
+    EXPECT_EQ(toks[0].value, "1E10");
+}
+
+TEST(LexerTest, NumericLiteralScientificPositiveSign) {
+    auto toks = tokenize("1e+10");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Float);
+    EXPECT_EQ(toks[0].value, "1e+10");
+}
+
+TEST(LexerTest, NumericLiteralScientificNegativeSign) {
+    auto toks = tokenize("1.5e-10");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Float);
+    EXPECT_EQ(toks[0].value, "1.5e-10");
+}
+
+TEST(LexerTest, NumericLiteralScientificWithFraction) {
+    auto toks = tokenize("3.14e2");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Float);
+    EXPECT_EQ(toks[0].value, "3.14e2");
+}
+
+TEST(LexerTest, NumericLiteralScientificWithUnderscoreInMantissa) {
+    auto toks = tokenize("1_000e3");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Float);
+    EXPECT_EQ(toks[0].value, "1_000e3");
+}
+
+TEST(LexerTest, NumericLiteralScientificWithUnderscoreInExponent) {
+    auto toks = tokenize("1e1_000");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Float);
+    EXPECT_EQ(toks[0].value, "1e1_000");
+}
+
+TEST(LexerTest, NumericLiteralScientificWithF32Suffix) {
+    auto toks = tokenize("1e10f32");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Float);
+    EXPECT_EQ(toks[0].value, "1e10f32");
+}
+
+TEST(LexerTest, NumericLiteralScientificMissingDigitsThrows) {
+    EXPECT_THROW(tokenize("1e"), std::runtime_error);
+    EXPECT_THROW(tokenize("1e-"), std::runtime_error);
+}
+
+TEST(LexerTest, NumericLiteralIdentifierLikeEDoesNotSteal) {
+    // Regression: `1exp` must NOT be tokenized as a scientific float.
+    // The lexer should emit the existing "invalid character after numeric
+    // literal" error because `e` is the start of an identifier.
+    EXPECT_THROW(tokenize("1exp"), std::runtime_error);
+}
+
+TEST(LexerTest, NumericLiteralHexELettersUnchanged) {
+    // Regression: hex literals use `e`/`E` as hex digits and must not enter
+    // the scientific-notation branch.
+    auto toks = tokenize("0xFE");
+    ASSERT_EQ(toks.size(), 2u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Number);
+    EXPECT_EQ(toks[0].value, "0xFE");
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2158,6 +2158,19 @@ TEST(ParserTest, ScientificMissingExponentThrows) {
     EXPECT_THROW(parseStr("x = 1e"), std::runtime_error);
 }
 
+TEST(ParserTest, ScientificSignedMissingExponentThrows) {
+    // `1e-` has a sign but no digits; same fallthrough as `1e`.
+    EXPECT_THROW(parseStr("x = 1e-"), std::runtime_error);
+}
+
+TEST(ParserTest, FloatLiteralLeadingDotScientific) {
+    // `.5e10` is also a valid float with exponent — the leading-dot lexer
+    // branch must reuse the same exponent scan as the digit-prefixed one.
+    Program prog = parseStr("x = .5e10");
+    const auto &f = std::get<FloatExpr>(std::get<AssignStmt>(prog[0]).value->data);
+    EXPECT_DOUBLE_EQ(f.value, 0.5e10);
+}
+
 TEST(ParserTest, IdentifierStartingWithENotStolen) {
     // Regression guard: `1exp` must not swallow `e` as an exponent.
     EXPECT_THROW(parseStr("x = 1exp"), std::runtime_error);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2068,13 +2068,97 @@ TEST(ParserTest, IntLiteralInt64Max) {
     EXPECT_EQ(n.value, INT64_MAX);
 }
 
-TEST(ParserTest, IntLiteralOutOfRangeThrows) {
-    // INT64_MAX + 1 should produce a diagnostic error, not a crash
+TEST(ParserTest, IntLiteralInt64MaxPlus1AcceptedAsBitPattern) {
+    // After #807 the parser accepts up to UINT64_MAX by storing the value as
+    // a bit pattern in int64_t. INT64_MAX+1 is stored as INT64_MIN; codegen
+    // is responsible for rejecting it when the target type is i64 or bare
+    // int (see test_codegen.cpp).
+    Program prog = parseStr("x = 9223372036854775808");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    const auto &n = std::get<NumberExpr>(s.value->data);
+    EXPECT_EQ(static_cast<uint64_t>(n.value),
+              static_cast<uint64_t>(INT64_MAX) + 1);
+    EXPECT_TRUE(n.suffix.empty());
+}
+
+TEST(ParserTest, IntLiteralU64MaxSuffixed) {
+    // #807: 18446744073709551615u64 must parse without error and store the
+    // bit pattern in NumberExpr.value.
+    Program prog = parseStr("x = 18446744073709551615u64");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    const auto &n = std::get<NumberExpr>(s.value->data);
+    EXPECT_EQ(n.suffix, "u64");
+    EXPECT_EQ(static_cast<uint64_t>(n.value), UINT64_MAX);
+}
+
+TEST(ParserTest, IntLiteralU64MaxHexSuffixed) {
+    Program prog = parseStr("x = 0xFFFFFFFFFFFFFFFFu64");
+    const auto &n = std::get<NumberExpr>(std::get<AssignStmt>(prog[0]).value->data);
+    EXPECT_EQ(n.suffix, "u64");
+    EXPECT_EQ(static_cast<uint64_t>(n.value), UINT64_MAX);
+}
+
+TEST(ParserTest, IntLiteralUint64OverflowThrows) {
+    // Magnitudes strictly greater than UINT64_MAX must still be rejected at
+    // parse time (strtoull returns ERANGE).
     try {
-        parseStr("x = 9223372036854775808");
+        parseStr("x = 18446744073709551616");  // UINT64_MAX + 1
         FAIL() << "expected exception";
     } catch (const DiagnosticError &e) {
         std::string msg = e.what();
         EXPECT_NE(msg.find("integer literal out of range"), std::string::npos);
     }
+}
+
+TEST(ParserTest, FloatLiteralScientificBasic) {
+    Program prog = parseStr("x = 1e10");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<FloatExpr>(s.value->data));
+    const auto &f = std::get<FloatExpr>(s.value->data);
+    EXPECT_DOUBLE_EQ(f.value, 1e10);
+    EXPECT_TRUE(f.suffix.empty());
+}
+
+TEST(ParserTest, FloatLiteralScientificNegExponent) {
+    Program prog = parseStr("x = 1.5e-3");
+    const auto &f = std::get<FloatExpr>(std::get<AssignStmt>(prog[0]).value->data);
+    EXPECT_DOUBLE_EQ(f.value, 1.5e-3);
+}
+
+TEST(ParserTest, FloatLiteralScientificUppercaseE) {
+    Program prog = parseStr("x = 2.5E+2");
+    const auto &f = std::get<FloatExpr>(std::get<AssignStmt>(prog[0]).value->data);
+    EXPECT_DOUBLE_EQ(f.value, 250.0);
+}
+
+TEST(ParserTest, FloatLiteralScientificWithUnderscore) {
+    Program prog = parseStr("x = 1_000e3");
+    const auto &f = std::get<FloatExpr>(std::get<AssignStmt>(prog[0]).value->data);
+    EXPECT_DOUBLE_EQ(f.value, 1e6);
+}
+
+TEST(ParserTest, FloatLiteralScientificF32Suffix) {
+    Program prog = parseStr("x = 1e10f32");
+    const auto &f = std::get<FloatExpr>(std::get<AssignStmt>(prog[0]).value->data);
+    EXPECT_EQ(f.suffix, "f32");
+}
+
+TEST(ParserTest, ScientificWithIntSuffixRejected) {
+    // `1e10` is a float literal; an integer suffix is an error.
+    EXPECT_THROW(parseStr("x = 1e10i32"), DiagnosticError);
+}
+
+TEST(ParserTest, ScientificMissingExponentThrows) {
+    // `1e` has no exponent digits; lexer keeps `e` as the start of an
+    // identifier which the "invalid character after numeric literal"
+    // guard then rejects.
+    EXPECT_THROW(parseStr("x = 1e"), std::runtime_error);
+}
+
+TEST(ParserTest, IdentifierStartingWithENotStolen) {
+    // Regression guard: `1exp` must not swallow `e` as an exponent.
+    EXPECT_THROW(parseStr("x = 1exp"), std::runtime_error);
 }


### PR DESCRIPTION
## Summary

Frontend-only fixes for two long-standing numeric-literal gaps.

### #807 — `u64` max value literal

`h: u64 = 18446744073709551615` now parses. `tryParseIntLiteral` switches to `strtoull` and stores the value as a non-negative bit pattern in `int64_t`. `emitVarDecl` / `emitAssignStmt` / `emitModuleGlobalWriteThrough` inject the target low-level type as a suffix so the codegen range check runs against `u64` instead of bare `int`. `u64` suffix, hex (`0xFFFFFFFFFFFFFFFFu64`), and annotation-driven forms all work; `0xFFFFFFFFFFFFFFFF` / `u32`-`u8` max values are also accepted.

Pattern negation in `parser_decl.cpp` (`case -1:`) now wraps the magnitude in `UnaryExpr(\"-\", ...)` to preserve the invariant "`NumberExpr.value` is always a non-negative bit pattern".

### #819 — scientific notation

`1e10`, `1.5e-3`, `2.5E+2`, `1_000e3`, `1e1_000`, `1e10f32` all tokenize. The lexer's decimal path accepts an `e`/`E` exponent with optional sign, using a one-char lookahead so `1exp` and `1e` still fall through to the existing "invalid character after numeric literal" error. Integer suffix + exponent (`1e10i32`) is rejected via the pre-existing float+int-suffix guard in `parser_expr.cpp`.

`parseFloatLiteral` switches from `std::stod` to `strtod + errno` so `1e400` yields `+Inf` instead of throwing `out_of_range`.

### Key files

- `include/ry/parser.hpp` — `tryParseIntLiteral`/`parseFloatLiteral` rewrites
- `src/lexer.cpp` — exponent scanning in decimal path
- `src/codegen_expr.cpp` — `validateIntRange` bit-pattern semantics + empty-suffix overflow check
- `src/codegen_stmt.cpp` — `injectLowLevelSuffix` helper, called from decl/assign/module-global paths
- `src/parser_decl.cpp` — `isSignedInt64Magnitude` helper; pattern negation via UnaryExpr
- `src/formatter.cpp` — unsigned NumberExpr output
- `include/ry/ast.hpp` — `NumberExpr` bit-pattern invariant documented at the struct definition

### Docs / knowledge

- `docs/reference/types.md`: new **Numeric Literals** section with the integer range table and float EBNF
- `changelog.d/807-819-numeric-literal.md`
- `KNOWLEDGE.md`: two new entries (bit-pattern invariant, `strtod`-over-`stod` rule)

## Test plan

- [x] C++ unit tests: 1541/1541 pass (`./build/ry_tests`)
- [x] Ry spec tests: 103 files, 0 failures (`./build/ry test -p`)
- [x] ASan build: 1540/1540 pass (`ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests` and `./build-asan/ry test -p`)
- [x] Ad-hoc verification for all scope-check items in the issues (u64 max via annotation / suffix / hex / bin, all scientific-notation forms, error paths for `1e10i32` / bare overflow / `1e`)
- [x] `case -1:` pattern match still works (regression check)

## Issues

- Closes #807
- Closes #819

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Scientific-notation floats supported (e/E, optional sign) with underscores in mantissa/exponent; leading-dot forms accepted.
  * Max-range u64 literals accepted in decimal/hex/bin when suffixed or annotated; formatter emits unsigned values correctly.

* **Bug Fixes**
  * Numeric literal range checks clarified and tightened; negative literals represented consistently to avoid misrange accepts.
  * Float parsing improved to allow ±Inf on overflow and reject malformed/trailing-garbage forms.

* **Documentation**
  * Expanded numeric-literal reference and knowledge docs with examples and rules.

* **Tests**
  * Added parser/lexer/codegen tests covering these cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->