### PR TITLE
fix(codegen): propagate List<T> element suffix on AssignStmt reassignment (#1085)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3053,12 +3053,14 @@ Enforced in `CodeGen::emitTableDrivenNativeCall` (`src/codegen_call_native.cpp`)
 audit table above. When adding a new byte-list producer, set `ListElemMeta::I8` in its
 entry or call `setTypeMeta(TypeMeta::ListElem, result, i8Ty_)` post-call.
 
-**Annotation-driven element suffix (#1079)**: `bs: List<u8> = [97, 0, 98]` now works.
-`injectLowLevelSuffix` is shallow — it does not descend into `ListExpr` elements on its own.
-When the variable annotation is `List<T>` and `T` is a low-level integer type, the parent
-`emitVarDecl` loop in `src/codegen_stmt.cpp` propagates `T` into each element AST node
-before calling `emitExpr`. This mirrors the fixed-size array path at line 247-293. The fix
-must happen before `emitExpr`; post-emit metadata rescue (line 444-493) cannot repair the
-stride because `getListElementType(val)` returns i64 (truthy) and the annotation-fallback
-branch is gated on `!elemTy`. Scope: `let`/`var` declarations only — `AssignStmt`
-reassignment and inline call-argument paths are not covered.
+**Annotation-driven element suffix (#1079, #1085)**: `bs: List<u8> = [97, 0, 98]` and
+subsequent `bs = [99, 100, 101]` both work. `injectLowLevelSuffix` is shallow — it does not
+descend into `ListExpr` elements on its own. Both `emitVarDecl` and `AssignStmt` propagate
+`T` into each element AST node before calling `emitExpr` via `injectListExprElemSuffixes`
+(`include/ry/ast.hpp`). The fix must happen before `emitExpr`; post-emit metadata rescue
+cannot repair the stride because `getListElementType(val)` returns i64 (truthy) and the
+annotation-fallback branch is gated on `!elemTy`. AssignStmt recovers the element type name
+from `ValueMetadata::list_elem_type_name` (now populated for low-level int types at
+declaration time) to preserve source-level signedness ("i8" vs "u8"); `reverseResolveTypeName`
+is the fallback but is lossy (always returns "u8" for `i8Ty_`). Scope: `let`/`var`
+declarations and plain `=` reassignment — inline call-argument paths are not covered.

--- a/changelog.d/1085-list-u8-reassign.md
+++ b/changelog.d/1085-list-u8-reassign.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Reassignment to a `List<u8>` (or other `List<T>` with low-level integer element type) variable now propagates the element suffix so `bytes_to_str`, `write_bytes`, and TLS/TCP byte-list consumers accept the list, matching the declaration-time behavior from #1079 (#1085)

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -116,6 +116,6 @@ case read_text("missing.txt"):
 ## Notes
 
 - `List<u8>` is used as the buffer type. Standard list operations (`length()`, `append()`, `slice()`, index access) all work with byte lists.
-- `bytes_to_str()` and `write_bytes()` require a `List<u8>` argument. Three ways to produce a compatible byte list: (1) explicit `u8` suffixes (`[97u8, 0u8, 98u8]`), (2) `to_bytes("...")` to convert a string literal, or (3) a type-annotated variable declaration (`bs: List<u8> = [97, 0, 98]`). Plain integer list literals without annotation or explicit suffix use 64-bit element layout and are rejected at compile time.
+- `bytes_to_str()` and `write_bytes()` require a `List<u8>` argument. Four ways to produce a compatible byte list: (1) explicit `u8` suffixes (`[97u8, 0u8, 98u8]`), (2) `to_bytes("...")` to convert a string literal, (3) a type-annotated variable declaration (`bs: List<u8> = [97, 0, 98]`), or (4) reassignment to a `List<u8>` variable (`bs = [99, 100, 101]`). Plain integer list literals without annotation, explicit suffix, or a typed variable target use 64-bit element layout and are rejected at compile time.
 - File paths are relative to the current working directory unless absolute paths are specified.
 - `write_text` and `write_bytes` overwrite existing files. Use `append_text` to add content to existing files.

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -549,4 +549,15 @@ inline void injectLowLevelSuffix(ExprNode &value, const std::string &annot) {
     }
 }
 
+// Propagate `name` onto every direct NumberExpr/UnaryExpr child of a
+// ListExpr. This is the iteration half of the annotation-driven suffix
+// path: the caller is responsible for resolving the element type name and
+// checking isLowLevelIntTypeName. Shared by emitVarDecl (#1079) and the
+// AssignStmt reassignment path (#1085) so the two sites cannot drift.
+inline void injectListExprElemSuffixes(ListExpr &le, const std::string &name) {
+    if (!isLowLevelIntTypeName(name)) return;
+    for (auto &el : le.elements)
+        if (el) injectLowLevelSuffix(*el, name);
+}
+
 } // namespace ry

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -1054,6 +1054,19 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
             injectLowLevelSuffix(*s.value, anchorLL);
     }
 
