### PR TITLE
fix: rebuild collection metadata after ExtractValue in Option equality (#982)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1692,6 +1692,33 @@ Guard the call with `!elemName.empty() && elemName != "str"` — `str` elements 
 plain `char*` pointers that `isStringValue` already handles correctly without
 metadata, and the type name may be empty for untyped string literals.
 
+### ExtractValue on Option<Collection> inner field drops metadata — rebuild before recursive comparison
+
+**Source**: #982 (2026-04-16, bugfix)
+**Tags**: codegen, metadata, equality, option, collection, emitComparisonOp, ExtractValue
+
+**Rule**: `builder_.CreateExtractValue(optVal, 1)` to read the inner value from an
+`Option<T>` struct produces a fresh SSA value with no entry in `value_metadata_`,
+exactly like a GEP-loaded pointer. For `Option<List<T>>`, `Option<Map<K,V>>`, and
+`Option<Set<T>>`, the inner LLVM type is `ptrTy_`. Without metadata, the recursive
+`emitComparisonOp` call falls through to the `isStringValue` + `strcmp` path and
+produces false-positive equality.
+
+**Why**: `buildSomeValue` calls `propagateMeta(inner, optVal)`, so the outer `Option`
+aggregate already carries `list_elem_type_name` / `map_*_type_name` / `set_elem_type_name`.
+The extracted inner is an orphan: there is no automatic metadata inheritance from the
+containing aggregate.
+
+**How to apply**: After extracting the inner values, check whether `innerTy == ptrTy_`.
+If so, call `buildTypeNameFromMeta(lhs)` (or `rhs` as fallback) to snapshot the inner
+type name, then `propagateTypeMeta(innerName, lhsInner)` + `propagateMeta(lhsInner, rhsInner)`
+before the recursive comparison. Guard with `!innerName.empty() && innerName != "str"`.
+Snapshot into a local `std::string` **before** calling `propagateTypeMeta` to avoid
+rehash-invalidation of `ValueMetadata *` pointers (see #858 gotcha).
+
+This same class of bug can arise wherever `CreateExtractValue` is used on a struct
+that wraps a collection pointer (e.g., `Result<Collection, E>` Ok/Err payloads).
+
 ### Empty collection literal early-return in codegen_stmt.cpp does not propagate closure/nested-type metadata
 
 **Source**: #958 (2026-04-15, implementation)

--- a/changelog.d/982-option-collection-equality.md
+++ b/changelog.d/982-option-collection-equality.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `Option<List<T>>`, `Option<Map<K, V>>`, and `Option<Set<T>>` equality no
+  longer returns a false-positive `true` when inner collections share a byte
+  prefix; inner values are now compared element-wise. (#982)

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -441,6 +441,19 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
         builder_.SetInsertPoint(cmpInnerBB);
         llvm::Value *lhsInner = builder_.CreateExtractValue(lhs, 1, "opt_l_inner");
         llvm::Value *rhsInner = builder_.CreateExtractValue(rhs, 1, "opt_r_inner");
+
+        // Option<Collection>: ExtractValue loses ValueMetadata; rebuild from outer aggregate.
+        // Snapshot name before propagateTypeMeta — it may rehash value_metadata_.
+        if (llvm::cast<llvm::StructType>(lhs->getType())->getElementType(1) == ptrTy_) {
+            std::string innerName = buildTypeNameFromMeta(lhs);
+            if (innerName.empty())
+                innerName = buildTypeNameFromMeta(rhs);
+            if (!innerName.empty() && innerName != "str") {
+                propagateTypeMeta(innerName, lhsInner);
+                propagateMeta(lhsInner, rhsInner);
+            }
+        }
+
         llvm::Value *innerEq  = emitComparisonOp("==", lhsInner, rhsInner, "", "");
         llvm::BasicBlock *cmpDoneBB = builder_.GetInsertBlock();
         builder_.CreateBr(mergeBB);

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -102,6 +102,17 @@ describe("equality — Option with collection inner types", ():
     b: List<str>? = Some(["world"])
     expect(a == b).to_be_false()
   )
+  # Matcher-level regression: to_eq / to_not_eq delegate to emitComparisonOp
+  # and Option<Collection> was previously excluded due to the metadata-loss bug (#982)
+  it("matcher to_eq works for equal Some(List<int>)", ():
+    a: List<int>? = Some([1, 2, 3])
+    b: List<int>? = Some([1, 2, 3])
+    expect(a).to_eq(b)
+  )
+  it("matcher to_not_eq works for differing Some(List<int>)", ():
+    a: List<int>? = Some([1, 2, 3])
+    expect(a).to_not_eq(Some([9, 9]))
+  )
 )
 
 function res_ok(v: int) -> Result<int, Error>:

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -44,6 +44,66 @@ describe("equality — Option", ():
   )
 )
 
+describe("equality — Option with collection inner types", ():
+  # Option<List<int>> (#982)
+  it("should consider Some equal List<int> values equal", ():
+    a: List<int>? = Some([1, 2, 3])
+    b: List<int>? = Some([1, 2, 3])
+    expect(a == b).to_be_true()
+  )
+  it("should consider Some differing List<int> values unequal", ():
+    a: List<int>? = Some([1, 2])
+    b: List<int>? = Some([9, 9])
+    expect(a == b).to_be_false()
+    expect(a != b).to_be_true()
+  )
+  it("should consider Some(list) unequal to none", ():
+    a: List<int>? = Some([1])
+    b: List<int>? = none
+    expect(a != b).to_be_true()
+  )
+  it("should consider two none List<int>? equal", ():
+    a: List<int>? = none
+    b: List<int>? = none
+    expect(a == b).to_be_true()
+  )
+  # Option<Map<str, int>> (#982)
+  it("should consider Some equal Map<str, int> values equal", ():
+    a: Map<str, int>? = Some({"x": 1, "y": 2})
+    b: Map<str, int>? = Some({"x": 1, "y": 2})
+    expect(a == b).to_be_true()
+  )
+  it("should consider Some differing Map<str, int> values unequal", ():
+    a: Map<str, int>? = Some({"x": 1})
+    b: Map<str, int>? = Some({"x": 9})
+    expect(a == b).to_be_false()
+    expect(a != b).to_be_true()
+  )
+  # Option<Set<int>> (#982)
+  it("should consider Some equal Set<int> values equal", ():
+    a: Set<int>? = Some({1, 2, 3})
+    b: Set<int>? = Some({3, 2, 1})
+    expect(a == b).to_be_true()
+  )
+  it("should consider Some differing Set<int> values unequal", ():
+    a: Set<int>? = Some({1, 2})
+    b: Set<int>? = Some({1, 9})
+    expect(a == b).to_be_false()
+    expect(a != b).to_be_true()
+  )
+  # Option<List<str>> (#982)
+  it("should consider Some equal List<str> values equal", ():
+    a: List<str>? = Some(["hello", "world"])
+    b: List<str>? = Some(["hello", "world"])
+    expect(a == b).to_be_true()
+  )
+  it("should consider Some differing List<str> values unequal", ():
+    a: List<str>? = Some(["hello"])
+    b: List<str>? = Some(["world"])
+    expect(a == b).to_be_false()
+  )
+)
+
 function res_ok(v: int) -> Result<int, Error>:
   return Ok(v)
 function res_err(msg: str) -> Result<int, Error>:


### PR DESCRIPTION
## Summary

- `Option<List<T>>`, `Option<Map<K,V>>`, and `Option<Set<T>>` equality previously returned false-positive `true` when inner collections shared a byte prefix (e.g. `Some([1, 2]) == Some([9, 9])`)
- Root cause: `CreateExtractValue(lhs, 1)` produces a fresh SSA value with no entry in `value_metadata_`; without metadata the recursive comparison fell through to `isStringValue` + `strcmp`
- Fix: after extracting the inner values, if the inner type is `ptrTy_`, snapshot the collection type name from the outer Option aggregate (`buildSomeValue` already propagates it via `propagateMeta`) and call `propagateTypeMeta` + `propagateMeta` to restore it — mirroring the union variant path

Closes #982

## Test plan

- [ ] New `describe("equality — Option with collection inner types")` block covers `Option<List<int>>`, `Option<Map<str,int>>`, `Option<Set<int>>`, `Option<List<str>>` — equal and unequal pairs, `Some` vs `none`
- [ ] `./build/ry_tests` — 1654 tests passed
- [ ] `./build/ry test -p` — 119 files, 0 failures
- [ ] ASan + UBSan — clean
- [ ] TSan C++ tests — clean

## Out of scope

t0k0sh1/ry#985 — same bug in `Result<Collection, E>` equality (filed separately, same milestone)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Equality for Option types wrapping collections (List, Map, Set) now compares inner collections element-wise, avoiding false-positive equalities.

* **Documentation**
  * Added a knowledge entry describing the root cause and mitigation for metadata loss affecting Option-with-collection comparisons.

* **Tests**
  * Added test suite covering equality cases for Option<List>, Option<Map>, Option<Set> (Some vs Some, Some vs none, none vs none).

* **Chores**
  * Added changelog entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->