### PR TITLE
fix(codegen): forward elem type sigs in emitArcReleaseLoadedElement to prevent nested str leak (#1108)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3091,6 +3091,8 @@ that `getListElementType(currentVal)` in `emitListConcat` returns the correct el
 
 **How to apply**: `resolveCollectionDestructor(alloca)` reads `list_elem_type_name` / `map_key_type_name` / `map_value_type_name` from the alloca's `ValueMeta` and calls `resolveTypeAlias` before passing to `getOrCreateCollectionDestructor`. Always ensure the alloca carries the correct type name metadata before this call.
 
+**Extension (#1108)**: The same requirement applies to `emitArcReleaseLoadedElement`. When an ARC-managed element (e.g. `List<str>`) is stored in a slot (`List<List<str>>` element, `Map<K, List<str>>` value, record field), overwriting the slot must call `getOrCreateCollectionDestructor` with the **inner** elem/val signatures derived from the element's type name, not the generic (empty-sig) version. Fix: `emitArcReleaseLoadedElement` now accepts `elemTypeName` and calls `resolveTypeAlias` + `splitGenericTypeName` internally to derive `innerElemSig`/`innerValSig`. Callers must pass the declared element type name; passing `""` falls back to the generic destructor (leaks inner str). Rule: any new ARC release helper that calls `getOrCreateCollectionDestructor` must pass the full element type name, not just the `CollectionKind`.
+
 ---
 
 ### CoW copy of `List<str>` must retain str elements (#1046)

--- a/changelog.d/1108-fix-nested-collection-leak-on-overwrite.md
+++ b/changelog.d/1108-fix-nested-collection-leak-on-overwrite.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Fixed memory leak when overwriting a slot in `List<List<str>>`, `Map<K, List<str>>`, or a record field of a nested collection type containing `str` elements. The overwritten inner collection's `str` handles are now released correctly (#1108).

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -255,6 +255,14 @@ public:
                                                           const std::string &elemSig = "",
                                                           const std::string &valSig = "");
 
+    // Splits a generic type name like "List<str>" into head="List" and
+    // inner=["str"].  Returns false for non-generic names (no '<').
+    // Extracted from codegen_fn_generic.cpp so callers across translation
+    // units can use the same parsing logic.
+    static bool splitGenericTypeName(const std::string &s,
+                                     std::string &head,
+                                     std::vector<std::string> &inner);
+
     // Predicate: does the container's *element* type itself own an
     // ARC-managed allocation that needs releasing on slot overwrite?
     // Returns true only for non-weak nested collection element types
@@ -311,8 +319,13 @@ public:
     // join block on return so the caller can continue emitting the
     // store. Used by IndexAssignStmt to release the previously-stored
     // ARC element before overwriting a list/map slot (#855).
+    // `elemTypeName` is the declared type of the element (e.g. "List<str>")
+    // and is used to select the specialized destructor that releases inner
+    // str handles (#1108). Pass "" when the type name is not available;
+    // the function falls back to the generic destructor.
     void emitArcReleaseLoadedElement(llvm::Value *oldElemVal,
                                      CollectionKind elemKind,
+                                     const std::string &elemTypeName,
                                      const llvm::Twine &label);
 
     llvm::AllocaInst *tryGetReceiverAlloca(const ExprNode &expr);

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -583,7 +583,7 @@ void CodeGen::emitRecordArcFieldsRelease(llvm::Value *recordVal,
             continue;
         llvm::Value *fieldVal = builder_.CreateExtractValue(
             recordVal, i, fd.name + ".record_release");
-        emitArcReleaseLoadedElement(fieldVal, fk, fd.name);
+        emitArcReleaseLoadedElement(fieldVal, fk, fd.type->toString(), fd.name);
     }
 }
 

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -284,9 +284,9 @@ static std::vector<std::string> splitTopLevelCommas(const std::string &body) {
     return out;
 }
 
