### PR TITLE
fix(str): make contains/starts_with/ends_with/find NUL-safe (#1047)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1143,7 +1143,7 @@ Key constants:
 **How to free a dynamic str**: `freeStringSlot(handle)` — calls `free(handle - STRING_HEADER_SIZE)`.  
 **Literal globals**: created by `buildArcGlobal` in `src/codegen.cpp`; `strong_count = ARC_IMMORTAL` so retain/release are no-ops. GEP index is `(0, 3, 0)` into the struct.
 
-**NUL safety in PR #1022**: `byte_len`, `length`, `==`/`!=`/`<`/`>`, `+`, `*`, Map/Set key hash+compare are NUL-safe. Remaining ops (`contains`, `starts_with`, `split`, `replace`, `substring`, etc.) still use `strlen`/`strstr` internally — NUL truncates them. Track in follow-up issues.
+**NUL safety**: `byte_len`, `length`, `==`/`!=`/`<`/`>`, `+`, `*`, Map/Set key hash+compare (#1022), and `contains`, `starts_with`, `ends_with`, `find` (#1047) are NUL-safe. The remaining ops (`split`, `replace`, `substring`, `char_at`, etc.) still use `strlen`/`strstr` internally — NUL truncates them. Track in follow-up issues.
 
 **`markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`** (Source: #1016):
 TuplePattern / RecordPattern / EnumConstructorPattern pre-mark a temporary alloca

--- a/changelog.d/1047-str-search-nul-safe.md
+++ b/changelog.d/1047-str-search-nul-safe.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `contains`, `starts_with`, `ends_with`, and `find` now honour embedded NUL bytes instead of truncating at the first `\0` (#1047).

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -6,7 +6,7 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 
 > **Note:** All string operations are UTF-8 aware. `length()`, `char_at()`, `substring()`, `find()`, and `reverse()` operate on Unicode code points, not bytes. Use `byte_len()` if you need the byte length.
 >
-> **NUL bytes:** As of #1022, `str` stores an explicit byte length and supports embedded NUL bytes (`\0`). The operations `byte_len`, `length`, `==`, `!=`, `<`, `>`, `+`, `*`, and hash/Map/Set key lookup are fully NUL-safe. Other operations (`contains`, `starts_with`, `ends_with`, `split`, `replace`, etc.) may still truncate at the first NUL byte — this will be addressed in follow-up issues.
+> **NUL bytes:** `str` stores an explicit byte length and supports embedded NUL bytes (`\0`). The following operations are fully NUL-safe: `byte_len`, `length`, `==`, `!=`, `<`, `>`, `+`, `*`, hash/Map/Set key lookup (#1022), and `contains`, `starts_with`, `ends_with`, `find` (#1047). Other operations (`split`, `replace`, `substring`, `char_at`, etc.) may still truncate at the first NUL byte.
 
 ## Function List
 
@@ -71,12 +71,13 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 
 **Signature:** `contains(string: str, substring: str, ignore_case: bool = false) -> bool`
 
-Returns whether string `string` contains the substring `substring`. When `ignore_case` is `true`, the comparison is case-insensitive (ASCII only).
+Returns whether string `string` contains the substring `substring`. When `ignore_case` is `true`, the comparison is case-insensitive (ASCII only). Both `string` and `substring` may contain embedded NUL bytes (`\0`).
 
 ```python
 print(contains("hello", "ell"))              # true
 print("hello".contains("xyz"))               # false (UFCS)
 print(contains("Hello World", "hello", true))  # true (case-insensitive)
+print(contains("a\0b", "\0b"))               # true (NUL-safe)
 ```
 
 ---
@@ -85,12 +86,13 @@ print(contains("Hello World", "hello", true))  # true (case-insensitive)
 
 **Signature:** `starts_with(string: str, prefix: str, ignore_case: bool = false) -> bool`
 
-Returns whether string `string` starts with `prefix`. When `ignore_case` is `true`, the comparison is case-insensitive (ASCII only).
+Returns whether string `string` starts with `prefix`. When `ignore_case` is `true`, the comparison is case-insensitive (ASCII only). Both arguments may contain embedded NUL bytes (`\0`).
 
 ```python
 print(starts_with("hello", "hel"))              # true
 print("hello".starts_with("world"))              # false (UFCS)
 print(starts_with("Hello", "hello", true))  # true (case-insensitive)
+print(starts_with("a\0b", "a\0"))            # true (NUL-safe)
 ```
 
 ---
@@ -99,12 +101,13 @@ print(starts_with("Hello", "hello", true))  # true (case-insensitive)
 
 **Signature:** `ends_with(string: str, suffix: str, ignore_case: bool = false) -> bool`
 
-Returns whether string `string` ends with `suffix`. When `ignore_case` is `true`, the comparison is case-insensitive (ASCII only).
+Returns whether string `string` ends with `suffix`. When `ignore_case` is `true`, the comparison is case-insensitive (ASCII only). Both arguments may contain embedded NUL bytes (`\0`).
 
 ```python
 print(ends_with("hello", "llo"))              # true
 print("hello".ends_with("world"))              # false (UFCS)
 print(ends_with("Hello World", "WORLD", true))  # true (case-insensitive)
+print(ends_with("a\0b", "\0b"))               # true (NUL-safe)
 ```
 
 ---
@@ -113,12 +116,13 @@ print(ends_with("Hello World", "WORLD", true))  # true (case-insensitive)
 
 **Signature:** `find(string: str, substring: str) -> Option<int>`
 
-Returns the character position of the first occurrence of substring `substring` in string `string`. Returns `None` if not found.
+Returns the character position of the first occurrence of substring `substring` in string `string`. Returns `None` if not found. Both arguments may contain embedded NUL bytes (`\0`); the returned index counts Unicode code points (NUL counts as one code point).
 
 ```python
 print(find("hello world", "world"))   # Some(6)
 print(find("hello", "xyz"))           # None
 print("abcdef".find("cd"))            # Some(2) (UFCS)
+print(find("a\0b", "\0"))             # Some(1) (NUL-safe)
 ```
 
 ---

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -75,31 +75,18 @@ llvm::Value *CodeGen::emitStrOp_contains(const CallExpr &e) {
     if (s->getType() != ptrTy_ || sub->getType() != ptrTy_)
         codegenError("contains() requires str arguments");
 
-    auto strstrFn = getStdlibStrstr();
-    auto strcasestrFn = getStdlibStrcasestr();
-    llvm::Value *null = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
-
-    llvm::BasicBlock *icTrueBB = llvm::BasicBlock::Create(*ctx_, "ct.ic_true", fn_);
-    llvm::BasicBlock *icFalseBB = llvm::BasicBlock::Create(*ctx_, "ct.ic_false", fn_);
-    llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "ct.merge", fn_);
-
-    builder_.CreateCondBr(ignoreCase, icTrueBB, icFalseBB);
-
-    builder_.SetInsertPoint(icTrueBB);
-    llvm::Value *resIC = builder_.CreateCall(strcasestrFn, {s, sub}, "strcasestr");
-    llvm::Value *containsIC = builder_.CreateICmpNE(resIC, null, "contains_ic");
-    builder_.CreateBr(mergeBB);
-
-    builder_.SetInsertPoint(icFalseBB);
-    llvm::Value *resCS = builder_.CreateCall(strstrFn, {s, sub}, "strstr");
-    llvm::Value *containsCS = builder_.CreateICmpNE(resCS, null, "contains_cs");
-    builder_.CreateBr(mergeBB);
-
-    builder_.SetInsertPoint(mergeBB);
-    llvm::PHINode *phi = builder_.CreatePHI(i1Ty_, 2, "contains");
-    phi->addIncoming(containsIC, icTrueBB);
-    phi->addIncoming(containsCS, icFalseBB);
-    return phi;
+    // NUL-safe: read byte lengths from StringHeader and call __ry_str_find_byte.
+    // Returns byte offset >= 0 when found, -1 when not found.
+    llvm::Value *sl   = emitStringByteLen(s);
+    llvm::Value *subl = emitStringByteLen(sub);
+    llvm::Value *icI32 = builder_.CreateZExt(ignoreCase, i32Ty_, "ic_i32");
+    auto findByteFn = getRuntimeFn("__ry_str_find_byte", i64Ty_,
+                                   {ptrTy_, i64Ty_, ptrTy_, i64Ty_, i32Ty_});
+    llvm::Value *byteOff = builder_.CreateCall(findByteFn, {s, sl, sub, subl, icI32},
+                                               "find_byte_off");
+    return builder_.CreateICmpNE(byteOff,
+                                 llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(-1LL)),
+                                 "contains");
 }
 
 // starts_with(s, prefix[, ignore_case]) → bool
@@ -113,32 +100,15 @@ llvm::Value *CodeGen::emitStrOp_starts_with(const CallExpr &e) {
         : llvm::ConstantInt::get(i1Ty_, 0);
     if (s->getType() != ptrTy_ || prefix->getType() != ptrTy_)
         codegenError("starts_with() requires str arguments");
-    auto strlenFn = getStdlibStrlen();
-    auto strncmpFn = getStdlibStrncmp();
-    auto strncasecmpFn = getStdlibStrncasecmp();
-    llvm::Value *prefixLen = builder_.CreateCall(strlenFn, {prefix}, "prefix_len");
 
-    llvm::BasicBlock *icTrueBB = llvm::BasicBlock::Create(*ctx_, "sw.ic_true", fn_);
-    llvm::BasicBlock *icFalseBB = llvm::BasicBlock::Create(*ctx_, "sw.ic_false", fn_);
-    llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "sw.merge", fn_);
-
-    builder_.CreateCondBr(ignoreCase, icTrueBB, icFalseBB);
-
-    builder_.SetInsertPoint(icTrueBB);
-    llvm::Value *cmpIC = builder_.CreateCall(strncasecmpFn, {s, prefix, prefixLen}, "strncasecmp");
-    llvm::Value *matchIC = builder_.CreateICmpEQ(cmpIC, llvm::ConstantInt::get(i32Ty_, 0), "sw_ic");
-    builder_.CreateBr(mergeBB);
-
-    builder_.SetInsertPoint(icFalseBB);
-    llvm::Value *cmpCS = builder_.CreateCall(strncmpFn, {s, prefix, prefixLen}, "strncmp");
-    llvm::Value *matchCS = builder_.CreateICmpEQ(cmpCS, llvm::ConstantInt::get(i32Ty_, 0), "sw_cs");
-    builder_.CreateBr(mergeBB);
-
-    builder_.SetInsertPoint(mergeBB);
-    llvm::PHINode *phi = builder_.CreatePHI(i1Ty_, 2, "starts_with");
-    phi->addIncoming(matchIC, icTrueBB);
-    phi->addIncoming(matchCS, icFalseBB);
-    return phi;
+    // NUL-safe: read byte lengths from StringHeader and call __ry_str_starts_with.
+    llvm::Value *sl = emitStringByteLen(s);
+    llvm::Value *pl = emitStringByteLen(prefix);
+    llvm::Value *icI32 = builder_.CreateZExt(ignoreCase, i32Ty_, "ic_i32");
+    auto swFn = getRuntimeFn("__ry_str_starts_with", i32Ty_,
+                             {ptrTy_, i64Ty_, ptrTy_, i64Ty_, i32Ty_});
+    llvm::Value *result = builder_.CreateCall(swFn, {s, sl, prefix, pl, icI32}, "sw_result");
+    return builder_.CreateICmpNE(result, llvm::ConstantInt::get(i32Ty_, 0), "starts_with");
 }
 
 // ends_with(s, suffix[, ignore_case]) → bool
@@ -152,52 +122,15 @@ llvm::Value *CodeGen::emitStrOp_ends_with(const CallExpr &e) {
         : llvm::ConstantInt::get(i1Ty_, 0);
     if (s->getType() != ptrTy_ || suffix->getType() != ptrTy_)
         codegenError("ends_with() requires str arguments");
-    auto strlenFn = getStdlibStrlen();
-    auto strncmpFn = getStdlibStrncmp();
-    auto strncasecmpFn = getStdlibStrncasecmp();
-    llvm::Value *sLen = builder_.CreateCall(strlenFn, {s}, "s_len");
-    llvm::Value *suffixLen = builder_.CreateCall(strlenFn, {suffix}, "suffix_len");
 
-    llvm::Value *tooLong = builder_.CreateICmpUGT(suffixLen, sLen, "too_long");
-
-    llvm::BasicBlock *checkBB = llvm::BasicBlock::Create(*ctx_, "ew.check", fn_);
-    llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "ew.merge", fn_);
-    llvm::BasicBlock *curBB = builder_.GetInsertBlock();
-
-    builder_.CreateCondBr(tooLong, mergeBB, checkBB);
-
-    builder_.SetInsertPoint(checkBB);
-    llvm::Value *offset = builder_.CreateSub(sLen, suffixLen, "offset");
-    llvm::Value *tailPtr = builder_.CreateGEP(builder_.getInt8Ty(), s, offset, "tail_ptr");
-
-    // Branch on ignore_case
-    llvm::BasicBlock *icTrueBB = llvm::BasicBlock::Create(*ctx_, "ew.ic_true", fn_);
-    llvm::BasicBlock *icFalseBB = llvm::BasicBlock::Create(*ctx_, "ew.ic_false", fn_);
-    llvm::BasicBlock *cmpMergeBB = llvm::BasicBlock::Create(*ctx_, "ew.cmp_merge", fn_);
-
-    builder_.CreateCondBr(ignoreCase, icTrueBB, icFalseBB);
-
-    builder_.SetInsertPoint(icTrueBB);
-    llvm::Value *cmpIC = builder_.CreateCall(strncasecmpFn, {tailPtr, suffix, suffixLen}, "strncasecmp");
-    llvm::Value *matchIC = builder_.CreateICmpEQ(cmpIC, llvm::ConstantInt::get(i32Ty_, 0), "ew_ic");
-    builder_.CreateBr(cmpMergeBB);
-
-    builder_.SetInsertPoint(icFalseBB);
-    llvm::Value *cmpCS = builder_.CreateCall(strncmpFn, {tailPtr, suffix, suffixLen}, "strncmp");
-    llvm::Value *matchCS = builder_.CreateICmpEQ(cmpCS, llvm::ConstantInt::get(i32Ty_, 0), "ew_cs");
-    builder_.CreateBr(cmpMergeBB);
-
-    builder_.SetInsertPoint(cmpMergeBB);
-    llvm::PHINode *matchPhi = builder_.CreatePHI(i1Ty_, 2, "ew_match");
-    matchPhi->addIncoming(matchIC, icTrueBB);
-    matchPhi->addIncoming(matchCS, icFalseBB);
-    builder_.CreateBr(mergeBB);
-
-    builder_.SetInsertPoint(mergeBB);
-    llvm::PHINode *phi = builder_.CreatePHI(i1Ty_, 2, "ends_with");
-    phi->addIncoming(llvm::ConstantInt::get(i1Ty_, 0), curBB);
-    phi->addIncoming(matchPhi, cmpMergeBB);
-    return phi;
+    // NUL-safe: read byte lengths from StringHeader and call __ry_str_ends_with.
+    llvm::Value *sl  = emitStringByteLen(s);
+    llvm::Value *sfl = emitStringByteLen(suffix);
+    llvm::Value *icI32 = builder_.CreateZExt(ignoreCase, i32Ty_, "ic_i32");
+    auto ewFn = getRuntimeFn("__ry_str_ends_with", i32Ty_,
+                             {ptrTy_, i64Ty_, ptrTy_, i64Ty_, i32Ty_});
+    llvm::Value *result = builder_.CreateCall(ewFn, {s, sl, suffix, sfl, icI32}, "ew_result");
+    return builder_.CreateICmpNE(result, llvm::ConstantInt::get(i32Ty_, 0), "ends_with");
 }
 
 // find(s, sub) → Option<int>
@@ -209,23 +142,28 @@ llvm::Value *CodeGen::emitStrOp_find(const CallExpr &e) {
         codegenError("find() requires str arguments");
 
     llvm::StructType *optTy = getOptionType(i64Ty_);
-    auto strstrFn = getStdlibStrstr();
-    llvm::Value *result = builder_.CreateCall(strstrFn, {s, sub}, "find_ptr");
-    llvm::Value *null = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
-    llvm::Value *isNull = builder_.CreateICmpEQ(result, null, "find_null");
 
-    llvm::BasicBlock *foundBB = llvm::BasicBlock::Create(*ctx_, "find.found", fn_);
+    // NUL-safe: read byte lengths from StringHeader, call __ry_str_find_byte which
+    // returns the byte offset (>= 0) or -1 if not found.
+    llvm::Value *sl   = emitStringByteLen(s);
+    llvm::Value *subl = emitStringByteLen(sub);
+    auto findByteFn = getRuntimeFn("__ry_str_find_byte", i64Ty_,
+                                   {ptrTy_, i64Ty_, ptrTy_, i64Ty_, i32Ty_});
+    llvm::Value *byteOff = builder_.CreateCall(
+        findByteFn, {s, sl, sub, subl, llvm::ConstantInt::get(i32Ty_, 0)}, "find_byte_off");
+    llvm::Value *notFound = builder_.CreateICmpEQ(
+        byteOff, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(-1LL)), "find_notfound");
+
+    llvm::BasicBlock *foundBB    = llvm::BasicBlock::Create(*ctx_, "find.found", fn_);
     llvm::BasicBlock *notFoundBB = llvm::BasicBlock::Create(*ctx_, "find.notfound", fn_);
-    llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "find.merge", fn_);
-    builder_.CreateCondBr(isNull, notFoundBB, foundBB);
+    llvm::BasicBlock *mergeBB    = llvm::BasicBlock::Create(*ctx_, "find.merge", fn_);
+    builder_.CreateCondBr(notFound, notFoundBB, foundBB);
 
     builder_.SetInsertPoint(foundBB);
