### PR TITLE
fix(thread): update @native declarations for thread_spawn/thread_join to use `any` (#1135)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2235,6 +2235,46 @@ drift.
 
 ---
 
+### For heterogeneous return types on custom-emitter natives, use `any` as the declaration placeholder
+
+**Source**: #1135
+**Tags**: `stdlib, @native, codegen, type-declaration, hygiene`
+
+When a custom-emitter native can return multiple concrete types at runtime
+(e.g. `thread_spawn` / `thread_join` which return `Unit`, `int`, `float`,
+or `bool` depending on the worker body), the declaration in
+`share/std/**/*.ry` cannot use a true generic — several options fail:
+
+| Option | Why it fails |
+|---|---|
+| `<T>` generic | `src/codegen_fn.cpp:471-481` diverts any function with `type_params` into `generic_fn_templates_` and returns early — no `NativeFnSignature` is registered, breaking dispatch |
+| Bare `T` at top-level | `src/codegen_type.cpp:160-162`: `resolveType` fails for unbound identifier |
+| `function() -> T` nested | Parser free-pass (interior not validated), but the identifier is semantically meaningless — fragile |
+| Overloads differing only in return type | `src/codegen_fn.cpp:531-545` dedupes on param types only; the second declaration is silently dropped |
+
+**Rule**: Use `any` as the hygienic placeholder. `any` resolves cleanly via
+`src/codegen_type.cpp:23` at both top-level and generic argument positions
+(e.g. `Result<any, Error>`, `function() -> any`). The custom emitter still
+drives actual runtime type dispatch through `TypeMeta` metadata — `any` in
+the declaration is never consulted at codegen time.
+
+**Precedent for `any` at generic argument position**: `tests/spec/any.test.ry`
+uses `Map<str, any>` and `List<any>` in 30+ places; `src/parser_decl.cpp:159`
+uses `any` as the default element type for inferred collections. `Result<any, Error>`
+was introduced by #1135 as a new pattern, but the surrounding type machinery
+already handled `any` as a generic argument.
+
+**Annotation in the `.ry` file**: Add a top-of-file comment explaining the
+`any` ↔ `T` spelling gap, e.g.:
+```
+# `any` in thread_spawn / thread_join declarations below stands in for `T`
+# in docs/reference/thread.md. The runtime narrows the actual type to
+# Unit / int / float / bool via TypeMeta::ThreadResult metadata.
+```
+This prevents future readers from "fixing" `any` back to `Unit`.
+
+---
+
 ### Ry has soft keywords that are NOT in the lexer `keyword_map`
 
 **Source**: #1118 PR 1 docs audit

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2266,7 +2266,7 @@ already handled `any` as a generic argument.
 
 **Annotation in the `.ry` file**: Add a top-of-file comment explaining the
 `any` ↔ `T` spelling gap, e.g.:
-```
+```ry
 # `any` in thread_spawn / thread_join declarations below stands in for `T`
 # in docs/reference/thread.md. The runtime narrows the actual type to
 # Unit / int / float / bool via TypeMeta::ThreadResult metadata.

--- a/changelog.d/1135-thread-native-decl.md
+++ b/changelog.d/1135-thread-native-decl.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- thread: align `thread_spawn` / `thread_join` `@native` declarations with their runtime behaviour (supports `int` / `float` / `bool` workers in addition to `Unit`) by using `any` as the declaration-level placeholder (#1135)

--- a/share/std/thread/thread.ry
+++ b/share/std/thread/thread.ry
@@ -1,9 +1,14 @@
+# `any` in thread_spawn / thread_join declarations below stands in for `T`
+# in docs/reference/thread.md. The runtime narrows the actual type to
+# Unit / int / float / bool via TypeMeta::ThreadResult metadata (see
+# src/codegen_call_thread.cpp).
+
 # Thread — spawn and join OS threads
 @native("thread")
-function thread_spawn(body: function() -> Unit) -> Thread
+function thread_spawn(body: function() -> any) -> Thread
 
 @native("thread")
-function thread_join(thread: Thread) -> Result<Unit, Error>
+function thread_join(thread: Thread) -> Result<any, Error>
 
 # Lock (mutex)
 @native("thread")


### PR DESCRIPTION
## Summary

- `share/std/thread/thread.ry` was declaring `thread_spawn(body: function() -> Unit) -> Thread` and `thread_join(thread: Thread) -> Result<Unit, Error>`, but the custom emitter (`src/codegen_call_thread.cpp`) already correctly handles workers returning `int`, `float`, and `bool` via `TypeMeta::ThreadResult` metadata
- Replaces `Unit` with `any` as the hygienic declaration-level placeholder, aligning the `.ry` file with `docs/reference/thread.md` (which correctly uses `T`) and the actual runtime behaviour
- Adds a top-of-file comment in `share/std/thread/thread.ry` explaining the `any` ↔ `T` mapping so future readers don't "fix" `any` back to `Unit`
- Adds a `KNOWLEDGE.md` entry documenting why generic `<T>`, bare `T`, and overload-by-return-type are all non-viable for custom-emitter natives with heterogeneous return types

## Test plan

- [x] Existing 18 thread spec tests (`tests/spec/thread.test.ry`) all pass, including `int`/`float`/`bool` worker cases (#828 MVP, lines 188–253)
- [x] Other spec files using `thread_spawn`/`thread_join` (`for_mutation.test.ry`, `for_mutation_field.test.ry`, `concurrency_stress.test.ry`, `resource_arc.test.ry`) pass unchanged
- [x] Full suite: 1802 C++ GoogleTest + 143 Ry self-test files — 0 failures
- [x] ASan + UBSan: 1802 + 143 — clean
- [x] TSan: 1802 + 143 — clean
- [x] `grep -rn "function() -> Unit" share/std/` — no remaining drift in thread declarations
- [x] `git diff share/std/thread/thread.ry` — exactly a 4-line comment block + two `Unit` → `any` edits

Closes #1135

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Worker thread API updated to reflect actual runtime behavior: thread results may now be int, float, or bool (in addition to Unit) by using a generic placeholder type.

* **Documentation**
  * Added guidance documenting the placeholder usage and a note warning not to rely on it for runtime dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->