### PR TITLE
fix(result): Result type inference for typed binding + unannotated lambda and 3-branch if-expr (#1111)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2694,7 +2694,7 @@ testResult = phi;
 
 ### Post-hoc Result coercion: preferred over modifying Ok/Err constructors for annotation-driven type resolution
 
-**Source**: #1001 (2026-04-16, design choice); updated #1111 (2026-04-17, anyTy_ runtime branch + both-slot bailout fix)
+**Source**: #1001 (2026-04-16, design choice); updated #1111 (2026-04-17, `anyTy_` runtime branch + both-slot bailout fix)
 **Tags**: codegen_stmt, coercion, Result, Ok, Err, annotation, emitVarDecl, anyTy_, type-inference
 
 **Rule**: When `Err([...])` (or `Ok(...)`) yields a Result struct whose layout does not match the variable's type annotation, fix the mismatch in `emitVarDecl`'s post-hoc coercion chain (`coerceResultType`) rather than threading the annotation down into the Ok/Err constructor emitter in `codegen_call.cpp`.
@@ -2836,7 +2836,7 @@ Alternatively, derive run IDs directly from `detailsUrl` in the `gh pr checks` o
 
 ### `inferExprType` / `inferExprTypeName` visitor must handle `IfExpr`/`IfBlockExpr` and ADT constructors (`Ok`/`Err`/`Some`/`None`/`Error`) to infer lambda return type correctly
 
-**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog); #1111 (2026-04-17, bugfix — Error constructor + anyTy_ IfExpr merge)
+**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog); #1111 (2026-04-17, bugfix — Error constructor + `anyTy_` IfExpr merge)
 **Tags**: codegen, inference, visitor, lambda, Result, Option, IfExpr, anyTy_, Error
 
 **Rule**: `inferExprType` and `inferExprTypeName` in `src/codegen_lambda.cpp` are the visitor functions that determine the return type of an expression-body lambda (`(x: int) => expr`). Both functions must have explicit `if constexpr` cases for every AST node that can appear as the outermost expression. Any unhandled node falls through to the default which returns `i64Ty_` (= `int`) — silently and without error.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2694,7 +2694,7 @@ testResult = phi;
 
 ### Post-hoc Result coercion: preferred over modifying Ok/Err constructors for annotation-driven type resolution
 
-**Source**: #1001 (2026-04-16, design choice); updated #1111 (2026-04-17, anyTy_ runtime branch)
+**Source**: #1001 (2026-04-16, design choice); updated #1111 (2026-04-17, anyTy_ runtime branch + both-slot bailout fix)
 **Tags**: codegen_stmt, coercion, Result, Ok, Err, annotation, emitVarDecl, anyTy_, type-inference
 
 **Rule**: When `Err([...])` (or `Ok(...)`) yields a Result struct whose layout does not match the variable's type annotation, fix the mismatch in `emitVarDecl`'s post-hoc coercion chain (`coerceResultType`) rather than threading the annotation down into the Ok/Err constructor emitter in `codegen_call.cpp`.
@@ -2702,11 +2702,12 @@ testResult = phi;
 **Why**: The Ok/Err constructors can be called from many contexts (function arguments, return values, inlined expressions) where the target type is unavailable or ambiguous. Post-hoc coercion at the declaration site is localised, mirrors the existing Option auto-wrap pattern.
 
 **How to apply**: `coerceResultType(val, dstResTy)` in `codegen_stmt.cpp`:
