### PR TITLE
fix(http): add NUL-safety at C API boundaries (#1054)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,8 +245,8 @@ endif()
 # needs hash symbols at link time for HTTP header map construction.
 # Shared TCP utilities are compiled directly into ry_http via runtime_net_utils.hpp.
 add_ry_native_lib(http       src/runtime_http.cpp src/runtime_http_client.cpp
-                             src/runtime_http_multipart.cpp src/runtime_tls.cpp
-                             src/runtime_hash.cpp)
+                             src/runtime_http_multipart.cpp src/runtime_http_error.cpp
+                             src/runtime_tls.cpp src/runtime_hash.cpp)
 target_link_libraries(ry_http PRIVATE OpenSSL::SSL OpenSSL::Crypto Threads::Threads)
 
 set(RY_NATIVE_LIBS ry_base64 ry_path ry_convert ry_filesystem ry_gc ry_io ry_json ry_net ry_thread ry_http)

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3001,3 +3001,50 @@ a copy of `c` — silently succeeding when it should propagate the error.
 - Upgrade bare `-> str` runtime functions that pass user strings to NUL-sensitive C APIs to
   `-> Result<str, Error>` (return nullptr + `setLastError`; set `ReturnWrapping::ResultPtr` in
   the dispatch table).
+
+### Ry case arms: `()` unit expression and `if <var>:` as sole body cause parse failures
+
+**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: testing, case, parser, unit, if
+
+**Rule**: Two patterns in case arm bodies trigger parser errors that manifest as a confusing
+"unexpected token ')'" at the nearest enclosing `describe(..., ():` or `it(..., ():` line:
+
+**Pattern 1: `()` as a case arm body**
+```ry
+# Fails — parser sees ')' and thinks it closes the outer describe/it closure:
+case is_dir(d):
+  Ok(v): remove_all(d)
+  Err(_): ()         # <-- breaks parser
+
+# Fix: use a real expression, or discard the conditional entirely:
+remove_all(d)        # discard Result; Ok = removed, Err = didn't exist, both fine for setup
+```
+
+**Pattern 2: `if <bool>:` as the sole statement in an inline case arm body**
+```ry
+# Fails — single-arm if expression at end of inline case arm body breaks parser:
+case is_dir(d):
+  Ok(v): if v: remove_all(d)   # <-- breaks parser
+  Err(_): 0
+
+# Fix: use unconditional call (discard result) or move inside a multiline body with a trailing statement:
+remove_all(d)          # simplest fix for setup guards
+```
+
+**Pattern 3: `Ok(true)` / `Ok(false)` literal patterns are NOT supported**
+```ry
+# Fails — nested literal matching inside constructor patterns:
+case is_dir(d):
+  Ok(true): remove_all(d)   # <-- parser error, not a type error
+  _: ()
+
+# Fix: bind to variable, then check:
+case is_dir(d):
+  Ok(v): expect(v).to_be_true()
+  Err(e): fail("is_dir failed: " + e.message)
+```
+
+**How to apply**: In test files, always use `Err(e): fail(...)` (not `Err(_): ()`) for error arms.
+For setup guards ("if dir exists, remove it"), prefer unconditional `remove_all(d)` — the returned
+`Result<Unit, Error>` is discarded if unused. For `Result<bool, Error>` predicates, use
+`Ok(v): expect(v).to_be_true()` / `Ok(v): expect(v).to_be_false()` patterns.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3200,21 +3200,26 @@ For setup guards ("if dir exists, remove it"), prefer unconditional `remove_all(
 `Result<Unit, Error>` is discarded if unused. For `Result<bool, Error>` predicates, use
 `Ok(v): expect(v).to_be_true()` / `Ok(v): expect(v).to_be_false()` patterns.
 
-### `hasEmbeddedNul` is only safe on Ry string handles — never on raw C strings
+### `hasEmbeddedNul` / `stringByteLen` are only safe on Ry string handles — never on raw C strings
 
 **Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: nul-safety, stringheader, c-api-boundary, runtime
 
-**Rule**: `hasEmbeddedNul(handle)` reads a `StringHeader` struct immediately *before* the pointer
-to obtain `byte_len`, then calls `memchr`. This is only valid when `handle` points into a Ry
-string slot (i.e., the pointer came from `makeString` or was read from a Ry `str` handle).
+**Rule**: Both `hasEmbeddedNul(handle)` and `stringByteLen(handle)` read a `StringHeader` struct
+immediately *before* the pointer to obtain `byte_len`. This is only valid when `handle` points
+into a Ry string slot (i.e., the pointer came from `makeString` or was read from a Ry `str` handle).
 
 **It is undefined behaviour** (reads garbage memory) when applied to:
 - C string literals: `hasEmbeddedNul("POST")` — no `StringHeader` prefix
 - `std::string::c_str()` results — allocated by the STL without a `StringHeader`
+- `strdup`/`malloc`-allocated strings (e.g. map keys built by C++ tests) — no `StringHeader` prefix
 - Any other raw `const char *` that did not originate from a Ry string slot
 
-The symptom is a false positive: `hasEmbeddedNul` reads random bytes before the pointer as
-`byte_len`, and `memchr` finds a NUL in that range, incorrectly returning `true`.
+**Symptoms**:
+- `hasEmbeddedNul` false positive: reads random bytes as `byte_len`, `memchr` finds NUL → returns
+  `true` unexpectedly, causing the runtime function to return nullptr and HTTP mock server tests
+  to hang (server `::accept` waits for a client that never connects).
+- `stringByteLen` garbage value: random bytes interpreted as body/data length → `Content-Length`
+  header wildly wrong → HTTP server reads wrong number of bytes → test hangs.
 
 **How to apply**: Only call `hasEmbeddedNul` inside codegen emitters (where arguments are known
 Ry handles) or inside runtime functions whose callers pass exclusively Ry handles. If a runtime

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2911,3 +2911,93 @@ must happen before `emitExpr`; post-emit metadata rescue (line 444-493) cannot r
 stride because `getListElementType(val)` returns i64 (truthy) and the annotation-fallback
 branch is gated on `!elemTy`. Scope: `let`/`var` declarations only — `AssignStmt`
 reassignment and inline call-argument paths are not covered.
+
+### `emitTableDrivenNativeCall` variadic path must use raw `ptr` type for `ResultPtr` entries
+
+**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: codegen, ResultPtr, variadic, emitTableDrivenNativeCall, nul-safety
+
+**Rule**: In `src/codegen_call_native.cpp`, the fixed-arity path of `emitTableDrivenNativeCall`
+already handled `ReturnWrapping::ResultPtr` (uses `ptrTy_` for the C ABI return, then wraps via
+`wrapPtrAsResult`). The variadic-arity path (for functions like `path.join` with 2/3/4 overloads)
+did **not** — it called `resolveType(matchedSig->returnTypeName)` to determine the C return type.
+After upgrading `.ry` signatures to `Result<str, Error>`, `matchedSig->returnTypeName` becomes
+`"Result<str, Error>"`, which `resolveType` maps to an LLVM struct type instead of `ptr` — causing
+an ABI mismatch crash (the runtime still returns `char *`).
+
+**Fix pattern**:
+```cpp
+// In the variadic path, before CreateCall:
+llvm::Type *cRetTyVariadic = (entry->wrapping == ReturnWrapping::ResultPtr)
+    ? ptrTy_
+    : resolveType(matchedSig->returnTypeName);
+auto *fnTy = llvm::FunctionType::get(cRetTyVariadic, argTypes, false);
+// ... CreateCall, then:
+if (entry->wrapping == ReturnWrapping::ResultPtr) {
+    std::string errFn = getErrFnName();
+    return wrapPtrAsResult(callResult, errFn.c_str());
+}
+return callResult;
+```
+
+**How to apply**: Any time a function with multiple overloads at different arities (variadic
+dispatch path) is upgraded from bare `-> str` to `-> Result<str, Error>`, both the
+`NativeDispatchEntry::wrapping` field AND the variadic code path in `emitTableDrivenNativeCall`
+need updating. The fixed-arity path handles it automatically once `wrapping = ResultPtr` is set;
+the variadic path requires explicit `ResultPtr` detection before `resolveType`.
+
+### NUL-safety at C API boundaries: `stringByteLen`, `hasEmbeddedNul`, and propagating nullptr
+
+**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: nul-safety, c-api-boundary, stringByteLen, hasEmbeddedNul, Result
+
+**Rule**: PR #1022 introduced `StringHeader` with an explicit `byte_len` field, allowing Ry `str`
+to contain embedded NUL bytes. C library APIs (`realpath`, `stat`, `mkdir`, `getaddrinfo`, etc.)
+assume NUL-terminated strings and silently truncate at the first `\0`. Apply the following three
+patterns consistently when implementing or auditing runtime functions that pass Ry string handles
+to POSIX/libc:
+
+**1. Use `stringByteLen(handle)` instead of `strlen(handle)`**:
+```cpp
+// Wrong (silently truncates at \0):
+size_t n = strlen(handle);
+// Right:
+size_t n = static_cast<size_t>(stringByteLen(handle));
+```
+
+**2. Validate with `hasEmbeddedNul` before passing to NUL-sensitive C APIs**:
+```cpp
+// Defined in include/ry/runtime_string.hpp:
+inline bool hasEmbeddedNul(const char *handle) {
+    if (!handle) return false;
+    size_t n = static_cast<size_t>(stringByteLen(handle));
+    return n > 0 && memchr(handle, '\0', n) != nullptr;
+}
+
+// Usage in runtime functions:
+if (hasEmbeddedNul(p)) {
+    setLastError("path.basename: argument contains an embedded NUL byte");
+    return nullptr;  // caller wraps as Result<str, Error> via ResultPtr
+}
+```
+
+**3. Propagate `nullptr` through chained join-style helpers**:
+When a helper like `join2_impl(a, b)` returns nullptr on NUL, callers must guard and propagate:
+```cpp
+extern "C" const char *__ry_path_join3(const char *a, const char *b, const char *c) {
+    char *ab = join2_impl(a, b);
+    if (!ab) return nullptr;  // without this, join2_impl(nullptr, c) silently returns c
+    char *result = join2_impl(ab, c);
+    freeStringSlot(ab);
+    return result;
+}
+```
+Without the `if (!ab)` guard, `join2_impl(nullptr, c)` treats nullptr as empty string and returns
+a copy of `c` — silently succeeding when it should propagate the error.
+
+**How to apply**:
+- Binary-safe consumers (HTTP body, multipart file values): use `stringByteLen` for length; do NOT
+  reject NUL — these legitimately carry binary payloads.
+- Text/path consumers (URLs, host names, header names, file paths): reject NUL with `hasEmbeddedNul`
+  and return `Err` / nullptr.
+- Upgrade bare `-> str` runtime functions that pass user strings to NUL-sensitive C APIs to
+  `-> Result<str, Error>` (return nullptr + `setLastError`; set `ReturnWrapping::ResultPtr` in
+  the dispatch table).

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3048,3 +3048,77 @@ case is_dir(d):
 For setup guards ("if dir exists, remove it"), prefer unconditional `remove_all(d)` — the returned
 `Result<Unit, Error>` is discarded if unused. For `Result<bool, Error>` predicates, use
 `Ok(v): expect(v).to_be_true()` / `Ok(v): expect(v).to_be_false()` patterns.
+
+### `hasEmbeddedNul` is only safe on Ry string handles — never on raw C strings
+
+**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: nul-safety, stringheader, c-api-boundary, runtime
+
+**Rule**: `hasEmbeddedNul(handle)` reads a `StringHeader` struct immediately *before* the pointer
+to obtain `byte_len`, then calls `memchr`. This is only valid when `handle` points into a Ry
+string slot (i.e., the pointer came from `makeString` or was read from a Ry `str` handle).
+
+**It is undefined behaviour** (reads garbage memory) when applied to:
+- C string literals: `hasEmbeddedNul("POST")` — no `StringHeader` prefix
+- `std::string::c_str()` results — allocated by the STL without a `StringHeader`
+- Any other raw `const char *` that did not originate from a Ry string slot
+
+The symptom is a false positive: `hasEmbeddedNul` reads random bytes before the pointer as
+`byte_len`, and `memchr` finds a NUL in that range, incorrectly returning `true`.
+
+**How to apply**: Only call `hasEmbeddedNul` inside codegen emitters (where arguments are known
+Ry handles) or inside runtime functions whose callers pass exclusively Ry handles. If a runtime
+function is also called from C++ unit tests with `.c_str()` or with C literals, move the NUL
+check to the codegen emitter.
+
+### NUL checks belong in the codegen emitter, not the runtime, for multi-context functions
+
+**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: nul-safety, codegen, runtime, c-api-boundary
+
+**Context**: `__ry_http_client_request(method, url, headers, body)` is invoked from three contexts:
+1. User Ry code → codegen emitter → all arguments are Ry handles (StringHeader present)
+2. C++ unit tests calling the function directly with `url.c_str()` or C string literals
+3. Internal runtime functions (`__ry_http_post` calls it with the literal `"POST"`)
+
+Applying `hasEmbeddedNul` inside the runtime covers case 1 but produces false positives for
+cases 2 and 3 (reads garbage memory before the pointer).
+
+**Rule**: If a runtime function is called from Ry codegen *and* from C++ or internal C code,
+put NUL checks in the codegen emitter only. Leave the runtime function unchecked (treat it as
+an internal C API). Add a comment in the runtime explaining the split:
+
+```cpp
+// NUL checks for method and url are done in codegen (emitHttpClientCall) for
+// the user-facing Ry paths. This function is also called directly from C++
+// tests and internally with plain C strings that carry no Ry StringHeader —
+// applying hasEmbeddedNul here would read garbage before those pointers.
+```
+
+### Thread-local HTTP error buffer is shared across tests in the same process
+
+**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: nul-safety, testing, http, thread-local
+
+**Rule**: `http_last_error_buf` in `runtime_http_error.cpp` is `thread_local` and persists for
+the lifetime of the thread. If test A sets an error message (e.g. "url contains embedded NUL")
+and test B then performs an operation that fails but does *not* write to `http_last_error_buf`
+(e.g. a connection refused), test B's `e.message` will still contain test A's stale message.
+
+**How to apply**: Do not write spec tests that assert error message contents after a network
+failure that may or may not set the buffer. For NUL-safety tests, assert only that the result
+is `Err` and that `e.message` contains the expected string. Never assert the message is
+*absent* across test boundaries.
+
+### Ry expect matchers: use `to_not_contain`, not `not_to_contain`
+
+**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: testing, ry-syntax, matchers
+
+**Rule**: The correct negating form for string containment in Ry expect matchers is
+`to_not_contain("...")`, not `not_to_contain("...")`. Using `not_to_contain` compiles but calls
+a non-existent method at runtime, producing an "undefined method" error.
+
+```ry
+# ❌ Wrong — runtime error
+expect(e.message).not_to_contain("NUL")
+
+# ✅ Correct
+expect(e.message).to_not_contain("NUL")
+```

--- a/changelog.d/1054-nul-safety.md
+++ b/changelog.d/1054-nul-safety.md
@@ -1,0 +1,18 @@
+### Changed
+
+- `path.join`, `path.basename`, `path.dirname`, `path.extension` now return `Result<str, Error>` instead of `str`; callers receive a typed error if any argument contains an embedded NUL byte (#1054)
+- `filesystem.is_file`, `filesystem.is_dir`, `filesystem.is_symlink` now return `Result<bool, Error>` instead of `bool`; callers receive a typed error if the path contains an embedded NUL byte (#1054)
+- `http.listen` handler type is now `function(HttpRequest) -> Result<HttpResponse, Error>`; the listen loop synthesises a 500 response when the handler returns `Err` (#1054)
+- `http.header(req, key)`, `http.query(req, key)`, `http.cookie(req, name)`, `http.form_field(req, name)`, `http.form_file(req, name)` now return `Result<Option<…>, Error>` instead of `Option<…>`; callers receive a typed error if the key/name contains an embedded NUL byte (#1054)
+- `http.response(status, headers, body)` now returns `Result<HttpResponse, Error>` instead of `HttpResponse`; callers receive a typed error if any header key or value contains an embedded NUL byte (#1054)
+- `http.header(resp, key)` (client response accessor) now returns `Result<Option<str>, Error>` instead of `Option<str>` (#1054)
+
+### Fixed
+
+- HTTP client body truncated at first embedded NUL byte: `Content-Length` was computed with `strlen(body)`; now uses `stringByteLen(body)` for binary-safe payloads (#1054)
+- HTTP request URL silently truncated at embedded NUL: `http_get`, `http_post`, and `http_request` now reject URLs containing embedded NUL bytes with a typed `Err` (#1054)
+- HTTP `http_request` method silently truncated at embedded NUL: now rejected with a typed `Err` (#1054)
+- HTTP header build used `std::string::operator+=` on Ry handles, truncating values at the first NUL; replaced with byte-length-correct `append(data, byte_len)` (#1054)
+- DNS hostname lookup (`net.bind`, `net.connect`, `net.tls_connect`) silently truncated hosts containing embedded NUL bytes; now rejected with a typed `Err` (#1054)
+- `path.join`, `path.basename`, `path.dirname`, `path.extension`, `path.resolve` silently truncated paths at embedded NUL bytes; now rejected with a typed `Err` (#1054)
+- `filesystem` functions silently truncated paths at embedded NUL bytes; now rejected with a typed `Err` (#1054)

--- a/docs/reference/filesystem.md
+++ b/docs/reference/filesystem.md
@@ -26,9 +26,9 @@ from filesystem import chmod, symlink, read_link
 | `make_dir` | `(str) -> Result<Unit, Error>` | Creates a single directory |
 | `make_dir_all` | `(str) -> Result<Unit, Error>` | Creates a directory and all missing parents |
 | `file_size` | `(str) -> Result<int, Error>` | Returns file size in bytes |
-| `is_file` | `(str) -> bool` | Checks if path is a regular file |
-| `is_dir` | `(str) -> bool` | Checks if path is a directory |
-| `is_symlink` | `(str) -> bool` | Checks if path is a symbolic link |
+| `is_file` | `(str) -> Result<bool, Error>` | Checks if path is a regular file. Returns `Err` if path contains an embedded NUL byte. |
+| `is_dir` | `(str) -> Result<bool, Error>` | Checks if path is a directory. Returns `Err` if path contains an embedded NUL byte. |
+| `is_symlink` | `(str) -> Result<bool, Error>` | Checks if path is a symbolic link. Returns `Err` if path contains an embedded NUL byte. |
 | `chmod` | `(str, int) -> Result<Unit, Error>` | Changes file permissions (POSIX mode) |
 | `symlink` | `(str, str) -> Result<Unit, Error>` | Creates a symbolic link |
 | `read_link` | `(str) -> Result<str, Error>` | Reads the target of a symbolic link |
@@ -114,14 +114,18 @@ case glob_files("/var/log/*.log"):
 ```python
 from filesystem import is_file, is_dir, is_symlink
 
