### PR TITLE
feat(str): add StringHeader with explicit byte_len for NUL-safe strings (#1022)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(ry_lib STATIC
     src/module_loader.cpp
     src/jit.cpp
     src/test_runtime.cpp
+    src/runtime_string.cpp
     src/runtime_hash.cpp
     src/runtime_regex.cpp
     src/runtime_regex_parser.cpp
@@ -305,6 +306,7 @@ add_executable(ry_tests
     tests/test_runtime_json.cpp
     tests/test_runtime_any.cpp
     tests/test_runtime_print.cpp
+    tests/test_runtime_string.cpp
     tests/test_stdin.cpp
     tests/test_entry_point.cpp
     tests/test_help.cpp

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1124,7 +1124,7 @@ Affected patterns and what typeSig to pass:
 
 **Layout** (defined in `include/ry/ry_layout.hpp` and `include/ry/runtime_string.hpp`):
 
-```
+```text
 Offset from handle:  Field
   handle - 24       strong_count : i64  (ARC_IMMORTAL for literals; 1 for dynamic)
   handle - 16       weak_count   : i64  (0 always in PR #1022)
@@ -1635,6 +1635,32 @@ workaround for the TSan runtime bug, not tolerance for real races.
 `parallel_for_depth_` only propagates to ARC ops emitted **inside**
 the thunk body, not through helper calls; if a helper-alias race
 surfaces, widen via #872 rather than blindly expanding the flag.
+
+### LLVM ORC JIT intermittent `cfree` crash in `removeResourceTracker` on Linux CI
+
+**Source**: #1022 (2026-04-16), CI run 24507853564
+**Tags**: llvm, orc, jit, ci, flaky, linux, cleanup
+
+**Symptom**: The Ry self-test (`ry test -p`) completes all `it` blocks
+successfully, then crashes with an LLVM `PLEASE submit a bug report` message
+pointing into `cfree` → `removeResourceTracker`:
+
+```text
+135 passed, 0 failed
+PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/...
+#4  cfree (/lib/x86_64-linux-gnu/libc.so.6)
+#5  llvm::orc::ExecutionSession::removeResourceTracker(...)
+#7  scope_exit destructor in jit_runner.cpp
+#8  runRySource(...)
+```
+
+**Rule**: This crash is in LLVM's internal JIT cleanup (not user code) and
+is intermittent on the Linux CI runner. It does **not** reproduce under ASan
+on macOS. When this crash appears, trigger a CI re-run immediately; if the
+re-run passes, the failure is a pre-existing LLVM ORC JIT flakiness, not a
+regression introduced by the PR. Do not suppress the LLVM crash reporter or
+add `|| true` to the test runner command — a genuine double-free in user code
+would produce the same stack frame and must not be silently ignored.
 
 ### `@parallel for` captures must be retained AND ARC-backed inside the thunk
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1092,7 +1092,37 @@ Affected patterns and what typeSig to pass:
 5. If `typeSig` is `"str"` or another non-collection non-closure pointer type: do not retain (see **Do not retain `str`** below). Return.
 6. Otherwise (no `typeSig`): fall through to `tryRetainArcSource(val)` (source-alloca heuristic); then check `arc_owned_values_`; then check collection-type metadata set by `propagateTypeMeta`.
 
-**Do not retain `str`**: `str` values returned from C runtime functions (e.g. `read_text`, `bytes_to_str`) use `checked_malloc`, not `arc_alloc`. Retaining them causes `free(ptr - 16)` on malloc metadata → crash. The correct approach is: only retain collections (`List<T>`, `Map<K,V>`, `Set<T>`), never bare `str`.
+**Do not retain `str`**: `str` values are not ARC-managed in PR #1022. Dynamic `str` values use a `StringHeader` layout (`{strong_count, weak_count, byte_len, data[], '\0'}`), where the handle points to `alloc + STRING_HEADER_SIZE (24)`. The ARC header is at `handle - 24`, but `emitArcGetHeaderFromData` uses offset `ARC_HEADER_SIZE (16)`, so retaining a `str` would point to the middle of the header (16 bytes instead of 24) → corrupts the `byte_len` field → crash. The correct approach is: only retain collections (`List<T>`, `Map<K,V>`, `Set<T>`), never bare `str`. Full ARC management of `str` (with the correct `-24` offset) is deferred to a follow-up issue after #1022.
+
+### StringHeader layout — `str` memory representation (#1022)
+
+**Source**: #1022 (2026-04-16)
+**Tags**: str, StringHeader, ARC, memory-layout, NUL, byte_len, makeString
+
+**Rule**: Every Ry `str` value is a pointer to the *data* region of a `StringHeader` block. Never treat a Ry `str` handle as a raw `char*` allocated with `malloc`/`strdup`; always use `makeString`/`makeStringUninit` to create them and `freeStringSlot` to free them.
+
+**Layout** (defined in `include/ry/ry_layout.hpp` and `include/ry/runtime_string.hpp`):
+
+```
+Offset from handle:  Field
+  handle - 24       strong_count : i64  (ARC_IMMORTAL for literals; 1 for dynamic)
+  handle - 16       weak_count   : i64  (0 always in PR #1022)
+  handle - 8        byte_len     : i64  (STRING_BYTELEN_OFFSET = 8)
+  handle + 0 ..     data bytes          ← the char* passed to Ry / codegen
+  handle + byte_len '\0'                (null terminator for libc compat)
+```
+
+Key constants:
+- `ARC_HEADER_SIZE = 16` (unchanged — collection headers keep this offset)
+- `STRING_HEADER_SIZE = 24` (= ARC_HEADER_SIZE + 8 for the byte_len field)
+- `STRING_BYTELEN_OFFSET = 8`
+
+**How to get byte length in C++**: `stringByteLen(handle)` — reads `*(int64_t*)(handle - 8)`.  
+**How to get byte length in LLVM IR**: `emitStringByteLen(handle)` — emits a GEP + load.  
+**How to free a dynamic str**: `freeStringSlot(handle)` — calls `free(handle - STRING_HEADER_SIZE)`.  
+**Literal globals**: created by `buildArcGlobal` in `src/codegen.cpp`; `strong_count = ARC_IMMORTAL` so retain/release are no-ops. GEP index is `(0, 3, 0)` into the struct.
+
+**NUL safety in PR #1022**: `byte_len`, `length`, `==`/`!=`/`<`/`>`, `+`, `*`, Map/Set key hash+compare are NUL-safe. Remaining ops (`contains`, `starts_with`, `split`, `replace`, `substring`, etc.) still use `strlen`/`strstr` internally — NUL truncates them. Track in follow-up issues.
 
 **`markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`** (Source: #1016):
 TuplePattern / RecordPattern / EnumConstructorPattern pre-mark a temporary alloca
@@ -1144,6 +1174,32 @@ incoming.push_back({armVal, armEndBB});
 
 The same rule applies to any code that records an insert-block BB for later
 PHI use while a scope with ARC-managed variables is still open.
+
+### `isStringValue` must not be used to dispatch `weak` header offset
+
+**Source**: #1022 (2026-04-16, implementation)
+**Tags**: codegen, weak, str, StringHeader, isStringValue, emitWeakExpr
+
+**Rule**: Do not use `isStringValue(val)` to choose between `STRING_HEADER_SIZE` (24) and `ARC_HEADER_SIZE` (16) offsets when computing the ARC header pointer for a `weak` variable. `isStringValue` returns `true` for **any** `ptrTy_` value that has no `hasAnyMeta()` flag — captured `List<int>` / `Map` / `Set` values inside closure bodies lack collection metadata after the capture injection in `codegen_fn.cpp` / `codegen_lambda.cpp`, so they are misclassified as `str` and get the wrong `-24` offset.
+
+**How**: The inner type name is available from the annotation at the `LetStmt` site (`weakInnerTypeName(*annot)`) and from `weak_inner_type_names_[ptr]` at reassignment. Use `innerName == "str"` there:
+
+```cpp
+// codegen_stmt.cpp — initial let
+llvm::Value *headerPtr = (innerName == "str")
+    ? emitStrGetHeaderFromData(val)
+    : emitArcGetHeaderFromData(val);
+
+// codegen_stmt.cpp — reassignment (ptr is the existing weak alloca)
+auto it = weak_inner_type_names_.find(ptr);
+const std::string &weakInner = (it != weak_inner_type_names_.end())
+    ? it->second : std::string{};
+llvm::Value *headerPtr = (weakInner == "str")
+    ? emitStrGetHeaderFromData(val)
+    : emitArcGetHeaderFromData(val);
+```
+
+`emitExprVariant(WeakExpr)` (codegen_expr.cpp) must return the raw data pointer; the conversion happens at the call sites above, not inside the emitter.
 
 ---
 

--- a/changelog.d/1022-str-embedded-nul.md
+++ b/changelog.d/1022-str-embedded-nul.md
@@ -1,0 +1,8 @@
+### Changed
+
+- `str` now stores an explicit byte length (`StringHeader` layout: `strong_count`, `weak_count`, `byte_len` prefix before the character data). The operations `byte_len`, `length`, `==`, `!=`, `<`, `>`, `+`, `*`, and Map/Set key lookup are fully NUL-safe; strings containing embedded NUL bytes (`\0`) are no longer silently truncated. (#1022)
+
+### Fixed
+
+- `bytes_to_str` now preserves embedded NUL bytes instead of rejecting them. (#1022)
+- `weak str` upgrade no longer returns `None` instead of `Some` when the strong reference is alive; codegen now uses the correct `STRING_HEADER_SIZE` (24) offset to reach `strong_count` instead of the collection `ARC_HEADER_SIZE` (16). (#1022)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -5,6 +5,8 @@
 A list of operation functions for strings (`str`). All functions support UFCS notation.
 
 > **Note:** All string operations are UTF-8 aware. `length()`, `char_at()`, `substring()`, `find()`, and `reverse()` operate on Unicode code points, not bytes. Use `byte_len()` if you need the byte length.
+>
+> **NUL bytes:** As of #1022, `str` stores an explicit byte length and supports embedded NUL bytes (`\0`). The operations `byte_len`, `length`, `==`, `!=`, `<`, `>`, `+`, `*`, and hash/Map/Set key lookup are fully NUL-safe. Other operations (`contains`, `starts_with`, `ends_with`, `split`, `replace`, etc.) may still truncate at the first NUL byte — this will be addressed in follow-up issues.
 
 ## Function List
 
@@ -268,10 +270,13 @@ print("abc".reverse())     # cba (UFCS)
 
 Returns the byte length of string `string`. Unlike `length()`, which returns the number of UTF-8 characters, `byte_len()` returns the number of bytes.
 
+Embedded NUL bytes (`\0`) are counted — `byte_len("a\0b")` returns `3`.
+
 ```python
 print(byte_len("hello"))   # 5
 print(byte_len("あいう"))   # 9
 print(length("あいう"))        # 3 (characters)
+print(byte_len("a\0b"))    # 3 (NUL byte is counted)
 ```
 
 ---

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -10,7 +10,7 @@
 | `u8` | i8 | (no dedicated literal) | Unsigned 8-bit integer (0-255). Used with type annotation `b: u8 = 42` |
 | `float` | f64 | `3.14`, `0.5`, `3.14_159`, `1e10`, `1.5e-3`, `2.5E+2` | 64-bit floating-point number (scientific notation supported) |
 | `bool` | i1 | `true`, `false` | Boolean value |
-| `str` | ptr | `"hello"`, `""`, `"a\nb"` | String (immutable byte sequence on the heap) |
+| `str` | ptr | `"hello"`, `""`, `"a\nb"` | String (immutable byte sequence on the heap). Internally a pointer to the data portion of a `StringHeader` (`{strong_count, weak_count, byte_len, data[], '\0'}`). Supports embedded NUL bytes (#1022). |
 | `Unit` | void | (no return value) | Return type for functions with no return value. Must be specified explicitly with `-> Unit` |
 | `Option<T>` | `{ i1, T }` | `Some(42)`, `None` | A type that may or may not contain a value |
 | `(T1, T2, ...)` | LLVM StructType (literal) | `(1, 3.14)` | Tuple type |
@@ -25,7 +25,7 @@
 | `any` | `{ i64, [8 x i8] }` | `x: any = 42` | Tagged union that can hold any primitive value |
 | `T1 \| T2` | `{ i64, [N x i8] }` | `int \| str` | Union type (holds one of multiple types) |
 | Int literal | i64 | `42`, `0 \| 1` | Int literal type (value constraint) |
-| String literal | ptr | `"N" \| "S"` | String literal type (value constraint) |
+| String literal | ptr | `"N" \| "S"` | String literal type (value constraint). The handle points to an immortal `StringHeader` global. |
 | Range | i64 | `1..12`, `-10..10` | Range type (inclusive integer range constraint) |
 | `i8` | i8 | `x: i8 = 42`, `x = 42i8` | 8-bit signed integer (low-level, no implicit conversion) |
 | `i16` | i16 | `x: i16 = 100`, `x = 100i16` | 16-bit signed integer (low-level, no implicit conversion) |

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -191,7 +191,16 @@ public:
                         llvm::Function *gcVisitFn = nullptr);
     llvm::Value *emitArcGetDataPtr(llvm::Value *headerPtr);
     llvm::Value *emitArcGetHeaderFromData(llvm::Value *dataPtr);
+    // String variant: subtracts STRING_HEADER_SIZE (24) instead of ARC_HEADER_SIZE (16).
+    // Must be used whenever the data pointer is a Ry str (StringHeader-prefixed).
+    llvm::Value *emitStrGetHeaderFromData(llvm::Value *strHandle);
+    // String variant: adds STRING_HEADER_SIZE (24) back to get the str handle.
+    llvm::Value *emitStrGetDataPtr(llvm::Value *strHeaderPtr);
     llvm::Value *emitArcAllocCollectionHeader(llvm::Type *headerTy);
+    // Emit a load of the byte_len field from a StringHeader handle.
+    // `handle` must be a Ry str value (StringHeader data pointer).
+    // Returns an i64 value representing the byte length of the string.
+    llvm::Value *emitStringByteLen(llvm::Value *handle);
     // Aligned i64 load at `ptr` with the given atomic ordering (or plain
     // load when ordering == NotAtomic). Used for ARC strong_count reads
     // that race with atomicrmw retain/release (#630).
@@ -1244,6 +1253,7 @@ public:
     llvm::FunctionCallee getStdlibMemcpy();
     llvm::FunctionCallee getStdlibMemmove();
     llvm::FunctionCallee getStdlibMemset();
+    llvm::FunctionCallee getStdlibMemcmp();
     llvm::FunctionCallee getStdlibStrcmp();
     llvm::FunctionCallee getStdlibStrncmp();
     llvm::FunctionCallee getStdlibStrstr();

--- a/include/ry/runtime_http_types.hpp
+++ b/include/ry/runtime_http_types.hpp
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "ry/runtime_alloc.hpp"
+#include "ry/runtime_string.hpp"
 
 
 namespace ry {
@@ -114,8 +115,8 @@ struct ParsedUrl {
 
 inline void free_kv_pairs(char **keys, char **vals, int64_t count) {
     for (int64_t i = 0; i < count; i++) {
-        free(keys[i]);
-        free(vals[i]);
+        freeStringSlot(keys[i]);
+        freeStringSlot(vals[i]);
     }
     free(keys);
     free(vals);

--- a/include/ry/runtime_list.hpp
+++ b/include/ry/runtime_list.hpp
@@ -8,6 +8,7 @@
 
 #include "ry/runtime_alloc.hpp"
 #include "ry/runtime_arc.hpp"
+#include "ry/runtime_string.hpp"
 
 
 namespace ry {
@@ -21,17 +22,15 @@ struct ListHeader {
     char **data;
 };
 
-// Duplicate a string of known length into a plain heap buffer.
-// Individual list element strings are owned by the caller and are never
-// individually freed by the list destructor (which only frees the
-// data-pointer array).  Plain checked_malloc is sufficient here — the ARC
-// machinery never retains/releases individual string elements extracted from
-// a list.
+// Duplicate a string of known length into a StringHeader-managed buffer.
+// The handle (data pointer past the StringHeader) is returned.
+// Individual list element strings are not freed by the list destructor (which
+// only frees the data-pointer array); they will be managed by a follow-up
+// PR that enables full ARC management for str.  After the migration to
+// StringHeader (PR #1022), freeStringSlot() must be used instead of free()
+// to release these elements if/when that becomes necessary.
 inline char *dupString(const char *s, size_t n) {
-    char *buf = (char *)checked_malloc(n + 1);
-    memcpy(buf, s, n);
-    buf[n] = '\0';
-    return buf;
+    return makeString(s, n);
 }
 
 // Build an ARC-managed ListHeader from a vector of strings.

--- a/include/ry/runtime_string.hpp
+++ b/include/ry/runtime_string.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "ry/ry_layout.hpp"
+#include "ry/runtime_alloc.hpp"
+#include <cstdint>
+#include <cstring>
+
+// ── StringHeader helpers ────────────────────────────────────────────────────
+//
+// Every `str` value in Ry points to the *data* portion of a StringHeader.
+// The full allocation layout is (see ry_layout.hpp for constants):
+//
+//   [ strong_count : i64 ]   ← STRING_HEADER_SIZE (24) bytes before handle
+//   [ weak_count   : i64 ]
+//   [ byte_len     : i64 ]   ← 8 bytes before handle (STRING_BYTELEN_OFFSET)
+//   [ data[0..N-1] : i8  ]   ← handle (the char* exposed to Ry / codegen)
+//   [ '\0'         : i8  ]   ← handle[byte_len] — kept for @native / libc compat
+//
+// Invariants
+// ----------
+// 1. All `str` values are StringHeader handles (either immortal literal globals
+//    or dynamically allocated with makeString/makeStringUninit).
+// 2. handle[byte_len] == '\0' always (null terminator for C library compat).
+// 3. In PR #1022, str is NOT yet ARC-managed by codegen:
+//    fieldTypeIsArcManaged("str") remains false.  makeString sets strong_count=1
+//    as a forward-compat marker, but retain/release are never emitted for str.
+// 4. Literal globals use ARC_IMMORTAL for strong_count (no-op on any retain).
+
+namespace ry {
+
+// Return the byte_len stored in the StringHeader for `handle`.
+// handle must be a valid StringHeader data pointer (not a raw C string).
+inline int64_t stringByteLen(const char *handle) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return *reinterpret_cast<const int64_t *>(handle - static_cast<ptrdiff_t>(STRING_BYTELEN_OFFSET));
+}
+
+// Return a pointer to the beginning of the StringHeader for `handle`
+// (i.e. handle - STRING_HEADER_SIZE).  This points to strong_count.
+// Provided for forward-compat; full ARC management of str comes in a later PR.
+inline char *stringHeaderPtr(const char *handle) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    return const_cast<char *>(handle) - static_cast<ptrdiff_t>(STRING_HEADER_SIZE);
+}
+
+// Allocate a StringHeader-managed string of `byte_len` bytes, copy `byte_len`
+// bytes from `src` (may contain embedded NUL bytes), append a null terminator,
+// and return a handle (pointer to data).
+//
+// If `src` is nullptr an empty string is returned (byte_len is forced to 0).
+// Aborts on OOM or integer overflow.
+inline char *makeString(const char *src, size_t byte_len) {
+    if (!src) byte_len = 0;
+
+    // Overflow-safe total: STRING_HEADER_SIZE + byte_len + 1 (null terminator)
+    size_t total;
+    if (__builtin_add_overflow(STRING_HEADER_SIZE, byte_len, &total) ||
+        __builtin_add_overflow(total, size_t{1}, &total)) {
+        oom_abort(byte_len);
+    }
+
+    auto *block = static_cast<int64_t *>(checked_malloc(total));
+    block[0] = 1;  // strong_count (not yet decremented in PR #1022)
+    block[1] = 0;  // weak_count
+    block[2] = static_cast<int64_t>(byte_len);  // byte_len
+
+    auto *data = reinterpret_cast<char *>(block + 3);  // past the 3×i64 header
+    if (byte_len > 0) memcpy(data, src, byte_len);
+    data[byte_len] = '\0';
+
+    return data;
+}
+
+// Allocate a StringHeader-managed string of `byte_len` bytes without copying
+// any data (the data region is uninitialized).  The null terminator at
+// data[byte_len] IS written.  Used by concat/repeat where the caller fills the
+// buffer with memcpy before returning the handle.
+//
+// Aborts on OOM or integer overflow.
+inline char *makeStringUninit(size_t byte_len) {
+    size_t total;
+    if (__builtin_add_overflow(STRING_HEADER_SIZE, byte_len, &total) ||
+        __builtin_add_overflow(total, size_t{1}, &total)) {
+        oom_abort(byte_len);
+    }
+
+    auto *block = static_cast<int64_t *>(checked_malloc(total));
+    block[0] = 1;
+    block[1] = 0;
+    block[2] = static_cast<int64_t>(byte_len);
+
+    auto *data = reinterpret_cast<char *>(block + 3);
+    data[byte_len] = '\0';
+
+    return data;
+}
+
+// Free a StringHeader-managed string given its handle.
+// Use this instead of plain free() whenever the pointer came from
+// makeString/makeStringUninit (not from a literal global).
+// Calling this on a literal global (ARC_IMMORTAL) is NOT safe; only call it
+// on dynamically-allocated strings.
+inline void freeStringSlot(char *handle) {
+    if (!handle) return;
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+    free(handle - static_cast<ptrdiff_t>(STRING_HEADER_SIZE));
+}
+
+} // namespace ry

--- a/include/ry/ry_layout.hpp
+++ b/include/ry/ry_layout.hpp
@@ -11,6 +11,29 @@ namespace ry {
 inline constexpr size_t  ARC_HEADER_SIZE = sizeof(int64_t) * 2;
 inline constexpr int64_t ARC_IMMORTAL    = INT64_MAX;
 
+// ── StringHeader layout ────────────────────────────────
+// Strings use an extended header that appends a byte_len field after the
+// standard ARC header, followed by the string bytes and a null terminator.
+//
+//   [ strong_count : i64 ]  ← STRING_HEADER_SIZE bytes before handle
+//   [ weak_count   : i64 ]
+//   [ byte_len     : i64 ]  ← handle - STRING_BYTELEN_OFFSET (== 8)
+//   [ data[0..N-1] : i8  ]  ← handle (the char* exposed to Ry code)
+//   [ '\0'         : i8  ]  ← handle[byte_len] (null-terminator for @native compat)
+//
+// ARC_HEADER_SIZE (16) is intentionally NOT changed — collection headers
+// (ListHeader, MapHeader, etc.) still reside exactly 16 bytes past ARC alloc.
+// String-specific helpers use STRING_HEADER_SIZE (24) for their own offsets.
+//
+// In PR #1022, strings carry this header but are NOT yet ARC-managed by codegen
+// (fieldTypeIsArcManaged("str") remains false). The strong_count/weak_count
+// fields are present for forward compatibility: literals get ARC_IMMORTAL, and
+// dynamic strings get strong_count=1 (written by makeString but never decremented
+// until a follow-up issue enables full ARC management for str).
+inline constexpr size_t  STRING_HEADER_EXTRA  = sizeof(int64_t);    // byte_len field
+inline constexpr size_t  STRING_HEADER_SIZE   = ARC_HEADER_SIZE + STRING_HEADER_EXTRA; // 24
+inline constexpr int64_t STRING_BYTELEN_OFFSET = static_cast<int64_t>(STRING_HEADER_EXTRA); // 8
+
 // ── RyAny type tag ─────────────────────────────────────
 enum class RyAnyTag : int64_t {
     Int   = 0,

--- a/src/args_runtime.cpp
+++ b/src/args_runtime.cpp
@@ -1,4 +1,7 @@
 #include "ry/args_runtime.hpp"
+#include "ry/runtime_string.hpp"
+#include <cstdlib>
+#include <cstring>
 
 
 namespace ry {
@@ -15,9 +18,19 @@ extern "C" int __ry_args_count() {
     return g_argc;
 }
 
+// Returns a StringHeader-managed str handle (not a raw argv pointer).
+// Callers can safely call byte_len() / length() on the returned value.
 extern "C" const char* __ry_args_get(int index) {
-    if (index < 0 || index >= g_argc) return "";
-    return g_argv[index];
+    const char *raw = (index < 0 || index >= g_argc) ? "" : g_argv[index];
+    return makeString(raw, strlen(raw));
+}
+
+// Wraps getenv() result in a StringHeader-managed str handle.
+// Returns nullptr when the variable is not set (caller converts to None/default).
+extern "C" const char* __ry_env_get(const char *key) {
+    const char *val = getenv(key); // key has null terminator — safe for getenv
+    if (!val) return nullptr;
+    return makeString(val, strlen(val));
 }
 
 } // namespace ry

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -103,16 +103,20 @@ llvm::Constant *CodeGen::buildArcGlobal(
     auto it = cache.find(str);
     if (it != cache.end()) return it->second;
 
-    // Create global with ARC header prefix: { i64 INT64_MAX, i64 0, [N+1 x i8] "...\0" }
-    // The returned pointer points to the string data (after ARC header),
-    // so existing code uses it as char*. If ARC retain/release is called,
-    // ptr-16 leads to the immortal sentinel (INT64_MAX) which skips the op.
+    // Create global with StringHeader prefix:
+    //   { i64 ARC_IMMORTAL, i64 0, i64 byte_len, [N+1 x i8] "...\0" }
+    // Layout matches the runtime StringHeader (see include/ry/runtime_string.hpp):
+    //   handle - 8  → byte_len
+    //   handle - 24 → strong_count (ARC_IMMORTAL → retain/release are no-ops)
+    // str.size() gives the correct byte count even when str contains NUL bytes
+    // (std::string is NUL-safe).  ConstantDataArray::getString appends one \0.
     auto *strData = llvm::ConstantDataArray::getString(*ctx_, str);
     auto *wrapTy = llvm::StructType::get(
-        *ctx_, {i64Ty_, i64Ty_, strData->getType()});
+        *ctx_, {i64Ty_, i64Ty_, i64Ty_, strData->getType()});
     auto *initVal = llvm::ConstantStruct::get(wrapTy,
         {llvm::ConstantInt::get(i64Ty_, ARC_IMMORTAL),
          llvm::ConstantInt::get(i64Ty_, 0),
+         llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(str.size())),
          strData});
     auto *gv = new llvm::GlobalVariable(
         *mod_, wrapTy, /*isConstant=*/true,
@@ -121,11 +125,11 @@ llvm::Constant *CodeGen::buildArcGlobal(
     gv->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
     gv->setAlignment(llvm::Align(8));
 
-    // GEP to the string data part (index 2, then index 0 for first byte)
+    // GEP to the string data part (index 3, then index 0 for first byte)
     auto *zero = llvm::ConstantInt::get(i64Ty_, 0);
-    auto *idx2 = llvm::ConstantInt::get(i32Ty_, 2);
+    auto *idx3 = llvm::ConstantInt::get(i32Ty_, 3);
     auto *gs = llvm::ConstantExpr::getInBoundsGetElementPtr(
-        wrapTy, gv, llvm::ArrayRef<llvm::Constant*>{zero, idx2, zero});
+        wrapTy, gv, llvm::ArrayRef<llvm::Constant*>{zero, idx3, zero});
 
     cache[str] = gs;
     return gs;

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -65,6 +65,34 @@ llvm::Value *CodeGen::emitArcGetHeaderFromData(llvm::Value *dataPtr) {
                               "arc_hdr_from_data");
 }
 
+llvm::Value *CodeGen::emitStrGetHeaderFromData(llvm::Value *strHandle) {
+    // Strings have STRING_HEADER_SIZE (24) bytes before the data pointer:
+    // { strong_count: i64, weak_count: i64, byte_len: i64, data... }
+    return builder_.CreateGEP(i8Ty_, strHandle,
+        llvm::ConstantInt::get(i64Ty_,
+            static_cast<uint64_t>(-static_cast<int64_t>(STRING_HEADER_SIZE))),
+        "str_hdr_from_data");
+}
+
+llvm::Value *CodeGen::emitStrGetDataPtr(llvm::Value *strHeaderPtr) {
+    // Recover the str handle from the StringHeader pointer.
+    auto *dataPtr = builder_.CreateGEP(i8Ty_, strHeaderPtr,
+        llvm::ConstantInt::get(i64Ty_, STRING_HEADER_SIZE),
+        "str_data");
+    arc_owned_values_.insert(dataPtr);
+    return dataPtr;
+}
+
+llvm::Value *CodeGen::emitStringByteLen(llvm::Value *handle) {
+    // The byte_len field lives STRING_BYTELEN_OFFSET (8) bytes before the
+    // string data pointer.  Emit: load i64, (handle - 8)
+    auto *bytelenPtr = builder_.CreateGEP(
+        i8Ty_, handle,
+        llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(-static_cast<int64_t>(STRING_BYTELEN_OFFSET))),
+        "str_bytelen_ptr");
+    return builder_.CreateLoad(i64Ty_, bytelenPtr, "str_bytelen");
+}
+
 llvm::LoadInst *CodeGen::emitAtomicI64Load(llvm::Value *ptr,
                                            llvm::AtomicOrdering ordering,
                                            const llvm::Twine &name) {
@@ -642,7 +670,10 @@ llvm::Value *CodeGen::emitWeakUpgrade(llvm::Value *headerPtr,
 
     // Immortal path: return Some(data_ptr) without incrementing
     builder_.SetInsertPoint(immortalBB);
-    auto *immortalDataPtr = emitArcGetDataPtr(headerPtr);
+    // str uses StringHeader (24 bytes); other ARC types use ArcHeader (16 bytes).
+    auto *immortalDataPtr = (innerTypeName == "str")
+        ? emitStrGetDataPtr(headerPtr)
+        : emitArcGetDataPtr(headerPtr);
     auto *immortalSome = buildSomeValue(immortalDataPtr, optionTy);
     builder_.CreateStore(immortalSome, resultAlloca);
     builder_.CreateBr(doneBB);
@@ -667,7 +698,9 @@ llvm::Value *CodeGen::emitWeakUpgrade(llvm::Value *headerPtr,
 
     // Success: strong_count incremented, return Some(data_ptr)
     builder_.SetInsertPoint(successBB);
-    auto *dataPtr = emitArcGetDataPtr(headerPtr);
+    auto *dataPtr = (innerTypeName == "str")
+        ? emitStrGetDataPtr(headerPtr)
+        : emitArcGetDataPtr(headerPtr);
     auto *someVal = buildSomeValue(dataPtr, optionTy);
     builder_.CreateStore(someVal, resultAlloca);
     builder_.CreateBr(doneBB);

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -553,9 +553,11 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         if (key->getType() != ptrTy_)
             codegenError("env() key must be str");
 
-        auto getenvTy = llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
-        auto getenvFn = mod_->getOrInsertFunction("getenv", getenvTy);
-        llvm::Value *result = builder_.CreateCall(getenvFn, {key}, "env_result");
+        // __ry_env_get wraps getenv() result in a StringHeader-managed handle
+        // so that byte_len / length / etc. work correctly on the returned str.
+        auto envGetTy = llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
+        auto envGetFn = mod_->getOrInsertFunction("__ry_env_get", envGetTy);
+        llvm::Value *result = builder_.CreateCall(envGetFn, {key}, "env_result");
         llvm::Value *isNull = builder_.CreateICmpEQ(result,
             llvm::ConstantPointerNull::get(
                 llvm::cast<llvm::PointerType>(ptrTy_)), "env_null");

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -747,20 +747,20 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         // Check if it's a list
         if (getListElementType(ptr))
             return loadListHeader(ptr, "list").len;
-        // String: call __ry_utf8_len (character count)
-        auto utf8LenTy = fnTy_ptr_to_i64_;
-        auto utf8LenFn = mod_->getOrInsertFunction("__ry_utf8_len", utf8LenTy);
-        return builder_.CreateCall(utf8LenFn, {ptr}, "str_len");
+        // String: call __ry_utf8_len_n (NUL-safe character count)
+        llvm::Value *byteLen = emitStringByteLen(ptr);
+        auto utf8LenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, i64Ty_}, false);
+        auto utf8LenFn = mod_->getOrInsertFunction("__ry_utf8_len_n", utf8LenTy);
+        return builder_.CreateCall(utf8LenFn, {ptr, byteLen}, "str_len");
     }
 
-    // byte_len(str) → int (byte length)
+    // byte_len(str) → int (byte length — NUL-safe, reads from StringHeader)
     if (e.callee == "byte_len") {
         requireArgs(e, 1);
         llvm::Value *ptr = emitExpr(*e.args[0]);
         if (ptr->getType() != ptrTy_)
             codegenError("byte_len() requires str argument");
-        auto strlenFn = getStdlibStrlen();
-        return builder_.CreateCall(strlenFn, {ptr}, "byte_len");
+        return emitStringByteLen(ptr);
     }
 
     // Some(x) → Option<T> constructor

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -312,12 +312,14 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
         codegenError("replace() requires str arguments");
     auto strlenFn = getStdlibStrlen();
     auto strstrFn = getStdlibStrstr();
-    auto mallocFn = getStdlibMalloc();
     auto memcpyFn = getStdlibMemcpy();
 
-    llvm::Value *sLen = builder_.CreateCall(strlenFn, {s}, "repl_s_len");
-    llvm::Value *oldLen = builder_.CreateCall(strlenFn, {oldStr}, "repl_old_len");
-    llvm::Value *newLen = builder_.CreateCall(strlenFn, {newStr}, "repl_new_len");
+    llvm::Value *sLen = emitStringByteLen(s);
+    llvm::Value *oldLen = emitStringByteLen(oldStr);
+    llvm::Value *newLen = emitStringByteLen(newStr);
+
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
 
     // Guard against empty pattern (#802): strstr("...", "") returns its first
     // argument without advancing, which would cause the count/build loops below
@@ -331,9 +333,8 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
     builder_.CreateCondBr(oldIsEmpty, replEmptyBB, replMainBB);
 
     builder_.SetInsertPoint(replEmptyBB);
-    llvm::Value *replEmptySize = builder_.CreateAdd(sLen, llvm::ConstantInt::get(i64Ty_, 1), "repl_empty_buf_size");
-    llvm::Value *replEmptyBuf = builder_.CreateCall(mallocFn, {replEmptySize}, "repl_empty_buf");
-    builder_.CreateCall(memcpyFn, {replEmptyBuf, s, replEmptySize});
+    llvm::Value *replEmptyBuf = builder_.CreateCall(makeUninitFn, {sLen}, "repl_empty_buf");
+    builder_.CreateCall(memcpyFn, {replEmptyBuf, s, sLen});
     builder_.CreateBr(replEndBB);
 
     builder_.SetInsertPoint(replMainBB);
@@ -366,12 +367,11 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
     builder_.SetInsertPoint(countEndBB);
     llvm::Value *count = builder_.CreateLoad(i64Ty_, countVar, "final_count");
 
-    // Calculate new length: sLen + count * (newLen - oldLen) + 1
+    // Calculate new length: sLen + count * (newLen - oldLen)
     llvm::Value *diff = builder_.CreateSub(newLen, oldLen, "len_diff");
     llvm::Value *totalDiff = builder_.CreateMul(count, diff, "total_diff");
     llvm::Value *resultLen = builder_.CreateAdd(sLen, totalDiff, "result_len");
-    llvm::Value *bufSize = builder_.CreateAdd(resultLen, llvm::ConstantInt::get(i64Ty_, 1), "buf_size");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "repl_buf");
+    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {resultLen}, "repl_buf");
 
     // Pass 2: build result
     llvm::AllocaInst *srcVar = builder_.CreateAlloca(ptrTy_, nullptr, "repl_src");
@@ -408,8 +408,7 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
     llvm::Value *finalSrc = builder_.CreateLoad(ptrTy_, srcVar, "final_src");
     llvm::Value *finalDst = builder_.CreateLoad(ptrTy_, dstVar, "final_dst");
     llvm::Value *remainLen = builder_.CreateCall(strlenFn, {finalSrc}, "remain_len");
-    llvm::Value *remainPlusNull = builder_.CreateAdd(remainLen, llvm::ConstantInt::get(i64Ty_, 1), "remain_plus_null");
-    builder_.CreateCall(memcpyFn, {finalDst, finalSrc, remainPlusNull});
+    builder_.CreateCall(memcpyFn, {finalDst, finalSrc, remainLen});
     builder_.CreateBr(replEndBB);
 
     // Merge empty-pattern path and main path
@@ -426,12 +425,11 @@ llvm::Value *CodeGen::emitStrOp_to_upper(const CallExpr &e) {
     llvm::Value *s = emitExpr(*e.args[0]);
     if (s->getType() != ptrTy_)
         codegenError("to_upper() requires str argument");
-    auto strlenFn = getStdlibStrlen();
-    auto mallocFn = getStdlibMalloc();
 
-    llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "upper_len");
-    llvm::Value *bufSize = builder_.CreateAdd(len, llvm::ConstantInt::get(i64Ty_, 1), "upper_buf_size");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "upper_buf");
+    llvm::Value *len = emitStringByteLen(s);
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
+    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {len}, "upper_buf");
 
     llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "upper_i");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
@@ -460,8 +458,6 @@ llvm::Value *CodeGen::emitStrOp_to_upper(const CallExpr &e) {
     builder_.CreateBr(condBB);
 
     builder_.SetInsertPoint(endBB);
-    llvm::Value *nullPtr = builder_.CreateGEP(builder_.getInt8Ty(), buf, len, "upper_null");
-    builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), nullPtr);
     return buf;
 }
 
@@ -471,12 +467,11 @@ llvm::Value *CodeGen::emitStrOp_to_lower(const CallExpr &e) {
     llvm::Value *s = emitExpr(*e.args[0]);
     if (s->getType() != ptrTy_)
         codegenError("to_lower() requires str argument");
-    auto strlenFn = getStdlibStrlen();
-    auto mallocFn = getStdlibMalloc();
 
-    llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "lower_len");
-    llvm::Value *bufSize = builder_.CreateAdd(len, llvm::ConstantInt::get(i64Ty_, 1), "lower_buf_size");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "lower_buf");
+    llvm::Value *len = emitStringByteLen(s);
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
+    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {len}, "lower_buf");
 
     llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "lower_i");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
