### PR TITLE
docs(reference): replace ```python fence with ```ry across docs/reference/ (#1126)

### DIFF
--- a/docs/reference/base64.md
+++ b/docs/reference/base64.md
@@ -4,7 +4,7 @@
 
 Base64 encoding and decoding. All functions require explicit import from `base64`.
 
-```python
+```ry
 from base64 import encode, decode, encode_url_safe, decode_url_safe
 ```
 
@@ -21,7 +21,7 @@ from base64 import encode, decode, encode_url_safe, decode_url_safe
 
 ### Basic Encoding and Decoding
 
-```python
+```ry
 from base64 import encode, decode
 
 encoded = encode("Hello, World!")
@@ -38,7 +38,7 @@ case decode(encoded):
 
 URL-safe base64 uses `-` and `_` instead of `+` and `/`, and omits padding (`=`). Useful for URLs, filenames, and tokens.
 
-```python
+```ry
 from base64 import encode_url_safe, decode_url_safe
 
 encoded = encode_url_safe("data with special chars: ?&=")
@@ -60,7 +60,7 @@ Input strings may contain embedded NUL bytes (`\0`); `encode` and `encode_url_sa
 
 `decode` and `decode_url_safe` return `Result<str, Error>`. Decoding fails if the input contains invalid base64 characters.
 
-```python
+```ry
 case decode("!!!not-valid!!!"):
     Ok(s):
         print(s)
@@ -70,7 +70,7 @@ case decode("!!!not-valid!!!"):
 
 With the `?` operator:
 
-```python
+```ry
 function process(input: str) -> Result<str, Error>:
     decoded = decode(input)?
     return Ok(decoded)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -75,7 +75,7 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 
 Returns whether string `string` contains the substring `substring`. When `ignore_case` is `true`, the comparison is case-insensitive (ASCII only). Both `string` and `substring` may contain embedded NUL bytes (`\0`).
 
-```python
+```ry
 print(contains("hello", "ell"))              # true
 print("hello".contains("xyz"))               # false (UFCS)
 print(contains("Hello World", "hello", true))  # true (case-insensitive)
@@ -90,7 +90,7 @@ print(contains("a\0b", "\0b"))               # true (NUL-safe)
 
 Returns whether string `string` starts with `prefix`. When `ignore_case` is `true`, the comparison is case-insensitive (ASCII only). Both arguments may contain embedded NUL bytes (`\0`).
 
-```python
+```ry
 print(starts_with("hello", "hel"))              # true
 print("hello".starts_with("world"))              # false (UFCS)
 print(starts_with("Hello", "hello", true))  # true (case-insensitive)
@@ -105,7 +105,7 @@ print(starts_with("a\0b", "a\0"))            # true (NUL-safe)
 
 Returns whether string `string` ends with `suffix`. When `ignore_case` is `true`, the comparison is case-insensitive (ASCII only). Both arguments may contain embedded NUL bytes (`\0`).
 
-```python
+```ry
 print(ends_with("hello", "llo"))              # true
 print("hello".ends_with("world"))              # false (UFCS)
 print(ends_with("Hello World", "WORLD", true))  # true (case-insensitive)
@@ -120,7 +120,7 @@ print(ends_with("a\0b", "\0b"))               # true (NUL-safe)
 
 Returns the character position of the first occurrence of substring `substring` in string `string`. Returns `None` if not found. Both arguments may contain embedded NUL bytes (`\0`); the returned index counts Unicode code points (NUL counts as one code point).
 
-```python
+```ry
 print(find("hello world", "world"))   # Some(6)
 print(find("hello", "xyz"))           # None
 print("abcdef".find("cd"))            # Some(2) (UFCS)
@@ -137,7 +137,7 @@ Returns the substring of `string` from `start` to `end` (exclusive). Indices are
 
 Out-of-range indices are clamped to `[0, length]`. If `end < start` after clamping, returns an empty string.
 
-```python
+```ry
 print(substring("hello world", 0, 5))   # hello
 print(substring("hello world", 6, 11))  # world
 print("abcdef".substring(1, 4))         # bcd (UFCS)
@@ -155,7 +155,7 @@ Returns the UTF-8 character at position `i` in string `string` as a string. Rais
 
 Negative indices wrap around from the end (Python-style): `-1` refers to the last character, `-2` to the second-to-last, and so on.
 
-```python
+```ry
 print(char_at("hello", 0))    # h
 print(char_at("hello", -1))   # o (last character)
 print("abc".char_at(2))       # c (UFCS)
@@ -172,7 +172,7 @@ Returns a new string with all occurrences of `old` in `string` replaced with `ne
 
 If `old` is an empty string, the input is returned unchanged (as a fresh copy).
 
-```python
+```ry
 print(replace("hello world", "world", "ry"))   # hello ry
 print(replace("aaa", "a", "bb"))                # bbbbbb
 print("foo bar foo".replace("foo", "baz"))      # baz bar baz (UFCS)
@@ -188,7 +188,7 @@ print(replace("a\0b\0a", "\0", "-"))            # a-b-a (NUL-safe)
 
 Returns a new string with ASCII lowercase letters (a-z) converted to uppercase. Embedded NUL bytes (`\0`) are preserved unchanged (#1050).
 
-```python
+```ry
 print(to_upper("hello"))         # HELLO
 print("Hello World".to_upper())  # HELLO WORLD (UFCS)
 print(byte_len(to_upper("a\0B"))) # 3 (NUL byte preserved)
@@ -202,7 +202,7 @@ print(byte_len(to_upper("a\0B"))) # 3 (NUL byte preserved)
 
 Returns a new string with ASCII uppercase letters (A-Z) converted to lowercase. Embedded NUL bytes (`\0`) are preserved unchanged (#1050).
 
-```python
+```ry
 print(to_lower("HELLO"))         # hello
 print("Hello World".to_lower())  # hello world (UFCS)
 print(byte_len(to_lower("A\0b"))) # 3 (NUL byte preserved)
@@ -216,7 +216,7 @@ print(byte_len(to_lower("A\0b"))) # 3 (NUL byte preserved)
 
 Returns a new string with leading and trailing whitespace characters (spaces, tabs, newlines, carriage returns) removed. Interior NUL bytes (`\0`) are preserved (#1050).
 
-```python
+```ry
 print(trim("  hello  "))   # hello
 print("  hi  ".trim())     # hi (UFCS)
 print(byte_len(trim("  a\0b  "))) # 3 (interior NUL preserved)
@@ -230,7 +230,7 @@ print(byte_len(trim("  a\0b  "))) # 3 (interior NUL preserved)
 
 Returns a new string with leading whitespace characters removed. Interior NUL bytes (`\0`) are preserved (#1050).
 
-```python
+```ry
 print(trim_start("  hello  "))   # hello
 print("  hi".trim_start())       # hi (UFCS)
 ```
@@ -243,7 +243,7 @@ print("  hi".trim_start())       # hi (UFCS)
 
 Returns a new string with trailing whitespace characters removed. Interior NUL bytes (`\0`) are preserved (#1050).
 
-```python
+```ry
 print(trim_end("  hello  "))   #   hello
 print("hi  ".trim_end())       # hi (UFCS)
 ```
@@ -256,7 +256,7 @@ print("hi  ".trim_end())       # hi (UFCS)
 
 Returns a new string with `string` repeated `count` times. Embedded NUL bytes (`\0`) are preserved (#1051).
 
-```python
+```ry
 print(repeat("ab", 3))     # ababab
 print("ha".repeat(3))      # hahaha (UFCS)
 print(byte_len("\0a".repeat(3))) # 6 (NUL bytes preserved)
@@ -270,7 +270,7 @@ print(byte_len("\0a".repeat(3))) # 6 (NUL bytes preserved)
 
 Returns a new string with the characters reversed (UTF-8 aware).
 
-```python
+```ry
 print(reverse("hello"))    # olleh
 print("abc".reverse())     # cba (UFCS)
 print(byte_len(reverse("a\0b")))   # 3 (NUL bytes are preserved when reversing)
@@ -286,7 +286,7 @@ Returns the byte length of string `string`. Unlike `length()`, which returns the
 
 Embedded NUL bytes (`\0`) are counted — `byte_len("a\0b")` returns `3`.
 
-```python
+```ry
 print(byte_len("hello"))   # 5
 print(byte_len("あいう"))   # 9
 print(length("あいう"))        # 3 (characters)
@@ -305,7 +305,7 @@ When the delimiter is an empty string `""`, the string is split into individual 
 
 Both `string` and `delimiter` may contain embedded NUL bytes (`\0`); all paths are NUL-safe (#1051).
 
-```python
+```ry
 parts = split("a,b,c", ",")
 print(parts[0])   # a
 print(parts[1])   # b
@@ -344,7 +344,7 @@ print(byte_len(parts[0]))       # 3  ("a\0b")
 
 Joins the elements of a string list with separator `sep` and returns a string. Both list elements and `sep` may contain embedded NUL bytes (`\0`) (#1051).
 
-```python
+```ry
 parts = ["a", "b", "c"]
 print(join(parts, ","))        # a,b,c
 print(parts.join("-"))         # a-b-c (UFCS)
@@ -359,7 +359,7 @@ print(",".join(parts))         # a,b,c (UFCS, Python-style)
 
 Converts a string to an integer. Leading whitespace is allowed. Returns `Err` if the string is empty, contains invalid characters, or overflows.
 
-```python
+```ry
 case to_int("42"):
     Ok(v):
         print(v)              # 42
@@ -385,7 +385,7 @@ print(to_int(""))             # Err(Error("to_int: empty string"))
 
 Converts a string to a floating-point number. Returns `Err` if the string is empty, contains invalid characters, or is out of range for `float`.
 
-```python
+```ry
 case to_float("3.14"):
     Ok(v):
         print(v)              # 3.14
@@ -428,7 +428,7 @@ Converts a value to a string.
 
 Whole-number `float` values are formatted with a trailing `.0` (e.g. `to_str(3.0) == "3.0"`) so they are visually distinguishable from `int`. Record types automatically generate a `to_str` representation. If a user-defined `function to_str(v: MyRecord) -> str` is provided, it takes precedence over the auto-generated version. This also works with `print()` and f-string interpolation.
 
-```python
+```ry
 print(to_str(42))         # 42
 print(to_str(3.14))       # 3.14
 print(to_str(3.0))        # 3.0          (whole-number float keeps .0)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -177,7 +177,7 @@ Prints one or more values to standard output, separated by `sep` (default: space
 
 `float` values are formatted using the **shortest round-trip representation**: the fewest decimal digits that reconstruct the exact `double` value when parsed back, matching the behaviour of Python 3, Rust, Go, and JavaScript. Whole-number floats additionally append `.0` (e.g. `3.0`, `0.0`) so they are visually distinguishable from `int`. As a result, imprecise arithmetic like `0.1 + 0.2` prints as `"0.30000000000000004"` rather than `"0.3"`, accurately reflecting the stored value. Nested collections (e.g. `Map<str, List<int>>`) are recursively formatted using the inner element's formatter. Union variants whose underlying type is `List`, `Map`, or `Set` format as that collection; variants whose underlying type is a function value format as `<closure>`.
 
-```python
+```ry
 print(42)          # 42
 print(3.14)        # 3.14
 print(3.0)         # 3.0         (whole-number float keeps .0)
@@ -226,7 +226,7 @@ print("a", "b", sep="-", end="!\n")  # a-b!
 
 Constructs the value-present variant of an Option type.
 
-```python
+```ry
 x: Option<int> = Some(42)
 print(x)   # Some(42)
 ```
@@ -239,7 +239,7 @@ print(x)   # Some(42)
 
 Returns the number of elements in a list, map, or set, or the number of UTF-8 characters in a string. Use `byte_len()` for the byte length.
 
-```python
+```ry
 print(length([1, 2, 3]))         # 3
 print(length({"a": 1, "b": 2})) # 2
 print(length({1, 2, 3}))         # 3
@@ -255,7 +255,7 @@ print(length("あいう"))           # 3 (UTF-8 characters)
 
 Returns whether a specified key exists in the map. UFCS notation is also available.
 
-```python
+```ry
 m = {"a": 1, "b": 2}
 print(has_key(m, "a"))    # true
 print(m.has_key("z"))     # false (UFCS)
@@ -269,7 +269,7 @@ print(m.has_key("z"))     # false (UFCS)
 
 Adds an element to a set. Does nothing if the element already exists. UFCS notation is also available.
 
-```python
+```ry
 s = {1, 2, 3}
 s.add(4)          # UFCS
 add(s, 5)         # Normal call
@@ -285,7 +285,7 @@ print(length(s))     # 5
 
 Removes an element from a set. UFCS notation is also available.
 
-```python
+```ry
 s = {1, 2, 3}
 s.remove(2)       # UFCS
 print(2 in s)     # false
@@ -310,7 +310,7 @@ Generates a list of integers.
 - When `step == 0`, a runtime error occurs.
 - If the range is empty (e.g., `range(0, 10, -1)`), returns an empty list.
 
-```python
+```ry
 print(range(3))           # [0, 1, 2]
 print(range(2, 5))        # [2, 3, 4]
 print(range(0, 10, 2))    # [0, 2, 4, 6, 8]
@@ -333,7 +333,7 @@ Terminates the process immediately with the given exit code. Statements
 after `exit()` are compiled into an unreachable block that LLVM removes
 during optimization, so they never run:
 
-```python
+```ry
 exit(0)        # normal termination
 exit(1)        # error termination
 
@@ -353,7 +353,7 @@ after any diverging control-flow statement is silently elided.
 
 Returns the command-line arguments passed to the script as a list of strings. Does not include the interpreter name or the script filename — only the arguments after the script path.
 
-```python
+```ry
 # Run: ry script.ry hello world
 a = arguments()
 print(length(a))    # 2
@@ -372,7 +372,7 @@ for x in arguments():
 
 Suspends execution of the current thread for the specified number of milliseconds. If `duration_ms` is 0 or negative, the function returns immediately.
 
-```python
+```ry
 sleep(1000)    # wait 1 second
 sleep(0)       # returns immediately
 ```
@@ -389,7 +389,7 @@ If a `.env` file exists in the project root (the directory containing `package.t
 
 > **Security note:** `.env` files typically contain secrets (API keys, database passwords, tokens, etc.). Do **not** commit `.env` to version control (add it to `.gitignore` or equivalent), and treat its contents as sensitive configuration.
 
-```python
+```ry
 # One-argument form: returns Option<str>
 path = env("PATH")
 case path:
@@ -432,7 +432,7 @@ See [RY_ENV](packages.md#ry_env) for details on environment modes.
 
 Adds an element to the end of a list. This is a mutating operation — the list is modified in place. UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2]
 xs.append(3)
 print(xs)   # [1, 2, 3]
@@ -446,7 +446,7 @@ print(xs)   # [1, 2, 3]
 
 Removes and returns the last element of a list as `Option<T>`. Returns `None` if the list is empty. UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2, 3]
 v = xs.pop()
 print(v)    # Some(3)
@@ -461,7 +461,7 @@ print(xs)   # [1, 2]
 
 Returns a new list with elements in reverse order. The original list is not modified. Also works on strings (see [String Operations](builtins-string.md)). UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2, 3]
 ys = reverse(xs)
 print(ys)   # [3, 2, 1]
