### PR TITLE
ci: introduce Clang-Tidy static analysis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,55 @@
+---
+# Clang-Tidy configuration for ry (#893)
+#
+# Check selection rationale:
+#   bugprone-*      — common bug-prone patterns
+#   cert-*          — CERT C++ secure coding standards
+#   performance-*   — unnecessary copies, inefficient operations
+#   modernize-*     — selective modern C++ improvements
+#
+# Disabled checks and reasons:
+#   bugprone-easily-swappable-parameters  — noisy on codegen functions with many LLVM type params
+#   bugprone-reserved-identifier           — __ry_* runtime function naming is intentional
+#   bugprone-unchecked-optional-access    — false positives with custom optional patterns
+#   cert-dcl37-c     — alias of bugprone-reserved-identifier for C
+#   cert-dcl51-cpp   — alias of bugprone-reserved-identifier for C++
+#   cert-dcl50-cpp   — C-style variadic functions used intentionally in runtime error formatting
+#   cert-err58-cpp   — fires on static initializers (RY_REGISTER_STDLIB_PACKAGE, etc.)
+#   cert-dcl58-cpp   — fires on std namespace extensions in LLVM interop
+#   performance-enum-size    — enum base type sizing is often intentional (ABI, JIT layout)
+#   performance-no-int-to-ptr — incompatible with LLVM IR construction patterns
+#
+# WarningsAsErrors is empty initially; set to '*' once existing warnings are resolved.
+
+Checks: >
+  -*,
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-reserved-identifier,
+  -bugprone-unchecked-optional-access,
+  cert-*,
+  -cert-dcl37-c,
+  -cert-dcl51-cpp,
+  -cert-err58-cpp,
+  -cert-dcl50-cpp,
+  -cert-dcl58-cpp,
+  performance-*,
+  -performance-enum-size,
+  -performance-no-int-to-ptr,
+  modernize-use-override,
+  modernize-use-nullptr,
+  modernize-use-using,
+
+WarningsAsErrors: ''
+
+HeaderFilterRegex: 'include/ry/.*\.hpp$'
+
+FormatStyle: none
+
+CheckOptions:
+  - key: bugprone-argument-comment.StrictMode
+    value: '0'
+  - key: cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value: 'true'
+  - key: performance-move-const-arg.CheckTriviallyCopyableMove
+    value: 'false'

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,11 +9,13 @@
 #
 # Disabled checks and reasons:
 #   bugprone-easily-swappable-parameters  — noisy on codegen functions with many LLVM type params
+#   bugprone-multi-level-implicit-pointer-conversion — C-style void* casts of T** are idiomatic in runtime
 #   bugprone-reserved-identifier           — __ry_* runtime function naming is intentional
 #   bugprone-unchecked-optional-access    — false positives with custom optional patterns
 #   cert-dcl37-c     — alias of bugprone-reserved-identifier for C
 #   cert-dcl51-cpp   — alias of bugprone-reserved-identifier for C++
 #   cert-dcl50-cpp   — C-style variadic functions used intentionally in runtime error formatting
+#   cert-err33-c     — snprintf/vsnprintf return values are not meaningful in formatting-only contexts
 #   cert-err58-cpp   — fires on static initializers (RY_REGISTER_STDLIB_PACKAGE, etc.)
 #   cert-dcl58-cpp   — fires on std namespace extensions in LLVM interop
 #   performance-enum-size    — enum base type sizing is often intentional (ABI, JIT layout)
@@ -25,6 +27,7 @@ Checks: >
   -*,
   bugprone-*,
   -bugprone-easily-swappable-parameters,
+  -bugprone-multi-level-implicit-pointer-conversion,
   -bugprone-reserved-identifier,
   -bugprone-unchecked-optional-access,
   cert-*,
@@ -33,6 +36,7 @@ Checks: >
   -cert-err58-cpp,
   -cert-dcl50-cpp,
   -cert-dcl58-cpp,