-    llvm::Value *sInt = builder_.CreatePtrToInt(s, i64Ty_, "s_int");
-    llvm::Value *rInt = builder_.CreatePtrToInt(result, i64Ty_, "r_int");
-    llvm::Value *byteOffset = builder_.CreateSub(rInt, sInt, "find_byte_offset");
-    // Convert byte offset to character index
-    auto charIdxFn = getRuntimeFn("__ry_utf8_char_index", i64Ty_, {ptrTy_, i64Ty_});
-    llvm::Value *charIdx = builder_.CreateCall(charIdxFn, {s, byteOffset}, "find_char_idx");
+    // NUL-safe byte-offset → char-index conversion (replaces __ry_utf8_char_index
+    // which stopped at the first '\0').
+    auto charIdxFn = getRuntimeFn("__ry_utf8_char_index_n", i64Ty_, {ptrTy_, i64Ty_, i64Ty_});
+    llvm::Value *charIdx = builder_.CreateCall(charIdxFn, {s, sl, byteOff}, "find_char_idx");
     llvm::Value *someVal = buildSomeValue(charIdx, optTy);
     builder_.CreateBr(mergeBB);
     llvm::BasicBlock *foundEndBB = builder_.GetInsertBlock();

--- a/src/runtime_string.cpp
+++ b/src/runtime_string.cpp
@@ -1,4 +1,5 @@
 #include "ry/runtime_string.hpp"
