### PR TITLE
ci: promote filecheck job from warn-only to required (#1172)

### DIFF
--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -141,7 +141,6 @@ jobs:
       - name: Build ry
         run: cmake --build build --target ry
       - name: Run FileCheck IR golden tests
-        continue-on-error: true
         run: ctest --test-dir build -L filecheck --output-on-failure
 
   asan:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,9 +182,6 @@ jobs:
       - name: Build ry
         run: cmake --build build --target ry
       - name: Run FileCheck IR golden tests
-        # warn-only: triage LLVM-version sensitivity before making this required.
-        # Once goldens are confirmed stable across LLVM updates, remove continue-on-error.
-        continue-on-error: true
         run: ctest --test-dir build -L filecheck --output-on-failure
 
   asan:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ CI の `scan-build` ジョブがシンボリック実行ベースのパス感度
   - LLVM 17+ opaque pointer を前提 — 引数・alloca・load/store はすべて `ptr` 型
   - `--emit-llvm-ir` は unoptimized IR — mem2reg 後のレジスタ化とは異なり、alloca + store + load が残る
   - LLVM バージョンアップ時は goldens の再確認が必要
-- CI の `filecheck` ジョブは全イベント（PR・main/v*.*.* push）で実行（`ry` のみビルドするため高速、`continue-on-error: true` で warn-only 運用中）
+- CI の `filecheck` ジョブは全イベント（PR・main/v*.*.* push）で実行し、失敗時はマージをブロックする（`ry` のみビルドするため高速）
 
 ## CI: LLVM ツールチェーン (ミラー)
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -515,4 +515,4 @@ CMake auto-detects FileCheck at configure time. If not found, `cmake --preset de
 
 ### CI gate
 
-The `filecheck` CI job runs on all events — pull requests and push to `main`/`v*.*.*` branches. It builds only the `ry` binary (not `ry_tests`), so it completes quickly. It uses `continue-on-error: true` (warn-only) during the initial rollout. FileCheck is bundled in the LLVM mirror tarball via `llvm-{MAJOR}-tools` (#1171); the `setup-llvm` action's apt fallback path also installs it via `extra-packages`.
+The `filecheck` CI job runs on all events — pull requests and push to `main`/`v*.*.*` branches. It builds only the `ry` binary (not `ry_tests`), so it completes quickly. Failures block merges. FileCheck is bundled in the LLVM mirror tarball via `llvm-{MAJOR}-tools` (#1171); the `setup-llvm` action's apt fallback path also installs it via `extra-packages`.


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` from the `Run FileCheck IR golden tests` step in both `ci.yml` and `ci-scheduled.yml`
- Update `AGENTS.md` and `docs/reference/testing.md` to reflect required gate status

## Background

The `filecheck` CI job was introduced in #897 as warn-only to triage LLVM-version sensitivity. The tooling dependency (FileCheck binary) was resolved in #1171 by bundling `llvm-{MAJOR}-tools` in the LLVM mirror tarball.

The 3 goldens (`function_call`, `result_wrap`, `str_ptr`) have been stable across 5/5 consecutive v0.0.13 merge CI runs. The one run that reported `filecheck: failure` (run #24620166904) was due to LLVM toolchain cache corruption that failed all jobs — not a golden mismatch.

## Verification

- Negative test: temporarily corrupted `# CHECK-LABEL` in `function_call.ry` → `ctest` returned exit code 8 ✓
- Golden baseline: `ctest --test-dir build -L filecheck --output-on-failure` → 3/3 passed ✓
- Full test suite: `./build/ry_tests` (1817 tests) + `./build/ry test -p` (145 files) → all green ✓

Closes #1172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow to enforce FileCheck IR golden tests as hard failures. Tests now block merges if they fail, rather than being warnings only.

* **Documentation**
  * Updated testing documentation to reflect stricter FileCheck test enforcement in the CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->