### PR TITLE
fix(docs): classify #1182 as ORC JIT teardown flake fixed by #1200; add chunk_main_arena variant to KNOWLEDGE.md

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: /usr/local/llvm
-        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v5-${{ inputs.sha256-short }}
+        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v6-${{ inputs.sha256-short }}
 
     - name: Download and install LLVM
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -89,6 +89,13 @@ runs:
     - name: Register LLVM shared libraries
       shell: bash
       run: |
+        V="${{ inputs.llvm-version }}"
+        MAJOR="${V%%.*}"
+        # The tarball is repacked from apt packages and contains absolute symlinks
+        # (e.g. lib/libclang-cpp.so -> /usr/lib/x86_64-linux-gnu/libclang-cpp.so.21).
+        # Install the lightweight runtime packages so those symlinks resolve.
+        sudo apt-get install -y -q --no-install-recommends \
+          "libllvm${MAJOR}" "libclang-cpp${MAJOR}"
         if [ -d /usr/local/llvm/lib ]; then
           echo /usr/local/llvm/lib | sudo tee /etc/ld.so.conf.d/llvm-local.conf
           sudo ldconfig

--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: /usr/local/llvm
-        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v4-${{ inputs.sha256-short }}
+        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v5-${{ inputs.sha256-short }}
 
     - name: Download and install LLVM
       if: steps.cache.outputs.cache-hit != 'true'
@@ -85,3 +85,11 @@ runs:
     - name: Add LLVM to PATH
       shell: bash
       run: echo "/usr/local/llvm/bin" >> "$GITHUB_PATH"
+
+    - name: Register LLVM shared libraries
+      shell: bash
+      run: |
+        if [ -d /usr/local/llvm/lib ]; then
+          echo /usr/local/llvm/lib | sudo tee /etc/ld.so.conf.d/llvm-local.conf
+          sudo ldconfig
+        fi

--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -94,6 +94,16 @@ runs:
         # The tarball is repacked from apt packages and contains absolute symlinks
         # (e.g. lib/libclang-cpp.so -> /usr/lib/x86_64-linux-gnu/libclang-cpp.so.21).
         # Install the lightweight runtime packages so those symlinks resolve.
+        # libllvm${MAJOR} / libclang-cpp${MAJOR} ship on apt.llvm.org only, not
+        # on Ubuntu's default sources. The apt-fallback path in the step above
+        # runs llvm.sh which adds the repo; on the mirror-download path we add
+        # it here so the install below can resolve the packages.
+        CODENAME="$(lsb_release -cs)"
+        curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+          | sudo gpg --dearmor --yes -o /usr/share/keyrings/llvm-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${MAJOR} main" \
+          | sudo tee /etc/apt/sources.list.d/llvm-${MAJOR}.list >/dev/null
+        sudo apt-get update -q
         sudo apt-get install -y -q --no-install-recommends \
           "libllvm${MAJOR}" "libclang-cpp${MAJOR}"
         if [ -d /usr/local/llvm/lib ]; then

--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -58,23 +58,23 @@ jobs:
 
           # Copy the apt-installed tree preserving structure. cp -aL would follow
           # the cyclic build/Debug+Asserts and build/Release symlinks and fail,
-          # so we copy with cp -a first and resolve absolute symlinks in a
-          # second pass (the ones pointing to /usr/include/llvm-{MAJOR} for
-          # headers and /usr/lib/x86_64-linux-gnu/ for .so files).
+          # so we copy with cp -a first and resolve tree-escaping symlinks in a
+          # second pass. Both absolute targets (/usr/include/llvm-{MAJOR}, etc.)
+          # and relative ones that climb out with ../../.. (include/llvm,
+          # lib/libLLVM.so, lib/libclang-cpp.so, ...) must be materialised so
+          # the tarball is self-contained.
           cp -a "/usr/lib/llvm-${LLVM_MAJOR}" llvm
 
-          # Replace any absolute symlink (pointing outside our tree) with a
-          # copy of the referent so the tarball is self-contained.
+          ROOT="$(readlink -f llvm)"
           find llvm -type l | while read -r link; do
