### PR TITLE
fix: None() and bare none in lambda call args adopt callee param Option<T> inner type (#1179)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3301,10 +3301,10 @@ This is the same rule as the `IfBlockExpr` path tested in `tests/spec/option_lam
 
 **How to apply**: When adding a new syntactic form of `None` to the language, extend `isNoneLiteral` first. Then all three sites above automatically inherit the fix. The `None()` emitter in `codegen_call.cpp` is a separate fallback for contexts where no annotation is available (e.g., return-stmt); it is not a substitute for `isNoneLiteral`. Use `std::get_if<std::unique_ptr<CallExpr>>` (not `std::get_if<CallExpr>`) because `CallExpr` is stored as `unique_ptr` in the `ExprNode` variant.
 
-### Hint channel for `None()`/`none` inner type in branch-merge positions
+### Hint channel for `None()`/`none` inner type in branch-merge and lambda-call argument positions
 
-**Source**: #1154 (2026-04-18, bugfix — `None()` in if/case branch defaults to `Option<i8>`)
-**Tags**: codegen, Option, None, NoneExpr, branch-merge, IfExpr, CaseExpr, hint-channel, RAII
+**Source**: #1154 (2026-04-18, bugfix — `None()` in if/case branch defaults to `Option<i8>`), #1179 (2026-04-19, bugfix — `None()` in lambda call arg defaults to wrong inner type)
+**Tags**: codegen, Option, None, NoneExpr, branch-merge, IfExpr, CaseExpr, hint-channel, RAII, lambda-call
 
 **Rule**: `None()` and `none` in branch-merge positions (e.g., `if cond => None() else Some(42)`) previously defaulted to `Option<i8>` or `Option<i64>` because the emitters only consulted `fn_->getReturnType()`. The fix introduces a two-field class-state hint channel:
 
@@ -3317,8 +3317,11 @@ This is the same rule as the `IfBlockExpr` path tested in `tests/spec/option_lam
 - **`NoneExpr` added to `inferExprType` and `inferExprTypeName`** in `codegen_lambda.cpp`: `inferExprType` returns `getOptionType(i8Ty_)` so `computeBranchOptionInnerHint` detects it as an Option placeholder; `inferExprTypeName` returns `"Option"`.
 - **CaseExpr (pattern match) uses scrutinee-based hint** in `codegen_match.cpp::emitExprVariant(CaseExpr)`: `Some(v)` arm values reference pattern-bound variables not in scope at pre-scan time, so `computeBranchOptionInnerHint` cannot be applied. Instead, the scrutinee type (`subjectTy`) is used — if it is `Option<T>`, its inner `T` is extracted and installed as the `OptionNoneHintGuard` hint before any arm is emitted. Fallback is `option_decl_annotation_inner_`.
 - **CaseCondExpr (`when cond => value`) uses pre-scan** in `codegen_expr.cpp::emitExprVariant(CaseCondExpr)`: no pattern variables are involved, so `computeBranchOptionInnerHint` on the first arm value and `else_expr` is safe. Guard is installed inside each value emit block (after the arm condition) to prevent hint leaking into condition expressions.
+- **Lambda variable (indirect) call arguments** in `codegen_call_dispatch.cpp` (#1179): per-arg `OptionNoneHintGuard` with inner derived from the callee's `FnTypeInfo::paramTypes[i]` — only when that param is `isOptionType`. The hint source is the **callee signature** (not `option_decl_annotation_inner_`), so the invariant "decl annotation must not flow into arg positions" is preserved — the two channels remain disjoint by design. Non-Option params pass `nullptr` as inner (guard saves/restores nullptr, which is also a correct "clear" for nested contexts such as a call inside a branch-merge).
 
-**Known limitation**: `None()` and `none` in function argument positions (e.g., `f(none)`) do NOT inherit the enclosing declaration annotation; they fall back to `fn_->getReturnType()` or the default `i64`/`i8` placeholder. Filed as #1179. The `option_decl_annotation_inner_` field intentionally does NOT flow into argument positions to avoid incorrect type propagation.
+**Design invariant**: `option_decl_annotation_inner_` does NOT flow directly into argument positions. Argument-position hints always come from the callee's declared parameter types (lambda variable call) or are absent (regular `fn` calls, which use `resolveOverload`'s `isNoneLiteral` short-circuit). This prevents LHS declaration annotations from contaminating arbitrary sub-expressions.
+
+**Remaining gap**: Struct/record constructor arg positions (`emitRecordConstructor` at `src/codegen_expr_literal.cpp:71-78`) have the same gap. Filed as #1186.
 
 **Priority invariant**: `isNoneLiteral` short-circuit at the three annotation-aware `codegen_stmt.cpp` sites must remain the *first* check (runs before the hint seed). It handles the trivial `x: Option<int> = None()` case without touching hint state and is faster.
 

--- a/changelog.d/1179-none-lambda-call-arg-contextual-type.md
+++ b/changelog.d/1179-none-lambda-call-arg-contextual-type.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `None()` and bare `none` in lambda variable call arguments now adopt the callee parameter's `Option<T>` inner type, so `g(None())` compiles where `g: (o: Option<str>) -> Option<str>`. Previously required a typed-variable workaround. (#1179)

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -130,8 +130,14 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
 
             std::vector<llvm::Value*> argVals;
             argVals.reserve(e->args.size());
-            for (auto &arg : e->args)
-                argVals.push_back(emitExpr(*arg));
+            for (size_t i = 0; i < e->args.size(); ++i) {
+                // #1179: propagate Option<T> inner from callee param so None()/none args resolve correctly.
+                llvm::Type *argHintInner = nullptr;
+                if (i < info.paramTypes.size() && isOptionType(info.paramTypes[i]))
+                    argHintInner = llvm::cast<llvm::StructType>(info.paramTypes[i])->getElementType(1);
+                OptionNoneHintGuard argHint(*this, argHintInner);
+                argVals.push_back(emitExpr(*e->args[i]));
+            }
 
             auto ucTemps = wrapFnTypedArgs(argVals, info.paramTypeNames);
 

--- a/tests/spec/option_branch_merge_none.test.ry
+++ b/tests/spec/option_branch_merge_none.test.ry
@@ -214,7 +214,39 @@ describe("None() as return from if-expr function body (#1154)", ():
       Some(s) => Some(s)
       None => None()
     expect(g(Some("x"))).to_be_some()
-    g_none_arg: Option<str> = None()
-    expect(g(g_none_arg)).to_be_none()
+    expect(g(None())).to_be_none()
+  )
+)
+
+describe("None()/none in lambda call arguments (#1179)", ():
+  it("None() as only arg adopts Option<str> param inner", ():
+    g = (o: Option<str>) -> Option<str> => o
+    expect(g(None())).to_be_none()
+  )
+  it("bare none as only arg adopts Option<str> param inner", ():
+    g = (o: Option<str>) -> Option<str> => o
+    expect(g(none)).to_be_none()
+  )
+  it("None() in non-first arg position uses correct paramTypes index", ():
+    h = (a: int, b: Option<str>) -> Option<str> => b
+    expect(h(42, None())).to_be_none()
+  )
+  it("non-Option param passes through unchanged", ():
+    f = (n: int) -> int => n
+    expect(f(7)).to_eq(7)
+  )
+  it("issue repro: case-returning lambda accepts None() argument directly", ():
+    g = (o: Option<str>) -> Option<str> => case o:
+      Some(s) => Some(s)
+      None => None()
+    expect(g(Some("x"))).to_be_some()
+    expect(g(None())).to_be_none()
+  )
+  it("no regression when lambda call follows a branch-merge statement", ():
+    g = (o: Option<str>) -> Option<str> => o
+    flag: bool = true
+    result: Option<int> = if flag => Some(1) else None()
+    expect(g(None())).to_be_none()
+    expect(result).to_be_some()
   )
 )


### PR DESCRIPTION
## Summary

- Fixes #1179: calling a lambda with `g(None())` where `g: (o: Option<str>) -> Option<str>` previously failed with `lambda call: argument 0 type mismatch` because `None()` emitted `Option<i8>` with no type hint in argument position
- Per-arg `OptionNoneHintGuard` is now installed in the indirect (lambda variable) call path in `codegen_call_dispatch.cpp`, deriving the inner type from the callee's `FnTypeInfo::paramTypes[i]`
- Hint comes from the **callee signature**, not `option_decl_annotation_inner_`, preserving the design invariant that LHS declaration annotations do not flow into argument positions

## Changes

- **`src/codegen_call_dispatch.cpp`**: replaced the simple arg-emit loop with a per-arg `OptionNoneHintGuard` loop
- **`tests/spec/option_branch_merge_none.test.ry`**: added 6 new test cases in a `#1179` describe block; simplified the existing typed-variable workaround at line 217 to a direct `g(None())` call
- **`KNOWLEDGE.md`**: extended the hint-channel entry to cover lambda-call argument positions, removed "Known limitation" paragraph, added design invariant note and remaining-gap pointer to #1186
- **`changelog.d/1179-none-lambda-call-arg-contextual-type.md`**: new fragment

## Follow-ups filed

- #1186 — same gap in `emitRecordConstructor` for struct field arguments
- #1190 — extract `optionInnerType()` helper to replace repeated `getElementType(1)` idiom (20+ sites)

## Test plan

- [ ] `./build/ry test tests/spec/option_branch_merge_none.test.ry` — 32 passed, 0 failed (26 original + 6 new)
- [ ] `./build/ry_tests` — 1814 C++ tests green
- [ ] `./build/ry test -p` — 144 Ry test files green
- [ ] ASan + UBSan clean
- [ ] TSan clean
- [ ] libFuzzer 60s × 3 harnesses clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * `None()` and `none` now correctly infer types when passed as arguments in lambda variable calls, enabling direct use without manual type annotations.

* **Tests**
  * Added test coverage for contextual typing of `None()` and `none` in lambda call argument positions.

* **Documentation**
  * Updated documentation to clarify type inference behavior and design invariants for option-type arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->