### PR TITLE
fix(codegen): unify Some(T)/None() branches in lambda if-expr inference (#1043)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2773,10 +2773,10 @@ gh run list --branch <headRefName> --limit 20 \
 
 Alternatively, derive run IDs directly from `detailsUrl` in the `gh pr checks` output (`grep -oE '/runs/([0-9]+)' | grep -oE '[0-9]+'`).
 
-### `inferExprType` / `inferExprTypeName` visitor must handle `IfExpr`/`IfBlockExpr` and ADT constructors (`Ok`/`Err`/`Some`) to infer lambda return type correctly
+### `inferExprType` / `inferExprTypeName` visitor must handle `IfExpr`/`IfBlockExpr` and ADT constructors (`Ok`/`Err`/`Some`/`None`) to infer lambda return type correctly
 
-**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification)
-**Tags**: codegen, inference, visitor, lambda, Result, IfExpr
+**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog)
+**Tags**: codegen, inference, visitor, lambda, Result, Option, IfExpr
 
 **Rule**: `inferExprType` and `inferExprTypeName` in `src/codegen_lambda.cpp` are the visitor functions that determine the return type of an expression-body lambda (`(x: int) => expr`). Both functions must have explicit `if constexpr` cases for every AST node that can appear as the outermost expression. Any unhandled node falls through to the default which returns `i64Ty_` (= `int`) — silently and without error.
 
@@ -2792,7 +2792,20 @@ return getResultType(mergedOk, mergedEr);
 ```
 This produces the correct unified `Result<T, Error>` StructType that both `Ok` and `Err` emitters in `codegen_call.cpp` will reuse via `fn_->getReturnType()`.
 
-**Analogous gap for Option**: `Some`/`None()` in an `if`-expr body has the same structural problem (#1043). The Option merge logic mirrors the Result one but must handle the Option StructType layout instead of `getResultType`.
+**Option merge logic (IfExpr — fixed in #1043)**: Option layout is 2-slot `{i1, innerTy}` vs Result's 3-slot. Three gaps existed beyond the structural #1024 analog:
+1. `Some` was missing from `inferExprType` (it was only in `inferExprTypeName`), causing `(x) => Some(x)` to fail.
+2. `None()` (zero-arg CallExpr) had no emitter anywhere — it fell through to `findFunction("None")` and failed with `undefined function: None`.
+3. `None` in `inferExprType` also needed a placeholder: `getOptionType(i8Ty_)`.
+
+Option merge (same `i8Ty_` placeholder convention as Result):
+```cpp
+if (isOptionType(thenTy) && isOptionType(elseTy)) {
+    llvm::Type *innerA = thenSt->getElementType(1);
+    llvm::Type *innerB = elseSt->getElementType(1);
+    return getOptionType((innerA == i8Ty_) ? innerB : innerA);
+}
+```
+`None()` emitter in `codegen_call.cpp` reads `fn_->getReturnType()` to derive inner (like `Err` does for the Ok slot), so the emitted struct matches the inferred return type and `validateBranchTypes` pointer-equality succeeds.
 
 **How to check for new gaps**: When adding a new ADT constructor or a new expression-level control-flow node, grep for both `inferExprType` and `inferExprTypeName` and verify each has a case for the new node. A missing case is a silent wrong-type inference, not a compile error.
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1869,19 +1869,21 @@ workaround for the TSan runtime bug, not tolerance for real races.
 the thunk body, not through helper calls; if a helper-alias race
 surfaces, widen via #872 rather than blindly expanding the flag.
 
-### LLVM ORC JIT intermittent crash in `~LLJIT()` / `removeResourceTracker` (Linux + macOS)
+### LLVM ORC JIT intermittent crash in `~LLJIT()` / `removeResourceTracker` / `~CodeGen()` (Linux + macOS)
 
-**Source**: #1022 (2026-04-16) CI run 24507853564; #1088 (2026-04-17) macOS Darwin 25.3.0
+**Source**: #1022 (2026-04-16) CI run 24507853564; #1088 (2026-04-17) macOS Darwin 25.3.0; #1043 (2026-04-17) CI runs 24547110395 + 24547575356
 **Tags**: llvm, orc, jit, ci, flaky, linux, macos, cleanup, parallel-test
 
 **Symptom**: The Ry self-test (`ry test -p`) completes all `it` blocks
 successfully, then crashes during JIT teardown.
 
-- **Linux CI**: `cfree` → `removeResourceTracker` LLVM abort message after the test summary.
+- **Linux CI**: glibc heap consolidation crash (`cfree`) during LLVM teardown. The crash frame
+  varies — most commonly `removeResourceTracker`, but `CodeGen::~CodeGen()` has also been observed
+  ("corrupted size vs. prev_size while consolidating"). Same root cause; different destruction order.
 - **macOS (non-ASan)**: intermittent `~40%` failure rate in parallel mode — worker subprocess
   exits with signal (`128+N`) silently; the parent counts `+1 total failures` with no red line.
 
-On Linux:
+On Linux (`removeResourceTracker` variant):
 ```text
 135 passed, 0 failed
 PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/...
