### PR TITLE
fix(runtime): use arc_alloc for ListHeader in __ry_split_chars (#1010)

### DIFF
--- a/changelog.d/1010-split-chars-arc-alloc.md
+++ b/changelog.d/1010-split-chars-arc-alloc.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `__ry_split_chars` (used by `split(str, "")`) now allocates its returned `ListHeader`
+  with `arc_alloc` so that ARC retain/release in `emitVarDecl` reads a valid counter
+  prefix. Previously the `checked_malloc` allocation placed malloc metadata at
+  `header_ptr - 16`, which could be corrupted by retain and crash on scope-exit
+  release with `pointer being freed was not allocated` on non-ASan macOS builds.
+  Same bug class as #1007. (#1010)

--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 
 #include "ry/runtime_alloc.hpp"
+#include "ry/runtime_arc.hpp"
 #include "ry/runtime_list.hpp"
 
 
@@ -179,7 +180,7 @@ void *__ry_split_chars(const char *s) {
         ++count;
 
     // Build ListHeader directly (avoids intermediate vector + double-copy)
-    auto *header = (ListHeader *)checked_malloc(sizeof(ListHeader));
+    auto *header = (ListHeader *)arc_alloc(sizeof(ListHeader));
     header->len = count;
     header->cap = count;
     header->data = (char **)checked_array_malloc(count ? static_cast<size_t>(count) : 1, sizeof(char *));

--- a/tests/spec/arc_split_chars.test.ry
+++ b/tests/spec/arc_split_chars.test.ry
@@ -1,0 +1,21 @@
+from runtime_internal import arc_live_count
+
+describe("__ry_split_chars ARC correctness (#1010)", ():
+  it("split(s, \"\") — overwrite does not leak (arc_live_count stays constant)", ():
+    before = arc_live_count()
+    cs: List<str> = split("abc", "")
+    cs = split("def", "")
+    cs = split("ghi", "")
+    cs = split("jkl", "")
+    after = arc_live_count()
+    expect(after - before).to_eq(1)
+  )
+
+  it("split(unicode, \"\") — ARC retain works for multi-byte chars", ():
+    before = arc_live_count()
+    cs: List<str> = split("あいう", "")
+    expect(cs).to_have_length(3)
+    after = arc_live_count()
+    expect(after - before).to_eq(1)
+  )
+)


### PR DESCRIPTION
## Summary

- `__ry_split_chars` (called by `split(str, "")` via `emitStringToCharList`) was allocating its returned `ListHeader *` with `checked_malloc` instead of `arc_alloc`
- Codegen-emitted `emitVarDecl` retain/release reads `header_ptr - 16` as the ARC strong-count prefix; `checked_malloc` leaves malloc metadata there, which gets corrupted by each retain, then freed as a non-ARC pointer on scope-exit — crashing with `pointer being freed was not allocated` on non-ASan macOS
- Fix: add `#include "ry/runtime_arc.hpp"` and replace the single `checked_malloc` call with `arc_alloc` at `src/runtime_utf8.cpp:183`
- Same bug class as #1007 (`IOListHeader`)

## Changes

- `src/runtime_utf8.cpp` — include `runtime_arc.hpp`, replace `checked_malloc` → `arc_alloc` for `ListHeader`
- `tests/spec/arc_split_chars.test.ry` — delta-based `arc_live_count` regression tests (overwrite leak detection + Unicode multi-byte ARC retain)
- `changelog.d/1010-split-chars-arc-alloc.md` — `### Fixed` fragment

## Test plan

- [ ] `arc_split_chars.test.ry` — 2 new cases pass (overwrite leak + unicode)
- [ ] `./build/ry_tests` — 1686 tests pass
- [ ] `./build/ry test -p` — 127 files pass
- [ ] ASan+UBSan `ry_tests` / `ry test -p` — clean
- [ ] TSan `ry_tests` / `ry test -p` — clean
- [ ] Default build: zero compiler warnings

Closes #1010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed crashes when splitting strings with empty separators
  * Improved memory allocation strategy to prevent resource corruption during cleanup operations

* **Tests**
  * Added tests validating string splitting memory management and Unicode handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->