### PR TITLE
feat(pattern): support nested patterns in enum constructor payloads (#990)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1996,3 +1996,27 @@ Options considered for #872:
 (`ConcurrencySpecSuite`, `concurrency_stress.test.ry`,
 `test_runtime_arc_contention_stress.cpp`) did NOT expose a helper-function
 race.  Revisit only if future stress tests expose such a race.
+
+### ADT enum constructor pattern: single TuplePattern binding must be "unwrapped"
+
+**Source**: #990 (2026-04-16, implementation)
+**Tags**: codegen, pattern, enum, tuple, ADT, emitPatternTest, emitPatternBindings
+
+**Rule**: `Event::Click((0, 0))` is parsed as `EnumConstructorPattern` with **one** binding that is a `TuplePattern{elements: [0, 0]}`. If `emitPatternTest` / `emitPatternBindings` naively iterate `pat->bindings` (size 1) and try to match `fieldTypes[0]` ("int") against a `TuplePattern`, the recursive call to `emitPatternTest(TuplePattern{...}, int_val, "int")` will call `splitTupleSig("int")` → empty → crash ("tuple pattern applied to non-tuple subject").
+
+The fix: before the field loop in both `emitPatternTest` and `emitPatternBindings`, detect the "single TuplePattern whose arity == variant's field count" case and redirect the loop to iterate over the TuplePattern's **elements** instead:
+
+```cpp
+const std::vector<Pattern> *fieldPats = &pat->bindings;
+if (pat->bindings.size() == 1) {
+    if (auto *tp = std::get_if<std::unique_ptr<TuplePattern>>(&pat->bindings[0])) {
+        if ((*tp)->elements.size() == fit->second.fieldTypes.size())
+            fieldPats = &(*tp)->elements;
+    }
+}
+// Use (*fieldPats)[i] and fieldPats->size() in the loop.
+```
+
+**Why**: `(0, 0)` inside `Event::Click(...)` is grammatically a tuple pattern (two elements), not two separate arguments. The parser correctly emits one `TuplePattern`, but codegen must recognise this as syntactic sugar for "match the N fields individually". The unwrap only triggers when element count == field count; mismatched arities fall through to the normal path (which will produce a runtime type-check error, matching the behaviour of other arity mismatches).
+
+**How to apply**: Mirrored changes are required in **both** `emitPatternTest` (for the test-phase) and `emitPatternBindings` (for the binding-phase). Missing either half causes the other phase to use the wrong pattern → incorrect runtime behaviour.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2044,3 +2044,43 @@ if (pat->bindings.size() == 1) {
 **Why**: `(0, 0)` inside `Event::Click(...)` is grammatically a tuple pattern (two elements), not two separate arguments. The parser correctly emits one `TuplePattern`, but codegen must recognise this as syntactic sugar for "match the N fields individually". The unwrap only triggers when element count == field count; mismatched arities fall through to the normal path (which will produce a runtime type-check error, matching the behaviour of other arity mismatches).
 
 **How to apply**: Mirrored changes are required in **both** `emitPatternTest` (for the test-phase) and `emitPatternBindings` (for the binding-phase). Missing either half causes the other phase to use the wrong pattern → incorrect runtime behaviour.
+
+### ADT enum constructor pattern: payload tests must be gated by a tag-match branch
+
+**Source**: #990 (2026-04-16, CodeRabbit review)
+**Tags**: codegen, pattern, enum, ADT, emitPatternTest, PHI, LLVM, safety
+
+**Rule**: In `emitPatternTest` for `EnumConstructorPattern`, do **not** use `CreateAnd` to combine the tag equality with payload sub-tests. `CreateAnd` does not short-circuit in LLVM IR, so payload loads execute unconditionally even when the tag does not match. Loading a `str` pointer field from a variant that actually stores an `int` payload (or vice versa) and then passing it to `strcmp` / pointer tests will crash at runtime.
+
+**Fix**: Gate payload loads with a conditional branch (`CreateCondBr`) on the tag equality result, run the GEP/load/test loop in the `ecp.payload` basic block, then merge with a PHI node:
+
+```cpp
+llvm::BasicBlock *tagMatchBB = builder_.GetInsertBlock();
+auto *payloadBB = llvm::BasicBlock::Create(*ctx_, "ecp.payload", fn);
+auto *mergeBB   = llvm::BasicBlock::Create(*ctx_, "ecp.merge",   fn);
+builder_.CreateCondBr(testResult, payloadBB, mergeBB);
+
+builder_.SetInsertPoint(payloadBB);
+// ... GEP / load / emitPatternTest loop builds fieldsMatch ...
+llvm::BasicBlock *payloadEndBB = builder_.GetInsertBlock();
+builder_.CreateBr(mergeBB);
+
+builder_.SetInsertPoint(mergeBB);
+llvm::PHINode *phi = builder_.CreatePHI(i1Ty_, 2, "ecp.final");
+phi->addIncoming(llvm::ConstantInt::get(i1Ty_, 0), tagMatchBB); // tag missed → false
+phi->addIncoming(fieldsMatch, payloadEndBB);                     // tag hit → payload result
+testResult = phi;
+```
+
+**Why**: Tagged-union variants can have entirely different payload types (int vs str). Loading the wrong type's bytes as a pointer and dereferencing it is undefined behaviour that manifests as a crash. The `emitPatternTest` for `TuplePattern` uses `CreateExtractValue` (safe, always valid), but `EnumConstructorPattern` uses `CreateLoad` from raw GEP — inherently unsafe when the tag doesn't match.
+
+**How to apply**: This pattern applies to any new pattern type that (1) lives inside a tagged union and (2) loads payload bytes via a GEP through the union's raw byte array. Always branch on the discriminant before loading.
+
+### sema_return exhaustiveness: EnumConstructorPattern covers a variant only when payload is irrefutable
+
+**Source**: #990 (2026-04-16, CodeRabbit review)
+**Tags**: sema_return, exhaustiveness, pattern, enum, irrefutable, return-analysis
+
+**Rule**: In `collectPatternInfo` (`sema_return.cpp`), only call `cov.coveredVariants.insert(variant_name)` for an `EnumConstructorPattern` when every binding in `pat->bindings` is irrefutable (i.e. `WildcardPattern`, `VariablePattern`, or recursively-irrefutable `TuplePattern`). An arm like `Event::Click((0, 0))` only matches a subset of `Click` values — adding `Click` to `coveredVariants` unconditionally would make `isExhaustiveMatch()` unsound and allow a non-returning `case` to pass return analysis.
+
+**How to apply**: Use a small `isIrrefutable(const Pattern &)` recursive helper (see `src/sema_return.cpp`). Pattern types that are always refutable: `LiteralPattern`, `EnumPattern` (always a specific tag), `SomePattern`, `NonePattern`, etc. When adding any new pattern type to the language, update `isIrrefutable` accordingly. Pre-existing `EnumPattern` arms (without payload) are always irrefutable for their specific variant (the tag check is the only condition), so they continue to insert unconditionally.

--- a/changelog.d/990-nested-enum-constructor-pattern.md
+++ b/changelog.d/990-nested-enum-constructor-pattern.md
@@ -1,0 +1,8 @@
+### Added
+
+- Nested patterns are now supported inside ADT enum constructor pattern arms (#990).
+  Each binding position may be a variable, a literal, a wildcard, or a tuple pattern.
+  A single tuple pattern whose arity matches the variant's field count is unwrapped
+  and matched field-by-field, so `Event::Click((0, 0))`, `Event::Click((x, y))`,
+  `Event::Click((_, y))`, and `Wrapper::Val(42)` all work as expected. Plain variable
+  bindings (`Shape::Circle(r)`) continue to work unchanged.

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -443,7 +443,7 @@ case expression:
 | Literal | `0`, `"hello"`, `true` | Equality comparison |
 | Variable binding | `n` | Matches anything and binds to a variable |
 | enum variant | `Color::Red` | Compares enum tag (simple enum) |
-| ADT enum variant | `Shape::Circle(r)` | Matches an enum variant with associated data and binds it |
+| ADT enum variant | `Shape::Circle(r)`, `Event::Click((0, y))` | Matches an enum variant with associated data; each position may be a variable, literal, wildcard, or tuple pattern |
 | `Some(x)` | `Some(v)` | When Option has a value, binds the inner value |
 | `None` | `None` | When Option has no value |
 | `Ok(x)` | `Ok(v)` | When Result is Ok, binds the inner value |
@@ -561,6 +561,45 @@ case s:
 ```
 
 Multi-field variants bind each field to a separate name in declaration order.
+
+Each binding position in a constructor pattern may be any pattern, not only a plain variable name. You can use:
+
+- **A variable** (`r`, `x`, `y`) — binds the field value to that name.
+- **A literal** (`42`, `0`) — tests that the field equals the literal; the arm is taken only if all fields match.
+- **A wildcard** (`_`) — ignores the field value.
+- **A tuple pattern** (`(x, y)`) — when a variant has multiple fields, a single tuple pattern whose element count equals the field count is unwrapped and matched field-by-field.
+
+```python
+enum Event:
+    Click(int, int)
+    Key(str)
+
+e = Event::Click(0, 0)
+
+# Nested tuple literal — matches only when both fields are 0
+case e:
+    Event::Click((0, 0)):
+        print("origin")
+    _:
+        print("other")
+
+# Nested tuple variable binding — binds both fields
+case e:
+    Event::Click((x, y)):
+        print(x)   # 0
+        print(y)   # 0
+
+# Mixed literal + variable — first field must be 0, second is bound
+e2 = Event::Click(0, 7)
+case e2:
+    Event::Click((0, y)):
+        print(y)   # 7
+
+# Wildcard — ignore first field, bind second
+case e2:
+    Event::Click((_, y)):
+        print(y)   # 7
+```
 
 ### Tuple Pattern Matching
 

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -466,12 +466,7 @@ struct SomePattern { std::string binding; };
 struct NonePattern {};
 struct OkPattern { std::string binding; };
 struct ErrPattern { std::string binding; };
-struct EnumConstructorPattern {
-    std::string enum_name;
-    std::string variant_name;
-    std::vector<std::string> bindings;
-};
-
+struct EnumConstructorPattern;  // defined after Pattern (needs Pattern for nested bindings)
 struct OrPattern;
 struct TuplePattern;   // elements may be nested Patterns (e.g. Some(v) inside a tuple)
 struct RecordPattern;  // positional record destructuring: Point(a, b)
@@ -480,7 +475,7 @@ using Pattern = std::variant<
     WildcardPattern, LiteralPattern, VariablePattern,
     EnumPattern, SomePattern, NonePattern,
     OkPattern, ErrPattern,
-    EnumConstructorPattern,
+    std::unique_ptr<EnumConstructorPattern>,
     std::unique_ptr<OrPattern>,
     std::unique_ptr<TuplePattern>,
     std::unique_ptr<RecordPattern>
@@ -493,6 +488,12 @@ struct TuplePattern { std::vector<Pattern> elements; };
 struct RecordPattern {
     std::string name;
     std::vector<Pattern> elements;
+};
+// Enum constructor with payload; bindings are recursive Patterns (e.g. Event::Click((0, 0))).
+struct EnumConstructorPattern {
+    std::string enum_name;
+    std::string variant_name;
+    std::vector<Pattern> bindings;
 };
 
 struct CaseArm {

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -67,9 +67,9 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
                 if (p.binding != "_") excludedNames.insert(p.binding);
             } else if constexpr (std::is_same_v<P, ErrPattern>) {
                 if (p.binding != "_") excludedNames.insert(p.binding);
-            } else if constexpr (std::is_same_v<P, EnumConstructorPattern>) {
-                for (auto &b : p.bindings)
-                    if (b != "_") excludedNames.insert(b);
+            } else if constexpr (std::is_same_v<P, std::unique_ptr<EnumConstructorPattern>>) {
+                for (const auto &b : p->bindings)
+                    excludePatternBindings(b);
             } else if constexpr (std::is_same_v<P, std::unique_ptr<OrPattern>>) {
                 if (p) {
                     for (const auto &alt : p->alternatives)

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -68,8 +68,20 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
             } else if constexpr (std::is_same_v<P, ErrPattern>) {
                 if (p.binding != "_") excludedNames.insert(p.binding);
             } else if constexpr (std::is_same_v<P, std::unique_ptr<EnumConstructorPattern>>) {
-                for (const auto &b : p->bindings)
-                    excludePatternBindings(b);
+                if (p) {
+                    for (const auto &b : p->bindings)
+                        excludePatternBindings(b);
+                }
+            } else if constexpr (std::is_same_v<P, std::unique_ptr<TuplePattern>>) {
+                if (p) {
+                    for (const auto &elem : p->elements)
+                        excludePatternBindings(elem);
+                }
+            } else if constexpr (std::is_same_v<P, std::unique_ptr<RecordPattern>>) {
+                if (p) {
+                    for (const auto &elem : p->elements)
+                        excludePatternBindings(elem);
+                }
             } else if constexpr (std::is_same_v<P, std::unique_ptr<OrPattern>>) {
                 if (p) {
                     for (const auto &alt : p->alternatives)

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -7,6 +7,21 @@ namespace ry {
 
 // ===== Shared match helpers =====
 
+// When an EnumConstructorPattern has a single TuplePattern whose element count equals the
+// variant's field count, the user wrote e.g. Event::Click((x, y)) — the outer parens form a
+// tuple pattern that serves as sugar for matching all fields individually.  Unwrap it so the
+// recursive emitPatternTest / emitPatternBindings calls receive one element per field.
+static const std::vector<Pattern> *unwrapEnumPayloadTuple(const std::vector<Pattern> &bindings,
+                                                          size_t fieldCount) {
+    if (bindings.size() == 1) {
+        if (auto *tp = std::get_if<std::unique_ptr<TuplePattern>>(&bindings[0])) {
+            if ((*tp)->elements.size() == fieldCount)
+                return &(*tp)->elements;
+        }
+    }
+    return &bindings;
+}
+
 std::string CodeGen::resolveEnumType(llvm::Value *val) const {
     auto *meta = getMeta(val);
     if (meta && !meta->enum_value_type.empty())
@@ -86,8 +101,8 @@ void CodeGen::checkMatchExhaustiveness(
             enumName = ep->enum_name;
             break;
         }
-        if (auto *ecp = std::get_if<EnumConstructorPattern>(pat)) {
-            enumName = ecp->enum_name;
+        if (auto *ecp = std::get_if<std::unique_ptr<EnumConstructorPattern>>(pat)) {
+            enumName = (*ecp)->enum_name;
             break;
         }
         if (auto *op = std::get_if<std::unique_ptr<OrPattern>>(pat)) {
@@ -96,8 +111,8 @@ void CodeGen::checkMatchExhaustiveness(
                     enumName = ep2->enum_name;
                     break;
                 }
-                if (auto *ecp2 = std::get_if<EnumConstructorPattern>(&alt)) {
-                    enumName = ecp2->enum_name;
+                if (auto *ecp2 = std::get_if<std::unique_ptr<EnumConstructorPattern>>(&alt)) {
+                    enumName = (*ecp2)->enum_name;
                     break;
                 }
             }
@@ -117,14 +132,14 @@ void CodeGen::checkMatchExhaustiveness(
                 if (!hasGuard) {
                     if (auto *ep = std::get_if<EnumPattern>(pat))
                         covered.insert(ep->variant_name);
-                    if (auto *ecp = std::get_if<EnumConstructorPattern>(pat))
-                        covered.insert(ecp->variant_name);
+                    if (auto *ecp = std::get_if<std::unique_ptr<EnumConstructorPattern>>(pat))
+                        covered.insert((*ecp)->variant_name);
                     if (auto *op = std::get_if<std::unique_ptr<OrPattern>>(pat)) {
                         for (auto &alt : (*op)->alternatives) {
                             if (auto *ep2 = std::get_if<EnumPattern>(&alt))
                                 covered.insert(ep2->variant_name);
-                            if (auto *ecp2 = std::get_if<EnumConstructorPattern>(&alt))
-                                covered.insert(ecp2->variant_name);
+                            if (auto *ecp2 = std::get_if<std::unique_ptr<EnumConstructorPattern>>(&alt))
+                                covered.insert((*ecp2)->variant_name);
                         }
                     }
                 }
@@ -250,25 +265,51 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                 llvm::Value *tag = llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(varIt->second));
                 testResult = builder_.CreateICmpEQ(subjectVal, tag, "match.enum_eq");
             }
-        } else if constexpr (std::is_same_v<T, EnumConstructorPattern>) {
-            std::string resolvedEnum = pat.enum_name;
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>) {
+            std::string resolvedEnum = pat->enum_name;
             auto enumIt = enum_types_.find(resolvedEnum);
             if (enumIt == enum_types_.end() && !subjectEnumType.empty()) {
                 auto ltPos = subjectEnumType.find('<');
-                if (ltPos != std::string::npos && subjectEnumType.substr(0, ltPos) == pat.enum_name) {
+                if (ltPos != std::string::npos && subjectEnumType.substr(0, ltPos) == pat->enum_name) {
                     resolvedEnum = subjectEnumType;
                     enumIt = enum_types_.find(resolvedEnum);
                 }
             }
             if (enumIt == enum_types_.end())
-                codegenError("match: unknown enum '" + pat.enum_name + "'");
+                codegenError("match: unknown enum '" + pat->enum_name + "'");
             if (!enumIt->second.isADT)
-                codegenError("match: constructor pattern requires ADT enum, but '" + pat.enum_name + "' is not ADT");
-            auto varIt = enumIt->second.variants.find(pat.variant_name);
+                codegenError("match: constructor pattern requires ADT enum, but '" + pat->enum_name + "' is not ADT");
+            auto varIt = enumIt->second.variants.find(pat->variant_name);
             if (varIt == enumIt->second.variants.end())
-                codegenError("match: unknown variant '" + pat.enum_name + "::" + pat.variant_name + "'");
+                codegenError("match: unknown variant '" + pat->enum_name + "::" + pat->variant_name + "'");
             llvm::Value *subjectTag = builder_.CreateExtractValue(subjectVal, 0, "adt.tag");
             testResult = builder_.CreateICmpEQ(subjectTag, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(varIt->second)), "match.adt_eq");
+            auto fit = enumIt->second.variantFields.find(pat->variant_name);
+            if (fit != enumIt->second.variantFields.end() && !pat->bindings.empty()) {
+                const std::vector<Pattern> *fieldPats =
+                    unwrapEnumPayloadTuple(pat->bindings, fit->second.fieldTypes.size());
+                llvm::AllocaInst *tmpAlloca = builder_.CreateAlloca(subjectTy, nullptr, "ecp.test.tmp");
+                builder_.CreateStore(subjectVal, tmpAlloca);
+                llvm::Value *payloadPtr = builder_.CreateStructGEP(
+                    enumIt->second.adtType, tmpAlloca, 1, "ecp.test.payload");
+                const llvm::DataLayout &dl = mod_->getDataLayout();
+                size_t offset = 0;
+                for (size_t i = 0; i < fieldPats->size() && i < fit->second.fieldTypes.size(); ++i) {
+                    llvm::Type *fieldTy = fit->second.fieldTypes[i];
+                    uint64_t align = dl.getABITypeAlign(fieldTy).value();
+                    offset = (offset + align - 1) / align * align;
+                    llvm::Value *fieldPtr = builder_.CreateGEP(
+                        llvm::Type::getInt8Ty(*ctx_), payloadPtr,
+                        {llvm::ConstantInt::get(i64Ty_, offset)},
+                        "ecp.test.field." + std::to_string(i));
+                    llvm::Value *fieldVal = builder_.CreateLoad(fieldTy, fieldPtr, "ecp.test.fval");
+                    const std::string &fieldTypeName = (i < fit->second.fieldTypeNames.size())
+                        ? fit->second.fieldTypeNames[i] : std::string{};
+                    llvm::Value *sub = emitPatternTest((*fieldPats)[i], fieldVal, fieldTy, fieldTypeName);
+                    testResult = builder_.CreateAnd(testResult, sub, "ecp.test.and");
+                    offset += dl.getTypeAllocSize(fieldTy);
+                }
+            }
         } else if constexpr (std::is_same_v<T, SomePattern>) {
             if (!isOptionType(subjectTy))
                 codegenError("match: Some pattern requires Option type");
@@ -431,17 +472,20 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 const std::string subEnumSig = enum_types_.count(resolvedElemSig) ? resolvedElemSig : std::string{};
                 emitPatternBindings(pat->elements[i], tmp, elemTy, subEnumSig);
             }
-        } else if constexpr (std::is_same_v<T, EnumConstructorPattern>) {
-            std::string resolvedEnum = pat.enum_name;
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>) {
+            std::string resolvedEnum = pat->enum_name;
             if (!enum_types_.count(resolvedEnum) && !subjectEnumType.empty()) {
                 auto ltPos = subjectEnumType.find('<');
-                if (ltPos != std::string::npos && subjectEnumType.substr(0, ltPos) == pat.enum_name)
+                if (ltPos != std::string::npos && subjectEnumType.substr(0, ltPos) == pat->enum_name)
                     resolvedEnum = subjectEnumType;
             }
+            // emitPatternTest already validated the enum; skip silently if lookup fails here.
             auto enumIt = enum_types_.find(resolvedEnum);
             if (enumIt != enum_types_.end()) {
-                auto fit = enumIt->second.variantFields.find(pat.variant_name);
+                auto fit = enumIt->second.variantFields.find(pat->variant_name);
                 if (fit != enumIt->second.variantFields.end()) {
+                    const std::vector<Pattern> *fieldPats =
+                        unwrapEnumPayloadTuple(pat->bindings, fit->second.fieldTypes.size());
                     llvm::Value *sv = builder_.CreateLoad(subjectTy, subjectAlloca, "adt.val");
                     llvm::AllocaInst *tmpAlloca = builder_.CreateAlloca(subjectTy, nullptr, "adt.tmp");
                     builder_.CreateStore(sv, tmpAlloca);
@@ -449,22 +493,29 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                         enumIt->second.adtType, tmpAlloca, 1, "adt.payload");
                     const llvm::DataLayout &dl = mod_->getDataLayout();
                     size_t offset = 0;
-                    for (size_t bi = 0; bi < pat.bindings.size() && bi < fit->second.fieldTypes.size(); ++bi) {
+                    for (size_t bi = 0; bi < fieldPats->size() && bi < fit->second.fieldTypes.size(); ++bi) {
                         llvm::Type *fieldTy = fit->second.fieldTypes[bi];
-                        const std::string &bindingName = pat.bindings[bi];
                         uint64_t align = dl.getABITypeAlign(fieldTy).value();
                         offset = (offset + align - 1) / align * align;
-                        if (bindingName == "_") {
-                            offset += dl.getTypeAllocSize(fieldTy);
-                            continue;
-                        }
                         llvm::Value *fieldPtr = builder_.CreateGEP(
                             llvm::Type::getInt8Ty(*ctx_), payloadPtr,
                             {llvm::ConstantInt::get(i64Ty_, offset)},
                             "adt.bind." + std::to_string(bi));
-                        llvm::Value *fieldVal = builder_.CreateLoad(fieldTy, fieldPtr, bindingName);
-                        llvm::AllocaInst *bindAlloca = getOrCreateVar(bindingName, fieldTy);
-                        builder_.CreateStore(fieldVal, bindAlloca);
+                        llvm::Value *fieldVal = builder_.CreateLoad(fieldTy, fieldPtr,
+                                                                    "adt.bind.fval." + std::to_string(bi));
+                        llvm::AllocaInst *tmp = builder_.CreateAlloca(fieldTy, nullptr,
+                                                                       "adt.bind.alloca." + std::to_string(bi));
+                        builder_.CreateStore(fieldVal, tmp);
+                        const std::string &fieldTypeName = (bi < fit->second.fieldTypeNames.size())
+                            ? fit->second.fieldTypeNames[bi] : std::string{};
+                        if (!fieldTypeName.empty())
+                            propagateTypeMeta(fieldTypeName, tmp);
+                        // Guard: only pass fieldTypeName as subjectEnumType when it names a known enum.
+                        // Passing a primitive type name ("int", "str", etc.) would crash valueToString().
+                        const std::string resolvedFieldType = resolveTypeAlias(fieldTypeName);
+                        const std::string subEnumSig = enum_types_.count(resolvedFieldType)
+                            ? resolvedFieldType : std::string{};
+                        emitPatternBindings((*fieldPats)[bi], tmp, fieldTy, subEnumSig);
                         offset += dl.getTypeAllocSize(fieldTy);
                     }
                 }

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -288,12 +288,23 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
             if (fit != enumIt->second.variantFields.end() && !pat->bindings.empty()) {
                 const std::vector<Pattern> *fieldPats =
                     unwrapEnumPayloadTuple(pat->bindings, fit->second.fieldTypes.size());
+                // Branch on tag match so payload loads only run when the tag is correct.
+                // Unconditional payload loads would reinterpret wrong-typed bytes (e.g.
+                // an int payload read as a str pointer) and could crash nested tests like strcmp.
+                llvm::BasicBlock *tagMatchBB = builder_.GetInsertBlock();
+                llvm::Function *fn = tagMatchBB->getParent();
+                auto *payloadBB = llvm::BasicBlock::Create(*ctx_, "ecp.payload", fn);
+                auto *mergeBB = llvm::BasicBlock::Create(*ctx_, "ecp.merge", fn);
+                builder_.CreateCondBr(testResult, payloadBB, mergeBB);
+
+                builder_.SetInsertPoint(payloadBB);
                 llvm::AllocaInst *tmpAlloca = builder_.CreateAlloca(subjectTy, nullptr, "ecp.test.tmp");
                 builder_.CreateStore(subjectVal, tmpAlloca);
                 llvm::Value *payloadPtr = builder_.CreateStructGEP(
                     enumIt->second.adtType, tmpAlloca, 1, "ecp.test.payload");
                 const llvm::DataLayout &dl = mod_->getDataLayout();
                 size_t offset = 0;
+                llvm::Value *fieldsMatch = llvm::ConstantInt::get(i1Ty_, 1);
                 for (size_t i = 0; i < fieldPats->size() && i < fit->second.fieldTypes.size(); ++i) {
                     llvm::Type *fieldTy = fit->second.fieldTypes[i];
                     uint64_t align = dl.getABITypeAlign(fieldTy).value();
@@ -306,9 +317,17 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                     const std::string &fieldTypeName = (i < fit->second.fieldTypeNames.size())
                         ? fit->second.fieldTypeNames[i] : std::string{};
                     llvm::Value *sub = emitPatternTest((*fieldPats)[i], fieldVal, fieldTy, fieldTypeName);
-                    testResult = builder_.CreateAnd(testResult, sub, "ecp.test.and");
+                    fieldsMatch = builder_.CreateAnd(fieldsMatch, sub, "ecp.test.and");
                     offset += dl.getTypeAllocSize(fieldTy);
                 }
+                llvm::BasicBlock *payloadEndBB = builder_.GetInsertBlock();
+                builder_.CreateBr(mergeBB);
+
+                builder_.SetInsertPoint(mergeBB);
+                llvm::PHINode *phi = builder_.CreatePHI(i1Ty_, 2, "ecp.final");
+                phi->addIncoming(llvm::ConstantInt::get(i1Ty_, 0), tagMatchBB);
+                phi->addIncoming(fieldsMatch, payloadEndBB);
+                testResult = phi;
             }
         } else if constexpr (std::is_same_v<T, SomePattern>) {
             if (!isOptionType(subjectTy))

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -463,11 +463,11 @@ std::string Formatter::formatPattern(const Pattern &pat) {
             return "Ok(" + v.binding + ")";
         } else if constexpr (std::is_same_v<T, ErrPattern>) {
             return "Err(" + v.binding + ")";
-        } else if constexpr (std::is_same_v<T, EnumConstructorPattern>) {
-            std::string result = v.enum_name + "::" + v.variant_name + "(";
-            for (size_t i = 0; i < v.bindings.size(); ++i) {
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>) {
+            std::string result = v->enum_name + "::" + v->variant_name + "(";
+            for (size_t i = 0; i < v->bindings.size(); ++i) {
                 if (i > 0) result += ", ";
-                result += v.bindings[i];
+                result += formatPattern(v->bindings[i]);
             }
             return result + ")";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<OrPattern>>) {

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -825,10 +825,8 @@ bool Parser::patternHasBinding(const Pattern &p) {
         return std::get<OkPattern>(p).binding != "_";
     if (std::holds_alternative<ErrPattern>(p))
         return std::get<ErrPattern>(p).binding != "_";
-    if (std::holds_alternative<EnumConstructorPattern>(p)) {
-        const auto &ec = std::get<EnumConstructorPattern>(p);
-        return std::any_of(ec.bindings.begin(), ec.bindings.end(),
-                           [](const std::string &b) { return b != "_"; });
+    if (auto *ecp = std::get_if<std::unique_ptr<EnumConstructorPattern>>(&p)) {
+        return std::any_of((*ecp)->bindings.begin(), (*ecp)->bindings.end(), patternHasBinding);
     }
     if (auto *tp = std::get_if<std::unique_ptr<TuplePattern>>(&p)) {
         return std::any_of((*tp)->elements.begin(), (*tp)->elements.end(), patternHasBinding);
@@ -1005,29 +1003,26 @@ Pattern Parser::parsePattern() {
             if (variant.kind != TokenKind::Ident)
                 parseError(variant.line, "expected variant name after '::'");
             lex_.next(); // consume variant name
-            // Check for constructor pattern: Enum::Variant(a, b, ...)
+            // Check for constructor pattern: Enum::Variant(a, b, ...) or Enum::Variant((x, y), ...)
             if (lex_.peek().kind == TokenKind::LParen) {
                 lex_.next(); // consume '('
-                std::vector<std::string> bindings;
+                std::vector<Pattern> bindings;
                 bindings.reserve(4);
                 if (lex_.peek().kind != TokenKind::RParen) {
                     for (;;) {
-                        Token binding = lex_.peek();
-                        if (binding.kind != TokenKind::Ident)
-                            parseError(binding.line, "expected binding name in constructor pattern");
-                        lex_.next();
-                        bindings.push_back(binding.value);
+                        bindings.push_back(parsePattern());
                         if (lex_.peek().kind != TokenKind::Comma)
                             break;
                         lex_.next(); // consume ','
                         if (lex_.peek().kind == TokenKind::RParen)
-                            break;
+                            break; // trailing comma
                     }
                 }
                 if (lex_.peek().kind != TokenKind::RParen)
                     parseError("expected ')' in constructor pattern");
                 lex_.next(); // consume ')'
-                return EnumConstructorPattern{t.value, variant.value, std::move(bindings)};
+                return std::make_unique<EnumConstructorPattern>(
+                    EnumConstructorPattern{t.value, variant.value, std::move(bindings)});
             }
             return EnumPattern{t.value, variant.value};
         }

--- a/src/sema_return.cpp
+++ b/src/sema_return.cpp
@@ -31,10 +31,12 @@ void collectPatternInfo(const Pattern &pat, PatternCoverage &cov,
             cov.hasSome = true;
         } else if constexpr (std::is_same_v<T, NonePattern>) {
             cov.hasNone = true;
-        } else if constexpr (std::is_same_v<T, EnumPattern> ||
-                             std::is_same_v<T, EnumConstructorPattern>) {
+        } else if constexpr (std::is_same_v<T, EnumPattern>) {
             if (cov.enumName.empty()) cov.enumName = p.enum_name;
             cov.coveredVariants.insert(p.variant_name);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>) {
+            if (cov.enumName.empty()) cov.enumName = p->enum_name;
+            cov.coveredVariants.insert(p->variant_name);
         } else if constexpr (std::is_same_v<T, LiteralPattern>) {
             if (auto *be = std::get_if<BoolExpr>(&p.value->data)) {
                 if (be->value) cov.hasTrue = true;

--- a/src/sema_return.cpp
+++ b/src/sema_return.cpp
@@ -5,6 +5,23 @@ namespace ry {
 
 namespace {
 
+// Returns true if `p` can never fail to match at runtime — i.e. it contains no
+// literals, no EnumPattern/EnumConstructorPattern with fixed tags, etc.
+// Used to decide whether an EnumConstructorPattern arm fully covers its variant.
+static bool isIrrefutable(const Pattern &p) {
+    return std::visit([](const auto &v) -> bool {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, WildcardPattern> ||
+                      std::is_same_v<T, VariablePattern>)
+            return true;
+        if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>)
+            return v && std::all_of(v->elements.begin(), v->elements.end(), isIrrefutable);
+        if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>)
+            return v && std::all_of(v->bindings.begin(), v->bindings.end(), isIrrefutable);
+        return false; // LiteralPattern, EnumPattern, SomePattern, etc. are refutable
+    }, p);
+}
+
 struct PatternCoverage {
     bool hasOk = false, hasErr = false;
     bool hasSome = false, hasNone = false;
@@ -36,7 +53,11 @@ void collectPatternInfo(const Pattern &pat, PatternCoverage &cov,
             cov.coveredVariants.insert(p.variant_name);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>) {
             if (cov.enumName.empty()) cov.enumName = p->enum_name;
-            cov.coveredVariants.insert(p->variant_name);
+            // Only mark variant as fully covered when every binding is irrefutable
+            // (variable or wildcard). Restrictive payloads like Click((0, 0)) only
+            // cover the variant partially and must not satisfy exhaustiveness.
+            if (p && std::all_of(p->bindings.begin(), p->bindings.end(), isIrrefutable))
+                cov.coveredVariants.insert(p->variant_name);
         } else if constexpr (std::is_same_v<T, LiteralPattern>) {
             if (auto *be = std::get_if<BoolExpr>(&p.value->data)) {
                 if (be->value) cov.hasTrue = true;

--- a/tests/spec/pattern_enum_nested.test.ry
+++ b/tests/spec/pattern_enum_nested.test.ry
@@ -1,0 +1,162 @@
+# Tests for nested patterns in enum constructor payloads (issue #990)
+
+# ── Setup ────────────────────────────────────────────────────────────────────
+
+enum Event:
+    Click(int, int)
+    Key(str)
+
+enum Wrapper:
+    Val(int)
+    Pair(int, int)
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("enum constructor pattern - nested tuple literal", ():
+    it("should match Event::Click((0, 0))", ():
+        e = Event::Click(0, 0)
+        matched = false
+        case e:
+            Event::Click((0, 0)):
+                matched = true
+            _:
+                matched = false
+        expect(matched).to_eq(true)
+    )
+
+    it("should not match Event::Click((0, 0)) when values differ", ():
+        e = Event::Click(1, 0)
+        matched = false
+        case e:
+            Event::Click((0, 0)):
+                matched = true
+            _:
+                matched = false
+        expect(matched).to_eq(false)
+    )
+)
+
+describe("enum constructor pattern - nested variable binding", ():
+    it("should bind x and y from Event::Click((x, y))", ():
+        e = Event::Click(3, 7)
+        x_out = 0
+        y_out = 0
+        case e:
+            Event::Click((x, y)):
+                x_out = x
+                y_out = y
+            _:
+                x_out = -1
+                y_out = -1
+        expect(x_out).to_eq(3)
+        expect(y_out).to_eq(7)
+    )
+)
+
+describe("enum constructor pattern - backward compat (flat bindings)", ():
+    it("should still work with Event::Click(a, b)", ():
+        e = Event::Click(10, 20)
+        a_out = 0
+        b_out = 0
+        case e:
+            Event::Click(a, b):
+                a_out = a
+                b_out = b
+            _:
+                a_out = -1
+                b_out = -1
+        expect(a_out).to_eq(10)
+        expect(b_out).to_eq(20)
+    )
+)
+
+describe("enum constructor pattern - nested literal (single field)", ():
+    it("should match Wrapper::Val(42) literally", ():
+        w = Wrapper::Val(42)
+        matched = false
+        case w:
+            Wrapper::Val(42):
+                matched = true
+            Wrapper::Val(_):
+                matched = false
+            _:
+                matched = false
+        expect(matched).to_eq(true)
+    )
+
+    it("should fall through to variable binding when literal does not match", ():
+        w = Wrapper::Val(99)
+        n_out = 0
+        case w:
+            Wrapper::Val(42):
+                n_out = -1
+            Wrapper::Val(n):
+                n_out = n
+            _:
+                n_out = -2
+        expect(n_out).to_eq(99)
+    )
+)
+
+describe("enum constructor pattern - mixed literal and variable", ():
+    it("should bind y from Wrapper::Pair(0, y)", ():
+        p = Wrapper::Pair(0, 99)
+        y_out = 0
+        case p:
+            Wrapper::Pair(0, y):
+                y_out = y
+            _:
+                y_out = -1
+        expect(y_out).to_eq(99)
+    )
+
+    it("should not match Wrapper::Pair(0, y) when first field is non-zero", ():
+        p = Wrapper::Pair(5, 99)
+        y_out = 0
+        case p:
+            Wrapper::Pair(0, y):
+                y_out = y
+            _:
+                y_out = -1
+        expect(y_out).to_eq(-1)
+    )
+)
+
+describe("enum constructor pattern - wildcard in nested tuple", ():
+    it("should bind y2 from Event::Click((_, y2))", ():
+        e = Event::Click(5, 8)
+        y2_out = 0
+        case e:
+            Event::Click((_, y2)):
+                y2_out = y2
+            _:
+                y2_out = -1
+        expect(y2_out).to_eq(8)
+    )
+)
+
+describe("enum constructor pattern - no match falls through to wildcard", ():
+    it("should take wildcard arm when nested literal does not match", ():
+        e = Event::Click(1, 2)
+        matched = false
+        case e:
+            Event::Click((0, _)):
+                matched = false
+            _:
+                matched = true
+        expect(matched).to_eq(true)
+    )
+)
+
+describe("enum constructor pattern - regression: non-nested variant", ():
+    it("should bind k from Event::Key(k)", ():
+        e = Event::Key("enter")
+        k_out = ""
+        case e:
+            Event::Key(k):
+                k_out = k
+            _:
+                k_out = "other"
+        expect(k_out).to_eq("enter")
+    )
+)

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2444,6 +2444,10 @@ TEST(ParserTest, EnumConstructorPatternNestedLiteral) {
     const auto &ep = *std::get<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern);
     ASSERT_EQ(ep.bindings.size(), 1u);
     ASSERT_TRUE(std::holds_alternative<LiteralPattern>(ep.bindings[0]));
+    const auto &lp = std::get<LiteralPattern>(ep.bindings[0]);
+    const auto *ne = std::get_if<NumberExpr>(&lp.value->data);
+    ASSERT_NE(ne, nullptr);
+    EXPECT_EQ(ne->value, 42);
 }
 
 TEST(ParserTest, EnumConstructorPatternNestedWildcard) {
@@ -2455,7 +2459,8 @@ TEST(ParserTest, EnumConstructorPatternNestedWildcard) {
     const auto &ep = *std::get<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern);
     ASSERT_EQ(ep.bindings.size(), 2u);
     EXPECT_TRUE(std::holds_alternative<WildcardPattern>(ep.bindings[0]));
-    EXPECT_TRUE(std::holds_alternative<VariablePattern>(ep.bindings[1]));
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(ep.bindings[1]));
+    EXPECT_EQ(std::get<VariablePattern>(ep.bindings[1]).name, "y");
 }
 
 TEST(ParserTest, DoubleTrailingCommaError) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2398,11 +2398,56 @@ TEST(ParserTest, EnumConstructorPatternTrailingComma) {
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CaseStmt>>(prog[0]));
     const auto &cs = *std::get<std::unique_ptr<CaseStmt>>(prog[0]);
     ASSERT_EQ(cs.arms.size(), 1u);
-    ASSERT_TRUE(std::holds_alternative<EnumConstructorPattern>(cs.arms[0].pattern));
-    const auto &ep = std::get<EnumConstructorPattern>(cs.arms[0].pattern);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern));
+    const auto &ep = *std::get<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern);
     ASSERT_EQ(ep.bindings.size(), 2u);
-    EXPECT_EQ(ep.bindings[0], "a");
-    EXPECT_EQ(ep.bindings[1], "b");
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(ep.bindings[0]));
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(ep.bindings[1]));
+    EXPECT_EQ(std::get<VariablePattern>(ep.bindings[0]).name, "a");
+    EXPECT_EQ(std::get<VariablePattern>(ep.bindings[1]).name, "b");
+}
+
+TEST(ParserTest, EnumConstructorPatternNestedTuple) {
+    Program prog = parseStr("case e:\n    Event::Click((x, y)):\n        print(x)\n");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CaseStmt>>(prog[0]));
+    const auto &cs = *std::get<std::unique_ptr<CaseStmt>>(prog[0]);
+    ASSERT_EQ(cs.arms.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern));
+    const auto &ep = *std::get<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern);
+    EXPECT_EQ(ep.enum_name, "Event");
+    EXPECT_EQ(ep.variant_name, "Click");
+    ASSERT_EQ(ep.bindings.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<TuplePattern>>(ep.bindings[0]));
+    const auto &tp = *std::get<std::unique_ptr<TuplePattern>>(ep.bindings[0]);
+    ASSERT_EQ(tp.elements.size(), 2u);
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(tp.elements[0]));
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(tp.elements[1]));
+    EXPECT_EQ(std::get<VariablePattern>(tp.elements[0]).name, "x");
+    EXPECT_EQ(std::get<VariablePattern>(tp.elements[1]).name, "y");
+}
+
+TEST(ParserTest, EnumConstructorPatternNestedLiteral) {
+    Program prog = parseStr("case w:\n    Wrap::Val(42):\n        print(42)\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &cs = *std::get<std::unique_ptr<CaseStmt>>(prog[0]);
+    ASSERT_EQ(cs.arms.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern));
+    const auto &ep = *std::get<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern);
+    ASSERT_EQ(ep.bindings.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<LiteralPattern>(ep.bindings[0]));
+}
+
+TEST(ParserTest, EnumConstructorPatternNestedWildcard) {
+    Program prog = parseStr("case w:\n    Wrap::Val(_, y):\n        print(y)\n");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &cs = *std::get<std::unique_ptr<CaseStmt>>(prog[0]);
+    ASSERT_EQ(cs.arms.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern));
+    const auto &ep = *std::get<std::unique_ptr<EnumConstructorPattern>>(cs.arms[0].pattern);
+    ASSERT_EQ(ep.bindings.size(), 2u);
+    EXPECT_TRUE(std::holds_alternative<WildcardPattern>(ep.bindings[0]));
+    EXPECT_TRUE(std::holds_alternative<VariablePattern>(ep.bindings[1]));
 }
 
 TEST(ParserTest, DoubleTrailingCommaError) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1879,6 +1879,14 @@ TEST(ParserTest, OrPatternRejectsEnumConstructorBinding) {
     }, std::runtime_error);
 }
 
+TEST(ParserTest, OrPatternRejectsNestedTupleBindingInEnumConstructor) {
+    // Nested tuple variable bindings inside constructor payloads must also be
+    // rejected in OR patterns, exercising the recursive patternHasBinding path.
+    EXPECT_THROW({
+        parseStr("case x:\n    Foo::Bar((a, b)) | Foo::Baz((c, d)):\n        print(a)\n");
+    }, std::runtime_error);
+}
+
 TEST(ParserTest, OrPatternAllowsWildcardBindings) {
     EXPECT_NO_THROW({
         parseStr("case x:\n    Ok(_) | Err(_):\n        print(\"done\")\n");


### PR DESCRIPTION
## Summary

- Generalises `EnumConstructorPattern::bindings` from `vector<string>` to `vector<Pattern>`, enabling literals, wildcards, and nested tuple patterns in ADT constructor arms
- A new static helper `unwrapEnumPayloadTuple` handles the `Event::Click((x, y))` sugar — a single TuplePattern with matching arity is unwrapped to match fields individually in both `emitPatternTest` and `emitPatternBindings`
- All 6 downstream files (`codegen_match`, `codegen_lambda`, `formatter`, `parser_decl`, `sema_return`, `ast.hpp`) updated for `unique_ptr<EnumConstructorPattern>` wrapping

Closes #990

## Patterns now supported

| Pattern | Example |
|---------|---------|
| Nested tuple literal | `Event::Click((0, 0))` |
| Nested tuple variable binding | `Event::Click((x, y))` |
| Wildcard + variable | `Event::Click((_, y))` |
| Single field literal | `Wrapper::Val(42)` |
| Mixed literal + variable | `Wrapper::Pair(0, y)` |
| Flat bindings (backward compat) | `Shape::Circle(r)` |

## Test plan

- [ ] 4 new parser unit tests (`EnumConstructorPatternNestedTuple`, `NestedLiteral`, `NestedWildcard`, updated `TrailingComma`)
- [ ] 11 new integration tests in `tests/spec/pattern_enum_nested.test.ry`
- [ ] `./build/ry_tests` — 1685 tests pass
- [ ] `./build/ry test -p` — 123 test files, 0 failures
- [ ] ASan+UBSan: 1685 C++ tests + 123 Ry tests pass clean
- [ ] TSan: 1685 C++ tests + 123 Ry self-tests pass clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enum constructor patterns now support nested payload patterns (tuples, literals, wildcards, and variables), e.g., Event::Click((x, y)) and Wrapper::Val(42).

* **Bug Fixes**
  * Pattern matching and exhaustiveness now correctly handle nested payloads and avoid false coverage or incorrect match behavior.

* **Documentation**
  * Reference docs and changelog updated with examples and explanation for nested constructor patterns.

* **Tests**
  * New tests cover nested enum constructor pattern matching and related parser/exhaustiveness regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->