@@ -476,7 +476,7 @@ print(xs)   # [1, 2, 3] (unchanged)
 
 Returns a new sub-list from `start` (inclusive) to `end` (exclusive). Indices are clamped to the valid range (`0` to `length(list)`). UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 print(slice(xs, 1, 3))     # [2, 3]
 print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (clamped)
@@ -490,7 +490,7 @@ print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (clamped)
 
 Returns a new list with the first `count` elements. If `count` exceeds the list length, returns a copy of the entire list. If `count <= 0`, returns an empty list. The original list is not modified. UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 ys = xs.take(3)
 print(ys)   # [1, 2, 3]
@@ -506,7 +506,7 @@ print(xs.take(0))    # []
 
 Calls the given function on each element (ignoring any return value), then returns the original list unchanged. Useful for debugging or inserting side effects in a method chain. UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2, 3]
 ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 # prints 1, 2, 3, then ys = [2, 4, 6]
@@ -522,7 +522,7 @@ ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 
 Returns a new list containing only elements for which the predicate returns `true`. The original list is not modified. UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 ys = xs.filter((x: int) => x > 3)
 print(ys)   # [4, 5]
@@ -537,7 +537,7 @@ print(xs)   # [1, 2, 3, 4, 5]  (unchanged)
 
 Returns a new list with each element transformed by the given function. The output element type can differ from the input type. The original list is not modified. UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2, 3]
 ys = xs.map((x: int) => x * 2)
 print(ys)   # [2, 4, 6]
@@ -551,7 +551,7 @@ print(ys)   # [2, 4, 6]
 
 Returns a new sorted list. Default is ascending order. An optional comparator function can be provided that returns `true` if the first argument should come before the second. The original list is not modified. The sort is **stable** (equal elements preserve their original order). UFCS notation is also available.
 
-```python
+```ry
 xs = [3, 1, 2]
 print(xs.sort())   # [1, 2, 3]
 
@@ -568,7 +568,7 @@ print(desc)   # [3, 2, 1]
 
 Sorts a list in place. Same sorting algorithm as `sort()`, but modifies the original list instead of creating a new one. UFCS notation is also available.
 
-```python
+```ry
 xs = [3, 1, 2]
 xs.sort!()
 print(xs)   # [1, 2, 3]
@@ -582,7 +582,7 @@ print(xs)   # [1, 2, 3]
 
 Reverses a list in place. UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2, 3]
 xs.reverse!()
 print(xs)   # [3, 2, 1]
@@ -596,7 +596,7 @@ print(xs)   # [3, 2, 1]
 
 Returns a new list with the element added at the end. The original list is not modified. UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2]
 ys = xs.appended(3)
 print(xs)   # [1, 2] (unchanged)
@@ -619,7 +619,7 @@ Alias for `append()`. Adds an element to the end of a list in place. Provided fo
 
 Returns the first element of a list as `Option<T>`. Returns `None` if the list is empty.
 
-```python
+```ry
 print(first([10, 20, 30]))   # Some(10)
 ```
 
@@ -631,7 +631,7 @@ print(first([10, 20, 30]))   # Some(10)
 
 Returns the last element of a list as `Option<T>`. Returns `None` if the list is empty.
 
-```python
+```ry
 print(last([10, 20, 30]))   # Some(30)
 ```
 
@@ -643,7 +643,7 @@ print(last([10, 20, 30]))   # Some(30)
 
 Two-argument form returns the value for key as `Option<V>`. Three-argument form returns the value or the default.
 
-```python
+```ry
 m = {"a": 1, "b": 2}
 print(get(m, "a"))       # Some(1)
 print(get(m, "z"))       # None
@@ -661,7 +661,7 @@ Creates a lazy iterator from a collection. The iterator does not copy data; it r
 - For `List<T>` and `Set<T>`, the element type is `T`.
 - For `Map<K, V>`, the element type is the tuple `(K, V)`.
 
-```python
+```ry
 xs = [1, 2, 3]
 it = xs.iter()           # Iterator<int>
 ys = it.to_list()        # [1, 2, 3]
@@ -679,7 +679,7 @@ for k, v in m.iter():        # Iterator<(str, int)>
 
 Returns the next element from the iterator as `Option<T>`. Returns `None` when the iterator is exhausted. The iterator advances its internal state on each call. UFCS notation is also available.
 
-```python
+```ry
 it = [10, 20].iter()
 print(it.next())   # Some(10)
 print(it.next())   # Some(20)
@@ -694,7 +694,7 @@ print(it.next())   # None
 
 Collects all remaining elements from the iterator into a new list. UFCS notation is also available.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 ys = xs.iter().filter((x: int) => x > 2).to_list()
 print(ys)   # [3, 4, 5]

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -10,7 +10,7 @@ A fixed-length combination of heterogeneous values. Implemented as a stack-alloc
 
 ### Syntax
 
-```python
+```ry
 t = (42,)                      # single-element tuple (trailing comma required)
 t = (1, 3.14)
 t: (int, float) = (1, 3.14)
@@ -18,7 +18,7 @@ t: (int, float) = (1, 3.14)
 
 ### Type Annotation
 
-```python
+```ry
 single: (int,) = (42,)                     # trailing comma required for single-element
 pair: (int, str) = (42, "hello")
 triple: (int, float, bool) = (1, 2.0, true)
@@ -28,7 +28,7 @@ triple: (int, float, bool) = (1, 2.0, true)
 
 Tuples support `==` and `!=` via element-wise comparison.
 
-```python
+```ry
 print((1, 2) == (1, 2))    # true
 print((1, 2) != (3, 4))    # true
 print(("a", 1) == ("b", 1))  # false
@@ -38,7 +38,7 @@ print(("a", 1) == ("b", 1))  # false
 
 Access elements using numeric indices `.0`, `.1`, etc.
 
-```python
+```ry
 t = (10, 3.14)
 print(t.0)   # 10
 print(t.1)   # 3.14
@@ -46,7 +46,7 @@ print(t.1)   # 3.14
 
 ### Function Return Values
 
-```python
+```ry
 function swap(a: int, b: int) -> (int, int):
     return (b, a)
 
@@ -72,7 +72,7 @@ A variable-length sequence of elements of the same type. Allocated on the heap.
 
 ### Syntax
 
-```python
+```ry
 xs = [1, 2, 3]
 xs: List<int> = [1, 2, 3]
 xs = [1, 2, 3,]          # trailing comma allowed
@@ -82,7 +82,7 @@ xs = [1, 2, 3,]          # trailing comma allowed
 
 An empty list requires a type annotation so the element type can be determined:
 
-```python
+```ry
 xs: List<int> = []
 xs: List<str> = []
 ```
@@ -91,7 +91,7 @@ xs: List<str> = []
 
 Lists can be concatenated with `+` and `+=`:
 
-```python
+```ry
 a = [1, 2, 3]
 b = [4, 5, 6]
 c = a + b       # [1, 2, 3, 4, 5, 6]
@@ -108,7 +108,7 @@ Both operands must have the same element type.
 
 Lists support `==` and `!=`. Two lists are equal when they have the same length and all corresponding elements are equal.
 
-```python
+```ry
 [1, 2, 3] == [1, 2, 3]   # true
 [1, 2, 3] != [1, 2, 4]   # true
 [1, 2]    != [1, 2, 3]   # true (different lengths)
@@ -116,7 +116,7 @@ Lists support `==` and `!=`. Two lists are equal when they have the same length 
 
 ### Index Access
 
-```python
+```ry
 xs = [1, 2, 3]
 print(xs[0])   # 1
 print(xs[2])   # 3
@@ -124,7 +124,7 @@ print(xs[2])   # 3
 
 Negative indices wrap around from the end (Python-style):
 
-```python
+```ry
 xs = [10, 20, 30]
 print(xs[-1])   # 30 (last element)
 print(xs[-2])   # 20
@@ -135,7 +135,7 @@ Out-of-bounds access (including negative indices that exceed the list length) ra
 
 ### Index Assignment
 
-```python
+```ry
 xs = [1, 2, 3]
 xs[0] = 99
 print(xs[0])   # 99
@@ -149,7 +149,7 @@ Index and field assignment compose: the left-hand side of `=` / `+=` / `-=` /
 `*=` / `/=` / `//=` / `%=` / `**=` / `&=` / `|=` / `^=` / `<<=` / `>>=` can be
 any postfix chain rooted at a mutable variable.
 
-```python
+```ry
 record Point:
   x: int
   y: int
@@ -171,7 +171,7 @@ Compound assignment evaluates each index exactly once, so `xs[f()] += 1` calls
 `f()` a single time. Compound assignment to a missing map key is a runtime
 error — insert the key first if you want to accumulate:
 
-```python
+```ry
 m = {"a": 1}
 m["a"] += 10            # OK  → {"a": 11}
 m["b"] += 10            # runtime error: compound assignment to missing map key
@@ -186,21 +186,21 @@ m["b"] += 10            # runtime error: compound assignment to missing map key
 
 ### length
 
-```python
+```ry
 xs = [1, 2, 3]
 print(length(xs))   # 3
 ```
 
 ### print
 
-```python
+```ry
 xs = [1, 2, 3]
 print(xs)   # [1, 2, 3]
 ```
 
 ### for Iteration
 
-```python
+```ry
 xs = [10, 20, 30]
 for x in xs:
     print(x)
@@ -213,7 +213,7 @@ for x in xs:
 
 Adds an element to the end of the list. This is a mutating operation.
 
-```python
+```ry
 xs = [1, 2]
 xs.append(3)
 print(xs)   # [1, 2, 3]
@@ -223,7 +223,7 @@ print(xs)   # [1, 2, 3]
 
 Removes and returns the last element. Returns `None` if the list is empty.
 
-```python
+```ry
 xs = [1, 2, 3]
 v = xs.pop()
 print(v)    # Some(3)
@@ -234,7 +234,7 @@ print(xs)   # [1, 2]
 
 Returns a new list with elements in reverse order. The original list is not modified. Also works on strings.
 
-```python
+```ry
 xs = [1, 2, 3]
 print(reverse(xs))   # [3, 2, 1]
 print(xs)            # [1, 2, 3] (unchanged)
@@ -244,7 +244,7 @@ print(xs)            # [1, 2, 3] (unchanged)
 
 Returns a new sub-list from `start` (inclusive) to `end` (exclusive). Indices are clamped to the valid range.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 print(slice(xs, 1, 3))     # [2, 3]
 print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (clamped)
@@ -254,7 +254,7 @@ print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (clamped)
 
 Returns a new list with the first `count` elements. If `count` exceeds the list length, returns a copy of the entire list. If `count <= 0`, returns an empty list. The original list is not modified.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 ys = xs.take(3)
 print(ys)   # [1, 2, 3]
@@ -266,7 +266,7 @@ print(xs.take(0))    # []
 
 Calls the given function on each element (ignoring any return value), then returns the original list unchanged. Useful for debugging or inserting side effects in a method chain.
 
-```python
+```ry
 xs = [1, 2, 3]
 ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 # prints 1, 2, 3, then ys = [2, 4, 6]
@@ -278,7 +278,7 @@ ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 
 Returns a new list containing only elements that satisfy the predicate. The original list is not modified.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 ys = xs.filter((x: int) => x > 3)
 print(ys)   # [4, 5]
@@ -288,7 +288,7 @@ print(ys)   # [4, 5]
 
 Returns a new list with each element transformed by the given function. The output element type can differ from the input. The original list is not modified.
 
-```python
+```ry
 xs = [1, 2, 3]
 ys = xs.map((x: int) => x * 2)
 print(ys)   # [2, 4, 6]
@@ -298,7 +298,7 @@ print(ys)   # [2, 4, 6]
 
 Returns a new sorted list. Default is ascending order. A custom comparator can be provided. The original list is not modified. The sort is **stable** (equal elements preserve their original order). Internally uses TimSort.
 
-```python
+```ry
 xs = [3, 1, 2]
 print(xs.sort())   # [1, 2, 3]
 
@@ -311,7 +311,7 @@ print(desc)   # [3, 2, 1]
 
 These functions return new lists, so they can be chained via UFCS.
 
-```python
+```ry
 xs = [5, 3, 1, 4, 2]
 result = xs.filter((x: int) => x > 1).map((x: int) => x * 10).sort()
 print(result)   # [20, 30, 40, 50]
@@ -321,7 +321,7 @@ print(result)   # [20, 30, 40, 50]
 
 Reduces a list to a single value using an accumulator function, starting with the first element.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 total = reduce(xs, (a: int, b: int) => a + b)
 print(total)   # 15
@@ -329,7 +329,7 @@ print(total)   # 15
 
 Type annotations on lambda parameters are optional:
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 print(reduce(xs, (a, b) => a + b))   # 15
 ```
@@ -340,7 +340,7 @@ Calling `reduce` on an empty list is a runtime error: `runtime error: reduce() o
 
 Folds a list to a single value using an accumulator function and an explicit initial value.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 total = fold(xs, 0, (a: int, b: int) => a + b)
 print(total)   # 15