+    // Mirror the AssignStmt List<T> branch (#1085) so module-global List<u8>
+    // variables reassigned from inside a function also get byte-stride elements.
+    if (auto *le = std::get_if<std::unique_ptr<ListExpr>>(&s.value->data);
+            le && !(*le)->elements.empty()) {
+        std::string inner;
+        if (auto *meta = getMeta(anchor); meta && !meta->list_elem_type_name.empty())
+            inner = meta->list_elem_type_name;
+        else if (llvm::Type *elemTy = getTypeMeta(TypeMeta::ListElem, anchor))
+            inner = reverseResolveTypeName(elemTy);
+        if (isLowLevelIntTypeName(inner))
+            injectListExprElemSuffixes(**le, inner);
+    }
+
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();
 

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -190,8 +190,9 @@ void CodeGen::emitVarDecl(const std::string &name,
             getOrCreateMeta(ptr).list_elem_type_name = inner;
         }
 
-        // Set list element type metadata for List<Map>, List<Set>, List<closure> annotations
-        if (isMapTypeName(inner) || isSetTypeName(inner))
+        // Set list element type metadata. Also covers low-level int names
+        // ("i8", "u8", …) so AssignStmt (#1085) can recover them faithfully.
+        if (isMapTypeName(inner) || isSetTypeName(inner) || isLowLevelIntTypeName(inner))
             getOrCreateMeta(ptr).list_elem_type_name = inner;
         else if (inner.size() > 9 && inner.substr(0, 9) == "function(")
             getOrCreateMeta(ptr).list_elem_fn_type_info = parseFnTypeAnnotation(inner);
@@ -309,10 +310,8 @@ void CodeGen::emitVarDecl(const std::string &name,
                     inner.erase(0, 1);
                 while (!inner.empty() && inner.back() == ' ')
                     inner.pop_back();
-                if (isLowLevelIntTypeName(inner)) {
-                    for (auto &el : (*le)->elements)
-                        if (el) injectLowLevelSuffix(*el, inner);
-                }
+                if (isLowLevelIntTypeName(inner))
+                    injectListExprElemSuffixes(**le, inner);
             }
         }
     }
@@ -493,7 +492,12 @@ void CodeGen::emitVarDecl(const std::string &name,
                 if (isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
                     std::string inner = resolved.substr(5, resolved.size() - 6);
                     while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
-                    if (isMapTypeName(inner) || isSetTypeName(inner)) {
+                    if (isMapTypeName(inner) || isSetTypeName(inner) ||
+                            isLowLevelIntTypeName(inner)) {
+                        // Also covers low-level int names (e.g. "i8", "u8") so that
+                        // AssignStmt (#1085) can recover the source-level element name
+                        // faithfully without the lossy reverseResolveTypeName round-trip
+                        // (i8Ty_ → "u8" regardless of the declared signedness).
                         letn = inner;
                     } else if (inner.size() > 9 && inner.substr(0, 9) == "function(") {
                         lefti = parseFnTypeAnnotation(inner);
@@ -857,6 +861,24 @@ void CodeGen::emitStmt(AssignStmt &s) {
         const std::string &varLL = getLowLevelTypeName(ptr);
         if (!varLL.empty())
             injectLowLevelSuffix(*s.value, varLL);
+    }
+
+    // #1085: List<T> element suffix propagation for reassignment. Mirrors the
+    // #1079 decl-time loop (emitVarDecl). Byte stride is committed inside
+    // emitExpr(ListExpr); post-emit metadata stamping cannot repair a
+    // mis-strided heap allocation, so the suffix must be injected before emit.
+    // The target ptr's TypeMeta::ListElem was stamped at declaration time;
+    // recover the element type name via list_elem_type_name (source-level) or
+    // reverseResolveTypeName (LLVM-level; i8Ty_ → "u8").
+    if (auto *le = std::get_if<std::unique_ptr<ListExpr>>(&s.value->data);
+            le && !(*le)->elements.empty()) {
+        std::string inner;
+        if (auto *meta = getMeta(ptr); meta && !meta->list_elem_type_name.empty())
+            inner = meta->list_elem_type_name;
+        else if (llvm::Type *elemTy = getTypeMeta(TypeMeta::ListElem, ptr))
+            inner = reverseResolveTypeName(elemTy);
+        if (isLowLevelIntTypeName(inner))
+            injectListExprElemSuffixes(**le, inner);
     }
 
     llvm::Value *val = emitExpr(*s.value);

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -1,5 +1,12 @@
 from io import read_text, write_text, append_text, exists, delete_file, read_bytes, write_bytes, to_bytes, bytes_to_str
 
+# Module-global List<u8> for the emitModuleGlobalWriteThrough test (#1085).
+glob_bs: List<u8> = [97, 0, 98]
+
+function update_glob_bs() -> int:
+  glob_bs = [99, 100, 101]
+  return 0
+
 describe("file I/O", ():
   it("should write and read text", ():
     case write_text("/tmp/ry_selftest_io.txt", "hello world"):
@@ -203,5 +210,13 @@ describe("file I/O", ():
       Err(e):
         fail("unexpected write error")
     delete_file("/tmp/ry_selftest_io_reassign_u8.bin")
+  )
+  it("should accept List<u8> module-global reassignment from function (#1085)", ():
+    update_glob_bs()
+    case bytes_to_str(glob_bs):
+      Ok(s):
+        expect(s == "cde").to_eq(true)
+      Err(e):
+        fail("unexpected error")
   )
 )

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -183,4 +183,25 @@ describe("file I/O", ():
         fail("unexpected write error")
     delete_file("/tmp/ry_selftest_io_annot_u8.bin")
   )
+  it("should accept List<u8> reassignment via bytes_to_str (#1085)", ():
+    bs: List<u8> = [97, 0, 98]
+    bs = [99, 100, 101]
+    case bytes_to_str(bs):
+      Ok(s):
+        expect(s == "cde").to_eq(true)
+      Err(e):
+        fail("unexpected error")
+  )
+  it("should accept List<u8> reassignment for write_bytes (#1085)", ():
+    bs: List<u8> = [72, 105]
+    bs = [97, 98, 99]
+    case write_bytes("/tmp/ry_selftest_io_reassign_u8.bin", bs):
+      Ok(_):
+        case read_bytes("/tmp/ry_selftest_io_reassign_u8.bin"):
+          Ok(rb): expect(length(rb)).to_eq(3)
+          Err(e): fail("unexpected read error")
+      Err(e):
+        fail("unexpected write error")
+    delete_file("/tmp/ry_selftest_io_reassign_u8.bin")
+  )
 )

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -896,3 +896,16 @@ bs = [-128]
 print(length(bs))
 )"));
 }
+
+TEST_F(CodeGenTest, ListU8ModuleGlobalWriteThroughAccepted) {
+    EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
+bs: List<u8> = [97, 0, 98]
+function update() -> int:
+    bs = [99, 100, 101]
+    return 0
+update()
+case bytes_to_str(bs):
+    Ok(s): print(s)
+    Err(e): print(e.message)
+)"));
+}

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -858,3 +858,41 @@ xs: List<u16> = [300, 1000, 65535]
 print(length(xs))
 )"));
 }
