### PR TITLE
docs(reference): audit stdlib 基礎 5ファイルの実装 drift 修正 (#1118 PR 3)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2324,6 +2324,37 @@ grep -n 'env.*=.*\|' src/cli.cpp | head -10
 
 ---
 
+### Runtime errors in stdlib dispatchers must be mirrored in docs/reference/
+
+**Source**: #1118 PR 3 docs audit
+**Tags**: documentation, drift, stdlib
+
+**Context**: During the PR 3 audit of `docs/reference/{builtins,collections,math}.md`, several
+runtime (and compile-time) errors emitted inside `src/codegen_call_*.cpp` were found to be
+completely absent from the corresponding reference pages. Examples found:
+
+| Error message | Emitter location |
+|---|---|
+| `runtime error: reduce() on empty list` | `codegen_call_higher_order.cpp:237` |
+| `runtime error: min() on empty list` | `codegen_call_higher_order.cpp:480` |
+| `runtime error: max() on empty list` | `codegen_call_higher_order.cpp:480` |
+| `runtime error: floor()/ceil()/round() argument out of int range` | `codegen_call.cpp:1097-1104` |
+| `flatten() requires a list of lists` (compile) | `codegen_call_collection.cpp` |
+| `fold() initial value type must match function return type` (compile) | `codegen_call_higher_order.cpp:291-294` |
+
+**Rule**: When auditing stdlib docs (PR 3–5 of #1118), grep all `codegenError()` and
+`runtime error:` strings in `src/codegen_call_*.cpp` and `src/runtime_*.cpp`, then verify
+each is mentioned (at least as a brief note) in the matching docs page:
+
+```bash
+grep -rn '"runtime error:' src/codegen_call_*.cpp src/runtime_*.cpp
+grep -rn 'codegenError' src/codegen_call_*.cpp | grep '"' | grep -v '//'
+```
+
+Cross-check each hit against the corresponding `docs/reference/*.md` page. Missing ones are α drift.
+
+---
+
 ## Commands / Environment gotchas
 
 This section records command/environment mistakes that were

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -95,13 +95,13 @@ All functions accept `int` or any low-level integer type (`i8`..`i64`, `u8`..`u6
 | `is_empty(list / map / set / str)` | Returns whether the collection or string is empty |
 | `distinct(list)` | Returns a new list with duplicates removed |
 | `flatten(list)` | Returns a new list with nested lists flattened |
-| `reduce(list, fn)` | Reduces a list to a single value using the reducer function |
+| `reduce(list, fn)` | Reduces a list to a single value using the reducer function. Empty list is a runtime error |
 | `fold(list, init, fn)` | Folds a list with an initial accumulator value |
 | `any(list, pred)` | Returns `true` if any element matches the predicate |
 | `all(list, pred)` | Returns `true` if all elements match the predicate |
 | `sum(list)` | Returns the sum of all elements |
-| `min(list)` | Returns the minimum element |
-| `max(list)` | Returns the maximum element |
+| `min(list)` | Returns the minimum element. Empty list is a runtime error |
+| `max(list)` | Returns the maximum element. Empty list is a runtime error |
 | `enumerate(list)` | Returns a list of `(index, value)` tuples. Also accepts a `str`, yielding `(int, str)` per UTF-8 code point |
 | `zip(list1, list2)` | Returns a list of `(a, b)` tuples pairing elements from two lists. Either (or both) arguments may be a `str` |
 | `keys(map)` | Returns all keys as a `List<K>` |
@@ -515,6 +515,8 @@ ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 ---
 
 ## filter
+
+> **See also**: The higher-order functions in this section (`filter`, `map`, `sort`, `sort!`, `reverse!`, `appended`, `append!`) and those listed below (`reduce`, `fold`, etc.) overlap with entries in [Collections](collections.md). Full reference with mutation semantics and CoW details: [Collections — List](collections.md#list).
 
 **Signature:** `filter(list: List<T>, pred: function(T) -> bool) -> List<T>`
 

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -274,6 +274,8 @@ ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 
 ### filter
 
+> **See also**: The functions in this section (`filter`, `map`, `reduce`, `fold`, `any`, `all`, `sum`, `min`, `max`) are also individually documented in [Builtins](builtins.md) with full signatures and UFCS examples.
+
 Returns a new list containing only elements that satisfy the predicate. The original list is not modified.
 
 ```python
@@ -332,6 +334,8 @@ xs = [1, 2, 3, 4, 5]
 print(reduce(xs, (a, b) => a + b))   # 15
 ```
 
+Calling `reduce` on an empty list is a runtime error: `runtime error: reduce() on empty list`.
+
 ### fold
 
 Folds a list to a single value using an accumulator function and an explicit initial value.
@@ -348,6 +352,8 @@ Type annotations on lambda parameters are optional:
 xs = [1, 2, 3, 4, 5]
 print(fold(xs, 0, (a, b) => a + b))   # 15
 ```
+
+The initial value must have the same type as the accumulator function's return type; mismatches are a compile error: `fold() initial value type must match function return type`.
 
 ### any
 
@@ -380,7 +386,7 @@ print(sum(xs))   # 15
 
 ### min
 
-Returns the minimum element.
+Returns the minimum element. Calling `min` on an empty list is a runtime error: `runtime error: min() on empty list`.
 
 ```python
 xs = [3, 1, 4, 1, 5]
@@ -389,7 +395,7 @@ print(min(xs))   # 1
 
 ### max
 
-Returns the maximum element.
+Returns the maximum element. Calling `max` on an empty list is a runtime error: `runtime error: max() on empty list`.
 
 ```python
 xs = [3, 1, 4, 1, 5]
@@ -498,7 +504,7 @@ print(xs)             # [1, 2, 3, 2, 1, 4] (unchanged)
 
 ### flatten
 
-Flattens a nested list (list of lists) by one level. Returns a new list. The original list is not modified.
+Flattens a nested list (list of lists) by one level. Returns a new list. The original list is not modified. Passing a non-nested list (e.g. `List<int>`) is a compile error: `flatten() requires a list of lists`.
 
 ```python
 xs = [[1, 2], [3, 4]]
@@ -632,7 +638,7 @@ error; assign the intermediate value to a local variable first.
 
 | Type | Mutating operations |
 |------|-------------------|
-| **List** | `append()`, `pop()`, `insert()`, `remove()`, `remove_at()`, `sort!()`, `reverse!()`, index assignment (`xs[i] = val`) |
+| **List** | `append()` / `append!()`, `pop()`, `insert()`, `remove()`, `remove_at()`, `sort!()`, `reverse!()`, index assignment (`xs[i] = val`) |
 | **Map** | `remove()`, index assignment (`m[key] = val`) |
 | **Set** | `add()`, `remove()` |
 
@@ -741,10 +747,15 @@ print(m)   # {b: 2}
 
 ### get
 
-Returns the value for the specified key, or a default value if the key does not exist.
+Two overloads are available:
+
+- `get(map, key) -> Option<V>`: Returns `Some(value)` if the key exists, or `None` if it does not.
+- `get(map, key, default) -> V`: Returns the value for the key, or `default` if the key does not exist.
 
 ```python
 m = {"a": 1, "b": 2}
+print(get(m, "a"))       # Some(1)
+print(get(m, "z"))       # None
 print(get(m, "a", 0))   # 1
 print(get(m, "z", 0))   # 0
 ```

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -75,7 +75,9 @@ round(1234.5, -2)    # 1200.0
 round(1750.0, -3)    # 2000.0
 ```
 
-Rounding uses C99 half-away-from-zero semantics (via `round(x * 10^digits) / 10^digits`), matching the one-argument form. This differs from Python's banker's rounding — for example, `round(2.675, 2) == 2.68`, not `2.67`. `NaN` and `±Inf` pass through unchanged.
+Rounding uses C99 half-away-from-zero semantics (via `round(x * 10^digits) / 10^digits`), matching the one-argument form. This differs from Python's banker's rounding — for example, `round(2.675, 2) == 2.68`, not `2.67`. `NaN` and `±Inf` pass through unchanged in the two-argument forms.
+
+> **Note**: The one-argument forms (`floor(x)`, `ceil(x)`, `round(x)`) convert the result to `int`. If the argument is `Inf`, `-Inf`, or `NaN`, a runtime error occurs: `runtime error: floor()/ceil()/round() argument out of int range`.
 
 ---
 
@@ -116,7 +118,7 @@ log(8.0, 2.0)      # 3.0
 log(100.0, 10.0)   # 2.0
 ```
 
-`log(x, base)` is computed as `log(x) / log(base)`, so domain errors on either argument propagate as `NaN` or `-Inf`.
+`log(x, base)` is computed as `log(x) / log(base)`, so domain errors on either argument propagate as `NaN` or `-Inf`. Due to floating-point arithmetic, results for "clean" bases may not be exact (e.g. `log(1000000.0, 10.0)` evaluates to `5.999999999999999` rather than `6.0`); use `1e-12` tolerance when comparing.
 
 ---
 

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -4,7 +4,7 @@
 
 ## Regex Literal Syntax
 
-Regex literals use the `/pattern/` syntax and produce a `Regex` type value:
+Regex literals use the `/pattern/` syntax. They can be stored in variables or passed directly to functions that accept a `Regex` parameter:
 
 ```ry
 from regex import is_match, split, replace
@@ -51,7 +51,7 @@ y = is_match("a", /a/) # regex literal
 
 ### Regex Literal Functions (text-first, UFCS-compatible)
 
-These functions take a `Regex` type pattern and use text-first argument order for UFCS:
+These functions take a regex literal pattern and use text-first argument order for UFCS:
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
@@ -155,7 +155,7 @@ Unmatched optional groups (e.g., `(a)?` when the group did not participate) expa
 | `\s` | Whitespace | `"\s+"` matches spaces/tabs |
 | `\S` | Non-whitespace | |
 | `\b` | Word boundary | `"\bword\b"` matches whole word |
-| `\B` | Non-word boundary | `"\Bword"` matches inside a word |
+| `\B` | Non-word boundary (opposite of `\b`; matches where `\b` does not) | `"\Bword\B"` matches `"word"` embedded within another word |
 | `(?i)` | Case-insensitive flag | `"(?i)hello"` matches `"HELLO"` |
 | `\.` | Escaped special character | `"\."` matches literal `.` |
 

--- a/share/std/list.ry
+++ b/share/std/list.ry
@@ -39,6 +39,9 @@ function sort!(values: List<int>) -> Unit
 function sort!(values: List<int>, comparator: function(int, int) -> bool) -> Unit
 
 @native
+function reverse(values: List<int>) -> List<int>
+
+@native
 function reverse!(values: List<int>) -> Unit
 
 @native

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -1689,6 +1689,14 @@ TEST_F(CodeGenTest, ReduceVariants) {
     }
 }
 
+TEST_F(CodeGenTest, ReduceEmptyListError) {
+    std::string src =
+        "xs: List<int> = []\n"
+        "reduce(xs, (a: int, b: int) => a + b)";
+    EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1),
+                "runtime error: reduce\\(\\) on empty list");
+}
+
 TEST_F(CodeGenTest, FoldVariants) {
     // FoldBasic
     {
@@ -1784,6 +1792,18 @@ TEST_F(CodeGenTest, SumMinMax) {
     }
 }
 
+TEST_F(CodeGenTest, MinEmptyListError) {
+    std::string src = "xs: List<int> = []\nprint(min(xs))";
+    EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1),
+                "runtime error: min\\(\\) on empty list");
+}
+
+TEST_F(CodeGenTest, MaxEmptyListError) {
+    std::string src = "xs: List<int> = []\nprint(max(xs))";
+    EXPECT_EXIT(runSource(src), ::testing::ExitedWithCode(1),
+                "runtime error: max\\(\\) on empty list");
+}
+
 // ===== enumerate / zip =====
 
 TEST_F(CodeGenTest, EnumerateBasic) {
@@ -1866,6 +1886,14 @@ TEST_F(CodeGenTest, MapGetWithDefault) {
         "print(get(m, \"a\", 0))\n"
         "print(get(m, \"b\", 99))";
     EXPECT_EQ(runSource(src), "10\n99\n");
+}
+
+TEST_F(CodeGenTest, MapGetTwoArgOption) {
+    std::string src =
+        "m = {\"a\": 10}\n"
+        "print(get(m, \"a\"))\n"
+        "print(get(m, \"z\"))";
+    EXPECT_EQ(runSource(src), "Some(10)\nNone\n");
 }
 
 // ===== remove(map, key) =====


### PR DESCRIPTION
## 概要

issue #1118 `docs/reference/` drift 監査 シリーズの PR 3 (stdlib 基礎 5ファイル)。

対象: `builtins.md` / `builtins-string.md` / `collections.md` / `regex.md` / `math.md`

**audit 結果: drift 13件発見 (内訳: docs 修正 12 / 実装修正 1 / 別 issue 化 3)**

## 修正内容 (α — 本 PR で対応)

### builtins.md
- `reduce` / `min` / `max` の Quick Reference テーブル行に空リスト runtime error を追記
- `filter` section に `collections.md` への cross-ref を追加 (γ — higher-order docs 分担の明示)

### collections.md
- `get(map, key) -> Option<V>` 2-arg overload が未文書化だったため追記 (dispatcher 実装・テストは存在)
- `reduce` に空リスト runtime error: `runtime error: reduce() on empty list`
- `fold` に初期値型不一致 compile error: `fold() initial value type must match function return type`
- `min` / `max` に空リスト runtime error: `runtime error: min()/max() on empty list`
- `flatten` に非ネストリスト compile error: `flatten() requires a list of lists`
- CoW テーブルの List 行に `append!()` を追加 (欠落していた mutating operation)
- `filter` section に `builtins.md` への cross-ref を追加

### math.md
- 1-arg `floor(x)` / `ceil(x)` / `round(x)` が `Inf`/`-Inf`/`NaN` 引数で abort することを Note として追記
  - `runtime error: floor()/ceil()/round() argument out of int range`
  - 2-arg 形 ("NaN and ±Inf pass through unchanged") との非対称が解消
- `log(x, base)` の精度注記: 浮動小数点演算により `log(1000000.0, 10.0)` は `5.999999999999999` になるため `1e-12` tolerance 推奨

### regex.md
- `Regex type value` / `Regex type pattern` の misleading 表現を修正 (内部型に過ぎず user-nameable な Regex record は存在しない)
- `\B` の説明 "matches inside a word" → "Non-word boundary (opposite of `\b`; matches where `\b` does not)"

### share/std/list.ry (実装修正)
- `@native function reverse(values: List<int>) -> List<int>` 宣言を追加
  - dispatcher (`src/codegen_call_string.cpp:39`) とテストは実装済みだが `.ry` 宣言が欠けていた (#889 ルール適用)

### builtins-string.md
- drift なし — verify only、変更なし

## 回帰防止テスト (tests/test_codegen_collection.cpp)

| Test | Expected |
|------|---------|
| `ReduceEmptyListError` | `EXPECT_EXIT` → `runtime error: reduce() on empty list` |
| `MinEmptyListError` | `EXPECT_EXIT` → `runtime error: min() on empty list` |
| `MaxEmptyListError` | `EXPECT_EXIT` → `runtime error: max() on empty list` |
| `MapGetTwoArgOption` | `get(m,"a")` → `Some(10)`, `get(m,"z")` → `None` |

## 実測値 (./build/ry -c で確認)

```
reduce([]) → runtime error: reduce() on empty list
min([])    → runtime error: min() on empty list
max([])    → runtime error: max() on empty list
floor(Inf) → runtime error: floor()/ceil()/round() argument out of int range
round(NaN) → runtime error: floor()/ceil()/round() argument out of int range
log(1000000.0, 10.0) → 5.999999999999999  (not 6.0)
log(8.0, 2.0)        → 3.0  (exact for this case)
```

## 別 issue 化 (β — 本 PR では対応しない)

- #1124 — Dead `reverse!` dispatch registered for strings (`codegen_call_string.cpp:40, 614`)
- #1125 — Dedup higher-order function docs between `builtins.md` and `collections.md`
- #1126 — Replace `python` code fence with `ry` across `docs/reference/` (394箇所 / 21ファイル)

## チェック

- [x] `cmake --build build && ./build/ry_tests` — 1799 tests passed
- [x] `./build/ry test -p` — 142 files passed
- [x] 実エラー文言を `./build/ry -c` で実測してから docs 記述
- [x] issue #1118 の stdlib 基礎 5ファイルチェックボックスを更新済み

Closes #1118 (partial — PR 3 of 5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added immutable `reverse()` operation for lists.

* **Documentation**
  * Clarified runtime error behavior for reduce, min, and max functions on empty lists.
  * Enhanced rounding function and logarithm precision documentation.
  * Improved regex literal and metacharacter documentation clarity.
  * Added cross-references across collection operation references.

* **Tests**
  * Added test coverage for empty list error cases and map get operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->