### PR TITLE
feat: add capture group backreferences ($1, $2) to regex.replace (#829)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -32,6 +32,7 @@ grep -nE '\*\*Tags\*\*:.*codegen' KNOWLEDGE.md
 - [Codegen](#codegen)
 - [Parser / Lexer](#parser--lexer)
 - [Runtime / Memory](#runtime--memory)
+- [Regex Engine](#regex-engine)
 - [Build / CI](#build--ci)
 - [Documentation](#documentation)
 - [Commands / Environment gotchas](#commands--environment-gotchas)
@@ -1133,6 +1134,39 @@ works under all sanitizers, runs in the required step, and is more
 direct anyway — we are testing a runtime invariant, not a language
 feature. See also the entry at the top of this "Testing" section for
 the `runSource` / `runTestSource` limitation.
+
+---
+
+## Regex Engine
+
+### Thompson NFA stores per-thread state on NFAState itself — extending to capture slots requires a separate approach
+
+**Source**: #829 (2026-04-14, implementation)
+**Tags**: regex, nfa, capture-groups, design-decision
+
+**Rule**: The `NFASimulator` in `src/runtime_regex.cpp` stores per-thread tracking data
+directly on `NFAState` (`matchStartPos`). This is safe because only one value is tracked.
+Extending the Thompson NFA to carry per-thread capture slot arrays (RE2 style) would require
+moving to a `Thread = {NFAState*, vector<pair<int,int>>}` approach — a significant rewrite.
+
+Instead, capture group extraction for `replace` uses a separate backtracking pass over the
+NFA graph, anchored to the match boundaries already found by `findAll`. This:
+1. Keeps the Thompson path completely unchanged (no performance impact for non-backreference patterns)
+2. Is safe against catastrophic backtracking because the span is bounded by the match
+
+If full capture group support is needed beyond `replace` (e.g., `find_all` returning subgroups),
+revisit the Thompson NFA and migrate to per-thread capture slot arrays.
+
+### GroupOpen / GroupClose epsilon states are transparent to the Thompson NFA simulator
+
+**Source**: #829 (2026-04-14, implementation)
+**Tags**: regex, nfa, capture-groups, epsilon-states
+
+**Rule**: `GroupOpen` and `GroupClose` are added to `NFAState::Kind` as epsilon states.
+`addState()` treats them like `Split` — follows `out1` without consuming input, incrementing
+no generation. This means the existing Thompson simulator ignores them at zero cost.
+The `CaptureBacktracker` (used only when `$N` appears in the replacement) uses the same NFA
+graph and reads these states explicitly.
 
 ---
 

--- a/changelog.d/829-regex-replace-backreferences.md
+++ b/changelog.d/829-regex-replace-backreferences.md
@@ -1,0 +1,3 @@
+### Added
+
+- `regex.replace` and `regex_replace` now support capture group backreferences in the replacement string: `$1`–`$9` expand to the corresponding captured groups, `$0` expands to the entire match, `$$` produces a literal `$`, and `${N}` handles multi-digit group indices (#829)

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -101,7 +101,7 @@ pos = regex_search("abc123", "[0-9]+")  # 3
 | `+?` | One or more (non-greedy) | `".+?"` matches shortest |
 | `??` | Zero or one (non-greedy) | `"a??"` prefers zero |
 | `{n,m}?` | Range (non-greedy) | `"a{2,4}?"` prefers n times |
-| `(...)` | Group | `"(ab)+"` matches `"abab"` |
+| `(...)` | Capture group (see [Backreferences](#capture-group-backreferences)) | `"(ab)+"` matches `"abab"` |
 | `[abc]` | Character class | `"[aeiou]"` matches vowels |
 | `[a-z]` | Character range | `"[a-z]+"` matches lowercase words |
 | `[^...]` | Negated character class | `"[^0-9]"` matches non-digits |
@@ -156,6 +156,40 @@ print(pos)  # 6
 # Find all words
 words = regex_find_all("hello world foo", "\\b\\w+\\b")
 print(length(words))  # 3
+```
+
+### Capture Group Backreferences
+
+The `replace` / `regex_replace` functions support backreferences in the replacement string, allowing captured text to be inserted into the output.
+
+| Syntax | Expands to |
+|--------|-----------|
+| `$0` | The entire match |
+| `$1` – `$9` | Contents of capture group N |
+| `${10}`, `${11}`, … | Multi-digit group (use `${N}` to avoid ambiguity) |
+| `$$` | A literal `$` character |
+| `$` + non-digit | A literal `$` followed by that character |
+
+Out-of-range or unmatched groups expand to an empty string.
+
+```ry
+from regex import replace
+
+# Swap words: $2 and $1
+print(replace("hello world", /(\w+) (\w+)/, "$2, $1!"))
+# world, hello!
+
+# Reformat date: YYYY-MM-DD → DD/MM/YYYY
+print(replace("2026-04-10", /(\d+)-(\d+)-(\d+)/, "$3/$2/$1"))
+# 10/04/2026
+
+# $0 is the whole match (no capture groups needed)
+print(replace("hello world", /\w+/, "[$0]"))
+# [hello] [world]
+
+# Prefix a number with a literal $
+print(replace("price: 100", /(\d+)/, "$$$1"))
+# price: $100
 ```
 
 ### Case-Insensitive Matching

--- a/include/ry/runtime_regex_internal.hpp
+++ b/include/ry/runtime_regex_internal.hpp
@@ -41,6 +41,9 @@ struct RegexNode {
     int repeatMax = -1;  // maximum repetitions (-1 = unlimited)
     bool greedy = true;  // false = non-greedy (lazy)
 
+    // Group (1-based index assigned by parser; -1 = no capture)
+    int groupIndex = -1;
+
     // Children
     std::vector<std::unique_ptr<RegexNode>> children;
 };
@@ -60,6 +63,7 @@ public:
     explicit RegexParser(const char *pattern);
 
     bool caseInsensitive() const { return caseInsensitive_; }
+    int groupCount() const { return groupCount_; }
 
     RegexNodePtr parse();
 
@@ -69,6 +73,7 @@ private:
     size_t pos_;
     bool caseInsensitive_ = false;
     int groupDepth_ = 0;
+    int groupCount_ = 0;
     static constexpr int MAX_GROUP_DEPTH = 50;
 
     char peek() const;

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -336,9 +336,9 @@ public:
 
             if (stateSetContains(current_, matchState_)) {
                 if (fullMatch) {
-                    if (i + 1 == textLen) return (int64_t)(i + 1);
+                    if (i + 1 == textLen) return static_cast<int64_t>(i) + 1;
                 } else {
-                    lastMatch = (int64_t)(i + 1);
+                    lastMatch = static_cast<int64_t>(i) + 1;
                     if (preferShortest) return lastMatch;
                 }
             }
@@ -906,11 +906,7 @@ const char *__ry_regex_replace(const char *pattern, const char *text,
         result.append(text + lastEnd, static_cast<size_t>(start) - lastEnd);
         if (needsCaptures) {
             CaptureVec caps;
-            if (bt) {
-                bt->extractCaptures(text, textLen, start, end, caps);
-            } else {
-                caps = CaptureVec(1, {start, end});
-            }
+            bt->extractCaptures(text, textLen, start, end, caps);
             result += expandReplacement(replacement, repLen, text, caps);
         } else {
             result.append(replacement, repLen);
@@ -941,8 +937,9 @@ void *__ry_regex_find_all(const char *pattern, const char *text) {
     auto matches = cr.findAll(text);
 
     std::vector<std::string> items;
+    items.reserve(matches.size());
     for (auto &[start, end] : matches) {
-        items.emplace_back(text + start, (size_t)(end - start));
+        items.emplace_back(text + start, static_cast<size_t>(end - start));
     }
     return makeStringList(items);
 }

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -6,6 +6,7 @@
 #include <cstdlib>
 #include <cctype>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <vector>
 #include <memory>
@@ -694,16 +695,25 @@ public:
 
     // Extract capture positions for a known match span [matchStart, matchEnd).
     // caps[0] = whole match, caps[i] = group i, or {-1,-1} if unmatched.
-    CaptureVec extractCaptures(const char *text, size_t textLen,
-                               int64_t matchStart, int64_t matchEnd) {
-        CaptureVec caps(static_cast<size_t>(groupCount_ + 1), {-1, -1});
+    // Returns true on success; false if the step limit was hit (caps may be partial).
+    bool extractCaptures(const char *text, size_t textLen,
+                         int64_t matchStart, int64_t matchEnd,
+                         CaptureVec &caps) {
+        caps.assign(static_cast<size_t>(groupCount_) + 1, {-1, -1});
         int64_t steps = 0;
-        backtrack(start_, text, textLen, static_cast<size_t>(matchStart),
-                  static_cast<size_t>(matchEnd), caps, steps);
+        bool ok = backtrack(start_, text, textLen, static_cast<size_t>(matchStart),
+                            static_cast<size_t>(matchEnd), caps, steps);
+        if (!ok) {
+            fprintf(stderr,
+                    "regex warning: capture extraction failed for match [%lld, %lld) "
+                    "(step limit or no path found); backreferences may expand to empty\n",
+                    static_cast<long long>(matchStart),
+                    static_cast<long long>(matchEnd));
+        }
         // backtrack may set caps[0] via GroupOpen/GroupClose on a wrapping group;
         // always overwrite with the authoritative bounds from findAll.
         caps[0] = {matchStart, matchEnd};
-        return caps;
+        return ok;
     }
 
 private:
@@ -809,11 +819,19 @@ static std::string expandReplacement(const char *repl, size_t repLen,
             size_t numStart = i;
             while (i < repLen && std::isdigit((unsigned char)repl[i])) ++i;
             if (i < repLen && repl[i] == '}' && i > numStart) {
-                int idx = 0;
-                for (size_t j = numStart; j < i; ++j)
-                    idx = idx * 10 + (repl[j] - '0');
-                if (idx >= 0 && static_cast<size_t>(idx) < caps.size()) {
-                    auto [s, e] = caps[static_cast<size_t>(idx)];
+                size_t idx = 0;
+                bool overflow = false;
+                for (size_t j = numStart; j < i; ++j) {
+                    const size_t digit = static_cast<size_t>(repl[j] - '0');
+                    if (idx > (std::numeric_limits<size_t>::max() - digit) / 10) {
+                        overflow = true;
+                        break;
+                    }
+                    idx = idx * 10 + digit;
+                    if (idx >= caps.size()) break;
+                }
+                if (!overflow && idx < caps.size()) {
+                    auto [s, e] = caps[idx];
                     if (s >= 0 && e >= s) out.append(text + s, static_cast<size_t>(e - s));
                 }
                 // if '}' missing or no digits, skip and consume what we have
@@ -887,9 +905,12 @@ const char *__ry_regex_replace(const char *pattern, const char *text,
     for (auto &[start, end] : matches) {
         result.append(text + lastEnd, static_cast<size_t>(start) - lastEnd);
         if (needsCaptures) {
-            CaptureVec caps = bt
-                ? bt->extractCaptures(text, textLen, start, end)
-                : CaptureVec(1, {start, end});
+            CaptureVec caps;
+            if (bt) {
+                bt->extractCaptures(text, textLen, start, end, caps);
+            } else {
+                caps = CaptureVec(1, {start, end});
+            }
             result += expandReplacement(replacement, repLen, text, caps);
         } else {
             result.append(replacement, repLen);

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -20,7 +20,8 @@ namespace {
 // ============================================================
 
 struct NFAState {
-    enum class Kind { Match, Split, Char, Dot, CharClass, Anchor, WordBoundary };
+    enum class Kind { Match, Split, Char, Dot, CharClass, Anchor, WordBoundary,
+                      GroupOpen, GroupClose };
     Kind kind = Kind::Match;
 
     // Char
@@ -39,6 +40,9 @@ struct NFAState {
 
     // For single-pass search: tracks the text position where this match attempt started
     size_t matchStartPos = 0;
+
+    // GroupOpen / GroupClose: 1-based capture group index
+    int groupIndex = 0;
 };
 
 struct NFAFragment {
@@ -205,8 +209,19 @@ public:
                 return result;
             }
         }
-        case RegexNodeKind::Group:
+        case RegexNodeKind::Group: {
+            if (node.groupIndex > 0) {
+                auto *open = newState(NFAState::Kind::GroupOpen);
+                open->groupIndex = node.groupIndex;
+                auto inner = build(*node.children[0]);
+                auto *close = newState(NFAState::Kind::GroupClose);
+                close->groupIndex = node.groupIndex;
+                open->out1 = inner.start;
+                patch(inner, close);
+                return {open, {&close->out1}};
+            }
             return build(*node.children[0]);
+        }
         }
         // unreachable
         fprintf(stderr, "regex internal error: unknown node kind\n");
@@ -221,6 +236,52 @@ public:
 private:
     std::vector<NFAState *> states_;
 };
+
+// ============================================================
+// Shared character-matching helpers (used by NFASimulator and CaptureBacktracker)
+// ============================================================
+
+static bool nfaIsWordChar(char c) {
+    for (auto &[lo, hi] : WORD_CHAR_RANGES) {
+        if (c >= lo && c <= hi) return true;
+    }
+    return false;
+}
+
+static bool nfaCharInRange(char c, char lo, char hi, bool caseInsensitive) {
+    if (c >= lo && c <= hi) return true;
+    if (caseInsensitive) {
+        char cl = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+        char cu = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+        return (cl >= lo && cl <= hi) || (cu >= lo && cu <= hi);
+    }
+    return false;
+}
+
+static bool nfaCharClassMatches(NFAState *s, char c, bool caseInsensitive) {
+    bool inRange = false;
+    for (auto &[lo, hi] : s->ranges) {
+        if (nfaCharInRange(c, lo, hi, caseInsensitive)) { inRange = true; break; }
+    }
+    return s->negated ? !inRange : inRange;
+}
+
+static bool nfaStateMatchesChar(NFAState *s, char c, bool caseInsensitive) {
+    switch (s->kind) {
+    case NFAState::Kind::Char:
+        if (caseInsensitive) {
+            return std::tolower((unsigned char)s->ch) ==
+                   std::tolower((unsigned char)c);
+        }
+        return s->ch == c;
+    case NFAState::Kind::Dot:
+        return c != '\n';
+    case NFAState::Kind::CharClass:
+        return nfaCharClassMatches(s, c, caseInsensitive);
+    default:
+        return false;
+    }
+}
 
 // ============================================================
 // NFA Simulation
@@ -509,6 +570,11 @@ private:
             addState(stateSet, s->out2, text, textLen, pos, matchStartPos);
             return;
         }
+        if (s->kind == NFAState::Kind::GroupOpen ||
+            s->kind == NFAState::Kind::GroupClose) {
+            addState(stateSet, s->out1, text, textLen, pos, matchStartPos);
+            return;
+        }
         if (s->kind == NFAState::Kind::Anchor) {
             if (s->ch == '^') {
                 if (pos == 0) addState(stateSet, s->out1, text, textLen, pos, matchStartPos);
@@ -518,8 +584,8 @@ private:
             return;
         }
         if (s->kind == NFAState::Kind::WordBoundary) {
-            bool prevIsWord = (pos > 0) && isWordChar(text[pos - 1]);
-            bool currIsWord = (pos < textLen) && isWordChar(text[pos]);
+            bool prevIsWord = (pos > 0) && nfaIsWordChar(text[pos - 1]);
+            bool currIsWord = (pos < textLen) && nfaIsWordChar(text[pos]);
             bool atBoundary = (prevIsWord != currIsWord);
             if (atBoundary != s->negated) {
                 addState(stateSet, s->out1, text, textLen, pos, matchStartPos);
@@ -529,28 +595,8 @@ private:
         stateSet.push_back(s);
     }
 
-    static bool isWordChar(char c) {
-        for (auto &[lo, hi] : WORD_CHAR_RANGES) {
-            if (c >= lo && c <= hi) return true;
-        }
-        return false;
-    }
-
     bool stateMatchesChar(NFAState *s, char c) const {
-        switch (s->kind) {
-        case NFAState::Kind::Char:
-            if (caseInsensitive_) {
-                return std::tolower((unsigned char)s->ch) ==
-                       std::tolower((unsigned char)c);
-            }
-            return s->ch == c;
-        case NFAState::Kind::Dot:
-            return c != '\n';
-        case NFAState::Kind::CharClass:
-            return charClassMatches(s, c, caseInsensitive_);
-        default:
-            return false;
-        }
+        return nfaStateMatchesChar(s, c, caseInsensitive_);
     }
 
     bool hasActiveThreadFrom(size_t startPos) const {
@@ -569,23 +615,6 @@ private:
         return false;
     }
 
-    static bool charInRange(char c, char lo, char hi, bool caseInsensitive) {
-        if (c >= lo && c <= hi) return true;
-        if (caseInsensitive) {
-            char cl = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
-            char cu = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
-            return (cl >= lo && cl <= hi) || (cu >= lo && cu <= hi);
-        }
-        return false;
-    }
-
-    static bool charClassMatches(NFAState *s, char c, bool caseInsensitive = false) {
-        bool inRange = false;
-        for (auto &[lo, hi] : s->ranges) {
-            if (charInRange(c, lo, hi, caseInsensitive)) { inRange = true; break; }
-        }
-        return s->negated ? !inRange : inRange;
-    }
 };
 
 // ============================================================
@@ -598,6 +627,8 @@ struct CompiledRegex {
     NFAState *start;
     bool hasLazy_ = false;
     bool caseInsensitive_ = false;
+    int groupCount_ = 0;
+    int groupCount() const { return groupCount_; }
 
     static bool detectLazy(const RegexNode &node) {
         if (node.kind == RegexNodeKind::Repeat && !node.greedy) return true;
@@ -614,6 +645,7 @@ struct CompiledRegex {
         CompiledRegex cr;
         cr.hasLazy_ = detectLazy(*ast);
         cr.caseInsensitive_ = parser.caseInsensitive();
+        cr.groupCount_ = parser.groupCount();
         auto frag = cr.builder.build(*ast);
         cr.matchState = cr.builder.newState(NFAState::Kind::Match);
         cr.builder.patch(frag, cr.matchState);
@@ -642,6 +674,171 @@ struct CompiledRegex {
         return sim.findAllSinglePass(text, len, hasLazy_);
     }
 };
+
+// ============================================================
+// Backtracking capture extractor (used only when $N is in replacement)
+// ============================================================
+
+// Per-group capture span: {start, end} or {-1, -1} if not matched.
+// captures[0] = whole match, captures[i] = group i (1-based).
+using CaptureVec = std::vector<std::pair<int64_t, int64_t>>;
+
+class CaptureBacktracker {
+public:
+    static constexpr int64_t MAX_STEPS = 1'000'000;
+
+    CaptureBacktracker(NFAState *start, NFAState *matchState,
+                       int groupCount, bool caseInsensitive)
+        : start_(start), matchState_(matchState),
+          groupCount_(groupCount), caseInsensitive_(caseInsensitive) {}
+
+    // Extract capture positions for a known match span [matchStart, matchEnd).
+    // caps[0] = whole match, caps[i] = group i, or {-1,-1} if unmatched.
+    CaptureVec extractCaptures(const char *text, size_t textLen,
+                               int64_t matchStart, int64_t matchEnd) {
+        CaptureVec caps(static_cast<size_t>(groupCount_ + 1), {-1, -1});
+        int64_t steps = 0;
+        backtrack(start_, text, textLen, static_cast<size_t>(matchStart),
+                  static_cast<size_t>(matchEnd), caps, steps);
+        // backtrack may set caps[0] via GroupOpen/GroupClose on a wrapping group;
+        // always overwrite with the authoritative bounds from findAll.
+        caps[0] = {matchStart, matchEnd};
+        return caps;
+    }
+
+private:
+    NFAState *start_;
+    NFAState *matchState_;
+    int groupCount_;
+    bool caseInsensitive_;
+
+    // Recursive backtracking. Returns true if we reach matchState_ at pos == matchEnd.
+    bool backtrack(NFAState *s, const char *text, size_t textLen,
+                   size_t pos, size_t matchEnd, CaptureVec &caps, int64_t &steps) {
+        if (++steps > MAX_STEPS) return false;
+        if (!s) return false;
+
+        if (s == matchState_) {
+            return pos == matchEnd;
+        }
+
+        switch (s->kind) {
+        case NFAState::Kind::Split: {
+            if (backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps)) return true;
+            return backtrack(s->out2, text, textLen, pos, matchEnd, caps, steps);
+        }
+        case NFAState::Kind::GroupOpen: {
+            int64_t saved = caps[static_cast<size_t>(s->groupIndex)].first;
+            caps[static_cast<size_t>(s->groupIndex)].first = static_cast<int64_t>(pos);
+            if (backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps)) return true;
+            caps[static_cast<size_t>(s->groupIndex)].first = saved;
+            return false;
+        }
+        case NFAState::Kind::GroupClose: {
+            int64_t saved = caps[static_cast<size_t>(s->groupIndex)].second;
+            caps[static_cast<size_t>(s->groupIndex)].second = static_cast<int64_t>(pos);
+            if (backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps)) return true;
+            caps[static_cast<size_t>(s->groupIndex)].second = saved;
+            return false;
+        }
+        case NFAState::Kind::Anchor: {
+            bool ok = false;
+            if (s->ch == '^') ok = (pos == 0);
+            else               ok = (pos == textLen);
+            if (!ok) return false;
+            return backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps);
+        }
+        case NFAState::Kind::WordBoundary: {
+            bool prevIsWord = (pos > 0) && nfaIsWordChar(text[pos - 1]);
+            bool currIsWord = (pos < textLen) && nfaIsWordChar(text[pos]);
+            bool atBoundary = (prevIsWord != currIsWord);
+            if (atBoundary == s->negated) return false;
+            return backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps);
+        }
+        default:
+            break;
+        }
+
+        // Char / Dot / CharClass: consume one character
+        if (pos >= textLen) return false;
+        if (!nfaStateMatchesChar(s, text[pos], caseInsensitive_)) return false;
+        return backtrack(s->out1, text, textLen, pos + 1, matchEnd, caps, steps);
+    }
+};
+
+// ============================================================
+// Replacement string utilities
+// ============================================================
+
+// Returns true if the replacement string contains any $N or ${ backreference.
+static bool hasBackreferences(const char *repl, size_t len) {
+    for (size_t i = 0; i + 1 < len; ++i) {
+        if (repl[i] == '$') {
+            char next = repl[i + 1];
+            if (next == '$') { ++i; continue; } // skip $$
+            if (std::isdigit((unsigned char)next) || next == '{') return true;
+        }
+    }
+    return false;
+}
+
+// Expand $N / ${N} / $$ / $0 in replacement using the provided captures.
+// Captures[0] = whole match, captures[i] = group i.
+// Out-of-range or unmatched groups expand to empty string.
+static std::string expandReplacement(const char *repl, size_t repLen,
+                                     const char *text,
+                                     const CaptureVec &caps) {
+    std::string out;
+    out.reserve(repLen);
+    for (size_t i = 0; i < repLen; ++i) {
+        if (repl[i] != '$') {
+            out += repl[i];
+            continue;
+        }
+        ++i;
+        if (i >= repLen) {
+            out += '$';
+            break;
+        }
+        char next = repl[i];
+        if (next == '$') {
+            out += '$';
+        } else if (next == '{') {
+            // ${N} syntax for multi-digit groups
+            ++i;
+            size_t numStart = i;
+            while (i < repLen && std::isdigit((unsigned char)repl[i])) ++i;
+            if (i < repLen && repl[i] == '}' && i > numStart) {
+                int idx = 0;
+                for (size_t j = numStart; j < i; ++j)
+                    idx = idx * 10 + (repl[j] - '0');
+                if (idx >= 0 && static_cast<size_t>(idx) < caps.size()) {
+                    auto [s, e] = caps[static_cast<size_t>(idx)];
+                    if (s >= 0 && e >= s) out.append(text + s, static_cast<size_t>(e - s));
+                }
+                // if '}' missing or no digits, skip and consume what we have
+            } else {
+                // malformed ${...} — emit literally
+                out += '$';
+                out += '{';
+                for (size_t j = numStart; j < i; ++j) out += repl[j];
+                if (i < repLen && repl[i] == '}') { /* consumed */ } else --i;
+            }
+        } else if (std::isdigit((unsigned char)next)) {
+            int idx = next - '0';
+            if (idx >= 0 && static_cast<size_t>(idx) < caps.size()) {
+                auto [s, e] = caps[static_cast<size_t>(idx)];
+                if (s >= 0 && e >= s) out.append(text + s, static_cast<size_t>(e - s));
+            }
+            // out-of-range → empty string (intentional)
+        } else {
+            // $ followed by non-digit, non-{ → literal $
+            out += '$';
+            out += next;
+        }
+    }
+    return out;
+}
 
 } // anonymous namespace
 
@@ -675,13 +872,29 @@ const char *__ry_regex_replace(const char *pattern, const char *text,
 
     size_t textLen = strlen(text);
     size_t repLen = strlen(replacement);
+    bool needsCaptures = hasBackreferences(replacement, repLen);
+
     std::string result;
     result.reserve(textLen + matches.size() * repLen);
     size_t lastEnd = 0;
+
+    std::unique_ptr<CaptureBacktracker> bt;
+    if (needsCaptures) {
+        bt = std::make_unique<CaptureBacktracker>(
+            cr.start, cr.matchState, cr.groupCount(), cr.caseInsensitive_);
+    }
+
     for (auto &[start, end] : matches) {
-        result.append(text + lastEnd, (size_t)start - lastEnd);
-        result.append(replacement, repLen);
-        lastEnd = (size_t)end;
+        result.append(text + lastEnd, static_cast<size_t>(start) - lastEnd);
+        if (needsCaptures) {
+            CaptureVec caps = bt
+                ? bt->extractCaptures(text, textLen, start, end)
+                : CaptureVec(1, {start, end});
+            result += expandReplacement(replacement, repLen, text, caps);
+        } else {
+            result.append(replacement, repLen);
+        }
+        lastEnd = static_cast<size_t>(end);
     }
     result.append(text + lastEnd);
     return dupString(result.c_str(), result.size());

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -780,13 +780,20 @@ private:
 // Replacement string utilities
 // ============================================================
 
-// Returns true if the replacement string contains any $N or ${ backreference.
+// Returns true if the replacement string contains any $N or ${digits} backreference.
 static bool hasBackreferences(const char *repl, size_t len) {
     for (size_t i = 0; i + 1 < len; ++i) {
         if (repl[i] == '$') {
             char next = repl[i + 1];
             if (next == '$') { ++i; continue; } // skip $$
-            if (std::isdigit((unsigned char)next) || next == '{') return true;
+            if (std::isdigit((unsigned char)next)) return true;
+            if (next == '{') {
+                // Only ${digits} counts — scan ahead for at least one digit + '}'
+                size_t j = i + 2;
+                while (j < len && std::isdigit((unsigned char)repl[j])) ++j;
+                if (j > i + 2 && j < len && repl[j] == '}') return true;
+                // else: malformed ${...}, not a backreference — keep scanning
+            }
         }
     }
     return false;
@@ -840,7 +847,11 @@ static std::string expandReplacement(const char *repl, size_t repLen,
                 out += '$';
                 out += '{';
                 for (size_t j = numStart; j < i; ++j) out += repl[j];
-                if (i < repLen && repl[i] == '}') { /* consumed */ } else --i;
+                if (i < repLen && repl[i] == '}') {
+                    out += '}';
+                } else {
+                    --i;
+                }
             }
         } else if (std::isdigit((unsigned char)next)) {
             int idx = next - '0';

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -7,6 +7,7 @@
 #include <cctype>
 #include <cstring>
 #include <limits>
+#include <set>
 #include <string>
 #include <vector>
 #include <memory>
@@ -686,8 +687,6 @@ using CaptureVec = std::vector<std::pair<int64_t, int64_t>>;
 
 class CaptureBacktracker {
 public:
-    static constexpr int64_t MAX_STEPS = 1'000'000;
-
     CaptureBacktracker(NFAState *start, NFAState *matchState,
                        int groupCount, bool caseInsensitive)
         : start_(start), matchState_(matchState),
@@ -695,18 +694,20 @@ public:
 
     // Extract capture positions for a known match span [matchStart, matchEnd).
     // caps[0] = whole match, caps[i] = group i, or {-1,-1} if unmatched.
-    // Returns true on success; false if the step limit was hit (caps may be partial).
+    // Returns true on success; false if no path was found.
     bool extractCaptures(const char *text, size_t textLen,
                          int64_t matchStart, int64_t matchEnd,
                          CaptureVec &caps) {
         caps.assign(static_cast<size_t>(groupCount_) + 1, {-1, -1});
-        int64_t steps = 0;
+        // onPath tracks (state, pos) pairs on the current DFS path to detect
+        // epsilon cycles (states that loop without consuming input).
+        DFSPath onPath;
         bool ok = backtrack(start_, text, textLen, static_cast<size_t>(matchStart),
-                            static_cast<size_t>(matchEnd), caps, steps);
+                            static_cast<size_t>(matchEnd), caps, onPath);
         if (!ok) {
             fprintf(stderr,
-                    "regex warning: capture extraction failed for match [%lld, %lld) "
-                    "(step limit or no path found); backreferences may expand to empty\n",
+                    "regex warning: capture extraction found no valid path for match "
+                    "[%lld, %lld); backreferences may expand to empty\n",
                     static_cast<long long>(matchStart),
                     static_cast<long long>(matchEnd));
         }
@@ -722,57 +723,68 @@ private:
     int groupCount_;
     bool caseInsensitive_;
 
+    // (state pointer, text position) — used to detect epsilon cycles in the DFS.
+    using DFSPath = std::set<std::pair<NFAState *, size_t>>;
+
     // Recursive backtracking. Returns true if we reach matchState_ at pos == matchEnd.
+    // onPath contains all (state, pos) pairs currently on the recursion stack;
+    // any repeat signals an epsilon cycle and is pruned immediately.
     bool backtrack(NFAState *s, const char *text, size_t textLen,
-                   size_t pos, size_t matchEnd, CaptureVec &caps, int64_t &steps) {
-        if (++steps > MAX_STEPS) return false;
+                   size_t pos, size_t matchEnd, CaptureVec &caps, DFSPath &onPath) {
         if (!s) return false;
 
         if (s == matchState_) {
             return pos == matchEnd;
         }
 
+        // Epsilon-cycle guard: if this (state, pos) pair is already on the current
+        // DFS path we would loop forever — prune this branch.
+        auto key = std::make_pair(s, pos);
+        if (!onPath.insert(key).second) return false;
+
+        bool result = false;
         switch (s->kind) {
         case NFAState::Kind::Split: {
-            if (backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps)) return true;
-            return backtrack(s->out2, text, textLen, pos, matchEnd, caps, steps);
+            result = backtrack(s->out1, text, textLen, pos, matchEnd, caps, onPath) ||
+                     backtrack(s->out2, text, textLen, pos, matchEnd, caps, onPath);
+            break;
         }
         case NFAState::Kind::GroupOpen: {
             int64_t saved = caps[static_cast<size_t>(s->groupIndex)].first;
             caps[static_cast<size_t>(s->groupIndex)].first = static_cast<int64_t>(pos);
-            if (backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps)) return true;
-            caps[static_cast<size_t>(s->groupIndex)].first = saved;
-            return false;
+            result = backtrack(s->out1, text, textLen, pos, matchEnd, caps, onPath);
+            if (!result) caps[static_cast<size_t>(s->groupIndex)].first = saved;
+            break;
         }
         case NFAState::Kind::GroupClose: {
             int64_t saved = caps[static_cast<size_t>(s->groupIndex)].second;
             caps[static_cast<size_t>(s->groupIndex)].second = static_cast<int64_t>(pos);
-            if (backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps)) return true;
-            caps[static_cast<size_t>(s->groupIndex)].second = saved;
-            return false;
+            result = backtrack(s->out1, text, textLen, pos, matchEnd, caps, onPath);
+            if (!result) caps[static_cast<size_t>(s->groupIndex)].second = saved;
+            break;
         }
         case NFAState::Kind::Anchor: {
-            bool ok = false;
-            if (s->ch == '^') ok = (pos == 0);
-            else               ok = (pos == textLen);
-            if (!ok) return false;
-            return backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps);
+            bool pass = (s->ch == '^') ? (pos == 0) : (pos == textLen);
+            if (pass) result = backtrack(s->out1, text, textLen, pos, matchEnd, caps, onPath);
+            break;
         }
         case NFAState::Kind::WordBoundary: {
             bool prevIsWord = (pos > 0) && nfaIsWordChar(text[pos - 1]);
             bool currIsWord = (pos < textLen) && nfaIsWordChar(text[pos]);
             bool atBoundary = (prevIsWord != currIsWord);
-            if (atBoundary == s->negated) return false;
-            return backtrack(s->out1, text, textLen, pos, matchEnd, caps, steps);
+            if (atBoundary != s->negated)
+                result = backtrack(s->out1, text, textLen, pos, matchEnd, caps, onPath);
+            break;
         }
         default:
+            // Char / Dot / CharClass: consume one character
+            if (pos < textLen && nfaStateMatchesChar(s, text[pos], caseInsensitive_))
+                result = backtrack(s->out1, text, textLen, pos + 1, matchEnd, caps, onPath);
             break;
         }
 
-        // Char / Dot / CharClass: consume one character
-        if (pos >= textLen) return false;
-        if (!nfaStateMatchesChar(s, text[pos], caseInsensitive_)) return false;
-        return backtrack(s->out1, text, textLen, pos + 1, matchEnd, caps, steps);
+        onPath.erase(key);
+        return result;
     }
 };
 

--- a/src/runtime_regex_parser.cpp
+++ b/src/runtime_regex_parser.cpp
@@ -194,6 +194,7 @@ RegexNodePtr RegexParser::parseAtom() {
         --groupDepth_;
         auto node = std::make_unique<RegexNode>();
         node->kind = RegexNodeKind::Group;
+        node->groupIndex = ++groupCount_;
         node->children.push_back(std::move(inner));
         return node;
     }

--- a/tests/spec/regex_capture.test.ry
+++ b/tests/spec/regex_capture.test.ry
@@ -1,0 +1,37 @@
+from regex import replace, regex_replace
+
+describe("regex replace capture group backreferences", ():
+  it("should expand $1 to first capture group", ():
+    expect(replace("hello world", /(\w+) (\w+)/, "$2, $1!")).to_eq("world, hello!")
+  )
+  it("should expand $0 to the whole match", ():
+    expect(replace("hello world", /\w+/, "[$0]")).to_eq("[hello] [world]")
+  )
+  it("should reformat date using $3/$2/$1", ():
+    expect(replace("2026-04-10", /(\d+)-(\d+)-(\d+)/, "$3/$2/$1")).to_eq("10/04/2026")
+  )
+  it("should treat $$ as literal dollar sign", ():
+    expect(replace("price: 100", /(\d+)/, "$$$1")).to_eq("price: $100")
+  )
+  it("should treat out-of-range $N as empty string", ():
+    expect(replace("a", /(a)/, "$2")).to_eq("")
+  )
+  it("should treat $ without digit as literal $", ():
+    expect(replace("a", /a/, "$ x")).to_eq("$ x")
+  )
+  it("should support $0 with no capture groups", ():
+    expect(replace("hello", /\w+/, "($0)")).to_eq("(hello)")
+  )
+  it("should support multiple matches each with captures", ():
+    expect(replace("a1 b2 c3", /(\w)(\d)/, "$2$1")).to_eq("1a 2b 3c")
+  )
+  it("should support UFCS form", ():
+    expect("user@host".replace(/(\w+)@(\w+)/, "$2@$1")).to_eq("host@user")
+  )
+  it("should support legacy regex_replace form", ():
+    expect(regex_replace("user@host", "(\\w+)@(\\w+)", "$2@$1")).to_eq("host@user")
+  )
+  it("should not affect patterns without backreferences", ():
+    expect(replace("a1b2", /\d+/, "X")).to_eq("aXbX")
+  )
+)

--- a/tests/spec/regex_capture.test.ry
+++ b/tests/spec/regex_capture.test.ry
@@ -16,6 +16,9 @@ describe("regex replace capture group backreferences", ():
   it("should treat out-of-range $N as empty string", ():
     expect(replace("a", /(a)/, "$2")).to_eq("")
   )
+  it("should treat existing-but-unmatched group as empty string", ():
+    expect(replace("b", /(a)?b/, "[$1]")).to_eq("[]")
+  )
   it("should treat $ without digit as literal $", ():
     expect(replace("a", /a/, "$ x")).to_eq("$ x")
   )

--- a/tests/test_regex_runtime.cpp
+++ b/tests/test_regex_runtime.cpp
@@ -250,6 +250,18 @@ TEST(RegexRuntime, ReplaceCaptureMultiDigitBrace) {
     free((void *)r);
 }
 
+TEST(RegexRuntime, ReplaceMalformedBrace) {
+    // Malformed ${...} tokens must NOT trigger the capture backtracker
+    // and must be emitted literally in the output.
+    const char *r1 = __ry_regex_replace("(a)", "a", "${foo}");
+    EXPECT_STREQ(r1, "${foo}");  // non-digit content: literal
+    free((void *)r1);
+
+    const char *r2 = __ry_regex_replace("(a)", "a", "${}");
+    EXPECT_STREQ(r2, "${}");   // empty braces: literal
+    free((void *)r2);
+}
+
 // ============================================================
 // regex_split tests
 // ============================================================

--- a/tests/test_regex_runtime.cpp
+++ b/tests/test_regex_runtime.cpp
@@ -166,6 +166,91 @@ TEST(RegexRuntime, ReplaceEmpty) {
 }
 
 // ============================================================
+// Capture group backreference tests (#829)
+// ============================================================
+
+TEST(RegexRuntime, ReplaceCaptureFastPath) {
+    // No backreferences → existing fast path, groups have no effect
+    const char *r = __ry_regex_replace("(\\d+)", "a1b2", "X");
+    EXPECT_STREQ(r, "aXbX");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureWholeMatch) {
+    // $0 expands to the whole match
+    const char *r = __ry_regex_replace("\\w+", "hello world", "[$0]");
+    EXPECT_STREQ(r, "[hello] [world]");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureGroup1) {
+    // $1 expands to first capture group
+    const char *r = __ry_regex_replace("(\\w+)", "hello world", "[$1]");
+    EXPECT_STREQ(r, "[hello] [world]");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureSwapGroups) {
+    // Swap two captured words: $2 $1
+    const char *r = __ry_regex_replace("(\\w+)@(\\w+)", "user@host", "$2@$1");
+    EXPECT_STREQ(r, "host@user");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureThreeGroups) {
+    // Date reformat: YYYY-MM-DD → DD/MM/YYYY
+    const char *r = __ry_regex_replace("(\\d+)-(\\d+)-(\\d+)", "2026-04-10", "$3/$2/$1");
+    EXPECT_STREQ(r, "10/04/2026");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureMultipleMatches) {
+    // Multiple matches, each gets its own capture extraction
+    const char *r = __ry_regex_replace("(\\w)(\\d)", "a1 b2 c3", "$2$1");
+    EXPECT_STREQ(r, "1a 2b 3c");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureLiteralDollar) {
+    // $$ → literal $
+    const char *r = __ry_regex_replace("(\\d+)", "price 100", "$$$1");
+    EXPECT_STREQ(r, "price $100");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureOutOfRange) {
+    // $2 when only 1 group → empty string
+    const char *r = __ry_regex_replace("(a)", "a", "$2");
+    EXPECT_STREQ(r, "");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureNoGroupsWithDollar0) {
+    // $0 works even with no capture groups (whole match)
+    const char *r = __ry_regex_replace("\\d+", "num 42 num", "($0)");
+    EXPECT_STREQ(r, "num (42) num");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureDollarNoDigit) {
+    // $ not followed by digit → literal $
+    const char *r = __ry_regex_replace("a", "abc", "$ b");
+    EXPECT_STREQ(r, "$ bbc");
+    free((void *)r);
+}
+
+TEST(RegexRuntime, ReplaceCaptureMultiDigitBrace) {
+    // ${N} syntax for groups beyond $9
+    // Build pattern with 10 groups: (a)(b)(c)(d)(e)(f)(g)(h)(i)(j)
+    const char *r = __ry_regex_replace(
+        "(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)",
+        "abcdefghij",
+        "${10}${9}");
+    EXPECT_STREQ(r, "ji");
+    free((void *)r);
+}
+
+// ============================================================
 // regex_split tests
 // ============================================================
 


### PR DESCRIPTION
## Summary

- `regex.replace` and `regex_replace` now expand `$1`–`$9`, `$0` (whole match), `${N}` (multi-digit), and `$$` (literal dollar) in replacement strings
- Uses a backtracking capture extractor anchored to each match span — existing Thompson NFA fast path is completely unchanged when no `$N` appears in the replacement
- Shared character-matching helpers (`nfaIsWordChar`, `nfaStateMatchesChar`, `nfaCharClassMatches`) extracted as free functions to eliminate code duplication between `NFASimulator` and the new `CaptureBacktracker`

Closes #829

## Changes

- `include/ry/runtime_regex_internal.hpp` — `RegexNode.groupIndex`, `RegexParser.groupCount()`
- `src/runtime_regex_parser.cpp` — assign 1-based group indices during parse
- `src/runtime_regex.cpp` — `GroupOpen`/`GroupClose` NFA states, `CaptureBacktracker`, `hasBackreferences`, `expandReplacement`, wired into `__ry_regex_replace`
- `docs/reference/regex.md` — Capture Group Backreferences section added
- `changelog.d/829-regex-replace-backreferences.md` — changelog fragment

## Test plan

- [x] 11 C++ unit tests in `tests/test_regex_runtime.cpp` (`ReplaceCapture*`)
- [x] 11 Ry spec tests in `tests/spec/regex_capture.test.ry`
- [x] All 1635 C++ tests pass (`./build/ry_tests`)
- [x] All 119 Ry test files pass (`./build/ry test -p`)
- [x] ASan + UBSan clean
- [x] TSan clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Regex replacement strings now support capture-group backreferences: `$0` (full match), `$1`–`$9`, `${N}` for multi-digit groups, and `$$` for literal `$`. Out-of-range or unmatched groups expand to empty strings. Both `replace` and `regex_replace` forms are supported.

* **Documentation**
  * Added a "Regex Engine" section and expanded reference docs with capture-group backreference guidance and examples.

* **Tests**
  * Added unit and spec tests covering parsing, expansion, escaping, multi-match behavior, and fast-path non-backreference cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->