### PR TITLE
feat: extend ADT enum == / != to compare payload values (#959)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1712,3 +1712,25 @@ are populated as appropriate:
 - `getOrCreateMeta(ptr).set_elem_type_name` (for nested collection element types)
 - `getOrCreateMeta(ptr).set_elem_fn_type_info` (for closure element types)
 - The `list_*` and `map_*` counterparts for List/Map early paths
+
+### `instantiateGenericEnum` omitted `variantOrder` population
+
+**Source**: #959 (2026-04-15, implementation)
+**Tags**: codegen, generic-enum, ADT, variantOrder, regression
+
+**Rule**: `instantiateGenericEnum` in `src/codegen_fn_generic.cpp` builds `EnumInfo` for
+concrete instantiations (e.g., `MyOpt<int>`). It populates `info.variants` (the
+`unordered_map<name → tag>`) but historically did NOT populate `info.variantOrder` (the
+ordered variant name vector). Any code that iterates `variantOrder` — such as the
+payload-aware ADT equality comparison introduced in #959 — will silently iterate zero
+elements, causing generic enum variants to fall through to the "no payload" fast path and
+produce wrong results (tag-only comparison).
+
+**Why**: The non-generic path in `codegen_stmt_misc.cpp` populates `variantOrder` inside
+the same loop that adds entries to `variants`. The generic path duplicated most of the
+loop body but missed this line.
+
+**How to apply**: Any new code that reads `EnumInfo::variantOrder` for logic that must also
+apply to generic enum instantiations must verify that `instantiateGenericEnum` keeps
+`variantOrder` in sync with `variants`. When adding `EnumInfo` fields in the future,
+update both `codegen_stmt_misc.cpp` and `codegen_fn_generic.cpp` together.

--- a/changelog.d/959-adt-enum-equality-payload.md
+++ b/changelog.d/959-adt-enum-equality-payload.md
@@ -1,5 +1,11 @@
+### Added
+
 ### Changed
+
+### Fixed
 
 - ADT enum `==` / `!=` now compares the variant payload in addition to the tag.
   Previously two values with the same tag but different payload were incorrectly treated
   as equal (e.g. `Circle(1.0) == Circle(2.0)` returned `true`). (#959)
+
+### Removed

--- a/changelog.d/959-adt-enum-equality-payload.md
+++ b/changelog.d/959-adt-enum-equality-payload.md
@@ -1,0 +1,5 @@
+### Changed
+
+- ADT enum `==` / `!=` now compares the variant payload in addition to the tag.
+  Previously two values with the same tag but different payload were incorrectly treated
+  as equal (e.g. `Circle(1.0) == Circle(2.0)` returned `true`). (#959)

--- a/docs/reference/structs.md
+++ b/docs/reference/structs.md
@@ -362,6 +362,24 @@ enum Shape:
 - Field names must be `snake_case`. Mixing named and unnamed fields within a single variant is not allowed.
 - Unnamed syntax (`Circle(float)`) remains valid.
 
+### ADT Enum Equality
+
+ADT enum values support `==` and `!=`. Comparison is structural: the variant tag is checked first; if the tags differ the values are unequal. When the tags match, every payload field is compared in order using the same rules as record field comparison.
+
+```python
+enum Shape:
+    Circle(float)
+    Rect(float, float)
+    Point
+
+Shape::Circle(1.0) == Shape::Circle(1.0)  # true
+Shape::Circle(1.0) == Shape::Circle(2.0)  # false — same variant, different payload
+Shape::Circle(1.0) == Shape::Point        # false — different variant
+Shape::Point       == Shape::Point        # true  — no payload
+```
+
+Payload fields with function types are not equatable; comparing values whose matching variant carries a `function` payload is a compile-time error.
+
 ### Constraints and Errors
 
 | Constraint | Details |
@@ -369,4 +387,5 @@ enum Shape:
 | Variant access requires `EnumName::VariantName` | The `::` operator is required |
 | Variant values | Auto-assigned (0, 1, 2, ...) by default, or explicitly specified with `= value` |
 | Comparison uses integer comparison | `==`, `!=` can be used |
+| ADT comparison | Structural: tag then payload field-by-field; function-typed fields are a compile error |
 | Named field names | Must be `snake_case`; no duplicates within a variant; no mixing named/unnamed |

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -479,6 +479,21 @@ case c:
         print("point")
 ```
 
+### Equality
+
+ADT enums support `==` and `!=`. Comparison is structural: first the variant tag is compared; if the tags differ the values are unequal. If the tags match, every payload field is compared in order (the same field-by-field semantics used for records).
+
+```python
+Shape::Circle(1.0) == Shape::Circle(1.0)   # true
+Shape::Circle(1.0) == Shape::Circle(2.0)   # false — same tag, different payload
+Shape::Circle(1.0) == Shape::Point         # false — different tag
+Shape::Point       == Shape::Point         # true  — no payload, tag equality
+```
+
+Variants with no payload (e.g. `Point`) compare by tag only, which is always enough.
+Payload fields that are themselves ADT enums, records, collections, or strings are compared recursively.
+Payload fields with function types are not equatable; comparing two values whose matching variant carries a `function` payload is a compile-time error.
+
 ### Internal Representation
 
 An ADT enum is stored as a tagged union: `{ i64 tag, [N x i8] data }` where `N` is sized to fit the largest variant's payload.

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -517,12 +517,178 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                 }
                 return emitStructComparison(op, lhs, rhs, synth);
             }
-            // ADT enum: compare by tag
-            if (!findAdtEnumName(lhsST).empty()) {
-                llvm::Value *lhsTag = builder_.CreateExtractValue(lhs, 0, "lhs.tag");
-                llvm::Value *rhsTag = builder_.CreateExtractValue(rhs, 0, "rhs.tag");
-                if (op == "==") return builder_.CreateICmpEQ(lhsTag, rhsTag, "enum_eq");
-                return builder_.CreateICmpNE(lhsTag, rhsTag, "enum_ne");
+            // ADT enum: compare by tag, then by payload field-by-field (#959)
+            {
+                std::string adtName = findAdtEnumName(lhsST);
+                if (!adtName.empty()) {
+                    const EnumInfo &einfo = enum_types_.at(adtName);
+
+                    // Check for function-typed fields before emitting any IR.
+                    for (const auto &vname : einfo.variantOrder) {
+                        auto fit = einfo.variantFields.find(vname);
+                        if (fit == einfo.variantFields.end()) continue;
+                        for (size_t fi = 0; fi < fit->second.fieldTypeNames.size(); ++fi) {
+                            const std::string &ftn = fit->second.fieldTypeNames[fi];
+                            if (isFunctionTypeName(ftn))
+                                codegenError("ADT enum == / != is not supported for "
+                                    "function-typed payload '" + vname + "." +
+                                    std::to_string(fi) + "'");
+                        }
+                    }
+
+                    // Fast path: all variants have no payload → tag-only comparison
+                    bool anyPayload = false;
+                    for (const auto &vname : einfo.variantOrder) {
+                        auto apit = einfo.variantFields.find(vname);
+                        if (apit != einfo.variantFields.end() &&
+                                !apit->second.fieldTypes.empty()) {
+                            anyPayload = true; break;
+                        }
+                    }
+                    if (!anyPayload) {
+                        llvm::Value *lhsTag = builder_.CreateExtractValue(lhs, 0, "lhs.tag");
+                        llvm::Value *rhsTag = builder_.CreateExtractValue(rhs, 0, "rhs.tag");
+                        if (op == "==") return builder_.CreateICmpEQ(lhsTag, rhsTag, "enum_eq");
+                        return builder_.CreateICmpNE(lhsTag, rhsTag, "enum_ne");
+                    }
+
+                    // Full comparison: tag mismatch → false; tag match → switch per-variant
+                    llvm::Value *lhsTag = builder_.CreateExtractValue(lhs, 0, "lhs.etag");
+                    llvm::Value *rhsTag = builder_.CreateExtractValue(rhs, 0, "rhs.etag");
+                    llvm::Function *curFn = builder_.GetInsertBlock()->getParent();
+                    llvm::BasicBlock *sameTagBB  = llvm::BasicBlock::Create(*ctx_, "aeq.same",  curFn);
+                    llvm::BasicBlock *invalidBB  = llvm::BasicBlock::Create(*ctx_, "aeq.inv",   curFn);
+                    llvm::BasicBlock *mergeBB    = llvm::BasicBlock::Create(*ctx_, "aeq.merge", curFn);
+
+                    llvm::BasicBlock *entryBB = builder_.GetInsertBlock();
+                    builder_.CreateCondBr(
+                        builder_.CreateICmpEQ(lhsTag, rhsTag, "aeq_tag"), sameTagBB, mergeBB);
+
+                    builder_.SetInsertPoint(sameTagBB);
+
+                    const llvm::DataLayout &dl = mod_->getDataLayout();
+
+                    // Store lhs/rhs into allocas so we can GEP into the payload bytes
+                    llvm::AllocaInst *lhsTmp = builder_.CreateAlloca(lhsST, nullptr, "aeq.la");
+                    llvm::AllocaInst *rhsTmp = builder_.CreateAlloca(lhsST, nullptr, "aeq.ra");
+                    lhsTmp->setAlignment(dl.getABITypeAlign(lhsST));
+                    rhsTmp->setAlignment(dl.getABITypeAlign(lhsST));
+                    builder_.CreateStore(lhs, lhsTmp);
+                    builder_.CreateStore(rhs, rhsTmp);
+
+                    llvm::SwitchInst *sw = builder_.CreateSwitch(
+                        lhsTag, invalidBB,
+                        static_cast<unsigned>(einfo.variantOrder.size()));
+
+                    builder_.SetInsertPoint(invalidBB);
+                    builder_.CreateBr(mergeBB);
+
+                    // PHI: entry→false, invalid→false, per-variant→result
+                    builder_.SetInsertPoint(mergeBB);
+                    auto *phi = builder_.CreatePHI(
+                        i1Ty_,
+                        static_cast<unsigned>(einfo.variantOrder.size() + 2),
+                        "aeq.phi");
+                    phi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), entryBB);
+                    phi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), invalidBB);
+
+                    for (const auto &vname : einfo.variantOrder) {
+                        auto tagVal = static_cast<uint64_t>(einfo.variants.at(vname));
+                        llvm::BasicBlock *caseBB = llvm::BasicBlock::Create(
+                            *ctx_, "aeq.v." + vname, curFn);
+                        sw->addCase(
+                            llvm::ConstantInt::get(
+                                llvm::cast<llvm::IntegerType>(i64Ty_), tagVal),
+                            caseBB);
+                        builder_.SetInsertPoint(caseBB);
+
+                        auto vfit = einfo.variantFields.find(vname);
+                        bool hasFields = (vfit != einfo.variantFields.end() &&
+                                          !vfit->second.fieldTypes.empty());
+
+                        if (!hasFields) {
+                            // No payload: tags matched → equal
+                            phi->addIncoming(llvm::ConstantInt::getTrue(*ctx_), caseBB);
+                            builder_.CreateBr(mergeBB);
+                            continue;
+                        }
+
+                        // Get pointer to start of payload ([N x i8])
+                        llvm::Value *lhsPayload = builder_.CreateStructGEP(
+                            einfo.adtType, lhsTmp, 1, "aeq.lp." + vname);
+                        llvm::Value *rhsPayload = builder_.CreateStructGEP(
+                            einfo.adtType, rhsTmp, 1, "aeq.rp." + vname);
+
+                        // Compare fields sequentially with short-circuit AND
+                        size_t offset = 0;
+                        llvm::Value *lastEq = llvm::ConstantInt::getTrue(*ctx_);
+
+                        for (size_t fi = 0; fi < vfit->second.fieldTypes.size(); ++fi) {
+                            llvm::Type *fieldTy = vfit->second.fieldTypes[fi];
+                            const std::string &fieldTyName = vfit->second.fieldTypeNames[fi];
+
+                            uint64_t align = dl.getABITypeAlign(fieldTy).value();
+                            offset = (offset + align - 1) / align * align;
+
+                            std::string sfx;
+                            sfx.reserve(vname.size() + 2 + 4);
+                            sfx += vname;
+                            sfx += '.';
+                            sfx += std::to_string(fi);
+
+                            llvm::Value *lhsFieldPtr = builder_.CreateGEP(
+                                llvm::Type::getInt8Ty(*ctx_), lhsPayload,
+                                {llvm::ConstantInt::get(i64Ty_, offset)},
+                                "aeq.lfp." + sfx);
+                            llvm::Value *rhsFieldPtr = builder_.CreateGEP(
+                                llvm::Type::getInt8Ty(*ctx_), rhsPayload,
+                                {llvm::ConstantInt::get(i64Ty_, offset)},
+                                "aeq.rfp." + sfx);
+
+                            llvm::Value *lf = builder_.CreateLoad(
+                                fieldTy, lhsFieldPtr, "aeq.lf." + sfx);
+                            llvm::Value *rf = builder_.CreateLoad(
+                                fieldTy, rhsFieldPtr, "aeq.rf." + sfx);
+
+                            // Rebuild metadata for pointer-typed fields (#736 pattern)
+                            if (fieldTy == ptrTy_ &&
+                                    !fieldTyName.empty() && fieldTyName != "str") {
+                                propagateTypeMeta(fieldTyName, lf);
+                                propagateMeta(lf, rf);
+                            }
+
+                            llvm::Value *fieldEq = emitComparisonOp("==", lf, rf, "", "");
+
+                            if (fi == 0) {
+                                lastEq = fieldEq;
+                            } else {
+                                // Short-circuit: only evaluate next field if all
+                                // previous fields were equal
+                                llvm::BasicBlock *continBB = llvm::BasicBlock::Create(
+                                    *ctx_, "aeq.fc." + sfx, curFn);
+                                llvm::BasicBlock *shortBB = llvm::BasicBlock::Create(
+                                    *ctx_, "aeq.fs." + sfx, curFn);
+                                builder_.CreateCondBr(lastEq, continBB, shortBB);
+
+                                builder_.SetInsertPoint(shortBB);
+                                phi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), shortBB);
+                                builder_.CreateBr(mergeBB);
+
+                                builder_.SetInsertPoint(continBB);
+                                lastEq = fieldEq;
+                            }
+
+                            offset += dl.getTypeAllocSize(fieldTy);
+                        }
+
+                        phi->addIncoming(lastEq, builder_.GetInsertBlock());
+                        builder_.CreateBr(mergeBB);
+                    }
+
+                    builder_.SetInsertPoint(mergeBB);
+                    if (op == "!=") return builder_.CreateNot(phi, "aeq_ne");
+                    return phi;
+                }
             }
             // Union type: compare tag then dispatch to per-variant inner comparison
             for (auto &[uname, uinfo] : union_type_info_) {

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -619,7 +619,10 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                         llvm::Value *rhsPayload = builder_.CreateStructGEP(
                             einfo.adtType, rhsTmp, 1, "aeq.rp." + vname);
 
-                        // Compare fields sequentially with short-circuit AND
+                        // Compare fields sequentially with true short-circuit AND:
+                        // for fi > 0, branch on the previous result before loading
+                        // the next field so that loads/comparisons for field N are
+                        // only emitted inside continBB (i.e., when field N-1 was equal).
                         size_t offset = 0;
                         llvm::Value *lastEq = llvm::ConstantInt::getTrue(*ctx_);
 
@@ -635,6 +638,21 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                             sfx += vname;
                             sfx += '.';
                             sfx += std::to_string(fi);
+
+                            // Branch on previous result before loading this field
+                            if (fi > 0) {
+                                llvm::BasicBlock *continBB = llvm::BasicBlock::Create(
+                                    *ctx_, "aeq.fc." + sfx, curFn);
+                                llvm::BasicBlock *shortBB = llvm::BasicBlock::Create(
+                                    *ctx_, "aeq.fs." + sfx, curFn);
+                                builder_.CreateCondBr(lastEq, continBB, shortBB);
+
+                                builder_.SetInsertPoint(shortBB);
+                                phi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), shortBB);
+                                builder_.CreateBr(mergeBB);
+
+                                builder_.SetInsertPoint(continBB);
+                            }
 
                             llvm::Value *lhsFieldPtr = builder_.CreateGEP(
                                 llvm::Type::getInt8Ty(*ctx_), lhsPayload,
@@ -657,26 +675,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                                 propagateMeta(lf, rf);
                             }
 
-                            llvm::Value *fieldEq = emitComparisonOp("==", lf, rf, "", "");
-
-                            if (fi == 0) {
-                                lastEq = fieldEq;
-                            } else {
-                                // Short-circuit: only evaluate next field if all
-                                // previous fields were equal
-                                llvm::BasicBlock *continBB = llvm::BasicBlock::Create(
-                                    *ctx_, "aeq.fc." + sfx, curFn);
-                                llvm::BasicBlock *shortBB = llvm::BasicBlock::Create(
-                                    *ctx_, "aeq.fs." + sfx, curFn);
-                                builder_.CreateCondBr(lastEq, continBB, shortBB);
-
-                                builder_.SetInsertPoint(shortBB);
-                                phi->addIncoming(llvm::ConstantInt::getFalse(*ctx_), shortBB);
-                                builder_.CreateBr(mergeBB);
-
-                                builder_.SetInsertPoint(continBB);
-                                lastEq = fieldEq;
-                            }
+                            lastEq = emitComparisonOp("==", lf, rf, "", "");
 
                             offset += dl.getTypeAllocSize(fieldTy);
                         }

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -148,6 +148,7 @@ void CodeGen::instantiateGenericEnum(const std::string &fullName, const std::str
     for (size_t i = 0; i < tmpl.variants.size(); ++i) {
         auto &v = tmpl.variants[i];
         info.variants[v.name] = static_cast<int64_t>(i);
+        info.variantOrder.push_back(v.name);
         llvm::Constant *str = cachedGlobalString(
             v.name, ".enum_" + fullName + "_" + v.name);
         nameStrings.push_back(str);

--- a/tests/spec/control_flow.test.ry
+++ b/tests/spec/control_flow.test.ry
@@ -646,7 +646,8 @@ describe("ADT enum as function parameter (#507)", ():
   it("should support ADT enum equality", ():
     expect(Shape::Point == Shape::Point).to_eq(true)
     expect(Shape::Point != Shape::Circle(1.0)).to_eq(true)
-    expect(Shape::Circle(1.0) == Shape::Circle(2.0)).to_eq(true)
+    expect(Shape::Circle(1.0) == Shape::Circle(1.0)).to_eq(true)
+    expect(Shape::Circle(1.0) == Shape::Circle(2.0)).to_eq(false)
     expect(Shape::Circle(1.0) != Shape::Rect(1.0, 2.0)).to_eq(true)
   )
 )

--- a/tests/spec/structs.test.ry
+++ b/tests/spec/structs.test.ry
@@ -239,9 +239,55 @@ describe("explicit enum values", ():
   )
 )
 
+enum Wrapper:
+  IntVal(int)
+  StrVal(str)
+
+describe("ADT enum equality", ():
+  it("same tag same payload → equal", ():
+    expect(Shape::CircleS(1.0) == Shape::CircleS(1.0)).to_be_true()
+  )
+  it("same tag different payload → not equal", ():
+    expect(Shape::CircleS(1.0) == Shape::CircleS(2.0)).to_be_false()
+  )
+  it("different tag → not equal", ():
+    expect(Shape::CircleS(1.0) == Shape::PointS).to_be_false()
+    expect(Shape::PointS == Shape::CircleS(0.0)).to_be_false()
+  )
+  it("no-payload variant → tag equality", ():
+    expect(Shape::PointS == Shape::PointS).to_be_true()
+    expect(Shape::PointS != Shape::PointS).to_be_false()
+  )
+  it("multi-field variant field-by-field", ():
+    expect(Shape::RectS(1.0, 2.0) == Shape::RectS(1.0, 2.0)).to_be_true()
+    expect(Shape::RectS(1.0, 2.0) == Shape::RectS(1.0, 3.0)).to_be_false()
+    expect(Shape::RectS(1.0, 2.0) != Shape::RectS(1.0, 3.0)).to_be_true()
+  )
+  it("pointer-typed (str) payload equality", ():
+    expect(Wrapper::StrVal("hello") == Wrapper::StrVal("hello")).to_be_true()
+    expect(Wrapper::StrVal("hello") == Wrapper::StrVal("world")).to_be_false()
+  )
+  it("int payload != operator", ():
+    expect(Wrapper::IntVal(1) != Wrapper::IntVal(2)).to_be_true()
+    expect(Wrapper::IntVal(1) != Wrapper::IntVal(1)).to_be_false()
+  )
+)
+
 enum MyOption<T>:
   MySome(T)
   MyNone
+
+describe("ADT enum equality — generic", ():
+  it("generic same payload → equal", ():
+    expect(MyOption<int>::MySome(42) == MyOption<int>::MySome(42)).to_be_true()
+  )
+  it("generic different payload → not equal", ():
+    expect(MyOption<int>::MySome(1) == MyOption<int>::MySome(2)).to_be_false()
+  )
+  it("MySome vs MyNone → not equal", ():
+    expect(MyOption<int>::MySome(1) == MyOption<int>::MyNone).to_be_false()
+  )
+)
 
 describe("generic enum", ():
   it("should support generic enum with type parameter", ():

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -951,6 +951,105 @@ TEST_F(CodeGenTest, EnumADTSingleField) {
     EXPECT_EQ(runSource(src), "42\n");
 }
 
+// ===== ADT enum equality (payload-aware) =====
+
+static const char *kShapeEnum =
+    "enum Shape:\n"
+    "    Circle(float)\n"
+    "    Rectangle(float, float)\n"
+    "    Point\n";
+
+// Same tag + same primitive payload → equal
+TEST_F(CodeGenTest, EnumADTEqSamePayload) {
+    EXPECT_EQ(runSource(std::string(kShapeEnum) +
+        "print(Shape::Circle(1.0) == Shape::Circle(1.0))"), "true\n");
+}
+
+// Same tag + different primitive payload → not equal (#959 regression)
+TEST_F(CodeGenTest, EnumADTEqDifferentPayload) {
+    EXPECT_EQ(runSource(std::string(kShapeEnum) +
+        "print(Shape::Circle(1.0) == Shape::Circle(2.0))"), "false\n");
+}
+
+// Different tag → not equal (tag-only regression guard)
+TEST_F(CodeGenTest, EnumADTEqDifferentTag) {
+    EXPECT_EQ(runSource(std::string(kShapeEnum) +
+        "print(Shape::Circle(1.0) == Shape::Point)"), "false\n");
+}
+
+// No-payload variant: tag equality is sufficient
+TEST_F(CodeGenTest, EnumADTEqNoPayload) {
+    EXPECT_EQ(runSource(std::string(kShapeEnum) +
+        "print(Shape::Point == Shape::Point)\n"
+        "print(Shape::Point != Shape::Point)"),
+        "true\nfalse\n");
+}
+
+// Multi-field variant: field-by-field
+TEST_F(CodeGenTest, EnumADTEqMultiField) {
+    EXPECT_EQ(runSource(std::string(kShapeEnum) +
+        "print(Shape::Rectangle(1.0, 2.0) == Shape::Rectangle(1.0, 2.0))\n"
+        "print(Shape::Rectangle(1.0, 2.0) == Shape::Rectangle(1.0, 3.0))"),
+        "true\nfalse\n");
+}
+
+// != operator
+TEST_F(CodeGenTest, EnumADTNeOperator) {
+    EXPECT_EQ(runSource(std::string(kShapeEnum) +
+        "print(Shape::Circle(1.0) != Shape::Circle(2.0))\n"
+        "print(Shape::Circle(1.0) != Shape::Circle(1.0))"),
+        "true\nfalse\n");
+}
+
+// Pointer-typed payload (str): exercises propagateTypeMeta path
+TEST_F(CodeGenTest, EnumADTEqStrPayload) {
+    EXPECT_EQ(runSource(
+        "enum Wrapper:\n"
+        "    IntVal(int)\n"
+        "    StrVal(str)\n"
+        "print(Wrapper::StrVal(\"hello\") == Wrapper::StrVal(\"hello\"))\n"
+        "print(Wrapper::StrVal(\"hello\") == Wrapper::StrVal(\"world\"))"),
+        "true\nfalse\n");
+}
+
+// Generic ADT: same payload → equal, different payload → not equal
+TEST_F(CodeGenTest, GenericEnumADTEqSame) {
+    EXPECT_EQ(runSource(
+        "enum MyOpt<T>:\n"
+        "    Some(T)\n"
+        "    None\n"
+        "print(MyOpt<int>::Some(42) == MyOpt<int>::Some(42))\n"
+        "print(MyOpt<int>::Some(1)  == MyOpt<int>::Some(2))"),
+        "true\nfalse\n");
+}
+
+// List<int>-typed payload: exercises propagateTypeMeta for collection fields
+TEST_F(CodeGenTest, EnumADTEqListPayload) {
+    EXPECT_EQ(runSource(
+        "enum Bag:\n"
+        "    Items(List<int>)\n"
+        "    Empty\n"
+        "a = Bag::Items([1, 2, 3])\n"
+        "b = Bag::Items([1, 2, 3])\n"
+        "c = Bag::Items([1, 2, 4])\n"
+        "print(a == b)\n"
+        "print(a == c)"),
+        "true\nfalse\n");
+}
+
+// Nested ADT payload: recursive emitComparisonOp
+TEST_F(CodeGenTest, EnumADTEqNestedPayload) {
+    EXPECT_EQ(runSource(
+        "enum Tree:\n"
+        "    Leaf(int)\n"
+        "    Node(int, int)\n"
+        "print(Tree::Leaf(1) == Tree::Leaf(1))\n"
+        "print(Tree::Leaf(1) == Tree::Leaf(2))\n"
+        "print(Tree::Node(1, 2) == Tree::Node(1, 2))\n"
+        "print(Tree::Node(1, 2) == Tree::Node(1, 3))"),
+        "true\nfalse\ntrue\nfalse\n");
+}
+
 // ===== Generic enum =====
 
 TEST_F(CodeGenTest, GenericEnumBasic) {

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1037,17 +1037,21 @@ TEST_F(CodeGenTest, EnumADTEqListPayload) {
         "true\nfalse\n");
 }
 
-// Nested ADT payload: recursive emitComparisonOp
+// Nested ADT payload: outer variant carries an inner ADT enum as its payload,
+// so emitComparisonOp is called recursively for the inner enum.
 TEST_F(CodeGenTest, EnumADTEqNestedPayload) {
     EXPECT_EQ(runSource(
-        "enum Tree:\n"
-        "    Leaf(int)\n"
-        "    Node(int, int)\n"
-        "print(Tree::Leaf(1) == Tree::Leaf(1))\n"
-        "print(Tree::Leaf(1) == Tree::Leaf(2))\n"
-        "print(Tree::Node(1, 2) == Tree::Node(1, 2))\n"
-        "print(Tree::Node(1, 2) == Tree::Node(1, 3))"),
-        "true\nfalse\ntrue\nfalse\n");
+        "enum Inner:\n"
+        "    Val(int)\n"
+        "    Empty\n"
+        "enum Outer:\n"
+        "    Wrap(Inner)\n"
+        "    None\n"
+        "print(Outer::Wrap(Inner::Val(1)) == Outer::Wrap(Inner::Val(1)))\n"
+        "print(Outer::Wrap(Inner::Val(1)) == Outer::Wrap(Inner::Val(2)))\n"
+        "print(Outer::Wrap(Inner::Empty)  == Outer::Wrap(Inner::Val(1)))\n"
+        "print(Outer::None == Outer::None)"),
+        "true\nfalse\nfalse\ntrue\n");
 }
 
 // ===== Generic enum =====

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2522,3 +2522,19 @@ TEST_F(CodeGenTest, SetFnElemEqualityRejected) {
         "_ = a == b\n",
         "function-typed");
 }
+
+// ADT enum with a function-typed payload must be rejected at compile time.
+// Regression for the closure-payload guard added in #959.
+TEST_F(CodeGenTest, AdtEnumFnPayloadEqualityRejected) {
+    expectCompileError(
+        "enum Bad:\n"
+        "    F(function(int) -> int)\n"
+        "function make_id() -> function(int) -> int:\n"
+        "    return (x: int) => x\n"
+        "function make_inc() -> function(int) -> int:\n"
+        "    return (x: int) => x + 1\n"
+        "f1 = Bad::F(make_id())\n"
+        "f2 = Bad::F(make_inc())\n"
+        "_ = f1 == f2\n",
+        "function-typed payload");
+}


### PR DESCRIPTION
## Summary

- **Fixes #959**: `emitComparisonOp` previously compared ADT enum values by tag only — `Circle(1.0) == Circle(2.0)` incorrectly returned `true`. Now emits a tag-check followed by a per-variant `switch` that compares each payload field in aligned order (structural equality).
- **Fixes pre-existing bug**: `instantiateGenericEnum` never populated `EnumInfo::variantOrder`, silently causing generic enum variants (e.g. `MyOpt<int>`) to skip payload comparison.
- Uses the aligned-offset extraction pattern from `codegen_match.cpp` and the `propagateTypeMeta` approach from #736 for pointer-typed payload fields (`str`, `List<T>`, `Map<K,V>`, etc.).
- Function-typed payload fields are rejected at compile time (`codegenError`).

## Changes

| File | Change |
|------|--------|
| `src/codegen_expr.cpp` | Replace 7-line tag-only ADT comparison with full payload-aware comparison |
| `src/codegen_fn_generic.cpp` | Add missing `variantOrder.push_back` in `instantiateGenericEnum` |
| `tests/test_codegen_advanced.cpp` | 10 new C++ tests (same/different payload, multi-field, str/List payloads, generic, nested) |
| `tests/test_codegen_collection.cpp` | Compile-fail test for function-typed payload |
| `tests/spec/structs.test.ry` | 10 Ry self-tests (primitive, str, generic variants) |
| `tests/spec/control_flow.test.ry` | Fix stale expectation: `Circle(1) == Circle(2)` → `false` |
| `docs/reference/types.md` | Add Equality subsection to ADT enum section |
| `docs/reference/structs.md` | Add ADT Enum Equality subsection |
| `changelog.d/959-adt-enum-equality-payload.md` | Changelog fragment |
| `KNOWLEDGE.md` | Document `instantiateGenericEnum` / `variantOrder` pitfall |

## Test plan

- [x] `cmake --build build && ./build/ry_tests` — 1650 tests passed
- [x] `./build/ry test -p` — 119 files, 0 failures
- [x] ASan + UBSan `ry_tests` — 1650 tests passed
- [x] ASan + UBSan `ry test -p` — 0 failures
- [x] TSan `ry_tests` — 1651 tests passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ADT enum equality (`==` / `!=`) now compares variant tags and associated payloads.

* **Bug Fixes**
  * Fixed generic enum variant ordering during instantiation.
  * Added compile-time error for comparisons when a variant’s payload is a function type.

* **Documentation**
  * Added docs explaining ADT enum equality semantics and constraints.

* **Tests**
  * Added comprehensive tests covering payload-aware and generic ADT equality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->