### PR TITLE
fix: lst[a..b] range-index routes to slice helper (#1184)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1341,6 +1341,8 @@ Fix (post-#1046): use `CollectionKind fk; if (fieldTypeIsArcManaged(elemSig, &fk
 
 **Why `isStringValue` is the right predicate**: `isStringValue(val)` (`src/codegen_any.cpp:28`) returns true when `val->getType() == ptrTy_` and `isNonStrPointer(val)` is false (i.e., no collection/resource metadata). Lists, Maps, Sets, and resource handles all have metadata (`hasAnyMeta() == true`), so only `str` triggers the new guard. This is the canonical predicate used throughout codegen to distinguish `str` from other `ptrTy_` values.
 
+- **#1184 related**: The same emitter also rejects index values that are `RangeExpr` nodes and routes them to the slice path — see "IndexExpr first index is scalar only — RangeExpr routes to emitListSlice" below.
+
 ### `emitExprVariant` (CaseExpr): capture `armEndBB` AFTER `popScope()`
 
 **Source**: #997 (2026-04-16, fix)
@@ -3934,3 +3936,34 @@ Key constraints:
 **Tags**: skill, gh-cli, review-feedback
 
 **Rule**: Using `gh repo view --json owner,name --jq '.owner.login + "/" + .name'` and storing the result as both `owner` and `repo` is correct only when the downstream code treats the combined value as a single placeholder (e.g. `repos/$FULL/...`). When downstream steps separately substitute `{owner}` and `{repo}` (REST paths like `repos/{owner}/{repo}/pulls/{PR}/...` or GraphQL `repository(owner: "<owner>", name: "<repo>")`), the combined string causes doubled path segments (e.g. `repos/t0k0sh1/ry/ry/pulls/...`) or an incorrect GraphQL `owner` argument. In that case, fetch them separately: `OWNER=$(gh repo view --json owner --jq '.owner.login')` / `REPO=$(gh repo view --json name --jq '.name')`. When writing or reviewing a skill step that stores repository coordinates, verify whether downstream uses the value as one unit or as two — they require different fetch forms.
+
+---
+
+### IndexExpr first index is scalar only — RangeExpr routes to emitListSlice
+
+**Source**: #1184 (2026-04-19, fix)
+**Tags**: codegen, IndexExpr, RangeExpr, slice, index-type-guard, emitExprVariant, emitListSlice
+
+**Rule**: `emitExprVariant(IndexExpr)` (`src/codegen_expr_literal.cpp`) has always assumed that `emitExpr(*e->indices[0])` produces an i64 (or map key type). `lst[a..b]` is parsed as `IndexExpr{ object: lst, indices: [RangeExpr{a,b}] }` (via `parseConditional` → `parseRange` in `src/parser_expr.cpp`), which means without a type-guard the `RangeExpr` emitter (`src/codegen_expr_cast.cpp`) materialises an ARC-allocated `List<i64>` header (`ptr`). That `ptr` then flows into `emitBoundsCheck` / GEP, producing `ICmp ptr vs i64` type-mismatch errors in the IR verifier.
+
+**Fix (since #1184)**: Before the `indexValues` emit loop, check:
+```cpp
+if (e->indices.size() == 1 &&
+    std::holds_alternative<std::unique_ptr<RangeExpr>>(e->indices[0]->data)) {
+    // reject str / map; get list elemTy; emitExpr start/end directly (i64);
+    // emitNegativeIndexWrap each bound; endExcl = end + 1; emitListSlice(...)
+}
+```
+This avoids materialising the intermediate `List<i64>` entirely.
+
+**Semantics**:
+- `lst[a..b]` is **inclusive** on both ends (matches `..` operator semantics per `docs/reference/operators.md`)
+- Negative bounds are **wrapped** against list length (matches `lst[-1]` behaviour via `emitNegativeIndexWrap`)
+- Out-of-bounds bounds are **clamped** (matches `slice()` behaviour)
+- Equivalent to `slice(lst, a, b + 1)` — the `+ 1` conversion from inclusive to exclusive is done at the call site, not inside `emitListSlice`
+- Non-list receivers (`str`, maps, fixed-length arrays) emit `codegenError` in the new guard
+
+**Related helpers**:
+- `emitListSlice(listPtr, startVal, endExclVal, elemTy)` (`src/codegen_call_collection.cpp`) — shared between `slice()` builtin and `lst[a..b]`. Clamps internally.
+- `emitNegativeIndexWrap(idx, len, prefix)` (`src/codegen_call_user.cpp:645`) — use prefix `"ri_start"` / `"ri_end"` to avoid label collision with scalar-index prefix `"index"`.
+- Pre-existing defects in `emitListSlice`: ARC retain omitted for reference-typed elements (#1204), nested TypeMeta not propagated (#1205) — tracked separately.

--- a/changelog.d/1184-list-range-index.md
+++ b/changelog.d/1184-list-range-index.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `lst[a..b]` (list range-indexing) no longer crashes at codegen with `ICmp`
+  type mismatch between `ptr` and `i64`. The indexing path now detects a
+  `RangeExpr` as the first index, negative-wraps each bound against the list
+  length, and routes to the shared slice helper. Semantics match
+  `slice(lst, a, b + 1)` (inclusive, out-of-bounds clamped, negatives wrap).
+  (#1184)

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -250,6 +250,15 @@ print(slice(xs, 1, 3))     # [2, 3]
 print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (clamped)
 ```
 
+You can also use the `..` range operator as a list index for an equivalent, more concise syntax. `lst[a..b]` is inclusive on both ends and is equivalent to `slice(lst, a, b + 1)`. Negative indices wrap against the list length (like `lst[-1]`), and out-of-bounds bounds are clamped.
+
+```ry
+xs = [1, 2, 3, 4, 5]
+print(xs[1..3])     # [2, 3, 4]  (inclusive)
+print(xs[-3..-1])   # [3, 4, 5]  (negative wrap)
+print(xs[1..100])   # [2, 3, 4, 5] (clamped)
+```
+
 ### take
 
 Returns a new list with the first `count` elements. If `count` exceeds the list length, returns a copy of the entire list. If `count <= 0`, returns an empty list. The original list is not modified.

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -221,6 +221,14 @@ for i in 1 .. 3:
 
 The result is a `List<int>` containing all integers from the left operand to the right operand (inclusive).
 
+When used as a list index (`lst[a..b]`), the range denotes an inclusive subrange: negative `a`/`b` wrap against the list length (like `lst[-1]`), and out-of-bounds bounds are clamped. `lst[a..b]` is equivalent to `slice(lst, a, b + 1)`. Non-list receivers (`str`, maps, fixed-length arrays) reject range-indexing at compile time.
+
+```ry
+xs = [10, 20, 30, 40, 50]
+print(xs[1..3])    # [20, 30, 40]
+print(xs[-2..-1])  # [40, 50]
+```
+
 ---
 
 ## Null Coalescing Operator (`??`)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1475,6 +1475,13 @@ public:
     llvm::Value *emitCollOp_appended(const CallExpr &e);
     llvm::Value *emitCollOp_pop(const CallExpr &e);
     llvm::Value *emitCollOp_slice(const CallExpr &e);
+    // Shared slice helper: emit IR for list[start, endExcl).
+    // startVal/endExclVal must be i64 and already negative-wrapped if needed.
+    // emitListSlice clamps the half-open range to [0, lf.len] internally.
+    llvm::Value *emitListSlice(llvm::Value *listPtr,
+                                llvm::Value *startVal,
+                                llvm::Value *endExclVal,
+                                llvm::Type *elemTy);
     llvm::Value *emitCollOp_take(const CallExpr &e);
     llvm::Value *emitCollOp_take_impl(const CallExpr &e, llvm::Value *listPtr);
     llvm::Value *emitCollOp_insert(const CallExpr &e);

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -509,52 +509,52 @@ llvm::Value *CodeGen::emitCollOp_pop(const CallExpr &e) {
 
 llvm::Value *CodeGen::emitCollOp_slice(const CallExpr &e) {
     if (e.args.size() != 3) return nullptr;
-    // slice(list, start, end) -> new sub-list
     llvm::Value *listPtr = emitExpr(*e.args[0]);
     llvm::Type *elemTy = getListElementType(listPtr);
-    if (elemTy) {
-        llvm::Value *startVal = emitExpr(*e.args[1]);
-        llvm::Value *endVal = emitExpr(*e.args[2]);
+    if (!elemTy) return nullptr;
+    llvm::Value *startVal = emitExpr(*e.args[1]);
+    llvm::Value *endVal   = emitExpr(*e.args[2]);
+    // slice() builtin is [start, end) exclusive — pass endVal unchanged.
+    return emitListSlice(listPtr, startVal, endVal, elemTy);
+}
 
-        const llvm::DataLayout &dl = mod_->getDataLayout();
-        uint64_t elemSize = dl.getTypeAllocSize(elemTy);
-        auto mallocFn = getStdlibMalloc();
-        auto memcpyFn = getStdlibMemcpy();
+llvm::Value *CodeGen::emitListSlice(llvm::Value *listPtr,
+                                     llvm::Value *startVal,
+                                     llvm::Value *endExclVal,
+                                     llvm::Type *elemTy) {
+    const llvm::DataLayout &dl = mod_->getDataLayout();
+    uint64_t elemSize = dl.getTypeAllocSize(elemTy);
+    auto mallocFn = getStdlibMalloc();
+    auto memcpyFn = getStdlibMemcpy();
 
-        auto lf = loadListHeader(listPtr, "sl");
+    llvm::Value *slLen  = builder_.CreateLoad(i64Ty_,
+        builder_.CreateStructGEP(listHeaderTy_, listPtr, 0, "sl_len_ptr"), "sl_len");
+    llvm::Value *slData = builder_.CreateLoad(ptrTy_,
+        builder_.CreateStructGEP(listHeaderTy_, listPtr, 2, "sl_data_ptr"), "sl_data");
 
-        // Clamp start and end
-        llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
-        llvm::Value *clampedStart = builder_.CreateSelect(
-            builder_.CreateICmpSLT(startVal, zero), zero, startVal, "sl_cstart");
-        clampedStart = builder_.CreateSelect(
-            builder_.CreateICmpSGT(clampedStart, lf.len), lf.len, clampedStart, "sl_cstart2");
-        llvm::Value *clampedEnd = builder_.CreateSelect(
-            builder_.CreateICmpSLT(endVal, zero), zero, endVal, "sl_cend");
-        clampedEnd = builder_.CreateSelect(
-            builder_.CreateICmpSGT(clampedEnd, lf.len), lf.len, clampedEnd, "sl_cend2");
+    llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
+    llvm::Value *clampedStart = builder_.CreateSelect(
+        builder_.CreateICmpSLT(startVal, zero), zero, startVal, "sl_cstart");
+    clampedStart = builder_.CreateSelect(
+        builder_.CreateICmpSGT(clampedStart, slLen), slLen, clampedStart, "sl_cstart2");
+    llvm::Value *clampedEnd = builder_.CreateSelect(
+        builder_.CreateICmpSLT(endExclVal, zero), zero, endExclVal, "sl_cend");
+    clampedEnd = builder_.CreateSelect(
+        builder_.CreateICmpSGT(clampedEnd, slLen), slLen, clampedEnd, "sl_cend2");
 
-        // Compute count = max(0, end - start)
-        llvm::Value *diff = builder_.CreateSub(clampedEnd, clampedStart, "sl_diff");
-        llvm::Value *count = builder_.CreateSelect(
-            builder_.CreateICmpSGT(diff, zero), diff, zero, "sl_count");
+    llvm::Value *diff = builder_.CreateSub(clampedEnd, clampedStart, "sl_diff");
+    llvm::Value *count = builder_.CreateSelect(
+        builder_.CreateICmpSGT(diff, zero), diff, zero, "sl_count");
 
-        // Allocate new list
-        llvm::Value *newHeader = emitArcAllocCollectionHeader(listHeaderTy_);
-        llvm::Value *dataSize = builder_.CreateMul(count, llvm::ConstantInt::get(i64Ty_, elemSize), "sl_dsize");
-        llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "sl_data");
+    llvm::Value *newHeader = emitArcAllocCollectionHeader(listHeaderTy_);
+    llvm::Value *dataSize = builder_.CreateMul(count, llvm::ConstantInt::get(i64Ty_, elemSize), "sl_dsize");
+    llvm::Value *newData = builder_.CreateCall(mallocFn, {dataSize}, "sl_data");
+    llvm::Value *srcOffset = builder_.CreateGEP(elemTy, slData, clampedStart, "sl_src_off");
+    builder_.CreateCall(memcpyFn, {newData, srcOffset, dataSize});
 
-        // Copy elements
-        llvm::Value *srcOffset = builder_.CreateGEP(elemTy, lf.data, clampedStart, "sl_src_off");
-        builder_.CreateCall(memcpyFn, {newData, srcOffset, dataSize});
-
-        // Set header fields
-        storeListHeaderFields(newHeader, count, count, newData);
-
-        setTypeMeta(TypeMeta::ListElem, newHeader, elemTy);
-        return newHeader;
-    }
-    return nullptr;
+    storeListHeaderFields(newHeader, count, count, newData);
+    setTypeMeta(TypeMeta::ListElem, newHeader, elemTy);
+    return newHeader;
 }
 
 llvm::Value *CodeGen::emitCollOp_take(const CallExpr &e) {

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -471,6 +471,32 @@ llvm::Value *CodeGen::emitExprVariant(const EnumAccessExpr &e) {
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     llvm::Value *objPtr = emitExpr(*e->object);
 
+    // #1184: lst[a..b] arrives as IndexExpr{ object, indices:[RangeExpr{a,b}] }.
+    // Without this guard, emitExpr(RangeExpr) would materialize an ARC-allocated
+    // List<i64> header (ptr), flowing into emitBoundsCheck/GEP and producing
+    // invalid IR (ICmp ptr vs i64). Route to the shared slice helper instead.
+    if (e->indices.size() == 1) {
+        if (const auto *rp = std::get_if<std::unique_ptr<RangeExpr>>(&e->indices[0]->data)) {
+            if (objPtr->getType() != ptrTy_)
+                codegenError("range index requires a list");
+            if (isStringValue(objPtr))
+                codegenError("str does not support range index; use substring(s, a, b) instead");
+            llvm::Type *elemTy = getListElementType(objPtr);
+            if (!elemTy)
+                codegenError("range index requires a list");
+            const auto &range = **rp;
+            llvm::Value *startRaw = emitExpr(*range.start);
+            llvm::Value *endRaw   = emitExpr(*range.end);
+            llvm::Value *length = loadListHeader(objPtr, "ri").len;
+            llvm::Value *startWrapped = emitNegativeIndexWrap(startRaw, length, "ri_start");
+            llvm::Value *endWrapped   = emitNegativeIndexWrap(endRaw, length, "ri_end");
+            // `..` is inclusive; emitListSlice takes [start, endExcl). Convert.
+            llvm::Value *endExcl = builder_.CreateAdd(
+                endWrapped, llvm::ConstantInt::get(i64Ty_, 1), "ri_end_excl");
+            return emitListSlice(objPtr, startWrapped, endExcl, elemTy);
+        }
+    }
+
     llvm::SmallVector<llvm::Value*, 2> indexValues;
     for (auto &idx : e->indices)
         indexValues.push_back(emitExpr(*idx));

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -475,10 +475,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     // Without this guard, emitExpr(RangeExpr) would materialize an ARC-allocated
     // List<i64> header (ptr), flowing into emitBoundsCheck/GEP and producing
     // invalid IR (ICmp ptr vs i64). Route to the shared slice helper instead.
-    if (e->indices.size() == 1) {
+    if (e->indices.size() == 1 && objPtr->getType() == ptrTy_) {
         if (const auto *rp = std::get_if<std::unique_ptr<RangeExpr>>(&e->indices[0]->data)) {
-            if (objPtr->getType() != ptrTy_)
-                codegenError("range index requires a list");
             if (isStringValue(objPtr))
                 codegenError("str does not support range index; use substring(s, a, b) instead");
             llvm::Type *elemTy = getListElementType(objPtr);

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -491,8 +491,13 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
             llvm::Value *startWrapped = emitNegativeIndexWrap(startRaw, length, "ri_start");
             llvm::Value *endWrapped   = emitNegativeIndexWrap(endRaw, length, "ri_end");
             // `..` is inclusive; emitListSlice takes [start, endExcl). Convert.
-            llvm::Value *endExcl = builder_.CreateAdd(
-                endWrapped, llvm::ConstantInt::get(i64Ty_, 1), "ri_end_excl");
+            // Guard against INT64_MAX overflow: if endWrapped >= length, skip
+            // the +1 (emitListSlice will clamp to length regardless).
+            llvm::Value *endExcl = builder_.CreateSelect(
+                builder_.CreateICmpSGE(endWrapped, length),
+                length,
+                builder_.CreateAdd(endWrapped, llvm::ConstantInt::get(i64Ty_, 1), "ri_end_add"),
+                "ri_end_excl");
             return emitListSlice(objPtr, startWrapped, endExcl, elemTy);
         }
     }

--- a/tests/spec/list_range_index.test.ry
+++ b/tests/spec/list_range_index.test.ry
@@ -1,0 +1,83 @@
+describe("list range-index lst[a..b] (#1184)", ():
+  it("basic inclusive subrange [1..3] on [1,2,3,4,5]", ():
+    xs = [1, 2, 3, 4, 5]
+    ys = xs[1..3]
+    expect(ys).to_have_length(3)
+    expect(ys[0]).to_eq(2)
+    expect(ys[1]).to_eq(3)
+    expect(ys[2]).to_eq(4)
+  )
+  it("single-element [2..2] returns [3]", ():
+    xs = [1, 2, 3, 4, 5]
+    ys = xs[2..2]
+    expect(ys).to_have_length(1)
+    expect(ys[0]).to_eq(3)
+  )
+  it("full range [0..4] equals copy of list", ():
+    xs = [10, 20, 30, 40, 50]
+    ys = xs[0..4]
+    expect(ys).to_have_length(5)
+    expect(ys[0]).to_eq(10)
+    expect(ys[4]).to_eq(50)
+  )
+  it("negative wrap [-3..-1] on [1,2,3,4,5] returns [3,4,5]", ():
+    xs = [1, 2, 3, 4, 5]
+    ys = xs[-3..-1]
+    expect(ys).to_have_length(3)
+    expect(ys[0]).to_eq(3)
+    expect(ys[1]).to_eq(4)
+    expect(ys[2]).to_eq(5)
+  )
+  it("mixed negative/positive bounds [-4..3] returns [2,3,4]", ():
+    xs = [1, 2, 3, 4, 5]
+    ys = xs[-4..3]
+    expect(ys).to_have_length(3)
+    expect(ys[0]).to_eq(2)
+    expect(ys[2]).to_eq(4)
+  )
+  it("empty range (start > end after wrap) returns []", ():
+    xs = [1, 2, 3, 4, 5]
+    ys = xs[3..1]
+    expect(ys).to_have_length(0)
+  )
+  it("out-of-bounds upper bound is clamped", ():
+    xs = [1, 2, 3]
+    ys = xs[1..100]
+    expect(ys).to_have_length(2)
+    expect(ys[0]).to_eq(2)
+    expect(ys[1]).to_eq(3)
+  )
+  it("out-of-bounds lower bound is clamped to 0", ():
+    xs = [1, 2, 3]
+    ys = xs[-100..1]
+    expect(ys).to_have_length(2)
+    expect(ys[0]).to_eq(1)
+    expect(ys[1]).to_eq(2)
+  )
+  it("range over List<str> preserves element type", ():
+    xs = ["a", "b", "c", "d"]
+    ys = xs[1..2]
+    expect(ys).to_have_length(2)
+    expect(ys[0]).to_eq("b")
+    expect(ys[1]).to_eq("c")
+  )
+  # NOTE: nested List<List<int>> second-level index is disabled pending #1205
+  # (emitListSlice drops list_elem_type_name / nested TypeMeta).
+  # The same defect exists in slice() — slice([[1,2],[3,4]],0,2)[0][0] fails too.
+  # Re-enable ys[0][0] / ys[1][1] assertions after #1205 is fixed.
+  it("range over List<List<int>> preserves outer length", ():
+    xs = [[1, 2], [3, 4], [5, 6]]
+    ys = xs[0..1]
+    expect(ys).to_have_length(2)
+  )
+  it("consistency with slice: lst[a..b] == slice(lst, a, b+1) for non-negatives", ():
+    xs = [10, 20, 30, 40, 50]
+    a = xs[1..3]
+    b = slice(xs, 1, 4)
+    expect(a).to_have_length(3)
+    expect(b).to_have_length(3)
+    expect(a[0]).to_eq(b[0])
+    expect(a[1]).to_eq(b[1])
+    expect(a[2]).to_eq(b[2])
+  )
+)

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -992,3 +992,27 @@ TEST_F(CodeGenTest, ReverseMutOnStringRejected) {
         "s.reverse!()\n",
         {"reverse!", "list", "immutable"});
 }
+
+// ============================================================
+// range-index (..) on non-list receivers is rejected (#1184)
+// ============================================================
+
+TEST_F(CodeGenTest, StrRangeIndexRejected) {
+    expectCompileError(
+        "s = \"hello\"\n"
+        "_ = s[0..2]\n",
+        {"str", "range index"});
+}
+
+TEST_F(CodeGenTest, StrLiteralRangeIndexRejected) {
+    expectCompileError(
+        "_ = \"hello\"[0..2]\n",
+        {"str", "range index"});
+}
+
+TEST_F(CodeGenTest, MapRangeIndexRejected) {
+    expectCompileError(
+        "m = {\"a\": 1}\n"
+        "_ = m[0..1]\n",
+        {"range index", "list"});
+}


### PR DESCRIPTION
## Summary

- `lst[a..b]` was parsed as `IndexExpr{ object: lst, indices: [RangeExpr{a,b}] }`, causing `emitExpr(RangeExpr)` to materialise an ARC-allocated `List<i64>` header (`ptr`) that flowed into `emitBoundsCheck`/GEP, producing `ICmp ptr vs i64` type-mismatch in the IR verifier
- Added a `RangeExpr` intercept in `emitExprVariant(IndexExpr)` before the `indexValues` emit loop; extracts `start`/`end` directly (no temp list), applies `emitNegativeIndexWrap`, converts inclusive→exclusive (`end + 1`), and routes to `emitListSlice`
- Extracted `emitListSlice` shared helper from `emitCollOp_slice`; both `slice()` builtin and `lst[a..b]` now share identical IR generation — future fixes for ARC retain (#1204) and nested TypeMeta (#1205) will benefit both call sites

## Semantics

- `lst[a..b]` is **inclusive** on both ends (matches `..` operator semantics)
- Negative bounds **wrap** against list length (like `lst[-1]`)
- Out-of-bounds bounds are **clamped** (matches `slice()` behaviour)
- Equivalent to `slice(lst, a, b + 1)`

## Test plan

- [ ] `tests/spec/list_range_index.test.ry` — 11 new cases: basic inclusive, single-element, full range, negative wrap, mixed negative/positive, empty range (start > end), OOB upper clamp, OOB lower clamp, `List<str>`, `List<List<int>>` outer length, consistency with `slice()`
- [ ] `tests/spec/collections.test.ry` — existing slice tests pass without regression
- [ ] `./build/ry_tests` — full C++ test suite
- [ ] `./build/ry test -p` — full Ry self-test suite
- [ ] ASan + UBSan clean
- [ ] TSan clean
- [ ] libFuzzer 60s × 3 clean

## Pre-existing defects tracked separately

- **#1204** — `emitListSlice` omits ARC retain for reference-typed elements (`List<str>`, `List<List<int>>`)
- **#1205** — `emitListSlice` drops `list_elem_type_name` / nested TypeMeta (affects two-level index after slice)

Closes #1184

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed list range indexing (`lst[a..b]`) crash in codegen; now wraps negative bounds, clamps out-of-bounds, and uses half-open slice semantics so `lst[a..b]` matches `slice(lst, a, b+1)`.

* **Documentation**
  * Added and expanded docs (including an internal knowledge entry) for the `..` list-range syntax, semantics, examples, and a compile-time restriction rejecting range-indexing on non-list receivers.

* **Tests**
  * Added tests covering positive/negative/mixed ranges, clamping, equivalence to slice behavior, and rejection for non-list receivers.

* **Changelog**
  * Recorded the fix for list range indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->