### PR TITLE
docs: remove broken language switch links from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[English](README.md) | [日本語](README.ja.md) | [繁體中文](README.zh.md)
-
 <p align="center">
   <img src="docs/logo.png" alt="Ry" width="200">
 </p>


### PR DESCRIPTION
## Summary

- `README.md` の先頭行にあった言語切り替えリンクを削除しました
- `README.ja.md` / `README.zh.md` は存在しないためリンク切れでした

Closes #975