@@ -505,8 +500,6 @@ llvm::Value *CodeGen::emitStrOp_to_lower(const CallExpr &e) {
     builder_.CreateBr(condBB);
 
     builder_.SetInsertPoint(endBB);
-    llvm::Value *nullPtr = builder_.CreateGEP(builder_.getInt8Ty(), buf, len, "lower_null");
-    builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), nullPtr);
     return buf;
 }
 
@@ -516,11 +509,9 @@ llvm::Value *CodeGen::emitStrOp_trim(const CallExpr &e) {
     llvm::Value *s = emitExpr(*e.args[0]);
     if (s->getType() != ptrTy_)
         codegenError("trim() requires str argument");
-    auto strlenFn = getStdlibStrlen();
-    auto mallocFn = getStdlibMalloc();
     auto memcpyFn = getStdlibMemcpy();
 
-    llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "trim_len");
+    llvm::Value *len = emitStringByteLen(s);
 
     llvm::AllocaInst *startVar = builder_.CreateAlloca(i64Ty_, nullptr, "trim_start");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), startVar);
@@ -584,12 +575,11 @@ llvm::Value *CodeGen::emitStrOp_trim(const CallExpr &e) {
     llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
     llvm::Value *isNeg = builder_.CreateICmpSLT(resultLen, zero, "trim_neg");
     llvm::Value *safeLen = builder_.CreateSelect(isNeg, zero, resultLen, "trim_safe_len");
-    llvm::Value *bufSize = builder_.CreateAdd(safeLen, llvm::ConstantInt::get(i64Ty_, 1), "trim_buf_size");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "trim_buf");
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
+    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {safeLen}, "trim_buf");
     llvm::Value *srcPtr = builder_.CreateGEP(builder_.getInt8Ty(), s, finalStart, "trim_src");
     builder_.CreateCall(memcpyFn, {buf, srcPtr, safeLen});
-    llvm::Value *nullEnd = builder_.CreateGEP(builder_.getInt8Ty(), buf, safeLen, "trim_null");
-    builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), nullEnd);
     return buf;
 }
 
@@ -599,11 +589,9 @@ llvm::Value *CodeGen::emitStrOp_trim_start(const CallExpr &e) {
     llvm::Value *s = emitExpr(*e.args[0]);
     if (s->getType() != ptrTy_)
         codegenError("trim_start() requires str argument");
-    auto strlenFn = getStdlibStrlen();
-    auto mallocFn = getStdlibMalloc();
     auto memcpyFn = getStdlibMemcpy();
 
-    llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "tstart_len");
+    llvm::Value *len = emitStringByteLen(s);
 
     llvm::AllocaInst *startVar = builder_.CreateAlloca(i64Ty_, nullptr, "tstart_start");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), startVar);
@@ -631,12 +619,11 @@ llvm::Value *CodeGen::emitStrOp_trim_start(const CallExpr &e) {
     builder_.SetInsertPoint(endBB);
     llvm::Value *finalStart = builder_.CreateLoad(i64Ty_, startVar, "tstart_final");
     llvm::Value *resultLen = builder_.CreateSub(len, finalStart, "tstart_rlen");
-    llvm::Value *bufSize = builder_.CreateAdd(resultLen, llvm::ConstantInt::get(i64Ty_, 1), "tstart_bsize");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "tstart_buf");
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
+    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {resultLen}, "tstart_buf");
     llvm::Value *srcPtr = builder_.CreateGEP(builder_.getInt8Ty(), s, finalStart, "tstart_src");
     builder_.CreateCall(memcpyFn, {buf, srcPtr, resultLen});
-    llvm::Value *nullEnd = builder_.CreateGEP(builder_.getInt8Ty(), buf, resultLen, "tstart_null");
-    builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), nullEnd);
     return buf;
 }
 
@@ -646,11 +633,9 @@ llvm::Value *CodeGen::emitStrOp_trim_end(const CallExpr &e) {
     llvm::Value *s = emitExpr(*e.args[0]);
     if (s->getType() != ptrTy_)
         codegenError("trim_end() requires str argument");
-    auto strlenFn = getStdlibStrlen();
-    auto mallocFn = getStdlibMalloc();
     auto memcpyFn = getStdlibMemcpy();
 
-    llvm::Value *len = builder_.CreateCall(strlenFn, {s}, "tend_len");
+    llvm::Value *len = emitStringByteLen(s);
 
     llvm::AllocaInst *endVar = builder_.CreateAlloca(i64Ty_, nullptr, "tend_end");
     builder_.CreateStore(len, endVar);
@@ -679,11 +664,10 @@ llvm::Value *CodeGen::emitStrOp_trim_end(const CallExpr &e) {
 
     builder_.SetInsertPoint(endBB);
     llvm::Value *finalEnd = builder_.CreateLoad(i64Ty_, endVar, "tend_final");
-    llvm::Value *bufSize = builder_.CreateAdd(finalEnd, llvm::ConstantInt::get(i64Ty_, 1), "tend_bsize");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "tend_buf");
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
+    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {finalEnd}, "tend_buf");
     builder_.CreateCall(memcpyFn, {buf, s, finalEnd});
-    llvm::Value *nullEnd2 = builder_.CreateGEP(builder_.getInt8Ty(), buf, finalEnd, "tend_null");
-    builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), nullEnd2);
     return buf;
 }
 
@@ -822,7 +806,9 @@ llvm::Value *CodeGen::emitStrOp_split(const CallExpr &e) {
 
     // Empty delimiter: split into individual characters (UTF-8 aware)
     auto strlenFn = getStdlibStrlen();
-    llvm::Value *delimLen = builder_.CreateCall(strlenFn, {delim}, "split_dlen");
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
+    llvm::Value *delimLen = emitStringByteLen(delim);
     llvm::Value *isEmptyDelim = builder_.CreateICmpEQ(
         delimLen, llvm::ConstantInt::get(i64Ty_, 0), "split_empty_delim");
 
@@ -897,11 +883,8 @@ llvm::Value *CodeGen::emitStrOp_split(const CallExpr &e) {
     llvm::Value *curSrcInt = builder_.CreatePtrToInt(curSrc, i64Ty_, "split_src_int");
     llvm::Value *foundInt = builder_.CreatePtrToInt(foundBuild, i64Ty_, "split_found_int");
     llvm::Value *segLen = builder_.CreateSub(foundInt, curSrcInt, "split_seg_len");
-    llvm::Value *segBufSize = builder_.CreateAdd(segLen, llvm::ConstantInt::get(i64Ty_, 1), "split_seg_bsize");
-    llvm::Value *segBuf = builder_.CreateCall(mallocFn, {segBufSize}, "split_seg_buf");
+    llvm::Value *segBuf = builder_.CreateCall(makeUninitFn, {segLen}, "split_seg_buf");
     builder_.CreateCall(memcpyFn, {segBuf, curSrc, segLen});
-    llvm::Value *segNull = builder_.CreateGEP(builder_.getInt8Ty(), segBuf, segLen, "split_seg_null");
-    builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), segNull);
     llvm::Value *curIdx = builder_.CreateLoad(i64Ty_, idxVar, "split_cur_idx");
     llvm::Value *elemPtr = builder_.CreateGEP(ptrTy_, dataPtr, {curIdx}, "split_elem_ptr");
     builder_.CreateStore(segBuf, elemPtr);
