### PR TITLE
fix(codegen): make is_empty NUL-safe by reading byte_len (#1069)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1155,7 +1155,7 @@ Key constants:
 **How to free a dynamic str**: `freeStringSlot(handle)` — calls `free(handle - STRING_HEADER_SIZE)`.  
 **Literal globals**: created by `buildArcGlobal` in `src/codegen.cpp`; `strong_count = ARC_IMMORTAL` so retain/release are no-ops. GEP index is `(0, 3, 0)` into the struct.
 
-**NUL safety**: `byte_len`, `length`, `==`/`!=`/`<`/`>`, `+`, `*`, Map/Set key hash+compare (#1022), `contains`, `starts_with`, `ends_with`, `find` (#1047), `replace` (#1048), `substring`, `char_at`, `reverse`, `split("", _)`, `for c in str:`, `enumerate(str)` (#1049) are NUL-safe. Remaining op (non-empty-delim `split`) still uses `strstr` internally — NUL truncates it. Track in follow-up issues.
+**NUL safety**: `byte_len`, `length`, `==`/`!=`/`<`/`>`, `+`, `*`, Map/Set key hash+compare (#1022), `contains`, `starts_with`, `ends_with`, `find` (#1047), `replace` (#1048), `substring`, `char_at`, `reverse`, `split("", _)`, `for c in str:`, `enumerate(str)` (#1049), `is_empty` (#1069) are NUL-safe. Remaining op (non-empty-delim `split`) still uses `strstr` internally — NUL truncates it. Track in follow-up issues.
 
 **`markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`** (Source: #1016):
 TuplePattern / RecordPattern / EnumConstructorPattern pre-mark a temporary alloca

--- a/changelog.d/1069-is-empty-nul-safe.md
+++ b/changelog.d/1069-is-empty-nul-safe.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `is_empty` on strings now honours embedded NUL bytes instead of returning `true` for strings that begin with `\0`. The check now reads `byte_len` from the StringHeader (via `emitStringByteLen`) instead of comparing only the first byte (#1069).

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -301,11 +301,13 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
             llvm::Value *len = builder_.CreateLoad(i64Ty_, builder_.CreateStructGEP(headerTy, val, 0), "ie_len");
             return builder_.CreateICmpEQ(len, llvm::ConstantInt::get(i64Ty_, 0), "is_empty");
         }
-        // String (#831): peek the first byte. Ry strings are NUL-terminated,
-        // so emptiness is O(1) — avoid walking the whole string via __ry_utf8_len.
+        // String (#831, #1022, #1069): read byte_len from the StringHeader instead of
+        // peeking the first data byte — embedded NUL bytes are valid string content
+        // (tracked by byte_len since #1022) and must not be mistaken for an empty
+        // string. emitStringByteLen is also O(1) (a single i64 load from handle - 8).
         if (val->getType() == ptrTy_) {
-            llvm::Value *firstByte = builder_.CreateLoad(i8Ty_, val, "ie_first_byte");
-            return builder_.CreateICmpEQ(firstByte, llvm::ConstantInt::get(i8Ty_, 0), "is_empty");
+            llvm::Value *len = emitStringByteLen(val);
+            return builder_.CreateICmpEQ(len, llvm::ConstantInt::get(i64Ty_, 0), "is_empty");
         }
         codegenError("is_empty() requires a collection (list, map, set) or str");
     }

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -98,6 +98,16 @@ describe("is_empty on strings (#831)", ():
     expect(is_empty("")).to_eq(true)
     expect(is_empty("日本語")).to_eq(false)
   )
+  it("should return false for single NUL byte (#1069)", ():
+    expect(is_empty("\0")).to_eq(false)
+    expect("\0".is_empty()).to_eq(false)
+  )
+  it("should return false for multiple NUL bytes (#1069)", ():
+    expect(is_empty("\0\0")).to_eq(false)
+  )
+  it("should return false for string starting with NUL (#1069)", ():
+    expect(is_empty("\0abc")).to_eq(false)
+  )
 )
 
 describe("case conversion", ():


### PR DESCRIPTION
## Summary

- `is_empty` on strings was comparing the first data byte to `\0` to detect an empty string. Since #1022 introduced `StringHeader` with an explicit `byte_len` field, embedded NUL bytes are valid string content — a string like `"\0"` has `byte_len=1` and is not empty.
- Fix: replace the first-byte peek with `emitStringByteLen(val)` (reads `byte_len` from `handle - 8`) and compare it to zero — the same O(1) pattern already used for `list`/`map`/`set` `is_empty`.
- Both `is_empty(s)` and `s.is_empty()` (UFCS) go through the same codegen branch, so both are fixed by this single change.

Closes #1069

## Test plan

- [ ] `./build/ry test tests/spec/strings.test.ry` — 3 new NUL cases pass (`"\0"`, `"\0\0"`, `"\0abc"`; UFCS form included)
- [ ] `./build/ry_tests` — 1724 C++ tests pass (no regressions)
- [ ] `./build/ry test -p` — 131 files, 0 failures
- [ ] ASan + UBSan — 1724 C++ / 131 Ry files all clean
- [ ] TSan (`ry_tests`) — 1724 tests pass, no races

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `is_empty` to correctly handle strings with embedded NUL bytes. Previously, strings beginning with `\0` were incorrectly reported as empty. The function now properly uses the string's total byte length for the emptiness check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->