### PR TITLE
chore: git-fix-pr-reviews skill — split combined owner/repo string

### DIFF
--- a/.claude/skills/git-fix-pr-reviews/SKILL.md
+++ b/.claude/skills/git-fix-pr-reviews/SKILL.md
@@ -30,7 +30,16 @@ User input: $ARGUMENTS
 
 ### Step 2: Fetch review comments
 
-Get repository info with `gh repo view --json owner,name --jq '.owner.login + "/" + .name'` and call the following two APIs **in parallel**:
+Get repository owner and name as separate variables (run both in parallel):
+
+```shell
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+```
+
+Use `OWNER` wherever `<owner>` or `{owner}` appears in subsequent steps, and `REPO` wherever `<repo>` or `{repo}` appears.
+
+Then call the following two APIs **in parallel**:
 
 1. `gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments` — inline comments (each has an `id` field needed for replies)
 2. `gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews` — review summaries (general comments). Read each review `body` and extract any **nitpick / suggestion items embedded inside the summary** — these are NOT inline comments and do not have their own `id`, so they cannot receive inline replies. Treat them as separate triage items referenced by file/line in the summary body. Common reviewer-specific markers to recognize (non-exhaustive): CodeRabbit uses a `<summary>🧹 Nitpick comments</summary>` `<details>` block; other reviewers may use `## Nitpicks`, `### Suggestions`, or similar section headers. If the review body has no recognizable nitpick section, treat the whole body as a general summary comment and skip this extraction.

--- a/.claude/skills/git-fix-pr-reviews/SKILL.md
+++ b/.claude/skills/git-fix-pr-reviews/SKILL.md
@@ -30,7 +30,7 @@ User input: $ARGUMENTS
 
 ### Step 2: Fetch review comments
 
-Get repository owner and name as separate variables (run both in parallel):
+Get repository owner and name as separate variables:
 
 ```shell
 OWNER=$(gh repo view --json owner --jq '.owner.login')

--- a/.codex/skills/git-fix-pr-reviews/SKILL.md
+++ b/.codex/skills/git-fix-pr-reviews/SKILL.md
@@ -29,7 +29,7 @@ User input: $ARGUMENTS
 
 ### Step 2: Fetch review comments
 
-Get repository owner and name as separate variables (run both in parallel):
+Get repository owner and name as separate variables:
 
 ```shell
 OWNER=$(gh repo view --json owner --jq '.owner.login')

--- a/.codex/skills/git-fix-pr-reviews/SKILL.md
+++ b/.codex/skills/git-fix-pr-reviews/SKILL.md
@@ -29,7 +29,16 @@ User input: $ARGUMENTS
 
 ### Step 2: Fetch review comments
 
-Get repository info with `gh repo view --json owner,name --jq '.owner.login + "/" + .name'` and call the following two APIs **in parallel**:
+Get repository owner and name as separate variables (run both in parallel):
+
+```shell
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+```
+
+Use `OWNER` wherever `<owner>` or `{owner}` appears in subsequent steps, and `REPO` wherever `<repo>` or `{repo}` appears.
+
+Then call the following two APIs **in parallel**:
 
 1. `gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments` — inline comments (each has an `id` field needed for replies)
 2. `gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews` — review summaries (general comments)


### PR DESCRIPTION
## Summary

- Both `.claude/` and `.codex/` copies of `git-fix-pr-reviews/SKILL.md` Step 2 were fetching repository coordinates as a single `"owner/repo"` string via `.owner.login + "/" + .name`
- Downstream REST paths use `{owner}` and `{repo}` as separate path segments; substituting the combined string into `{owner}` produced doubled paths (`repos/t0k0sh1/ry/ry/pulls/...`) and 404 errors
- Applied the same OWNER/REPO variable-split pattern used for `git-followup-unresolved-reviews` in PR #1188 (issue #1152)

Closes #1183

## Test plan

- [x] `grep` confirms no residual combined-string pattern in either file
- [x] Both files contain `OWNER=$(gh repo view --json owner ...)` and `REPO=$(gh repo view --json name ...)`
- [x] `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p` — 144 test files, 0 failures
- [ ] Sanitizers / libFuzzer — skipped (MD-only change, no C++ code modified)

## Out-of-scope finding

`harvest-review-knowledge` skill has the same class of bug → filed as #1206 (milestone `v0.0.13`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated skill instructions for pull request review workflows to retrieve repository owner and name as separate values and to align API path examples for inline comments and review summaries; workflow behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->