### PR TITLE
fix(lexer): translate \0 escape to NUL byte in regex literals (#1076)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1213,7 +1213,7 @@ Key constants:
 - `is_empty` (#1069)
 - `to_upper`, `to_lower`, `trim`, `trim_start`, `trim_end` (#1050)
 - `split(str, delim)` with non-empty delimiter (runtime `__ry_str_split` via `memmem`), `join`, `repeat`, `*` operator (#1051)
-- `regex_match`, `regex_search`, `regex_replace`, `regex_split`, `regex_find_all` and all UFCS variants (`is_match`, `search`, `replace`, `split`, `find_all`) — subject + pattern + replacement all length-driven, no `strlen` (#1052). **Caveat:** regex *literal* syntax (`/a\0b/`) cannot encode NUL bytes (lexer limitation, tracked in #1076); the ABI and runtime handle NUL in pattern/text/replacement correctly but a NUL cannot be spelled inside a `/…/` literal.
+- `regex_match`, `regex_search`, `regex_replace`, `regex_split`, `regex_find_all` and all UFCS variants (`is_match`, `search`, `replace`, `split`, `find_all`) — subject + pattern + replacement all length-driven, no `strlen` (#1052). Regex *literal* syntax also supports `\0` to encode a NUL byte in the pattern (`/a\0b/` matches `"a\0b"`) since #1076.
 
 The non-empty-delim `split` now uses `__ry_str_split` in `src/runtime_string.cpp` (replaces inline `strstr`/`strlen`/`malloc` IR). The regex ABI was extended to `(pattern, patternLen, text, textLen[, replacement, replacementLen])` across `include/ry/runtime_regex.hpp`, `src/runtime_regex.cpp`, `src/codegen_call_io.cpp`, and `src/codegen_call_string.cpp`.
 

--- a/changelog.d/1076-regex-literal-nul-escape.md
+++ b/changelog.d/1076-regex-literal-nul-escape.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Regex literal `\0` escape now produces a NUL byte in the pattern, matching string literal behavior (`/a\0b/` now correctly matches `"a\0b"`) (#1076)

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -28,6 +28,13 @@ The `/` inside a regex literal can be escaped with `\/`:
 "a/b".is_match(/a\/b/)  # true
 ```
 
+The `\0` escape sequence inside a regex literal produces a NUL byte in the pattern:
+
+```ry
+s = "a\0b"            # 3-byte string: a, NUL, b
+s.is_match(/a\0b/)    # true — \0 in regex literal is a NUL byte
+```
+
 ### Division vs Regex
 
 The lexer uses context to distinguish regex literals from division:
@@ -246,4 +253,4 @@ All regex operations — `regex_match`, `regex_search`, `regex_replace`, `regex_
 - `regex_split` returns segments whose byte lengths account for any embedded NUL bytes.
 - `regex_find_all` counts every matched byte, including `\0`, and returns all non-overlapping matches.
 
-> **Note:** Regex *literal* syntax (`/pattern/`) cannot encode NUL bytes — the lexer does not interpret `\0` inside `/…/` as a NUL byte. This limitation is tracked in #1076. To match NUL bytes with the literal API, use the string-pattern functions (`regex_match`, `regex_search`, etc.) or pass a `Regex` value constructed at runtime.
+- The `\0` escape in a regex literal (`/a\0b/`) produces a NUL byte in the pattern, matching NUL bytes in the subject string (#1076).

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -329,18 +329,29 @@ Token Lexer::readToken() {
             prev_kind_ != TokenKind::True && prev_kind_ != TokenKind::False &&
             prev_kind_ != TokenKind::NoneKw && prev_kind_ != TokenKind::PlusPlus &&
             prev_kind_ != TokenKind::MinusMinus && prev_kind_ != TokenKind::RegexLiteral) {
-            size_t regexStart = pos_;
+            std::string pattern;
+            size_t runStart = pos_;
             while (pos_ < src_.size() && src_[pos_] != '/' && src_[pos_] != '\n') {
                 if (src_[pos_] == '\\') {
-                    ++pos_; ++col_;
-                    if (pos_ >= src_.size() || src_[pos_] == '\n')
+                    if (pos_ + 1 >= src_.size() || src_[pos_ + 1] == '\n')
                         return {TokenKind::Error, "unterminated regex literal", line_, startCol};
+                    if (src_[pos_ + 1] == '0') {
+                        // \0 → NUL byte (mirrors string literal escape handling)
+                        pattern.append(src_, runStart, pos_ - runStart);
+                        pattern += '\0';
+                        pos_ += 2; col_ += 2;
+                        runStart = pos_;
+                    } else {
+                        // Other escapes (e.g. \/, \d, \\) pass through verbatim for the runtime parser
+                        pos_ += 2; col_ += 2;
+                    }
+                } else {
+                    ++pos_; ++col_;
                 }
-                ++pos_; ++col_;
             }
             if (pos_ >= src_.size() || src_[pos_] != '/')
                 return {TokenKind::Error, "unterminated regex literal", line_, startCol};
-            std::string pattern(src_, regexStart, pos_ - regexStart);
+            pattern.append(src_, runStart, pos_ - runStart);
             ++pos_; ++col_; // consume closing /
             return {TokenKind::RegexLiteral, std::move(pattern), line_, startCol};
         }

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -331,9 +331,11 @@ Token Lexer::readToken() {
             prev_kind_ != TokenKind::MinusMinus && prev_kind_ != TokenKind::RegexLiteral) {
             std::string pattern;
             size_t runStart = pos_;
-            while (pos_ < src_.size() && src_[pos_] != '/' && src_[pos_] != '\n') {
+            while (pos_ < src_.size() && src_[pos_] != '/' &&
+                   src_[pos_] != '\n' && src_[pos_] != '\r') {
                 if (src_[pos_] == '\\') {
-                    if (pos_ + 1 >= src_.size() || src_[pos_ + 1] == '\n')
+                    if (pos_ + 1 >= src_.size() || src_[pos_ + 1] == '\n' ||
+                        src_[pos_ + 1] == '\r')
                         return {TokenKind::Error, "unterminated regex literal", line_, startCol};
                     if (src_[pos_ + 1] == '0') {
                         // \0 → NUL byte (mirrors string literal escape handling)

--- a/tests/spec/regex_literal.test.ry
+++ b/tests/spec/regex_literal.test.ry
@@ -83,6 +83,18 @@ describe("regex literal escaped slash", ():
   )
 )
 
+describe("regex literal NUL escape", ():
+  it("should translate \\0 in regex literal to NUL byte", ():
+    expect(is_match("a\0b", /a\0b/)).to_eq(true)
+  )
+  it("should not match non-NUL bytes at NUL position", ():
+    expect(is_match("aXb", /a\0b/)).to_eq(false)
+  )
+  it("should match a sole NUL pattern against a NUL subject", ():
+    expect(is_match("\0", /\0/)).to_eq(true)
+  )
+)
+
 describe("string split/replace still work", ():
   it("should support string split", ():
     parts = split("a,b,c", ",")

--- a/tests/test_codegen_regex.cpp
+++ b/tests/test_codegen_regex.cpp
@@ -255,6 +255,12 @@ print(is_match("a/b", /a\/b/))
 )"), "true\n");
 }
 
+TEST_F(CodeGenTest, RegexLiteralNulEscape) {
+    EXPECT_EQ(runSource("print(is_match(\"a\\0b\", /a\\0b/))"), "true\n");
+    EXPECT_EQ(runSource("print(is_match(\"aXb\", /a\\0b/))"), "false\n");
+    EXPECT_EQ(runSource("print(is_match(\"\\0\", /\\0/))"), "true\n");
+}
+
 TEST_F(CodeGenTest, RegexLiteralWithPrefixedFunctions) {
     EXPECT_EQ(runSource(R"(
 print(regex_match("hello", "[a-z]+"))

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -327,6 +327,32 @@ TEST(LexerTest, MultiCharOperators) {
     }
 }
 
+// ===== Regex literal escape sequences =====
+
+TEST(LexerTest, RegexLiteralNulEscape) {
+    // \0 inside a regex literal must be translated to a NUL byte (same as in string literals)
+    {
+        auto toks = tokenize("/a\\0b/");
+        ASSERT_EQ(toks[0].kind, TokenKind::RegexLiteral);
+        EXPECT_EQ(toks[0].value.size(), 3u);
+        EXPECT_EQ(toks[0].value[0], 'a');
+        EXPECT_EQ(toks[0].value[1], '\0');
+        EXPECT_EQ(toks[0].value[2], 'b');
+    }
+    {
+        auto toks = tokenize("/\\0/");
+        ASSERT_EQ(toks[0].kind, TokenKind::RegexLiteral);
+        EXPECT_EQ(toks[0].value.size(), 1u);
+        EXPECT_EQ(toks[0].value[0], '\0');
+    }
+    // Regression: other escapes continue to pass through verbatim
+    {
+        auto toks = tokenize("/a\\/b/");
+        ASSERT_EQ(toks[0].kind, TokenKind::RegexLiteral);
+        EXPECT_EQ(toks[0].value, "a\\/b");
+    }
+}
+
 // ===== Shift operator tokens =====
 
 TEST(LexerTest, ShiftOperatorTokens) {

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -353,6 +353,20 @@ TEST(LexerTest, RegexLiteralNulEscape) {
     }
 }
 
+TEST(LexerTest, RegexLiteralCrlfUnterminated) {
+    // A backslash before \r\n (CRLF) must yield an unterminated-regex error,
+    // not silently consume \r into the pattern.
+    {
+        auto toks = tokenize("/abc\\\r\n/");
+        EXPECT_EQ(toks[0].kind, TokenKind::Error);
+    }
+    // A bare \r (CR-only) without a closing / also signals unterminated.
+    {
+        auto toks = tokenize("/abc\r/");
+        EXPECT_EQ(toks[0].kind, TokenKind::Error);
+    }
+}
+
 // ===== Shift operator tokens =====
 
 TEST(LexerTest, ShiftOperatorTokens) {


### PR DESCRIPTION
## Summary

- The regex literal lexer was passing `\0` verbatim to the runtime regex parser, which treated it as the literal character `'0'`. As a result, `/a\0b/` failed to match `"a\0b"` (a 3-byte string with an embedded NUL).
- Fixed by adopting the same `runStart/append` incremental-build pattern used for string literals: when `\0` is encountered inside a `/…/` literal, a NUL byte is appended to the pattern and the source scan advances past both characters. All other escapes (`\/`, `\d`, `\\`, etc.) continue to pass through verbatim so the runtime regex parser can handle them.
- No changes to AST, codegen, or runtime — the fix is entirely contained in the lexer.

## Test plan

- [ ] `LexerTest.RegexLiteralNulEscape` (new) — verifies `/a\0b/` tokenises to a 3-byte value `{a, NUL, b}` and `/\0/` to a 1-byte NUL; regression check that `\/` still passes through verbatim
- [ ] `CodeGenTest.RegexLiteralNulEscape` (new) — end-to-end: `is_match("a\0b", /a\0b/)` → `true`, `is_match("aXb", /a\0b/)` → `false`, sole-NUL case
- [ ] `regex_literal.test.ry` — `describe("regex literal NUL escape")` block (3 cases)
- [ ] Full `./build/ry_tests` and `./build/ry test -p` — all passing
- [ ] ASan + UBSan clean
- [ ] TSan clean (C++ tests required; self-test warn-only per project rules)

Closes #1076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Regex literals now correctly interpret `\0` escapes as NUL bytes, so patterns like `/a\0b/` match subjects containing NUL bytes.

* **Documentation**
  * NUL-safety guidance updated to state regex literals can encode NUL bytes via `\0` escapes.

* **Tests**
  * Added tests verifying regex literal `\0` behavior and related lexer/codegen handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->