### PR TITLE
feat: add Option.map() combinator (#804)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,6 +117,7 @@ add_library(ry_lib STATIC
     src/codegen_call_io.cpp
     src/codegen_call_iterator.cpp
     src/codegen_call_result.cpp
+    src/codegen_call_option.cpp
     src/codegen_lambda.cpp
     src/sema_return.cpp
     src/module_loader.cpp

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -42,6 +42,27 @@ grep -nE '\*\*Tags\*\*:.*codegen' KNOWLEDGE.md
 
 ## Testing
 
+### `case` arms in `.test.ry` files must have a non-empty body
+
+**Source**: #804 (2026-04-14, implementation)
+**Tags**: testing, case, option, ry-syntax
+
+**Rule**: Every arm of a `case` expression in Ry must have at least one statement. An arm with no body (e.g. `None:` followed immediately by the closing `)`) causes a parser error pointing at the enclosing `describe` or `it` call — which can be confusing.
+
+```ry
+# ❌ Parser error — empty arm not allowed
+case opt:
+    Some(v): expect(v).to_eq(1)
+    None:           # ← triggers "unexpected token ')'"
+
+# ✅ Use a flag variable to verify the None path
+got_none = false
+case opt:
+    Some(v): fail("unexpected Some")
+    None: got_none = true
+expect(got_none).to_eq(true)
+```
+
 ### CodeGenTest::runSource cannot compile code that imports stdlib packages
 
 **Source**: #842 (2026-04-11, implementation)

--- a/changelog.d/804-option-map.md
+++ b/changelog.d/804-option-map.md
@@ -1,0 +1,3 @@
+### Added
+
+- `Option.map()` combinator: transform the inner value of an `Option` with a function, returning `Some(f(x))` for `Some(x)` and `None` for `None` (#804)

--- a/docs/tutorial/08-error-handling.md
+++ b/docs/tutorial/08-error-handling.md
@@ -38,6 +38,26 @@ case x:
 
 You have already seen `Option` in action: `iterator.next()` returns `Option<T>`, giving `Some(element)` for each element and `None` when the iterator is exhausted.
 
+### Transforming Option Values with `map`
+
+Use `map` to transform the inner value of an `Option` without unwrapping it. If the Option is `Some`, the function is applied and the result is wrapped in a new `Some`. If it is `None`, `None` is returned unchanged.
+
+```python
+o: int? = Some(42)
+doubled = o.map((x: int) => x * 2)
+print(doubled)   # Some(84)
+
+nothing: int? = None
+print(nothing.map((x: int) => x * 2))   # None
+```
+
+You can chain `map` calls:
+
+```python
+result = Some(10).map((x: int) => x + 5).map((x: int) => x * 2)
+print(result)   # Some(30)
+```
+
 ---
 
 ## Result Type

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1445,6 +1445,7 @@ public:
     llvm::Value *emitPtrToResult(llvm::Value *ptr, const std::string &name,
                                  const std::string &errMsg, int rk);
     llvm::Value *emitBuiltinResult(const CallExpr &e, llvm::Value *preEmittedArg0 = nullptr);
+    llvm::Value *emitBuiltinOption(const CallExpr &e, llvm::Value *preEmittedArg0 = nullptr);
     llvm::Value *emitBuiltinIterator(const CallExpr &e, llvm::Value *preEmittedArg0 = nullptr);
     llvm::Type *getIteratorElementType(llvm::Value *iterVal);
     void emitBucketInit(llvm::Value *headerPtr, llvm::StructType *headerTy,

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -87,6 +87,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
     if (e->args.size() >= 2 && (e->callee == "map" || e->callee == "filter")) {
         llvm::Value *arg0 = emitExpr(*e->args[0]);
         if (auto *v = emitBuiltinResult(*e, arg0))      return v;
+        if (auto *v = emitBuiltinOption(*e, arg0))      return v;
         if (auto *v = emitBuiltinIterator(*e, arg0))    return v;
         if (auto *v = emitBuiltinHigherOrder(*e, arg0)) return v;
     } else if (e->args.size() == 2 && e->callee == "take") {
@@ -96,6 +97,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
     } else {
         // Dispatch to language-builtin helpers (Pattern B: no @native registry)
         if (auto *v = emitBuiltinResult(*e))      return v;
+        if (auto *v = emitBuiltinOption(*e))      return v;
         if (auto *v = emitBuiltinIterator(*e))    return v;
         if (auto *v = emitBuiltinString(*e))      return v;
         if (auto *v = emitBuiltinConversion(*e))  return v;

--- a/src/codegen_call_option.cpp
+++ b/src/codegen_call_option.cpp
@@ -1,0 +1,43 @@
+#include "ry/codegen.hpp"
+#include "ry/diagnostic.hpp"
+
+
+namespace ry {
+
+// ===== Builtin Option Methods (map) =====
+
+llvm::Value *CodeGen::emitBuiltinOption(const CallExpr &e, llvm::Value *preEmittedArg0) {
+    if (e.args.size() != 2) return nullptr;
+    if (e.callee != "map") return nullptr;
+
+    llvm::Value *optVal = preEmittedArg0 ? preEmittedArg0 : emitExpr(*e.args[0]);
+    if (!isOptionType(optVal->getType()))
+        return nullptr;
+
+    llvm::Value *lambdaVal = emitExpr(*e.args[1]);
+    auto *fnInfo = lookupFnTypeInfo(lambdaVal);
+    if (!fnInfo)
+        codegenError("map() on Option requires a function as second argument");
+    const FnTypeInfo &info = *fnInfo;
+
+    llvm::StructType *outOptTy = getOptionType(info.returnType);
+
+    llvm::Value *hasVal = builder_.CreateExtractValue(optVal, 0, "has_val");
+    llvm::Value *isNone = builder_.CreateNot(hasVal, "is_none");
+
+    llvm::Value *someResult = nullptr;
+    llvm::Value *mergedResult = emitResultBranch(isNone, outOptTy,
+        [&]() {
+            llvm::Value *innerVal = builder_.CreateExtractValue(optVal, 1, "some_val");
+            someResult = buildSomeValue(emitLambdaCall(lambdaVal, info, {innerVal}, "mapped"), outOptTy);
+            return someResult;
+        },
+        [&]() { return buildNoneValue(outOptTy); });
+
+    if (someResult)
+        propagateMeta(someResult, mergedResult);
+
+    return mergedResult;
+}
+
+} // namespace ry

--- a/tests/spec/option_map.test.ry
+++ b/tests/spec/option_map.test.ry
@@ -1,0 +1,45 @@
+describe("Option map", ():
+  it("should map Some value", ():
+    o: int? = Some(42)
+    result = o.map((x: int) => x * 2)
+    case result:
+      Some(v): expect(v).to_eq(84)
+      None: fail("expected Some but got None")
+  )
+
+  it("should return None when mapping None", ():
+    o: int? = None
+    got_none = false
+    result = o.map((x: int) => x * 2)
+    case result:
+      Some(_): fail("expected None but got Some")
+      None: got_none = true
+    expect(got_none).to_eq(true)
+  )
+
+  it("should support chained map", ():
+    o: int? = Some(10)
+    result = o.map((x: int) => x + 5).map((x: int) => x * 2)
+    case result:
+      Some(v): expect(v).to_eq(30)
+      None: fail("expected Some but got None")
+  )
+
+  it("should map with type change to bool", ():
+    o: int? = Some(42)
+    result = o.map((x: int) => x > 40)
+    case result:
+      Some(v): expect(v).to_eq(true)
+      None: fail("expected Some but got None")
+  )
+
+  it("should preserve None through chained map", ():
+    o: int? = None
+    got_none = false
+    result = o.map((x: int) => x + 5).map((x: int) => x * 2)
+    case result:
+      Some(_): fail("expected None but got Some")
+      None: got_none = true
+    expect(got_none).to_eq(true)
+  )
+)

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -126,6 +126,17 @@ TEST_F(CodeGenTest, QuestionOnResultInOptionFnRejected) {
 }
 
 // ============================================================
+// Option.map() requires a callable second argument
+// ============================================================
+
+TEST_F(CodeGenTest, OptionMapRejectsNonCallableSecondArg) {
+    expectCompileError(
+        "o: int? = Some(1)\n"
+        "v = o.map(42)\n",
+        "map() on Option requires a function as second argument");
+}
+
+// ============================================================
 // Top-level `?` on `Result<_, E>` requires E == Error
 // ============================================================
 


### PR DESCRIPTION
## Summary

- Adds `Option.map(fn)` combinator: returns `Some(fn(x))` for `Some(x)`, `None` for `None`
- Plugs into the existing `map`/`filter` fast-path dispatch chain between `emitBuiltinResult` and `emitBuiltinIterator`
- Reuses `emitResultBranch()` helper (consistent with `Result.map` pattern)
- Adds 5 spec tests covering: Some mapping, None passthrough, chaining, type-changing map, chained None propagation

## Implementation

**New file**: `src/codegen_call_option.cpp` — `emitBuiltinOption()` implementation  
**Modified**: `include/ry/codegen.hpp`, `src/codegen_call_dispatch.cpp`, `CMakeLists.txt`

```ry
o: int? = Some(42)
print(o.map((x: int) => x * 2))   # Some(84)

nothing: int? = None
print(nothing.map((x: int) => x * 2))   # None

# Chainable
result = Some(10).map((x: int) => x + 5).map((x: int) => x * 2)
print(result)   # Some(30)
```

## Test plan

- [x] `./build/ry test tests/spec/option_map.test.ry` — 5 passed
- [x] `./build/ry_tests` — 1623 passed
- [x] `./build/ry test -p` — 118 files, 0 failures
- [x] ASan + UBSan clean
- [x] TSan clean

Closes #804

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Option.map() combinator to transform the inner value of an Option, returning Some(f(x)) for Some(x) and preserving None.

* **Documentation**
  * Added a tutorial subsection with examples showing single and chained map() usage.

* **Tests**
  * Added positive tests for mapping, chaining, type changes and None preservation, plus a negative test ensuring a non-callable second argument is rejected.

* **Chores**
  * Build updated to include the new map implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->