-static bool splitGenericTypeName(const std::string &s,
-                                  std::string &head,
-                                  std::vector<std::string> &inner) {
+bool CodeGen::splitGenericTypeName(const std::string &s,
+                                    std::string &head,
+                                    std::vector<std::string> &inner) {
     std::string t = trimWs(s);
     size_t lt = t.find('<');
     if (lt == std::string::npos) return false;

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -18,6 +18,7 @@ namespace ry {
 // operates on a slot value rather than an alloca-backed variable.
 void CodeGen::emitArcReleaseLoadedElement(llvm::Value *oldElemVal,
                                           CollectionKind elemKind,
+                                          const std::string &elemTypeName,
                                           const llvm::Twine &label) {
     auto *isOldNull = builder_.CreateICmpEQ(
         oldElemVal,
@@ -37,10 +38,27 @@ void CodeGen::emitArcReleaseLoadedElement(llvm::Value *oldElemVal,
     } else {
         auto *oldHdr = emitArcGetHeaderFromData(oldElemVal);
         // Element slots in lists/maps/sets are not marked atomic; collections
-        // themselves are not @atomic by default. The destructor for the inner
-        // kind walks its own data buffer and cascades releases to its elements.
+        // themselves are not @atomic by default. Resolve the inner type
+        // signatures from `elemTypeName` so that the destructor for the inner
+        // collection releases its own str/collection elements (#1108).
+        std::string innerElemSig;
+        std::string innerValSig;
+        if (!elemTypeName.empty()) {
+            std::string resolved = resolveTypeAlias(elemTypeName);
+            std::string head;
+            std::vector<std::string> innerArgs;
+            if (splitGenericTypeName(resolved, head, innerArgs)) {
+                if ((elemKind == CollectionKind::List || elemKind == CollectionKind::Set) &&
+                    !innerArgs.empty()) {
+                    innerElemSig = innerArgs[0];
+                } else if (elemKind == CollectionKind::Map && innerArgs.size() >= 2) {
+                    innerElemSig = innerArgs[0];
+                    innerValSig  = innerArgs[1];
+                }
+            }
+        }
         emitArcRelease(oldHdr, /*atomic=*/false,
-                       getOrCreateCollectionDestructor(elemKind),
+                       getOrCreateCollectionDestructor(elemKind, innerElemSig, innerValSig),
                        /*gcVisitFn=*/nullptr);
     }
     builder_.CreateBr(joinBB);
@@ -160,17 +178,18 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
     auto emitArcFieldReleaseOnOverwrite = [&](llvm::Value *structVal,
                                                int fieldIdx,
                                                CollectionKind fieldArcKind,
+                                               const std::string &fieldTypeName,
                                                llvm::Value *currentField,
                                                llvm::Value *newFieldVal,
                                                const std::string &label) {
         if (s.compound_op) {
-            emitArcReleaseLoadedElement(currentField, fieldArcKind,
+            emitArcReleaseLoadedElement(currentField, fieldArcKind, fieldTypeName,
                                          label + "_compound");
         } else {
             retainArcValue(newFieldVal);
             llvm::Value *oldField = builder_.CreateExtractValue(
                 structVal, static_cast<unsigned>(fieldIdx), s.field + ".arc_old");
-            emitArcReleaseLoadedElement(oldField, fieldArcKind, label);
+            emitArcReleaseLoadedElement(oldField, fieldArcKind, fieldTypeName, label);
         }
     };
 
@@ -239,7 +258,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         }
 
         if (fieldIsArc)
-            emitArcFieldReleaseOnOverwrite(currentStruct, fieldIdx, fieldArcKind,
+            emitArcFieldReleaseOnOverwrite(currentStruct, fieldIdx, fieldArcKind, fieldTypeName,
                                             currentField, newFieldVal,
                                             varExpr->name + "." + s.field);
 
@@ -298,7 +317,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         }
 
         if (fieldIsArc)
-            emitArcFieldReleaseOnOverwrite(innerStruct, fieldIdx, fieldArcKind,
+            emitArcFieldReleaseOnOverwrite(innerStruct, fieldIdx, fieldArcKind, fieldTypeName,
                                             currentField, newFieldVal,
                                             it->first + "." + s.field);
 
@@ -402,7 +421,7 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
         }
 
         if (fieldIsArc)
-            emitArcFieldReleaseOnOverwrite(curStruct, fieldIdx, fieldArcKind,
+            emitArcFieldReleaseOnOverwrite(curStruct, fieldIdx, fieldArcKind, fieldTypeName,
                                             curField, newFieldVal,
                                             it->first + "." + s.field);
 
@@ -744,6 +763,17 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         CollectionKind mapValArcKind = CollectionKind::List;
         bool mapValIsArc = elementTypeIsArcManaged(objPtr, CollectionKind::Map, &mapValArcKind);
 
+        // Snapshot map_value_type_name before any propagateTypeMeta call:
+        // getOrCreateMeta inside it may rehash value_metadata_ and
+        // invalidate a raw pointer from getMeta. See KNOWLEDGE.md
+        // "Compound-op loaded slot values must propagate container
+        // metadata" and #858. Extracted here (before the compound/plain
+        // branch) so both paths can pass it to emitArcReleaseLoadedElement
+        // for the specialized str-aware destructor (#1108).
+        std::string mapValTypeName;
+        if (auto *containerMeta = getMeta(objPtr))
+            mapValTypeName = containerMeta->map_value_type_name;
+
         // Compound assignment on a map requires the key to already exist —
         // an "insert default then apply op" behavior is not yet supported
         // and would silently paper over typos. Reject at runtime with a
@@ -763,14 +793,6 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
             llvm::Value *valsPtr = builder_.CreateLoad(ptrTy_, valsPtrField, "map_vals");
             llvm::Value *valElemPtr = builder_.CreateGEP(mapValTy, valsPtr, {idx}, "val_elem_ptr");
             llvm::Value *oldVal = builder_.CreateLoad(mapValTy, valElemPtr, "map_val_cur");
-            // Snapshot map_value_type_name before propagateTypeMeta: the
-            // getOrCreateMeta inside it may rehash value_metadata_ and
-            // invalidate the raw pointer from getMeta. See KNOWLEDGE.md
-            // "Compound-op loaded slot values must propagate container
-            // metadata" and #858.
-            std::string mapValTypeName;
-            if (auto *containerMeta = getMeta(objPtr))
-                mapValTypeName = containerMeta->map_value_type_name;
             if (!mapValTypeName.empty())
                 propagateTypeMeta(mapValTypeName, oldVal);
             llvm::Value *rhs = emitExpr(*s.value);
@@ -778,7 +800,7 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
             // Compound result is a fresh alloc (never aliases the old
             // slot); reuse the pre-op load rather than re-loading (#812).
             if (mapValIsArc)
-                emitArcReleaseLoadedElement(oldVal, mapValArcKind, "map_val_compound");
+                emitArcReleaseLoadedElement(oldVal, mapValArcKind, mapValTypeName, "map_val_compound");
             builder_.CreateStore(newVal, valElemPtr);
             return;
         }
@@ -811,7 +833,7 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         if (mapValIsArc) {
             retainArcValue(rhsVal);
             llvm::Value *oldVal = builder_.CreateLoad(ptrTy_, valElemPtr, "map_val_arc_old");
-            emitArcReleaseLoadedElement(oldVal, mapValArcKind, "map_val");
+            emitArcReleaseLoadedElement(oldVal, mapValArcKind, mapValTypeName, "map_val");
         }
         builder_.CreateStore(rhsVal, valElemPtr);
         builder_.CreateBr(endBB);
@@ -923,18 +945,21 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     CollectionKind elemArcKind = CollectionKind::List;
     bool elemIsArc = elementTypeIsArcManaged(objPtr, CollectionKind::List, &elemArcKind);
 
+    // Snapshot list_elem_type_name before propagateTypeMeta: the
+    // getOrCreateMeta inside it may rehash value_metadata_ and invalidate a
+    // raw pointer from getMeta. See KNOWLEDGE.md "Compound-op loaded slot
+    // values must propagate container metadata" and #858. Extracted here
+    // (before the compound/plain branch) so both paths can pass it to
+    // emitArcReleaseLoadedElement for the specialized str-aware destructor
+    // (#1108).
+    std::string elemTypeName;
+    if (auto *containerMeta = getMeta(objPtr))
+        elemTypeName = containerMeta->list_elem_type_name;
+
     llvm::Value *finalVal = nullptr;
     llvm::Value *compoundOldVal = nullptr;  // captured for the ARC release path
     if (s.compound_op) {
         compoundOldVal = builder_.CreateLoad(elemTy, elemPtr, "list_elem_cur");
-        // Snapshot list_elem_type_name before propagateTypeMeta: the
-        // getOrCreateMeta inside it may rehash value_metadata_ and
-        // invalidate the raw pointer from getMeta. See KNOWLEDGE.md
-        // "Compound-op loaded slot values must propagate container
-        // metadata" and #858.
-        std::string elemTypeName;
-        if (auto *containerMeta = getMeta(objPtr))
-            elemTypeName = containerMeta->list_elem_type_name;
         if (!elemTypeName.empty())
             propagateTypeMeta(elemTypeName, compoundOldVal);
         llvm::Value *rhs = emitExpr(*s.value);
@@ -969,11 +994,11 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     // needed.
     if (elemIsArc) {
         if (s.compound_op) {
-            emitArcReleaseLoadedElement(compoundOldVal, elemArcKind, "list_elem_compound");
+            emitArcReleaseLoadedElement(compoundOldVal, elemArcKind, elemTypeName, "list_elem_compound");
         } else {
             retainArcValue(finalVal);
             llvm::Value *oldVal = builder_.CreateLoad(ptrTy_, elemPtr, "list_elem_arc_old");
-            emitArcReleaseLoadedElement(oldVal, elemArcKind, "list_elem");
+            emitArcReleaseLoadedElement(oldVal, elemArcKind, elemTypeName, "list_elem");
         }
     }
 

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -50,10 +50,10 @@ void CodeGen::emitArcReleaseLoadedElement(llvm::Value *oldElemVal,
             if (splitGenericTypeName(resolved, head, innerArgs)) {
                 if ((elemKind == CollectionKind::List || elemKind == CollectionKind::Set) &&
                     !innerArgs.empty()) {
-                    innerElemSig = innerArgs[0];
+                    innerElemSig = resolveTypeAlias(innerArgs[0]);
                 } else if (elemKind == CollectionKind::Map && innerArgs.size() >= 2) {
-                    innerElemSig = innerArgs[0];
-                    innerValSig  = innerArgs[1];
+                    innerElemSig = resolveTypeAlias(innerArgs[0]);
+                    innerValSig  = resolveTypeAlias(innerArgs[1]);
                 }
             }
         }

--- a/tests/spec/arc_release_on_field_overwrite.test.ry
+++ b/tests/spec/arc_release_on_field_overwrite.test.ry
@@ -40,6 +40,9 @@ record AliasListBox:
 record AliasMapBox:
   items: StrIntMap
 
+record StrListBox:
+  items: List<str>
+
 describe("ARC release on record field overwrite (VariableExpr branch)", ():
   it("List<int> field repeated overwrite", ():
     b = FieldBox([1, 2, 3])
@@ -216,5 +219,34 @@ describe("ARC release on heap record field overwrite (IndexExpr branch)", ():
     grid: List<FieldBox> = [FieldBox([1, 2])]
     grid[0].items += [3]
     expect(grid[0].items).to_eq([1, 2, 3])
+  )
+)
+
+# Issue #1108: record field whose type is List<str> — the str handles inside
+# the old list must be released when the field is overwritten.
+describe("ARC release on record field overwrite with str-typed collection (#1108)", ():
+  it("List<str> field repeated overwrite does not leak str handles", ():
+    b = StrListBox(["hello", "world"])
+    b.items = ["goodbye"]
+    b.items = ["a", "b", "c"]
+    expect(b.items[0]).to_eq("a")
+    expect(length(b.items)).to_eq(3)
+  )
+
+  it("List<str> field overwrite in a loop does not leak", ():
+    b = StrListBox(["initial"])
+    i = 0
+    while i < 16:
+      b.items = ["overwritten"]
+      i = i + 1
+    expect(b.items[0]).to_eq("overwritten")
+    expect(length(b.items)).to_eq(1)
+  )
+
+  it("List<str> field self-assignment is safe", ():
+    b = StrListBox(["hello", "world"])
+    b.items = b.items
+    expect(b.items[0]).to_eq("hello")
+    expect(length(b.items)).to_eq(2)
   )
 )

--- a/tests/spec/arc_release_on_index_overwrite.test.ry
+++ b/tests/spec/arc_release_on_index_overwrite.test.ry
@@ -164,3 +164,51 @@ describe("ARC live-count leak detection (runtime_internal)", ():
     expect(after - before < 10).to_eq(true)
   )
 )
+
+# Issue #1108: emitArcReleaseLoadedElement was calling
+# getOrCreateCollectionDestructor without elemSig/valSig, so the generic
+# destructor (outer buffer free only) was used instead of the str-aware one.
+# These tests verify that str elements inside nested collections are released
+# on slot overwrite.  ASan/LSan is the primary gate; the functional assertions
+# confirm correctness as well.
+
+describe("ARC release on str-typed nested element overwrite (#1108)", ():
+  it("List<List<str>> repeated overwrite does not leak str handles", ():
+    xs: List<List<str>> = [["hello", "world"], ["foo"]]
+    xs[0] = ["goodbye"]
+    xs[0] = ["a", "b", "c"]
+    expect(xs[0][0]).to_eq("a")
+    expect(xs[0][2]).to_eq("c")
+    expect(xs[1][0]).to_eq("foo")
+  )
+
+  it("List<List<str>> loop overwrite: live count grows by O(1) not O(N)", ():
+    before = arc_live_count()
+    xs: List<List<str>> = [["initial"]]
+    i = 0
+    while i < 16:
+      xs[0] = ["overwritten"]
+      i = i + 1
+    delta = arc_live_count() - before
+    expect(delta < 10).to_eq(true)
+  )
+
+  it("Map<str, List<str>> value overwrite does not leak str handles", ():
+    m: Map<str, List<str>> = {"key": ["hello", "world"]}
+    m["key"] = ["goodbye"]
+    m["key"] = ["x", "y"]
+    expect(m["key"][0]).to_eq("x")
+    expect(m["key"][1]).to_eq("y")
+  )
+
+  it("Map<str, List<str>> loop overwrite: live count grows by O(1) not O(N)", ():
+    before = arc_live_count()
+    m: Map<str, List<str>> = {"k": ["initial"]}
+    i = 0
+    while i < 16:
+      m["k"] = ["overwritten"]
+      i = i + 1
+    delta = arc_live_count() - before
+    expect(delta < 10).to_eq(true)
+  )
+)

--- a/tests/spec/arc_release_on_index_overwrite.test.ry
+++ b/tests/spec/arc_release_on_index_overwrite.test.ry
@@ -212,3 +212,29 @@ describe("ARC release on str-typed nested element overwrite (#1108)", ():
     expect(delta < 10).to_eq(true)
   )
 )
+
+# Alias-backed inner type regression (#1108 follow-up): innerArgs from
+# splitGenericTypeName must themselves be resolved via resolveTypeAlias so that
+# alias-spelled inner element types select the str-aware destructor.
+type StrList = List<str>
+
+describe("ARC release with alias-backed inner element type (#1108 alias)", ():
+  it("List<StrList> overwrite releases str handles", ():
+    xs: List<StrList> = [["hello", "world"]]
+    xs[0] = ["goodbye"]
+    xs[0] = ["a", "b"]
+    expect(xs[0][0]).to_eq("a")
+    expect(xs[0][1]).to_eq("b")
+  )
+
+  it("List<StrList> loop overwrite: live count grows by O(1) not O(N)", ():
+    before = arc_live_count()
+    xs: List<StrList> = [["initial"]]
+    i = 0
+    while i < 16:
+      xs[0] = ["overwritten"]
+      i = i + 1
+    delta = arc_live_count() - before
+    expect(delta < 10).to_eq(true)
+  )
+)

--- a/tests/spec/compound_assign_arc_element.test.ry
+++ b/tests/spec/compound_assign_arc_element.test.ry
@@ -108,4 +108,20 @@ describe("compound assignment on ARC-managed map/set element slots (issue #866)"
     expect(xs[0]).to_have_length(3)
     expect(other).to_have_length(2)
   )
+
+  it("List<List<str>> xs[i] += literal appends and releases old inner list (#1108)", ():
+    xs: List<List<str>> = [["a", "b"]]
+    xs[0] += ["c"]
+    expect(xs[0]).to_have_length(3)
+    expect(xs[0][0]).to_eq("a")
+    expect(xs[0][2]).to_eq("c")
+  )
+
+  it("List<List<str>> xs[i] += variable preserves variable (#1108)", ():
+    xs: List<List<str>> = [["x"]]
+    extra: List<str> = ["y", "z"]
+    xs[0] += extra
+    expect(xs[0]).to_have_length(3)
+    expect(extra).to_have_length(2)
+  )
 )


### PR DESCRIPTION
## Summary

- `emitArcReleaseLoadedElement` was calling `getOrCreateCollectionDestructor` without elem/val type signatures, causing the generic destructor (outer-buffer free only) to be selected for nested collection types
- Overwriting a slot in `List<List<str>>`, `Map<K, List<str>>`, or a record field containing `List<str>` would silently leak all inner `str` handles
- Fix: add `elemTypeName` parameter, resolve alias via `resolveTypeAlias`, parse inner type sigs via `splitGenericTypeName` (hoisted from file-scope static to `CodeGen` private static member), and pass to `getOrCreateCollectionDestructor`
- All 7 call sites updated (3 in `emitArcFieldReleaseOnOverwrite` lambda, 2 in map path, 2 in list path); record field release path in `codegen_arc.cpp` also fixed

## Test plan

- [ ] `./build/ry_tests` — 1791 C++ tests pass
- [ ] `./build/ry test -p` — 141 Ry self-test files pass
- [ ] `tests/spec/arc_release_on_index_overwrite.test.ry` — new `#1108` describe block: `List<List<str>>` and `Map<str, List<str>>` overwrite + live-count O(1) checks
- [ ] `tests/spec/arc_release_on_field_overwrite.test.ry` — new `#1108` describe block: `StrListBox` field overwrite correctness and loop
- [ ] `tests/spec/compound_assign_arc_element.test.ry` — new `#1108` tests: `List<List<str>> xs[0] += ["c"]` and variable compound
- [ ] ASan + UBSan clean: `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry test -p`
- [ ] TSan clean: `cmake --preset tsan && cmake --build build-tsan && TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests`

Closes #1108

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a memory leak when overwriting slots in nested collections (e.g., List<List<str>>, Map<K, List<str>>, and record fields) so inner string handles are released correctly.

* **Tests**
  * Added comprehensive tests covering overwrite and compound-assignment scenarios for nested collections and alias-backed cases to prevent regressions.

* **Documentation**
  * Clarified release-path requirements: helpers must be given the declared element type name so specialized destructors correctly release inner elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->