### PR TITLE
test(strings): add regression tests for NUL-byte and str[i] diagnostic (#1034)

### DIFF
--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -354,6 +354,12 @@ describe("NUL byte handling", ():
     expect("a\0b" == "a\0c").to_eq(false)
     expect("a\0" == "a").to_eq(false)
   )
+  it("inequality distinguishes strings with embedded NUL (#1022)", ():
+    expect("a" != "a\0b").to_eq(true)
+    expect("a\0b" != "a\0b").to_eq(false)
+    expect("a\0b" != "a\0c").to_eq(true)
+    expect("a\0" != "a").to_eq(true)
+  )
   it("concat preserves embedded NUL bytes", ():
     s = "a\0" + "b\0"
     expect(byte_len(s)).to_eq(4)
@@ -389,6 +395,11 @@ describe("NUL byte handling", ():
     expect(contains("A\0B", "a\0b", true)).to_eq(true)
     expect(contains("A\0B", "a\0c", true)).to_eq(false)
   )
+  it("contains finds bare NUL needle (#1022)", ():
+    expect(contains("a\0b", "\0")).to_eq(true)
+    expect(contains("abc", "\0")).to_eq(false)
+    expect(contains("\0", "\0")).to_eq(true)
+  )
   it("starts_with with embedded NUL (#1047)", ():
     expect(starts_with("a\0b", "a\0")).to_eq(true)
     expect(starts_with("a\0b", "a\0c")).to_eq(false)
@@ -410,6 +421,12 @@ describe("NUL byte handling", ():
     expect(find("a\0b", "\0b")).to_eq(Some(1))
     expect(find("a\0b", "b")).to_eq(Some(2))
     expect(find("a\0b", "c")).to_be_none()
+  )
+  it("find returns first match in multi-NUL haystack (#1022)", ():
+    expect(find("a\0b\0c", "\0")).to_eq(Some(1))
+    expect(find("a\0b\0c", "\0c")).to_eq(Some(3))
+    expect(find("a\0b\0c", "b\0c")).to_eq(Some(2))
+    expect(find("\0\0\0", "\0")).to_eq(Some(0))
   )
   it("empty needle parity for NUL-containing strings (#1047)", ():
     s = "a\0b"

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -773,14 +773,37 @@ TEST_F(CodeGenTest, StrIndexAccessRejected) {
     expectCompileError(
         "s = \"hello\"\n"
         "_ = s[0]\n",
-        "does not support index access");
+        {"str", "char_at"});
+}
+
+TEST_F(CodeGenTest, StrLiteralIndexAccessRejected) {
+    expectCompileError(
+        "_ = \"hello\"[0]\n",
+        {"str", "char_at"});
+}
+
+TEST_F(CodeGenTest, StrFnReturnIndexAccessRejected) {
+    expectCompileError(
+        "function f() -> str:\n"
+        "    return \"x\"\n"
+        "_ = f()[0]\n",
+        {"str", "char_at"});
 }
 
 TEST_F(CodeGenTest, StrIndexAssignmentRejected) {
     expectCompileError(
         "s = \"hello\"\n"
         "s[0] = \"x\"\n",
-        "does not support index assignment");
+        {"str", "immutable"});
+}
+
+TEST_F(CodeGenTest, StrFnReturnVarIndexAssignmentRejected) {
+    expectCompileError(
+        "function f() -> str:\n"
+        "    return \"x\"\n"
+        "s = f()\n"
+        "s[0] = \"y\"\n",
+        {"str", "immutable"});
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

- **Set A (NUL-byte gap coverage)** — three new `it(...)` blocks added to the existing `describe("NUL byte handling", ...)` section in `tests/spec/strings.test.ry`:
  - `!=` operator on NUL-containing strings (mirrors the existing `==` tests)
  - `contains` with a bare `"\0"` needle (existing tests only covered `"\0b"` / `"a\0"` needles)
  - `find` with a multi-NUL haystack (existing test only covered single-NUL haystack)
- **Set B (str[i] diagnostic coverage)** — `tests/test_codegen_type_safety.cpp` extended:
  - Existing `StrIndexAccessRejected` / `StrIndexAssignmentRejected` strengthened to multi-fragment form `{"str","char_at"}` / `{"str","immutable"}` so both the type name and the recommended alternative must appear in the diagnostic
  - New `StrLiteralIndexAccessRejected` — tests literal form `"hello"[0]`
  - New `StrFnReturnIndexAccessRejected` — tests function-return form `f()[0]`
  - New `StrFnReturnVarIndexAssignmentRejected` — tests write-path via function-return variable

Closes #1034

## Test plan

- [x] `./build/ry_tests` — 1794 tests passed, 0 failed
- [x] `./build/ry test -p` — 141 test files, 0 failures
- [x] `./build/ry test tests/spec/strings.test.ry` — 108 passed, 0 failed (NUL byte handling block verified)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for NUL byte string operations including inequality comparisons, substring search, and find operations with multiple NUL bytes
  * Updated string indexing error diagnostics to provide more specific compile-time error messages for improved developer experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->