+
+// ============================================================
+// List<T> reassignment propagates element suffix (#1085)
+// ============================================================
+
+TEST_F(CodeGenTest, ListU8ReassignmentAccepted) {
+    EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
+bs: List<u8> = [97, 0, 98]
+bs = [99, 100, 101]
+case bytes_to_str(bs):
+    Ok(s): print(s)
+    Err(e): print(e.message)
+)"));
+}
+
+TEST_F(CodeGenTest, ListU8ReassignmentRangeCheckRejected) {
+    expectCompileError(IO_DECLS_1055 + R"(
+bs: List<u8> = [97]
+bs = [256]
+print(length(bs))
+)", {"u8 literal out of range"});
+}
+
+TEST_F(CodeGenTest, ListU8ReassignmentNegativeRejected) {
+    expectCompileError(IO_DECLS_1055 + R"(
+bs: List<u8> = [97]
+bs = [-1]
+print(length(bs))
+)", {"cannot negate unsigned type"});
+}
+
+TEST_F(CodeGenTest, ListI8ReassignmentBoundaryCompiles) {
+    EXPECT_NO_THROW(compileSource(R"(
+bs: List<i8> = [0]
+bs = [-128]
+print(length(bs))
+)"));
+}


### PR DESCRIPTION
## Summary

- After #1079 fixed `bs: List<u8> = [97, 0, 98]` at declaration time, reassignment `bs = [99, 100, 101]` still failed the `requireListU8Arg` compile-time gate because the `AssignStmt` path never injected element suffixes into the RHS `ListExpr` before `emitExpr`.
- Extracts `injectListExprElemSuffixes` helper (shared by `emitVarDecl` and `AssignStmt`) to prevent the two sites from drifting.
- Persists `list_elem_type_name` for low-level int element types at declaration time so reassignment recovers `"i8"` vs `"u8"` faithfully (not via the lossy `reverseResolveTypeName` round-trip).

## Test plan

- [x] New `it()` blocks in `tests/spec/io.test.ry`: golden path via `bytes_to_str` and `write_bytes`
- [x] 4 new C++ tests in `tests/test_codegen_type_safety.cpp`: accepted, range-check rejected, negative rejected, `List<i8>` boundary compiles
- [x] Full `./build/ry_tests` suite passes
- [x] Full `./build/ry test -p` self-test suite passes
- [x] ASan + UBSan clean (`./build-asan/ry_tests` and `./build-asan/ry test -p`)
- [x] TSan clean (`./build-tsan/ry_tests`)
- Compound assignment `+=` gap tracked in #1102

Closes #1085

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reassignment to List<u8> now preserves element signedness so bytes_to_str, write_bytes and related byte-list operations accept reassigned lists.

* **Documentation**
  * I/O docs updated to note reassignment-to-List<u8> as an accepted construction pattern and clarify rejection criteria for unannotated integer lists.

* **Tests**
  * New test cases added to verify reassignment behavior and related acceptance/rejection diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->