### PR TITLE
fix(codegen): extend for-loop UAF guard to IndexExpr iterables (#1091)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1648,24 +1648,23 @@ inside the header is separately `checked_malloc`'d and must be freed with plain
 
 ### `for` loop over a collection: snapshot via `emitArcRetain` to prevent buffer-pointer UAF
 
-**Source**: #1021 (2026-04-16), #1041 (2026-04-17)
+**Source**: #1021 (2026-04-16), #1041 (2026-04-17), #1091 (2026-04-17)
 **Tags**: codegen, for-loop, list, set, map, arc, cow, use-after-free, iteration
 
 **Rule**: Never cache a collection's internal buffer pointer (`data`, `keys`,
 `vals`) in an SSA value that is read inside the loop body **when the iterable
-carries an external alias** (`VariableExpr` or `FieldAccessExpr`). `append!`/`add`/map-insert grow the
+carries an external alias** (`VariableExpr`, `FieldAccessExpr`, or `IndexExpr`). `append!`/`add`/map-insert grow the
 collection; when the buffer is full, they `arc_alloc` a new buffer, copy, and
 **`free` the old buffer** — leaving any pre-loop SSA pointer dangling (UAF).
 
 **External-alias gate**: Apply retain+snapshot when
 `iterableHasExternalAlias(*s->iterable)` returns true — i.e., the iterable is
-`VariableExpr` **or** `FieldAccessExpr` (e.g. `obj.items`, `self.xs`). For true
-temporaries (`range(100)`, result of a call expression, `emitStringToCharList`
-output, list/set/map literals, etc.) there is no external alias that can mutate
-the collection through CoW — pre-loop SSA values are safe. `IndexExpr`
-(`xs[i]`) is also an alias-carrying node but is not yet guarded; tracked in #1091.
+`VariableExpr`, `FieldAccessExpr` (e.g. `obj.items`, `self.xs`), **or** `IndexExpr`
+(e.g. `xs[i]`, `m["key"]`). For true temporaries (`range(100)`, result of a call
+expression, `emitStringToCharList` output, list/set/map literals, etc.) there is no
+external alias that can mutate the collection through CoW — pre-loop SSA values are safe.
 
-**FieldAccessExpr semantic difference**: `tryGetReceiverAlloca` returns `nullptr`
+**FieldAccessExpr / IndexExpr semantic difference**: `tryGetReceiverAlloca` returns `nullptr`
 for `FieldAccessExpr` (only handles `VariableExpr`), so no CoW fork occurs on
 mutation — `append!` mutates in-place. The retain still protects the snapshot:
 the header's `strong_count` is bumped to ≥ 2, so the buffer is not freed. The
