### PR TITLE
chore: add .cache/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,7 @@ build/
 build-asan/
 build-tsan/
 
+# Editor / tool caches
+.cache/
+
 .DS_Store


### PR DESCRIPTION
## Summary

Closes #936

- Add `.cache/` to `.gitignore` to exclude editor/tool cache directories (clangd index files, etc.) from version control

## Test plan

- [x] `git status` no longer shows `.cache/clangd/index/*.idx` as untracked files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated git configuration to exclude cache-related files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->