-            target="$(readlink "$link")"
-            case "$target" in
-              /*)
-                real="$(readlink -f "$link" 2>/dev/null)" || continue
-                [ -n "$real" ] && [ -e "$real" ] || continue
-                rm -f "$link"
-                cp -a "$real" "$link"
-                ;;
+            real="$(readlink -f "$link" 2>/dev/null)" || continue
+            [ -n "$real" ] && [ -e "$real" ] || continue
+            # Skip symlinks whose resolved target stays inside llvm/.
+            case "$real" in
+              "$ROOT"/*|"$ROOT") continue ;;
             esac
+            rm -f "$link"
+            cp -a "$real" "$link"
           done
 
           # Repack

--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -56,8 +56,10 @@ jobs:
           V="${{ inputs.llvm_version }}"
           cd /tmp
 
-          # Copy the apt-installed tree into a clean 'llvm/' directory
-          cp -a "/usr/lib/llvm-${LLVM_MAJOR}" llvm
+          # Copy the apt-installed tree into a clean 'llvm/' directory.
+          # Use -L to follow symlinks so shared .so files are included as real
+          # files rather than dangling symlinks to /usr/lib/x86_64-linux-gnu/.
+          cp -aL "/usr/lib/llvm-${LLVM_MAJOR}" llvm
 
           # Repack
           ASSET="llvm-${V}-linux-x86_64.tar.xz"

--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -56,10 +56,26 @@ jobs:
           V="${{ inputs.llvm_version }}"
           cd /tmp
 
-          # Copy the apt-installed tree into a clean 'llvm/' directory.
-          # Use -L to follow symlinks so shared .so files are included as real
-          # files rather than dangling symlinks to /usr/lib/x86_64-linux-gnu/.
-          cp -aL "/usr/lib/llvm-${LLVM_MAJOR}" llvm
+          # Copy the apt-installed tree preserving structure. cp -aL would follow
+          # the cyclic build/Debug+Asserts and build/Release symlinks and fail,
+          # so we copy with cp -a first and resolve absolute symlinks in a
+          # second pass (the ones pointing to /usr/include/llvm-{MAJOR} for
+          # headers and /usr/lib/x86_64-linux-gnu/ for .so files).
+          cp -a "/usr/lib/llvm-${LLVM_MAJOR}" llvm
+
+          # Replace any absolute symlink (pointing outside our tree) with a
+          # copy of the referent so the tarball is self-contained.
+          find llvm -type l | while read -r link; do
+            target="$(readlink "$link")"
+            case "$target" in
+              /*)
+                real="$(readlink -f "$link" 2>/dev/null)" || continue
+                [ -n "$real" ] && [ -e "$real" ] || continue
+                rm -f "$link"
+                cp -a "$real" "$link"
+                ;;
+            esac
+          done
 
           # Repack
           ASSET="llvm-${V}-linux-x86_64.tar.xz"

--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -56,26 +56,15 @@ jobs:
           V="${{ inputs.llvm_version }}"
           cd /tmp
 
-          # Copy the apt-installed tree preserving structure. cp -aL would follow
-          # the cyclic build/Debug+Asserts and build/Release symlinks and fail,
-          # so we copy with cp -a first and resolve tree-escaping symlinks in a
-          # second pass. Both absolute targets (/usr/include/llvm-{MAJOR}, etc.)
-          # and relative ones that climb out with ../../.. (include/llvm,
-          # lib/libLLVM.so, lib/libclang-cpp.so, ...) must be materialised so
-          # the tarball is self-contained.
-          cp -a "/usr/lib/llvm-${LLVM_MAJOR}" llvm
-
-          ROOT="$(readlink -f llvm)"
-          find llvm -type l | while read -r link; do
-            real="$(readlink -f "$link" 2>/dev/null)" || continue
-            [ -n "$real" ] && [ -e "$real" ] || continue
-            # Skip symlinks whose resolved target stays inside llvm/.
-            case "$real" in
-              "$ROOT"/*|"$ROOT") continue ;;
-            esac
-            rm -f "$link"
-            cp -a "$real" "$link"
-          done
+          # Produce a self-contained copy of the apt-installed tree. rsync with
+          # --copy-unsafe-links dereferences only symlinks that point outside
+          # the source tree (/usr/include/llvm-{MAJOR}, /usr/lib/x86_64-linux-gnu)
+          # while keeping in-tree symlink chains (libLLVM.so -> libLLVM.so.21 ->
+          # libLLVM.so.21.1 -> ../../x86_64-linux-gnu/...) as symlinks, so only
+          # the ultimate referent is copied once. Cyclic in-tree symlinks
+          # (build/Debug+Asserts -> ., build/Release -> .) are safe and left as
+          # symlinks -- rsync does not recurse into them.
+          rsync -a --copy-unsafe-links "/usr/lib/llvm-${LLVM_MAJOR}/" llvm/
 
           # Repack
           ASSET="llvm-${V}-linux-x86_64.tar.xz"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ CI は `.github/actions/setup-llvm/` composite action 経由で LLVM を取得�
 
 ミラー tarball は `.github/workflows/mirror-llvm-toolchain.yml`（手動 `workflow_dispatch`）で構築・アップロードする。
 
-**キャッシュキー**: `llvm-${VERSION}-linux-x86_64-v2-${SHA256_SHORT}`。`restore-keys` は意図的に設定しない — 部分一致ヒットは異なるバージョンの LLVM を復元し、ビルド失敗や ABI 不整合を引き起こす。
+**キャッシュキー**: `llvm-${VERSION}-linux-x86_64-v5-${SHA256_SHORT}`。`restore-keys` は意図的に設定しない — 部分一致ヒットは異なるバージョンの LLVM を復元し、ビルド失敗や ABI 不整合を引き起こす。
 
 **バージョンバンプ手順**:
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2140,14 +2140,23 @@ fatal error: llvm/IR/IRBuilder.h: No such file or directory
 
 **Fix applied** (PR #1216):
 1. Cache key bumped `v4` → `v5` to evict the poisoned stub (`setup-llvm/action.yml`).
-2. `Register LLVM shared libraries` step now installs the lightweight runtime apt packages and
-   runs `ldconfig` (always, regardless of cache-hit or tarball path):
+2. `Register LLVM shared libraries` step now adds the `apt.llvm.org` source, installs the
+   lightweight runtime apt packages, and runs `ldconfig` (always, regardless of cache-hit or
+   tarball path):
    ```bash
+   CODENAME="$(lsb_release -cs)"
+   curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key \
+     | sudo gpg --dearmor --yes -o /usr/share/keyrings/llvm-archive-keyring.gpg
+   echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/${CODENAME}/ llvm-toolchain-${CODENAME}-${MAJOR} main" \
+     | sudo tee /etc/apt/sources.list.d/llvm-${MAJOR}.list
+   sudo apt-get update -q
    sudo apt-get install -y -q --no-install-recommends "libllvm${MAJOR}" "libclang-cpp${MAJOR}"
    echo /usr/local/llvm/lib | sudo tee /etc/ld.so.conf.d/llvm-local.conf && sudo ldconfig
    ```
    This makes the dangling symlinks in `/usr/local/llvm/lib/` resolve by installing the actual
-   `.so` files in `/usr/lib/x86_64-linux-gnu/`.
+   `.so` files in `/usr/lib/x86_64-linux-gnu/`. `libllvm${MAJOR}` and `libclang-cpp${MAJOR}` are
+   available only from `apt.llvm.org`, not Ubuntu's default sources — the apt-fallback path gets
+   the repo added by `llvm.sh`, but the mirror-download path does not, so we add it here.
 3. Mirror workflow changed `cp -a` → `cp -aL` (`mirror-llvm-toolchain.yml`) so future tarballs
    contain real `.so` files instead of dangling symlinks. Requires re-dispatch with `force=true`
    to rebuild the `llvm-toolchain-{VERSION}` release asset.

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2087,7 +2087,7 @@ The mirror tarball includes `clang-tidy` (added in #934), `scan-build` / `analyz
 the apt fallback path; the mirror/cache path already contains all
 tools. If new tools are needed, add them to
 `mirror-llvm-toolchain.yml`'s apt-get line, bump the cache key
-version suffix (e.g. `v3` → `v4`), and re-dispatch the mirror workflow
+version suffix (e.g. `v4` → `v5`), and re-dispatch the mirror workflow
 with `force=true`.
 
 Version bump checklist — update `env.LLVM_VERSION` (and
@@ -2095,13 +2095,63 @@ Version bump checklist — update `env.LLVM_VERSION` (and
 - `.github/workflows/ci.yml`
 - `.github/workflows/codeql.yml`
 
-Cache key format: `llvm-${VERSION}-linux-x86_64-v4-${SHA256_SHORT}`.
+Cache key format: `llvm-${VERSION}-linux-x86_64-v5-${SHA256_SHORT}`.
 `restore-keys` is intentionally omitted: a partial cache hit would
 restore a mismatched LLVM version, causing build failures or silent ABI
 mismatches. An exact-match-only policy guarantees the correct toolchain.
 
 `release.yml` still uses `apt.llvm.org` directly and is not yet
 migrated — tracked as a separate follow-up from #892.
+
+---
+
+### setup-llvm: tarball install requires ldconfig; apt-fallback symlink corrupts cache
+
+**Source**: #1216 (2026-04-19) — CI broken after PR #1215 merged into v0.0.13
+**Tags**: llvm, ci, cache, ldconfig, setup-llvm, gotcha
+
+**Symptom**:
+```text
+/usr/local/llvm/bin/clang: error while loading shared libraries:
+    libclang-cpp.so.21.1: cannot open shared object file: No such file or directory
+```
+or
+```text
+fatal error: llvm/IR/IRBuilder.h: No such file or directory
+```
+
+**Root cause (two interacting bugs)**:
+
+1. **Missing `ldconfig`** — The tarball install path in `setup-llvm/action.yml` extracts files to
+   `/usr/local/llvm/lib/` but never registers them with the Linux dynamic linker. The apt fallback
+   path does not need this because `apt` runs `ldconfig` automatically. Without it, `clang`
+   launches successfully (the binary exists) but immediately fails because `libclang-cpp.so.21.1`
+   is not in the linker cache.
+
+2. **Apt-fallback symlink poisons the cache** — When the apt fallback runs, it creates
+   `sudo ln -sfn /usr/lib/llvm-{MAJOR} /usr/local/llvm`. `actions/cache@v4` then saves this
+   ~205-byte symlink under the cache key. On a subsequent runner (no apt LLVM installed), the
+   cache restore tries to recreate the symlink but fails with
+   `Cannot create symlink to '/usr/lib/llvm-21': Permission denied`. `actions/cache` treats this
+   as a restoration failure and marks `cache-hit: false`, so the "Download and install LLVM" step
+   runs. But the key is **immutable** — the good tarball installation cannot overwrite the existing
+   stub, so every subsequent cold-cache run falls through to tarball install without ldconfig.
+
+**Fix applied** (PR #1216, `setup-llvm/action.yml`):
+1. Cache key bumped `v4` → `v5` to evict the poisoned stub.
+2. New step `Register LLVM shared libraries` (always runs after cache-restore or tarball install):
+   ```yaml
+   if [ -d /usr/local/llvm/lib ]; then
+     echo /usr/local/llvm/lib | sudo tee /etc/ld.so.conf.d/llvm-local.conf
+     sudo ldconfig
+   fi
+   ```
+   The `[ -d /usr/local/llvm/lib ]` guard is a no-op for apt fallback (harmless re-registration)
+   and the real fix for the tarball path.
+
+**Rule**: When bumping the cache key version (needed when tarball contents change), also verify
+that the tarball install path runs `ldconfig` — otherwise the first cold-cache run will always
+fail. Do NOT rely on `actions/cache` to overwrite a poisoned stub entry; change the key instead.
 
 ### Compiler warning flags require SYSTEM includes for third-party headers
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2105,7 +2105,7 @@ migrated — tracked as a separate follow-up from #892.
 
 ---
 
-### setup-llvm: tarball install requires ldconfig; apt-fallback symlink corrupts cache
+### setup-llvm: tarball has broken .so symlinks; apt-fallback symlink corrupts cache
 
 **Source**: #1216 (2026-04-19) — CI broken after PR #1215 merged into v0.0.13
 **Tags**: llvm, ci, cache, ldconfig, setup-llvm, gotcha
@@ -2120,38 +2120,42 @@ or
 fatal error: llvm/IR/IRBuilder.h: No such file or directory
 ```
 
-**Root cause (two interacting bugs)**:
+**Root cause (three interacting bugs)**:
 
-1. **Missing `ldconfig`** — The tarball install path in `setup-llvm/action.yml` extracts files to
-   `/usr/local/llvm/lib/` but never registers them with the Linux dynamic linker. The apt fallback
-   path does not need this because `apt` runs `ldconfig` automatically. Without it, `clang`
-   launches successfully (the binary exists) but immediately fails because `libclang-cpp.so.21.1`
-   is not in the linker cache.
+1. **Tarball has broken absolute symlinks for shared `.so` files** — The mirror workflow builds the
+   tarball with `cp -a /usr/lib/llvm-{MAJOR} llvm/`. On Ubuntu 24.04, shared libraries such as
+   `libclang-cpp.so.21.1` live in `/usr/lib/x86_64-linux-gnu/`, NOT in `/usr/lib/llvm-{MAJOR}/`.
+   The `llvm-{MAJOR}` directory contains only absolute symlinks (e.g.
+   `lib/libclang-cpp.so → /usr/lib/x86_64-linux-gnu/libclang-cpp.so.21`). When extracted on a
+   runner without apt LLVM, those symlinks are dangling — the target path does not exist.
 
-2. **Apt-fallback symlink poisons the cache** — When the apt fallback runs, it creates
-   `sudo ln -sfn /usr/lib/llvm-{MAJOR} /usr/local/llvm`. `actions/cache@v4` then saves this
-   ~205-byte symlink under the cache key. On a subsequent runner (no apt LLVM installed), the
-   cache restore tries to recreate the symlink but fails with
-   `Cannot create symlink to '/usr/lib/llvm-21': Permission denied`. `actions/cache` treats this
-   as a restoration failure and marks `cache-hit: false`, so the "Download and install LLVM" step
-   runs. But the key is **immutable** — the good tarball installation cannot overwrite the existing
-   stub, so every subsequent cold-cache run falls through to tarball install without ldconfig.
+2. **Missing runtime package install** — Previously the CI runner image pre-installed `libclang-cpp21`
+   from the GitHub-managed Ubuntu image, making the dangling symlinks resolve silently. After a
+   runner image update removed those packages, the symlinks started failing.
 
-**Fix applied** (PR #1216, `setup-llvm/action.yml`):
-1. Cache key bumped `v4` → `v5` to evict the poisoned stub.
-2. New step `Register LLVM shared libraries` (always runs after cache-restore or tarball install):
-   ```yaml
-   if [ -d /usr/local/llvm/lib ]; then
-     echo /usr/local/llvm/lib | sudo tee /etc/ld.so.conf.d/llvm-local.conf
-     sudo ldconfig
-   fi
+3. **Apt-fallback symlink poisons the cache** — When the apt fallback path runs, it creates
+   `sudo ln -sfn /usr/lib/llvm-{MAJOR} /usr/local/llvm`. `actions/cache@v4` saves this ~205-byte
+   symlink under the cache key. The key is **immutable** — a subsequent tarball-based run cannot
+   overwrite it, so every cold-cache run hits the broken symlink problem indefinitely.
+
+**Fix applied** (PR #1216):
+1. Cache key bumped `v4` → `v5` to evict the poisoned stub (`setup-llvm/action.yml`).
+2. `Register LLVM shared libraries` step now installs the lightweight runtime apt packages and
+   runs `ldconfig` (always, regardless of cache-hit or tarball path):
+   ```bash
+   sudo apt-get install -y -q --no-install-recommends "libllvm${MAJOR}" "libclang-cpp${MAJOR}"
+   echo /usr/local/llvm/lib | sudo tee /etc/ld.so.conf.d/llvm-local.conf && sudo ldconfig
    ```
-   The `[ -d /usr/local/llvm/lib ]` guard is a no-op for apt fallback (harmless re-registration)
-   and the real fix for the tarball path.
+   This makes the dangling symlinks in `/usr/local/llvm/lib/` resolve by installing the actual
+   `.so` files in `/usr/lib/x86_64-linux-gnu/`.
+3. Mirror workflow changed `cp -a` → `cp -aL` (`mirror-llvm-toolchain.yml`) so future tarballs
+   contain real `.so` files instead of dangling symlinks. Requires re-dispatch with `force=true`
+   to rebuild the `llvm-toolchain-{VERSION}` release asset.
 
-**Rule**: When bumping the cache key version (needed when tarball contents change), also verify
-that the tarball install path runs `ldconfig` — otherwise the first cold-cache run will always
-fail. Do NOT rely on `actions/cache` to overwrite a poisoned stub entry; change the key instead.
+**Rule**: When the mirror tarball is built from apt packages, use `cp -aL` (not `cp -a`) so shared
+library symlinks are resolved into actual files. Otherwise the tarball is not portable to runners
+that don't have the matching apt packages pre-installed. If a cache key is poisoned by an
+apt-symlink entry, bump the key version — `actions/cache` does not allow overwriting existing keys.
 
 ### Compiler warning flags require SYSTEM includes for third-party headers
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1927,15 +1927,16 @@ surfaces, widen via #872 rather than blindly expanding the flag.
 
 ### LLVM ORC JIT intermittent crash in `~LLJIT()` / `removeResourceTracker` / `~CodeGen()` (Linux + macOS)
 
-**Source**: #1022 (2026-04-16) CI run 24507853564; #1088 (2026-04-17) macOS Darwin 25.3.0; #1043 (2026-04-17) CI runs 24547110395 + 24547575356; #1187 (2026-04-19) macOS Darwin 25.3.0 residual ~16 % rate
+**Source**: #1022 (2026-04-16) CI run 24507853564; #1088 (2026-04-17) macOS Darwin 25.3.0; #1043 (2026-04-17) CI runs 24547110395 + 24547575356; #1187 (2026-04-19) macOS Darwin 25.3.0 residual ~16 % rate; #1200 (2026-04-19) fix PR; #1182 (2026-04-19) Linux CI `chunk_main_arena (fwd)` glibc variant, confirmed fixed by #1200
 **Tags**: llvm, orc, jit, ci, flaky, linux, macos, cleanup, parallel-test
 
 **Symptom**: The Ry self-test (`ry test -p`) completes all `it` blocks
 successfully, then crashes during JIT teardown.
 
-- **Linux CI**: glibc heap consolidation crash (`cfree`) during LLVM teardown. The crash frame
-  varies — most commonly `removeResourceTracker`, but `CodeGen::~CodeGen()` has also been observed
-  ("corrupted size vs. prev_size while consolidating"). Same root cause; different destruction order.
+- **Linux CI**: glibc heap consolidation crash during LLVM teardown. The crash frame varies —
+  most commonly `removeResourceTracker` (`cfree`), but `CodeGen::~CodeGen()` ("corrupted size vs.
+  prev_size while consolidating") and glibc `_int_malloc` assertion (`chunk_main_arena (fwd)`) have
+  also been observed. Same root cause; different destruction order.
 - **macOS (non-ASan)**: intermittent `~40%` failure rate in parallel mode — worker subprocess
   exits with signal (`128+N`) silently; the parent counts `+1 total failures` with no red line.
 
@@ -1957,6 +1958,13 @@ corrupted size vs. prev_size while consolidating
 #5  CodeGen::~CodeGen()
 ```
 
+On Linux (`chunk_main_arena` variant — glibc `_int_malloc` assertion):
+```text
+14 passed, 0 failed
+Fatal glibc error: malloc.c:4192 (_int_malloc): assertion failed: chunk_main_arena (fwd)
+Aborted (core dumped)
+```
+
 **Discriminating evidence for flake vs. regression**: If all test cases in the failing file report
 success (N passed, 0 failed) and only the teardown crashes, and a re-run on the same commit passes,
 classify as flake. A genuine heap corruption from user code would fail a specific test case or fail
@@ -1970,7 +1978,7 @@ entry in the Runtime / Memory section for the diagnostic checklist.
 1. `(void)jit.release()` — guarded by `#if defined(__linux__) || defined(__APPLE__)`. Leaks the
    LLJIT so `~LLJIT()` never runs. Extended from Linux-only to macOS in #1088 (suppressed the
    `~LLJIT()` crash frame).
-2. `rtCleanup.release()` — added immediately before `jit.release()` in the same `#if` block (#1187).
+2. `rtCleanup.release()` — added immediately before `jit.release()` in the same `#if` block (PR #1200, issue #1187).
    Cancels the `scope_exit` destructor so `RT->remove()` never fires during stack unwind. This is
    necessary because `jit.release()` leaks but does NOT destroy the LLJIT; the leaked
    `ExecutionSession` remains alive, so `RT->remove()` → `handleRemoveResources` →
@@ -1979,11 +1987,12 @@ entry in the Runtime / Memory section for the diagnostic checklist.
    `removeResourceTracker` frame, causing a residual ~16 % failure rate in `ry test -p`.
 
 **Rule**: On Linux CI, trigger a re-run if this crash appears — it is pre-existing LLVM ORC
-flakiness, not a regression. The `~CodeGen()` frame variant is the same flake family as
-`removeResourceTracker`. On macOS, both workarounds together suppress the crash; if any failure
-rate reappears after the fix, the root cause is broader than these two frames and needs fresh
-investigation. Do not suppress the LLVM crash reporter or add `|| true` — a genuine double-free in
-user code would produce the same frame.
+flakiness, not a regression. The `~CodeGen()` and `chunk_main_arena (fwd)` frame variants are the
+same flake family as `removeResourceTracker`. As of PR #1200 on v0.0.13, both steps together
+suppress the crash (Docker default × 30 + ASan × 30: 0 crashes). On macOS, both workarounds
+together suppress the crash; if any failure rate reappears after the fix, the root cause is broader
+than these two frames and needs fresh investigation. Do not suppress the LLVM crash reporter or add
+`|| true` — a genuine double-free in user code would produce the same frame.
 
 ### `@parallel for` captures must be retained AND ARC-backed inside the thunk
 


### PR DESCRIPTION
## Summary

Closes #1182

Issue #1182 reported a `Fatal glibc error: malloc.c:4192 (_int_malloc): assertion failed: chunk_main_arena (fwd)` SIGABRT on Linux CI when running `tests/spec/combinatorial/collection_element.test.ry`.

**Classification**: This is the same LLVM ORC JIT teardown flake as #1022 / #1043 / #1087 / #1161. The crash was observed in PR #1181 attempt 1 (commit `7441d6af`, 2026-04-19 00:48 UTC) — **before** PR #1200 (`rtCleanup.release()` fix, commit `2c49ff99`, 2026-04-19 01:51 UTC) landed on `v0.0.13`. Attempt 2 on the same commit passed; all v0.0.13 CI runs after #1200 are green.

**Evidence**:
- `git merge-base --is-ancestor 2c49ff99 7441d6af` → false (PR #1200 not in attempt-1 ancestry)
- All 14 test cases passed in the failing run; only teardown crashed (classic flake signature)
- Test is read-only (`xs[i]` / `for v in xs` only) — CoW/ARC write paths not exercised
- Linux Docker default × 30 and ASan × 30 on v0.0.13 HEAD: **0/60 crashes**

**Changes** (KNOWLEDGE.md only):
- Add `chunk_main_arena (fwd)` as a third Linux crash variant in the Symptom section (with crash output)
- Trim verbose #1182 Source citation to a concise form; add #1200 as fix PR reference
- Clarify Fix applied step 2 attribution: `(PR #1200, issue #1187)`
- Update Rule to name all three frame variants and note PR #1200 confirmed fix on v0.0.13

## Test plan

- [x] Classification: Docker default × 30 loop — 30/30 pass, 0 crashes
- [x] ASan classification: Docker ASan × 30 loop — 30/30 pass, 0 ASan errors
- [x] Full test suite: `ry_tests` 1817/1817 + `ry test -p` 145 files 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded troubleshooting for an intermittent LLVM ORC JIT teardown crash: added PR/issue references (PR #1200, issue #1187), broader macOS/Linux evidence, a new Linux crash example, refined symptom description, and confirmed the two-step suppression yields 0 crashes on v0.0.13 (Docker ×30 + ASan ×30).

* **Chores**
  * CI/tooling fixes for tarball-installed LLVM: bumped cache key v4→v5, register runtime libs via apt.llvm.org + ldconfig, and repackaging now resolves absolute shared-library symlinks to avoid broken restores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->