### PR TITLE
docs(#889): fix errors and gaps found in English README / docs audit

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1239,6 +1239,39 @@ grep -nE '\bval\b|\bvar\b|\bpublic\b|\bprivate\b' docs/reference/*.md
 
 ---
 
+### `@native` declarations can silently drift from their dispatcher implementation
+
+**Source**: #889 docs audit
+**Tags**: stdlib, native, codegen, drift
+
+**Context**: During a docs audit, `docs/reference/collections.md` was
+suspected of being wrong because `share/std/list.ry` declared
+`remove_at(...) -> Unit` while the docs described a return value.
+Investigation showed the opposite was true: `CodeGen::emitCollOp_remove_at`
+(`src/codegen_call_collection.cpp`) actually returns the removed element,
+and `tests/spec/collections.test.ry` has long asserted on it
+(`v = remove_at(xs, 1); expect(v).to_eq(2)`). The `-> Unit` declaration
+in `list.ry` was the bug — it had been ignored by the custom dispatcher
+for so long that nobody noticed.
+
+**Rule**: The declared signature in `share/std/*.ry` is **not** the
+source of truth for `@native` functions that go through a hand-written
+codegen dispatcher (`src/codegen_call_*.cpp`). The dispatcher can —
+and for historical reasons does — produce a different shape than the
+declaration. Before treating a declaration as spec, cross-check the
+dispatcher and the tests.
+
+**How to apply**:
+- When docs disagree with a `@native` signature, diff all three: the
+  declaration file, the dispatcher in `src/codegen_call_*.cpp`, and an
+  existing test in `tests/spec/`. The test's assertions reveal the
+  actually observable return shape.
+- If the declaration is wrong, fix the declaration rather than the
+  docs or the tests; the dispatcher/test pair is the de-facto contract.
+- Consider this whenever you audit or regenerate stdlib signatures.
+
+---
+
 ## Commands / Environment gotchas
 
 This section records command/environment mistakes that were

--- a/README.md
+++ b/README.md
@@ -12,17 +12,20 @@
 ## Features
 
 - **LLVM JIT Compilation** — Fast native execution powered by ORC LLJIT
-- **Rich Type System** — `int`, `float`, `bool`, `str`, `Option<T>`, `Error`, tuples, `List<T>`, `Map<K,V>`, `Set<T>`, `enum`, function types, user-defined structs
-- **Operators** — Arithmetic, comparison, logical, bitwise (`>>>` logical right shift), compound assignment, `in` / `not in`, string repetition (`"ab" * 3`), `as` type cast, with operator overloading support
+- **Rich Type System** — `int`, `float`, `bool`, `str`, `Option<T>`, `Error`, tuples, `List<T>`, `Map<K,V>`, `Set<T>`, `enum`, function types, user-defined records, union types (`int | str`)
+- **Operators** — Arithmetic, comparison, logical, bitwise (`>>>` logical right shift), compound assignment, `in` / `not in`, string repetition (`"ab" * 3`), `as` type cast, error propagation `?`, with operator overloading support
+- **Pattern Matching** — `case` expressions with enum / `Option` / `Result` / literal / tuple / record destructuring, guard clauses (`x if x > 0`), exhaustiveness checking
 - **F-String** — String interpolation with `f"Hello {name}"`
 - **Design by Contract** — `require` (preconditions), `ensure` (postconditions), `invariant` (record invariants), `old()`, `result`
-- **Directives** — `@deprecated` compile-time metadata annotations
+- **Directives** — `@deprecated`, `@const`, `@native`, `@parallel`, `@inline`, `@each`, `@property`, `@describe`, `@it` and other compile-time metadata annotations
 - **Functions** — `function` definitions, recursion, overloading, lambdas (closures), higher-order functions, UFCS
 - **Control Flow** — `if`/`else`, `when`, `while`, `for...in`, `break`/`continue`
 - **File I/O** — File read/write, byte operations, standard input (`std.io`)
 - **Filesystem** — Directory listing, recursive walk, glob, copy, move, remove, permissions (`std.filesystem`)
 - **Packages** — Directory-based packages, auto-imported `std` library, `from ... import ...`
 - **Concurrency** — `async`/`await` with work-stealing scheduler, `@parallel` for loops, native thread API (`std.thread`)
+- **Memory Management** — ARC (Automatic Reference Counting) with a cycle collector (`std.gc`)
+- **Testing Framework** — `@describe` / `@it` directives on named functions, matchers (`expect(x).to_eq(...)`), parameterized tests (`@each`), property-based tests (`@property`)
 - **Type Safety** — Type inference, type annotations, immutable type bindings, `@const` directive
 
 ## Sample Code
@@ -46,7 +49,7 @@ offset = 10
 add_offset = (x: int) -> int => x + offset
 print(add_offset(5))   # 15
 
-# Structs
+# Records
 record Point:
     x: int
     y: int
@@ -102,7 +105,7 @@ curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh
 To specify a particular version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh -s v0.0.4
+curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh -s v0.0.7
 ```
 
 By default, it installs to `~/.local/bin`. You can change this with the `RY_INSTALL_DIR` environment variable.

--- a/changelog.d/889-docs-audit-fixes.md
+++ b/changelog.d/889-docs-audit-fixes.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- Corrected `` `match value:` `` references to `` `case value:` `` in the pattern matching tutorial — the actual keyword is `case` (#889)
+- Rewrote the networking example in the concurrency tutorial so the server/client snippets match runnable `net` test code (#889)
+- Replaced outdated "struct" phrasing in `README.md` and `docs/README.md` with "record" to match the Ry keyword (#889)
+- Updated the install one-liner in `README.md` to the current release version (#889)
+- Added the `@describe` / `@it` directive-based test style to the testing tutorial and to the directives reference, so the new preferred syntax is actually documented (#889)
+- Expanded the `README.md` feature list to mention pattern matching, the built-in testing framework, union types, GC (`std.gc`), and the `?` error propagation operator (#889)
+- Expanded the `README.md` directives line beyond `@deprecated` to include the other common directives (#889)
+- Added an explicit "In-Place Mutating Variants" section to the collections reference covering `append!`, `sort!`, `reverse!`, and the non-mutating `appended` counterpart (#889)
+
+### Changed
+
+- `remove_at(values: List<int>, index: int)` in `share/std/list.ry` is now declared to return `int` instead of `Unit`, matching both the runtime implementation and the existing `collections.test.ry` expectations (#889)

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ For detailed language specifications, see the reference pages below.
 | [Operators and Precedence](reference/operators.md) | All operators and precedence table |
 | [Control Flow](reference/control-flow.md) | Complete grammar for if/else, when, while, for |
 | [Functions, Lambdas, UFCS, Operator Overloading](reference/functions.md) | All forms of function definitions |
-| [Structs and Enums](reference/structs.md) | Complete grammar for type and enum definitions |
+| [Records and Enums](reference/structs.md) | Complete grammar for record and enum definitions |
 | [Tuples, Lists, Maps, Sets](reference/collections.md) | Collection type operations |
 | [Built-in Functions](reference/builtins.md) | print, length, Some, range, etc. |
 | [String Functions](reference/builtins-string.md) | contains, find, replace, split, join, etc. |

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -491,6 +491,43 @@ print(flatten(xs))   # [1, 2, 3, 4]
 print(xs)            # [[1, 2], [3, 4]] (unchanged)
 ```
 
+### In-Place Mutating Variants
+
+Some list operations have two forms: a non-mutating version that returns a new list, and an in-place variant whose name ends with `!`. Use the `!` form when you intend to mutate the receiver and want to make that intent explicit at the call site; use the non-mutating form when you want to preserve the original.
+
+| In-place (`!`) | Non-mutating equivalent | Difference |
+|------|-----|-----|
+| `append!(xs, v)` / `append(xs, v)` | `appended(xs, v)` | `append!` / `append` mutate in place and return `Unit`; `appended` returns a new list |
+| `sort!(xs)` / `sort!(xs, cmp)` | `sort(xs)` / `sort(xs, cmp)` | `sort!` mutates `xs` in place; `sort` returns a new sorted list |
+| `reverse!(xs)` | `reverse(xs)` | `reverse!` mutates `xs` in place; `reverse` returns a new reversed list |
+
+All `!` variants participate in Copy-on-Write: if `xs` is shared (reference count > 1), the outer buffer is cloned once before the in-place mutation so that aliases are not affected (see [Copy-on-Write (CoW) Semantics](#copy-on-write-cow-semantics)).
+
+```python
+xs = [3, 1, 2]
+sort!(xs)
+print(xs)         # [1, 2, 3]
+
+ys = [1, 2, 3]
+reverse!(ys)
+print(ys)         # [3, 2, 1]
+
+zs = [1, 2]
+append!(zs, 3)
+print(zs)         # [1, 2, 3]
+
+# Non-mutating variant: appended returns a new list
+a = [1, 2]
+b = appended(a, 3)
+print(a)          # [1, 2] (unchanged)
+print(b)          # [1, 2, 3]
+```
+
+**When to use which**:
+
+- Prefer `sort`, `reverse`, `appended` when readers benefit from seeing that the original is preserved (e.g. functional pipelines, or when the original is still needed afterwards).
+- Prefer `sort!`, `reverse!`, `append!` when the original is genuinely being replaced, to avoid the allocation of an intermediate copy and to make the mutation explicit at the call site.
+
 ### Operation Complexity
 
 | Operation | Complexity |

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -17,12 +17,12 @@ Directives are placed before the target declaration. Multiple directives can be 
 
 Directives can be applied to the following declarations:
 
-- `function` - Function definitions
-- `record` - Struct definitions
+- `function` - Function definitions (including named test functions decorated with `@it` / `@describe`)
+- `record` - Record definitions
 - Variable declarations (with or without `@const`)
 - Fields within a `record` definition
 - `for` - Counted loops only for `@parallel`
-- `it` - Test case definitions (for `@each` and `@property` only)
+- `it` / `describe` calls (legacy lambda form) - Test cases and test groups for `@each` and `@property`
 
 ## Built-in Directives
 
@@ -208,9 +208,18 @@ for i in range(8):
 
 ### `@each`
 
-Enables parameterized testing by running an `it` block multiple times with different parameters.
+Enables parameterized testing by running a test multiple times with different parameters.
 
-**Syntax:**
+**Syntax (on a named function, preferred):**
+
+```
+@each([(arg1, arg2, ...), ...])
+@it("should handle {0} and {1}")
+function test_handle(param1: type, param2: type):
+    # test body
+```
+
+**Syntax (on a legacy `it` lambda):**
 
 ```
 @each([(arg1, arg2, ...), ...])
@@ -223,23 +232,32 @@ The argument can be any expression that evaluates to a list of tuples, including
 
 ```ry
 @each(make_inputs())
-it("should handle {0}", (x: int):
+@it("should handle {0}")
+function test_handle(x: int):
     # test body
-)
 ```
 
-**Supported target:** `it` calls only
+**Supported targets:** functions decorated with `@it`, or legacy `it` calls.
 
 **Constraints:**
 - The argument must evaluate to a list of tuples
-- Tuple arity must match the lambda parameter count
+- Tuple arity must match the function parameter count
 - Placeholders `{0}`, `{1}`, ... in the description string are replaced with stringified values
 
 ### `@property`
 
-Enables property-based testing by generating random inputs for an `it` block.
+Enables property-based testing by generating random inputs for a test.
 
-**Syntax:**
+**Syntax (on a named function, preferred):**
+
+```
+@property(count=100)
+@it("should verify property name")
+function test_property(a: int, b: int):
+    # test body with random values
+```
+
+**Syntax (on a legacy `it` lambda):**
 
 ```
 @property(count=100)
@@ -248,7 +266,7 @@ it("should verify property name", (a: int, b: int):
 )
 ```
 
-**Supported target:** `it` calls only
+**Supported targets:** functions decorated with `@it`, or legacy `it` calls.
 
 **Parameters:**
 
@@ -266,6 +284,108 @@ it("should verify property name", (a: int, b: int):
 | `str` | Random ASCII, 0-20 characters |
 
 On failure, the counterexample (parameter values that caused the failure) is printed.
+
+### `@it`
+
+Declares a test case by decorating a named function. The function body becomes the test body and is executed by `ry test`. See [Testing Reference](testing.md) for the full specification.
+
+**Syntax:**
+
+```
+@it("description")
+function test_name():
+    # assertions
+```
+
+**Basic example:**
+
+```ry
+@it("should add 1 + 2 = 3")
+function test_add():
+    expect(1 + 2).to_eq(3)
+```
+
+**Composed with `@each` or `@property`:**
+
+```ry
+@each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
+@it("should add {0} + {1} = {2}")
+function test_add_each(a: int, b: int, expected: int):
+    expect(a + b).to_eq(expected)
+
+@property(count=100)
+@it("should verify addition is commutative")
+function test_commutative(a: int, b: int):
+    expect(a + b).to_eq(b + a)
+```
+
+**Supported target:** `function` declarations only. The function must not have a return type annotation.
+
+**Constraints:**
+- Only valid in `*.test.ry` files executed with `ry test`
+- When combined with `@each`, the function's parameter list must match the tuple arity
+- When combined with `@property`, each parameter type must be one of the supported generator types (`int`, `float`, `bool`, `str`)
+
+### `@describe`
+
+Groups a set of related tests by decorating a named function. Inner `@it` functions declared in the body belong to the group, and variables declared directly in the body act as shared setup captured by every inner `@it`. Unlike the legacy lambda form, `@describe` groups **may be nested**; output is indented proportionally to nesting depth.
+
+**Syntax:**
+
+```
+@describe("group name")
+function group_name():
+    @it("nested test")
+    function test_nested():
+        # assertions
+```
+
+**Basic example:**
+
+```ry
+@describe("arithmetic")
+function arithmetic_tests():
+    @it("should subtract")
+    function test_sub():
+        expect(10 - 3).to_eq(7)
+
+    @it("should multiply")
+    function test_mul():
+        expect(4 * 5).to_eq(20)
+```
+
+**Shared setup:**
+
+Variables declared in the outer `@describe` body are automatically captured by every inner `@it` function.
+
+```ry
+@describe("shared setup")
+function shared_setup_tests():
+    base = 100
+    offset = 5
+
+    @it("should use base")
+    function test_base():
+        expect(base).to_eq(100)
+
+    @it("should use base and offset")
+    function test_combined():
+        expect(base + offset).to_eq(105)
+```
+
+**Nested groups:**
+
+```ry
+@describe("outer")
+function outer():
+    @describe("inner")
+    function inner():
+        @it("should pass deeply nested test")
+        function test_deep():
+            expect(1 + 1).to_eq(2)
+```
+
+**Supported target:** `function` declarations only. The function must not have parameters or a return type annotation.
 
 ### `@inline`
 

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -212,7 +212,7 @@ Enables parameterized testing by running a test multiple times with different pa
 
 **Syntax (on a named function, preferred):**
 
-```
+```ry
 @each([(arg1, arg2, ...), ...])
 @it("should handle {0} and {1}")
 function test_handle(param1: type, param2: type):
@@ -221,7 +221,7 @@ function test_handle(param1: type, param2: type):
 
 **Syntax (on a legacy `it` lambda):**
 
-```
+```ry
 @each([(arg1, arg2, ...), ...])
 it("should handle {0} and {1}", (param1: type, param2: type):
     # test body
@@ -250,7 +250,7 @@ Enables property-based testing by generating random inputs for a test.
 
 **Syntax (on a named function, preferred):**
 
-```
+```ry
 @property(count=100)
 @it("should verify property name")
 function test_property(a: int, b: int):
@@ -259,7 +259,7 @@ function test_property(a: int, b: int):
 
 **Syntax (on a legacy `it` lambda):**
 
-```
+```ry
 @property(count=100)
 it("should verify property name", (a: int, b: int):
     # test body with random values
@@ -291,7 +291,7 @@ Declares a test case by decorating a named function. The function body becomes t
 
 **Syntax:**
 
-```
+```ry
 @it("description")
 function test_name():
     # assertions
@@ -332,7 +332,7 @@ Groups a set of related tests by decorating a named function. Inner `@it` functi
 
 **Syntax:**
 
-```
+```ry
 @describe("group name")
 function group_name():
     @it("nested test")

--- a/docs/tutorial/04-control-flow.md
+++ b/docs/tutorial/04-control-flow.md
@@ -293,7 +293,7 @@ print(x)       # 99
 
 ## Pattern Matching
 
-`match value:` safely branches on enums, `Option`, `Result`, and literals.
+`case value:` safely branches on enums, `Option`, `Result`, and literals.
 
 ```python
 enum Color:
@@ -314,7 +314,7 @@ case c:
 
 ### Option Matching
 
-Use `match value:` to safely handle both the `Some` and `None` cases.
+Use `case value:` to safely handle both the `Some` and `None` cases.
 
 ```python
 x: Option<int> = Some(42)
@@ -356,7 +356,7 @@ case n:
         print("zero")
 ```
 
-> **Note**: `match value:` must be exhaustive. For enums, all variants must be covered. For Options, both `Some` and `None` are required. For literals, a `_` wildcard is needed.
+> **Note**: `case value:` must be exhaustive. For enums, all variants must be covered. For Options, both `Some` and `None` are required. For literals, a `_` wildcard is needed.
 
 ---
 

--- a/docs/tutorial/10-concurrency.md
+++ b/docs/tutorial/10-concurrency.md
@@ -178,6 +178,20 @@ See [Thread Reference](../reference/thread.md) for the full API.
 
 Ry provides TCP socket support through the `net` module. Network operations return `Result` types (from [Error Handling](08-error-handling.md)) since connections can fail.
 
+Core TCP primitives:
+
+| Function | Description |
+|----------|-------------|
+| `bind(host, port)` | Allocate a listener. Returns `Result<TcpListener, Error>` |
+| `listen(listener, backlog)` | Start accepting connections. Returns `Result<Unit, Error>` |
+| `accept(listener)` | Wait for the next connection. Returns `Result<TcpStream, Error>` |
+| `connect(host, port)` | Open an outbound stream. Returns `Result<TcpStream, Error>` |
+| `send(stream, bytes)` | Send a `List<u8>`. Returns `Result<int, Error>` |
+| `receive(stream, max)` | Read up to `max` bytes. Returns `Result<List<u8>, Error>` |
+| `close(handle)` | Release a `TcpListener`, `TcpStream`, or `TlsStream` |
+
+An echo exchange between an async server and a synchronous client:
+
 ```python
 from net import bind, listen, accept, connect, listener_port
 from io import to_bytes, bytes_to_str
@@ -199,9 +213,45 @@ async function echo_server(server: TcpListener) -> str:
             ...
     close(server)
     return "done"
+
+function run_client(port: int) -> str:
+    case connect("127.0.0.1", port):
+        Ok(conn):
+            case send(conn, to_bytes("hello")):
+                Ok(_):
+                    ...
+                Err(e):
+                    ...
+            case receive(conn, 4096):
+                Ok(resp):
+                    case bytes_to_str(resp):
+                        Ok(msg):
+                            close(conn)
+                            return msg
+                        Err(e):
+                            ...
+                Err(e):
+                    ...
+            close(conn)
+            return "fail"
+        Err(e):
+            return "fail"
+
+case bind("127.0.0.1", 0):
+    Ok(server):
+        case listen(server, 1):
+            Ok(_):
+                port = listener_port(server)
+                t = echo_server(server)
+                print(run_client(port))   # hello
+                block_on(t)
+            Err(e):
+                print(e.message)
+    Err(e):
+        print(e.message)
 ```
 
-See [Network Reference](../reference/net.md) for the full TCP API.
+See [Network Reference](../reference/net.md) for the full TCP API, including TLS (`tls_connect`) and per-stream timeouts.
 
 ---
 

--- a/docs/tutorial/11-testing.md
+++ b/docs/tutorial/11-testing.md
@@ -96,13 +96,13 @@ function shared_setup_tests():
 `fail()` immediately marks the current test as failed.
 
 ```python
-it("should handle error", ():
+@it("should handle error")
+function test_should_handle_error():
     case result:
         Ok(v):
             fail("expected error")
         Err(e):
             expect(e.message).to_eq("not found")
-)
 ```
 
 - `fail()` — marks the test as failed with a generic message
@@ -125,7 +125,7 @@ Calculator
 
 `+` indicates pass (green), `-` indicates failure (red). Nested `@describe` groups indent their inner tests proportionally to the nesting depth:
 
-```
+```text
 outer group
   inner group
     + should pass deeply nested test

--- a/docs/tutorial/11-testing.md
+++ b/docs/tutorial/11-testing.md
@@ -4,7 +4,7 @@
 
 [<- Prev: Concurrency](10-concurrency.md) | [Next: Building a Project ->](12-building-a-project.md)
 
-Ry has a built-in RSpec-style test syntax using `describe`, `it`, and `expect`. For the full specification, see [Testing Reference](../reference/testing.md).
+Ry has a built-in RSpec-style test syntax using `@describe`, `@it`, and `expect`. For the full specification, see [Testing Reference](../reference/testing.md).
 
 ---
 
@@ -25,26 +25,46 @@ When run without arguments, `ry test` searches for `package.toml` to find the pr
 
 ## Writing Tests
 
-Use `describe` to group related tests and `it` to define individual test cases.
+Attach `@it` to a named function to declare a test case, and wrap a group of related tests in a function annotated with `@describe`.
 
 ```python
-describe("Calculator", ():
-    it("should add integers", ():
-        expect(1 + 2).to_eq(3)
+@it("should add integers")
+function test_add():
+    expect(1 + 2).to_eq(3)
 
-    )
-    it("should subtract integers", ():
+@describe("Calculator")
+function calculator_tests():
+    @it("should subtract integers")
+    function test_sub():
         expect(5 - 3).to_eq(2)
 
-    )
-    it("should check booleans", ():
+    @it("should check booleans")
+    function test_bool():
         expect(3 > 1).to_be_true()
-    )
-)
 ```
 
-- `describe` and `it` take a description string and a **lambda argument** `():` as the second parameter
-- `describe`, `it`, `expect`, `mock`, and `verify` are only available with `ry test` (compile error with normal `ry` execution)
+- `@it` takes a description string. The decorated function becomes the test body
+- `@describe` groups the inner `@it` functions defined in its body. Groups may be nested; output is indented proportionally to nesting depth
+- Variables declared directly in the body of a `@describe` function act as **shared setup** and are captured by every inner `@it` function
+
+```python
+@describe("shared setup")
+function shared_setup_tests():
+    base = 100
+    offset = 5
+
+    @it("should use base value")
+    function test_base():
+        expect(base).to_eq(100)
+
+    @it("should use base and offset")
+    function test_combined():
+        expect(base + offset).to_eq(105)
+```
+
+- `expect`, `mock`, and `verify` are only available with `ry test` (compile error with normal `ry` execution)
+
+> **Legacy lambda form**: `describe("name", (): ...)` and `it("desc", (): ...)` with a lambda argument still parse but are **deprecated**. Prefer the directive form on named functions for new code.
 
 ---
 
@@ -103,7 +123,13 @@ Calculator
 2 passed, 1 failed
 ```
 
-`+` indicates pass (green), `-` indicates failure (red).
+`+` indicates pass (green), `-` indicates failure (red). Nested `@describe` groups indent their inner tests proportionally to the nesting depth:
+
+```
+outer group
+  inner group
+    + should pass deeply nested test
+```
 
 ---
 
@@ -118,16 +144,16 @@ The original function's `require` and `ensure` contracts still run for mocked ca
 function fetch_data() -> str:
     return "real data"
 
-describe("mocking", ():
-    it("should replace function", ():
+@describe("mocking")
+function mocking_tests():
+    @it("should replace function")
+    function test_replace():
         mock(fetch_data, () => "fake")
         expect(fetch_data()).to_eq("fake")
 
-    )
-    it("should auto-restore after it block", ():
+    @it("should auto-restore after it block")
+    function test_restore():
         expect(fetch_data()).to_eq("real data")
-    )
-)
 ```
 
 ### `verify(fn_name)`
@@ -135,45 +161,45 @@ describe("mocking", ():
 Returns the number of times a mocked function was called.
 
 ```python
-describe("verify", ():
-    it("should count calls", ():
+@describe("verify")
+function verify_tests():
+    @it("should count calls")
+    function test_count():
         mock(fetch_data, () => "fake")
         fetch_data()
         fetch_data()
         expect(verify(fetch_data)).to_eq(2)
-    )
-)
 ```
 
 ---
 
 ## Parameterized Tests
 
-Use `@each` to run the same test with multiple inputs:
+Combine `@each` with `@it` on a named function to run the same test with multiple inputs:
 
 ```python
 @each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
-it("should add {0} + {1} = {2}", (a: int, b: int, expected: int):
+@it("should add {0} + {1} = {2}")
+function test_add_each(a: int, b: int, expected: int):
     expect(a + b).to_eq(expected)
-)
 ```
 
-Each tuple becomes a separate test case. `{0}`, `{1}`, etc. in the description are replaced with actual values.
+Each tuple becomes a separate test case. `{0}`, `{1}`, etc. in the description are replaced with actual values. The function's parameter list must match the tuple arity.
 
 ---
 
 ## Property-Based Tests
 
-Use `@property` to test with randomly generated inputs:
+Combine `@property` with `@it` on a named function to test with randomly generated inputs:
 
 ```python
 @property(count=100)
-it("should verify addition is commutative", (a: int, b: int):
+@it("should verify addition is commutative")
+function test_add_commutative(a: int, b: int):
     expect(a + b).to_eq(b + a)
-)
 ```
 
-The test runs `count` times with random values. On failure, the counterexample is printed.
+The test runs `count` times with random values. Ry infers the generator from each parameter's type annotation. On failure, the counterexample is printed.
 
 ---
 
@@ -189,13 +215,13 @@ function deposit(amount: int, balance: int) -> int:
         v > balance
     return balance + amount
 
-describe("deposit", ():
-    it("should enforce contracts even when mocked", ():
+@describe("deposit")
+function deposit_tests():
+    @it("should enforce contracts even when mocked")
+    function test_contract():
         mock(deposit, (amount: int, balance: int) => balance + amount)
         expect(deposit(10, 100)).to_eq(110)
         # deposit(-1, 100) would terminate with "require failed"
-    )
-)
 ```
 
 > **Why this matters**: You can mock implementation details while keeping the contract safety net. If a mock violates a postcondition, the test catches it immediately.
@@ -204,8 +230,8 @@ describe("deposit", ():
 
 ## Limitations
 
-- Nesting of `describe` is not supported
-- `before_each` / `after_each` are not supported
+- Nesting is only supported with `@describe` on named functions. The legacy lambda form `describe("name", (): ...)` cannot be nested
+- `before_each` / `after_each` are not supported — use shared setup variables declared in a `@describe` function body instead
 - Overloaded and `@native` functions cannot be mocked
 
 ---

--- a/share/std/list.ry
+++ b/share/std/list.ry
@@ -9,7 +9,7 @@ function pop(values: List<int>) -> Option<int>
 function insert(values: List<int>, index: int, value: int) -> Unit
 
 @native
-function remove_at(values: List<int>, index: int) -> Unit
+function remove_at(values: List<int>, index: int) -> int
 
 @native
 function slice(values: List<int>, start: int, end: int) -> List<int>


### PR DESCRIPTION
## Summary

Closes #889 (manual close — merging to non-default branch `v0.0.8`).

Fixes the 12 documentation errors and gaps identified in the English README / docs audit, plus one stdlib declaration bug discovered during the investigation.

### Critical fixes

- `docs/tutorial/04-control-flow.md`: the prose used `` `match value:` `` 3 times while the real keyword (and the code examples) is `case`. Replaced all 3.
- `docs/tutorial/10-concurrency.md`: the TCP example was incomplete and used `receive`/`send`/`close` without showing the server-setup side. Rewrote the section with a full async server + sync client based on `tests/spec/net.test.ry`, and added a table of core TCP primitives (`bind`/`listen`/`accept`/`connect`/`send`/`receive`/`close`). Verified end-to-end with `./build/ry -c` — the example prints `hello`.
- `share/std/list.ry:12`: the audit flagged `docs/reference/collections.md` as wrong for saying `remove_at` returns the removed element — but the opposite was true. `CodeGen::emitCollOp_remove_at` (`src/codegen_call_collection.cpp:704`) returns the element, and `tests/spec/collections.test.ry:157-162` has long asserted `v = remove_at(xs, 1); expect(v).to_eq(2)`. The `-> Unit` declaration was the drift. Fixed the declaration to `-> int`.
- `README.md`: `# Structs` comment → `# Records`, `user-defined structs` → `user-defined records`, install one-liner bumped `v0.0.4` → `v0.0.7`.
- `docs/README.md`: reference TOC entry `Structs and Enums` → `Records and Enums` (file path unchanged).

### Content expansions

- `README.md` Features/Directives: added pattern matching, the built-in testing framework, union types, GC (`std.gc`), `?` error propagation, and the full directive list (`@const`, `@native`, `@parallel`, `@inline`, `@each`, `@property`, `@describe`, `@it`).
- `docs/tutorial/11-testing.md`: rewrote the tutorial around the `@describe` / `@it` directive style on named functions (introduced in #634/#635), including shared setup, nested groups with indented output, and `@each`/`@property` composition. The legacy lambda form is kept but marked deprecated.
- `docs/reference/collections.md`: added a new "In-Place Mutating Variants" section covering `append!`, `sort!`, `reverse!`, and the non-mutating `appended`, with guidance on when to pick each.
- `docs/reference/directives.md`: added `@it` and `@describe` sections; updated `@each` and `@property` to show the named-function syntax alongside the legacy lambda one.

### Lessons learned

- `KNOWLEDGE.md`: added "`@native` declarations can silently drift from their dispatcher implementation". The `remove_at` signature mismatch had gone unnoticed for a long time because a hand-written codegen dispatcher can return a different shape than the declaration advertises. When docs disagree with a `@native` signature, diff all three: declaration, dispatcher, and test.

### Out of scope (follow-up)

- Opened #890 to systematically audit `@native` declaration signatures against their codegen dispatchers. The `remove_at` fix in this PR is a one-off; other stdlib entries may have the same kind of drift.

## Test plan

- [x] `cmake --preset default && cmake --build build && ./build/ry_tests` → 1601 tests PASSED
- [x] `./build/ry test -p` → 115 test files, 0 failures (0.98s)
- [x] `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests` → 1600 tests PASSED
- [x] `ASAN_OPTIONS=... ./build-asan/ry test -p` → 115 test files, 0 failures (2.40s)
- [x] `grep -n "match value" docs/tutorial/04-control-flow.md` → 0 hits
- [x] `grep -nE '\bstructs?\b' README.md docs/README.md` → only the `reference/structs.md` link path remains (file name unchanged by design)
- [x] `docs/reference/directives.md` contains both `### \`@it\`` and `### \`@describe\`` sections
- [x] Concurrency tutorial example verified end-to-end via `./build/ry -c` (prints `hello`)
- [x] `remove_at` docs example verified via `./build/ry -c` (prints `2` and `[1, 3, 4]`)
- [x] TSan skipped — no concurrency changes; only docs + one stdlib signature adjustment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive pattern-matching docs (case expressions, destructuring, guards, exhaustiveness).
  * Documented directive-based testing with decorators, parameterized and property tests.
  * Added in-place mutation guidance for list operations (`!` variants).

* **Bug Fixes**
  * Fixed tutorial syntax and runnable networking examples.
  * Updated terminology from "structs" to "records".

* **Documentation**
  * Expanded README with union types, ARC, and `?` error propagation; added docs-audit guidance.

* **API Changes**
  * List removal now returns the removed element (callers can observe the value).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->