### PR TITLE
feat(codegen): accept int in checked_*/saturating_*/wrapping_* builtins

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2484,3 +2484,33 @@ This also applies to the signed-suffix path — add `-9223372036854775808i64` to
 **How to apply**: If you touch this fast-path, keep the bare-int branch in sync with the
 signed-low-level-suffix branch. Always use unsigned subtraction for `negBits`; never
 negate a `uint64_t` value via `static_cast<int64_t>` when the magnitude may equal 2^(N-1).
+
+---
+
+### `low_level_type_name` mix check: convert empty metadata to "int" before comparing
+
+**Source**: PR #1063 (CodeRabbit review). **Tags**: codegen, type-metadata, checked-arithmetic, mix-check
+
+The three-way guard `!lhsName.empty() && !rhsName.empty() && lhsName != rhsName` is
+insufficient when one side is bare `int` (empty metadata) and the other is a named low-level
+type (e.g. `"i64"`): both conditions involving emptiness are false, so the mix silently passes.
+
+**Why**: `getLowLevelTypeName` returns `""` for `int` (no `low_level_type_name` metadata). The
+three-way check only fires when *both* names are non-empty.
+
+**How to apply**: Map empty metadata to a display sentinel before comparing:
+
+```cpp
+const std::string &lhsLL = getLowLevelTypeName(lhs);
+const std::string &rhsLL = getLowLevelTypeName(rhs);
+const std::string lhsName = lhsLL.empty() ? "int" : lhsLL;
+const std::string rhsName = rhsLL.empty() ? "int" : rhsLL;
+if (lhsName != rhsName)
+    codegenError(callee + "() cannot mix " + lhsName + " and " + rhsName);
+```
+
+Two bare `int` args (`"int" == "int"`) correctly pass; `int`+`i64` (`"int" != "i64"`) is caught.
+
+**Corollary — testing int vs. low-level mix**: A bare literal `1` alongside `1i64` may be
+coerced to `i64` by type inference, so `checked_add(1, 1i64)` appears to succeed. Use typed
+variables (`a = 1; b: i64 = 2i64`) to force the mix in tests.

