### PR TITLE
fix(runtime): use arc_alloc for IOListHeader to prevent ARC retain crash (#1007)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1196,6 +1196,48 @@ directly for the tail line.
 
 ## Runtime / Memory
 
+### Runtime functions returning ARC-managed structs must use `arc_alloc`, not `checked_malloc`
+
+**Source**: #1007 (2026-04-16, bug fix), PR #997 (pattern established for ListHeader)
+**Tags**: arc, runtime, memory-safety, iolistheader, listheader, mapheader, gotcha
+
+**Rule**: Any runtime function that returns a heap-allocated struct (e.g.
+`IOListHeader`, `ListHeader`, `MapHeader`) **to Ry code** must allocate the
+struct with `arc_alloc`, not `checked_malloc`.
+
+**Why**: `emitVarDecl` in the codegen emits a retain that reads
+`header_ptr - ARC_HEADER_SIZE` (16 bytes) to increment the strong-count.
+When the header was allocated with `checked_malloc` that region is malloc
+metadata, not an ARC counter. Corrupting it and then calling
+`arc_release`/`__ry_arc_free_counted` on scope exit causes a crash:
+
+```
+malloc: *** error for object 0x...: pointer being freed was not allocated
+```
+
+ASan builds do not reproduce the crash because the allocator's internal
+layout differs and the metadata region happens not to be misinterpreted as
+zero.
+
+**Affected sites in this codebase** (checked 2026-04-16):
+
+| Function | File | Fixed by |
+|---|---|---|
+| `makeStringList`, `makeMatchList` | `include/ry/runtime_list.hpp` | PR #997 |
+| `makeByteList` | `include/ry/runtime_io.hpp` | PR #1007 |
+| `__ry_read_bytes` | `src/runtime_io.cpp` | PR #1007 |
+| `makeEmptyIOList`, `__ry_tcp_receive` | `src/runtime_net.cpp` | PR #1007 |
+| `__ry_tls_receive` | `src/runtime_tls.cpp` | PR #1007 |
+
+**Error-path pairing**: when an allocation succeeds with `arc_alloc` but
+the function later bails out before returning to Ry, free with `arc_free`,
+not `free`. Example: `__ry_tcp_receive` allocates the header with
+`arc_alloc`, then on `recv()` error calls `free(header->data)` (plain `free`
+because the data buffer uses `checked_malloc`) and `arc_free(header)`.
+
+**Also**: C++ tests that call these runtime functions directly must also use
+`arc_free` (not `free`) to release the returned struct.
+
 ### RWLock dispatch state must be thread-local, not guarded by a shared mutex
 
 **Source**: #871 (2026-04-11, implementation; follow-up to #630 P1 audit)

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1211,7 +1211,7 @@ When the header was allocated with `checked_malloc` that region is malloc
 metadata, not an ARC counter. Corrupting it and then calling
 `arc_release`/`__ry_arc_free_counted` on scope exit causes a crash:
 
-```
+```text
 malloc: *** error for object 0x...: pointer being freed was not allocated
 ```
 

--- a/changelog.d/1007-iolistheader-arc-alloc.md
+++ b/changelog.d/1007-iolistheader-arc-alloc.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `to_bytes`, `read_bytes`, `tcp_receive`, `tls_receive`, HTTP `body_bytes` が返す `List<u8>` を変数に代入すると macOS で `malloc: *** error for object ...: pointer being freed was not allocated` がクラッシュしていた問題を修正 (#1007)

--- a/include/ry/runtime_io.hpp
+++ b/include/ry/runtime_io.hpp
@@ -5,6 +5,7 @@
 #include <cstring>
 
 #include "ry/runtime_alloc.hpp"
+#include "ry/runtime_arc.hpp"
 
 
 namespace ry {
@@ -18,10 +19,19 @@ struct IOListHeader {
     int8_t *data;
 };
 
-// Build a heap-allocated IOListHeader from raw bytes.
+// Build an ARC-managed empty IOListHeader (len=0, data=nullptr).
+inline IOListHeader *makeEmptyIOList() {
+    auto *header = (IOListHeader *)arc_alloc(sizeof(IOListHeader));
+    header->len = 0;
+    header->cap = 0;
+    header->data = nullptr;
+    return header;
+}
+
+// Build an ARC-managed IOListHeader from raw bytes.
 // Each byte is stored as an int8_t element.
 inline IOListHeader *makeByteList(const uint8_t *bytes, int64_t len) {
-    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
+    auto *header = (IOListHeader *)arc_alloc(sizeof(IOListHeader));
     header->len = len;
     header->cap = len;
     if (len > 0) {

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -174,7 +174,7 @@ extern "C" void *__ry_read_bytes(const char *path) {
     }
     fseek(f, 0, SEEK_SET);
 
-    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
+    auto *header = (IOListHeader *)arc_alloc(sizeof(IOListHeader));
     header->data = (int8_t *)checked_malloc(static_cast<size_t>(size));
     size_t nread = fread(header->data, 1, static_cast<size_t>(size), f);
     header->len = (int64_t)nread;

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -174,27 +174,18 @@ extern "C" int64_t __ry_tcp_send(void *stream, void *byte_list) {
     return (int64_t)sent;
 }
 
-static IOListHeader *makeEmptyIOList() {
-    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
-    header->len = 0;
-    header->cap = 0;
-    header->data = nullptr;
-    return header;
-}
-
 extern "C" void *__ry_tcp_receive(void *stream, int64_t max_bytes) {
     if (max_bytes <= 0) {
         return makeEmptyIOList();
     }
     auto *handle = (TcpStreamHandle *)stream;
     ry_net_apply_default_recv_timeout(handle->fd);
-    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
+    auto *header = (IOListHeader *)arc_alloc(sizeof(IOListHeader));
     header->data = (int8_t *)checked_malloc((size_t)max_bytes);
     ssize_t n = ::recv(handle->fd, header->data, (size_t)max_bytes, 0);
     if (n < 0) {
-        // Error: free everything and return nullptr
         free(header->data);
-        free(header);
+        arc_free(header);
         return nullptr;
     }
     if (n == 0) {

--- a/src/runtime_tls.cpp
+++ b/src/runtime_tls.cpp
@@ -154,21 +154,17 @@ extern "C" void *__ry_tls_receive(void *tls_stream, int64_t max_bytes) {
     auto *h = (TlsStreamHandle *)tls_stream;
     ry_net_apply_default_recv_timeout(h->fd);
     if (max_bytes <= 0) {
-        auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
-        header->len = 0;
-        header->cap = 0;
-        header->data = nullptr;
-        return header;
+        return makeEmptyIOList();
     }
     auto *handle = (TlsStreamHandle *)tls_stream;
 
-    auto *header = (IOListHeader *)checked_malloc(sizeof(IOListHeader));
+    auto *header = (IOListHeader *)arc_alloc(sizeof(IOListHeader));
     header->data = (int8_t *)checked_malloc((size_t)max_bytes);
 
     int n = SSL_read(handle->ssl, header->data, (int)max_bytes);
     if (n < 0) {
         free(header->data);
-        free(header);
+        arc_free(header);
         return nullptr;
     }
     if (n == 0) {

--- a/tests/spec/arc_iolist.test.ry
+++ b/tests/spec/arc_iolist.test.ry
@@ -1,0 +1,56 @@
+# Issue #1007: IOListHeader must use arc_alloc so that ARC retain/release works
+# correctly on List<u8> values returned by to_bytes / read_bytes.
+#
+# Root cause: emitVarDecl reads header_ptr - 16 (the ARC prefix) on every
+# assignment.  When the header was allocated with checked_malloc, that region
+# is malloc metadata, not an ARC counter.  Corrupting it and then calling
+# arc_release on scope exit caused a crash.  After switching to arc_alloc the
+# ARC prefix is valid and retain/release work correctly.
+#
+# Verification strategy (KNOWLEDGE.md:153-169):
+#   Delta-based arc_live_count assertions — take a snapshot before the block,
+#   overwrite the slot N times, check that the live-count delta equals exactly
+#   the number of containers still held (not N).  If release is broken (i.e.
+#   the old checked_malloc path) the delta grows linearly with N instead.
+
+from runtime_internal import arc_live_count
+from io import to_bytes, read_bytes, write_bytes, delete_file
+
+describe("IOListHeader ARC correctness (#1007)", ():
+  it("to_bytes — overwrite does not leak (arc_live_count stays constant)", ():
+    before = arc_live_count()
+    bs: List<u8> = to_bytes("first")
+    bs = to_bytes("second")
+    bs = to_bytes("third")
+    bs = to_bytes("fourth")
+    after = arc_live_count()
+    # Without the fix delta grows to 4 (each overwrite leaks the previous
+    # header); with arc_alloc exactly 1 remains live.
+    expect(after - before).to_eq(1)
+  )
+
+  it("read_bytes — result is an ARC-managed List<u8> (arc_live_count +1)", ():
+    path = "/tmp/ry_arc_iolist_test.bin"
+    seed = to_bytes("hello arc")
+    case write_bytes(path, seed):
+      Ok(_):
+        ...
+      Err(e):
+        fail("write_bytes failed")
+    # seed counted before 'before', so only read_bytes result appears as delta.
+    before = arc_live_count()
+    case read_bytes(path):
+      Ok(rb):
+        after = arc_live_count()
+        # read_bytes allocated exactly 1 ARC-managed IOListHeader for rb.
+        expect(after - before).to_eq(1)
+        expect(rb.length()).to_eq(9)
+      Err(e):
+        fail("read_bytes failed")
+    case delete_file(path):
+      Ok(_):
+        ...
+      Err(e):
+        fail("delete_file failed")
+  )
+)

--- a/tests/test_codegen_net.cpp
+++ b/tests/test_codegen_net.cpp
@@ -271,7 +271,7 @@ TEST(TcpRecv, PeerCloseReturnsEmptyList) {
     EXPECT_EQ(result->cap, 0);
     EXPECT_EQ(result->data, nullptr);
 
-    free(result);
+    arc_free(result);
     ::close(fds[0]);
 }
 
@@ -459,7 +459,7 @@ TEST(TcpRecv, ZeroMaxBytesReturnsEmptyList) {
     EXPECT_EQ(result->cap, 0);
     EXPECT_EQ(result->data, nullptr);
 
-    free(result);
+    arc_free(result);
     ::close(fds[0]);
     ::close(fds[1]);
 }

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -1869,7 +1869,7 @@ TEST(RuntimeHttp, ReadRequestBodyWithNulByte) {
     EXPECT_EQ(bheader->data[3], 'c');
     EXPECT_EQ(bheader->data[4], 'd');
     free(bheader->data);
-    free(bheader);
+    arc_free(bheader);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -2023,7 +2023,7 @@ TEST_F(RuntimeHttpClientTest, ClientResponseBodyWithNulByte) {
     EXPECT_EQ(header->data[3], 'l');
     EXPECT_EQ(header->data[4], 'o');
     free(header->data);
-    free(header);
+    arc_free(header);
 
     __ry_http_client_response_free(resp);
     ::close(srv);
@@ -2058,7 +2058,7 @@ TEST_F(RuntimeHttpClientTest, ClientBodyBytesEmptyBody) {
     auto *header = (IOListHeader *)bytes;
     EXPECT_EQ(header->len, 0);
     free(header->data);
-    free(header);
+    arc_free(header);
 
     __ry_http_client_response_free(resp);
     ::close(srv);


### PR DESCRIPTION
## Summary

- `IOListHeader` returned by `to_bytes`, `read_bytes`, `tcp_receive`, `tls_receive`, and HTTP `body_bytes` was allocated with `checked_malloc`. `emitVarDecl` reads `header_ptr - 16` (the ARC prefix) on every `List<u8>`-typed variable assignment; with `checked_malloc` that region is malloc metadata, not an ARC counter. Corrupting it and then calling `arc_release` on scope exit caused `malloc: *** error for object ...: pointer being freed was not allocated` on macOS.
- Fix: allocate all `IOListHeader` structs returned to Ry with `arc_alloc` (same pattern as #997 for `makeStringList`/`makeMatchList`). Pair error-path `free(header)` → `arc_free(header)` in `__ry_tcp_receive` and `__ry_tls_receive`. Update C++ tests to use `arc_free` for headers obtained from runtime functions.
- Move `makeEmptyIOList` from a `static` function in `runtime_net.cpp` to an `inline` helper in `runtime_io.hpp` so `runtime_tls.cpp` can share it instead of duplicating.
- Add `arc_live_count` delta regression test in `tests/spec/arc_iolist.test.ry`.
- File scope-out bugs as #1010 (`__ry_split_chars`) and #1011 (`build_str_map`).

## Changed files

| File | Change |
|---|---|
| `include/ry/runtime_io.hpp` | Add `#include "ry/runtime_arc.hpp"`; move `makeEmptyIOList` here as `inline`; `makeByteList` → `arc_alloc` |
| `src/runtime_io.cpp` | `__ry_read_bytes` → `arc_alloc` |
| `src/runtime_net.cpp` | Remove `static makeEmptyIOList`; `__ry_tcp_receive` → `arc_alloc` + `arc_free` on error path |
| `src/runtime_tls.cpp` | `__ry_tls_receive` → `makeEmptyIOList()` + `arc_alloc` + `arc_free` on error path |
| `tests/test_codegen_net.cpp` | `free(result)` → `arc_free(result)` (2 places) |
| `tests/test_runtime_http.cpp` | `free(header/bheader)` → `arc_free(...)` (3 places) |
| `tests/spec/arc_iolist.test.ry` | New: `arc_live_count` delta regression test for `to_bytes` and `read_bytes` |
| `KNOWLEDGE.md` | New entry: ARC-managed struct allocation rule |
| `changelog.d/1007-iolistheader-arc-alloc.md` | Changelog fragment |

## Test plan

- [x] `./build/ry_tests` — 1686 C++ tests passed
- [x] `./build/ry test -p` — 127 Ry test files, 0 failures
- [x] ASan + UBSan: `./build-asan/ry_tests` + `./build-asan/ry test -p` — clean
- [x] TSan: `./build-tsan/ry_tests` + `./build-tsan/ry test -p` — clean, no races
- [x] `tests/spec/arc_iolist.test.ry` — both `arc_live_count` delta assertions pass

Closes #1007

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a macOS crash when assigning byte-list values returned from file, network, and HTTP body operations.

* **Documentation**
  * Added guidance about runtime/memory allocation expectations and an entry to the changelog noting the fix.

* **Tests**
  * Added and updated tests to validate ARC-managed byte-list behavior and correct test teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->