### PR TITLE
fix(#871): harden RWLock tracking and ThreadHandle error sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -302,6 +302,7 @@ add_executable(ry_tests
     tests/test_trace.cpp
     tests/test_codegen_arc.cpp
     tests/test_runtime_gc.cpp
+    tests/test_runtime_rwlock_stress.cpp
     tests/test_codegen_type_safety.cpp
 )
 if(APPLE)

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -941,25 +941,27 @@ previous map-based tracker had the same property — unbalanced lock
 usage is a program bug, not something the runtime should engineer
 around.
 
-### `rwlock_read_lock` must reserve the thread-local tracking slot BEFORE calling `lock_shared()`
+### Recursive `lock_shared()` on `std::shared_mutex` is undefined behavior in C++17
 
-**Source**: #871 (2026-04-11, implementation)
-**Tags**: rwlock, runtime-thread, exception-safety, gotcha
+**Source**: #871 (2026-04-11, CodeRabbit review on PR #885)
+**Tags**: rwlock, runtime-thread, std-shared-mutex, ub, gotcha
 
-**Rule**: `__ry_rwlock_read_lock` calls `try_emplace(rwlock, 0)` on
-`tls_rwlock_read_counts` first, THEN calls `rwlock->mu.lock_shared()`,
-THEN increments `it->second`. If the map allocation throws, nothing
-has been locked — safe to return `-1`. If `lock_shared()` throws
-afterwards, erase the entry ONLY if we created it on this call
-(`inserted == true`); a pre-existing positive count belongs to an
-earlier, still-held nested lock and must not be discarded.
+**Rule**: `__ry_rwlock_read_lock` must call `rwlock->mu.lock_shared()`
+**only on the outermost read acquire**, gated by `tls_rwlock_read_counts`
+being empty for that rwlock. Nested reads just bump the TLS counter.
+`__ry_rwlock_unlock` mirrors this: the underlying `unlock_shared()`
+only runs when the TLS counter drops from 1 to 0.
 
-**Why**: Calling `try_emplace` after `lock_shared()` would reintroduce
-a transient window where the shared lock is held but the tracker
-lacks the entry — exactly the two-step race the fix eliminates.
-Calling `try_emplace` first makes the race impossible: the
-tracking slot is ready before the lock is acquired, so the increment
-after `lock_shared()` is a pure thread-local write.
+**Why**: Per [thread.sharedmutex.requirements] / cppreference
+"If lock_shared is called by a thread that already owns the mutex in
+any mode (exclusive or shared), the behavior is undefined." The TLS
+counter exists solely to dispatch unlock correctly; it does not make
+the underlying mutex reentrant. An earlier draft of the #871 fix
+called `lock_shared()` unconditionally and still passed tests on
+libc++ because the UB happened to be benign, but it would be a
+time-bomb under a stricter standard library or instrumented build.
+The regression is covered by
+`tests/test_runtime_rwlock_stress.cpp::NestedReadLockPerThread`.
 
 ### RWLock stress tests for #871 must be C++ GoogleTests, not Ry spec files
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -910,7 +910,82 @@ directly for the tail line.
 
 ## Runtime / Memory
 