--- a/changelog.d/1028-checked-arith-int.md
+++ b/changelog.d/1028-checked-arith-int.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `checked_add`, `checked_sub`, `checked_mul`, `saturating_add`, `saturating_sub`, `saturating_mul`, `wrapping_add`, `wrapping_sub`, `wrapping_mul` now accept the high-level `int` type in addition to low-level integer types (`i8`..`i64`, `u8`..`u64`) (#1028)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -44,14 +44,16 @@
 
 ### Checked Arithmetic
 
+All functions accept `int` or any low-level integer type (`i8`..`i64`, `u8`..`u64`). Both arguments must be the same type.
+
 | Function | Description |
 |------|------|
 | `checked_add(a, b)` | Returns `Ok(a + b)` if no overflow, otherwise `Err(Error("arithmetic overflow"))` |
 | `checked_sub(a, b)` | Returns `Ok(a - b)` if no overflow, otherwise `Err(Error("arithmetic overflow"))` |
 | `checked_mul(a, b)` | Returns `Ok(a * b)` if no overflow, otherwise `Err(Error("arithmetic overflow"))` |
-| `saturating_add(a, b)` | Returns `a + b`, clamped to `int` range on overflow |
-| `saturating_sub(a, b)` | Returns `a - b`, clamped to `int` range on overflow |
-| `saturating_mul(a, b)` | Returns `a * b`, clamped to `int` range on overflow |
+| `saturating_add(a, b)` | Returns `a + b`, clamped to operand type's min/max on overflow |
+| `saturating_sub(a, b)` | Returns `a - b`, clamped to operand type's min/max on overflow |
+| `saturating_mul(a, b)` | Returns `a * b`, clamped to operand type's min/max on overflow |
 | `wrapping_add(a, b)` | Returns `a + b` with wrapping on overflow |
 | `wrapping_sub(a, b)` | Returns `a - b` with wrapping on overflow |
 | `wrapping_mul(a, b)` | Returns `a * b` with wrapping on overflow |

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -770,7 +770,7 @@ v4 = -v1        # Vec2(-1.0, -2.0)
 
 ## Checked/Saturating Arithmetic
 
-Built-in functions for explicit overflow control on low-level integer types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`). Both arguments must be the same type.
+Built-in functions for explicit overflow control on integer types (`int`, `i8`..`i64`, `u8`..`u64`). Both arguments must be the same type.
 
 | Function | Returns | Behavior |
 |----------|---------|----------|
@@ -785,6 +785,14 @@ Built-in functions for explicit overflow control on low-level integer types (`i8
 | `wrapping_mul(a, b)` | `T` | Explicit wrapping (same as `*`) |
 
 ```python
+# int: trap-free checked arithmetic (default + on int traps on overflow)
+r = checked_add(9223372036854775807, 1)
+case r:
+  Ok(v):
+    print(v)
+  Err(e):
+    print("overflow!")   # prints "overflow!"
+
 # Checked: returns Result, use match or ? to handle
 r = checked_add(2147483647i32, 1i32)
 case r:
@@ -802,4 +810,4 @@ v = wrapping_add(2147483647i32, 1i32)
 print(v as int)   # -2147483648
 ```
 
-> **Note**: These functions do not support floating-point types (`f32`) or the high-level `int` type. The default `+`, `-`, `*` operators on low-level integers use wrapping behavior (two's complement for signed, modular for unsigned).
+> **Note**: These functions do not support floating-point types (`f32`). The default `+`, `-`, `*` operators on `int` trap on overflow; on low-level integers they use wrapping behavior (two's complement for signed, modular for unsigned).

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -780,9 +780,9 @@ Built-in functions for explicit overflow control on integer types (`int`, `i8`..
 | `saturating_add(a, b)` | `T` | Clamps to type min/max on overflow |
 | `saturating_sub(a, b)` | `T` | Clamps to type min/max on underflow |
 | `saturating_mul(a, b)` | `T` | Clamps to type min/max on overflow |
-| `wrapping_add(a, b)` | `T` | Explicit wrapping (same as `+`) |
-| `wrapping_sub(a, b)` | `T` | Explicit wrapping (same as `-`) |
-| `wrapping_mul(a, b)` | `T` | Explicit wrapping (same as `*`) |
+| `wrapping_add(a, b)` | `T` | Explicit wrapping on overflow |
+| `wrapping_sub(a, b)` | `T` | Explicit wrapping on underflow |
+| `wrapping_mul(a, b)` | `T` | Explicit wrapping on overflow |
 
 ```python
 # int: trap-free checked arithmetic (default + on int traps on overflow)

--- a/src/codegen_arith.cpp
+++ b/src/codegen_arith.cpp
@@ -24,11 +24,15 @@ void CodeGen::validateCheckedArithArgs(llvm::Value *lhs, llvm::Value *rhs,
     if (!ty->isIntegerTy())
         codegenError(callee + "() requires integer type arguments (int, i8..i64, u8..u64)");
 
-    const std::string &lhsName = getLowLevelTypeName(lhs);
-    const std::string &rhsName = getLowLevelTypeName(rhs);
+    // Treat bare int (empty metadata) as "int" for display and mix checking.
+    // Without this, int+i64 would pass because only one side is empty.
+    const std::string &lhsLL = getLowLevelTypeName(lhs);
+    const std::string &rhsLL = getLowLevelTypeName(rhs);
+    const std::string lhsName = lhsLL.empty() ? "int" : lhsLL;
+    const std::string rhsName = rhsLL.empty() ? "int" : rhsLL;
 
-    // Check signed/unsigned consistency
-    if (!lhsName.empty() && !rhsName.empty() && lhsName != rhsName)
+    // Check type consistency: int+int is fine, i32+i32 is fine, int+i32 is not.
+    if (lhsName != rhsName)
         codegenError(callee + "() cannot mix " + lhsName + " and " + rhsName);
 }
 

--- a/src/codegen_arith.cpp
+++ b/src/codegen_arith.cpp
@@ -6,12 +6,12 @@ namespace ry {
 
 // ===== Checked/Saturating/Wrapping Arithmetic =====
 //
-// These builtins provide explicit overflow control for low-level integer types.
+// These builtins provide explicit overflow control for integer types (int, i8..i64, u8..u64).
 // - checked_*  : returns Result<T, Error> (Err on overflow)
-// - saturating_*: returns T (clamped to min/max on overflow)
+// - saturating_*: returns T (clamped to operand type's min/max on overflow)
 // - wrapping_* : returns T (wraps, same as default +/-/*)
 
-// Shared validation: both args must be the same low-level integer type
+// Shared validation: both args must be the same integer type
 void CodeGen::validateCheckedArithArgs(llvm::Value *lhs, llvm::Value *rhs,
                                         const std::string &callee) {
     if (lhs->getType() != rhs->getType())
@@ -22,14 +22,10 @@ void CodeGen::validateCheckedArithArgs(llvm::Value *lhs, llvm::Value *rhs,
         codegenError(callee + "() does not support floating-point types");
 
     if (!ty->isIntegerTy())
-        codegenError(callee + "() requires low-level integer type arguments");
+        codegenError(callee + "() requires integer type arguments (int, i8..i64, u8..u64)");
 
     const std::string &lhsName = getLowLevelTypeName(lhs);
     const std::string &rhsName = getLowLevelTypeName(rhs);
-
-    // For i64 type, require metadata to distinguish i64/u64 from high-level int
-    if (ty->isIntegerTy(64) && lhsName.empty() && rhsName.empty())
-        codegenError(callee + "() requires low-level integer type arguments, not int");
 
     // Check signed/unsigned consistency
     if (!lhsName.empty() && !rhsName.empty() && lhsName != rhsName)

--- a/tests/spec/checked_arith.test.ry
+++ b/tests/spec/checked_arith.test.ry
@@ -75,4 +75,24 @@ describe("checked arithmetic", ():
       Err(e):
         expect(true).to_eq(false)
   )
+  it("should return ok for checked_add with int", ():
+    r = checked_add(10, 20)
+    case r:
+      Ok(v):
+        expect(v).to_eq(30)
+      Err(e):
+        expect(true).to_eq(false)
+  )
+  it("should return error for checked_add int overflow", ():
+    r = checked_add(9223372036854775807, 1)
+    case r:
+      Ok(v):
+        expect(true).to_eq(false)
+      Err(e):
+        expect(true).to_eq(true)
+  )
+  it("should wrap on wrapping_add with int", ():
+    v = wrapping_add(9223372036854775807, 1)
+    expect(v).to_eq(-9223372036854775808)
+  )
 )

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1002,8 +1002,32 @@ TEST_F(CodeGenTest, CheckedTypeMismatch) {
     EXPECT_THROW(runSource("checked_add(1i32, 1i16)"), std::runtime_error);
 }
 
-TEST_F(CodeGenTest, CheckedNonLowLevel) {
-    EXPECT_THROW(runSource("checked_add(1, 2)"), std::runtime_error);
+TEST_F(CodeGenTest, CheckedIntOk) {
+    EXPECT_EQ(runSource(
+        "r = checked_add(1, 2)\n"
+        "case r:\n"
+        "  Ok(v): print(v)\n"
+        "  Err(e): print(\"err\")"),
+        "3\n");
+}
+
+TEST_F(CodeGenTest, CheckedIntOverflow) {
+    EXPECT_EQ(runSource(
+        "r = checked_add(9223372036854775807, 1)\n"
+        "case r:\n"
+        "  Ok(v): print(v)\n"
+        "  Err(e): print(\"overflow\")"),
+        "overflow\n");
+}
+
+TEST_F(CodeGenTest, SaturatingIntMax) {
+    EXPECT_EQ(runSource("print(saturating_add(9223372036854775807, 100))"),
+        "9223372036854775807\n");
+}
+
+TEST_F(CodeGenTest, WrappingIntOverflow) {
+    EXPECT_EQ(runSource("print(wrapping_add(9223372036854775807, 1))"),
+        "-9223372036854775808\n");
 }
 
 TEST_F(CodeGenTest, CheckedFloat) {

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1002,6 +1002,13 @@ TEST_F(CodeGenTest, CheckedTypeMismatch) {
     EXPECT_THROW(runSource("checked_add(1i32, 1i16)"), std::runtime_error);
 }
 
+TEST_F(CodeGenTest, CheckedIntMixedLowLevel) {
+    // int (no metadata) must not silently mix with a named low-level type.
+    // Use typed variables to force int vs i64 — a bare literal 1 alongside
+    // 1i64 can be coerced to i64 by type inference.
+    EXPECT_THROW(runSource("a = 1\nb: i64 = 2i64\nchecked_add(a, b)"), std::runtime_error);
+}
+
 TEST_F(CodeGenTest, CheckedIntOk) {
     EXPECT_EQ(runSource(
         "r = checked_add(1, 2)\n"


### PR DESCRIPTION
## Summary

- Remove the bare-i64 guard in `validateCheckedArithArgs` that rejected the high-level `int` type
- `checked_add/sub/mul`, `saturating_add/sub/mul`, `wrapping_add/sub/mul` now accept `int` and route through the signed overflow-intrinsic path (signed because bare `i64` has no low-level metadata)
- Fix misleading "clamped to \`int\` range" wording in `docs/reference/builtins.md` → "clamped to operand type's min/max"

## Test plan

- [x] Replaced `CheckedNonLowLevel` (reject test) with `CheckedIntOk` (positive test)
- [x] Added `CheckedIntOverflow`, `SaturatingIntMax`, `WrappingIntOverflow` C++ tests
- [x] Added 3 Ry spec cases to `tests/spec/checked_arith.test.ry` (`checked_add` ok/overflow, `wrapping_add` wrap)
- [x] All 1693 C++ tests pass; 131 Ry self-test files pass
- [x] ASan+UBSan clean; TSan clean

Closes #1028

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checked, saturating, and wrapping arithmetic functions now accept the high-level `int` type alongside low-level integer types (`i8`–`i64`, `u8`–`u64`).

* **Documentation**
  * Enhanced arithmetic function documentation with `int` type support details, usage examples, and overflow handling clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->