+#include <cctype>
 #include <cstdint>
 #include <cstring>
 
@@ -42,6 +43,67 @@ int32_t __ry_str_cmp(const char *a, int64_t la, const char *b, int64_t lb) {
     if (la > lb) return 1;
     if (la < lb) return -1;
     return 0;
+}
+
+// ASCII case-insensitive fixed-length comparison: returns 1 if all len bytes
+// of a and b match under tolower, 0 otherwise.  Shared by starts_with and ends_with.
+static int32_t mem_eq_icase(const char *a, const char *b, int64_t len) {
+    for (int64_t i = 0; i < len; ++i) {
+        if (tolower(static_cast<unsigned char>(a[i])) !=
+            tolower(static_cast<unsigned char>(b[i])))
+            return 0;
+    }
+    return 1;
+}
+
+// NUL-safe starts_with: returns 1 if the first pl bytes of s match the pl bytes
+// of p (case-sensitive or ASCII-folded), 0 otherwise.
+// Called by codegen for starts_with() / _starts_with().
+int32_t __ry_str_starts_with(const char *s, int64_t sl, const char *p, int64_t pl,
+                              int32_t ignore_case) {
+    if (pl > sl) return 0;
+    if (ignore_case) return mem_eq_icase(s, p, pl);
+    return memcmp(s, p, static_cast<size_t>(pl)) == 0 ? 1 : 0;
+}
+
+// NUL-safe ends_with: returns 1 if the last pl bytes of s match the pl bytes
+// of suffix (case-sensitive or ASCII-folded), 0 otherwise.
+// Called by codegen for ends_with() / _ends_with().
+int32_t __ry_str_ends_with(const char *s, int64_t sl, const char *suffix, int64_t pl,
+                            int32_t ignore_case) {
+    if (pl > sl) return 0;
+    const char *tail = s + (sl - pl);
+    if (ignore_case) return mem_eq_icase(tail, suffix, pl);
+    return memcmp(tail, suffix, static_cast<size_t>(pl)) == 0 ? 1 : 0;
+}
+
+// NUL-safe find: returns the byte offset of the first occurrence of needle
+// (length nl) within haystack (length hl), or -1 if not found.
+// Empty needle (nl == 0) returns 0, matching strstr() semantics.
+// Case-insensitive path uses a naive O(hl*nl) ASCII-tolower loop (matching the
+// existing strcasestr() behaviour which is also ASCII-only).
+// Called by codegen for contains() and find().
+int64_t __ry_str_find_byte(const char *s, int64_t hl, const char *p, int64_t nl,
+                            int32_t ignore_case) {
+    if (nl == 0) return 0;
+    if (nl > hl) return -1;
+    if (ignore_case) {
+        for (int64_t i = 0; i <= hl - nl; ++i) {
+            bool match = true;
+            for (int64_t j = 0; j < nl; ++j) {
+                if (static_cast<unsigned char>(tolower(static_cast<unsigned char>(s[i + j]))) !=
+                    static_cast<unsigned char>(tolower(static_cast<unsigned char>(p[j])))) {
+                    match = false;
+                    break;
+                }
+            }
+            if (match) return i;
+        }
+        return -1;
+    }
+    const void *found = memmem(s, static_cast<size_t>(hl), p, static_cast<size_t>(nl));
+    if (!found) return -1;
+    return static_cast<int64_t>(static_cast<const char *>(found) - s);
 }
 
 } // extern "C"

