### PR TITLE
docs(reference): audit 言語仕様周辺 5ファイルの実装 drift 修正 (#1118 PR 2)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2280,6 +2280,50 @@ without promotion when both operands are low-level integers.
 
 ---
 
+### `docs/reference/` directory paths in prose can silently drift when source layout changes
+
+**Source**: #1118 PR 2 docs audit
+**Tags**: documentation, drift, stdlib
+
+**Context**: `docs/reference/directives.md` referred to `core/*.ry` as the location of
+`@native` prelude declarations (e.g. `core/builtins.ry`, `core/str.ry`). The actual
+layout has been `share/std/` for a long time (e.g. `share/std/builtins.ry`). No `core/`
+directory exists. The prose survived because it was never executed — only read.
+
+**Rule**: When auditing stdlib-adjacent docs (PR 3–5 of #1118), grep for hardcoded
+directory names in prose and verify them against the actual filesystem:
+
+```bash
+grep -rn 'core/' docs/reference/
+ls share/std/           # verify actual layout
+```
+
+If a table lists filenames or paths, run `ls` on the claimed directory before trusting it.
+
+---
+
+### CLI flag value sets can drift between doc pages independently
+
+**Source**: #1118 PR 2 docs audit
+**Tags**: documentation, drift, CLI
+
+**Context**: `project.md` global options table listed `--env=<env>` as accepting
+`production|development|internal` (3 values). `packages.md` RY_ENV table had
+5 values (`prod`, `dev`, `test`, `staging`, `internal`) plus their aliases. The
+authoritative source is `src/dotenv.cpp:resolveRyEnv` + `src/cli.cpp` help text.
+
+**Rule**: When two doc pages both describe the same CLI flag or env var value set,
+verify they are consistent with each other AND with the implementation. Quick check:
+
+```bash
+# Find all pages that mention --env or RY_ENV
+grep -rn 'env\|RY_ENV' docs/reference/ | grep -v '\.env\.'
+# Check implementation's documented values
+grep -n 'env.*=.*\|' src/cli.cpp | head -10
+```
+
+---
+
 ## Commands / Environment gotchas
 
 This section records command/environment mistakes that were

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -100,7 +100,7 @@ record BankAccount:
 
 ```python
 a = BankAccount(100, 0)    # OK: 100 >= 0
-a.balance = -1                  # Contract violation: invariant failed
+a.balance = -1                  # Contract violation: invariant failed for BankAccount
 ```
 
 ---
@@ -109,7 +109,10 @@ a.balance = -1                  # Contract violation: invariant failed
 
 - `require` and `ensure` blocks are optional and appear before the function body.
 - `require` must come before `ensure` when both are present.
+- `ensure` can only be used on functions that return a non-Unit value; applying it to a Unit-return function is a parse error (`'ensure' requires a non-Unit return type`).
 - `ensure` requires a variable binding (e.g., `ensure v:`) to name the return value.
 - For tuple returns, multiple bindings can be specified (e.g., `ensure q, r:`).
 - `invariant` appears at the end of a `record` definition, after all field declarations.
 - All contract violations terminate with `exit(1)` and print a diagnostic message.
+
+> **See also**: For error-as-value patterns using `Result<T, E>`, `Ok`, `Err`, and the `?` operator, see [Types — Result](types.md#result-type) and [Operators — `?`](operators.md).

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -146,30 +146,21 @@ When a `@native` declaration includes a type signature, the compiler validates t
 
 ```
 @native
-function range(n: int) -> List<int>
+function range(count: int) -> List<int>
 @native
 function range(start: int, end: int) -> List<int>
+@native
+function range(start: int, end: int, step: int) -> List<int>
 
-print(length(range(5)))       # OK: matches 1-arg overload
-print(length(range(1, 10)))   # OK: matches 2-arg overload
-print(length(range()))        # Error: expects 1 or 2 argument(s), but got 0
+print(length(range(5)))          # OK: matches 1-arg overload
+print(length(range(1, 10)))      # OK: matches 2-arg overload
+print(length(range(1, 10, 2)))   # OK: matches 3-arg overload
+print(length(range()))           # Error: range() takes 1, 2, or 3 arguments
 ```
 
-**Standard library declarations (`core/`):**
+**Standard library declarations (`share/std/`):**
 
-The `core/` directory contains `@native` declarations for all built-in functions, organized by category:
-
-| File | Contents |
-|---|---|
-| `core/builtins.ry` | `print`, `length`, `range`, `enumerate`, `zip`, `exit`, `args`, `available_parallelism`, `sleep` |
-| `core/str.ry` | `contains`, `starts_with`, `ends_with`, `find`, `substring`, `char_at`, `replace`, `to_upper`, `to_lower`, `trim`, `trim_start`, `trim_end`, `repeat`, `reverse`, `split`, `join` |
-| `core/convert.ry` | `to_int`, `to_float`, `to_str` |
-| `core/list.ry` | `append`, `pop`, `insert`, `remove_at`, `slice`, `distinct`, `flatten`, `sort`, `first`, `last`, `is_empty` |
-| `core/map.ry` | `keys`, `values`, `items`, `has_key`, `get`, `merge` |
-| `core/set.ry` | `add`, `remove`, `union`, `intersection`, `difference`, `symmetric_difference`, `is_subset`, `is_superset` |
-| `core/higher_order.ry` | `filter`, `map`, `reduce`, `fold`, `any`, `all`, `sum`, `min`, `max` |
-
-These files are automatically loaded as a prelude when the `core/` directory is found relative to the `ry` executable. The prelude enables argument count validation for built-in function calls.
+`@native` declarations for all built-in functions live under `share/std/` relative to the `ry` executable, organized by category. These files are automatically loaded as a prelude and enable argument count validation for built-in function calls. For the full function reference, see [Builtins](builtins.md), [Builtins — String](builtins-string.md), and [Collections](collections.md).
 
 **Constraints:**
 - `@native` functions must not have a body (no `:` after the signature).
@@ -205,6 +196,7 @@ for i in range(8):
 - Destructuring iteration is not supported.
 - Assigning to outer mutable variables is rejected.
 - `break`, `continue`, indexed assignment, and field assignment inside the loop body are rejected in v1.
+- Nested function definitions (`function` statements) inside the loop body are not allowed.
 
 ### `@each`
 
@@ -227,6 +219,8 @@ it("should handle {0} and {1}", (param1: type, param2: type):
     # test body
 )
 ```
+
+> **Note**: The legacy lambda form is deprecated. Prefer the named function form with `@it`. See [Testing Reference](testing.md) for details.
 
 The argument can be any expression that evaluates to a list of tuples, including a function call:
 
@@ -265,6 +259,8 @@ it("should verify property name", (a: int, b: int):
     # test body with random values
 )
 ```
+
+> **Note**: The legacy lambda form is deprecated. Prefer the named function form with `@it`. See [Testing Reference](testing.md) for details.
 
 **Supported targets:** functions decorated with `@it`, or legacy `it` calls.
 
@@ -319,7 +315,7 @@ function test_commutative(a: int, b: int):
     expect(a + b).to_eq(b + a)
 ```
 
-**Supported target:** `function` declarations only. The function must not have a return type annotation.
+**Supported target:** `function` declarations only.
 
 **Constraints:**
 - Only valid in `*.test.ry` files executed with `ry test`
@@ -385,7 +381,7 @@ function outer():
             expect(1 + 1).to_eq(2)
 ```
 
-**Supported target:** `function` declarations only. The function must not have parameters or a return type annotation.
+**Supported target:** `function` declarations only. The function must not have parameters.
 
 ### `@inline`
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -20,7 +20,11 @@ Each error message includes:
 - **Source line** with the relevant code
 - **Caret indicator** (`^`) pointing to the exact column
 
+> **See also**: For the `Result<T, E>`, `Ok`, `Err`, and `Error` types, see [Types — Result](types.md#result-type). For the `?` early-return operator, see [Operators](operators.md).
+
 ## Compile Errors
+
+The table below shows the most common compile errors; it is not exhaustive.
 
 | Error | Cause | Example |
 |-----------|------|-----|
@@ -40,8 +44,9 @@ Each error message includes:
 | Circular import | Modules import each other | `a.ry` imports `b.ry` and `b.ry` imports `a.ry` |
 | Duplicate field name | Defined the same field name twice in a record | Defining `x` twice in `type T: x: int` |
 | Non-exhaustive match | `case` does not cover all patterns | Some enum variants uncovered, missing `None` for Option, missing `Ok`/`Err` for Result, no `_` for literals |
-| `?` on non-Result type | Applied `?` to an expression that is not a `Result` type | `x = 42` -> `x?` |
-| `?` in non-Result function | Used `?` in a function that does not return `Result` | `function foo() -> int:` -> `bar()?` |
+| `?` on non-Result/Option type | Applied `?` to an expression that is not a `Result` or `Option` type (`'?' operator requires a Result or Option type operand`) | `x = 42` -> `x?` |
+| `?` in non-Result function | Used `?` on a `Result` in a function that does not return `Result` (`'?' on Result can only be used in a function that returns Result`) | `function foo() -> int:` with `bar()?` inside |
+| `ensure` on Unit-return function | Used `ensure` in a function with no return value (`'ensure' requires a non-Unit return type`) | `function log():` with `ensure v:` |
 
 ### Compile Error Examples
 
@@ -75,11 +80,15 @@ record Bad:
 
 ## Runtime Errors
 
+The table below shows the most common runtime errors; it is not exhaustive.
+
 | Error | Cause | Example |
 |-----------|------|-----|
 | List out-of-range access | List index exceeds bounds | `xs = [1, 2, 3]` -> `xs[5]` |
 | Map non-existent key access | Referenced a key that does not exist in the map | `m = {"a": 1}` -> `m["b"]` |
 | Contract violation | A `require`, `ensure`, or `invariant` condition evaluated to false | See [Design by Contract](contracts.md) |
+| Integer overflow | A checked integer operation (e.g., `+`, `-`, `*`) overflowed (`runtime error: integer overflow`) | `max_int + 1` with overflow checking enabled |
+| `range()` step zero | Called `range()` with a step argument of `0` (`runtime error: range() step must not be zero`) | `range(1, 10, 0)` |
 
 All runtime errors terminate the process with `exit(1)`.
 

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -22,7 +22,7 @@ ry self-update [options]            # Update ry itself
 | `-c` | Read and execute code from stdin |
 | `-h`, `--help` | Show help |
 | `-v`, `--version` | Show version |
-| `--env=<env>` | Set environment (`production`\|`development`\|`internal`). Overrides the `RY_ENV` environment variable. |
+| `--env=<env>` | Set environment. Valid values: `prod`/`production`, `dev`/`development`, `internal`, `test`, `staging`. Overrides the `RY_ENV` environment variable. See [Package Reference — RY_ENV](packages.md#ry_env) for details. |
 
 ### Entry Point Execution
 
@@ -74,7 +74,7 @@ my-project/
 
 1. Exits with an error if `package.toml` already exists
 2. Creates the `src/` directory (if it doesn't exist)
-3. Generates `package.toml` (`name` is set to the current directory name)
+3. Generates `package.toml` (`name` is set to the current directory name with hyphens normalized to underscores)
 4. Generates `src/main.ry` (skipped if it already exists)
 
 ---
@@ -102,7 +102,7 @@ my-project/
 2. Exits with an error if the directory already exists
 3. Creates the `<project-name>/` directory
 4. Creates the `src/` directory inside it
-5. Generates `package.toml` (`name` is set to the given project name)
+5. Generates `package.toml` (`name` is set to the given project name with hyphens silently normalized to underscores, e.g. `my-project` → `my_project`)
 6. Generates `src/main.ry`
 
 ---
@@ -121,7 +121,7 @@ ry run test         # Run the "test" script
 
 1. Searches for `package.toml` from the current directory upward
 2. Without arguments, lists all available scripts and their commands
-3. With a script name, executes the corresponding shell command via `/bin/sh -c`
+3. With a script name, executes the corresponding shell command via the system shell (`std::system()`, OS-dependent)
 4. The exit code of the executed command is propagated
 5. If the script name is not found, shows an error with a list of available scripts
 
@@ -188,6 +188,9 @@ ry test --coverage             # Collect line coverage information
 | `-p`, `--parallel` | Run tests in parallel |
 | `-w`, `--watch` | Watch for changes and re-run |
 | `--coverage`, `--cov` | Collect coverage information |
+| `--outline` | Print the describe/it structure without running tests |
+| `--trace` | Emit structured internal trace as JSON Lines to stdout |
+| `--trace-out=PATH` | Write trace output to `PATH` (use `-` for stderr) |
 | `-h`, `--help` | Show help |
 
 ### Behavior

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -189,7 +189,7 @@ ry test --coverage             # Collect line coverage information
 | `-w`, `--watch` | Watch for changes and re-run |
 | `--coverage`, `--cov` | Collect coverage information |
 | `--outline` | Print the describe/it structure without running tests |
-| `--trace` | Emit structured internal trace as JSON Lines to stdout |
+| `--trace` | Emit structured internal trace as JSON Lines to stderr |
 | `--trace-out=PATH` | Write trace output to `PATH` (use `-` for stderr) |
 | `-h`, `--help` | Show help |
 

--- a/tests/test_codegen_contract.cpp
+++ b/tests/test_codegen_contract.cpp
@@ -157,6 +157,21 @@ TEST_F(CodeGenTest, InvariantViolatedAfterFieldAssign) {
     EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1), "");
 }
 
+TEST_F(CodeGenTest, InvariantViolationMessageIncludesRecordName) {
+    // Regression: message must be "invariant failed for <Name>", not "in <Name>()" (#1118)
+    std::string src =
+        "record Account:\n"
+        "    balance: int\n"
+        "    min_balance: int\n"
+        "    invariant:\n"
+        "        balance >= min_balance\n"
+        "a = Account(100, 0)\n"
+        "a.balance = -1\n"
+        "print(a.balance)";
+    EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1),
+                "Contract violation: invariant failed for Account");
+}
+
 // ===== Inherited invariant tests =====
 
 TEST_F(CodeGenTest, InheritedInvariantSatisfied) {


### PR DESCRIPTION
## Summary

- `directives.md`, `contracts.md`, `errors.md`, `packages.md` (変更なし), `project.md` の 5 ファイルを対象とした実装 drift 監査 (#1118 PR 2)
- audit 結果: **drift 25 件発見** (内訳: docs 修正 α 15件 / 別 issue 化 1件, 役割分担 cross-ref γ 4件)

## 主な修正内容

### `directives.md`

| # | 分類 | 内容 |
|---|------|------|
| 1 | α (γ) | `core/*.ry` prelude table を `share/std/` cross-ref に圧縮 (`core/` ディレクトリは存在しない) |
| 5 | α | `range()` 0-arg エラー文言 → 実測値 `"range() takes 1, 2, or 3 arguments"` に修正、3-arg overload 例を追加 |
| 6 | α | `@parallel` constraints に nested `function` 拒否制約を追加 |
| 7 | α→γ | `@it`/`@describe` "must not have return type annotation" 主張を削除 (未強制 — 別 issue #1122 で仕様決定) |
| 8 | γ | `@each`/`@property` legacy lambda に非推奨注記 + testing.md cross-ref |

### `contracts.md`

| # | 分類 | 内容 |
|---|------|------|
| 10 | α | invariant 違反メッセージ修正: `"invariant failed"` → `"invariant failed for BankAccount"` |
| 11 | α | `ensure` + Unit-return 拒否ルール追加 (exact message: `'ensure' requires a non-Unit return type`) |
| 12 | γ | `Result<T, E>` / `?` への see also cross-ref 追加 |

### `errors.md`

| # | 分類 | 内容 |
|---|------|------|
| 13 | α | `?` on non-Result/Option: 文言修正、Option 対応明記 (実測: `'?' operator requires a Result or Option type operand`) |
| 14 | α | `?` in non-Result fn: 文言修正 (実測: `'?' on Result can only be used in a function that returns Result`) |
| 15 | α | 両表に "not exhaustive" 注記追加、Compile Errors に `ensure`/Unit 追加、Runtime に overflow/range-step 0 追加 |
| 16 | γ | `Result<T, E>` / `Error` / `?` への see also 追加 |

### `project.md`

| # | 分類 | 内容 |
|---|------|------|
| 20 | α | `--env` global options: 全値 (`prod`/`production`, `dev`/`development`, `internal`, `test`, `staging`) + packages.md リンク |
| 21 | α | `ry test` options: `--outline`, `--trace`, `--trace-out=PATH` 追加 |
| 22 | α | `ry init`/`ry new`: ハイフン→アンダースコア正規化を明記 |
| 23 | α | `ry run`: "`/bin/sh -c`" → `std::system()` (OS-dependent) |

### `packages.md`

drift なし (RY_ENV テーブルは既に正確、`from ..` 制約も既記載)

## 実測値 (./build/ry -c で検証)

```
$ printf 'print(range())' | ./build/ry -c -
error: range() takes 1, 2, or 3 arguments

$ printf 'x = 42\nprint(x?)' | ./build/ry -c -
error: '?' operator requires a Result or Option type operand

$ # ? on Result in non-Result function
error: '?' on Result can only be used in a function that returns Result

$ # invariant violation
Contract violation: invariant failed for BankAccount
```

## テスト

- `tests/test_codegen_contract.cpp`: `InvariantViolationMessageIncludesRecordName` 追加 (exact-message 回帰テスト)
- 全テスト Pass: 1795 C++ tests / 142 Ry self-test files

## 別 issue 起票

- #1122: `@it`/`@describe` の return-type annotation 強制の仕様判断 (本 PR では docs claim を削除)

Closes (partial) #1118 — 言語仕様系 10 ファイル完了、残り stdlib 系 15 ファイル (PR 3–5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on keeping documented paths and CLI/env value sets synchronized with implementation
  * Clarified contract invariant messages, `ensure` usage rules, directive examples/constraints, operator/error tables, and prelude location
  * Expanded project docs: env value aliases, package name normalization, shell execution note, and new test flags

* **Tests**
  * Added a test ensuring invariant violation messages include the record name
<!-- end of auto-generated comment: release notes by coderabbit.ai -->