### PR TITLE
feat(ci): add UBSan to ASan build and new TSan build (#630)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,14 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+      - name: Lower ASLR entropy for TSan compatibility
+        # Ubuntu 24.04 (ubuntu-latest) defaults to vm.mmap_rnd_bits=32, which
+        # is incompatible with the TSan LargeMmapAllocator: it triggers
+        # "CHECK failed: sanitizer_allocator_secondary.h:297 ...IsAligned..."
+        # during deallocation. Lowering to 28 matches the pre-24.04 default
+        # and is the upstream-recommended workaround.
+        # See: https://github.com/google/sanitizers/issues/1716
+        run: sudo sysctl -w vm.mmap_rnd_bits=28
       - name: Install LLVM 21
         run: |
           wget https://apt.llvm.org/llvm.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,12 @@ jobs:
 
   tsan:
     runs-on: ubuntu-latest
-    # ThreadSanitizer job is currently warn-only: known data races in the
-    # @parallel for / ARC / GC layer (see issue #630) are expected to trigger
-    # TSan reports until the concurrency fixes land. Promote to required once
-    # #630 is resolved.
-    continue-on-error: true
+    # ThreadSanitizer *test* steps are currently warn-only: known data races
+    # in the @parallel for / ARC / GC layer (see issue #630) are expected to
+    # trigger TSan reports until the concurrency fixes land. Build/configure
+    # steps must still fail the job — continue-on-error is applied per test
+    # step below, not at the job level. Promote the test steps to required
+    # once #630 is resolved.
     steps:
       - uses: actions/checkout@v4
       - name: Lower ASLR entropy for TSan compatibility
@@ -137,10 +138,12 @@ jobs:
             -DENABLE_TSAN=ON
           cmake --build build-tsan
       - name: Test (C++ / TSan)
+        continue-on-error: true
         env:
           TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
         run: ./build-tsan/ry_tests
       - name: Test (Ry self-tests / TSan)
+        continue-on-error: true
         env:
           TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
         run: ./build-tsan/ry test -p

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,20 +75,64 @@ jobs:
           key: ci-asan-${{ github.ref }}
           restore-keys: |
             ci-asan-
-      - name: Build (ASan)
+      - name: Build (ASan + UBSan)
         run: |
           cmake -B build-asan -G Ninja \
             -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm \
             -DCMAKE_C_COMPILER=clang-21 \
             -DCMAKE_CXX_COMPILER=clang++-21 \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DENABLE_ASAN=ON
+            -DENABLE_ASAN=ON \
+            -DENABLE_UBSAN=ON
           cmake --build build-asan
-      - name: Test (C++ / ASan)
+      - name: Test (C++ / ASan + UBSan)
         env:
           ASAN_OPTIONS: detect_container_overflow=0:detect_leaks=0:halt_on_error=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: ./build-asan/ry_tests
-      - name: Test (Ry self-tests / ASan)
+      - name: Test (Ry self-tests / ASan + UBSan)
         env:
           ASAN_OPTIONS: detect_container_overflow=0:detect_leaks=0:halt_on_error=1
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
         run: ./build-asan/ry test -p
+
+  tsan:
+    runs-on: ubuntu-latest
+    # ThreadSanitizer job is currently warn-only: known data races in the
+    # @parallel for / ARC / GC layer (see issue #630) are expected to trigger
+    # TSan reports until the concurrency fixes land. Promote to required once
+    # #630 is resolved.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install LLVM 21
+        run: |
+          wget https://apt.llvm.org/llvm.sh
+          chmod +x llvm.sh
+          sudo ./llvm.sh 21
+          sudo apt-get install -y libllvm21 llvm-21-dev clang-21
+      - name: Install dependencies
+        run: sudo apt-get install -y libssl-dev ninja-build libgtest-dev libgmock-dev
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ci-tsan-${{ github.ref }}
+          restore-keys: |
+            ci-tsan-
+      - name: Build (TSan)
+        run: |
+          cmake -B build-tsan -G Ninja \
+            -DLLVM_DIR=/usr/lib/llvm-21/lib/cmake/llvm \
+            -DCMAKE_C_COMPILER=clang-21 \
+            -DCMAKE_CXX_COMPILER=clang++-21 \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DENABLE_TSAN=ON
+          cmake --build build-tsan
+      - name: Test (C++ / TSan)
+        env:
+          TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
+        run: ./build-tsan/ry_tests
+      - name: Test (Ry self-tests / TSan)
+        env:
+          TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
+        run: ./build-tsan/ry test -p

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@
 # build files
 build/
 build-asan/
+build-tsan/
 
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,8 @@ ASan または UBSan が検出した問題（メモリリーク、バッファ�
 ```bash
 cmake --preset tsan                                     # Debug + TSan（build-tsan/）
 cmake --build build-tsan                                # ビルド
-TSAN_OPTIONS=halt_on_error=1 ./build-tsan/ry_tests      # C++ テスト
-TSAN_OPTIONS=halt_on_error=1 ./build-tsan/ry test -p    # Ry セルフテスト
+TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests      # C++ テスト
+TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry test -p    # Ry セルフテスト
 ```
 
 > 現時点では `@parallel for` / ARC / GC 周りに既知のデータレースがある（issue #630）。TSan テストはそれらを検出して失敗しうるため、CI でも `continue-on-error: true` で warn-only 運用している。#630 の修正が landing したら required に昇格する。
@@ -358,8 +358,8 @@ ASan / UBSan が検出した問題は原因を修正してから作業完了と�
 
 ```bash
 cmake --preset tsan && cmake --build build-tsan && \
-  TSAN_OPTIONS=halt_on_error=1 ./build-tsan/ry_tests && \
-  TSAN_OPTIONS=halt_on_error=1 ./build-tsan/ry test -p
+  TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests && \
+  TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry test -p
 ```
 
 TSan は issue #630 の既知データレースにより失敗しうる。ビルドが成功すれば本 PR スコープでは OK とし、race が検出された場合は #630 にコメントで追記する。ただし**新しい変更が原因の race** は本 PR スコープ内で修正すること。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,20 +25,39 @@ cmake --build build                                     # Ninja が自動並列�
 - **書き方**: 1 つの教訓につき 1 エントリ。`Source` と `Tags` と `Rule` を必ず書く。詳細は `KNOWLEDGE.md` 冒頭の writing rules に従う
 - **言語**: 英語推奨（CodeRabbit / Codex 等 AI レビュワーも読める）
 
-## ASan（AddressSanitizer）
+## ASan + UBSan（Address + UndefinedBehavior Sanitizer）
 
-ローカル開発では ASan を有効にしてテストを実行する:
+ローカル開発では ASan と UBSan を同時に有効化してテストを実行する。`asan` preset は `ENABLE_ASAN=ON` と `ENABLE_UBSAN=ON` を両方設定する:
 
 ```bash
-cmake --preset asan                                     # Debug + ASan（build-asan/）
+cmake --preset asan                                     # Debug + ASan + UBSan（build-asan/）
 cmake --build build-asan                                # ビルド
-ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests      # C++ テスト（ASan 有効）
-ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p    # Ry セルフテスト（ASan 有効）
+ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
+    ./build-asan/ry_tests                               # C++ テスト
+ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
+    ./build-asan/ry test -p                             # Ry セルフテスト
 ```
 
 > `detect_container_overflow=0` は、ASan なしでビルドされた LLVM ライブラリとの混在で生じる false positive を抑制するために必要。
+>
+> UBSan は `-fno-sanitize=vptr,function` を付与してビルドされる。前者はプロジェクトが `-fno-rtti` を使うため動作せず、後者は LLVM が C 風の関数ポインタキャストを多用するため false positive の温床になる。
 
-ASan が検出した問題（メモリリーク、バッファオーバーフロー、use-after-free 等）は必ず解消すること。ASan エラーを残したままコミットしてはならない。
+ASan または UBSan が検出した問題（メモリリーク、バッファオーバーフロー、use-after-free、未定義動作等）は必ず解消すること。サニタイザーエラーを残したままコミットしてはならない。
+
+## TSan（ThreadSanitizer）
+
+スレッド安全性の検証には TSan ビルドを使う。TSan は ASan / UBSan と排他で、別ディレクトリ（`build-tsan/`）にビルドされる:
+
+```bash
+cmake --preset tsan                                     # Debug + TSan（build-tsan/）
+cmake --build build-tsan                                # ビルド
+TSAN_OPTIONS=halt_on_error=1 ./build-tsan/ry_tests      # C++ テスト
+TSAN_OPTIONS=halt_on_error=1 ./build-tsan/ry test -p    # Ry セルフテスト
+```
+
+> 現時点では `@parallel for` / ARC / GC 周りに既知のデータレースがある（issue #630）。TSan テストはそれらを検出して失敗しうるため、CI でも `continue-on-error: true` で warn-only 運用している。#630 の修正が landing したら required に昇格する。
+>
+> 本 PR スコープ外の既知 race が検出された場合は、#630 に再現ログをコメントで追記する。未知のパターンを発見した場合も #630 に追記する（新規 issue は不要）。
 
 ## メモリ安全ルール（C++ ランタイム）
 
@@ -323,15 +342,27 @@ cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry 
 
 テストが失敗した場合は、原因を修正してから作業完了とすること。
 
-### 3.5. ASan 検証
+### 3.5. サニタイザー検証
 
-ASan（AddressSanitizer）を有効にしたビルドでテストを実行し、メモリ安全性を確認する。
+**ASan + UBSan**（メモリ安全性 + 未定義動作）:
 
 ```bash
-cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry_tests && ASAN_OPTIONS=detect_container_overflow=0 ./build-asan/ry test -p
+cmake --preset asan && cmake --build build-asan && \
+  ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests && \
+  ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry test -p
 ```
 
-ASan エラーが検出された場合は、原因を修正してから作業完了とすること。ASan エラーを残したままコミットしてはならない。
+ASan / UBSan が検出した問題は原因を修正してから作業完了とする。これらのエラーを残したままコミットしてはならない。
+
+**TSan**（スレッド安全性）:
+
+```bash
+cmake --preset tsan && cmake --build build-tsan && \
+  TSAN_OPTIONS=halt_on_error=1 ./build-tsan/ry_tests && \
+  TSAN_OPTIONS=halt_on_error=1 ./build-tsan/ry test -p
+```
+
+TSan は issue #630 の既知データレースにより失敗しうる。ビルドが成功すれば本 PR スコープでは OK とし、race が検出された場合は #630 にコメントで追記する。ただし**新しい変更が原因の race** は本 PR スコープ内で修正すること。
 
 ### 4. ラベル整理
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,9 +25,33 @@ find_package(OpenSSL 3.0 REQUIRED)
 add_compile_options(-fno-rtti)
 
 option(ENABLE_ASAN "Enable AddressSanitizer" OFF)
+option(ENABLE_UBSAN "Enable UndefinedBehaviorSanitizer" OFF)
+option(ENABLE_TSAN "Enable ThreadSanitizer" OFF)
+
+if(ENABLE_TSAN AND (ENABLE_ASAN OR ENABLE_UBSAN))
+    message(FATAL_ERROR "ENABLE_TSAN cannot be combined with ENABLE_ASAN or ENABLE_UBSAN")
+endif()
+
 if(ENABLE_ASAN)
     add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
     add_link_options(-fsanitize=address)
+endif()
+
+if(ENABLE_UBSAN)
+    # vptr: プロジェクトは -fno-rtti でビルドされているため vptr チェックは機能しない
+    # function: LLVM が C 風の関数ポインタキャストを多用するため false positive だらけになる
+    add_compile_options(
+        -fsanitize=undefined
+        -fno-sanitize=vptr,function
+        -fno-sanitize-recover=undefined
+        -fno-omit-frame-pointer
+    )
+    add_link_options(-fsanitize=undefined)
+endif()
+
+if(ENABLE_TSAN)
+    add_compile_options(-fsanitize=thread -fno-omit-frame-pointer)
+    add_link_options(-fsanitize=thread)
 endif()
 
 find_package(LLVM REQUIRED CONFIG)
@@ -303,12 +327,15 @@ target_compile_definitions(ry_tests PRIVATE RY_BINARY_PATH="$<TARGET_FILE:ry>")
 target_precompile_headers(ry_tests REUSE_FROM ry_lib)
 
 include(GoogleTest)
-if(ENABLE_ASAN)
-    # ASan 有効時は gtest_discover_tests を使わない（ビルド時のバイナリ実行で
-    # LLVM の container-overflow false positive が発生するため）
+if(ENABLE_ASAN OR ENABLE_UBSAN OR ENABLE_TSAN)
+    # サニタイザー有効時は gtest_discover_tests を使わない:
+    #   - ASan: ビルド時のバイナリ実行で LLVM の container-overflow false positive が発生
+    #   - UBSan/TSan: 同様に discovery 時の実行が予期せぬ失敗を引き起こしうる
     add_test(NAME ry_tests COMMAND ry_tests)
-    set_tests_properties(ry_tests PROPERTIES
-        ENVIRONMENT "ASAN_OPTIONS=detect_container_overflow=0")
+    if(ENABLE_ASAN)
+        set_tests_properties(ry_tests PROPERTIES
+            ENVIRONMENT "ASAN_OPTIONS=detect_container_overflow=0")
+    endif()
 else()
     gtest_discover_tests(ry_tests)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,7 +23,17 @@
       "binaryDir": "${sourceDir}/build-asan",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "ENABLE_ASAN": "ON"
+        "ENABLE_ASAN": "ON",
+        "ENABLE_UBSAN": "ON"
+      }
+    },
+    {
+      "name": "tsan",
+      "inherits": "default",
+      "binaryDir": "${sourceDir}/build-tsan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "ENABLE_TSAN": "ON"
       }
     }
   ],
