### PR TITLE
fix(codegen): move reverse! dispatch from String to HigherOrder (#1124)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3600,3 +3600,14 @@ This matters any time a `str` is extracted from an enum field via `EnumConstruct
 **Rule**: In `cachedGlobalString` (`src/codegen.cpp`), the StringHeader global for string literals is created with `isConstant=true`. The JIT maps such globals as read-only pages. Any code that uses `emitArcGetHeaderFromData` (offset −16) instead of `emitStrGetHeaderFromData` (offset −24) on a literal `str` will bypass the `ARC_IMMORTAL` guard (because `weak_count=0 ≠ INT64_MAX`), then attempt an atomic write to the read-only page → SIGSEGV (exit 139), not SIGABRT.
 
 This makes wrong-offset bugs on str literals almost always fatal immediately, which is useful for diagnosis but means the stack trace will point into JIT code at an unusual address. Cross-reference with `arc_str_managed_vars_` membership at the crashing alloca's declaration site.
+
+---
+
+### Mutating collection operations belong in `codegen_call_higher_order.cpp`, not `codegen_call_string.cpp`
+
+**Source**: #1124 (2026-04-18)
+**Tags**: codegen, dispatch, placement, list, string
+
+**Rule**: `sort!` and `reverse!` (and any future in-place list mutation) must be registered in `emitBuiltinHigherOrder` (`src/codegen_call_higher_order.cpp`), not in the String dispatcher table in `emitBuiltinString` (`src/codegen_call_string.cpp`). The String dispatcher is tried before HigherOrder in the dispatch chain (`codegen_call_dispatch.cpp`), so a stray entry in the String dispatcher will unconditionally claim the call for every type — including lists — before HigherOrder gets a chance. This caused `reverse!` to silently route list calls through a misleadingly-named `emitStrOp_reverse_mut` function, and to produce the confusing error "requires a list" when called on a string.
+
+**How to apply**: When adding a new mutating built-in that applies to lists, check whether `sort!` already lives in HigherOrder and mirror that placement. If a built-in should error on strings with a user-facing message, add the `getListElementType() == nullptr` guard in the HigherOrder handler and emit a clear diagnostic (e.g. "requires a list; strings are immutable, use reverse() instead").

--- a/changelog.d/1124-reverse-mut-string-diagnostic.md
+++ b/changelog.d/1124-reverse-mut-string-diagnostic.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- `reverse!()` on a string now produces a clear diagnostic instead of a misleading
+  "requires a list" internal error (#1124)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1456,7 +1456,6 @@ public:
     llvm::Value *emitSetUnionCore(llvm::Value *set1, llvm::Value *set2,
                                    llvm::Type *elemTy);
     llvm::Value *emitStrOp_reverse(const CallExpr &e);
-    llvm::Value *emitStrOp_reverse_mut(const CallExpr &e);
     llvm::Value *emitStrOp_split(const CallExpr &e);
     llvm::Value *emitStrOp_join(const CallExpr &e);
 

--- a/src/codegen_call_higher_order.cpp
+++ b/src/codegen_call_higher_order.cpp
@@ -212,6 +212,49 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e, llvm::Value *pre
         return llvm::ConstantInt::get(i64Ty_, 0);
     }
 
+    // reverse!(list) → in-place reverse
+    if (e.callee == "reverse!") {
+        requireArgs(e, 1);
+        llvm::AllocaInst *receiverAlloca = tryGetReceiverAlloca(*e.args[0]);
+        llvm::Value *listPtr = emitExpr(*e.args[0]);
+        llvm::Type *elemTy = getListElementType(listPtr);
+        if (!elemTy)
+            codegenError("reverse!() requires a list; strings are immutable, use reverse() instead");
+        listPtr = emitCowCheck(listPtr, receiverAlloca, CollectionKind::List);
+
+        auto lf = loadListHeader(listPtr, "revm");
+        llvm::Value *len = lf.len;
+        llvm::Value *dataPtr = lf.data;
+
+        llvm::Value *half = builder_.CreateSDiv(len, llvm::ConstantInt::get(i64Ty_, 2), "revm_half");
+        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "revm_i");
+        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+
+        llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "revm.cond", fn_);
+        llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, "revm.body", fn_);
+        llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "revm.end", fn_);
+        builder_.CreateBr(condBB);
+
+        builder_.SetInsertPoint(condBB);
+        llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "revm_idx");
+        builder_.CreateCondBr(builder_.CreateICmpSLT(i, half, "revm_cond"), bodyBB, endBB);
+
+        builder_.SetInsertPoint(bodyBB);
+        llvm::Value *iCur = builder_.CreateLoad(i64Ty_, iVar, "revm_cur");
+        llvm::Value *j = builder_.CreateSub(builder_.CreateSub(len, llvm::ConstantInt::get(i64Ty_, 1)), iCur, "revm_j");
+        llvm::Value *ptrI = builder_.CreateGEP(elemTy, dataPtr, iCur, "revm_pi");
+        llvm::Value *ptrJ = builder_.CreateGEP(elemTy, dataPtr, j, "revm_pj");
+        llvm::Value *vi = builder_.CreateLoad(elemTy, ptrI, "revm_vi");
+        llvm::Value *vj = builder_.CreateLoad(elemTy, ptrJ, "revm_vj");
+        builder_.CreateStore(vj, ptrI);
+        builder_.CreateStore(vi, ptrJ);
+        builder_.CreateStore(builder_.CreateAdd(iCur, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
+        builder_.CreateBr(condBB);
+
+        builder_.SetInsertPoint(endBB);
+        return llvm::ConstantInt::get(i64Ty_, 0);
+    }
+
     // ===== reduce(list, fn(a, b) -> a op b) =====
     if (e.callee == "reduce") {
         requireArgs(e, 2);

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -37,7 +37,6 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         {"trim_end",    &CodeGen::emitStrOp_trim_end},
         {"repeat",      &CodeGen::emitStrOp_repeat},
         {"reverse",     &CodeGen::emitStrOp_reverse},
-        {"reverse!",    &CodeGen::emitStrOp_reverse_mut},
         {"split",       &CodeGen::emitStrOp_split},
         {"join",        &CodeGen::emitStrOp_join},
     };
@@ -608,49 +607,6 @@ llvm::Value *CodeGen::emitStrOp_reverse(const CallExpr &e) {
     auto *r = builder_.CreateCall(revFn, {s, emitStringByteLen(s)}, "str_rev");
     arc_str_owned_values_.insert(r);
     return r;
-}
-
-// reverse!(list) → in-place reverse
-llvm::Value *CodeGen::emitStrOp_reverse_mut(const CallExpr &e) {
-    requireArgs(e, 1);
-    llvm::AllocaInst *receiverAlloca = tryGetReceiverAlloca(*e.args[0]);
-    llvm::Value *listPtr = emitExpr(*e.args[0]);
-    llvm::Type *elemTy = getListElementType(listPtr);
-    if (!elemTy) codegenError("reverse!() requires a list");
-    listPtr = emitCowCheck(listPtr, receiverAlloca, CollectionKind::List);
-
-    auto lf = loadListHeader(listPtr, "revm");
-    llvm::Value *len = lf.len;
-    llvm::Value *dataPtr = lf.data;
-
-    // Swap elements: i from 0 to len/2
-    llvm::Value *half = builder_.CreateSDiv(len, llvm::ConstantInt::get(i64Ty_, 2), "revm_half");
-    llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "revm_i");
-    builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
-
-    llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "revm.cond", fn_);
-    llvm::BasicBlock *bodyBB = llvm::BasicBlock::Create(*ctx_, "revm.body", fn_);
-    llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "revm.end", fn_);
-    builder_.CreateBr(condBB);
-
-    builder_.SetInsertPoint(condBB);
-    llvm::Value *i = builder_.CreateLoad(i64Ty_, iVar, "revm_idx");
-    builder_.CreateCondBr(builder_.CreateICmpSLT(i, half, "revm_cond"), bodyBB, endBB);
-
-    builder_.SetInsertPoint(bodyBB);
-    llvm::Value *iCur = builder_.CreateLoad(i64Ty_, iVar, "revm_cur");
-    llvm::Value *j = builder_.CreateSub(builder_.CreateSub(len, llvm::ConstantInt::get(i64Ty_, 1)), iCur, "revm_j");
-    llvm::Value *ptrI = builder_.CreateGEP(elemTy, dataPtr, iCur, "revm_pi");
-    llvm::Value *ptrJ = builder_.CreateGEP(elemTy, dataPtr, j, "revm_pj");
-    llvm::Value *vi = builder_.CreateLoad(elemTy, ptrI, "revm_vi");
-    llvm::Value *vj = builder_.CreateLoad(elemTy, ptrJ, "revm_vj");
-    builder_.CreateStore(vj, ptrI);
-    builder_.CreateStore(vi, ptrJ);
-    builder_.CreateStore(builder_.CreateAdd(iCur, llvm::ConstantInt::get(i64Ty_, 1)), iVar);
-    builder_.CreateBr(condBB);
-
-    builder_.SetInsertPoint(endBB);
-    return llvm::ConstantInt::get(i64Ty_, 0);
 }
 
 // split(s, delim) → List<str>

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -981,3 +981,14 @@ bs += [256]
 print(length(bs))
 )", {"u8 literal out of range"});
 }