@@ -1673,8 +1672,8 @@ loop iterates the original length read from the snapshot before mutation.
 
 **Known limitation — thread closure bodies** (#1090): the retain+snapshot guard
 crashes in `LowerExpectIntrinsicPass` on `__ry_thread.N` functions when the
-for-loop is inside a `thread_spawn` closure body (for both `VariableExpr` and
-`FieldAccessExpr` iterables). Root cause is unknown — it is NOT a stale alloca
+for-loop is inside a `thread_spawn` closure body (for `VariableExpr`, `FieldAccessExpr`,
+and `IndexExpr` iterables). Root cause is unknown — it is NOT a stale alloca
 placement; `FnScope`/`getOrCreateVar` correctly targets the thunk's entry block.
 Until #1090 is fixed, avoid emitting the guard inside thread closure bodies.
 

--- a/changelog.d/1091-for-loop-indexexpr-uaf.md
+++ b/changelog.d/1091-for-loop-indexexpr-uaf.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `for x in xs[i]:` now snapshots the indexed collection via ARC retain, preventing
+  use-after-free when the same slot is mutated (`append!`/`add`/`xs[i][k] = v`) inside
+  the loop body. Extends the guard from #1021 (`VariableExpr`) and #1041 (`FieldAccessExpr`)
+  to `IndexExpr` iterables. (#1091)

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -6,15 +6,16 @@ namespace ry {
 
 // Returns true when the iterable expression carries an external alias that
 // could trigger in-place CoW mutations of the underlying collection during
-// the loop body. These paths need the retain+snapshot guard (#1021, #1041):
+// the loop body. These paths need the retain+snapshot guard (#1021, #1041, #1091):
 //   - VariableExpr: a named binding in scope (e.g. `for x in ys:`).
 //   - FieldAccessExpr: a record field access (e.g. `for x in obj.items:`).
+//   - IndexExpr: a container slot access (e.g. `for x in xs[i]:`, `for k, v in m["key"]:`).
 // Temporaries — range(), call results, literals, emitStringToCharList output —
 // carry no aliasable binding, so pre-loop SSA values are safe without a guard.
-// IndexExpr is excluded here and tracked as a follow-up issue.
 static bool iterableHasExternalAlias(const ExprNode &e) {
     return std::get_if<VariableExpr>(&e.data) != nullptr
-        || std::get_if<std::unique_ptr<FieldAccessExpr>>(&e.data) != nullptr;
+        || std::get_if<std::unique_ptr<FieldAccessExpr>>(&e.data) != nullptr
+        || std::get_if<std::unique_ptr<IndexExpr>>(&e.data) != nullptr;
 }
 
 void CodeGen::emitStmt(std::unique_ptr<WhileStmt> &s) {

--- a/tests/spec/for_mutation_index.test.ry
+++ b/tests/spec/for_mutation_index.test.ry
@@ -1,0 +1,57 @@
+describe("for mutation safety — IndexExpr iterables (#1091)", ():
+  it("should not visit appended elements when appending via list index (list of list)", ():
+    # Issue #1091: the retain+snapshot guard must also fire when the iterable is an
+    # IndexExpr (e.g. xs[0]). Without the fix, append! frees the old buffer and
+    # the loop reads dangling memory (UAF).
+    xs: List<List<int>> = [[10, 20, 30]]
+    count = 0
+    seen_sum = 0
+    for x in xs[0]:
+      count = count + 1
+      seen_sum = seen_sum + x
+      append!(xs[0], x + 100)
+    expect(count).to_eq(3)
+    expect(seen_sum).to_eq(60)
+    expect(length(xs[0])).to_eq(6)
+  )
+
+  it("should not visit added elements when adding via list index (list of set)", ():
+    xs: List<Set<int>> = [{10, 20, 30}]
+    count = 0
+    for t in xs[0]:
+      count = count + 1
+      add(xs[0], t + 100)
+    expect(count).to_eq(3)
+    expect(length(xs[0])).to_eq(6)
+  )
+
+  it("should not visit inserted entries when inserting via list index (list of map)", ():
+    xs: List<Map<str, int>> = [{"a": 1, "b": 2, "c": 3}]
+    count = 0
+    for k, v in xs[0]:
+      count = count + 1
+      xs[0][k + "_new"] = v + 10
+    expect(count).to_eq(3)
+    expect(length(xs[0])).to_eq(6)
+  )
+
+  # NOTE: the following cases are deferred to separate issues due to pre-existing bugs
+  # in IndexExpr iteration unrelated to the UAF guard:
+  #   - tuple-destructure (for a, b in xs[i]:): second slot has wrong type metadata (#1094)
+  #   - nested IndexExpr (for x in outer[0][0]:): triple-nesting resolves to wrong element type (#1095)
+
+  it("should not visit appended elements when appending via map index (map of list)", ():
+    # Exercises the Map-outer IndexExpr code path. m["key"] returns a List<int>;
+    # the loop iterates it while append! via the same index expression grows it.
+    m: Map<str, List<int>> = {"key": [10, 20, 30]}
+    count = 0
+    seen_sum = 0
+    for x in m["key"]:
+      count = count + 1
+      seen_sum = seen_sum + x
+      append!(m["key"], x + 100)
+    expect(count).to_eq(3)
+    expect(seen_sum).to_eq(60)
+    expect(length(m["key"])).to_eq(6)
+  )
+)


### PR DESCRIPTION
## Summary

- Extends `iterableHasExternalAlias()` in `src/codegen_stmt_loop.cpp` to return `true` for `IndexExpr` (in addition to `VariableExpr` and `FieldAccessExpr`), activating the existing retain+snapshot guard for `for x in xs[i]:` and `for k, v in m["key"]:` loops
- Adds 4 regression tests in `tests/spec/for_mutation_index.test.ry` covering list-outer (list, set, map inner collections) and map-outer IndexExpr paths
- Two pre-existing bugs discovered during TDD were triaged and filed as separate issues: tuple-destructure second-slot type metadata (#1094) and triple-nested IndexExpr zero-iterations (#1095)

## Problem

`for x in xs[0]: append!(xs[0], x + 100)` had the same use-after-free as the `VariableExpr` (#1021) and `FieldAccessExpr` (#1041) iterable cases. When `append!` grew the inner collection, `arc_alloc` handed out a new buffer and freed the old one — the pre-loop SSA `data` pointer became dangling.

## Fix

One-line extension to `iterableHasExternalAlias()`. No ARC, AST, or parser changes needed — the existing retain+snapshot infrastructure already handles `IndexExpr` correctly once the helper returns `true`.

## Docs

No English docs update required. `docs/reference/` already documents `for` as iterating the collection at loop entry; this PR makes reality match the existing documented behavior.

## Test plan

- [x] `tests/spec/for_mutation_index.test.ry` — 4 new regression cases pass (default build)
- [x] `for_mutation.test.ry` and `for_mutation_field.test.ry` — no regression on existing guarded paths
- [x] `./build/ry_tests` — all 1780 C++ tests pass (default, ASan+UBSan, TSan)
- [x] `./build/ry test -p` — all 133 Ry self-test files pass (default, ASan+UBSan, TSan)
- [x] Pre-fix default build: garbage `seen_sum` (1725094) + SIGSEGV on list-of-list case confirms UAF
- [x] Post-fix: all 4 cases clean under ASan+UBSan

Closes #1091

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a use-after-free when iterating over indexed collections in for-loops while the loop body mutates the underlying storage (e.g., append/add or indexed assignment). Indexed iterables now remain valid during mutation.
* **Documentation**
  * Clarified examples and semantics for indexed iterables and temporary-safe cases.
* **Tests**
  * Added tests covering mutation safety when iterating over indexed collections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->