### PR TITLE
feat(math): add missing overloads for round/floor/ceil/log/pow (#842)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -39,6 +39,43 @@ grep -nE '\*\*Tags\*\*:.*codegen' KNOWLEDGE.md
 
 ## Testing
 
+### CodeGenTest::runSource cannot compile code that imports stdlib packages
+
+**Source**: #842 (2026-04-11, implementation)
+**Tags**: testing, codegen-test, stdlib, module-loader, harness
+
+**Context**: `CodeGenTest::runSource` / `expectCompileError` in
+`tests/test_codegen_common.hpp` goes directly from `Parser` to
+`CodeGen::compile` without invoking `ModuleLoader`. Source that contains
+`from math import ...` (or any stdlib import) therefore fails with
+`error: unresolved import: math (ModuleLoader should have resolved this)`
+because codegen expects the import node to have been pre-resolved.
+
+The only test harness that currently runs `ModuleLoader` is
+`ImportTest` (`tests/test_codegen_stmt.cpp:617`), which uses a tempdir
++ `writeFile()` — it is designed for user-level imports of files you
+write yourself, NOT for pulling in the real `share/std/*` packages.
+
+**Consequences for custom-emitter compile-error tests**: Rejection
+branches inside stdlib-package custom emitters
+(e.g. `emitMathPow`'s "requires (float, float) or (int, int)" error)
+cannot be covered via `expectCompileError` today. Workarounds:
+
+- Smoke-verify the error via `./build/ry -c '...'` during development
+  and document the expected error text in the PR description.
+- Add a happy-path test in `tests/spec/<pkg>.test.ry` that exercises the
+  *successful* branches of the custom emitter, so any refactor that
+  breaks dispatch is still caught by the Ry self-test suite.
+- A proper fix is to extend the C++ test harness with a helper that
+  sets up a `ModuleLoader` pointing at the repo's `share/` directory.
+  Tracked as a future enhancement; not blocking feature work.
+
+**Rule**: If you need a C++ unit test for a rejection branch inside a
+stdlib custom emitter, the harness limitation applies — fall back to
+smoke tests + document the gap in the PR. Don't add failing
+`expectCompileError` tests for `from math import` / `from json import`
+/ etc.
+
 ### Every new rejection branch needs a test that triggers it directly
 
 **Source**: #841 PR review (CodeRabbit, 2026-04-10)
@@ -605,6 +642,44 @@ also store an owning ARC pointer that must be released on overwrite —
 but live in the `FieldAssignStmt` write path which uses
 `InsertValue`/`store` of whole structs, requiring a field walker. Tracked
 separately from #855.
+
+### One dispatch-table entry per fn name handles multiple overloaded arities
+
+**Source**: #842 (2026-04-11, math overloads implementation)
+**Tags**: codegen, stdlib, dispatch-table, custom-emitter, overload
+
+**Context**: The stdlib dispatch tables (`math_table`, `string_table`,
+etc.) in `src/codegen_call*.cpp` are keyed by function name, and
+`emitTableDrivenNativeCall` (`src/codegen_call_native.cpp:21-28`) does a
+first-match-wins linear scan — so adding a second entry for the same
+name is a dead entry. For overloaded functions like `math.round` (1-arg
+→ int, 2-arg → float) or `math.pow` (`(float, float)` vs `(int, int)`),
+you must use a **single entry whose `customEmitter` handles every
+arity / type combination internally**.
+
+The custom-emitter gate at `codegen_call_native.cpp:135-149` dispatches
+based on the CALL's actual argument count against all registered
+`@native` sigs — not against the table entry's `arity` field. That
+means: once the new overload is declared as `@native` in
+`share/std/<pkg>/<pkg>.ry`, the custom emitter just checks
+`e.args.size()` (and argument LLVM types) and routes accordingly. The
+table-entry `arity` is effectively metadata / legacy hint for custom
+emitters; only the pure-table path (nullptr `customEmitter`) reads it.
+
+Upstream type matching (the type-match loop at
+`codegen_call_native.cpp:172-189`) runs only on the non-custom-emitter
+path, so **custom emitters must perform their own argument-type checks
+and emit clear `codegenError` messages** when types don't match any
+supported overload. Otherwise a mixed-type call like
+`pow(1, 2.0)` would silently reach the wrong branch.
+
+**Rule**: When adding an overload for an existing stdlib function with
+a custom emitter, (1) add the `@native function` declaration, (2)
+extend the existing custom emitter to handle the new arity / type
+combination, (3) add explicit type checks with clear errors for
+unsupported combinations — do NOT add a second table entry, it will
+never fire. See `emitMathFloorCeilRound` / `emitMathLog` /
+`emitMathPow` in `src/codegen_call.cpp` for the canonical pattern.
 
 ---
 

--- a/changelog.d/842-math-overloads.md
+++ b/changelog.d/842-math-overloads.md
@@ -1,0 +1,17 @@
+### Added
+
+- `math.round(x, digits)`, `math.floor(x, digits)`, and `math.ceil(x, digits)`
+  overloads for rounding a `float` to a given number of decimal places,
+  returning a `float`. Negative `digits` rounds to powers of ten
+  (`round(1234.5, -2) == 1200.0`). The two-argument forms reuse C99
+  half-away-from-zero semantics so the result matches the one-argument
+  `round()` applied to the scaled value — note this differs from Python's
+  banker's rounding (`round(2.675, 2) == 2.68`, not `2.67`). `NaN` and `±Inf`
+  pass through unchanged. (#842)
+- `math.log(x, base)` overload for computing a logarithm with an arbitrary
+  base, defined as `log(x) / log(base)`. Domain errors on either argument
+  propagate as `NaN` or `-Inf`. (#842)
+- `math.pow(x, y)` overload for `(int, int) -> int` using fast-exponentiation
+  (O(log y)). A negative exponent raises a runtime error
+  (`pow() integer exponent must be non-negative`). Overflow wraps silently,
+  matching Ry's existing integer arithmetic model. (#842)

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -50,16 +50,32 @@ abs(-3.14)   # 3.14
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `floor(x)` | `(float) -> int` | Round down to nearest integer |
+| `floor(x, digits)` | `(float, int) -> float` | Round down to given decimal places |
 | `ceil(x)` | `(float) -> int` | Round up to nearest integer |
-| `round(x)` | `(float) -> int` | Round to nearest integer |
+| `ceil(x, digits)` | `(float, int) -> float` | Round up to given decimal places |
+| `round(x)` | `(float) -> int` | Round to nearest integer (half away from zero) |
+| `round(x, digits)` | `(float, int) -> float` | Round to given decimal places (half away from zero) |
 
 ```python
 from math import floor, ceil, round
 
-floor(3.7)    # 3
-ceil(3.2)     # 4
-round(3.5)    # 4
+floor(3.7)           # 3
+ceil(3.2)            # 4
+round(3.5)           # 4
+
+round(3.14159, 2)    # 3.14
+floor(3.789, 1)      # 3.7
+ceil(3.123, 1)       # 3.2
 ```
+
+The two-argument forms accept negative `digits` for rounding to powers of ten:
+
+```python
+round(1234.5, -2)    # 1200.0
+round(1750.0, -3)    # 2000.0
+```
+
+Rounding uses C99 half-away-from-zero semantics (via `round(x * 10^digits) / 10^digits`), matching the one-argument form. This differs from Python's banker's rounding — for example, `round(2.675, 2) == 2.68`, not `2.67`. `NaN` and `±Inf` pass through unchanged.
 
 ---
 
@@ -69,13 +85,18 @@ round(3.5)    # 4
 |----------|-----------|-------------|
 | `sqrt(x)` | `(float) -> float` | Square root |
 | `pow(x, y)` | `(float, float) -> float` | x raised to the power of y |
+| `pow(x, y)` | `(int, int) -> int` | Integer exponentiation via fast-exponentiation |
 
 ```python
 from math import sqrt, pow
 
 sqrt(9.0)       # 3.0
 pow(2.0, 3.0)   # 8.0
+pow(2, 10)      # 1024
+pow(-2, 3)      # -8
 ```
+
+The integer overload raises a runtime error when the exponent is negative (`pow(2, -1)` aborts with `pow() integer exponent must be non-negative`). Overflow wraps silently, matching Ry's existing integer arithmetic model.
 
 ---
 
@@ -84,8 +105,18 @@ pow(2.0, 3.0)   # 8.0
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `log(x)` | `(float) -> float` | Natural logarithm (base e) |
+| `log(x, base)` | `(float, float) -> float` | Logarithm with arbitrary base |
 | `log2(x)` | `(float) -> float` | Base-2 logarithm |
 | `log10(x)` | `(float) -> float` | Base-10 logarithm |
+
+```python
+from math import log
+
+log(8.0, 2.0)      # 3.0
+log(100.0, 10.0)   # 2.0
+```
+
+`log(x, base)` is computed as `log(x) / log(base)`, so domain errors on either argument propagate as `NaN` or `-Inf`.
 
 ---
 

--- a/share/std/math/math.ry
+++ b/share/std/math/math.ry
@@ -25,10 +25,19 @@ function abs(x: float) -> float
 function floor(x: float) -> int
 
 @native
+function floor(x: float, digits: int) -> float
+
+@native
 function ceil(x: float) -> int
 
 @native
+function ceil(x: float, digits: int) -> float
+
+@native
 function round(x: float) -> int
+
+@native
+function round(x: float, digits: int) -> float
 
 @native
 function sqrt(x: float) -> float
@@ -37,7 +46,13 @@ function sqrt(x: float) -> float
 function pow(x: float, y: float) -> float
 
 @native
+function pow(x: int, y: int) -> int
+
+@native
 function log(x: float) -> float
+
+@native
+function log(x: float, base: float) -> float
 
 @native
 function log2(x: float) -> float

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -986,10 +986,16 @@ static llvm::Value *emitMathFloorCeilRound(CodeGen &cg, const CallExpr &e) {
         // to 0 when digits < -323, turning the multiply/divide into NaN.
         // Collapse to a sensible value in both extremes (Python-compatible):
         // scale==Inf → precision finer than double can represent → return x;
-        // scale==0 → precision coarser than any finite value → return 0,
-        // except non-finite x (NaN/±Inf) must pass through unchanged.
+        // scale==0 → precision coarser than any finite value → rounding at
+        //           a step larger than any representable magnitude. The
+        //           correct limit depends on callee/sign:
+        //             round: 0 for all finite x
+        //             floor: -Inf if x is finite negative, else 0
+        //             ceil : +Inf if x is finite positive, else 0
+        //           Non-finite x (NaN / ±Inf) passes through unchanged.
         llvm::Value *zeroD = llvm::ConstantFP::get(cg.f64Ty_, 0.0);
-        llvm::Value *infV = llvm::ConstantFP::getInfinity(cg.f64Ty_);
+        llvm::Value *infV  = llvm::ConstantFP::getInfinity(cg.f64Ty_);
+        llvm::Value *negInfV = llvm::ConstantFP::getInfinity(cg.f64Ty_, /*Negative=*/true);
         auto fabsFn = cg.getRuntimeFn("fabs", cg.f64Ty_, {cg.f64Ty_});
         llvm::Value *xAbs = cg.builder_.CreateCall(fabsFn, {x}, "x_abs");
         llvm::Value *xIsNaN = cg.builder_.CreateFCmpUNO(x, x, "x_is_nan");
@@ -997,8 +1003,34 @@ static llvm::Value *emitMathFloorCeilRound(CodeGen &cg, const CallExpr &e) {
         llvm::Value *xIsNonFinite = cg.builder_.CreateOr(xIsNaN, xIsInf, "x_nonfinite");
         llvm::Value *scaleIsInf  = cg.builder_.CreateFCmpOEQ(scale, infV, "scale_is_inf");
         llvm::Value *scaleIsZero = cg.builder_.CreateFCmpOEQ(scale, zeroD, "scale_is_zero");
-        llvm::Value *zeroOrX     = cg.builder_.CreateSelect(xIsNonFinite, x, zeroD, "scale_zero_val");
-        llvm::Value *afterZero   = cg.builder_.CreateSelect(scaleIsZero, zeroOrX, divided, "scale_zero_sel");
+
+        // Base fallback: non-finite x passes through, everything else is 0.
+        llvm::Value *scaleZeroVal =
+            cg.builder_.CreateSelect(xIsNonFinite, x, zeroD, "scale_zero_val");
+
+        // Callee-specific override: ceil(positive finite) → +Inf,
+        // floor(negative finite) → -Inf. Both FCmp ordered comparisons
+        // return false for non-finite x, so the base fallback wins there.
+        if (e.callee == "floor") {
+            llvm::Value *xIsNeg = cg.builder_.CreateFCmpOLT(x, zeroD, "x_is_neg");
+            llvm::Value *xIsNegFinite = cg.builder_.CreateAnd(
+                xIsNeg,
+                cg.builder_.CreateNot(xIsNonFinite, "x_finite"),
+                "x_neg_finite");
+            scaleZeroVal = cg.builder_.CreateSelect(
+                xIsNegFinite, negInfV, scaleZeroVal, "floor_scale_zero_val");
+        } else if (e.callee == "ceil") {
+            llvm::Value *xIsPos = cg.builder_.CreateFCmpOGT(x, zeroD, "x_is_pos");
+            llvm::Value *xIsPosFinite = cg.builder_.CreateAnd(
+                xIsPos,
+                cg.builder_.CreateNot(xIsNonFinite, "x_finite"),
+                "x_pos_finite");
+            scaleZeroVal = cg.builder_.CreateSelect(
+                xIsPosFinite, infV, scaleZeroVal, "ceil_scale_zero_val");
+        }
+
+        llvm::Value *afterZero = cg.builder_.CreateSelect(
+            scaleIsZero, scaleZeroVal, divided, "scale_zero_sel");
         return cg.builder_.CreateSelect(scaleIsInf, x, afterZero, "scale_inf_sel");
     }
 

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -980,7 +980,19 @@ static llvm::Value *emitMathFloorCeilRound(CodeGen &cg, const CallExpr &e) {
         llvm::Value *scaled = cg.builder_.CreateFMul(x, scale, "scaled");
         auto roundFn = cg.getRuntimeFn(e.callee.c_str(), cg.f64Ty_, {cg.f64Ty_});
         llvm::Value *rounded = cg.builder_.CreateCall(roundFn, {scaled}, e.callee);
-        return cg.builder_.CreateFDiv(rounded, scale, e.callee + "_unscaled");
+        llvm::Value *divided = cg.builder_.CreateFDiv(rounded, scale, e.callee + "_unscaled");
+
+        // Guard: 10^digits overflows to +Inf when digits > 308 and underflows
+        // to 0 when digits < -323, turning the multiply/divide into NaN.
+        // Collapse to a sensible value in both extremes (Python-compatible):
+        // scale==Inf → precision finer than double can represent → return x;
+        // scale==0 → precision coarser than any finite value → return 0.
+        llvm::Value *zeroD = llvm::ConstantFP::get(cg.f64Ty_, 0.0);
+        llvm::Value *infV = llvm::ConstantFP::getInfinity(cg.f64Ty_);
+        llvm::Value *scaleIsInf  = cg.builder_.CreateFCmpOEQ(scale, infV, "scale_is_inf");
+        llvm::Value *scaleIsZero = cg.builder_.CreateFCmpOEQ(scale, zeroD, "scale_is_zero");
+        llvm::Value *afterZero   = cg.builder_.CreateSelect(scaleIsZero, zeroD, divided, "scale_zero_sel");
+        return cg.builder_.CreateSelect(scaleIsInf, x, afterZero, "scale_inf_sel");
     }
 
     auto fabsFn = cg.getRuntimeFn("fabs", cg.f64Ty_, {cg.f64Ty_});

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -986,12 +986,19 @@ static llvm::Value *emitMathFloorCeilRound(CodeGen &cg, const CallExpr &e) {
         // to 0 when digits < -323, turning the multiply/divide into NaN.
         // Collapse to a sensible value in both extremes (Python-compatible):
         // scale==Inf → precision finer than double can represent → return x;
-        // scale==0 → precision coarser than any finite value → return 0.
+        // scale==0 → precision coarser than any finite value → return 0,
+        // except non-finite x (NaN/±Inf) must pass through unchanged.
         llvm::Value *zeroD = llvm::ConstantFP::get(cg.f64Ty_, 0.0);
         llvm::Value *infV = llvm::ConstantFP::getInfinity(cg.f64Ty_);
+        auto fabsFn = cg.getRuntimeFn("fabs", cg.f64Ty_, {cg.f64Ty_});
+        llvm::Value *xAbs = cg.builder_.CreateCall(fabsFn, {x}, "x_abs");
+        llvm::Value *xIsNaN = cg.builder_.CreateFCmpUNO(x, x, "x_is_nan");
+        llvm::Value *xIsInf = cg.builder_.CreateFCmpOEQ(xAbs, infV, "x_is_inf");
+        llvm::Value *xIsNonFinite = cg.builder_.CreateOr(xIsNaN, xIsInf, "x_nonfinite");
         llvm::Value *scaleIsInf  = cg.builder_.CreateFCmpOEQ(scale, infV, "scale_is_inf");
         llvm::Value *scaleIsZero = cg.builder_.CreateFCmpOEQ(scale, zeroD, "scale_is_zero");
-        llvm::Value *afterZero   = cg.builder_.CreateSelect(scaleIsZero, zeroD, divided, "scale_zero_sel");
+        llvm::Value *zeroOrX     = cg.builder_.CreateSelect(xIsNonFinite, x, zeroD, "scale_zero_val");
+        llvm::Value *afterZero   = cg.builder_.CreateSelect(scaleIsZero, zeroOrX, divided, "scale_zero_sel");
         return cg.builder_.CreateSelect(scaleIsInf, x, afterZero, "scale_inf_sel");
     }
 

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -960,10 +960,28 @@ static llvm::Value *emitMathAbs(CodeGen &cg, const CallExpr &e) {
 }
 
 static llvm::Value *emitMathFloorCeilRound(CodeGen &cg, const CallExpr &e) {
-    cg.requireArgs(e, 1);
+    if (e.args.size() != 1 && e.args.size() != 2)
+        cg.codegenError(e.callee + "() expects 1 or 2 arguments");
+
     llvm::Value *x = cg.emitExpr(*e.args[0]);
     if (x->getType() != cg.f64Ty_)
         cg.codegenError(e.callee + "() requires float argument");
+
+    if (e.args.size() == 2) {
+        // round(x * 10^digits) / 10^digits. Stays in float (no OOR check).
+        llvm::Value *digits = cg.emitExpr(*e.args[1]);
+        if (!digits->getType()->isIntegerTy(64))
+            cg.codegenError(e.callee + "() second argument must be int");
+
+        llvm::Value *digitsF = cg.builder_.CreateSIToFP(digits, cg.f64Ty_, "digits_f");
+        auto powFn = cg.getRuntimeFn("pow", cg.f64Ty_, {cg.f64Ty_, cg.f64Ty_});
+        llvm::Value *ten = llvm::ConstantFP::get(cg.f64Ty_, 10.0);
+        llvm::Value *scale = cg.builder_.CreateCall(powFn, {ten, digitsF}, "scale");
+        llvm::Value *scaled = cg.builder_.CreateFMul(x, scale, "scaled");
+        auto roundFn = cg.getRuntimeFn(e.callee.c_str(), cg.f64Ty_, {cg.f64Ty_});
+        llvm::Value *rounded = cg.builder_.CreateCall(roundFn, {scaled}, e.callee);
+        return cg.builder_.CreateFDiv(rounded, scale, e.callee + "_unscaled");
+    }
 
     auto fabsFn = cg.getRuntimeFn("fabs", cg.f64Ty_, {cg.f64Ty_});
 
@@ -985,10 +1003,96 @@ static llvm::Value *emitMathFloorCeilRound(CodeGen &cg, const CallExpr &e) {
                       ".math_err_" + std::to_string(mathErrCounter++));
 
     cg.builder_.SetInsertPoint(okBB);
-    auto fnTy = llvm::FunctionType::get(cg.f64Ty_, {cg.f64Ty_}, false);
-    auto fn = cg.mod_->getOrInsertFunction(e.callee, fnTy);
+    auto fn = cg.getRuntimeFn(e.callee.c_str(), cg.f64Ty_, {cg.f64Ty_});
     llvm::Value *result = cg.builder_.CreateCall(fn, {x}, e.callee);
     return cg.builder_.CreateFPToSI(result, cg.i64Ty_, e.callee + "_i");
+}
+
+static llvm::Value *emitMathLog(CodeGen &cg, const CallExpr &e) {
+    if (e.args.size() != 1 && e.args.size() != 2)
+        cg.codegenError("log() expects 1 or 2 arguments");
+
+    llvm::Value *x = cg.emitExpr(*e.args[0]);
+    if (x->getType() != cg.f64Ty_)
+        cg.codegenError("log() requires float argument");
+
+    auto logFn = cg.getRuntimeFn("log", cg.f64Ty_, {cg.f64Ty_});
+    llvm::Value *logX = cg.builder_.CreateCall(logFn, {x}, "log");
+
+    if (e.args.size() == 1)
+        return logX;
+
+    llvm::Value *base = cg.emitExpr(*e.args[1]);
+    if (base->getType() != cg.f64Ty_)
+        cg.codegenError("log() base argument must be float");
+    llvm::Value *logBase = cg.builder_.CreateCall(logFn, {base}, "log_base");
+    return cg.builder_.CreateFDiv(logX, logBase, "log_div");
+}
+
+static llvm::Value *emitMathPow(CodeGen &cg, const CallExpr &e) {
+    cg.requireArgs(e, 2);
+    llvm::Value *x = cg.emitExpr(*e.args[0]);
+    llvm::Value *y = cg.emitExpr(*e.args[1]);
+
+    if (x->getType() == cg.f64Ty_ && y->getType() == cg.f64Ty_) {
+        auto powFn = cg.getRuntimeFn("pow", cg.f64Ty_, {cg.f64Ty_, cg.f64Ty_});
+        return cg.builder_.CreateCall(powFn, {x, y}, "pow");
+    }
+
+    // (int, int): fast-exp loop. Overflow wraps silently to match Ry's
+    // int arithmetic model; negative exponent raises a runtime error.
+    if (x->getType()->isIntegerTy(64) && y->getType()->isIntegerTy(64)) {
+        llvm::Value *zero = llvm::ConstantInt::get(cg.i64Ty_, 0);
+        llvm::Value *one  = llvm::ConstantInt::get(cg.i64Ty_, 1);
+        llvm::Value *isNeg = cg.builder_.CreateICmpSLT(y, zero, "pow_neg_exp_chk");
+
+        llvm::BasicBlock *curBB = cg.builder_.GetInsertBlock();
+        llvm::BasicBlock *errBB =
+            llvm::BasicBlock::Create(*cg.ctx_, "pow_int.err", cg.fn_);
+        llvm::BasicBlock *condBB =
+            llvm::BasicBlock::Create(*cg.ctx_, "pow_int.cond", cg.fn_);
+        llvm::BasicBlock *bodyBB =
+            llvm::BasicBlock::Create(*cg.ctx_, "pow_int.body", cg.fn_);
+        llvm::BasicBlock *endBB =
+            llvm::BasicBlock::Create(*cg.ctx_, "pow_int.end", cg.fn_);
+        cg.builder_.CreateCondBr(isNeg, errBB, condBB);
+
+        cg.builder_.SetInsertPoint(errBB);
+        static int powErrCounter = 0;
+        cg.emitRuntimeError(
+            "runtime error: pow() integer exponent must be non-negative\n",
+            ".pow_int_err_" + std::to_string(powErrCounter++));
+
+        cg.builder_.SetInsertPoint(condBB);
+        llvm::PHINode *resultPhi =
+            cg.builder_.CreatePHI(cg.i64Ty_, 2, "pow_result");
+        llvm::PHINode *basePhi =
+            cg.builder_.CreatePHI(cg.i64Ty_, 2, "pow_base");
+        llvm::PHINode *expPhi =
+            cg.builder_.CreatePHI(cg.i64Ty_, 2, "pow_exp");
+        resultPhi->addIncoming(one, curBB);
+        basePhi->addIncoming(x, curBB);
+        expPhi->addIncoming(y, curBB);
+        llvm::Value *done = cg.builder_.CreateICmpEQ(expPhi, zero, "pow_done");
+        cg.builder_.CreateCondBr(done, endBB, bodyBB);
+
+        cg.builder_.SetInsertPoint(bodyBB);
+        llvm::Value *loBit = cg.builder_.CreateAnd(expPhi, one, "pow_lo_bit");
+        llvm::Value *isOdd = cg.builder_.CreateICmpNE(loBit, zero, "pow_is_odd");
+        llvm::Value *resultMul = cg.builder_.CreateMul(resultPhi, basePhi, "pow_result_mul");
+        llvm::Value *resultNext = cg.builder_.CreateSelect(isOdd, resultMul, resultPhi, "pow_result_next");
+        llvm::Value *baseSq = cg.builder_.CreateMul(basePhi, basePhi, "pow_base_sq");
+        llvm::Value *expShr = cg.builder_.CreateLShr(expPhi, one, "pow_exp_shr");
+        resultPhi->addIncoming(resultNext, bodyBB);
+        basePhi->addIncoming(baseSq, bodyBB);
+        expPhi->addIncoming(expShr, bodyBB);
+        cg.builder_.CreateBr(condBB);
+
+        cg.builder_.SetInsertPoint(endBB);
+        return resultPhi;
+    }
+
+    cg.codegenError("pow() requires (float, float) or (int, int) arguments");
 }
 
 static llvm::Value *emitMathIsNan(CodeGen &cg, const CallExpr &e) {
@@ -1015,7 +1119,6 @@ static llvm::Value *emitMathIsInf(CodeGen &cg, const CallExpr &e) {
 static const CodeGen::NativeDispatchEntry math_table[] = {
     // 1-arg float->float (bare C library names)
     {"sqrt",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "sqrt"},
-    {"log",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "log"},
     {"log2",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "log2"},
     {"log10", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "log10"},
     {"exp",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "exp"},
@@ -1026,14 +1129,17 @@ static const CodeGen::NativeDispatchEntry math_table[] = {
     {"acos",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "acos"},
     {"atan",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, nullptr, "atan"},
     // 2-arg float->float
-    {"pow",   nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, nullptr, "pow"},
     {"atan2", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, nullptr, "atan2"},
     {"hypot", nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, nullptr, "hypot"},
-    // Custom emitters
+    // Custom emitters (arity is metadata for the 1-arg legacy overload —
+    // actual arity dispatch happens via registered @native sigs at the
+    // custom-emitter gate in emitTableDrivenNativeCall; see codegen_call_native.cpp).
     {"abs",    nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathAbs},
     {"floor",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathFloorCeilRound},
     {"ceil",   nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathFloorCeilRound},
     {"round",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathFloorCeilRound},
+    {"log",    nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathLog},
+    {"pow",    nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitMathPow},
     {"is_nan", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathIsNan},
     {"is_inf", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathIsInf},
 };

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -69,6 +69,45 @@ describe("math rounding", ():
   )
 )
 
+describe("math rounding with digits", ():
+  it("should round to given decimal places", ():
+    expect(round(3.14159, 2)).to_eq(3.14)
+    expect(round(3.14159, 4)).to_eq(3.1416)
+    expect(round(3.14159, 0)).to_eq(3.0)
+  )
+  it("should round half away from zero (matches 1-arg round)", ():
+    expect(round(2.5, 0)).to_eq(3.0)
+    expect(round(-2.5, 0)).to_eq(-3.0)
+  )
+  it("should round to powers of ten with negative digits", ():
+    expect(round(1234.5, -2)).to_eq(1200.0)
+    expect(round(1750.0, -3)).to_eq(2000.0)
+    expect(round(-1250.0, -2)).to_eq(-1300.0)
+  )
+  it("should match the 1-arg round behavior under scaling", ():
+    # round(x, digits) is defined as round(x * 10^digits) / 10^digits using
+    # C99 round() (half-away-from-zero), so it matches whatever the 1-arg
+    # round() would produce on the scaled value. This differs from Python's
+    # banker's rounding. 2.675 is representable such that 2.675 * 100 rounds
+    # to 267.5 in double, and round(267.5) = 268, giving 2.68.
+    expect(round(2.675, 2)).to_eq(2.68)
+  )
+  it("should propagate NaN and Inf through rounding with digits", ():
+    expect(is_nan(round(NaN, 2))).to_be_true()
+    expect(is_inf(round(Inf, 2))).to_be_true()
+  )
+  it("should floor to given decimal places", ():
+    expect(floor(3.789, 1)).to_eq(3.7)
+    expect(floor(3.999, 2)).to_eq(3.99)
+    expect(floor(-2.3, 0)).to_eq(-3.0)
+  )
+  it("should ceil to given decimal places", ():
+    expect(ceil(3.123, 1)).to_eq(3.2)
+    expect(ceil(3.001, 2)).to_eq(3.01)
+    expect(ceil(-2.7, 0)).to_eq(-2.0)
+  )
+)
+
 describe("math pow/sqrt", ():
   it("should compute sqrt", ():
     expect(sqrt(4.0)).to_eq(2.0)
@@ -94,6 +133,33 @@ describe("math pow/sqrt", ():
   )
 )
 
+describe("math pow int overload", ():
+  it("should compute integer powers", ():
+    expect(pow(2, 3)).to_eq(8)
+    expect(pow(3, 4)).to_eq(81)
+    expect(pow(10, 5)).to_eq(100000)
+  )
+  it("should compute pow with zero exponent", ():
+    expect(pow(5, 0)).to_eq(1)
+    expect(pow(0, 0)).to_eq(1)
+  )
+  it("should compute pow with zero base", ():
+    expect(pow(0, 5)).to_eq(0)
+  )
+  it("should preserve sign with odd exponent", ():
+    expect(pow(-2, 3)).to_eq(-8)
+    expect(pow(-3, 5)).to_eq(-243)
+  )
+  it("should cancel sign with even exponent", ():
+    expect(pow(-2, 2)).to_eq(4)
+    expect(pow(-3, 4)).to_eq(81)
+  )
+  it("should compute small powers", ():
+    expect(pow(2, 1)).to_eq(2)
+    expect(pow(7, 2)).to_eq(49)
+  )
+)
+
 describe("math log", ():
   it("should compute log", ():
     expect(log(1.0)).to_eq(0.0)
@@ -109,6 +175,24 @@ describe("math log", ():
   )
   it("should compute log10", ():
     expect(log10(100.0)).to_eq(2.0)
+  )
+)
+
+describe("math log with base", ():
+  it("should compute log with base 2", ():
+    expect(log(8.0, 2.0)).to_eq(3.0)
+    expect(log(1024.0, 2.0)).to_eq(10.0)
+  )
+  it("should compute log with base 10", ():
+    expect(log(100.0, 10.0)).to_eq(2.0)
+    expect(log(1.0, 10.0)).to_eq(0.0)
+  )
+  it("should compute log with arbitrary base", ():
+    expect(log(81.0, 3.0)).to_eq(4.0)
+    expect(log(1.0, 5.0)).to_eq(0.0)
+  )
+  it("should return NaN for negative argument", ():
+    expect(is_nan(log(-1.0, 2.0))).to_be_true()
   )
 )
 

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -107,6 +107,16 @@ describe("math rounding with digits", ():
     expect(floor(9999.0, -500)).to_eq(0.0)
     expect(ceil(-9999.0, -1000)).to_eq(0.0)
   )
+  it("should preserve non-finite inputs even when 10^digits underflows", ():
+    # NaN / ±Inf must pass through the scale==0 shortcut unchanged;
+    # collapsing them to 0 would silently destroy the input.
+    expect(is_nan(round(NaN, -500))).to_be_true()
+    expect(is_nan(floor(NaN, -500))).to_be_true()
+    expect(is_nan(ceil(NaN, -500))).to_be_true()
+    expect(is_inf(round(Inf, -500))).to_be_true()
+    expect(is_inf(floor(Inf, -500))).to_be_true()
+    expect(is_inf(ceil(-Inf, -1000))).to_be_true()
+  )
   it("should floor to given decimal places", ():
     expect(floor(3.789, 1)).to_eq(3.7)
     expect(floor(3.999, 2)).to_eq(3.99)

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -96,6 +96,17 @@ describe("math rounding with digits", ():
     expect(is_nan(round(NaN, 2))).to_be_true()
     expect(is_inf(round(Inf, 2))).to_be_true()
   )
+  it("should short-circuit when 10^digits overflows or underflows", ():
+    # digits > 308 overflows pow(10, digits) to +Inf. Without a guard,
+    # the multiply/divide chain would return NaN. Collapse to x.
+    expect(round(1.23, 400)).to_eq(1.23)
+    expect(floor(1.23, 500)).to_eq(1.23)
+    expect(ceil(-3.14, 1000)).to_eq(-3.14)
+    # digits < -323 underflows pow(10, digits) to 0. Collapse to 0.
+    expect(round(1.23, -400)).to_eq(0.0)
+    expect(floor(9999.0, -500)).to_eq(0.0)
+    expect(ceil(-9999.0, -1000)).to_eq(0.0)
+  )
   it("should floor to given decimal places", ():
     expect(floor(3.789, 1)).to_eq(3.7)
     expect(floor(3.999, 2)).to_eq(3.99)
@@ -179,17 +190,19 @@ describe("math log", ():
 )
 
 describe("math log with base", ():
+  # log(x, base) is implemented as log(x) / log(base). Exact equality
+  # is brittle across libm implementations, so compare with a tolerance.
   it("should compute log with base 2", ():
-    expect(log(8.0, 2.0)).to_eq(3.0)
-    expect(log(1024.0, 2.0)).to_eq(10.0)
+    expect(abs(log(8.0, 2.0) - 3.0) < 1e-12).to_eq(true)
+    expect(abs(log(1024.0, 2.0) - 10.0) < 1e-12).to_eq(true)
   )
   it("should compute log with base 10", ():
-    expect(log(100.0, 10.0)).to_eq(2.0)
-    expect(log(1.0, 10.0)).to_eq(0.0)
+    expect(abs(log(100.0, 10.0) - 2.0) < 1e-12).to_eq(true)
+    expect(abs(log(1.0, 10.0) - 0.0) < 1e-12).to_eq(true)
   )
   it("should compute log with arbitrary base", ():
-    expect(log(81.0, 3.0)).to_eq(4.0)
-    expect(log(1.0, 5.0)).to_eq(0.0)
+    expect(abs(log(81.0, 3.0) - 4.0) < 1e-12).to_eq(true)
+    expect(abs(log(1.0, 5.0) - 0.0) < 1e-12).to_eq(true)
   )
   it("should return NaN for negative argument", ():
     expect(is_nan(log(-1.0, 2.0))).to_be_true()

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -102,10 +102,27 @@ describe("math rounding with digits", ():
     expect(round(1.23, 400)).to_eq(1.23)
     expect(floor(1.23, 500)).to_eq(1.23)
     expect(ceil(-3.14, 1000)).to_eq(-3.14)
-    # digits < -323 underflows pow(10, digits) to 0. Collapse to 0.
+    # digits < -323 underflows pow(10, digits) to 0. round always
+    # collapses finite x to 0 (nearest multiple of a huge step is 0).
+    # floor/ceil pick the sign-appropriate limit: floor(negative)=-Inf,
+    # ceil(positive)=+Inf, everything else collapses to 0.
     expect(round(1.23, -400)).to_eq(0.0)
-    expect(floor(9999.0, -500)).to_eq(0.0)
-    expect(ceil(-9999.0, -1000)).to_eq(0.0)
+    expect(round(-1250.0, -500)).to_eq(0.0)
+    expect(floor(9999.0, -500)).to_eq(0.0)   # positive → 0
+    expect(ceil(-9999.0, -1000)).to_eq(0.0)  # negative → 0
+    expect(floor(0.0, -500)).to_eq(0.0)
+    expect(ceil(0.0, -500)).to_eq(0.0)
+  )
+  it("should overflow ceil/floor toward ±Inf on sign-appropriate underflow", ():
+    # ceil(positive finite) with step larger than any representable value
+    # → smallest multiple of step ≥ x is +Inf.
+    expect(is_inf(ceil(1.23, -400))).to_be_true()
+    expect(ceil(1.23, -400) > 0.0).to_eq(true)
+    expect(is_inf(ceil(9999.0, -500))).to_be_true()
+    # floor(negative finite) → largest multiple of step ≤ x is -Inf.
+    expect(is_inf(floor(-1.23, -400))).to_be_true()
+    expect(floor(-1.23, -400) < 0.0).to_eq(true)
+    expect(is_inf(floor(-9999.0, -500))).to_be_true()
   )
   it("should preserve non-finite inputs even when 10^digits underflows", ():
     # NaN / ±Inf must pass through the scale==0 shortcut unchanged;

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -166,3 +166,23 @@ TEST_F(CodeGenTest, NestedFunctionCannotModifyCapturedVariable) {
         "print(outer())\n"
     ), std::runtime_error);
 }
+
+// ============================================================
+// math.pow(int, int) with a negative exponent aborts at runtime.
+//
+// Declares `pow` via a bare `@native` so the dispatcher's fallback
+// bare-name lookup routes the call through `emitMathPow` in
+// `math_table` without needing `ModuleLoader` to resolve the real
+// stdlib import (see KNOWLEDGE.md "CodeGenTest::runSource cannot
+// compile stdlib-import code").
+// ============================================================
+
+TEST_F(CodeGenTest, MathPowIntNegativeExponentAborts) {
+    EXPECT_EXIT(
+        runSource(
+            "@native\n"
+            "function pow(x: int, y: int) -> int\n"
+            "print(pow(2, -1))\n"),
+        ::testing::ExitedWithCode(1),
+        "pow\\(\\) integer exponent must be non-negative");
+}


### PR DESCRIPTION
## Summary

Closes #842. Adds five math-package overloads that users naturally expect:

- `round(x: float, digits: int) -> float`
- `floor(x: float, digits: int) -> float`
- `ceil(x: float, digits: int) -> float`
- `log(x: float, base: float) -> float`
- `pow(x: int, y: int) -> int`

The motivating case is the misleading \`undefined function: round\` error on \`round(pie, 2)\`. After this PR, the original repro works:

\`\`\`ry
from math import round
pie = 3.14159265
print(round(pie, 2))   # 3.14
\`\`\`

## Design notes

- **Rounding with digits**: `round(x * 10^digits) / 10^digits`, staying in `float` (no OOR check). Inherits C99 half-away-from-zero from the 1-arg form, so `round(2.675, 2) == 2.68` (differs from Python's banker's rounding — documented in `docs/reference/math.md`). Negative `digits` supported (`round(1234.5, -2) == 1200.0`). NaN/Inf pass through unchanged.
- **`log(x, base)`**: emitted as `log(x) / log(base)`. Domain errors propagate via C `log` as NaN / -Inf.
- **`pow(int, int)`**: fast-exponentiation IR loop (O(log y)). Negative exponent raises a runtime error (`pow() integer exponent must be non-negative`). Overflow wraps silently to match Ry's existing int arithmetic model.
- **Dispatch**: `log` and `pow` are moved from direct-dispatch `math_table` entries to custom emitters (`emitMathLog`, `emitMathPow`). The table lookup is first-match-wins, so a single entry per name must serve all overloaded arities; the custom-emitter gate in `emitTableDrivenNativeCall` dispatches by call-arity against registered `@native` sigs. This pattern is now documented in `KNOWLEDGE.md`.
- **No new `src/runtime_math.cpp`**: all five overloads fit cleanly in inline IR, matching the existing math dispatch pattern (current math has zero runtime helpers).

## Error surfaces

Compile-time type errors for mismatched overloads (manually verified via `./build/ry -c`, not covered by `expectCompileError` due to a C++ test-harness limitation documented in a new KNOWLEDGE.md entry):

- `round(3.14, 2.0)` → `round() second argument must be int`
- `log(8.0, 2)` → `log() base argument must be float`
- `pow(2, 3.0)` → `pow() requires (float, float) or (int, int) arguments`

Runtime error, also manually verified:

- `pow(2, -1)` → `runtime error: pow() integer exponent must be non-negative`

## Changes

- `share/std/math/math.ry` — 5 new `@native function` declarations
- `src/codegen_call.cpp` — extend `emitMathFloorCeilRound`, new `emitMathLog` / `emitMathPow`, route `log`/`pow` through custom emitters
- `tests/spec/math.test.ry` — 3 new `describe` blocks, 18 new cases
- `docs/reference/math.md` — new table rows + behavior notes
- `changelog.d/842-math-overloads.md` — new fragment
- `KNOWLEDGE.md` — 2 new entries (dispatch-table one-entry-per-name rule, CodeGenTest stdlib-import harness limitation)

## Test plan

- [x] `./build/ry_tests` — 1590/1590 pass
- [x] `./build/ry test -p` — 112 test files, 0 failures
- [x] `tests/spec/math.test.ry` — 61/61 pass (18 new + 43 existing)
- [x] ASan + UBSan via `cmake --preset asan` — 1589 C++ tests + 112 Ry files clean
- [x] Manual smoke: issue #842 original repro, all 3 type-mismatch compile errors, `pow(2, -1)` runtime error
- [x] Manual smoke: `round(1234.5, -2) == 1200.0`, `log(8.0, 2.0) == 3.0`, `pow(2, 10) == 1024`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added decimal-place overloads for floor(), ceil(), and round() (preserve NaN/±Inf; half-away-from-zero), log(x, base), and integer pow(x, y) (fast exponentiation; negative exponents error).

* **Documentation**
  * Updated math reference, changelog, and knowledge lessons with examples, semantics, dispatch/emitter behavior, and workarounds.

* **Tests**
  * Added unit tests for rounding, log, and integer pow; added a failing runtime test for negative integer exponents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->