### PR TITLE
fix: cancel ResourceTracker scope_exit before leaking LLJIT (#1187)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1925,7 +1925,7 @@ surfaces, widen via #872 rather than blindly expanding the flag.
 
 ### LLVM ORC JIT intermittent crash in `~LLJIT()` / `removeResourceTracker` / `~CodeGen()` (Linux + macOS)
 
-**Source**: #1022 (2026-04-16) CI run 24507853564; #1088 (2026-04-17) macOS Darwin 25.3.0; #1043 (2026-04-17) CI runs 24547110395 + 24547575356
+**Source**: #1022 (2026-04-16) CI run 24507853564; #1088 (2026-04-17) macOS Darwin 25.3.0; #1043 (2026-04-17) CI runs 24547110395 + 24547575356; #1187 (2026-04-19) macOS Darwin 25.3.0 residual ~16 % rate
 **Tags**: llvm, orc, jit, ci, flaky, linux, macos, cleanup, parallel-test
 
 **Symptom**: The Ry self-test (`ry test -p`) completes all `it` blocks
@@ -1963,16 +1963,25 @@ just glibc's `cfree` check), it is user-code OOB/UAF — not an ORC flake. In th
 [`~CodeGen() glibc heap-check crashes`](#codegen-glibc-heap-check-crashes-are-not-destructor-bugs)
 entry in the Runtime / Memory section for the diagnostic checklist.
 
-**Fix applied**: `src/jit_runner.cpp` — `(void)jit.release()` workaround is now guarded by
-`#if defined(__linux__) || defined(__APPLE__)` (previously Linux-only). The LLJIT is intentionally
-leaked so `~LLJIT()` never runs; the OS reclaims memory on process exit. Tracked in #742.
+**Fix applied** (two-step suppression — both steps are required):
+
+1. `(void)jit.release()` — guarded by `#if defined(__linux__) || defined(__APPLE__)`. Leaks the
+   LLJIT so `~LLJIT()` never runs. Extended from Linux-only to macOS in #1088 (suppressed the
+   `~LLJIT()` crash frame).
+2. `rtCleanup.release()` — added immediately before `jit.release()` in the same `#if` block (#1187).
+   Cancels the `scope_exit` destructor so `RT->remove()` never fires during stack unwind. This is
+   necessary because `jit.release()` leaks but does NOT destroy the LLJIT; the leaked
+   `ExecutionSession` remains alive, so `RT->remove()` → `handleRemoveResources` →
+   `InProcessMemoryManager::deallocate` → `WrapperFunctionCall::runWithSPSRet` hits the same
+   JITLink deallocation crash. Suppressing only the `~LLJIT()` frame left the
+   `removeResourceTracker` frame, causing a residual ~16 % failure rate in `ry test -p`.
 
 **Rule**: On Linux CI, trigger a re-run if this crash appears — it is pre-existing LLVM ORC
 flakiness, not a regression. The `~CodeGen()` frame variant is the same flake family as
-`removeResourceTracker`. On macOS, the workaround suppresses the crash; if the `~40%` failure
-rate reappears after the fix, the root cause has changed and needs fresh investigation. Do not
-suppress the LLVM crash reporter or add `|| true` — a genuine double-free in user code would
-produce the same frame.
+`removeResourceTracker`. On macOS, both workarounds together suppress the crash; if any failure
+rate reappears after the fix, the root cause is broader than these two frames and needs fresh
+investigation. Do not suppress the LLVM crash reporter or add `|| true` — a genuine double-free in
+user code would produce the same frame.
 
 ### `@parallel for` captures must be retained AND ARC-backed inside the thunk
 

--- a/changelog.d/1187-rt-cleanup-leak.md
+++ b/changelog.d/1187-rt-cleanup-leak.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Eliminate intermittent SIGABRT/SIGBUS in `ry test -p` triggered by
+  `tests/spec/combinatorial/collection_element.test.ry` during JIT
+  teardown by cancelling the ResourceTracker scope_exit before leaking
+  the LLJIT (#1187)

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -391,6 +391,14 @@ int runRySource(const std::string &src, const std::string &source_name,
     }
 
 #if defined(__linux__) || defined(__APPLE__)
+    // Cancel rtCleanup before leaking the LLJIT.  Otherwise scope_exit fires
+    // RT->remove() during stack unwind, which walks the same JITLink wrapper-
+    // call deallocation path that crashes inside ~LLJIT() — only suppressing
+    // one frame in the family leaves the second frame (removeResourceTracker)
+    // intermittently aborting under parallel load (#1187).  The OS reclaims
+    // memory on process exit since the LLJIT is leaked below.
+    rtCleanup.release();
+
     // Intentionally leak the LLJIT to prevent an intermittent crash in
     // ~LLJIT() during JIT teardown.  On Linux: ~ExecutorProcessControl() →
     // __libc_free due to JIT relocation side-effects on ELF+JITLink (#742).


### PR DESCRIPTION
## Summary

- `jit.release()` intentionally leaks the LLJIT to prevent `~LLJIT()` teardown crash (#742/#1088), but keeps the `ExecutionSession` alive
- The `rtCleanup` `scope_exit` destructor fires `RT->remove()` during stack unwind **after** `jit.release()`, hitting the same `InProcessMemoryManager::deallocate` → `WrapperFunctionCall::runWithSPSRet` crash path
- This caused a residual ~16% SIGABRT/SIGBUS failure rate in `ry test -p` on macOS (particularly with `collection_element.test.ry` which uses `List<record>` with `str` fields)
- Fix: add `rtCleanup.release()` immediately before `jit.release()` inside the existing `#if defined(__linux__) || defined(__APPLE__)` guard

## Test plan

- [x] 100 consecutive `./build/ry test -p` runs: **0 failures** (pre-fix: 8/50 = 16%)
- [x] `./build/ry_tests` — 1814 passed
- [x] ASan + UBSan: `ry_tests` + `ry test -p` — clean
- [x] TSan: `ry_tests` + `ry test -p` — clean
- [x] libFuzzer: `fuzz_parser`, `fuzz_json`, `fuzz_utf8` × 60s each — clean

Closes #1187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed intermittent crashes (SIGABRT/SIGBUS) during test execution on Linux and macOS caused by resource cleanup conflicts during JIT teardown. Improved cleanup procedure enhances test stability.

## Documentation
* Updated known issues documentation with new findings on JIT crash patterns and updated workaround requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->