+  -cert-err33-c,
   performance-*,
   -performance-enum-size,
   -performance-no-int-to-ptr,

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,12 +54,21 @@ jobs:
           sudo apt-get install -y clang-tidy-${MAJOR}
           sudo ln -sf /usr/bin/clang-tidy-${MAJOR} /usr/local/bin/clang-tidy
       - name: Install dependencies
-        run: sudo apt-get install -y libssl-dev ninja-build
-      - name: Configure
+        run: sudo apt-get install -y libssl-dev ninja-build libgtest-dev libgmock-dev
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ci-clang-tidy-${{ github.ref }}
+          restore-keys: |
+            ci-clang-tidy-
+          save: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}
+      - name: Build
         env:
           CC: /usr/local/llvm/bin/clang
           CXX: /usr/local/llvm/bin/clang++
-        run: cmake --preset default
+        run: |
+          cmake --preset default
+          cmake --build build
       - name: Run clang-tidy
         run: |
           find src -name '*.cpp' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,40 @@ jobs:
             exit 1
           fi
 
+  clang-tidy:
+    runs-on: ubuntu-24.04
+    continue-on-error: true  # Remove once existing warnings are resolved
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup LLVM
+        uses: ./.github/actions/setup-llvm
+        with:
+          llvm-version: ${{ env.LLVM_VERSION }}
+          sha256-short: ${{ env.LLVM_SHA256_SHORT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install clang-tidy
+        run: |
+          MAJOR="${LLVM_VERSION%%.*}"
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
+            | sudo gpg --dearmor -o /usr/share/keyrings/llvm.gpg
+          echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] \
+            http://apt.llvm.org/noble/ llvm-toolchain-noble-${MAJOR} main" \
+            | sudo tee /etc/apt/sources.list.d/llvm.list
+          sudo apt-get update
+          sudo apt-get install -y clang-tidy-${MAJOR}
+          sudo ln -sf /usr/bin/clang-tidy-${MAJOR} /usr/local/bin/clang-tidy
+      - name: Install dependencies
+        run: sudo apt-get install -y libssl-dev ninja-build
+      - name: Configure
+        env:
+          CC: /usr/local/llvm/bin/clang
+          CXX: /usr/local/llvm/bin/clang++
+        run: cmake --preset default
+      - name: Run clang-tidy
+        run: |
+          find src -name '*.cpp' \
+            | xargs clang-tidy -p build --quiet
+
   test:
     runs-on: ubuntu-24.04
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,21 @@ cmake --build build                                     # Ninja が自動並列�
 - `-Werror` は現時点では未導入（別 issue）
 - フラグは `CMakeLists.txt` の `RY_WARNING_FLAGS` 変数で一元管理し、`target_compile_options(... PRIVATE ...)` で各ターゲットに適用
 
+## Clang-Tidy 静的解析
+
+プロジェクトルートの `.clang-tidy` でチェック設定を管理する。CI の `clang-tidy` ジョブが全 `src/*.cpp` ファイルに対して実行する。
+
+```text
+有効: bugprone-*, performance-*, cert-*, 選択的 modernize-*
+除外: bugprone-easily-swappable-parameters, cert-err58-cpp 等（詳細は .clang-tidy 参照）
+```
+
+- `HeaderFilterRegex` はプロジェクトヘッダ (`include/ry/`) のみに制限
+- LLVM / GoogleTest ヘッダは SYSTEM include のため自動除外
+- `compile_commands.json` は `CMAKE_EXPORT_COMPILE_COMMANDS=ON` で自動生成（`build/` 内）
+- ローカル実行: `find src -name '*.cpp' | xargs clang-tidy -p build --quiet`
+- 新規コードは Clang-Tidy 警告ゼロを維持すること
+
 ## CI: LLVM ツールチェーン (ミラー)
 
 CI は `.github/actions/setup-llvm/` composite action 経由で LLVM を取得する。優先順に:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.25)
 project(ry)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(NOT RY_VERSION)
     file(READ "${CMAKE_CURRENT_SOURCE_DIR}/VERSION" RY_VERSION)

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1282,6 +1282,12 @@ produce false positives in this project. Key decisions:
   intentional (ABI stability, JIT layout constraints).
 - `performance-no-int-to-ptr`: Incompatible with LLVM IR builder
   patterns.