-if is_file("/etc/hosts"):
-  print("regular file")
+case is_file("/etc/hosts"):
+  Ok(true): print("regular file")
+  Ok(false): print("not a regular file")
+  Err(e): print("error: " + e.message)
 
-if is_dir("/tmp"):
-  print("directory")
+case is_dir("/tmp"):
+  Ok(true): print("directory")
+  _: ...
 
-if is_symlink("/usr/local/bin/python"):
-  print("symbolic link")
+case is_symlink("/usr/local/bin/python"):
+  Ok(true): print("symbolic link")
+  _: ...
 ```
 
 ### Symbolic Links
@@ -133,12 +137,14 @@ from filesystem import symlink, read_link, is_symlink
 symlink("/usr/local/bin/ry", "/tmp/ry_link")
 
 # Check and read symlink
-if is_symlink("/tmp/ry_link"):
-  case read_link("/tmp/ry_link"):
-    Ok(target):
-      print("points to: " + target)
-    Err(e):
-      print("error: " + e.message)
+case is_symlink("/tmp/ry_link"):
+  Ok(true):
+    case read_link("/tmp/ry_link"):
+      Ok(target):
+        print("points to: " + target)
+      Err(e):
+        print("error: " + e.message)
+  _: ...
 ```
 
 ### Permissions
@@ -155,7 +161,7 @@ chmod("/tmp/data.txt", 420)
 
 ## Notes
 
-- `is_file`, `is_dir`, and `is_symlink` return `false` on error (e.g., path does not exist)
+- `is_file`, `is_dir`, and `is_symlink` return `Ok(false)` when the path does not exist; `Err` when the path contains an embedded NUL byte
 - `is_file` and `is_dir` follow symlinks; `is_symlink` uses `lstat` to detect links
 - `list_dir` returns entry names only (not full paths)
 - `walk` returns full paths for all entries (both files and directories)

--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -24,9 +24,9 @@ from http import listen, method, path, header, body, body_bytes, query, query_al
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `listen` | `(host: str, port: int, handler: function(HttpRequest) -> HttpResponse) -> Unit` | Starts an HTTP server on the given address. Blocks in an accept loop, calling `handler` for each request. |
-| `listen` | `(host: str, port: int, handler: function(HttpRequest) -> HttpResponse, max_requests: int) -> Unit` | Starts an HTTP server that stops after processing `max_requests` requests. Enables `async function` + `block_on()` lifecycle management. |
-| `listen` | `(host: str, port: int, handler: function(HttpRequest) -> HttpResponse, max_requests: int, port_callback: function(int) -> Unit) -> Unit` | Same as above, but calls `port_callback` with the actual bound port after `bind` + `listen` succeeds. Use with port `0` for OS-assigned ephemeral ports. |
+| `listen` | `(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>) -> Result<Unit, Error>` | Starts an HTTP server on the given address. Blocks in an accept loop, calling `handler` for each request. Returns `Err` if bind fails. |
+| `listen` | `(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int) -> Result<Unit, Error>` | Starts an HTTP server that stops after processing `max_requests` requests. Enables `async function` + `block_on()` lifecycle management. |
+| `listen` | `(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int, port_callback: function(int) -> Unit) -> Result<Unit, Error>` | Same as above, but calls `port_callback` with the actual bound port after `bind` + `listen` succeeds. Use with port `0` for OS-assigned ephemeral ports. |
 
 ### Request Accessors
 
@@ -34,22 +34,22 @@ from http import listen, method, path, header, body, body_bytes, query, query_al
 |----------|-----------|-------------|
 | `method` | `(req: HttpRequest) -> str` | Returns the HTTP method (e.g., `"GET"`, `"POST"`). |
 | `path` | `(req: HttpRequest) -> str` | Returns the request path without the query string (e.g., `"/search"` for `"/search?q=hello"`). |
-| `header` | `(req: HttpRequest, key: str) -> Option<str>` | Returns the value of a request header (case-insensitive lookup). Returns `None` if not found. |
+| `header` | `(req: HttpRequest, key: str) -> Result<Option<str>, Error>` | Returns the value of a request header (case-insensitive lookup). Returns `Ok(None)` if not found. Returns `Err` if `key` contains an embedded NUL byte. |
 | `body` | `(req: HttpRequest) -> str` | Returns the request body as a string. Truncated at the first NUL byte; use `body_bytes` for binary data. |
 | `body_bytes` | `(req: HttpRequest) -> List<u8>` | Returns the request body as a byte list. Binary-safe — preserves all bytes including NUL. |
-| `query` | `(req: HttpRequest, key: str) -> Option<str>` | Returns the value of a query parameter. Returns `None` if not found. Values are automatically URL-decoded. |
+| `query` | `(req: HttpRequest, key: str) -> Result<Option<str>, Error>` | Returns the value of a query parameter. Returns `Ok(None)` if not found. Values are automatically URL-decoded. Returns `Err` if `key` contains an embedded NUL byte. |
 | `query_all` | `(req: HttpRequest) -> Map<str, str>` | Returns all query parameters as a map. Keys and values are automatically URL-decoded. |
-| `cookie` | `(req: HttpRequest, name: str) -> Option<str>` | Returns the value of a cookie by name. Returns `None` if not found. |
+| `cookie` | `(req: HttpRequest, name: str) -> Result<Option<str>, Error>` | Returns the value of a cookie by name. Returns `Ok(None)` if not found. Returns `Err` if `name` contains an embedded NUL byte. |
 | `cookies` | `(req: HttpRequest) -> Map<str, str>` | Returns all cookies as a map. |
-| `form_field` | `(req: HttpRequest, name: str) -> Option<str>` | Returns the value of a multipart form text field. Returns `None` if not found. |
-| `form_file` | `(req: HttpRequest, name: str) -> Option<Map<str, str>>` | Returns file upload info as an `Option`. `Some(map)` contains keys `"filename"`, `"content_type"`, `"data"`. Returns `None` if not found. |
+| `form_field` | `(req: HttpRequest, name: str) -> Result<Option<str>, Error>` | Returns the value of a multipart form text field. Returns `Ok(None)` if not found. Returns `Err` if `name` contains an embedded NUL byte. |
+| `form_file` | `(req: HttpRequest, name: str) -> Result<Option<Map<str, str>>, Error>` | Returns file upload info as an `Option`. `Some(map)` contains keys `"filename"`, `"content_type"`, `"data"`. Returns `Ok(None)` if not found. Returns `Err` if `name` contains an embedded NUL byte. |
 | `form_fields` | `(req: HttpRequest) -> Map<str, str>` | Returns all multipart form text fields as a map. |
 
 ### Response Builder
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `response` | `(status: int, headers: Map<str, str>, body: str) -> HttpResponse` | Creates an HTTP response with the given status code, headers, and body. |
+| `response` | `(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>` | Creates an HTTP response with the given status code, headers, and body. Returns `Err` if any header key or value contains an embedded NUL byte. The `body` is binary-safe and may contain NUL bytes. |
 
 ## Usage Example
 
@@ -58,7 +58,7 @@ from http import listen, method, path, header, body, body_bytes, query, query_al
 ```python
 from http import listen, method, path, header, body, response
 
-listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
+listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
     m = method(req)
     p = path(req)
     if p == "/hello":
@@ -76,7 +76,7 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
 from http import listen, path, response
 
 async function start_server(port: int) -> str:
-    listen("127.0.0.1", port, (req: HttpRequest) -> HttpResponse:
+    listen("127.0.0.1", port, (req: HttpRequest) -> Result<HttpResponse, Error>:
         p = path(req)
         if p == "/api/health":
             return response(200, {"Content-Type": "application/json"}, "{\"status\": \"ok\"}")
@@ -98,7 +98,7 @@ function on_port(p: int) -> Unit:
     port_holder[0] = p
 
 async function start_server() -> str:
-    listen("127.0.0.1", 0, (req: HttpRequest) -> HttpResponse:
+    listen("127.0.0.1", 0, (req: HttpRequest) -> Result<HttpResponse, Error>:
         return response(200, {"Content-Type": "text/plain"}, "Hello!")
     , 1, on_port)  # Stop after 1 request; call on_port with bound port
     return "done"
@@ -121,10 +121,10 @@ result = block_on(t)  # Server exits after 1 request; block_on completes
 ```python
 from http import listen, path, query, query_all, response
 
-listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
+listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
     p = path(req)
     if p == "/search":
-        case query(req, "q"):
+        case query(req, "q")?:
             Some(q):
                 return response(200, {"Content-Type": "text/plain"}, "Search: " + q)
             None:
@@ -138,8 +138,8 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
 ```python
 from http import listen, header, response
 
-listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
-    case header(req, "Authorization"):
+listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
+    case header(req, "Authorization")?:
         Some(token):
             return response(200, {"Content-Type": "text/plain"}, "Authenticated: " + token)
         None:
@@ -152,10 +152,10 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
 ```python
 from http import listen, form_field, form_file, response
 
-listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
-    case form_field(req, "username"):
+listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
+    case form_field(req, "username")?:
         Some(name):
-            case form_file(req, "avatar"):
+            case form_file(req, "avatar")?:
                 Some(file_info):
                     filename = file_info["filename"]
                     return response(200, {"Content-Type": "text/plain"}, "Hello " + name + ", file: " + filename)
@@ -171,8 +171,8 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
 ```python
 from http import listen, cookie, cookies, response
 
-listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
-    case cookie(req, "session_id"):
+listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
+    case cookie(req, "session_id")?:
         Some(sid):
             return response(200, {"Content-Type": "text/plain"}, "Session: " + sid)
         None:
@@ -203,8 +203,20 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> HttpResponse:
 - The `boundary` parameter is extracted from the `Content-Type` header and supports both quoted and unquoted values.
 - Parts with a `filename` in `Content-Disposition` are treated as file uploads; parts without are treated as text fields.
 - For duplicate field/file names, the first value is returned.
-- `form_file()` returns `Some(map)` with keys `"filename"`, `"content_type"`, and `"data"`, or `None` if the field is not found. If no `Content-Type` is specified for the part, it defaults to `"application/octet-stream"`.
-- For non-multipart requests, form functions return `None` (for `form_field`, `form_file`) or an empty map (for `form_fields`).
+- `form_file()` returns `Ok(Some(map))` with keys `"filename"`, `"content_type"`, and `"data"`, or `Ok(None)` if the field is not found. If no `Content-Type` is specified for the part, it defaults to `"application/octet-stream"`.
+- For non-multipart requests, form functions return `Ok(None)` (for `form_field`, `form_file`) or an empty map (for `form_fields`).
+
+## NUL Safety
+
+Functions that accept `str` arguments ultimately pass them to C APIs (HTTP headers, query string lookup) that cannot handle embedded NUL bytes. These functions return `Err` when a NUL byte is detected:
+
+- `header(req, key)` — `key` must not contain NUL
+- `query(req, key)` — `key` must not contain NUL
+- `cookie(req, name)` — `name` must not contain NUL
+- `form_field(req, name)` — `name` must not contain NUL
+- `form_file(req, name)` — `name` must not contain NUL
+- `response(status, headers, body)` — header keys and values must not contain NUL; `body` is binary-safe and **may** contain NUL
+- `http_get(url)` / `http_post(url, ...)` / `http_request(method, url, ...)` — `url` and `method` must not contain NUL; request body is binary-safe
 
 ## Supported Status Codes
 
@@ -261,9 +273,9 @@ Other status codes use `"Unknown"` as the reason phrase.
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `http_get` | `(url: str) -> Result<HttpClientResponse, Error>` | Sends an HTTP GET request to the given URL. |
-| `http_post` | `(url: str, body: str, headers: Map<str, str>) -> Result<HttpClientResponse, Error>` | Sends an HTTP POST request with body and headers. |
-| `http_request` | `(method: str, url: str, headers: Map<str, str>, body: str) -> Result<HttpClientResponse, Error>` | Sends an HTTP request with a custom method. |
+| `http_get` | `(url: str) -> Result<HttpClientResponse, Error>` | Sends an HTTP GET request to the given URL. Returns `Err` if `url` contains an embedded NUL byte, or on connection/protocol failure. |
+| `http_post` | `(url: str, body: str, headers: Map<str, str>) -> Result<HttpClientResponse, Error>` | Sends an HTTP POST request with body and headers. Returns `Err` if `url` or any header key/value contains an embedded NUL byte, or on failure. The `body` is binary-safe. |
+| `http_request` | `(method: str, url: str, headers: Map<str, str>, body: str) -> Result<HttpClientResponse, Error>` | Sends an HTTP request with a custom method. Returns `Err` if `method` or `url` contains an embedded NUL byte, or on failure. |
 
 ### Response Accessors
 
@@ -272,7 +284,7 @@ Other status codes use `"Unknown"` as the reason phrase.
 | `status` | `(resp: HttpClientResponse) -> int` | Returns the HTTP status code. |
 | `body` | `(resp: HttpClientResponse) -> str` | Returns the response body as a string. Truncated at the first NUL byte; use `body_bytes` for binary data. |
 | `body_bytes` | `(resp: HttpClientResponse) -> List<u8>` | Returns the response body as a byte list. Binary-safe — preserves all bytes including NUL. |
-| `header` | `(resp: HttpClientResponse, key: str) -> Option<str>` | Returns the value of a response header (case-insensitive). Returns `None` if not found. |
+| `header` | `(resp: HttpClientResponse, key: str) -> Result<Option<str>, Error>` | Returns the value of a response header (case-insensitive). Returns `Ok(None)` if not found. Returns `Err` if `key` contains an embedded NUL byte. |
 | `http_client_response_free` | `(resp: HttpClientResponse) -> Unit` | Frees the response and its associated memory. Call when done with the response. |
 
 ### Client Usage Example
@@ -327,7 +339,7 @@ HTTP client functions automatically follow redirect responses (3xx with `Locatio
 
 ## Error Handling
 
