### PR TITLE
docs(reference): audit 言語仕様コア 5ファイルの実装 drift 修正 (#1118 PR 1)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2234,6 +2234,52 @@ drift.
 
 ---
 
+### Ry has soft keywords that are NOT in the lexer `keyword_map`
+
+**Source**: #1118 PR 1 docs audit
+**Tags**: documentation, syntax, lexer
+
+**Context**: Auditing `docs/reference/types.md` found `weak` described as "a keyword".
+`src/lexer.cpp` keyword_map contains only hard keywords. `weak` is handled in
+`parser_expr.cpp:463` and `parser_decl.cpp:726` as a contextual identifier
+(`t.kind == TokenKind::Ident && t.value == "weak"`). Other examples:
+`None`, `Some`, `Ok`, `Err` (variant constructors), and `_` (wildcard) are
+similarly soft — they are legal variable names and only gain special meaning
+in specific syntactic positions.
+
+**Rule**: When writing or auditing docs, do **not** call soft keywords "keywords".
+Use "contextual identifier" instead, or describe the syntax without labeling the
+token class.
+
+**How to verify**: Check `src/lexer.cpp`'s `keyword_map` (lines 35–66). If the
+token is not there, it is not a reserved keyword — the parser must be checking
+`t.value == "..."` explicitly to give it special meaning.
+
+---
+
+### Low-level integer types have different arithmetic semantics from `int`
+
+**Source**: #1118 PR 1 docs audit
+**Tags**: documentation, types, operators
+
+**Context**: `operators.md` described `/` as "always float, IEEE 754". This is
+correct for high-level `int`/`float` operands, but for low-level integer types
+(`i8`..`i64`, `u8`..`u64`) `/` performs **integer division** and returns the
+same type (`7i32 / 2i32` → `3i32`). Mixing a low-level type with `int` in the
+same expression is a compile-time type error.
+
+**Rule**: When auditing or writing docs for arithmetic operators, always
+spot-check behavior with low-level integer types using `./build/ry -c`:
+
+```bash
+printf 'print(7i32 / 2i32)\nprint(type_of(7i32 / 2i32))' | ./build/ry -c -
+```
+
+The pattern extends to `+`, `-`, `*`, `%`, `//` — all produce the same type
+without promotion when both operands are low-level integers.
+
+---
+
 ## Commands / Environment gotchas
 
 This section records command/environment mistakes that were

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -341,7 +341,7 @@ for i in range(8):
 - Assigning to outer mutable bindings is rejected.
 - `break` and `continue` are rejected.
 - Indexed assignment and field assignment inside the loop body are rejected in v1.
-- Function definitions (including lambda literals) inside the body are not allowed.
+- Nested function definitions (`function` statements) inside the body are not allowed.
 
 Use `available_parallelism()` to inspect the runtime worker count.
 

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -341,6 +341,7 @@ for i in range(8):
 - Assigning to outer mutable bindings is rejected.
 - `break` and `continue` are rejected.
 - Indexed assignment and field assignment inside the loop body are rejected in v1.
+- Function definitions (including lambda literals) inside the body are not allowed.
 
 Use `available_parallelism()` to inspect the runtime worker count.
 

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -712,13 +712,14 @@ function operator<op>(a: type) -> return_type:
 |---|---|
 | Arithmetic (binary) | `+` `-` `*` `/` `%` `**` `//` |
 | Comparison (binary) | `==` `!=` `<` `<=` `>` `>=` |
-| Bitwise (binary) | `&` `\|` `^` `<<` `>>` |
+| Bitwise (binary) | `&` `\|` `^` `<<` `>>` `>>>` |
 | Logical (binary) | `and` `or` |
 | Membership | `in` |
 | Subscript | `[]` (read), `[]=` (write) |
 | Call | `()` |
 | Cast | `as` |
 | Unary | `-` `~` `not` |
+| Compound assignment | `+=` `-=` `*=` `/=` `%=` `//=` `**=` `&=` `\|=` `^=` `<<=` `>>=` |
 
 ### Return Type Constraints
 
@@ -773,6 +774,8 @@ v4 = -v1        # Vec2(-1.0, -2.0)
 ---
 
 ## Checked/Saturating Arithmetic
+
+> **See also**: [Builtins — Checked Arithmetic](builtins.md#checked-arithmetic) for the full API reference. This section provides a function-context summary and examples.
 
 Built-in functions for explicit overflow control on integer types (`int`, `i8`..`i64`, `u8`..`u64`). Both arguments must be the same type.
 

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -19,6 +19,7 @@ Lower numbers indicate higher precedence (evaluated first).
 | 7 | `&` | Bitwise AND | Left |
 | 8 | `^` | Bitwise XOR | Left |
 | 9 | `\|` | Bitwise OR | Left |
+| 9.5 | `..` | Range (inclusive) | Left |
 | 10 | `==` `!=` `<` `<=` `>` `>=` `in` `not in` | Comparison, membership | Left |
 | 11 | `not` | Logical NOT | Right |
 | 12 | `and` | Logical AND | Left |
@@ -32,7 +33,7 @@ Lower numbers indicate higher precedence (evaluated first).
 | `+` | Addition / string concatenation | `1 + 2` -> `3`, `"a" + "b"` -> `"ab"`, `"x" + 1` -> `"x1"` |
 | `-` | Subtraction | `5 - 3` -> `2` |
 | `*` | Multiplication / string repetition | `4 * 3` -> `12`, `"ab" * 3` -> `"ababab"` |
-| `/` | Division (always float, IEEE 754) | `7 / 2` -> `3.5`, `7 / 0` -> `inf`, `0 / 0` -> `nan` |
+| `/` | Division: `int`/`float` → always `float` (IEEE 754); low-level integers (`i32`, `u8`, …) → integer division, same type | `7 / 2` -> `3.5`, `7i32 / 2i32` -> `3i32`, `7 / 0` -> `inf`, `0 / 0` -> `nan` |
 | `//` | Floor division (toward -∞) | `7 // 2` -> `3`, `-7 // 2` -> `-4` |
 | `%` | Modulo | `7 % 3` -> `1` |
 | `**` | Exponentiation (always float) | `2 ** 10` -> `1024.0` |
@@ -50,7 +51,7 @@ u = 3.14 + "!"    # "3.14!"
 
 When one operand of `+` is `str` and the other is `int`, `float`, or `bool`, the non-`str` operand is automatically converted to its string representation and concatenated.
 
-The `/` operator always produces a `float` and follows IEEE 754 for special values: `x / 0` evaluates to `±inf` (sign follows the dividend), and `0 / 0` evaluates to `nan`. For integer operands, `//` and `%` retain integer semantics and raise a runtime error when the divisor is zero.
+For `int` and `float` operands, `/` always produces a `float` and follows IEEE 754: `x / 0` evaluates to `±inf` (sign follows the dividend), and `0 / 0` evaluates to `nan`. For `int` operands, `//` and `%` retain integer semantics and raise a runtime error when the divisor is zero. For low-level integer types (`i8`..`i64`, `u8`..`u64`), `/` performs integer division and returns the same type (mixing low-level and `int` in one expression is a type error).
 
 ## Comparison Operators
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -7,7 +7,6 @@
 | Type | Internal Representation | Literal Examples | Description |
 |---|---|---|---|
 | `int` | i64 | `42`, `-7`, `0xFF`, `0b1010`, `100_000` | 64-bit signed integer |
-| `u8` | i8 | (no dedicated literal) | Unsigned 8-bit integer (0-255). Used with type annotation `b: u8 = 42` |
 | `float` | f64 | `3.14`, `0.5`, `3.14_159`, `1e10`, `1.5e-3`, `2.5E+2` | 64-bit floating-point number (scientific notation supported) |
 | `bool` | i1 | `true`, `false` | Boolean value |
 | `str` | ptr | `"hello"`, `""`, `"a\nb"` | String (immutable byte sequence on the heap). Internally a pointer to the data portion of a `StringHeader` (`{strong_count, weak_count, byte_len, data[], '\0'}`). Supports embedded NUL bytes (#1022). |
@@ -38,7 +37,7 @@
 | `f32` | float | `x: f32 = 3.14`, `x = 1e10f32` | 32-bit floating-point (low-level, no implicit conversion) |
 | `weak T` | ptr (header) | `weak s` | Weak reference to an ARC-managed value (does not prevent deallocation) |
 | `Regex` | ptr | `/[a-z]+/`, `/\d{3}/` | Regular expression pattern (created via regex literal syntax) |
-| `Result<T, E>` | `{ i1, T/E }` | `Ok(42)`, `Err(Error("fail"))` | A type representing success (`Ok`) or failure (`Err`) |
+| `Result<T, E>` | `{ i1, T, E }` | `Ok(42)`, `Err(Error("fail"))` | A type representing success (`Ok`) or failure (`Err`). Both `T` and `E` slots are always present in the struct; only the active variant is meaningful |
 | `Task<T>` | ptr | (returned by async functions) | Asynchronous task handle (used with `await` and `block_on`) |
 | `Iterator<T>` | ptr | (created by `iter()`) | Lazy iterator for sequential element access |
 | `T[N]` | `[N x T]` | `buf: i32[8]` | Fixed-length contiguous array of low-level type T with N elements (stack-allocated) |
@@ -69,7 +68,6 @@ a: any = 42
 | Type Name | Notes |
 |---|---|
 | `int` | Built-in scalar type |
-| `u8` | Built-in scalar type (unsigned 0-255) |
 | `float` | Built-in scalar type |
 | `bool` | Built-in scalar type |
 | `str` | Built-in string type |
@@ -287,7 +285,7 @@ Weak references are the user-facing mechanism for breaking reference cycles.
 
 ### Creating a Weak Reference
 
-Use the `weak` keyword in both type annotation and expression position:
+Use `weak` (a contextual identifier, not a reserved keyword) in both type annotation and expression position:
 
 ```python
 s = "hello"

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1019,6 +1019,13 @@ TEST_F(CodeGenTest, ParallelForErrors) {
         "for i in range(4):\n"
         "    total = total + i\n"
         "print(total)"), std::runtime_error);
+    // ParallelForRejectsNestedFunctionDef (#1118)
+    EXPECT_THROW(runSource(
+        "@parallel\n"
+        "for i in range(4):\n"
+        "    function helper() -> int:\n"
+        "        return i\n"
+        "    print(helper())\n"), std::runtime_error);
 }
 
 // ===== Int literal type =====


### PR DESCRIPTION
## Summary

Issue #1118 PR 1 — `docs/reference/` 言語仕様コア 5ファイル (`types.md`, `operators.md`, `control-flow.md`, `functions.md`, `records.md`) の系統的 drift 監査。

**Audit 結果**: drift **~12 件**発見
- (a) docs 修正: 10 件
- (b) 実装修正: 0 件
- (c) 別 issue 化: 0 件
- docs 重複 (α 矛盾修正): 2 件 (`>>>` 欠落、複合代入演算子欠落)
- docs 重複 (β 別 issue): 0 件
- docs 重複 (γ 役割分担保持): 2 件 (Operator Overloading 重複、`enum` 重複)

## Changes

### `docs/reference/types.md`
- `u8` 行を高レベル型テーブルから削除（`u8` は低レベル型のみ。`200u8` リテラルが有効なのに "no dedicated literal" と誤記していた）
- `u8` を Available Type Names の "Built-in scalar type" から削除（低レベル型テーブルに既掲載）
- `Result<T, E>` の内部表現 `{ i1, T/E }` → `{ i1, T, E }` に修正（3フィールド構造体、T と E は両方常に存在）
- `weak` を "keyword" → "contextual identifier (not a reserved keyword)" に修正

### `docs/reference/operators.md`
- `..` 演算子を優先順位表に追加（9.5位、`|` と `==` の間）。`src/parser_expr.cpp:234-248` の `parseComparison→parseRange→parseBitwiseOr` チェーンで確認
- `/` 演算子の説明を更新：`int`/`float` → 常に `float` (IEEE 754)、低レベル整数 (`i32`, `u8` 等) → 整数除算・同型返却

### `docs/reference/functions.md`
- Overloadable operators テーブルのビット演算子行に `>>>` を追加（`src/parser_decl.cpp:68` で確認）
- 複合代入演算子行を追加（`src/parser_decl.cpp:72-78` で確認）
- Checked/Saturating Arithmetic の "See also" リンクのアンカーを修正 (`#checked-arithmetic`)

### `docs/reference/control-flow.md`
- `@parallel for` の制約リストに「ネスト関数定義不可」を追加（`src/codegen_stmt_loop.cpp:585` の `codegenError` で確認済み）

### `docs/reference/records.md`
- 変更なし。`enum` 二重記載は γ（types.md = ADT 視点、records.md = 基本定義視点の意図的分担）

### `tests/test_codegen_stmt.cpp`
- `ParallelForErrors` に `ParallelForRejectsNestedFunctionDef` 回帰テストを追加

### `KNOWLEDGE.md`
- 新エントリ: "Ry has soft keywords that are NOT in the lexer `keyword_map`"
- 新エントリ: "Low-level integer types have different arithmetic semantics from `int`"

## Verification

```bash
cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p
```

- 非 Ry キーワード grep: 対象 5 ファイルで stray `val`/`var`/`fun`/`def` ヒット 0
- コード例 spot-check: `7i32 / 2i32` → `3`, `200u8 / 3u8` → `66`, `7u64 / 2u64` → `3`

Closes: N/A（issue #1118 は PR 5 マージ時にクローズ）
Related: #1118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added two new lessons clarifying contextual identifiers and low-level vs high-level arithmetic/division semantics
  * Enhanced operator reference: inclusive range operator (`..`), `>>>` in bitwise list, and compound-assignment operators
  * Clarified `Result` representation and removed `u8` from the top-level type list
  * Added rule: nested function definitions are disallowed inside `@parallel for` bodies

* **Tests**
  * Added test validating the parallel-loop function-definition restriction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->