### PR TITLE
fix(#890): correct drifted return types on items/enumerate/zip @native declarations

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1270,6 +1270,49 @@ dispatcher and the tests.
   docs or the tests; the dispatcher/test pair is the de-facto contract.
 - Consider this whenever you audit or regenerate stdlib signatures.
 
+**Follow-up audit (#890)**: A systematic sweep of every `@native`
+declaration in `share/std/**/*.ry` against its dispatcher uncovered two
+more drifts of the same shape and fixed all three:
+
+| Declaration | Was | Correct |
+|---|---|---|
+| `share/std/map.ry` `items(Map<str, int>)` | `List<int>` | `List<(str, int)>` |
+| `share/std/builtins.ry` `enumerate(List<int>)` | `List<int>` | `List<(int, int)>` |
+| `share/std/builtins.ry` `zip(List<int>, List<int>)` | `List<int>` | `List<(int, int)>` |
+
+In all three the dispatcher (`src/codegen_call.cpp` `emitBuiltinQuery`
+for `enumerate`/`zip`, `src/codegen_call_collection.cpp:925`
+`emitCollOp_items` for `items`) builds an `llvm::StructType::get(ctx,
+{T1, T2})` tuple and calls
+`setTypeMeta(TypeMeta::ListElem, newHeader, tupleTy)`. Type inference at
+the call site consults the dispatcher's `ListElem` metadata, not the
+declaration's return type — which is exactly why these drifts survived
+so long: the compiler silently ignores `pairs: List<int> = enumerate(xs)`
+and lets you call `pairs[0].0` on it without complaint. The declaration
+is dormant documentation, not a gate. **Watch for this drift class in
+any `emitBuiltin*` helper that calls `setTypeMeta(TypeMeta::ListElem,
+..., tupleTy)` where `tupleTy` is a `StructType`.**
+
+**Audit scope limits**: Pattern C (generic fallback, e.g. `base64`,
+`filesystem`, `gc` — `emitGenericNativeCall` infers wrapping from the
+declaration's return type) cannot drift by construction and was skipped.
+Pattern A1 entries (table-driven with `ReturnWrapping` enum but no
+`customEmitter`, e.g. `io`) are validated against the sig's return type
+and got only a spot check. The audit focused on Pattern A2 (table
+entries with `customEmitter`, which bypass type checking per
+`codegen_call_native.cpp:135-149`) and Pattern B (hand-written
+`emitBuiltin*` helpers that never consult the sig). Those are the two
+places where drift is actually possible.
+
+**Polymorphism constraint**: Ry declaration syntax has no generics /
+`List<T>` / `Any`, so polymorphic collection ops (`list::filter`,
+`list::map`, `map::keys`, etc.) will keep using monomorphic placeholder
+element types like `List<int>` even when the dispatcher is
+element-type-agnostic. Only drifts where the **structural shape** is
+wrong (`List<int>` vs `List<tuple>`, `Unit` vs `int`) are actionable
+until generics land. Don't re-chase placeholder-only inaccuracies as
+drift.
+
 ---
 
 ## Commands / Environment gotchas

--- a/changelog.d/890-native-decl-audit.md
+++ b/changelog.d/890-native-decl-audit.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Corrected stdlib `@native` declaration return types that had silently drifted from their codegen dispatcher implementations (#890):
+  - `items(map: Map<str, int>)` now declared as `-> List<(str, int)>` (was `-> List<int>`)
+  - `enumerate(values: List<int>)` now declared as `-> List<(int, int)>` (was `-> List<int>`)
+  - `zip(values: List<int>, other_values: List<int>)` now declared as `-> List<(int, int)>` (was `-> List<int>`)
+
+  The dispatchers (`emitCollOp_items`, `emitBuiltinQuery` for `enumerate`/`zip`) always returned lists of tuples; only the declarations were wrong. No behavior change — this corrects the stdlib documentation to match reality.

--- a/share/std/builtins.ry
+++ b/share/std/builtins.ry
@@ -24,10 +24,10 @@ function range(start: int, end: int) -> List<int>
 function range(start: int, end: int, step: int) -> List<int>
 
 @native
-function enumerate(values: List<int>) -> List<int>
+function enumerate(values: List<int>) -> List<(int, int)>
 
 @native
-function zip(values: List<int>, other_values: List<int>) -> List<int>
+function zip(values: List<int>, other_values: List<int>) -> List<(int, int)>
 
 @native
 function exit(code: int) -> Unit

--- a/share/std/map.ry
+++ b/share/std/map.ry
@@ -6,7 +6,7 @@ function keys(map: Map<str, int>) -> List<str>
 function values(map: Map<str, int>) -> List<int>
 
 @native
-function items(map: Map<str, int>) -> List<int>
+function items(map: Map<str, int>) -> List<(str, int)>
 
 @native
 function has_key(map: Map<str, int>, key: str) -> bool

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -473,6 +473,13 @@ describe("Map", ():
     pairs = items(m)
     expect(pairs).to_have_length(1)
   )
+  it("should return items as (key, value) tuples", ():
+    # Pins #890: items(Map<K, V>) returns List<(K, V)>, not List<V>.
+    m = {"a": 1}
+    pairs = items(m)
+    expect(pairs[0].0).to_eq("a")
+    expect(pairs[0].1).to_eq(1)
+  )
   it("should remove", ():
     m = {"a": 1, "b": 2}
     remove(m, "a")


### PR DESCRIPTION
## Summary

Closes #890.

A systematic audit of every `@native` declaration in `share/std/**/*.ry` against its Pattern A2 (custom emitter) / Pattern B (hand-written `emitBuiltin*`) dispatcher surfaced three return-type drifts of the exact shape that #889 originally caught. All three are declaration-only fixes — the dispatchers have always returned tuples, only the `.ry` declarations lied.

| Declaration | Was | Now |
|---|---|---|
| `share/std/map.ry` `items(Map<str, int>)` | `-> List<int>` | `-> List<(str, int)>` |
| `share/std/builtins.ry` `enumerate(List<int>)` | `-> List<int>` | `-> List<(int, int)>` |
| `share/std/builtins.ry` `zip(List<int>, List<int>)` | `-> List<int>` | `-> List<(int, int)>` |

### Why the drift survived so long

In all three cases the dispatcher already builds a `llvm::StructType::get(ctx, {T1, T2})` tuple (e.g. `emitCollOp_items` at `src/codegen_call_collection.cpp:934`, `emitBuiltinQuery` for `enumerate` at `src/codegen_call.cpp:335` and for `zip` at `:406`) and publishes it through `setTypeMeta(TypeMeta::ListElem, newHeader, tupleTy)`. Type inference at the call site consults that metadata and **never looks at the declared return type** — you can even write `pairs: List<int> = enumerate(xs)` today and call `pairs[0].0` on it without the compiler complaining. The declaration is dormant documentation, not a gate. That's exactly why nobody noticed.

### Audit scope (out-of-scope parts documented in KNOWLEDGE.md)

- **Pattern C** (`base64`, `filesystem`, `gc` — generic fallback via `emitGenericNativeCall`) infers wrapping from the declaration's return type, so drift is impossible by construction. Skipped.
- **Pattern A1** (table-driven `ReturnWrapping` entries with no `customEmitter`, e.g. `io`) is validated against the sig's return type — got a spot check, no drift found.
- **Pattern A2** (`thread`, `net`, `json`, parts of `http` / `path` / `math`) and **Pattern B** (`list`, `map`, `set`, `str`, `higher_order`, `regex`, `convert`, `builtins`) were fully audited — the only drifts are the three above.
- **Polymorphism constraint**: Ry declaration syntax has no generics / `List<T>` / `Any`, so polymorphic collection ops (`list::filter`, `map::keys`, etc.) keep their monomorphic placeholder `List<int>`. Only drifts where the *structural shape* is wrong (`List<int>` vs `List<tuple>`, `Unit` vs `int`) are actionable until generics land. This is now documented so the next auditor doesn't re-chase it.

### Regression test

`tests/spec/collections.test.ry` already pinned the tuple shape for `enumerate` and `zip` (`pairs[0].0` / `pairs[0].1`). The `items` test only asserted length, so this PR adds a tuple-field assertion to close that gap and pin #890.

### KNOWLEDGE.md

The existing `@native declarations can silently drift from their dispatcher implementation` entry (from #889) has been extended with the #890 findings, a warning to watch for `setTypeMeta(TypeMeta::ListElem, ..., StructType)` as the canonical drift-signature, and the polymorphism constraint.

## Test plan

- [x] `cmake --build build && ./build/ry_tests` — 1601 tests passed
- [x] `./build/ry test -p` — 115 test files, 0 failures
- [x] `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests` — 1600 tests passed
- [x] `ASAN_OPTIONS=... UBSAN_OPTIONS=... ./build-asan/ry test -p` — 115 files, 0 failures
- [x] TSan skipped — no concurrency code touched
- [x] English docs (`docs/reference/collections.md`, `docs/reference/builtins.md`) already describe the tuple returns correctly; no docs update needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed return types for standard library collection functions.
  * `items()` now returns key-value pairs instead of single values, providing access to both keys and values from maps.
  * `enumerate()` now returns tuples pairing indices with values.
  * `zip()` now returns element tuples for paired sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->