### PR TITLE
docs: remove old() and result from DBC feature list (#824)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **Operators** — Arithmetic, comparison, logical, bitwise (`>>>` logical right shift), compound assignment, `in` / `not in`, string repetition (`"ab" * 3`), `as` type cast, error propagation `?`, with operator overloading support
 - **Pattern Matching** — `case` expressions with enum / `Option` / `Result` / literal / tuple / record destructuring, guard clauses (`x if x > 0`), exhaustiveness checking
 - **F-String** — String interpolation with `f"Hello {name}"`
-- **Design by Contract** — `require` (preconditions), `ensure` (postconditions), `invariant` (record invariants), `old()`, `result`
+- **Design by Contract** — `require` (preconditions), `ensure` (postconditions), `invariant` (record invariants)
 - **Directives** — `@deprecated`, `@const`, `@native`, `@parallel`, `@inline`, `@each`, `@property`, `@describe`, `@it` and other compile-time metadata annotations
 - **Functions** — `function` definitions, recursion, overloading, lambdas (closures), higher-order functions, UFCS
 - **Control Flow** — `if`/`else`, `case`, `while`, `for...in`, `break`/`continue`

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,6 @@ For detailed language specifications, see the reference pages below.
 | [Package System](reference/packages.md) | from/import syntax, directory packages, std, RY_HOME |
 | [Testing](reference/testing.md) | Testing with describe/it/expect |
 | [Project Management](reference/project.md) | ry init and package.toml specification |
-| [Design by Contract](reference/contracts.md) | require, ensure, invariant, old, result |
+| [Design by Contract](reference/contracts.md) | require, ensure, invariant |
 | [Directives](reference/directives.md) | @deprecated and compile-time metadata |
 | [Error List](reference/errors.md) | Compile errors and runtime errors |

--- a/docs/ja/README.md
+++ b/docs/ja/README.md
@@ -57,6 +57,6 @@ Ry を初めて使う方はこちらから順番に読み進めてください�
 | [パッケージシステム](reference/packages.md) | from/import の文法・ディレクトリパッケージ・std・RY_HOME |
 | [テスト機能](reference/testing.md) | describe/it/expect によるテスト |
 | [プロジェクト管理](reference/project.md) | ry init・package.toml の仕様 |
-| [契約による設計](reference/contracts.md) | require・ensure・invariant・old・result |
+| [契約による設計](reference/contracts.md) | require・ensure・invariant |
 | [ディレクティブ](reference/directives.md) | @deprecated とコンパイル時メタデータ |
 | [エラー一覧](reference/errors.md) | コンパイルエラーと実行時エラーの説明 |

--- a/docs/zh/README.md
+++ b/docs/zh/README.md
@@ -57,6 +57,6 @@ Ry 是一个基于 LLVM JIT 的简洁编程语言。采用 Python 风格的缩�
 | [包系统](reference/packages.md) | from/import 的语法、目录包、std、RY_HOME |
 | [测试功能](reference/testing.md) | 使用 describe/it/expect 进行测试 |
 | [项目管理](reference/project.md) | ry init 与 package.toml 的规格 |
-| [契约式设计](reference/contracts.md) | require、ensure、invariant、old、result |
+| [契约式设计](reference/contracts.md) | require、ensure、invariant |
 | [指令](reference/directives.md) | @deprecated 与编译时元数据 |
 | [错误一览](reference/errors.md) | 编译错误与运行时错误的说明 |


### PR DESCRIPTION
## Summary

- `old` and `result` were listed as DBC keywords in `README.md` and the docs index tables (`docs/README.md`, `docs/ja/README.md`, `docs/zh/README.md`), but neither is implemented as a language keyword
- The lexer's `keyword_map` (`src/lexer.cpp:35-66`) has never included either word — they are plain identifiers
- Existing regression tests (`OldAsIdentifier`, `ResultAsIdentifier`) already confirm correct behavior
- `docs/reference/contracts.md` was already correct (no mention of `old()`) and required no changes

## Reserved word audit (closes #824)

| Word | In `keyword_map`? | Status |
|------|-------------------|--------|
| `old` | NO | Regular identifier — tests confirm |
| `result` | NO | Regular identifier — tests confirm |
| `spawn` | NO | Not a keyword; `thread_spawn` is a stdlib function |
| `select` | NO | Not implemented anywhere |
| `operator` | YES | ACTIVE — operator overloading; **kept** |
| `expect` | YES | ACTIVE — test framework; **kept** |

## Test plan

- [x] `./build/ry_tests` — 1616 tests passed
- [x] `./build/ry test -p` — 116 test files, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Design by Contract" feature documentation across all language versions to clarify the list of currently supported contract constructs. Removed references to deprecated elements from feature descriptions in English, Japanese, and Chinese documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->