@@ -39,6 +49,10 @@
     {
       "name": "asan",
       "configurePreset": "asan"
+    },
+    {
+      "name": "tsan",
+      "configurePreset": "tsan"
     }
   ]
 }

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -796,6 +796,50 @@ touches concurrency at all.
   issue rather than filing a separate one. The goal is to keep the
   concurrency-audit trail in one place.
 
+### TSan on ubuntu-latest needs `vm.mmap_rnd_bits=28`
+
+**Source**: #868 CI (2026-04-11, implementation)
+**Tags**: tsan, sanitizer, ci, ubuntu-24.04, gotcha
+
+**Context**: When the `tsan` CI job was first landed in #868, the
+build and the C++ tests ran fine but the Ry self-tests crashed
+partway through with:
+
+```
+ThreadSanitizer: CHECK failed: sanitizer_allocator_secondary.h:297
+  "((IsAligned(p, page_size_))) != (0)" (0x0, 0x0)
+  #2 LargeMmapAllocator::Deallocate
+  #3 __tsan::user_free
+  #4 operator delete(void*)
+```
+
+This is **not** a race in ry code — it's a TSan runtime internal
+failure caused by Ubuntu 24.04 (the current `ubuntu-latest` runner)
+raising the default ASLR entropy from `vm.mmap_rnd_bits=28` to
+`vm.mmap_rnd_bits=32`. TSan's `LargeMmapAllocator` assumes the
+mmap-returned pointers fit within its expected range; at 32 bits
+of entropy the high bits collide with the allocator's metadata
+layout and the alignment CHECK trips during `free`.
+
+See upstream: https://github.com/google/sanitizers/issues/1716
+
+**Rule**: Any CI job that runs a TSan-instrumented binary on
+`ubuntu-latest` (or any Ubuntu ≥ 24.04 image) MUST lower the ASLR
+entropy first:
+
+```yaml
+- name: Lower ASLR entropy for TSan compatibility
+  run: sudo sysctl -w vm.mmap_rnd_bits=28
+```
+
+Apply this **before** the test step (the build step itself is fine
+— the issue is only at run time when the instrumented allocator
+actually services `free`). ASan does not need this workaround
+because it uses a different allocator layout.
+
+Locally on macOS this issue does not reproduce at all; the crash
+is specific to Linux + high-entropy ASLR.
+
 ---
 
 ## Documentation

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -805,7 +805,7 @@ touches concurrency at all.
 build and the C++ tests ran fine but the Ry self-tests crashed
 partway through with:
 