--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -178,6 +178,28 @@ int64_t __ry_utf8_char_index(const char *s, int64_t byte_offset) {
     return charIdx;
 }
 
+// NUL-safe variant: walks exactly byte_offset bytes (ignoring any embedded NUL
+// bytes), counting UTF-8 codepoints.  Each NUL counts as one character unit,
+// matching __ry_utf8_len_n.  Precondition: 0 <= byte_offset <= byte_len.
+// byte_len is accepted for interface consistency but is not needed as a bound
+// (byte_offset is already the tighter bound).
+// Called by codegen for find() to convert a NUL-safe byte offset to a char index.
+int64_t __ry_utf8_char_index_n(const char *s, int64_t /*byte_len*/, int64_t byte_offset) {
+    const char *p = s;
+    const char *target = s + byte_offset;
+    int64_t charIdx = 0;
+    while (p < target) {
+        unsigned char c = static_cast<unsigned char>(*p);
+        if (c == 0) {
+            ++p; // NUL byte is one character unit
+        } else {
+            p += utf8_char_len_nul(p);
+        }
+        ++charIdx;
+    }
+    return charIdx;
+}
+
 void *__ry_split_chars(const char *s) {
     // First pass: count UTF-8 characters
     int64_t count = 0;

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -358,4 +358,43 @@ describe("NUL byte handling", ():
       Err(_):
         expect(false).to_eq(true)
   )
+  it("contains finds substring crossing embedded NUL (#1047)", ():
+    expect(contains("a\0b", "\0b")).to_eq(true)
+    expect(contains("a\0b", "\0c")).to_eq(false)
+    expect(contains("a\0b", "a\0")).to_eq(true)
+    expect(contains("a\0b", "b")).to_eq(true)
+  )
+  it("contains case-insensitive with embedded NUL (#1047)", ():
+    expect(contains("A\0B", "a\0b", true)).to_eq(true)
+    expect(contains("A\0B", "a\0c", true)).to_eq(false)
+  )
+  it("starts_with with embedded NUL (#1047)", ():
+    expect(starts_with("a\0b", "a\0")).to_eq(true)
+    expect(starts_with("a\0b", "a\0c")).to_eq(false)
+    expect(starts_with("a", "a\0")).to_eq(false)
+  )
+  it("starts_with case-insensitive with embedded NUL (#1047)", ():
+    expect(starts_with("A\0B", "a\0", true)).to_eq(true)
+  )
+  it("ends_with with embedded NUL (#1047)", ():
+    expect(ends_with("a\0b", "\0b")).to_eq(true)
+    expect(ends_with("a\0b", "\0c")).to_eq(false)
+    expect(ends_with("b", "\0b")).to_eq(false)
+  )
+  it("ends_with case-insensitive with embedded NUL (#1047)", ():
+    expect(ends_with("A\0B", "\0b", true)).to_eq(true)
+  )
+  it("find returns correct char index for NUL-containing string (#1047)", ():
+    expect(find("a\0b", "\0")).to_eq(Some(1))
+    expect(find("a\0b", "\0b")).to_eq(Some(1))
+    expect(find("a\0b", "b")).to_eq(Some(2))
+    expect(find("a\0b", "c")).to_be_none()
+  )
+  it("empty needle parity for NUL-containing strings (#1047)", ():
+    s = "a\0b"
+    expect(contains(s, "")).to_eq(true)
+    expect(starts_with(s, "")).to_eq(true)
+    expect(ends_with(s, "")).to_eq(true)
+    expect(find(s, "")).to_eq(Some(0))
+  )
 )


