### PR TITLE
fix(#790): propagate returnTypeName for block-bodied lambda inferred returns

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -507,6 +507,34 @@ fallback must use `getAllocatedType()`, not the alloca's pointer type,
 or bounded generic calls like `get_name<T: Animal>(dog_local)` will
 regress to inferring `T = str`.
 
+### `inferReturnType` and `inferReturnTypeName` must be maintained in lockstep
+
+**Source**: #790 (2026-04-11, follow-up to #788)
+**Tags**: codegen, lambda, returnTypeName, inferReturnType, type-inference
+
+**Context**: `#788` added `inferExprTypeName` + `returnTypeName` propagation
+for the **expression-bodied** lambda branch in `emitExprVariant(LambdaExpr)`.
+The symmetric **block-bodied** branch only called `inferReturnType` (which
+returns `llvm::Type*` and loses `List<int>` / `Map<K,V>` shape), leaving
+`returnTypeName` empty. Downstream `propagateTypeMeta()` is gated on
+`if (!info.returnTypeName.empty())`, so collection metadata silently never
+reached the call-site alloca — breaking `result.length()` and `result[i]`
+on values returned by block lambdas with literal-collection returns.
+
+**Rule**: Any inference helper that produces an `llvm::Type*` for a
+lambda/function return (currently `inferReturnType` + `collectReturnTypes`)
+must have a sibling that produces the shaped type-name string
+(`inferReturnTypeName` + `collectReturnTypeNames` in `src/codegen_lambda.cpp`).
+When you touch one, update the other. The call site in
+`emitExprVariant(LambdaExpr)` must populate `returnTypeName` on every
+inferred-return branch (expression-body AND block-body), not just one.
+
+**How to verify**: `tests/spec/lambda_collection_return.test.ry` covers
+block-bodied lambdas returning list / map / set literals and branched
+returns with consistent element types. Known limitation (tracked separately):
+returning a **local** collection variable from a block lambda still loses
+shape — see #883.
+
 ### Ry records are SSA struct values, not pointers — nested field writes unroll up to the root alloca
 
 **Source**: #812 (2026-04-11, implementation)

--- a/changelog.d/790-block-lambda-return-type-name.md
+++ b/changelog.d/790-block-lambda-return-type-name.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Propagate collection return type metadata for block-bodied lambdas with inferred return types, so `result.length()` / indexing work on the value returned by `f = (x: int):\n  return [x, x * 2]` style lambdas (#790).

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1468,6 +1468,11 @@ public:
     void collectReturnTypes(const std::vector<StmtNode> &body,
         const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
         std::vector<llvm::Type*> &out);
+    std::string inferReturnTypeName(const std::vector<StmtNode> &body,
+        const std::unordered_map<std::string, llvm::Type*> &paramTypeMap);
+    void collectReturnTypeNames(const std::vector<StmtNode> &body,
+        const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+        std::vector<std::string> &out);
     llvm::Type *deduceReturnType(const std::vector<llvm::Type*> &types);
     std::string reverseResolveTypeName(llvm::Type *ty);
     std::string inferCollectionTypeName(llvm::Value *val);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -294,6 +294,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
         } else {
             buildLocalTypeMap(e->body, paramTypeMap);
             retTy = inferReturnType(e->body, paramTypeMap);
+            returnTypeName = inferReturnTypeName(e->body, paramTypeMap);
         }
     } else {
         retTy = resolveType(retTypeStr);
@@ -769,6 +770,60 @@ void CodeGen::collectReturnTypes(const std::vector<StmtNode> &body,
             }
         }, stmt);
     }
+}
+
+void CodeGen::collectReturnTypeNames(const std::vector<StmtNode> &body,
+    const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+    std::vector<std::string> &out) {
+    for (auto &stmt : body) {
+        std::visit([&](const auto &s) {
+            using T = std::decay_t<decltype(s)>;
+            if constexpr (std::is_same_v<T, ReturnStmt>) {
+                if (s.value)
+                    out.push_back(inferExprTypeName(*s.value, paramTypeMap));
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) {
+                collectReturnTypeNames(s->branch.body, paramTypeMap, out);
+                collectReturnTypeNames(s->else_body, paramTypeMap, out);
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondStmt>>) {
+                for (auto &arm : s->arms)
+                    collectReturnTypeNames(arm.body, paramTypeMap, out);
+                collectReturnTypeNames(s->else_body, paramTypeMap, out);
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseStmt>>) {
+                for (auto &arm : s->arms)
+                    collectReturnTypeNames(arm.body, paramTypeMap, out);
+            }
+        }, stmt);
+    }
+}
+
+std::string CodeGen::inferReturnTypeName(const std::vector<StmtNode> &body,
+    const std::unordered_map<std::string, llvm::Type*> &paramTypeMap) {
+    std::vector<std::string> names;
+    collectReturnTypeNames(body, paramTypeMap, names);
+    if (names.empty())
+        return "";
+    // Conservative: if any return branch can't produce a shaped type name,
+    // bail out so that downstream propagateTypeMeta() stays a no-op rather
+    // than propagating partial/incorrect metadata.
+    for (auto &n : names)
+        if (n.empty())
+            return "";
+    // Deduplicate while preserving order.
+    std::vector<std::string> unique;
+    for (auto &n : names)
+        if (std::find(unique.begin(), unique.end(), n) == unique.end())
+            unique.push_back(n);
+    if (unique.size() == 1)
+        return unique[0];
+    // Multiple distinct names — build a union-style name mirroring
+    // deduceReturnType()'s policy. propagateTypeMeta currently ignores union
+    // names, which matches the conservative behavior we want here.
+    std::string joined;
+    for (size_t i = 0; i < unique.size(); ++i) {
+        if (i > 0) joined += " | ";
+        joined += unique[i];
+    }
+    return joined;
 }
 
 llvm::Type *CodeGen::deduceReturnType(const std::vector<llvm::Type*> &types) {

--- a/tests/spec/lambda_collection_return.test.ry
+++ b/tests/spec/lambda_collection_return.test.ry
@@ -63,3 +63,67 @@ describe("lambda returning nested list", ():
     expect(result[1][0]).to_eq(3)
   )
 )
