### PR TITLE
fix(codegen): unify Ok/Err branches in unannotated lambda if-expr (#1024)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2406,3 +2406,26 @@ int list (sum), 2/3-elem lists, and float list. These cases provide functional r
 coverage. For uninitialized-read detection specifically, use MemorySanitizer (MSan) rather
 than ASan — ASan detects memory-access errors (buffer overflows, use-after-free) but does
 not detect uninit reads.
+
+### `inferExprType` / `inferExprTypeName` visitor must handle `IfExpr`/`IfBlockExpr` and ADT constructors (`Ok`/`Err`/`Some`) to infer lambda return type correctly
+
+**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification)
+**Tags**: codegen, inference, visitor, lambda, Result, IfExpr
+
+**Rule**: `inferExprType` and `inferExprTypeName` in `src/codegen_lambda.cpp` are the visitor functions that determine the return type of an expression-body lambda (`(x: int) => expr`). Both functions must have explicit `if constexpr` cases for every AST node that can appear as the outermost expression. Any unhandled node falls through to the default which returns `i64Ty_` (= `int`) — silently and without error.
+
+Two gaps were confirmed in #1024:
+1. **`IfExpr` / `IfBlockExpr`** — neither visitor had a case for these nodes, so any lambda whose body is an `if` expression with mismatched-type branches (e.g., `Ok(T)` vs `Err(E)`) fell through to `int`, baking the wrong return type into the function signature before codegen.
+2. **`Ok` / `Err` in CallExpr** — the CallExpr branch already had a `Some` case but not `Ok`/`Err`. Without these, the Ok/Err payload types could not be inferred, making the IfExpr merge logic unreachable even after adding it.
+
+**Result merge logic (IfExpr)**: When both branches of an `if` expression yield `isResultType`, the inferred types are `{i1, realOkTy, Unit}` and `{i1, Unit, realErrTy}` (each side uses `i8Ty_` as the placeholder for the missing payload). Merge by preferring the non-`i8Ty_` element for each of Ok and Err:
+```cpp
+llvm::Type *mergedOk = (okA == i8Ty_) ? okB : okA;
+llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
+return getResultType(mergedOk, mergedEr);
+```
+This produces the correct unified `Result<T, Error>` StructType that both `Ok` and `Err` emitters in `codegen_call.cpp` will reuse via `fn_->getReturnType()`.
+
+**Analogous gap for Option**: `Some`/`None()` in an `if`-expr body has the same structural problem (#1043). The Option merge logic mirrors the Result one but must handle the Option StructType layout instead of `getResultType`.
+
+**How to check for new gaps**: When adding a new ADT constructor or a new expression-level control-flow node, grep for both `inferExprType` and `inferExprTypeName` and verify each has a case for the new node. A missing case is a silent wrong-type inference, not a compile error.

--- a/changelog.d/1024-result-lambda-if-inference.md
+++ b/changelog.d/1024-result-lambda-if-inference.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Lambda return-type inference now correctly unifies `Ok(T)` and `Err(Error)` branches in an if-expression body, so unannotated lambdas like `(x: int) => if x > 10 => Ok(x * 2) else Err(Error("too small"))` compile without a spurious "all branches must have the same type" error (#1024)

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -596,6 +596,14 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 c == "filter" || c == "map" || c == "sort" ||
                 c == "keys" || c == "values" || c == "enumerate" || c == "zip")
                 return ptrTy_;
+            if (c == "Ok" && v->args.size() == 1) {
+                llvm::Type *okTy = inferExprType(*v->args[0], paramTypeMap);
+                return getResultType(okTy, errorTy_);
+            }
+            if (c == "Err" && v->args.size() == 1) {
+                llvm::Type *errTy = inferExprType(*v->args[0], paramTypeMap);
+                return getResultType(i8Ty_, errTy);
+            }
             return i64Ty_; // fallback
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondExpr>>) {
             return inferExprType(*v->else_expr, paramTypeMap);
@@ -603,6 +611,40 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
             if (!v->arms.empty())
                 return inferExprType(*v->arms[0].value, paramTypeMap);
             return i64Ty_;
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<IfExpr>>) {
+            llvm::Type *thenTy = inferExprType(*v->then_value, paramTypeMap);
+            llvm::Type *elseTy = inferExprType(*v->else_value, paramTypeMap);
+            if (isResultType(thenTy) && isResultType(elseTy)) {
+                auto *thenSt = llvm::cast<llvm::StructType>(thenTy);
+                auto *elseSt = llvm::cast<llvm::StructType>(elseTy);
+                llvm::Type *okA = thenSt->getElementType(1), *okB = elseSt->getElementType(1);
+                llvm::Type *erA = thenSt->getElementType(2), *erB = elseSt->getElementType(2);
+                llvm::Type *mergedOk = (okA == i8Ty_) ? okB : okA;
+                llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
+                return getResultType(mergedOk, mergedEr);
+            }
+            return thenTy;
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
+            llvm::Type *thenTy = i64Ty_;
+            llvm::Type *elseTy = i64Ty_;
+            if (!v->then_body.empty()) {
+                const auto *tail = std::get_if<ExprStmt>(&v->then_body.back());
+                if (tail) thenTy = inferExprType(*tail->expr, paramTypeMap);
+            }
+            if (!v->else_body.empty()) {
+                const auto *tail = std::get_if<ExprStmt>(&v->else_body.back());
+                if (tail) elseTy = inferExprType(*tail->expr, paramTypeMap);
+            }
+            if (isResultType(thenTy) && isResultType(elseTy)) {
+                auto *thenSt = llvm::cast<llvm::StructType>(thenTy);
+                auto *elseSt = llvm::cast<llvm::StructType>(elseTy);
+                llvm::Type *okA = thenSt->getElementType(1), *okB = elseSt->getElementType(1);
+                llvm::Type *erA = thenSt->getElementType(2), *erB = elseSt->getElementType(2);
+                llvm::Type *mergedOk = (okA == i8Ty_) ? okB : okA;
+                llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
+                return getResultType(mergedOk, mergedEr);
+            }
+            return thenTy;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<InterpolatedStringExpr>>) {
             return ptrTy_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
@@ -725,6 +767,8 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
                 return "Option<" + inner + ">";
             }
             if (v->callee == "type_of") return "Type";
