### PR TITLE
chore: Linux Docker development environment for multi-preset testing (#1165)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Build artifacts (bind-mounted at runtime; excluded from image build context)
+build/
+build-asan/
+build-tsan/
+build-docker/
+build-asan-docker/
+build-tsan-docker/
+
+# VCS and tool caches
+.git/
+.cache/
+.claude/
+.codex/
+.serena/
+
+# macOS artefacts
+.DS_Store
+
+# Node (if any)
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@
 build/
 build-asan/
 build-tsan/
+build-docker/
+build-asan-docker/
+build-tsan-docker/
 
 # Editor / tool caches
 .cache/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,43 @@ TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry test -p    
 >
 > 新しい race を導入した場合は同 PR 内で必ず修正すること。warn-only は TSan allocator バグの回避のみであり、実際の race 導入を許容するものではない。TSan が #630 の audit に無い race パターンを検出した場合は新規 concurrency issue を起票し、`tests/spec/concurrency*.test.ry` に再現テストを追加する。
 
+## Linux Docker Development Environment
+
+Run tests under Linux (Ubuntu 24.04 + glibc) from macOS using the scripts in `docker/`. This reproduces the CI `asan`/`tsan` job environment locally and exposes Linux-only behaviour such as glibc heap consolidation checks that are invisible under macOS libSystem malloc.
+
+See [`docker/README.md`](docker/README.md) for a quick-start reference.
+
+### Commands
+
+```bash
+# Build the image once; subsequent runs reuse ccache (~1-2 min)
+./docker/run.sh default ry_tests                                  # default preset, C++ tests
+./docker/run.sh default ry test -p                                # default preset, Ry self-tests
+
+./docker/run.sh asan ry_tests                                     # ASan + UBSan, C++ tests
+./docker/run.sh asan ry test -p                                   # ASan + UBSan, Ry self-tests
+./docker/run.sh asan ry test tests/spec/some.test.ry              # single file
+
+./docker/run.sh tsan ry_tests                                     # TSan, C++ tests
+./docker/run.sh default bash                                      # interactive shell
+
+./docker/run.sh --rebuild asan ry_tests                           # force image rebuild
+```
+
+### Preset summary
+
+| Preset | Sanitizers | Sanitizer env vars (auto-set by run.sh) | Host build dir |
+|--------|-----------|----------------------------------------|----------------|
+| `default` | none | — | `build-docker/` |
+| `asan` | ASan + UBSan | `ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0:halt_on_error=1`, `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1` | `build-asan-docker/` |
+| `tsan` | TSan | `TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1` | `build-tsan-docker/` |
+
+### Known limitations
+
+- **First build takes 5-10 minutes** (LLVM 21 is installed from apt.llvm.org). Subsequent runs use ccache and complete in ~1-2 minutes.
+- On Apple Silicon, the container runs **arm64 Linux natively**. To test x86_64-specific behaviour, pass `--platform linux/amd64` manually to `docker run` (not wired into `run.sh` by default — qemu emulation is 5-10× slower and rarely needed).
+- macOS builds (`build/`, `build-asan/`, `build-tsan/`) and Docker builds (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`) are **fully separate**. Running Docker commands will not overwrite your local CMake build.
+
 ## メモリ安全ルール（C++ ランタイム）
 
 `include/ry/runtime_alloc.hpp` の安全なラッパーを使用すること。以下の関数は新規コードで直接呼び出してはならない:

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2143,6 +2143,59 @@ where possible.
 in `--suppressions-list` files. Comment syntax was added in 2.14. Keep
 `.cppcheck-suppressions` comment-free to remain compatible with 2.13.
 
+### LLVM 21 via apt.llvm.org requires zlib1g-dev and libzstd-dev in addition to LLVM packages
+
+**Source**: #1165 Docker dev environment setup (2026-04-18)
+**Tags**: build, llvm, cmake, docker, dependencies
+
+**Rule**: When using LLVM 21 packages from `apt.llvm.org` on Ubuntu, the CMake package
+`find_package(LLVM REQUIRED ...)` will fail at configure time unless `zlib1g-dev` and
+`libzstd-dev` are installed — even if you never explicitly use zlib or zstd yourself.
+
+**Why**: `LLVMExports.cmake` (generated when LLVM was compiled) lists `ZLIB::ZLIB` and
+`zstd::libzstd_shared` in the `INTERFACE_LINK_LIBRARIES` of the `LLVMSupport` target.
+CMake validates all link-interface targets at import time. If either target is missing,
+you get:
+
+```
+CMake Error at .../LLVMExports.cmake:73 (set_target_properties):
+  The link interface of target "LLVMSupport" contains: ZLIB::ZLIB
+  but the target was not found.
+```
+
+**How to apply**: Any Dockerfile or CI step that installs LLVM 21 via `apt.llvm.org`
+must also `apt-get install -y zlib1g-dev libzstd-dev` BEFORE the `find_package(LLVM)`
+CMake configure step. Add them to the same `apt-get install` layer as `cmake`, not after.
+
+### ubuntu:24.04 archive signing key expires — bypass for dev Dockerfiles
+
+**Source**: #1165 Docker dev environment setup (2026-04-18)
+**Tags**: docker, ubuntu, gpg, apt, dev-environment
+
+**Rule**: On Apple Silicon (arm64) the ubuntu:24.04 Docker image uses `ports.ubuntu.com`
+which is signed with a key that can expire on systems whose clock is ahead of the key's
+validity period. When `apt-get update` fails with "At least one invalid signature was
+encountered", installing `ubuntu-keyring` will not help (it is already the newest version
+in-image). The correct fix for a **dev-only** Dockerfile is to replace `Signed-By:` with
+`Trusted: yes` in `/etc/apt/sources.list.d/ubuntu.sources` before the first
+`apt-get update`:
+
+```dockerfile
+RUN sed -i 's|^Signed-By:.*|Trusted: yes|' /etc/apt/sources.list.d/ubuntu.sources \
+  && apt-get update \
+  && apt-get install -y ...
+```
+
+**Why**: ubuntu 24.04 uses the deb822 sources format at
+`/etc/apt/sources.list.d/ubuntu.sources`. The `Signed-By:` directive points to the GPG
+keyring. Replacing it with `Trusted: yes` bypasses signature verification entirely. Do
+NOT use this workaround for production images.
+
+**How to apply**: Add the `sed` step as the first line of the `RUN` block that installs
+build dependencies. Keep it in the same `RUN` as the `apt-get install` so that the
+`Trusted: yes` directive is baked in and future `apt-get update` calls within the build
+also work.
+
 ---
 
 ## Documentation
@@ -2509,6 +2562,22 @@ write a 3-line entry under this section with a descriptive subheading.
 **Why**: `--label` in `gh issue edit` is a *set* operation, not an *append*. The flag name is misleading because `gh issue create --label` is safe (empty initial state). The asymmetry bites every time you remember the create syntax and apply it to edit.
 
 **How to apply**: Use `git-claim-issue` skill for `wip` attachment (enforces `--add-label` internally). Use `git-merge-pr` Step 5 for `wip` removal (enforces `--remove-label` internally). Never call `gh issue edit --label` directly for additive changes.
+
+### bash `set -u` with empty array: use `"${arr[@]+"${arr[@]}"}"` not `"${arr[@]}"`
+
+**Source**: #1165 Docker run.sh (2026-04-18)
+**Tags**: commands, bash, shell, docker
+
+**Wrong**: `docker run ... "${ENV_ARGS[@]}" ...` with `set -euo pipefail` and `ENV_ARGS=()`
+→ Error: `ENV_ARGS[@]: unbound variable` when the array is empty
+
+**Correct**: `docker run ... "${ENV_ARGS[@]+"${ENV_ARGS[@]}"}" ...`
+
+**Why**: bash's `set -u` (nounset) treats an empty array expansion `"${arr[@]}"` as an
+unbound variable. The idiom `"${arr[@]+"${arr[@]}"}"` uses parameter expansion with a
+default — it expands to nothing when the array is empty, and to the full array contents
+when non-empty. This is the standard POSIX-compatible workaround for `set -u` + optional
+arrays in shell scripts.
 
 ---
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2157,7 +2157,7 @@ in `--suppressions-list` files. Comment syntax was added in 2.14. Keep
 CMake validates all link-interface targets at import time. If either target is missing,
 you get:
 
-```
+```text
 CMake Error at .../LLVMExports.cmake:73 (set_target_properties):
   The link interface of target "LLVMSupport" contains: ZLIB::ZLIB
   but the target was not found.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,46 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# The ubuntu:24.04 archive signing key may be expired in environments where the system clock is
+# set to a future date. Replace Signed-By with Trusted:yes to bypass GPG verification.
+# This is intentional for a dev-only image; do not use in production.
+# zlib1g-dev: required by LLVMSupport link interface (ZLIB::ZLIB) when using apt.llvm.org packages
+# libzstd-dev: required by LLVMSupport link interface (zstd::libzstd_shared)
+RUN sed -i 's|^Signed-By:.*|Trusted: yes|' /etc/apt/sources.list.d/ubuntu.sources \
+  && apt-get update \
+  && apt-get install -y \
+    cmake \
+    ninja-build \
+    ccache \
+    libssl-dev \
+    libgtest-dev \
+    libgmock-dev \
+    zlib1g-dev \
+    libzstd-dev \
+    wget \
+    gnupg \
+    ca-certificates \
+    software-properties-common \
+    git \
+  && rm -rf /var/lib/apt/lists/*
+
+# Install LLVM 21 via apt.llvm.org (mirrors CI apt fallback path in setup-llvm action)
+RUN wget -qO- https://apt.llvm.org/llvm.sh | bash -s -- 21 \
+  && apt-get install -y \
+    libllvm21 \
+    llvm-21-dev \
+    clang-21 \
+  && rm -rf /var/lib/apt/lists/* \
+  && ln -sfn /usr/lib/llvm-21 /usr/local/llvm
+
+ENV CC=/usr/local/llvm/bin/clang \
+    CXX=/usr/local/llvm/bin/clang++ \
+    PATH=/usr/local/llvm/bin:$PATH
+
+WORKDIR /workspace
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # libzstd-dev: required by LLVMSupport link interface (zstd::libzstd_shared)
 RUN sed -i 's|^Signed-By:.*|Trusted: yes|' /etc/apt/sources.list.d/ubuntu.sources \
   && apt-get update \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     cmake \
     ninja-build \
     ccache \
@@ -27,7 +27,7 @@ RUN sed -i 's|^Signed-By:.*|Trusted: yes|' /etc/apt/sources.list.d/ubuntu.source
 
 # Install LLVM 21 via apt.llvm.org (mirrors CI apt fallback path in setup-llvm action)
 RUN wget -qO- https://apt.llvm.org/llvm.sh | bash -s -- 21 \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
     libllvm21 \
     llvm-21-dev \
     clang-21 \
@@ -38,9 +38,18 @@ ENV CC=/usr/local/llvm/bin/clang \
     CXX=/usr/local/llvm/bin/clang++ \
     PATH=/usr/local/llvm/bin:$PATH
 
+# ubuntu:24.04 ships with an ubuntu user (uid 1000); reuse it for safer container execution.
+# Pre-create ccache dir so the named volume inherits ubuntu ownership on first mount.
+RUN mkdir -p /home/ubuntu/.cache/ccache \
+  && chown -R ubuntu:ubuntu /home/ubuntu
+
+ENV HOME=/home/ubuntu \
+    CCACHE_DIR=/home/ubuntu/.cache/ccache
+
 WORKDIR /workspace
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
+USER ubuntu
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,42 @@
+# ry Linux Docker Development Environment
+
+Run tests in a Linux (Ubuntu 24.04 + glibc) environment from macOS, matching CI conditions for all sanitizer presets.
+
+See [AGENTS.md](../AGENTS.md) (search for "Linux Docker") for full workflow documentation.
+
+## Quick start
+
+```bash
+# First run builds the image (~5-10 min); subsequent runs use ccache (1-2 min)
+./docker/run.sh default ry_tests
+./docker/run.sh default ry test -p
+
+# ASan + UBSan (mirrors CI asan job)
+./docker/run.sh asan ry_tests
+./docker/run.sh asan ry test -p
+./docker/run.sh asan ry test tests/spec/combinatorial/collection_element.test.ry
+
+# TSan (mirrors CI tsan job)
+./docker/run.sh tsan ry_tests
+
+# Interactive shell
+./docker/run.sh default bash
+
+# Force image rebuild (after Dockerfile changes)
+./docker/run.sh --rebuild asan ry_tests
+```
+
+## Presets
+
+| Preset | Sanitizers | Sanitizer env vars | Host build dir |
+|--------|-----------|-------------------|----------------|
+| `default` | none | — | `build-docker/` |
+| `asan` | ASan + UBSan | `ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0:halt_on_error=1`<br>`UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1` | `build-asan-docker/` |
+| `tsan` | TSan | `TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1` | `build-tsan-docker/` |
+
+## Notes
+
+- Host build dirs (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`) are separate from native macOS builds (`build/`, `build-asan/`, `build-tsan/`). They will not interfere with each other.
+- On Apple Silicon the container runs arm64 Linux natively (no x86_64 QEMU emulation).
+- ccache is persisted in a named Docker volume (`ry-ccache-docker`). The first build compiles everything; subsequent runs reuse the cache.
+- Image name: `ry-linux-dev:latest`. Built locally; not pushed to any registry.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Ensure ccache dir exists (volume may be new or owned by a previous root-run)
+mkdir -p "${CCACHE_DIR:-/home/ubuntu/.cache/ccache}"
+
 PRESET="${1:-default}"
 shift || true
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PRESET="${1:-default}"
+shift || true
+
+case "$PRESET" in
+  default) BUILD_DIR="build" ;;
+  asan)    BUILD_DIR="build-asan" ;;
+  tsan)    BUILD_DIR="build-tsan" ;;
+  *)       echo "error: unknown preset '$PRESET' (supported: default, asan, tsan)" >&2; exit 1 ;;
+esac
+
+# Build
+cmake --preset "$PRESET"
+cmake --build "$BUILD_DIR"
+
+# If no command given, exit after build
+if [[ $# -eq 0 ]]; then
+  exit 0
+fi
+
+CMD="$1"
+shift
+
+case "$CMD" in
+  ry_tests)
+    exec "./$BUILD_DIR/ry_tests" "$@"
+    ;;
+  ry)
+    exec "./$BUILD_DIR/ry" "$@"
+    ;;
+  bash)
+    exec bash "$@"
+    ;;
+  *)
+    echo "error: unknown command '$CMD' (supported: ry_tests, ry, bash)" >&2
+    exit 1
+    ;;
+esac

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Run ry tests inside a Linux (ubuntu:24.04) container from macOS.
+# Usage: docker/run.sh [--rebuild] <preset> [cmd [args...]]
+#   preset: default | asan | tsan
+#   cmd:    ry_tests | ry | bash  (omit for build-only)
+#   Examples:
+#     ./docker/run.sh asan ry_tests
+#     ./docker/run.sh asan ry test -p
+#     ./docker/run.sh asan ry test tests/spec/combinatorial/collection_element.test.ry
+#     ./docker/run.sh default bash
+#     ./docker/run.sh --rebuild asan ry_tests
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMAGE="ry-linux-dev:latest"
+CCACHE_VOLUME="ry-ccache-docker"
+
+# Parse --rebuild flag
+REBUILD=0
+if [[ "${1:-}" == "--rebuild" ]]; then
+  REBUILD=1
+  shift
+fi
+
+PRESET="${1:-default}"
+
+# Validate preset and resolve host build dir
+case "$PRESET" in
+  default) BUILD_DIR_HOST="build-docker";     BUILD_DIR_CONTAINER="build" ;;
+  asan)    BUILD_DIR_HOST="build-asan-docker"; BUILD_DIR_CONTAINER="build-asan" ;;
+  tsan)    BUILD_DIR_HOST="build-tsan-docker"; BUILD_DIR_CONTAINER="build-tsan" ;;
+  *)       echo "error: unknown preset '$PRESET' (supported: default, asan, tsan)" >&2; exit 1 ;;
+esac
+
+# Build image if absent or --rebuild requested
+if [[ "$REBUILD" -eq 1 ]] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "Building Docker image $IMAGE..."
+  docker build -t "$IMAGE" "$SCRIPT_DIR"
+fi
+
+# Ensure host build dir exists so Docker doesn't create it as root
+mkdir -p "$PROJECT_DIR/$BUILD_DIR_HOST"
+
+# Sanitizer env vars matching CI jobs
+ENV_ARGS=()
+case "$PRESET" in
+  asan)
+    ENV_ARGS+=(
+      -e "ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0:halt_on_error=1"
+      -e "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1"
+    )
+    ;;
+  tsan)
+    ENV_ARGS+=(
+      -e "TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1"
+    )
+    ;;
+esac
+
+# Allocate a pseudo-TTY only when stdin is a terminal (omit -t in CI / non-interactive)
+TTY_FLAG=()
+if [[ -t 0 ]]; then
+  TTY_FLAG=(-it)
+else
+  TTY_FLAG=(-i)
+fi
+
+docker run --rm "${TTY_FLAG[@]}" \
+  -v "$PROJECT_DIR:/workspace" \
+  -v "$PROJECT_DIR/$BUILD_DIR_HOST:/workspace/$BUILD_DIR_CONTAINER" \
+  -v "$CCACHE_VOLUME:/root/.cache/ccache" \
+  "${ENV_ARGS[@]+"${ENV_ARGS[@]}"}" \
+  "$IMAGE" \
+  "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -69,7 +69,7 @@ fi
 docker run --rm "${TTY_FLAG[@]}" \
   -v "$PROJECT_DIR:/workspace" \
   -v "$PROJECT_DIR/$BUILD_DIR_HOST:/workspace/$BUILD_DIR_CONTAINER" \
