### PR TITLE
fix: support parenthesized tuple destructuring assignment (#1189)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2954,6 +2954,28 @@ the resolved `ref` output rather than `github.ref_name`.
 
 **How to apply**: When adding the next pattern type that starts with `(` (e.g., positional record `Point(a, b)` — note that starts with `Ident LParen`, not bare `LParen`), keep the bare-`LParen` branch as tuple-only and handle `Ident LParen` in a separate branch.
 
+### `parseDirectives` must defer `LParen` when tuple-destructure LHS lookahead matches
+
+**Source**: #1189 (2026-04-19, implementation)
+**Tags**: parser, directive, tuple, destructure, lookahead, ambiguity
+
+**Rule**: In `parseDirectives()`, before consuming `LParen` as the start of a directive argument list (`@name(arg, ...)`), check `!looksLikeParenthesizedTupleDestructure()`. If the lookahead matches, leave the `LParen` for `parseStatement()` to handle as the start of a tuple-destructure LHS (`@const (a, b) = expr`).
+
+**Why**: Directive-arg syntax `@name(arg, ...)` and statement-level tuple-destructure LHS `(ident, ident, ...) =` both start with `@name LParen Ident`. The only disambiguator is the trailing `=` after `RParen`. Without this guard, `@const (a, b) = expr` is misparsed as `@const(a, b)` with positional args `a` and `b`, and the subsequent `=` trips the "directives are not supported on this statement" gate. `couldBeLambda`-style conservative lookahead (restored via `lex_.saveState()` / `restoreState()`) is the right tool — false negatives are fine because they fall through to the old behavior.
+
+**How to apply**: When adding any new statement form that begins with `LParen` after directives (e.g., `@const (_ as Pattern) = expr`, hypothetical future destructuring variants), extend `looksLikeParenthesizedTupleDestructure` (or add a parallel predicate) and make `parseDirectives` defer to it in the same guard location. Never let `parseDirectives` unconditionally eat `LParen`.
+
+### Formatter→parser roundtrip: `TupleDestructStmt` must not emit `: ` between pattern and `=`
+
+**Source**: #1189 (2026-04-19, implementation)
+**Tags**: formatter, parser, tuple, destructure, roundtrip, latent_bug
+
+**Rule**: `formatTupleDestruct()` in `src/formatter_stmt.cpp` must emit only `<pattern> = <value>` (plus optional `@const` directive on a prior line). Do **not** emit a stray `: ` between the closing `)` of the pattern and the `=`. The immutability is conveyed by the `@const` directive emitted before the statement, not by a `:` suffix on the LHS.
+
+**Why**: Until #1189 landed, the parser rejected all parenthesized tuple-destructure forms, so the formatter's output `(a, b):  = (1, 2)` never round-tripped through parse. Enabling the parenthesized parse branch exposed the latent `: ` bug — formatted output now fails `ry fmt` verification ("formatted output failed to re-parse"). Adding `FormatterTest.ParenTupleDestructRoundTrip` locks this in so future formatter edits cannot regress.
+
+**How to apply**: When adding or modifying a formatter rule for a new statement shape, grep for a matching parser spec test and add a `verifyFormatting` / roundtrip assertion. Formatter output that fails to re-parse is a silent correctness bug during `ry fmt`; only the verification pass catches it.
+
 ### Record pattern in `case`: do NOT propagate primitive field type names as `subjectEnumType` in bindings
 
 **Source**: #989 (2026-04-16, implementation)

--- a/changelog.d/1189-tuple-destruct-parens.md
+++ b/changelog.d/1189-tuple-destruct-parens.md
@@ -1,0 +1,11 @@
+### Added
+
+- Parenthesized tuple destructuring assignment `(a, b) = expr` and
+  `@const (a, b) = expr` (#1189). Mirrors the existing bare form
+  `a, b = expr` and matches what the formatter has been emitting.
+
+### Fixed
+
+- Formatter no longer emits a stray `: ` between the pattern and `=` in
+  `TupleDestructStmt` output, which previously broke formatter → parser
+  round-tripping for `@const` variants (#1189).

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -219,6 +219,14 @@ for a, _, c in triples:
     print(a + c)          # 4, 10 (middle element discarded)
 ```
 
+Statement-level destructuring assignment is also available and accepts both a bare and a parenthesized LHS. See [directives.md#const](directives.md) for the `@const` variant.
+
+```ry
+a, b = (10, 20)           # bare form
+(c, d) = (30, 40)         # parenthesized form — same meaning
+(_, e) = (50, 60)         # discard first component
+```
+
 ### Range Operator (`..`)
 
 The `..` operator creates an inclusive integer range. `1 .. 5` produces `[1, 2, 3, 4, 5]`.

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -95,9 +95,16 @@ name: str = "hello"
 
 **Tuple destructuring:**
 
+Both the bare form and the parenthesized form are supported. The parenthesized form also works without `@const` to declare the names as mutable.
+
 ```
 @const
 a, b = (1, 2)
+
+@const (c, d) = (3, 4)        # same meaning, parenthesized pattern
+
+(e, f) = (5, 6)               # declares mutable e, f
+(_, g) = (7, 8)               # `_` skips a component
 ```
 
 **Top-level `@const` and functions.** A top-level `@const` declaration is visible from any top-level function defined after it in the same source file, and the immutability is enforced for every reference — including field mutations through a top-level `@const` record. See the "Top-Level Variables and `@const` in Function Bodies" section in [functions.md](functions.md) for details.

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -129,6 +129,10 @@ private:
     ExprPtr parseParenLambdaExpr();
     bool couldBeLambda();
     bool couldBeGenericEnum();
+    // Lookahead predicate for `(a, b, ...) = expr` statement form (#1189).
+    // Returns true only when the current '(' is followed by `Ident (Comma Ident)+ RParen Equals`,
+    // requiring at least two names to avoid ambiguity with grouping and single-name forms.
+    bool looksLikeParenthesizedTupleDestructure();
     TypeNodePtr parseCastTypeName();
     ExprPtr parseAwaitExpr();
 };

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -447,7 +447,6 @@ void Formatter::formatTupleDestruct(const TupleDestructStmt &s) {
         emit(s.names[i]);
     }
     emit(")");
-    if (s.is_immutable) emit(": ");
     emit(" = " + formatExpr(*s.value));
     emitInlineComment(s.loc.line);
     emitNewline();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -299,7 +299,12 @@ std::vector<Directive> Parser::parseDirectives() {
         d.loc = {atTok.line, atTok.col, file_id_};
 
         // Optional argument list: @name(arg1, key=arg2, ...)
-        if (lex_.peek().kind == TokenKind::LParen) {
+        // Exception (#1189): if the `(` starts a parenthesized tuple-destructure
+        // LHS — shape `(Ident (, Ident)+ ) =` — leave it for parseStatement so
+        // `@const (a, b) = expr` parses as directive + statement, not as
+        // `@const(a, b)` with positional arguments.
+        if (lex_.peek().kind == TokenKind::LParen &&
+            !looksLikeParenthesizedTupleDestructure()) {
             lex_.next(); // consume '('
 
             while (lex_.peek().kind != TokenKind::RParen) {
@@ -468,6 +473,34 @@ StmtNode Parser::parseStatement() {
             s.directives = std::move(directives);
             return s;
         }
+    }
+
+    // Parenthesized tuple destructuring (#1189). Must run before the directive
+    // gate below so `@const (a, b) = expr` passes through.
+    if (first.kind == TokenKind::LParen && looksLikeParenthesizedTupleDestructure()) {
+        lex_.next();
+        std::vector<std::string> names;
+        names.push_back(lex_.peek().value);
+        lex_.next();
+        while (lex_.peek().kind == TokenKind::Comma) {
+            lex_.next();
+            names.push_back(lex_.peek().value);
+            lex_.next();
+        }
+        if (lex_.peek().kind != TokenKind::RParen)
+            parseError(lex_.peek().line, "expected ')' in tuple destructuring");
+        lex_.next();
+        if (lex_.peek().kind != TokenKind::Equals)
+            parseError(lex_.peek().line, "expected '=' after tuple destructuring pattern");
+        lex_.next();
+        ExprPtr value = parseConditional();
+        TupleDestructStmt s;
+        s.names = std::move(names);
+        s.value = std::move(value);
+        s.is_immutable = hasDirective(directives, "const");
+        s.directives = std::move(directives);
+        s.loc = locFromToken(first);
+        return s;
     }
 
     // Non-identifier statements (except those already handled above) do not accept directives

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -803,6 +803,38 @@ bool Parser::couldBeLambda() {
     return result;
 }
 
+bool Parser::looksLikeParenthesizedTupleDestructure() {
+    // Must always restore lexer state — false negatives fall through to the
+    // existing expression-statement / lambda branches.
+    auto saved = lex_.saveState();
+    lex_.next();
+    if (lex_.peek().kind != TokenKind::Ident) {
+        lex_.restoreState(std::move(saved));
+        return false;
+    }
+    lex_.next();
+    if (lex_.peek().kind != TokenKind::Comma) {
+        lex_.restoreState(std::move(saved));
+        return false;
+    }
+    while (lex_.peek().kind == TokenKind::Comma) {
+        lex_.next();
+        if (lex_.peek().kind != TokenKind::Ident) {
+            lex_.restoreState(std::move(saved));
+            return false;
+        }
+        lex_.next();
+    }
+    if (lex_.peek().kind != TokenKind::RParen) {
+        lex_.restoreState(std::move(saved));
+        return false;
+    }
+    lex_.next();
+    bool result = (lex_.peek().kind == TokenKind::Equals);
+    lex_.restoreState(std::move(saved));
+    return result;
+}
+
 TypeNodePtr Parser::parseCastTypeName() {
     // In expression context after 'as', '<' is ambiguous between generic type
     // parameter and comparison operator.  Use speculative parse: try

--- a/tests/spec/tuple_destructure_assign_parens.test.ry
+++ b/tests/spec/tuple_destructure_assign_parens.test.ry
@@ -1,0 +1,51 @@
+describe("parenthesized tuple destructuring assignment (#1189)", ():
+  it("should destructure a 2-tuple literal into two names", ():
+    (a, b) = (10, 20)
+    expect(a).to_eq(10)
+    expect(b).to_eq(20)
+  )
+
+  it("should destructure a 3-tuple literal into three names", ():
+    (a, b, c) = (1, 2, 3)
+    expect(a).to_eq(1)
+    expect(b).to_eq(2)
+    expect(c).to_eq(3)
+  )
+
+  it("should destructure a function return value (issue repro)", ():
+    function min_max(lst: List<int>) -> (int, int):
+      return (min(lst), max(lst))
+
+    (lo, hi) = min_max([3, 1, 4])
+    expect(lo).to_eq(1)
+    expect(hi).to_eq(4)
+  )
+
+  it("should accept `_` wildcard on the left side", ():
+    (_, b) = (10, 20)
+    expect(b).to_eq(20)
+  )
+
+  it("should accept `_` wildcard on the right side", ():
+    (a, _) = (10, 20)
+    expect(a).to_eq(10)
+  )
+
+  it("should support @const parenthesized form", ():
+    @const (a, b) = (1, 2)
+    expect(a).to_eq(1)
+    expect(b).to_eq(2)
+  )
+
+  it("should bind names to tuple of mixed types", ():
+    (x, y) = (42, 3.14)
+    expect(x).to_eq(42)
+    expect(y).to_eq(3.14)
+  )
+
+  it("should keep the non-parenthesized form working (regression guard)", ():
+    a, b = (7, 8)
+    expect(a).to_eq(7)
+    expect(b).to_eq(8)
+  )
+)

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -471,6 +471,31 @@ TEST(FormatterTest, TupleMultiElementRoundTrip) {
     EXPECT_EQ(first, second);
 }
 
+TEST(FormatterTest, ParenTupleDestructRoundTrip) {
+    // #1189 — parenthesized tuple destructuring must round-trip through the
+    // formatter. Guards against the historical `: ` emission between `)` and
+    // `=` that made @const variants unparseable on re-format.
+    {
+        auto src = "(a, b) = (1, 2)\n";
+        auto first = Formatter::formatSource(src);
+        EXPECT_EQ(first, src);
+        EXPECT_EQ(Formatter::formatSource(first), first);
+    }
+    {
+        auto src = "@const\n(c, d) = (3, 4)\n";
+        auto first = Formatter::formatSource(src);
+        EXPECT_EQ(first, src);
+        EXPECT_EQ(Formatter::formatSource(first), first);
+    }
+    {
+        // `_` wildcard round-trip
+        auto src = "(_, e) = (5, 6)\n";
+        auto first = Formatter::formatSource(src);
+        EXPECT_EQ(first, src);
+        EXPECT_EQ(Formatter::formatSource(first), first);
+    }
+}
+
 TEST(FormatterTest, DefaultArgRoundTrip) {
     auto src = "function greet(name: str, greeting: str = \"Hello\") -> str:\n  return greeting\n";
     auto first = Formatter::formatSource(src);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -822,6 +822,73 @@ TEST(ParserTest, TupleSingleElementString) {
     ASSERT_TRUE(std::holds_alternative<StringExpr>(tuple.elements[0]->data));
 }
 
+// ===== Parenthesized tuple destructuring assignment (#1189) =====
+
+TEST(ParserTest, ParenTupleDestructBasic) {
+    Program prog = parseStr("(a, b) = (10, 20)");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<TupleDestructStmt>(prog[0]));
+    const auto &s = std::get<TupleDestructStmt>(prog[0]);
+    ASSERT_EQ(s.names.size(), 2u);
+    EXPECT_EQ(s.names[0], "a");
+    EXPECT_EQ(s.names[1], "b");
+    EXPECT_FALSE(s.is_immutable);
+}
+
+TEST(ParserTest, ParenTupleDestructThree) {
+    Program prog = parseStr("(a, b, c) = (1, 2, 3)");
+    const auto &s = std::get<TupleDestructStmt>(prog[0]);
+    ASSERT_EQ(s.names.size(), 3u);
+    EXPECT_EQ(s.names[2], "c");
+}
+
+TEST(ParserTest, ParenTupleDestructWildcard) {
+    Program prog = parseStr("(_, b) = (10, 20)");
+    const auto &s = std::get<TupleDestructStmt>(prog[0]);
+    ASSERT_EQ(s.names.size(), 2u);
+    EXPECT_EQ(s.names[0], "_");
+    EXPECT_EQ(s.names[1], "b");
+}
+
+TEST(ParserTest, ParenTupleDestructConst) {
+    Program prog = parseStr("@const\n(a, b) = (1, 2)");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<TupleDestructStmt>(prog[0]));
+    const auto &s = std::get<TupleDestructStmt>(prog[0]);
+    EXPECT_TRUE(s.is_immutable);
+    ASSERT_EQ(s.names.size(), 2u);
+    EXPECT_EQ(s.names[0], "a");
+}
+
+TEST(ParserTest, ParenTupleDestructSingleNameIsGroupingExpr) {
+    // `(a) = expr` must NOT be treated as tuple destructuring.
+    // The lookahead requires ≥1 comma (≥2 names). `(a)` alone falls through
+    // to expression-statement parsing, which then treats '=' as unexpected.
+    EXPECT_THROW(parseStr("(a) = 42"), std::runtime_error);
+}
+
+TEST(ParserTest, ParenTupleDestructRejectsArbitraryExprLhs) {
+    // `(a + b) = expr` is not a tuple destructure — the lookahead rejects
+    // non-ident tokens and falls through to expression parsing.
+    EXPECT_THROW(parseStr("(a + b) = 42"), std::runtime_error);
+}
+
+TEST(ParserTest, ParenTupleAsExpressionStatement) {
+    // Bare `(a, b)` (without `=`) stays an expression statement producing a
+    // TupleExpr — ensuring the lookahead did not consume tokens speculatively.
+    Program prog = parseStr("a = 1\nb = 2\n(a, b)");
+    ASSERT_EQ(prog.size(), 3u);
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(prog[2]));
+    const auto &es = std::get<ExprStmt>(prog[2]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<TupleExpr>>(es.expr->data));
+}
+
+TEST(ParserTest, ParenTupleDestructTrailingCommaRejected) {
+    // Single-name with trailing comma: the lookahead requires an identifier
+    // after each comma, so `(a,)` is not a valid destructure LHS.
+    EXPECT_THROW(parseStr("(a,) = (1,)"), std::runtime_error);
+}
+
 // ===== UFCS パーサーテスト =====
 
 TEST(ParserTest, UFCSBasic) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -860,6 +860,27 @@ TEST(ParserTest, ParenTupleDestructConst) {
     EXPECT_EQ(s.names[0], "a");
 }
 
+TEST(ParserTest, ParenTupleDestructConstSameLine) {
+    // Same-line form exercises the `parseDirectives` LParen-deferral guard:
+    // without it, `@const (a, b)` would be parsed as `@const(a, b)` directive
+    // args and the trailing `=` would trip the directive-not-supported error.
+    Program prog = parseStr("@const (a, b) = (1, 2)");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<TupleDestructStmt>(prog[0]));
+    const auto &s = std::get<TupleDestructStmt>(prog[0]);
+    EXPECT_TRUE(s.is_immutable);
+    ASSERT_EQ(s.names.size(), 2u);
+    EXPECT_EQ(s.names[0], "a");
+    EXPECT_EQ(s.names[1], "b");
+}
+
+TEST(ParserTest, ParenTupleDestructConstSameLineTrailingCommaRejected) {
+    // Same-line `@const (a,)` must still reject: lookahead returns false (no
+    // second Ident after comma), parseDirectives falls back to treating `(..)`
+    // as directive args, and the statement parser raises parserError.
+    EXPECT_THROW(parseStr("@const (a,) = (1,)"), std::runtime_error);
+}
+
 TEST(ParserTest, ParenTupleDestructSingleNameIsGroupingExpr) {
     // `(a) = expr` must NOT be treated as tuple destructuring.
     // The lookahead requires ≥1 comma (≥2 names). `(a)` alone falls through


### PR DESCRIPTION
## Summary

- Adds parser support for `(a, b) = expr` and `@const (a, b) = expr`, mirroring the bare form `a, b = expr` that already works and matching the output the formatter has been producing
- Fixes a latent `formatTupleDestruct` bug that emitted a stray `: ` between the pattern and `=`, which only surfaced now that the parser accepts the parenthesized form (formatter → parser round-trip would otherwise fail)
- Resolves #1189

## Implementation

- `src/parser_expr.cpp`: new `looksLikeParenthesizedTupleDestructure()` lookahead predicate — accepts only the shape `LParen Ident (Comma Ident)+ RParen Equals` (≥2 names, so it never collides with grouping `(a)` or 1-tuple `(a,)`)
- `src/parser.cpp`:
  - `parseDirectives()`: defer `LParen` consumption when the lookahead matches, so `@const (a, b) = expr` is not misparsed as `@const(a, b)` with positional args
  - `parseStatement()`: new branch, placed before the directive gate so `@const` passes through; builds `TupleDestructStmt` with `is_immutable = hasDirective(directives, "const")`
- `src/formatter_stmt.cpp`: remove the stray `: ` emission in `formatTupleDestruct`
- Codegen / sema: unchanged — the existing `TupleDestructStmt` path (`emitStmt`) already handles `is_immutable`, `_` wildcard, arity, and directive validation

## Test plan

- [x] `./build/ry_tests` — all 1836 tests pass (includes 8 new parser tests + 1 new formatter round-trip test)
- [x] `./build/ry test -p` — all 159 spec files pass (new spec: `tests/spec/tuple_destructure_assign_parens.test.ry` with 8 cases: basic / 3-tuple / function-return repro / `_` wildcard (both sides) / `@const` / mixed types / regression guard for bare form)
- [x] ASan + UBSan (`./build-asan/ry_tests` and `./build-asan/ry test -p`) — clean
- [x] TSan (`./build-tsan/ry_tests`) — clean
- [x] libFuzzer 60s × 3 targets (`fuzz_parser`, `fuzz_json`, `fuzz_utf8`) — clean
- [x] Issue repro manually verified: `(lo, hi) = min_max([3, 1, 4])` and `@const (a, b) = (10, 20)` both work
- [x] Formatter round-trip manually verified via `./build/ry fmt` on `(a, b) = …`, `@const (c, d) = …`, `(_, e) = …`

## Out of scope (follow-up if requested)

- 1-tuple parenthesized form `(a,) = expr`
- Nested patterns `((a, b), c) = expr`
- Compound assignment with parenthesized LHS `(a, b) += expr`
- Type annotations in the pattern `(a: int, b: str) = …`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parenthesized tuple destructuring assignments supported (e.g., `(a, b) = expr`), including `@const` variants; `_` can skip components.

* **Bug Fixes**
  * Formatter now renders parenthesized tuple destructures correctly (no stray delimiter between `)` and `=`).

* **Documentation**
  * Control-flow and directive docs updated with parenthesized destructuring examples and clarifications.

* **Tests**
  * Added parser and formatter tests to cover parenthesized tuple destructuring and round-trip formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->