### PR TITLE
fix: Map CoW key retain unconditional + keyName in map merge lookup

### DIFF
--- a/src/codegen_arc_cow.cpp
+++ b/src/codegen_arc_cow.cpp
@@ -301,8 +301,7 @@ llvm::Value *CodeGen::emitCowCheckSlot(llvm::Value *dataPtr,
         auto *meta = getMeta(dataPtr);
         if (meta && !meta->map_key_type_name.empty()) {
             CollectionKind keyArcKind = CollectionKind::List;
-            bool doKeyRetain = fieldTypeIsArcManaged(meta->map_key_type_name, &keyArcKind) &&
-                               (retainElements || keyArcKind == CollectionKind::Str);
+            bool doKeyRetain = fieldTypeIsArcManaged(meta->map_key_type_name, &keyArcKind);
             if (doKeyRetain) {
                 auto *lenPtr = builder_.CreateStructGEP(mapHeaderTy_, newDataPtr, 0, "cow_kret_len_ptr");
                 auto *keyLen = builder_.CreateLoad(i64Ty_, lenPtr, "cow_kret_len");

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -1167,7 +1167,7 @@ llvm::Value *CodeGen::emitMapMergeCore(llvm::Value *map1, llvm::Value *map2,
         llvm::Value *vv = builder_.CreateLoad(valTy, vp, "mg_vv2");
 
         // Check if key exists in new map
-        llvm::Value *lookupIdx = emitMapKeyLookup(newHeader, kv, keyTy);
+        llvm::Value *lookupIdx = emitMapKeyLookup(newHeader, kv, keyTy, keyName);
         llvm::Value *exists = builder_.CreateICmpSGE(lookupIdx, llvm::ConstantInt::get(i64Ty_, 0), "mg_exists");
 
         llvm::BasicBlock *updateBB = llvm::BasicBlock::Create(*ctx_, "mg.update", fn_);


### PR DESCRIPTION
## Summary

Fixes two issues caught in the second CodeRabbit review of PR #1148:

- **`emitCowCheckSlot` — `doKeyRetain` gate removed**: The `retainElements` condition incorrectly suppressed key retain in Map CoW. Keys are never overwritten by the slot-update protocol, so all ARC-managed keys must be retained unconditionally when cloning the CoW copy. The old guard could leak key ARC refcounts when `retainElements` was false.

- **`emitMapKeyLookup` missing `keyName` in map-merge path** (`codegen_call_collection.cpp:1170`): The map-merge call omitted `keyName`, causing struct/tuple keys to fall through to the hash-based lookup instead of the correct linear-scan branch (`keyIsStruct` guard). This could produce wrong lookup results for struct/tuple keys during map merge.

## Test plan

- [ ] `cmake --build build && ./build/ry_tests` passes
- [ ] `./build/ry test -p` passes
- [ ] ASan/UBSan clean: `cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests && ./build-asan/ry test -p`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined Map key retention behavior to ensure proper handling of managed key types across operations.
  * Improved map merge operations by providing additional metadata for key lookups during merge processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->