### PR TITLE
fix: reject 'function operator +(...)' with space for symbolic operators (#1210)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -129,6 +129,17 @@ git diff origin/<base> -- 'src/**' 'include/**' \
 
 For each hit, confirm a test exists that executes that exact line.
 
+### New rejections that narrow a form need a positive test for the preserved sibling
+
+**Source**: #1210 (2026-04-20, implementation — advisor call-out)
+**Tags**: testing, tdd, parser-error, regression, expect-throw, blind-spot
+
+**Context**: In #1210, `parseFnStatement` was split so that `And` / `Or` / `Not` moved out of the symbolic operator arm (which gained a "no whitespace between `operator` and the symbol" adjacency check) into a keyword arm that still permits a space. Existing `EXPECT_THROW` tests for these keyword operators (`OperatorAndMustReturnBool`, `OperatorOrMustReturnBool`, `OperatorNotMustReturnBool` in `tests/test_parser.cpp`) throw on the bool-return-type check at `parser_decl.cpp:237`, not on parse acceptance. If the split had mistakenly left them under the adjacency-checked arm, those tests would still pass (for the wrong reason: both paths throw) and the regression would ship.
+
+**Rule**: When adding a rejection branch that narrows a previously legal form, and the legal sibling form is only exercised by `EXPECT_THROW` tests that throw on unrelated downstream validation (return type, parameter count, typecheck), add a positive `EXPECT_EQ(prog.size(), 1u)` test whose input satisfies every downstream check. That way the only possible failure is the new rejection itself, and the positive test actually proves the legal form still parses.
+
+**How to apply**: For #1210 this meant `OperatorAndKeywordAcceptsSpaceForm` (`-> bool` + valid params), `OperatorOrKeywordAcceptsSpaceForm`, `OperatorNotKeywordAcceptsSpaceForm`, `OperatorInKeywordAcceptsSpaceForm`, `OperatorAsKeywordAcceptsSpaceForm` alongside the four `OperatorXxxRejectsSpaceForm` negative tests for symbolic operators.
+
 ### Use `-> Unit` in @it/@describe rejection tests to isolate the directive check
 
 **Source**: #1122 (2026-04-18, implementation)

--- a/changelog.d/1210-operator-space.md
+++ b/changelog.d/1210-operator-space.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Reject `function operator +(...)` with whitespace between `operator` and a symbolic operator. Only the canonical `function operator+(...)` (no space) is now accepted for symbolic operators. Keyword operators (`in`, `as`, `and`, `or`, `not`) and bracket/call operators (`[]`, `[]=`, `()`) are unaffected. (#1210)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -717,6 +717,8 @@ function operator<op>(a: type) -> return_type:
     ...
 ```
 
+Symbolic operators (`+`, `-`, `*`, `==`, `+=`, etc.) must be written directly after `operator` with no whitespace: `operator+`, not `operator +`. Keyword operators (`in`, `as`, `and`, `or`, `not`) and bracket/call operators (`[]`, `[]=`, `()`) are written with the natural word/token boundary.
+
 ### Overloadable Operators
 
 | Category | Operators |

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -48,6 +48,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
     fnStmt->is_async = is_async;
 
     if (lex_.peek().kind == TokenKind::Operator) {
+        Token opKwTok = lex_.peek();
         lex_.next(); // consume 'operator'
         fnStmt->is_operator = true;
 
@@ -66,8 +67,6 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
             case TokenKind::Caret: case TokenKind::Tilde:
             case TokenKind::LessLess: case TokenKind::GreaterGreater:
             case TokenKind::GreaterGreaterGreater:
-            case TokenKind::And: case TokenKind::Or:
-            case TokenKind::Not:
             // Compound assignment operators
             case TokenKind::PlusEq: case TokenKind::MinusEq:
             case TokenKind::StarEq: case TokenKind::SlashEq:
@@ -75,9 +74,21 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
             case TokenKind::StarStarEq:
             case TokenKind::AmpEq: case TokenKind::PipeEq:
             case TokenKind::CaretEq:
-            case TokenKind::LessLessEq: case TokenKind::GreaterGreaterEq:
+            case TokenKind::LessLessEq: case TokenKind::GreaterGreaterEq: {
+                if (opTok.line != opKwTok.line ||
+                    opTok.col != opKwTok.col + static_cast<int>(opKwTok.value.size())) {
+                    parseError(opTok.line,
+                        "no whitespace allowed between 'operator' and symbolic operator '" +
+                        opTok.value + "' (write 'operator" + opTok.value + "')");
+                }
                 opName = opTok.value;
-                lex_.next(); // consume operator
+                lex_.next();
+                break;
+            }
+            case TokenKind::And: case TokenKind::Or:
+            case TokenKind::Not:
+                opName = opTok.value;
+                lex_.next();
                 break;
             case TokenKind::LBracket: {
                 lex_.next(); // consume '['

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1142,6 +1142,65 @@ TEST(ParserTest, OperatorPlusReturnsNonBoolOk) {
     EXPECT_EQ(prog.size(), 1u);
 }
 
+TEST(ParserTest, OperatorPlusRejectsSpaceForm) {
+    EXPECT_THROW(parseStr(
+        "function operator +(a: int, b: int) -> int:\n"
+        "    return a + b\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorEqEqRejectsSpaceForm) {
+    EXPECT_THROW(parseStr(
+        "function operator ==(a: int, b: int) -> bool:\n"
+        "    return true\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorPlusEqRejectsSpaceForm) {
+    EXPECT_THROW(parseStr(
+        "function operator +=(a: int, b: int) -> int:\n"
+        "    return a + b\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorTildeRejectsSpaceForm) {
+    EXPECT_THROW(parseStr(
+        "function operator ~(a: int) -> int:\n"
+        "    return a\n"), std::runtime_error);
+}
+
+TEST(ParserTest, OperatorAndKeywordAcceptsSpaceForm) {
+    Program prog = parseStr(
+        "function operator and(a: bool, b: bool) -> bool:\n"
+        "    return a\n");
+    EXPECT_EQ(prog.size(), 1u);
+}
+
+TEST(ParserTest, OperatorInKeywordAcceptsSpaceForm) {
+    Program prog = parseStr(
+        "function operator in(a: int, b: int) -> bool:\n"
+        "    return true\n");
+    EXPECT_EQ(prog.size(), 1u);
+}
+
+TEST(ParserTest, OperatorOrKeywordAcceptsSpaceForm) {
+    Program prog = parseStr(
+        "function operator or(a: bool, b: bool) -> bool:\n"
+        "    return a\n");
+    EXPECT_EQ(prog.size(), 1u);
+}
+
+TEST(ParserTest, OperatorNotKeywordAcceptsSpaceForm) {
+    Program prog = parseStr(
+        "function operator not(a: bool) -> bool:\n"
+        "    return a\n");
+    EXPECT_EQ(prog.size(), 1u);
+}
+
+TEST(ParserTest, OperatorAsKeywordAcceptsSpaceForm) {
+    Program prog = parseStr(
+        "function operator as(a: int) -> bool:\n"
+        "    return true\n");
+    EXPECT_EQ(prog.size(), 1u);
+}
+
 // ===== Compound assignment operator tests =====
 
 TEST(ParserTest, CompoundAssignPreservesOp) {


### PR DESCRIPTION
## Summary

- Reject `function operator +(...)` (and other symbolic operators written with whitespace between `operator` and the symbol). Only the canonical `function operator+(...)` form is accepted.
- Keyword operators (`in`, `as`, `and`, `or`, `not`) and bracket/call operators (`[]`, `[]=`, `()`) are unaffected — they continue to accept their natural word/token-boundary spelling.
- Implementation: `parseFnStatement` captures the `operator` token, then validates column adjacency (`opTok.col == opKwTok.col + len("operator")` on the same line) for symbolic kinds only. `And`/`Or`/`Not` were split out of the symbolic switch arm into a dedicated keyword arm.

Closes #1210

## Test plan

- [x] Added 4 negative `EXPECT_THROW` tests for symbolic operators with space (`+`, `==`, `+=`, `~`)
- [x] Added 5 positive `EXPECT_EQ(prog.size(), 1u)` tests for keyword operators with space (`and`, `in`, `or`, `not`, `as`) to lock in that the split preserves legal forms
- [x] `./build/ry_tests` — all 1877 C++ tests pass (including 27 `ParserTest.Operator*`)
- [x] `./build/ry test -p` — all 161 Ry self-test files pass
- [x] ASan + UBSan clean (`./build-asan/ry_tests`, `./build-asan/ry test -p`)
- [x] TSan clean (`./build-tsan/ry_tests`, `./build-tsan/ry test -p`)
- [x] libFuzzer 60s × 3 targets (`fuzz_parser`, `fuzz_json`, `fuzz_utf8`) — no crashes
- [x] CLI smoke: `function operator +(...)` rejected with clear error; `function operator+(...)` parses; `function operator in(...)` still parses

## Docs / metadata

- `docs/reference/functions.md` — added a one-paragraph note clarifying that symbolic operators take no whitespace while keyword operators take the natural word boundary
- `changelog.d/1210-operator-space.md` — new fragment under `### Fixed`
- `KNOWLEDGE.md` — added entry "New rejections that narrow a form need a positive test for the preserved sibling" (lesson from this fix: existing `EXPECT_THROW` tests for keyword operators throw on downstream type checks, not on parse acceptance, so the split needed explicit positive tests to prevent a regression shipping silently)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parser now correctly rejects operator declarations with whitespace between `operator` and symbolic operators (e.g., `operator +`), requiring the canonical form `operator+` instead. Keyword and bracket operators are unaffected.

* **Documentation**
  * Updated operator overloading guidelines specifying that symbolic operators must be written immediately after the `operator` keyword with no whitespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->