### PR TITLE
fix: reject type alias name collisions across type kinds (#850)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -73,29 +73,41 @@ For each hit, confirm a test exists that executes that exact line.
 
 ### Adding a new type kind requires cross-checking every other type registry
 
-**Source**: #815 (2026-04-11, implementation)
+**Source**: #815 (2026-04-11, implementation), extended by #850 (2026-04-11)
 **Tags**: codegen, types, registry, duplicate-check, naming
 
 **Context**: Type definitions in `include/ry/codegen.hpp` are stored
-across at least five separate registries: `struct_types_` (records),
-`enum_types_` (concrete enums), `generic_enum_templates_` (generic enum
-templates), `type_aliases_`, and `union_type_info_`. Each `emitStmt`
-path only checked its **own** registry for duplicate names. Before #815,
-`record Foo` and `enum Foo` silently coexisted because neither path
-consulted the other registry, producing inconsistent lookup depending
-on which map was probed first.
+across four **user-name** registries: `struct_types_` (records),
+`enum_types_` (concrete enums), `generic_enum_templates_` (generic
+enum templates), and `type_aliases_`. All four share a single user-facing
+type name space. The `rejectIfTypeNameTakenByOtherKind()` helper
+(`src/codegen_stmt_misc.cpp`) now consults all four before allowing a
+new declaration. Each `emitStmt(<Decl>Stmt &)` path (Record, Enum concrete,
+Enum generic, TypeAlias) must (a) reject its own same-kind duplicate
+with a kind-specific message, and (b) call
+`rejectIfTypeNameTakenByOtherKind()` for cross-kind collisions.
+
+`union_type_info_` (`include/ry/codegen.hpp`) is **not** a user-name
+registry — it is an **anonymous cache** populated by `resolveType()` in
+`src/codegen_type.cpp` when an inline union like `int | str` is
+encountered. Its key is a flattened type string, not a user-chosen
+name. Named unions like `type Foo = int | str` go through
+`TypeAliasStmt` and land in `type_aliases_`, so a cross-kind check
+against `union_type_info_` is unnecessary and would be wrong (it would
+reject legitimate anonymous cache hits).
 
 **Rule**: When introducing a new type kind (or touching an existing
 `emitStmt(<Decl>Stmt &)` path), reject the name if it collides with
-**any** other type registry — not just the one for the current kind.
-Pair record/enum/generic-enum/alias/union as a single name space.
+**any other user-name type registry**. Pair
+record/enum/generic-enum/alias as a single name space. Do not treat
+`union_type_info_` as a user-name registry.
 
 **How to verify**: grep the codegen header for
 `std::unordered_map<std::string, .*(?:Info|Template|Type)>` to find
 every type registry, then confirm each `emitStmt` for a type
-declaration consults all registries before inserting. Add a regression
-test (`EXPECT_THROW` with `runSource`) per cross-category pair — legal
-cases alone won't catch a missing guard.
+declaration consults all user-name registries before inserting. Add a
+regression test (`EXPECT_THROW` with `runSource`) per cross-category
+pair in both orders — legal cases alone won't catch a missing guard.
 
 ### Canonicalization that may collapse shape must be handled at all call sites
 

--- a/changelog.d/850-type-alias-cross-category.md
+++ b/changelog.d/850-type-alias-cross-category.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Compiler now rejects a `type` alias whose name collides with an existing `record`, `enum`, generic `enum`, or previously-defined `type` alias, in either declaration order. This extends the cross-category duplicate check added in #815 to type aliases (including named unions such as `type Foo = int | str`). Duplicate error messages also now point at the offending declaration instead of a stale location. (#850)

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -283,7 +283,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<InterpolatedStringEx
 // ===== TypeAliasStmt =====
 
 void CodeGen::emitStmt(TypeAliasStmt &s) {
+    if (s.loc.isValid()) current_loc_ = s.loc;
     emitTraceSymbolDefine("type_alias", s.name, s.loc);
+    if (type_aliases_.count(s.name))
+        codegenError("type alias '" + s.name + "' is already defined");
+    rejectIfTypeNameTakenByOtherKind(s.name);
     // Type aliases are resolved at compile time via resolveType()
     // Store the alias mapping for later lookup
     type_aliases_[s.name] = s.target_type->toString();

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -73,6 +73,8 @@ void CodeGen::rejectIfTypeNameTakenByOtherKind(const std::string &name) {
         codegenError("type '" + name + "' is already defined as an enum");
     if (generic_enum_templates_.count(name))
         codegenError("type '" + name + "' is already defined as a generic enum");
+    if (type_aliases_.count(name))
+        codegenError("type '" + name + "' is already defined as a type alias");
 }
 
 void CodeGen::emitStmt(EnumStmt &s) {

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -551,3 +551,89 @@ TEST_F(CodeGenTest, DuplicateGenericEnumRejected) {
         "    MyOther(U)\n",
         "generic enum 'Foo' is already defined");
 }
+
+// ============================================================
+// Type alias cross-category duplicate rejection (#850)
+// ============================================================
+
+TEST_F(CodeGenTest, TypeAliasThenRecordWithSameNameRejected) {
+    expectCompileError(
+        "type Foo = int\n"
+        "record Foo:\n"
+        "    x: int\n",
+        "already defined as a type alias");
+}
+
+TEST_F(CodeGenTest, RecordThenTypeAliasWithSameNameRejected) {
+    expectCompileError(
+        "record Foo:\n"
+        "    x: int\n"
+        "type Foo = int\n",
+        "already defined as a record");
+}
+
+TEST_F(CodeGenTest, TypeAliasThenEnumWithSameNameRejected) {
+    expectCompileError(
+        "type Foo = int\n"
+        "enum Foo:\n"
+        "    A\n"
+        "    B\n",
+        "already defined as a type alias");
+}
+
+TEST_F(CodeGenTest, EnumThenTypeAliasWithSameNameRejected) {
+    expectCompileError(
+        "enum Foo:\n"
+        "    A\n"
+        "    B\n"
+        "type Foo = int\n",
+        "already defined as an enum");
+}
+
+TEST_F(CodeGenTest, TypeAliasThenGenericEnumWithSameNameRejected) {
+    expectCompileError(
+        "type Foo = int\n"
+        "enum Foo<T>:\n"
+        "    MySome(T)\n"
+        "    MyNone\n",
+        "already defined as a type alias");
+}
+
+TEST_F(CodeGenTest, GenericEnumThenTypeAliasWithSameNameRejected) {
+    expectCompileError(
+        "enum Foo<T>:\n"
+        "    MySome(T)\n"
+        "    MyNone\n"
+        "type Foo = int\n",
+        "already defined as a generic enum");
+}
+
+TEST_F(CodeGenTest, DuplicateTypeAliasRejected) {
+    expectCompileError(
+        "type Foo = int\n"
+        "type Foo = str\n",
+        "type alias 'Foo' is already defined");
+}
+
+TEST_F(CodeGenTest, UnionTypeAliasThenRecordWithSameNameRejected) {
+    expectCompileError(
+        "type Foo = int | str\n"
+        "record Foo:\n"
+        "    x: int\n",
+        "already defined as a type alias");
+}
+
+TEST_F(CodeGenTest, RecordThenUnionTypeAliasWithSameNameRejected) {
+    expectCompileError(
+        "record Foo:\n"
+        "    x: int\n"
+        "type Foo = int | str\n",
+        "already defined as a record");
+}
+
+TEST_F(CodeGenTest, DuplicateUnionTypeAliasRejected) {
+    expectCompileError(
+        "type Foo = int | str\n"
+        "type Foo = bool | str\n",
+        "type alias 'Foo' is already defined");
+}


### PR DESCRIPTION
## Summary

Extends the cross-category duplicate check from #815 to `type` aliases.
Previously `type Foo = int` could silently coexist with `record Foo`,
`enum Foo`, `enum Foo<T>`, or another `type Foo = str`, producing
inconsistent type lookup.

- `rejectIfTypeNameTakenByOtherKind()` now also consults `type_aliases_`, so Record/Enum/GenericEnum declarations reject aliases that took the name first.
- `emitStmt(TypeAliasStmt)` now (a) rejects its own same-kind duplicate and (b) calls `rejectIfTypeNameTakenByOtherKind()` for cross-kind collisions.
- Drive-by fix: `emitStmt(TypeAliasStmt)` now updates `current_loc_`, so the newly-introduced duplicate-alias error (and any future errors raised from this path) point at the offending declaration rather than a stale stdlib location that `current_loc_` happened to be pointing at.

Named union aliases like `type Foo = int | str` are covered for free
because they lower to `TypeAliasStmt`.

`union_type_info_` is intentionally **not** added to the cross-kind
check — it is an anonymous cache populated by `resolveType()` for
inline `int | str`-style types, not a user-name registry. Checking it
would reject legitimate cache hits. KNOWLEDGE.md is updated to record
this distinction so future contributors do not re-introduce the same
confusion.

Closes #850.

## Test plan

- [x] 10 new `TEST_F(CodeGenTest, ...)` cases in `tests/test_codegen_type_safety.cpp` covering every pair (Alias↔Record, Alias↔Enum, Alias↔GenericEnum, Alias↔Alias) in both declaration orders, plus the union-as-alias variants
- [x] `./build/ry_tests` — 1566 / 1566 PASS
- [x] `./build/ry test -p` — 103 files / 0 failures
- [x] ASan: `./build-asan/ry_tests` — 1565 / 1565 PASS
- [x] ASan: `./build-asan/ry test -p` — 0 failures
- [x] Manual repro via `./build/ry -c` for all four error-producing snippets, including verification that the error source location now points to the correct line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The compiler now rejects type aliases whose names collide with existing records, enums, generic enums, or previously-defined type aliases, regardless of declaration order. Duplicate-name detection now spans all user-defined type categories with improved error reporting.

* **Tests**
  * Added comprehensive test coverage for type alias name conflicts across all type categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->