### PR TITLE
fix: accept chained LHS assignment forms (#812)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -381,6 +381,70 @@ grep -nE 'i64Ty_|boolTy_|strTy_|f64Ty_' src/ include/
 The new type should appear wherever these existing primitives do
 (justify any exceptions explicitly).
 
+### Ry records are SSA struct values, not pointers — nested field writes unroll up to the root alloca
+
+**Source**: #812 (2026-04-11, implementation)
+**Tags**: codegen, records, lvalue, insertvalue, chained-lhs
+
+**Context**: Records in Ry are *value types*: a `record Point: x: int; y: int`
+is emitted as `{i64, i64}` stored in an alloca. There is no stable address
+for an individual field — `CreateLoad(struct) → ExtractValue(x) → ...` gives
+you an SSA value, not a pointer you can `CreateStore` into. The #812 fix
+for `rec.a.b = v` therefore has to be: load the outer struct, `InsertValue`
+at the right field index, and if the target lives deeper in a chain
+(`rec.a.b.c = v`) walk back up inserting each updated inner struct into its
+parent until we reach the root alloca and do a single `CreateStore`.
+
+**Rule**: When implementing any write through a record field chain, treat
+every intermediate record as an SSA value. Never try to take a pointer into
+a struct field — use `ExtractValue` / `InsertValue` instead, and end the
+chain with one store at the root alloca. See `writeBackFieldChain` in
+`src/codegen_stmt_misc.cpp` for the reference pattern.
+
+### Compound assignment must be expanded in codegen, not desugared in parser
+
+**Source**: #812 (2026-04-11, implementation)
+**Tags**: codegen, compound-assign, side-effects, chained-lhs
+
+**Context**: Naively desugaring `a[f()] += v` as `a[f()] = a[f()] + v` in
+the parser would evaluate `f()` twice — once for the load and once for the
+store. That violates the "each subexpression evaluates once" rule and
+multiplies CoW work. The fix for #812 introduced `applyCompoundOp` in
+`src/codegen_stmt_misc.cpp` and expanded `IndexAssignStmt` / `FieldAssignStmt`
+with an optional `compound_op` field that codegen interprets as
+"load at the resolved slot → apply op → store at the same slot" — a single
+index evaluation per statement.
+
+**Rule**: When adding a new compound-assignment-capable statement form, do
+NOT desugar in the parser. Reuse `applyCompoundOp` and evaluate the LHS
+address exactly once in codegen. For maps, a compound op on a missing key
+is a runtime error (`"compound assignment to missing map key"`) — users
+must insert the key explicitly before accumulating.
+
+### Chained writes through nested collections are shallow — document, don't silently deep-copy
+
+**Source**: #812 + follow-up issue (2026-04-11)
+**Tags**: codegen, cow, arc, nested-collections, semantics
+
+**Context**: `emitCowCheck` only copies the top-level header and data
+buffer; inner element pointers are bit-copied, so a CoW of `List<List<int>>`
+leaves the inner lists shared with any aliases. The #812 fix exposes this
+more frequently because users now routinely write `grid[i][j] = v`,
+`rec.items[i] = v`, `m["a"]["x"] = v`. The chosen semantics for v0.0.8 is
+"shallow CoW", meaning chained writes mutate shared heap state in place
+and may be observable through aliases. Deep CoW is tracked as a follow-up
+issue.
+
+**Rule**: When implementing new mutation paths on collections, decide up
+front whether the semantic is deep-copy, shallow-copy-at-root-only, or
+"just mutate in place". Do not silently deep-copy — it changes the
+complexity model and may double-free ARC elements. Document the chosen
+semantic in the reference docs and `KNOWLEDGE.md`. When the LHS chain has
+a non-`VariableExpr` base (`rec.field[i] = v`, `grid[i][j] = v`), pass
+`nullptr` as the CoW anchor to `emitCowCheck` so it stays a no-op; any
+"proper" write-back through a record chain requires deep CoW and should be
+part of the follow-up.
+
 ---
 
 ## Parser / Lexer
@@ -433,6 +497,34 @@ UnaryExpr. The empty-suffix `value < 0` check in
 on this invariant — a regression would either silently accept
 `x = 18446744073709551615` (wrong i64 emit) or reject `case -1:`
 (false positive).
+
+### Statement-level LHS should reuse parsePostfixContinuation, not re-implement postfix hops
+
+**Source**: #812 (2026-04-11, implementation)
+**Tags**: parser, lvalue, lhs, postfix, assignment
+
+**Context**: Before #812, `Parser::parseStatement` dispatched `Ident [ ... ]`
+and `Ident . field` with a hardcoded 1-hop switch, rejecting any chained
+form (`list[i].field = v`, `record.a.b = v`, `list[i][j] = v`, etc.) with
+"expected '=' after index expression" or "expected '=' after field name".
+The fix split `parsePostfix` into `parsePrimary` + `parsePostfixContinuation(base)`
+and drives the statement LHS by feeding a synthetic `VariableExpr` base
+into the continuation, then inspecting the chain tail (`IndexExpr` /
+`FieldAccessExpr` / `CallExpr`) to decide which `*AssignStmt` variant to
+emit.
+
+**Rule**: When a new statement form needs to accept the same expression
+shapes as an lvalue, do NOT duplicate the `.`/`[` loop in the statement
+parser. Extract a continuation helper from `parsePostfix` and call it from
+the statement entry point. Dispatch on the chain tail node to choose the
+stmt variant.
+
+**How to apply**: Any statement that starts with `Ident` and may accept
+chained postfix hops (e.g. a future `move var.a.b into ...` or similar)
+should call `parsePostfixContinuation(baseExpr)` rather than re-parsing `.`
+and `[` inline. UFCS call statements (`ident.method(args)`) remain a
+special case detected before entering the continuation, because they
+produce a `CallStmt` rather than an `ExprStmt<CallExpr>`.
 
 ### Use strtod, not std::stod, for float literal parsing
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ for x in xs:
 print(2 in s)          # true
 print(m["a"])           # 1
 
+# Chained / compound assignment on indexed fields
+pts = [Point(1, 2), Point(3, 4)]
+pts[0].x += 10          # list[i].field compound assignment
+print(pts[0].x)         # 11
+
 # Stream-like operations (filter, map, sort)
 result = [5, 3, 1, 4, 2].filter((x: int) => x > 1).map((x: int) => x * 10).sort()
 print(result)          # [20, 30, 40, 50]

--- a/changelog.d/812-chained-lhs-assignment.md
+++ b/changelog.d/812-chained-lhs-assignment.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Chained assignment targets are now accepted by the parser and codegen,
+  including `list[i].field = v`, `record.a.b = v`, `list[i][j] = v`, and
+  compound forms such as `list[i] += v` and `record.field[i] *= v` (#812).
+  Previously these raised "expected '=' after index expression" or
+  "expected '=' after field name". Compound assignment to a missing map key
+  (`m["absent"] += 1`) now produces a clear runtime error instead of
+  silently inserting a default value.

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -142,6 +142,47 @@ xs[-1] = 42    # assigns to last element
 print(xs[2])   # 42
 ```
 
+### Chained Index and Field Assignment
+
+Index and field assignment compose: the left-hand side of `=` / `+=` / `-=` /
+`*=` / `//=` / `%=` / `&=` / `|=` / `^=` / `<<=` / `>>=` can be any postfix
+chain rooted at a mutable variable.
+
+```python
+record Point:
+  x: int
+  y: int
+
+pts = [Point(1, 2), Point(3, 4)]
+pts[0].x = 99           # list-of-records field update
+pts[0].x += 1
+print(pts[0].x)         # 100
+
+grid = [[1, 2], [3, 4]]
+grid[0][1] = 99         # nested list element
+print(grid[0])          # [1, 99]
+
+m: Map<str, Map<str, int>> = {"a": {"x": 1}}
+m["a"]["x"] = 42        # nested map element
+```
+
+Compound assignment evaluates each index exactly once, so `xs[f()] += 1` calls
+`f()` a single time. Compound assignment to a missing map key is a runtime
+error — insert the key first if you want to accumulate:
+
+```python
+m = {"a": 1}
+m["a"] += 10            # OK  → {"a": 11}
+m["b"] += 10            # runtime error: compound assignment to missing map key
+```
+
+> **Aliasing caveat**: nested collection writes (`grid[i][j] = v`,
+> `r.items[i] = v` through a record field containing a list) currently apply
+> copy-on-write only at the outermost container. If you have multiple
+> variables sharing inner collection pointers, mutating through one is
+> observable through the other. Use explicit copies to isolate writes. Deep
+> CoW is tracked in the follow-up issue for this feature.
+
 ### length
 
 ```python

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -145,8 +145,8 @@ print(xs[2])   # 42
 ### Chained Index and Field Assignment
 
 Index and field assignment compose: the left-hand side of `=` / `+=` / `-=` /
-`*=` / `//=` / `%=` / `&=` / `|=` / `^=` / `<<=` / `>>=` can be any postfix
-chain rooted at a mutable variable.
+`*=` / `/=` / `//=` / `%=` / `**=` / `&=` / `|=` / `^=` / `<<=` / `>>=` can be
+any postfix chain rooted at a mutable variable.
 
 ```python
 record Point:
@@ -523,19 +523,25 @@ print(xs)            # [[1, 2], [3, 4]] (unchanged)
 All collection types (List, Map, Set) use **Copy-on-Write** semantics when managed by ARC. This means:
 
 - **Assignment shares data**: `b = a` does not copy the collection — both variables reference the same data. The reference count is incremented.
-- **Mutation triggers a copy**: When a shared collection is mutated (e.g., `append`, `remove`, index assignment), a deep copy is automatically created before the mutation. Only the mutator pays the cost.
+- **Mutation triggers a shallow copy**: When a shared collection is mutated (e.g., `append`, `remove`, index assignment), the outermost container's header and element buffer are copied before the mutation; element pointers in that buffer are bit-copied, so any nested heap-allocated elements (`List<List<T>>`, `List<Record>` with collection fields, etc.) remain shared with the original. Only the mutator pays the cost of the outer copy.
 - **Unique owners mutate in-place**: When a collection has only one reference (`strong_count == 1`), mutations are performed in-place with zero copy overhead.
 
 ```python
 a = [1, 2, 3]       # strong_count = 1
 b = a                # strong_count = 2 (shared)
-append(b, 4)         # strong_count > 1 → deep copy b, then mutate
+append(b, 4)         # strong_count > 1 → copy outer buffer, then mutate
                      # a = [1, 2, 3]  (strong_count = 1)
                      # b = [1, 2, 3, 4]  (strong_count = 1, new allocation)
 
 c = [10, 20]         # strong_count = 1
 append(c, 30)        # strong_count == 1 → mutate in-place (no copy)
 ```
+
+> **Nested aliasing**: because CoW is shallow, chained writes through nested
+> collections (`grid[i][j] = v`, `rec.items[i] = v`) mutate the inner heap
+> state in place even after the outer container is privatized. Aliases that
+> share inner element pointers will observe the mutation. Use an explicit
+> deep copy if you need full isolation. Tracked as a follow-up to #812.
 
 ### Operations that trigger CoW
 

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -242,6 +242,26 @@ x //= 3  # x = 8
 x &= 6   # x = 0
 ```
 
+Compound assignment is allowed on any lvalue — plain variables, list or map
+elements, record fields, and arbitrarily nested chains:
+
+```python
+xs = [1, 2, 3]
+xs[0] += 10              # list element
+
+record Point:
+  x: int
+  y: int
+p = Point(1, 2)
+p.x *= 5                 # record field
+
+pts = [Point(1, 2), Point(3, 4)]
+pts[0].x -= 1            # chained: list-of-records field
+```
+
+Each index expression on a chained LHS is evaluated exactly once. Compound
+assignment to a missing map key (`m["absent"] += 1`) is a runtime error.
+
 ## Increment / Decrement Operators
 
 Postfix-only, statement-level operators for incrementing or decrementing a variable by 1. These are desugared to `x = x + 1` and `x = x - 1` respectively.

--- a/docs/reference/structs.md
+++ b/docs/reference/structs.md
@@ -71,6 +71,34 @@ q = Point(10, 20)
 q.x = 100    # Error: fields of @const variables cannot be modified
 ```
 
+### Chained and Deep Field Assignment
+
+Field assignment composes across nested records, collection elements, and
+compound operators. The left-hand side can be any postfix chain rooted at a
+mutable variable.
+
+```python
+record Inner:
+    val: int
+
+record Outer:
+    inner: Inner
+    tag: str
+
+o = Outer(Inner(1), "t")
+o.inner.val = 42              # deep field write
+o.inner.val += 1              # compound form
+print(o.inner.val)            # 43
+
+pts = [Point(1, 2), Point(3, 4)]
+pts[0].x = 99                 # list-of-records field update
+pts[0].x *= 2
+print(pts[0].x)               # 198
+```
+
+See [collections → Chained Index and Field Assignment](collections.md) for
+the full matrix and the aliasing caveat for nested collections inside records.
+
 ---
 
 ## Usage as Function Parameters and Return Values

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -251,6 +251,7 @@ struct IndexAssignStmt {
     ExprPtr object;
     std::vector<ExprPtr> indices;
     ExprPtr value;
+    std::optional<std::string> compound_op;  // "+", "-", "*", "/", "%", "//", "**", "&", "|", "^", "<<", ">>" — set when source used `a[i] += v` etc.
     SourceLocation loc;
 };
 
@@ -290,6 +291,7 @@ struct FieldAssignStmt {
     ExprPtr object;
     std::string field;
     ExprPtr value;
+    std::optional<std::string> compound_op;  // mirrors IndexAssignStmt.compound_op for `rec.f += v` etc.
     SourceLocation loc;
 };
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -332,6 +332,15 @@ public:
         std::vector<ExprPtr> invariants;
         std::string parentName;
         int64_t type_id = -1;   // unique identity for type_of
+
+        // Linear scan for a field by name. Returns the field index, or -1
+        // if the name is not present.
+        int findField(const std::string &name) const {
+            for (unsigned i = 0; i < fields.size(); ++i)
+                if (fields[i].name == name)
+                    return static_cast<int>(i);
+            return -1;
+        }
     };
     std::unordered_map<std::string, StructInfo> struct_types_;
 
@@ -810,6 +819,37 @@ public:
     void emitStmt(ContinueStmt &s);
     void emitStmt(EllipsisStmt &s);
     void emitStmt(FieldAssignStmt &s);
+
+    // Helpers for chained LHS assignment (#812).
+    //
+    // `applyCompoundOp` resolves a compound assignment operator
+    // (`+=` / `-=` / ... / `**=`) against a current value and rhs expression,
+    // trying user-defined `operator+=` first, then user-defined `operator+`,
+    // and finally the built-in binary op. Used by both `AssignStmt`'s
+    // re-assignment path and the chained `IndexAssignStmt` / `FieldAssignStmt`
+    // paths so the evaluation order (LHS address computed exactly once) is
+    // shared.
+    llvm::Value *applyCompoundOp(const std::string &op,
+                                  llvm::Value *currentVal,
+                                  llvm::Value *rhs,
+                                  ExprNode &rhsExpr,
+                                  llvm::Type *targetTy,
+                                  const std::string &contextName);
+
+    // Walk a FieldAccessExpr chain (possibly 1-deep) down to its base, which
+    // must be a VariableExpr referring to an alloca or module-global of
+    // struct type. Performs the immutable/@const rejection on the base and
+    // writes `newInnerVal` as the new value of the chain's innermost struct
+    // by `InsertValue`-ing it up through all intermediate record hops, then
+    // storing the fully-updated root struct back to its alloca. Throws
+    // `codegenError` if any node in the chain is not a VariableExpr /
+    // FieldAccessExpr (e.g. IndexExpr / CallExpr — those cases are handled
+    // separately by the FieldAssignStmt dispatcher).
+    //
+    // `writeBackInvariant` re-runs the outermost record's invariant check
+    // after the store completes.
+    void writeBackFieldChain(ExprNode &chainTarget, llvm::Value *newInnerVal);
+
     void emitStmt(EnumStmt &s);
     void emitStmt(ExpectStmt &s);
     void emitStmt(AwaitStmt &s);

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -94,6 +94,12 @@ private:
     // Compound assignment helper: x op= rhs
     AssignStmt makeCompoundAssign(const Token &nameTok, const std::string &op, ExprPtr rhs);
 
+    // Finalize a chained LHS (postfix chain rooted at an Ident) into an
+    // IndexAssignStmt / FieldAssignStmt / AssignStmt / ExprStmt based on the
+    // trailing token and the chain tail node. Used by parseStatement for the
+    // new `LBracket` / `Dot` paths that may traverse multiple postfix hops.
+    StmtNode finishChainedLhs(ExprPtr chain, const Token &first);
+
     // Binary expression helper (left-associative)
     using ParseFn = ExprPtr (Parser::*)();
     ExprPtr parseBinaryLeft(ParseFn operand, std::initializer_list<TokenKind> ops);
@@ -103,6 +109,7 @@ private:
     ExprPtr parsePower();
     ExprPtr parseCast();
     ExprPtr parsePostfix();
+    ExprPtr parsePostfixContinuation(ExprPtr expr);
     ExprPtr makeErrorPropagateExpr(ExprPtr operand, const Token &tok);
     ExprPtr parsePrimary();
     ExprPtr parseComparison();

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -708,34 +708,14 @@ void CodeGen::emitStmt(AssignStmt &s) {
     if (isImmutable(s.name))
         codegenError("cannot reassign @const variable: " + s.name);
 
-    // Compound assignment resolution: operator+= → operator+ → built-in
+    // Compound assignment resolution: operator+= → operator+ → built-in.
+    // Shares the load-modify-store core with the chained LHS forms (#812)
+    // via `applyCompoundOp` so the operator resolution order stays in sync.
     if (s.compound_op) {
         llvm::Value *currentVal = builder_.CreateLoad(ptr->getAllocatedType(), ptr, s.name);
         llvm::Value *rhs = emitExpr(*s.value);
-
-        // Priority 1: user-defined compound assignment operator (e.g., operator+=)
-        std::string compoundOpName = "operator" + *s.compound_op + "=";
-        llvm::Value *result = tryOperatorCall(compoundOpName, currentVal, rhs);
-
-        if (!result) {
-            // Priority 2: user-defined binary operator or built-in (e.g., operator+)
-            std::string rhsHint = getExprLowLevelSuffix(*s.value);
-            result = emitBinaryOp(*s.compound_op, currentVal, rhs, "", rhsHint);
-        }
-
-        // Type compatibility check (same as plain assignment path)
-        llvm::Type *varTy = ptr->getAllocatedType();
-        if (result->getType() != varTy) {
-            if (varTy == i8Ty_ && result->getType() == i64Ty_) {
-                result = builder_.CreateTrunc(result, i8Ty_, "bytetrunc");
-            } else if (isAnyType(varTy)) {
-                result = wrapInAny(result);
-            } else {
-                codegenError("type error: compound assignment on '" + s.name +
-                    "' produces incompatible type");
-            }
-        }
-
+        llvm::Value *result = applyCompoundOp(*s.compound_op, currentVal, rhs, *s.value,
+                                               ptr->getAllocatedType(), s.name);
         builder_.CreateStore(result, ptr);
         return;
     }
@@ -868,27 +848,13 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
     // path reuses `ptr` throughout).
     llvm::Value *storagePtr = loadModuleGlobalStorage(b, s.name);
 
-    // Compound assignment (e.g., x += 1): load current, evaluate RHS, apply
-    // operator (via overload or built-in), coerce, store.
+    // Compound assignment shares the resolution order with the local
+    // AssignStmt and chained LHS paths via `applyCompoundOp` (#812).
     if (s.compound_op) {
         llvm::Value *currentVal = builder_.CreateLoad(valueTy, storagePtr, s.name);
         llvm::Value *rhs = emitExpr(*s.value);
-        std::string compoundOpName = "operator" + *s.compound_op + "=";
-        llvm::Value *result = tryOperatorCall(compoundOpName, currentVal, rhs);
-        if (!result) {
-            std::string rhsHint = getExprLowLevelSuffix(*s.value);
-            result = emitBinaryOp(*s.compound_op, currentVal, rhs, "", rhsHint);
-        }
-        if (result->getType() != valueTy) {
-            if (valueTy == i8Ty_ && result->getType() == i64Ty_) {
-                result = builder_.CreateTrunc(result, i8Ty_, "bytetrunc");
-            } else if (isAnyType(valueTy)) {
-                result = wrapInAny(result);
-            } else {
-                codegenError("type error: compound assignment on '" + s.name +
-                             "' produces incompatible type");
-            }
-        }
+        llvm::Value *result = applyCompoundOp(*s.compound_op, currentVal, rhs, *s.value,
+                                               valueTy, s.name);
         builder_.CreateStore(result, storagePtr);
         return;
     }

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -3,67 +3,293 @@
 
 namespace ry {
 
+// ===== Chained LHS helpers (#812) =====
+//
+// These helpers support the generalized assignment dispatch: an LHS is now a
+// postfix-expression chain whose root is a variable and whose hops are any
+// mix of `.field` and `[index]`. The codegen for `FieldAssignStmt` and
+// `IndexAssignStmt` branches on the type of the outermost chain node and
+// routes to the appropriate write path.
+
+llvm::Value *CodeGen::applyCompoundOp(const std::string &op,
+                                       llvm::Value *currentVal,
+                                       llvm::Value *rhs,
+                                       ExprNode &rhsExpr,
+                                       llvm::Type *targetTy,
+                                       const std::string &contextName) {
+    // Priority 1: user-defined compound assignment operator (e.g. operator+=)
+    std::string compoundOpName = "operator" + op + "=";
+    llvm::Value *result = tryOperatorCall(compoundOpName, currentVal, rhs);
+    if (!result) {
+        // Priority 2: user-defined binary operator or built-in (e.g. operator+)
+        std::string rhsHint = getExprLowLevelSuffix(rhsExpr);
+        result = emitBinaryOp(op, currentVal, rhs, "", rhsHint);
+    }
+    if (targetTy && result->getType() != targetTy) {
+        if (targetTy == i8Ty_ && result->getType() == i64Ty_) {
+            result = builder_.CreateTrunc(result, i8Ty_, contextName + ".bytetrunc");
+        } else if (isAnyType(targetTy)) {
+            result = wrapInAny(result);
+        } else if (auto *sliced = tryEmitSubtypeCoerce(result, targetTy)) {
+            result = sliced;
+        } else {
+            codegenError("type error: compound assignment on '" + contextName +
+                         "' produces incompatible type");
+        }
+    }
+    return result;
+}
+
+void CodeGen::writeBackFieldChain(ExprNode &chainTarget,
+                                   llvm::Value *newInnerVal) {
+    if (auto *ve = std::get_if<VariableExpr>(&chainTarget.data)) {
+        llvm::Value *storagePtr = nullptr;
+        llvm::Type *varTy = nullptr;
+        if (llvm::AllocaInst *ptr = findVar(ve->name)) {
+            storagePtr = ptr;
+            varTy = ptr->getAllocatedType();
+        } else if (auto *b = findModuleGlobal(ve->name)) {
+            storagePtr = loadModuleGlobalStorage(*b, ve->name);
+            varTy = b->valueTy();
+        } else {
+            codegenError("undefined variable: " + ve->name);
+        }
+        if (isImmutable(ve->name))
+            codegenError("cannot modify field of @const variable: " + ve->name);
+        if (!captured_vars_.empty()) {
+            if (auto *ptr = llvm::dyn_cast<llvm::AllocaInst>(storagePtr))
+                if (isCapturedVar(ptr))
+                    codegenError("cannot modify field of captured variable '" +
+                                 ve->name + "' inside closure");
+        }
+        if (newInnerVal->getType() != varTy)
+            codegenError("internal: chained field assignment produced mismatched struct type for '" + ve->name + "'");
+        builder_.CreateStore(newInnerVal, storagePtr);
+        if (auto *rootSt = llvm::dyn_cast<llvm::StructType>(varTy)) {
+            auto rit = struct_types_.find(rootSt->getName().str());
+            if (rit != struct_types_.end())
+                emitInvariantCheck(rit->first, rit->second, newInnerVal);
+        }
+        return;
+    }
+
+    if (auto *faPtr = std::get_if<std::unique_ptr<FieldAccessExpr>>(&chainTarget.data)) {
+        FieldAccessExpr *fa = faPtr->get();
+        llvm::Value *outerVal = emitExpr(*fa->object);
+        auto *outerSt = llvm::dyn_cast<llvm::StructType>(outerVal->getType());
+        if (!outerSt)
+            codegenError("field access on non-struct type in chained assignment");
+        auto it = struct_types_.find(outerSt->getName().str());
+        if (it == struct_types_.end())
+            codegenError("unknown struct type: " + outerSt->getName().str());
+        int idx = it->second.findField(fa->field);
+        if (idx < 0)
+            codegenError("type '" + it->first + "' has no field '" + fa->field + "'");
+        llvm::Type *expectedTy = outerSt->getElementType(idx);
+        if (newInnerVal->getType() != expectedTy) {
+            if (auto *sliced = tryEmitSubtypeCoerce(newInnerVal, expectedTy))
+                newInnerVal = sliced;
+            else
+                codegenError("field '" + fa->field + "' type mismatch in chained assignment");
+        }
+        llvm::Value *updated = builder_.CreateInsertValue(outerVal, newInnerVal, idx, "chain_upd");
+        writeBackFieldChain(*fa->object, updated);
+        return;
+    }
+
+    // Anything else (IndexExpr, CallExpr, literal, ...) is not a simple
+    // record field chain. The `FieldAssignStmt` dispatcher handles those
+    // cases (`list[i].field = v` etc.) directly and never reaches this
+    // helper, so treat a stray call here as an internal invariant break.
+    codegenError("cannot chain-assign through non-record expression");
+}
+
 void CodeGen::emitStmt(FieldAssignStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
-    // Get the variable name from the object expression
-    auto *varExpr = std::get_if<VariableExpr>(&s.object->data);
-    if (!varExpr)
-        codegenError("field assignment requires variable on left side");
 
-    // Resolve the storage pointer: first a local alloca, then a top-level
-    // module global (#817) via the pointer trampoline.
-    llvm::Value *storagePtr = nullptr;
-    llvm::Type *varTy = nullptr;
+    // Dispatch based on the shape of s.object: VariableExpr (plain),
+    // FieldAccessExpr (deep record chain), IndexExpr (struct living inside
+    // a heap collection element). Anything else is rejected as a non-lvalue.
 
-    if (llvm::AllocaInst *ptr = findVar(varExpr->name)) {
-        storagePtr = ptr;
-        varTy = ptr->getAllocatedType();
-    } else if (auto *b = findModuleGlobal(varExpr->name)) {
-        storagePtr = loadModuleGlobalStorage(*b, varExpr->name);
-        varTy = b->valueTy();
-    } else {
-        codegenError("undefined variable: " + varExpr->name);
-    }
-
-    if (isImmutable(varExpr->name))
-        codegenError("cannot modify field of @const variable: " + varExpr->name);
-
-    llvm::StructType *structTy = llvm::dyn_cast<llvm::StructType>(varTy);
-    if (!structTy)
-        codegenError("field assignment on non-struct type");
-
-    std::string typeName = structTy->getName().str();
-    auto it = struct_types_.find(typeName);
-    if (it == struct_types_.end())
-        codegenError("unknown struct type: " + typeName);
-
-    const auto &info = it->second;
-    int fieldIdx = -1;
-    for (unsigned i = 0; i < info.fields.size(); ++i) {
-        if (info.fields[i].name == s.field) {
-            fieldIdx = static_cast<int>(i);
-            break;
+    if (auto *varExpr = std::get_if<VariableExpr>(&s.object->data)) {
+        llvm::Value *storagePtr = nullptr;
+        llvm::Type *varTy = nullptr;
+        if (llvm::AllocaInst *ptr = findVar(varExpr->name)) {
+            storagePtr = ptr;
+            varTy = ptr->getAllocatedType();
+        } else if (auto *b = findModuleGlobal(varExpr->name)) {
+            storagePtr = loadModuleGlobalStorage(*b, varExpr->name);
+            varTy = b->valueTy();
+        } else {
+            codegenError("undefined variable: " + varExpr->name);
         }
+        if (isImmutable(varExpr->name))
+            codegenError("cannot modify field of @const variable: " + varExpr->name);
+
+        llvm::StructType *structTy = llvm::dyn_cast<llvm::StructType>(varTy);
+        if (!structTy)
+            codegenError("field assignment on non-struct type");
+        std::string typeName = structTy->getName().str();
+        auto it = struct_types_.find(typeName);
+        if (it == struct_types_.end())
+            codegenError("unknown struct type: " + typeName);
+        const auto &info = it->second;
+        int fieldIdx = info.findField(s.field);
+        if (fieldIdx < 0)
+            codegenError("type '" + typeName + "' has no field '" + s.field + "'");
+        llvm::Type *expectedTy = structTy->getElementType(fieldIdx);
+
+        llvm::Value *newFieldVal = nullptr;
+        llvm::Value *currentStruct = builder_.CreateLoad(varTy, storagePtr, "struct_cur");
+        if (s.compound_op) {
+            llvm::Value *currentField = builder_.CreateExtractValue(
+                currentStruct, fieldIdx, s.field + ".compound_cur");
+            llvm::Value *rhs = emitExpr(*s.value);
+            newFieldVal = applyCompoundOp(*s.compound_op, currentField, rhs, *s.value,
+                                           expectedTy, varExpr->name + "." + s.field);
+        } else {
+            newFieldVal = emitExpr(*s.value);
+            if (newFieldVal->getType() != expectedTy) {
+                if (auto *sliced = tryEmitSubtypeCoerce(newFieldVal, expectedTy))
+                    newFieldVal = sliced;
+                else
+                    codegenError("field '" + s.field + "' type mismatch");
+            }
+        }
+
+        llvm::Value *updated = builder_.CreateInsertValue(
+            currentStruct, newFieldVal, fieldIdx, "struct_upd");
+        builder_.CreateStore(updated, storagePtr);
+        emitInvariantCheck(typeName, info, updated);
+        return;
     }
-    if (fieldIdx < 0)
-        codegenError("type '" + typeName + "' has no field '" + s.field + "'");
 
-    llvm::Value *newVal = emitExpr(*s.value);
-    llvm::Type *expectedTy = structTy->getElementType(fieldIdx);
-    if (newVal->getType() != expectedTy) {
-        if (auto *sliced = tryEmitSubtypeCoerce(newVal, expectedTy))
-            newVal = sliced;
-        else
-            codegenError("field '" + s.field + "' type mismatch");
+    if (std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(s.object->data)) {
+        llvm::Value *innerStruct = emitExpr(*s.object);
+        auto *innerSt = llvm::dyn_cast<llvm::StructType>(innerStruct->getType());
+        if (!innerSt)
+            codegenError("field assignment on non-struct type");
+        auto it = struct_types_.find(innerSt->getName().str());
+        if (it == struct_types_.end())
+            codegenError("unknown struct type: " + innerSt->getName().str());
+        const auto &info = it->second;
+        int fieldIdx = info.findField(s.field);
+        if (fieldIdx < 0)
+            codegenError("type '" + it->first + "' has no field '" + s.field + "'");
+        llvm::Type *expectedTy = innerSt->getElementType(fieldIdx);
+
+        llvm::Value *newFieldVal = nullptr;
+        if (s.compound_op) {
+            llvm::Value *currentField = builder_.CreateExtractValue(
+                innerStruct, fieldIdx, s.field + ".compound_cur");
+            llvm::Value *rhs = emitExpr(*s.value);
+            newFieldVal = applyCompoundOp(*s.compound_op, currentField, rhs, *s.value,
+                                           expectedTy, it->first + "." + s.field);
+        } else {
+            newFieldVal = emitExpr(*s.value);
+            if (newFieldVal->getType() != expectedTy) {
+                if (auto *sliced = tryEmitSubtypeCoerce(newFieldVal, expectedTy))
+                    newFieldVal = sliced;
+                else
+                    codegenError("field '" + s.field + "' type mismatch");
+            }
+        }
+
+        llvm::Value *updatedInner = builder_.CreateInsertValue(
+            innerStruct, newFieldVal, fieldIdx, "nested_upd");
+        writeBackFieldChain(*s.object, updatedInner);
+        return;
     }
 
-    // Load current struct value, insert new field value, store back
-    llvm::Value *current = builder_.CreateLoad(varTy, storagePtr, "struct_cur");
-    llvm::Value *updated = builder_.CreateInsertValue(current, newVal, fieldIdx, "struct_upd");
-    builder_.CreateStore(updated, storagePtr);
+    // Shallow CoW only on the outermost alloca anchor for chained forms
+    // (`list[i].field = v`, `grid[i][j].field = v`). Deep CoW write-back
+    // through record / nested-collection chains is tracked by issue #854.
+    if (auto *idxPtr = std::get_if<std::unique_ptr<IndexExpr>>(&s.object->data)) {
+        IndexExpr *idxExpr = idxPtr->get();
+        llvm::AllocaInst *receiverAlloca = tryGetReceiverAlloca(*idxExpr->object);
+        llvm::Value *containerPtr = emitExpr(*idxExpr->object);
+        if (idxExpr->indices.size() != 1)
+            codegenError("multi-index chained field assignment not supported");
+        llvm::Value *indexVal = emitExpr(*idxExpr->indices[0]);
+        if (containerPtr->getType() != ptrTy_)
+            codegenError("chained field assignment requires a list or map base");
+        llvm::Type *mapKeyTy = getMapKeyType(containerPtr);
+        llvm::Value *elemSlot = nullptr;
+        llvm::Type *elemTy = nullptr;
+        if (mapKeyTy) {
+            containerPtr = emitCowCheck(containerPtr, receiverAlloca, CollectionKind::Map);
+            llvm::Type *mapValTy = getMapValueType(containerPtr);
+            if (!mapValTy)
+                codegenError("cannot determine map value type for chained field assignment");
+            if (indexVal->getType() != mapKeyTy)
+                codegenError("map key type mismatch");
+            llvm::Value *slot = emitMapKeyLookup(containerPtr, indexVal, mapKeyTy);
+            llvm::Value *missing = builder_.CreateICmpSLT(slot, llvm::ConstantInt::get(i64Ty_, 0), "map_key_missing");
+            auto *fn = builder_.GetInsertBlock()->getParent();
+            auto *errBB = llvm::BasicBlock::Create(*ctx_, "map_chain_missing", fn);
+            auto *okBB = llvm::BasicBlock::Create(*ctx_, "map_chain_ok", fn);
+            builder_.CreateCondBr(missing, errBB, okBB);
+            builder_.SetInsertPoint(errBB);
+            emitRuntimeError("runtime error: missing map key in chained field assignment\n",
+                             ".map_chain_missing");
+            builder_.SetInsertPoint(okBB);
+            llvm::Value *valsPtrField = builder_.CreateStructGEP(mapHeaderTy_, containerPtr, 3, "map_vals_ptr");
+            llvm::Value *valsPtr = builder_.CreateLoad(ptrTy_, valsPtrField, "map_vals");
+            elemSlot = builder_.CreateGEP(mapValTy, valsPtr, {slot}, "map_val_elem_ptr");
+            elemTy = mapValTy;
+        } else {
+            containerPtr = emitCowCheck(containerPtr, receiverAlloca, CollectionKind::List);
+            elemTy = getListElementType(containerPtr);
+            if (!elemTy)
+                codegenError("cannot determine list element type for chained field assignment");
+            llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, containerPtr, 0, "len_ptr");
+            llvm::Value *length = builder_.CreateLoad(i64Ty_, lenPtr, "length");
+            emitBoundsCheck(indexVal, length,
+                            "runtime error: index %lld out of bounds for list of length %lld\n",
+                            ".idx_chain_err", "idx_chain");
+            llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, containerPtr, 2, "data_ptr");
+            llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "data");
+            elemSlot = builder_.CreateGEP(elemTy, dataPtr, {indexVal}, "list_elem_ptr");
+        }
 
-    emitInvariantCheck(typeName, info, updated);
+        auto *structTy = llvm::dyn_cast<llvm::StructType>(elemTy);
+        if (!structTy)
+            codegenError("chained field assignment requires a struct element type");
+        auto it = struct_types_.find(structTy->getName().str());
+        if (it == struct_types_.end())
+            codegenError("unknown struct type: " + structTy->getName().str());
+        const auto &info = it->second;
+        int fieldIdx = info.findField(s.field);
+        if (fieldIdx < 0)
+            codegenError("type '" + it->first + "' has no field '" + s.field + "'");
+        llvm::Type *expectedTy = structTy->getElementType(fieldIdx);
+        llvm::Value *curStruct = builder_.CreateLoad(elemTy, elemSlot, "elem_struct_cur");
+
+        llvm::Value *newFieldVal = nullptr;
+        if (s.compound_op) {
+            llvm::Value *curField = builder_.CreateExtractValue(curStruct, fieldIdx, s.field + ".compound_cur");
+            llvm::Value *rhs = emitExpr(*s.value);
+            newFieldVal = applyCompoundOp(*s.compound_op, curField, rhs, *s.value,
+                                           expectedTy, it->first + "." + s.field);
+        } else {
+            newFieldVal = emitExpr(*s.value);
+            if (newFieldVal->getType() != expectedTy) {
+                if (auto *sliced = tryEmitSubtypeCoerce(newFieldVal, expectedTy))
+                    newFieldVal = sliced;
+                else
+                    codegenError("field '" + s.field + "' type mismatch");
+            }
+        }
+
+        llvm::Value *updatedStruct = builder_.CreateInsertValue(
+            curStruct, newFieldVal, fieldIdx, "elem_struct_upd");
+        builder_.CreateStore(updatedStruct, elemSlot);
+        emitInvariantCheck(it->first, info, updatedStruct);
+        return;
+    }
+
+    codegenError("left side of field assignment is not an lvalue");
 }
 
 void CodeGen::rejectIfTypeNameTakenByOtherKind(const std::string &name) {
@@ -282,16 +508,43 @@ void CodeGen::emitStmt(ImportStmt &s) {
 void CodeGen::emitStmt(IndexAssignStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
-    llvm::AllocaInst *receiverAlloca = tryGetReceiverAlloca(*s.object);
+
+    // Resolve the container's CoW anchor. Only plain `var[i] = v` forms
+    // support CoW today: the anchor must be the alloca that holds the
+    // container pointer so emitCowCheck can write-back a new pointer on
+    // copy. For chained forms (`rec.field[i] = v`, `grid[i][j] = v`) the
+    // container pointer is reached through a field extract or a nested
+    // index load, so there is no single alloca slot to write-back to
+    // without deep record / nested-collection CoW. Those cases are scoped
+    // out to a follow-up issue — we fall through with anchor == nullptr so
+    // emitCowCheck is a no-op and mutation happens in place on whatever
+    // heap state is reached.
+    llvm::AllocaInst *receiverAlloca = nullptr;
+    if (std::get_if<VariableExpr>(&s.object->data)) {
+        receiverAlloca = tryGetReceiverAlloca(*s.object);
+    } else if (!std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(s.object->data) &&
+               !std::holds_alternative<std::unique_ptr<IndexExpr>>(s.object->data)) {
+        codegenError("left side of index assignment is not an lvalue");
+    }
+
     llvm::Value *objPtr = emitExpr(*s.object);
 
     llvm::SmallVector<llvm::Value*, 2> indexValues;
     for (auto &idx : s.indices)
         indexValues.push_back(emitExpr(*idx));
-    llvm::Value *val = emitExpr(*s.value);
 
-    if (trySubscriptAssignOperatorCall(objPtr, indexValues, val))
-        return;
+    // For non-compound assignment we can still route through a user-defined
+    // `operator[]=` overload (which expects the replacement value directly
+    // and bypasses the built-in list/map paths). Compound forms don't go
+    // through the overload because the operand on the LHS is the live
+    // element, not a plain rhs — let the built-in paths below do the
+    // load-modify-store.
+    llvm::Value *rhsVal = nullptr;
+    if (!s.compound_op) {
+        rhsVal = emitExpr(*s.value);
+        if (trySubscriptAssignOperatorCall(objPtr, indexValues, rhsVal))
+            return;
+    }
     if (indexValues.size() > 1)
         codegenError("multi-index requires operator[]= overload");
 
@@ -306,6 +559,18 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
             emitBoundsCheck(key, llvm::ConstantInt::get(i64Ty_, arrSize),
                             "runtime error: index %lld out of bounds for array of length %lld\n", ".arr_assign_err", "arr_assign");
 
+            llvm::Value *elemPtr = builder_.CreateGEP(
+                arrTy, ai, {llvm::ConstantInt::get(i64Ty_, 0), key}, "arr_assign_ptr");
+
+            llvm::Value *val = nullptr;
+            if (s.compound_op) {
+                llvm::Value *oldVal = builder_.CreateLoad(elemTy, elemPtr, "arr_elem_cur");
+                llvm::Value *rhs = emitExpr(*s.value);
+                val = applyCompoundOp(*s.compound_op, oldVal, rhs, *s.value, elemTy, "array element");
+            } else {
+                val = rhsVal;
+            }
+
             if (val->getType() != elemTy) {
                 auto nit = array_elem_type_names_.find(ai);
                 std::string tn = (nit != array_elem_type_names_.end()) ? nit->second : "i32";
@@ -318,8 +583,6 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
                 }
             }
 
-            llvm::Value *elemPtr = builder_.CreateGEP(
-                arrTy, ai, {llvm::ConstantInt::get(i64Ty_, 0), key}, "arr_assign_ptr");
             builder_.CreateStore(val, elemPtr);
             return;
         }
@@ -339,10 +602,35 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
             codegenError("cannot determine map value type");
         if (key->getType() != mapKeyTy)
             codegenError("map key type mismatch");
-        if (val->getType() != mapValTy)
+
+        // Compound assignment on a map requires the key to already exist —
+        // an "insert default then apply op" behavior is not yet supported
+        // and would silently paper over typos. Reject at runtime with a
+        // clear message (#812 user decision).
+        if (s.compound_op) {
+            llvm::Value *idx = emitMapKeyLookup(objPtr, key, mapKeyTy);
+            llvm::Value *found = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "found");
+            auto *parentFn = builder_.GetInsertBlock()->getParent();
+            auto *missBB = llvm::BasicBlock::Create(*ctx_, "map.compound_missing", parentFn);
+            auto *okBB = llvm::BasicBlock::Create(*ctx_, "map.compound_ok", parentFn);
+            builder_.CreateCondBr(found, okBB, missBB);
+            builder_.SetInsertPoint(missBB);
+            emitRuntimeError("runtime error: compound assignment to missing map key\n",
+                             ".map_compound_missing");
+            builder_.SetInsertPoint(okBB);
+            llvm::Value *valsPtrField = builder_.CreateStructGEP(mapHeaderTy_, objPtr, 3, "map_vals_ptr");
+            llvm::Value *valsPtr = builder_.CreateLoad(ptrTy_, valsPtrField, "map_vals");
+            llvm::Value *valElemPtr = builder_.CreateGEP(mapValTy, valsPtr, {idx}, "val_elem_ptr");
+            llvm::Value *oldVal = builder_.CreateLoad(mapValTy, valElemPtr, "map_val_cur");
+            llvm::Value *rhs = emitExpr(*s.value);
+            llvm::Value *newVal = applyCompoundOp(*s.compound_op, oldVal, rhs, *s.value, mapValTy, "map element");
+            builder_.CreateStore(newVal, valElemPtr);
+            return;
+        }
+
+        if (rhsVal->getType() != mapValTy)
             codegenError("map value type mismatch");
 
-        // Lookup key
         llvm::Value *idx = emitMapKeyLookup(objPtr, key, mapKeyTy);
         llvm::Value *found = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "found");
 
@@ -352,15 +640,13 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
 
         builder_.CreateCondBr(found, updateBB, insertBB);
 
-        // Update existing value
         builder_.SetInsertPoint(updateBB);
         llvm::Value *valsPtrField = builder_.CreateStructGEP(mapHeaderTy_, objPtr, 3, "map_vals_ptr");
         llvm::Value *valsPtr = builder_.CreateLoad(ptrTy_, valsPtrField, "map_vals");
         llvm::Value *valElemPtr = builder_.CreateGEP(mapValTy, valsPtr, {idx}, "val_elem_ptr");
-        builder_.CreateStore(val, valElemPtr);
+        builder_.CreateStore(rhsVal, valElemPtr);
         builder_.CreateBr(endBB);
 
-        // Insert new key-value pair
         builder_.SetInsertPoint(insertBB);
         llvm::Value *lenPtr = builder_.CreateStructGEP(mapHeaderTy_, objPtr, 0, "map_len_ptr");
         llvm::Value *length = builder_.CreateLoad(i64Ty_, lenPtr, "map_len");
@@ -427,7 +713,7 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         llvm::Value *valsPtrField3 = builder_.CreateStructGEP(mapHeaderTy_, objPtr, 3, "vals_field3");
         llvm::Value *curValsPtr = builder_.CreateLoad(ptrTy_, valsPtrField3, "cur_vals");
         llvm::Value *newValPtr = builder_.CreateGEP(mapValTy, curValsPtr, {curLen}, "new_val_ptr");
-        builder_.CreateStore(val, newValPtr);
+        builder_.CreateStore(rhsVal, newValPtr);
 
         // length++
         llvm::Value *newLen = builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1), "new_len");
@@ -456,7 +742,22 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, objPtr, 2, "data_ptr");
     llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "data");
     llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {key}, "elem_ptr");
-    builder_.CreateStore(val, elemPtr);
+
+    llvm::Value *finalVal = nullptr;
+    if (s.compound_op) {
+        llvm::Value *oldVal = builder_.CreateLoad(elemTy, elemPtr, "list_elem_cur");
+        llvm::Value *rhs = emitExpr(*s.value);
+        finalVal = applyCompoundOp(*s.compound_op, oldVal, rhs, *s.value, elemTy, "list element");
+    } else {
+        finalVal = rhsVal;
+    }
+    if (finalVal->getType() != elemTy) {
+        if (auto *sliced = tryEmitSubtypeCoerce(finalVal, elemTy))
+            finalVal = sliced;
+        else
+            codegenError("list element type mismatch in index assignment");
+    }
+    builder_.CreateStore(finalVal, elemPtr);
 }
 
 } // namespace ry

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -378,14 +378,16 @@ void Formatter::formatIndexAssign(const IndexAssignStmt &s) {
         if (i > 0) idxStr += ", ";
         idxStr += formatExpr(*s.indices[i]);
     }
-    emit(formatExpr(*s.object) + "[" + idxStr + "] = " + formatExpr(*s.value));
+    std::string op = s.compound_op ? (" " + *s.compound_op + "= ") : " = ";
+    emit(formatExpr(*s.object) + "[" + idxStr + "]" + op + formatExpr(*s.value));
     emitInlineComment(s.loc.line);
     emitNewline();
     last_emitted_line_ = s.loc.line;
 }
 
 void Formatter::formatFieldAssign(const FieldAssignStmt &s) {
-    emit(formatExpr(*s.object) + "." + s.field + " = " + formatExpr(*s.value));
+    std::string op = s.compound_op ? (" " + *s.compound_op + "= ") : " = ";
+    emit(formatExpr(*s.object) + "." + s.field + op + formatExpr(*s.value));
     emitInlineComment(s.loc.line);
     emitNewline();
     last_emitted_line_ = s.loc.line;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -91,6 +91,100 @@ AssignStmt Parser::makeCompoundAssign(const Token &nameTok, const std::string &o
     return s;
 }
 
+// ===== Chained LHS finalizer =====
+//
+// Given a postfix expression chain whose root is an Ident (built by the
+// Dot/LBracket paths of parseStatement), look at the next token and produce:
+//   - IndexAssignStmt   if the chain tail is an IndexExpr   and '='/'+='/etc. follows
+//   - FieldAssignStmt   if the chain tail is a FieldAccessExpr and '='/'+='/etc. follows
+//   - ExprStmt          if no assignment operator follows and the tail is a CallExpr
+//                       (e.g. deeper UFCS chains like `a.b.c(d)`)
+//   - parseError        preserving the existing "expected '=' after index expression" /
+//                       "expected '=' after field name" messages for the common typo
+//                       cases that the old 1-hop parser used to emit.
+//
+// The helper is intentionally narrow: the caller has already committed to a
+// statement starting with `Ident` followed by `.` or `[`, so the chain root
+// is always a VariableExpr.
+StmtNode Parser::finishChainedLhs(ExprPtr chain, const Token &first) {
+    auto tailKindIsIndex = [](const ExprNode &n) {
+        return std::holds_alternative<std::unique_ptr<IndexExpr>>(n.data);
+    };
+    auto tailKindIsField = [](const ExprNode &n) {
+        return std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(n.data);
+    };
+
+    auto isCompoundAssignTok = [](TokenKind k) {
+        return k == TokenKind::PlusEq  || k == TokenKind::MinusEq ||
+               k == TokenKind::StarEq  || k == TokenKind::SlashEq ||
+               k == TokenKind::PercentEq ||
+               k == TokenKind::SlashSlashEq || k == TokenKind::StarStarEq ||
+               k == TokenKind::AmpEq  || k == TokenKind::PipeEq ||
+               k == TokenKind::CaretEq ||
+               k == TokenKind::LessLessEq || k == TokenKind::GreaterGreaterEq;
+    };
+
+    auto buildStmt = [&](ExprPtr value, std::optional<std::string> op) -> StmtNode {
+        if (tailKindIsIndex(*chain)) {
+            auto &idx = std::get<std::unique_ptr<IndexExpr>>(chain->data);
+            IndexAssignStmt s;
+            s.object = std::move(idx->object);
+            s.indices = std::move(idx->indices);
+            s.value = std::move(value);
+            s.compound_op = std::move(op);
+            s.loc = locFromToken(first);
+            return s;
+        }
+        if (tailKindIsField(*chain)) {
+            auto &fa = std::get<std::unique_ptr<FieldAccessExpr>>(chain->data);
+            FieldAssignStmt s;
+            s.object = std::move(fa->object);
+            s.field = fa->field;
+            s.value = std::move(value);
+            s.compound_op = std::move(op);
+            s.loc = locFromToken(first);
+            return s;
+        }
+        // A chain that begins with `[` or `.` can still end in a CallExpr if
+        // parsePostfixContinuation consumed a UFCS-style `.f(args)` at the
+        // tail, but that is not an assignable lvalue. Reject here with a
+        // clear message rather than silently producing a garbage stmt.
+        parseError(first.line, "left side of assignment is not an lvalue");
+    };
+
+    Token peek = lex_.peek();
+    if (peek.kind == TokenKind::Equals) {
+        lex_.next(); // consume '='
+        ExprPtr value = parseConditional();
+        return buildStmt(std::move(value), std::nullopt);
+    }
+    if (isCompoundAssignTok(peek.kind)) {
+        Token opTok = lex_.next(); // consume compound op
+        std::string op = opTok.value.substr(0, opTok.value.size() - 1);
+        ExprPtr value = parseConditional();
+        return buildStmt(std::move(value), op);
+    }
+    if (peek.kind == TokenKind::PlusPlus || peek.kind == TokenKind::MinusMinus) {
+        Token opTok = lex_.next();
+        std::string op = (opTok.kind == TokenKind::PlusPlus) ? "+" : "-";
+        auto one = std::make_unique<ExprNode>();
+        one->data = NumberExpr{1, ""};
+        one->loc = locFromToken(first);
+        return buildStmt(std::move(one), op);
+    }
+
+    // No assignment operator. Preserve the old strict errors for the direct
+    // typo cases (ending in index or field access), and route legitimate
+    // statement-level postfix expressions (UFCS chains, error-propagate
+    // tails, etc.) to ExprStmt so they behave like any other expression
+    // statement.
+    if (tailKindIsIndex(*chain))
+        parseError(peek.line, "expected '=' after index expression");
+    if (tailKindIsField(*chain))
+        parseError(peek.line, "expected '=' after field name");
+    return ExprStmt{std::move(chain), locFromToken(first)};
+}
+
 // ===== A2: parseBinaryLeft helper =====
 
 ExprPtr Parser::parseBinaryLeft(ParseFn operand, std::initializer_list<TokenKind> ops) {
@@ -433,8 +527,11 @@ StmtNode Parser::parseStatement() {
     } else if (next.kind == TokenKind::LBracket) {
         if (!directives.empty())
             parseError(first.line, "directives are not supported on index assignment");
-        // index assignment: ident[expr, ...] = value
-        lex_.next(); // consume '['
+        // Chained index LHS: parse `ident[...]` and then any further postfix
+        // hops so we can handle `a[i].field = v`, `a[i][j] = v`,
+        // `a[i] += v`, etc. The trailing token is examined by
+        // finishChainedLhs which emits the correct stmt variant.
+        Token lbTok = lex_.next(); // consume '['
         std::vector<ExprPtr> indices;
         indices.push_back(parseConditional());
         while (lex_.peek().kind == TokenKind::Comma) {
@@ -444,24 +541,26 @@ StmtNode Parser::parseStatement() {
         if (lex_.peek().kind != TokenKind::RBracket)
             parseError("expected ']'");
         lex_.next(); // consume ']'
-        if (lex_.peek().kind != TokenKind::Equals)
-            parseError("expected '=' after index expression");
-        lex_.next(); // consume '='
-        ExprPtr val = parseConditional();
-        IndexAssignStmt s;
-        auto obj = std::make_unique<ExprNode>();
-        obj->data = VariableExpr{first.value};
-        obj->loc = locFromToken(first);
-        s.object = std::move(obj);
-        s.indices = std::move(indices);
-        s.value = std::move(val);
-        s.loc = locFromToken(first);
-        return s;
+
+        auto varExpr = std::make_unique<ExprNode>();
+        varExpr->data = VariableExpr{first.value};
+        varExpr->loc = locFromToken(first);
+        auto idxExpr = std::make_unique<IndexExpr>();
+        idxExpr->object = std::move(varExpr);
+        idxExpr->indices = std::move(indices);
+        auto chain = std::make_unique<ExprNode>();
+        chain->data = std::move(idxExpr);
+        chain->loc = locFromToken(lbTok);
+
+        chain = parsePostfixContinuation(std::move(chain));
+        return finishChainedLhs(std::move(chain), first);
     } else if (next.kind == TokenKind::Dot) {
         if (!directives.empty())
             parseError(first.line, "directives are not supported on field assignment or method call");
-        // field assignment: ident.field = value
-        lex_.next(); // consume '.'
+        // Consume the first `.field` hop manually so we can preserve the
+        // existing 1-hop UFCS call-statement special case (`ident.method(...)`)
+        // which produces a CallStmt rather than an ExprStmt<CallExpr>.
+        Token dotTok = lex_.next(); // consume '.'
         Token fieldTok = lex_.peek();
         if (fieldTok.kind != TokenKind::Ident)
             parseError(fieldTok.line, "expected field name after '.'");
@@ -484,19 +583,21 @@ StmtNode Parser::parseStatement() {
             return s;
         }
 
-        if (lex_.peek().kind != TokenKind::Equals)
-            parseError("expected '=' after field name");
-        lex_.next(); // consume '='
-        ExprPtr val = parseConditional();
-        FieldAssignStmt s;
-        auto obj = std::make_unique<ExprNode>();
-        obj->data = VariableExpr{first.value};
-        obj->loc = locFromToken(first);
-        s.object = std::move(obj);
-        s.field = fieldTok.value;
-        s.value = std::move(val);
-        s.loc = locFromToken(first);
-        return s;
+        // Build `ident.field` as the chain base and continue parsing any
+        // further postfix hops (`.a`, `[i]`, etc.) to support chained LHS
+        // forms like `rec.field[i] = v`, `rec.a.b = v`, `rec.a[i].x = v`.
+        auto varExpr = std::make_unique<ExprNode>();
+        varExpr->data = VariableExpr{first.value};
+        varExpr->loc = locFromToken(first);
+        auto fa = std::make_unique<FieldAccessExpr>();
+        fa->object = std::move(varExpr);
+        fa->field = fieldTok.value;
+        auto chain = std::make_unique<ExprNode>();
+        chain->data = std::move(fa);
+        chain->loc = locFromToken(dotTok);
+
+        chain = parsePostfixContinuation(std::move(chain));
+        return finishChainedLhs(std::move(chain), first);
     } else if (next.kind == TokenKind::Comma) {
         // Tuple destructuring: a, b = (10, 20)
         std::vector<std::string> names;

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -860,7 +860,10 @@ ExprPtr Parser::makeErrorPropagateExpr(ExprPtr operand, const Token &tok) {
 }
 
 ExprPtr Parser::parsePostfix() {
-    ExprPtr expr = parsePrimary();
+    return parsePostfixContinuation(parsePrimary());
+}
+
+ExprPtr Parser::parsePostfixContinuation(ExprPtr expr) {
     while (lex_.peek().kind == TokenKind::Dot || lex_.peek().kind == TokenKind::LBracket ||
            lex_.peek().kind == TokenKind::BangBang || lex_.peek().kind == TokenKind::Question) {
         if (lex_.peek().kind == TokenKind::Question) {

--- a/tests/spec/chained_lhs_assign.test.ry
+++ b/tests/spec/chained_lhs_assign.test.ry
@@ -1,0 +1,226 @@
+# Issue #812: chained LHS (list[i].field, record.field[i], list[i][j], etc.)
+# and compound assignment on indexed/field targets.
+#
+# This file must fail to parse on the v0.0.8 baseline and fully pass after the
+# fix lands. Error-path cases (immutable/const, rvalue LHS, missing map key
+# compound) live in C++ tests, not here.
+
+record LhsPoint:
+  x: int
+  y: int
+
+record LhsBox:
+  items: List<int>
+  label: str
+
+record LhsMapBox:
+  m: Map<str, int>
+
+record LhsInner:
+  val: int
+
+record LhsOuter:
+  inner: LhsInner
+  tag: str
+
+record LhsDeep:
+  a: LhsOuter
+
+record LhsDeepBox:
+  out: LhsBox
+
+# Module-level counter for side-effect guards. Written from top-level
+# function per #817 pattern.
+chained_lhs_fcalls: int = 0
+
+function chained_lhs_reset_counter() -> int:
+  chained_lhs_fcalls = 0
+  return 0
+
+function chained_lhs_fidx() -> int:
+  chained_lhs_fcalls = chained_lhs_fcalls + 1
+  return 0
+
+describe("chained LHS plain assign", ():
+  it("list[i].field = v", ():
+    pts = [LhsPoint(1, 2), LhsPoint(3, 4)]
+    pts[0].x = 99
+    expect(pts[0].x).to_eq(99)
+    expect(pts[0].y).to_eq(2)
+    expect(pts[1].x).to_eq(3)
+  )
+
+  it("map[k].field = v", ():
+    m = {"a": LhsPoint(1, 2), "b": LhsPoint(3, 4)}
+    m["a"].y = 42
+    expect(m["a"].y).to_eq(42)
+    expect(m["a"].x).to_eq(1)
+    expect(m["b"].y).to_eq(4)
+  )
+
+  it("record.field[i] = v with List field", ():
+    b = LhsBox([10, 20, 30], "things")
+    b.items[1] = 99
+    expect(b.items[0]).to_eq(10)
+    expect(b.items[1]).to_eq(99)
+    expect(b.items[2]).to_eq(30)
+    expect(b.label).to_eq("things")
+  )
+
+  it("record.field[k] = v with Map field", ():
+    mb = LhsMapBox({"a": 1, "b": 2})
+    mb.m["a"] = 99
+    expect(mb.m["a"]).to_eq(99)
+    expect(mb.m["b"]).to_eq(2)
+  )
+
+  it("list[i][j] = v with nested list", ():
+    grid = [[1, 2], [3, 4]]
+    grid[0][1] = 99
+    expect(grid[0][0]).to_eq(1)
+    expect(grid[0][1]).to_eq(99)
+    expect(grid[1][0]).to_eq(3)
+    expect(grid[1][1]).to_eq(4)
+  )
+
+  it("map[k1][k2] = v with nested map", ():
+    m: Map<str, Map<str, int>> = {"a": {"x": 1}, "b": {"x": 2}}
+    m["a"]["x"] = 99
+    expect(m["a"]["x"]).to_eq(99)
+    expect(m["b"]["x"]).to_eq(2)
+  )
+
+  it("list[i][j].field = v (mixed chain)", ():
+    grid = [[LhsPoint(1, 2), LhsPoint(3, 4)]]
+    grid[0][1].x = 99
+    expect(grid[0][1].x).to_eq(99)
+    expect(grid[0][1].y).to_eq(4)
+    expect(grid[0][0].x).to_eq(1)
+  )
+
+  it("record.a.b = v (nested record)", ():
+    d = LhsOuter(LhsInner(1), "tag")
+    d.inner.val = 99
+    expect(d.inner.val).to_eq(99)
+    expect(d.tag).to_eq("tag")
+  )
+
+  it("record.a.b.c = v (deep nested record)", ():
+    d = LhsDeep(LhsOuter(LhsInner(1), "t"))
+    d.a.inner.val = 99
+    expect(d.a.inner.val).to_eq(99)
+    expect(d.a.tag).to_eq("t")
+  )
+
+  it("record.a.b.c[i] = v (deep mixed)", ():
+    d = LhsDeepBox(LhsBox([1, 2, 3], "x"))
+    d.out.items[2] = 99
+    expect(d.out.items[0]).to_eq(1)
+    expect(d.out.items[2]).to_eq(99)
+    expect(d.out.label).to_eq("x")
+  )
+)
+
+describe("chained LHS compound assign", ():
+  it("list[i] += v", ():
+    xs = [1, 2, 3]
+    xs[0] += 10
+    expect(xs[0]).to_eq(11)
+    expect(xs[1]).to_eq(2)
+  )
+
+  it("map[k] += v", ():
+    m = {"a": 1, "b": 2}
+    m["a"] += 10
+    expect(m["a"]).to_eq(11)
+    expect(m["b"]).to_eq(2)
+  )
+
+  it("record.field += v (regression guard)", ():
+    p = LhsPoint(1, 2)
+    p.x += 100
+    expect(p.x).to_eq(101)
+    expect(p.y).to_eq(2)
+  )
+
+  it("list[i].field += v", ():
+    pts = [LhsPoint(1, 2), LhsPoint(3, 4)]
+    pts[0].x += 10
+    expect(pts[0].x).to_eq(11)
+    expect(pts[1].x).to_eq(3)
+  )
+
+  it("record.field[i] += v", ():
+    b = LhsBox([10, 20, 30], "x")
+    b.items[1] += 5
+    expect(b.items[1]).to_eq(25)
+    expect(b.items[0]).to_eq(10)
+  )
+
+  it("list[i] -= v", ():
+    xs = [10, 20, 30]
+    xs[0] -= 3
+    expect(xs[0]).to_eq(7)
+  )
+
+  it("list[i] *= v", ():
+    xs = [1, 2, 3]
+    xs[1] *= 4
+    expect(xs[1]).to_eq(8)
+  )
+
+  it("list[i] //= v", ():
+    xs = [7, 20, 30]
+    xs[0] //= 2
+    expect(xs[0]).to_eq(3)
+  )
+
+  it("list[i] %= v", ():
+    xs = [10, 20, 30]
+    xs[1] %= 7
+    expect(xs[1]).to_eq(6)
+  )
+)
+
+describe("chained LHS negative index", ():
+  it("xs[-1] = v (regression)", ():
+    xs = [1, 2, 3]
+    xs[-1] = 99
+    expect(xs[2]).to_eq(99)
+    expect(xs[0]).to_eq(1)
+  )
+
+  it("xs[-1].field = v", ():
+    pts = [LhsPoint(1, 2), LhsPoint(3, 4)]
+    pts[-1].x = 99
+    expect(pts[1].x).to_eq(99)
+    expect(pts[0].x).to_eq(1)
+  )
+
+  it("xs[i][-1] = v", ():
+    grid = [[1, 2], [3, 4]]
+    grid[0][-1] = 99
+    expect(grid[0][1]).to_eq(99)
+    expect(grid[0][0]).to_eq(1)
+  )
+)
+
+describe("chained LHS side-effect guards", ():
+  it("grid[fidx()][fidx()] = v evaluates indices once each", ():
+    chained_lhs_reset_counter()
+    grid = [[1, 2], [3, 4]]
+    grid[chained_lhs_fidx()][chained_lhs_fidx()] = 99
+    expect(chained_lhs_fcalls).to_eq(2)
+    expect(grid[0][0]).to_eq(99)
+    expect(grid[0][1]).to_eq(2)
+  )
+
+  it("xs[fidx()] += v evaluates index once", ():
+    chained_lhs_reset_counter()
+    xs = [10, 20, 30]
+    xs[chained_lhs_fidx()] += 5
+    expect(chained_lhs_fcalls).to_eq(1)
+    expect(xs[0]).to_eq(15)
+    expect(xs[1]).to_eq(20)
+  )
+)

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2175,3 +2175,78 @@ TEST(ParserTest, IdentifierStartingWithENotStolen) {
     // Regression guard: `1exp` must not swallow `e` as an exponent.
     EXPECT_THROW(parseStr("x = 1exp"), std::runtime_error);
 }
+
+// ===== Chained LHS assignment (#812) =====
+
+TEST(ParserTest, ChainedLhsListFieldAssign) {
+    // `list[i].field = v` parses as FieldAssignStmt with IndexExpr object.
+    Program prog = parseStr("pts[0].x = 99");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<FieldAssignStmt>(prog[0]));
+    const auto &s = std::get<FieldAssignStmt>(prog[0]);
+    EXPECT_EQ(s.field, "x");
+    EXPECT_FALSE(s.compound_op.has_value());
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<IndexExpr>>(s.object->data));
+}
+
+TEST(ParserTest, ChainedLhsRecordFieldListAssign) {
+    // `record.field[i] = v` parses as IndexAssignStmt with FieldAccessExpr object.
+    Program prog = parseStr("b.items[1] = 99");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<IndexAssignStmt>(prog[0]));
+    const auto &s = std::get<IndexAssignStmt>(prog[0]);
+    ASSERT_EQ(s.indices.size(), 1u);
+    EXPECT_FALSE(s.compound_op.has_value());
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(s.object->data));
+}
+
+TEST(ParserTest, ChainedLhsNestedListAssign) {
+    // `grid[0][1] = 99` parses as IndexAssignStmt with IndexExpr object.
+    Program prog = parseStr("grid[0][1] = 99");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<IndexAssignStmt>(prog[0]));
+    const auto &s = std::get<IndexAssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<IndexExpr>>(s.object->data));
+}
+
+TEST(ParserTest, ChainedLhsDeepFieldAssign) {
+    // `d.a.inner.val = 99` parses as FieldAssignStmt with FieldAccessExpr object.
+    Program prog = parseStr("d.a.inner.val = 99");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<FieldAssignStmt>(prog[0]));
+    const auto &s = std::get<FieldAssignStmt>(prog[0]);
+    EXPECT_EQ(s.field, "val");
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(s.object->data));
+}
+
+TEST(ParserTest, ChainedLhsIndexCompoundAssign) {
+    // `xs[0] += 10` sets compound_op = "+".
+    Program prog = parseStr("xs[0] += 10");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<IndexAssignStmt>(prog[0]));
+    const auto &s = std::get<IndexAssignStmt>(prog[0]);
+    ASSERT_TRUE(s.compound_op.has_value());
+    EXPECT_EQ(*s.compound_op, "+");
+}
+
+TEST(ParserTest, ChainedLhsFieldCompoundAssign) {
+    // `pts[0].x -= 5` on a list-of-records sets compound_op = "-".
+    Program prog = parseStr("pts[0].x -= 5");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<FieldAssignStmt>(prog[0]));
+    const auto &s = std::get<FieldAssignStmt>(prog[0]);
+    ASSERT_TRUE(s.compound_op.has_value());
+    EXPECT_EQ(*s.compound_op, "-");
+}
+
+TEST(ParserTest, ChainedLhsIndexMissingEqualsThrows) {
+    // Preserving the old strict error: a chain ending in `[i]` without an
+    // assignment operator must still raise "expected '=' after index
+    // expression" rather than silently becoming an expression statement.
+    EXPECT_THROW(parseStr("xs[0]\n"), std::runtime_error);
+}
+
+TEST(ParserTest, ChainedLhsFieldMissingEqualsThrows) {
+    // Same guard for field chains without an assignment operator.
+    EXPECT_THROW(parseStr("rec.field\n"), std::runtime_error);
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2239,6 +2239,30 @@ TEST(ParserTest, ChainedLhsFieldCompoundAssign) {
     EXPECT_EQ(*s.compound_op, "-");
 }
 
+TEST(ParserTest, ChainedLhsIndexPostfixIncrement) {
+    // `xs[0]++` on a list element desugars to compound_op = "+" with rhs = 1.
+    Program prog = parseStr("xs[0]++");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<IndexAssignStmt>(prog[0]));
+    const auto &s = std::get<IndexAssignStmt>(prog[0]);
+    ASSERT_TRUE(s.compound_op.has_value());
+    EXPECT_EQ(*s.compound_op, "+");
+    ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.value->data));
+    EXPECT_EQ(std::get<NumberExpr>(s.value->data).value, 1);
+}
+
+TEST(ParserTest, ChainedLhsFieldPostfixDecrement) {
+    // `pts[0].x--` on a list-of-records desugars to compound_op = "-" with rhs = 1.
+    Program prog = parseStr("pts[0].x--");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<FieldAssignStmt>(prog[0]));
+    const auto &s = std::get<FieldAssignStmt>(prog[0]);
+    ASSERT_TRUE(s.compound_op.has_value());
+    EXPECT_EQ(*s.compound_op, "-");
+    ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.value->data));
+    EXPECT_EQ(std::get<NumberExpr>(s.value->data).value, 1);
+}
+
 TEST(ParserTest, ChainedLhsIndexMissingEqualsThrows) {
     // Preserving the old strict error: a chain ending in `[i]` without an
     // assignment operator must still raise "expected '=' after index


### PR DESCRIPTION
## Summary

Closes #812. Previously the parser only recognized 1-hop assignment targets (`x = v`, `x[i] = v`, `x.f = v`) and rejected any chained form with "expected '=' after index expression" / "expected '=' after field name", making mutable collections and records impractical to update in place. This PR generalizes the assignment dispatcher and codegen to accept arbitrarily chained LHS forms.

- **Parser**: Split `parsePostfix` into `parsePrimary + parsePostfixContinuation`, reused from the statement-level LHS dispatcher. `parseStatement` now builds a postfix chain starting from a synthetic `VariableExpr` base and hands it to the new `finishChainedLhs` helper, which inspects the tail (`IndexExpr` / `FieldAccessExpr`) and emits the right `*AssignStmt` variant, with `compound_op` set for `+=` / `-=` / ... forms. The 1-hop UFCS call-statement path (`ident.method(args)`) is preserved.
- **AST**: Added ` std::optional<std::string> compound_op` to `IndexAssignStmt` and `FieldAssignStmt`.
- **Codegen**: Extracted `applyCompoundOp` so local `AssignStmt`, module-global write-through, and all chained forms share one operator resolution path (user-defined `operator+=` → user-defined `operator+` → built-in). Generalized `emitStmt(FieldAssignStmt&)` / `emitStmt(IndexAssignStmt&)` to dispatch on object shape:
  * `VariableExpr` → existing alloca path
  * `FieldAccessExpr` → new `writeBackFieldChain` walks the record chain back to the root alloca via a sequence of `InsertValue`s (records are SSA struct values, not pointers)
  * `IndexExpr` → resolve container, GEP to element slot, read-modify-write the struct in place
  Compound ops are expanded in codegen (not via parser-level desugar) so each index expression is evaluated exactly once.
- **Shallow CoW**: chained writes through nested collections (`grid[i][j] = v`, `rec.items[i] = v`) anchor CoW only on the outermost alloca. Deep CoW / aliasing semantics are tracked as follow-up in #854. Pre-existing ARC leak on overwritten collection elements is tracked as #855.
- **Runtime semantics**: compound assignment to a missing map key (`m["absent"] += 1`) is now a runtime error rather than silently inserting a default.
- **Docs**: updated `docs/reference/collections.md` (new chained index/field section + CoW caveat), `docs/reference/structs.md` (deep field assignment), `docs/reference/operators.md` (compound on lvalues), `README.md` (sample).
- **KNOWLEDGE.md**: added entries for the postfix reuse pattern, record SSA semantics, no-parser-desugar rule, and shallow nested CoW caveat.

## Matrix

All of the following now parse, codegen, and execute correctly:

| Shape | Example |
|---|---|
| list-of-records field | \`pts[0].x = 99\` |
| map-of-records field | \`m[\"a\"].y = 42\` |
| record.list index | \`b.items[1] = 99\` |
| record.map index | \`mb.m[\"a\"] = 99\` |
| nested list | \`grid[0][1] = 99\` |
| nested map | \`m[\"a\"][\"x\"] = 99\` |
| mixed | \`grid[0][1].x = 99\` |
| nested record | \`d.inner.val = 99\` |
| deep nested record | \`d.a.inner.val = 99\` |
| deep mixed | \`d.out.items[2] = 99\` |
| compound on chain | \`pts[0].x += 10\`, \`b.items[1] *= 5\` |
| negative index chain | \`pts[-1].x = 99\` |

Side-effect ordering is guaranteed: \`a[f()][g()] = v\` evaluates \`f()\` and \`g()\` exactly once; \`xs[f()] += 1\` evaluates \`f()\` exactly once.

## Test plan

- [x] Add failing spec \`tests/spec/chained_lhs_assign.test.ry\` (24 cases) first to establish red baseline
- [x] Add parser unit tests for chained LHS AST shape and compound_op propagation (\`ParserTest.ChainedLhs*\`, 8 cases)
- [x] \`./build/ry_tests\` — 1574 passed
- [x] \`./build/ry test -p\` — 106 spec files, 0 failures
- [x] \`cmake --preset asan && ./build-asan/ry_tests\` — 1573 passed, no ASan findings
- [x] \`./build-asan/ry test -p\` — 106 spec files, 0 failures
- [x] Manual walk of the chain matrix above, including side-effect counter tests
- [x] Manual verification that existing \`collections.test.ry\`, \`structs.test.ry\`, \`record_field_index.test.ry\`, \`bounds_check.test.ry\`, \`expr_stmt.test.ry\` still pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chained and compound assignment now supported on nested targets (e.g., list[index].field += v); compound ops evaluate each index expression exactly once.

* **Bug Fixes**
  * Resolved parse errors and incorrect behaviors for chained/indexed/field assignment and compound forms; missing map-key compound ops now raise a runtime error.

* **Documentation**
  * Expanded docs and samples explaining chained LHS, shallow copy-on-write semantics, and compound-assignment evaluation.

* **Tests**
  * Added comprehensive tests covering chained and compound assignment scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->