### PR TITLE
docs: document LLVM mirror workflow and cache-key rationale

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,25 @@ cmake --build build                                     # Ninja が自動並列�
 
 > repo 内でビルドした `./build/ry` は `package.toml` の hidden 設定 `[paths]._dev_stdlib` に従ってプロジェクトローカルの `share/std/` を優先する。`RY_ENV=internal` は追加の isolation が必要な場合だけ使う。
 
+## CI: LLVM ツールチェーン (ミラー)
+
+CI は `.github/actions/setup-llvm/` composite action 経由で LLVM を取得する。優先順に:
+
+1. **`actions/cache`** — キャッシュヒット時は即復元（< 5s）
+2. **GitHub Releases ミラー** — `llvm-toolchain-${VERSION}` タグからダウンロード + SHA256 検証
+3. **apt.llvm.org フォールバック** — ミラーが存在しない場合のみ
+
+ミラー tarball は `.github/workflows/mirror-llvm-toolchain.yml`（手動 `workflow_dispatch`）で構築・アップロードする。
+
+**キャッシュキー**: `llvm-${VERSION}-linux-x86_64-v1-${SHA256_SHORT}`。`restore-keys` は意図的に設定しない — 部分一致ヒットは異なるバージョンの LLVM を復元し、ビルド失敗や ABI 不整合を引き起こす。
+
+**バージョンバンプ手順**:
+
+1. `mirror-llvm-toolchain.yml` を `workflow_dispatch` で実行し、新バージョンの tarball をアップロード
+2. 以下のワークフローの `env.LLVM_VERSION`（および `env.LLVM_SHA256_SHORT`）を更新:
+   - `.github/workflows/ci.yml`
+   - `.github/workflows/codeql.yml`
+
 ## ナレッジベース (KNOWLEDGE.md)
 
 プロジェクトルートの `KNOWLEDGE.md` は、PR レビューで受けた指摘・実装中に発見した落とし穴・設計判断の理由など、コードを読んでも分からない知見を蓄積する long-term memory。リポジトリ管理されており、Claude Code も人間コントリビュータも読む。

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1215,6 +1215,28 @@ were both tried. `./build-tsan/ry_tests` (which includes
 `ConcurrencySpecSuite`) runs cleanly on the same binary, so that
 is the required gate for #630's race fixes. macOS is unaffected.
 
+### LLVM mirror workflow and version-bump checklist
+
+**Source**: #892 / #919
+**Tags**: llvm, ci, cache, mirror, version-bump
+
+**Rule**: CI fetches LLVM from a GitHub Releases mirror via
+`.github/actions/setup-llvm/`. The mirror tarball is built by
+`.github/workflows/mirror-llvm-toolchain.yml` (manual `workflow_dispatch`).
+
+Version bump checklist — update `env.LLVM_VERSION` (and
+`env.LLVM_SHA256_SHORT` when non-empty) in:
+- `.github/workflows/ci.yml`
+- `.github/workflows/codeql.yml`
+
+Cache key format: `llvm-${VERSION}-linux-x86_64-v1-${SHA256_SHORT}`.
+`restore-keys` is intentionally omitted: a partial cache hit would
+restore a mismatched LLVM version, causing build failures or silent ABI
+mismatches. An exact-match-only policy guarantees the correct toolchain.
+
+`release.yml` still uses `apt.llvm.org` directly and is not yet
+migrated — tracked as a separate follow-up from #892.
+
 ---
 
 ## Documentation

--- a/changelog.d/892-llvm-ci-mirror.md
+++ b/changelog.d/892-llvm-ci-mirror.md
@@ -1,0 +1,3 @@
+### Changed
+
+- CI now uses a mirrored LLVM 21.1.8 toolchain from GitHub Releases instead of fetching from apt.llvm.org on every run (#892)


### PR DESCRIPTION
## Summary

- Add CI LLVM mirror subsection to `AGENTS.md` explaining the `setup-llvm` composite action, cache key strategy (`restore-keys` intentionally omitted), and version bump procedure
- Add `KNOWLEDGE.md` entry with LLVM version-bump checklist and cache-key rationale
- Create `changelog.d/892-llvm-ci-mirror.md` fragment

Closes #919
Part of #892 (Phase D)

## Verification

- [x] No residual `apt.llvm.org` / `llvm-21-dev` / `/usr/lib/llvm-21` references outside `release.yml` (out-of-scope) and intentional mirror/fallback files
- [x] AGENTS.md documents the mirror workflow and bump procedure
- [x] KNOWLEDGE.md has cache-key rationale entry with Source/Tags/Rule
- [x] changelog.d fragment exists

## Test plan

- Documentation-only change — no runtime or CI impact
- Verify markdown renders correctly in PR diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the LLVM toolchain mirror infrastructure used in CI, covering mirror production via automated workflows, GitHub Releases hosting, cache key specifications with exact-match enforcement, ordered fallback procedures, and detailed version bump procedures. These guidelines help maintainers manage toolchain updates reliably across all CI environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->