-*(entries to be added as they are learned)*
+### RWLock dispatch state must be thread-local, not guarded by a shared mutex
+
+**Source**: #871 (2026-04-11, implementation; follow-up to #630 P1 audit)
+**Tags**: rwlock, runtime-thread, concurrency, deadlock, thread-local, gotcha
+
+**Rule**: In `src/runtime_thread.cpp`, the per-thread counter that tells
+`__ry_rwlock_unlock` whether to call `unlock_shared()` vs `unlock()` on
+the underlying `std::shared_mutex` lives in a
+`thread_local std::unordered_map<RWLockHandle*, int>` at namespace
+scope. Do NOT reintroduce a shared `std::unordered_map<std::thread::id, int>`
+guarded by a separate `mode_mu`.
+
+**Why**: The #630 audit suggested two fixes for the original two-step
+race (where `mu.lock_shared()` was held before the tracking map was
+updated). Option A — "hold mode_mu across lock_shared()" — **deadlocks**
+under writer contention: a thread holding `mode_mu` while blocked
+inside `lock_shared()` prevents any existing reader from taking
+`mode_mu` to dispatch its own unlock, so the writer it is waiting on
+can never make progress. Three-way deadlock: writer waits for existing
+reader, existing reader waits for `mode_mu`, `mode_mu` owner waits
+for writer. Thread-local tracking (Option B) sidesteps this entirely
+because no shared data structure exists for the dispatch.
+
+**Caveat**: unbalanced `rwlock_read_lock` without a matching
+`rwlock_unlock` leaves a stale TLS entry that persists until thread
+exit. If an RWLockHandle is then freed and a new one is allocated at
+the same address, the stale count could be misinterpreted. The
+previous map-based tracker had the same property — unbalanced lock
+usage is a program bug, not something the runtime should engineer
+around.
+
+### `rwlock_read_lock` must reserve the thread-local tracking slot BEFORE calling `lock_shared()`
+
+**Source**: #871 (2026-04-11, implementation)
+**Tags**: rwlock, runtime-thread, exception-safety, gotcha
+
+**Rule**: `__ry_rwlock_read_lock` calls `try_emplace(rwlock, 0)` on
+`tls_rwlock_read_counts` first, THEN calls `rwlock->mu.lock_shared()`,
+THEN increments `it->second`. If the map allocation throws, nothing
+has been locked — safe to return `-1`. If `lock_shared()` throws
+afterwards, erase the entry ONLY if we created it on this call
+(`inserted == true`); a pre-existing positive count belongs to an
+earlier, still-held nested lock and must not be discarded.
+
+**Why**: Calling `try_emplace` after `lock_shared()` would reintroduce
+a transient window where the shared lock is held but the tracker
+lacks the entry — exactly the two-step race the fix eliminates.
+Calling `try_emplace` first makes the race impossible: the
+tracking slot is ready before the lock is acquired, so the increment
+after `lock_shared()` is a pure thread-local write.
+
+### RWLock stress tests for #871 must be C++ GoogleTests, not Ry spec files
+
+**Source**: #871 (2026-04-11, implementation)
+**Tags**: rwlock, testing, tsan, spec-loader, gotcha
+
+**Rule**: When adding a TSan-gated stress test for
+`src/runtime_thread.cpp` primitives, put it in a pure C++
+GoogleTest under `tests/` (e.g.
+`tests/test_runtime_rwlock_stress.cpp`), NOT in
+`tests/spec/concurrency.test.ry`. Wire it into `ry_tests` via
+`CMakeLists.txt` so it runs under the **required** `build-tsan/ry_tests`
+step.
+
+**Why**: The C++ test harness used by `CodeGenTest.ConcurrencySpecSuite`
+is `runTestSource` in `tests/test_codegen_common.hpp`, which goes
+`Lexer → Parser → CodeGen` directly and never invokes `ModuleLoader`.
+Any `from thread import ...` statement in a spec run via that harness
+fails with `unresolved import: thread (ModuleLoader should have
+resolved this)`. Adding a stress test to `concurrency.test.ry`
+therefore silently breaks the TSan-required gate. A pure C++ test
+that calls `__ry_rwlock_*` directly via `include/ry/runtime_thread.hpp`
+works under all sanitizers, runs in the required step, and is more
+direct anyway — we are testing a runtime invariant, not a language
+feature. See also the entry at the top of this "Testing" section for
+the `runSource` / `runTestSource` limitation.
 
 ---
 

