### PR TITLE
feat: support string char iteration in for loops (#746, #827)

### DIFF
--- a/changelog.d/746-827-string-for-iteration.md
+++ b/changelog.d/746-827-string-for-iteration.md
@@ -1,0 +1,3 @@
+### Added
+
+- `for c in s:` now iterates a string character by character, yielding each UTF-8 code point as a single-character `str`. `enumerate(s)` and `zip(s, t)` also accept `str` arguments with the same semantics. (#746, #827)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -304,6 +304,8 @@ chars = split("あいう", "")
 print(chars)   # [あ, い, う]
 ```
 
+> **Tip:** To iterate a string character by character, you can use a `for` loop directly without calling `split`: `for c in s:` yields each UTF-8 code point as a single-character `str`. See [control-flow.md](control-flow.md#string-iteration).
+
 ---
 
 ## join

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -100,8 +100,8 @@
 | `sum(list)` | Returns the sum of all elements |
 | `min(list)` | Returns the minimum element |
 | `max(list)` | Returns the maximum element |
-| `enumerate(list)` | Returns a list of `(index, value)` tuples |
-| `zip(list1, list2)` | Returns a list of `(a, b)` tuples pairing elements from two lists |
+| `enumerate(list)` | Returns a list of `(index, value)` tuples. Also accepts a `str`, yielding `(int, str)` per UTF-8 code point |
+| `zip(list1, list2)` | Returns a list of `(a, b)` tuples pairing elements from two lists. Either (or both) arguments may be a `str` |
 | `keys(map)` | Returns all keys as a `List<K>` |
 | `values(map)` | Returns all values as a `List<V>` |
 | `merge(map1, map2)` | Returns a new map containing entries from both maps |

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -153,6 +153,38 @@ for i in range(start, end, step):
     # i = start, start+step, start+2*step, ...
 ```
 
+### String Iteration
+
+A `for` loop over a `str` yields each **Unicode code point** as a single-character `str`. Multi-byte UTF-8 sequences (including CJK characters and emoji) are decoded correctly; bytes within a multi-byte character are never split.
+
+```python
+for c in "hello":
+    print(c)               # h, e, l, l, o
+
+for c in "こんにちは":
+    print(c)               # こ, ん, に, ち, は  (not individual bytes)
+
+for c in "a🙂b":
+    print(c)               # a, 🙂, b
+```
+
+The loop variable is typed as `str`, so you can pass it to other string functions:
+
+```python
+for c in "abc":
+    print(to_upper(c))     # A, B, C
+```
+
+Iterating an empty string runs the loop body zero times. `enumerate` and `zip` also accept `str` arguments and yield the same code-point units:
+
+```python
+for i, c in enumerate("abc"):
+    print(i, c)
+
+for a, b in zip("abc", "xyz"):
+    print(a + b)           # ax, by, cz
+```
+
 ### Map Key-Value Iteration
 
 ```python

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -157,6 +157,8 @@ for i in range(start, end, step):
 
 A `for` loop over a `str` yields each **Unicode code point** as a single-character `str`. Multi-byte UTF-8 sequences (including CJK characters and emoji) are decoded correctly; bytes within a multi-byte character are never split.
 
+This is **code-point** iteration, not **grapheme-cluster** iteration: user-perceived characters that span multiple code points — combining-mark sequences (e.g., base letter + U+0301) and ZWJ emoji sequences (e.g., family or skin-tone compositions) — are yielded as several iterations, one per code point. If you need grapheme-cluster-aware iteration, decompose the string with a future segmentation helper rather than relying on `for c in s:`.
+
 ```python
 for c in "hello":
     print(c)               # h, e, l, l, o

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -454,6 +454,13 @@ public:
     // Used by enumerate()/zip() to build the tuple `list_elem_type_name`.
     std::string snapshotListElemName(llvm::Value *listVal, llvm::Type *elemTy);
 
+    // Desugar a Ry `str` value into a `List<str>` of UTF-8 code points by
+    // calling `__ry_split_chars` at codegen time. Returns the new list value
+    // already tagged with `TypeMeta::ListElem = ptrTy_` and
+    // `list_elem_type_name = "str"`. Shared by `for c in s:` iteration and
+    // by `enumerate(s)` / `zip(s, ...)` (#746, #827).
+    llvm::Value *emitStringToCharList(llvm::Value *s, const char *label);
+
     // Reject `name` if it is already registered under a different type kind
     // (record, enum, generic enum). Callers must check same-kind duplicates
     // themselves so they can emit a caller-specific error.

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -174,6 +174,17 @@ std::string CodeGen::snapshotListElemName(llvm::Value *listVal, llvm::Type *elem
     return name;
 }
 
+llvm::Value *CodeGen::emitStringToCharList(llvm::Value *s, const char *label) {
+    // Runtime returns a List<str> of UTF-8 code points. See
+    // src/runtime_utf8.cpp:__ry_split_chars. The result list is ARC-managed
+    // exactly like any other List<str> (#746, #827).
+    auto fn = getRuntimeFn("__ry_split_chars", ptrTy_, {ptrTy_});
+    llvm::Value *result = builder_.CreateCall(fn, {s}, label);
+    setTypeMeta(TypeMeta::ListElem, result, ptrTy_);
+    getOrCreateMeta(result).list_elem_type_name = "str";
+    return result;
+}
+
 // Returns a source-level type name for a value that can be stored in a
 // container literal's element-name slot. Despite the "Collection" in the
 // name, enum type names are also returned (needed by #820 so

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -315,7 +315,13 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         requireArgs(e, 1);
         llvm::Value *listVal = emitExpr(*e.args[0]);
         llvm::Type *elemTy = getListElementType(listVal);
-        if (!elemTy) codegenError("enumerate() requires a list");
+        // String fallback (#746, #827): enumerate over a str yields
+        // `(int, str)` pairs per UTF-8 code point.
+        if (!elemTy && isStringValue(listVal)) {
+            listVal = emitStringToCharList(listVal, "enum_str_chars");
+            elemTy = ptrTy_;
+        }
+        if (!elemTy) codegenError("enumerate() requires a list or str");
 
         // Snapshot the source list's element name so we can rebuild a tuple
         // type string "(int, <elem>)" for the result (#813). See
@@ -370,7 +376,18 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *list2 = emitExpr(*e.args[1]);
         llvm::Type *elemTy1 = getListElementType(list1);
         llvm::Type *elemTy2 = getListElementType(list2);
-        if (!elemTy1 || !elemTy2) codegenError("zip() requires two lists");
+        // String fallback (#746, #827): either (or both) zip arguments may
+        // be a str; each is desugared independently to a List<str>.
+        auto stringifyIfStr = [&](llvm::Value *&val, llvm::Type *&ty,
+                                   const char *name) {
+            if (!ty && isStringValue(val)) {
+                val = emitStringToCharList(val, name);
+                ty = ptrTy_;
+            }
+        };
+        stringifyIfStr(list1, elemTy1, "zip_str_chars1");
+        stringifyIfStr(list2, elemTy2, "zip_str_chars2");
+        if (!elemTy1 || !elemTy2) codegenError("zip() requires two lists or strs");
 
         // Snapshot both source element names before entering the IR loop
         // (same rationale as enumerate — see snapshotListElemName).

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -209,6 +209,14 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
         elemTy = getListElementType(iterable);
         headerTy = listHeaderTy_;
     }
+    // String iteration (#746, #827): `for c in s:` desugars to iterating
+    // the List<str> produced by __ry_split_chars, so each loop step yields
+    // one UTF-8 code point rather than a raw byte.
+    if (!elemTy && isStringValue(iterable)) {
+        iterable = emitStringToCharList(iterable, "for_str_chars");
+        elemTy = ptrTy_;
+        headerTy = listHeaderTy_;
+    }
     if (!elemTy)
         codegenError("cannot determine element type for for loop iterable");
 

--- a/tests/spec/string_for_iteration.test.ry
+++ b/tests/spec/string_for_iteration.test.ry
@@ -1,0 +1,86 @@
+describe("string for-loop iteration (#746, #827)", ():
+  it("should iterate an ASCII string character by character", ():
+    cs: List<str> = []
+    for c in "hello":
+      cs = cs + [c]
+    expect(cs).to_eq(["h", "e", "l", "l", "o"])
+  )
+
+  it("should iterate a multi-byte UTF-8 string by code points, not bytes", ():
+    cs: List<str> = []
+    for c in "こんにちは":
+      cs = cs + [c]
+    expect(cs).to_eq(["こ", "ん", "に", "ち", "は"])
+  )
+
+  it("should iterate a string containing 4-byte UTF-8 emoji", ():
+    cs: List<str> = []
+    for c in "a🙂b":
+      cs = cs + [c]
+    expect(cs).to_eq(["a", "🙂", "b"])
+  )
+
+  it("should iterate a string variable (not just a literal)", ():
+    s: str = "xyz"
+    cs: List<str> = []
+    for c in s:
+      cs = cs + [c]
+    expect(cs).to_eq(["x", "y", "z"])
+  )
+
+  it("should run the loop body zero times for an empty string", ():
+    count: int = 0
+    for c in "":
+      count = count + 1
+    expect(count).to_eq(0)
+  )
+
+  it("should bind the loop variable as str so string APIs accept it", ():
+    parts: List<str> = []
+    for c in "abc":
+      parts = parts + [to_upper(c)]
+    expect(parts).to_eq(["A", "B", "C"])
+  )
+
+  it("should support enumerate over a string", ():
+    indices: List<int> = []
+    chars: List<str> = []
+    for i, c in enumerate("abc"):
+      indices = indices + [i]
+      chars = chars + [c]
+    expect(indices).to_eq([0, 1, 2])
+    expect(chars).to_eq(["a", "b", "c"])
+  )
+
+  it("should support enumerate over a multi-byte string", ():
+    indices: List<int> = []
+    chars: List<str> = []
+    for i, c in enumerate("あい"):
+      indices = indices + [i]
+      chars = chars + [c]
+    expect(indices).to_eq([0, 1])
+    expect(chars).to_eq(["あ", "い"])
+  )
+
+  it("should support zip of two strings", ():
+    pairs: List<str> = []
+    for a, b in zip("abc", "xyz"):
+      pairs = pairs + [a + b]
+    expect(pairs).to_eq(["ax", "by", "cz"])
+  )
+
+  it("should zip a string with a List<str>", ():
+    labels: List<str> = ["first", "second", "third"]
+    out: List<str> = []
+    for c, label in zip("abc", labels):
+      out = out + [c + "=" + label]
+    expect(out).to_eq(["a=first", "b=second", "c=third"])
+  )
+
+  it("should handle zip over strings of different lengths (min length)", ():
+    pairs: List<str> = []
+    for a, b in zip("abcde", "xy"):
+      pairs = pairs + [a + b]
+    expect(pairs).to_eq(["ax", "by"])
+  )
+)

--- a/tests/spec/string_for_iteration.test.ry
+++ b/tests/spec/string_for_iteration.test.ry
@@ -20,6 +20,29 @@ describe("string for-loop iteration (#746, #827)", ():
     expect(cs).to_eq(["a", "🙂", "b"])
   )
 
+  it("should iterate combining marks by code point, not grapheme cluster", ():
+    # "é" in NFD form: base 'e' (U+0065) followed by combining acute (U+0301).
+    # A grapheme-cluster-aware iterator would yield one element; code-point
+    # iteration yields two. This test guards against accidental drift toward
+    # grapheme semantics.
+    cs: List<str> = []
+    for c in "é":
+      cs = cs + [c]
+    expect(length(cs)).to_eq(2)
+    expect(cs[0]).to_eq("e")
+  )
+
+  it("should iterate ZWJ sequences by code point, not grapheme cluster", ():
+    # "a" + ZWJ (U+200D) + "b" — three code points, one perceived cluster
+    # when rendered. Code-point iteration must yield exactly three elements.
+    cs: List<str> = []
+    for c in "a‍b":
+      cs = cs + [c]
+    expect(length(cs)).to_eq(3)
+    expect(cs[0]).to_eq("a")
+    expect(cs[2]).to_eq("b")
+  )
+
   it("should iterate a string variable (not just a literal)", ():
     s: str = "xyz"
     cs: List<str> = []


### PR DESCRIPTION
## Summary

- `for c in s:` now iterates a string by UTF-8 code points. Multi-byte sequences (CJK, emoji) are decoded correctly; bytes within a multi-byte character are never split. The loop variable is typed as `str`, so it can be passed to other string functions.
- `enumerate(s)` and `zip(s, t)` also accept `str` arguments with the same semantics. Either (or both) sides of `zip` can be a `str`.
- At codegen time, string iterables are desugared via a new `CodeGen::emitStringToCharList` helper that calls `__ry_split_chars` and tags the result as `List<str>`, so the normal list-iteration path handles binding, metadata, and ARC uniformly. Three call sites (for-loop, `enumerate`, `zip`) share the helper.

Closes #746
Closes #827

## Test plan

- [x] New `tests/spec/string_for_iteration.test.ry` covers ASCII, CJK code points, 4-byte emoji, literal vs variable, empty string, `to_upper(c)` type propagation, `enumerate(str)`, `zip(str, str)`, `zip(str, List<str>)`, and unequal-length `zip` (11 cases, all pass)
- [x] `./build/ry_tests` — 1590/1590 pass
- [x] `./build/ry test -p` — 112 files, 0 failures
- [x] ASan: `./build-asan/ry_tests` — 1589/1589 pass; `./build-asan/ry test -p` — 112 files, 0 failures
- [x] English docs updated: `docs/reference/control-flow.md` (new "String Iteration" section), `docs/reference/builtins.md` (enumerate/zip entries), `docs/reference/builtins-string.md` (cross-reference from `split`)
- [x] `changelog.d/746-827-string-for-iteration.md` fragment added

## Design notes

- Desugaring reuses the existing `__ry_split_chars` runtime (`src/runtime_utf8.cpp`) that `split(s, "")` already uses, so UTF-8 semantics are consistent.
- Tradeoff: the desugar path materializes a temporary `List<str>` for each iterated string. This matches the workaround users already have (`for c in s.split(""):`), so there is no regression. A zero-allocation stateful UTF-8 iterator is a possible future optimization.
- `propagateTypeMeta("str", loopVar)` is a no-op for primitives, so setting `list_elem_type_name = "str"` uniformly in `emitStringToCharList` preserves `isStringValue(loopVar) == true` at all three call sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * String iteration: `for c in s:` now iterates character-by-character over UTF-8 code points as single-character strings.
  * `enumerate()` and `zip()` now accept string arguments with the same iteration semantics.

* **Documentation**
  * Added comprehensive guides on string iteration behavior with examples for ASCII, multi-byte UTF-8, and emoji handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->