### PR TITLE
fix(codegen): extend for-loop UAF guard to FieldAccessExpr iterables (#1041)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1626,25 +1626,37 @@ inside the header is separately `checked_malloc`'d and must be freed with plain
 
 ### `for` loop over a collection: snapshot via `emitArcRetain` to prevent buffer-pointer UAF
 
-**Source**: #1021 (2026-04-16)
+**Source**: #1021 (2026-04-16), #1041 (2026-04-17)
 **Tags**: codegen, for-loop, list, set, map, arc, cow, use-after-free, iteration
 
 **Rule**: Never cache a collection's internal buffer pointer (`data`, `keys`,
 `vals`) in an SSA value that is read inside the loop body **when the iterable
-is a named variable (`VariableExpr`)**. `append!`/`add`/map-insert grow the
+carries an external alias** (`VariableExpr` or `FieldAccessExpr`). `append!`/`add`/map-insert grow the
 collection; when the buffer is full, they `arc_alloc` a new buffer, copy, and
 **`free` the old buffer** — leaving any pre-loop SSA pointer dangling (UAF).
 
-**VarExpr gate**: Only apply retain+snapshot when
-`std::get_if<VariableExpr>(&s->iterable->data) != nullptr`. For temporaries
-(`range(100)`, `f().items`, `emitStringToCharList` output, etc.) there is no
-external alias that can mutate the collection through CoW — pre-loop SSA values
-are safe, and emitting an alloca inside a thread thunk with a stale
-`entryBlock_` would produce invalid IR and crash the optimizer. If you expand
-the retain+snapshot to non-VarExpr paths unconditionally, thread/concurrency
-tests will crash in `SimplifyCFGPass` on `__ry_thread.N` functions.
+**External-alias gate**: Apply retain+snapshot when
+`iterableHasExternalAlias(*s->iterable)` returns true — i.e., the iterable is
+`VariableExpr` **or** `FieldAccessExpr` (e.g. `obj.items`, `self.xs`). For true
+temporaries (`range(100)`, result of a call expression, `emitStringToCharList`
+output, list/set/map literals, etc.) there is no external alias that can mutate
+the collection through CoW — pre-loop SSA values are safe. `IndexExpr`
+(`xs[i]`) is also an alias-carrying node but is not yet guarded; tracked in #1091.
 
