### PR TITLE
feat: tuple destructuring patterns in case statements and expressions (#834)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1765,3 +1765,29 @@ workflows is fragile.
 **How to apply**: In scheduled workflows that dynamically check out a branch, replace the
 conditional `save:` expression with `save: true` (always save) or compute the condition from
 the resolved `ref` output rather than `github.ref_name`.
+
+### Tuple pattern in `case`: per-element metadata via `splitTypeArgs`
+
+**Source**: #834 (2026-04-16, implementation)
+**Tags**: codegen, pattern, tuple, metadata, case, splitTypeArgs
+
+**Rule**: When emitting a `TuplePattern` in `emitPatternTest` / `emitPatternBindings`, the subject's type signature arrives as a `"(T1, T2, ...)"` string in `subjectEnumType`. Strip the outer parentheses and call `splitTypeArgs(inner)` to obtain per-element signatures. Pass each element's signature as the `subjectEnumType` argument in the recursive `emitPatternTest` / `emitPatternBindings` calls so that nested Option/Result/generic patterns can resolve their metadata correctly.
+
+**Why**: `propagateTypeMeta` (KNOWLEDGE.md entry at ~L420) is deliberately single-purpose and does not decompose tuple type strings. The correct decomposition point is the `TuplePattern` codegen arm itself, mirroring the existing `emitTupleDestructure` helper in `codegen_stmt_loop.cpp`.
+
+**How to apply**: When a future pattern type (e.g., positional record `Point(a, b)`) also needs per-element metadata, use the same pattern: strip the outer delimiters, split with `splitTypeArgs`, and feed each component signature into the recursive call. Do NOT extend `propagateTypeMeta` to handle composite type strings.
+
+### Tuple pattern `parsePattern`: same ambiguity resolution as expression parser
+
+**Source**: #834 (2026-04-16, implementation)
+**Tags**: parser, pattern, tuple, grouping, ambiguity
+
+**Rule**: The `parsePattern` `LParen` branch uses the same grouping-vs-tuple disambiguation as the expression parser (`src/parser_expr.cpp`):
+- `()` → rejected ("zero-tuple pattern not supported")
+- `(p)` (no comma) → grouping, returns the inner pattern unwrapped
+- `(p,)` → 1-tuple `TuplePattern` with one element
+- `(p1, p2, ...)` → N-tuple `TuplePattern`
+
+**Why**: Keeping expression and pattern parsers consistent avoids user confusion (grouping `(p)` behaves the same in both contexts) and makes future record / enum-payload pattern parsers easier to cross-reference.
+
+**How to apply**: When adding the next pattern type that starts with `(` (e.g., positional record `Point(a, b)` — note that starts with `Ident LParen`, not bare `LParen`), keep the bare-`LParen` branch as tuple-only and handle `Ident LParen` in a separate branch.

--- a/changelog.d/834-tuple-patterns.md
+++ b/changelog.d/834-tuple-patterns.md
@@ -1,0 +1,3 @@
+### Added
+
+- Tuple destructuring patterns in `case` statements and expressions (#834). Supports binding patterns `(a, b)`, literal patterns `(1, 2)`, mixed `(1, n)`, wildcard `(_, n)`, 1-tuples `(v,)`, guard clauses `(a, b) if a > b`, and nested patterns such as `(Some(v), _)`. A fully irrefutable tuple pattern (all elements are variables or `_`) is treated as exhaustive.

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -612,6 +612,15 @@ case pair2:
 
 **Exhaustiveness**: A tuple pattern where every element is a variable or `_` (irrefutable) is treated as exhaustive — no wildcard arm is required.
 
+**Syntax rules**:
+
+| Syntax | Meaning |
+|--------|---------|
+| `(a, b)` | 2-tuple pattern |
+| `(v,)` | 1-tuple pattern — the trailing comma is required |
+| `(p)` | Grouping — equivalent to just `p`; **not** a 1-tuple |
+| `()` | Not supported (parse error) |
+
 **Restrictions**: Variable bindings are not allowed inside OR patterns. `(1, x) | (2, y)` is rejected at parse time.
 
 ### Expression Forms

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -448,6 +448,7 @@ case expression:
 | `None` | `None` | When Option has no value |
 | `Ok(x)` | `Ok(v)` | When Result is Ok, binds the inner value |
 | `Err(x)` | `Err(e)` | When Result is Err, binds the error value |
+| Tuple pattern | `(a, b)`, `(1, n)` | Matches a tuple by element; binds, tests literals, or ignores (`_`) each position |
 | OR pattern | `1 \| 2 \| 3` | Matches if any alternative matches |
 
 ### Guard Clause
@@ -560,6 +561,59 @@ case s:
 
 Multi-field variants bind each field to a separate name in declaration order.
 
+### Tuple Pattern Matching
+
+Tuple patterns destructure a tuple subject by element position. Each element may be a variable binding, a literal, or a wildcard (`_`). Nested patterns (e.g., `Some(v)` inside a tuple element) are also supported.
+
+```python
+# Binding pattern — bind both elements
+t = (10, 20)
+case t:
+    (x, y):
+        print(x)   # 10
+        print(y)   # 20
+
+# Mixed literal + binding
+point = (0, 99)
+case point:
+    (0, n):
+        print(n)   # 99
+    _:
+        print("other")
+
+# Wildcard
+pair = (55, 77)
+case pair:
+    (_, second):
+        print(second)  # 77
+
+# Guard clause
+case t:
+    (a, b) if a > b:
+        print("first bigger")
+    (a, b):
+        print("other")
+
+# 1-tuple (trailing comma required)
+single = (42,)
+case single:
+    (v,):
+        print(v)   # 42
+
+# Nested: Option inside a tuple
+opt: Option<int> = Some(7)
+pair2 = (opt, 0)
+case pair2:
+    (Some(v), _):
+        print(v)   # 7
+    (None, _):
+        print("none")
+```
+
+**Exhaustiveness**: A tuple pattern where every element is a variable or `_` (irrefutable) is treated as exhaustive — no wildcard arm is required.
+
+**Restrictions**: Variable bindings are not allowed inside OR patterns. `(1, x) | (2, y)` is rejected at parse time.
+
 ### Expression Forms
 
 Both `case:` and `case <expr>:` can be used as expressions by replacing `:` with `=>` in each arm. Each arm provides a single expression whose value becomes the result.
@@ -584,7 +638,7 @@ result = case expression:
     _ => default_value
 ```
 
-All patterns supported in `case:` statements are also supported in `case` expressions: literals, variable bindings, enums, ADT enums, `Some`/`None`, `Ok`/`Err`, OR patterns, guards, and wildcards.
+All patterns supported in `case:` statements are also supported in `case` expressions: literals, variable bindings, enums, ADT enums, `Some`/`None`, `Ok`/`Err`, tuple patterns, OR patterns, guards, and wildcards.
 
 `case` expressions must be exhaustive (same rules as `case:` statements).
 
@@ -619,12 +673,18 @@ area = case shape:
     Shape::Circle(r)  => 3.14 * r * r
     Shape::Rectangle(w, h) => w * h
     Shape::Point      => 0.0
+
+# Tuple pattern
+t = (3, 4)
+sum = case t:
+    (a, b) => a + b
+    _ => 0
 ```
 
 ### Scope Rules
 
 - Each `case` arm has its own block scope.
-- Variables bound by variable binding patterns (`n`), `Some(x)`, `Ok(v)`, or `Err(e)` are only valid within that arm.
+- Variables bound by variable binding patterns (`n`), `Some(x)`, `Ok(v)`, `Err(e)`, or tuple patterns `(a, b)` are only valid within that arm.
 
 ---
 

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -473,16 +473,20 @@ struct EnumConstructorPattern {
 };
 
 struct OrPattern;
+struct TuplePattern;  // elements may be nested Patterns (e.g. Some(v) inside a tuple)
 
 using Pattern = std::variant<
     WildcardPattern, LiteralPattern, VariablePattern,
     EnumPattern, SomePattern, NonePattern,
     OkPattern, ErrPattern,
     EnumConstructorPattern,
-    std::unique_ptr<OrPattern>
+    std::unique_ptr<OrPattern>,
+    std::unique_ptr<TuplePattern>
 >;
 
 struct OrPattern { std::vector<Pattern> alternatives; };
+// 1-tuple requires trailing comma: (a,).  Bare (p) without comma is grouping in the parser.
+struct TuplePattern { std::vector<Pattern> elements; };
 
 struct CaseArm {
     Pattern pattern;

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1188,6 +1188,7 @@ public:
     llvm::Value *buildErrValue(llvm::Value *inner, llvm::StructType *resultTy);
     llvm::Value *buildStaticError(const std::string &msg, const std::string &globalName);
     static std::vector<std::string> splitTypeArgs(const std::string &argsStr);
+    std::vector<std::string> splitTupleSig(const std::string &tupleTypeSig);
     static size_t findMatchingCloseParen(const std::string &s, size_t openParen);
     std::pair<llvm::Type*, llvm::Type*> parseMapTypeAnnotation(const std::string &typeStr);
     FnTypeInfo parseFnTypeAnnotation(const std::string &typeStr);

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -293,15 +293,19 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                 testResult = builder_.CreateOr(testResult, altResult, "or.comb");
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
+            const std::vector<std::string> elemSigs = splitTupleSig(subjectEnumType);
             auto *sTy = llvm::dyn_cast<llvm::StructType>(subjectTy);
-            if (!sTy)
+            // Reject if: not a struct, OR the Ry type is known but not a tuple
+            // signature (e.g. Option<T>, Result<T,E>, a record, an ADT enum).
+            // When subjectEnumType is empty (unannotated variable), the LLVM struct
+            // check alone is sufficient — we have no type name to discriminate.
+            if (!sTy || (!subjectEnumType.empty() && elemSigs.empty()))
                 codegenError("case: tuple pattern applied to non-tuple subject");
             if (sTy->getNumElements() != pat->elements.size())
                 codegenError("case: tuple pattern arity mismatch: subject has " +
                              std::to_string(sTy->getNumElements()) +
                              " elements, pattern has " +
                              std::to_string(pat->elements.size()));
-            const std::vector<std::string> elemSigs = splitTupleSig(subjectEnumType);
             testResult = llvm::ConstantInt::get(i1Ty_, 1);
             for (size_t i = 0; i < pat->elements.size(); ++i) {
                 llvm::Value *elem = builder_.CreateExtractValue(subjectVal, static_cast<unsigned>(i), "tup.elem");
@@ -352,9 +356,9 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
         } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
             llvm::Value *loaded = builder_.CreateLoad(subjectTy, subjectAlloca, "tup.load");
             auto *sTy = llvm::cast<llvm::StructType>(subjectTy);
+            const std::vector<std::string> elemSigs = splitTupleSig(subjectEnumType);
             assert(sTy->getNumElements() == pat->elements.size() &&
                    "TuplePattern arity must be verified by emitPatternTest before binding");
-            const std::vector<std::string> elemSigs = splitTupleSig(subjectEnumType);
             for (size_t i = 0; i < pat->elements.size(); ++i) {
                 llvm::Value *elem = builder_.CreateExtractValue(loaded, static_cast<unsigned>(i), "tup.bind");
                 llvm::Type  *elemTy = sTy->getElementType(static_cast<unsigned>(i));

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -1,5 +1,6 @@
 #include "ry/codegen.hpp"
 #include "ry/diagnostic.hpp"
+#include <cassert>
 
 
 namespace ry {
@@ -39,31 +40,41 @@ void CodeGen::validateBranchTypes(llvm::Value *lhs, llvm::Value *rhs, const char
     }
 }
 
+// Strips the outer parens from a Ry tuple type signature like "(int, List<str>)" and
+// returns the resolved, trimmed per-element type names.  Returns an empty vector when
+// the signature is absent or not a parenthesised tuple string.
+std::vector<std::string> CodeGen::splitTupleSig(const std::string &tupleTypeSig) {
+    if (tupleTypeSig.empty()) return {};
+    const std::string resolved = resolveTypeAlias(tupleTypeSig);
+    if (resolved.size() < 2 || resolved.front() != '(' || resolved.back() != ')') return {};
+    std::vector<std::string> parts = splitTypeArgs(resolved.substr(1, resolved.size() - 2));
+    for (auto &p : parts) p = trimTypeNameSpaces(p);
+    return parts;
+}
+
 void CodeGen::checkMatchExhaustiveness(
     const std::vector<std::pair<const Pattern*, bool>> &armPatterns,
     llvm::Type *subjectTy, const std::string &subjectEnumType) {
 
-    bool hasWildcardOrVar = false;
-    auto checkWildcardOrVar = [](const Pattern &p) {
-        return std::holds_alternative<WildcardPattern>(p) ||
-               std::holds_alternative<VariablePattern>(p);
+    // Recursively determines whether a pattern is irrefutable (always matches).
+    // A TuplePattern is irrefutable iff every element is irrefutable.
+    // EnumConstructorPattern is not irrefutable: it has a tag discriminator.
+    std::function<bool(const Pattern &)> isIrrefutable = [&](const Pattern &p) -> bool {
+        if (std::holds_alternative<WildcardPattern>(p)) return true;
+        if (std::holds_alternative<VariablePattern>(p)) return true;
+        if (auto *tp = std::get_if<std::unique_ptr<TuplePattern>>(&p))
+            return std::all_of((*tp)->elements.begin(), (*tp)->elements.end(), isIrrefutable);
+        return false;
     };
     for (auto &[pat, hasGuard] : armPatterns) {
-        if (!hasGuard) {
-            if (checkWildcardOrVar(*pat)) {
-                hasWildcardOrVar = true;
-            } else if (auto *op = std::get_if<std::unique_ptr<OrPattern>>(pat)) {
-                for (auto &alt : (*op)->alternatives) {
-                    if (checkWildcardOrVar(alt)) {
-                        hasWildcardOrVar = true;
-                        break;
-                    }
-                }
+        if (hasGuard) continue;
+        if (isIrrefutable(*pat)) return;
+        if (auto *op = std::get_if<std::unique_ptr<OrPattern>>(pat)) {
+            for (auto &alt : (*op)->alternatives) {
+                if (isIrrefutable(alt)) return;
             }
         }
     }
-
-    if (hasWildcardOrVar) return;
 
     // Check enum exhaustiveness
     std::string enumName;
@@ -281,6 +292,24 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                 llvm::Value *altResult = emitPatternTest(alt, subjectVal, subjectTy, subjectEnumType);
                 testResult = builder_.CreateOr(testResult, altResult, "or.comb");
             }
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
+            auto *sTy = llvm::dyn_cast<llvm::StructType>(subjectTy);
+            if (!sTy)
+                codegenError("case: tuple pattern applied to non-tuple subject");
+            if (sTy->getNumElements() != pat->elements.size())
+                codegenError("case: tuple pattern arity mismatch: subject has " +
+                             std::to_string(sTy->getNumElements()) +
+                             " elements, pattern has " +
+                             std::to_string(pat->elements.size()));
+            const std::vector<std::string> elemSigs = splitTupleSig(subjectEnumType);
+            testResult = llvm::ConstantInt::get(i1Ty_, 1);
+            for (size_t i = 0; i < pat->elements.size(); ++i) {
+                llvm::Value *elem = builder_.CreateExtractValue(subjectVal, static_cast<unsigned>(i), "tup.elem");
+                llvm::Type  *elemTy = sTy->getElementType(static_cast<unsigned>(i));
+                const std::string elemSig = (i < elemSigs.size()) ? elemSigs[i] : std::string{};
+                llvm::Value *sub = emitPatternTest(pat->elements[i], elem, elemTy, elemSig);
+                testResult = builder_.CreateAnd(testResult, sub, "tup.and");
+            }
         }
     }, pattern);
     return testResult;
@@ -319,6 +348,22 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 llvm::Value *errVal = builder_.CreateExtractValue(sv, 2, "err_val");
                 llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, errVal->getType());
                 builder_.CreateStore(errVal, varAlloca);
+            }
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
+            llvm::Value *loaded = builder_.CreateLoad(subjectTy, subjectAlloca, "tup.load");
+            auto *sTy = llvm::cast<llvm::StructType>(subjectTy);
+            assert(sTy->getNumElements() == pat->elements.size() &&
+                   "TuplePattern arity must be verified by emitPatternTest before binding");
+            const std::vector<std::string> elemSigs = splitTupleSig(subjectEnumType);
+            for (size_t i = 0; i < pat->elements.size(); ++i) {
+                llvm::Value *elem = builder_.CreateExtractValue(loaded, static_cast<unsigned>(i), "tup.bind");
+                llvm::Type  *elemTy = sTy->getElementType(static_cast<unsigned>(i));
+                llvm::AllocaInst *tmp = builder_.CreateAlloca(elemTy, nullptr, "tup.bind.alloca");
+                builder_.CreateStore(elem, tmp);
+                const std::string elemSig = (i < elemSigs.size()) ? elemSigs[i] : std::string{};
+                if (!elemSig.empty())
+                    propagateTypeMeta(elemSig, tmp);
+                emitPatternBindings(pat->elements[i], tmp, elemTy, elemSig);
             }
         } else if constexpr (std::is_same_v<T, EnumConstructorPattern>) {
             std::string resolvedEnum = pat.enum_name;

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -477,6 +477,14 @@ std::string Formatter::formatPattern(const Pattern &pat) {
                 result += formatPattern(v->alternatives[i]);
             }
             return result;
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
+            std::string result = "(";
+            for (size_t i = 0; i < v->elements.size(); ++i) {
+                if (i > 0) result += ", ";
+                result += formatPattern(v->elements[i]);
+            }
+            if (v->elements.size() == 1) result += ",";
+            return result + ")";
         } else {
             return "/* unknown pattern */";
         }

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -830,6 +830,9 @@ bool Parser::patternHasBinding(const Pattern &p) {
         return std::any_of(ec.bindings.begin(), ec.bindings.end(),
                            [](const std::string &b) { return b != "_"; });
     }
+    if (auto *tp = std::get_if<std::unique_ptr<TuplePattern>>(&p)) {
+        return std::any_of((*tp)->elements.begin(), (*tp)->elements.end(), patternHasBinding);
+    }
     return false;
 }
 
