### PR TITLE
fix(codegen): propagate List<T> annotation to literal element suffixes (#1079)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2893,6 +2893,12 @@ Enforced in `CodeGen::emitTableDrivenNativeCall` (`src/codegen_call_native.cpp`)
 audit table above. When adding a new byte-list producer, set `ListElemMeta::I8` in its
 entry or call `setTypeMeta(TypeMeta::ListElem, result, i8Ty_)` post-call.
 
-**Deferred**: `let bs: List<u8> = [97, 0, 98]` still compiles with i64 stride because
-`injectLowLevelSuffix` does not descend into `ListExpr` elements. After the #1055 gate,
-`bytes_to_str(bs)` will fail. A follow-up issue tracks annotation-driven `u8` inference.
+**Annotation-driven element suffix (#1079)**: `bs: List<u8> = [97, 0, 98]` now works.
+`injectLowLevelSuffix` is shallow — it does not descend into `ListExpr` elements on its own.
+When the variable annotation is `List<T>` and `T` is a low-level integer type, the parent
+`emitVarDecl` loop in `src/codegen_stmt.cpp` propagates `T` into each element AST node
+before calling `emitExpr`. This mirrors the fixed-size array path at line 247-293. The fix
+must happen before `emitExpr`; post-emit metadata rescue (line 444-493) cannot repair the
+stride because `getListElementType(val)` returns i64 (truthy) and the annotation-fallback
+branch is gated on `!elemTy`. Scope: `let`/`var` declarations only — `AssignStmt`
+reassignment and inline call-argument paths are not covered.

--- a/changelog.d/1079-list-annotation-u8.md
+++ b/changelog.d/1079-list-annotation-u8.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `bs: List<u8> = [97, 0, 98]` now compiles correctly; the `List<u8>` annotation propagates `u8` to each integer literal element so the list has 8-bit element stride and passes the `bytes_to_str` / `write_bytes` compile-time type gate (#1079)

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -116,6 +116,6 @@ case read_text("missing.txt"):
 ## Notes
 
 - `List<u8>` is used as the buffer type. Standard list operations (`length()`, `append()`, `slice()`, index access) all work with byte lists.
-- `bytes_to_str()` and `write_bytes()` require a `List<u8>` argument. Use explicit `u8` suffixes (`[97u8, 0u8, 98u8]`) or `to_bytes("...")` to produce a compatible byte list. Plain integer list literals like `[97, 0, 98]` use 64-bit element layout and are rejected at compile time.
+- `bytes_to_str()` and `write_bytes()` require a `List<u8>` argument. Three ways to produce a compatible byte list: (1) explicit `u8` suffixes (`[97u8, 0u8, 98u8]`), (2) `to_bytes("...")` to convert a string literal, or (3) a type-annotated variable declaration (`bs: List<u8> = [97, 0, 98]`). Plain integer list literals without annotation or explicit suffix use 64-bit element layout and are rejected at compile time.
 - File paths are relative to the current working directory unless absolute paths are specified.
 - `write_text` and `write_bytes` overwrite existing files. Use `append_text` to add content to existing files.

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -293,6 +293,30 @@ void CodeGen::emitVarDecl(const std::string &name,
         }
     }
 
+    // #1079: List<T> annotation + non-empty ListExpr — propagate the element
+    // type name into each NumberExpr/UnaryExpr element before emitExpr so
+    // emitExpr(ListExpr) stamps TypeMeta::ListElem = T (not i64). Mirrors the
+    // fixed-size array path above. Non-recursive: List<List<u8>> inner
+    // elements stay i64 (cosmetic; #1055 gate checks only top-level elem type).
+    if (annot) {
+        if (auto *le = std::get_if<std::unique_ptr<ListExpr>>(&value.data);
+                le && !(*le)->elements.empty()) {
+            std::string resolved = resolveTypeAlias(*annot);
+            if (isListTypeName(resolved) && resolved.size() >= 7 &&
+                    resolved.back() == '>') {
+                std::string inner = resolved.substr(5, resolved.size() - 6);
+                while (!inner.empty() && inner.front() == ' ')
+                    inner.erase(0, 1);
+                while (!inner.empty() && inner.back() == ' ')
+                    inner.pop_back();
+                if (isLowLevelIntTypeName(inner)) {
+                    for (auto &el : (*le)->elements)
+                        if (el) injectLowLevelSuffix(*el, inner);
+                }
+            }
+        }
+    }
+
     // Propagate a low-level integer annotation onto bare integer literals
     // in the initializer so the codegen range check runs against the target
     // type (required for u64 max literals that don't fit in bare i64).

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -164,4 +164,23 @@ describe("file I/O", ():
       Err(e):
         fail("unexpected error")
   )
+  it("should accept List<u8> annotation and route through byte stride (#1079)", ():
+    bs: List<u8> = [97, 0, 98]
+    case bytes_to_str(bs):
+      Ok(s):
+        expect(s == "a\0b").to_eq(true)
+      Err(e):
+        fail("unexpected error")
+  )
+  it("should accept List<u8> annotation for write_bytes (#1079)", ():
+    bs: List<u8> = [72, 105]
+    case write_bytes("/tmp/ry_selftest_io_annot_u8.bin", bs):
+      Ok(_):
+        case read_bytes("/tmp/ry_selftest_io_annot_u8.bin"):
+          Ok(rb): expect(length(rb)).to_eq(2)
+          Err(e): fail("unexpected read error")
+      Err(e):
+        fail("unexpected write error")
+    delete_file("/tmp/ry_selftest_io_annot_u8.bin")
+  )
 )

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -817,3 +817,44 @@ case bytes_to_str([97u16, 0u16, 98u16]):
     Err(e): print(e.message)
 )", {"bytes_to_str", "List<u8>"});
 }
