### PR TITLE
fix(#886): thread param type names through lambda return-name inference

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -535,6 +535,41 @@ returns with consistent element types. Known limitation (tracked separately):
 returning a **local** collection variable from a block lambda still loses
 shape — see #883.
 
+### Lambda return-name inference must thread declared param type NAMES, not just `llvm::Type*`
+
+**Source**: #886 (2026-04-11, follow-up to #788 / #790 / #884)
+**Tags**: codegen, lambda, returnTypeName, inferExprTypeName, paramType, type-inference
+
+**Context**: `inferExprTypeName` recovers shaped collection names
+(`List<int>`, `Map<str,int>`, `Set<T>`) for local variables via `findVar(name)`
+→ `TypeMeta`. But lambda parameters are NOT yet in `scope_stack_` during
+return-type inference in `emitExprVariant(LambdaExpr)` — their allocas are
+created only after inference runs. When a lambda body returned one of its
+own parameters (`(xs: List<int>) => xs`, or the block-body equivalent),
+`findVar` missed and the fallback
+`reverseResolveTypeName(inferExprType(expr, paramTypeMap))` collapsed
+`ptrTy_` to `"str"`. The lambda's `returnTypeName` came out wrong and
+downstream `propagateTypeMeta()` skipped populating `list_elem_type_name` /
+`map_*_type_name` / `set_elem_type_name` on the call-site alloca, breaking
+`result.length()` / indexing on the returned collection.
+
+**Rule**: Whenever `paramTypeMap` (name → `llvm::Type*`) is built and passed
+to `inferExprTypeName` / `inferReturnTypeName` / `collectReturnTypeNames`,
+build a parallel `paramTypeNameMap` (name → resolved Ry type-name string via
+`resolveTypeAlias(p.type->toString())`) and thread it through the same three
+helpers. In the `VariableExpr` case, consult `paramTypeNameMap` BEFORE
+falling back to the `inferExprType` path. For nested `LambdaExpr` inside a
+lambda body, extend BOTH maps symmetrically. This is the parameter-side
+analog of "`inferReturnType` and `inferReturnTypeName` must be maintained in
+lockstep" — the string path needs its own data source because `llvm::Type*`
+is lossy for opaque-pointer collection types.
+
+**How to verify**: `tests/spec/lambda_collection_return.test.ry` under the
+"lambda returning its collection parameter" describe block covers both
+expression-body and block-body returns of `List<int>`, `Map<str, int>`,
+`Set<int>`, and nested `List<List<int>>` parameters, plus a branched
+block-body case that exercises `collectReturnTypeNames` → `IfStmt` walking.
+
 ### Ry records are SSA struct values, not pointers — nested field writes unroll up to the root alloca
 
 **Source**: #812 (2026-04-11, implementation)

--- a/changelog.d/886-lambda-param-collection-return.md
+++ b/changelog.d/886-lambda-param-collection-return.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Lambdas (expression-body and block-body) that return one of their own
+  collection-typed parameters now correctly propagate the parameter's
+  declared shape so that `result.length()` and indexing work on the
+  returned value (#886).

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1464,16 +1464,19 @@ public:
     llvm::Type *inferExprType(const ExprNode &expr,
         const std::unordered_map<std::string, llvm::Type*> &paramTypeMap);
     std::string inferExprTypeName(const ExprNode &expr,
-        const std::unordered_map<std::string, llvm::Type*> &paramTypeMap);
+        const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+        const std::unordered_map<std::string, std::string> &paramTypeNameMap);
     llvm::Type *inferReturnType(const std::vector<StmtNode> &body,
         const std::unordered_map<std::string, llvm::Type*> &paramTypeMap);
     void collectReturnTypes(const std::vector<StmtNode> &body,
         const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
         std::vector<llvm::Type*> &out);
     std::string inferReturnTypeName(const std::vector<StmtNode> &body,
-        const std::unordered_map<std::string, llvm::Type*> &paramTypeMap);
+        const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+        const std::unordered_map<std::string, std::string> &paramTypeNameMap);
     void collectReturnTypeNames(const std::vector<StmtNode> &body,
         const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+        const std::unordered_map<std::string, std::string> &paramTypeNameMap,
         std::vector<std::string> &out);
     llvm::Type *deduceReturnType(const std::vector<llvm::Type*> &types);
     std::string reverseResolveTypeName(llvm::Type *ty);

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -446,9 +446,11 @@ std::vector<std::string> CodeGen::inferTypeArgs(
         typeParamSet.insert(tp.name);
 
     std::unordered_map<std::string, llvm::Type*> emptyParamMap;
+    std::unordered_map<std::string, std::string> emptyParamNameMap;
     for (size_t i = 0; i < args.size(); ++i) {
         const TypeNode &pt = *tmpl.params[i].type;
-        std::string argName = inferExprTypeName(*args[i], emptyParamMap);
+        std::string argName = inferExprTypeName(*args[i], emptyParamMap,
+                                                 emptyParamNameMap);
 
         if (!argName.empty()) {
             if (unifyTypeParam(pt, argName, typeParamSet, inferred, baseName))

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -285,16 +285,24 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     } else if (!e->return_type) {
         // Infer return type when omitted
         std::unordered_map<std::string, llvm::Type*> paramTypeMap;
-        for (auto &p : e->params)
-            paramTypeMap[p.name] = resolveType(p.type->toString());
+        // Parallel name map: paramTypeMap stores llvm::Type* which
+        // collapses collection params to ptrTy_ → "str". (#886)
+        std::unordered_map<std::string, std::string> paramTypeNameMap;
+        for (auto &p : e->params) {
+            std::string ptn = p.type->toString();
+            paramTypeMap[p.name] = resolveType(ptn);
+            paramTypeNameMap[p.name] = resolveTypeAlias(ptn);
+        }
 
         if (e->expr_body) {
             retTy = inferExprType(*e->expr_body, paramTypeMap);
-            returnTypeName = inferExprTypeName(*e->expr_body, paramTypeMap);
+            returnTypeName = inferExprTypeName(*e->expr_body, paramTypeMap,
+                                                paramTypeNameMap);
         } else {
             buildLocalTypeMap(e->body, paramTypeMap);
             retTy = inferReturnType(e->body, paramTypeMap);
-            returnTypeName = inferReturnTypeName(e->body, paramTypeMap);
+            returnTypeName = inferReturnTypeName(e->body, paramTypeMap,
+                                                  paramTypeNameMap);
         }
     } else {
         retTy = resolveType(retTypeStr);
@@ -616,30 +624,36 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
 }
 
 std::string CodeGen::inferExprTypeName(const ExprNode &expr,
-    const std::unordered_map<std::string, llvm::Type*> &paramTypeMap) {
+    const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+    const std::unordered_map<std::string, std::string> &paramTypeNameMap) {
     return std::visit([&](const auto &v) -> std::string {
         using T = std::decay_t<decltype(v)>;
         if constexpr (std::is_same_v<T, std::unique_ptr<ListExpr>>) {
             if (v->elements.empty()) return "";
-            std::string elem = inferExprTypeName(*v->elements[0], paramTypeMap);
+            std::string elem = inferExprTypeName(*v->elements[0], paramTypeMap,
+                                                  paramTypeNameMap);
             if (elem.empty()) return "";
             return "List<" + elem + ">";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<MapExpr>>) {
             if (v->keys.empty()) return "";
-            std::string key = inferExprTypeName(*v->keys[0], paramTypeMap);
-            std::string val = inferExprTypeName(*v->values[0], paramTypeMap);
+            std::string key = inferExprTypeName(*v->keys[0], paramTypeMap,
+                                                 paramTypeNameMap);
+            std::string val = inferExprTypeName(*v->values[0], paramTypeMap,
+                                                 paramTypeNameMap);
             if (key.empty() || val.empty()) return "";
             return "Map<" + key + ", " + val + ">";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<SetExpr>>) {
             if (v->elements.empty()) return "";
-            std::string elem = inferExprTypeName(*v->elements[0], paramTypeMap);
+            std::string elem = inferExprTypeName(*v->elements[0], paramTypeMap,
+                                                  paramTypeNameMap);
             if (elem.empty()) return "";
             return "Set<" + elem + ">";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<TupleExpr>>) {
             if (v->elements.empty()) return "";
             std::string out = "(";
             for (size_t i = 0; i < v->elements.size(); ++i) {
-                std::string e = inferExprTypeName(*v->elements[i], paramTypeMap);
+                std::string e = inferExprTypeName(*v->elements[i], paramTypeMap,
+                                                   paramTypeNameMap);
                 if (e.empty()) return "";
                 if (i > 0) out += ", ";
                 out += e;
@@ -682,11 +696,19 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
                 }
                 return reverseResolveTypeName(alloca->getAllocatedType());
             }
+            // Lambda params aren't in scope_stack_ during return-type
+            // inference, so findVar missed. Consult the name map before
+            // the llvm::Type* fallback which would collapse collection
+            // params to "str". (#886)
+            auto nameIt = paramTypeNameMap.find(v.name);
+            if (nameIt != paramTypeNameMap.end() && !nameIt->second.empty())
+                return nameIt->second;
             return reverseResolveTypeName(inferExprType(expr, paramTypeMap));
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CallExpr>>) {
             // `Some(x)` constructs an Option<T>; propagate inner type.
             if (v->callee == "Some" && v->args.size() == 1) {
-                std::string inner = inferExprTypeName(*v->args[0], paramTypeMap);
+                std::string inner = inferExprTypeName(*v->args[0], paramTypeMap,
+                                                       paramTypeNameMap);
                 if (inner.empty()) return "";
                 return "Option<" + inner + ">";
             }
@@ -718,11 +740,16 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
                 // the lambda's declared parameter types so identifiers
                 // in the body resolve correctly.
                 std::unordered_map<std::string, llvm::Type*> lambdaParamTypeMap = paramTypeMap;
+                std::unordered_map<std::string, std::string> lambdaParamTypeNameMap = paramTypeNameMap;
                 for (const auto &p : v->params) {
-                    if (p.type)
-                        lambdaParamTypeMap[p.name] = resolveType(p.type->toString());
+                    if (p.type) {
+                        std::string ptn = p.type->toString();
+                        lambdaParamTypeMap[p.name] = resolveType(ptn);
+                        lambdaParamTypeNameMap[p.name] = resolveTypeAlias(ptn);
+                    }
                 }
-                ret = inferExprTypeName(*v->expr_body, lambdaParamTypeMap);
+                ret = inferExprTypeName(*v->expr_body, lambdaParamTypeMap,
+                                         lambdaParamTypeNameMap);
             }
             if (ret.empty()) return "";
             out += " -> " + ret;
@@ -730,10 +757,12 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CastExpr>>) {
             return resolveTypeAlias(v->target_type->toString());
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondExpr>>) {
-            return inferExprTypeName(*v->else_expr, paramTypeMap);
+            return inferExprTypeName(*v->else_expr, paramTypeMap,
+                                      paramTypeNameMap);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseExpr>>) {
             if (!v->arms.empty())
-                return inferExprTypeName(*v->arms[0].value, paramTypeMap);
+                return inferExprTypeName(*v->arms[0].value, paramTypeMap,
+                                          paramTypeNameMap);
             return "";
         } else {
             return reverseResolveTypeName(inferExprType(expr, paramTypeMap));
@@ -774,32 +803,40 @@ void CodeGen::collectReturnTypes(const std::vector<StmtNode> &body,
 
 void CodeGen::collectReturnTypeNames(const std::vector<StmtNode> &body,
     const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+    const std::unordered_map<std::string, std::string> &paramTypeNameMap,
     std::vector<std::string> &out) {
     for (auto &stmt : body) {
         std::visit([&](const auto &s) {
             using T = std::decay_t<decltype(s)>;
             if constexpr (std::is_same_v<T, ReturnStmt>) {
                 if (s.value)
-                    out.push_back(inferExprTypeName(*s.value, paramTypeMap));
+                    out.push_back(inferExprTypeName(*s.value, paramTypeMap,
+                                                     paramTypeNameMap));
             } else if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) {
-                collectReturnTypeNames(s->branch.body, paramTypeMap, out);
-                collectReturnTypeNames(s->else_body, paramTypeMap, out);
+                collectReturnTypeNames(s->branch.body, paramTypeMap,
+                                        paramTypeNameMap, out);
+                collectReturnTypeNames(s->else_body, paramTypeMap,
+                                        paramTypeNameMap, out);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondStmt>>) {
                 for (auto &arm : s->arms)
-                    collectReturnTypeNames(arm.body, paramTypeMap, out);
-                collectReturnTypeNames(s->else_body, paramTypeMap, out);
+                    collectReturnTypeNames(arm.body, paramTypeMap,
+                                            paramTypeNameMap, out);
+                collectReturnTypeNames(s->else_body, paramTypeMap,
+                                        paramTypeNameMap, out);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseStmt>>) {
                 for (auto &arm : s->arms)
-                    collectReturnTypeNames(arm.body, paramTypeMap, out);
+                    collectReturnTypeNames(arm.body, paramTypeMap,
+                                            paramTypeNameMap, out);
             }
         }, stmt);
     }
 }
 
 std::string CodeGen::inferReturnTypeName(const std::vector<StmtNode> &body,
-    const std::unordered_map<std::string, llvm::Type*> &paramTypeMap) {
+    const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+    const std::unordered_map<std::string, std::string> &paramTypeNameMap) {
     std::vector<std::string> names;
-    collectReturnTypeNames(body, paramTypeMap, names);
+    collectReturnTypeNames(body, paramTypeMap, paramTypeNameMap, names);
     if (names.empty())
         return "";
     // Conservative: if any return branch can't produce a shaped type name,

--- a/tests/spec/lambda_collection_return.test.ry
+++ b/tests/spec/lambda_collection_return.test.ry
@@ -127,3 +127,60 @@ describe("block-bodied lambda with branched returns", ():
     expect(f(false).length()).to_eq(2)
   )
 )
+
+describe("lambda returning its collection parameter", ():
+  it("expression-body returns List<int> param", ():
+    g = (xs: List<int>) => xs
+    expect(g([1, 2, 3]).length()).to_eq(3)
+    expect(g([1, 2, 3])[0]).to_eq(1)
+  )
+
+  it("block-body returns List<int> param", ():
+    f = (xs: List<int>):
+      return xs
+    expect(f([1, 2, 3]).length()).to_eq(3)
+  )
+
+  it("expression-body returns Map<str, int> param", ():
+    m = (d: Map<str, int>) => d
+    expect(m({"a": 1, "b": 2, "c": 3}).length()).to_eq(3)
+    expect(m({"a": 1, "b": 2, "c": 3})["b"]).to_eq(2)
+  )
+
+  it("block-body returns Map<str, int> param", ():
+    m = (d: Map<str, int>):
+      return d
+    expect(m({"a": 1, "b": 2}).length()).to_eq(2)
+  )
+
+  it("expression-body returns Set<int> param", ():
+    s = (xs: Set<int>) => xs
+    expect(s({1, 2, 3, 4}).length()).to_eq(4)
+  )
+
+  it("block-body returns Set<int> param", ():
+    s = (xs: Set<int>):
+      return xs
+    expect(s({1, 2, 3}).length()).to_eq(3)
+  )
+
+  it("expression-body returns List<List<int>> param", ():
+    n = (xss: List<List<int>>) => xss
+    expect(n([[1, 2], [3, 4]]).length()).to_eq(2)
+    expect(n([[1, 2], [3, 4]])[0].length()).to_eq(2)
+  )
+
+  it("block-body returns List<List<int>> param", ():
+    n = (xss: List<List<int>>):
+      return xss
+    expect(n([[1, 2], [3, 4]]).length()).to_eq(2)
+  )
+
+  it("block-body returns param across branches", ():
+    f = (xs: List<int>):
+      if xs.length() > 0:
+        return xs
+      return xs
+    expect(f([1, 2, 3]).length()).to_eq(3)
+  )
+)


### PR DESCRIPTION
## Summary

- Lambdas (expression- and block-bodied) that return one of their own collection-typed parameters now correctly propagate the parameter's declared shape, so `result.length()` / indexing work on the returned value (#886).
- Fixes the parameter-side analog of #788 / #790 / #884 — those landed literal-return propagation; this one handles `return xs` where `xs: List<int>` (or Map/Set/nested) is a lambda parameter.

## Root cause

`inferExprTypeName(VariableExpr)` could only recover shaped collection names from an in-scope alloca's `TypeMeta` via `findVar()`, or from the `llvm::Type*`-path fallback. At inference time in `emitExprVariant(LambdaExpr)`, lambda params aren't yet in `scope_stack_`, and `paramTypeMap` only stores `llvm::Type*` — which for collection params is `ptrTy_` (opaque pointer, LLVM 15+). The fallback `reverseResolveTypeName(ptrTy_)` yields `"str"`, so `returnTypeName` came out wrong and downstream `propagateTypeMeta()` skipped populating list/map/set element metadata on the call-site alloca.

## Fix

Thread a parallel `paramTypeNameMap` (name → resolved Ry type-name string via `resolveTypeAlias(p.type->toString())`) through `inferExprTypeName`, `inferReturnTypeName`, and `collectReturnTypeNames`. In the `VariableExpr` branch, consult it after the `findVar` miss and before the `llvm::Type*` fallback. For nested `LambdaExpr` inside a lambda body, extend both maps symmetrically. The single external caller (`codegen_fn_generic.cpp:inferTypeArgs`) passes an empty map — generic inference has no lambda-param context.

`src/codegen_fn.cpp` top-level `fn` uses a different codepath (`inferReturnType` → `reverseResolveTypeName`) and is not affected by this fix — noted as a separate latent issue.

## Test plan

- [x] Rebuilt `./build/ry` and `./build/ry_tests`
- [x] New describe block in `tests/spec/lambda_collection_return.test.ry` covers `List<int>` / `Map<str, int>` / `Set<int>` / nested `List<List<int>>` params in both expression- and block-body lambdas, plus a branched block-body case that exercises `collectReturnTypeNames` walking through `IfStmt`
- [x] `./build/ry test tests/spec/lambda_collection_return.test.ry` — **24 passed, 0 failed**
- [x] `./build/ry_tests` — **1597 passed** (post-merge with #871)
- [x] `./build/ry test -p` — **115 files, 0 failures**
- [x] ASan + UBSan: `./build-asan/ry_tests` (1592 pass) + `./build-asan/ry test -p` (115 files pass), no sanitizer diagnostics
- [x] Issue repros from the issue body now print correct values (3, 3, 3, 2)
- [x] New `KNOWLEDGE.md` entry as parameter-side analog to the existing #790 "must be maintained in lockstep" entry
- [x] Changelog fragment `changelog.d/886-lambda-param-collection-return.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lambda expressions that return collection-typed parameters. Returned collections now maintain their declared shape, enabling operations like `.length()` and indexing to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->