### PR TITLE
fix: propagate enum and collection metadata across return/destructure boundaries (#820, #813)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -319,7 +319,7 @@ across multiple downstream values must be parsed by the caller using
 `splitTypeArgs`, which already understands nested `<>` and `()`.
 
 **How to apply**: When you see a tuple type string arriving at a
-destructure / unpacking site (for-loop, `let (a, b) = ...`), parse the
+destructure or unpacking site (for-loop, `let (a, b) = ...`), parse the
 components via `splitTypeArgs(inner)` after stripping the outer parens
 and call `propagateTypeMeta(component[i], boundVar[i])` for each
 bound variable. Do **not** extend `propagateTypeMeta` itself to write

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -294,6 +294,67 @@ each one either expects the helper's post-state or explicitly
 re-establishes its own. If any caller is silent about the post-state,
 the fixup belongs in the helper.
 
+### propagateTypeMeta is single-value; callers decompose tuples
+
+**Source**: #820 + #813 sweep (2026-04-11, implementation)
+**Tags**: codegen, metadata, propagation, tuple, destructure, enum
+
+**Context**: Fixing function-return / for-loop destructure metadata
+propagation (#820, #813) required teaching `propagateTypeMeta` to
+recognize enum type names (concrete and generic templates), but
+deliberately *not* to recognize tuple type strings like
+`"(int, List<int>)"`. Tuples are not a single metadata carrier — the
+components are stored in separate bound variables during destructure,
+so the decomposition must happen at the call site that owns those
+variables (`emitTupleDestructure` in `src/codegen_stmt_loop.cpp`), not
+inside `propagateTypeMeta`. The rejected alternative was to add a
+`tuple_elem_type_names: std::vector<std::string>` field to
+`ValueMetadata`; this was declined because it would require updating
+`propagateMeta`, `hasAnyMeta`, and every metadata-copy site with no
+benefit over parsing the string once at the caller (compile-time O(n)).
+
+**Rule**: `propagateTypeMeta(name, val)` fills metadata for a single
+value. Composite types (tuples, future records) that need to split
+across multiple downstream values must be parsed by the caller using
+`splitTypeArgs`, which already understands nested `<>` and `()`.
+
+**How to apply**: When you see a tuple type string arriving at a
+destructure / unpacking site (for-loop, `let (a, b) = ...`), parse the
+components via `splitTypeArgs(inner)` after stripping the outer parens
+and call `propagateTypeMeta(component[i], boundVar[i])` for each
+bound variable. Do **not** extend `propagateTypeMeta` itself to write
+to a `tuple_elem_type_names` slot — keep the helper single-purpose.
+
+### Enum metadata propagation: list literals of enum values need a direct check
+
+**Source**: #820 sweep (2026-04-11, implementation)
+**Tags**: codegen, list, enum, metadata, propagation
+
+**Context**: `emitExprVariant(ListExpr)` in
+`src/codegen_expr_literal.cpp` guards its `inferCollectionTypeName`
+fallback behind `if (elemTy == ptrTy_)` because list-of-list,
+list-of-map, and list-of-set all use pointer-typed elements. Simple
+enums are `i64` and ADT enums are LLVM struct values — neither is a
+pointer type — so the pointer-guarded path skipped them entirely and
+`list_elem_type_name` was never set on the list header. Consequently
+`valueToString`'s list branch (which relies on
+`propagateTypeMeta(list_elem_type_name, loaded_elem)` to rebuild enum
+metadata on each loaded element) received an empty string and printed
+the raw i64 bit pattern.
+
+**Rule**: When a container literal is built over a non-pointer element
+type that still carries *source-level* metadata (enums today,
+potentially small-struct values in future work), copy the element's
+`enum_value_type` (or equivalent) into the container's
+`list_elem_type_name` explicitly, outside the `elemTy == ptrTy_`
+guard. The guard exists for nested-collection tracking, not for
+generic metadata propagation.
+
+**How to verify**: grep for `if (elemTy == ptrTy_)` in container
+literal paths (`codegen_expr_literal.cpp`) and confirm each of them
+handles non-pointer elements whose metadata still needs to reach the
+container's element-type-name slot.
+
 ### New primitive types must be wired into every type-reflection site
 
 **Source**: #825 PR review (CodeRabbit, 4 comments)

--- a/changelog.d/820-813-metadata-propagation.md
+++ b/changelog.d/820-813-metadata-propagation.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- Enum values returned from user functions now print as variant names
+  (or `Variant(payload)` for ADT enums) instead of raw integers. Simple
+  enums, ADT enums, and already-instantiated generic enums are all
+  handled. Enum-typed elements stored in `List<Color>` literals also
+  propagate correctly. (#820)
+- `for i, x in enumerate(...)`, `for a, b in zip(...)`, and
+  `for k, v in Map<K, V>` now preserve collection-element metadata on
+  destructured variables, so `print` / `sum` / `length` work correctly
+  when the elements are themselves `List` / `Map` / `Set` / enum. (#813)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -402,6 +402,18 @@ public:
     std::unordered_map<std::string, GenericEnumTemplate> generic_enum_templates_;
     void instantiateGenericEnum(const std::string &fullName, const std::string &baseName,
                                 const std::vector<std::string> &typeArgs);
+    // Ensure a concrete or generic enum named `typeName` is registered in
+    // `enum_types_`. If `typeName` is a generic enum instantiation like
+    // `Option<int>` not yet instantiated, parse the base/args and call
+    // `instantiateGenericEnum`. Returns true iff `enum_types_.count(typeName)`
+    // after the call. Used by enum construction sites and metadata propagation.
+    bool ensureEnumInstantiated(const std::string &typeName);
+    // Strip ASCII spaces from both ends of a type-name substring. Shared by
+    // the comma-separated annotation parsers (Map key/value, tuple destructure).
+    static std::string trimTypeNameSpaces(const std::string &s);
+    // Return the best source-level element type name for a list value.
+    // Used by enumerate()/zip() to build the tuple `list_elem_type_name`.
+    std::string snapshotListElemName(llvm::Value *listVal, llvm::Type *elemTy);
 
     // Reject `name` if it is already registered under a different type kind
     // (record, enum, generic enum). Callers must check same-kind duplicates
@@ -652,6 +664,7 @@ public:
 
         // String-typed metadata
         std::string low_level_type_name;
+        std::string map_key_type_name;      // Ry type name for map keys (#813)
         std::string map_value_type_name;    // Ry type name for map values
         std::string list_elem_type_name;    // Ry type name for list elements (e.g. "Map<str, int>")
         std::string set_elem_type_name;     // Ry type name for set elements (e.g. "List<int>")
@@ -724,8 +737,13 @@ public:
     void emitIndexedForLoop(llvm::Value *length,
                             std::vector<StmtNode> &body,
                             std::function<void(llvm::Value *iCur)> bindVars);
+    // `tupleTypeName` is the Ry tuple type string (e.g. "(int, List<int>)")
+    // used to propagate per-component metadata onto the bound variables.
+    // Pass "" when no source-level name is available (e.g. iterator-sourced
+    // tuples); metadata propagation is skipped in that case.
     void emitTupleDestructure(const std::vector<std::string> &var_names,
-                              llvm::Value *tupleVal, llvm::StructType *structTy);
+                              llvm::Value *tupleVal, llvm::StructType *structTy,
+                              const std::string &tupleTypeName);
     void emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *end, llvm::Value *step);
     void validateParallelFor(const ForStmt &s);
 

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -64,6 +64,25 @@ RY_IS_RESOURCE(isRegex,              "Regex")
 #undef RY_IS_RESOURCE
 
 
+std::string CodeGen::trimTypeNameSpaces(const std::string &s) {
+    size_t b = 0;
+    while (b < s.size() && s[b] == ' ') ++b;
+    size_t e = s.size();
+    while (e > b && s[e - 1] == ' ') --e;
+    return s.substr(b, e - b);
+}
+
+bool CodeGen::ensureEnumInstantiated(const std::string &typeName) {
+    if (enum_types_.count(typeName)) return true;
+    auto lt = typeName.find('<');
+    if (lt == std::string::npos || typeName.back() != '>') return false;
+    std::string base = typeName.substr(0, lt);
+    if (!generic_enum_templates_.count(base)) return false;
+    std::string argsStr = typeName.substr(lt + 1, typeName.size() - lt - 2);
+    instantiateGenericEnum(typeName, base, splitTypeArgs(argsStr));
+    return enum_types_.count(typeName) > 0;
+}
+
 void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
     if (typeName.size() > 5 && typeName.compare(0, 5, "Task<") == 0 && typeName.back() == '>') {
         std::string inner = typeName.substr(5, typeName.size() - 6);
@@ -82,11 +101,19 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         auto [keyTy, valTy] = parseMapTypeAnnotation(typeName);
         if (keyTy) setTypeMeta(TypeMeta::MapKey, val, keyTy);
         if (valTy) setTypeMeta(TypeMeta::MapValue, val, valTy);
-        std::string vtn = extractMapValueTypeName(typeName);
-        if (!vtn.empty()) {
-            getOrCreateMeta(val).map_value_type_name = vtn;
-            if (isFunctionTypeName(vtn))
-                getOrCreateMeta(val).map_value_fn_type_info = parseFnTypeAnnotation(vtn);
+        // Split the inner "K, V" form exactly once and record both names
+        // (key name is used by map-iteration destructure in #813).
+        auto parts = splitTypeArgs(typeName.substr(4, typeName.size() - 5));
+        if (parts.size() == 2) {
+            std::string ktn = trimTypeNameSpaces(parts[0]);
+            std::string vtn = trimTypeNameSpaces(parts[1]);
+            if (!ktn.empty())
+                getOrCreateMeta(val).map_key_type_name = ktn;
+            if (!vtn.empty()) {
+                getOrCreateMeta(val).map_value_type_name = vtn;
+                if (isFunctionTypeName(vtn))
+                    getOrCreateMeta(val).map_value_fn_type_info = parseFnTypeAnnotation(vtn);
+            }
         }
     } else if (isSetTypeName(typeName) && typeName.back() == '>') {
         std::string inner = typeName.substr(4, typeName.size() - 5);
@@ -96,6 +123,10 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
             getOrCreateMeta(val).set_elem_fn_type_info = parseFnTypeAnnotation(inner);
     } else if (isLowLevelTypeName(typeName)) {
         getOrCreateMeta(val).low_level_type_name = typeName;
+    } else if (ensureEnumInstantiated(typeName)) {
+        // Concrete enum or generic enum instantiation: tag the value so
+        // valueToString() dispatches on enum_value_type metadata (#820).
+        getOrCreateMeta(val).enum_value_type = typeName;
     }
 }
 
@@ -125,6 +156,25 @@ std::string CodeGen::extractMapValueTypeName(const std::string &mapTypeName) {
     return vStr;
 }
 
+std::string CodeGen::snapshotListElemName(llvm::Value *listVal, llvm::Type *elemTy) {
+    // Prefer the list's recorded source-level element name; fall back to a
+    // reverse-resolved LLVM type name so primitives still produce a usable
+    // tuple component name. Shared by enumerate()/zip() so the tuple result
+    // carries list_elem_type_name = "(int, <elem>)" / "(<a>, <b>)" (#813).
+    std::string name;
+    if (auto *sm = getMeta(listVal))
+        name = sm->list_elem_type_name;
+    if (name.empty())
+        name = reverseResolveTypeName(elemTy);
+    return name;
+}
+
+// Returns a source-level type name for a value that can be stored in a
+// container literal's element-name slot. Despite the "Collection" in the
+// name, enum type names are also returned (needed by #820 so
+// `List<Color>` printing propagates enum metadata). Returns "" for plain
+// primitives (int/bool/str/float) — callers should fall back to
+// reverseResolveTypeName if they need a name for those.
 std::string CodeGen::inferCollectionTypeName(llvm::Value *val) {
     if (auto *keyTy = getMapKeyType(val)) {
         std::string keyName = reverseResolveTypeName(keyTy);
@@ -137,6 +187,11 @@ std::string CodeGen::inferCollectionTypeName(llvm::Value *val) {
         return "List<" + reverseResolveTypeName(elemTy) + ">";
     if (auto *setTy = getSetElementType(val))
         return "Set<" + reverseResolveTypeName(setTy) + ">";
+    // Enum element types: needed so container literals whose first element is
+    // an enum (e.g. [Color::Red]) propagate enum_value_type to printed
+    // elements via list_elem_type_name → propagateTypeMeta (#820).
+    if (auto *meta = getMeta(val); meta && !meta->enum_value_type.empty())
+        return meta->enum_value_type;
     return "";
 }
 

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -84,11 +84,16 @@ bool CodeGen::ensureEnumInstantiated(const std::string &typeName) {
 }
 
 void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
-    if (typeName.size() > 5 && typeName.compare(0, 5, "Task<") == 0 && typeName.back() == '>') {
-        std::string inner = typeName.substr(5, typeName.size() - 6);
+    // Resolve type aliases once so surface names like `type ColorAlias = Color`
+    // or `type MaybeInt = Option<int>` propagate to the same metadata slots as
+    // their canonical spellings. resolveTypeAlias returns the input unchanged
+    // when no alias matches. (PR #853 review)
+    const std::string resolved = resolveTypeAlias(typeName);
+    if (resolved.size() > 5 && resolved.compare(0, 5, "Task<") == 0 && resolved.back() == '>') {
+        std::string inner = resolved.substr(5, resolved.size() - 6);
         setTypeMeta(TypeMeta::TaskResult, val, resolveType(inner));
-    } else if (isListTypeName(typeName) && typeName.back() == '>') {
-        std::string inner = typeName.substr(5, typeName.size() - 6);
+    } else if (isListTypeName(resolved) && resolved.back() == '>') {
+        std::string inner = resolved.substr(5, resolved.size() - 6);
         setTypeMeta(TypeMeta::ListElem, val, resolveType(inner));
         getOrCreateMeta(val).list_elem_type_name = inner;
         if (isFunctionTypeName(inner))
@@ -97,13 +102,13 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
             std::string nested = inner.substr(5, inner.size() - 6);
             setTypeMeta(TypeMeta::NestedListElem, val, resolveType(nested));
         }
-    } else if (isMapTypeName(typeName) && typeName.back() == '>') {
-        auto [keyTy, valTy] = parseMapTypeAnnotation(typeName);
+    } else if (isMapTypeName(resolved) && resolved.back() == '>') {
+        auto [keyTy, valTy] = parseMapTypeAnnotation(resolved);
         if (keyTy) setTypeMeta(TypeMeta::MapKey, val, keyTy);
         if (valTy) setTypeMeta(TypeMeta::MapValue, val, valTy);
         // Split the inner "K, V" form exactly once and record both names
         // (key name is used by map-iteration destructure in #813).
-        auto parts = splitTypeArgs(typeName.substr(4, typeName.size() - 5));
+        auto parts = splitTypeArgs(resolved.substr(4, resolved.size() - 5));
         if (parts.size() == 2) {
             std::string ktn = trimTypeNameSpaces(parts[0]);
             std::string vtn = trimTypeNameSpaces(parts[1]);
@@ -115,18 +120,18 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
                     getOrCreateMeta(val).map_value_fn_type_info = parseFnTypeAnnotation(vtn);
             }
         }
-    } else if (isSetTypeName(typeName) && typeName.back() == '>') {
-        std::string inner = typeName.substr(4, typeName.size() - 5);
+    } else if (isSetTypeName(resolved) && resolved.back() == '>') {
+        std::string inner = resolved.substr(4, resolved.size() - 5);
         setTypeMeta(TypeMeta::SetElem, val, resolveType(inner));
         getOrCreateMeta(val).set_elem_type_name = inner;
         if (isFunctionTypeName(inner))
             getOrCreateMeta(val).set_elem_fn_type_info = parseFnTypeAnnotation(inner);
-    } else if (isLowLevelTypeName(typeName)) {
-        getOrCreateMeta(val).low_level_type_name = typeName;
-    } else if (ensureEnumInstantiated(typeName)) {
+    } else if (isLowLevelTypeName(resolved)) {
+        getOrCreateMeta(val).low_level_type_name = resolved;
+    } else if (ensureEnumInstantiated(resolved)) {
         // Concrete enum or generic enum instantiation: tag the value so
         // valueToString() dispatches on enum_value_type metadata (#820).
-        getOrCreateMeta(val).enum_value_type = typeName;
+        getOrCreateMeta(val).enum_value_type = resolved;
     }
 }
 

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -317,6 +317,11 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Type *elemTy = getListElementType(listVal);
         if (!elemTy) codegenError("enumerate() requires a list");
 
+        // Snapshot the source list's element name so we can rebuild a tuple
+        // type string "(int, <elem>)" for the result (#813). See
+        // snapshotListElemName for the fallback rules.
+        std::string srcElemName = snapshotListElemName(listVal, elemTy);
+
         auto lf = loadListHeader(listVal, "enum");
         llvm::Value *srcLen = lf.len;
         llvm::Value *srcData = lf.data;
@@ -352,6 +357,9 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
 
         storeListHeaderFields(newHeader, srcLen, srcLen, newData);
         setTypeMeta(TypeMeta::ListElem, newHeader, tupleTy);
+        if (!srcElemName.empty())
+            getOrCreateMeta(newHeader).list_elem_type_name =
+                "(int, " + srcElemName + ")";
         return newHeader;
     }
 
