### PR TITLE
fix(codegen): add ptr-shape validation guards for set element type mismatches (#987)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -999,6 +999,39 @@ set/map literal emitter), so downstream callers can retrieve it via `getMeta`.
 `emitSubsetCheck` (`src/codegen_call_set_ops.cpp`) already follows this
 pattern correctly for sets and is the canonical reference.
 
+### Defensive ptr-shape validation guards are unreachable from Ry source — no regression test required
+
+**Source**: #987 (2026-04-16, fix)
+**Tags**: codegen, collections, set, defensive, testing
+
+**Context**: #987 added a guard at each of the five `emitSetElementLookup`
+call sites that pass `ptrTy_` elements: after reading `elemName` from
+`getSetElemName`, the guard calls `inferCollectionTypeName(elem)` and emits
+`codegenError` if the two names differ (e.g. element is `Map<str,int>` but
+set expects `List<int>`).
+
+These branches are **unreachable from Ry source** today: the Ry type checker
+rejects a kind-mismatch before codegen is reached, and no unsafe-cast
+operator exists to bypass it. A Ry-source-level regression test therefore
+cannot be written without access to a type-checking bypass.
+
+**Decision**: ship the guards without regression tests, consistent with
+commit 136166b which added the sibling set-literal consistency guard under
+the same reasoning. Instead, document here so a future reader does not:
+- waste time trying to write a Ry snippet that triggers the branch, or
+- conclude that the branches are dead and remove them.
+
+Affected sites (all in `codegen_call_collection.cpp`, `codegen_call_string.cpp`,
+`codegen_expr.cpp`, and `codegen_expr_literal.cpp`):
+- `emitCollOp_add` — `"add(): element type mismatch: expected '...', got '...'"`
+- `emitSetRemove` — `"remove(): element type mismatch: ..."`
+- `emitStrOp_contains` Set path — `"contains(): element type mismatch: ..."`
+- `in`/`not in` Set branch — `"'in'/'not in' operator: element type mismatch: ..."`
+- `emitSetLiteral` (commit 136166b) — `"set literal has inconsistent element types: '...' vs '...'"`
+
+**If a reachable path is found** (e.g. via a future union type edge case), add
+a direct Ry-source regression test per AGENTS.md and remove this exception entry.
+
 ---
 
 ## Parser / Lexer

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -865,6 +865,13 @@ public:
     // Type-name accessors — return "" when metadata is absent
     std::string getSetElemName(llvm::Value *setPtr) const;
 
+    // Validate that elem (ptrTy_) matches the container's expected collection type
+    // name, then propagate type metadata.  No-op when elemName is empty (primitive
+    // element types don't carry a name).  errorContext is the operator/function
+    // name used in the error message (e.g. "add()", "'in' operator").
+    void validateSetElemType(const std::string &elemName, llvm::Value *elem,
+                             const std::string &errorContext);
+
     // Unified propagation (replaces propagateCollectionMetadata + propagateResourceTracking)
     void propagateMeta(llvm::Value *src, llvm::Value *dst);
     void propagateMetaWide(llvm::Value *src, llvm::Value *dst);

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -51,8 +51,7 @@ llvm::Value *CodeGen::emitCollOp_add(const CallExpr &e) {
             codegenError("add() element type mismatch");
 
         std::string addElemName = getSetElemName(setPtr);
-        if (!addElemName.empty())
-            propagateTypeMeta(addElemName, elem);
+        validateSetElemType(addElemName, elem, "add()");
         llvm::Value *idx = emitSetElementLookup(setPtr, elem, elemTy, addElemName);
         llvm::Value *found = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "found");
 
@@ -153,8 +152,7 @@ void CodeGen::emitHashTableUpdateIndex(
 
 llvm::Value *CodeGen::emitSetRemove(llvm::Value *containerPtr, llvm::Value *elem, llvm::Type *elemTy) {
     std::string rmElemName = getSetElemName(containerPtr);
-    if (!rmElemName.empty())
-        propagateTypeMeta(rmElemName, elem);
+    validateSetElemType(rmElemName, elem, "remove()");
     llvm::Value *idx = emitSetElementLookup(containerPtr, elem, elemTy, rmElemName);
     llvm::Value *found = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "found");
 

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -63,8 +63,7 @@ llvm::Value *CodeGen::emitStrOp_contains(const CallExpr &e) {
         if (elem->getType() != setElemTy)
             codegenError("contains() element type mismatch");
         std::string cElemName = getSetElemName(s);
-        if (!cElemName.empty())
-            propagateTypeMeta(cElemName, elem);
+        validateSetElemType(cElemName, elem, "contains()");
         llvm::Value *idx = emitSetElementLookup(s, elem, setElemTy, cElemName);
         return builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "set_contains");
     }

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1404,8 +1404,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
             if (elem->getType() != setElemTy)
                 codegenError("'" + e->op + "' operator: element type mismatch");
             std::string inElemName = getSetElemName(container);
-            if (!inElemName.empty())
-                propagateTypeMeta(inElemName, elem);
+            validateSetElemType(inElemName, elem, "'" + e->op + "' operator");
             llvm::Value *idx = emitSetElementLookup(container, elem, setElemTy, inElemName);
             llvm::Value *result = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "set_in");
             if (e->op == "not in")

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -94,6 +94,18 @@ std::string CodeGen::getSetElemName(llvm::Value *setPtr) const {
     return meta ? meta->set_elem_type_name : std::string{};
 }
 
