### PR TITLE
feat: extend List/Map == / != to support complex element types (#736)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1660,7 +1660,7 @@ user-facing constructor), define it in the `.ry` file as a normal `record`.
 
 ### Rebuild metadata on values loaded from collection slots before recursive codegen
 
-**Source**: #736 (2026-04-15, implementation)
+**Source**: #736 (2026-04-14, implementation)
 **Tags**: codegen, metadata, equality, collection, emitComparisonOp
 
 **Rule**: `ValueMetadata` is keyed by `llvm::Value*`. When you

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1657,3 +1657,30 @@ the fully-typed `List<Match>` result, including field access via `.full` and `.g
 regardless of explicit import, register it programmatically in the `CodeGen` constructor
 alongside `Error`. If instead the type should only be available on explicit import (e.g., a
 user-facing constructor), define it in the `.ry` file as a normal `record`.
+
+### Rebuild metadata on values loaded from collection slots before recursive codegen
+
+**Source**: #736 (2026-04-15, implementation)
+**Tags**: codegen, metadata, equality, collection, emitComparisonOp
+
+**Rule**: `ValueMetadata` is keyed by `llvm::Value*`. When you
+`CreateLoad(elemTy, GEP(data, i))` to read an element from a `List` data pointer,
+a `Map` values slot, or any similar array-of-elements, the produced SSA value is
+fresh and has no entry in `value_metadata_`. Calls to helpers that dispatch on
+metadata — `getListElementType`, `getMapValueType`, `getSetElementType`,
+`isStringValue` — all return null/false, causing silent misclassification (e.g.,
+pointer values treated as `str` and compared via `strcmp`).
+
+**Why**: `getMeta` resolves `LoadInst → pointer operand` as a convenience, but a
+`GEP`-produced pointer is itself a fresh SSA value with no entry; the resolution
+stops there.
+
+**How to apply**: Before passing a GEP-loaded pointer value to any helper that
+dispatches on metadata, call
+`propagateTypeMeta(outerMeta->list_elem_type_name, loaded)` (or the
+`map_value_type_name` / `set_elem_type_name` equivalent) to reconstruct
+`ValueMetadata` from the parent container's stored type name.
+
+Guard the call with `!elemName.empty() && elemName != "str"` — `str` elements are
+plain `char*` pointers that `isStringValue` already handles correctly without
+metadata, and the type name may be empty for untyped string literals.

--- a/changelog.d/736-collection-equality-complex-elements.md
+++ b/changelog.d/736-collection-equality-complex-elements.md
@@ -1,0 +1,8 @@
+### Changed
+
+- `List<T>` and `Map<K, V>` `==` / `!=` now support complex element/value types: records, tuples, and nested collections (`List<List<T>>`, `List<Map<K,V>>`, `Map<str, List<T>>`, `Map<str, Map<K,V>>`, etc.) (#736).
+
+### Fixed
+
+- `List<Set<T>>` and `List<Map<K,V>>` equality no longer silently falls back to pointer comparison, which produced incorrect results (#736).
+- Clearer compile-time error for `Set<T>` equality with non-primitive element types, with reference to tracking issue (#736).

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -66,6 +66,9 @@ All return `bool`.
 - Can be used with numeric types (int / float) and bool.
 - `str` values are compared lexicographically (byte order).
 - Record types support `==` and `!=` with auto-generated field-by-field comparison (see [Struct Reference](structs.md#comparison--)).
+- Tuple types support `==` and `!=` with element-wise comparison.
+- `List<T>` and `Map<K, V>` support `==` and `!=` for all element/value types including records, tuples, and nested collections (`List<List<T>>`, `Map<str, List<T>>`, etc.).
+- `Set<T>` supports `==` and `!=` for primitive element types (`int`, `float`, `str`, `bool`) only.
 - The `in` operator is used for membership checks on sets, lists, and maps (`x in s`).
 - The `not in` operator is the negation of `in` (`x not in s`).
 - For maps, `in` checks whether the key exists.

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -67,7 +67,7 @@ All return `bool`.
 - `str` values are compared lexicographically (byte order).
 - Record types support `==` and `!=` with auto-generated field-by-field comparison (see [Struct Reference](structs.md#comparison--)).
 - Tuple types support `==` and `!=` with element-wise comparison.
-- `List<T>` and `Map<K, V>` support `==` and `!=` for all element/value types including records, tuples, and nested collections (`List<List<T>>`, `Map<str, List<T>>`, etc.).
+- `List<T>` and `Map<K, V>` support `==` and `!=` for all element/value types including records, tuples, and nested collections (`List<List<T>>`, `Map<str, List<T>>`, etc.). Note: `Map` key types must be primitive (`str`, `int`, `float`, `bool`); complex key equality is not yet supported.
 - `Set<T>` supports `==` and `!=` for primitive element types (`int`, `float`, `str`, `bool`) only.
 - The `in` operator is used for membership checks on sets, lists, and maps (`x in s`).
 - The `not in` operator is the negation of `in` (`x not in s`).

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -668,10 +668,17 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             // Set equality only supports primitive element types (int, float, str, bool).
             // Complex elements (records, tuples, nested collections) require a structural
             // hash function generator which is not yet implemented (see issue follow-up).
-            if (lhsSetElemTy == ptrTy_) {
-                auto *lhsMeta = getMeta(lhs);
-                const std::string &tn = lhsMeta ? lhsMeta->set_elem_type_name : std::string{};
-                if (tn.empty() || !kEqPrimitives.count(tn))
+            {
+                auto *lhsSetMeta = getMeta(lhs);
+                const std::string &tn = lhsSetMeta ? lhsSetMeta->set_elem_type_name : std::string{};
+                // Reject non-primitive element types. Two cases:
+                // 1. Named pointer element (List/Map/Set/closure): tn is non-empty and not a primitive.
+                // 2. Struct-backed element (record/tuple): caught via StructType check.
+                // Note: str is ptrTy_ with empty tn — allowed (hash/subset check handles it).
+                const bool isNonPrimitive =
+                    (!tn.empty() && !kEqPrimitives.count(tn)) ||
+                    llvm::isa<llvm::StructType>(lhsSetElemTy);
+                if (isNonPrimitive)
                     codegenError("set == / != is not supported for non-primitive element type '" +
                                  tn + "' (tracked in #958)");
             }

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -392,6 +392,10 @@ llvm::Value *CodeGen::tryCallOperator(const std::string &callee,
 llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs,
                                         const std::string &lhsHint, const std::string &rhsHint) {
     const std::string &llNameHint = !lhsHint.empty() ? lhsHint : rhsHint;
+    // Shared primitive-type allowlist used by union/set equality guards.
+    static const std::unordered_set<std::string> kEqPrimitives = {
+        "int", "float", "str", "bool"
+    };
 
     // Type (from type_of) comparison: identity by id field only (ignore name)
     if (lhs->getType() == typeTy_ && rhs->getType() == typeTy_ &&
@@ -529,11 +533,8 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                 // metadata when loaded from the union payload, causing them to
                 // be misclassified as strings by isStringValue().
                 {
-                    static const std::unordered_set<std::string> kUnionEqPrimitives = {
-                        "int", "float", "str", "bool"
-                    };
                     for (const auto &cname : uinfo.componentNames) {
-                        if (!kUnionEqPrimitives.count(cname))
+                        if (!kEqPrimitives.count(cname))
                             codegenError("union == / != is not supported for non-primitive variant '" + cname + "'");
                     }
                 }
@@ -598,12 +599,17 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         if (lhsElemTy && rhsElemTy && (op == "==" || op == "!=")) {
             if (lhsElemTy != rhsElemTy)
                 codegenError("cannot compare List values with different element types");
-            // Reject equality for non-string pointer elements.
-            // Loaded list elements have no ValueMetadata; if lhsElemTy == ptrTy_
-            // but elements are not strings (e.g. List<List<T>>), isStringValue()
-            // would misclassify them and emit strcmp on arbitrary pointers.
-            if (lhsElemTy == ptrTy_ && getTypeMeta(TypeMeta::NestedListElem, lhs))
-                codegenError("list == / != is not supported for element type 'List<T>'");
+            // Hoist pointer-element metadata checks before loop scaffolding:
+            // lhs metadata is loop-invariant; resolve and validate it once here.
+            std::string leqElemName;
+            if (lhsElemTy == ptrTy_) {
+                auto *lhsMeta = getMeta(lhs);
+                if (lhsMeta && lhsMeta->list_elem_fn_type_info)
+                    codegenError("list == / != is not supported for function-typed elements");
+                if (lhsMeta && !lhsMeta->list_elem_type_name.empty() &&
+                        lhsMeta->list_elem_type_name != "str")
+                    leqElemName = lhsMeta->list_elem_type_name;
+            }
             auto lf = loadListHeader(lhs, "leq_l");
             auto rf = loadListHeader(rhs, "leq_r");
             llvm::Function *curFn = builder_.GetInsertBlock()->getParent();
@@ -629,6 +635,12 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                 builder_.CreateGEP(lhsElemTy, lf.data, {leqIc}, "leq_lep"), "leq_le");
             llvm::Value *re = builder_.CreateLoad(lhsElemTy,
                 builder_.CreateGEP(lhsElemTy, rf.data, {leqIc}, "leq_rep"), "leq_re");
+            // Pointer elements lose ValueMetadata when loaded via GEP.
+            // Rebuild from the pre-resolved type name so emitComparisonOp recurses correctly.
+            if (!leqElemName.empty()) {
+                propagateTypeMeta(leqElemName, le);
+                propagateMeta(le, re);  // copy from le; avoids re-parsing the type name
+            }
             builder_.CreateCondBr(emitComparisonOp("==", le, re, "", ""), nextBB, failBB);
             builder_.SetInsertPoint(nextBB);
             builder_.CreateStore(
@@ -653,6 +665,16 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         if (lhsSetElemTy && rhsSetElemTy && (op == "==" || op == "!=")) {
             if (lhsSetElemTy != rhsSetElemTy)
                 codegenError("cannot compare Set values with different element types");
+            // Set equality only supports primitive element types (int, float, str, bool).
+            // Complex elements (records, tuples, nested collections) require a structural
+            // hash function generator which is not yet implemented (see issue follow-up).
+            if (lhsSetElemTy == ptrTy_) {
+                auto *lhsMeta = getMeta(lhs);
+                const std::string &tn = lhsMeta ? lhsMeta->set_elem_type_name : std::string{};
+                if (tn.empty() || !kEqPrimitives.count(tn))
+                    codegenError("set == / != is not supported for non-primitive element type '" +
+                                 tn + "' (tracked in #958)");
+            }
             auto lf = loadSetHeader(lhs, "seq_l");
             auto rf = loadSetHeader(rhs, "seq_r");
             llvm::Value *lenEq = builder_.CreateICmpEQ(lf.len, rf.len, "seq_leneq");
@@ -690,15 +712,15 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             llvm::Type *valTy = getMapValueType(lhs);
             if (!valTy || valTy != getMapValueType(rhs))
                 codegenError("cannot compare Map values with different value types");
-            // Reject equality for non-string pointer map values.
-            // map_value_type_name is non-empty when map values are non-string pointers
-            // (e.g. Map<str, List<int>>); loaded values lose metadata and would be
-            // misclassified as strings by isStringValue().
+            // Hoist pointer-value metadata checks before loop scaffolding.
+            std::string meqValName;
             if (valTy == ptrTy_) {
-                auto *lhsMapMeta = getMeta(lhs);
-                if (lhsMapMeta && !lhsMapMeta->map_value_type_name.empty())
-                    codegenError("map == / != is not supported for non-string value type '" +
-                                 lhsMapMeta->map_value_type_name + "'");
+                auto *lhsMeta = getMeta(lhs);
+                if (lhsMeta && lhsMeta->map_value_fn_type_info)
+                    codegenError("map == / != is not supported for function-typed values");
+                if (lhsMeta && !lhsMeta->map_value_type_name.empty() &&
+                        lhsMeta->map_value_type_name != "str")
+                    meqValName = lhsMeta->map_value_type_name;
             }
             auto lf = loadMapHeader(lhs, "meq_l");
             auto rf = loadMapHeader(rhs, "meq_r");
@@ -733,6 +755,12 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                 builder_.CreateGEP(valTy, lf.vals, {meqIc}, "meq_lvep"), "meq_lv");
             llvm::Value *rv = builder_.CreateLoad(valTy,
                 builder_.CreateGEP(valTy, rf.vals, {rhsIdx}, "meq_rvep"), "meq_rv");
+            // Pointer values lose ValueMetadata when loaded via GEP.
+            // Rebuild from the pre-resolved type name so emitComparisonOp recurses correctly.
+            if (!meqValName.empty()) {
+                propagateTypeMeta(meqValName, lv);
+                propagateMeta(lv, rv);  // copy from lv; avoids re-parsing the type name
+            }
             builder_.CreateCondBr(emitComparisonOp("==", lv, rv, "", ""), nextBB, failBB);
             builder_.SetInsertPoint(nextBB);
             builder_.CreateStore(

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -170,3 +170,103 @@ describe("equality — Map", ():
 #   g = (x: int) => x + 1
 #   _ = f == g
 # )
+
+record EqPoint:
+  x: int
+  y: int
+
+describe("equality — List with complex element types", ():
+  it("should compare List<record> equal", ():
+    a: List<EqPoint> = [EqPoint(1, 2), EqPoint(3, 4)]
+    b: List<EqPoint> = [EqPoint(1, 2), EqPoint(3, 4)]
+    expect(a == b).to_be_true()
+  )
+  it("should compare List<record> unequal", ():
+    a: List<EqPoint> = [EqPoint(1, 2)]
+    b: List<EqPoint> = [EqPoint(1, 9)]
+    expect(a != b).to_be_true()
+  )
+  it("should compare List<tuple> equal", ():
+    a: List<(int, str)> = [(1, "a"), (2, "b")]
+    b: List<(int, str)> = [(1, "a"), (2, "b")]
+    expect(a == b).to_be_true()
+  )
+  it("should compare List<tuple> unequal", ():
+    a: List<(int, str)> = [(1, "a")]
+    b: List<(int, str)> = [(1, "z")]
+    expect(a != b).to_be_true()
+  )
+  it("should compare List<List<int>> equal", ():
+    a: List<List<int>> = [[1, 2], [3, 4]]
+    b: List<List<int>> = [[1, 2], [3, 4]]
+    expect(a == b).to_be_true()
+  )
+  it("should compare List<List<int>> unequal", ():
+    a: List<List<int>> = [[1, 2], [3, 4]]
+    b: List<List<int>> = [[1, 2], [3, 5]]
+    expect(a != b).to_be_true()
+  )
+  it("should compare List<List<int>> with different inner lengths unequal", ():
+    a: List<List<int>> = [[1, 2]]
+    b: List<List<int>> = [[1, 2, 3]]
+    expect(a != b).to_be_true()
+  )
+  it("should compare List<List<str>> equal", ():
+    a: List<List<str>> = [["x", "y"], ["z"]]
+    b: List<List<str>> = [["x", "y"], ["z"]]
+    expect(a == b).to_be_true()
+  )
+  it("should compare List<Map<str, int>> equal", ():
+    a: List<Map<str, int>> = [{"x": 1}, {"y": 2}]
+    b: List<Map<str, int>> = [{"x": 1}, {"y": 2}]
+    expect(a == b).to_be_true()
+  )
+  it("should compare List<Map<str, int>> unequal", ():
+    a: List<Map<str, int>> = [{"x": 1}]
+    b: List<Map<str, int>> = [{"x": 9}]
+    expect(a != b).to_be_true()
+  )
+  it("should compare List<Set<int>> equal", ():
+    a: List<Set<int>> = [{1, 2}, {3}]
+    b: List<Set<int>> = [{1, 2}, {3}]
+    expect(a == b).to_be_true()
+  )
+  it("should compare List<Set<int>> unequal", ():
+    a: List<Set<int>> = [{1, 2}]
+    b: List<Set<int>> = [{1, 3}]
+    expect(a != b).to_be_true()
+  )
+)
+
+describe("equality — Map with complex value types", ():
+  it("should compare Map<str, List<int>> equal", ():
+    a: Map<str, List<int>> = {"x": [1, 2], "y": [3]}
+    b: Map<str, List<int>> = {"x": [1, 2], "y": [3]}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Map<str, List<int>> unequal", ():
+    a: Map<str, List<int>> = {"x": [1, 2]}
+    b: Map<str, List<int>> = {"x": [1, 9]}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Map<str, Map<str, int>> equal", ():
+    a: Map<str, Map<str, int>> = {"outer": {"inner": 42}}
+    b: Map<str, Map<str, int>> = {"outer": {"inner": 42}}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Map<str, Map<str, int>> unequal", ():
+    a: Map<str, Map<str, int>> = {"outer": {"inner": 1}}
+    b: Map<str, Map<str, int>> = {"outer": {"inner": 2}}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Map<str, record> equal", ():
+    a: Map<str, EqPoint> = {"p": EqPoint(1, 2)}
+    b: Map<str, EqPoint> = {"p": EqPoint(1, 2)}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Map<str, record> unequal", ():
+    a: Map<str, EqPoint> = {"p": EqPoint(1, 2)}
+    b: Map<str, EqPoint> = {"p": EqPoint(1, 9)}
+    expect(a != b).to_be_true()
+  )
+)

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2499,3 +2499,28 @@ TEST_F(CodeGenTest, DiscardedCollectionResults) {
         "distinct(xs)\n"
         "print(length(xs))"), "3\n");
 }
+
+// ===== Collection equality: compile-time rejection of unsupported element types =====
+
+// List<function> == List<function> must be rejected at compile time.
+// Regression for the list_elem_fn_type_info guard added in #736.
+TEST_F(CodeGenTest, ListFnElemEqualityRejected) {
+    expectCompileError(
+        "a: List<function(int) -> int> = []\n"
+        "b: List<function(int) -> int> = []\n"
+        "_ = a == b\n",
+        "function-typed elements");
+}
+
+// Set<record> == Set<record> must be rejected at compile time.
+// Regression for the StructType guard added in #736 (covers struct-backed elements
+// that escape the earlier ptrTy_ check).
+TEST_F(CodeGenTest, SetRecordElemEqualityRejected) {
+    expectCompileError(
+        "record Pt:\n"
+        "  x: int\n"
+        "a: Set<Pt> = {}\n"
+        "b: Set<Pt> = {}\n"
+        "_ = a == b\n",
+        "non-primitive element type");
+}


### PR DESCRIPTION
## Summary

Follow-up to #725 (V1 of collection equality). Extends `==` / `!=` on `List<T>` and `Map<K, V>` to support complex element/value types.

### What's new

| Type | Before | After |
|------|--------|-------|
| `List<List<T>>` | compile error | ✅ element-wise recursive equality |
| `List<Map<K,V>>` | silent wrong result (strcmp on ptrs) | ✅ correct |
| `List<Set<T>>` | silent wrong result | ✅ correct |
| `List<record>` | ✅ already worked | ✅ confirmed with tests |
| `List<tuple>` | ✅ already worked | ✅ confirmed with tests |
| `Map<str, List<T>>` | compile error | ✅ value-wise recursive equality |
| `Map<str, Map<K,V>>` | compile error | ✅ correct |
| `Map<str, record>` | ✅ already worked | ✅ confirmed with tests |
| `Set<complex>` | no error (wrong results) | explicit compile error with #958 reference |

### Root cause & fix

**Root cause**: Elements loaded via `CreateLoad(ty, GEP(data, i))` produce fresh SSA values with no `ValueMetadata` entry. Without metadata, `getListElementType` / `isStringValue` misclassify pointer-typed elements (e.g., treating a `List<int>*` as a `str`).

**Fix**: Hoist `getMeta(lhs)` before the loop scaffolding, capture the element/value type name, then call `propagateTypeMeta(name, le)` + `propagateMeta(le, re)` in the loop body to reconstruct `ValueMetadata` on loaded elements before the recursive `emitComparisonOp` call.

### Scope

- `Set<complex>` equality is **out of scope** — `emitSubsetCheck` is hash-based; follow-up: #958
- Map complex key equality is **out of scope** — same hash prerequisite; follow-up: #961
- ADT enum payload equality: follow-up #959
- Union variant collection: follow-up #960

### Changes

- `src/codegen_expr.cpp` — List/Map/Set equality in `emitComparisonOp`
- `tests/spec/combinatorial/equality.test.ry` — 16 new `it(...)` blocks (53 total, all pass)
- `docs/reference/operators.md` — document complex element support
- `changelog.d/736-collection-equality-complex-elements.md` — changelog fragment
- `KNOWLEDGE.md` — "Rebuild metadata on values loaded from collection slots" entry

### Test results

```
53 passed, 0 failed   (equality.test.ry)
1638 passed           (ry_tests C++)
119 files, 0 failures (ry test -p)
ASan+UBSan: clean
TSan (C++): clean
```

Closes #736

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended `==` / `!=` to support `List` and `Map` with complex element/value types (records, tuples, nested containers).

* **Bug Fixes**
  * Fixed cases where nested collection equality reverted to pointer-based comparison.
  * Added compile-time rejection for function-typed list elements and non-primitive set elements.

* **Documentation**
  * Updated operator reference and KNOWLEDGE guidance on container equality and metadata handling.

* **Tests**
  * Added comprehensive tests covering records, tuples, nested lists/maps/sets, and rejection cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->