+- `bugprone-multi-level-implicit-pointer-conversion`: C-style
+  `free(ptr)` where `ptr` is `T**` is idiomatic in the runtime's
+  manual memory management. This check fires on clang-tidy 21+ only.
+- `cert-err33-c`: `snprintf`/`vsnprintf` return values are not
+  meaningful in formatting-only contexts (error message buffers,
+  string formatting). `std::atexit` failure is also not actionable.
 
 **Rule**: Do not re-enable these checks without understanding why they
 were disabled. If adding a new disabled check, document the reason in

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1261,6 +1261,32 @@ applied per-target via `target_compile_options(... PRIVATE ...)` so they
 do not leak into FetchContent targets. The `add_ry_native_lib()` helper
 applies them automatically to all native shared libraries.
 
+### Clang-Tidy check selection and __ry_ naming convention
+
+**Source**: #893 (implementation)
+**Tags**: build, ci, clang-tidy, static-analysis, naming
+
+**Context**: The `.clang-tidy` config disables several checks that
+produce false positives in this project. Key decisions:
+
+- `bugprone-reserved-identifier` / `cert-dcl37-c` / `cert-dcl51-cpp`:
+  All runtime functions use `__ry_*` prefix (double underscore = reserved
+  in C++). This naming is intentional for ABI and FFI reasons — do not
+  rename them, disable the check instead.
+- `cert-err58-cpp`: `RY_REGISTER_STDLIB_PACKAGE` macro creates static
+  initializers. This is the standard pattern for self-registering
+  stdlib packages.
+- `cert-dcl50-cpp`: C-style variadic functions are used intentionally
+  in runtime error formatting helpers.
+- `performance-enum-size`: Internal enum base types are often
+  intentional (ABI stability, JIT layout constraints).
+- `performance-no-int-to-ptr`: Incompatible with LLVM IR builder
+  patterns.
+
+**Rule**: Do not re-enable these checks without understanding why they
+were disabled. If adding a new disabled check, document the reason in
+the `.clang-tidy` comment header.
+
 ---
 
 ## Documentation

