### PR TITLE
feat(lang): support str substring check with `in` / `not in` (#1032)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1150,6 +1150,28 @@ Affected sites (all in `codegen_call_collection.cpp`, `codegen_call_string.cpp`,
 **If a reachable path is found** (e.g. via a future union type edge case), add
 a direct Ry-source regression test per AGENTS.md and remove this exception entry.
 
+### `in`/`not in` dispatch order in `emitExprVariant`
+
+**Source**: #1032 (2026-04-17, feat)
+**Tags**: codegen, in-operator, str, dispatch-order, isStringValue
+
+**Rule**: The dispatch order in `emitExprVariant` for `in` / `not in` is:
+user overload (`tryOperatorCall`) → Set → Map → List → **str** → error.
+The str branch must come *after* Set/Map/List because `isStringValue(container)`
+returns `true` for any `ptrTy_` value without collection/resource metadata —
+and since Set, Map, and List headers are all tagged with metadata
+(`hasAnyMeta() == true`), `isStringValue` correctly excludes them.
+Adding str before Set/Map/List would fire on plain `str` RHS before the
+collection branches even run.
+
+**LHS widening**: when the RHS is `str` but the LHS has type `any`, unwrap with
+`unwrapFromAny(elem, ptrTy_)`. The "wrapInAny" direction is not needed — str has
+no element type to promote into. Any other LHS type (int, float, bool, collection)
+emits a compile error: `"'in'/'not in' operator: left side must be str when right side is str"`.
+
+**Empty needle**: `"" in s` is `true` for any `s` — the runtime (`__ry_str_find_byte`)
+returns `0` when `nl == 0`, matching Python and the existing `contains` semantics.
+
 ### Pattern binding ARC and `emitPatternBindingArc`
 
 **Source**: #997 (2026-04-16, fix)

--- a/changelog.d/1032-in-operator-str-substring.md
+++ b/changelog.d/1032-in-operator-str-substring.md
@@ -1,0 +1,5 @@
+### Added
+
+- `in` and `not in` operators now support substring check when the right operand is a `str`.
+  `"world" in "hello world"` evaluates to `true`; empty-needle `"" in s` evaluates to `true`
+  to match Python and the existing `contains` semantics. (#1032)

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -71,9 +71,10 @@ All return `bool`.
 - Tuple types support `==` and `!=` with element-wise comparison.
 - `List<T>` and `Map<K, V>` support `==` and `!=` for all element/value types including records, tuples, and nested collections (`List<List<T>>`, `Map<str, List<T>>`, `Map<Point, int>`, `Map<(int, int), str>`, etc.). Map key types may be primitive or complex (records, tuples, nested collections); function-typed keys are not supported.
 - `Set<T>` supports `==` and `!=` for all element types including records, tuples, and nested collections (`Set<Point>`, `Set<List<int>>`, `Set<Set<int>>`, etc.). Comparison is order-independent (set semantics). Note: element types must themselves be equatable (closures are not supported).
-- The `in` operator is used for membership checks on sets, lists, and maps (`x in s`).
+- The `in` operator is used for membership checks on sets, lists, and maps (`x in s`), and for substring checks on strings (`sub in s`).
 - The `not in` operator is the negation of `in` (`x not in s`).
 - For maps, `in` checks whether the key exists.
+- For strings, `in` returns `true` when the left operand is a substring of the right operand. An empty string is always a substring of any string.
 
 ```python
 x = 3 < 5       # true
@@ -85,6 +86,9 @@ xs = [1, 2, 3]
 a = 2 in xs     # true (list linear search)
 m = {"a": 1}
 b = "a" in m    # true (map key lookup)
+c = "world" in "hello world"  # true (substring check)
+d = "xyz" not in "hello world"  # true
+e = "" in "hello"  # true (empty string is always a substring)
 ```
 
 ## Logical Operators
@@ -360,8 +364,10 @@ f++           # f = 2.5 (int 1 is promoted to float)
 | `+` | Set\<T\> | Set\<T\> | Set\<T\> (union) |
 | `== != < <= > >=` | numeric / bool / str | same type | bool |
 | `*` | str | int | str |
-| `in` | any | Set<T> / List<T> / Map<K, V> | bool |
-| `not in` | any | Set<T> / List<T> / Map<K, V> | bool |
+| `in` | any | Set\<T\> / List\<T\> / Map\<K, V\> | bool |
+| `in` | str | str | bool (substring check) |
+| `not in` | any | Set\<T\> / List\<T\> / Map\<K, V\> | bool |
+| `not in` | str | str | bool (substring check) |
 | `& \| ^ ~ << >> >>>` | int | int | int |
 | `and or not` | bool | bool | bool |
 
@@ -526,7 +532,7 @@ print(5 in r)       # true
 print(15 not in r)  # true
 ```
 
-User-defined `in` operators are tried first; if no match is found, built-in behavior (for sets, maps, and lists) is used as a fallback. `not in` is automatically supported when `in` is defined.
+User-defined `in` operators are tried first; if no match is found, built-in behavior (for sets, maps, lists, and strings) is used as a fallback. `not in` is automatically supported when `in` is defined.
 
 ### Call Operator Overloading
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1582,7 +1582,28 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
             return result;
         }
 
-        codegenError("'" + e->op + "' operator requires a set, list, or map on the right side");
+        // Try str (substring check) — #1032
+        if (isStringValue(container)) {
+            if (!isStringValue(elem)) {
+                if (isAnyType(elem->getType()) && canAnyHoldType(ptrTy_))
+                    elem = unwrapFromAny(elem, ptrTy_);
+                else
+                    codegenError("'" + e->op + "' operator: left side must be str when right side is str");
+            }
+            llvm::Value *hlen = emitStringByteLen(container);
+            llvm::Value *nlen = emitStringByteLen(elem);
+            auto findByteFn = getRuntimeFn("__ry_str_find_byte", i64Ty_,
+                                           {ptrTy_, i64Ty_, ptrTy_, i64Ty_, i32Ty_});
+            llvm::Value *byteOff = builder_.CreateCall(findByteFn,
+                {container, hlen, elem, nlen, llvm::ConstantInt::get(i32Ty_, 0)}, "str_in_find");
+            llvm::Value *result = builder_.CreateICmpNE(byteOff,
+                llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(-1LL)), "str_in");
+            if (e->op == "not in")
+                result = builder_.CreateNot(result, "str_not_in");
+            return result;
+        }
+
+        codegenError("'" + e->op + "' operator requires a set, list, map, or str on the right side");
     }
 
     // Short-circuit evaluation for 'and' / 'or'

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1585,6 +1585,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<BinaryExpr> &e) {
         // Try str (substring check) — #1032
         if (isStringValue(container)) {
             if (!isStringValue(elem)) {
+                // Safety: wrapInAny() rejects non-str pointers (List/Map/Set) at
+                // compile time, so any<ptrTy_> can only carry a str handle.
+                // unwrapFromAny also performs a runtime RyAnyTag::Str check and
+                // aborts on mismatch, providing a second layer of defense.
                 if (isAnyType(elem->getType()) && canAnyHoldType(ptrTy_))
                     elem = unwrapFromAny(elem, ptrTy_);
                 else

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -50,6 +50,17 @@ describe("search and check", ():
   it("should return true when contains empty haystack and needle", ():
     expect(contains("", "")).to_be_true()
   )
+  it("should check substring with in operator", ():
+    expect("world" in "hello world").to_be_true()
+    expect("xyz" in "hello world").to_be_false()
+    expect("hello" in "hello").to_be_true()
+    expect("hello" in "").to_be_false()
+    expect("" in "hello").to_be_true()
+  )
+  it("should check substring with not in operator", ():
+    expect("world" not in "hello world").to_be_false()
+    expect("xyz" not in "hello world").to_be_true()
+  )
 )
 
 describe("extraction and transformation", ():

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -1185,6 +1185,8 @@ TEST_F(CodeGenTest, InNotInOperatorsStr) {
     EXPECT_THROW(runSource("print(1 in \"hello\")"), std::runtime_error);
     // InStrAnyWidening: any-typed LHS holding a str should work
     EXPECT_EQ(runSource("x: any = \"world\"\nprint(x in \"hello world\")"), "true\n");
+    // InStrAnyListRejection: List cannot be assigned to any (wrapInAny compile-time guard)
+    EXPECT_THROW(runSource("x: any = [1]\nprint(x in \"hello world\")"), std::runtime_error);
 }
 
 // ===== List append / pop / reverse / slice =====

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -1166,6 +1166,27 @@ TEST_F(CodeGenTest, InNotInOperators) {
     EXPECT_EQ(runSource("print(\"b\" not in {\"a\": 1})"), "true\n");
 }
 
+TEST_F(CodeGenTest, InNotInOperatorsStr) {
+    // InStrTrue
+    EXPECT_EQ(runSource("print(\"world\" in \"hello world\")"), "true\n");
+    // InStrFalse
+    EXPECT_EQ(runSource("print(\"xyz\" in \"hello world\")"), "false\n");
+    // NotInStrFalse
+    EXPECT_EQ(runSource("print(\"world\" not in \"hello world\")"), "false\n");
+    // NotInStrTrue
+    EXPECT_EQ(runSource("print(\"xyz\" not in \"hello world\")"), "true\n");
+    // EmptyNeedleInStr
+    EXPECT_EQ(runSource("print(\"\" in \"hello\")"), "true\n");
+    // StrInEmpty
+    EXPECT_EQ(runSource("print(\"hello\" in \"\")"), "false\n");
+    // FullMatchInStr
+    EXPECT_EQ(runSource("print(\"hello\" in \"hello\")"), "true\n");
+    // InStrRejectionNonStr
+    EXPECT_THROW(runSource("print(1 in \"hello\")"), std::runtime_error);
+    // InStrAnyWidening: any-typed LHS holding a str should work
+    EXPECT_EQ(runSource("x: any = \"world\"\nprint(x in \"hello world\")"), "true\n");
+}
+
 // ===== List append / pop / reverse / slice =====
 
 TEST_F(CodeGenTest, ListAppendVariants) {


### PR DESCRIPTION
## Summary

- `"world" in "hello world"` now evaluates to `true`; `"xyz" in "hello world"` to `false`
- `not in` is the negation: `"xyz" not in "hello world"` → `true`
- Empty needle `"" in s` is always `true` (matches Python / existing `contains` semantics)
- `any`-typed LHS holding a `str` is transparently unwrapped via `unwrapFromAny`
- Non-`str` LHS with a `str` RHS is a compile error

## Implementation

Adds a new `str` branch in `emitExprVariant` (`src/codegen_expr.cpp`) after the existing Set/Map/List branches, lowering to the existing `__ry_str_find_byte` runtime function used by `contains()`.

Dispatch order: user overload (`tryOperatorCall`) → Set → Map → List → **str** → error.

`isStringValue(container)` correctly excludes collection/resource-metadata pointers, so the str branch does not interfere with existing container branches.

No parser, lexer, AST, `share/std`, or runtime changes needed.

## Test plan

- [x] `CodeGenTest.InNotInOperatorsStr` — 9 C++ cases: true/false, `not in`, empty needle, full match, non-str rejection, `any` LHS widening
- [x] `tests/spec/strings.test.ry` — 2 new `it` blocks: `in` operator (5 cases) and `not in` operator (2 cases)
- [x] `./build/ry_tests` — 1773 tests pass
- [x] `./build/ry test -p` — spec tests pass (serial mode; parallel runner has pre-existing flakiness tracked in #1088)
- [x] ASan+UBSan: 1773 C++ tests + 131 Ry spec files clean
- [x] TSan: 1773 C++ tests clean

Closes #1032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `in` and `not in` now perform substring membership checks for strings (e.g., `"world" in "hello world"` → true); empty-string needle always matches.

* **Documentation**
  * Added KNOWLEDGE.md and updated operator reference and changelog to describe string membership semantics and edge cases.

* **Tests**
  * Added unit and spec tests covering substring membership, empty-needle behavior, type-error cases, and `any`-typed needle handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->