### PR TITLE
fix(codegen): accept -9223372036854775808 (INT64_MIN) as bare int literal (#1025)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2457,3 +2457,30 @@ This produces the correct unified `Result<T, Error>` StructType that both `Ok` a
 **Analogous gap for Option**: `Some`/`None()` in an `if`-expr body has the same structural problem (#1043). The Option merge logic mirrors the Result one but must handle the Option StructType layout instead of `getResultType`.
 
 **How to check for new gaps**: When adding a new ADT constructor or a new expression-level control-flow node, grep for both `inferExprType` and `inferExprTypeName` and verify each has a case for the new node. A missing case is a silent wrong-type inference, not a compile error.
+
+### UnaryExpr fast-path covers bare int for INT64_MIN (`-9223372036854775808`)
+
+**Source**: #1025 (2026-04-16)
+**Tags**: codegen, numeric-literal, unary-minus, int64-min, ubsan
+
+**Rule**: The `-<NumberExpr>` fast-path in `src/codegen_expr.cpp::emitExprVariant(UnaryExpr)`
+accepts bare int (empty suffix) as equivalent to `i64` for the magnitude check
+(`|INT64_MIN|` = 2^63). A standalone `9223372036854775808` without the unary minus must
+still be rejected by the bare-`NumberExpr` path (`value < 0` check).
+
+Magnitude > 2^63 on the bare path produces `"integer literal out of range for int: -<mag>"`
+(matching the existing bare-int error wording); the signed-suffix path keeps the
+`"<suffix> literal out of range: -<mag>"` wording.
+
+**UB fix**: The original computation `static_cast<uint64_t>(-static_cast<int64_t>(mag))`
+is signed-integer UB when `mag == 2^63` (negation of INT64_MIN overflows). Use
+unsigned two's-complement arithmetic instead:
+```cpp
+const uint64_t negBits = static_cast<uint64_t>(0) - mag;  // well-defined, same bits
+```
+This also applies to the signed-suffix path — add `-9223372036854775808i64` to
+`SignedSuffixMinAcceptedViaUnaryMinus` to keep it covered.
+
+**How to apply**: If you touch this fast-path, keep the bare-int branch in sync with the
+signed-low-level-suffix branch. Always use unsigned subtraction for `negBits`; never
+negate a `uint64_t` value via `static_cast<int64_t>` when the magnitude may equal 2^(N-1).

--- a/changelog.d/1025-int64-min-bare-literal.md
+++ b/changelog.d/1025-int64-min-bare-literal.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `-9223372036854775808` (INT64_MIN) is now accepted as a bare integer
+  literal. Previously it required the `i64` suffix or a workaround
+  such as `-9223372036854775807 - 1`. A standalone
+  `9223372036854775808` (without the unary minus) remains rejected,
+  and `-9223372036854775809` is rejected at compile time (#1025).

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -170,7 +170,7 @@ The accepted magnitude is determined by the target type:
 | `u8` / `u16` / `u32` | `0 .. 2^N - 1` |
 | `u64` | `0 .. 18_446_744_073_709_551_615` (2^64 − 1) |
 
-Large unsigned literals require either a suffix (`18446744073709551615u64`) or a type annotation on the receiving variable (`x: u64 = 18446744073709551615`). Negative literals arrive as a unary minus on a non-negative magnitude, so `-1i8` is accepted while `-1u8` is rejected.
+Large unsigned literals require either a suffix (`18446744073709551615u64`) or a type annotation on the receiving variable (`x: u64 = 18446744073709551615`). Negative literals arrive as a unary minus on a non-negative magnitude, so `-1i8` is accepted while `-1u8` is rejected. The bare `int` minimum `-9223372036854775808` (INT64_MIN) can be written directly as a literal; the positive form `9223372036854775808` (without the leading `-`) is rejected.
 
 ```python
 max_u64: u64 = 18446744073709551615     # 2^64 - 1

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -237,23 +237,36 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
 }
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<UnaryExpr> &e) {
-    // Constant-fold `-<signed low-level int literal>` before recursing into
-    // emitExpr, so that magnitudes up to `|INT{N}_MIN|` are accepted (e.g.
-    // `-128i8`, `-9223372036854775808i64`). validateIntRange limits a bare
-    // NumberExpr to INT{N}_MAX; the unary-minus wrapper is the only way to
-    // reach the signed MIN edge.
+    // Constant-fold `-<int literal>` before recursing into emitExpr, so that
+    // magnitudes up to `|INT{N}_MIN|` are accepted (e.g. `-128i8`,
+    // `-9223372036854775808i64`, `-9223372036854775808`). validateIntRange
+    // limits a bare NumberExpr to INT{N}_MAX; the unary-minus wrapper is the
+    // only way to reach the signed MIN edge. Bare int (empty suffix) is
+    // treated as i64 (#1025).
     if (e->op == "-") {
         if (auto *ne = std::get_if<NumberExpr>(&e->operand->data)) {
-            if (!ne->suffix.empty() && isLowLevelTypeName(ne->suffix) &&
-                !isUnsignedLowLevelName(ne->suffix) && ne->suffix != "f32") {
-                llvm::Type *ty = resolveType(ne->suffix);
-                unsigned bits = ty->getIntegerBitWidth();
-                uint64_t absMin = static_cast<uint64_t>(1) << (bits - 1);
-                uint64_t mag = static_cast<uint64_t>(ne->value);
-                if (mag > absMin)
-                    codegenError(ne->suffix + " literal out of range: -" +
-                                 std::to_string(mag));
-                uint64_t negBits = static_cast<uint64_t>(-static_cast<int64_t>(mag));
+            const bool isBareInt = ne->suffix.empty();
+            const bool isSignedSuffix =
+                !ne->suffix.empty() && isLowLevelTypeName(ne->suffix) &&
+                !isUnsignedLowLevelName(ne->suffix) && ne->suffix != "f32";
+            if (isBareInt || isSignedSuffix) {
+                llvm::Type *ty = isBareInt ? i64Ty_ : resolveType(ne->suffix);
+                const unsigned bits = ty->getIntegerBitWidth();
+                const uint64_t absMin = static_cast<uint64_t>(1) << (bits - 1);
+                const uint64_t mag = static_cast<uint64_t>(ne->value);
+                if (mag > absMin) {
+                    if (isBareInt)
+                        codegenError(
+                            "integer literal out of range for int: -" +
+                            std::to_string(mag));
+                    else
+                        codegenError(ne->suffix + " literal out of range: -" +
+                                     std::to_string(mag));
+                }
+                // Unsigned two's-complement negation avoids signed overflow
+                // when mag == 2^63 (INT64_MIN). Equivalent to
+                // -static_cast<int64_t>(mag) for all representable values.
+                const uint64_t negBits = static_cast<uint64_t>(0) - mag;
                 return llvm::ConstantInt::get(ty, negBits, /*isSigned=*/false);
             }
         }

--- a/tests/spec/int_overflow.test.ry
+++ b/tests/spec/int_overflow.test.ry
@@ -40,4 +40,10 @@ describe("int overflow safety", ():
     x *= 2
     expect(x).to_eq(500)
   )
+  it("should parse INT64_MIN as a direct literal", ():
+    min_direct = -9223372036854775808
+    expect(min_direct).to_eq(-9223372036854775807 - 1)
+    expect(min_direct + 1).to_eq(-9223372036854775807)
+    expect(min_direct - 0).to_eq(-9223372036854775807 - 1)
+  )
 )

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1411,6 +1411,23 @@ TEST_F(CodeGenTest, I64MaxPlus1BareIntRejected) {
                  std::runtime_error);
 }
 
+// #1025 – bare int INT64_MIN literal support
+TEST_F(CodeGenTest, NegInt64MinBareLiteralAccepted) {
+    EXPECT_EQ(runSource("x = -9223372036854775808\nprint(x)"),
+              "-9223372036854775808\n");
+}
+
+TEST_F(CodeGenTest, NegBareIntMagnitudeOverI64MinRejected) {
+    EXPECT_THROW(runSource("x = -9223372036854775809\nprint(x)"),
+                 std::runtime_error);
+}
+
+TEST_F(CodeGenTest, NegInt64MinBareNegatedRuntimeOverflow) {
+    EXPECT_EXIT(runSource("x = -9223372036854775808\nprint(-x)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: integer overflow");
+}
+
 TEST_F(CodeGenTest, U64OverflowInCodegenRejected) {
     EXPECT_THROW(runSource("x: u64 = 18446744073709551616\nprint(x)"),
                  std::runtime_error);
@@ -1460,6 +1477,8 @@ TEST_F(CodeGenTest, SignedSuffixMinAcceptedViaUnaryMinus) {
     EXPECT_EQ(runSource("x = -128i8\nprint(x as int)"), "-128\n");
     EXPECT_EQ(runSource("x = -32768i16\nprint(x as int)"), "-32768\n");
     EXPECT_EQ(runSource("x = -2147483648i32\nprint(x as int)"), "-2147483648\n");
+    EXPECT_EQ(runSource("x = -9223372036854775808i64\nprint(x)"),
+              "-9223372036854775808\n");
 }
 
 TEST_F(CodeGenTest, U64ArrayInitializerMax) {


### PR DESCRIPTION
## Summary

- Widens the `UnaryExpr` fast-path guard in `emitExprVariant` (`src/codegen_expr.cpp`) to accept a bare `int` (empty suffix) as equivalent to `i64`, enabling `-9223372036854775808` to constant-fold to a `ConstantInt` instead of being rejected
- Fixes a pre-existing signed-integer UB in `negBits` computation: replaces `static_cast<uint64_t>(-static_cast<int64_t>(mag))` with the UB-free form `static_cast<uint64_t>(0) - mag`; UBSan now passes for all signed paths including `-9223372036854775808i64`
- Rejected cases remain unchanged: `9223372036854775808` (no unary minus) → compile error; `-9223372036854775809` (magnitude > 2^63) → compile error; `-(-9223372036854775808)` → runtime overflow exit

## Test plan

- [x] `NegInt64MinBareLiteralAccepted` — bare `-9223372036854775808` prints correctly
- [x] `NegBareIntMagnitudeOverI64MinRejected` — `-9223372036854775809` rejected at compile time
- [x] `NegInt64MinBareNegatedRuntimeOverflow` — `-(-9223372036854775808)` exits with overflow
- [x] `SignedSuffixMinAcceptedViaUnaryMinus` extended with `-9223372036854775808i64` case
- [x] `tests/spec/int_overflow.test.ry` — new `should parse INT64_MIN as a direct literal` block
- [x] All 1690 C++ tests green (default, ASan+UBSan, TSan)
- [x] All 131 Ry spec files green (default, ASan+UBSan)

Closes #1025

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The minimum 64-bit integer literal `-9223372036854775808` can now be written directly without an `i64` suffix, previously requiring explicit type annotation or workarounds.

* **Documentation**
  * Updated type reference documentation to clarify the rules for large integer literals, including the newly supported minimum value syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->