### PR TITLE
ci: add strict compiler warning flags to internal targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,19 @@ cmake --build build                                     # Ninja が自動並列�
 
 > repo 内でビルドした `./build/ry` は `package.toml` の hidden 設定 `[paths]._dev_stdlib` に従ってプロジェクトローカルの `share/std/` を優先する。`RY_ENV=internal` は追加の isolation が必要な場合だけ使う。
 
+## コンパイラ警告フラグ
+
+内部ターゲット（`ry_lib`, `ry`, `ry_tests`, native libs）には厳格な警告フラグが有効化されている:
+
+```
+-Wall -Wextra -Wpedantic -Wconversion -Wshadow
+```
+
+- 新規コードは警告ゼロを維持すること
+- LLVM / GoogleTest のヘッダは `SYSTEM` include として扱われ、警告対象外
+- `-Werror` は現時点では未導入（別 issue）
+- フラグは `CMakeLists.txt` の `RY_WARNING_FLAGS` 変数で一元管理し、`target_compile_options(... PRIVATE ...)` で各ターゲットに適用
+
 ## CI: LLVM ツールチェーン (ミラー)
 
 CI は `.github/actions/setup-llvm/` composite action 経由で LLVM を取得する。優先順に:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ cmake --build build                                     # Ninja が自動並列�
 
 内部ターゲット（`ry_lib`, `ry`, `ry_tests`, native libs）には厳格な警告フラグが有効化されている:
 
