### PR TITLE
fix: install.sh stdlib guard and arc_alloc overflow (PR #901 release blockers)

### DIFF
--- a/changelog.d/901-install-arc-release-blockers.md
+++ b/changelog.d/901-install-arc-release-blockers.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `install.sh` now fails with a clear error when the release archive does not contain a standard library at `share/std` or `lib/std`, instead of silently installing a broken `ry` that crashes at runtime (PR #901 review)
+- `arc_alloc` now guards `ARC_HEADER_SIZE + data_size` against integer overflow via `__builtin_add_overflow`, preventing an undersized heap allocation followed by out-of-bounds writes if `data_size` is near `SIZE_MAX` (PR #901 review)

--- a/include/ry/runtime_alloc.hpp
+++ b/include/ry/runtime_alloc.hpp
@@ -17,6 +17,11 @@ namespace ry {
     abort();
 }
 
+[[noreturn]] inline void add_overflow_abort(size_t a, size_t b) {
+    fprintf(stderr, "ry: allocation size overflow (%zu + %zu)\n", a, b);
+    abort();
+}
+
 [[noreturn]] inline void depth_limit_abort(const char *what, size_t limit) {
     fprintf(stderr, "ry: %s nesting depth exceeded (max %zu)\n", what, limit);
     abort();

--- a/include/ry/runtime_arc.hpp
+++ b/include/ry/runtime_arc.hpp
@@ -10,7 +10,11 @@ namespace ry {
 // Returns a pointer to the data area (past ARC_HEADER_SIZE bytes).
 // Caller must placement-new or initialize the data area.
 inline void *arc_alloc(size_t data_size) {
-    void *block = checked_malloc(ARC_HEADER_SIZE + data_size);
+    size_t total;
+    if (__builtin_add_overflow(ARC_HEADER_SIZE, data_size, &total)) {
+        add_overflow_abort(ARC_HEADER_SIZE, data_size);
+    }
+    void *block = checked_malloc(total);
     auto *header = static_cast<int64_t *>(block);
     header[0] = 1; // strong_count
     header[1] = 0; // weak_count

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,28 @@ trap 'rm -rf "$TMPDIR" ${STD_STAGING:+"$STD_STAGING"}' EXIT
 echo "Downloading ry..."
 curl -fsSL "$DOWNLOAD_URL" -o "$TMPDIR/ry.tar.gz"
 tar xzf "$TMPDIR/ry.tar.gz" -C "$TMPDIR"
+
+# Validate archive layout BEFORE mutating any installed artifacts.
+# Detect stdlib layout in the extracted archive and bail out early if it's
+# missing — otherwise a partial install (new ry binary, stale/missing stdlib)
+# would leave the user with a broken runtime.
+STD_DIR=""
+SRC_STD=""
+NEW_LAYOUT=0
+if [ -d "$TMPDIR/share/std" ]; then
+    STD_DIR="$RY_HOME/share/std"
+    SRC_STD="$TMPDIR/share/std"
+    NEW_LAYOUT=1
+elif [ -d "$TMPDIR/lib/std" ]; then
+    STD_DIR="$RY_HOME/lib/std"
+    SRC_STD="$TMPDIR/lib/std"
+fi
+if [ -z "$SRC_STD" ] || [ ! -d "$SRC_STD" ]; then
+    echo "ERROR: release archive does not contain a standard library (expected share/std or lib/std)" >&2
+    exit 1
+fi
+
+# Archive validated — safe to mutate installed artifacts.
 install -m 755 "$TMPDIR/ry" "$INSTALL_DIR/ry"
 
 # Install native shared libraries
@@ -43,27 +65,8 @@ if [ -d "$TMPDIR/lib" ]; then
     fi
 fi
 
-# Install standard library (clean replace)
-# Detect archive layout and install to the matching destination so the
-# corresponding binary can find stdlib at the path it expects.
-STD_DIR=""
-SRC_STD=""
-NEW_LAYOUT=0
-if [ -d "$TMPDIR/share/std" ]; then
-    STD_DIR="$RY_HOME/share/std"
-    SRC_STD="$TMPDIR/share/std"
-    NEW_LAYOUT=1
-elif [ -d "$TMPDIR/lib/std" ]; then
-    STD_DIR="$RY_HOME/lib/std"
-    SRC_STD="$TMPDIR/lib/std"
-fi
-if [ -z "$SRC_STD" ] || [ ! -d "$SRC_STD" ]; then
-    echo "ERROR: release archive does not contain a standard library (expected share/std or lib/std)" >&2
-    exit 1
-fi
-
+# Install standard library (clean replace).
 # Copy to a staging directory first, then atomically swap into place.
-# On copy failure the previous stdlib remains intact.
 mkdir -p "$(dirname "$STD_DIR")"
 STD_STAGING="$(mktemp -d "${STD_DIR}.XXXXXX")"
 cp -r "$SRC_STD/." "$STD_STAGING/"

--- a/install.sh
+++ b/install.sh
@@ -57,22 +57,25 @@ elif [ -d "$TMPDIR/lib/std" ]; then
     STD_DIR="$RY_HOME/lib/std"
     SRC_STD="$TMPDIR/lib/std"
 fi
-if [ -n "$SRC_STD" ] && [ -d "$SRC_STD" ]; then
-    # Copy to a staging directory first, then atomically swap into place.
-    # On copy failure the previous stdlib remains intact.
-    mkdir -p "$(dirname "$STD_DIR")"
-    STD_STAGING="$(mktemp -d "${STD_DIR}.XXXXXX")"
-    cp -r "$SRC_STD/." "$STD_STAGING/"
-    rm -rf "$STD_DIR"
-    mv "$STD_STAGING" "$STD_DIR"
-    echo "Standard library installed to $STD_DIR"
-    # Clean up old lib/std layout only after successful install (migration)
-    if [ "$NEW_LAYOUT" = 1 ]; then
-        rm -rf "$RY_HOME/lib/std"
-        # rmdir only removes empty directories — safe when native libs
-        # (libry_*) are installed in $RY_HOME/lib (no-op in that case).
-        rmdir "$RY_HOME/lib" 2>/dev/null || true
-    fi
+if [ -z "$SRC_STD" ] || [ ! -d "$SRC_STD" ]; then
+    echo "ERROR: release archive does not contain a standard library (expected share/std or lib/std)" >&2
+    exit 1
+fi
+
+# Copy to a staging directory first, then atomically swap into place.
+# On copy failure the previous stdlib remains intact.
+mkdir -p "$(dirname "$STD_DIR")"
+STD_STAGING="$(mktemp -d "${STD_DIR}.XXXXXX")"
+cp -r "$SRC_STD/." "$STD_STAGING/"
+rm -rf "$STD_DIR"
+mv "$STD_STAGING" "$STD_DIR"
+echo "Standard library installed to $STD_DIR"
+# Clean up old lib/std layout only after successful install (migration)
+if [ "$NEW_LAYOUT" = 1 ]; then
+    rm -rf "$RY_HOME/lib/std"
+    # rmdir only removes empty directories — safe when native libs
+    # (libry_*) are installed in $RY_HOME/lib (no-op in that case).
+    rmdir "$RY_HOME/lib" 2>/dev/null || true
 fi
 
 echo "ry installed to ${INSTALL_DIR}/ry"


### PR DESCRIPTION
## Summary

Addresses two release-blocker findings from the CodeRabbit review of PR #901 (v0.0.8 → main).

- **`install.sh`**: fail with a clear error when the release archive is missing both `share/std` and `lib/std`, instead of silently installing a broken `ry` that crashes at runtime. Removes the redundant inner `if [ -d \"\$SRC_STD\" ]` wrapper since the new guard is authoritative.
- **`include/ry/runtime_arc.hpp`**: guard `ARC_HEADER_SIZE + data_size` against integer overflow via `__builtin_add_overflow`. Previously the addition could wrap silently when `data_size > SIZE_MAX - ARC_HEADER_SIZE`, passing an undersized allocation to `checked_malloc()` and triggering heap overflow on subsequent header writes.
- **`include/ry/runtime_alloc.hpp`**: add `add_overflow_abort(a, b)` helper so the abort message reads `allocation size overflow (a + b)` instead of the misleading multiplicative form (`a * b`).

## Rationale

### `install.sh`
The installer ships via the public one-liner (`curl … | sh`). A silent failure to install stdlib leaves users with a broken `ry` binary whose first invocation dies at runtime trying to resolve stdlib modules. Failing loud and early is the correct behaviour.

### `arc_alloc`
AGENTS.md §メモリ安全ルール requires OOM-safe wrappers and overflow-safe array allocation via `__builtin_mul_overflow` (see `checked_array_malloc`). `arc_alloc` was the only remaining allocator performing an unchecked size computation. All current callers pass compile-time `sizeof(Handle)` values (bounded), so this is a defensive fix — not a live vulnerability — but it closes the gap and keeps allocator hardening uniform across the codebase.

## Self-verification

All run from scratch on this branch:

| Suite | Result |
|---|---|
| `cmake --preset default` + `./build/ry_tests` | 1601/1601 passed |
| `./build/ry test -p` | 115 test files, 0 failures |
| `cmake --preset asan` + `./build-asan/ry_tests` | 1600/1600 passed, ASan/UBSan clean |
| `./build-asan/ry test -p` (ASan/UBSan env) | 115 test files, 0 failures |
| `cmake --preset tsan` + `./build-tsan/ry_tests` | 1601/1601 passed (required) |

### `install.sh` manual verification

- Empty `TMPDIR` (no `share/std`, no `lib/std`) → exits with `1` and prints `ERROR: release archive does not contain a standard library (expected share/std or lib/std)` ✓
- `TMPDIR/share/std/core/core.ry` present → proceeds through staging + atomic swap as before, installs to `\$RY_HOME/share/std` ✓

## CHANGELOG

Added `changelog.d/901-install-arc-release-blockers.md` with Fixed entries for both issues. Will flow into the next release's CHANGELOG via `scripts/assemble-changelog.sh`.

## Test plan

- [ ] Merge into `v0.0.8`
- [ ] CI re-runs on PR #901 with these fixes applied
- [ ] Release workflow publishes a tarball that passes the stdlib guard
- [ ] Spot check installed `ry` binary works after running the updated `install.sh`

## Tracking

The remaining 33 non-blocking items from the PR #901 review are consolidated in #907 with the `v0.0.9` milestone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now verifies the extracted release contains the required standard library and aborts with a clear error if missing, preventing incomplete installs.
  * Memory allocation now detects integer overflow when computing allocation size and aborts safely, avoiding undersized allocations that could lead to crashes or memory corruption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->