-- `listen()` raises a runtime error if `bind()` fails (e.g., port already in use).
+- `listen()` returns `Err` if `bind()` fails (e.g., port already in use). Previously this panicked; callers should now handle the `Result`.
 - Malformed requests or idle timeouts on a keep-alive connection cause the connection to be closed. The server then resumes accepting new connections.
-- The handler function must always return an `HttpResponse` — there is no default response.
+- The handler function must always return a `Result<HttpResponse, Error>` — when the handler returns `Err`, the server synthesizes a 500 Internal Server Error response.
 - Client functions return `Result<HttpClientResponse, Error>` — use `case` to handle success and failure.

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -22,7 +22,7 @@ from net import bind, listen, accept, connect, listener_port, shutdown, set_time
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `bind` | `(host: str, port: int) -> Result<TcpListener, Error>` | Creates a TCP server socket bound to the given address. Returns `Err` on failure. Use port `0` for dynamic allocation. |
+| `bind` | `(host: str, port: int) -> Result<TcpListener, Error>` | Creates a TCP server socket bound to the given address. Returns `Err` on failure (including if `host` contains an embedded NUL byte). Use port `0` for dynamic allocation. |
 | `listen` | `(listener: TcpListener, backlog: int) -> Result<Unit, Error>` | Starts listening for incoming connections. Returns `Err` on failure. |
 | `accept` | `(listener: TcpListener) -> Result<TcpStream, Error>` | Accepts a new connection. Waits up to 1 second for a client to connect. Returns `Err` on timeout or failure. |
 | `connect` | `(host: str, port: int) -> Result<TcpStream, Error>` | Connects to a remote TCP server. Times out after 5 seconds. Returns `Err` on timeout or failure. |

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -25,10 +25,10 @@ from net import bind, listen, accept, connect, listener_port, shutdown, set_time
 | `bind` | `(host: str, port: int) -> Result<TcpListener, Error>` | Creates a TCP server socket bound to the given address. Returns `Err` on failure (including if `host` contains an embedded NUL byte). Use port `0` for dynamic allocation. |
 | `listen` | `(listener: TcpListener, backlog: int) -> Result<Unit, Error>` | Starts listening for incoming connections. Returns `Err` on failure. |
 | `accept` | `(listener: TcpListener) -> Result<TcpStream, Error>` | Accepts a new connection. Waits up to 1 second for a client to connect. Returns `Err` on timeout or failure. |
-| `connect` | `(host: str, port: int) -> Result<TcpStream, Error>` | Connects to a remote TCP server. Times out after 5 seconds. Returns `Err` on timeout or failure. |
+| `connect` | `(host: str, port: int) -> Result<TcpStream, Error>` | Connects to a remote TCP server. Times out after 5 seconds. Returns `Err` on timeout or failure (including if `host` contains an embedded NUL byte). |
 | `listener_port` | `(listener: TcpListener) -> int` | Returns the actual port number the listener is bound to. Useful when binding to port `0` (OS-assigned port). |
 | `shutdown` | `(listener: TcpListener) -> Unit` | Signals the listener to stop accepting connections. Causes any pending `accept()` to return within at most 1 second. |
-| `tls_connect` | `(host: str, port: int) -> Result<TlsStream, Error>` | Connects to a remote server with TLS encryption. Validates the server certificate against the system CA bundle. Returns `Err` on connection or handshake failure. |
+| `tls_connect` | `(host: str, port: int) -> Result<TlsStream, Error>` | Connects to a remote server with TLS encryption. Validates the server certificate against the system CA bundle. Returns `Err` on connection or handshake failure (including if `host` contains an embedded NUL byte). |
 | `set_timeout` | `(stream: TcpStream\|TlsStream, ms: int) -> Unit` | Sets both receive and send timeout in milliseconds. |
 | `set_receive_timeout` | `(stream: TcpStream\|TlsStream, ms: int) -> Unit` | Sets the receive timeout in milliseconds. `receive()` returns `Err` if no data arrives within this time. |
 | `set_send_timeout` | `(stream: TcpStream\|TlsStream, ms: int) -> Unit` | Sets the send timeout in milliseconds. |

--- a/docs/reference/path.md
+++ b/docs/reference/path.md
@@ -12,14 +12,16 @@ from path import join, basename, dirname, extension, resolve, is_absolute
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `join` | `(str, str) -> str` | Joins two path segments |
-| `join` | `(str, str, str) -> str` | Joins three path segments |
-| `join` | `(str, str, str, str) -> str` | Joins four path segments |
-| `basename` | `(str) -> str` | Extracts the filename component |
-| `dirname` | `(str) -> str` | Extracts the directory component |
-| `extension` | `(str) -> str` | Extracts the file extension (including dot) |
+| `join` | `(str, str) -> Result<str, Error>` | Joins two path segments |
+| `join` | `(str, str, str) -> Result<str, Error>` | Joins three path segments |
+| `join` | `(str, str, str, str) -> Result<str, Error>` | Joins four path segments |
+| `basename` | `(str) -> Result<str, Error>` | Extracts the filename component |
+| `dirname` | `(str) -> Result<str, Error>` | Extracts the directory component |
+| `extension` | `(str) -> Result<str, Error>` | Extracts the file extension (including dot) |
 | `resolve` | `(str) -> Result<str, Error>` | Resolves a path to its absolute canonical form |
 | `is_absolute` | `(str) -> bool` | Returns whether a path is absolute |
+
+`join`, `basename`, `dirname`, and `extension` return `Err` when any path argument contains an embedded NUL byte. `is_absolute` is never an error — it only reads the first byte of the path.
 
 ## Examples
 
@@ -28,11 +30,14 @@ from path import join, basename, dirname, extension, resolve, is_absolute
 ```python
 from path import join
 
-p = join("/tmp", "data", "file.txt")
-print(p)  # /tmp/data/file.txt
+case join("/tmp", "data", "file.txt"):
+  Ok(p): print(p)   # /tmp/data/file.txt
+  Err(e): print(e.message)
 
 # Absolute second argument replaces the first
-print(join("/tmp", "/usr"))  # /usr
+case join("/tmp", "/usr"):
+  Ok(p): print(p)   # /usr
+  Err(e): print(e.message)
 ```
 
 ### Extracting Path Components
@@ -42,9 +47,17 @@ from path import basename, dirname, extension
 
 p = "/home/user/docs/report.pdf"
 
-print(basename(p))    # report.pdf
-print(dirname(p))     # /home/user/docs
-print(extension(p))   # .pdf
+case basename(p):
+  Ok(b): print(b)   # report.pdf
+  Err(e): print(e.message)
+
+case dirname(p):
+  Ok(d): print(d)   # /home/user/docs
+  Err(e): print(e.message)
+
+case extension(p):
+  Ok(ext): print(ext)   # .pdf
+  Err(e): print(e.message)
 ```
 
 ### Extension Edge Cases
@@ -52,10 +65,10 @@ print(extension(p))   # .pdf
 ```python
 from path import extension
 
