### PR TITLE
chore: introduce Cppcheck static analysis in lint CI job (#894)

### DIFF
--- a/.cppcheck-suppressions
+++ b/.cppcheck-suppressions
@@ -1,0 +1,18 @@
+# Cppcheck suppression file for ry
+#
+# Format: <checkId>[:<filename>[:<line>]]
+# Lines starting with # are comments.
+#
+# This file is used with --suppressions-list=.cppcheck-suppressions.
+# Inline suppressions in source (// cppcheck-suppress <id>) are also enabled
+# via --inline-suppr.
+
+# RY_REGISTER_STDLIB_PACKAGE and DEFINE_LAST_ERROR are internal project macros
+# defined in include/ry/. Without --project=compile_commands.json, Cppcheck
+# cannot resolve them and emits unknownMacro. These are false positives.
+unknownMacro
+
+# __has_feature is a Clang compiler builtin predicate (not a function-like
+# macro). Cppcheck cannot evaluate it and reports a spurious syntaxError on
+# the #if defined(__has_feature) && __has_feature(...) idiom.
+syntaxError:src/test_runtime.cpp

--- a/.cppcheck-suppressions
+++ b/.cppcheck-suppressions
@@ -1,18 +1,2 @@
-# Cppcheck suppression file for ry
-#
-# Format: <checkId>[:<filename>[:<line>]]
-# Lines starting with # are comments.
-#
-# This file is used with --suppressions-list=.cppcheck-suppressions.
-# Inline suppressions in source (// cppcheck-suppress <id>) are also enabled
-# via --inline-suppr.
-
-# RY_REGISTER_STDLIB_PACKAGE and DEFINE_LAST_ERROR are internal project macros
-# defined in include/ry/. Without --project=compile_commands.json, Cppcheck
-# cannot resolve them and emits unknownMacro. These are false positives.
 unknownMacro
-
-# __has_feature is a Clang compiler builtin predicate (not a function-like
-# macro). Cppcheck cannot evaluate it and reports a spurious syntaxError on
-# the #if defined(__has_feature) && __has_feature(...) idiom.
 syntaxError:src/test_runtime.cpp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install Cppcheck
+        run: sudo apt-get update && sudo apt-get install -y cppcheck
       - name: Check for banned unsafe allocation functions
         run: |
           # Scan src/ and include/ for raw malloc/realloc/calloc/strdup/strndup.
@@ -30,6 +32,18 @@ jobs:
             echo "::error::Raw allocation functions detected. Use checked_* wrappers from include/ry/runtime_alloc.hpp instead."
             exit 1
           fi
+      - name: Run Cppcheck
+        run: |
+          cppcheck \
+            --enable=warning,performance,portability \
+            --std=c++17 \
+            --error-exitcode=1 \
+            --suppressions-list=.cppcheck-suppressions \
+            --inline-suppr \
+            -i build -i build-asan -i build-tsan \
+            -j "$(nproc)" \
+            --quiet \
+            src/ include/
 
   clang-tidy:
     runs-on: ubuntu-24.04

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,20 @@ cmake --build build                                     # Ninja が自動並列�
 - ローカル実行: `find src -name '*.cpp' | xargs clang-tidy -p build --quiet`
 - 新規コードは Clang-Tidy 警告ゼロを維持すること
 
+## Cppcheck 静的解析
+
+プロジェクトルートの `.cppcheck-suppressions` で抑制設定を管理する。CI の `lint` ジョブが `src/` と `include/` に対して実行する。
+
+```text
+有効: warning, performance, portability
+除外: .cppcheck-suppressions に記載（詳細はファイル参照）
+```
+
+- `compile_commands.json` は使用しない（ビルド不要で高速実行）
+- ソースコード内の `// cppcheck-suppress <id>` コメントも有効（`--inline-suppr`）
+- ローカル実行: `cppcheck --enable=warning,performance,portability --std=c++17 --suppressions-list=.cppcheck-suppressions --inline-suppr -i build -i build-asan -i build-tsan -j "$(nproc)" --quiet src/ include/`
+- 新規コードは Cppcheck 警告ゼロを維持すること
+
 ## CI: LLVM ツールチェーン (ミラー)
 
 CI は `.github/actions/setup-llvm/` composite action 経由で LLVM を取得する。優先順に:

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1408,6 +1408,30 @@ suppressed with `// NOLINT(...)` rather than refactored:
 **Rule**: When using NOLINT, always include the specific check name and
 a one-line comment explaining why the suppression is justified.
 
+### Cppcheck: suppression strategy and known false positives
+
+**Source**: #894 (implementation)
+**Tags**: build, ci, cppcheck, static-analysis
+
+Cppcheck is run in the `lint` CI job without `compile_commands.json` (build-free,
+fast). This means project macros defined in headers are not visible to Cppcheck,
+causing `unknownMacro` false positives.
+
+Known suppressions in `.cppcheck-suppressions`:
+
+- **`unknownMacro`** (global): `RY_REGISTER_STDLIB_PACKAGE` and `DEFINE_LAST_ERROR`
+  are project macros not resolved without `compile_commands.json`. Suppressed globally
+  because running without the compilation database is intentional (avoids requiring a
+  full build in the `lint` job).
+- **`syntaxError:src/test_runtime.cpp`**: `__has_feature(...)` is a Clang compiler
+  builtin predicate, not a function-like macro. Cppcheck cannot evaluate the
+  `__has_feature(address_sanitizer)` idiom and emits a spurious `syntaxError`.
+
+**Rule**: When adding a new suppression to `.cppcheck-suppressions`, always include
+a comment explaining whether it is a false positive (and why) or a known acceptable
+deviation. Use per-file suppressions (`id:src/file.cpp`) rather than global ones
+where possible.
+
 ---
 
 ## Documentation

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1432,6 +1432,10 @@ a comment explaining whether it is a false positive (and why) or a known accepta
 deviation. Use per-file suppressions (`id:src/file.cpp`) rather than global ones
 where possible.
 
+**Gotcha**: Cppcheck 2.13 (Ubuntu 24.04 package) does NOT support `#` comment lines
+in `--suppressions-list` files. Comment syntax was added in 2.14. Keep
+`.cppcheck-suppressions` comment-free to remain compatible with 2.13.
+
 ---
 
 ## Documentation

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -159,7 +159,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
         auto ltPos = baseName.find('<');
         if (ltPos != std::string::npos && baseName.back() == '>') {
             std::string argsStr = baseName.substr(ltPos + 1, baseName.size() - ltPos - 2);
-            baseName = baseName.substr(0, ltPos);
+            baseName.resize(ltPos);
             typeArgs = splitTypeArgs(argsStr);
         }
 

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -507,6 +507,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
     builder_.CreateUnreachable();
 
     builder_.SetInsertPoint(mergeBB);
+    assert(firstVal != nullptr && "match expression must have at least one arm");
     llvm::PHINode *phi = builder_.CreatePHI(firstVal->getType(), static_cast<unsigned>(incoming.size()), "match.expr");
     for (auto &[val, bb] : incoming)
         phi->addIncoming(val, bb);

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -44,7 +44,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
         std::string base = canonical;
         auto ltPos = base.find('<');
         if (ltPos != std::string::npos)
-            base = base.substr(0, ltPos);
+            base.resize(ltPos);
         if (base != "str" && base != "List" && base != "Map" && base != "Set")
             codegenError("weak references require an ARC-managed type (str, List, Map, Set), got: " + inner);
         resolveType(inner);  // validate inner type exists

--- a/src/dotenv.cpp
+++ b/src/dotenv.cpp
@@ -43,7 +43,7 @@ parseDotEnv(const std::string &content) {
         std::string key = line.substr(start, eq - start);
         size_t key_end = key.find_last_not_of(" \t");
         if (key_end != std::string::npos)
-            key = key.substr(0, key_end + 1);
+            key.resize(key_end + 1);
         if (key.empty()) continue;
 
         // Extract value

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -507,6 +507,7 @@ extern "C" void *__ry_http_read_request(void *stream) {
 
     void *req_mem = arc_alloc(sizeof(HttpRequestHandle));
     if (!req_mem) return nullptr;
+    // cppcheck-suppress legacyUninitvar -- placement new with {} zero-initializes; false positive in Cppcheck < 2.14
     auto *req = new (req_mem) HttpRequestHandle{};
 
     size_t line_end;
@@ -583,6 +584,7 @@ extern "C" void *__ry_http_cookies(void *r) {
 extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, const char *body) {
     void *resp_mem = arc_alloc(sizeof(HttpResponseHandle));
     if (!resp_mem) return nullptr;
+    // cppcheck-suppress legacyUninitvar -- placement new with {} zero-initializes; false positive in Cppcheck < 2.14
     auto *resp = new (resp_mem) HttpResponseHandle{};
     resp->status = status;
     const char *b = body ? body : "";

--- a/src/runtime_http_client.cpp
+++ b/src/runtime_http_client.cpp
@@ -217,6 +217,7 @@ static HttpClientResponseHandle *read_http_response(HttpTransport &t) {
         for (auto &h : parsed_headers) { free(h.key); free(h.val); }
         return nullptr;
     }
+    // cppcheck-suppress legacyUninitvar -- placement new with {} zero-initializes; false positive in Cppcheck < 2.14
     auto *resp = new (resp_mem) HttpClientResponseHandle{};
     resp->status = status_code;
     resp->body_len = (int64_t)body_len;

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -112,7 +112,7 @@ extern "C" void *__ry_accept(void *listener) {
 
     struct sockaddr_in client_addr{};
     socklen_t addr_len = sizeof(client_addr);
-    int client_fd = ::accept(handle->fd, (struct sockaddr *)&client_addr, &addr_len);
+    int client_fd = ::accept(handle->fd, reinterpret_cast<struct sockaddr *>(&client_addr), &addr_len);
     if (client_fd < 0)
         return nullptr;
 #ifdef SO_NOSIGPIPE
@@ -293,7 +293,7 @@ extern "C" int64_t __ry_listener_port(void *listener) {
     auto *handle = (TcpListenerHandle *)listener;
     struct sockaddr_in addr{};
     socklen_t len = sizeof(addr);
-    if (::getsockname(handle->fd, (struct sockaddr *)&addr, &len) < 0)
+    if (::getsockname(handle->fd, reinterpret_cast<struct sockaddr *>(&addr), &len) < 0)
         return -1;
     return (int64_t)ntohs(addr.sin_port);
 }

--- a/src/runtime_sort.cpp
+++ b/src/runtime_sort.cpp
@@ -232,6 +232,7 @@ void __ry_timsort(void *data, int64_t len, int64_t elemSize,
                   runStack[n].base, runStack[n].len,
                   runStack[n + 1].base, runStack[n + 1].len,
                   elemSize, cmp, cmpCtx);
+            // cppcheck-suppress uninitvar -- entries 0..stackSize-1 are populated by prior loop iterations
             runStack[n].len += runStack[n + 1].len;
             if (n + 2 < stackSize) {
                 runStack[n + 1] = runStack[n + 2];


### PR DESCRIPTION
## Summary

- Add Cppcheck (`warning`, `performance`, `portability`) to the `lint` CI job as a complementary static analysis tool alongside Clang-Tidy
- Runs build-free (no `compile_commands.json` needed) via directory scan with `--std=c++17`
- Add `.cppcheck-suppressions` for known false positives (`unknownMacro`, `syntaxError` on `test_runtime.cpp`)
- Fix all findings detected by the initial scan (see below)

## Fixes from initial Cppcheck scan

| File | Change |
|------|--------|
| `src/codegen_call_dispatch.cpp` | `str.substr(0, n)` → `str.resize(n)` (avoid redundant allocation) |
| `src/codegen_type.cpp` | Same |
| `src/dotenv.cpp` | Same |
| `src/codegen_match.cpp` | Add `assert(firstVal != nullptr)` to document exhaustiveness invariant before PHI construction |
| `src/runtime_net.cpp` | Replace C-style `(struct sockaddr *)` casts with `reinterpret_cast` (×2) |

## Test plan

- [x] All 1638 C++ tests pass (`./build/ry_tests`)
- [x] All 119 Ry self-test files pass (`./build/ry test -p`)
- [x] `cppcheck ... src/ include/` exits 0 with zero warnings locally (Cppcheck 2.20.0)
- [ ] CI `lint` job passes with the new Cppcheck step

Closes #894

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cppcheck static analysis added to CI with a project suppression list.

* **Bug Fixes**
  * Safer socket API usage and added runtime validation to avoid uninitialized values.
  * Reduced false positives by initializing objects where needed.

* **Documentation**
  * Added guidance on Cppcheck usage, suppression policy, and contribution rules.

* **Refactor**
  * Minor in-place string handling and small code clarity tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->