### PR TITLE
fix: None() and bare none in branch-merge positions adopt contextual Option<T> inner type (#1154)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3306,19 +3306,23 @@ This is the same rule as the `IfBlockExpr` path tested in `tests/spec/option_lam
 **Source**: #1154 (2026-04-18, bugfix — `None()` in if/case branch defaults to `Option<i8>`)
 **Tags**: codegen, Option, None, NoneExpr, branch-merge, IfExpr, CaseExpr, hint-channel, RAII
 
-**Rule**: `None()` and `none` in branch-merge positions (e.g., `if cond => None() else Some(42)`) previously defaulted to `Option<i8>` or `Option<i64>` because the emitters only consulted `fn_->getReturnType()`. The fix introduces a class-state hint channel:
+**Rule**: `None()` and `none` in branch-merge positions (e.g., `if cond => None() else Some(42)`) previously defaulted to `Option<i8>` or `Option<i64>` because the emitters only consulted `fn_->getReturnType()`. The fix introduces a two-field class-state hint channel:
 
-- `option_none_hint_inner_: llvm::Type*` on `CodeGen` (nullptr = no hint).
-- `OptionNoneHintGuard` RAII saves/restores the hint, keeping nested branches independent.
+- **`option_none_hint_inner_: llvm::Type*`** — arm hint, read directly by `None()` and `NoneExpr` emitters (nullptr = no hint).
+- **`option_decl_annotation_inner_: llvm::Type*`** — declaration-context annotation inner, written by `emitVarDecl`/local-reassign/global-reassign via `DeclAnnotationInnerGuard`. **NOT read by None()/NoneExpr emitters directly** — only used as fallback in IfExpr/IfBlockExpr guards so it cannot leak into arbitrary sub-expressions (e.g., function arguments such as `foo(none)`).
+- `OptionNoneHintGuard` RAII saves/restores `option_none_hint_inner_`; `DeclAnnotationInnerGuard` RAII saves/restores `option_decl_annotation_inner_`.
 - `computeBranchOptionInnerHint(a, b)` in `codegen_lambda.cpp` runs `inferExprType` on both arms and picks the more-concrete inner via `preferConcrete`.
-- **Annotation seed** at three `codegen_stmt.cpp` sites: `emitVarDecl`, local reassign, module-global reassign — sets hint from the declared `Option<T>` inner before `emitExpr(RHS)`. Handles annotated variable declarations whose RHS is an if/case expression.
-- **IfExpr / IfBlockExpr pre-scan** in `codegen_expr.cpp`: calls `computeBranchOptionInnerHint` on the arm expressions and wraps both arm emits in a guard. Handles non-annotated contexts such as lambda bodies.
-- **`NoneExpr` added to `inferExprType`** in `codegen_lambda.cpp`: previously fell through to the `i64Ty_` fallback; now returns `getOptionType(i8Ty_)` so `computeBranchOptionInnerHint` can detect it as an Option placeholder.
-- **CaseExpr (pattern match) does NOT use pre-scan**: `Some(v)` arm values reference pattern-bound variables (`v`) that are not in scope at pre-scan time, so `inferExprType(VariableExpr{v})` would return the wrong type for non-integer inner types. Annotation seed covers the annotated-variable case; `fn_->getReturnType()` covers the lambda-return case.
+- **Annotation seed** at three `codegen_stmt.cpp` sites: `emitVarDecl`, local reassign, module-global reassign — writes `option_decl_annotation_inner_` (not `option_none_hint_inner_`) from the declared `Option<T>` inner before `emitExpr(RHS)`.
+- **IfExpr / IfBlockExpr pre-scan** in `codegen_expr.cpp`: computes hint **before** condition emit, installs `OptionNoneHintGuard` **after** condition emit. The fallback for all-None arms uses `option_decl_annotation_inner_`. **Critical**: the guard must be installed after the condition because `none`/`None()` in the condition expression must not inherit the arm hint.
+- **`NoneExpr` added to `inferExprType` and `inferExprTypeName`** in `codegen_lambda.cpp`: `inferExprType` returns `getOptionType(i8Ty_)` so `computeBranchOptionInnerHint` detects it as an Option placeholder; `inferExprTypeName` returns `"Option"`.
+- **CaseExpr (pattern match) uses scrutinee-based hint** in `codegen_match.cpp::emitExprVariant(CaseExpr)`: `Some(v)` arm values reference pattern-bound variables not in scope at pre-scan time, so `computeBranchOptionInnerHint` cannot be applied. Instead, the scrutinee type (`subjectTy`) is used — if it is `Option<T>`, its inner `T` is extracted and installed as the `OptionNoneHintGuard` hint before any arm is emitted. Fallback is `option_decl_annotation_inner_`.
+- **CaseCondExpr (`when cond => value`) uses pre-scan** in `codegen_expr.cpp::emitExprVariant(CaseCondExpr)`: no pattern variables are involved, so `computeBranchOptionInnerHint` on the first arm value and `else_expr` is safe. Guard is installed inside each value emit block (after the arm condition) to prevent hint leaking into condition expressions.
+
+**Known limitation**: `None()` and `none` in function argument positions (e.g., `f(none)`) do NOT inherit the enclosing declaration annotation; they fall back to `fn_->getReturnType()` or the default `i64`/`i8` placeholder. Filed as #1179. The `option_decl_annotation_inner_` field intentionally does NOT flow into argument positions to avoid incorrect type propagation.
 
 **Priority invariant**: `isNoneLiteral` short-circuit at the three annotation-aware `codegen_stmt.cpp` sites must remain the *first* check (runs before the hint seed). It handles the trivial `x: Option<int> = None()` case without touching hint state and is faster.
 
-**ADR #1111 compliance**: The hint is threaded via CodeGen class state + RAII guard, not via `emitExpr` signature changes.
+**ADR #1111 compliance**: The hint is threaded via CodeGen class state + RAII guards, not via `emitExpr` signature changes.
 
 ### UnaryExpr fast-path covers bare int for INT64_MIN (`-9223372036854775808`)
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3301,6 +3301,25 @@ This is the same rule as the `IfBlockExpr` path tested in `tests/spec/option_lam
 
 **How to apply**: When adding a new syntactic form of `None` to the language, extend `isNoneLiteral` first. Then all three sites above automatically inherit the fix. The `None()` emitter in `codegen_call.cpp` is a separate fallback for contexts where no annotation is available (e.g., return-stmt); it is not a substitute for `isNoneLiteral`. Use `std::get_if<std::unique_ptr<CallExpr>>` (not `std::get_if<CallExpr>`) because `CallExpr` is stored as `unique_ptr` in the `ExprNode` variant.
 
+### Hint channel for `None()`/`none` inner type in branch-merge positions
+
+**Source**: #1154 (2026-04-18, bugfix — `None()` in if/case branch defaults to `Option<i8>`)
+**Tags**: codegen, Option, None, NoneExpr, branch-merge, IfExpr, CaseExpr, hint-channel, RAII
+
+**Rule**: `None()` and `none` in branch-merge positions (e.g., `if cond => None() else Some(42)`) previously defaulted to `Option<i8>` or `Option<i64>` because the emitters only consulted `fn_->getReturnType()`. The fix introduces a class-state hint channel:
+
+- `option_none_hint_inner_: llvm::Type*` on `CodeGen` (nullptr = no hint).
+- `OptionNoneHintGuard` RAII saves/restores the hint, keeping nested branches independent.
+- `computeBranchOptionInnerHint(a, b)` in `codegen_lambda.cpp` runs `inferExprType` on both arms and picks the more-concrete inner via `preferConcrete`.
+- **Annotation seed** at three `codegen_stmt.cpp` sites: `emitVarDecl`, local reassign, module-global reassign — sets hint from the declared `Option<T>` inner before `emitExpr(RHS)`. Handles annotated variable declarations whose RHS is an if/case expression.
+- **IfExpr / IfBlockExpr pre-scan** in `codegen_expr.cpp`: calls `computeBranchOptionInnerHint` on the arm expressions and wraps both arm emits in a guard. Handles non-annotated contexts such as lambda bodies.
+- **`NoneExpr` added to `inferExprType`** in `codegen_lambda.cpp`: previously fell through to the `i64Ty_` fallback; now returns `getOptionType(i8Ty_)` so `computeBranchOptionInnerHint` can detect it as an Option placeholder.
+- **CaseExpr (pattern match) does NOT use pre-scan**: `Some(v)` arm values reference pattern-bound variables (`v`) that are not in scope at pre-scan time, so `inferExprType(VariableExpr{v})` would return the wrong type for non-integer inner types. Annotation seed covers the annotated-variable case; `fn_->getReturnType()` covers the lambda-return case.
+
+**Priority invariant**: `isNoneLiteral` short-circuit at the three annotation-aware `codegen_stmt.cpp` sites must remain the *first* check (runs before the hint seed). It handles the trivial `x: Option<int> = None()` case without touching hint state and is faster.
+
+**ADR #1111 compliance**: The hint is threaded via CodeGen class state + RAII guard, not via `emitExpr` signature changes.
+
 ### UnaryExpr fast-path covers bare int for INT64_MIN (`-9223372036854775808`)
 
 **Source**: #1025 (2026-04-16)

--- a/changelog.d/1154-none-contextual-type.md
+++ b/changelog.d/1154-none-contextual-type.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `None()` and bare `none` in `if`/`case` branch-merge positions now correctly
+  adopt the sibling arm's `Option<T>` inner type instead of defaulting to
+  `Option<i8>` or `Option<i64>` (#1154)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -171,6 +171,30 @@ public:
     // non-zero depth into subsequent unrelated codegen. See #630.
     int parallel_for_depth_ = 0;
 
+    // Hint for None()/none inner type in branch-merge positions (#1154).
+    // Set to the expected inner type before emitting an arm expression that
+    // may contain None() or bare none. nullptr means "no hint; fall back to
+    // fn_->getReturnType() or i8/i64 defaults".
+    llvm::Type *option_none_hint_inner_ = nullptr;
+
+    // RAII guard: saves and restores option_none_hint_inner_ so nested
+    // branches have independent scopes.
+    struct OptionNoneHintGuard {
+        CodeGen &cg_;
+        llvm::Type *saved_;
+        explicit OptionNoneHintGuard(CodeGen &cg, llvm::Type *hint)
+            : cg_(cg), saved_(cg.option_none_hint_inner_) {
+            cg_.option_none_hint_inner_ = hint;
+        }
+        ~OptionNoneHintGuard() { cg_.option_none_hint_inner_ = saved_; }
+        OptionNoneHintGuard(const OptionNoneHintGuard &) = delete;
+        OptionNoneHintGuard &operator=(const OptionNoneHintGuard &) = delete;
+    };
+
+    // Compute the Option inner type hint from a pair of if/case arm expressions.
+    // Returns nullptr if neither arm is an Option literal or both are placeholders.
+    llvm::Type *computeBranchOptionInnerHint(const ExprNode &a, const ExprNode &b);
+
     // RAII guard that increments parallel_for_depth_ on construction and
     // decrements on destruction (including during stack unwinding from a
     // codegenError thrown inside the thunk body).

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -181,8 +181,10 @@ public:
 
     // Declaration-context annotation inner type (#1154). Written by
     // emitVarDecl / local-reassign / global-reassign to carry the LHS
-    // Option<T> inner into the RHS emitter. Read only by IfExpr/IfBlockExpr
-    // guards as a fallback when computeBranchOptionInnerHint returns nullptr.
+    // Option<T> inner into the RHS emitter. Read by branch-arm guards
+    // (IfExpr, IfBlockExpr, CaseCondExpr, and CaseExpr scrutinee path) as a
+    // fallback when computeBranchOptionInnerHint or scrutinee-derived hints
+    // are unavailable.
     // None()/NoneExpr emitters do NOT read this field directly, so it cannot
     // leak into arbitrary sub-expressions (e.g., function arguments).
     llvm::Type *option_decl_annotation_inner_ = nullptr;

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -175,7 +175,8 @@ public:
     // Set to the expected inner type before emitting an arm expression that
     // may contain None() or bare none. nullptr means "no hint; fall back to
     // fn_->getReturnType() or i8/i64 defaults".
-    // Only IfExpr/IfBlockExpr guards write this field; None()/NoneExpr
+    // Written by branch-arm guard paths (IfExpr, IfBlockExpr, CaseCondExpr,
+    // and CaseExpr arm-scoped/scrutinee-derived flows); None()/NoneExpr
     // emitters read it.
     llvm::Type *option_none_hint_inner_ = nullptr;
 
@@ -216,8 +217,9 @@ public:
         DeclAnnotationInnerGuard &operator=(const DeclAnnotationInnerGuard &) = delete;
     };
 
-    // Compute the Option inner type hint from a pair of if/case arm expressions.
-    // Returns nullptr if neither arm is an Option literal or both are placeholders.
+    // Compute an Option inner-type hint from a pair of branch-arm expressions.
+    // Returns nullptr when no concrete inner type can be derived
+    // (e.g., non-Option arms or placeholder-only outcomes).
     llvm::Type *computeBranchOptionInnerHint(const ExprNode &a, const ExprNode &b);
 
     // RAII guard that increments parallel_for_depth_ on construction and

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -175,7 +175,17 @@ public:
     // Set to the expected inner type before emitting an arm expression that
     // may contain None() or bare none. nullptr means "no hint; fall back to
     // fn_->getReturnType() or i8/i64 defaults".
+    // Only IfExpr/IfBlockExpr guards write this field; None()/NoneExpr
+    // emitters read it.
     llvm::Type *option_none_hint_inner_ = nullptr;
+
+    // Declaration-context annotation inner type (#1154). Written by
+    // emitVarDecl / local-reassign / global-reassign to carry the LHS
+    // Option<T> inner into the RHS emitter. Read only by IfExpr/IfBlockExpr
+    // guards as a fallback when computeBranchOptionInnerHint returns nullptr.
+    // None()/NoneExpr emitters do NOT read this field directly, so it cannot
+    // leak into arbitrary sub-expressions (e.g., function arguments).
+    llvm::Type *option_decl_annotation_inner_ = nullptr;
 
     // RAII guard: saves and restores option_none_hint_inner_ so nested
     // branches have independent scopes.
@@ -189,6 +199,19 @@ public:
         ~OptionNoneHintGuard() { cg_.option_none_hint_inner_ = saved_; }
         OptionNoneHintGuard(const OptionNoneHintGuard &) = delete;
         OptionNoneHintGuard &operator=(const OptionNoneHintGuard &) = delete;
+    };
+
+    // RAII guard: saves and restores option_decl_annotation_inner_.
+    struct DeclAnnotationInnerGuard {
+        CodeGen &cg_;
+        llvm::Type *saved_;
+        explicit DeclAnnotationInnerGuard(CodeGen &cg, llvm::Type *inner)
+            : cg_(cg), saved_(cg.option_decl_annotation_inner_) {
+            cg_.option_decl_annotation_inner_ = inner;
+        }
+        ~DeclAnnotationInnerGuard() { cg_.option_decl_annotation_inner_ = saved_; }
+        DeclAnnotationInnerGuard(const DeclAnnotationInnerGuard &) = delete;
+        DeclAnnotationInnerGuard &operator=(const DeclAnnotationInnerGuard &) = delete;
     };
 
     // Compute the Option inner type hint from a pair of if/case arm expressions.

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -767,10 +767,13 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         return emitStringByteLen(ptr);
     }
 
-    // None() → Option<T> constructor (T derived from enclosing return type)
+    // None() → Option<T> constructor (T derived from hint, then return type)
     if (e.callee == "None") {
         if (!e.args.empty())
             codegenError("None() takes no arguments");
+        // Prefer branch-merge hint (#1154), then enclosing function return type.
+        if (option_none_hint_inner_)
+            return buildNoneValue(getOptionType(option_none_hint_inner_));
         llvm::Type *innerTy = i8Ty_;
         if (fn_) {
             llvm::Type *retTy = fn_->getReturnType();

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1746,6 +1746,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
 // ===== IfExpr (single-expression form: `if cond => then_val else else_val`) =====
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IfExpr> &e) {
+    // Pre-scan: derive None() inner-type hint from the non-None sibling arm
+    // so both arms get the same Option<T> type (#1154). The guard restores
+    // the previous hint after this if-expr is fully emitted.
+    llvm::Type *ifExprHint = computeBranchOptionInnerHint(*e->then_value, *e->else_value);
+    OptionNoneHintGuard ifExprGuard(*this, ifExprHint ? ifExprHint : option_none_hint_inner_);
+
     llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(*ctx_, "if.expr.then", fn_);
     llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(*ctx_, "if.expr.else", fn_);
     llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "if.expr.merge", fn_);
@@ -1792,6 +1798,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IfBlockExpr> &e) {
 
     const ExprNode *thenTail = extractTailExpr(e->then_body, "then");
     const ExprNode *elseTail = extractTailExpr(e->else_body, "else");
+
+    // Pre-scan: derive None() hint from the tail expressions (#1154).
+    llvm::Type *ifBlockHint = computeBranchOptionInnerHint(*thenTail, *elseTail);
+    OptionNoneHintGuard ifBlockGuard(*this, ifBlockHint ? ifBlockHint : option_none_hint_inner_);
 
     // Emit one branch body into an existing basic block: execute the
     // non-tail statements, then evaluate the tail expression. Returns
@@ -1841,11 +1851,16 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IfBlockExpr> &e) {
 // ===== NoneExpr =====
 
 llvm::Value *CodeGen::emitExprVariant(const NoneExpr &) {
-    // Build a None value for the expected Option type
-    // The type will be inferred from context (assignment, comparison, etc.)
-    // Default to Option<int> if no context is available
-    llvm::StructType *optTy = getOptionType(i64Ty_);
-    return buildNoneValue(optTy);
+    // Prefer branch-merge hint (#1154), then enclosing function return type.
+    if (option_none_hint_inner_)
+        return buildNoneValue(getOptionType(option_none_hint_inner_));
+    llvm::Type *innerTy = i64Ty_;
+    if (fn_) {
+        llvm::Type *retTy = fn_->getReturnType();
+        if (isOptionType(retTy))
+            innerTy = llvm::cast<llvm::StructType>(retTy)->getElementType(1);
+    }
+    return buildNoneValue(getOptionType(innerTy));
 }
 
 // ===== ErrorPropagateExpr (?) =====

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1703,6 +1703,14 @@ llvm::Value *CodeGen::emitBinaryOp(const std::string &op, llvm::Value *lhs, llvm
 }
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
+    // Pre-scan: compute None() hint from first arm value and else_expr (#1154).
+    // Arm conditions are emitted before each value so we re-install the guard
+    // around each value emit to avoid leaking the hint into condition exprs.
+    llvm::Type *caseCondHint = nullptr;
+    if (!e->arms.empty())
+        caseCondHint = computeBranchOptionInnerHint(*e->arms[0].value, *e->else_expr);
+    llvm::Type *caseCondFallback = caseCondHint ? caseCondHint : option_decl_annotation_inner_;
+
     llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "case.expr.merge", fn_);
     std::vector<std::pair<llvm::Value*, llvm::BasicBlock*>> incoming;
 
@@ -1718,7 +1726,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
         builder_.CreateCondBr(cond, thenBB, nextBB);
 
         builder_.SetInsertPoint(thenBB);
-        llvm::Value *armVal = emitExpr(*arm.value);
+        llvm::Value *armVal;
+        {
+            OptionNoneHintGuard g(*this, caseCondFallback);
+            armVal = emitExpr(*arm.value);
+        }
         if (!firstVal) firstVal = armVal;
         else validateBranchTypes(firstVal, armVal, "case expression");
         llvm::BasicBlock *armEndBB = builder_.GetInsertBlock();
@@ -1728,7 +1740,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
         builder_.SetInsertPoint(nextBB);
     }
 
-    llvm::Value *elseVal = emitExpr(*e->else_expr);
+    llvm::Value *elseVal;
+    {
+        OptionNoneHintGuard g(*this, caseCondFallback);
+        elseVal = emitExpr(*e->else_expr);
+    }
     if (!firstVal) firstVal = elseVal;
     else validateBranchTypes(firstVal, elseVal, "case expression");
     llvm::BasicBlock *elseEndBB = builder_.GetInsertBlock();
@@ -1746,17 +1762,19 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
 // ===== IfExpr (single-expression form: `if cond => then_val else else_val`) =====
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IfExpr> &e) {
-    // Pre-scan: derive None() inner-type hint from the non-None sibling arm
-    // so both arms get the same Option<T> type (#1154). The guard restores
-    // the previous hint after this if-expr is fully emitted.
+    // Pre-scan: compute None() hint before any emit so the fallback is stable
+    // (#1154). The guard is installed *after* the condition is emitted so that
+    // none/None() in the condition expression is not affected by arm context.
     llvm::Type *ifExprHint = computeBranchOptionInnerHint(*e->then_value, *e->else_value);
-    OptionNoneHintGuard ifExprGuard(*this, ifExprHint ? ifExprHint : option_none_hint_inner_);
+    llvm::Type *ifExprFallback = ifExprHint ? ifExprHint : option_decl_annotation_inner_;
 
     llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(*ctx_, "if.expr.then", fn_);
     llvm::BasicBlock *elseBB = llvm::BasicBlock::Create(*ctx_, "if.expr.else", fn_);
     llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "if.expr.merge", fn_);
 
     llvm::Value *cond = toBool(emitExpr(*e->condition));
+    // Install the arm hint only after the condition has been emitted.
+    OptionNoneHintGuard ifExprGuard(*this, ifExprFallback);
     builder_.CreateCondBr(cond, thenBB, elseBB);
 
     builder_.SetInsertPoint(thenBB);
@@ -1799,9 +1817,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IfBlockExpr> &e) {
     const ExprNode *thenTail = extractTailExpr(e->then_body, "then");
     const ExprNode *elseTail = extractTailExpr(e->else_body, "else");
 
-    // Pre-scan: derive None() hint from the tail expressions (#1154).
+    // Pre-scan: compute hint before condition emit; guard installed after.
     llvm::Type *ifBlockHint = computeBranchOptionInnerHint(*thenTail, *elseTail);
-    OptionNoneHintGuard ifBlockGuard(*this, ifBlockHint ? ifBlockHint : option_none_hint_inner_);
+    llvm::Type *ifBlockFallback = ifBlockHint ? ifBlockHint : option_decl_annotation_inner_;
 
     // Emit one branch body into an existing basic block: execute the
     // non-tail statements, then evaluate the tail expression. Returns
@@ -1831,6 +1849,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IfBlockExpr> &e) {
     llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "if.block.merge", fn_);
 
     llvm::Value *cond = toBool(emitExpr(*e->condition));
+    // Install the arm hint only after the condition has been emitted.
+    OptionNoneHintGuard ifBlockGuard(*this, ifBlockFallback);
     builder_.CreateCondBr(cond, thenBB, elseBB);
 
     auto [thenVal, thenEndBB] = emitBodyTail(thenBB, e->then_body, thenTail);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1703,12 +1703,14 @@ llvm::Value *CodeGen::emitBinaryOp(const std::string &op, llvm::Value *lhs, llvm
 }
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
-    // Pre-scan: compute None() hint from first arm value and else_expr (#1154).
-    // Arm conditions are emitted before each value so we re-install the guard
-    // around each value emit to avoid leaking the hint into condition exprs.
+    // Pre-scan: scan all arm values against else_expr to find a concrete inner
+    // type for None() hint. Stop at the first non-nullptr result (#1154).
+    // Guard is re-installed per value emit to avoid leaking into conditions.
     llvm::Type *caseCondHint = nullptr;
-    if (!e->arms.empty())
-        caseCondHint = computeBranchOptionInnerHint(*e->arms[0].value, *e->else_expr);
+    for (const auto &arm : e->arms) {
+        caseCondHint = computeBranchOptionInnerHint(*arm.value, *e->else_expr);
+        if (caseCondHint) break;
+    }
     llvm::Type *caseCondFallback = caseCondHint ? caseCondHint : option_decl_annotation_inner_;
 
     llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "case.expr.merge", fn_);
@@ -1831,14 +1833,17 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IfBlockExpr> &e) {
     // `body` arrives as a const vector. The AST itself is not mutated —
     // only codegen side state. See KNOWLEDGE.md "IfBlockExpr const_cast"
     // for the full architectural rationale.
+    // Emit one branch body: non-tail stmts, then tail with hint active only
+    // during the tail expression so non-tail stmts are not affected (#1154).
     auto emitBodyTail = [this](llvm::BasicBlock *entry, const std::vector<StmtNode> &body,
-                               const ExprNode *tail)
+                               const ExprNode *tail, llvm::Type *tailHint)
         -> std::pair<llvm::Value *, llvm::BasicBlock *> {
         builder_.SetInsertPoint(entry);
         pushScope();
         auto &mutBody = const_cast<std::vector<StmtNode> &>(body);
         for (size_t i = 0; i + 1 < mutBody.size(); ++i)
             std::visit([this](auto &s) { emitStmt(s); }, mutBody[i]);
+        OptionNoneHintGuard g(*this, tailHint);
         llvm::Value *val = emitExpr(*tail);
         popScope();
         return {val, builder_.GetInsertBlock()};
@@ -1849,14 +1854,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IfBlockExpr> &e) {
     llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "if.block.merge", fn_);
 
     llvm::Value *cond = toBool(emitExpr(*e->condition));
-    // Install the arm hint only after the condition has been emitted.
-    OptionNoneHintGuard ifBlockGuard(*this, ifBlockFallback);
     builder_.CreateCondBr(cond, thenBB, elseBB);
 
-    auto [thenVal, thenEndBB] = emitBodyTail(thenBB, e->then_body, thenTail);
+    auto [thenVal, thenEndBB] = emitBodyTail(thenBB, e->then_body, thenTail, ifBlockFallback);
     builder_.CreateBr(mergeBB);
 
-    auto [elseVal, elseEndBB] = emitBodyTail(elseBB, e->else_body, elseTail);
+    auto [elseVal, elseEndBB] = emitBodyTail(elseBB, e->else_body, elseTail, ifBlockFallback);
     validateBranchTypes(thenVal, elseVal, "if expression");
     builder_.CreateBr(mergeBB);
 

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -719,10 +719,51 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
             return ptrTy_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CastExpr>>) {
             return resolveType(v->target_type->toString());
+        } else if constexpr (std::is_same_v<T, NoneExpr>) {
+            // NoneExpr (bare `none`) is an Option literal with placeholder inner.
+            // Use i8Ty_ so preferConcrete() will prefer the sibling arm's inner type.
+            return getOptionType(i8Ty_);
         } else {
             return i64Ty_; // fallback
         }
     }, expr.data);
+}
+
+// Infer the Option inner-type hint from two branch arm expressions.
+// Used by IfExpr / IfBlockExpr / CaseCondExpr pre-scan (#1154).
+// Returns nullptr when neither arm is a None placeholder or when both
+// have the i8 placeholder (all-None — the annotation seed handles that).
+llvm::Type *CodeGen::computeBranchOptionInnerHint(const ExprNode &a,
+                                                   const ExprNode &b) {
+    static const std::unordered_map<std::string, llvm::Type*> empty;
+    llvm::Type *ta = inferExprType(a, empty);
+    llvm::Type *tb = inferExprType(b, empty);
+
+    bool aIsOpt = isOptionType(ta);
+    bool bIsOpt = isOptionType(tb);
+    if (!aIsOpt && !bIsOpt)
+        return nullptr;
+
+    auto inner = [&](llvm::Type *optTy) -> llvm::Type * {
+        return llvm::cast<llvm::StructType>(optTy)->getElementType(1);
+    };
+
+    auto preferConcrete = [&](llvm::Type *x, llvm::Type *y) -> llvm::Type * {
+        if (x == i8Ty_) return y;
+        if (x == i64Ty_ || !isAnyType(x)) return x;
+        return (y != i8Ty_) ? y : x;
+    };
+
+    if (aIsOpt && bIsOpt) {
+        llvm::Type *hint = preferConcrete(inner(ta), inner(tb));
+        return (hint == i8Ty_) ? nullptr : hint;
+    }
+    if (aIsOpt) {
+        llvm::Type *ia = inner(ta);
+        return (ia == i8Ty_) ? nullptr : ia;
+    }
+    llvm::Type *ib = inner(tb);
+    return (ib == i8Ty_) ? nullptr : ib;
 }
 
 std::string CodeGen::inferExprTypeName(const ExprNode &expr,

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -942,6 +942,8 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             };
             if (isOptName(thenName) || isOptName(elseName)) return "Option";
             return "";
+        } else if constexpr (std::is_same_v<T, NoneExpr>) {
+            return "Option";
         } else {
             return reverseResolveTypeName(inferExprType(expr, paramTypeMap));
         }

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -834,6 +834,16 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
         getOrCreateMeta(subjectAlloca).enum_value_type = subjectEnumType;
     propagateMetaWide(subject, subjectAlloca);
 
+    // If the scrutinee is Option<T>, seed the None() hint so that None() / bare
+    // none in any arm value inherits the correct inner type (#1154). This avoids
+    // the pattern-variable scope problem of compile-time pre-scan: we read the
+    // runtime subjectTy directly instead of inspecting arm expressions.
+    llvm::Type *scrutineeOptInner = isOptionType(subjectTy)
+        ? llvm::cast<llvm::StructType>(subjectTy)->getElementType(1)
+        : nullptr;
+    OptionNoneHintGuard scrutineeHintGuard(*this,
+        scrutineeOptInner ? scrutineeOptInner : option_decl_annotation_inner_);
+
     llvm::Value *firstVal = nullptr;
 
     for (size_t i = 0; i < e->arms.size(); ++i) {

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -390,7 +390,7 @@ void CodeGen::emitVarDecl(const std::string &name,
         if (isOptionType(at))
             annotOptionInner = llvm::cast<llvm::StructType>(at)->getElementType(1);
     }
-    OptionNoneHintGuard noneHintGuard(*this, annotOptionInner);
+    DeclAnnotationInnerGuard noneHintGuard(*this, annotOptionInner);
 
     llvm::Value *val = emitExpr(value);
     llvm::Type *newTy = val->getType();
@@ -1033,7 +1033,7 @@ void CodeGen::emitStmt(AssignStmt &s) {
         if (isOptionType(varTy))
             localOptInner = llvm::cast<llvm::StructType>(varTy)->getElementType(1);
     }
-    OptionNoneHintGuard localNoneGuard(*this, localOptInner);
+    DeclAnnotationInnerGuard localNoneGuard(*this, localOptInner);
 
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();
@@ -1249,7 +1249,7 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
     llvm::Type *globalOptInner = isOptionType(valueTy)
         ? llvm::cast<llvm::StructType>(valueTy)->getElementType(1)
         : nullptr;
-    OptionNoneHintGuard globalNoneGuard(*this, globalOptInner);
+    DeclAnnotationInnerGuard globalNoneGuard(*this, globalOptInner);
 
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -380,6 +380,18 @@ void CodeGen::emitVarDecl(const std::string &name,
     if (annot)
         injectLowLevelSuffix(value, *annot);
 
+    // Seed None() hint so if/case branches in the RHS resolve to the
+    // declared Option inner type (#1154). Only when annotation is a plain
+    // Option (not a literal/range constraint — those don't have inner types).
+    llvm::Type *annotOptionInner = nullptr;
+    if (annot && !constraint) {
+        const std::string &ra = resolvedAnnot.empty() ? *annot : resolvedAnnot;
+        llvm::Type *at = resolveType(ra);
+        if (isOptionType(at))
+            annotOptionInner = llvm::cast<llvm::StructType>(at)->getElementType(1);
+    }
+    OptionNoneHintGuard noneHintGuard(*this, annotOptionInner);
+
     llvm::Value *val = emitExpr(value);
     llvm::Type *newTy = val->getType();
 
@@ -1013,6 +1025,16 @@ void CodeGen::emitStmt(AssignStmt &s) {
             injectListExprElemSuffixes(**le, inner);
     }
 
+    // Seed None() hint from local variable's type so if/case branches
+    // containing None() resolve to the correct Option inner type (#1154).
+    llvm::Type *localOptInner = nullptr;
+    {
+        llvm::Type *varTy = ptr->getAllocatedType();
+        if (isOptionType(varTy))
+            localOptInner = llvm::cast<llvm::StructType>(varTy)->getElementType(1);
+    }
+    OptionNoneHintGuard localNoneGuard(*this, localOptInner);
+
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();
 
@@ -1222,6 +1244,12 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
         if (isLowLevelIntTypeName(inner))
             injectListExprElemSuffixes(**le, inner);
     }
+
+    // Seed None() hint from module-global variable's type (#1154).
+    llvm::Type *globalOptInner = isOptionType(valueTy)
+        ? llvm::cast<llvm::StructType>(valueTy)->getElementType(1)
+        : nullptr;
+    OptionNoneHintGuard globalNoneGuard(*this, globalOptInner);
 
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();

--- a/tests/spec/option_branch_merge_none.test.ry
+++ b/tests/spec/option_branch_merge_none.test.ry
@@ -1,0 +1,123 @@
+# Tests for None() / none contextual type in branch-merge positions (#1154).
+#
+# Prior to this fix, None() and bare `none` in if/case/match branches
+# defaulted to Option<i8> or Option<i64> respectively, causing a type
+# mismatch with same-branch Some<T> values.
+
+describe("None() in if-expr then-branch (#1154)", ():
+  it("should unify None() with Some<int> in else-branch", ():
+    x: Option<int> = if false => None() else Some(42)
+    expect(x).to_be_some()
+  )
+
+  it("should unify None() with Some<str> in else-branch", ():
+    x: Option<str> = if false => None() else Some("hi")
+    expect(x).to_be_some()
+  )
+
+  it("should unify Some<int> with None() in else-branch", ():
+    x: Option<int> = if true => Some(1) else None()
+    expect(x).to_be_some()
+  )
+
+  it("should unify Some<str> with None() in else-branch", ():
+    x: Option<str> = if true => Some("ok") else None()
+    expect(x).to_be_some()
+  )
+
+  it("should handle all-None() branches with annotation", ():
+    x: Option<int> = if false => None() else None()
+    expect(x).to_be_none()
+  )
+)
+
+describe("None() in if-expr with List inner type (#1154)", ():
+  it("should unify None() with Some<List<int>>", ():
+    lst: List<int> = [1, 2, 3]
+    x: Option<List<int>> = if false => None() else Some(lst)
+    expect(x).to_be_some()
+  )
+)
+
+describe("bare none in if-expr (#1154)", ():
+  it("should unify bare none with Some<int>", ():
+    x: Option<int> = if false => none else Some(99)
+    expect(x).to_be_some()
+  )
+
+  it("should unify Some<str> with bare none", ():
+    x: Option<str> = if true => Some("hello") else none
+    expect(x).to_be_some()
+  )
+)
+
+describe("mixed None() and none in if-expr (#1154)", ():
+  it("should handle Some<int> in true-branch None() in false-branch", ():
+    x: Option<int> = if true => Some(5) else None()
+    y: Option<int> = if false => none else Some(7)
+    expect(x).to_be_some()
+    expect(y).to_be_some()
+  )
+)
+
+describe("nested if-expr with None() (#1154)", ():
+  it("should infer inner type through nested if", ():
+    outer: bool = true
+    inner_cond: bool = false
+    x: Option<int> = if outer => (if inner_cond => None() else Some(10)) else None()
+    expect(x).to_be_some()
+  )
+)
+
+describe("None() in case-expr arms (#1154)", ():
+  it("should unify None() with Some<int> in case match arm", ():
+    o: Option<int> = Some(3)
+    result: Option<int> = case o:
+      Some(v) => Some(v * 2)
+      None => None()
+    expect(result).to_be_some()
+  )
+
+  it("should unify Some<str> with None() in case match arm", ():
+    o: Option<str> = None
+    result: Option<str> = case o:
+      Some(s) => Some(s)
+      None => None()
+    expect(result).to_be_none()
+  )
+
+  it("should unify None() arms with annotation in case", ():
+    o: Option<int> = None
+    result: Option<int> = case o:
+      Some(_) => None()
+      None => None()
+    expect(result).to_be_none()
+  )
+)
+
+describe("bare none in case-expr arms (#1154)", ():
+  it("should unify bare none with Some<int> in case arm", ():
+    o: Option<int> = Some(5)
+    result: Option<int> = case o:
+      Some(v) => Some(v)
+      None => none
+    expect(result).to_be_some()
+  )
+)
+
+describe("None() as return from if-expr function body (#1154)", ():
+  it("should compile function returning if-expr with None() branch", ():
+    f = (flag: bool) -> Option<int> => if flag => Some(1) else None()
+    expect(f(true)).to_be_some()
+    expect(f(false)).to_be_none()
+  )
+
+  it("should compile function returning case-expr with None() arm", ():
+    g = (o: Option<str>) -> Option<str> => case o:
+      Some(s) => Some(s)
+      None => None()
+    expect(g(Some("x"))).to_be_some()
+    g_none_arg: Option<str> = None()
+    expect(g(g_none_arg)).to_be_none()
+  )
+)

--- a/tests/spec/option_branch_merge_none.test.ry
+++ b/tests/spec/option_branch_merge_none.test.ry
@@ -187,6 +187,19 @@ describe("None() in case-cond-expr arms (case: with no subject) (#1154)", ():
     expect(f(true)).to_be_some()
     expect(f(false)).to_be_none()
   )
+
+  it("hint derived from non-first arm when arms[0] and else are None() (no annotation) (#1154)", ():
+    # No LHS annotation; arms[0] and else_expr are None(), concrete arm is arms[1].
+    # With arms[0]-only scan: computeBranchOptionInnerHint(None(), None()) = nullptr
+    # → guard gives nullptr → None() defaults to i8 → Option<i8> vs Option<int> mismatch.
+    # With full-arm scan: finds Some(42) in arm 1 → hint = int → all arms emit Option<int>.
+    x = case:
+      false => None()
+      true  => Some(42)
+      _     => None()
+    result: Option<int> = x
+    expect(result).to_be_some()
+  )
 )
 
 describe("None() as return from if-expr function body (#1154)", ():

--- a/tests/spec/option_branch_merge_none.test.ry
+++ b/tests/spec/option_branch_merge_none.test.ry
@@ -105,6 +105,90 @@ describe("bare none in case-expr arms (#1154)", ():
   )
 )
 
+describe("None() in if-block-expr arms (#1154)", ():
+  it("should unify None() with Some<int> in block-form if", ():
+    flag: bool = false
+    x: Option<int> = if flag:
+      (Some(1))
+    else:
+      (None())
+    expect(x).to_be_none()
+  )
+
+  it("should unify Some<str> with None() in block-form if", ():
+    flag: bool = true
+    x: Option<str> = if flag:
+      (Some("hello"))
+    else:
+      (None())
+    expect(x).to_be_some()
+  )
+)
+
+describe("None() in condition should not be affected by arm hint (#1154)", ():
+  it("condition None() should use function return type, not arm hint", ():
+    # None() in the condition must not pick up the arm hint.
+    # The function returns Option<str>; the condition compares to none (Option<int>).
+    # If the guard leaks into the condition, the type mismatch would crash.
+    x: Option<int> = Some(1)
+    result: Option<int> = if x == none => None() else Some(2)
+    expect(result).to_be_some()
+  )
+)
+
+describe("annotation seed does not leak into function arguments (#1154)", ():
+  it("none passed to identity function should use its own type, not LHS annotation", ():
+    id_opt = (o: Option<int>) -> Option<int> => o
+    x: Option<int> = id_opt(none)
+    expect(x).to_be_none()
+  )
+)
+
+describe("None() in case-cond-expr arms (case: with no subject) (#1154)", ():
+  it("should unify None() in first arm with Some<int> in else", ():
+    flag: bool = false
+    x: Option<int> = case:
+      flag => None()
+      _ => Some(42)
+    expect(x).to_be_some()
+  )
+
+  it("should unify Some<str> in first arm with None() in else", ():
+    flag: bool = true
+    x: Option<str> = case:
+      flag => Some("hi")
+      _ => None()
+    expect(x).to_be_some()
+  )
+
+  it("should handle all-None() arms with annotation in case-cond", ():
+    flag: bool = false
+    x: Option<int> = case:
+      flag => None()
+      _ => None()
+    expect(x).to_be_none()
+  )
+
+  it("should unify multi-arm None() with Some<int> using annotation", ():
+    a: bool = false
+    b: bool = false
+    x: Option<int> = case:
+      a => None()
+      b => Some(7)
+      _ => None()
+    expect(x).to_be_none()
+  )
+
+  it("regression: lambda with explicit Option<int> return and None() arm in case-cond", ():
+    # fn_->getReturnType() already handled this in old code; kept as regression guard.
+    f = (flag: bool) -> Option<int> => case:
+      flag => Some(99)
+      _ => None()
+    expect(f(true)).to_be_some()
+    expect(f(false)).to_be_none()
+  )
+)
+
 describe("None() as return from if-expr function body (#1154)", ():
   it("should compile function returning if-expr with None() branch", ():
     f = (flag: bool) -> Option<int> => if flag => Some(1) else None()


### PR DESCRIPTION
## Summary

- Introduces a class-state **hint channel** (`option_none_hint_inner_` + `OptionNoneHintGuard` RAII guard) on `CodeGen` so `None()` and bare `none` in `if`/`case` arms adopt the sibling arm's `Option<T>` inner type instead of defaulting to `Option<i8>` or `Option<i64>`
- `computeBranchOptionInnerHint(a, b)` pre-scans both arms via `inferExprType` and picks the more-concrete inner type using `preferConcrete`
- Annotation seed at three `codegen_stmt.cpp` callsites ensures RHS `if`/`case` expressions with no sibling `Some(x)` arm still pick up the declared type
- ADR #1111 compliant — no `emitExpr` signature changes; hint is threaded via class state + RAII

## Affected files

| File | Change |
|---|---|
| `include/ry/codegen.hpp` | `option_none_hint_inner_` field, `OptionNoneHintGuard`, `computeBranchOptionInnerHint` decl |
| `src/codegen_lambda.cpp` | `computeBranchOptionInnerHint` impl; `NoneExpr` branch in `inferExprType` |
| `src/codegen_call.cpp` | `None()` emitter consults hint before `fn_->getReturnType()` |
| `src/codegen_expr.cpp` | `NoneExpr` emitter updated; `IfExpr`/`IfBlockExpr` pre-scan guard |
| `src/codegen_stmt.cpp` | Annotation seed at `emitVarDecl`, local reassign, module-global reassign |
| `tests/spec/option_branch_merge_none.test.ry` | 16 new spec cases |
| `changelog.d/1154-none-contextual-type.md` | Changelog fragment |
| `KNOWLEDGE.md` | Hint channel design and invariants documented |

## Known limitation

`None()` passed directly as a lambda call argument (e.g. `g(None())`) still defaults to `Option<i8>` because the argument-emit loop has no hint guard. Tracked separately in #1179.

## Test plan

- [x] 16 new `tests/spec/option_branch_merge_none.test.ry` cases cover `if`/`case`/nested/function-body positions for `T ∈ {int, str, List<int>}`
- [x] Existing `tests/spec/option_none_call.test.ry` (7 cases) continue to pass
- [x] Full test suite: `cmake --build build && ./build/ry_tests && ./build/ry test -p` — all pass
- [x] ASan + UBSan: clean
- [x] TSan: clean (C++ tests)
- [x] libFuzzer: `fuzz_parser` / `fuzz_json` / `fuzz_utf8` each 60 s — exit 0

Closes #1154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixes type inference for `None()` and `none` in if/case branch-merge positions so they adopt the sibling arm’s concrete `Option<T>` inner type (including scrutinee/runtime-driven cases) instead of falling back to placeholder defaults.

* **Tests**
  * Added comprehensive regression tests covering `None`/`none` across if/case forms, nested branches, annotated all-None scenarios, multi-arm cases, and related edge cases.

* **Documentation**
  * Added changelog and knowledge base entries describing the fix, remaining limitation for function-argument positions, and rationale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->