### PR TITLE
fix(lexer): add targeted diagnostic for unsupported octal literals (#1027)

### DIFF
--- a/changelog.d/1027-octal-literal-diagnostic.md
+++ b/changelog.d/1027-octal-literal-diagnostic.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Writing an octal literal (`0o...`) now produces a targeted compile error
+  explaining that octal literals are not supported and suggesting `0x...`
+  (hex) or `0b...` (binary) instead. Previously it produced the generic
+  `invalid character after numeric literal` diagnostic. (#1027)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -159,7 +159,7 @@ z: B = true
 
 ### Integer Literals
 
-Decimal, hexadecimal (`0x`/`0X`), and binary (`0b`/`0B`) forms are accepted. Underscores are allowed between digits as a visual separator (`1_000_000`, `0xFFFF_FFFF`).
+Decimal, hexadecimal (`0x`/`0X`), and binary (`0b`/`0B`) forms are accepted. Underscores are allowed between digits as a visual separator (`1_000_000`, `0xFFFF_FFFF`). Octal literals (`0o...`) are not supported; use `0x...` or `0b...` instead.
 
 The accepted magnitude is determined by the target type:
 

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -581,6 +581,12 @@ Token Lexer::readToken() {
                 checkNoTrailingIdentStart();
                 return {numKind, std::string(src_, start, pos_ - start), line_, startCol};
             }
+            if (next == 'o' || next == 'O') {
+                throw std::runtime_error(
+                    "line " + std::to_string(line_) +
+                    ": octal literals (0o...) are not supported; "
+                    "use hex (0x...) or binary (0b...) instead");
+            }
         }
         consumeDigitsWithSeparators(src_, pos_, col_, line_,
             isDecDigit);

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -349,3 +349,16 @@ TEST_F(CodeGenTest, FoldTypedLambdaSeedTypeMismatch) {
         "fold(xs, \"hello\", (a: int, b: int) => a + b)\n",
         "fold() initial value type must match function return type");
 }
+
+// ============================================================
+// #1027: octal literals must produce a targeted diagnostic
+// ============================================================
+
+TEST_F(CodeGenTest, OctalLiteralRejectedWithTargetedDiagnostic) {
+    expectCompileError("x = 0o17\n",
+                       "octal literals (0o...) are not supported");
+    expectCompileError("x = 0o755\n",
+                       "use hex (0x...) or binary (0b...) instead");
+    expectCompileError("x = 0O17\n",
+                       "octal literals (0o...) are not supported");
+}

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -1336,6 +1336,46 @@ TEST(LexerTest, InvalidTrailingAlphaAfterNumeric) {
     }
 }
 
+// ===== #1027 octal literal diagnostic =====
+
+TEST(LexerTest, RejectOctalLiteralWithSuggestion) {
+    auto expectOctalError = [](const std::string &src) {
+        try {
+            tokenize(src);
+            FAIL() << "Expected octal-literal error for: " << src;
+        } catch (const std::runtime_error &e) {
+            std::string msg = e.what();
+            EXPECT_NE(msg.find("octal literals (0o...) are not supported"), std::string::npos)
+                << "Missing 'not supported' fragment in: " << msg;
+            EXPECT_NE(msg.find("use hex (0x...) or binary (0b...) instead"), std::string::npos)
+                << "Missing suggestion fragment in: " << msg;
+        }
+    };
+    // Lowercase prefix
+    expectOctalError("0o17");
+    expectOctalError("0o755");
+    expectOctalError("0o0");
+    // Uppercase prefix
+    expectOctalError("0O17");
+    expectOctalError("0O755");
+    // Bare prefix (no digits)
+    expectOctalError("0o");
+    expectOctalError("0O");
+    // Non-octal digits after prefix — still rejected early
+    expectOctalError("0o9");
+    expectOctalError("0o89");
+
+    // Line number appears in message
+    try {
+        tokenize("x = 1\n0o17\n");
+        FAIL() << "Expected octal-literal error";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("line 2"), std::string::npos) << "Expected line 2, got: " << msg;
+        EXPECT_NE(msg.find("octal literals"), std::string::npos) << "Missing octal fragment, got: " << msg;
+    }
+}
+
 // ===== #819 scientific notation =====
 
 TEST(LexerTest, NumericLiteralScientificBasic) {


### PR DESCRIPTION
## Summary

- `0o...` / `0O...` integer literals now produce a targeted compile error instead of the generic `invalid character after numeric literal`
- New message: `line N: octal literals (0o...) are not supported; use hex (0x...) or binary (0b...) instead`
- Documents the restriction in `docs/reference/types.md`

## Changes

| File | Change |
|---|---|
| `src/lexer.cpp` | Added `'o'/'O'` branch in the numeric-literal lexer path |
| `tests/test_lexer.cpp` | `RejectOctalLiteralWithSuggestion` — 10 input variants + line-number check |
| `tests/test_codegen_fail.cpp` | `OctalLiteralRejectedWithTargetedDiagnostic` — E2E pipeline test |
| `docs/reference/types.md` | Added note that octal literals are not supported |
| `changelog.d/1027-octal-literal-diagnostic.md` | Changelog fragment |

## Test plan

- [x] `./build/ry_tests` — 1771 tests passed
- [x] `./build/ry test -p` — 131 spec files, 0 failures
- [x] ASan + UBSan — clean
- [x] TSan — clean
- [x] Manual: `echo 'print(0o17)' | ./build/ry -c` produces targeted message
- [x] Manual: `echo 'print(0xFFgg)' | ./build/ry -c` still produces generic message (no regression)

Closes #1027

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changed**
  * Octal literals (`0o...`) now produce targeted error messages suggesting hexadecimal (`0x...`) or binary (`0b...`) alternatives instead of generic numeric literal diagnostics.

* **Documentation**
  * Updated type reference to clarify that octal literals are not supported and recommend alternative formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->