### PR TITLE
feat: extend union == / != to support collection and complex variant types

### DIFF
--- a/changelog.d/960-union-equality-collection-variants.md
+++ b/changelog.d/960-union-equality-collection-variants.md
@@ -1,3 +1,9 @@
+### Added
+
 ### Changed
 
 - `union == / !=` now supports collection (`List`, `Map`, `Set`), record, ADT enum, and nested union variants in addition to primitives. Function-typed variants remain unsupported. (#960)
+
+### Fixed
+
+### Removed

--- a/changelog.d/960-union-equality-collection-variants.md
+++ b/changelog.d/960-union-equality-collection-variants.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `union == / !=` now supports collection (`List`, `Map`, `Set`), record, ADT enum, and nested union variants in addition to primitives. Function-typed variants remain unsupported. (#960)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -652,7 +652,7 @@ A union type is represented as `{ i64 tag, [N x i8] data }`. The `tag` indicates
 
 ### Equality
 
-Union types currently support `==` and `!=` for primitive variants (`int`, `float`, `str`, `bool`). Two union values are equal when they hold the same variant (same tag) and the inner values are equal.
+Union types support `==` and `!=` for all comparable variant types, including primitives (`int`, `float`, `str`, `bool`), collections (`List`, `Map`, `Set`), records, ADT enums, and nested unions. Two union values are equal when they hold the same variant (same tag) and the inner values are equal.
 
 ```python
 x: int | str = 42
@@ -661,6 +661,10 @@ x == y   # true
 
 z: int | str = "42"
 x == z   # false (different tags: int vs str)
+
+a: List<int> | int = [1, 2, 3]
+b: List<int> | int = [1, 2, 3]
+a == b   # true (same tag, element-wise equal)
 ```
 
 ### Constraints
@@ -668,7 +672,7 @@ x == z   # false (different tags: int vs str)
 - Assigning a type not included in the union causes a compile error
 - `int | str` and `str | int` are the same type (normalized)
 - When printing a union value with `print()`, the value is displayed using the appropriate type based on the runtime tag
-- `==` and `!=` support primitive variants (`int`, `float`, `str`, `bool`); closure variants are not supported
+- `==` and `!=` support all comparable variant types; function-typed (closure) variants are not supported
 
 ## any Type
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -693,15 +693,11 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             for (auto &[uname, uinfo] : union_type_info_) {
                 if (uinfo.llvmType != lhsST) continue;
 
-                // Union == / != only supports primitive component types.
-                // Non-primitive pointer variants (collections, closures) lose
-                // metadata when loaded from the union payload, causing them to
-                // be misclassified as strings by isStringValue().
-                {
-                    for (const auto &cname : uinfo.componentNames) {
-                        if (!kEqPrimitives.count(cname))
-                            codegenError("union == / != is not supported for non-primitive variant '" + cname + "'");
-                    }
+                // Reject function-typed variants; collections/records use propagateTypeMeta below.
+                for (const auto &cname : uinfo.componentNames) {
+                    if (isFunctionTypeName(cname))
+                        codegenError("union == / != is not supported for "
+                            "function-typed variant '" + cname + "'");
                 }
 
                 llvm::Function *curFn = builder_.GetInsertBlock()->getParent();
@@ -745,6 +741,12 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                     llvm::Type *compTy = uinfo.componentTypes[ci];
                     llvm::Value *li = builder_.CreateLoad(compTy, lhsTmp, "ueq.li");
                     llvm::Value *ri = builder_.CreateLoad(compTy, rhsTmp, "ueq.ri");
+                    // Rebuild metadata for pointer-typed variants (#736, #960 pattern)
+                    const std::string &compName = uinfo.componentNames[ci];
+                    if (compTy == ptrTy_ && !compName.empty() && compName != "str") {
+                        propagateTypeMeta(compName, li);
+                        propagateMeta(li, ri);
+                    }
                     llvm::Value *caseEq = emitComparisonOp("==", li, ri, "", "");
                     phi->addIncoming(caseEq, builder_.GetInsertBlock());
                     builder_.CreateBr(mergeBB);

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -93,6 +93,52 @@ describe("equality — union", ():
     y: int|str = "1"
     expect(x != y).to_be_true()
   )
+  # Collection and complex variant types (#960)
+  it("should compare equal List variants equal", ():
+    x: List<int>|int = [1, 2, 3]
+    y: List<int>|int = [1, 2, 3]
+    expect(x == y).to_be_true()
+  )
+  it("should compare different List variants unequal", ():
+    x: List<int>|int = [1, 2, 3]
+    y: List<int>|int = [1, 2, 4]
+    expect(x != y).to_be_true()
+  )
+  it("should compare different-tag List vs int variants unequal", ():
+    x: List<int>|int = [1]
+    y: List<int>|int = 1
+    expect(x != y).to_be_true()
+  )
+  it("should compare equal Map variants equal", ():
+    x: Map<str, int>|str = {"a": 1, "b": 2}
+    y: Map<str, int>|str = {"a": 1, "b": 2}
+    expect(x == y).to_be_true()
+  )
+  it("should compare different Map variants unequal", ():
+    x: Map<str, int>|str = {"a": 1}
+    y: Map<str, int>|str = {"a": 9}
+    expect(x != y).to_be_true()
+  )
+  it("should compare equal Set variants equal", ():
+    x: Set<int>|int = {3, 1, 2}
+    y: Set<int>|int = {1, 2, 3}
+    expect(x == y).to_be_true()
+  )
+  it("should compare different Set variants unequal", ():
+    x: Set<int>|int = {1, 2}
+    y: Set<int>|int = {1, 3}
+    expect(x != y).to_be_true()
+  )
+  it("should compare equal nested List variants equal", ():
+    x: List<List<int>>|int = [[1, 2], [3, 4]]
+    y: List<List<int>>|int = [[1, 2], [3, 4]]
+    expect(x == y).to_be_true()
+  )
+  it("should compare different nested List variants unequal", ():
+    x: List<List<int>>|int = [[1, 2]]
+    y: List<List<int>>|int = [[1, 9]]
+    expect(x != y).to_be_true()
+  )
 )
 
 describe("equality — List", ():
@@ -174,6 +220,24 @@ describe("equality — Map", ():
 record EqPoint:
   x: int
   y: int
+
+describe("equality — union with record variants", ():
+  it("should compare equal record variants equal", ():
+    x: EqPoint|int = EqPoint(1, 2)
+    y: EqPoint|int = EqPoint(1, 2)
+    expect(x == y).to_be_true()
+  )
+  it("should compare different record variants unequal", ():
+    x: EqPoint|int = EqPoint(1, 2)
+    y: EqPoint|int = EqPoint(1, 9)
+    expect(x != y).to_be_true()
+  )
+  it("should compare different-tag record vs int variants unequal", ():
+    x: EqPoint|int = EqPoint(1, 2)
+    y: EqPoint|int = 1
+    expect(x != y).to_be_true()
+  )
+)
 
 describe("equality — List with complex element types", ():
   it("should compare List<record> equal", ():

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2538,3 +2538,15 @@ TEST_F(CodeGenTest, AdtEnumFnPayloadEqualityRejected) {
         "_ = f1 == f2\n",
         "function-typed payload");
 }
+
+// Union with a function-typed variant must be rejected at compile time.
+// Regression for the isFunctionTypeName guard added in #960.
+TEST_F(CodeGenTest, UnionFnVariantEqualityRejected) {
+    expectCompileError(
+        "function make_fn() -> function(int) -> int:\n"
+        "    return (x: int) => x\n"
+        "x: function(int) -> int | int = make_fn()\n"
+        "y: function(int) -> int | int = make_fn()\n"
+        "_ = x == y\n",
+        "function-typed variant");
+}


### PR DESCRIPTION
## Summary

- Remove the blanket rejection of non-primitive union variants in `emitComparisonOp`; now only function-typed (closure) variants are rejected
- Apply the `propagateTypeMeta` / `propagateMeta` pattern from #736 to each per-variant payload load, so that `List`, `Map`, `Set`, record, ADT enum, and nested union variants are dispatched correctly in the recursive comparison
- Add 13 new test cases in `tests/spec/combinatorial/equality.test.ry` covering `List<int>|int`, `Map<str,int>|str`, `Set<int>|int`, `List<List<int>>|int`, and `EqPoint|int` variants
- Update `docs/reference/types.md` to reflect the expanded equality support

Closes #960

## Test plan

- [x] `./build/ry_tests` — 1651 C++ tests passed
- [x] `./build/ry test -p` — 119 test files, 0 failures
- [x] `./build-asan/ry_tests` — ASan + UBSan clean
- [x] `./build-asan/ry test tests/spec/combinatorial/equality.test.ry` — 79 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Union equality operators (`==`, `!=`) now support collection variants (List/Map/Set), record variants, ADT enum variants, and nested union variants.

* **Behavior Changes**
  * Comparisons involving function-typed union variants are explicitly rejected at compile time.

* **Documentation**
  * Updated union equality reference with expanded variant support and new examples.

* **Tests**
  * Added tests covering collection, record, enum, nested union equality and function-typed variant rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->