### PR TITLE
fix: propagate field type metadata on compound field-assign (#862)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -480,30 +480,38 @@ part of the follow-up.
 
 ### Compound-op loaded slot values must propagate container metadata
 
-**Source**: #858 (2026-04-11)
-**Tags**: codegen, compound-assign, metadata, arc, collection, index-assign
+**Source**: #858, #862 (2026-04-11)
+**Tags**: codegen, compound-assign, metadata, arc, collection, index-assign, field-assign
 
-**Context**: `emitStmt(IndexAssignStmt &)` in `src/codegen_stmt_misc.cpp`
-loads `compoundOldVal` / `oldVal` from the slot via a bare `CreateLoad`
-before passing it into `applyCompoundOp`. For nested ARC-managed elements
-(`List<List<T>>`, `Map<K, List<V>>`, …) the element type is `ptrTy_`, so
-the load yields an opaque pointer with no metadata attached. The value
-then flows through `applyCompoundOp → emitBinaryOp → emitArithmeticOp`,
-whose list-concat dispatch at `src/codegen_expr.cpp:1015-1023` reads
-`TypeMeta::ListElem` from the SSA value (via `getListElementType(lhs)`),
-**not** the `lhsHint` string parameter. Without metadata on the load,
-dispatch falls through to the str-vs-non-str rejection path and emits a
-completely misleading error for a legal `List<int> + List<int>` operation.
+**Context**: `emitStmt(IndexAssignStmt &)` and `emitStmt(FieldAssignStmt &)`
+in `src/codegen_stmt_misc.cpp` load the compound LHS from the slot via a
+bare `CreateLoad` (for collection slots, #858) or `CreateExtractValue`
+(for record fields, #862) before passing it into `applyCompoundOp`. When
+the element / field type is an ARC-managed collection (`List<T>`,
+`Map<K, V>`, `List<List<T>>`, …) the loaded value is an opaque pointer
+with no metadata attached. The value then flows through
+`applyCompoundOp → emitBinaryOp → emitArithmeticOp`, whose list-concat
+dispatch at `src/codegen_expr.cpp:1015-1023` reads `TypeMeta::ListElem`
+from the SSA value (via `getListElementType(lhs)`), **not** the `lhsHint`
+string parameter. Without metadata on the load, dispatch falls through
+to the str-vs-non-str rejection path and emits a completely misleading
+error for a legal `List<int> + List<int>` operation.
 
-The fix is to call `propagateTypeMeta(container_meta->list_elem_type_name,
-compoundOldVal)` (or `map_value_type_name` for maps) immediately after
-the load, matching the canonical pattern already documented for
+The fix is to call `propagateTypeMeta(name, loadedVal)` immediately
+after the load, matching the canonical pattern already documented for
 `valueToString` element loads. `propagateTypeMeta` internally rebuilds
 every `TypeMeta::*` slot from the name string, so one call restores the
-full dispatch context. Snapshot the name into a local `std::string`
-*before* calling `propagateTypeMeta` — the helper inserts into
-`value_metadata_` and may rehash, invalidating the `ValueMetadata *`
-returned by `getMeta`.
+full dispatch context. The name source depends on the code path:
+
+- `IndexAssignStmt` (#858): pull from the container's metadata
+  (`container_meta->list_elem_type_name` or `map_value_type_name`).
+  **Snapshot the name into a local `std::string` *before* calling
+  `propagateTypeMeta`** — the helper inserts into `value_metadata_` and
+  may rehash, invalidating the `ValueMetadata *` returned by `getMeta`.
+- `FieldAssignStmt` (#862): use `info.fields[fieldIdx].type->toString()`
+  directly. `.toString()` returns a new `std::string` by value, so the
+  rehash aliasing concern from #858 does not apply here. This matches
+  the canonical pattern at `src/codegen_expr_literal.cpp:120-122`.
 
 Also note that `src/codegen_stmt.cpp` (empty-list-declaration path) must
 record `list_elem_type_name` for `List<List<T>>` exactly the way it
@@ -529,10 +537,9 @@ grep -nE 'CreateLoad.*elem|CreateExtractValue.*field|applyCompoundOp' \
 Every such load that flows into `applyCompoundOp`, `emitBinaryOp`, or
 `valueToString` should be followed by a metadata-propagation block (or
 be an i64/bool/float path where metadata is unnecessary). Known remaining
-sites NOT yet covered: `FieldAssignStmt` compound branches at lines
-176-181, 213-219, 300-305 (tracked in a sibling issue), and the
-fixed-length array compound path at lines 597-600 (low priority,
-typically pointer-free).
+sites NOT yet covered: the fixed-length array compound path at
+`src/codegen_stmt_misc.cpp:597-600` (low priority, element types are
+typically pointer-free primitives).
 
 ### Element-slot writes must release the overwritten ARC pointer
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -536,10 +536,13 @@ grep -nE 'CreateLoad.*elem|CreateExtractValue.*field|applyCompoundOp' \
 
 Every such load that flows into `applyCompoundOp`, `emitBinaryOp`, or
 `valueToString` should be followed by a metadata-propagation block (or
-be an i64/bool/float path where metadata is unnecessary). Known remaining
-sites NOT yet covered: the fixed-length array compound path at
-`src/codegen_stmt_misc.cpp:597-600` (low priority, element types are
-typically pointer-free primitives).
+be an i64/bool/float path where metadata is unnecessary). The remaining
+fixed-length array compound path at `src/codegen_stmt_misc.cpp:597-600`
+is **not** a missing-metadata site: fixed-length array element types
+are restricted to low-level primitive types by a hard compile-time
+check at `src/codegen_type.cpp:125` (`array element type must be a
+low-level type`), so ARC-managed collection element types are rejected
+at type resolution and never reach the compound path.
 
 ### Element-slot writes must release the overwritten ARC pointer
 

--- a/changelog.d/862-compound-assign-arc-field.md
+++ b/changelog.d/862-compound-assign-arc-field.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- `rec.arcField += v` now dispatches correctly when the field type is
+  itself an ARC-managed collection (`List<T>`, `List<List<T>>`, etc.).
+  This covers plain record field assignment (`b.items += [3]`), nested
+  record field access (`outer.inner.items += [3]`), and chained LHS
+  through a list of records (`lst[0].items += [3]`). Previously the
+  field extracted from the struct lost its type metadata, so
+  `emitArithmeticOp`'s list-concat dispatch fell through to the string
+  path and produced a misleading `operator '+' not supported between
+  str and non-str types` error. The fix propagates the field's declared
+  type name onto the extracted SSA value via `propagateTypeMeta` at all
+  three `FieldAssignStmt` compound branches — sibling fix to #858,
+  which addressed the same class of metadata-loss bug on the
+  `IndexAssignStmt` compound path. (#862)

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -176,6 +176,14 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         if (s.compound_op) {
             llvm::Value *currentField = builder_.CreateExtractValue(
                 currentStruct, fieldIdx, s.field + ".compound_cur");
+            // Propagate the field's declared type onto the extracted SSA value
+            // so downstream emitArithmeticOp can dispatch list concat / map /
+            // set metadata correctly. Sibling fix of #858; see KNOWLEDGE.md
+            // "Compound-op loaded slot values must propagate container
+            // metadata" and the canonical pattern at
+            // src/codegen_expr_literal.cpp:120-122. Issue #862.
+            if (info.fields[fieldIdx].type)
+                propagateTypeMeta(info.fields[fieldIdx].type->toString(), currentField);
             llvm::Value *rhs = emitExpr(*s.value);
             newFieldVal = applyCompoundOp(*s.compound_op, currentField, rhs, *s.value,
                                            expectedTy, varExpr->name + "." + s.field);
@@ -214,6 +222,10 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         if (s.compound_op) {
             llvm::Value *currentField = builder_.CreateExtractValue(
                 innerStruct, fieldIdx, s.field + ".compound_cur");
+            // Propagate the field's declared type onto the extracted SSA value.
+            // See the VariableExpr branch above and #862 for the rationale.
+            if (info.fields[fieldIdx].type)
+                propagateTypeMeta(info.fields[fieldIdx].type->toString(), currentField);
             llvm::Value *rhs = emitExpr(*s.value);
             newFieldVal = applyCompoundOp(*s.compound_op, currentField, rhs, *s.value,
                                            expectedTy, it->first + "." + s.field);
@@ -300,6 +312,10 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         llvm::Value *newFieldVal = nullptr;
         if (s.compound_op) {
             llvm::Value *curField = builder_.CreateExtractValue(curStruct, fieldIdx, s.field + ".compound_cur");
+            // Propagate the field's declared type onto the extracted SSA value.
+            // See the VariableExpr branch above and #862 for the rationale.
+            if (info.fields[fieldIdx].type)
+                propagateTypeMeta(info.fields[fieldIdx].type->toString(), curField);
             llvm::Value *rhs = emitExpr(*s.value);
             newFieldVal = applyCompoundOp(*s.compound_op, curField, rhs, *s.value,
                                            expectedTy, it->first + "." + s.field);

--- a/tests/spec/compound_assign_arc_field.test.ry
+++ b/tests/spec/compound_assign_arc_field.test.ry
@@ -1,0 +1,102 @@
+# Issue #862: compound assignment to a record field whose type is itself an
+# ARC-managed collection (`List<T>` etc.) must dispatch correctly. Before the
+# fix the field value extracted from the struct carried no metadata, so
+# emitArithmeticOp's list-concat dispatch (which probes TypeMeta::ListElem on
+# the lhs SSA value) fell through to the str-vs-non-str path and produced a
+# misleading type error.
+#
+# Sibling of #858 (compound_assign_arc_element.test.ry): same root cause in
+# the FieldAssignStmt compound branches instead of IndexAssignStmt. Three
+# sites are fixed — VariableExpr, FieldAccessExpr, IndexExpr-chain.
+
+record Box:
+  items: List<int>
+
+record Outer:
+  inner: Box
+
+record NestedBox:
+  items: List<List<int>>
+
+record MultiField:
+  a: List<int>
+  b: List<int>
+
+describe("compound assignment to ARC-managed record field (VariableExpr branch)", ():
+  it("b.items += [literal] for List<int> field", ():
+    b = Box([1, 2])
+    b.items += [3]
+    expect(b.items).to_eq([1, 2, 3])
+  )
+
+  it("b.items += variable for List<int> field", ():
+    b = Box([1])
+    ys: List<int> = [2, 3]
+    b.items += ys
+    expect(b.items).to_eq([1, 2, 3])
+    # ys remains usable after the compound op
+    expect(ys).to_eq([2, 3])
+  )
+
+  it("b.items += b.items (self compound)", ():
+    b = Box([1, 2])
+    b.items += b.items
+    expect(b.items).to_eq([1, 2, 1, 2])
+  )
+
+  it("only the targeted field is modified; siblings untouched", ():
+    m = MultiField([1], [9])
+    m.a += [2, 3]
+    expect(m.a).to_eq([1, 2, 3])
+    expect(m.b).to_eq([9])
+  )
+)
+
+describe("compound assignment through FieldAccessExpr chain", ():
+  it("o.inner.items += [literal] for nested record field", ():
+    o = Outer(Box([1, 2]))
+    o.inner.items += [3]
+    expect(o.inner.items).to_eq([1, 2, 3])
+  )
+
+  it("o.inner.items += variable preserves the variable", ():
+    o = Outer(Box([1]))
+    ys: List<int> = [2, 3]
+    o.inner.items += ys
+    expect(o.inner.items).to_eq([1, 2, 3])
+    expect(ys).to_eq([2, 3])
+  )
+)
+
+describe("compound assignment through IndexExpr chain (list of records)", ():
+  it("lst[i].items += [literal]", ():
+    lst: List<Box> = [Box([1, 2]), Box([3, 4])]
+    lst[0].items += [99]
+    expect(lst[0].items).to_eq([1, 2, 99])
+    expect(lst[1].items).to_eq([3, 4])
+  )
+
+  it("lst[i].items += variable", ():
+    lst: List<Box> = [Box([1])]
+    ys: List<int> = [2, 3]
+    lst[0].items += ys
+    expect(lst[0].items).to_eq([1, 2, 3])
+    expect(ys).to_eq([2, 3])
+  )
+)
+
+describe("compound assignment with nested ARC element types", ():
+  it("List<List<int>> field + [[int]] literal", ():
+    b = NestedBox([[1], [2, 3]])
+    b.items += [[4, 5]]
+    expect(b.items).to_eq([[1], [2, 3], [4, 5]])
+  )
+
+  it("List<List<int>> field + variable", ():
+    b = NestedBox([[1]])
+    ys: List<List<int>> = [[2, 3], [4]]
+    b.items += ys
+    expect(b.items).to_eq([[1], [2, 3], [4]])
+    expect(ys).to_eq([[2, 3], [4]])
+  )
+)


### PR DESCRIPTION
## Summary

Sibling fix of #858. `rec.arcField += v` now dispatches correctly when the record field type is itself an ARC-managed collection (`List<T>`, `List<List<T>>`, …). Previously the field extracted from the struct via `CreateExtractValue` carried no metadata, so `emitArithmeticOp`'s list-concat dispatch — which reads `TypeMeta::ListElem` from the SSA value, not the `lhsHint` string — fell through to the str rejection path and emitted a misleading error:

```
error: type error: operator '+' not supported between str and non-str types
```

The fix adds a `propagateTypeMeta(info.fields[fieldIdx].type->toString(), ...)` call immediately after the `CreateExtractValue` in all three ``FieldAssignStmt`` compound branches — matching the canonical pattern at ``src/codegen_expr_literal.cpp:120-122``:

- **VariableExpr branch** — `b.items += v`
- **FieldAccessExpr branch** — `outer.inner.items += v`
- **IndexExpr chain branch** — `lst[0].items += v`

## Before / after

```ry
record Box:
  items: List<int>
b = Box([1, 2])
b.items += [3]
# before: error: operator '+' not supported between str and non-str types
# after:  [1, 2, 3]
```

## Scope

- Unchanged: ARC release semantics on overwrite (#857 tracks that separately for `FieldAssignStmt`)
- Unchanged: the fixed-length array compound path (low priority, element types are typically pointer-free)

## Test plan

- [x] New test file `tests/spec/compound_assign_arc_field.test.ry` — 10 cases across all 3 branches
  - VariableExpr: `b.items += [3]`, `b.items += ys`, `b.items += b.items` (self), multi-field isolation
  - FieldAccessExpr: `o.inner.items += [3]`, `o.inner.items += ys`
  - IndexExpr chain: `lst[0].items += [99]`, `lst[0].items += ys`
  - Nested ARC: `NestedBox(List<List<int>>).items += [[...]]` literal + variable
- [x] `./build/ry test tests/spec/compound_assign_arc_field.test.ry` → 10 / 10 passed
- [x] `./build/ry_tests` (1590 tests) → all passed
- [x] `./build/ry test -p` (110 files) → 0 failures
- [x] `./build-asan/ry_tests` (1589 tests) → all passed
- [x] `ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p` → 0 failures
- [x] Existing `tests/spec/compound_assign_arc_element.test.ry` (#858 regression) still passes

## Docs / KNOWLEDGE

- `KNOWLEDGE.md` — expanded the "Compound-op loaded slot values must propagate container metadata" entry to cover both `IndexAssignStmt` (#858) and `FieldAssignStmt` (#862). Documented that for `FieldAssignStmt`, `info.fields[fieldIdx].type->toString()` returns a new ``std::string`` by value so the rehash aliasing concern from #858 does not apply. Removed the now-stale "FieldAssignStmt compound branches not yet covered" note.
- No user-facing docs changes — internal codegen bug fix with no language/CLI surface change.
- Changelog fragment `changelog.d/862-compound-assign-arc-field.md` added.

Closes #862

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed runtime dispatch for compound assignment (`+=`) on ARC-managed record fields typed as collections (e.g., `List<T>`, including nested `List<List<T>>`), ensuring correct arithmetic/concatenation behavior.

* **Tests**
  * Added comprehensive tests covering compound `+=` for ARC-managed record fields across variable, chained field, and indexed access patterns, including nested collection cases.

* **Documentation**
  * Updated internal knowledge and changelog entries explaining the compound-assignment metadata behavior and the applied fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->