### PR TITLE
fix: stdlib correctness bundle — replace(), NaN !=, is_empty(str) (#802, #803, #831)

### DIFF
--- a/changelog.d/802-803-831-stdlib-correctness.md
+++ b/changelog.d/802-803-831-stdlib-correctness.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `replace(s, "", repl)` no longer hangs with an infinite loop; an empty pattern now returns a fresh copy of the input unchanged (#802)
+- `NaN != NaN` now returns `true` as required by IEEE 754; float `!=` comparisons use `fcmp une` (unordered not-equal) instead of `fcmp one` (#803)
+- `is_empty()` now accepts `str` arguments in addition to lists, maps, and sets (#831)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -160,10 +160,13 @@ print("abc".char_at(2))       # c (UFCS)
 
 Returns a new string with all occurrences of `old` in `string` replaced with `new`.
 
+If `old` is an empty string, the input is returned unchanged (as a fresh copy).
+
 ```python
 print(replace("hello world", "world", "ry"))   # hello ry
 print(replace("aaa", "a", "bb"))                # bbbbbb
 print("foo bar foo".replace("foo", "baz"))      # baz bar baz (UFCS)
+print(replace("hello", "", "X"))                # hello (empty pattern is a no-op)
 ```
 
 ---

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -90,7 +90,7 @@
 | `first(list)` | Returns the first element as `Option<T>`, or `None` if empty |
 | `last(list)` | Returns the last element as `Option<T>`, or `None` if empty |
 | `remove(list, value)` | Removes the first occurrence of value from a list |
-| `is_empty(list)` | Returns whether the list is empty |
+| `is_empty(list / map / set / str)` | Returns whether the collection or string is empty |
 | `distinct(list)` | Returns a new list with duplicates removed |
 | `flatten(list)` | Returns a new list with nested lists flattened |
 | `reduce(list, fn)` | Reduces a list to a single value using the reducer function |

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -360,12 +360,14 @@ print(last(xs))   # Some(30)
 
 ### is_empty
 
-Returns `true` if the list has no elements.
+Returns `true` if the container has no elements. Accepts lists, maps, sets, and strings.
 
 ```python
 xs = [1, 2, 3]
-print(is_empty(xs))   # false
-print(is_empty([]))   # true (requires type annotation in practice)
+print(is_empty(xs))        # false
+print(is_empty([]))        # true (requires type annotation in practice)
+print(is_empty(""))        # true  (str support, #831)
+print(is_empty("hello"))   # false
 ```
 
 ### enumerate

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -279,7 +279,7 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         return phiL;
     }
 
-    // ===== is_empty(list/map/set) =====
+    // ===== is_empty(list/map/set/str) =====
     if (e.callee == "is_empty") {
         requireArgs(e, 1);
         llvm::Value *val = emitExpr(*e.args[0]);
@@ -287,10 +287,17 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         if (getListElementType(val)) headerTy = listHeaderTy_;
         else if (getMapKeyType(val)) headerTy = mapHeaderTy_;
         else if (getSetElementType(val)) headerTy = setHeaderTy_;
-        if (!headerTy)
-            codegenError("is_empty() requires a collection (list, map, or set)");
-        llvm::Value *len = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(headerTy, val, 0), "ie_len");
-        return builder_.CreateICmpEQ(len, llvm::ConstantInt::get(i64Ty_, 0), "is_empty");
+        if (headerTy) {
+            llvm::Value *len = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(headerTy, val, 0), "ie_len");
+            return builder_.CreateICmpEQ(len, llvm::ConstantInt::get(i64Ty_, 0), "is_empty");
+        }
+        // String (#831): peek the first byte. Ry strings are NUL-terminated,
+        // so emptiness is O(1) — avoid walking the whole string via __ry_utf8_len.
+        if (val->getType() == ptrTy_) {
+            llvm::Value *firstByte = builder_.CreateLoad(i8Ty_, val, "ie_first_byte");
+            return builder_.CreateICmpEQ(firstByte, llvm::ConstantInt::get(i8Ty_, 0), "is_empty");
+        }
+        codegenError("is_empty() requires a collection (list, map, set) or str");
     }
 
     // ===== enumerate(list) =====

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -304,6 +304,25 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
     llvm::Value *oldLen = builder_.CreateCall(strlenFn, {oldStr}, "repl_old_len");
     llvm::Value *newLen = builder_.CreateCall(strlenFn, {newStr}, "repl_new_len");
 
+    // Guard against empty pattern (#802): strstr("...", "") returns its first
+    // argument without advancing, which would cause the count/build loops below
+    // to spin forever. When `old` is empty, return a fresh copy of `s` so the
+    // callee still owns an independent allocation like the non-empty path.
+    llvm::BasicBlock *replEmptyBB = llvm::BasicBlock::Create(*ctx_, "repl.empty_pat", fn_);
+    llvm::BasicBlock *replMainBB  = llvm::BasicBlock::Create(*ctx_, "repl.main", fn_);
+    llvm::BasicBlock *replEndBB   = llvm::BasicBlock::Create(*ctx_, "repl.done", fn_);
+
+    llvm::Value *oldIsEmpty = builder_.CreateICmpEQ(oldLen, llvm::ConstantInt::get(i64Ty_, 0), "repl_old_empty");
+    builder_.CreateCondBr(oldIsEmpty, replEmptyBB, replMainBB);
+
+    builder_.SetInsertPoint(replEmptyBB);
+    llvm::Value *replEmptySize = builder_.CreateAdd(sLen, llvm::ConstantInt::get(i64Ty_, 1), "repl_empty_buf_size");
+    llvm::Value *replEmptyBuf = builder_.CreateCall(mallocFn, {replEmptySize}, "repl_empty_buf");
+    builder_.CreateCall(memcpyFn, {replEmptyBuf, s, replEmptySize});
+    builder_.CreateBr(replEndBB);
+
+    builder_.SetInsertPoint(replMainBB);
+
     // Pass 1: count occurrences
     llvm::AllocaInst *countVar = builder_.CreateAlloca(i64Ty_, nullptr, "repl_count");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), countVar);
