### PR TITLE
fix(option): Option branch merge preferConcrete + Some emitter anyTy_ unwrap (#1115)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2836,7 +2836,7 @@ Alternatively, derive run IDs directly from `detailsUrl` in the `gh pr checks` o
 
 ### `inferExprType` / `inferExprTypeName` visitor must handle `IfExpr`/`IfBlockExpr` and ADT constructors (`Ok`/`Err`/`Some`/`None`/`Error`) to infer lambda return type correctly
 
-**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog); #1111 (2026-04-17, bugfix — Error constructor + `anyTy_` IfExpr merge)
+**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog); #1111 (2026-04-17, bugfix — Error constructor + `anyTy_` IfExpr merge); #1115 (2026-04-18, bugfix — Option branch merge `preferConcrete` + `Some` emitter `anyTy_` unwrap)
 **Tags**: codegen, inference, visitor, lambda, Result, Option, IfExpr, anyTy_, Error
 
 **Rule**: `inferExprType` and `inferExprTypeName` in `src/codegen_lambda.cpp` are the visitor functions that determine the return type of an expression-body lambda (`(x: int) => expr`). Both functions must have explicit `if constexpr` cases for every AST node that can appear as the outermost expression. Any unhandled node falls through to the default which returns `i64Ty_` (= `int`) — silently and without error.
