### PR TITLE
fix: resolve all 85 clang-tidy warnings and enable WarningsAsErrors (#935)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,7 +21,7 @@
 #   performance-enum-size    — enum base type sizing is often intentional (ABI, JIT layout)
 #   performance-no-int-to-ptr — incompatible with LLVM IR construction patterns
 #
-# WarningsAsErrors is empty initially; set to '*' once existing warnings are resolved.
+# WarningsAsErrors: all warnings are now errors (#935).
 
 Checks: >
   -*,
@@ -44,7 +44,7 @@ Checks: >
   modernize-use-nullptr,
   modernize-use-using,
 
-WarningsAsErrors: ''
+WarningsAsErrors: '*'
 
 HeaderFilterRegex: 'include/ry/.*\.hpp$'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ jobs:
 
   clang-tidy:
     runs-on: ubuntu-24.04
-    continue-on-error: true  # Remove once existing warnings are resolved
     steps:
       - uses: actions/checkout@v4
       - name: Setup LLVM

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1386,6 +1386,28 @@ produce false positives in this project. Key decisions:
 were disabled. If adding a new disabled check, document the reason in
 the `.clang-tidy` comment header.
 
+### Clang-Tidy: NOLINT patterns for intentional code
+
+**Source**: #935 (implementation)
+**Tags**: build, ci, clang-tidy, static-analysis
+
+Some clang-tidy warnings are intentional patterns that should be
+suppressed with `// NOLINT(...)` rather than refactored:
+
+- **`performance-unnecessary-value-param`** on sink parameters
+  (`std::string name` → `std::move(name)`): This is correct C++ sink
+  idiom. Changing to `const std::string &` would break move semantics.
+  Affected: `TypeNode::make*` factory methods in `ast.hpp`,
+  `SourceManager::addSource` in `source_manager.hpp`.
+- **`bugprone-empty-catch`** on shutdown/cleanup paths:
+  `worker.join()` in `runtime_parallel.cpp` and stdlib-load try/catch
+  in `jit_runner.cpp` intentionally swallow exceptions because join
+  failure on thread shutdown is non-recoverable, and stdlib absence is
+  expected. Add a brief justification comment alongside NOLINT.
+
+**Rule**: When using NOLINT, always include the specific check name and
+a one-line comment explaining why the suppression is justified.
+
 ---
 
 ## Documentation

--- a/changelog.d/935-clang-tidy-warnings.md
+++ b/changelog.d/935-clang-tidy-warnings.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Resolved all 85 existing clang-tidy warnings across `src/` and `include/ry/`; clang-tidy is now a hard CI gate with `WarningsAsErrors: '*'` (#935)

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -46,15 +46,15 @@ struct TypeNode {
 
     std::string toString() const;
 
-    static TypeNodePtr makeBasic(std::string name);
-    static TypeNodePtr makeGeneric(std::string name, std::vector<TypeNodePtr> args);
+    static TypeNodePtr makeBasic(std::string name); // NOLINT(performance-unnecessary-value-param)
+    static TypeNodePtr makeGeneric(std::string name, std::vector<TypeNodePtr> args); // NOLINT(performance-unnecessary-value-param)
     static TypeNodePtr makeArray(TypeNodePtr elem, uint64_t size);
-    static TypeNodePtr makeTuple(std::vector<TypeNodePtr> elems);
-    static TypeNodePtr makeFn(std::vector<TypeNodePtr> params, TypeNodePtr ret);
-    static TypeNodePtr makeUnion(std::vector<TypeNodePtr> comps);
+    static TypeNodePtr makeTuple(std::vector<TypeNodePtr> elems); // NOLINT(performance-unnecessary-value-param)
+    static TypeNodePtr makeFn(std::vector<TypeNodePtr> params, TypeNodePtr ret); // NOLINT(performance-unnecessary-value-param)
+    static TypeNodePtr makeUnion(std::vector<TypeNodePtr> comps); // NOLINT(performance-unnecessary-value-param)
     static TypeNodePtr makeOptional(TypeNodePtr inner);
     static TypeNodePtr makeWeak(TypeNodePtr inner);
-    static TypeNodePtr makeRange(std::string start, std::string end);
+    static TypeNodePtr makeRange(std::string start, std::string end); // NOLINT(performance-unnecessary-value-param)
     static TypeNodePtr clone(const TypeNodePtr &src);
 };
 

--- a/include/ry/formatter.hpp
+++ b/include/ry/formatter.hpp
@@ -81,6 +81,7 @@ private:
     void formatDirectives(const std::vector<Directive> &directives);
     void formatBlock(const std::vector<StmtNode> &body);
     std::string formatParams(const std::vector<FnParam> &params);
+    std::string formatLambdaSig(const LambdaExpr &lambda);
     void emitTypeParams(const std::vector<TypeParam> &params);
     std::string formatPattern(const Pattern &pat);
     std::string escapeString(const std::string &s);

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -73,13 +73,13 @@ private:
     StmtNode parseReturnStatement();
     StmtNode parseExpectStatement();
     StmtNode parseCaseStatement();
-    StmtNode parseCaseStatementNoSubject(Token caseTok);
-    StmtNode parseCaseStatementWithSubject(Token caseTok);
+    StmtNode parseCaseStatementNoSubject(const Token &caseTok);
+    StmtNode parseCaseStatementWithSubject(const Token &caseTok);
     void tryParseTrailingBlock(CallStmt &s);
     ExprPtr parseTrailingBlockAsLambda();
     ExprPtr parseCaseExpr();
-    ExprPtr parseCaseExprNoSubject(Token caseTok);
-    ExprPtr parseCaseExprWithSubject(Token caseTok);
+    ExprPtr parseCaseExprNoSubject(const Token &caseTok);
+    ExprPtr parseCaseExprWithSubject(const Token &caseTok);
     ExprPtr parseIfExpression();
     Pattern parsePattern();
     void parseOrPattern(Pattern &pat);

--- a/include/ry/source_manager.hpp
+++ b/include/ry/source_manager.hpp
@@ -9,7 +9,7 @@ namespace ry {
 
 class SourceManager {
 public:
-    int addSource(std::string filename, std::string content);
+    int addSource(std::string filename, std::string content); // NOLINT(performance-unnecessary-value-param)
     std::string_view getLine(int fileId, int line) const;
     const std::string& getFilename(int fileId) const;
     int getFileCount() const { return static_cast<int>(files_.size()); }

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -500,7 +500,7 @@ static void collectMockedFunctionsFromStmt(const StmtNode &stmt,
             for (auto &arm : s->arms)
                 collectMockedFunctionsFromStmts(arm.body, out);
             collectMockedFunctionsFromStmts(s->else_body, out);
-        } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) {
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) { // NOLINT(bugprone-branch-clone)
             collectMockedFunctionsFromStmts(s->body, out);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) {
             collectMockedFunctionsFromStmts(s->body, out);

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -247,7 +247,10 @@ std::string CodeGen::buildTypeNameFromMeta(llvm::Value *val) {
         std::string elemName = !meta->set_elem_type_name.empty()
             ? meta->set_elem_type_name
             : reverseResolveTypeName(meta->set_elem);
-        return "Set<" + elemName + ">";
+        std::string setName = "Set<";
+        setName += elemName;
+        setName += '>';
+        return setName;
     }
     if (meta->fn_type_info) {
         const auto &info = *meta->fn_type_info;

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -129,6 +129,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
             auto info = *fnInfo;
 
             std::vector<llvm::Value*> argVals;
+            argVals.reserve(e->args.size());
             for (auto &arg : e->args)
                 argVals.push_back(emitExpr(*arg));
 

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -63,6 +63,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
 
         // Emit args once, then find the sig whose types match
         std::vector<llvm::Value *> args;
+        args.reserve(n);
         for (size_t i = 0; i < n; i++)
             args.push_back(emitExpr(*e.args[i]));
 
@@ -164,6 +165,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
 
     // Emit args once, then find the sig whose types match
     std::vector<llvm::Value *> args;
+    args.reserve(static_cast<size_t>(entry->arity));
     for (size_t i = 0; i < static_cast<size_t>(entry->arity); i++)
         args.push_back(emitExpr(*e.args[i]));
 
@@ -367,6 +369,7 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     // This avoids committing to the first arity match when a different
     // library's signature may match the actual argument types.
     std::vector<llvm::Value *> args;
+    args.reserve(e.args.size());
     for (size_t i = 0; i < e.args.size(); i++)
         args.push_back(emitExpr(*e.args[i]));
 

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -393,10 +393,16 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
                 candidateTypes.push_back(expectedTy);
             }
             if (typesMatch) {
-                if (matchedSig)
-                    codegenError("ambiguous @native call: '" + e.callee +
-                                 "' matches both @native(\"" + matchedPackage +
-                                 "\") and @native(\"" + lib + "\")");
+                if (matchedSig) {
+                    std::string ambigMsg = "ambiguous @native call: '";
+                    ambigMsg += e.callee;
+                    ambigMsg += "' matches both @native(\"";
+                    ambigMsg += matchedPackage;
+                    ambigMsg += "\") and @native(\"";
+                    ambigMsg += lib;
+                    ambigMsg += "\")";
+                    codegenError(ambigMsg);
+                }
                 matchedSig = &sig;
                 matchedPackage = lib;
                 paramTypes = std::move(candidateTypes);

--- a/src/codegen_call_thread.cpp
+++ b/src/codegen_call_thread.cpp
@@ -59,7 +59,7 @@ static std::unordered_set<std::string> collectReferencedVars(const LambdaExpr &l
     scanStmt = [&](const StmtNode &stmt) {
         std::visit([&](const auto &s) {
             using T = std::decay_t<decltype(s)>;
-            if constexpr (std::is_same_v<T, AssignStmt>) {
+            if constexpr (std::is_same_v<T, AssignStmt>) { // NOLINT(bugprone-branch-clone)
                 if (s.value) scanExpr(*s.value);
             } else if constexpr (std::is_same_v<T, CallStmt>) {
                 for (auto &arg : s.args) scanExpr(*arg);

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -440,7 +440,7 @@ void CodeGen::emitStmt(CallStmt &s) {
                      (s.callee == "remove_at" && nargs == 2) ||
                      (s.callee == "remove" && nargs == 2) ||
                      (s.callee == "sort!" && (nargs == 1 || nargs == 2)) ||
-                     (s.callee == "reverse!" && nargs == 1))) {
+                     (s.callee == "reverse!" && nargs == 1))) { // NOLINT(bugprone-branch-clone)
                     intercept = true;
                 } else if (isSet &&
                     ((s.callee == "add" && nargs == 2) ||

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -96,7 +96,7 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
                 continue;
             }
 
-            if (isAnyType(entry.paramTypes[i])) {
+            if (isAnyType(entry.paramTypes[i])) { // NOLINT(bugprone-branch-clone)
                 // Match: any type accepts all primitives; wrapping deferred to arg building
                 candidate.anyMatches++;
             } else if (isUnionType(resolvedParamTypeName)) {
@@ -432,7 +432,7 @@ void CodeGen::emitStmt(CallStmt &s) {
                 bool isMap = !isList && !isSet && getMapKeyType(alloca) != nullptr;
                 size_t nargs = s.args.size();
 
-                if (isList &&
+                if (isList && // NOLINT(bugprone-branch-clone)
                     ((s.callee == "append" && nargs == 2) ||
                      (s.callee == "append!" && nargs == 2) ||
                      (s.callee == "pop" && nargs == 1) ||

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1003,9 +1003,7 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
             strVal = rhs; intVal = lhs;
         }
         if (strVal) {
-            if (intVal->getType() == i1Ty_)
-                intVal = builder_.CreateZExt(intVal, i64Ty_, "n_ext");
-            else if (intVal->getType() == i8Ty_)
+            if (intVal->getType() == i1Ty_ || intVal->getType() == i8Ty_)
                 intVal = builder_.CreateZExt(intVal, i64Ty_, "n_ext");
             return emitStringRepeat(strVal, intVal);
         }

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -57,22 +57,17 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
     }
     if (target == "int") {
         if (srcTy == i64Ty_) return val;
-        if (srcTy->isDoubleTy()) return builder_.CreateFPToSI(val, i64Ty_, "cast_i");
+        if (srcTy->isDoubleTy() || srcTy == f32Ty_) return builder_.CreateFPToSI(val, i64Ty_, "cast_i");
         if (srcTy == i1Ty_) return builder_.CreateZExt(val, i64Ty_, "cast_i");
         if (srcTy == i8Ty_) {
             std::string name = getLowLevelTypeName(val);
             if (name == "i8") return builder_.CreateSExt(val, i64Ty_, "cast_i");
             return builder_.CreateZExt(val, i64Ty_, "cast_i");
         }
-        if (srcTy == i32Ty_) {
+        if (srcTy == i32Ty_ || srcTy == i16Ty_) {
             if (isUnsignedLowLevel(val)) return builder_.CreateZExt(val, i64Ty_, "cast_i");
             return builder_.CreateSExt(val, i64Ty_, "cast_i");
         }
-        if (srcTy == i16Ty_) {
-            if (isUnsignedLowLevel(val)) return builder_.CreateZExt(val, i64Ty_, "cast_i");
-            return builder_.CreateSExt(val, i64Ty_, "cast_i");
-        }
-        if (srcTy == f32Ty_) return builder_.CreateFPToSI(val, i64Ty_, "cast_i");
         codegenError("cannot cast to int");
     }
     if (target == "bool") {
@@ -103,80 +98,59 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
                                         : builder_.CreateSExt(val, i32Ty_, "cast_i32");
         }
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_i32");
-        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToSI(val, i32Ty_, "cast_i32");
-        else if (srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i32Ty_, "cast_i32");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i32Ty_, "cast_i32");
         else codegenError("cannot cast to i32");
         return withMeta(r, "i32");
     }
     if (target == "i16") {
         llvm::Value *r;
         if (srcTy == i16Ty_) r = val;
-        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_i16");
-        else if (srcTy == i32Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_i16");
+        else if (srcTy == i64Ty_ || srcTy == i32Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_i16");
         else if (srcTy == i8Ty_) {
             r = isUnsignedLowLevel(val) ? builder_.CreateZExt(val, i16Ty_, "cast_i16")
                                         : builder_.CreateSExt(val, i16Ty_, "cast_i16");
         }
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i16Ty_, "cast_i16");
-        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToSI(val, i16Ty_, "cast_i16");
-        else if (srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i16Ty_, "cast_i16");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i16Ty_, "cast_i16");
         else codegenError("cannot cast to i16");
         return withMeta(r, "i16");
     }
     if (target == "i8") {
         llvm::Value *r;
         if (srcTy == i8Ty_) r = val;
-        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_i8");
-        else if (srcTy == i32Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_i8");
-        else if (srcTy == i16Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_i8");
+        else if (srcTy == i64Ty_ || srcTy == i32Ty_ || srcTy == i16Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_i8");
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i8Ty_, "cast_i8");
-        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToSI(val, i8Ty_, "cast_i8");
-        else if (srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i8Ty_, "cast_i8");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i8Ty_, "cast_i8");
         else codegenError("cannot cast to i8");
         return withMeta(r, "i8");
     }
     if (target == "i64") {
         llvm::Value *r;
         if (srcTy == i64Ty_) r = val;
-        else if (srcTy == i32Ty_) {
-            r = isUnsignedLowLevel(val) ? builder_.CreateZExt(val, i64Ty_, "cast_i64")
-                                        : builder_.CreateSExt(val, i64Ty_, "cast_i64");
-        }
-        else if (srcTy == i16Ty_) {
-            r = isUnsignedLowLevel(val) ? builder_.CreateZExt(val, i64Ty_, "cast_i64")
-                                        : builder_.CreateSExt(val, i64Ty_, "cast_i64");
-        }
-        else if (srcTy == i8Ty_) {
+        else if (srcTy == i32Ty_ || srcTy == i16Ty_ || srcTy == i8Ty_) {
             r = isUnsignedLowLevel(val) ? builder_.CreateZExt(val, i64Ty_, "cast_i64")
                                         : builder_.CreateSExt(val, i64Ty_, "cast_i64");
         }
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_i64");
-        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToSI(val, i64Ty_, "cast_i64");
-        else if (srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i64Ty_, "cast_i64");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i64Ty_, "cast_i64");
         else codegenError("cannot cast to i64");
         return withMeta(r, "i64");
     }
     if (target == "u8") {
         llvm::Value *r;
         if (srcTy == i8Ty_) r = val;
-        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_u8");
-        else if (srcTy == i32Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_u8");
-        else if (srcTy == i16Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_u8");
+        else if (srcTy == i64Ty_ || srcTy == i32Ty_ || srcTy == i16Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_u8");
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i8Ty_, "cast_u8");
-        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToUI(val, i8Ty_, "cast_u8");
-        else if (srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i8Ty_, "cast_u8");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i8Ty_, "cast_u8");
         else codegenError("cannot cast to u8");
         return withMeta(r, "u8");
     }
     if (target == "u16") {
         llvm::Value *r;
         if (srcTy == i16Ty_) r = val;
-        else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_u16");
-        else if (srcTy == i32Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_u16");
-        else if (srcTy == i8Ty_) r = builder_.CreateZExt(val, i16Ty_, "cast_u16");
-        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i16Ty_, "cast_u16");
-        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToUI(val, i16Ty_, "cast_u16");
-        else if (srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i16Ty_, "cast_u16");
+        else if (srcTy == i64Ty_ || srcTy == i32Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_u16");
+        else if (srcTy == i8Ty_ || srcTy == i1Ty_) r = builder_.CreateZExt(val, i16Ty_, "cast_u16");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i16Ty_, "cast_u16");
         else codegenError("cannot cast to u16");
         return withMeta(r, "u16");
     }
@@ -184,43 +158,27 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         llvm::Value *r;
         if (srcTy == i32Ty_) r = val;
         else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i32Ty_, "cast_u32");
-        else if (srcTy == i16Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_u32");
-        else if (srcTy == i8Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_u32");
-        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_u32");
-        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToUI(val, i32Ty_, "cast_u32");
-        else if (srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i32Ty_, "cast_u32");
+        else if (srcTy == i16Ty_ || srcTy == i8Ty_ || srcTy == i1Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_u32");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i32Ty_, "cast_u32");
         else codegenError("cannot cast to u32");
         return withMeta(r, "u32");
     }
     if (target == "u64") {
         llvm::Value *r;
         if (srcTy == i64Ty_) r = val;
-        else if (srcTy == i32Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
-        else if (srcTy == i16Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
-        else if (srcTy == i8Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
-        else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
-        else if (srcTy->isDoubleTy()) r = builder_.CreateFPToUI(val, i64Ty_, "cast_u64");
-        else if (srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i64Ty_, "cast_u64");
+        else if (srcTy == i32Ty_ || srcTy == i16Ty_ || srcTy == i8Ty_ || srcTy == i1Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i64Ty_, "cast_u64");
         else codegenError("cannot cast to u64");
         return withMeta(r, "u64");
     }
     if (target == "f32") {
         if (srcTy == f32Ty_) return val;
         if (srcTy->isDoubleTy()) return builder_.CreateFPTrunc(val, f32Ty_, "cast_f32");
-        if (srcTy == i64Ty_) {
+        if (srcTy == i64Ty_ || srcTy == i32Ty_ || srcTy == i16Ty_) {
             if (isUnsignedLowLevel(val)) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
             return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
         }
-        if (srcTy == i32Ty_) {
-            if (isUnsignedLowLevel(val)) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
-            return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
-        }
-        if (srcTy == i16Ty_) {
-            if (isUnsignedLowLevel(val)) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
-            return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
-        }
-        if (srcTy == i8Ty_)  return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
-        if (srcTy == i1Ty_)  return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
+        if (srcTy == i8Ty_ || srcTy == i1Ty_) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
         codegenError("cannot cast to f32");
     }
     codegenError("unsupported cast target type: " + target);

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -178,7 +178,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
             if (isUnsignedLowLevel(val)) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
             return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
         }
-        if (srcTy == i8Ty_ || srcTy == i1Ty_) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
+        if (srcTy == i8Ty_) {
+            if (isUnsignedLowLevel(val)) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
+            return builder_.CreateSIToFP(val, f32Ty_, "cast_f32");
+        }
+        if (srcTy == i1Ty_) return builder_.CreateUIToFP(val, f32Ty_, "cast_f32");
         codegenError("cannot cast to f32");
     }
     codegenError("unsupported cast target type: " + target);

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -42,6 +42,7 @@ void CodeGen::emitStmt(RecordStmt &s) {
         allFields.push_back({f.name, TypeNode::clone(f.type), std::move(f.directives)});
 
     std::vector<llvm::Type*> fieldTypes;
+    fieldTypes.reserve(allFields.size());
     for (auto &f : allFields)
         fieldTypes.push_back(resolveType(f.type->toString()));
 

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -875,7 +875,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             {
                 builder_.CreateBitCast(thunk, ptrTy_),
                 envPtr,
-                llvm::ConstantInt::get(i64Ty_, bodyRetTy->isVoidTy() ? 0 : dl.getTypeAllocSize(bodyRetTy))
+                llvm::ConstantInt::get(i64Ty_, bodyRetTy->isVoidTy() ? static_cast<uint64_t>(0) : static_cast<uint64_t>(dl.getTypeAllocSize(bodyRetTy)))
             },
             "task");
         builder_.CreateRet(task);

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -576,6 +576,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         // Build return type name string
         // Deduplicate for name construction
         std::vector<llvm::Type*> unique;
+        unique.reserve(retTypes.size());
         for (auto *ty : retTypes)
             if (std::find(unique.begin(), unique.end(), ty) == unique.end())
                 unique.push_back(ty);
@@ -583,6 +584,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
             s->return_type = TypeNode::makeBasic(reverseResolveTypeName(bodyRetTy));
         } else {
             std::vector<TypeNodePtr> comps;
+            comps.reserve(unique.size());
             for (auto *ty : unique)
                 comps.push_back(TypeNode::makeBasic(reverseResolveTypeName(ty)));
             s->return_type = TypeNode::makeUnion(std::move(comps));

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -100,10 +100,18 @@ void CodeGen::validateTypeBounds(const std::vector<TypeParam> &typeParams,
         if (!struct_types_.count(bound))
             codegenError("unknown type constraint: '" + bound + "'");
 
-        if (concrete != bound && !isSubtypeOf(concrete, bound))
-            codegenError("type '" + concrete + "' does not satisfy constraint '" +
-                         bound + "': not a subtype of '" + bound +
-                         "' (" + context + ")");
+        if (concrete != bound && !isSubtypeOf(concrete, bound)) {
+            std::string constraintMsg = "type '";
+            constraintMsg += concrete;
+            constraintMsg += "' does not satisfy constraint '";
+            constraintMsg += bound;
+            constraintMsg += "': not a subtype of '";
+            constraintMsg += bound;
+            constraintMsg += "' (";
+            constraintMsg += context;
+            constraintMsg += ")";
+            codegenError(constraintMsg);
+        }
     }
 }
 
@@ -466,7 +474,7 @@ std::vector<std::string> CodeGen::inferTypeArgs(
             else if (argTy == i8Ty_)  resolved = "u8";
             else if (argTy == ptrTy_) resolved = "str";
             else if (argTy == typeTy_) resolved = "Type";
-            else if (isAnyType(argTy)) resolved = "any";
+            else if (isAnyType(argTy)) resolved = "any"; // NOLINT(bugprone-branch-clone)
             else if (auto *st = llvm::dyn_cast<llvm::StructType>(argTy)) {
                 std::string sname = st->getName().str();
                 if (struct_types_.count(sname))
@@ -595,7 +603,7 @@ void CodeGen::instantiateGenericFn(const std::string &baseName,
             builder_.CreateStore(&arg, alloca);
             scope_stack_.back()[s.params[idx].name] = alloca;
 
-            std::string ptype = paramTypeNames[idx];
+            const auto &ptype = paramTypeNames[idx];
             applyParamTypeMeta(ptype, alloca, paramTypes[idx], s.params[idx].name);
             ++idx;
         }

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -148,10 +148,9 @@ void CodeGen::instantiateGenericEnum(const std::string &fullName, const std::str
             hasADT = true;
             VariantFieldInfo vfi;
             for (auto &ft : v.field_types) {
-                std::string ftStr = ft->toString();
-                std::string resolved = ftStr;
-                auto mit = typeMap.find(ftStr);
-                if (mit != typeMap.end()) resolved = mit->second;
+                const std::string ftStr = ft->toString();
+                const auto mit = typeMap.find(ftStr);
+                const std::string &resolved = (mit != typeMap.end()) ? mit->second : ftStr;
                 vfi.fieldTypes.push_back(resolveType(resolved));
                 vfi.fieldTypeNames.push_back(resolved);
             }
@@ -256,6 +255,7 @@ static std::string trimWs(const std::string &s) {
 // when `toString()` emits nested generics).
 static std::vector<std::string> splitTopLevelCommas(const std::string &body) {
     std::vector<std::string> out;
+    out.reserve(static_cast<size_t>(std::count(body.begin(), body.end(), ',')) + 1);
     int depth = 0;
     size_t start = 0;
     for (size_t i = 0; i < body.size(); ++i) {
@@ -483,6 +483,7 @@ std::vector<std::string> CodeGen::inferTypeArgs(
 
     // Build result in template parameter order
     std::vector<std::string> result;
+    result.reserve(tmpl.type_params.size());
     for (auto &tp : tmpl.type_params) {
         auto found = inferred.find(tp.name);
         if (found == inferred.end())
@@ -498,7 +499,8 @@ std::vector<std::string> CodeGen::inferTypeArgs(
 void CodeGen::instantiateGenericFn(const std::string &baseName,
                                     const std::vector<std::string> &typeArgs) {
     // Build full name: "identity<int>" or "map<int,str>"
-    std::string fullName = baseName + "<";
+    std::string fullName = baseName;
+    fullName += '<';
     for (size_t i = 0; i < typeArgs.size(); ++i) {
         if (i > 0) fullName += ",";
         fullName += typeArgs[i];

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -847,6 +847,7 @@ std::string CodeGen::inferReturnTypeName(const std::vector<StmtNode> &body,
             return "";
     // Deduplicate while preserving order.
     std::vector<std::string> unique;
+    unique.reserve(names.size());
     for (auto &n : names)
         if (std::find(unique.begin(), unique.end(), n) == unique.end())
             unique.push_back(n);
@@ -869,6 +870,7 @@ llvm::Type *CodeGen::deduceReturnType(const std::vector<llvm::Type*> &types) {
 
     // Deduplicate types
     std::vector<llvm::Type*> unique;
+    unique.reserve(types.size());
     for (auto *ty : types) {
         if (std::find(unique.begin(), unique.end(), ty) == unique.end())
             unique.push_back(ty);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -61,7 +61,7 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
             using P = std::decay_t<decltype(p)>;
             if constexpr (std::is_same_v<P, VariablePattern>) {
                 if (p.name != "_") excludedNames.insert(p.name);
-            } else if constexpr (std::is_same_v<P, SomePattern>) {
+            } else if constexpr (std::is_same_v<P, SomePattern>) { // NOLINT(bugprone-branch-clone)
                 if (p.binding != "_") excludedNames.insert(p.binding);
             } else if constexpr (std::is_same_v<P, OkPattern>) {
                 if (p.binding != "_") excludedNames.insert(p.binding);
@@ -93,7 +93,7 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
                 for (auto &arg : v->args) scanExpr(*arg);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<FieldAccessExpr>>) {
                 scanExpr(*v->object);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<TupleExpr>>) {
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<TupleExpr>>) { // NOLINT(bugprone-branch-clone)
                 for (auto &el : v->elements) scanExpr(*el);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<ListExpr>>) {
                 for (auto &el : v->elements) scanExpr(*el);
@@ -490,7 +490,7 @@ void CodeGen::buildLocalTypeMap(const std::vector<StmtNode> &body,
             } else if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) {
                 buildLocalTypeMap(s->branch.body, typeMap);
                 buildLocalTypeMap(s->else_body, typeMap);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) {
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) { // NOLINT(bugprone-branch-clone)
                 buildLocalTypeMap(s->body, typeMap);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) {
                 buildLocalTypeMap(s->body, typeMap);
@@ -516,7 +516,7 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
             return v.suffix.empty() ? f64Ty_ : resolveType(v.suffix);
         } else if constexpr (std::is_same_v<T, BoolExpr>) {
             return i1Ty_;
-        } else if constexpr (std::is_same_v<T, StringExpr>) {
+        } else if constexpr (std::is_same_v<T, StringExpr>) { // NOLINT(bugprone-branch-clone)
             return ptrTy_;
         } else if constexpr (std::is_same_v<T, VariableExpr>) {
             auto it = paramTypeMap.find(v.name);
@@ -933,6 +933,7 @@ llvm::Function *CodeGen::getOrCreateForwardingThunk(llvm::Function *realFn, cons
 
     // Forward user args to realFn
     std::vector<llvm::Value*> args;
+    args.reserve(info.paramTypes.size());
     for (size_t i = 0; i < info.paramTypes.size(); ++i)
         args.push_back(thunk->getArg(static_cast<unsigned>(i)));
 
@@ -982,6 +983,7 @@ llvm::Function *CodeGen::getOrCreateCapturingThunk(llvm::Function *realFn, const
 
     // Build full args: user_params + captured values loaded from env
     std::vector<llvm::Value*> fullArgs;
+    fullArgs.reserve(info.paramTypes.size() + info.capturedTypes.size());
     for (size_t i = 0; i < info.paramTypes.size(); ++i)
         fullArgs.push_back(thunk->getArg(static_cast<unsigned>(i)));
 

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -86,7 +86,7 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
                 tryCaptureVar(v.name);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<BinaryExpr>>) {
                 scanExpr(*v->lhs); scanExpr(*v->rhs);
-            } else if constexpr (std::is_same_v<T, std::unique_ptr<UnaryExpr>>) {
+            } else if constexpr (std::is_same_v<T, std::unique_ptr<UnaryExpr>>) { // NOLINT(bugprone-branch-clone)
                 scanExpr(*v->operand);
             } else if constexpr (std::is_same_v<T, std::unique_ptr<CallExpr>>) {
                 tryCaptureVar(v->callee);

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -116,9 +116,14 @@ void CodeGen::checkMatchExhaustiveness(
                 }
             }
             for (auto &[vname, _] : it->second.variants) {
-                if (!covered.count(vname))
-                    codegenError("non-exhaustive match: missing variant '" +
-                        enumName + "::" + vname + "'");
+                if (!covered.count(vname)) {
+                    std::string exhaustMsg = "non-exhaustive match: missing variant '";
+                    exhaustMsg += enumName;
+                    exhaustMsg += "::";
+                    exhaustMsg += vname;
+                    exhaustMsg += "'";
+                    codegenError(exhaustMsg);
+                }
             }
         }
     }
@@ -190,7 +195,7 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
     llvm::Value *testResult = nullptr;
     std::visit([&](auto &pat) {
         using T = std::decay_t<decltype(pat)>;
-        if constexpr (std::is_same_v<T, WildcardPattern>) {
+        if constexpr (std::is_same_v<T, WildcardPattern>) { // NOLINT(bugprone-branch-clone)
             testResult = llvm::ConstantInt::get(i1Ty_, 1);
         } else if constexpr (std::is_same_v<T, LiteralPattern>) {
             llvm::Value *litVal = emitExpr(*pat.value);
@@ -378,7 +383,7 @@ void CodeGen::emitStmt(std::unique_ptr<CaseStmt> &s) {
     llvm::AllocaInst *subjectAlloca = builder_.CreateAlloca(subjectTy, nullptr, "match.subject");
     builder_.CreateStore(subject, subjectAlloca);
 
-    std::string subjectEnumType = subjectEnumTypeForCheck;
+    const auto &subjectEnumType = subjectEnumTypeForCheck;
     if (!subjectEnumType.empty())
         getOrCreateMeta(subjectAlloca).enum_value_type = subjectEnumType;
 

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -513,6 +513,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
 
 std::vector<std::string> CodeGen::parseUnionComponents(const std::string &typeName) {
     std::vector<std::string> components;
+    size_t sepCount = 0;
+    for (size_t p = 0; (p = typeName.find(" | ", p)) != std::string::npos; p += 3)
+        ++sepCount;
+    components.reserve(sepCount + 1);
     size_t start = 0;
     while (start < typeName.size()) {
         size_t pos = typeName.find(" | ", start);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -364,7 +364,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             !getTypeMeta(TypeMeta::ListElem, ptr) &&
             !getTypeMeta(TypeMeta::SetElem, ptr) &&
             !getTypeMeta(TypeMeta::TaskResult, ptr)) {
-            std::string ann = *annot;
+            const auto &ann = *annot;
             std::string inner;
             if (ann.size() > 7 && ann.substr(0, 7) == "Option<" && ann.back() == '>')
                 inner = ann.substr(7, ann.size() - 8);

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -287,7 +287,7 @@ void CodeGen::emitTupleDestructure(const std::vector<std::string> &var_names,
 
 void CodeGen::emitIndexedForLoop(llvm::Value *length,
                                   std::vector<StmtNode> &body,
-                                  std::function<void(llvm::Value *iCur)> bindVars) {
+                                  std::function<void(llvm::Value *iCur)> bindVars) { // NOLINT(performance-unnecessary-value-param)
     llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "for_i");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
 

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -250,6 +250,7 @@ void CodeGen::emitEachItCall(CallStmt &s) {
 
     // Build parameter types from tuple
     std::vector<llvm::Type*> paramTypes;
+    paramTypes.reserve(numFields);
     for (unsigned i = 0; i < numFields; ++i)
         paramTypes.push_back(tupleTy->getElementType(i));
 
@@ -292,6 +293,8 @@ void CodeGen::emitEachItLoop(llvm::Value *listPtr, llvm::Type *elemTy, unsigned 
 
     std::vector<llvm::Value*> fieldVals;
     std::vector<llvm::Value*> fieldStrs;
+    fieldVals.reserve(numFields);
+    fieldStrs.reserve(numFields);
     for (unsigned i = 0; i < numFields; ++i) {
         llvm::Value *field = builder_.CreateExtractValue(tupleVal, i, "field_" + std::to_string(i));
         fieldVals.push_back(field);

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -27,8 +27,13 @@ llvm::SmallVector<llvm::Value*, 4> CodeGen::loadCapturedArgs(const OverloadEntry
     llvm::SmallVector<llvm::Value*, 4> args;
     for (const auto &capName : entry.capturedNames) {
         llvm::AllocaInst *alloca = findVar(capName);
-        if (!alloca)
-            codegenError(directive + ": captured variable '" + capName + "' not found in scope");
+        if (!alloca) {
+            std::string capErrMsg = directive;
+            capErrMsg += ": captured variable '";
+            capErrMsg += capName;
+            capErrMsg += "' not found in scope";
+            codegenError(capErrMsg);
+        }
         args.push_back(builder_.CreateLoad(alloca->getAllocatedType(), alloca, capName + ".cap_pass"));
     }
     return args;
@@ -366,12 +371,14 @@ void CodeGen::emitPropertyItCall(CallStmt &s) {
 
     // Resolve parameter types
     std::vector<llvm::Type*> paramTypes;
+    paramTypes.reserve(lam.params.size());
     for (auto &p : lam.params)
         paramTypes.push_back(resolveType(p.type->toString()));
 
     llvm::Function *testFunc = emitTestFunction("__prop_test_", paramTypes, lam, "@property test");
 
     std::vector<std::string> paramNames;
+    paramNames.reserve(lam.params.size());
     for (auto &p : lam.params)
         paramNames.push_back(p.name);
 
@@ -757,7 +764,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         llvm::Type *expectedTy = expectedVal->getType();
 
         llvm::Value *eqResult = nullptr;
-        if (actualTy == i64Ty_ && expectedTy == i64Ty_) {
+        if (actualTy == i64Ty_ && expectedTy == i64Ty_) { // NOLINT(bugprone-branch-clone)
             eqResult = builder_.CreateICmpEQ(actualVal, expectedVal, "eq");
         } else if (actualTy == f64Ty_ && expectedTy == f64Ty_) {
             eqResult = builder_.CreateFCmpOEQ(actualVal, expectedVal, "eq");
@@ -788,7 +795,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
             llvm::Type *innerTy = aInner->getType();
 
             llvm::Value *innerEq;
-            if (innerTy == i64Ty_)
+            if (innerTy == i64Ty_) // NOLINT(bugprone-branch-clone)
                 innerEq = builder_.CreateICmpEQ(aInner, bInner, "opt_inner_eq");
             else if (innerTy == f64Ty_)
                 innerEq = builder_.CreateFCmpOEQ(aInner, bInner, "opt_inner_eq");
@@ -893,7 +900,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
                 codegenError("line " + std::to_string(s.loc.line) +
                                          ": " + s.matcher + ": element type mismatch");
             llvm::Value *eq;
-            if (elemTy == i64Ty_)
+            if (elemTy == i64Ty_) // NOLINT(bugprone-branch-clone)
                 eq = builder_.CreateICmpEQ(elem, expectedVal, "eq");
             else if (elemTy == ptrTy_) {
                 auto strcmpFn = getStdlibStrcmp();

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -795,8 +795,8 @@ void CodeGen::emitStmt(ExpectStmt &s) {
             llvm::Type *innerTy = aInner->getType();
 
             llvm::Value *innerEq;
-            if (innerTy == i64Ty_) // NOLINT(bugprone-branch-clone)
-                innerEq = builder_.CreateICmpEQ(aInner, bInner, "opt_inner_eq");
+            if (innerTy == i64Ty_)
+                innerEq = builder_.CreateICmpEQ(aInner, bInner, "opt_inner_eq"); // NOLINT(bugprone-branch-clone)
             else if (innerTy == f64Ty_)
                 innerEq = builder_.CreateFCmpOEQ(aInner, bInner, "opt_inner_eq");
             else if (innerTy == i1Ty_)
@@ -900,8 +900,8 @@ void CodeGen::emitStmt(ExpectStmt &s) {
                 codegenError("line " + std::to_string(s.loc.line) +
                                          ": " + s.matcher + ": element type mismatch");
             llvm::Value *eq;
-            if (elemTy == i64Ty_) // NOLINT(bugprone-branch-clone)
-                eq = builder_.CreateICmpEQ(elem, expectedVal, "eq");
+            if (elemTy == i64Ty_)
+                eq = builder_.CreateICmpEQ(elem, expectedVal, "eq"); // NOLINT(bugprone-branch-clone)
             else if (elemTy == ptrTy_) {
                 auto strcmpFn = getStdlibStrcmp();
                 llvm::Value *cmp = builder_.CreateCall(strcmpFn, {elem, expectedVal}, "strcmp");

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -573,14 +573,10 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
             llvm::Constant *fmt = cachedGlobalString("%d", ".vts_i8_fmt");
             llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i8_ext");
             builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
-        } else if (llName == "u8") {
+        } else {
+            // u8
             llvm::Constant *fmt = cachedGlobalString("%u", ".vts_u8_fmt");
             llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "u8_ext");
-            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
-        } else {
-            // u8 (default)
-            llvm::Constant *fmt = cachedGlobalString("%u", ".vts_u8_def_fmt");
-            llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "u8_def_ext");
             builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
         }
         return buf;

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -61,8 +61,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
     // Check type alias (with cycle detection)
     auto aliasIt = type_aliases_.find(typeName);
     if (aliasIt != type_aliases_.end()) {
-        std::string resolved = resolveTypeAlias(typeName);
-        return resolveType(resolved);
+        return resolveType(resolveTypeAlias(typeName));
     }
 
     // Int literal type: "42", "-5"
@@ -95,6 +94,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
 
         auto components = parseUnionComponents(flattened);
         std::vector<llvm::Type*> compTypes;
+        compTypes.reserve(components.size());
         uint64_t maxSize = 0;
         const auto &dl = mod_->getDataLayout();
         for (auto &c : components) {
@@ -135,6 +135,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
         // Parse element types from "(T1, T2, ...)"
         std::string inner = typeName.substr(1, typeName.size() - 2); // strip parens
         std::vector<llvm::Type*> elementTypes;
+        elementTypes.reserve(std::count(inner.begin(), inner.end(), ',') + 1);
         size_t depth = 0;
         size_t start = 0;
         for (size_t i = 0; i <= inner.size(); ++i) {
@@ -385,6 +386,9 @@ CodeGen::FnTypeInfo CodeGen::parseFnTypeAnnotation(const std::string &typeStr) {
     std::string paramStr = typeStr.substr(openParen + 1, closeParen - openParen - 1);
     // Parse comma-separated parameter types
     if (!paramStr.empty()) {
+        size_t numParams = static_cast<size_t>(std::count(paramStr.begin(), paramStr.end(), ',')) + 1;
+        info.paramTypes.reserve(numParams);
+        info.paramTypeNames.reserve(numParams);
         size_t start = 0;
         int depth = 0;
         for (size_t i = 0; i <= paramStr.size(); ++i) {
@@ -550,6 +554,7 @@ std::optional<CodeGen::TypeConstraint> CodeGen::parseTypeConstraint(const std::s
         if (allInt) {
             TypeConstraint tc;
             tc.kind = TypeConstraint::Kind::IntLiteral;
+            tc.int_values.reserve(components.size());
             for (auto &c : components)
                 tc.int_values.push_back(std::stoll(c));
             return tc;
@@ -563,6 +568,7 @@ std::optional<CodeGen::TypeConstraint> CodeGen::parseTypeConstraint(const std::s
         if (allStr) {
             TypeConstraint tc;
             tc.kind = TypeConstraint::Kind::StrLiteral;
+            tc.str_values.reserve(components.size());
             for (auto &c : components)
                 tc.str_values.push_back(c.substr(1, c.size() - 2));
             return tc;

--- a/src/file_watcher.cpp
+++ b/src/file_watcher.cpp
@@ -92,7 +92,7 @@ struct SigintGuard {
 };
 
 void watchAndRunTests(const std::string &root_dir,
-                      std::function<void()> run_tests) {
+                      std::function<void()> run_tests) { // NOLINT(performance-unnecessary-value-param)
     g_watch_stop = 0;
     SigintGuard sigint_guard;
 

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -381,16 +381,18 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                     }
                 }
                 if (i < v->exprs.size()) {
-                    result += "{" + formatExpr(*v->exprs[i]) + "}";
+                    result += '{';
+                    result += formatExpr(*v->exprs[i]);
+                    result += '}';
                 }
             }
             result += "\"";
             return result;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
-            std::string result = "(" + formatParams(v->params) + ")";
-            if (v->return_type) result += " -> " + v->return_type->toString();
+            std::string result = formatLambdaSig(*v);
             if (v->expr_body) {
-                result += " => " + formatExpr(*v->expr_body);
+                result += " => ";
+                result += formatExpr(*v->expr_body);
                 return result;
             } else if (!v->body.empty()) {
                 result += ":\n";
@@ -418,11 +420,26 @@ std::string Formatter::formatParams(const std::vector<FnParam> &params) {
     std::string result;
     for (size_t i = 0; i < params.size(); ++i) {
         if (i > 0) result += ", ";
-        result += params[i].name + ": " + params[i].type->toString();
-        if (params[i].default_value)
-            result += " = " + formatExpr(*params[i].default_value);
+        result += params[i].name;
+        result += ": ";
+        result += params[i].type->toString();
+        if (params[i].default_value) {
+            result += " = ";
+            result += formatExpr(*params[i].default_value);
+        }
     }
     return result;
+}
+
+std::string Formatter::formatLambdaSig(const LambdaExpr &lambda) {
+    std::string sig = "(";
+    sig += formatParams(lambda.params);
+    sig += ')';
+    if (lambda.return_type) {
+        sig += " -> ";
+        sig += lambda.return_type->toString();
+    }
+    return sig;
 }
 
 // --- Pattern formatting ---

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -514,11 +514,11 @@ void Formatter::formatDirectives(const std::vector<Directive> &directives) {
 bool Formatter::hasDirectives(const StmtNode &stmt) const {
     return std::visit([](const auto &v) -> bool {
         using T = std::decay_t<decltype(v)>;
-        if constexpr (std::is_same_v<T, AssignStmt>) return !v.directives.empty();
+        if constexpr (std::is_same_v<T, AssignStmt>) return !v.directives.empty(); // NOLINT(bugprone-branch-clone)
         else if constexpr (std::is_same_v<T, CallStmt>) return !v.directives.empty();
         else if constexpr (std::is_same_v<T, RecordStmt>) return !v.directives.empty();
         else if constexpr (std::is_same_v<T, TupleDestructStmt>) return !v.directives.empty();
-        else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) return !v->directives.empty();
+        else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) return !v->directives.empty(); // NOLINT(bugprone-branch-clone)
         else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) return !v->directives.empty();
         else return false;
     }, stmt);
@@ -550,7 +550,7 @@ bool Formatter::isDefinition(const StmtNode &stmt) const {
 int Formatter::getStmtLine(const StmtNode &stmt) const {
     return std::visit([](const auto &v) -> int {
         using T = std::decay_t<decltype(v)>;
-        if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) return v->loc.line;
+        if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) return v->loc.line; // NOLINT(bugprone-branch-clone)
         else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondStmt>>) return v->loc.line;
         else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) return v->loc.line;
         else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) return v->loc.line;
@@ -559,7 +559,7 @@ int Formatter::getStmtLine(const StmtNode &stmt) const {
             return v->loc.line;
         }
         else if constexpr (std::is_same_v<T, std::unique_ptr<CaseStmt>>) return v->loc.line;
-        else if constexpr (std::is_same_v<T, AssignStmt>) {
+        else if constexpr (std::is_same_v<T, AssignStmt>) { // NOLINT(bugprone-branch-clone)
             if (!v.directives.empty()) return v.directives.front().loc.line;
             return v.loc.line;
         }
@@ -567,7 +567,7 @@ int Formatter::getStmtLine(const StmtNode &stmt) const {
             if (!v.directives.empty()) return v.directives.front().loc.line;
             return v.loc.line;
         }
-        else if constexpr (std::is_same_v<T, ReturnStmt>) return v.loc.line;
+        else if constexpr (std::is_same_v<T, ReturnStmt>) return v.loc.line; // NOLINT(bugprone-branch-clone)
         else if constexpr (std::is_same_v<T, ExprStmt>) return v.loc.line;
         else if constexpr (std::is_same_v<T, ImportStmt>) return v.loc.line;
         else if constexpr (std::is_same_v<T, RecordStmt>) {
@@ -653,10 +653,7 @@ void Formatter::formatProgram(const Program &prog) {
         bool prev_is_def = (i > 0) && isDefinition(prog[i - 1]);
 
         // Blank line between top-level definitions or around definitions
-        if (i > 0 && (is_def || prev_is_def)) {
-            emitNewline();
-        } else if (i > 0 && stmt_line > last_emitted_line_ + 1) {
-            // Preserve blank line from source
+        if (i > 0 && ((is_def || prev_is_def) || stmt_line > last_emitted_line_ + 1)) {
             emitNewline();
         }
 
@@ -699,7 +696,7 @@ static void collectRyFiles(const std::string &dir, std::vector<std::string> &fil
     std::error_code ec;
     for (auto &entry : fs::recursive_directory_iterator(dir, fs::directory_options::skip_permission_denied, ec)) {
         if (!entry.is_regular_file()) continue;
-        auto path = entry.path();
+        const auto &path = entry.path();
 
         // Skip common directories
         std::string path_str = path.string();

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -28,7 +28,10 @@ void Formatter::formatAssign(const AssignStmt &s) {
     }
 
     if (s.compound_op) {
-        emit(" " + *s.compound_op + "= ");
+        std::string op = " ";
+        op += *s.compound_op;
+        op += "= ";
+        emit(op);
     } else {
         emit(" = ");
     }
@@ -37,8 +40,7 @@ void Formatter::formatAssign(const AssignStmt &s) {
     if (auto *lambda_ptr = std::get_if<std::unique_ptr<LambdaExpr>>(&s.value->data)) {
         const auto &lambda = **lambda_ptr;
         if (!lambda.expr_body && !lambda.body.empty()) {
-            emit("(" + formatParams(lambda.params) + ")");
-            if (lambda.return_type) emit(" -> " + lambda.return_type->toString());
+            emit(formatLambdaSig(lambda));
             emit(":");
             emitInlineComment(s.loc.line);
             emitNewline();
@@ -77,8 +79,7 @@ void Formatter::formatCall(const CallStmt &s) {
 
         if (has_trailing_lambda && i == lambda_idx) {
             const auto &lambda = *std::get<std::unique_ptr<LambdaExpr>>(s.args[i]->data);
-            emit("(" + formatParams(lambda.params) + ")");
-            if (lambda.return_type) emit(" -> " + lambda.return_type->toString());
+            emit(formatLambdaSig(lambda));
             emit(":");
             emitInlineComment(s.loc.line);
             emitNewline();
@@ -94,8 +95,7 @@ void Formatter::formatCall(const CallStmt &s) {
             auto *lp = std::get_if<std::unique_ptr<LambdaExpr>>(&s.args[i]->data);
             if (lp && !(*lp)->expr_body && !(*lp)->body.empty()) {
                 const auto &lambda = **lp;
-                emit("(" + formatParams(lambda.params) + ")");
-                if (lambda.return_type) emit(" -> " + lambda.return_type->toString());
+                emit(formatLambdaSig(lambda));
                 emit(":");
                 emitNewline();
                 last_emitted_line_ = s.loc.line;
@@ -429,7 +429,9 @@ void Formatter::formatExpect(const ExpectStmt &s) {
 }
 
 void Formatter::formatAwaitStmt(const AwaitStmt &s) {
-    emit("await " + formatExpr(*s.operand));
+    std::string awaitStr = "await ";
+    awaitStr += formatExpr(*s.operand);
+    emit(awaitStr);
     emitInlineComment(s.loc.line);
     emitNewline();
     last_emitted_line_ = s.loc.line;

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -137,7 +137,7 @@ int runRySource(const std::string &src, const std::string &source_name,
         prog.insert(prog.begin(),
             std::make_move_iterator(std_prog.begin()),
             std::make_move_iterator(std_prog.end()));
-    } catch (const std::runtime_error &) {
+    } catch (const std::runtime_error &) { // NOLINT(bugprone-empty-catch): stdlib is optional, absence is expected
         // stdlib not installed — continue without it
     }
 

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -375,7 +375,7 @@ int runRySource(const std::string &src, const std::string &source_name,
     // since ry always exits after the run/test command completes, the
     // per-invocation leak is bounded by the process lifetime.
     // TODO(#742): Investigate root cause; fix or file upstream LLVM bug.
-    (void)jit.release();
+    (void)jit.release(); // NOLINT(bugprone-unused-return-value)
 #endif
 
     return result > 0 ? 1 : 0;

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -353,7 +353,7 @@ int runRySource(const std::string &src, const std::string &source_name,
                 canonical_share = fs::weakly_canonical(share_dir).string();
             cs->filenames.resize(static_cast<size_t>(new_total));
             for (int i = 0; i < fc; ++i) {
-                size_t gid = static_cast<size_t>(cs->file_id_offset + i);
+                size_t gid = static_cast<size_t>(cs->file_id_offset) + static_cast<size_t>(i);
                 const std::string &fname = sm.getFilename(i);
                 bool is_stdlib = false;
                 if (!canonical_share.empty()) {
@@ -375,7 +375,7 @@ int runRySource(const std::string &src, const std::string &source_name,
     // since ry always exits after the run/test command completes, the
     // per-invocation leak is bounded by the process lifetime.
     // TODO(#742): Investigate root cause; fix or file upstream LLVM bug.
-    jit.release();
+    (void)jit.release();
 #endif
 
     return result > 0 ? 1 : 0;

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -70,11 +70,16 @@ static void extractDefinitions(Program &source, Program &dest,
 
     // Named import: error on private names
     for (const auto &name : requested_names) {
-        if (isPrivateName(name))
-            throw std::runtime_error("line " + std::to_string(line) +
-                                     ": cannot import private symbol '" +
-                                     name + "' from package '" +
-                                     import_path + "'");
+        if (isPrivateName(name)) {
+            std::string privMsg = "line ";
+            privMsg += std::to_string(line);
+            privMsg += ": cannot import private symbol '";
+            privMsg += name;
+            privMsg += "' from package '";
+            privMsg += import_path;
+            privMsg += "'";
+            throw std::runtime_error(privMsg);
+        }
     }
 
     std::unordered_set<std::string> requested(requested_names.begin(), requested_names.end());
@@ -92,11 +97,16 @@ static void extractDefinitions(Program &source, Program &dest,
         }
     }
     for (const auto &name : requested_names) {
-        if (!found.count(name))
-            throw std::runtime_error("line " + std::to_string(line) +
-                                     ": '" + name +
-                                     "' not found in package '" +
-                                     import_path + "'");
+        if (!found.count(name)) {
+            std::string notFoundMsg = "line ";
+            notFoundMsg += std::to_string(line);
+            notFoundMsg += ": '";
+            notFoundMsg += name;
+            notFoundMsg += "' not found in package '";
+            notFoundMsg += import_path;
+            notFoundMsg += "'";
+            throw std::runtime_error(notFoundMsg);
+        }
     }
 }
 

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -1026,7 +1026,7 @@ StmtNode Parser::parseCaseStatement() {
 
 // Parse the body of `case:` (no subject). Called with the leading `case` token
 // already consumed and the upcoming token being the `:`.
-StmtNode Parser::parseCaseStatementNoSubject(Token caseTok) {
+StmtNode Parser::parseCaseStatementNoSubject(const Token &caseTok) {
     if (lex_.peek().kind != TokenKind::Colon)
         parseError("expected ':' after 'case'");
     lex_.next(); // consume ':'
@@ -1054,7 +1054,7 @@ StmtNode Parser::parseCaseStatementNoSubject(Token caseTok) {
         bool isWildcard = (first.kind == TokenKind::Ident && first.value == "_");
         if (isWildcard) {
             // Peek ahead to see if the next non-`_` token is `:`.
-            Token saved = first;
+            const auto &saved = first;
             lex_.next(); // consume '_'
             if (lex_.peek().kind != TokenKind::Colon) {
                 parseError(saved.line, "'_' in case: block must be followed by ':' (wildcard arm)");
@@ -1088,7 +1088,7 @@ StmtNode Parser::parseCaseStatementNoSubject(Token caseTok) {
 // Parse the body of `case <expr>:` (with subject). Called with the leading
 // `case` token already consumed and the upcoming tokens being the subject
 // expression.
-StmtNode Parser::parseCaseStatementWithSubject(Token caseTok) {
+StmtNode Parser::parseCaseStatementWithSubject(const Token &caseTok) {
     ExprPtr subject = parseConditional();
 
     if (lex_.peek().kind != TokenKind::Colon)

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -22,7 +22,7 @@ ExprPtr Parser::parseCaseExpr() {
     return parseCaseExprWithSubject(caseTok);
 }
 
-ExprPtr Parser::parseCaseExprNoSubject(Token caseTok) {
+ExprPtr Parser::parseCaseExprNoSubject(const Token &caseTok) {
     if (lex_.peek().kind != TokenKind::Colon)
         parseError("expected ':' after 'case'");
     lex_.next(); // consume ':'
@@ -47,7 +47,7 @@ ExprPtr Parser::parseCaseExprNoSubject(Token caseTok) {
             // a sub-expression of a condition`, but in this context the `_`
             // must always be a wildcard default — no other interpretation is
             // legal at arm position.
-            Token saved = first;
+            const auto &saved = first;
             lex_.next(); // consume '_'
             if (lex_.peek().kind != TokenKind::FatArrow)
                 parseError(saved.line, "expected '=>' after '_' in case expression wildcard arm");
@@ -86,7 +86,7 @@ ExprPtr Parser::parseCaseExprNoSubject(Token caseTok) {
     return node;
 }
 
-ExprPtr Parser::parseCaseExprWithSubject(Token caseTok) {
+ExprPtr Parser::parseCaseExprWithSubject(const Token &caseTok) {
     ExprPtr subject = parseConditional();
 
     if (lex_.peek().kind != TokenKind::Colon)

--- a/src/paths.cpp
+++ b/src/paths.cpp
@@ -134,8 +134,8 @@ StdlibManifest read_manifest(const fs::path &dir) {
     manifest.version = ry::self_update::detail::extract_json_string(json, "version");
 
     // Extract files array
-    auto arr_start = json.find("[");
-    auto arr_end = json.find("]");
+    auto arr_start = json.find('[');
+    auto arr_end = json.find(']');
     if (arr_start != std::string::npos && arr_end != std::string::npos) {
         std::string arr = json.substr(arr_start + 1, arr_end - arr_start - 1);
         size_t pos = 0;

--- a/src/project_config.cpp
+++ b/src/project_config.cpp
@@ -324,7 +324,7 @@ int cmd_run(int argc, char *argv[]) {
         return 1;
     }
 
-    int status = std::system(it->second.c_str());
+    int status = std::system(it->second.c_str()); // NOLINT(cert-env33-c) -- intentional: ry run executes user-defined scripts
     if (status == -1) {
         std::cerr << "Error: failed to execute command\n";
         return 1;

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -186,7 +186,7 @@ extern "C" void __ry_any_add(RyAny *result, const RyAny *a, const RyAny *b) {
         const char *sb = __ry_any_to_string(b);
         size_t la = strlen(sa), lb = strlen(sb);
         char *buf = static_cast<char *>(checked_malloc(la + lb + 1));
-        memcpy(buf, sa, la);
+        memcpy(buf, sa, la); // NOLINT(bugprone-not-null-terminated-result) -- second memcpy copies lb+1 bytes including null terminator
         memcpy(buf + la, sb, lb + 1);
         if (a_alloc) free(const_cast<char *>(sa));
         if (b_alloc) free(const_cast<char *>(sb));

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -255,7 +255,7 @@ std::string recv_all(HttpTransport &t, size_t max_bytes) {
         ssize_t n = t.do_recv(&buf[total], max_bytes - total);
         if (n <= 0) break;
         total += (size_t)n;
-        size_t search_from = (total > (size_t)n + 3) ? total - (size_t)n - 3 : 0;
+        size_t search_from = (total > static_cast<size_t>(n) + 3) ? total - static_cast<size_t>(n) - 3 : 0;
         if (buf.find("\r\n\r\n", search_from) != std::string::npos)
             break;
     }

--- a/src/runtime_parallel.cpp
+++ b/src/runtime_parallel.cpp
@@ -82,7 +82,7 @@ public:
         global_cv_.notify_all();
         for (std::thread &worker : workers_) {
             if (worker.joinable()) {
-                try { worker.join(); } catch (...) {}
+                try { worker.join(); } catch (...) {} // NOLINT(bugprone-empty-catch): shutdown best-effort, join failure is non-recoverable
             }
         }
 

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -948,8 +948,8 @@ void *__ry_regex_split(const char *pattern, const char *text) {
     std::vector<std::string> parts;
     size_t lastEnd = 0;
     for (auto &[start, end] : matches) {
-        parts.emplace_back(text + lastEnd, (size_t)start - lastEnd);
-        lastEnd = (size_t)end;
+        parts.emplace_back(text + lastEnd, static_cast<size_t>(start) - lastEnd);
+        lastEnd = static_cast<size_t>(end);
     }
     parts.emplace_back(text + lastEnd);
     return makeStringList(parts);

--- a/src/runtime_regex_parser.cpp
+++ b/src/runtime_regex_parser.cpp
@@ -265,6 +265,7 @@ RegexNodePtr RegexParser::parseShorthandClass(char code) {
         case 'W': node->negated = true;  node->ranges = WORD_CHAR_RANGES; break;
         case 's': node->negated = false; node->ranges = {{' ',' '},{'\t','\t'},{'\n','\n'},{'\r','\r'},{'\f','\f'}}; break;
         case 'S': node->negated = true;  node->ranges = {{' ',' '},{'\t','\t'},{'\n','\n'},{'\r','\r'},{'\f','\f'}}; break;
+        default: break;
     }
     return node;
 }

--- a/src/runtime_sort.cpp
+++ b/src/runtime_sort.cpp
@@ -205,7 +205,7 @@ void __ry_timsort(void *data, int64_t len, int64_t elemSize,
     }
 
     // Allocate temp buffer for merging (max half of array)
-    void *tmpBuf = checked_array_malloc((size_t)(len / 2 + 1), (size_t)elemSize);
+    void *tmpBuf = checked_array_malloc(static_cast<size_t>(len) / 2 + 1, static_cast<size_t>(elemSize));
 
     // Run stack (max 85 entries for 2^64 elements)
     RunEntry runStack[85];

--- a/src/self_update.cpp
+++ b/src/self_update.cpp
@@ -120,6 +120,7 @@ int run_command(const std::vector<std::string> &args, std::string *output) {
             close(pipefd[1]);
         }
         std::vector<char *> argv;
+        argv.reserve(args.size() + 1);
         for (auto &a : args) argv.push_back(const_cast<char *>(a.c_str()));
         argv.push_back(nullptr);
         // Use execv for absolute paths (secure), execvp as fallback

--- a/src/source_manager.cpp
+++ b/src/source_manager.cpp
@@ -5,6 +5,7 @@ namespace ry {
 
 void SourceManager::buildLineOffsets(SourceFile &sf) {
     sf.lineOffsets.clear();
+    sf.lineOffsets.reserve(sf.content.size() / 40 + 1);
     sf.lineOffsets.push_back(0);
     for (size_t i = 0; i < sf.content.size(); ++i) {
         if (sf.content[i] == '\n') {
@@ -30,10 +31,11 @@ std::string_view SourceManager::getLine(int fileId, int line) const {
     int idx = line - 1;
     if (idx < 0 || static_cast<size_t>(idx) >= sf.lineOffsets.size())
         return "";
-    size_t start = sf.lineOffsets[static_cast<size_t>(idx)];
+    auto uidx = static_cast<size_t>(idx);
+    size_t start = sf.lineOffsets[uidx];
     size_t end;
-    if (static_cast<size_t>(idx + 1) < sf.lineOffsets.size()) {
-        end = sf.lineOffsets[static_cast<size_t>(idx + 1)];
+    if (uidx + 1 < sf.lineOffsets.size()) {
+        end = sf.lineOffsets[uidx + 1];
     } else {
         end = sf.content.size();
     }

--- a/src/test_runner.cpp
+++ b/src/test_runner.cpp
@@ -144,14 +144,13 @@ static TestFileResult runTestFileSubprocess(const std::string &filepath,
         if (errno != EINTR) break;
     }
 
-    if (wp == -1)
-        result.exit_code = -1;
-    else if (WIFEXITED(status))
-        result.exit_code = WEXITSTATUS(status);
-    else if (WIFSIGNALED(status))
-        result.exit_code = 128 + WTERMSIG(status);
-    else
-        result.exit_code = -1;
+    result.exit_code = -1;
+    if (wp != -1) {
+        if (WIFEXITED(status))
+            result.exit_code = WEXITSTATUS(status);
+        else if (WIFSIGNALED(status))
+            result.exit_code = 128 + WTERMSIG(status);
+    }
 
     return result;
 }

--- a/src/type_node.cpp
+++ b/src/type_node.cpp
@@ -17,7 +17,11 @@ std::string TypeNode::toString() const {
             result += ">";
             return result;
         } else if constexpr (std::is_same_v<T, ArrayType>) {
-            return v.element_type->toString() + "[" + std::to_string(v.size) + "]";
+            std::string result = v.element_type->toString();
+            result += '[';
+            result += std::to_string(v.size);
+            result += ']';
+            return result;
         } else if constexpr (std::is_same_v<T, TupleType>) {
             std::string result = "(";
             for (size_t i = 0; i < v.elements.size(); ++i) {

--- a/src/type_node.cpp
+++ b/src/type_node.cpp
@@ -120,20 +120,24 @@ TypeNodePtr TypeNode::clone(const TypeNodePtr &src) {
             return makeBasic(v.name);
         } else if constexpr (std::is_same_v<T, GenericType>) {
             std::vector<TypeNodePtr> args;
+            args.reserve(v.type_args.size());
             for (auto &a : v.type_args) args.push_back(clone(a));
             return makeGeneric(v.name, std::move(args));
         } else if constexpr (std::is_same_v<T, ArrayType>) {
             return makeArray(clone(v.element_type), v.size);
         } else if constexpr (std::is_same_v<T, TupleType>) {
             std::vector<TypeNodePtr> elems;
+            elems.reserve(v.elements.size());
             for (auto &e : v.elements) elems.push_back(clone(e));
             return makeTuple(std::move(elems));
         } else if constexpr (std::is_same_v<T, FnType>) {
             std::vector<TypeNodePtr> params;
+            params.reserve(v.param_types.size());
             for (auto &p : v.param_types) params.push_back(clone(p));
             return makeFn(std::move(params), clone(v.return_type));
         } else if constexpr (std::is_same_v<T, UnionType>) {
             std::vector<TypeNodePtr> comps;
+            comps.reserve(v.components.size());
             for (auto &c : v.components) comps.push_back(clone(c));
             return makeUnion(std::move(comps));
         } else if constexpr (std::is_same_v<T, OptionalType>) {

--- a/tests/spec/low_level_types.test.ry
+++ b/tests/spec/low_level_types.test.ry
@@ -166,6 +166,16 @@ describe("as cast with low-level types", ():
     y = x as i32
     expect(y as int).to_eq(3)
   )
+  it("should cast signed i8 to f32 preserving sign", ():
+    x: i8 = -5
+    y = x as f32
+    expect(y as float).to_eq(-5.0)
+  )
+  it("should cast unsigned u8 to f32 as positive", ():
+    x: u8 = 200
+    y = x as f32
+    expect(y as float).to_eq(200.0)
+  )
 )
 
 describe("low-level type inference and propagation", ():


### PR DESCRIPTION
## Summary

- Resolves all 85 existing clang-tidy warnings across `src/` and `include/ry/`
- Enables `WarningsAsErrors: '*'` in `.clang-tidy` and removes `continue-on-error: true` from CI — clang-tidy is now a hard gate

Fixes #935

### Changes by category

| Check | Count | Files |
|-------|-------|-------|
| `bugprone-branch-clone` | 37 | `codegen_expr_cast.cpp`, `codegen_tostring.cpp`, `codegen_expr.cpp` |
| `performance-inefficient-vector-operation` | 16 | `codegen_type.cpp`, `codegen_call_native.cpp`, `codegen_call_dispatch.cpp`, `codegen_fn_generic.cpp`, `codegen_fn.cpp`, `codegen_test.cpp`, `codegen_lambda.cpp`, `codegen_match.cpp`, `self_update.cpp`, `source_manager.cpp` |
| `performance-inefficient-string-concatenation` | 8 | `type_node.cpp`, `formatter.cpp`, `formatter_stmt.cpp`, `codegen_builtin.cpp`, `codegen_fn_generic.cpp` |
| `performance-unnecessary-copy-initialization` | 6 | `codegen_fn_generic.cpp`, `codegen_type.cpp` |
| `performance-unnecessary-value-param` | 6 | `ast.hpp`, `source_manager.hpp` (NOLINT — sink parameter idiom is intentional) |
| `performance-faster-string-find` | 2 | `paths.cpp` |
| `bugprone-misplaced-widening-cast` | 3 | `runtime_sort.cpp`, `runtime_regex.cpp`, `runtime_http.cpp`, `source_manager.cpp` |
| `bugprone-empty-catch` | 2 | `runtime_parallel.cpp`, `jit_runner.cpp` (NOLINT — shutdown best-effort) |

### Refactoring (from /simplify review)

- Extracted `Formatter::formatLambdaSig()` private helper — eliminates 4 copies of `"(params) -> RetType"` pattern and removes the scoped `sig2`/`ret2` workaround in `formatter_stmt.cpp`
- Simplified `parseUnionComponents` reserve to use `find`-based count (consistent with the parsing loop below)
- Simplified `source_manager.cpp` repeated `static_cast<size_t>(idx)` to a single `uidx` variable

## Test plan

- [x] `cmake --build build` — clean build, 0 errors
- [x] `./build/ry_tests` — 1638/1638 passed
- [x] `./build/ry test -p` — 119 files, 0 failures
- [x] ASan + UBSan — 1637 passed, 0 failures
- [x] TSan — 1638 passed, 0 failures
- [ ] CI clang-tidy job — expected to pass with 0 warnings (hard gate)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Code Quality**
  * Clang-tidy warnings fixed and now treated as errors; lint issues will fail CI.

* **CI**
  * Lint job is now a hard gate (no continue-on-error).

* **Documentation**
  * Added guidance for intentional lint suppressions with required justifications.

* **Performance**
  * Multiple small optimizations to reduce reallocations and improve efficiency.

* **Tests**
  * Added test cases validating low-level numeric casting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->