### PR TITLE
Revert PR #1214 (bundle llvm-tools in LLVM mirror tarball for #1171)

### DIFF
--- a/.github/actions/setup-llvm/action.yml
+++ b/.github/actions/setup-llvm/action.yml
@@ -28,7 +28,7 @@ runs:
       uses: actions/cache@v4
       with:
         path: /usr/local/llvm
-        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v4-${{ inputs.sha256-short }}
+        key: llvm-${{ inputs.llvm-version }}-linux-x86_64-v3-${{ inputs.sha256-short }}
 
     - name: Download and install LLVM
       if: steps.cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -133,7 +133,18 @@ jobs:
           llvm-version: ${{ env.LLVM_VERSION }}
           sha256-short: ${{ env.LLVM_SHA256_SHORT }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          extra-packages: llvm-{MAJOR}-tools
+      - name: Install FileCheck
+        run: |
+          MAJOR="${LLVM_VERSION%%.*}"
+          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
+          sudo apt-get install -y --no-install-recommends llvm-${MAJOR}-tools
+          if [ ! -f /usr/local/llvm/bin/FileCheck ] && \
+             [ -f /usr/lib/llvm-${MAJOR}/bin/FileCheck ]; then
+            sudo ln -s /usr/lib/llvm-${MAJOR}/bin/FileCheck \
+                       /usr/local/llvm/bin/FileCheck
+          fi
+        env:
+          LLVM_VERSION: ${{ env.LLVM_VERSION }}
       - name: Install build dependencies
         run: sudo apt-get install -y libssl-dev ninja-build
       - name: Configure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,22 @@ jobs:
           llvm-version: ${{ env.LLVM_VERSION }}
           sha256-short: ${{ env.LLVM_SHA256_SHORT }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          extra-packages: llvm-{MAJOR}-tools
+      - name: Install FileCheck
+        # FileCheck is not bundled in the LLVM mirror tarball (mirror-llvm-toolchain.yml
+        # does not include llvm-X-tools). Install it unconditionally via apt.llvm.org,
+        # then symlink into /usr/local/llvm/bin/ so CMake find_program can locate it
+        # even when the mirror tarball (not /usr/lib/llvm-X) is used as /usr/local/llvm.
+        run: |
+          MAJOR="${LLVM_VERSION%%.*}"
+          wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
+          sudo apt-get install -y --no-install-recommends llvm-${MAJOR}-tools
+          if [ ! -f /usr/local/llvm/bin/FileCheck ] && \
+             [ -f /usr/lib/llvm-${MAJOR}/bin/FileCheck ]; then
+            sudo ln -s /usr/lib/llvm-${MAJOR}/bin/FileCheck \
+                       /usr/local/llvm/bin/FileCheck
+          fi
+        env:
+          LLVM_VERSION: ${{ env.LLVM_VERSION }}
       - name: Install build dependencies
         run: sudo apt-get install -y libssl-dev ninja-build
       - name: Setup ccache

--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -47,7 +47,7 @@ jobs:
           V="${{ inputs.llvm_version }}"
           MAJOR="${V%%.*}"
           wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
-          sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}" clang-tidy-"${MAJOR}" clang-tools-"${MAJOR}" llvm-"${MAJOR}"-tools
+          sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}" clang-tidy-"${MAJOR}" clang-tools-"${MAJOR}"
           echo "LLVM_MAJOR=${MAJOR}" >> "$GITHUB_ENV"
 
       - name: Repack as portable tarball

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,7 +80,7 @@ CI の `scan-build` ジョブがシンボリック実行ベースのパス感度
 `tests/filecheck/` ディレクトリに LLVM IR ゴールデンテストを配置する。`ry --emit-llvm-ir <file.ry>` で unoptimized IR を生成し、LLVM FileCheck ツールで宣言的にアサートする。
 
 - **`ry --emit-llvm-ir <file>`**: parser → typecheck → codegen まで実行し、JIT 最適化なしで unoptimized LLVM IR を stdout に出力して終了（実行しない）
