### PR TITLE
chore(ci): enable asan/tsan on v*.*.* branch pushes (#1166)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,9 +76,11 @@ jobs:
       - name: Test (Ry self-tests)
         run: ./build/ry test -p
 
-  # Heavy analysis jobs — only run on push to main.
-  # On v*.*.* pushes these are skipped (handled by ci-scheduled.yml daily).
-  # On pull_request these are skipped to keep PR CI fast.
+  # Heavy analysis jobs:
+  # - clang-tidy / scan-build: push to main only; v*.*.* covered by ci-scheduled.yml daily.
+  # - asan / tsan: push to main OR any v*.*.* branch, to catch sanitizer-caught
+  #   bugs early on active release branches (#1166).
+  # - On pull_request all four are skipped to keep PR CI fast.
 
   clang-tidy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -154,7 +156,9 @@ jobs:
           if-no-files-found: ignore
 
   asan:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'v'))
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -192,7 +196,9 @@ jobs:
         run: ./build-asan/ry test -p
 
   tsan:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'v'))
     runs-on: ubuntu-24.04
     # ThreadSanitizer coverage for #630's P0 race fixes is split:
     #


### PR DESCRIPTION
## Summary

- Extends the `asan` and `tsan` job `if:` conditions in `ci.yml` to also fire on push to any `v*.*.* ` release branch (in addition to `main`).
- `clang-tidy` and `scan-build` remain `main`-push-only; static analysis on every release-branch push offers diminishing ROI and is already covered by `ci-scheduled.yml` daily.
- `ci-scheduled.yml` is left unchanged as cold-path coverage for days without push activity.
- Updates the section comment to accurately reflect the split policy.

Closes #1166

## ⚠️ Expected CI behaviour after merge

Because #1161 (heap corruption in `collection_element.test.ry`) is still open, the **first `asan` run triggered by a push to `v0.0.13` may fail**. That failure is the intended outcome of this PR — it means ASan successfully detected the pre-existing bug. Treat it as a signal to work on #1161, not as a regression from this change.

## Test plan

- [ ] PR CI (lint + test) passes — heavy jobs are skipped on `pull_request` events as designed.
- [ ] After merge: push to `v0.0.13` triggers `asan` and `tsan` jobs (verify in Actions tab).
- [ ] After merge: `clang-tidy` and `scan-build` are still skipped on `v0.0.13` push (only run on `main`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline to run expanded automated testing and code analysis on release branches, ensuring consistent quality standards across all production releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->