@@ -348,7 +348,7 @@ print(total)   # 15
 
 Type annotations on lambda parameters are optional:
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 print(fold(xs, 0, (a, b) => a + b))   # 15
 ```
@@ -359,7 +359,7 @@ The initial value must have the same type as the accumulator function's return t
 
 Returns `true` if at least one element satisfies the predicate.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 print(any(xs, (x: int) => x > 4))   # true
 print(any(xs, (x: int) => x > 9))   # false
@@ -369,7 +369,7 @@ print(any(xs, (x: int) => x > 9))   # false
 
 Returns `true` if every element satisfies the predicate.
 
-```python
+```ry
 xs = [2, 4, 6]
 print(all(xs, (x: int) => x > 0))   # true
 print(all(xs, (x: int) => x > 3))   # false
@@ -379,7 +379,7 @@ print(all(xs, (x: int) => x > 3))   # false
 
 Returns the sum of all elements.
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 print(sum(xs))   # 15
 ```
@@ -388,7 +388,7 @@ print(sum(xs))   # 15
 
 Returns the minimum element. Calling `min` on an empty list is a runtime error: `runtime error: min() on empty list`.
 
-```python
+```ry
 xs = [3, 1, 4, 1, 5]
 print(min(xs))   # 1
 ```
@@ -397,7 +397,7 @@ print(min(xs))   # 1
 
 Returns the maximum element. Calling `max` on an empty list is a runtime error: `runtime error: max() on empty list`.
 
-```python
+```ry
 xs = [3, 1, 4, 1, 5]
 print(max(xs))   # 5
 ```
@@ -406,7 +406,7 @@ print(max(xs))   # 5
 
 Returns the first element. Returns `None` if the list is empty.
 
-```python
+```ry
 xs = [10, 20, 30]
 print(first(xs))   # Some(10)
 ```
@@ -415,7 +415,7 @@ print(first(xs))   # Some(10)
 
 Returns the last element. Returns `None` if the list is empty.
 
-```python
+```ry
 xs = [10, 20, 30]
 print(last(xs))   # Some(30)
 ```
@@ -424,7 +424,7 @@ print(last(xs))   # Some(30)
 
 Returns `true` if the container has no elements. Accepts lists, maps, sets, and strings.
 
-```python
+```ry
 xs = [1, 2, 3]
 print(is_empty(xs))        # false
 print(is_empty([]))        # true (requires type annotation in practice)
@@ -436,7 +436,7 @@ print(is_empty("hello"))   # false
 
 Returns a list of `(index, element)` tuples.
 
-```python
+```ry
 xs = [10, 20, 30]
 pairs = enumerate(xs)
 # pairs = [(0, 10), (1, 20), (2, 30)]
@@ -450,7 +450,7 @@ for i, x in enumerate(xs):
 
 Combines two lists into a list of `(elem1, elem2)` tuples. The result length equals the shorter list.
 
-```python
+```ry
 xs = [1, 2, 3]
 ys = ["a", "b", "c"]
 pairs = zip(xs, ys)
@@ -465,7 +465,7 @@ for a, b in zip(xs, ys):
 
 Inserts an element at the specified index. Elements at and after the index are shifted right.
 
-```python
+```ry
 xs = [1, 2, 3]
 insert(xs, 1, 99)
 print(xs)   # [1, 99, 2, 3]
@@ -475,7 +475,7 @@ print(xs)   # [1, 99, 2, 3]
 
 Removes and returns the element at the specified index. Elements after the index are shifted left.
 
-```python
+```ry
 xs = [1, 2, 3, 4]
 v = remove_at(xs, 1)
 print(v)    # 2
@@ -486,7 +486,7 @@ print(xs)   # [1, 3, 4]
 
 Removes the first occurrence of the specified value from the list. Does nothing if the value is not found. This is a mutating operation.
 
-```python
+```ry
 xs = [1, 2, 3, 2, 4]
 remove(xs, 2)
 print(xs)   # [1, 3, 2, 4]
@@ -496,7 +496,7 @@ print(xs)   # [1, 3, 2, 4]
 
 Returns a new list with duplicate elements removed. The original order is preserved (first occurrence kept). The original list is not modified.
 
-```python
+```ry
 xs = [1, 2, 3, 2, 1, 4]
 print(distinct(xs))   # [1, 2, 3, 4]
 print(xs)             # [1, 2, 3, 2, 1, 4] (unchanged)
@@ -506,7 +506,7 @@ print(xs)             # [1, 2, 3, 2, 1, 4] (unchanged)
 
 Flattens a nested list (list of lists) by one level. Returns a new list. The original list is not modified. Passing a non-nested list (e.g. `List<int>`) is a compile error: `flatten() requires a list of lists`.
 
-```python
+```ry
 xs = [[1, 2], [3, 4]]
 print(flatten(xs))   # [1, 2, 3, 4]
 print(xs)            # [[1, 2], [3, 4]] (unchanged)