-```
+```text
 ThreadSanitizer: CHECK failed: sanitizer_allocator_secondary.h:297
   "((IsAligned(p, page_size_))) != (0)" (0x0, 0x0)
   #2 LargeMmapAllocator::Deallocate

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -741,7 +741,60 @@ directly for the tail line.
 
 ## Build / CI
 
-*(entries to be added as they are learned)*
+### UBSan must disable `vptr` and `function` checks on this project
+
+**Source**: #630 (2026-04-11, implementation)
+**Tags**: ubsan, sanitizer, cmake, llvm, cxx-flags
+
+**Context**: When enabling UBSan (`-fsanitize=undefined`) on ry, two
+sub-checks fail in ways that have nothing to do with actual
+undefined behavior:
+
+1. `vptr` — ry compiles with `-fno-rtti` (to match LLVM's build
+   flags, see `CMakeLists.txt:25`). The `vptr` check requires RTTI
+   to resolve virtual-call types, so enabling it under `-fno-rtti`
+   produces no coverage and in some toolchains hard-errors.
+2. `function` — LLVM exposes many C-style function pointers that
+   ry casts through `void *` (JIT symbol resolution, runtime
+   dispatch, etc.). UBSan's `function` check flags every one of
+   these as a type mismatch, drowning out real signal.
+
+**Rule**: When adding or extending UBSan flags in `CMakeLists.txt`,
+always pair `-fsanitize=undefined` with
+`-fno-sanitize=vptr,function`. Do not try to fix the false positives
+by changing the LLVM interop code — the checks themselves are the
+wrong tool for this codebase.
+
+**Also**: UBSan and ASan are compatible and are enabled together via
+the `asan` CMake preset (`ENABLE_ASAN=ON` + `ENABLE_UBSAN=ON`). TSan
+is **not** compatible with either and lives in its own `tsan` preset
+(`build-tsan/`). `CMakeLists.txt` enforces this with a
+`FATAL_ERROR` if `ENABLE_TSAN` is combined with the others.
+
+### TSan job is warn-only until #630's known races are fixed
+
+**Source**: #630 (2026-04-11, implementation)
+**Tags**: tsan, sanitizer, ci, concurrency, known-failure
+
+**Context**: The CI `tsan` job was added alongside the `asan` job
+but uses `continue-on-error: true`. The reason is that ry has
+documented, pre-existing data races in the `@parallel for` / ARC /
+GC layer (captured in issue #630's thread-safety audit). TSan
+correctly reports those races, so running the job in required mode
+would immediately block every PR regardless of whether the PR
+touches concurrency at all.
+
+**Rule**:
+
+- Do **not** flip `continue-on-error` to `false` on the `tsan` CI
+  job until #630's P0 fixes (atomic CoW guard, atomic strong_count,
+  auto-atomic capture in `@parallel for`) have landed.
+- When a PR introduces a **new** race, it is still the PR author's
+  responsibility to fix it — the warn-only status only covers the
+  catalog of known races documented in #630.
+- If TSan exposes a race pattern not yet in #630, add it to the
+  issue rather than filing a separate one. The goal is to keep the
+  concurrency-audit trail in one place.
 
 ---
 


