### PR TITLE
fix: deep (path) copy-on-write for chained writes through nested collections (#854)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -641,8 +641,9 @@ runtime value metadata.
 **Follow-up landed** (#854): Deep-chain middle-hop ARC ownership —
 intermediate record hops that are shallow-copied through
 `writeBackFieldChain`, and more generally any chained LHS whose root is
-not a direct `VariableExpr` — is now handled by path CoW (`emitPathCow`
-in `src/codegen_arc_cow.cpp`). Record-to-record assignment retains each
+not a direct `VariableExpr` — is now handled by path CoW
+(`emitPathCowForChain` in `src/codegen_arc_cow.cpp`), which drives
+`emitCowCheckSlot` at each hop. Record-to-record assignment retains each
 ARC field (`emitRecordArcFieldsRetain`) so path CoW can observe
 strong_count > 1 at the record-field slot; scope exit releases the
 fields (`emitRecordArcFieldsRelease`). See "Path copy-on-write isolates

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -454,29 +454,58 @@ address exactly once in codegen. For maps, a compound op on a missing key
 is a runtime error (`"compound assignment to missing map key"`) — users
 must insert the key explicitly before accumulating.
 
-### Chained writes through nested collections are shallow — document, don't silently deep-copy
+### Path copy-on-write isolates chained writes through nested collections
 
-**Source**: #812 + follow-up issue (2026-04-11)
-**Tags**: codegen, cow, arc, nested-collections, semantics
+**Source**: #812 (shallow baseline) + #854 (path CoW) (2026-04-11)
+**Tags**: codegen, cow, arc, nested-collections, path-cow, semantics
 
 **Context**: `emitCowCheck` only copies the top-level header and data
-buffer; inner element pointers are bit-copied, so a CoW of `List<List<int>>`
-leaves the inner lists shared with any aliases. The #812 fix exposes this
-more frequently because users now routinely write `grid[i][j] = v`,
-`rec.items[i] = v`, `m["a"]["x"] = v`. The chosen semantics for v0.0.8 is
-"shallow CoW", meaning chained writes mutate shared heap state in place
-and may be observable through aliases. Deep CoW is tracked as a follow-up
-issue.
+buffer; inner element pointers are bit-copied. The top-level 1-hop CoW
+path used by `var[i] = v` / `var.append(...)` keeps this "shallow"
+behavior — cheap, documented in `docs/reference/collections.md`, tested
+by `tests/spec/cow.test.ry`. Top-level mutations on simple collections
+do not need element retain because the leaf slot-overwrite protocol
+(#855) owns ownership transfer.
 
-**Rule**: When implementing new mutation paths on collections, decide up
-front whether the semantic is deep-copy, shallow-copy-at-root-only, or
-"just mutate in place". Do not silently deep-copy — it changes the
-complexity model and may double-free ARC elements. Document the chosen
-semantic in the reference docs and `KNOWLEDGE.md`. When the LHS chain has
-a non-`VariableExpr` base (`rec.field[i] = v`, `grid[i][j] = v`), pass
-`nullptr` as the CoW anchor to `emitCowCheck` so it stays a no-op; any
-"proper" write-back through a record chain requires deep CoW and should be
-part of the follow-up.
+Chained writes (`b[i][j] = v`, `r.items[i] = v`, `m[k1][k2] = v`) cannot
+use the top-level path: the LHS root would resolve to nullptr CoW anchor
+and the mutation would leak through aliases. The #854 fix introduces
+**path CoW** — a second code path rooted in `emitPathCowForChain` that
+walks the LHS inside-out, privatizes every container level whose
+`strong_count > 1`, and retains each ARC element of the cloned buffer
+(via the previously-unused `emitCowRetainArcElements`). The new
+`emitCowCheckSlot` generalizes `emitCowCheck` to accept any writable
+slot (alloca, module-global storage, nested record field GEP, heap
+container data GEP) rather than just an alloca.
+
+The collection destructors (`__ry_arc_dtor_list/map/set` in
+`src/codegen_arc.cpp:633-665`) still only free internal buffers and do
+not release ARC-managed elements. This is the pre-existing "element leak
+on destructor" bug, accepted by the `detect_leaks=0` budget. Path CoW's
+retain-on-clone amplifies this leak by a small constant (one extra leak
+per mutation chain on shared inner collections) — same order of
+magnitude, tracked as a separate follow-up along with insertion retain
+protocol changes.
+
+**Rule**: When implementing a new mutation path that can reach a
+container through a chained LHS, route through `emitPathCowForChain`
+(the caller passes `s.object` — everything except the innermost leaf
+index). Do NOT evaluate `s.object` with a plain `emitExpr` first —
+that re-loads the chain against stale parents after privatization.
+The top-level 1-hop CoW in `emitCowCheck` still uses
+`retainElements=false`; the path CoW path uses `retainElements=true`.
+The asymmetry is deliberate: top-level CoW relies on #855's
+retain-then-release-old slot protocol at the leaf store to transfer
+inner ownership, whereas path CoW needs each intermediate container's
+siblings to survive (inner lists that are not on the mutation path).
+
+**Unsupported shapes** (compile-time error from path CoW):
+- Method-call roots: `f().items[i] = v`
+- Chains that interleave an index hop inside a record field walk
+  (e.g. `rec.arr[0].items[i] = v`). Assign the intermediate to a local.
+These match the narrow #854 scope; record-of-records chains without
+interleaved index hops (`d.out.items[i] = v`) ARE supported via a
+multi-level struct GEP through the root alloca.
 
 ### Compound-op loaded slot values must propagate container metadata
 
@@ -607,10 +636,18 @@ three `FieldAssignStmt` branches (VariableExpr / FieldAccessExpr /
 IndexExpr) and introducing a string-based `fieldTypeIsArcManaged`
 predicate that consults the AST `FieldDef.type->toString()` rather than
 container metadata — record fields are typed by declaration, not by
-runtime value metadata. Deep-chain middle-hop ARC ownership (e.g.
+runtime value metadata.
+
+**Follow-up landed** (#854): Deep-chain middle-hop ARC ownership —
 intermediate record hops that are shallow-copied through
-`writeBackFieldChain`) remains out of scope here and is tracked with
-the deep-CoW work in issue `#854`.
+`writeBackFieldChain`, and more generally any chained LHS whose root is
+not a direct `VariableExpr` — is now handled by path CoW (`emitPathCow`
+in `src/codegen_arc_cow.cpp`). Record-to-record assignment retains each
+ARC field (`emitRecordArcFieldsRetain`) so path CoW can observe
+strong_count > 1 at the record-field slot; scope exit releases the
+fields (`emitRecordArcFieldsRelease`). See "Path copy-on-write isolates
+chained writes through nested collections" earlier in this file for
+the full protocol and unsupported shapes.
 
 ---
 

--- a/changelog.d/854-path-cow.md
+++ b/changelog.d/854-path-cow.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Chained writes through nested collections (`a[i][j] = v`, `r.items[i] = v`, `m[k1][k2] = v`) no longer leak through aliases. Path copy-on-write walks the LHS from root to leaf and clones every level whose reference count is greater than one before the mutation (#854)
+- Record-to-record assignment (`r2 = r1`) now retains ARC-managed fields (`List<T>`, `Map<K, V>`, `Set<T>`) so both aliases share ownership of the inner containers. A subsequent mutation through one alias is isolated from the other by path copy-on-write (#854)

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -176,12 +176,12 @@ m["a"] += 10            # OK  → {"a": 11}
 m["b"] += 10            # runtime error: compound assignment to missing map key
 ```
 
-> **Aliasing caveat**: nested collection writes (`grid[i][j] = v`,
-> `r.items[i] = v` through a record field containing a list) currently apply
-> copy-on-write only at the outermost container. If you have multiple
-> variables sharing inner collection pointers, mutating through one is
-> observable through the other. Use explicit copies to isolate writes. Deep
-> CoW is tracked in the follow-up issue for this feature.
+> **Nested writes are isolated**: chained writes like `grid[i][j] = v` and
+> `r.items[i] = v` (through a record field containing a list) privatize
+> every level on the LHS path whose reference count > 1 before the
+> mutation lands, so aliases of the outer container — or any inner
+> container on the path — observe the pre-write state. See
+> [Path Copy-on-Write](#path-copy-on-write) below for the details.
 
 ### length
 
@@ -523,8 +523,8 @@ print(xs)            # [[1, 2], [3, 4]] (unchanged)
 All collection types (List, Map, Set) use **Copy-on-Write** semantics when managed by ARC. This means:
 
 - **Assignment shares data**: `b = a` does not copy the collection — both variables reference the same data. The reference count is incremented.
-- **Mutation triggers a shallow copy**: When a shared collection is mutated (e.g., `append`, `remove`, index assignment), the outermost container's header and element buffer are copied before the mutation; element pointers in that buffer are bit-copied, so any nested heap-allocated elements (`List<List<T>>`, `List<Record>` with collection fields, etc.) remain shared with the original. Only the mutator pays the cost of the outer copy.
-- **Unique owners mutate in-place**: When a collection has only one reference (`strong_count == 1`), mutations are performed in-place with zero copy overhead.
+- **Mutation triggers a path-walking copy**: When a shared collection is mutated, every level on the LHS path whose reference count > 1 is cloned before the mutation lands. A top-level write (`b.append(...)`, `b[i] = v` with `b` shared) clones only the outermost container. A chained write (`b[i][j] = v`, `r.items[i] = v`, `m[k1][k2] = v`) walks from the root down and clones each intervening container that is still shared, so aliases of the outer container — or any inner container on the path — are isolated from the mutation.
+- **Unique owners mutate in-place**: When a collection (or the container at some hop) has only one reference (`strong_count == 1`), the CoW check skips the clone for that level and mutates in-place with zero copy overhead.
 
 ```python
 a = [1, 2, 3]       # strong_count = 1
@@ -537,11 +537,44 @@ c = [10, 20]         # strong_count = 1
 append(c, 30)        # strong_count == 1 → mutate in-place (no copy)
 ```
 
-> **Nested aliasing**: because CoW is shallow, chained writes through nested
-> collections (`grid[i][j] = v`, `rec.items[i] = v`) mutate the inner heap
-> state in place even after the outer container is privatized. Aliases that
-> share inner element pointers will observe the mutation. Use an explicit
-> deep copy if you need full isolation. Tracked as a follow-up to #812.
+### Path Copy-on-Write
+
+Path CoW handles chained writes through nested collections — the writer walks
+from the LHS root variable (or record field) down to the leaf write site and
+privatizes each level whose reference count is greater than one. This gives
+strict aliasing isolation between aliases sharing the outer container and any
+inner container on the write path.
+
+```python
+a = [[1, 2], [3, 4]]
+b = a                    # outer list shared: strong_count = 2
+b[0][0] = 99             # walks: clone outer (a and b now have their own
+                         # outer); clone b's inner[0] (a's inner[0] keeps [1, 2]);
+                         # write 99 into the clone
+# a = [[1, 2], [3, 4]]
+# b = [[99, 2], [3, 4]]
+```
+
+Record fields with ARC-managed collection values participate in path CoW
+the same way as direct index hops. Record-to-record assignment (`r2 = r1`)
+retains each ARC field so a subsequent `r2.items[i] = v` observes the
+refcount > 1 at the field slot and clones before mutating:
+
+```python
+record Box:
+  items: List<int>
+
+r1 = Box([1, 2, 3])
+r2 = r1
+r2.items[0] = 99
+# r1.items[0] == 1
+# r2.items[0] == 99
+```
+
+**Not supported** as the root of a path-CoW chain: method-call lvalues
+(`f().x[i] = v`) and chains that interleave an index hop inside a record
+field walk (`rec.arr[0].items[i] = v`). These shapes produce a compile-time
+error; assign the intermediate value to a local variable first.
 
 ### Operations that trigger CoW
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -236,6 +236,33 @@ public:
     bool fieldTypeIsArcManaged(const std::string &fieldTypeName,
                                 CollectionKind *outFieldKind = nullptr);
 
+    // Returns true if the struct type has at least one ARC-managed field
+    // (List/Map/Set, non-weak). Caller must pass a struct type registered
+    // in `struct_types_`. Used to drive retain/release of record ARC
+    // fields on copy and scope exit (#854 Layer 2).
+    bool structHasArcFields(llvm::StructType *st);
+
+    // Retains each ARC-managed field of an in-flight record SSA value.
+    // Emits null-guarded `emitArcRetain` on each field's header pointer.
+    // Used when copying a record value into a new variable so both
+    // aliases share ownership of the inner ARC containers (#854 Layer
+    // 2). Without this, a subsequent path-CoW through one alias would
+    // see strong_count==1 and mutate in place, breaking isolation from
+    // the other alias.
+    void emitRecordArcFieldsRetain(llvm::Value *recordVal,
+                                     llvm::StructType *st);
+
+    // Releases each ARC-managed field of an in-flight record SSA value.
+    // Symmetric to emitRecordArcFieldsRetain. Used on record scope exit
+    // and record re-assignment (#854 Layer 2).
+    void emitRecordArcFieldsRelease(llvm::Value *recordVal,
+                                      llvm::StructType *st);
+
+    // Allocas holding records whose type has at least one ARC-managed
+    // field. Populated at declaration time so `emitScopeCleanupToDepth`
+    // can walk and release the ARC fields before the struct dies.
+    std::unordered_set<llvm::AllocaInst*> arc_field_struct_vars_;
+
     // Releases an already-loaded ARC element pointer with a null guard
     // and CFG branching. The builder's insertion point is left at the
     // join block on return so the caller can continue emitting the
@@ -247,6 +274,25 @@ public:
 
     llvm::AllocaInst *tryGetReceiverAlloca(const ExprNode &expr);
     llvm::Value *emitCowCheck(llvm::Value *dataPtr, llvm::AllocaInst *alloca, CollectionKind kind);
+    // Generalized CoW: `slotPtr` is any pointer to the storage cell holding
+    // the container data pointer (alloca, module-global storage, record
+    // field slot, or heap container slot). When `retainElements` is true
+    // AND the container's element type is ARC-managed, each element pointer
+    // in the cloned buffer is retained so the clone shares ownership of
+    // nested ARC state with the original. Used by path CoW (#854) to walk
+    // chained LHS hops and privatize each level whose refcount > 1.
+    llvm::Value *emitCowCheckSlot(llvm::Value *dataPtr, llvm::Value *slotPtr,
+                                    CollectionKind kind, bool retainElements);
+    // Walk a chained LHS `object` expression (typically `s.object` from
+    // IndexAssignStmt / FieldAssignStmt) inside-out, privatize every
+    // container level in the chain, and return the privatized leaf
+    // container pointer. For IndexExpr and FieldAccessExpr bases the walk
+    // recursively descends until it reaches a VariableExpr root. For
+    // VariableExpr it is a 1-hop privatization equivalent to the existing
+    // trivial emitCowCheck path (but with retainElements=true). Used to
+    // implement deep (path) copy-on-write for nested collection writes
+    // through aliases (#854).
+    llvm::Value *emitPathCowForChain(ExprNode &chain);
     llvm::Value *emitCowDeepCopyList(llvm::Value *oldDataPtr, llvm::Type *elemTy);
     llvm::Value *emitCowDeepCopyMap(llvm::Value *oldDataPtr, llvm::Type *keyTy, llvm::Type *valTy);
     llvm::Value *emitCowDeepCopySet(llvm::Value *oldDataPtr, llvm::Type *elemTy);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -340,6 +340,18 @@ void CodeGen::emitScopeCleanupToDepth(size_t targetDepth) {
                 weak_inner_type_names_.erase(alloca);
                 continue;
             }
+            // Records with ARC fields (#854 Layer 2): release each ARC
+            // field to pair with the retain-on-copy at emitVarDecl /
+            // AssignStmt so path CoW at `r.field[i] = v` observes the
+            // correct strong_count on inner containers.
+            if (arc_field_struct_vars_.count(alloca)) {
+                auto *recSt = llvm::cast<llvm::StructType>(alloca->getAllocatedType());
+                llvm::Value *recVal = builder_.CreateLoad(
+                    recSt, alloca, name + ".record_scope_cleanup");
+                emitRecordArcFieldsRelease(recVal, recSt);
+                arc_field_struct_vars_.erase(alloca);
+                continue;
+            }
             if (!arc_managed_vars_.count(alloca)) continue;
             emitArcReleaseVar(name, alloca);
             arc_managed_vars_.erase(alloca);

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -375,6 +375,76 @@ bool CodeGen::fieldTypeIsArcManaged(const std::string &fieldTypeName,
     return false;
 }
 
+// ===== Record ARC field retain/release (#854 Layer 2) =====
+
+bool CodeGen::structHasArcFields(llvm::StructType *st) {
+    if (!st || !st->hasName())
+        return false;
+    auto it = struct_types_.find(st->getName().str());
+    if (it == struct_types_.end())
+        return false;
+    for (const auto &fd : it->second.fields) {
+        if (!fd.type) continue;
+        if (fieldTypeIsArcManaged(fd.type->toString()))
+            return true;
+    }
+    return false;
+}
+
+void CodeGen::emitRecordArcFieldsRetain(llvm::Value *recordVal,
+                                          llvm::StructType *st) {
+    if (!st || !st->hasName())
+        return;
+    auto it = struct_types_.find(st->getName().str());
+    if (it == struct_types_.end())
+        return;
+    const auto &info = it->second;
+    for (unsigned i = 0; i < info.fields.size(); ++i) {
+        const auto &fd = info.fields[i];
+        if (!fd.type) continue;
+        CollectionKind fk;
+        if (!fieldTypeIsArcManaged(fd.type->toString(), &fk))
+            continue;
+        llvm::Value *fieldVal = builder_.CreateExtractValue(
+            recordVal, i, fd.name + ".record_retain");
+        // Null guard — freshly-inserted fields are always non-null in
+        // practice but cheap to defend against for robustness.
+        auto *isNull = builder_.CreateICmpEQ(
+            fieldVal,
+            llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
+            fd.name + ".record_retain_null");
+        auto *fn = builder_.GetInsertBlock()->getParent();
+        auto *retainBB = llvm::BasicBlock::Create(*ctx_, "record.field_retain", fn);
+        auto *skipBB = llvm::BasicBlock::Create(*ctx_, "record.field_retain_skip", fn);
+        builder_.CreateCondBr(isNull, skipBB, retainBB);
+        builder_.SetInsertPoint(retainBB);
+        auto *hdr = emitArcGetHeaderFromData(fieldVal);
+        emitArcRetain(hdr, /*atomic=*/false);
+        builder_.CreateBr(skipBB);
+        builder_.SetInsertPoint(skipBB);
+    }
+}
+
+void CodeGen::emitRecordArcFieldsRelease(llvm::Value *recordVal,
+                                           llvm::StructType *st) {
+    if (!st || !st->hasName())
+        return;
+    auto it = struct_types_.find(st->getName().str());
+    if (it == struct_types_.end())
+        return;
+    const auto &info = it->second;
+    for (unsigned i = 0; i < info.fields.size(); ++i) {
+        const auto &fd = info.fields[i];
+        if (!fd.type) continue;
+        CollectionKind fk;
+        if (!fieldTypeIsArcManaged(fd.type->toString(), &fk))
+            continue;
+        llvm::Value *fieldVal = builder_.CreateExtractValue(
+            recordVal, i, fd.name + ".record_release");
+        emitArcReleaseLoadedElement(fieldVal, fk, fd.name);
+    }
+}
+
 bool CodeGen::elementTypeIsArcManaged(llvm::Value *containerPtr,
                                        CollectionKind containerKind,
                                        CollectionKind *outElemKind) {

--- a/src/codegen_arc_cow.cpp
+++ b/src/codegen_arc_cow.cpp
@@ -319,18 +319,23 @@ llvm::Value *CodeGen::emitPathCowForChain(ExprNode &chain) {
     // subsequent hops observe the correct refcount on inner containers.
     if (auto *ve = std::get_if<VariableExpr>(&chain.data)) {
         llvm::Value *slotPtr = nullptr;
+        // Metadata anchor: for an alloca it's the alloca itself; for a
+        // module global it's `ModuleBinding.original_alloca` (the real
+        // storage in __ry_main__). `loadModuleGlobalStorage` returns the
+        // trampoline-loaded storage pointer which has no metadata.
+        llvm::AllocaInst *metaAnchor = nullptr;
         if (llvm::AllocaInst *alloca = findVar(ve->name)) {
             slotPtr = alloca;
+            metaAnchor = alloca;
         } else if (auto *b = findModuleGlobal(ve->name)) {
             slotPtr = loadModuleGlobalStorage(*b, ve->name);
+            metaAnchor = b->original_alloca;
         } else {
             codegenError("undefined variable: " + ve->name);
         }
         llvm::Value *containerPtr = builder_.CreateLoad(ptrTy_, slotPtr, ve->name + ".pcow_root");
-        // Transfer metadata from the slot so kind detection and element
-        // type queries work on the loaded pointer.
-        if (auto *alloca = llvm::dyn_cast<llvm::AllocaInst>(slotPtr))
-            propagateMeta(alloca, containerPtr);
+        if (metaAnchor)
+            propagateMeta(metaAnchor, containerPtr);
         CollectionKind kind = CollectionKind::List;
         if (getMapKeyType(containerPtr))
             kind = CollectionKind::Map;

--- a/src/codegen_arc_cow.cpp
+++ b/src/codegen_arc_cow.cpp
@@ -175,6 +175,23 @@ llvm::Value *CodeGen::emitCowCheck(llvm::Value *dataPtr,
         }
     }
 
+    // Delegate to the generalized slot-based form. The trivial `var[i] = v`
+    // path does NOT retain elements during clone: the canonical #855
+    // retain-then-release-old slot protocol at the leaf mutation still owns
+    // the "transfer ownership from old to new slot value" semantics, and
+    // preserving that keeps existing 1-hop CoW tests unchanged.
+    return emitCowCheckSlot(dataPtr, alloca, kind, /*retainElements=*/false);
+}
+
+// ===== Slot-based CoW (#854 path CoW support) =====
+
+llvm::Value *CodeGen::emitCowCheckSlot(llvm::Value *dataPtr,
+                                         llvm::Value *slotPtr,
+                                         CollectionKind kind,
+                                         bool retainElements) {
+    if (!slotPtr)
+        return dataPtr;
+
     auto *fn = builder_.GetInsertBlock()->getParent();
     auto *headerPtr = emitArcGetHeaderFromData(dataPtr);
     auto *strongPtr = builder_.CreateStructGEP(arcHeaderTy_, headerPtr, 0, "cow_strong_ptr");
@@ -191,6 +208,16 @@ llvm::Value *CodeGen::emitCowCheck(llvm::Value *dataPtr,
     builder_.CreateCondBr(skipCow, contBB, copyBB);
 
     builder_.SetInsertPoint(copyBB);
+
+    // Determine whether elements need retention BEFORE cloning: the
+    // metadata query uses `dataPtr` which is the *old* container ptr that
+    // still carries the element-type metadata propagated at construction.
+    // The cloned buffer does not receive metadata automatically — we have
+    // to drive the retain loop from here rather than from
+    // `emitCowDeepCopyList` so the decision uses the correct source.
+    CollectionKind elemArcKind = CollectionKind::List;
+    bool doElemRetain =
+        retainElements && elementTypeIsArcManaged(dataPtr, kind, &elemArcKind);
 
     llvm::Value *newDataPtr = nullptr;
     switch (kind) {
@@ -216,11 +243,46 @@ llvm::Value *CodeGen::emitCowCheck(llvm::Value *dataPtr,
     }
     }
 
+    // Retain each ARC-managed element in the cloned buffer so the clone
+    // shares ownership of nested state with the original. Without this,
+    // the subsequent release of the old header would drop the strong
+    // count of elements still reachable through the original alias to
+    // zero, corrupting heap state. This is what wires up the previously-
+    // unused `emitCowRetainArcElements` helper (#854 path CoW).
+    if (doElemRetain) {
+        llvm::Value *elemBuf = nullptr;
+        llvm::Value *elemLen = nullptr;
+        switch (kind) {
+        case CollectionKind::List: {
+            auto *lenPtr = builder_.CreateStructGEP(listHeaderTy_, newDataPtr, 0, "cow_ret_len_ptr");
+            elemLen = builder_.CreateLoad(i64Ty_, lenPtr, "cow_ret_len");
+            auto *dataField = builder_.CreateStructGEP(listHeaderTy_, newDataPtr, 2, "cow_ret_data_field");
+            elemBuf = builder_.CreateLoad(ptrTy_, dataField, "cow_ret_data");
+            break;
+        }
+        case CollectionKind::Map: {
+            auto *lenPtr = builder_.CreateStructGEP(mapHeaderTy_, newDataPtr, 0, "cow_ret_len_ptr");
+            elemLen = builder_.CreateLoad(i64Ty_, lenPtr, "cow_ret_len");
+            auto *valsField = builder_.CreateStructGEP(mapHeaderTy_, newDataPtr, 3, "cow_ret_vals_field");
+            elemBuf = builder_.CreateLoad(ptrTy_, valsField, "cow_ret_vals");
+            break;
+        }
+        case CollectionKind::Set: {
+            auto *lenPtr = builder_.CreateStructGEP(setHeaderTy_, newDataPtr, 0, "cow_ret_len_ptr");
+            elemLen = builder_.CreateLoad(i64Ty_, lenPtr, "cow_ret_len");
+            auto *elemsField = builder_.CreateStructGEP(setHeaderTy_, newDataPtr, 2, "cow_ret_elems_field");
+            elemBuf = builder_.CreateLoad(ptrTy_, elemsField, "cow_ret_elems");
+            break;
+        }
+        }
+        emitCowRetainArcElements(elemBuf, elemLen, "cow_elem");
+    }
+
     // Reuse headerPtr (dominates copyBB) instead of re-computing
     emitArcRelease(headerPtr, isArcAtomic(dataPtr),
                    getOrCreateCollectionDestructor(kind));
 
-    builder_.CreateStore(newDataPtr, alloca);
+    builder_.CreateStore(newDataPtr, slotPtr);
     arc_owned_values_.insert(newDataPtr);
 
     auto *copyEndBB = builder_.GetInsertBlock();
@@ -231,10 +293,216 @@ llvm::Value *CodeGen::emitCowCheck(llvm::Value *dataPtr,
     phi->addIncoming(dataPtr, origBB);
     phi->addIncoming(newDataPtr, copyEndBB);
 
-    // Propagate all metadata (type_meta_, fn_type_info_, etc.) to the PHI
-    propagateMeta(alloca, phi);
+    // Propagate metadata so downstream type queries on the result work.
+    // When the slot is an alloca we can use the existing propagateMeta
+    // keyed on the alloca; otherwise we copy from the source ptr which
+    // still has its metadata.
+    if (auto *alloca = llvm::dyn_cast<llvm::AllocaInst>(slotPtr)) {
+        propagateMeta(alloca, phi);
+    } else {
+        propagateMetaWide(dataPtr, phi);
+    }
 
     return phi;
+}
+
+// ===== Path CoW driver (#854) =====
+
+// Walks `chain` (typically `s.object` from IndexAssignStmt / FieldAssignStmt)
+// inside-out, privatizing every container level whose strong_count > 1 so
+// the final mutation on the leaf cannot leak through aliases. Returns the
+// privatized leaf container pointer. Throws codegenError for unsupported
+// shapes (method-call roots, non-lvalue chains, etc.).
+llvm::Value *CodeGen::emitPathCowForChain(ExprNode &chain) {
+    // Base case: VariableExpr is the chain root. Privatize via the slot
+    // (alloca or module-global storage) with retainElements=true so that
+    // subsequent hops observe the correct refcount on inner containers.
+    if (auto *ve = std::get_if<VariableExpr>(&chain.data)) {
+        llvm::Value *slotPtr = nullptr;
+        if (llvm::AllocaInst *alloca = findVar(ve->name)) {
+            slotPtr = alloca;
+        } else if (auto *b = findModuleGlobal(ve->name)) {
+            slotPtr = loadModuleGlobalStorage(*b, ve->name);
+        } else {
+            codegenError("undefined variable: " + ve->name);
+        }
+        llvm::Value *containerPtr = builder_.CreateLoad(ptrTy_, slotPtr, ve->name + ".pcow_root");
+        // Transfer metadata from the slot so kind detection and element
+        // type queries work on the loaded pointer.
+        if (auto *alloca = llvm::dyn_cast<llvm::AllocaInst>(slotPtr))
+            propagateMeta(alloca, containerPtr);
+        CollectionKind kind = CollectionKind::List;
+        if (getMapKeyType(containerPtr))
+            kind = CollectionKind::Map;
+        else if (getSetElementType(containerPtr))
+            kind = CollectionKind::Set;
+        return emitCowCheckSlot(containerPtr, slotPtr, kind, /*retainElements=*/true);
+    }
+
+    // Recursive case: IndexExpr hop. Privatize the parent first, then
+    // reach into the new parent's data/vals buffer to find the child slot
+    // and privatize the child stored there.
+    if (auto *idxPtr = std::get_if<std::unique_ptr<IndexExpr>>(&chain.data)) {
+        IndexExpr *idx = idxPtr->get();
+        if (idx->indices.size() != 1)
+            codegenError("path CoW: multi-index hop not supported");
+        llvm::Value *parent = emitPathCowForChain(*idx->object);
+        if (parent->getType() != ptrTy_)
+            codegenError("path CoW: parent is not a heap collection");
+        // Determine parent kind from metadata (propagated by recursive call).
+        CollectionKind parentKind = CollectionKind::List;
+        llvm::Type *mapKeyTy = getMapKeyType(parent);
+        if (mapKeyTy)
+            parentKind = CollectionKind::Map;
+        llvm::Value *indexVal = emitExpr(*idx->indices[0]);
+
+        llvm::Value *childSlot = nullptr;
+        if (parentKind == CollectionKind::Map) {
+            if (indexVal->getType() != mapKeyTy)
+                codegenError("map key type mismatch in nested assignment");
+            llvm::Type *mapValTy = getMapValueType(parent);
+            if (!mapValTy)
+                codegenError("cannot determine map value type for nested assignment");
+            llvm::Value *slot = emitMapKeyLookup(parent, indexVal, mapKeyTy);
+            llvm::Value *missing = builder_.CreateICmpSLT(
+                slot, llvm::ConstantInt::get(i64Ty_, 0), "pcow_map_missing");
+            auto *fn = builder_.GetInsertBlock()->getParent();
+            auto *errBB = llvm::BasicBlock::Create(*ctx_, "pcow_map_err", fn);
+            auto *okBB = llvm::BasicBlock::Create(*ctx_, "pcow_map_ok", fn);
+            builder_.CreateCondBr(missing, errBB, okBB);
+            builder_.SetInsertPoint(errBB);
+            emitRuntimeError("runtime error: missing map key in nested assignment\n",
+                             ".pcow_map_missing");
+            builder_.SetInsertPoint(okBB);
+            llvm::Value *valsField = builder_.CreateStructGEP(
+                mapHeaderTy_, parent, 3, "pcow_vals_field");
+            llvm::Value *valsPtr = builder_.CreateLoad(ptrTy_, valsField, "pcow_vals");
+            childSlot = builder_.CreateGEP(mapValTy, valsPtr, {slot}, "pcow_slot");
+        } else {
+            // List hop
+            llvm::Type *elemTy = getListElementType(parent);
+            if (!elemTy)
+                codegenError("cannot determine list element type for nested assignment");
+            llvm::Value *lenPtr = builder_.CreateStructGEP(
+                listHeaderTy_, parent, 0, "pcow_len_ptr");
+            llvm::Value *length = builder_.CreateLoad(i64Ty_, lenPtr, "pcow_length");
+            emitBoundsCheck(indexVal, length,
+                            "runtime error: index %lld out of bounds for list of length %lld\n",
+                            ".pcow_list_err", "pcow_list");
+            llvm::Value *dataField = builder_.CreateStructGEP(
+                listHeaderTy_, parent, 2, "pcow_data_field");
+            llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataField, "pcow_data");
+            childSlot = builder_.CreateGEP(elemTy, dataPtr, {indexVal}, "pcow_slot");
+        }
+
+        llvm::Value *child = builder_.CreateLoad(ptrTy_, childSlot, "pcow_child");
+        // Propagate inner-container type metadata from the parent's
+        // element_type_name so downstream emitCowCheckSlot / recursive
+        // hops can detect the child's kind and element ARC-ness.
+        std::string childTypeName;
+        if (auto *parentMeta = getMeta(parent)) {
+            if (parentKind == CollectionKind::Map)
+                childTypeName = parentMeta->map_value_type_name;
+            else
+                childTypeName = parentMeta->list_elem_type_name;
+        }
+        if (!childTypeName.empty())
+            propagateTypeMeta(childTypeName, child);
+        CollectionKind childKind = CollectionKind::List;
+        if (getMapKeyType(child))
+            childKind = CollectionKind::Map;
+        else if (getSetElementType(child))
+            childKind = CollectionKind::Set;
+        return emitCowCheckSlot(child, childSlot, childKind, /*retainElements=*/true);
+    }
+
+    // Recursive case: FieldAccessExpr hop reaching an ARC container
+    // field through a (possibly nested) record path. The chain root
+    // must be a simple variable so we can GEP into its backing
+    // storage — we then walk the entire FAE chain from outermost
+    // variable down to the ARC-container field and compute a single
+    // multi-level struct GEP that yields a writable slot.
+    // Method-call roots (`f().items[i] = v`) and field chains
+    // interleaved with IndexExpr hops (`rec.arr[0].items[i] = v`)
+    // are not supported in the narrow #854 scope.
+    if (auto *faPtr = std::get_if<std::unique_ptr<FieldAccessExpr>>(&chain.data)) {
+        // `fieldChain` is ordered leaf-first (outermost FAE at index 0).
+        std::vector<FieldAccessExpr *> fieldChain;
+        ExprNode *cur = &chain;
+        while (auto *fp = std::get_if<std::unique_ptr<FieldAccessExpr>>(&cur->data)) {
+            fieldChain.push_back(fp->get());
+            cur = fp->get()->object.get();
+        }
+        auto *ve = std::get_if<VariableExpr>(&cur->data);
+        if (!ve)
+            codegenError("path CoW: record base must be a variable "
+                         "(method-call roots and interleaved index hops not supported)");
+        llvm::Value *storagePtr = nullptr;
+        llvm::Type *curTy = nullptr;
+        if (llvm::AllocaInst *alloca = findVar(ve->name)) {
+            storagePtr = alloca;
+            curTy = alloca->getAllocatedType();
+        } else if (auto *b = findModuleGlobal(ve->name)) {
+            storagePtr = loadModuleGlobalStorage(*b, ve->name);
+            curTy = b->valueTy();
+        } else {
+            codegenError("undefined variable: " + ve->name);
+        }
+        // Walk from root (closest to variable) to leaf (ARC field).
+        // `fieldChain` is ordered leaf-first, so iterate in reverse.
+        llvm::StructType *curSt = nullptr;
+        llvm::Type *fieldTy = nullptr;
+        std::string fieldTypeName;
+        for (int i = static_cast<int>(fieldChain.size()) - 1; i >= 0; --i) {
+            FieldAccessExpr *thisFa = fieldChain[i];
+            curSt = llvm::dyn_cast<llvm::StructType>(curTy);
+            if (!curSt)
+                codegenError("path CoW: non-struct intermediate in record chain");
+            auto sit = struct_types_.find(curSt->getName().str());
+            if (sit == struct_types_.end())
+                codegenError("unknown struct type: " + curSt->getName().str());
+            int fieldIdx = sit->second.findField(thisFa->field);
+            if (fieldIdx < 0)
+                codegenError("type '" + sit->first + "' has no field '" + thisFa->field + "'");
+            storagePtr = builder_.CreateStructGEP(
+                curSt, storagePtr, fieldIdx,
+                "pcow_" + thisFa->field + "_slot");
+            fieldTy = curSt->getElementType(fieldIdx);
+            if (sit->second.fields[fieldIdx].type)
+                fieldTypeName = sit->second.fields[fieldIdx].type->toString();
+            else
+                fieldTypeName.clear();
+            curTy = fieldTy;
+        }
+        // `storagePtr` is now the slot pointer for the innermost field.
+        // If that field is not ARC-managed (e.g. `d.tag = ...` where
+        // tag is a str), path CoW has nothing to do — fall through to
+        // a plain no-op that just returns the loaded value. The caller
+        // will treat that as a non-lvalue leaf and let the regular
+        // index/field assignment code paths fire.
+        if (!fieldTypeName.empty() && fieldTypeIsArcManaged(fieldTypeName)) {
+            llvm::Value *fieldContainer = builder_.CreateLoad(
+                fieldTy, storagePtr, "pcow_field_val");
+            propagateTypeMeta(fieldTypeName, fieldContainer);
+            CollectionKind fieldKind = CollectionKind::List;
+            if (getMapKeyType(fieldContainer))
+                fieldKind = CollectionKind::Map;
+            else if (getSetElementType(fieldContainer))
+                fieldKind = CollectionKind::Set;
+            return emitCowCheckSlot(fieldContainer, storagePtr, fieldKind,
+                                    /*retainElements=*/true);
+        }
+        // Non-ARC field: just load and return. No CoW is applicable —
+        // the caller's leaf mutation path will handle this.
+        llvm::Value *fieldContainer = builder_.CreateLoad(
+            fieldTy, storagePtr, "pcow_nonarc_field");
+        if (!fieldTypeName.empty())
+            propagateTypeMeta(fieldTypeName, fieldContainer);
+        return fieldContainer;
+    }
+
+    codegenError("path CoW: chain root must be an lvalue (variable, field access, or index)");
+    return nullptr;
 }
 
 // ===== Closure ARC support =====

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -308,9 +308,9 @@ void CodeGen::emitVarDecl(const std::string &name,
     // *source* of the stored value decides whether ownership is "moved"
     // (fresh construction from a constructor call / insertvalue chain →
     // no retain, the record alloca becomes the sole owner) or "shared"
-    // (loaded from another alloca, e.g. `r2 = r1` → retain each ARC
-    // field so both aliases can observe strong_count > 1 and path CoW
-    // at write time correctly clones before mutation).
+    // (view of existing state via LoadInst or ExtractValueInst → retain
+    // each ARC field so both aliases can observe strong_count > 1 and
+    // path CoW at write time correctly clones before mutation).
     //
     // Regardless of retain vs move, any record alloca with ARC fields
     // must be registered in `arc_field_struct_vars_` so scope cleanup
@@ -319,8 +319,8 @@ void CodeGen::emitVarDecl(const std::string &name,
     // compounds it.
     if (auto *recSt = llvm::dyn_cast<llvm::StructType>(newTy)) {
         if (structHasArcFields(recSt)) {
-            if (llvm::isa<llvm::LoadInst>(val)) {
-                // Copy from another record variable — share ownership.
+            if (llvm::isa<llvm::LoadInst>(val) || llvm::isa<llvm::ExtractValueInst>(val)) {
+                // Copy from another record alloca or sub-field extract.
                 emitRecordArcFieldsRetain(val, recSt);
             }
             arc_field_struct_vars_.insert(ptr);
@@ -805,14 +805,15 @@ void CodeGen::emitStmt(AssignStmt &s) {
     // Record-with-ARC-fields reassignment (#854 Layer 2). Mirrors the
     // retain-then-release-old protocol used for ARC-managed variables but
     // walks each ARC field of the struct rather than a single header.
-    // Construction-vs-copy detection: retain only when RHS is loaded
-    // from another alloca (`r2 = r1`). For fresh constructions
-    // (`r2 = CowBox(...)`) the new struct is the sole owner of its ARC
-    // fields so retain would leak a ref.
+    // Construction-vs-copy detection: retain when RHS is a view of
+    // existing state (LoadInst from another alloca, or ExtractValueInst
+    // from a parent record). For fresh constructions (`r2 = CowBox(...)`
+    // — an InsertValue / CallInst chain) the new struct is the sole
+    // owner of its ARC fields so retain would leak a ref.
     if (arc_field_struct_vars_.count(ptr)) {
         auto *recSt = llvm::dyn_cast<llvm::StructType>(ptr->getAllocatedType());
         if (recSt) {
-            if (llvm::isa<llvm::LoadInst>(val))
+            if (llvm::isa<llvm::LoadInst>(val) || llvm::isa<llvm::ExtractValueInst>(val))
                 emitRecordArcFieldsRetain(val, recSt);
             llvm::Value *oldStruct = builder_.CreateLoad(
                 recSt, ptr, s.name + ".record_old");
@@ -982,6 +983,23 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
         builder_.CreateBr(storeBB);
 
         builder_.SetInsertPoint(storeBB);
+    }
+    // Module-global record-with-ARC-fields reassignment (#854 Layer 2).
+    // Mirrors the local AssignStmt retain-then-release-old protocol so
+    // a top-level `global_box = other_box` keeps ARC-field strong counts
+    // consistent across aliases. The anchor alloca is registered in
+    // `arc_field_struct_vars_` during __ry_main__; live queries against
+    // that set are valid here because it persists across FnScope (same
+    // lifetime as `value_metadata_`).
+    else if (arc_field_struct_vars_.count(anchor)) {
+        auto *recSt = llvm::dyn_cast<llvm::StructType>(valueTy);
+        if (recSt) {
+            if (llvm::isa<llvm::LoadInst>(val) || llvm::isa<llvm::ExtractValueInst>(val))
+                emitRecordArcFieldsRetain(val, recSt);
+            llvm::Value *oldStruct = builder_.CreateLoad(
+                recSt, storagePtr, s.name + ".record_old");
+            emitRecordArcFieldsRelease(oldStruct, recSt);
+        }
     }
 
     builder_.CreateStore(val, storagePtr);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -302,6 +302,31 @@ void CodeGen::emitVarDecl(const std::string &name,
     }
 
     llvm::AllocaInst *ptr = getOrCreateVar(name, newTy);
+
+    // Record ARC field retain (#854 Layer 2). When declaring a variable
+    // of a record type that has at least one ARC-managed field, the
+    // *source* of the stored value decides whether ownership is "moved"
+    // (fresh construction from a constructor call / insertvalue chain →
+    // no retain, the record alloca becomes the sole owner) or "shared"
+    // (loaded from another alloca, e.g. `r2 = r1` → retain each ARC
+    // field so both aliases can observe strong_count > 1 and path CoW
+    // at write time correctly clones before mutation).
+    //
+    // Regardless of retain vs move, any record alloca with ARC fields
+    // must be registered in `arc_field_struct_vars_` so scope cleanup
+    // can release those fields — otherwise the construction path
+    // leaves items orphaned (a pre-existing leak) and the copy path
+    // compounds it.
+    if (auto *recSt = llvm::dyn_cast<llvm::StructType>(newTy)) {
+        if (structHasArcFields(recSt)) {
+            if (llvm::isa<llvm::LoadInst>(val)) {
+                // Copy from another record variable — share ownership.
+                emitRecordArcFieldsRetain(val, recSt);
+            }
+            arc_field_struct_vars_.insert(ptr);
+        }
+    }
+
     builder_.CreateStore(val, ptr);
 
     // Track low-level type metadata
@@ -777,8 +802,25 @@ void CodeGen::emitStmt(AssignStmt &s) {
         }
     }
 
+    // Record-with-ARC-fields reassignment (#854 Layer 2). Mirrors the
+    // retain-then-release-old protocol used for ARC-managed variables but
+    // walks each ARC field of the struct rather than a single header.
+    // Construction-vs-copy detection: retain only when RHS is loaded
+    // from another alloca (`r2 = r1`). For fresh constructions
+    // (`r2 = CowBox(...)`) the new struct is the sole owner of its ARC
+    // fields so retain would leak a ref.
+    if (arc_field_struct_vars_.count(ptr)) {
+        auto *recSt = llvm::dyn_cast<llvm::StructType>(ptr->getAllocatedType());
+        if (recSt) {
+            if (llvm::isa<llvm::LoadInst>(val))
+                emitRecordArcFieldsRetain(val, recSt);
+            llvm::Value *oldStruct = builder_.CreateLoad(
+                recSt, ptr, s.name + ".record_old");
+            emitRecordArcFieldsRelease(oldStruct, recSt);
+        }
+    }
     // Weak ref reassignment: retain new, release old
-    if (isWeakManaged(ptr)) {
+    else if (isWeakManaged(ptr)) {
         if (!std::get_if<std::unique_ptr<WeakExpr>>(&s.value->data))
             codegenError("weak variable must be reassigned with a 'weak' expression");
         emitWeakRetain(val);

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -627,25 +627,36 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
 
-    // Resolve the container's CoW anchor. Only plain `var[i] = v` forms
-    // support CoW today: the anchor must be the alloca that holds the
-    // container pointer so emitCowCheck can write-back a new pointer on
-    // copy. For chained forms (`rec.field[i] = v`, `grid[i][j] = v`) the
-    // container pointer is reached through a field extract or a nested
-    // index load, so there is no single alloca slot to write-back to
-    // without deep record / nested-collection CoW. Those cases are scoped
-    // out to a follow-up issue — we fall through with anchor == nullptr so
-    // emitCowCheck is a no-op and mutation happens in place on whatever
-    // heap state is reached.
+    // Resolve the container's CoW strategy.
+    //
+    // For plain `var[i] = v` we keep the existing 1-hop CoW via
+    // `emitCowCheck(ptr, alloca, kind)` — cheap, preserves the top-level
+    // aliasing semantics documented in KNOWLEDGE.md and tested by
+    // `tests/spec/cow.test.ry`.
+    //
+    // For chained forms (`rec.field[i] = v`, `grid[i][j] = v`, nested
+    // map index, etc.) we walk the LHS chain inside-out via
+    // `emitPathCowForChain(*s.object)` (#854). Path CoW privatizes every
+    // level whose strong_count > 1 and returns the privatized leaf
+    // container pointer. We then run the usual list/map mutation body
+    // against that privatized container with `receiverAlloca == nullptr`
+    // so the in-body `emitCowCheck` call becomes a no-op (privatization
+    // already happened).
     llvm::AllocaInst *receiverAlloca = nullptr;
+    llvm::Value *objPtr = nullptr;
     if (std::get_if<VariableExpr>(&s.object->data)) {
         receiverAlloca = tryGetReceiverAlloca(*s.object);
-    } else if (!std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(s.object->data) &&
-               !std::holds_alternative<std::unique_ptr<IndexExpr>>(s.object->data)) {
+        objPtr = emitExpr(*s.object);
+    } else if (std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(s.object->data) ||
+               std::holds_alternative<std::unique_ptr<IndexExpr>>(s.object->data)) {
+        // Path CoW handles the chain walk and returns the privatized
+        // leaf container pointer directly — do NOT also call emitExpr
+        // on s.object, that would re-load the chain against stale
+        // parents.
+        objPtr = emitPathCowForChain(*s.object);
+    } else {
         codegenError("left side of index assignment is not an lvalue");
     }
-
-    llvm::Value *objPtr = emitExpr(*s.object);
 
     llvm::SmallVector<llvm::Value*, 2> indexValues;
     for (auto &idx : s.indices)

--- a/tests/spec/cow_path.test.ry
+++ b/tests/spec/cow_path.test.ry
@@ -1,0 +1,116 @@
+# Issue #854: deep (path) copy-on-write for chained writes through nested
+# collections. Before this fix, chained LHS writes like `b[0][0] = 99` where
+# `b = a` leak the mutation through the shared inner container. Path CoW
+# walks the LHS root-to-leaf and privatizes every level whose strong_count > 1.
+#
+# Also covers record-to-record assignment: `r2 = r1` must retain ARC-managed
+# fields (List/Map/Set) so path CoW can observe strong_count > 1 at the
+# record-field boundary (Layer 2 sub-fix).
+
+record CowBox:
+  items: List<int>
+
+record CowGrid:
+  grid: List<List<int>>
+
+describe("path CoW", ():
+  describe("nested list", ():
+    it("should isolate shared outer list (case 1)", ():
+      a = [[1, 2], [3, 4]]
+      b = a
+      b[0][0] = 99
+      expect(a[0][0]).to_eq(1)
+      expect(a[0][1]).to_eq(2)
+      expect(a[1][0]).to_eq(3)
+      expect(a[1][1]).to_eq(4)
+      expect(b[0][0]).to_eq(99)
+      expect(b[0][1]).to_eq(2)
+      expect(b[1][0]).to_eq(3)
+      expect(b[1][1]).to_eq(4)
+    )
+
+    it("should isolate three-way alias", ():
+      a = [[1]]
+      b = a
+      c = a
+      b[0][0] = 99
+      expect(a[0][0]).to_eq(1)
+      expect(c[0][0]).to_eq(1)
+      expect(b[0][0]).to_eq(99)
+    )
+
+    it("should preserve unique fast path", ():
+      a = [[1]]
+      a[0][0] = 99
+      expect(a[0][0]).to_eq(99)
+    )
+
+    it("should handle self-assign without leak", ():
+      a = [[1, 2]]
+      b = a
+      b[0][0] = b[0][0]
+      expect(a[0][0]).to_eq(1)
+      expect(b[0][0]).to_eq(1)
+    )
+  )
+
+  describe("nested map", ():
+    it("should isolate shared outer map (case 3)", ():
+      m1: Map<str, Map<str, int>> = {"a": {"x": 1}}
+      m2 = m1
+      m2["a"]["x"] = 99
+      expect(m1["a"]["x"]).to_eq(1)
+      expect(m2["a"]["x"]).to_eq(99)
+    )
+  )
+
+  describe("mixed containers", ():
+    it("should isolate map of list", ():
+      m1: Map<str, List<int>> = {"k": [1, 2]}
+      m2 = m1
+      m2["k"][0] = 99
+      expect(m1["k"][0]).to_eq(1)
+      expect(m2["k"][0]).to_eq(99)
+    )
+
+    it("should isolate list of map", ():
+      xs1: List<Map<str, int>> = [{"k": 1}]
+      xs2 = xs1
+      xs2[0]["k"] = 99
+      expect(xs1[0]["k"]).to_eq(1)
+      expect(xs2[0]["k"]).to_eq(99)
+    )
+  )
+
+  describe("record + ARC field", ():
+    it("should isolate record with list field (case 2)", ():
+      r1 = CowBox([1, 2, 3])
+      r2 = r1
+      r2.items[0] = 99
+      expect(r1.items[0]).to_eq(1)
+      expect(r1.items[1]).to_eq(2)
+      expect(r1.items[2]).to_eq(3)
+      expect(r2.items[0]).to_eq(99)
+      expect(r2.items[1]).to_eq(2)
+      expect(r2.items[2]).to_eq(3)
+    )
+
+    it("should isolate record with nested list field", ():
+      r1 = CowGrid([[1, 2], [3, 4]])
+      r2 = r1
+      r2.grid[0][0] = 99
+      expect(r1.grid[0][0]).to_eq(1)
+      expect(r2.grid[0][0]).to_eq(99)
+    )
+  )
+
+  describe("compound assignment", ():
+    it("should isolate compound on nested list", ():
+      a = [[10, 20]]
+      b = a
+      b[0][0] += 5
+      expect(a[0][0]).to_eq(10)
+      expect(b[0][0]).to_eq(15)
+    )
+  )
+)

--- a/tests/spec/cow_path.test.ry
+++ b/tests/spec/cow_path.test.ry
@@ -13,6 +13,14 @@ record CowBox:
 record CowGrid:
   grid: List<List<int>>
 
+record CowOuter:
+  box: CowBox
+
+# Module-global record with an ARC field exercises the `findModuleGlobal`
+# branch of `emitPathCowForChain` and `emitModuleGlobalWriteThrough`'s
+# new record-ARC path (#854 review).
+cow_global_box: CowBox = CowBox([1, 2, 3])
+
 describe("path CoW", ():
   describe("nested list", ():
     it("should isolate shared outer list (case 1)", ():
@@ -101,6 +109,31 @@ describe("path CoW", ():
       r2.grid[0][0] = 99
       expect(r1.grid[0][0]).to_eq(1)
       expect(r2.grid[0][0]).to_eq(99)
+    )
+
+    it("should isolate copy of nested record sub-field (ExtractValue source)", ():
+      # `let x = o.box` copies a sub-record out of a parent record via
+      # ExtractValueInst (not LoadInst). The retain heuristic must
+      # recognize this aggregate read as a "copy" so path CoW observes
+      # strong_count > 1 at the ARC field (#854 review, CodeRabbit).
+      o = CowOuter(CowBox([1, 2, 3]))
+      x = o.box
+      x.items[0] = 99
+      expect(o.box.items[0]).to_eq(1)
+      expect(x.items[0]).to_eq(99)
+    )
+  )
+
+  describe("module-global root", ():
+    it("should isolate module-global record alias", ():
+      # Exercise emitPathCowForChain's findModuleGlobal branch: alias
+      # the top-level record into a local and mutate through the local.
+      local_box = cow_global_box
+      local_box.items[0] = 999
+      expect(cow_global_box.items[0]).to_eq(1)
+      expect(local_box.items[0]).to_eq(999)
+      # Reset for test isolation.
+      local_box.items[0] = 1
     )
   )
 


### PR DESCRIPTION
## Summary

Fixes #854 — chained writes like `b[i][j] = v`, `r.items[i] = v`, and `m[k1][k2] = v` previously leaked through aliases because CoW only fired for `VariableExpr` roots and only cloned the outermost container. Inner containers were shared between aliases and mutations through one alias were observable through the other.

This PR implements **path copy-on-write** — the writer walks the LHS from root to leaf and privatizes every level whose `strong_count > 1` before the mutation lands. Strict aliasing isolation between aliases sharing the outer container and any inner container on the write path.

## Layer 1 — Path CoW

- Add `emitCowCheckSlot(dataPtr, slotPtr, kind, retainElements)` — generalized form of `emitCowCheck` accepting any writable slot (alloca, module-global storage, record-field GEP, or heap container data GEP) instead of just an alloca.
- Add `emitPathCowForChain(chain)` — walks the chained LHS inside-out from the `VariableExpr` root through `FieldAccessExpr` / `IndexExpr` hops, privatizing each container level whose `strong_count > 1` and retaining each ARC element of the cloned buffer (wires up the previously-unused `emitCowRetainArcElements`).
- `emitStmt(IndexAssignStmt)` routes non-`VariableExpr` bases through path CoW; `VariableExpr` bases keep the existing 1-hop CoW so top-level `tests/spec/cow.test.ry` semantics are unchanged.
- Nested `FieldAccessExpr` chains (`d.out.items[i] = v`) are handled via a multi-level struct GEP into the root alloca.

## Layer 2 — Record ARC field retain/release

- Record-to-record assignment (`r2 = r1`) did not retain ARC-managed fields, so path CoW at the record-field hop would see `strong_count == 1` and mutate in place. Fix by retaining ARC fields when the RHS is a `LoadInst` (copy) in both `emitVarDecl` and `emitStmt(AssignStmt)`.
- `emitScopeCleanupToDepth` now walks `arc_field_struct_vars_` and releases each ARC field before the struct dies.
- Add `structHasArcFields`, `emitRecordArcFieldsRetain`, and `emitRecordArcFieldsRelease` helpers.

## Acceptance cases (all green)

```ry
# Case 1: nested list
a = [[1, 2], [3, 4]]; b = a; b[0][0] = 99
# a[0][0] == 1, b[0][0] == 99

# Case 2: record with list field
r1 = Box([1, 2, 3]); r2 = r1; r2.items[0] = 99
# r1.items[0] == 1, r2.items[0] == 99

# Case 3: nested map
m1 = {"a": {"x": 1}}; m2 = m1; m2["a"]["x"] = 99
# m1["a"]["x"] == 1, m2["a"]["x"] == 99
```

## Not supported (compile-time error)

- Method-call lvalue roots: `f().x[i] = v`
- Chains that interleave an index hop inside a record field walk: `rec.arr[0].items[i] = v` — assign the intermediate to a local first

## Known limitation (out of scope, follow-up)

The pre-existing "collection destructor does not release ARC elements" leak remains as-is (accepted under the `detect_leaks=0` budget). Path CoW's retain-on-clone amplifies this by one extra leak per mutation chain on shared inner collections. The full ARC element-release protocol across insertion / destruction paths is tracked as a separate follow-up.

## Files changed

| File | Purpose |
|---|---|
| `src/codegen_arc_cow.cpp` | `emitCowCheckSlot`, `emitPathCowForChain`, wires `emitCowRetainArcElements` |
| `src/codegen_arc.cpp` | Record ARC field helpers (`structHasArcFields`, retain/release) |
| `src/codegen_stmt.cpp` | Layer 2 retain in `emitVarDecl` and `emitStmt(AssignStmt)` |
| `src/codegen.cpp` | Record scope cleanup in `emitScopeCleanupToDepth` |
| `src/codegen_stmt_misc.cpp` | Path CoW dispatch in `emitStmt(IndexAssignStmt)` |
| `include/ry/codegen.hpp` | New declarations + `arc_field_struct_vars_` set |
| `tests/spec/cow_path.test.ry` | 10 new regression cases (NEW) |
| `docs/reference/collections.md` | Path CoW docs, replaces shallow CoW caveat |
| `KNOWLEDGE.md` | Updated CoW entry, deep-CoW rule |
| `changelog.d/854-path-cow.md` | Changelog fragment (NEW) |

## Test plan

- [x] `tests/spec/cow_path.test.ry` (new, 10 cases): all 3 acceptance patterns + regression cases (3-way alias, nested record+index, map-of-list, list-of-map, compound assignment, self-assign, unique fast path)
- [x] `tests/spec/cow.test.ry`: existing top-level CoW semantics preserved (no regressions)
- [x] `tests/spec/chained_lhs_assign.test.ry`: nested record chains like `d.out.items[2] = 99` still work
- [x] `tests/spec/arc_release_on_index_overwrite.test.ry`: #855/#857 slot-overwrite protocol preserved
- [x] `./build/ry_tests` — 1590/1590 C++ GoogleTest pass
- [x] `./build/ry test -p` — 114/114 self-test files, 0 failures
- [x] ASan + UBSan (`cmake --preset asan`): no UAF / double-free / UBsan violations
- [x] TSan (`cmake --preset tsan`): no new data races (pre-existing #630 races unchanged)

Closes #854

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chained writes through nested collections (e.g., grid[i][j] = value) no longer leak mutations to aliases.
  * Record-to-record assignment now preserves ARC-managed fields so inner containers remain shared until mutated.

* **Documentation**
  * Updated Copy-on-Write docs to describe path-based privatization for nested mutations and supported/unsupported LHS shapes.

* **Tests**
  * Added a test suite validating deep path copy-on-write across lists, maps, records, globals, and compound assignments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->