### PR TITLE
fix(arc): retain collection param in Result/Option builder functions (#999)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1861,13 +1861,13 @@ This ensures the alloca for `a = make_result_fn()` carries `list_elem` metadata 
 without explicit type annotation, so `buildTypeNameFromMeta` can recover the type name
 at compare time.
 
-**ARC limitation — collections inside Result/Option returned from functions** (#999):
-`buildOkValue` / `buildErrValue` / `buildSomeValue` insert the raw collection pointer
-into the aggregate without retaining it. If the collection was created as a temporary and
-the function's local variable releases it on exit, the Result/Option contains a dangling
-pointer. Direct construction (`a: Result<List<int>, Error> = Ok([1, 2])`) is safe because
-no intermediate release occurs. Until #999 is fixed, regression tests for this path
-must use direct construction rather than function wrappers.
+**ARC — collections inside Result/Option returned from functions** (#999, fixed):
+`buildOkValue` / `buildErrValue` / `buildSomeValue` now call `tryRetainArcSource(inner)`
+when `inner->getType() == ptrTy_`. This retains the collection before scope cleanup at
+function exit can release the local variable. `tryRetainArcSource` handles the two relevant
+cases: LoadInst from an ARC-managed alloca (emits retain — the bugfix case) and
+`arc_owned_values_` (no-op — `Ok([1, 2])` inline construction stays unaffected).
+Regression tests live in `tests/spec/result_option_arc_return.test.ry`.
 
 **Limitation**: For `Result<List<T>, List<U>>` where both Ok and Err payloads are
 collections of different types, the metadata on the outer aggregate reflects whichever

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1864,9 +1864,15 @@ at compare time.
 **ARC — collections inside Result/Option returned from functions** (#999, fixed):
 `buildOkValue` / `buildErrValue` / `buildSomeValue` now call `tryRetainArcSource(inner)`
 when `inner->getType() == ptrTy_`. This retains the collection before scope cleanup at
-function exit can release the local variable. `tryRetainArcSource` handles the two relevant
-cases: LoadInst from an ARC-managed alloca (emits retain — the bugfix case) and
-`arc_owned_values_` (no-op — `Ok([1, 2])` inline construction stays unaffected).
+function exit can release the local variable. `tryRetainArcSource` handles three cases:
+1. `LoadInst` from an ARC-managed alloca (emits retain — the direct-param bugfix case)
+2. `arc_owned_values_` (no-op — `Ok([1, 2])` inline construction stays unaffected)
+3. `ExtractValueInst` (record/tuple field access via `CreateExtractValue`) — retains only
+   when collection metadata (`list_elem` / `map_key` / `set_elem`) is set on the value;
+   this guards against incorrectly retaining non-ARC `ptrTy_` values (closures, weak refs).
+Note: `codegen_expr.cpp` previously had a standalone `tryRetainArcSource(errVal)` after
+`buildErrValue` in the `?` operator error path. With Case 3 added, this became a
+double-retain and was removed — `buildErrValue` now handles the retain internally.
 Regression tests live in `tests/spec/result_option_arc_return.test.ry`.
 
 **Limitation**: For `Result<List<T>, List<U>>` where both Ok and Err payloads are

--- a/changelog.d/999-arc-result-option-return.md
+++ b/changelog.d/999-arc-result-option-return.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- Fix use-after-free when a function returns `Result` or `Option` wrapping a collection (List, Map, Set) parameter — the inner value is now retained before scope cleanup releases local variables (#999)
+- Fix use-after-free when a function returns `Result` or `Option` wrapping a collection (List, Map, Set) — covers direct parameters (`Ok(v)`) and record/tuple field access (`Ok(rec.field)`) — the inner value is now retained before scope cleanup releases local variables (#999)

--- a/changelog.d/999-arc-result-option-return.md
+++ b/changelog.d/999-arc-result-option-return.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix use-after-free when a function returns `Result` or `Option` wrapping a collection (List, Map, Set) parameter — the inner value is now retained before scope cleanup releases local variables (#999)

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -722,6 +722,17 @@ bool CodeGen::tryRetainArcSource(llvm::Value *val) {
     // but signal to caller that this is ARC-owned
     if (arc_owned_values_.count(val))
         return true;
+    // Case 3: ExtractValueInst — record/tuple field access (CreateExtractValue).
+    // Guard on collection metadata so closures, weak refs, and other non-ARC
+    // ptrTy_ values are not incorrectly retained (#999).
+    if (llvm::isa<llvm::ExtractValueInst>(val)) {
+        auto *meta = getMeta(val);
+        if (meta && (meta->list_elem || meta->map_key || meta->set_elem)) {
+            auto *hdr = emitArcGetHeaderFromData(val);
+            emitArcRetain(hdr, /*atomic=*/false);
+            return true;
+        }
+    }
     return false;
 }
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1841,7 +1841,6 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ErrorPropagateExpr> 
         }
         llvm::Value *retErr = buildErrValue(errVal, retResultTy);
         emitEnsureChecks(retErr);
-        tryRetainArcSource(errVal);
         emitScopeCleanupToDepth(0);
         builder_.CreateRet(retErr);
 

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -301,6 +301,10 @@ llvm::Value *CodeGen::buildOkValue(llvm::Value *inner, llvm::StructType *resultT
     val = builder_.CreateInsertValue(val, inner, 1, "res.ok_val");
     val = builder_.CreateInsertValue(val, llvm::Constant::getNullValue(resultTy->getElementType(2)), 2);
     propagateMeta(inner, val);
+    // Retain the inner collection so scope cleanup of the caller's local variable
+    // does not free it before the returned aggregate is consumed (#999).
+    if (inner->getType() == ptrTy_)
+        tryRetainArcSource(inner);
     return val;
 }
 
@@ -310,6 +314,10 @@ llvm::Value *CodeGen::buildErrValue(llvm::Value *inner, llvm::StructType *result
     val = builder_.CreateInsertValue(val, llvm::Constant::getNullValue(resultTy->getElementType(1)), 1);
     val = builder_.CreateInsertValue(val, inner, 2, "res.err_val");
     propagateMeta(inner, val);
+    // Retain the inner collection so scope cleanup of the caller's local variable
+    // does not free it before the returned aggregate is consumed (#999).
+    if (inner->getType() == ptrTy_)
+        tryRetainArcSource(inner);
     return val;
 }
 
@@ -447,6 +455,10 @@ llvm::Value *CodeGen::buildSomeValue(llvm::Value *inner, llvm::Type *optionTy) {
     val = builder_.CreateInsertValue(val, llvm::ConstantInt::get(i1Ty_, 1), 0);
     val = builder_.CreateInsertValue(val, inner, 1);
     propagateMeta(inner, val);
+    // Retain the inner collection so scope cleanup of the caller's local variable
+    // does not free it before the returned aggregate is consumed (#999).
+    if (inner->getType() == ptrTy_)
+        tryRetainArcSource(inner);
     return val;
 }
 

--- a/tests/spec/result_option_arc_return.test.ry
+++ b/tests/spec/result_option_arc_return.test.ry
@@ -1,0 +1,148 @@
+from runtime_internal import arc_live_count
+
+# Without the fix the collection parameter is freed by scope cleanup when the
+# function exits, leaving a dangling pointer in the returned Result/Option.
+
+function make_ok_list(v: List<int>) -> Result<List<int>, Error>:
+  return Ok(v)
+
+function make_ok_map(v: Map<str, int>) -> Result<Map<str, int>, Error>:
+  return Ok(v)
+
+function make_ok_set(v: Set<int>) -> Result<Set<int>, Error>:
+  return Ok(v)
+
+# Use Option<T> spelling (not T?) because the T? shorthand has a pre-existing
+# metadata propagation limitation for Option<Collection> (#999 scope: ARC only).
+function make_some_list(v: List<int>) -> Option<List<int>>:
+  return Some(v)
+
+function make_ok_inline() -> Result<List<int>, Error>:
+  return Ok([10, 20, 30])
+
+function make_err_list(v: List<int>) -> Result<int, List<int>>:
+  return Err(v)
+
+describe("Result/Option ARC return (#999)", ():
+  it("Ok(list_param) — data survives scope cleanup", ():
+    r: Result<List<int>, Error> = make_ok_list([1, 2, 3])
+    case r:
+      Ok(xs):
+        expect(xs.length()).to_eq(3)
+        expect(xs[0]).to_eq(1)
+        expect(xs[1]).to_eq(2)
+        expect(xs[2]).to_eq(3)
+      Err(e):
+        fail("unexpected Err: " + e.message)
+  )
+
+  it("Ok(map_param) — data survives scope cleanup", ():
+    r: Result<Map<str, int>, Error> = make_ok_map({"a": 1, "b": 2})
+    case r:
+      Ok(m):
+        expect(m["a"]).to_eq(1)
+        expect(m["b"]).to_eq(2)
+      Err(e):
+        fail("unexpected Err: " + e.message)
+  )
+
+  it("Ok(set_param) — data survives scope cleanup", ():
+    r: Result<Set<int>, Error> = make_ok_set({10, 20, 30})
+    case r:
+      Ok(s):
+        expect(s.length()).to_eq(3)
+        expect(s.contains(10)).to_be_true()
+        expect(s.contains(20)).to_be_true()
+        expect(s.contains(30)).to_be_true()
+      Err(e):
+        fail("unexpected Err: " + e.message)
+  )
+
+  it("Some(list_param) — data survives scope cleanup", ():
+    opt: Option<List<int>> = make_some_list([7, 8, 9])
+    case opt:
+      Some(xs):
+        expect(xs.length()).to_eq(3)
+        expect(xs[0]).to_eq(7)
+        expect(xs[2]).to_eq(9)
+      None:
+        fail("unexpected None")
+  )
+
+  it("Ok(list_param) — equality: original reproduction case from #999", ():
+    # Without the fix, both inner pointers dangled to the same freed memory
+    # and compared equal.
+    a: Result<List<int>, Error> = make_ok_list([1, 2])
+    b: Result<List<int>, Error> = make_ok_list([9, 9])
+    expect(a == b).to_be_false()
+    expect(a != b).to_be_true()
+  )
+
+  it("Ok(list_param) — equal values compare equal after fix", ():
+    a: Result<List<int>, Error> = make_ok_list([1, 2, 3])
+    b: Result<List<int>, Error> = make_ok_list([1, 2, 3])
+    expect(a == b).to_be_true()
+  )
+
+  it("Some(list_param) — equality: unequal lists", ():
+    a: Option<List<int>> = make_some_list([1, 2])
+    b: Option<List<int>> = make_some_list([9, 9])
+    expect(a == b).to_be_false()
+    expect(a != b).to_be_true()
+  )
+
+  it("Ok([inline]) inside function — no double-retain via arc_owned_values_", ():
+    # arc_owned_values_ path: tryRetainArcSource returns true without retaining.
+    before = arc_live_count()
+    r: Result<List<int>, Error> = make_ok_inline()
+    after_make = arc_live_count()
+    expect(after_make - before).to_eq(1)
+    case r:
+      Ok(xs):
+        expect(xs.length()).to_eq(3)
+        expect(xs[0]).to_eq(10)
+      Err(e):
+        fail("unexpected Err")
+  )
+
+  it("Ok(list_param) — inner list is alive after function returns (no use-after-free)", ():
+    # The critical invariant: arc_live_count rises by 1 when make_ok_list returns,
+    # proving that the retain in buildOkValue kept the list alive past scope cleanup.
+    before = arc_live_count()
+    r: Result<List<int>, Error> = make_ok_list([42, 43])
+    after_call = arc_live_count()
+    expect(after_call - before).to_eq(1)
+    case r:
+      Ok(xs):
+        expect(xs[0]).to_eq(42)
+        expect(xs[1]).to_eq(43)
+      Err(e):
+        fail("unexpected Err")
+  )
+
+  it("Err(list_param) — data survives scope cleanup", ():
+    # Two results with distinct lists; without the fix both inner pointers would
+    # dangle to the same freed memory and compare equal.
+    a: Result<int, List<int>> = make_err_list([5, 6, 7])
+    b: Result<int, List<int>> = make_err_list([8, 9, 10])
+    expect(a == b).to_be_false()
+  )
+
+  it("Err(list_param) — equality: unequal lists", ():
+    a: Result<int, List<int>> = make_err_list([1, 2])
+    b: Result<int, List<int>> = make_err_list([9, 9])
+    expect(a == b).to_be_false()
+    expect(a != b).to_be_true()
+  )
+
+  it("Err(list_param) — inner list is alive after function returns", ():
+    # arc_live_count rises by 1: the retain in buildErrValue keeps the list alive
+    # past scope cleanup of the parameter inside make_err_list.
+    before = arc_live_count()
+    r: Result<int, List<int>> = make_err_list([100, 200])
+    expect(arc_live_count() - before).to_eq(1)
+    case r:
+      Ok(_): fail("unexpected Ok")
+      Err(_): expect(arc_live_count() - before).to_eq(1)
+  )
+)

--- a/tests/spec/result_option_arc_return.test.ry
+++ b/tests/spec/result_option_arc_return.test.ry
@@ -3,6 +3,20 @@ from runtime_internal import arc_live_count
 # Without the fix the collection parameter is freed by scope cleanup when the
 # function exits, leaving a dangling pointer in the returned Result/Option.
 
+# --- Record-field extraction helpers (#999 ExtractValueInst case) ---
+# Ok(rec.field) / Some(rec.field) uses CreateExtractValue, which was not
+# previously handled by tryRetainArcSource.
+record Container:
+  items: List<int>
+
+function make_ok_from_field(c: Container) -> Result<List<int>, Error>:
+  return Ok(c.items)
+
+function make_some_from_field(c: Container) -> Option<List<int>>:
+  return Some(c.items)
+
+# --- Direct-parameter helpers ---
+
 function make_ok_list(v: List<int>) -> Result<List<int>, Error>:
   return Ok(v)
 
@@ -144,5 +158,38 @@ describe("Result/Option ARC return (#999)", ():
     case r:
       Ok(_): fail("unexpected Ok")
       Err(_): expect(arc_live_count() - before).to_eq(1)
+  )
+
+  # ExtractValueInst cases: Ok/Some wrapping a record field (#999 case 3)
+  it("Ok(rec.field) — data survives scope cleanup", ():
+    c = Container([10, 20, 30])
+    r: Result<List<int>, Error> = make_ok_from_field(c)
+    case r:
+      Ok(xs):
+        expect(xs.length()).to_eq(3)
+        expect(xs[0]).to_eq(10)
+        expect(xs[1]).to_eq(20)
+        expect(xs[2]).to_eq(30)
+      Err(e):
+        fail("unexpected Err: " + e.message)
+  )
+
+  it("Some(rec.field) — data survives scope cleanup", ():
+    c = Container([7, 8, 9])
+    opt: Option<List<int>> = make_some_from_field(c)
+    case opt:
+      Some(xs):
+        expect(xs.length()).to_eq(3)
+        expect(xs[0]).to_eq(7)
+        expect(xs[2]).to_eq(9)
+      None:
+        fail("unexpected None")
+  )
+
+  it("Ok(rec.field) — equality: distinct containers compare unequal", ():
+    r1: Result<List<int>, Error> = make_ok_from_field(Container([1, 2]))
+    r2: Result<List<int>, Error> = make_ok_from_field(Container([9, 9]))
+    expect(r1 == r2).to_be_false()
+    expect(r1 != r2).to_be_true()
   )
 )


### PR DESCRIPTION
## Summary

- **Root cause**: `buildOkValue`, `buildErrValue`, and `buildSomeValue` inserted the raw collection pointer into the aggregate without retaining it. When the function's local scope cleaned up, the refcount dropped to 0 and the collection was freed — leaving a dangling pointer in the returned `Result`/`Option`.
- **Fix**: Add `tryRetainArcSource(inner)` guarded by `inner->getType() == ptrTy_` in all three builder functions. `tryRetainArcSource` handles: (1) `LoadInst` from ARC-managed alloca → emits retain (the bugfix case); (2) `arc_owned_values_` (fresh inline allocation) → no-op, no double-retain.
- **Follow-ups filed**: #1003 (`T?` shorthand loses `list_elem` metadata), #1004 (`case Err(xs)` binding loses `list_elem` metadata for `Result<T, List<U>>`).

## Test plan

- [ ] `Ok(list_param)` / `Ok(map_param)` / `Ok(set_param)` — data survives scope cleanup
- [ ] `Some(list_param)` — data survives scope cleanup
- [ ] Equality: `make_ok_list([1,2]) != make_ok_list([9,9])` (original #999 reproduction case)
- [ ] Equality: equal values compare equal after fix
- [ ] Inline `Ok([1,2,3])` inside function — no double-retain via `arc_owned_values_`
- [ ] `arc_live_count` invariant: count rises by exactly 1 after function returns (Ok and Err)
- [ ] `Err(list_param)` — data survives scope cleanup; Err-side equality
- [ ] ASan+UBSan: 1682 C++ tests + 123 Ry test files — clean
- [ ] TSan: 1682 C++ tests + 123 Ry test files — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a use-after-free when returning Result/Option that wrap collection types (List, Map, Set); inner collections are now retained so returned values remain valid.

* **Documentation**
  * Updated ARC handling docs for Result/Option returns to reflect correct retention behavior.

* **Tests**
  * Added tests covering ARC lifetime, equality, and retention for returned Result/Option with collection payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->