### PR DESCRIPTION
## Summary

Extends sanitizer coverage for local dev and CI, addressing part of #630's acceptance criteria ("Add TSan CI job"). Race fixes themselves are out of scope for this PR — this just lays the infrastructure so they can be verified when they land.

- **ASan + UBSan**: the existing `asan` CMake preset now enables both. UBSan runs with `-fno-sanitize=vptr,function` because the project uses `-fno-rtti` (vptr is unusable) and LLVM's C-style function pointer casts produce too much noise on `function`.
- **TSan**: new `tsan` CMake preset (`build-tsan/`) and matching CI job. `CMakeLists.txt` refuses to combine `ENABLE_TSAN` with `ENABLE_ASAN`/`ENABLE_UBSAN`. CI job is `continue-on-error: true` until #630's P0 race fixes land.
- **Docs**: `AGENTS.md` sanitizer section rewritten; `KNOWLEDGE.md` has new entries explaining the UBSan/LLVM interaction and the TSan warn-only rationale.

## Local verification

Run on macOS + Apple clang 21 (Debug builds):

| Build | C++ tests | Ry self-tests |
|---|---|---|
| `default` (regression) | 1590 / 1590 | 111 files / 0 failures |
| `asan` (ASan + UBSan) | 1589 / 1589 | 111 files / 0 failures |
| `tsan` | 1590 / 1590 (inc. `ConcurrencySpecSuite`) | 111 files / 0 failures |

