### PR TITLE
fix(codegen): int / 0 follows IEEE 754, returns inf not error (#1023)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -403,6 +403,27 @@ site owns the basic-block split. See `emitIntZeroDivGuard`
 (`src/codegen_call_user.cpp:625-636`) and the top-level `?` path in
 `emitExprVariant(ErrorPropagateExpr)` for canonical examples.
 
+### `/` is always float + IEEE 754; `//` and `%` are integer and error on zero
+
+**Source**: #1023 (2026-04-16, implementation)
+**Tags**: codegen, operators, ieee754, division, floor-div, modulo
+
+**Rule**: The `/` operator always returns `float` and follows IEEE 754 for
+zero divisors — `x / 0` → `±inf` (sign follows the dividend), `0 / 0` → `nan`.
+Do NOT add an integer zero-division guard to the `/` branch of
+`emitArithmeticOp` (`src/codegen_expr.cpp:1333`) or to the `(Int, Int)`
+branch of `__ry_any_div` (`src/runtime_any.cpp:229`).
+
+The integer-semantics operators `//` and `%` do error on zero divisor
+(`src/codegen_expr.cpp:1318,1364` and `__ry_any_floordiv` / `__ry_any_mod`).
+Low-level native-width integer `/` and `%` (`i32`, `u8`, …) also error
+(`src/codegen_expr.cpp:1170-1178`) because they are true integer division,
+not float-promoted.
+
+Issue #754 previously added an int-specific guard to `/` that contradicted
+the "always float" spec; #1023 reverts that decision for `/` while keeping
+integer semantics (and the guards) for `//` and `%`.
+
 ### Dual-path builtins must share terminator / cleanup handling
 
 **Source**: #821 sweep (2026-04-10)

--- a/changelog.d/1023-int-div-zero-float-semantics.md
+++ b/changelog.d/1023-int-div-zero-float-semantics.md
@@ -6,4 +6,5 @@
   returning `float`, so integer operands are promoted before division and
   IEEE 754 semantics apply. This reverts the integer-specific runtime-error
   guard added in #754; `//` (floor division) and `%` (modulo) retain
-  integer semantics and still raise a runtime error on a zero divisor (#1023).
+  integer semantics and still raise a runtime error on a zero divisor for
+  integer operands (#1023).

--- a/changelog.d/1023-int-div-zero-float-semantics.md
+++ b/changelog.d/1023-int-div-zero-float-semantics.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- `int / 0` now follows IEEE 754 and returns `inf` (or `-inf` for negative
+  dividends; `nan` for `0 / 0`), consistent with `10.0 / 0` and `10 / 0.0`
+  which already returned `inf`. The `/` operator is documented as always
+  returning `float`, so integer operands are promoted before division and
+  IEEE 754 semantics apply. This reverts the integer-specific runtime-error
+  guard added in #754; `//` (floor division) and `%` (modulo) retain
+  integer semantics and still raise a runtime error on a zero divisor (#1023).

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -32,7 +32,7 @@ Lower numbers indicate higher precedence (evaluated first).
 | `+` | Addition / string concatenation | `1 + 2` -> `3`, `"a" + "b"` -> `"ab"`, `"x" + 1` -> `"x1"` |
 | `-` | Subtraction | `5 - 3` -> `2` |
 | `*` | Multiplication / string repetition | `4 * 3` -> `12`, `"ab" * 3` -> `"ababab"` |
-| `/` | Division (always float) | `7 / 2` -> `3.5` |
+| `/` | Division (always float, IEEE 754) | `7 / 2` -> `3.5`, `7 / 0` -> `inf`, `0 / 0` -> `nan` |
 | `//` | Floor division (toward -∞) | `7 // 2` -> `3`, `-7 // 2` -> `-4` |
 | `%` | Modulo | `7 % 3` -> `1` |
 | `**` | Exponentiation (always float) | `2 ** 10` -> `1024.0` |
@@ -49,6 +49,8 @@ u = 3.14 + "!"    # "3.14!"
 ```
 
 When one operand of `+` is `str` and the other is `int`, `float`, or `bool`, the non-`str` operand is automatically converted to its string representation and concatenated.
+
+The `/` operator always produces a `float` and follows IEEE 754 for special values: `x / 0` evaluates to `±inf` (sign follows the dividend), and `0 / 0` evaluates to `nan`. The integer-division operators `//` and `%` retain integer semantics and raise a runtime error when the divisor is zero.
 
 ## Comparison Operators
 

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -50,7 +50,7 @@ u = 3.14 + "!"    # "3.14!"
 
 When one operand of `+` is `str` and the other is `int`, `float`, or `bool`, the non-`str` operand is automatically converted to its string representation and concatenated.
 
-The `/` operator always produces a `float` and follows IEEE 754 for special values: `x / 0` evaluates to `±inf` (sign follows the dividend), and `0 / 0` evaluates to `nan`. The integer-division operators `//` and `%` retain integer semantics and raise a runtime error when the divisor is zero.
+The `/` operator always produces a `float` and follows IEEE 754 for special values: `x / 0` evaluates to `±inf` (sign follows the dividend), and `0 / 0` evaluates to `nan`. For integer operands, `//` and `%` retain integer semantics and raise a runtime error when the divisor is zero.
 
 ## Comparison Operators
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1330,12 +1330,8 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
         return builder_.CreateSelect(needsAdj, adjusted, q, "floordiv");
     }
 
-    // / 除算: 常にf64
+    // / 除算: 常にf64, IEEE 754 semantics (x/0 → ±inf, 0/0 → nan) (#1023)
     if (op == "/") {
-        // int / int: zero-division guard (fdiv doesn't trap, but Ry treats int/0 as error)
-        if (lhs->getType()->isIntegerTy() && rhs->getType()->isIntegerTy()) {
-            emitIntZeroDivGuard(promoteToInt(rhs), "div", "runtime error: division by zero\n");
-        }
         std::tie(lhs, rhs) = promoteToFloat(lhs, rhs);
         return builder_.CreateFDiv(lhs, rhs, "div");
     }

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -229,10 +229,7 @@ extern "C" void __ry_any_mul(RyAny *result, const RyAny *a, const RyAny *b) {
 extern "C" void __ry_any_div(RyAny *result, const RyAny *a, const RyAny *b) {
     if (a->tag == static_cast<int64_t>(RyAnyTag::Int) && b->tag == static_cast<int64_t>(RyAnyTag::Int)) {
         int64_t av = extractInt(a), bv = extractInt(b);
-        if (bv == 0) {
-            fprintf(stderr, "runtime error: division by zero\n");
-            exit(1);
-        }
+        // IEEE 754: int/0 → ±inf, 0/0 → nan (#1023)
         makeFloat(result, static_cast<double>(av) / static_cast<double>(bv));
     } else if (a->tag == static_cast<int64_t>(RyAnyTag::Float) && b->tag == static_cast<int64_t>(RyAnyTag::Float)) {
         makeFloat(result, extractFloat(a) / extractFloat(b));

--- a/tests/spec/div_zero_guard.test.ry
+++ b/tests/spec/div_zero_guard.test.ry
@@ -1,3 +1,5 @@
+from math import Inf, is_nan, is_inf
+
 describe("division", ():
   it("should divide integers correctly", ():
     expect(6 / 3).to_eq(2.0)
@@ -5,9 +7,27 @@ describe("division", ():
     expect(-7 / 2).to_eq(-3.5)
     expect(0 / 1).to_eq(0.0)
   )
-
   it("should divide floats correctly", ():
     expect(6.0 / 3.0).to_eq(2.0)
     expect(1.0 / 2.0).to_eq(0.5)
+  )
+  it("should return +Inf for positive int divided by zero (#1023)", ():
+    expect(10 / 0).to_eq(Inf)
+    expect(is_inf(10 / 0)).to_be_true()
+    expect(10 / 0 > 0.0).to_be_true()
+  )
+  it("should return -Inf for negative int divided by zero (#1023)", ():
+    expect(-10 / 0).to_eq(-Inf)
+    expect(is_inf(-10 / 0)).to_be_true()
+    expect(-10 / 0 < 0.0).to_be_true()
+  )
+  it("should return NaN for 0 / 0 (#1023)", ():
+    expect(is_nan(0 / 0)).to_be_true()
+  )
+  it("should return ±Inf for mixed int/float zero division", ():
+    expect(10 / 0.0).to_eq(Inf)
+    expect(10.0 / 0).to_eq(Inf)
+    expect(-10 / 0.0).to_eq(-Inf)
+    expect(-10.0 / 0).to_eq(-Inf)
   )
 )

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -420,16 +420,22 @@ TEST_F(CodeGenTest, NativeFunctionMissingDispatcher) {
 
 // ===== Zero division guard tests (death tests - individual) =====
 
-TEST_F(CodeGenTest, DivByZeroExits) {
-    EXPECT_EXIT(runSource("print(1 / 0)"),
-                ::testing::ExitedWithCode(1),
-                "runtime error: division by zero");
+TEST_F(CodeGenTest, DivByZeroReturnsInf) {
+    EXPECT_EQ(runSource("print(1 / 0)"),   "inf\n");
+    EXPECT_EQ(runSource("print(-1 / 0)"),  "-inf\n");
+    EXPECT_EQ(runSource("print(10 / 0)"),  "inf\n");
+    EXPECT_EQ(runSource("print(-10 / 0)"), "-inf\n");
 }
 
-TEST_F(CodeGenTest, DivByZeroVariableExits) {
-    EXPECT_EXIT(runSource("x = 0\nprint(1 / x)"),
-                ::testing::ExitedWithCode(1),
-                "runtime error: division by zero");
+TEST_F(CodeGenTest, DivByZeroVariableReturnsInf) {
+    EXPECT_EQ(runSource("x = 0\nprint(1 / x)"),   "inf\n");
+    EXPECT_EQ(runSource("x = 0\nprint(-1 / x)"),  "-inf\n");
+}
+
+TEST_F(CodeGenTest, DivZeroByZeroReturnsNaN) {
+    EXPECT_EQ(runSource("print(0 / 0)"),   "nan\n");
+    EXPECT_EQ(runSource("print(0.0 / 0)"), "nan\n");
+    EXPECT_EQ(runSource("print(0 / 0.0)"), "nan\n");
 }
 
 TEST_F(CodeGenTest, DivFloatByZeroReturnsInf) {

--- a/tests/test_runtime_any.cpp
+++ b/tests/test_runtime_any.cpp
@@ -209,6 +209,29 @@ TEST(RuntimeAnyArith, DivVariants) {
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Float));
         EXPECT_DOUBLE_EQ(getFloat(&r), 3.5);
     }
+    // IntDivIntByZero → +inf  (#1023)
+    {
+        RyAny a = mkInt(1), b = mkInt(0), r;
+        __ry_any_div(&r, &a, &b);
+        EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Float));
+        EXPECT_TRUE(std::isinf(getFloat(&r)));
+        EXPECT_GT(getFloat(&r), 0.0);
+    }
+    // NegIntDivIntByZero → -inf  (#1023)
+    {
+        RyAny a = mkInt(-1), b = mkInt(0), r;
+        __ry_any_div(&r, &a, &b);
+        EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Float));
+        EXPECT_TRUE(std::isinf(getFloat(&r)));
+        EXPECT_LT(getFloat(&r), 0.0);
+    }
+    // ZeroDivZero → nan  (#1023)
+    {
+        RyAny a = mkInt(0), b = mkInt(0), r;
+        __ry_any_div(&r, &a, &b);
+        EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Float));
+        EXPECT_TRUE(std::isnan(getFloat(&r)));
+    }
 }
 
 // ===== Arithmetic: mod =====
@@ -485,16 +508,7 @@ TEST(RuntimeAnyArith, AddBoolPlusStr) {
     free(const_cast<char *>(getStr(&r)));
 }
 
-TEST_F(RuntimeAnyDeathTest, ArithDivisionAndModByZero) {
-    // DivByZero
-    {
-        RyAny a = mkInt(1), b = mkInt(0);
-        EXPECT_EXIT(
-            { RyAny r; __ry_any_div(&r, &a, &b); },
-            ::testing::ExitedWithCode(1),
-            "division by zero"
-        );
-    }
+TEST_F(RuntimeAnyDeathTest, ArithModAndFloordivByZero) {
     // ModByZero
     {
         RyAny a = mkInt(5), b = mkInt(0);


### PR DESCRIPTION
## Summary

- `int / 0` now returns `inf` (or `-inf` / `nan`) per IEEE 754, consistent with `10.0 / 0` and `10 / 0.0` which already behaved that way
- Removes the `int/int`-specific `emitIntZeroDivGuard` from the `/` branch in `emitArithmeticOp` (`src/codegen_expr.cpp`) and the matching `bv == 0` abort in `__ry_any_div` (`src/runtime_any.cpp`)
- `//` (floor division) and `%` (modulo) retain integer semantics and still error on zero divisor; low-level integer types (`i32`, `u32`, …) are unchanged
- Reverts the guard introduced in #754, which contradicted the documented "always float" semantics of `/`

## Test plan

- [x] Converted `DivByZeroExits` / `DivByZeroVariableExits` death tests to `EXPECT_EQ` asserting `inf` / `-inf`
- [x] Added `DivZeroByZeroReturnsNaN` test (`0 / 0 → nan`)
- [x] Added `±inf` and `nan` blocks to `RuntimeAnyArith.DivVariants`
- [x] Renamed `ArithDivisionAndModByZero` → `ArithModAndFloordivByZero` (DivByZero block removed)
- [x] Extended `tests/spec/div_zero_guard.test.ry` with 4 new `it` blocks covering `+Inf`, `-Inf`, `NaN`, and mixed int/float zero division
- [x] `FloorDivByZeroExits`, `ModByZeroExits`, all `LowLevel*` death tests remain unchanged and pass
- [x] 1687 C++ tests pass (default build, ASan+UBSan, TSan)
- [x] 130 Ry self-test files pass (default build, ASan+UBSan)

Closes #1023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Division operator (`/`) now follows IEEE 754 for division-by-zero: `x / 0` → `±inf`, `0 / 0` → `nan` instead of raising a runtime error.
  * Integer operands are promoted to floating-point for `/` to ensure consistent results.

* **Documentation**
  * Operator reference updated: `/` always yields float with IEEE 754 behavior; `//` (floor division) and `%` (modulo) retain integer semantics and still error on zero divisors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->