### PR TITLE
fix(codegen): recognise None() as None literal in let-decl and reassignment (#1099)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2874,6 +2874,23 @@ This is the same rule as the `IfBlockExpr` path tested in `tests/spec/option_lam
 
 **How to check for new gaps**: When adding a new ADT constructor or a new expression-level control-flow node, grep for both `inferExprType` and `inferExprTypeName` and verify each has a case for the new node. A missing case is a silent wrong-type inference, not a compile error.
 
+### `isNoneLiteral` must match all three None syntactic forms: `None`, `none`, `None()`
+
+**Source**: #1099 (2026-04-17, bugfix — `None()` in let-decl and reassignment contexts)
+**Tags**: codegen, Option, None, isNoneLiteral, let-decl, reassignment, emitVarDecl, CallExpr
+
+**Rule**: `None`, `none`, and `None()` are semantically identical Option literals. `isNoneLiteral` in `src/codegen_type.cpp` must recognise all three:
+- `NoneExpr` — the keyword `none`
+- `VariableExpr{name:"None"}` — the bareword `None`
+- `std::unique_ptr<CallExpr>{callee:"None", args.empty()}` — the call form `None()`
+
+`None()` was introduced in #1043 for lambda if-expr unification. Its emitter in `codegen_call.cpp` uses `fn_->getReturnType()` to derive the inner type — correct for return-statement contexts, but wrong in let-decl and reassignment where the enclosing function is unrelated to the variable's annotation. Three sites that use `isNoneLiteral` to short-circuit into annotation-aware `buildNoneValue(annotTy)` were therefore bypassed:
+- `src/codegen_stmt.cpp` `emitVarDecl` (line ≈204) — let-decl short-circuit (auto-fires after fix)
+- `src/codegen_stmt.cpp` local reassignment (line ≈845) — previously had a raw `VariableExpr{"None"}` check
+- `src/codegen_stmt.cpp` module-global reassignment (line ≈1020) — same raw check
+
+**How to apply**: When adding a new syntactic form of `None` to the language, extend `isNoneLiteral` first. Then all three sites above automatically inherit the fix. The `None()` emitter in `codegen_call.cpp` is a separate fallback for contexts where no annotation is available (e.g., return-stmt); it is not a substitute for `isNoneLiteral`. Use `std::get_if<std::unique_ptr<CallExpr>>` (not `std::get_if<CallExpr>`) because `CallExpr` is stored as `unique_ptr` in the `ExprNode` variant.
+
 ### UnaryExpr fast-path covers bare int for INT64_MIN (`-9223372036854775808`)
 
 **Source**: #1025 (2026-04-16)

--- a/changelog.d/1099-none-call-let-decl-annotation.md
+++ b/changelog.d/1099-none-call-let-decl-annotation.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `None()` call-form is now recognised as a None literal in let-decl, local
+  variable reassignment, and module-global reassignment contexts, matching the
+  behaviour of bareword `None` and `none`. Previously `x: Option<int> = None()`
+  and `x = None()` (on an already-declared `Option<T>` variable) produced a
+  type-mismatch compile error (#1099).

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -841,8 +841,8 @@ void CodeGen::emitStmt(AssignStmt &s) {
         return;
     }
 
-    // Handle None literal in assignment
-    if (auto *ve = std::get_if<VariableExpr>(&s.value->data); ve && ve->name == "None") {
+    // Handle None literal in assignment (None, none, or None() call-form)
+    if (isNoneLiteral(*s.value)) {
         llvm::Type *varTy = ptr->getAllocatedType();
         if (!isOptionType(varTy))
             codegenError("None can only be assigned to Option type");
@@ -1016,8 +1016,8 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
         return;
     }
 
-    // None-literal assignment on an Option-typed module global.
-    if (auto *ve = std::get_if<VariableExpr>(&s.value->data); ve && ve->name == "None") {
+    // None-literal assignment on an Option-typed module global (None, none, or None() call-form)
+    if (isNoneLiteral(*s.value)) {
         if (!isOptionType(valueTy))
             codegenError("None can only be assigned to Option type");
         builder_.CreateStore(buildNoneValue(valueTy), storagePtr);

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -262,9 +262,11 @@ bool CodeGen::isTupleStructType(llvm::StructType *st) {
 }
 
 bool CodeGen::isNoneLiteral(const ExprNode &expr) {
-    return std::holds_alternative<NoneExpr>(expr.data) ||
-           (std::holds_alternative<VariableExpr>(expr.data) &&
-            std::get<VariableExpr>(expr.data).name == "None");
+    if (std::holds_alternative<NoneExpr>(expr.data)) return true;
+    if (auto *v = std::get_if<VariableExpr>(&expr.data); v && v->name == "None") return true;
+    // None() call-form introduced in #1043 for lambda if-expr unification.
+    if (auto *cp = std::get_if<std::unique_ptr<CallExpr>>(&expr.data); cp && (*cp)->callee == "None" && (*cp)->args.empty()) return true;
+    return false;
 }
 
 bool CodeGen::isOptionType(llvm::Type *ty) {

--- a/tests/spec/option_none_call.test.ry
+++ b/tests/spec/option_none_call.test.ry
@@ -1,0 +1,64 @@
+# Tests for None() call-form as an Option literal (#1099).
+#
+# None(), None, and none are three syntactic forms of the same literal.
+# After PR #1043 introduced None() for lambda if-expr unification, these
+# paths were broken in let-decl and reassignment contexts because
+# isNoneLiteral did not recognise CallExpr{"None", args.empty()}.
+
+g_none_call_opt: Option<int> = Some(1)
+
+function g_none_call_reset():
+  g_none_call_opt = None()
+
+function accept_none_opt(o: Option<int>) -> bool:
+  return case o:
+    Some(_) => false
+    None => true
+
+describe("None() in let-decl (#1099)", ():
+  it("should accept None() with Option<int> annotation", ():
+    x: Option<int> = None()
+    expect(x).to_be_none()
+  )
+
+  it("should accept None() with Option<str> annotation", ():
+    x: Option<str> = None()
+    expect(x).to_be_none()
+  )
+
+  it("should accept None() with Option<List<int>> annotation", ():
+    x: Option<List<int>> = None()
+    expect(x).to_be_none()
+  )
+)
+
+describe("None() in local variable reassignment (#1099)", ():
+  it("should reassign Option<int> variable to None()", ():
+    x: Option<int> = Some(1)
+    expect(x).to_be_some()
+    x = None()
+    expect(x).to_be_none()
+  )
+)
+
+describe("None() in module-global reassignment (#1099)", ():
+  it("should reassign module-global Option<int> to None()", ():
+    g_none_call_reset()
+    expect(accept_none_opt(g_none_call_opt)).to_eq(true)
+  )
+)
+
+describe("None() as function argument (#1099)", ():
+  it("should pass None() where Option<int> is expected", ():
+    expect(accept_none_opt(None())).to_eq(true)
+  )
+)
+
+describe("None() in return-stmt — regression guard for #1043 emitter path", ():
+  it("should still return None() from a function with Option<str> return type", ():
+    f = () -> Option<str> => None()
+    case f():
+      Some(_): fail("expected None but got Some")
+      None: expect(true).to_eq(true)
+  )
+)


### PR DESCRIPTION
## Summary

- `None()` call-form was not recognised by `isNoneLiteral`, so `x: Option<int> = None()` and `x = None()` (on a declared `Option<T>` variable) failed with a type-mismatch compile error
- Root cause: `isNoneLiteral` in `src/codegen_type.cpp` only matched `NoneExpr` and `VariableExpr{"None"}`, not `CallExpr{"None", args:[]}` introduced in #1043
- Fix: extend `isNoneLiteral` to also recognise the zero-arg `CallExpr` form; replace two raw `VariableExpr` checks in `codegen_stmt.cpp` (local and module-global reassignment) with `isNoneLiteral`

## Changes

| File | Change |
|---|---|
| `src/codegen_type.cpp` | Extend `isNoneLiteral` to match `CallExpr{"None", args.empty()}` |
| `src/codegen_stmt.cpp` | Replace raw `VariableExpr{"None"}` checks at local and module-global reassignment with `isNoneLiteral` |
| `tests/spec/option_none_call.test.ry` | 7 new test cases (let-decl × 3, local reassign, module-global reassign, fn-arg, return-stmt regression guard) |
| `changelog.d/1099-none-call-let-decl-annotation.md` | CHANGELOG fragment |
| `KNOWLEDGE.md` | Entry on `isNoneLiteral` three-form invariant |

## Test plan

- [x] `tests/spec/option_none_call.test.ry` — 7/7 new cases pass
- [x] `tests/spec/option_lambda_if.test.ry` — 7/7 #1043 regression cases still pass
- [x] `NoneWithArgsIsRejected` GoogleTest — `None(1)` still errors
- [x] Full suite: `ry_tests` 1781/1781, `ry test -p` 140 files, 0 failures
- [x] ASan+UBSan: clean
- [x] TSan (C++ tests): clean

Closes #1099

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed compiler errors when using `None()` syntax in variable declarations and reassignments. All three `None` syntactic forms now behave consistently and correctly type-check in Option contexts.

* **Tests**
  * Added test suite validating `None()` functionality across declarations, reassignments, function arguments, and pattern matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->