-**Fix for VariableExpr iterables**:
+**FieldAccessExpr semantic difference**: `tryGetReceiverAlloca` returns `nullptr`
+for `FieldAccessExpr` (only handles `VariableExpr`), so no CoW fork occurs on
+mutation — `append!` mutates in-place. The retain still protects the snapshot:
+the header's `strong_count` is bumped to ≥ 2, so the buffer is not freed. The
+loop iterates the original length read from the snapshot before mutation.
+
+**Known limitation — thread closure bodies** (#1090): the retain+snapshot guard
+crashes in `LowerExpectIntrinsicPass` on `__ry_thread.N` functions when the
+for-loop is inside a `thread_spawn` closure body (for both `VariableExpr` and
+`FieldAccessExpr` iterables). Root cause is unknown — it is NOT a stale alloca
+placement; `FnScope`/`getOrCreateVar` correctly targets the thunk's entry block.
+Until #1090 is fixed, avoid emitting the guard inside thread closure bodies.
+
+**Fix**:
 
 1. Before emitting the loop header, call `emitArcGetHeaderFromData(iterable)` →
    `emitArcRetain(arcHdr)` to bump `strong_count`.
@@ -1659,7 +1671,7 @@ tests will crash in `SimplifyCFGPass` on `__ry_thread.N` functions.
 4. **Do NOT emit an explicit release.** `popScope()` / `emitScopeCleanupToDepth`
    walk `arc_managed_vars_` and call `emitArcReleaseVar` on every exit path.
 
-**For non-VariableExpr iterables**: load `data`/`keys`/`vals`/`len` once before
+**For non-alias iterables**: load `data`/`keys`/`vals`/`len` once before
 `emitIndexedForLoop` as SSA values, capture them in the body lambda.
 
 **Why retain works**: any mutation through the source alias inside the loop body
@@ -1673,8 +1685,9 @@ the **current scope**, so sequential loops in the same function scope cannot
 accidentally share a snapshot alloca if the names differ.
 
 **How to verify**: in `codegen_stmt_loop.cpp`, per-iteration buffer loads for
-VarExpr paths should read from a `for_snap` alloca; for non-VarExpr paths, the
-captured SSA `dataPtr`/`keysPtr`/`valsPtr` values are used directly.
+`iterableHasExternalAlias` paths should read from a `for_snap` alloca; for
+non-alias paths, the captured SSA `dataPtr`/`keysPtr`/`valsPtr` values are used
+directly.
 
 ---
 

--- a/changelog.d/1041-for-loop-fieldaccess-uaf.md
+++ b/changelog.d/1041-for-loop-fieldaccess-uaf.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- For-loop UAF guard now fires for `FieldAccessExpr` iterables
+  (e.g. `for x in obj.items: append!(obj.items, ...)`), not only bare
+  variable references (#1041).

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -4,6 +4,19 @@
 
 namespace ry {
 
+// Returns true when the iterable expression carries an external alias that
+// could trigger in-place CoW mutations of the underlying collection during
+// the loop body. These paths need the retain+snapshot guard (#1021, #1041):
+//   - VariableExpr: a named binding in scope (e.g. `for x in ys:`).
+//   - FieldAccessExpr: a record field access (e.g. `for x in obj.items:`).
+// Temporaries — range(), call results, literals, emitStringToCharList output —
+// carry no aliasable binding, so pre-loop SSA values are safe without a guard.
+// IndexExpr is excluded here and tracked as a follow-up issue.
+static bool iterableHasExternalAlias(const ExprNode &e) {
+    return std::get_if<VariableExpr>(&e.data) != nullptr
+        || std::get_if<std::unique_ptr<FieldAccessExpr>>(&e.data) != nullptr;
+}
+
 void CodeGen::emitStmt(std::unique_ptr<WhileStmt> &s) {
     emitCoverage(s->loc);
     llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "while.cond", fn_);
@@ -143,16 +156,15 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
                 codegenError("for loop destructuring requires a list of tuples");
 
             // Snapshot the iterable to prevent UAF when the source alias is
-            // mutated inside the loop body (#1021). Only needed when iterating
-            // a named variable (VariableExpr); for temporaries (range(),
-            // function calls, etc.) there is no external alias that can
-            // mutate the collection through CoW.
-            const bool tupleIterIsVar =
-                std::get_if<VariableExpr>(&s->iterable->data) != nullptr;
+            // mutated inside the loop body (#1021, #1041). Applies when the
+            // iterable carries an external alias (VariableExpr or
+            // FieldAccessExpr); temporaries (range(), function calls, etc.)
+            // have no external alias and are safe without a guard.
+            const bool tupleIterHasAlias = iterableHasExternalAlias(*s->iterable);
             llvm::AllocaInst *tupleSnapAlloca = nullptr;
             llvm::Value *tupleDataPtr = nullptr;
             llvm::Value *length;
-            if (tupleIterIsVar) {
+            if (tupleIterHasAlias) {
                 llvm::Value *arcHdr = emitArcGetHeaderFromData(iterable);
                 emitArcRetain(arcHdr);
                 std::string snapName =
@@ -208,16 +220,15 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
                          std::to_string(s->var_names.size()));
 
         // Snapshot the iterable to prevent UAF when the source alias is
-        // mutated inside the loop body (#1021). Only needed when iterating
-        // a named variable (VariableExpr); for temporaries there is no
-        // external alias that can mutate the collection through CoW.
-        const bool mapIterIsVar =
-            std::get_if<VariableExpr>(&s->iterable->data) != nullptr;
+        // mutated inside the loop body (#1021, #1041). Applies when the
+        // iterable carries an external alias (VariableExpr or
+        // FieldAccessExpr); temporaries have no external alias.
+        const bool mapIterHasAlias = iterableHasExternalAlias(*s->iterable);
         llvm::AllocaInst *mapSnapAlloca = nullptr;
         llvm::Value *mapKeysPtr = nullptr;
         llvm::Value *mapValsPtr = nullptr;
         llvm::Value *length;
-        if (mapIterIsVar) {
+        if (mapIterHasAlias) {
             llvm::Value *mapArcHdr = emitArcGetHeaderFromData(iterable);
             emitArcRetain(mapArcHdr);
             std::string mapSnapName =
@@ -286,11 +297,11 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
         return;
     }
 
-    // Only snapshot (retain+alloca) when iterating a named variable — there
-    // must be an external alias that can trigger CoW mutations during the loop.
-    // For temporaries (range(), function calls, string-to-char conversion, etc.)
-    // no external alias exists, so the pre-loop SSA values are safe (#1021).
-    bool elemIterIsVar = std::get_if<VariableExpr>(&s->iterable->data) != nullptr;
+    // Only snapshot (retain+alloca) when the iterable carries an external alias
+    // that can trigger CoW mutations during the loop (VariableExpr or
+    // FieldAccessExpr). Temporaries (range(), function calls,
+    // string-to-char conversion, etc.) have no external alias (#1021, #1041).
+    bool elemIterHasAlias = iterableHasExternalAlias(*s->iterable);
 
     // Try set first, then list
     llvm::Type *elemTy = getSetElementType(iterable);
@@ -306,17 +317,18 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
         iterable = emitStringToCharList(iterable, "for_str_chars");
         elemTy = ptrTy_;
         headerTy = listHeaderTy_;
-        elemIterIsVar = false;  // fresh temp — no external alias, no retain needed
+        elemIterHasAlias = false;  // fresh temp — no external alias, no retain needed
     }
     if (!elemTy)
         codegenError("cannot determine element type for for loop iterable");
 
     // Snapshot the iterable to prevent UAF when the source alias is mutated
-    // inside the loop body (#1021). Only applied for VariableExpr iterables.
+    // inside the loop body (#1021, #1041). Applies for VariableExpr and
+    // FieldAccessExpr iterables.
     llvm::AllocaInst *elemSnapAlloca = nullptr;
     llvm::Value *elemDataPtr = nullptr;
     llvm::Value *length;
-    if (elemIterIsVar) {
+    if (elemIterHasAlias) {
         llvm::Value *elemArcHdr = emitArcGetHeaderFromData(iterable);
         emitArcRetain(elemArcHdr);
         std::string elemSnapName =

--- a/tests/spec/for_mutation_field.test.ry
+++ b/tests/spec/for_mutation_field.test.ry
@@ -1,0 +1,78 @@
+record ListBag:
+  items: List<int>
+
+record SetBag:
+  tags: Set<int>
+
+record MapBag:
+  lookup: Map<str, int>
+
+record InnerBag:
+  values: List<int>
+
+record OuterBag:
+  inner: InnerBag
+
+record TupleBag:
+  pairs: List<(int, int)>
+
+describe("for mutation safety — FieldAccessExpr iterables (#1041)", ():
+  it("should not visit appended elements when appending via field access (list)", ():
+    # Issue #1041: the retain+snapshot guard must also fire when the iterable
+    # is a FieldAccessExpr (e.g. bag.items). Without the fix, append! frees
+    # the old buffer and the loop reads dangling memory (UAF).
+    b = ListBag([10, 20, 30])
+    count = 0
+    seen_sum = 0
+    for x in b.items:
+      count = count + 1
+      seen_sum = seen_sum + x
+      append!(b.items, x + 100)
+    expect(count).to_eq(3)
+    expect(seen_sum).to_eq(60)
+    expect(length(b.items)).to_eq(6)
+  )
+
+  it("should not visit added elements when adding via field access (set)", ():
+    b = SetBag({10, 20, 30})
+    count = 0
+    for t in b.tags:
+      count = count + 1
+      add(b.tags, t + 100)
+    expect(count).to_eq(3)
+    expect(length(b.tags)).to_eq(6)
+  )
+
+  it("should not visit inserted entries when inserting via field access (map)", ():
+    b = MapBag({"a": 1, "b": 2, "c": 3})
+    count = 0
+    for k, v in b.lookup:
+      count = count + 1
+      b.lookup[k + "_new"] = v + 10
+    expect(count).to_eq(3)
+    expect(length(b.lookup)).to_eq(6)
+  )
+
+  it("should not visit appended tuples when appending via field access (tuple destructure)", ():
+    b = TupleBag([(1, 10), (2, 20), (3, 30)])
+    count = 0
+    for a, v in b.pairs:
+      count = count + 1
+      append!(b.pairs, (a + 10, v + 100))
+    expect(count).to_eq(3)
+    expect(length(b.pairs)).to_eq(6)
+  )
+
+  it("should not visit appended elements when iterating nested field access", ():
+    # outer.inner.values is a FieldAccessExpr whose object is itself a
+    # FieldAccessExpr. The outermost node is FieldAccessExpr, so the gate
+    # fires on the iterable (the List<int> held by inner.values).
+    outer = OuterBag(InnerBag([10, 20, 30]))
+    count = 0
+    for x in outer.inner.values:
+      count = count + 1
+      append!(outer.inner.values, x + 100)
+    expect(count).to_eq(3)
+    expect(length(outer.inner.values)).to_eq(6)
+  )
+)


### PR DESCRIPTION
## Summary

- Extends the retain+snapshot guard (introduced in #1021) to cover `FieldAccessExpr` iterables (`obj.field`, `self.items`) in addition to bare `VariableExpr` iterables.
- Adds `iterableHasExternalAlias()` static helper in `src/codegen_stmt_loop.cpp`, replacing the three `*IterIsVar` gate checks.
- Adds `tests/spec/for_mutation_field.test.ry` with 5 regression tests (list, set, map, tuple-destructure, nested field access).
- Updates `KNOWLEDGE.md` #1021 entry: "VarExpr gate" → "External-alias gate", corrects incorrect "stale `entryBlock_`" claim, documents the thread-closure limitation.
- Files follow-up issues #1090 (thread_spawn closure crash) and #1091 (IndexExpr iterable not yet guarded).

Closes #1041

## Root cause

`append!`/`add`/map-insert reallocate the backing buffer and `free` the old one. The pre-loop SSA buffer pointer becomes dangling (UAF). The gate in #1021 was `std::get_if<VariableExpr>(&s->iterable->data) != nullptr` — it fired only for bare variable references. `FieldAccessExpr` nodes (`obj.items`) fell through, leaving the cached pointer unguarded.

## Fix

```cpp
static bool iterableHasExternalAlias(const ExprNode &e) {
    return std::get_if<VariableExpr>(&e.data) != nullptr
        || std::get_if<std::unique_ptr<FieldAccessExpr>>(&e.data) != nullptr;
}
```

Three gate sites in `codegen_stmt_loop.cpp` (`tupleIterIsVar`, `mapIterIsVar`, `elemIterIsVar`) now call `iterableHasExternalAlias()`.

## Test plan

- [x] `./build/ry test tests/spec/for_mutation_field.test.ry` — 5 passed, 0 failed
- [x] `./build/ry_tests` — 1777 passed
- [x] `./build/ry test -p` — 132 files, 0 failures
- [x] ASan+UBSan `ry_tests` — 1777 passed, no UAF reported
- [x] ASan+UBSan `ry test -p` — 132 files, 0 failures
- [x] TSan `ry_tests` — 1777 passed, no race detected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a use-after-free guard for for-loops to now trigger when iterating over field-accessed collections (e.g., `for x in obj.items`), preventing crashes when mutating containers during iteration.

* **Documentation**
  * Updated loop iteration guidance to reflect expanded mutation-safety coverage.

* **Tests**
  * Added comprehensive test coverage for safe iteration over field-accessed containers during mutations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->