+
+describe("block-bodied lambda returning list literal", ():
+  it("should return list with correct length", ():
+    f = (x: int):
+      return [x, x * 2, x * 3]
+    result = f(5)
+    expect(result.length()).to_eq(3)
+  )
+
+  it("should return list with correct elements", ():
+    f = (x: int):
+      return [x, x * 2, x * 3]
+    result = f(5)
+    expect(result[0]).to_eq(5)
+    expect(result[1]).to_eq(10)
+    expect(result[2]).to_eq(15)
+  )
+
+  it("should return string list", ():
+    f = (a: str, b: str):
+      return [a, b]
+    result = f("hello", "world")
+    expect(result.length()).to_eq(2)
+    expect(result[0]).to_eq("hello")
+    expect(result[1]).to_eq("world")
+  )
+)
+
+describe("block-bodied lambda returning map literal", ():
+  it("should return map with correct length", ():
+    f = (x: int):
+      return {"a": x, "b": x * 2}
+    result = f(5)
+    expect(result.length()).to_eq(2)
+  )
+
+  it("should return map with correct values", ():
+    f = (x: int):
+      return {"a": x, "b": x * 2}
+    result = f(5)
+    expect(result["a"]).to_eq(5)
+    expect(result["b"]).to_eq(10)
+  )
+)
+
+describe("block-bodied lambda returning set literal", ():
+  it("should return set with correct length", ():
+    f = (x: int):
+      return {x, x * 2, x * 3}
+    result = f(5)
+    expect(result.length()).to_eq(3)
+  )
+)
+
+describe("block-bodied lambda with branched returns", ():
+  it("should return list with consistent element type across branches", ():
+    f = (flag: bool):
+      if flag:
+        return [1, 2, 3]
+      return [10, 20]
+    expect(f(true).length()).to_eq(3)
+    expect(f(false).length()).to_eq(2)
+  )
+)


### PR DESCRIPTION
## Summary

- Block-bodied lambdas with inferred return types left `returnTypeName` empty, so `propagateTypeMeta()` skipped call-site metadata and `result.length()` / indexing failed on collection returns like `f = (x: int):\n  return [x, x * 2]`. This is the symmetric gap to #788 (which fixed the expression-body branch).
- Add sibling helpers `inferReturnTypeName` / `collectReturnTypeNames` mirroring the existing `inferReturnType` / `collectReturnTypes` walkers, but dispatching to `inferExprTypeName` to produce shaped names (`List<int>`, `Map<str, int>`, ...). Wire them into the block-body branch of `emitExprVariant(LambdaExpr)`.
- Returning a **local** collection variable from a block lambda (e.g. `items = [x]; return items`) still loses shape because `inferExprTypeName(VariableExpr)` can't see locals in `scope_stack_` at inference time. Tracked separately as #883.

Closes #790

## Test plan

- [x] Added 6 block-bodied cases to `tests/spec/lambda_collection_return.test.ry` (list / map / set literals, string list, branched returns). Verified they fail before the fix (`cannot determine list element type for index access`) and pass after.
- [x] `./build/ry_tests` — 1593/1593 passed
- [x] `./build/ry test -p` — 115 files / 0 failures
- [x] ASan + UBSan: `./build-asan/ry_tests` 1592/1592 passed, `./build-asan/ry test -p` 115 files / 0 failures
- [x] TSan C++ (required): `./build-tsan/ry_tests` 1593/1593 passed (`ConcurrencySpecSuite` included)
- [x] `KNOWLEDGE.md` updated with a lockstep rule for `inferReturnType` / `inferReturnTypeName`
- [x] `changelog.d/790-block-lambda-return-type-name.md` added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed metadata propagation for collections returned from block-bodied lambdas with inferred return types, enabling proper support for collection operations such as `.length()` and element access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->