### PR TITLE
feat: find_all returns List<Match> with capture groups (#830)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1154,8 +1154,10 @@ NFA graph, anchored to the match boundaries already found by `findAll`. This:
 1. Keeps the Thompson path completely unchanged (no performance impact for non-backreference patterns)
 2. Is safe against catastrophic backtracking because the span is bounded by the match
 
-If full capture group support is needed beyond `replace` (e.g., `find_all` returning subgroups),
-revisit the Thompson NFA and migrate to per-thread capture slot arrays.
+As of #830, `find_all` also uses `CaptureBacktracker` to expose capture groups in `Match.groups`.
+The same two-phase approach (NFA finds boundaries, CaptureBacktracker extracts groups) works
+well without modifying the NFA simulator. Migrating to per-thread capture slot arrays would
+only be necessary if performance profiling shows the per-match backtracking is a bottleneck.
 
 ### GroupOpen / GroupClose epsilon states are transparent to the Thompson NFA simulator
 
@@ -1576,3 +1578,24 @@ functions are all handled by custom codegen emitters and have no
 separate shared library. Use `@native("pkg")` only when the package
 has a corresponding `libry_<pkg>.*` shared library built via
 `add_ry_native_lib()`.
+
+### `Match` type is registered programmatically in codegen, not via a `record` declaration in regex.ry
+
+**Source**: #830 (2026-04-14, implementation)
+**Tags**: regex, record-type, codegen, stdlib-design
+
+**Rule**: The `Match` type (`{full: str, groups: List<str>}`) used as the element type of
+`find_all`'s return value is registered in `struct_types_` inside the `CodeGen` constructor
+(same pattern as `Error`), not declared as a `record` in `share/std/regex.ry`.
+
+**Why**: If `Match` were declared in `regex.ry`, it would only be registered when a user
+explicitly imports it (e.g., `from regex import Match, find_all`). Omitting `Match` from the
+import would cause codegen to silently fail to find the type in `struct_types_` when it tries
+to tag the `find_all` result. By registering it unconditionally at construction time (same as
+`Error`), users can write `from regex import find_all` without importing `Match` and still get
+the fully-typed `List<Match>` result, including field access via `.full` and `.groups`.
+
+**How to apply**: When a stdlib function returns a record type and that type must be available
+regardless of explicit import, register it programmatically in the `CodeGen` constructor
+alongside `Error`. If instead the type should only be available on explicit import (e.g., a
+user-facing constructor), define it in the `.ry` file as a normal `record`.

--- a/changelog.d/830-find-all-match-type.md
+++ b/changelog.d/830-find-all-match-type.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `find_all` and `regex_find_all` now return `List<Match>` instead of `List<str>`. Each `Match` record has a `full: str` field (the matched text) and a `groups: List<str>` field (captured groups, in order). Patterns without capture groups return an empty `groups` list. (#830)

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -52,7 +52,7 @@ These functions take a `Regex` type pattern and use text-first argument order fo
 | `search` | `(str, Regex) -> int` | Returns the start position of the first match (-1 if not found) |
 | `replace` | `(str, Regex, str) -> str` | Replaces all matches with a replacement string |
 | `split` | `(str, Regex) -> List<str>` | Splits text by pattern matches |
-| `find_all` | `(str, Regex) -> List<str>` | Returns all non-overlapping matches |
+| `find_all` | `(str, Regex) -> List<Match>` | Returns all non-overlapping matches with capture groups |
 
 ```ry
 from regex import is_match, search, replace, split, find_all
@@ -64,7 +64,8 @@ print(is_match("hello", /[a-z]+/))       # true
 print("abc123".search(/[0-9]+/))          # 3
 print("abc123".replace(/[0-9]+/, "X"))    # abcX
 parts = "hello world".split(/\s+/)
-nums = "a1b2c3".find_all(/[0-9]/)
+matches = "a1b2c3".find_all(/[0-9]/)
+print(matches[0].full)   # "1"
 ```
 
 ### Legacy Functions (text-first)
@@ -77,12 +78,45 @@ The original `regex_*` functions remain available for backward compatibility. Th
 | `regex_search` | `(text: str, pattern: str) -> int` | Returns the start position of the first match (-1 if not found) |
 | `regex_replace` | `(text: str, pattern: str, replacement: str) -> str` | Replaces all matches with a replacement string |
 | `regex_split` | `(text: str, pattern: str) -> List<str>` | Splits text by pattern matches |
-| `regex_find_all` | `(text: str, pattern: str) -> List<str>` | Returns all non-overlapping matches |
+| `regex_find_all` | `(text: str, pattern: str) -> List<Match>` | Returns all non-overlapping matches with capture groups |
 
 ```ry
 print(regex_match("hello", "[a-z]+"))   # true
 pos = regex_search("abc123", "[0-9]+")  # 3
 ```
+
+## Match Type
+
+`find_all` and `regex_find_all` return `List<Match>` where each `Match` record has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `full` | `str` | The entire matched substring |
+| `groups` | `List<str>` | Captured group texts, in order (empty list if no capture groups) |
+
+```ry
+from regex import find_all
+
+# Without capture groups: groups is empty
+matches = find_all("a1b2c3", /[0-9]/)
+print(matches[0].full)                 # "1"
+print(length(matches[0].groups))       # 0
+
+# With capture groups
+matches = find_all("2026-04-10", /(\d+)-(\d+)-(\d+)/)
+print(matches[0].full)                 # "2026-04-10"
+print(matches[0].groups[0])            # "2026"
+print(matches[0].groups[1])            # "04"
+print(matches[0].groups[2])            # "10"
+
+# Multiple matches, each with their own capture groups
+for m in find_all("a@b x@y", /(\w+)@(\w+)/):
+    print(m.full)       # "a@b", "x@y"
+    print(m.groups[0])  # "a",   "x"
+    print(m.groups[1])  # "b",   "y"
+```
+
+Unmatched optional groups (e.g., `(a)?` when the group did not participate) expand to an empty string in `groups`.
 
 ## Supported Pattern Syntax
 
@@ -141,10 +175,9 @@ print(l)  # X and X
 
 # Find individual HTML-like tags
 tags = regex_find_all("<a> <bb> <ccc>", "<.*?>")
-print(length(tags))  # 3
+print(length(tags))         # 3
+print(tags[0].full)         # "<a>"
 ```
-
-> **Note:** Non-greedy matching controls the overall match length. Without support for extracting parenthesized groups, mixed greedy/lazy patterns may behave differently from PCRE-style engines.
 
 ### Word Boundary
 
@@ -155,7 +188,8 @@ print(pos)  # 6
 
 # Find all words
 words = regex_find_all("hello world foo", "\\b\\w+\\b")
-print(length(words))  # 3
+print(length(words))         # 3
+print(words[0].full)         # "hello"
 ```
 
 ### Capture Group Backreferences

--- a/include/ry/runtime_list.hpp
+++ b/include/ry/runtime_list.hpp
@@ -43,4 +43,26 @@ inline ListHeader *makeStringList(const std::vector<std::string> &items) {
     return header;
 }
 
+// MatchData layout: {char* full, ListHeader* groups}
+// Matches the LLVM StructType for the Ry `Match` record: {ptr, ptr}.
+// data is cast to char** per the generic list ABI; actual element stride is
+// sizeof(MatchData) and is resolved at codegen time via TypeMeta::ListElem.
+struct MatchData {
+    char *full;
+    void *groups; // ListHeader* for the captured groups (List<str>)
+};
+
+// Build a heap-allocated ListHeader from a vector of MatchData values.
+inline ListHeader *makeMatchList(const std::vector<MatchData> &items) {
+    auto *header = (ListHeader *)checked_malloc(sizeof(ListHeader));
+    header->len = (int64_t)items.size();
+    header->cap = (int64_t)items.size();
+    auto *data = (MatchData *)checked_array_malloc(
+        items.empty() ? 1 : items.size(), sizeof(MatchData));
+    for (size_t i = 0; i < items.size(); ++i)
+        data[i] = items[i];
+    header->data = (char **)data;
+    return header;
+}
+
 } // namespace ry

--- a/share/std/regex.ry
+++ b/share/std/regex.ry
@@ -12,7 +12,7 @@ function regex_replace(text: str, pattern: str, replacement: str) -> str
 function regex_split(text: str, pattern: str) -> List<str>
 
 @native
-function regex_find_all(text: str, pattern: str) -> List<str>
+function regex_find_all(text: str, pattern: str) -> List<Match>
 
 # Regex literal overloads (text-first for UFCS)
 @native
@@ -28,4 +28,4 @@ function replace(text: str, pattern: Regex, replacement: str) -> str
 function split(text: str, pattern: Regex) -> List<str>
 
 @native
-function find_all(text: str, pattern: Regex) -> List<str>
+function find_all(text: str, pattern: Regex) -> List<Match>

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -41,6 +41,17 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
         struct_types_["Error"] = {errorTy_, std::move(errorFields), {}, "", next_type_id_++};
     }
 
