### PR TITLE
fix: validate extra-packages before running llvm.sh (#951)

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -59,7 +59,6 @@ runs:
           sudo tar -xJf "$WORK/${ASSET}" -C /usr/local
         else
           echo "Mirrored release not found, installing via apt.llvm.org..."
-          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
           EXTRA_RAW="${{ inputs.extra-packages }}"
           EXTRA_RAW="${EXTRA_RAW//\{MAJOR\}/$MAJOR}"
           EXTRA_PKGS=()
@@ -72,6 +71,7 @@ runs:
               fi
             done
           fi
+          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
           sudo apt-get install -y \
             libllvm"${MAJOR}" \
             llvm-"${MAJOR}"-dev \


### PR DESCRIPTION
## Summary

- `extra-packages` のバリデーションを `llvm.sh` 実行前に移動し、不正なパッケージ名で early fail するようにした
- ロジックの変更はなく、実行順序のみの変更

## Changes

`.github/actions/setup-llvm/action.yml` の apt fallback パスで、`extra-packages` のパース＆バリデーションブロックを `wget ... llvm.sh` 呼び出しの前に移動した。

## Test plan

- [ ] CI の `clang-tidy` / `build-and-test` ジョブで apt fallback パスが使われる場合に正常動作することを確認
- [ ] 変更はコード移動のみ（ロジック変更なし）

Closes #951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the execution order of LLVM setup steps in the GitHub Actions workflow to ensure proper validation of package configurations before installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->