### PR TITLE
feat: add mirror-llvm-toolchain workflow

### DIFF
--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -63,13 +63,13 @@ jobs:
           cd /tmp
           tar -xJf "${UPSTREAM_FILE}"
           # Rename extracted directory to 'llvm'
-          EXTRACTED=$(ls -d clang+llvm-* | head -1)
+          EXTRACTED=$(tar -tf "${UPSTREAM_FILE}" | head -1 | cut -d/ -f1)
           mv "${EXTRACTED}" llvm
 
-          # Strip unused tools if requested or if size > 1.9 GB
-          SIZE=$(du -sb llvm | cut -f1)
-          if [ "${{ inputs.strip_unused }}" = "true" ] || [ "$SIZE" -gt 1932735283 ]; then
-            echo "Stripping unused tools (size: ${SIZE} bytes)"
+          # Strip unused tools if requested or if upstream tarball > 1.9 GB
+          UPSTREAM_SIZE=$(stat -c%s "${UPSTREAM_FILE}")
+          if [ "${{ inputs.strip_unused }}" = "true" ] || [ "$UPSTREAM_SIZE" -gt 1932735283 ]; then
+            echo "Stripping unused tools (upstream tarball size: ${UPSTREAM_SIZE} bytes)"
             cd llvm
             rm -f bin/clang-format bin/clang-tidy bin/clang-scan-deps \
                   bin/clang-query bin/clangd bin/clang-doc bin/clang-refactor
@@ -99,5 +99,10 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         run: |
           V="${{ inputs.llvm_version }}"
-          gh release view "llvm-toolchain-${V}" --json assets \
-            --jq '.assets[].name'
+          gh release view "llvm-toolchain-${V}" --json assets --jq '.assets[].name'
+          mkdir -p /tmp/verify
+          gh release download "llvm-toolchain-${V}" \
+            -p "llvm-${V}-linux-x86_64.tar.xz" \
+            -p "llvm-${V}-linux-x86_64.tar.xz.sha256" \
+            -D /tmp/verify
+          (cd /tmp/verify && sha256sum -c "llvm-${V}-linux-x86_64.tar.xz.sha256")

--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -1,0 +1,103 @@
+name: Mirror LLVM Toolchain
+
+on:
+  workflow_dispatch:
+    inputs:
+      llvm_version:
+        description: 'LLVM version to mirror'
+        required: true
+        default: '21.1.8'
+      strip_unused:
+        description: 'Strip unused tools to reduce size'
+        required: false
+        type: boolean
+        default: false
+      force:
+        description: 'Force re-upload even if release exists'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  mirror:
+    runs-on: ubuntu-24.04
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check existing release
+        id: check
+        run: |
+          V="${{ inputs.llvm_version }}"
+          if gh release view "llvm-toolchain-${V}" >/dev/null 2>&1; then
+            if [ "${{ inputs.force }}" != "true" ]; then
+              echo "Release llvm-toolchain-${V} already exists. Use force=true to re-upload."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "Force mode: deleting existing release"
+              gh release delete "llvm-toolchain-${V}" --yes --cleanup-tag
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download upstream tarball
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          V="${{ inputs.llvm_version }}"
+          UPSTREAM="clang+llvm-${V}-x86_64-linux-gnu-ubuntu-24.04.tar.xz"
+          URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-${V}/${UPSTREAM}"
+          echo "Downloading ${URL}"
+          curl -fL --retry 5 -o "/tmp/${UPSTREAM}" "${URL}"
+          echo "UPSTREAM_FILE=/tmp/${UPSTREAM}" >> "$GITHUB_ENV"
+
+      - name: Extract and repack
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          V="${{ inputs.llvm_version }}"
+          cd /tmp
+          tar -xJf "${UPSTREAM_FILE}"
+          # Rename extracted directory to 'llvm'
+          EXTRACTED=$(ls -d clang+llvm-* | head -1)
+          mv "${EXTRACTED}" llvm
+
+          # Strip unused tools if requested or if size > 1.9 GB
+          SIZE=$(du -sb llvm | cut -f1)
+          if [ "${{ inputs.strip_unused }}" = "true" ] || [ "$SIZE" -gt 1932735283 ]; then
+            echo "Stripping unused tools (size: ${SIZE} bytes)"
+            cd llvm
+            rm -f bin/clang-format bin/clang-tidy bin/clang-scan-deps \
+                  bin/clang-query bin/clangd bin/clang-doc bin/clang-refactor
+            rm -f bin/lldb* bin/flang* bin/mlir-*
+            rm -rf lib/libclc* share/clang share/clang-doc \
+                   share/scan-view share/scan-build
+            cd /tmp
+          fi
+
+          # Repack
+          ASSET="llvm-${V}-linux-x86_64.tar.xz"
+          tar -cJf "${ASSET}" llvm/
+          sha256sum "${ASSET}" > "${ASSET}.sha256"
+          echo "ASSET=/tmp/${ASSET}" >> "$GITHUB_ENV"
+          echo "ASSET_SHA=/tmp/${ASSET}.sha256" >> "$GITHUB_ENV"
+
+      - name: Create release and upload
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          V="${{ inputs.llvm_version }}"
+          gh release create "llvm-toolchain-${V}" \
+            --title "LLVM Toolchain ${V}" \
+            --notes "Mirrored LLVM ${V} Linux x86_64 toolchain for CI use. Source: github.com/llvm/llvm-project/releases/tag/llvmorg-${V}" \
+            "${ASSET}" "${ASSET_SHA}"
+
+      - name: Verify upload
+        if: steps.check.outputs.skip != 'true'
+        run: |
+          V="${{ inputs.llvm_version }}"
+          gh release view "llvm-toolchain-${V}" --json assets \
+            --jq '.assets[].name'


### PR DESCRIPTION
## Summary

- Add `.github/workflows/mirror-llvm-toolchain.yml` — a `workflow_dispatch` workflow that mirrors official LLVM binary tarballs to a GitHub Release on this repo
- Supports idempotency (skips if release exists), force re-upload, and optional stripping of unused tools
- Extraction target is `llvm/` directory matching `CMakePresets.json`'s `/usr/local/llvm` path

Closes #916

## Test plan

- [ ] Run workflow manually: `gh workflow run mirror-llvm-toolchain.yml -f llvm_version=21.1.8`
- [ ] Verify release created: `gh release view llvm-toolchain-21.1.8`
- [ ] Verify two assets: `llvm-21.1.8-linux-x86_64.tar.xz` + `.sha256`
- [ ] Re-run without force → exits cleanly with skip

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual workflow to mirror and publish LLVM/Clang toolchain releases with configurable version input.
  * Supports options to force overwrite existing releases and to strip unused artifacts for smaller uploads.
  * Produces a repackaged archive plus SHA256 checksum and verifies uploaded assets after release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->