### PR TITLE
fix(codegen): handle T? suffix in extractGenericTypeArg (#1015)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2279,11 +2279,11 @@ testResult = phi;
 
 ### `propagateTypeMeta`: handle both `Option<T>` prefix and `T?` suffix — they are the same type
 
-**Source**: #1003 (2026-04-16, bugfix)
-**Tags**: codegen, metadata, option, shorthand, list_elem, propagateTypeMeta, OptionalType
+**Source**: #1003 (2026-04-16, bugfix); extended by #1015 (2026-04-16, `extractGenericTypeArg` in `codegen_match.cpp`)
+**Tags**: codegen, metadata, option, shorthand, list_elem, propagateTypeMeta, OptionalType, extractGenericTypeArg
 
 **Rule**: Whenever you add or modify a code path that recognises `"Option<..."` as a prefix string, also handle the `"T?"` suffix form. `OptionalType::toString()` (`src/type_node.cpp:51-52`) emits the `"?"` suffix form, and `OverloadEntry::returnTypeName` stores it verbatim. So functions declared as `-> List<int>?` have `returnTypeName = "List<int>?"`, not `"Option<List<int>>"`. A branch that only checks `resolved.compare(0, 7, "Option<")` will silently skip `T?` returns.
 
 **How to apply**: After the `Option<T>` branch, add an `else if (resolved.size() > 1 && resolved.back() == '?')` branch that strips the `?` and recurses: `propagateTypeMeta(resolved.substr(0, resolved.size() - 1), val)`. See `src/codegen_builtin.cpp:169-173` (added #1003) and the earlier precedent in `src/codegen_arc_gc.cpp:136-138`. The `resolveTypeAlias` function is a pure string map lookup and cannot produce `?`-suffixed strings for non-optional aliases (the lexer tokenises `?` as a standalone `Question` token, so identifiers cannot contain it), making the `resolved.back() == '?'` guard safe.
 
-**Known parallel gap (not yet fixed)**: `src/codegen_stmt.cpp:430` checks `ann.substr(0, 7) == "Option<"` when propagating collection metadata from a variable's explicit type annotation. The gap only matters when the RHS value carries no metadata of its own (e.g., `x: List<int>? = None`). Since `None` contains no collection, any subsequent index on `x` would raise a runtime unwrap error before metadata is needed — so the practical impact is negligible. Track in a future issue if a concrete regression is found.
+**Known parallel gaps**: `src/codegen_match.cpp` (`extractGenericTypeArg`) was resolved in #1015 — both `Option<T>` prefix and `T?` suffix are now handled, ensuring the typed ARC retain path (Path 2a in `emitPatternBindingArc`) is taken for `SomePattern`. The remaining gap is `src/codegen_stmt.cpp:430`, which checks `ann.substr(0, 7) == "Option<"` when propagating collection metadata from a variable's explicit type annotation. That gap only matters when the RHS value carries no metadata of its own (e.g., `x: List<int>? = None`). Since `None` contains no collection, any subsequent index on `x` would raise a runtime unwrap error before metadata is needed — so the practical impact is negligible. Track in a future issue if a concrete regression is found.

--- a/changelog.d/1015-extract-generic-type-arg-optional.md
+++ b/changelog.d/1015-extract-generic-type-arg-optional.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fix refcount imbalance when pattern-matching `Some(...)` on a value declared with the `T?` shorthand (e.g., `str?`, `List<int>?`). `extractGenericTypeArg` now recognises the `T?` suffix form as equivalent to `Option<T>`, ensuring the typed ARC retain path (Path 2a) is selected instead of the heuristic fallback (#1015).

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -413,13 +413,21 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
 }
 
 // Extract the Nth type argument (0-indexed) from a generic type string like
-// "Option<T>" or "Result<T, E>".  Returns "" when the string does not start
-// with `prefix` or the index is out of range.  Delegates to splitTypeArgs so
-// that both angle-bracket and parenthesis depth are tracked correctly (handles
-// function types such as "Option<(int, str) -> bool>").
+// "Option<T>", "T?" (OptionalType shorthand for Option<T>), or "Result<T, E>".
+// Returns "" when the string does not start with `prefix` or the index is out
+// of range.  Delegates to splitTypeArgs so that both angle-bracket and
+// parenthesis depth are tracked correctly (handles function types such as
+// "Option<(int, str) -> bool>").
 static std::string extractGenericTypeArg(const std::string &typeStr,
                                           const std::string &prefix,
                                           size_t argIdx) {
+    // T? suffix is OptionalType::toString() shorthand for Option<T> (#1003, #1015).
+    // Only Option has a shorthand form; Result<T, E> does not.
+    if (prefix == "Option<" && typeStr.size() > 1 && typeStr.back() == '?') {
+        if (argIdx != 0)
+            return {};
+        return CodeGen::trimTypeNameSpaces(typeStr.substr(0, typeStr.size() - 1));
+    }
     if (typeStr.size() <= prefix.size() ||
         typeStr.compare(0, prefix.size(), prefix) != 0 ||
         typeStr.back() != '>')

--- a/tests/spec/pattern_arc.test.ry
+++ b/tests/spec/pattern_arc.test.ry
@@ -29,6 +29,15 @@ function make_err_msg() -> Result<int, str>:
   prefix = "fail"
   return Err(prefix + "ed")
 
+function make_some_str_short() -> str?:
+  # Use string concatenation so the payload is a heap-backed ARC string rather
+  # than a compile-time constant — same technique as make_err_msg.
+  prefix = "hello"
+  return Some(prefix + " world")
+
+function make_some_list_short() -> List<int>?:
+  return Some([1, 2, 3])
+
 describe("pattern binding ARC retain (#997)", ():
   it("Some pattern retains List<int> binding", ():
     # SomePattern: inner = ExtractValue(opt_val, 1) — was missing retain.
@@ -157,5 +166,29 @@ describe("pattern binding ARC retain (#997)", ():
       None:
         matched = -2
     expect(matched).to_eq(5)
+  )
+
+  it("Some pattern binds str with T? suffix form", ():
+    # str? is the T? shorthand for Option<str>.
+    # extractGenericTypeArg must recognise this suffix form so the typed ARC
+    # path (Path 2a) is taken and the binding is properly retained (#1015).
+    # Without the fix, Path 2b has no ListElem/MapKey metadata to fall back on,
+    # so the binding is not added to arc_backed_vars_ (refcount imbalance).
+    case make_some_str_short():
+      Some(s):
+        expect(s).to_eq("hello world")
+      None:
+        fail("expected Some")
+  )
+
+  it("Some pattern binds List<int> with T? suffix form", ():
+    # List<int>? is the T? shorthand for Option<List<int>>.
+    # Ensures the typed ARC path is taken instead of the heuristic fallback.
+    case make_some_list_short():
+      Some(xs):
+        expect(xs).to_have_length(3)
+        expect(xs[0]).to_eq(1)
+      None:
+        fail("expected Some")
   )
 )

--- a/tests/spec/pattern_arc.test.ry
+++ b/tests/spec/pattern_arc.test.ry
@@ -170,10 +170,11 @@ describe("pattern binding ARC retain (#997)", ():
 
   it("Some pattern binds str with T? suffix form", ():
     # str? is the T? shorthand for Option<str>.
-    # extractGenericTypeArg must recognise this suffix form so the typed ARC
-    # path (Path 2a) is taken and the binding is properly retained (#1015).
-    # Without the fix, Path 2b has no ListElem/MapKey metadata to fall back on,
-    # so the binding is not added to arc_backed_vars_ (refcount imbalance).
+    # extractGenericTypeArg must recognise this suffix form so the typed
+    # classification path (Path 2a) is taken (#1015).
+    # For `str`, Path 2a intentionally does not retain (same as Option<str>);
+    # the fix prevents falling into heuristic Path 2b, which mis-balances
+    # arc_backed_vars_ for non-collection T? bindings.
     case make_some_str_short():
       Some(s):
         expect(s).to_eq("hello world")


### PR DESCRIPTION
## Summary

- `extractGenericTypeArg` previously rejected any type string not ending with `>`, causing `T?` shorthand forms (e.g., `str?`, `List<int>?`) to return an empty `innerSig`
- For `SomePattern`, this caused `emitPatternBindingArc` to fall to the heuristic Path 2b, which has no `ListElem`/`MapKey`/`SetElem` metadata to fall back on for `str?` — leaving bindings untracked in `arc_backed_vars_` (refcount imbalance)
- Added a `prefix == "Option<" && typeStr.back() == '?'` guard before the existing check; scoped to `Option<` only since `Result<T, E>` has no shorthand
- Same pattern applied in `propagateTypeMeta` (`codegen_builtin.cpp:169-171`, #1003) and `isPotentiallyCyclic` (`codegen_arc_gc.cpp:136-138`)

## Test plan

- [ ] `./build/ry test tests/spec/pattern_arc.test.ry` — 12 tests pass (including new `str?` and `List<int>?` SomePattern tests)
- [ ] `./build/ry_tests` — 1686 C++ tests pass
- [ ] ASan+UBSan: `./build-asan/ry_tests` + `./build-asan/ry test -p` — clean
- [ ] TSan: `./build-tsan/ry_tests` — clean (pre-existing flaky `PrintsHelpWithoutPackageToml` unrelated)

Closes #1015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a reference-count imbalance when pattern-matching `Some(...)` against optional values using the `T?` shorthand (e.g., `str?`, `List<int>?`); `T?` is now treated equivalent to `Option<T>` for correct ARC behavior.
* **Tests**
  * Added tests validating `Some(...)` pattern binding and retention for `T?` shorthand types.
* **Documentation**
  * Updated knowledge and changelog entries to document the fix and coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->