### PR TITLE
test(collections): regression tests for #1033 (reduce untyped + for-loop mutation gaps)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2407,6 +2407,44 @@ coverage. For uninitialized-read detection specifically, use MemorySanitizer (MS
 than ASan — ASan detects memory-access errors (buffer overflows, use-after-free) but does
 not detect uninit reads.
 
+### `fold()` rejects untyped lambda with type-check error (#1061)
+
+**Source**: #1061 (2026-04-16, discovered during pre-verification for #1033)
+**Tags**: codegen, fold, untyped-lambda, type-check
+
+**Context**: `fold(xs, 0, (a, b) => a + b)` produces a compile error:
+`fold() initial value type must match function return type`. Unlike `reduce()` which was
+patched in #1020 to accept untyped lambdas, `fold()` was not given the same treatment.
+The type-check logic in `fold`'s emitter validates that the initial value type matches the
+lambda's return type; when both params are untyped the lambda returns `any`, while `0` is
+inferred as `int` — causing the mismatch.
+
+**Rule**: When applying a fix for untyped-lambda compatibility to one higher-order function
+(e.g., `reduce`), audit all sibling functions with similar emitters (`fold`, `scan`, etc.)
+for the same gap. Do not assume a fix to one function automatically covers others.
+
+**How to verify**: Issue #1061 tracks the fix. Until resolved, `fold` only works with typed
+lambda params (e.g., `(a: int, b: int) => a + b`).
+
+### `reduce()` rejects `(a, b) -> ReturnType => body` annotation when params are untyped (#1062)
+
+**Source**: #1062 (2026-04-16, discovered during pre-verification for #1033)
+**Tags**: codegen, reduce, lambda, return-type-annotation, untyped-params
+
+**Context**: `reduce([1,2,3,4,5], (a, b) -> int => a + b)` produces:
+`lambda expression return type mismatch: expected 'int', found 'any'`. When lambda params
+are untyped they default to `any`, so `a + b` is inferred as `any`. The explicit `-> int`
+annotation then conflicts with `any` at the type-check stage.
+
+**Rule**: The `(params) -> ReturnType => body` annotation form does NOT widen param types
+to match the declared return type — it only asserts that the body's inferred type matches
+`ReturnType`. If params are `any`, the body is `any`, and `any != int` is a hard error.
+To use a return-type annotation with this pattern, params must also be typed:
+`(a: int, b: int) -> int => a + b`.
+
+**How to verify**: Issue #1062 tracks the fix. Until resolved, use fully typed params when
+combining `reduce`/`fold` with an explicit return-type annotation.
+
 ### Skill `allowed-tools` must cover all Bash commands the skill body prescribes
 
 **Source**: #1045 (2026-04-16, CodeRabbit review)

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -97,6 +97,10 @@ describe("List", ():
     xs = [1, 2, 3, 4, 5]
     expect(reduce(xs, (a, b) => a + b)).to_eq(fold(xs, 0, (a: int, b: int) => a + b))
   )
+  it("should match fold result when using untyped reduce on float list", ():
+    xs = [1.0, 2.0, 3.0, 4.0, 5.0]
+    expect(reduce(xs, (a, b) => a + b)).to_eq(fold(xs, 0.0, (a: float, b: float) => a + b))
+  )
   it("should fold", ():
     xs = [1, 2, 3, 4, 5]
     total = fold(xs, 0, (a: int, b: int) => a + b)

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -90,6 +90,13 @@ describe("List", ():
   it("should reduce float list with untyped lambda", ():
     expect(reduce([1.0, 2.0, 3.0], (a, b) => a + b)).to_eq(6.0)
   )
+  it("should reduce 1-element list with untyped lambda", ():
+    expect(reduce([42], (a, b) => a + b)).to_eq(42)
+  )
+  it("should match fold result when using untyped reduce", ():
+    xs = [1, 2, 3, 4, 5]
+    expect(reduce(xs, (a, b) => a + b)).to_eq(fold(xs, 0, (a: int, b: int) => a + b))
+  )
   it("should fold", ():
     xs = [1, 2, 3, 4, 5]
     total = fold(xs, 0, (a: int, b: int) => a + b)

--- a/tests/spec/for_mutation.test.ry
+++ b/tests/spec/for_mutation.test.ry
@@ -86,4 +86,18 @@ describe("for mutation safety", ():
       seen_sum = seen_sum + x
     expect(seen_sum).to_eq(60)
   )
+
+  it("should visit all elements including those appended before the loop", ():
+    # Control case for #1021: append! OUTSIDE a for loop should make the new
+    # elements visible to subsequent iteration, in contrast to the snapshot
+    # behavior for in-loop append!.
+    ys = [10, 20]
+    append!(ys, 30)
+    append!(ys, 40)
+    seen_sum = 0
+    for y in ys:
+      seen_sum = seen_sum + y
+    expect(seen_sum).to_eq(100)
+    expect(length(ys)).to_eq(4)
+  )
 )


### PR DESCRIPTION
## Summary

Closes #1033 (partial — fills remaining checklist gaps after fix PRs #1038 and #1039 already added the primary regression tests).

- Add `reduce` 1-element identity test: verifies the lambda-not-called code path with untyped params
- Add `reduce`/`fold` cross-check: untyped `reduce` vs typed `fold` must return the same result
- Add pre-loop `append!` control test to `for_mutation.test.ry`: negative control demonstrating that elements appended **before** a loop (outside the snapshot) are visible, contrasting with the in-loop snapshot semantics fixed in #1021

Two annotation-matrix variants (fold untyped lambda, reduce `-> int` annotation) were verified during pre-verification and found to be broken — filed as separate issues rather than including broken tests:
- **#1061**: `fold()` rejects untyped lambda (`fold() initial value type must match function return type`)
- **#1062**: `reduce()` rejects `(a, b) -> int => expr` when params are untyped (`lambda expression return type mismatch: expected 'int', found 'any'`)

KNOWLEDGE.md entries added for both newly discovered bugs.

## Test plan

- [x] `./build/ry test tests/spec/collections.test.ry` — 137 passed, 0 failed
- [x] `./build/ry test tests/spec/for_mutation.test.ry` — 9 passed, 0 failed
- [x] `./build/ry_tests && ./build/ry test -p` — all pass
- [x] ASan + UBSan — clean
- [x] TSan — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded documentation for `fold()` and `reduce()` functions with additional technical guidance.

* **Tests**
  * Added comprehensive test coverage for `reduce()` function behavior with various input scenarios.
  * Enhanced safety verification for `for` loops to cover element appending during iteration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->