### PR TITLE
fix: reject runtime-disc Result coercion to prevent silent payload loss (#1157)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3095,7 +3095,7 @@ testResult = phi;
 
 ### Post-hoc Result coercion: preferred over modifying Ok/Err constructors for annotation-driven type resolution
 
-**Source**: #1001 (2026-04-16, design choice); updated #1111 (2026-04-17, `anyTy_` runtime branch + both-slot bailout fix)
+**Source**: #1001 (2026-04-16, design choice); updated #1111 (2026-04-17, `anyTy_` runtime branch + both-slot bailout fix); updated #1157 (2026-04-19, disc-static provenance gate)
 **Tags**: codegen_stmt, coercion, Result, Ok, Err, annotation, emitVarDecl, anyTy_, type-inference
 
 **Rule**: When `Err([...])` (or `Ok(...)`) yields a Result struct whose layout does not match the variable's type annotation, fix the mismatch in `emitVarDecl`'s post-hoc coercion chain (`coerceResultType`) rather than threading the annotation down into the Ok/Err constructor emitter in `codegen_call.cpp`.
@@ -3104,9 +3104,10 @@ testResult = phi;
 
 **How to apply**: `coerceResultType(val, dstResTy)` in `codegen_stmt.cpp`:
 - Compute `okNeedsRuntimeBranch` and `errNeedsRuntimeBranch` **before** the early bailout. These booleans check: `isAnyType(srcSlotTy) && !isAnyType(dstSlotTy) && dstSlotTy != i8Ty_ && canAnyHoldType(dstSlotTy)`. They must be available at the bailout call site (#1111 CodeRabbit review finding).
-- **Bailout condition**: `srcOkTy != dstOkTy && srcErrTy != dstErrTy && (!okNeedsRuntimeBranch || !errNeedsRuntimeBranch)` → return `nullptr` (genuine type error). The original `both differ → nullptr` was wrong for `Result<any,any> → Result<T1,T2>`. Single-slot mismatches with `i8Ty_` placeholder (Err constructor) or `errorTy_` default (Ok constructor) are safe — the compile-time path handles them via zero-fill of the inactive slot.
+- **Bailout condition**: `srcOkTy != dstOkTy && srcErrTy != dstErrTy && (!okNeedsRuntimeBranch || !errNeedsRuntimeBranch)` → return `nullptr` (genuine type error). The original `both differ → nullptr` was wrong for `Result<any,any> → Result<T1,T2>`.
 - Both slots differ AND both can be anyTy_-unwrapped → emit a **runtime disc branch** (disc=1 → Ok, disc=0 → Err), `unwrapFromAny` the any-typed payload to the dst concrete type in the active path, PHI the two rebuilt structs. A compile-time slot selection silently zeroes the active payload for the wrong disc value (#1111 Manifestation 1).
-- Exactly one slot differs AND the mismatched src slot is `i8Ty_` / `errorTy_` placeholder → compile-time slot copy of the matching slot is safe; avoids a dead-code branch.
+- **Single-slot mismatch — disc-static gate (#1157)**: Exactly one slot differs → **only** accept when `tryGetStaticResultDisc(val, &staticDisc)` returns true. This function walks the `InsertValueInst` chain (accounting for LLVM constant-folding of all-constant chains into `ConstantStruct`/`ConstantAggregateZero`) and recurses into `PHINode` incomings. Sources with a runtime disc (function call results, loads, mixed Ok/Err PHI) must return `nullptr` — they were silently miscompiling by zero-filling the active payload slot. Literal `Ok()`/`Err()` and if-exprs where all branches share the same disc (e.g., both Ok) remain accepted.
+- **Placeholder types are NOT a safe signal at the LLVM level**: `Result<Unit,E>`, `Result<i8,E>`, and `Result<u8,E>` all lower to `{i1, i8, E}`. Checking `srcOkTy == i8Ty_` cannot distinguish a Unit dummy from a genuine i8 Ok payload. The disc value (static provenance) is the only reliable discriminant.
 - The `Ok` emitter (`codegen_call.cpp`) must also unwrap `anyTy_` inner to the expected ok type from `fn_->getReturnType()` when building the Result struct — otherwise two branches of an if-expr (e.g., `Ok(x)` vs `Ok(0)`) produce different Result struct types and `validateBranchTypes` rejects them (#1111 Manifestation 2, fixed alongside `inferExprType`).
 - Add the same coercion branch to variable reassignment handlers for consistency.
 

--- a/changelog.d/1157-result-coerce-runtime-disc.md
+++ b/changelog.d/1157-result-coerce-runtime-disc.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `coerceResultType` no longer silently drops the active payload when a
+  function-returned `Result` is bound to a variable with a different `Result`
+  annotation. Such mismatches are now rejected at compile time with an explicit
+  type-error message (#1157)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1299,6 +1299,14 @@ public:
     // with the destination layout.  Returns null if both payload types differ
     // (genuine type error).
     llvm::Value *coerceResultType(llvm::Value *val, llvm::StructType *dstResTy);
+    // Walk the InsertValueInst chain of val to find the index-{0} (disc) slot.
+    // Returns true and writes 0 or 1 to *staticDisc when the disc was inserted
+    // with a ConstantInt.  For PHINodes, recurses into all incoming values and
+    // returns true only when every incoming yields the same constant disc.
+    // Returns false for any runtime-produced value (CallInst, LoadInst, etc.).
+    static bool tryGetStaticResultDisc(llvm::Value *val, int *staticDisc);
+    static bool tryGetStaticResultDiscImpl(llvm::Value *val, int *staticDisc,
+                                           llvm::SmallPtrSetImpl<llvm::Value *> &visited);
     llvm::Value *buildStaticError(const std::string &msg, const std::string &globalName);
     static std::vector<std::string> splitTypeArgs(const std::string &argsStr);
     std::vector<std::string> splitTupleSig(const std::string &tupleTypeSig);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -19,21 +19,32 @@ void CodeGen::emitDeprecationWarning(const std::string &name) {
 bool CodeGen::tryGetStaticResultDiscImpl(llvm::Value *val, int *staticDisc,
                                          llvm::SmallPtrSetImpl<llvm::Value *> &visited) {
     // PHI node: all incoming values must yield the same constant disc.
+    // visited acts as a recursion-stack guard (not a global seen-set): erase phi
+    // before every return so a shared PHI reachable via two independent incoming
+    // edges is not misclassified as a cycle on the second traversal.
     if (auto *phi = llvm::dyn_cast<llvm::PHINode>(val)) {
         if (!visited.insert(phi).second)
-            return false;  // PHI cycle — treat as unknown
+            return false;  // genuine back-edge cycle — treat as unknown
         std::optional<int> disc;
         for (llvm::Value *incoming : phi->incoming_values()) {
             int inDisc = -1;
-            if (!tryGetStaticResultDiscImpl(incoming, &inDisc, visited))
+            if (!tryGetStaticResultDiscImpl(incoming, &inDisc, visited)) {
+                visited.erase(phi);
                 return false;
+            }
             if (!disc)
                 disc = inDisc;
-            else if (*disc != inDisc)
+            else if (*disc != inDisc) {
+                visited.erase(phi);
                 return false;  // mixed Ok/Err disc — runtime only
+            }
         }
-        if (!disc) return false;
+        if (!disc) {
+            visited.erase(phi);
+            return false;
+        }
         *staticDisc = *disc;
+        visited.erase(phi);
         return true;
     }
 

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -1,6 +1,7 @@
 #include "ry/codegen.hpp"
 #include "ry/stdlib_registry.hpp"
 #include "ry/diagnostic.hpp"
+#include <llvm/IR/Instructions.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -11,6 +12,64 @@ namespace ry {
 
 void CodeGen::emitDeprecationWarning(const std::string &name) {
     warnings_.push_back("warning: '" + name + "' is deprecated");
+}
+
+// ===== Result disc provenance helper =====
+
+bool CodeGen::tryGetStaticResultDiscImpl(llvm::Value *val, int *staticDisc,
+                                         llvm::SmallPtrSetImpl<llvm::Value *> &visited) {
+    // PHI node: all incoming values must yield the same constant disc.
+    if (auto *phi = llvm::dyn_cast<llvm::PHINode>(val)) {
+        if (!visited.insert(phi).second)
+            return false;  // PHI cycle — treat as unknown
+        std::optional<int> disc;
+        for (llvm::Value *incoming : phi->incoming_values()) {
+            int inDisc = -1;
+            if (!tryGetStaticResultDiscImpl(incoming, &inDisc, visited))
+                return false;
+            if (!disc)
+                disc = inDisc;
+            else if (*disc != inDisc)
+                return false;  // mixed Ok/Err disc — runtime only
+        }
+        if (!disc) return false;
+        *staticDisc = *disc;
+        return true;
+    }
+
+    // Walk the InsertValueInst chain from outermost to innermost looking for
+    // the insertion at index {0} (the disc slot).  LLVM constant-folds chains
+    // of purely-constant insertions into ConstantStruct/ConstantAggregateZero,
+    // so the walk may bottom out at a folded constant before hitting index 0.
+    for (llvm::Value *cur = val; ; ) {
+        if (auto *iv = llvm::dyn_cast<llvm::InsertValueInst>(cur)) {
+            if (iv->getNumIndices() == 1 && iv->getIndices()[0] == 0) {
+                auto *c = llvm::dyn_cast<llvm::ConstantInt>(iv->getInsertedValueOperand());
+                if (!c) return false;
+                *staticDisc = static_cast<int>(c->getZExtValue());
+                return true;
+            }
+            cur = iv->getAggregateOperand();
+            continue;
+        }
+        // Folded constant aggregate: read the disc directly from field 0.
+        if (auto *cs = llvm::dyn_cast<llvm::ConstantStruct>(cur)) {
+            auto *c = llvm::dyn_cast<llvm::ConstantInt>(cs->getOperand(0));
+            if (!c) return false;
+            *staticDisc = static_cast<int>(c->getZExtValue());
+            return true;
+        }
+        if (llvm::isa<llvm::ConstantAggregateZero>(cur)) {
+            *staticDisc = 0;  // all-zero aggregate → disc == 0 (Err)
+            return true;
+        }
+        return false;  // CallInst, LoadInst, Argument, etc. — runtime disc
+    }
+}
+
+bool CodeGen::tryGetStaticResultDisc(llvm::Value *val, int *staticDisc) {
+    llvm::SmallPtrSet<llvm::Value *, 4> visited;
+    return tryGetStaticResultDiscImpl(val, staticDisc, visited);
 }
 
 // ===== Result coercion helper =====
@@ -90,17 +149,29 @@ llvm::Value *CodeGen::coerceResultType(llvm::Value *val,
         return phi;
     }
 
-    // Compile-time slot selection for i8Ty_ placeholder mismatches: the struct
-    // was built with either Err-only or Ok-only, so the matching slot is always
-    // the active one at runtime.
+    // Compile-time slot selection: only valid when the source discriminator is
+    // statically provable (literal Ok/Err constructor, or PHI where every
+    // incoming branch has the same constant disc).  Runtime-disc sources —
+    // function call results, loads, mixed Ok/Err PHI — are rejected here to
+    // prevent silently zero-filling the active payload slot (#1157).
+    int staticDisc = -1;
+    if (!tryGetStaticResultDisc(val, &staticDisc))
+        return nullptr;
+
     llvm::Value *coerced = llvm::ConstantAggregateZero::get(dstResTy);
-    coerced = builder_.CreateInsertValue(coerced, disc, 0);
-    if (srcOkTy == dstOkTy)
+    coerced = builder_.CreateInsertValue(
+        coerced, llvm::ConstantInt::get(i1Ty_, static_cast<uint64_t>(staticDisc)), 0);
+    if (staticDisc == 1) {
+        // Source is statically Ok — copy slot 1; zero-fill slot 2 is correct.
+        if (srcOkTy != dstOkTy) return nullptr;
         coerced = builder_.CreateInsertValue(
             coerced, builder_.CreateExtractValue(val, 1, "res.ok"), 1);
-    else
+    } else {
+        // Source is statically Err — copy slot 2; zero-fill slot 1 is correct.
+        if (srcErrTy != dstErrTy) return nullptr;
         coerced = builder_.CreateInsertValue(
             coerced, builder_.CreateExtractValue(val, 2, "res.err"), 2);
+    }
 
     propagateMeta(val, coerced);
     return coerced;

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1554,3 +1554,4 @@ TEST_F(CodeGenTest, ResultCoerceIfBothBranchesOk) {
         "  return r\n"
     ));
 }
+

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1504,3 +1504,23 @@ TEST_F(CodeGenTest, ForwardFunctionReference) {
         "\n"
         "print(caller(5))"), "11\n");
 }
+
+// ============================================================
+// #1157: Result coerce — PHI-static disc via if-expr both-branches Ok
+// ============================================================
+
+TEST_F(CodeGenTest, ResultCoerceIfBothBranchesOk) {
+    // Both branches of the if-expr emit Ok (disc=1 statically through PHI).
+    // tryGetStaticResultDisc recurses through the PHI and allows the
+    // compile-time slot copy despite the Err type mismatch (errorTy_ to MyErr).
+    EXPECT_NO_THROW(compileSource(
+        "record MyErr:\n"
+        "  msg: str\n"
+        "function test_fn(x: int) -> Result<int, MyErr>:\n"
+        "  r: Result<int, MyErr> = if x > 0:\n"
+        "    (Ok(x))\n"
+        "  else:\n"
+        "    (Ok(0))\n"
+        "  return r\n"
+    ));
+}

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -394,3 +394,49 @@ TEST_F(CodeGenTest, Base64EncodeBytesUrlSafeRejectsNonU8List) {
         "print(encode_bytes_url_safe(xs))\n",
         "requires List<u8>");
 }
+
+// ============================================================
+// #1157: coerceResultType must reject function-returned Result
+// when the discriminator is a runtime value, not a provably
+// literal Ok/Err. Without the fix, these silently miscompile.
+// ============================================================
+
+TEST_F(CodeGenTest, ResultCoerceFnReturnDifferentErrType) {
+    // f() returns Result<bool, MyErr1>; binding to Result<bool, MyErr2> is
+    // a single-slot Err mismatch. srcOkTy==dstOkTy so the old compile-time
+    // path would copy the Ok slot — silently zeroing the Err payload when
+    // the runtime disc is 0 (Err). The fix rejects this with a type error.
+    expectCompileError(
+        "record MyErr1:\n"
+        "  msg: str\n"
+        "record MyErr2:\n"
+        "  msg: str\n"
+        "function f() -> Result<bool, MyErr1>:\n"
+        "  return Err(MyErr1(\"x\"))\n"
+        "r: Result<bool, MyErr2> = f()\n",
+        "type error: annotation");
+}
+
+TEST_F(CodeGenTest, ResultCoerceFnReturnNarrowOkType) {
+    // g() returns Result<i8, Error>; binding to Result<int, Error> is a
+    // single-slot Ok mismatch. srcErrTy==dstErrTy so the old compile-time
+    // path would copy the Err slot — silently zeroing the Ok payload when
+    // the runtime disc is 1 (Ok). The fix rejects this with a type error.
+    expectCompileError(
+        "function g() -> Result<i8, Error>:\n"
+        "  return Err(Error(\"test\"))\n"
+        "r: Result<int, Error> = g()\n",
+        "type error: annotation");
+}
+
+TEST_F(CodeGenTest, ResultCoerceFnReturnWideOkType) {
+    // mk() returns Result<int, Error>; binding to Result<bool, Error> is a
+    // single-slot Ok mismatch. srcErrTy==dstErrTy so the old compile-time
+    // path would copy the Err slot — silently zeroing the Ok payload when
+    // the runtime disc is 1 (Ok). The fix rejects this with a type error.
+    expectCompileError(
+        "function mk() -> Result<int, Error>:\n"
+        "  return Ok(42)\n"
+        "r: Result<bool, Error> = mk()\n",
+        "type error: annotation");
+}


### PR DESCRIPTION
## Summary

- `coerceResultType`'s compile-time slot-copy path assumed the source discriminator was always statically known, silently zeroing the active payload when a function-returned `Result` was bound to a differently-annotated variable (#1157)
- Add `tryGetStaticResultDiscImpl`: walks `InsertValueInst` chains, handles LLVM constant-folded `ConstantStruct`/`ConstantAggregateZero`, recurses into `PHINode` incomings with `SmallPtrSet` cycle detection
- Add thin public wrapper `tryGetStaticResultDisc`; gate the compile-time fast-path on it — runtime-disc sources (function calls, loads, mixed Ok/Err PHI) now produce an explicit type-error instead of a silent miscompile

## Changes

- `src/codegen_stmt.cpp`: new `tryGetStaticResultDiscImpl` + `tryGetStaticResultDisc`; compile-time path in `coerceResultType` now guarded by disc-static check
- `include/ry/codegen.hpp`: public + private declarations (visited set stays out of public API)
- `tests/test_codegen_fail.cpp`: 3 new tests — fn-return with different Err type, narrower Ok type, wider Ok type
- `tests/test_codegen_advanced.cpp`: 1 regression guard — PHI with both branches Ok still passes
- `KNOWLEDGE.md`: updated "Post-hoc Result coercion" entry with disc-static gate rule and placeholder-type indistinguishability note
- `changelog.d/1157-result-coerce-runtime-disc.md`: changelog fragment

## Test plan

- [ ] All 1821 C++ tests pass (`./build/ry_tests`)
- [ ] `*ResultCoerce*` filter: 4/4 pass
- [ ] `tests/spec/result_coerce.test.ry`: 11/11 pass
- [ ] ASan + UBSan clean (`./build-asan/ry_tests` + `./build-asan/ry test -p`)
- [ ] TSan clean (`./build-tsan/ry_tests`)
- [ ] libFuzzer 3×60s exit 0 (parser / json / utf8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Coercion of Result values no longer silently discards the active payload when the Result discriminant can't be proven at compile time; such mismatches are now rejected with an explicit type error.

* **Tests**
  * Added tests for successful coercion when the discriminant is provable and for compile-time failures when it is runtime-only.

* **Documentation**
  * Updated knowledge and changelog entries describing the new discriminator provenance checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->