+
+// ============================================================
+// reverse!() on a string is rejected with a clear diagnostic (#1124)
+// ============================================================
+
+TEST_F(CodeGenTest, ReverseMutOnStringRejected) {
+    expectCompileError(
+        "s = \"hello\"\n"
+        "s.reverse!()\n",
+        {"reverse!", "list", "immutable"});
+}


### PR DESCRIPTION
## Summary

- `reverse!` was registered in `emitBuiltinString`'s dispatch table, causing all calls (even on lists) to route through `emitStrOp_reverse_mut` — a function that already lived in the String file but was purely a list operation
- Calling `"hello".reverse!()` produced the opaque internal error `"reverse!() requires a list"` instead of a clear user-facing diagnostic
- Moved the handler inline into `emitBuiltinHigherOrder`, matching the existing `sort!` placement; updated the error message to `"reverse!() requires a list; strings are immutable, use reverse() instead"`
- Removed `emitStrOp_reverse_mut` member function and its declaration from `codegen.hpp`

## Test plan

- [x] New regression test `CodeGenTest.ReverseMutOnStringRejected` verifies `s.reverse!()` on a string emits a diagnostic containing `"reverse!"`, `"list"`, and `"immutable"`
- [x] `./build/ry_tests` — 1800 tests passed
- [x] `./build/ry test -p` — 143 test files, 0 failures
- [x] ASan + UBSan clean (`./build-asan/ry_tests` + `./build-asan/ry test -p`)
- [x] Manual: `[1,2,3].reverse!()` → `[3, 2, 1]`; `"hello".reverse!()` → clear error

Closes #1124

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error message when calling `reverse!()` on a string. Now displays a clear diagnostic indicating strings are immutable, instead of the previous misleading "requires a list" error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->