### PR TITLE
fix: propagate nested element metadata in emitListSlice (#1205)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -953,6 +953,46 @@ check at `src/codegen_type.cpp:125` (`array element type must be a
 low-level type`), so ARC-managed collection element types are rejected
 at type resolution and never reach the compound path.
 
+### Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`
+
+**Source**: #1205 (2026-04-19, implementation); #961 precedent (map merge)
+**Tags**: codegen, metadata, ListHeader, MapHeader, propagateMeta, setTypeMeta, slice, appended, take, distinct
+
+**Context**: `setTypeMeta(TypeMeta::ListElem, newHeader, elemTy)` only
+records the LLVM-level element type. Source-level string metadata
+(`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`,
+`map_value_type_name`, etc.) is NOT touched. Without it, downstream
+code that needs source-level type names (nested indexing on the result,
+`valueToString` formatting, generic dispatch) silently falls through to
+defaults and emits confusing errors like "str does not support index
+access" for a legal `slice(xs, 0, 1)[0][0]` where `xs: List<List<int>>`.
+
+**Rule**: Helpers that allocate a new collection header and copy
+elements verbatim from a source collection of the **same element type**
+(slice, take, drop, appended, distinct, …) must call BOTH:
+
+1. `setTypeMeta(TypeMeta::ListElem, newHeader, elemTy)` — LLVM type
+2. `propagateMeta(src, newHeader)` — string names, `list_elem_fn_type_info`,
+   `nested_list_elem`, `map_value_type_name`, `resource_kinds`, etc.
+
+`propagateMeta` is rehash-safe by construction (`src/codegen_metadata.cpp:
+125-131` calls `getOrCreateMeta(dst)` first, then re-fetches `getMeta(src)`),
+so no local snapshot is required at the call site — unlike
+`propagateTypeMeta(name, val)` which IS subject to the #858 rehash-
+invalidation gotcha documented in the entry above.
+
+**Canonical references**: `src/codegen_call_collection.cpp:1204-1208`
+(map merge, #961) and `src/codegen_call_collection.cpp:555-558`
+(`emitListSlice`, #1205).
+
+**How to apply**: When adding or reviewing a collection helper that
+returns `List<SameT>` / `Map<SameK, SameV>` / `Set<SameT>`, confirm the
+trailing `setTypeMeta` block is followed by `propagateMeta(src,
+newHeader)`. Helpers that change element type (`flatten`, `enumerate`,
+`zip`, `map`) need a different approach — see the `enumerate`/`zip`
+precedent in `src/codegen_call.cpp:366-443` that manually constructs
+`list_elem_type_name = "(T1, T2)"`.
+
 ### New dispatch branches in `emitArithmeticOp` must precede the str-vs-non-str reject
 
 **Source**: #863 (2026-04-11)
@@ -4116,7 +4156,7 @@ compile-time-enforced distinction. The guard at VariablePattern binding
 **Follow-up**: Add a lossless `source_type_name` field to `ValueMetadata` so
 `Option<List<int>>` reconstruction is accurate, enabling ARC Path 2a for nested
 generics (currently handled by Path 2b heuristic via `propagateMeta`).
-- Pre-existing defects in `emitListSlice`: ARC retain omitted for reference-typed elements (#1204), nested TypeMeta not propagated (#1205) — tracked separately.
+- Pre-existing defect in `emitListSlice`: ARC retain omitted for reference-typed elements (#1204) — tracked separately.
 
 ### All str handles passed to `emitStringByteLen` must be StringHeader-backed (#1159)
 

--- a/changelog.d/1205-emit-list-slice-nested-typemeta.md
+++ b/changelog.d/1205-emit-list-slice-nested-typemeta.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Fix `lst[a..b]` and `slice(lst, a, b)` losing nested element metadata
+  (`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`,
+  `map_value_type_name`) when slicing collections such as
+  `List<List<int>>`, `List<Map<str, int>>`, or `List<function>`.
+  Second-level access on the resulting slice (e.g.
+  `slice(xs, 0, 1)[0][0]`) now works correctly. (#1205)

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -554,6 +554,7 @@ llvm::Value *CodeGen::emitListSlice(llvm::Value *listPtr,
 
     storeListHeaderFields(newHeader, count, count, newData);
     setTypeMeta(TypeMeta::ListElem, newHeader, elemTy);
+    propagateMeta(listPtr, newHeader);
     return newHeader;
 }
 

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -44,6 +44,13 @@ describe("List", ():
     expect(ys[0]).to_eq(2)
     expect(ys[1]).to_eq(3)
   )
+  it("slice preserves nested List<List<int>> element metadata (#1205)", ():
+    xs = [[1, 2], [3, 4], [5, 6]]
+    ys = slice(xs, 0, 2)
+    expect(ys).to_have_length(2)
+    expect(ys[0][0]).to_eq(1)
+    expect(ys[1][1]).to_eq(4)
+  )
   it("should filter", ():
     xs = [1, 2, 3, 4, 5]
     ys = filter(xs, (x: int) => x > 3)

--- a/tests/spec/list_range_index.test.ry
+++ b/tests/spec/list_range_index.test.ry
@@ -61,14 +61,26 @@ describe("list range-index lst[a..b] (#1184)", ():
     expect(ys[0]).to_eq("b")
     expect(ys[1]).to_eq("c")
   )
-  # NOTE: nested List<List<int>> second-level index is disabled pending #1205
-  # (emitListSlice drops list_elem_type_name / nested TypeMeta).
-  # The same defect exists in slice() — slice([[1,2],[3,4]],0,2)[0][0] fails too.
-  # Re-enable ys[0][0] / ys[1][1] assertions after #1205 is fixed.
-  it("range over List<List<int>> preserves outer length", ():
+  it("range over List<List<int>> preserves nested element metadata (#1205)", ():
     xs = [[1, 2], [3, 4], [5, 6]]
     ys = xs[0..1]
     expect(ys).to_have_length(2)
+    expect(ys[0][0]).to_eq(1)
+    expect(ys[1][1]).to_eq(4)
+  )
+  it("range over List<Map<str,int>> preserves map value access (#1205)", ():
+    xs: List<Map<str, int>> = [{"a": 1}, {"b": 2}, {"c": 3}]
+    ys = xs[0..1]
+    expect(ys).to_have_length(2)
+    expect(ys[0]["a"]).to_eq(1)
+    expect(ys[1]["b"]).to_eq(2)
+  )
+  it("range over List<function> preserves closure invocation (#1205)", ():
+    xs: List<function(int) -> int> = [(x: int) => x + 1, (x: int) => x * 2]
+    ys = xs[0..0]
+    expect(ys).to_have_length(1)
+    f = ys[0]
+    expect(f(5)).to_eq(6)
   )
   it("consistency with slice: lst[a..b] == slice(lst, a, b+1) for non-negatives", ():
     xs = [10, 20, 30, 40, 50]


### PR DESCRIPTION
## Summary

- Fix `emitListSlice` losing source-level type metadata (`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`, `map_value_type_name`) when slicing collections.
- Affects both `slice(lst, a, b)` and `lst[a..b]` since they share `emitListSlice` (introduced by #1184).
- Single-line fix: add `propagateMeta(listPtr, newHeader)` after the existing `setTypeMeta` call. Pattern mirrors the canonical map-merge precedent at `src/codegen_call_collection.cpp:1204-1208`.

Closes #1205.

## Reproduction (now passing)

```ry
xs: List<List<int>> = [[1, 2], [3, 4]]
ys = slice(xs, 0, 1)
print(ys[0][0])  # was: error "str does not support index access"; now: 1

ys2 = xs[0..0]
print(ys2[0][0])  # was: same error; now: 1
```

## Test plan

- [x] New test `tests/spec/list_range_index.test.ry` — `List<List<int>>`, `List<Map<str,int>>`, `List<function(int) -> int>` ranges
- [x] New test `tests/spec/collections.test.ry` — nested `slice()` over `List<List<int>>`
- [x] Removed stale `NOTE: ... pending #1205` comment
- [x] `./build/ry_tests` (C++ tests) — pass
- [x] `./build/ry test -p` (Ry self-tests) — pass
- [x] ASan + UBSan — clean
- [x] TSan — clean (C++ tests required, self-test warn-only per upstream allocator bug)
- [x] libFuzzer 60s × 3 (parser / json / utf8) — no crashes
- [x] E2E reproduction from issue body — outputs `1\n1`

## Scope-out

Audit found the same defect class in three sibling helpers; filed as separate issues per the 1-issue ≈ 1-PR convention:

- #1239 — `emitCollOp_appended` (`src/codegen_call_collection.cpp:464`)
- #1240 — `emitCollOp_take_impl` (`src/codegen_call_collection.cpp:597`)
- #1241 — `emitCollOp_distinct` (`src/codegen_call_collection.cpp:864`)

`emitListSlice`'s separate ARC retain defect (#1204) remains tracked separately.

## Documentation

- `changelog.d/1205-emit-list-slice-nested-typemeta.md` — user-facing fix note
- `KNOWLEDGE.md` — new entry "Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`" documenting the rule and rehash-safety of `propagateMeta` (vs `propagateTypeMeta` #858 gotcha)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed list slicing operations to preserve nested element metadata for nested collections (e.g., `List<List<int>>`, `List<Map<str, int>>`), enabling proper access to nested elements after slicing. Subsequent indexing operations on sliced results now work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->