### PR TITLE
fix(#823): infer generic type parameters inside container parameters

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -451,6 +451,62 @@ grep -nE 'i64Ty_|boolTy_|strTy_|f64Ty_' src/ include/
 The new type should appear wherever these existing primitives do
 (justify any exceptions explicitly).
 
+### Generic function type inference must walk TypeNode structurally, not string-match `toString()`
+
+**Source**: #823 (2026-04-11, implementation)
+**Tags**: codegen, generics, type-inference, unification
+
+**Context**: The original `inferTypeArgs()` in
+`src/codegen_fn_generic.cpp` compared the whole parameter type
+`toString()` against the set of type-parameter names
+(`if (typeParamSet.count(paramType))`). That check only fires when the
+parameter type *is* a bare type variable — so `function identity<T>(x: T)`
+worked but `function first_of<T>(xs: List<T>)` silently produced no
+binding and the caller saw "could not infer type parameter 'T'". Every
+container, tuple, and function-type parameter was broken the same way
+because `"List<T>" != "T"`.
+
+**Rule**: Inference must recurse over the `TypeNode` variant
+(`BasicType` / `GenericType` / `TupleType` / `FnType` / `OptionalType`)
+and unify each type variable against the matching slice of the
+argument's inferred type name (`inferExprTypeName`, which already
+produces shaped strings like `"List<int>"`). Use `unifyTypeParam` in
+`src/codegen_fn_generic.cpp` as the reference walker, with
+`splitGenericTypeName` / `splitTupleTypeName` / `splitFunctionTypeName`
+helpers doing the string-side splitting at top-level commas while
+respecting `<`, `>`, `>>`, `>>>`, parens, and brackets. Keep the
+LLVM-type fallback (alloca type → `reverseResolveTypeName`) for the
+bare-variable + scalar-argument case so existing test coverage keeps
+working.
+
+**How to verify**: `tests/spec/generic_infer_container.test.ry` covers
+`List`, `Map`, `Set`, tuple, nested, named-local, and cross-parameter
+unification cases. `tests/test_codegen_fail.cpp` covers the two error
+paths (empty-container "could not infer" and conflicting-bindings).
+
+### `inferExprTypeName` must read alloca metadata for container locals, not just primitives
+
+**Source**: #823 (2026-04-11, implementation)
+**Tags**: codegen, type-inference, value-metadata, generics
+
+**Context**: For a local `xs: List<int> = [1, 2, 3]`, the alloca
+carries `TypeMeta::ListElem = i64Ty_` but **not** the string field
+`list_elem_type_name` — that string is populated only for nested /
+non-primitive inner types (`List<Map<str, int>>`). When
+`inferExprTypeName(VariableExpr)` fell through to
+`reverseResolveTypeName(inferExprType(...))`, it got `ptrTy_` (the
+opaque-pointer alloca type in LLVM 15+) and returned `"str"`, which
+then caused generic inference to bind `T = str` for a list argument.
+
+**Rule**: In `inferExprTypeName` for `VariableExpr`, look up the alloca
+with `findVar(name)` and check `getTypeMeta(TypeMeta::ListElem|MapKey|
+MapValue|SetElem, alloca)` FIRST to build shaped names like
+`"List<int>"`. Only fall back to `reverseResolveTypeName(alloca->
+getAllocatedType())` for structs and primitives. The struct-local
+fallback must use `getAllocatedType()`, not the alloca's pointer type,
+or bounded generic calls like `get_name<T: Animal>(dog_local)` will
+regress to inferring `T = str`.
+
 ### Ry records are SSA struct values, not pointers — nested field writes unroll up to the root alloca
 
 **Source**: #812 (2026-04-11, implementation)