@@ -376,8 +395,14 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
     llvm::Value *remainLen = builder_.CreateCall(strlenFn, {finalSrc}, "remain_len");
     llvm::Value *remainPlusNull = builder_.CreateAdd(remainLen, llvm::ConstantInt::get(i64Ty_, 1), "remain_plus_null");
     builder_.CreateCall(memcpyFn, {finalDst, finalSrc, remainPlusNull});
+    builder_.CreateBr(replEndBB);
 
-    return buf;
+    // Merge empty-pattern path and main path
+    builder_.SetInsertPoint(replEndBB);
+    llvm::PHINode *replResult = builder_.CreatePHI(ptrTy_, 2, "repl_result");
+    replResult->addIncoming(replEmptyBuf, replEmptyBB);
+    replResult->addIncoming(buf, buildEndBB);
+    return replResult;
 }
 
 // to_upper(s) → str

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -791,7 +791,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         if (isLowLevelFloatTy(lhs->getType())) {
             llvm::CmpInst::Predicate pred;
             if      (op == "==") pred = llvm::CmpInst::FCMP_OEQ;
-            else if (op == "!=") pred = llvm::CmpInst::FCMP_ONE;
+            else if (op == "!=") pred = llvm::CmpInst::FCMP_UNE;
             else if (op == "<")  pred = llvm::CmpInst::FCMP_OLT;
             else if (op == "<=") pred = llvm::CmpInst::FCMP_OLE;
             else if (op == ">")  pred = llvm::CmpInst::FCMP_OGT;
@@ -818,7 +818,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         std::tie(lhs, rhs) = promoteToFloat(lhs, rhs);
         llvm::CmpInst::Predicate pred;
         if      (op == "==") pred = llvm::CmpInst::FCMP_OEQ;
-        else if (op == "!=") pred = llvm::CmpInst::FCMP_ONE;
+        else if (op == "!=") pred = llvm::CmpInst::FCMP_UNE;
         else if (op == "<")  pred = llvm::CmpInst::FCMP_OLT;
         else if (op == "<=") pred = llvm::CmpInst::FCMP_OLE;
         else if (op == ">")  pred = llvm::CmpInst::FCMP_OGT;

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -25,8 +25,8 @@ describe("NaN comparisons", ():
   it("should verify NaN == NaN is false", ():
     expect(NaN == NaN).to_eq(false)
   )
-  it("should verify NaN != NaN is false (ordered)", ():
-    expect(NaN != NaN).to_eq(false)
+  it("should verify NaN != NaN is true (IEEE 754 unordered)", ():
+    expect(NaN != NaN).to_eq(true)
   )
   it("should verify NaN < 1.0 is false", ():
     expect(NaN < 1.0).to_eq(false)

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -73,6 +73,29 @@ describe("extraction and transformation", ():
   it("should return original when replace target not found", ():
     expect(replace("hello", "xyz", "abc")).to_eq("hello")
   )
+  it("should return input unchanged when pattern is empty (#802)", ():
+    expect(replace("hello", "", "X")).to_eq("hello")
+    expect(replace("", "", "X")).to_eq("")
+  )
+)
+
+describe("is_empty on strings (#831)", ():
+  it("should return true for empty string", ():
+    expect(is_empty("")).to_eq(true)
+  )
+  it("should return false for non-empty string", ():
+    expect(is_empty("hello")).to_eq(false)
+  )
+  it("should work via UFCS on empty string", ():
+    expect("".is_empty()).to_eq(true)
+  )
+  it("should work via UFCS on non-empty string", ():
+    expect("x".is_empty()).to_eq(false)
+  )
+  it("should handle multi-byte UTF-8 empty vs non-empty", ():
+    expect(is_empty("")).to_eq(true)
+    expect(is_empty("日本語")).to_eq(false)
+  )
 )
 
 describe("case conversion", ():


### PR DESCRIPTION
## Summary

Bundle three small but high-impact bug fixes in stdlib / float correctness, all targeting `v0.0.8`.

- **#802**: `replace("hello", "", "X")` no longer hangs indefinitely. Empty pattern now returns a fresh copy of the input through a guarded branch that mirrors the non-empty path's allocation ownership model.
- **#803**: `NaN != NaN` now returns `true` as required by IEEE 754. Float `!=` uses `FCMP_UNE` (unordered not-equal) instead of the previous `FCMP_ONE` (ordered). Ordered comparisons (`<`, `<=`, `>`, `>=`) remain untouched so the existing `NaN < 1.0 → false` semantics are preserved.
- **#831**: `is_empty()` now accepts `str` in addition to lists/maps/sets. Implemented as an O(1) first-byte NUL check instead of walking the whole string via `__ry_utf8_len`.

## Changes

| File | Change |
|---|---|
| `src/codegen_expr.cpp` | `FCMP_ONE` → `FCMP_UNE` in both low-level and general float `!=` paths |
| `src/codegen_call_string.cpp` | `emitStrOp_replace` gets an `oldLen == 0` guard that emits a separate BasicBlock: `malloc(sLen+1) + memcpy`, then merges back via a PHI with the main path |
| `src/codegen_call.cpp` | `is_empty` dispatch adds a str fallback after list/map/set checks |
| `tests/spec/math.test.ry` | Updated `NaN != NaN` assertion to expect `true` (was encoding the bug as expected) |
| `tests/spec/strings.test.ry` | New tests: `replace` empty pattern (1), `is_empty` on str (5 cases incl. UFCS and multi-byte UTF-8) |
| `docs/reference/builtins-string.md`, `collections.md`, `builtins.md` | Documented empty-pattern behavior and str support for `is_empty` |
| `changelog.d/802-803-831-stdlib-correctness.md` | CHANGELOG fragment |

## Test plan

- [x] `cmake --build build` succeeds
- [x] `./build/ry_tests` — 1549 C++ tests PASS
- [x] `./build/ry test -p` — 103 Ry spec files PASS
- [x] `cmake --build build-asan` + `ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests` — 1548 tests PASS, no ASan errors
- [x] `ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p` — 103 files PASS, no leaks in the new PHI path
- [x] `replace("hello", "", "X")` returns `"hello"` (previously hung)
- [x] `NaN != NaN` returns `true`
- [x] `is_empty("")` / `"".is_empty()` returns `true`, `is_empty("hello")` returns `false`
- [x] Non-empty multi-byte UTF-8 (`日本語`) correctly reports `is_empty` → `false`

Closes #802, #803, #831

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `is_empty()` now supports string inputs alongside lists, maps, and sets.

* **Bug Fixes**
  * `replace()` with an empty pattern now returns the original string unchanged instead of causing infinite loops.
  * Floating-point `!=` comparisons now correctly follow IEEE 754 semantics—`NaN != NaN` evaluates to `true`.

* **Documentation**
  * Updated function references to reflect `is_empty()` string support and `replace()` empty-pattern behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->