### PR TITLE
feat: introduce LLVM FileCheck IR golden tests and --emit-llvm-ir flag (#897)

### DIFF
--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -120,6 +120,41 @@ jobs:
           retention-days: 14
           if-no-files-found: ignore
 
+  filecheck:
+    needs: resolve-target
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve-target.outputs.ref }}
+      - name: Setup LLVM
+        uses: ./.github/actions/setup-llvm
+        with:
+          llvm-version: ${{ env.LLVM_VERSION }}
+          sha256-short: ${{ env.LLVM_SHA256_SHORT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install FileCheck
+        run: |
+          MAJOR="${LLVM_VERSION%%.*}"
+          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
+          sudo apt-get install -y --no-install-recommends llvm-${MAJOR}-tools
+          if [ ! -f /usr/local/llvm/bin/FileCheck ] && \
+             [ -f /usr/lib/llvm-${MAJOR}/bin/FileCheck ]; then
+            sudo ln -s /usr/lib/llvm-${MAJOR}/bin/FileCheck \
+                       /usr/local/llvm/bin/FileCheck
+          fi
+        env:
+          LLVM_VERSION: ${{ env.LLVM_VERSION }}
+      - name: Install build dependencies
+        run: sudo apt-get install -y libssl-dev ninja-build
+      - name: Configure
+        run: cmake --preset default
+      - name: Build ry
+        run: cmake --build build --target ry
+      - name: Run FileCheck IR golden tests
+        continue-on-error: true
+        run: ctest --test-dir build -L filecheck --output-on-failure
+
   asan:
     needs: resolve-target
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,8 @@ jobs:
   # - clang-tidy / scan-build: push to main only; v*.*.* covered by ci-scheduled.yml daily.
   # - asan / tsan: push to main OR any v*.*.* branch, to catch sanitizer-caught
   #   bugs early on active release branches (#1166).
-  # - On pull_request all four are skipped to keep PR CI fast.
+  # - filecheck: all events including pull_request (fast: only builds ry, not ry_tests).
+  # - On pull_request clang-tidy, scan-build, asan, tsan are skipped to keep PR CI fast.
 
   clang-tidy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -154,6 +155,52 @@ jobs:
           path: scan-build-report
           retention-days: 14
           if-no-files-found: ignore
+
+  filecheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup LLVM
+        uses: ./.github/actions/setup-llvm
+        with:
+          llvm-version: ${{ env.LLVM_VERSION }}
+          sha256-short: ${{ env.LLVM_SHA256_SHORT }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install FileCheck
+        # FileCheck is not bundled in the LLVM mirror tarball (mirror-llvm-toolchain.yml
+        # does not include llvm-X-tools). Install it unconditionally via apt.llvm.org,
+        # then symlink into /usr/local/llvm/bin/ so CMake find_program can locate it
+        # even when the mirror tarball (not /usr/lib/llvm-X) is used as /usr/local/llvm.
+        run: |
+          MAJOR="${LLVM_VERSION%%.*}"
+          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
+          sudo apt-get install -y --no-install-recommends llvm-${MAJOR}-tools
+          if [ ! -f /usr/local/llvm/bin/FileCheck ] && \
+             [ -f /usr/lib/llvm-${MAJOR}/bin/FileCheck ]; then
+            sudo ln -s /usr/lib/llvm-${MAJOR}/bin/FileCheck \
+                       /usr/local/llvm/bin/FileCheck
+          fi
+        env:
+          LLVM_VERSION: ${{ env.LLVM_VERSION }}
+      - name: Install build dependencies
+        run: sudo apt-get install -y libssl-dev ninja-build
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ci-filecheck-${{ github.ref }}
+          restore-keys: |
+            ci-filecheck-
+            ci-ubuntu-
+          save: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}
+      - name: Configure
+        run: cmake --preset default
+      - name: Build ry
+        run: cmake --build build --target ry
+      - name: Run FileCheck IR golden tests
+        # warn-only: triage LLVM-version sensitivity before making this required.
+        # Once goldens are confirmed stable across LLVM updates, remove continue-on-error.
+        continue-on-error: true
+        run: ctest --test-dir build -L filecheck --output-on-failure
 
   asan:
     if: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,28 @@ CI の `scan-build` ジョブがシンボリック実行ベースのパス感度
 - false positive の抑制は `#ifndef __clang_analyzer__` でインライン抑制する（clang-tidy の `// NOLINT` と同様の粒度）
 - 新規コードは scan-build 警告ゼロを維持すること
 
+## FileCheck IR Golden Tests
+
+`tests/filecheck/` ディレクトリに LLVM IR ゴールデンテストを配置する。`ry --emit-llvm-ir <file.ry>` で unoptimized IR を生成し、LLVM FileCheck ツールで宣言的にアサートする。
+
+- **`ry --emit-llvm-ir <file>`**: parser → typecheck → codegen まで実行し、JIT 最適化なしで unoptimized LLVM IR を stdout に出力して終了（実行しない）
+- **FileCheck の入手**: macOS は `brew install llvm@21`（`/opt/homebrew/opt/llvm@21/bin/FileCheck`）、Linux は `sudo apt-get install llvm-21-tools`（注意: llvm-mirror tarball に FileCheck は同梱されていないため apt からの取得が必要）
+- **ローカル実行**:
+  ```bash
+  # 単一ゴールデン手動確認
+  ./build/ry --emit-llvm-ir tests/filecheck/function_call.ry \
+    | /opt/homebrew/opt/llvm@21/bin/FileCheck tests/filecheck/function_call.ry
+
+  # CTest 経由（FileCheck を CMake が自動検出）
+  ctest --test-dir build -L filecheck --output-on-failure
+  ```
+- **ゴールデン追加手順**: `tests/filecheck/<name>.ry` を作成し、先頭の `#` コメントとして `# CHECK: ...` / `# CHECK-NEXT: ...` / `# CHECK-NOT: ...` を記述する（Ry は `#` コメント構文を使用。`//` は Ry 構文エラー）
+- **CHECK パターン指針**:
+  - LLVM 17+ opaque pointer を前提 — 引数・alloca・load/store はすべて `ptr` 型
+  - `--emit-llvm-ir` は unoptimized IR — mem2reg 後のレジスタ化とは異なり、alloca + store + load が残る
+  - LLVM バージョンアップ時は goldens の再確認が必要
+- CI の `filecheck` ジョブは全イベント（PR・main/v*.*.* push）で実行（`ry` のみビルドするため高速、`continue-on-error: true` で warn-only 運用中）
+
 ## CI: LLVM ツールチェーン (ミラー)
 
 CI は `.github/actions/setup-llvm/` composite action 経由で LLVM を取得する。優先順に:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,7 @@ add_executable(ry_tests
     tests/test_runtime_arc_contention_stress.cpp
     tests/test_runtime_lock_stress.cpp
     tests/test_codegen_type_safety.cpp
+    tests/test_emit_llvm_ir.cpp
 )
 if(APPLE)
     target_link_libraries(ry_tests PRIVATE
@@ -354,4 +355,29 @@ if(ENABLE_ASAN OR ENABLE_UBSAN OR ENABLE_TSAN)
     endif()
 else()
     gtest_discover_tests(ry_tests)
+endif()
+
+# ===== FileCheck IR ゴールデンテスト =====
+find_program(FILECHECK_EXECUTABLE FileCheck
+    HINTS
+        ${LLVM_TOOLS_BINARY_DIR}
+        /opt/homebrew/opt/llvm@${LLVM_VERSION_MAJOR}/bin
+        /opt/homebrew/opt/llvm/bin
+        /usr/local/llvm/bin
+        /usr/lib/llvm-${LLVM_VERSION_MAJOR}/bin
+    DOC "LLVM FileCheck for IR golden tests")
+
+if(FILECHECK_EXECUTABLE)
+    message(STATUS "FileCheck found: ${FILECHECK_EXECUTABLE}")
+    file(GLOB FILECHECK_TEST_FILES "${CMAKE_CURRENT_SOURCE_DIR}/tests/filecheck/*.ry")
+    foreach(f IN LISTS FILECHECK_TEST_FILES)
+        get_filename_component(name "${f}" NAME_WE)
+        add_test(NAME "filecheck_${name}"
+            COMMAND bash -c
+                "$<TARGET_FILE:ry> --emit-llvm-ir ${f} | ${FILECHECK_EXECUTABLE} ${f}")
+        set_tests_properties("filecheck_${name}" PROPERTIES LABELS "filecheck")
+    endforeach()
+else()
+    message(STATUS "FileCheck not found; skipping IR golden tests \
+(macOS: brew install llvm@${LLVM_VERSION_MAJOR}, Linux: apt-get install llvm-${LLVM_VERSION_MAJOR}-tools)")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -374,7 +374,7 @@ if(FILECHECK_EXECUTABLE)
         get_filename_component(name "${f}" NAME_WE)
         add_test(NAME "filecheck_${name}"
             COMMAND bash -c
-                "$<TARGET_FILE:ry> --emit-llvm-ir ${f} | ${FILECHECK_EXECUTABLE} ${f}")
+                "set -o pipefail; \"$<TARGET_FILE:ry>\" --emit-llvm-ir \"${f}\" | \"${FILECHECK_EXECUTABLE}\" \"${f}\"")
         set_tests_properties("filecheck_${name}" PROPERTIES LABELS "filecheck")
     endforeach()
 else()

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2062,13 +2062,14 @@ is the required gate for #630's race fixes. macOS is unaffected.
 `.github/actions/setup-llvm/`. The mirror tarball is built by
 `.github/workflows/mirror-llvm-toolchain.yml` (manual `workflow_dispatch`).
 
-The mirror tarball includes `clang-tidy` (added in #934) and `scan-build` / `analyze-build` via `clang-tools-{MAJOR}` (added in #898). The
+The mirror tarball includes `clang-tidy` (added in #934) and `scan-build` / `analyze-build` via `clang-tools-{MAJOR}` (added in #898). **FileCheck is NOT bundled** in the mirror tarball (#897) — the `filecheck` CI job installs it separately via `apt-get install llvm-{MAJOR}-tools` from `apt.llvm.org`. The
 `setup-llvm` action accepts an optional `extra-packages` input for
 the apt fallback path; the mirror/cache path already contains all
 tools. If new tools are needed, add them to
 `mirror-llvm-toolchain.yml`'s apt-get line, bump the cache key
 version suffix (e.g. `v2` → `v3`), and re-dispatch the mirror workflow
-with `force=true`.
+with `force=true`. A follow-up issue tracks adding `llvm-{MAJOR}-tools`
+to the mirror tarball to eliminate the extra apt install step.
 
 Version bump checklist — update `env.LLVM_VERSION` (and
 `env.LLVM_SHA256_SHORT` when non-empty) in:
@@ -3847,3 +3848,22 @@ This makes wrong-offset bugs on str literals almost always fatal immediately, wh
 **Tags**: codegen, ARC, record, reassignment, InsertValueInst
 
 **Rule**: The guard in `codegen_stmt.cpp` (`AssignStmt` record-with-ARC-fields path) that determines whether to call `emitRecordArcFieldsRetain` must be `!isa<CallInst>(val) && !isa<InvokeInst>(val)` — **not** `isa<LoadInst>(val) || isa<ExtractValueInst>(val)`. Fresh constructions (CallInst = direct call, InvokeInst = call with unwind) are sole owners and must not be retained. Every other value — including `InsertValueInst` chains like `r2 = { r.field, new_val }` — is a view of existing state and must be retained. The original allowlist of two cases was too narrow and caused use-after-free for `InsertValueInst` records.
+
+---
+
+### FileCheck golden authoring conventions
+
+**Source**: #897 (2026-04-18)
+**Tags**: filecheck, codegen, ir, testing, ci
+
+**Rule**: FileCheck goldens live in `tests/filecheck/*.ry`. Each file is both valid Ry source and a FileCheck script — Ry uses `#` line comments, and `# CHECK:` lines work because FileCheck searches for the `CHECK:` substring regardless of prefix. **Do not use `//`** — that is not a Ry comment and causes a parse error.
+
+Key constraints:
+
+1. **Ry comment syntax is `#`**: Write `# CHECK:`, `# CHECK-NEXT:`, `# CHECK-NOT:`, `# CHECK-DAG:`, `# CHECK-LABEL:`. Never `// CHECK:`.
+2. **Unoptimized IR only**: `ry --emit-llvm-ir` emits codegen output before any LLVM optimization passes. `alloca`/`store`/`load` patterns for every function argument are always present. `mem2reg` has not run.
+3. **Opaque pointers (LLVM 17+)**: All pointer types are `ptr`; never write `i64*`, `i8*`, etc. in CHECK patterns.
+4. **ARC retain/release visibility**: `@ry_retain` / `@ry_release` BasicBlocks only appear in CoW clone paths, lambda captures, and `@parallel for` patterns. They do not appear in simple scalar or string identity functions — choose goldens accordingly.
+5. **Result type layout**: `%Result = type { i1, i64, ptr }` — `i1` is the `is_ok` flag; `Err` uses constant aggregate `{ i1 false, ... }`, `Ok` uses `insertvalue %Result { i1 true, ... }`.
+6. **LLVM version bumps**: Goldens are LLVM-version-sensitive. After any LLVM version bump, re-run `ctest -L filecheck` and update patterns if IR structure changed.
+7. **FileCheck installation**: Mirror tarball does NOT include FileCheck (#897). CI installs it via `apt-get install llvm-{MAJOR}-tools` from `apt.llvm.org`. macOS: `brew install llvm@{MAJOR}` → `/opt/homebrew/opt/llvm@{MAJOR}/bin/FileCheck`.

--- a/changelog.d/897-filecheck.md
+++ b/changelog.d/897-filecheck.md
@@ -1,0 +1,4 @@
+### Added
+
+- Introduced LLVM FileCheck-based golden IR tests for codegen regressions (`tests/filecheck/`) (#897)
+- Added `ry --emit-llvm-ir` flag to emit unoptimized LLVM IR to stdout without running the program (#897)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -435,3 +435,84 @@ it should return error when file is missing
 
 - Nesting of `describe` (lambda syntax) is not supported; use the function-based `@describe` directive syntax for nested grouping
 - `before_each` / `after_each` are not supported
+
+---
+
+## IR Golden Tests (FileCheck)
+
+Ry exposes an `--emit-llvm-ir` flag that runs the full compiler pipeline (parse → type-check → codegen) and prints the **unoptimized LLVM IR** to stdout without executing the program. Combined with [LLVM FileCheck](https://llvm.org/docs/CommandGuide/FileCheck.html), this enables declarative structural assertions on the generated IR.
+
+### When to use
+
+Use FileCheck goldens when you need to assert IR structure directly:
+
+- Opaque pointer convention (`ptr` instead of typed `i8*`)
+- Arithmetic overflow patterns (`llvm.sadd.with.overflow`)
+- ARC retain/release order in CoW or lambda capture scenarios
+- Result/Error type layout (`%Result = type { i1, i64, ptr }`)
+
+For behavioral correctness ("does this produce the right answer?"), use `ry test` instead.
+
+### `ry --emit-llvm-ir` contract
+
+```bash
+ry --emit-llvm-ir <file.ry>       # Emit unoptimized IR for a .ry file
+ry --emit-llvm-ir -c '<source>'   # Emit IR for inline source
+```
+
+- Runs parse → type-check → codegen only; **does not JIT-run the program**
+- Prints unoptimized IR to stdout (codegen output before LLVM O2 passes)
+- On success: exits with code 0
+- On parse/codegen error: prints diagnostics to stderr, exits non-zero, stdout is empty
+
+### File location
+
+Golden files live in `tests/filecheck/*.ry`. Each `.ry` file is both a valid Ry source file and a FileCheck script — `# CHECK:` lines are Ry comments that FileCheck reads as directives.
+
+### Writing a golden
+
+Create a `.ry` file in `tests/filecheck/`. Place `# CHECK:` directives at the top as comments:
+
+```ry
+# FileCheck golden: brief description of what is verified.
+#
+# CHECK-LABEL: define i64 @my_func(i64 %x)
+# CHECK:         alloca i64
+# CHECK:         ret i64
+
+function my_func(x: int) -> int:
+  return x
+```
+
+**Authoring guidelines:**
+
+- Use `# CHECK:` (Ry `#` comment syntax; `//` is not a Ry comment and causes a parse error)
+- Write patterns against **unoptimized IR** — optimization passes are not applied, so `alloca`/`store`/`load` sequences for function arguments are always present
+- All pointer types are `ptr` (LLVM 17+ opaque pointer convention); never write `i64*`, `i8*`, etc.
+- Use `CHECK-LABEL:` to anchor patterns to a specific function definition (`define ... @func_name(...)`)
+- Use `CHECK-NEXT:` for consecutive-line assertions; use `CHECK-DAG:` for order-independent assertions
+- Use `CHECK-NOT:` to assert that an instruction does not appear
+- When a function requires `Ok`/`Err`/`Result` (stdlib types), the file is run from the project root so `package.toml` resolves stdlib automatically; no special flag is needed
+
+### Running locally
+
+```bash
+# Run all FileCheck goldens via CTest
+ctest --test-dir build -L filecheck --output-on-failure
+
+# Run a single golden manually
+./build/ry --emit-llvm-ir tests/filecheck/function_call.ry \
+  | /opt/homebrew/opt/llvm@21/bin/FileCheck tests/filecheck/function_call.ry
+
+# Install FileCheck (macOS)
+brew install llvm@21   # → /opt/homebrew/opt/llvm@21/bin/FileCheck
+
+# Install FileCheck (Linux)
+sudo apt-get install llvm-21-tools   # → /usr/lib/llvm-21/bin/FileCheck
+```
+
+CMake auto-detects FileCheck at configure time. If not found, `cmake --preset default` prints a status message and skips the `filecheck` CTest label — other tests are unaffected.
+
+### CI gate
+
+The `filecheck` CI job runs on all events — pull requests and push to `main`/`v*.*.*` branches. It builds only the `ry` binary (not `ry_tests`), so it completes quickly. It uses `continue-on-error: true` (warn-only) during the initial rollout. FileCheck is installed explicitly via `apt.llvm.org` because the LLVM mirror tarball does not include `llvm-tools`.

--- a/include/ry/cli.hpp
+++ b/include/ry/cli.hpp
@@ -27,8 +27,9 @@ void printSelfUpdateHelp();
 // Parse --env= flag or RY_ENV env var. Returns true if skip_global_lib should be set.
 bool parseRyEnv(int &argc, char **&argv);
 
-// Parse --trace / --trace-out= flags, updating trace_enabled and trace_out.
-void parseGlobalFlags(int &argc, char **&argv, bool &trace_enabled, std::string &trace_out);
+// Parse --trace / --trace-out= / --emit-llvm-ir flags.
+void parseGlobalFlags(int &argc, char **&argv, bool &trace_enabled, std::string &trace_out,
+                      bool &emit_llvm_ir);
 
 } // namespace cli
 } // namespace ry

--- a/include/ry/jit_runner.hpp
+++ b/include/ry/jit_runner.hpp
@@ -17,11 +17,11 @@ int runRySource(const std::string &src, const std::string &source_name,
                 const std::string &referrer_dir, bool test_mode,
                 const char *argv0, bool skip_global_lib,
                 bool coverage_mode = false, bool outline_mode = false,
-                CoverageState *cs = nullptr);
+                CoverageState *cs = nullptr, bool emit_llvm_ir = false);
 
 int runRyFile(const std::string &filepath, bool test_mode,
               const char *argv0, bool skip_global_lib,
               bool coverage_mode = false, bool outline_mode = false,
-              CoverageState *cs = nullptr);
+              CoverageState *cs = nullptr, bool emit_llvm_ir = false);
 
 } // namespace ry

--- a/src/cli.cpp
+++ b/src/cli.cpp
@@ -142,6 +142,7 @@ void printMainHelp() {
     llvm::outs() << "  --env=<env>      Set environment (production|development|internal)\n";
     llvm::outs() << "  --trace          Emit structured internal trace as JSON Lines\n";
     llvm::outs() << "  --trace-out=PATH Write trace output to PATH (or '-' for stderr)\n";
+    llvm::outs() << "  --emit-llvm-ir   Emit unoptimized LLVM IR to stdout and exit\n";
     llvm::outs() << "\n";
     llvm::outs() << "Run 'ry <command> --help' for more information on a command.\n";
 }
@@ -216,13 +217,16 @@ bool parseRyEnv(int &argc, char **&argv) {
     return skip_global_lib;
 }
 
-void parseGlobalFlags(int &argc, char **&argv, bool &trace_enabled, std::string &trace_out) {
+void parseGlobalFlags(int &argc, char **&argv, bool &trace_enabled, std::string &trace_out,
+                      bool &emit_llvm_ir) {
     while (argc >= 2) {
         if (std::strcmp(argv[1], "--trace") == 0) {
             trace_enabled = true;
         } else if (std::strncmp(argv[1], "--trace-out=", 12) == 0) {
             trace_enabled = true;
             trace_out = argv[1] + 12;
+        } else if (std::strcmp(argv[1], "--emit-llvm-ir") == 0) {
+            emit_llvm_ir = true;
         } else {
             break;
         }

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -71,7 +71,7 @@ int runRySource(const std::string &src, const std::string &source_name,
                 const std::string &referrer_dir, bool test_mode,
                 const char *argv0, bool skip_global_lib,
                 bool coverage_mode, bool outline_mode,
-                CoverageState *cs) {
+                CoverageState *cs, bool emit_llvm_ir) {
     SourceLocation sourceLoc{1, 1, 0};
     if (ry::traceEnabled()) {
         ry::emitTraceEvent("source.loaded", "compile", &sourceLoc,
@@ -173,6 +173,11 @@ int runRySource(const std::string &src, const std::string &source_name,
             throw;
         }
     }();
+
+    if (emit_llvm_ir) {
+        tsm.getModuleUnlocked()->print(llvm::outs(), nullptr);
+        return 0;
+    }
 
     // Build LLJIT
     if (ry::traceEnabled())
@@ -404,7 +409,7 @@ int runRySource(const std::string &src, const std::string &source_name,
 int runRyFile(const std::string &filepath, bool test_mode,
               const char *argv0, bool skip_global_lib,
               bool coverage_mode, bool outline_mode,
-              CoverageState *cs) {
+              CoverageState *cs, bool emit_llvm_ir) {
     auto bufOrErr = MemoryBuffer::getFile(filepath);
     if (!bufOrErr) {
         errs() << "Error reading file: " << filepath << "\n";
@@ -413,7 +418,7 @@ int runRyFile(const std::string &filepath, bool test_mode,
     std::string src = (*bufOrErr)->getBuffer().str();
     std::string referrer_dir = fs::path(filepath).parent_path().string();
     return runRySource(src, filepath, referrer_dir, test_mode, argv0, skip_global_lib,
-                       coverage_mode, outline_mode, cs);
+                       coverage_mode, outline_mode, cs, emit_llvm_ir);
 }
 
 } // namespace ry

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,8 @@ int main(int argc, char *argv[]) {
     bool skip_global_lib = ry::cli::parseRyEnv(argc, argv);
     bool trace_enabled = false;
     std::string trace_out = "-";
-    ry::cli::parseGlobalFlags(argc, argv, trace_enabled, trace_out);
+    bool emit_llvm_ir = false;
+    ry::cli::parseGlobalFlags(argc, argv, trace_enabled, trace_out, emit_llvm_ir);
     ry::configureTrace(trace_enabled, trace_out);
     bool sessionStarted = false;
     if (ry::traceEnabled()) {
@@ -103,7 +104,8 @@ int main(int argc, char *argv[]) {
         __ry_args_init(0, nullptr);
         std::string cwd = fs::current_path().string();
         try {
-            return ry::runRySource(src, "<stdin>", cwd, false, argv[0], skip_global_lib);
+            return ry::runRySource(src, "<stdin>", cwd, false, argv[0], skip_global_lib,
+                                   false, false, nullptr, emit_llvm_ir);
         } catch (const DiagnosticError &e) {
             errs() << e.what();
             return 1;
@@ -296,7 +298,8 @@ int main(int argc, char *argv[]) {
         ry::CoverageState cs;
         if (coverage_mode) ry::resetCoverageState(cs);
         int rc = ry::runRyFile(filename, test_mode, argv[0], skip_global_lib,
-                               coverage_mode, outline_mode, coverage_mode ? &cs : nullptr);
+                               coverage_mode, outline_mode, coverage_mode ? &cs : nullptr,
+                               emit_llvm_ir);
         if (coverage_mode) ry::emitCoverageReport(cs);
         return rc;
     } catch (const DiagnosticError &e) {

--- a/tests/filecheck/function_call.ry
+++ b/tests/filecheck/function_call.ry
@@ -1,0 +1,13 @@
+# FileCheck golden: integer function with overflow-checked addition.
+# Verifies opaque-pointer IR, sadd.with.overflow pattern, and overflow branch.
+#
+# CHECK-LABEL: define i64 @add(i64 %a, i64 %b)
+# CHECK:         alloca i64
+# CHECK:         store i64 {{.*}}, ptr
+# CHECK:         call { i64, i1 } @llvm.sadd.with.overflow.i64
+# CHECK:         br i1 {{.*}}, label %add.overflow_err, label %add.ok
+# CHECK:       add.ok:
+# CHECK-NEXT:    ret i64
+
+function add(a: int, b: int) -> int:
+  return a + b

--- a/tests/filecheck/result_wrap.ry
+++ b/tests/filecheck/result_wrap.ry
@@ -1,0 +1,15 @@
+# FileCheck golden: Result<int, str> wrapping structure.
+# Verifies that Ok(v) uses insertvalue with is_ok=true (i1 true) and
+# Err(msg) uses a direct constant aggregate with is_ok=false (i1 false).
+#
+# CHECK: %Result = type { i1, i64, ptr }
+# CHECK-LABEL: define %Result @safe_div(i64 %a, i64 %b)
+# CHECK:         ret %Result { i1 false,
+# CHECK:         insertvalue %Result { i1 true,
+# CHECK:         ret %Result
+
+function safe_div(a: int, b: int) -> Result<int, str>:
+  if b == 0:
+    return Err("division by zero")
+  result: int = a // b
+  return Ok(result)

--- a/tests/filecheck/str_ptr.ry
+++ b/tests/filecheck/str_ptr.ry
@@ -1,0 +1,11 @@
+# FileCheck golden: str arguments use opaque pointer type (ptr) throughout.
+# Verifies LLVM 17+ opaque pointer convention: no typed i8*, char* etc.
+#
+# CHECK-LABEL: define ptr @identity(ptr %s)
+# CHECK:         alloca ptr
+# CHECK:         store ptr {{.*}}, ptr
+# CHECK:         load ptr, ptr
+# CHECK:         ret ptr
+
+function identity(s: str) -> str:
+  return s

--- a/tests/test_emit_llvm_ir.cpp
+++ b/tests/test_emit_llvm_ir.cpp
@@ -1,0 +1,159 @@
+#include <gtest/gtest.h>
+#include <array>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unistd.h>
+#include <sys/wait.h>
+
+namespace fs = std::filesystem;
+
+// Run ry binary with the given arguments.
+// Returns {stdout, stderr, exit_code}.  stdin is closed in the child.
+// RY_ENV=internal is set so tests run without the installed global stdlib;
+// all test sources in this file use only built-in types (no stdlib import).
+struct RunResult {
+    std::string out;
+    std::string err;
+    int exit_code = -1;
+};
+
+static RunResult runRy(std::vector<const char *> args) {
+    int pipeOut[2];
+    int pipeErr[2];
+    if (pipe(pipeOut) != 0 || pipe(pipeErr) != 0)
+        return {};
+
+    pid_t pid = fork();
+    if (pid < 0)
+        return {};
+
+    if (pid == 0) {
+        close(pipeOut[0]);
+        close(pipeErr[0]);
+        dup2(pipeOut[1], STDOUT_FILENO);
+        dup2(pipeErr[1], STDERR_FILENO);
+        close(pipeOut[1]);
+        close(pipeErr[1]);
+        close(STDIN_FILENO);
+        setenv("RY_ENV", "internal", 1);
+
+        std::vector<const char *> argv{"ry"};
+        argv.insert(argv.end(), args.begin(), args.end());
+        argv.push_back(nullptr);
+
+        execv(RY_BINARY_PATH, const_cast<char *const *>(argv.data()));
+        _exit(127);
+    }
+
+    close(pipeOut[1]);
+    close(pipeErr[1]);
+
+    auto readAll = [](int fd) -> std::string {
+        std::string result;
+        std::array<char, 4096> buf{};
+        ssize_t n;
+        while ((n = read(fd, buf.data(), buf.size())) > 0)
+            result.append(buf.data(), static_cast<size_t>(n));
+        close(fd);
+        return result;
+    };
+
+    RunResult r;
+    r.out = readAll(pipeOut[0]);
+    r.err = readAll(pipeErr[0]);
+    int status = 0;
+    waitpid(pid, &status, 0);
+    r.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    return r;
+}
+
+class EmitLlvmIrTest : public ::testing::Test {
+protected:
+    fs::path tmpDir_;
+
+    void SetUp() override {
+        tmpDir_ = fs::temp_directory_path() / "ry_emit_llvm_ir_test";
+        fs::create_directories(tmpDir_);
+    }
+
+    void TearDown() override { fs::remove_all(tmpDir_); }
+
+    fs::path writeTmp(const std::string &name, const std::string &content) {
+        auto p = tmpDir_ / name;
+        std::ofstream(p) << content;
+        return p;
+    }
+};
+
+// ------------------------------------------------------------------
+// Happy paths
+// ------------------------------------------------------------------
+
+TEST_F(EmitLlvmIrTest, ValidFileExitZero) {
+    auto p = writeTmp("add.ry",
+        "function add(a: int, b: int) -> int:\n"
+        "  return a + b\n");
+    auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+}
+
+TEST_F(EmitLlvmIrTest, OutputContainsModuleId) {
+    auto p = writeTmp("add.ry",
+        "function add(a: int, b: int) -> int:\n"
+        "  return a + b\n");
+    auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
+    EXPECT_NE(r.out.find("ModuleID"), std::string::npos);
+}
+
+TEST_F(EmitLlvmIrTest, OutputContainsFunctionDefine) {
+    auto p = writeTmp("add.ry",
+        "function add(a: int, b: int) -> int:\n"
+        "  return a + b\n");
+    auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
+    EXPECT_NE(r.out.find("define"), std::string::npos);
+}
+
+TEST_F(EmitLlvmIrTest, UnoptimizedIrRetainsAlloca) {
+    // Unoptimized IR keeps alloca/store/load for function arguments.
+    // Post-opt IR would mem2reg these away; --emit-llvm-ir must not run opt.
+    auto p = writeTmp("add.ry",
+        "function add(a: int, b: int) -> int:\n"
+        "  return a + b\n");
+    auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
+    EXPECT_NE(r.out.find("alloca"), std::string::npos);
+}
+
+TEST_F(EmitLlvmIrTest, DoesNotExecuteProgram) {
+    // --emit-llvm-ir must not JIT-run the program; stderr must be empty
+    // (no runtime prints, no assertion output).
+    auto p = writeTmp("noop.ry",
+        "function add(a: int, b: int) -> int:\n"
+        "  return a + b\n");
+    auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_TRUE(r.err.empty());
+}
+
+// ------------------------------------------------------------------
+// Error paths
+// ------------------------------------------------------------------
+
+TEST_F(EmitLlvmIrTest, NonexistentFileExitNonzero) {
+    auto r = runRy({"--emit-llvm-ir", "/nonexistent/does_not_exist.ry"});
+    EXPECT_NE(r.exit_code, 0);
+}
+
+TEST_F(EmitLlvmIrTest, SyntaxErrorExitNonzero) {
+    auto p = writeTmp("bad.ry", "function bad( -> int:\n  return 0\n");
+    auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
+    EXPECT_NE(r.exit_code, 0);
+    EXPECT_FALSE(r.err.empty());
+}
+
+TEST_F(EmitLlvmIrTest, SyntaxErrorStdoutEmpty) {
+    // On error, no partial IR should appear on stdout.
+    auto p = writeTmp("bad.ry", "function bad( -> int:\n  return 0\n");
+    auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
+    EXPECT_TRUE(r.out.empty());
+}

--- a/tests/test_emit_llvm_ir.cpp
+++ b/tests/test_emit_llvm_ir.cpp
@@ -1,9 +1,11 @@
 #include <gtest/gtest.h>
 #include <array>
+#include <cstdlib>
 #include <filesystem>
 #include <fstream>
 #include <string>
 #include <thread>
+#include <vector>
 #include <unistd.h>
 #include <sys/wait.h>
 
@@ -138,11 +140,13 @@ TEST_F(EmitLlvmIrTest, UnoptimizedIrRetainsAlloca) {
 }
 
 TEST_F(EmitLlvmIrTest, DoesNotExecuteProgram) {
-    // --emit-llvm-ir must not JIT-run the program; stderr must be empty
-    // (no runtime prints, no assertion output).
+    // If executed, main() overflows INT64_MAX + 1 and the overflow handler
+    // aborts with a non-zero exit and stderr output.  With --emit-llvm-ir,
+    // codegen must succeed and execution must be skipped entirely.
     auto p = writeTmp("noop.ry",
-        "function add(a: int, b: int) -> int:\n"
-        "  return a + b\n");
+        "function main():\n"
+        "  x: int = 9223372036854775807\n"
+        "  x = x + 1\n");
     auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
     EXPECT_EQ(r.exit_code, 0);
     EXPECT_TRUE(r.err.empty());

--- a/tests/test_emit_llvm_ir.cpp
+++ b/tests/test_emit_llvm_ir.cpp
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <fstream>
 #include <string>
+#include <thread>
 #include <unistd.h>
 #include <sys/wait.h>
 
@@ -21,12 +22,22 @@ struct RunResult {
 static RunResult runRy(std::vector<const char *> args) {
     int pipeOut[2];
     int pipeErr[2];
-    if (pipe(pipeOut) != 0 || pipe(pipeErr) != 0)
+    if (pipe(pipeOut) != 0)
         return {};
+    if (pipe(pipeErr) != 0) {
+        close(pipeOut[0]);
+        close(pipeOut[1]);
+        return {};
+    }
 
     pid_t pid = fork();
-    if (pid < 0)
+    if (pid < 0) {
+        close(pipeOut[0]);
+        close(pipeOut[1]);
+        close(pipeErr[0]);
+        close(pipeErr[1]);
         return {};
+    }
 
     if (pid == 0) {
         close(pipeOut[0]);
@@ -60,8 +71,10 @@ static RunResult runRy(std::vector<const char *> args) {
     };
 
     RunResult r;
-    r.out = readAll(pipeOut[0]);
-    r.err = readAll(pipeErr[0]);
+    std::thread outReader([&]() { r.out = readAll(pipeOut[0]); });
+    std::thread errReader([&]() { r.err = readAll(pipeErr[0]); });
+    outReader.join();
+    errReader.join();
     int status = 0;
     waitpid(pid, &status, 0);
     r.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;


### PR DESCRIPTION
## Summary

- Add `ry --emit-llvm-ir` flag: runs parse → typecheck → codegen and prints unoptimized LLVM IR to stdout without JIT-running the program
- Add 8 GTests in `tests/test_emit_llvm_ir.cpp` for CLI contract verification (exit codes, stdout/stderr content, alloca retention)
- Add 3 initial FileCheck goldens in `tests/filecheck/`:
  - `function_call.ry` — `sadd.with.overflow` overflow-checked arithmetic + branch pattern
  - `str_ptr.ry` — LLVM 17+ opaque pointer convention for `str` arguments
  - `result_wrap.ry` — `Result<int, str>` wrapping layout (`{ i1, i64, ptr }`)
- CMake auto-detects FileCheck via `find_program` HINTS; registers goldens as `ctest -L filecheck`
- CI: `filecheck` job added to `ci.yml` (runs on **all events including PRs**, ccache enabled) and `ci-scheduled.yml` (daily on latest `v*.*.*`)
- AGENTS.md, docs, KNOWLEDGE.md updated; `changelog.d/897-filecheck.md` added

## Follow-up issues filed

- #1171 — Bundle `llvm-tools` in LLVM mirror tarball (eliminates extra apt install)
- #1172 — Promote `filecheck` CI job from warn-only → required
- #1173 — Expand FileCheck goldens (List, GC, `@parallel`, stdlib imports)
- #1174 — Evaluate llvm-lit upgrade when golden count exceeds ~20

## Test plan

- [x] `./build/ry_tests` — 1814/1814 PASSED (includes 8 new EmitLlvmIrTest)
- [x] `./build/ry test -p` — 143 files, 0 failures
- [x] `ctest --test-dir build -L filecheck` — 3/3 PASSED
- [x] ASan+UBSan: `./build-asan/ry_tests` — 1814/1814 PASSED
- [x] TSan: `./build-tsan/ry_tests` — 1814/1814 PASSED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --emit-llvm-ir CLI flag to emit unoptimized LLVM IR to stdout without executing the program.
  * Introduced LLVM FileCheck-based IR golden tests to detect codegen regressions.

* **Documentation**
  * Added IR golden testing guidance, authoring conventions, and platform/setup notes.

* **Tests**
  * Added automated tests for emit behavior and FileCheck golden validations.

* **Chores**
  * Integrated FileCheck checks into CI and test registration (warn-only on PRs).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->