### PR TITLE
fix(codegen): unwrap any→narrow in lambda/fn return when annotation provided (#1062)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2644,24 +2644,33 @@ for the same gap. Do not assume a fix to one function automatically covers other
 float seed, string seed); `tests/test_codegen_fail.cpp::FoldTypedLambdaSeedTypeMismatch`
 verifies the preserved rejection branch.
 
-### `reduce()` rejects `(a, b) -> ReturnType => body` annotation when params are untyped (#1062)
+### Lambda / function return paths need bidirectional `any ↔ narrow` coercion (#1062)
 
-**Source**: #1062 (2026-04-16, discovered during pre-verification for #1033)
-**Tags**: codegen, reduce, lambda, return-type-annotation, untyped-params
+**Source**: #1062 (2026-04-17, fixed in fix/1062-lambda-return-type-annot)
+**Tags**: codegen, lambda, return-type-annotation, any-type, asymmetric-coercion, type-coercion
 
-**Context**: `reduce([1,2,3,4,5], (a, b) -> int => a + b)` produces:
+**Context**: `reduce([1,2,3,4,5], (a, b) -> int => a + b)` produced:
 `lambda expression return type mismatch: expected 'int', found 'any'`. When lambda params
-are untyped they default to `any`, so `a + b` is inferred as `any`. The explicit `-> int`
-annotation then conflicts with `any` at the type-check stage.
+are untyped they default to `any`, so `a + b` is evaluated via `emitAnyBinaryOp` and returns
+`any`. The `-> int` annotation resolves to `i64Ty_`. Only `any ← narrow` (via `wrapInAny`)
+was handled; `narrow ← any` (`unwrapFromAny`) was missing in both return codegen sites.
 
-**Rule**: The `(params) -> ReturnType => body` annotation form does NOT widen param types
-to match the declared return type — it only asserts that the body's inferred type matches
-`ReturnType`. If params are `any`, the body is `any`, and `any != int` is a hard error.
-To use a return-type annotation with this pattern, params must also be typed:
-`(a: int, b: int) -> int => a + b`.
+**Fix**: Added inverse coercion guard at two sites, symmetric with the existing `wrapInAny` branch:
+```cpp
+// src/codegen_lambda.cpp (expression-body) and src/codegen_fn.cpp (block-body + regular fn return)
+else if (isAnyType(val->getType()) && !isAnyType(retTy) && canAnyHoldType(retTy))
+    val = unwrapFromAny(val, retTy);
+```
+`unwrapFromAny` emits a runtime tag check; type mismatches (e.g., float list with `-> int`)
+become runtime errors, not compile errors. `canAnyHoldType` limits the guard to primitives
+(`i64/f64/i1/ptr`); non-primitive return types (List, Result, Map) still produce a compile error.
 
-**How to verify**: Issue #1062 tracks the fix. Until resolved, use fully typed params when
-combining `reduce`/`fold` with an explicit return-type annotation.
+**Rule**: Whenever you add a `wrapInAny` (narrow→any) branch at a return site, audit the
+same site for the inverse `unwrapFromAny` (any→narrow) case. Both directions are required.
+Omitting either direction causes asymmetric behavior between annotated and unannotated lambdas.
+
+**How to verify**: `tests/spec/collections.test.ry` — `reduce`/`fold` tests with `-> int`
+and `-> float` annotations on untyped params; block-body lambda variant via lambda variable.
 
 ### Skill `allowed-tools` must cover all Bash commands the skill body prescribes
 