+            if (v->callee == "Ok" && v->args.size() == 1) return "Result";
+            if (v->callee == "Err" && v->args.size() == 1) return "Result";
             auto *overloads = findFunction(v->callee);
             if (overloads && !overloads->empty() && !(*overloads)[0].returnTypeName.empty())
                 return (*overloads)[0].returnTypeName;
@@ -776,6 +820,30 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
                 return inferExprTypeName(*v->arms[0].value, paramTypeMap,
                                           paramTypeNameMap);
             return "";
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<IfExpr>>) {
+            std::string thenName = inferExprTypeName(*v->then_value, paramTypeMap,
+                                                      paramTypeNameMap);
+            std::string elseName = inferExprTypeName(*v->else_value, paramTypeMap,
+                                                      paramTypeNameMap);
+            if (thenName == "Result" || elseName == "Result") return "Result";
+            return thenName;
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
+            std::string thenName;
+            std::string elseName;
+            if (!v->then_body.empty()) {
+                const auto *tail = std::get_if<ExprStmt>(&v->then_body.back());
+                if (tail)
+                    thenName = inferExprTypeName(*tail->expr, paramTypeMap,
+                                                   paramTypeNameMap);
+            }
+            if (!v->else_body.empty()) {
+                const auto *tail = std::get_if<ExprStmt>(&v->else_body.back());
+                if (tail)
+                    elseName = inferExprTypeName(*tail->expr, paramTypeMap,
+                                                   paramTypeNameMap);
+            }
+            if (thenName == "Result" || elseName == "Result") return "Result";
+            return thenName;
         } else {
             return reverseResolveTypeName(inferExprType(expr, paramTypeMap));
         }

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -598,7 +598,7 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 return ptrTy_;
             if (c == "Ok" && v->args.size() == 1) {
                 llvm::Type *okTy = inferExprType(*v->args[0], paramTypeMap);
-                return getResultType(okTy, errorTy_);
+                return getResultType(okTy, i8Ty_);
             }
             if (c == "Err" && v->args.size() == 1) {
                 llvm::Type *errTy = inferExprType(*v->args[0], paramTypeMap);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -623,7 +623,7 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
                 return getResultType(mergedOk, mergedEr);
             }
-            return thenTy;
+            return i64Ty_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
             llvm::Type *thenTy = i64Ty_;
             llvm::Type *elseTy = i64Ty_;
@@ -644,7 +644,7 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
                 return getResultType(mergedOk, mergedEr);
             }
-            return thenTy;
+            return i64Ty_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<InterpolatedStringExpr>>) {
             return ptrTy_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
@@ -826,7 +826,7 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             std::string elseName = inferExprTypeName(*v->else_value, paramTypeMap,
                                                       paramTypeNameMap);
             if (thenName == "Result" || elseName == "Result") return "Result";
-            return thenName;
+            return "";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
             std::string thenName;
             std::string elseName;
@@ -843,7 +843,7 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
                                                    paramTypeNameMap);
             }
             if (thenName == "Result" || elseName == "Result") return "Result";
-            return thenName;
+            return "";
         } else {
             return reverseResolveTypeName(inferExprType(expr, paramTypeMap));
         }

