### PR TITLE
fix: slice(lst, start, end) resolves negative indices via Python-style wrap (#1198)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3976,3 +3976,4 @@ This avoids materialising the intermediate `List<i64>` entirely.
 - `emitListSlice(listPtr, startVal, endExclVal, elemTy)` (`src/codegen_call_collection.cpp`) — shared between `slice()` builtin and `lst[a..b]`. Clamps internally.
 - `emitNegativeIndexWrap(idx, len, prefix)` (`src/codegen_call_user.cpp:645`) — use prefix `"ri_start"` / `"ri_end"` to avoid label collision with scalar-index prefix `"index"`.
 - Pre-existing defects in `emitListSlice`: ARC retain omitted for reference-typed elements (#1204), nested TypeMeta not propagated (#1205) — tracked separately.
+- **#1198**: `emitCollOp_slice` was missing the pre-wrap step required by this contract; fixed by applying `emitNegativeIndexWrap(start, len, "sl_start")` / `emitNegativeIndexWrap(end, len, "sl_end")` before the `emitListSlice` call, mirroring the range-index route.

--- a/changelog.d/1198-slice-negative-index.md
+++ b/changelog.d/1198-slice-negative-index.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `slice(lst, start, end)` now resolves negative `start` / `end` as offsets from the end of the list (`length + idx`), consistent with Python-style indexing, subscript access, and the `lst[a..b]` range-index operator (#1184). Over-negative inputs are silently clamped to `0`. (#1198)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -476,12 +476,14 @@ print(xs)   # [1, 2, 3] (unchanged)
 
 **Signature:** `slice(list: List<T>, start: int, end: int) -> List<T>`
 
-Returns a new sub-list from `start` (inclusive) to `end` (exclusive). Indices are clamped to the valid range (`0` to `length(list)`). UFCS notation is also available.
+Returns a new sub-list covering `[start, end)` (end exclusive). Negative indices are resolved as `length + idx` (Python-style, consistent with `lst[-1]` and `lst[a..b]`). The resolved range is then silently clamped to `[0, length(list)]`. UFCS notation is also available.
 
 ```ry
 xs = [1, 2, 3, 4, 5]
 print(slice(xs, 1, 3))     # [2, 3]
-print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (clamped)
+print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (end clamped)
+print(slice(xs, -2, 5))    # [4, 5]  (negative start wraps to index 3)
+print(slice(xs, -4, -1))   # [2, 3, 4]  (both bounds wrap)
 ```
 
 ---

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -242,12 +242,14 @@ print(xs)            # [1, 2, 3] (unchanged)
 
 ### slice
 
-Returns a new sub-list from `start` (inclusive) to `end` (exclusive). Indices are clamped to the valid range.
+Returns a new sub-list covering `[start, end)` (end exclusive). Negative indices are resolved as `length + idx` (Python-style, consistent with `lst[-1]`). The resolved range is then silently clamped to `[0, length(list)]`.
 
 ```ry
 xs = [1, 2, 3, 4, 5]
 print(slice(xs, 1, 3))     # [2, 3]
-print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (clamped)
+print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (end clamped)
+print(slice(xs, -2, 5))    # [4, 5]  (negative start wraps to index 3)
+print(slice(xs, -4, -1))   # [2, 3, 4]  (both bounds wrap)
 ```
 
 You can also use the `..` range operator as a list index for an equivalent, more concise syntax. `lst[a..b]` is inclusive on both ends and is equivalent to `slice(lst, a, b + 1)`. Negative indices wrap against the list length (like `lst[-1]`), and out-of-bounds bounds are clamped.

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -514,8 +514,11 @@ llvm::Value *CodeGen::emitCollOp_slice(const CallExpr &e) {
     if (!elemTy) return nullptr;
     llvm::Value *startVal = emitExpr(*e.args[1]);
     llvm::Value *endVal   = emitExpr(*e.args[2]);
-    // slice() builtin is [start, end) exclusive — pass endVal unchanged.
-    return emitListSlice(listPtr, startVal, endVal, elemTy);
+    llvm::Value *length = loadListHeader(listPtr, "sc").len;
+    llvm::Value *startWrapped = emitNegativeIndexWrap(startVal, length, "sl_start");
+    llvm::Value *endWrapped   = emitNegativeIndexWrap(endVal,   length, "sl_end");
+    // slice() builtin is [start, end) exclusive — no +1 adjustment.
+    return emitListSlice(listPtr, startWrapped, endWrapped, elemTy);
 }
 
 llvm::Value *CodeGen::emitListSlice(llvm::Value *listPtr,

--- a/tests/spec/bounds_check.test.ry
+++ b/tests/spec/bounds_check.test.ry
@@ -108,4 +108,47 @@ describe("bounds checking", ():
       expect(xs).to_have_length(2)
     )
   )
+
+  describe("slice negative index", ():
+    it("should wrap negative start (-3) for slice", ():
+      xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      ys = slice(xs, -3, 10)
+      expect(ys).to_have_length(3)
+      expect(ys[0]).to_eq(7)
+      expect(ys[1]).to_eq(8)
+      expect(ys[2]).to_eq(9)
+    )
+    it("should wrap negative end (-1) for slice", ():
+      xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      ys = slice(xs, 0, -1)
+      expect(ys).to_have_length(9)
+      expect(ys[0]).to_eq(0)
+      expect(ys[8]).to_eq(8)
+    )
+    it("should wrap both negative bounds for slice", ():
+      xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      ys = slice(xs, -5, -2)
+      expect(ys).to_have_length(3)
+      expect(ys[0]).to_eq(5)
+      expect(ys[1]).to_eq(6)
+      expect(ys[2]).to_eq(7)
+    )
+    it("should clamp over-negative start to 0", ():
+      xs = [1, 2, 3]
+      ys = slice(xs, -100, 2)
+      expect(ys).to_have_length(2)
+      expect(ys[0]).to_eq(1)
+      expect(ys[1]).to_eq(2)
+    )
+    it("should return empty slice when end clamps below start", ():
+      xs = [1, 2, 3]
+      ys = slice(xs, 1, -100)
+      expect(ys).to_have_length(0)
+    )
+    it("should return empty slice when start > end after wrap", ():
+      xs = [1, 2, 3]
+      ys = slice(xs, -2, -3)
+      expect(ys).to_have_length(0)
+    )
+  )
 )

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -1254,6 +1254,19 @@ TEST_F(CodeGenTest, ListSliceVariants) {
     EXPECT_EQ(runSource("print(slice([1, 2, 3], 2, 2))"), "[]\n");
 }
 
+TEST_F(CodeGenTest, ListSliceNegativeIndex) {
+    // Negative start wraps to len+start: issue #1198 examples
+    EXPECT_EQ(runSource("print(slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], -3, 10))"), "[7, 8, 9]\n");
+    EXPECT_EQ(runSource("print(slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 0, -1))"),
+              "[0, 1, 2, 3, 4, 5, 6, 7, 8]\n");
+    EXPECT_EQ(runSource("print(slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], -5, -2))"), "[5, 6, 7]\n");
+    // Over-negative silently clamps to 0
+    EXPECT_EQ(runSource("print(slice([1, 2, 3], -100, 2))"), "[1, 2]\n");
+    EXPECT_EQ(runSource("print(slice([1, 2, 3], 1, -100))"), "[]\n");
+    // start > end after wrap → empty
+    EXPECT_EQ(runSource("print(slice([1, 2, 3], -2, -3))"), "[]\n");
+}
+
 // ===== filter テスト =====
 
 TEST_F(CodeGenTest, FilterBasics) {


### PR DESCRIPTION
## Summary

- `emitCollOp_slice` was passing raw `start`/`end` directly to `emitListSlice`, which only clamps to `[0, len]` — so negative inputs like `-3` collapsed to `0`, returning the wrong result
- Fix: apply `emitNegativeIndexWrap(start, len, "sl_start")` / `emitNegativeIndexWrap(end, len, "sl_end")` before calling `emitListSlice`, mirroring the `lst[a..b]` range-index route in `codegen_expr_literal.cpp:489-490`
- Use prefix `"sc"` (slice-call) for the header load to avoid IR label collision with `emitListSlice`'s own `sl_*` internal names

## Semantics

- Negative `start` / `end` resolve as `length + idx` (Python-style), then silently clamp to `[0, length]`
- Over-negative inputs (e.g. `-100` on a 3-element list) clamp to `0` — no error, consistent with Python `list[-100:2]`
- `emitListSlice` itself is unchanged — its contract ("caller pre-wraps, I clamp") now applies to both call sites

## Test plan

- [x] `tests/spec/bounds_check.test.ry` — 6 new cases: issue #1198 examples, over-negative start/end, start > end after wrap
- [x] `tests/test_codegen_collection.cpp` — `ListSliceNegativeIndex` test covering all 3 issue examples + edge cases
- [x] `./build/ry_tests` — 1818 tests pass
- [x] `./build/ry test -p` — 145 test files pass
- [x] ASan + UBSan clean
- [x] TSan clean (`ry_tests` required + `ry test -p` warn-only both clean)
- [x] libFuzzer 60s × 3 targets clean

## Related

- Closes #1198
- `lst[a..b]` range-index (fixed in #1184) already pre-wrapped negatives correctly via the same helper; this PR aligns `slice()` to match
- `substring(s, start, end)` has the same 0-clamp bug → tracked separately as #1213

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `slice()` function to properly handle negative `start` and `end` indices using Python-style semantics, where negative values are interpreted as offsets from the end of the list. Over-negative bounds are automatically clamped to valid ranges.

* **Documentation**
  * Updated slice function reference documentation with clarified semantics for negative index handling and end-exclusive behavior.

* **Tests**
  * Added comprehensive test coverage for slice behavior with negative indices and boundary conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->