### PR TITLE
fix(codegen): guard markArcManaged with fieldTypeIsArcManaged in pattern binding (#1016)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1094,6 +1094,22 @@ Affected patterns and what typeSig to pass:
 
 **Do not retain `str`**: `str` values returned from C runtime functions (e.g. `read_text`, `bytes_to_str`) use `checked_malloc`, not `arc_alloc`. Retaining them causes `free(ptr - 16)` on malloc metadata → crash. The correct approach is: only retain collections (`List<T>`, `Map<K,V>`, `Set<T>`), never bare `str`.
 
+**`markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`** (Source: #1016):
+TuplePattern / RecordPattern / EnumConstructorPattern pre-mark a temporary alloca
+(`tmp`) as ARC-managed so the recursive leaf `VariablePattern` binding can emit a
+single retain via `tryRetainArcSource` Case 1. Without the guard, _any_ `ptrTy_`
+field (including `str`, bare fn-ptr, and resource ptrs) is incorrectly marked,
+causing `tryRetainArcSource` to call `emitArcGetHeaderFromData(val)` — which points
+16 bytes before a plain `checked_malloc` pointer, corrupting malloc metadata. ASan
+detects this as "attempting free on address which was not malloc()-ed".
+Fix: replace `if (elemTy == ptrTy_) markArcManaged(tmp)` with
+`if (elemTy == ptrTy_ && fieldTypeIsArcManaged(elemSig, nullptr)) markArcManaged(tmp)`
+at all three sites (`src/codegen_match.cpp`). `fieldTypeIsArcManaged` resolves
+aliases and returns true only for non-weak List/Map/Set types. Capturing closure in
+tuple/record/enum fields is intentionally excluded: `fn_type_info` metadata is not
+propagated by `propagateTypeMeta` onto `ExtractValue` intermediates, so closure
+detection is impossible here; this was also the pre-#1008 behaviour.
+
 ### `emitExprVariant` (CaseExpr): capture `armEndBB` AFTER `popScope()`
 
 **Source**: #997 (2026-04-16, fix)

--- a/changelog.d/1016-pattern-binding-arc-filter.md
+++ b/changelog.d/1016-pattern-binding-arc-filter.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fix use-after-free when pattern-binding `str` or bare function pointer
+  fields of tuples / records / enum variants (#1016)

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -495,7 +495,10 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 // VariablePattern binding can detect them via tryRetainArcSource and
                 // emit a single retain.  The tmp alloca is not in scope_stack_ so
                 // there is no matching release — varAlloca owns the refcount.
-                if (elemTy == ptrTy_)
+                // Only mark collection types (List/Map/Set); str, bare fn-ptr, and
+                // other ptrTy_ values are NOT ARC-managed and must not be retained
+                // here — doing so corrupts malloc metadata (see #1016).
+                if (elemTy == ptrTy_ && fieldTypeIsArcManaged(elemSig, nullptr))
                     markArcManaged(tmp);
                 // Guard: only pass elemSig as subjectEnumType when it names an actual enum.
                 // Passing a primitive type name ("int", "str", etc.) would set enum_value_type
@@ -523,7 +526,10 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 // VariablePattern binding can detect them via tryRetainArcSource and
                 // emit a single retain.  The tmp alloca is not in scope_stack_ so
                 // there is no matching release — varAlloca owns the refcount.
-                if (elemTy == ptrTy_)
+                // Only mark collection types (List/Map/Set); str, bare fn-ptr, and
+                // other ptrTy_ values are NOT ARC-managed and must not be retained
+                // here — doing so corrupts malloc metadata (see #1016).
+                if (elemTy == ptrTy_ && fieldTypeIsArcManaged(elemSig, nullptr))
                     markArcManaged(tmp);
                 // Pass elemSig as subjectEnumType only for enum types; primitive and collection
                 // types are already handled by propagateTypeMeta above. Passing "int" or "str"
@@ -576,7 +582,10 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                         // VariablePattern binding can detect them via tryRetainArcSource and
                         // emit a single retain.  The tmp alloca is not in scope_stack_ so
                         // there is no matching release — varAlloca owns the refcount.
-                        if (fieldTy == ptrTy_)
+                        // Only mark collection types (List/Map/Set); str, bare fn-ptr, and
+                        // other ptrTy_ values are NOT ARC-managed and must not be retained
+                        // here — doing so corrupts malloc metadata (see #1016).
+                        if (fieldTy == ptrTy_ && fieldTypeIsArcManaged(fieldTypeName, nullptr))
                             markArcManaged(tmp);
                         // Guard: only pass fieldTypeName as subjectEnumType when it names a known enum.
                         // Passing a primitive type name ("int", "str", etc.) would crash valueToString().

--- a/tests/spec/pattern_arc.test.ry
+++ b/tests/spec/pattern_arc.test.ry
@@ -158,4 +158,51 @@ describe("pattern binding ARC retain (#997)", ():
         matched = -2
     expect(matched).to_eq(5)
   )
+
+  it("tuple pattern does not over-retain heap str binding (#1016)", ():
+    # TuplePattern: str field is ptrTy_ but NOT ARC-managed.  Without the
+    # fieldTypeIsArcManaged guard, markArcManaged(tmp) was called for str,
+    # causing tryRetainArcSource Case 1 to emit an ARC retain that points
+    # emitArcGetHeaderFromData 16 bytes before a plain checked_malloc ptr.
+    # This corrupts malloc metadata and is detected as bad-free under ASan.
+    # Use heap str (concatenation) so the pointer is malloc-backed.
+    i = 0
+    while i < 5:
+      prefix: str = "hel" + "lo"
+      t = (prefix, 42)
+      case t:
+        (s, n):
+          expect(s).to_eq("hello")
+          expect(n).to_eq(42)
+      i = i + 1
+  )
+
+  it("record pattern does not over-retain heap str field binding (#1016)", ():
+    # RecordPattern: the str field (label) in Box is ptrTy_ but NOT ARC-managed.
+    # Without the guard, markArcManaged(tmp) was called unconditionally.
+    i = 0
+    while i < 5:
+      lbl: str = "my" + "box"
+      b = Box([7, 8, 9], lbl)
+      case b:
+        Box(xs, s):
+          expect(xs).to_have_length(3)
+          expect(s).to_eq("mybox")
+      i = i + 1
+  )
+
+  it("enum constructor pattern does not over-retain heap str field binding (#1016)", ():
+    # EnumConstructorPattern: Tree::Node(str) — str is ptrTy_ but NOT ARC-managed.
+    # Without the guard, markArcManaged(tmp) was called unconditionally.
+    i = 0
+    while i < 5:
+      payload: str = "no" + "de"
+      t = Tree::Node(payload)
+      case t:
+        Tree::Leaf(xs):
+          fail("expected Node")
+        Tree::Node(s):
+          expect(s).to_eq("node")
+      i = i + 1
+  )
 )


### PR DESCRIPTION
## Summary

- `TuplePattern` / `RecordPattern` / `EnumConstructorPattern` in `src/codegen_match.cpp` were unconditionally calling `markArcManaged(tmp)` for any `ptrTy_` element alloca (added by PR #1008 / #997 fix)
- This caused `tryRetainArcSource` Case 1 to emit an ARC retain for non-ARC pointers (`str`, bare fn-ptr), which pointed `emitArcGetHeaderFromData` 16 bytes before a plain `checked_malloc` pointer — corrupting malloc metadata
- ASan detects this as `"attempting free on address which was not malloc()-ed"`

## Fix

Replace `if (elemTy == ptrTy_) markArcManaged(tmp)` with a guarded version using the existing `fieldTypeIsArcManaged(elemSig, nullptr)` helper at all three call sites. `fieldTypeIsArcManaged` resolves type aliases and returns `true` only for non-weak `List<T>` / `Map<K,V>` / `Set<T>` types.

## Test plan

- [x] Added 3 regression `it` blocks to `tests/spec/pattern_arc.test.ry`:
  - Tuple `(str, int)` with heap-allocated str (via concatenation)
  - Record `Box` with heap str `label` field
  - Enum `Tree::Node(str)` with heap str payload
  - Each loops 5× to verify ARC balance
- [x] All 13 `pattern_arc` tests pass
- [x] `./build/ry_tests` — 1686 tests passed
- [x] `./build/ry test -p` — 129 files, 0 failures
- [x] ASan + UBSan — clean (no malloc metadata corruption)
- [x] TSan C++ — clean

## Notes

- **No docs/reference/ update**: internal codegen fix, no user-facing behavior change
- **Capturing closure in tuple/record/enum fields**: intentionally excluded from `markArcManaged` — `fn_type_info` metadata is not propagated by `propagateTypeMeta` onto `ExtractValue` intermediates, so closure detection is impossible at this site. This was also the pre-#1008 behavior. Tracked as a future enhancement if needed.

Closes #1016

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented incorrect ARC retention during pattern binding of string or bare function-pointer fields in tuple, record, and enum variants, eliminating a use-after-free/memory-corruption scenario.

* **Tests**
  * Added tests validating safe pattern binding for tuple, record, and enum cases with non-ARC pointer-like fields.

* **Documentation**
  * Clarified guidance on ARC pre-marking predicates and excluded closure detection for certain intermediate extracts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->