### PR TITLE
feat: add end and sep named parameters to print() (#747)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -367,6 +367,34 @@ each one either expects the helper's post-state or explicitly
 re-establishes its own. If any caller is silent about the post-state,
 the fixup belongs in the helper.
 
+### Named arguments for builtins: generic parse, builtin-only dispatch
+
+**Source**: #747 (2026-04-14)
+**Tags**: codegen, builtins, named-args, parser, print
+
+**Context**: `print(end="", sep=", ")` required named/keyword argument
+support, which did not exist in Ry's function call syntax.
+
+Three options were considered:
+1. Full language-wide named args (large scope: AST, type checker,
+   overload resolution)
+2. Special-case `print` in the parser (parser knows builtin names —
+   violates separation of concerns)
+3. Generic named-arg parse + builtin-only codegen restriction ← **chosen**
+
+Option 3 adds `std::vector<NamedArg> named_args` to `CallExpr` /
+`CallStmt`, teaches `parseArgList()` to detect `ident = expr` (same
+lookahead as directive parsing), and restricts usage to builtins at
+codegen time. Non-builtin calls with named args emit a codegen error.
+
+The `=` token is never valid inside an expression (equality uses `==`),
+so the lookahead is unambiguous.
+
+**Rule**: When adding the next named-arg builtin, only `emitPrint()` in
+`src/codegen_call_io.cpp` and the `builtins_` map in `src/codegen.cpp`
+need updating. To lift the builtin-only restriction later, remove the
+check in `codegen_call_user.cpp` and add type-checker support.
+
 ### propagateTypeMeta is single-value; callers decompose tuples
 
 **Source**: #820 + #813 sweep (2026-04-11, implementation)

--- a/changelog.d/747-print-end-sep.md
+++ b/changelog.d/747-print-end-sep.md
@@ -1,0 +1,3 @@
+### Added
+
+- `print()` now supports `end` and `sep` named parameters to control line ending and separator (#747)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -8,7 +8,7 @@
 
 | Function | Description |
 |------|------|
-| `print()` / `print(expr1, expr2, ...)` | Prints values to standard output (space-separated) |
+| `print()` / `print(expr1, expr2, ..., sep=" ", end="\n")` | Prints values to standard output. `sep` controls the separator (default: space), `end` controls the line ending (default: newline) |
 | `length(value)` | Returns the number of elements in a list, map, or set, or the number of UTF-8 characters in a string |
 | `range(n)` / `range(start, end)` / `range(start, end, step)` | Generates a list of integers |
 | `exit(code)` | Terminates the process with the given exit code |
@@ -143,9 +143,16 @@
 
 ## print
 
-**Signature:** `print()` / `print(expr1, expr2, ...)`
+**Signature:** `print()` / `print(expr1, expr2, ..., sep=" ", end="\n")`
 
-Prints one or more values to standard output, separated by spaces. A newline is appended at the end. When called with no arguments, prints only a newline.
+Prints one or more values to standard output, separated by `sep` (default: space). Appends `end` (default: newline) after the last value. When called with no arguments, prints only `end`.
+
+### Named Parameters
+
+| Parameter | Type  | Default | Description                              |
+|-----------|-------|---------|------------------------------------------|
+| `sep`     | `str` | `" "`   | Separator inserted between values        |
+| `end`     | `str` | `"\n"`  | String appended after the last value     |
 
 | Type | Output Format |
 |----|---------|
@@ -201,6 +208,12 @@ print(1, 2, 3)             # 1 2 3
 print("hello", "world")   # hello world
 print(1, "hello", true)   # 1 hello true
 print()                    # (empty line)
+
+# Named parameters: end and sep
+print("hello", end="")    # hello  (no newline)
+print("hello", end="!\n") # hello!
+print(1, 2, 3, sep=", ")  # 1, 2, 3
+print("a", "b", sep="-", end="!\n")  # a-b!
 ```
 
 ---

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -58,6 +58,13 @@ struct TypeNode {
     static TypeNodePtr clone(const TypeNodePtr &src);
 };
 
+// ===== Named argument (for builtin function calls) =====
+
+struct NamedArg {
+    std::string name;
+    ExprPtr value;
+};
+
 // ===== Directive =====
 
 struct DirectiveArg {
@@ -209,6 +216,7 @@ struct UnaryExpr {
 struct CallExpr {
     std::string callee;
     std::vector<ExprPtr> args;
+    std::vector<NamedArg> named_args;
 };
 
 struct FieldAccessExpr {
@@ -239,7 +247,7 @@ struct SetExpr {
 };
 
 struct AssignStmt { std::string name; TypeNodePtr type_annotation; ExprPtr value; std::optional<std::string> compound_op; std::vector<Directive> directives; SourceLocation loc; };
-struct CallStmt   { std::string callee; std::vector<ExprPtr> args; std::vector<Directive> directives; SourceLocation loc; };
+struct CallStmt   { std::string callee; std::vector<ExprPtr> args; std::vector<NamedArg> named_args; std::vector<Directive> directives; SourceLocation loc; };
 struct ExprStmt   { ExprPtr expr; SourceLocation loc; };
 
 struct ReturnStmt { ExprPtr value; SourceLocation loc; };

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -432,7 +432,7 @@ public:
     std::vector<OverloadEntry> *findFunction(const std::string &name);
     void forwardDeclareFunctionsInBody(std::vector<StmtNode> &stmts, bool validateOperatorReturn);
     void forwardDeclareNestedFunctions(std::vector<StmtNode> &body);
-    using BuiltinFn = std::function<void(const std::vector<ExprPtr>&)>;
+    using BuiltinFn = std::function<void(const std::vector<ExprPtr>&, const std::vector<NamedArg>&)>;
     std::unordered_map<std::string, BuiltinFn> builtins_;
 
     // ======== Type System (Structs, Enums, Unions, Generics) ========
@@ -1453,7 +1453,7 @@ public:
     void emitBucketInsertAndRehashCheck(llvm::Value *headerPtr, llvm::StructType *headerTy,
                                          unsigned lenIdx, unsigned bucketCountIdx, unsigned bucketsPtrIdx,
                                          llvm::Value *key, llvm::Type *keyTy, llvm::Value *denseIndex);
-    void emitPrint(const std::vector<ExprPtr> &args);
+    void emitPrint(const std::vector<ExprPtr> &args, const std::vector<NamedArg> &named_args);
     void emitExit(const std::vector<ExprPtr> &args);
 
     // ======== Lambda & Type Inference ========

--- a/include/ry/formatter.hpp
+++ b/include/ry/formatter.hpp
@@ -85,6 +85,7 @@ private:
     std::string formatPattern(const Pattern &pat);
     std::string escapeString(const std::string &s);
     std::string formatFloat(double v);
+    std::string formatNamedArgs(const std::vector<NamedArg> &named, bool has_positionals);
 
     bool isDefinition(const StmtNode &stmt) const;
     bool hasDirectives(const StmtNode &stmt) const;

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -90,7 +90,7 @@ private:
     TypeNodePtr parseFnType();
     std::vector<StmtNode> parseBlock();
     std::vector<StmtNode> parseBlockOrInline();
-    std::vector<ExprPtr> parseArgList();
+    std::vector<ExprPtr> parseArgList(std::vector<NamedArg> *named_out = nullptr);
     void parseContractClause(const std::string &clauseName, std::vector<ExprPtr> &out);
     void parseEnsureClause(FnStmt &fn);
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -26,8 +26,8 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
     i1Ty_  = llvm::Type::getInt1Ty(*ctx_);
     ptrTy_ = llvm::PointerType::getUnqual(*ctx_);
 
-    builtins_["print"] = [this](const std::vector<ExprPtr> &args) { emitPrint(args); };
-    builtins_["exit"] = [this](const std::vector<ExprPtr> &args) { emitExit(args); };
+    builtins_["print"] = [this](const std::vector<ExprPtr> &args, const std::vector<NamedArg> &named) { emitPrint(args, named); };
+    builtins_["exit"] = [this](const std::vector<ExprPtr> &args, const std::vector<NamedArg> &) { emitExit(args); };
 
     errorTy_ = llvm::StructType::create(*ctx_, {ptrTy_, i64Ty_}, "Error");
     {

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -27,7 +27,11 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
     ptrTy_ = llvm::PointerType::getUnqual(*ctx_);
 
     builtins_["print"] = [this](const std::vector<ExprPtr> &args, const std::vector<NamedArg> &named) { emitPrint(args, named); };
-    builtins_["exit"] = [this](const std::vector<ExprPtr> &args, const std::vector<NamedArg> &) { emitExit(args); };
+    builtins_["exit"] = [this](const std::vector<ExprPtr> &args, const std::vector<NamedArg> &named) {
+        if (!named.empty())
+            codegenError("unknown named argument '" + named.front().name + "' for exit()");
+        emitExit(args);
+    };
 
     errorTy_ = llvm::StructType::create(*ctx_, {ptrTy_, i64Ty_}, "Error");
     {

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -8,6 +8,9 @@ namespace ry {
 // ===== CallExpr Dispatcher =====
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
+    if (!e->named_args.empty())
+        codegenError("named arguments are only supported for builtin functions");
+
     // ADT constructor: Enum::Variant(args...)
     {
         auto colonPos = e->callee.find("::");

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -8,9 +8,6 @@ namespace ry {
 // ===== CallExpr Dispatcher =====
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
-    if (!e->named_args.empty())
-        codegenError("named arguments are only supported for builtin functions");
-
     // ADT constructor: Enum::Variant(args...)
     {
         auto colonPos = e->callee.find("::");
@@ -185,6 +182,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
     // resolution but before user function fallback, and falls through on
     // type mismatch so user-defined overloads with the same name still work.
     if (auto *v = emitGenericNativeCall(*e)) return v;
+
+    if (!e->named_args.empty())
+        codegenError("named arguments are only supported for builtin functions");
 
     return emitUserFnCall(e->callee, e->args);
 }

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -662,11 +662,19 @@ void CodeGen::emitPrint(const std::vector<ExprPtr> &args, const std::vector<Name
     auto printfFn = getBufferedPrintf();
     llvm::Constant *fmtS = cachedGlobalString("%s", ".fmt_print_s");
 
+    // Emit a named string argument (sep or end), requiring str type
+    auto emitNamedStr = [&](const ExprNode &expr, const char *param) -> llvm::Value * {
+        llvm::Value *v = emitExpr(expr);
+        if (!isStringValue(v))
+            codegenError(std::string("print() '") + param + "' must be str");
+        return v;
+    };
+
     // Determine separator value (emit once, reuse across iterations)
     llvm::Value *separator = nullptr;
     if (args.size() > 1) {
         if (sepExpr)
-            separator = valueToString(emitExpr(*sepExpr));
+            separator = emitNamedStr(*sepExpr, "sep");
         else
             separator = cachedGlobalString(" ", ".fmt_space");
     }
@@ -680,7 +688,7 @@ void CodeGen::emitPrint(const std::vector<ExprPtr> &args, const std::vector<Name
 
     // Emit end string (default: newline)
     if (endExpr) {
-        llvm::Value *endStr = valueToString(emitExpr(*endExpr));
+        llvm::Value *endStr = emitNamedStr(*endExpr, "end");
         builder_.CreateCall(printfFn, {fmtS, endStr});
     } else {
         builder_.CreateCall(printfFn, {fmtS, cachedGlobalString("\n", ".fmt_nl")});

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -643,23 +643,48 @@ static llvm::Value *dispatchHttp(CodeGen &cg, const CallExpr &e) {
 
 // ===== Print =====
 
-void CodeGen::emitPrint(const std::vector<ExprPtr> &args) {
+void CodeGen::emitPrint(const std::vector<ExprPtr> &args, const std::vector<NamedArg> &named_args) {
+    // Extract named parameters: end and sep
+    const ExprNode *endExpr = nullptr;
+    const ExprNode *sepExpr = nullptr;
+    for (const auto &na : named_args) {
+        if (na.name == "end")
+            endExpr = na.value.get();
+        else if (na.name == "sep")
+            sepExpr = na.value.get();
+        else
+            codegenError("unknown named argument '" + na.name + "' for print()");
+    }
+
     builder_.CreateCall(getRuntimeFn("__ry_print_begin",
         llvm::Type::getVoidTy(*ctx_), {}));
 
     auto printfFn = getBufferedPrintf();
     llvm::Constant *fmtS = cachedGlobalString("%s", ".fmt_print_s");
-    llvm::Constant *space = args.size() > 1
-        ? cachedGlobalString(" ", ".fmt_space") : nullptr;
+
+    // Determine separator value (emit once, reuse across iterations)
+    llvm::Value *separator = nullptr;
+    if (args.size() > 1) {
+        if (sepExpr)
+            separator = valueToString(emitExpr(*sepExpr));
+        else
+            separator = cachedGlobalString(" ", ".fmt_space");
+    }
 
     for (size_t i = 0; i < args.size(); ++i) {
-        if (i > 0)
-            builder_.CreateCall(printfFn, {space});
+        if (i > 0 && separator != nullptr)
+            builder_.CreateCall(printfFn, {fmtS, separator});
         llvm::Value *str = valueToString(emitExpr(*args[i]));
         builder_.CreateCall(printfFn, {fmtS, str});
     }
 
-    builder_.CreateCall(printfFn, {cachedGlobalString("\n", ".fmt_nl")});
+    // Emit end string (default: newline)
+    if (endExpr) {
+        llvm::Value *endStr = valueToString(emitExpr(*endExpr));
+        builder_.CreateCall(printfFn, {fmtS, endStr});
+    } else {
+        builder_.CreateCall(printfFn, {fmtS, cachedGlobalString("\n", ".fmt_nl")});
+    }
 
     builder_.CreateCall(getRuntimeFn("__ry_print_end",
         llvm::Type::getVoidTy(*ctx_), {}));

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -393,6 +393,8 @@ void CodeGen::emitStmt(CallStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
     validateDirectives(s.directives);
+    if (!s.named_args.empty() && builtins_.find(s.callee) == builtins_.end())
+        codegenError(s.loc, "named arguments are only supported for builtin functions");
     if (s.callee == "describe") {
         emitDescribeCall(s);
         return;
@@ -414,8 +416,6 @@ void CodeGen::emitStmt(CallStmt &s) {
         it->second(s.args, s.named_args);
         return;
     }
-    if (!s.named_args.empty())
-        codegenError(s.loc, "named arguments are only supported for builtin functions");
     auto sit = struct_types_.find(s.callee);
     if (sit != struct_types_.end()) {
         emitStructConstructor(sit->second, s.callee, s.args);

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -411,9 +411,11 @@ void CodeGen::emitStmt(CallStmt &s) {
     }
     auto it = builtins_.find(s.callee);
     if (it != builtins_.end()) {
-        it->second(s.args);
+        it->second(s.args, s.named_args);
         return;
     }
+    if (!s.named_args.empty())
+        codegenError(s.loc, "named arguments are only supported for builtin functions");
     auto sit = struct_types_.find(s.callee);
     if (sit != struct_types_.end()) {
         emitStructConstructor(sit->second, s.callee, s.args);

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -169,6 +169,15 @@ std::string Formatter::formatFloat(double v) {
     return s;
 }
 
+std::string Formatter::formatNamedArgs(const std::vector<NamedArg> &named, bool has_positionals) {
+    std::string result;
+    for (size_t i = 0; i < named.size(); ++i) {
+        if (i > 0 || has_positionals) result += ", ";
+        result += named[i].name + "=" + formatExpr(*named[i].value);
+    }
+    return result;
+}
+
 // --- Operator precedence ---
 
 int Formatter::operatorPrecedence(const std::string &op) const {
@@ -256,6 +265,7 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                 if (i > 0) args += ", ";
                 args += formatExpr(*call.args[i]);
             }
+            args += formatNamedArgs(call.named_args, !call.args.empty());
             // Restore bracket syntax: parser converts name[T]() to name<T>()
             // but generic enum constructors use <> with :: (e.g. Option<int>::Some)
             std::string callee = call.callee;

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -106,6 +106,7 @@ void Formatter::formatCall(const CallStmt &s) {
         }
     }
 
+    emit(formatNamedArgs(s.named_args, !s.args.empty()));
     emit(")");
     emitInlineComment(s.loc.line);
     emitNewline();

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -85,6 +85,7 @@ void Formatter::formatCall(const CallStmt &s) {
             last_emitted_line_ = s.loc.line;
             formatBlock(lambda.body);
             emitIndent();
+            emit(formatNamedArgs(s.named_args, true));
             emit(")");
             emitNewline();
             return;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -2,6 +2,7 @@
 #include "ry/diagnostic.hpp"
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 
 
 namespace ry {
@@ -216,6 +217,7 @@ std::vector<ExprPtr> Parser::parseArgList(std::vector<NamedArg> *named_out) {
     std::vector<ExprPtr> args;
     args.reserve(4);
     bool seen_named = false;
+    std::unordered_set<std::string> seen_named_names;
     if (lex_.peek().kind != TokenKind::RParen) {
         auto parseOne = [&]() {
             ExprPtr expr = parseConditional();
@@ -227,6 +229,8 @@ std::vector<ExprPtr> Parser::parseArgList(std::vector<NamedArg> *named_out) {
                 NamedArg na;
                 na.name = var->name;
                 na.value = parseConditional();
+                if (!seen_named_names.insert(na.name).second)
+                    parseError("duplicate named argument '" + na.name + "'");
                 named_out->push_back(std::move(na));
                 seen_named = true;
             } else {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -212,16 +212,35 @@ ExprPtr Parser::parseBinaryLeft(ParseFn operand, std::initializer_list<TokenKind
 
 // ===== A3: parseArgList helper =====
 
-std::vector<ExprPtr> Parser::parseArgList() {
+std::vector<ExprPtr> Parser::parseArgList(std::vector<NamedArg> *named_out) {
     std::vector<ExprPtr> args;
     args.reserve(4);
+    bool seen_named = false;
     if (lex_.peek().kind != TokenKind::RParen) {
-        args.push_back(parseConditional());
+        auto parseOne = [&]() {
+            ExprPtr expr = parseConditional();
+            auto *var = std::get_if<VariableExpr>(&expr->data);
+            if (var != nullptr && lex_.peek().kind == TokenKind::Equals) {
+                if (named_out == nullptr)
+                    parseError("named arguments are not supported here");
+                lex_.next(); // consume '='
+                NamedArg na;
+                na.name = var->name;
+                na.value = parseConditional();
+                named_out->push_back(std::move(na));
+                seen_named = true;
+            } else {
+                if (seen_named)
+                    parseError("positional arguments cannot follow named arguments");
+                args.push_back(std::move(expr));
+            }
+        };
+        parseOne();
         while (lex_.peek().kind == TokenKind::Comma) {
             lex_.next();
             if (lex_.peek().kind == TokenKind::RParen)
                 break;
-            args.push_back(parseConditional());
+            parseOne();
         }
     }
     if (lex_.peek().kind != TokenKind::RParen)
@@ -575,7 +594,7 @@ StmtNode Parser::parseStatement() {
             obj->data = VariableExpr{first.value};
             obj->loc = locFromToken(first);
             s.args.push_back(std::move(obj));
-            auto rest = parseArgList();
+            auto rest = parseArgList(&s.named_args);
             for (auto &arg : rest)
                 s.args.push_back(std::move(arg));
             tryParseTrailingBlock(s);
@@ -654,7 +673,7 @@ StmtNode Parser::parseStatement() {
         lex_.next(); // consume '('
         CallStmt s;
         s.callee = first.value;
-        s.args = parseArgList();
+        s.args = parseArgList(&s.named_args);
         s.loc = locFromToken(first);
         if (s.callee == "mock")
             coerceFirstArgToString(s.args);

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -636,7 +636,7 @@ ExprPtr Parser::parsePrimary() {
             lex_.next(); // consume '('
             auto call = std::make_unique<CallExpr>();
             call->callee = t.value;
-            call->args = parseArgList();
+            call->args = parseArgList(&call->named_args);
             if (call->callee == "verify")
                 coerceFirstArgToString(call->args);
             auto node = std::make_unique<ExprNode>();
@@ -1039,7 +1039,7 @@ ExprPtr Parser::parsePostfixContinuation(ExprPtr expr) {
             auto call = std::make_unique<CallExpr>();
             call->callee = field.value;
             call->args.push_back(std::move(expr));
-            auto rest = parseArgList(); // consumes ')'
+            auto rest = parseArgList(&call->named_args); // consumes ')'
             for (auto &arg : rest)
                 call->args.push_back(std::move(arg));
             auto node = std::make_unique<ExprNode>();

--- a/tests/spec/print_end_sep.test.ry
+++ b/tests/spec/print_end_sep.test.ry
@@ -1,0 +1,49 @@
+describe("print end parameter", ():
+  it("should suppress newline with end=\"\"", ():
+    print("hello", end="")
+    print(" world")
+    # expect-output: hello world
+  )
+
+  it("should use custom end string", ():
+    print("hello", end="!\n")
+    # expect-output: hello!
+  )
+
+  it("should work with no positional args", ():
+    print(end="---\n")
+    # expect-output: ---
+  )
+
+  it("should work with multiple args and end", ():
+    print(1, 2, 3, end=".\n")
+    # expect-output: 1 2 3.
+  )
+
+  it("should preserve default newline when end is omitted", ():
+    print("hello")
+    # expect-output: hello
+  )
+)
+
+describe("print sep parameter", ():
+  it("should use custom separator", ():
+    print(1, 2, 3, sep=", ")
+    # expect-output: 1, 2, 3
+  )
+
+  it("should use empty separator", ():
+    print("a", "b", "c", sep="")
+    # expect-output: abc
+  )
+
+  it("should combine sep and end", ():
+    print("a", "b", sep="-", end="!\n")
+    # expect-output: a-b!
+  )
+
+  it("should use sep with two args", ():
+    print("x", "y", sep=" | ")
+    # expect-output: x | y
+  )
+)

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -218,6 +218,24 @@ TEST_F(CodeGenTest, GenericInferenceConflictingBindingError) {
 }
 
 // ============================================================
+// print() named argument error cases
+// ============================================================
+
+TEST_F(CodeGenTest, PrintUnknownNamedArgError) {
+    expectCompileError(
+        "print(\"hello\", file=\"stderr\")\n",
+        "unknown named argument 'file' for print()");
+}
+
+TEST_F(CodeGenTest, NamedArgsOnNonBuiltinError) {
+    expectCompileError(
+        "function greet(name: str):\n"
+        "  print(name)\n"
+        "greet(name=\"world\")\n",
+        "named arguments are only supported for builtin functions");
+}
+
+// ============================================================
 // `+` on Map / Set / mixed collection operands must produce a
 // type-aware error that names the actual collection type.  Before
 // #863 these operations fell through to the str-vs-non-str reject

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2450,3 +2450,7 @@ TEST(ParserTest, MultipleNamedArgsInCallStmt) {
 TEST(ParserTest, PositionalAfterNamedArgError) {
     EXPECT_THROW(parseStr("print(end=\"\", \"hello\")\n"), std::runtime_error);
 }
+
+TEST(ParserTest, DuplicateNamedArgError) {
+    EXPECT_THROW(parseStr("print(end=\"\\n\", end=\"!\")\n"), std::runtime_error);
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2412,3 +2412,41 @@ TEST(ParserTest, DoubleTrailingCommaError) {
 TEST(ParserTest, GenericTypeArgDoubleCommaError) {
     EXPECT_THROW(parseStr("function foo(x: List<int,,>) -> int:\n    return 0\n"), std::runtime_error);
 }
+
+// ============================================================
+// Named arguments in function calls (#747)
+// ============================================================
+
+TEST(ParserTest, NamedArgInCallStmt) {
+    Program prog = parseStr("print(\"hello\", end=\"\")\n");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<CallStmt>(prog[0]));
+    const auto &s = std::get<CallStmt>(prog[0]);
+    EXPECT_EQ(s.callee, "print");
+    ASSERT_EQ(s.args.size(), 1u);
+    ASSERT_EQ(s.named_args.size(), 1u);
+    EXPECT_EQ(s.named_args[0].name, "end");
+}
+
+TEST(ParserTest, NamedArgOnlyInCallStmt) {
+    Program prog = parseStr("print(end=\"\\n\")\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<CallStmt>(prog[0]);
+    EXPECT_EQ(s.args.size(), 0u);
+    ASSERT_EQ(s.named_args.size(), 1u);
+    EXPECT_EQ(s.named_args[0].name, "end");
+}
+
+TEST(ParserTest, MultipleNamedArgsInCallStmt) {
+    Program prog = parseStr("print(\"a\", sep=\"-\", end=\"!\\n\")\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<CallStmt>(prog[0]);
+    ASSERT_EQ(s.args.size(), 1u);
+    ASSERT_EQ(s.named_args.size(), 2u);
+    EXPECT_EQ(s.named_args[0].name, "sep");
+    EXPECT_EQ(s.named_args[1].name, "end");
+}
+
+TEST(ParserTest, PositionalAfterNamedArgError) {
+    EXPECT_THROW(parseStr("print(end=\"\", \"hello\")\n"), std::runtime_error);
+}


### PR DESCRIPTION
## Summary

- Add `end` and `sep` named parameters to `print()`, similar to Python's `print()`
- `end` (default `"\n"`) controls the string appended after the last value — use `end=""` to suppress the newline
- `sep` (default `" "`) controls the separator inserted between multiple values
- Implements generic named argument parsing in `parseArgList()` using the same `ident=expr` lookahead pattern already used by directive parsing
- Named args are stored in `CallExpr`/`CallStmt` as a separate `named_args` vector; usage is restricted to builtin functions at codegen time

## Test plan

- [ ] `tests/spec/print_end_sep.test.ry` — 9 new Ry spec tests covering `end`, `sep`, and combined usage
- [ ] `tests/test_parser.cpp` — 4 new parser tests verifying AST structure and positional-after-named error
- [ ] `tests/test_codegen_fail.cpp` — 2 new error tests for unknown named arg and named args on non-builtins
- [ ] All 1622 C++ tests pass (`./build/ry_tests`)
- [ ] All 117 Ry self-test files pass (`./build/ry test -p`)
- [ ] ASan + UBSan clean
- [ ] TSan clean

Closes #747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `print()` now supports named parameters: sep (default " ") and end (default "\n").

* **Behavior Changes / Bug Fixes**
  * Named arguments are accepted for builtins; using named arguments with non-builtin calls now produces a clear error.
  * Unknown named parameters for builtins produce a diagnostic.

* **Documentation**
  * Builtins reference updated with named-parameter docs and examples.

* **Tests**
  * Added unit and integration tests covering valid/invalid named-argument usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->