### PR TITLE
fix(bytes_to_str): reject non-u8 list args at compile time (#1055)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2824,6 +2824,8 @@ Only `to_have_length` and `to_be_empty` are NUL-safe matchers besides `to_eq(boo
 
 **Source**: PR #1055. **Tags**: codegen, runtime, IOListHeader, ListHeader, bytes_to_str, write_bytes, send
 
+**Rule**: Any native function that casts a `List` argument to `IOListHeader *` must set `NativeDispatchEntry::requireListU8Arg` to the 0-based index of that argument (or stamp `ListElemMeta::I8` for producers). Codegen enforces the gate via `CodeGen::emitTableDrivenNativeCall`. Do not add a new byte-list consumer without updating the audit table above and adding this field.
+
 `IOListHeader` (`include/ry/runtime_io.hpp`) reads `data` with 1-byte stride (`int8_t *`).
 Plain Ry list literals like `[97, 0, 98]` default element type to `int`, which codegen stores
 with 8-byte (`i64`) stride. Passing such a list to a byte-list consumer produces silent memory

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2800,3 +2800,46 @@ expect(expr).to_eq("a\0b")           # NUL-truncating: strcmp stops at \0
 ```
 Assertions whose expected value has no embedded NUL are safe to leave as `to_eq("literal")`.
 Only `to_have_length` and `to_be_empty` are NUL-safe matchers besides `to_eq(bool)`.
+
+### Byte-list APIs require `TypeMeta::ListElem == i8Ty_`; plain int list literals are rejected at compile time
+
+**Source**: PR #1055. **Tags**: codegen, runtime, IOListHeader, ListHeader, bytes_to_str, write_bytes, send
+
+`IOListHeader` (`include/ry/runtime_io.hpp`) reads `data` with 1-byte stride (`int8_t *`).
+Plain Ry list literals like `[97, 0, 98]` default element type to `int`, which codegen stores
+with 8-byte (`i64`) stride. Passing such a list to a byte-list consumer produces silent memory
+corruption (reads 8× too much data, interprets padding as bytes).
+
+**Why rejected at compile time**: `IOListHeader` and `ListHeader` share the same LLVM struct
+shape (`{i64 len, i64 cap, ptr data}`), so no runtime flag can distinguish them without an ABI
+break. A compile-time gate is the only safe option.
+
+**Four byte-list consumers** (all gated to require `TypeMeta::ListElem == i8Ty_`):
+
+| Consumer | Gate location |
+|---|---|
+| `bytes_to_str` | `src/codegen_call_io.cpp` table, `requireListU8Arg = 0` |
+| `write_bytes` | `src/codegen_call_io.cpp` table, `requireListU8Arg = 1` |
+| `tcp_send` / `tls_send` | `src/codegen_call.cpp:577-595` (inline guard) |
+
+**Four byte-list producers** (all stamp `TypeMeta::ListElem = i8Ty_`):
+
+| Producer | Location |
+|---|---|
+| `to_bytes` | `src/codegen_call_io.cpp` table, `ListElemMeta::I8` |
+| `read_bytes` | `src/codegen_call_io.cpp` table, `ListElemMeta::I8` |
+| `tcp_receive` / `tls_receive` | `src/codegen_call.cpp:616` |
+| HTTP `body_bytes` | `src/codegen_call_io.cpp:337` |
+
+**Gate mechanism**: `NativeDispatchEntry::requireListU8Arg` (field in
+`include/ry/codegen.hpp`) holds the 0-based arg index to check; `-1` means no check.
+Enforced in `CodeGen::emitTableDrivenNativeCall` (`src/codegen_call_native.cpp`).
+
+**How to apply**: When adding a new byte-list consumer that casts its argument to
+`IOListHeader *`, set `requireListU8Arg` in its table entry and add the function to the
+audit table above. When adding a new byte-list producer, set `ListElemMeta::I8` in its
+entry or call `setTypeMeta(TypeMeta::ListElem, result, i8Ty_)` post-call.
+
+**Deferred**: `let bs: List<u8> = [97, 0, 98]` still compiles with i64 stride because
+`injectLowLevelSuffix` does not descend into `ListExpr` elements. After the #1055 gate,
+`bytes_to_str(bs)` will fail. A follow-up issue tracks annotation-driven `u8` inference.

--- a/changelog.d/1055-bytes-to-str-require-list-u8.md
+++ b/changelog.d/1055-bytes-to-str-require-list-u8.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `bytes_to_str()` and `write_bytes()` now reject non-`u8` list arguments at compile time instead of silently producing garbage output. Plain integer list literals like `[97, 0, 98]` use 64-bit element layout incompatible with the byte-list runtime; passing them previously caused corrupted output. Use `[97u8, 0u8, 98u8]` (explicit `u8` literals) or `to_bytes("...")` instead (#1055).

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -116,5 +116,6 @@ case read_text("missing.txt"):
 ## Notes
 
 - `List<u8>` is used as the buffer type. Standard list operations (`length()`, `append()`, `slice()`, index access) all work with byte lists.
+- `bytes_to_str()` and `write_bytes()` require a `List<u8>` argument. Use explicit `u8` suffixes (`[97u8, 0u8, 98u8]`) or `to_bytes("...")` to produce a compatible byte list. Plain integer list literals like `[97, 0, 98]` use 64-bit element layout and are rejected at compile time.
 - File paths are relative to the current working directory unless absolute paths are specified.
 - `write_text` and `write_bytes` overwrite existing files. Use `append_text` to add content to existing files.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -82,6 +82,7 @@ public:
         const char *rtNameOverride = nullptr;      // full runtime name (e.g. "sin", "__ry_file_exists")
         const char *errFnOverride = nullptr;       // error function override (nullptr = derive from package)
         ListElemMeta listElemMeta = ListElemMeta::None;  // post-call TypeMeta::ListElem annotation
+        int requireListU8Arg = -1;  // arg index that must carry TypeMeta::ListElem==i8; -1=no check
     };
 
     // Access the @native function signature registry.

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -130,14 +130,14 @@ static const CodeGen::NativeDispatchEntry io_table[] = {
     {"read_text",   nullptr, CodeGen::ReturnWrapping::ResultPtr,    1, nullptr,
      nullptr, "__ry_read_text", IO_ERR},
     {"bytes_to_str",nullptr, CodeGen::ReturnWrapping::ResultPtr,    1, nullptr,
-     nullptr, "__ry_bytes_to_str", IO_ERR},
+     nullptr, "__ry_bytes_to_str", IO_ERR, CodeGen::ListElemMeta::None, 0},
     // 2-arg -> Result<Unit, Error>
     {"write_text",  nullptr, CodeGen::ReturnWrapping::ResultStatus, 2, nullptr,
      nullptr, "__ry_write_text", IO_ERR},
     {"append_text", nullptr, CodeGen::ReturnWrapping::ResultStatus, 2, nullptr,
      nullptr, "__ry_append_text", IO_ERR},
     {"write_bytes", nullptr, CodeGen::ReturnWrapping::ResultStatus, 2, nullptr,
-     nullptr, "__ry_write_bytes", IO_ERR},
+     nullptr, "__ry_write_bytes", IO_ERR, CodeGen::ListElemMeta::None, 1},
     // 1-arg -> Result<Unit, Error>
     {"delete_file", nullptr, CodeGen::ReturnWrapping::ResultStatus, 1, nullptr,
      nullptr, "__ry_delete_file", IO_ERR},

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -246,6 +246,16 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         args.push_back(outSlot);
     }
 
+    // Reject list arguments whose element type is not i8 (e.g. bare int literals
+    // produce i64-stride lists that are incompatible with IOListHeader).
+    if (entry->requireListU8Arg >= 0) {
+        auto argIdx = static_cast<size_t>(entry->requireListU8Arg);
+        if (!getListElementType(args[argIdx]) || getListElementType(args[argIdx]) != i8Ty_)
+            codegenError(std::string(entry->fnName) + "() requires List<u8> as argument " +
+                         std::to_string(argIdx) + "; use [97u8, 0u8, 98u8]"
+                         " (explicit u8 literals) or to_bytes(\"...\") to produce a byte list");
+    }
+
     auto *fnTy = llvm::FunctionType::get(cRetTy, paramLLVMTypes, false);
     auto fn = mod_->getOrInsertFunction(rtName, fnTy);
     llvm::Value *callResult;

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -249,8 +249,12 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     // Reject list arguments whose element type is not i8 (e.g. bare int literals
     // produce i64-stride lists that are incompatible with IOListHeader).
     if (entry->requireListU8Arg >= 0) {
-        auto argIdx = static_cast<size_t>(entry->requireListU8Arg);
-        if (!getListElementType(args[argIdx]) || getListElementType(args[argIdx]) != i8Ty_)
+        const auto argIdx = static_cast<size_t>(entry->requireListU8Arg);
+        if (argIdx >= args.size())
+            codegenError(std::string(entry->fnName) +
+                         "() has invalid requireListU8Arg dispatch metadata");
+        llvm::Type *elemTy = getListElementType(args[argIdx]);
+        if (!elemTy || elemTy != i8Ty_)
             codegenError(std::string(entry->fnName) + "() requires List<u8> as argument " +
                          std::to_string(argIdx) + "; use [97u8, 0u8, 98u8]"
                          " (explicit u8 literals) or to_bytes(\"...\") to produce a byte list");

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -135,7 +135,7 @@ describe("file I/O", ():
   it("should convert u8 list literal including embedded NUL to str", ():
     case bytes_to_str([97u8, 0u8, 98u8]):
       Ok(s):
-        expect(byte_len(s)).to_eq(3)
+        expect(s == "a\0b").to_eq(true)
       Err(e):
         fail("unexpected error")
   )
@@ -145,6 +145,11 @@ describe("file I/O", ():
         case read_bytes("/tmp/ry_selftest_io_u8lit.bin"):
           Ok(rb):
             expect(length(rb)).to_eq(3)
+            case bytes_to_str(rb):
+              Ok(s):
+                expect(s == "a\0b").to_eq(true)
+              Err(e):
+                fail("unexpected decode error")
           Err(e):
             fail("unexpected read error")
       Err(e):

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -132,4 +132,31 @@ describe("file I/O", ():
         fail("unexpected error")
     delete_file("/tmp/ry_selftest_io_overwrite.txt")
   )
+  it("should convert u8 list literal including embedded NUL to str", ():
+    case bytes_to_str([97u8, 0u8, 98u8]):
+      Ok(s):
+        expect(byte_len(s)).to_eq(3)
+      Err(e):
+        fail("unexpected error")
+  )
+  it("should write and read back u8 list literal with embedded NUL", ():
+    case write_bytes("/tmp/ry_selftest_io_u8lit.bin", [97u8, 0u8, 98u8]):
+      Ok(_):
+        case read_bytes("/tmp/ry_selftest_io_u8lit.bin"):
+          Ok(rb):
+            expect(length(rb)).to_eq(3)
+          Err(e):
+            fail("unexpected read error")
+      Err(e):
+        fail("unexpected write error")
+    delete_file("/tmp/ry_selftest_io_u8lit.bin")
+  )
+  it("should convert to_bytes output back to str (regression guard)", ():
+    data = to_bytes("hello")
+    case bytes_to_str(data):
+      Ok(s):
+        expect(s).to_eq("hello")
+      Err(e):
+        fail("unexpected error")
+  )
 )

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -92,6 +92,19 @@ protected:
         }
     }
 
+    static void expectCompileError(const std::string &src,
+                                   std::initializer_list<std::string> fragments) {
+        try {
+            compileSource(src);
+            FAIL() << "Expected compile error";
+        } catch (const std::runtime_error &e) {
+            std::string msg = e.what();
+            for (const auto &frag : fragments)
+                EXPECT_NE(msg.find(frag), std::string::npos)
+                    << "Expected error to contain: '" << frag << "', got: " << msg;
+        }
+    }
+
     static std::string runTestSource(const std::string &src) {
         Lexer lex(src);
         Parser parser(lex);
@@ -105,6 +118,7 @@ protected:
     static std::string runSourceWithArgs(const std::string &src, const std::vector<std::string> &args) {
         std::vector<const char*> argv_ptrs;
         std::vector<std::string> owned_args(args);
+        argv_ptrs.reserve(owned_args.size());
         for (const auto &a : owned_args)
             argv_ptrs.push_back(a.c_str());
         __ry_args_init(static_cast<int>(argv_ptrs.size()),

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -795,50 +795,25 @@ function write_bytes(path: str, data: List<u8>) -> Result<Unit, Error>
 )";
 
 TEST_F(CodeGenTest, BytesToStrIntListRejected) {
-    std::string err;
-    try {
-        compileSource(IO_DECLS_1055 + R"(
+    expectCompileError(IO_DECLS_1055 + R"(
 case bytes_to_str([97, 0, 98]):
     Ok(s): print(s)
     Err(e): print(e.message)
-)");
-    } catch (const std::runtime_error &e) {
-        err = e.what();
-    }
-    EXPECT_NE(err.find("bytes_to_str"), std::string::npos) << "error was: " << err;
-    EXPECT_NE(err.find("List<u8>"), std::string::npos) << "error was: " << err;
-    EXPECT_NE(err.find("97u8"), std::string::npos) << "error was: " << err;
-    EXPECT_NE(err.find("to_bytes"), std::string::npos) << "error was: " << err;
+)", {"bytes_to_str", "List<u8>", "97u8", "to_bytes"});
 }
 
 TEST_F(CodeGenTest, WriteBytesIntListRejected) {
-    std::string err;
-    try {
-        compileSource(IO_DECLS_1055 + R"(
+    expectCompileError(IO_DECLS_1055 + R"(
 case write_bytes("/tmp/x", [97, 0, 98]):
     Ok(_): print("ok")
     Err(e): print(e.message)
-)");
-    } catch (const std::runtime_error &e) {
-        err = e.what();
-    }
-    EXPECT_NE(err.find("write_bytes"), std::string::npos) << "error was: " << err;
-    EXPECT_NE(err.find("List<u8>"), std::string::npos) << "error was: " << err;
-    EXPECT_NE(err.find("97u8"), std::string::npos) << "error was: " << err;
-    EXPECT_NE(err.find("to_bytes"), std::string::npos) << "error was: " << err;
+)", {"write_bytes", "List<u8>", "97u8", "to_bytes"});
 }
 
 TEST_F(CodeGenTest, BytesToStrU16ListRejected) {
-    std::string err;
-    try {
-        compileSource(IO_DECLS_1055 + R"(
+    expectCompileError(IO_DECLS_1055 + R"(
 case bytes_to_str([97u16, 0u16, 98u16]):
     Ok(s): print(s)
     Err(e): print(e.message)
-)");
-    } catch (const std::runtime_error &e) {
-        err = e.what();
-    }
-    EXPECT_NE(err.find("bytes_to_str"), std::string::npos) << "error was: " << err;
-    EXPECT_NE(err.find("List<u8>"), std::string::npos) << "error was: " << err;
+)", {"bytes_to_str", "List<u8>"});
 }

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -782,3 +782,63 @@ TEST_F(CodeGenTest, StrIndexAssignmentRejected) {
         "s[0] = \"x\"\n",
         "does not support index assignment");
 }
+
+// ============================================================
+// bytes_to_str / write_bytes require List<u8> (#1055)
+// ============================================================
+
+static const std::string IO_DECLS_1055 = R"(
+@native
+function bytes_to_str(bs: List<u8>) -> Result<str, Error>
+@native
+function write_bytes(path: str, data: List<u8>) -> Result<Unit, Error>
+)";
+
+TEST_F(CodeGenTest, BytesToStrIntListRejected) {
+    std::string err;
+    try {
+        compileSource(IO_DECLS_1055 + R"(
+case bytes_to_str([97, 0, 98]):
+    Ok(s): print(s)
+    Err(e): print(e.message)
+)");
+    } catch (const std::runtime_error &e) {
+        err = e.what();
+    }
+    EXPECT_NE(err.find("bytes_to_str"), std::string::npos) << "error was: " << err;
+    EXPECT_NE(err.find("List<u8>"), std::string::npos) << "error was: " << err;
+    EXPECT_NE(err.find("97u8"), std::string::npos) << "error was: " << err;
+    EXPECT_NE(err.find("to_bytes"), std::string::npos) << "error was: " << err;
+}
+
+TEST_F(CodeGenTest, WriteBytesIntListRejected) {
+    std::string err;
+    try {
+        compileSource(IO_DECLS_1055 + R"(
+case write_bytes("/tmp/x", [97, 0, 98]):
+    Ok(_): print("ok")
+    Err(e): print(e.message)
+)");
+    } catch (const std::runtime_error &e) {
+        err = e.what();
+    }
+    EXPECT_NE(err.find("write_bytes"), std::string::npos) << "error was: " << err;
+    EXPECT_NE(err.find("List<u8>"), std::string::npos) << "error was: " << err;
+    EXPECT_NE(err.find("97u8"), std::string::npos) << "error was: " << err;
+    EXPECT_NE(err.find("to_bytes"), std::string::npos) << "error was: " << err;
+}
+
+TEST_F(CodeGenTest, BytesToStrU16ListRejected) {
+    std::string err;
+    try {
+        compileSource(IO_DECLS_1055 + R"(
+case bytes_to_str([97u16, 0u16, 98u16]):
+    Ok(s): print(s)
+    Err(e): print(e.message)
+)");
+    } catch (const std::runtime_error &e) {
+        err = e.what();
+    }
+    EXPECT_NE(err.find("bytes_to_str"), std::string::npos) << "error was: " << err;
+    EXPECT_NE(err.find("List<u8>"), std::string::npos) << "error was: " << err;
+}


### PR DESCRIPTION
## Summary

- `bytes_to_str()` and `write_bytes()` now reject non-`u8` list arguments at compile time instead of silently producing garbage output
- Plain integer list literals like `[97, 0, 98]` compile with 64-bit (`i64`) element stride, while `IOListHeader *` reads with 1-byte stride — passing them previously caused silent memory corruption
- Mirrors the existing `send()` gate (`src/codegen_call.cpp:577-595`): checks `TypeMeta::ListElem == i8Ty_` before emitting the runtime call
- Error message names both workarounds: `[97u8, 0u8, 98u8]` (explicit `u8` literals) and `to_bytes("...")`

## Implementation

- `NativeDispatchEntry` gets a new `int requireListU8Arg = -1` field (`include/ry/codegen.hpp`)
- Gate inserted in `emitTableDrivenNativeCall` (`src/codegen_call_native.cpp`) — fires after args are collected, before the runtime call
- `bytes_to_str` tagged `requireListU8Arg=0`, `write_bytes` tagged `requireListU8Arg=1` (`src/codegen_call_io.cpp`)

## Tests

- 3 negative codegen tests (`tests/test_codegen_type_safety.cpp`): plain `int` list rejected for both functions; `u16` list also rejected (confirms gate checks `i8Ty_` specifically)
- 3 positive spec tests (`tests/spec/io.test.ry`): `[97u8, 0u8, 98u8]` round-trips correctly including embedded NUL; `to_bytes` path unchanged

## Closes

Closes #1055

## Related

- Follow-up: annotation-driven `u8` inference for `let bs: List<u8> = [97, 0, 98]` → #1079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `bytes_to_str()` and `write_bytes()` now reject non-`List<u8>` arguments at compile time to prevent silent data corruption; plain integer list literals are rejected—use explicit `u8` literals (e.g., `[97u8, 0u8, 98u8]`) or `to_bytes("...")`.

* **Documentation**
  * Updated reference docs and added a KNOWLEDGE lesson explaining the compile-time enforcement and recommended byte-list usage; added changelog entry for the behavior change.

* **Tests**
  * Added tests covering byte/string conversion, file I/O round-trips, and type-safety compile-time failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->