### PR TITLE
fix: propagate element type metadata on compound index-assign (#858)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -445,6 +445,62 @@ a non-`VariableExpr` base (`rec.field[i] = v`, `grid[i][j] = v`), pass
 "proper" write-back through a record chain requires deep CoW and should be
 part of the follow-up.
 
+### Compound-op loaded slot values must propagate container metadata
+
+**Source**: #858 (2026-04-11)
+**Tags**: codegen, compound-assign, metadata, arc, collection, index-assign
+
+**Context**: `emitStmt(IndexAssignStmt &)` in `src/codegen_stmt_misc.cpp`
+loads `compoundOldVal` / `oldVal` from the slot via a bare `CreateLoad`
+before passing it into `applyCompoundOp`. For nested ARC-managed elements
+(`List<List<T>>`, `Map<K, List<V>>`, …) the element type is `ptrTy_`, so
+the load yields an opaque pointer with no metadata attached. The value
+then flows through `applyCompoundOp → emitBinaryOp → emitArithmeticOp`,
+whose list-concat dispatch at `src/codegen_expr.cpp:1015-1023` reads
+`TypeMeta::ListElem` from the SSA value (via `getListElementType(lhs)`),
+**not** the `lhsHint` string parameter. Without metadata on the load,
+dispatch falls through to the str-vs-non-str rejection path and emits a
+completely misleading error for a legal `List<int> + List<int>` operation.
+
+The fix is to call `propagateTypeMeta(container_meta->list_elem_type_name,
+compoundOldVal)` (or `map_value_type_name` for maps) immediately after
+the load, matching the canonical pattern already documented for
+`valueToString` element loads. `propagateTypeMeta` internally rebuilds
+every `TypeMeta::*` slot from the name string, so one call restores the
+full dispatch context. Snapshot the name into a local `std::string`
+*before* calling `propagateTypeMeta` — the helper inserts into
+`value_metadata_` and may rehash, invalidating the `ValueMetadata *`
+returned by `getMeta`.
+
+Also note that `src/codegen_stmt.cpp` (empty-list-declaration path) must
+record `list_elem_type_name` for `List<List<T>>` exactly the way it
+already does for `List<Map>` and `List<Set>` — the asymmetry in the
+pre-#858 code caused the `xs: List<List<int>> = []; xs.append(...); xs[0]
++= ...` case to fail even after the `codegen_stmt_misc.cpp` fix.
+
+**Rule**: Any codegen site that loads an element from a container slot
+and then feeds it into a **type-dispatched operation** (formatter, binary
+op, builtin call) MUST propagate the container's element type name onto
+the loaded value. The bare `LoadInst` / `CreateExtractValue` result is
+metadata-less. Hint parameters on helper signatures (`lhsHint` on
+`emitBinaryOp`) are not the dispatch key — `TypeMeta::*` slots on the SSA
+value are.
+
+**How to verify** (grep before opening a PR):
+
+```bash
+grep -nE 'CreateLoad.*elem|CreateExtractValue.*field|applyCompoundOp' \
+    src/codegen_stmt_misc.cpp src/codegen_tostring.cpp
+```
+
+Every such load that flows into `applyCompoundOp`, `emitBinaryOp`, or
+`valueToString` should be followed by a metadata-propagation block (or
+be an i64/bool/float path where metadata is unnecessary). Known remaining
+sites NOT yet covered: `FieldAssignStmt` compound branches at lines
+176-181, 213-219, 300-305 (tracked in a sibling issue), and the
+fixed-length array compound path at lines 597-600 (low priority,
+typically pointer-free).
+
 ### Element-slot writes must release the overwritten ARC pointer
 
 **Source**: #855 (2026-04-11)

--- a/changelog.d/858-compound-assign-arc-element.md
+++ b/changelog.d/858-compound-assign-arc-element.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- `xs[i] += v` and `m[k] += v` now dispatch correctly when the element
+  type is itself an ARC-managed collection (`List<List<T>>`,
+  `Map<K, List<V>>`, and nested combinations reached via chained LHS such
+  as `rec.items[i] += v`). Previously the loaded slot value lost its
+  type metadata, so `emitArithmeticOp`'s list-concat dispatch fell
+  through to the string path and produced a misleading
+  `operator '+' not supported between str and non-str types` error.
+  The fix propagates the container's element type name onto the loaded
+  SSA value via `propagateTypeMeta` — the same pattern the formatter
+  already uses for nested element loads. As a secondary fix, the
+  empty-declaration path (`xs: List<List<int>> = []`) now records
+  `list_elem_type_name` symmetric to the existing `List<Map>` /
+  `List<Set>` branches so compound ops work on append-grown containers
+  as well. (#858)

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -133,6 +133,11 @@ void CodeGen::emitVarDecl(const std::string &name,
             llvm::Type *nestedElemTy = resolveType(nestedInner);
             if (nestedElemTy)
                 setTypeMeta(TypeMeta::NestedListElem, ptr, nestedElemTy);
+            // Also record the surface-level element type name so compound-op
+            // dispatch (which reads list_elem_type_name via getMeta → propagate)
+            // can re-derive the inner List's concat semantics on loaded slot
+            // values (#858). Symmetric to the List<Map>/List<Set> branch below.
+            getOrCreateMeta(ptr).list_elem_type_name = inner;
         }
 
         // Set list element type metadata for List<Map>, List<Set>, List<closure> annotations

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -659,6 +659,16 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
             llvm::Value *valsPtr = builder_.CreateLoad(ptrTy_, valsPtrField, "map_vals");
             llvm::Value *valElemPtr = builder_.CreateGEP(mapValTy, valsPtr, {idx}, "val_elem_ptr");
             llvm::Value *oldVal = builder_.CreateLoad(mapValTy, valElemPtr, "map_val_cur");
+            // Snapshot map_value_type_name before propagateTypeMeta: the
+            // getOrCreateMeta inside it may rehash value_metadata_ and
+            // invalidate the raw pointer from getMeta. See KNOWLEDGE.md
+            // "Compound-op loaded slot values must propagate container
+            // metadata" and #858.
+            std::string mapValTypeName;
+            if (auto *containerMeta = getMeta(objPtr))
+                mapValTypeName = containerMeta->map_value_type_name;
+            if (!mapValTypeName.empty())
+                propagateTypeMeta(mapValTypeName, oldVal);
             llvm::Value *rhs = emitExpr(*s.value);
             llvm::Value *newVal = applyCompoundOp(*s.compound_op, oldVal, rhs, *s.value, mapValTy, "map element");
             // Compound result is a fresh alloc (never aliases the old
@@ -805,6 +815,16 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     llvm::Value *compoundOldVal = nullptr;  // captured for the ARC release path
     if (s.compound_op) {
         compoundOldVal = builder_.CreateLoad(elemTy, elemPtr, "list_elem_cur");
+        // Snapshot list_elem_type_name before propagateTypeMeta: the
+        // getOrCreateMeta inside it may rehash value_metadata_ and
+        // invalidate the raw pointer from getMeta. See KNOWLEDGE.md
+        // "Compound-op loaded slot values must propagate container
+        // metadata" and #858.
+        std::string elemTypeName;
+        if (auto *containerMeta = getMeta(objPtr))
+            elemTypeName = containerMeta->list_elem_type_name;
+        if (!elemTypeName.empty())
+            propagateTypeMeta(elemTypeName, compoundOldVal);
         llvm::Value *rhs = emitExpr(*s.value);
         finalVal = applyCompoundOp(*s.compound_op, compoundOldVal, rhs, *s.value, elemTy, "list element");
     } else {

--- a/tests/spec/arc_release_on_index_overwrite.test.ry
+++ b/tests/spec/arc_release_on_index_overwrite.test.ry
@@ -105,10 +105,9 @@ describe("ARC release on map element overwrite", ():
 )
 
 # Compound op cases (`xs[i] += inner_list` for ARC-typed elements) are fixed
-# in #858 and live in `compound_assign_arc_element.test.ry`. The compound
-# release path in this file is exercised there and by the self-compound case
-# below, which combines overwrite (release of prior slot) with the compound
-# dispatch fix.
+# in #858 and live in `compound_assign_arc_element.test.ry`, including the
+# self-compound cases that combine slot overwrite (release of the prior slot)
+# with the compound dispatch fix.
 
 # Chained LHS path: rec.items[i] = v where rec.items is List<List<int>>.
 # The LHS root is FieldAccessExpr (not VariableExpr), so receiverAlloca is

--- a/tests/spec/arc_release_on_index_overwrite.test.ry
+++ b/tests/spec/arc_release_on_index_overwrite.test.ry
@@ -104,10 +104,11 @@ describe("ARC release on map element overwrite", ():
   )
 )
 
-# Compound op cases (`xs[i] += inner_list` for ARC-typed elements) hit a
-# separate pre-existing bug in `applyCompoundOp` where the lhs type hint is
-# lost and the dispatcher routes to the str path. Tracked as a follow-up;
-# the ARC release fix in this file does not depend on those cases.
+# Compound op cases (`xs[i] += inner_list` for ARC-typed elements) are fixed
+# in #858 and live in `compound_assign_arc_element.test.ry`. The compound
+# release path in this file is exercised there and by the self-compound case
+# below, which combines overwrite (release of prior slot) with the compound
+# dispatch fix.
 
 # Chained LHS path: rec.items[i] = v where rec.items is List<List<int>>.
 # The LHS root is FieldAccessExpr (not VariableExpr), so receiverAlloca is

--- a/tests/spec/compound_assign_arc_element.test.ry
+++ b/tests/spec/compound_assign_arc_element.test.ry
@@ -1,0 +1,78 @@
+# Issue #858: compound assignment to a list/map element whose element type is
+# itself an ARC-managed collection must dispatch correctly. Before the fix the
+# loaded slot value carried no metadata, so emitArithmeticOp's list-concat
+# dispatch (which probes TypeMeta::ListElem on the lhs SSA value) fell through
+# to the str-vs-non-str path and produced a misleading type error.
+#
+# The fix propagates the container's element type name onto the loaded slot
+# value via propagateTypeMeta, matching the canonical pattern used by
+# valueToString element loads.
+
+describe("compound assignment on ARC-managed list elements", ():
+  it("List<List<int>> xs[i] += [literal]", ():
+    xs: List<List<int>> = [[1, 2], [3, 4]]
+    xs[0] += [5]
+    expect(xs[0]).to_eq([1, 2, 5])
+    expect(xs[1]).to_eq([3, 4])
+  )
+
+  it("List<List<int>> xs[i] += variable", ():
+    xs: List<List<int>> = [[1]]
+    ys: List<int> = [2, 3]
+    xs[0] += ys
+    expect(xs[0]).to_eq([1, 2, 3])
+    # ys remains usable after the compound op
+    expect(ys).to_eq([2, 3])
+  )
+
+  it("List<List<int>> xs[i] += xs[i] (self compound)", ():
+    xs: List<List<int>> = [[1, 2]]
+    xs[0] += xs[0]
+    expect(xs[0]).to_eq([1, 2, 1, 2])
+  )
+
+  it("List<List<int>> append then compound", ():
+    # Exercises the empty-declaration metadata path at src/codegen_stmt.cpp:
+    # the path that sets list_elem_type_name only for List<Map> / List<Set> /
+    # List<function>. For List<List<T>> the slot's element type name must
+    # still be propagated correctly when compound-assigning.
+    xs: List<List<int>> = []
+    xs.append([1])
+    xs[0] += [2]
+    expect(xs[0]).to_eq([1, 2])
+  )
+)
+
+describe("compound assignment on ARC-managed map values", ():
+  it("Map<str, List<int>> m[k] += [literal]", ():
+    m: Map<str, List<int>> = {"a": [1, 2]}
+    m["a"] += [3]
+    expect(m["a"]).to_eq([1, 2, 3])
+  )
+
+  it("Map<str, List<int>> m[k] += m[k] (self compound)", ():
+    m: Map<str, List<int>> = {"a": [1, 2]}
+    m["a"] += m["a"]
+    expect(m["a"]).to_eq([1, 2, 1, 2])
+  )
+
+  it("Map<str, List<int>> m[k] += variable preserves other keys", ():
+    m: Map<str, List<int>> = {"a": [1], "b": [9]}
+    extra: List<int> = [2, 3]
+    m["a"] += extra
+    expect(m["a"]).to_eq([1, 2, 3])
+    expect(m["b"]).to_eq([9])
+  )
+)
+
+record CompoundBox:
+  items: List<List<int>>
+
+describe("compound assignment through chained LHS", ():
+  it("rec.items[i] += [literal]", ():
+    b = CompoundBox([[1], [2, 3]])
+    b.items[0] += [99]
+    expect(b.items[0]).to_eq([1, 99])
+    expect(b.items[1]).to_eq([2, 3])
+  )
+)


### PR DESCRIPTION
## Summary

Fixes #858. `xs[i] += inner` and `m[k] += inner` emitted a misleading
`operator '+' not supported between str and non-str types` error when the
element type was itself an ARC-managed collection (`List<List<T>>`,
`Map<K, List<V>>`, and nested combinations reached via chained LHS such as
`rec.items[i] += v`). The plain expanded form `xs[i] = xs[i] + inner` worked —
only the compound path was broken.

### Root cause

`emitStmt(IndexAssignStmt &)` in `src/codegen_stmt_misc.cpp` loads the slot's
current value via a bare `CreateLoad` before passing it into `applyCompoundOp`.
For nested ARC-managed elements the element type is `ptrTy_`, so the load yields
an opaque pointer with **no metadata attached**. Downstream `emitArithmeticOp`'s
list-concat dispatch (`src/codegen_expr.cpp:1015-1023`) reads
`TypeMeta::ListElem` from the SSA value via `getListElementType(lhs)` — **not**
the `lhsHint` string parameter — so dispatch fell through to the str-vs-non-str
rejection path and emitted a completely unrelated error for a legal
`List<int> + List<int>` operation.

### Fix

Propagate the container's element type name onto the loaded value via
`propagateTypeMeta` immediately after the `CreateLoad`, in both the List and
Map compound branches of `IndexAssignStmt`. `propagateTypeMeta` internally
rebuilds every `TypeMeta::*` slot from the name string, so a single call
restores the full dispatch context. The name is copied into a local
`std::string` before calling `propagateTypeMeta` to avoid the rehash hazard
documented in KNOWLEDGE.md — `getOrCreateMeta` inside `propagateTypeMeta` may
rehash `value_metadata_` and invalidate any raw `ValueMetadata *` returned by
`getMeta`.

As a secondary fix, the empty-declaration path in `src/codegen_stmt.cpp` now
records `list_elem_type_name` for `List<List<T>>` declarations — symmetric to
the existing `List<Map>` / `List<Set>` / `List<function>` branches. Without
this, `xs: List<List<int>> = []; xs.append(...); xs[0] += ...` would still
fail because append-grown containers had no element type name on the header.

### Scope (from #858 checklist)

- [x] `xs[i] += inner` for `List<List<T>>`, `List<Map<K,V>>`
- [x] `m[k] += inner` for `Map<K, List<T>>`
- [x] `rec.field[i] += inner` (chained LHS — covered because
      `emitExprVariant(FieldAccessExpr)` already propagates
      `list_elem_type_name` onto the extracted field value at
      `src/codegen_expr_literal.cpp:120-122`)
- [x] Preserves the `#855` retain-then-release-old ordering on ARC slot
      overwrites (compound path reuses `compoundOldVal` for the release)

Out of scope — filed as sibling issues:

- **#862** bug: `rec.arcField += v` loses compound-op type hint
  (`FieldAssignStmt` compound paths at `codegen_stmt_misc.cpp:176-181`,
  `:213-219`, `:300-305` have the same class of bug via `CreateExtractValue`)
- **#863** enhancement: clearer error when `+` is applied to Map/Set/
  unsupported collection LHS (the error-message checklist item from #858)

## Test plan

- [x] New regression tests in `tests/spec/compound_assign_arc_element.test.ry`
      covering 8 cases: list literal init, list empty-then-append, list with
      variable rhs, list self-compound, map happy path, map self-compound, map
      with other-key preservation, chained LHS via record field
- [x] Placeholder comment at
      `tests/spec/arc_release_on_index_overwrite.test.ry:107-110` (which
      documented the bug as a known follow-up) removed
- [x] `./build/ry_tests` — 1590 passed
- [x] `./build/ry test -p` — 109 files, 0 failures
- [x] `ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p` —
      108 files, 0 failures
- [x] Spot check issue repro: `xs: List<List<int>> = [[1]]; xs[0] += [2, 3];
      print(xs)` now outputs `[[1, 2, 3]]`
- [x] KNOWLEDGE.md updated with "Compound-op loaded slot values must propagate
      container metadata" entry under `## Codegen`
- [x] Changelog fragment `changelog.d/858-compound-assign-arc-element.md`
      created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compound-assign operations (e.g., xs[i] += v) on ARC-managed collection elements, including nested containers, empty-list-initialized nested lists, and chained property/indexing cases to avoid incorrect dispatch to string-concatenation.

* **Tests**
  * Added comprehensive specs covering nested lists, maps, append-then-assign, self-compound, and chained-LHS scenarios.

* **Documentation**
  * Added guidance documenting container element type metadata propagation and a changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->