--- a/changelog.d/823-generic-container-inference.md
+++ b/changelog.d/823-generic-container-inference.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- Generic function type inference now succeeds when the type parameter
+  appears inside a container type in the declared parameter. `List<T>`,
+  `Map<K, V>`, `Set<T>`, tuples `(T, T)`, and function types
+  `function(T) -> T` now infer their type arguments from the call site,
+  including nested combinations and cross-parameter unification. Previously
+  calls such as `first_of([1, 2, 3])` for
+  `function first_of<T>(xs: List<T>)` failed with
+  "could not infer type parameter 'T'" even though the shape was
+  unambiguous. The existing `name[T](args)` explicit syntax continues to
+  work for cases where inference cannot determine the type (e.g., empty
+  containers) (#823).

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -559,6 +559,63 @@ result = pick_first(1, "x")       # T = int, U = str, result = 1
 result = pick_first("hello", 42)  # T = str, U = int, result = "hello"
 ```
 
+### Type Parameters Inside Container Types
+
+Type parameters can appear inside generic container types (`List<T>`,
+`Map<K, V>`, `Set<T>`), tuples `(T, T)`, and function types
+`function(T) -> T`. Inference walks the declared parameter type
+structurally against the actual argument, so explicit type annotations
+are not required when the shape is unambiguous.
+
+```python
+function first_of<T>(xs: List<T>) -> T:
+    return xs[0]
+
+first_of([1, 2, 3])            # T = int  → 1
+first_of(["hello", "world"])   # T = str  → "hello"
+first_of([[1, 2], [3, 4]])     # T = List<int>  → [1, 2]
+
+function map_lookup<K, V>(m: Map<K, V>, k: K) -> V:
+    return m[k]
+
+map_lookup({1: "a", 2: "b"}, 1)     # K = int, V = str → "a"
+map_lookup({"x": 10, "y": 20}, "y") # K = str, V = int → 20
+
+function pair_first<T>(p: (T, T)) -> T:
+    return p.0
+
+pair_first((42, 7))      # T = int → 42
+pair_first(("a", "b"))   # T = str → "a"
+```
+
+A type parameter referenced across multiple parameter positions is
+unified — both occurrences must resolve to the same concrete type:
+
+```python
+function apply_list<T>(xs: List<T>, f: function(T) -> T) -> T:
+    return f(xs[0])
+
+apply_list([10, 20, 30], (x: int) => x + 1)  # T = int → 11
+```
+
+If inference cannot determine a type parameter (for example, from an
+empty container literal), use the explicit `name[Type](args)` syntax:
+
+```python
+first_of[int]([])   # empty list: tell the compiler T = int explicitly
+```
+
+Conflicting inferences across arguments produce a clear compile error
+naming the type parameter and function rather than an opaque type
+mismatch:
+
+```python
+function same<T>(a: T, b: T) -> T:
+    return a
+
+same(1, "x")  # error: conflicting type inference for 'T' in call to 'same'
+```
+
 ### Type Constraints (Bounds)
 
 Type parameters can be constrained with record types using `: RecordName` syntax. The concrete type must be the bound type itself or a subtype of it.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -561,6 +561,27 @@ public:
                             const std::string &context);
     std::vector<std::string> inferTypeArgs(const std::string &baseName,
                                            const std::vector<ExprPtr> &args);
+
+    // Recursively unify the declared parameter type (an AST TypeNode,
+    // which may reference type parameters like `T`) against the
+    // inferred argument type-name string (e.g., `"List<int>"`). On
+    // success, records bindings in `inferred`. Returns false when the
+    // argument side lacks information (e.g., empty string) so the
+    // caller can continue with other arguments. Emits codegenError on
+    // shape mismatches or conflicting bindings.
+    bool unifyTypeParam(const TypeNode &paramType,
+                        const std::string &argTypeName,
+                        const std::unordered_set<std::string> &typeParamSet,
+                        std::unordered_map<std::string, std::string> &inferred,
+                        const std::string &fnName);
+
+    // Merge a new binding into `inferred`; emit a clear conflict error
+    // if the name is already bound to a different resolved type.
+    void mergeInferredBinding(std::unordered_map<std::string, std::string> &inferred,
+                              const std::string &paramName,
+                              const std::string &resolved,
+                              const std::string &fnName);
+
     std::string reverseResolveType(llvm::Value *val);
 
     // ======== Closure & Lambda Support ========

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -242,6 +242,191 @@ std::string CodeGen::reverseResolveType(llvm::Value *val) {
     return "any";
 }
 
+// ===== Helpers for structural type-argument unification =====
+
+// Trim ASCII whitespace from both ends. Used by the type-name string
+// splitters below which consume output of `TypeNode::toString()` and
+// `inferExprTypeName` — both produce human-readable strings with
+// optional spaces after commas.
+static std::string trimWs(const std::string &s) {
+    size_t a = 0, b = s.size();
+    while (a < b && std::isspace(static_cast<unsigned char>(s[a]))) ++a;
+    while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) --b;
+    return s.substr(a, b - a);
+}
+
+// Split `body` on top-level commas, honoring nesting of <, >, (, ),
+// [, ], and the lexer-compound tokens `>>` / `>>>` (which can appear
+// when `toString()` emits nested generics).
+static std::vector<std::string> splitTopLevelCommas(const std::string &body) {
+    std::vector<std::string> out;
+    int depth = 0;
+    size_t start = 0;
+    for (size_t i = 0; i < body.size(); ++i) {
+        char c = body[i];
+        if (c == '<' || c == '(' || c == '[') depth++;
+        else if (c == '>' || c == ')' || c == ']') depth--;
+        else if (c == ',' && depth == 0) {
+            out.push_back(trimWs(body.substr(start, i - start)));
+            start = i + 1;
+        }
+    }
+    out.push_back(trimWs(body.substr(start)));
+    return out;
+}
+
+static bool splitGenericTypeName(const std::string &s,
+                                  std::string &head,
+                                  std::vector<std::string> &inner) {
+    std::string t = trimWs(s);
+    size_t lt = t.find('<');
+    if (lt == std::string::npos) return false;
+    if (t.back() != '>') return false;
+    head = trimWs(t.substr(0, lt));
+    std::string body = t.substr(lt + 1, t.size() - lt - 2);
+    inner = splitTopLevelCommas(body);
+    return true;
+}
+
+static bool splitTupleTypeName(const std::string &s,
+                                std::vector<std::string> &elements) {
+    std::string t = trimWs(s);
+    if (t.size() < 2 || t.front() != '(' || t.back() != ')') return false;
+    std::string body = t.substr(1, t.size() - 2);
+    // Single-element tuples spell as "(x,)" — drop the empty trailing slice.
+    elements = splitTopLevelCommas(body);
+    if (!elements.empty() && elements.back().empty())
+        elements.pop_back();
+    return true;
+}
+
+static bool splitFunctionTypeName(const std::string &s,
+                                   std::vector<std::string> &params,
+                                   std::string &returnType) {
+    std::string t = trimWs(s);
+    const std::string prefix = "function(";
+    if (t.rfind(prefix, 0) != 0) return false;
+    int depth = 1;
+    size_t i = prefix.size();
+    for (; i < t.size() && depth > 0; ++i) {
+        if (t[i] == '(') depth++;
+        else if (t[i] == ')') depth--;
+        if (depth == 0) break;
+    }
+    if (depth != 0) return false;
+    std::string body = t.substr(prefix.size(), i - prefix.size());
+    params = splitTopLevelCommas(body);
+    if (params.size() == 1 && params[0].empty()) params.clear();
+    size_t j = i + 1;
+    while (j < t.size() && std::isspace(static_cast<unsigned char>(t[j]))) ++j;
+    if (j < t.size() && t[j] == '-' && j + 1 < t.size() && t[j + 1] == '>') {
+        j += 2;
+        while (j < t.size() && std::isspace(static_cast<unsigned char>(t[j]))) ++j;
+        returnType = trimWs(t.substr(j));
+    } else {
+        returnType.clear();
+    }
+    return true;
+}
+
+void CodeGen::mergeInferredBinding(
+    std::unordered_map<std::string, std::string> &inferred,
+    const std::string &paramName,
+    const std::string &resolved,
+    const std::string &fnName) {
+    if (resolved.empty()) return;
+    auto it = inferred.find(paramName);
+    if (it == inferred.end()) {
+        inferred[paramName] = resolved;
+        return;
+    }
+    if (it->second != resolved) {
+        codegenError("conflicting type inference for '" + paramName +
+                     "' in call to generic function '" + fnName + "': '" +
+                     it->second + "' vs '" + resolved + "'");
+    }
+}
+
+bool CodeGen::unifyTypeParam(
+    const TypeNode &paramType,
+    const std::string &argTypeName,
+    const std::unordered_set<std::string> &typeParamSet,
+    std::unordered_map<std::string, std::string> &inferred,
+    const std::string &fnName) {
+    if (argTypeName.empty()) return false;
+
+    return std::visit([&](const auto &v) -> bool {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, BasicType>) {
+            if (typeParamSet.count(v.name)) {
+                mergeInferredBinding(inferred, v.name, argTypeName, fnName);
+                return true;
+            }
+            // Concrete leaf — no binding to produce. We do not emit an
+            // error on mismatch here because the existing callee
+            // dispatch will catch shape errors later with a clearer
+            // call-site diagnostic.
+            return false;
+        } else if constexpr (std::is_same_v<T, GenericType>) {
+            std::string head;
+            std::vector<std::string> innerArgs;
+            if (!splitGenericTypeName(argTypeName, head, innerArgs))
+                return false;
+            if (head != v.name) return false;
+            if (innerArgs.size() != v.type_args.size()) return false;
+            bool any = false;
+            for (size_t k = 0; k < v.type_args.size(); ++k)
+                if (unifyTypeParam(*v.type_args[k], innerArgs[k],
+                                   typeParamSet, inferred, fnName))
+                    any = true;
+            return any;
+        } else if constexpr (std::is_same_v<T, TupleType>) {
+            std::vector<std::string> elems;
+            if (!splitTupleTypeName(argTypeName, elems)) return false;
+            if (elems.size() != v.elements.size()) return false;
+            bool any = false;
+            for (size_t k = 0; k < v.elements.size(); ++k)
+                if (unifyTypeParam(*v.elements[k], elems[k],
+                                   typeParamSet, inferred, fnName))
+                    any = true;
+            return any;
+        } else if constexpr (std::is_same_v<T, FnType>) {
+            std::vector<std::string> fparams;
+            std::string fret;
+            if (!splitFunctionTypeName(argTypeName, fparams, fret))
+                return false;
+            if (fparams.size() != v.param_types.size()) return false;
+            bool any = false;
+            for (size_t k = 0; k < v.param_types.size(); ++k)
+                if (unifyTypeParam(*v.param_types[k], fparams[k],
+                                   typeParamSet, inferred, fnName))
+                    any = true;
+            if (v.return_type && !fret.empty())
+                if (unifyTypeParam(*v.return_type, fret,
+                                   typeParamSet, inferred, fnName))
+                    any = true;
+            return any;
+        } else if constexpr (std::is_same_v<T, OptionalType>) {
+            // Accept either `"T?"` or the equivalent `"Option<T>"` spelling.
+            std::string t = trimWs(argTypeName);
+            if (!t.empty() && t.back() == '?') {
+                return unifyTypeParam(*v.inner, trimWs(t.substr(0, t.size() - 1)),
+                                      typeParamSet, inferred, fnName);
+            }
+            std::string head;
+            std::vector<std::string> innerArgs;
+            if (splitGenericTypeName(t, head, innerArgs) &&
+                head == "Option" && innerArgs.size() == 1) {
+                return unifyTypeParam(*v.inner, innerArgs[0],
+                                      typeParamSet, inferred, fnName);
+            }
+            return false;
+        } else {
+            return false;
+        }
+    }, paramType.data);
+}
+
 std::vector<std::string> CodeGen::inferTypeArgs(
     const std::string &baseName, const std::vector<ExprPtr> &args) {
 
@@ -256,13 +441,22 @@ std::vector<std::string> CodeGen::inferTypeArgs(
     for (auto &tp : tmpl.type_params)
         typeParamSet.insert(tp.name);
 
-    // Use AST-based type inference to avoid emitting IR for arguments
     std::unordered_map<std::string, llvm::Type*> emptyParamMap;
     for (size_t i = 0; i < args.size(); ++i) {
-        const std::string paramType = tmpl.params[i].type->toString();
-        llvm::Type *argTy = inferExprType(*args[i], emptyParamMap);
+        const TypeNode &pt = *tmpl.params[i].type;
+        std::string argName = inferExprTypeName(*args[i], emptyParamMap);
 
-        if (typeParamSet.count(paramType)) {
+        if (!argName.empty()) {
+            if (unifyTypeParam(pt, argName, typeParamSet, inferred, baseName))
+                continue;
+        }
+
+        // Fallback for bare type variables when `inferExprTypeName` could
+        // not produce a shaped name (e.g., scalar literal arguments whose
+        // Ry-level name equals their LLVM type).
+        if (auto *bt = std::get_if<BasicType>(&pt.data);
+            bt && typeParamSet.count(bt->name)) {
+            llvm::Type *argTy = inferExprType(*args[i], emptyParamMap);
             std::string resolved;
             if (argTy == i64Ty_)  resolved = "int";
             else if (argTy == f64Ty_) resolved = "float";
@@ -281,11 +475,7 @@ std::vector<std::string> CodeGen::inferTypeArgs(
                 }
             }
             else resolved = "any";
-
-            if (inferred.count(paramType) && inferred[paramType] != resolved)
-                codegenError("conflicting type inference for '" + paramType +
-                             "': '" + inferred[paramType] + "' vs '" + resolved + "'");
-            inferred[paramType] = resolved;
+            mergeInferredBinding(inferred, bt->name, resolved, baseName);
         }
     }
 

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -265,7 +265,11 @@ static std::vector<std::string> splitTopLevelCommas(const std::string &body) {
     for (size_t i = 0; i < body.size(); ++i) {
         char c = body[i];
         if (c == '<' || c == '(' || c == '[') depth++;
-        else if (c == '>' || c == ')' || c == ']') depth--;
+        else if (c == '>' || c == ')' || c == ']') {
+            // Clamp: malformed input with unmatched closers should not
+            // drop `depth` below zero and start splitting mid-group.
+            if (depth > 0) depth--;
+        }
         else if (c == ',' && depth == 0) {
             out.push_back(trimWs(body.substr(start, i - start)));
             start = i + 1;

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -656,17 +656,12 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             // LLVM 15+ allocas have opaque-pointer type.
             if (llvm::AllocaInst *alloca = findVar(v.name)) {
                 if (auto *meta = getMeta(alloca)) {
-                    if (llvm::Type *elemTy = meta->list_elem)
-                        return "List<" + reverseResolveTypeName(elemTy) + ">";
-                    if (llvm::Type *keyTy = meta->map_key)
-                        if (llvm::Type *valTy = meta->map_value)
-                            return "Map<" + reverseResolveTypeName(keyTy) +
-                                   ", " + reverseResolveTypeName(valTy) + ">";
-                    if (llvm::Type *setTy = meta->set_elem)
-                        return "Set<" + reverseResolveTypeName(setTy) + ">";
-                    // String-typed metadata covers non-primitive inner
-                    // types that have no single llvm::Type (e.g.,
-                    // List<Map<str, int>>).
+                    // Prefer string-typed metadata: it carries the
+                    // precise shape for non-primitive inner types
+                    // (e.g., `List<Map<str, int>>`). Checking the
+                    // `llvm::Type*` fields first would collapse
+                    // pointer-backed inners via reverseResolveTypeName
+                    // (`ptrTy_` → `"str"`).
                     if (!meta->list_elem_type_name.empty())
                         return "List<" + meta->list_elem_type_name + ">";
                     if (!meta->map_key_type_name.empty() &&
@@ -675,6 +670,14 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
                                meta->map_value_type_name + ">";
                     if (!meta->set_elem_type_name.empty())
                         return "Set<" + meta->set_elem_type_name + ">";
+                    if (llvm::Type *elemTy = meta->list_elem)
+                        return "List<" + reverseResolveTypeName(elemTy) + ">";
+                    if (llvm::Type *keyTy = meta->map_key)
+                        if (llvm::Type *valTy = meta->map_value)
+                            return "Map<" + reverseResolveTypeName(keyTy) +
+                                   ", " + reverseResolveTypeName(valTy) + ">";
+                    if (llvm::Type *setTy = meta->set_elem)
+                        return "Set<" + reverseResolveTypeName(setTy) + ">";
                 }
                 return reverseResolveTypeName(alloca->getAllocatedType());
             }

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -634,12 +634,85 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             std::string elem = inferExprTypeName(*v->elements[0], paramTypeMap);
             if (elem.empty()) return "";
             return "Set<" + elem + ">";
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<TupleExpr>>) {
+            if (v->elements.empty()) return "";
+            std::string out = "(";
+            for (size_t i = 0; i < v->elements.size(); ++i) {
+                std::string e = inferExprTypeName(*v->elements[i], paramTypeMap);
+                if (e.empty()) return "";
+                if (i > 0) out += ", ";
+                out += e;
+            }
+            // Single-element tuples use a trailing comma in Ry's type
+            // grammar ("(int,)"), match that spelling here.
+            if (v->elements.size() == 1) out += ",";
+            out += ")";
+            return out;
+        } else if constexpr (std::is_same_v<T, VariableExpr>) {
+            // Consult the alloca's metadata to recover Ry-level shaped
+            // names (List<int>, Map<str, int>, Set<float>). Falling
+            // through to reverseResolveTypeName on the alloca's
+            // pointer type would lose this information because
+            // LLVM 15+ allocas have opaque-pointer type.
+            if (llvm::AllocaInst *alloca = findVar(v.name)) {
+                if (auto *meta = getMeta(alloca)) {
+                    if (llvm::Type *elemTy = meta->list_elem)
+                        return "List<" + reverseResolveTypeName(elemTy) + ">";
+                    if (llvm::Type *keyTy = meta->map_key)
+                        if (llvm::Type *valTy = meta->map_value)
+                            return "Map<" + reverseResolveTypeName(keyTy) +
+                                   ", " + reverseResolveTypeName(valTy) + ">";
+                    if (llvm::Type *setTy = meta->set_elem)
+                        return "Set<" + reverseResolveTypeName(setTy) + ">";
+                    // String-typed metadata covers non-primitive inner
+                    // types that have no single llvm::Type (e.g.,
+                    // List<Map<str, int>>).
+                    if (!meta->list_elem_type_name.empty())
+                        return "List<" + meta->list_elem_type_name + ">";
+                    if (!meta->map_key_type_name.empty() &&
+                        !meta->map_value_type_name.empty())
+                        return "Map<" + meta->map_key_type_name + ", " +
+                               meta->map_value_type_name + ">";
+                    if (!meta->set_elem_type_name.empty())
+                        return "Set<" + meta->set_elem_type_name + ">";
+                }
+                return reverseResolveTypeName(alloca->getAllocatedType());
+            }
+            return reverseResolveTypeName(inferExprType(expr, paramTypeMap));
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CallExpr>>) {
+            // `Some(x)` constructs an Option<T>; propagate inner type.
+            if (v->callee == "Some" && v->args.size() == 1) {
+                std::string inner = inferExprTypeName(*v->args[0], paramTypeMap);
+                if (inner.empty()) return "";
+                return "Option<" + inner + ">";
+            }
             if (v->callee == "type_of") return "Type";
             auto *overloads = findFunction(v->callee);
             if (overloads && !overloads->empty() && !(*overloads)[0].returnTypeName.empty())
                 return (*overloads)[0].returnTypeName;
             return "";
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
+            // Build "function(t1, t2) -> r" from declared annotations.
+            // A missing annotation (no TypeNode) means we can't build
+            // a shaped name and bail — but `any` is a legitimate
+            // annotation and is preserved.
+            std::string out = "function(";
+            for (size_t i = 0; i < v->params.size(); ++i) {
+                if (!v->params[i].type) return "";
+                std::string pn = v->params[i].type->toString();
+                if (pn.empty()) return "";
+                if (i > 0) out += ", ";
+                out += pn;
+            }
+            out += ")";
+            std::string ret;
+            if (v->return_type)
+                ret = v->return_type->toString();
+            else if (v->expr_body)
+                ret = inferExprTypeName(*v->expr_body, paramTypeMap);
+            if (ret.empty()) return "";
+            out += " -> " + ret;
+            return out;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CastExpr>>) {
             return resolveTypeAlias(v->target_type->toString());
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondExpr>>) {

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -709,10 +709,20 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             }
             out += ")";
             std::string ret;
-            if (v->return_type)
+            if (v->return_type) {
                 ret = v->return_type->toString();
-            else if (v->expr_body)
-                ret = inferExprTypeName(*v->expr_body, paramTypeMap);
+            } else if (v->expr_body) {
+                // Expression-bodied lambdas may reference their own
+                // parameters. Extend the inherited param-type map with
+                // the lambda's declared parameter types so identifiers
+                // in the body resolve correctly.
+                std::unordered_map<std::string, llvm::Type*> lambdaParamTypeMap = paramTypeMap;
+                for (const auto &p : v->params) {
+                    if (p.type)
+                        lambdaParamTypeMap[p.name] = resolveType(p.type->toString());
+                }
+                ret = inferExprTypeName(*v->expr_body, lambdaParamTypeMap);
+            }
             if (ret.empty()) return "";
             out += " -> " + ret;
             return out;

--- a/tests/spec/generic_infer_container.test.ry
+++ b/tests/spec/generic_infer_container.test.ry
@@ -88,4 +88,7 @@ describe("generic inference: cross-parameter unification", ():
   it("should unify T from List<T> and function(T) -> T", ():
     expect(apply_list([10, 20, 30], (x: int) => x + 1)).to_eq(11)
   )
+  it("should resolve lambda param reference in return-type inference", ():
+    expect(apply_list(["a", "b"], (s: str) => s)).to_eq("a")
+  )
 )

--- a/tests/spec/generic_infer_container.test.ry
+++ b/tests/spec/generic_infer_container.test.ry
@@ -50,6 +50,11 @@ describe("generic inference: nested List<List<T>>", ():
     inner = first_of([[1, 2], [3, 4]])
     expect(first_of(inner)).to_eq(1)
   )
+  it("should infer nested list from named local", ():
+    xs: List<List<int>> = [[11, 22], [33, 44]]
+    inner = first_of(xs)
+    expect(first_of(inner)).to_eq(11)
+  )
 )
 
 describe("generic inference: Map<K, V> literal argument", ():

--- a/tests/spec/generic_infer_container.test.ry
+++ b/tests/spec/generic_infer_container.test.ry
@@ -1,0 +1,86 @@
+function first_of<T>(xs: List<T>) -> T:
+    return xs[0]
+
+function second_of<T>(xs: List<T>) -> T:
+    return xs[1]
+
+function map_lookup<K, V>(m: Map<K, V>, k: K) -> V:
+    return m[k]
+
+function set_size<T>(s: Set<T>) -> int:
+    return 1
+
+function pair_first<T>(p: (T, T)) -> T:
+    return p.0
+
+function apply_list<T>(xs: List<T>, f: function(T) -> T) -> T:
+    return f(xs[0])
+
+describe("generic inference: List<T> literal argument", ():
+  it("should infer T = int from [1, 2, 3]", ():
+    expect(first_of([1, 2, 3])).to_eq(1)
+  )
+  it("should infer T = str from string list", ():
+    expect(first_of(["hello", "world"])).to_eq("hello")
+  )
+  it("should infer T = float from float list", ():
+    expect(first_of([1.5, 2.5, 3.5])).to_eq(1.5)
+  )
+  it("should infer T = bool from bool list", ():
+    expect(first_of([true, false, true])).to_be_true()
+  )
+  it("should preserve order with second_of", ():
+    expect(second_of([10, 20, 30])).to_eq(20)
+  )
+)
+
+describe("generic inference: List<T> named local", ():
+  it("should infer T = int from named local variable", ():
+    xs: List<int> = [100, 200, 300]
+    expect(first_of(xs)).to_eq(100)
+  )
+  it("should infer T = str from named local variable", ():
+    names: List<str> = ["a", "b"]
+    expect(first_of(names)).to_eq("a")
+  )
+)
+
+describe("generic inference: nested List<List<T>>", ():
+  it("should infer nested list literal", ():
+    inner = first_of([[1, 2], [3, 4]])
+    expect(first_of(inner)).to_eq(1)
+  )
+)
+
+describe("generic inference: Map<K, V> literal argument", ():
+  it("should infer K = int, V = str from map literal", ():
+    expect(map_lookup({1: "a", 2: "b"}, 1)).to_eq("a")
+  )
+  it("should infer K = str, V = int", ():
+    expect(map_lookup({"x": 10, "y": 20}, "y")).to_eq(20)
+  )
+)
+
+describe("generic inference: Set<T> literal argument", ():
+  it("should infer T = int from set literal", ():
+    expect(set_size({1, 2, 3})).to_eq(1)
+  )
+  it("should infer T = str from string set literal", ():
+    expect(set_size({"a", "b"})).to_eq(1)
+  )
+)
+
+describe("generic inference: tuple (T, T) literal argument", ():
+  it("should infer T = int from tuple literal", ():
+    expect(pair_first((42, 7))).to_eq(42)
+  )
+  it("should infer T = str from string tuple", ():
+    expect(pair_first(("hi", "there"))).to_eq("hi")
+  )
+)
+
+describe("generic inference: cross-parameter unification", ():
+  it("should unify T from List<T> and function(T) -> T", ():
+    expect(apply_list([10, 20, 30], (x: int) => x + 1)).to_eq(11)
+  )
+)

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -186,3 +186,33 @@ TEST_F(CodeGenTest, MathPowIntNegativeExponentAborts) {
         ::testing::ExitedWithCode(1),
         "pow\\(\\) integer exponent must be non-negative");
 }
+
+// ============================================================
+// Generic inference for container parameters (#823).
+// An empty container literal yields no information for the
+// type variable, so inference must emit a clear error naming
+// the parameter and the function, not a vague codegen error or
+// an "undefined variable" message.
+// ============================================================
+
+TEST_F(CodeGenTest, GenericInferenceEmptyListHasClearError) {
+    expectCompileError(
+        "function first_of<T>(xs: List<T>) -> T:\n"
+        "  return xs[0]\n"
+        "print(first_of([]))\n",
+        "could not infer type parameter 'T' in call to generic function 'first_of'");
+}
+
+// ============================================================
+// When the same type parameter appears in two argument slots
+// and the concrete arguments disagree, inference must report a
+// clear conflict naming the parameter.
+// ============================================================
+
+TEST_F(CodeGenTest, GenericInferenceConflictingBindingError) {
+    expectCompileError(
+        "function same<T>(a: T, b: T) -> T:\n"
+        "  return a\n"
+        "print(same(1, \"x\"))\n",
+        "conflicting type inference for 'T'");
+}


### PR DESCRIPTION
## Summary

Fixes #823. Generic function calls like `first_of([1, 2, 3])` for
`function first_of<T>(xs: List<T>)` previously failed with
"could not infer type parameter 'T'" because `inferTypeArgs` only
unified when the declared parameter type was a bare type variable
(it compared the whole `toString()` of the parameter type against
the type-parameter name set, so `"List<T>" != "T"` silently skipped
every container parameter).

### Changes

- **Structural unifier** (`src/codegen_fn_generic.cpp`): new
  `unifyTypeParam` walks the declared parameter `TypeNode` variant
  (`BasicType` / `GenericType` / `TupleType` / `FnType` / `OptionalType`)
  and unifies each type variable against the matching slice of the
  argument-side inferred type name produced by `inferExprTypeName`.
  File-local `splitGenericTypeName` / `splitTupleTypeName` /
  `splitFunctionTypeName` helpers split the type-name strings at
  top-level commas while honoring nesting of `<`, `>`, `>>`, `>>>`,
  parens, and brackets. `mergeInferredBinding` centralizes conflict
  detection.
- **`inferExprTypeName` extensions** (`src/codegen_lambda.cpp`): new
  cases for `TupleExpr` → `"(a, b, c)"`, `LambdaExpr` → `"function(t1,
  t2) -> r"` (from declared annotations), `Some(x)` → `"Option<T>"`,
  and `VariableExpr` that consults the alloca's `ValueMetadata` to
  recover shaped names like `"List<int>"` (LLVM 15+ opaque pointers
  would otherwise lose the information). Bare type variables with
  scalar arguments still fall back to the existing LLVM-type path.
