### PR TITLE
fix(runtime): io path 引数への hasEmbeddedNul ガード追加 (#1128)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3471,6 +3471,17 @@ failure that may or may not set the buffer. For NUL-safety tests, assert only th
 is `Err` and that `e.message` contains the expected string. Never assert the message is
 *absent* across test boundaries.
 
+### Do not call `setLastError` in bool-return runtime functions — thread-local `last_error_buf` pollution
+
+**Source**: #1128 (2026-04-18). **Tags**: nul-safety, setLastError, thread-local, runtime, bool-return
+
+**Rule**: `setLastError` writes to a thread-local buffer (`last_error_buf` in `runtime_error.cpp`). In runtime functions whose Ry return type has **no error channel** (e.g. `bool`-returning `__ry_file_exists`), calling `setLastError` when rejecting NUL would leave stale error text in the buffer. The next Result-returning call on the same thread that fails an unrelated check reads the buffer for `e.message`, and would silently report the stale NUL rejection message instead of its own.
+
+**How to apply**:
+- Bool-return-only functions (e.g. `exists`) that detect an invalid argument: return the safe conservative value (`false` / `0`) silently — do **not** call `setLastError`.
+- Result-returning functions: call `setLastError("fn: argument contains an embedded NUL byte")` before returning `nullptr` / `1`.
+- This matches the split used in `src/runtime_io.cpp` after #1128: `__ry_file_exists` has `if (hasEmbeddedNul(path)) return 0;` with no `setLastError`, while all other path-taking functions call it.
+
 ### Ry expect matchers: use `to_not_contain`, not `not_to_contain`
 
 **Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: testing, ry-syntax, matchers

--- a/changelog.d/1128-runtime-io-nul-safety.md
+++ b/changelog.d/1128-runtime-io-nul-safety.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Rejected embedded NUL bytes in path arguments of `io.read_text`, `io.write_text`,
+  `io.append_text`, `io.delete_file`, `io.read_bytes`, and `io.write_bytes`; each
+  now returns `Err(Error{ message: "<fn>: argument contains an embedded NUL byte" })`
+  instead of silently truncating the C string and operating on an unintended file.
+  `io.exists` returns `false` for such paths (no error channel available). Brings
+  `io` to parity with the existing guards in `filesystem` and `path` (#1128).

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -112,10 +112,12 @@ case read_text("missing.txt"):
 | `write_text` / `write_bytes` / `append_text` | File cannot be opened for writing |
 | `delete_file` | File cannot be deleted |
 | `bytes_to_str` | Input contains NUL byte |
+| `read_text` / `write_text` / `append_text` / `delete_file` / `read_bytes` / `write_bytes` | Path contains an embedded NUL byte |
 
 ## Notes
 
 - `List<u8>` is used as the buffer type. Standard list operations (`length()`, `append()`, `slice()`, index access) all work with byte lists.
 - `bytes_to_str()` and `write_bytes()` require a `List<u8>` argument. Four ways to produce a compatible byte list: (1) explicit `u8` suffixes (`[97u8, 0u8, 98u8]`), (2) `to_bytes("...")` to convert a string literal, (3) a type-annotated variable declaration (`bs: List<u8> = [97, 0, 98]`), or (4) reassignment to a `List<u8>` variable (`bs = [99, 100, 101]`). Plain integer list literals without annotation, explicit suffix, or a typed variable target use 64-bit element layout and are rejected at compile time.
 - File paths are relative to the current working directory unless absolute paths are specified.
+- `exists` returns `false` for paths containing an embedded NUL byte (such paths cannot refer to a real file under POSIX).
 - `write_text` and `write_bytes` overwrite existing files. Use `append_text` to add content to existing files.

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -87,6 +87,10 @@ extern "C" const char *__ry_read_all() {
 // ===== File I/O =====
 
 extern "C" const char *__ry_read_text(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("read_text: argument contains an embedded NUL byte");
+        return nullptr;
+    }
     FILE *f = fopen_nofollow(path, "r");
     if (!f) {
         setLastError("cannot open file '%s' for reading", path);
@@ -119,6 +123,10 @@ extern "C" const char *__ry_read_text(const char *path) {
 }
 
 extern "C" int64_t __ry_write_text(const char *path, const char *content) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("write_text: argument contains an embedded NUL byte");
+        return 1;
+    }
     FILE *f = fopen_nofollow(path, "w");
     if (!f) {
         setLastError("cannot open file '%s' for writing", path);
@@ -132,6 +140,10 @@ extern "C" int64_t __ry_write_text(const char *path, const char *content) {
 }
 
 extern "C" int64_t __ry_append_text(const char *path, const char *content) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("append_text: argument contains an embedded NUL byte");
+        return 1;
+    }
     FILE *f = fopen_nofollow(path, "a");
     if (!f) {
         setLastError("cannot open file '%s' for appending", path);
@@ -145,10 +157,15 @@ extern "C" int64_t __ry_append_text(const char *path, const char *content) {
 }
 
 extern "C" int64_t __ry_file_exists(const char *path) {
+    if (hasEmbeddedNul(path)) return 0;
     return access(path, F_OK) == 0 ? 1 : 0;
 }
 
 extern "C" int64_t __ry_delete_file(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("delete_file: argument contains an embedded NUL byte");
+        return 1;
+    }
     if (remove(path) != 0) {
         setLastError("cannot delete file '%s'", path);
         return 1;
@@ -157,6 +174,10 @@ extern "C" int64_t __ry_delete_file(const char *path) {
 }
 
 extern "C" void *__ry_read_bytes(const char *path) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("read_bytes: argument contains an embedded NUL byte");
+        return nullptr;
+    }
     FILE *f = fopen_nofollow(path, "rb");
     if (!f) {
         setLastError("cannot open file '%s' for reading", path);
@@ -190,6 +211,10 @@ extern "C" void *__ry_read_bytes(const char *path) {
 }
 
 extern "C" int64_t __ry_write_bytes(const char *path, void *list) {
+    if (hasEmbeddedNul(path)) {
+        setLastError("write_bytes: argument contains an embedded NUL byte");
+        return 1;
+    }
     auto *header = (IOListHeader *)list;
     FILE *f = fopen_nofollow(path, "wb");
     if (!f) {

--- a/tests/spec/nul_safety_io.test.ry
+++ b/tests/spec/nul_safety_io.test.ry
@@ -1,0 +1,81 @@
+from io import read_text, write_text, append_text, exists, delete_file, read_bytes, write_bytes, to_bytes
+
+describe("nul_safety_io", ():
+  describe("read_text", ():
+    it("rejects NUL in path", ():
+      case read_text("/tmp/ry_nul_io\0bad.txt"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("normal path works", ():
+      case write_text("/tmp/ry_nul_io_rt.txt", "hello"):
+        Ok(_): 0
+        Err(e): fail("unexpected write error: " + e.message)
+      case read_text("/tmp/ry_nul_io_rt.txt"):
+        Ok(s): expect(s).to_eq("hello")
+        Err(e): fail("unexpected read error: " + e.message)
+      delete_file("/tmp/ry_nul_io_rt.txt")
+    )
+  )
+
+  describe("write_text", ():
+    it("rejects NUL in path", ():
+      case write_text("/tmp/ry_nul_io\0bad.txt", "x"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("content with embedded NUL is not rejected (path guard only)", ():
+      case write_text("/tmp/ry_nul_io_ct.txt", "a\0b"):
+        Ok(_): 0
+        Err(e): fail("content NUL should not be rejected: " + e.message)
+      delete_file("/tmp/ry_nul_io_ct.txt")
+    )
+  )
+
+  describe("append_text", ():
+    it("rejects NUL in path", ():
+      case append_text("/tmp/ry_nul_io\0bad.txt", "x"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("delete_file", ():
+    it("rejects NUL in path", ():
+      case delete_file("/tmp/ry_nul_io\0bad.txt"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("read_bytes", ():
+    it("rejects NUL in path", ():
+      case read_bytes("/tmp/ry_nul_io\0bad.bin"):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("write_bytes", ():
+    it("rejects NUL in path", ():
+      data = to_bytes("x")
+      case write_bytes("/tmp/ry_nul_io\0bad.bin", data):
+        Ok(_): fail("expected Err but got Ok")
+        Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+  )
+
+  describe("exists", ():
+    it("returns false for path with embedded NUL", ():
+      expect(exists("/tmp/ry_nul_io\0bad.txt")).to_eq(false)
+    )
+    it("returns true for existing file, false after delete", ():
+      case write_text("/tmp/ry_nul_io_ex.txt", "x"):
+        Ok(_): 0
+        Err(e): fail("unexpected error: " + e.message)
+      expect(exists("/tmp/ry_nul_io_ex.txt")).to_eq(true)
+      delete_file("/tmp/ry_nul_io_ex.txt")
+      expect(exists("/tmp/ry_nul_io_ex.txt")).to_eq(false)
+    )
+  )
+)


### PR DESCRIPTION
## Summary

- `src/runtime_io.cpp` の 7 関数に `hasEmbeddedNul(path)` チェックを追加。NUL を含む path が C 標準関数に渡されると最初の `\0` で silent truncation が起きていたが、これを防ぐ。
- `read_text` / `write_text` / `append_text` / `delete_file` / `read_bytes` / `write_bytes`: `setLastError` + `nullptr` / `1` を返す
- `exists` (bool return, no error channel): `setLastError` は呼ばず `false` を返す（thread-local `last_error_buf` 汚染防止）
- `filesystem` / `path` モジュール (#1054) とのパリティが揃った

## Changes

- `src/runtime_io.cpp` — 7 関数に NUL guard (+25 lines)
- `tests/spec/nul_safety_io.test.ry` — 新規 spec (10 tests)
- `docs/reference/io.md` — Error Handling 表 + Notes 更新
- `changelog.d/1128-runtime-io-nul-safety.md` — 新規 changelog fragment
- `KNOWLEDGE.md` — bool-return 関数での `setLastError` 非呼び出しルールを追記

## Test plan

- [ ] `./build/ry test tests/spec/nul_safety_io.test.ry` — 全 10 テスト通過
- [ ] `./build/ry test tests/spec/io.test.ry` — 既存テストに regression なし
- [ ] `./build/ry_tests` — C++ テスト全通過 (1799)
- [ ] `./build/ry test -p` — Ry セルフテスト全通過 (143)
- [ ] ASan + UBSan clean
- [ ] cppcheck clean

Closes #1128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * File I/O functions now validate and reject paths containing embedded NUL bytes with descriptive error messages for `read_text`, `write_text`, `append_text`, `delete_file`, `read_bytes`, and `write_bytes`.
  * `io.exists` now returns `false` for paths with embedded NUL bytes instead of producing an error.

* **Documentation**
  * Updated I/O API reference with embedded NUL byte error conditions.

* **Tests**
  * Added comprehensive test suite for NUL-byte path safety validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->