--- a/changelog.d/871-rwlock-and-thread-handle-sync.md
+++ b/changelog.d/871-rwlock-and-thread-handle-sync.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- `rwlock_unlock` now dispatches between shared and exclusive release via
+  a `thread_local` counter per RWLock, eliminating the two-step window in
+  `rwlock_read_lock` where `std::shared_mutex::lock_shared()` was held
+  but the tracking map had not yet been updated. Under the previous
+  implementation an unlock that observed the transient state would have
+  fallen through to exclusive `unlock()`, corrupting `std::shared_mutex`
+  state. (#871, follow-up to #630 P1)
+- `ThreadHandle::has_error` is now a `std::atomic<bool>`; the worker
+  thread's catch blocks store it with `memory_order_release` after
+  writing `error_msg`, and `thread_join` loads it with
+  `memory_order_acquire`. This makes the error-field publish/subscribe
+  contract explicit, TSan-friendly, and robust for any future pre-join
+  error polling path. (#871, follow-up to #630 P1)

--- a/src/runtime_thread.cpp
+++ b/src/runtime_thread.cpp
@@ -47,8 +47,20 @@ enum JoinState : uint8_t {
 
 struct ThreadHandle {
     std::thread thread;
+    // Worker error fields (#871 — thread error sync hardening).
+    //
+    // Publish/subscribe contract: the worker writes `error_msg` FIRST, then
+    // stores `has_error = true` with `memory_order_release`. Any reader
+    // must `acquire`-load `has_error` before reading `error_msg`; if that
+    // load returns `true`, the release/acquire pair guarantees the string
+    // write is visible.
+    //
+    // Reading `error_msg` without observing `has_error=true` is undefined
+    // (the string may still be in its default-constructed state or
+    // partially written). `__ry_thread_join` follows this contract; any
+    // future pre-join polling path must follow it too.
     std::string error_msg;
-    bool has_error = false;
+    std::atomic<bool> has_error{false};
     std::atomic<uint8_t> join_state{kJoinNotStarted};
     int64_t result_size = 0;       // 0 = Unit, kThreadResultSlotBytes otherwise
     alignas(kThreadResultSlotBytes) unsigned char result[kThreadResultSlotBytes] = {0};
@@ -65,11 +77,20 @@ struct LockHandle {
 
 struct RWLockHandle {
     std::shared_mutex mu;
-    // Track per-thread lock mode so a single rwlock_unlock() can dispatch correctly.
-    // Key: thread id, Value: count of shared locks held by that thread.
-    std::mutex mode_mu;
-    std::unordered_map<std::thread::id, int> shared_holders;
 };
+
+// Per-thread shared-lock counts keyed by RWLockHandle. `__ry_rwlock_unlock`
+// consults this table (thread-private, no mutex required) to dispatch
+// between `unlock_shared()` and `unlock()`. Using a namespace-scope
+// `thread_local` eliminates the two-step lock/update window #871 fixed.
+// See KNOWLEDGE.md (Runtime / Memory, "RWLock dispatch state") for the
+// deadlock analysis of the rejected shared-mutex alternative.
+//
+// Caveat: an unbalanced `rwlock_read_lock` leaves a stale entry that
+// could be misinterpreted if the RWLock address is later reused — a
+// program bug the previous implementation also did not defend against.
+static thread_local std::unordered_map<RWLockHandle *, int>
+    tls_rwlock_read_counts;
 
 struct SemaphoreHandle {
     std::mutex mu;
@@ -114,10 +135,10 @@ extern "C" void *__ry_thread_spawn(__ry_thread_entry_fn entry, void *env, int64_
             entry(env, result_buf);
         } catch (const std::exception &ex) {
             handle->error_msg = ex.what();
-            handle->has_error = true;
+            handle->has_error.store(true, std::memory_order_release);
         } catch (...) {
             handle->error_msg = "unknown thread error";
-            handle->has_error = true;
+            handle->has_error.store(true, std::memory_order_release);
         }
     });
     return handle;
@@ -154,9 +175,11 @@ extern "C" int64_t __ry_thread_join(void *thread_ptr, void *out_buf) {
         __ry_set_last_error(ex.what());
         return -1;
     }
-    // thread.join() establishes happens-before on the worker's writes.
-    // Check has_error first — on error, the result slot is undefined.
-    if (handle->has_error) {
+    // thread.join() already establishes happens-before on the worker's
+    // writes, so a plain load would be sound here. The explicit acquire
+    // documents the publish/subscribe contract on the ThreadHandle and
+    // stays correct for any future pre-join polling path (#871).
+    if (handle->has_error.load(std::memory_order_acquire)) {
         __ry_set_last_error(handle->error_msg.c_str());
         return -1;
     }
@@ -249,22 +272,32 @@ extern "C" void *__ry_rwlock_new() {
 extern "C" int64_t __ry_rwlock_read_lock(void *rwlock_ptr) {
     if (!rwlock_ptr) { __ry_set_last_error("rwlock_read_lock: null handle"); return -1; }
     auto *rwlock = static_cast<RWLockHandle *>(rwlock_ptr);
+
+    // Reserve the tracking slot BEFORE acquiring the shared lock so there
+    // is no window where the lock is held but the tracker lacks an entry.
+    // Nested read locks skip the allocation entirely via `find`.
+    auto it = tls_rwlock_read_counts.find(rwlock);
+    if (it == tls_rwlock_read_counts.end()) {
+        try {
+            it = tls_rwlock_read_counts.emplace(rwlock, 0).first;
+        } catch (const std::exception &ex) {
+            __ry_set_last_error(ex.what());
+            return -1;
+        }
+    }
+
     try {
         rwlock->mu.lock_shared();
     } catch (const std::exception &ex) {
+        // A zero count uniquely identifies the entry we just created: any
+        // pre-existing nested lock would have second > 0. Erase only in
+        // that case so nested rollback doesn't drop a valid outer count.
+        if (it->second == 0) tls_rwlock_read_counts.erase(it);
         __ry_set_last_error(ex.what());
         return -1;
     }
-    // Track shared ownership after lock_shared succeeds — done outside try
-    // so a map allocation failure doesn't leave the shared lock held.
-    try {
-        std::lock_guard<std::mutex> g(rwlock->mode_mu);
-        rwlock->shared_holders[std::this_thread::get_id()]++;
-    } catch (...) {
-        rwlock->mu.unlock_shared();
-        __ry_set_last_error("rwlock_read_lock: internal tracking failure");
-        return -1;
-    }
+
+    it->second++;
     return 0;
 }
 
@@ -283,16 +316,16 @@ extern "C" int64_t __ry_rwlock_write_lock(void *rwlock_ptr) {
 extern "C" int64_t __ry_rwlock_unlock(void *rwlock_ptr) {
     if (!rwlock_ptr) { __ry_set_last_error("rwlock_unlock: null handle"); return -1; }
     auto *rwlock = static_cast<RWLockHandle *>(rwlock_ptr);
-    {
-        std::lock_guard<std::mutex> g(rwlock->mode_mu);
-        auto it = rwlock->shared_holders.find(std::this_thread::get_id());
-        if (it != rwlock->shared_holders.end() && it->second > 0) {
-            it->second--;
-            if (it->second == 0)
-                rwlock->shared_holders.erase(it);
-            rwlock->mu.unlock_shared();
-            return 0;
-        }
+
+    // Dispatch via thread-local ownership (#871). No shared mutex is
+    // required because each thread only reads/writes its own entry.
+    auto it = tls_rwlock_read_counts.find(rwlock);
+    if (it != tls_rwlock_read_counts.end() && it->second > 0) {
+        it->second--;
+        if (it->second == 0)
+            tls_rwlock_read_counts.erase(it);
+        rwlock->mu.unlock_shared();
+        return 0;
     }
     rwlock->mu.unlock();
     return 0;

--- a/src/runtime_thread.cpp
+++ b/src/runtime_thread.cpp
@@ -273,9 +273,11 @@ extern "C" int64_t __ry_rwlock_read_lock(void *rwlock_ptr) {
     if (!rwlock_ptr) { __ry_set_last_error("rwlock_read_lock: null handle"); return -1; }
     auto *rwlock = static_cast<RWLockHandle *>(rwlock_ptr);
 
-    // Reserve the tracking slot BEFORE acquiring the shared lock so there
-    // is no window where the lock is held but the tracker lacks an entry.
-    // Nested read locks skip the allocation entirely via `find`.
+    // Recursive `lock_shared()` on `std::shared_mutex` is UB in C++17
+    // (cppreference, [thread.sharedmutex.requirements]). The TLS counter
+    // models the user-visible nesting depth, but we must only enter the
+    // underlying mutex once per thread — subsequent nested reads just
+    // bump the counter.
     auto it = tls_rwlock_read_counts.find(rwlock);
     if (it == tls_rwlock_read_counts.end()) {
         try {
@@ -284,17 +286,13 @@ extern "C" int64_t __ry_rwlock_read_lock(void *rwlock_ptr) {
             __ry_set_last_error(ex.what());
             return -1;
         }
-    }
-
-    try {
-        rwlock->mu.lock_shared();
-    } catch (const std::exception &ex) {
-        // A zero count uniquely identifies the entry we just created: any
-        // pre-existing nested lock would have second > 0. Erase only in
-        // that case so nested rollback doesn't drop a valid outer count.
-        if (it->second == 0) tls_rwlock_read_counts.erase(it);
-        __ry_set_last_error(ex.what());
-        return -1;
+        try {
+            rwlock->mu.lock_shared();
+        } catch (const std::exception &ex) {
+            tls_rwlock_read_counts.erase(it);
+            __ry_set_last_error(ex.what());
+            return -1;
+        }
     }
 
     it->second++;
@@ -319,12 +317,15 @@ extern "C" int64_t __ry_rwlock_unlock(void *rwlock_ptr) {
 
     // Dispatch via thread-local ownership (#871). No shared mutex is
     // required because each thread only reads/writes its own entry.
+    // Only the outermost release drops the underlying `unlock_shared()`,
+    // matching the single `lock_shared()` taken in `read_lock`.
     auto it = tls_rwlock_read_counts.find(rwlock);
     if (it != tls_rwlock_read_counts.end() && it->second > 0) {
         it->second--;
-        if (it->second == 0)
+        if (it->second == 0) {
             tls_rwlock_read_counts.erase(it);
-        rwlock->mu.unlock_shared();
+            rwlock->mu.unlock_shared();
+        }
         return 0;
     }
     rwlock->mu.unlock();

--- a/tests/test_runtime_rwlock_stress.cpp
+++ b/tests/test_runtime_rwlock_stress.cpp
@@ -1,0 +1,107 @@
+#include "ry/runtime_thread.hpp"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+
+// Stress test for #871 — RWLock unlock dispatch under contention.
+//
+// Exercises the extern "C" runtime primitives in src/runtime_thread.cpp
+// directly. The Ry-language harness cannot be used here because
+// runTestSource (tests/test_codegen_common.hpp) bypasses the module
+// loader, so `from thread import ...` fails inside specs it runs.
+//
+// Each worker takes many shared locks, then exclusive locks, on the
+// same RWLock. The shared → exclusive transition within a single
+// thread verifies that `__ry_rwlock_unlock` dispatches to `unlock()`
+// (not `unlock_shared()`) after the thread-local count drops to zero;
+// a mis-dispatch would corrupt std::shared_mutex state.
+//
+// Runs under the required `build-tsan/ry_tests` step and doubles as a
+// shared_mutex contention stress for TSan.
+
+
+namespace {
+
+constexpr int kNumWorkers = 4;
+constexpr int kReadsPerWorker = 40;
+constexpr int kWritesPerWorker = 10;
+
+} // namespace
+
+TEST(RuntimeRWLockStress, UnlockDispatchUnderContention) {
+    void *rw = ry::__ry_rwlock_new();
+    ASSERT_NE(rw, nullptr);
+
+    std::atomic<int64_t> reads{0};
+    std::atomic<int64_t> writes{0};
+
+    auto worker = [&]() {
+        for (int i = 0; i < kReadsPerWorker; ++i) {
+            ASSERT_EQ(ry::__ry_rwlock_read_lock(rw), 0);
+            reads.fetch_add(1, std::memory_order_relaxed);
+            ASSERT_EQ(ry::__ry_rwlock_unlock(rw), 0);
+        }
+        for (int i = 0; i < kWritesPerWorker; ++i) {
+            ASSERT_EQ(ry::__ry_rwlock_write_lock(rw), 0);
+            writes.fetch_add(1, std::memory_order_relaxed);
+            ASSERT_EQ(ry::__ry_rwlock_unlock(rw), 0);
+        }
+    };
+
+    std::vector<std::thread> workers;
+    workers.reserve(kNumWorkers);
+    for (int i = 0; i < kNumWorkers; ++i)
+        workers.emplace_back(worker);
+    for (auto &t : workers)
+        t.join();
+
+    EXPECT_EQ(reads.load(), static_cast<int64_t>(kNumWorkers * kReadsPerWorker));
+    EXPECT_EQ(writes.load(), static_cast<int64_t>(kNumWorkers * kWritesPerWorker));
+
+    ry::__ry_rwlock_free(rw);
+}
+
+// Nested-read stress: the same thread takes multiple overlapping read
+// locks on the same RWLock and releases them in LIFO order. This
+// specifically exercises the thread-local counter's increment/decrement
+// logic — the entry's count should only be erased when it drops back
+// to zero, matching the semantics of the previous map-based tracker.
+TEST(RuntimeRWLockStress, NestedReadLockPerThread) {
+    void *rw = ry::__ry_rwlock_new();
+    ASSERT_NE(rw, nullptr);
+
+    std::atomic<int> reached{0};
+
+    auto worker = [&]() {
+        for (int i = 0; i < 30; ++i) {
+            ASSERT_EQ(ry::__ry_rwlock_read_lock(rw), 0);
+            ASSERT_EQ(ry::__ry_rwlock_read_lock(rw), 0);
+            ASSERT_EQ(ry::__ry_rwlock_read_lock(rw), 0);
+            reached.fetch_add(1, std::memory_order_relaxed);
+            ASSERT_EQ(ry::__ry_rwlock_unlock(rw), 0);
+            ASSERT_EQ(ry::__ry_rwlock_unlock(rw), 0);
+            ASSERT_EQ(ry::__ry_rwlock_unlock(rw), 0);
+        }
+    };
+
+    std::vector<std::thread> workers;
+    workers.reserve(kNumWorkers);
+    for (int i = 0; i < kNumWorkers; ++i)
+        workers.emplace_back(worker);
+    for (auto &t : workers)
+        t.join();
+
+    EXPECT_EQ(reached.load(), kNumWorkers * 30);
+
+    // Workers unlock all three levels before returning, so by the time
+    // join() completes their thread-local entries are gone. A following
+    // write_lock on the main thread must succeed.
+    ASSERT_EQ(ry::__ry_rwlock_write_lock(rw), 0);
+    ASSERT_EQ(ry::__ry_rwlock_unlock(rw), 0);
+
+    ry::__ry_rwlock_free(rw);
+}

--- a/tests/test_runtime_rwlock_stress.cpp
+++ b/tests/test_runtime_rwlock_stress.cpp
@@ -1,10 +1,23 @@
 #include "ry/runtime_thread.hpp"
+#include "ry/runtime_arc.hpp"
+#include "ry/runtime_io.hpp"
 
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <cstring>
+#include <stdexcept>
 #include <thread>
 #include <vector>
+
+
+// `__ry_thread_cleanup` is an internal helper (runs the ThreadHandle
+// destructor after ensuring the worker has been joined) and is not
+// exposed via runtime_thread.hpp. Forward-declare it for the error-path
+// test so the handle does not leak under ASan.
+namespace ry {
+extern "C" void __ry_thread_cleanup(void *thread_ptr);
+} // namespace ry
 
 
 // Stress test for #871 — RWLock unlock dispatch under contention.
@@ -104,4 +117,54 @@ TEST(RuntimeRWLockStress, NestedReadLockPerThread) {
     ASSERT_EQ(ry::__ry_rwlock_unlock(rw), 0);
 
     ry::__ry_rwlock_free(rw);
+}
+
+namespace {
+
+// Entry function passed to `__ry_thread_spawn` that throws a
+// std::runtime_error. Exercises the `has_error` / `error_msg` publish
+// path (the worker's `catch(std::exception&)` arm).
+void throwing_entry(void * /*env*/, void * /*result_buf*/) {
+    throw std::runtime_error("worker-boom-#871");
+}
+
+// Entry function that throws a non-std::exception type. Exercises the
+// worker's `catch(...)` arm, which publishes the fallback message.
+void unknown_throw_entry(void * /*env*/, void * /*result_buf*/) {
+    throw 42;
+}
+
+} // namespace
+
+// Regression for the ThreadHandle::has_error release/acquire publish
+// contract (#871). If the worker-side release or the join-side acquire
+// were dropped, TSan would catch it on this path. If the error-field
+// wiring regressed functionally, thread_join would return 0 instead of
+// surfacing the error.
+TEST(RuntimeThreadError, JoinSurfacesStdExceptionFromWorker) {
+    void *t = ry::__ry_thread_spawn(&throwing_entry, nullptr, 0);
+    ASSERT_NE(t, nullptr);
+
+    EXPECT_EQ(ry::__ry_thread_join(t, nullptr), -1);
+
+    const char *msg = ry::__ry_get_last_error();
+    ASSERT_NE(msg, nullptr);
+    EXPECT_STREQ(msg, "worker-boom-#871");
+
+    ry::__ry_thread_cleanup(t);
+    ry::arc_free(t);
+}
+
+TEST(RuntimeThreadError, JoinSurfacesUnknownExceptionFromWorker) {
+    void *t = ry::__ry_thread_spawn(&unknown_throw_entry, nullptr, 0);
+    ASSERT_NE(t, nullptr);
+
+    EXPECT_EQ(ry::__ry_thread_join(t, nullptr), -1);
+
+    const char *msg = ry::__ry_get_last_error();
+    ASSERT_NE(msg, nullptr);
+    EXPECT_STREQ(msg, "unknown thread error");
+
+    ry::__ry_thread_cleanup(t);
+    ry::arc_free(t);
 }


### PR DESCRIPTION
## Summary

Follow-up to #630 P1 audit. Two correctness-hardening fixes in `src/runtime_thread.cpp` plus a stress test.

- **RWLock two-step race** — `__ry_rwlock_read_lock` previously did `mu.lock_shared()` first and then took `mode_mu` to update a shared `shared_holders` map. Between those two steps, `__ry_rwlock_unlock` could observe an inconsistent state and fall through to exclusive `unlock()` — corrupting `std::shared_mutex` state. The fix moves dispatch tracking to a namespace-scope `thread_local std::unordered_map<RWLockHandle*, int>`, eliminating the shared state entirely. The audit's alternative (hold `mode_mu` across `lock_shared()`) would deadlock under writer contention — documented in KNOWLEDGE.md.
- **ThreadHandle error sync** — `has_error` is now `std::atomic<bool>` with release-store in the worker's catch blocks (after writing `error_msg`) and acquire-load in `__ry_thread_join`. Makes the publish/subscribe contract on the ThreadHandle explicit and robust for any future pre-join polling path.
- **Regression test** — new `tests/test_runtime_rwlock_stress.cpp` (pure C++ GoogleTest) exercises the shared → exclusive transition and LIFO nested read locks under contention. Wired into the required `build-tsan/ry_tests` step. The stress test lives in C++ rather than `tests/spec/concurrency.test.ry` because `runTestSource` bypasses `ModuleLoader` and cannot handle `from thread import ...`.

## Why not hold `mode_mu` during `lock_shared`?

Three-way deadlock under writer contention: thread A holds `mode_mu` and blocks inside `lock_shared()` waiting for a pending writer W, but W is waiting on existing reader R to unlock, and R needs `mode_mu` (held by A) to dispatch its unlock. KNOWLEDGE.md carries the full analysis.

## Test plan

- [x] `./build/ry_tests` — 1595/1595 passed
- [x] `./build/ry test -p` — 115/115 test files passed
- [x] `./build-asan/ry_tests` — 1594/1594 passed (`ConcurrencySpecSuite` is `DISABLED_` under ASan per existing guard; one unrelated flake on first run, clean on second, not caused by this change)
- [x] `./build-asan/ry test -p` — 115/115 passed
- [x] **`./build-tsan/ry_tests` — 1595/1595 passed (required TSan gate, covers `ConcurrencySpecSuite` + new `RuntimeRWLockStress` tests)**
- [x] `./build-tsan/ry test -p` — 115/115 passed (warn-only gate per KNOWLEDGE.md `LargeMmapAllocator` entry)

## Scope notes

- `rwlock_unlock` / `thread_join` semantics are observationally unchanged — no user-visible behavior change, no docs/README updates needed.
- `changelog.d/871-rwlock-and-thread-handle-sync.md` added with two `### Fixed` entries.
- `KNOWLEDGE.md` gains three entries under Runtime / Memory: the deadlock analysis for the rejected audit option, the reserve-before-lock exception-safety rule, and the TSan stress-test harness gotcha (for future contributors hitting `runTestSource`'s lack of module resolution).

Closes #871 (after merge to v0.0.8 — `Closes #` does not auto-close on non-default base, will close via GitHub API after merge per AGENTS.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed RWLock unlock behavior to prevent state corruption in concurrent read/write scenarios.
  * Improved thread error signaling synchronization for reliable error publication and observation.

* **Tests**
  * Added multi-threaded RWLock stress tests and runtime thread error tests to validate fixes.

* **Documentation**
  * Expanded runtime/memory guidance with rules and a regression note for RWLock behavior.

* **Chores**
  * Updated build to include the new test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->