### PR TITLE
fix: update LLVM cache key version from v1 to v2 in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ CI は `.github/actions/setup-llvm/` composite action 経由で LLVM を取得�
 
 ミラー tarball は `.github/workflows/mirror-llvm-toolchain.yml`（手動 `workflow_dispatch`）で構築・アップロードする。
 
-**キャッシュキー**: `llvm-${VERSION}-linux-x86_64-v1-${SHA256_SHORT}`。`restore-keys` は意図的に設定しない — 部分一致ヒットは異なるバージョンの LLVM を復元し、ビルド失敗や ABI 不整合を引き起こす。
+**キャッシュキー**: `llvm-${VERSION}-linux-x86_64-v2-${SHA256_SHORT}`。`restore-keys` は意図的に設定しない — 部分一致ヒットは異なるバージョンの LLVM を復元し、ビルド失敗や ABI 不整合を引き起こす。
 
 **バージョンバンプ手順**:
 


### PR DESCRIPTION
## Summary

- AGENTS.md のキャッシュキー記述が `v1` のままだったのを、実際の `setup-llvm/action.yml` に合わせて `v2` に修正

Closes #949 のレビュー指摘対応

## Test plan

- ドキュメントのみの変更のため、テスト不要

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LLVM toolchain cache configuration version in build documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->