### PR TITLE
test(result): add Result type inference regression tests for unannotated lambdas (#1036)

### DIFF
--- a/tests/spec/result_type_inference.test.ry
+++ b/tests/spec/result_type_inference.test.ry
@@ -1,0 +1,85 @@
+describe("Result type inference in unannotated lambdas", ():
+  it("should infer Result when (x) has no annotation and body is if-expr Ok/Err — ok path", ():
+    r: Result<int, Error> = Ok(42)
+    r2 = r.and_then((x) => if x > 10 => Ok(x * 2) else Err(Error("too small")))
+    case r2:
+      Ok(v): expect(v).to_eq(84)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+  )
+
+  it("should infer Result when (x) has no annotation and body is if-expr Ok/Err — err path", ():
+    r: Result<int, Error> = Ok(5)
+    r2 = r.and_then((x) => if x > 10 => Ok(x * 2) else Err(Error("too small")))
+    case r2:
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("too small")
+  )
+
+  it("should chain two unannotated (x) => if ... Ok/Err lambdas — both ok", ():
+    r: Result<int, Error> = Ok(100)
+    r2 = r.and_then((x) => if x > 50 => Ok(x - 50) else Err(Error("small"))).and_then((y) => if y > 10 => Ok(y) else Err(Error("still small")))
+    case r2:
+      Ok(v): expect(v).to_eq(50)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+  )
+
+  it("should chain two unannotated lambdas — first short-circuits", ():
+    r: Result<int, Error> = Ok(5)
+    r2 = r.and_then((x) => if x > 50 => Ok(x - 50) else Err(Error("small"))).and_then((y) => if y > 10 => Ok(y) else Err(Error("still small")))
+    case r2:
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("small")
+  )
+
+  it("should chain two unannotated lambdas — second short-circuits", ():
+    r: Result<int, Error> = Ok(55)
+    r2 = r.and_then((x) => if x > 50 => Ok(x - 50) else Err(Error("small"))).and_then((y) => if y > 10 => Ok(y) else Err(Error("still small")))
+    case r2:
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("still small")
+  )
+
+  it("should infer Result from 3-branch if-else-if-else with typed param", ():
+    f = (x: int) => if x > 0 => Ok(x) else if x == 0 => Ok(0) else Err(Error("neg"))
+    case f(5):
+      Ok(v): expect(v).to_eq(5)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    case f(0):
+      Ok(v): expect(v).to_eq(0)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    case f(-5):
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("neg")
+  )
+
+  it("should infer variable-bound lambda type and allow later case-match", ():
+    f = (x: int) => if x > 0 => Ok(x) else Err(Error("non-positive"))
+    case f(5):
+      Ok(v): expect(v).to_eq(5)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    case f(-1):
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("non-positive")
+  )
+
+  it("should infer Result via map with unannotated param — ok preserved", ():
+    r: Result<int, Error> = Ok(21)
+    r2 = r.map((x) => x * 2)
+    case r2:
+      Ok(v): expect(v).to_eq(42)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+  )
+
+  it("should still work with explicit -> Result<int, Error> annotation on and_then callback (regression guard)", ():
+    r: Result<int, Error> = Ok(20)
+    r2 = r.and_then((v: int) -> Result<int, Error> => if v > 10 => Ok(v * 2) else Err(Error("too small")))
+    case r2:
+      Ok(v): expect(v).to_eq(40)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    r3: Result<int, Error> = Ok(5)
+    r4 = r3.and_then((v: int) -> Result<int, Error> => if v > 10 => Ok(v * 2) else Err(Error("too small")))
+    case r4:
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("too small")
+  )
+)


### PR DESCRIPTION
## Summary

- Add `tests/spec/result_type_inference.test.ry` with 9 regression test cases covering Result type inference patterns for unannotated lambdas
- Complements `result_lambda_if.test.ry` (PR #1044) which was limited to 2-branch if-expr + typed params

## Test cases added

| # | Pattern | Status |
|---|---|---|
| 1 | `(x) => if ... Ok/Err` in `and_then` — ok path | ✅ pass |
| 2 | `(x) => if ... Ok/Err` in `and_then` — err path | ✅ pass |
| 3 | two chained unannotated lambdas — both ok | ✅ pass |
| 4 | two chained unannotated lambdas — first short-circuits | ✅ pass |
| 5 | two chained unannotated lambdas — second short-circuits | ✅ pass |
| 6 | 3-branch `if/else if/else` with typed param | ✅ pass |
| 7 | variable-bound lambda + subsequent `case`-match | ✅ pass |
| 8 | `map` with unannotated param | ✅ pass |
| 9 | explicit `-> Result<int, Error>` annotation on callback (regression guard) | ✅ pass |

## Scope-out findings

Two bugs discovered during test authoring that are outside this PR's scope are tracked in #1111:
1. **Silent wrong value**: `r2: Result<int, Error> = r.and_then((x) => ...)` returns `Ok(0)` instead of the correct value when `r2` has a type annotation
2. **3-branch unannotated unify failure**: `(x) => if ... Ok/Ok/Err` produces "all branches must have the same type" compile error

Both patterns are intentionally avoided in this test file using workarounds. Tests for the fixed behavior will be added in the #1111 fix PR.

## Documentation

- `README.md` / `docs/reference/`: no update needed (test-only, no behavior change)
- `changelog.d/`: no update needed (test-only, no user-visible impact)
- `KNOWLEDGE.md`: no update needed (no new pitfalls discovered beyond what was already documented at line 2831)

Closes #1036

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for type inference in lambda expressions, including verification of result type inference for chained callback methods, multi-branch conditional logic, and error short-circuiting behavior. Tests ensure backward compatibility with explicitly annotated callbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->