### PR TITLE
fix(fold): accept untyped lambdas via wrapInAny seed coercion (#1061)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2595,22 +2595,32 @@ not detect uninit reads.
 
 ### `fold()` rejects untyped lambda with type-check error (#1061)
 
-**Source**: #1061 (2026-04-16, discovered during pre-verification for #1033)
+**Source**: #1061 (2026-04-16, discovered during pre-verification for #1033; resolved in fix/1061-fold-untyped-lambda)
 **Tags**: codegen, fold, untyped-lambda, type-check
 
-**Context**: `fold(xs, 0, (a, b) => a + b)` produces a compile error:
+**Context**: `fold(xs, 0, (a, b) => a + b)` produced a compile error:
 `fold() initial value type must match function return type`. Unlike `reduce()` which was
 patched in #1020 to accept untyped lambdas, `fold()` was not given the same treatment.
 The type-check logic in `fold`'s emitter validates that the initial value type matches the
 lambda's return type; when both params are untyped the lambda returns `any`, while `0` is
 inferred as `int` — causing the mismatch.
 
+**Fix** (`src/codegen_call_higher_order.cpp:287-290`): Insert `wrapInAny(initVal)` coercion
+before the equality check, mirroring the reduce fix at L247-248:
+```cpp
+if (isAnyType(info.returnType) && !isAnyType(initVal->getType()))
+    initVal = wrapInAny(initVal);
+```
+The equality check is preserved — it still rejects genuine typed-lambda mismatches such as
+`fold([1,2,3], "hi", (a: int, b: int) => a + b)`.
+
 **Rule**: When applying a fix for untyped-lambda compatibility to one higher-order function
 (e.g., `reduce`), audit all sibling functions with similar emitters (`fold`, `scan`, etc.)
 for the same gap. Do not assume a fix to one function automatically covers others.
 
-**How to verify**: Issue #1061 tracks the fix. Until resolved, `fold` only works with typed
-lambda params (e.g., `(a: int, b: int) => a + b`).
+**How to verify**: `tests/spec/collections.test.ry` — untyped-lambda fold cases (int seed,
+float seed, string seed); `tests/test_codegen_fail.cpp::FoldTypedLambdaSeedTypeMismatch`
+verifies the preserved rejection branch.
 
 ### `reduce()` rejects `(a, b) -> ReturnType => body` annotation when params are untyped (#1062)
 

--- a/changelog.d/1061-fold-untyped-lambda.md
+++ b/changelog.d/1061-fold-untyped-lambda.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `fold()` now accepts untyped lambdas (e.g. `fold(xs, 0, (a, b) => a + b)`), matching the fix already applied to `reduce()` in #1038 (#1061)

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -342,6 +342,13 @@ total = fold(xs, 0, (a: int, b: int) => a + b)
 print(total)   # 15
 ```
 
+Type annotations on lambda parameters are optional:
+
+```python
+xs = [1, 2, 3, 4, 5]
+print(fold(xs, 0, (a, b) => a + b))   # 15
+```
+
 ### any
 
 Returns `true` if at least one element satisfies the predicate.

--- a/src/codegen_call_higher_order.cpp
+++ b/src/codegen_call_higher_order.cpp
@@ -284,6 +284,12 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e, llvm::Value *pre
         auto info = *fnInfo;
         if (info.paramTypes.size() != 2)
             codegenError("fold() function must take 2 parameters (accumulator, element)");
+        // Untyped lambda makes info.returnType = anyTy_ (16B) while initVal is a
+        // raw primitive (e.g. i64, 8B). A narrow CreateStore would leave the Any
+        // data field uninitialized; coerce initVal via wrapInAny so the full 16B
+        // slot is always initialised. Mirrors the same fix applied to reduce (#1020).
+        if (isAnyType(info.returnType) && !isAnyType(initVal->getType()))
+            initVal = wrapInAny(initVal);
         if (info.returnType != initVal->getType())
             codegenError("fold() initial value type must match function return type");
 

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -106,6 +106,26 @@ describe("List", ():
     total = fold(xs, 0, (a: int, b: int) => a + b)
     expect(total).to_eq(15)
   )
+  it("should fold with untyped lambda", ():
+    xs = [1, 2, 3, 4, 5]
+    expect(fold(xs, 0, (a, b) => a + b)).to_eq(15)
+  )
+  it("should fold 2-element list with untyped lambda", ():
+    expect(fold([1, 2], 0, (a, b) => a + b)).to_eq(3)
+  )
+  it("should fold 3-element list with untyped lambda", ():
+    expect(fold([1, 2, 3], 0, (a, b) => a + b)).to_eq(6)
+  )
+  it("should fold float list with untyped lambda", ():
+    expect(fold([1.0, 2.0, 3.0], 0.0, (a, b) => a + b)).to_eq(6.0)
+  )
+  it("should fold string list with untyped lambda", ():
+    expect(fold(["a", "b", "c"], "", (a, b) => a + b)).to_eq("abc")
+  )
+  it("should match reduce result when using untyped fold", ():
+    xs = [1, 2, 3, 4, 5]
+    expect(fold(xs, 0, (a, b) => a + b)).to_eq(reduce(xs, (a, b) => a + b))
+  )
   it("should support any predicate", ():
     xs = [1, 2, 3, 4, 5]
     expect(any(xs, (x: int) => x > 4)).to_be_true()

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -338,3 +338,14 @@ TEST_F(CodeGenTest, ListInsertAnyRejectsCollectionType) {
         "insert(xs, 0, [1, 2, 3])\n",
         "'any' can only hold int/float/bool/str");
 }
+
+// ============================================================
+// fold(): seed/return-type mismatch must still fire for typed lambda
+// ============================================================
+
+TEST_F(CodeGenTest, FoldTypedLambdaSeedTypeMismatch) {
+    expectCompileError(
+        "xs = [1, 2, 3]\n"
+        "fold(xs, \"hello\", (a: int, b: int) => a + b)\n",
+        "fold() initial value type must match function return type");
+}


### PR DESCRIPTION
## Summary

- `fold(xs, 0, (a, b) => a + b)` previously failed with `"fold() initial value type must match function return type"` — untyped lambda params default to `any`, making the accumulator type `anyTy_` (16B) while the seed `0` is a narrow `int`
- Applies the same seed-coercion fix used for `reduce` in #1038: insert `wrapInAny(initVal)` when `info.returnType` is `any` and `initVal` is narrow, before the type-equality check
- The equality check is preserved — genuine typed-lambda/seed type mismatches (e.g. `fold([1,2,3], "hi", (a: int, b: int) => a + b)`) still produce a compile error

Closes #1061

## Test plan

- [ ] `tests/spec/collections.test.ry` — 6 new untyped-fold cases: int seed (1/2/3/5-element), float seed, string seed (exercises pointer-in-data `wrapInAny` path), cross-check with untyped `reduce`
- [ ] `tests/test_codegen_fail.cpp::FoldTypedLambdaSeedTypeMismatch` — preserved rejection branch (typed lambda + mismatched seed type) still errors with the correct message
- [ ] `ry_tests` 1764 pass, `ry test -p` 131 files 0 failures
- [ ] ASan + UBSan full pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * fold() now accepts untyped lambda expressions where parameter type annotations are optional, aligning with reduce() behavior.

* **Documentation**
  * Updated fold() reference documentation with examples demonstrating optional lambda parameter types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->