### PR TITLE
fix(io): write_text / append_text embedded NUL truncation fix (#1133)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1285,6 +1285,7 @@ Key constants:
 - `split(str, delim)` with non-empty delimiter (runtime `__ry_str_split` via `memmem`), `join`, `repeat`, `*` operator (#1051)
 - `regex_match`, `regex_search`, `regex_replace`, `regex_split`, `regex_find_all` and all UFCS variants (`is_match`, `search`, `replace`, `split`, `find_all`) — subject + pattern + replacement all length-driven, no `strlen` (#1052). Regex *literal* syntax also supports `\0` to encode a NUL byte in the pattern (`/a\0b/` matches `"a\0b"`) since #1076.
 - `json.parse`, `json.stringify`, `json.to_str`, `json.get`, `json.keys` (#1053) — `JsonValue::string_val` and `JsonObjectVal::keys[i]` are now StringHeader handles allocated via `makeString`; `stringByteLen` is the single length source; `escape_string` iterates by index and emits `\u0000` for NUL bytes; `Parser` uses explicit `src_len` from `stringByteLen` instead of `strlen`/`'\0'` sentinel. C++ test helpers updated to wrap literals in `makeString` since `__ry_json_parse` / `__ry_json_get` expect StringHeader handles.
+- `io.write_text`, `io.append_text` (#1133) — replaced `fputs(content, f)` (stops at first `\0`) with `fwrite(content, 1, stringByteLen(content), f)`. Binary-transparent round-trip for content now matches `io.write_bytes`. `fclose` return code is still checked so buffered-write errors surface as `Err`.
 
 ### C++ `\xNN` hex escape consumes ALL following hex digits — never use `\xNNX` when X is a hex char
 

--- a/changelog.d/1133-io-write-append-text-nul-safety.md
+++ b/changelog.d/1133-io-write-append-text-nul-safety.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `io.write_text` and `io.append_text` silently truncated content at the first
+  embedded NUL byte because they used `fputs(content, f)`. They now use
+  `fwrite(content, 1, stringByteLen(content), f)` for binary-transparent writes,
+  matching the already-safe `io.write_bytes` path. `fclose` return code is still
+  checked so buffered-write errors surface as `Err` (#1133).

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -120,3 +120,4 @@ case read_text("missing.txt"):
 - File paths are relative to the current working directory unless absolute paths are specified.
 - `exists` returns `false` for paths containing an embedded NUL byte (such paths cannot refer to a real file under POSIX).
 - `write_text` and `write_bytes` overwrite existing files. Use `append_text` to add content to existing files.
+- `write_text`, `append_text`, and `read_text` are binary-transparent: content may contain embedded NUL bytes and the full byte sequence is preserved (#1133).

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -132,7 +132,10 @@ extern "C" int64_t __ry_write_text(const char *path, const char *content) {
         setLastError("cannot open file '%s' for writing", path);
         return 1;
     }
-    if (fputs(content, f) == EOF || fclose(f) != 0) {
+    int64_t byteLen = stringByteLen(content);
+    size_t written = fwrite(content, 1, static_cast<size_t>(byteLen), f);
+    int closeRc = fclose(f);
+    if (static_cast<int64_t>(written) != byteLen || closeRc != 0) {
         setLastError("failed to write to file '%s'", path);
         return 1;
     }
@@ -149,7 +152,10 @@ extern "C" int64_t __ry_append_text(const char *path, const char *content) {
         setLastError("cannot open file '%s' for appending", path);
         return 1;
     }
-    if (fputs(content, f) == EOF || fclose(f) != 0) {
+    int64_t byteLen = stringByteLen(content);
+    size_t written = fwrite(content, 1, static_cast<size_t>(byteLen), f);
+    int closeRc = fclose(f);
+    if (static_cast<int64_t>(written) != byteLen || closeRc != 0) {
         setLastError("failed to append to file '%s'", path);
         return 1;
     }

--- a/tests/spec/nul_safety_io.test.ry
+++ b/tests/spec/nul_safety_io.test.ry
@@ -31,7 +31,7 @@ describe("nul_safety_io", ():
       case read_text("/tmp/ry_nul_io_ct.txt"):
         Ok(s):
           expect(length(s)).to_eq(3)
-          expect(s).to_eq("a\0b")
+          expect(s == "a\0b").to_eq(true)
         Err(e): fail("read_text failed: " + e.message)
       case read_bytes("/tmp/ry_nul_io_ct.txt"):
         Ok(bs): expect(length(bs)).to_eq(3)
@@ -56,7 +56,7 @@ describe("nul_safety_io", ():
       case read_text("/tmp/ry_nul_io_at.txt"):
         Ok(s):
           expect(length(s)).to_eq(8)
-          expect(s).to_eq("hellox\0y")
+          expect(s == "hellox\0y").to_eq(true)
         Err(e): fail("read_text failed: " + e.message)
       case read_bytes("/tmp/ry_nul_io_at.txt"):
         Ok(bs): expect(length(bs)).to_eq(8)

--- a/tests/spec/nul_safety_io.test.ry
+++ b/tests/spec/nul_safety_io.test.ry
@@ -24,10 +24,18 @@ describe("nul_safety_io", ():
         Ok(_): fail("expected Err but got Ok")
         Err(e): expect(e.message).to_contain("embedded NUL")
     )
-    it("content with embedded NUL is not rejected (path guard only)", ():
+    it("round-trips content with embedded NUL bytes", ():
       case write_text("/tmp/ry_nul_io_ct.txt", "a\0b"):
         Ok(_): 0
-        Err(e): fail("content NUL should not be rejected: " + e.message)
+        Err(e): fail("write_text failed: " + e.message)
+      case read_text("/tmp/ry_nul_io_ct.txt"):
+        Ok(s):
+          expect(length(s)).to_eq(3)
+          expect(s).to_eq("a\0b")
+        Err(e): fail("read_text failed: " + e.message)
+      case read_bytes("/tmp/ry_nul_io_ct.txt"):
+        Ok(bs): expect(length(bs)).to_eq(3)
+        Err(e): fail("read_bytes failed: " + e.message)
       delete_file("/tmp/ry_nul_io_ct.txt")
     )
   )
@@ -37,6 +45,23 @@ describe("nul_safety_io", ():
       case append_text("/tmp/ry_nul_io\0bad.txt", "x"):
         Ok(_): fail("expected Err but got Ok")
         Err(e): expect(e.message).to_contain("embedded NUL")
+    )
+    it("round-trips content with embedded NUL bytes", ():
+      case write_text("/tmp/ry_nul_io_at.txt", "hello"):
+        Ok(_): 0
+        Err(e): fail("write_text failed: " + e.message)
+      case append_text("/tmp/ry_nul_io_at.txt", "x\0y"):
+        Ok(_): 0
+        Err(e): fail("append_text failed: " + e.message)
+      case read_text("/tmp/ry_nul_io_at.txt"):
+        Ok(s):
+          expect(length(s)).to_eq(8)
+          expect(s).to_eq("hellox\0y")
+        Err(e): fail("read_text failed: " + e.message)
+      case read_bytes("/tmp/ry_nul_io_at.txt"):
+        Ok(bs): expect(length(bs)).to_eq(8)
+        Err(e): fail("read_bytes failed: " + e.message)
+      delete_file("/tmp/ry_nul_io_at.txt")
     )
   )
 


### PR DESCRIPTION
## Summary

- `io.write_text` and `io.append_text` used `fputs(content, f)` which stops at the first `\0` byte, silently truncating content containing embedded NUL bytes
- Replaced with `fwrite(content, 1, stringByteLen(content), f)` for binary-transparent writes; `fclose` return value check preserved to surface buffered-write errors as `Err`
- Added round-trip tests (`write_text` → `read_text` with `"a\0b"`, `append_text` → `read_text` with `"x\0y"` after initial write); byte count cross-checked via `read_bytes`

## Test plan

- [x] New round-trip tests confirmed failing before fix, passing after (TDD)
- [x] `./build/ry_tests` — 1799/1799 pass
- [x] `./build/ry test -p` — 143 files, 0 failures
- [x] ASan+UBSan clean
- [x] TSan C++ clean
- [x] Reproduction snippet `length(s)` outputs `3` (was `1`)

Closes #1133

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed write_text and append_text truncating at embedded NUL bytes; they now preserve all bytes and surface buffered write failures.

* **Documentation**
  * Clarified reference docs and changelog noting text I/O preserves embedded NULs consistently with byte I/O.

* **Tests**
  * Added/expanded round-trip tests verifying exact length and content (including embedded NULs) for write/append/read operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->