### PR TITLE
test(match): add regression tests for Err(xs) named binding metadata propagation (#1004)

### DIFF
--- a/tests/spec/result_option_arc_return.test.ry
+++ b/tests/spec/result_option_arc_return.test.ry
@@ -193,3 +193,53 @@ describe("Result/Option ARC return (#999)", ():
     expect(r1 != r2).to_be_true()
   )
 )
+
+describe("Err(xs) named binding — metadata propagation (#1004)", ():
+  # Regression guard: all four cases fail on a pre-#1001 build (list_elem metadata
+  # not propagated to the Err binding alloca) and pass on current HEAD.
+
+  it("Err(xs) from function return — xs.length() and xs[0]", ():
+    r: Result<int, List<int>> = make_err_list([5, 6, 7])
+    case r:
+      Ok(_):
+        fail("unexpected Ok")
+      Err(xs):
+        expect(xs.length()).to_eq(3)
+        expect(xs[0]).to_eq(5)
+  )
+
+  it("Err(xs) inferred type — no type annotation on declaration", ():
+    # Guards against a regression where only the annotation path propagates
+    # metadata correctly.
+    r = make_err_list([100, 200])
+    case r:
+      Ok(_):
+        fail("unexpected Ok")
+      Err(xs):
+        expect(xs.length()).to_eq(2)
+        expect(xs[0]).to_eq(100)
+  )
+
+  it("Err(xs) full indexing sweep — all three elements accessible", ():
+    # Verifies list_elem_type_name is persistent across multiple index dispatches
+    # on the same Err binding.
+    r: Result<int, List<int>> = make_err_list([10, 20, 30])
+    case r:
+      Ok(_):
+        fail("unexpected Ok")
+      Err(xs):
+        expect(xs.length()).to_eq(3)
+        expect(xs[1]).to_eq(20)
+        expect(xs[2]).to_eq(30)
+  )
+
+  it("Err(xs) in case expression form — xs.length() via CaseExpr path", ():
+    # CaseExpr code path in codegen_match.cpp is distinct from CaseStmt;
+    # protects CaseExpr metadata propagation.
+    r: Result<int, List<int>> = make_err_list([7, 8, 9])
+    v = case r:
+      Ok(_) => 0
+      Err(xs) => xs.length()
+    expect(v).to_eq(3)
+  )
+)


### PR DESCRIPTION
## Summary

- Adds a `describe` block with 4 regression test cases to `tests/spec/result_option_arc_return.test.ry` for issue #1004
- The bug (list_elem metadata lost on named `Err(xs)` pattern bindings when the `Result<int, List<int>>` value comes from a function return) was already fixed by #1001 as a side effect
- No source code changes; test coverage only

## Background

The existing test suite had two near-hits but missed the exact reporter scenario:

- `result_coerce.test.ry` binds `Err(lst)` with `.length()`/indexing, but the source is always a **direct `Err([...])` literal** at the declaration site, not a function return
- `result_option_arc_return.test.ry` sources from `make_err_list(...)` (the issue's exact helper) but deliberately uses `Err(_)` wildcard binding — the workaround the issue reporter flagged as masking the bug

So the combination **function-return source + named `Err(xs)` binding + `xs.length()` + `xs[0]`** had no direct coverage.

## New test cases

All four cases fail on a pre-#1001 build and pass on current HEAD.

| Case | What it guards |
|---|---|
| `Err(xs)` from function return — `xs.length()` and `xs[0]` | Exact issue #1004 reproducer |
| `Err(xs)` inferred type — no annotation | Guards the non-annotation codegen path |
| `Err(xs)` full indexing sweep — `xs[1]`, `xs[2]` | `list_elem_type_name` persistence across multiple index dispatches |
| `Err(xs)` in `case` expression form | `CaseExpr` path in `codegen_match.cpp` (distinct from `CaseStmt`) |

## Verification

- Reproducer confirmed working on HEAD: `./build/ry /tmp/repro_1004.ry` → `3\n5`
- `./build/ry test tests/spec/result_option_arc_return.test.ry` → 19 passed, 0 failed
- `./build/ry test -p` → 126 files, 0 failures
- `./build/ry_tests` → 1686 tests, 0 failures
- ASan+UBSan: clean
- TSan (C++ tests): clean

Closes #1004 (fixed by #1001; this PR adds the regression test coverage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for error result bindings to verify metadata is correctly retained during pattern matching, function returns, and element access operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->