### PR TITLE
fix(codegen): propagate collection metadata for T? shorthand return type (#1003)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2147,3 +2147,14 @@ testResult = phi;
 **Why**: The Ok/Err constructors can be called from many contexts (function arguments, return values, inlined expressions) where the target type is unavailable or ambiguous. Post-hoc coercion at the declaration site is localised, mirrors the existing Option auto-wrap pattern, and is safe because the inactive field of a Result is always zero (never read through the discriminant).
 
 **How to apply**: `coerceResultType(val, dstResTy)` in `codegen_stmt.cpp` — extract discriminant and the matching payload, zero the non-matching payload with `getNullValue`, rebuild via `CreateInsertValue`, then `propagateMeta(val, coerced)`. Return `nullptr` if both payload types differ (genuine type error). Add the same coercion branch to variable reassignment handlers for consistency.
+
+### `propagateTypeMeta`: handle both `Option<T>` prefix and `T?` suffix — they are the same type
+
+**Source**: #1003 (2026-04-16, bugfix)
+**Tags**: codegen, metadata, option, shorthand, list_elem, propagateTypeMeta, OptionalType
+
+**Rule**: Whenever you add or modify a code path that recognises `"Option<..."` as a prefix string, also handle the `"T?"` suffix form. `OptionalType::toString()` (`src/type_node.cpp:51-52`) emits the `"?"` suffix form, and `OverloadEntry::returnTypeName` stores it verbatim. So functions declared as `-> List<int>?` have `returnTypeName = "List<int>?"`, not `"Option<List<int>>"`. A branch that only checks `resolved.compare(0, 7, "Option<")` will silently skip `T?` returns.
+
+**How to apply**: After the `Option<T>` branch, add an `else if (resolved.size() > 1 && resolved.back() == '?')` branch that strips the `?` and recurses: `propagateTypeMeta(resolved.substr(0, resolved.size() - 1), val)`. See `src/codegen_builtin.cpp:169-173` (added #1003) and the earlier precedent in `src/codegen_arc_gc.cpp:136-138`. The `resolveTypeAlias` function is a pure string map lookup and cannot produce `?`-suffixed strings for non-optional aliases (the lexer tokenises `?` as a standalone `Question` token, so identifiers cannot contain it), making the `resolved.back() == '?'` guard safe.
+
+**Known parallel gap (not yet fixed)**: `src/codegen_stmt.cpp:430` checks `ann.substr(0, 7) == "Option<"` when propagating collection metadata from a variable's explicit type annotation. The gap only matters when the RHS value carries no metadata of its own (e.g., `x: List<int>? = None`). Since `None` contains no collection, any subsequent index on `x` would raise a runtime unwrap error before metadata is needed — so the practical impact is negligible. Track in a future issue if a concrete regression is found.

--- a/changelog.d/1003-t-shorthand-metadata.md
+++ b/changelog.d/1003-t-shorthand-metadata.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `T?` shorthand return type now propagates collection metadata identically to
+  `Option<T>` — `xs.length()`, index access, and equality now work correctly for
+  functions declared as `-> List<T>?` / `-> Map<K,V>?` / `-> Set<T>?` (#1003)

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -166,6 +166,9 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
     } else if (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0 && resolved.back() == '>') {
         // Same treatment for Option<Collection> (#985 — mirrors Result handling above).
         propagateTypeMeta(resolved.substr(7, resolved.size() - 8), val);
+    } else if (resolved.size() > 1 && resolved.back() == '?') {
+        // T? suffix is OptionalType::toString() shorthand for Option<T> (#1003).
+        propagateTypeMeta(resolved.substr(0, resolved.size() - 1), val);
     } else if (isLowLevelTypeName(resolved)) {
         getOrCreateMeta(val).low_level_type_name = resolved;
     } else if (ensureEnumInstantiated(resolved)) {

--- a/tests/spec/option_shorthand_metadata.test.ry
+++ b/tests/spec/option_shorthand_metadata.test.ry
@@ -1,0 +1,72 @@
+function make_list_opt(v: List<int>) -> List<int>?:
+  return Some(v)
+
+function make_map_opt(v: Map<str, int>) -> Map<str, int>?:
+  return Some(v)
+
+function make_set_opt(v: Set<int>) -> Set<int>?:
+  return Some(v)
+
+function make_list_none() -> List<int>?:
+  return None
+
+describe("T? shorthand return type — metadata propagation (#1003)", ():
+  it("List<int>? — length() reflects actual element count", ():
+    opt = make_list_opt([7, 8, 9])
+    case opt:
+      Some(xs):
+        expect(xs.length()).to_eq(3)
+      None:
+        fail("unexpected None")
+  )
+
+  it("List<int>? — index access works", ():
+    opt = make_list_opt([7, 8, 9])
+    case opt:
+      Some(xs):
+        expect(xs[0]).to_eq(7)
+        expect(xs[1]).to_eq(8)
+        expect(xs[2]).to_eq(9)
+      None:
+        fail("unexpected None")
+  )
+
+  it("List<int>? — equality: same contents → true", ():
+    a = make_list_opt([1, 2, 3])
+    b = make_list_opt([1, 2, 3])
+    expect(a == b).to_be_true()
+  )
+
+  it("List<int>? — equality: different contents → false", ():
+    a = make_list_opt([1, 2])
+    b = make_list_opt([9, 9])
+    expect(a == b).to_be_false()
+  )
+
+  it("List<int>? — equality: Some vs None → false", ():
+    a = make_list_opt([1, 2])
+    b = make_list_none()
+    expect(a == b).to_be_false()
+  )
+
+  it("Map<str,int>? — key lookup works", ():
+    opt = make_map_opt({"x": 42, "y": 7})
+    case opt:
+      Some(m):
+        expect(m["x"]).to_eq(42)
+        expect(m["y"]).to_eq(7)
+      None:
+        fail("unexpected None")
+  )
+
+  it("Set<int>? — length() and contains() work", ():
+    opt = make_set_opt({10, 20, 30})
+    case opt:
+      Some(s):
+        expect(s.length()).to_eq(3)
+        expect(s.contains(10)).to_be_true()
+        expect(s.contains(99)).to_be_false()
+      None:
+        fail("unexpected None")
+  )
+)


### PR DESCRIPTION
## Summary

- `propagateTypeMeta` in `src/codegen_builtin.cpp` only matched `Option<T>` prefix strings. Functions declared as `-> List<int>?` (where `OptionalType::toString()` emits the `"T?"` suffix form stored verbatim in `OverloadEntry::returnTypeName`) were silently skipped, losing `list_elem` / `map_key` / `set_elem` metadata.
- Add a new `else if` branch that strips the `?` suffix and recurses, mirroring the `Option<T>` branch and the existing precedent at `src/codegen_arc_gc.cpp:136-138`.
- Fixes three reported symptoms: `xs.length()` returning 1 instead of actual count, `xs[0]` failing with "cannot determine list element type for index access", and `==` falling back to pointer comparison.

## Test plan

- [ ] New spec: `tests/spec/option_shorthand_metadata.test.ry` — 7 cases covering `List<int>?`, `Map<str,int>?`, `Set<int>?` (length, index access, equality same/different/Some-vs-None, key lookup, contains)
- [ ] `./build/ry test tests/spec/option_shorthand_metadata.test.ry` → 7 passed, 0 failed
- [ ] `./build/ry test -p` → 0 failures
- [ ] ASan+UBSan: `ry_tests` 1686 passed, `ry test -p` 0 failures
- [ ] TSan: `ry_tests` 1686 passed (required), `ry test -p` 0 failures (warn-only)

Closes #1003

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Collection metadata now propagates correctly for functions declared with nullable collection return types using the `T?` shorthand notation—for example, `List<T>?`, `Map<K,V>?`, and `Set<T>?`. This ensures collection behaviors including `length`, index access, and equality comparison work as expected.

* **Tests**
  * Added comprehensive test suite for optional shorthand metadata propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->