+    // Match type: {full: str, groups: List<str>}
+    // Registered globally so `from regex import find_all` works without
+    // explicitly importing Match — same rationale as the Error type above.
+    {
+        auto *matchTy = llvm::StructType::create(*ctx_, {ptrTy_, ptrTy_}, "Match");
+        std::vector<FieldDef> matchFields;
+        matchFields.push_back({"full", TypeNode::makeBasic("str"), {}});
+        matchFields.push_back({"groups", TypeNode::makeBasic("List<str>"), {}});
+        struct_types_["Match"] = {matchTy, std::move(matchFields), {}, "", next_type_id_++};
+    }
+
     listHeaderTy_ = llvm::StructType::create(*ctx_, {i64Ty_, i64Ty_, ptrTy_}, "ListHeader");
     mapHeaderTy_ = llvm::StructType::create(*ctx_, {i64Ty_, i64Ty_, ptrTy_, ptrTy_, i64Ty_, ptrTy_}, "MapHeader");
     setHeaderTy_ = llvm::StructType::create(*ctx_, {i64Ty_, i64Ty_, ptrTy_, i64Ty_, ptrTy_}, "SetHeader");

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -56,10 +56,11 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
         setTypeMeta(TypeMeta::ListElem, r, ptrTy_);
         return r;
     }
