### PR TITLE
fix: split match subject type channel; guard TuplePattern against Option/Result (#1156)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3975,4 +3975,52 @@ This avoids materialising the intermediate `List<i64>` entirely.
 **Related helpers**:
 - `emitListSlice(listPtr, startVal, endExclVal, elemTy)` (`src/codegen_call_collection.cpp`) — shared between `slice()` builtin and `lst[a..b]`. Clamps internally.
 - `emitNegativeIndexWrap(idx, len, prefix)` (`src/codegen_call_user.cpp:645`) — use prefix `"ri_start"` / `"ri_end"` to avoid label collision with scalar-index prefix `"index"`.
+
+---
+
+## #1156: split match subject type into enum-only vs broad source name
+
+**Source**: PR #1156 fix for `codegen_match.cpp` subjectEnumType wrong channel
+**Tags**: pattern, match, ARC, codegen, Option, Result, tuple, subjectEnumType
+
+**Rule**: `emitPatternTest`, `emitPatternBindings`, and `checkMatchExhaustiveness`
+take **two** source-name parameters:
+
+- `subjectEnumName` — narrow channel (`ValueMetadata::enum_value_type`).
+  Only set for enum/ADT subjects (from `resolveEnumType()`). Used by
+  `EnumPattern`/`EnumConstructorPattern` generic-instantiated lookup, by
+  `Some`/`Ok`/`Err` binding `extractGenericTypeArg`, and by `VariablePattern`
+  binding's `enum_value_type` write (still guarded by
+  `enum_types_.count(resolveTypeAlias(name))` per the KNOWLEDGE L2946 rule).
+- `subjectSourceTypeName` — broad channel (`resolveSubjectSourceTypeName()`).
+  Reconstructs `Option<T>` / `Result<T, E>` / `(T1, T2, ...)` from the LLVM
+  subject type when no enum annotation exists. Used by `TuplePattern` /
+  `RecordPattern` structural verification and by `emitPatternBindingArc`
+  Path 2a from `VariablePattern` only.
+
+**Reconstruction lossiness**: `reverseResolveTypeName(ptrTy_)` returns `"str"`;
+unknown structs return `"any"`. So `Option<List<int>>` reconstructs as
+`"Option<str>"`. The reconstructed string is therefore **only** safe for
+structural checks ("is this a tuple struct?" / "does this match record name X?").
+Do NOT re-feed it into `extractGenericTypeArg` for ARC payload classification —
+`Option<List<int>>` would be misclassified as `Option<str>` (wrong header
+offset: str uses -24, List uses -16), causing heap corruption under ASan.
+
+**Defense-in-depth on TuplePattern**: the test arm rejects via
+`!sTy || !isTupleStructType(sTy)` regardless of any source name. This fires
+even when both names are empty — closing the path where Option's `{i1, T}`
+2-element struct silently passed the 2-arity check and crashed with ICmp
+type mismatch (original #1156 crash vector).
+
+**Why split rather than unify**: the previous single `subjectEnumType`
+parameter was overloaded with non-enum names via the new broad helper
+would force every consumer to add an `enum_types_.count(name)` guard.
+The split signature makes "enum-only" vs "broader subject type" a
+compile-time-enforced distinction. The guard at VariablePattern binding
+(`KNOWLEDGE L2946`) remains necessary but is now purely defensive
+(subjectEnumName is already enum-only).
+
+**Follow-up**: Add a lossless `source_type_name` field to `ValueMetadata` so
+`Option<List<int>>` reconstruction is accurate, enabling ARC Path 2a for nested
+generics (currently handled by Path 2b heuristic via `propagateMeta`).
 - Pre-existing defects in `emitListSlice`: ARC retain omitted for reference-typed elements (#1204), nested TypeMeta not propagated (#1205) — tracked separately.

--- a/changelog.d/1156-codegen-match-subject-type.md
+++ b/changelog.d/1156-codegen-match-subject-type.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- `case <subject>: (a, b)` where the subject is `Option<T>` or `Result<T, E>`
+  no longer silently destructures the LLVM struct layout as a tuple.
+  Previously the TuplePattern arm's source-name-based guard was skipped when
+  the subject had no enum annotation, allowing `{i1, T}` to pass arity
+  validation and producing wrong IR or an `ICmp` type-mismatch crash.
+  The pattern test now rejects these subjects structurally via
+  `isTupleStructType`, independent of any source-level type name. (#1156)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1124,15 +1124,22 @@ public:
     llvm::Type *tryResolveType(const std::string &typeName);
     void emitStmt(std::unique_ptr<CaseStmt> &s);
     llvm::Value *emitPatternTest(const Pattern &pattern, llvm::Value *subjectVal,
-                                  llvm::Type *subjectTy, const std::string &subjectEnumType);
+                                  llvm::Type *subjectTy,
+                                  const std::string &subjectEnumName,
+                                  const std::string &subjectSourceTypeName);
     void emitPatternBindings(const Pattern &pattern, llvm::AllocaInst *subjectAlloca,
-                              llvm::Type *subjectTy, const std::string &subjectEnumType);
+                              llvm::Type *subjectTy,
+                              const std::string &subjectEnumName,
+                              const std::string &subjectSourceTypeName);
     void emitPatternBindingArc(llvm::Value *val, llvm::AllocaInst *bindAlloca,
                                 const std::string &typeSig);
     void checkMatchExhaustiveness(const std::vector<std::pair<const Pattern*, bool>> &armPatterns,
-                                   llvm::Type *subjectTy, const std::string &subjectEnumType);
+                                   llvm::Type *subjectTy, const std::string &subjectEnumName);
     void validateBranchTypes(llvm::Value *lhs, llvm::Value *rhs, const char *exprKind);
     std::string resolveEnumType(llvm::Value *val) const;
