### PR TITLE
fix: make is_match perform partial (unanchored) search (#1197)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1933,6 +1933,13 @@ no generation. This means the existing Thompson simulator ignores them at zero c
 The `CaptureBacktracker` (used only when `$N` appears in the replacement) uses the same NFA
 graph and reads these states explicitly.
 
+### UFCS regex functions must dispatch to a dedicated `__ry_regex_<verb>` runtime symbol — never alias to the legacy `regex_*` form
+
+**Source**: #1197 (2026-04-19, implementation)
+**Tags**: regex, codegen, api-naming, ufcs, dispatch
+
+**Rule**: Each unprefixed UFCS regex function (`is_match`, `search`, `replace`, `split`, `find_all`) must dispatch to a dedicated `__ry_regex_<verb>` runtime symbol whose semantics literally match the function's name. Never alias a UFCS form to the `regex_*` legacy form's runtime symbol — the two can have different semantics (e.g. `is_match` is partial/unanchored search, but `regex_match` is full-string match). When adding a new UFCS regex function, add a matching `__ry_regex_<verb>` C entry point in `src/runtime_regex.cpp` + `include/ry/runtime_regex.hpp` and cover it directly in `tests/test_regex_runtime.cpp` — do not rely on a shared symbol and a LLVM `Trunc` to paper over a semantic mismatch.
+
 ---
 
 ## Build / CI

--- a/changelog.d/1197-is-match-partial-search.md
+++ b/changelog.d/1197-is-match-partial-search.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `is_match(text, /pattern/)` now performs **partial (unanchored) search** — it returns `true` if the pattern matches anywhere in the text, consistent with its name and with `search()` / `regex_search()`. Previously it performed a full-string match. To require a full-string match, anchor the pattern explicitly with `^` and `$` (e.g. `/^[a-z]+$/`). The legacy string-pattern `regex_match(text, pattern)` is unchanged and still requires a full-string match (#1197).

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -55,7 +55,7 @@ These functions take a regex literal pattern and use text-first argument order f
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `is_match` | `(str, Regex) -> bool` | Returns whether the entire text matches the pattern |
+| `is_match` | `(str, Regex) -> bool` | Returns whether the pattern matches anywhere in the text (use `^...$` to require a full-string match) |
 | `search` | `(str, Regex) -> int` | Returns the start position of the first match (-1 if not found) |
 | `replace` | `(str, Regex, str) -> str` | Replaces all matches with a replacement string |
 | `split` | `(str, Regex) -> List<str>` | Splits text by pattern matches |
@@ -66,6 +66,7 @@ from regex import is_match, search, replace, split, find_all
 
 # Direct call
 print(is_match("hello", /[a-z]+/))       # true
+print(is_match("Hello 123 World", /[0-9]+/))  # true — partial (unanchored) match
 
 # UFCS (text.function(pattern))
 print("abc123".search(/[0-9]+/))          # 3

--- a/include/ry/runtime_regex.hpp
+++ b/include/ry/runtime_regex.hpp
@@ -16,6 +16,10 @@ int64_t __ry_regex_match(const char *pattern, int64_t patternLen,
 int64_t __ry_regex_search(const char *pattern, int64_t patternLen,
                            const char *text,    int64_t textLen);
 
+// Like __ry_regex_match but unanchored (searches anywhere in text), not full-string.
+int64_t __ry_regex_is_match(const char *pattern, int64_t patternLen,
+                             const char *text,    int64_t textLen);
+
 // Replace all occurrences: returns a StringHeader-managed string.
 const char *__ry_regex_replace(const char *pattern,     int64_t patternLen,
                                 const char *text,        int64_t textLen,

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -94,9 +94,9 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
     };
 
     if (e.callee == "is_match" && e.args.size() == 2) {
-        if (auto *r = emitUfcsRegex("regex_match",
+        if (auto *r = emitUfcsRegex("regex_is_match",
                                     fnTy_ptr_i64_ptr_i64_to_i64_))
-            return builder_.CreateTrunc(r, i1Ty_, "regex_match_bool");
+            return builder_.CreateTrunc(r, i1Ty_, "is_match_bool");
     }
     if (e.callee == "search" && e.args.size() == 2) {
         if (auto *r = emitUfcsRegex("regex_search",

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -901,6 +901,11 @@ int64_t __ry_regex_search(const char *pattern, int64_t patternLen,
     return result.first;
 }
 
+int64_t __ry_regex_is_match(const char *pattern, int64_t patternLen,
+                             const char *text,    int64_t textLen) {
+    return __ry_regex_search(pattern, patternLen, text, textLen) >= 0 ? 1 : 0;
+}
+
 const char *__ry_regex_replace(const char *pattern,     int64_t patternLen,
                                 const char *text,        int64_t textLen,
                                 const char *replacement, int64_t replacementLen) {

--- a/tests/spec/regex_literal.test.ry
+++ b/tests/spec/regex_literal.test.ry
@@ -1,14 +1,18 @@
 from regex import is_match, search, replace, split, find_all
 
 describe("regex literal match", ():
-  it("should perform full match", ():
+  it("should perform partial (unanchored) match", ():
     expect(is_match("hello", /[a-z]+/)).to_eq(true)
     expect(is_match("123", /[a-z]+/)).to_eq(false)
     expect(is_match("123", /[0-9]+/)).to_eq(true)
+    # #1197: partial match — pattern matches anywhere in text
+    expect(is_match("Hello 123 World", /[0-9]+/)).to_eq(true)
+    expect(is_match("no digits here", /[0-9]+/)).to_eq(false)
   )
-  it("should support UFCS for match", ():
+  it("should support UFCS for partial match", ():
     expect("hello".is_match(/[a-z]+/)).to_eq(true)
     expect("123".is_match(/[a-z]+/)).to_eq(false)
+    expect("Hello 123 World".is_match(/[0-9]+/)).to_eq(true)
   )
 )
 

--- a/tests/test_regex_runtime.cpp
+++ b/tests/test_regex_runtime.cpp
@@ -54,6 +54,9 @@ static int64_t rm(const char *p, const char *t) {
 static int64_t rs(const char *p, const char *t) {
     return __ry_regex_search(p, (int64_t)strlen(p), t, (int64_t)strlen(t));
 }
+static int64_t rim(const char *p, const char *t) {
+    return __ry_regex_is_match(p, (int64_t)strlen(p), t, (int64_t)strlen(t));
+}
 static const char *rr(const char *p, const char *t, const char *r) {
     return __ry_regex_replace(p, (int64_t)strlen(p), t, (int64_t)strlen(t),
                               r, (int64_t)strlen(r));
@@ -788,4 +791,41 @@ TEST(RegexNul, PatternWithNul) {
     const char bad[]  = {'a', 'X',  'b'};
     EXPECT_EQ(__ry_regex_match(pat, 3, text, 3), 1);
     EXPECT_EQ(__ry_regex_match(pat, 3, bad,  3), 0);
+}
+
+// ============================================================
+// __ry_regex_is_match tests — partial (unanchored) match semantics (#1197)
+// ============================================================
+
+TEST(RegexRuntime, IsMatchPartial_FoundAnywhere) {
+    EXPECT_EQ(rim("[0-9]+", "Hello 123 World"), 1);
+    EXPECT_EQ(rim("World",  "Hello 123 World"), 1);
+    EXPECT_EQ(rim("Hello",  "Hello 123 World"), 1);
+}
+
+TEST(RegexRuntime, IsMatchPartial_FullInputMatch) {
+    EXPECT_EQ(rim("[a-z]+", "hello"), 1);
+    EXPECT_EQ(rim("[0-9]+", "123"),   1);
+}
+
+TEST(RegexRuntime, IsMatchPartial_NoMatch) {
+    EXPECT_EQ(rim("[a-z]+", "123"),            0);
+    EXPECT_EQ(rim("[0-9]+", "no digits here"), 0);
+}
+
+TEST(RegexRuntime, IsMatchPartial_DifferentFromFullMatch) {
+    // Key API contract: is_match is partial, regex_match is full-string.
+    EXPECT_EQ(rim("[0-9]+", "abc123def"), 1);
+    EXPECT_EQ(rm ("[0-9]+", "abc123def"), 0);
+}
+
+TEST(RegexRuntime, IsMatchPartial_NullInputs) {
+    EXPECT_EQ(__ry_regex_is_match(nullptr, 0, "text", 4), 0);
+    EXPECT_EQ(__ry_regex_is_match("[a-z]+", 6, nullptr, 0), 0);
+}
+
+TEST(RegexRuntime, IsMatchPartial_NULInSubject) {
+    // "a.b" (. matches any byte including NUL) should match "a<NUL>b" anywhere
+    const char subj[] = {'X', 'a', '\0', 'b', 'Y'};
+    EXPECT_EQ(__ry_regex_is_match("a.b", 3, subj, 5), 1);
 }


### PR DESCRIPTION
## Summary

- `is_match(text, /pattern/)` now performs **partial (unanchored) search**, returning `true` if the pattern matches anywhere in the text — consistent with its name and with `search()` / `regex_search()`.
- Root cause: UFCS `is_match` codegen aliased to `__ry_regex_match` (full-match), sharing the runtime symbol with the legacy string-pattern API despite different semantics.
- Fix: add dedicated `__ry_regex_is_match` C entry point (delegates to `__ry_regex_search(...) >= 0`), and route the UFCS dispatch through it. Legacy `regex_match(text, pattern)` unchanged.

## Test plan

- [x] C++ tests: 6 new `RegexRuntime.IsMatchPartial_*` cases (incl. null-input & NUL-in-subject)
- [x] Ry self-test: partial / UFCS canaries added to `tests/spec/regex_literal.test.ry`
- [x] Full suite pass: default + ASan+UBSan + TSan (`ry_tests` + `ry test -p`)
- [x] libFuzzer parser/json/utf8 60s each, exit 0
- [x] E2E repro confirmed: `is_match("Hello 123 World", /[0-9]+/)` → `true`
- [x] Docs updated: `docs/reference/regex.md` description + partial-match example
- [x] CHANGELOG fragment: `changelog.d/1197-is-match-partial-search.md` (`### Changed`)
- [x] KNOWLEDGE.md entry added under "Regex Engine" to prevent future UFCS-alias regressions

Closes #1197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated `is_match` documentation to clarify it now performs unanchored, partial matching—returning true when a pattern matches anywhere in the text. Full-string matching requires explicit anchors (`^` and `$`).

* **Tests**
  * Extended test coverage for `is_match` partial matching semantics, including edge cases and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->