-- Both payload types differ → return `nullptr` (genuine type error).
-- Exactly one payload type differs AND the mismatched src slot is `anyTy_` (unannotated lambda param) → emit a **runtime disc branch** (disc=1 → Ok, disc=0 → Err), `unwrapFromAny` the any-typed payload to the dst concrete type in the active path, PHI the two rebuilt structs. A compile-time slot selection silently zeroes the active payload for the wrong disc value (#1111 Manifestation 1).
-- Exactly one payload type differs AND the mismatched src slot is `i8Ty_` placeholder → compile-time slot copy is safe (the value is structurally always-Err or always-Ok), avoids emitting a pointless dead-code branch.
+- Compute `okNeedsRuntimeBranch` and `errNeedsRuntimeBranch` **before** the early bailout. These booleans check: `isAnyType(srcSlotTy) && !isAnyType(dstSlotTy) && dstSlotTy != i8Ty_ && canAnyHoldType(dstSlotTy)`. They must be available at the bailout call site (#1111 CodeRabbit review finding).
+- **Bailout condition**: `srcOkTy != dstOkTy && srcErrTy != dstErrTy && (!okNeedsRuntimeBranch || !errNeedsRuntimeBranch)` → return `nullptr` (genuine type error). The original `both differ → nullptr` was wrong for `Result<any,any> → Result<T1,T2>`. Single-slot mismatches with `i8Ty_` placeholder (Err constructor) or `errorTy_` default (Ok constructor) are safe — the compile-time path handles them via zero-fill of the inactive slot.
+- Both slots differ AND both can be anyTy_-unwrapped → emit a **runtime disc branch** (disc=1 → Ok, disc=0 → Err), `unwrapFromAny` the any-typed payload to the dst concrete type in the active path, PHI the two rebuilt structs. A compile-time slot selection silently zeroes the active payload for the wrong disc value (#1111 Manifestation 1).
+- Exactly one slot differs AND the mismatched src slot is `i8Ty_` / `errorTy_` placeholder → compile-time slot copy of the matching slot is safe; avoids a dead-code branch.
 - The `Ok` emitter (`codegen_call.cpp`) must also unwrap `anyTy_` inner to the expected ok type from `fn_->getReturnType()` when building the Result struct — otherwise two branches of an if-expr (e.g., `Ok(x)` vs `Ok(0)`) produce different Result struct types and `validateBranchTypes` rejects them (#1111 Manifestation 2, fixed alongside `inferExprType`).
-- Return `nullptr` if both payload types differ (genuine type error). Add the same coercion branch to variable reassignment handlers for consistency.
+- Add the same coercion branch to variable reassignment handlers for consistency.
 
 ### `propagateTypeMeta`: handle both `Option<T>` prefix and `T?` suffix — they are the same type
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2694,14 +2694,19 @@ testResult = phi;
 
 ### Post-hoc Result coercion: preferred over modifying Ok/Err constructors for annotation-driven type resolution
 
-**Source**: #1001 (2026-04-16, design choice)
-**Tags**: codegen_stmt, coercion, Result, Ok, Err, annotation, emitVarDecl
+**Source**: #1001 (2026-04-16, design choice); updated #1111 (2026-04-17, anyTy_ runtime branch)
+**Tags**: codegen_stmt, coercion, Result, Ok, Err, annotation, emitVarDecl, anyTy_, type-inference
 
 **Rule**: When `Err([...])` (or `Ok(...)`) yields a Result struct whose layout does not match the variable's type annotation, fix the mismatch in `emitVarDecl`'s post-hoc coercion chain (`coerceResultType`) rather than threading the annotation down into the Ok/Err constructor emitter in `codegen_call.cpp`.
 
-**Why**: The Ok/Err constructors can be called from many contexts (function arguments, return values, inlined expressions) where the target type is unavailable or ambiguous. Post-hoc coercion at the declaration site is localised, mirrors the existing Option auto-wrap pattern, and is safe because the inactive field of a Result is always zero (never read through the discriminant).
+**Why**: The Ok/Err constructors can be called from many contexts (function arguments, return values, inlined expressions) where the target type is unavailable or ambiguous. Post-hoc coercion at the declaration site is localised, mirrors the existing Option auto-wrap pattern.
 
-**How to apply**: `coerceResultType(val, dstResTy)` in `codegen_stmt.cpp` — extract discriminant and the matching payload, zero the non-matching payload with `getNullValue`, rebuild via `CreateInsertValue`, then `propagateMeta(val, coerced)`. Return `nullptr` if both payload types differ (genuine type error). Add the same coercion branch to variable reassignment handlers for consistency.
+**How to apply**: `coerceResultType(val, dstResTy)` in `codegen_stmt.cpp`:
+- Both payload types differ → return `nullptr` (genuine type error).
+- Exactly one payload type differs AND the mismatched src slot is `anyTy_` (unannotated lambda param) → emit a **runtime disc branch** (disc=1 → Ok, disc=0 → Err), `unwrapFromAny` the any-typed payload to the dst concrete type in the active path, PHI the two rebuilt structs. A compile-time slot selection silently zeroes the active payload for the wrong disc value (#1111 Manifestation 1).
+- Exactly one payload type differs AND the mismatched src slot is `i8Ty_` placeholder → compile-time slot copy is safe (the value is structurally always-Err or always-Ok), avoids emitting a pointless dead-code branch.
+- The `Ok` emitter (`codegen_call.cpp`) must also unwrap `anyTy_` inner to the expected ok type from `fn_->getReturnType()` when building the Result struct — otherwise two branches of an if-expr (e.g., `Ok(x)` vs `Ok(0)`) produce different Result struct types and `validateBranchTypes` rejects them (#1111 Manifestation 2, fixed alongside `inferExprType`).
+- Return `nullptr` if both payload types differ (genuine type error). Add the same coercion branch to variable reassignment handlers for consistency.
 
 ### `propagateTypeMeta`: handle both `Option<T>` prefix and `T?` suffix — they are the same type
 
@@ -2828,24 +2833,31 @@ gh run list --branch <headRefName> --limit 20 \
 
 Alternatively, derive run IDs directly from `detailsUrl` in the `gh pr checks` output (`grep -oE '/runs/([0-9]+)' | grep -oE '[0-9]+'`).
 
-### `inferExprType` / `inferExprTypeName` visitor must handle `IfExpr`/`IfBlockExpr` and ADT constructors (`Ok`/`Err`/`Some`/`None`) to infer lambda return type correctly
+### `inferExprType` / `inferExprTypeName` visitor must handle `IfExpr`/`IfBlockExpr` and ADT constructors (`Ok`/`Err`/`Some`/`None`/`Error`) to infer lambda return type correctly
 
-**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog)
-**Tags**: codegen, inference, visitor, lambda, Result, Option, IfExpr
+**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog); #1111 (2026-04-17, bugfix — Error constructor + anyTy_ IfExpr merge)
+**Tags**: codegen, inference, visitor, lambda, Result, Option, IfExpr, anyTy_, Error
 
 **Rule**: `inferExprType` and `inferExprTypeName` in `src/codegen_lambda.cpp` are the visitor functions that determine the return type of an expression-body lambda (`(x: int) => expr`). Both functions must have explicit `if constexpr` cases for every AST node that can appear as the outermost expression. Any unhandled node falls through to the default which returns `i64Ty_` (= `int`) — silently and without error.
 
-Two gaps were confirmed in #1024:
-1. **`IfExpr` / `IfBlockExpr`** — neither visitor had a case for these nodes, so any lambda whose body is an `if` expression with mismatched-type branches (e.g., `Ok(T)` vs `Err(E)`) fell through to `int`, baking the wrong return type into the function signature before codegen.
-2. **`Ok` / `Err` in CallExpr** — the CallExpr branch already had a `Some` case but not `Ok`/`Err`. Without these, the Ok/Err payload types could not be inferred, making the IfExpr merge logic unreachable even after adding it.
+Confirmed gaps (all fixed):
+1. **`IfExpr` / `IfBlockExpr`** — neither visitor had a case for these nodes, so any lambda whose body is an `if` expression with mismatched-type branches (e.g., `Ok(T)` vs `Err(E)`) fell through to `int`, baking the wrong return type into the function signature before codegen. (#1024)
+2. **`Ok` / `Err` in CallExpr** — the CallExpr branch had `Some` but not `Ok`/`Err`. Without these, the Ok/Err payload types could not be inferred, making the IfExpr merge logic unreachable even after adding it. (#1024)
+3. **`Error` constructor in CallExpr** — `Err(Error("msg"))` must infer as `getResultType(i8Ty_, errorTy_)`. Without an explicit `if (c == "Error") return errorTy_` case, it falls through to `i64Ty_`, making the inferred branch type `{i1, i8, i64}` instead of `{i1, i8, errorTy_}`. The IfExpr merge then produces the wrong StructType pointer, and `validateBranchTypes` rejects the mismatch. (#1111)
 
-**Result merge logic (IfExpr)**: When both branches of an `if` expression yield `isResultType`, the inferred types are `{i1, realOkTy, Unit}` and `{i1, Unit, realErrTy}` (each side uses `i8Ty_` as the placeholder for the missing payload). Merge by preferring the non-`i8Ty_` element for each of Ok and Err:
+**Result merge logic (IfExpr)**: When both branches of an `if` expression yield `isResultType`, the inferred types are `{i1, realOkTy, Unit}` and `{i1, Unit, realErrTy}` (each side uses `i8Ty_` as the placeholder for the missing payload). Also, unannotated lambda params yield `anyTy_` — which must lose to a concrete type but win over `i8Ty_`. Use a `preferConcrete` merge:
 ```cpp
-llvm::Type *mergedOk = (okA == i8Ty_) ? okB : okA;
-llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
-return getResultType(mergedOk, mergedEr);
+// Priority: concrete > anyTy_ (unannotated param) > i8Ty_ (absent-payload placeholder)
+auto preferConcrete = [&](llvm::Type *a, llvm::Type *b) -> llvm::Type * {
+    if (a == i8Ty_) return b;
+    if (!isAnyType(a)) return a;
+    return (b != i8Ty_) ? b : a; // a=any: prefer concrete b, else keep any
+};
+return getResultType(preferConcrete(okA, okB), preferConcrete(erA, erB));
 ```
-This produces the correct unified `Result<T, Error>` StructType that both `Ok` and `Err` emitters in `codegen_call.cpp` will reuse via `fn_->getReturnType()`.
+The old `(a == i8Ty_) ? b : a` rule was broken for `anyTy_`: `(any, i8) → i8` (wrong) instead of `any`. (#1111)
+
+**`Ok` emitter must unwrap `anyTy_` to the expected ok type**: When `fn_->getReturnType()` indicates a concrete ok type (e.g., `i64`) but `Ok(x)` emits with `x` of type `anyTy_` (unannotated param), the emitted Result struct is `{i1, anyTy_, errTy}` — different from the `{i1, i64, errTy}` produced by `Ok(0)`. `validateBranchTypes` pointer-equality fails. Fix: in the `Ok` emitter (`codegen_call.cpp`), after deriving `expectedOkTy` from `retStructTy->getElementType(1)`, call `unwrapFromAny(inner, expectedOkTy)` when `isAnyType(inner->getType()) && canAnyHoldType(expectedOkTy)`. (#1111)
 
 **Option merge logic (IfExpr — fixed in #1043)**: Option layout is 2-slot `{i1, innerTy}` vs Result's 3-slot. Three gaps existed beyond the structural #1024 analog:
 1. `Some` was missing from `inferExprType` (it was only in `inferExprTypeName`), causing `(x) => Some(x)` to fail.

--- a/changelog.d/1111-result-type-inference-fix.md
+++ b/changelog.d/1111-result-type-inference-fix.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Result-returning lambda with unannotated parameter no longer loses its `Ok` payload when flowing into a typed `Result<T, E>` binding (#1111)
+- Unannotated lambda body with 3+ branches constructing `Err(Error(...))` now compiles without "all branches must have the same type" error (#1111)

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -794,15 +794,24 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
     if (e.callee == "Ok") {
         requireArgs(e, 1);
         llvm::Value *inner = emitExpr(*e.args[0]);
-        // Determine the error type from the enclosing function's return type
+        // Determine the error type (and expected ok type) from the enclosing function's return type
         llvm::Type *errTy = errorTy_;
+        llvm::Type *expectedOkTy = nullptr;
         if (fn_) {
             llvm::Type *retTy = fn_->getReturnType();
             if (isResultType(retTy)) {
                 auto *retStructTy = llvm::cast<llvm::StructType>(retTy);
                 errTy = retStructTy->getElementType(2);
+                expectedOkTy = retStructTy->getElementType(1);
             }
         }
+        // Unwrap any-typed value to the expected ok type when the function return type
+        // is more specific (e.g. unannotated param `x` emits as anyTy_ but Ok(x) in a
+        // branch alongside Ok(0) must produce the same Result struct type).
+        if (expectedOkTy && isAnyType(inner->getType()) &&
+            !isAnyType(expectedOkTy) && expectedOkTy != i8Ty_ &&
+            canAnyHoldType(expectedOkTy))
+            inner = unwrapFromAny(inner, expectedOkTy);
         llvm::StructType *resTy = getResultType(inner->getType(), errTy);
         return buildOkValue(inner, resTy);
     }

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -615,6 +615,8 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
             if (c == "None" && v->args.empty()) {
                 return getOptionType(i8Ty_); // placeholder — merged in IfExpr arm
             }
+            if (c == "Error")
+                return errorTy_;
             return i64Ty_; // fallback
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondExpr>>) {
             return inferExprType(*v->else_expr, paramTypeMap);
@@ -630,9 +632,15 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 auto *elseSt = llvm::cast<llvm::StructType>(elseTy);
                 llvm::Type *okA = thenSt->getElementType(1), *okB = elseSt->getElementType(1);
                 llvm::Type *erA = thenSt->getElementType(2), *erB = elseSt->getElementType(2);
-                llvm::Type *mergedOk = (okA == i8Ty_) ? okB : okA;
-                llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
-                return getResultType(mergedOk, mergedEr);
+                // Priority: concrete > anyTy_ (unannotated) > i8Ty_ (absent-payload placeholder).
+                // If A is absent-placeholder, take B; if A is concrete, take A;
+                // if A is any and B is concrete, take B; otherwise keep A (any vs any/i8).
+                auto preferConcrete = [&](llvm::Type *a, llvm::Type *b) -> llvm::Type * {
+                    if (a == i8Ty_) return b;
+                    if (!isAnyType(a)) return a;
+                    return (b != i8Ty_) ? b : a; // a=any: prefer concrete b, else keep any
+                };
+                return getResultType(preferConcrete(okA, okB), preferConcrete(erA, erB));
             }
             if (isOptionType(thenTy) && isOptionType(elseTy)) {
                 auto *thenSt = llvm::cast<llvm::StructType>(thenTy);
@@ -659,9 +667,12 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 auto *elseSt = llvm::cast<llvm::StructType>(elseTy);
                 llvm::Type *okA = thenSt->getElementType(1), *okB = elseSt->getElementType(1);
                 llvm::Type *erA = thenSt->getElementType(2), *erB = elseSt->getElementType(2);
-                llvm::Type *mergedOk = (okA == i8Ty_) ? okB : okA;
-                llvm::Type *mergedEr = (erA == i8Ty_) ? erB : erA;
-                return getResultType(mergedOk, mergedEr);
+                auto preferConcrete = [&](llvm::Type *a, llvm::Type *b) -> llvm::Type * {
+                    if (a == i8Ty_) return b;
+                    if (!isAnyType(a)) return a;
+                    return (b != i8Ty_) ? b : a;
+                };
+                return getResultType(preferConcrete(okA, okB), preferConcrete(erA, erB));
             }
             if (isOptionType(thenTy) && isOptionType(elseTy)) {
                 auto *thenSt = llvm::cast<llvm::StructType>(thenTy);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -33,8 +33,63 @@ llvm::Value *CodeGen::coerceResultType(llvm::Value *val,
 
     llvm::Value *disc = builder_.CreateExtractValue(val, 0, "res.disc");
 
-    // ConstantAggregateZero zeroes all fields; only the disc and the active
-    // (matching) payload need explicit InsertValue — the inactive slot stays 0.
+    // When the mismatched slot holds an anyTy_ value (unannotated lambda param),
+    // a compile-time slot selection zeroes the active payload for the other disc
+    // value.  Emit a runtime disc branch so each disc path copies its own slot.
+    // For i8Ty_ placeholder slots the value is structurally always-Err or
+    // always-Ok, so compile-time selection is safe and avoids extra codegen.
+    const bool okNeedsRuntimeBranch =
+        srcOkTy != dstOkTy && isAnyType(srcOkTy) &&
+        !isAnyType(dstOkTy) && dstOkTy != i8Ty_ && canAnyHoldType(dstOkTy);
+    const bool errNeedsRuntimeBranch =
+        srcErrTy != dstErrTy && isAnyType(srcErrTy) &&
+        !isAnyType(dstErrTy) && dstErrTy != i8Ty_ && canAnyHoldType(dstErrTy);
+
+    if (okNeedsRuntimeBranch || errNeedsRuntimeBranch) {
+        // disc=1 → Ok (slot 1 active), disc=0 → Err (slot 2 active).
+        llvm::Value *isOk = builder_.CreateICmpEQ(
+            disc, llvm::ConstantInt::get(i1Ty_, 1), "res.isok");
+
+        llvm::Function *curFn = builder_.GetInsertBlock()->getParent();
+        llvm::BasicBlock *okBB    = llvm::BasicBlock::Create(*ctx_, "res.coerce.ok",    curFn);
+        llvm::BasicBlock *errBB   = llvm::BasicBlock::Create(*ctx_, "res.coerce.err",   curFn);
+        llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "res.coerce.merge", curFn);
+        builder_.CreateCondBr(isOk, okBB, errBB);
+
+        // Ok path
+        builder_.SetInsertPoint(okBB);
+        llvm::Value *okPayload = builder_.CreateExtractValue(val, 1, "res.ok.raw");
+        if (okNeedsRuntimeBranch)
+            okPayload = unwrapFromAny(okPayload, dstOkTy);
+        llvm::Value *coercedOk = llvm::ConstantAggregateZero::get(dstResTy);
+        coercedOk = builder_.CreateInsertValue(coercedOk, disc, 0);
+        coercedOk = builder_.CreateInsertValue(coercedOk, okPayload, 1);
+        builder_.CreateBr(mergeBB);
+        llvm::BasicBlock *okEndBB = builder_.GetInsertBlock();
+
+        // Err path
+        builder_.SetInsertPoint(errBB);
+        llvm::Value *errPayload = builder_.CreateExtractValue(val, 2, "res.err.raw");
+        if (errNeedsRuntimeBranch)
+            errPayload = unwrapFromAny(errPayload, dstErrTy);
+        llvm::Value *coercedErr = llvm::ConstantAggregateZero::get(dstResTy);
+        coercedErr = builder_.CreateInsertValue(coercedErr, disc, 0);
+        coercedErr = builder_.CreateInsertValue(coercedErr, errPayload, 2);
+        builder_.CreateBr(mergeBB);
+        llvm::BasicBlock *errEndBB = builder_.GetInsertBlock();
+
+        builder_.SetInsertPoint(mergeBB);
+        llvm::PHINode *phi = builder_.CreatePHI(dstResTy, 2, "res.coerced");
+        phi->addIncoming(coercedOk, okEndBB);
+        phi->addIncoming(coercedErr, errEndBB);
+
+        propagateMeta(val, phi);
+        return phi;
+    }
+
+    // Compile-time slot selection for i8Ty_ placeholder mismatches: the struct
+    // was built with either Err-only or Ok-only, so the matching slot is always
+    // the active one at runtime.
     llvm::Value *coerced = llvm::ConstantAggregateZero::get(dstResTy);
     coerced = builder_.CreateInsertValue(coerced, disc, 0);
     if (srcOkTy == dstOkTy)

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -27,23 +27,26 @@ llvm::Value *CodeGen::coerceResultType(llvm::Value *val,
     if (srcOkTy == dstOkTy && srcErrTy == dstErrTy)
         return val; // no rebuild needed
 
-    // Both payload types differ: genuine type mismatch.
-    if (srcOkTy != dstOkTy && srcErrTy != dstErrTy)
-        return nullptr;
-
-    llvm::Value *disc = builder_.CreateExtractValue(val, 0, "res.disc");
-
-    // When the mismatched slot holds an anyTy_ value (unannotated lambda param),
-    // a compile-time slot selection zeroes the active payload for the other disc
-    // value.  Emit a runtime disc branch so each disc path copies its own slot.
-    // For i8Ty_ placeholder slots the value is structurally always-Err or
-    // always-Ok, so compile-time selection is safe and avoids extra codegen.
+    // Determine which slots need runtime anyTy_→concrete unwrapping before
+    // deciding whether a mismatch can be resolved or is a genuine type error.
+    // These booleans must be computed before the bailout so both-slot anyTy_
+    // cases (e.g. Result<any,any> → Result<int,str>) are handled correctly.
     const bool okNeedsRuntimeBranch =
         srcOkTy != dstOkTy && isAnyType(srcOkTy) &&
         !isAnyType(dstOkTy) && dstOkTy != i8Ty_ && canAnyHoldType(dstOkTy);
     const bool errNeedsRuntimeBranch =
         srcErrTy != dstErrTy && isAnyType(srcErrTy) &&
         !isAnyType(dstErrTy) && dstErrTy != i8Ty_ && canAnyHoldType(dstErrTy);
+
+    // Single-slot mismatches (i8Ty_ placeholder or errorTy_ inactive slot) are
+    // handled below by compile-time zero-fill.  Both-slot mismatches are only
+    // valid when both can be resolved by runtime anyTy_ unwrap (e.g.
+    // Result<any,any> → Result<int,int>); otherwise it's a genuine type error.
+    if (srcOkTy != dstOkTy && srcErrTy != dstErrTy &&
+        (!okNeedsRuntimeBranch || !errNeedsRuntimeBranch))
+        return nullptr;
+
+    llvm::Value *disc = builder_.CreateExtractValue(val, 0, "res.disc");
 
     if (okNeedsRuntimeBranch || errNeedsRuntimeBranch) {
         // disc=1 → Ok (slot 1 active), disc=0 → Err (slot 2 active).

--- a/tests/spec/result_type_inference.test.ry
+++ b/tests/spec/result_type_inference.test.ry
@@ -82,4 +82,43 @@ describe("Result type inference in unannotated lambdas", ():
       Ok(v): fail("expected Err but got Ok")
       Err(e): expect(e.message).to_eq("too small")
   )
+
+  it("should infer Result from unannotated 3-branch if-else-if-else with Error constructor", ():
+    f = (x) => if x > 0 => Ok(x) else if x == 0 => Ok(0) else Err(Error("neg"))
+    case f(5):
+      Ok(v): expect(v).to_eq(5)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    case f(0):
+      Ok(v): expect(v).to_eq(0)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    case f(-5):
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("neg")
+  )
+
+  it("should preserve Ok payload when unannotated lambda flows into typed binding", ():
+    r: Result<int, Error> = Ok(42)
+    r2: Result<int, Error> = r.and_then((x) => if x > 10 => Ok(x * 2) else Err(Error("too small")))
+    case r2:
+      Ok(v): expect(v).to_eq(84)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    r3: Result<int, Error> = Ok(5)
+    r4: Result<int, Error> = r3.and_then((x) => if x > 10 => Ok(x * 2) else Err(Error("too small")))
+    case r4:
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("too small")
+  )
+
+  it("should infer Result from unannotated block-if-expr lambda with Error constructor", ():
+    f = (x) => if x > 0:
+      (Ok(x * 2))
+    else:
+      (Err(Error("np")))
+    case f(3):
+      Ok(v): expect(v).to_eq(6)
+      Err(e): fail("expected Ok but got Err: " + e.message)
+    case f(-1):
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e.message).to_eq("np")
+  )
 )

--- a/tests/spec/result_type_inference.test.ry
+++ b/tests/spec/result_type_inference.test.ry
@@ -121,4 +121,16 @@ describe("Result type inference in unannotated lambdas", ():
       Ok(v): fail("expected Err but got Ok")
       Err(e): expect(e.message).to_eq("np")
   )
+
+  it("should coerce both-slot anyTy_ Result into typed Result<int, int> binding", ():
+    f = (a, b) => if a > 0 => Ok(a) else Err(b)
+    r: Result<int, int> = f(42, -1)
+    case r:
+      Ok(v): expect(v).to_eq(42)
+      Err(e): fail("expected Ok but got Err")
+    r2: Result<int, int> = f(-1, 99)
+    case r2:
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e).to_eq(99)
+  )
 )


### PR DESCRIPTION
## Summary

- **Manifestation 1**: `r2: Result<int, Error> = r.and_then((x) => ...)` compiled but `Ok` payload was silently `0`. `coerceResultType` did compile-time slot selection on `anyTy_` src vs `int` dst, copying the Err slot unconditionally. Fixed by emitting a runtime disc branch (PHI) with `unwrapFromAny` in `coerceResultType` whenever `isAnyType(srcSlotTy)`.
- **Manifestation 2**: Unannotated 3-branch `(x) => if x>0 => Ok(x) else if x==0 => Ok(0) else Err(Error("neg"))` failed with "all branches must have the same type". Root cause chain: missing `Error` constructor case in `inferExprType<CallExpr>` + broken `(a==i8Ty_)?b:a` IfExpr merge for `anyTy_` + Ok emitter lacked `unwrapFromAny` for unannotated params. Fixed by adding the `Error` case, replacing merge with `preferConcrete` (concrete > anyTy_ > i8Ty_), and adding `unwrapFromAny` to the Ok emitter.

## Changed files

| File | Change |
|---|---|
| `src/codegen_lambda.cpp` | Add `Error` constructor case to `inferExprType<CallExpr>`; replace IfExpr/IfBlockExpr merge with `preferConcrete` |
| `src/codegen_stmt.cpp` | Rewrite `coerceResultType` to emit runtime disc branch when `isAnyType(srcSlotTy)` |
| `src/codegen_call.cpp` | Add `unwrapFromAny` to Ok emitter when `fn_->getReturnType()` specifies a concrete ok type |
| `tests/spec/result_type_inference.test.ry` | Add 3 new regression tests (3-branch unannotated, typed binding, block-form) |
| `changelog.d/1111-result-type-inference-fix.md` | Changelog fragment |
| `KNOWLEDGE.md` | Update two entries with root cause details for both manifestations |

## Test plan

- [ ] `./build/ry test tests/spec/result_type_inference.test.ry` — all 11 cases pass including the 3 new ones
- [ ] `./build/ry test tests/spec/result_lambda_if.test.ry` — regression guard for #1024
- [ ] `./build/ry test tests/spec/result.test.ry` — core Result semantics
- [ ] `./build/ry_tests` — 1794 C++ tests pass
- [ ] `./build/ry test -p` — 142 test files, 0 failures
- [ ] ASan+UBSan clean
- [ ] TSan C++ clean

Closes #1111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Result type inference corrected so unannotated lambdas preserve Ok payloads when assigned to typed Result bindings.
  * Fixed spurious "all branches must have the same type" errors for multi-branch bodies constructing Error values.
  * Improved runtime coercion between Result variants so Ok/Err payloads and error messages are preserved across assignments.

* **Tests**
  * Added tests for multi-branch lambdas, block-style branches, and Result coercion into typed bindings.

* **Documentation**
  * Updated docs and changelog describing Result inference and coercion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->