@@ -524,7 +524,7 @@ Some list operations have two forms: a non-mutating version that returns a new l
 
 All `!` variants participate in Copy-on-Write: if `xs` is shared (reference count > 1), the outer buffer is cloned once before the in-place mutation so that aliases are not affected (see [Copy-on-Write (CoW) Semantics](#copy-on-write-cow-semantics)).
 
-```python
+```ry
 xs = [3, 1, 2]
 sort!(xs)
 print(xs)         # [1, 2, 3]
@@ -584,7 +584,7 @@ All collection types (List, Map, Set) use **Copy-on-Write** semantics when manag
 - **Mutation triggers a path-walking copy**: When a shared collection is mutated, every level on the LHS path whose reference count > 1 is cloned before the mutation lands. A top-level write (`b.append(...)`, `b[i] = v` with `b` shared) clones only the outermost container. A chained write (`b[i][j] = v`, `r.items[i] = v`, `m[k1][k2] = v`) walks from the root down and clones each intervening container that is still shared, so aliases of the outer container — or any inner container on the path — are isolated from the mutation.
 - **Unique owners mutate in-place**: When a collection (or the container at some hop) has only one reference (`strong_count == 1`), the CoW check skips the clone for that level and mutates in-place with zero copy overhead.
 
-```python
+```ry
 a = [1, 2, 3]       # strong_count = 1
 b = a                # strong_count = 2 (shared)
 append(b, 4)         # strong_count > 1 → copy outer buffer, then mutate
@@ -603,7 +603,7 @@ privatizes each level whose reference count is greater than one. This gives
 strict aliasing isolation between aliases sharing the outer container and any
 inner container on the write path.
 
-```python
+```ry
 a = [[1, 2], [3, 4]]
 b = a                    # outer list shared: strong_count = 2
 b[0][0] = 99             # walks: clone outer (a and b now have their own
@@ -618,7 +618,7 @@ the same way as direct index hops. Record-to-record assignment (`r2 = r1`)
 retains each ARC field so a subsequent `r2.items[i] = v` observes the
 refcount > 1 at the field slot and clones before mutating:
 
-```python
+```ry
 record Box:
   items: List<int>
 
@@ -654,7 +654,7 @@ A key-value mapping. Allocated on the heap.
 
 ### Syntax
 
-```python
+```ry
 m = {"a": 1, "b": 2}
 m: Map<str, int> = {"a": 1, "b": 2}
 m = {"a": 1, "b": 2,}         # trailing comma allowed
@@ -664,7 +664,7 @@ m = {"a": 1, "b": 2,}         # trailing comma allowed
 
 Maps support `==` and `!=`. Two maps are equal when they have the same number of entries and every key-value pair in one map exists with an equal value in the other.
 
-```python
+```ry
 {"a": 1, "b": 2} == {"a": 1, "b": 2}   # true
 {"a": 1}         != {"a": 2}            # true (different values)
 {"a": 1}         != {"b": 1}            # true (different keys)
@@ -672,14 +672,14 @@ Maps support `==` and `!=`. Two maps are equal when they have the same number of
 
 ### Key Access
 
-```python
+```ry
 m = {"a": 1, "b": 2}
 print(m["a"])   # 1
 ```
 
 ### Insert and Update
 
-```python
+```ry
 m = {"a": 1}
 m["b"] = 2     # Insert new entry
 m["a"] = 99    # Update existing entry
@@ -687,21 +687,21 @@ m["a"] = 99    # Update existing entry
 
 ### length
 
-```python
+```ry
 m = {"a": 1, "b": 2, "c": 3}
 print(length(m))   # 3
 ```
 
 ### print
 
-```python
+```ry
 m = {"a": 1, "b": 2}
 print(m)   # {a: 1, b: 2}
 ```
 
 ### has_key
 
-```python
+```ry
 m = {"a": 1, "b": 2}
 print(m.has_key("a"))   # true
 print(m.has_key("z"))   # false
@@ -711,7 +711,7 @@ print(m.has_key("z"))   # false
 
 Returns a list of all keys in the map.
 
-```python
+```ry
 m = {"a": 1, "b": 2, "c": 3}
 print(keys(m))   # ["a", "b", "c"]
 ```
@@ -720,7 +720,7 @@ print(keys(m))   # ["a", "b", "c"]
 
 Returns a list of all values in the map.
 
-```python
+```ry
 m = {"a": 1, "b": 2, "c": 3}
 print(values(m))   # [1, 2, 3]
 ```
@@ -729,7 +729,7 @@ print(values(m))   # [1, 2, 3]
 
 Returns a list of `(key, value)` tuples for all entries in the map.
 
-```python
+```ry
 m = {"a": 1, "b": 2}
 pairs = items(m)
 # pairs = [("a", 1), ("b", 2)]
@@ -739,7 +739,7 @@ pairs = items(m)
 
 Removes the entry with the specified key from the map. Does nothing if the key does not exist.
 
-```python
+```ry
 m = {"a": 1, "b": 2}
 remove(m, "a")
 print(m)   # {b: 2}
@@ -752,7 +752,7 @@ Two overloads are available:
 - `get(map, key) -> Option<V>`: Returns `Some(value)` if the key exists, or `None` if it does not.
 - `get(map, key, default) -> V`: Returns the value for the key, or `default` if the key does not exist.
 
-```python
+```ry
 m = {"a": 1, "b": 2}
 print(get(m, "a"))       # Some(1)
 print(get(m, "z"))       # None
@@ -764,7 +764,7 @@ print(get(m, "z", 0))   # 0
 
 `+` returns a new map that combines all entries from both maps; the original maps are not modified. When keys overlap, values from the right-hand side take precedence (rhs-wins). `+=` rebinds the left-hand variable to the merged result (`m1 += m2` is equivalent to `m1 = m1 + m2`).
 
-```python
+```ry
 m1 = {"a": 1, "b": 2}
 m2 = {"b": 99, "c": 3}
 m3 = m1 + m2
@@ -781,7 +781,7 @@ Both maps must have the same key type and value type.
 
 Equivalent to `m1 + m2`. Returns a new map combining all entries from both maps with rhs-wins semantics. The original maps are not modified.
 
-```python
+```ry
 m1 = {"a": 1, "b": 2}
 m2 = {"b": 99, "c": 3}
 m3 = merge(m1, m2)
@@ -811,7 +811,7 @@ A collection that holds elements of the same type without duplicates. Allocated 
 
 ### Syntax
 
-```python
+```ry
 s = {1, 2, 3}
 s: Set<int> = {1, 2, 3}
 s = {1, 2, 3,}               # trailing comma allowed
@@ -825,14 +825,14 @@ s = {1, 2, 3,}               # trailing comma allowed
 
 Sets support `==` and `!=`. Equality is order-independent — two sets are equal when they contain exactly the same elements.
 
-```python
+```ry
 {1, 2, 3} == {3, 2, 1}   # true (order does not matter)
 {1, 2}    != {1, 2, 3}   # true (different sizes)
 ```
 
 ### in Operator (Membership Check)
 
-```python
+```ry
 s = {1, 2, 3}
 print(2 in s)   # true
 print(5 in s)   # false
@@ -840,14 +840,14 @@ print(5 in s)   # false
 
 ### length
 
-```python
+```ry
 s = {1, 2, 3}
 print(length(s))   # 3
 ```
 
 ### print
 
-```python
+```ry
 s = {1, 2, 3}
 print(s)   # {1, 2, 3}
 ```
@@ -856,7 +856,7 @@ print(s)   # {1, 2, 3}
 
 Duplicate elements are ignored when added.
 
-```python
+```ry
 s = {1, 2, 3}
 s.add(4)         # Add
 s.add(1)         # Ignored because it already exists
@@ -865,7 +865,7 @@ print(length(s))    # 4
 
 ### remove (Remove Element)
 
-```python
+```ry
 s = {1, 2, 3}
 s.remove(2)
 print(2 in s)   # false
@@ -873,7 +873,7 @@ print(2 in s)   # false
 
 ### for Iteration
 
-```python
+```ry
 s = {10, 20, 30}
 for x in s:
     print(x)
@@ -883,13 +883,13 @@ for x in s:
 
 An empty set requires a type annotation.
 
-```python
+```ry
 s: Set<int> = {}
 ```
 
 ### Function Parameters
 
-```python
+```ry
 function has_value(s: Set<int>, v: int) -> bool:
     return v in s
 ```
@@ -898,7 +898,7 @@ function has_value(s: Set<int>, v: int) -> bool:
 
 `+` returns a new set containing all elements from both sets; the original sets are not modified. `+=` rebinds the left-hand variable to the union result (`a += b` is equivalent to `a = a + b`).
 
-```python
+```ry
 a = {1, 2, 3}
 b = {3, 4, 5}
 c = a + b            # {1, 2, 3, 4, 5}
@@ -912,7 +912,7 @@ Both sets must have the same element type.
 
 Equivalent to `s1 + s2`. Returns a new set containing all elements from both sets. The original sets are not modified.
 
-```python
+```ry
 a = {1, 2, 3}
 b = {3, 4, 5}
 print(union(a, b))   # {1, 2, 3, 4, 5}
@@ -922,7 +922,7 @@ print(union(a, b))   # {1, 2, 3, 4, 5}
 
 Returns a new set containing only elements present in both sets.
 
-```python
+```ry
 a = {1, 2, 3}
 b = {2, 3, 4}
 print(intersection(a, b))   # {2, 3}
@@ -932,7 +932,7 @@ print(intersection(a, b))   # {2, 3}
 
 Returns a new set containing elements in the first set but not in the second.
 
-```python
+```ry
 a = {1, 2, 3}
 b = {2, 3, 4}
 print(difference(a, b))   # {1}
@@ -942,7 +942,7 @@ print(difference(a, b))   # {1}
 
 Returns a new set containing elements that are in either set but not in both.
 
-```python
+```ry
 a = {1, 2, 3}
 b = {2, 3, 4}
 print(symmetric_difference(a, b))   # {1, 4}
@@ -952,7 +952,7 @@ print(symmetric_difference(a, b))   # {1, 4}
 
 Returns `true` if all elements of the first set are contained in the second set.
 
-```python
+```ry
 a = {1, 2}
 b = {1, 2, 3}
 print(is_subset(a, b))   # true
@@ -963,7 +963,7 @@ print(is_subset(b, a))   # false
 
 Returns `true` if the first set contains all elements of the second set.
 
-```python
+```ry
 a = {1, 2, 3}
 b = {1, 2}
 print(is_superset(a, b))   # true
@@ -991,7 +991,7 @@ A lazy iterator abstraction that enables efficient data transformation pipelines
 
 Use `iter()` to create an iterator from any collection:
 
-```python
+```ry
 xs = [1, 2, 3, 4, 5]
 it = xs.iter()           # Iterator<int>
 
@@ -1012,7 +1012,7 @@ Iterator methods return new iterators, forming a pipeline that is only evaluated
 | `.map(function)` | Transforms each element using the given function |
 | `.take(count)` | Yields at most `count` elements |
 
-```python
+```ry
 result = [1, 2, 3, 4, 5]
     .iter()
     .filter((x: int) => x > 2)
@@ -1028,7 +1028,7 @@ result = [1, 2, 3, 4, 5]
 | `.to_list()` | Collects all elements into a `List<T>` |
 | `.next()` | Returns the next element as `Option<T>` |
 
-```python
+```ry
 it = [10, 20].iter()
 print(it.next())   # Some(10)
 print(it.next())   # Some(20)
@@ -1039,7 +1039,7 @@ print(it.next())   # None
 
 Iterators can be used directly in `for` loops:
 
-```python
+```ry
 for x in [1, 2, 3].iter().filter((x: int) => x > 1):
     print(x)
 # 2

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -10,7 +10,7 @@ Ry supports Eiffel-style Design by Contract with preconditions (`require`), post
 
 Preconditions are checked at function entry. They specify what must be true for the function to be called correctly.
 
-```python
+```ry
 function deposit(amount: int, balance: int) -> int:
     require:
         amount > 0
@@ -34,7 +34,7 @@ Postconditions are checked before every `return`. They specify what the function
 
 `ensure` requires a variable name that binds the return value. This variable can be used in the postcondition expressions.
 
-```python
+```ry
 function abs(x: int) -> int:
     ensure v:
         v >= 0
@@ -45,7 +45,7 @@ function abs(x: int) -> int:
 
 Since function arguments are immutable in Ry, you can reference them directly in `ensure` blocks to compare with entry values:
 
-```python
+```ry
 function increment(x: int) -> int:
     ensure v:
         v == x + 1
@@ -56,7 +56,7 @@ function increment(x: int) -> int:
 
 For functions that return tuples, multiple variable names can be specified, separated by commas:
 
-```python
+```ry
 function divide(a: int, b: int) -> (int, int):
     ensure q, r:
         q >= 0
@@ -70,7 +70,7 @@ The number of binding variables must match the number of tuple elements.
 
 ## Combined Example
 
-```python
+```ry
 function deposit(amount: int, balance: int) -> int:
     require:
         amount > 0
@@ -90,7 +90,7 @@ Invariants are conditions that must always hold for a record instance. They are 
 - After construction
 - After every field assignment
 
-```python
+```ry
 record BankAccount:
     balance: int
     min_balance: int
@@ -98,7 +98,7 @@ record BankAccount:
         balance >= min_balance
 ```
 
-```python
+```ry
 a = BankAccount(100, 0)    # OK: 100 >= 0
 a.balance = -1                  # Contract violation: invariant failed for BankAccount
 ```

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -6,7 +6,7 @@
 
 ### Statement Syntax
 
-```python
+```ry
 if condition:
     # then block
 else:
@@ -19,13 +19,13 @@ else:
 
 **Single-expression form** (`=>`):
 
-```python
+```ry
 x = if condition => true_value else false_value
 ```
 
 Examples:
 
-```python
+```ry
 abs_val = if x > 0 => x else -x
 label = if score >= 90 => "A" else "B"
 ```
@@ -34,7 +34,7 @@ The `else` branch in the single-expression form takes a value directly (without 
 
 **Block form** (`:`):
 
-```python
+```ry
 x = if condition:
     compute_something()
 else:
@@ -58,7 +58,7 @@ Only `bool`, integer, and `float` types may appear in a condition. `str`,
 cannot be used directly as conditions. For collections and strings, write
 the length check explicitly:
 
-```python
+```ry
 xs = [1, 2, 3]
 # ✗ error: value of this type cannot be used as a boolean condition
 # if xs:
@@ -77,7 +77,7 @@ For `Option` and `Result`, pattern-match the variants explicitly with
 
 ### Example
 
-```python
+```ry
 x = 10
 
 if x > 5:
@@ -91,7 +91,7 @@ else:
 - Each `if` / `else` block has its own independent block scope.
 - Variables declared inside a block are not accessible outside the block.
 
-```python
+```ry
 if true:
     y = 42
 # y is not accessible here
@@ -103,7 +103,7 @@ if true:
 
 ### Syntax
 
-```python
+```ry
 while condition:
     # loop body
 ```
@@ -112,7 +112,7 @@ Repeats the loop body while the condition is `true`.
 
 ### Example
 
-```python
+```ry
 i = 0
 while i < 5:
     print(i)
@@ -121,7 +121,7 @@ while i < 5:
 
 ### Combining with break / continue
 
-```python
+```ry
 i = 0
 while true:
     if i >= 3:
@@ -135,7 +135,7 @@ while true:
 
 ### Syntax
 
-```python
+```ry
 # List / set iteration
 for x in iterable_expr:
     # x is assigned each element
@@ -159,7 +159,7 @@ A `for` loop over a `str` yields each **Unicode code point** as a single-charact
 
 This is **code-point** iteration, not **grapheme-cluster** iteration: user-perceived characters that span multiple code points — combining-mark sequences (e.g., base letter + U+0301) and ZWJ emoji sequences (e.g., family or skin-tone compositions) — are yielded as several iterations, one per code point. If you need grapheme-cluster-aware iteration, decompose the string with a future segmentation helper rather than relying on `for c in s:`.
 
-```python
+```ry
 for c in "hello":
     print(c)               # h, e, l, l, o
 
@@ -172,14 +172,14 @@ for c in "a🙂b":
 
 The loop variable is typed as `str`, so you can pass it to other string functions:
 
-```python
+```ry
 for c in "abc":
     print(to_upper(c))     # A, B, C
 ```
 
 Iterating an empty string runs the loop body zero times. `enumerate` and `zip` also accept `str` arguments and yield the same code-point units:
 
-```python
+```ry
 for i, c in enumerate("abc"):
     print(i, c)
 
@@ -189,7 +189,7 @@ for a, b in zip("abc", "xyz"):
 
 ### Map Key-Value Iteration
 
-```python
+```ry
 for k, v in map_expr:
     # k is the key, v is the value for each entry
 ```
@@ -198,7 +198,7 @@ for k, v in map_expr:
 
 When iterating over a list of tuples, you can destructure into N variables matching the tuple's element count. Use `_` to discard a value.
 
-```python
+```ry
 xs = [10, 20, 30]
 
 for i, x in enumerate(xs):
@@ -223,14 +223,14 @@ for a, _, c in triples:
 
 The `..` operator creates an inclusive integer range. `1 .. 5` produces `[1, 2, 3, 4, 5]`.
 
-```python
+```ry
 for i in 1 .. 5:
     print(i)     # 1 2 3 4 5
 ```
 
 ### Example
 
-```python
+```ry
 xs = [10, 20, 30]
 for x in xs:
     print(x)
@@ -268,7 +268,7 @@ Mutating the iterable from inside the loop body is allowed and memory-safe.
 The loop observes the collection as it was **at loop entry**; elements added
 after the loop starts are not visited, and elements removed are still visited.
 
-```python
+```ry
 ys = [10, 20, 30]
 for y in ys:
     append!(ys, y + 100)   # grows ys, but the loop still sees only 3 elements
@@ -283,7 +283,7 @@ This applies to lists, sets, and maps:
 To explicitly iterate over a growing list, use a `while` loop that re-checks
 the length each iteration:
 
-```python
+```ry
 i = 0
 while i < length(xs):
     # xs[i] — observes elements appended after the loop starts
@@ -296,7 +296,7 @@ while i < length(xs):
 
 `async function` declares a function that runs concurrently. Calling an `async function` returns `Task<T>`. Use `await` inside another `async function` or `block_on()` from synchronous context to wait for the result.
 
-```python
+```ry
 async function add(a: int, b: int) -> int:
     return a + b
 
@@ -328,7 +328,7 @@ async function double_add(a: int, b: int) -> int:
 
 `@parallel` can be attached only to counted `for` loops over `range(...)` or integer `..` ranges. The loop body runs in parallel chunks on the runtime worker pool.
 
-```python
+```ry
 @parallel
 for i in range(8):
     print(i)
@@ -352,7 +352,7 @@ Use `available_parallelism()` to inspect the runtime worker count.
 - Immediately exits the innermost loop (`while` or `for`).
 - Using it outside a loop causes a compile error.
 
-```python
+```ry
 for i in range(10):
     if i == 5:
         break    # Exits when i == 5
@@ -361,7 +361,7 @@ for i in range(10):
 
 ### Error Example
 
-```python
+```ry
 # break outside a loop is a compile error
 break   # Error: break outside loop
 ```
@@ -373,7 +373,7 @@ break   # Error: break outside loop
 - Ends the current iteration of the innermost loop and skips to the next iteration.
 - Using it outside a loop causes a compile error.
 
-```python
+```ry
 for i in range(5):
     if i == 2:
         continue   # Skip i == 2
@@ -387,7 +387,7 @@ for i in range(5):
 - A no-op statement that does nothing. Used as a placeholder for empty blocks.
 - Can be used in any block: function body, `if`/`else`, `while`, `for`, `case` arm, etc.
 
-```python
+```ry
 function not_yet():
     ...
 
@@ -419,7 +419,7 @@ Use `case:` for multi-branch conditional flow without a subject value.
 
 #### Syntax
 
-```python
+```ry
 case:
     condition:
         # body
@@ -431,7 +431,7 @@ case:
 
 #### Example
 
-```python
+```ry
 x = 0
 
 case:
@@ -454,7 +454,7 @@ For the expression form of `case:`, see the Expression Forms section below.
 
 ### Syntax
 
-```python
+```ry
 case expression:
     pattern:
         # body
@@ -489,7 +489,7 @@ A guard condition can be specified in the form `pattern if condition:`. The arm 
 
 Multiple patterns can be combined with `|` to match any of them. Variable bindings (`n`, `Some(x)`, `Ok(v)`, `Err(e)`) are not allowed in OR patterns.
 
-```python
+```ry
 case x:
     1 | 2 | 3:
         print("small")
@@ -514,7 +514,7 @@ case color:
 
 ### Example
 
-```python
+```ry
 # enum pattern match
 enum Color:
     Red
@@ -572,7 +572,7 @@ case x:
 
 When an enum variant carries associated data, use a binding pattern to extract the value(s).
 
-```python
+```ry
 enum Shape:
     Circle(float)
     Rectangle(float, float)
@@ -598,7 +598,7 @@ Each binding position in a constructor pattern may be any pattern, not only a pl
 - **A wildcard** (`_`) — ignores the field value.
 - **A tuple pattern** (`(x, y)`) — when a variant has multiple fields, a single tuple pattern whose element count equals the field count is unwrapped and matched field-by-field.
 
-```python
+```ry
 enum Event:
     Click(int, int)
     Key(str)
@@ -634,7 +634,7 @@ case e2:
 
 Tuple patterns destructure a tuple subject by element position. Each element may be a variable binding, a literal, or a wildcard (`_`). Nested patterns (e.g., `Some(v)` inside a tuple element) are also supported.
 
-```python
+```ry
 # Binding pattern — bind both elements
 t = (10, 20)
 case t:
@@ -696,7 +696,7 @@ case pair2:
 
 Record patterns destructure a record subject by positional field order. Each element may be a variable binding, a literal, or a wildcard (`_`). Nested patterns (including nested record patterns) are supported.
 
-```python
+```ry
 record Point:
     x: int
     y: int
@@ -765,7 +765,7 @@ case seg:
 
 Both `case:` and `case <expr>:` can be used as expressions by replacing `:` with `=>` in each arm. Each arm provides a single expression whose value becomes the result.
 
-```python
+```ry
 # case: expression (no subject)
 label = case:
     x > 100 => "huge"
@@ -778,7 +778,7 @@ Pattern-matching expression form:
 
 #### Syntax
 
-```python
+```ry
 result = case expression:
     pattern => value_expression
     pattern if guard => value_expression
@@ -791,7 +791,7 @@ All patterns supported in `case:` statements are also supported in `case` expres
 
 #### Examples
 
-```python
+```ry
 # Option
 value = case opt:
     Some(v) => v
@@ -842,7 +842,7 @@ sum = case t:
 - Each block of `if` / `else` / `while` / `for` / `case` has a block scope.
 - Variables declared inside a block go out of scope when the block ends.
 
-```python
+```ry
 for i in range(3):
     tmp = i * 2
 # tmp is not accessible here
@@ -857,7 +857,7 @@ if true:
 - Assigning to a variable inside an inner scope modifies the outer variable (Python-style scoping).
 - There is no shadowing — the inner assignment changes the same variable.
 
-```python
+```ry
 x = 10
 if true:
     x = 99   # Modifies the outer x

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -50,7 +50,7 @@ The table below shows the most common compile errors; it is not exhaustive.
 
 ### Compile Error Examples
 
-```python
+```ry
 # Reassignment to @const variable
 @const
 x = 10
@@ -94,7 +94,7 @@ All runtime errors terminate the process with `exit(1)`.
 
 ### Runtime Error Examples
 
-```python
+```ry
 # List out-of-range access
 xs = [1, 2, 3]
 print(xs[10])   # Runtime error: exit(1)

--- a/docs/reference/filesystem.md
+++ b/docs/reference/filesystem.md
@@ -6,7 +6,7 @@ File and directory manipulation. All functions require explicit import from `fil
 
 The `filesystem` package handles operations on files and directories themselves (copy, move, remove, etc.), while the `io` package handles reading and writing file contents.
 
-```python
+```ry
 from filesystem import list_dir, walk, glob_files, copy, move, remove, remove_all
 from filesystem import make_dir, make_dir_all, file_size, is_file, is_dir, is_symlink
 from filesystem import chmod, symlink, read_link
@@ -37,7 +37,7 @@ from filesystem import chmod, symlink, read_link
 
 ### Directory Operations
 
-```python
+```ry
 from filesystem import make_dir, make_dir_all, list_dir, remove_all
 
 # Create a single directory
@@ -64,7 +64,7 @@ remove_all("/tmp/myapp")
 
 ### File Operations
 
-```python
+```ry
 from filesystem import copy, move, remove, file_size
 from io import write_text
 
@@ -89,7 +89,7 @@ remove("/tmp/renamed.txt")
 
 ### Recursive Traversal
 
-```python
+```ry
 from filesystem import walk, glob_files
 
 # Walk a directory tree (like find)
@@ -111,7 +111,7 @@ case glob_files("/var/log/*.log"):
 
 ### Path Type Checks
 
-```python
+```ry
 from filesystem import is_file, is_dir, is_symlink
 
 case is_file("/etc/hosts"):
@@ -130,7 +130,7 @@ case is_symlink("/usr/local/bin/python"):
 
 ### Symbolic Links
 
-```python
+```ry
 from filesystem import symlink, read_link, is_symlink
 
 # Create a symlink
@@ -149,7 +149,7 @@ case is_symlink("/tmp/ry_link"):
 
 ### Permissions
 
-```python
+```ry
 from filesystem import chmod
 
 # chmod 755 (rwxr-xr-x) — use decimal value: 0o755 = 493

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -4,7 +4,7 @@
 
 ## Function Definition Syntax
 
-```python
+```ry
 function function_name(param_name: type, ...) -> return_type:
     # body
     return value
@@ -19,7 +19,7 @@ function function_name(param_name: type, ...) -> return_type:
 
 > **Naming convention**: Function names and parameter names must use snake_case (e.g., `add`, `get_value`, `map_list`). The compiler enforces this convention.
 
-```python
+```ry
 function add(a: int, b: int) -> int:
     return a + b
 
@@ -39,7 +39,7 @@ function greet(name: str) -> Unit:
 
 > **Note**: Function parameters are **immutable**. You cannot reassign a parameter inside the function body. This ensures that parameter values at entry are always available for postcondition checks (see [Design by Contract](contracts.md)).
 
-```python
+```ry
 function no_return(x: int) -> Unit:  # Return type Unit (explicit)
     print(x)
 
@@ -54,7 +54,7 @@ function identity(x) -> any:    # Parameter type any (omitted)
 
 When a parameter type annotation is omitted, the parameter is treated as `any` — a dynamic type that accepts any primitive value at runtime. This is similar to Python's untyped parameters.
 
-```python
+```ry
 # All parameters default to any
 function add(a, b):
     return a + b
@@ -66,7 +66,7 @@ add(1, 2.0)            # 3.0 (int + float)
 
 You can also use `any` explicitly in type annotations:
 
-```python
+```ry
 function identity(x: any) -> any:
     return x
 ```
@@ -75,7 +75,7 @@ function identity(x: any) -> any:
 
 When the return type is omitted, it is inferred from the `return` statements in the body:
 
-```python
+```ry
 function double(x: int):     # return type inferred as int
     return x * 2
 
@@ -85,7 +85,7 @@ function greet(name: str):   # return type inferred as Unit (no return)
 
 To explicitly allow any return type, use `-> any`:
 
-```python
+```ry
 function flexible(x: any) -> any:
     return x    # can return int, float, str, etc.
 ```
@@ -96,7 +96,7 @@ function flexible(x: any) -> any:
 
 Functions can be defined inside other functions. A nested function is only visible within its enclosing function's scope — it cannot be called from outside.
 
-```python
+```ry
 function outer() -> int:
     function helper() -> int:
         return 42
@@ -108,7 +108,7 @@ outer()     # 42
 
 Same-named nested functions in sibling scopes do not collide:
 
-```python
+```ry
 function foo() -> int:
     function helper() -> int:
         return 1
@@ -129,7 +129,7 @@ Nested functions can be used as values and passed to higher-order functions. Mut
 
 Nested named functions can capture variables from enclosing scopes, just like lambdas. When a nested function references an outer variable, it becomes a closure:
 
-```python
+```ry
 function make_adder(base: int) -> function(int) -> int:
     function add(x: int) -> int:
         return x + base
@@ -153,7 +153,7 @@ Capture rules:
 
 Functions can call themselves.
 
-```python
+```ry
 function factorial(n: int) -> int:
     if n <= 1:
         return 1
@@ -164,7 +164,7 @@ function factorial(n: int) -> int:
 
 Functions can call each other regardless of definition order. The compiler forward-declares functions with explicit return types before processing function bodies — this applies both at the top level and inside another function body (nested functions) — provided all referenced types are already known (primitive types are always available; record/enum types must be defined earlier in the file).
 
-```python
+```ry
 function is_even(n: int) -> bool:
     if n == 0:
         return true
@@ -186,7 +186,7 @@ function is_odd(n: int) -> bool:
 
 Top-level `let` bindings and `@const` declarations are visible from any top-level function — including nested functions and lambdas inside those functions — as long as the declaration appears **textually before** the referencing function in the same source file.
 
-```python
+```ry
 @const
 PI: float = 3.14
 
@@ -223,7 +223,7 @@ function bump():
 
 The compiler automatically detects self-recursive tail calls — where the last action in a function is a call to itself — and applies LLVM's `musttail` optimization. This guarantees that tail-recursive functions use constant stack space, preventing stack overflow for deep recursion.
 
-```python
+```ry
 function sum_to(n: int, acc: int) -> int:
     if n <= 0:
         return acc
@@ -252,7 +252,7 @@ Multiple functions with the same name can be defined if they differ in the numbe
 - The appropriate function is selected at the call site based on the argument types and count.
 - Overloading by return type alone is not allowed.
 
-```python
+```ry
 function area(side: int) -> int:
     return side * side
 
@@ -276,7 +276,7 @@ The overload with the most exact matches wins. If two or more overloads have equ
 
 Low-level numeric types (`i8`, `i16`, `i32`, `i64`, `u8`–`u64`, `f32`) do **not** participate in implicit widening — they require explicit `as` casts.
 
-```python
+```ry
 function process(x: int) -> str:
     return "int"
 
@@ -287,7 +287,7 @@ process(42)       # "int" — exact match (int) beats any
 process("hello")  # "any" — no exact match for str, falls back to any
 ```
 
-```python
+```ry
 function double(x: float) -> float:
     return x * 2.0
 
@@ -302,7 +302,7 @@ Parameters can have default values, allowing callers to omit trailing arguments.
 
 ### Syntax
 
-```python
+```ry
 function connect(host: str, port: int = 8080, timeout: int = 30):
     # ...
 
@@ -318,7 +318,7 @@ connect("localhost", 3000, 10000)       # port=3000, timeout=10000
 - Default values must be compile-time constant expressions (literals and `@const` variables).
 - If a function with default arguments creates an ambiguous overload (overlapping arity with matching types), the compiler reports an error.
 
-```python
+```ry
 # Error: ambiguous overload
 function calc(x: int, y: int = 0) -> int:
     return x + y
@@ -336,7 +336,7 @@ function calc(x: int) -> int:      # conflicts with calc(int) from above
 
 Functions without a return value return `Unit`. The return type can be omitted (inferred as `Unit`) or explicitly specified with `-> Unit`.
 
-```python
+```ry
 function log(msg: str) -> Unit:
     print(msg)
 ```
@@ -347,7 +347,7 @@ function log(msg: str) -> Unit:
 
 `Task<T>` is the built-in handle type for concurrent work. `async function` returns `Task<T>`, `await` extracts `T` inside another `async function`, and `block_on(task)` blocks from synchronous context until the task completes.
 
-```python
+```ry
 async function add(a: int, b: int) -> int:
     return a + b
 
@@ -380,7 +380,7 @@ Anonymous functions can be defined inline.
 
 ### Syntax
 
-```python
+```ry
 # Single expression (return type inferred from expression)
  (param_name: type, ...) => expression
 
@@ -402,7 +402,7 @@ Anonymous functions can be defined inline.
 
 ### Example
 
-```python
+```ry
 double = (x: int) => x * 2
 result = double(5)   # 10
 
@@ -426,7 +426,7 @@ Lambda functions **capture by value** the variables from the outer scope at the 
 
 Because the closure holds a copy, reassigning the original variable after the closure is defined has no effect on the captured value:
 
-```python
+```ry
 base = 10
 add_base = (x: int) => x + base   # Captures base by value (copy of 10)
 
@@ -438,7 +438,7 @@ r = add_base(5)   # 15 (uses base = 10 from capture time)
 
 Captured variables **cannot be reassigned** inside the closure. Attempting to do so produces a compile error:
 
-```python
+```ry
 counter = 0
 inc = ():
     counter += 1    # Compile error: cannot modify captured variable 'counter' inside closure
@@ -448,7 +448,7 @@ inc()
 
 **Field assignment on captured records is allowed**, since it modifies the copy's internal state rather than reassigning the variable itself:
 
-```python
+```ry
 record Point:
     x: int
     y: int
@@ -480,13 +480,13 @@ A type for treating functions as values.
 
 ### Syntax
 
-```python
+```ry
 function(param_type1, param_type2, ...) -> return_type
 ```
 
 ### Example
 
-```python
+```ry
 f: function(int) -> int = (x: int) => x * 2
 g: function(int, int) -> int = (a: int, b: int) => a + b
 
@@ -500,7 +500,7 @@ result = apply(f, 5)   # 10
 
 `print()`, `to_str()`, and f-string interpolation all produce `"<closure>"` for function values:
 
-```python
+```ry
 f = (x: int) => x + 1
 print(f)              # <closure>
 s = to_str(f)         # "<closure>"
@@ -515,7 +515,7 @@ msg = f"fn={f}"       # "fn=<closure>"
 
 Functions can accept functions as arguments or return them as values.
 
-```python
+```ry
 function map_list(xs: List<int>, f: function(int) -> int) -> List<int>:
     result: List<int> = []
     for x in xs:
@@ -534,14 +534,14 @@ Functions can have type parameters, enabling type-safe reuse without code duplic
 
 ### Syntax
 
-```python
+```ry
 function name<T, U>(param1: T, param2: U) -> T:
     # body using T, U as types
 ```
 
 ### Example
 
-```python
+```ry
 function identity<T>(x: T) -> T:
     return x
 
@@ -556,7 +556,7 @@ result = identity("hello")     # T = str, result = "hello"
 
 ### Multiple Type Parameters
 
-```python
+```ry
 function pick_first<T, U>(a: T, b: U) -> T:
     return a
 
@@ -572,7 +572,7 @@ Type parameters can appear inside generic container types (`List<T>`,
 structurally against the actual argument, so explicit type annotations
 are not required when the shape is unambiguous.
 
-```python
+```ry
 function first_of<T>(xs: List<T>) -> T:
     return xs[0]
 
@@ -596,7 +596,7 @@ pair_first(("a", "b"))   # T = str → "a"
 A type parameter referenced across multiple parameter positions is
 unified — both occurrences must resolve to the same concrete type:
 
-```python
+```ry
 function apply_list<T>(xs: List<T>, f: function(T) -> T) -> T:
     return f(xs[0])
 
@@ -606,7 +606,7 @@ apply_list([10, 20, 30], (x: int) => x + 1)  # T = int → 11
 If inference cannot determine a type parameter (for example, from an
 empty container literal), use the explicit `name[Type](args)` syntax:
 
-```python
+```ry
 first_of[int]([])   # empty list: tell the compiler T = int explicitly
 ```
 
@@ -614,7 +614,7 @@ Conflicting inferences across arguments produce a clear compile error
 naming the type parameter and function rather than an opaque type
 mismatch:
 
-```python
+```ry
 function same<T>(a: T, b: T) -> T:
     return a
 
@@ -625,7 +625,7 @@ same(1, "x")  # error: conflicting type inference for 'T' in call to 'same'
 
 Type parameters can be constrained with record types using `: RecordName` syntax. The concrete type must be the bound type itself or a subtype of it.
 
-```python
+```ry
 record Animal:
     name: str
     legs: int
@@ -642,7 +642,7 @@ get_name(Animal("Cat", 4))      # OK — exact type match
 
 Bounded and unbounded type parameters can be mixed:
 
-```python
+```ry
 function pair_name<T: Animal, U>(a: T, x: U) -> str:
     return a.name
 ```
@@ -659,7 +659,7 @@ Generic functions use **monomorphization**: a specialized version of the functio
 
 ### Syntax
 
-```python
+```ry
 # Normal call
 f(a, b)
 
@@ -669,7 +669,7 @@ a.f(b)
 
 ### Chaining
 
-```python
+```ry
 function double(x: int) -> int:
     return x * 2
 
@@ -683,7 +683,7 @@ result = 5.double().add_one()   # double(5) -> 10, add_one(10) -> 11
 
 Field access (`.field`) and UFCS (`.method()`) use the same dot notation but are distinguished by the presence of arguments.
 
-```python
+```ry
 p = Point(3, 4)
 length = p.x.to_float()   # Field access + UFCS
 ```
@@ -696,7 +696,7 @@ You can define operator behavior for user-defined types.
 
 ### Syntax
 
-```python
+```ry
 # Binary operator (2 parameters)
 function operator<op>(a: type, b: type) -> return_type:
     ...
@@ -732,7 +732,7 @@ Comparison, logical, and membership operators must return `bool`:
 | Membership | `in` | `bool` |
 | Cast | `as` | Required (target type) |
 
-```python
+```ry
 # OK
 function operator==(a: Vec2, b: Vec2) -> bool:
     return a.x == b.x and a.y == b.y
@@ -748,7 +748,7 @@ Arithmetic and bitwise operators have no return type constraint.
 
 Distinguished by the number of parameters.
 
-```python
+```ry
 record Vec2:
     x: float
     y: float
@@ -791,7 +791,7 @@ Built-in functions for explicit overflow control on integer types (`int`, `i8`..
 | `wrapping_sub(a, b)` | `T` | Explicit wrapping on underflow |
 | `wrapping_mul(a, b)` | `T` | Explicit wrapping on overflow |
 
-```python
+```ry
 # int: trap-free checked arithmetic (default + on int traps on overflow)
 r = checked_add(9223372036854775807, 1)
 case r:

--- a/docs/reference/gc.md
+++ b/docs/reference/gc.md
@@ -12,7 +12,7 @@ Using `weak` references is still the recommended way to avoid cycles, but the cy
 
 ## Import
 
-```python
+```ry
 from gc import collect, enable, disable, set_threshold
 ```
 
@@ -38,7 +38,7 @@ The compiler performs static analysis at compile time to identify which types ca
 
 ## Example
 
-```python
+```ry
 from gc import collect, disable, enable
 
 # Disable automatic collection for a performance-critical section

--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -16,7 +16,7 @@
 
 These functions require explicit import:
 
-```python
+```ry
 from http import listen, method, path, header, body, body_bytes, query, query_all, cookie, cookies, form_field, form_file, form_fields, response
 ```
 
@@ -55,7 +55,7 @@ from http import listen, method, path, header, body, body_bytes, query, query_al
 
 ### Basic HTTP Server
 
-```python
+```ry
 from http import listen, method, path, header, body, response
 
 listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
@@ -72,7 +72,7 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
 
 ### Non-blocking Server with `async function`
 
-```python
+```ry
 from http import listen, path, response
 
 async function start_server(port: int) -> str:
@@ -90,7 +90,7 @@ t = start_server(8080)
 
 ### Server with Request Limit (`max_requests`)
 
-```python
+```ry
 from http import listen, path, response, http_get, status, body
 
 port_holder = [0]
@@ -118,7 +118,7 @@ result = block_on(t)  # Server exits after 1 request; block_on completes
 
 ### Reading Query Parameters
 
-```python
+```ry
 from http import listen, path, query, query_all, response
 
 listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
@@ -135,7 +135,7 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
 
 ### Reading Headers
 
-```python
+```ry
 from http import listen, header, response
 
 listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
@@ -149,7 +149,7 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
 
 ### Handling Form Submissions
 
-```python
+```ry
 from http import listen, form_field, form_file, response
 
 listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
@@ -168,7 +168,7 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
 
 ### Reading Cookies
 
-```python
+```ry
 from http import listen, cookie, cookies, response
 
 listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
@@ -301,7 +301,7 @@ Other status codes use `"Unknown"` as the reason phrase.
 
 ### Client Usage Example
 
-```python
+```ry
 from http import http_get, http_post, status, body, header
 
 # Simple GET request

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -4,7 +4,7 @@
 
 Standard I/O and file operations. All functions require explicit import from `io`.
 
-```python
+```ry
 from io import read_text, write_text, exists
 ```
 
@@ -40,7 +40,7 @@ from io import read_text, write_text, exists
 
 ### Reading and Writing Files
 
-```python
+```ry
 from io import read_text, write_text, append_text, exists, delete_file
 
 case write_text("hello.txt", "Hello, World!"):
@@ -64,7 +64,7 @@ case delete_file("hello.txt"):
 
 ### Byte Operations
 
-```python
+```ry
 from io import to_bytes, bytes_to_str, write_bytes, read_bytes
 
 bs = to_bytes("ABC")
@@ -87,7 +87,7 @@ case write_bytes("data.bin", bs):
 
 ### Reading from Standard Input
 
-```python
+```ry
 from io import read_line
 
 name = read_line()
@@ -98,7 +98,7 @@ print(f"Hello, {name}!")
 
 File operations return `Result<T, Error>` instead of terminating on failure. Use `case` with `Ok`/`Err` patterns to handle errors:
 
-```python
+```ry
 case read_text("missing.txt"):
     Ok(content):
         print(content)

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -4,7 +4,7 @@
 
 JSON parsing and serialization. All functions require explicit import from `json`.
 
-```python
+```ry
 from json import parse, stringify, kind, get, at, to_str, to_int, to_float, to_bool, length, keys, json_free
 ```
 
@@ -63,7 +63,7 @@ The `json` package provides functions to parse JSON text into an opaque `JsonVal
 unwrap the `Result` before passing the inner value to another json
 function — passing the `Result` directly is rejected at compile time:
 
-```python
+```ry
 case parse(text):
   Ok(doc):
     # ✗ error: kind() requires a JsonValue argument
@@ -86,7 +86,7 @@ interpolation) still works on a `Result` and formats as `Ok(...)` /
 
 ### Parsing and accessing fields
 
-```python
+```ry
 from json import parse, get, to_str, to_int, json_free
 
 case parse("{\"name\": \"Alice\", \"age\": 30}"):
@@ -107,7 +107,7 @@ case parse("{\"name\": \"Alice\", \"age\": 30}"):
 
 ### Working with arrays
 
-```python
+```ry
 from json import parse, at, to_int, length, json_free
 
 case parse("[10, 20, 30]"):
@@ -129,7 +129,7 @@ case parse("[10, 20, 30]"):
 
 ### Stringify with pretty printing
 
-```python
+```ry
 from json import parse, stringify, json_free
 
 case parse("{\"key\":\"value\",\"count\":42}"):

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -6,7 +6,7 @@
 
 The `math` package provides mathematical constants and functions. Unlike the `std` package, it is not automatically imported. Use explicit import to access the functions.
 
-```python
+```ry
 from math import sqrt, PI, sin
 ```
 
@@ -21,7 +21,7 @@ from math import sqrt, PI, sin
 | `Inf` | `float` | Positive infinity |
 | `NaN` | `float` | Not a Number |
 
-```python
+```ry
 from math import PI, E, Inf, NaN
 
 circumference = 2.0 * PI * radius
@@ -36,7 +36,7 @@ circumference = 2.0 * PI * radius
 | `abs(x)` | `(int) -> int` | Absolute value of integer |
 | `abs(x)` | `(float) -> float` | Absolute value of float |
 
-```python
+```ry
 from math import abs
 
 abs(-5)      # 5
@@ -56,7 +56,7 @@ abs(-3.14)   # 3.14
 | `round(x)` | `(float) -> int` | Round to nearest integer (half away from zero) |
 | `round(x, digits)` | `(float, int) -> float` | Round to given decimal places (half away from zero) |
 
-```python
+```ry
 from math import floor, ceil, round
 
 floor(3.7)           # 3
@@ -70,7 +70,7 @@ ceil(3.123, 1)       # 3.2
 
 The two-argument forms accept negative `digits` for rounding to powers of ten:
 
-```python
+```ry
 round(1234.5, -2)    # 1200.0
 round(1750.0, -3)    # 2000.0
 ```
@@ -89,7 +89,7 @@ Rounding uses C99 half-away-from-zero semantics (via `round(x * 10^digits) / 10^
 | `pow(x, y)` | `(float, float) -> float` | x raised to the power of y |
 | `pow(x, y)` | `(int, int) -> int` | Integer exponentiation via fast-exponentiation |
 
-```python
+```ry
 from math import sqrt, pow
 
 sqrt(9.0)       # 3.0
@@ -111,7 +111,7 @@ The integer overload raises a runtime error when the exponent is negative (`pow(
 | `log2(x)` | `(float) -> float` | Base-2 logarithm |
 | `log10(x)` | `(float) -> float` | Base-10 logarithm |
 
-```python
+```ry
 from math import log
 
 log(8.0, 2.0)      # 3.0
@@ -166,7 +166,7 @@ log(100.0, 10.0)   # 2.0
 | `is_nan(x)` | `(float) -> bool` | True if x is NaN |
 | `is_inf(x)` | `(float) -> bool` | True if x is positive or negative infinity |
 
-```python
+```ry
 from math import is_nan, is_inf, NaN, Inf
 
 is_nan(NaN)   # true

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -16,7 +16,7 @@ All types are opaque pointers managed by ARC (Automatic Reference Counting). The
 
 These functions require explicit import:
 
-```python
+```ry
 from net import bind, listen, accept, connect, listener_port, shutdown, set_timeout, set_receive_timeout, set_send_timeout, tls_connect
 ```
 
@@ -48,7 +48,7 @@ These functions are built-in and work with TCP socket types. No import needed.
 
 ### Echo Server
 
-```python
+```ry
 from net import bind, listen, accept, connect
 from io import to_bytes, bytes_to_str
 
@@ -80,7 +80,7 @@ case bind("127.0.0.1", 8080):
 
 ### Client
 
-```python
+```ry
 case connect("127.0.0.1", 8080):
     Ok(conn):
         case send(conn, to_bytes("hello")):
@@ -104,7 +104,7 @@ case connect("127.0.0.1", 8080):
 
 ### Concurrent Echo Server with `async function`
 
-```python
+```ry
 from net import bind, listen, accept, connect, listener_port
 from io import to_bytes, bytes_to_str
 
@@ -144,7 +144,7 @@ case bind("127.0.0.1", 0):
 
 By default, `receive()` uses a 30-second timeout if no custom timeout is set. Use `set_timeout()`, `set_receive_timeout()`, or `set_send_timeout()` to override the default:
 
-```python
+```ry
 from net import connect, set_receive_timeout
 
 case connect("127.0.0.1", 8080):

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -40,7 +40,7 @@ Lower numbers indicate higher precedence (evaluated first).
 | `-x` | Unary minus | `-5`, `-3.14` |
 | `+x` | Unary plus | `+5` (no sign change) |
 
-```python
+```ry
 a = 10 // 3    # 3 (int)
 b = 10 / 3     # 3.3333... (float)
 c = 2 ** 8     # 256.0 (float)
@@ -77,7 +77,7 @@ All return `bool`.
 - For maps, `in` checks whether the key exists.
 - For strings, `in` returns `true` when the left operand is a substring of the right operand. An empty string is always a substring of any string.
 
-```python
+```ry
 x = 3 < 5       # true
 y = "abc" < "abd"  # true (lexicographic)
 s = {1, 2, 3}
@@ -100,7 +100,7 @@ e = "" in "hello"  # true (empty string is always a substring)
 | `or` | Logical OR | `bool` x `bool` -> `bool` |
 | `not` | Logical NOT | `bool` -> `bool` |
 
-```python
+```ry
 a = true and false   # false
 b = true or false    # true
 c = not true         # false
@@ -120,7 +120,7 @@ Only available for `int` type. Applying to `float` or `bool` causes a compile er
 | `>>` | Arithmetic right shift | `16 >> 2` -> `4` |
 | `>>>` | Logical right shift | `-1 >>> 1` -> `9223372036854775807` |
 
-```python
+```ry
 flags = 0b0001 | 0b0010   # 3
 masked = flags & 0b0011   # 3
 shifted = 1 << 8          # 256
@@ -140,7 +140,7 @@ When used inside a function, the operand type must match the enclosing function'
 - `?` on a `Result` value requires the enclosing function to return `Result`.
 - `?` on an `Option` value requires the enclosing function to return `Option`.
 
-```python
+```ry
 function safe_divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
         return Err(Error("division by zero"))
@@ -166,7 +166,7 @@ function first_plus_second(xs: List<int>) -> Option<int>:
 
 `?` and `!!` can also be used directly at the top level of a script. There, `Err(e)` and `None` are treated as fatal errors: the error message is written to stderr and the process exits with status `1`.
 
-```python
+```ry
 function mk() -> Result<int, Error>:
     return Err(Error("something broke"))
 
@@ -182,7 +182,7 @@ At the top level, a `Result`'s `Err` type must be `Error` (so its `message` fiel
 
 ## `case:` Conditional Expression
 
-```python
+```ry
 x = case:
     condition => true_value
     _ => false_value
@@ -190,7 +190,7 @@ x = case:
 
 Evaluates conditions from top to bottom and returns the expression from the first truthy arm. All result expressions must have the same type. The `_ =>` wildcard arm is required, so the expression always produces a value.
 
-```python
+```ry
 x = case:
     3 > 2 => 10
     _ => 20     # 10
@@ -212,7 +212,7 @@ y = case:
 
 The `..` operator creates an inclusive integer range.
 
-```python
+```ry
 xs = 1 .. 5    # [1, 2, 3, 4, 5]
 
 for i in 1 .. 3:
@@ -225,7 +225,7 @@ The result is a `List<int>` containing all integers from the left operand to the
 
 ## Null Coalescing Operator (`??`)
 
-```python
+```ry
 x = optional_val ?? default_val
 ```
 
@@ -240,7 +240,7 @@ The `??` operator accepts either an `Option<T>` or a `Result<T, E>` on the left-
 
 The right-hand operand must have the same type as the `Option`'s inner type (or the `Result`'s `Ok` type).
 
-```python
+```ry
 a: int? = Some(10)
 b: int? = none
 
@@ -275,7 +275,7 @@ Shorthand for updating a variable. `x op= y` is equivalent to `x = x op y`.
 | `x <<= y` | `x = x << y` |
 | `x >>= y` | `x = x >> y` |
 
-```python
+```ry
 x = 10
 x += 5    # x = 15
 x -= 3    # x = 12
@@ -287,7 +287,7 @@ x &= 6   # x = 0
 Compound assignment is allowed on any lvalue — plain variables, list or map
 elements, record fields, and arbitrarily nested chains:
 
-```python
+```ry
 xs = [1, 2, 3]
 xs[0] += 10              # list element
 
@@ -303,7 +303,7 @@ pts[0].x -= 1            # chained: list-of-records field
 
 For collection types, `+=` uses the collection's `+` semantics:
 
-```python
+```ry
 # List concatenation
 xs: List<int> = [1, 2]
 xs += [3, 4]             # xs = [1, 2, 3, 4]
@@ -329,7 +329,7 @@ Postfix-only, statement-level operators for incrementing or decrementing a varia
 | `x++` | `x = x + 1` |
 | `x--` | `x = x - 1` |
 
-```python
+```ry
 count = 0
 count++       # count = 1
 count++       # count = 2
@@ -383,7 +383,7 @@ You can define operator behavior for user-defined types.
 
 ### Syntax
 
-```python
+```ry
 # Binary operator (2 parameters)
 function operator+(a: MyType, b: MyType) -> MyType:
     ...
@@ -419,7 +419,7 @@ Comparison and logical operators must return `bool`:
 | Membership | `in` | `bool` |
 | Cast | `as` | Required (target type) |
 
-```python
+```ry
 # OK
 function operator==(a: Vec2, b: Vec2) -> bool:
     return a.x == b.x and a.y == b.y
@@ -435,7 +435,7 @@ Arithmetic and bitwise operators have no return type constraint.
 
 Distinguished by the number of parameters.
 
-```python
+```ry
 # Binary -
 function operator-(a: Vec2, b: Vec2) -> Vec2:
     return Vec2(a.x - b.x, a.y - b.y)
@@ -449,7 +449,7 @@ function operator-(v: Vec2) -> Vec2:
 
 Compound assignment operators (`+=`, `-=`, etc.) can be independently overloaded. This enables in-place optimization for large data structures.
 
-```python
+```ry
 record Matrix:
     data: List
     rows: int
@@ -469,7 +469,7 @@ When `x += y` is evaluated:
 2. If `operator+=` is not defined but `operator+` is → fall back to `x = x + y`
 3. If neither is defined (for non-builtin types) → compile error
 
-```python
+```ry
 record Vec2:
     x: float
     y: float
@@ -488,7 +488,7 @@ Compound assignment operators require exactly 2 parameters and have no return ty
 
 The `[]` (read) and `[]=` (write) operators enable custom subscript behavior for user-defined types. Multi-index access (e.g., `m[row, col]`) is supported.
 
-```python
+```ry
 record Grid:
     a: int
     b: int
@@ -520,7 +520,7 @@ User-defined subscript operators are tried first; if no match is found, built-in
 
 The `in` operator can be overloaded to define custom membership tests. Must return `bool`.
 
-```python
+```ry
 record Range:
     lo: int
     hi: int
@@ -539,7 +539,7 @@ User-defined `in` operators are tried first; if no match is found, built-in beha
 
 The `()` operator enables records to behave as callable objects. Requires at least 2 parameters (object + arguments).
 
-```python
+```ry
 record Adder:
     base: int
 
@@ -556,7 +556,7 @@ When a variable holding a record value is called like a function, the compiler t
 
 The `as` operator can be overloaded to define custom type conversions. Takes exactly 1 parameter (the source value) and must specify a return type (the target type). Dispatch matches by source type and return type.
 
-```python
+```ry
 record Celsius:
     value: int
 
@@ -572,7 +572,7 @@ f = c as Fahrenheit   # Fahrenheit(212)
 
 The target type can be any type the compiler can resolve, including generic types:
 
-```python
+```ry
 record Temperature:
     value: int
 

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -14,7 +14,7 @@ The `std` package (standard library) is automatically imported into every progra
 
 ### Import All Definitions
 
-```python
+```ry
 from math
 ```
 
@@ -22,7 +22,7 @@ Imports all functions and types from the package.
 
 ### Selective Import
 
-```python
+```ry
 from math import sqrt
 ```
 
@@ -30,7 +30,7 @@ Imports only the specified definition.
 
 ### Multiple Selective Import
 
-```python
+```ry
 from math import sqrt, PI
 ```
 
@@ -38,7 +38,7 @@ Imports multiple definitions separated by commas.
 
 ### Relative Import
 
-```python
+```ry
 from .helper import greet
 ```
 
@@ -46,7 +46,7 @@ Imports from a module relative to the current file's directory. The `.` prefix r
 
 ### Relative Import from Subdirectory
 
-```python
+```ry
 from .utils import helper_fn
 from .utils.calc import add
 ```
@@ -55,7 +55,7 @@ Imports from a subdirectory relative to the current file's directory.
 
 ### Relative Import All from Current Directory
 
-```python
+```ry
 from . import add, sub
 ```
 
@@ -95,7 +95,7 @@ Definitions whose names start with `_` (underscore) are private to the package a
 - Wildcard imports (`from pkg`) automatically exclude `_`-prefixed symbols
 - Named imports (`from pkg import _helper`) produce a compile error
 
-```python
+```ry
 # mylib/internal.ry
 function _helper() -> int:     # private — not importable
     return 42
@@ -109,7 +109,7 @@ mypackage/
   string.ry    # function concat()
 ```
 
-```python
+```ry
 from mypackage          # imports add, sub, concat
 from mypackage import add   # imports only add
 ```
@@ -134,13 +134,13 @@ The following sub-packages require explicit import:
 | [`io`](io.md) | File I/O, standard input, and byte conversions |
 | [`path`](path.md) | File path operations (join, basename, dirname, etc.) |
 
-```python
+```ry
 from math import sqrt, PI, sin
 ```
 
 You can also explicitly import specific definitions from standard library packages:
 
-```python
+```ry
 from str import contains
 ```
 
@@ -223,7 +223,7 @@ export RY_PATH="/usr/local/ry/lib:/home/user/ry-packages"
 | Parent directory imports | `from ..` is not supported |
 | Package names | Only letters, digits, and underscores are allowed (no hyphens) |
 
-```python
+```ry
 # Error example: Import inside a block
 function main():
     from math   # Error: imports only allowed at top level
@@ -239,7 +239,7 @@ from math   # Skipped
 
 ### Single File Package
 
-```python
+```ry
 # calc.ry
 function add(a: int, b: int) -> int:
     return a + b
@@ -248,7 +248,7 @@ function sub(a: int, b: int) -> int:
     return a - b
 ```
 
-```python
+```ry
 # main.ry
 from calc import add, sub
 
@@ -264,7 +264,7 @@ mylib/
   string.ry
 ```
 
-```python
+```ry
 # main.ry
 from mylib import add, concat
 ```

--- a/docs/reference/path.md
+++ b/docs/reference/path.md
@@ -4,7 +4,7 @@
 
 File path operations. All functions require explicit import from `path`.
 
-```python
+```ry
 from path import join, basename, dirname, extension, resolve, is_absolute
 ```
 
@@ -27,7 +27,7 @@ from path import join, basename, dirname, extension, resolve, is_absolute
 
 ### Joining Paths
 
-```python
+```ry
 from path import join
 
 case join("/tmp", "data", "file.txt"):
@@ -42,7 +42,7 @@ case join("/tmp", "/usr"):
 
 ### Extracting Path Components
 
-```python
+```ry
 from path import basename, dirname, extension
 
 p = "/home/user/docs/report.pdf"
@@ -62,7 +62,7 @@ case extension(p):
 
 ### Extension Edge Cases
 
-```python
+```ry
 from path import extension
 
 print(extension("archive.tar.gz")?)   # .gz
@@ -73,7 +73,7 @@ print(extension("Makefile")?)         # (empty string)
 
 ### Checking Absolute Paths
 
-```python
+```ry
 from path import is_absolute
 
 print(is_absolute("/usr/local"))  # true
@@ -82,7 +82,7 @@ print(is_absolute("src/main.ry")) # false
 
 ### Resolving Paths
 
-```python
+```ry
 from path import resolve
 
 case resolve("/tmp"):

--- a/docs/reference/records.md
+++ b/docs/reference/records.md
@@ -12,7 +12,7 @@ Records are value types allocated on the stack. They are defined with the `recor
 
 ## Definition Syntax
 
-```python
+```ry
 record TypeName:
     field_name: type
     field_name: type
@@ -20,7 +20,7 @@ record TypeName:
 
 ### Example
 
-```python
+```ry
 record Point:
     x: int
     y: int
@@ -36,7 +36,7 @@ record Rectangle:
 
 Arguments are passed in the order of field definitions. Named arguments are not supported.
 
-```python
+```ry
 p = Point(10, 20)
 r = Rectangle(3.0, 4.5)
 ```
@@ -47,7 +47,7 @@ r = Rectangle(3.0, 4.5)
 
 Fields are read using dot notation.
 
-```python
+```ry
 p = Point(10, 20)
 print(p.x)   # 10
 print(p.y)   # 20
@@ -62,7 +62,7 @@ print(p.y)   # 20
 | Mutable (no `@const`) | Allowed      |
 | `@const`   | Compile error |
 
-```python
+```ry
 p = Point(10, 20)
 p.x = 100    # OK: mutable variable
 
@@ -77,7 +77,7 @@ Field assignment composes across nested records, collection elements, and
 compound operators. The left-hand side can be any postfix chain rooted at a
 mutable variable.
 
-```python
+```ry
 record Inner:
     val: int
 
@@ -103,7 +103,7 @@ the full matrix and the aliasing caveat for nested collections inside records.
 
 ## Usage as Function Parameters and Return Values
 
-```python
+```ry
 function distance(p: Point) -> float:
     return (p.x * p.x + p.y * p.y) as float
 
@@ -117,7 +117,7 @@ function make_point(x: int, y: int) -> Point:
 
 Records can be used as fields of other records.
 
-```python
+```ry
 record Point:
     x: int
     y: int
@@ -136,7 +136,7 @@ print(c.center.x)   # 0
 
 Record types automatically support `==` and `!=` operators. Comparison is performed field-by-field (structural equality).
 
-```python
+```ry
 record Point:
     x: int
     y: int
@@ -161,14 +161,14 @@ Records support single inheritance using the `<` syntax. A child record inherits
 
 ### Syntax
 
-```python
+```ry
 record ChildName < ParentName:
     child_field: type
 ```
 
 ### Example
 
-```python
+```ry
 record HttpError < Error:
     status: int
     url: str
@@ -179,7 +179,7 @@ record HttpError < Error:
 - The child record inherits all parent fields at the beginning of its layout.
 - The constructor takes parent fields first, then child-specific fields.
 
-```python
+```ry
 err = HttpError("not found", 404, 404, "/api")
 print(err.message)  # "not found" (inherited from Error)
 print(err.status)   # 404 (own field)
@@ -189,7 +189,7 @@ print(err.status)   # 404 (own field)
 
 A child value can be passed where the parent type is expected. The child is automatically sliced to extract the parent-prefix fields (value-type slicing).
 
-```python
+```ry
 function handle(e: Error) -> str:
     return e.message
 
@@ -201,7 +201,7 @@ handle(err)  # OK — HttpError coerced to Error
 
 Records can form inheritance chains. Each level inherits all ancestor fields.
 
-```python
+```ry
 record DetailedHttpError < HttpError:
     detail: str
 
@@ -232,7 +232,7 @@ handle(derr)  # OK — coerced to Error (grandparent)
 | Duplicate field names | Compile error |
 | Field assignment on `@const` variables | Compile error |
 
-```python
+```ry
 # Error example: Duplicate field names
 record Bad:
     x: int
@@ -249,7 +249,7 @@ Enumerations are a set of named constants. By default, they are represented as s
 
 ### Definition Syntax
 
-```python
+```ry
 enum TypeName:
     VariantName
     VariantName
@@ -258,7 +258,7 @@ enum TypeName:
 
 ### Example
 
-```python
+```ry
 enum Color:
     Red
     Green
@@ -269,7 +269,7 @@ enum Color:
 
 Variants are accessed using the `::` operator.
 
-```python
+```ry
 c = Color::Red
 print(c)   # Red
 ```
@@ -278,14 +278,14 @@ print(c)   # Red
 
 Since enum values are integers, they can be compared directly with `==` / `!=`.
 
-```python
+```ry
 print(Color::Red == Color::Red)    # true
 print(Color::Red != Color::Green)  # true
 ```
 
 ### Usage in if Statements
 
-```python
+```ry
 c = Color::Green
 case:
     c == Color::Red:
@@ -300,7 +300,7 @@ case:
 
 Use the enum name as the type name.
 
-```python
+```ry
 function is_red(c: Color) -> bool:
     return c == Color::Red
 
@@ -312,7 +312,7 @@ print(is_red(Color::Green))  # false
 
 `print()` outputs the variant name.
 
-```python
+```ry
 c = Color::Blue
 print(c)   # Blue
 ```
@@ -321,7 +321,7 @@ print(c)   # Blue
 
 Simple enum variants can be assigned explicit integer values for use cases like HTTP status codes or bitmask patterns.
 
-```python
+```ry
 enum HttpStatus:
     Ok = 200
     NotFound = 404
@@ -332,7 +332,7 @@ print(s)                              # NotFound
 print(s == HttpStatus::NotFound)      # true
 ```
 
-```python
+```ry
 enum Permission:
     Read = 1
     Write = 2
@@ -350,7 +350,7 @@ Rules:
 
 ADT variant fields can optionally include names for documentation purposes. Named fields make definitions self-describing without changing construction or pattern matching semantics.
 
-```python
+```ry
 enum Shape:
     Circle(radius: float)
     Rect(width: float, height: float)
@@ -366,7 +366,7 @@ enum Shape:
 
 ADT enum values support `==` and `!=`. Comparison is structural: the variant tag is checked first; if the tags differ the values are unequal. When the tags match, every payload field is compared in order using the same rules as record field comparison.
 
-```python
+```ry
 enum Shape:
     Circle(float)
     Rect(float, float)

--- a/docs/reference/thread.md
+++ b/docs/reference/thread.md
@@ -20,7 +20,7 @@ All types are opaque pointers managed by ARC (Automatic Reference Counting). Use
 
 ## Import
 
-```python
+```ry
 from thread import thread_spawn, thread_join, lock_new, lock_acquire, lock_release
 ```
 
@@ -33,7 +33,7 @@ from thread import thread_spawn, thread_join, lock_new, lock_acquire, lock_relea
 
 ### Example — side-effect worker (`Unit`)
 
-```python
+```ry
 from thread import thread_spawn, thread_join, atomic_int_new, atomic_int_load, atomic_int_add
 
 counter = atomic_int_new(0)
@@ -46,7 +46,7 @@ print(atomic_int_load(counter))  # 1
 
 ### Example — value-returning worker (`int` / `float` / `bool`)
 
-```python
+```ry
 from thread import thread_spawn, thread_join
 
 t = thread_spawn(() => 42)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -46,7 +46,7 @@
 
 You can explicitly specify the type when declaring a variable. The annotation can be omitted when the type is inferrable.
 
-```python
+```ry
 x: int = 42
 b: u8 = 255
 f: float = 3.14
@@ -97,7 +97,7 @@ a: any = 42
 
 The `type` keyword creates a new name for an existing type. The alias is fully interchangeable with the original type.
 
-```python
+```ry
 type Meters = float
 type StringList = List<str>
 
@@ -109,14 +109,14 @@ names: StringList = ["Alice", "Bob"]
 
 Type aliases also work with function types, literal types, and range types:
 
-```python
+```ry
 type Callback = function(int, int) -> int
 
 add: Callback = function(a: int, b: int) => a + b
 print(add(3, 4))    # 7
 ```
 
-```python
+```ry
 type Month = 1..12
 type Direction = "N" | "S" | "E" | "W"
 type Digit = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9
@@ -128,7 +128,7 @@ n: Digit = 5
 
 Type aliases can also target union types (including primitive and user-defined types), and the alias behaves identically to the inlined union:
 
-```python
+```ry
 type Simple = int | str | bool
 
 x: Simple = 42
@@ -141,7 +141,7 @@ function describe(v: Simple) -> str:
 
 Nested aliases whose union components are themselves aliases are flattened transparently, and duplicate members are deduplicated. The following three forms are equivalent:
 
-```python
+```ry
 type A = int | str
 type B = A | bool          # same as `int | str | bool`
 type C = B | int           # same as `int | str | bool` (int is deduplicated)
@@ -170,7 +170,7 @@ The accepted magnitude is determined by the target type:
 
 Large unsigned literals require either a suffix (`18446744073709551615u64`) or a type annotation on the receiving variable (`x: u64 = 18446744073709551615`). Negative literals arrive as a unary minus on a non-negative magnitude, so `-1i8` is accepted while `-1u8` is rejected. The bare `int` minimum `-9223372036854775808` (INT64_MIN) can be written directly as a literal; the positive form `9223372036854775808` (without the leading `-`) is rejected.
 
-```python
+```ry
 max_u64: u64 = 18446744073709551615     # 2^64 - 1
 mask:    u64 = 0xFFFF_FFFF_FFFF_FFFF    # same value via hex
 word:    u32 = 4294967295               # 2^32 - 1
@@ -187,7 +187,7 @@ FloatSuffix  := 'f32' | 'f64'
 
 Scientific notation is supported anywhere a float is expected:
 
-```python
+```ry
 avogadro  = 6.022e23
 planck    = 6.626e-34
 light_spd = 2.998E8
@@ -204,7 +204,7 @@ A literal type restricts a variable to specific constant values. The compiler ch
 
 ### Int Literal Type
 
-```python
+```ry
 x: 42 = 42           # single literal type
 y: 0 | 1 = 0         # union of int literals
 z: 0 | 1 = 0
@@ -214,7 +214,7 @@ z = 1                     # OK
 
 ### String Literal Type
 
-```python
+```ry
 dir: "N" | "S" | "E" | "W" = "N"
 # @const bad: "N" | "S" = "X"    # compile error
 ```
@@ -230,7 +230,7 @@ dir: "N" | "S" | "E" | "W" = "N"
 
 A range type constrains an integer variable to a contiguous range of values (inclusive on both ends).
 
-```python
+```ry
 month: 1..12 = 6       # OK
 # @const bad: 1..12 = 0       # compile error: out of range
 # @const bad: 1..12 = 13      # compile error: out of range
@@ -240,7 +240,7 @@ t: -10..10 = -5        # negative ranges are supported
 
 ### With Mutable Variables (Runtime Check)
 
-```python
+```ry
 x: 1..12 = 6
 x = 12                      # OK
 # x = dynamic_value()       # runtime check: exits if out of range
@@ -248,7 +248,7 @@ x = 12                      # OK
 
 ### In Function Parameters
 
-```python
+```ry
 function set_month(m: 1..12) -> int:
     return m
 
@@ -264,7 +264,7 @@ The `none` keyword represents the absence of a value for Option types, equivalen
 
 The `T?` syntax is a shorthand for `Option<T>`.
 
-```python
+```ry
 x: int? = 42       # equivalent to Option<int>
 y: int? = none      # equivalent to None
 
@@ -287,14 +287,14 @@ Weak references are the user-facing mechanism for breaking reference cycles.
 
 Use `weak` (a contextual identifier, not a reserved keyword) in both type annotation and expression position:
 
-```python
+```ry
 s = "hello"
 w: weak str = weak s
 ```
 
 The type `weak T` is a new type constructor where `T` must be an ARC-managed type (currently `str`, `List<T>`, `Map<K, V>`, `Set<T>`). `T` may also be a type alias that resolves to one of these managed types — the compiler resolves aliases to their canonical form at the point the weak variable is declared.
 
-```python
+```ry
 type MyStr = str
 s = "hello"
 w: weak MyStr = weak s   # MyStr resolves to str — works correctly
@@ -307,7 +307,7 @@ Accessing a weak variable automatically performs an **upgrade** — an atomic ch
 - `Some(value)` if the referent is still alive (strong count > 0)
 - `None` if the referent has been deallocated (strong count == 0)
 
-```python
+```ry
 s = "alive"
 w: weak str = weak s
 case w:
@@ -319,7 +319,7 @@ case w:
 
 The coalesce operator (`??`) also works with weak references:
 
-```python
+```ry
 w: weak str = weak s
 val = w ?? "default"
 ```
@@ -328,7 +328,7 @@ val = w ?? "default"
 
 Weak references can be reassigned. The old weak reference is released and the new one is retained:
 
-```python
+```ry
 a = "first"
 b = "second"
 w: weak str = weak a
@@ -349,7 +349,7 @@ Weak references are automatically released when they go out of scope. If both st
 
 String interpolation with the `f"..."` syntax. Expressions inside `{}` are evaluated and converted to strings.
 
-```python
+```ry
 name = "world"
 print(f"Hello {name}")     # Hello world
 
@@ -362,7 +362,7 @@ print(f"{a} + {b} = {a + b}")   # 1 + 2 = 3
 
 Any expression that evaluates to `int`, `float`, `bool`, `str`, a record type, a tuple, or a collection type (`List`, `Map`, `Set`) can be used inside `{}`.
 
-```python
+```ry
 xs = [1, 2, 3]
 print(f"items: {xs}")     # items: [1, 2, 3]
 
@@ -378,7 +378,7 @@ print(f"tuple: {t}")      # tuple: (1, hello)
 | `}}` | `}` (literal brace) |
 | `\n` `\r` `\t` `\\` `\"` | Same as regular strings |
 
-```python
+```ry
 print(f"{{braces}}")   # {braces}
 ```
 
@@ -386,7 +386,7 @@ print(f"{{braces}}")   # {braces}
 
 Explicit type conversion using the `as` keyword.
 
-```python
+```ry
 x = 42 as float     # 42.0
 y = 3.14 as int      # 3
 z = 1 as bool        # true
@@ -424,7 +424,7 @@ b = 255 as u8         # u8 value 255
 
 The target type of `as` supports the full type syntax, including generic types:
 
-```python
+```ry
 x = value as Option<int>
 y = data as Map<str, int>
 ```
@@ -435,7 +435,7 @@ Any `as` cast (including with generics) must be a built-in cast or have a matchi
 
 Enum variants can carry associated data by specifying types in parentheses after the variant name. Variants without parentheses remain simple tags.
 
-```python
+```ry
 enum Shape:
     Circle(float)
     Rectangle(float, float)
@@ -446,7 +446,7 @@ enum Shape:
 
 Variants can optionally use named fields for documentation clarity. Named fields make variant definitions self-describing but do not change runtime behavior — construction and pattern matching remain positional.
 
-```python
+```ry
 enum Shape:
     Circle(radius: float)
     Rectangle(width: float, height: float)
@@ -462,7 +462,7 @@ Rules:
 
 Use the `EnumName::Variant(value)` syntax to construct a variant with data. Arguments are always positional, even when fields are named.
 
-```python
+```ry
 c = Shape::Circle(3.14)
 r = Shape::Rectangle(4.0, 5.0)
 p = Shape::Point
@@ -472,7 +472,7 @@ p = Shape::Point
 
 Use `case EnumName::Variant(binding):` to extract the associated data. Bindings use user-chosen variable names, not field names.
 
-```python
+```ry
 case c:
     Shape::Circle(r):
         print(r)            # 3.14
@@ -487,7 +487,7 @@ case c:
 
 ADT enums support `==` and `!=`. Comparison is structural: first the variant tag is compared; if the tags differ the values are unequal. If the tags match, every payload field is compared in order (the same field-by-field semantics used for records).
 
-```python
+```ry
 Shape::Circle(1.0) == Shape::Circle(1.0)   # true
 Shape::Circle(1.0) == Shape::Circle(2.0)   # false — same tag, different payload
 Shape::Circle(1.0) == Shape::Point         # false — different tag
@@ -508,7 +508,7 @@ An ADT enum is stored as a tagged union: `{ i64 tag, [N x i8] data }` where `N` 
 
 An enum can have type parameters using angle-bracket syntax `<T>`. This allows the same enum shape to hold different payload types.
 
-```python
+```ry
 enum MyOption<T>:
     MySome(T)
     MyNone
@@ -518,7 +518,7 @@ enum MyOption<T>:
 
 Instantiate by providing a concrete type argument. The type argument is required when the compiler cannot infer it.
 
-```python
+```ry
 a = MyOption<int>::MySome(42)
 b = MyOption<int>::MyNone
 
@@ -535,7 +535,7 @@ case a:
 
 A built-in type for error handling. `Error` has two fields: `message` (str) and `code` (int).
 
-```python
+```ry
 e = Error("something went wrong")       # code defaults to 0
 e2 = Error("not found", 404)            # explicit code
 
@@ -548,7 +548,7 @@ print(e2)          # Error: not found (code: 404)
 
 Functions that can fail return `Result<V, E>`:
 
-```python
+```ry
 function divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
         return Err(Error("division by zero"))
@@ -563,7 +563,7 @@ case divide(10, 2):
 
 When the return value is not meaningful, use `Result<Unit, Error>`:
 
-```python
+```ry
 function save(path: str, data: str) -> Result<Unit, Error>:
     return Ok(0 as u8)   # Unit placeholder
 
@@ -586,7 +586,7 @@ It is used with `case` for exhaustive error handling. Both `Ok` and `Err` cases 
 **Equality:**
 `Result<T, E>` supports `==` and `!=`. Two results are equal when both variants match (`Ok`/`Ok` or `Err`/`Err`) and the inner values are equal.
 
-```python
+```ry
 function make_ok(v: int) -> Result<int, Error>: return Ok(v)
 make_ok(42) == make_ok(42)   # true
 make_ok(1)  == make_ok(2)    # false
@@ -631,7 +631,7 @@ Key properties:
 
 You can declare a variable that may hold one of multiple types using `|`.
 
-```python
+```ry
 x: int | str = 42
 x = "hello"     # Reassignment is allowed (any type in the union)
 print(x)        # hello
@@ -639,7 +639,7 @@ print(x)        # hello
 
 ### Usage in Function Parameters and Return Types
 
-```python
+```ry
 function show(x: int | str) -> int:
     print(x)
     return 0
@@ -658,7 +658,7 @@ A union type is represented as `{ i64 tag, [N x i8] data }`. The `tag` indicates
 
 Union types support `==` and `!=` for all comparable variant types, including primitives (`int`, `float`, `str`, `bool`), collections (`List`, `Map`, `Set`), records, ADT enums, and nested unions. Two union values are equal when they hold the same variant (same tag) and the inner values are equal.
 
-```python
+```ry
 x: int | str = 42
 y: int | str = 42
 x == y   # true
@@ -710,7 +710,7 @@ The `tag` field identifies the stored type, and the `data` field holds the value
 
 Concrete values are automatically **wrapped** when assigned to `any`, and `any` values are automatically **unwrapped** when assigned to a concrete type.
 
-```python
+```ry
 # Wrapping: concrete → any
 x: any = 42          # int is wrapped into any
 x = "hello"          # reassignment with a different type is allowed
@@ -730,7 +730,7 @@ If the runtime type does not match the target type (e.g., unwrapping `any(str)` 
 
 An `any` variable can be reassigned to a value of any supported type:
 
-```python
+```ry
 x: any = 42
 x = 3.14       # OK: now holds float
 x = "hello"    # OK: now holds str
@@ -760,7 +760,7 @@ When both operands are `any`, arithmetic operations dispatch at runtime based on
 
 When one operand is `any` and the other is a concrete type, the concrete value is automatically wrapped before the operation.
 
-```python
+```ry
 x: any = 10
 y: any = x + 20    # 20 is auto-wrapped; result is any(int) = 30
 ```
@@ -774,7 +774,7 @@ Incompatible type combinations (e.g., `str - int`) cause a **runtime error**.
 | `==`, `!=` | Works for same types; int/float mixing is allowed |
 | `<`, `<=`, `>`, `>=` | Numeric (int/float mixing allowed) and string (lexicographic) |
 
-```python
+```ry
 x: any = 3
 y: any = 3.0
 print(x == y)    # true (int/float comparison)
@@ -786,7 +786,7 @@ Type mismatches in comparison (e.g., `int < str`) cause a **runtime error**.
 
 `any` values support `print()` and f-string interpolation:
 
-```python
+```ry
 x: any = 42
 print(x)              # 42
 print(f"value: {x}")  # value: 42
@@ -798,7 +798,7 @@ Conversion rules: `int` → decimal string, `float` → `%g` format, `bool` → 
 
 An `any` value can be passed to a function with concrete parameter types. The value is automatically unwrapped with a runtime type check:
 
-```python
+```ry
 function add_one(x: int) -> int:
     return x + 1
 


### PR DESCRIPTION
## Summary

- Replaces all 393 occurrences of ` ```python ` code fences with ` ```ry ` across 21 files in `docs/reference/`
- The `python` tag was a legacy artifact predating the `ry` language tag definition
- All affected code blocks contain Ry syntax — no Python-specific constructs were present
- Mechanical find-and-replace via `sed -i '' 's/^```python$/```ry/g'`

Closes #1126

## Test plan

- [x] `grep -rn '^```python$' docs/reference/ | wc -l` → **0** (all replaced)
- [x] `grep -rn '^```ry$' docs/reference/ | wc -l` → **429** (36 pre-existing + 393 new)
- [x] 21 files changed, 393 insertions(+), 393 deletions(-) — pure fence-tag swap, no code body changes
- [x] Python-specific syntax scan (`def self`, `@property`, `import os`, etc.) → only `@property(count=100)` hit in `directives.md` / `testing.md` (Ry's property-based testing directive, not in the replaced files)
- [x] `./build/ry_tests` — 1799 tests PASS
- [x] `./build/ry test -p` — 143 test files, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples across reference documentation to use proper syntax highlighting for the language, improving readability and consistency throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->