@@ -2860,20 +2860,28 @@ The old `(a == i8Ty_) ? b : a` rule was broken for `anyTy_`: `(any, i8) → i8` 
 
 **`Ok` emitter must unwrap `anyTy_` to the expected ok type**: When `fn_->getReturnType()` indicates a concrete ok type (e.g., `i64`) but `Ok(x)` emits with `x` of type `anyTy_` (unannotated param), the emitted Result struct is `{i1, anyTy_, errTy}` — different from the `{i1, i64, errTy}` produced by `Ok(0)`. `validateBranchTypes` pointer-equality fails. Fix: in the `Ok` emitter (`codegen_call.cpp`), after deriving `expectedOkTy` from `retStructTy->getElementType(1)`, call `unwrapFromAny(inner, expectedOkTy)` when `isAnyType(inner->getType()) && canAnyHoldType(expectedOkTy)`. (#1111)
 
-**Option merge logic (IfExpr — fixed in #1043)**: Option layout is 2-slot `{i1, innerTy}` vs Result's 3-slot. Three gaps existed beyond the structural #1024 analog:
+**Option merge logic (IfExpr — fixed in #1043, updated in #1115)**: Option layout is 2-slot `{i1, innerTy}` vs Result's 3-slot. Three gaps existed beyond the structural #1024 analog:
 1. `Some` was missing from `inferExprType` (it was only in `inferExprTypeName`), causing `(x) => Some(x)` to fail.
 2. `None()` (zero-arg CallExpr) had no emitter anywhere — it fell through to `findFunction("None")` and failed with `undefined function: None`.
 3. `None` in `inferExprType` also needed a placeholder: `getOptionType(i8Ty_)`.
 
-Option merge (same `i8Ty_` placeholder convention as Result):
+Option merge must use the same `preferConcrete` rule as Result (#1115 — the old `(a == i8Ty_) ? b : a` was broken for `anyTy_`):
 ```cpp
 if (isOptionType(thenTy) && isOptionType(elseTy)) {
     llvm::Type *innerA = thenSt->getElementType(1);
     llvm::Type *innerB = elseSt->getElementType(1);
-    return getOptionType((innerA == i8Ty_) ? innerB : innerA);
+    // Priority: concrete > anyTy_ (unannotated param) > i8Ty_ (None placeholder)
+    auto preferConcrete = [&](llvm::Type *a, llvm::Type *b) -> llvm::Type * {
+        if (a == i8Ty_) return b;
+        if (!isAnyType(a)) return a;
+        return (b != i8Ty_) ? b : a;
+    };
+    return getOptionType(preferConcrete(innerA, innerB));
 }
 ```
 `None()` emitter in `codegen_call.cpp` reads `fn_->getReturnType()` to derive inner (like `Err` does for the Ok slot), so the emitted struct matches the inferred return type and `validateBranchTypes` pointer-equality succeeds.
+
+**`Some` emitter must also unwrap `anyTy_` (mirrors `Ok` emitter, #1115)**: After the `preferConcrete` lambda-inference fix sets the function return type to `Option<int>`, the `Some(x)` call with unannotated `x` still emits `anyTy_`. Without an explicit unwrap, the produced struct is `{i1, anyTy_}` while `Some(0)` produces `{i1, int}` — `validateBranchTypes` pointer-equality fails. Fix: in the `Some` emitter (`codegen_call.cpp`), derive `expectedInnerTy` from `retStructTy->getElementType(1)`, then call `unwrapFromAny(inner, expectedInnerTy)` when `isAnyType(inner->getType()) && canAnyHoldType(expectedInnerTy)`. Both fixes must be bundled: `preferConcrete` alone converts a silent wrong value into a compile error without fixing correctness.
 
 **Parser trap — block-form branches with `Some(...)`/`None()` tail**: In an `IfBlockExpr` (colon-indent body), a bare `Some(x)` or `None()` on the last line is parsed as a `CallStmt` (discarded statement), not as the block's return value. Wrap it in parentheses to produce an `ExprStmt` that is recognised as the tail expression:
 ```ry

--- a/changelog.d/1115-option-prefer-concrete.md
+++ b/changelog.d/1115-option-prefer-concrete.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Option branch-type merge in unannotated lambda if-expressions now prefers concrete types over `anyTy_` placeholders, matching the Result merge logic. Also propagates the `anyTy_` unwrap pattern from `Ok` to `Some` so concrete-vs-any branches produce matching `Option<T>` structs (#1115).

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -786,6 +786,20 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
     if (e.callee == "Some") {
         requireArgs(e, 1);
         llvm::Value *inner = emitExpr(*e.args[0]);
+        llvm::Type *expectedInnerTy = nullptr;
+        if (fn_) {
+            llvm::Type *retTy = fn_->getReturnType();
+            if (isOptionType(retTy)) {
+                auto *retStructTy = llvm::cast<llvm::StructType>(retTy);
+                expectedInnerTy = retStructTy->getElementType(1);
+            }
+        }
+        // Unwrap any-typed value to the expected inner type when the function return type
+        // is more specific (mirror of Ok emitter for #1115).
+        if (expectedInnerTy && isAnyType(inner->getType()) &&
+            !isAnyType(expectedInnerTy) && expectedInnerTy != i8Ty_ &&
+            canAnyHoldType(expectedInnerTy))
+            inner = unwrapFromAny(inner, expectedInnerTy);
         llvm::StructType *optTy = getOptionType(inner->getType());
         return buildSomeValue(inner, optTy);
     }

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -647,8 +647,13 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 auto *elseSt = llvm::cast<llvm::StructType>(elseTy);
                 llvm::Type *innerA = thenSt->getElementType(1);
                 llvm::Type *innerB = elseSt->getElementType(1);
-                llvm::Type *mergedInner = (innerA == i8Ty_) ? innerB : innerA;
-                return getOptionType(mergedInner);
+                // Priority: concrete > anyTy_ (unannotated param) > i8Ty_ (None placeholder)
+                auto preferConcrete = [&](llvm::Type *a, llvm::Type *b) -> llvm::Type * {
+                    if (a == i8Ty_) return b;
+                    if (!isAnyType(a)) return a;
+                    return (b != i8Ty_) ? b : a;
+                };
+                return getOptionType(preferConcrete(innerA, innerB));
             }
             return i64Ty_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
@@ -679,8 +684,13 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 auto *elseSt = llvm::cast<llvm::StructType>(elseTy);
                 llvm::Type *innerA = thenSt->getElementType(1);
                 llvm::Type *innerB = elseSt->getElementType(1);
-                llvm::Type *mergedInner = (innerA == i8Ty_) ? innerB : innerA;
-                return getOptionType(mergedInner);
+                // Priority: concrete > anyTy_ (unannotated param) > i8Ty_ (None placeholder)
+                auto preferConcrete = [&](llvm::Type *a, llvm::Type *b) -> llvm::Type * {
+                    if (a == i8Ty_) return b;
+                    if (!isAnyType(a)) return a;
+                    return (b != i8Ty_) ? b : a;
+                };
+                return getOptionType(preferConcrete(innerA, innerB));
             }
             return i64Ty_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<InterpolatedStringExpr>>) {

--- a/tests/spec/option_lambda_if.test.ry
+++ b/tests/spec/option_lambda_if.test.ry
@@ -60,4 +60,62 @@ describe("Option lambda if-expr inference (unannotated return type)", ():
       Some(v): expect(v).to_eq(10)
       None: fail("expected Some but got None")
   )
+
+  it("should infer Option<int> from unannotated lambda with Some(x) vs Some(literal)", ():
+    f = (x) => if x > 0 => Some(x) else Some(0)
+    case f(5):
+      Some(v): expect(v).to_eq(5)
+      None: fail("expected Some but got None")
+    case f(-1):
+      Some(v): expect(v).to_eq(0)
+      None: fail("expected Some but got None")
+  )
+
+  it("should infer Option<int> from unannotated 3-branch if with Some/None/Some mix", ():
+    f = (x) => if x > 0 => Some(x) else if x == 0 => None() else Some(-1)
+    case f(5):
+      Some(v): expect(v).to_eq(5)
+      None: fail("expected Some but got None")
+    case f(0):
+      Some(v): fail("expected None but got Some")
+      None: expect(true).to_eq(true)
+    case f(-3):
+      Some(v): expect(v).to_eq(-1)
+      None: fail("expected Some but got None")
+  )
+
+  it("should preserve Some payload when unannotated lambda flows into typed binding", ():
+    f = (x) => if x > 0 => Some(x) else Some(0)
+    o: Option<int> = f(42)
+    case o:
+      Some(v): expect(v).to_eq(42)
+      None: fail("expected Some but got None")
+    o2: Option<int> = f(-1)
+    case o2:
+      Some(v): expect(v).to_eq(0)
+      None: fail("expected Some but got None")
+  )
+
+  it("should infer Option<int> from unannotated block-if-expr lambda with Some/Some", ():
+    f = (x) => if x > 0:
+      (Some(x))
+    else:
+      (Some(0))
+    case f(7):
+      Some(v): expect(v).to_eq(7)
+      None: fail("expected Some but got None")
+    case f(-2):
+      Some(v): expect(v).to_eq(0)
+      None: fail("expected Some but got None")
+  )
+
+  it("should still handle Some(x) vs None() with unannotated param", ():
+    f = (x) => if x > 0 => Some(x) else None()
+    case f(3):
+      Some(v): expect(v).to_eq(3)
+      None: fail("expected Some but got None")
+    case f(-1):
+      Some(v): fail("expected None but got Some")
+      None: expect(true).to_eq(true)
+  )
 )


### PR DESCRIPTION
## Summary

- Replace stale `(a == i8Ty_) ? b : a` rule in the `inferExprType` Option branch merge (both `IfExpr` and `IfBlockExpr` paths) with the same `preferConcrete` helper introduced for Result in #1111 — fixes unannotated params (`anyTy_`) being dropped in favour of concrete types
- Mirror `Ok` emitter's `unwrapFromAny` path in the `Some` emitter so concrete-vs-`anyTy_` branches produce matching `Option<T>` structs; without this, the inference fix alone converts a silent wrong value into a `validateBranchTypes` compile error
- Add 5 regression tests to `tests/spec/option_lambda_if.test.ry` covering unannotated-param `Some/Some`, 3-branch `Some/None/Some`, typed-binding flow, `IfBlockExpr`, and `Some/None` regression guard

## Test plan

- [x] `./build/ry test tests/spec/option_lambda_if.test.ry` — 12/12 pass (7 existing + 5 new)
- [x] `./build/ry test tests/spec/result_type_inference.test.ry` — 13/13 pass (regression guard)
- [x] `./build/ry_tests && ./build/ry test -p` — 1794 C++ tests + 142 Ry test files, 0 failures
- [x] ASan+UBSan: `./build-asan/ry_tests` 1794/1794 pass, `./build-asan/ry test -p` 142/142 pass
- [x] TSan: `./build-tsan/ry_tests` 1794/1794 pass, `./build-tsan/ry test -p` 142/142 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for `Option` branch merging in unannotated lambda if-expressions, now preferring concrete types over placeholders for more accurate type handling.
  * Enhanced `Some` constructor to properly unwrap and match expected types from the enclosing function's return signature, ensuring consistent type shapes across Option branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->