### PR TITLE
feat: add release-prep and release skills (#912)

### DIFF
--- a/.claude/skills/release-prep/SKILL.md
+++ b/.claude/skills/release-prep/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: release-prep
+description: Prepare a release by assembling changelog, translating docs, generating PDFs, and merging to the release branch.
+allowed-tools: Bash(git checkout -b:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(git fetch:*), Bash(git merge:*), Bash(git branch:*), Bash(git diff:*), Bash(git log:*), Bash(gh pr:*), Bash(cat:*), Bash(bash:*), Bash(ls:*), Bash(date:*), Read, Edit
+metadata:
+  short-description: Run release preparation (changelog, translation, PDF, merge)
+---
+
+# Release Prep
+
+Prepare a release from a `vx.x.x` branch through changelog assembly, translation, PDF generation, and pre-release merge.
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- VERSION file: !`cat VERSION`
+- Pending changelog fragments: !`ls changelog.d/ 2>/dev/null || echo "(none)"`
+- Release branches: !`git branch --list 'v*.*.*' | head -5`
+
+## Inputs
+
+User input: $ARGUMENTS
+
+Expected: version number like `0.0.9`, or nothing to read from VERSION file.
+
+## Steps
+
+### Step 1: Determine version
+
+- If user provided a version in $ARGUMENTS, use it
+- Otherwise read from `VERSION` file
+- Validate it matches semver pattern `x.x.x`
+- Set RELEASE_VERSION to this value
+- Confirm we are on the `v<RELEASE_VERSION>` branch (if not, inform user and stop)
+
+### Step 2: Create pre-release branch
+
+- Create `chore/pre-release-v<RELEASE_VERSION>` from the current `v<RELEASE_VERSION>` branch
+
+### Step 3: Update VERSION file
+
+- Write RELEASE_VERSION into the `VERSION` file (if not already correct)
+- Stage and commit: `chore: bump VERSION to <RELEASE_VERSION>`
+
+### Step 4: Assemble changelog
+
+1. Run `bash scripts/assemble-changelog.sh`
+2. Edit `CHANGELOG.md`:
+   - Replace the `[Unreleased]` header with `[<RELEASE_VERSION>] - <YYYY-MM-DD>` (use today's date)
+   - Add a new empty `[Unreleased]` section above it with standard subsection headers
+   - Update the comparison links at the bottom of the file
+3. Stage and commit: `chore: assemble changelog for v<RELEASE_VERSION>`
+
+### Step 5: Translation (English → ja/zh)
+
+**IMPORTANT: Ask the user for confirmation before proceeding.** Translation is a heavy operation.
+
+Translate updated English docs to Japanese and Chinese:
+
+| Source | Targets |
+|--------|---------|
+| `docs/reference/` | `docs/ja/reference/`, `docs/zh/reference/` |
+| `docs/tutorial/` | `docs/ja/tutorial/`, `docs/zh/tutorial/` |
+| `docs/README.md` | `docs/ja/README.md`, `docs/zh/README.md` |
+| `README.md` | `README.ja.md`, `README.zh.md` |
+
+Approach:
+1. Diff the English sources against the base branch to identify what changed: `git diff v<RELEASE_VERSION>...HEAD -- <source_path>`
+2. Apply equivalent changes to each target locale
+3. Stage and commit per locale: `docs: translate to ja for v<RELEASE_VERSION>`, `docs: translate to zh for v<RELEASE_VERSION>`
+
+### Step 6: PDF generation
+
+Run:
+```bash
+cd docs && bash generate-pdf.sh
+```
+
+Verify that 6 PDFs are produced: `tutorial-{en,ja,zh}.pdf`, `reference-{en,ja,zh}.pdf`
+
+Stage and commit: `docs: regenerate PDFs for v<RELEASE_VERSION>`
+
+### Step 7: Push and merge to release branch
+
+1. Push `chore/pre-release-v<RELEASE_VERSION>` to origin
+2. Create PR targeting `v<RELEASE_VERSION>` branch
+3. **Ask user for confirmation before merging**
+4. Merge the PR using `gh pr merge --merge --delete-branch`
+
+### Completion
+
+Report summary to the user:
+- Version prepared
+- Number of changelog fragments assembled
+- Translation status (files updated)
+- PDF generation status
+- PR URL and merge status

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: release
+description: Create and merge the release PR from vx.x.x to main, then verify release notes.
+allowed-tools: Bash(gh pr:*), Bash(gh release:*), Bash(gh repo:*), Bash(gh issue:*), Bash(git branch:*), Bash(git fetch:*), Bash(git log:*), Bash(git diff:*), Bash(cat:*), Read
+metadata:
+  short-description: Merge release branch to main and verify release
+---
+
+# Release
+
+Create the release PR from `vx.x.x` to `main`, merge it, and verify that the GitHub Release is generated correctly.
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- VERSION file: !`cat VERSION`
+- Release branches: !`git branch --list 'v*.*.*' | head -5`
+- Recent releases: !`gh release list --limit 3 2>/dev/null || echo "(none)"`
+
+## Inputs
+
+User input: $ARGUMENTS
+
+Expected: version number like `0.0.9`, or nothing to auto-detect from VERSION file.
+
+## Steps
+
+### Step 1: Determine version
+
+- If user provided a version in $ARGUMENTS, use it
+- Otherwise read from `VERSION` file
+- Validate the branch `v<RELEASE_VERSION>` exists on remote (`git fetch origin v<RELEASE_VERSION>`)
+
+### Step 2: Verify release readiness
+
+- Confirm that the CHANGELOG.md contains a `[<RELEASE_VERSION>]` section (i.e., `/release-prep` has been run)
+- If not found, inform the user that `/release-prep` should be run first and stop
+
+### Step 3: Create release PR
+
+Create a PR from `v<RELEASE_VERSION>` to `main`:
+
+```bash
+gh pr create --base main --head "v<RELEASE_VERSION>" --title "Release v<RELEASE_VERSION>" --body "<body>"
+```
+
+The body should include the CHANGELOG.md section for this version (extracted between the version header and the next version header or end of relevant content).
+
+### Step 4: Merge release PR
+
+- **Ask user for confirmation before merging**
+- Merge with: `gh pr merge <PR_NUMBER> --merge`
+- Do NOT delete the branch (release branches are kept for history)
+
+### Step 5: Verify release
+
+After merging, check if the GitHub Release was auto-created:
+
+```bash
+gh release view "v<RELEASE_VERSION>" 2>/dev/null
+```
+
+- If the release exists, verify the release notes content matches CHANGELOG.md
+- If not yet created, inform the user that the release workflow may still be running (check `.github/workflows/release.yml`)
+
+### Step 6: Report
+
+Report to the user:
+- PR URL and merge status
+- Release URL (if available)
+- Any discrepancies in release notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -373,35 +373,4 @@ C++ TSan テスト (`ry_tests`) は required で、`ConcurrencySpecSuite` (= `te
 
 ## リリース準備ワークフロー
 
-`vx.x.x` ブランチを `main` にマージしてリリースする前に、以下の準備を行う。
-
-### フロー
-
-1. `vx.x.x` から `chore/pre-release-vx.x.x` ブランチを作成
-2. `VERSION` ファイルをリリースバージョンに更新（例: `0.0.5`）
-3. `scripts/assemble-changelog.sh` を実行してフラグメントファイルを `CHANGELOG.md` に集約する。その後 `[Unreleased]` を `[x.x.x] - YYYY-MM-DD` に変更し、新しい空の `[Unreleased]` セクションを追加。末尾の比較リンクも更新する
-4. 翻訳と PDF 生成を実施（下記参照）
-5. `chore/pre-release-vx.x.x` を `vx.x.x` にマージ
-6. `vx.x.x` を `main` にマージする PR を作成・マージ
-
-### 翻訳（英語 → ja/zh）
-
-通常開発で更新された英語ドキュメントの差分を他言語に反映する。
-
-対象:
-- `docs/reference/` → `docs/ja/reference/`, `docs/zh/reference/`
-- `docs/tutorial/` → `docs/ja/tutorial/`, `docs/zh/tutorial/`
-- `docs/README.md` → `docs/ja/README.md`, `docs/zh/README.md`
-- `README.md` → `README.ja.md`, `README.zh.md`
-
-### PDF 生成
-
-```bash
-cd docs && bash generate-pdf.sh
-```
-
-6 つの PDF（`tutorial-{en,ja,zh}.pdf`, `reference-{en,ja,zh}.pdf`）が更新される。
-
-### リリースノート
-
-GitHub Release のリリースノートは `CHANGELOG.md` の該当バージョンセクションから自動抽出される（`.github/workflows/release.yml`）。リリース準備時に `CHANGELOG.md` の内容が正確であることを確認すること。
+リリース準備は `/release-prep` スキルを使用する。リリース（`vx.x.x` → `main` マージ）は `/release` スキルを使用する。


### PR DESCRIPTION
## Summary

- Add `/release-prep` skill for release preparation (VERSION update, changelog assembly, translation, PDF generation, pre-release branch merge)
- Add `/release` skill for the actual release (vx.x.x → main PR creation, merge, release verification)
- Replace the verbose "リリース準備ワークフロー" section in AGENTS.md with a brief pointer to the two skills

Closes #912

## Test plan

- [ ] Verify `/release-prep` and `/release` appear in the skill list
- [ ] Verify AGENTS.md still has the section heading with skill references
- [ ] Verify `changelog.d/` fragment creation rules remain in AGENTS.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated release preparation workflow including version validation, changelog assembly with dated release sections, multi-language documentation translation, and PDF generation.
  * Added automated release workflow for promoting prepared branches to main with changelog-populated PR creation and release verification.

* **Documentation**
  * Updated release procedures to streamline via automated workflows, removing detailed manual steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->