### PR TITLE
improve(diagnostics): emit clear error when indexing str with []

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1175,6 +1175,19 @@ tuple/record/enum fields is intentionally excluded: `fn_type_info` metadata is n
 propagated by `propagateTypeMeta` onto `ExtractValue` intermediates, so closure
 detection is impossible here; this was also the pre-#1008 behaviour.
 
+### `str` does not support `[]` index syntax — guard with `isStringValue` before list/map dispatch
+
+**Source**: #1026 (2026-04-16, diagnostic improvement)
+**Tags**: codegen, diagnostics, str, index-access, emitExprVariant, IndexExpr, IndexAssignStmt
+
+**Rule**: In `emitExprVariant(IndexExpr)` (`src/codegen_expr_literal.cpp`) and the `IndexAssignStmt` emitter (`src/codegen_stmt_misc.cpp`), `str` values are `ptrTy_` pointers and pass the "must be ptr" gate. Without an explicit guard they fall through the Map check (no map metadata) and then either (a) hit the List fallthrough and emit the misleading `"cannot determine list element type for index access"` error or (b) reach `emitCowCheck(objPtr, ..., CollectionKind::List)` which may corrupt state.
+
+**Fix**: After the `"index operator requires list or map"` gate and before the Map dispatch, check `isStringValue(objPtr)` and emit a targeted diagnostic:
+- Read path: `"str does not support index access; use char_at(s, i) instead"`
+- Write path: `"str does not support index assignment; strings are immutable"` — and critically, this guard must come **before** the `emitCowCheck(objPtr, receiverAlloca, CollectionKind::List)` call; passing a `str` pointer with `CollectionKind::List` to `emitCowCheck` is unsafe.
+
+**Why `isStringValue` is the right predicate**: `isStringValue(val)` (`src/codegen_any.cpp:28`) returns true when `val->getType() == ptrTy_` and `isNonStrPointer(val)` is false (i.e., no collection/resource metadata). Lists, Maps, Sets, and resource handles all have metadata (`hasAnyMeta() == true`), so only `str` triggers the new guard. This is the canonical predicate used throughout codegen to distinguish `str` from other `ptrTy_` values.
+
 ### `emitExprVariant` (CaseExpr): capture `armEndBB` AFTER `popScope()`
 
 **Source**: #997 (2026-04-16, fix)

--- a/changelog.d/1026-str-index-diagnostic.md
+++ b/changelog.d/1026-str-index-diagnostic.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Indexing a `str` value with `[]` now emits a clear diagnostic pointing to `char_at(s, i)`, instead of the misleading "cannot determine list element type" message (#1026)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -7,6 +7,8 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 > **Note:** All string operations are UTF-8 aware. `length()`, `char_at()`, `substring()`, `find()`, and `reverse()` operate on Unicode code points, not bytes. Use `byte_len()` if you need the byte length.
 >
 > **NUL bytes:** `str` stores an explicit byte length and supports embedded NUL bytes (`\0`). The following operations are fully NUL-safe: `byte_len`, `length`, `==`, `!=`, `<`, `>`, `+`, `*`, hash/Map/Set key lookup (#1022), `contains`, `starts_with`, `ends_with`, `find` (#1047), and `replace` (#1048). Other operations (`split`, `substring`, `char_at`, etc.) may still truncate at the first NUL byte.
+>
+> **Index access:** `str` does not support `[]` index syntax. Use `char_at(s, i)` to get the character at position `i`.
 
 ## Function List
 

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -522,6 +522,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     if (objPtr->getType() != ptrTy_)
         codegenError("index operator requires list or map");
 
+    if (isStringValue(objPtr))
+        codegenError("str does not support index access; use char_at(s, i) instead");
+
     // Check if this is a map
     llvm::Type *mapKeyTy = getMapKeyType(objPtr);
     if (mapKeyTy) {

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -892,6 +892,8 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     }
 
     // List index assignment
+    if (isStringValue(objPtr))
+        codegenError("str does not support index assignment; strings are immutable");
     objPtr = emitCowCheck(objPtr, receiverAlloca, CollectionKind::List);
     llvm::Type *elemTy = getListElementType(objPtr);
     if (!elemTy)

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -632,3 +632,21 @@ TEST_F(CodeGenTest, DuplicateUnionTypeAliasRejected) {
         "type Foo = bool | str\n",
         "type alias 'Foo' is already defined");
 }
+
+// ============================================================
+// str does not support index access (#1026)
+// ============================================================
+
+TEST_F(CodeGenTest, StrIndexAccessRejected) {
+    expectCompileError(
+        "s = \"hello\"\n"
+        "_ = s[0]\n",
+        "does not support index access");
+}
+
+TEST_F(CodeGenTest, StrIndexAssignmentRejected) {
+    expectCompileError(
+        "s = \"hello\"\n"
+        "s[0] = \"x\"\n",
+        "does not support index assignment");
+}


### PR DESCRIPTION
## Summary

- `str[i]` and `str[i] = v` previously fell through to the list-element-type lookup in codegen, producing the misleading `cannot determine list element type for index access` error. This change adds an `isStringValue()` guard in both `emitExprVariant(IndexExpr)` and `emitStmt(IndexAssignStmt)` that fires before the list/map dispatch and emits a targeted message.
- The write-path guard is placed **before** `emitCowCheck(..., CollectionKind::List)` to avoid corrupting state by passing a `str` pointer as a list.
- Added two `expectCompileError` regression tests and a note in the string reference docs.

Closes #1026

## Test plan

- [ ] `./build/ry_tests --gtest_filter="CodeGenTest.StrIndex*"` — 2 new tests pass
- [ ] `./build/ry_tests` — all 1717 tests pass
- [ ] `./build/ry test -p` — 131 spec files, 0 failures
- [ ] ASan + UBSan: clean
- [ ] TSan (C++ tests): clean
- [ ] Manual: `./build/ry /tmp/repro_read.ry` → `str does not support index access; use char_at(s, i) instead`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error diagnostics for string indexing operations; attempting to read or write string elements using `[]` now produces clearer error messages directing users to use `char_at(s, i)` instead of the previous misleading diagnostic.

* **Documentation**
  * Added clarification to the string builtin reference that strings do not support `[]` index access and users should use `char_at(s, i)` to retrieve characters at specific positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->