--- a/changelog.d/1062-lambda-return-type-annot.md
+++ b/changelog.d/1062-lambda-return-type-annot.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Lambda with explicit return type annotation (e.g. `(a, b) -> int => a + b`)
+  now correctly coerces `any`-typed body expressions to the declared return
+  type. Previously this failed at compile time when lambda parameters were
+  untyped (which default to `any`), blocking the common
+  `reduce(xs, (a, b) -> int => a + b)` pattern. Fix applies to both
+  expression-body and block-body lambdas, and to `return` statements in
+  regular functions. (#1062)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -394,6 +394,10 @@ Anonymous functions can be defined inline.
 
 # With explicit return type (optional)
  (param_name: type, ...) -> return_type => expression
+
+# Untyped params with explicit return type annotation
+# Params default to `any`; the body result is unwrapped to the declared type at runtime.
+ (param_name, ...) -> return_type => expression
 ```
 
 ### Example

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -166,6 +166,8 @@ void CodeGen::emitStmt(ReturnStmt &s) {
                 std::string resolvedRetName = resolveTypeAlias(current_fn_return_type_);
                 if (isAnyType(retTy)) {
                     val = wrapInAny(val);
+                } else if (isAnyType(val->getType()) && !isAnyType(retTy) && canAnyHoldType(retTy)) {
+                    val = unwrapFromAny(val, retTy);
                 } else if (isUnionType(resolvedRetName)) {
                     val = wrapInUnion(val, resolvedRetName);
                 } else if (auto *sliced = tryEmitSubtypeCoerce(val, retTy)) {

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -384,6 +384,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
             llvm::Value *val = emitExpr(*e->expr_body);
             if (isAnyType(retTy) && !isAnyType(val->getType()))
                 val = wrapInAny(val);
+            else if (isAnyType(val->getType()) && !isAnyType(retTy) && canAnyHoldType(retTy))
+                val = unwrapFromAny(val, retTy);
             else if (val->getType() != retTy) {
                 std::string resolvedRetTypeStr = resolveTypeAlias(retTypeStr);
                 if (isUnionType(resolvedRetTypeStr))

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -126,6 +126,20 @@ describe("List", ():
     xs = [1, 2, 3, 4, 5]
     expect(fold(xs, 0, (a, b) => a + b)).to_eq(reduce(xs, (a, b) => a + b))
   )
+  it("should reduce with -> int return type annotation on untyped params", ():
+    expect(reduce([1, 2, 3, 4, 5], (a, b) -> int => a + b)).to_eq(15)
+  )
+  it("should fold with -> int return type annotation on untyped params", ():
+    expect(fold([1, 2, 3, 4, 5], 0, (a, b) -> int => a + b)).to_eq(15)
+  )
+  it("should reduce float list with -> float return type annotation", ():
+    expect(reduce([1.0, 2.0, 3.0], (a, b) -> float => a + b)).to_eq(6.0)
+  )
+  it("should reduce with -> int annotation and block-body lambda", ():
+    f = (a, b) -> int:
+      return a + b
+    expect(reduce([1, 2, 3, 4, 5], f)).to_eq(15)
+  )
   it("should support any predicate", ():
     xs = [1, 2, 3, 4, 5]
     expect(any(xs, (x: int) => x > 4)).to_be_true()


### PR DESCRIPTION
## Summary

- `reduce([1,2,3,4,5], (a, b) -> int => a + b)` previously produced a compile error (`lambda expression return type mismatch: expected 'int', found 'any'`). This PR fixes the bug.
- **Root cause**: The `any ← narrow` coercion (`wrapInAny`) was in place at return codegen sites, but the inverse `narrow ← any` (`unwrapFromAny`) was not. When lambda params are untyped (default `any`), the body expression is `any`-typed even with an explicit `-> int` annotation.
- **Fix**: Added a symmetric `unwrapFromAny` guard at two sites:
  - `src/codegen_lambda.cpp` — expression-body lambda return path
  - `src/codegen_fn.cpp` — `emitStmt(ReturnStmt)` covering block-body lambdas and regular functions
- Type mismatches at runtime (e.g., float list with `-> int`) are caught by the existing `unwrapFromAny` tag check and reported as runtime errors.

Closes #1062

## Test plan

- [ ] `tests/spec/collections.test.ry` — 4 new tests: `reduce`/`fold` with `-> int` annotation, `-> float` annotation, block-body lambda variant
- [ ] `./build/ry_tests` — 1769 tests passed
- [ ] `./build/ry test -p` — 131 test files, 0 failures
- [ ] ASan + UBSan — 1769 tests passed, 0 errors
- [ ] TSan — 1769 tests passed, 0 races
- [ ] Manual: `echo 'print(reduce([1,2,3,4,5], (a, b) -> int => a + b))' | ./build/ry -c` → `15`
- [ ] Manual: float list with `-> int` → `runtime error: any type mismatch (expected int)` (runtime, not compile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lambda functions with explicit return type annotations now correctly coerce values when parameters are untyped, resolving compile-time failures in patterns like `reduce(xs, (a, b) -> int => a + b)`. Fix applies to expression-bodied lambdas, block-bodied lambdas, and function return statements.

* **Documentation**
  * Added documentation for lambda syntax with explicit return type annotations, explaining how untyped parameters default to `any` and how declared return types are applied at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->