### PR TITLE
fix: to_float Result and record/enum name clash (#806, #815)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -71,6 +71,32 @@ For each hit, confirm a test exists that executes that exact line.
 
 ## Codegen
 
+### Adding a new type kind requires cross-checking every other type registry
+
+**Source**: #815 (2026-04-11, implementation)
+**Tags**: codegen, types, registry, duplicate-check, naming
+
+**Context**: Type definitions in `include/ry/codegen.hpp` are stored
+across at least five separate registries: `struct_types_` (records),
+`enum_types_` (concrete enums), `generic_enum_templates_` (generic enum
+templates), `type_aliases_`, and `union_type_info_`. Each `emitStmt`
+path only checked its **own** registry for duplicate names. Before #815,
+`record Foo` and `enum Foo` silently coexisted because neither path
+consulted the other registry, producing inconsistent lookup depending
+on which map was probed first.
+
+**Rule**: When introducing a new type kind (or touching an existing
+`emitStmt(<Decl>Stmt &)` path), reject the name if it collides with
+**any** other type registry — not just the one for the current kind.
+Pair record/enum/generic-enum/alias/union as a single name space.
+
+**How to verify**: grep the codegen header for
+`std::unordered_map<std::string, .*(?:Info|Template|Type)>` to find
+every type registry, then confirm each `emitStmt` for a type
+declaration consults all registries before inserting. Add a regression
+test (`EXPECT_THROW` with `runSource`) per cross-category pair — legal
+cases alone won't catch a missing guard.
+
 ### Canonicalization that may collapse shape must be handled at all call sites
 
 **Source**: #844 PR review (CodeRabbit, critical)

--- a/changelog.d/806-to-float-result.md
+++ b/changelog.d/806-to-float-result.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `to_float(str)` now returns `Result<float, Error>` instead of `float`, matching the shape of `to_int(str)`. Invalid input previously returned `0.0` silently; it now returns `Err(Error(...))`. Empty strings, non-numeric content, and out-of-range values are reported as errors. **Breaking change**: existing code must unwrap the `Result` (e.g., via `match` or `?`). (#806)

--- a/changelog.d/815-type-duplicate-crosscheck.md
+++ b/changelog.d/815-type-duplicate-crosscheck.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Compiler now rejects defining a `record` and an `enum` with the same name in the same compilation unit. This also covers generic enum templates: `record Foo` and `enum Foo<T>` can no longer coexist, and duplicate generic enum declarations are rejected. Previously both declarations were accepted, leading to inconsistent type lookup. (#815)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -60,7 +60,7 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 | Function | Signature | Description |
 |------|-----------|------|
 | `to_int` | `str -> Result<int, Error>` | Convert string to integer |
-| `to_float` | `str -> float` | Convert string to floating-point number |
+| `to_float` | `str -> Result<float, Error>` | Convert string to floating-point number |
 | `to_str` | `int/float/bool/str/enum/record -> str` | Convert value to string |
 
 ---
@@ -349,13 +349,27 @@ print(to_int(""))             # Err(Error("to_int: empty string"))
 
 ## to_float
 
-**Signature:** `to_float(string: str) -> float`
+**Signature:** `to_float(string: str) -> Result<float, Error>`
 
-Converts a string to a floating-point number.
+Converts a string to a floating-point number. Returns `Err` if the string is empty, contains invalid characters, or is out of range for `float`.
 
 ```python
-print(to_float("3.14"))   # 3.14
-print("2.5".to_float())   # 2.5 (UFCS)
+match to_float("3.14"):
+    case Ok(v):
+        print(v)              # 3.14
+    case Err(e):
+        print(e.message)
+
+match "2.5".to_float():        # UFCS
+    case Ok(v):
+        print(v)              # 2.5
+    case Err(e):
+        print(e.message)
+
+# Invalid input returns Err
+print(to_float("abc"))         # Err(Error("to_float: invalid character in 'abc'"))
+print(to_float(""))            # Err(Error("to_float: empty string"))
+print(to_float("1e400"))       # Err(Error("to_float: out of range in '1e400'"))
 ```
 
 ---

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -135,7 +135,7 @@
 | `reverse(string)` | Reverse a string |
 | `split(string, delimiter)` | Split a string into a list |
 | `join(list, sep)` | Join list elements with a separator |
-| `to_int(s)` / `to_float(s)` / `to_str(v)` | Type conversion (`to_int` returns `Result<int, Error>`) |
+| `to_int(s)` / `to_float(s)` / `to_str(v)` | Type conversion (`to_int` and `to_float` return `Result<T, Error>`) |
 
 -> See **[String Operation Function Reference](builtins-string.md)** for details
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -196,7 +196,7 @@ light_spd = 2.998E8
 big       = 1e10f32
 ```
 
-Overflowing exponents produce `+Inf`/`-Inf` (not a compile error), matching the runtime `to_float` converter.
+Overflowing exponents produce `+Inf`/`-Inf` (not a compile error). Note that the runtime `to_float()` converter is stricter: it returns `Err(Error)` on overflow rather than producing `+Inf`.
 
 ---
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -403,6 +403,11 @@ public:
     void instantiateGenericEnum(const std::string &fullName, const std::string &baseName,
                                 const std::vector<std::string> &typeArgs);
 
+    // Reject `name` if it is already registered under a different type kind
+    // (record, enum, generic enum). Callers must check same-kind duplicates
+    // themselves so they can emit a caller-specific error.
+    void rejectIfTypeNameTakenByOtherKind(const std::string &name);
+
     // Generic function templates
     struct GenericFnTemplate {
         std::unique_ptr<FnStmt> fnStmt;

--- a/share/std/convert.ry
+++ b/share/std/convert.ry
@@ -3,7 +3,7 @@
 function to_int(value: str) -> Result<int, Error>
 
 @native
-function to_float(value: str) -> float
+function to_float(value: str) -> Result<float, Error>
 
 @native
 function to_str(value: int) -> str

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -31,16 +31,26 @@ llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
             [&]() { return buildErrValue(buildErrorFromRuntime("__ry_convert_get_last_error"), resTy); });
     }
 
-    // to_float(s) → float — fall through for JsonValue to let JSON dispatcher handle it
+    // to_float(s) → Result<float, Error> — fall through for JsonValue to let JSON dispatcher handle it
     if (e.callee == "to_float") {
         requireArgs(e, 1);
         llvm::Value *s = emitExpr(*e.args[0]);
         if (isJsonValue(s)) return nullptr;
         if (s->getType() != ptrTy_)
             codegenError("to_float() requires str argument");
-        auto atofTy = llvm::FunctionType::get(f64Ty_, {ptrTy_}, false);
-        auto atofFn = mod_->getOrInsertFunction("atof", atofTy);
-        return builder_.CreateCall(atofFn, {s}, "to_float");
+        llvm::AllocaInst *outSlot = builder_.CreateAlloca(f64Ty_, nullptr, "to_float_out");
+        auto fn = mod_->getOrInsertFunction("__ry_str_to_float", fnTy_ptr_ptr_to_i64_);
+        used_native_libraries_.insert("convert");
+        llvm::Value *status = builder_.CreateCall(fn, {s, outSlot}, "to_float_status");
+        llvm::Value *isErr = builder_.CreateICmpNE(status,
+            llvm::ConstantInt::get(i64Ty_, 0), "to_float_err");
+        llvm::StructType *resTy = getResultType(f64Ty_, errorTy_);
+        return emitResultBranch(isErr, resTy,
+            [&]() {
+                llvm::Value *loaded = builder_.CreateLoad(f64Ty_, outSlot, "to_float_val");
+                return buildOkValue(loaded, resTy);
+            },
+            [&]() { return buildErrValue(buildErrorFromRuntime("__ry_convert_get_last_error"), resTy); });
     }
 
     // to_str(v) → str — fall through for JsonValue to let JSON dispatcher handle it

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -11,6 +11,7 @@ void CodeGen::emitStmt(RecordStmt &s) {
     emitTraceSymbolDefine("record", s.name, s.loc);
     if (struct_types_.count(s.name))
         codegenError("redefined type: " + s.name);
+    rejectIfTypeNameTakenByOtherKind(s.name);
 
     std::string parentName;
     std::vector<FieldDef> allFields;

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -66,10 +66,23 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
     emitInvariantCheck(typeName, info, updated);
 }
 
+void CodeGen::rejectIfTypeNameTakenByOtherKind(const std::string &name) {
+    if (struct_types_.count(name))
+        codegenError("type '" + name + "' is already defined as a record");
+    if (enum_types_.count(name))
+        codegenError("type '" + name + "' is already defined as an enum");
+    if (generic_enum_templates_.count(name))
+        codegenError("type '" + name + "' is already defined as a generic enum");
+}
+
 void CodeGen::emitStmt(EnumStmt &s) {
+    if (s.loc.isValid()) current_loc_ = s.loc;
     emitTraceSymbolDefine("enum", s.name, s.loc);
     // Generic enum: save as template, don't instantiate yet
     if (!s.type_params.empty()) {
+        if (generic_enum_templates_.count(s.name))
+            codegenError("generic enum '" + s.name + "' is already defined");
+        rejectIfTypeNameTakenByOtherKind(s.name);
         GenericEnumTemplate tmpl;
         tmpl.name = s.name;
         tmpl.typeParams = s.type_params;
@@ -80,6 +93,7 @@ void CodeGen::emitStmt(EnumStmt &s) {
 
     if (enum_types_.count(s.name))
         codegenError("enum '" + s.name + "' is already defined");
+    rejectIfTypeNameTakenByOtherKind(s.name);
 
     EnumInfo info;
     info.name = s.name;

--- a/src/runtime_convert.cpp
+++ b/src/runtime_convert.cpp
@@ -32,4 +32,27 @@ extern "C" int64_t __ry_str_to_int(const char *str, int64_t *out) {
     return 0;
 }
 
+extern "C" int64_t __ry_str_to_float(const char *str, double *out) {
+    if (!str || *str == '\0') {
+        setLastError("to_float: empty string");
+        return 1;
+    }
+
+    errno = 0;
+    char *end = nullptr;
+    double val = strtod(str, &end);
+
+    if (errno == ERANGE) {
+        setLastError("to_float: out of range in '%s'", str);
+        return 1;
+    }
+    if (end == str || *end != '\0') {
+        setLastError("to_float: invalid character in '%s'", str);
+        return 1;
+    }
+
+    *out = val;
+    return 0;
+}
+
 } // namespace ry

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -280,13 +280,32 @@ describe("type conversion", ():
       case Err(_):
         expect(false).to_eq(true)
   )
-  it("should convert string to float with to_float", ():
-    expect(to_float("3.14")).to_eq(3.14)
-    expect(to_float("2.5")).to_eq(2.5)
+  it("should return Ok for valid to_float input", ():
+    match to_float("3.14"):
+      case Ok(v):
+        expect(v).to_eq(3.14)
+      case Err(_):
+        expect(false).to_eq(true)
+    match to_float("-0.5"):
+      case Ok(v):
+        expect(v).to_eq(-0.5)
+      case Err(_):
+        expect(false).to_eq(true)
+    expect(to_float("2.5")).to_be_ok()
+    expect(to_float("0")).to_be_ok()
   )
-  it("should return 0 for non-numeric to_float input", ():
-    expect(to_float("xyz")).to_eq(0.0)
-    expect(to_float("")).to_eq(0.0)
+  it("should return Err for invalid to_float input", ():
+    expect(to_float("xyz")).to_be_err()
+    expect(to_float("")).to_be_err()
+    expect(to_float("1.2abc")).to_be_err()
+    expect(to_float("1e400")).to_be_err()
+  )
+  it("should return Result from to_float via UFCS", ():
+    match "3.14".to_float():
+      case Ok(v):
+        expect(v).to_eq(3.14)
+      case Err(_):
+        expect(false).to_eq(true)
   )
   it("should convert value to string with to_str", ():
     expect(to_str(42)).to_eq("42")

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -358,12 +358,32 @@ match s.to_int():
 }
 
 TEST_F(CodeGenTest, StringToFloat) {
-    // ToFloatBasic
-    EXPECT_EQ(runSource("print(to_float(\"3.14\"))"), "3.14\n");
-    // ToFloatInteger
-    EXPECT_EQ(runSource("print(to_float(\"42\"))"), "42.0\n");
-    // ToFloatUFCS
-    EXPECT_EQ(runSource("s = \"2.5\"\nprint(s.to_float())"), "2.5\n");
+    auto checkToFloat = [&](const char *input, const char *expected) {
+        std::string src = "match to_float(\"";
+        src += input;
+        src += "\"):\n    case Ok(v):\n        print(v)\n    case Err(e):\n        print(\"err\")";
+        EXPECT_EQ(runSource(src), expected);
+    };
+    // Valid input returns Ok
+    checkToFloat("3.14", "3.14\n");
+    checkToFloat("42", "42.0\n");
+    checkToFloat("-0.5", "-0.5\n");
+    checkToFloat("0", "0.0\n");
+    // Invalid input returns Err
+    checkToFloat("abc", "err\n");
+    checkToFloat("", "err\n");
+    checkToFloat("1.2abc", "err\n");
+    // Overflow returns Err
+    checkToFloat("1e400", "err\n");
+    // UFCS
+    EXPECT_EQ(runSource(R"(
+s = "2.5"
+match s.to_float():
+    case Ok(v):
+        print(v)
+    case Err(e):
+        print("err")
+)"), "2.5\n");
 }
 
 TEST_F(CodeGenTest, ToStrVariants) {

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -81,6 +81,17 @@ protected:
         return runModule(compileSource(src));
     }
 
+    static void expectCompileError(const std::string &src, const std::string &fragment) {
+        try {
+            compileSource(src);
+            FAIL() << "Expected compile error containing: " << fragment;
+        } catch (const std::runtime_error &e) {
+            std::string msg = e.what();
+            EXPECT_NE(msg.find(fragment), std::string::npos)
+                << "Expected error to contain: '" << fragment << "', got: " << msg;
+        }
+    }
+
     static std::string runTestSource(const std::string &src) {
         Lexer lex(src);
         Parser parser(lex);

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -533,6 +533,16 @@ TEST_F(CodeGenTest, EnumThenGenericEnumWithSameNameRejected) {
         "already defined as an enum");
 }
 
+TEST_F(CodeGenTest, GenericEnumThenEnumWithSameNameRejected) {
+    expectCompileError(
+        "enum Foo<T>:\n"
+        "    MySome(T)\n"
+        "    MyNone\n"
+        "enum Foo:\n"
+        "    A\n",
+        "already defined as a generic enum");
+}
+
 TEST_F(CodeGenTest, DuplicateGenericEnumRejected) {
     expectCompileError(
         "enum Foo<T>:\n"

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -479,3 +479,65 @@ TEST(FindMatchingCloseParen, NoMatch) {
     std::string s = "function(int";
     ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), std::string::npos);
 }
+
+// ============================================================
+// Cross-category type duplicate rejection (#815)
+// ============================================================
+
+TEST_F(CodeGenTest, RecordThenEnumWithSameNameRejected) {
+    expectCompileError(
+        "record Foo:\n"
+        "    x: int\n"
+        "enum Foo:\n"
+        "    A\n"
+        "    B\n",
+        "already defined as a record");
+}
+
+TEST_F(CodeGenTest, EnumThenRecordWithSameNameRejected) {
+    expectCompileError(
+        "enum Foo:\n"
+        "    A\n"
+        "    B\n"
+        "record Foo:\n"
+        "    x: int\n",
+        "already defined as an enum");
+}
+
+TEST_F(CodeGenTest, RecordThenGenericEnumWithSameNameRejected) {
+    expectCompileError(
+        "record Foo:\n"
+        "    x: int\n"
+        "enum Foo<T>:\n"
+        "    MySome(T)\n"
+        "    MyNone\n",
+        "already defined as a record");
+}
+
+TEST_F(CodeGenTest, GenericEnumThenRecordWithSameNameRejected) {
+    expectCompileError(
+        "enum Foo<T>:\n"
+        "    MySome(T)\n"
+        "    MyNone\n"
+        "record Foo:\n"
+        "    x: int\n",
+        "already defined as a generic enum");
+}
+
+TEST_F(CodeGenTest, EnumThenGenericEnumWithSameNameRejected) {
+    expectCompileError(
+        "enum Foo:\n"
+        "    A\n"
+        "enum Foo<T>:\n"
+        "    MySome(T)\n",
+        "already defined as an enum");
+}
+
+TEST_F(CodeGenTest, DuplicateGenericEnumRejected) {
+    expectCompileError(
+        "enum Foo<T>:\n"
+        "    MySome(T)\n"
+        "enum Foo<U>:\n"
+        "    MyOther(U)\n",
+        "generic enum 'Foo' is already defined");
+}


### PR DESCRIPTION
## Summary

Two quick-win bug fixes:

- **#806** — `to_float(str)` now returns `Result<float, Error>`, matching `to_int(str)`. Previously it silently returned `0.0` on invalid input (via `atof`). Added `__ry_str_to_float` runtime using `strtod`/`errno`/`setLastError`, rewrote the codegen dispatch to reuse the existing `emitResultBranch`/`buildErrValue`/`buildErrorFromRuntime` helpers, and updated the stdlib declaration, tests, and reference docs. **Breaking change**: callers must now unwrap the `Result`.

- **#815** — The compiler now rejects defining a \`record\` and an \`enum\` (or generic enum) with the same name in one compilation unit. Introduces \`CodeGen::rejectIfTypeNameTakenByOtherKind\` so all three \`emitStmt\` paths share one cross-category check. Also fixes a pre-existing missing \`current_loc_\` update in \`emitStmt(EnumStmt &)\` so the error location points at the clashing statement rather than the previous one.

Follow-up **#850** created for the remaining \`type_aliases_\` / \`union_type_info_\` cross-category audit (explicitly marked as follow-up in #815's body).

## Changes

- \`src/runtime_convert.cpp\`: new \`__ry_str_to_float\` (mirrors \`__ry_str_to_int\`)
- \`src/codegen_call.cpp\`: \`to_float\` dispatch rewritten to emit \`Result<float, Error>\`
- \`share/std/convert.ry\`: \`to_float\` signature updated
- \`include/ry/codegen.hpp\` + \`src/codegen_stmt_misc.cpp\` + \`src/codegen_expr_literal.cpp\`: \`rejectIfTypeNameTakenByOtherKind\` helper extracted, plus \`current_loc_\` fix
- \`tests/test_codegen_common.hpp\`: new \`expectCompileError\` helper that asserts on the error message substring (so cross-check tests can't pass for the wrong reason)
- \`tests/test_codegen_collection.cpp\` + \`tests/spec/strings.test.ry\`: \`to_float\` tests updated to \`Result\` shape, including overflow case
- \`tests/test_codegen_type_safety.cpp\`: 6 new cross-category regression tests using \`expectCompileError\`
- \`docs/reference/{builtins,builtins-string,types}.md\`: \`to_float\` signature and overflow note updated
- \`changelog.d/806-to-float-result.md\` and \`815-type-duplicate-crosscheck.md\` added
- \`KNOWLEDGE.md\`: new entry "Adding a new type kind requires cross-checking every other type registry"

## Test plan

- [x] \`cmake --build build && ./build/ry_tests\` — 1555 tests PASS
- [x] \`./build/ry test -p\` — 103 files PASS
- [x] \`cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests\` — 1554 tests PASS (no ASan errors)
- [x] \`ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p\` — 103 files PASS
- [x] Manual verification: \`to_float("3.14")\` → \`Ok(3.14)\`, \`to_float("abc")\` → \`Err("to_float: invalid character in 'abc'")\`, \`to_float("1e400")\` → \`Err("to_float: out of range in '1e400'")\`
- [x] Manual verification: \`record Foo\` + \`enum Foo\` → \`error: type 'Foo' is already defined as a record --> <stdin>:3:1\` (location points at the enum line)

Closes #806
Closes #815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * to_float() now returns Result<float, Error> instead of float — callers must handle errors for invalid or out-of-range input

* **Bug Fixes**
  * Compiler now rejects reusing the same type name across different type kinds (record, enum, generic enum)

* **Documentation**
  * Updated to_float() docs and builtins reference to show Result return and failure cases

* **Tests**
  * Added tests covering to_float() success/error cases and cross-category type-name collision diagnostics
<!-- end of auto-generated comment: release notes by coderabbit.ai -->