-- **FileCheck の入手**: macOS は `brew install llvm@21`（`/opt/homebrew/opt/llvm@21/bin/FileCheck`）、Linux は `sudo apt-get install llvm-21-tools`
+- **FileCheck の入手**: macOS は `brew install llvm@21`（`/opt/homebrew/opt/llvm@21/bin/FileCheck`）、Linux は `sudo apt-get install llvm-21-tools`（注意: llvm-mirror tarball に FileCheck は同梱されていないため apt からの取得が必要）
 - **ローカル実行**:
   ```bash
   # 単一ゴールデン手動確認

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2073,20 +2073,21 @@ is the required gate for #630's race fixes. macOS is unaffected.
 `.github/actions/setup-llvm/`. The mirror tarball is built by
 `.github/workflows/mirror-llvm-toolchain.yml` (manual `workflow_dispatch`).
 
-The mirror tarball includes `clang-tidy` (added in #934), `scan-build` / `analyze-build` via `clang-tools-{MAJOR}` (added in #898), and **FileCheck via `llvm-{MAJOR}-tools` (bundled in #1171)**. The
+The mirror tarball includes `clang-tidy` (added in #934) and `scan-build` / `analyze-build` via `clang-tools-{MAJOR}` (added in #898). **FileCheck is NOT bundled** in the mirror tarball (#897) — the `filecheck` CI job installs it separately via `apt-get install llvm-{MAJOR}-tools` from `apt.llvm.org`. The
 `setup-llvm` action accepts an optional `extra-packages` input for
 the apt fallback path; the mirror/cache path already contains all
 tools. If new tools are needed, add them to
 `mirror-llvm-toolchain.yml`'s apt-get line, bump the cache key
-version suffix (e.g. `v3` → `v4`), and re-dispatch the mirror workflow
-with `force=true`.
+version suffix (e.g. `v2` → `v3`), and re-dispatch the mirror workflow
+with `force=true`. A follow-up issue tracks adding `llvm-{MAJOR}-tools`
+to the mirror tarball to eliminate the extra apt install step.
 
 Version bump checklist — update `env.LLVM_VERSION` (and
 `env.LLVM_SHA256_SHORT` when non-empty) in:
 - `.github/workflows/ci.yml`
 - `.github/workflows/codeql.yml`
 
-Cache key format: `llvm-${VERSION}-linux-x86_64-v4-${SHA256_SHORT}`.
+Cache key format: `llvm-${VERSION}-linux-x86_64-v2-${SHA256_SHORT}`.
 `restore-keys` is intentionally omitted: a partial cache hit would
 restore a mismatched LLVM version, causing build failures or silent ABI
 mismatches. An exact-match-only policy guarantees the correct toolchain.
@@ -3934,7 +3935,7 @@ Key constraints:
 4. **ARC retain/release visibility**: `@ry_retain` / `@ry_release` BasicBlocks only appear in CoW clone paths, lambda captures, and `@parallel for` patterns. They do not appear in simple scalar or string identity functions — choose goldens accordingly.
 5. **Result type layout**: `%Result = type { i1, i64, ptr }` — `i1` is the `is_ok` flag; `Err` uses constant aggregate `{ i1 false, ... }`, `Ok` uses `insertvalue %Result { i1 true, ... }`.
 6. **LLVM version bumps**: Goldens are LLVM-version-sensitive. After any LLVM version bump, re-run `ctest -L filecheck` and update patterns if IR structure changed.
-7. **FileCheck installation**: Mirror tarball includes FileCheck via `llvm-{MAJOR}-tools` (bundled in #1171). CI `filecheck` job gets it from the mirror tarball or the `setup-llvm` apt fallback path (`extra-packages: llvm-{MAJOR}-tools`). macOS: `brew install llvm@{MAJOR}` → `/opt/homebrew/opt/llvm@{MAJOR}/bin/FileCheck`.
+7. **FileCheck installation**: Mirror tarball does NOT include FileCheck (#897). CI installs it via `apt-get install llvm-{MAJOR}-tools` from `apt.llvm.org`. macOS: `brew install llvm@{MAJOR}` → `/opt/homebrew/opt/llvm@{MAJOR}/bin/FileCheck`.
 
 ---
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -515,4 +515,4 @@ CMake auto-detects FileCheck at configure time. If not found, `cmake --preset de
 
 ### CI gate
 
-The `filecheck` CI job runs on all events — pull requests and push to `main`/`v*.*.*` branches. It builds only the `ry` binary (not `ry_tests`), so it completes quickly. It uses `continue-on-error: true` (warn-only) during the initial rollout. FileCheck is bundled in the LLVM mirror tarball via `llvm-{MAJOR}-tools` (#1171); the `setup-llvm` action's apt fallback path also installs it via `extra-packages`.
+The `filecheck` CI job runs on all events — pull requests and push to `main`/`v*.*.*` branches. It builds only the `ry` binary (not `ry_tests`), so it completes quickly. It uses `continue-on-error: true` (warn-only) during the initial rollout. FileCheck is installed explicitly via `apt.llvm.org` because the LLVM mirror tarball does not include `llvm-tools`.


### PR DESCRIPTION
Reverts #1214 (merge commit ec017d10).

Part of unwinding changes up through PR #1214 to restore a working v0.0.13 baseline. Issue #1171 will be reopened.

## Affected
- `.github/workflows/mirror-llvm-toolchain.yml`: drops `llvm-{MAJOR}-tools` from apt install
- `.github/actions/setup-llvm/action.yml`: cache key `v4` → `v3`
- `.github/workflows/ci.yml`, `.github/workflows/ci-scheduled.yml`: reinstates the per-job `Install FileCheck` step (wget apt.llvm.org + apt-get + symlink) and removes `extra-packages: llvm-{MAJOR}-tools`
- `KNOWLEDGE.md`, `AGENTS.md`, `docs/reference/testing.md`: reverts doc changes

## Follow-up
- Reopen #1171 so the original task is live again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/toolchain workflows to explicitly install FileCheck via package manager instead of relying on bundled artifacts.
  * Adjusted LLVM cache key versioning.

* **Documentation**
  * Updated build and testing documentation to reflect FileCheck installation changes.
  * Clarified that FileCheck is not included in the LLVM mirror tarball and must be installed separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->