--- a/changelog.d/893-clang-tidy.md
+++ b/changelog.d/893-clang-tidy.md
@@ -1,0 +1,3 @@
+### Added
+
+- Clang-Tidy static analysis with `bugprone-*`, `performance-*`, `cert-*` checks (#893)

--- a/include/ry/runtime_arc.hpp
+++ b/include/ry/runtime_arc.hpp
@@ -12,7 +12,7 @@ namespace ry {
 inline void *arc_alloc(size_t data_size) {
     size_t total;
     if (__builtin_add_overflow(ARC_HEADER_SIZE, data_size, &total)) {
-        add_overflow_abort(ARC_HEADER_SIZE, data_size);
+        add_overflow_abort(ARC_HEADER_SIZE, data_size); // NOLINT(bugprone-narrowing-conversions)
     }
     void *block = checked_malloc(total);
     auto *header = static_cast<int64_t *>(block);

--- a/include/ry/runtime_http_types.hpp
+++ b/include/ry/runtime_http_types.hpp
@@ -28,7 +28,7 @@ int64_t *__ry_ht_rehash_str(const char **keys, int64_t count,
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
-inline constexpr int64_t MAX_BODY_SIZE = 10 * 1024 * 1024; // 10 MB
+inline constexpr int64_t MAX_BODY_SIZE = INT64_C(10) * 1024 * 1024; // 10 MB
 inline constexpr size_t kRecvBufSize = 4096;
 inline constexpr size_t kMaxHeaderSize = 8192;
 

--- a/include/ry/runtime_net_utils.hpp
+++ b/include/ry/runtime_net_utils.hpp
@@ -8,6 +8,7 @@
 
 #include <cstdint>
 #include <cstdio>
+#include <limits>
 #include <cstring>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -156,6 +157,8 @@ static inline void *ry_net_connect(const char *host, int64_t port) {
 // ===== Data transfer =====
 
 static inline ssize_t ry_net_send_all(int fd, const void *buf, size_t len) {
+    if (len > static_cast<size_t>(std::numeric_limits<ssize_t>::max()))
+        return -1;
     auto *data = static_cast<const char *>(buf);
     size_t remaining = len;
     int flags = 0;

--- a/include/ry/runtime_net_utils.hpp
+++ b/include/ry/runtime_net_utils.hpp
@@ -172,7 +172,7 @@ static inline ssize_t ry_net_send_all(int fd, const void *buf, size_t len) {
         data += n;
         remaining -= static_cast<size_t>(n);
     }
-    return static_cast<ssize_t>(len);
+    return static_cast<ssize_t>(len); // NOLINT(bugprone-narrowing-conversions)
 }
 
 // ===== Timeout configuration =====

--- a/include/ry/runtime_tls.hpp
+++ b/include/ry/runtime_tls.hpp
@@ -5,7 +5,7 @@
 #include <sys/types.h>
 
 // Forward declarations for C library types (must be at global scope)
-typedef struct ssl_st SSL;
+using SSL = struct ssl_st;
 struct addrinfo;
 
 namespace ry {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -272,7 +272,7 @@ int main(int argc, char *argv[]) {
                 return 1;
             }
             if (watch) {
-                std::string root_dir = *root;
+                const std::string &root_dir = *root;
                 const char *a0 = argv[0];
                 bool sgl = skip_global_lib;
                 ry::watchAndRunTests(root_dir, [root_dir, a0, sgl, parallel, coverage, outline]() {

--- a/src/runtime_base64.cpp
+++ b/src/runtime_base64.cpp
@@ -108,7 +108,9 @@ static char *base64_decode_impl(const char *input, size_t len, const int8_t *dec
 
 // Null/empty input guard shared by all public functions
 static const char *empty_guard(const char *input, size_t *len) {
-    if (!input || (*len = strlen(input)) == 0) return checked_strdup("");
+    if (!input) return checked_strdup("");
+    *len = strlen(input);
+    if (*len == 0) return checked_strdup("");
     return nullptr;
 }
 

--- a/src/runtime_base64.cpp
+++ b/src/runtime_base64.cpp
@@ -89,7 +89,7 @@ static char *base64_decode_impl(const char *input, size_t len, const int8_t *dec
                 setLastError("invalid base64 character at position %zu", i);
                 return nullptr;
             }
-            sextet[k] = (uint32_t)val;
+            sextet[k] = static_cast<uint32_t>(static_cast<unsigned char>(val));
             count++;
         }
         if (count < 2) {

--- a/src/runtime_filesystem.cpp
+++ b/src/runtime_filesystem.cpp
@@ -148,6 +148,7 @@ void *__ry_filesystem_glob_files(const char *pattern) {
         return nullptr;
     }
     std::vector<std::string> matches;
+    matches.reserve(gl.gl_pathc);
     for (size_t i = 0; i < gl.gl_pathc; ++i) {
         matches.emplace_back(gl.gl_pathv[i]);
     }

--- a/src/runtime_filesystem.cpp
+++ b/src/runtime_filesystem.cpp
@@ -227,7 +227,7 @@ int64_t __ry_filesystem_copy(const char *src, const char *dst) {
         const char *p = buf;
         ssize_t remaining = n;
         while (remaining > 0) {
-            ssize_t written = write(dst_fd, p, remaining);
+            ssize_t written = write(dst_fd, p, static_cast<size_t>(remaining));
             if (written <= 0) {
                 if (written < 0 && errno == EINTR) continue;
                 setLastError("copy: write error to '%s': %s", dst,

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -181,7 +181,7 @@ static void parse_cookie_header(HttpRequestHandle *req) {
         const char *semi = strchr(p, ';');
         size_t pair_len = semi ? (size_t)(semi - p) : strlen(p);
 
-        const char *eq = (const char *)memchr(p, '=', pair_len);
+        const char *eq = static_cast<const char *>(memchr(p, '=', pair_len)); // NOLINT(bugprone-not-null-terminated-result)
         if (eq) {
             const char *key_end = eq;
             while (key_end > p && (*(key_end - 1) == ' ' || *(key_end - 1) == '\t'))

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -45,7 +45,7 @@ static void setLastError(const char *fmt, ...) {
 // ===== Standard input =====
 
 extern "C" const char *__ry_read_line() {
-    char *line = NULL;
+    char *line = nullptr;
     size_t len = 0;
     ssize_t nread = getline(&line, &len, stdin);
     if (nread == -1) {

--- a/src/runtime_json.cpp
+++ b/src/runtime_json.cpp
@@ -609,7 +609,7 @@ const char *__ry_json_type(void *value) {
     switch (v->type) {
         case JsonType::Null:   return "null";
         case JsonType::Bool:   return "boolean";
-        case JsonType::Int:    return "number";
+        case JsonType::Int:
         case JsonType::Float:  return "number";
         case JsonType::String: return "string";
         case JsonType::Array:  return "array";
@@ -749,7 +749,8 @@ void *__ry_json_keys(void *value) {
             keys.emplace_back(v->object_val.keys[i]);
         if (auto *result = makeStringList(keys))
             return result;
-    } catch (const std::exception &) {
+    } catch (const std::exception &) { // NOLINT(bugprone-empty-catch)
+        // Fall through to set error below.
     }
     __ry_set_last_error("json_keys: out of memory");
     return nullptr;

--- a/src/runtime_thread.cpp
+++ b/src/runtime_thread.cpp
@@ -208,7 +208,7 @@ extern "C" void __ry_thread_cleanup(void *thread_ptr) {
         try {
             if (handle->thread.joinable())
                 handle->thread.join();
-        } catch (...) {
+        } catch (...) { // NOLINT(bugprone-empty-catch)
             // Swallow exceptions to prevent them from crossing extern "C" boundary.
         }
     } else {


### PR DESCRIPTION
## Summary

Closes #893

- Add `.clang-tidy` config with `bugprone-*`, `performance-*`, `cert-*`, and selective `modernize-*` checks
- Add `CMAKE_EXPORT_COMPILE_COMMANDS ON` to `CMakeLists.txt` for `compile_commands.json` generation
- Add dedicated `clang-tidy` CI job that installs `clang-tidy-21` from apt.llvm.org and runs against all `src/*.cpp` files (`continue-on-error: true` initially)
- Fix existing warnings: `typedef`→`using`, assignment-in-if, branch clone; NOLINT for intentional empty-catch and false-positive narrowing conversions
- Document in AGENTS.md and KNOWLEDGE.md

### Disabled checks rationale

| Check | Reason |
|-------|--------|
| `bugprone-reserved-identifier` / `cert-dcl37-c` / `cert-dcl51-cpp` | `__ry_*` naming is intentional |
| `bugprone-easily-swappable-parameters` | Noisy on codegen LLVM type params |
| `cert-err58-cpp` | Static initializers from `RY_REGISTER_STDLIB_PACKAGE` |
| `cert-dcl50-cpp` | C-style variadic functions for error formatting |
| `performance-enum-size` | Enum sizing is ABI/JIT-intentional |
| `performance-no-int-to-ptr` | LLVM IR construction patterns |

## Test plan

- [x] `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p` — 1601 C++ tests passed, 115 Ry test files passed
- [x] ASan + UBSan — clean
- [x] TSan — C++ tests clean
- [x] `clang-tidy -p build` — 0 warnings locally
- [ ] CI `clang-tidy` job runs successfully (may need iteration on apt.llvm.org availability)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Clang‑Tidy configuration, a CI job to run it, enabled generation of compile_commands, and added a changelog entry.
  * Updated docs with configuration and operational guidance.

* **Bug Fixes**
  * Added small runtime robustness checks and early returns to avoid out-of-range behavior; suppressed specific lint false positives.

* **Refactor**
  * Modernized a TLS forward-declaration form.

* **Style**
  * Added targeted lint annotations and minor type-safety/initialization cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->