### PR TITLE
chore: introduce Clang Static Analyzer (scan-build) in CI (#898)

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: /usr/local/llvm
-        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v2-${{ inputs.sha256-short }}
+        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v3-${{ inputs.sha256-short }}
 
     - name: Download and install LLVM
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,52 @@ jobs:
           find src -name '*.cpp' \
             | xargs clang-tidy -p build --quiet
 
+  scan-build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup LLVM
+        uses: ./.github/actions/setup-llvm
+        with:
+          llvm-version: ${{ env.LLVM_VERSION }}
+          sha256-short: ${{ env.LLVM_SHA256_SHORT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          extra-packages: clang-tools-{MAJOR}
+      - name: Install dependencies
+        run: sudo apt-get install -y libssl-dev ninja-build libgtest-dev libgmock-dev
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ci-scan-build-${{ github.ref }}
+          restore-keys: |
+            ci-scan-build-
+          save: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}
+      - name: Configure
+        run: |
+          scan-build \
+            --use-cc=/usr/local/llvm/bin/clang \
+            --use-c++=/usr/local/llvm/bin/clang++ \
+            cmake --preset default
+      - name: Build + Analyze
+        # warn-only: triage existing findings before making this required.
+        # Once findings are resolved, remove continue-on-error.
+        continue-on-error: true
+        run: |
+          scan-build \
+            --use-cc=/usr/local/llvm/bin/clang \
+            --use-c++=/usr/local/llvm/bin/clang++ \
+            -o scan-build-report \
+            --status-bugs \
+            cmake --build build
+      - name: Upload scan-build report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: scan-build-report
+          path: scan-build-report
+          retention-days: 14
+          if-no-files-found: ignore
+
   test:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -47,7 +47,7 @@ jobs:
           V="${{ inputs.llvm_version }}"
           MAJOR="${V%%.*}"
           wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
-          sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}" clang-tidy-"${MAJOR}"
+          sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}" clang-tidy-"${MAJOR}" clang-tools-"${MAJOR}"
           echo "LLVM_MAJOR=${MAJOR}" >> "$GITHUB_ENV"
 
       - name: Repack as portable tarball

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,27 @@ cmake --build build                                     # Ninja が自動並列�
 - ローカル実行: `cppcheck --enable=warning,performance,portability --std=c++17 --suppressions-list=.cppcheck-suppressions --inline-suppr -i build -i build-asan -i build-tsan -j "$(nproc)" --quiet src/ include/`
 - 新規コードは Cppcheck 警告ゼロを維持すること
 
+## Clang Static Analyzer (scan-build)
+
+CI の `scan-build` ジョブがシンボリック実行ベースのパス感度解析を実行する。Clang-Tidy / Cppcheck では検出しづらい null 参照・use-after-free・memory leak・未初期化変数・dead store を検出する。
+
+- `scan-build` は `clang-tools-21` apt パッケージに同梱（mirror tarball にも含まれる）
+- `compile_commands.json` は使用しない（scan-build がビルドをラップして解析する）
+- ローカル実行:
+  ```bash
+  scan-build --use-cc=/usr/local/llvm/bin/clang \
+             --use-c++=/usr/local/llvm/bin/clang++ \
+             cmake --preset default
+  scan-build --use-cc=/usr/local/llvm/bin/clang \
+             --use-c++=/usr/local/llvm/bin/clang++ \
+             -o /tmp/scan-build-report \
+             --status-bugs \
+             cmake --build build
+  # HTML レポートが /tmp/scan-build-report/<timestamp>/index.html に生成される
+  ```
+- false positive の抑制は `#ifndef __clang_analyzer__` でインライン抑制する（clang-tidy の `// NOLINT` と同様の粒度）
+- 新規コードは scan-build 警告ゼロを維持すること
+
 ## CI: LLVM ツールチェーン (ミラー)
 
 CI は `.github/actions/setup-llvm/` composite action 経由で LLVM を取得する。優先順に:

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1309,7 +1309,7 @@ is the required gate for #630's race fixes. macOS is unaffected.
 `.github/actions/setup-llvm/`. The mirror tarball is built by
 `.github/workflows/mirror-llvm-toolchain.yml` (manual `workflow_dispatch`).
 
-The mirror tarball includes `clang-tidy` (added in #934). The
+The mirror tarball includes `clang-tidy` (added in #934) and `scan-build` / `analyze-build` via `clang-tools-{MAJOR}` (added in #898). The
 `setup-llvm` action accepts an optional `extra-packages` input for
 the apt fallback path; the mirror/cache path already contains all
 tools. If new tools are needed, add them to

--- a/changelog.d/898-scan-build.md
+++ b/changelog.d/898-scan-build.md
@@ -1,0 +1,3 @@
+### Added
+
+- Integrated Clang Static Analyzer (`scan-build`) into CI `scan-build` job (#898)


### PR DESCRIPTION
## Summary

- Add a new `scan-build` CI job that wraps the clang build with Clang Static Analyzer, providing path-sensitive symbolic execution analysis (null pointer dereference, use-after-free, memory leaks, uninitialized variables, dead stores) that complements existing clang-tidy and cppcheck jobs
- Job runs warn-only (`continue-on-error: true`) for initial rollout; HTML report is uploaded as a CI artifact for findings triage
- Add `clang-tools-{MAJOR}` to `mirror-llvm-toolchain.yml` so future mirror tarballs include `scan-build`
- Bump LLVM cache key `v2 → v3` to invalidate stale caches that lack `clang-tools`; `extra-packages: clang-tools-{MAJOR}` in the job covers the apt fallback path in the interim
- Document local run instructions and `#ifndef __clang_analyzer__` suppression convention in AGENTS.md

Closes #898

## Test plan

- [ ] CI `scan-build` job starts and runs `scan-build` successfully
- [ ] HTML artifact `scan-build-report` is uploaded (even if no findings)
- [ ] Other CI jobs (`test`, `asan`, `tsan`, `lint`, `clang-tidy`) are unaffected
- [ ] After PR merge: re-dispatch `mirror-llvm-toolchain.yml` with `force=true` to rebuild the mirror tarball with `clang-tools-21` included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Clang Static Analyzer (scan-build) into the CI pipeline to perform static code analysis and identify potential issues.

* **Documentation**
  * Added documentation describing the scan-build analysis tool, including local execution instructions and guidelines for suppressing false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->