### PR TITLE
fix(codegen): coerce Err(collection) to Result<Ok,Collection> at declaration site (#1001)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2119,3 +2119,25 @@ testResult = phi;
 **Rule**: In `collectPatternInfo` (`sema_return.cpp`), only call `cov.coveredVariants.insert(variant_name)` for an `EnumConstructorPattern` when every binding in `pat->bindings` is irrefutable (i.e. `WildcardPattern`, `VariablePattern`, or recursively-irrefutable `TuplePattern`). An arm like `Event::Click((0, 0))` only matches a subset of `Click` values — adding `Click` to `coveredVariants` unconditionally would make `isExhaustiveMatch()` unsound and allow a non-returning `case` to pass return analysis.
 
 **How to apply**: Use a small `isIrrefutable(const Pattern &)` recursive helper (see `src/sema_return.cpp`). Pattern types that are always refutable: `LiteralPattern`, `EnumPattern` (always a specific tag), `SomePattern`, `NonePattern`, etc. When adding any new pattern type to the language, update `isIrrefutable` accordingly. Pre-existing `EnumPattern` arms (without payload) are always irrefutable for their specific variant (the tag check is the only condition), so they continue to insert unconditionally.
+
+### ErrPattern binding in codegen_match.cpp must propagateMeta to preserve collection element-type metadata
+
+**Source**: #1001 (2026-04-16, implementation)
+**Tags**: codegen_match, pattern, Result, Err, metadata, collection, propagateMeta
+
+**Rule**: In `emitPatternBindings` (`codegen_match.cpp`), the `ErrPattern` arm must call `propagateMeta(subjectAlloca, varAlloca)` after storing the extracted Err payload — exactly like `OkPattern` (index 1) and `SomePattern` do. Without this call, the bound variable (e.g., `lst` in `Err(lst)`) loses the collection element-type metadata stored on the subject alloca. Any subsequent index access or collection-kind dispatch on the binding will then fail with "cannot determine list element type".
+
+**Why**: `CreateExtractValue` produces a new LLVM `Value *` that does not inherit the custom metadata stored in the compiler's `value_metadata_` side-table. `propagateMeta` is the mechanism to copy that metadata to the new binding alloca. The same pattern was already applied to `OkPattern` and `SomePattern`, but the `ErrPattern` arm was accidentally left without it — there was no test that could trigger the gap before #1001 made `Err(collection)` construction possible.
+
+**How to apply**: Whenever a new `xyzPattern` is added that extracts a sub-value from a subject alloca and introduces a binding variable, always add `propagateMeta(subjectAlloca, varAlloca)` after `CreateStore`. Review the neighbouring arms as a checklist.
+
+### Post-hoc Result coercion: preferred over modifying Ok/Err constructors for annotation-driven type resolution
+
+**Source**: #1001 (2026-04-16, design choice)
+**Tags**: codegen_stmt, coercion, Result, Ok, Err, annotation, emitVarDecl
+
+**Rule**: When `Err([...])` (or `Ok(...)`) yields a Result struct whose layout does not match the variable's type annotation, fix the mismatch in `emitVarDecl`'s post-hoc coercion chain (`coerceResultType`) rather than threading the annotation down into the Ok/Err constructor emitter in `codegen_call.cpp`.
+
+**Why**: The Ok/Err constructors can be called from many contexts (function arguments, return values, inlined expressions) where the target type is unavailable or ambiguous. Post-hoc coercion at the declaration site is localised, mirrors the existing Option auto-wrap pattern, and is safe because the inactive field of a Result is always zero (never read through the discriminant).
+
+**How to apply**: `coerceResultType(val, dstResTy)` in `codegen_stmt.cpp` — extract discriminant and the matching payload, zero the non-matching payload with `getNullValue`, rebuild via `CreateInsertValue`, then `propagateMeta(val, coerced)`. Return `nullptr` if both payload types differ (genuine type error). Add the same coercion branch to variable reassignment handlers for consistency.

--- a/changelog.d/1001-err-payload-coercion.md
+++ b/changelog.d/1001-err-payload-coercion.md
@@ -1,0 +1,11 @@
+### Fixed
+
+- `Err([...])` and similar Err-constructor expressions can now be coerced to a
+  `Result<Ok, Collection>` type annotation at variable declaration and reassignment
+  sites (e.g., `a: Result<int, List<int>> = Err([1, 2, 3])`).  Previously this
+  emitted a type error because the inferred struct layout differed from the
+  annotation layout (#1001).
+- Pattern-matching an `Err(binding)` arm now correctly propagates collection
+  element-type metadata to the bound variable, enabling index access and
+  collection operations on the Err payload without a "cannot determine list
+  element type" error.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1196,6 +1196,10 @@ public:
     bool isResultType(llvm::Type *ty);
     llvm::Value *buildOkValue(llvm::Value *inner, llvm::StructType *resultTy);
     llvm::Value *buildErrValue(llvm::Value *inner, llvm::StructType *resultTy);
+    // Coerce a Result value to a different Result struct type by rebuilding it
+    // with the destination layout.  Returns null if both payload types differ
+    // (genuine type error).
+    llvm::Value *coerceResultType(llvm::Value *val, llvm::StructType *dstResTy);
     llvm::Value *buildStaticError(const std::string &msg, const std::string &globalName);
     static std::vector<std::string> splitTypeArgs(const std::string &argsStr);
     std::vector<std::string> splitTupleSig(const std::string &tupleTypeSig);

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -445,6 +445,7 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 llvm::Value *errVal = builder_.CreateExtractValue(sv, 2, "err_val");
                 llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, errVal->getType());
                 builder_.CreateStore(errVal, varAlloca);
+                propagateMeta(subjectAlloca, varAlloca);
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
             llvm::Value *loaded = builder_.CreateLoad(subjectTy, subjectAlloca, "tup.load");

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -13,6 +13,41 @@ void CodeGen::emitDeprecationWarning(const std::string &name) {
     warnings_.push_back("warning: '" + name + "' is deprecated");
 }
 
+// ===== Result coercion helper =====
+
+llvm::Value *CodeGen::coerceResultType(llvm::Value *val,
+                                        llvm::StructType *dstResTy) {
+    auto *srcResTy = llvm::cast<llvm::StructType>(val->getType());
+
+    llvm::Type *srcOkTy  = srcResTy->getElementType(1);
+    llvm::Type *srcErrTy = srcResTy->getElementType(2);
+    llvm::Type *dstOkTy  = dstResTy->getElementType(1);
+    llvm::Type *dstErrTy = dstResTy->getElementType(2);
+
+    if (srcOkTy == dstOkTy && srcErrTy == dstErrTy)
+        return val; // no rebuild needed
+
+    // Both payload types differ: genuine type mismatch.
+    if (srcOkTy != dstOkTy && srcErrTy != dstErrTy)
+        return nullptr;
+
+    llvm::Value *disc = builder_.CreateExtractValue(val, 0, "res.disc");
+
+    // ConstantAggregateZero zeroes all fields; only the disc and the active
+    // (matching) payload need explicit InsertValue — the inactive slot stays 0.
+    llvm::Value *coerced = llvm::ConstantAggregateZero::get(dstResTy);
+    coerced = builder_.CreateInsertValue(coerced, disc, 0);
+    if (srcOkTy == dstOkTy)
+        coerced = builder_.CreateInsertValue(
+            coerced, builder_.CreateExtractValue(val, 1, "res.ok"), 1);
+    else
+        coerced = builder_.CreateInsertValue(
+            coerced, builder_.CreateExtractValue(val, 2, "res.err"), 2);
+
+    propagateMeta(val, coerced);
+    return coerced;
+}
+
 // ===== B3: emitVarDecl =====
 
 void CodeGen::emitVarDecl(const std::string &name,
@@ -298,6 +333,17 @@ void CodeGen::emitVarDecl(const std::string &name,
                             "' does not match expression type for variable '" + name + "'");
                     val = buildSomeValue(val, annotTy);
                     newTy = annotTy;
+                } else if (isResultType(annotTy) && isResultType(newTy)) {
+                    auto *dstResTy = llvm::cast<llvm::StructType>(annotTy);
+                    llvm::Value *resCoerced = coerceResultType(val, dstResTy);
+                    if (resCoerced) {
+                        val = resCoerced;
+                        newTy = annotTy;
+                    } else {
+                        codegenError(
+                            "type error: annotation '" + *annot +
+                            "' does not match expression type for variable '" + name + "'");
+                    }
                 } else if (isAnyType(annotTy)) {
                     val = wrapInAny(val);
                     newTy = anyTy_;
@@ -384,17 +430,11 @@ void CodeGen::emitVarDecl(const std::string &name,
             if (ann.size() > 7 && ann.substr(0, 7) == "Option<" && ann.back() == '>')
                 inner = ann.substr(7, ann.size() - 8);
             else if (ann.size() > 7 && ann.substr(0, 7) == "Result<" && ann.back() == '>') {
-                // Extract first type param: Result<Map<K,V>, E> → Map<K,V>
-                std::string params = ann.substr(7, ann.size() - 8);
-                int depth = 0;
-                for (size_t i = 0; i < params.size(); ++i) {
-                    if (params[i] == '<') ++depth;
-                    else if (params[i] == '>') --depth;
-                    else if (params[i] == ',' && depth == 0) {
-                        inner = params.substr(0, i);
-                        break;
-                    }
-                }
+                // Pass the full "Result<Ok,Err>" annotation to propagateTypeMeta, which
+                // handles both the Ok-payload and Err-payload collection cases with an
+                // automatic Ok→Err fallback (added in #985). This covers patterns like
+                // Result<int,List<int>> where the Err type carries the collection.
+                inner = ann;
             }
             if (!inner.empty())
                 propagateTypeMeta(inner, ptr);
@@ -797,6 +837,15 @@ void CodeGen::emitStmt(AssignStmt &s) {
         } else if (isAnyType(newTy) && canAnyHoldType(ptr->getAllocatedType())) {
             val = unwrapFromAny(val, ptr->getAllocatedType());
             newTy = val->getType();
+        } else if (isResultType(ptr->getAllocatedType()) && isResultType(newTy)) {
+            auto *dstResTy = llvm::cast<llvm::StructType>(ptr->getAllocatedType());
+            llvm::Value *resCoerced = coerceResultType(val, dstResTy);
+            if (resCoerced)
+                val = resCoerced;
+            else
+                codegenError(
+                    "type error: variable '" + s.name +
+                    "' cannot be reassigned to a different type");
         } else {
             auto *uvMeta = getMeta(ptr);
             if (uvMeta && !uvMeta->union_value_type.empty()) {
@@ -952,6 +1001,15 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
         } else if (isAnyType(newTy) && canAnyHoldType(valueTy)) {
             val = unwrapFromAny(val, valueTy);
             newTy = val->getType();
+        } else if (isResultType(valueTy) && isResultType(newTy)) {
+            auto *dstResTy = llvm::cast<llvm::StructType>(valueTy);
+            llvm::Value *resCoerced = coerceResultType(val, dstResTy);
+            if (resCoerced)
+                val = resCoerced;
+            else
+                codegenError(
+                    "type error: variable '" + s.name +
+                    "' cannot be reassigned to a different type");
         } else {
             auto *uvMeta = getMeta(anchor);
             if (uvMeta && !uvMeta->union_value_type.empty()) {

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -138,16 +138,8 @@ describe("equality — Result", ():
   )
 )
 
-# Helper for Err-side of Result<List<int>, Error> (no collection in parameters,
-# so no ARC lifetime issue when the function returns).
-function list_result_err(msg: str) -> Result<List<int>, Error>:
-  return Err(Error(msg))
-
 describe("equality — Result with collection payloads", ():
-  # Result<List<int>, Error> — Ok payload (#985)
-  # Ok([...]) with explicit annotation works; Err(Error(...)) requires the helper
-  # because bare `Err(...)` cannot be coerced to a specific Result type at the
-  # variable declaration site.
+  # Result<List<int>, Error> — Ok payload (#985), Err inline coercion (#1001)
   it("should consider Ok equal List<int> values equal", ():
     a: Result<List<int>, Error> = Ok([1, 2, 3])
     b: Result<List<int>, Error> = Ok([1, 2, 3])
@@ -161,12 +153,12 @@ describe("equality — Result with collection payloads", ():
   )
   it("should consider Ok vs Err unequal for List<int>", ():
     a: Result<List<int>, Error> = Ok([1, 2])
-    b = list_result_err("e")
+    b: Result<List<int>, Error> = Err(Error("e"))
     expect(a != b).to_be_true()
   )
   it("should consider two Err equal for List<int> Ok-type", ():
-    a = list_result_err("oops")
-    b = list_result_err("oops")
+    a: Result<List<int>, Error> = Err(Error("oops"))
+    b: Result<List<int>, Error> = Err(Error("oops"))
     expect(a == b).to_be_true()
   )
   # Result<Map<str, int>, Error> — Ok payload (#985)

--- a/tests/spec/result_coerce.test.ry
+++ b/tests/spec/result_coerce.test.ry
@@ -1,0 +1,92 @@
+# Tests for post-hoc Result coercion at variable declaration sites (#1001).
+# Verifies that Ok/Err constructors can be coerced to match a type annotation
+# when the inferred struct layout differs from the annotation layout.
+
+describe("Result coercion — Err with collection payload", ():
+  it("Err([1,2,3]) coerces to Result<int, List<int>>", ():
+    a: Result<int, List<int>> = Err([1, 2, 3])
+    expect(a).to_be_err()
+  )
+  it("Err payload List<int> is accessible via pattern match", ():
+    a: Result<int, List<int>> = Err([1, 2, 3])
+    case a:
+      Ok(v):
+        fail("expected Err")
+      Err(lst):
+        expect(lst[0]).to_eq(1)
+        expect(lst[1]).to_eq(2)
+        expect(lst[2]).to_eq(3)
+  )
+  it("Ok arm is unreachable for Err value", ():
+    a: Result<int, List<int>> = Err([10, 20])
+    matched_ok = false
+    case a:
+      Ok(v):
+        matched_ok = true
+      Err(lst):
+        expect(lst.length()).to_eq(2)
+    expect(matched_ok).to_be_false()
+  )
+)
+
+describe("Result coercion — Err with Error payload, non-Error Ok type", ():
+  it("Err(Error('fail')) coerces to Result<int, Error>", ():
+    a: Result<int, Error> = Err(Error("fail"))
+    expect(a).to_be_err()
+  )
+  it("Err payload message is accessible via pattern match", ():
+    a: Result<int, Error> = Err(Error("something went wrong"))
+    case a:
+      Ok(v):
+        fail("expected Err")
+      Err(e):
+        expect(e.message).to_eq("something went wrong")
+  )
+)
+
+describe("Result coercion — Ok with non-Error Err type", ():
+  it("Ok(42) coerces to Result<int, str>", ():
+    a: Result<int, str> = Ok(42)
+    expect(a).to_be_ok()
+  )
+  it("Ok payload is accessible via pattern match for Result<int, str>", ():
+    a: Result<int, str> = Ok(99)
+    case a:
+      Ok(v):
+        expect(v).to_eq(99)
+      Err(s):
+        fail("expected Ok")
+  )
+)
+
+describe("Result coercion — equality after coercion", ():
+  it("two Err([...]) coerced to Result<int, List<int>> are equal when payloads match", ():
+    a: Result<int, List<int>> = Err([1, 2, 3])
+    b: Result<int, List<int>> = Err([1, 2, 3])
+    expect(a == b).to_be_true()
+  )
+  it("two Err([...]) coerced to Result<int, List<int>> are unequal when payloads differ", ():
+    a: Result<int, List<int>> = Err([1, 2, 3])
+    b: Result<int, List<int>> = Err([4, 5, 6])
+    expect(a == b).to_be_false()
+    expect(a != b).to_be_true()
+  )
+  it("Ok vs Err are unequal after coercion", ():
+    a: Result<int, List<int>> = Ok(1)
+    b: Result<int, List<int>> = Err([1, 2, 3])
+    expect(a != b).to_be_true()
+  )
+)
+
+describe("Result coercion — variable reassignment", ():
+  it("Err([...]) can be reassigned to Result<int, List<int>> variable", ():
+    a: Result<int, List<int>> = Ok(1)
+    a = Err([7, 8, 9])
+    expect(a).to_be_err()
+    case a:
+      Ok(v):
+        fail("expected Err")
+      Err(lst):
+        expect(lst[0]).to_eq(7)
+  )
+)


### PR DESCRIPTION
## Summary

- Adds `coerceResultType` helper in `codegen_stmt.cpp` that rebuilds a Result struct to match a type annotation layout, carrying the active payload and zeroing the inactive slot
- Wires the coercion into `emitVarDecl`, local `AssignStmt`, and module-global reassignment coercion chains (mirrors the existing Option auto-wrap pattern)
- Fixes `ErrPattern` bindings in `codegen_match.cpp` to call `propagateMeta(subjectAlloca, varAlloca)` — was missing unlike `OkPattern`/`SomePattern`, causing index access on bound `lst` to fail with "cannot determine list element type"
- Updates `emitVarDecl` metadata block to pass full `Result<Ok,Err>` annotation to `propagateTypeMeta` so the Err-side collection type (`List<int>` in `Result<int, List<int>>`) propagates correctly
- Removes the `list_result_err` workaround helper from `equality.test.ry` and inlines with type annotations
- Adds `tests/spec/result_coerce.test.ry` (11 test cases covering construction, pattern match, equality, and reassignment)

## Test plan

- [ ] `cmake --preset default && cmake --build build && ./build/ry_tests` — 1686 tests pass
- [ ] `./build/ry test -p` — 124 files, 0 failures (includes new `result_coerce.test.ry`)
- [ ] `./build/ry test tests/spec/result_coerce.test.ry` — 11/11 pass
- [ ] `./build/ry test tests/spec/combinatorial/equality.test.ry` — 123/123 pass (no `list_result_err` helper)
- [ ] ASan + UBSan: `cmake --preset asan && cmake --build build-asan` + both test runners — clean
- [ ] TSan: `cmake --preset tsan && cmake --build build-tsan` + `ry_tests` — clean

Closes #1001

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Result error values can now be coerced to annotated Result types containing collections, resolving type mismatch errors.
  * Pattern matching on error value bindings now properly preserves collection element-type metadata, eliminating "cannot determine list element type" failures when accessing error payloads.

* **Tests**
  * Added comprehensive test coverage for Result type coercion at variable declaration and reassignment sites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->