-    // regex_find_all(text, pattern) -> List<str>
+    // regex_find_all(text, pattern) -> List<Match>
     if (e.callee == "regex_find_all") {
         llvm::Value *r = emitRegexCall("regex_find_all", 2, fnTy_ptr_ptr_to_ptr_);
-        setTypeMeta(TypeMeta::ListElem, r, ptrTy_);
+        setTypeMeta(TypeMeta::ListElem, r, struct_types_["Match"].llvmType);
+        getOrCreateMeta(r).list_elem_type_name = "Match";
         return r;
     }
 
@@ -86,7 +87,8 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
     }
     if (e.callee == "find_all" && e.args.size() == 2) {
         if (auto *r = emitUfcsRegex("regex_find_all", fnTy_ptr_ptr_to_ptr_)) {
-            setTypeMeta(TypeMeta::ListElem, r, ptrTy_);
+            setTypeMeta(TypeMeta::ListElem, r, struct_types_["Match"].llvmType);
+            getOrCreateMeta(r).list_elem_type_name = "Match";
             return r;
         }
     }

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -956,15 +956,44 @@ void *__ry_regex_split(const char *pattern, const char *text) {
 }
 
 void *__ry_regex_find_all(const char *pattern, const char *text) {
+    if (!pattern || !text) return makeMatchList({});
     auto cr = CompiledRegex::compile(pattern);
     auto matches = cr.findAll(text);
 
-    std::vector<std::string> items;
-    items.reserve(matches.size());
-    for (auto &[start, end] : matches) {
-        items.emplace_back(text + start, static_cast<size_t>(end - start));
+    size_t textLen = strlen(text);
+    int numGroups = cr.groupCount();
+
+    std::unique_ptr<CaptureBacktracker> bt;
+    if (numGroups > 0) {
+        bt = std::make_unique<CaptureBacktracker>(
+            cr.start, cr.matchState, numGroups, cr.caseInsensitive_);
     }
-    return makeStringList(items);
+
+    std::vector<MatchData> items;
+    items.reserve(matches.size());
+    CaptureVec caps;
+    for (auto &[start, end] : matches) {
+        MatchData md;
+        md.full = dupString(text + start, static_cast<size_t>(end - start));
+        if (numGroups > 0) {
+            bt->extractCaptures(text, textLen, start, end, caps);
+            std::vector<std::string> groupStrs;
+            groupStrs.reserve(static_cast<size_t>(numGroups));
+            for (int g = 1; g <= numGroups; ++g) {
+                auto [gs, ge] = caps[static_cast<size_t>(g)];
+                if (gs >= 0 && ge >= gs)
+                    groupStrs.emplace_back(text + gs,
+                                           static_cast<size_t>(ge - gs));
+                else
+                    groupStrs.emplace_back();
+            }
+            md.groups = makeStringList(groupStrs);
+        } else {
+            md.groups = makeStringList({});
+        }
+        items.push_back(md);
+    }
+    return makeMatchList(items);
 }
 
 } // extern "C"