-print(extension("archive.tar.gz"))  # .gz
-print(extension(".gitignore"))      # (empty string — hidden file with no extension)
-print(extension(".config.json"))    # .json
-print(extension("Makefile"))        # (empty string)
+print(extension("archive.tar.gz")?)   # .gz
+print(extension(".gitignore")?)       # (empty string — hidden file with no extension)
+print(extension(".config.json")?)     # .json
+print(extension("Makefile")?)         # (empty string)
 ```
 
 ### Checking Absolute Paths

--- a/include/ry/runtime_http_error.hpp
+++ b/include/ry/runtime_http_error.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <cstdarg>
+
+
+namespace ry {
+
+// Cross-TU shared error buffer for the http native library.
+// runtime_http.cpp, runtime_http_client.cpp, and runtime_http_multipart.cpp
+// all include this header and call setHttpLastError; only runtime_http_error.cpp
+// defines the buffer and the extern "C" accessor.
+
+void setHttpLastError(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+
+} // namespace ry

--- a/include/ry/runtime_string.hpp
+++ b/include/ry/runtime_string.hpp
@@ -95,6 +95,15 @@ inline char *makeStringUninit(size_t byte_len) {
     return data;
 }
 
+// Return true if `handle` contains an embedded NUL byte (i.e. a NUL before the
+// terminal NUL written by makeString).  Use this before passing a Ry str to any
+// C API that treats the first NUL as the end of the string.
+inline bool hasEmbeddedNul(const char *handle) {
+    if (!handle) return false;
+    size_t n = static_cast<size_t>(stringByteLen(handle));
+    return n > 0 && memchr(handle, '\0', n) != nullptr;
+}
+
 // Free a StringHeader-managed string given its handle.
 // Use this instead of plain free() whenever the pointer came from
 // makeString/makeStringUninit (not from a literal global).

--- a/share/std/filesystem/filesystem.ry
+++ b/share/std/filesystem/filesystem.ry
@@ -43,15 +43,15 @@ function file_size(path: str) -> Result<int, Error>
 
 # Check whether path is a regular file
 @native("filesystem")
-function is_file(path: str) -> bool
+function is_file(path: str) -> Result<bool, Error>
 
 # Check whether path is a directory
 @native("filesystem")
-function is_dir(path: str) -> bool
+function is_dir(path: str) -> Result<bool, Error>
 
 # Check whether path is a symbolic link
 @native("filesystem")
-function is_symlink(path: str) -> bool
+function is_symlink(path: str) -> Result<bool, Error>
 
 # Change file permissions (POSIX mode, e.g. 0o755)
 @native("filesystem")

--- a/share/std/http/http.ry
+++ b/share/std/http/http.ry
@@ -1,12 +1,12 @@
 # HTTP server operations
 @native("http")
-function listen(host: str, port: int, handler: function(HttpRequest) -> HttpResponse) -> Unit
+function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>) -> Result<Unit, Error>
 
 @native("http")
-function listen(host: str, port: int, handler: function(HttpRequest) -> HttpResponse, max_requests: int) -> Unit
+function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int) -> Result<Unit, Error>
 
 @native("http")
-function listen(host: str, port: int, handler: function(HttpRequest) -> HttpResponse, max_requests: int, port_callback: function(int) -> Unit) -> Unit
+function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int, port_callback: function(int) -> Unit) -> Result<Unit, Error>
 
 @native("http")
 function method(req: HttpRequest) -> str
@@ -15,7 +15,7 @@ function method(req: HttpRequest) -> str
 function path(req: HttpRequest) -> str
 
 @native("http")
-function header(req: HttpRequest, key: str) -> Option<str>
+function header(req: HttpRequest, key: str) -> Result<Option<str>, Error>
 
 @native("http")
 function body(req: HttpRequest) -> str
@@ -24,28 +24,28 @@ function body(req: HttpRequest) -> str
 function body_bytes(req: HttpRequest) -> List<u8>
 
 @native("http")
-function query(req: HttpRequest, key: str) -> Option<str>
+function query(req: HttpRequest, key: str) -> Result<Option<str>, Error>
 
 @native("http")
 function query_all(req: HttpRequest) -> Map<str, str>
 
 @native("http")
-function cookie(req: HttpRequest, name: str) -> Option<str>
+function cookie(req: HttpRequest, name: str) -> Result<Option<str>, Error>
 
 @native("http")
 function cookies(req: HttpRequest) -> Map<str, str>
 
 @native("http")
-function form_field(req: HttpRequest, name: str) -> Option<str>
+function form_field(req: HttpRequest, name: str) -> Result<Option<str>, Error>
 
 @native("http")
-function form_file(req: HttpRequest, name: str) -> Option<Map<str, str>>
+function form_file(req: HttpRequest, name: str) -> Result<Option<Map<str, str>>, Error>
 
 @native("http")
 function form_fields(req: HttpRequest) -> Map<str, str>
 
 @native("http")
-function response(status: int, headers: Map<str, str>, body: str) -> HttpResponse
+function response(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>
 
 # HTTP client operations
 @native("http")
@@ -67,7 +67,7 @@ function body(response: HttpClientResponse) -> str
 function body_bytes(response: HttpClientResponse) -> List<u8>
 
 @native("http")
-function header(response: HttpClientResponse, key: str) -> Option<str>
+function header(response: HttpClientResponse, key: str) -> Result<Option<str>, Error>
 
 @native("http")
 function http_client_response_free(response: HttpClientResponse) -> Unit

--- a/share/std/path/path.ry
+++ b/share/std/path/path.ry
@@ -1,22 +1,22 @@
 # File path operations
 
 @native("path")
-function join(first: str, second: str) -> str
+function join(first: str, second: str) -> Result<str, Error>
 
 @native("path")
-function join(first: str, second: str, third: str) -> str
+function join(first: str, second: str, third: str) -> Result<str, Error>
 
 @native("path")
-function join(first: str, second: str, third: str, fourth: str) -> str
+function join(first: str, second: str, third: str, fourth: str) -> Result<str, Error>
 
 @native("path")
-function basename(path: str) -> str
+function basename(path: str) -> Result<str, Error>
 
 @native("path")
-function dirname(path: str) -> str
+function dirname(path: str) -> Result<str, Error>
 
 @native("path")
-function extension(path: str) -> str
+function extension(path: str) -> Result<str, Error>
 
 @native("path")
 function resolve(path: str) -> Result<str, Error>

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -723,12 +723,12 @@ void CodeGen::emitPrint(const std::vector<ExprPtr> &args, const std::vector<Name
 // ===== Path =====
 
 static const CodeGen::NativeDispatchEntry path_table[] = {
-    {"join",        nullptr, CodeGen::ReturnWrapping::Direct,      -1, nullptr},
-    {"basename",    nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr},
-    {"dirname",     nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr},
-    {"extension",   nullptr, CodeGen::ReturnWrapping::Direct,        1, nullptr},
-    {"resolve",     nullptr, CodeGen::ReturnWrapping::ResultPtr,     1, nullptr},
-    {"is_absolute", nullptr, CodeGen::ReturnWrapping::BoolFromI64,   1, nullptr},
+    {"join",        nullptr, CodeGen::ReturnWrapping::ResultPtr,   -1, nullptr},
+    {"basename",    nullptr, CodeGen::ReturnWrapping::ResultPtr,    1, nullptr},
+    {"dirname",     nullptr, CodeGen::ReturnWrapping::ResultPtr,    1, nullptr},
+    {"extension",   nullptr, CodeGen::ReturnWrapping::ResultPtr,    1, nullptr},
+    {"resolve",     nullptr, CodeGen::ReturnWrapping::ResultPtr,    1, nullptr},
+    {"is_absolute", nullptr, CodeGen::ReturnWrapping::BoolFromI64,  1, nullptr},
 };
 
 RY_REGISTER_STDLIB_PACKAGE(path, "share/std/path/path.ry", dispatchPath)

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -179,7 +179,9 @@ static llvm::Value *emitNetBind(CodeGen &cg, const CallExpr &e) {
     llvm::Value *port = cg.emitExpr(*e.args[1]);
     auto fn = cg.mod_->getOrInsertFunction("__ry_bind", cg.fnTy_ptr_i64_to_ptr_);
     llvm::Value *result = cg.builder_.CreateCall(fn, {host, port}, "bind_result");
-    return cg.emitPtrToResult(result, "bind", "bind failed", rk_tcp_listener);
+    llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_net_get_last_error");
+    cg.addResourceKind(res, rk_tcp_listener);
+    return res;
 }
 
 static llvm::Value *emitNetTcpListen(CodeGen &cg, const CallExpr &e) {
@@ -236,9 +238,12 @@ static llvm::Value *emitNetConnect(CodeGen &cg, const CallExpr &e) {
         isTls ? "__ry_tls_connect" : "__ry_connect", cg.fnTy_ptr_i64_to_ptr_);
     cg.used_native_libraries_.insert(isTls ? "http" : "net");
     llvm::Value *result = cg.builder_.CreateCall(fn, {host, port}, e.callee + "_result");
-    if (isTls)
+    if (isTls) {
         return cg.emitPtrToResult(result, "tls_connect", "TLS connection failed", rk_tls_stream);
-    return cg.emitPtrToResult(result, "connect", "connection failed", rk_tcp_stream);
+    }
+    llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_net_get_last_error");
+    cg.addResourceKind(res, rk_tcp_stream);
+    return res;
 }
 
 static llvm::Value *emitNetTimeout(CodeGen &cg, const CallExpr &e) {

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -1,6 +1,5 @@
 #include "ry/codegen.hpp"
 #include "ry/stdlib_registry.hpp"
-#include "ry/diagnostic.hpp"
 
 
 namespace ry {
@@ -287,6 +286,14 @@ static llvm::Value *dispatchNet(CodeGen &cg, const CallExpr &e) {
 
 // ===== Http custom emitters =====
 
+// Emit a NUL check on a Ry str value. Returns an i1: true if NUL found (= Err path).
+static llvm::Value *emitHttpNulCheck(CodeGen &cg, llvm::Value *strVal, const std::string &hint) {
+    auto nulFnTy = llvm::FunctionType::get(cg.i64Ty_, {cg.ptrTy_}, false);
+    auto nulFn = cg.mod_->getOrInsertFunction("__ry_http_str_has_nul", nulFnTy);
+    llvm::Value *hasNul = cg.builder_.CreateCall(nulFn, {strVal}, hint + "_has_nul");
+    return cg.builder_.CreateICmpNE(hasNul, llvm::ConstantInt::get(cg.i64Ty_, 0), hint + "_is_nul");
+}
+
 static llvm::Value *emitHttpResponse(CodeGen &cg, const CallExpr &e) {
     cg.requireArgs(e, 3);
     llvm::Value *status = cg.emitExpr(*e.args[0]);
@@ -300,8 +307,9 @@ static llvm::Value *emitHttpResponse(CodeGen &cg, const CallExpr &e) {
         cg.codegenError("response() body must be str");
     auto fn = cg.getRuntimeFn("__ry_http_response_create", cg.ptrTy_, {cg.i64Ty_, cg.ptrTy_, cg.ptrTy_});
     llvm::Value *result = cg.builder_.CreateCall(fn, {status, headers, body}, "http_resp");
-    cg.addResourceKind(result, rk_http_response);
-    return result;
+    llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_http_get_last_error");
+    cg.addResourceKind(res, rk_http_response);
+    return res;
 }
 
 static llvm::Value *emitHttpRequestStr(CodeGen &cg, const CallExpr &e) {
@@ -349,15 +357,37 @@ static llvm::Value *emitHttpHeader(CodeGen &cg, const CallExpr &e) {
     llvm::Value *key = cg.emitExpr(*e.args[1]);
     if (key->getType() != cg.ptrTy_)
         cg.codegenError("header() key must be str");
+
+    llvm::Value *isNul = emitHttpNulCheck(cg, key, "hdr_key");
+    llvm::StructType *optTy = cg.getOptionType(cg.ptrTy_);
+    llvm::StructType *resTy = cg.getResultType(optTy, cg.errorTy_);
+    static int hdrNulCtr = 0;
+
     if (cg.isHttpRequest(arg)) {
-        auto fn = cg.mod_->getOrInsertFunction("__ry_http_header", cg.fnTy_ptr_ptr_to_ptr_);
-        llvm::Value *result = cg.builder_.CreateCall(fn, {arg, key}, "http_hdr");
-        return cg.wrapPtrAsOption(result, "http_hdr");
+        return cg.emitResultBranch(isNul, resTy,
+            [&]() {
+                auto fn = cg.mod_->getOrInsertFunction("__ry_http_header", cg.fnTy_ptr_ptr_to_ptr_);
+                llvm::Value *r = cg.builder_.CreateCall(fn, {arg, key}, "http_hdr");
+                return cg.buildOkValue(cg.wrapPtrAsOption(r, "http_hdr"), resTy);
+            },
+            [&]() {
+                return cg.buildErrValue(
+                    cg.buildStaticError("header: key contains embedded NUL",
+                                        ".http_hdr_nul_" + std::to_string(hdrNulCtr++)), resTy);
+            });
     }
     if (cg.isHttpClientResponse(arg)) {
-        auto fn = cg.mod_->getOrInsertFunction("__ry_http_client_header", cg.fnTy_ptr_ptr_to_ptr_);
-        llvm::Value *result = cg.builder_.CreateCall(fn, {arg, key}, "http_client_hdr");
-        return cg.wrapPtrAsOption(result, "http_client_hdr");
+        return cg.emitResultBranch(isNul, resTy,
+            [&]() {
+                auto fn = cg.mod_->getOrInsertFunction("__ry_http_client_header", cg.fnTy_ptr_ptr_to_ptr_);
+                llvm::Value *r = cg.builder_.CreateCall(fn, {arg, key}, "http_client_hdr");
+                return cg.buildOkValue(cg.wrapPtrAsOption(r, "http_client_hdr"), resTy);
+            },
+            [&]() {
+                return cg.buildErrValue(
+                    cg.buildStaticError("header: key contains embedded NUL",
+                                        ".http_hdr_nul_" + std::to_string(hdrNulCtr++)), resTy);
+            });
     }
     cg.codegenError("header() requires HttpRequest or HttpClientResponse argument");
 }
@@ -372,11 +402,25 @@ static llvm::Value *emitHttpOptionField(CodeGen &cg, const CallExpr &e) {
         std::string param = (e.callee == "cookie") ? "name" : "key";
         cg.codegenError(e.callee + "() " + param + " must be str");
     }
-    auto fn = cg.mod_->getOrInsertFunction("__ry_http_" + e.callee, cg.fnTy_ptr_ptr_to_ptr_);
     std::string hint = (e.callee == "query") ? "http_qry"
                      : (e.callee == "cookie") ? "http_ck" : "http_ff";
-    llvm::Value *result = cg.builder_.CreateCall(fn, {req, key}, hint);
-    return cg.wrapPtrAsOption(result, hint);
+
+    llvm::Value *isNul = emitHttpNulCheck(cg, key, hint);
+    llvm::StructType *optTy = cg.getOptionType(cg.ptrTy_);
+    llvm::StructType *resTy = cg.getResultType(optTy, cg.errorTy_);
+    static int optNulCtr = 0;
+    std::string errMsg = e.callee + ": key contains embedded NUL";
+    std::string errName = ".http_opt_nul_" + std::to_string(optNulCtr++);
+
+    auto fn = cg.mod_->getOrInsertFunction("__ry_http_" + e.callee, cg.fnTy_ptr_ptr_to_ptr_);
+    return cg.emitResultBranch(isNul, resTy,
+        [&]() {
+            llvm::Value *r = cg.builder_.CreateCall(fn, {req, key}, hint);
+            return cg.buildOkValue(cg.wrapPtrAsOption(r, hint), resTy);
+        },
+        [&]() {
+            return cg.buildErrValue(cg.buildStaticError(errMsg, errName), resTy);
+        });
 }
 
 static llvm::Value *emitHttpMapAll(CodeGen &cg, const CallExpr &e) {
@@ -399,12 +443,29 @@ static llvm::Value *emitHttpFormFile(CodeGen &cg, const CallExpr &e) {
         cg.codegenError("form_file() requires HttpRequest argument");
     if (key->getType() != cg.ptrTy_)
         cg.codegenError("form_file() name must be str");
+
+    llvm::Value *isNul = emitHttpNulCheck(cg, key, "ff_key");
+    llvm::StructType *optTy = cg.getOptionType(cg.ptrTy_);
+    llvm::StructType *resTy = cg.getResultType(optTy, cg.errorTy_);
+    static int ffNulCtr = 0;
+
     auto fn = cg.mod_->getOrInsertFunction("__ry_http_form_file", cg.fnTy_ptr_ptr_to_ptr_);
-    llvm::Value *result = cg.builder_.CreateCall(fn, {req, key}, "http_ffile");
-    llvm::Value *optResult = cg.wrapPtrAsOption(result, "http_ffile");
-    cg.setTypeMeta(CodeGen::TypeMeta::MapKey, optResult, cg.ptrTy_);
-    cg.setTypeMeta(CodeGen::TypeMeta::MapValue, optResult, cg.ptrTy_);
-    return optResult;
+    llvm::Value *res = cg.emitResultBranch(isNul, resTy,
+        [&]() {
+            llvm::Value *r = cg.builder_.CreateCall(fn, {req, key}, "http_ffile");
+            cg.setTypeMeta(CodeGen::TypeMeta::MapKey, r, cg.ptrTy_);
+            cg.setTypeMeta(CodeGen::TypeMeta::MapValue, r, cg.ptrTy_);
+            llvm::Value *opt = cg.wrapPtrAsOption(r, "http_ffile");
+            return cg.buildOkValue(opt, resTy);
+        },
+        [&]() {
+            return cg.buildErrValue(
+                cg.buildStaticError("form_file: name contains embedded NUL",
+                                    ".http_ff_nul_" + std::to_string(ffNulCtr++)), resTy);
+        });
+    cg.setTypeMeta(CodeGen::TypeMeta::MapKey, res, cg.ptrTy_);
+    cg.setTypeMeta(CodeGen::TypeMeta::MapValue, res, cg.ptrTy_);
+    return res;
 }
 
 static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
@@ -420,14 +481,14 @@ static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
 
     auto *fnInfo = cg.lookupFnTypeInfo(handler);
     if (!fnInfo)
-        cg.codegenError("listen() handler must be a function fn(HttpRequest) -> HttpResponse");
+        cg.codegenError("listen() handler must be fn(HttpRequest) -> Result<HttpResponse, Error>");
     CodeGen::FnTypeInfo handlerInfo = *fnInfo;
 
-    if (handlerInfo.paramTypes.size() != 1 ||
-        handlerInfo.returnType != cg.ptrTy_ ||
-        handlerInfo.paramTypes[0] != cg.ptrTy_) {
-        cg.codegenError("listen() handler must be a function fn(HttpRequest) -> HttpResponse");
-    }
+    if (handlerInfo.paramTypes.size() != 1 || handlerInfo.paramTypes[0] != cg.ptrTy_)
+        cg.codegenError("listen() handler must be fn(HttpRequest) -> Result<HttpResponse, Error>");
+    bool handlerReturnsResult = cg.isResultType(handlerInfo.returnType);
+    if (!handlerReturnsResult && handlerInfo.returnType != cg.ptrTy_)
+        cg.codegenError("listen() handler must be fn(HttpRequest) -> Result<HttpResponse, Error>");
 
     llvm::Value *maxReqs = llvm::ConstantInt::get(cg.i64Ty_, 0);
     if (e.args.size() >= 4) {
@@ -447,6 +508,12 @@ static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
             cg.codegenError("listen() port_callback must be fn(int) -> Unit");
     }
 
+    // Return type: Result<Unit, Error>
+    llvm::StructType *unitResTy = cg.getResultType(cg.i8Ty_, cg.errorTy_);
+    // Alloca to hold the final result (avoids complex PHI over multiple error paths)
+    llvm::Value *resultAlloca = cg.builder_.CreateAlloca(unitResTy, nullptr, "listen_result");
+    llvm::BasicBlock *returnBB = llvm::BasicBlock::Create(*cg.ctx_, "http.listen_return", cg.fn_);
+
     // 1. bind(host, port)
     auto bindFn = cg.mod_->getOrInsertFunction("__ry_bind", cg.fnTy_ptr_i64_to_ptr_);
     llvm::Value *listener = cg.builder_.CreateCall(bindFn, {host, port}, "http_listener");
@@ -458,23 +525,34 @@ static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
     cg.builder_.CreateCondBr(isNull, bindFailBB, bindOkBB);
 
     cg.builder_.SetInsertPoint(bindFailBB);
-    static int httpErrCounter = 0;
-    cg.emitRuntimeError("runtime error: listen() bind failed\n",
-                      ".http_err_" + std::to_string(httpErrCounter++));
+    {
+        llvm::Value *errVal = cg.buildErrValue(
+            cg.buildErrorFromRuntime("__ry_net_get_last_error"), unitResTy);
+        cg.builder_.CreateStore(errVal, resultAlloca);
+        cg.builder_.CreateBr(returnBB);
+    }
 
     // 2. listen(listener, 128)
     cg.builder_.SetInsertPoint(bindOkBB);
     auto listenFn = cg.getRuntimeFn("__ry_listen", cg.i64Ty_, {cg.ptrTy_, cg.i64Ty_});
-    llvm::Value *listenStatus = cg.builder_.CreateCall(listenFn, {listener, llvm::ConstantInt::get(cg.i64Ty_, 128)}, "listen_status");
+    llvm::Value *listenStatus = cg.builder_.CreateCall(
+        listenFn, {listener, llvm::ConstantInt::get(cg.i64Ty_, 128)}, "listen_status");
     llvm::Value *listenFailed = cg.builder_.CreateICmpNE(listenStatus,
         llvm::ConstantInt::get(cg.i64Ty_, 0), "listen_failed");
     llvm::BasicBlock *listenFailBB = llvm::BasicBlock::Create(*cg.ctx_, "http.listen_fail", cg.fn_);
     llvm::BasicBlock *listenOkBB = llvm::BasicBlock::Create(*cg.ctx_, "http.listen_ok", cg.fn_);
     cg.builder_.CreateCondBr(listenFailed, listenFailBB, listenOkBB);
+
     cg.builder_.SetInsertPoint(listenFailBB);
-    static int httpListenErrCounter = 0;
-    cg.emitRuntimeError("runtime error: listen() listen failed\n",
-                      ".http_listen_err_" + std::to_string(httpListenErrCounter++));
+    {
+        static int listenErrCtr = 0;
+        llvm::Value *errVal = cg.buildErrValue(
+            cg.buildStaticError("listen failed", ".http_listen_err_" + std::to_string(listenErrCtr++)),
+            unitResTy);
+        cg.builder_.CreateStore(errVal, resultAlloca);
+        cg.builder_.CreateBr(returnBB);
+    }
+
     cg.builder_.SetInsertPoint(listenOkBB);
 
     if (portCallback) {
@@ -533,10 +611,41 @@ static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
     auto keepAliveFn = cg.getRuntimeFn("__ry_http_should_keep_alive", cg.i64Ty_, {cg.ptrTy_});
     llvm::Value *keepAlive = cg.builder_.CreateCall(keepAliveFn, {req}, "keep_alive");
 
-    llvm::Value *resp = cg.emitLambdaCall(handler, handlerInfo, {req}, "http_resp_val");
+    llvm::Value *handlerResult = cg.emitLambdaCall(handler, handlerInfo, {req}, "http_resp_val");
+    llvm::Value *resp;
+    if (handlerReturnsResult) {
+        // Extract Ok ptr or synthesize 500 response on Err
+        llvm::Value *disc = cg.builder_.CreateExtractValue(handlerResult, {0}, "resp_disc");
+        llvm::Value *isOk = cg.builder_.CreateICmpEQ(
+            disc, llvm::ConstantInt::get(cg.i1Ty_, 1), "resp_is_ok");
+        llvm::BasicBlock *respOkBB = llvm::BasicBlock::Create(*cg.ctx_, "http.resp_ok", cg.fn_);
+        llvm::BasicBlock *respErrBB = llvm::BasicBlock::Create(*cg.ctx_, "http.resp_err", cg.fn_);
+        llvm::BasicBlock *respMergeBB = llvm::BasicBlock::Create(*cg.ctx_, "http.resp_merge", cg.fn_);
+        cg.builder_.CreateCondBr(isOk, respOkBB, respErrBB);
+
+        cg.builder_.SetInsertPoint(respOkBB);
+        llvm::Value *okResp = cg.builder_.CreateExtractValue(handlerResult, {1}, "resp_ok_ptr");
+        cg.builder_.CreateBr(respMergeBB);
+
+        cg.builder_.SetInsertPoint(respErrBB);
+        auto defRespFnTy = llvm::FunctionType::get(cg.ptrTy_, {cg.i64Ty_}, false);
+        auto defRespFn = cg.mod_->getOrInsertFunction("__ry_http_default_error_response", defRespFnTy);
+        llvm::Value *errResp = cg.builder_.CreateCall(
+            defRespFn, {llvm::ConstantInt::get(cg.i64Ty_, 500)}, "default_500");
+        cg.builder_.CreateBr(respMergeBB);
+
+        cg.builder_.SetInsertPoint(respMergeBB);
+        llvm::PHINode *phi = cg.builder_.CreatePHI(cg.ptrTy_, 2, "final_resp");
+        phi->addIncoming(okResp, respOkBB);
+        phi->addIncoming(errResp, respErrBB);
+        resp = phi;
+    } else {
+        resp = handlerResult;
+    }
     cg.addResourceKind(resp, rk_http_response);
 
-    auto sendRespFn = cg.getRuntimeFn("__ry_http_send_response", llvm::Type::getVoidTy(*cg.ctx_), {cg.ptrTy_, cg.ptrTy_, cg.i64Ty_});
+    auto sendRespFn = cg.getRuntimeFn("__ry_http_send_response",
+        llvm::Type::getVoidTy(*cg.ctx_), {cg.ptrTy_, cg.ptrTy_, cg.i64Ty_});
     cg.builder_.CreateCall(sendRespFn, {conn, resp, keepAlive});
 
     cg.builder_.CreateCall(freeReqFn, {req});
@@ -570,9 +679,17 @@ static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
     cg.builder_.CreateCall(closeFn, {conn});
     cg.builder_.CreateBr(loopBB);
 
+    // Loop completed normally
     cg.builder_.SetInsertPoint(loopEndBB);
+    {
+        llvm::Value *okVal = cg.buildOkValue(llvm::ConstantInt::get(cg.i8Ty_, 0), unitResTy);
+        cg.builder_.CreateStore(okVal, resultAlloca);
+        cg.builder_.CreateBr(returnBB);
+    }
 
-    return llvm::ConstantInt::get(cg.i64Ty_, 0);
+    // Final return block
+    cg.builder_.SetInsertPoint(returnBB);
+    return cg.builder_.CreateLoad(unitResTy, resultAlloca, "listen_final");
 }
 
 static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
@@ -581,9 +698,24 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
         llvm::Value *url = cg.emitExpr(*e.args[0]);
         if (url->getType() != cg.ptrTy_)
             cg.codegenError("http_get() url must be str");
-        auto fn = cg.mod_->getOrInsertFunction("__ry_http_get", cg.fnTy_ptr_to_ptr_);
-        llvm::Value *result = cg.builder_.CreateCall(fn, {url}, "http_get_result");
-        return cg.emitPtrToResult(result, "http_get", "HTTP request failed", rk_http_client_response);
+        {
+            llvm::Value *urlNul = emitHttpNulCheck(cg, url, "get_url");
+            llvm::StructType *getResTy = cg.getResultType(cg.ptrTy_, cg.errorTy_);
+            static int getUrlNulCtr = 0;
+            return cg.emitResultBranch(urlNul, getResTy,
+                [&]() {
+                    auto fn = cg.mod_->getOrInsertFunction("__ry_http_get", cg.fnTy_ptr_to_ptr_);
+                    llvm::Value *result = cg.builder_.CreateCall(fn, {url}, "http_get_result");
+                    llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_http_get_last_error");
+                    cg.addResourceKind(res, rk_http_client_response);
+                    return res;
+                },
+                [&]() {
+                    return cg.buildErrValue(
+                        cg.buildStaticError("http_get: url contains embedded NUL",
+                            ".http_get_url_nul_" + std::to_string(getUrlNulCtr++)), getResTy);
+                });
+        }
     }
     if (e.callee == "http_post") {
         cg.requireArgs(e, 3);
@@ -596,9 +728,24 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
             cg.codegenError("http_post() body must be str");
         if (headers->getType() != cg.ptrTy_)
             cg.codegenError("http_post() headers must be Map<str, str>");
-        auto fn = cg.mod_->getOrInsertFunction("__ry_http_post", cg.fnTy_ptr_ptr_ptr_to_ptr_);
-        llvm::Value *result = cg.builder_.CreateCall(fn, {url, body, headers}, "http_post_result");
-        return cg.emitPtrToResult(result, "http_post", "HTTP request failed", rk_http_client_response);
+        {
+            llvm::Value *urlNul = emitHttpNulCheck(cg, url, "post_url");
+            llvm::StructType *postResTy = cg.getResultType(cg.ptrTy_, cg.errorTy_);
+            static int postUrlNulCtr = 0;
+            return cg.emitResultBranch(urlNul, postResTy,
+                [&]() {
+                    auto fn = cg.mod_->getOrInsertFunction("__ry_http_post", cg.fnTy_ptr_ptr_ptr_to_ptr_);
+                    llvm::Value *result = cg.builder_.CreateCall(fn, {url, body, headers}, "http_post_result");
+                    llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_http_get_last_error");
+                    cg.addResourceKind(res, rk_http_client_response);
+                    return res;
+                },
+                [&]() {
+                    return cg.buildErrValue(
+                        cg.buildStaticError("http_post: url contains embedded NUL",
+                            ".http_post_url_nul_" + std::to_string(postUrlNulCtr++)), postResTy);
+                });
+        }
     }
     // http_request
     if (e.callee != "http_request") return nullptr;
@@ -615,9 +762,34 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
         cg.codegenError("http_request() headers must be Map<str, str>");
     if (body->getType() != cg.ptrTy_)
         cg.codegenError("http_request() body must be str");
-    auto fn = cg.getRuntimeFn("__ry_http_client_request", cg.ptrTy_, {cg.ptrTy_, cg.ptrTy_, cg.ptrTy_, cg.ptrTy_});
-    llvm::Value *result = cg.builder_.CreateCall(fn, {method, url, headers, body}, "http_request_result");
-    return cg.emitPtrToResult(result, "http_request", "HTTP request failed", rk_http_client_response);
+    // NUL check for method (user-supplied Ry str); __ry_http_post/__ry_http_get
+    // pass C literals so the check lives here, not in the runtime.
+    llvm::Value *methodNul = emitHttpNulCheck(cg, method, "req_method");
+    llvm::StructType *reqResTy = cg.getResultType(cg.ptrTy_, cg.errorTy_);
+    static int reqMethodNulCtr = 0;
+    static int reqUrlNulCtr = 0;
+    return cg.emitResultBranch(methodNul, reqResTy,
+        [&]() {
+            llvm::Value *urlNul = emitHttpNulCheck(cg, url, "req_url");
+            return cg.emitResultBranch(urlNul, reqResTy,
+                [&]() {
+                    auto fn = cg.getRuntimeFn("__ry_http_client_request", cg.ptrTy_, {cg.ptrTy_, cg.ptrTy_, cg.ptrTy_, cg.ptrTy_});
+                    llvm::Value *result = cg.builder_.CreateCall(fn, {method, url, headers, body}, "http_request_result");
+                    llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_http_get_last_error");
+                    cg.addResourceKind(res, rk_http_client_response);
+                    return res;
+                },
+                [&]() {
+                    return cg.buildErrValue(
+                        cg.buildStaticError("http_request: url contains embedded NUL",
+                            ".http_req_url_nul_" + std::to_string(reqUrlNulCtr++)), reqResTy);
+                });
+        },
+        [&]() {
+            return cg.buildErrValue(
+                cg.buildStaticError("http_request: method contains embedded NUL",
+                    ".http_req_method_nul_" + std::to_string(reqMethodNulCtr++)), reqResTy);
+        });
 }
 
 static llvm::Value *emitHttpStatus(CodeGen &cg, const CallExpr &e) {

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -109,10 +109,20 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
             ? std::string(entry->rtNameOverride)
             : deriveRuntimeFnName(package, rtSuffix))
             + std::to_string(n);
-        auto *fnTy = llvm::FunctionType::get(
-            resolveType(matchedSig->returnTypeName), argTypes, false);
+
+        // For ResultPtr, the C runtime returns a raw pointer; wrap after call.
+        llvm::Type *cRetTyVariadic = (entry->wrapping == ReturnWrapping::ResultPtr)
+            ? ptrTy_
+            : resolveType(matchedSig->returnTypeName);
+        auto *fnTy = llvm::FunctionType::get(cRetTyVariadic, argTypes, false);
         auto fn = mod_->getOrInsertFunction(rtName, fnTy);
-        return builder_.CreateCall(fn, args, entry->fnName);
+        llvm::Value *callResult = builder_.CreateCall(fn, args, entry->fnName);
+
+        if (entry->wrapping == ReturnWrapping::ResultPtr) {
+            std::string errFn = getErrFnName();
+            return wrapPtrAsResult(callResult, errFn.c_str());
+        }
+        return callResult;
     }
 
     // --- Normal path ---

--- a/src/runtime_filesystem.cpp
+++ b/src/runtime_filesystem.cpp
@@ -441,7 +441,7 @@ const char *__ry_filesystem_read_link(const char *path) {
         return nullptr;
     }
     buf[len] = '\0';
-    return checked_strdup(buf);
+    return makeString(buf, static_cast<size_t>(len));
 }
 
 } // extern "C"

--- a/src/runtime_filesystem.cpp
+++ b/src/runtime_filesystem.cpp
@@ -1,6 +1,7 @@
 #include "ry/runtime_alloc.hpp"
 #include "ry/runtime_list.hpp"
 #include "ry/runtime_error.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <cerrno>
 #include <climits>
@@ -95,6 +96,10 @@ static int removeCallback(const char *fpath, const struct stat * /*sb*/,
 extern "C" {
 
 void *__ry_filesystem_list_dir(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("list_dir: argument contains an embedded NUL byte");
+        return nullptr;
+    }
     DIR *dp = opendir(path);
     if (!dp) {
         setLastError("list_dir: cannot open directory '%s': %s", path, strerror(errno));
@@ -114,6 +119,10 @@ void *__ry_filesystem_list_dir(const char *path) {
 }
 
 void *__ry_filesystem_walk(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("walk: argument contains an embedded NUL byte");
+        return nullptr;
+    }
     struct stat st;
     if (lstat(path, &st) != 0) {
         setLastError("walk: cannot access '%s': %s", path, strerror(errno));
@@ -134,6 +143,10 @@ void *__ry_filesystem_walk(const char *path) {
 }
 
 void *__ry_filesystem_glob_files(const char *pattern) {
+    if (hasEmbeddedNul(pattern)) {
+        setLastError("glob_files: argument contains an embedded NUL byte");
+        return nullptr;
+    }
     glob_t gl;
     int ret = glob(pattern, GLOB_NOSORT | GLOB_TILDE, nullptr, &gl);
     if (ret == GLOB_NOMATCH) {
@@ -159,6 +172,14 @@ void *__ry_filesystem_glob_files(const char *pattern) {
 }
 
 int64_t __ry_filesystem_copy(const char *src, const char *dst) {
+    if (hasEmbeddedNul(src)) {
+        setLastError("copy: argument contains an embedded NUL byte");
+        return 1;
+    }
+    if (hasEmbeddedNul(dst)) {
+        setLastError("copy: argument contains an embedded NUL byte");
+        return 1;
+    }
 #ifdef __APPLE__
     if (copyfile(src, dst, nullptr, COPYFILE_ALL) != 0) {
         setLastError("copy: failed to copy '%s' to '%s': %s", src, dst, strerror(errno));
@@ -256,6 +277,14 @@ int64_t __ry_filesystem_copy(const char *src, const char *dst) {
 }
 
 int64_t __ry_filesystem_move(const char *src, const char *dst) {
+    if (hasEmbeddedNul(src)) {
+        setLastError("move: argument contains an embedded NUL byte");
+        return 1;
+    }
+    if (hasEmbeddedNul(dst)) {
+        setLastError("move: argument contains an embedded NUL byte");
+        return 1;
+    }
     if (rename(src, dst) == 0) return 0;
     if (errno == EXDEV) {
         // Cross-device: fall back to copy + remove
@@ -271,12 +300,20 @@ int64_t __ry_filesystem_move(const char *src, const char *dst) {
 }
 
 int64_t __ry_filesystem_remove(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("remove: argument contains an embedded NUL byte");
+        return 1;
+    }
     if (::remove(path) == 0) return 0;
     setLastError("remove: failed to remove '%s': %s", path, strerror(errno));
     return 1;
 }
 
 int64_t __ry_filesystem_remove_all(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("remove_all: argument contains an embedded NUL byte");
+        return 1;
+    }
     // Try unlink first (handles files and symlinks without TOCTOU).
     // If it fails because the path is a directory, fall through to nftw.
     if (unlink(path) == 0) return 0;
@@ -304,18 +341,30 @@ int64_t __ry_filesystem_remove_all(const char *path) {
 }
 
 int64_t __ry_filesystem_make_dir(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("make_dir: argument contains an embedded NUL byte");
+        return 1;
+    }
     if (mkdir(path, 0755) == 0) return 0;
     setLastError("make_dir: failed to create '%s': %s", path, strerror(errno));
     return 1;
 }
 
 int64_t __ry_filesystem_make_dir_all(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("make_dir_all: argument contains an embedded NUL byte");
+        return 1;
+    }
     if (mkdirAll(path, 0755) == 0) return 0;
     setLastError("make_dir_all: failed to create '%s': %s", path, strerror(errno));
     return 1;
 }
 
 int64_t __ry_filesystem_file_size(const char *path, int64_t *out_size) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("file_size: argument contains an embedded NUL byte");
+        return 1;
+    }
     struct stat st;
     if (stat(path, &st) != 0) {
         setLastError("file_size: cannot stat '%s': %s", path, strerror(errno));
@@ -325,31 +374,55 @@ int64_t __ry_filesystem_file_size(const char *path, int64_t *out_size) {
     return 0;
 }
 
-int64_t __ry_filesystem_is_file(const char *path) {
+int64_t __ry_filesystem_is_file(const char *path, int64_t *out) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("is_file: argument contains an embedded NUL byte");
+        return 1;
+    }
     struct stat st;
-    if (stat(path, &st) != 0) return 0;
-    return S_ISREG(st.st_mode) ? 1 : 0;
+    *out = (stat(path, &st) == 0 && S_ISREG(st.st_mode)) ? 1 : 0;
+    return 0;
 }
 
-int64_t __ry_filesystem_is_dir(const char *path) {
+int64_t __ry_filesystem_is_dir(const char *path, int64_t *out) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("is_dir: argument contains an embedded NUL byte");
+        return 1;
+    }
     struct stat st;
-    if (stat(path, &st) != 0) return 0;
-    return S_ISDIR(st.st_mode) ? 1 : 0;
+    *out = (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) ? 1 : 0;
+    return 0;
 }
 
-int64_t __ry_filesystem_is_symlink(const char *path) {
+int64_t __ry_filesystem_is_symlink(const char *path, int64_t *out) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("is_symlink: argument contains an embedded NUL byte");
+        return 1;
+    }
     struct stat st;
-    if (lstat(path, &st) != 0) return 0;
-    return S_ISLNK(st.st_mode) ? 1 : 0;
+    *out = (lstat(path, &st) == 0 && S_ISLNK(st.st_mode)) ? 1 : 0;
+    return 0;
 }
 
 int64_t __ry_filesystem_chmod(const char *path, int64_t mode) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("chmod: argument contains an embedded NUL byte");
+        return 1;
+    }
     if (::chmod(path, (mode_t)mode) == 0) return 0;
     setLastError("chmod: failed to chmod '%s': %s", path, strerror(errno));
     return 1;
 }
 
 int64_t __ry_filesystem_symlink(const char *target, const char *link_path) {
+    if (hasEmbeddedNul(target)) {
+        setLastError("symlink: argument contains an embedded NUL byte");
+        return 1;
+    }
+    if (hasEmbeddedNul(link_path)) {
+        setLastError("symlink: argument contains an embedded NUL byte");
+        return 1;
+    }
     if (::symlink(target, link_path) == 0) return 0;
     setLastError("symlink: failed to create symlink '%s' -> '%s': %s",
                  link_path, target, strerror(errno));
@@ -357,6 +430,10 @@ int64_t __ry_filesystem_symlink(const char *target, const char *link_path) {
 }
 
 const char *__ry_filesystem_read_link(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("read_link: argument contains an embedded NUL byte");
+        return nullptr;
+    }
     char buf[PATH_MAX];
     ssize_t len = readlink(path, buf, sizeof(buf) - 1);
     if (len < 0) {

--- a/src/runtime_http.cpp
+++ b/src/runtime_http.cpp
@@ -1,8 +1,10 @@
 #include "ry/runtime_http_internal.hpp"
 #include "ry/runtime_http.hpp"
+#include "ry/runtime_http_error.hpp"
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_net_utils.hpp"
 #include "ry/runtime_arc.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <openssl/err.h>
 
@@ -581,6 +583,14 @@ extern "C" void *__ry_http_cookies(void *r) {
 }
 
 extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, const char *body) {
+    auto *map = (MapHeader *)headers_map;
+    for (int64_t i = 0; i < map->len; i++) {
+        if (hasEmbeddedNul(map->keys[i]) || hasEmbeddedNul(map->vals[i])) {
+            setHttpLastError("response: header key or value contains an embedded NUL byte");
+            return nullptr;
+        }
+    }
+
     void *resp_mem = arc_alloc(sizeof(HttpResponseHandle));
     if (!resp_mem) return nullptr;
     // cppcheck-suppress legacyUninitvar -- placement new with {} zero-initializes; false positive in Cppcheck < 2.14
@@ -590,7 +600,6 @@ extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, co
     resp->body_len = blen;
     resp->body = makeString(blen > 0 ? body : "", (size_t)blen);
 
-    auto *map = (MapHeader *)headers_map;
     if (map->len > 0) {
         resp->header_keys = (char **)checked_malloc(sizeof(char *) * (size_t)map->len);
         resp->header_values = (char **)checked_malloc(sizeof(char *) * (size_t)map->len);
@@ -607,6 +616,23 @@ extern "C" void *__ry_http_response_create(int64_t status, void *headers_map, co
         resp->header_values = nullptr;
     }
 
+    return resp;
+}
+
+extern "C" void *__ry_http_default_error_response(int64_t status) {
+    void *mem = arc_alloc(sizeof(HttpResponseHandle));
+    if (!mem) return nullptr;
+    // cppcheck-suppress legacyUninitvar
+    auto *resp = new (mem) HttpResponseHandle{};
+    resp->status = status;
+    const char *phrase = __ry_http_reason_phrase(status);
+    if (!phrase) phrase = "Internal Server Error";
+    size_t plen = strlen(phrase);
+    resp->body = makeString(phrase, plen);
+    resp->body_len = (int64_t)plen;
+    resp->header_keys = nullptr;
+    resp->header_values = nullptr;
+    resp->header_count = 0;
     return resp;
 }
 

--- a/src/runtime_http_client.cpp
+++ b/src/runtime_http_client.cpp
@@ -1,6 +1,5 @@
 #include "ry/runtime_http_internal.hpp"
 #include "ry/runtime_http.hpp"
-#include "ry/runtime_http_error.hpp"
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_net_utils.hpp"
 #include "ry/runtime_arc.hpp"
@@ -390,7 +389,7 @@ static std::string build_http_request(const char *method, const ParsedUrl *parse
         }
     }
 
-    size_t body_len = body ? (size_t)stringByteLen(body) : 0;
+    size_t body_len = (body && *body) ? strlen(body) : 0;
     request += "Content-Length: ";
     request += std::to_string(body_len);
     request += "\r\n";
@@ -411,16 +410,6 @@ extern "C" void *__ry_http_client_request(const char *method, const char *url,
     // is also called directly from C++ tests and internally (e.g. redirect
     // follow) with plain C strings that carry no Ry StringHeader prefix —
     // applying hasEmbeddedNul here would read garbage before those pointers.
-    if (headers_map) {
-        auto *map = (MapHeader *)headers_map;
-        for (int64_t i = 0; i < map->len; i++) {
-            if (hasEmbeddedNul(map->keys[i]) || hasEmbeddedNul(map->vals[i])) {
-                setHttpLastError("http request: header key or value contains an embedded NUL byte");
-                return nullptr;
-            }
-        }
-    }
-
     char *owned_url = nullptr;
     char *owned_method = nullptr;
     const char *current_url = url;

--- a/src/runtime_http_client.cpp
+++ b/src/runtime_http_client.cpp
@@ -1,8 +1,10 @@
 #include "ry/runtime_http_internal.hpp"
 #include "ry/runtime_http.hpp"
+#include "ry/runtime_http_error.hpp"
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_net_utils.hpp"
 #include "ry/runtime_arc.hpp"
+#include "ry/runtime_string.hpp"
 
 
 namespace ry {
@@ -388,7 +390,7 @@ static std::string build_http_request(const char *method, const ParsedUrl *parse
         }
     }
 
-    size_t body_len = (body && *body) ? strlen(body) : 0;
+    size_t body_len = body ? (size_t)stringByteLen(body) : 0;
     request += "Content-Length: ";
     request += std::to_string(body_len);
     request += "\r\n";
@@ -404,6 +406,20 @@ static std::string build_http_request(const char *method, const ParsedUrl *parse
 extern "C" void *__ry_http_client_request(const char *method, const char *url,
                                            void *headers_map, const char *body) {
     if (has_crlf(method)) return nullptr;
+    // NUL checks for method and url are done in codegen (emitHttpClientCall)
+    // for the user-facing http_get/http_post/http_request paths. This function
+    // is also called directly from C++ tests and internally (e.g. redirect
+    // follow) with plain C strings that carry no Ry StringHeader prefix —
+    // applying hasEmbeddedNul here would read garbage before those pointers.
+    if (headers_map) {
+        auto *map = (MapHeader *)headers_map;
+        for (int64_t i = 0; i < map->len; i++) {
+            if (hasEmbeddedNul(map->keys[i]) || hasEmbeddedNul(map->vals[i])) {
+                setHttpLastError("http request: header key or value contains an embedded NUL byte");
+                return nullptr;
+            }
+        }
+    }
 
     char *owned_url = nullptr;
     char *owned_method = nullptr;

--- a/src/runtime_http_error.cpp
+++ b/src/runtime_http_error.cpp
@@ -1,0 +1,29 @@
+#include "ry/runtime_alloc.hpp"
+#include "ry/runtime_http_error.hpp"
+#include "ry/runtime_string.hpp"
+
+#include <cstdarg>
+#include <cstdio>
+
+
+namespace ry {
+
+static thread_local char http_last_error_buf[512] = {0};
+
+void setHttpLastError(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(http_last_error_buf, sizeof(http_last_error_buf), fmt, args);
+    va_end(args);
+}
+
+extern "C" const char *__ry_http_get_last_error() {
+    return checked_strdup(http_last_error_buf);
+}
+
+// Called from JIT'd code to check if a Ry string contains an embedded NUL.
+extern "C" int64_t __ry_http_str_has_nul(const char *s) {
+    return hasEmbeddedNul(s) ? 1 : 0;
+}
+
+} // namespace ry

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -1,9 +1,11 @@
 #include "ry/runtime_alloc.hpp"
+#include "ry/runtime_error.hpp"
 #include "ry/runtime_net.hpp"
 #include "ry/runtime_net_types.hpp"
 #include "ry/runtime_net_utils.hpp"
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_arc.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <cstdio>
 #include <cstdlib>
@@ -25,6 +27,8 @@
 
 namespace ry {
 
+DEFINE_LAST_ERROR(net)
+
 struct TcpListenerHandle {
     int fd;
     std::atomic<bool> shutdown{false};
@@ -32,8 +36,14 @@ struct TcpListenerHandle {
 
 
 extern "C" void *__ry_bind(const char *host, int64_t port) {
-    if (port < 0 || port > 65535)
+    if (hasEmbeddedNul(host)) {
+        setLastError("bind: host argument contains an embedded NUL byte");
         return nullptr;
+    }
+    if (port < 0 || port > 65535) {
+        setLastError("bind: port %lld is out of range [0, 65535]", (long long)port);
+        return nullptr;
+    }
 
     ::addrinfo hints{}, *result = nullptr;
     hints.ai_family = AF_INET;
@@ -43,11 +53,14 @@ extern "C" void *__ry_bind(const char *host, int64_t port) {
     char port_str[16];
     snprintf(port_str, sizeof(port_str), "%lld", (long long)port);
 
-    if (::getaddrinfo(host, port_str, &hints, &result) != 0)
+    if (::getaddrinfo(host, port_str, &hints, &result) != 0) {
+        setLastError("bind: cannot resolve host '%s': %s", host, strerror(errno));
         return nullptr;
+    }
 
     int fd = ::socket(result->ai_family, result->ai_socktype, result->ai_protocol);
     if (fd < 0) {
+        setLastError("bind: cannot create socket: %s", strerror(errno));
         ::freeaddrinfo(result);
         return nullptr;
     }
@@ -59,6 +72,7 @@ extern "C" void *__ry_bind(const char *host, int64_t port) {
 #endif
 
     if (::bind(fd, result->ai_addr, result->ai_addrlen) < 0) {
+        setLastError("bind: cannot bind to %s:%lld: %s", host, (long long)port, strerror(errno));
         ::close(fd);
         ::freeaddrinfo(result);
         return nullptr;
@@ -68,6 +82,7 @@ extern "C" void *__ry_bind(const char *host, int64_t port) {
 
     void *mem = arc_alloc(sizeof(TcpListenerHandle));
     if (!mem) {
+        setLastError("bind: memory allocation failed");
         ::close(fd);
         return nullptr;
     }
@@ -160,7 +175,14 @@ extern "C" void *__ry_connect_resolved(const ::addrinfo *info) {
 }
 
 extern "C" void *__ry_connect(const char *host, int64_t port) {
-    return ry_net_connect(host, port);
+    if (hasEmbeddedNul(host)) {
+        setLastError("connect: host argument contains an embedded NUL byte");
+        return nullptr;
+    }
+    void *stream = ry_net_connect(host, port);
+    if (!stream)
+        setLastError("connect: failed to connect to %s:%lld: %s", host, (long long)port, strerror(errno));
+    return stream;
 }
 
 ssize_t __ry_send_all(int fd, const void *buf, size_t len) {

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -53,8 +53,9 @@ extern "C" void *__ry_bind(const char *host, int64_t port) {
     char port_str[16];
     snprintf(port_str, sizeof(port_str), "%lld", (long long)port);
 
-    if (::getaddrinfo(host, port_str, &hints, &result) != 0) {
-        setLastError("bind: cannot resolve host '%s': %s", host, strerror(errno));
+    int gai_ret = ::getaddrinfo(host, port_str, &hints, &result);
+    if (gai_ret != 0) {
+        setLastError("bind: cannot resolve host '%s': %s", host, gai_strerror(gai_ret));
         return nullptr;
     }
 

--- a/src/runtime_path.cpp
+++ b/src/runtime_path.cpp
@@ -35,13 +35,22 @@ static const char *find_base(const char *p, size_t len) {
 
 // If b is absolute, returns a copy of b.
 // Otherwise concatenates a + "/" + b, normalizing double slashes.
+// Returns nullptr (+ setLastError) if either argument contains an embedded NUL.
 static char *join2_impl(const char *a, const char *b) {
-    if (!a || !*a) return makeString(b ? b : "", b ? strlen(b) : 0);
-    if (!b || !*b) return makeString(a, strlen(a));
-    if (b[0] == '/') return makeString(b, strlen(b));
+    if (hasEmbeddedNul(a)) {
+        setLastError("path.join: argument contains an embedded NUL byte");
+        return nullptr;
+    }
+    if (hasEmbeddedNul(b)) {
+        setLastError("path.join: argument contains an embedded NUL byte");
+        return nullptr;
+    }
+    if (!a || !*a) return makeString(b ? b : "", b ? static_cast<size_t>(stringByteLen(b)) : 0);
+    if (!b || !*b) return makeString(a, static_cast<size_t>(stringByteLen(a)));
+    if (b[0] == '/') return makeString(b, static_cast<size_t>(stringByteLen(b)));
 
-    size_t a_len = strip_trailing(a, strlen(a));
-    size_t b_len = strlen(b);
+    size_t a_len = strip_trailing(a, static_cast<size_t>(stringByteLen(a)));
+    size_t b_len = static_cast<size_t>(stringByteLen(b));
 
     // If a ends with '/' (root path), don't insert an extra separator
     bool need_sep = (a[a_len - 1] != '/');
@@ -63,6 +72,7 @@ extern "C" const char *__ry_path_join2(const char *a, const char *b) {
 
 extern "C" const char *__ry_path_join3(const char *a, const char *b, const char *c) {
     char *ab = join2_impl(a, b);
+    if (!ab) return nullptr;  // propagate NUL error from first pair
     char *result = join2_impl(ab, c);
     freeStringSlot(ab);
     return result;
@@ -70,8 +80,10 @@ extern "C" const char *__ry_path_join3(const char *a, const char *b, const char 
 
 extern "C" const char *__ry_path_join4(const char *a, const char *b, const char *c, const char *d) {
     char *ab = join2_impl(a, b);
+    if (!ab) return nullptr;  // propagate NUL error from first pair
     char *abc = join2_impl(ab, c);
     freeStringSlot(ab);
+    if (!abc) return nullptr;  // propagate NUL error from second pair
     char *result = join2_impl(abc, d);
     freeStringSlot(abc);
     return result;
@@ -79,8 +91,12 @@ extern "C" const char *__ry_path_join4(const char *a, const char *b, const char 
 
 extern "C" const char *__ry_path_basename(const char *p) {
     if (!p || !*p) return makeString("", 0);
+    if (hasEmbeddedNul(p)) {
+        setLastError("path.basename: argument contains an embedded NUL byte");
+        return nullptr;
+    }
 
-    size_t len = strip_trailing(p, strlen(p));
+    size_t len = strip_trailing(p, static_cast<size_t>(stringByteLen(p)));
     if (len == 1 && p[0] == '/') return makeString("", 0);
 
     const char *end = p + len;
@@ -94,8 +110,12 @@ extern "C" const char *__ry_path_basename(const char *p) {
 
 extern "C" const char *__ry_path_dirname(const char *p) {
     if (!p || !*p) return makeString(".", 1);
+    if (hasEmbeddedNul(p)) {
+        setLastError("path.dirname: argument contains an embedded NUL byte");
+        return nullptr;
+    }
 
-    size_t len = strip_trailing(p, strlen(p));
+    size_t len = strip_trailing(p, static_cast<size_t>(stringByteLen(p)));
 
     // Find last slash
     const char *slash = p + len - 1;
@@ -119,8 +139,12 @@ extern "C" const char *__ry_path_dirname(const char *p) {
 
 extern "C" const char *__ry_path_extension(const char *p) {
     if (!p || !*p) return makeString("", 0);
+    if (hasEmbeddedNul(p)) {
+        setLastError("path.extension: argument contains an embedded NUL byte");
+        return nullptr;
+    }
 
-    size_t len = strip_trailing(p, strlen(p));
+    size_t len = strip_trailing(p, static_cast<size_t>(stringByteLen(p)));
     const char *end = p + len;
     const char *base = find_base(p, len);
     size_t base_len = (size_t)(end - base);
@@ -141,6 +165,10 @@ extern "C" const char *__ry_path_extension(const char *p) {
 extern "C" const char *__ry_path_resolve(const char *p) {
     if (!p || !*p) {
         setLastError("cannot resolve path: empty path");
+        return nullptr;
+    }
+    if (hasEmbeddedNul(p)) {
+        setLastError("path.resolve: argument contains an embedded NUL byte");
         return nullptr;
     }
 

--- a/tests/spec/filesystem.test.ry
+++ b/tests/spec/filesystem.test.ry
@@ -61,9 +61,15 @@ describe("list_dir", ():
     if is_dir(d):
       remove_all(d)
     make_dir(d)
-    write_text(join(d, "a.txt"), "a")
-    write_text(join(d, "b.txt"), "b")
-    make_dir(join(d, "subdir"))
+    case join(d, "a.txt"):
+      Ok(pa): write_text(pa, "a")
+      Err(e): fail("join failed: " + e.message)
+    case join(d, "b.txt"):
+      Ok(pb): write_text(pb, "b")
+      Err(e): fail("join failed: " + e.message)
+    case join(d, "subdir"):
+      Ok(ps): make_dir(ps)
+      Err(e): fail("join failed: " + e.message)
     case list_dir(d):
       Ok(entries):
         expect(entries).to_have_length(3)
@@ -82,10 +88,18 @@ describe("walk", ():
     d = "/tmp/ry_fs_test/walk_test"
     if is_dir(d):
       remove_all(d)
-    make_dir_all(join(d, "sub1", "sub2"))
-    write_text(join(d, "root.txt"), "r")
-    write_text(join(d, "sub1", "mid.txt"), "m")
-    write_text(join(d, "sub1", "sub2", "deep.txt"), "d")
+    case join(d, "sub1", "sub2"):
+      Ok(p): make_dir_all(p)
+      Err(e): fail("join failed: " + e.message)
+    case join(d, "root.txt"):
+      Ok(p): write_text(p, "r")
+      Err(e): fail("join failed: " + e.message)
+    case join(d, "sub1", "mid.txt"):
+      Ok(p): write_text(p, "m")
+      Err(e): fail("join failed: " + e.message)
+    case join(d, "sub1", "sub2", "deep.txt"):
+      Ok(p): write_text(p, "d")
+      Err(e): fail("join failed: " + e.message)
     case walk(d):
       Ok(entries):
         expect(length(entries) >= 5).to_be_true()
@@ -105,14 +119,23 @@ describe("glob_files", ():
     if is_dir(d):
       remove_all(d)
     make_dir(d)
-    write_text(join(d, "file1.log"), "1")
-    write_text(join(d, "file2.log"), "2")
-    write_text(join(d, "file3.txt"), "3")
-    case glob_files(join(d, "*.log")):
-      Ok(matches):
-        expect(matches).to_have_length(2)
-      Err(e):
-        fail("glob_files failed: " + e.message)
+    case join(d, "file1.log"):
+      Ok(p): write_text(p, "1")
+      Err(e): fail("join failed: " + e.message)
+    case join(d, "file2.log"):
+      Ok(p): write_text(p, "2")
+      Err(e): fail("join failed: " + e.message)
+    case join(d, "file3.txt"):
+      Ok(p): write_text(p, "3")
+      Err(e): fail("join failed: " + e.message)
+    case join(d, "*.log"):
+      Ok(pattern):
+        case glob_files(pattern):
+          Ok(matches):
+            expect(matches).to_have_length(2)
+          Err(e):
+            fail("glob_files failed: " + e.message)
+      Err(e): fail("join failed: " + e.message)
   )
 
   it("should return empty list when nothing matches", ():
@@ -178,7 +201,9 @@ describe("remove / remove_all", ():
   it("should fail to remove non-empty directory", ():
     d = "/tmp/ry_fs_test/nonempty_dir"
     make_dir(d)
-    write_text(join(d, "child.txt"), "x")
+    case join(d, "child.txt"):
+      Ok(p): write_text(p, "x")
+      Err(e): fail("join failed: " + e.message)
     result = remove(d)
     expect(result).to_be_err()
     remove_all(d)
@@ -186,8 +211,12 @@ describe("remove / remove_all", ():
 
   it("should remove directory tree with remove_all", ():
     d = "/tmp/ry_fs_test/tree_to_remove"
-    make_dir_all(join(d, "a", "b"))
-    write_text(join(d, "a", "b", "file.txt"), "x")
+    case join(d, "a", "b"):
+      Ok(p): make_dir_all(p)
+      Err(e): fail("join failed: " + e.message)
+    case join(d, "a", "b", "file.txt"):
+      Ok(p): write_text(p, "x")
+      Err(e): fail("join failed: " + e.message)
     case remove_all(d):
       Ok(_):
         expect(is_dir(d)).to_be_false()

--- a/tests/spec/filesystem.test.ry
+++ b/tests/spec/filesystem.test.ry
@@ -5,12 +5,13 @@ from path import join
 describe("make_dir / make_dir_all", ():
   it("should create a single directory", ():
     d = "/tmp/ry_fs_test/single_dir"
-    if is_dir(d):
-      remove_all(d)
+    remove_all(d)
     make_dir_all("/tmp/ry_fs_test")
     case make_dir(d):
       Ok(_):
-        expect(is_dir(d)).to_be_true()
+        case is_dir(d):
+          Ok(v): expect(v).to_be_true()
+          Err(e): fail("is_dir failed: " + e.message)
       Err(e):
         fail("make_dir failed: " + e.message)
   )
@@ -25,7 +26,9 @@ describe("make_dir / make_dir_all", ():
     d = "/tmp/ry_fs_test/a/b/c"
     case make_dir_all(d):
       Ok(_):
-        expect(is_dir(d)).to_be_true()
+        case is_dir(d):
+          Ok(v): expect(v).to_be_true()
+          Err(e): fail("is_dir failed: " + e.message)
       Err(e):
         fail("make_dir_all failed: " + e.message)
   )
@@ -36,30 +39,45 @@ describe("is_file / is_dir / is_symlink", ():
     f = "/tmp/ry_fs_test/test_file.txt"
     case write_text(f, "hello"):
       Ok(_):
-        expect(is_file(f)).to_be_true()
-        expect(is_dir(f)).to_be_false()
-        expect(is_symlink(f)).to_be_false()
+        case is_file(f):
+          Ok(v): expect(v).to_be_true()
+          Err(e): fail("is_file failed: " + e.message)
+        case is_dir(f):
+          Ok(v): expect(v).to_be_false()
+          Err(e): fail("is_dir failed: " + e.message)
+        case is_symlink(f):
+          Ok(v): expect(v).to_be_false()
+          Err(e): fail("is_symlink failed: " + e.message)
       Err(e):
         fail("write_text failed: " + e.message)
   )
 
   it("should detect a directory", ():
-    expect(is_dir("/tmp/ry_fs_test")).to_be_true()
-    expect(is_file("/tmp/ry_fs_test")).to_be_false()
+    case is_dir("/tmp/ry_fs_test"):
+      Ok(v): expect(v).to_be_true()
+      Err(e): fail("is_dir failed: " + e.message)
+    case is_file("/tmp/ry_fs_test"):
+      Ok(v): expect(v).to_be_false()
+      Err(e): fail("is_file failed: " + e.message)
   )
 
   it("should return false for non-existent path", ():
-    expect(is_file("/tmp/ry_fs_test_nonexistent_xyz")).to_be_false()
-    expect(is_dir("/tmp/ry_fs_test_nonexistent_xyz")).to_be_false()
-    expect(is_symlink("/tmp/ry_fs_test_nonexistent_xyz")).to_be_false()
+    case is_file("/tmp/ry_fs_test_nonexistent_xyz"):
+      Ok(v): expect(v).to_be_false()
+      Err(e): fail("is_file failed: " + e.message)
+    case is_dir("/tmp/ry_fs_test_nonexistent_xyz"):
+      Ok(v): expect(v).to_be_false()
+      Err(e): fail("is_dir failed: " + e.message)
+    case is_symlink("/tmp/ry_fs_test_nonexistent_xyz"):
+      Ok(v): expect(v).to_be_false()
+      Err(e): fail("is_symlink failed: " + e.message)
   )
 )
 
 describe("list_dir", ():
   it("should list directory entries", ():
     d = "/tmp/ry_fs_test/listdir_test"
-    if is_dir(d):
-      remove_all(d)
+    remove_all(d)
     make_dir(d)
     case join(d, "a.txt"):
       Ok(pa): write_text(pa, "a")
@@ -86,8 +104,7 @@ describe("list_dir", ():
 describe("walk", ():
   it("should recursively list files and directories", ():
     d = "/tmp/ry_fs_test/walk_test"
-    if is_dir(d):
-      remove_all(d)
+    remove_all(d)
     case join(d, "sub1", "sub2"):
       Ok(p): make_dir_all(p)
       Err(e): fail("join failed: " + e.message)
@@ -116,8 +133,7 @@ describe("walk", ():
 describe("glob_files", ():
   it("should match files by pattern", ():
     d = "/tmp/ry_fs_test/glob_test"
-    if is_dir(d):
-      remove_all(d)
+    remove_all(d)
     make_dir(d)
     case join(d, "file1.log"):
       Ok(p): write_text(p, "1")
@@ -219,7 +235,9 @@ describe("remove / remove_all", ():
       Err(e): fail("join failed: " + e.message)
     case remove_all(d):
       Ok(_):
-        expect(is_dir(d)).to_be_false()
+        case is_dir(d):
+          Ok(v): expect(v).to_be_false()
+          Err(e): fail("is_dir failed: " + e.message)
       Err(e):
         fail("remove_all failed: " + e.message)
   )
@@ -248,7 +266,9 @@ describe("chmod", ():
     write_text(f, "x")
     case chmod(f, 420):
       Ok(_):
-        expect(is_file(f)).to_be_true()
+        case is_file(f):
+          Ok(v): expect(v).to_be_true()
+          Err(e): fail("is_file failed: " + e.message)
       Err(e):
         fail("chmod failed: " + e.message)
   )
@@ -258,13 +278,16 @@ describe("symlink / read_link / is_symlink", ():
   it("should create and read a symbolic link", ():
     target = "/tmp/ry_fs_test/symlink_target.txt"
     link = "/tmp/ry_fs_test/symlink_link.txt"
-    if is_symlink(link):
-      remove(link)
+    remove(link)
     write_text(target, "target content")
     case symlink(target, link):
       Ok(_):
-        expect(is_symlink(link)).to_be_true()
-        expect(is_file(link)).to_be_true()
+        case is_symlink(link):
+          Ok(v): expect(v).to_be_true()
+          Err(e): fail("is_symlink failed: " + e.message)
+        case is_file(link):
+          Ok(v): expect(v).to_be_true()
+          Err(e): fail("is_file failed: " + e.message)
         case read_link(link):
           Ok(t):
             expect(t).to_eq(target)

--- a/tests/spec/nul_safety_filesystem.test.ry
+++ b/tests/spec/nul_safety_filesystem.test.ry
@@ -1,0 +1,148 @@
+from filesystem import list_dir, walk, glob_files, copy, move, remove, remove_all, make_dir, make_dir_all, file_size, is_file, is_dir, is_symlink, chmod, symlink, read_link
+
+describe("nul_safety_filesystem", ():
+  describe("is_file", ():
+    it("rejects NUL in path", ():
+      case is_file("/tmp/ry_fs\0bad"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case is_file("/tmp"):
+        Ok(_): 0
+        Err(e): fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("is_dir", ():
+    it("rejects NUL in path", ():
+      case is_dir("/tmp/ry_fs\0bad"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case is_dir("/tmp"):
+        Ok(_): 0
+        Err(e): fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("is_symlink", ():
+    it("rejects NUL in path", ():
+      case is_symlink("/tmp/ry_fs\0bad"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case is_symlink("/tmp"):
+        Ok(_): 0
+        Err(e): fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("list_dir", ():
+    it("rejects NUL in path", ():
+      case list_dir("/tmp/ry_fs\0bad"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("walk", ():
+    it("rejects NUL in path", ():
+      case walk("/tmp/ry_fs\0bad"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("glob_files", ():
+    it("rejects NUL in pattern", ():
+      case glob_files("/tmp/ry\0*.txt"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("make_dir", ():
+    it("rejects NUL in path", ():
+      case make_dir("/tmp/ry_fs\0bad"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("make_dir_all", ():
+    it("rejects NUL in path", ():
+      case make_dir_all("/tmp/ry_fs\0bad/a/b"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("file_size", ():
+    it("rejects NUL in path", ():
+      case file_size("/tmp/ry_fs\0bad.txt"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("copy", ():
+    it("rejects NUL in source", ():
+      case copy("/tmp/ry_fs\0src.txt", "/tmp/ry_fs_dst.txt"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("rejects NUL in destination", ():
+      case copy("/tmp/ry_fs_src.txt", "/tmp/ry_fs\0dst.txt"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("remove", ():
+    it("rejects NUL in path", ():
+      case remove("/tmp/ry_fs\0bad.txt"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("remove_all", ():
+    it("rejects NUL in path", ():
+      case remove_all("/tmp/ry_fs\0bad"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("read_link", ():
+    it("rejects NUL in path", ():
+      case read_link("/tmp/ry_fs\0bad"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("symlink", ():
+    it("rejects NUL in target", ():
+      case symlink("/tmp/ry_fs\0target", "/tmp/ry_fs_link"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("rejects NUL in link path", ():
+      case symlink("/tmp/ry_fs_target", "/tmp/ry_fs\0link"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("chmod", ():
+    it("rejects NUL in path", ():
+      case chmod("/tmp/ry_fs\0bad.txt", 420):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+)

--- a/tests/spec/nul_safety_filesystem.test.ry
+++ b/tests/spec/nul_safety_filesystem.test.ry
@@ -101,6 +101,19 @@ describe("nul_safety_filesystem", ():
     )
   )
 
+  describe("move", ():
+    it("rejects NUL in source", ():
+      case move("/tmp/ry_fs\0src.txt", "/tmp/ry_fs_dst.txt"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("rejects NUL in destination", ():
+      case move("/tmp/ry_fs_src.txt", "/tmp/ry_fs\0dst.txt"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
   describe("remove", ():
     it("rejects NUL in path", ():
       case remove("/tmp/ry_fs\0bad.txt"):

--- a/tests/spec/nul_safety_http.test.ry
+++ b/tests/spec/nul_safety_http.test.ry
@@ -1,0 +1,22 @@
+from http import response
+
+describe("nul_safety_http", ():
+  describe("response", ():
+    it("rejects NUL in header key", ():
+      case response(200, {"key\0bad": "value"}, "ok"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("rejects NUL in header value", ():
+      case response(200, {"Content-Type": "text/plain\0bad"}, "ok"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("accepts binary body (NUL in body is OK)", ():
+      no_headers: Map<str, str> = {}
+      case response(200, no_headers, "bin\0ary"):
+        Ok(_): ...
+        Err(e): fail("binary body should be accepted: " + e.message)
+    )
+  )
+)

--- a/tests/spec/nul_safety_http_client.test.ry
+++ b/tests/spec/nul_safety_http_client.test.ry
@@ -1,0 +1,35 @@
+from http import http_get, http_post, http_request
+
+describe("nul_safety_http_client", ():
+  describe("http_get", ():
+    it("rejects NUL in url", ():
+      case http_get("http://127.0.0.1\0bad/path"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("http_post", ():
+    it("rejects NUL in url", ():
+      no_headers: Map<str, str> = {}
+      case http_post("http://127.0.0.1\0bad/path", "body", no_headers):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("http_request", ():
+    it("rejects NUL in method", ():
+      no_headers: Map<str, str> = {}
+      case http_request("GET\0bad", "http://127.0.0.1:1/path", no_headers, ""):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("rejects NUL in url", ():
+      no_headers: Map<str, str> = {}
+      case http_request("GET", "http://127.0.0.1\0bad/path", no_headers, ""):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+)

--- a/tests/spec/nul_safety_net.test.ry
+++ b/tests/spec/nul_safety_net.test.ry
@@ -1,0 +1,19 @@
+from net import bind, connect
+
+describe("nul_safety_net", ():
+  describe("bind", ():
+    it("rejects NUL in host", ():
+      case bind("localhost\0bad", 19876):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("connect", ():
+    it("rejects NUL in host", ():
+      case connect("localhost\0bad", 19876):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+)

--- a/tests/spec/nul_safety_path.test.ry
+++ b/tests/spec/nul_safety_path.test.ry
@@ -1,0 +1,119 @@
+from path import join, basename, dirname, extension, resolve
+
+describe("nul_safety_path", ():
+  describe("join (2-arg)", ():
+    it("rejects NUL in first argument", ():
+      case join("/foo\0bar", "b"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("rejects NUL in second argument", ():
+      case join("/foo", "baz\0qux"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case join("/foo", "bar"):
+        Ok(s): expect(s).to_eq("/foo/bar")
+        Err(e): fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("join (3-arg)", ():
+    it("rejects NUL in first argument", ():
+      case join("/foo\0bar", "b", "c"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("rejects NUL in second argument", ():
+      case join("/a", "baz\0qux", "c"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("rejects NUL in third argument", ():
+      case join("/a", "b", "baz\0qux"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case join("/a", "b", "c"):
+        Ok(s): expect(s).to_eq("/a/b/c")
+        Err(e): fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("join (4-arg)", ():
+    it("rejects NUL in fourth argument", ():
+      case join("/a", "b", "c", "baz\0qux"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case join("/a", "b", "c", "d"):
+        Ok(s): expect(s).to_eq("/a/b/c/d")
+        Err(e): fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("basename", ():
+    it("rejects NUL", ():
+      case basename("/foo\0bar"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case basename("/foo/bar.txt"):
+        Ok(s): expect(s).to_eq("bar.txt")
+        Err(e): fail("unexpected error: " + e.message)
+    )
+    it("empty path returns empty string", ():
+      case basename(""):
+        Ok(s): expect(s).to_eq("")
+        Err(e): fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("dirname", ():
+    it("rejects NUL", ():
+      case dirname("/foo\0bar"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case dirname("/foo/bar.txt"):
+        Ok(s): expect(s).to_eq("/foo")
+        Err(e): fail("unexpected error: " + e.message)
+    )
+    it("empty path returns dot", ():
+      case dirname(""):
+        Ok(s): expect(s).to_eq(".")
+        Err(e): fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("extension", ():
+    it("rejects NUL", ():
+      case extension("/foo\0bar"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case extension("/foo/bar.txt"):
+        Ok(s): expect(s).to_eq(".txt")
+        Err(e): fail("unexpected error: " + e.message)
+    )
+    it("no extension returns empty string", ():
+      case extension("/foo/bar"):
+        Ok(s): expect(s).to_eq("")
+        Err(e): fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("resolve", ():
+    it("rejects NUL", ():
+      case resolve("/foo\0bar"):
+        Ok(s): fail("expected Err but got Ok: " + s)
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+)

--- a/tests/spec/path.test.ry
+++ b/tests/spec/path.test.ry
@@ -3,88 +3,138 @@ from path import join, basename, dirname, extension, resolve, is_absolute
 describe("path", ():
   describe("join", ():
     it("should join two parts", ():
-      expect(join("/tmp", "file.txt")).to_eq("/tmp/file.txt")
+      case join("/tmp", "file.txt"):
+        Ok(s): expect(s).to_eq("/tmp/file.txt")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should join three parts", ():
-      expect(join("/tmp", "data", "file.txt")).to_eq("/tmp/data/file.txt")
+      case join("/tmp", "data", "file.txt"):
+        Ok(s): expect(s).to_eq("/tmp/data/file.txt")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should join four parts", ():
-      expect(join("/tmp", "a", "b", "file.txt")).to_eq("/tmp/a/b/file.txt")
+      case join("/tmp", "a", "b", "file.txt"):
+        Ok(s): expect(s).to_eq("/tmp/a/b/file.txt")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should replace first arg when second is absolute", ():
-      expect(join("/tmp", "/usr")).to_eq("/usr")
+      case join("/tmp", "/usr"):
+        Ok(s): expect(s).to_eq("/usr")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should handle trailing slash", ():
-      expect(join("/tmp/", "file.txt")).to_eq("/tmp/file.txt")
+      case join("/tmp/", "file.txt"):
+        Ok(s): expect(s).to_eq("/tmp/file.txt")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should join from root", ():
-      expect(join("/", "tmp")).to_eq("/tmp")
+      case join("/", "tmp"):
+        Ok(s): expect(s).to_eq("/tmp")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should handle empty first arg", ():
-      expect(join("", "file.txt")).to_eq("file.txt")
+      case join("", "file.txt"):
+        Ok(s): expect(s).to_eq("file.txt")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should handle empty second arg", ():
-      expect(join("/tmp", "")).to_eq("/tmp")
+      case join("/tmp", ""):
+        Ok(s): expect(s).to_eq("/tmp")
+        Err(e): fail("unexpected error: " + e.message)
     )
   )
 
   describe("basename", ():
     it("should extract filename", ():
-      expect(basename("/tmp/data/file.txt")).to_eq("file.txt")
+      case basename("/tmp/data/file.txt"):
+        Ok(s): expect(s).to_eq("file.txt")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return empty string for root path", ():
-      expect(basename("/")).to_eq("")
+      case basename("/"):
+        Ok(s): expect(s).to_eq("")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return filename when no directory", ():
-      expect(basename("file.txt")).to_eq("file.txt")
+      case basename("file.txt"):
+        Ok(s): expect(s).to_eq("file.txt")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should handle trailing slash", ():
-      expect(basename("/tmp/data/")).to_eq("data")
+      case basename("/tmp/data/"):
+        Ok(s): expect(s).to_eq("data")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should handle empty string", ():
-      expect(basename("")).to_eq("")
+      case basename(""):
+        Ok(s): expect(s).to_eq("")
+        Err(e): fail("unexpected error: " + e.message)
     )
   )
 
   describe("dirname", ():
     it("should extract directory", ():
-      expect(dirname("/tmp/data/file.txt")).to_eq("/tmp/data")
+      case dirname("/tmp/data/file.txt"):
+        Ok(s): expect(s).to_eq("/tmp/data")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return root for file at root", ():
-      expect(dirname("/file.txt")).to_eq("/")
+      case dirname("/file.txt"):
+        Ok(s): expect(s).to_eq("/")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return dot when no directory", ():
-      expect(dirname("file.txt")).to_eq(".")
+      case dirname("file.txt"):
+        Ok(s): expect(s).to_eq(".")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return root for root path", ():
-      expect(dirname("/")).to_eq("/")
+      case dirname("/"):
+        Ok(s): expect(s).to_eq("/")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return dot for empty string", ():
-      expect(dirname("")).to_eq(".")
+      case dirname(""):
+        Ok(s): expect(s).to_eq(".")
+        Err(e): fail("unexpected error: " + e.message)
     )
   )
 
   describe("extension", ():
     it("should extract extension", ():
-      expect(extension("/tmp/file.txt")).to_eq(".txt")
+      case extension("/tmp/file.txt"):
+        Ok(s): expect(s).to_eq(".txt")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return empty string when no extension", ():
-      expect(extension("/tmp/file")).to_eq("")
+      case extension("/tmp/file"):
+        Ok(s): expect(s).to_eq("")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return empty string for hidden file with no ext", ():
-      expect(extension(".gitignore")).to_eq("")
+      case extension(".gitignore"):
+        Ok(s): expect(s).to_eq("")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should extract extension from hidden file", ():
-      expect(extension(".config.json")).to_eq(".json")
+      case extension(".config.json"):
+        Ok(s): expect(s).to_eq(".json")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return last extension with multiple dots", ():
-      expect(extension("archive.tar.gz")).to_eq(".gz")
+      case extension("archive.tar.gz"):
+        Ok(s): expect(s).to_eq(".gz")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return empty string for empty string", ():
-      expect(extension("")).to_eq("")
+      case extension(""):
+        Ok(s): expect(s).to_eq("")
+        Err(e): fail("unexpected error: " + e.message)
     )
     it("should return empty string for dot in directory", ():
-      expect(extension("/usr/local.d/file")).to_eq("")
+      case extension("/usr/local.d/file"):
+        Ok(s): expect(s).to_eq("")
+        Err(e): fail("unexpected error: " + e.message)
     )
   )
 

--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -265,23 +265,23 @@ case bind("127.0.0.1", 0):
 
 static const std::string HTTP_LISTEN_DECLS = HTTP_DECLS + R"(
 @native
-function listen(host: str, port: int, handler: function(HttpRequest) -> HttpResponse) -> Unit
+function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>) -> Result<Unit, Error>
 @native
-function listen(host: str, port: int, handler: function(HttpRequest) -> HttpResponse, max_requests: int) -> Unit
+function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int) -> Result<Unit, Error>
 @native
-function listen(host: str, port: int, handler: function(HttpRequest) -> HttpResponse, max_requests: int, port_callback: function(int) -> Unit) -> Unit
+function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int, port_callback: function(int) -> Unit) -> Result<Unit, Error>
 @native
 function method(req: HttpRequest) -> str
 @native
 function path(req: HttpRequest) -> str
 @native
-function response(status: int, headers: Map<str, str>, body: str) -> HttpResponse
+function response(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>
 )";
 
 TEST_F(CodeGenTest, HttpListenMaxRequests) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
 async function server() -> str:
-    listen("127.0.0.1", 18932, (req: HttpRequest) -> HttpResponse:
+    listen("127.0.0.1", 18932, (req: HttpRequest) -> Result<HttpResponse, Error>:
         return response(200, {"Content-Type": "text/plain"}, "ok")
     , 1)
     return "done"
@@ -319,7 +319,7 @@ print(result)
 TEST_F(CodeGenTest, HttpListenMaxRequestsMultiple) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
 async function server() -> str:
-    listen("127.0.0.1", 18933, (req: HttpRequest) -> HttpResponse:
+    listen("127.0.0.1", 18933, (req: HttpRequest) -> Result<HttpResponse, Error>:
         path = path(req)
         return response(200, {"Content-Type": "text/plain"}, path)
     , 2)
@@ -378,7 +378,7 @@ print(result)
 TEST_F(CodeGenTest, HttpKeepAlive) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
 async function server() -> str:
-    listen("127.0.0.1", 18934, (req: HttpRequest) -> HttpResponse:
+    listen("127.0.0.1", 18934, (req: HttpRequest) -> Result<HttpResponse, Error>:
         path = path(req)
         return response(200, {"Content-Type": "text/plain"}, path)
     , 2)
@@ -442,7 +442,7 @@ print(result)
 TEST_F(CodeGenTest, HttpConnectionClose) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
 async function server() -> str:
-    listen("127.0.0.1", 18935, (req: HttpRequest) -> HttpResponse:
+    listen("127.0.0.1", 18935, (req: HttpRequest) -> Result<HttpResponse, Error>:
         return response(200, {"Content-Type": "text/plain"}, "ok")
     , 2)
     return "done"
@@ -504,7 +504,7 @@ print(result)
 TEST_F(CodeGenTest, HttpKeepAliveWithMaxRequests) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
 async function server() -> str:
-    listen("127.0.0.1", 18936, (req: HttpRequest) -> HttpResponse:
+    listen("127.0.0.1", 18936, (req: HttpRequest) -> Result<HttpResponse, Error>:
         path = path(req)
         return response(200, {"Content-Type": "text/plain"}, path)
     , 3)


### PR DESCRIPTION
## Summary

Completes #1054 NUL-safety audit for the `http` package (previous commits covered `path`, `filesystem`, and `net`).

- Upgrades `http.listen` handler signature to `function(HttpRequest) -> Result<HttpResponse, Error>`; the listen loop synthesises a 500 response when the handler returns `Err`
- Upgrades `http.header`, `query`, `cookie`, `form_field`, `form_file`, `response`, and the client-side `header` accessor to `Result<…, Error>` — reject embedded NUL in header keys/names
- Rejects embedded NUL in HTTP client URL (`http_get`, `http_post`, `http_request`) and in `http_request` method, via codegen emitters; NUL checks live in the codegen layer, not the runtime, so C-string callers in C++ tests and internal functions (`__ry_http_post` → `__ry_http_client_request("POST", …)`) are unaffected
- Fixes binary body truncation: `Content-Length` was computed via `strlen(body)`; now uses `stringByteLen` for correct binary payloads
- Fixes header build using `std::string::operator+=` on Ry handles: replaced with byte-length-correct `append(data, byte_len)`
- Introduces `runtime_http_error.cpp` with a cross-TU `thread_local` error buffer (`DEFINE_LAST_ERROR` creates per-TU statics and cannot be shared across `runtime_http.cpp`, `runtime_http_client.cpp`, `runtime_http_multipart.cpp`)

## Test plan

- [ ] New spec tests: `tests/spec/nul_safety_http.test.ry` (3 tests) and `tests/spec/nul_safety_http_client.test.ry` (4 tests) all pass
- [ ] All 48 NUL-safety spec tests (path 19, filesystem 20, net 2, http 3, http_client 4) pass
- [ ] `./build/ry_tests` (non-network, 1768 tests) — all pass
- [ ] `./build/ry test -p` (136 test files) — 0 failures
- [ ] ASan+UBSan: 1768 C++ tests and 136 Ry self-test files clean
- [ ] TSan: 1768 C++ tests pass, no races detected
- [ ] `tests/test_codegen_http.cpp` updated to match new `Result<HttpResponse, Error>` / `Result<Unit, Error>` handler/listen signatures
- [ ] `docs/reference/http.md` fully rewritten with new signatures and a "NUL Safety" section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inputs containing embedded NUL bytes are now detected and rejected across path, filesystem, HTTP, and network APIs; HTTP client body length handling preserves binary payloads.

* **New Features**
  * Many path, filesystem, HTTP, and network APIs now return Result<..., Error> for explicit error propagation. HTTP server handlers now return Result and the listen call surfaces failures (handler Err results produce a 500 fallback).

* **Documentation**
  * Docs and knowledge notes updated with NUL-safety and Result-based API guidance.

* **Tests**
  * New and updated tests covering NUL-safety and Result-returning behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->