- **Error clarity**: conflicting inferences (`same<T>(a: T, b: T)`
  called with `(1, "x")`) emit
  `"conflicting type inference for 'T' in call to generic function 'same'"`;
  empty-container inference failures keep the existing
  `"could not infer type parameter 'T'"` message.

### Scope decision

The issue also raised explicit turbofish syntax (`first_of<int>(...)`
parses as comparison today). I split that into follow-up #876 to keep
this PR focused on inference. The existing `foo[T](args)` bracket
syntax remains as the explicit escape hatch.

### Tests

- `tests/spec/generic_infer_container.test.ry` (new, 15 cases):
  `List<T>` / `Map<K, V>` / `Set<T>` literal args, named locals
  (`xs: List<int>`), nested `List<List<int>>`, tuple `(T, T)`, and
  cross-parameter unification
  (`apply_list<T>(List<T>, function(T) -> T)`).
- `tests/test_codegen_fail.cpp` (2 cases): regression for
  "could not infer" on `first_of([])` and conflict error on
  `same(1, "x")`.

### Docs / meta

- `docs/reference/functions.md`: new "Type Parameters Inside Container
  Types" subsection under Generic Functions.
- `KNOWLEDGE.md`: two entries — structural-unification rule and the
  alloca-metadata gotcha for container locals.
- `changelog.d/823-generic-container-inference.md`.

## Test plan

- [x] `./build/ry_tests` — 1593 passed
- [x] `./build/ry test -p` — 115 files, 0 failures
- [x] ASan + UBSan: `./build-asan/ry_tests` + `./build-asan/ry test -p` clean
- [x] TSan: `./build-tsan/ry_tests` clean (`ConcurrencySpecSuite` required)
- [x] Trace-verified: `first_of([1, 2, 3])` resolves `T = int`
- [x] Issue #823 reproducer now runs end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generic type inference now succeeds for type parameters inside containers, tuples, and function types (including nested shapes) and unifies parameters across arguments.

* **Bug Fixes**
  * Corrected local/container type inference so inner element types are inferred reliably.
  * Improved error messages for ambiguous or conflicting inference, naming the type parameter and function.

* **Documentation**
  * Added guidance on inferring type parameters within structured types and using explicit type arguments.

* **Tests**
  * Added positive and negative tests covering container inference and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->