### PR TITLE
feat: extend ? and ?? operators for Option/Result and top-level (#745, #795, #796)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -269,6 +269,39 @@ last thing in its basic block must either be followed by a new block
 creation + `SetInsertPoint`, or the caller loop must break on
 `GetInsertBlock()->getTerminator()`.
 
+### emitRuntimeError terminates its block; callers must pre-split to continue
+
+**Source**: #745/#795/#796 implementation (2026-04-11)
+**Tags**: codegen, runtime-error, unreachable, branch, control-flow
+
+**Context**: `CodeGen::emitRuntimeError` (`src/codegen_call_user.cpp:600-618`)
+emits `fprintf(stderr, ...)` → `call exit(1)` → `CreateUnreachable`. Unlike
+`emitExit`, it does **not** switch to a fresh dead block afterwards. If the
+caller still wants to continue emitting IR along a happy path, the split
+must be done **before** the call:
+
+```cpp
+llvm::BasicBlock *okBB  = llvm::BasicBlock::Create(*ctx_, "foo.ok",  fn_);
+llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, "foo.err", fn_);
+builder_.CreateCondBr(cond, okBB, errBB);
+
+builder_.SetInsertPoint(errBB);
+emitRuntimeError("error: %s\n", ".foo_err", {msgPtr});
+// errBB is now terminated by `unreachable` — do NOT keep emitting here.
+
+builder_.SetInsertPoint(okBB);  // continue happy path here
+```
+
+Callers that just dump `emitRuntimeError` into the current block without
+creating a separate happy-path block will lose any IR they emit afterward
+(it gets attached to a block that already ends in `unreachable`, which LLVM
+verify rejects).
+
+**Rule**: Treat `emitRuntimeError` like `CreateRet` / `CreateBr` — the call
+site owns the basic-block split. See `emitIntZeroDivGuard`
+(`src/codegen_call_user.cpp:625-636`) and the top-level `?` path in
+`emitExprVariant(ErrorPropagateExpr)` for canonical examples.
+
 ### Dual-path builtins must share terminator / cleanup handling
 
 **Source**: #821 sweep (2026-04-10)

--- a/changelog.d/745-795-796-error-propagate.md
+++ b/changelog.d/745-795-796-error-propagate.md
@@ -1,0 +1,9 @@
+### Added
+
+- `?` operator now accepts `Option<T>` operands in addition to `Result<T, E>`. When used on a `Some(v)` it evaluates to `v`; when used on a `None` the enclosing function returns `None` early. The enclosing function must declare an `Option` return type. `!!` is an alias with identical semantics. (#795)
+- `??` operator now accepts `Result<T, E>` on the left-hand side in addition to `Option<T>`. For `Ok(v)` it evaluates to `v`; for `Err(_)` it evaluates to the right-hand default (the error value is discarded). (#796)
+- `?` / `!!` can now be used directly at the top level of a script. When the operand is `Err(e)` or `None`, the error message is written to stderr and the process exits with status `1`. `__ry_main__`'s existing return-type contract is unchanged. (#745)
+
+### Changed
+
+- Error messages for `?` and `??` operator misuse now mention both `Option` and `Result` in the offending context.

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -118,11 +118,17 @@ shifted = 1 << 8          # 256
 
 ## Error Propagation Operator (`?` / `!!`)
 
-The postfix `?` operator unwraps a `Result` value. If the value is `Ok(v)`, it evaluates to `v`. If the value is `Err(e)`, the enclosing function immediately returns `Err(e)`.
+The postfix `?` operator unwraps a `Result` or `Option` value on the happy path and short-circuits on the unhappy path. The `!!` operator is an alias for `?` with identical semantics.
 
-The `!!` operator is an alias for `?` with identical semantics. Both can be used interchangeably.
+| Operand | Happy path | Unhappy path |
+|---|---|---|
+| `Result<T, E>` | evaluates to the `Ok` inner value `v` | the enclosing function returns `Err(e)` |
+| `Option<T>` | evaluates to the `Some` inner value `v` | the enclosing function returns `None` |
 
-The enclosing function must have a `Result` return type.
+When used inside a function, the operand type must match the enclosing function's return type:
+
+- `?` on a `Result` value requires the enclosing function to return `Result`.
+- `?` on an `Option` value requires the enclosing function to return `Option`.
 
 ```python
 function safe_divide(a: int, b: int) -> Result<int, Error>:
@@ -134,22 +140,33 @@ function compute(a: int, b: int, c: int) -> Result<int, Error>:
     x = safe_divide(a, b)?    # returns Err early if b == 0
     y = safe_divide(x, c)!!
     return Ok(y + 1)
+
+function safe_get(xs: List<int>, i: int) -> Option<int>:
+    if i < 0 or i >= xs.length():
+        return none
+    return Some(xs[i])
+
+function first_plus_second(xs: List<int>) -> Option<int>:
+    a = safe_get(xs, 0)?    # returns None early if out of range
+    b = safe_get(xs, 1)?
+    return Some(a + b)
 ```
 
-This is equivalent to the following `match` pattern, but much more concise:
+### At the top level
+
+`?` and `!!` can also be used directly at the top level of a script. There, `Err(e)` and `None` are treated as fatal errors: the error message is written to stderr and the process exits with status `1`.
 
 ```python
-function compute(a: int, b: int, c: int) -> Result<int, Error>:
-    match safe_divide(a, b):
-        case Ok(x):
-            match safe_divide(x, c):
-                case Ok(y):
-                    return Ok(y + 1)
-                case Err(e):
-                    return Err(e)
-        case Err(e):
-            return Err(e)
+function mk() -> Result<int, Error>:
+    return Err(Error("something broke"))
+
+v = mk()?   # prints "error: something broke" to stderr and exits with 1
+
+x: int? = none
+y = x?      # prints "error: unexpected None" to stderr and exits with 1
 ```
+
+At the top level, a `Result`'s `Err` type must be `Error` (so its `message` field can be printed).
 
 ---
 
@@ -199,10 +216,19 @@ The result is a `List<int>` containing all integers from the left operand to the
 ## Null Coalescing Operator (`??`)
 
 ```python
-x = option_val ?? default_val
+x = optional_val ?? default_val
 ```
 
-If `option_val` is `Some(v)`, returns `v`. Otherwise returns `default_val`. The right-hand operand must have the same type as the inner type of the Option.
+The `??` operator accepts either an `Option<T>` or a `Result<T, E>` on the left-hand side:
+
+| Left-hand side | Result |
+|---|---|
+| `Some(v)` | `v` |
+| `None` | `default_val` |
+| `Ok(v)` | `v` |
+| `Err(_)` | `default_val` (the error value is discarded) |
+
+The right-hand operand must have the same type as the `Option`'s inner type (or the `Result`'s `Ok` type).
 
 ```python
 a: int? = Some(10)
@@ -210,6 +236,12 @@ b: int? = none
 
 print(a ?? 0)    # 10
 print(b ?? 0)    # 0
+
+function parse_int(s: str) -> Result<int, Error>:
+    # ...
+
+i = parse_int("42") ?? -1      # 42 on success, -1 on Err
+j = parse_int("nope") ?? -1    # -1 — the Err value is discarded
 ```
 
 ---

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1263,16 +1263,28 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
     }
 
     // Null coalescing operator: lhs ?? rhs
+    // Accepts Option<T> or Result<T, E> on the left side. In either case the
+    // struct's tag lives at index 0 (Some=1 / Ok=1, None=0 / Err=0) and the
+    // happy-path value lives at index 1. This lets us share one CreateSelect
+    // for both cases.
     if (e->op == "??") {
         llvm::Value *lhs = emitExpr(*e->lhs);
-        if (!isOptionType(lhs->getType()))
-            codegenError("'" "??" "' operator requires Option type on the left side");
-        llvm::Value *hasVal = builder_.CreateExtractValue(lhs, {0}, "has_val");
-        llvm::Value *innerVal = builder_.CreateExtractValue(lhs, {1}, "inner_val");
+        llvm::Type *lhsTy = lhs->getType();
+        bool lhsIsOption = isOptionType(lhsTy);
+        bool lhsIsResult = isResultType(lhsTy);
+        if (!lhsIsOption && !lhsIsResult)
+            codegenError("'" "??" "' operator requires Option or Result type on the left side");
+        llvm::Value *tag = builder_.CreateExtractValue(
+            lhs, {0}, lhsIsOption ? "has_val" : "is_ok");
+        llvm::Value *happyVal = builder_.CreateExtractValue(
+            lhs, {1}, lhsIsOption ? "inner_val" : "ok_val");
         llvm::Value *rhs = emitExpr(*e->rhs);
-        if (rhs->getType() != innerVal->getType())
-            codegenError("'" "??" "' operator: right-hand side type must match Option's inner type");
-        return builder_.CreateSelect(hasVal, innerVal, rhs, "coalesce");
+        if (rhs->getType() != happyVal->getType()) {
+            codegenError(lhsIsOption
+                ? "'" "??" "' operator: right-hand side type must match Option's inner type"
+                : "'" "??" "' operator: right-hand side type must match Result's Ok type");
+        }
+        return builder_.CreateSelect(tag, happyVal, rhs, "coalesce");
     }
 
     llvm::Value *lhs = emitExpr(*e->lhs);
@@ -1367,43 +1379,127 @@ llvm::Value *CodeGen::emitExprVariant(const NoneExpr &) {
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ErrorPropagateExpr> &e) {
     llvm::Value *operandVal = emitExpr(*e->operand);
     llvm::Type *operandTy = operandVal->getType();
-    if (!isResultType(operandTy))
-        codegenError("'?' operator requires a Result type operand");
+    bool operandIsResult = isResultType(operandTy);
+    bool operandIsOption = isOptionType(operandTy);
+    if (!operandIsResult && !operandIsOption)
+        codegenError("'?' operator requires a Result or Option type operand");
+
+    // At the top level (inside __ry_main__), `?` desugars to "print the error
+    // to stderr and exit(1)" on the unhappy path. See #745. We detect this by
+    // inspecting the enclosing LLVM function name; __ry_main__'s return type
+    // (i32, for the process exit code) is intentionally left unchanged so the
+    // existing test_summary / outline / CreateRet(0) paths keep working.
+    bool topLevel = fn_ && fn_->getName() == "__ry_main__";
+
+    if (topLevel) {
+        if (operandIsResult) {
+            llvm::StructType *operandResultTy =
+                llvm::cast<llvm::StructType>(operandTy);
+            llvm::Type *operandErrTy = operandResultTy->getElementType(2);
+            if (operandErrTy != errorTy_)
+                codegenError("'?' at top level: Result err type must be Error");
+
+            llvm::Value *isOk =
+                builder_.CreateExtractValue(operandVal, 0, "is_ok");
+            llvm::BasicBlock *okBB =
+                llvm::BasicBlock::Create(*ctx_, "try.top.ok", fn_);
+            llvm::BasicBlock *errBB =
+                llvm::BasicBlock::Create(*ctx_, "try.top.err", fn_);
+            builder_.CreateCondBr(isOk, okBB, errBB);
+
+            builder_.SetInsertPoint(errBB);
+            llvm::Value *errVal =
+                builder_.CreateExtractValue(operandVal, 2, "err_val");
+            llvm::Value *msgPtr =
+                builder_.CreateExtractValue(errVal, 0, "err_msg_ptr");
+            emitRuntimeError("error: %s\n", ".top_ep_err_msg", {msgPtr});
+
+            builder_.SetInsertPoint(okBB);
+            llvm::Value *okVal =
+                builder_.CreateExtractValue(operandVal, 1, "ok_val");
+            propagateMeta(operandVal, okVal);
+            return okVal;
+        }
+
+        // Option operand at the top level: None aborts with a fixed message.
+        llvm::Value *hasVal =
+            builder_.CreateExtractValue(operandVal, 0, "has_val");
+        llvm::BasicBlock *someBB =
+            llvm::BasicBlock::Create(*ctx_, "try.top.some", fn_);
+        llvm::BasicBlock *noneBB =
+            llvm::BasicBlock::Create(*ctx_, "try.top.none", fn_);
+        builder_.CreateCondBr(hasVal, someBB, noneBB);
+
+        builder_.SetInsertPoint(noneBB);
+        emitRuntimeError("error: unexpected None\n", ".top_ep_none");
+
+        builder_.SetInsertPoint(someBB);
+        llvm::Value *someVal =
+            builder_.CreateExtractValue(operandVal, 1, "some_val");
+        propagateMeta(operandVal, someVal);
+        return someVal;
+    }
 
     llvm::Type *fnRetTy = fn_->getReturnType();
-    if (!isResultType(fnRetTy))
-        codegenError("'?' operator can only be used in a function that returns Result");
 
-    llvm::StructType *operandResultTy = llvm::cast<llvm::StructType>(operandTy);
-    llvm::StructType *retResultTy = llvm::cast<llvm::StructType>(fnRetTy);
-    llvm::Type *operandErrTy = operandResultTy->getElementType(2);
-    llvm::Type *retErrTy = retResultTy->getElementType(2);
+    if (operandIsResult) {
+        if (!isResultType(fnRetTy))
+            codegenError("'?' on Result can only be used in a function that returns Result");
 
-    llvm::Value *isOk = builder_.CreateExtractValue(operandVal, 0, "is_ok");
-    llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "try.ok", fn_);
-    llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, "try.err", fn_);
-    builder_.CreateCondBr(isOk, okBB, errBB);
+        llvm::StructType *operandResultTy = llvm::cast<llvm::StructType>(operandTy);
+        llvm::StructType *retResultTy = llvm::cast<llvm::StructType>(fnRetTy);
+        llvm::Type *operandErrTy = operandResultTy->getElementType(2);
+        llvm::Type *retErrTy = retResultTy->getElementType(2);
 
-    // Err path: extract error, wrap in function return type, return
-    builder_.SetInsertPoint(errBB);
-    llvm::Value *errVal = builder_.CreateExtractValue(operandVal, 2, "err_val");
-    if (operandErrTy != retErrTy) {
-        if (auto *sliced = tryEmitSubtypeCoerce(errVal, retErrTy))
-            errVal = sliced;
-        else
-            codegenError("'?' operator error type mismatch: operand and function return different error types");
+        llvm::Value *isOk = builder_.CreateExtractValue(operandVal, 0, "is_ok");
+        llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "try.ok", fn_);
+        llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, "try.err", fn_);
+        builder_.CreateCondBr(isOk, okBB, errBB);
+
+        // Err path: extract error, wrap in function return type, return
+        builder_.SetInsertPoint(errBB);
+        llvm::Value *errVal = builder_.CreateExtractValue(operandVal, 2, "err_val");
+        if (operandErrTy != retErrTy) {
+            if (auto *sliced = tryEmitSubtypeCoerce(errVal, retErrTy))
+                errVal = sliced;
+            else
+                codegenError("'?' operator error type mismatch: operand and function return different error types");
+        }
+        llvm::Value *retErr = buildErrValue(errVal, retResultTy);
+        emitEnsureChecks(retErr);
+        tryRetainArcSource(errVal);
+        emitScopeCleanupToDepth(0);
+        builder_.CreateRet(retErr);
+
+        // Ok path: extract ok value, continue
+        builder_.SetInsertPoint(okBB);
+        llvm::Value *okVal = builder_.CreateExtractValue(operandVal, 1, "ok_val");
+        propagateMeta(operandVal, okVal);
+        return okVal;
     }
