### PR TITLE
fix: release overwritten ARC elements on index assignment (#855)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -445,6 +445,68 @@ a non-`VariableExpr` base (`rec.field[i] = v`, `grid[i][j] = v`), pass
 "proper" write-back through a record chain requires deep CoW and should be
 part of the follow-up.
 
+### Element-slot writes must release the overwritten ARC pointer
+
+**Source**: #855 (2026-04-11)
+**Tags**: codegen, arc, collections, index-assign, slot-overwrite
+
+**Context**: A list/map/set slot whose element type is itself an ARC-managed
+collection holds the sole owning ref to the inner allocation — `append` /
+collection-literal construction insert without retain, and the container's
+`emitArcReleaseVar` only releases the *container's* header on scope exit
+(its destructor walks elements, but only after the container itself dies).
+Therefore overwriting a slot via `list[i] = v`, `m[k] = v`, or their
+compound forms MUST load the previously-stored pointer and `emitArcRelease`
+it before storing the new one, otherwise the prior inner allocation is
+orphaned. The fix mirrors the canonical pattern in
+`src/codegen_stmt.cpp::emitStmt(AssignStmt&)` ARC branch (the retain-then-
+release-with-null-check sequence) but operates on a heap slot rather than
+an alloca-backed variable.
+
+`tryRetainArcSource` handles the retain only for two cases: a `LoadInst`
+whose pointer operand is an ARC-managed alloca, and a value already in
+`arc_owned_values_` (literals / fresh allocations). It does NOT retain for
+a `LoadInst` from a GEP (cross-slot copy `xs[i] = ys[j]`), so the slot-
+overwrite path manually retains via `emitArcGetHeaderFromData` +
+`emitArcRetain` when `tryRetainArcSource` returns false. Order matters:
+**retain new before releasing old** so self-assignment `xs[i] = xs[i]`
+cannot transiently drop the refcount to zero.
+
+**Rule**: When adding a write into any collection slot whose element is
+pointer-typed and ARC-managed, follow this sequence:
+1. Determine "is the slot's element type ARC-managed?" via
+   `elementTypeIsArcManaged(containerPtr, kind, &elemKind)` — this checks
+   the type *name*, not the LLVM type. Strings, weak refs, closures, and
+   records are intentionally excluded.
+2. For the **plain form**, retain the new value first
+   (`tryRetainArcSource`, falling back to a manual `emitArcRetain` when
+   the rhs is a Load from a GEP).
+3. Load the old slot value with a null check.
+4. Release the old value via `emitArcReleaseLoadedElement(...)` (the
+   helper handles null guard + CFG branching).
+5. Store the new value.
+6. For the **compound form** (`xs[i] += v`), reuse the `oldVal` already
+   loaded for `applyCompoundOp` rather than re-loading from the slot —
+   preserves the "evaluate index/slot exactly once" rule from #812. The
+   compound op produces a fresh ARC allocation that never aliases the
+   slot, so no retain of the new value is needed.
+
+**Verification gap**: The current self-test harness does NOT detect ARC
+leaks. ASan on macOS has no LSan; CI explicitly sets `detect_leaks=0` to
+avoid noise from existing leaks. Functional tests under
+`tests/spec/arc_release_on_index_overwrite.test.ry` exercise the fix
+paths but cannot directly assert "no leak". Wiring up CI leak detection
+is tracked separately. Until then, ARC release correctness is verified
+by code review against the canonical pattern and by absence of crashes
+under existing ASan use-after-free checks.
+
+**Out of scope (separate follow-ups)**: Records and record fields with
+ARC fields (`rec.arcField = newList`) have the same root cause — they
+also store an owning ARC pointer that must be released on overwrite —
+but live in the `FieldAssignStmt` write path which uses
+`InsertValue`/`store` of whole structs, requiring a field walker. Tracked
+separately from #855.
+
 ---
 
 ## Parser / Lexer

--- a/changelog.d/855-arc-release-on-index-overwrite.md
+++ b/changelog.d/855-arc-release-on-index-overwrite.md
@@ -1,0 +1,10 @@
+### Fixed
+
+- `list[i] = v`, `m[k] = v`, and their compound forms now release the
+  previously-held value before storing the new one when the element type
+  is itself an ARC-managed collection (`List<List<T>>`, `List<Map<K,V>>`,
+  `Map<K, List<V>>`, `List<Set<T>>`, and nested combinations). Previously
+  every overwrite leaked the prior inner collection's heap allocation.
+  The fix is safe under self-assignment (`xs[i] = xs[i]`) and cross-slot
+  copy (`xs[i] = ys[j]`) by retaining the new value before releasing the
+  old one. (#855)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -184,6 +184,13 @@ public:
     llvm::FunctionCallee resolveCollectionDestructor(llvm::AllocaInst *alloca);
     void emitArcReleaseVar(const std::string &name, llvm::AllocaInst *alloca);
     bool tryRetainArcSource(llvm::Value *val);
+    // Unconditional retain for a pointer-typed ARC value: tries the
+    // `tryRetainArcSource` fast path (LoadInst-from-alloca and arc_owned
+    // values) and falls back to a header-based retain for any other
+    // source (e.g. a Load from a GEP — cross-slot reads like `xs[i]`).
+    // Required to keep the strong count balanced when transferring an
+    // ARC pointer into a slot that owns its element (#855).
+    void retainArcValue(llvm::Value *val);
 
     // Collection type name predicates
     static bool isListTypeName(const std::string &typeName);
@@ -204,6 +211,29 @@ public:
     // ======== Copy-on-Write & Destructors ========
     enum class CollectionKind { List, Map, Set };
     llvm::FunctionCallee getOrCreateCollectionDestructor(CollectionKind kind);
+
+    // Predicate: does the container's *element* type itself own an
+    // ARC-managed allocation that needs releasing on slot overwrite?
+    // Returns true only for non-weak nested collection element types
+    // (`List<List<T>>`, `Map<K, List<V>>`, `List<Set<T>>`, …). Records
+    // and record fields with ARC fields are intentionally excluded —
+    // they have the same root cause but a different fix path.
+    // `containerKind` selects which metadata field to consult; on a
+    // true return, `*outElemKind` (if non-null) is set to the inner
+    // collection's kind so the caller can resolve a destructor.
+    bool elementTypeIsArcManaged(llvm::Value *containerPtr,
+                                 CollectionKind containerKind,
+                                 CollectionKind *outElemKind = nullptr) const;
+
+    // Releases an already-loaded ARC element pointer with a null guard
+    // and CFG branching. The builder's insertion point is left at the
+    // join block on return so the caller can continue emitting the
+    // store. Used by IndexAssignStmt to release the previously-stored
+    // ARC element before overwriting a list/map slot (#855).
+    void emitArcReleaseLoadedElement(llvm::Value *oldElemVal,
+                                     CollectionKind elemKind,
+                                     const llvm::Twine &label);
+
     llvm::AllocaInst *tryGetReceiverAlloca(const ExprNode &expr);
     llvm::Value *emitCowCheck(llvm::Value *dataPtr, llvm::AllocaInst *alloca, CollectionKind kind);
     llvm::Value *emitCowDeepCopyList(llvm::Value *oldDataPtr, llvm::Type *elemTy);

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -1,5 +1,6 @@
 #include "ry/codegen.hpp"
 #include "ry/stdlib_registry.hpp"
+#include <cassert>
 
 
 namespace ry {
@@ -340,6 +341,58 @@ bool CodeGen::isCollectionTypeName(const std::string &typeName) {
     return isListTypeName(typeName) || isMapTypeName(typeName) || isSetTypeName(typeName);
 }
 
+bool CodeGen::elementTypeIsArcManaged(llvm::Value *containerPtr,
+                                       CollectionKind containerKind,
+                                       CollectionKind *outElemKind) const {
+    // Callers reach this only after `objPtr->getType() != ptrTy_` has
+    // already been rejected with `codegenError("index assignment requires
+    // list or map")`, so `containerPtr` is guaranteed non-null and of
+    // pointer type. An assert documents the invariant without paying for
+    // a runtime check in release builds.
+    assert(containerPtr && containerPtr->getType() == ptrTy_ &&
+           "elementTypeIsArcManaged expects a pointer-typed container");
+
+    auto *meta = getMeta(containerPtr);
+    if (!meta)
+        return false;
+
+    // Element-level ARC management is decided by the Ry *type name* stored
+    // in metadata, not the LLVM type — ARC-managed elements are opaque ptr
+    // and the LLVM type alone tells us nothing. Only nested non-weak
+    // collections are owned by the slot; strings, weak refs, closures, and
+    // records are excluded and handled by different fix paths.
+    const std::string *elemTypeName = nullptr;
+    switch (containerKind) {
+    case CollectionKind::List:
+        elemTypeName = &meta->list_elem_type_name;
+        break;
+    case CollectionKind::Map:
+        elemTypeName = &meta->map_value_type_name;
+        break;
+    case CollectionKind::Set:
+        elemTypeName = &meta->set_elem_type_name;
+        break;
+    }
+    if (!elemTypeName || elemTypeName->empty())
+        return false;
+    if (isWeakTypeName(*elemTypeName))
+        return false;
+
+    if (isListTypeName(*elemTypeName)) {
+        if (outElemKind) *outElemKind = CollectionKind::List;
+        return true;
+    }
+    if (isMapTypeName(*elemTypeName)) {
+        if (outElemKind) *outElemKind = CollectionKind::Map;
+        return true;
+    }
+    if (isSetTypeName(*elemTypeName)) {
+        if (outElemKind) *outElemKind = CollectionKind::Set;
+        return true;
+    }
+    return false;
+}
+
 // ===== Weak reference operations =====
 
 bool CodeGen::isWeakTypeName(const std::string &typeName) {
@@ -499,6 +552,13 @@ void CodeGen::emitWeakReleaseVar(const std::string &name, llvm::AllocaInst *allo
     builder_.CreateBr(skipBB);
 
     builder_.SetInsertPoint(skipBB);
+}
+
+void CodeGen::retainArcValue(llvm::Value *val) {
+    if (tryRetainArcSource(val))
+        return;
+    auto *hdr = emitArcGetHeaderFromData(val);
+    emitArcRetain(hdr, /*atomic=*/false);
 }
 
 bool CodeGen::tryRetainArcSource(llvm::Value *val) {

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -11,6 +11,37 @@ namespace ry {
 // `IndexAssignStmt` branches on the type of the outermost chain node and
 // routes to the appropriate write path.
 
+// Null-guarded release of an already-loaded ARC element pointer. The
+// builder's insertion point is left at the join block on return so the
+// caller can continue emitting the store. Mirrors the retain-then-release
+// shape of `emitStmt(AssignStmt&)` (src/codegen_stmt.cpp ARC branch) but
+// operates on a slot value rather than an alloca-backed variable.
+void CodeGen::emitArcReleaseLoadedElement(llvm::Value *oldElemVal,
+                                          CollectionKind elemKind,
+                                          const llvm::Twine &label) {
+    auto *isOldNull = builder_.CreateICmpEQ(
+        oldElemVal,
+        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
+        label + ".arc_old_null");
+
+    auto *parentFn = builder_.GetInsertBlock()->getParent();
+    auto *releaseBB = llvm::BasicBlock::Create(*ctx_, "elem.arc_release", parentFn);
+    auto *joinBB = llvm::BasicBlock::Create(*ctx_, "elem.arc_release_done", parentFn);
+    builder_.CreateCondBr(isOldNull, joinBB, releaseBB);
+
+    builder_.SetInsertPoint(releaseBB);
+    auto *oldHdr = emitArcGetHeaderFromData(oldElemVal);
+    // Element slots in lists/maps/sets are not marked atomic; collections
+    // themselves are not @atomic by default. The destructor for the inner
+    // kind walks its own data buffer and cascades releases to its elements.
+    emitArcRelease(oldHdr, /*atomic=*/false,
+                   getOrCreateCollectionDestructor(elemKind),
+                   /*gcVisitFn=*/nullptr);
+    builder_.CreateBr(joinBB);
+
+    builder_.SetInsertPoint(joinBB);
+}
+
 llvm::Value *CodeGen::applyCompoundOp(const std::string &op,
                                        llvm::Value *currentVal,
                                        llvm::Value *rhs,
@@ -603,6 +634,12 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         if (key->getType() != mapKeyTy)
             codegenError("map key type mismatch");
 
+        // Determine whether the value type is itself an ARC-managed
+        // collection so we know whether to release the previously-stored
+        // pointer when overwriting an existing key (#855).
+        CollectionKind mapValArcKind = CollectionKind::List;
+        bool mapValIsArc = elementTypeIsArcManaged(objPtr, CollectionKind::Map, &mapValArcKind);
+
         // Compound assignment on a map requires the key to already exist —
         // an "insert default then apply op" behavior is not yet supported
         // and would silently paper over typos. Reject at runtime with a
@@ -624,6 +661,10 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
             llvm::Value *oldVal = builder_.CreateLoad(mapValTy, valElemPtr, "map_val_cur");
             llvm::Value *rhs = emitExpr(*s.value);
             llvm::Value *newVal = applyCompoundOp(*s.compound_op, oldVal, rhs, *s.value, mapValTy, "map element");
+            // Compound result is a fresh alloc (never aliases the old
+            // slot); reuse the pre-op load rather than re-loading (#812).
+            if (mapValIsArc)
+                emitArcReleaseLoadedElement(oldVal, mapValArcKind, "map_val_compound");
             builder_.CreateStore(newVal, valElemPtr);
             return;
         }
@@ -644,6 +685,14 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         llvm::Value *valsPtrField = builder_.CreateStructGEP(mapHeaderTy_, objPtr, 3, "map_vals_ptr");
         llvm::Value *valsPtr = builder_.CreateLoad(ptrTy_, valsPtrField, "map_vals");
         llvm::Value *valElemPtr = builder_.CreateGEP(mapValTy, valsPtr, {idx}, "val_elem_ptr");
+        // Same retain-then-release protocol as the list path below; see
+        // the explanation there. The insert branch stores into a fresh
+        // slot and has no old value to release.
+        if (mapValIsArc) {
+            retainArcValue(rhsVal);
+            llvm::Value *oldVal = builder_.CreateLoad(ptrTy_, valElemPtr, "map_val_arc_old");
+            emitArcReleaseLoadedElement(oldVal, mapValArcKind, "map_val");
+        }
         builder_.CreateStore(rhsVal, valElemPtr);
         builder_.CreateBr(endBB);
 
@@ -743,11 +792,21 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "data");
     llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {key}, "elem_ptr");
 
+    // Determine whether the element type owns an ARC allocation per slot.
+    // For ARC-managed nested collection elements (`List<List<T>>` etc.) the
+    // slot holds the sole strong ref to the inner collection — overwriting
+    // it without releasing the old pointer leaks the inner allocation.
+    // Records and record fields with ARC fields are intentionally excluded
+    // (different fix path; tracked separately).
+    CollectionKind elemArcKind = CollectionKind::List;
+    bool elemIsArc = elementTypeIsArcManaged(objPtr, CollectionKind::List, &elemArcKind);
+
     llvm::Value *finalVal = nullptr;
+    llvm::Value *compoundOldVal = nullptr;  // captured for the ARC release path
     if (s.compound_op) {
-        llvm::Value *oldVal = builder_.CreateLoad(elemTy, elemPtr, "list_elem_cur");
+        compoundOldVal = builder_.CreateLoad(elemTy, elemPtr, "list_elem_cur");
         llvm::Value *rhs = emitExpr(*s.value);
-        finalVal = applyCompoundOp(*s.compound_op, oldVal, rhs, *s.value, elemTy, "list element");
+        finalVal = applyCompoundOp(*s.compound_op, compoundOldVal, rhs, *s.value, elemTy, "list element");
     } else {
         finalVal = rhsVal;
     }
@@ -757,6 +816,31 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         else
             codegenError("list element type mismatch in index assignment");
     }
+
+    // Retain-then-release-old on slot overwrite (#855). Mirrors the
+    // canonical pattern in `emitStmt(AssignStmt&)` adapted to a heap slot.
+    //
+    // Plain form: retain first so self-assignment `xs[i] = xs[i]` cannot
+    // transiently drop the refcount to zero. `retainArcValue` handles
+    // both the `tryRetainArcSource` fast path (LoadInst from an alloca,
+    // arc_owned literals) and the manual header-based fallback for
+    // GEP-loaded values (cross-slot copies like `xs[i] = ys[j]`).
+    //
+    // Compound form: reuse `compoundOldVal` already loaded for the op
+    // rather than re-loading — preserves the "evaluate LHS slot exactly
+    // once" rule (#812). The compound op produces a fresh ARC allocation
+    // that never aliases the slot, so no retain of the new value is
+    // needed.
+    if (elemIsArc) {
+        if (s.compound_op) {
+            emitArcReleaseLoadedElement(compoundOldVal, elemArcKind, "list_elem_compound");
+        } else {
+            retainArcValue(finalVal);
+            llvm::Value *oldVal = builder_.CreateLoad(ptrTy_, elemPtr, "list_elem_arc_old");
+            emitArcReleaseLoadedElement(oldVal, elemArcKind, "list_elem");
+        }
+    }
+
     builder_.CreateStore(finalVal, elemPtr);
 }
 

--- a/tests/spec/arc_release_on_index_overwrite.test.ry
+++ b/tests/spec/arc_release_on_index_overwrite.test.ry
@@ -1,0 +1,129 @@
+# Issue #855: IndexAssignStmt must release the previously-stored ARC-managed
+# element when overwriting a list/map/set slot. Without the release the inner
+# allocation is orphaned on every rewrite — caught by ASan/LSan at process
+# exit.
+#
+# Scope of this file: list/map element slots whose element type is itself an
+# ARC-managed collection (List<List<T>>, Map<str, List<T>>, List<Set<T>>, …).
+# Records and record fields with ARC fields are tracked separately.
+#
+# Note on aliasing: cross-slot writes like `xs[0] = xs[1]` are still shallow
+# per the v0.0.8 documented semantics (#854). These tests assert correctness
+# of the slot itself; they do NOT assert deep-copy isolation.
+
+describe("ARC release on list element overwrite", ():
+  it("List<List<int>> repeated overwrite", ():
+    outer: List<List<int>> = [[1, 2, 3], [4, 5, 6]]
+    outer[0] = [10, 20, 30]
+    outer[0] = [100, 200, 300]
+    outer[0] = [1000, 2000, 3000]
+    expect(outer[0][0]).to_eq(1000)
+    expect(outer[0][2]).to_eq(3000)
+    expect(outer[1][0]).to_eq(4)
+  )
+
+  it("List<List<int>> overwrite in a loop", ():
+    outer: List<List<int>> = [[0, 0]]
+    i = 0
+    while i < 16:
+      outer[0] = [i, i + 1]
+      i = i + 1
+    expect(outer[0][0]).to_eq(15)
+    expect(outer[0][1]).to_eq(16)
+  )
+
+  it("List<Map<str, int>> overwrite", ():
+    xs: List<Map<str, int>> = [{"a": 1}, {"b": 2}]
+    xs[0] = {"x": 10, "y": 20}
+    xs[1] = {"z": 99}
+    expect(xs[0]["x"]).to_eq(10)
+    expect(xs[1]["z"]).to_eq(99)
+  )
+
+  it("List<Set<int>> overwrite", ():
+    xs: List<Set<int>> = [{1, 2}, {3, 4}]
+    xs[0] = {10, 20, 30}
+    xs[1] = {99}
+    expect(length(xs[0])).to_eq(3)
+    expect(length(xs[1])).to_eq(1)
+  )
+
+  it("self assignment xs[i] = xs[i] is safe", ():
+    xs: List<List<int>> = [[1, 2], [3, 4]]
+    xs[0] = xs[0]
+    xs[1] = xs[1]
+    expect(xs[0][0]).to_eq(1)
+    expect(xs[0][1]).to_eq(2)
+    expect(xs[1][0]).to_eq(3)
+    expect(xs[1][1]).to_eq(4)
+  )
+
+  it("cross-slot copy xs[i] = xs[j] does not crash", ():
+    xs: List<List<int>> = [[1, 2], [3, 4]]
+    xs[0] = xs[1]
+    expect(xs[0][0]).to_eq(3)
+    expect(xs[0][1]).to_eq(4)
+    # Note: shallow CoW per #854 — xs[0] and xs[1] still share the inner
+    # list. We only assert no crash and correct values, not isolation.
+  )
+)
+
+describe("ARC release on map element overwrite", ():
+  it("Map<str, List<int>> repeated overwrite", ():
+    m: Map<str, List<int>> = {"a": [1, 2, 3]}
+    m["a"] = [10, 20]
+    m["a"] = [100, 200, 300, 400]
+    m["a"] = [1, 1, 1]
+    expect(m["a"][0]).to_eq(1)
+    expect(length(m["a"])).to_eq(3)
+  )
+
+  it("Map<str, List<int>> overwrite in a loop", ():
+    m: Map<str, List<int>> = {"k": [0]}
+    i = 0
+    while i < 16:
+      m["k"] = [i, i, i]
+      i = i + 1
+    expect(m["k"][0]).to_eq(15)
+    expect(length(m["k"])).to_eq(3)
+  )
+
+  it("Map<str, Map<str, int>> overwrite", ():
+    m: Map<str, Map<str, int>> = {"outer": {"a": 1}}
+    m["outer"] = {"b": 2, "c": 3}
+    m["outer"] = {"d": 4}
+    expect(m["outer"]["d"]).to_eq(4)
+    expect(length(m["outer"])).to_eq(1)
+  )
+
+  it("self assignment m[k] = m[k] is safe", ():
+    m: Map<str, List<int>> = {"a": [1, 2]}
+    m["a"] = m["a"]
+    expect(m["a"][0]).to_eq(1)
+    expect(m["a"][1]).to_eq(2)
+  )
+)
+
+# Compound op cases (`xs[i] += inner_list` for ARC-typed elements) hit a
+# separate pre-existing bug in `applyCompoundOp` where the lhs type hint is
+# lost and the dispatcher routes to the str path. Tracked as a follow-up;
+# the ARC release fix in this file does not depend on those cases.
+
+# Chained LHS path: rec.items[i] = v where rec.items is List<List<int>>.
+# The LHS root is FieldAccessExpr (not VariableExpr), so receiverAlloca is
+# nullptr and emitCowCheck is a no-op. The release of the old element must
+# still happen.
+
+record ArcReleaseRecBox:
+  items: List<List<int>>
+
+describe("ARC release through chained LHS", ():
+  it("rec.items[i] = v releases overwritten inner list", ():
+    r = ArcReleaseRecBox([[1, 2], [3, 4]])
+    r.items[0] = [10, 20, 30]
+    r.items[0] = [100]
+    expect(r.items[0][0]).to_eq(100)
+    expect(length(r.items[0])).to_eq(1)
+    expect(r.items[1][0]).to_eq(3)
+  )
+)


### PR DESCRIPTION
## Summary

- `list[i] = v`, `m[k] = v`, and their compound forms now release the previously-stored ARC pointer before overwriting the slot, for element types that are themselves ARC-managed collections (`List<List<T>>`, `Map<str, List<T>>`, `List<Set<T>>`, nested combinations). Previously every overwrite leaked the prior inner allocation.
- The fix mirrors the canonical retain-then-release pattern from `emitStmt(AssignStmt&)` (src/codegen_stmt.cpp ARC branch), adapted to a heap slot. Retain-before-release makes `xs[i] = xs[i]` safe; a new `retainArcValue` helper handles both the `tryRetainArcSource` fast path and the GEP-load fallback (cross-slot copies like `xs[i] = ys[j]`).
- Compound form reuses the `oldVal` already loaded for `applyCompoundOp` rather than re-loading, preserving the "evaluate LHS slot exactly once" rule (#812).

## Key changes

- **`src/codegen_arc.cpp`** — new `elementTypeIsArcManaged(container, kind, &elemKind)` predicate and `retainArcValue(val)` helper.
- **`src/codegen_stmt_misc.cpp`** — new `emitArcReleaseLoadedElement(oldVal, kind, label)` helper (null-guarded release); patched 4 leak sites in `emitStmt(IndexAssignStmt&)` — list plain, list compound, map plain update, map compound update.
- **`tests/spec/arc_release_on_index_overwrite.test.ry`** — 11 regression tests covering `List<List<int>>`, `List<Map<str,int>>`, `List<Set<int>>`, `Map<str,List<int>>`, `Map<str,Map<str,int>>`, self-assignment, cross-slot copy, and chained-LHS through record fields.
- **`KNOWLEDGE.md`** — new entry documenting the retain-then-release protocol and the verification gap.
- **`changelog.d/855-arc-release-on-index-overwrite.md`** — Fixed section.

## Out of scope (tracked separately)

- **#857** — `FieldAssignStmt` has the same root cause for record fields with ARC field types, but needs a different fix path (field walker via `InsertValue`/`Store` of whole structs).
- **#858** — `xs[i] += inner_list` for ARC element types fails with a misleading \`str + non-str\` error due to a pre-existing lhs-hint gap in \`applyCompoundOp\` — discovered while writing compound-op regression tests.
- **#859** — ARC leak detection infrastructure gap: macOS ASan has no LSan, and CI explicitly sets \`detect_leaks=0\`. The new regression tests exercise the fix paths for functional correctness but cannot directly assert leak absence. Correctness is verified by code review against the canonical pattern and by ASan use-after-free checks.

Closes #855.

## Test plan

- [x] \`cmake --preset default && cmake --build build\` — clean build
- [x] \`./build/ry_tests\` — **1576 C++ tests passed**
- [x] \`./build/ry test -p\` — **107 Ry test files, 0 failures**
- [x] \`cmake --preset asan && cmake --build build-asan\` — clean ASan build
- [x] \`ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests\` — **1575 passed**
- [x] \`ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p\` — **107 Ry test files, 0 failures**
- [x] New test file (\`arc_release_on_index_overwrite.test.ry\`) — **11 cases pass**
- [x] Regression spot-check: \`tests/spec/chained_lhs_assign.test.ry\` (#812 guard) still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory leak when overwriting elements in nested collections (e.g., assigning to `list[i]` where the element type is itself a collection like `List<List<T>>` or `Map<K,V>`). The previously-held value is now properly released before storing the new one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->