-```
+```text
 -Wall -Wextra -Wpedantic -Wconversion -Wshadow
 ```
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.25)
 project(ry)
 
 if(NOT RY_VERSION)
@@ -54,8 +54,11 @@ if(ENABLE_TSAN)
     add_link_options(-fsanitize=thread)
 endif()
 
+# Strict warning flags for internal targets (#895)
+# Applied per-target so FetchContent targets (GoogleTest) are not affected.
+set(RY_WARNING_FLAGS -Wall -Wextra -Wpedantic -Wconversion -Wshadow)
+
 find_package(LLVM REQUIRED CONFIG)
-include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64|ARM64")
@@ -76,6 +79,7 @@ FetchContent_Declare(
     googletest
     URL https://github.com/google/googletest/archive/refs/tags/v1.17.0.tar.gz
     DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    SYSTEM
 )
 set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
@@ -180,11 +184,10 @@ target_precompile_headers(ry_lib PRIVATE
     <llvm/IR/Verifier.h>
     <llvm/Support/raw_ostream.h>
 )
-target_include_directories(ry_lib PUBLIC
-    ${CMAKE_CURRENT_SOURCE_DIR}/include
-    ${LLVM_INCLUDE_DIRS}
-)
+target_include_directories(ry_lib PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_include_directories(ry_lib SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})
 target_link_libraries(ry_lib PUBLIC ${LLVM_LIBS} Threads::Threads OpenSSL::SSL OpenSSL::Crypto)
+target_compile_options(ry_lib PRIVATE ${RY_WARNING_FLAGS})
 
 # ===== Native shared libraries for @native("libname") =====
 # Stdlib runtime implementations live exclusively in shared libraries.
@@ -205,6 +208,7 @@ function(add_ry_native_lib PKG_NAME)
         INSTALL_RPATH "$<IF:$<PLATFORM_ID:Darwin>,@loader_path,\$ORIGIN>")
     # Native libs resolve infrastructure symbols (__ry_set_last_error etc.)
     # from the main process at runtime, not via link-time dependency.
+    target_compile_options(ry_${PKG_NAME} PRIVATE ${RY_WARNING_FLAGS})
     if(APPLE)
         target_link_options(ry_${PKG_NAME} PRIVATE -undefined dynamic_lookup)
     endif()
@@ -258,6 +262,7 @@ else()
     # dlopen'd native libs can find __ry_set_last_error etc. from the process
     target_link_options(ry PRIVATE -rdynamic)
 endif()
+target_compile_options(ry PRIVATE ${RY_WARNING_FLAGS})
 
 # ===== テスト =====
 enable_testing()
@@ -326,6 +331,7 @@ endif()
 
 target_compile_definitions(ry_tests PRIVATE RY_BINARY_PATH="$<TARGET_FILE:ry>")
 target_precompile_headers(ry_tests REUSE_FROM ry_lib)
+target_compile_options(ry_tests PRIVATE ${RY_WARNING_FLAGS})
 
 include(GoogleTest)
 if(ENABLE_ASAN OR ENABLE_UBSAN OR ENABLE_TSAN)

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1237,6 +1237,30 @@ mismatches. An exact-match-only policy guarantees the correct toolchain.
 `release.yml` still uses `apt.llvm.org` directly and is not yet
 migrated — tracked as a separate follow-up from #892.
 
+### Compiler warning flags require SYSTEM includes for third-party headers
+
+**Source**: #895 (implementation)
+**Tags**: build, cmake, warnings, llvm, googletest, system-include
+
+**Context**: When `-Wall -Wextra -Wpedantic -Wconversion -Wshadow` are
+enabled on internal targets, LLVM and GoogleTest headers produce hundreds
+of warnings (implicit conversions, unused parameters, non-standard
+extensions, etc.) that are not actionable.
+
+**Rule**: LLVM include directories must be added via
+`target_include_directories(... SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})`,
+not via the global `include_directories(${LLVM_INCLUDE_DIRS})`. The
+global form does not support SYSTEM and causes third-party warnings to
+leak into the build output. GoogleTest uses the `SYSTEM` keyword in
+`FetchContent_Declare` (requires cmake 3.25+). The project's own
+`include/` directory must NOT be marked SYSTEM — warnings on our own
+headers are intentional.
+
+Warning flags are stored in the `RY_WARNING_FLAGS` CMake variable and
+applied per-target via `target_compile_options(... PRIVATE ...)` so they
+do not leak into FetchContent targets. The `add_ry_native_lib()` helper
+applies them automatically to all native shared libraries.
+
 ---
 
 ## Documentation

--- a/include/ry/runtime_io.hpp
+++ b/include/ry/runtime_io.hpp
@@ -25,8 +25,8 @@ inline IOListHeader *makeByteList(const uint8_t *bytes, int64_t len) {
     header->len = len;
     header->cap = len;
     if (len > 0) {
-        header->data = (int8_t *)checked_malloc(len);
-        memcpy(header->data, bytes, len);
+        header->data = (int8_t *)checked_malloc(static_cast<size_t>(len));
+        memcpy(header->data, bytes, static_cast<size_t>(len));
     } else {
         header->data = nullptr;
     }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -204,8 +204,8 @@ void CodeGen::emitCoverage(const SourceLocation &loc) {
         llvm::Type::getVoidTy(*ctx_), {i32Ty_, i32Ty_}, false);
     auto hitFn = mod_->getOrInsertFunction("__ry_coverage_hit", ft);
     builder_.CreateCall(hitFn,
-        {llvm::ConstantInt::get(i32Ty_, gid),
-         llvm::ConstantInt::get(i32Ty_, loc.line)});
+        {llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(gid)),
+         llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.line))});
 }
 
 void CodeGen::emitTraceSymbolDefine(const std::string &kind, const std::string &name,
@@ -243,8 +243,8 @@ void CodeGen::emitTraceFunctionEnter(const std::string &fnName, const SourceLoca
                                 {ptrTy_, ptrTy_, i32Ty_, i32Ty_}, false));
     builder_.CreateCall(callee, {emitTraceSourceString(fnName),
                                  emitTraceFileString(loc),
-                                 llvm::ConstantInt::get(i32Ty_, loc.line),
-                                 llvm::ConstantInt::get(i32Ty_, loc.col)});
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.line)),
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.col))});
 }
 
 void CodeGen::emitTraceFunctionExit(const std::string &fnName, const SourceLocation &loc) {
@@ -255,8 +255,8 @@ void CodeGen::emitTraceFunctionExit(const std::string &fnName, const SourceLocat
                                 {ptrTy_, ptrTy_, i32Ty_, i32Ty_}, false));
     builder_.CreateCall(callee, {emitTraceSourceString(fnName),
                                  emitTraceFileString(loc),
-                                 llvm::ConstantInt::get(i32Ty_, loc.line),
-                                 llvm::ConstantInt::get(i32Ty_, loc.col)});
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.line)),
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.col))});
 }
 
 void CodeGen::emitTraceReturn(const SourceLocation &loc) {
@@ -267,8 +267,8 @@ void CodeGen::emitTraceReturn(const SourceLocation &loc) {
                                 {ptrTy_, ptrTy_, i32Ty_, i32Ty_}, false));
     builder_.CreateCall(callee, {emitTraceSourceString(current_function_name_),
                                  emitTraceFileString(loc),
-                                 llvm::ConstantInt::get(i32Ty_, loc.line),
-                                 llvm::ConstantInt::get(i32Ty_, loc.col)});
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.line)),
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.col))});
 }
 
 void CodeGen::emitTraceIfBranch(llvm::Value *cond, const SourceLocation &loc) {
@@ -279,8 +279,8 @@ void CodeGen::emitTraceIfBranch(llvm::Value *cond, const SourceLocation &loc) {
                                 {ptrTy_, i32Ty_, i32Ty_, i32Ty_}, false));
     llvm::Value *taken = builder_.CreateZExt(cond, i32Ty_, "trace_if_taken");
     builder_.CreateCall(callee, {emitTraceFileString(loc),
-                                 llvm::ConstantInt::get(i32Ty_, loc.line),
-                                 llvm::ConstantInt::get(i32Ty_, loc.col),
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.line)),
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.col)),
                                  taken});
 }
 
@@ -291,9 +291,9 @@ void CodeGen::emitTraceWhenBranch(int armIndex, const SourceLocation &loc) {
         llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_),
                                 {ptrTy_, i32Ty_, i32Ty_, i32Ty_}, false));
     builder_.CreateCall(callee, {emitTraceFileString(loc),
-                                 llvm::ConstantInt::get(i32Ty_, loc.line),
-                                 llvm::ConstantInt::get(i32Ty_, loc.col),
-                                 llvm::ConstantInt::get(i32Ty_, armIndex)});
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.line)),
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(loc.col)),
+                                 llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(armIndex))});
 }
 
 // ===== Error helpers =====
@@ -699,6 +699,7 @@ bool CodeGen::isSubtypeOf(const std::string &childType, const std::string &paren
 llvm::Value *CodeGen::emitSubtypeSlice(llvm::Value *childVal,
                                          const std::string &childTypeName,
                                          const std::string &parentTypeName) {
+    (void)childTypeName;
     auto pit = struct_types_.find(parentTypeName);
     if (pit == struct_types_.end())
         codegenError("unknown parent type: " + parentTypeName);

--- a/src/codegen_any.cpp
+++ b/src/codegen_any.cpp
@@ -45,7 +45,7 @@ llvm::Value *CodeGen::wrapInAny(llvm::Value *val) {
     // alloca required: data field is [8 x i8], val type differs (type punning)
     llvm::AllocaInst *tmp = builder_.CreateAlloca(anyTy_, nullptr, "any.tmp");
     auto *tagPtr = builder_.CreateStructGEP(anyTy_, tmp, 0, "any.tag");
-    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, tag), tagPtr);
+    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(tag)), tagPtr);
     auto *dataPtr = builder_.CreateStructGEP(anyTy_, tmp, 1, "any.data");
     builder_.CreateStore(val, dataPtr);
     return builder_.CreateLoad(anyTy_, tmp, "any.val");
@@ -110,7 +110,7 @@ llvm::Value *CodeGen::unwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy) {
     // Standard 2-way: exact tag match or error
     int64_t expectedTag = getAnyTypeTag(targetTy);
     llvm::Value *cmp = builder_.CreateICmpEQ(
-        tag, llvm::ConstantInt::get(i64Ty_, expectedTag), "any.tag.check");
+        tag, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(expectedTag)), "any.tag.check");
 
     auto *matchBB = llvm::BasicBlock::Create(*ctx_, "any.match", fn);
     auto *mismatchBB = llvm::BasicBlock::Create(*ctx_, "any.mismatch", fn);

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -36,7 +36,7 @@ llvm::Value *CodeGen::emitArcAllocCollectionHeader(llvm::Type *headerTy) {
 
 llvm::Value *CodeGen::emitArcGetHeaderFromData(llvm::Value *dataPtr) {
     return builder_.CreateGEP(i8Ty_, dataPtr,
-                              llvm::ConstantInt::get(i64Ty_, -static_cast<int64_t>(ARC_HEADER_SIZE)),
+                              llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(-static_cast<int64_t>(ARC_HEADER_SIZE))),
                               "arc_hdr_from_data");
 }
 

--- a/src/codegen_arc_cow.cpp
+++ b/src/codegen_arc_cow.cpp
@@ -435,7 +435,7 @@ llvm::Value *CodeGen::emitPathCowForChain(ExprNode &chain) {
     // Method-call roots (`f().items[i] = v`) and field chains
     // interleaved with IndexExpr hops (`rec.arr[0].items[i] = v`)
     // are not supported in the narrow #854 scope.
-    if (auto *faPtr = std::get_if<std::unique_ptr<FieldAccessExpr>>(&chain.data)) {
+    if (std::get_if<std::unique_ptr<FieldAccessExpr>>(&chain.data)) {
         // `fieldChain` is ordered leaf-first (outermost FAE at index 0).
         std::vector<FieldAccessExpr *> fieldChain;
         ExprNode *cur = &chain;
@@ -464,7 +464,7 @@ llvm::Value *CodeGen::emitPathCowForChain(ExprNode &chain) {
         llvm::Type *fieldTy = nullptr;
         std::string fieldTypeName;
         for (int i = static_cast<int>(fieldChain.size()) - 1; i >= 0; --i) {
-            FieldAccessExpr *thisFa = fieldChain[i];
+            FieldAccessExpr *thisFa = fieldChain[static_cast<size_t>(i)];
             curSt = llvm::dyn_cast<llvm::StructType>(curTy);
             if (!curSt)
                 codegenError("path CoW: non-struct intermediate in record chain");
@@ -475,11 +475,11 @@ llvm::Value *CodeGen::emitPathCowForChain(ExprNode &chain) {
             if (fieldIdx < 0)
                 codegenError("type '" + sit->first + "' has no field '" + thisFa->field + "'");
             storagePtr = builder_.CreateStructGEP(
-                curSt, storagePtr, fieldIdx,
+                curSt, storagePtr, static_cast<unsigned>(fieldIdx),
                 "pcow_" + thisFa->field + "_slot");
-            fieldTy = curSt->getElementType(fieldIdx);
-            if (sit->second.fields[fieldIdx].type)
-                fieldTypeName = sit->second.fields[fieldIdx].type->toString();
+            fieldTy = curSt->getElementType(static_cast<unsigned>(fieldIdx));
+            if (sit->second.fields[static_cast<size_t>(fieldIdx)].type)
+                fieldTypeName = sit->second.fields[static_cast<size_t>(fieldIdx)].type->toString();
             else
                 fieldTypeName.clear();
             curTy = fieldTy;
@@ -586,7 +586,7 @@ llvm::FunctionCallee CodeGen::getOrCreateClosureDestructor(const FnTypeInfo &inf
             continue;
 
         auto *capField = builder_.CreateStructGEP(
-            closureTy, dataPtr, i + 1, "dtor.cap." + std::to_string(i));
+            closureTy, dataPtr, static_cast<unsigned>(i + 1), "dtor.cap." + std::to_string(i));
         auto *capVal = builder_.CreateLoad(info.capturedTypes[i], capField,
                                             "dtor.cap_val." + std::to_string(i));
 

--- a/src/codegen_arc_gc.cpp
+++ b/src/codegen_arc_gc.cpp
@@ -285,7 +285,7 @@ llvm::Function *CodeGen::createAdtVisitFunction(const std::string &typeName,
 
     // Create switch on tag to visit the right variant's fields.
     auto *doneBB = llvm::BasicBlock::Create(*ctx_, "gc.visit.done", visitFn);
-    auto *sw = builder_.CreateSwitch(tag, doneBB, info.variantOrder.size());
+    auto *sw = builder_.CreateSwitch(tag, doneBB, static_cast<unsigned>(info.variantOrder.size()));
 
     // Visitor call function type: void(ptr)
     auto *visitorCallTy = llvm::FunctionType::get(
@@ -310,13 +310,13 @@ llvm::Function *CodeGen::createAdtVisitFunction(const std::string &typeName,
         }
         if (!hasArcField) {
             // Wire this tag to doneBB (no ARC fields to visit).
-            sw->addCase(llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, tagVal)), doneBB);
+            sw->addCase(llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(tagVal))), doneBB);
             continue;
         }
 
         auto *caseBB = llvm::BasicBlock::Create(
             *ctx_, "gc.visit." + variantName, visitFn);
-        sw->addCase(llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, tagVal)), caseBB);
+        sw->addCase(llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(tagVal))), caseBB);
         builder_.SetInsertPoint(caseBB);
 
         // Walk through fields with proper alignment (same layout as codegen_call_dispatch).

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -336,14 +336,14 @@ void CodeGen::emitBucketInit(llvm::Value *headerPtr, llvm::StructType *headerTy,
 
     int64_t bucketBytes = initialBucketCount * 8; // sizeof(int64_t)
     llvm::Value *bucketsPtr = builder_.CreateCall(
-        mallocFn, {llvm::ConstantInt::get(i64Ty_, bucketBytes)}, "buckets");
+        mallocFn, {llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(bucketBytes))}, "buckets");
     // Fill with 0xFF bytes → each int64_t becomes -1 (EMPTY)
     builder_.CreateCall(memsetFn, {bucketsPtr,
         llvm::ConstantInt::get(i32Ty_, 0xFF),
-        llvm::ConstantInt::get(i64Ty_, bucketBytes)});
+        llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(bucketBytes))});
 
     llvm::Value *bcPtr = builder_.CreateStructGEP(headerTy, headerPtr, bucketCountIdx, "bc_ptr");
-    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, initialBucketCount), bcPtr);
+    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(initialBucketCount)), bcPtr);
     llvm::Value *bpPtr = builder_.CreateStructGEP(headerTy, headerPtr, bucketsPtrIdx, "bp_ptr");
     builder_.CreateStore(bucketsPtr, bpPtr);
 }

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -70,7 +70,7 @@ llvm::Value *CodeGen::buildTypeValue(int64_t id, const std::string &name) {
     llvm::Constant *nameStr = cachedGlobalString(name, ".type_of_name");
     return llvm::ConstantStruct::get(
         typeTy_,
-        {llvm::ConstantInt::get(i64Ty_, id), nameStr});
+        {llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(id)), nameStr});
 }
 
 std::pair<int64_t, std::string> CodeGen::resolveTypeOfKey(llvm::Value *val) {

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -196,7 +196,7 @@ llvm::Value *CodeGen::emitListRemove(llvm::Value *containerPtr, llvm::Value *val
 
     // Linear search for the value
     llvm::AllocaInst *foundIdx = builder_.CreateAlloca(i64Ty_, nullptr, "lrem_found_idx");
-    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, -1), foundIdx);
+    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(-1)), foundIdx);
     llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "lrem_i");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
 

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -33,7 +33,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
                         std::to_string(fieldInfo.fieldTypes.size()) + " arguments");
 
                 llvm::Value *adtVal = llvm::UndefValue::get(info.adtType);
-                adtVal = builder_.CreateInsertValue(adtVal, llvm::ConstantInt::get(i64Ty_, tag), 0, "adt.tag");
+                adtVal = builder_.CreateInsertValue(adtVal, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(tag)), 0, "adt.tag");
 
                 const llvm::DataLayout &dl = mod_->getDataLayout();
                 llvm::AllocaInst *tmpAlloca = builder_.CreateAlloca(info.adtType, nullptr, "adt.tmp");
@@ -276,7 +276,7 @@ llvm::Value *CodeGen::emitLambdaCall(llvm::Value *lambdaVal, const FnTypeInfo &i
         std::vector<llvm::Type*> allParamTypes = info.paramTypes;
         for (size_t i = 0; i < info.capturedTypes.size(); ++i) {
             llvm::Value *capField = builder_.CreateStructGEP(
-                closureTy, lambdaVal, i + 1, "lcall.cap." + std::to_string(i));
+                closureTy, lambdaVal, static_cast<unsigned>(i + 1), "lcall.cap." + std::to_string(i));
             llvm::Value *capVal = builder_.CreateLoad(
                 info.capturedTypes[i], capField, "lcall.cap_val." + std::to_string(i));
             fullArgs.push_back(capVal);

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -164,7 +164,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
 
     // Emit args once, then find the sig whose types match
     std::vector<llvm::Value *> args;
-    for (int i = 0; i < entry->arity; i++)
+    for (size_t i = 0; i < static_cast<size_t>(entry->arity); i++)
         args.push_back(emitExpr(*e.args[i]));
 
     const NativeFnSignature *matchedSig = nullptr;
@@ -173,7 +173,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         if (static_cast<int>(sig.params.size()) != entry->arity) continue;
         bool typesMatch = true;
         std::vector<llvm::Type *> candidateTypes;
-        for (int i = 0; i < entry->arity; i++) {
+        for (size_t i = 0; i < static_cast<size_t>(entry->arity); i++) {
             llvm::Type *expectedTy = resolveType(sig.params[i].typeName);
             if (args[i]->getType() != expectedTy) {
                 typesMatch = false;
@@ -190,7 +190,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     if (!matchedSig) {
         for (const auto &sig : sigIt->second) {
             if (static_cast<int>(sig.params.size()) == entry->arity) {
-                for (int i = 0; i < entry->arity; i++) {
+                for (size_t i = 0; i < static_cast<size_t>(entry->arity); i++) {
                     llvm::Type *expectedTy = resolveType(sig.params[i].typeName);
                     if (args[i]->getType() != expectedTy)
                         codegenError(e.callee + "() argument " + std::to_string(i) +

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -1002,7 +1002,6 @@ llvm::Value *CodeGen::emitStrOp_join(const CallExpr &e) {
 
     builder_.SetInsertPoint(buildBodyBB);
     llvm::Value *i2Cur = builder_.CreateLoad(i64Ty_, iVar, "join_i2_cur");
-    llvm::Value *curDst = builder_.CreateLoad(ptrTy_, dstVar, "join_cur_dst");
 
     llvm::Value *notFirst = builder_.CreateICmpSGT(i2Cur, llvm::ConstantInt::get(i64Ty_, 0), "join_not_first");
     llvm::BasicBlock *sepBB = llvm::BasicBlock::Create(*ctx_, "join.sep", fn_);

--- a/src/codegen_call_thread.cpp
+++ b/src/codegen_call_thread.cpp
@@ -193,7 +193,7 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
             cg.builder_.CreateStore(llvm::ConstantInt::get(cg.i8Ty_, 0), dummyField);
         } else {
             for (size_t i = 0; i < captures.size(); ++i) {
-                llvm::Value *fieldPtr = cg.builder_.CreateStructGEP(envTy, envPtr, i, "thread_env_field");
+                llvm::Value *fieldPtr = cg.builder_.CreateStructGEP(envTy, envPtr, static_cast<unsigned>(i), "thread_env_field");
                 llvm::AllocaInst *src = captures[i].second;
                 cg.builder_.CreateStore(
                     cg.builder_.CreateLoad(src->getAllocatedType(), src, captures[i].first + ".thr_cap"),
@@ -224,7 +224,7 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                 for (size_t i = 0; i < captures.size(); ++i) {
                     const auto &[name, src] = captures[i];
                     llvm::Type *capTy = src->getAllocatedType();
-                    llvm::Value *fieldPtr = cg.builder_.CreateStructGEP(envTy, envRaw, i, name + ".field");
+                    llvm::Value *fieldPtr = cg.builder_.CreateStructGEP(envTy, envRaw, static_cast<unsigned>(i), name + ".field");
                     llvm::AllocaInst *dst = cg.builder_.CreateAlloca(capTy, nullptr, name);
                     cg.builder_.CreateStore(cg.builder_.CreateLoad(capTy, fieldPtr, name + ".cap"), dst);
                     cg.scope_stack_.back()[name] = dst;
@@ -310,8 +310,8 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
             llvm::Value *dstFnPtr = cg.builder_.CreateStructGEP(closureTy, envPtr, 0, "dst.fn_ptr");
             cg.builder_.CreateStore(cg.builder_.CreateLoad(cg.ptrTy_, srcFnPtr, "fn_ptr.val"), dstFnPtr);
             for (size_t i = 0; i < info.capturedTypes.size(); ++i) {
-                llvm::Value *srcCap = cg.builder_.CreateStructGEP(closureTy, fnVal, i + 1, "src.cap." + std::to_string(i));
-                llvm::Value *dstCap = cg.builder_.CreateStructGEP(closureTy, envPtr, i + 1, "dst.cap." + std::to_string(i));
+                llvm::Value *srcCap = cg.builder_.CreateStructGEP(closureTy, fnVal, static_cast<unsigned>(i + 1), "src.cap." + std::to_string(i));
+                llvm::Value *dstCap = cg.builder_.CreateStructGEP(closureTy, envPtr, static_cast<unsigned>(i + 1), "dst.cap." + std::to_string(i));
                 cg.builder_.CreateStore(
                     cg.builder_.CreateLoad(info.capturedTypes[i], srcCap, "cap.val." + std::to_string(i)),
                     dstCap);
@@ -337,7 +337,7 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                 std::vector<llvm::Type*> allParamTypes;
                 for (size_t i = 0; i < info.capturedTypes.size(); ++i) {
                     llvm::Value *capField = cg.builder_.CreateStructGEP(
-                        closureTy, envRaw, i + 1, "tramp.cap." + std::to_string(i));
+                        closureTy, envRaw, static_cast<unsigned>(i + 1), "tramp.cap." + std::to_string(i));
                     callArgs.push_back(cg.builder_.CreateLoad(
                         info.capturedTypes[i], capField, "tramp.cap_val." + std::to_string(i)));
                     allParamTypes.push_back(info.capturedTypes[i]);
@@ -386,7 +386,7 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
     auto spawnFn = cg.mod_->getOrInsertFunction("__ry_thread_spawn", spawnTy);
     llvm::Value *thread = cg.builder_.CreateCall(
         spawnFn,
-        {thunk, envPtr, llvm::ConstantInt::get(cg.i64Ty_, resultSize)},
+        {thunk, envPtr, llvm::ConstantInt::get(cg.i64Ty_, static_cast<uint64_t>(resultSize))},
         "thread");
     cg.addResourceKind(thread, rk_thread);
     // Attach the worker's return type as metadata so that emitThreadJoin

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -239,7 +239,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
             std::string resolvedPtype = resolveTypeAlias(matchedEntry->paramTypeNames[i]);
             auto constraint = parseTypeConstraint(resolvedPtype);
             if (constraint) {
-                std::string paramName = fn->getArg(i)->getName().str();
+                std::string paramName = fn->getArg(static_cast<unsigned>(i))->getName().str();
                 emitConstraintCheck(argVals[i], *constraint, paramName);
             }
         }
@@ -658,7 +658,7 @@ void CodeGen::emitBoundsCheck(llvm::Value *&index, llvm::Value *size,
             if (idx < 0 || idx >= sz)
                 codegenError("index " + std::to_string(ci->getSExtValue()) +
                              " out of bounds (size " + std::to_string(sz) + ")");
-            index = llvm::ConstantInt::get(i64Ty_, idx);
+            index = llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(idx));
             return;
         }
     }

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -83,7 +83,7 @@ llvm::Value *CodeGen::emitExprVariant(const NumberExpr &e) {
         if (e.value < 0)
             codegenError("integer literal out of range for int: " +
                          std::to_string(static_cast<uint64_t>(e.value)));
-        return llvm::ConstantInt::get(i64Ty_, e.value, true);
+        return llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(e.value), true);
     }
 
     validateIntRange(e.value, e.suffix,
@@ -558,14 +558,14 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                 builder_.CreateStore(builder_.CreateExtractValue(lhs, 1, "lhs.udata"), lhsTmp);
                 builder_.CreateStore(builder_.CreateExtractValue(rhs, 1, "rhs.udata"), rhsTmp);
                 llvm::SwitchInst *sw = builder_.CreateSwitch(
-                    lhsTag, invalidBB, uinfo.componentTypes.size());
+                    lhsTag, invalidBB, static_cast<unsigned>(uinfo.componentTypes.size()));
 
                 builder_.SetInsertPoint(invalidBB);
                 builder_.CreateBr(mergeBB);
 
                 builder_.SetInsertPoint(mergeBB);
                 auto *phi = builder_.CreatePHI(
-                    i1Ty_, uinfo.componentTypes.size() + 2, "ueq.phi");
+                    i1Ty_, static_cast<unsigned>(uinfo.componentTypes.size() + 2), "ueq.phi");
                 phi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), entryBB);
                 phi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), invalidBB);
 
@@ -1379,7 +1379,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
     incoming.push_back({elseVal, elseEndBB});
 
     builder_.SetInsertPoint(mergeBB);
-    llvm::PHINode *phi = builder_.CreatePHI(firstVal->getType(), incoming.size(), "case.expr");
+    llvm::PHINode *phi = builder_.CreatePHI(firstVal->getType(), static_cast<unsigned>(incoming.size()), "case.expr");
     for (auto &[val, bb] : incoming)
         phi->addIncoming(val, bb);
     propagateMeta(firstVal, phi);

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -243,7 +243,6 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<InterpolatedStringEx
 
     // Compute total length
     auto strlenFn = getStdlibStrlen();
-    auto mallocFn = getStdlibMalloc();
     auto memcpyFn = getStdlibMemcpy();
 
     llvm::Value *totalLen = llvm::ConstantInt::get(i64Ty_, 0);

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -100,10 +100,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e)
 
     // Numeric index access for tuples (.0, .1, ...)
     if (!e->field.empty() && std::isdigit(static_cast<unsigned char>(e->field[0]))) {
-        unsigned idx = static_cast<unsigned>(std::stoul(e->field));
+        auto idx = std::stoul(e->field);
         if (idx >= structTy->getNumElements())
             codegenError("tuple index " + e->field + " out of range");
-        return builder_.CreateExtractValue(obj, idx, "tuple." + e->field);
+        return builder_.CreateExtractValue(obj, static_cast<unsigned>(idx), "tuple." + e->field);
     }
 
     std::string typeName = structTy->getName().str();

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -100,7 +100,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e)
 
     // Numeric index access for tuples (.0, .1, ...)
     if (!e->field.empty() && std::isdigit(static_cast<unsigned char>(e->field[0]))) {
-        unsigned idx = std::stoul(e->field);
+        unsigned idx = static_cast<unsigned>(std::stoul(e->field));
         if (idx >= structTy->getNumElements())
             codegenError("tuple index " + e->field + " out of range");
         return builder_.CreateExtractValue(obj, idx, "tuple." + e->field);
@@ -170,19 +170,19 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
     const llvm::DataLayout &dl = mod_->getDataLayout();
     auto mallocFn = getStdlibMalloc();
     uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-    llvm::Value *dataSize = llvm::ConstantInt::get(i64Ty_, elemSize * count);
+    llvm::Value *dataSize = llvm::ConstantInt::get(i64Ty_, elemSize * static_cast<uint64_t>(count));
     llvm::Value *dataPtr = builder_.CreateCall(mallocFn, {dataSize}, "list_data");
 
     // Store elements into data
     for (int64_t i = 0; i < count; ++i) {
         llvm::Value *elemPtr = builder_.CreateGEP(
-            elemTy, dataPtr, {llvm::ConstantInt::get(i64Ty_, i)}, "elem_ptr");
-        builder_.CreateStore(vals[i], elemPtr);
+            elemTy, dataPtr, {llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(i))}, "elem_ptr");
+        builder_.CreateStore(vals[static_cast<size_t>(i)], elemPtr);
     }
 
     // Store length, capacity, data pointer into header
-    storeListHeaderFields(headerPtr, llvm::ConstantInt::get(i64Ty_, count),
-                          llvm::ConstantInt::get(i64Ty_, count), dataPtr);
+    storeListHeaderFields(headerPtr, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(count)),
+                          llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(count)), dataPtr);
 
     // Track element type
     setTypeMeta(TypeMeta::ListElem, headerPtr, elemTy);
@@ -269,49 +269,45 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
     auto mallocFn = getStdlibMalloc();
     uint64_t keySize = dl.getTypeAllocSize(keyTy);
     llvm::Value *keysPtr = builder_.CreateCall(
-        mallocFn, {llvm::ConstantInt::get(i64Ty_, keySize * count)}, "map_keys");
+        mallocFn, {llvm::ConstantInt::get(i64Ty_, keySize * static_cast<uint64_t>(count))}, "map_keys");
 
     uint64_t valSize = dl.getTypeAllocSize(valTy);
     llvm::Value *valsPtr = builder_.CreateCall(
-        mallocFn, {llvm::ConstantInt::get(i64Ty_, valSize * count)}, "map_vals");
+        mallocFn, {llvm::ConstantInt::get(i64Ty_, valSize * static_cast<uint64_t>(count))}, "map_vals");
 
     // Store keys and values
     for (int64_t i = 0; i < count; ++i) {
         llvm::Value *kp = builder_.CreateGEP(keyTy, keysPtr,
-            {llvm::ConstantInt::get(i64Ty_, i)}, "key_ptr");
-        builder_.CreateStore(keyVals[i], kp);
+            {llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(i))}, "key_ptr");
+        builder_.CreateStore(keyVals[static_cast<size_t>(i)], kp);
         llvm::Value *vp = builder_.CreateGEP(valTy, valsPtr,
-            {llvm::ConstantInt::get(i64Ty_, i)}, "val_ptr");
-        builder_.CreateStore(valVals[i], vp);
+            {llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(i))}, "val_ptr");
+        builder_.CreateStore(valVals[static_cast<size_t>(i)], vp);
     }
 
     // Store header fields: length, capacity, keys_ptr, values_ptr
-    storeMapHeaderFields(headerPtr, llvm::ConstantInt::get(i64Ty_, count),
-                         llvm::ConstantInt::get(i64Ty_, count), keysPtr, valsPtr);
+    storeMapHeaderFields(headerPtr, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(count)),
+                         llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(count)), keysPtr, valsPtr);
 
     // Initialize hash table buckets via rehash
     int64_t initBucketCount = 8;
     while (initBucketCount * 3 < count * 4) initBucketCount *= 2;
     {
         std::string rehashName;
-        llvm::Type *rehashKeyTy;
         if (keyTy == ptrTy_) {
             rehashName = "__ry_ht_rehash_str";
-            rehashKeyTy = ptrTy_;
         } else if (keyTy->isDoubleTy()) {
             rehashName = "__ry_ht_rehash_f64";
-            rehashKeyTy = f64Ty_;
         } else {
             rehashName = "__ry_ht_rehash_i64";
-            rehashKeyTy = i64Ty_;
         }
         llvm::FunctionType *rehashTy = llvm::FunctionType::get(ptrTy_, {ptrTy_, i64Ty_, i64Ty_}, false);
         llvm::FunctionCallee rehashFn = mod_->getOrInsertFunction(rehashName, rehashTy);
         llvm::Value *buckets = builder_.CreateCall(rehashFn,
-            {keysPtr, llvm::ConstantInt::get(i64Ty_, count),
-             llvm::ConstantInt::get(i64Ty_, initBucketCount)}, "map_buckets");
+            {keysPtr, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(count)),
+             llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(initBucketCount))}, "map_buckets");
         llvm::Value *bcPtr = builder_.CreateStructGEP(mapHeaderTy_, headerPtr, 4, "map_bc_ptr");
-        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, initBucketCount), bcPtr);
+        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(initBucketCount)), bcPtr);
         llvm::Value *bpPtr = builder_.CreateStructGEP(mapHeaderTy_, headerPtr, 5, "map_bp_ptr");
         builder_.CreateStore(buckets, bpPtr);
     }
@@ -360,11 +356,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<SetExpr> &e) {
     auto mallocFn = getStdlibMalloc();
     uint64_t elemSize = dl.getTypeAllocSize(elemTy);
     llvm::Value *elemsPtr = builder_.CreateCall(
-        mallocFn, {llvm::ConstantInt::get(i64Ty_, elemSize * count)}, "set_elems");
+        mallocFn, {llvm::ConstantInt::get(i64Ty_, elemSize * static_cast<uint64_t>(count))}, "set_elems");
 
     // Initialize header: length=0, capacity=count, elements pointer
     storeSetHeaderFields(headerPtr, llvm::ConstantInt::get(i64Ty_, 0),
-                         llvm::ConstantInt::get(i64Ty_, count), elemsPtr);
+                         llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(count)), elemsPtr);
     llvm::Value *lenPtr = builder_.CreateStructGEP(setHeaderTy_, headerPtr, 0, "set_len_ptr");
     llvm::Value *elemsPtrField = builder_.CreateStructGEP(setHeaderTy_, headerPtr, 2, "set_elems_field");
 
@@ -379,7 +375,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<SetExpr> &e) {
 
     // Insert elements with deduplication (same pattern as add())
     for (int64_t i = 0; i < count; ++i) {
-        llvm::Value *idx = emitSetElementLookup(headerPtr, vals[i], elemTy);
+        llvm::Value *idx = emitSetElementLookup(headerPtr, vals[static_cast<size_t>(i)], elemTy);
         llvm::Value *found = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "found");
 
         llvm::BasicBlock *insertBB = llvm::BasicBlock::Create(*ctx_, "setlit.insert", fn_);
@@ -390,12 +386,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<SetExpr> &e) {
         llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "cur_len");
         llvm::Value *curElems = builder_.CreateLoad(ptrTy_, elemsPtrField, "cur_elems");
         llvm::Value *ep = builder_.CreateGEP(elemTy, curElems, {curLen}, "set_elem_ptr");
-        builder_.CreateStore(vals[i], ep);
+        builder_.CreateStore(vals[static_cast<size_t>(i)], ep);
         llvm::Value *newLen = builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1), "new_len");
         builder_.CreateStore(newLen, lenPtr);
         emitBucketInsertAndRehashCheck(headerPtr, setHeaderTy_,
             kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx,
-            vals[i], elemTy, curLen);
+            vals[static_cast<size_t>(i)], elemTy, curLen);
         builder_.CreateBr(nextBB);
 
         builder_.SetInsertPoint(nextBB);
@@ -423,7 +419,7 @@ llvm::Value *CodeGen::emitExprVariant(const EnumAccessExpr &e) {
                 " argument(s); use '" + e.enum_name + "::" + e.variant_name + "(...)' instead");
         // ADT enum: create struct { tag, zero-payload } for data-less variants
         llvm::Value *adtVal = llvm::UndefValue::get(it->second.adtType);
-        adtVal = builder_.CreateInsertValue(adtVal, llvm::ConstantInt::get(i64Ty_, vit->second), 0, "adt.tag");
+        adtVal = builder_.CreateInsertValue(adtVal, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(vit->second)), 0, "adt.tag");
         getOrCreateMeta(adtVal).enum_value_type = e.enum_name;
         return adtVal;
     }
@@ -433,7 +429,7 @@ llvm::Value *CodeGen::emitExprVariant(const EnumAccessExpr &e) {
     // directly to the interned constant would leak to unrelated int literals
     // with the same bit pattern (see type_of enum misidentification test).
     llvm::Value *val = builder_.CreateFreeze(
-        llvm::ConstantInt::get(i64Ty_, vit->second),
+        llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(vit->second)),
         "enum." + e.enum_name + "." + e.variant_name);
     getOrCreateMeta(val).enum_value_type = e.enum_name;
     return val;

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -733,7 +733,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         forwardDeclareNestedFunctions(s->body);
 
         // Emit require checks (preconditions)
-        for (int i = 0; i < static_cast<int>(s->preconditions.size()); ++i)
+        for (size_t i = 0; i < s->preconditions.size(); ++i)
             emitContractCheck("require", s->name, s->preconditions[i]);
 
         // Set up postcondition context
@@ -827,7 +827,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         thunkArgs.reserve(paramTypes.size());
         for (size_t i = 0; i < paramTypes.size(); ++i) {
             llvm::Value *argField = builder_.CreateStructGEP(
-                envTy, typedEnv, i, "async_arg_field." + std::to_string(i));
+                envTy, typedEnv, static_cast<unsigned>(i), "async_arg_field." + std::to_string(i));
             thunkArgs.push_back(builder_.CreateLoad(paramTypes[i], argField, "async_arg." + std::to_string(i)));
         }
 
@@ -861,7 +861,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             size_t idx = 0;
             for (auto &arg : func->args()) {
                 llvm::Value *argField = builder_.CreateStructGEP(
-                    envTy, envPtr, idx++, "async_env_arg");
+                    envTy, envPtr, static_cast<unsigned>(idx++), "async_env_arg");
                 builder_.CreateStore(&arg, argField);
             }
         }

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -83,7 +83,7 @@ void CodeGen::emitEnsureChecks(llvm::Value *retVal) {
     }
     in_ensure_context_ = true;
     std::string fnName = fn_->getName().str();
-    for (int i = 0; i < static_cast<int>(current_postconditions_->size()); ++i)
+    for (size_t i = 0; i < current_postconditions_->size(); ++i)
         emitContractCheck("ensure", fnName, (*current_postconditions_)[i]);
     in_ensure_context_ = false;
     popScope();
@@ -209,10 +209,6 @@ std::string CodeGen::reverseResolveType(llvm::Value *val) {
 
     if (ty == ptrTy_) {
         // Look through LoadInst to find metadata on the underlying alloca
-        llvm::Value *origin = val;
-        if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val))
-            origin = load->getPointerOperand();
-
         if (auto *elemTy = getTypeMeta(TypeMeta::ListElem, val))
             return "List<" + reverseResolveType(
                 llvm::UndefValue::get(elemTy)) + ">";
@@ -575,7 +571,8 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
         paramTypeNames.push_back(resolvedName);
     }
     functions_[fullName].push_back({func, paramTypes, paramNames, paramTypeNames, exposedReturnTypeName,
-                                    0, {}, &s.preconditions, &s.postconditions, &s.ensure_bindings});
+                                    0, {}, &s.preconditions, &s.postconditions, &s.ensure_bindings,
+                                    {}, {}, {}, {}, {}});
     generic_fn_instantiated_.insert(fullName);
 
     // Emit function body

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -246,7 +246,7 @@ llvm::Value *CodeGen::buildClosureStruct(
     // Store captured values and retain ARC-managed ones
     for (size_t i = 0; i < capturedValues.size(); ++i) {
         llvm::Value *capField = builder_.CreateStructGEP(
-            closureTy, closurePtr, i + 1, "closure.cap." + std::to_string(i));
+            closureTy, closurePtr, static_cast<unsigned>(i + 1), "closure.cap." + std::to_string(i));
         builder_.CreateStore(capturedValues[i], capField);
         if (info.capturedArcKinds[i] != CapturedArcKind::None) {
             auto *hdr = emitArcGetHeaderFromData(capturedValues[i]);
@@ -932,7 +932,7 @@ llvm::Function *CodeGen::getOrCreateForwardingThunk(llvm::Function *realFn, cons
     // Forward user args to realFn
     std::vector<llvm::Value*> args;
     for (size_t i = 0; i < info.paramTypes.size(); ++i)
-        args.push_back(thunk->getArg(i));
+        args.push_back(thunk->getArg(static_cast<unsigned>(i)));
 
     llvm::Value *result = builder_.CreateCall(realFn, args, info.returnType->isVoidTy() ? "" : "fwd_result");
     if (info.returnType->isVoidTy())
@@ -969,7 +969,7 @@ llvm::Function *CodeGen::getOrCreateCapturingThunk(llvm::Function *realFn, const
     builder_.SetInsertPoint(entry);
 
     // env is the last argument
-    llvm::Value *envPtr = thunk->getArg(info.paramTypes.size());
+    llvm::Value *envPtr = thunk->getArg(static_cast<unsigned>(info.paramTypes.size()));
 
     // Reconstruct the original closure struct type: {fn_ptr, cap1, cap2, ...}
     std::vector<llvm::Type*> closureFields;
@@ -981,11 +981,11 @@ llvm::Function *CodeGen::getOrCreateCapturingThunk(llvm::Function *realFn, const
     // Build full args: user_params + captured values loaded from env
     std::vector<llvm::Value*> fullArgs;
     for (size_t i = 0; i < info.paramTypes.size(); ++i)
-        fullArgs.push_back(thunk->getArg(i));
+        fullArgs.push_back(thunk->getArg(static_cast<unsigned>(i)));
 
     for (size_t i = 0; i < info.capturedTypes.size(); ++i) {
         auto *capField = builder_.CreateStructGEP(
-            closureTy, envPtr, i + 1, "thunk.cap." + std::to_string(i));
+            closureTy, envPtr, static_cast<unsigned>(i + 1), "thunk.cap." + std::to_string(i));
         auto *capVal = builder_.CreateLoad(
             info.capturedTypes[i], capField, "thunk.cap_val." + std::to_string(i));
         fullArgs.push_back(capVal);

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -226,9 +226,9 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                 codegenError("match: unknown variant '" + pat.enum_name + "::" + pat.variant_name + "'");
             if (enumIt->second.isADT) {
                 llvm::Value *subjectTag = builder_.CreateExtractValue(subjectVal, 0, "adt.tag");
-                testResult = builder_.CreateICmpEQ(subjectTag, llvm::ConstantInt::get(i64Ty_, varIt->second), "match.adt_eq");
+                testResult = builder_.CreateICmpEQ(subjectTag, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(varIt->second)), "match.adt_eq");
             } else {
-                llvm::Value *tag = llvm::ConstantInt::get(i64Ty_, varIt->second);
+                llvm::Value *tag = llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(varIt->second));
                 testResult = builder_.CreateICmpEQ(subjectVal, tag, "match.enum_eq");
             }
         } else if constexpr (std::is_same_v<T, EnumConstructorPattern>) {
@@ -249,7 +249,7 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
             if (varIt == enumIt->second.variants.end())
                 codegenError("match: unknown variant '" + pat.enum_name + "::" + pat.variant_name + "'");
             llvm::Value *subjectTag = builder_.CreateExtractValue(subjectVal, 0, "adt.tag");
-            testResult = builder_.CreateICmpEQ(subjectTag, llvm::ConstantInt::get(i64Ty_, varIt->second), "match.adt_eq");
+            testResult = builder_.CreateICmpEQ(subjectTag, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(varIt->second)), "match.adt_eq");
         } else if constexpr (std::is_same_v<T, SomePattern>) {
             if (!isOptionType(subjectTy))
                 codegenError("match: Some pattern requires Option type");
@@ -502,7 +502,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
     builder_.CreateUnreachable();
 
     builder_.SetInsertPoint(mergeBB);
-    llvm::PHINode *phi = builder_.CreatePHI(firstVal->getType(), incoming.size(), "match.expr");
+    llvm::PHINode *phi = builder_.CreatePHI(firstVal->getType(), static_cast<unsigned>(incoming.size()), "match.expr");
     for (auto &[val, bb] : incoming)
         phi->addIncoming(val, bb);
     propagateMeta(firstVal, phi);
@@ -616,7 +616,7 @@ llvm::Value *CodeGen::wrapInUnion(llvm::Value *val, const std::string &unionType
         infoIt = union_type_info_.find(norm);
     }
     auto &info = infoIt->second;
-    int tagIdx = -1;
+    size_t tagIdx = std::string::npos;
     // When multiple ptr-backed variants share the same LLVM type (e.g.
     // `List<int> | Map<str, int>` — both `ptr`, or `List<int> | List<str>` —
     // both `ptr` with the same kind), we must disambiguate by the value's
@@ -640,7 +640,7 @@ llvm::Value *CodeGen::wrapInUnion(llvm::Value *val, const std::string &unionType
     }
     // Pass 2: coarse kind match (handles `List<int> | Map<str, int>` when the
     // canonical name couldn't be built — e.g. literals without annotations).
-    if (tagIdx < 0 && meta) {
+    if (tagIdx == std::string::npos && meta) {
         for (size_t i = 0; i < info.componentTypes.size(); ++i) {
             if (info.componentTypes[i] != val->getType()) continue;
             const auto &compName = info.componentNames[i];
@@ -651,17 +651,17 @@ llvm::Value *CodeGen::wrapInUnion(llvm::Value *val, const std::string &unionType
         }
     }
     // Fallback: first variant with matching LLVM type.
-    if (tagIdx < 0) {
+    if (tagIdx == std::string::npos) {
         for (size_t i = 0; i < info.componentTypes.size(); ++i) {
             if (info.componentTypes[i] == val->getType()) { tagIdx = i; break; }
         }
     }
-    if (tagIdx < 0)
+    if (tagIdx == std::string::npos)
         codegenError("type is not in union " + norm);
 
     llvm::AllocaInst *tmp = builder_.CreateAlloca(info.llvmType, nullptr, "union.tmp");
     auto *tagPtr = builder_.CreateStructGEP(info.llvmType, tmp, 0, "union.tag");
-    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, tagIdx), tagPtr);
+    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(tagIdx)), tagPtr);
     auto *dataPtr = builder_.CreateStructGEP(info.llvmType, tmp, 1, "union.data");
     builder_.CreateStore(val, dataPtr);
     return builder_.CreateLoad(info.llvmType, tmp, "union.val");

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -275,8 +275,8 @@ void CodeGen::emitTupleDestructure(const std::vector<std::string> &var_names,
 
     for (size_t i = 0; i < var_names.size(); ++i) {
         if (var_names[i] == "_") continue;
-        llvm::Value *v = builder_.CreateExtractValue(tupleVal, i, "for_elem_" + std::to_string(i));
-        llvm::AllocaInst *var = getOrCreateVar(var_names[i], structTy->getElementType(i));
+        llvm::Value *v = builder_.CreateExtractValue(tupleVal, static_cast<unsigned>(i), "for_elem_" + std::to_string(i));
+        llvm::AllocaInst *var = getOrCreateVar(var_names[i], structTy->getElementType(static_cast<unsigned>(i)));
         builder_.CreateStore(v, var);
         if (i < componentNames.size() && !componentNames[i].empty())
             propagateTypeMeta(componentNames[i], var);
@@ -496,7 +496,7 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
         builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), dummyField);
     } else {
         for (size_t i = 0; i < captures.size(); ++i) {
-            llvm::Value *fieldPtr = builder_.CreateStructGEP(envTy, envPtr, i, "parallel_env_field");
+            llvm::Value *fieldPtr = builder_.CreateStructGEP(envTy, envPtr, static_cast<unsigned>(i), "parallel_env_field");
             llvm::AllocaInst *src = captures[i].second;
             builder_.CreateStore(
                 builder_.CreateLoad(src->getAllocatedType(), src, captures[i].first + ".par_cap"),
@@ -541,7 +541,7 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
             for (size_t i = 0; i < captures.size(); ++i) {
                 const auto &[name, src] = captures[i];
                 llvm::Type *capTy = src->getAllocatedType();
-                llvm::Value *fieldPtr = builder_.CreateStructGEP(envTy, typedEnv, i, name + ".field");
+                llvm::Value *fieldPtr = builder_.CreateStructGEP(envTy, typedEnv, static_cast<unsigned>(i), name + ".field");
                 llvm::AllocaInst *dst = builder_.CreateAlloca(capTy, nullptr, name);
                 builder_.CreateStore(builder_.CreateLoad(capTy, fieldPtr, name + ".cap"), dst);
                 scope_stack_.back()[name] = dst;

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -116,14 +116,14 @@ void CodeGen::writeBackFieldChain(ExprNode &chainTarget,
         int idx = it->second.findField(fa->field);
         if (idx < 0)
             codegenError("type '" + it->first + "' has no field '" + fa->field + "'");
-        llvm::Type *expectedTy = outerSt->getElementType(idx);
+        llvm::Type *expectedTy = outerSt->getElementType(static_cast<unsigned>(idx));
         if (newInnerVal->getType() != expectedTy) {
             if (auto *sliced = tryEmitSubtypeCoerce(newInnerVal, expectedTy))
                 newInnerVal = sliced;
             else
                 codegenError("field '" + fa->field + "' type mismatch in chained assignment");
         }
-        llvm::Value *updated = builder_.CreateInsertValue(outerVal, newInnerVal, idx, "chain_upd");
+        llvm::Value *updated = builder_.CreateInsertValue(outerVal, newInnerVal, static_cast<unsigned>(idx), "chain_upd");
         writeBackFieldChain(*fa->object, updated);
         return;
     }
@@ -163,7 +163,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         } else {
             retainArcValue(newFieldVal);
             llvm::Value *oldField = builder_.CreateExtractValue(
-                structVal, fieldIdx, s.field + ".arc_old");
+                structVal, static_cast<unsigned>(fieldIdx), s.field + ".arc_old");
             emitArcReleaseLoadedElement(oldField, fieldArcKind, label);
         }
     };
@@ -194,14 +194,14 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         int fieldIdx = info.findField(s.field);
         if (fieldIdx < 0)
             codegenError("type '" + typeName + "' has no field '" + s.field + "'");
-        llvm::Type *expectedTy = structTy->getElementType(fieldIdx);
+        llvm::Type *expectedTy = structTy->getElementType(static_cast<unsigned>(fieldIdx));
 
         // Determine whether the field's declared type owns an ARC allocation
         // per slot (non-weak List/Map/Set). If so, we release the old field
         // pointer before the InsertValue+Store overwrite (#857).
         std::string fieldTypeName;
-        if (info.fields[fieldIdx].type)
-            fieldTypeName = info.fields[fieldIdx].type->toString();
+        if (info.fields[static_cast<size_t>(fieldIdx)].type)
+            fieldTypeName = info.fields[static_cast<size_t>(fieldIdx)].type->toString();
         CollectionKind fieldArcKind = CollectionKind::List;
         bool fieldIsArc = fieldTypeIsArcManaged(fieldTypeName, &fieldArcKind);
 
@@ -210,7 +210,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         llvm::Value *currentField = nullptr;  // extracted iff compound_op; reused for ARC release
         if (s.compound_op) {
             currentField = builder_.CreateExtractValue(
-                currentStruct, fieldIdx, s.field + ".compound_cur");
+                currentStruct, static_cast<unsigned>(fieldIdx), s.field + ".compound_cur");
             // Propagate the field's declared type onto the extracted SSA value
             // so downstream emitArithmeticOp can dispatch list concat / map /
             // set metadata correctly. Sibling fix of #858; see KNOWLEDGE.md
@@ -238,7 +238,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
                                             varExpr->name + "." + s.field);
 
         llvm::Value *updated = builder_.CreateInsertValue(
-            currentStruct, newFieldVal, fieldIdx, "struct_upd");
+            currentStruct, newFieldVal, static_cast<unsigned>(fieldIdx), "struct_upd");
         builder_.CreateStore(updated, storagePtr);
         emitInvariantCheck(typeName, info, updated);
         return;
@@ -256,7 +256,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         int fieldIdx = info.findField(s.field);
         if (fieldIdx < 0)
             codegenError("type '" + it->first + "' has no field '" + s.field + "'");
-        llvm::Type *expectedTy = innerSt->getElementType(fieldIdx);
+        llvm::Type *expectedTy = innerSt->getElementType(static_cast<unsigned>(fieldIdx));
 
         // ARC release on the deepest field of the chain. Middle hops of a
         // `writeBackFieldChain` walk are shallow InsertValue updates that do
@@ -264,8 +264,8 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         // sufficient for #857. Deep-chain ARC ownership through middle hops
         // is tracked with #854 deep-CoW work.
         std::string fieldTypeName;
-        if (info.fields[fieldIdx].type)
-            fieldTypeName = info.fields[fieldIdx].type->toString();
+        if (info.fields[static_cast<size_t>(fieldIdx)].type)
+            fieldTypeName = info.fields[static_cast<size_t>(fieldIdx)].type->toString();
         CollectionKind fieldArcKind = CollectionKind::List;
         bool fieldIsArc = fieldTypeIsArcManaged(fieldTypeName, &fieldArcKind);
 
@@ -273,7 +273,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         llvm::Value *currentField = nullptr;
         if (s.compound_op) {
             currentField = builder_.CreateExtractValue(
-                innerStruct, fieldIdx, s.field + ".compound_cur");
+                innerStruct, static_cast<unsigned>(fieldIdx), s.field + ".compound_cur");
             // Propagate the field's declared type onto the extracted SSA value.
             // See the VariableExpr branch above and #862 for the rationale.
             if (!fieldTypeName.empty())
@@ -297,7 +297,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
                                             it->first + "." + s.field);
 
         llvm::Value *updatedInner = builder_.CreateInsertValue(
-            innerStruct, newFieldVal, fieldIdx, "nested_upd");
+            innerStruct, newFieldVal, static_cast<unsigned>(fieldIdx), "nested_upd");
         writeBackFieldChain(*s.object, updatedInner);
         return;
     }
@@ -363,21 +363,21 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         int fieldIdx = info.findField(s.field);
         if (fieldIdx < 0)
             codegenError("type '" + it->first + "' has no field '" + s.field + "'");
-        llvm::Type *expectedTy = structTy->getElementType(fieldIdx);
+        llvm::Type *expectedTy = structTy->getElementType(static_cast<unsigned>(fieldIdx));
         llvm::Value *curStruct = builder_.CreateLoad(elemTy, elemSlot, "elem_struct_cur");
 
         // ARC release on the struct field loaded from a heap element slot
         // (`list[i].field = v` etc.). Same protocol as the other branches.
         std::string fieldTypeName;
-        if (info.fields[fieldIdx].type)
-            fieldTypeName = info.fields[fieldIdx].type->toString();
+        if (info.fields[static_cast<size_t>(fieldIdx)].type)
+            fieldTypeName = info.fields[static_cast<size_t>(fieldIdx)].type->toString();
         CollectionKind fieldArcKind = CollectionKind::List;
         bool fieldIsArc = fieldTypeIsArcManaged(fieldTypeName, &fieldArcKind);
 
         llvm::Value *newFieldVal = nullptr;
         llvm::Value *curField = nullptr;
         if (s.compound_op) {
-            curField = builder_.CreateExtractValue(curStruct, fieldIdx, s.field + ".compound_cur");
+            curField = builder_.CreateExtractValue(curStruct, static_cast<unsigned>(fieldIdx), s.field + ".compound_cur");
             // Propagate the field's declared type onto the extracted SSA value.
             // See the VariableExpr branch above and #862 for the rationale.
             if (!fieldTypeName.empty())
@@ -401,7 +401,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
                                             it->first + "." + s.field);
 
         llvm::Value *updatedStruct = builder_.CreateInsertValue(
-            curStruct, newFieldVal, fieldIdx, "elem_struct_upd");
+            curStruct, newFieldVal, static_cast<unsigned>(fieldIdx), "elem_struct_upd");
         builder_.CreateStore(updatedStruct, elemSlot);
         emitInvariantCheck(it->first, info, updatedStruct);
         return;
@@ -537,7 +537,7 @@ void CodeGen::emitStmt(TupleDestructStmt &s) {
         // Redeclaration check (consistent with emitVarDecl)
         if (scope_stack_.back().count(s.names[i]))
             codegenError("variable '" + s.names[i] + "' already declared in this scope");
-        llvm::Value *elem = builder_.CreateExtractValue(tupleVal, i);
+        llvm::Value *elem = builder_.CreateExtractValue(tupleVal, static_cast<unsigned>(i));
         llvm::AllocaInst *ptr = getOrCreateVar(s.names[i], elem->getType());
         builder_.CreateStore(elem, ptr);
         if (s.is_immutable)

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -13,7 +13,7 @@ namespace ry {
 
 void CodeGen::emitOutlinePrintf(const std::string &label, llvm::Value *nameVal) {
     auto printfFn = getStdlibPrintf();
-    std::string indent(outline_depth_ * 2, ' ');
+    std::string indent(static_cast<size_t>(outline_depth_ * 2), ' ');
     llvm::Value *fmt = cachedGlobalString(indent + label, ".outline_fmt");
     if (nameVal)
         builder_.CreateCall(printfFn, {fmt, nameVal});
@@ -154,7 +154,7 @@ static void parseFormatPlaceholders(const std::string &fmtStr,
         if (fmtStr[i] == '{' && i + 2 < fmtStr.size() && fmtStr[i+2] == '}' &&
             fmtStr[i+1] >= '0' && fmtStr[i+1] <= '9') {
             cFmt += "%s";
-            fieldOrder.push_back(fmtStr[i+1] - '0');
+            fieldOrder.push_back(static_cast<unsigned>(fmtStr[i+1] - '0'));
             i += 2;
         } else if (fmtStr[i] == '%') {
             cFmt += "%%";
@@ -407,7 +407,7 @@ void CodeGen::emitPropertyItLoop(llvm::Function *testFunc, llvm::Value *descVal,
     builder_.CreateBr(condBB);
     builder_.SetInsertPoint(condBB);
     llvm::Value *iVal = builder_.CreateLoad(i64Ty_, iAlloca, "i");
-    llvm::Value *cond = builder_.CreateICmpSLT(iVal, llvm::ConstantInt::get(i64Ty_, count), "prop_cond");
+    llvm::Value *cond = builder_.CreateICmpSLT(iVal, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(count)), "prop_cond");
     builder_.CreateCondBr(cond, bodyBB, endBB);
 
     builder_.SetInsertPoint(bodyBB);
@@ -1178,7 +1178,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         expectedStr = cachedGlobalString("None", ".exp_none");
     }
 
-    builder_.CreateCall(failFn, {llvm::ConstantInt::get(i32Ty_, s.loc.line), actualStr, expectedStr});
+    builder_.CreateCall(failFn, {llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(s.loc.line)), actualStr, expectedStr});
     builder_.CreateBr(contBB);
 
     // Continue block
@@ -1209,7 +1209,7 @@ void CodeGen::emitFailCall(CallStmt &s) {
         msg = fail_empty_msg_;
     }
 
-    builder_.CreateCall(failFn, {llvm::ConstantInt::get(i32Ty_, s.loc.line), msg});
+    builder_.CreateCall(failFn, {llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(s.loc.line)), msg});
 }
 
 } // namespace ry

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -23,14 +23,14 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
                 if (einfo.hasExplicitValues) {
                     llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "vts.enum.merge", fn_);
                     llvm::BasicBlock *defaultBB = llvm::BasicBlock::Create(*ctx_, "vts.enum.default", fn_);
-                    auto *sw = builder_.CreateSwitch(val, defaultBB, einfo.variantCount);
+                    auto *sw = builder_.CreateSwitch(val, defaultBB, static_cast<unsigned>(einfo.variantCount));
                     builder_.SetInsertPoint(mergeBB);
-                    auto *namePhi = builder_.CreatePHI(ptrTy_, einfo.variantCount + 1, "vts.enum.name");
+                    auto *namePhi = builder_.CreatePHI(ptrTy_, static_cast<unsigned>(einfo.variantCount + 1), "vts.enum.name");
                     for (size_t i = 0; i < einfo.variantOrder.size(); ++i) {
                         const auto &vname = einfo.variantOrder[i];
                         int64_t vval = einfo.variants.at(vname);
                         llvm::BasicBlock *caseBB = llvm::BasicBlock::Create(*ctx_, "vts.enum." + vname, fn_);
-                        sw->addCase(llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, vval, true)), caseBB);
+                        sw->addCase(llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(vval))), caseBB);
                         builder_.SetInsertPoint(caseBB);
                         llvm::Value *namePtr = builder_.CreateGEP(
                             llvm::ArrayType::get(ptrTy_, einfo.variantCount),
@@ -79,12 +79,12 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
             if (anyFields) {
                 llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "vts.adt.end", fn_);
                 llvm::BasicBlock *defaultBB = llvm::BasicBlock::Create(*ctx_, "vts.adt.default", fn_);
-                auto *switchInst = builder_.CreateSwitch(tag, defaultBB, einfo.variantCount);
+                auto *switchInst = builder_.CreateSwitch(tag, defaultBB, static_cast<unsigned>(einfo.variantCount));
 
                 for (auto &[vname, vtag] : einfo.variants) {
                     llvm::BasicBlock *caseBB = llvm::BasicBlock::Create(*ctx_, "vts.adt." + vname, fn_);
                     switchInst->addCase(
-                        llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, vtag)), caseBB);
+                        llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(vtag))), caseBB);
                     builder_.SetInsertPoint(caseBB);
 
                     auto fit = einfo.variantFields.find(vname);
@@ -168,14 +168,14 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
 
             llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "vts.union.merge", fn_);
             llvm::BasicBlock *defaultBB = llvm::BasicBlock::Create(*ctx_, "vts.union.default", fn_);
-            llvm::SwitchInst *sw = builder_.CreateSwitch(tag, defaultBB, uinfo.componentTypes.size());
+            llvm::SwitchInst *sw = builder_.CreateSwitch(tag, defaultBB, static_cast<unsigned>(uinfo.componentTypes.size()));
 
             builder_.SetInsertPoint(defaultBB);
             llvm::Constant *unknownStr = cachedGlobalString("?", ".vts_union_unknown");
             builder_.CreateBr(mergeBB);
 
             builder_.SetInsertPoint(mergeBB);
-            auto *phi = builder_.CreatePHI(ptrTy_, uinfo.componentTypes.size() + 1, "vts.union.str");
+            auto *phi = builder_.CreatePHI(ptrTy_, static_cast<unsigned>(uinfo.componentTypes.size() + 1), "vts.union.str");
             phi->addIncoming(unknownStr, defaultBB);
 
             for (size_t i = 0; i < uinfo.componentTypes.size(); ++i) {

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -598,7 +598,7 @@ void CodeGen::emitConstraintCheck(llvm::Value *val, const TypeConstraint &constr
         llvm::Value *anyMatch = llvm::ConstantInt::get(i1Ty_, 0);
         for (int64_t allowed : constraint.int_values) {
             llvm::Value *cmp = builder_.CreateICmpEQ(
-                val, llvm::ConstantInt::get(i64Ty_, allowed), "lit_cmp");
+                val, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(allowed)), "lit_cmp");
             anyMatch = builder_.CreateOr(anyMatch, cmp, "lit_or");
         }
         llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "constraint.ok", fn_);
@@ -624,9 +624,9 @@ void CodeGen::emitConstraintCheck(llvm::Value *val, const TypeConstraint &constr
         }
         // Runtime check: low <= val <= high
         llvm::Value *geLow = builder_.CreateICmpSGE(
-            val, llvm::ConstantInt::get(i64Ty_, constraint.range_low), "range_ge");
+            val, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(constraint.range_low)), "range_ge");
         llvm::Value *leHigh = builder_.CreateICmpSLE(
-            val, llvm::ConstantInt::get(i64Ty_, constraint.range_high), "range_le");
+            val, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(constraint.range_high)), "range_le");
         llvm::Value *inRange = builder_.CreateAnd(geLow, leHigh, "in_range");
         llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "constraint.ok", fn_);
         llvm::BasicBlock *failBB = llvm::BasicBlock::Create(*ctx_, "constraint.fail", fn_);
@@ -638,7 +638,7 @@ void CodeGen::emitConstraintCheck(llvm::Value *val, const TypeConstraint &constr
 
     } else if (constraint.kind == TypeConstraint::Kind::StrLiteral) {
         // Compile-time check: if the value is a global string constant, check it
-        if (auto *constExpr = llvm::dyn_cast<llvm::ConstantExpr>(val)) {
+        if (llvm::isa<llvm::ConstantExpr>(val)) {
             // Can't easily extract string from ConstantExpr, fall through to runtime
         }
         // For string literals, we need runtime strcmp checks

--- a/src/diagnostic.cpp
+++ b/src/diagnostic.cpp
@@ -26,7 +26,7 @@ std::string formatDiagnostic(const Diagnostic &diag, const SourceManager *sm) {
     auto srcLine = sm->getLine(diag.loc.file_id, diag.loc.line);
 
     int lineNum = diag.loc.line;
-    int lineWidth = 1;
+    size_t lineWidth = 1;
     {
         int n = lineNum;
         while (n >= 10) { n /= 10; ++lineWidth; }
@@ -43,7 +43,7 @@ std::string formatDiagnostic(const Diagnostic &diag, const SourceManager *sm) {
 
     if (diag.loc.col > 0) {
         // Replicate whitespace from the source line for alignment
-        for (int i = 0; i < diag.loc.col - 1 && i < static_cast<int>(srcLine.size()); ++i) {
+        for (size_t i = 0; i < static_cast<size_t>(diag.loc.col - 1) && i < srcLine.size(); ++i) {
             os << (srcLine[i] == '\t' ? '\t' : ' ');
         }
         os << "^";

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -80,7 +80,7 @@ std::vector<Comment> Formatter::extractComments(const std::string &source) {
 
 void Formatter::emit(const std::string &s) { out_ += s; }
 void Formatter::emitIndent() {
-    out_.append(indent_level_ * indent_width_, ' ');
+    out_.append(static_cast<size_t>(indent_level_) * static_cast<size_t>(indent_width_), ' ');
 }
 void Formatter::emitNewline() { out_ += '\n'; }
 void Formatter::indent() { ++indent_level_; }
@@ -308,7 +308,7 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CastExpr>>) {
             return formatExpr(*v->value) + " as " + v->target_type->toString();
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondExpr>>) {
-            std::string indent((indent_level_ + 1) * indent_width_, ' ');
+            std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
             std::string out = "case:\n";
             for (const auto &arm : v->arms) {
                 out += indent + formatExpr(*arm.condition) + " => " + formatExpr(*arm.value) + "\n";
@@ -316,7 +316,7 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
             out += indent + "_ => " + formatExpr(*v->else_expr);
             return out;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseExpr>>) {
-            std::string indent((indent_level_ + 1) * indent_width_, ' ');
+            std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
             std::string out = "case " + formatExpr(*v->subject) + ":\n";
             for (size_t i = 0; i < v->arms.size(); ++i) {
                 const auto &arm = v->arms[i];
@@ -332,7 +332,7 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
             return "if " + formatExpr(*v->condition) + " => "
                  + formatExpr(*v->then_value) + " else " + formatExpr(*v->else_value);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
-            std::string indent((indent_level_ + 1) * indent_width_, ' ');
+            std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
             std::string out = "if " + formatExpr(*v->condition) + ":\n";
             for (size_t i = 0; i < v->then_body.size(); ++i) {
                 out += indent;

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -59,8 +59,8 @@ void resetCoverageState(CoverageState &cs) {
 
 void emitCoverageReport(const CoverageState &cs) {
     if (cs.file_count <= 0) return;
-    std::vector<const char*> ptrs(cs.file_count);
-    for (int i = 0; i < cs.file_count; ++i)
+    std::vector<const char*> ptrs(static_cast<size_t>(cs.file_count));
+    for (size_t i = 0; i < static_cast<size_t>(cs.file_count); ++i)
         ptrs[i] = cs.filenames[i].c_str();
     __ry_coverage_report_summary(ptrs.data(), cs.file_count);
 }
@@ -351,9 +351,9 @@ int runRySource(const std::string &src, const std::string &source_name,
             std::string canonical_share;
             if (!share_dir.empty())
                 canonical_share = fs::weakly_canonical(share_dir).string();
-            cs->filenames.resize(new_total);
+            cs->filenames.resize(static_cast<size_t>(new_total));
             for (int i = 0; i < fc; ++i) {
-                int gid = cs->file_id_offset + i;
+                size_t gid = static_cast<size_t>(cs->file_id_offset + i);
                 const std::string &fname = sm.getFilename(i);
                 bool is_stdlib = false;
                 if (!canonical_share.empty()) {

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -87,10 +87,11 @@ static void repeatStr(RyAny *result, const char *s, int64_t n) {
         fprintf(stderr, "runtime error: string repeat overflow\n");
         exit(1);
     }
-    char *buf = static_cast<char *>(checked_malloc(len * n + 1));
-    for (int64_t i = 0; i < n; i++)
+    size_t count = static_cast<size_t>(n);
+    char *buf = static_cast<char *>(checked_malloc(len * count + 1));
+    for (size_t i = 0; i < count; i++)
         memcpy(buf + i * len, s, len);
-    buf[len * n] = '\0';
+    buf[len * count] = '\0';
     makeStr(result, buf);
 }
 

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -175,8 +175,8 @@ extern "C" void *__ry_read_bytes(const char *path) {
     fseek(f, 0, SEEK_SET);
 
     auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
-    header->data = (int8_t *)checked_malloc(size);
-    size_t nread = fread(header->data, 1, size, f);
+    header->data = (int8_t *)checked_malloc(static_cast<size_t>(size));
+    size_t nread = fread(header->data, 1, static_cast<size_t>(size), f);
     header->len = (int64_t)nread;
     header->cap = (int64_t)nread;
     fclose(f);
@@ -190,7 +190,7 @@ extern "C" int64_t __ry_write_bytes(const char *path, void *list) {
         setLastError("cannot open file '%s' for writing", path);
         return 1;
     }
-    size_t written = fwrite(header->data, 1, header->len, f);
+    size_t written = fwrite(header->data, 1, static_cast<size_t>(header->len), f);
     fclose(f);
     if ((int64_t)written != header->len) {
         setLastError("failed to write all bytes to '%s'", path);
@@ -214,8 +214,8 @@ extern "C" const char *__ry_bytes_to_str(void *list) {
             return nullptr;
         }
     }
-    char *buf = (char *)checked_malloc(header->len + 1);
-    memcpy(buf, header->data, header->len);
+    char *buf = (char *)checked_malloc(static_cast<size_t>(header->len) + 1);
+    memcpy(buf, header->data, static_cast<size_t>(header->len));
     buf[header->len] = '\0';
     return buf;
 }

--- a/src/runtime_json.cpp
+++ b/src/runtime_json.cpp
@@ -19,6 +19,10 @@ namespace ry {
 
 enum class JsonType { Null, Bool, Int, Float, String, Array, Object };
 
+struct JsonValue;
+struct JsonArrayVal { JsonValue **items; int64_t len; };
+struct JsonObjectVal { char **keys; JsonValue **values; int64_t len; };
+
 struct JsonValue {
     JsonType type;
     union {
@@ -26,8 +30,8 @@ struct JsonValue {
         int64_t int_val;
         double float_val;
         char *string_val;
-        struct { JsonValue **items; int64_t len; } array_val;
-        struct { char **keys; JsonValue **values; int64_t len; } object_val;
+        JsonArrayVal array_val;
+        JsonObjectVal object_val;
     };
 };
 
@@ -493,7 +497,7 @@ static void escape_string(const char *s, std::string &out) {
 }
 
 static void stringify_value(const JsonValue *v, std::string &out,
-                            int indent, int depth, bool pretty) {
+                            size_t indent, size_t depth, bool pretty) {
     if (!v) { out += "null"; return; }
     switch (v->type) {
         case JsonType::Null: out += "null"; break;
@@ -594,7 +598,7 @@ const char *__ry_json_stringify_pretty(void *value, int64_t indent) {
     if (indent < 0) {
         stringify_value(v, out, 0, 0, false);
     } else {
-        stringify_value(v, out, (int)indent, 0, true);
+        stringify_value(v, out, static_cast<size_t>(indent), 0, true);
     }
     return checked_memdup(out.data(), out.size());
 }

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -572,8 +572,8 @@ private:
     static bool charInRange(char c, char lo, char hi, bool caseInsensitive) {
         if (c >= lo && c <= hi) return true;
         if (caseInsensitive) {
-            char cl = std::tolower((unsigned char)c);
-            char cu = std::toupper((unsigned char)c);
+            char cl = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+            char cu = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
             return (cl >= lo && cl <= hi) || (cu >= lo && cu <= hi);
         }
         return false;

--- a/src/runtime_sort.cpp
+++ b/src/runtime_sort.cpp
@@ -24,7 +24,7 @@ static int64_t computeMinRun(int64_t n) {
 using CmpFn = bool (*)(const void *, const void *, void *);
 
 static inline void elemCopy(void *dst, const void *src, int64_t elemSize) {
-    memcpy(dst, src, elemSize);
+    memcpy(dst, src, static_cast<size_t>(elemSize));
 }
 
 static inline void *elemAt(void *data, int64_t index, int64_t elemSize) {
@@ -34,7 +34,7 @@ static inline void *elemAt(void *data, int64_t index, int64_t elemSize) {
 
 static void reverseRange(void *data, int64_t lo, int64_t hi, int64_t elemSize) {
     char tmp[256];
-    void *tmpBuf = elemSize <= (int64_t)sizeof(tmp) ? tmp : checked_malloc(elemSize);
+    void *tmpBuf = elemSize <= (int64_t)sizeof(tmp) ? tmp : checked_malloc(static_cast<size_t>(elemSize));
     int64_t left = lo, right = hi - 1;
     while (left < right) {
         elemCopy(tmpBuf, elemAt(data, left, elemSize), elemSize);
@@ -51,7 +51,7 @@ static void binaryInsertionSort(void *data, int64_t lo, int64_t hi,
                                  int64_t start, int64_t elemSize,
                                  CmpFn cmp, void *ctx) {
     char tmp[256];
-    void *tmpBuf = elemSize <= (int64_t)sizeof(tmp) ? tmp : checked_malloc(elemSize);
+    void *tmpBuf = elemSize <= (int64_t)sizeof(tmp) ? tmp : checked_malloc(static_cast<size_t>(elemSize));
 
     for (int64_t i = start; i < hi; i++) {
         elemCopy(tmpBuf, elemAt(data, i, elemSize), elemSize);

--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -18,9 +18,9 @@ static int utf8_char_len_nul(const char *s) {
     unsigned char c = static_cast<unsigned char>(s[0]);
     if (c == 0) return 0;
     if (c < 0x80) return 1;
-    if ((c & 0xE0) == 0xC0 && is_cont(s[1])) return 2;
-    if ((c & 0xF0) == 0xE0 && is_cont(s[1]) && is_cont(s[2])) return 3;
-    if ((c & 0xF8) == 0xF0 && is_cont(s[1]) && is_cont(s[2]) && is_cont(s[3])) return 4;
+    if ((c & 0xE0) == 0xC0 && is_cont(static_cast<unsigned char>(s[1]))) return 2;
+    if ((c & 0xF0) == 0xE0 && is_cont(static_cast<unsigned char>(s[1])) && is_cont(static_cast<unsigned char>(s[2]))) return 3;
+    if ((c & 0xF8) == 0xF0 && is_cont(static_cast<unsigned char>(s[1])) && is_cont(static_cast<unsigned char>(s[2])) && is_cont(static_cast<unsigned char>(s[3]))) return 4;
     return 1; // invalid/truncated byte treated as 1
 }
 
@@ -38,7 +38,7 @@ int64_t __ry_utf8_len(const char *s) {
 char *__ry_utf8_char_at(const char *s, int64_t i) {
     const char *p = s;
     for (int64_t idx = 0; *p; ++idx) {
-        int len = utf8_char_len_nul(p);
+        size_t len = static_cast<size_t>(utf8_char_len_nul(p));
         if (idx == i) {
             char *buf = static_cast<char *>(checked_malloc(len + 1));
             memcpy(buf, p, len);
@@ -59,7 +59,7 @@ char *__ry_utf8_char_at_checked(const char *s, int64_t i) {
         // Positive index: single forward scan, stop at target — O(i).
         int64_t idx = 0;
         while (*p) {
-            int len = utf8_char_len_nul(p);
+            size_t len = static_cast<size_t>(utf8_char_len_nul(p));
             if (idx == i) {
                 char *buf = static_cast<char *>(checked_malloc(len + 1));
                 memcpy(buf, p, len);
@@ -96,7 +96,7 @@ char *__ry_utf8_char_at_checked(const char *s, int64_t i) {
     for (int64_t idx = 0; idx < resolved; ++idx)
         p += utf8_char_len_nul(p);
 
-    int len = utf8_char_len_nul(p);
+    size_t len = static_cast<size_t>(utf8_char_len_nul(p));
     char *buf = static_cast<char *>(checked_malloc(len + 1));
     memcpy(buf, p, len);
     buf[len] = '\0';
@@ -119,7 +119,7 @@ char *__ry_utf8_substring(const char *s, int64_t start, int64_t endIdx) {
     if (!endPtr) endPtr = p;
     if (!startPtr) startPtr = endPtr;
 
-    size_t byteLen = endPtr - startPtr;
+    size_t byteLen = static_cast<size_t>(endPtr - startPtr);
     char *buf = static_cast<char *>(checked_malloc(byteLen + 1));
     memcpy(buf, startPtr, byteLen);
     buf[byteLen] = '\0';
@@ -132,7 +132,7 @@ char *__ry_utf8_reverse(const char *s) {
     char *buf = static_cast<char *>(checked_malloc(totalBytes + 1));
 
     // First pass: collect codepoint boundaries
-    struct CPInfo { const char *ptr; int len; };
+    struct CPInfo { const char *ptr; size_t len; };
     size_t capacity = 64;
     size_t count = 0;
     CPInfo *cps = static_cast<CPInfo *>(checked_array_malloc(capacity, sizeof(CPInfo)));
@@ -143,7 +143,7 @@ char *__ry_utf8_reverse(const char *s) {
             capacity *= 2;
             cps = static_cast<CPInfo *>(checked_array_realloc(cps, capacity, sizeof(CPInfo)));
         }
-        int len = utf8_char_len_nul(p);
+        size_t len = static_cast<size_t>(utf8_char_len_nul(p));
         cps[count++] = {p, len};
         p += len;
     }
@@ -182,12 +182,12 @@ void *__ry_split_chars(const char *s) {
     auto *header = (ListHeader *)checked_malloc(sizeof(ListHeader));
     header->len = count;
     header->cap = count;
-    header->data = (char **)checked_array_malloc(count ? count : 1, sizeof(char *));
+    header->data = (char **)checked_array_malloc(count ? static_cast<size_t>(count) : 1, sizeof(char *));
 
     // Second pass: populate string array
     const char *p = s;
     for (int64_t i = 0; i < count; ++i) {
-        int len = utf8_char_len_nul(p);
+        size_t len = static_cast<size_t>(utf8_char_len_nul(p));
         header->data[i] = dupString(p, len);
         p += len;
     }

--- a/src/self_update.cpp
+++ b/src/self_update.cpp
@@ -135,7 +135,7 @@ int run_command(const std::vector<std::string> &args, std::string *output) {
         char buf[4096];
         ssize_t n;
         while ((n = read(pipefd[0], buf, sizeof(buf))) > 0) {
-            output->append(buf, n);
+            output->append(buf, static_cast<size_t>(n));
         }
         close(pipefd[0]);
     }
@@ -340,13 +340,13 @@ std::string base64_decode(const std::string &input) {
     }
     if (cleaned.empty()) return "";
 
-    int max_len = 3 * ((int)cleaned.size() + 3) / 4;
+    size_t max_len = 3 * (cleaned.size() + 3) / 4;
     std::string output(max_len, '\0');
 
     int decoded_len = EVP_DecodeBlock(
         reinterpret_cast<unsigned char *>(&output[0]),
         reinterpret_cast<const unsigned char *>(cleaned.data()),
-        (int)cleaned.size());
+        static_cast<int>(cleaned.size()));
 
     if (decoded_len < 0) return "";
 
@@ -356,7 +356,7 @@ std::string base64_decode(const std::string &input) {
     if (cleaned.size() >= 2 && cleaned[cleaned.size() - 2] == '=') padding++;
 
     if (decoded_len < padding) return "";
-    output.resize(decoded_len - padding);
+    output.resize(static_cast<size_t>(decoded_len - padding));
     return output;
 }
 

--- a/src/source_manager.cpp
+++ b/src/source_manager.cpp
@@ -24,16 +24,16 @@ int SourceManager::addSource(std::string filename, std::string content) {
 }
 
 std::string_view SourceManager::getLine(int fileId, int line) const {
-    if (fileId < 0 || fileId >= static_cast<int>(files_.size()))
+    if (fileId < 0 || static_cast<size_t>(fileId) >= files_.size())
         return "";
-    const auto &sf = files_[fileId];
+    const auto &sf = files_[static_cast<size_t>(fileId)];
     int idx = line - 1;
-    if (idx < 0 || idx >= static_cast<int>(sf.lineOffsets.size()))
+    if (idx < 0 || static_cast<size_t>(idx) >= sf.lineOffsets.size())
         return "";
-    size_t start = sf.lineOffsets[idx];
+    size_t start = sf.lineOffsets[static_cast<size_t>(idx)];
     size_t end;
-    if (idx + 1 < static_cast<int>(sf.lineOffsets.size())) {
-        end = sf.lineOffsets[idx + 1];
+    if (static_cast<size_t>(idx + 1) < sf.lineOffsets.size()) {
+        end = sf.lineOffsets[static_cast<size_t>(idx + 1)];
     } else {
         end = sf.content.size();
     }
@@ -45,9 +45,9 @@ std::string_view SourceManager::getLine(int fileId, int line) const {
 
 const std::string& SourceManager::getFilename(int fileId) const {
     static const std::string empty;
-    if (fileId < 0 || fileId >= static_cast<int>(files_.size()))
+    if (fileId < 0 || static_cast<size_t>(fileId) >= files_.size())
         return empty;
-    return files_[fileId].filename;
+    return files_[static_cast<size_t>(fileId)].filename;
 }
 
 } // namespace ry

--- a/src/stdlib_registry.cpp
+++ b/src/stdlib_registry.cpp
@@ -60,9 +60,9 @@ int ResourceKindRegistry::lookupByTypeName(const std::string &typeName) const {
 }
 
 const ResourceKindRegistry::Info *ResourceKindRegistry::getInfo(int id) const {
-    if (id < 0 || id >= static_cast<int>(entries_.size()))
+    if (id < 0 || static_cast<size_t>(id) >= entries_.size())
         return nullptr;
-    return &entries_[id];
+    return &entries_[static_cast<size_t>(id)];
 }
 
 } // namespace ry

--- a/src/test_runner.cpp
+++ b/src/test_runner.cpp
@@ -134,7 +134,7 @@ static TestFileResult runTestFileSubprocess(const std::string &filepath,
     char buf[4096];
     ssize_t n;
     while ((n = read(pipefd[0], buf, sizeof(buf))) > 0 || (n == -1 && errno == EINTR)) {
-        if (n > 0) result.output.append(buf, n);
+        if (n > 0) result.output.append(buf, static_cast<size_t>(n));
     }
     close(pipefd[0]);
 
@@ -158,12 +158,12 @@ static TestFileResult runTestFileSubprocess(const std::string &filepath,
 
 static int runTestFilesParallel(const std::vector<std::string> &test_files,
                                 const std::string &exe_path, int parallelism) {
-    int num_files = static_cast<int>(test_files.size());
+    size_t num_files = test_files.size();
     std::vector<TestFileResult> results(num_files);
 
     // Work queue: indices into test_files
-    std::deque<int> work_queue;
-    for (int i = 0; i < num_files; ++i)
+    std::deque<size_t> work_queue;
+    for (size_t i = 0; i < num_files; ++i)
         work_queue.push_back(i);
 
     std::mutex queue_mutex;
@@ -172,7 +172,7 @@ static int runTestFilesParallel(const std::vector<std::string> &test_files,
 
     auto worker = [&]() {
         while (true) {
-            int idx;
+            size_t idx;
             {
                 std::lock_guard<std::mutex> lock(queue_mutex);
                 if (work_queue.empty()) return;
@@ -183,18 +183,18 @@ static int runTestFilesParallel(const std::vector<std::string> &test_files,
             {
                 std::lock_guard<std::mutex> lock(progress_mutex);
                 ++completed;
-                std::fprintf(stderr, "\r\033[K[%d/%d] Running tests...",
+                std::fprintf(stderr, "\r\033[K[%d/%zu] Running tests...",
                              completed, num_files);
             }
         }
     };
 
-    int num_workers = std::min(parallelism, num_files);
+    size_t num_workers = std::min(static_cast<size_t>(parallelism), num_files);
     std::vector<std::thread> threads;
     threads.reserve(num_workers);
 
     auto wall_start = std::chrono::steady_clock::now();
-    for (int i = 0; i < num_workers; ++i)
+    for (size_t i = 0; i < num_workers; ++i)
         threads.emplace_back(worker);
     for (auto &t : threads)
         t.join();
@@ -210,7 +210,7 @@ static int runTestFilesParallel(const std::vector<std::string> &test_files,
             ++total_failed;
     }
 
-    std::printf("\n%d test files executed, %d total failures (%.2fs, %d workers)\n",
+    std::printf("\n%zu test files executed, %d total failures (%.2fs, %zu workers)\n",
                 num_files, total_failed, wall_elapsed, num_workers);
     return total_failed > 0 ? 1 : 0;
 }

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -152,7 +152,7 @@ const char *__ry_test_rand_str() {
     std::uniform_int_distribution<int> charDist(32, 126); // printable ASCII
     auto &rng = getRng();
     int len = lenDist(rng);
-    char *buf = static_cast<char*>(checked_malloc(len + 1));
+    char *buf = static_cast<char*>(checked_malloc(static_cast<size_t>(len) + 1));
     for (int i = 0; i < len; ++i)
         buf[i] = static_cast<char>(charDist(rng));
     buf[len] = '\0';

--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -107,7 +107,8 @@ private:
     static std::string escapeJson(const std::string &value) {
         std::string out;
         out.reserve(value.size() + 8);
-        for (unsigned char c : value) {
+        for (char ch : value) {
+            unsigned char c = static_cast<unsigned char>(ch);
             switch (c) {
                 case '\\': out += "\\\\"; break;
                 case '"': out += "\\\""; break;
@@ -121,7 +122,7 @@ private:
                         out += hex[(c >> 4) & 0x0f];
                         out += hex[c & 0x0f];
                     } else {
-                        out += static_cast<char>(c);
+                        out += ch;
                     }
             }
         }

--- a/tests/test_builtin_stdlib_registry.cpp
+++ b/tests/test_builtin_stdlib_registry.cpp
@@ -49,9 +49,9 @@ TEST(BuiltinStdlibRegistry, DeclarationFilesExist) {
 TEST(BuiltinStdlibRegistry, NetDispatchedBeforeHttp) {
     auto &pkgs = StdlibRegistry::instance().packages();
     int net_idx = -1, http_idx = -1;
-    for (int i = 0; i < static_cast<int>(pkgs.size()); ++i) {
-        if (std::string(pkgs[i].package_name) == "net") net_idx = i;
-        if (std::string(pkgs[i].package_name) == "http") http_idx = i;
+    for (size_t i = 0; i < pkgs.size(); ++i) {
+        if (std::string(pkgs[i].package_name) == "net") net_idx = static_cast<int>(i);
+        if (std::string(pkgs[i].package_name) == "http") http_idx = static_cast<int>(i);
     }
     ASSERT_NE(net_idx, -1) << "net package not registered";
     ASSERT_NE(http_idx, -1) << "http package not registered";

--- a/tests/test_codegen_arc.cpp
+++ b/tests/test_codegen_arc.cpp
@@ -24,7 +24,7 @@ static_assert(offsetof(ArcHeader, weak_count) == 8, "weak_count at offset 8");
 
 // Simulate arc_alloc: malloc(ARC_HEADER_SIZE + dataSize), init counts
 void *arcAlloc(int64_t dataSize) {
-    void *p = std::malloc(static_cast<size_t>(ARC_HEADER_SIZE + dataSize));
+    void *p = std::malloc(static_cast<size_t>(ARC_HEADER_SIZE) + static_cast<size_t>(dataSize));
     auto *hdr = static_cast<ArcHeader *>(p);
     hdr->strong_count = 1;
     hdr->weak_count = 0;

--- a/tests/test_entry_point.cpp
+++ b/tests/test_entry_point.cpp
@@ -62,7 +62,7 @@ static std::pair<std::string, int> runRyInDir(
     std::array<char, 4096> buf;
     ssize_t n;
     while ((n = read(pipeOut[0], buf.data(), buf.size())) > 0) {
-        output.append(buf.data(), n);
+        output.append(buf.data(), static_cast<size_t>(n));
     }
     close(pipeOut[0]);
 

--- a/tests/test_help.cpp
+++ b/tests/test_help.cpp
@@ -51,7 +51,7 @@ static RunResult runRy(std::initializer_list<const char *> args) {
         std::array<char, 4096> buf;
         ssize_t n;
         while ((n = read(fd, buf.data(), buf.size())) > 0)
-            result.append(buf.data(), n);
+            result.append(buf.data(), static_cast<size_t>(n));
         close(fd);
         return result;
     };
@@ -193,7 +193,7 @@ TEST(HelpOption, StdinPipeStillWorks) {
     std::array<char, 4096> buf;
     ssize_t n;
     while ((n = read(pipeOut[0], buf.data(), buf.size())) > 0)
-        output.append(buf.data(), n);
+        output.append(buf.data(), static_cast<size_t>(n));
     close(pipeOut[0]);
 
     int status;

--- a/tests/test_runtime_gc.cpp
+++ b/tests/test_runtime_gc.cpp
@@ -64,13 +64,13 @@ struct PairNodeData {
     void *child_b;
 };
 
-void visitPairNode(void *data, void (*visitor)(void *child_header)) {
+[[maybe_unused]] void visitPairNode(void *data, void (*visitor)(void *child_header)) {
     auto *node = static_cast<PairNodeData *>(data);
     if (node->child_a) visitor(node->child_a);
     if (node->child_b) visitor(node->child_b);
 }
 
-void dtorPairNode(void *data) {
+[[maybe_unused]] void dtorPairNode(void *data) {
     auto *node = static_cast<PairNodeData *>(data);
     node->child_a = nullptr;
     node->child_b = nullptr;

--- a/tests/test_stdin.cpp
+++ b/tests/test_stdin.cpp
@@ -44,7 +44,7 @@ static std::pair<std::string, int> runRyStdin(const std::string &code) {
     std::array<char, 4096> buf;
     ssize_t n;
     while ((n = read(pipeOut[0], buf.data(), buf.size())) > 0) {
-        output.append(buf.data(), n);
+        output.append(buf.data(), static_cast<size_t>(n));
     }
     close(pipeOut[0]);
 
@@ -120,7 +120,7 @@ TEST(StdinExecution, FileExecutionStillWorks) {
     std::array<char, 4096> buf;
     ssize_t n;
     while ((n = read(pipeOut[0], buf.data(), buf.size())) > 0) {
-        output.append(buf.data(), n);
+        output.append(buf.data(), static_cast<size_t>(n));
     }
     close(pipeOut[0]);
 

--- a/tests/test_trace.cpp
+++ b/tests/test_trace.cpp
@@ -79,7 +79,7 @@ static TraceRunResult runRy(const std::vector<std::string> &args,
             if (fds[i].revents & (POLLIN | POLLHUP)) {
                 ssize_t n = read(fds[i].fd, buf.data(), buf.size());
                 if (n > 0) {
-                    (i == 0 ? out : err).append(buf.data(), n);
+                    (i == 0 ? out : err).append(buf.data(), static_cast<size_t>(n));
                 } else {
                     close(fds[i].fd);
                     fds[i].fd = -1;


### PR DESCRIPTION
## Summary

Closes #895

- Add `-Wall -Wextra -Wpedantic -Wconversion -Wshadow` to all internal build targets (`ry_lib`, `ry`, `ry_tests`, native shared libraries)
- Fix all 239 existing warnings across 51 source files
- Mark LLVM and GoogleTest headers as `SYSTEM` includes to suppress third-party warnings
- Bump `cmake_minimum_required` from 3.20 to 3.25 (for `FetchContent_Declare(... SYSTEM)`)

### CMake changes

- New `RY_WARNING_FLAGS` variable applied per-target via `target_compile_options(PRIVATE)` — does not leak into FetchContent targets
- Replace global `include_directories(${LLVM_INCLUDE_DIRS})` with `target_include_directories(ry_lib SYSTEM PUBLIC ${LLVM_INCLUDE_DIRS})`
- Add `SYSTEM` keyword to `FetchContent_Declare(googletest ...)`
- Warning flags automatically applied to native libs via `add_ry_native_lib()`

### Warning fixes by category

| Category | Count | Fix |
|---------|-------|-----|
| `-Wsign-conversion` | 188 | `static_cast<uint64_t/size_t/unsigned>()` or type changes |
| `-Wshorten-64-to-32` | 37 | `static_cast<unsigned>()` for LLVM API calls |
| `-Wunused-but-set-variable` | 4 | Remove unused variables |
| `-Wunused-variable` | 2 | Remove unused variables |
| `-Wunused-function` | 2 | Add `[[maybe_unused]]` |
| `-Wnested-anon-types` | 2 | Name the inner structs |
| `-Wimplicit-int-conversion` | 2 | `static_cast<char>()` |
| `-Wunused-parameter` | 1 | `(void)param;` |
| `-Wmissing-field-initializers` | 1 | Add missing `{}` |

### Documentation

- **AGENTS.md**: Added compiler warning flags section
- **KNOWLEDGE.md**: Added entry on SYSTEM includes for third-party headers

## Test plan

- [x] Release build: 0 warnings, 1601 C++ tests passed, 115 Ry self-tests passed
- [x] ASan+UBSan build: 0 warnings, 1600 C++ tests passed, 115 Ry self-tests passed
- [x] TSan build: 0 warnings, 1601 C++ tests passed, 115 Ry self-tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Configuration**
  * Raised minimum CMake to 3.25 and improved system-include handling.
  * Enabled unified strict warning flags for internal build targets.

* **Code Quality**
  * Improved numeric/type-safety across the codebase, reducing compiler warnings.
  * Cleaned up redundant/unused locals to tighten generated code.

* **Documentation**
  * Added guidance for consistent warning management and build practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->