### PR TITLE
fix: restore clang-tidy HeaderFilterRegex to include/ry/ only (#1150)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,7 +46,7 @@ Checks: >
 
 WarningsAsErrors: '*'
 
-HeaderFilterRegex: '^(include/ry|src)/.*\.(h|hpp)$'
+HeaderFilterRegex: '^include/ry/.*\.hpp$'
 
 FormatStyle: none
 

--- a/changelog.d/1150-clang-tidy-header-filter.md
+++ b/changelog.d/1150-clang-tidy-header-filter.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Restored `HeaderFilterRegex` in `.clang-tidy` to `^include/ry/.*\.hpp$`, removing the unintentional `src/` inclusion added defensively in #950 (#1150)


### PR DESCRIPTION
## Summary

- Removes the `src/` path from `.clang-tidy` `HeaderFilterRegex`, restoring it to `^include/ry/.*\.hpp$`
- The `src/` inclusion was added defensively in #950 ("no src/ headers exist today; this is a defensive pre-emptive fix"), but violates the policy stated in AGENTS.md ("HeaderFilterRegex はプロジェクトヘッダ (`include/ry/`) のみに制限") and was flagged in the #1148 CodeRabbit review
- No `src/*.hpp` or `src/*.h` files exist, so this is a no-op behaviorally — pure config cleanup

## Test plan

- [x] Regex verified: `^include/ry/.*\.hpp$` matches all 46 `include/ry/*.hpp` files; rejects `src/`, `.h`, and LLVM headers
- [x] `./build/ry_tests` — passed
- [x] `./build/ry test -p` — passed
- [x] ASan+UBSan `ry_tests` + `ry test -p` — passed
- [x] TSan `ry_tests` (required) + `ry test -p` (warn-only) — passed
- [x] `fuzz_parser`, `fuzz_json`, `fuzz_utf8` × 60s — all exit 0

Closes #1150

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined static analysis tool configuration for improved header file filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->