--- a/tests/spec/regex_capture.test.ry
+++ b/tests/spec/regex_capture.test.ry
@@ -1,4 +1,4 @@
-from regex import replace, regex_replace
+from regex import replace, regex_replace, find_all, regex_find_all
 
 describe("regex replace capture group backreferences", ():
   it("should expand $1 to first capture group", ():
@@ -36,5 +36,57 @@ describe("regex replace capture group backreferences", ():
   )
   it("should not affect patterns without backreferences", ():
     expect(replace("a1b2", /\d+/, "X")).to_eq("aXbX")
+  )
+)
+
+describe("find_all returns Match with capture groups", ():
+  it("should return full match and groups for each match", ():
+    matches = find_all("date: 2026-04-10 time: 10:30", /(\d+)-(\d+)-(\d+)/)
+    expect(length(matches)).to_eq(1)
+    expect(matches[0].full).to_eq("2026-04-10")
+    expect(length(matches[0].groups)).to_eq(3)
+    expect(matches[0].groups[0]).to_eq("2026")
+    expect(matches[0].groups[1]).to_eq("04")
+    expect(matches[0].groups[2]).to_eq("10")
+  )
+  it("should return empty groups when pattern has no capture groups", ():
+    matches = find_all("a1b2c3", /[0-9]/)
+    expect(length(matches)).to_eq(3)
+    expect(matches[0].full).to_eq("1")
+    expect(length(matches[0].groups)).to_eq(0)
+  )
+  it("should handle multiple matches each with multiple groups", ():
+    matches = find_all("a@b x@y", /(\w+)@(\w+)/)
+    expect(length(matches)).to_eq(2)
+    expect(matches[0].full).to_eq("a@b")
+    expect(matches[0].groups[0]).to_eq("a")
+    expect(matches[0].groups[1]).to_eq("b")
+    expect(matches[1].full).to_eq("x@y")
+    expect(matches[1].groups[0]).to_eq("x")
+    expect(matches[1].groups[1]).to_eq("y")
+  )
+  it("should treat unmatched optional group as empty string", ():
+    matches = find_all("b", /(a)?b/)
+    expect(length(matches)).to_eq(1)
+    expect(matches[0].full).to_eq("b")
+    expect(length(matches[0].groups)).to_eq(1)
+    expect(matches[0].groups[0]).to_eq("")
+  )
+  it("should support UFCS form", ():
+    matches = "a1b2".find_all(/([a-z])(\d)/)
+    expect(length(matches)).to_eq(2)
+    expect(matches[0].full).to_eq("a1")
+    expect(matches[0].groups[0]).to_eq("a")
+    expect(matches[0].groups[1]).to_eq("1")
+  )
+  it("should support legacy regex_find_all form", ():
+    matches = regex_find_all("2026-04-10", "(\\d+)-(\\d+)-(\\d+)")
+    expect(length(matches)).to_eq(1)
+    expect(matches[0].full).to_eq("2026-04-10")
+    expect(matches[0].groups[0]).to_eq("2026")
+  )
+  it("should return empty list when there are no matches", ():
+    matches = find_all("hello", /\d+/)
+    expect(length(matches)).to_eq(0)
   )
 )

--- a/tests/spec/regex_literal.test.ry
+++ b/tests/spec/regex_literal.test.ry
@@ -52,9 +52,9 @@ describe("regex literal find_all", ():
   it("should find all matches", ():
     nums = find_all("a1b2c3", /[0-9]/)
     expect(length(nums)).to_eq(3)
-    expect(nums[0]).to_eq("1")
-    expect(nums[1]).to_eq("2")
-    expect(nums[2]).to_eq("3")
+    expect(nums[0].full).to_eq("1")
+    expect(nums[1].full).to_eq("2")
+    expect(nums[2].full).to_eq("3")
   )
   it("should support UFCS for find_all", ():
     nums = "a1b2c3".find_all(/[0-9]/)
@@ -113,5 +113,6 @@ describe("backward compatibility", ():
   it("should support regex_find_all", ():
     nums = regex_find_all("a1b2c3", "[0-9]")
     expect(length(nums)).to_eq(3)
+    expect(nums[0].full).to_eq("1")
   )
 )

--- a/tests/spec/regex_phase2.test.ry
+++ b/tests/spec/regex_phase2.test.ry
@@ -59,8 +59,8 @@ describe("non-greedy when", ():
   it("should find all matches with lazy quantifier", ():
     tags = regex_find_all("<x> <yy> <zzz>", "<.*?>")
     expect(length(tags)).to_eq(3)
-    expect(tags[0]).to_eq("<x>")
-    expect(tags[1]).to_eq("<yy>")
-    expect(tags[2]).to_eq("<zzz>")
+    expect(tags[0].full).to_eq("<x>")
+    expect(tags[1].full).to_eq("<yy>")
+    expect(tags[2].full).to_eq("<zzz>")
   )
 )

--- a/tests/spec/regex_phase3.test.ry
+++ b/tests/spec/regex_phase3.test.ry
@@ -18,9 +18,9 @@ describe("word boundary \\b / \\B", ():
   it("should find all words with \\b", ():
     words = regex_find_all("hello world foo", "\\b\\w+\\b")
     expect(length(words)).to_eq(3)
-    expect(words[0]).to_eq("hello")
-    expect(words[1]).to_eq("world")
-    expect(words[2]).to_eq("foo")
+    expect(words[0].full).to_eq("hello")
+    expect(words[1].full).to_eq("world")
+    expect(words[2].full).to_eq("foo")
   )
 )
 
@@ -46,9 +46,9 @@ describe("case-insensitive (?i)", ():
   it("should find all matches case-insensitively", ():
     matches = regex_find_all("Hello HELLO hello", "(?i)hello")
     expect(length(matches)).to_eq(3)
-    expect(matches[0]).to_eq("Hello")
-    expect(matches[1]).to_eq("HELLO")
-    expect(matches[2]).to_eq("hello")
+    expect(matches[0].full).to_eq("Hello")
+    expect(matches[1].full).to_eq("HELLO")
+    expect(matches[2].full).to_eq("hello")
   )
   it("should combine (?i) with \\b", ():
     expect(regex_search("Hello WORLD", "(?i)\\bworld\\b")).to_eq(6)

--- a/tests/test_codegen_regex.cpp
+++ b/tests/test_codegen_regex.cpp
@@ -96,9 +96,9 @@ TEST_F(CodeGenTest, RegexFindAllBasic) {
     EXPECT_EQ(runSource(R"(
 matches = regex_find_all("a1b23c456", "[0-9]+")
 print(length(matches))
-print(matches[0])
-print(matches[1])
-print(matches[2])
+print(matches[0].full)
+print(matches[1].full)
+print(matches[2].full)
 )"), "3\n1\n23\n456\n");
 }
 
@@ -161,8 +161,8 @@ TEST_F(CodeGenTest, RegexLazyFindAll) {
     EXPECT_EQ(runSource(R"(
 tags = regex_find_all("<x> <yy>", "<.*?>")
 print(length(tags))
-print(tags[0])
-print(tags[1])
+print(tags[0].full)
+print(tags[1].full)
 )"), "2\n<x>\n<yy>\n");
 }
 
@@ -203,9 +203,9 @@ TEST_F(CodeGenTest, RegexLiteralFindAll) {
     EXPECT_EQ(runSource(R"(
 nums = find_all("a1b2c3", /[0-9]/)
 print(length(nums))
-print(nums[0])
-print(nums[1])
-print(nums[2])
+print(nums[0].full)
+print(nums[1].full)
+print(nums[2].full)
 )"), "3\n1\n2\n3\n");
 }
 

--- a/tests/test_regex_runtime.cpp
+++ b/tests/test_regex_runtime.cpp
@@ -272,8 +272,28 @@ struct ListHeader {
     char **data;
 };
 
+// Layout of each element in a List<Match> returned by __ry_regex_find_all.
+// Must match MatchData in runtime_list.hpp: {char* full, void* groups}.
+struct MatchEntry {
+    char  *full;
+    void  *groups; // ListHeader* for captured groups
+};
+
 static void freeStringList(ListHeader *list) {
     for (int64_t i = 0; i < list->len; ++i) free(list->data[i]);
+    free(list->data);
+    free(list);
+}
+
+static void freeMatchList(ListHeader *list) {
+    auto *entries = (MatchEntry *)list->data;
+    for (int64_t i = 0; i < list->len; ++i) {
+        free(entries[i].full);
+        auto *groups = (ListHeader *)entries[i].groups;
+        for (int64_t g = 0; g < groups->len; ++g) free(groups->data[g]);
+        free(groups->data);
+        free(groups);
+    }
     free(list->data);
     free(list);
 }
@@ -310,25 +330,58 @@ TEST(RegexRuntime, SplitNoMatch) {
 TEST(RegexRuntime, FindAllBasic) {
     auto *list = (ListHeader *)__ry_regex_find_all("[0-9]+", "a1b23c456");
     ASSERT_EQ(list->len, 3);
-    EXPECT_STREQ(list->data[0], "1");
-    EXPECT_STREQ(list->data[1], "23");
-    EXPECT_STREQ(list->data[2], "456");
-    freeStringList(list);
+    auto *e = (MatchEntry *)list->data;
+    EXPECT_STREQ(e[0].full, "1");
+    EXPECT_STREQ(e[1].full, "23");
+    EXPECT_STREQ(e[2].full, "456");
+    // No capture groups -> each groups list has length 0
+    EXPECT_EQ(((ListHeader *)e[0].groups)->len, 0);
+    freeMatchList(list);
 }
 
 TEST(RegexRuntime, FindAllWords) {
     auto *list = (ListHeader *)__ry_regex_find_all("[a-z]+", "hello world foo");
     ASSERT_EQ(list->len, 3);
-    EXPECT_STREQ(list->data[0], "hello");
-    EXPECT_STREQ(list->data[1], "world");
-    EXPECT_STREQ(list->data[2], "foo");
-    freeStringList(list);
+    auto *e = (MatchEntry *)list->data;
+    EXPECT_STREQ(e[0].full, "hello");
+    EXPECT_STREQ(e[1].full, "world");
+    EXPECT_STREQ(e[2].full, "foo");
+    freeMatchList(list);
 }
 
 TEST(RegexRuntime, FindAllNoMatch) {
     auto *list = (ListHeader *)__ry_regex_find_all("[0-9]+", "hello");
     ASSERT_EQ(list->len, 0);
-    freeStringList(list);
+    freeMatchList(list);
+}
+
+TEST(RegexRuntime, FindAllWithCaptureGroups) {
+    auto *list = (ListHeader *)__ry_regex_find_all("(\\w+)@(\\w+)", "a@b x@y");
+    ASSERT_EQ(list->len, 2);
+    auto *e = (MatchEntry *)list->data;
+    EXPECT_STREQ(e[0].full, "a@b");
+    auto *g0 = (ListHeader *)e[0].groups;
+    ASSERT_EQ(g0->len, 2);
+    EXPECT_STREQ(g0->data[0], "a");
+    EXPECT_STREQ(g0->data[1], "b");
+    EXPECT_STREQ(e[1].full, "x@y");
+    auto *g1 = (ListHeader *)e[1].groups;
+    ASSERT_EQ(g1->len, 2);
+    EXPECT_STREQ(g1->data[0], "x");
+    EXPECT_STREQ(g1->data[1], "y");
+    freeMatchList(list);
+}
+
+TEST(RegexRuntime, FindAllUnmatchedOptionalGroup) {
+    // (a)? doesn't match in "b" -> group should be empty string
+    auto *list = (ListHeader *)__ry_regex_find_all("(a)?b", "b");
+    ASSERT_EQ(list->len, 1);
+    auto *e = (MatchEntry *)list->data;
+    EXPECT_STREQ(e[0].full, "b");
+    auto *g = (ListHeader *)e[0].groups;
+    ASSERT_EQ(g->len, 1);
+    EXPECT_STREQ(g->data[0], "");
+    freeMatchList(list);
 }
 
 // ============================================================
@@ -389,10 +442,11 @@ TEST(RegexRuntime, QuantifierBraceLiteralFallback) {
 TEST(RegexRuntime, QuantifierFindAll) {
     auto *list = (ListHeader *)__ry_regex_find_all("\\d{2,3}", "1 23 456 7890");
     ASSERT_EQ(list->len, 3);
-    EXPECT_STREQ(list->data[0], "23");
-    EXPECT_STREQ(list->data[1], "456");
-    EXPECT_STREQ(list->data[2], "789");
-    freeStringList(list);
+    auto *e = (MatchEntry *)list->data;
+    EXPECT_STREQ(e[0].full, "23");
+    EXPECT_STREQ(e[1].full, "456");
+    EXPECT_STREQ(e[2].full, "789");
+    freeMatchList(list);
 }
 
 // ============================================================
@@ -453,10 +507,11 @@ TEST(RegexRuntime, LazyFindAll) {
     // .*? in findAll should find shortest matches
     auto *list = (ListHeader *)__ry_regex_find_all("<.*?>", "<a> <bb> <ccc>");
     ASSERT_EQ(list->len, 3);
-    EXPECT_STREQ(list->data[0], "<a>");
-    EXPECT_STREQ(list->data[1], "<bb>");
-    EXPECT_STREQ(list->data[2], "<ccc>");
-    freeStringList(list);
+    auto *e = (MatchEntry *)list->data;
+    EXPECT_STREQ(e[0].full, "<a>");
+    EXPECT_STREQ(e[1].full, "<bb>");
+    EXPECT_STREQ(e[2].full, "<ccc>");
+    freeMatchList(list);
 }
 
 // ============================================================
@@ -499,10 +554,11 @@ TEST(RegexRuntime, WordBoundaryFullMatch) {
 TEST(RegexRuntime, WordBoundaryFindAll) {
     auto *list = (ListHeader *)__ry_regex_find_all("\\b\\w+\\b", "hello world foo");
     ASSERT_EQ(list->len, 3);
-    EXPECT_STREQ(list->data[0], "hello");
-    EXPECT_STREQ(list->data[1], "world");
-    EXPECT_STREQ(list->data[2], "foo");
-    freeStringList(list);
+    auto *e = (MatchEntry *)list->data;
+    EXPECT_STREQ(e[0].full, "hello");
+    EXPECT_STREQ(e[1].full, "world");
+    EXPECT_STREQ(e[2].full, "foo");
+    freeMatchList(list);
 }
 
 // ============================================================
@@ -543,10 +599,11 @@ TEST(RegexRuntime, CaseInsensitiveReplace) {
 TEST(RegexRuntime, CaseInsensitiveFindAll) {
     auto *list = (ListHeader *)__ry_regex_find_all("(?i)hello", "Hello HELLO hello");
     ASSERT_EQ(list->len, 3);
-    EXPECT_STREQ(list->data[0], "Hello");
-    EXPECT_STREQ(list->data[1], "HELLO");
-    EXPECT_STREQ(list->data[2], "hello");
-    freeStringList(list);
+    auto *e = (MatchEntry *)list->data;
+    EXPECT_STREQ(e[0].full, "Hello");
+    EXPECT_STREQ(e[1].full, "HELLO");
+    EXPECT_STREQ(e[2].full, "hello");
+    freeMatchList(list);
 }
 
 // ============================================================
@@ -586,7 +643,7 @@ TEST(RegexRuntime, PerfFindAllManyMatches) {
     auto elapsed = std::chrono::steady_clock::now() - start;
     EXPECT_GT(list->len, 0);
     EXPECT_LT(std::chrono::duration_cast<std::chrono::milliseconds>(elapsed).count(), 1000);
-    freeStringList(list);
+    freeMatchList(list);
 }
 
 // Regression test: lazy search must preserve leftmost-start semantics
@@ -603,8 +660,9 @@ TEST(RegexRuntime, LazyFindAllLeftmostStart) {
     // findAll must also respect leftmost-start ordering
     auto *list = (ListHeader *)__ry_regex_find_all("a.+?b|c", "acb");
     ASSERT_EQ(list->len, 1);
-    EXPECT_STREQ(list->data[0], "acb");
-    freeStringList(list);
+    auto *e = (MatchEntry *)list->data;
+    EXPECT_STREQ(e[0].full, "acb");
+    freeMatchList(list);
 }
 
 // --- ReDoS protection tests ---


### PR DESCRIPTION
## Summary

- Introduces a `Match` record type (`{full: str, groups: List<str>}`) for regex match results
- Changes `find_all` and `regex_find_all` return type from `List<str>` to `List<Match>`
- Reuses the existing `CaptureBacktracker` (from #829) to extract capture groups per match
- `Match` is registered programmatically in the `CodeGen` constructor (same pattern as `Error`) so `from regex import find_all` works without explicitly importing `Match`
- Patterns without capture groups return `Match` with an empty `groups` list (backward-compatible in structure; `m.full` replaces bare string access)

## Changes

- `src/codegen.cpp` — register `Match` type globally at codegen construction
- `share/std/regex.ry` — update return types to `List<Match>`
- `include/ry/runtime_list.hpp` — add `MatchData` struct and `makeMatchList()`
- `src/runtime_regex.cpp` — rewrite `__ry_regex_find_all` to build `List<Match>` with capture extraction
- `src/codegen_call_io.cpp` — update `TypeMeta` for `regex_find_all` and `find_all`
- `tests/spec/regex_capture.test.ry` — add 7 new `find_all` capture group tests
- All existing `find_all` tests updated to use `.full` field access
- `docs/reference/regex.md` — add `Match Type` section, update signatures and examples

## Test plan

- [ ] `./build/ry_tests` — 1638 tests pass
- [ ] `./build/ry test -p` — 119 files, 0 failures
- [ ] ASan/UBSan build clean
- [ ] TSan build clean

Closes #830

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * `find_all` and `regex_find_all` now return match objects with `full` (the matched text) and `groups` (captured groups) instead of plain strings
  * Patterns without capture groups return empty `groups` lists for each match

<!-- end of auto-generated comment: release notes by coderabbit.ai -->