### PR TITLE
fix(result): add unwrapFromAny to Err emitter for primitive Err slots (#1116)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2836,7 +2836,7 @@ Alternatively, derive run IDs directly from `detailsUrl` in the `gh pr checks` o
 
 ### `inferExprType` / `inferExprTypeName` visitor must handle `IfExpr`/`IfBlockExpr` and ADT constructors (`Ok`/`Err`/`Some`/`None`/`Error`) to infer lambda return type correctly
 
-**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog); #1111 (2026-04-17, bugfix — Error constructor + `anyTy_` IfExpr merge)
+**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog); #1111 (2026-04-17, bugfix — Error constructor + `anyTy_` IfExpr merge); #1116 (2026-04-18, bugfix — Err emitter analog of #1111 Ok fix)
 **Tags**: codegen, inference, visitor, lambda, Result, Option, IfExpr, anyTy_, Error
 
 **Rule**: `inferExprType` and `inferExprTypeName` in `src/codegen_lambda.cpp` are the visitor functions that determine the return type of an expression-body lambda (`(x: int) => expr`). Both functions must have explicit `if constexpr` cases for every AST node that can appear as the outermost expression. Any unhandled node falls through to the default which returns `i64Ty_` (= `int`) — silently and without error.
@@ -2858,7 +2858,7 @@ return getResultType(preferConcrete(okA, okB), preferConcrete(erA, erB));
 ```
 The old `(a == i8Ty_) ? b : a` rule was broken for `anyTy_`: `(any, i8) → i8` (wrong) instead of `any`. (#1111)
 
-**`Ok` emitter must unwrap `anyTy_` to the expected ok type**: When `fn_->getReturnType()` indicates a concrete ok type (e.g., `i64`) but `Ok(x)` emits with `x` of type `anyTy_` (unannotated param), the emitted Result struct is `{i1, anyTy_, errTy}` — different from the `{i1, i64, errTy}` produced by `Ok(0)`. `validateBranchTypes` pointer-equality fails. Fix: in the `Ok` emitter (`codegen_call.cpp`), after deriving `expectedOkTy` from `retStructTy->getElementType(1)`, call `unwrapFromAny(inner, expectedOkTy)` when `isAnyType(inner->getType()) && canAnyHoldType(expectedOkTy)`. (#1111)
+**`Ok` / `Err` emitters must unwrap `anyTy_` to the expected slot type**: When `fn_->getReturnType()` indicates a concrete ok/err type (e.g., `i64`) but `Ok(x)` / `Err(x)` emits with `x` of type `anyTy_` (unannotated param), the emitted Result struct contains `anyTy_` for that slot — different from the concrete type produced by the sibling branch. `validateBranchTypes` pointer-equality fails. Fix: in both the `Ok` and `Err` emitters (`codegen_call.cpp`), after deriving the expected slot type from `retStructTy->getElementType(1/2)`, call `unwrapFromAny(inner, expectedSlotTy)` when `isAnyType(inner->getType()) && canAnyHoldType(expectedSlotTy) && expectedSlotTy != i8Ty_`. `canAnyHoldType(errorTy_) = false`, so `Err(Error(...))` is unaffected — the gap is limited to `Result<T, primitive>` (int/float/bool/str) Err slots. (#1111 for Ok; #1116 for Err)
 
 **Option merge logic (IfExpr — fixed in #1043)**: Option layout is 2-slot `{i1, innerTy}` vs Result's 3-slot. Three gaps existed beyond the structural #1024 analog:
 1. `Some` was missing from `inferExprType` (it was only in `inferExprTypeName`), causing `(x) => Some(x)` to fail.

--- a/changelog.d/1116-err-emitter-anyty-unwrap.md
+++ b/changelog.d/1116-err-emitter-anyty-unwrap.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `Err(x)` with an unannotated lambda parameter no longer causes a branch-type mismatch when the enclosing function's Result Err slot is a primitive type (`int`, `float`, `bool`, `str`) (#1116)

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -821,16 +821,24 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         requireArgs(e, 1);
         llvm::Value *inner = emitExpr(*e.args[0]);
         llvm::Type *okTy = i8Ty_; // default: Unit (i8 dummy)
+        llvm::Type *expectedErrTy = nullptr;
         if (fn_) {
             llvm::Type *retTy = fn_->getReturnType();
             if (isResultType(retTy)) {
                 auto *retStructTy = llvm::cast<llvm::StructType>(retTy);
                 okTy = retStructTy->getElementType(1);
-                llvm::Type *expectedErrTy = retStructTy->getElementType(2);
+                expectedErrTy = retStructTy->getElementType(2);
                 if (auto *sliced = tryEmitSubtypeCoerce(inner, expectedErrTy))
                     inner = sliced;
             }
         }
+        // Unwrap any-typed value to the expected err type (mirrors Ok emitter):
+        // Err(x) with x: anyTy_ (unannotated param) into a concrete primitive Err slot
+        // must emit the same Result struct as Ok(concrete) in the sibling branch.
+        if (expectedErrTy && isAnyType(inner->getType()) &&
+            !isAnyType(expectedErrTy) && expectedErrTy != i8Ty_ &&
+            canAnyHoldType(expectedErrTy))
+            inner = unwrapFromAny(inner, expectedErrTy);
         llvm::StructType *resTy = getResultType(okTy, inner->getType());
         return buildErrValue(inner, resTy);
     }

--- a/tests/spec/result_type_inference.test.ry
+++ b/tests/spec/result_type_inference.test.ry
@@ -133,4 +133,14 @@ describe("Result type inference in unannotated lambdas", ():
       Ok(v): fail("expected Err but got Ok")
       Err(e): expect(e).to_eq(99)
   )
+
+  it("should unwrap anyTy_ in Err emitter when return type has primitive Err slot", ():
+    f = (x) -> Result<int, int> => if x > 0 => Ok(100) else Err(x)
+    case f(-5):
+      Ok(v): fail("expected Err but got Ok")
+      Err(e): expect(e).to_eq(-5)
+    case f(5):
+      Ok(v): expect(v).to_eq(100)
+      Err(e): fail("expected Ok but got Err")
+  )
 )


### PR DESCRIPTION
## Summary

- Mirrors the `Ok` emitter's `unwrapFromAny` fix from #1111 for the `Err` emitter in `src/codegen_call.cpp`
- When `fn_->getReturnType()` specifies a concrete primitive Err slot (`int`/`float`/`bool`/`str`) and `Err(x)` is emitted with `x: anyTy_` (unannotated lambda param), the Err payload is now unwrapped via `unwrapFromAny` instead of remaining as `anyTy_`
- Prevents the `validateBranchTypes` pointer-equality mismatch between `Ok(concrete)` and `Err(anyTy_)` branches in the same if-expr
- `canAnyHoldType(errorTy_) = false` — `Err(Error(...))` is unaffected; only `Result<T, primitive>` Err slots are impacted

## Test plan

- [ ] New regression test in `tests/spec/result_type_inference.test.ry`: `f = (x) -> Result<int, int> => if x > 0 => Ok(100) else Err(x)` — confirms ok path returns 100, err path returns -5
- [ ] All existing `result_type_inference.test.ry` cases (14 total) continue to pass
- [ ] `./build/ry_tests` — 1794/1794 passed
- [ ] `./build/ry test -p` — 142 files, 0 failures
- [ ] ASan + UBSan clean
- [ ] TSan C++ clean (self-test clean too)

Closes #1116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a type mismatch when using Err with unannotated lambda parameters so primitive error variants (int/float/bool/str) are now inferred and emitted correctly.

* **Documentation**
  * Clarified inference behavior for ADT constructor unwrapping in Result emitters, including when unwrapping is applied and its exceptions.

* **Tests**
  * Added a test validating Err emission for inferred primitive error types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->