### PR TITLE
feat: support Map + Map (merge) and Set + Set (union) via + / += (#866)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -798,19 +798,26 @@ metadata-less pointer operands (they are already classified as str and
 rejected with a misleading message), and adding a branch BEFORE it must
 be careful not to steal legitimate str mismatches like `"x" + myMap`.
 
-**Rule**: When adding a new type-specific error branch for `+` in
+**Rule**: When adding a new type-specific branch for `+` in
 `emitArithmeticOp`, insert it **after** the list-concat success path
-(around `codegen_expr.cpp:1023`) but **before** the str-vs-non-str
-reject. Use the typed metadata accessors (`getMapKeyType` /
-`getMapValueType` / `getSetElementType` / `getListElementType`) to
-recognize the operand kind and `buildTypeNameFromMeta()` to surface the
-source-level type name in the diagnostic. This is the placement used
-by the #863 Map/Set dispatch; see that fix for the canonical pattern.
+but **before** the str-vs-non-str reject. Use the typed metadata
+accessors (`getMapKeyType` / `getMapValueType` / `getSetElementType` /
+`getListElementType`) to recognize the operand kind. The current order
+in `codegen_expr.cpp::emitArithmeticOp` is:
+1. String concat / repeat (early return)
+2. List + List success → `emitListConcat`
+3. Map + Map success → `emitMapMergeCore` (#866)
+4. Set + Set success → `emitSetUnionCore` (#866)
+5. Mixed/one-sided Map-or-Set reject (named diagnostic, #863)
+6. str-vs-non-str reject
 
 **Related**: The companion #858/#862 entry covers the upstream side of
 the same trap — metadata propagation on compound-assign loaded slots —
-which must also be correct for the new dispatch branch to see accurate
+which must also be correct for the dispatch branch to see accurate
 kinds on LHS values produced by `m[k] += ...` and friends.
+`emitMapMergeCore` and `emitSetUnionCore` are extracted from
+`emitCollOp_merge` / `emitSetOp_union` and shared between `CallExpr`
+and `BinaryExpr` sites (#866).
 
 ### Element-slot writes must release the overwritten ARC pointer
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 - **LLVM JIT Compilation** — Fast native execution powered by ORC LLJIT
 - **Rich Type System** — `int`, `float`, `bool`, `str`, `Option<T>`, `Error`, tuples, `List<T>`, `Map<K,V>`, `Set<T>`, `enum`, function types, user-defined records, union types (`int | str`)
-- **Operators** — Arithmetic, comparison, logical, bitwise (`>>>` logical right shift), compound assignment, `in` / `not in`, string repetition (`"ab" * 3`), `as` type cast, error propagation `?`, with operator overloading support
+- **Operators** — Arithmetic, comparison, logical, bitwise (`>>>` logical right shift), compound assignment, `in` / `not in`, string repetition (`"ab" * 3`), collection arithmetic (`List + List` concatenation, `Map + Map` merge, `Set + Set` union), `as` type cast, error propagation `?`, with operator overloading support
 - **Pattern Matching** — `case` expressions with enum / `Option` / `Result` / literal / tuple / record destructuring, guard clauses (`x if x > 0`), exhaustiveness checking
 - **F-String** — String interpolation with `f"Hello {name}"`
 - **Design by Contract** — `require` (preconditions), `ensure` (postconditions), `invariant` (record invariants)

--- a/changelog.d/866-map-set-plus-operator.md
+++ b/changelog.d/866-map-set-plus-operator.md
@@ -1,0 +1,3 @@
+### Added
+
+- `Map + Map` (merge, rhs-wins on key collision) and `Set + Set` (union) are now supported via `+` and `+=` operators, parallel to existing `List + List` concatenation (#866)

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -737,7 +737,7 @@ print(get(m, "z", 0))   # 0
 
 ### Merge with `+` and `+=`
 
-Returns a new map that combines all entries from both maps. When keys overlap, values from the right-hand side take precedence (rhs-wins). The original maps are not modified.
+`+` returns a new map that combines all entries from both maps; the original maps are not modified. When keys overlap, values from the right-hand side take precedence (rhs-wins). `+=` rebinds the left-hand variable to the merged result (`m1 += m2` is equivalent to `m1 = m1 + m2`).
 
 ```python
 m1 = {"a": 1, "b": 2}
@@ -871,7 +871,7 @@ function has_value(s: Set<int>, v: int) -> bool:
 
 ### Union with `+` and `+=`
 
-Returns a new set containing all elements from both sets. The original sets are not modified.
+`+` returns a new set containing all elements from both sets; the original sets are not modified. `+=` rebinds the left-hand variable to the union result (`a += b` is equivalent to `a = a + b`).
 
 ```python
 a = {1, 2, 3}

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -735,9 +735,26 @@ print(get(m, "a", 0))   # 1
 print(get(m, "z", 0))   # 0
 ```
 
+### Merge with `+` and `+=`
+
+Returns a new map that combines all entries from both maps. When keys overlap, values from the right-hand side take precedence (rhs-wins). The original maps are not modified.
+
+```python
+m1 = {"a": 1, "b": 2}
+m2 = {"b": 99, "c": 3}
+m3 = m1 + m2
+print(m3["a"])   # 1
+print(m3["b"])   # 99  ← rhs wins
+print(m3["c"])   # 3
+
+m1 += m2         # same as m1 = m1 + m2
+```
+
+Both maps must have the same key type and value type.
+
 ### merge
 
-Returns a new map that combines all entries from both maps. When keys overlap, values from the second map take precedence. The original maps are not modified.
+Equivalent to `m1 + m2`. Returns a new map combining all entries from both maps with rhs-wins semantics. The original maps are not modified.
 
 ```python
 m1 = {"a": 1, "b": 2}
@@ -852,9 +869,23 @@ function has_value(s: Set<int>, v: int) -> bool:
     return v in s
 ```
 
+### Union with `+` and `+=`
+
+Returns a new set containing all elements from both sets. The original sets are not modified.
+
+```python
+a = {1, 2, 3}
+b = {3, 4, 5}
+c = a + b            # {1, 2, 3, 4, 5}
+
+a += b               # same as a = a + b
+```
+
+Both sets must have the same element type.
+
 ### union
 
-Returns a new set containing all elements from both sets.
+Equivalent to `s1 + s2`. Returns a new set containing all elements from both sets. The original sets are not modified.
 
 ```python
 a = {1, 2, 3}

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -294,6 +294,22 @@ pts = [Point(1, 2), Point(3, 4)]
 pts[0].x -= 1            # chained: list-of-records field
 ```
 
+For collection types, `+=` uses the collection's `+` semantics:
+
+```python
+# List concatenation
+xs: List<int> = [1, 2]
+xs += [3, 4]             # xs = [1, 2, 3, 4]
+
+# Map merge (rhs-wins on key collision)
+m: Map<str, int> = {"a": 1}
+m += {"a": 99, "b": 2}  # m = {"a": 99, "b": 2}
+
+# Set union
+s: Set<int> = {1, 2}
+s += {2, 3}              # s = {1, 2, 3}
+```
+
 Each index expression on a chained LHS is evaluated exactly once. Compound
 assignment to a missing map key (`m["absent"] += 1`) is a runtime error.
 
@@ -337,6 +353,9 @@ f++           # f = 2.5 (int 1 is promoted to float)
 | `+` | str | str | str |
 | `+` | str | int / float / bool | str |
 | `+` | int / float / bool | str | str |
+| `+` | List\<T\> | List\<T\> | List\<T\> (concatenation) |
+| `+` | Map\<K, V\> | Map\<K, V\> | Map\<K, V\> (merge, rhs-wins) |
+| `+` | Set\<T\> | Set\<T\> | Set\<T\> (union) |
 | `== != < <= > >=` | numeric / bool / str | same type | bool |
 | `*` | str | int | str |
 | `in` | any | Set<T> / List<T> / Map<K, V> | bool |

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1387,6 +1387,10 @@ public:
     llvm::Value *emitStrOp_repeat(const CallExpr &e);
     llvm::Value *emitStringRepeat(llvm::Value *strVal, llvm::Value *n);
     llvm::Value *emitListConcat(llvm::Value *lhs, llvm::Value *rhs, llvm::Type *elemTy);
+    llvm::Value *emitMapMergeCore(llvm::Value *map1, llvm::Value *map2,
+                                   llvm::Type *keyTy, llvm::Type *valTy);
+    llvm::Value *emitSetUnionCore(llvm::Value *set1, llvm::Value *set2,
+                                   llvm::Type *elemTy);
     llvm::Value *emitStrOp_reverse(const CallExpr &e);
     llvm::Value *emitStrOp_reverse_mut(const CallExpr &e);
     llvm::Value *emitStrOp_split(const CallExpr &e);

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -1065,6 +1065,9 @@ llvm::Value *CodeGen::emitMapMergeCore(llvm::Value *map1, llvm::Value *map2,
     auto mallocFn = getStdlibMalloc();
     auto memcpyFn = getStdlibMemcpy();
 
+    const ValueMetadata *map1Meta = getMeta(map1);
+    const std::string keyName = map1Meta ? map1Meta->map_key_type_name : std::string{};
+
     auto mf1 = loadMapHeader(map1, "mg1");
     auto mf2 = loadMapHeader(map2, "mg2");
 
@@ -1103,6 +1106,7 @@ llvm::Value *CodeGen::emitMapMergeCore(llvm::Value *map1, llvm::Value *map2,
         builder_.SetInsertPoint(rBodyBB);
         llvm::Value *kp = builder_.CreateGEP(keyTy, newKeys, {ri}, "mg_rh_kp");
         llvm::Value *kv = builder_.CreateLoad(keyTy, kp, "mg_rh_kv");
+        if (!keyName.empty()) propagateTypeMeta(keyName, kv);
         emitBucketInsertAndRehashCheck(newHeader, mapHeaderTy_, kMapLayout.lenIdx, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, kv, keyTy, ri);
         builder_.CreateStore(builder_.CreateAdd(ri, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
         builder_.CreateBr(rCondBB);
@@ -1124,6 +1128,7 @@ llvm::Value *CodeGen::emitMapMergeCore(llvm::Value *map1, llvm::Value *map2,
         builder_.SetInsertPoint(bodyBB);
         llvm::Value *kp = builder_.CreateGEP(keyTy, mf2.keys, {i}, "mg_kp2");
         llvm::Value *kv = builder_.CreateLoad(keyTy, kp, "mg_kv2");
+        if (!keyName.empty()) propagateTypeMeta(keyName, kv);
         llvm::Value *vp = builder_.CreateGEP(valTy, mf2.vals, {i}, "mg_vp2");
         llvm::Value *vv = builder_.CreateLoad(valTy, vp, "mg_vv2");
 

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -1056,133 +1056,133 @@ llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
     return nullptr;
 }
 
+llvm::Value *CodeGen::emitMapMergeCore(llvm::Value *map1, llvm::Value *map2,
+                                        llvm::Type *keyTy, llvm::Type *valTy) {
+    const llvm::DataLayout &dl = mod_->getDataLayout();
+    uint64_t keySize = dl.getTypeAllocSize(keyTy);
+    uint64_t valSize = dl.getTypeAllocSize(valTy);
+
+    auto mallocFn = getStdlibMalloc();
+    auto memcpyFn = getStdlibMemcpy();
+
+    auto mf1 = loadMapHeader(map1, "mg1");
+    auto mf2 = loadMapHeader(map2, "mg2");
+
+    // Allocate new map with capacity = len1 + len2
+    llvm::Value *maxCap = builder_.CreateAdd(mf1.len, mf2.len, "mg_max_cap");
+    llvm::Value *newHeader = emitArcAllocCollectionHeader(mapHeaderTy_);
+    llvm::Value *newKeysSize = builder_.CreateMul(maxCap, llvm::ConstantInt::get(i64Ty_, keySize), "mg_ks");
+    llvm::Value *newKeys = builder_.CreateCall(mallocFn, {newKeysSize}, "mg_keys");
+    llvm::Value *newValsSize = builder_.CreateMul(maxCap, llvm::ConstantInt::get(i64Ty_, valSize), "mg_vs");
+    llvm::Value *newVals = builder_.CreateCall(mallocFn, {newValsSize}, "mg_vals");
+
+    // Copy all of map1
+    llvm::Value *copy1KeySize = builder_.CreateMul(mf1.len, llvm::ConstantInt::get(i64Ty_, keySize), "mg_ck1");
+    builder_.CreateCall(memcpyFn, {newKeys, mf1.keys, copy1KeySize});
+    llvm::Value *copy1ValSize = builder_.CreateMul(mf1.len, llvm::ConstantInt::get(i64Ty_, valSize), "mg_cv1");
+    builder_.CreateCall(memcpyFn, {newVals, mf1.vals, copy1ValSize});
+
+    // Set up header
+    storeMapHeaderFields(newHeader, mf1.len, maxCap, newKeys, newVals);
+    llvm::Value *lenPtr = builder_.CreateStructGEP(mapHeaderTy_, newHeader, 0, "mg_len_ptr");
+
+    // Init hash buckets
+    emitBucketInit(newHeader, mapHeaderTy_, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, 16);
+
+    // Re-hash map1 keys into new map's buckets
+    {
+        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "mg_rh_i");
+        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        llvm::BasicBlock *rCondBB = llvm::BasicBlock::Create(*ctx_, "mg.rh.cond", fn_);
+        llvm::BasicBlock *rBodyBB = llvm::BasicBlock::Create(*ctx_, "mg.rh.body", fn_);
+        llvm::BasicBlock *rEndBB = llvm::BasicBlock::Create(*ctx_, "mg.rh.end", fn_);
+        builder_.CreateBr(rCondBB);
+        builder_.SetInsertPoint(rCondBB);
+        llvm::Value *ri = builder_.CreateLoad(i64Ty_, iVar, "mg_ri");
+        builder_.CreateCondBr(builder_.CreateICmpSLT(ri, mf1.len), rBodyBB, rEndBB);
+        builder_.SetInsertPoint(rBodyBB);
+        llvm::Value *kp = builder_.CreateGEP(keyTy, newKeys, {ri}, "mg_rh_kp");
+        llvm::Value *kv = builder_.CreateLoad(keyTy, kp, "mg_rh_kv");
+        emitBucketInsertAndRehashCheck(newHeader, mapHeaderTy_, kMapLayout.lenIdx, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, kv, keyTy, ri);
+        builder_.CreateStore(builder_.CreateAdd(ri, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        builder_.CreateBr(rCondBB);
+        builder_.SetInsertPoint(rEndBB);
+    }
+
+    // Add/update entries from map2 (rhs-wins on key collision)
+    {
+        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "mg_i2");
+        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "mg.add.cond", fn_);
+        llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, "mg.add.body", fn_);
+        llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "mg.add.end", fn_);
+        builder_.CreateBr(condBB);
+        builder_.SetInsertPoint(condBB);
+        llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "mg_ci");
+        builder_.CreateCondBr(builder_.CreateICmpSLT(i, mf2.len), bodyBB, endBB);
+
+        builder_.SetInsertPoint(bodyBB);
+        llvm::Value *kp = builder_.CreateGEP(keyTy, mf2.keys, {i}, "mg_kp2");
+        llvm::Value *kv = builder_.CreateLoad(keyTy, kp, "mg_kv2");
+        llvm::Value *vp = builder_.CreateGEP(valTy, mf2.vals, {i}, "mg_vp2");
+        llvm::Value *vv = builder_.CreateLoad(valTy, vp, "mg_vv2");
+
+        // Check if key exists in new map
+        llvm::Value *lookupIdx = emitMapKeyLookup(newHeader, kv, keyTy);
+        llvm::Value *exists = builder_.CreateICmpSGE(lookupIdx, llvm::ConstantInt::get(i64Ty_, 0), "mg_exists");
+
+        llvm::BasicBlock *updateBB = llvm::BasicBlock::Create(*ctx_, "mg.update", fn_);
+        llvm::BasicBlock *insertBB = llvm::BasicBlock::Create(*ctx_, "mg.insert", fn_);
+        llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, "mg.next", fn_);
+        builder_.CreateCondBr(exists, updateBB, insertBB);
+
+        // Update existing key's value
+        builder_.SetInsertPoint(updateBB);
+        llvm::Value *curVals = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, newHeader, 3), "mg_cur_vals");
+        llvm::Value *updPtr = builder_.CreateGEP(valTy, curVals, {lookupIdx}, "mg_upd_ptr");
+        builder_.CreateStore(vv, updPtr);
+        builder_.CreateBr(nextBB);
+
+        // Insert new key-value pair
+        builder_.SetInsertPoint(insertBB);
+        llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "mg_cur_len");
+        llvm::Value *curKeys = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, newHeader, 2), "mg_cur_keys");
+        llvm::Value *newKeyPtr = builder_.CreateGEP(keyTy, curKeys, {curLen}, "mg_new_kp");
+        builder_.CreateStore(kv, newKeyPtr);
+        llvm::Value *curVals2 = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, newHeader, 3), "mg_cur_vals2");
+        llvm::Value *newValPtr = builder_.CreateGEP(valTy, curVals2, {curLen}, "mg_new_vp");
+        builder_.CreateStore(vv, newValPtr);
+        builder_.CreateStore(builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1)), lenPtr);
+        emitBucketInsertAndRehashCheck(newHeader, mapHeaderTy_, kMapLayout.lenIdx, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, kv, keyTy, curLen);
+        builder_.CreateBr(nextBB);
+
+        builder_.SetInsertPoint(nextBB);
+        builder_.CreateStore(builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        builder_.CreateBr(condBB);
+        builder_.SetInsertPoint(endBB);
+    }
+
+    setTypeMeta(TypeMeta::MapKey, newHeader, keyTy);
+    setTypeMeta(TypeMeta::MapValue, newHeader, valTy);
+    // Carry Ry type names (key/value) from map1 so equality on the merged result
+    // works correctly for complex key and value types (#961).
+    propagateMeta(map1, newHeader);
+    return newHeader;
+}
+
 llvm::Value *CodeGen::emitCollOp_merge(const CallExpr &e) {
     if (e.args.size() != 2) return nullptr;
-    // merge(map1, map2) -> new map
     llvm::Value *map1 = emitExpr(*e.args[0]);
     llvm::Value *map2 = emitExpr(*e.args[1]);
     llvm::Type *keyTy = getMapKeyType(map1);
     llvm::Type *valTy = getMapValueType(map1);
     if (!keyTy || !valTy)
         codegenError("merge() requires maps as arguments");
-    {
-        llvm::Type *keyTy2 = getMapKeyType(map2);
-        llvm::Type *valTy2 = getMapValueType(map2);
-        if (!keyTy2 || keyTy2 != keyTy || !valTy2 || valTy2 != valTy)
-            codegenError("merge() requires two maps with the same key and value types");
-
-        const llvm::DataLayout &dl = mod_->getDataLayout();
-        uint64_t keySize = dl.getTypeAllocSize(keyTy);
-        uint64_t valSize = dl.getTypeAllocSize(valTy);
-
-        auto mallocFn = getStdlibMalloc();
-        auto memcpyFn = getStdlibMemcpy();
-
-        auto mf1 = loadMapHeader(map1, "mg1");
-        auto mf2 = loadMapHeader(map2, "mg2");
-
-        // Allocate new map with capacity = len1 + len2
-        llvm::Value *maxCap = builder_.CreateAdd(mf1.len, mf2.len, "mg_max_cap");
-        llvm::Value *newHeader = emitArcAllocCollectionHeader(mapHeaderTy_);
-        llvm::Value *newKeysSize = builder_.CreateMul(maxCap, llvm::ConstantInt::get(i64Ty_, keySize), "mg_ks");
-        llvm::Value *newKeys = builder_.CreateCall(mallocFn, {newKeysSize}, "mg_keys");
-        llvm::Value *newValsSize = builder_.CreateMul(maxCap, llvm::ConstantInt::get(i64Ty_, valSize), "mg_vs");
-        llvm::Value *newVals = builder_.CreateCall(mallocFn, {newValsSize}, "mg_vals");
-
-        // Copy all of map1
-        llvm::Value *copy1KeySize = builder_.CreateMul(mf1.len, llvm::ConstantInt::get(i64Ty_, keySize), "mg_ck1");
-        builder_.CreateCall(memcpyFn, {newKeys, mf1.keys, copy1KeySize});
-        llvm::Value *copy1ValSize = builder_.CreateMul(mf1.len, llvm::ConstantInt::get(i64Ty_, valSize), "mg_cv1");
-        builder_.CreateCall(memcpyFn, {newVals, mf1.vals, copy1ValSize});
-
-        // Set up header
-        storeMapHeaderFields(newHeader, mf1.len, maxCap, newKeys, newVals);
-        llvm::Value *lenPtr = builder_.CreateStructGEP(mapHeaderTy_, newHeader, 0, "mg_len_ptr");
-
-        // Init hash buckets
-        emitBucketInit(newHeader, mapHeaderTy_, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, 16);
-
-        // Re-hash map1 keys into new map's buckets
-        {
-            llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "mg_rh_i");
-            builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
-            llvm::BasicBlock *rCondBB = llvm::BasicBlock::Create(*ctx_, "mg.rh.cond", fn_);
-            llvm::BasicBlock *rBodyBB = llvm::BasicBlock::Create(*ctx_, "mg.rh.body", fn_);
-            llvm::BasicBlock *rEndBB = llvm::BasicBlock::Create(*ctx_, "mg.rh.end", fn_);
-            builder_.CreateBr(rCondBB);
-            builder_.SetInsertPoint(rCondBB);
-            llvm::Value *ri = builder_.CreateLoad(i64Ty_, iVar, "mg_ri");
-            builder_.CreateCondBr(builder_.CreateICmpSLT(ri, mf1.len), rBodyBB, rEndBB);
-            builder_.SetInsertPoint(rBodyBB);
-            llvm::Value *kp = builder_.CreateGEP(keyTy, newKeys, {ri}, "mg_rh_kp");
-            llvm::Value *kv = builder_.CreateLoad(keyTy, kp, "mg_rh_kv");
-            emitBucketInsertAndRehashCheck(newHeader, mapHeaderTy_, kMapLayout.lenIdx, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, kv, keyTy, ri);
-            builder_.CreateStore(builder_.CreateAdd(ri, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
-            builder_.CreateBr(rCondBB);
-            builder_.SetInsertPoint(rEndBB);
-        }
-
-        // Add/update entries from map2
-        {
-            llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "mg_i2");
-            builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
-            llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "mg.add.cond", fn_);
-            llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, "mg.add.body", fn_);
-            llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "mg.add.end", fn_);
-            builder_.CreateBr(condBB);
-            builder_.SetInsertPoint(condBB);
-            llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "mg_ci");
-            builder_.CreateCondBr(builder_.CreateICmpSLT(i, mf2.len), bodyBB, endBB);
-
-            builder_.SetInsertPoint(bodyBB);
-            llvm::Value *kp = builder_.CreateGEP(keyTy, mf2.keys, {i}, "mg_kp2");
-            llvm::Value *kv = builder_.CreateLoad(keyTy, kp, "mg_kv2");
-            llvm::Value *vp = builder_.CreateGEP(valTy, mf2.vals, {i}, "mg_vp2");
-            llvm::Value *vv = builder_.CreateLoad(valTy, vp, "mg_vv2");
-
-            // Check if key exists in new map
-            llvm::Value *lookupIdx = emitMapKeyLookup(newHeader, kv, keyTy);
-            llvm::Value *exists = builder_.CreateICmpSGE(lookupIdx, llvm::ConstantInt::get(i64Ty_, 0), "mg_exists");
-
-            llvm::BasicBlock *updateBB = llvm::BasicBlock::Create(*ctx_, "mg.update", fn_);
-            llvm::BasicBlock *insertBB = llvm::BasicBlock::Create(*ctx_, "mg.insert", fn_);
-            llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, "mg.next", fn_);
-            builder_.CreateCondBr(exists, updateBB, insertBB);
-
-            // Update existing key's value
-            builder_.SetInsertPoint(updateBB);
-            llvm::Value *curVals = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, newHeader, 3), "mg_cur_vals");
-            llvm::Value *updPtr = builder_.CreateGEP(valTy, curVals, {lookupIdx}, "mg_upd_ptr");
-            builder_.CreateStore(vv, updPtr);
-            builder_.CreateBr(nextBB);
-
-            // Insert new key-value pair
-            builder_.SetInsertPoint(insertBB);
-            llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "mg_cur_len");
-            llvm::Value *curKeys = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, newHeader, 2), "mg_cur_keys");
-            llvm::Value *newKeyPtr = builder_.CreateGEP(keyTy, curKeys, {curLen}, "mg_new_kp");
-            builder_.CreateStore(kv, newKeyPtr);
-            llvm::Value *curVals2 = builder_.CreateLoad(ptrTy_, builder_.CreateStructGEP(mapHeaderTy_, newHeader, 3), "mg_cur_vals2");
-            llvm::Value *newValPtr = builder_.CreateGEP(valTy, curVals2, {curLen}, "mg_new_vp");
-            builder_.CreateStore(vv, newValPtr);
-            builder_.CreateStore(builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1)), lenPtr);
-            emitBucketInsertAndRehashCheck(newHeader, mapHeaderTy_, kMapLayout.lenIdx, kMapLayout.bucketCountIdx, kMapLayout.bucketsPtrIdx, kv, keyTy, curLen);
-            builder_.CreateBr(nextBB);
-
-            builder_.SetInsertPoint(nextBB);
-            builder_.CreateStore(builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
-            builder_.CreateBr(condBB);
-            builder_.SetInsertPoint(endBB);
-        }
-
-        setTypeMeta(TypeMeta::MapKey, newHeader, keyTy);
-        setTypeMeta(TypeMeta::MapValue, newHeader, valTy);
-        // Carry Ry type names (key/value) from map1 so equality on the merged result
-        // works correctly for complex key and value types (#961).
-        propagateMeta(map1, newHeader);
-        return newHeader;
-    }
-    return nullptr;
+    llvm::Type *keyTy2 = getMapKeyType(map2);
+    llvm::Type *valTy2 = getMapValueType(map2);
+    if (!keyTy2 || keyTy2 != keyTy || !valTy2 || valTy2 != valTy)
+        codegenError("merge() requires two maps with the same key and value types");
+    return emitMapMergeCore(map1, map2, keyTy, valTy);
 }
 
 } // namespace ry

--- a/src/codegen_call_set_ops.cpp
+++ b/src/codegen_call_set_ops.cpp
@@ -122,6 +122,7 @@ llvm::Value *CodeGen::emitSetUnionCore(llvm::Value *set1, llvm::Value *set2,
         builder_.SetInsertPoint(rBodyBB);
         llvm::Value *ep = builder_.CreateGEP(elemTy, newData, {ri}, "u_rehash_ep");
         llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "u_rehash_ev");
+        if (!elemName.empty()) propagateTypeMeta(elemName, ev);
         emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, ev, elemTy, ri);
         builder_.CreateStore(builder_.CreateAdd(ri, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
         builder_.CreateBr(rCondBB);

--- a/src/codegen_call_set_ops.cpp
+++ b/src/codegen_call_set_ops.cpp
@@ -78,108 +78,112 @@ llvm::Value *CodeGen::emitBuiltinSetOps(const CallExpr &e) {
 
 // ===== Set Operation Handlers =====
 
+llvm::Value *CodeGen::emitSetUnionCore(llvm::Value *set1, llvm::Value *set2,
+                                        llvm::Type *elemTy) {
+    const ValueMetadata *set1Meta = getMeta(set1);
+    const std::string elemName = set1Meta ? set1Meta->set_elem_type_name : std::string{};
+    // Create new set with all elements from set1, then add elements from set2
+    auto sf1 = loadSetHeader(set1, "u1");
+    auto sf2 = loadSetHeader(set2, "u2");
+
+    const llvm::DataLayout &dl = mod_->getDataLayout();
+    uint64_t elemSize = dl.getTypeAllocSize(elemTy);
+    auto mallocFn = getStdlibMalloc();
+
+    // Allocate max possible size (len1 + len2)
+    llvm::Value *maxLen = builder_.CreateAdd(sf1.len, sf2.len, "u_max_len");
+    llvm::Value *newHeader = emitArcAllocCollectionHeader(setHeaderTy_);
+    llvm::Value *dataSize = builder_.CreateMul(maxLen, llvm::ConstantInt::get(i64Ty_, elemSize), "u_ds");
+    llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "u_data");
+
+    // Copy all of set1
+    auto memcpyFn = getStdlibMemcpy();
+    llvm::Value *copy1Size = builder_.CreateMul(sf1.len, llvm::ConstantInt::get(i64Ty_, elemSize), "u_copy1_size");
+    builder_.CreateCall(memcpyFn, {newData, sf1.elems, copy1Size});
+
+    // Init header with len1
+    storeSetHeaderFields(newHeader, sf1.len, maxLen, newData);
+    llvm::Value *lenPtr = builder_.CreateStructGEP(setHeaderTy_, newHeader, 0, "u_len_ptr");
+
+    // Init buckets for the new set
+    emitBucketInit(newHeader, setHeaderTy_, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, 16);
+
+    // Re-hash all elements from set1 into new set's buckets
+    {
+        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "u_rehash_i");
+        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        llvm::BasicBlock *rCondBB = llvm::BasicBlock::Create(*ctx_, "u.rehash.cond", fn_);
+        llvm::BasicBlock *rBodyBB = llvm::BasicBlock::Create(*ctx_, "u.rehash.body", fn_);
+        llvm::BasicBlock *rEndBB = llvm::BasicBlock::Create(*ctx_, "u.rehash.end", fn_);
+        builder_.CreateBr(rCondBB);
+        builder_.SetInsertPoint(rCondBB);
+        llvm::Value *ri = builder_.CreateLoad(i64Ty_, iVar, "u_ri");
+        builder_.CreateCondBr(builder_.CreateICmpSLT(ri, sf1.len), rBodyBB, rEndBB);
+        builder_.SetInsertPoint(rBodyBB);
+        llvm::Value *ep = builder_.CreateGEP(elemTy, newData, {ri}, "u_rehash_ep");
+        llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "u_rehash_ev");
+        emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, ev, elemTy, ri);
+        builder_.CreateStore(builder_.CreateAdd(ri, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        builder_.CreateBr(rCondBB);
+        builder_.SetInsertPoint(rEndBB);
+    }
+
+    // Add elements from set2 that are not in set1
+    {
+        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "u_i2");
+        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+        llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "u.add.cond", fn_);
+        llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, "u.add.body", fn_);
+        llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "u.add.end", fn_);
+        builder_.CreateBr(condBB);
+        builder_.SetInsertPoint(condBB);
+        llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "u_ci");
+        builder_.CreateCondBr(builder_.CreateICmpSLT(i, sf2.len), bodyBB, endBB);
+        builder_.SetInsertPoint(bodyBB);
+        llvm::Value *ep = builder_.CreateGEP(elemTy, sf2.elems, {i}, "u_ep2");
+        llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "u_ev2");
+        if (!elemName.empty())
+            propagateTypeMeta(elemName, ev);
+
+        // Check if already in new set
+        llvm::Value *lookupIdx = emitSetElementLookup(newHeader, ev, elemTy, elemName);
+        llvm::Value *notFound = builder_.CreateICmpSLT(lookupIdx, llvm::ConstantInt::get(i64Ty_, 0), "u_not_found");
+        llvm::BasicBlock *addBB = llvm::BasicBlock::Create(*ctx_, "u.add.do", fn_);
+        llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, "u.add.next", fn_);
+        builder_.CreateCondBr(notFound, addBB, nextBB);
+
+        builder_.SetInsertPoint(addBB);
+        llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "u_cur_len");
+        llvm::Value *storePtr = builder_.CreateGEP(elemTy, newData, {curLen}, "u_store_ptr");
+        builder_.CreateStore(ev, storePtr);
+        emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, ev, elemTy, curLen);
+        builder_.CreateStore(builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1)), lenPtr);
+        builder_.CreateBr(nextBB);
+
+        builder_.SetInsertPoint(nextBB);
+        builder_.CreateStore(builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        builder_.CreateBr(condBB);
+        builder_.SetInsertPoint(endBB);
+    }
+
+    setTypeMeta(TypeMeta::SetElem, newHeader, elemTy);
+    if (!elemName.empty())
+        getOrCreateMeta(newHeader).set_elem_type_name = elemName;
+    return newHeader;
+}
+
 // union(set1, set2)
 llvm::Value *CodeGen::emitSetOp_union(const CallExpr &e) {
     if (e.args.size() != 2) return nullptr;
     llvm::Value *set1 = emitExpr(*e.args[0]);
     llvm::Value *set2 = emitExpr(*e.args[1]);
     llvm::Type *elemTy = getSetElementType(set1);
-    if (elemTy) {
-        llvm::Type *elemTy2 = getSetElementType(set2);
-        if (!elemTy2 || elemTy2 != elemTy)
-            codegenError("union() requires two sets with the same element type");
-        const ValueMetadata *set1Meta = getMeta(set1);
-        const std::string elemName = set1Meta ? set1Meta->set_elem_type_name : std::string{};
-        // Create new set with all elements from set1, then add elements from set2
-        auto sf1 = loadSetHeader(set1, "u1");
-        auto sf2 = loadSetHeader(set2, "u2");
-
-        const llvm::DataLayout &dl = mod_->getDataLayout();
-        uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-        auto mallocFn = getStdlibMalloc();
-
-        // Allocate max possible size (len1 + len2)
-        llvm::Value *maxLen = builder_.CreateAdd(sf1.len, sf2.len, "u_max_len");
-        llvm::Value *newHeader = emitArcAllocCollectionHeader(setHeaderTy_);
-        llvm::Value *dataSize = builder_.CreateMul(maxLen, llvm::ConstantInt::get(i64Ty_, elemSize), "u_ds");
-        llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "u_data");
-
-        // Copy all of set1
-        auto memcpyFn = getStdlibMemcpy();
-        llvm::Value *copy1Size = builder_.CreateMul(sf1.len, llvm::ConstantInt::get(i64Ty_, elemSize), "u_copy1_size");
-        builder_.CreateCall(memcpyFn, {newData, sf1.elems, copy1Size});
-
-        // Init header with len1
-        storeSetHeaderFields(newHeader, sf1.len, maxLen, newData);
-        llvm::Value *lenPtr = builder_.CreateStructGEP(setHeaderTy_, newHeader, 0, "u_len_ptr");
-
-        // Init buckets for the new set
-        emitBucketInit(newHeader, setHeaderTy_, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, 16);
-
-        // Re-hash all elements from set1 into new set's buckets
-        {
-            llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "u_rehash_i");
-            builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
-            llvm::BasicBlock *rCondBB = llvm::BasicBlock::Create(*ctx_, "u.rehash.cond", fn_);
-            llvm::BasicBlock *rBodyBB = llvm::BasicBlock::Create(*ctx_, "u.rehash.body", fn_);
-            llvm::BasicBlock *rEndBB = llvm::BasicBlock::Create(*ctx_, "u.rehash.end", fn_);
-            builder_.CreateBr(rCondBB);
-            builder_.SetInsertPoint(rCondBB);
-            llvm::Value *ri = builder_.CreateLoad(i64Ty_, iVar, "u_ri");
-            builder_.CreateCondBr(builder_.CreateICmpSLT(ri, sf1.len), rBodyBB, rEndBB);
-            builder_.SetInsertPoint(rBodyBB);
-            llvm::Value *ep = builder_.CreateGEP(elemTy, newData, {ri}, "u_rehash_ep");
-            llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "u_rehash_ev");
-            emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, ev, elemTy, ri);
-            builder_.CreateStore(builder_.CreateAdd(ri, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
-            builder_.CreateBr(rCondBB);
-            builder_.SetInsertPoint(rEndBB);
-        }
-
-        // Add elements from set2 that are not in set1
-        {
-            llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "u_i2");
-            builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
-            llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "u.add.cond", fn_);
-            llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, "u.add.body", fn_);
-            llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "u.add.end", fn_);
-            builder_.CreateBr(condBB);
-            builder_.SetInsertPoint(condBB);
-            llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "u_ci");
-            builder_.CreateCondBr(builder_.CreateICmpSLT(i, sf2.len), bodyBB, endBB);
-            builder_.SetInsertPoint(bodyBB);
-            llvm::Value *ep = builder_.CreateGEP(elemTy, sf2.elems, {i}, "u_ep2");
-            llvm::Value *ev = builder_.CreateLoad(elemTy, ep, "u_ev2");
-            if (!elemName.empty())
-                propagateTypeMeta(elemName, ev);
-
-            // Check if already in new set
-            llvm::Value *lookupIdx = emitSetElementLookup(newHeader, ev, elemTy, elemName);
-            llvm::Value *notFound = builder_.CreateICmpSLT(lookupIdx, llvm::ConstantInt::get(i64Ty_, 0), "u_not_found");
-            llvm::BasicBlock *addBB = llvm::BasicBlock::Create(*ctx_, "u.add.do", fn_);
-            llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, "u.add.next", fn_);
-            builder_.CreateCondBr(notFound, addBB, nextBB);
-
-            builder_.SetInsertPoint(addBB);
-            llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "u_cur_len");
-            llvm::Value *storePtr = builder_.CreateGEP(elemTy, newData, {curLen}, "u_store_ptr");
-            builder_.CreateStore(ev, storePtr);
-            emitBucketInsertAndRehashCheck(newHeader, setHeaderTy_, kSetLayout.lenIdx, kSetLayout.bucketCountIdx, kSetLayout.bucketsPtrIdx, ev, elemTy, curLen);
-            builder_.CreateStore(builder_.CreateAdd(curLen, llvm::ConstantInt::get(i64Ty_, 1)), lenPtr);
-            builder_.CreateBr(nextBB);
-
-            builder_.SetInsertPoint(nextBB);
-            builder_.CreateStore(builder_.CreateAdd(i, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
-            builder_.CreateBr(condBB);
-            builder_.SetInsertPoint(endBB);
-        }
-
-        setTypeMeta(TypeMeta::SetElem, newHeader, elemTy);
-        if (!elemName.empty())
-            getOrCreateMeta(newHeader).set_elem_type_name = elemName;
-        return newHeader;
-    }
-    return nullptr;
+    if (!elemTy)
+        return nullptr;
+    llvm::Type *elemTy2 = getSetElementType(set2);
+    if (!elemTy2 || elemTy2 != elemTy)
+        codegenError("union() requires two sets with the same element type");
+    return emitSetUnionCore(set1, set2, elemTy);
 }
 
 // intersection(set1, set2)

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1225,15 +1225,34 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
         }
     }
 
-    // Map/Set do not support '+'; catch here before the str-vs-non-str
-    // reject below, which misclassifies any pointer without metadata as a
-    // string and would emit a misleading diagnostic. List + List is
-    // handled above at line 1015. (#863)
+    // Map/Set collection operands for '+': merge, union, or named reject.
+    // Must precede the str-vs-non-str reject below. (#863, #866)
     if (op == "+") {
-        bool lhsIsMapOrSet =
-            getMapKeyType(lhs) || getMapValueType(lhs) || getSetElementType(lhs);
-        bool rhsIsMapOrSet =
-            getMapKeyType(rhs) || getMapValueType(rhs) || getSetElementType(rhs);
+        llvm::Type *lhsKeyTy  = getMapKeyType(lhs);
+        llvm::Type *rhsKeyTy  = getMapKeyType(rhs);
+        llvm::Type *lhsElemTy = getSetElementType(lhs);
+        llvm::Type *rhsElemTy = getSetElementType(rhs);
+
+        // Map + Map merge (rhs-wins on key collision)
+        if (lhsKeyTy && rhsKeyTy) {
+            llvm::Type *lhsValTy = getMapValueType(lhs);
+            llvm::Type *rhsValTy = getMapValueType(rhs);
+            if (!lhsValTy || !rhsValTy || lhsKeyTy != rhsKeyTy || lhsValTy != rhsValTy)
+                codegenError("type error: map merge requires matching key/value types");
+            return emitMapMergeCore(lhs, rhs, lhsKeyTy, lhsValTy);
+        }
+
+        // Set + Set union
+        if (lhsElemTy && rhsElemTy) {
+            if (lhsElemTy != rhsElemTy)
+                codegenError("type error: set union requires matching element types");
+            return emitSetUnionCore(lhs, rhs, lhsElemTy);
+        }
+
+        // Mixed / one-sided Map or Set: emit a named diagnostic before the
+        // generic str-vs-non-str path misclassifies the pointer operand.
+        bool lhsIsMapOrSet = lhsKeyTy || getMapValueType(lhs) || lhsElemTy;
+        bool rhsIsMapOrSet = rhsKeyTy || getMapValueType(rhs) || rhsElemTy;
         if (lhsIsMapOrSet || rhsIsMapOrSet) {
             std::string lhsName = inferCollectionTypeName(lhs);
             std::string rhsName = inferCollectionTypeName(rhs);

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -544,6 +544,56 @@ describe("Map", ():
     expect(m3["a"]).to_eq(1)
     expect(m3).to_have_length(1)
   )
+  it("should merge with + operator", ():
+    m1 = {"a": 1, "b": 2}
+    m2 = {"b": 99, "c": 3}
+    m3 = m1 + m2
+    expect(m3["a"]).to_eq(1)
+    expect(m3["b"]).to_eq(99)
+    expect(m3["c"]).to_eq(3)
+    expect(m3).to_have_length(3)
+  )
+  it("should merge with += operator", ():
+    m = {"a": 1, "b": 2}
+    m += {"b": 99, "c": 3}
+    expect(m["a"]).to_eq(1)
+    expect(m["b"]).to_eq(99)
+    expect(m["c"]).to_eq(3)
+    expect(m).to_have_length(3)
+  )
+  it("should leave operands unchanged after +", ():
+    m1 = {"a": 1}
+    m2 = {"b": 2}
+    m3 = m1 + m2
+    expect(m1).to_have_length(1)
+    expect(m2).to_have_length(1)
+    expect(m3).to_have_length(2)
+  )
+  it("should merge empty map on left with +", ():
+    m1 = {"x": 1}
+    remove(m1, "x")
+    m2 = {"a": 1}
+    m3 = m1 + m2
+    expect(m3).to_have_length(1)
+    expect(m3["a"]).to_eq(1)
+  )
+  it("should merge empty map on right with +", ():
+    m1 = {"a": 1}
+    m2 = {"x": 1}
+    remove(m2, "x")
+    m3 = m1 + m2
+    expect(m3).to_have_length(1)
+    expect(m3["a"]).to_eq(1)
+  )
+  it("should agree with merge() function for + operator", ():
+    m1 = {"a": 1, "b": 2}
+    m2 = {"b": 99, "c": 3}
+    via_op = m1 + m2
+    via_fn = merge(m1, m2)
+    expect(via_op["a"]).to_eq(via_fn["a"])
+    expect(via_op["b"]).to_eq(via_fn["b"])
+    expect(via_op["c"]).to_eq(via_fn["c"])
+  )
 )
 
 describe("Set", ():
@@ -663,6 +713,50 @@ describe("Set", ():
     b = {1}
     remove(b, 1)
     expect(is_superset(a, b)).to_be_true()
+  )
+  it("should compute union with + operator", ():
+    s1 = {1, 2, 3}
+    s2 = {3, 4, 5}
+    s3 = s1 + s2
+    expect(s3).to_have_length(5)
+    expect(s3).to_contain(1)
+    expect(s3).to_contain(5)
+  )
+  it("should compute union with += operator", ():
+    s = {1, 2, 3}
+    s += {3, 4, 5}
+    expect(s).to_have_length(5)
+    expect(s).to_contain(4)
+  )
+  it("should leave operands unchanged after +", ():
+    s1 = {1, 2}
+    s2 = {3, 4}
+    s3 = s1 + s2
+    expect(s1).to_have_length(2)
+    expect(s2).to_have_length(2)
+    expect(s3).to_have_length(4)
+  )
+  it("should compute union with empty set on left using +", ():
+    s1 = {1}
+    remove(s1, 1)
+    s2 = {1, 2}
+    s3 = s1 + s2
+    expect(s3).to_have_length(2)
+  )
+  it("should compute union with empty set on right using +", ():
+    s1 = {1, 2}
+    s2 = {1}
+    remove(s2, 1)
+    s3 = s1 + s2
+    expect(s3).to_have_length(2)
+  )
+  it("should agree with union() function for + operator", ():
+    s1 = {1, 2, 3}
+    s2 = {3, 4, 5}
+    via_op = s1 + s2
+    via_fn = union(s1, s2)
+    expect(via_op).to_have_length(5)
+    expect(via_fn).to_have_length(5)
   )
 )
 

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -757,6 +757,10 @@ describe("Set", ():
     via_fn = union(s1, s2)
     expect(via_op).to_have_length(5)
     expect(via_fn).to_have_length(5)
+    expect(via_op).to_contain(1)
+    expect(via_op).to_contain(5)
+    expect(via_fn).to_contain(1)
+    expect(via_fn).to_contain(5)
   )
 )
 

--- a/tests/spec/compound_assign_arc_element.test.ry
+++ b/tests/spec/compound_assign_arc_element.test.ry
@@ -76,3 +76,36 @@ describe("compound assignment through chained LHS", ():
     expect(b.items[1]).to_eq([2, 3])
   )
 )
+
+describe("compound assignment on ARC-managed map/set element slots (issue #866)", ():
+  it("List<Map<str, int>> xs[i] += literal merges", ():
+    xs: List<Map<str, int>> = [{"a": 1}]
+    xs[0] += {"b": 2}
+    expect(xs[0]["a"]).to_eq(1)
+    expect(xs[0]["b"]).to_eq(2)
+    expect(xs[0]).to_have_length(2)
+  )
+
+  it("List<Map<str, int>> xs[i] += variable preserves variable", ():
+    xs: List<Map<str, int>> = [{"a": 1}]
+    other: Map<str, int> = {"b": 2}
+    xs[0] += other
+    expect(xs[0]).to_have_length(2)
+    expect(other).to_have_length(1)
+  )
+
+  it("List<Set<int>> xs[i] += literal unions", ():
+    xs: List<Set<int>> = [{1, 2}]
+    xs[0] += {3}
+    expect(xs[0]).to_have_length(3)
+    expect(xs[0]).to_contain(3)
+  )
+
+  it("List<Set<int>> xs[i] += variable preserves variable", ():
+    xs: List<Set<int>> = [{1}]
+    other: Set<int> = {2, 3}
+    xs[0] += other
+    expect(xs[0]).to_have_length(3)
+    expect(other).to_have_length(2)
+  )
+)

--- a/tests/spec/compound_assign_arc_field.test.ry
+++ b/tests/spec/compound_assign_arc_field.test.ry
@@ -100,3 +100,57 @@ describe("compound assignment with nested ARC element types", ():
     expect(ys).to_eq([[2, 3], [4]])
   )
 )
+
+record MapBox:
+  items: Map<str, int>
+
+record SetBox:
+  items: Set<int>
+
+describe("compound assignment for Map field using += (issue #866)", ():
+  it("b.items += literal merges into the map field", ():
+    b = MapBox({"a": 1})
+    b.items += {"b": 2}
+    expect(b.items["a"]).to_eq(1)
+    expect(b.items["b"]).to_eq(2)
+    expect(b.items).to_have_length(2)
+  )
+
+  it("rhs-wins on key collision for map field +=", ():
+    b = MapBox({"a": 1})
+    b.items += {"a": 99}
+    expect(b.items["a"]).to_eq(99)
+    expect(b.items).to_have_length(1)
+  )
+
+  it("b.items += variable preserves variable", ():
+    b = MapBox({"a": 1})
+    other: Map<str, int> = {"b": 2}
+    b.items += other
+    expect(b.items).to_have_length(2)
+    expect(other).to_have_length(1)
+  )
+)
+
+describe("compound assignment for Set field using += (issue #866)", ():
+  it("b.items += literal unions into the set field", ():
+    b = SetBox({1, 2})
+    b.items += {3, 4}
+    expect(b.items).to_have_length(4)
+    expect(b.items).to_contain(3)
+  )
+
+  it("duplicate elements are not added for set field +=", ():
+    b = SetBox({1, 2, 3})
+    b.items += {2, 3}
+    expect(b.items).to_have_length(3)
+  )
+
+  it("b.items += variable preserves variable", ():
+    b = SetBox({1})
+    other: Set<int> = {2, 3}
+    b.items += other
+    expect(b.items).to_have_length(3)
+    expect(other).to_have_length(2)
+  )
+)

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -247,28 +247,37 @@ TEST_F(CodeGenTest, NamedArgsOnNonBuiltinError) {
 }
 
 // ============================================================
-// `+` on Map / Set / mixed collection operands must produce a
-// type-aware error that names the actual collection type.  Before
-// #863 these operations fell through to the str-vs-non-str reject
-// path and surfaced a misleading "operator '+' not supported between
-// str and non-str types" message, which is actively wrong for
-// Map + Map.  These tests pin the corrected diagnostics.
+// `+` on Map / Set collection operands: type-aware diagnostics.
+// Before #863 these fell through to the str-vs-non-str reject path.
+// After #866 Map + Map (merge) and Set + Set (union) are supported,
+// but mismatched types must still produce a clear diagnostic.
 // ============================================================
 
-TEST_F(CodeGenTest, ArithPlusRejectsMapPlusMap) {
+TEST_F(CodeGenTest, ArithPlusRejectsMapPlusMapKeyMismatch) {
+    // Different key types → error
     expectCompileError(
         "a: Map<str, int> = {\"a\": 1}\n"
-        "b: Map<str, int> = {\"b\": 2}\n"
+        "b: Map<int, int> = {2: 2}\n"
         "c = a + b\n",
-        "operator '+' is not defined for Map<str, int> and Map<str, int>");
+        "map merge requires matching key/value types");
 }
 
-TEST_F(CodeGenTest, ArithPlusRejectsSetPlusSet) {
+TEST_F(CodeGenTest, ArithPlusRejectsMapPlusMapValueMismatch) {
+    // Different value types → error
+    expectCompileError(
+        "a: Map<str, int> = {\"a\": 1}\n"
+        "b: Map<str, str> = {\"b\": \"x\"}\n"
+        "c = a + b\n",
+        "map merge requires matching key/value types");
+}
+
+TEST_F(CodeGenTest, ArithPlusRejectsSetPlusSetElemMismatch) {
+    // Different element types → error
     expectCompileError(
         "a: Set<int> = {1}\n"
-        "b: Set<int> = {2}\n"
+        "b: Set<str> = {\"x\"}\n"
         "c = a + b\n",
-        "operator '+' is not defined for Set<int> and Set<int>");
+        "set union requires matching element types");
 }
 
 TEST_F(CodeGenTest, ArithPlusRejectsListPlusMap) {


### PR DESCRIPTION
## Summary

- Adds `Map<K,V> + Map<K,V>` (merge, rhs-wins on key collision) and `Set<T> + Set<T>` (union) support via the `+` and `+=` operators, parallel to existing `List + List` concatenation
- Extracts `emitMapMergeCore` / `emitSetUnionCore` helpers shared by both the `BinaryExpr` (`+`) and `CallExpr` (`merge()` / `union()`) dispatch paths
- The `+=` compound-assignment form works automatically via the existing `applyCompoundOp` path; ARC paths through record fields and collection element slots are verified by tests

## Details

**New behavior**
```ry
m1 = {"a": 1, "b": 2}
m2 = {"b": 99, "c": 3}
m3 = m1 + m2      # {"a": 1, "b": 99, "c": 3}  ← rhs-wins
m1 += m2          # same as m1 = m1 + m2

s1 = {1, 2, 3}
s2 = {3, 4, 5}
s3 = s1 + s2      # {1, 2, 3, 4, 5}
s1 += s2          # same as s1 = s1 + s2
```

**Changes**
- `src/codegen_expr.cpp` — unified `+` dispatch block: Map merge, Set union, mixed-type reject (eliminates repeated `getMapKeyType`/`getSetElementType` calls)
- `src/codegen_call_collection.cpp` — extracted `emitMapMergeCore`; `emitCollOp_merge` becomes a thin validator wrapper
- `src/codegen_call_set_ops.cpp` — extracted `emitSetUnionCore`; `emitSetOp_union` becomes a thin wrapper
- `include/ry/codegen.hpp` — declarations for the two new core helpers
- `tests/test_codegen_fail.cpp` — replaced "rejects Map+Map / Set+Set" tests with type-mismatch diagnostic tests
- `tests/spec/collections.test.ry` — 12 new tests for `+` and `+=` on Map and Set
- `tests/spec/compound_assign_arc_field.test.ry` — 6 new tests for Map/Set record field `+=`
- `tests/spec/compound_assign_arc_element.test.ry` — 4 new tests for `List<Map>`/`List<Set>` element `+=`
- `docs/reference/operators.md` / `docs/reference/collections.md` / `README.md` — updated docs

## Test plan

- [x] `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p` — 1654 C++ tests + 119 Ry spec files, 0 failures
- [x] ASan + UBSan clean (`cmake --preset asan`)
- [x] TSan clean — C++ tests required pass (`cmake --preset tsan`)
- [x] Semantics spot-checked: operands unchanged after `+`, rhs-wins on collision, union deduplication

Closes #866

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Map merge: `+`/`+=` merge maps (rhs wins on key collisions).
  * Set union: `+`/`+=` compute set unions.

* **Documentation**
  * Updated operator and collection references and README with examples and type rules for collection arithmetic and `+=`.

* **Tests**
  * Added/updated tests validating `+`/`+=` semantics for maps, sets, and compound-assignment cases.

* **Changelog**
  * Entry documenting `Map + Map` and `Set + Set` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->