-    llvm::Value *retErr = buildErrValue(errVal, retResultTy);
-    emitEnsureChecks(retErr);
-    tryRetainArcSource(errVal);
-    emitScopeCleanupToDepth(0);
-    builder_.CreateRet(retErr);
 
-    // Ok path: extract ok value, continue
-    builder_.SetInsertPoint(okBB);
-    llvm::Value *okVal = builder_.CreateExtractValue(operandVal, 1, "ok_val");
-    propagateMeta(operandVal, okVal);
-    return okVal;
+    if (!isOptionType(fnRetTy))
+        codegenError("'?' on Option can only be used in a function that returns Option");
+
+    llvm::StructType *retOptionTy = llvm::cast<llvm::StructType>(fnRetTy);
+
+    llvm::Value *hasVal = builder_.CreateExtractValue(operandVal, 0, "has_val");
+    llvm::BasicBlock *someBB = llvm::BasicBlock::Create(*ctx_, "try.some", fn_);
+    llvm::BasicBlock *noneBB = llvm::BasicBlock::Create(*ctx_, "try.none", fn_);
+    builder_.CreateCondBr(hasVal, someBB, noneBB);
+
+    // None path: return None in the enclosing function's Option type.
+    builder_.SetInsertPoint(noneBB);
+    llvm::Value *retNone = buildNoneValue(retOptionTy);
+    emitEnsureChecks(retNone);
+    emitScopeCleanupToDepth(0);
+    builder_.CreateRet(retNone);
+
+    // Some path: extract inner value, continue.
+    builder_.SetInsertPoint(someBB);
+    llvm::Value *someVal = builder_.CreateExtractValue(operandVal, 1, "some_val");
+    propagateMeta(operandVal, someVal);
+    return someVal;
 }
 
 llvm::Value *CodeGen::emitTaskWait(llvm::Value *taskVal, const char *runtimeFn, const char *label) {

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1278,12 +1278,15 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
             lhs, {0}, lhsIsOption ? "has_val" : "is_ok");
         llvm::Value *happyVal = builder_.CreateExtractValue(
             lhs, {1}, lhsIsOption ? "inner_val" : "ok_val");