@@ -922,6 +925,31 @@ Pattern Parser::parsePattern() {
         auto node = std::make_unique<ExprNode>();
         node->data = BoolExpr{t.kind == TokenKind::True};
         return LiteralPattern{std::move(node)};
+    }
+
+    // Tuple/grouping pattern: '(' p ')' is grouping; '(' p ',' ... ')' is a TuplePattern.
+    if (t.kind == TokenKind::LParen) {
+        lex_.next();
+        if (lex_.peek().kind == TokenKind::RParen)
+            parseError(t.line, "zero-tuple pattern '()' is not supported");
+        Pattern first = parsePattern();
+        if (lex_.peek().kind != TokenKind::Comma) {
+            if (lex_.peek().kind != TokenKind::RParen)
+                parseError(lex_.peek().line, "expected ')' in grouped pattern");
+            lex_.next();
+            return first;
+        }
+        auto tup = std::make_unique<TuplePattern>();
+        tup->elements.push_back(std::move(first));
+        while (lex_.peek().kind == TokenKind::Comma) {
+            lex_.next();
+            if (lex_.peek().kind == TokenKind::RParen) break;
+            tup->elements.push_back(parsePattern());
+        }
+        if (lex_.peek().kind != TokenKind::RParen)
+            parseError(lex_.peek().line, "expected ')' in tuple pattern");
+        lex_.next();
+        return Pattern{std::move(tup)};
     }
 
     // Negative number literal: -N

