### PR TITLE
chore: add Bash(gh issue list:*) to git-triage-issue allowed-tools

### DIFF
--- a/.claude/skills/git-triage-issue/SKILL.md
+++ b/.claude/skills/git-triage-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-triage-issue
 description: When a problem is found outside the current task scope, classify and act. Enforces strict triage rules: only direct regressions stay in the branch; everything else becomes a filed issue with full context, proper size split, and milestone set to match the current PR.
-allowed-tools: Bash(gh issue create:*), Bash(gh search issues:*), Bash(gh issue view:*), Bash(gh issue comment:*), Bash(gh issue edit:*), Bash(gh pr view:*), mcp__plugin_github_github__search_issues
+allowed-tools: Bash(gh issue create:*), Bash(gh search issues:*), Bash(gh issue view:*), Bash(gh issue comment:*), Bash(gh issue edit:*), Bash(gh issue list:*), Bash(gh pr view:*), mcp__plugin_github_github__search_issues
 metadata:
   short-description: Triage out-of-scope issues with strict filing rules
 ---

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3207,6 +3207,8 @@ When the reproduction command set is open-ended (e.g. "run the CI job's correspo
 
 **How to verify**: grep the skill body for bare Bash commands not covered by the `allowed-tools` line.
 
+**Note**: `.codex/skills/` mirrors intentionally omit the `allowed-tools` field — Codex CLI does not support this frontmatter field. Only `.claude/skills/` SKILL.md files use `allowed-tools`. Do not add `allowed-tools` to `.codex/` skill files.
+
 ### `gh run list --branch` returns all runs on a branch, not just the PR head commit
 
 **Source**: #1045 (2026-04-16, CodeRabbit review)


### PR DESCRIPTION
Closes #1151

## Summary

- Add `Bash(gh issue list:*)` to the `allowed-tools` frontmatter of `.claude/skills/git-triage-issue/SKILL.md`
- The skill's Step 1 ("Determine milestone") calls `gh issue list --milestone <title> --limit 1`, but this command was missing from `allowed-tools`, causing Claude Code to block the step at runtime
- Add a note to `KNOWLEDGE.md` clarifying that `.codex/skills/` mirrors intentionally omit `allowed-tools` (Codex CLI does not support this frontmatter field)

## `.codex/skills/` mirror — N/A

The issue body says "also update the `.codex/` mirror", but `.codex/skills/*/SKILL.md` files **intentionally omit `allowed-tools`** because Codex CLI does not support this frontmatter field. All other `.codex/skills/` files follow the same convention. No change to `.codex/` is needed.

## Source

PR #1148 CodeRabbit review — deferred to v0.0.13.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Clarified skill configuration guidance for different skill file types.

* **Chores**
  * Expanded skill tooling capabilities for issue management operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->