### PR TITLE
fix: @it/@describe の戻り値型注釈を compile error に格上げ (#1122)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -129,6 +129,17 @@ git diff origin/<base> -- 'src/**' 'include/**' \
 
 For each hit, confirm a test exists that executes that exact line.
 
+### Use `-> Unit` in @it/@describe rejection tests to isolate the directive check
+
+**Source**: #1122 (2026-04-18, implementation)
+**Tags**: testing, directives, codegen-test
+
+**Rule**: When writing a C++ rejection test for `@it` or `@describe` return-type enforcement, use `-> Unit` as the return type annotation — not `-> int`, `-> bool`, `-> str`, etc.
+
+**Why**: If the test function body (e.g. `expect(1).to_eq(1)`) doesn't return a value of the declared type, codegen fires a secondary error — "function does not return a value on all code paths" — **before** the directive check. The test then passes even if the directive enforcement is removed, silently breaking the regression guard.
+
+`-> Unit` is safe because `expect(...)` naturally returns `Unit`, so the body satisfies the return type. The only path that throws is the directive enforcement itself.
+
 ### ARC leak regression tests use `runtime_internal.arc_live_count()` delta assertions
 
 **Source**: #859 (2026-04-16, implementation)

--- a/changelog.d/1122-enforce-return-type.md
+++ b/changelog.d/1122-enforce-return-type.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `@it` and `@describe` functions with a return type annotation now produce a compile error instead of silently ignoring the annotation (#1122)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -319,6 +319,7 @@ function test_commutative(a: int, b: int):
 
 **Constraints:**
 - Only valid in `*.test.ry` files executed with `ry test`
+- The function must not have a return type annotation
 - When combined with `@each`, the function's parameter list must match the tuple arity
 - When combined with `@property`, each parameter type must be one of the supported generator types (`int`, `float`, `bool`, `str`)
 
@@ -381,7 +382,7 @@ function outer():
             expect(1 + 1).to_eq(2)
 ```
 
-**Supported target:** `function` declarations only. The function must not have parameters.
+**Supported target:** `function` declarations only. The function must not have parameters or a return type annotation.
 
 ### `@inline`
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -63,6 +63,7 @@ function arithmetic_tests():
 - The function name is used for code navigation and symbol identity
 - The description string (in the directive) is used for test output and reporting
 - `@it` functions must have no parameters unless combined with `@each` or `@property`
+- `@it` and `@describe` functions must not have a return type annotation
 - Both `@it` and `@describe` are only available with `ry test`
 
 #### Shared Setup

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -520,6 +520,8 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
         codegenError("@it: function '" + s->name + "' cannot be async");
     if (!s->type_params.empty())
         codegenError("@it: function '" + s->name + "' cannot be generic");
+    if (s->return_type)
+        codegenError("@it: function '" + s->name + "' cannot have a return type annotation");
 
     if (hasDirective(s->directives, "each")) {
         emitEachItDirective(s);
@@ -648,6 +650,8 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
         codegenError("@describe: function '" + s->name + "' cannot be generic");
     if (!s->params.empty())
         codegenError("@describe: function '" + s->name + "' cannot have parameters");
+    if (s->return_type)
+        codegenError("@describe: function '" + s->name + "' cannot have a return type annotation");
 
     std::string desc = getDirectivePositionalArg(s->directives, "describe");
     llvm::Value *descVal = cachedGlobalString(desc, ".describe_desc");

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1016,6 +1016,84 @@ TEST_F(DirectiveTest, DescribeDirectiveRejectsParams) {
     );
 }
 
+// @it on a function with a return type annotation should error.
+// Uses -> Unit so the body naturally returns Unit — the only throw is from @it enforcement,
+// not from the secondary "does not return a value on all code paths" check.
+TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeAnnotation) {
+    EXPECT_THROW(
+        []() {
+            Lexer lex(
+                "@it(\"bad\")\n"
+                "function test_with_ret() -> Unit:\n"
+                "    expect(1).to_eq(1)\n"
+            );
+            Parser parser(lex);
+            Program prog = parser.parseProgram();
+            CodeGen cg(true);
+            cg.compile(prog);
+        }(),
+        std::runtime_error
+    );
+}
+
+// @each @it on a function with a return type annotation should error.
+TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnEach) {
+    EXPECT_THROW(
+        []() {
+            Lexer lex(
+                "@each([(1, 2)])\n"
+                "@it(\"bad each {0} {1}\")\n"
+                "function test_each(a: int, b: int) -> Unit:\n"
+                "    expect(a).to_eq(b)\n"
+            );
+            Parser parser(lex);
+            Program prog = parser.parseProgram();
+            CodeGen cg(true);
+            cg.compile(prog);
+        }(),
+        std::runtime_error
+    );
+}
+
+// @property @it on a function with a return type annotation should error.
+TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnProperty) {
+    EXPECT_THROW(
+        []() {
+            Lexer lex(
+                "@property(count=10)\n"
+                "@it(\"bad property\")\n"
+                "function test_prop(a: int) -> Unit:\n"
+                "    expect(a).to_eq(a)\n"
+            );
+            Parser parser(lex);
+            Program prog = parser.parseProgram();
+            CodeGen cg(true);
+            cg.compile(prog);
+        }(),
+        std::runtime_error
+    );
+}
+
+// @describe on a function with a return type annotation should error.
+TEST_F(DirectiveTest, DescribeDirectiveRejectsReturnTypeAnnotation) {
+    EXPECT_THROW(
+        []() {
+            Lexer lex(
+                "@describe(\"group\")\n"
+                "function grp() -> Unit:\n"
+                "    @it(\"sub\")\n"
+                "    function t():\n"
+                "        expect(1).to_eq(1)\n"
+            );
+            Parser parser(lex);
+            Program prog = parser.parseProgram();
+            CodeGen cg(true);
+            cg.compile(prog);
+        }(),
+        std::runtime_error
+    );
+}
+
 // @describe nested inside @describe: inner @it functions run under the outer group header
 TEST_F(DirectiveTest, DescribeDirectiveNestedDescribe) {
     EXPECT_EQ(runTestSource(


### PR DESCRIPTION
## Summary

- `@it` / `@describe` に戻り値型注釈（`-> T`）がある場合、これまで暗黙的に無視されていたが、`codegenError` で明示的に拒否するように変更
- `cannot be async` / `cannot be generic` / `cannot have parameters` と同じ UX パターンに統一
- スコープ: `@it`（基本形 / `@each @it` / `@property @it`）と `@describe` のみ

## Changes

- **`src/codegen_test.cpp`**: `emitItDirective` / `emitDescribeDirective` に `return_type` チェックを追加（2箇所）
- **`tests/test_codegen_directive.cpp`**: reject テスト 4 件追加（`-> Unit` を使用し secondary codegen check を回避）
- **`docs/reference/directives.md`**: `@it` / `@describe` の制約に戻り値型注釈禁止を復元
- **`docs/reference/testing.md`**: 戻り値型制約の 1 文追記
- **`changelog.d/1122-enforce-return-type.md`**: Changed エントリ作成
- **`KNOWLEDGE.md`**: `-> Unit` テスト選択の理由を追記

## Test plan

- [x] `./build/ry_tests --gtest_filter='DirectiveTest.*'` — 69 tests pass（新規 4 件含む）
- [x] `./build/ry_tests` — 1804 tests pass
- [x] `./build/ry test -p` — 143 test files pass
- [x] ASan+UBSan: 1804 C++ tests + 143 Ry spec files pass
- [x] TSan: 1804 C++ tests pass
- [x] Smoke: `@it`/`@describe` に `-> Unit` を付けると期待通りのエラーメッセージが出力される

Closes #1122