--- a/tests/spec/result_lambda_if.test.ry
+++ b/tests/spec/result_lambda_if.test.ry
@@ -1,0 +1,51 @@
+describe("Result lambda if-expr inference (unannotated return type)", ():
+  it("should infer Result from if-expr with Ok then Err - ok branch", ():
+    f = (x: int) => if x > 10 => Ok(x * 2) else Err(Error("too small"))
+    case f(20):
+      Ok(v): expect(v).to_eq(40)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+  )
+
+  it("should infer Result from if-expr with Ok then Err - err branch", ():
+    f = (x: int) => if x > 10 => Ok(x * 2) else Err(Error("too small"))
+    case f(5):
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("too small")
+  )
+
+  it("should infer Result when passed to and_then - ok branch", ():
+    f = (x: int) => if x > 10 => Ok(x * 2) else Err(Error("too small"))
+    res = Ok(20).and_then(f)
+    case res:
+      Ok(v): expect(v).to_eq(40)
+      Err(e): fail("unexpected error: " + e.message)
+  )
+
+  it("should infer Result when passed to and_then - err branch", ():
+    f = (x: int) => if x > 10 => Ok(x * 2) else Err(Error("too small"))
+    res = Ok(5).and_then(f)
+    case res:
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("too small")
+  )
+
+  it("should infer Result when then-branch is Err and else-branch is Ok", ():
+    f = (x: int) => if x > 10 => Err(Error("too large")) else Ok(x * 3)
+    case f(5):
+      Ok(v): expect(v).to_eq(15)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    case f(20):
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("too large")
+  )
+
+  it("should still work with explicit -> Result<int, Error> annotation (regression guard)", ():
+    f = (x: int) -> Result<int, Error> => if x > 10 => Ok(x * 2) else Err(Error("too small"))
+    case f(20):
+      Ok(v): expect(v).to_eq(40)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    case f(5):
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("too small")
+  )
+)

--- a/tests/spec/result_lambda_if.test.ry
+++ b/tests/spec/result_lambda_if.test.ry
@@ -39,6 +39,19 @@ describe("Result lambda if-expr inference (unannotated return type)", ():
       Err(e): expect(e.message).to_eq("too large")
   )
 
+  it("should infer Result from block-form if-expr (IfBlockExpr path)", ():
+    f = (x: int) => if x > 10:
+      (Ok(x * 2))
+    else:
+      (Err(Error("too small")))
+    case f(20):
+      Ok(v): expect(v).to_eq(40)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    case f(5):
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("too small")
+  )
+
   it("should still work with explicit -> Result<int, Error> annotation (regression guard)", ():
     f = (x: int) -> Result<int, Error> => if x > 10 => Ok(x * 2) else Err(Error("too small"))
     case f(20):


### PR DESCRIPTION
## Summary

- Fixes a spurious "all branches must have the same type" error when an unannotated lambda body is an `if`-expression with `Ok(T)` and `Err(Error)` branches (e.g. `(x: int) => if x > 10 => Ok(x * 2) else Err(Error("too small"))`)
- Root cause: `inferExprType` / `inferExprTypeName` in `src/codegen_lambda.cpp` had no cases for `IfExpr`/`IfBlockExpr` or for `Ok`/`Err` constructors in the `CallExpr` branch, causing fallthrough to `i64Ty_` (= `int`) and baking the wrong return type into the lambda's function signature before codegen
- Fix adds `Ok`/`Err` cases to both visitors and `IfExpr`/`IfBlockExpr` cases with a payload-merge step: the two inferred Result types (`{i1, realOkTy, Unit}` and `{i1, Unit, realErrTy}`) are unified by preferring the non-Unit (`i8Ty_`) payload from each branch

## Test plan

- [ ] New test file `tests/spec/result_lambda_if.test.ry` — 6 cases covering standalone lambda (ok/err), `and_then`-chained lambda (ok/err), reversed branch order, and explicit annotation regression guard — all pass
- [ ] Full test suite: `./build/ry_tests` (1687 tests) and `./build/ry test -p` (131 files) — all pass
- [ ] ASan + UBSan clean run
- [ ] TSan `ry_tests` clean run (1687 tests)

Closes #1024

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lambda return-type inference for if-expressions producing Result values so unannotated lambdas with Ok/Err branches no longer produce incorrect types or spurious type errors.

* **Tests**
  * Added tests covering Result inference for lambda if-expressions across branch permutations, block-form arms, and use as callbacks/combinators.

* **Documentation**
  * Added detailed notes and a verification checklist documenting inference coverage and branch-merge behavior for Result and Option.

* **Changelog**
  * Recorded the fix and referenced the related issue.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->