### PR TITLE
fix(weak): resolve type aliases in weakInnerTypeName callsites for correct StringHeader offset (#1060)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1307,6 +1307,25 @@ llvm::Value *headerPtr = (weakInner == "str")
 
 `emitExprVariant(WeakExpr)` (codegen_expr.cpp) must return the raw data pointer; the conversion happens at the call sites above, not inside the emitter.
 
+### `weak T` header-offset dispatch requires alias resolution
+
+**Source**: #1060 (2026-04-17, implementation)
+**Tags**: codegen, weak, str, StringHeader, type-alias, resolveTypeAlias, emitWeakUpgrade
+
+**Rule**: `weakInnerTypeName()` only strips the `"weak "` prefix — it does **not** resolve type aliases. Before comparing the result to `"str"` (to pick `STRING_HEADER_SIZE` vs `ARC_HEADER_SIZE`), callers must feed the result through `resolveTypeAlias`. The preferred pattern is to store the resolved name at the single write site (`codegen_stmt.cpp LetStmt`) so all downstream readers get the canonical form:
+
+```cpp
+// codegen_stmt.cpp — initial let (resolve at the write site so all readers get canonical name)
+std::string innerName = resolveTypeAlias(weakInnerTypeName(*annot));
+// stored into weak_inner_type_names_[ptr]
+
+// codegen_arc.cpp — emitWeakUpgrade (defensive resolve inside the emitter)
+const std::string resolvedInner = resolveTypeAlias(innerTypeName);
+// use resolvedInner == "str" (not innerTypeName) for the two data-pointer dispatch branches
+```
+
+**Why**: `type MyStr = str; w: weak MyStr = weak s` passes `"weak MyStr"` to `weakInnerTypeName`, yielding `"MyStr"`. Without `resolveTypeAlias`, `"MyStr" == "str"` is false → `ARC_HEADER_SIZE` (16) is used instead of `STRING_HEADER_SIZE` (24) → `emitWeakRetain`'s atomic add hits `byte_len` (at `handle−8`) instead of `strong_count` → corrupts `byte_len` → UB / wrong comparison result. Keep `weakInnerTypeName` as a pure static string-slice helper so error messages preserve the user-written alias name (not the resolved RHS).
+
 ---
 
 ## Parser / Lexer

--- a/changelog.d/1060-weak-alias-header-offset.md
+++ b/changelog.d/1060-weak-alias-header-offset.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `weak <alias>` where the alias resolves to `str` now uses the correct `StringHeader`
+  offset instead of the `ArcHeader` offset. Without this fix, weak upgrade of a str-alias
+  weak ref could load the wrong `strong_count` and crash or return wrong results (#1060)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -294,7 +294,13 @@ s = "hello"
 w: weak str = weak s
 ```
 
-The type `weak T` is a new type constructor where `T` must be an ARC-managed type (currently `str`, `List<T>`, `Map<K, V>`, `Set<T>`).
+The type `weak T` is a new type constructor where `T` must be an ARC-managed type (currently `str`, `List<T>`, `Map<K, V>`, `Set<T>`). `T` may also be a type alias that resolves to one of these managed types — the compiler resolves aliases to their canonical form at the point the weak variable is declared.
+
+```python
+type MyStr = str
+s = "hello"
+w: weak MyStr = weak s   # MyStr resolves to str — works correctly
+```
 
 ### Accessing a Weak Reference (Upgrade)
 

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -647,6 +647,7 @@ void CodeGen::emitWeakRelease(llvm::Value *headerPtr) {
 
 llvm::Value *CodeGen::emitWeakUpgrade(llvm::Value *headerPtr,
                                        const std::string &innerTypeName) {
+    const std::string resolvedInner = resolveTypeAlias(innerTypeName);
     auto *innerTy = resolveType(innerTypeName);
     auto *optionTy = getOptionType(innerTy);
 
@@ -671,7 +672,7 @@ llvm::Value *CodeGen::emitWeakUpgrade(llvm::Value *headerPtr,
     // Immortal path: return Some(data_ptr) without incrementing
     builder_.SetInsertPoint(immortalBB);
     // str uses StringHeader (24 bytes); other ARC types use ArcHeader (16 bytes).
-    auto *immortalDataPtr = (innerTypeName == "str")
+    auto *immortalDataPtr = (resolvedInner == "str")
         ? emitStrGetDataPtr(headerPtr)
         : emitArcGetDataPtr(headerPtr);
     auto *immortalSome = buildSomeValue(immortalDataPtr, optionTy);
@@ -698,7 +699,7 @@ llvm::Value *CodeGen::emitWeakUpgrade(llvm::Value *headerPtr,
 
     // Success: strong_count incremented, return Some(data_ptr)
     builder_.SetInsertPoint(successBB);
-    auto *dataPtr = (innerTypeName == "str")
+    auto *dataPtr = (resolvedInner == "str")
         ? emitStrGetDataPtr(headerPtr)
         : emitArcGetDataPtr(headerPtr);
     auto *someVal = buildSomeValue(dataPtr, optionTy);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -646,7 +646,7 @@ void CodeGen::emitVarDecl(const std::string &name,
         if (annot && isWeakTypeName(*annot)) {
             if (!std::get_if<std::unique_ptr<WeakExpr>>(&value.data))
                 codegenError("weak-typed variable must be initialized with a 'weak' expression");
-            std::string innerName = weakInnerTypeName(*annot);
+            std::string innerName = resolveTypeAlias(weakInnerTypeName(*annot));
             // str uses StringHeader (24 bytes before the data pointer) while
             // other ARC types use ArcHeader (16 bytes). isStringValue() cannot
             // be used here because captured List/Map/Set values may lack

--- a/tests/spec/weak_ref.test.ry
+++ b/tests/spec/weak_ref.test.ry
@@ -59,3 +59,58 @@ describe("Weak references", ():
         fail("expected Some after reassignment")
   )
 )
+
+type WeakAliasStr1 = str
+type WeakAliasList1 = List<int>
+type WeakAliasA = str
+type WeakAliasB = WeakAliasA
+type WeakAliasStr2 = str
+
+describe("Weak references with type aliases", ():
+  it("alias for str — upgrade returns correct string", ():
+    s: str = "hello"
+    w: weak WeakAliasStr1 = weak s
+    case w:
+      Some(v):
+        expect(v).to_eq("hello")
+      None:
+        fail("expected Some but got None")
+  )
+
+  it("alias for List<T> — upgrade returns correct collection", ():
+    xs: List<int> = [1, 2, 3]
+    w: weak WeakAliasList1 = weak xs
+    case w:
+      Some(v):
+        expect(v.length()).to_eq(3)
+      None:
+        fail("expected Some but got None")
+  )
+
+  it("alias-of-alias for str — iterative resolution", ():
+    s: str = "hello"
+    w: weak WeakAliasB = weak s
+    case w:
+      Some(v):
+        expect(v).to_eq("hello")
+      None:
+        fail("expected Some but got None")
+  )
+
+  it("reassignment of alias-str weak ref", ():
+    s1: str = "hello"
+    s2: str = "world"
+    w: weak WeakAliasStr2 = weak s1
+    case w:
+      Some(v):
+        expect(v).to_eq("hello")
+      None:
+        fail("expected Some for s1")
+    w = weak s2
+    case w:
+      Some(v):
+        expect(v).to_eq("world")
+      None:
+        fail("expected Some for s2")
+  )
+)


### PR DESCRIPTION
## Summary

- **Root cause**: `weakInnerTypeName()` strips the `"weak "` prefix but does not resolve type aliases. When writing `type MyStr = str; w: weak MyStr = weak s`, the stored inner name was `"MyStr"` instead of `"str"`. The `innerName == "str"` dispatch fell through to `ARC_HEADER_SIZE` (16) instead of `STRING_HEADER_SIZE` (24), making `emitWeakRetain`'s atomic add land on `byte_len` rather than `strong_count` — corrupting the StringHeader and producing UB / wrong upgrade results.
- **Fix 1** (`codegen_stmt.cpp:649`): resolve at the single write site with `resolveTypeAlias(weakInnerTypeName(*annot))` so all downstream readers (`weak_inner_type_names_`, reassignment, auto-upgrade in `codegen_expr.cpp`) get the canonical name.
- **Fix 2** (`codegen_arc.cpp emitWeakUpgrade`): defensive `resolveTypeAlias` call at the top of `emitWeakUpgrade`, guarding future callers that may pass an unresolved alias.

## Test plan

- [ ] New `describe("Weak references with type aliases")` block in `tests/spec/weak_ref.test.ry` with 4 cases:
  1. `weak WeakAliasStr1` (`= str`) — upgrade returns correct string `"hello"`
  2. `weak WeakAliasList1` (`= List<int>`) — non-regression: collection alias still dispatches correctly
  3. `weak WeakAliasB` (alias-of-alias: `B = A`, `A = str`) — iterative resolution via `resolveTypeAlias` loop
  4. Reassignment of alias-str weak ref — confirms stored name is canonical
- [ ] All 9 weak-ref tests pass (verified failure before fix, pass after)
- [ ] `ry_tests` 1763/1763 pass
- [ ] `ry test -p` 131 files, 0 failures
- [ ] ASan + UBSan clean
- [ ] TSan clean

Closes #1060

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed weak reference behavior for type aliases that resolve to `str`; now correctly uses the string header offset instead of ARC header offset, preventing potential crashes during weak upgrades.

* **Documentation**
  * Updated type reference documentation to clarify that weak references can use type aliases that resolve to ARC-managed types.

* **Tests**
  * Added comprehensive test coverage for weak references with type aliases, including nested alias chains and reassignment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->