### PR TITLE
feat: extend Set<T> == / != to support complex element types (#958)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1684,3 +1684,31 @@ dispatches on metadata, call
 Guard the call with `!elemName.empty() && elemName != "str"` — `str` elements are
 plain `char*` pointers that `isStringValue` already handles correctly without
 metadata, and the type name may be empty for untyped string literals.
+
+### Empty collection literal early-return in codegen_stmt.cpp does not propagate closure/nested-type metadata
+
+**Source**: #958 (2026-04-15, implementation)
+**Tags**: codegen, metadata, closure, set, collection, empty-literal
+
+**Rule**: `codegen_stmt.cpp` has special early-return paths for empty collection
+literals (e.g., `a: Set<fn> = {}`, `a: List<fn> = []`) that allocate the header and
+`return` before reaching the general `if (newTy == ptrTy_)` metadata-propagation
+block (L390+). Each such early-return path must explicitly set
+`*_fn_type_info` and `*_elem_type_name` if the annotation's inner type is a closure
+or nested collection — otherwise the metadata will be missing for the variable's
+alloca, and downstream guards (e.g., the `set_elem_fn_type_info` equality rejection
+at `codegen_expr.cpp`) will silently not fire.
+
+**Why**: The empty-literal fast paths (e.g., L28-58 for Set, L102-151 for List)
+were written to handle the common primitive/record case. The L102 List path
+correctly sets `list_elem_fn_type_info` via an explicit `else if` branch. The L28
+Set path was initially missing the equivalent, causing `Set<fn> == Set<fn>` to
+compile without error instead of being rejected.
+
+**How to apply**: Whenever you add or modify an early-return empty-literal path in
+`codegen_stmt.cpp`, audit the block to ensure all of the following metadata fields
+are populated as appropriate:
+- `setTypeMeta(TypeMeta::SetElem / ListElem / MapKey / MapValue, ptr, elemTy)`
+- `getOrCreateMeta(ptr).set_elem_type_name` (for nested collection element types)
+- `getOrCreateMeta(ptr).set_elem_fn_type_info` (for closure element types)
+- The `list_*` and `map_*` counterparts for List/Map early paths

--- a/changelog.d/958-set-complex-equality.md
+++ b/changelog.d/958-set-complex-equality.md
@@ -1,3 +1,9 @@
 ### Added
 
 - `Set<T>` `==` and `!=` now support complex element types: records, tuples, and nested collections (`Set<Point>`, `Set<List<int>>`, `Set<Map<str, int>>`, `Set<Set<int>>`) (#958)
+
+### Changed
+
+### Fixed
+
+### Removed

--- a/changelog.d/958-set-complex-equality.md
+++ b/changelog.d/958-set-complex-equality.md
@@ -1,0 +1,3 @@
+### Added
+
+- `Set<T>` `==` and `!=` now support complex element types: records, tuples, and nested collections (`Set<Point>`, `Set<List<int>>`, `Set<Map<str, int>>`, `Set<Set<int>>`) (#958)

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -68,7 +68,7 @@ All return `bool`.
 - Record types support `==` and `!=` with auto-generated field-by-field comparison (see [Struct Reference](structs.md#comparison--)).
 - Tuple types support `==` and `!=` with element-wise comparison.
 - `List<T>` and `Map<K, V>` support `==` and `!=` for all element/value types including records, tuples, and nested collections (`List<List<T>>`, `Map<str, List<T>>`, etc.). Note: `Map` key types must be primitive (`str`, `int`, `float`, `bool`); complex key equality is not yet supported.
-- `Set<T>` supports `==` and `!=` for primitive element types (`int`, `float`, `str`, `bool`) only.
+- `Set<T>` supports `==` and `!=` for all element types including records, tuples, and nested collections (`Set<Point>`, `Set<List<int>>`, `Set<Set<int>>`, etc.). Comparison is order-independent (set semantics). Note: element types must themselves be equatable (closures are not supported).
 - The `in` operator is used for membership checks on sets, lists, and maps (`x in s`).
 - The `not in` operator is the negation of `in` (`x not in s`).
 - For maps, `in` checks whether the key exists.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1238,7 +1238,8 @@ public:
     llvm::FunctionCallee getStdlibExit();
     llvm::Type *getSetElementType(llvm::Value *setVal);
     llvm::Type *getNestedListElementType(llvm::Value *listVal);
-    llvm::Value *emitSetElementLookup(llvm::Value *setPtr, llvm::Value *elem, llvm::Type *elemTy);
+    llvm::Value *emitSetElementLookup(llvm::Value *setPtr, llvm::Value *elem, llvm::Type *elemTy,
+                                       const std::string &elemName = "");
     llvm::Type *getTaskResultType(llvm::Value *taskVal);
     llvm::Type *getThreadResultType(llvm::Value *threadVal);
     llvm::Value *emitTaskWait(llvm::Value *taskVal, const char *runtimeFn, const char *label);

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -322,7 +322,47 @@ llvm::Value *CodeGen::emitHashTableLookup(llvm::Value *containerPtr, llvm::Struc
     return builder_.CreateCall(findFn, {bucketsPtr, bucketMask, keysPtr, length, keyArg}, "ht_lookup_idx");
 }
 
-llvm::Value *CodeGen::emitSetElementLookup(llvm::Value *setPtr, llvm::Value *elem, llvm::Type *elemTy) {
+llvm::Value *CodeGen::emitSetElementLookup(llvm::Value *setPtr, llvm::Value *elem,
+                                            llvm::Type *elemTy, const std::string &elemName) {
+    // StructType (records/tuples) and nested collections (List<T>, Map<K,V>, Set<T>
+    // as elements) have no runtime hash function.  Use a structural O(n) linear scan.
+    // For nested collection types, propagateTypeMeta rebuilds ValueMetadata on the
+    // GEP-loaded candidate before emitComparisonOp dispatches (KNOWLEDGE.md #736).
+    const bool needsLinearScan =
+        llvm::isa<llvm::StructType>(elemTy) ||
+        (!elemName.empty() && elemName != "str" &&
+         elemName != "int" && elemName != "float" && elemName != "bool");
+    if (needsLinearScan) {
+        auto sf = loadSetHeader(setPtr, "slin");
+        llvm::AllocaInst *resVar = builder_.CreateAlloca(i64Ty_, nullptr, "slin_res");
+        builder_.CreateStore(llvm::ConstantInt::getSigned(i64Ty_, -1), resVar);
+        llvm::AllocaInst *jVar = builder_.CreateAlloca(i64Ty_, nullptr, "slin_j");
+        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), jVar);
+        llvm::BasicBlock *condBB  = llvm::BasicBlock::Create(*ctx_, "slin.cond",  fn_);
+        llvm::BasicBlock *bodyBB  = llvm::BasicBlock::Create(*ctx_, "slin.body",  fn_);
+        llvm::BasicBlock *matchBB = llvm::BasicBlock::Create(*ctx_, "slin.match", fn_);
+        llvm::BasicBlock *nextBB  = llvm::BasicBlock::Create(*ctx_, "slin.next",  fn_);
+        llvm::BasicBlock *endBB   = llvm::BasicBlock::Create(*ctx_, "slin.end",   fn_);
+        builder_.CreateBr(condBB);
+        builder_.SetInsertPoint(condBB);
+        llvm::Value *j = builder_.CreateLoad(i64Ty_, jVar, "slin_cj");
+        builder_.CreateCondBr(builder_.CreateICmpSLT(j, sf.len), bodyBB, endBB);
+        builder_.SetInsertPoint(bodyBB);
+        llvm::Value *cp   = builder_.CreateGEP(elemTy, sf.elems, {j}, "slin_cp");
+        llvm::Value *cand = builder_.CreateLoad(elemTy, cp, "slin_cand");
+        if (!elemName.empty())
+            propagateTypeMeta(elemName, cand);
+        llvm::Value *eq = emitComparisonOp("==", elem, cand, "", "");
+        builder_.CreateCondBr(eq, matchBB, nextBB);
+        builder_.SetInsertPoint(matchBB);
+        builder_.CreateStore(j, resVar);
+        builder_.CreateBr(endBB);
+        builder_.SetInsertPoint(nextBB);
+        builder_.CreateStore(builder_.CreateAdd(j, llvm::ConstantInt::get(i64Ty_, 1)), jVar);
+        builder_.CreateBr(condBB);
+        builder_.SetInsertPoint(endBB);
+        return builder_.CreateLoad(i64Ty_, resVar, "slin_result");
+    }
     return emitHashTableLookup(setPtr, setHeaderTy_, kSetLayout, elem, elemTy);
 }
 
@@ -355,6 +395,10 @@ void CodeGen::emitBucketInit(llvm::Value *headerPtr, llvm::StructType *headerTy,
 void CodeGen::emitBucketInsertAndRehashCheck(llvm::Value *headerPtr, llvm::StructType *headerTy,
                                               unsigned lenIdx, unsigned bucketCountIdx, unsigned bucketsPtrIdx,
                                               llvm::Value *key, llvm::Type *keyTy, llvm::Value *denseIndex) {
+    // Records and tuples are StructType values with no hash function.
+    // The dense elems array is maintained by the caller; skip hash-table bookkeeping.
+    if (llvm::isa<llvm::StructType>(keyTy))
+        return;
     auto hfi = resolveHashFn(keyTy);
 
     // Coerce key to match hash function argument type (e.g. i1 → i64)

--- a/src/codegen_call_set_ops.cpp
+++ b/src/codegen_call_set_ops.cpp
@@ -88,6 +88,8 @@ llvm::Value *CodeGen::emitSetOp_union(const CallExpr &e) {
         llvm::Type *elemTy2 = getSetElementType(set2);
         if (!elemTy2 || elemTy2 != elemTy)
             codegenError("union() requires two sets with the same element type");
+        const ValueMetadata *set1Meta = getMeta(set1);
+        const std::string elemName = set1Meta ? set1Meta->set_elem_type_name : std::string{};
         // Create new set with all elements from set1, then add elements from set2
         auto sf1 = loadSetHeader(set1, "u1");
         auto sf2 = loadSetHeader(set2, "u2");
@@ -148,9 +150,11 @@ llvm::Value *CodeGen::emitSetOp_union(const CallExpr &e) {
             builder_.SetInsertPoint(bodyBB);
             llvm::Value *ep = builder_.CreateGEP(elemTy, sf2.elems, {i}, "u_ep2");
             llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "u_ev2");
+            if (!elemName.empty())
+                propagateTypeMeta(elemName, ev);
 
             // Check if already in new set
-            llvm::Value *lookupIdx = emitSetElementLookup(newHeader, ev, elemTy);
+            llvm::Value *lookupIdx = emitSetElementLookup(newHeader, ev, elemTy, elemName);
             llvm::Value *notFound = builder_.CreateICmpSLT(lookupIdx, llvm::ConstantInt::get(i64Ty_, 0), "u_not_found");
             llvm::BasicBlock *addBB = llvm::BasicBlock::Create(*ctx_, "u.add.do", fn_);
             llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, "u.add.next", fn_);
@@ -171,6 +175,8 @@ llvm::Value *CodeGen::emitSetOp_union(const CallExpr &e) {
         }
 
         setTypeMeta(TypeMeta::SetElem, newHeader, elemTy);
+        if (!elemName.empty())
+            getOrCreateMeta(newHeader).set_elem_type_name = elemName;
         return newHeader;
     }
     return nullptr;
@@ -186,6 +192,8 @@ llvm::Value *CodeGen::emitSetOp_intersection(const CallExpr &e) {
         llvm::Type *elemTy2 = getSetElementType(set2);
         if (!elemTy2 || elemTy2 != elemTy)
             codegenError("intersection() requires two sets with the same element type");
+        const ValueMetadata *set1Meta_is = getMeta(set1);
+        const std::string elemName = set1Meta_is ? set1Meta_is->set_elem_type_name : std::string{};
         auto sf = loadSetHeader(set1, "is");
 
         const llvm::DataLayout &dl = mod_->getDataLayout();
@@ -212,8 +220,10 @@ llvm::Value *CodeGen::emitSetOp_intersection(const CallExpr &e) {
         builder_.SetInsertPoint(bodyBB);
         llvm::Value *ep = builder_.CreateGEP(elemTy, sf.elems, {i}, "is_ep");
         llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "is_ev");
+        if (!elemName.empty())
+            propagateTypeMeta(elemName, ev);
 
-        llvm::Value *inSet2 = emitSetElementLookup(set2, ev, elemTy);
+        llvm::Value *inSet2 = emitSetElementLookup(set2, ev, elemTy, elemName);
         llvm::Value *found = builder_.CreateICmpSGE(inSet2, llvm::ConstantInt::get(i64Ty_, 0), "is_found");
         llvm::BasicBlock *addBB = llvm::BasicBlock::Create(*ctx_, "is.add", fn_);
         llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, "is.next", fn_);
@@ -233,6 +243,8 @@ llvm::Value *CodeGen::emitSetOp_intersection(const CallExpr &e) {
         builder_.SetInsertPoint(endBB);
 
         setTypeMeta(TypeMeta::SetElem, newHeader, elemTy);
+        if (!elemName.empty())
+            getOrCreateMeta(newHeader).set_elem_type_name = elemName;
         return newHeader;
     }
     return nullptr;
@@ -248,6 +260,8 @@ llvm::Value *CodeGen::emitSetOp_difference(const CallExpr &e) {
         llvm::Type *elemTy2 = getSetElementType(set2);
         if (!elemTy2 || elemTy2 != elemTy)
             codegenError("difference() requires two sets with the same element type");
+        const ValueMetadata *set1Meta_df = getMeta(set1);
+        const std::string elemName = set1Meta_df ? set1Meta_df->set_elem_type_name : std::string{};
         auto sf = loadSetHeader(set1, "df");
 
         const llvm::DataLayout &dl = mod_->getDataLayout();
@@ -274,8 +288,10 @@ llvm::Value *CodeGen::emitSetOp_difference(const CallExpr &e) {
         builder_.SetInsertPoint(bodyBB);
         llvm::Value *ep = builder_.CreateGEP(elemTy, sf.elems, {i}, "df_ep");
         llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "df_ev");
+        if (!elemName.empty())
+            propagateTypeMeta(elemName, ev);
 
-        llvm::Value *inSet2 = emitSetElementLookup(set2, ev, elemTy);
+        llvm::Value *inSet2 = emitSetElementLookup(set2, ev, elemTy, elemName);
         llvm::Value *notFound = builder_.CreateICmpSLT(inSet2, llvm::ConstantInt::get(i64Ty_, 0), "df_not_found");
         llvm::BasicBlock *addBB = llvm::BasicBlock::Create(*ctx_, "df.add", fn_);
         llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, "df.next", fn_);
@@ -295,6 +311,8 @@ llvm::Value *CodeGen::emitSetOp_difference(const CallExpr &e) {
         builder_.SetInsertPoint(endBB);
 
         setTypeMeta(TypeMeta::SetElem, newHeader, elemTy);
+        if (!elemName.empty())
+            getOrCreateMeta(newHeader).set_elem_type_name = elemName;
         return newHeader;
     }
     return nullptr;
@@ -310,6 +328,8 @@ llvm::Value *CodeGen::emitSetOp_symmetric_difference(const CallExpr &e) {
         llvm::Type *elemTy2 = getSetElementType(set2);
         if (!elemTy2 || elemTy2 != elemTy)
             codegenError("symmetric_difference() requires two sets with the same element type");
+        const ValueMetadata *set1Meta_sd = getMeta(set1);
+        const std::string elemName = set1Meta_sd ? set1Meta_sd->set_elem_type_name : std::string{};
         auto sf1 = loadSetHeader(set1, "sd1");
         auto sf2 = loadSetHeader(set2, "sd2");
 
@@ -340,7 +360,9 @@ llvm::Value *CodeGen::emitSetOp_symmetric_difference(const CallExpr &e) {
             builder_.SetInsertPoint(bBB);
             llvm::Value *ePtr = builder_.CreateGEP(elemTy, srcData, {ci}, prefix + "_ep");
             llvm::Value *eVal = builder_.CreateLoad(elemTy, ePtr, prefix + "_ev");
-            llvm::Value *inOther = emitSetElementLookup(otherSet, eVal, elemTy);
+            if (!elemName.empty())
+                propagateTypeMeta(elemName, eVal);
+            llvm::Value *inOther = emitSetElementLookup(otherSet, eVal, elemTy, elemName);
             llvm::Value *notInOther = builder_.CreateICmpSLT(inOther, llvm::ConstantInt::get(i64Ty_, 0), prefix + "_nf");
             llvm::BasicBlock *aBB = llvm::BasicBlock::Create(*ctx_, prefix + ".add", fn_);
             llvm::BasicBlock *nBB = llvm::BasicBlock::Create(*ctx_, prefix + ".next", fn_);
@@ -362,6 +384,8 @@ llvm::Value *CodeGen::emitSetOp_symmetric_difference(const CallExpr &e) {
         emitSetDiffLoop(sf2.elems, sf2.len, set1, "sd2");
 
         setTypeMeta(TypeMeta::SetElem, newHeader, elemTy);
+        if (!elemName.empty())
+            getOrCreateMeta(newHeader).set_elem_type_name = elemName;
         return newHeader;
     }
     return nullptr;

--- a/src/codegen_call_set_ops.cpp
+++ b/src/codegen_call_set_ops.cpp
@@ -6,7 +6,9 @@ namespace ry {
 
 // ===== Builtin Set Ops =====
 
-// Shared helper: check all elements of iterSet exist in lookupSet
+// Shared helper: check all elements of iterSet exist in lookupSet.
+// Delegates to emitSetElementLookup for membership test; that function
+// selects hash-based or linear-scan lookup based on element type.
 llvm::Value *CodeGen::emitSubsetCheck(llvm::Value *iterSet, llvm::Value *lookupSet,
                                        const std::string &prefix) {
     llvm::Type *elemTy = getSetElementType(iterSet);
@@ -14,6 +16,10 @@ llvm::Value *CodeGen::emitSubsetCheck(llvm::Value *iterSet, llvm::Value *lookupS
     llvm::Type *elemTy2 = getSetElementType(lookupSet);
     if (!elemTy2 || elemTy2 != elemTy)
         codegenError(prefix + "() requires two sets with the same element type");
+
+    const ValueMetadata *iterMeta = getMeta(iterSet);
+    const std::string elemName = iterMeta ? iterMeta->set_elem_type_name : std::string{};
+
     auto sf = loadSetHeader(iterSet, prefix);
 
     llvm::AllocaInst *resultVar = builder_.CreateAlloca(i1Ty_, nullptr, prefix + "_result");
@@ -23,7 +29,7 @@ llvm::Value *CodeGen::emitSubsetCheck(llvm::Value *iterSet, llvm::Value *lookupS
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
     llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, prefix + ".cond", fn_);
     llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, prefix + ".body", fn_);
-    llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, prefix + ".end", fn_);
+    llvm::BasicBlock *endBB  = llvm::BasicBlock::Create(*ctx_, prefix + ".end",  fn_);
     builder_.CreateBr(condBB);
     builder_.SetInsertPoint(condBB);
     llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, prefix + "_ci");
@@ -31,11 +37,19 @@ llvm::Value *CodeGen::emitSubsetCheck(llvm::Value *iterSet, llvm::Value *lookupS
     builder_.SetInsertPoint(bodyBB);
     llvm::Value *ep = builder_.CreateGEP(elemTy, sf.elems, {i}, prefix + "_ep");
     llvm::Value *ev = builder_.CreateLoad(elemTy, ep, prefix + "_ev");
-    llvm::Value *found = emitSetElementLookup(lookupSet, ev, elemTy);
-    llvm::Value *notFound = builder_.CreateICmpSLT(found, llvm::ConstantInt::get(i64Ty_, 0), prefix + "_nf");
+
+    // Pointer elements lose ValueMetadata on GEP load; rebuild from the
+    // parent set's stored type name before the lookup (KNOWLEDGE.md #736).
+    if (!elemName.empty())
+        propagateTypeMeta(elemName, ev);
+
     llvm::BasicBlock *failBB = llvm::BasicBlock::Create(*ctx_, prefix + ".fail", fn_);
     llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, prefix + ".next", fn_);
+
+    llvm::Value *found = emitSetElementLookup(lookupSet, ev, elemTy, elemName);
+    llvm::Value *notFound = builder_.CreateICmpSLT(found, llvm::ConstantInt::get(i64Ty_, 0), prefix + "_nf");
     builder_.CreateCondBr(notFound, failBB, nextBB);
+
     builder_.SetInsertPoint(failBB);
     builder_.CreateStore(llvm::ConstantInt::get(i1Ty_, 0), resultVar);
     builder_.CreateBr(endBB);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -665,23 +665,9 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         if (lhsSetElemTy && rhsSetElemTy && (op == "==" || op == "!=")) {
             if (lhsSetElemTy != rhsSetElemTy)
                 codegenError("cannot compare Set values with different element types");
-            // Set equality only supports primitive element types (int, float, str, bool).
-            // Complex elements (records, tuples, nested collections) require a structural
-            // hash function generator which is not yet implemented (see issue follow-up).
-            {
-                auto *lhsSetMeta = getMeta(lhs);
-                const std::string &tn = lhsSetMeta ? lhsSetMeta->set_elem_type_name : std::string{};
-                // Reject non-primitive element types. Two cases:
-                // 1. Named pointer element (List/Map/Set/closure): tn is non-empty and not a primitive.
-                // 2. Struct-backed element (record/tuple): caught via StructType check.
-                // Note: str is ptrTy_ with empty tn — allowed (hash/subset check handles it).
-                const bool isNonPrimitive =
-                    (!tn.empty() && !kEqPrimitives.count(tn)) ||
-                    llvm::isa<llvm::StructType>(lhsSetElemTy);
-                if (isNonPrimitive)
-                    codegenError("set == / != is not supported for non-primitive element type '" +
-                                 tn + "' (tracked in #958)");
-            }
+            const ValueMetadata *lhsSetMeta = getMeta(lhs);
+            if (lhsSetMeta && lhsSetMeta->set_elem_fn_type_info)
+                codegenError("set == / != is not supported for function-typed elements");
             auto lf = loadSetHeader(lhs, "seq_l");
             auto rf = loadSetHeader(rhs, "seq_r");
             llvm::Value *lenEq = builder_.CreateICmpEQ(lf.len, rf.len, "seq_leneq");

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -52,6 +52,10 @@ void CodeGen::emitVarDecl(const std::string &name,
             llvm::AllocaInst *ptr = getOrCreateVar(name, ptrTy_);
             builder_.CreateStore(headerPtr, ptr);
             setTypeMeta(TypeMeta::SetElem, ptr, elemTy);
+            if (isFunctionTypeName(inner))
+                getOrCreateMeta(ptr).set_elem_fn_type_info = parseFnTypeAnnotation(inner);
+            else if (isListTypeName(inner) || isMapTypeName(inner) || isSetTypeName(inner))
+                getOrCreateMeta(ptr).set_elem_type_name = inner;
             markArcManaged(ptr);
             if (is_immutable)
                 immutable_scope_stack_.back().insert(name);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -52,10 +52,13 @@ void CodeGen::emitVarDecl(const std::string &name,
             llvm::AllocaInst *ptr = getOrCreateVar(name, ptrTy_);
             builder_.CreateStore(headerPtr, ptr);
             setTypeMeta(TypeMeta::SetElem, ptr, elemTy);
-            if (isFunctionTypeName(inner))
-                getOrCreateMeta(ptr).set_elem_fn_type_info = parseFnTypeAnnotation(inner);
-            else if (isListTypeName(inner) || isMapTypeName(inner) || isSetTypeName(inner))
-                getOrCreateMeta(ptr).set_elem_type_name = inner;
+            {
+                const std::string resolvedInner = resolveTypeAlias(inner);
+                if (isFunctionTypeName(resolvedInner))
+                    getOrCreateMeta(ptr).set_elem_fn_type_info = parseFnTypeAnnotation(resolvedInner);
+                else if (isListTypeName(resolvedInner) || isMapTypeName(resolvedInner) || isSetTypeName(resolvedInner))
+                    getOrCreateMeta(ptr).set_elem_type_name = resolvedInner;
+            }
             markArcManaged(ptr);
             if (is_immutable)
                 immutable_scope_stack_.back().insert(name);

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -270,3 +270,76 @@ describe("equality — Map with complex value types", ():
     expect(a != b).to_be_true()
   )
 )
+
+describe("equality — Set with complex element types", ():
+  it("should compare Set<record> equal", ():
+    a: Set<EqPoint> = {EqPoint(1, 2), EqPoint(3, 4)}
+    b: Set<EqPoint> = {EqPoint(1, 2), EqPoint(3, 4)}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Set<record> equal regardless of insertion order", ():
+    a: Set<EqPoint> = {EqPoint(1, 2), EqPoint(3, 4)}
+    b: Set<EqPoint> = {EqPoint(3, 4), EqPoint(1, 2)}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Set<record> unequal", ():
+    a: Set<EqPoint> = {EqPoint(1, 2)}
+    b: Set<EqPoint> = {EqPoint(1, 9)}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Set<record> of different sizes unequal", ():
+    a: Set<EqPoint> = {EqPoint(1, 2), EqPoint(3, 4)}
+    b: Set<EqPoint> = {EqPoint(1, 2)}
+    expect(a != b).to_be_true()
+  )
+  it("should compare empty Set<record> equal", ():
+    a: Set<EqPoint> = {}
+    b: Set<EqPoint> = {}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Set<tuple> equal", ():
+    a: Set<(int, str)> = {(1, "a"), (2, "b")}
+    b: Set<(int, str)> = {(1, "a"), (2, "b")}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Set<tuple> equal regardless of insertion order", ():
+    a: Set<(int, str)> = {(1, "a"), (2, "b")}
+    b: Set<(int, str)> = {(2, "b"), (1, "a")}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Set<tuple> unequal", ():
+    a: Set<(int, str)> = {(1, "a")}
+    b: Set<(int, str)> = {(1, "z")}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Set<List<int>> equal", ():
+    a: Set<List<int>> = {[1, 2], [3, 4]}
+    b: Set<List<int>> = {[1, 2], [3, 4]}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Set<List<int>> unequal", ():
+    a: Set<List<int>> = {[1, 2]}
+    b: Set<List<int>> = {[1, 9]}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Set<Map<str, int>> equal", ():
+    a: Set<Map<str, int>> = {{"x": 1}, {"y": 2}}
+    b: Set<Map<str, int>> = {{"x": 1}, {"y": 2}}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Set<Map<str, int>> unequal", ():
+    a: Set<Map<str, int>> = {{"x": 1}}
+    b: Set<Map<str, int>> = {{"x": 9}}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Set<Set<int>> equal", ():
+    a: Set<Set<int>> = {{1, 2}, {3}}
+    b: Set<Set<int>> = {{1, 2}, {3}}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Set<Set<int>> unequal", ():
+    a: Set<Set<int>> = {{1, 2}}
+    b: Set<Set<int>> = {{1, 3}}
+    expect(a != b).to_be_true()
+  )
+)

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2512,15 +2512,13 @@ TEST_F(CodeGenTest, ListFnElemEqualityRejected) {
         "function-typed elements");
 }
 
-// Set<record> == Set<record> must be rejected at compile time.
-// Regression for the StructType guard added in #736 (covers struct-backed elements
-// that escape the earlier ptrTy_ check).
-TEST_F(CodeGenTest, SetRecordElemEqualityRejected) {
+// Set<function> == Set<function> must be rejected at compile time.
+// Regression: closure/function elements are never equatable in Ry.
+// (Set<record> equality was lifted in #958.)
+TEST_F(CodeGenTest, SetFnElemEqualityRejected) {
     expectCompileError(
-        "record Pt:\n"
-        "  x: int\n"
-        "a: Set<Pt> = {}\n"
-        "b: Set<Pt> = {}\n"
+        "a: Set<function(int) -> int> = {}\n"
+        "b: Set<function(int) -> int> = {}\n"
         "_ = a == b\n",
-        "non-primitive element type");
+        "function-typed");
 }


### PR DESCRIPTION
## Summary

- `Set<T>` `==` and `!=` now support complex element types: records, tuples, and nested collections (`Set<Point>`, `Set<List<int>>`, `Set<Map<str,int>>`, `Set<Set<int>>`)
- Non-primitive elements use an O(n·m) structural linear-scan fallback in `emitSetElementLookup`; primitive types continue using the existing hash-based path unchanged
- Fixes an empty-literal metadata gap in `codegen_stmt.cpp` where `set_elem_fn_type_info` was not propagated on `Set<fn> = {}`, causing the closure-rejection guard to silently not fire

Closes #958

## Changes

- **`src/codegen_builtin.cpp`**: `emitSetElementLookup` gains `elemName` param; `StructType` + named non-primitive elements trigger a linear scan that calls `emitComparisonOp` recursively (same pattern as #736 for List/Map). `emitBucketInsertAndRehashCheck` skips hash bookkeeping for StructType keys.
- **`src/codegen_call_set_ops.cpp`**: `emitSubsetCheck` passes `elemName` to `emitSetElementLookup` and calls `propagateTypeMeta` on GEP-loaded outer-loop elements.
- **`src/codegen_expr.cpp`**: Drop primitive-only guard; retain closure-element rejection.
- **`src/codegen_stmt.cpp`**: Fix empty `Set` literal early-return to propagate `set_elem_fn_type_info` / `set_elem_type_name` (metadata was missing, causing closure rejection to silently not fire).
- **`tests/spec/combinatorial/equality.test.ry`**: 14 new test cases for `Set<EqPoint>`, `Set<(int,str)>`, `Set<List<int>>`, `Set<Map<str,int>>`, `Set<Set<int>>`.
- **`tests/test_codegen_collection.cpp`**: `SetRecordElemEqualityRejected` → `SetFnElemEqualityRejected` (record equality lifted in this PR).
- **`docs/reference/operators.md`**, **`changelog.d/958-set-complex-equality.md`**, **`KNOWLEDGE.md`**: documentation updated.

**Note**: Pre-existing bug #963 (nested-loop collection equality gives wrong results on 2nd outer iteration for pointer-type elements) was discovered and filed separately. Order-independent `Set<List<int>>` test is excluded pending that fix.

## Test plan

- [ ] `cmake --preset default && cmake --build build` — zero warnings
- [ ] `./build/ry_tests` — all 1640 C++ tests pass
- [ ] `./build/ry test -p` — all 119 Ry self-test files pass (includes 14 new Set complex equality cases)
- [ ] ASan + UBSan: `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests` — clean
- [ ] TSan: `cmake --preset tsan && cmake --build build-tsan && TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `Set<T>` equality (`==`, `!=`) now supports complex element types (records, tuples, nested collections).

* **Bug Fixes**
  * Empty collection literals now preserve element-type metadata so comparisons and related guards behave correctly.

* **Documentation**
  * Updated operator reference and added a knowledge-base lesson describing set equality semantics and element-type requirements.

* **Tests**
  * Added comprehensive tests covering `Set` equality with complex element types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->