### PR TITLE
fix: resolve negative indices in slice() via Python-style wrap (#1198)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -4270,6 +4270,7 @@ This avoids materialising the intermediate `List<i64>` entirely.
 **Related helpers**:
 - `emitListSlice(listPtr, startVal, endExclVal, elemTy)` (`src/codegen_call_collection.cpp`) — shared between `slice()` builtin and `lst[a..b]`. Clamps internally.
 - `emitNegativeIndexWrap(idx, len, prefix)` (`src/codegen_call_user.cpp:645`) — use prefix `"ri_start"` / `"ri_end"` to avoid label collision with scalar-index prefix `"index"`.
+- **#1198**: `emitCollOp_slice` was missing the pre-wrap step required by this contract (negatives were passed raw to `emitListSlice`, which clamps to `[0, len]` → `-3` collapsed to `0`). Fixed by applying `emitNegativeIndexWrap(start, len, "sl_start")` / `emitNegativeIndexWrap(end, len, "sl_end")` before the `emitListSlice` call, mirroring the range-index route. The `emitListSlice` invariant ("caller pre-wraps, I clamp") now applies to both call sites. `substring(s, a, b)` has the same 0-clamp bug tracked separately as #1213.
 
 ---
 

--- a/changelog.d/1198-slice-negative-index.md
+++ b/changelog.d/1198-slice-negative-index.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `slice(lst, start, end)` now resolves negative `start` / `end` as offsets from the end of the list (`length + idx`), consistent with Python-style indexing, subscript access, and the `lst[a..b]` range-index operator (#1184). Over-negative inputs are silently clamped to `0`. (#1198)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -478,12 +478,14 @@ print(xs)   # [1, 2, 3] (unchanged)
 
 **Signature:** `slice(list: List<T>, start: int, end: int) -> List<T>`
 
-Returns a new sub-list from `start` (inclusive) to `end` (exclusive). Indices are clamped to the valid range (`0` to `length(list)`). UFCS notation is also available.
+Returns a new sub-list covering `[start, end)` (end exclusive). Negative indices are resolved as `length + idx` (Python-style, consistent with `lst[-1]` and `lst[a..b]`). The resolved range is then silently clamped to `[0, length(list)]`. UFCS notation is also available.
 
 ```ry
 xs = [1, 2, 3, 4, 5]
 print(slice(xs, 1, 3))     # [2, 3]
-print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (clamped)
+print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (end clamped)
+print(slice(xs, -2, 5))    # [4, 5]  (negative start wraps to index 3)
+print(slice(xs, -4, -1))   # [2, 3, 4]  (both bounds wrap)
 ```
 
 ---

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -242,12 +242,14 @@ print(xs)            # [1, 2, 3] (unchanged)
 
 ### slice
 
-Returns a new sub-list from `start` (inclusive) to `end` (exclusive). Indices are clamped to the valid range.
+Returns a new sub-list covering `[start, end)` (end exclusive). Negative indices are resolved as `length + idx` (Python-style, consistent with `lst[-1]`). The resolved range is then silently clamped to `[0, length(list)]`.
 
 ```ry
 xs = [1, 2, 3, 4, 5]
 print(slice(xs, 1, 3))     # [2, 3]
-print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (clamped)
+print(slice(xs, 0, 100))   # [1, 2, 3, 4, 5] (end clamped)
+print(slice(xs, -2, 5))    # [4, 5]  (negative start wraps to index 3)
+print(slice(xs, -4, -1))   # [2, 3, 4]  (both bounds wrap)
 ```
 
 You can also use the `..` range operator as a list index for an equivalent, more concise syntax. `lst[a..b]` is inclusive on both ends and is equivalent to `slice(lst, a, b + 1)`. Negative indices wrap against the list length (like `lst[-1]`), and out-of-bounds bounds are clamped.

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -514,8 +514,11 @@ llvm::Value *CodeGen::emitCollOp_slice(const CallExpr &e) {
     if (!elemTy) return nullptr;
     llvm::Value *startVal = emitExpr(*e.args[1]);
     llvm::Value *endVal   = emitExpr(*e.args[2]);
-    // slice() builtin is [start, end) exclusive — pass endVal unchanged.
-    return emitListSlice(listPtr, startVal, endVal, elemTy);
+    llvm::Value *length = loadListHeader(listPtr, "sc").len;
+    llvm::Value *startWrapped = emitNegativeIndexWrap(startVal, length, "sl_start");
+    llvm::Value *endWrapped   = emitNegativeIndexWrap(endVal,   length, "sl_end");
+    // slice() builtin is [start, end) exclusive — no +1 adjustment.
+    return emitListSlice(listPtr, startWrapped, endWrapped, elemTy);
 }
 
 llvm::Value *CodeGen::emitListSlice(llvm::Value *listPtr,

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -517,7 +517,6 @@ llvm::Value *CodeGen::emitCollOp_slice(const CallExpr &e) {
     llvm::Value *length = loadListHeader(listPtr, "sc").len;
     llvm::Value *startWrapped = emitNegativeIndexWrap(startVal, length, "sl_start");
     llvm::Value *endWrapped   = emitNegativeIndexWrap(endVal,   length, "sl_end");
-    // slice() builtin is [start, end) exclusive — no +1 adjustment.
     return emitListSlice(listPtr, startWrapped, endWrapped, elemTy);
 }
 

--- a/tests/spec/bounds_check.test.ry
+++ b/tests/spec/bounds_check.test.ry
@@ -108,4 +108,47 @@ describe("bounds checking", ():
       expect(xs).to_have_length(2)
     )
   )
+
+  describe("slice negative index", ():
+    it("should wrap negative start (-3) for slice", ():
+      xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      ys = slice(xs, -3, 10)
+      expect(ys).to_have_length(3)
+      expect(ys[0]).to_eq(7)
+      expect(ys[1]).to_eq(8)
+      expect(ys[2]).to_eq(9)
+    )
+    it("should wrap negative end (-1) for slice", ():
+      xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      ys = slice(xs, 0, -1)
+      expect(ys).to_have_length(9)
+      expect(ys[0]).to_eq(0)
+      expect(ys[8]).to_eq(8)
+    )
+    it("should wrap both negative bounds for slice", ():
+      xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+      ys = slice(xs, -5, -2)
+      expect(ys).to_have_length(3)
+      expect(ys[0]).to_eq(5)
+      expect(ys[1]).to_eq(6)
+      expect(ys[2]).to_eq(7)
+    )
+    it("should clamp over-negative start to 0", ():
+      xs = [1, 2, 3]
+      ys = slice(xs, -100, 2)
+      expect(ys).to_have_length(2)
+      expect(ys[0]).to_eq(1)
+      expect(ys[1]).to_eq(2)
+    )
+    it("should return empty slice when end clamps below start", ():
+      xs = [1, 2, 3]
+      ys = slice(xs, 1, -100)
+      expect(ys).to_have_length(0)
+    )
+    it("should return empty slice when start > end after wrap", ():
+      xs = [1, 2, 3]
+      ys = slice(xs, -2, -3)
+      expect(ys).to_have_length(0)
+    )
+  )
 )

--- a/tests/spec/bounds_check.test.ry
+++ b/tests/spec/bounds_check.test.ry
@@ -110,7 +110,7 @@ describe("bounds checking", ():
   )
 
   describe("slice negative index", ():
-    it("should wrap negative start (-3) for slice", ():
+    it("should wrap negative start (-3)", ():
       xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
       ys = slice(xs, -3, 10)
       expect(ys).to_have_length(3)
@@ -118,14 +118,14 @@ describe("bounds checking", ():
       expect(ys[1]).to_eq(8)
       expect(ys[2]).to_eq(9)
     )
-    it("should wrap negative end (-1) for slice", ():
+    it("should wrap negative end (-1)", ():
       xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
       ys = slice(xs, 0, -1)
       expect(ys).to_have_length(9)
       expect(ys[0]).to_eq(0)
       expect(ys[8]).to_eq(8)
     )
-    it("should wrap both negative bounds for slice", ():
+    it("should wrap both negative bounds", ():
       xs = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
       ys = slice(xs, -5, -2)
       expect(ys).to_have_length(3)
@@ -140,12 +140,12 @@ describe("bounds checking", ():
       expect(ys[0]).to_eq(1)
       expect(ys[1]).to_eq(2)
     )
-    it("should return empty slice when end clamps below start", ():
+    it("should return empty when end clamps below start", ():
       xs = [1, 2, 3]
       ys = slice(xs, 1, -100)
       expect(ys).to_have_length(0)
     )
-    it("should return empty slice when start > end after wrap", ():
+    it("should return empty when start > end after wrap", ():
       xs = [1, 2, 3]
       ys = slice(xs, -2, -3)
       expect(ys).to_have_length(0)

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -1274,15 +1274,12 @@ TEST_F(CodeGenTest, ListSliceVariants) {
 }
 
 TEST_F(CodeGenTest, ListSliceNegativeIndex) {
-    // Negative start wraps to len+start: issue #1198 examples
     EXPECT_EQ(runSource("print(slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], -3, 10))"), "[7, 8, 9]\n");
     EXPECT_EQ(runSource("print(slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 0, -1))"),
               "[0, 1, 2, 3, 4, 5, 6, 7, 8]\n");
     EXPECT_EQ(runSource("print(slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], -5, -2))"), "[5, 6, 7]\n");
-    // Over-negative silently clamps to 0
     EXPECT_EQ(runSource("print(slice([1, 2, 3], -100, 2))"), "[1, 2]\n");
     EXPECT_EQ(runSource("print(slice([1, 2, 3], 1, -100))"), "[]\n");
-    // start > end after wrap → empty
     EXPECT_EQ(runSource("print(slice([1, 2, 3], -2, -3))"), "[]\n");
 }
 

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -1273,6 +1273,19 @@ TEST_F(CodeGenTest, ListSliceVariants) {
     EXPECT_EQ(runSource("print(slice([1, 2, 3], 2, 2))"), "[]\n");
 }
 
+TEST_F(CodeGenTest, ListSliceNegativeIndex) {
+    // Negative start wraps to len+start: issue #1198 examples
+    EXPECT_EQ(runSource("print(slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], -3, 10))"), "[7, 8, 9]\n");
+    EXPECT_EQ(runSource("print(slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], 0, -1))"),
+              "[0, 1, 2, 3, 4, 5, 6, 7, 8]\n");
+    EXPECT_EQ(runSource("print(slice([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], -5, -2))"), "[5, 6, 7]\n");
+    // Over-negative silently clamps to 0
+    EXPECT_EQ(runSource("print(slice([1, 2, 3], -100, 2))"), "[1, 2]\n");
+    EXPECT_EQ(runSource("print(slice([1, 2, 3], 1, -100))"), "[]\n");
+    // start > end after wrap → empty
+    EXPECT_EQ(runSource("print(slice([1, 2, 3], -2, -3))"), "[]\n");
+}
+
 // ===== filter テスト =====
 
 TEST_F(CodeGenTest, FilterBasics) {


### PR DESCRIPTION
## Summary

- Closes #1198 — `slice(lst, start, end)` now resolves negative `start` / `end` as `length + idx`, consistent with `lst[-1]`, `remove_at(lst, -1)`, and the `lst[a..b]` range-index operator.
- Root cause: `emitCollOp_slice` (`src/codegen_call_collection.cpp`) passed raw bounds to `emitListSlice`, whose `[0, len]` clamp silently collapsed negatives to `0`. Mirrors the `lst[a..b]` RangeExpr path by applying `emitNegativeIndexWrap` before `emitListSlice`. The `emitListSlice` function (its "caller pre-wraps, I clamp" invariant) is untouched.
- Over-negative inputs (e.g. `-100` on a 3-element list) remain silently clamped to `0` via the existing `emitListSlice` clamp, matching Python semantics.

Note: this re-applies the fix from PR #1215 that was cleanly reverted in PR #1218 due to unrelated #1214 baseline issues. `substring(s, a, b)` has the same 0-clamp bug tracked separately as #1213 (out of scope).

## Test plan

- [x] TDD Red → Green: `./build/ry_tests --gtest_filter='CodeGenTest.ListSliceNegativeIndex'` (6 cases: issue's 3 examples + over-negative start/end clamp + `start > end` after wrap)
- [x] Regression: `CodeGenTest.ListSlice*` (existing `ListSliceVariants` still passes)
- [x] Spec: `tests/spec/bounds_check.test.ry` `describe("slice negative index")` (6 `it()` cases mirroring the C++ test)
- [x] Full suite: `./build/ry_tests && ./build/ry test -p`
- [x] ASan + UBSan: clean on `ry_tests` and `ry test -p`
- [x] TSan: clean on `ry_tests` (required); `ry test -p` warn-only per AGENTS.md
- [x] libFuzzer: parser / json / utf8 × 60s — all clean
- [x] Manual repro with issue's 3 cases (`-3,10` → `[7, 8, 9]`, `0,-1` → `[0,...,8]`, `-5,-2` → `[5, 6, 7]`)
- [x] Docs updated: `docs/reference/builtins.md`, `docs/reference/collections.md` (slice negative-index semantics + examples)
- [x] KNOWLEDGE.md #1184 entry extended with #1198 bullet
- [x] `changelog.d/1198-slice-negative-index.md` added (`### Fixed`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed slice() to interpret negative start/end as offsets from the end (Python-style) and to silently clamp overly negative indices to zero.

* **Documentation**
  * Clarified slice() semantics: half-open [start, end) range, negative-index resolution, and clamping behavior with updated examples.

* **Tests**
  * Added unit and spec tests covering negative-index wrapping, combined bounds, clamping, and empty-slice edge cases.

* **Changelog**
  * Added entry summarizing the negative-index slice fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->