### PR TITLE
feat(codegen): make str ARC-managed, eliminate string leaks (#1046)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1301,21 +1301,12 @@ makeString("k\x00" "a", 3);                 // "k\x00" ends the hex sequence; "a
 
 The non-empty-delim `split` now uses `__ry_str_split` in `src/runtime_string.cpp` (replaces inline `strstr`/`strlen`/`malloc` IR). The regex ABI was extended to `(pattern, patternLen, text, textLen[, replacement, replacementLen])` across `include/ry/runtime_regex.hpp`, `src/runtime_regex.cpp`, `src/codegen_call_io.cpp`, and `src/codegen_call_string.cpp`.
 
-**`markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`** (Source: #1016):
+**`markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`, and `str` fields must also be inserted into `arc_str_managed_vars_`** (Source: #1016, updated #1046):
 TuplePattern / RecordPattern / EnumConstructorPattern pre-mark a temporary alloca
 (`tmp`) as ARC-managed so the recursive leaf `VariablePattern` binding can emit a
 single retain via `tryRetainArcSource` Case 1. Without the guard, _any_ `ptrTy_`
-field (including `str`, bare fn-ptr, and resource ptrs) is incorrectly marked,
-causing `tryRetainArcSource` to call `emitArcGetHeaderFromData(val)` — which points
-16 bytes before a plain `checked_malloc` pointer, corrupting malloc metadata. ASan
-detects this as "attempting free on address which was not malloc()-ed".
-Fix: replace `if (elemTy == ptrTy_) markArcManaged(tmp)` with
-`if (elemTy == ptrTy_ && fieldTypeIsArcManaged(elemSig, nullptr)) markArcManaged(tmp)`
-at all three sites (`src/codegen_match.cpp`). `fieldTypeIsArcManaged` resolves
-aliases and returns true only for non-weak List/Map/Set types. Capturing closure in
-tuple/record/enum fields is intentionally excluded: `fn_type_info` metadata is not
-propagated by `propagateTypeMeta` onto `ExtractValue` intermediates, so closure
-detection is impossible here; this was also the pre-#1008 behaviour.
+field (including bare fn-ptr and resource ptrs) is incorrectly marked.
+Fix (post-#1046): use `CollectionKind fk; if (fieldTypeIsArcManaged(elemSig, &fk)) { markArcManaged(tmp); if (fk == CollectionKind::Str) arc_str_managed_vars_.insert(tmp); }` at all three sites (`src/codegen_match.cpp`). `fieldTypeIsArcManaged` returns true for List/Map/Set/str and false for fn-ptr/resource/etc. The `arc_str_managed_vars_` insertion is required so `tryRetainArcSource` Case 1 dispatches to `emitStrGetHeaderFromData` (offset −24) instead of `emitArcGetHeaderFromData` (offset −16) for str fields. Capturing closure in tuple/record/enum fields is intentionally excluded: `fn_type_info` metadata is not propagated by `propagateTypeMeta` onto `ExtractValue` intermediates, so closure detection is impossible here; this was also the pre-#1008 behaviour.
 
 ### `str` does not support `[]` index syntax — guard with `isStringValue` before list/map dispatch
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1234,10 +1234,10 @@ Affected patterns and what typeSig to pass:
 2. If `val->getType() != ptrTy_` (scalar, non-ARC) → return.
 3. If `typeSig` resolves to a collection type (`isCollectionTypeName`): retain + mark ARC-managed + insert into `arc_backed_vars_`. Return.
 4. If `typeSig` is a function type (`isFunctionTypeName`): retain and mark ARC-managed **only for capturing/uniform closures** (detected via `fn_type_info` metadata on the source value). Bare function pointers are skipped. Return.
-5. If `typeSig` is `"str"` or another non-collection non-closure pointer type: do not retain (see **Do not retain `str`** below). Return.
+5. If `typeSig` is `"str"`: retain via `emitStrGetHeaderFromData` (offset −24), mark ARC-managed, insert into `arc_str_managed_vars_`. Return. (see **`str` is ARC-managed** below). Other non-collection non-closure pointer types: do not retain. Return.
 6. Otherwise (no `typeSig`): fall through to `tryRetainArcSource(val)` (source-alloca heuristic); then check `arc_owned_values_`; then check collection-type metadata set by `propagateTypeMeta`.
 
-**Do not retain `str`**: `str` values are not ARC-managed in PR #1022. Dynamic `str` values use a `StringHeader` layout (`{strong_count, weak_count, byte_len, data[], '\0'}`), where the handle points to `alloc + STRING_HEADER_SIZE (24)`. The ARC header is at `handle - 24`, but `emitArcGetHeaderFromData` uses offset `ARC_HEADER_SIZE (16)`, so retaining a `str` would point to the middle of the header (16 bytes instead of 24) → corrupts the `byte_len` field → crash. The correct approach is: only retain collections (`List<T>`, `Map<K,V>`, `Set<T>`), never bare `str`. Full ARC management of `str` (with the correct `-24` offset) is deferred to a follow-up issue after #1022.
+**`str` is ARC-managed (#1046)**: `str` values are fully ARC-managed since PR #1046. Use `emitStrGetHeaderFromData(handle)` (offset −24, `STRING_HEADER_SIZE`) — **not** `emitArcGetHeaderFromData` (offset −16, `ARC_HEADER_SIZE`) — to get the ARC header for a `str`. Dispatch via `resolveTypeAlias(typeName) == "str"` or check `arc_str_managed_vars_.count(alloca) > 0` before calling retain/release helpers. The `arc_str_managed_vars_` side-table records all AllocaInsts whose type is `str`, enabling correct offset selection in `emitArcReleaseVar`. `fieldTypeIsArcManaged("str")` returns true with `outKind = CollectionKind::Str`. Collection destructors for `List<str>`, `Map<K,str>`, `Set<str>` iterate elements and call `emitArcRelease(emitStrGetHeaderFromData(elem))` before freeing the data buffer.
 
 ### StringHeader layout — `str` memory representation (#1022)
 
@@ -3024,3 +3024,42 @@ must happen before `emitExpr`; post-emit metadata rescue (line 444-493) cannot r
 stride because `getListElementType(val)` returns i64 (truthy) and the annotation-fallback
 branch is gated on `!elemTy`. Scope: `let`/`var` declarations only — `AssignStmt`
 reassignment and inline call-argument paths are not covered.
+
+---
+
+### `List<str>` / `Map<K,str>` / `Set<str>` destructor specialization (#1046)
+
+**Source**: #1046 (2026-04-17)
+**Tags**: ARC, str, collection, destructor, List, Map, Set, memory-leak
+
+**Rule**: `getOrCreateCollectionDestructor` uses a `(CollectionKind, elemSig, valSig)` tuple cache key, not `CollectionKind` alone. Caching by kind only would produce a single generic destructor that does not release str elements, causing leaks for any `List<str>`, `Map<K,str>`, or `Set<str>`.
+
+**Why**: When `elemSig == "str"` (or `valSig == "str"` for Map values), the destructor must iterate the dense element array and call `emitArcRelease(emitStrGetHeaderFromData(elem))` for each element before freeing the buffer. The generic destructor (cache key with empty sigs) only frees the data buffer.
+
+**How to apply**: `resolveCollectionDestructor(alloca)` reads `list_elem_type_name` / `map_key_type_name` / `map_value_type_name` from the alloca's `ValueMeta` and calls `resolveTypeAlias` before passing to `getOrCreateCollectionDestructor`. Always ensure the alloca carries the correct type name metadata before this call.
+
+---
+
+### CoW copy of `List<str>` must retain str elements (#1046)
+
+**Source**: #1046 (2026-04-17)
+**Tags**: ARC, str, CoW, copy-on-write, double-free
+
+**Rule**: When CoW-copying a `List<str>` (or `Map<K,str>`, `Set<str>`), str elements **must** be retained immediately after the copy, regardless of whether the `retainElements` parameter is `true`. In `emitCowCheckSlot`, `doElemRetain` is forced `true` when `elemArcKind == CollectionKind::Str`.
+
+**Why**: Before #1046 the `List<str>` destructor did not release str elements (only freed the buffer), so no retention was needed during CoW. After #1046 the destructor releases elements — without retention the two lists (old + CoW copy) both try to release the same str elements, causing double-free.
+
+**How to apply**: In `emitCowRetainArcElements`, pass `elemArcKind` and use `emitStrGetHeaderFromData(elem)` (offset −24) when `elemArcKind == CollectionKind::Str`, otherwise `emitArcGetHeaderFromData(elem)` (offset −16). The wrong offset silently corrupts `weak_count` or `byte_len` instead of `strong_count`.
+
+---
+
+### `arc_str_managed_vars_` side-table for str ARC dispatch (#1046)
+
+**Source**: #1046 (2026-04-17)
+**Tags**: ARC, str, side-table, offset, emitStrGetHeaderFromData
+
+**Rule**: Whenever an `AllocaInst` holds a `str` value that participates in ARC (i.e., was retained on assignment), insert it into `arc_str_managed_vars_`. This side-table is the canonical way to select `emitStrGetHeaderFromData` vs `emitArcGetHeaderFromData` at release time in `emitArcReleaseVar`.
+
+**Why**: LLVM IR has no type-level distinction between a `str` handle (`ptr` at offset −24) and a collection handle (`ptr` at offset −16). Without the side-table, every release would use the wrong offset for one of the types, silently corrupting the ARC header.
+
+**How to apply**: After inserting into `arc_managed_vars_` (via `markArcManaged`) for a str-typed alloca, also insert into `arc_str_managed_vars_`. Intermediary tmp allocas created in RecordPattern / EnumConstructorPattern must be added too, so that downstream VariablePattern bindings loaded from them inherit the correct offset. Do NOT add allocas to `arc_backed_vars_` (the CoW set) for str — CoW uses `emitArcGetHeaderFromData` offset and would corrupt the str header.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3332,3 +3332,45 @@ expect(e.message).to_not_contain("NUL")
 **Why**: Before #1046, str was never ARC-managed, so no str captures reached the retain path. After #1046, a `str` variable captured by `@parallel for` entered the retain path with the wrong offset: `emitArcGetHeaderFromData` pointed to `weak_count` (not `strong_count`). Each worker retained/released `weak_count` instead. When the last worker's release decremented `weak_count` to 0, the destructor called `free()` on a literal global's static allocation → segfault.
 
 **How to apply**: Snapshot `capIsArcStr[i] = arc_str_managed_vars_.count(src) > 0` alongside `capIsArcManaged` and `capIsArcBacked` in the parent context (before `FnScope` clears the side-tables). In the thunk: after `markArcManaged(dst)`, if `capIsArcStr[i]` insert `dst` into `arc_str_managed_vars_`; at the retain site use `capIsArcStr[i] ? emitStrGetHeaderFromData(dataPtr) : emitArcGetHeaderFromData(dataPtr)`. The release via `popScope()→emitArcReleaseVar()` will then automatically select the correct offset via `arc_str_managed_vars_`.
+
+---
+
+### `emitPatternBindingArc` path 2b must propagate `arc_str_managed_vars_` from source (#1046)
+
+**Source**: #1046 (2026-04-17)
+**Tags**: ARC, str, pattern-binding, emitPatternBindingArc, arc_str_managed_vars_, segfault
+
+**Rule**: In `emitPatternBindingArc` path 2b ("no type signature — probe heuristically"), when `tryRetainArcSource(val)` returns true and `val` is a `LoadInst` from a source alloca in `arc_str_managed_vars_`, the destination `bindAlloca` must also be inserted into `arc_str_managed_vars_` — **not** into `arc_backed_vars_`. The check must mirror the full set hierarchy: closure → str → arc_backed.
+
+**Why**: `emitArcReleaseVar` dispatches on the alloca's set membership to pick the header offset. `arc_backed_vars_` members use `emitArcGetHeaderFromData` (offset −16). For a `str` value, offset −16 is the `weak_count` field, not `strong_count`. When the `strong_count` check reads `weak_count = 0` instead of `ARC_IMMORTAL`, the immortal guard is bypassed and the code tries to atomically decrement `*(handle − 16)`. Since Ry string literal globals are compiled as `isConstant=true` LLVM globals (mapped read-only by the JIT), any write to them causes a SIGSEGV.
+
+**How to apply**:
+```cpp
+// Correct propagation in emitPatternBindingArc path 2b:
+if (auto *ld = llvm::dyn_cast<llvm::LoadInst>(val)) {
+    auto *src = llvm::dyn_cast<llvm::AllocaInst>(ld->getPointerOperand());
+    if (src && closure_managed_vars_.count(src))
+        closure_managed_vars_.insert(bindAlloca);
+    else if (src && arc_str_managed_vars_.count(src))   // ← must check str before arc_backed
+        arc_str_managed_vars_.insert(bindAlloca);
+    else
+        arc_backed_vars_.insert(bindAlloca);
+} else if (arc_str_owned_values_.count(val)) {          // non-LoadInst str source
+    arc_str_managed_vars_.insert(bindAlloca);
+} else {
+    arc_backed_vars_.insert(bindAlloca);
+}
+```
+
+This matters any time a `str` is extracted from an enum field via `EnumConstructorPattern` with a `VariablePattern` binding: the tmp alloca for the field is in `arc_str_managed_vars_`, and when `emitPatternBindings` recurses into `VariablePattern`, the resulting binding alloca inherits the str classification.
+
+---
+
+### Str literal globals are `isConstant=true` — wrong offset → SIGSEGV, not SIGABRT
+
+**Source**: #1046 (2026-04-17)
+**Tags**: ARC, str, StringHeader, isConstant, LLVM, offset, segfault
+
+**Rule**: In `cachedGlobalString` (`src/codegen.cpp`), the StringHeader global for string literals is created with `isConstant=true`. The JIT maps such globals as read-only pages. Any code that uses `emitArcGetHeaderFromData` (offset −16) instead of `emitStrGetHeaderFromData` (offset −24) on a literal `str` will bypass the `ARC_IMMORTAL` guard (because `weak_count=0 ≠ INT64_MAX`), then attempt an atomic write to the read-only page → SIGSEGV (exit 139), not SIGABRT.
+
+This makes wrong-offset bugs on str literals almost always fatal immediately, which is useful for diagnosis but means the stack trace will point into JIT code at an unusual address. Cross-reference with `arc_str_managed_vars_` membership at the crashing alloca's declaration site.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3319,3 +3319,16 @@ expect(e.message).not_to_contain("NUL")
 # ✅ Correct
 expect(e.message).to_not_contain("NUL")
 ```
+
+---
+
+### `@parallel for` str captures must use `emitStrGetHeaderFromData` (#1046)
+
+**Source**: #1046 (2026-04-17)
+**Tags**: ARC, str, parallel_for, concurrency, offset, segfault
+
+**Rule**: In `emitParallelForRange` (`src/codegen_stmt_loop.cpp`), when a captured variable is a `str` (i.e., it is in `arc_str_managed_vars_`), the thunk entry retain and the `arc_str_managed_vars_` side-table insertion for the thunk-local dst alloca must both use `emitStrGetHeaderFromData` (offset −24), not `emitArcGetHeaderFromData` (offset −16).
+
+**Why**: Before #1046, str was never ARC-managed, so no str captures reached the retain path. After #1046, a `str` variable captured by `@parallel for` entered the retain path with the wrong offset: `emitArcGetHeaderFromData` pointed to `weak_count` (not `strong_count`). Each worker retained/released `weak_count` instead. When the last worker's release decremented `weak_count` to 0, the destructor called `free()` on a literal global's static allocation → segfault.
+
+**How to apply**: Snapshot `capIsArcStr[i] = arc_str_managed_vars_.count(src) > 0` alongside `capIsArcManaged` and `capIsArcBacked` in the parent context (before `FnScope` clears the side-tables). In the thunk: after `markArcManaged(dst)`, if `capIsArcStr[i]` insert `dst` into `arc_str_managed_vars_`; at the retain site use `capIsArcStr[i] ? emitStrGetHeaderFromData(dataPtr) : emitArcGetHeaderFromData(dataPtr)`. The release via `popScope()→emitArcReleaseVar()` will then automatically select the correct offset via `arc_str_managed_vars_`.

--- a/changelog.d/1046-str-arc-managed.md
+++ b/changelog.d/1046-str-arc-managed.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `str` values are now fully ARC-managed (#1046). Dynamic strings created by `+` concatenation, `repeat`, f-string interpolation, and runtime functions are automatically freed when their last reference goes out of scope, eliminating string leaks. `List<str>`, `Map<K, str>`, and `Set<str>` also release string payloads when the collection is freed.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -187,6 +188,9 @@ public:
     std::unordered_map<llvm::AllocaInst*, std::string> weak_inner_type_names_; // inner type name for upgrade
     std::unordered_map<llvm::AllocaInst*, ResourceKind> resource_managed_vars_;
     std::unordered_set<llvm::AllocaInst*> closure_managed_vars_; // allocas holding ARC-managed closures
+    // ARC-managed str tracking: str header is at handle-STRING_HEADER_SIZE (24), not handle-ARC_HEADER_SIZE (16)
+    std::unordered_set<llvm::AllocaInst*> arc_str_managed_vars_; // allocas holding str handles
+    std::unordered_set<llvm::Value*>      arc_str_owned_values_;  // str handles produced by makeString/runtime
 
     // ARC emit methods
     llvm::Value *emitArcAlloc(llvm::Value *dataSize);
@@ -246,8 +250,10 @@ public:
     void emitWeakReleaseVar(const std::string &name, llvm::AllocaInst *alloca);
 
     // ======== Copy-on-Write & Destructors ========
-    enum class CollectionKind { List, Map, Set };
-    llvm::FunctionCallee getOrCreateCollectionDestructor(CollectionKind kind);
+    enum class CollectionKind { List, Map, Set, Str };
+    llvm::FunctionCallee getOrCreateCollectionDestructor(CollectionKind kind,
+                                                          const std::string &elemSig = "",
+                                                          const std::string &valSig = "");
 
     // Predicate: does the container's *element* type itself own an
     // ARC-managed allocation that needs releasing on slot overwrite?
@@ -333,8 +339,10 @@ public:
     llvm::Value *emitCowDeepCopyList(llvm::Value *oldDataPtr, llvm::Type *elemTy);
     llvm::Value *emitCowDeepCopyMap(llvm::Value *oldDataPtr, llvm::Type *keyTy, llvm::Type *valTy);
     llvm::Value *emitCowDeepCopySet(llvm::Value *oldDataPtr, llvm::Type *elemTy);
-    void emitCowRetainArcElements(llvm::Value *buf, llvm::Value *len, const std::string &tag);
-    std::map<CollectionKind, llvm::FunctionCallee> arc_destructors_cache_;
+    void emitCowRetainArcElements(llvm::Value *buf, llvm::Value *len, const std::string &tag,
+                                   CollectionKind elemArcKind = CollectionKind::List);
+    std::map<std::tuple<CollectionKind, std::string, std::string>,
+             llvm::FunctionCallee> arc_destructors_cache_;
     llvm::FunctionCallee getOrCreateResourceDestructor(int rk);
     std::map<int, llvm::FunctionCallee> resource_destructors_cache_;
     llvm::FunctionCallee resolveDestructor(llvm::AllocaInst *alloca);

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -387,6 +387,7 @@ public:
         bool is_arc_managed = false;
         bool is_arc_atomic = false;
         bool is_resource = false;
+        bool is_str = false; // str uses offset -24 (STRING_HEADER_SIZE), not -16
         // Destructor resolved at registration time; may be empty for values
         // that do not need one.
         llvm::FunctionCallee destructor{};

--- a/include/ry/runtime_error.hpp
+++ b/include/ry/runtime_error.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ry/runtime_alloc.hpp"
+#include "ry/runtime_string.hpp"
 
 #include <cstdarg>
 #include <cstdio>
@@ -33,7 +34,7 @@ namespace ry {
     }                                                                          \
                                                                                \
     extern "C" const char *__ry_##prefix##_get_last_error() {                  \
-        return checked_strdup(last_error_buf);                                  \
+        return makeString(last_error_buf, strlen(last_error_buf));              \
     }
 
 } // namespace ry

--- a/include/ry/runtime_error.hpp
+++ b/include/ry/runtime_error.hpp
@@ -16,7 +16,7 @@ namespace ry {
 //   - extern "C" const char *__ry_<prefix>_get_last_error()
 //
 // Each expansion creates an independent thread-local buffer per module.
-// The getter returns a strdup'd copy (caller owns the memory).
+// The getter returns a makeString-allocated ARC-managed str handle (strong_count=1).
 //
 // Place at file scope (outside anonymous namespaces) because the getter
 // needs external C linkage.

--- a/include/ry/runtime_string.hpp
+++ b/include/ry/runtime_string.hpp
@@ -21,9 +21,10 @@
 // 1. All `str` values are StringHeader handles (either immortal literal globals
 //    or dynamically allocated with makeString/makeStringUninit).
 // 2. handle[byte_len] == '\0' always (null terminator for C library compat).
-// 3. In PR #1022, str is NOT yet ARC-managed by codegen:
-//    fieldTypeIsArcManaged("str") remains false.  makeString sets strong_count=1
-//    as a forward-compat marker, but retain/release are never emitted for str.
+// 3. Since PR #1046, str IS ARC-managed by codegen: fieldTypeIsArcManaged("str")
+//    returns true, retain/release are emitted, and collection destructors release
+//    str elements.  Use emitStrGetHeaderFromData (offset −24) not
+//    emitArcGetHeaderFromData (offset −16) when computing the ARC header.
 // 4. Literal globals use ARC_IMMORTAL for strong_count (no-op on any retain).
 
 namespace ry {
@@ -37,7 +38,7 @@ inline int64_t stringByteLen(const char *handle) {
 
 // Return a pointer to the beginning of the StringHeader for `handle`
 // (i.e. handle - STRING_HEADER_SIZE).  This points to strong_count.
-// Provided for forward-compat; full ARC management of str comes in a later PR.
+// Equivalent to emitStrGetHeaderFromData in codegen.
 inline char *stringHeaderPtr(const char *handle) {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
     return const_cast<char *>(handle) - static_cast<ptrdiff_t>(STRING_HEADER_SIZE);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -472,6 +472,7 @@ void CodeGen::registerModuleGlobal(const std::string &name,
     mb.is_arc_managed = isArcManaged(alloca);
     mb.is_arc_atomic = arc_atomic_values_.count(alloca) > 0;
     mb.is_resource = resource_managed_vars_.count(alloca) > 0;
+    mb.is_str = arc_str_managed_vars_.count(alloca) > 0;
     mb.destructor = resolveDestructor(alloca);
     module_globals_[name] = mb;
 }

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -502,6 +502,22 @@ bool CodeGen::recordHasArcFields(llvm::StructType *st) {
     return false;
 }
 
+// Trace an InsertValue chain to find the original value inserted at a given
+// field index.  LLVM's ConstantFolder does NOT fold
+//   ExtractValue(InsertValue(agg, v, {i}), {i}) → v
+// for non-constant aggregates, so the ExtractValue result is a fresh
+// instruction that is never in arc_owned_values_ / arc_str_owned_values_.
+// This helper recovers the original inserted operand so that ownership
+// checks work correctly for record construction IR.
+static llvm::Value *traceInsertValueField(llvm::Value *agg, unsigned idx) {
+    while (auto *iv = llvm::dyn_cast<llvm::InsertValueInst>(agg)) {
+        if (iv->getIndices().size() == 1 && iv->getIndices()[0] == idx)
+            return iv->getInsertedValueOperand();
+        agg = iv->getAggregateOperand();
+    }
+    return nullptr;
+}
+
 void CodeGen::emitRecordArcFieldsRetain(llvm::Value *recordVal,
                                           llvm::StructType *st) {
     if (!st || !st->hasName())
@@ -523,7 +539,14 @@ void CodeGen::emitRecordArcFieldsRetain(llvm::Value *recordVal,
         // becomes the sole owner so no retain is needed.  Named-variable values (loaded
         // from arc_backed_vars_ / arc_str_managed_vars_ allocas) are reference copies
         // that require a retain.
-        if (arc_owned_values_.count(fieldVal) || arc_str_owned_values_.count(fieldVal))
+        //
+        // For InsertValue construction IR, CreateExtractValue yields a fresh
+        // instruction not in the owned sets.  Trace the original operand instead.
+        llvm::Value *checkVal = fieldVal;
+        if (llvm::isa<llvm::InsertValueInst>(recordVal))
+            if (auto *orig = traceInsertValueField(recordVal, i))
+                checkVal = orig;
+        if (arc_owned_values_.count(checkVal) || arc_str_owned_values_.count(checkVal))
             continue;
         // Null guard — freshly-inserted fields are always non-null in
         // practice but cheap to defend against for robustness.

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -375,12 +375,24 @@ llvm::FunctionCallee CodeGen::getOrCreateResourceDestructor(int rk) {
 }
 
 llvm::FunctionCallee CodeGen::resolveCollectionDestructor(llvm::AllocaInst *alloca) {
-    if (getTypeMeta(TypeMeta::ListElem, alloca))
-        return getOrCreateCollectionDestructor(CollectionKind::List);
-    if (getTypeMeta(TypeMeta::MapKey, alloca))
-        return getOrCreateCollectionDestructor(CollectionKind::Map);
-    if (getTypeMeta(TypeMeta::SetElem, alloca))
-        return getOrCreateCollectionDestructor(CollectionKind::Set);
+    auto *meta = getMeta(alloca);
+    if (getTypeMeta(TypeMeta::ListElem, alloca)) {
+        std::string elem = (meta && !meta->list_elem_type_name.empty())
+            ? resolveTypeAlias(meta->list_elem_type_name) : "";
+        return getOrCreateCollectionDestructor(CollectionKind::List, elem, "");
+    }
+    if (getTypeMeta(TypeMeta::MapKey, alloca)) {
+        std::string key = (meta && !meta->map_key_type_name.empty())
+            ? resolveTypeAlias(meta->map_key_type_name) : "";
+        std::string val = (meta && !meta->map_value_type_name.empty())
+            ? resolveTypeAlias(meta->map_value_type_name) : "";
+        return getOrCreateCollectionDestructor(CollectionKind::Map, key, val);
+    }
+    if (getTypeMeta(TypeMeta::SetElem, alloca)) {
+        std::string elem = (meta && !meta->set_elem_type_name.empty())
+            ? resolveTypeAlias(meta->set_elem_type_name) : "";
+        return getOrCreateCollectionDestructor(CollectionKind::Set, elem, "");
+    }
     return {};
 }
 
@@ -396,7 +408,9 @@ void CodeGen::emitArcReleaseVar(const std::string &name, llvm::AllocaInst *alloc
     builder_.CreateCondBr(isNull, skipBB, releaseBB);
 
     builder_.SetInsertPoint(releaseBB);
-    auto *headerPtr = emitArcGetHeaderFromData(val);
+    const bool isStrVar = arc_str_managed_vars_.count(alloca) > 0;
+    auto *headerPtr = isStrVar ? emitStrGetHeaderFromData(val)
+                               : emitArcGetHeaderFromData(val);
 
     // Look up GC visit function for potentially cyclic types.
     llvm::Function *gcVisitFn = nullptr;
@@ -405,7 +419,10 @@ void CodeGen::emitArcReleaseVar(const std::string &name, llvm::AllocaInst *alloc
         gcVisitFn = getOrCreateVisitFunction(meta->enum_value_type);
     }
 
-    emitArcRelease(headerPtr, isArcAtomic(val), resolveDestructor(alloca), gcVisitFn);
+    // str values have no inner destructor (StringHeader has no child allocations).
+    llvm::FunctionCallee destructor = isStrVar ? llvm::FunctionCallee{}
+                                               : resolveDestructor(alloca);
+    emitArcRelease(headerPtr, isArcAtomic(val), destructor, gcVisitFn);
     builder_.CreateBr(skipBB);
 
     builder_.SetInsertPoint(skipBB);
@@ -448,6 +465,12 @@ bool CodeGen::fieldTypeIsArcManaged(const std::string &fieldTypeName,
     const std::string resolved = resolveTypeAlias(fieldTypeName);
     if (isWeakTypeName(resolved))
         return false;
+    if (resolved == "str") {
+        // str is ARC-managed via StringHeader (handle - STRING_HEADER_SIZE = 24).
+        // CollectionKind::Str signals callers to use emitStrGetHeaderFromData.
+        if (outFieldKind) *outFieldKind = CollectionKind::Str;
+        return true;
+    }
     if (isListTypeName(resolved)) {
         if (outFieldKind) *outFieldKind = CollectionKind::List;
         return true;
@@ -495,6 +518,13 @@ void CodeGen::emitRecordArcFieldsRetain(llvm::Value *recordVal,
             continue;
         llvm::Value *fieldVal = builder_.CreateExtractValue(
             recordVal, i, fd.name + ".record_retain");
+        // Skip freshly-owned values: inline list/str allocations (in arc_owned_values_ /
+        // arc_str_owned_values_) are being transferred into the record — the record
+        // becomes the sole owner so no retain is needed.  Named-variable values (loaded
+        // from arc_backed_vars_ / arc_str_managed_vars_ allocas) are reference copies
+        // that require a retain.
+        if (arc_owned_values_.count(fieldVal) || arc_str_owned_values_.count(fieldVal))
+            continue;
         // Null guard — freshly-inserted fields are always non-null in
         // practice but cheap to defend against for robustness.
         auto *isNull = builder_.CreateICmpEQ(
@@ -506,7 +536,8 @@ void CodeGen::emitRecordArcFieldsRetain(llvm::Value *recordVal,
         auto *skipBB = llvm::BasicBlock::Create(*ctx_, "record.field_retain_skip", fn);
         builder_.CreateCondBr(isNull, skipBB, retainBB);
         builder_.SetInsertPoint(retainBB);
-        auto *hdr = emitArcGetHeaderFromData(fieldVal);
+        auto *hdr = (fk == CollectionKind::Str) ? emitStrGetHeaderFromData(fieldVal)
+                                                 : emitArcGetHeaderFromData(fieldVal);
         emitArcRetain(hdr, /*atomic=*/false);
         builder_.CreateBr(skipBB);
         builder_.SetInsertPoint(skipBB);
@@ -559,6 +590,9 @@ bool CodeGen::elementTypeIsArcManaged(llvm::Value *containerPtr,
     case CollectionKind::Set:
         elemTypeName = &meta->set_elem_type_name;
         break;
+    case CollectionKind::Str:
+        // str is a scalar, not a container — no nested element type.
+        return false;
     }
     if (!elemTypeName)
         return false;
@@ -737,7 +771,8 @@ void CodeGen::emitWeakReleaseVar(const std::string &name, llvm::AllocaInst *allo
 void CodeGen::retainArcValue(llvm::Value *val) {
     if (tryRetainArcSource(val))
         return;
-    auto *hdr = emitArcGetHeaderFromData(val);
+    const bool isStr = arc_str_owned_values_.count(val) > 0;
+    auto *hdr = isStr ? emitStrGetHeaderFromData(val) : emitArcGetHeaderFromData(val);
     emitArcRetain(hdr, /*atomic=*/false);
 }
 
@@ -746,7 +781,9 @@ bool CodeGen::tryRetainArcSource(llvm::Value *val) {
     if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val)) {
         auto *srcAlloca = llvm::dyn_cast<llvm::AllocaInst>(load->getPointerOperand());
         if (srcAlloca && isArcManaged(srcAlloca)) {
-            auto *hdr = emitArcGetHeaderFromData(val);
+            const bool isStr = arc_str_managed_vars_.count(srcAlloca) > 0;
+            auto *hdr = isStr ? emitStrGetHeaderFromData(val)
+                              : emitArcGetHeaderFromData(val);
             emitArcRetain(hdr, isArcAtomic(val));
             return true;
         }
@@ -755,6 +792,10 @@ bool CodeGen::tryRetainArcSource(llvm::Value *val) {
     // These already have strong_count=1 from allocation, no retain needed,
     // but signal to caller that this is ARC-owned
     if (arc_owned_values_.count(val))
+        return true;
+    // Case 2b: str value produced by a runtime function (makeString-backed).
+    // strong_count=1 from makeString, so no retain needed.
+    if (arc_str_owned_values_.count(val))
         return true;
     // Case 3: ExtractValueInst — record/tuple field access (CreateExtractValue).
     // Guard on collection metadata so closures, weak refs, and other non-ARC
@@ -770,8 +811,11 @@ bool CodeGen::tryRetainArcSource(llvm::Value *val) {
     return false;
 }
 
-llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kind) {
-    auto it = arc_destructors_cache_.find(kind);
+llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kind,
+                                                               const std::string &elemSig,
+                                                               const std::string &valSig) {
+    auto cacheKey = std::make_tuple(kind, elemSig, valSig);
+    auto it = arc_destructors_cache_.find(cacheKey);
     if (it != arc_destructors_cache_.end())
         return it->second;
 
@@ -783,13 +827,19 @@ llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kin
     switch (kind) {
     case CollectionKind::List:
         name = "__ry_arc_dtor_list";
+        if (elemSig == "str") name += "_str";
         break;
     case CollectionKind::Map:
         name = "__ry_arc_dtor_map";
+        if (elemSig == "str") name += "_kstr";
+        if (valSig == "str") name += "_vstr";
         break;
     case CollectionKind::Set:
         name = "__ry_arc_dtor_set";
+        if (elemSig == "str") name += "_str";
         break;
+    case CollectionKind::Str:
+        llvm_unreachable("getOrCreateCollectionDestructor called with CollectionKind::Str");
     }
 
     auto *dtorFn = llvm::Function::Create(
@@ -806,22 +856,90 @@ llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kin
     auto *dataPtr = dtorFn->getArg(0);
     auto freeFn = getStdlibFree();
 
+    // Helper: emit a counted loop that ARC-releases each str element in a
+    // dense ptr-array [0, len).  After the call builder_ is in post_loop BB.
+    auto emitStrElemLoop = [&](llvm::Value *arrayPtr, llvm::Value *len,
+                                const char *tag) {
+        auto *loopHdrBB  = llvm::BasicBlock::Create(*ctx_,
+            std::string("dtor_lhdr_") + tag, dtorFn);
+        auto *loopBodyBB = llvm::BasicBlock::Create(*ctx_,
+            std::string("dtor_lbody_") + tag, dtorFn);
+        auto *doRelBB    = llvm::BasicBlock::Create(*ctx_,
+            std::string("dtor_dorel_") + tag, dtorFn);
+        auto *latchBB    = llvm::BasicBlock::Create(*ctx_,
+            std::string("dtor_latch_") + tag, dtorFn);
+        auto *postBB     = llvm::BasicBlock::Create(*ctx_,
+            std::string("dtor_post_") + tag, dtorFn);
+
+        auto *prevBB = builder_.GetInsertBlock();
+        builder_.CreateBr(loopHdrBB);
+
+        // loop header: phi i=0/i_next, exit when i == len
+        builder_.SetInsertPoint(loopHdrBB);
+        auto *iPhi = builder_.CreatePHI(i64Ty_, 2,
+            std::string("dtor_i_") + tag);
+        iPhi->addIncoming(llvm::ConstantInt::get(i64Ty_, 0), prevBB);
+        auto *done = builder_.CreateICmpEQ(iPhi, len,
+            std::string("dtor_done_") + tag);
+        builder_.CreateCondBr(done, postBB, loopBodyBB);
+
+        // loop body: load element, skip if null
+        builder_.SetInsertPoint(loopBodyBB);
+        auto *elemGEP = builder_.CreateGEP(ptrTy_, arrayPtr, {iPhi},
+            std::string("dtor_egep_") + tag);
+        auto *elem = builder_.CreateLoad(ptrTy_, elemGEP,
+            std::string("dtor_elem_") + tag);
+        auto *isNull = builder_.CreateICmpEQ(elem,
+            llvm::ConstantPointerNull::get(
+                llvm::cast<llvm::PointerType>(ptrTy_)),
+            std::string("dtor_null_") + tag);
+        builder_.CreateCondBr(isNull, latchBB, doRelBB);
+
+        // do_rel: ARC-release the str element
+        builder_.SetInsertPoint(doRelBB);
+        auto *hdr = emitStrGetHeaderFromData(elem);
+        emitArcRelease(hdr, /*atomic=*/false, {}, nullptr);
+        // emitArcRelease leaves builder_ in its doneBB
+        builder_.CreateBr(latchBB);
+
+        // latch: increment i and loop back
+        builder_.SetInsertPoint(latchBB);
+        auto *iNext = builder_.CreateAdd(iPhi,
+            llvm::ConstantInt::get(i64Ty_, 1),
+            std::string("dtor_inext_") + tag);
+        iPhi->addIncoming(iNext, latchBB);
+        builder_.CreateBr(loopHdrBB);
+
+        builder_.SetInsertPoint(postBB);
+    };
+
     switch (kind) {
     case CollectionKind::List: {
-        // Free data buffer: ListHeader { len, cap, data }
+        // ListHeader { i64 len, i64 cap, ptr data }
+        auto *lenField = builder_.CreateStructGEP(listHeaderTy_, dataPtr, 0, "dtor_len_f");
+        auto *len = builder_.CreateLoad(i64Ty_, lenField, "dtor_len");
         auto *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, dataPtr, 2, "dtor_data_field");
         auto *dataBuf = builder_.CreateLoad(ptrTy_, dataPtrField, "dtor_data_buf");
+        if (elemSig == "str")
+            emitStrElemLoop(dataBuf, len, "lst");
         builder_.CreateCall(freeFn, {dataBuf});
         break;
     }
     case CollectionKind::Map: {
-        // Free keys, values, and buckets buffers
+        // MapHeader { i64 len, i64 cap, ptr keys, ptr vals, i64 bucket_count, ptr buckets }
+        auto *lenField = builder_.CreateStructGEP(mapHeaderTy_, dataPtr, 0, "dtor_len_f");
+        auto *len = builder_.CreateLoad(i64Ty_, lenField, "dtor_len");
+
         auto *keysField = builder_.CreateStructGEP(mapHeaderTy_, dataPtr, 2, "dtor_keys_field");
         auto *keys = builder_.CreateLoad(ptrTy_, keysField, "dtor_keys");
+        if (elemSig == "str")
+            emitStrElemLoop(keys, len, "mkey");
         builder_.CreateCall(freeFn, {keys});
 
         auto *valsField = builder_.CreateStructGEP(mapHeaderTy_, dataPtr, 3, "dtor_vals_field");
         auto *vals = builder_.CreateLoad(ptrTy_, valsField, "dtor_vals");
+        if (valSig == "str")
+            emitStrElemLoop(vals, len, "mval");
         builder_.CreateCall(freeFn, {vals});
 
         auto *bucketsField = builder_.CreateStructGEP(mapHeaderTy_, dataPtr, 5, "dtor_buckets_field");
@@ -830,9 +948,14 @@ llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kin
         break;
     }
     case CollectionKind::Set: {
-        // Free elements and buckets buffers
+        // SetHeader { i64 len, i64 cap, ptr elems, i64 bucket_count, ptr buckets }
+        auto *lenField = builder_.CreateStructGEP(setHeaderTy_, dataPtr, 0, "dtor_len_f");
+        auto *len = builder_.CreateLoad(i64Ty_, lenField, "dtor_len");
+
         auto *elemsField = builder_.CreateStructGEP(setHeaderTy_, dataPtr, 2, "dtor_elems_field");
         auto *elems = builder_.CreateLoad(ptrTy_, elemsField, "dtor_elems");
+        if (elemSig == "str")
+            emitStrElemLoop(elems, len, "set");
         builder_.CreateCall(freeFn, {elems});
 
         auto *bucketsField = builder_.CreateStructGEP(setHeaderTy_, dataPtr, 4, "dtor_buckets_field");
@@ -840,6 +963,8 @@ llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kin
         builder_.CreateCall(freeFn, {buckets});
         break;
     }
+    case CollectionKind::Str:
+        llvm_unreachable("getOrCreateCollectionDestructor: Str has no collection destructor");
     }
 
     builder_.CreateRetVoid();
@@ -849,7 +974,7 @@ llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kin
         builder_.SetInsertPoint(savedBB, savedPt);
 
     llvm::FunctionCallee callee(dtorTy, dtorFn);
-    arc_destructors_cache_[kind] = callee;
+    arc_destructors_cache_[cacheKey] = callee;
     return callee;
 }
 

--- a/src/codegen_arc_cow.cpp
+++ b/src/codegen_arc_cow.cpp
@@ -14,7 +14,8 @@ llvm::AllocaInst *CodeGen::tryGetReceiverAlloca(const ExprNode &expr) {
 }
 
 void CodeGen::emitCowRetainArcElements(llvm::Value *buf, llvm::Value *len,
-                                        const std::string &tag) {
+                                        const std::string &tag,
+                                        CollectionKind elemArcKind) {
     auto *fn = builder_.GetInsertBlock()->getParent();
     auto *loopBB = llvm::BasicBlock::Create(*ctx_, "cow." + tag + "_loop", fn);
     auto *bodyBB = llvm::BasicBlock::Create(*ctx_, "cow." + tag + "_body", fn);
@@ -31,7 +32,9 @@ void CodeGen::emitCowRetainArcElements(llvm::Value *buf, llvm::Value *len,
     builder_.SetInsertPoint(bodyBB);
     auto *elemPtr = builder_.CreateGEP(ptrTy_, buf, idx, "cow_" + tag + "_ptr");
     auto *elem = builder_.CreateLoad(ptrTy_, elemPtr, "cow_" + tag + "_val");
-    auto *hdr = emitArcGetHeaderFromData(elem);
+    // str elements have StringHeader at offset -24; other ARC objects at -16.
+    auto *hdr = (elemArcKind == CollectionKind::Str)
+        ? emitStrGetHeaderFromData(elem) : emitArcGetHeaderFromData(elem);
     emitArcRetain(hdr, false);
     auto *next = builder_.CreateAdd(idx, llvm::ConstantInt::get(i64Ty_, 1), "cow_" + tag + "_next");
     idx->addIncoming(next, builder_.GetInsertBlock());
@@ -221,8 +224,11 @@ llvm::Value *CodeGen::emitCowCheckSlot(llvm::Value *dataPtr,
     // to drive the retain loop from here rather than from
     // `emitCowDeepCopyList` so the decision uses the correct source.
     CollectionKind elemArcKind = CollectionKind::List;
-    bool doElemRetain =
-        retainElements && elementTypeIsArcManaged(dataPtr, kind, &elemArcKind);
+    bool hasArcElems = elementTypeIsArcManaged(dataPtr, kind, &elemArcKind);
+    // str elements: destructor now releases them, so we must always retain
+    // during CoW to keep reference counts balanced (#1046).
+    bool doElemRetain = hasArcElems &&
+        (retainElements || elemArcKind == CollectionKind::Str);
 
     llvm::Value *newDataPtr = nullptr;
     switch (kind) {
@@ -246,6 +252,9 @@ llvm::Value *CodeGen::emitCowCheckSlot(llvm::Value *dataPtr,
         newDataPtr = emitCowDeepCopySet(dataPtr, elemTy);
         break;
     }
+    case CollectionKind::Str:
+        // str is immutable — CoW is not applicable; this path should never be reached.
+        llvm_unreachable("emitCowClone: CollectionKind::Str is not a CoW container");
     }
 
     // Retain each ARC-managed element in the cloned buffer so the clone
@@ -279,8 +288,10 @@ llvm::Value *CodeGen::emitCowCheckSlot(llvm::Value *dataPtr,
             elemBuf = builder_.CreateLoad(ptrTy_, elemsField, "cow_ret_elems");
             break;
         }
+        case CollectionKind::Str:
+            llvm_unreachable("emitCowClone retain loop: CollectionKind::Str is not a CoW container");
         }
-        emitCowRetainArcElements(elemBuf, elemLen, "cow_elem");
+        emitCowRetainArcElements(elemBuf, elemLen, "cow_elem", elemArcKind);
     }
 
     // Reuse headerPtr (dominates copyBB) instead of re-computing

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -198,8 +198,10 @@ llvm::Value *CodeGen::emitStrOp_substring(const CallExpr &e) {
             if (sv >= 0 && ev >= 0 && ev >= sv) {
                 auto substrFn = getRuntimeFn("__ry_utf8_substring", ptrTy_,
                                              {ptrTy_, i64Ty_, i64Ty_, i64Ty_});
-                return builder_.CreateCall(substrFn, {s, emitStringByteLen(s), start, end},
-                                           "substring");
+                auto *r = builder_.CreateCall(substrFn, {s, emitStringByteLen(s), start, end},
+                                              "substring");
+                arc_str_owned_values_.insert(r);
+                return r;
             }
         }
     }
@@ -218,8 +220,10 @@ llvm::Value *CodeGen::emitStrOp_substring(const CallExpr &e) {
         builder_.CreateICmpSLT(clampedEnd, clampedStart), clampedStart, clampedEnd, "substr_cend2");
 
     auto substrFn = getRuntimeFn("__ry_utf8_substring", ptrTy_, {ptrTy_, i64Ty_, i64Ty_, i64Ty_});
-    return builder_.CreateCall(substrFn, {s, emitStringByteLen(s), clampedStart, clampedEnd},
-                               "substring");
+    auto *r = builder_.CreateCall(substrFn, {s, emitStringByteLen(s), clampedStart, clampedEnd},
+                                  "substring");
+    arc_str_owned_values_.insert(r);
+    return r;
 }
 
 // char_at(s, i) → str (single UTF-8 character as string)
@@ -234,7 +238,9 @@ llvm::Value *CodeGen::emitStrOp_char_at(const CallExpr &e) {
         idx = builder_.CreateZExt(idx, i64Ty_, "char_at_idx");
 
     auto fn = getRuntimeFn("__ry_utf8_char_at_checked", ptrTy_, {ptrTy_, i64Ty_, i64Ty_});
-    return builder_.CreateCall(fn, {s, emitStringByteLen(s), idx}, "char_at");
+    auto *r = builder_.CreateCall(fn, {s, emitStringByteLen(s), idx}, "char_at");
+    arc_str_owned_values_.insert(r);
+    return r;
 }
 
 // replace(s, old, new) → str
@@ -248,11 +254,13 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
     if (isRegex(oldStr) && isStringValue(s)) {
         auto fn = mod_->getOrInsertFunction("__ry_regex_replace",
                                             fnTy_ptr_i64_ptr_i64_ptr_i64_to_ptr_);
-        return builder_.CreateCall(fn,
+        auto *r = builder_.CreateCall(fn,
             {oldStr, emitStringByteLen(oldStr),
              s,      emitStringByteLen(s),
              newStr, emitStringByteLen(newStr)},
             "regex_replace");
+        arc_str_owned_values_.insert(r);
+        return r;
     }
     if (s->getType() != ptrTy_ || oldStr->getType() != ptrTy_ || newStr->getType() != ptrTy_)
         codegenError("replace() requires str arguments");
@@ -262,8 +270,10 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
     llvm::Value *newLen = emitStringByteLen(newStr);
     auto replaceFn = getRuntimeFn("__ry_str_replace", ptrTy_,
                                   {ptrTy_, i64Ty_, ptrTy_, i64Ty_, ptrTy_, i64Ty_});
-    return builder_.CreateCall(replaceFn, {s, sLen, oldStr, oldLen, newStr, newLen},
-                               "replace_result");
+    auto *r = builder_.CreateCall(replaceFn, {s, sLen, oldStr, oldLen, newStr, newLen},
+                                  "replace_result");
+    arc_str_owned_values_.insert(r);
+    return r;
 }
 
 // to_upper(s) → str
@@ -305,6 +315,7 @@ llvm::Value *CodeGen::emitStrOp_to_upper(const CallExpr &e) {
     builder_.CreateBr(condBB);
 
     builder_.SetInsertPoint(endBB);
+    arc_str_owned_values_.insert(buf);
     return buf;
 }
 
@@ -347,6 +358,7 @@ llvm::Value *CodeGen::emitStrOp_to_lower(const CallExpr &e) {
     builder_.CreateBr(condBB);
 
     builder_.SetInsertPoint(endBB);
+    arc_str_owned_values_.insert(buf);
     return buf;
 }
 
@@ -427,6 +439,7 @@ llvm::Value *CodeGen::emitStrOp_trim(const CallExpr &e) {
     llvm::Value *buf = builder_.CreateCall(makeUninitFn, {safeLen}, "trim_buf");
     llvm::Value *srcPtr = builder_.CreateGEP(builder_.getInt8Ty(), s, finalStart, "trim_src");
     builder_.CreateCall(memcpyFn, {buf, srcPtr, safeLen});
+    arc_str_owned_values_.insert(buf);
     return buf;
 }
 
@@ -471,6 +484,7 @@ llvm::Value *CodeGen::emitStrOp_trim_start(const CallExpr &e) {
     llvm::Value *buf = builder_.CreateCall(makeUninitFn, {resultLen}, "tstart_buf");
     llvm::Value *srcPtr = builder_.CreateGEP(builder_.getInt8Ty(), s, finalStart, "tstart_src");
     builder_.CreateCall(memcpyFn, {buf, srcPtr, resultLen});
+    arc_str_owned_values_.insert(buf);
     return buf;
 }
 
@@ -515,6 +529,7 @@ llvm::Value *CodeGen::emitStrOp_trim_end(const CallExpr &e) {
     auto makeUninitFn = mod_->getOrInsertFunction("__ry_string_make_uninit", makeUninitTy);
     llvm::Value *buf = builder_.CreateCall(makeUninitFn, {finalEnd}, "tend_buf");
     builder_.CreateCall(memcpyFn, {buf, s, finalEnd});
+    arc_str_owned_values_.insert(buf);
     return buf;
 }
 
@@ -590,7 +605,9 @@ llvm::Value *CodeGen::emitStrOp_reverse(const CallExpr &e) {
         codegenError("reverse() requires list or str argument");
 
     auto revFn = getRuntimeFn("__ry_utf8_reverse", ptrTy_, {ptrTy_, i64Ty_});
-    return builder_.CreateCall(revFn, {s, emitStringByteLen(s)}, "str_rev");
+    auto *r = builder_.CreateCall(revFn, {s, emitStringByteLen(s)}, "str_rev");
+    arc_str_owned_values_.insert(r);
+    return r;
 }
 
 // reverse!(list) → in-place reverse
@@ -793,6 +810,7 @@ llvm::Value *CodeGen::emitStrOp_join(const CallExpr &e) {
     builder_.CreateBr(buildCondBB);
 
     builder_.SetInsertPoint(buildEndBB);
+    arc_str_owned_values_.insert(buf);
     return buf;
 }
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1260,6 +1260,7 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
         builder_.CreateCall(getStdlibMemcpy(), {buf, lhs, lenL});
         llvm::Value *dst = builder_.CreateGEP(i8Ty_, buf, lenL, "concat_dst");
         builder_.CreateCall(getStdlibMemcpy(), {dst, rhs, lenR});
+        arc_str_owned_values_.insert(buf);
         return buf;
     }
 

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -357,6 +357,7 @@ llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
     llvm::PHINode *result = builder_.CreatePHI(ptrTy_, 2, "str_rep_result");
     result->addIncoming(emptyStr, emptyBB);
     result->addIncoming(buf, doneBB);
+    arc_str_owned_values_.insert(result);
     return result;
 }
 

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -503,11 +503,16 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 // VariablePattern binding can detect them via tryRetainArcSource and
                 // emit a single retain.  The tmp alloca is not in scope_stack_ so
                 // there is no matching release — varAlloca owns the refcount.
-                // Only mark collection types (List/Map/Set); str, bare fn-ptr, and
-                // other ptrTy_ values are NOT ARC-managed and must not be retained
-                // here — doing so corrupts malloc metadata (see #1016).
-                if (elemTy == ptrTy_ && fieldTypeIsArcManaged(elemSig, nullptr))
-                    markArcManaged(tmp);
+                // For str fields, also register in arc_str_managed_vars_ so that
+                // tryRetainArcSource Case 1 uses emitStrGetHeaderFromData (offset -24).
+                if (elemTy == ptrTy_) {
+                    CollectionKind fk;
+                    if (fieldTypeIsArcManaged(elemSig, &fk)) {
+                        markArcManaged(tmp);
+                        if (fk == CollectionKind::Str)
+                            arc_str_managed_vars_.insert(tmp);
+                    }
+                }
                 // Guard: only pass elemSig as subjectEnumType when it names an actual enum.
                 // Passing a primitive type name ("int", "str", etc.) would set enum_value_type
                 // to a non-enum name in VariablePattern binding and crash valueToString().

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -534,11 +534,17 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 // VariablePattern binding can detect them via tryRetainArcSource and
                 // emit a single retain.  The tmp alloca is not in scope_stack_ so
                 // there is no matching release — varAlloca owns the refcount.
-                // Only mark collection types (List/Map/Set); str, bare fn-ptr, and
-                // other ptrTy_ values are NOT ARC-managed and must not be retained
-                // here — doing so corrupts malloc metadata (see #1016).
-                if (elemTy == ptrTy_ && fieldTypeIsArcManaged(elemSig, nullptr))
-                    markArcManaged(tmp);
+                // For str fields, also register in arc_str_managed_vars_ so that
+                // tryRetainArcSource Case 1 uses emitStrGetHeaderFromData (offset -24)
+                // instead of emitArcGetHeaderFromData (offset -16).
+                if (elemTy == ptrTy_) {
+                    CollectionKind fk;
+                    if (fieldTypeIsArcManaged(elemSig, &fk)) {
+                        markArcManaged(tmp);
+                        if (fk == CollectionKind::Str)
+                            arc_str_managed_vars_.insert(tmp);
+                    }
+                }
                 // Pass elemSig as subjectEnumType only for enum types; primitive and collection
                 // types are already handled by propagateTypeMeta above. Passing "int" or "str"
                 // as subjectEnumType would cause VariablePattern binding to set enum_value_type
@@ -590,11 +596,16 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                         // VariablePattern binding can detect them via tryRetainArcSource and
                         // emit a single retain.  The tmp alloca is not in scope_stack_ so
                         // there is no matching release — varAlloca owns the refcount.
-                        // Only mark collection types (List/Map/Set); str, bare fn-ptr, and
-                        // other ptrTy_ values are NOT ARC-managed and must not be retained
-                        // here — doing so corrupts malloc metadata (see #1016).
-                        if (fieldTy == ptrTy_ && fieldTypeIsArcManaged(fieldTypeName, nullptr))
-                            markArcManaged(tmp);
+                        // For str fields, also register in arc_str_managed_vars_ so that
+                        // tryRetainArcSource Case 1 uses emitStrGetHeaderFromData (offset -24).
+                        if (fieldTy == ptrTy_) {
+                            CollectionKind fk2;
+                            if (fieldTypeIsArcManaged(fieldTypeName, &fk2)) {
+                                markArcManaged(tmp);
+                                if (fk2 == CollectionKind::Str)
+                                    arc_str_managed_vars_.insert(tmp);
+                            }
+                        }
                         // Guard: only pass fieldTypeName as subjectEnumType when it names a known enum.
                         // Passing a primitive type name ("int", "str", etc.) would crash valueToString().
                         const std::string resolvedFieldType = resolveTypeAlias(fieldTypeName);
@@ -664,6 +675,17 @@ void CodeGen::emitPatternBindingArc(llvm::Value *val, llvm::AllocaInst *bindAllo
                 closure_managed_vars_.insert(bindAlloca);
             }
             // Bare function pointer: no ARC management.
+            return;
+        }
+        if (resolved == "str") {
+            // str is ARC-managed. Header is at handle-STRING_HEADER_SIZE (24).
+            // Immortal literals are no-ops; dynamic strs increment strong_count.
+            if (!tryRetainArcSource(val)) {
+                auto *hdr = emitStrGetHeaderFromData(val);
+                emitArcRetain(hdr, /*atomic=*/false);
+            }
+            markArcManaged(bindAlloca);
+            arc_str_managed_vars_.insert(bindAlloca);
             return;
         }
         // Resource types, enum values stored as ptr, and other non-ARC types:

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -703,8 +703,12 @@ void CodeGen::emitPatternBindingArc(llvm::Value *val, llvm::AllocaInst *bindAllo
             auto *src = llvm::dyn_cast<llvm::AllocaInst>(ld->getPointerOperand());
             if (src && closure_managed_vars_.count(src))
                 closure_managed_vars_.insert(bindAlloca);
+            else if (src && arc_str_managed_vars_.count(src))
+                arc_str_managed_vars_.insert(bindAlloca);
             else
                 arc_backed_vars_.insert(bindAlloca);
+        } else if (arc_str_owned_values_.count(val)) {
+            arc_str_managed_vars_.insert(bindAlloca);
         } else {
             arc_backed_vars_.insert(bindAlloca);
         }

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -989,7 +989,9 @@ void CodeGen::emitStmt(AssignStmt &s) {
         builder_.CreateCondBr(isOldNull, storeBB, releaseBB);
 
         builder_.SetInsertPoint(releaseBB);
-        auto *oldHdr = emitArcGetHeaderFromData(oldVal);
+        const bool oldIsStr = arc_str_managed_vars_.count(ptr) > 0;
+        auto *oldHdr = oldIsStr ? emitStrGetHeaderFromData(oldVal)
+                                : emitArcGetHeaderFromData(oldVal);
         // Look up GC visit function for potentially cyclic types on reassignment.
         llvm::Function *gcVisitFn = nullptr;
         {
@@ -1129,7 +1131,8 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
         builder_.CreateCondBr(isOldNull, storeBB, releaseBB);
 
         builder_.SetInsertPoint(releaseBB);
-        auto *oldHdr = emitArcGetHeaderFromData(oldVal);
+        auto *oldHdr = b.is_str ? emitStrGetHeaderFromData(oldVal)
+                                : emitArcGetHeaderFromData(oldVal);
         llvm::Function *gcVisitFn = nullptr;
         if (auto *evMeta = getMeta(anchor);
             evMeta && !evMeta->enum_value_type.empty() && isPotentiallyCyclic(evMeta->enum_value_type))

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -403,14 +403,15 @@ void CodeGen::emitVarDecl(const std::string &name,
     // compounds it.
     if (auto *recSt = llvm::dyn_cast<llvm::StructType>(newTy)) {
         if (recordHasArcFields(recSt)) {
-            // Retain ARC fields in all cases (construction + copy).
-            // emitRecordArcFieldsRetain skips freshly-owned inline values
-            // (arc_owned_values_ / arc_str_owned_values_) because those
-            // represent ownership transfers into the record. Named-variable
-            // references (loaded from tracked allocas) are reference copies
-            // that need a retain so both the variable and the record hold
-            // independent references.
-            emitRecordArcFieldsRetain(val, recSt);
+            if (!llvm::isa<llvm::CallInst>(val) && !llvm::isa<llvm::InvokeInst>(val)) {
+                // LoadInst / ExtractValueInst: copy from another alloca — retain
+                // each ARC field so both aliases see strong_count > 1.
+                // InsertValueInst: record construction — emitRecordArcFieldsRetain
+                // uses traceInsertValueField to skip freshly-owned fields (inline
+                // allocations) and retain only named-variable references.
+                // CallInst / InvokeInst: ownership transfer (strong_count already 1).
+                emitRecordArcFieldsRetain(val, recSt);
+            }
             arc_field_record_vars_.insert(ptr);
         }
     }

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -404,10 +404,14 @@ void CodeGen::emitVarDecl(const std::string &name,
     // compounds it.
     if (auto *recSt = llvm::dyn_cast<llvm::StructType>(newTy)) {
         if (recordHasArcFields(recSt)) {
-            if (llvm::isa<llvm::LoadInst>(val) || llvm::isa<llvm::ExtractValueInst>(val)) {
-                // Copy from another record alloca or sub-field extract.
-                emitRecordArcFieldsRetain(val, recSt);
-            }
+            // Retain ARC fields in all cases (construction + copy).
+            // emitRecordArcFieldsRetain skips freshly-owned inline values
+            // (arc_owned_values_ / arc_str_owned_values_) because those
+            // represent ownership transfers into the record. Named-variable
+            // references (loaded from tracked allocas) are reference copies
+            // that need a retain so both the variable and the record hold
+            // independent references.
+            emitRecordArcFieldsRetain(val, recSt);
             arc_field_record_vars_.insert(ptr);
         }
     }
@@ -698,6 +702,18 @@ void CodeGen::emitVarDecl(const std::string &name,
         auto detectedRK = detectResourceKind(val);
         bool isResource = (detectedRK != ResourceKindRegistry::NONE);
         bool isRetainedArc = tryRetainArcSource(val);
+        // Detect if tryRetainArcSource handled a str value (StringHeader, offset −24).
+        // str allocas must NOT enter arc_backed_vars_ (CoW assumes ArcHeader at offset −16).
+        bool isRetainedArcStr = false;
+        if (isRetainedArc) {
+            if (arc_str_owned_values_.count(val) > 0) {
+                isRetainedArcStr = true;
+            } else if (auto *ld = llvm::dyn_cast<llvm::LoadInst>(val)) {
+                auto *src = llvm::dyn_cast<llvm::AllocaInst>(ld->getPointerOperand());
+                if (src && arc_str_managed_vars_.count(src) > 0)
+                    isRetainedArcStr = true;
+            }
+        }
         // Detect closures with captures (ARC-managed closure structs)
         bool isClosure = false;
         {
@@ -719,9 +735,30 @@ void CodeGen::emitVarDecl(const std::string &name,
             if (isClosure)
                 closure_managed_vars_.insert(ptr);
         }
-        // Track allocas that are truly ARC-backed (have ARC header prepended)
-        if (isArcOwned || isRetainedArc)
+        // Track allocas that are truly ARC-backed (have ARC header prepended).
+        // Exclude str sources: str uses StringHeader (offset -24), not ArcHeader (offset -16).
+        if (isArcOwned || (isRetainedArc && !isRetainedArcStr))
             arc_backed_vars_.insert(ptr);
+
+        // --- str ARC tracking ---
+        // Runs regardless of isRetainedArc because str uses StringHeader (offset −24) and
+        // requires its own side-table (arc_str_managed_vars_) for correct release dispatch.
+        if (!isCollection && !isArcOwned && !isResource && !isClosure) {
+            const bool strByAnnot = annot && resolveTypeAlias(*annot) == "str";
+            const bool strByOwnedVal = arc_str_owned_values_.count(val) > 0;
+            const bool strBySrcAlloca = isRetainedArcStr; // LoadInst from arc_str_managed_vars_ alloca
+            if (strByAnnot || strByOwnedVal || strBySrcAlloca) {
+                // strByOwnedVal: strong_count=1 from makeString — no retain needed.
+                // strBySrcAlloca: tryRetainArcSource Case 1 already retained — no retain needed.
+                // Otherwise: retain (immortal literals are a no-op via ARC_IMMORTAL check).
+                if (!strByOwnedVal && !strBySrcAlloca && !isRetainedArc) {
+                    auto *hdr = emitStrGetHeaderFromData(val);
+                    emitArcRetain(hdr, /*atomic=*/false);
+                }
+                markArcManaged(ptr);
+                arc_str_managed_vars_.insert(ptr);
+            }
+        }
         }
     }
 

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -610,10 +610,12 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
     // KNOWLEDGE.md for why both flags matter.
     std::vector<bool> capIsArcManaged(captures.size(), false);
     std::vector<bool> capIsArcBacked(captures.size(), false);
+    std::vector<bool> capIsArcStr(captures.size(), false);
     for (size_t i = 0; i < captures.size(); ++i) {
         llvm::AllocaInst *src = captures[i].second;
         capIsArcManaged[i] = isArcManaged(src);
         capIsArcBacked[i] = arc_backed_vars_.count(src) > 0;
+        capIsArcStr[i] = arc_str_managed_vars_.count(src) > 0;
     }
 
     std::vector<llvm::Type*> envFields;
@@ -700,6 +702,11 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
                 if (!capIsArcManaged[i])
                     continue;
                 markArcManaged(dst);
+                // str captures need the -24 offset side-table entry so that
+                // emitArcReleaseVar (called by popScope below) uses the
+                // correct emitStrGetHeaderFromData path (#1046).
+                if (capIsArcStr[i])
+                    arc_str_managed_vars_.insert(dst);
 
                 // Retain the captured ARC value so strong_count stays
                 // >= 2 while workers run: that makes emitCowCheck's
@@ -717,7 +724,10 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
                 builder_.CreateCondBr(isNull, skipBB, retainBB);
 
                 builder_.SetInsertPoint(retainBB);
-                auto *hdr = emitArcGetHeaderFromData(dataPtr);
+                // str handles have StringHeader at offset -24; use the
+                // correct helper to avoid corrupting weak_count (#1046).
+                auto *hdr = capIsArcStr[i] ? emitStrGetHeaderFromData(dataPtr)
+                                           : emitArcGetHeaderFromData(dataPtr);
                 emitArcRetain(hdr, /*atomic=*/true);
                 builder_.CreateBr(skipBB);
 

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -30,13 +30,19 @@ void CodeGen::emitArcReleaseLoadedElement(llvm::Value *oldElemVal,
     builder_.CreateCondBr(isOldNull, joinBB, releaseBB);
 
     builder_.SetInsertPoint(releaseBB);
-    auto *oldHdr = emitArcGetHeaderFromData(oldElemVal);
-    // Element slots in lists/maps/sets are not marked atomic; collections
-    // themselves are not @atomic by default. The destructor for the inner
-    // kind walks its own data buffer and cascades releases to its elements.
-    emitArcRelease(oldHdr, /*atomic=*/false,
-                   getOrCreateCollectionDestructor(elemKind),
-                   /*gcVisitFn=*/nullptr);
+    if (elemKind == CollectionKind::Str) {
+        // str element: header is at handle-STRING_HEADER_SIZE (24); no inner destructor.
+        auto *oldHdr = emitStrGetHeaderFromData(oldElemVal);
+        emitArcRelease(oldHdr, /*atomic=*/false, /*destructor=*/{}, /*gcVisitFn=*/nullptr);
+    } else {
+        auto *oldHdr = emitArcGetHeaderFromData(oldElemVal);
+        // Element slots in lists/maps/sets are not marked atomic; collections
+        // themselves are not @atomic by default. The destructor for the inner
+        // kind walks its own data buffer and cascades releases to its elements.
+        emitArcRelease(oldHdr, /*atomic=*/false,
+                       getOrCreateCollectionDestructor(elemKind),
+                       /*gcVisitFn=*/nullptr);
+    }
     builder_.CreateBr(joinBB);
 
     builder_.SetInsertPoint(joinBB);

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -744,6 +744,7 @@ llvm::Value *CodeGen::concatStringParts(
         off = builder_.CreateAdd(off, p.second, prefix + "_off");
     }
     // NUL at buf[totalLen] already written by __ry_string_make_uninit
+    arc_str_owned_values_.insert(buf);
     return buf;
 }
 

--- a/src/runtime_filesystem.cpp
+++ b/src/runtime_filesystem.cpp
@@ -1,5 +1,6 @@
 #include "ry/runtime_alloc.hpp"
 #include "ry/runtime_list.hpp"
+#include "ry/runtime_string.hpp"
 #include "ry/runtime_error.hpp"
 
 #include <cerrno>
@@ -363,8 +364,7 @@ const char *__ry_filesystem_read_link(const char *path) {
         setLastError("read_link: failed to read link '%s': %s", path, strerror(errno));
         return nullptr;
     }
-    buf[len] = '\0';
-    return checked_strdup(buf);
+    return makeString(buf, static_cast<size_t>(len));
 }
 
 } // extern "C"

--- a/src/runtime_http_error.cpp
+++ b/src/runtime_http_error.cpp
@@ -18,7 +18,7 @@ void setHttpLastError(const char *fmt, ...) {
 }
 
 extern "C" const char *__ry_http_get_last_error() {
-    return checked_strdup(http_last_error_buf);
+    return makeString(http_last_error_buf, strlen(http_last_error_buf));
 }
 
 // Called from JIT'd code to check if a Ry string contains an embedded NUL.

--- a/tests/spec/pattern_arc.test.ry
+++ b/tests/spec/pattern_arc.test.ry
@@ -186,9 +186,9 @@ describe("pattern binding ARC retain (#997)", ():
       i = i + 1
   )
 
-  it("record pattern does not over-retain heap str field binding (#1016)", ():
-    # RecordPattern: the str field (label) in Box is ptrTy_ but NOT ARC-managed.
-    # Without the guard, markArcManaged(tmp) was called unconditionally.
+  it("record pattern str field is correctly ARC-managed (#1016, #1046)", ():
+    # RecordPattern: str field (label) in Box is ARC-managed since #1046.
+    # Verify no double-free and correct value across repeated construction.
     i = 0
     while i < 5:
       lbl: str = "my" + "box"
@@ -200,9 +200,9 @@ describe("pattern binding ARC retain (#997)", ():
       i = i + 1
   )
 
-  it("enum constructor pattern does not over-retain heap str field binding (#1016)", ():
-    # EnumConstructorPattern: Tree::Node(str) — str is ptrTy_ but NOT ARC-managed.
-    # Without the guard, markArcManaged(tmp) was called unconditionally.
+  it("enum constructor pattern str field is correctly ARC-managed (#1016, #1046)", ():
+    # EnumConstructorPattern: Tree::Node(str) — str is ARC-managed since #1046.
+    # Verify no double-free and correct value across repeated construction.
     i = 0
     while i < 5:
       payload: str = "no" + "de"

--- a/tests/spec/str_arc.test.ry
+++ b/tests/spec/str_arc.test.ry
@@ -1,0 +1,196 @@
+from runtime_internal import arc_live_count
+
+# str ARC management tests (#1046)
+# Verifies that dynamically-created str values are correctly managed
+# by ARC: retained when stored, released when scope ends.
+# Memory correctness (no leak / double-free) is enforced by ASan.
+
+describe("str ARC — dynamic string operations", ():
+  it("concat result is usable after assignment", ():
+    a = "hello"
+    b = "world"
+    c = a + ", " + b
+    expect(c).to_eq("hello, world")
+  )
+
+  it("f-string interpolation result is usable", ():
+    n = 42
+    s = f"value={n}"
+    expect(s).to_eq("value=42")
+  )
+
+  it("repeat result is usable", ():
+    s = "ab".repeat(3)
+    expect(s).to_eq("ababab")
+  )
+
+  it("repeat zero produces empty string", ():
+    s = "x".repeat(0)
+    expect(s).to_eq("")
+  )
+
+  it("to_upper / to_lower return valid strings", ():
+    s = "Hello World"
+    expect(s.to_upper()).to_eq("HELLO WORLD")
+    expect(s.to_lower()).to_eq("hello world")
+  )
+
+  it("trim returns valid string", ():
+    s = "  hello  ".trim()
+    expect(s).to_eq("hello")
+  )
+
+  it("substring returns valid string", ():
+    s = "hello world"
+    expect(s.substring(6, 11)).to_eq("world")
+  )
+
+  it("replace returns valid str", ():
+    s = "hello world"
+    r = s.replace("world", "Ry")
+    expect(r).to_eq("hello Ry")
+  )
+
+  it("concat loop produces correct result", ():
+    result = ""
+    for i in range(5):
+      result = result + (i as str)
+    expect(result).to_eq("01234")
+  )
+
+  it("str returned from function is usable", ():
+    function make_greeting(name: str) -> str:
+      return "Hello, " + name + "!"
+    g = make_greeting("World")
+    expect(g).to_eq("Hello, World!")
+  )
+
+  it("str passed through multiple function calls remains valid", ():
+    function double(s: str) -> str:
+      return s + s
+    a = "ab"
+    b = double(a)
+    c = double(b)
+    expect(c).to_eq("abababab")
+  )
+)
+
+describe("str ARC — List<str> management", ():
+  it("List<str> created with literals is correct", ():
+    xs = ["a", "b", "c"]
+    expect(xs).to_have_length(3)
+    expect(xs[0]).to_eq("a")
+    expect(xs[2]).to_eq("c")
+  )
+
+  it("List<str> with dynamic strings is correct", ():
+    a = "x" + "1"
+    b = "x" + "2"
+    xs = [a, b]
+    expect(xs[0]).to_eq("x1")
+    expect(xs[1]).to_eq("x2")
+  )
+
+  it("append to List<str> works correctly", ():
+    xs: List<str> = ["first", "second"]
+    append(xs, "third")
+    expect(xs).to_have_length(3)
+    expect(xs[2]).to_eq("third")
+  )
+
+  it("append dynamic str to List<str> works correctly", ():
+    xs: List<str> = []
+    s = "hel" + "lo"
+    append(xs, s)
+    expect(xs).to_have_length(1)
+    expect(xs[0]).to_eq("hello")
+  )
+
+  it("List<str> overwrite does not leak (arc_live_count stays constant)", ():
+    before = arc_live_count()
+    xs: List<str> = ["a", "b", "c"]
+    xs = ["d", "e", "f"]
+    xs = ["g", "h", "i"]
+    xs = ["j", "k", "l"]
+    after = arc_live_count()
+    expect(after - before).to_eq(1)
+  )
+
+  it("List<str> with dynamic elements does not leak on overwrite", ():
+    before = arc_live_count()
+    s1 = "foo" + "1"
+    s2 = "foo" + "2"
+    xs: List<str> = [s1, s2]
+    xs = [s1 + "a", s2 + "b"]
+    after = arc_live_count()
+    expect(after - before).to_eq(1)
+  )
+
+  it("List<str> copy-on-write preserves both copies", ():
+    a = ["alpha", "beta", "gamma"]
+    b = a
+    c = b
+    append(c, "delta")
+    expect(a).to_have_length(3)
+    expect(c).to_have_length(4)
+    expect(c[3]).to_eq("delta")
+  )
+
+  it("List<str> CoW with dynamic elements preserves both copies", ():
+    s1 = "x" + "1"
+    s2 = "x" + "2"
+    a = [s1, s2]
+    b = a
+    append(b, "x3")
+    expect(a).to_have_length(2)
+    expect(b).to_have_length(3)
+    expect(a[0]).to_eq("x1")
+    expect(b[2]).to_eq("x3")
+  )
+
+  it("map() over list produces List<str> correctly", ():
+    nums = [1, 2, 3]
+    strs = nums.map((n: int) => "n=" + (n as str))
+    expect(strs[0]).to_eq("n=1")
+    expect(strs[1]).to_eq("n=2")
+    expect(strs[2]).to_eq("n=3")
+  )
+
+  it("join on List<str> produces correct result", ():
+    parts = ["a", "b", "c"]
+    joined = ",".join(parts)
+    expect(joined).to_eq("a,b,c")
+  )
+)
+
+describe("str ARC — Map<str, str>", ():
+  it("Map<str, str> stores and retrieves values", ():
+    m = {"key": "value", "foo": "bar"}
+    expect(m["key"]).to_eq("value")
+    expect(m["foo"]).to_eq("bar")
+  )
+
+  it("Map<str, str> with dynamic values does not leak on overwrite", ():
+    before = arc_live_count()
+    m: Map<str, str> = {"k": "v1"}
+    m = {"k": "v2"}
+    m = {"k": "v3"}
+    after = arc_live_count()
+    expect(after - before).to_eq(1)
+  )
+)
+
+describe("str ARC — closure capture", ():
+  it("closure captures str by value", ():
+    prefix = "hello"
+    greet = (name: str) => prefix + ", " + name
+    expect(greet("Alice")).to_eq("hello, Alice")
+    expect(greet("Bob")).to_eq("hello, Bob")
+  )
+
+  it("closure captures dynamic str", ():
+    base = "x" + "y"
+    f = () => base + "z"
+    expect(f()).to_eq("xyz")
+  )
+)

--- a/tests/spec/str_arc.test.ry
+++ b/tests/spec/str_arc.test.ry
@@ -194,3 +194,43 @@ describe("str ARC — closure capture", ():
     expect(f()).to_eq("xyz")
   )
 )
+
+describe("str ARC — pattern binding", ():
+  it("Some(str) pattern binding retains dynamic str", ():
+    opt: Option<str> = Some("a" + "b")
+    case opt:
+      Some(s):
+        expect(s).to_eq("ab")
+      None:
+        expect(false).to_eq(true)
+  )
+
+  it("Ok(str) pattern binding retains dynamic str", ():
+    res: Result<str, str> = Ok("he" + "llo")
+    case res:
+      Ok(s):
+        expect(s).to_eq("hello")
+      Err(_):
+        expect(false).to_eq(true)
+  )
+
+  it("Err(str) pattern binding retains dynamic str", ():
+    res: Result<int, str> = Err("err" + "or")
+    case res:
+      Ok(_):
+        expect(false).to_eq(true)
+      Err(e):
+        expect(e).to_eq("error")
+  )
+
+  it("nested Some(str) survives outer scope exit", ():
+    outer = Some("pre" + "fix")
+    result = ""
+    case outer:
+      Some(s):
+        result = s + "_done"
+      None:
+        result = "none"
+    expect(result).to_eq("prefix_done")
+  )
+)


### PR DESCRIPTION
## Summary

- `str` values are now fully ARC-managed. `retain`/`release` are emitted at every binding site using `emitStrGetHeaderFromData` (offset −24, `STRING_HEADER_SIZE`) instead of `emitArcGetHeaderFromData` (offset −16).
- `List<str>`, `Map<K, str>`, and `Set<str>` destructors now release each `str` element before freeing the data buffer. The `getOrCreateCollectionDestructor` cache key is extended to `(CollectionKind, elemSig, valSig)` so str-specialized destructors are cached separately.
- CoW copies of str-bearing collections now retain `str` elements to balance reference counts (previously skipped when `retainElements=false`).
- `runtime_filesystem.cpp`: `read_link` now returns a `makeString`-allocated handle instead of `checked_strdup`, making it safe for ARC release.

Closes #1046

## Test plan

- [x] Default build: 1780 C++ tests + 134 Ry tests PASSED
- [x] ASan + UBSan: 1780 C++ tests + 134 Ry tests PASSED (no leaks, no double-free, no UAF)
- [x] TSan: 1780 C++ tests + 134 Ry tests PASSED
- [x] New test file `tests/spec/str_arc.test.ry` — 25 tests covering: dynamic concat/repeat/f-string/built-in string methods, concat loop, str in functions, `List<str>` create/append/overwrite/CoW, `Map<str,str>` leak detection, closure captures
- [x] `Map<str, int>` CoW key-retention scenario tested under ASan — clean pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Strings (str) are now fully ARC-managed; dynamically produced strings are automatically freed when last referenced.
* **Bug Fixes**
  * Collections (List<str>, Map<*,str>, Set<str>) correctly retain/release string elements, including during copy-on-write, captures, pattern bindings, assignments, and thunked/parallel captures.
* **Documentation**
  * Updated docs and changelog to describe the new string ARC model and invariants.
* **Tests**
  * Added comprehensive tests covering string ARC behavior and container interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->