### PR TITLE
fix: Map.contains() always returns false (#1185)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -4051,3 +4051,39 @@ generics (currently handled by Path 2b heuristic via `propagateMeta`).
 **Root cause**: `src/codegen_tostring.cpp` — `hasExplicitValues` enum branch — had a default fallback BB that used `builder_.CreateGlobalString("?", ".enum_unknown")`. The PHI on that branch collected the raw pointer, which `emitStringByteLen` later misread. The ADT/union default on the same file already used `cachedGlobalString` correctly; the explicit-value enum default was the outlier.
 
 **How to apply**: When adding a new `str` constant in codegen, always use `cachedGlobalString`. When reviewing existing codegen, grep for `CreateGlobalString(` and verify that the result never flows into `emitStringByteLen`, `emitStringLen`, or f-string concat helpers. The only safe uses of raw `CreateGlobalString` are LLVM format strings for `printf`-style calls that are never read back as Ry `str` handles.
+
+### `contains()` on Map must be intercepted in `emitStrOp_contains`, not via `@native`
+
+**Source**: #1185 (2026-04-19, fix)
+**Tags**: codegen, collections, map, dispatch-order, contains
+
+`emitBuiltinString` is invoked before `emitBuiltinCollection` in
+`src/codegen_call_dispatch.cpp`. Therefore every `contains(x, y)` call reaches
+`emitStrOp_contains` first. Since all collection pointers share `ptrTy_` with
+strings under the opaque pointer model, the Set and Map intercept blocks must
+live inside `emitStrOp_contains` — before the str fall-through logic — rather
+than in `emitBuiltinCollection`.
+
+**Rule**: If a new collection type needs `contains()` semantics, add a
+`getXxxType(s)` intercept block immediately after the Set block in
+`emitStrOp_contains` (`src/codegen_call_string.cpp`). Do NOT declare a
+`@native` `contains` overload in the stdlib package file; that would route
+through the Pattern-A dispatch table and interact unpredictably with the
+string handler.
+
+The Map intercept mirrors `has_key` (`src/codegen_call.cpp`) exactly:
+```cpp
+if (llvm::Type *mapKeyTy = getMapKeyType(s)) {
+    if (e.args.size() != 2)
+        codegenError("Map.contains() takes exactly 1 argument");
+    llvm::Value *key = emitExpr(*e.args[1]);
+    if (key->getType() != mapKeyTy)
+        codegenError("contains() key type mismatch");
+    llvm::Value *idx = emitMapKeyLookup(s, key, mapKeyTy);
+    return builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "map_contains");
+}
+```
+
+Note: `emitMapKeyLookup` is called without threading `keyName` here, matching
+the existing `has_key` implementation. Structural-key correctness (pointer-typed
+map keys) is a separate issue — see the L1106 entry.

--- a/changelog.d/1185-map-contains.md
+++ b/changelog.d/1185-map-contains.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `contains(map, key)` and `m.contains(key)` now correctly perform map key lookup instead of always returning `false` (#1185)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -263,6 +263,8 @@ print(has_key(m, "a"))    # true
 print(m.has_key("z"))     # false (UFCS)
 ```
 
+`contains(m, key)` is equivalent to `has_key(m, key)` for maps.
+
 ---
 
 ## add

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -715,6 +715,17 @@ print(m.has_key("a"))   # true
 print(m.has_key("z"))   # false
 ```
 
+### contains
+
+Equivalent to `has_key`. Both free-function and UFCS forms are available.
+
+```ry
+m = {"a": 1, "b": 2}
+print(contains(m, "a"))   # true
+print(m.contains("a"))    # true (UFCS)
+print(m.contains("z"))    # false
+```
+
 ### keys
 
 Returns a list of all keys in the map.

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -48,8 +48,8 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
 // ===== String operation handlers =====
 
 // contains(s, sub[, ignore_case]) → bool
-// Set membership (contains(set, elem)) is intercepted here because the dispatch
-// chain routes "contains" through the string handler before emitBuiltinCollection.
+// Set / Map membership are intercepted here because the dispatch chain routes
+// "contains" through the string handler before emitBuiltinCollection.
 llvm::Value *CodeGen::emitStrOp_contains(const CallExpr &e) {
     if (e.args.size() < 2 || e.args.size() > 3)
         codegenError("contains() takes 2 or 3 arguments");
@@ -65,6 +65,16 @@ llvm::Value *CodeGen::emitStrOp_contains(const CallExpr &e) {
         validateSetElemType(cElemName, elem, "contains()");
         llvm::Value *idx = emitSetElementLookup(s, elem, setElemTy, cElemName);
         return builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "set_contains");
+    }
+
+    if (llvm::Type *mapKeyTy = getMapKeyType(s)) {
+        if (e.args.size() != 2)
+            codegenError("Map.contains() takes exactly 1 argument");
+        llvm::Value *key = emitExpr(*e.args[1]);
+        if (key->getType() != mapKeyTy)
+            codegenError("contains() key type mismatch");
+        llvm::Value *idx = emitMapKeyLookup(s, key, mapKeyTy);
+        return builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "map_contains");
     }
 
     llvm::Value *sub = emitExpr(*e.args[1]);

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -515,6 +515,17 @@ describe("Map", ():
     expect(m).to_contain("a")
     expect(m).to_not_contain("z")
   )
+  it("should check contains on Map", ():
+    m = {"a": 1, "b": 2}
+    expect(contains(m, "a")).to_be_true()
+    expect(m.contains("a")).to_be_true()
+    expect(m.contains("z")).to_be_false()
+  )
+  it("should check contains on Map with int keys", ():
+    m = {1: "x", 2: "y"}
+    expect(contains(m, 1)).to_be_true()
+    expect(m.contains(99)).to_be_false()
+  )
   it("should return keys", ():
     m = {"x": 1}
     ks = keys(m)

--- a/tests/spec/generic_collection_param.test.ry
+++ b/tests/spec/generic_collection_param.test.ry
@@ -26,4 +26,8 @@ describe("generic function with collection params", ():
   it("should support Set int parameter", ():
     expect(set_count[int]({1, 2, 3})).to_eq(1)
   )
+  it("should check Map contains via generic param", ():
+    expect(map_has[str, int]({"a": 1, "b": 2}, "a")).to_be_true()
+    expect(map_has[str, int]({"a": 1, "b": 2}, "z")).to_be_false()
+  )
 )

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -151,6 +151,25 @@ TEST_F(CodeGenTest, MapBasicOperations) {
             "print(m.has_key(\"z\"))";
         EXPECT_EQ(runSource(src), "true\nfalse\n");
     }
+    // MapContains
+    {
+        std::string src =
+            "m = {\"a\": 1, \"b\": 2}\n"
+            "print(m.contains(\"a\"))\n"
+            "print(contains(m, \"b\"))\n"
+            "print(m.contains(\"z\"))";
+        EXPECT_EQ(runSource(src), "true\ntrue\nfalse\n");
+    }
+}
+
+TEST_F(CodeGenTest, MapContainsRejectTooManyArgs) {
+    EXPECT_THROW(runSource("m = {\"a\": 1}\nprint(m.contains(\"a\", true))"),
+                 std::runtime_error);
+}
+
+TEST_F(CodeGenTest, MapContainsRejectKeyTypeMismatch) {
+    EXPECT_THROW(runSource("m = {\"a\": 1}\nprint(m.contains(42))"),
+                 std::runtime_error);
 }
 
 TEST_F(CodeGenTest, MapKeyMutation) {


### PR DESCRIPTION
## Summary

- `contains(map, key)` and `m.contains(key)` were always returning `false` because the dispatch chain routes all `contains` calls through `emitBuiltinString` before `emitBuiltinCollection`, and `emitStrOp_contains` had a Set intercept but no Map intercept
- Added a Map intercept block in `emitStrOp_contains` (after the Set block), mirroring the existing `has_key` implementation via `getMapKeyType` + `emitMapKeyLookup`
- `"a" in m` and `has_key(m, "a")` were already correct; this fix makes `contains` and UFCS `m.contains()` consistent

## Test plan

- [x] Repro confirmed: pre-fix `contains(m, "a")` → `false`, post-fix → `true`
- [x] New Ry spec tests: `tests/spec/collections.test.ry` — str-key and int-key Map contains
- [x] New Ry spec test: `tests/spec/generic_collection_param.test.ry` — `map_has<K,V>` via generic param (was untested)
- [x] C++ smoke test in `MapBasicOperations` + 2 rejection-branch gtests (`MapContainsRejectTooManyArgs`, `MapContainsRejectKeyTypeMismatch`) per AGENTS.md §2.5
- [x] Type mismatch (`m.contains(42)` on `Map<str, int>`) → compile error
- [x] 1827 C++ tests / 158 Ry self-test files — all pass
- [x] ASan + UBSan clean
- [x] TSan clean
- [x] libFuzzer: `fuzz_parser`, `fuzz_json`, `fuzz_utf8` — 60s each, crash 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `contains()` on maps to perform actual key lookups instead of unconditionally returning false. Both `contains(m, key)` and `m.contains(key)` are now supported.

* **Documentation**
  * Clarified that `contains()` on maps is equivalent to `has_key()`.
  * Added API documentation and examples for map `contains()` usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->