### PR TITLE
fix(codegen): enable implicit any-widening for collection element writes (#1029)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2566,3 +2566,47 @@ This also applies to the signed-suffix path — add `-9223372036854775808i64` to
 **How to apply**: If you touch this fast-path, keep the bare-int branch in sync with the
 signed-low-level-suffix branch. Always use unsigned subtraction for `negBits`; never
 negate a `uint64_t` value via `static_cast<int64_t>` when the magnitude may equal 2^(N-1).
+
+### New collection element-write emitters must apply the canonical any-widening pattern
+
+**Source**: #1029 (2026-04-16)
+**Tags**: codegen, any, widening, collections, Map, List, Set
+
+**Rule**: Every site that writes a value into a collection element slot (`Map` index-assign,
+`List` index-assign, `List.append!`, `List.appended`, `List.insert`, `Set.add`) must apply the
+canonical 3-branch widening pattern immediately after `emitExpr` on the RHS value:
+
+```cpp
+if (val->getType() != elemTy) {
+    if (isAnyType(elemTy))
+        val = wrapInAny(val);           // concrete → any
+    else if (isAnyType(val->getType()) && canAnyHoldType(elemTy))
+        val = unwrapFromAny(val, elemTy); // any → concrete (runtime-checked)
+    else
+        codegenError("... type mismatch");
+}
+```
+
+For `List` index-assign, the existing `tryEmitSubtypeCoerce` check must remain first.
+
+**Why**: Without widening, `m["name"] = "Alice"` on `Map<str, any>` fails with "type mismatch"
+even though `any` is documented to accept implicit conversion from all primitives.
+
+**Files**: `src/codegen_stmt_misc.cpp` (map + list index-assign) and
+`src/codegen_call_collection.cpp` (add, append, appended, insert).
+When adding a new collection mutation emitter, apply this pattern immediately.
+
+### `Set<any>` element comparison requires `emitAnyBinaryOp`, not `emitComparisonOp`
+
+**Source**: #1029 (2026-04-16)
+**Tags**: codegen, any, Set, emitSetElementLookup, LLVM, icmp
+
+**Rule**: `anyTy_` is a 16-byte struct `{i64 tag, [8 x i8] data}`. The `[8 x i8]`
+array field cannot be used as an operand to `icmp eq` — LLVM IR verification rejects it.
+
+In `emitSetElementLookup` (`src/codegen_builtin.cpp`), when `isAnyType(elemTy)`,
+replace `emitComparisonOp("==", elem, cand, "", "")` with
+`emitAnyBinaryOp("==", elem, cand)`, which calls `__ry_any_eq` at runtime.
+
+The linear-scan path is taken automatically for `anyTy_` because it is a `StructType`
+(`llvm::isa<llvm::StructType>(elemTy)` is true), so no additional predicate is needed.

--- a/changelog.d/1029-any-collection-widening.md
+++ b/changelog.d/1029-any-collection-widening.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `Map<K, any>`, `List<any>`, and `Set<any>` now accept direct assignment of concrete values (`str`, `int`, `float`, `bool`). Previously, assignments like `m["name"] = "Alice"` or `xs.append!(42)` would fail with a type mismatch error even though the `any` type is documented to support implicit conversion. The fix applies the canonical widening pattern to six collection element-write sites: `Map` index-assign, `List` index-assign, `List.append!`, `List.appended`, `List.insert`, and `Set.add`. The symmetric unwrap direction (`any` → concrete) is also supported at all six sites, and `Set<any>` element comparison uses the `__ry_any_eq` runtime function. (#1029)

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -384,6 +384,7 @@ llvm::Value *CodeGen::emitSetElementLookup(llvm::Value *setPtr, llvm::Value *ele
         (!elemName.empty() && elemName != "str" &&
          elemName != "int" && elemName != "float" && elemName != "bool");
     if (needsLinearScan) {
+        const bool elemIsAny = isAnyType(elemTy);
         auto sf = loadSetHeader(setPtr, "slin");
         llvm::AllocaInst *resVar = builder_.CreateAlloca(i64Ty_, nullptr, "slin_res");
         builder_.CreateStore(llvm::ConstantInt::getSigned(i64Ty_, -1), resVar);
@@ -403,7 +404,9 @@ llvm::Value *CodeGen::emitSetElementLookup(llvm::Value *setPtr, llvm::Value *ele
         llvm::Value *cand = builder_.CreateLoad(elemTy, cp, "slin_cand");
         if (!elemName.empty())
             propagateTypeMeta(elemName, cand);
-        llvm::Value *eq = emitComparisonOp("==", elem, cand, "", "");
+        llvm::Value *eq = elemIsAny
+                              ? emitAnyBinaryOp("==", elem, cand)
+                              : emitComparisonOp("==", elem, cand, "", "");
         builder_.CreateCondBr(eq, matchBB, nextBB);
         builder_.SetInsertPoint(matchBB);
         builder_.CreateStore(j, resVar);
@@ -432,6 +435,7 @@ llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, ll
         // The "__record__" sentinel opts into the linear scan for StructType keys
         // when map_key_type_name is absent; skip propagateTypeMeta in that case
         // since the sentinel is not a valid Ry type name.
+        const bool keyIsAny = isAnyType(keyTy);
         if (keyName != "__record__")
             propagateTypeMeta(keyName, key);
         auto mf = loadMapHeader(mapPtr, "mklin");
@@ -454,7 +458,9 @@ llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, ll
         // cand changes each iteration; propagate per-iteration (skip sentinel).
         if (keyName != "__record__")
             propagateTypeMeta(keyName, cand);
-        llvm::Value *eq = emitComparisonOp("==", key, cand, "", "");
+        llvm::Value *eq = keyIsAny
+                              ? emitAnyBinaryOp("==", key, cand)
+                              : emitComparisonOp("==", key, cand, "", "");
         builder_.CreateCondBr(eq, matchBB, nextBB);
         builder_.SetInsertPoint(matchBB);
         builder_.CreateStore(j, resVar);

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -390,6 +390,18 @@ llvm::Value *CodeGen::emitSetElementLookup(llvm::Value *setPtr, llvm::Value *ele
         builder_.CreateStore(llvm::ConstantInt::getSigned(i64Ty_, -1), resVar);
         llvm::AllocaInst *jVar = builder_.CreateAlloca(i64Ty_, nullptr, "slin_j");
         builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), jVar);
+        // For Set<any>, hoist scratch alloca/store for the search element outside
+        // the loop so emitAnyBinaryOp does not create new allocas every iteration.
+        llvm::AllocaInst *anyElemPtr = nullptr;
+        llvm::AllocaInst *anyCandPtr = nullptr;
+        llvm::FunctionCallee anyEqFn;
+        if (elemIsAny) {
+            anyElemPtr = builder_.CreateAlloca(anyTy_, nullptr, "slin.any.elem");
+            builder_.CreateStore(elem, anyElemPtr);
+            anyCandPtr = builder_.CreateAlloca(anyTy_, nullptr, "slin.any.cand");
+            llvm::FunctionType *fnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, ptrTy_}, false);
+            anyEqFn = mod_->getOrInsertFunction("__ry_any_eq", fnTy);
+        }
         llvm::BasicBlock *condBB  = llvm::BasicBlock::Create(*ctx_, "slin.cond",  fn_);
         llvm::BasicBlock *bodyBB  = llvm::BasicBlock::Create(*ctx_, "slin.body",  fn_);
         llvm::BasicBlock *matchBB = llvm::BasicBlock::Create(*ctx_, "slin.match", fn_);
@@ -404,9 +416,14 @@ llvm::Value *CodeGen::emitSetElementLookup(llvm::Value *setPtr, llvm::Value *ele
         llvm::Value *cand = builder_.CreateLoad(elemTy, cp, "slin_cand");
         if (!elemName.empty())
             propagateTypeMeta(elemName, cand);
-        llvm::Value *eq = elemIsAny
-                              ? emitAnyBinaryOp("==", elem, cand)
-                              : emitComparisonOp("==", elem, cand, "", "");
+        llvm::Value *eq;
+        if (elemIsAny) {
+            builder_.CreateStore(cand, anyCandPtr);
+            llvm::Value *r = builder_.CreateCall(anyEqFn, {anyElemPtr, anyCandPtr}, "slin.any.eq");
+            eq = builder_.CreateICmpNE(r, builder_.getInt64(0), "slin.any.eq.bool");
+        } else {
+            eq = emitComparisonOp("==", elem, cand, "", "");
+        }
         builder_.CreateCondBr(eq, matchBB, nextBB);
         builder_.SetInsertPoint(matchBB);
         builder_.CreateStore(j, resVar);
@@ -422,12 +439,13 @@ llvm::Value *CodeGen::emitSetElementLookup(llvm::Value *setPtr, llvm::Value *ele
 
 llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, llvm::Type *keyTy,
                                         const std::string &keyName) {
-    // Named non-primitive keys (records, tuples, List<T>, Map<K,V>, Set<T>) have no
+    // Named non-primitive keys (records, tuples, List<T>, Map<K,V>, Set<T>, any) have no
     // runtime hash function.  Use a structural O(n) linear scan over mf.keys.
-    // The caller must pass a non-empty keyName to opt into this path; callers that
-    // do not (get(), remove(), merge(), etc.) keep the existing hash-table behavior
-    // so that non-equality operations are not affected.  Mirrors emitSetElementLookup.
+    // `any` keys always require linear scan regardless of whether the caller
+    // passed a keyName, since emitHashTableLookup has no hash path for anyTy_.
+    const bool keyIsAny = isAnyType(keyTy);
     const bool needsLinearScan =
+        keyIsAny ||
         (!keyName.empty() && keyName != "str" &&
          keyName != "int" && keyName != "float" && keyName != "bool");
     if (needsLinearScan) {
@@ -435,14 +453,25 @@ llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, ll
         // The "__record__" sentinel opts into the linear scan for StructType keys
         // when map_key_type_name is absent; skip propagateTypeMeta in that case
         // since the sentinel is not a valid Ry type name.
-        const bool keyIsAny = isAnyType(keyTy);
-        if (keyName != "__record__")
+        if (!keyIsAny && keyName != "__record__")
             propagateTypeMeta(keyName, key);
         auto mf = loadMapHeader(mapPtr, "mklin");
         llvm::AllocaInst *resVar = builder_.CreateAlloca(i64Ty_, nullptr, "mklin_res");
         builder_.CreateStore(llvm::ConstantInt::getSigned(i64Ty_, -1), resVar);
         llvm::AllocaInst *jVar = builder_.CreateAlloca(i64Ty_, nullptr, "mklin_j");
         builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), jVar);
+        // For Map<any, V>, hoist scratch alloca/store for the search key outside
+        // the loop so the comparison does not create new allocas every iteration.
+        llvm::AllocaInst *anyKeyPtr = nullptr;
+        llvm::AllocaInst *anyKeyCandPtr = nullptr;
+        llvm::FunctionCallee anyEqFn;
+        if (keyIsAny) {
+            anyKeyPtr = builder_.CreateAlloca(anyTy_, nullptr, "mklin.any.key");
+            builder_.CreateStore(key, anyKeyPtr);
+            anyKeyCandPtr = builder_.CreateAlloca(anyTy_, nullptr, "mklin.any.cand");
+            llvm::FunctionType *fnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, ptrTy_}, false);
+            anyEqFn = mod_->getOrInsertFunction("__ry_any_eq", fnTy);
+        }
         llvm::BasicBlock *condBB  = llvm::BasicBlock::Create(*ctx_, "mklin.cond",  fn_);
         llvm::BasicBlock *bodyBB  = llvm::BasicBlock::Create(*ctx_, "mklin.body",  fn_);
         llvm::BasicBlock *matchBB = llvm::BasicBlock::Create(*ctx_, "mklin.match", fn_);
@@ -455,12 +484,17 @@ llvm::Value *CodeGen::emitMapKeyLookup(llvm::Value *mapPtr, llvm::Value *key, ll
         builder_.SetInsertPoint(bodyBB);
         llvm::Value *cp   = builder_.CreateGEP(keyTy, mf.keys, {j}, "mklin_cp");
         llvm::Value *cand = builder_.CreateLoad(keyTy, cp, "mklin_cand");
-        // cand changes each iteration; propagate per-iteration (skip sentinel).
-        if (keyName != "__record__")
+        // cand changes each iteration; propagate per-iteration (skip any and sentinel).
+        if (!keyIsAny && keyName != "__record__")
             propagateTypeMeta(keyName, cand);
-        llvm::Value *eq = keyIsAny
-                              ? emitAnyBinaryOp("==", key, cand)
-                              : emitComparisonOp("==", key, cand, "", "");
+        llvm::Value *eq;
+        if (keyIsAny) {
+            builder_.CreateStore(cand, anyKeyCandPtr);
+            llvm::Value *r = builder_.CreateCall(anyEqFn, {anyKeyPtr, anyKeyCandPtr}, "mklin.any.eq");
+            eq = builder_.CreateICmpNE(r, builder_.getInt64(0), "mklin.any.eq.bool");
+        } else {
+            eq = emitComparisonOp("==", key, cand, "", "");
+        }
         builder_.CreateCondBr(eq, matchBB, nextBB);
         builder_.SetInsertPoint(matchBB);
         builder_.CreateStore(j, resVar);

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -47,8 +47,14 @@ llvm::Value *CodeGen::emitCollOp_add(const CallExpr &e) {
     if (elemTy) {
         setPtr = emitCowCheck(setPtr, receiverAlloca, CollectionKind::Set);
         llvm::Value *elem = emitExpr(*e.args[1]);
-        if (elem->getType() != elemTy)
-            codegenError("add() element type mismatch");
+        if (elem->getType() != elemTy) {
+            if (isAnyType(elemTy))
+                elem = wrapInAny(elem);
+            else if (isAnyType(elem->getType()) && canAnyHoldType(elemTy))
+                elem = unwrapFromAny(elem, elemTy);
+            else
+                codegenError("add() element type mismatch");
+        }
 
         std::string addElemName = getSetElemName(setPtr);
         validateSetElemType(addElemName, elem, "add()");
@@ -360,8 +366,14 @@ llvm::Value *CodeGen::emitCollOp_append(const CallExpr &e) {
     if (elemTy) {
         listPtr = emitCowCheck(listPtr, receiverAlloca, CollectionKind::List);
         llvm::Value *val = emitExpr(*e.args[1]);
-        if (val->getType() != elemTy)
-            codegenError("append() element type mismatch");
+        if (val->getType() != elemTy) {
+            if (isAnyType(elemTy))
+                val = wrapInAny(val);
+            else if (isAnyType(val->getType()) && canAnyHoldType(elemTy))
+                val = unwrapFromAny(val, elemTy);
+            else
+                codegenError("append() element type mismatch");
+        }
 
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t elemSize = dl.getTypeAllocSize(elemTy);
@@ -414,8 +426,14 @@ llvm::Value *CodeGen::emitCollOp_appended(const CallExpr &e) {
     llvm::Type *elemTy = getListElementType(listPtr);
     if (elemTy) {
         llvm::Value *val = emitExpr(*e.args[1]);
-        if (val->getType() != elemTy)
-            codegenError("appended() element type mismatch");
+        if (val->getType() != elemTy) {
+            if (isAnyType(elemTy))
+                val = wrapInAny(val);
+            else if (isAnyType(val->getType()) && canAnyHoldType(elemTy))
+                val = unwrapFromAny(val, elemTy);
+            else
+                codegenError("appended() element type mismatch");
+        }
 
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t elemSize = dl.getTypeAllocSize(elemTy);
@@ -587,8 +605,14 @@ llvm::Value *CodeGen::emitCollOp_insert(const CallExpr &e) {
         if (idx->getType() != i64Ty_)
             codegenError("insert() index must be int");
         llvm::Value *val = emitExpr(*e.args[2]);
-        if (val->getType() != elemTy)
-            codegenError("insert() element type mismatch");
+        if (val->getType() != elemTy) {
+            if (isAnyType(elemTy))
+                val = wrapInAny(val);
+            else if (isAnyType(val->getType()) && canAnyHoldType(elemTy))
+                val = unwrapFromAny(val, elemTy);
+            else
+                codegenError("insert() element type mismatch");
+        }
 
         const llvm::DataLayout &dl = mod_->getDataLayout();
         uint64_t elemSize = dl.getTypeAllocSize(elemTy);

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -777,8 +777,14 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
             return;
         }
 
-        if (rhsVal->getType() != mapValTy)
-            codegenError("map value type mismatch");
+        if (rhsVal->getType() != mapValTy) {
+            if (isAnyType(mapValTy))
+                rhsVal = wrapInAny(rhsVal);
+            else if (isAnyType(rhsVal->getType()) && canAnyHoldType(mapValTy))
+                rhsVal = unwrapFromAny(rhsVal, mapValTy);
+            else
+                codegenError("map value type mismatch");
+        }
 
         llvm::Value *idx = emitMapKeyLookup(objPtr, key, mapKeyTy);
         llvm::Value *found = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "found");
@@ -931,6 +937,10 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     if (finalVal->getType() != elemTy) {
         if (auto *sliced = tryEmitSubtypeCoerce(finalVal, elemTy))
             finalVal = sliced;
+        else if (isAnyType(elemTy))
+            finalVal = wrapInAny(finalVal);
+        else if (isAnyType(finalVal->getType()) && canAnyHoldType(elemTy))
+            finalVal = unwrapFromAny(finalVal, elemTy);
         else
             codegenError("list element type mismatch in index assignment");
     }

--- a/tests/spec/any.test.ry
+++ b/tests/spec/any.test.ry
@@ -410,3 +410,138 @@ describe("any to concrete conversion", ():
     expect(x).to_eq(99)
   )
 )
+
+describe("any element in Map", ():
+  it("should accept str value in Map<str, any>", ():
+    m: Map<str, any> = {}
+    m["name"] = "Alice"
+    v: str = m["name"]
+    expect(v).to_eq("Alice")
+  )
+  it("should accept int value in Map<str, any>", ():
+    m: Map<str, any> = {}
+    m["age"] = 30
+    v: int = m["age"]
+    expect(v).to_eq(30)
+  )
+  it("should accept float value in Map<str, any>", ():
+    m: Map<str, any> = {}
+    m["pi"] = 3.14
+    v: float = m["pi"]
+    expect(v).to_eq(3.14)
+  )
+  it("should accept bool value in Map<str, any>", ():
+    m: Map<str, any> = {}
+    m["flag"] = true
+    v: bool = m["flag"]
+    expect(v).to_eq(true)
+  )
+  it("should update existing key with new concrete value", ():
+    m: Map<str, any> = {}
+    m["x"] = 1
+    m["x"] = "updated"
+    v: str = m["x"]
+    expect(v).to_eq("updated")
+  )
+  it("should unwrap any value into Map<str, int>", ():
+    v: any = 42
+    m: Map<str, int> = {}
+    m["x"] = v
+    expect(m["x"]).to_eq(42)
+  )
+)
+
+describe("any element in List", ():
+  it("should append! str to List<any>", ():
+    xs: List<any> = []
+    append!(xs, "hello")
+    v: str = xs[0]
+    expect(v).to_eq("hello")
+  )
+  it("should append! int to List<any>", ():
+    xs: List<any> = []
+    append!(xs, 42)
+    v: int = xs[0]
+    expect(v).to_eq(42)
+  )
+  it("should append! float to List<any>", ():
+    xs: List<any> = []
+    append!(xs, 3.14)
+    v: float = xs[0]
+    expect(v).to_eq(3.14)
+  )
+  it("should append! bool to List<any>", ():
+    xs: List<any> = []
+    append!(xs, true)
+    v: bool = xs[0]
+    expect(v).to_eq(true)
+  )
+  it("should use appended with concrete value on List<any>", ():
+    xs: List<any> = []
+    ys = appended(xs, "new")
+    v: str = ys[0]
+    expect(v).to_eq("new")
+  )
+  it("should insert concrete value into List<any>", ():
+    xs: List<any> = []
+    append!(xs, 99)
+    insert(xs, 0, "first")
+    v: str = xs[0]
+    expect(v).to_eq("first")
+  )
+  it("should assign concrete value at index in List<any>", ():
+    xs: List<any> = []
+    append!(xs, 0)
+    xs[0] = 99
+    v: int = xs[0]
+    expect(v).to_eq(99)
+  )
+  it("should unwrap any value into List<int>", ():
+    v: any = 7
+    xs: List<int> = [1, 2, 3]
+    xs[0] = v
+    expect(xs[0]).to_eq(7)
+  )
+  it("should support compound assign += on List<any>", ():
+    xs: List<any> = []
+    append!(xs, 10)
+    xs[0] += 5
+    v: int = xs[0]
+    expect(v).to_eq(15)
+  )
+)
+
+describe("any element in Set", ():
+  it("should add str to Set<any>", ():
+    s: Set<any> = {}
+    add(s, "x")
+    expect(s).to_have_length(1)
+  )
+  it("should add int to Set<any>", ():
+    s: Set<any> = {}
+    add(s, 1)
+    expect(s).to_have_length(1)
+  )
+  it("should add float to Set<any>", ():
+    s: Set<any> = {}
+    add(s, 3.14)
+    expect(s).to_have_length(1)
+  )
+  it("should add bool to Set<any>", ():
+    s: Set<any> = {}
+    add(s, true)
+    expect(s).to_have_length(1)
+  )
+  it("should add multiple distinct concrete types to Set<any>", ():
+    s: Set<any> = {}
+    add(s, "x")
+    add(s, 1)
+    expect(s).to_have_length(2)
+  )
+  it("should unwrap any value into Set<int>", ():
+    v: any = 5
+    s: Set<int> = {}
+    add(s, v)
+    expect(5 in s).to_eq(true)
+  )
+)

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -310,3 +310,31 @@ TEST_F(CodeGenTest, MapAnyValueRejectsCollectionType) {
         "m[\"bad\"] = [1, 2, 3]\n",
         "'any' can only hold int/float/bool/str");
 }
+
+TEST_F(CodeGenTest, SetAddAnyRejectsCollectionType) {
+    expectCompileError(
+        "s: Set<any> = {}\n"
+        "add(s, [1, 2, 3])\n",
+        "'any' can only hold int/float/bool/str");
+}
+
+TEST_F(CodeGenTest, ListAppendAnyRejectsCollectionType) {
+    expectCompileError(
+        "xs: List<any> = []\n"
+        "append!(xs, [1, 2, 3])\n",
+        "'any' can only hold int/float/bool/str");
+}
+
+TEST_F(CodeGenTest, ListAppendedAnyRejectsCollectionType) {
+    expectCompileError(
+        "xs: List<any> = []\n"
+        "ys = appended(xs, [1, 2, 3])\n",
+        "'any' can only hold int/float/bool/str");
+}
+
+TEST_F(CodeGenTest, ListInsertAnyRejectsCollectionType) {
+    expectCompileError(
+        "xs: List<any> = []\n"
+        "insert(xs, 0, [1, 2, 3])\n",
+        "'any' can only hold int/float/bool/str");
+}

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -297,3 +297,16 @@ TEST_F(CodeGenTest, ArithPlusListConcatMismatchMessageUnchanged) {
         "c = a + b\n",
         "list concatenation requires matching element types");
 }
+
+// ============================================================
+// Map<K, any>: collection / non-str-pointer types are rejected by wrapInAny
+// ============================================================
+
+TEST_F(CodeGenTest, MapAnyValueRejectsCollectionType) {
+    // wrapInAny rejects non-str pointers (collections, resources, etc.)
+    // with "any can only hold int/float/bool/str".
+    expectCompileError(
+        "m: Map<str, any> = {}\n"
+        "m[\"bad\"] = [1, 2, 3]\n",
+        "'any' can only hold int/float/bool/str");
+}


### PR DESCRIPTION
## Summary

- Applies the canonical 3-branch any-widening pattern (`wrapInAny` / `unwrapFromAny` / error) to all six collection element-write sites: `Map` index-assign, `List` index-assign, `List.append!`, `List.appended`, `List.insert`, and `Set.add`. Previously, assignments like `m["name"] = "Alice"` on `Map<str, any>` or `xs.append!(42)` on `List<any>` failed with a type-mismatch error despite `any` being documented to accept implicit conversion from all primitives.
- Fixes `emitSetElementLookup` and `emitMapKeyLookup` to route through `emitAnyBinaryOp` when the element/key type is `anyTy_`, preventing an LLVM IR verify error (`icmp eq` on `[8 x i8]` data field).
- Adds spec tests covering all four primitive types (str/int/float/bool) in all three collection kinds, plus unwrap direction (`any` → concrete) and a negative rejection test for collection values.
- Separately filed t0k0sh1/ry#1065 for the symmetric gap in the `in` membership-test operator.

## Test plan

- [x] `./build/ry_tests` — 1706 C++ tests pass
- [x] `./build/ry test -p` — 131 spec files pass (0 failures)
- [x] ASan + UBSan — clean
- [x] TSan — clean (C++ tests required; Ry self-test warn-only per AGENTS.md)
- [x] `/simplify` — hoisted loop-invariant `isAnyType` predicates in both linear-scan helpers; trimmed redundant test comment

Closes #1029

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed type-checking for `any` collection elements so `Map<K, any>`, `List<any>`, and `Set<any>` accept direct assignment of concrete values (`str`, `int`, `float`, `bool`) at index/append/insert/add sites; `Set<any>` membership comparisons use the runtime `any` equality.

* **Tests**
  * Added tests covering `any` in collections (assignments, overwrites, unwrapping) and compile-failure cases when assigning unsupported collection values into `any`.

* **Chores**
  * Added a changelog entry documenting these fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->