@@ -912,11 +895,8 @@ llvm::Value *CodeGen::emitStrOp_split(const CallExpr &e) {
     builder_.SetInsertPoint(buildEndBB);
     llvm::Value *lastSrc = builder_.CreateLoad(ptrTy_, srcVar, "split_last_src");
     llvm::Value *lastLen = builder_.CreateCall(strlenFn, {lastSrc}, "split_last_len");
-    llvm::Value *lastBufSize = builder_.CreateAdd(lastLen, llvm::ConstantInt::get(i64Ty_, 1), "split_last_bsize");
-    llvm::Value *lastBuf = builder_.CreateCall(mallocFn, {lastBufSize}, "split_last_buf");
+    llvm::Value *lastBuf = builder_.CreateCall(makeUninitFn, {lastLen}, "split_last_buf");
     builder_.CreateCall(memcpyFn, {lastBuf, lastSrc, lastLen});
-    llvm::Value *lastNull = builder_.CreateGEP(builder_.getInt8Ty(), lastBuf, lastLen, "split_last_null");
-    builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), lastNull);
     llvm::Value *lastIdx = builder_.CreateLoad(i64Ty_, idxVar, "split_last_idx");
     llvm::Value *lastElemPtr = builder_.CreateGEP(ptrTy_, dataPtr, {lastIdx}, "split_last_elem_ptr");
     builder_.CreateStore(lastBuf, lastElemPtr);
@@ -958,14 +938,14 @@ llvm::Value *CodeGen::emitStrOp_join(const CallExpr &e) {
     }
     if (elemTy != ptrTy_)
         codegenError("join() requires List<str> as first argument");
-    auto strlenFn = getStdlibStrlen();
-    auto mallocFn = getStdlibMalloc();
     auto memcpyFn = getStdlibMemcpy();
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
 
     auto lf = loadListHeader(listPtr, "join");
     llvm::Value *listLen = lf.len;
     llvm::Value *listData = lf.data;
-    llvm::Value *sepLen = builder_.CreateCall(strlenFn, {sep}, "join_sep_len");
+    llvm::Value *sepLen = emitStringByteLen(sep);
 
     llvm::AllocaInst *totalVar = builder_.CreateAlloca(i64Ty_, nullptr, "join_total");
     builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), totalVar);
@@ -985,7 +965,7 @@ llvm::Value *CodeGen::emitStrOp_join(const CallExpr &e) {
     llvm::Value *i1Cur = builder_.CreateLoad(i64Ty_, iVar, "join_i1_cur");
     llvm::Value *elemPtr = builder_.CreateGEP(ptrTy_, listData, {i1Cur}, "join_elem_ptr");
     llvm::Value *elem = builder_.CreateLoad(ptrTy_, elemPtr, "join_elem");
-    llvm::Value *elemLen = builder_.CreateCall(strlenFn, {elem}, "join_elem_len");
+    llvm::Value *elemLen = emitStringByteLen(elem);
     llvm::Value *total = builder_.CreateLoad(i64Ty_, totalVar, "join_total_cur");
     llvm::Value *newTotal = builder_.CreateAdd(total, elemLen, "join_total_add");
     builder_.CreateStore(newTotal, totalVar);
@@ -999,8 +979,7 @@ llvm::Value *CodeGen::emitStrOp_join(const CallExpr &e) {
     llvm::Value *safeSepCount = builder_.CreateSelect(isPositive, sepCount, llvm::ConstantInt::get(i64Ty_, 0), "safe_sep_count");
     llvm::Value *sepTotal = builder_.CreateMul(safeSepCount, sepLen, "join_sep_total");
     llvm::Value *grandTotal = builder_.CreateAdd(elemTotal, sepTotal, "join_grand_total");
-    llvm::Value *bufSize = builder_.CreateAdd(grandTotal, llvm::ConstantInt::get(i64Ty_, 1), "join_bsize");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "join_buf");
+    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {grandTotal}, "join_buf");
 
     llvm::AllocaInst *dstVar = builder_.CreateAlloca(ptrTy_, nullptr, "join_dst");
     builder_.CreateStore(buf, dstVar);
@@ -1034,7 +1013,7 @@ llvm::Value *CodeGen::emitStrOp_join(const CallExpr &e) {
     llvm::Value *dstForElem = builder_.CreateLoad(ptrTy_, dstVar, "dst_for_elem");
     llvm::Value *elemPtr2 = builder_.CreateGEP(ptrTy_, listData, {i2Cur}, "join_elem_ptr2");
     llvm::Value *elem2 = builder_.CreateLoad(ptrTy_, elemPtr2, "join_elem2");
-    llvm::Value *elem2Len = builder_.CreateCall(strlenFn, {elem2}, "join_elem2_len");
+    llvm::Value *elem2Len = emitStringByteLen(elem2);
     builder_.CreateCall(memcpyFn, {dstForElem, elem2, elem2Len});
     llvm::Value *dstAfterElem = builder_.CreateGEP(builder_.getInt8Ty(), dstForElem, elem2Len, "dst_after_elem");
     builder_.CreateStore(dstAfterElem, dstVar);
@@ -1042,8 +1021,6 @@ llvm::Value *CodeGen::emitStrOp_join(const CallExpr &e) {
     builder_.CreateBr(buildCondBB);
 
     builder_.SetInsertPoint(buildEndBB);
-    llvm::Value *finalDst = builder_.CreateLoad(ptrTy_, dstVar, "join_final_dst");
-    builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), finalDst);
     return buf;
 }
 

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -539,6 +539,11 @@ llvm::FunctionCallee CodeGen::getStdlibMemset() {
     return mod_->getOrInsertFunction("memset", ty);
 }
 
+llvm::FunctionCallee CodeGen::getStdlibMemcmp() {
+    auto ty = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_, i64Ty_}, false);
+    return mod_->getOrInsertFunction("memcmp", ty);
+}
+
 llvm::FunctionCallee CodeGen::getStdlibStrcmp() {
     auto ty = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, false);
     return mod_->getOrInsertFunction("strcmp", ty);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1235,6 +1235,19 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
         llvm::Value *lenL = emitStringByteLen(lhs);
         llvm::Value *lenR = emitStringByteLen(rhs);
         llvm::Value *total = builder_.CreateAdd(lenL, lenR, "concat_len");
+
+        // Overflow guard: if lenL + lenR wraps (total < lenL for non-negative inputs),
+        // abort before underallocating the buffer.
+        llvm::Value *catOverflow = builder_.CreateICmpSLT(total, lenL, "cat_ovf");
+        llvm::BasicBlock *catErrBB   = llvm::BasicBlock::Create(*ctx_, "str_cat.ovf_err",  fn_);
+        llvm::BasicBlock *catAllocBB = llvm::BasicBlock::Create(*ctx_, "str_cat.alloc",    fn_);
+        builder_.CreateCondBr(catOverflow, catErrBB, catAllocBB);
+
+        builder_.SetInsertPoint(catErrBB);
+        emitRuntimeError("runtime error: str + str overflows\n", ".str_cat_overflow");
+        // emitRuntimeError ends with CreateUnreachable(); no fall-through.
+
+        builder_.SetInsertPoint(catAllocBB);
         auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
         auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
         llvm::Value *buf = builder_.CreateCall(makeUninitFn, {total}, "concat_buf");

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -999,10 +999,13 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
     bool lhsIsStr = isStringValue(lhs);
     bool rhsIsStr = isStringValue(rhs);
 
-    // String comparison via strcmp
+    // String comparison — NUL-safe via __ry_str_cmp (byte_len + memcmp)
     if (lhsIsStr && rhsIsStr) {
-        auto strcmpFn = getStdlibStrcmp();
-        llvm::Value *cmp = builder_.CreateCall(strcmpFn, {lhs, rhs}, "strcmp");
+        llvm::Value *lenL = emitStringByteLen(lhs);
+        llvm::Value *lenR = emitStringByteLen(rhs);
+        auto strCmpTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, i64Ty_, ptrTy_, i64Ty_}, false);
+        auto strCmpFn = mod_->getOrInsertFunction("__ry_str_cmp", strCmpTy);
+        llvm::Value *cmp = builder_.CreateCall(strCmpFn, {lhs, lenL, rhs, lenR}, "str_cmp");
         llvm::Value *zero = llvm::ConstantInt::get(i32Ty_, 0);
         if (op == "==") return builder_.CreateICmpEQ(cmp, zero, "str_eq");
         if (op == "!=") return builder_.CreateICmpNE(cmp, zero, "str_ne");
@@ -1214,20 +1217,17 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
         lhsIsStr = true;
     }
 
-    // String concatenation
+    // String concatenation — NUL-safe via StringHeader (byte_len + makeStringUninit + memcpy)
     if (op == "+" && lhsIsStr && rhsIsStr) {
-        auto strlenFn = getStdlibStrlen();
-        auto mallocFn = getStdlibMalloc();
-        auto strcpyFn = getStdlibStrcpy();
-        auto strcatFn = getStdlibStrcat();
-
-        llvm::Value *lenL = builder_.CreateCall(strlenFn, {lhs}, "len_l");
-        llvm::Value *lenR = builder_.CreateCall(strlenFn, {rhs}, "len_r");
-        llvm::Value *total = builder_.CreateAdd(lenL, lenR, "total_len");
-        total = builder_.CreateAdd(total, llvm::ConstantInt::get(i64Ty_, 1), "total_plus_null");
-        llvm::Value *buf = builder_.CreateCall(mallocFn, {total}, "concat_buf");
-        builder_.CreateCall(strcpyFn, {buf, lhs});
-        builder_.CreateCall(strcatFn, {buf, rhs});
+        llvm::Value *lenL = emitStringByteLen(lhs);
+        llvm::Value *lenR = emitStringByteLen(rhs);
+        llvm::Value *total = builder_.CreateAdd(lenL, lenR, "concat_len");
+        auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+        auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
+        llvm::Value *buf = builder_.CreateCall(makeUninitFn, {total}, "concat_buf");
+        builder_.CreateCall(getStdlibMemcpy(), {buf, lhs, lenL});
+        llvm::Value *dst = builder_.CreateGEP(i8Ty_, buf, lenL, "concat_dst");
+        builder_.CreateCall(getStdlibMemcpy(), {dst, rhs, lenR});
         return buf;
     }
 
@@ -1902,7 +1902,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<WeakExpr> &e) {
     llvm::Value *val = emitExpr(*e->operand);
     if (val->getType() != ptrTy_)
         codegenError("weak can only be applied to ARC-managed reference values (str, List, Map, Set)");
-    return emitArcGetHeaderFromData(val);
+    // Return the raw data pointer. The caller (codegen_stmt.cpp) has the inner
+    // type name from the annotation and performs the correct header offset:
+    // STRING_HEADER_SIZE (24) for str, ARC_HEADER_SIZE (16) for collections.
+    // We cannot use isStringValue() here because captured List/Map/Set values
+    // may lack collection metadata, causing false positives.
+    return val;
 }
 
 llvm::Value *CodeGen::emitListConcat(llvm::Value *lhs, llvm::Value *rhs, llvm::Type *elemTy) {

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -305,12 +305,13 @@ llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
 
     // Repeat case: guard against strLen * n overflowing int64, then allocate.
     builder_.SetInsertPoint(repeatBB);
-    // Overflow is only possible when strLen > 0 (empty string * n is always 0).
+    // When strLen == 0, "" * n == "" regardless of n — short-circuit to emptyBB (O(1)).
+    // Overflow is only possible when strLen > 0.
     llvm::Value *strLenPos = builder_.CreateICmpSGT(
         strLen, llvm::ConstantInt::get(i64Ty_, 0), "slen_pos");
     llvm::BasicBlock *ovfCheckBB = llvm::BasicBlock::Create(*ctx_, "str_rep.ovf_check", fn_);
     llvm::BasicBlock *allocBB    = llvm::BasicBlock::Create(*ctx_, "str_rep.alloc",     fn_);
-    builder_.CreateCondBr(strLenPos, ovfCheckBB, allocBB);
+    builder_.CreateCondBr(strLenPos, ovfCheckBB, emptyBB);
 
     builder_.SetInsertPoint(ovfCheckBB);
     llvm::Value *maxN = builder_.CreateSDiv(

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -303,8 +303,28 @@ llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
     llvm::Value *emptyStr = cachedGlobalString("", ".empty_str");
     builder_.CreateBr(mergeBB);
 
-    // Repeat case: allocate StringHeader with totalLen = strLen * n
+    // Repeat case: guard against strLen * n overflowing int64, then allocate.
     builder_.SetInsertPoint(repeatBB);
+    // Overflow is only possible when strLen > 0 (empty string * n is always 0).
+    llvm::Value *strLenPos = builder_.CreateICmpSGT(
+        strLen, llvm::ConstantInt::get(i64Ty_, 0), "slen_pos");
+    llvm::BasicBlock *ovfCheckBB = llvm::BasicBlock::Create(*ctx_, "str_rep.ovf_check", fn_);
+    llvm::BasicBlock *allocBB    = llvm::BasicBlock::Create(*ctx_, "str_rep.alloc",     fn_);
+    builder_.CreateCondBr(strLenPos, ovfCheckBB, allocBB);
+
+    builder_.SetInsertPoint(ovfCheckBB);
+    llvm::Value *maxN = builder_.CreateSDiv(
+        llvm::ConstantInt::get(i64Ty_, INT64_MAX), strLen, "max_n");
+    llvm::Value *wouldOverflow = builder_.CreateICmpSGT(n, maxN, "would_overflow");
+    llvm::BasicBlock *ovfErrBB = llvm::BasicBlock::Create(*ctx_, "str_rep.ovf_err", fn_);
+    builder_.CreateCondBr(wouldOverflow, ovfErrBB, allocBB);
+
+    builder_.SetInsertPoint(ovfErrBB);
+    emitRuntimeError("runtime error: str * count overflows\n", ".str_rep_overflow");
+    // emitRuntimeError ends with CreateUnreachable(); no fall-through.
+
+    // Alloc case: compute totalLen = strLen * n (overflow-free), then allocate.
+    builder_.SetInsertPoint(allocBB);
     llvm::Value *totalLen = builder_.CreateMul(strLen, n, "total_len");
     llvm::Value *buf = builder_.CreateCall(makeUninitFn, {totalLen}, "rep_buf");
 
@@ -316,7 +336,7 @@ llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
     builder_.SetInsertPoint(loopBB);
 
     llvm::PHINode *i = builder_.CreatePHI(i64Ty_, 2, "i");
-    i->addIncoming(llvm::ConstantInt::get(i64Ty_, 0), repeatBB);
+    i->addIncoming(llvm::ConstantInt::get(i64Ty_, 0), allocBB);
 
     llvm::Value *offset = builder_.CreateMul(i, strLen, "offset");
     llvm::Value *dst = builder_.CreateGEP(builder_.getInt8Ty(), buf, {offset}, "dst");

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -189,56 +189,23 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
 }
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<InterpolatedStringExpr> &e) {
-    // Convert each expression to string
-    std::vector<llvm::Value*> strParts;
-    strParts.reserve(e->parts.size() + e->exprs.size());
+    // Build (str_ptr, byte_len) pairs for each non-empty segment.  All parts
+    // must be StringHeader-managed handles so emitStringByteLen works correctly.
+    std::vector<std::pair<llvm::Value *, llvm::Value *>> parts;
+    parts.reserve(e->parts.size() + e->exprs.size());
     for (size_t i = 0; i < e->parts.size(); ++i) {
-        if (!e->parts[i].empty())
-            strParts.push_back(cachedGlobalString(e->parts[i], ".fstr_lit"));
-        else
-            strParts.push_back(nullptr); // empty literal segment
+        if (!e->parts[i].empty()) {
+            llvm::Value *litPtr = cachedGlobalString(e->parts[i], ".fstr_lit");
+            llvm::Value *litLen = emitStringByteLen(litPtr);
+            parts.emplace_back(litPtr, litLen);
+        }
         if (i < e->exprs.size()) {
-            llvm::Value *exprVal = emitExpr(*e->exprs[i]);
-            strParts.push_back(valueToString(exprVal));
+            llvm::Value *exprStr = valueToString(emitExpr(*e->exprs[i]));
+            llvm::Value *exprLen = emitStringByteLen(exprStr);
+            parts.emplace_back(exprStr, exprLen);
         }
     }
-
-    // Compute total length
-    auto strlenFn = getStdlibStrlen();
-    auto memcpyFn = getStdlibMemcpy();
-
-    llvm::Value *totalLen = llvm::ConstantInt::get(i64Ty_, 0);
-    std::vector<llvm::Value*> lengths;
-    for (auto *sp : strParts) {
-        if (sp) {
-            llvm::Value *len = builder_.CreateCall(strlenFn, {sp}, "fstr_len");
-            lengths.push_back(len);
-            totalLen = builder_.CreateAdd(totalLen, len, "fstr_total");
-        } else {
-            lengths.push_back(llvm::ConstantInt::get(i64Ty_, 0));
-        }
-    }
-
-    // Allocate result buffer with ARC header
-    llvm::Value *bufSize = builder_.CreateAdd(totalLen, llvm::ConstantInt::get(i64Ty_, 1), "fstr_bufsize");
-    auto *arcHdr = emitArcAlloc(bufSize);
-    llvm::Value *buf = emitArcGetDataPtr(arcHdr);
-
-    // Copy segments
-    llvm::Value *offset = llvm::ConstantInt::get(i64Ty_, 0);
-    for (size_t i = 0; i < strParts.size(); ++i) {
-        if (strParts[i]) {
-            llvm::Value *dst = builder_.CreateGEP(builder_.getInt8Ty(), buf, {offset}, "fstr_dst");
-            builder_.CreateCall(memcpyFn, {dst, strParts[i], lengths[i]});
-            offset = builder_.CreateAdd(offset, lengths[i], "fstr_off");
-        }
-    }
-
-    // Null-terminate
-    llvm::Value *endPtr = builder_.CreateGEP(builder_.getInt8Ty(), buf, {offset}, "fstr_end");
-    builder_.CreateStore(llvm::ConstantInt::get(builder_.getInt8Ty(), 0), endPtr);
-
-    return buf;
+    return concatStringParts(parts, "fstr");
 }
 
 // ===== TypeAliasStmt =====
@@ -313,15 +280,16 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<RangeExpr> &e) {
 }
 
 // Common helper: emit IR for string repetition.
-// strVal must be ptr (i8*), n must be i64.
+// strVal must be a StringHeader handle (ptr), n must be i64.
 llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
-    auto strlenFn = getStdlibStrlen();
-    auto mallocFn = getStdlibMalloc();
     auto memcpyFn = getStdlibMemcpy();
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
 
-    llvm::Value *strLen = builder_.CreateCall(strlenFn, {strVal}, "str_len");
+    // NUL-safe: read byte_len from StringHeader
+    llvm::Value *strLen = emitStringByteLen(strVal);
 
-    // If n <= 0, return empty string
+    // If n <= 0, return empty string (a StringHeader global)
     llvm::Value *nPos = builder_.CreateICmpSGT(n, llvm::ConstantInt::get(i64Ty_, 0), "n_pos");
 
     llvm::BasicBlock *emptyBB = llvm::BasicBlock::Create(*ctx_, "str_rep.empty", fn_);
@@ -330,16 +298,15 @@ llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
 
     builder_.CreateCondBr(nPos, repeatBB, emptyBB);
 
-    // Empty case: return ""
+    // Empty case: return "" (StringHeader global via cachedGlobalString)
     builder_.SetInsertPoint(emptyBB);
     llvm::Value *emptyStr = cachedGlobalString("", ".empty_str");
     builder_.CreateBr(mergeBB);
 
-    // Repeat case
+    // Repeat case: allocate StringHeader with totalLen = strLen * n
     builder_.SetInsertPoint(repeatBB);
     llvm::Value *totalLen = builder_.CreateMul(strLen, n, "total_len");
-    llvm::Value *bufSize = builder_.CreateAdd(totalLen, llvm::ConstantInt::get(i64Ty_, 1), "buf_size");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, "rep_buf");
+    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {totalLen}, "rep_buf");
 
     // Loop: copy strVal into buf n times
     llvm::BasicBlock *loopBB = llvm::BasicBlock::Create(*ctx_, "str_rep.loop", fn_);
@@ -361,9 +328,7 @@ llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
     builder_.CreateCondBr(cond, loopBB, doneBB);
 
     builder_.SetInsertPoint(doneBB);
-    // Null-terminate
-    llvm::Value *endPtr = builder_.CreateGEP(builder_.getInt8Ty(), buf, {totalLen}, "end_ptr");
-    builder_.CreateStore(llvm::ConstantInt::get(builder_.getInt8Ty(), 0), endPtr);
+    // NUL at buf[totalLen] already written by __ry_string_make_uninit
     builder_.CreateBr(mergeBB);
 
     // Merge

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -646,9 +646,21 @@ void CodeGen::emitVarDecl(const std::string &name,
         if (annot && isWeakTypeName(*annot)) {
             if (!std::get_if<std::unique_ptr<WeakExpr>>(&value.data))
                 codegenError("weak-typed variable must be initialized with a 'weak' expression");
-            emitWeakRetain(val);
-            markWeakManaged(ptr);
             std::string innerName = weakInnerTypeName(*annot);
+            // str uses StringHeader (24 bytes before the data pointer) while
+            // other ARC types use ArcHeader (16 bytes). isStringValue() cannot
+            // be used here because captured List/Map/Set values may lack
+            // collection metadata and would be misclassified as str.
+            // Instead, use the inner type name from the annotation.
+            llvm::Value *headerPtr = (innerName == "str")
+                ? emitStrGetHeaderFromData(val)
+                : emitArcGetHeaderFromData(val);
+            // Override the store: we want the header pointer (not the data
+            // pointer) in the alloca so that VariableExpr loads the correct
+            // pointer to pass to emitWeakUpgrade / emitWeakRetain.
+            builder_.CreateStore(headerPtr, ptr);
+            emitWeakRetain(headerPtr);
+            markWeakManaged(ptr);
             weak_inner_type_names_[ptr] = innerName;
             // Set collection metadata on weak alloca so it propagates through upgrade
             propagateTypeMeta(innerName, ptr);
@@ -888,9 +900,18 @@ void CodeGen::emitStmt(AssignStmt &s) {
     else if (isWeakManaged(ptr)) {
         if (!std::get_if<std::unique_ptr<WeakExpr>>(&s.value->data))
             codegenError("weak variable must be reassigned with a 'weak' expression");
-        emitWeakRetain(val);
+        // val is the raw data pointer from emitExprVariant(WeakExpr).
+        // Convert to header pointer using the stored inner type name.
+        auto itWeak = weak_inner_type_names_.find(ptr);
+        const std::string &weakInner = (itWeak != weak_inner_type_names_.end())
+            ? itWeak->second : std::string{};
+        llvm::Value *headerPtr = (weakInner == "str")
+            ? emitStrGetHeaderFromData(val)
+            : emitArcGetHeaderFromData(val);
+        emitWeakRetain(headerPtr);
         auto *oldVal = builder_.CreateLoad(ptrTy_, ptr, s.name + ".weak_old");
         emitWeakRelease(oldVal);
+        val = headerPtr;
     }
     // ARC: retain new value before releasing old to avoid use-after-free on self-assignment
     else if (isArcManaged(ptr)) {

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -475,15 +475,19 @@ void CodeGen::emitPropertyItLoop(llvm::Function *testFunc, llvm::Value *descVal,
         builder_.CreateCall(printfFn, ceArgs);
     }
     for (unsigned i = 0; i < paramTypes.size(); ++i) {
-        if (paramTypes[i] == ptrTy_)
-            builder_.CreateCall(getStdlibFree(), {randVals[i]});
+        if (paramTypes[i] == ptrTy_) {
+            llvm::Value *hdr = emitStrGetHeaderFromData(randVals[i]);
+            builder_.CreateCall(getStdlibFree(), {hdr});
+        }
     }
     builder_.CreateBr(endBB);
 
     builder_.SetInsertPoint(contBB);
     for (unsigned i = 0; i < paramTypes.size(); ++i) {
-        if (paramTypes[i] == ptrTy_)
-            builder_.CreateCall(getStdlibFree(), {randVals[i]});
+        if (paramTypes[i] == ptrTy_) {
+            llvm::Value *hdr = emitStrGetHeaderFromData(randVals[i]);
+            builder_.CreateCall(getStdlibFree(), {hdr});
+        }
     }
     llvm::Value *nextI = builder_.CreateAdd(iVal, llvm::ConstantInt::get(i64Ty_, 1), "next_i");
     builder_.CreateStore(nextI, iAlloca);
@@ -958,9 +962,11 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         } else if (getListElementType(actualVal)) {
             len = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(listHeaderTy_, actualVal, 0), "list_len");
         } else {
-            auto utf8LenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
-            auto utf8LenFn = mod_->getOrInsertFunction("__ry_utf8_len", utf8LenTy);
-            len = builder_.CreateCall(utf8LenFn, {actualVal}, "str_len");
+            // NUL-safe string character count via __ry_utf8_len_n
+            llvm::Value *byteLen = emitStringByteLen(actualVal);
+            auto utf8LenTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, i64Ty_}, false);
+            auto utf8LenFn = mod_->getOrInsertFunction("__ry_utf8_len_n", utf8LenTy);
+            len = builder_.CreateCall(utf8LenFn, {actualVal, byteLen}, "str_len");
         }
 
         if (s.matcher == "to_have_length") {

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -550,8 +550,34 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
         }
         return val; // string pointer
     }
