### PR TITLE
docs(reference): audit stdlib IO/Data 5ファイルの実装 drift 修正 (#1118 PR 4)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2355,6 +2355,31 @@ Cross-check each hit against the corresponding `docs/reference/*.md` page. Missi
 
 ---
 
+### Cross-check operator-level specs before flagging per-file code examples as drift
+
+**Source**: #1118 PR 4 docs audit
+**Tags**: documentation, audit, drift, operators
+
+**Context**: During PR 4 audit of `docs/reference/base64.md`, a code example using
+`?` at the top level was initially flagged as drift ("top-level `?` is a compile error").
+However, `docs/reference/operators.md:165-177` explicitly documents that `?` and `!!` work
+at the top level (Err maps to exit 1 with error message). The implementation in
+`src/codegen_expr.cpp:1861-1895` confirms this with a dedicated top-level `?` desugar path.
+The false alarm arose because only per-package docs were consulted, not the canonical
+operator spec.
+
+**Rule**: When a per-file doc example uses a language operator (`?`, `!!`, `case`, `@`
+directives, etc.), do NOT judge it solely by analogy with how that operator appears in
+function bodies. Always:
+1. Check `docs/reference/operators.md` for the full spec (including top-level usage rules).
+2. Cross-check `src/codegen_expr.cpp` or the relevant codegen for the operator's desugar
+   behavior in different contexts (function body vs. top level vs. lambda).
+
+**How to verify**: For `?` operator specifically, the top-level desugar constraint is
+`src/codegen_expr.cpp:1873-1874`: the `Err` type must be `Error` exactly.
+
+---
+
 ## Commands / Environment gotchas
 
 This section records command/environment mistakes that were

--- a/docs/reference/base64.md
+++ b/docs/reference/base64.md
@@ -51,18 +51,6 @@ case decode_url_safe(encoded):
         print(e.message)
 ```
 
-### Working with Byte Data
-
-To encode/decode byte data, combine with `to_bytes` / `bytes_to_str` from `io`.
-
-```python
-from base64 import encode, decode
-from io import to_bytes, bytes_to_str
-
-bytes = to_bytes("binary data")
-encoded = encode(bytes_to_str(bytes)?)
-```
-
 ## Error Handling
 
 `decode` and `decode_url_safe` return `Result<str, Error>`. Decoding fails if the input contains invalid base64 characters.

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -111,7 +111,6 @@ case read_text("missing.txt"):
 | `read_text` / `read_bytes` | File does not exist or cannot be opened |
 | `write_text` / `write_bytes` / `append_text` | File cannot be opened for writing |
 | `delete_file` | File cannot be deleted |
-| `bytes_to_str` | Input contains NUL byte |
 
 ## Notes
 

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -20,7 +20,7 @@ The `json` package provides functions to parse JSON text into an opaque `JsonVal
 |----------|-----------|-------------|
 | `parse` | `(str) -> Result<JsonValue, Error>` | Parses a JSON string into a JsonValue |
 | `stringify` | `(JsonValue) -> str` | Serializes a JsonValue to compact JSON text |
-| `stringify` | `(JsonValue, int) -> str` | Serializes with pretty printing (indent = number of spaces) |
+| `stringify` | `(JsonValue, int) -> str` | Serializes with pretty printing (indent = number of spaces). A negative indent falls back to compact output. |
 
 ### Type Query
 
@@ -48,7 +48,7 @@ The `json` package provides functions to parse JSON text into an opaque `JsonVal
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `length` | `(JsonValue) -> int` | Returns the length of an array or number of keys in an object |
+| `length` | `(JsonValue) -> int` | Returns the length of an array or number of keys in an object. Returns `0` for non-container values (string / number / boolean / null). |
 | `keys` | `(JsonValue) -> Result<List<str>, Error>` | Returns the keys of an object, or an error if the value is not an object |
 
 ### Memory Management

--- a/docs/reference/path.md
+++ b/docs/reference/path.md
@@ -21,7 +21,7 @@ from path import join, basename, dirname, extension, resolve, is_absolute
 | `resolve` | `(str) -> Result<str, Error>` | Resolves a path to its absolute canonical form |
 | `is_absolute` | `(str) -> bool` | Returns whether a path is absolute |
 
-`join`, `basename`, `dirname`, and `extension` return `Err` when any path argument contains an embedded NUL byte. `is_absolute` is never an error — it only reads the first byte of the path.
+`join`, `basename`, `dirname`, `extension`, and `resolve` return `Err` when any path argument contains an embedded NUL byte. `is_absolute` is never an error — it only reads the first byte of the path.
 
 ## Examples
 
@@ -97,3 +97,5 @@ case resolve("/nonexistent"):
   Err(e):
     print(e.message)  # cannot resolve path '/nonexistent': No such file or directory
 ```
+
+> **Note:** `resolve("")` returns `Err` with message `"cannot resolve path: empty path"`.


### PR DESCRIPTION
## Summary

issue #1118 の PR 4。stdlib IO/Data カテゴリ 5 ファイルの系統的 drift 監査。

- `io.md` ✅ — drift 1 件修正
- `json.md` ✅ — docs 穴埋め 2 件
- `base64.md` ✅ — drift 1 件修正
- `path.md` ✅ — drift 1 件修正 + docs 穴埋め 1 件
- `filesystem.md` ✅ — 全 5 観点 drift 無し

**audit 結果: drift 3 件発見 / docs 穴埋め 3 件 / 実装変更 0 件**

## Changes

### drift 修正 (docs → 実装に合わせる)

- **`io.md`**: Error Handling 表の `bytes_to_str | Input contains NUL byte` 行を削除。#1022 で `bytes_to_str` は NUL を保持する挙動に変わっており、記述が誤り (`tests/spec/io.test.ry:142-148` が根拠)。

- **`path.md`**: NUL-Err 対象関数列挙から `resolve` が漏れていた → 追加。`src/runtime_path.cpp:170-172` で `resolve` も `hasEmbeddedNul` で `Err` を返す。

- **`base64.md`**: "Working with Byte Data" セクションを削除。`to_bytes("data") → bytes_to_str → encode` は `#1022` 以降の NUL-safe str により `encode("data")` と等価な no-op round-trip になっており、バイナリデータを扱う例として誤解を招く内容だった。`List<u8>` overload 追加は #1130 に委ねる。

### docs 穴埋め (実装の挙動を docs に明記)

- **`json.md`**: `stringify(v, indent<0)` は compact 出力になることを明記 (`runtime_json.cpp:605-609`)。
- **`json.md`**: `length` が非コンテナ (string / number / boolean / null) に対して `0` を返すことを明記 (`runtime_json.cpp:740-745`)。
- **`path.md`**: `resolve("")` が `"cannot resolve path: empty path"` エラーを返すことを Note として追記 (`runtime_path.cpp:166-169`)。

### KNOWLEDGE.md

audit 過程で `base64.md` の top-level `?` が誤ってコンパイルエラーと誤判定されそうになった件から、per-file doc の例を評価する前に `docs/reference/operators.md` と `src/codegen_expr.cpp` で全仕様を参照するパターンを追記。

## 別 issue 化 (実装変更を要するもの)

- **#1128** `bug` — `io` パッケージの path 引数に `hasEmbeddedNul` チェックが無い (`filesystem`/`path` との非対称)
- **#1129** `bug` — `base64 encode/decode` が NUL を含む str 入力を `strlen` で途中切り詰める
- **#1130** `enhancement` — `base64` に `List<u8>` overload を追加 (現状バイナリデータを扱える API が無い)

## Test plan

- [x] `grep -nE '\bval\b|\bvar\b|\bpublic\b|\bprivate\b|\bfun\b|\bdef\b' docs/reference/{io,json,base64,path,filesystem}.md` — 0 hit (観点 1 再確認)
- [x] `./build/ry -c 'from base64 import encode; print(encode("hi"))'` — OK
- [x] `./build/ry -c 'from path import extension; print(extension("archive.tar.gz")?)'` — OK (top-level `?` は仕様通り動作)
- [x] `./build/ry_tests` — 1799 tests passed
- [x] `./build/ry test -p` — 142 ファイル 0 failures

Closes (partial — issue #1118 の PR 4): チェックボックス `io`, `json`, `base64`, `path`, `filesystem` を ✅ に更新してください。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for path manipulation functions, clarifying error conditions when paths contain NUL bytes and empty path handling
  * Clarified JSON stringify to fall back to compact output when indent is negative
  * Updated JSON length documentation to specify it returns 0 for non-container values
  * Removed byte data handling section from base64 documentation
  * Enhanced auditing guidance in knowledge base

<!-- end of auto-generated comment: release notes by coderabbit.ai -->