### PR TITLE
fix(test): eliminate silent failures and intermittent crash in ry test -p (#1088)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1784,15 +1784,19 @@ workaround for the TSan runtime bug, not tolerance for real races.
 the thunk body, not through helper calls; if a helper-alias race
 surfaces, widen via #872 rather than blindly expanding the flag.
 
-### LLVM ORC JIT intermittent `cfree` crash in `removeResourceTracker` on Linux CI
+### LLVM ORC JIT intermittent crash in `~LLJIT()` / `removeResourceTracker` (Linux + macOS)
 
-**Source**: #1022 (2026-04-16), CI run 24507853564
-**Tags**: llvm, orc, jit, ci, flaky, linux, cleanup
+**Source**: #1022 (2026-04-16) CI run 24507853564; #1088 (2026-04-17) macOS Darwin 25.3.0
+**Tags**: llvm, orc, jit, ci, flaky, linux, macos, cleanup, parallel-test
 
 **Symptom**: The Ry self-test (`ry test -p`) completes all `it` blocks
-successfully, then crashes with an LLVM `PLEASE submit a bug report` message
-pointing into `cfree` → `removeResourceTracker`:
+successfully, then crashes during JIT teardown.
 
+- **Linux CI**: `cfree` → `removeResourceTracker` LLVM abort message after the test summary.
+- **macOS (non-ASan)**: intermittent `~40%` failure rate in parallel mode — worker subprocess
+  exits with signal (`128+N`) silently; the parent counts `+1 total failures` with no red line.
+
+On Linux:
 ```text
 135 passed, 0 failed
 PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/...
@@ -1802,13 +1806,15 @@ PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/...
 #8  runRySource(...)
 ```
 
-**Rule**: This crash is in LLVM's internal JIT cleanup (not user code) and
-is intermittent on the Linux CI runner. It does **not** reproduce under ASan
-on macOS. When this crash appears, trigger a CI re-run immediately; if the
-re-run passes, the failure is a pre-existing LLVM ORC JIT flakiness, not a
-regression introduced by the PR. Do not suppress the LLVM crash reporter or
-add `|| true` to the test runner command — a genuine double-free in user code
-would produce the same stack frame and must not be silently ignored.
+**Fix applied**: `src/jit_runner.cpp` — `(void)jit.release()` workaround is now guarded by
+`#if defined(__linux__) || defined(__APPLE__)` (previously Linux-only). The LLJIT is intentionally
+leaked so `~LLJIT()` never runs; the OS reclaims memory on process exit. Tracked in #742.
+
+**Rule**: On Linux CI, trigger a re-run if this crash appears — it is pre-existing LLVM ORC
+flakiness, not a regression. On macOS, the workaround suppresses the crash; if the `~40%` failure
+rate reappears after the fix, the root cause has changed and needs fresh investigation. Do not
+suppress the LLVM crash reporter or add `|| true` — a genuine double-free in user code would
+produce the same frame.
 
 ### `@parallel for` captures must be retained AND ARC-backed inside the thunk
 

--- a/changelog.d/1088-parallel-test-flake.md
+++ b/changelog.d/1088-parallel-test-flake.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Parallel test runner (`ry test -p`) now prints the failing file path and exit code for any non-zero worker, eliminating silent failure-count increments that were unattributable to a specific file. (#1088)
+- Test runtime flushes stdout at every `it` boundary and after the summary, so output is preserved even when a worker exits abnormally. (#1088)
+- Fixed an intermittent `~40%` failure rate in `ry test -p` on macOS caused by a crash in `~LLJIT()` during JIT teardown. Extended the existing Linux `(void)jit.release()` workaround to also apply on macOS. (#1088, #742)

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -385,13 +385,15 @@ int runRySource(const std::string &src, const std::string &source_name,
         cs->file_id_offset += fc;
     }
 
-#ifdef __linux__
-    // Intentionally leak the LLJIT on Linux to prevent a crash in ~LLJIT()
-    // (~ExecutorProcessControl() → __libc_free) caused by JIT relocation
-    // side-effects on ELF+JITLink.  The OS reclaims memory on process exit.
-    // Affects both subprocess (ry test -p) and sequential (ry test) modes;
-    // since ry always exits after the run/test command completes, the
-    // per-invocation leak is bounded by the process lifetime.
+#if defined(__linux__) || defined(__APPLE__)
+    // Intentionally leak the LLJIT to prevent an intermittent crash in
+    // ~LLJIT() during JIT teardown.  On Linux: ~ExecutorProcessControl() →
+    // __libc_free due to JIT relocation side-effects on ELF+JITLink (#742).
+    // On macOS: same intermittent crash signature observed in parallel test
+    // mode (ry test -p) — ~40 % failure rate; exit code 128+N (#1088).
+    // The OS reclaims memory on process exit.  Affects both subprocess and
+    // sequential modes; since ry always exits after run/test, the per-
+    // invocation leak is bounded by the process lifetime.
     // TODO(#742): Investigate root cause; fix or file upstream LLVM bug.
     (void)jit.release(); // NOLINT(bugprone-unused-return-value)
 #endif

--- a/src/test_runner.cpp
+++ b/src/test_runner.cpp
@@ -204,9 +204,12 @@ static int runTestFilesParallel(const std::vector<std::string> &test_files,
 
     int total_failed = 0;
     for (const auto &r : results) {
-        std::fputs(r.output.c_str(), stdout);
-        if (r.exit_code != 0)
+        if (r.exit_code != 0) {
+            std::printf("\n\033[31m[FAIL exit=%d] %s\033[0m\n",
+                        r.exit_code, r.filepath.c_str());
             ++total_failed;
+        }
+        std::fputs(r.output.c_str(), stdout);
     }
 
     std::printf("\n%zu test files executed, %d total failures (%.2fs, %zu workers)\n",

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -68,6 +68,7 @@ void __ry_test_it_end() {
         std::printf("%s\033[32m+ %s\033[0m\n", indent.c_str(), g_current_it.c_str());
         ++g_passed;
     }
+    std::fflush(stdout);
     g_current_it.clear();
 }
 
@@ -88,6 +89,7 @@ void __ry_test_fail(int line, const char *msg) {
 
 int __ry_test_summary() {
     std::printf("\n%d passed, %d failed\n", g_passed, g_failed);
+    std::fflush(stdout);
     int result = g_failed;
     // Reset for potential multiple invocations
     g_passed = 0;


### PR DESCRIPTION
## Summary

Fixes #1088 — `ry test -p` intermittently reported `1 total failures` with no red failure line (~40% failure rate on macOS, 8 workers). Three related fixes:

- **Diagnostic**: parallel runner now prints `[FAIL exit=N] <filepath>` before the captured output for any non-zero worker, so failures are attributable to a specific file and exit code.
- **Flush**: `__ry_test_it_end` and `__ry_test_summary` now call `fflush(stdout)` after each `printf`. Worker output is captured through a block-buffered pipe; without an explicit flush, output is lost when a worker exits via `_exit()` or signal.
- **LLJIT teardown workaround**: extends the existing `(void)jit.release()` leak workaround from Linux-only (`#ifdef __linux__`) to also apply on macOS (`#if defined(__linux__) || defined(__APPLE__)`). The same intermittent crash in `~LLJIT()` that affected Linux CI (#742) also caused silent signal-death exits in macOS parallel workers.

### Root cause analysis

The issue body's hypothesis ("JIT shared state") is incorrect — each test file runs in a fresh `posix_spawn` subprocess, so there is no cross-worker JIT context sharing. The actual causes:
1. `runTestFilesParallel` derived `total_failed` from `r.exit_code != 0` only, with no attribution to a filename or exit code.
2. `std::printf` calls in `test_runtime.cpp` had no `fflush`; block-buffered pipe output was silently lost on abnormal worker exit.
3. macOS lacked the `~LLJIT()` leak workaround that Linux already has.

## Test plan

- [x] 1780 C++ tests (`./build/ry_tests`) — all pass
- [x] 20× parallel self-tests (`./build/ry test -p`) — 0 failures every run
- [x] ASan + UBSan (`./build-asan/ry_tests` + `./build-asan/ry test -p`) — clean
- [x] TSan C++ gate (`./build-tsan/ry_tests`) — clean
- [ ] Post-merge: verify macOS intermittent failure no longer reproduces under the original conditions (high-load parallel run)

> **Note**: No CI gate exists for macOS `ry test -p` (CI runs the parallel test on Ubuntu only). Verification is local. If the `~40%` failure rate reappears after this fix, the root cause has changed and needs fresh investigation (see updated KNOWLEDGE.md entry).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed intermittent crashes during parallel test execution on macOS
  * Enhanced parallel test failure reporting to display exit codes and failing test file paths
  * Improved output preservation in parallel tests to prevent loss of output during worker process failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->