@@ -363,6 +371,11 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Type *elemTy1 = getListElementType(list1);
         llvm::Type *elemTy2 = getListElementType(list2);
         if (!elemTy1 || !elemTy2) codegenError("zip() requires two lists");
+
+        // Snapshot both source element names before entering the IR loop
+        // (same rationale as enumerate — see snapshotListElemName).
+        std::string n1 = snapshotListElemName(list1, elemTy1);
+        std::string n2 = snapshotListElemName(list2, elemTy2);
 
         auto lf1 = loadListHeader(list1, "zip1");
         auto lf2 = loadListHeader(list2, "zip2");
@@ -406,6 +419,9 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
 
         storeListHeaderFields(newHeader, minLen, minLen, newData);
         setTypeMeta(TypeMeta::ListElem, newHeader, tupleTy);
+        if (!n1.empty() && !n2.empty())
+            getOrCreateMeta(newHeader).list_elem_type_name =
+                "(" + n1 + ", " + n2 + ")";
         return newHeader;
     }
 

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -15,15 +15,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
             std::string enumName = e->callee.substr(0, colonPos);
             std::string variantName = e->callee.substr(colonPos + 2);
             // Try to instantiate generic enum if not found
-            if (!enum_types_.count(enumName)) {
-                auto ltPos = enumName.find('<');
-                if (ltPos != std::string::npos && enumName.back() == '>') {
-                    std::string baseName = enumName.substr(0, ltPos);
-                    std::string argsStr = enumName.substr(ltPos + 1, enumName.size() - ltPos - 2);
-                    auto typeArgs = splitTypeArgs(argsStr);
-                    instantiateGenericEnum(enumName, baseName, typeArgs);
-                }
-            }
+            ensureEnumInstantiated(enumName);
             auto eit = enum_types_.find(enumName);
             if (eit != enum_types_.end() && eit->second.isADT) {
                 auto &info = eit->second;

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -187,6 +187,16 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
     // Track element type
     setTypeMeta(TypeMeta::ListElem, headerPtr, elemTy);
 
+    // Enum elements (simple i64 or ADT struct) need list_elem_type_name so
+    // valueToString() on the list can propagate enum_value_type to each loaded
+    // element via propagateTypeMeta (#820). This path runs regardless of the
+    // LLVM element type because enum simple values are i64 and ADT enums are
+    // structs, neither of which is a pointer type.
+    if (auto *firstMeta = getMeta(vals[0]);
+            firstMeta && !firstMeta->enum_value_type.empty()) {
+        getOrCreateMeta(headerPtr).list_elem_type_name = firstMeta->enum_value_type;
+    }
+
     // Track nested list element type (for flatten support)
     // Only set if ALL elements are lists with the same inner element type
     if (elemTy == ptrTy_) {
@@ -396,15 +406,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<SetExpr> &e) {
 
 llvm::Value *CodeGen::emitExprVariant(const EnumAccessExpr &e) {
     // Try to instantiate generic enum if not found
-    if (!enum_types_.count(e.enum_name)) {
-        auto ltPos = e.enum_name.find('<');
-        if (ltPos != std::string::npos && e.enum_name.back() == '>') {
-            std::string baseName = e.enum_name.substr(0, ltPos);
-            std::string argsStr = e.enum_name.substr(ltPos + 1, e.enum_name.size() - ltPos - 2);
-            auto typeArgs = splitTypeArgs(argsStr);
-            instantiateGenericEnum(e.enum_name, baseName, typeArgs);
-        }
-    }
+    ensureEnumInstantiated(e.enum_name);
     auto it = enum_types_.find(e.enum_name);
     if (it == enum_types_.end())
         codegenError("undefined enum: " + e.enum_name);

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -20,6 +20,7 @@ bool CodeGen::ValueMetadata::hasAnyMeta() const {
     return hasAnyCollectionType() || hasAnyResourceKind() ||
            fn_type_info.has_value() ||
            !low_level_type_name.empty() ||
+           !map_key_type_name.empty() ||
            !map_value_type_name.empty() ||
            !union_value_type.empty() ||
            !enum_value_type.empty() ||
@@ -120,6 +121,8 @@ void CodeGen::propagateMeta(llvm::Value *src, llvm::Value *dst) {
     // String metadata
     if (!srcMeta.low_level_type_name.empty())
         dstMeta.low_level_type_name = srcMeta.low_level_type_name;
+    if (!srcMeta.map_key_type_name.empty())
+        dstMeta.map_key_type_name = srcMeta.map_key_type_name;
     if (!srcMeta.map_value_type_name.empty())
         dstMeta.map_value_type_name = srcMeta.map_value_type_name;
     if (!srcMeta.list_elem_type_name.empty())

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -384,10 +384,21 @@ void CodeGen::emitVarDecl(const std::string &name,
                 if (isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
                     std::string inner = resolved.substr(5, resolved.size() - 6);
                     while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
-                    if (isMapTypeName(inner) || isSetTypeName(inner))
+                    if (isMapTypeName(inner) || isSetTypeName(inner)) {
                         letn = inner;
-                    else if (inner.size() > 9 && inner.substr(0, 9) == "function(")
+                    } else if (inner.size() > 9 && inner.substr(0, 9) == "function(") {
                         lefti = parseFnTypeAnnotation(inner);
+                    } else {
+                        // Tuple annotation (or alias resolving to one): record
+                        // the resolved tuple signature so for-loop destructure
+                        // in #813 can split per-component metadata. PR #853
+                        // review.
+                        std::string innerResolved = resolveTypeAlias(inner);
+                        if (innerResolved.size() >= 2
+                                && innerResolved.front() == '('
+                                && innerResolved.back() == ')')
+                            letn = innerResolved;
+                    }
                 }
             }
             if (!letn.empty())

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -251,12 +251,16 @@ void CodeGen::emitTupleDestructure(const std::vector<std::string> &var_names,
     // If the tuple type name is a Ry tuple literal like "(int, List<int>)",
     // split the components so we can propagate per-element metadata onto the
     // bound variables. Without this, destructured collection/enum elements
-    // degrade to `any` (#813). splitTypeArgs handles nested <> and ().
+    // degrade to `any` (#813). Resolve aliases first so `type Pair = (int,
+    // List<int>)` is treated identically to the literal form (PR #853 review).
+    // splitTypeArgs handles nested <> and ().
     std::vector<std::string> componentNames;
-    if (tupleTypeName.size() >= 2 && tupleTypeName.front() == '('
-            && tupleTypeName.back() == ')') {
+    const std::string tupleSig =
+        tupleTypeName.empty() ? tupleTypeName : resolveTypeAlias(tupleTypeName);
+    if (tupleSig.size() >= 2 && tupleSig.front() == '('
+            && tupleSig.back() == ')') {
         componentNames = splitTypeArgs(
-            tupleTypeName.substr(1, tupleTypeName.size() - 2));
+            tupleSig.substr(1, tupleSig.size() - 2));
         for (auto &n : componentNames)
             n = trimTypeNameSpaces(n);
     }

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -111,7 +111,10 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
             auto *structTy = llvm::dyn_cast<llvm::StructType>(iterElemTy);
             if (!structTy)
                 codegenError("for loop destructuring requires tuple elements");
-            emitTupleDestructure(s->var_names, elem, structTy);
+            // Iterator-sourced tuples do not carry a Ry tuple type string
+            // today, so metadata propagation is skipped here. If iterators
+            // grow a source-level element-name slot, thread it through.
+            emitTupleDestructure(s->var_names, elem, structTy, /*tupleTypeName=*/"");
         } else {
             llvm::AllocaInst *loopVar = getOrCreateVar(s->var_names[0], iterElemTy);
             builder_.CreateStore(elem, loopVar);
@@ -144,10 +147,18 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
             llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, iterable, 2, "for_data_ptr");
             llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "for_data");
 
+            // Snapshot source-level tuple type name before entering the loop
+            // body lambda — unordered_map rehash inside propagateTypeMeta may
+            // invalidate any pointer we hold across the boundary (same pattern
+            // as the single-variable path below at lines 195-202).
+            std::string tupleTypeName;
+            if (auto *iterMeta = getMeta(iterable))
+                tupleTypeName = iterMeta->list_elem_type_name;
+
             emitIndexedForLoop(length, s->body, [&](llvm::Value *iCur) {
                 llvm::Value *tuplePtr = builder_.CreateGEP(structTy, dataPtr, {iCur}, "for_tuple_ptr");
                 llvm::Value *tuple = builder_.CreateLoad(structTy, tuplePtr, "for_tuple");
-                emitTupleDestructure(s->var_names, tuple, structTy);
+                emitTupleDestructure(s->var_names, tuple, structTy, tupleTypeName);
             });
             return;
         }
@@ -164,6 +175,16 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
         llvm::Value *valsPtrField = builder_.CreateStructGEP(mapHeaderTy_, iterable, 3, "vals_ptr_field");
         llvm::Value *valsPtr = builder_.CreateLoad(ptrTy_, valsPtrField, "vals_ptr");
 
+        // Snapshot source-level key/value type names before entering the loop
+        // body lambda so we can propagate nested collection/enum metadata onto
+        // the bound variables (#813). propagateTypeMeta() may rehash the
+        // metadata map and invalidate pointers taken inside the lambda.
+        std::string keyTypeName, valTypeName;
+        if (auto *iterMeta = getMeta(iterable)) {
+            keyTypeName = iterMeta->map_key_type_name;
+            valTypeName = iterMeta->map_value_type_name;
+        }
+
         emitIndexedForLoop(length, s->body, [&](llvm::Value *iCur) {
             llvm::Value *keyPtr = builder_.CreateGEP(keyTy, keysPtr, {iCur}, "for_key_ptr");
             llvm::Value *key = builder_.CreateLoad(keyTy, keyPtr, "for_key");
@@ -173,6 +194,10 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
             builder_.CreateStore(key, keyVar);
             llvm::AllocaInst *valVar = getOrCreateVar(s->var_names[1], valTy);
             builder_.CreateStore(val, valVar);
+            if (!keyTypeName.empty())
+                propagateTypeMeta(keyTypeName, keyVar);
+            if (!valTypeName.empty())
+                propagateTypeMeta(valTypeName, valVar);
         });
         return;
     }
@@ -214,18 +239,35 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
 }
 
 void CodeGen::emitTupleDestructure(const std::vector<std::string> &var_names,
-                                    llvm::Value *tupleVal, llvm::StructType *structTy) {
+                                    llvm::Value *tupleVal, llvm::StructType *structTy,
+                                    const std::string &tupleTypeName) {
     if (structTy->getNumElements() != var_names.size())
         codegenError("for loop destructuring: expected " +
                      std::to_string(var_names.size()) +
                      "-element tuple, but got " +
                      std::to_string(structTy->getNumElements()) +
                      " elements");
+
+    // If the tuple type name is a Ry tuple literal like "(int, List<int>)",
+    // split the components so we can propagate per-element metadata onto the
+    // bound variables. Without this, destructured collection/enum elements
+    // degrade to `any` (#813). splitTypeArgs handles nested <> and ().
+    std::vector<std::string> componentNames;
+    if (tupleTypeName.size() >= 2 && tupleTypeName.front() == '('
+            && tupleTypeName.back() == ')') {
+        componentNames = splitTypeArgs(
+            tupleTypeName.substr(1, tupleTypeName.size() - 2));
+        for (auto &n : componentNames)
+            n = trimTypeNameSpaces(n);
+    }
+
     for (size_t i = 0; i < var_names.size(); ++i) {
         if (var_names[i] == "_") continue;
         llvm::Value *v = builder_.CreateExtractValue(tupleVal, i, "for_elem_" + std::to_string(i));
         llvm::AllocaInst *var = getOrCreateVar(var_names[i], structTy->getElementType(i));
         builder_.CreateStore(v, var);
+        if (i < componentNames.size() && !componentNames[i].empty())
+            propagateTypeMeta(componentNames[i], var);
     }
 }
 

--- a/tests/spec/for_loop_destructure_meta.test.ry
+++ b/tests/spec/for_loop_destructure_meta.test.ry
@@ -1,0 +1,89 @@
+enum Color:
+  Red
+  Green
+  Blue
+
+describe("for-loop destructure preserves collection element metadata (#813)", ():
+  it("should preserve List element type in enumerate over nested list", ():
+    m: List<List<int>> = [[1, 2], [3, 4, 5]]
+    total: int = 0
+    for i, row in enumerate(m):
+      total = total + sum(row)
+    expect(total).to_eq(15)
+  )
+
+  it("should preserve Map element type in enumerate over list of maps", ():
+    ms: List<Map<str, int>> = [{"a": 1}, {"b": 2, "c": 3}]
+    total_size: int = 0
+    for i, mm in enumerate(ms):
+      total_size = total_size + length(mm)
+    expect(total_size).to_eq(3)
+  )
+
+  it("should preserve List element type in zip left side", ():
+    xs: List<List<int>> = [[10, 20], [30, 40]]
+    ys: List<str> = ["a", "b"]
+    total: int = 0
+    for a, b in zip(xs, ys):
+      total = total + sum(a)
+    expect(total).to_eq(100)
+  )
+
+  it("should preserve List element type in zip right side", ():
+    xs: List<str> = ["x", "y"]
+    ys: List<List<int>> = [[1, 2], [3, 4]]
+    total: int = 0
+    for a, b in zip(xs, ys):
+      total = total + sum(b)
+    expect(total).to_eq(10)
+  )
+
+  it("should preserve List value type in Map iteration", ():
+    m: Map<str, List<int>> = {"a": [1, 2, 3], "b": [4, 5]}
+    total: int = 0
+    for k, v in m:
+      total = total + sum(v)
+    expect(total).to_eq(15)
+  )
+
+  it("should preserve Map value type in Map iteration with nested map", ():
+    m: Map<str, Map<str, int>> = {"outer": {"inner": 7, "other": 3}}
+    total: int = 0
+    for k, v in m:
+      total = total + length(v)
+    expect(total).to_eq(2)
+  )
+
+  it("should preserve enum metadata in enumerate over list of enums (#813 x #820)", ():
+    cs: List<Color> = [Color::Red, Color::Green, Color::Blue]
+    concat: str = ""
+    for i, c in enumerate(cs):
+      concat = concat + to_str(c)
+    expect(concat).to_eq("RedGreenBlue")
+  )
+
+  it("should preserve metadata through nested enumerate over nested list", ():
+    m: List<List<int>> = [[1, 2], [3, 4]]
+    total: int = 0
+    for i, row in enumerate(m):
+      for j, val in enumerate(row):
+        total = total + val
+    expect(total).to_eq(10)
+  )
+
+  it("should keep direct (non-destructure) for loop working (regression guard)", ():
+    m: List<List<int>> = [[1, 2], [3, 4]]
+    total: int = 0
+    for row in m:
+      total = total + sum(row)
+    expect(total).to_eq(10)
+  )
+
+  it("should keep primitive destructure working (regression guard)", ():
+    xs: List<int> = [10, 20, 30]
+    total: int = 0
+    for i, x in enumerate(xs):
+      total = total + x
+    expect(total).to_eq(60)
+  )
+)

--- a/tests/spec/for_loop_destructure_meta.test.ry
+++ b/tests/spec/for_loop_destructure_meta.test.ry
@@ -71,6 +71,16 @@ describe("for-loop destructure preserves collection element metadata (#813)", ()
     expect(total).to_eq(10)
   )
 
+  it("should propagate metadata when destructuring through a tuple type alias", ():
+    # PR #853 review: type aliases need resolution before tuple component split
+    type Pair = (int, List<int>)
+    xs: List<Pair> = [(1, [10, 20]), (2, [30, 40])]
+    total: int = 0
+    for i, row in xs:
+      total = total + sum(row)
+    expect(total).to_eq(100)
+  )
+
   it("should keep direct (non-destructure) for loop working (regression guard)", ():
     m: List<List<int>> = [[1, 2], [3, 4]]
     total: int = 0

--- a/tests/spec/return_type_meta_enum.test.ry
+++ b/tests/spec/return_type_meta_enum.test.ry
@@ -72,6 +72,14 @@ describe("enum return value preserves type metadata (#820)", ():
     expect(to_str(xs)).to_eq("[Green, Red]")
   )
 
+  it("should propagate enum metadata through a type alias in return position", ():
+    # PR #853 review: type aliases need resolution before enum lookup
+    type ColorAlias = Color
+    function get_alias() -> ColorAlias:
+      return Color::Red
+    expect(to_str(get_alias())).to_eq("Red")
+  )
+
   it("should still print Option<int> from function (regression guard)", ():
     function make_some() -> Option<int>:
       return Some(42)

--- a/tests/spec/return_type_meta_enum.test.ry
+++ b/tests/spec/return_type_meta_enum.test.ry
@@ -1,0 +1,86 @@
+enum Color:
+  Red
+  Green
+  Blue
+
+enum Shape:
+  Circle(float)
+  Rect(float, float)
+  Point
+
+describe("enum return value preserves type metadata (#820)", ():
+  it("should print simple enum variant name when returned inline", ():
+    function get_color() -> Color:
+      return Color::Red
+    expect(to_str(get_color())).to_eq("Red")
+  )
+
+  it("should print simple enum variant name when returned via local variable", ():
+    function get_color() -> Color:
+      return Color::Green
+    c = get_color()
+    expect(to_str(c)).to_eq("Green")
+  )
+
+  it("should print simple enum in f-string interpolation", ():
+    function get_color() -> Color:
+      return Color::Blue
+    expect(f"color: {get_color()}").to_eq("color: Blue")
+  )
+
+  it("should print ADT enum variant with payload when returned inline", ():
+    function make_circle() -> Shape:
+      return Shape::Circle(3.14)
+    expect(to_str(make_circle())).to_eq("Circle(3.14)")
+  )
+
+  it("should print ADT enum variant with payload when returned via local variable", ():
+    function make_rect() -> Shape:
+      return Shape::Rect(3.0, 4.0)
+    s = make_rect()
+    expect(to_str(s)).to_eq("Rect(3.0, 4.0)")
+  )
+
+  it("should print ADT enum variant without payload when returned from function", ():
+    function make_point() -> Shape:
+      return Shape::Point
+    expect(to_str(make_point())).to_eq("Point")
+  )
+
+  it("should match ADT enum returned from user function (regression guard)", ():
+    function make_circle() -> Shape:
+      return Shape::Circle(5.0)
+    match make_circle():
+      case Shape::Circle(r):
+        expect(r).to_eq(5.0)
+      case _:
+        expect(false).to_eq(true)
+  )
+
+  it("should propagate enum metadata through a wrapper function call chain", ():
+    function inner() -> Color:
+      return Color::Red
+    function outer() -> Color:
+      return inner()
+    expect(to_str(outer())).to_eq("Red")
+  )
+
+  it("should print simple enum stored in list after function return", ():
+    function get_color() -> Color:
+      return Color::Green
+    xs: List<Color> = [get_color(), Color::Red]
+    expect(to_str(xs)).to_eq("[Green, Red]")
+  )
+
+  it("should still print Option<int> from function (regression guard)", ():
+    function make_some() -> Option<int>:
+      return Some(42)
+    expect(to_str(make_some())).to_eq("Some(42)")
+  )
+
+  it("should still print Result<int, Error> from function (regression guard)", ():
+    function make_ok() -> Result<int, Error>:
+      return Ok(7)
+    expect(to_str(make_ok())).to_eq("Ok(7)")
+  )
+)


### PR DESCRIPTION
## Summary

Two bugs with a shared root cause — metadata is not propagated when a value crosses certain codegen boundaries — fixed together because the fix sites overlap in \`propagateTypeMeta\` / codegen_stmt_loop.

### #820 — enum return values lose type info

Before: \`print(get_color())\` printed \`0\` instead of \`Red\`, and \`print(make_shape())\` failed with \`cannot convert this struct type to string: enum.Shape\`. \`propagateTypeMeta\` had branches for \`List<T>\` / \`Map<K,V>\` / \`Set<T>\` / \`Task<T>\` / low-level suffixes, but no branch for enum type names, so \`propagateReturnTypeMeta\` silently dropped enum metadata at the call site.

Fix: new enum branch in \`propagateTypeMeta\` via a shared \`ensureEnumInstantiated\` helper that also handles generic enum templates. The helper consolidates three previously-duplicated copies of the \`baseName + splitTypeArgs + instantiateGenericEnum\` pattern (codegen_expr_literal, codegen_call_dispatch, and the new propagation branch).

\`List<Color>\` literals also needed a direct \`list_elem_type_name\` set outside the existing \`elemTy == ptrTy_\` guard, because simple enums are \`i64\` and ADT enums are LLVM struct values — neither is a pointer, so the guarded collection-name inference skipped them.

### #813 — for-loop destructure loses collection element type

Before: \`for i, row in enumerate(List<List<int>>):\` bound \`row\` as \`any\`, so \`sum(row)\` failed with \`sum() requires a list\`. Same for \`zip\` and \`for k, v in Map<str, List<int>>\`. \`enumerate\` / \`zip\` set the new list's \`TypeMeta::ListElem\` but not its source-level \`list_elem_type_name\`, and \`emitTupleDestructure\` never called \`propagateTypeMeta\` on the bound variables.

Fix:
- \`enumerate\` / \`zip\` now record \`list_elem_type_name = \"(int, <elem>)\"\` / \`\"(<a>, <b>)\"\` via a new \`snapshotListElemName\` helper (with \`reverseResolveTypeName\` fallback for primitives).
- \`emitTupleDestructure\` takes a \`tupleTypeName\` argument, splits components via \`splitTypeArgs\`, and calls \`propagateTypeMeta\` on each bound variable.
- Map iteration (\`for k, v in m\`) gains \`ValueMetadata::map_key_type_name\` and propagates both key and value names.

### Scope-out

#828 (\`thread_join\` returns \`Ok(0)\`) was in the original root-cause group but turned out to be a runtime ABI + type-system design gap (needs \`Thread<T>\` generic, \`ThreadHandle.result\` slot, non-void thunk). Split to a separate PR. \`(a, b) = tuple\` outside for-loops is also left to a follow-up — different AST path.

## Files touched

- \`include/ry/codegen.hpp\` — \`ValueMetadata::map_key_type_name\`, new helper declarations (\`ensureEnumInstantiated\`, \`trimTypeNameSpaces\`, \`snapshotListElemName\`)
- \`src/codegen_builtin.cpp\` — \`propagateTypeMeta\` enum branch, Map single-parse refactor, new helpers, \`inferCollectionTypeName\` contract extension
- \`src/codegen_call.cpp\` — \`enumerate\` / \`zip\` tuple-name recording
- \`src/codegen_call_dispatch.cpp\`, \`src/codegen_expr_literal.cpp\` — dedup generic-enum instantiation via \`ensureEnumInstantiated\`
- \`src/codegen_expr_literal.cpp\` — list literal enum element → \`list_elem_type_name\`
- \`src/codegen_metadata.cpp\` — \`propagateMeta\` / \`hasAnyMeta\` carry \`map_key_type_name\`
- \`src/codegen_stmt_loop.cpp\` — \`emitTupleDestructure\` tuple-name decomposition, map iteration propagation
- \`KNOWLEDGE.md\` — 2 new entries (tuple decomposition rule + list-literal enum element pattern)
- \`changelog.d/820-813-metadata-propagation.md\`

## Test plan

New self-test files covering the full bug matrices:

- \`tests/spec/return_type_meta_enum.test.ry\` — 11 cases (simple enum, ADT enum, enum via local var, via wrapper fn, in List, Option/Result regression guards)
- \`tests/spec/for_loop_destructure_meta.test.ry\` — 10 cases (enumerate over \`List<List<int>>\`, enumerate over \`List<Map<str, int>>\`, zip on either side, \`Map<str, List<int>>\`, \`Map<str, Map<str, int>>\`, #820×#813 interaction, nested enumerate, direct-for and primitive destructure regression guards)

Verification (all green):

- [x] \`./build/ry_tests\` — 1566/1566
- [x] \`./build/ry test -p\` — 105 files, 0 failures
- [x] \`ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests\` — 1565/1565
- [x] \`ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p\` — 105 files, 0 failures

## Documentation

No \`docs/reference/\` or \`docs/tutorial/\` updates needed — these are pure bug fixes and the existing docs do not document the broken behaviour. Translations deferred per release workflow.

Closes #820
Closes #813

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enum values now stringify as enum/variant names (including ADT variants) instead of raw integers.
  * Destructuring iteration (enumerate, zip, map iteration, tuple destructures) preserves element/type metadata for bound variables.
  * Lists and nested collections containing enums now retain enum type info for correct printing and operations.

* **Tests**
  * Added tests covering enum return/stringify behavior and metadata in collections.
  * Added tests for destructuring iteration metadata preservation.

* **Documentation**
  * Added guidance entries documenting metadata propagation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->