### PR TITLE
chore: split combined owner/repo string in git-followup-unresolved-reviews skill (#1152)

### DIFF
--- a/.claude/skills/git-followup-unresolved-reviews/SKILL.md
+++ b/.claude/skills/git-followup-unresolved-reviews/SKILL.md
@@ -32,7 +32,7 @@ User input: $ARGUMENTS
 
 ### Step 2: Fetch viewer login and repository metadata (in parallel)
 
-Run both commands **in parallel**:
+Run all three commands **in parallel**:
 
 1. Get the GitHub login of the currently authenticated user:
 
@@ -42,13 +42,14 @@ Run both commands **in parallel**:
 
    Store this as `viewer`.
 
-2. Get repository owner and name:
+2. Get repository owner and name as separate variables:
 
    ```shell
-   gh repo view --json owner,name --jq '.owner.login + "/" + .name'
+   OWNER=$(gh repo view --json owner --jq '.owner.login')
+   REPO=$(gh repo view --json name --jq '.name')
    ```
 
-   Store as `owner` and `repo` for use in subsequent steps.
+   Use `OWNER` wherever `<owner>` or `{owner}` appears in subsequent steps, and `REPO` wherever `<repo>` or `{repo}` appears.
 
 ### Step 3: Fetch unresolved review threads
 

--- a/.codex/skills/git-followup-unresolved-reviews/SKILL.md
+++ b/.codex/skills/git-followup-unresolved-reviews/SKILL.md
@@ -31,7 +31,7 @@ User input: $ARGUMENTS
 
 ### Step 2: Fetch viewer login and repository metadata (in parallel)
 
-Run both commands **in parallel**:
+Run all three commands **in parallel**:
 
 1. Get the GitHub login of the currently authenticated user:
 
@@ -41,13 +41,14 @@ Run both commands **in parallel**:
 
    Store this as `viewer`.
 
-2. Get repository owner and name:
+2. Get repository owner and name as separate variables:
 
    ```shell
-   gh repo view --json owner,name --jq '.owner.login + "/" + .name'
+   OWNER=$(gh repo view --json owner --jq '.owner.login')
+   REPO=$(gh repo view --json name --jq '.name')
    ```
 
-   Store as `owner` and `repo` for use in subsequent steps.
+   Use `OWNER` wherever `<owner>` or `{owner}` appears in subsequent steps, and `REPO` wherever `<repo>` or `{repo}` appears.
 
 ### Step 3: Fetch unresolved review threads
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3922,3 +3922,12 @@ Key constraints:
 5. **Result type layout**: `%Result = type { i1, i64, ptr }` — `i1` is the `is_ok` flag; `Err` uses constant aggregate `{ i1 false, ... }`, `Ok` uses `insertvalue %Result { i1 true, ... }`.
 6. **LLVM version bumps**: Goldens are LLVM-version-sensitive. After any LLVM version bump, re-run `ctest -L filecheck` and update patterns if IR structure changed.
 7. **FileCheck installation**: Mirror tarball does NOT include FileCheck (#897). CI installs it via `apt-get install llvm-{MAJOR}-tools` from `apt.llvm.org`. macOS: `brew install llvm@{MAJOR}` → `/opt/homebrew/opt/llvm@{MAJOR}/bin/FileCheck`.
+
+---
+
+### Skill SKILL.md: keep `owner` and `repo` as separate variables when downstream steps use `{owner}`/`{repo}` individually
+
+**Source**: PR #1148 CodeRabbit review / issue #1152 (2026-04-19)
+**Tags**: skill, gh-cli, review-feedback
+
+**Rule**: Using `gh repo view --json owner,name --jq '.owner.login + "/" + .name'` and storing the result as both `owner` and `repo` is correct only when the downstream code treats the combined value as a single placeholder (e.g. `repos/$FULL/...`). When downstream steps separately substitute `{owner}` and `{repo}` (REST paths like `repos/{owner}/{repo}/pulls/{PR}/...` or GraphQL `repository(owner: "<owner>", name: "<repo>")`), the combined string causes doubled path segments (e.g. `repos/t0k0sh1/ry/ry/pulls/...`) or an incorrect GraphQL `owner` argument. In that case, fetch them separately: `OWNER=$(gh repo view --json owner --jq '.owner.login')` / `REPO=$(gh repo view --json name --jq '.name')`. When writing or reviewing a skill step that stores repository coordinates, verify whether downstream uses the value as one unit or as two — they require different fetch forms.


### PR DESCRIPTION
## Summary

- Fixes the `owner/repo` combined-string bug in `.codex/skills/git-followup-unresolved-reviews/SKILL.md` and its `.claude/skills/` mirror
- Step 2 was returning a single concatenated string (`'.owner.login + "/" + .name'`), but downstream steps in Step 3 (GraphQL) and Step 7 (REST) use `{owner}` and `{repo}` as **separate** placeholders — causing doubled path segments (`repos/t0k0sh1/ry/ry/pulls/...`) or incorrect GraphQL `owner` values
- Replace with two separate fetch commands (`OWNER=$(...)` / `REPO=$(...)`) and update the description to clarify how each variable maps to downstream placeholders
- Update "Run both commands in parallel" → "Run all three commands in parallel" (now: `gh api user` + two `gh repo view` calls)
- Add a KNOWLEDGE.md entry for the downstream-placeholder-mismatch failure mode

## Related

- Closes #1152
- Filed #1183 — same issue in `git-fix-pr-reviews` skill (out of scope for this PR)
- Filed #1187 — pre-existing `collection_element.test.ry` SIGABRT (unrelated, found during self-verification)

## Test plan

- [x] `diff .codex/.../SKILL.md .claude/.../SKILL.md` shows only `allowed-tools` line difference (`.codex/` intentionally omits it per KNOWLEDGE.md)
- [x] `grep '.owner.login + "/" + .name'` returns no matches in either file
- [x] `OWNER=` and `REPO=` lines present in both files
- [x] C++ tests: 1814 passed, 0 failed (`./build/ry_tests`)
- [x] Ry self-tests: 1 pre-existing failure in `collection_element.test.ry` (exit=134, tracked in #1187, unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated skill workflow instructions to extract repository owner and name as separate variables for improved downstream template substitution.
  * Enhanced parallel execution in repository metadata retrieval steps.
  * Added knowledge base entry documenting shell variable handling patterns for workflow steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->