### PR TITLE
chore: git-claim-issue skill を追加して wip ラベル運用を skill 化 (#1144)

### DIFF
--- a/.claude/skills/git-claim-issue/SKILL.md
+++ b/.claude/skills/git-claim-issue/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: git-claim-issue
+description: Claim a GitHub issue by safely adding the `wip` label without erasing existing labels. Use when starting work on an issue, e.g. "start working on #123", "claim issue 456", "issue に取り組む", "wip つけて", "着手".
+allowed-tools: Bash(gh issue view:*), Bash(gh issue edit:*)
+metadata:
+  short-description: Add wip label to an issue without clobbering other labels
+---
+
+# Git Claim Issue
+
+Mark a GitHub issue as in-progress by adding the `wip` label. This is the counterpart of `git-merge-pr` Step 5, which removes `wip` after merge.
+
+## When to use
+
+- At the start of issue-driven development, before entering Plan mode
+- When the user says 「取り組む」 / 「着手」 / "start working" / "claim" / 「wip つけて」 for a specific issue
+- Whenever AGENTS.md "Plan モード開始条件" requires confirmation that `wip` is attached
+
+## Repository
+
+- owner: `t0k0sh1`
+- repo: `ry`
+
+## Inputs
+
+User input: `$ARGUMENTS` (issue number, e.g. `907` or `#907`)
+
+If no issue number is supplied, ask the user before proceeding. Do NOT guess.
+
+## Critical safety rule
+
+Always use `--add-label`. **Never** use `--label` with `gh issue edit`:
+
+| Command | Effect |
+|---|---|
+| `gh issue edit <n> --label wip` | **Replaces all labels** (destructive — do NOT use) |
+| `gh issue edit <n> --add-label wip` | Appends, preserves existing labels (correct) |
+| `gh issue edit <n> --remove-label wip` | Removes only the named label (used by `git-merge-pr`) |
+
+Note: `gh issue create --label foo` is safe because there are no pre-existing labels to overwrite. The destructive case applies only to `gh issue edit --label`.
+
+Violating this rule wipes labels such as `bug`, `enhancement`, milestone-shadow labels, etc.
+
+## Steps
+
+### Step 1: Read current labels
+
+```bash
+gh issue view <n> --json number,title,state,labels --jq '{number, title, state, labels: [.labels[].name]}'
+```
+
+- If `state` is not `OPEN`, report to the user and stop.
+- Record the current label array as `BEFORE`.
+
+### Step 2: Idempotency check
+
+- If `BEFORE` already contains `wip`, report "issue #<n> is already claimed (wip present). No change." and stop. Do NOT re-run `gh issue edit`.
+
+### Step 3: Add the `wip` label
+
+```bash
+gh issue edit <n> --add-label wip
+```
+
+Do not pass any other flags. Do not combine with `--remove-label` or `--milestone` in the same invocation.
+
+### Step 4: Verify
+
+```bash
+gh issue view <n> --json labels --jq '[.labels[].name]'
+```
+
+Record as `AFTER`. Assert:
+- `wip` ∈ `AFTER`
+- `BEFORE ⊆ AFTER` (every label present before is still present)
+
+If either assertion fails, STOP and report the diff to the user. Do not attempt automatic rollback; the user decides.
+
+### Step 5: Report
+
+Report to the user: issue number, title, `BEFORE` labels, `AFTER` labels, and confirmation that `wip` was added.

--- a/.claude/skills/git-merge-pr/SKILL.md
+++ b/.claude/skills/git-merge-pr/SKILL.md
@@ -58,13 +58,33 @@ gh api graphql -f query='{ repository(owner: "<owner>", name: "<repo>") { pullRe
 
 Execute `gh pr merge <PR> --merge --delete-branch`
 
-### Step 5: Non-default branch warning
+### Step 5: Post-merge issue cleanup
 
-Using the `defaultBranchRef.name` from Step 3, compare the PR's `baseRefName` against it:
-- If the base branch is **not** the default branch (e.g. merging into `v0.0.8` when the default is `main`):
-  > **Note**: This PR was merged into `<baseRefName>`, not the default branch `<defaultBranch>`. GitHub's `Closes #xx` auto-close does not work for non-default branches. Remember to:
-  > - Manually close the related issue
-  > - Remove the `wip` label from the issue
+Identify the linked issue number `<n>` from the PR body (`Closes #<n>` / `Fixes #<n>` / `Refs #<n>`) or from the branch name. If no linked issue can be determined, skip this step and note it in the report.
+
+**Always run** (regardless of base branch):
+
+```bash
+gh issue edit <n> --remove-label wip
+```
+
+Use `--remove-label`. **Never** use `--label` alone — it would replace all existing labels with an empty set, destroying `bug`, `enhancement`, etc. Verify with:
+
+```bash
+gh issue view <n> --json labels --jq '[.labels[].name]'
+```
+
+Confirm `wip` is gone and every other pre-existing label is still present.
+
+If the base branch (`baseRefName` from Step 2) is **not** the default branch (from Step 3's `defaultBranchRef.name`), GitHub's `Closes #xx` auto-close does not fire. Additionally run:
+
+```bash
+gh issue close <n>
+```
+
+Verify with `gh issue view <n> --json state --jq .state` returning `CLOSED`.
+
+Execute this step autonomously, immediately after merge, without waiting for user confirmation.
 
 ### Step 6: Report
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry test -p    
 ## ワークフロー全体像
 
 1. **issue 確認** — 対象 issue の内容を把握する
-2. **`wip` ラベル付与** — 対象 issue に `wip` ラベルを付ける
+2. **issue クレーム** — `git-claim-issue` スキルを起動し、対象 issue に `wip` ラベルを付与する
 3. **KNOWLEDGE.md 参照** — 関連しそうな既存エントリを grep して一読する
 4. **Plan モード** — 実装計画を立てる
 5. **実装** — TDD ベースで開発する
@@ -177,9 +177,9 @@ TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry test -p    
   - ユーザーが issue 番号または URL を指定 → GitHub MCP で issue を読み取り、内容を把握して Plan モードへ
   - ユーザーが「次の issue を探して」と指示 → open な issue を取得し（`wip` ラベル付きは除外）、バグ優先・効果の高い改善を優先して候補を提示、ユーザーが選択後に Plan モードへ
 - **Plan モードとの接続**: issue の内容を仕様として Plan に反映する
-- **ラベル運用**:
-  - issue に着手する時点で `wip` ラベルを付与する
-  - `wip` ラベルの除去と issue クローズは **PR マージ後** に行う（詳細は「作業完了前チェックリスト > 4. ラベル整理」）
+- **ラベル運用**: 付与・除去は必ずスキル経由で行う
+  - 着手時: `git-claim-issue` スキルを起動（`--add-label` を使用、既存ラベルを保持）
+  - PR マージ後: `git-merge-pr` スキル Step 5（`--remove-label` を使用、非デフォルトブランチ時は `gh issue close` も実行）
 
 ## Plan モードのルール
 
@@ -334,7 +334,7 @@ echo 'print(1)' | ./build/ry --trace -c
 - テスト実行
 - セルフ検証
 - ドキュメント更新
-- PR マージ後の issue クローズと `wip` ラベル除去（マージ完了直後に実行、ユーザーの指示を待たない）
+- PR マージ後の issue クローズと `wip` ラベル除去（`git-merge-pr` Step 5 に集約。マージ完了直後に自律実行、ユーザーの指示を待たない）
 
 #### スコープ外の問題を発見した場合の対応ルール
 
@@ -482,10 +482,7 @@ C++ TSan テスト (`ry_tests`) は required で、`ConcurrencySpecSuite` (= `te
 
 ### 4. ラベル整理
 
-**セルフ検証完了時点ではラベルを変更しない。** ラベルの切り替えは PR マージ後に行う:
-- PR がマージされたら、Claude Code が自律的に対象 issue の `wip` ラベルを外し issue をクローズする
-- PR を非デフォルトブランチ（`vx.x.x` 等）にマージした場合、GitHub の `Closes #xx` による自動クローズは動作しないため、Claude Code が GitHub API で issue をクローズすること
-- この操作はマージ完了の直後に必ず実行し、ユーザーの指示を待たない
+**セルフ検証完了時点ではラベルを変更しない。** ラベルの切り替えは PR マージ後、`git-merge-pr` スキル Step 5 が自律的に処理する（`wip` 除去・非デフォルトブランチ時の `gh issue close`）。個別コマンドを直接実行しない。
 
 ## リリース準備ワークフロー
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2442,7 +2442,22 @@ write a 3-line entry under this section with a descriptive subheading.
 
 **Why**: `./build/ry` resolves the stdlib path via `package.toml`'s hidden `[paths]._dev_stdlib` key, which requires a `package.toml` somewhere in the ancestor directory chain. Files under `/tmp/` have no such ancestor, so the module loader falls back to `~/.ry/share/std` (the globally-installed stdlib), which does not contain the newly added declarations. The trace event to look for: `"resolved_path":"/Users/.../.ry/share/std"` instead of `"resolved_path":"/Users/.../Workspace/ry-2/share/std"`.
 
-*(specific entries to be added as they are encountered)*
+### `gh issue edit --label` replaces all labels; use `--add-label` / `--remove-label`
+
+**Source**: #1144 (2026-04-18)
+**Tags**: gh, issue, label, wip, workflow
+
+**Wrong**: `gh issue edit <n> --label wip`
+→ **Replaces** the entire label set with `["wip"]`. All other labels (`bug`, `enhancement`, milestone-shadow labels, etc.) are silently deleted.
+
+**Correct**:
+- Add a label: `gh issue edit <n> --add-label wip`
+- Remove a label: `gh issue edit <n> --remove-label wip`
+- Create with labels (safe — no pre-existing labels): `gh issue create --label enhancement --label documentation`
+
+**Why**: `--label` in `gh issue edit` is a *set* operation, not an *append*. The flag name is misleading because `gh issue create --label` is safe (empty initial state). The asymmetry bites every time you remember the create syntax and apply it to edit.
+
+**How to apply**: Use `git-claim-issue` skill for `wip` attachment (enforces `--add-label` internally). Use `git-merge-pr` Step 5 for `wip` removal (enforces `--remove-label` internally). Never call `gh issue edit --label` directly for additive changes.
 
 ---
 


### PR DESCRIPTION
## Summary

- `git-claim-issue` skill を新設 — `--add-label` 強制・BEFORE/AFTER ラベル検証・idempotency チェック付きで `wip` ラベルを安全に付与
- `git-merge-pr` Step 5 を「Post-merge issue cleanup」に改名し、`--remove-label wip` コマンドと非デフォルトブランチ時の `gh issue close` を明示
- `AGENTS.md` の wip 関連 5 箇所を skill 参照にスリム化（how-to を skill に一本化）
- `KNOWLEDGE.md` に `gh issue edit --label`（全置換・破壊的）vs `--add-label`（追加・安全）の pitfall エントリを追加

Closes #1144

## Test plan

- [ ] `git-claim-issue` skill frontmatter が既存 skill と同形式であることを目視確認
- [ ] `rg -n 'wip|--label|--add-label|--remove-label' AGENTS.md .claude/skills/ KNOWLEDGE.md` で AGENTS.md 側に how-to が残らず、skill 側に `--add-label` / `--remove-label` が明記されていることを確認
- [ ] issue #1144 に対して skill を起動し、idempotency パス（既に `wip` 付き）が正しく動作することを確認