### PR TITLE
feat(base64): List<u8> 入出力の encode/decode 関数を追加 (#1130)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ add_library(ry_lib STATIC
     src/codegen_call_set_ops.cpp
     src/codegen_call_higher_order.cpp
     src/codegen_call_io.cpp
+    src/codegen_call_base64.cpp
     src/codegen_call_iterator.cpp
     src/codegen_call_result.cpp
     src/codegen_call_option.cpp

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2410,6 +2410,18 @@ Skip: plain typos and mistakes that anyone would catch immediately.
 the second invocation works, ask "was the fix non-obvious?". If yes,
 write a 3-line entry under this section with a descriptive subheading.
 
+### Testing stdlib changes: run from the project root, not from /tmp/
+
+**Source**: #1130 implementation (base64 `List<u8>` overloads)
+**Tags**: commands, environment, stdlib, dev-stdlib, module-loader
+
+**Wrong**: `printf '...\n' > /tmp/b64_smoke.ry && ./build/ry /tmp/b64_smoke.ry`
+→ Error: `'encode_bytes' not found in package 'base64'`
+
+**Correct**: `./build/ry test tests/spec/base64.test.ry` (or any `.ry` inside the repo)
+
+**Why**: `./build/ry` resolves the stdlib path via `package.toml`'s hidden `[paths]._dev_stdlib` key, which requires a `package.toml` somewhere in the ancestor directory chain. Files under `/tmp/` have no such ancestor, so the module loader falls back to `~/.ry/share/std` (the globally-installed stdlib), which does not contain the newly added declarations. The trace event to look for: `"resolved_path":"/Users/.../.ry/share/std"` instead of `"resolved_path":"/Users/.../Workspace/ry-2/share/std"`.
+
 *(specific entries to be added as they are encountered)*
 
 ---

--- a/changelog.d/1130-base64-list-bytes.md
+++ b/changelog.d/1130-base64-list-bytes.md
@@ -1,0 +1,4 @@
+### Added
+
+- `base64.encode_bytes(List<u8>) -> str` and `base64.encode_bytes_url_safe(List<u8>) -> str` for encoding raw binary byte lists to base64 without going through `str` (#1130)
+- `base64.decode_bytes(str) -> Result<List<u8>, Error>` and `base64.decode_bytes_url_safe(str) -> Result<List<u8>, Error>` for decoding base64 directly to raw bytes, preserving embedded NUL bytes and non-UTF-8 sequences (#1130)

--- a/docs/reference/base64.md
+++ b/docs/reference/base64.md
@@ -16,6 +16,10 @@ from base64 import encode, decode, encode_url_safe, decode_url_safe
 | `decode` | `(str) -> Result<str, Error>` | Decodes a standard base64 string |
 | `encode_url_safe` | `(str) -> str` | Encodes a string to URL-safe base64 (no padding) |
 | `decode_url_safe` | `(str) -> Result<str, Error>` | Decodes a URL-safe base64 string |
+| `encode_bytes` | `(List<u8>) -> str` | Encodes raw bytes to standard base64 |
+| `encode_bytes_url_safe` | `(List<u8>) -> str` | Encodes raw bytes to URL-safe base64 (no padding) |
+| `decode_bytes` | `(str) -> Result<List<u8>, Error>` | Decodes a standard base64 string to raw bytes |
+| `decode_bytes_url_safe` | `(str) -> Result<List<u8>, Error>` | Decodes a URL-safe base64 string to raw bytes |
 
 ## Examples
 
@@ -47,6 +51,50 @@ encoded = encode_url_safe("data with special chars: ?&=")
 case decode_url_safe(encoded):
     Ok(s):
         print(s)
+    Err(e):
+        print(e.message)
+```
+
+## Working with Byte Data
+
+`encode_bytes` and `decode_bytes` operate directly on `List<u8>`, making them suitable for binary data such as images, audio, or cryptographic payloads that may contain arbitrary byte values including embedded NUL bytes.
+
+```python
+from base64 import encode_bytes, decode_bytes
+from io import read_bytes, write_bytes
+
+# Encode raw binary file content to base64
+case read_bytes("/path/to/image.jpg"):
+    Ok(data):
+        encoded = encode_bytes(data)
+        print(encoded)
+    Err(e):
+        print(e.message)
+
+# Decode base64 back to raw bytes
+case decode_bytes("AP8A"):
+    Ok(data):
+        case write_bytes("/tmp/out.bin", data):
+            Ok(_):
+                print("written")
+            Err(e):
+                print(e.message)
+    Err(e):
+        print(e.message)
+```
+
+URL-safe variants are also available for byte data:
+
+```python
+from base64 import encode_bytes_url_safe, decode_bytes_url_safe
+
+token: List<u8> = [0xFBu8, 0xFFu8, 0x00u8, 0x01u8]
+encoded = encode_bytes_url_safe(token)
+# encoded contains only A-Z, a-z, 0-9, - and _ (no padding)
+
+case decode_bytes_url_safe(encoded):
+    Ok(original):
+        print(original == token)  # true
     Err(e):
         print(e.message)
 ```

--- a/share/std/base64/base64.ry
+++ b/share/std/base64/base64.ry
@@ -11,3 +11,15 @@ function encode_url_safe(input: str) -> str
 
 @native("base64")
 function decode_url_safe(input: str) -> Result<str, Error>
+
+@native("base64")
+function encode_bytes(input: List<u8>) -> str
+
+@native("base64")
+function encode_bytes_url_safe(input: List<u8>) -> str
+
+@native("base64")
+function decode_bytes(input: str) -> Result<List<u8>, Error>
+
+@native("base64")
+function decode_bytes_url_safe(input: str) -> Result<List<u8>, Error>

--- a/src/codegen_call_base64.cpp
+++ b/src/codegen_call_base64.cpp
@@ -1,0 +1,38 @@
+#include "ry/codegen.hpp"
+#include "ry/stdlib_registry.hpp"
+
+
+namespace ry {
+
+static constexpr const char *BASE64_ERR = "__ry_base64_get_last_error";
+
+static const CodeGen::NativeDispatchEntry base64_table[] = {
+    // str → str / Result<str, Error>
+    {"encode",               nullptr, CodeGen::ReturnWrapping::Direct,    1, nullptr,
+     nullptr, "__ry_base64_encode",               nullptr,    CodeGen::ListElemMeta::None, -1},
+    {"decode",               nullptr, CodeGen::ReturnWrapping::ResultPtr, 1, nullptr,
+     nullptr, "__ry_base64_decode",               BASE64_ERR, CodeGen::ListElemMeta::None, -1},
+    {"encode_url_safe",      nullptr, CodeGen::ReturnWrapping::Direct,    1, nullptr,
+     nullptr, "__ry_base64_encode_url_safe",      nullptr,    CodeGen::ListElemMeta::None, -1},
+    {"decode_url_safe",      nullptr, CodeGen::ReturnWrapping::ResultPtr, 1, nullptr,
+     nullptr, "__ry_base64_decode_url_safe",      BASE64_ERR, CodeGen::ListElemMeta::None, -1},
+
+    // List<u8> → str
+    {"encode_bytes",          nullptr, CodeGen::ReturnWrapping::Direct,    1, nullptr,
+     nullptr, "__ry_base64_encode_bytes",          nullptr,    CodeGen::ListElemMeta::None, 0},
+    {"encode_bytes_url_safe", nullptr, CodeGen::ReturnWrapping::Direct,    1, nullptr,
+     nullptr, "__ry_base64_encode_bytes_url_safe", nullptr,    CodeGen::ListElemMeta::None, 0},
+
+    // str → Result<List<u8>, Error>
+    {"decode_bytes",          nullptr, CodeGen::ReturnWrapping::ResultPtr, 1, nullptr,
+     nullptr, "__ry_base64_decode_bytes",          BASE64_ERR, CodeGen::ListElemMeta::I8,  -1},
+    {"decode_bytes_url_safe", nullptr, CodeGen::ReturnWrapping::ResultPtr, 1, nullptr,
+     nullptr, "__ry_base64_decode_bytes_url_safe", BASE64_ERR, CodeGen::ListElemMeta::I8,  -1},
+};
+
+RY_REGISTER_STDLIB_PACKAGE(base64, "share/std/base64/base64.ry", dispatchBase64)
+static llvm::Value *dispatchBase64(CodeGen &cg, const CallExpr &e) {
+    return cg.emitTableDrivenNativeCall(e, "base64", base64_table, std::size(base64_table));
+}
+
+} // namespace ry

--- a/src/runtime_base64.cpp
+++ b/src/runtime_base64.cpp
@@ -1,5 +1,6 @@
 #include "ry/runtime_alloc.hpp"
 #include "ry/runtime_error.hpp"
+#include "ry/runtime_io.hpp"
 #include "ry/runtime_string.hpp"
 
 #include <cstdint>
@@ -71,14 +72,14 @@ static char *base64_encode_impl(const char *input, size_t len, const char *table
     return out;
 }
 
-static char *base64_decode_impl(const char *input, size_t len, const int8_t *decode_tbl) {
-    // Strip trailing padding
+// Core decode: writes decoded bytes into a heap buffer. Caller must free().
+// Returns nullptr + setLastError on invalid input; writes byte count to *out_len on success.
+static uint8_t *base64_decode_raw(const char *input, size_t len,
+                                   const int8_t *decode_tbl, size_t *out_len) {
     while (len > 0 && input[len - 1] == '=')
         len--;
 
-    size_t out_cap = len * 3 / 4;
-    // Use a plain temp buffer; wrap with makeString at the end.
-    char *out = (char *)checked_malloc(out_cap + 1);
+    auto *out = (uint8_t *)checked_malloc(len * 3 / 4 + 1);
     size_t j = 0;
 
     for (size_t i = 0; i < len; ) {
@@ -100,12 +101,20 @@ static char *base64_decode_impl(const char *input, size_t len, const int8_t *dec
             return nullptr;
         }
         uint32_t triple = (sextet[0] << 18) | (sextet[1] << 12) | (sextet[2] << 6) | sextet[3];
-        if (count >= 2) out[j++] = (char)((triple >> 16) & 0xFF);
-        if (count >= 3) out[j++] = (char)((triple >> 8) & 0xFF);
-        if (count >= 4) out[j++] = (char)(triple & 0xFF);
+        if (count >= 2) out[j++] = (uint8_t)((triple >> 16) & 0xFF);
+        if (count >= 3) out[j++] = (uint8_t)((triple >> 8) & 0xFF);
+        if (count >= 4) out[j++] = (uint8_t)(triple & 0xFF);
     }
-    char *result = makeString(out, j);
-    free(out);
+    *out_len = j;
+    return out;
+}
+
+static char *base64_decode_impl(const char *input, size_t len, const int8_t *decode_tbl) {
+    size_t j;
+    auto *raw = base64_decode_raw(input, len, decode_tbl, &j);
+    if (!raw) return nullptr;
+    char *result = makeString(reinterpret_cast<const char *>(raw), j);
+    free(raw);
     return result;
 }
 
@@ -143,6 +152,46 @@ extern "C" const char *__ry_base64_decode_url_safe(const char *input) {
     if (auto *r = empty_guard(input, &len)) return r;
     ensure_decode_tables();
     return base64_decode_impl(input, len, url_decode_tbl);
+}
+
+// ===== List<u8> variants =====
+
+extern "C" const char *__ry_base64_encode_bytes(void *list) {
+    auto *header = (IOListHeader *)list;
+    if (header->len == 0) return makeString("", 0);
+    return base64_encode_impl(reinterpret_cast<const char *>(header->data),
+                              static_cast<size_t>(header->len), std_table, true);
+}
+
+extern "C" const char *__ry_base64_encode_bytes_url_safe(void *list) {
+    auto *header = (IOListHeader *)list;
+    if (header->len == 0) return makeString("", 0);
+    return base64_encode_impl(reinterpret_cast<const char *>(header->data),
+                              static_cast<size_t>(header->len), url_table, false);
+}
+
+extern "C" void *__ry_base64_decode_bytes(const char *input) {
+    size_t len = static_cast<size_t>(stringByteLen(input));
+    if (len == 0) return makeEmptyIOList();
+    ensure_decode_tables();
+    size_t out_len;
+    auto *raw = base64_decode_raw(input, len, std_decode_tbl, &out_len);
+    if (!raw) return nullptr;
+    IOListHeader *hdr = makeByteList(raw, static_cast<int64_t>(out_len));
+    free(raw);
+    return hdr;
+}
+
+extern "C" void *__ry_base64_decode_bytes_url_safe(const char *input) {
+    size_t len = static_cast<size_t>(stringByteLen(input));
+    if (len == 0) return makeEmptyIOList();
+    ensure_decode_tables();
+    size_t out_len;
+    auto *raw = base64_decode_raw(input, len, url_decode_tbl, &out_len);
+    if (!raw) return nullptr;
+    IOListHeader *hdr = makeByteList(raw, static_cast<int64_t>(out_len));
+    free(raw);
+    return hdr;
 }
 
 } // namespace ry

--- a/tests/spec/base64.test.ry
+++ b/tests/spec/base64.test.ry
@@ -1,4 +1,4 @@
-from base64 import encode, decode, encode_url_safe, decode_url_safe
+from base64 import encode, decode, encode_url_safe, decode_url_safe, encode_bytes, encode_bytes_url_safe, decode_bytes, decode_bytes_url_safe
 
 describe("base64", ():
   describe("encode", ():
@@ -97,6 +97,113 @@ describe("base64", ():
       case decode(encode(original)):
         Ok(s):
           expect(s).to_eq(original)
+        Err(e):
+          fail("unexpected error: " + e.message)
+    )
+  )
+
+  describe("encode_bytes", ():
+    it("should encode known byte vector", ():
+      # [0x48, 0x69] = "Hi" -> "SGk="
+      expect(encode_bytes([0x48u8, 0x69u8])).to_eq("SGk=")
+    )
+    it("should encode JPEG magic bytes", ():
+      # [0xFF, 0xD8, 0xFF, 0xE0] -> "/9j/4A=="
+      expect(encode_bytes([0xFFu8, 0xD8u8, 0xFFu8, 0xE0u8])).to_eq("/9j/4A==")
+    )
+    it("should encode empty list", ():
+      empty: List<u8> = []
+      expect(encode_bytes(empty)).to_eq("")
+    )
+    it("should encode NUL-containing bytes", ():
+      # [0x00, 0xFF, 0x00] -> "AP8A"
+      expect(encode_bytes([0x00u8, 0xFFu8, 0x00u8])).to_eq("AP8A")
+    )
+  )
+
+  describe("encode_bytes_url_safe", ():
+    it("should use - and _ instead of + and /", ():
+      # [0xFB, 0xFF] -> standard "+/w=", url_safe "-_w"
+      b = [0xFBu8, 0xFFu8]
+      std_enc = encode_bytes(b)
+      url_enc = encode_bytes_url_safe(b)
+      expect(contains(std_enc, "+")).to_eq(true)
+      expect(contains(url_enc, "+")).to_eq(false)
+      expect(contains(url_enc, "/")).to_eq(false)
+      expect(contains(url_enc, "=")).to_eq(false)
+    )
+    it("should encode empty list", ():
+      empty: List<u8> = []
+      expect(encode_bytes_url_safe(empty)).to_eq("")
+    )
+  )
+
+  describe("decode_bytes", ():
+    it("should decode to known bytes", ():
+      case decode_bytes("SGk="):
+        Ok(b):
+          expect(b).to_eq([0x48u8, 0x69u8])
+        Err(e):
+          fail("unexpected error: " + e.message)
+    )
+    it("should decode NUL-containing bytes", ():
+      case decode_bytes("AP8A"):
+        Ok(b):
+          expect(b).to_eq([0x00u8, 0xFFu8, 0x00u8])
+        Err(e):
+          fail("unexpected error: " + e.message)
+    )
+    it("should decode empty string", ():
+      case decode_bytes(""):
+        Ok(b):
+          empty: List<u8> = []
+          expect(b).to_eq(empty)
+        Err(e):
+          fail("unexpected error: " + e.message)
+    )
+    it("should return error for invalid base64", ():
+      case decode_bytes("!!!"):
+        Ok(b):
+          fail("expected error but got Ok")
+        Err(e):
+          expect(e.message).to_contain("invalid")
+    )
+  )
+
+  describe("decode_bytes_url_safe", ():
+    it("should decode url_safe encoded bytes", ():
+      # "-_8" is the URL-safe base64 encoding of [0xFB, 0xFF]
+      case decode_bytes_url_safe("-_8"):
+        Ok(b):
+          expect(b).to_eq([0xFBu8, 0xFFu8])
+        Err(e):
+          fail("unexpected error: " + e.message)
+    )
+    it("should return error for invalid input", ():
+      case decode_bytes_url_safe("!!!"):
+        Ok(b):
+          fail("expected error but got Ok")
+        Err(e):
+          expect(e.message).to_contain("invalid")
+    )
+  )
+
+  describe("bytes roundtrip", ():
+    it("should roundtrip binary bytes through standard base64", ():
+      original: List<u8> = [0x00u8, 0x01u8, 0x7Fu8, 0x80u8, 0xFFu8]
+      encoded = encode_bytes(original)
+      case decode_bytes(encoded):
+        Ok(b):
+          expect(b).to_eq(original)
+        Err(e):
+          fail("unexpected error: " + e.message)
+    )
+    it("should roundtrip binary bytes through url_safe base64", ():
+      original: List<u8> = [0xFBu8, 0xFFu8, 0x00u8, 0x01u8]
+      encoded = encode_bytes_url_safe(original)
+      case decode_bytes_url_safe(encoded):
+        Ok(b):
+          expect(b).to_eq(original)
         Err(e):
           fail("unexpected error: " + e.message)
     )

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -371,3 +371,26 @@ TEST_F(CodeGenTest, NoneWithArgsIsRejected) {
     expectCompileError("x: int? = None(1)\n",
                        "None() takes no arguments");
 }
+
+// ============================================================
+// base64.encode_bytes / encode_bytes_url_safe reject non-u8 list
+// at compile time via requireListU8Arg gate (#1130)
+// ============================================================
+
+TEST_F(CodeGenTest, Base64EncodeBytesRejectsNonU8List) {
+    expectCompileError(
+        "@native(\"base64\")\n"
+        "function encode_bytes(input: List<int>) -> str\n"
+        "xs: List<int> = [1, 2, 3]\n"
+        "print(encode_bytes(xs))\n",
+        "requires List<u8>");
+}
+
+TEST_F(CodeGenTest, Base64EncodeBytesUrlSafeRejectsNonU8List) {
+    expectCompileError(
+        "@native(\"base64\")\n"
+        "function encode_bytes_url_safe(input: List<int>) -> str\n"
+        "xs: List<int> = [1, 2, 3]\n"
+        "print(encode_bytes_url_safe(xs))\n",
+        "requires List<u8>");
+}


### PR DESCRIPTION
## Summary

- `encode_bytes(List<u8>) -> str` / `encode_bytes_url_safe(List<u8>) -> str` を追加 — JPEG マジックバイトなどの任意バイナリを `str` 経由なしで base64 エンコード
- `decode_bytes(str) -> Result<List<u8>, Error>` / `decode_bytes_url_safe(str) -> Result<List<u8>, Error>` を追加 — NUL バイトを含む生バイト列として base64 をデコード
- `base64_decode_raw` ヘルパを抽出して str/bytes 版でデコードロジックを共有
- `requireListU8Arg = 0` によるコンパイル時型ガード（`List<i64>` 等の誤用を compile error で弾く）
- `encode_bytes` 系は `header->len`、`decode_bytes` 系は `stringByteLen` を使用し、`strlen` NUL バグを新 API 側に持ち込まない

## Test plan

- [ ] `tests/spec/base64.test.ry` — 36 テスト全通過（既存 15 + NUL safety 7 + bytes 系 14）
- [ ] compile-time gate: `encode_bytes(bad: List<i64>)` → `error: encode_bytes() requires List<u8> as argument 0`
- [ ] `./build/ry_tests` — C++ テスト全通過
- [ ] `./build/ry test -p` — 143 ファイル全通過
- [ ] ASan + UBSan: `ry_tests` および `ry test -p` クリーン
- [ ] TSan: `ry_tests` 1799 テスト全通過

Closes #1130

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Base64 encode/decode APIs for raw binary byte data with standard and URL-safe variants, preserving arbitrary bytes (including NUL/non-UTF-8).

* **Documentation**
  * Added reference docs, examples, and a “Working with Byte Data” section for the new byte-oriented Base64 APIs.
  * Added testing guidance to run stdlib tests from the project root to avoid module resolution pitfalls.

* **Tests**
  * Expanded and added unit and compile-fail tests covering byte-oriented Base64 behavior and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->