### PR TITLE
fix(codegen): emit popScope() before CreateRetVoid() in thread thunk (#1090)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1671,12 +1671,6 @@ mutation — `append!` mutates in-place. The retain still protects the snapshot:
 the header's `strong_count` is bumped to ≥ 2, so the buffer is not freed. The
 loop iterates the original length read from the snapshot before mutation.
 
-**Known limitation — thread closure bodies** (#1090): the retain+snapshot guard
-crashes in `LowerExpectIntrinsicPass` on `__ry_thread.N` functions when the
-for-loop is inside a `thread_spawn` closure body (for both `VariableExpr` and
-`FieldAccessExpr` iterables). Root cause is unknown — it is NOT a stale alloca
-placement; `FnScope`/`getOrCreateVar` correctly targets the thunk's entry block.
-Until #1090 is fixed, avoid emitting the guard inside thread closure bodies.
 
 **Fix**:
 
@@ -1710,6 +1704,45 @@ accidentally share a snapshot alloca if the names differ.
 `iterableHasExternalAlias` paths should read from a `for_snap` alloca; for
 non-alias paths, the captured SSA `dataPtr`/`keysPtr`/`valsPtr` values are used
 directly.
+
+---
+
+### Thread / parallel-for thunk epilogue: `popScope()` before `CreateRetVoid()`
+
+**Source**: #1090 (2026-04-17)
+**Tags**: codegen, thread, parallel-for, arc, thunk, ir-verification
+
+**Rule**: In any internally-generated thunk function (`__ry_thread.N`,
+`__ry_parallel_for.N`), call `popScope()` **before** `builder_.CreateRetVoid()`.
+`popScope()` → `emitScopeCleanupToDepth()` → `emitArcReleaseVar()` emits
+`CreateLoad` + `CreateCondBr` diamond blocks. If `CreateRetVoid()` has already
+terminated the current BB, those instructions land after the terminator, producing
+malformed IR (multiple terminators / post-terminator instructions). The JIT
+optimizer (`LowerExpectIntrinsicPass` for O2) crashes on such IR.
+
+**Correct epilogue pattern** (from `emitParallelForRange`, `codegen_stmt_loop.cpp:765-766`):
+
+```cpp
+// body terminated by explicit return?  ReturnStmt already drained
+// arc_managed_vars_; iterator_malloc_stack_ items also emitted; skip.
+if (!builder_.GetInsertBlock()->getTerminator()) {
+    popScope();
+    if (!builder_.GetInsertBlock()->getTerminator())
+        builder_.CreateRetVoid();
+}
+```
+
+Note: if `iterator_malloc_stack_` at the current scope has items,
+`emitScopeCleanupToDepth` emits `free` calls but does **not** clear the vector
+(`codegen.cpp:384-390`). If `ReturnStmt` already fired `emitScopeCleanupToDepth(0)`,
+those free calls were already emitted; an unconditional subsequent `popScope()` would
+re-emit them into the (terminated) block. The `if (!terminated)` outer guard prevents
+this double-free / post-terminator insertion.
+
+**IR verification gap**: `thread_spawn` thunks now have `llvm::verifyFunction`
+(`codegen_call_thread.cpp:284-288`). `emitParallelForRange` does not yet have it
+(follow-up opportunity). Root cause of #1090 was the missing verify — the malformed
+IR survived codegen and crashed only during JIT optimization.
 
 ---
 

--- a/changelog.d/1090-thread-thunk-popscope-order.md
+++ b/changelog.d/1090-thread-thunk-popscope-order.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- For-loops over captured collections (`VariableExpr` / `FieldAccessExpr` iterables) inside `thread_spawn` closures no longer crash the JIT optimizer (`LowerExpectIntrinsicPass`). The thread thunk now releases ARC-managed locals before its `ret void`, matching the parallel-for thunk pattern (#1090).

--- a/src/codegen_call_thread.cpp
+++ b/src/codegen_call_thread.cpp
@@ -267,10 +267,25 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
             }
             resultSize = workerRetTy->isVoidTy() ? 0 : 8;
 
-            if (!cg.builder_.GetInsertBlock()->getTerminator())
-                cg.builder_.CreateRetVoid();
+            // popScope() must run BEFORE CreateRetVoid() because it emits ARC
+            // release diamonds (CreateLoad + CreateCondBr). If the BB is already
+            // terminated those instructions would land after the terminator,
+            // producing malformed IR that crashes LowerExpectIntrinsicPass (#1090).
+            // If the body ended with an explicit return (already terminated),
+            // ReturnStmt already called emitScopeCleanupToDepth(0) and drained
+            // arc_managed_vars_; skip both to avoid post-terminator IR.
+            if (!cg.builder_.GetInsertBlock()->getTerminator()) {
+                cg.popScope();
+                if (!cg.builder_.GetInsertBlock()->getTerminator())
+                    cg.builder_.CreateRetVoid();
+            }
+        }
 
-            cg.popScope();
+        {
+            std::string err;
+            llvm::raw_string_ostream errStream(err);
+            if (llvm::verifyFunction(*thunk, &errStream))
+                cg.codegenError("Internal: malformed thread thunk IR: " + err);
         }
 
     } else {

--- a/tests/spec/for_mutation.test.ry
+++ b/tests/spec/for_mutation.test.ry
@@ -1,3 +1,5 @@
+from thread import thread_spawn, thread_join, atomic_int_new, atomic_int_load, atomic_int_add
+
 describe("for mutation safety", ():
   it("should not visit appended elements when appending to list during iteration", ():
     # Issue #1021: append! grows the list, freeing the old buffer; the cached
@@ -99,5 +101,73 @@ describe("for mutation safety", ():
       seen_sum = seen_sum + y
     expect(seen_sum).to_eq(100)
     expect(length(ys)).to_eq(4)
+  )
+)
+
+describe("for mutation safety — inside thread_spawn closure (#1090)", ():
+  it("should not crash JIT when iterating a captured list inside thread closure", ():
+    # Issue #1090: retain+snapshot guard emitted popScope() AFTER CreateRetVoid()
+    # in thread_spawn thunks, producing post-terminator IR that crashed
+    # LowerExpectIntrinsicPass. The minimal repro doesn't even need append! —
+    # the guard fires whenever iterableHasExternalAlias(ys) is true.
+    ys = [10, 20, 30]
+    counter = atomic_int_new(0)
+    t = thread_spawn(():
+      for y in ys:
+        atomic_int_add(counter, y)
+    )
+    thread_join(t)
+    expect(atomic_int_load(counter)).to_eq(60)
+  )
+
+  it("should not crash JIT when iterating a captured set inside thread closure", ():
+    s = {10, 20, 30}
+    counter = atomic_int_new(0)
+    t = thread_spawn(():
+      for x in s:
+        atomic_int_add(counter, 1)
+    )
+    thread_join(t)
+    expect(atomic_int_load(counter)).to_eq(3)
+  )
+
+  it("should not crash JIT when iterating a captured map inside thread closure", ():
+    m = {"a": 1, "b": 2, "c": 3}
+    counter = atomic_int_new(0)
+    t = thread_spawn(():
+      for k, v in m:
+        atomic_int_add(counter, v)
+    )
+    thread_join(t)
+    expect(atomic_int_load(counter)).to_eq(6)
+  )
+
+  it("should not crash JIT when snapshot guard runs alongside in-thunk mutation", ():
+    # We do NOT assert on main's length(ys) because capture rebinds into a
+    # thunk-local alloca; the worker's append! CoW-forks only the worker's
+    # alloca. The snapshot guard inside the worker freezes the original buffer
+    # for the loop, so the counter accumulates the original 3 elements (60).
+    ys = [10, 20, 30]
+    counter = atomic_int_new(0)
+    t = thread_spawn(():
+      for y in ys:
+        atomic_int_add(counter, y)
+        append!(ys, y + 100)
+    )
+    thread_join(t)
+    expect(atomic_int_load(counter)).to_eq(60)
+  )
+
+  it("should not crash JIT when an ARC-managed local lives in thread closure", ():
+    # Broader coverage: any ARC-managed local in the thunk would have hit
+    # the same post-terminator IR bug. A bare str local exercises the generic
+    # ARC release path independent of the for-loop snap alloca.
+    counter = atomic_int_new(0)
+    t = thread_spawn(():
+      s = "hello world"
+      atomic_int_add(counter, length(s))
+    )
+    thread_join(t)
+    expect(atomic_int_load(counter)).to_eq(11)
   )
 )

--- a/tests/spec/for_mutation_field.test.ry
+++ b/tests/spec/for_mutation_field.test.ry
@@ -1,3 +1,5 @@
+from thread import thread_spawn, thread_join, atomic_int_new, atomic_int_load, atomic_int_add
+
 record ListBag:
   items: List<int>
 
@@ -74,5 +76,38 @@ describe("for mutation safety — FieldAccessExpr iterables (#1041)", ():
       append!(outer.inner.values, x + 100)
     expect(count).to_eq(3)
     expect(length(outer.inner.values)).to_eq(6)
+  )
+)
+
+describe("for mutation safety — FieldAccessExpr iterables inside thread_spawn (#1090)", ():
+  it("should not crash JIT when iterating bag.items inside thread closure", ():
+    # Record-field iteration inside a thread closure must also pass the
+    # retain+snapshot guard without crashing the JIT optimizer.
+    b = ListBag([10, 20, 30])
+    counter = atomic_int_new(0)
+    t = thread_spawn(():
+      for x in b.items:
+        atomic_int_add(counter, x)
+    )
+    thread_join(t)
+    expect(atomic_int_load(counter)).to_eq(60)
+  )
+
+  it("should snapshot-iterate when appending to bag.items inside thread closure", ():
+    # FieldAccessExpr: tryGetReceiverAlloca returns nullptr, so append! mutates
+    # the field buffer in-place via CoW on the field slot. The record pointer is
+    # captured by value but the heap record is shared, so main observes the new
+    # length after join. The retain freezes the snapshot so the counter sees
+    # only the original 3 elements (60).
+    b = ListBag([10, 20, 30])
+    counter = atomic_int_new(0)
+    t = thread_spawn(():
+      for x in b.items:
+        atomic_int_add(counter, x)
+        append!(b.items, x + 100)
+    )
+    thread_join(t)
+    expect(atomic_int_load(counter)).to_eq(60)
+    expect(length(b.items)).to_eq(6)
   )
 )


### PR DESCRIPTION
## Summary

- **Root cause**: `src/codegen_call_thread.cpp` called `CreateRetVoid()` before `popScope()` in thread spawn thunks. `popScope()` → `emitArcReleaseVar()` emits `CreateLoad` + `CreateCondBr` blocks. With the BB already terminated those instructions landed after the terminator, producing malformed IR (multiple terminators / post-terminator instructions).
- **Crash site**: No `verifyFunction` was called on thread thunks, so the malformed IR survived codegen and reached the JIT O2 pipeline where `LowerExpectIntrinsicPass` crashed on `__ry_thread.N` functions.
- **Fix**: Guard the entire epilogue with `if (!terminated)`, call `popScope()` first, then `CreateRetVoid()`. Added `llvm::verifyFunction` after thunk generation as a safety net for future regressions.

## Test plan

- [ ] `tests/spec/for_mutation.test.ry` — 5 new `thread_spawn` tests: captured list / set / map iteration, snapshot-under-mutation, bare ARC-managed local (`str`)
- [ ] `tests/spec/for_mutation_field.test.ry` — 2 new `thread_spawn` tests: `FieldAccessExpr` (`bag.items`) read-only and with `append!`
- [ ] All tests pass: `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p`
- [ ] ASan + UBSan clean: `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests && ./build-asan/ry test -p`
- [ ] TSan clean: `cmake --preset tsan && cmake --build build-tsan && TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests && ./build-tsan/ry test -p`

Closes #1090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in the JIT optimizer when using `thread_spawn` closures containing for-loops over captured collections (lists, sets, maps, and field access expressions).

* **Tests**
  * Added comprehensive test coverage for thread-spawn closure iteration behavior with various collection types and concurrent mutations.

* **Documentation**
  * Updated internal codegen documentation regarding scope cleanup ordering for thread worker functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->