+void CodeGen::validateSetElemType(const std::string &elemName, llvm::Value *elem,
+                                   const std::string &errorContext) {
+    if (elemName.empty()) return;
+    if (elem->getType() == ptrTy_) {
+        std::string actualName = inferCollectionTypeName(elem);
+        if (!actualName.empty() && actualName != elemName)
+            codegenError(errorContext + ": element type mismatch: expected '" +
+                         elemName + "', got '" + actualName + "'");
+    }
+    propagateTypeMeta(elemName, elem);
+}
+
 // ======== TypeMeta convenience ========
 
 void CodeGen::setTypeMeta(TypeMeta kind, llvm::Value *val, llvm::Type *ty) {


### PR DESCRIPTION
## Summary

- Add defensive `codegenError` guards at the four `emitSetElementLookup` call sites where a pointer-typed element could silently bypass collection-kind type checking: `emitCollOp_add`, `emitSetRemove`, `emitStrOp_contains` (Set path), and the `in`/`not in` operator Set branch
- Each guard calls `inferCollectionTypeName(elem)` and compares against the container's `set_elem_type_name`; a kind mismatch (e.g. `Map<str,int>` passed to `Set<List<int>>`) now produces a clear `codegenError` instead of silently building malformed IR
- Extract the repeated 7-line validation pattern into `validateSetElemType(elemName, elem, errorContext)` in `codegen_metadata.cpp`, reducing each call site to one line
- Add `KNOWLEDGE.md` entry documenting that these guards are unreachable from Ry source (type checker prevents kind-mismatches), so no regression test is required — consistent with the sibling guard added in commit 136166b

## Test plan

- [x] `cmake --preset default && cmake --build build` — clean build, no warnings
- [x] `./build/ry_tests` — 1654 tests passed
- [x] `./build/ry test -p` — 119 test files, 0 failures
- [x] ASan+UBSan: `./build-asan/ry_tests` — 1653 tests passed; `./build-asan/ry test -p` — 119 files, 0 failures
- [x] TSan: `./build-tsan/ry_tests` — 1654 tests passed
- [x] Smoke test: `Set<List<int>>` with `add`, `in`, `contains`, `remove` all return correct results and do not false-positive on the new guard

Closes #987

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added knowledge base entry documenting type validation patterns for set-element operations.

* **Refactor**
  * Consolidated type validation logic for set elements across collection operations (add, remove, contains) and comparison operators (in/not-in) for consistent error detection and messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->