+    std::string resolveSubjectSourceTypeName(const std::string &subjectEnumName, llvm::Type *subjectTy);
+    std::string filterToEnumOnly(const std::string &typeSig);
+    void markFieldAllocaArcManaged(llvm::AllocaInst *tmp, llvm::Type *ty, const std::string &typeSig);
     void emitDescribeCall(CallStmt &s);
     void emitItCall(CallStmt &s);
     void emitEachItCall(CallStmt &s);

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -29,6 +29,49 @@ std::string CodeGen::resolveEnumType(llvm::Value *val) const {
     return {};
 }
 
+// Returns a broad Ry source-level type name for a match subject: returns
+// subjectEnumName unchanged when non-empty, otherwise reconstructs from LLVM
+// type (Option<T>, Result<T,E>, tuple). Used for structural pattern checks —
+// NOT for ARC payload extraction, since reconstruction is lossy for nested
+// generics (Option<List<int>> → "Option<str>").
+std::string CodeGen::resolveSubjectSourceTypeName(const std::string &subjectEnumName, llvm::Type *subjectTy) {
+    if (!subjectEnumName.empty())
+        return subjectEnumName;
+    auto *st = llvm::dyn_cast<llvm::StructType>(subjectTy);
+    if (!st) return {};
+    if (isOptionType(st))
+        return "Option<" + reverseResolveTypeName(st->getElementType(1)) + ">";
+    if (isResultType(st))
+        return "Result<" + reverseResolveTypeName(st->getElementType(1)) +
+               ", " + reverseResolveTypeName(st->getElementType(2)) + ">";
+    if (isTupleStructType(st)) {
+        std::string sig = "(";
+        for (unsigned i = 0; i < st->getNumElements(); ++i) {
+            if (i) sig += ", ";
+            sig += reverseResolveTypeName(st->getElementType(i));
+        }
+        return sig + ")";
+    }
+    return {};
+}
+
+std::string CodeGen::filterToEnumOnly(const std::string &typeSig) {
+    const std::string resolved = resolveTypeAlias(typeSig);
+    return enum_types_.count(resolved) ? resolved : std::string{};
+}
+
+// tmp is an intermediate field alloca that is NOT in scope_stack_, so there
+// is no matching release — the recursive VariablePattern leaf owns the refcount.
+void CodeGen::markFieldAllocaArcManaged(llvm::AllocaInst *tmp, llvm::Type *ty, const std::string &typeSig) {
+    if (ty != ptrTy_) return;
+    CollectionKind fk;
+    if (fieldTypeIsArcManaged(typeSig, &fk)) {
+        markArcManaged(tmp);
+        if (fk == CollectionKind::Str)
+            arc_str_managed_vars_.insert(tmp);
+    }
+}
+
 void CodeGen::validateBranchTypes(llvm::Value *lhs, llvm::Value *rhs, const char *exprKind) {
     if (lhs->getType() != rhs->getType())
         codegenError(std::string(exprKind) + ": all branches must have the same type");
@@ -69,7 +112,7 @@ std::vector<std::string> CodeGen::splitTupleSig(const std::string &tupleTypeSig)
 
 void CodeGen::checkMatchExhaustiveness(
     const std::vector<std::pair<const Pattern*, bool>> &armPatterns,
-    llvm::Type *subjectTy, const std::string &subjectEnumType) {
+    llvm::Type *subjectTy, const std::string &subjectEnumName) {
 
     // Recursively determines whether a pattern is irrefutable (always matches).
     // A TuplePattern is irrefutable iff every element is irrefutable.
@@ -120,10 +163,10 @@ void CodeGen::checkMatchExhaustiveness(
         }
     }
     if (!enumName.empty()) {
-        if (!enum_types_.count(enumName) && !subjectEnumType.empty()) {
-            auto ltPos = subjectEnumType.find('<');
-            if (ltPos != std::string::npos && subjectEnumType.substr(0, ltPos) == enumName)
-                enumName = subjectEnumType;
+        if (!enum_types_.count(enumName) && !subjectEnumName.empty()) {
+            auto ltPos = subjectEnumName.find('<');
+            if (ltPos != std::string::npos && subjectEnumName.substr(0, ltPos) == enumName)
+                enumName = subjectEnumName;
         }
         auto it = enum_types_.find(enumName);
         if (it != enum_types_.end()) {
@@ -220,7 +263,8 @@ void CodeGen::checkMatchExhaustiveness(
 }
 
 llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
-    llvm::Value *subjectVal, llvm::Type *subjectTy, const std::string &subjectEnumType) {
+    llvm::Value *subjectVal, llvm::Type *subjectTy,
+    const std::string &subjectEnumName, const std::string &subjectSourceTypeName) {
     llvm::Value *testResult = nullptr;
     std::visit([&](auto &pat) {
         using T = std::decay_t<decltype(pat)>;
@@ -246,10 +290,10 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
         } else if constexpr (std::is_same_v<T, EnumPattern>) {
             std::string resolvedEnum = pat.enum_name;
             auto enumIt = enum_types_.find(resolvedEnum);
-            if (enumIt == enum_types_.end() && !subjectEnumType.empty()) {
-                auto ltPos = subjectEnumType.find('<');
-                if (ltPos != std::string::npos && subjectEnumType.substr(0, ltPos) == pat.enum_name) {
-                    resolvedEnum = subjectEnumType;
+            if (enumIt == enum_types_.end() && !subjectEnumName.empty()) {
+                auto ltPos = subjectEnumName.find('<');
+                if (ltPos != std::string::npos && subjectEnumName.substr(0, ltPos) == pat.enum_name) {
+                    resolvedEnum = subjectEnumName;
                     enumIt = enum_types_.find(resolvedEnum);
                 }
             }
@@ -268,10 +312,10 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
         } else if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>) {
             std::string resolvedEnum = pat->enum_name;
             auto enumIt = enum_types_.find(resolvedEnum);
-            if (enumIt == enum_types_.end() && !subjectEnumType.empty()) {
-                auto ltPos = subjectEnumType.find('<');
-                if (ltPos != std::string::npos && subjectEnumType.substr(0, ltPos) == pat->enum_name) {
-                    resolvedEnum = subjectEnumType;
+            if (enumIt == enum_types_.end() && !subjectEnumName.empty()) {
+                auto ltPos = subjectEnumName.find('<');
+                if (ltPos != std::string::npos && subjectEnumName.substr(0, ltPos) == pat->enum_name) {
+                    resolvedEnum = subjectEnumName;
                     enumIt = enum_types_.find(resolvedEnum);
                 }
             }
@@ -316,7 +360,8 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                     llvm::Value *fieldVal = builder_.CreateLoad(fieldTy, fieldPtr, "ecp.test.fval");
                     const std::string &fieldTypeName = (i < fit->second.fieldTypeNames.size())
                         ? fit->second.fieldTypeNames[i] : std::string{};
-                    llvm::Value *sub = emitPatternTest((*fieldPats)[i], fieldVal, fieldTy, fieldTypeName);
+                    llvm::Value *sub = emitPatternTest((*fieldPats)[i], fieldVal, fieldTy,
+                                                      filterToEnumOnly(fieldTypeName), fieldTypeName);
                     fieldsMatch = builder_.CreateAnd(fieldsMatch, sub, "ecp.test.and");
                     offset += dl.getTypeAllocSize(fieldTy);
                 }
@@ -352,18 +397,19 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
         } else if constexpr (std::is_same_v<T, std::unique_ptr<OrPattern>>) {
             testResult = llvm::ConstantInt::get(i1Ty_, 0);
             for (auto &alt : pat->alternatives) {
-                llvm::Value *altResult = emitPatternTest(alt, subjectVal, subjectTy, subjectEnumType);
+                llvm::Value *altResult = emitPatternTest(alt, subjectVal, subjectTy,
+                                                        subjectEnumName, subjectSourceTypeName);
                 testResult = builder_.CreateOr(testResult, altResult, "or.comb");
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
-            const std::vector<std::string> elemSigs = splitTupleSig(subjectEnumType);
             auto *sTy = llvm::dyn_cast<llvm::StructType>(subjectTy);
-            // Reject if: not a struct, OR the Ry type is known but not a tuple
-            // signature (e.g. Option<T>, Result<T,E>, a record, an ADT enum).
-            // When subjectEnumType is empty (unannotated variable), the LLVM struct
-            // check alone is sufficient — we have no type name to discriminate.
-            if (!sTy || (!subjectEnumType.empty() && elemSigs.empty()))
+            // #1156: structural reject of non-tuple LLVM structs (Option, Result,
+            // record, ADT enum, union, error). Fires even when subjectSourceTypeName is
+            // empty, closing the silent-destructure path where Option<T> = {i1, T}
+            // silently passed the 2-arity check and produced wrong IR.
+            if (!sTy || !isTupleStructType(sTy))
                 codegenError("case: tuple pattern applied to non-tuple subject");
+            const std::vector<std::string> elemSigs = splitTupleSig(subjectSourceTypeName);
             if (sTy->getNumElements() != pat->elements.size())
                 codegenError("case: tuple pattern arity mismatch: subject has " +
                              std::to_string(sTy->getNumElements()) +
@@ -374,7 +420,7 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                 llvm::Value *elem = builder_.CreateExtractValue(subjectVal, static_cast<unsigned>(i), "tup.elem");
                 llvm::Type  *elemTy = sTy->getElementType(static_cast<unsigned>(i));
                 const std::string elemSig = (i < elemSigs.size()) ? elemSigs[i] : std::string{};
-                llvm::Value *sub = emitPatternTest(pat->elements[i], elem, elemTy, elemSig);
+                llvm::Value *sub = emitPatternTest(pat->elements[i], elem, elemTy, elemSig, elemSig);
                 testResult = builder_.CreateAnd(testResult, sub, "tup.and");
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<RecordPattern>>) {
@@ -387,11 +433,11 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                 codegenError("case: unknown record type '" + pat->name + "' in pattern");
             }
             // When Ry type metadata is available, verify subject is this record type.
-            const std::string resolvedSubject = subjectEnumType.empty()
-                ? std::string{} : resolveTypeAlias(subjectEnumType);
+            const std::string resolvedSubject = subjectSourceTypeName.empty()
+                ? std::string{} : resolveTypeAlias(subjectSourceTypeName);
             if (!resolvedSubject.empty() && resolvedSubject != resolvedName)
                 codegenError("case: record pattern '" + pat->name +
-                             "' applied to subject of type '" + subjectEnumType + "'");
+                             "' applied to subject of type '" + subjectSourceTypeName + "'");
             const RecordInfo &info = sit->second;
             if (subjectTy != info.llvmType)
                 codegenError("case: record pattern '" + pat->name + "' applied to non-record subject");
@@ -404,7 +450,7 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                 llvm::Value *elem = builder_.CreateExtractValue(subjectVal, static_cast<unsigned>(i), "rec.elem");
                 llvm::Type  *elemTy = info.llvmType->getElementType(static_cast<unsigned>(i));
                 const std::string elemSig = info.fields[i].type->toString();
-                llvm::Value *sub = emitPatternTest(pat->elements[i], elem, elemTy, elemSig);
+                llvm::Value *sub = emitPatternTest(pat->elements[i], elem, elemTy, elemSig, elemSig);
                 testResult = builder_.CreateAnd(testResult, sub, "rec.and");
             }
         }
@@ -441,7 +487,7 @@ static std::string extractGenericTypeArg(const std::string &typeStr,
 
 void CodeGen::emitPatternBindings(const Pattern &pattern,
     llvm::AllocaInst *subjectAlloca, llvm::Type *subjectTy,
-    const std::string &subjectEnumType) {
+    const std::string &subjectEnumName, const std::string &subjectSourceTypeName) {
     std::visit([&](auto &pat) {
         using T = std::decay_t<decltype(pat)>;
         if constexpr (std::is_same_v<T, VariablePattern>) {
@@ -449,9 +495,11 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
             llvm::AllocaInst *varAlloca = getOrCreateVar(pat.name, subjectTy);
             builder_.CreateStore(sv, varAlloca);
             propagateMeta(subjectAlloca, varAlloca);
-            if (!subjectEnumType.empty())
-                getOrCreateMeta(varAlloca).enum_value_type = subjectEnumType;
-            emitPatternBindingArc(sv, varAlloca, "");
+            // Defence-in-depth: subjectEnumName may carry field-type names from recursive calls.
+            if (!subjectEnumName.empty() &&
+                    enum_types_.count(resolveTypeAlias(subjectEnumName)))
+                getOrCreateMeta(varAlloca).enum_value_type = subjectEnumName;
+            emitPatternBindingArc(sv, varAlloca, subjectSourceTypeName);
         } else if constexpr (std::is_same_v<T, SomePattern>) {
             if (pat.binding != "_") {
                 llvm::Value *sv = builder_.CreateLoad(subjectTy, subjectAlloca, "opt_val");
@@ -459,8 +507,9 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, inner->getType());
                 builder_.CreateStore(inner, varAlloca);
                 propagateMeta(subjectAlloca, varAlloca);
+                // Use narrow channel only — lossy reconstruction would misclassify nested types.
                 const std::string innerSig = extractGenericTypeArg(
-                    resolveTypeAlias(subjectEnumType), "Option<", 0);
+                    resolveTypeAlias(subjectEnumName), "Option<", 0);
                 emitPatternBindingArc(inner, varAlloca, innerSig);
             }
         } else if constexpr (std::is_same_v<T, OkPattern>) {
@@ -470,8 +519,9 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, okVal->getType());
                 builder_.CreateStore(okVal, varAlloca);
                 propagateMeta(subjectAlloca, varAlloca);
+                // Use narrow channel only — lossy reconstruction would misclassify nested types.
                 const std::string innerSig = extractGenericTypeArg(
-                    resolveTypeAlias(subjectEnumType), "Result<", 0);
+                    resolveTypeAlias(subjectEnumName), "Result<", 0);
                 emitPatternBindingArc(okVal, varAlloca, innerSig);
             }
         } else if constexpr (std::is_same_v<T, ErrPattern>) {
@@ -481,14 +531,15 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, errVal->getType());
                 builder_.CreateStore(errVal, varAlloca);
                 propagateMeta(subjectAlloca, varAlloca);
+                // Use narrow channel only — lossy reconstruction would misclassify nested types.
                 const std::string innerSig = extractGenericTypeArg(
-                    resolveTypeAlias(subjectEnumType), "Result<", 1);
+                    resolveTypeAlias(subjectEnumName), "Result<", 1);
                 emitPatternBindingArc(errVal, varAlloca, innerSig);
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
             llvm::Value *loaded = builder_.CreateLoad(subjectTy, subjectAlloca, "tup.load");
             auto *sTy = llvm::cast<llvm::StructType>(subjectTy);
-            const std::vector<std::string> elemSigs = splitTupleSig(subjectEnumType);
+            const std::vector<std::string> elemSigs = splitTupleSig(subjectSourceTypeName);
             assert(sTy->getNumElements() == pat->elements.size() &&
                    "TuplePattern arity must be verified by emitPatternTest before binding");
             for (size_t i = 0; i < pat->elements.size(); ++i) {
@@ -499,27 +550,8 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 const std::string elemSig = (i < elemSigs.size()) ? elemSigs[i] : std::string{};
                 if (!elemSig.empty())
                     propagateTypeMeta(elemSig, tmp);
-                // Mark ptr-type intermediates as ARC-managed so the recursive leaf
-                // VariablePattern binding can detect them via tryRetainArcSource and
-                // emit a single retain.  The tmp alloca is not in scope_stack_ so
-                // there is no matching release — varAlloca owns the refcount.
-                // For str fields, also register in arc_str_managed_vars_ so that
-                // tryRetainArcSource Case 1 uses emitStrGetHeaderFromData (offset -24).
-                if (elemTy == ptrTy_) {
-                    CollectionKind fk;
-                    if (fieldTypeIsArcManaged(elemSig, &fk)) {
-                        markArcManaged(tmp);
-                        if (fk == CollectionKind::Str)
-                            arc_str_managed_vars_.insert(tmp);
-                    }
-                }
-                // Guard: only pass elemSig as subjectEnumType when it names an actual enum.
-                // Passing a primitive type name ("int", "str", etc.) would set enum_value_type
-                // to a non-enum name in VariablePattern binding and crash valueToString().
-                // Resolve aliases first so that aliased enum field types are also recognised.
-                const std::string resolvedElemSig = resolveTypeAlias(elemSig);
-                const std::string subElemEnumSig = enum_types_.count(resolvedElemSig) ? resolvedElemSig : std::string{};
-                emitPatternBindings(pat->elements[i], tmp, elemTy, subElemEnumSig);
+                markFieldAllocaArcManaged(tmp, elemTy, elemSig);
+                emitPatternBindings(pat->elements[i], tmp, elemTy, filterToEnumOnly(elemSig), elemSig);
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<RecordPattern>>) {
             const std::string resolvedName = resolveTypeAlias(pat->name);
@@ -535,36 +567,15 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 const std::string elemSig = info.fields[i].type->toString();
                 if (!elemSig.empty())
                     propagateTypeMeta(elemSig, tmp);
-                // Mark ptr-type intermediates as ARC-managed so the recursive leaf
-                // VariablePattern binding can detect them via tryRetainArcSource and
-                // emit a single retain.  The tmp alloca is not in scope_stack_ so
-                // there is no matching release — varAlloca owns the refcount.
-                // For str fields, also register in arc_str_managed_vars_ so that
-                // tryRetainArcSource Case 1 uses emitStrGetHeaderFromData (offset -24)
-                // instead of emitArcGetHeaderFromData (offset -16).
-                if (elemTy == ptrTy_) {
-                    CollectionKind fk;
-                    if (fieldTypeIsArcManaged(elemSig, &fk)) {
-                        markArcManaged(tmp);
-                        if (fk == CollectionKind::Str)
-                            arc_str_managed_vars_.insert(tmp);
-                    }
-                }
-                // Pass elemSig as subjectEnumType only for enum types; primitive and collection
-                // types are already handled by propagateTypeMeta above. Passing "int" or "str"
-                // as subjectEnumType would cause VariablePattern binding to set enum_value_type
-                // to a non-enum name and crash valueToString().
-                // Resolve aliases first so that aliased enum field types are also recognised.
-                const std::string resolvedElemSig = resolveTypeAlias(elemSig);
-                const std::string subEnumSig = enum_types_.count(resolvedElemSig) ? resolvedElemSig : std::string{};
-                emitPatternBindings(pat->elements[i], tmp, elemTy, subEnumSig);
+                markFieldAllocaArcManaged(tmp, elemTy, elemSig);
+                emitPatternBindings(pat->elements[i], tmp, elemTy, filterToEnumOnly(elemSig), elemSig);
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>) {
             std::string resolvedEnum = pat->enum_name;
-            if (!enum_types_.count(resolvedEnum) && !subjectEnumType.empty()) {
-                auto ltPos = subjectEnumType.find('<');
-                if (ltPos != std::string::npos && subjectEnumType.substr(0, ltPos) == pat->enum_name)
-                    resolvedEnum = subjectEnumType;
+            if (!enum_types_.count(resolvedEnum) && !subjectEnumName.empty()) {
+                auto ltPos = subjectEnumName.find('<');
+                if (ltPos != std::string::npos && subjectEnumName.substr(0, ltPos) == pat->enum_name)
+                    resolvedEnum = subjectEnumName;
             }
             // emitPatternTest already validated the enum; skip silently if lookup fails here.
             auto enumIt = enum_types_.find(resolvedEnum);
@@ -597,26 +608,8 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                             ? fit->second.fieldTypeNames[bi] : std::string{};
                         if (!fieldTypeName.empty())
                             propagateTypeMeta(fieldTypeName, tmp);
-                        // Mark ptr-type intermediates as ARC-managed so the recursive leaf
-                        // VariablePattern binding can detect them via tryRetainArcSource and
-                        // emit a single retain.  The tmp alloca is not in scope_stack_ so
-                        // there is no matching release — varAlloca owns the refcount.
-                        // For str fields, also register in arc_str_managed_vars_ so that
-                        // tryRetainArcSource Case 1 uses emitStrGetHeaderFromData (offset -24).
-                        if (fieldTy == ptrTy_) {
-                            CollectionKind fk2;
-                            if (fieldTypeIsArcManaged(fieldTypeName, &fk2)) {
-                                markArcManaged(tmp);
-                                if (fk2 == CollectionKind::Str)
-                                    arc_str_managed_vars_.insert(tmp);
-                            }
-                        }
-                        // Guard: only pass fieldTypeName as subjectEnumType when it names a known enum.
-                        // Passing a primitive type name ("int", "str", etc.) would crash valueToString().
-                        const std::string resolvedFieldType = resolveTypeAlias(fieldTypeName);
-                        const std::string subEnumSig = enum_types_.count(resolvedFieldType)
-                            ? resolvedFieldType : std::string{};
-                        emitPatternBindings((*fieldPats)[bi], tmp, fieldTy, subEnumSig);
+                        markFieldAllocaArcManaged(tmp, fieldTy, fieldTypeName);
+                        emitPatternBindings((*fieldPats)[bi], tmp, fieldTy, filterToEnumOnly(fieldTypeName), fieldTypeName);
                         offset += dl.getTypeAllocSize(fieldTy);
                     }
                 }
@@ -748,8 +741,9 @@ void CodeGen::emitStmt(std::unique_ptr<CaseStmt> &s) {
     for (auto &arm : s->arms)
         armPatterns.push_back({&arm.pattern, arm.guard != nullptr});
 
-    std::string subjectEnumTypeForCheck = resolveEnumType(subject);
-    checkMatchExhaustiveness(armPatterns, subjectTy, subjectEnumTypeForCheck);
+    std::string subjectEnumName = resolveEnumType(subject);
+    std::string subjectSourceTypeName = resolveSubjectSourceTypeName(subjectEnumName, subjectTy);
+    checkMatchExhaustiveness(armPatterns, subjectTy, subjectEnumName);
 
     // --- Code generation: chain of conditional branches ---
     llvm::BasicBlock *matchEndBB = llvm::BasicBlock::Create(*ctx_, "match.end", fn_);
@@ -757,9 +751,8 @@ void CodeGen::emitStmt(std::unique_ptr<CaseStmt> &s) {
     llvm::AllocaInst *subjectAlloca = builder_.CreateAlloca(subjectTy, nullptr, "match.subject");
     builder_.CreateStore(subject, subjectAlloca);
 
-    const auto &subjectEnumType = subjectEnumTypeForCheck;
-    if (!subjectEnumType.empty())
-        getOrCreateMeta(subjectAlloca).enum_value_type = subjectEnumType;
+    if (!subjectEnumName.empty())
+        getOrCreateMeta(subjectAlloca).enum_value_type = subjectEnumName;
 
     propagateMetaWide(subject, subjectAlloca);
 
@@ -771,7 +764,8 @@ void CodeGen::emitStmt(std::unique_ptr<CaseStmt> &s) {
             : matchEndBB;
 
         llvm::Value *subjectVal = builder_.CreateLoad(subjectTy, subjectAlloca, "match.subj");
-        llvm::Value *testResult = emitPatternTest(arm.pattern, subjectVal, subjectTy, subjectEnumType);
+        llvm::Value *testResult = emitPatternTest(arm.pattern, subjectVal, subjectTy,
+                                                  subjectEnumName, subjectSourceTypeName);
 
         if (arm.guard) {
             llvm::BasicBlock *guardBB = llvm::BasicBlock::Create(*ctx_, "match.guard", fn_);
@@ -779,7 +773,8 @@ void CodeGen::emitStmt(std::unique_ptr<CaseStmt> &s) {
             builder_.SetInsertPoint(guardBB);
 
             pushScope();
-            emitPatternBindings(arm.pattern, subjectAlloca, subjectTy, subjectEnumType);
+            emitPatternBindings(arm.pattern, subjectAlloca, subjectTy,
+                                subjectEnumName, subjectSourceTypeName);
 
             llvm::Value *guardVal = emitExpr(*arm.guard);
             guardVal = toBool(guardVal);
@@ -793,7 +788,8 @@ void CodeGen::emitStmt(std::unique_ptr<CaseStmt> &s) {
         builder_.SetInsertPoint(armBodyBB);
         emitTraceWhenBranch(static_cast<int>(i), s->loc);
         pushScope();
-        emitPatternBindings(arm.pattern, subjectAlloca, subjectTy, subjectEnumType);
+        emitPatternBindings(arm.pattern, subjectAlloca, subjectTy,
+                            subjectEnumName, subjectSourceTypeName);
 
         for (auto &stmt : arm.body)
             std::visit([this](auto &st) { emitStmt(st); }, stmt);
@@ -820,8 +816,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
     for (auto &arm : e->arms)
         armPatterns.push_back({&arm.pattern, arm.guard != nullptr});
 
-    std::string subjectEnumType = resolveEnumType(subject);
-    checkMatchExhaustiveness(armPatterns, subjectTy, subjectEnumType);
+    std::string subjectEnumName = resolveEnumType(subject);
+    std::string subjectSourceTypeName = resolveSubjectSourceTypeName(subjectEnumName, subjectTy);
+    checkMatchExhaustiveness(armPatterns, subjectTy, subjectEnumName);
 
     // --- Code generation with PHI node ---
     llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "match.expr.merge", fn_);
@@ -830,8 +827,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
     llvm::AllocaInst *subjectAlloca = builder_.CreateAlloca(subjectTy, nullptr, "match.subject");
     builder_.CreateStore(subject, subjectAlloca);
 
-    if (!subjectEnumType.empty())
-        getOrCreateMeta(subjectAlloca).enum_value_type = subjectEnumType;
+    if (!subjectEnumName.empty())
+        getOrCreateMeta(subjectAlloca).enum_value_type = subjectEnumName;
     propagateMetaWide(subject, subjectAlloca);
 
     // If the scrutinee is Option<T>, seed the None() hint so that None() / bare
@@ -849,7 +846,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
     for (size_t i = 0; i < e->arms.size(); ++i) {
         auto &arm = e->arms[i];
         llvm::Value *subjectVal = builder_.CreateLoad(subjectTy, subjectAlloca, "match.subj");
-        llvm::Value *testResult = emitPatternTest(arm.pattern, subjectVal, subjectTy, subjectEnumType);
+        llvm::Value *testResult = emitPatternTest(arm.pattern, subjectVal, subjectTy,
+                                                  subjectEnumName, subjectSourceTypeName);
 
         llvm::BasicBlock *thenBB = llvm::BasicBlock::Create(*ctx_, "match.expr.then", fn_);
         llvm::BasicBlock *nextBB = llvm::BasicBlock::Create(*ctx_, "match.expr.next", fn_);
@@ -860,7 +858,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
             builder_.SetInsertPoint(guardBB);
 
             pushScope();
-            emitPatternBindings(arm.pattern, subjectAlloca, subjectTy, subjectEnumType);
+            emitPatternBindings(arm.pattern, subjectAlloca, subjectTy,
+                                subjectEnumName, subjectSourceTypeName);
 
             llvm::Value *guardVal = emitExpr(*arm.guard);
             guardVal = toBool(guardVal);
@@ -873,7 +872,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
 
         builder_.SetInsertPoint(thenBB);
         pushScope();
-        emitPatternBindings(arm.pattern, subjectAlloca, subjectTy, subjectEnumType);
+        emitPatternBindings(arm.pattern, subjectAlloca, subjectTy,
+                            subjectEnumName, subjectSourceTypeName);
 
         llvm::Value *armVal = emitExpr(*arm.value);
         if (!firstVal) firstVal = armVal;

--- a/tests/spec/pattern_tuple.test.ry
+++ b/tests/spec/pattern_tuple.test.ry
@@ -235,4 +235,18 @@ describe("regression - existing patterns unaffected", ():
       Color::Blue => 2
     expect(res).to_eq(1)
   )
+
+  it("annotated (str, str) tuple destructure (#1156)", ():
+    # Regression guard: isTupleStructType-based guard must not reject genuine
+    # annotated tuple subjects, only Option/Result/record/ADT/union structs.
+    ss: (str, str) = ("hello", "world")
+    x_out = ""
+    y_out = ""
+    case ss:
+      (x, y):
+        x_out = x
+        y_out = y
+    expect(x_out).to_eq("hello")
+    expect(y_out).to_eq("world")
+  )
 )

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -394,3 +394,37 @@ TEST_F(CodeGenTest, Base64EncodeBytesUrlSafeRejectsNonU8List) {
         "print(encode_bytes_url_safe(xs))\n",
         "requires List<u8>");
 }
+
+// ============================================================
+// #1156: tuple pattern on Option / Result must be rejected
+// ============================================================
+
+// Option<T> is represented as {i1, T} — a 2-element struct.  Before #1156
+// the structural guard only fired when subjectEnumType was non-empty, so an
+// Option<int> subject silently passed the arity check for `(a, b)`.
+TEST_F(CodeGenTest, TuplePatternOnOptionSubjectRejected) {
+    expectCompileError(
+        "opt: int? = Some(1)\n"
+        "case opt:\n"
+        "  (a, b):\n"
+        "    print(a)\n"
+        "  _:\n"
+        "    print(\"other\")\n",
+        "tuple pattern applied to non-tuple subject");
+}
+
+// Result<T, E> is {i1, T, E}.  Arity 3 already triggered an arity-mismatch
+// error for a 2-element pattern, but the error text was wrong.  After #1156
+// both Option and Result use the same structural rejection path.
+TEST_F(CodeGenTest, TuplePatternOnResultSubjectRejected) {
+    expectCompileError(
+        "function mk() -> Result<int, str>:\n"
+        "  return Ok(1)\n"
+        "r = mk()\n"
+        "case r:\n"
+        "  (a, b, c):\n"
+        "    print(a)\n"
+        "  _:\n"
+        "    print(\"other\")\n",
+        "tuple pattern applied to non-tuple subject");
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `resolveEnumType()` reads only `ValueMetadata::enum_value_type`, which is never set for Option/Result/tuple subjects. The single `subjectEnumType` parameter propagated as `""` for these subjects, allowing `case opt: (a, b)` (where `opt: Option<T>`) to pass the arity check — Option's `{i1, T}` is a 2-element struct, same arity as a 2-tuple — producing wrong IR or an ICmp type-mismatch crash.
- **Fix**: Split into two parameters (`subjectEnumName` narrow / `subjectSourceTypeName` broad) and add a structural `isTupleStructType(sTy)` guard in the TuplePattern test arm that fires regardless of any source name.
- **Refactor**: Extract `filterToEnumOnly` and `markFieldAllocaArcManaged` helpers to eliminate three-way copy-paste across TuplePattern / RecordPattern / EnumConstructorPattern binding arms.

## Changes

- `src/codegen_match.cpp`: Split `subjectEnumType` → `subjectEnumName` + `subjectSourceTypeName`; add `resolveSubjectSourceTypeName`, `filterToEnumOnly`, `markFieldAllocaArcManaged` helpers; replace TuplePattern string-based guard with `isTupleStructType`
- `include/ry/codegen.hpp`: Updated declarations for the new two-parameter signatures and new helpers
- `tests/test_codegen_fail.cpp`: Two new negative tests — `TuplePatternOnOptionSubjectRejected`, `TuplePatternOnResultSubjectRejected`
- `tests/spec/pattern_tuple.test.ry`: Regression guard for legitimate `(str, str)` tuple destructure
- `changelog.d/1156-codegen-match-subject-type.md`: CHANGELOG entry
- `KNOWLEDGE.md`: Design rationale entry for the two-parameter split and lossiness constraint

## Test plan

- [x] 1819 gtest pass (`./build/ry_tests`)
- [x] 145 Ry self-tests pass (`./build/ry test -p`)
- [x] ASan + UBSan clean (1819 gtest + 145 self-tests)
- [x] TSan clean (1819 gtest)
- [x] libFuzzer 60s clean (`fuzz_parser`, `fuzz_json`, `fuzz_utf8`)
- [x] `TuplePatternOnOptionSubjectRejected` — rejects `case opt: (a, b)` where `opt: int?`
- [x] `TuplePatternOnResultSubjectRejected` — rejects `case r: (a, b, c)` where `r: Result<int, str>`
- [x] Legitimate `(str, str)` tuple destructure still works

Closes #1156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Pattern matching now correctly rejects tuple patterns when applied to `Option` and `Result` subjects. This prevents incorrect IR generation and crashes that could occur when LLVM struct layouts were mistakenly treated as tuples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->