### PR TITLE
fix: expand clang-tidy HeaderFilterRegex to include src/ headers (#950)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,7 +46,7 @@ Checks: >
 
 WarningsAsErrors: '*'
 
-HeaderFilterRegex: 'include/ry/.*\.hpp$'
+HeaderFilterRegex: '^(include/ry|src)/.*\.(h|hpp)$'
 
 FormatStyle: none
 

--- a/changelog.d/950-clang-tidy-header-filter.md
+++ b/changelog.d/950-clang-tidy-header-filter.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Expanded clang-tidy `HeaderFilterRegex` to include `src/` implementation headers (#950)


### PR DESCRIPTION
## Summary

- `HeaderFilterRegex` を `include/ry/.*\.hpp$` から `^(include/ry|src)/.*\.(h|hpp)$` に拡張し、`src/` 配下の実装ヘッダーも clang-tidy の診断対象に含める
- 現時点で `src/` 配下に `.hpp` / `.h` ファイルは存在しないが、将来の追加に備えた防御的変更
- PR #949 での CodeRabbit レビュー（Major）指摘への対応

Closes #950

## Test plan

- [x] `cmake --preset default && cmake --build build` — ビルド成功
- [x] `./build/ry_tests` — 1638 tests passed
- [x] `./build/ry test -p` — 119 files, 0 failures
- [x] ASan + UBSan — clean
- [x] TSan (`ry_tests`) — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated clang-tidy configuration to expand header file checking across additional directories and file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->