@@ -1891,12 +1893,26 @@ PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/...
 #8  runRySource(...)
 ```
 
+On Linux (`~CodeGen()` variant):
+```text
+135 passed, 0 failed
+corrupted size vs. prev_size while consolidating
+#4  cfree (/lib/x86_64-linux-gnu/libc.so.6)
+#5  CodeGen::~CodeGen()
+```
+
+**Discriminating evidence for flake vs. regression**: If all test cases in the failing file report
+success (N passed, 0 failed) and only the teardown crashes, and a re-run on the same commit passes,
+classify as flake. A genuine heap corruption from user code would fail a specific test case or fail
+deterministically.
+
 **Fix applied**: `src/jit_runner.cpp` — `(void)jit.release()` workaround is now guarded by
 `#if defined(__linux__) || defined(__APPLE__)` (previously Linux-only). The LLJIT is intentionally
 leaked so `~LLJIT()` never runs; the OS reclaims memory on process exit. Tracked in #742.
 
 **Rule**: On Linux CI, trigger a re-run if this crash appears — it is pre-existing LLVM ORC
-flakiness, not a regression. On macOS, the workaround suppresses the crash; if the `~40%` failure
+flakiness, not a regression. The `~CodeGen()` frame variant is the same flake family as
+`removeResourceTracker`. On macOS, the workaround suppresses the crash; if the `~40%` failure
 rate reappears after the fix, the root cause has changed and needs fresh investigation. Do not
 suppress the LLVM crash reporter or add `|| true` — a genuine double-free in user code would
 produce the same frame.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2847,6 +2847,15 @@ if (isOptionType(thenTy) && isOptionType(elseTy)) {
 ```
 `None()` emitter in `codegen_call.cpp` reads `fn_->getReturnType()` to derive inner (like `Err` does for the Ok slot), so the emitted struct matches the inferred return type and `validateBranchTypes` pointer-equality succeeds.
 
+**Parser trap — block-form branches with `Some(...)`/`None()` tail**: In an `IfBlockExpr` (colon-indent body), a bare `Some(x)` or `None()` on the last line is parsed as a `CallStmt` (discarded statement), not as the block's return value. Wrap it in parentheses to produce an `ExprStmt` that is recognised as the tail expression:
+```ry
+f = (x: int) => if x > 0:
+  (Some(x * 2))   # ← parens required; bare Some(x * 2) would be a discarded CallStmt
+else:
+  (None())
+```
+This is the same rule as the `IfBlockExpr` path tested in `tests/spec/option_lambda_if.test.ry`.
+
 **How to check for new gaps**: When adding a new ADT constructor or a new expression-level control-flow node, grep for both `inferExprType` and `inferExprTypeName` and verify each has a case for the new node. A missing case is a silent wrong-type inference, not a compile error.
 
 ### UnaryExpr fast-path covers bare int for INT64_MIN (`-9223372036854775808`)

--- a/changelog.d/1043-option-lambda-if-inference.md
+++ b/changelog.d/1043-option-lambda-if-inference.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Lambda return-type inference now unifies `Some(T)` and `None()` branches in
+  if-expr, matching the `Ok`/`Err` behavior added in #1024. Previously
+  `(x: int) => if cond => Some(x) else None()` failed with `undefined function: None`,
+  and even `(x: int) => Some(x)` alone failed with a return-type mismatch (#1043)

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -767,6 +767,21 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         return emitStringByteLen(ptr);
     }
 
+    // None() → Option<T> constructor (T derived from enclosing return type)
+    if (e.callee == "None") {
+        if (!e.args.empty())
+            codegenError("None() takes no arguments");
+        llvm::Type *innerTy = i8Ty_;
+        if (fn_) {
+            llvm::Type *retTy = fn_->getReturnType();
+            if (isOptionType(retTy)) {
+                auto *retStructTy = llvm::cast<llvm::StructType>(retTy);
+                innerTy = retStructTy->getElementType(1);
+            }
+        }
+        return buildNoneValue(getOptionType(innerTy));
+    }
+
     // Some(x) → Option<T> constructor
     if (e.callee == "Some") {
         requireArgs(e, 1);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -606,6 +606,13 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 llvm::Type *errTy = inferExprType(*v->args[0], paramTypeMap);
                 return getResultType(i8Ty_, errTy);
             }
+            if (c == "Some" && v->args.size() == 1) {
+                llvm::Type *innerTy = inferExprType(*v->args[0], paramTypeMap);
+                return getOptionType(innerTy);
+            }
+            if (c == "None" && v->args.empty()) {
+                return getOptionType(i8Ty_); // placeholder — merged in IfExpr arm
+            }
             return i64Ty_; // fallback
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondExpr>>) {
             return inferExprType(*v->else_expr, paramTypeMap);
@@ -624,6 +631,14 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 llvm::Type *mergedOk = (okA == i8Ty_) ? okB : okA;
                 llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
                 return getResultType(mergedOk, mergedEr);
+            }
+            if (isOptionType(thenTy) && isOptionType(elseTy)) {
+                auto *thenSt = llvm::cast<llvm::StructType>(thenTy);
+                auto *elseSt = llvm::cast<llvm::StructType>(elseTy);
+                llvm::Type *innerA = thenSt->getElementType(1);
+                llvm::Type *innerB = elseSt->getElementType(1);
+                llvm::Type *mergedInner = (innerA == i8Ty_) ? innerB : innerA;
+                return getOptionType(mergedInner);
             }
             return i64Ty_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
@@ -645,6 +660,14 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 llvm::Type *mergedOk = (okA == i8Ty_) ? okB : okA;
                 llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
                 return getResultType(mergedOk, mergedEr);
+            }
+            if (isOptionType(thenTy) && isOptionType(elseTy)) {
+                auto *thenSt = llvm::cast<llvm::StructType>(thenTy);
+                auto *elseSt = llvm::cast<llvm::StructType>(elseTy);
+                llvm::Type *innerA = thenSt->getElementType(1);
+                llvm::Type *innerB = elseSt->getElementType(1);
+                llvm::Type *mergedInner = (innerA == i8Ty_) ? innerB : innerA;
+                return getOptionType(mergedInner);
             }
             return i64Ty_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<InterpolatedStringExpr>>) {
@@ -771,6 +794,7 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             if (v->callee == "type_of") return "Type";
             if (v->callee == "Ok" && v->args.size() == 1) return "Result";
             if (v->callee == "Err" && v->args.size() == 1) return "Result";
+            if (v->callee == "None" && v->args.empty()) return "Option";
             auto *overloads = findFunction(v->callee);
             if (overloads && !overloads->empty() && !(*overloads)[0].returnTypeName.empty())
                 return (*overloads)[0].returnTypeName;
@@ -828,6 +852,10 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             std::string elseName = inferExprTypeName(*v->else_value, paramTypeMap,
                                                       paramTypeNameMap);
             if (thenName == "Result" || elseName == "Result") return "Result";
+            auto isOptName = [](const std::string &s) {
+                return s == "Option" || s.rfind("Option<", 0) == 0;
+            };
+            if (isOptName(thenName) || isOptName(elseName)) return "Option";
             return "";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
             std::string thenName;
@@ -845,6 +873,10 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
                                                    paramTypeNameMap);
             }
             if (thenName == "Result" || elseName == "Result") return "Result";
+            auto isOptName = [](const std::string &s) {
+                return s == "Option" || s.rfind("Option<", 0) == 0;
+            };
+            if (isOptName(thenName) || isOptName(elseName)) return "Option";
             return "";
         } else {
             return reverseResolveTypeName(inferExprType(expr, paramTypeMap));

--- a/tests/spec/option_lambda_if.test.ry
+++ b/tests/spec/option_lambda_if.test.ry
@@ -1,0 +1,63 @@
+describe("Option lambda if-expr inference (unannotated return type)", ():
+  it("should infer Option from if-expr with Some then None - some branch", ():
+    f = (x: int) => if x > 0 => Some(x * 2) else None()
+    case f(5):
+      Some(v): expect(v).to_eq(10)
+      None: fail("expected Some but got None")
+  )
+
+  it("should infer Option from if-expr with Some then None - none branch", ():
+    f = (x: int) => if x > 0 => Some(x * 2) else None()
+    case f(-1):
+      Some(v): fail("expected None but got Some")
+      None: expect(true).to_eq(true)
+  )
+
+  it("should infer Option when passed to map - some branch", ():
+    f = (x: int) => if x > 0 => Some(x * 3) else None()
+    result = f(4).map((v: int) => v + 1)
+    case result:
+      Some(v): expect(v).to_eq(13)
+      None: fail("expected Some but got None")
+  )
+
+  it("should infer Option when then-branch is None and else-branch is Some", ():
+    f = (x: int) => if x > 100 => None() else Some(x + 1)
+    case f(5):
+      Some(v): expect(v).to_eq(6)
+      None: fail("expected Some but got None")
+    case f(200):
+      Some(v): fail("expected None but got Some")
+      None: expect(true).to_eq(true)
+  )
+
+  it("should infer Option from block-form if-expr (IfBlockExpr path)", ():
+    f = (x: int) => if x > 0:
+      (Some(x * 2))
+    else:
+      (None())
+    case f(7):
+      Some(v): expect(v).to_eq(14)
+      None: fail("expected Some but got None")
+    case f(-3):
+      Some(v): fail("expected None but got Some")
+      None: expect(true).to_eq(true)
+  )
+
+  it("should still work with explicit -> Option<int> annotation (regression guard)", ():
+    f = (x: int) -> Option<int> => if x > 0 => Some(x * 2) else None()
+    case f(5):
+      Some(v): expect(v).to_eq(10)
+      None: fail("expected Some but got None")
+    case f(-1):
+      Some(v): fail("expected None but got Some")
+      None: expect(true).to_eq(true)
+  )
+
+  it("should infer Option from plain Some(x) lambda without if-expr", ():
+    f = (x: int) => Some(x * 2)
+    case f(5):
+      Some(v): expect(v).to_eq(10)
+      None: fail("expected Some but got None")
+  )
+)

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -362,3 +362,12 @@ TEST_F(CodeGenTest, OctalLiteralRejectedWithTargetedDiagnostic) {
     expectCompileError("x = 0O17\n",
                        "octal literals (0o...) are not supported");
 }
+
+// ============================================================
+// None() rejects non-zero arguments (#1043)
+// ============================================================
+
+TEST_F(CodeGenTest, NoneWithArgsIsRejected) {
+    expectCompileError("x: int? = None(1)\n",
+                       "None() takes no arguments");
+}


### PR DESCRIPTION
## Summary

- Add `None()` emitter to `codegen_call.cpp` (was missing entirely — fell through to `undefined function: None`)
- Extend `inferExprType` in `codegen_lambda.cpp` to handle `Some`/`None` `CallExpr` and `IfExpr`/`IfBlockExpr` Option merge
- Extend `inferExprTypeName` in `codegen_lambda.cpp` with matching `None` case and `isOptName` check for if-expr branches
- Mirror the `Ok`/`Err` fix from #1024 — same `i8Ty_` placeholder convention, same `fn_->getReturnType()` pattern for `None()` emitter

Fixes #1043.

## Test plan

- [ ] `tests/spec/option_lambda_if.test.ry` — 7 cases: Some/None branches (both orientations), `map` consumer, `IfBlockExpr` form, explicit annotation regression guard, plain `Some(x)` lambda regression guard
- [ ] `./build/ry_tests` — 1780 C++ tests pass
- [ ] `./build/ry test -p` — 134 Ry self-test files pass
- [ ] ASan + UBSan: `cmake --preset asan && cmake --build build-asan && ./build-asan/ry_tests && ./build-asan/ry test -p` — clean
- [ ] TSan: `cmake --preset tsan && cmake --build build-tsan && ./build-tsan/ry_tests` — clean (C++ required)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed lambda return-type inference for if-expressions returning Option types: Some and None branches are now unified, preventing prior inference and runtime errors.
  * None() is now handled correctly; calls with arguments are rejected with a compile-time diagnostic.

* **Documentation**
  * Updated knowledge/changelog entries to document the Option/if-expression inference behavior and teardown notes.

* **Tests**
  * Added tests covering Option inference for expression/block if-expressions and None argument rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->