--- a/tests/spec/pattern_tuple.test.ry
+++ b/tests/spec/pattern_tuple.test.ry
@@ -1,0 +1,238 @@
+# Spec for tuple destructuring patterns in `case` (issue #834)
+#
+# Covers:
+#   - 2-tuple and 3-tuple binding patterns
+#   - 1-tuple (trailing comma) binding pattern
+#   - Literal tuple patterns (1, 2), mixed (1, n), wildcard (_)
+#   - Guard with tuple binding
+#   - Nested: tuple as outer container (Some(v), _)
+#   - Irrefutability: case (_, _) is exhaustive
+#   - case expression form
+#   - Regression: existing patterns unaffected
+
+describe("tuple pattern - binding", ():
+  it("should destructure a 2-tuple binding", ():
+    t = (10, 20)
+    a_out = 0
+    b_out = 0
+    case t:
+      (x, y):
+        a_out = x
+        b_out = y
+      _:
+        a_out = -1
+        b_out = -1
+    expect(a_out).to_eq(10)
+    expect(b_out).to_eq(20)
+  )
+
+  it("should destructure a 3-tuple binding", ():
+    t = (1, 2, 3)
+    a_out = 0
+    b_out = 0
+    c_out = 0
+    case t:
+      (x, y, z):
+        a_out = x
+        b_out = y
+        c_out = z
+      _:
+        a_out = -1
+        b_out = -1
+        c_out = -1
+    expect(a_out).to_eq(1)
+    expect(b_out).to_eq(2)
+    expect(c_out).to_eq(3)
+  )
+
+  it("should destructure a 1-tuple (trailing comma)", ():
+    t = (42,)
+    v_out = 0
+    case t:
+      (v,):
+        v_out = v
+      _:
+        v_out = -1
+    expect(v_out).to_eq(42)
+  )
+)
+
+describe("tuple pattern - literal and mixed", ():
+  it("should match a fully literal tuple pattern", ():
+    t = (1, 2)
+    matched = false
+    case t:
+      (1, 2):
+        matched = true
+      _:
+        matched = false
+    expect(matched).to_be_true()
+  )
+
+  it("should not match a wrong literal tuple", ():
+    t = (1, 3)
+    matched = false
+    case t:
+      (1, 2):
+        matched = true
+      _:
+        matched = false
+    expect(matched).to_be_false()
+  )
+
+  it("should match mixed literal + binding pattern", ():
+    t = (1, 99)
+    n_out = 0
+    case t:
+      (1, n):
+        n_out = n
+      _:
+        n_out = -1
+    expect(n_out).to_eq(99)
+  )
+
+  it("should match wildcard + binding pattern", ():
+    t = (55, 77)
+    n_out = 0
+    case t:
+      (_, n):
+        n_out = n
+      _:
+        n_out = -1
+    expect(n_out).to_eq(77)
+  )
+)
+
+describe("tuple pattern - guard", ():
+  it("should apply guard to tuple binding", ():
+    t = (10, 3)
+    result = ""
+    case t:
+      (a, b) if a > b:
+        result = "first bigger"
+      (a, b):
+        result = "other"
+    expect(result).to_eq("first bigger")
+  )
+
+  it("should fall through guard to next arm", ():
+    t = (3, 10)
+    result = ""
+    case t:
+      (a, b) if a > b:
+        result = "first bigger"
+      (a, b):
+        result = "other"
+    expect(result).to_eq("other")
+  )
+)
+
+describe("tuple pattern - nested (tuple as outer container)", ():
+  it("should match Some(v) inside a tuple", ():
+    opt: Option<int> = Some(7)
+    t = (opt, 42)
+    found = 0
+    case t:
+      (Some(v), _):
+        found = v
+      _:
+        found = -1
+    expect(found).to_eq(7)
+  )
+
+  it("should match None inside a tuple", ():
+    opt: Option<int> = None
+    t = (opt, 42)
+    found = false
+    case t:
+      (None, _):
+        found = true
+      _:
+        found = false
+    expect(found).to_be_true()
+  )
+)
+
+describe("tuple pattern - exhaustiveness", ():
+  it("case (x, y) should be treated as irrefutable (no wildcard needed)", ():
+    t = (5, 6)
+    a_out = 0
+    b_out = 0
+    case t:
+      (x, y):
+        a_out = x
+        b_out = y
+    expect(a_out).to_eq(5)
+    expect(b_out).to_eq(6)
+  )
+)
+
+describe("tuple pattern - case expression form", ():
+  it("should work in expression position", ():
+    t = (3, 4)
+    result = case t:
+      (a, b) => a + b
+      _ => -1
+    expect(result).to_eq(7)
+  )
+
+  it("should work with literal pattern in expression form", ():
+    t = (0, 0)
+    label = case t:
+      (0, 0) => "origin"
+      _ => "other"
+    expect(label).to_eq("origin")
+  )
+)
+
+describe("regression - existing patterns unaffected", ():
+  it("should still work with literal patterns", ():
+    x = 42
+    res = case x:
+      42 => "found"
+      _ => "not found"
+    expect(res).to_eq("found")
+  )
+
+  it("should still work with Some/None", ():
+    opt: Option<int> = Some(10)
+    res = case opt:
+      Some(v) => v
+      None => 0
+    expect(res).to_eq(10)
+  )
+
+  it("should still work with Ok pattern", ():
+    function try_parse(s: str) -> Result<int, Error>:
+      return Ok(42)
+    r = try_parse("42")
+    res = 0
+    case r:
+      Ok(v):
+        res = v
+      Err(_):
+        res = -1
+    expect(res).to_eq(42)
+  )
+
+  it("should still work with OR patterns", ():
+    x = 2
+    res = case x:
+      1 | 2 | 3 => "small"
+      _ => "other"
+    expect(res).to_eq("small")
+  )
+
+  it("should still work with enum variant patterns", ():
+    enum Color:
+      Red
+      Green
+      Blue
+    c: Color = Color::Green
+    res = case c:
+      Color::Red => 0
+      Color::Green => 1
+      Color::Blue => 2
+    expect(res).to_eq(1)
+  )
+)

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -914,6 +914,32 @@ TEST_F(CodeGenTest, MatchOrPatternVariableError) {
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
+// ===== Tuple patterns in case (#834) =====
+
+TEST_F(CodeGenTest, TuplePatternArityMismatch) {
+    // (int, int) subject matched with a 3-element pattern -> codegen error
+    std::string src =
+        "t: (int, int) = (1, 2)\n"
+        "case t:\n"
+        "    (a, b, c):\n"
+        "        print(a)\n"
+        "    _:\n"
+        "        print(0)\n";
+    EXPECT_THROW(runSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, TuplePatternNonTupleSubject) {
+    // scalar subject with a tuple pattern -> codegen error
+    std::string src =
+        "n: int = 1\n"
+        "case n:\n"
+        "    (a, b):\n"
+        "        print(a)\n"
+        "    _:\n"
+        "        print(0)\n";
+    EXPECT_THROW(runSource(src), std::runtime_error);
+}
+
 // ===== enum ADT (associated data) =====
 
 TEST_F(CodeGenTest, EnumADTCreate) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2507,3 +2507,8 @@ TEST(ParserTest, TuplePatternGroupingUnwrapped) {
     EXPECT_FALSE(std::holds_alternative<std::unique_ptr<TuplePattern>>(cs.arms[0].pattern));
     EXPECT_TRUE(std::holds_alternative<LiteralPattern>(cs.arms[0].pattern));
 }
+
+TEST(ParserTest, TuplePatternGroupingUnclosedError) {
+    // (42: — single element grouping with missing ')' hits the distinct rejection branch
+    EXPECT_THROW(parseStr("case x:\n    (42:\n        print(0)\n"), std::runtime_error);
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2454,3 +2454,56 @@ TEST(ParserTest, PositionalAfterNamedArgError) {
 TEST(ParserTest, DuplicateNamedArgError) {
     EXPECT_THROW(parseStr("print(end=\"\\n\", end=\"!\")\n"), std::runtime_error);
 }
+
+// ============================================================
+// Tuple patterns in case (#834)
+// ============================================================
+
+TEST(ParserTest, TuplePatternZeroTupleRejected) {
+    // '()' as a pattern is not supported
+    EXPECT_THROW(parseStr("case x:\n    ():\n        print(0)\n"), std::runtime_error);
+}
+
+TEST(ParserTest, TuplePatternUnclosedError) {
+    // Missing closing ')' in tuple pattern
+    EXPECT_THROW(parseStr("case x:\n    (a, b:\n        print(0)\n"), std::runtime_error);
+}
+
+TEST(ParserTest, TuplePatternOrWithBindingRejected) {
+    // OR-pattern containing a binding inside a tuple should be rejected
+    EXPECT_THROW(parseStr("case x:\n    (1, y) | (2, z):\n        print(0)\n"), std::runtime_error);
+}
+
+TEST(ParserTest, TuplePattern2ElementParsed) {
+    Program prog = parseStr("case t:\n    (a, b):\n        print(a)\n");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CaseStmt>>(prog[0]));
+    const auto &cs = *std::get<std::unique_ptr<CaseStmt>>(prog[0]);
+    ASSERT_EQ(cs.arms.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<TuplePattern>>(cs.arms[0].pattern));
+    const auto &tp = *std::get<std::unique_ptr<TuplePattern>>(cs.arms[0].pattern);
+    ASSERT_EQ(tp.elements.size(), 2u);
+    EXPECT_TRUE(std::holds_alternative<VariablePattern>(tp.elements[0]));
+    EXPECT_TRUE(std::holds_alternative<VariablePattern>(tp.elements[1]));
+}
+
+TEST(ParserTest, TuplePattern1TupleParsed) {
+    Program prog = parseStr("case t:\n    (v,):\n        print(v)\n");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CaseStmt>>(prog[0]));
+    const auto &cs = *std::get<std::unique_ptr<CaseStmt>>(prog[0]);
+    ASSERT_EQ(cs.arms.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<TuplePattern>>(cs.arms[0].pattern));
+    const auto &tp = *std::get<std::unique_ptr<TuplePattern>>(cs.arms[0].pattern);
+    ASSERT_EQ(tp.elements.size(), 1u);
+}
+
+TEST(ParserTest, TuplePatternGroupingUnwrapped) {
+    // (p) with no comma is grouping — the inner pattern is returned, not a TuplePattern
+    Program prog = parseStr("case x:\n    (42):\n        print(0)\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &cs = *std::get<std::unique_ptr<CaseStmt>>(prog[0]);
+    ASSERT_EQ(cs.arms.size(), 1u);
+    EXPECT_FALSE(std::holds_alternative<std::unique_ptr<TuplePattern>>(cs.arms[0].pattern));
+    EXPECT_TRUE(std::holds_alternative<LiteralPattern>(cs.arms[0].pattern));
+}


### PR DESCRIPTION
## Summary

- Adds `TuplePattern` to the `Pattern` AST variant so `case (a, b):` and `case (1, n):` work in both `case` statements and `case` expressions
- Parser disambiguates `(p)` as grouping vs `(p,)` / `(p, q, ...)` as 1-tuple / N-tuple, following the same rules as the expression parser
- Codegen emits element-wise `ExtractValue` + AND-chain for tests, and per-element alloca/store/bind for bindings; per-element Ry type metadata is propagated via the new `splitTupleSig` helper
- Exhaustiveness checker extended to treat a tuple pattern as irrefutable when every element is irrefutable

## What's included

| Feature | Example |
|---------|---------|
| Binding | `(a, b)`, `(a, b, c)` |
| 1-tuple | `(v,)` |
| Literal | `(1, 2)` |
| Mixed | `(1, n)`, `(_, n)` |
| Guard | `(a, b) if a > b` |
| Nested | `(Some(v), _)`, `(None, _)` |
| Expression form | `r = case t: (a, b) => a + b; _ => 0` |
| Irrefutable exhaustiveness | `case (a, b):` with no `_` arm |

## Out of scope (filed as separate issues)

- Positional record patterns `Point(a, b)` → #989
- Nested patterns in enum constructor payloads `Event::Click((0, 0))` → #990

## Tests

- 19 spec cases in `tests/spec/pattern_tuple.test.ry` (all pass)
- 8 C++ error tests (parser rejection + codegen arity/type mismatch)
- Full suite: 1662 C++ tests + 120 Ry spec files — zero failures
- ASan + UBSan: clean; TSan: clean

Closes #834

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tuple destructuring patterns in case statements and expressions (including nested patterns, mixed literal/binding, wildcards, and 1-tuple syntax)

* **Behavior**
  * Guard clauses now work with tuple patterns; fully irrefutable tuple bindings are treated as exhaustive

* **Documentation**
  * Reference and changelog updated with examples, syntax clarifications, and scope/exhaustiveness rules

* **Tests**
  * New parser, spec, and codegen tests covering tuple parsing, matching, guards, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->