-    auto mallocFn = getStdlibMalloc();
     auto snprintfFn = getStdlibSnprintf();
+    // All numeric-to-string conversions produce StringHeader-managed strings so
+    // that emitStringByteLen() works correctly when the result is used in str
+    // operations (e.g. "prefix" + 42).  We allocate via __ry_string_make_uninit
+    // (which sets byte_len = capacity), then overwrite byte_len with the actual
+    // character count from snprintf's return value.
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
+    // snprintfStr: emit buf = makeUninit(32); nw = snprintf(buf, 32, fmt, ...);
+    //              byte_len(buf) = nw;  return buf.
+    auto snprintfStr = [&](llvm::Constant *fmt,
+                           llvm::ArrayRef<llvm::Value *> args) -> llvm::Value * {
+        llvm::Value *buf = builder_.CreateCall(
+            makeUninitFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");
+        llvm::SmallVector<llvm::Value *, 8> snArgs = {
+            buf, llvm::ConstantInt::get(i64Ty_, 32), fmt};
+        snArgs.append(args.begin(), args.end());
+        llvm::Value *nw = builder_.CreateCall(snprintfFn, snArgs, "vts_nw");
+        llvm::Value *actualLen = builder_.CreateSExt(nw, i64Ty_, "vts_len");
+        auto *bytelenPtr = builder_.CreateGEP(
+            i8Ty_, buf,
+            llvm::ConstantInt::get(
+                i64Ty_,
+                static_cast<uint64_t>(-static_cast<int64_t>(STRING_BYTELEN_OFFSET))),
+            "vts_bl_ptr");
+        builder_.CreateStore(actualLen, bytelenPtr);
+        return buf;
+    };
 
     if (ty == i1Ty_) {
         llvm::Constant *trueStr = cachedGlobalString("true", ".vts_true");
@@ -568,42 +594,33 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
     std::string llName = getLowLevelTypeName(val);
 
     if (ty == i8Ty_) {
-        llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");
         if (llName == "i8") {
             llvm::Constant *fmt = cachedGlobalString("%d", ".vts_i8_fmt");
             llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i8_ext");
-            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
-        } else {
-            // u8
-            llvm::Constant *fmt = cachedGlobalString("%u", ".vts_u8_fmt");
-            llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "u8_ext");
-            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
+            return snprintfStr(fmt, {ext});
         }
-        return buf;
+        // u8
+        llvm::Constant *fmt = cachedGlobalString("%u", ".vts_u8_fmt");
+        llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "u8_ext");
+        return snprintfStr(fmt, {ext});
     }
     if (ty == i16Ty_) {
-        llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");
         if (llName == "u16") {
             llvm::Constant *fmt = cachedGlobalString("%u", ".vts_u16_fmt");
             llvm::Value *ext = builder_.CreateZExt(val, i32Ty_, "u16_ext");
-            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
-        } else {
-            llvm::Constant *fmt = cachedGlobalString("%d", ".vts_i16_fmt");
-            llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i16_ext");
-            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, ext});
+            return snprintfStr(fmt, {ext});
         }
-        return buf;
+        llvm::Constant *fmt = cachedGlobalString("%d", ".vts_i16_fmt");
+        llvm::Value *ext = builder_.CreateSExt(val, i32Ty_, "i16_ext");
+        return snprintfStr(fmt, {ext});
     }
     if (ty == i32Ty_) {
-        llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");
         if (llName == "u32") {
             llvm::Constant *fmt = cachedGlobalString("%u", ".vts_u32_fmt");
-            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
-        } else {
-            llvm::Constant *fmt = cachedGlobalString("%d", ".vts_i32_fmt");
-            builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
+            return snprintfStr(fmt, {val});
         }
-        return buf;
+        llvm::Constant *fmt = cachedGlobalString("%d", ".vts_i32_fmt");
+        return snprintfStr(fmt, {val});
     }
     if (ty == f32Ty_) {
         // Promote to f64 and call the shared float formatter helper (#808).
@@ -612,15 +629,12 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
         return builder_.CreateCall(fmtFn, {ext}, "vts_f32_str");
     }
     // default: int (i64) or i64/u64
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {llvm::ConstantInt::get(i64Ty_, 32)}, "vts_buf");
     if (llName == "u64") {
         llvm::Constant *fmt = cachedGlobalString("%lu", ".vts_u64_fmt");
-        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
-    } else {
-        llvm::Constant *fmt = cachedGlobalString("%ld", ".vts_int_fmt");
-        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 32), fmt, val});
+        return snprintfStr(fmt, {val});
     }
