### PR TITLE
feat(skill): add /ci-investigate for systematic CI failure investigation

### DIFF
--- a/.claude/skills/ci-investigate/SKILL.md
+++ b/.claude/skills/ci-investigate/SKILL.md
@@ -1,0 +1,219 @@
+---
+name: ci-investigate
+description: Investigate CI failures on a PR in parallel with a re-run. Classifies failures as PR-caused / Pre-existing / Indeterminate, proposes next actions, and never concludes "flaky" without positive infrastructure evidence.
+allowed-tools: Bash(gh pr:*), Bash(gh run:*), Bash(git branch:*), Read, Grep
+metadata:
+  short-description: Investigate CI failures on a PR with parallel re-run
+---
+
+# CI Investigate
+
+Investigate CI failures on a PR and classify each failure so that re-runs, fixes, and triage happen in parallel — not serialised behind guesswork.
+
+## Why this skill exists
+
+The anti-pattern this skill breaks:
+
+```
+CI fails
+  → "can't reproduce locally, probably flaky"
+  → re-run (no investigation)
+  → fails again
+  → investigate → root cause found
+```
+
+The goal: re-run and investigation run **in parallel**. By the time the re-run finishes, the investigation is already done.
+
+"Cannot reproduce locally" is a signal to investigate CI-specific conditions — not evidence of flakiness.
+
+## Context
+
+- Current branch: !`git branch --show-current`
+- PR for this branch: !`gh pr view --json number,title,headRefName,headRefOid,state 2>/dev/null || echo "No PR found"`
+
+## Inputs
+
+User input: $ARGUMENTS
+
+## Steps
+
+### Step 1: Identify the PR
+
+- If `$ARGUMENTS` is a number (e.g. `123` or `#123`), use that PR number.
+- Otherwise, use the PR from the Context above.
+- If no PR is found:
+  > No PR found for the current branch. Provide a PR number (e.g. `/ci-investigate 123`) or push the branch and open a PR first.
+
+  Stop.
+
+### Step 2: List CI check states
+
+```bash
+gh pr checks <PR> --json name,status,conclusion,detailsUrl
+```
+
+- Extract all jobs where `conclusion == "failure"` → **failed job list**.
+- Record jobs where `conclusion == "success"` for comparison.
+- If **all** jobs are green:
+  > CI is green — all checks passed on PR #<PR>. Nothing to investigate.
+
+  Stop.
+
+### Step 3: Trigger re-run in parallel with investigation
+
+Identify the failing workflow runs:
+
+```bash
+gh run list --branch <headRefName> --limit 10 \
+  --json databaseId,name,status,conclusion,workflowName
+```
+
+For each run where `conclusion == "failure"`, trigger a re-run immediately:
+
+```bash
+gh run rerun <runId> --failed
+```
+
+After triggering:
+
+> Re-run triggered for run #<runId> (`<workflowName>`). Continuing investigation in parallel — **do not wait** for the re-run to complete.
+
+Proceed directly to Step 4.
+
+### Step 4: Fetch PR diff (changed files)
+
+```bash
+gh pr diff <PR> --name-only
+```
+
+Store this list. It is used in Step 5-3 to determine whether an error file is in scope.
+
+### Step 5: Analyse failure logs
+
+Process each failed job **in parallel**. For each job:
+
+#### 5-1: Get failure log
+
+Use the run ID from Step 3. To avoid context pressure from very long output, redirect to a temporary file and use `Read` or `Grep` to scan the relevant section:
+
+```bash
+gh run view <runId> --log-failed > /tmp/ci-investigate-<runId>.log
+```
+
+Then scan with `Grep` for error keywords, or `Read` the file in targeted ranges.
+
+If the run ID is not known yet, find it via `detailsUrl` from Step 2 or by re-running:
+
+```bash
+gh run list --branch <headRefName> --limit 20 --json databaseId,name,conclusion,workflowName
+```
+
+#### 5-2: Classify the failure type
+
+| Type | Detection pattern |
+|------|-------------------|
+| **Build error** | `error:` or `fatal error:` with file/line reference |
+| **Test failure** | `FAILED`, `ASSERTION FAILED`, `Expected ... but got ...`, GoogleTest `[ FAILED ]` |
+| **Lint error** | `clang-tidy:`, `cppcheck:`, warning flagged as error |
+| **Sanitizer error** | `AddressSanitizer:`, `UndefinedBehaviorSanitizer:`, `ThreadSanitizer:` |
+| **Link error** | `undefined reference to`, `linker command failed` |
+| **Ry self-test failure** | `FAIL` in `.test.ry` output, `describe` / `it` blocks |
+
+#### 5-3: Determine PR-caused / Pre-existing / Indeterminate
+
+- Extract the error file path(s) and line number(s) from the log.
+- Compare against the changed file list from Step 4:
+  - **PR-caused** — error location is in a file modified by this PR.
+  - **Pre-existing** — error location is in a file **not** touched by this PR.
+  - **Indeterminate** — no file location can be extracted (CI config error, infrastructure issue, etc.).
+
+> **Forbidden conclusion**: "Cannot reproduce locally → flaky." That fact is a trigger for Step 5-4, not evidence of flakiness.
+
+#### 5-4: Local reproduction (when the failure cannot be reproduced with a default build)
+
+Map the CI job name to its local reproduction command and run it:
+
+| CI job | Local reproduction command |
+|--------|---------------------------|
+| `test (asan)` / `sanitizer` | `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry test -p` |
+| `test (tsan)` / `tsan` | `cmake --preset tsan && cmake --build build-tsan && TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests` |
+| `clang-tidy` | `find src -name '*.cpp' \| xargs clang-tidy -p build --quiet` |
+| `cppcheck` / `lint` | `cppcheck --enable=warning,performance,portability --std=c++17 --suppressions-list=.cppcheck-suppressions --inline-suppr -i build -i build-asan -i build-tsan -j "$(nproc)" --quiet src/ include/` |
+| `scan-build` | `scan-build --use-cc=/usr/local/llvm/bin/clang --use-c++=/usr/local/llvm/bin/clang++ cmake --build build` |
+
+**Known CI-only failure patterns (do not misclassify as PR-caused):**
+
+- **TSan `ry test -p` aborts on Linux** with `LargeMmapAllocator CHECK` — upstream TSan runtime bug, not a regression. See KNOWLEDGE.md "TSan LargeMmapAllocator CHECK failure on Linux". Only `ry_tests` is required; `ry test -p` is warn-only.
+- **TSan gate** — `ry_tests` is required, `ry test -p` is warn-only. See KNOWLEDGE.md "TSan job — C++ required, Ry self-tests warn-only".
+- **UBSan vptr/function violations** — built with `-fno-sanitize=vptr,function`; these are LLVM false positives. See KNOWLEDGE.md "UBSan must disable vptr and function checks".
+
+**Environment-caused (flaky) — positive evidence required:**
+
+Classify as environment-caused **only** when the log contains one of:
+
+- `OOM Killed`
+- `No space left on device`
+- `Connection timed out`
+- `curl: (6) Could not resolve host`
+- `Error: The process '/usr/bin/apt-get' failed`
+
+If **none** of the above appear and local reproduction also fails, leave the classification as **Indeterminate** and present findings to the user. Do **not** conclude "flaky" without positive evidence.
+
+### Step 6: Report and propose next actions
+
+Report in the following format, replacing placeholders with actual values:
+
+---
+
+**CI Investigation Report: PR #\<PR\>**
+
+> Re-run triggered for run #\<runId\>. Investigating in parallel.
+
+**Summary**
+
+| Job | Status | Type | Cause | Local reproduction |
+|-----|--------|------|-------|--------------------|
+| build (linux) | ❌ Failed | Build error | PR-caused | — |
+| test (asan) | ❌ Failed | Sanitizer error | PR-caused | `cmake --preset asan && ...` |
+| clang-tidy | ❌ Failed | Lint error | Pre-existing | `find src ... \| xargs clang-tidy` |
+
+---
+
+**[N] \<job-name\> — \<Type\> — \<Cause\>**
+
+Error:
+```
+<relevant log excerpt — error message, file, line number>
+```
+
+Changed files involved: `<file>` (or "none — Pre-existing")
+
+Local reproduction:
+```bash
+<exact command from the table above>
+```
+
+Proposed action: \<1–2 sentences describing what to do\>
+
+---
+
+**Next steps**
+
+1. **PR-caused failures** — Fix using the investigation above. Push and let the re-run or a new run verify.
+2. **Pre-existing failures** — File a separate issue via `/git-triage-issue` (use the current PR's milestone) and decouple from this PR's CI.
+3. **Flaky / environment-caused (positive evidence confirmed)** — Check the re-run result triggered in Step 3.
+4. **Indeterminate** — Review the log excerpts above and decide with the user whether to investigate further or file an issue.
+
+---
+
+## Re-run policy
+
+- Re-run is triggered in Step 3 **before** investigation begins, to eliminate flakiness as a confounding variable.
+- Re-run is **not** a substitute for investigation. Proceed to Step 4 immediately after triggering.
+- If a failure is **PR-caused**, fixing the code is required regardless of whether the re-run passes.
+
+> **Important:** This skill does NOT commit, push, or fix code. It investigates, reports, and triggers re-runs only. For Pre-existing issues, use `/git-triage-issue`.
+
+---
+
+*Canonical source for sanitizer commands and environment flags: AGENTS.md "サニタイザー" and "作業完了前チェックリスト §3.5".*

--- a/.claude/skills/ci-investigate/SKILL.md
+++ b/.claude/skills/ci-investigate/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ci-investigate
 description: Investigate CI failures on a PR in parallel with a re-run. Classifies failures as PR-caused / Pre-existing / Indeterminate, proposes next actions, and never concludes "flaky" without positive infrastructure evidence.
-allowed-tools: Bash(gh pr:*), Bash(gh run:*), Bash(git branch:*), Read, Grep
+allowed-tools: Bash, Read, Grep
 metadata:
   short-description: Investigate CI failures on a PR with parallel re-run
 ---
@@ -14,7 +14,7 @@ Investigate CI failures on a PR and classify each failure so that re-runs, fixes
 
 The anti-pattern this skill breaks:
 
-```
+```text
 CI fails
   → "can't reproduce locally, probably flaky"
   → re-run (no investigation)
@@ -61,14 +61,15 @@ gh pr checks <PR> --json name,status,conclusion,detailsUrl
 
 ### Step 3: Trigger re-run in parallel with investigation
 
-Identify the failing workflow runs:
+Identify the failing workflow runs, scoped to the PR's head commit (use `headRefOid` from the Context preflight):
 
 ```bash
-gh run list --branch <headRefName> --limit 10 \
-  --json databaseId,name,status,conclusion,workflowName
+gh run list --branch <headRefName> --limit 20 \
+  --json databaseId,headSha,name,status,conclusion,workflowName \
+  | jq --arg sha "<headRefOid>" '[.[] | select(.headSha == $sha)]'
 ```
 
-For each run where `conclusion == "failure"`, trigger a re-run immediately:
+For each run in the result where `conclusion == "failure"`, trigger a re-run immediately:
 
 ```bash
 gh run rerun <runId> --failed
@@ -102,10 +103,12 @@ gh run view <runId> --log-failed > /tmp/ci-investigate-<runId>.log
 
 Then scan with `Grep` for error keywords, or `Read` the file in targeted ranges.
 
-If the run ID is not known yet, find it via `detailsUrl` from Step 2 or by re-running:
+If the run ID is not known yet, derive it from `detailsUrl` in Step 2 (extract the numeric run ID with `grep -oE '/runs/([0-9]+)' | grep -oE '[0-9]+'`), or re-query with headSha filtering:
 
 ```bash
-gh run list --branch <headRefName> --limit 20 --json databaseId,name,conclusion,workflowName
+gh run list --branch <headRefName> --limit 20 \
+  --json databaseId,headSha,name,conclusion,workflowName \
+  | jq --arg sha "<headRefOid>" '[.[] | select(.headSha == $sha)]'
 ```
 
 #### 5-2: Classify the failure type
@@ -182,7 +185,7 @@ Report in the following format, replacing placeholders with actual values:
 **[N] \<job-name\> — \<Type\> — \<Cause\>**
 
 Error:
-```
+```text
 <relevant log excerpt — error message, file, line number>
 ```
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2406,3 +2406,31 @@ int list (sum), 2/3-elem lists, and float list. These cases provide functional r
 coverage. For uninitialized-read detection specifically, use MemorySanitizer (MSan) rather
 than ASan — ASan detects memory-access errors (buffer overflows, use-after-free) but does
 not detect uninit reads.
+
+### Skill `allowed-tools` must cover all Bash commands the skill body prescribes
+
+**Source**: #1045 (2026-04-16, CodeRabbit review)
+**Tags**: skill, allowed-tools, claude-code, ci-investigate, review-feedback
+
+**Rule**: Every Bash command that a SKILL.md step instructs the agent to run must be covered by an entry in `allowed-tools`. A common pitfall is listing only `gh pr:*`/`gh run:*`/`git branch:*` while the skill body also calls `cmake`, `clang-tidy`, `cppcheck`, `scan-build`, `find`, etc. At runtime the agent will be blocked from running those uncovered commands, silently breaking the step.
+
+When the reproduction command set is open-ended (e.g. "run the CI job's corresponding local command"), use `Bash` (unrestricted) rather than a long enumeration of prefixes that will grow stale.
+
+**How to verify**: grep the skill body for bare Bash commands not covered by the `allowed-tools` line.
+
+### `gh run list --branch` returns all runs on a branch, not just the PR head commit
+
+**Source**: #1045 (2026-04-16, CodeRabbit review)
+**Tags**: github-actions, gh-cli, ci-investigate, review-feedback, gotcha
+
+**Rule**: `gh run list --branch <name>` includes runs from every commit on that branch. In a CI investigation or re-run tool, this causes reruns and log analysis for commits unrelated to the PR being investigated.
+
+Always filter by the PR's `headRefOid` (head commit SHA) immediately after the `gh run list` call:
+
+```bash
+gh run list --branch <headRefName> --limit 20 \
+  --json databaseId,headSha,name,status,conclusion,workflowName \
+  | jq --arg sha "<headRefOid>" '[.[] | select(.headSha == $sha)]'
+```
+
+Alternatively, derive run IDs directly from `detailsUrl` in the `gh pr checks` output (`grep -oE '/runs/([0-9]+)' | grep -oE '[0-9]+'`).


### PR DESCRIPTION
Closes #1040

## Summary

- Adds `.claude/skills/ci-investigate/SKILL.md`, a new Agent Skill invoked as `/ci-investigate` or `/ci-investigate <PR-number>`
- Triggers a CI re-run immediately on entry (Step 3) and investigates failure logs in parallel — eliminating the anti-pattern of waiting for re-runs before investigating
- Classifies each failed job as **PR-caused**, **Pre-existing**, or **Indeterminate** by diffing error locations against the PR's changed files
- Provides a CI job → local reproduction command table (asan / tsan / clang-tidy / cppcheck / scan-build) inline, so the skill is self-contained at execution time
- Requires positive infrastructure evidence (`OOM Killed`, `No space left on device`, etc.) before classifying a failure as flaky/environment-caused
- References KNOWLEDGE.md entries for known CI-only gotchas (TSan warn-only, UBSan false positives, LargeMmapAllocator CHECK) by title, not line number
- Routes Pre-existing failures to `/git-triage-issue` for proper decoupling from the PR's CI

## Test plan

- [ ] Skill appears in the skill list as `ci-investigate`
- [ ] `/ci-investigate` on a branch with no open PR reports "No PR found" and stops
- [ ] `/ci-investigate` on a green PR reports "CI is green" and stops
- [ ] `/ci-investigate <PR>` on a PR with failures triggers a re-run in Step 3 and proceeds to log analysis without waiting
- [ ] Each Acceptance Criteria from issue #1040 is addressed by the corresponding Step (verified by plan §4-1 mapping)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated CI investigation workflow for PRs: triggers reruns, gathers failing jobs, classifies failures (PR-caused, pre-existing, indeterminate, or infrastructure), maps failures to changed files, provides local reproduction commands, and emits a standardized per-failure report with next-action suggestions.

* **Documentation**
  * Added guidance on required allowlisting for scripted commands and clarified how to scope CI run listings to a PR to avoid analyzing unrelated commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->