### PR TITLE
ci: only save ccache on main and release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
           key: ci-ubuntu-${{ github.ref }}
           restore-keys: |
             ci-ubuntu-
+          save: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}
       - name: Build
         env:
           CC: /usr/local/llvm/bin/clang
@@ -79,6 +80,7 @@ jobs:
           key: ci-asan-${{ github.ref }}
           restore-keys: |
             ci-asan-
+          save: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}
       - name: Build (ASan + UBSan)
         env:
           CC: /usr/local/llvm/bin/clang
@@ -143,6 +145,7 @@ jobs:
           key: ci-tsan-${{ github.ref }}
           restore-keys: |
             ci-tsan-
+          save: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}
       - name: Build (TSan)
         env:
           CC: /usr/local/llvm/bin/clang


### PR DESCRIPTION
## Summary

- Add `save` condition to `hendrikmuhs/ccache-action` in all three CI jobs (`test`, `asan`, `tsan`)
- Caches are only saved on `main` and `v*` branch pushes; PR runs restore via `restore-keys` fallback but skip saving
- Prevents accumulation of redundant immutable cache entries on every PR push

Closes #926

## Test plan

- [ ] Verify CI passes on this PR (ccache restores from fallback but does not save)
- [ ] Verify next push to `main` or `v*` still saves ccache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline build caching to conditionally persist cache artifacts for main branch and tagged releases, improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->