### PR TITLE
fix: propagate Option<T> inner hint in record constructor field positions (#1186)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3333,8 +3333,8 @@ This is the same rule as the `IfBlockExpr` path tested in `tests/spec/option_lam
 
 ### Hint channel for `None()`/`none` inner type in branch-merge and lambda-call argument positions
 
-**Source**: #1154 (2026-04-18, bugfix — `None()` in if/case branch defaults to `Option<i8>`), #1179 (2026-04-19, bugfix — `None()` in lambda call arg defaults to wrong inner type)
-**Tags**: codegen, Option, None, NoneExpr, branch-merge, IfExpr, CaseExpr, hint-channel, RAII, lambda-call
+**Source**: #1154 (2026-04-18, bugfix — `None()` in if/case branch defaults to `Option<i8>`), #1179 (2026-04-19, bugfix — `None()` in lambda call arg defaults to wrong inner type), #1186 (2026-04-19, bugfix — `None()` in record/struct constructor field position defaults to wrong inner type)
+**Tags**: codegen, Option, None, NoneExpr, branch-merge, IfExpr, CaseExpr, hint-channel, RAII, lambda-call, record-constructor
 
 **Rule**: `None()` and `none` in branch-merge positions (e.g., `if cond => None() else Some(42)`) previously defaulted to `Option<i8>` or `Option<i64>` because the emitters only consulted `fn_->getReturnType()`. The fix introduces a two-field class-state hint channel:
 
@@ -3348,10 +3348,9 @@ This is the same rule as the `IfBlockExpr` path tested in `tests/spec/option_lam
 - **CaseExpr (pattern match) uses scrutinee-based hint** in `codegen_match.cpp::emitExprVariant(CaseExpr)`: `Some(v)` arm values reference pattern-bound variables not in scope at pre-scan time, so `computeBranchOptionInnerHint` cannot be applied. Instead, the scrutinee type (`subjectTy`) is used — if it is `Option<T>`, its inner `T` is extracted and installed as the `OptionNoneHintGuard` hint before any arm is emitted. Fallback is `option_decl_annotation_inner_`.
 - **CaseCondExpr (`when cond => value`) uses pre-scan** in `codegen_expr.cpp::emitExprVariant(CaseCondExpr)`: no pattern variables are involved, so `computeBranchOptionInnerHint` on the first arm value and `else_expr` is safe. Guard is installed inside each value emit block (after the arm condition) to prevent hint leaking into condition expressions.
 - **Lambda variable (indirect) call arguments** in `codegen_call_dispatch.cpp` (#1179): per-arg `OptionNoneHintGuard` with inner derived from the callee's `FnTypeInfo::paramTypes[i]` — only when that param is `isOptionType`. The hint source is the **callee signature** (not `option_decl_annotation_inner_`), so the invariant "decl annotation must not flow into arg positions" is preserved — the two channels remain disjoint by design. Non-Option params pass `nullptr` as inner (guard saves/restores nullptr, which is also a correct "clear" for nested contexts such as a call inside a branch-merge).
+- **Record/struct constructor field positions** in `codegen_expr_literal.cpp::emitRecordConstructor` (#1186): per-field `OptionNoneHintGuard` with inner derived from `info.llvmType->getElementType(i)` — only when that field is `isOptionType`. The hint source is the **field's declared LLVM struct element type**, which covers inherited fields via `allFields` pre-flattening (parent fields occupy lower indices). Non-Option fields pass `nullptr` as inner (correctly clears any outer hint when emitting e.g. `Outer(Some(UserWithAvatar("carol", None())))` so the nested `None()` inherits `UserWithAvatar.avatar`'s `str` rather than `Outer.inner`'s `UserWithAvatar`).
 
-**Design invariant**: `option_decl_annotation_inner_` does NOT flow directly into argument positions. Argument-position hints always come from the callee's declared parameter types (lambda variable call) or are absent (regular `fn` calls, which use `resolveOverload`'s `isNoneLiteral` short-circuit). This prevents LHS declaration annotations from contaminating arbitrary sub-expressions.
-
-**Remaining gap**: Struct/record constructor arg positions (`emitRecordConstructor` at `src/codegen_expr_literal.cpp:71-78`) have the same gap. Filed as #1186.
+**Design invariant**: `option_decl_annotation_inner_` does NOT flow directly into argument positions. Argument-position hints always come from the callee's declared parameter types (lambda variable call), the record's declared field types (record constructor), or are absent (regular `fn` calls, which use `resolveOverload`'s `isNoneLiteral` short-circuit). This prevents LHS declaration annotations from contaminating arbitrary sub-expressions.
 
 **Priority invariant**: `isNoneLiteral` short-circuit at the three annotation-aware `codegen_stmt.cpp` sites must remain the *first* check (runs before the hint seed). It handles the trivial `x: Option<int> = None()` case without touching hint state and is faster.
 

--- a/changelog.d/1186-record-constructor-none-hint.md
+++ b/changelog.d/1186-record-constructor-none-hint.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- `None()` / `none` passed as a positional field value in a record/struct
+  constructor now correctly inherits the field's `Option<T>` inner type,
+  matching the behavior already available in `let` annotations, if/case
+  branches, and lambda call arguments (#1186).

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -69,8 +69,13 @@ llvm::Value *CodeGen::emitRecordConstructor(const RecordInfo &info,
     llvm::Value *result = llvm::UndefValue::get(info.llvmType);
 
     for (unsigned i = 0; i < info.fields.size(); ++i) {
-        llvm::Value *val = emitExpr(*args[i]);
         llvm::Type *expectedTy = info.llvmType->getElementType(i);
+        // #1186: propagate Option<T> inner from field type so None()/none args resolve correctly.
+        llvm::Type *argHintInner = nullptr;
+        if (isOptionType(expectedTy))
+            argHintInner = llvm::cast<llvm::StructType>(expectedTy)->getElementType(1);
+        OptionNoneHintGuard argHint(*this, argHintInner);
+        llvm::Value *val = emitExpr(*args[i]);
         if (val->getType() != expectedTy)
             codegenError("type '" + name + "': field '" + info.fields[i].name +
                                      "' type mismatch");

--- a/tests/spec/records.test.ry
+++ b/tests/spec/records.test.ry
@@ -311,3 +311,70 @@ describe("generic enum", ():
     expect(res).to_eq(-1)
   )
 )
+
+record UserWithAvatar:
+  name: str
+  avatar: Option<str>
+
+record MixOptInt:
+  id: int
+  opt: Option<str>
+
+record OptIntField:
+  count: Option<int>
+
+record Outer:
+  inner: Option<UserWithAvatar>
+
+record BaseWithOpt:
+  avatar: Option<str>
+
+record SubWithOpt < BaseWithOpt:
+  name: str
+
+describe("None()/none in record constructor field positions (#1186)", ():
+  it("None() in Option<str> field adopts correct inner", ():
+    u = UserWithAvatar("alice", None())
+    expect(u.avatar).to_be_none()
+  )
+  it("bare none in Option<str> field adopts correct inner", ():
+    u = UserWithAvatar("alice", none)
+    expect(u.avatar).to_be_none()
+  )
+  it("Some(...) still works alongside None() support", ():
+    u = UserWithAvatar("bob", Some("face.png"))
+    expect(u.avatar).to_be_some()
+  )
+  it("None() in non-first position uses correct field index", ():
+    m = MixOptInt(42, None())
+    expect(m.id).to_eq(42)
+    expect(m.opt).to_be_none()
+  )
+  it("Option<int> inner differs from Option<str>", ():
+    o = OptIntField(None())
+    expect(o.count).to_be_none()
+  )
+  it("inline-nested: inner record's None() uses inner field hint (not outer's)", ():
+    # Exercises RAII shadow/restore: Outer's field hint (UserWithAvatar) must be
+    # shadowed by UserWithAvatar's own per-field loop when emitting the inner
+    # constructor. Without the shadow, None() would get inner = UserWithAvatar
+    # and fail the field-type check against Option<str>.
+    u = Outer(Some(UserWithAvatar("carol", None())))
+    case u.inner:
+      Some(user):
+        expect(user.avatar).to_be_none()
+        expect(user.name).to_eq("carol")
+      None:
+        expect(false).to_be_true()
+  )
+  it("inherited Option<str> field receives hint via pre-flattened fields", ():
+    s = SubWithOpt(None(), "dave")
+    expect(s.avatar).to_be_none()
+    expect(s.name).to_eq("dave")
+  )
+  it("non-Option fields are not affected (regression guard)", ():
+    p = Point(10, 20)
+    expect(p.x).to_eq(10)
+    expect(p.y).to_eq(20)
+  )
+)


### PR DESCRIPTION
## Summary

- `emitRecordConstructor` に per-field `OptionNoneHintGuard` を追加し、`None()` / `none` がフィールドの `Option<T>` inner 型を継承できるようにした (#1186)
- #1154 (branch-merge) と #1179 (lambda-call arg) で確立された hint channel パターンを record/struct コンストラクタにも適用
- 親フィールドを含む `info.llvmType->getElementType(i)` から inner を抽出するため、継承レコード (`record Sub < Base`) にも自動対応

## 詳細

修正前: `User("alice", None())` が `type 'User': field 'avatar' type mismatch` で compile error
修正後: inline で通る。workaround (`av: Option<str> = None(); User("alice", av)`) 不要。

RAII shadow/restore が正しく機能するため、`Outer(Some(UserWithAvatar("carol", None())))` のようなネストケースでも内側の `None()` は内側レコードのフィールド型を継承する (外側の `Outer.inner` 型に汚染されない)。

## Test plan

- [x] `./build/ry test tests/spec/records.test.ry` — 追加 8 ケース + 既存 40 ケースが全 pass (48/48)
- [x] `./build/ry_tests` — C++ 全テスト pass (1827 tests)
- [x] `./build/ry test -p` — Ry 全 spec pass (158 files)
- [x] ASan + UBSan: `ry_tests` と `ry test -p` clean
- [x] TSan: `ry_tests` clean (`ConcurrencySpecSuite` 含む)
- [x] libFuzzer: fuzz_parser / fuzz_json / fuzz_utf8 各 60s exit 0
- [x] FileCheck goldens: 3/3 pass
- [x] Issue の再現ケース (`User("alice", None())`) が inline 動作することを確認

Closes #1186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed type inference for `None()` / `none` when passed as positional field values in record and struct constructors. The field's declared `Option<T>` inner type is now correctly propagated, aligning constructor behavior with existing type inference in variable annotations, conditional branches, and function calls. Enhanced test coverage for nested and inherited record fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->