### PR TITLE
fix(#863): emit type-aware error for `+` on Map/Set operands

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -694,6 +694,36 @@ check at `src/codegen_type.cpp:125` (`array element type must be a
 low-level type`), so ARC-managed collection element types are rejected
 at type resolution and never reach the compound path.
 
+### New dispatch branches in `emitArithmeticOp` must precede the str-vs-non-str reject
+
+**Source**: #863 (2026-04-11)
+**Tags**: codegen, arithmetic, type-error, collection, dispatch-order
+
+**Context**: `src/codegen_expr.cpp::emitArithmeticOp` uses a
+str-vs-non-str reject (`if (lhsIsStr || rhsIsStr) codegenError(...)`) as
+the last line of defense for ill-typed `+` operands. The catch is that
+`isStringValue()` (`src/codegen_any.cpp:28`) returns `true` for **any**
+`ptrTy_` value whose metadata side table has no `hasAnyMeta()` flag —
+it is effectively "unknown pointer type", not "string". Consequently
+any dispatch branch added AFTER this reject is unreachable for
+metadata-less pointer operands (they are already classified as str and
+rejected with a misleading message), and adding a branch BEFORE it must
+be careful not to steal legitimate str mismatches like `"x" + myMap`.
+
+**Rule**: When adding a new type-specific error branch for `+` in
+`emitArithmeticOp`, insert it **after** the list-concat success path
+(around `codegen_expr.cpp:1023`) but **before** the str-vs-non-str
+reject. Use the typed metadata accessors (`getMapKeyType` /
+`getMapValueType` / `getSetElementType` / `getListElementType`) to
+recognize the operand kind and `buildTypeNameFromMeta()` to surface the
+source-level type name in the diagnostic. This is the placement used
+by the #863 Map/Set dispatch; see that fix for the canonical pattern.
+
+**Related**: The companion #858/#862 entry covers the upstream side of
+the same trap — metadata propagation on compound-assign loaded slots —
+which must also be correct for the new dispatch branch to see accurate
+kinds on LHS values produced by `m[k] += ...` and friends.
+
 ### Element-slot writes must release the overwritten ARC pointer
 
 **Source**: #855 (2026-04-11)

--- a/changelog.d/863-plus-map-set-error.md
+++ b/changelog.d/863-plus-map-set-error.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `+` applied to `Map` or `Set` operands now produces a clear error that names the actual collection type instead of the misleading `"operator '+' not supported between str and non-str types"` message. Mixed cases such as `List<int> + Map<str, int>` also name both operand types. (#863)

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1022,6 +1022,25 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
         }
     }
 
+    // Map/Set do not support '+'; catch here before the str-vs-non-str
+    // reject below, which misclassifies any pointer without metadata as a
+    // string and would emit a misleading diagnostic. List + List is
+    // handled above at line 1015. (#863)
+    if (op == "+") {
+        bool lhsIsMapOrSet =
+            getMapKeyType(lhs) || getMapValueType(lhs) || getSetElementType(lhs);
+        bool rhsIsMapOrSet =
+            getMapKeyType(rhs) || getMapValueType(rhs) || getSetElementType(rhs);
+        if (lhsIsMapOrSet || rhsIsMapOrSet) {
+            std::string lhsName = inferCollectionTypeName(lhs);
+            std::string rhsName = inferCollectionTypeName(rhs);
+            if (lhsName.empty()) lhsName = "non-collection";
+            if (rhsName.empty()) rhsName = "non-collection";
+            codegenError("type error: operator '+' is not defined for " +
+                         lhsName + " and " + rhsName);
+        }
+    }
+
     // Reject str with non-str operands (must come after string concat/repeat checks)
     if (lhsIsStr || rhsIsStr)
         codegenError("type error: operator '" + op + "' not supported between str and non-str types");

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -216,3 +216,46 @@ TEST_F(CodeGenTest, GenericInferenceConflictingBindingError) {
         "print(same(1, \"x\"))\n",
         "conflicting type inference for 'T'");
 }
+
+// ============================================================
+// `+` on Map / Set / mixed collection operands must produce a
+// type-aware error that names the actual collection type.  Before
+// #863 these operations fell through to the str-vs-non-str reject
+// path and surfaced a misleading "operator '+' not supported between
+// str and non-str types" message, which is actively wrong for
+// Map + Map.  These tests pin the corrected diagnostics.
+// ============================================================
+
+TEST_F(CodeGenTest, ArithPlusRejectsMapPlusMap) {
+    expectCompileError(
+        "a: Map<str, int> = {\"a\": 1}\n"
+        "b: Map<str, int> = {\"b\": 2}\n"
+        "c = a + b\n",
+        "operator '+' is not defined for Map<str, int> and Map<str, int>");
+}
+
+TEST_F(CodeGenTest, ArithPlusRejectsSetPlusSet) {
+    expectCompileError(
+        "a: Set<int> = {1}\n"
+        "b: Set<int> = {2}\n"
+        "c = a + b\n",
+        "operator '+' is not defined for Set<int> and Set<int>");
+}
+
+TEST_F(CodeGenTest, ArithPlusRejectsListPlusMap) {
+    expectCompileError(
+        "a: List<int> = [1]\n"
+        "b: Map<str, int> = {\"b\": 2}\n"
+        "c = a + b\n",
+        "operator '+' is not defined for List<int> and Map<str, int>");
+}
+
+// The existing list-concat mismatch diagnostic must still fire for
+// List<T> + List<U> so the new Map/Set branch does not overshadow it.
+TEST_F(CodeGenTest, ArithPlusListConcatMismatchMessageUnchanged) {
+    expectCompileError(
+        "a: List<int> = [1]\n"
+        "b: List<str> = [\"x\"]\n"
+        "c = a + b\n",
+        "list concatenation requires matching element types");
+}


### PR DESCRIPTION
## Summary

- `emitArithmeticOp` now detects `Map` / `Set` operands on `+` and emits a diagnostic that names the actual collection type, instead of falling through to the str-vs-non-str reject and surfacing the misleading `"operator '+' not supported between str and non-str types"` error.
- The new branch sits between the list-concat success path and the str-vs-non-str reject in `src/codegen_expr.cpp`, uses the typed metadata accessors to detect Map/Set, and reuses the existing `inferCollectionTypeName()` helper to render source-level type names.
- `KNOWLEDGE.md` gains a dispatch-order entry so future contributors adding branches to `emitArithmeticOp` know to insert them before the str-vs-non-str reject (which misclassifies any metadata-less pointer as a string via `isStringValue`).

Closes #863.

## Example

Before:

```
error: type error: operator '+' not supported between str and non-str types
```

After:

```
error: type error: operator '+' is not defined for Map<str, int> and Map<str, int>
```

## Test plan

- [x] `./build/ry_tests --gtest_filter='CodeGenTest.ArithPlus*'` — 4 new regression tests pass (Map+Map, Set+Set, List+Map, and a guardrail pin that the existing list-concat element-type mismatch diagnostic is unchanged).
- [x] `./build/ry_tests` — full C++ suite green (1601 tests).
- [x] `./build/ry test -p` — full Ry self-test green (115 files).
- [x] ASan + UBSan full sweep (`ry_tests` + `ry test -p`).
- [x] TSan full sweep (`ry_tests` + `ry test -p`), both C++ and self-test clean.
- [x] Playground smoke test on the issue's reproducer (`Map<str, int> + Map<str, int>`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when using the `+` operator with Map or Set operands. The compiler now correctly identifies the collection types involved instead of providing misleading type mismatch errors.

* **Tests**
  * Added test cases verifying accurate error diagnostics for collection-type operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->