### PR DESCRIPTION
## Summary

- Replaces `strstr`/`strcasestr`/`strlen`/`strncmp` in four string search emitters with explicit byte-length runtime helpers (`__ry_str_starts_with`, `__ry_str_ends_with`, `__ry_str_find_byte`) that use `memcmp`/`memmem` and never truncate at `\0`
- Adds `__ry_utf8_char_index_n` to fix the secondary NUL truncation in `find()`'s byte-offset → char-index conversion
- Codegen reads byte lengths via `emitStringByteLen` (follows the `__ry_str_cmp` pattern from #1022)
- Extracts `mem_eq_icase` static helper to deduplicate identical `tolower` loops in `starts_with` and `ends_with`

## Reproduction (issue #1047)

```ry
s = "a\0b"
print(contains(s, "\0b"))    # was: false  →  now: true
print(starts_with(s, "a\0")) # was: false  →  now: true
print(ends_with(s, "\0b"))   # was: false  →  now: true
print(find(s, "\0"))         # was: None   →  now: Some(1)
```

## Test plan

- [ ] 8 new `it` cases added to `describe("NUL byte handling", ...)` in `tests/spec/strings.test.ry` — all green
- [ ] `./build/ry_tests` — 1709 tests pass
- [ ] `./build/ry test -p` — 131 self-tests pass (76 string tests)
- [ ] ASan + UBSan (`build-asan` preset) — clean
- [ ] TSan (`build-tsan` preset) — clean

Closes #1047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * String search operations (`contains`, `starts_with`, `ends_with`, `find`) now correctly handle embedded NUL bytes without truncation, including case-insensitive variants.

* **Documentation**
  * Updated reference documentation to clearly mark string search operations as NUL-safe and clarify behavior when strings contain embedded NUL bytes.

* **Tests**
  * Added test cases covering NUL byte handling in string search operations, including case-sensitive and case-insensitive matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->