### PR TITLE
fix(codegen): extend List<T> suffix propagation to compound-op branches (#1102)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3053,17 +3053,22 @@ Enforced in `CodeGen::emitTableDrivenNativeCall` (`src/codegen_call_native.cpp`)
 audit table above. When adding a new byte-list producer, set `ListElemMeta::I8` in its
 entry or call `setTypeMeta(TypeMeta::ListElem, result, i8Ty_)` post-call.
 
-**Annotation-driven element suffix (#1079, #1085)**: `bs: List<u8> = [97, 0, 98]` and
-subsequent `bs = [99, 100, 101]` both work. `injectLowLevelSuffix` is shallow — it does not
-descend into `ListExpr` elements on its own. Both `emitVarDecl` and `AssignStmt` propagate
-`T` into each element AST node before calling `emitExpr` via `injectListExprElemSuffixes`
+**Annotation-driven element suffix (#1079, #1085, #1102)**: `bs: List<u8> = [97, 0, 98]`,
+`bs = [99, 100, 101]`, and `bs += [99]` all work. `injectLowLevelSuffix` is shallow — it
+does not descend into `ListExpr` elements on its own. `emitVarDecl`, `AssignStmt` (plain `=`
+and compound `+=`), and `emitModuleGlobalWriteThrough` (both variants) propagate `T` into
+each element AST node before calling `emitExpr` via `injectListExprElemSuffixes`
 (`include/ry/ast.hpp`). The fix must happen before `emitExpr`; post-emit metadata rescue
 cannot repair the stride because `getListElementType(val)` returns i64 (truthy) and the
 annotation-fallback branch is gated on `!elemTy`. AssignStmt recovers the element type name
 from `ValueMetadata::list_elem_type_name` (now populated for low-level int types at
 declaration time) to preserve source-level signedness ("i8" vs "u8"); `reverseResolveTypeName`
-is the fallback but is lossy (always returns "u8" for `i8Ty_`). Scope: `let`/`var`
-declarations and plain `=` reassignment — inline call-argument paths are not covered.
+is the fallback but is lossy (always returns "u8" for `i8Ty_`). Compound-op branches also
+require `propagateTypeMeta("List<" + elemTypeName + ">", currentVal)` after `CreateLoad` so
+that `getListElementType(currentVal)` in `emitListConcat` returns the correct element type
+(without this, the loaded SSA value has no ListElem metadata and dispatch falls through to
+`emitArithmeticOp`, triggering "cannot mix types"). Scope: `let`/`var` declarations, plain
+`=` reassignment, and compound ops (`+=`) — inline call-argument paths are not covered.
 
 ### `emitTableDrivenNativeCall` variadic path must use raw `ptr` type for `ResultPtr` entries
 

--- a/changelog.d/1102-compound-list-elem-suffix.md
+++ b/changelog.d/1102-compound-list-elem-suffix.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `List<u8>` / `List<i8>` compound assignment (`bs += [99]`) no longer raises "list concatenation requires matching element types"; element suffix propagation now covers compound-op branches for both local variables and module-global write-through (#1102)

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -838,6 +838,36 @@ void CodeGen::emitStmt(AssignStmt &s) {
     // via `applyCompoundOp` so the operator resolution order stays in sync.
     if (s.compound_op) {
         llvm::Value *currentVal = builder_.CreateLoad(ptr->getAllocatedType(), ptr, s.name);
+
+        // #1102: Propagate List<T> element type onto the loaded LHS value so
+        // that getListElementType(currentVal) resolves correctly inside
+        // emitListConcat / applyCompoundOp. Same pattern as #858/#862
+        // (Compound-op loaded slot values must propagate container metadata).
+        // Use the full container type name (e.g. "List<u8>") so propagateTypeMeta
+        // stamps TypeMeta::ListElem; list_elem_type_name alone would not do so.
+        {
+            std::string elemTypeName;
+            if (auto *meta = getMeta(ptr))
+                elemTypeName = meta->list_elem_type_name;
+            if (!elemTypeName.empty())
+                propagateTypeMeta("List<" + elemTypeName + ">", currentVal);
+        }
+
+        // #1102: Mirror the plain-= RHS suffix injection (lines below) so
+        // `bs += [99]` on a List<u8> variable injects the `:u8` suffix before
+        // emitExpr evaluates the literal (byte-stride committed inside emitExpr
+        // cannot be repaired post-emit).
+        if (auto *le = std::get_if<std::unique_ptr<ListExpr>>(&s.value->data);
+                le && !(*le)->elements.empty()) {
+            std::string inner;
+            if (auto *meta = getMeta(ptr); meta && !meta->list_elem_type_name.empty())
+                inner = meta->list_elem_type_name;
+            else if (llvm::Type *elemTy = getTypeMeta(TypeMeta::ListElem, ptr))
+                inner = reverseResolveTypeName(elemTy);
+            if (isLowLevelIntTypeName(inner))
+                injectListExprElemSuffixes(**le, inner);
+        }
+
         llvm::Value *rhs = emitExpr(*s.value);
         llvm::Value *result = applyCompoundOp(*s.compound_op, currentVal, rhs, *s.value,
                                                ptr->getAllocatedType(), s.name);
@@ -1031,6 +1061,30 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
     // AssignStmt and chained LHS paths via `applyCompoundOp` (#812).
     if (s.compound_op) {
         llvm::Value *currentVal = builder_.CreateLoad(valueTy, storagePtr, s.name);
+
+        // #1102: Propagate List<T> element type onto the loaded LHS value
+        // (same pattern as local AssignStmt compound_op fix and #858/#862).
+        {
+            std::string elemTypeName;
+            if (auto *meta = getMeta(anchor))
+                elemTypeName = meta->list_elem_type_name;
+            if (!elemTypeName.empty())
+                propagateTypeMeta("List<" + elemTypeName + ">", currentVal);
+        }
+
+        // #1102: Mirror the plain-= RHS suffix injection (lines below) for
+        // module-global List<u8> compound assignment.
+        if (auto *le = std::get_if<std::unique_ptr<ListExpr>>(&s.value->data);
+                le && !(*le)->elements.empty()) {
+            std::string inner;
+            if (auto *meta = getMeta(anchor); meta && !meta->list_elem_type_name.empty())
+                inner = meta->list_elem_type_name;
+            else if (llvm::Type *elemTy = getTypeMeta(TypeMeta::ListElem, anchor))
+                inner = reverseResolveTypeName(elemTy);
+            if (isLowLevelIntTypeName(inner))
+                injectListExprElemSuffixes(**le, inner);
+        }
+
         llvm::Value *rhs = emitExpr(*s.value);
         llvm::Value *result = applyCompoundOp(*s.compound_op, currentVal, rhs, *s.value,
                                                valueTy, s.name);

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -219,4 +219,14 @@ describe("file I/O", ():
       Err(e):
         fail("unexpected error")
   )
+  it("should accept List<u8> compound assignment (local, #1102)", ():
+    bs: List<u8> = [97]
+    bs += [99]
+    expect(length(bs)).to_eq(2)
+    case bytes_to_str(bs):
+      Ok(s):
+        expect(s == "ac").to_eq(true)
+      Err(e):
+        fail("unexpected error")
+  )
 )

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -909,3 +909,52 @@ case bytes_to_str(bs):
     Err(e): print(e.message)
 )"));
 }
+
+// ============================================================
+// List<T> compound assignment propagates element suffix (#1102)
+// ============================================================
+
+TEST_F(CodeGenTest, ListU8CompoundAssignmentAccepted) {
+    EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
+bs: List<u8> = [97]
+bs += [99]
+print(length(bs))
+)"));
+}
+
+TEST_F(CodeGenTest, ListU8CompoundAssignmentFromVariableAccepted) {
+    EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
+bs: List<u8> = [97]
+rhs: List<u8> = [99]
+bs += rhs
+print(length(bs))
+)"));
+}
+
+TEST_F(CodeGenTest, ListU8ModuleGlobalCompoundAssignmentAccepted) {
+    EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
+bs: List<u8> = [97]
+function update() -> int:
+    bs += [99]
+    return 0
+update()
+print(length(bs))
+)"));
+}
+
+TEST_F(CodeGenTest, ListI8CompoundAssignmentBoundaryCompiles) {
+    EXPECT_NO_THROW(compileSource(R"(
+bs: List<i8> = [0]
+bs += [-128]
+bs += [127]
+print(length(bs))
+)"));
+}
+
+TEST_F(CodeGenTest, ListU8CompoundAssignmentRangeCheckRejected) {
+    expectCompileError(IO_DECLS_1055 + R"(
+bs: List<u8> = [0]
+bs += [256]
+print(length(bs))
+)", {"u8 literal out of range"});
+}


### PR DESCRIPTION
## Summary

- `bs: List<u8> = [97]; bs += [99]` was raising "list concatenation requires matching element types" because the `compound_op` early-return branches in `emitStmt` and `emitModuleGlobalWriteThrough` bypassed the RHS suffix injection added by #1085
- Both compound-op branches now inject `injectListExprElemSuffixes` on the RHS literal before `emitExpr`, and propagate `TypeMeta::ListElem` onto the loaded LHS value via `propagateTypeMeta("List<T>", currentVal)` so `getListElementType(lhs)` resolves correctly inside `emitListConcat`

Closes #1102

## Test plan

- [x] `ListU8CompoundAssignmentAccepted` — `bs: List<u8> = [97]; bs += [99]` compiles
- [x] `ListU8CompoundAssignmentFromVariableAccepted` — RHS variable path
- [x] `ListU8ModuleGlobalCompoundAssignmentAccepted` — module-global write-through path
- [x] `ListI8CompoundAssignmentBoundaryCompiles` — `List<i8>` boundary literals `-128`/`127`
- [x] `ListU8CompoundAssignmentRangeCheckRejected` — `bs += [256]` still raises range error
- [x] Ry self-test `io.test.ry` — local compound assignment (`bs += [99]`, length + bytes_to_str)
- [x] All 1791 C++ tests pass
- [x] 139 Ry self-test files pass
- [x] ASan + UBSan clean
- [x] TSan clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed compound assignment operations (`+=`) for byte-typed lists (`List<u8>`, `List<i8>`), which previously raised type incompatibility errors. List concatenation through compound operators now functions correctly in all execution contexts.

## Tests
* Added comprehensive test coverage for compound list assignments, validating both signed and unsigned byte list operations across local and global scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->