+
+// ============================================================
+// List<T> annotation propagates element suffix (#1079)
+// ============================================================
+
+TEST_F(CodeGenTest, ListU8AnnotationAccepted) {
+    EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
+bs: List<u8> = [97, 0, 98]
+case bytes_to_str(bs):
+    Ok(s): print(s)
+    Err(e): print(e.message)
+)"));
+}
+
+TEST_F(CodeGenTest, ListU8AnnotationRangeCheckRejected) {
+    expectCompileError(R"(
+bs: List<u8> = [256]
+print(length(bs))
+)", {"u8 literal out of range"});
+}
+
+TEST_F(CodeGenTest, ListI8AnnotationBoundaryCompiles) {
+    EXPECT_NO_THROW(compileSource(R"(
+bs: List<i8> = [-128]
+print(length(bs))
+)"));
+}
+
+TEST_F(CodeGenTest, ListU8AnnotationNegativeRejected) {
+    expectCompileError(R"(
+bs: List<u8> = [-1]
+print(length(bs))
+)", {"cannot negate unsigned type"});
+}
+
+TEST_F(CodeGenTest, ListU16AnnotationAccepted) {
+    EXPECT_NO_THROW(compileSource(R"(
+xs: List<u16> = [300, 1000, 65535]
+print(length(xs))
+)"));
+}


### PR DESCRIPTION
## Summary

- `bs: List<u8> = [97, 0, 98]` now compiles correctly; the `List<u8>` annotation propagates `u8` to each integer literal element
- After the #1055 compile-time gate, the annotated form was erroneously rejected with "use [97u8, 0u8, 98u8] or to_bytes()"
- Fix: in `emitVarDecl`, when annotation is `List<T>` with a low-level integer `T`, iterate `ListExpr` elements and call `injectLowLevelSuffix(*el, inner)` on each — mirroring the existing fixed-size array path (`u8[3] = [...]`)

## Root Cause

`injectLowLevelSuffix` (`include/ry/ast.hpp:536`) is a shallow helper that only rewrites `NumberExpr`/`UnaryExpr` nodes; it returns early for `"List<u8>"` (not `isLowLevelIntTypeName`). Post-emit metadata rescue (`codegen_stmt.cpp:444-493`) cannot repair stride because `getListElementType(val)` returns i64 (truthy), bypassing the annotation-fallback. The fix must happen at the AST layer, before `emitExpr`.

## Test plan

- [x] New spec tests: `bs: List<u8> = [97, 0, 98]` + `bytes_to_str` / `write_bytes` round-trip (`tests/spec/io.test.ry`)
- [x] New C++ tests: annotation accepted, u8 range check rejected, i8 boundary compiles, u8 negation rejected, u16 accepted (`tests/test_codegen_type_safety.cpp`)
- [x] Existing regression guard (`BytesToStrIntListRejected`, `WriteBytesIntListRejected`, `BytesToStrU16ListRejected`) — all still pass
- [x] Full suite: 1774 C++ tests + 131 Ry self-test files (normal / ASan+UBSan / TSan)

## Scope boundary

Declaration-site only. AssignStmt reassignment (`bs = [1, 2, 3]` to existing `List<u8>` var) is tracked in #1085.

Closes #1079

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compilation errors when using `List<u8>` type annotations on byte-list literals, enabling proper element type propagation and stride alignment.

* **Documentation**
  * Updated I/O function reference documentation to clarify three supported approaches for providing `List<u8>` values: explicit byte literals with `u8` suffix, string literal conversion via `to_bytes()`, and type-annotated variable declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->