### PR TITLE
fix(codegen): prefer stored list_elem_type_name in inferCollectionTypeName (#1094, #1095)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -550,6 +550,46 @@ literal paths (`codegen_expr_literal.cpp`) and confirm each of them
 handles non-pointer elements whose metadata still needs to reach the
 container's element-type-name slot.
 
+### `inferCollectionTypeName` List branch must prefer stored `list_elem_type_name` over `reverseResolveTypeName`
+
+**Source**: #1094 + #1095 (2026-04-17, implementation)
+**Tags**: codegen, metadata, list, inferCollectionTypeName, reverseResolveTypeName, nested-list, tuple
+
+**Context**: The List branch of `inferCollectionTypeName`
+(`src/codegen_builtin.cpp`) originally called
+`reverseResolveTypeName(elemTy)` unconditionally.
+`reverseResolveTypeName` is lossy:
+- `ptrTy_` → `"str"` (L981 of `codegen_lambda.cpp`), so a
+  `List<List<int>>` whose middle list correctly stored
+  `list_elem_type_name = "List<int>"` had that info discarded, and the
+  outer list was annotated as `"List<str>"` instead of
+  `"List<List<int>>"` (#1095: for-loop over `outer[0][0]` ran 0 times).
+- Unnamed `StructType` (tuples) → fall-through to `"any"` (L989), so
+  a `List<List<(int,int)>>` was annotated as `"List<any>"`, bypassing
+  `emitVarDecl`'s annotation fallback and causing the second destructured
+  variable to receive wrong metadata (#1094).
+
+The Map branch (`L243-250`) already prefered stored names via
+`meta->map_key_type_name` / `meta->map_value_type_name` — the List
+branch simply wasn't updated.
+
+**Rule**: In `inferCollectionTypeName`, check
+`meta->list_elem_type_name` before falling back to
+`reverseResolveTypeName`. Additionally, return `""` for unnamed
+`StructType` elements (tuples) so callers (`emitVarDecl`'s annotation
+fallback, `codegen_stmt.cpp:491-512`) can derive the correct name from
+the source annotation. Do **not** return `""` for `ptrTy_`
+unconditionally — plain `List<str>` lists set no `list_elem_type_name`
+(string literals have no collection metadata), so returning `""` for
+them would break nested-list display (e.g. `to_str([["a","b"],["c"]])`
+prints `["",""]` instead of `[["a","b"],["c"]]`).
+
+**How to apply**: When extending `inferCollectionTypeName` for Set or
+other container kinds, mirror the same pattern: (1) stored name first,
+(2) return `""` only for types with no canonical LLVM-to-name mapping
+(currently unnamed StructType), (3) fall back to `reverseResolveTypeName`
+for everything else.
+
 ### New primitive types must be wired into every type-reflection site
 
 **Source**: #825 PR review (CodeRabbit, 4 comments)

--- a/changelog.d/1094-1095-indexexpr-metadata.md
+++ b/changelog.d/1094-1095-indexexpr-metadata.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `for a, b in xs[0]:` where `xs: List<List<(int, int)>>` now correctly types the second destructured variable `b` as `int` instead of reading raw bytes (#1094)
+- `for x in outer[0][0]:` where `outer: List<List<List<int>>>` now correctly iterates all elements instead of running 0 times (#1095)

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -249,8 +249,20 @@ std::string CodeGen::inferCollectionTypeName(llvm::Value *val) {
             ? meta->map_value_type_name : reverseResolveTypeName(getMapValueType(val));
         return "Map<" + keyName + ", " + valName + ">";
     }
-    if (auto *elemTy = getListElementType(val))
+    if (auto *elemTy = getListElementType(val)) {
+        // Prefer stored source-level element name (mirrors Map branch above).
+        // reverseResolveTypeName(ptrTy_) loses nested-list info ("List<List<int>>"
+        // collapses to "List<str>") — so check the stored name first (#1095).
+        if (auto *meta = getMeta(val); meta && !meta->list_elem_type_name.empty())
+            return "List<" + meta->list_elem_type_name + ">";
+        // Unnamed StructType (tuple) has no canonical name from LLVM type alone.
+        // Return "" so callers (emitVarDecl) can derive the correct name from the
+        // type annotation (#1094).
+        if (auto *st = llvm::dyn_cast<llvm::StructType>(elemTy);
+                st && findRecordTypeName(st).empty())
+            return "";
         return "List<" + reverseResolveTypeName(elemTy) + ">";
+    }
     if (auto *setTy = getSetElementType(val))
         return "Set<" + reverseResolveTypeName(setTy) + ">";
     // Enum element types: needed so container literals whose first element is

--- a/tests/spec/for_mutation_index.test.ry
+++ b/tests/spec/for_mutation_index.test.ry
@@ -35,10 +35,35 @@ describe("for mutation safety — IndexExpr iterables (#1091)", ():
     expect(length(xs[0])).to_eq(6)
   )
 
-  # NOTE: the following cases are deferred to separate issues due to pre-existing bugs
-  # in IndexExpr iteration unrelated to the UAF guard:
-  #   - tuple-destructure (for a, b in xs[i]:): second slot has wrong type metadata (#1094)
-  #   - nested IndexExpr (for x in outer[0][0]:): triple-nesting resolves to wrong element type (#1095)
+  it("should correctly destructure tuple elements when iterating via list index (#1094)", ():
+    # for a, b in xs[0]: where xs: List<List<(int, int)>>
+    # Without the fix, inferCollectionTypeName returned "List<any>" for xs[0]
+    # (unnamed StructType fell through reverseResolveTypeName to "any"), causing
+    # emitVarDecl's annotation fallback to be skipped and b to receive wrong metadata.
+    xs: List<List<(int, int)>> = [[(1, 2), (3, 4), (5, 6)]]
+    sum_a = 0
+    sum_b = 0
+    for a, b in xs[0]:
+      sum_a = sum_a + a
+      sum_b = sum_b + b
+    expect(sum_a).to_eq(9)
+    expect(sum_b).to_eq(12)
+  )
+
+  it("should iterate over innermost list when accessed via double index (#1095)", ():
+    # for x in outer[0][0]: where outer: List<List<List<int>>>
+    # Without the fix, inferCollectionTypeName returned "List<str>" for outer[0]
+    # (ptrTy_ collapsed to "str" via reverseResolveTypeName), so the middle list's
+    # elem metadata was corrupted and the loop ran 0 iterations.
+    outer: List<List<List<int>>> = [[[10, 20, 30]]]
+    count = 0
+    seen_sum = 0
+    for x in outer[0][0]:
+      count = count + 1
+      seen_sum = seen_sum + x
+    expect(count).to_eq(3)
+    expect(seen_sum).to_eq(60)
+  )
 
   it("should not visit appended elements when appending via map index (map of list)", ():
     # Exercises the Map-outer IndexExpr code path. m["key"] returns a List<int>;


### PR DESCRIPTION
## Summary

- **Root cause**: `inferCollectionTypeName` List branch unconditionally called `reverseResolveTypeName(elemTy)`, which is lossy: `ptrTy_` collapses to `"str"` and unnamed `StructType` (tuple) falls through to `"any"`. The Map branch already had the correct pattern (prefer stored names), but the List branch was never updated.
- **Fix**: Check `meta->list_elem_type_name` first (mirrors Map branch). For unnamed `StructType` (tuple), return `""` so `emitVarDecl`'s annotation fallback can derive the correct name. `ptrTy_` without a stored name still falls back to `reverseResolveTypeName` to preserve `List<str>` display behavior.
- **Tests**: Adds regression tests for both issues in `tests/spec/for_mutation_index.test.ry` (cases d and f, previously deferred as NOTE comments by PR #1097).

Closes #1094
Closes #1095

## Test plan

- [x] `./build/ry test tests/spec/for_mutation_index.test.ry` — 6 passed (includes new cases d, f)
- [x] `./build/ry_tests` — 1780 passed
- [x] `./build/ry test -p` — 133 files, 0 failures
- [x] ASan+UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p` — clean
- [x] TSan: `./build-tsan/ry_tests` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed type inference for destructuring variables in nested list iterations—previously incorrectly typed as raw bytes
* Fixed iteration failing to execute on deeply nested indexed list access—now properly iterates through elements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->