### PR TITLE
fix(runtime): use arc_alloc for MapHeader to prevent ARC retain crash (#1011)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1198,8 +1198,8 @@ directly for the tail line.
 
 ### Runtime functions returning ARC-managed structs must use `arc_alloc`, not `checked_malloc`
 
-**Source**: #1007 (2026-04-16, bug fix), PR #997 (pattern established for ListHeader)
-**Tags**: arc, runtime, memory-safety, iolistheader, listheader, mapheader, gotcha
+**Source**: #1007, #1011 (2026-04-16, bug fixes), PR #997 (pattern established for ListHeader)
+**Tags**: arc, runtime, memory-safety, iolistheader, listheader, mapheader, http, gotcha
 
 **Rule**: Any runtime function that returns a heap-allocated struct (e.g.
 `IOListHeader`, `ListHeader`, `MapHeader`) **to Ry code** must allocate the
@@ -1228,6 +1228,7 @@ zero.
 | `__ry_read_bytes` | `src/runtime_io.cpp` | PR #1007 |
 | `makeEmptyIOList`, `__ry_tcp_receive` | `src/runtime_net.cpp` | PR #1007 |
 | `__ry_tls_receive` | `src/runtime_tls.cpp` | PR #1007 |
+| `build_str_map` | `src/runtime_http.cpp` | PR #1011 |
 
 **Error-path pairing**: when an allocation succeeds with `arc_alloc` but
 the function later bails out before returning to Ry, free with `arc_free`,

--- a/changelog.d/1011-mapheader-arc-alloc.md
+++ b/changelog.d/1011-mapheader-arc-alloc.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- HTTP リクエストの `query_all`, `cookies_all`, `form_fields`, `form_file` が返す `Map<str, str>` を変数に代入すると macOS で `malloc: *** error for object ...: pointer being freed was not allocated` がクラッシュしていた問題を修正 (#1011)

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -40,7 +40,7 @@ std::vector<HeaderPair> parse_raw_headers(const std::string &raw,
 }
 
 void *build_str_map(char **keys, char **vals, int64_t count) {
-    auto *map = (MapHeader *)checked_malloc(sizeof(MapHeader));
+    auto *map = (MapHeader *)arc_alloc(sizeof(MapHeader));
     map->len = count;
     map->cap = count;
     if (count > 0) {

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -486,7 +486,7 @@ TEST(RuntimeHttp, QueryAllBasic) {
     free(map->keys);
     free(map->vals);
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -511,7 +511,7 @@ TEST(RuntimeHttp, QueryAllEmpty) {
     EXPECT_GE(map->bucket_count, 4);
 
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -545,7 +545,7 @@ TEST(RuntimeHttp, QueryAllDuplicateFirstWins) {
     free(map->keys);
     free(map->vals);
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -1036,7 +1036,7 @@ TEST(RuntimeHttp, CookiesAll) {
     free(map->keys);
     free(map->vals);
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -1061,7 +1061,7 @@ TEST(RuntimeHttp, CookiesAllEmpty) {
     EXPECT_GE(map->bucket_count, 4);
 
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -1095,7 +1095,7 @@ TEST(RuntimeHttp, CookiesAllDuplicateFirstWins) {
     free(map->keys);
     free(map->vals);
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -1656,7 +1656,7 @@ TEST(RuntimeHttp, FormFileBasic) {
     free(map->keys);
     free(map->vals);
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     // Missing file returns nullptr (None)
     EXPECT_EQ(__ry_http_form_file(result, "missing"), nullptr);
@@ -1719,7 +1719,7 @@ TEST(RuntimeHttp, FormMixedFieldsAndFiles) {
     free(map->keys);
     free(map->vals);
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -1769,7 +1769,7 @@ TEST(RuntimeHttp, FormFieldsAll) {
     free(map->keys);
     free(map->vals);
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -1799,7 +1799,7 @@ TEST(RuntimeHttp, FormFieldNonMultipart) {
     ASSERT_NE(map, nullptr);
     EXPECT_EQ(map->len, 0);
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -1968,7 +1968,7 @@ TEST(RuntimeHttp, MultipartFileDataWithNulByte) {
     free(file_map->keys);
     free(file_map->vals);
     free(file_map->buckets);
-    free(file_map);
+    arc_free(file_map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);
@@ -2103,7 +2103,7 @@ TEST(RuntimeHttp, FormFileDefaultContentType) {
     free(map->keys);
     free(map->vals);
     free(map->buckets);
-    free(map);
+    arc_free(map);
 
     __ry_http_request_free(result);
     ::close(fds[0]);


### PR DESCRIPTION
## Summary

- `build_str_map` in `src/runtime_http.cpp` was allocating `MapHeader` with `checked_malloc`, but `emitVarDecl` reads `header_ptr - 16` (the ARC prefix) on every assignment. On non-ASan macOS builds this corrupted malloc metadata and caused a crash: `malloc: *** error for object ...: pointer being freed was not allocated`
- Switch to `arc_alloc` — same fix as #1007 for `IOListHeader`. A single change at the `build_str_map` call site covers all four entry points: `query_all`, `cookies_all`, `form_fields`, and `form_file`
- Update 12 C++ test sites that free a `build_str_map`-returned `MapHeader` from `free(map)` to `arc_free(map)` — these act as a regression guard (reverting the allocator fix immediately breaks the test suite)

## Test plan

- [x] Default build: `./build/ry_tests` — 1686/1686 pass
- [x] Default build: `./build/ry test -p` — 128 files, 0 failures
- [x] ASan + UBSan: `./build-asan/ry_tests` — 1686/1686 pass
- [x] ASan + UBSan: `./build-asan/ry test -p` — 128 files, 0 failures
- [x] TSan: `./build-tsan/ry_tests` — 1686/1686 pass (required)
- [x] TSan: `./build-tsan/ry test -p` — 128 files, 0 failures (warn-only)

Closes #1011

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a macOS crash that occurred when handling HTTP request data, specifically when processing query parameters, cookies, and form fields, which previously resulted in memory allocation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->