### PR TITLE
chore: integrate clang-tidy provisioning into setup-llvm action (#934)

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -12,6 +12,13 @@ inputs:
   github-token:
     description: GitHub token for downloading release assets
     required: true
+  extra-packages:
+    description: >-
+      Space-separated list of extra apt packages to install in the apt
+      fallback path (e.g. "clang-tidy-{MAJOR}"). {MAJOR} is replaced
+      with the LLVM major version. Ignored on cache/mirror hit.
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -21,7 +28,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: /usr/local/llvm
-        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v1-${{ inputs.sha256-short }}
+        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v2-${{ inputs.sha256-short }}
 
     - name: Download and install LLVM
       if: steps.cache.outputs.cache-hit != 'true'
@@ -53,7 +60,9 @@ runs:
         else
           echo "Mirrored release not found, installing via apt.llvm.org..."
           wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
-          sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}"
+          EXTRA="${{ inputs.extra-packages }}"
+          EXTRA="${EXTRA//\{MAJOR\}/$MAJOR}"
+          sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}" $EXTRA
 
           # Symlink to /usr/local/llvm so cmake --preset works unchanged
           sudo ln -sfn "/usr/lib/llvm-${MAJOR}" /usr/local/llvm

--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -60,9 +60,23 @@ runs:
         else
           echo "Mirrored release not found, installing via apt.llvm.org..."
           wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
-          EXTRA="${{ inputs.extra-packages }}"
-          EXTRA="${EXTRA//\{MAJOR\}/$MAJOR}"
-          sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}" $EXTRA
+          EXTRA_RAW="${{ inputs.extra-packages }}"
+          EXTRA_RAW="${EXTRA_RAW//\{MAJOR\}/$MAJOR}"
+          EXTRA_PKGS=()
+          if [ -n "${EXTRA_RAW}" ]; then
+            read -r -a EXTRA_PKGS <<< "${EXTRA_RAW}"
+            for pkg in "${EXTRA_PKGS[@]}"; do
+              if [[ ! "${pkg}" =~ ^[a-z0-9][a-z0-9+.-]*$ ]]; then
+                echo "::error::Invalid apt package name: ${pkg}"
+                exit 1
+              fi
+            done
+          fi
+          sudo apt-get install -y \
+            libllvm"${MAJOR}" \
+            llvm-"${MAJOR}"-dev \
+            clang-"${MAJOR}" \
+            "${EXTRA_PKGS[@]}"
 
           # Symlink to /usr/local/llvm so cmake --preset works unchanged
           sudo ln -sfn "/usr/lib/llvm-${MAJOR}" /usr/local/llvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,17 +42,7 @@ jobs:
           llvm-version: ${{ env.LLVM_VERSION }}
           sha256-short: ${{ env.LLVM_SHA256_SHORT }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install clang-tidy
-        run: |
-          MAJOR="${LLVM_VERSION%%.*}"
-          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key \
-            | sudo gpg --dearmor -o /usr/share/keyrings/llvm.gpg
-          echo "deb [signed-by=/usr/share/keyrings/llvm.gpg] \
-            http://apt.llvm.org/noble/ llvm-toolchain-noble-${MAJOR} main" \
-            | sudo tee /etc/apt/sources.list.d/llvm.list
-          sudo apt-get update
-          sudo apt-get install -y clang-tidy-${MAJOR}
-          sudo ln -sf /usr/bin/clang-tidy-${MAJOR} /usr/local/bin/clang-tidy
+          extra-packages: clang-tidy-{MAJOR}
       - name: Install dependencies
         run: sudo apt-get install -y libssl-dev ninja-build libgtest-dev libgmock-dev
       - name: Setup ccache

--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -47,7 +47,7 @@ jobs:
           V="${{ inputs.llvm_version }}"
           MAJOR="${V%%.*}"
           wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
-          sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}"
+          sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}" clang-tidy-"${MAJOR}"
           echo "LLVM_MAJOR=${MAJOR}" >> "$GITHUB_ENV"
 
       - name: Repack as portable tarball

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1302,19 +1302,27 @@ is the required gate for #630's race fixes. macOS is unaffected.
 
 ### LLVM mirror workflow and version-bump checklist
 
-**Source**: #892 / #919
+**Source**: #892 / #919 / #934
 **Tags**: llvm, ci, cache, mirror, version-bump
 
 **Rule**: CI fetches LLVM from a GitHub Releases mirror via
 `.github/actions/setup-llvm/`. The mirror tarball is built by
 `.github/workflows/mirror-llvm-toolchain.yml` (manual `workflow_dispatch`).
 
+The mirror tarball includes `clang-tidy` (added in #934). The
+`setup-llvm` action accepts an optional `extra-packages` input for
+the apt fallback path; the mirror/cache path already contains all
+tools. If new tools are needed, add them to
+`mirror-llvm-toolchain.yml`'s apt-get line, bump the cache key
+version suffix (e.g. `v2` → `v3`), and re-dispatch the mirror workflow
+with `force=true`.
+
 Version bump checklist — update `env.LLVM_VERSION` (and
 `env.LLVM_SHA256_SHORT` when non-empty) in:
 - `.github/workflows/ci.yml`
 - `.github/workflows/codeql.yml`
 
-Cache key format: `llvm-${VERSION}-linux-x86_64-v1-${SHA256_SHORT}`.
+Cache key format: `llvm-${VERSION}-linux-x86_64-v2-${SHA256_SHORT}`.
 `restore-keys` is intentionally omitted: a partial cache hit would
 restore a mismatched LLVM version, causing build failures or silent ABI
 mismatches. An exact-match-only policy guarantees the correct toolchain.

--- a/changelog.d/934-setup-llvm-clang-tidy.md
+++ b/changelog.d/934-setup-llvm-clang-tidy.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Integrated clang-tidy provisioning into `setup-llvm` action; CI no longer installs clang-tidy via a separate apt step (#934)


### PR DESCRIPTION
## Summary

- Add `extra-packages` input to `setup-llvm` composite action; supports `{MAJOR}` placeholder substitution for version-specific apt package names
- Include `clang-tidy-{MAJOR}` in the mirror tarball build (`mirror-llvm-toolchain.yml`) so cache/mirror hits already contain `clang-tidy`
- Replace the standalone 10-line "Install clang-tidy" step in the `clang-tidy` CI job with `extra-packages: clang-tidy-{MAJOR}` on the `setup-llvm` call
- Bump cache key `v1` → `v2` to invalidate stale caches that do not contain `clang-tidy`

## Behavior

| Path | `clang-tidy` available? |
|------|------------------------|
| Cache hit (v2 key, new tarball) | Yes — included in tarball |
| Mirror download (after tarball rebuild) | Yes — included in tarball |
| apt fallback | Yes — installed via `extra-packages` substitution |

## After merging

Manually dispatch `mirror-llvm-toolchain.yml` with `force=true` to rebuild the tarball and include `clang-tidy`. Until then, the apt fallback path handles it.

Closes #934

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `extra-packages` input to allow specifying additional apt packages during LLVM setup.

* **Changed**
  * Clang-tidy provisioning moved into the LLVM setup action, simplifying CI job steps.
  * LLVM cache key version bumped to require repopulation of the cache.

* **Documentation**
  * Docs and changelog updated to note the mirror/toolchain now includes clang-tidy and related process changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->