### PR TITLE
docs(reference): audit stdlib runtime/network 5ファイルの実装 drift 修正 (#1118 PR 5)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2380,6 +2380,25 @@ function bodies. Always:
 
 ---
 
+### Regenerate enumerated doc tables from implementation, not by hand
+
+**Source**: #1118 PR 5 docs audit
+**Tags**: documentation, audit, drift, http, enumerated-tables
+
+**Context**: `__ry_http_reason_phrase` in `src/runtime_http.cpp:639-696` had 50 `case` statements, but `docs/reference/http.md` listed only 38 status codes — 12 were silently missing (402, 407, 412, 418, 421, 425, 428, 431, 451, 507, 508, 511).
+
+**Rule**: When the implementation contains an enumerated list (status code switch, kind string registry, format specifier table) that is mirrored in a documentation table, **regenerate the doc table from the implementation** rather than hand-editing. For HTTP status codes specifically:
+
+```bash
+grep -nE '^\s*case [0-9]+:' src/runtime_http.cpp
+```
+
+gives the authoritative list; compare it against the `docs/reference/http.md` table before declaring clean. Apply the same pattern to any other enumerated registry (error kind strings, format specifiers, etc.).
+
+**How to verify**: Count `case` statements in the switch vs. rows in the doc table. A mismatch always signals drift.
+
+---
+
 ## Commands / Environment gotchas
 
 This section records command/environment mistakes that were

--- a/docs/reference/gc.md
+++ b/docs/reference/gc.md
@@ -22,8 +22,8 @@ from gc import collect, enable, disable, set_threshold
 |----------|-----------|-------------|
 | `collect` | `() -> int` | Runs a full collection cycle. Returns the number of objects collected. |
 | `enable` | `() -> Unit` | Enables automatic collection (enabled by default). |
-| `disable` | `() -> Unit` | Disables automatic collection. Useful for performance-critical sections. |
-| `set_threshold` | `(n: int) -> Unit` | Sets the candidate count threshold for automatic collection (default: 700). |
+| `disable` | `() -> Unit` | Disables automatic collection AND candidate tracking. Useful for performance-critical sections. Cycles created while disabled are not queued as collection candidates; they remain unreclaimed until one of their objects undergoes another ARC decrement after `enable()` re-enables tracking. |
+| `set_threshold` | `(n: int) -> Unit` | Sets the candidate count threshold for automatic collection (default: 700). Negative values force a collection on every candidate addition (not recommended). |
 
 ## How It Works
 

--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -49,7 +49,7 @@ from http import listen, method, path, header, body, body_bytes, query, query_al
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `response` | `(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>` | Creates an HTTP response with the given status code, headers, and body. Returns `Err` if any header key or value contains an embedded NUL byte. The `body` is binary-safe and may contain NUL bytes. |
+| `response` | `(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>` | Creates an HTTP response with the given status code, headers, and body. Returns `Err` if any header key or value contains an embedded NUL byte. Headers whose key or value contains CR (`\r`) or LF (`\n`) are silently dropped. The `body` is binary-safe and may contain NUL bytes. |
 
 ## Usage Example
 
@@ -242,28 +242,40 @@ The following status codes have standard reason phrases (RFC 9110):
 | 308 | Permanent Redirect |
 | 400 | Bad Request |
 | 401 | Unauthorized |
+| 402 | Payment Required |
 | 403 | Forbidden |
 | 404 | Not Found |
 | 405 | Method Not Allowed |
 | 406 | Not Acceptable |
+| 407 | Proxy Authentication Required |
 | 408 | Request Timeout |
 | 409 | Conflict |
 | 410 | Gone |
 | 411 | Length Required |
+| 412 | Precondition Failed |
 | 413 | Content Too Large |
 | 414 | URI Too Long |
 | 415 | Unsupported Media Type |
 | 416 | Range Not Satisfiable |
 | 417 | Expectation Failed |
+| 418 | I'm a teapot |
+| 421 | Misdirected Request |
 | 422 | Unprocessable Content |
+| 425 | Too Early |
 | 426 | Upgrade Required |
+| 428 | Precondition Required |
 | 429 | Too Many Requests |
+| 431 | Request Header Fields Too Large |
+| 451 | Unavailable For Legal Reasons |
 | 500 | Internal Server Error |
 | 501 | Not Implemented |
 | 502 | Bad Gateway |
 | 503 | Service Unavailable |
 | 504 | Gateway Timeout |
 | 505 | HTTP Version Not Supported |
+| 507 | Insufficient Storage |
+| 508 | Loop Detected |
+| 511 | Network Authentication Required |
 
 Other status codes use `"Unknown"` as the reason phrase.
 

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -22,11 +22,11 @@ from net import bind, listen, accept, connect, listener_port, shutdown, set_time
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `bind` | `(host: str, port: int) -> Result<TcpListener, Error>` | Creates a TCP server socket bound to the given address. Returns `Err` on failure (including if `host` contains an embedded NUL byte). Use port `0` for dynamic allocation. |
+| `bind` | `(host: str, port: int) -> Result<TcpListener, Error>` | Creates a TCP server socket bound to the given address. Returns `Err` on failure (including if `host` contains an embedded NUL byte, or `port` is outside [0, 65535]). Use port `0` for dynamic allocation. |
 | `listen` | `(listener: TcpListener, backlog: int) -> Result<Unit, Error>` | Starts listening for incoming connections. Returns `Err` on failure. |
 | `accept` | `(listener: TcpListener) -> Result<TcpStream, Error>` | Accepts a new connection. Waits up to 1 second for a client to connect. Returns `Err` on timeout or failure. |
 | `connect` | `(host: str, port: int) -> Result<TcpStream, Error>` | Connects to a remote TCP server. Times out after 5 seconds. Returns `Err` on timeout or failure (including if `host` contains an embedded NUL byte). |
-| `listener_port` | `(listener: TcpListener) -> int` | Returns the actual port number the listener is bound to. Useful when binding to port `0` (OS-assigned port). |
+| `listener_port` | `(listener: TcpListener) -> int` | Returns the actual port number the listener is bound to. Useful when binding to port `0` (OS-assigned port). Returns `-1` if the underlying `getsockname` call fails. |
 | `shutdown` | `(listener: TcpListener) -> Unit` | Signals the listener to stop accepting connections. Causes any pending `accept()` to return within at most 1 second. |
 | `tls_connect` | `(host: str, port: int) -> Result<TlsStream, Error>` | Connects to a remote server with TLS encryption. Validates the server certificate against the system CA bundle. Returns `Err` on connection or handshake failure (including if `host` contains an embedded NUL byte). |
 | `set_timeout` | `(stream: TcpStream\|TlsStream, ms: int) -> Unit` | Sets both receive and send timeout in milliseconds. |

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -163,7 +163,7 @@ foo("arg", ():
 | `to_be_less_than(v)` | Asserts `actual < v` | int, float |
 | `to_be_greater_than_or_eq(v)` | Asserts `actual >= v` | int, float |
 | `to_be_less_than_or_eq(v)` | Asserts `actual <= v` | int, float |
-| `to_have_length(n)` | Asserts length equals `n` | List, Set, Map, str |
+| `to_have_length(n)` | Asserts length equals `n` (for `str`, counts UTF-8 codepoints, not bytes) | List, Set, Map, str |
 | `to_be_empty()` | Asserts length is 0 | List, Set, Map, str |
 | `to_start_with(prefix)` | Asserts string starts with prefix | str |
 | `to_end_with(suffix)` | Asserts string ends with suffix | str |
@@ -340,7 +340,7 @@ it("should verify addition is commutative", (a: int, b: int):
 )
 ```
 
-- `count=N` specifies the number of random trials (default: 100)
+- `count=N` specifies the number of random trials (default: 100). `count` must be a positive integer; zero or negative values are rejected at compile time.
 - On failure, the counterexample (failing inputs) is printed
 - The test stops at the first failure
 - Supported parameter types: `int` ([-1000, 1000]), `float` ([-1000.0, 1000.0]), `bool`, `str` (random ASCII, 0-20 chars)


### PR DESCRIPTION
## Summary

issue #1118「docs/reference/ 全 25 ファイルの実装 drift 系統監査」の PR 5 (最終)。stdlib runtime/network カテゴリ 5 ファイル (`net`, `http`, `thread`, `gc`, `testing`) を対象に監査を実施し、8 箇所の drift を修正。これで #1118 の全 25 ファイル audit が完了する。

### 修正内容

#### `docs/reference/net.md`
- `bind`: port が [0, 65535] 範囲外のとき `Err` を返すことを追記 (根拠: `src/runtime_net.cpp:43-46`)
- `listener_port`: `getsockname` 失敗時に `-1` を返すことを追記 (根拠: `src/runtime_net.cpp:307-315`)

#### `docs/reference/http.md`
- `response()`: header key/value に CR/LF を含む場合 silently drop されることを追記 (根拠: `src/runtime_http.cpp:605-619`)
- Supported Status Codes テーブルに 12 コードを追加: 402, 407, 412, 418, 421, 425, 428, 431, 451, 507, 508, 511 (根拠: `src/runtime_http.cpp:639-696`)

#### `docs/reference/gc.md`
- `disable()`: candidate tracking も停止することを明記、disable 中に作られたサイクルの回収タイミングを正確に記述 (根拠: `src/runtime_gc.cpp:207-208`)
- `set_threshold()`: 負数を渡すと毎回 GC が走ることを追記 (根拠: `src/runtime_gc.cpp:245-249`)

#### `docs/reference/testing.md`
- `to_have_length`: `str` に対して UTF-8 codepoint 数を数えることを明記 (根拠: `src/codegen_test.cpp:965-969`)
- `@property count`: 0 以下の値はコンパイルエラーになることを追記 (根拠: `src/codegen_test.cpp:353`)

#### `KNOWLEDGE.md`
- 列挙テーブル (status code switch など) は実装から再生成する audit パターンを追記

### スコープ外で発見した事項

- **別 issue 起票済み** (#1135): `share/std/thread/thread.ry` の `thread_spawn`/`thread_join` @native 宣言が `Unit` 固定で、dispatcher・test・docs が正しく `T` を記述しているのに宣言だけ古い。型チェッカー影響ありのため別 PR で対応。
- **E-1** (任意): `tests/spec/http.test.ry` が `http` パッケージ関数自体をテストしていない coverage gap
- **E-2** (任意): `testing.md:258` の mock contract enforcement 記述が実装と食い違う可能性

### 検証

- `grep -nE '\bval\b|\bvar\b|\bpublic\b|\bprivate\b|\bfun\b|\bdef\b' docs/reference/{net,http,gc,testing}.md` → 変更行なし
- 12 status codes が `runtime_http.cpp` の switch と完全一致
- `./build/ry_tests`: 1799 tests passed
- `./build/ry test -p`: 142 files, 0 failures

Closes #1118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded HTTP API documentation with 12 additional standard HTTP status codes (402, 407, 412, 418, 421, 425, 428, 431, 451, 507, 508, 511)
  * Clarified garbage collection module behavior for disable/enable operations and threshold handling
  * Updated network binding documentation to specify port range validation and error handling
  * Refined testing framework documentation for UTF-8 codepoint measurement in string length assertions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->