### PR TITLE
feat: extend Map<K,V> == / != to support complex key types (#961)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1711,7 +1711,8 @@ are populated as appropriate:
 - `setTypeMeta(TypeMeta::SetElem / ListElem / MapKey / MapValue, ptr, elemTy)`
 - `getOrCreateMeta(ptr).set_elem_type_name` (for nested collection element types)
 - `getOrCreateMeta(ptr).set_elem_fn_type_info` (for closure element types)
-- The `list_*` and `map_*` counterparts for List/Map early paths
+- `getOrCreateMeta(ptr).map_key_type_name` / `map_key_fn_type_info` (for Map key side — added in #961; mirror of Set path)
+- The `list_*` and remaining `map_value_*` counterparts for List/Map early paths
 
 ### `instantiateGenericEnum` omitted `variantOrder` population
 

--- a/changelog.d/961-map-complex-key-equality.md
+++ b/changelog.d/961-map-complex-key-equality.md
@@ -1,0 +1,3 @@
+### Added
+
+- `Map<K, V>` `==` and `!=` now support complex key types: records, tuples, and nested collections (`Map<Point, int>`, `Map<(int, int), str>`, `Map<List<int>, str>`, etc.). Non-primitive keys use an O(n·m) structural linear-scan lookup; primitive keys continue using the existing hash-based path unchanged (#961)

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -67,7 +67,7 @@ All return `bool`.
 - `str` values are compared lexicographically (byte order).
 - Record types support `==` and `!=` with auto-generated field-by-field comparison (see [Struct Reference](structs.md#comparison--)).
 - Tuple types support `==` and `!=` with element-wise comparison.
-- `List<T>` and `Map<K, V>` support `==` and `!=` for all element/value types including records, tuples, and nested collections (`List<List<T>>`, `Map<str, List<T>>`, etc.). Note: `Map` key types must be primitive (`str`, `int`, `float`, `bool`); complex key equality is not yet supported.
+- `List<T>` and `Map<K, V>` support `==` and `!=` for all element/value types including records, tuples, and nested collections (`List<List<T>>`, `Map<str, List<T>>`, `Map<Point, int>`, `Map<(int, int), str>`, etc.). Map key types may be primitive or complex (records, tuples, nested collections); function-typed keys are not supported.
 - `Set<T>` supports `==` and `!=` for all element types including records, tuples, and nested collections (`Set<Point>`, `Set<List<int>>`, `Set<Set<int>>`, etc.). Comparison is order-independent (set semantics). Note: element types must themselves be equatable (closures are not supported).
 - The `in` operator is used for membership checks on sets, lists, and maps (`x in s`).
 - The `not in` operator is the negation of `in` (`x not in s`).

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -827,6 +827,7 @@ public:
 
         // Closure/function type info for collection elements
         std::optional<FnTypeInfo> list_elem_fn_type_info;
+        std::optional<FnTypeInfo> map_key_fn_type_info;
         std::optional<FnTypeInfo> map_value_fn_type_info;
         std::optional<FnTypeInfo> set_elem_fn_type_info;
 
@@ -1209,7 +1210,8 @@ public:
     llvm::Type *getListElementType(llvm::Value *listAlloca);
     llvm::Type *getMapKeyType(llvm::Value *mapVal);
     llvm::Type *getMapValueType(llvm::Value *mapVal);
-    llvm::Value *emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, llvm::Type *keyTy);
+    llvm::Value *emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, llvm::Type *keyTy,
+                                  const std::string &keyName = "");
     llvm::Value *emitIsWhitespace(llvm::Value *ch);
 
     // Runtime function helper: getOrInsertFunction with inline FunctionType creation
@@ -1490,6 +1492,7 @@ public:
     std::string reverseResolveTypeName(llvm::Type *ty);
     std::string inferCollectionTypeName(llvm::Value *val);
     std::string buildTypeNameFromMeta(llvm::Value *val);
+    std::string extractMapKeyTypeName(const std::string &mapTypeName);
     std::string extractMapValueTypeName(const std::string &mapTypeName);
 
     // ======== Union & Any Type Helpers ========

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -201,8 +201,10 @@ llvm::Value *CodeGen::emitStringToCharList(llvm::Value *s, const char *label) {
 // reverseResolveTypeName if they need a name for those.
 std::string CodeGen::inferCollectionTypeName(llvm::Value *val) {
     if (auto *keyTy = getMapKeyType(val)) {
-        std::string keyName = reverseResolveTypeName(keyTy);
         auto *meta = getMeta(val);
+        std::string keyName = (meta && !meta->map_key_type_name.empty())
+            ? meta->map_key_type_name
+            : reverseResolveTypeName(keyTy);
         std::string valName = (meta && !meta->map_value_type_name.empty())
             ? meta->map_value_type_name : reverseResolveTypeName(getMapValueType(val));
         return "Map<" + keyName + ", " + valName + ">";
@@ -241,8 +243,9 @@ std::string CodeGen::buildTypeNameFromMeta(llvm::Value *val) {
         return "List<" + elemName + ">";
     }
     if (meta->map_key || meta->map_value) {
-        std::string keyName = meta->map_key
-            ? reverseResolveTypeName(meta->map_key) : "";
+        std::string keyName = !meta->map_key_type_name.empty()
+            ? meta->map_key_type_name
+            : (meta->map_key ? reverseResolveTypeName(meta->map_key) : "");
         std::string valName;
         if (!meta->map_value_type_name.empty())
             valName = meta->map_value_type_name;

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -376,14 +376,21 @@ llvm::Value *CodeGen::emitSetElementLookup(llvm::Value *setPtr, llvm::Value *ele
 
 llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, llvm::Type *keyTy,
                                         const std::string &keyName) {
-    // Records, tuples (StructType) and named non-primitive keys (List<T>, Map<K,V>, Set<T>)
-    // have no runtime hash function.  Use a structural O(n) linear scan over mf.keys.
-    // Mirrors emitSetElementLookup; hash table bookkeeping is bypassed for these types.
+    // Named non-primitive keys (records, tuples, List<T>, Map<K,V>, Set<T>) have no
+    // runtime hash function.  Use a structural O(n) linear scan over mf.keys.
+    // The caller must pass a non-empty keyName to opt into this path; callers that
+    // do not (get(), remove(), merge(), etc.) keep the existing hash-table behavior
+    // so that non-equality operations are not affected.  Mirrors emitSetElementLookup.
     const bool needsLinearScan =
-        llvm::isa<llvm::StructType>(keyTy) ||
         (!keyName.empty() && keyName != "str" &&
          keyName != "int" && keyName != "float" && keyName != "bool");
     if (needsLinearScan) {
+        // key is loop-invariant: propagate type metadata once before the loop.
+        // The "__struct__" sentinel opts into the linear scan for StructType keys
+        // when map_key_type_name is absent; skip propagateTypeMeta in that case
+        // since the sentinel is not a valid Ry type name.
+        if (keyName != "__struct__")
+            propagateTypeMeta(keyName, key);
         auto mf = loadMapHeader(mapPtr, "mklin");
         llvm::AllocaInst *resVar = builder_.CreateAlloca(i64Ty_, nullptr, "mklin_res");
         builder_.CreateStore(llvm::ConstantInt::getSigned(i64Ty_, -1), resVar);
@@ -401,7 +408,8 @@ llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, ll
         builder_.SetInsertPoint(bodyBB);
         llvm::Value *cp   = builder_.CreateGEP(keyTy, mf.keys, {j}, "mklin_cp");
         llvm::Value *cand = builder_.CreateLoad(keyTy, cp, "mklin_cand");
-        if (!keyName.empty())
+        // cand changes each iteration; propagate per-iteration (skip sentinel).
+        if (keyName != "__struct__")
             propagateTypeMeta(keyName, cand);
         llvm::Value *eq = emitComparisonOp("==", key, cand, "", "");
         builder_.CreateCondBr(eq, matchBB, nextBB);

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -112,8 +112,11 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         if (parts.size() == 2) {
             std::string ktn = trimTypeNameSpaces(parts[0]);
             std::string vtn = trimTypeNameSpaces(parts[1]);
-            if (!ktn.empty())
+            if (!ktn.empty()) {
                 getOrCreateMeta(val).map_key_type_name = ktn;
+                if (isFunctionTypeName(ktn))
+                    getOrCreateMeta(val).map_key_fn_type_info = parseFnTypeAnnotation(ktn);
+            }
             if (!vtn.empty()) {
                 getOrCreateMeta(val).map_value_type_name = vtn;
                 if (isFunctionTypeName(vtn))
@@ -152,13 +155,18 @@ void CodeGen::propagateReturnFnTypeMeta(const OverloadEntry *entry, llvm::Functi
     getOrCreateMeta(result).fn_type_info = parseFnTypeAnnotation(resolved);
 }
 
+std::string CodeGen::extractMapKeyTypeName(const std::string &mapTypeName) {
+    std::string inner = mapTypeName.substr(4, mapTypeName.size() - 5);
+    auto parts = splitTypeArgs(inner);
+    if (parts.size() != 2) return "";
+    return trimTypeNameSpaces(parts[0]);
+}
+
 std::string CodeGen::extractMapValueTypeName(const std::string &mapTypeName) {
     std::string inner = mapTypeName.substr(4, mapTypeName.size() - 5);
     auto parts = splitTypeArgs(inner);
     if (parts.size() != 2) return "";
-    std::string vStr = parts[1];
-    while (!vStr.empty() && vStr.front() == ' ') vStr = vStr.substr(1);
-    return vStr;
+    return trimTypeNameSpaces(parts[1]);
 }
 
 std::string CodeGen::snapshotListElemName(llvm::Value *listVal, llvm::Type *elemTy) {
@@ -366,7 +374,46 @@ llvm::Value *CodeGen::emitSetElementLookup(llvm::Value *setPtr, llvm::Value *ele
     return emitHashTableLookup(setPtr, setHeaderTy_, kSetLayout, elem, elemTy);
 }
 
-llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, llvm::Type *keyTy) {
+llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, llvm::Type *keyTy,
+                                        const std::string &keyName) {
+    // Records, tuples (StructType) and named non-primitive keys (List<T>, Map<K,V>, Set<T>)
+    // have no runtime hash function.  Use a structural O(n) linear scan over mf.keys.
+    // Mirrors emitSetElementLookup; hash table bookkeeping is bypassed for these types.
+    const bool needsLinearScan =
+        llvm::isa<llvm::StructType>(keyTy) ||
+        (!keyName.empty() && keyName != "str" &&
+         keyName != "int" && keyName != "float" && keyName != "bool");
+    if (needsLinearScan) {
+        auto mf = loadMapHeader(mapPtr, "mklin");
+        llvm::AllocaInst *resVar = builder_.CreateAlloca(i64Ty_, nullptr, "mklin_res");
+        builder_.CreateStore(llvm::ConstantInt::getSigned(i64Ty_, -1), resVar);
+        llvm::AllocaInst *jVar = builder_.CreateAlloca(i64Ty_, nullptr, "mklin_j");
+        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), jVar);
+        llvm::BasicBlock *condBB  = llvm::BasicBlock::Create(*ctx_, "mklin.cond",  fn_);
+        llvm::BasicBlock *bodyBB  = llvm::BasicBlock::Create(*ctx_, "mklin.body",  fn_);
+        llvm::BasicBlock *matchBB = llvm::BasicBlock::Create(*ctx_, "mklin.match", fn_);
+        llvm::BasicBlock *nextBB  = llvm::BasicBlock::Create(*ctx_, "mklin.next",  fn_);
+        llvm::BasicBlock *endBB   = llvm::BasicBlock::Create(*ctx_, "mklin.end",   fn_);
+        builder_.CreateBr(condBB);
+        builder_.SetInsertPoint(condBB);
+        llvm::Value *j = builder_.CreateLoad(i64Ty_, jVar, "mklin_cj");
+        builder_.CreateCondBr(builder_.CreateICmpSLT(j, mf.len), bodyBB, endBB);
+        builder_.SetInsertPoint(bodyBB);
+        llvm::Value *cp   = builder_.CreateGEP(keyTy, mf.keys, {j}, "mklin_cp");
+        llvm::Value *cand = builder_.CreateLoad(keyTy, cp, "mklin_cand");
+        if (!keyName.empty())
+            propagateTypeMeta(keyName, cand);
+        llvm::Value *eq = emitComparisonOp("==", key, cand, "", "");
+        builder_.CreateCondBr(eq, matchBB, nextBB);
+        builder_.SetInsertPoint(matchBB);
+        builder_.CreateStore(j, resVar);
+        builder_.CreateBr(endBB);
+        builder_.SetInsertPoint(nextBB);
+        builder_.CreateStore(builder_.CreateAdd(j, llvm::ConstantInt::get(i64Ty_, 1)), jVar);
+        builder_.CreateBr(condBB);
+        builder_.SetInsertPoint(endBB);
+        return builder_.CreateLoad(i64Ty_, resVar, "mklin_result");
+    }
     return emitHashTableLookup(mapPtr, mapHeaderTy_, kMapLayout, key, keyTy);
 }
 

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -1177,6 +1177,9 @@ llvm::Value *CodeGen::emitCollOp_merge(const CallExpr &e) {
 
         setTypeMeta(TypeMeta::MapKey, newHeader, keyTy);
         setTypeMeta(TypeMeta::MapValue, newHeader, valTy);
+        // Carry Ry type names (key/value) from map1 so equality on the merged result
+        // works correctly for complex key and value types (#961).
+        propagateMeta(map1, newHeader);
         return newHeader;
     }
     return nullptr;

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -872,7 +872,21 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             llvm::Type *valTy = getMapValueType(lhs);
             if (!valTy || valTy != getMapValueType(rhs))
                 codegenError("cannot compare Map values with different value types");
-            // Hoist pointer-value metadata checks before loop scaffolding.
+            // Hoist key-side and value-side metadata checks before loop scaffolding.
+            // Keys: guard against function-typed keys; capture name for linear-scan
+            // fallback (records, tuples, nested collections have no hash function).
+            std::string meqKeyName;
+            {
+                auto *lhsMeta = getMeta(lhs);
+                if (lhsMeta && lhsMeta->map_key_fn_type_info)
+                    codegenError("map == / != is not supported for function-typed keys");
+                if (lhsMeta && !lhsMeta->map_key_type_name.empty() &&
+                        lhsMeta->map_key_type_name != "str" &&
+                        lhsMeta->map_key_type_name != "int" &&
+                        lhsMeta->map_key_type_name != "float" &&
+                        lhsMeta->map_key_type_name != "bool")
+                    meqKeyName = lhsMeta->map_key_type_name;
+            }
             std::string meqValName;
             if (valTy == ptrTy_) {
                 auto *lhsMeta = getMeta(lhs);
@@ -906,7 +920,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
             llvm::Value *meqIc = builder_.CreateLoad(i64Ty_, meqI, "meq_ic");
             llvm::Value *key = builder_.CreateLoad(lhsKeyTy,
                 builder_.CreateGEP(lhsKeyTy, lf.keys, {meqIc}, "meq_kep"), "meq_k");
-            llvm::Value *rhsIdx = emitMapKeyLookup(rhs, key, lhsKeyTy);
+            llvm::Value *rhsIdx = emitMapKeyLookup(rhs, key, lhsKeyTy, meqKeyName);
             builder_.CreateCondBr(
                 builder_.CreateICmpSGE(rhsIdx, llvm::ConstantInt::get(i64Ty_, 0), "meq_found"),
                 valBB, failBB);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -886,6 +886,12 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                         lhsMeta->map_key_type_name != "float" &&
                         lhsMeta->map_key_type_name != "bool")
                     meqKeyName = lhsMeta->map_key_type_name;
+                // StructType keys (records, tuples) always need the linear scan.
+                // When map_key_type_name is absent (e.g. non-empty literal without
+                // annotation), fall back to a sentinel that opts into the scan path
+                // without triggering metadata rebuild inside emitMapKeyLookup.
+                if (meqKeyName.empty() && llvm::isa<llvm::StructType>(lhsKeyTy))
+                    meqKeyName = "__struct__";
             }
             std::string meqValName;
             if (valTy == ptrTy_) {

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -881,10 +881,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                 if (lhsMeta && lhsMeta->map_key_fn_type_info)
                     codegenError("map == / != is not supported for function-typed keys");
                 if (lhsMeta && !lhsMeta->map_key_type_name.empty() &&
-                        lhsMeta->map_key_type_name != "str" &&
-                        lhsMeta->map_key_type_name != "int" &&
-                        lhsMeta->map_key_type_name != "float" &&
-                        lhsMeta->map_key_type_name != "bool")
+                        !kEqPrimitives.count(lhsMeta->map_key_type_name))
                     meqKeyName = lhsMeta->map_key_type_name;
                 // StructType keys (records, tuples) always need the linear scan.
                 // When map_key_type_name is absent (e.g. non-empty literal without

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -317,6 +317,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
     setTypeMeta(TypeMeta::MapKey, headerPtr, keyTy);
     setTypeMeta(TypeMeta::MapValue, headerPtr, valTy);
 
+    if (keyTy == ptrTy_ && !keyVals.empty()) {
+        std::string keyTypeName = inferCollectionTypeName(keyVals[0]);
+        if (!keyTypeName.empty())
+            getOrCreateMeta(headerPtr).map_key_type_name = keyTypeName;
+    }
     if (valTy == ptrTy_ && !valVals.empty()) {
         std::string valTypeName = inferCollectionTypeName(valVals[0]);
         if (!valTypeName.empty())

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -134,6 +134,8 @@ void CodeGen::propagateMeta(llvm::Value *src, llvm::Value *dst) {
         dstMeta.set_elem_type_name = srcMeta.set_elem_type_name;
     if (srcMeta.list_elem_fn_type_info)
         dstMeta.list_elem_fn_type_info = srcMeta.list_elem_fn_type_info;
+    if (srcMeta.map_key_fn_type_info)
+        dstMeta.map_key_fn_type_info = srcMeta.map_key_fn_type_info;
     if (srcMeta.map_value_fn_type_info)
         dstMeta.map_value_fn_type_info = srcMeta.map_value_fn_type_info;
     if (srcMeta.set_elem_fn_type_info)

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -91,7 +91,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             setTypeMeta(TypeMeta::MapKey, ptr, keyTy);
             setTypeMeta(TypeMeta::MapValue, ptr, valTy);
             {
-                std::string ktn = extractMapKeyTypeName(*annot);
+                std::string ktn = resolveTypeAlias(extractMapKeyTypeName(*annot));
                 if (!ktn.empty()) {
                     getOrCreateMeta(ptr).map_key_type_name = ktn;
                     if (isFunctionTypeName(ktn))

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -91,6 +91,14 @@ void CodeGen::emitVarDecl(const std::string &name,
             setTypeMeta(TypeMeta::MapKey, ptr, keyTy);
             setTypeMeta(TypeMeta::MapValue, ptr, valTy);
             {
+                std::string ktn = extractMapKeyTypeName(*annot);
+                if (!ktn.empty()) {
+                    getOrCreateMeta(ptr).map_key_type_name = ktn;
+                    if (isFunctionTypeName(ktn))
+                        getOrCreateMeta(ptr).map_key_fn_type_info = parseFnTypeAnnotation(ktn);
+                }
+            }
+            {
                 std::string vtn = extractMapValueTypeName(*annot);
                 if (!vtn.empty()) {
                     getOrCreateMeta(ptr).map_value_type_name = vtn;

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -407,3 +407,56 @@ describe("equality — Set with complex element types", ():
     expect(a != b).to_be_true()
   )
 )
+
+describe("equality — Map with complex key types", ():
+  it("should compare Map<record, int> equal", ():
+    a: Map<EqPoint, int> = {EqPoint(1, 2): 10, EqPoint(3, 4): 20}
+    b: Map<EqPoint, int> = {EqPoint(1, 2): 10, EqPoint(3, 4): 20}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Map<record, int> unequal by value", ():
+    a: Map<EqPoint, int> = {EqPoint(1, 2): 10}
+    b: Map<EqPoint, int> = {EqPoint(1, 2): 99}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Map<record, int> unequal by key", ():
+    a: Map<EqPoint, int> = {EqPoint(1, 2): 10}
+    b: Map<EqPoint, int> = {EqPoint(9, 9): 10}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Map<record, int> of different sizes unequal", ():
+    a: Map<EqPoint, int> = {EqPoint(1, 2): 10, EqPoint(3, 4): 20}
+    b: Map<EqPoint, int> = {EqPoint(1, 2): 10}
+    expect(a != b).to_be_true()
+  )
+  it("should compare empty Map<record, int> equal", ():
+    a: Map<EqPoint, int> = {}
+    b: Map<EqPoint, int> = {}
+    expect(a == b).to_be_true()
+  )
+  it("should compare empty Map<record, int> unequal to non-empty", ():
+    a: Map<EqPoint, int> = {}
+    b: Map<EqPoint, int> = {EqPoint(1, 2): 10}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Map<tuple, str> equal", ():
+    a: Map<(int, int), str> = {(1, 2): "a", (3, 4): "b"}
+    b: Map<(int, int), str> = {(1, 2): "a", (3, 4): "b"}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Map<tuple, str> unequal", ():
+    a: Map<(int, int), str> = {(1, 2): "a"}
+    b: Map<(int, int), str> = {(1, 2): "z"}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Map<record, List<int>> equal (mixed complex key + value)", ():
+    a: Map<EqPoint, List<int>> = {EqPoint(1, 2): [10, 20], EqPoint(3, 4): [30]}
+    b: Map<EqPoint, List<int>> = {EqPoint(1, 2): [10, 20], EqPoint(3, 4): [30]}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Map<record, List<int>> unequal when values differ", ():
+    a: Map<EqPoint, List<int>> = {EqPoint(1, 2): [10, 20]}
+    b: Map<EqPoint, List<int>> = {EqPoint(1, 2): [10, 99]}
+    expect(a != b).to_be_true()
+  )
+)

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -459,4 +459,19 @@ describe("equality — Map with complex key types", ():
     b: Map<EqPoint, List<int>> = {EqPoint(1, 2): [10, 99]}
     expect(a != b).to_be_true()
   )
+  it("should compare Map<List<int>, str> equal (pointer-backed key)", ():
+    a: Map<List<int>, str> = {[1, 2]: "a", [3]: "b"}
+    b: Map<List<int>, str> = {[1, 2]: "a", [3]: "b"}
+    expect(a == b).to_be_true()
+  )
+  it("should compare Map<List<int>, str> unequal by value", ():
+    a: Map<List<int>, str> = {[1, 2]: "a"}
+    b: Map<List<int>, str> = {[1, 2]: "z"}
+    expect(a != b).to_be_true()
+  )
+  it("should compare Map<List<int>, str> unequal by key", ():
+    a: Map<List<int>, str> = {[1, 2]: "a"}
+    b: Map<List<int>, str> = {[9, 9]: "a"}
+    expect(a != b).to_be_true()
+  )
 )

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2523,6 +2523,18 @@ TEST_F(CodeGenTest, SetFnElemEqualityRejected) {
         "function-typed");
 }
 
+// Map with a function-typed key via type alias must be rejected at == / != (#961).
+// Direct Map<function(...)...> annotations are rejected by annotation parsing;
+// the alias path exercises the map_key_fn_type_info guard in codegen_expr.cpp.
+TEST_F(CodeGenTest, MapFnKeyEqualityRejected) {
+    expectCompileError(
+        "type FnKey = function(int) -> int\n"
+        "a: Map<FnKey, int> = {}\n"
+        "b: Map<FnKey, int> = {}\n"
+        "_ = a == b\n",
+        "function-typed keys");
+}
+
 // ADT enum with a function-typed payload must be rejected at compile time.
 // Regression for the closure-payload guard added in #959.
 TEST_F(CodeGenTest, AdtEnumFnPayloadEqualityRejected) {


### PR DESCRIPTION
## Summary

- `Map<K, V>` `==` and `!=` now support complex key types: records, tuples, and nested collections (`Map<EqPoint, int>`, `Map<(int, int), str>`, `Map<EqPoint, List<int>>`, etc.)
- Non-primitive keys use an O(n·m) structural linear-scan lookup in `emitMapKeyLookup`; primitive keys continue using the existing hash-based path unchanged
- Mirrors the pattern established in #964 (Set complex element support)

Closes #961

## Changes

- **`src/codegen_builtin.cpp`**: `emitMapKeyLookup` gains `keyName` param; StructType + named non-primitive keys trigger a linear scan over `mf.keys` that calls `propagateTypeMeta` and `emitComparisonOp` recursively (same metadata-rebuild pattern as #736). `extractMapKeyTypeName` added (symmetric to `extractMapValueTypeName`); both now use `trimTypeNameSpaces` for consistency.
- **`src/codegen_expr.cpp`**: Hoist key-side metadata before the Map == / != loop; capture `meqKeyName` and forward to `emitMapKeyLookup`. Defensive guard for function-typed keys.
- **`src/codegen_stmt.cpp`**: Propagate `map_key_type_name` / `map_key_fn_type_info` on empty `Map<K,V> = {}` literals (mirrors Set fix from #958).
- **`src/codegen_call_collection.cpp`**: Replace 4-field manual copy in `emitCollOp_merge` with `propagateMeta(map1, newHeader)` so merged maps carry key/value type names for downstream equality.
- **`src/codegen_metadata.cpp`**: Add `map_key_fn_type_info` propagation in `propagateMeta`.
- **`include/ry/codegen.hpp`**: `map_key_fn_type_info` field added to `ValueMetadata`; `emitMapKeyLookup` and `extractMapKeyTypeName` declarations updated.
- **`tests/spec/combinatorial/equality.test.ry`**: 10 new test cases: `Map<record,int>`, `Map<tuple,str>`, `Map<record,List<int>>`, empty-literal equality.
- **`docs/reference/operators.md`**, **`changelog.d/961-map-complex-key-equality.md`**, **`KNOWLEDGE.md`**: documentation updated.

## Test plan

- [ ] `cmake --preset default && cmake --build build` — zero warnings
- [ ] `./build/ry_tests` — 1652 tests pass
- [ ] `./build/ry test -p` — 119 files, 0 failures (includes 10 new Map complex-key equality cases)
- [ ] ASan+UBSan: `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests` — clean
- [ ] TSan: `cmake --preset tsan && cmake --build build-tsan && TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests` — 1652 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map equality (`==`, `!=`) now supports complex key types (records, tuples, nested collections); non-primitive keys use a structural O(n) linear-scan lookup while primitives keep hash-based lookup; function-typed keys are rejected.
  * Merged maps now preserve key/value type metadata affecting equality behavior.

* **Documentation**
  * Reference and knowledge docs clarified with examples and metadata requirements for Map keys and literals.

* **Tests**
  * Added positive equality suites for complex keys and a compile-time rejection test for function-typed keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->