The clean TSan run is **not** a contradiction of #630's audit — the current test workload doesn't force the racy interleavings. See the progress comment on #630 for details.

## Why TSan is warn-only

#630 documents real structural races in `@parallel for` / ARC / GC. Promoting TSan to required before those fixes land would block unrelated PRs. Flip `continue-on-error: false` once #630's P0 criteria are met.

## No CHANGELOG fragment

This is developer-only build/CI infrastructure with no user-visible behavior change — no `changelog.d/` fragment needed.

## Test plan

- [ ] CI `test` job passes (default build regression)
- [ ] CI `asan` job passes with `ENABLE_UBSAN=ON` and `UBSAN_OPTIONS` set
- [ ] CI `tsan` job runs (warn-only); whether it passes or fails does not block merge
- [ ] `cmake --preset asan && cmake --build build-asan` succeeds locally
- [ ] `cmake --preset tsan && cmake --build build-tsan` succeeds locally
- [ ] `cmake --preset tsan && cmake -B build-asan -DENABLE_TSAN=ON` correctly fails with `FATAL_ERROR` if TSan is combined with ASan/UBSan

Refs #630

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs combined AddressSanitizer + UndefinedBehaviorSanitizer checks and adds a warn-only ThreadSanitizer job to surface races.
  * New UBSan/TSan build variants and presets are available; TSan uses a separate build output ignored by version control.
  * Build logic enforces sanitizer mutual-exclusivity and adjusts test registration for sanitizer builds.

* **Documentation**
  * Expanded sanitizer guidance and operational rules, including UBSan/TSan caveats, local validation commands, and CI handling policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->