### PR TITLE
fix: resolve type aliases in validateTypeBounds before registry lookup (#1155)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1404,6 +1404,22 @@ llvm::Value *headerPtr = (weakInner == "str")
 
 `emitExprVariant(WeakExpr)` (codegen_expr.cpp) must return the raw data pointer; the conversion happens at the call sites above, not inside the emitter.
 
+### Resolve type aliases before registry lookup or type-name equality
+
+**Source**: #1060 (2026-04-17), #1155 (2026-04-19)
+**Tags**: codegen, type-alias, resolveTypeAlias, registry-lookup, generics, bounds
+
+**Rule**: Before looking up a user-supplied type name in `record_types_` / `enum_types_` / `type_aliases_`, or comparing it by string equality against another type name, always route it through `resolveTypeAlias()`. Always keep the user-written original in `codegenError` messages — rewriting those to the resolved name degrades the diagnostic.
+
+**Canonical examples**:
+- `RecordPattern` case (`codegen_match.cpp:381-393`) — correct template.
+- `validateTypeBounds` (`codegen_fn_generic.cpp`) — #1155 regression: alias bound / concrete were looked up and compared un-resolved, producing a false negative.
+- `emitWeakUpgrade` (`codegen_arc.cpp`) — #1060 regression: `"MyStr" == "str"` returned false and the wrong header offset was chosen.
+
+**Why**: `type A = B` registers `A` only in `type_aliases_`, never in the canonical registries. A `count(name)` or `name == "str"` without alias resolution yields a false negative whenever the user writes an alias, silently breaking the language-level promise that aliases are transparent. Reviews of any diff that contains `count(...)` / `== "<name>"` against a user-supplied type name should always ask "is this resolved?".
+
+---
+
 ### `weak T` header-offset dispatch requires alias resolution
 
 **Source**: #1060 (2026-04-17, implementation)

--- a/changelog.d/1155-generic-alias-constraint.md
+++ b/changelog.d/1155-generic-alias-constraint.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Generic type constraint checks (`<T: RecordName>`) no longer reject
+  type aliases that resolve to a record type. Both the bound and the
+  concrete type argument are now resolved through the alias table
+  before the subtype check, while error messages continue to report
+  the user-written names. (#1155)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -640,6 +640,17 @@ get_name(Dog("Rex", 4, "Lab"))  # OK — Dog is a subtype of Animal
 get_name(Animal("Cat", 4))      # OK — exact type match
 ```
 
+Type aliases that resolve to a record type can be used either as the bound or as the concrete type argument; the compiler resolves aliases before checking the constraint.
+
+```ry
+type AnimalAlias = Animal
+
+function describe<T: AnimalAlias>(a: T) -> str:
+    return a.name
+
+describe(Dog("Rex", 4, "Lab"))  # OK — AnimalAlias resolves to Animal
+```
+
 Bounded and unbounded type parameters can be mixed:
 
 ```ry

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -96,21 +96,21 @@ void CodeGen::validateTypeBounds(const std::vector<TypeParam> &typeParams,
         if (!typeParams[i].bound) continue;
         const std::string &bound = *typeParams[i].bound;
         const std::string &concrete = typeArgs[i];
+        const std::string resolvedBound = resolveTypeAlias(bound);
+        const std::string resolvedConcrete = resolveTypeAlias(concrete);
 
-        if (!record_types_.count(bound))
+        if (!record_types_.count(resolvedBound))
             codegenError("unknown type constraint: '" + bound + "'");
 
-        if (concrete != bound && !isSubtypeOf(concrete, bound)) {
-            std::string constraintMsg = "type '";
-            constraintMsg += concrete;
-            constraintMsg += "' does not satisfy constraint '";
-            constraintMsg += bound;
-            constraintMsg += "': not a subtype of '";
-            constraintMsg += bound;
-            constraintMsg += "' (";
-            constraintMsg += context;
-            constraintMsg += ")";
-            codegenError(constraintMsg);
+        if (resolvedConcrete != resolvedBound && !isSubtypeOf(resolvedConcrete, resolvedBound)) {
+            std::string msg = "type '";
+            msg += concrete;
+            msg += "' does not satisfy constraint '";
+            msg += bound;
+            msg += "' (";
+            msg += context;
+            msg += ")";
+            codegenError(msg);
         }
     }
 }

--- a/tests/spec/generic_bounds.test.ry
+++ b/tests/spec/generic_bounds.test.ry
@@ -14,6 +14,9 @@ function get_name<T: Animal>(a: T) -> str:
 function count_legs<T: Animal>(a: T) -> int:
   return a.legs
 
+type AnimalAlias = Animal
+type DogAlias = Dog
+
 describe("generic record bounds", ():
   it("should accept subtype", ():
     d = Dog("Rex", 4, "Lab")
@@ -35,5 +38,13 @@ describe("generic record bounds", ():
     function pair_name<T: Animal, U>(a: T, x: U) -> str:
       return a.name
     expect(pair_name(Dog("Rex", 4, "Lab"), 42)).to_eq("Rex")
+  )
+  it("should accept concrete type expressed via alias for explicit type arg", ():
+    expect(get_name[DogAlias](Dog("Rex", 4, "Lab"))).to_eq("Rex")
+  )
+  it("should accept bound expressed as alias of record", ():
+    function get_alias_name<T: AnimalAlias>(a: T) -> str:
+      return a.name
+    expect(get_alias_name(Dog("Rex", 4, "Lab"))).to_eq("Rex")
   )
 )

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1421,6 +1421,36 @@ TEST_F(CodeGenTest, GenericRecordBoundMixedParams) {
     EXPECT_EQ(runSource(src), "Rex\n");
 }
 
+TEST_F(CodeGenTest, GenericRecordBoundAliasAcceptsSubtype) {
+    std::string src =
+        "record Animal:\n"
+        "    name: str\n"
+        "record Dog < Animal:\n"
+        "    breed: str\n"
+        "type AnimalAlias = Animal\n"
+        "function describe<T: AnimalAlias>(a: T) -> str:\n"
+        "    return a.name\n"
+        "print(describe(Dog(\"Rex\", \"Lab\")))";
+    EXPECT_EQ(runSource(src), "Rex\n");
+}
+
+TEST_F(CodeGenTest, GenericRecordBoundAliasRejectsNonSubtype) {
+    // Cat has 'name' so that the body's `a.name` typechecks — the only
+    // reason this source must throw is the bound check itself rejecting
+    // a non-subtype. This guards against a regression that silently
+    // loosens validateTypeBounds when aliases are involved.
+    std::string src =
+        "record Animal:\n"
+        "    name: str\n"
+        "record Cat:\n"
+        "    name: str\n"
+        "type AnimalAlias = Animal\n"
+        "function describe<T: AnimalAlias>(a: T) -> str:\n"
+        "    return a.name\n"
+        "describe(Cat(\"Tom\"))";
+    EXPECT_THROW(runSource(src), std::runtime_error);
+}
+
 // ===== Tail Call Optimization (#214) =====
 
 TEST_F(CodeGenTest, TailCallOptimization) {


### PR DESCRIPTION
## Summary

- `validateTypeBounds()` in `src/codegen_fn_generic.cpp` was comparing the bound and concrete type names directly against `record_types_` and `isSubtypeOf()` without first resolving type aliases, causing `<T: AnimalAlias>` or `get_name[DogAlias](...)` to be incorrectly rejected with "unknown type constraint" or a false constraint violation error.
- Fix: route both `bound` and `concrete` through `resolveTypeAlias()` before registry lookup and subtype check; keep the user-written alias names in error messages.
- This is the same pattern already applied in `codegen_match.cpp`, `codegen_arc.cpp`, and `codegen_stmt.cpp` per the KNOWLEDGE.md general rule.

## Changes

- `src/codegen_fn_generic.cpp` — add `resolvedBound`/`resolvedConcrete` locals; use them for all checks; error messages use original names
- `tests/spec/generic_bounds.test.ry` — 2 new spec cases (alias as bound, alias as explicit type arg)
- `tests/test_codegen_advanced.cpp` — 2 new GoogleTests (`AliasAcceptsSubtype`, `AliasRejectsNonSubtype`)
- `docs/reference/functions.md` — document alias support in type constraint section
- `changelog.d/1155-generic-alias-constraint.md` — new changelog fragment
- `KNOWLEDGE.md` — add general rule entry "Resolve type aliases before registry lookup or type-name equality"

## TDD note

Step 5 (delete pre-change spec) is skipped: the old `validateTypeBounds` behaviour was never pinned in spec or docs, so this PR follows the "new feature" 3-step TDD path.

## Test plan

- [ ] `./build/ry test tests/spec/generic_bounds.test.ry` — 7/7 pass (5 pre-existing + 2 new)
- [ ] `./build/ry_tests --gtest_filter='*GenericRecordBound*'` — 8/8 pass (6 pre-existing + 2 new)
- [ ] `./build/ry_tests` — 1819/1819 pass
- [ ] `./build/ry test -p` — 145 files, 0 failures
- [ ] ASan + UBSan — 1819/1819 pass
- [ ] TSan `ry_tests` — 1819/1819 pass
- [ ] libFuzzer (parser / json / utf8) — 60s exit 0 each

Closes #1155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Generic type constraint checks now correctly handle type aliases that resolve to record types, ensuring proper validation when aliases are used in type bounds and concrete type arguments.

* **Documentation**
  * Added clarification that type aliases resolving to record types are fully supported in generic function declarations and constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->