### PR TITLE
fix: resolve negative indices in substring() via Python-style wrap (#1199)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -4281,7 +4281,30 @@ This avoids materialising the intermediate `List<i64>` entirely.
 **Related helpers**:
 - `emitListSlice(listPtr, startVal, endExclVal, elemTy)` (`src/codegen_call_collection.cpp`) — shared between `slice()` builtin and `lst[a..b]`. Clamps internally.
 - `emitNegativeIndexWrap(idx, len, prefix)` (`src/codegen_call_user.cpp:645`) — use prefix `"ri_start"` / `"ri_end"` to avoid label collision with scalar-index prefix `"index"`.
-- **#1198**: `emitCollOp_slice` was missing the pre-wrap step required by this contract (negatives were passed raw to `emitListSlice`, which clamps to `[0, len]` → `-3` collapsed to `0`). Fixed by applying `emitNegativeIndexWrap(start, len, "sl_start")` / `emitNegativeIndexWrap(end, len, "sl_end")` before the `emitListSlice` call, mirroring the range-index route. The `emitListSlice` invariant ("caller pre-wraps, I clamp") now applies to both call sites. `substring(s, a, b)` has the same 0-clamp bug tracked separately as #1213.
+- **#1198**: `emitCollOp_slice` was missing the pre-wrap step required by this contract (negatives were passed raw to `emitListSlice`, which clamps to `[0, len]` → `-3` collapsed to `0`). Fixed by applying `emitNegativeIndexWrap(start, len, "sl_start")` / `emitNegativeIndexWrap(end, len, "sl_end")` before the `emitListSlice` call, mirroring the range-index route. The `emitListSlice` invariant ("caller pre-wraps, I clamp") now applies to both call sites.
+- **#1199**: `emitStrOp_substring` had the same 0-clamp bug on strings. Fixed by mirroring the slice pattern, with one extra step: `wrapBase` must be the UTF-8 codepoint count via `__ry_utf8_len_n(s, byteLen)`, not `emitStringByteLen(s)` (`"あいうえお"` is 5 chars / 15 bytes — using byte length wraps against the wrong base). See the sibling entry "String negative-index wrap uses UTF-8 char count, not byte length" below.
+
+---
+
+### String negative-index wrap uses UTF-8 char count, not byte length
+
+**Source**: PR #1199 fix for `emitStrOp_substring` (2026-04-20)
+**Tags**: codegen, substring, emitNegativeIndexWrap, UTF-8, char-count, __ry_utf8_len_n
+
+**Rule**: When applying `emitNegativeIndexWrap(idx, wrapBase, prefix)` to string (char) indices, `wrapBase` MUST be the UTF-8 codepoint count obtained via `__ry_utf8_len_n(s, byteLen)`, not `emitStringByteLen(s)`. For a 5-char, 15-byte string like `"あいうえお"`, using byte length as wrap base gives `-1 + 15 = 14` (a garbage index into a 5-char string); using char count gives `-1 + 5 = 4` (correct last-char index). The `_n` variant is NUL-safe (counts embedded `\0` as one codepoint).
+
+**Pattern** (copy from `src/codegen_call_string.cpp:218-245`):
+```cpp
+llvm::Value *byteLen = emitStringByteLen(s);    // hoisted: reused for runtime call
+auto utf8LenFn = getRuntimeFn("__ry_utf8_len_n", i64Ty_, {ptrTy_, i64Ty_});
+llvm::Value *charLen = builder_.CreateCall(utf8LenFn, {s, byteLen}, "charlen");
+llvm::Value *wrapped = emitNegativeIndexWrap(idx, charLen, "prefix");
+// ... then zero-clamp (wrap of very negative idx can still be negative), then runtime call
+```
+
+Always hoist `emitStringByteLen(s)` into a local so the same byte length feeds both `__ry_utf8_len_n` and the downstream string-indexed runtime call (e.g. `__ry_utf8_substring`). The zero-clamp after wrap is still required: `-100 + 5 = -95` needs to be clamped to `0`.
+
+**Why this differs from `emitCollOp_slice`**: `emitCollOp_slice` uses list length (element count = storage length), so there is no "byte vs codepoint" distinction. String call sites must remember this extra indirection.
 
 ---
 

--- a/changelog.d/1199-substring-negative-index.md
+++ b/changelog.d/1199-substring-negative-index.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `substring(s, start, end)` now resolves negative `start` / `end` as offsets from the end of the string (`length + idx`), consistent with Python-style indexing and matching `char_at()`, `slice()`, and `lst[-1]` subscript access. Over-negative inputs are silently clamped to `0`. (#1199)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -135,14 +135,15 @@ print(find("a\0b", "\0"))             # Some(1) (NUL-safe)
 
 Returns the substring of `string` from `start` to `end` (exclusive). Indices are character positions (UTF-8 aware).
 
-Out-of-range indices are clamped to `[0, length]`. If `end < start` after clamping, returns an empty string.
+Negative indices wrap Python-style: `-1` refers to the last character, `-2` to the second-to-last, etc. (`length + idx`). Indices are then clamped to `[0, length]`. If `end < start` after these adjustments, returns an empty string.
 
 ```ry
-print(substring("hello world", 0, 5))   # hello
-print(substring("hello world", 6, 11))  # world
-print("abcdef".substring(1, 4))         # bcd (UFCS)
-print(substring("hello", -1, 100))      # hello (clamped)
-print(substring("a\0b", 0, 3))          # "a\0b" (NUL byte is preserved)
+print(substring("hello world", 0, 5))       # hello
+print(substring("hello world", 6, 11))      # world
+print("abcdef".substring(1, 4))             # bcd (UFCS)
+print(substring("Hello, World", -5, 12))    # World       (-5 wraps to 7)
+print(substring("Hello, World", 0, -1))     # Hello, Worl (-1 wraps to 11)
+print(substring("a\0b", 0, 3))              # "a\0b" (NUL byte is preserved)
 ```
 
 ---

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -199,7 +199,7 @@ llvm::Value *CodeGen::emitStrOp_substring(const CallExpr &e) {
         codegenError("substring() requires str as first argument");
 
     // Fast path: both indices are compile-time constants satisfying sv >= 0, ev >= 0, ev >= sv.
-    // All three clamping selects are provably no-ops, so skip them and call the runtime directly.
+    // All wrap and clamp operations are provably no-ops, so skip them and call the runtime directly.
     if (auto *ciStart = llvm::dyn_cast<llvm::ConstantInt>(start)) {
         if (auto *ciEnd = llvm::dyn_cast<llvm::ConstantInt>(end)) {
             int64_t sv = ciStart->getSExtValue();
@@ -215,21 +215,31 @@ llvm::Value *CodeGen::emitStrOp_substring(const CallExpr &e) {
         }
     }
 
-    // Clamp start and end to be non-negative; let the runtime clamp to string length.
+    // Wrap negative indices Python-style (length + idx), then clamp the lower bound to 0.
+    // The upper bound clamp (end <= length) is performed by __ry_utf8_substring at runtime.
+    // wrapBase must be the UTF-8 codepoint count, not the byte length — multi-byte
+    // strings like "あいうえお" (5 chars / 15 bytes) otherwise wrap against the wrong base.
+    llvm::Value *byteLen = emitStringByteLen(s);
+    auto utf8LenFn = getRuntimeFn("__ry_utf8_len_n", i64Ty_, {ptrTy_, i64Ty_});
+    llvm::Value *charLen = builder_.CreateCall(utf8LenFn, {s, byteLen}, "substr_charlen");
+
+    llvm::Value *startWrapped = emitNegativeIndexWrap(start, charLen, "substr_start");
+    llvm::Value *endWrapped = emitNegativeIndexWrap(end, charLen, "substr_end");
+
     llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
 
     llvm::Value *clampedStart = builder_.CreateSelect(
-        builder_.CreateICmpSLT(start, zero), zero, start, "substr_cstart");
+        builder_.CreateICmpSLT(startWrapped, zero), zero, startWrapped, "substr_cstart");
 
     llvm::Value *clampedEnd = builder_.CreateSelect(
-        builder_.CreateICmpSLT(end, zero), zero, end, "substr_cend");
+        builder_.CreateICmpSLT(endWrapped, zero), zero, endWrapped, "substr_cend");
 
     // Ensure end >= start
     clampedEnd = builder_.CreateSelect(
         builder_.CreateICmpSLT(clampedEnd, clampedStart), clampedStart, clampedEnd, "substr_cend2");
 
     auto substrFn = getRuntimeFn("__ry_utf8_substring", ptrTy_, {ptrTy_, i64Ty_, i64Ty_, i64Ty_});
-    auto *r = builder_.CreateCall(substrFn, {s, emitStringByteLen(s), clampedStart, clampedEnd},
+    auto *r = builder_.CreateCall(substrFn, {s, byteLen, clampedStart, clampedEnd},
                                   "substring");
     arc_str_owned_values_.insert(r);
     return r;

--- a/tests/spec/bounds_check.test.ry
+++ b/tests/spec/bounds_check.test.ry
@@ -53,15 +53,27 @@ describe("bounds checking", ():
     )
   )
 
-  describe("substring clamping", ():
-    it("should clamp negative start to 0", ():
-      expect(substring("hello", -1, 3)).to_eq("hel")
+  describe("substring negative index / clamping", ():
+    it("should wrap negative start (Python-style)", ():
+      expect(substring("Hello, World", -5, 12)).to_eq("World")
+    )
+    it("should wrap negative end", ():
+      expect(substring("Hello, World", 0, -1)).to_eq("Hello, Worl")
+    )
+    it("should wrap both negative bounds", ():
+      expect(substring("Hello, World", -5, -1)).to_eq("Worl")
+    )
+    it("should clamp over-negative wrap result to 0", ():
+      expect(substring("hello", -100, 3)).to_eq("hel")
     )
     it("should clamp end beyond length", ():
       expect(substring("hello", 0, 100)).to_eq("hello")
     )
-    it("should return empty when end < start after clamping", ():
+    it("should return empty when end < start after wrap", ():
       expect(substring("hello", 3, 1)).to_eq("")
+    )
+    it("should wrap in UTF-8 string using char count", ():
+      expect(substring("あいうえお", -2, 5)).to_eq("えお")
     )
     it("should return normal substring", ():
       expect(substring("hello", 1, 4)).to_eq("ell")

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -72,8 +72,9 @@ describe("extraction and transformation", ():
     expect(substring("abc", 0, 100)).to_eq("abc")
     expect(substring("abc", 5, 10)).to_eq("")
   )
-  it("should clamp negative substring index to zero", ():
-    expect(substring("abc", -1, 2)).to_eq("ab")
+  it("should wrap negative substring index Python-style", ():
+    expect(substring("abc", -1, 3)).to_eq("c")
+    expect(substring("abc", -2, 3)).to_eq("bc")
   )
   it("should get char_at position", ():
     expect(char_at("hello", 0)).to_eq("h")

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2516,11 +2516,23 @@ TEST_F(CodeGenTest, StringCharAtUTF8OutOfRange) {
 }
 
 TEST_F(CodeGenTest, SubstringClamp) {
-    // Out-of-range values are clamped
-    EXPECT_EQ(runSource("print(substring(\"hello\", -1, 10))"), "hello\n");
+    // Negative indices wrap Python-style; over-negative wraps clamp to [0, length]
+    EXPECT_EQ(runSource("print(substring(\"hello\", -1, 10))"), "o\n");
     EXPECT_EQ(runSource("print(substring(\"hello\", 0, 100))"), "hello\n");
     EXPECT_EQ(runSource("print(substring(\"hello\", 3, 1))"), "\n");
-    EXPECT_EQ(runSource("print(substring(\"hello\", -5, -2))"), "\n");
+    EXPECT_EQ(runSource("print(substring(\"hello\", -5, -2))"), "hel\n");
+}
+
+TEST_F(CodeGenTest, SubstringNegativeIndexWrap) {
+    // #1199: Python-style wrap (length + idx) then clamp to [0, length]
+    EXPECT_EQ(runSource("print(substring(\"Hello, World\", -5, 12))"), "World\n");
+    EXPECT_EQ(runSource("print(substring(\"Hello, World\", 0, -1))"), "Hello, Worl\n");
+    EXPECT_EQ(runSource("print(substring(\"Hello, World\", -5, -1))"), "Worl\n");
+    // Over-negative: wrap result still negative, clamps to 0
+    EXPECT_EQ(runSource("print(substring(\"hello\", -100, 3))"), "hel\n");
+    // UTF-8: wrap base must be char count (5), not byte count (15)
+    EXPECT_EQ(runSource("print(substring(\"あいうえお\", -2, 5))"), "えお\n");
+    EXPECT_EQ(runSource("print(substring(\"あいうえお\", 0, -1))"), "あいうえ\n");
 }
 
 TEST_F(CodeGenTest, ArrayNegativeIndexWrap) {


### PR DESCRIPTION
## Summary

- `substring(s, start, end)` now treats negative `start` / `end` as offsets from the end of the string (Python-style wrap: `length + idx`), matching `char_at()`, `slice()` (#1198), and `lst[-1]` subscript access. Over-negative inputs are silently clamped to `0`. (Closes #1199)
- Mirrors the #1198 pattern (`emitNegativeIndexWrap` before the lower-bound zero-clamp) with one extra step: the wrap base must be the UTF-8 codepoint count via `__ry_utf8_len_n(s, byteLen)`, not the byte length. `"あいうえお"` is 5 chars but 15 bytes — byteLen as wrapBase would produce garbage indices.
- `byteLen` is hoisted into a local so the same value feeds both `__ry_utf8_len_n` and the downstream `__ry_utf8_substring` call.

## Behavior examples

```ry
@const s = "Hello, World"     # length 12
print(substring(s, -5, 12))   # "World"
print(substring(s, 0, -1))    # "Hello, Worl"
print(substring(s, -5, -1))   # "Worl"
print(substring(s, -100, 3))  # "hel"        (over-negative wraps clamp to 0)
print(substring("あいうえお", -2, 5))  # "えお"  (wrap against char count, not byte count)
```

## Test plan

- [x] `./build/ry_tests --gtest_filter='CodeGenTest.Substring*'` — `SubstringClamp` expectations updated to wrap semantics; new `SubstringNegativeIndexWrap` covers issue reproducer + over-negative + UTF-8 (byte vs char count).
- [x] `./build/ry test tests/spec/bounds_check.test.ry tests/spec/strings.test.ry` — substring blocks rewritten for wrap semantics.
- [x] `./build/ry_tests` (full C++ suite, 1881 tests) + `./build/ry test -p` (Ry self-test, 161 files) — all pass.
- [x] ASan+UBSan / TSan — pass.
- [x] libFuzzer: `fuzz_parser` / `fuzz_json` / `fuzz_utf8` 60s each — all exit 0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `substring()` to support Python-style negative index wrapping. Negative start/end indices now wrap relative to string length (e.g., `-1` refers to the last character). Over-negative values are clamped to valid bounds, aligning behavior with other string indexing operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->