+        // Carry metadata (list_elem_type_name, map_key_type_name, etc.) from
+        // the Option/Result wrapper down to the extracted inner value so the
+        // downstream type check can tell e.g. `List<int>` from `str` — both
+        // are backed by `ptrTy_`, so raw LLVM-type equality is not enough.
+        propagateMeta(lhs, happyVal);
         llvm::Value *rhs = emitExpr(*e->rhs);
-        if (rhs->getType() != happyVal->getType()) {
-            codegenError(lhsIsOption
-                ? "'" "??" "' operator: right-hand side type must match Option's inner type"
-                : "'" "??" "' operator: right-hand side type must match Result's Ok type");
-        }
+        validateBranchTypes(happyVal, rhs,
+            lhsIsOption ? "'" "??" "' on Option"
+                        : "'" "??" "' on Result");
         return builder_.CreateSelect(tag, happyVal, rhs, "coalesce");
     }
 

--- a/tests/spec/operators.test.ry
+++ b/tests/spec/operators.test.ry
@@ -1,3 +1,8 @@
+function make_int_result(ok: bool, v: int, msg: str) -> Result<int, Error>:
+  if ok:
+    return Ok(v)
+  return Err(Error(msg))
+
 describe("arithmetic", ():
   it("should add integers", ():
     expect(1 + 2).to_eq(3)
@@ -275,6 +280,18 @@ describe("null coalescing", ():
   it("should recognize Some(0) as not None", ():
     c: int? = Some(0)
     expect(c ?? 99).to_eq(0)
+  )
+  it("should return Ok value with ?? on Result", ():
+    r = make_int_result(true, 42, "")
+    expect(r ?? 0).to_eq(42)
+  )
+  it("should return default for Err with ?? on Result", ():
+    r = make_int_result(false, 0, "boom")
+    expect(r ?? -1).to_eq(-1)
+  )
+  it("should recognize Ok(0) as not Err", ():
+    r = make_int_result(true, 0, "")
+    expect(r ?? 99).to_eq(0)
   )
 )
 

--- a/tests/spec/option_propagate.test.ry
+++ b/tests/spec/option_propagate.test.ry
@@ -1,0 +1,62 @@
+function safe_get(xs: List<int>, i: int) -> Option<int>:
+  if i < 0 or i >= xs.length():
+    return none
+  return Some(xs[i])
+
+function first_plus_second(xs: List<int>) -> Option<int>:
+  a = safe_get(xs, 0)?
+  b = safe_get(xs, 1)?
+  return Some(a + b)
+
+function first_plus_second_bang(xs: List<int>) -> Option<int>:
+  a = safe_get(xs, 0)!!
+  b = safe_get(xs, 1)!!
+  return Some(a + b)
+
+function inline_expr(xs: List<int>) -> Option<int>:
+  return Some(safe_get(xs, 0)? + 1)
+
+describe("Option error propagation", ():
+  it("should unwrap Some value with ?", ():
+    match first_plus_second([10, 20, 30]):
+      case Some(v):
+        expect(v).to_eq(30)
+      case None:
+        fail("unexpected none")
+  )
+  it("should propagate None with ?", ():
+    match first_plus_second([10]):
+      case Some(v):
+        fail("expected None but got Some")
+      case None:
+        expect(true).to_eq(true)
+  )
+  it("should support !! as alias for ? on Option", ():
+    match first_plus_second_bang([1, 2]):
+      case Some(v):
+        expect(v).to_eq(3)
+      case None:
+        fail("unexpected none")
+  )
+  it("should propagate None through !!", ():
+    match first_plus_second_bang([7]):
+      case Some(v):
+        fail("expected None but got Some")
+      case None:
+        expect(true).to_eq(true)
+  )
+  it("should support ? in expression position", ():
+    match inline_expr([41]):
+      case Some(v):
+        expect(v).to_eq(42)
+      case None:
+        fail("unexpected none")
+  )
+  it("should propagate None from ? in expression position", ():
+    match inline_expr([42, -1]):
+      case Some(v):
+        expect(v).to_eq(43)
+      case None:
+        fail("unexpected none")
+  )
+)

--- a/tests/spec/option_propagate.test.ry
+++ b/tests/spec/option_propagate.test.ry
@@ -16,6 +16,11 @@ function first_plus_second_bang(xs: List<int>) -> Option<int>:
 function inline_expr(xs: List<int>) -> Option<int>:
   return Some(safe_get(xs, 0)? + 1)
 
+function inline_expr_always_none() -> Option<int>:
+  # safe_get on index 99 of a 1-element list always returns None, so the
+  # `?` inside the expression position short-circuits to `None`.
+  return Some(safe_get([1], 99)? + 1)
+
 describe("Option error propagation", ():
   it("should unwrap Some value with ?", ():
     match first_plus_second([10, 20, 30]):
@@ -53,10 +58,10 @@ describe("Option error propagation", ():
         fail("unexpected none")
   )
   it("should propagate None from ? in expression position", ():
-    match inline_expr([42, -1]):
+    match inline_expr_always_none():
       case Some(v):
-        expect(v).to_eq(43)
+        fail("expected None but got Some")
       case None:
-        fail("unexpected none")
+        expect(true).to_eq(true)
   )
 )

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -340,6 +340,54 @@ TEST_F(CodeGenTest, ExitArgumentErrors) {
     EXPECT_THROW(runSource("exit(1, 2)"), std::runtime_error);
 }
 
+// ===== Top-level `?` operator tests (#745) =====
+// `?` at the top level desugars to "print error to stderr + exit(1)"
+// when the operand is Err/None; otherwise it unwraps the happy value.
+
+TEST_F(CodeGenTest, TopLevelQuestionOnResultOkContinues) {
+    EXPECT_EQ(runSource(
+        "function mk() -> Result<int, Error>:\n"
+        "  return Ok(42)\n"
+        "v = mk()?\n"
+        "print(v)\n"), "42\n");
+}
+
+TEST_F(CodeGenTest, TopLevelQuestionOnResultErrExits) {
+    EXPECT_EXIT(runSource(
+        "function mk() -> Result<int, Error>:\n"
+        "  return Err(Error(\"top level boom\"))\n"
+        "v = mk()?\n"
+        "print(v)\n"),
+        ::testing::ExitedWithCode(1),
+        "top level boom");
+}
+
+TEST_F(CodeGenTest, TopLevelBangBangOnResultErrExits) {
+    EXPECT_EXIT(runSource(
+        "function mk() -> Result<int, Error>:\n"
+        "  return Err(Error(\"bang bang fail\"))\n"
+        "v = mk()!!\n"
+        "print(v)\n"),
+        ::testing::ExitedWithCode(1),
+        "bang bang fail");
+}
+
+TEST_F(CodeGenTest, TopLevelQuestionOnOptionSomeContinues) {
+    EXPECT_EQ(runSource(
+        "x: int? = Some(7)\n"
+        "v = x?\n"
+        "print(v)\n"), "7\n");
+}
+
+TEST_F(CodeGenTest, TopLevelQuestionOnOptionNoneExits) {
+    EXPECT_EXIT(runSource(
+        "x: int? = none\n"
+        "v = x?\n"
+        "print(v)\n"),
+        ::testing::ExitedWithCode(1),
+        "unexpected None");
+}
+
 // ===== arguments() tests =====
 
 TEST_F(CodeGenTest, ArgumentsTests) {

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -55,7 +55,7 @@ TEST_F(CodeGenTest, NullCoalesceRhsTypeMismatchOnOption) {
     expectCompileError(
         "a: int? = Some(1)\n"
         "x = a ?? \"str\"\n",
-        "match Option's inner type");
+        "'" "??" "' on Option");
 }
 
 TEST_F(CodeGenTest, NullCoalesceRhsTypeMismatchOnResult) {
@@ -63,7 +63,18 @@ TEST_F(CodeGenTest, NullCoalesceRhsTypeMismatchOnResult) {
         "function mk() -> Result<int, Error>:\n"
         "  return Ok(1)\n"
         "x = mk() ?? \"str\"\n",
-        "match Result's Ok type");
+        "'" "??" "' on Result");
+}
+
+// Raw LLVM-type equality would wrongly accept `Result<List<int>, Error>`
+// and `str` because both are pointer-backed. The check must use Ry-level
+// metadata via `validateBranchTypes`.
+TEST_F(CodeGenTest, NullCoalesceRejectsPtrBackedTypeMismatch) {
+    expectCompileError(
+        "xs: List<int> = [1, 2, 3]\n"
+        "r: Result<List<int>, Error> = Ok(xs)\n"
+        "v = r ?? \"bad\"\n",
+        "'" "??" "' on Result");
 }
 
 // ============================================================
@@ -112,6 +123,18 @@ TEST_F(CodeGenTest, QuestionOnResultInOptionFnRejected) {
         "  v = mk()?\n"
         "  return Some(v)\n",
         "function that returns Result");
+}
+
+// ============================================================
+// Top-level `?` on `Result<_, E>` requires E == Error
+// ============================================================
+
+TEST_F(CodeGenTest, TopLevelQuestionRejectsNonErrorResult) {
+    expectCompileError(
+        "function mk() -> Result<int, str>:\n"
+        "  return Err(\"boom\")\n"
+        "v = mk()?\n",
+        "err type must be Error");
 }
 
 // ============================================================

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -41,6 +41,80 @@ TEST_F(CodeGenTest, FailOutsideTestModeIsRejected) {
 }
 
 // ============================================================
+// Null coalescing (`??`) rejects non-Option/non-Result operands
+// ============================================================
+
+TEST_F(CodeGenTest, NullCoalesceRequiresOptionOrResult) {
+    // Plain int on the LHS is not allowed.
+    expectCompileError(
+        "x = 1 ?? 0\n",
+        "Option or Result");
+}
+
+TEST_F(CodeGenTest, NullCoalesceRhsTypeMismatchOnOption) {
+    expectCompileError(
+        "a: int? = Some(1)\n"
+        "x = a ?? \"str\"\n",
+        "match Option's inner type");
+}
+
+TEST_F(CodeGenTest, NullCoalesceRhsTypeMismatchOnResult) {
+    expectCompileError(
+        "function mk() -> Result<int, Error>:\n"
+        "  return Ok(1)\n"
+        "x = mk() ?? \"str\"\n",
+        "match Result's Ok type");
+}
+
+// ============================================================
+// `?` operator rejects non-Result/non-Option operands
+// ============================================================
+
+TEST_F(CodeGenTest, QuestionRequiresResultOrOption) {
+    expectCompileError(
+        "function f() -> int:\n"
+        "  x = 1?\n"
+        "  return x\n",
+        "Result or Option");
+}
+
+// ============================================================
+// `?` on Option requires an Option-returning enclosing function
+// ============================================================
+
+TEST_F(CodeGenTest, QuestionOnOptionRequiresOptionReturn) {
+    expectCompileError(
+        "function f() -> int:\n"
+        "  a: int? = Some(1)\n"
+        "  v = a?\n"
+        "  return v\n",
+        "function that returns Option");
+}
+
+TEST_F(CodeGenTest, QuestionOnOptionInResultFnRejected) {
+    expectCompileError(
+        "function f() -> Result<int, Error>:\n"
+        "  a: int? = Some(1)\n"
+        "  v = a?\n"
+        "  return Ok(v)\n",
+        "function that returns Option");
+}
+
+// ============================================================
+// `?` on Result requires a Result-returning enclosing function
+// ============================================================
+
+TEST_F(CodeGenTest, QuestionOnResultInOptionFnRejected) {
+    expectCompileError(
+        "function mk() -> Result<int, Error>:\n"
+        "  return Ok(1)\n"
+        "function f() -> Option<int>:\n"
+        "  v = mk()?\n"
+        "  return Some(v)\n",
+        "function that returns Result");
+}
+
+// ============================================================
 // Nested function is not visible outside its enclosing scope
 // ============================================================
 


### PR DESCRIPTION
## Summary

Closes #745, #795, #796.

Resolves the long-standing asymmetry in Ry's error-propagation operators:

- **`?` on `Option<T>` (#795)** — `Some(v)` unwraps to `v`; `None` causes the enclosing function to return `None` early. The enclosing function must declare an `Option` return type. `!!` is an alias with identical semantics.
- **`??` on `Result<T, E>` (#796)** — `Ok(v)` evaluates to `v`; `Err(_)` falls through to the RHS default (the error value is discarded, matching null-coalescing semantics).
- **`?` / `!!` at the top level (#745)** — outside any user function, `Err(e)` and `None` are treated as fatal errors: the message is written to stderr and the process exits with status `1`. For top-level `?` on `Result`, the `Err` type must currently be `Error` (so its `message` field can be printed). `__ry_main__`'s existing `i32` return type is intentionally left unchanged so `test_summary` / outline / `CreateRet(0)` paths keep working.

## Implementation notes

All three paths reuse existing helpers — no new runtime functions are introduced:

- `buildNoneValue` / `buildErrValue` for wrapping early-return values
- `emitEnsureChecks` / `emitScopeCleanupToDepth` / `tryRetainArcSource` for function-exit hygiene
- `emitRuntimeError` (from `src/codegen_call_user.cpp`) for the top-level ""print-to-stderr + exit(1) + unreachable"" pattern, mirroring `emitIntZeroDivGuard`

Top-level detection is a single `fn_->getName() == ""__ry_main__""` check inside `emitExprVariant(ErrorPropagateExpr)`; the callers in the Result/Option happy path fall through to a separate ok/some block via `SetInsertPoint`, the same shape as the zero-division guard. A KNOWLEDGE.md entry captures why callers must pre-split the block before calling `emitRuntimeError`.

## Test plan

- [x] `cmake --preset default && cmake --build build && ./build/ry_tests` — 1588 tests pass
- [x] `./build/ry test -p` — 107 test files / 0 failures
- [x] `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests` — clean
- [x] `ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p` — clean
- [x] Manual stderr / exit-code verification for `?` on Err / None at top level

New regression coverage:

- `tests/spec/operators.test.ry` — 3 new cases for `??` on `Result`
- `tests/spec/option_propagate.test.ry` — 6 cases covering `?`/`!!` on `Option` (Some chaining, None propagation, inline expression)
- `tests/test_codegen_fail.cpp` — 7 rejection tests (`Option or Result` LHS check, RHS type mismatch on Option and Result, `?` requires `Result or Option`, Option-in-Result-fn and Result-in-Option-fn cross-rejection)
- `tests/test_codegen.cpp` — 5 `EXPECT_EXIT` death tests for the top-level `?` / `!!` paths

## Documentation & changelog

- `docs/reference/operators.md` — Error Propagation and Null Coalescing sections rewritten to cover both `Option` and `Result`, plus the top-level behavior.
- `changelog.d/745-795-796-error-propagate.md` — added.
- `KNOWLEDGE.md` — new entry: "`emitRuntimeError` terminates its block; callers must pre-split to continue".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `?` now unwraps both Option<T> and Result<T, E>; `!!` is added as an alias.
  * `??` accepts Result<T, E> as well as Option<T>.
  * `?`/`!!` allowed at script top-level (prints error to stderr and exits with status 1).

* **Documentation**
  * Updated operator reference, changelog, and guidance entry clarifying usage, constraints, and top-level behavior.

* **Tests**
  * Added unit and compile-fail tests covering new operator semantics and top-level behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->