### PR TITLE
fix(str): make replace NUL-safe (#1048)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1157,6 +1157,8 @@ Key constants:
 
 **NUL safety**: `byte_len`, `length`, `==`/`!=`/`<`/`>`, `+`, `*`, Map/Set key hash+compare (#1022), `contains`, `starts_with`, `ends_with`, `find` (#1047), and `replace` (#1048) are NUL-safe. The remaining ops (`split`, `substring`, `char_at`, etc.) still use `strlen`/`strstr` internally — NUL truncates them. Track in follow-up issues.
 
+**`to_eq` in test assertions is NUL-unsafe** (Source: #1048 CodeRabbit review): `expect(result).to_eq("str\0with\0nuls")` compares via `emitStmt(ExpectStmt&)` which truncates at the first `\0`. Only `to_have_length` and `to_be_empty` are NUL-safe matchers today. **Rule**: when the *expected* string literal in a test contains embedded `\0`, use `expect(result == expected).to_eq(true)` — the NUL-safe `==` operator does the comparison, and `to_eq(true)` only sees a `bool`.
+
 **`markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`** (Source: #1016):
 TuplePattern / RecordPattern / EnumConstructorPattern pre-mark a temporary alloca
 (`tmp`) as ARC-managed so the recursive leaf `VariablePattern` binding can emit a

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1143,7 +1143,7 @@ Key constants:
 **How to free a dynamic str**: `freeStringSlot(handle)` — calls `free(handle - STRING_HEADER_SIZE)`.  
 **Literal globals**: created by `buildArcGlobal` in `src/codegen.cpp`; `strong_count = ARC_IMMORTAL` so retain/release are no-ops. GEP index is `(0, 3, 0)` into the struct.
 
-**NUL safety**: `byte_len`, `length`, `==`/`!=`/`<`/`>`, `+`, `*`, Map/Set key hash+compare (#1022), and `contains`, `starts_with`, `ends_with`, `find` (#1047) are NUL-safe. The remaining ops (`split`, `replace`, `substring`, `char_at`, etc.) still use `strlen`/`strstr` internally — NUL truncates them. Track in follow-up issues.
+**NUL safety**: `byte_len`, `length`, `==`/`!=`/`<`/`>`, `+`, `*`, Map/Set key hash+compare (#1022), `contains`, `starts_with`, `ends_with`, `find` (#1047), and `replace` (#1048) are NUL-safe. The remaining ops (`split`, `substring`, `char_at`, etc.) still use `strlen`/`strstr` internally — NUL truncates them. Track in follow-up issues.
 
 **`markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`** (Source: #1016):
 TuplePattern / RecordPattern / EnumConstructorPattern pre-mark a temporary alloca

--- a/changelog.d/1048-str-replace-nul-safe.md
+++ b/changelog.d/1048-str-replace-nul-safe.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `replace` now honours embedded NUL bytes in the haystack, needle, and replacement instead of truncating at the first `\0` (#1048).

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -6,7 +6,7 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 
 > **Note:** All string operations are UTF-8 aware. `length()`, `char_at()`, `substring()`, `find()`, and `reverse()` operate on Unicode code points, not bytes. Use `byte_len()` if you need the byte length.
 >
-> **NUL bytes:** `str` stores an explicit byte length and supports embedded NUL bytes (`\0`). The following operations are fully NUL-safe: `byte_len`, `length`, `==`, `!=`, `<`, `>`, `+`, `*`, hash/Map/Set key lookup (#1022), and `contains`, `starts_with`, `ends_with`, `find` (#1047). Other operations (`split`, `replace`, `substring`, `char_at`, etc.) may still truncate at the first NUL byte.
+> **NUL bytes:** `str` stores an explicit byte length and supports embedded NUL bytes (`\0`). The following operations are fully NUL-safe: `byte_len`, `length`, `==`, `!=`, `<`, `>`, `+`, `*`, hash/Map/Set key lookup (#1022), `contains`, `starts_with`, `ends_with`, `find` (#1047), and `replace` (#1048). Other operations (`split`, `substring`, `char_at`, etc.) may still truncate at the first NUL byte.
 
 ## Function List
 
@@ -164,7 +164,7 @@ print("abc".char_at(2))       # c (UFCS)
 
 **Signature:** `replace(string: str, old: str, new: str) -> str`
 
-Returns a new string with all occurrences of `old` in `string` replaced with `new`.
+Returns a new string with all occurrences of `old` in `string` replaced with `new`. All three arguments may contain embedded NUL bytes (`\0`).
 
 If `old` is an empty string, the input is returned unchanged (as a fresh copy).
 
@@ -173,6 +173,7 @@ print(replace("hello world", "world", "ry"))   # hello ry
 print(replace("aaa", "a", "bb"))                # bbbbbb
 print("foo bar foo".replace("foo", "baz"))      # baz bar baz (UFCS)
 print(replace("hello", "", "X"))                # hello (empty pattern is a no-op)
+print(replace("a\0b\0a", "\0", "-"))            # a-b-a (NUL-safe)
 ```
 
 ---

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -248,113 +248,14 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
     }
     if (s->getType() != ptrTy_ || oldStr->getType() != ptrTy_ || newStr->getType() != ptrTy_)
         codegenError("replace() requires str arguments");
-    auto strlenFn = getStdlibStrlen();
-    auto strstrFn = getStdlibStrstr();
-    auto memcpyFn = getStdlibMemcpy();
 
-    llvm::Value *sLen = emitStringByteLen(s);
+    llvm::Value *sLen   = emitStringByteLen(s);
     llvm::Value *oldLen = emitStringByteLen(oldStr);
     llvm::Value *newLen = emitStringByteLen(newStr);
-
-    auto makeUninitTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
-
-    // Guard against empty pattern (#802): strstr("...", "") returns its first
-    // argument without advancing, which would cause the count/build loops below
-    // to spin forever. When `old` is empty, return a fresh copy of `s` so the
-    // callee still owns an independent allocation like the non-empty path.
-    llvm::BasicBlock *replEmptyBB = llvm::BasicBlock::Create(*ctx_, "repl.empty_pat", fn_);
-    llvm::BasicBlock *replMainBB  = llvm::BasicBlock::Create(*ctx_, "repl.main", fn_);
-    llvm::BasicBlock *replEndBB   = llvm::BasicBlock::Create(*ctx_, "repl.done", fn_);
-
-    llvm::Value *oldIsEmpty = builder_.CreateICmpEQ(oldLen, llvm::ConstantInt::get(i64Ty_, 0), "repl_old_empty");
-    builder_.CreateCondBr(oldIsEmpty, replEmptyBB, replMainBB);
-
-    builder_.SetInsertPoint(replEmptyBB);
-    llvm::Value *replEmptyBuf = builder_.CreateCall(makeUninitFn, {sLen}, "repl_empty_buf");
-    builder_.CreateCall(memcpyFn, {replEmptyBuf, s, sLen});
-    builder_.CreateBr(replEndBB);
-
-    builder_.SetInsertPoint(replMainBB);
-
-    // Pass 1: count occurrences
-    llvm::AllocaInst *countVar = builder_.CreateAlloca(i64Ty_, nullptr, "repl_count");
-    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), countVar);
-    llvm::AllocaInst *searchVar = builder_.CreateAlloca(ptrTy_, nullptr, "repl_search");
-    builder_.CreateStore(s, searchVar);
-
-    llvm::BasicBlock *countCondBB = llvm::BasicBlock::Create(*ctx_, "repl.count_cond", fn_);
-    llvm::BasicBlock *countBodyBB = llvm::BasicBlock::Create(*ctx_, "repl.count_body", fn_);
-    llvm::BasicBlock *countEndBB = llvm::BasicBlock::Create(*ctx_, "repl.count_end", fn_);
-
-    builder_.CreateBr(countCondBB);
-    builder_.SetInsertPoint(countCondBB);
-    llvm::Value *searchPtr = builder_.CreateLoad(ptrTy_, searchVar, "search_ptr");
-    llvm::Value *found = builder_.CreateCall(strstrFn, {searchPtr, oldStr}, "found_ptr");
-    llvm::Value *null = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
-    llvm::Value *notNull = builder_.CreateICmpNE(found, null, "found_not_null");
-    builder_.CreateCondBr(notNull, countBodyBB, countEndBB);
-
-    builder_.SetInsertPoint(countBodyBB);
-    llvm::Value *cnt = builder_.CreateLoad(i64Ty_, countVar, "cnt");
-    builder_.CreateStore(builder_.CreateAdd(cnt, llvm::ConstantInt::get(i64Ty_, 1), "cnt_inc"), countVar);
-    llvm::Value *nextSearch = builder_.CreateGEP(builder_.getInt8Ty(), found, oldLen, "next_search");
-    builder_.CreateStore(nextSearch, searchVar);
-    builder_.CreateBr(countCondBB);
-
-    builder_.SetInsertPoint(countEndBB);
-    llvm::Value *count = builder_.CreateLoad(i64Ty_, countVar, "final_count");
-
-    // Calculate new length: sLen + count * (newLen - oldLen)
-    llvm::Value *diff = builder_.CreateSub(newLen, oldLen, "len_diff");
-    llvm::Value *totalDiff = builder_.CreateMul(count, diff, "total_diff");
-    llvm::Value *resultLen = builder_.CreateAdd(sLen, totalDiff, "result_len");
-    llvm::Value *buf = builder_.CreateCall(makeUninitFn, {resultLen}, "repl_buf");
-
-    // Pass 2: build result
-    llvm::AllocaInst *srcVar = builder_.CreateAlloca(ptrTy_, nullptr, "repl_src");
-    builder_.CreateStore(s, srcVar);
-    llvm::AllocaInst *dstVar = builder_.CreateAlloca(ptrTy_, nullptr, "repl_dst");
-    builder_.CreateStore(buf, dstVar);
-
-    llvm::BasicBlock *buildCondBB = llvm::BasicBlock::Create(*ctx_, "repl.build_cond", fn_);
-    llvm::BasicBlock *buildBodyBB = llvm::BasicBlock::Create(*ctx_, "repl.build_body", fn_);
-    llvm::BasicBlock *buildEndBB = llvm::BasicBlock::Create(*ctx_, "repl.build_end", fn_);
-
-    builder_.CreateBr(buildCondBB);
-    builder_.SetInsertPoint(buildCondBB);
-    llvm::Value *curSrc = builder_.CreateLoad(ptrTy_, srcVar, "cur_src");
-    llvm::Value *foundBuild = builder_.CreateCall(strstrFn, {curSrc, oldStr}, "found_build");
-    llvm::Value *notNullBuild = builder_.CreateICmpNE(foundBuild, null, "found_build_nn");
-    builder_.CreateCondBr(notNullBuild, buildBodyBB, buildEndBB);
-
-    builder_.SetInsertPoint(buildBodyBB);
-    llvm::Value *curDst = builder_.CreateLoad(ptrTy_, dstVar, "cur_dst");
-    llvm::Value *srcInt = builder_.CreatePtrToInt(curSrc, i64Ty_, "src_int");
-    llvm::Value *foundInt = builder_.CreatePtrToInt(foundBuild, i64Ty_, "found_int");
-    llvm::Value *prefixLen = builder_.CreateSub(foundInt, srcInt, "prefix_len");
-    builder_.CreateCall(memcpyFn, {curDst, curSrc, prefixLen});
-    llvm::Value *dstAfterPrefix = builder_.CreateGEP(builder_.getInt8Ty(), curDst, prefixLen, "dst_after_prefix");
-    builder_.CreateCall(memcpyFn, {dstAfterPrefix, newStr, newLen});
-    llvm::Value *dstAfterNew = builder_.CreateGEP(builder_.getInt8Ty(), dstAfterPrefix, newLen, "dst_after_new");
-    builder_.CreateStore(dstAfterNew, dstVar);
-    llvm::Value *srcAfterOld = builder_.CreateGEP(builder_.getInt8Ty(), foundBuild, oldLen, "src_after_old");
-    builder_.CreateStore(srcAfterOld, srcVar);
-    builder_.CreateBr(buildCondBB);
-
-    builder_.SetInsertPoint(buildEndBB);
-    llvm::Value *finalSrc = builder_.CreateLoad(ptrTy_, srcVar, "final_src");
-    llvm::Value *finalDst = builder_.CreateLoad(ptrTy_, dstVar, "final_dst");
-    llvm::Value *remainLen = builder_.CreateCall(strlenFn, {finalSrc}, "remain_len");
-    builder_.CreateCall(memcpyFn, {finalDst, finalSrc, remainLen});
-    builder_.CreateBr(replEndBB);
-
-    // Merge empty-pattern path and main path
-    builder_.SetInsertPoint(replEndBB);
-    llvm::PHINode *replResult = builder_.CreatePHI(ptrTy_, 2, "repl_result");
-    replResult->addIncoming(replEmptyBuf, replEmptyBB);
-    replResult->addIncoming(buf, buildEndBB);
-    return replResult;
+    auto replaceFn = getRuntimeFn("__ry_str_replace", ptrTy_,
+                                  {ptrTy_, i64Ty_, ptrTy_, i64Ty_, ptrTy_, i64Ty_});
+    return builder_.CreateCall(replaceFn, {s, sLen, oldStr, oldLen, newStr, newLen},
+                               "replace_result");
 }
 
 // to_upper(s) → str

--- a/src/runtime_string.cpp
+++ b/src/runtime_string.cpp
@@ -106,4 +106,60 @@ int64_t __ry_str_find_byte(const char *s, int64_t hl, const char *p, int64_t nl,
     return static_cast<int64_t>(static_cast<const char *>(found) - s);
 }
 
+// NUL-safe replace: replaces every occurrence of oldStr (length oldLen) in s
+// (length sLen) with newStr (length newLen).  All three arguments may contain
+// embedded NUL bytes.  Empty needle (oldLen == 0) returns a fresh copy of s
+// unchanged (#802); fresh copy ensures caller always owns the result.
+// Called by codegen for replace(s, old, new).
+const char *__ry_str_replace(const char *s, int64_t sLen,
+                              const char *oldStr, int64_t oldLen,
+                              const char *newStr, int64_t newLen) {
+    if (oldLen == 0)
+        return ry::makeString(s, static_cast<size_t>(sLen));
+
+    int64_t count = 0;
+    const char *cur = s;
+    int64_t remain = sLen;
+    while (remain >= oldLen) {
+        const void *match = memmem(cur, static_cast<size_t>(remain), oldStr,
+                                   static_cast<size_t>(oldLen));
+        if (!match) break;
+        ++count;
+        int64_t advance = static_cast<const char *>(match) - cur + oldLen;
+        cur += advance;
+        remain -= advance;
+    }
+
+    if (count == 0)
+        return ry::makeString(s, static_cast<size_t>(sLen));
+
+    // Guard against int64_t overflow when newLen > oldLen.
+    int64_t delta = newLen - oldLen;
+    int64_t resultLen;
+    if (delta > 0 && count > (INT64_MAX - sLen) / delta)
+        resultLen = INT64_MAX;  // triggers OOM abort in makeStringUninit
+    else
+        resultLen = sLen + count * delta;
+    char *out = ry::makeStringUninit(static_cast<size_t>(resultLen));
+
+    cur = s;
+    remain = sLen;
+    char *dst = out;
+    while (remain >= oldLen) {
+        const void *match = memmem(cur, static_cast<size_t>(remain), oldStr,
+                                   static_cast<size_t>(oldLen));
+        if (!match) break;
+        int64_t prefixLen = static_cast<const char *>(match) - cur;
+        memcpy(dst, cur, static_cast<size_t>(prefixLen));
+        dst += prefixLen;
+        memcpy(dst, newStr, static_cast<size_t>(newLen));
+        dst += newLen;
+        cur = static_cast<const char *>(match) + oldLen;
+        remain -= prefixLen + oldLen;
+    }
+    memcpy(dst, cur, static_cast<size_t>(remain));
+
+    return out;
+}
+
 } // extern "C"

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -397,4 +397,27 @@ describe("NUL byte handling", ():
     expect(ends_with(s, "")).to_eq(true)
     expect(find(s, "")).to_eq(Some(0))
   )
+
+  it("replace finds and rewrites NUL needle (#1048)", ():
+    expect(replace("a\0b\0a", "\0", "-")).to_eq("a-b-a")
+    expect(replace("\0\0\0", "\0", "X")).to_eq("XXX")
+  )
+
+  it("replace preserves NUL bytes in haystack tail (#1048)", ():
+    expect(replace("a\0b\0a", "a", "X")).to_eq("X\0b\0X")
+    expect(replace("foo\0bar\0foo", "foo", "Y")).to_eq("Y\0bar\0Y")
+  )
+
+  it("replace handles NUL inside multi-byte needle (#1048)", ():
+    expect(replace("xx\0yy\0xx", "\0y", "Z")).to_eq("xxZy\0xx")
+  )
+
+  it("replace empty needle returns input unchanged (NUL parity #1048)", ():
+    expect(replace("a\0b", "", "X")).to_eq("a\0b")
+  )
+
+  it("replace inserts NUL bytes from replacement (#1048)", ():
+    expect(replace("ab", "a", "x\0y")).to_eq("x\0yb")
+    expect(replace("aa", "a", "\0")).to_eq("\0\0")
+  )
 )

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -404,20 +404,20 @@ describe("NUL byte handling", ():
   )
 
   it("replace preserves NUL bytes in haystack tail (#1048)", ():
-    expect(replace("a\0b\0a", "a", "X")).to_eq("X\0b\0X")
-    expect(replace("foo\0bar\0foo", "foo", "Y")).to_eq("Y\0bar\0Y")
+    expect(replace("a\0b\0a", "a", "X") == "X\0b\0X").to_eq(true)
+    expect(replace("foo\0bar\0foo", "foo", "Y") == "Y\0bar\0Y").to_eq(true)
   )
 
   it("replace handles NUL inside multi-byte needle (#1048)", ():
-    expect(replace("xx\0yy\0xx", "\0y", "Z")).to_eq("xxZy\0xx")
+    expect(replace("xx\0yy\0xx", "\0y", "Z") == "xxZy\0xx").to_eq(true)
   )
 
   it("replace empty needle returns input unchanged (NUL parity #1048)", ():
-    expect(replace("a\0b", "", "X")).to_eq("a\0b")
+    expect(replace("a\0b", "", "X") == "a\0b").to_eq(true)
   )
 
   it("replace inserts NUL bytes from replacement (#1048)", ():
-    expect(replace("ab", "a", "x\0y")).to_eq("x\0yb")
-    expect(replace("aa", "a", "\0")).to_eq("\0\0")
+    expect(replace("ab", "a", "x\0y") == "x\0yb").to_eq(true)
+    expect(replace("aa", "a", "\0") == "\0\0").to_eq(true)
   )
 )


### PR DESCRIPTION
## Summary

- Replaces the 120-line two-pass IR loop in `emitStrOp_replace` (which used `strstr`/`strlen`, both of which truncate at embedded NUL bytes) with a single call to a new runtime helper `__ry_str_replace`
- `__ry_str_replace` uses `memmem` throughout — haystack, needle, and replacement all support embedded `\0`
- Empty needle returns a fresh copy unchanged (preserves #802 behaviour; guard moved to C++ runtime)
- `count == 0` fast-path avoids an unnecessary allocation when the needle is not found
- Overflow guard prevents int64_t UB when `count * (newLen - oldLen)` would exceed `INT64_MAX`

Closes #1048

## Test plan

- [ ] New `describe("NUL byte handling")` cases in `tests/spec/strings.test.ry` (5 `it` blocks tagged `#1048`):
  - NUL as needle (`replace("a\0b\0a", "\0", "-")` → `"a-b-a"`)
  - NUL in haystack tail (`replace("a\0b\0a", "a", "X")` → `"X\0b\0X"`)
  - Multi-byte needle containing NUL
  - Empty-needle parity
  - NUL bytes in replacement string
- [ ] Existing `replace` tests (lines 71–81) continue to pass
- [ ] `./build/ry_tests` — 1709 C++ tests pass
- [ ] `./build/ry test -p` — 131 Ry self-tests pass
- [ ] ASan + UBSan clean
- [ ] TSan `ry_tests` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The `replace` string operation now correctly handles and preserves embedded NUL bytes in strings, instead of truncating at the first `\0`.

* **Documentation**
  * Updated reference documentation with examples demonstrating NUL-safe string replacement behavior.

* **Tests**
  * Added test cases for NUL byte handling in the `replace` function, covering edge cases with embedded NUL bytes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->