-  -v "$CCACHE_VOLUME:/root/.cache/ccache" \
+  -v "$CCACHE_VOLUME:/home/ubuntu/.cache/ccache" \
   "${ENV_ARGS[@]+"${ENV_ARGS[@]}"}" \
   "$IMAGE" \
   "$@"


### PR DESCRIPTION
## Summary

- Adds `docker/` directory with `Dockerfile`, `entrypoint.sh`, `run.sh`, and `README.md` to run ry tests under Ubuntu 24.04 + glibc from macOS
- Supports `default`, `asan`, and `tsan` presets; host build dirs (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`) are kept separate from macOS builds via bind-mount
- Updates `AGENTS.md` with new "Linux Docker Development Environment" section, `.gitignore`, `.dockerignore`, and `KNOWLEDGE.md` (3 new entries: LLVM zlib/zstd deps, ubuntu GPG workaround, bash `set -u` array idiom)

## Verification

All presets tested and passing on Linux arm64 (Apple Silicon):

| Command | Result |
|---------|--------|
| `./docker/run.sh default ry_tests` | 1806 tests PASSED |
| `./docker/run.sh default ry test -p` | 143 files, 0 failures |
| `./docker/run.sh asan ry_tests` | 1806 tests PASSED |
| `./docker/run.sh tsan ry_tests` | 1806 tests PASSED |
| `./docker/run.sh asan ry test tests/spec/combinatorial/collection_element.test.ry` | 14 passed, 0 failed |

macOS `build/`, `build-asan/`, `build-tsan/` are unaffected.

Closes #1165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux Docker development environment with runnable test/build presets (default, ASan, TSan) and helper scripts to invoke builds/tests from macOS.

* **Documentation**
  * Detailed Docker README and AGENTS updates with usage examples, presets, environment notes, and known limitations; added dev-environment gotchas and troubleshooting tips.

* **Chores**
  * Added ignore files to streamline Docker build context and host-side build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->