-    return buf;
+    llvm::Constant *fmt = cachedGlobalString("%ld", ".vts_int_fmt");
+    return snprintfStr(fmt, {val});
 }
 
 llvm::Value *CodeGen::recordToString(llvm::Value *val) {
@@ -709,16 +723,18 @@ llvm::Value *CodeGen::emitSprintEnd(const llvm::Twine &name) {
 llvm::Value *CodeGen::concatStringParts(
     const std::vector<std::pair<llvm::Value*, llvm::Value*>> &parts,
     const std::string &prefix) {
-    auto mallocFn = getStdlibMalloc();
     auto memcpyFn = getStdlibMemcpy();
+    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
+    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
 
     llvm::Value *totalLen = llvm::ConstantInt::get(i64Ty_, 0);
     for (auto &p : parts)
         totalLen = builder_.CreateAdd(totalLen, p.second, prefix + "_total");
 
-    llvm::Value *bufSize = builder_.CreateAdd(
-        totalLen, llvm::ConstantInt::get(i64Ty_, 1), prefix + "_bufsize");
-    llvm::Value *buf = builder_.CreateCall(mallocFn, {bufSize}, prefix + "_buf");
+    // __ry_string_make_uninit allocates STRING_HEADER_SIZE + totalLen + 1 bytes,
+    // sets byte_len = totalLen and writes '\0' at buf[totalLen].  No explicit NUL
+    // write or +1 to bufSize needed.
+    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {totalLen}, prefix + "_buf");
     llvm::Value *off = llvm::ConstantInt::get(i64Ty_, 0);
     for (auto &p : parts) {
         llvm::Value *dst = builder_.CreateGEP(
@@ -726,10 +742,7 @@ llvm::Value *CodeGen::concatStringParts(
         builder_.CreateCall(memcpyFn, {dst, p.first, p.second});
         off = builder_.CreateAdd(off, p.second, prefix + "_off");
     }
-
-    llvm::Value *ep = builder_.CreateGEP(
-        builder_.getInt8Ty(), buf, {off}, prefix + "_end");
-    builder_.CreateStore(llvm::ConstantInt::get(builder_.getInt8Ty(), 0), ep);
+    // NUL at buf[totalLen] already written by __ry_string_make_uninit
     return buf;
 }
 

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -1,5 +1,5 @@
-#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_any.hpp"
+#include "ry/runtime_string.hpp"
 #include <cmath>
 #include <cstddef>
 #include <cstdio>
@@ -76,22 +76,20 @@ static bool hasNaN(const RyAny *a, const RyAny *b) {
 
 static void repeatStr(RyAny *result, const char *s, int64_t n) {
     if (n <= 0) {
-        char *buf = static_cast<char *>(checked_malloc(1));
-        buf[0] = '\0';
-        makeStr(result, buf);
+        makeStr(result, makeString("", 0));
         return;
     }
-    size_t len = strlen(s);
+    size_t len = static_cast<size_t>(stringByteLen(s));
     if (len > 0 && (static_cast<uint64_t>(n) > SIZE_MAX ||
                     static_cast<size_t>(n) > SIZE_MAX / len)) {
         fprintf(stderr, "runtime error: string repeat overflow\n");
         exit(1);
     }
     size_t count = static_cast<size_t>(n);
-    char *buf = static_cast<char *>(checked_malloc(len * count + 1));
+    char *buf = makeStringUninit(len * count);
     for (size_t i = 0; i < count; i++)
         memcpy(buf + i * len, s, len);
-    buf[len * count] = '\0';
+    // NUL at buf[len*count] already set by makeStringUninit
     makeStr(result, buf);
 }
 
@@ -102,12 +100,12 @@ static void repeatStr(RyAny *result, const char *s, int64_t n) {
 // Precision stays at %g (~6 digits) to match existing test expectations like
 // `to_str(3.14) == "3.14"`.
 extern "C" const char *__ry_any_fmt_float(double x) {
-    char *buf = static_cast<char *>(checked_malloc(64));
-    snprintf(buf, 64, "%g", x);
+    char tmp[64];
+    snprintf(tmp, sizeof(tmp), "%g", x);
     // Skip ".0" correction for NaN/Inf ("nan", "inf", "-nan", "-inf") and for
     // values already containing a decimal point or exponent.
     bool needsDotZero = true;
-    for (char *p = buf; *p; ++p) {
+    for (const char *p = tmp; *p; ++p) {
         if (*p == '.' || *p == 'e' || *p == 'E' ||
             *p == 'n' || *p == 'N' || *p == 'i' || *p == 'I') {
             needsDotZero = false;
@@ -115,31 +113,31 @@ extern "C" const char *__ry_any_fmt_float(double x) {
         }
     }
     if (needsDotZero) {
-        size_t len = strlen(buf);
-        if (len + 3 < 64) {
-            buf[len] = '.';
-            buf[len + 1] = '0';
-            buf[len + 2] = '\0';
+        size_t len = strlen(tmp);
+        if (len + 3 < sizeof(tmp)) {
+            tmp[len] = '.';
+            tmp[len + 1] = '0';
+            tmp[len + 2] = '\0';
         }
     }
-    return buf;
+    return makeString(tmp, strlen(tmp));
 }
 
 extern "C" const char *__ry_any_to_string(const RyAny *a) {
     switch (a->tag) {
     case static_cast<int64_t>(RyAnyTag::Int): {
-        char *buf = static_cast<char *>(checked_malloc(32));
-        snprintf(buf, 32, "%lld", (long long)extractInt(a));
-        return buf;
+        char tmp[32];
+        int n = snprintf(tmp, sizeof(tmp), "%lld", (long long)extractInt(a));
+        return makeString(tmp, static_cast<size_t>(n > 0 ? n : 0));
     }
     case static_cast<int64_t>(RyAnyTag::Float):
         return __ry_any_fmt_float(extractFloat(a));
     case static_cast<int64_t>(RyAnyTag::Bool):
-        return extractInt(a) ? "true" : "false";
+        return extractInt(a) ? makeString("true", 4) : makeString("false", 5);
     case static_cast<int64_t>(RyAnyTag::Str):
-        return extractStr(a);
+        return extractStr(a); // already a StringHeader handle — do NOT copy
     case static_cast<int64_t>(RyAnyTag::Unit):
-        return "Unit";
+        return makeString("Unit", 4);
     default:
         fprintf(stderr,
                 "runtime error: __ry_any_to_string: unsupported any tag %lld\n",
@@ -180,16 +178,19 @@ extern "C" void __ry_any_add(RyAny *result, const RyAny *a, const RyAny *b) {
             __ry_any_type_error("+", a->tag, b->tag);
         if (b->tag != static_cast<int64_t>(RyAnyTag::Str) && b->tag != static_cast<int64_t>(RyAnyTag::Int) && b->tag != static_cast<int64_t>(RyAnyTag::Float) && b->tag != static_cast<int64_t>(RyAnyTag::Bool))
             __ry_any_type_error("+", a->tag, b->tag);
-        bool a_alloc = (a->tag == static_cast<int64_t>(RyAnyTag::Int) || a->tag == static_cast<int64_t>(RyAnyTag::Float));
-        bool b_alloc = (b->tag == static_cast<int64_t>(RyAnyTag::Int) || b->tag == static_cast<int64_t>(RyAnyTag::Float));
+        // Non-Str tags allocate a new StringHeader via __ry_any_to_string;
+        // Str extracts the existing handle (must NOT be freed).
+        bool a_alloc = (a->tag != static_cast<int64_t>(RyAnyTag::Str));
+        bool b_alloc = (b->tag != static_cast<int64_t>(RyAnyTag::Str));
         const char *sa = __ry_any_to_string(a);
         const char *sb = __ry_any_to_string(b);
-        size_t la = strlen(sa), lb = strlen(sb);
-        char *buf = static_cast<char *>(checked_malloc(la + lb + 1));
-        memcpy(buf, sa, la); // NOLINT(bugprone-not-null-terminated-result) -- second memcpy copies lb+1 bytes including null terminator
-        memcpy(buf + la, sb, lb + 1);
-        if (a_alloc) free(const_cast<char *>(sa));
-        if (b_alloc) free(const_cast<char *>(sb));
+        size_t la = static_cast<size_t>(stringByteLen(sa));
+        size_t lb = static_cast<size_t>(stringByteLen(sb));
+        char *buf = makeStringUninit(la + lb);
+        memcpy(buf, sa, la); // NOLINT(bugprone-not-null-terminated-result) — NUL at buf[la+lb] set by makeStringUninit
+        memcpy(buf + la, sb, lb);
+        if (a_alloc) freeStringSlot(const_cast<char *>(sa));
+        if (b_alloc) freeStringSlot(const_cast<char *>(sb));
         makeStr(result, buf);
     } else {
         __ry_any_type_error("+", a->tag, b->tag);
@@ -324,7 +325,11 @@ extern "C" int64_t __ry_any_eq(const RyAny *a, const RyAny *b) {
         case static_cast<int64_t>(RyAnyTag::Int):   return extractInt(a) == extractInt(b) ? 1 : 0;
         case static_cast<int64_t>(RyAnyTag::Float): return extractFloat(a) == extractFloat(b) ? 1 : 0;
         case static_cast<int64_t>(RyAnyTag::Bool):  return extractInt(a) == extractInt(b) ? 1 : 0;
-        case static_cast<int64_t>(RyAnyTag::Str):   return strcmp(extractStr(a), extractStr(b)) == 0 ? 1 : 0;
+        case static_cast<int64_t>(RyAnyTag::Str): {
+            const char *sa = extractStr(a); const char *sb = extractStr(b);
+            int64_t la = stringByteLen(sa), lb = stringByteLen(sb);
+            return (la == lb && memcmp(sa, sb, static_cast<size_t>(la)) == 0) ? 1 : 0;
+        }
         case static_cast<int64_t>(RyAnyTag::Unit):  return 1;
         default:        return 0;
         }
@@ -356,7 +361,12 @@ static int64_t orderCompare(const char *op, const RyAny *a, const RyAny *b) {
         return (av > bv) - (av < bv);
     }
     if (a->tag == static_cast<int64_t>(RyAnyTag::Str) && b->tag == static_cast<int64_t>(RyAnyTag::Str)) {
-        return strcmp(extractStr(a), extractStr(b));
+        const char *sa = extractStr(a); const char *sb = extractStr(b);
+        int64_t la = stringByteLen(sa), lb = stringByteLen(sb);
+        int64_t minLen = la < lb ? la : lb;
+        int r = memcmp(sa, sb, static_cast<size_t>(minLen));
+        if (r != 0) return r > 0 ? 1 : -1;
+        return (la > lb) ? 1 : (la < lb) ? -1 : 0;
     }
     __ry_any_type_error(op, a->tag, b->tag);
     return 0; // unreachable

--- a/src/runtime_base64.cpp
+++ b/src/runtime_base64.cpp
@@ -1,5 +1,6 @@
 #include "ry/runtime_alloc.hpp"
 #include "ry/runtime_error.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <cstdint>
 #include <cstdlib>
@@ -46,7 +47,7 @@ static char *base64_encode_impl(const char *input, size_t len, const char *table
         if (rem == 1) out_len += 2;
         else if (rem == 2) out_len += 3;
     }
-    char *out = (char *)checked_malloc(out_len + 1);
+    char *out = makeStringUninit(out_len);
 
     size_t j = 0;
     for (size_t i = 0; i < len; i += 3) {
@@ -66,7 +67,7 @@ static char *base64_encode_impl(const char *input, size_t len, const char *table
         else if (pad)
             out[j++] = '=';
     }
-    out[j] = '\0';
+    // NUL at out[out_len] already written by makeStringUninit
     return out;
 }
 
@@ -76,6 +77,7 @@ static char *base64_decode_impl(const char *input, size_t len, const int8_t *dec
         len--;
 
     size_t out_cap = len * 3 / 4;
+    // Use a plain temp buffer; wrap with makeString at the end.
     char *out = (char *)checked_malloc(out_cap + 1);
     size_t j = 0;
 
@@ -102,15 +104,16 @@ static char *base64_decode_impl(const char *input, size_t len, const int8_t *dec
         if (count >= 3) out[j++] = (char)((triple >> 8) & 0xFF);
         if (count >= 4) out[j++] = (char)(triple & 0xFF);
     }
-    out[j] = '\0';
-    return out;
+    char *result = makeString(out, j);
+    free(out);
+    return result;
 }
 
 // Null/empty input guard shared by all public functions
 static const char *empty_guard(const char *input, size_t *len) {
-    if (!input) return checked_strdup("");
+    if (!input) return makeString("", 0);
     *len = strlen(input);
-    if (*len == 0) return checked_strdup("");
+    if (*len == 0) return makeString("", 0);
     return nullptr;
 }
 

--- a/src/runtime_error.cpp
+++ b/src/runtime_error.cpp
@@ -5,6 +5,7 @@
 // -rdynamic (Linux).
 
 #include "ry/runtime_alloc.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <cstdio>
 #include <cstdlib>
@@ -19,8 +20,8 @@ extern "C" void __ry_set_last_error(const char *msg) {
 }
 
 extern "C" const char *__ry_get_last_error() {
-    // Return a heap copy so it can be stored as a ry str
-    return checked_strdup(last_error_buf);
+    // Return a StringHeader-managed copy so it can be stored as a Ry str.
+    return makeString(last_error_buf, strlen(last_error_buf));
 }
 
 } // namespace ry

--- a/src/runtime_hash.cpp
+++ b/src/runtime_hash.cpp
@@ -3,6 +3,7 @@
 #include <cstring>
 
 #include "ry/runtime_alloc.hpp"
+#include "ry/runtime_string.hpp"
 
 namespace ry {
 
@@ -24,10 +25,11 @@ uint64_t __ry_hash_f64(double key) {
 }
 
 uint64_t __ry_hash_str(const char *key) {
-    // FNV-1a
+    // FNV-1a — NUL-safe: reads exactly byte_len bytes from the StringHeader
     uint64_t h = 14695981039346656037ULL;
-    for (const unsigned char *p = (const unsigned char *)key; *p; ++p) {
-        h ^= *p;
+    int64_t len = stringByteLen(key);
+    for (int64_t i = 0; i < len; ++i) {
+        h ^= static_cast<unsigned char>(key[i]);
         h *= 1099511628211ULL;
     }
     return h;
@@ -63,12 +65,16 @@ int64_t __ry_ht_find_f64(int64_t *buckets, int64_t bucketMask,
 int64_t __ry_ht_find_str(int64_t *buckets, int64_t bucketMask,
                           const char **keys, int64_t len, const char *key) {
     uint64_t h = __ry_hash_str(key);
+    int64_t keyLen = stringByteLen(key);
     int64_t bc = bucketMask + 1;
     for (int64_t i = 0; i < bc; ++i) {
         int64_t idx = (int64_t)((h + (uint64_t)i) & (uint64_t)bucketMask);
         int64_t slot = buckets[idx];
         if (slot == EMPTY) return -1;
-        if (slot >= 0 && slot < len && strcmp(keys[slot], key) == 0) return slot;
+        if (slot >= 0 && slot < len) {
+            int64_t slotLen = stringByteLen(keys[slot]);
+            if (slotLen == keyLen && memcmp(keys[slot], key, (size_t)keyLen) == 0) return slot;
+        }
     }
     return -1;
 }
@@ -113,6 +119,7 @@ int64_t *__ry_ht_rehash_str(const char **keys, int64_t count, int64_t newBucketC
     memset(buckets, 0xFF, (size_t)newBucketCount * sizeof(int64_t));
     int64_t mask = newBucketCount - 1;
     for (int64_t i = 0; i < count; ++i) {
+        // __ry_hash_str already reads byte_len from the StringHeader; no change needed here
         __ry_ht_insert(buckets, mask, __ry_hash_str(keys[i]), i);
     }
     return buckets;

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -30,8 +30,8 @@ std::vector<HeaderPair> parse_raw_headers(const std::string &raw,
             while (vstart < eol && (raw[vstart] == ' ' || raw[vstart] == '\t'))
                 vstart++;
             headers.push_back({
-                checked_strndup(raw.c_str() + pos, colon - pos),
-                checked_strndup(raw.c_str() + vstart, eol - vstart)
+                makeString(raw.c_str() + pos, colon - pos),
+                makeString(raw.c_str() + vstart, eol - vstart)
             });
         }
         pos = eol + 2;
@@ -66,8 +66,8 @@ void *build_str_map_copy(char **keys, char **vals, int64_t count) {
         dup_keys = (char **)checked_malloc(sizeof(char *) * (size_t)count);
         dup_vals = (char **)checked_malloc(sizeof(char *) * (size_t)count);
         for (int64_t i = 0; i < count; i++) {
-            dup_keys[i] = checked_strdup(keys[i]);
-            dup_vals[i] = checked_strdup(vals[i]);
+            dup_keys[i] = makeString(keys[i], strlen(keys[i]));
+            dup_vals[i] = makeString(vals[i], strlen(vals[i]));
         }
     }
     return build_str_map(dup_keys, dup_vals, count);
@@ -141,7 +141,7 @@ static void parse_query_string(const char *qs, size_t qs_len, HttpRequestHandle 
                 if (strcmp(params[j].key, key.c_str()) == 0) { dup = true; break; }
             }
             if (!dup)
-                params.push_back({checked_strdup(key.c_str()), checked_strdup(val.c_str())});
+                params.push_back({makeString(key.c_str(), key.size()), makeString(val.c_str(), val.size())});
         }
         pos += seg_len + 1;
     }
@@ -205,7 +205,7 @@ static void parse_cookie_header(HttpRequestHandle *req) {
                     }
                 }
                 if (!dup)
-                    pairs.push_back({checked_strndup(p, key_len), checked_strndup(val_start, val_len)});
+                    pairs.push_back({makeString(p, key_len), makeString(val_start, val_len)});
             }
         }
 
@@ -413,7 +413,7 @@ static bool parse_request_line(const std::string &raw, HttpRequestHandle *req,
     const char *sp1 = (const char *)memchr(line, ' ', line_end);
     if (!sp1) return false;
 
-    req->method = checked_strndup(line, (size_t)(sp1 - line));
+    req->method = makeString(line, (size_t)(sp1 - line));
 
     // Find second space (end of path, before HTTP/x.x)
     size_t remaining = line_end - (size_t)(sp1 + 1 - line);
@@ -424,12 +424,12 @@ static bool parse_request_line(const std::string &raw, HttpRequestHandle *req,
     // Find '?' within path to split path and query string
     const char *qmark = (const char *)memchr(path_start, '?', path_len);
     if (qmark) {
-        req->path = checked_strndup(path_start, (size_t)(qmark - path_start));
+        req->path = makeString(path_start, (size_t)(qmark - path_start));
         const char *qs = qmark + 1;
         size_t qs_len = path_len - (size_t)(qs - path_start);
         parse_query_string(qs, qs_len, req);
     } else {
-        req->path = checked_strndup(path_start, path_len);
+        req->path = makeString(path_start, path_len);
         parse_query_string(nullptr, 0, req);
     }
     line_end_out = line_end;
@@ -455,7 +455,7 @@ static bool read_request_body(int fd, std::string &raw, size_t body_start,
         std::string body_data = read_chunked_body(fd, raw, body_start, ok);
         if (!ok) return false;
         req->body_len = (int64_t)body_data.size();
-        req->body = checked_memdup(body_data.data(), body_data.size());
+        req->body = makeString(body_data.data(), body_data.size());
         return true;
     }
 
@@ -467,7 +467,7 @@ static bool read_request_body(int fd, std::string &raw, size_t body_start,
     if (content_length > 0) {
         // Allocate final buffer directly to avoid intermediate string copy
         size_t cl = (size_t)content_length;
-        char *body = (char *)checked_malloc(cl + 1);
+        char *body = makeStringUninit(cl);
         size_t have = (initial_len < cl) ? initial_len : cl;
         if (have > 0)
             memcpy(body, raw.c_str() + body_start, have);
@@ -480,20 +480,19 @@ static bool read_request_body(int fd, std::string &raw, size_t body_start,
             got += (size_t)n;
         }
 
-        if ((int64_t)got < content_length) { free(body); return false; }
+        if ((int64_t)got < content_length) { freeStringSlot(body); return false; }
 
-        body[cl] = '\0';
         req->body_len = content_length;
         req->body = body;
     } else if (content_length == 0) {
         req->body_len = 0;
-        req->body = checked_memdup("", 0);
+        req->body = makeString("", 0);
     } else {
         // No Content-Length: use whatever data is available after headers
         req->body_len = (int64_t)initial_len;
         req->body = (initial_len > 0)
-            ? checked_memdup(raw.c_str() + body_start, initial_len)
-            : checked_memdup("", 0);
+            ? makeString(raw.c_str() + body_start, initial_len)
+            : makeString("", 0);
     }
     return true;
 }
@@ -587,9 +586,9 @@ extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, co
     // cppcheck-suppress legacyUninitvar -- placement new with {} zero-initializes; false positive in Cppcheck < 2.14
     auto *resp = new (resp_mem) HttpResponseHandle{};
     resp->status = status;
-    const char *b = body ? body : "";
-    resp->body_len = (int64_t)strlen(b);
-    resp->body = checked_memdup(b, (size_t)resp->body_len);
+    int64_t blen = body ? stringByteLen(body) : 0;
+    resp->body_len = blen;
+    resp->body = makeString(blen > 0 ? body : "", (size_t)blen);
 
     auto *map = (MapHeader *)headers_map;
     if (map->len > 0) {
@@ -598,8 +597,8 @@ extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, co
         int64_t actual = 0;
         for (int64_t i = 0; i < map->len; i++) {
             if (has_crlf(map->keys[i]) || has_crlf(map->vals[i])) continue;
-            resp->header_keys[actual] = checked_strdup(map->keys[i]);
-            resp->header_values[actual] = checked_strdup(map->vals[i]);
+            resp->header_keys[actual] = makeString(map->keys[i], strlen(map->keys[i]));
+            resp->header_values[actual] = makeString(map->vals[i], strlen(map->vals[i]));
             actual++;
         }
         resp->header_count = actual;
@@ -612,61 +611,63 @@ extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, co
 }
 
 extern "C" const char *__ry_http_reason_phrase(int64_t status) {
+    const char *s = nullptr;
     switch (status) {
-        case 100: return "Continue";
-        case 101: return "Switching Protocols";
-        case 200: return "OK";
-        case 201: return "Created";
-        case 202: return "Accepted";
-        case 203: return "Non-Authoritative Information";
-        case 204: return "No Content";
-        case 205: return "Reset Content";
-        case 206: return "Partial Content";
-        case 300: return "Multiple Choices";
-        case 301: return "Moved Permanently";
-        case 302: return "Found";
-        case 303: return "See Other";
-        case 304: return "Not Modified";
-        case 307: return "Temporary Redirect";
-        case 308: return "Permanent Redirect";
-        case 400: return "Bad Request";
-        case 401: return "Unauthorized";
-        case 402: return "Payment Required";
-        case 403: return "Forbidden";
-        case 404: return "Not Found";
-        case 405: return "Method Not Allowed";
-        case 406: return "Not Acceptable";
-        case 407: return "Proxy Authentication Required";
-        case 408: return "Request Timeout";
-        case 409: return "Conflict";
-        case 410: return "Gone";
-        case 411: return "Length Required";
-        case 412: return "Precondition Failed";
-        case 413: return "Content Too Large";
-        case 414: return "URI Too Long";
-        case 415: return "Unsupported Media Type";
-        case 416: return "Range Not Satisfiable";
-        case 417: return "Expectation Failed";
-        case 418: return "I'm a teapot";
-        case 421: return "Misdirected Request";
-        case 422: return "Unprocessable Content";
-        case 425: return "Too Early";
-        case 426: return "Upgrade Required";
-        case 428: return "Precondition Required";
-        case 429: return "Too Many Requests";
-        case 431: return "Request Header Fields Too Large";
-        case 451: return "Unavailable For Legal Reasons";
-        case 500: return "Internal Server Error";
-        case 501: return "Not Implemented";
-        case 502: return "Bad Gateway";
-        case 503: return "Service Unavailable";
-        case 504: return "Gateway Timeout";
-        case 505: return "HTTP Version Not Supported";
-        case 507: return "Insufficient Storage";
-        case 508: return "Loop Detected";
-        case 511: return "Network Authentication Required";
-        default: return "Unknown";
+        case 100: s = "Continue"; break;
+        case 101: s = "Switching Protocols"; break;
+        case 200: s = "OK"; break;
+        case 201: s = "Created"; break;
+        case 202: s = "Accepted"; break;
+        case 203: s = "Non-Authoritative Information"; break;
+        case 204: s = "No Content"; break;
+        case 205: s = "Reset Content"; break;
+        case 206: s = "Partial Content"; break;
+        case 300: s = "Multiple Choices"; break;
+        case 301: s = "Moved Permanently"; break;
+        case 302: s = "Found"; break;
+        case 303: s = "See Other"; break;
+        case 304: s = "Not Modified"; break;
+        case 307: s = "Temporary Redirect"; break;
+        case 308: s = "Permanent Redirect"; break;
+        case 400: s = "Bad Request"; break;
+        case 401: s = "Unauthorized"; break;
+        case 402: s = "Payment Required"; break;
+        case 403: s = "Forbidden"; break;
+        case 404: s = "Not Found"; break;
+        case 405: s = "Method Not Allowed"; break;
+        case 406: s = "Not Acceptable"; break;
+        case 407: s = "Proxy Authentication Required"; break;
+        case 408: s = "Request Timeout"; break;
+        case 409: s = "Conflict"; break;
+        case 410: s = "Gone"; break;
+        case 411: s = "Length Required"; break;
+        case 412: s = "Precondition Failed"; break;
+        case 413: s = "Content Too Large"; break;
+        case 414: s = "URI Too Long"; break;
+        case 415: s = "Unsupported Media Type"; break;
+        case 416: s = "Range Not Satisfiable"; break;
+        case 417: s = "Expectation Failed"; break;
+        case 418: s = "I'm a teapot"; break;
+        case 421: s = "Misdirected Request"; break;
+        case 422: s = "Unprocessable Content"; break;
+        case 425: s = "Too Early"; break;
+        case 426: s = "Upgrade Required"; break;
+        case 428: s = "Precondition Required"; break;
+        case 429: s = "Too Many Requests"; break;
+        case 431: s = "Request Header Fields Too Large"; break;
+        case 451: s = "Unavailable For Legal Reasons"; break;
+        case 500: s = "Internal Server Error"; break;
+        case 501: s = "Not Implemented"; break;
+        case 502: s = "Bad Gateway"; break;
+        case 503: s = "Service Unavailable"; break;
+        case 504: s = "Gateway Timeout"; break;
+        case 505: s = "HTTP Version Not Supported"; break;
+        case 507: s = "Insufficient Storage"; break;
+        case 508: s = "Loop Detected"; break;
+        case 511: s = "Network Authentication Required"; break;
+        default:  s = "Unknown"; break;
     }
+    return makeString(s, strlen(s));
 }
 
 extern "C" int64_t __ry_http_should_keep_alive(void *request) {
@@ -751,24 +752,24 @@ extern "C" void __ry_http_send_response(void *stream, void *response, int64_t ke
 extern "C" void __ry_http_request_cleanup(void *r) {
     if (!r) return;
     auto *req = (HttpRequestHandle *)r;
-    free(req->method);
-    free(req->path);
+    freeStringSlot(req->method);
+    freeStringSlot(req->path);
     free_kv_pairs(req->header_keys, req->header_values, req->header_count);
     free_kv_pairs(req->query_keys, req->query_values, req->query_count);
     free_kv_pairs(req->cookie_keys, req->cookie_values, req->cookie_count);
     for (int64_t i = 0; i < req->form_field_count; i++) {
-        free(req->form_fields[i].key);
-        free(req->form_fields[i].value);
+        freeStringSlot(req->form_fields[i].key);
+        freeStringSlot(req->form_fields[i].value);
     }
     free(req->form_fields);
     for (int64_t i = 0; i < req->form_file_count; i++) {
-        free(req->form_files[i].name);
-        free(req->form_files[i].filename);
-        free(req->form_files[i].content_type);
-        free(req->form_files[i].data);
+        freeStringSlot(req->form_files[i].name);
+        freeStringSlot(req->form_files[i].filename);
+        freeStringSlot(req->form_files[i].content_type);
+        freeStringSlot(req->form_files[i].data);
     }
     free(req->form_files);
-    free(req->body);
+    freeStringSlot(req->body);
 }
 
 extern "C" void __ry_http_request_free(void *r) {
@@ -783,7 +784,7 @@ extern "C" void __ry_http_response_cleanup(void *r) {
     if (!r) return;
     auto *resp = (HttpResponseHandle *)r;
     free_kv_pairs(resp->header_keys, resp->header_values, resp->header_count);
-    free(resp->body);
+    freeStringSlot(resp->body);
 }
 
 extern "C" void __ry_http_response_free(void *r) {

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -66,8 +66,8 @@ void *build_str_map_copy(char **keys, char **vals, int64_t count) {
         dup_keys = (char **)checked_malloc(sizeof(char *) * (size_t)count);
         dup_vals = (char **)checked_malloc(sizeof(char *) * (size_t)count);
         for (int64_t i = 0; i < count; i++) {
-            dup_keys[i] = makeString(keys[i], strlen(keys[i]));
-            dup_vals[i] = makeString(vals[i], strlen(vals[i]));
+            dup_keys[i] = makeString(keys[i], (size_t)stringByteLen(keys[i]));
+            dup_vals[i] = makeString(vals[i], (size_t)stringByteLen(vals[i]));
         }
     }
     return build_str_map(dup_keys, dup_vals, count);

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -597,8 +597,8 @@ extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, co
         int64_t actual = 0;
         for (int64_t i = 0; i < map->len; i++) {
             if (has_crlf(map->keys[i]) || has_crlf(map->vals[i])) continue;
-            resp->header_keys[actual] = makeString(map->keys[i], strlen(map->keys[i]));
-            resp->header_values[actual] = makeString(map->vals[i], strlen(map->vals[i]));
+            resp->header_keys[actual] = makeString(map->keys[i], (size_t)stringByteLen(map->keys[i]));
+            resp->header_values[actual] = makeString(map->vals[i], (size_t)stringByteLen(map->vals[i]));
             actual++;
         }
         resp->header_count = actual;

--- a/src/runtime_http_client.cpp
+++ b/src/runtime_http_client.cpp
@@ -130,7 +130,7 @@ static bool read_response_body(HttpTransport &t, std::string &raw, size_t body_s
         std::string body_data = read_chunked_body(t, raw, body_start, ok);
         if (!ok) return false;
         body_len_out = body_data.size();
-        body_ptr = (char *)checked_memdup(body_data.data(), body_data.size());
+        body_ptr = makeString(body_data.data(), body_data.size());
         return true;
     }
 
@@ -150,7 +150,7 @@ static bool read_response_body(HttpTransport &t, std::string &raw, size_t body_s
     if (content_length >= 0) {
         // Known Content-Length: allocate final buffer directly
         size_t cl = (size_t)content_length;
-        char *body = (char *)checked_malloc(cl + 1);
+        char *body = makeStringUninit(cl);
         size_t have = (initial_len < cl) ? initial_len : cl;
         if (have > 0)
             memcpy(body, raw.c_str() + body_start, have);
@@ -161,9 +161,8 @@ static bool read_response_body(HttpTransport &t, std::string &raw, size_t body_s
             if (n <= 0) break;
             got += (size_t)n;
         }
-        if ((int64_t)got < content_length) { free(body); return false; }
+        if ((int64_t)got < content_length) { freeStringSlot(body); return false; }
 
-        body[cl] = '\0';
         body_ptr = body;
         body_len_out = cl;
     } else {
@@ -182,7 +181,7 @@ static bool read_response_body(HttpTransport &t, std::string &raw, size_t body_s
             }
         }
         body_len_out = body_data.size();
-        body_ptr = (char *)checked_memdup(body_data.data(), body_data.size());
+        body_ptr = makeString(body_data.data(), body_data.size());
     }
 
     return true;
@@ -207,14 +206,14 @@ static HttpClientResponseHandle *read_http_response(HttpTransport &t) {
     char *body_ptr = nullptr;
     size_t body_len = 0;
     if (!read_response_body(t, raw, body_start, parsed_headers, body_ptr, body_len)) {
-        for (auto &h : parsed_headers) { free(h.key); free(h.val); }
+        for (auto &h : parsed_headers) { freeStringSlot(h.key); freeStringSlot(h.val); }
         return nullptr;
     }
 
     void *resp_mem = arc_alloc(sizeof(HttpClientResponseHandle));
     if (!resp_mem) {
-        free(body_ptr);
-        for (auto &h : parsed_headers) { free(h.key); free(h.val); }
+        freeStringSlot(body_ptr);
+        for (auto &h : parsed_headers) { freeStringSlot(h.key); freeStringSlot(h.val); }
         return nullptr;
     }
     // cppcheck-suppress legacyUninitvar -- placement new with {} zero-initializes; false positive in Cppcheck < 2.14
@@ -519,7 +518,7 @@ extern "C" int64_t __ry_http_client_status(void *r) {
 }
 
 extern "C" const char *__ry_http_client_body(void *r) {
-    if (!r) return "";
+    if (!r) return makeString("", 0);
     return ((HttpClientResponseHandle *)r)->body;
 }
 
@@ -541,7 +540,7 @@ extern "C" void __ry_http_client_response_cleanup(void *r) {
     if (!r) return;
     auto *resp = (HttpClientResponseHandle *)r;
     free_kv_pairs(resp->header_keys, resp->header_values, resp->header_count);
-    free(resp->body);
+    freeStringSlot(resp->body);
 }
 
 extern "C" void __ry_http_client_response_free(void *r) {

--- a/src/runtime_http_multipart.cpp
+++ b/src/runtime_http_multipart.cpp
@@ -44,7 +44,7 @@ static std::string extract_param(const char *header_value, const char *param_nam
 }
 
 static void free_header_pairs(std::vector<HeaderPair> &headers) {
-    for (auto &h : headers) { free(h.key); free(h.val); }
+    for (auto &h : headers) { freeStringSlot(h.key); freeStringSlot(h.val); }
 }
 
 // Process a single multipart part: extract Content-Disposition, categorize as
@@ -71,19 +71,20 @@ static void process_multipart_part(const char *body, size_t data_start, size_t d
     std::string filename = extract_param(disposition, "filename");
     if (!filename.empty()) {
         if (seen_file_names.insert(name).second) {
+            const char *ct = part_content_type ? part_content_type : "application/octet-stream";
             files.push_back({
-                checked_strdup(name.c_str()),
-                checked_strdup(filename.c_str()),
-                checked_strdup(part_content_type ? part_content_type : "application/octet-stream"),
-                checked_memdup(body + data_start, data_end - data_start),
+                makeString(name.c_str(), name.size()),
+                makeString(filename.c_str(), filename.size()),
+                makeString(ct, strlen(ct)),
+                makeString(body + data_start, data_end - data_start),
                 (int64_t)(data_end - data_start)
             });
         }
     } else {
         if (seen_field_names.insert(name).second) {
             fields.push_back({
-                checked_strdup(name.c_str()),
-                checked_strndup(body + data_start, data_end - data_start)
+                makeString(name.c_str(), name.size()),
+                makeString(body + data_start, data_end - data_start)
             });
         }
     }
@@ -187,12 +188,12 @@ extern "C" void *__ry_http_form_file(void *r, const char *name) {
             // Build a Map<str, str> with keys: "filename", "content_type", "data"
             char **keys = (char **)checked_malloc(sizeof(char *) * 3);
             char **vals = (char **)checked_malloc(sizeof(char *) * 3);
-            keys[0] = checked_strdup("filename");
-            vals[0] = checked_strdup(req->form_files[i].filename);
-            keys[1] = checked_strdup("content_type");
-            vals[1] = checked_strdup(req->form_files[i].content_type);
-            keys[2] = checked_strdup("data");
-            vals[2] = checked_memdup(req->form_files[i].data, (size_t)req->form_files[i].data_len);
+            keys[0] = makeString("filename", 8);
+            vals[0] = makeString(req->form_files[i].filename, strlen(req->form_files[i].filename));
+            keys[1] = makeString("content_type", 12);
+            vals[1] = makeString(req->form_files[i].content_type, strlen(req->form_files[i].content_type));
+            keys[2] = makeString("data", 4);
+            vals[2] = makeString(req->form_files[i].data, (size_t)req->form_files[i].data_len);
             return build_str_map(keys, vals, 3);
         }
     }
@@ -209,8 +210,8 @@ extern "C" void *__ry_http_form_fields(void *r) {
         dup_keys = (char **)checked_malloc(sizeof(char *) * (size_t)req->form_field_count);
         dup_vals = (char **)checked_malloc(sizeof(char *) * (size_t)req->form_field_count);
         for (int64_t i = 0; i < req->form_field_count; i++) {
-            dup_keys[i] = checked_strdup(req->form_fields[i].key);
-            dup_vals[i] = checked_strdup(req->form_fields[i].value);
+            dup_keys[i] = makeString(req->form_fields[i].key, strlen(req->form_fields[i].key));
+            dup_vals[i] = makeString(req->form_fields[i].value, strlen(req->form_fields[i].value));
         }
     }
     return build_str_map(dup_keys, dup_vals, req->form_field_count);

--- a/src/runtime_http_multipart.cpp
+++ b/src/runtime_http_multipart.cpp
@@ -210,8 +210,8 @@ extern "C" void *__ry_http_form_fields(void *r) {
         dup_keys = (char **)checked_malloc(sizeof(char *) * (size_t)req->form_field_count);
         dup_vals = (char **)checked_malloc(sizeof(char *) * (size_t)req->form_field_count);
         for (int64_t i = 0; i < req->form_field_count; i++) {
-            dup_keys[i] = makeString(req->form_fields[i].key, strlen(req->form_fields[i].key));
-            dup_vals[i] = makeString(req->form_fields[i].value, strlen(req->form_fields[i].value));
+            dup_keys[i] = makeString(req->form_fields[i].key, (size_t)stringByteLen(req->form_fields[i].key));
+            dup_vals[i] = makeString(req->form_fields[i].value, (size_t)stringByteLen(req->form_fields[i].value));
         }
     }
     return build_str_map(dup_keys, dup_vals, req->form_field_count);

--- a/src/runtime_http_multipart.cpp
+++ b/src/runtime_http_multipart.cpp
@@ -189,9 +189,9 @@ extern "C" void *__ry_http_form_file(void *r, const char *name) {
             char **keys = (char **)checked_malloc(sizeof(char *) * 3);
             char **vals = (char **)checked_malloc(sizeof(char *) * 3);
             keys[0] = makeString("filename", 8);
-            vals[0] = makeString(req->form_files[i].filename, strlen(req->form_files[i].filename));
+            vals[0] = makeString(req->form_files[i].filename, (size_t)stringByteLen(req->form_files[i].filename));
             keys[1] = makeString("content_type", 12);
-            vals[1] = makeString(req->form_files[i].content_type, strlen(req->form_files[i].content_type));
+            vals[1] = makeString(req->form_files[i].content_type, (size_t)stringByteLen(req->form_files[i].content_type));
             keys[2] = makeString("data", 4);
             vals[2] = makeString(req->form_files[i].data, (size_t)req->form_files[i].data_len);
             return build_str_map(keys, vals, 3);

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -1,6 +1,7 @@
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_arc.hpp"
 #include "ry/runtime_http_types.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <cstdarg>
 #include <cstdio>
@@ -51,11 +52,13 @@ extern "C" const char *__ry_read_line() {
     ssize_t nread = getline(&line, &len, stdin);
     if (nread == -1) {
         free(line);
-        return checked_strdup("");
+        return makeString("", 0);
     }
     if (nread > 0 && line[nread - 1] == '\n')
-        line[nread - 1] = '\0';
-    return line;
+        --nread;
+    const char *result = makeString(line, static_cast<size_t>(nread));
+    free(line);
+    return result;
 }
 
 extern "C" const char *__ry_read_all() {
@@ -76,8 +79,9 @@ extern "C" const char *__ry_read_all() {
         }
         len += n;
     }
-    buf[len] = '\0';
-    return buf;
+    const char *result = makeString(buf, len);
+    free(buf);
+    return result;
 }
 
 // ===== File I/O =====
@@ -108,9 +112,10 @@ extern "C" const char *__ry_read_text(const char *path) {
 
     char *buf = (char *)checked_malloc((size_t)size + 1);
     size_t nread = fread(buf, 1, (size_t)size, f);
-    buf[nread] = '\0';
     fclose(f);
-    return buf;
+    const char *result = makeString(buf, nread);
+    free(buf);
+    return result;
 }
 
 extern "C" int64_t __ry_write_text(const char *path, const char *content) {
@@ -203,22 +208,13 @@ extern "C" int64_t __ry_write_bytes(const char *path, void *list) {
 // ===== Byte conversions =====
 
 extern "C" void *__ry_str_to_bytes(const char *s) {
-    size_t len = strlen(s);
-    return makeByteList((const uint8_t *)s, (int64_t)len);
+    return makeByteList((const uint8_t *)s, stringByteLen(s));
 }
 
 extern "C" const char *__ry_bytes_to_str(void *list) {
     auto *header = (IOListHeader *)list;
-    for (int64_t i = 0; i < header->len; ++i) {
-        if (header->data[i] == 0) {
-            setLastError("bytes_to_str() input contains NUL byte at index %lld", (long long)i);
-            return nullptr;
-        }
-    }
-    char *buf = (char *)checked_malloc(static_cast<size_t>(header->len) + 1);
-    memcpy(buf, header->data, static_cast<size_t>(header->len));
-    buf[header->len] = '\0';
-    return buf;
+    return makeString(reinterpret_cast<const char *>(header->data),
+                      static_cast<size_t>(header->len));
 }
 
 } // namespace ry

--- a/src/runtime_json.cpp
+++ b/src/runtime_json.cpp
@@ -2,6 +2,7 @@
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_arc.hpp"
 #include "ry/runtime_list.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <cctype>
 #include <new>
@@ -589,7 +590,7 @@ const char *__ry_json_stringify(void *value) {
     auto *v = (JsonValue*)value;
     std::string out;
     stringify_value(v, out, 0, 0, false);
-    return checked_memdup(out.data(), out.size());
+    return makeString(out.data(), out.size());
 }
 
 const char *__ry_json_stringify_pretty(void *value, int64_t indent) {
@@ -600,22 +601,27 @@ const char *__ry_json_stringify_pretty(void *value, int64_t indent) {
     } else {
         stringify_value(v, out, static_cast<size_t>(indent), 0, true);
     }
-    return checked_memdup(out.data(), out.size());
+    return makeString(out.data(), out.size());
 }
 
 const char *__ry_json_type(void *value) {
-    if (!value) return "null";
-    auto *v = (JsonValue*)value;
-    switch (v->type) {
-        case JsonType::Null:   return "null";
-        case JsonType::Bool:   return "boolean";
-        case JsonType::Int:
-        case JsonType::Float:  return "number";
-        case JsonType::String: return "string";
-        case JsonType::Array:  return "array";
-        case JsonType::Object: return "object";
+    const char *s = nullptr;
+    if (!value) {
+        s = "null";
+    } else {
+        auto *v = (JsonValue*)value;
+        switch (v->type) {
+            case JsonType::Null:   s = "null";    break;
+            case JsonType::Bool:   s = "boolean"; break;
+            case JsonType::Int:
+            case JsonType::Float:  s = "number";  break;
+            case JsonType::String: s = "string";  break;
+            case JsonType::Array:  s = "array";   break;
+            case JsonType::Object: s = "object";  break;
+        }
+        if (!s) s = "unknown";
     }
-    return "unknown";
+    return makeString(s, strlen(s));
 }
 
 void *__ry_json_get(void *value, const char *key) {
@@ -667,7 +673,7 @@ const char *__ry_json_str(void *value) {
         __ry_set_last_error("json_str: value is not a string");
         return nullptr;
     }
-    return checked_strdup(v->string_val);
+    return makeString(v->string_val, strlen(v->string_val));
 }
 
 int64_t __ry_json_int(void *value, int64_t *out) {

--- a/src/runtime_path.cpp
+++ b/src/runtime_path.cpp
@@ -1,5 +1,5 @@
-#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_error.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <cerrno>
 #include <cstdint>
@@ -36,9 +36,9 @@ static const char *find_base(const char *p, size_t len) {
 // If b is absolute, returns a copy of b.
 // Otherwise concatenates a + "/" + b, normalizing double slashes.
 static char *join2_impl(const char *a, const char *b) {
-    if (!a || !*a) return checked_strdup(b ? b : "");
-    if (!b || !*b) return checked_strdup(a);
-    if (b[0] == '/') return checked_strdup(b);
+    if (!a || !*a) return makeString(b ? b : "", b ? strlen(b) : 0);
+    if (!b || !*b) return makeString(a, strlen(a));
+    if (b[0] == '/') return makeString(b, strlen(b));
 
     size_t a_len = strip_trailing(a, strlen(a));
     size_t b_len = strlen(b);
@@ -46,12 +46,12 @@ static char *join2_impl(const char *a, const char *b) {
     // If a ends with '/' (root path), don't insert an extra separator
     bool need_sep = (a[a_len - 1] != '/');
     size_t out_len = a_len + (need_sep ? 1 : 0) + b_len;
-    char *out = (char *)checked_malloc(out_len + 1);
-    memcpy(out, a, a_len);
+    char *out = makeStringUninit(out_len);
+    memcpy(out, a, a_len); // NOLINT(bugprone-not-null-terminated-result) — makeStringUninit appends NUL at out[out_len]
     if (need_sep)
         out[a_len] = '/';
-    memcpy(out + a_len + (need_sep ? 1 : 0), b, b_len);
-    out[out_len] = '\0';
+    memcpy(out + a_len + (need_sep ? 1 : 0), b, b_len); // NOLINT(bugprone-not-null-terminated-result) — NUL already at out[out_len]
+    // NUL at out[out_len] already written by makeStringUninit
     return out;
 }
 
@@ -64,24 +64,24 @@ extern "C" const char *__ry_path_join2(const char *a, const char *b) {
 extern "C" const char *__ry_path_join3(const char *a, const char *b, const char *c) {
     char *ab = join2_impl(a, b);
     char *result = join2_impl(ab, c);
-    free(ab);
+    freeStringSlot(ab);
     return result;
 }
 
 extern "C" const char *__ry_path_join4(const char *a, const char *b, const char *c, const char *d) {
     char *ab = join2_impl(a, b);
     char *abc = join2_impl(ab, c);
-    free(ab);
+    freeStringSlot(ab);
     char *result = join2_impl(abc, d);
-    free(abc);
+    freeStringSlot(abc);
     return result;
 }
 
 extern "C" const char *__ry_path_basename(const char *p) {
-    if (!p || !*p) return checked_strdup("");
+    if (!p || !*p) return makeString("", 0);
 
     size_t len = strip_trailing(p, strlen(p));
-    if (len == 1 && p[0] == '/') return checked_strdup("");
+    if (len == 1 && p[0] == '/') return makeString("", 0);
 
     const char *end = p + len;
     const char *base = find_base(p, len);
@@ -89,11 +89,11 @@ extern "C" const char *__ry_path_basename(const char *p) {
     // If base points to a '/', skip it
     if (*base == '/') base++;
 
-    return checked_strndup(base, (size_t)(end - base));
+    return makeString(base, (size_t)(end - base));
 }
 
 extern "C" const char *__ry_path_dirname(const char *p) {
-    if (!p || !*p) return checked_strdup(".");
+    if (!p || !*p) return makeString(".", 1);
 
     size_t len = strip_trailing(p, strlen(p));
 
@@ -103,7 +103,7 @@ extern "C" const char *__ry_path_dirname(const char *p) {
         slash--;
 
     if (slash == p) {
-        return checked_strdup(*slash == '/' ? "/" : ".");
+        return *slash == '/' ? makeString("/", 1) : makeString(".", 1);
     }
 
     // Strip trailing slashes from dirname portion
@@ -112,13 +112,13 @@ extern "C" const char *__ry_path_dirname(const char *p) {
         dir_end--;
 
     size_t dir_len = (size_t)(dir_end - p);
-    if (dir_len == 0) return checked_strdup("/");
+    if (dir_len == 0) return makeString("/", 1);
 
-    return checked_strndup(p, dir_len);
+    return makeString(p, dir_len);
 }
 
 extern "C" const char *__ry_path_extension(const char *p) {
-    if (!p || !*p) return checked_strdup("");
+    if (!p || !*p) return makeString("", 0);
 
     size_t len = strip_trailing(p, strlen(p));
     const char *end = p + len;
@@ -133,9 +133,9 @@ extern "C" const char *__ry_path_extension(const char *p) {
     }
 
     // No dot, or dot is the first character (hidden file like .gitignore)
-    if (!dot || dot == base) return checked_strdup("");
+    if (!dot || dot == base) return makeString("", 0);
 
-    return checked_strndup(dot, (size_t)(end - dot));
+    return makeString(dot, (size_t)(end - dot));
 }
 
 extern "C" const char *__ry_path_resolve(const char *p) {
@@ -149,7 +149,9 @@ extern "C" const char *__ry_path_resolve(const char *p) {
         setLastError("cannot resolve path '%s': %s", p, strerror(errno));
         return nullptr;
     }
-    return resolved;
+    const char *result = makeString(resolved, strlen(resolved));
+    free(resolved);
+    return result;
 }
 
 extern "C" int64_t __ry_path_is_absolute(const char *p) {

--- a/src/runtime_print.cpp
+++ b/src/runtime_print.cpp
@@ -1,5 +1,6 @@
 #include "ry/runtime_alloc.hpp"
 #include "ry/runtime_print.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <cstdarg>
 #include <cstdio>
@@ -127,10 +128,9 @@ extern "C" char *__ry_sprint_end() {
     if (tl_sprint_depth < kMaxSprintDepth)
         start = tl_sprint_offsets[tl_sprint_depth];
     size_t len = tl_sprint_len - start;
-    char *result = static_cast<char *>(checked_malloc(len + 1));
+    char *result = ry::makeStringUninit(len);
     if (len > 0)
         std::memcpy(result, tl_sprint_buf + start, len);
-    result[len] = '\0';
     tl_sprint_len = start;
     return result;
 }
@@ -144,7 +144,8 @@ extern "C" const char *__ry_print_str_quote_escape(const char *raw) {
         if (raw[i] == '"' || raw[i] == '\\')
             ++extra;
     }
-    char *buf = static_cast<char *>(ry::checked_malloc(len + extra + 3));
+    // data size = 2 (quotes) + len + extra; makeStringUninit writes NUL at data[len+extra+2]
+    char *buf = ry::makeStringUninit(len + extra + 2);
     char *p = buf;
     *p++ = '"';
     for (size_t i = 0; i < len; ++i) {
@@ -153,6 +154,6 @@ extern "C" const char *__ry_print_str_quote_escape(const char *raw) {
         *p++ = raw[i];
     }
     *p++ = '"';
-    *p = '\0';
+    // NUL at buf[len+extra+2] already written by makeStringUninit
     return buf;
 }

--- a/src/runtime_string.cpp
+++ b/src/runtime_string.cpp
@@ -1,0 +1,47 @@
+#include "ry/runtime_string.hpp"
+#include <cstdint>
+#include <cstring>
+
+// ── StringHeader C-level exports called from JIT-compiled IR ─────────────
+//
+// Codegen emits CreateCall to these symbols when it needs to allocate Ry str
+// values at runtime (string concat, repeat, f-string construction, etc.).
+// C++ runtime code that returns str (runtime_io, runtime_path, ...) uses the
+// inline ry::makeString / ry::makeStringUninit helpers from runtime_string.hpp
+// directly instead of going through these symbols.
+
+extern "C" {
+
+// Allocate a StringHeader-managed string of `byte_len` bytes, uninitialized
+// data (except for the null terminator at data[byte_len]).  Returns the handle
+// (data pointer).  Called by codegen for string concat / repeat.
+char *__ry_string_make_uninit(int64_t byte_len) {
+    if (byte_len < 0) byte_len = 0;
+    return ry::makeStringUninit(static_cast<size_t>(byte_len));
+}
+
+// Allocate a StringHeader-managed string by copying `byte_len` bytes from
+// `src` (NUL bytes included).  Returns the handle.
+char *__ry_string_make(const char *src, int64_t byte_len) {
+    if (byte_len < 0) byte_len = 0;
+    return ry::makeString(src, static_cast<size_t>(byte_len));
+}
+
+// Return the byte_len stored in the StringHeader for `handle`.
+int64_t __ry_string_len(const char *handle) {
+    return ry::stringByteLen(handle);
+}
+
+// NUL-safe string comparison: compares first min(la,lb) bytes with memcmp,
+// then breaks ties by byte length.  Semantics match strcmp for NUL-free strings.
+// Called by codegen for str == / != / < / <= / > / >= operators.
+int32_t __ry_str_cmp(const char *a, int64_t la, const char *b, int64_t lb) {
+    int64_t min_len = la < lb ? la : lb;
+    int r = memcmp(a, b, static_cast<size_t>(min_len));
+    if (r != 0) return r;
+    if (la > lb) return 1;
+    if (la < lb) return -1;
+    return 0;
+}
+
+} // extern "C"

--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -6,6 +6,7 @@
 #include "ry/runtime_alloc.hpp"
 #include "ry/runtime_arc.hpp"
 #include "ry/runtime_list.hpp"
+#include "ry/runtime_string.hpp"
 
 
 namespace ry {
@@ -36,16 +37,30 @@ int64_t __ry_utf8_len(const char *s) {
     return count;
 }
 
+// NUL-safe variant: walks exactly byte_len bytes, counting UTF-8 codepoints.
+// Embedded NUL bytes each count as one character unit.
+int64_t __ry_utf8_len_n(const char *s, int64_t byte_len) {
+    int64_t count = 0;
+    const char *end = s + byte_len;
+    while (s < end) {
+        unsigned char c = static_cast<unsigned char>(*s);
+        if (c == 0) {
+            ++s; // NUL byte is one character unit
+        } else {
+            int step = utf8_char_len_nul(s);
+            s += step;
+        }
+        ++count;
+    }
+    return count;
+}
+
 char *__ry_utf8_char_at(const char *s, int64_t i) {
     const char *p = s;
     for (int64_t idx = 0; *p; ++idx) {
         size_t len = static_cast<size_t>(utf8_char_len_nul(p));
-        if (idx == i) {
-            char *buf = static_cast<char *>(checked_malloc(len + 1));
-            memcpy(buf, p, len);
-            buf[len] = '\0';
-            return buf;
-        }
+        if (idx == i)
+            return makeString(p, len);
         p += len;
     }
     // Safety net: codegen should have caught this via emitBoundsCheck
@@ -61,12 +76,8 @@ char *__ry_utf8_char_at_checked(const char *s, int64_t i) {
         int64_t idx = 0;
         while (*p) {
             size_t len = static_cast<size_t>(utf8_char_len_nul(p));
-            if (idx == i) {
-                char *buf = static_cast<char *>(checked_malloc(len + 1));
-                memcpy(buf, p, len);
-                buf[len] = '\0';
-                return buf;
-            }
+            if (idx == i)
+                return makeString(p, len);
             p += len;
             ++idx;
         }
@@ -98,10 +109,7 @@ char *__ry_utf8_char_at_checked(const char *s, int64_t i) {
         p += utf8_char_len_nul(p);
 
     size_t len = static_cast<size_t>(utf8_char_len_nul(p));
-    char *buf = static_cast<char *>(checked_malloc(len + 1));
-    memcpy(buf, p, len);
-    buf[len] = '\0';
-    return buf;
+    return makeString(p, len);
 }
 
 char *__ry_utf8_substring(const char *s, int64_t start, int64_t endIdx) {
@@ -121,16 +129,13 @@ char *__ry_utf8_substring(const char *s, int64_t start, int64_t endIdx) {
     if (!startPtr) startPtr = endPtr;
 
     size_t byteLen = static_cast<size_t>(endPtr - startPtr);
-    char *buf = static_cast<char *>(checked_malloc(byteLen + 1));
-    memcpy(buf, startPtr, byteLen);
-    buf[byteLen] = '\0';
-    return buf;
+    return makeString(startPtr, byteLen);
 }
 
 char *__ry_utf8_reverse(const char *s) {
     // Collect character byte-offsets and lengths
     size_t totalBytes = strlen(s);
-    char *buf = static_cast<char *>(checked_malloc(totalBytes + 1));
+    char *buf = makeStringUninit(totalBytes);
 
     // First pass: collect codepoint boundaries
     struct CPInfo { const char *ptr; size_t len; };
@@ -155,7 +160,7 @@ char *__ry_utf8_reverse(const char *s) {
         memcpy(dst, cps[i - 1].ptr, cps[i - 1].len);
         dst += cps[i - 1].len;
     }
-    *dst = '\0';
+    // NUL at buf[totalBytes] is already written by makeStringUninit
 
     free(cps);
     return buf;

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -1,4 +1,5 @@
 #include "ry/runtime_alloc.hpp"
+#include "ry/runtime_string.hpp"
 #include "ry/test_runtime.hpp"
 #include <cstdio>
 #include <cstdint>
@@ -152,10 +153,9 @@ const char *__ry_test_rand_str() {
     std::uniform_int_distribution<int> charDist(32, 126); // printable ASCII
     auto &rng = getRng();
     int len = lenDist(rng);
-    char *buf = static_cast<char*>(checked_malloc(static_cast<size_t>(len) + 1));
+    char *buf = makeStringUninit(static_cast<size_t>(len));
     for (int i = 0; i < len; ++i)
         buf[i] = static_cast<char>(charDist(rng));
-    buf[len] = '\0';
     return buf;
 }
 

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -1,3 +1,5 @@
+from io import bytes_to_str, to_bytes
+
 describe("search and check", ():
   it("should check contains", ():
     expect("hello").to_contain("ell")
@@ -311,5 +313,49 @@ describe("type conversion", ():
     expect(to_str(42)).to_eq("42")
     expect(to_str(true)).to_eq("true")
     expect(to_str(99)).to_eq("99")
+  )
+)
+
+describe("NUL byte handling", ():
+  it("byte_len counts embedded NUL bytes", ():
+    expect(byte_len("a\0b")).to_eq(3)
+    expect(byte_len("\0")).to_eq(1)
+    expect(byte_len("\0\0")).to_eq(2)
+    expect(byte_len("")).to_eq(0)
+  )
+  it("length counts all characters including embedded NUL", ():
+    expect(length("a\0b")).to_eq(3)
+    expect(length("\0")).to_eq(1)
+  )
+  it("equality distinguishes strings with embedded NUL", ():
+    expect("a" == "a\0b").to_eq(false)
+    expect("a\0b" == "a\0b").to_eq(true)
+    expect("a\0b" == "a\0c").to_eq(false)
+    expect("a\0" == "a").to_eq(false)
+  )
+  it("concat preserves embedded NUL bytes", ():
+    s = "a\0" + "b\0"
+    expect(byte_len(s)).to_eq(4)
+    s2 = "\0" + "\0"
+    expect(byte_len(s2)).to_eq(2)
+    expect(s2 == "\0\0").to_eq(true)
+  )
+  it("Map<str, T> handles keys with embedded NUL", ():
+    m: Map<str, int> = {"a\0x": 1, "a\0y": 2}
+    expect(m["a\0x"]).to_eq(1)
+    expect(m["a\0y"]).to_eq(2)
+  )
+  it("bytes_to_str round-trips embedded NUL", ():
+    # Use to_bytes to get a byte list from a NUL-containing string,
+    # then verify bytes_to_str recovers the original string.
+    orig = "a\0b"
+    bs = to_bytes(orig)
+    expect(length(bs)).to_eq(3)
+    case bytes_to_str(bs):
+      Ok(s):
+        expect(byte_len(s)).to_eq(3)
+        expect(s == orig).to_eq(true)
+      Err(_):
+        expect(false).to_eq(true)
   )
 )

--- a/tests/test_regex_runtime.cpp
+++ b/tests/test_regex_runtime.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "ry/runtime_arc.hpp"
 #include "ry/runtime_regex.hpp"
+#include "ry/runtime_string.hpp"
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
@@ -145,25 +146,25 @@ TEST(RegexRuntime, SearchNotFound) {
 TEST(RegexRuntime, ReplaceBasic) {
     const char *result = __ry_regex_replace("world", "hello world", "universe");
     EXPECT_STREQ(result, "hello universe");
-    free((void *)result);
+    freeStringSlot(const_cast<char *>(result));
 }
 
 TEST(RegexRuntime, ReplaceAll) {
     const char *result = __ry_regex_replace("[0-9]+", "a1b2c3", "X");
     EXPECT_STREQ(result, "aXbXcX");
-    free((void *)result);
+    freeStringSlot(const_cast<char *>(result));
 }
 
 TEST(RegexRuntime, ReplaceNoMatch) {
     const char *result = __ry_regex_replace("xyz", "hello", "abc");
     EXPECT_STREQ(result, "hello");
-    free((void *)result);
+    freeStringSlot(const_cast<char *>(result));
 }
 
 TEST(RegexRuntime, ReplaceEmpty) {
     const char *result = __ry_regex_replace("x", "xxx", "");
     EXPECT_STREQ(result, "");
-    free((void *)result);
+    freeStringSlot(const_cast<char *>(result));
 }
 
 // ============================================================
@@ -174,70 +175,70 @@ TEST(RegexRuntime, ReplaceCaptureFastPath) {
     // No backreferences → existing fast path, groups have no effect
     const char *r = __ry_regex_replace("(\\d+)", "a1b2", "X");
     EXPECT_STREQ(r, "aXbX");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureWholeMatch) {
     // $0 expands to the whole match
     const char *r = __ry_regex_replace("\\w+", "hello world", "[$0]");
     EXPECT_STREQ(r, "[hello] [world]");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureGroup1) {
     // $1 expands to first capture group
     const char *r = __ry_regex_replace("(\\w+)", "hello world", "[$1]");
     EXPECT_STREQ(r, "[hello] [world]");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureSwapGroups) {
     // Swap two captured words: $2 $1
     const char *r = __ry_regex_replace("(\\w+)@(\\w+)", "user@host", "$2@$1");
     EXPECT_STREQ(r, "host@user");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureThreeGroups) {
     // Date reformat: YYYY-MM-DD → DD/MM/YYYY
     const char *r = __ry_regex_replace("(\\d+)-(\\d+)-(\\d+)", "2026-04-10", "$3/$2/$1");
     EXPECT_STREQ(r, "10/04/2026");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureMultipleMatches) {
     // Multiple matches, each gets its own capture extraction
     const char *r = __ry_regex_replace("(\\w)(\\d)", "a1 b2 c3", "$2$1");
     EXPECT_STREQ(r, "1a 2b 3c");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureLiteralDollar) {
     // $$ → literal $
     const char *r = __ry_regex_replace("(\\d+)", "price 100", "$$$1");
     EXPECT_STREQ(r, "price $100");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureOutOfRange) {
     // $2 when only 1 group → empty string
     const char *r = __ry_regex_replace("(a)", "a", "$2");
     EXPECT_STREQ(r, "");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureNoGroupsWithDollar0) {
     // $0 works even with no capture groups (whole match)
     const char *r = __ry_regex_replace("\\d+", "num 42 num", "($0)");
     EXPECT_STREQ(r, "num (42) num");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureDollarNoDigit) {
     // $ not followed by digit → literal $
     const char *r = __ry_regex_replace("a", "abc", "$ b");
     EXPECT_STREQ(r, "$ bbc");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceCaptureMultiDigitBrace) {
@@ -248,7 +249,7 @@ TEST(RegexRuntime, ReplaceCaptureMultiDigitBrace) {
         "abcdefghij",
         "${10}${9}");
     EXPECT_STREQ(r, "ji");
-    free((void *)r);
+    freeStringSlot(const_cast<char *>(r));
 }
 
 TEST(RegexRuntime, ReplaceMalformedBrace) {
@@ -256,11 +257,11 @@ TEST(RegexRuntime, ReplaceMalformedBrace) {
     // and must be emitted literally in the output.
     const char *r1 = __ry_regex_replace("(a)", "a", "${foo}");
     EXPECT_STREQ(r1, "${foo}");  // non-digit content: literal
-    free((void *)r1);
+    freeStringSlot(const_cast<char *>(r1));
 
     const char *r2 = __ry_regex_replace("(a)", "a", "${}");
     EXPECT_STREQ(r2, "${}");   // empty braces: literal
-    free((void *)r2);
+    freeStringSlot(const_cast<char *>(r2));
 }
 
 // ============================================================
@@ -281,7 +282,7 @@ struct MatchEntry {
 };
 
 static void freeStringList(ListHeader *list) {
-    for (int64_t i = 0; i < list->len; ++i) free(list->data[i]);
+    for (int64_t i = 0; i < list->len; ++i) freeStringSlot(list->data[i]);
     free(list->data);
     arc_free(list); // ListHeader is arc_alloc'd by makeStringList
 }
@@ -289,9 +290,9 @@ static void freeStringList(ListHeader *list) {
 static void freeMatchList(ListHeader *list) {
     auto *entries = (MatchEntry *)list->data;
     for (int64_t i = 0; i < list->len; ++i) {
-        free(entries[i].full);
+        freeStringSlot(entries[i].full);
         auto *groups = (ListHeader *)entries[i].groups;
-        for (int64_t g = 0; g < groups->len; ++g) free(groups->data[g]);
+        for (int64_t g = 0; g < groups->len; ++g) freeStringSlot(groups->data[g]);
         free(groups->data);
         arc_free(groups); // groups ListHeader is arc_alloc'd by makeStringList
     }
@@ -458,12 +459,12 @@ TEST(RegexRuntime, LazyStarReplace) {
     // Greedy: ".*" matches the longest string between first and last quote
     const char *greedy = __ry_regex_replace("\".*\"", "\"a\" and \"b\"", "X");
     EXPECT_STREQ(greedy, "X");
-    free((void *)greedy);
+    freeStringSlot(const_cast<char *>(greedy));
 
     // Lazy: ".*?" matches the shortest string between quotes
     const char *lazy = __ry_regex_replace("\".*?\"", "\"a\" and \"b\"", "X");
     EXPECT_STREQ(lazy, "X and X");
-    free((void *)lazy);
+    freeStringSlot(const_cast<char *>(lazy));
 }
 
 TEST(RegexRuntime, LazyPlusSearch) {
@@ -472,7 +473,7 @@ TEST(RegexRuntime, LazyPlusSearch) {
     // Verify it matched just 1 character by using replace
     const char *result = __ry_regex_replace("a+?", "aaa", "X");
     EXPECT_STREQ(result, "XXX");
-    free((void *)result);
+    freeStringSlot(const_cast<char *>(result));
 }
 
 TEST(RegexRuntime, LazyQuestion) {
@@ -480,14 +481,14 @@ TEST(RegexRuntime, LazyQuestion) {
     const char *result = __ry_regex_replace("a??", "aaa", "X");
     // a?? matches empty string before each char and after last
     EXPECT_STREQ(result, "XaXaXaX");
-    free((void *)result);
+    freeStringSlot(const_cast<char *>(result));
 }
 
 TEST(RegexRuntime, LazyQuantifierBrace) {
     // a{2,4}? prefers matching 2 'a's (minimum)
     const char *result = __ry_regex_replace("a{2,4}?", "aaaa", "X");
     EXPECT_STREQ(result, "XX");
-    free((void *)result);
+    freeStringSlot(const_cast<char *>(result));
 }
 
 TEST(RegexRuntime, LazyFullMatch) {
@@ -501,7 +502,7 @@ TEST(RegexRuntime, LazyPracticalExample) {
     // Replace individual quoted strings
     const char *result = __ry_regex_replace("\"[^\"]*\"", "say \"hello\" and \"world\"", "X");
     EXPECT_STREQ(result, "say X and X");
-    free((void *)result);
+    freeStringSlot(const_cast<char *>(result));
 }
 
 TEST(RegexRuntime, LazyFindAll) {
@@ -594,7 +595,7 @@ TEST(RegexRuntime, CaseInsensitiveSearch) {
 TEST(RegexRuntime, CaseInsensitiveReplace) {
     const char *result = __ry_regex_replace("(?i)hello", "Hello HELLO hello", "X");
     EXPECT_STREQ(result, "X X X");
-    free((void *)result);
+    freeStringSlot(const_cast<char *>(result));
 }
 
 TEST(RegexRuntime, CaseInsensitiveFindAll) {

--- a/tests/test_runtime_any.cpp
+++ b/tests/test_runtime_any.cpp
@@ -39,6 +39,13 @@ static RyAny mkStr(const char *v) {
     return a;
 }
 
+// Free the StringHeader allocated by mkStr.
+static void freeStr(const RyAny &a) {
+    const char *handle;
+    memcpy(&handle, a.data, sizeof(handle));
+    ry::freeStringSlot(const_cast<char *>(handle));
+}
+
 static RyAny mkBool(bool v) {
     RyAny a;
     a.tag = static_cast<int64_t>(RyAnyTag::Bool);
@@ -128,6 +135,7 @@ TEST(RuntimeAnyArith, AddVariants) {
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "hello world");
         freeStringSlot(const_cast<char *>(getStr(&r)));
+        freeStr(a); freeStr(b);
     }
 }
 
@@ -167,6 +175,7 @@ TEST(RuntimeAnyArith, MulVariants) {
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "ababab");
         freeStringSlot(const_cast<char *>(getStr(&r)));
+        freeStr(a);
     }
     // IntTimesStr
     {
@@ -175,6 +184,7 @@ TEST(RuntimeAnyArith, MulVariants) {
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "xyxy");
         freeStringSlot(const_cast<char *>(getStr(&r)));
+        freeStr(b);
     }
     // StrTimesZero
     {
@@ -183,6 +193,7 @@ TEST(RuntimeAnyArith, MulVariants) {
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "");
         freeStringSlot(const_cast<char *>(getStr(&r)));
+        freeStr(a);
     }
     // StrTimesNegative
     {
@@ -191,6 +202,7 @@ TEST(RuntimeAnyArith, MulVariants) {
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "");
         freeStringSlot(const_cast<char *>(getStr(&r)));
+        freeStr(a);
     }
 }
 

--- a/tests/test_runtime_any.cpp
+++ b/tests/test_runtime_any.cpp
@@ -496,6 +496,7 @@ TEST(RuntimeAnyArith, AddIntPlusStr) {
     EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
     EXPECT_STREQ(getStr(&r), "1x");
     freeStringSlot(const_cast<char *>(getStr(&r)));
+    freeStr(b);
 }
 
 TEST(RuntimeAnyArith, AddStrPlusInt) {
@@ -504,6 +505,7 @@ TEST(RuntimeAnyArith, AddStrPlusInt) {
     EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
     EXPECT_STREQ(getStr(&r), "abc2");
     freeStringSlot(const_cast<char *>(getStr(&r)));
+    freeStr(a);
 }
 
 TEST(RuntimeAnyArith, AddFloatPlusStr) {
@@ -512,6 +514,7 @@ TEST(RuntimeAnyArith, AddFloatPlusStr) {
     EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
     EXPECT_STREQ(getStr(&r), "3.14 pi");
     freeStringSlot(const_cast<char *>(getStr(&r)));
+    freeStr(b);
 }
 
 TEST(RuntimeAnyArith, AddBoolPlusStr) {
@@ -520,6 +523,7 @@ TEST(RuntimeAnyArith, AddBoolPlusStr) {
     EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
     EXPECT_STREQ(getStr(&r), "true!");
     freeStringSlot(const_cast<char *>(getStr(&r)));
+    freeStr(b);
 }
 
 TEST_F(RuntimeAnyDeathTest, ArithModAndFloordivByZero) {
@@ -658,7 +662,7 @@ TEST(RuntimeAnyToStringInCollection, StrQuoted) {
     RyAny a = mkStr("hello");
     const char *s = __ry_any_to_string_in_collection(&a);
     EXPECT_STREQ(s, "\"hello\"");
-    // __ry_print_str_quote_escape returns a StringHeader-managed pointer
+    // __ry_str_quote_escape returns a StringHeader-managed pointer
     freeStringSlot(const_cast<char *>(s));
 }
 

--- a/tests/test_runtime_any.cpp
+++ b/tests/test_runtime_any.cpp
@@ -1,4 +1,5 @@
 #include "ry/runtime_any.hpp"
+#include "ry/runtime_string.hpp"
 #include <gtest/gtest.h>
 #include <cstring>
 #include <cstdlib>
@@ -33,7 +34,8 @@ static RyAny mkFloat(double v) {
 static RyAny mkStr(const char *v) {
     RyAny a;
     a.tag = static_cast<int64_t>(RyAnyTag::Str);
-    memcpy(a.data, &v, sizeof(v));
+    const char *handle = makeString(v, strlen(v));
+    memcpy(a.data, &handle, sizeof(handle));
     return a;
 }
 
@@ -125,7 +127,7 @@ TEST(RuntimeAnyArith, AddVariants) {
         __ry_any_add(&r, &a, &b);
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "hello world");
-        free(const_cast<char *>(getStr(&r)));
+        freeStringSlot(const_cast<char *>(getStr(&r)));
     }
 }
 
@@ -164,7 +166,7 @@ TEST(RuntimeAnyArith, MulVariants) {
         __ry_any_mul(&r, &a, &b);
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "ababab");
-        free(const_cast<char *>(getStr(&r)));
+        freeStringSlot(const_cast<char *>(getStr(&r)));
     }
     // IntTimesStr
     {
@@ -172,7 +174,7 @@ TEST(RuntimeAnyArith, MulVariants) {
         __ry_any_mul(&r, &a, &b);
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "xyxy");
-        free(const_cast<char *>(getStr(&r)));
+        freeStringSlot(const_cast<char *>(getStr(&r)));
     }
     // StrTimesZero
     {
@@ -180,7 +182,7 @@ TEST(RuntimeAnyArith, MulVariants) {
         __ry_any_mul(&r, &a, &b);
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "");
-        free(const_cast<char *>(getStr(&r)));
+        freeStringSlot(const_cast<char *>(getStr(&r)));
     }
     // StrTimesNegative
     {
@@ -188,7 +190,7 @@ TEST(RuntimeAnyArith, MulVariants) {
         __ry_any_mul(&r, &a, &b);
         EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
         EXPECT_STREQ(getStr(&r), "");
-        free(const_cast<char *>(getStr(&r)));
+        freeStringSlot(const_cast<char *>(getStr(&r)));
     }
 }
 
@@ -458,7 +460,7 @@ TEST(RuntimeAnyArith, AddIntPlusStr) {
     __ry_any_add(&r, &a, &b);
     EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
     EXPECT_STREQ(getStr(&r), "1x");
-    free(const_cast<char *>(getStr(&r)));
+    freeStringSlot(const_cast<char *>(getStr(&r)));
 }
 
 TEST(RuntimeAnyArith, AddStrPlusInt) {
@@ -466,7 +468,7 @@ TEST(RuntimeAnyArith, AddStrPlusInt) {
     __ry_any_add(&r, &a, &b);
     EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
     EXPECT_STREQ(getStr(&r), "abc2");
-    free(const_cast<char *>(getStr(&r)));
+    freeStringSlot(const_cast<char *>(getStr(&r)));
 }
 
 TEST(RuntimeAnyArith, AddFloatPlusStr) {
@@ -474,7 +476,7 @@ TEST(RuntimeAnyArith, AddFloatPlusStr) {
     __ry_any_add(&r, &a, &b);
     EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
     EXPECT_STREQ(getStr(&r), "3.14 pi");
-    free(const_cast<char *>(getStr(&r)));
+    freeStringSlot(const_cast<char *>(getStr(&r)));
 }
 
 TEST(RuntimeAnyArith, AddBoolPlusStr) {
@@ -482,7 +484,7 @@ TEST(RuntimeAnyArith, AddBoolPlusStr) {
     __ry_any_add(&r, &a, &b);
     EXPECT_EQ(r.tag, static_cast<int64_t>(RyAnyTag::Str));
     EXPECT_STREQ(getStr(&r), "true!");
-    free(const_cast<char *>(getStr(&r)));
+    freeStringSlot(const_cast<char *>(getStr(&r)));
 }
 
 TEST_F(RuntimeAnyDeathTest, ArithDivisionAndModByZero) {
@@ -582,21 +584,21 @@ TEST(RuntimeAnyToString, IntToString) {
     RyAny a = mkInt(42);
     const char *s = __ry_any_to_string(&a);
     EXPECT_STREQ(s, "42");
-    free(const_cast<char*>(s));
+    freeStringSlot(const_cast<char*>(s));
 }
 
 TEST(RuntimeAnyToString, NegativeIntToString) {
     RyAny a = mkInt(-123);
     const char *s = __ry_any_to_string(&a);
     EXPECT_STREQ(s, "-123");
-    free(const_cast<char*>(s));
+    freeStringSlot(const_cast<char*>(s));
 }
 
 TEST(RuntimeAnyToString, FloatToString) {
     RyAny a = mkFloat(3.14);
     const char *s = __ry_any_to_string(&a);
     EXPECT_STREQ(s, "3.14");
-    free(const_cast<char*>(s));
+    freeStringSlot(const_cast<char*>(s));
 }
 
 TEST(RuntimeAnyToString, BoolTrueToString) {
@@ -630,28 +632,29 @@ TEST(RuntimeAnyToStringInCollection, StrQuoted) {
     RyAny a = mkStr("hello");
     const char *s = __ry_any_to_string_in_collection(&a);
     EXPECT_STREQ(s, "\"hello\"");
-    free(const_cast<char*>(s));
+    // __ry_print_str_quote_escape returns a StringHeader-managed pointer
+    freeStringSlot(const_cast<char *>(s));
 }
 
 TEST(RuntimeAnyToStringInCollection, EmptyStrQuoted) {
     RyAny a = mkStr("");
     const char *s = __ry_any_to_string_in_collection(&a);
     EXPECT_STREQ(s, "\"\"");
-    free(const_cast<char*>(s));
+    freeStringSlot(const_cast<char *>(s));
 }
 
 TEST(RuntimeAnyToStringInCollection, IntUnchanged) {
     RyAny a = mkInt(42);
     const char *s = __ry_any_to_string_in_collection(&a);
     EXPECT_STREQ(s, "42");
-    free(const_cast<char*>(s));
+    freeStringSlot(const_cast<char*>(s));
 }
 
 TEST(RuntimeAnyToStringInCollection, FloatUnchanged) {
     RyAny a = mkFloat(3.14);
     const char *s = __ry_any_to_string_in_collection(&a);
     EXPECT_STREQ(s, "3.14");
-    free(const_cast<char*>(s));
+    freeStringSlot(const_cast<char*>(s));
 }
 
 TEST(RuntimeAnyToStringInCollection, BoolUnchanged) {

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -1263,8 +1263,8 @@ TEST(RuntimeHttp, ChunkedResponseSend) {
     map->cap = 1;
     map->keys = (char **)malloc(sizeof(char *));
     map->vals = (char **)malloc(sizeof(char *));
-    map->keys[0] = strdup("Transfer-Encoding");
-    map->vals[0] = strdup("chunked");
+    map->keys[0] = ry::makeString("Transfer-Encoding", 17);
+    map->vals[0] = ry::makeString("chunked", 7);
     map->bucket_count = 4;
     map->buckets = calloc(4, sizeof(int64_t));
 
@@ -1292,8 +1292,8 @@ TEST(RuntimeHttp, ChunkedResponseSend) {
     EXPECT_NE(received.find("b\r\nhello world\r\n0\r\n\r\n"), std::string::npos);
 
     __ry_http_response_free(resp);
-    free(map->keys[0]);
-    free(map->vals[0]);
+    ry::freeStringSlot(map->keys[0]);
+    ry::freeStringSlot(map->vals[0]);
     free(map->keys);
     free(map->vals);
     free(map->buckets);
@@ -1888,7 +1888,9 @@ TEST(RuntimeHttp, ResponseSendBodyWithNulByte) {
     map->bucket_count = 4;
     map->buckets = calloc(4, sizeof(int64_t));
 
-    void *resp = __ry_http_response_create(200, map, ry::makeString("hello world", 11));
+    // Body with embedded NUL: "ab\0cd" (5 bytes).
+    // Content-Length must use byte_len (5), not strlen (2).
+    void *resp = __ry_http_response_create(200, map, ry::makeString("ab\0cd", 5));
 
     auto *handle = (TcpStreamHandle *)malloc(sizeof(TcpStreamHandle));
     handle->fd = fds[0];
@@ -1904,10 +1906,10 @@ TEST(RuntimeHttp, ResponseSendBodyWithNulByte) {
     }
     ::close(fds[1]);
 
-    // Verify Content-Length is 11 (strlen("hello world"))
-    EXPECT_NE(received.find("Content-Length: 11"), std::string::npos);
-    // Verify body is present
-    EXPECT_NE(received.find("hello world"), std::string::npos);
+    // Verify Content-Length uses byte_len (5), not strlen (2)
+    EXPECT_NE(received.find("Content-Length: 5"), std::string::npos);
+    // Verify body bytes "ab\0cd" are present in the wire data
+    EXPECT_NE(received.find(std::string("ab\0cd", 5)), std::string::npos);
 
     __ry_http_response_free(resp);
     free(map->buckets);
@@ -2127,8 +2129,8 @@ static MapHeader *build_response_headers(
     map->buckets = calloc(4, sizeof(int64_t));
     int64_t i = 0;
     for (auto &[k, v] : entries) {
-        map->keys[i] = strdup(k);
-        map->vals[i] = strdup(v);
+        map->keys[i] = ry::makeString(k, strlen(k));
+        map->vals[i] = ry::makeString(v, strlen(v));
         i++;
     }
     return map;
@@ -2136,8 +2138,8 @@ static MapHeader *build_response_headers(
 
 static void free_response_headers(MapHeader *map) {
     for (int64_t i = 0; i < map->len; i++) {
-        free(map->keys[i]);
-        free(map->vals[i]);
+        ry::freeStringSlot(map->keys[i]);
+        ry::freeStringSlot(map->vals[i]);
     }
     free(map->keys);
     free(map->vals);

--- a/tests/test_runtime_http.cpp
+++ b/tests/test_runtime_http.cpp
@@ -11,6 +11,7 @@
 #include "ry/runtime_http_types.hpp"
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_arc.hpp"
+#include "ry/runtime_string.hpp"
 
 
 using namespace ry;
@@ -479,10 +480,10 @@ TEST(RuntimeHttp, QueryAllBasic) {
     EXPECT_STREQ(map->keys[1], "page");
     EXPECT_STREQ(map->vals[1], "2");
 
-    // Cleanup map
+    // Cleanup map (keys/vals are StringHeader-managed via makeString in runtime)
     for (int64_t i = 0; i < map->len; i++) {
-        free(map->keys[i]);
-        free(map->vals[i]);
+        freeStringSlot(map->keys[i]);
+        freeStringSlot(map->vals[i]);
     }
     free(map->keys);
     free(map->vals);
@@ -540,8 +541,8 @@ TEST(RuntimeHttp, QueryAllDuplicateFirstWins) {
     EXPECT_STREQ(map->vals[1], "2");
 
     for (int64_t i = 0; i < map->len; i++) {
-        free(map->keys[i]);
-        free(map->vals[i]);
+        freeStringSlot(map->keys[i]);
+        freeStringSlot(map->vals[i]);
     }
     free(map->keys);
     free(map->vals);
@@ -1031,8 +1032,8 @@ TEST(RuntimeHttp, CookiesAll) {
     EXPECT_STREQ(map->vals[2], "3");
 
     for (int64_t i = 0; i < map->len; i++) {
-        free(map->keys[i]);
-        free(map->vals[i]);
+        freeStringSlot(map->keys[i]);
+        freeStringSlot(map->vals[i]);
     }
     free(map->keys);
     free(map->vals);
@@ -1090,8 +1091,8 @@ TEST(RuntimeHttp, CookiesAllDuplicateFirstWins) {
     EXPECT_STREQ(map->vals[1], "2");
 
     for (int64_t i = 0; i < map->len; i++) {
-        free(map->keys[i]);
-        free(map->vals[i]);
+        freeStringSlot(map->keys[i]);
+        freeStringSlot(map->vals[i]);
     }
     free(map->keys);
     free(map->vals);
@@ -1267,7 +1268,7 @@ TEST(RuntimeHttp, ChunkedResponseSend) {
     map->bucket_count = 4;
     map->buckets = calloc(4, sizeof(int64_t));
 
-    void *resp = __ry_http_response_create(200, map, "hello world");
+    void *resp = __ry_http_response_create(200, map, ry::makeString("hello world", 11));
 
     auto *handle = (TcpStreamHandle *)malloc(sizeof(TcpStreamHandle));
     handle->fd = fds[0];
@@ -1651,8 +1652,8 @@ TEST(RuntimeHttp, FormFileBasic) {
     EXPECT_STREQ(data, "FAKE_PNG_DATA");
 
     for (int64_t i = 0; i < map->len; i++) {
-        free(map->keys[i]);
-        free(map->vals[i]);
+        freeStringSlot(map->keys[i]);
+        freeStringSlot(map->vals[i]);
     }
     free(map->keys);
     free(map->vals);
@@ -1714,8 +1715,8 @@ TEST(RuntimeHttp, FormMixedFieldsAndFiles) {
     EXPECT_STREQ(data, "Hello World");
 
     for (int64_t i = 0; i < map->len; i++) {
-        free(map->keys[i]);
-        free(map->vals[i]);
+        freeStringSlot(map->keys[i]);
+        freeStringSlot(map->vals[i]);
     }
     free(map->keys);
     free(map->vals);
@@ -1764,8 +1765,8 @@ TEST(RuntimeHttp, FormFieldsAll) {
     EXPECT_STREQ(map->vals[1], "2");
 
     for (int64_t i = 0; i < map->len; i++) {
-        free(map->keys[i]);
-        free(map->vals[i]);
+        freeStringSlot(map->keys[i]);
+        freeStringSlot(map->vals[i]);
     }
     free(map->keys);
     free(map->vals);
@@ -1887,7 +1888,7 @@ TEST(RuntimeHttp, ResponseSendBodyWithNulByte) {
     map->bucket_count = 4;
     map->buckets = calloc(4, sizeof(int64_t));
 
-    void *resp = __ry_http_response_create(200, map, "hello world");
+    void *resp = __ry_http_response_create(200, map, ry::makeString("hello world", 11));
 
     auto *handle = (TcpStreamHandle *)malloc(sizeof(TcpStreamHandle));
     handle->fd = fds[0];
@@ -1963,8 +1964,8 @@ TEST(RuntimeHttp, MultipartFileDataWithNulByte) {
     EXPECT_EQ(data[0], 'X');
 
     for (int64_t i = 0; i < file_map->len; i++) {
-        free(file_map->keys[i]);
-        free(file_map->vals[i]);
+        freeStringSlot(file_map->keys[i]);
+        freeStringSlot(file_map->vals[i]);
     }
     free(file_map->keys);
     free(file_map->vals);
@@ -2098,8 +2099,8 @@ TEST(RuntimeHttp, FormFileDefaultContentType) {
     EXPECT_STREQ(ct, "application/octet-stream");
 
     for (int64_t i = 0; i < map->len; i++) {
-        free(map->keys[i]);
-        free(map->vals[i]);
+        freeStringSlot(map->keys[i]);
+        freeStringSlot(map->vals[i]);
     }
     free(map->keys);
     free(map->vals);
@@ -2151,7 +2152,7 @@ TEST(RuntimeHttp, ResponseHeaderCRLFInKeyIsSkipped) {
         {"X-Also-Safe", "fine"},
     });
 
-    void *resp_ptr = __ry_http_response_create(200, map, "body");
+    void *resp_ptr = __ry_http_response_create(200, map, ry::makeString("body", 4));
     auto *resp = (HttpResponseHandle *)resp_ptr;
 
     ASSERT_EQ(resp->header_count, 2);
@@ -2171,7 +2172,7 @@ TEST(RuntimeHttp, ResponseHeaderCRLFInValueIsSkipped) {
         {"X-Also-Safe", "fine"},
     });
 
-    void *resp_ptr = __ry_http_response_create(200, map, "body");
+    void *resp_ptr = __ry_http_response_create(200, map, ry::makeString("body", 4));
     auto *resp = (HttpResponseHandle *)resp_ptr;
 
     ASSERT_EQ(resp->header_count, 2);
@@ -2189,7 +2190,7 @@ TEST(RuntimeHttp, ResponseHeaderLFOnlyIsSkipped) {
         {"X-Clean", "safe"},
     });
 
-    void *resp_ptr = __ry_http_response_create(200, map, "body");
+    void *resp_ptr = __ry_http_response_create(200, map, ry::makeString("body", 4));
     auto *resp = (HttpResponseHandle *)resp_ptr;
 
     ASSERT_EQ(resp->header_count, 1);
@@ -2207,7 +2208,7 @@ TEST(RuntimeHttp, ResponseHeaderSafeHeadersUnaffected) {
         {"Cache-Control", "no-cache"},
     });
 
-    void *resp_ptr = __ry_http_response_create(200, map, "body");
+    void *resp_ptr = __ry_http_response_create(200, map, ry::makeString("body", 4));
     auto *resp = (HttpResponseHandle *)resp_ptr;
 
     ASSERT_EQ(resp->header_count, 3);

--- a/tests/test_runtime_json.cpp
+++ b/tests/test_runtime_json.cpp
@@ -2,6 +2,7 @@
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_list.hpp"
 #include "ry/runtime_arc.hpp"
+#include "ry/runtime_string.hpp"
 #include <gtest/gtest.h>
 #include <cstdlib>
 #include <cstring>
@@ -15,6 +16,13 @@ struct JsonDeleter {
 };
 using JsonPtr = std::unique_ptr<void, JsonDeleter>;
 
+// Helper: retrieve type string, assert it equals expected, then free it.
+static void expectJsonType(void *v, const char *expected) {
+    const char *t = __ry_json_type(v);
+    EXPECT_STREQ(t, expected);
+    freeStringSlot(const_cast<char *>(t));
+}
+
 // ===== Merged parse type tests =====
 
 TEST(RuntimeJson, ParseTypes) {
@@ -22,7 +30,7 @@ TEST(RuntimeJson, ParseTypes) {
     {
         void *v = __ry_json_parse("{\"name\": \"Alice\", \"age\": 30}");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "object");
+        expectJsonType(v, "object");
         EXPECT_EQ(__ry_json_len(v), 2);
         __ry_json_free(v);
     }
@@ -31,7 +39,7 @@ TEST(RuntimeJson, ParseTypes) {
     {
         void *v = __ry_json_parse("[1, 2, 3]");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "array");
+        expectJsonType(v, "array");
         EXPECT_EQ(__ry_json_len(v), 3);
         __ry_json_free(v);
     }
@@ -40,11 +48,11 @@ TEST(RuntimeJson, ParseTypes) {
     {
         void *v = __ry_json_parse("\"hello world\"");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "string");
+        expectJsonType(v, "string");
         const char *s = __ry_json_str(v);
         ASSERT_NE(s, nullptr);
         EXPECT_STREQ(s, "hello world");
-        free((void*)s);
+        freeStringSlot(const_cast<char *>(s));
         __ry_json_free(v);
     }
 
@@ -52,7 +60,7 @@ TEST(RuntimeJson, ParseTypes) {
     {
         void *v = __ry_json_parse("42");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "number");
+        expectJsonType(v, "number");
         int64_t out;
         EXPECT_EQ(__ry_json_int(v, &out), 0);
         EXPECT_EQ(out, 42);
@@ -63,7 +71,7 @@ TEST(RuntimeJson, ParseTypes) {
     {
         void *v = __ry_json_parse("3.14");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "number");
+        expectJsonType(v, "number");
         double out;
         EXPECT_EQ(__ry_json_float(v, &out), 0);
         EXPECT_NEAR(out, 3.14, 0.001);
@@ -74,7 +82,7 @@ TEST(RuntimeJson, ParseTypes) {
     {
         void *v = __ry_json_parse("true");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "boolean");
+        expectJsonType(v, "boolean");
         int64_t out;
         EXPECT_EQ(__ry_json_bool(v, &out), 0);
         EXPECT_EQ(out, 1);
@@ -95,7 +103,7 @@ TEST(RuntimeJson, ParseTypes) {
     {
         void *v = __ry_json_parse("null");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "null");
+        expectJsonType(v, "null");
         __ry_json_free(v);
     }
 }
@@ -134,7 +142,7 @@ TEST(RuntimeJson, AccessTests) {
         const char *s = __ry_json_str(field);
         ASSERT_NE(s, nullptr);
         EXPECT_STREQ(s, "Alice");
-        free((void*)s);
+        freeStringSlot(const_cast<char *>(s));
     }
 
     // GetMissingKey
@@ -193,7 +201,7 @@ TEST(RuntimeJson, NestedObject) {
     const char *s = __ry_json_str(name);
     ASSERT_NE(s, nullptr);
     EXPECT_STREQ(s, "Bob");
-    free((void*)s);
+    freeStringSlot(const_cast<char *>(s));
     __ry_json_free(v);
 }
 
@@ -209,7 +217,7 @@ TEST(RuntimeJson, ObjectKeys) {
     const char **data = (const char**)lh->data;
     EXPECT_STREQ(data[0], "a");
     EXPECT_STREQ(data[1], "b");
-    for (int64_t i = 0; i < lh->len; i++) free((void*)data[i]);
+    for (int64_t i = 0; i < lh->len; i++) freeStringSlot(const_cast<char *>(data[i]));
     free(data);
     arc_free(keys); // ListHeader is arc_alloc'd by makeStringList
 }
@@ -219,7 +227,7 @@ TEST(RuntimeJson, ObjectKeysNullInput) {
     EXPECT_EQ(keys, nullptr);
     const char *err = __ry_get_last_error();
     EXPECT_STREQ(err, "json_keys: value is null");
-    free((void*)err);
+    freeStringSlot(const_cast<char *>(err));
 }
 
 TEST(RuntimeJson, ObjectKeysNonObject) {
@@ -229,7 +237,7 @@ TEST(RuntimeJson, ObjectKeysNonObject) {
     EXPECT_EQ(keys, nullptr);
     const char *err = __ry_get_last_error();
     EXPECT_STREQ(err, "json_keys: value is not an object");
-    free((void*)err);
+    freeStringSlot(const_cast<char *>(err));
 }
 
 TEST(RuntimeJson, ObjectKeysEmptyObject) {
@@ -256,7 +264,7 @@ TEST(RuntimeJson, StringifyTests) {
         void *v2 = __ry_json_parse(s);
         ASSERT_NE(v2, nullptr);
         EXPECT_EQ(__ry_json_len(v2), 2);
-        free((void*)s);
+        freeStringSlot(const_cast<char *>(s));
         __ry_json_free(v);
         __ry_json_free(v2);
     }
@@ -268,7 +276,7 @@ TEST(RuntimeJson, StringifyTests) {
         const char *s = __ry_json_stringify_pretty(v, 2);
         ASSERT_NE(s, nullptr);
         EXPECT_NE(strstr(s, "\n"), nullptr);
-        free((void*)s);
+        freeStringSlot(const_cast<char *>(s));
         __ry_json_free(v);
     }
 }
@@ -281,7 +289,7 @@ TEST(RuntimeJson, StringEscapes) {
     const char *s = __ry_json_str(v);
     ASSERT_NE(s, nullptr);
     EXPECT_STREQ(s, "hello\nworld\t!");
-    free((void*)s);
+    freeStringSlot(const_cast<char *>(s));
     __ry_json_free(v);
 }
 
@@ -291,7 +299,7 @@ TEST(RuntimeJson, UnicodeEscape) {
     const char *s = __ry_json_str(v);
     ASSERT_NE(s, nullptr);
     EXPECT_STREQ(s, "A");
-    free((void*)s);
+    freeStringSlot(const_cast<char *>(s));
     __ry_json_free(v);
 }
 
@@ -342,7 +350,7 @@ TEST(RuntimeJson, NumberConversions) {
     {
         void *v = __ry_json_parse("1.5e10");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "number");
+        expectJsonType(v, "number");
         double out;
         EXPECT_EQ(__ry_json_float(v, &out), 0);
         EXPECT_NEAR(out, 1.5e10, 1e5);
@@ -357,7 +365,7 @@ TEST(RuntimeJson, EmptyContainers) {
     {
         void *v = __ry_json_parse("{}");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "object");
+        expectJsonType(v, "object");
         EXPECT_EQ(__ry_json_len(v), 0);
         __ry_json_free(v);
     }
@@ -366,7 +374,7 @@ TEST(RuntimeJson, EmptyContainers) {
     {
         void *v = __ry_json_parse("[]");
         ASSERT_NE(v, nullptr);
-        EXPECT_STREQ(__ry_json_type(v), "array");
+        expectJsonType(v, "array");
         EXPECT_EQ(__ry_json_len(v), 0);
         __ry_json_free(v);
     }

--- a/tests/test_runtime_print.cpp
+++ b/tests/test_runtime_print.cpp
@@ -1,4 +1,5 @@
 #include "ry/runtime_print.hpp"
+#include "ry/runtime_string.hpp"
 #include <gtest/gtest.h>
 #include <cstdlib>
 
@@ -31,6 +32,6 @@ TEST(RuntimePrintTest, SprintNestingWorks) {
     char *outer = __ry_sprint_end();
     EXPECT_STREQ(inner, "inner");
     EXPECT_STREQ(outer, "outer + done");
-    free(inner);
-    free(outer);
+    freeStringSlot(inner);
+    freeStringSlot(outer);
 }

--- a/tests/test_runtime_string.cpp
+++ b/tests/test_runtime_string.cpp
@@ -1,0 +1,167 @@
+#include "ry/runtime_string.hpp"
+#include "ry/ry_layout.hpp"
+#include <gtest/gtest.h>
+#include <cstring>
+
+
+using namespace ry;
+
+// ===== Layout constants =====
+
+TEST(StringHeader, LayoutConstants) {
+    EXPECT_EQ(STRING_HEADER_EXTRA, 8u);
+    EXPECT_EQ(STRING_HEADER_SIZE,  24u);
+    EXPECT_EQ(STRING_BYTELEN_OFFSET, 8);
+    // STRING_HEADER_SIZE = ARC_HEADER_SIZE (16) + byte_len field (8)
+    EXPECT_EQ(STRING_HEADER_SIZE, ARC_HEADER_SIZE + 8u);
+}
+
+// ===== makeString =====
+
+TEST(StringHeader, MakeStringEmpty) {
+    char *s = makeString("", 0);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(stringByteLen(s), 0);
+    EXPECT_EQ(s[0], '\0');
+    freeStringSlot(s);
+}
+
+TEST(StringHeader, MakeStringBasic) {
+    char *s = makeString("hello", 5);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(stringByteLen(s), 5);
+    EXPECT_STREQ(s, "hello");
+    EXPECT_EQ(s[5], '\0');
+    freeStringSlot(s);
+}
+
+TEST(StringHeader, MakeStringWithEmbeddedNul) {
+    const char src[] = {'a', '\0', 'b'};
+    char *s = makeString(src, 3);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(stringByteLen(s), 3);
+    EXPECT_EQ(s[0], 'a');
+    EXPECT_EQ(s[1], '\0');
+    EXPECT_EQ(s[2], 'b');
+    EXPECT_EQ(s[3], '\0');  // null terminator
+    freeStringSlot(s);
+}
+
+TEST(StringHeader, MakeStringNullSrcBecomesEmpty) {
+    char *s = makeString(nullptr, 42);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(stringByteLen(s), 0);
+    EXPECT_EQ(s[0], '\0');
+    freeStringSlot(s);
+}
+
+TEST(StringHeader, MakeStringSingleNulByte) {
+    const char src[] = {'\0'};
+    char *s = makeString(src, 1);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(stringByteLen(s), 1);
+    EXPECT_EQ(s[0], '\0');
+    EXPECT_EQ(s[1], '\0');  // terminator
+    freeStringSlot(s);
+}
+
+// ===== makeStringUninit =====
+
+TEST(StringHeader, MakeStringUninitSetsLenAndTerminator) {
+    char *s = makeStringUninit(7);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(stringByteLen(s), 7);
+    EXPECT_EQ(s[7], '\0');
+    freeStringSlot(s);
+}
+
+TEST(StringHeader, MakeStringUninitZeroLength) {
+    char *s = makeStringUninit(0);
+    ASSERT_NE(s, nullptr);
+    EXPECT_EQ(stringByteLen(s), 0);
+    EXPECT_EQ(s[0], '\0');
+    freeStringSlot(s);
+}
+
+// ===== stringByteLen =====
+
+TEST(StringHeader, ByteLenReflectsActualLength) {
+    char *s = makeString("xyz", 3);
+    EXPECT_EQ(stringByteLen(s), 3);
+    freeStringSlot(s);
+}
+
+TEST(StringHeader, ByteLenCountsEmbeddedNulBytes) {
+    const char src[] = {'\0', '\0', '\0'};
+    char *s = makeString(src, 3);
+    EXPECT_EQ(stringByteLen(s), 3);  // not 0
+    freeStringSlot(s);
+}
+
+TEST(StringHeader, ByteLenIsIndependentOfStrcmp) {
+    // Two strings that differ only beyond the first NUL
+    const char a_src[] = {'a', '\0', 'x'};
+    const char b_src[] = {'a', '\0', 'y'};
+    char *a = makeString(a_src, 3);
+    char *b = makeString(b_src, 3);
+    EXPECT_EQ(stringByteLen(a), 3);
+    EXPECT_EQ(stringByteLen(b), 3);
+    // strcmp sees them as equal (stops at '\0'), but they differ at byte 2
+    EXPECT_EQ(strcmp(a, b), 0);  // both look like "a" to strcmp
+    EXPECT_EQ(a[2], 'x');
+    EXPECT_EQ(b[2], 'y');
+    freeStringSlot(a);
+    freeStringSlot(b);
+}
+
+// ===== stringHeaderPtr =====
+
+TEST(StringHeader, HeaderPtrIsOffsetBeforeData) {
+    char *s = makeString("test", 4);
+    char *hdr = stringHeaderPtr(s);
+    EXPECT_EQ(hdr, s - static_cast<ptrdiff_t>(STRING_HEADER_SIZE));
+    // strong_count at offset 0, weak_count at offset 8, byte_len at offset 16
+    auto *block = reinterpret_cast<int64_t *>(hdr);
+    EXPECT_EQ(block[0], 1);   // strong_count = 1 (not immortal for dynamic alloc)
+    EXPECT_EQ(block[1], 0);   // weak_count = 0
+    EXPECT_EQ(block[2], 4);   // byte_len = 4
+    freeStringSlot(s);
+}
+
+// ===== freeStringSlot =====
+
+TEST(StringHeader, FreeStringSlotNullIsNoop) {
+    // Should not crash
+    freeStringSlot(nullptr);
+}
+
+// ===== NUL-safe operations =====
+
+TEST(StringHeader, MemcmpCanDistinguishNulEmbeddedStrings) {
+    const char a_src[] = {'a', '\0', 'b'};
+    const char b_src[] = {'a', '\0', 'c'};
+    char *a = makeString(a_src, 3);
+    char *b = makeString(b_src, 3);
+    EXPECT_EQ(stringByteLen(a), 3);
+    EXPECT_EQ(stringByteLen(b), 3);
+    int cmp = memcmp(a, b, static_cast<size_t>(stringByteLen(a)));
+    EXPECT_LT(cmp, 0);  // 'b' < 'c'
+    freeStringSlot(a);
+    freeStringSlot(b);
+}
+
+TEST(StringHeader, ConcatViaMemcpy) {
+    const char a_src[] = {'a', '\0'};
+    const char b_src[] = {'b', '\0'};
+    int64_t la = 2, lb = 2;
+    char *buf = makeStringUninit(static_cast<size_t>(la + lb));
+    memcpy(buf, a_src, static_cast<size_t>(la));
+    memcpy(buf + la, b_src, static_cast<size_t>(lb));
+    EXPECT_EQ(stringByteLen(buf), 4);
+    EXPECT_EQ(buf[0], 'a');
+    EXPECT_EQ(buf[1], '\0');
+    EXPECT_EQ(buf[2], 'b');
+    EXPECT_EQ(buf[3], '\0');
+    EXPECT_EQ(buf[4], '\0');  // null terminator
+    freeStringSlot(buf);
+}

--- a/tests/test_runtime_utf8.cpp
+++ b/tests/test_runtime_utf8.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include "ry/runtime_string.hpp"
 #include <cstdlib>
 
 
@@ -11,10 +12,10 @@ int64_t __ry_utf8_char_index(const char *s, int64_t byte_offset);
 char *__ry_utf8_char_at_checked(const char *s, int64_t i);
 }
 
-// Helper: compare and free
+// Helper: compare and free (runtime_utf8 returns StringHeader-managed pointers)
 static void expectStr(char *got, const char *expected) {
     EXPECT_STREQ(got, expected);
-    free(got);
+    ry::freeStringSlot(got);
 }
 
 TEST(RuntimeUtf8, LenAscii) {


### PR DESCRIPTION
## Summary

- Introduces `StringHeader` layout (`strong_count`, `weak_count`, `byte_len` prefix, 24 bytes before the data pointer) for all `str` values, enabling NUL-safe operations without breaking `@native` / libc compatibility (the handle is still a plain `char*` with a NUL terminator)
- Migrates all str-returning runtime functions (path, http, base64, json, io, utf8, print, error, regex, any, etc.) from `strdup`/`checked_malloc` to `makeString()` / `makeStringUninit()`
- Makes the following operations fully NUL-safe: `byte_len`, `length`, `==`, `!=`, `<`, `>`, `+`, `*`, hash, Map/Set key lookup, `bytes_to_str`
- Adds `tests/test_runtime_string.cpp` (15 C++ unit tests) and a `NUL byte handling` describe block in `tests/spec/strings.test.ry`
- Adds `include/ry/runtime_string.hpp` / `src/runtime_string.cpp` with `makeString`, `makeStringUninit`, `stringByteLen`, `freeStringSlot` helpers
- Updates `docs/reference/types.md` and `docs/reference/builtins-string.md` with NUL-byte semantics

## Operations still truncating at NUL (tracked in follow-up issues)

`contains`, `starts_with`, `ends_with`, `find`, `replace`, `substring`, `char_at`, `trim*`, `to_upper`, `to_lower`, `split`, `join`, `repeat`, regex, JSON stringify, HTTP/path/filesystem C API boundaries — see #1047–#1054.

## Follow-up issues filed

- #1046 — str ARC management (eliminate string leaks)
- #1047 — `contains` / `starts_with` / `ends_with` / `find` NUL-safe
- #1048 — `replace` NUL-safe
- #1049 — `substring` / `char_at` / UTF-8 traversal NUL-safe
- #1050 — `to_upper` / `to_lower` / `trim*` NUL-safe
- #1051 — `split` / `join` / `repeat` NUL-safe
- #1052 — regex NUL-safe
- #1053 — JSON stringify NUL escape (`\u0000`)
- #1054 — C API boundary validation (http, path, filesystem, net)
- #1055 — `bytes_to_str([...])` literal layout mismatch bug

## Test plan

- [x] `cmake --build build && ./build/ry_tests` — 1701 tests passed
- [x] `./build/ry test -p` — 130 test files, 0 failures
- [x] ASan + UBSan: 0 errors
- [x] TSan: 0 races
- [x] Manual: `byte_len("a\0b") == 3`, `"a\0b" == "a\0b"`, Map keys with NUL, `bytes_to_str` round-trip

Closes #1022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * str now supports embedded NUL bytes; byte_len counts embedded NULs and string ops (length, concatenation, repetition, hashing, Map/Set keys) are NUL-safe.
  * Strings are now returned/managed as runtime-backed string objects with unified allocation/deallocation semantics.

* **Bug Fixes**
  * Fixed comparisons, ordering and hashing to be length-aware (no premature truncation).
  * Fixed weak-reference upgrade correctness for str.

* **Documentation**
  * Updated string reference and type docs with byte_len and NUL-safety details.

* **Tests**
  * Added comprehensive tests for NUL handling and runtime string behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->