### PR TITLE
docs(knowledge): document ~CodeGen() glibc crash class — ARC OOB, not destructor bug (#1167)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1796,6 +1796,43 @@ IR survived codegen and crashed only during JIT optimization.
 
 ---
 
+### `~CodeGen()` glibc heap-check crashes are not destructor bugs
+
+**Source**: #1161 / #1167 (2026-04-18)
+**Tags**: codegen, arc, glibc, debugging, heap-corruption, gotcha
+
+**Rule**: When `ry::CodeGen::~CodeGen()` aborts on Linux glibc with
+`corrupted size vs. prev_size while consolidating`, treat it as an
+**earlier** OOB write or UAF in ARC-managed runtime buffers (Map/List/Set
+CoW copies, ARC headers) that glibc only detects when a neighbouring chunk
+is freed during `ThreadSafeModule` teardown — not as a destructor-ordering
+or member-lifetime bug in `CodeGen` itself.
+
+**Why `~CodeGen()` is not the culprit**:
+- `~CodeGen` is compiler-generated. `mod_` / `ctx_` are moved into
+  `ThreadSafeModule` at `src/codegen.cpp:575`; the destructor never touches IR objects.
+- ARC tracking sets (`include/ry/codegen.hpp:184-193`) store bare `llvm::Value*`
+  and only walk hash buckets at destruction — no dereference.
+
+**Diagnostic checklist**:
+1. Reproduce on Linux with ASan (ARM64 Docker via `docker/run.sh asan`; x86_64 CI
+   asan job on `v*` push). macOS libSystem malloc does not expose glibc's chunk
+   metadata checks, so the crash is Linux-only even with the same bug.
+2. ASan will pinpoint the actual OOB/UAF site instead of just the late `free()`.
+3. Look first at recent changes to `emitCowCheckSlot` / `emitCowDeepCopy*` /
+   `emitMapKeyLookup` / `emitSetElementLookup`: ARC retain gating, `keyName` /
+   `elemName` propagation, and hash-vs-linear-scan branch selection are the
+   class of change that introduced `~CodeGen()` crash #1161.
+
+**History**: #1161 crash (`corrupted size vs. prev_size`) was observed after PR #1148
+landed. The bug was most likely a heap-layout-dependent OOB that became non-reproducible
+after PR #1160 (`emitCowCheckSlot` `doKeyRetain` unconditional + `emitMapKeyLookup`
+`keyName` fix). CI ASan clean on x86_64 Linux was confirmed at commit `998edc42`
+(CI run #24601715375, 2026-04-18). The exact commit that fixed it was not bisected;
+if the crash re-appears, revert to the diagnostic checklist above.
+
+---
+
 ## Regex Engine
 
 ### Thompson NFA stores per-thread state on NFAState itself — extending to capture slots requires a separate approach

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1801,11 +1801,17 @@ IR survived codegen and crashed only during JIT optimization.
 **Source**: #1161 / #1167 (2026-04-18)
 **Tags**: codegen, arc, glibc, debugging, heap-corruption, gotcha
 
+**Scope**: This entry covers crashes that **persist under ASan** (i.e. ASan itself reports
+a heap-buffer-overflow or use-after-free). For crashes where all test cases pass and only
+the teardown crashes — and the crash disappears on re-run — see the ORC JIT flake entry
+([`LLVM ORC JIT intermittent crash`](#llvm-orc-jit-intermittent-crash-in-lljit--removeresourcetracker--codegen-linux--macos))
+instead; those are pre-existing LLVM ORC flakiness, not user-code bugs.
+
 **Rule**: When `ry::CodeGen::~CodeGen()` aborts on Linux glibc with
-`corrupted size vs. prev_size while consolidating`, treat it as an
-**earlier** OOB write or UAF in ARC-managed runtime buffers (Map/List/Set
-CoW copies, ARC headers) that glibc only detects when a neighbouring chunk
-is freed during `ThreadSafeModule` teardown — not as a destructor-ordering
+`corrupted size vs. prev_size while consolidating` **and the crash reproduces persistently**
+(especially under ASan), treat it as an **earlier** OOB write or UAF in ARC-managed
+runtime buffers (Map/List/Set CoW copies, ARC headers) that glibc only detects when a
+neighbouring chunk is freed during `ThreadSafeModule` teardown — not as a destructor-ordering
 or member-lifetime bug in `CodeGen` itself.
 
 **Why `~CodeGen()` is not the culprit**:
@@ -1952,7 +1958,10 @@ corrupted size vs. prev_size while consolidating
 **Discriminating evidence for flake vs. regression**: If all test cases in the failing file report
 success (N passed, 0 failed) and only the teardown crashes, and a re-run on the same commit passes,
 classify as flake. A genuine heap corruption from user code would fail a specific test case or fail
-deterministically.
+deterministically. If the crash **persists under ASan** (ASan reports a heap error on its own, not
+just glibc's `cfree` check), it is user-code OOB/UAF — not an ORC flake. In that case, see the
+[`~CodeGen() glibc heap-check crashes`](#codegen-glibc-heap-check-crashes-are-not-destructor-bugs)
+entry in the Runtime / Memory section for the diagnostic checklist.
 
 **Fix applied**: `src/jit_runner.cpp` — `(void)jit.release()` workaround is now guarded by
 `#if defined(__linux__) || defined(__APPLE__)` (previously Linux-only). The LLJIT is intentionally


### PR DESCRIPTION
## Summary

- Add a KNOWLEDGE.md entry explaining that `corrupted size vs. prev_size while consolidating` in `ry::CodeGen::~CodeGen()` is caused by an **earlier** OOB write or UAF in ARC-managed runtime buffers, not a destructor-ordering or member-lifetime bug in `CodeGen` itself.
- Includes: why `~CodeGen` is safe (compiler-generated, `mod_`/`ctx_` moved-out at `src/codegen.cpp:575`, ARC tracking sets only walk hash buckets), a 3-step diagnostic checklist for future recurrences, and the #1161 recovery history.

## Non-reproduction confirmation

| Signal | Result |
|--------|--------|
| Docker ARM64 ASan — `collection_element.test.ry` × 20 runs | ✅ all pass |
| Local macOS ASan + UBSan (`ry_tests` + `ry test -p`) | ✅ 1806 / 143 files |
| Local macOS TSan (`ry_tests` + `ry test -p`) | ✅ 1806 / 143 files |
| x86_64 CI ASan at `998edc42` (run [#24601715375](https://github.com/t0k0sh1/ry/actions/runs/24601715375)) | ✅ success |

x86_64 CI ASan will re-run automatically when this PR merges to `v0.0.13`.

## Code changes

None — KNOWLEDGE.md documentation only.

Closes #1167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * New Runtime / Memory guidance explaining that persistent glibc aborts under ASan often indicate earlier out-of-bounds/use-after-free memory corruption, not destructor-order issues.
  * Added a Linux/ASan diagnostic checklist for heap-check crashes.
  * Updated JIT crash guidance to include ASan-persistence as a discriminant and linked to the new checklist.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->