### PR TITLE
fix: allow !! operator immediately after identifier (#1211)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1663,6 +1663,34 @@ in user documentation, (b) use non-identifier expressions (literals,
 calls), or (c) write a custom block parser that calls `parseConditional`
 directly for the tail line.
 
+### Identifier-trailing `!` tokenization must exclude every multi-char operator starting with `!`
+
+**Source**: #1211 (2026-04-20, bug fix)
+**Tags**: parser, lexer, identifier, trailing-bang, bangbang, ambiguity
+
+**Context**: The lexer greedily absorbs a trailing `!` into an
+identifier to support mutating method names (`sort!`, `reverse!`,
+`append!`, `clear!`). The original guard only excluded `!=`, so `r!!`
+tokenized as `r!` (Ident) + `!` (Error) and parse-failed as
+`expected ')'` when used in expression position like `Ok(r!!)`. The
+postfix error-propagation alias `!!` was thus broken for the
+identifier-direct case — the documented equivalence with `?` was only
+honored when the preceding token was not an identifier (e.g. after `)`).
+
+**Rule**: The trailing-bang absorption in the identifier branch
+(`src/lexer.cpp` identifier tokenization) must exclude **every**
+multi-character operator token that begins with `!`, not just `!=`.
+Currently that means `!=` and `!!`; any future operator starting with
+`!` (hypothetical `!~`, `!?`, etc.) must be added to the exclusion set
+at the same time it is introduced in the operator lexer branch.
+
+**How to apply**: When adding a new operator whose first character is
+`!`, update both (a) the operator dispatch in `Lexer::next` and
+(b) the trailing-bang exclusion in the identifier tokenizer. A unit
+test asserting `tokenize("r<op>")` yields `Ident("r")` + the new
+operator prevents regression — `tokenize("<op>")` standalone does not
+catch it because the bug is specific to the identifier-adjacent case.
+
 ---
 
 ## Runtime / Memory

--- a/changelog.d/1211-bangbang-expr-position.md
+++ b/changelog.d/1211-bangbang-expr-position.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `!!` error-propagation operator now works in expression position immediately after an identifier (e.g. `Ok(r!!)`, `Some(v!! + 1)`), matching the documented equivalence with `?`. The lexer previously consumed the trailing `!` as part of the identifier (to support mutating method names like `sort!`), so `r!!` tokenized as `r!` + `!` and failed to parse (#1211)

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -623,9 +623,10 @@ Token Lexer::readToken() {
         size_t start = pos_;
         while (pos_ < src_.size() && (std::isalnum(static_cast<unsigned char>(src_[pos_])) || src_[pos_] == '_')) { ++pos_; ++col_; }
         // Allow trailing '!' for mutating method names (e.g., sort!, reverse!)
-        // but not '!=' which is the not-equal operator
+        // but not '!=' (not-equal) or '!!' (error-propagate operator)
         if (pos_ < src_.size() && src_[pos_] == '!' &&
-            (pos_ + 1 >= src_.size() || src_[pos_ + 1] != '=')) {
+            (pos_ + 1 >= src_.size() ||
+             (src_[pos_ + 1] != '=' && src_[pos_ + 1] != '!'))) {
             ++pos_; ++col_;
         }
         std::string id(src_, start, pos_ - start);

--- a/tests/spec/option_propagate.test.ry
+++ b/tests/spec/option_propagate.test.ry
@@ -21,6 +21,16 @@ function inline_expr_always_none() -> Option<int>:
   # `?` inside the expression position short-circuits to `None`.
   return Some(safe_get([1], 99)? + 1)
 
+function wrap_bang(r: Option<int>) -> Option<int>:
+  return Some(r!!)
+
+function add_one_bang(v: Option<int>) -> Option<int>:
+  return Some(v!! + 1)
+
+function add_one_bang_none() -> Option<int>:
+  x: Option<int> = none
+  return Some(x!! + 1)
+
 describe("Option error propagation", ():
   it("should unwrap Some value with ?", ():
     case first_plus_second([10, 20, 30]):
@@ -59,6 +69,34 @@ describe("Option error propagation", ():
   )
   it("should propagate None from ? in expression position", ():
     case inline_expr_always_none():
+      Some(v):
+        fail("expected None but got Some")
+      None:
+        expect(true).to_eq(true)
+  )
+  it("should support !! on identifier inside call argument", ():
+    case wrap_bang(Some(42)):
+      Some(v):
+        expect(v).to_eq(42)
+      None:
+        fail("unexpected none")
+  )
+  it("should propagate None via !! on identifier inside call argument", ():
+    case wrap_bang(none):
+      Some(v):
+        fail("expected None but got Some")
+      None:
+        expect(true).to_eq(true)
+  )
+  it("should support !! on identifier in arithmetic expression", ():
+    case add_one_bang(Some(41)):
+      Some(v):
+        expect(v).to_eq(42)
+      None:
+        fail("unexpected none")
+  )
+  it("should propagate None via !! on identifier in arithmetic expression", ():
+    case add_one_bang_none():
       Some(v):
         fail("expected None but got Some")
       None:

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -1164,6 +1164,28 @@ TEST(LexerTest, BangBangOperator) {
     EXPECT_EQ(toks[0].value, "!!");
 }
 
+TEST(LexerTest, BangBangAfterIdentifier) {
+    auto toks = tokenize("r!!");
+    ASSERT_EQ(toks.size(), 3u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Ident);
+    EXPECT_EQ(toks[0].value, "r");
+    EXPECT_EQ(toks[1].kind, TokenKind::BangBang);
+    EXPECT_EQ(toks[1].value, "!!");
+    EXPECT_EQ(toks[2].kind, TokenKind::Eof);
+}
+
+TEST(LexerTest, MutatingMethodIdentifier) {
+    auto toks = tokenize("sort!(xs)");
+    ASSERT_EQ(toks.size(), 5u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Ident);
+    EXPECT_EQ(toks[0].value, "sort!");
+    EXPECT_EQ(toks[1].kind, TokenKind::LParen);
+    EXPECT_EQ(toks[2].kind, TokenKind::Ident);
+    EXPECT_EQ(toks[2].value, "xs");
+    EXPECT_EQ(toks[3].kind, TokenKind::RParen);
+    EXPECT_EQ(toks[4].kind, TokenKind::Eof);
+}
+
 TEST(LexerTest, ManyConsecutiveComments) {
     // Generate many comment lines to verify no stack overflow
     std::string src;


### PR DESCRIPTION
## Summary

Closes #1211.

The `!!` error-propagation operator failed to parse when placed immediately after an identifier in expression position (e.g. `Ok(r!!)`, `Some(v!! + 1)`), even though it is documented as an alias for `?`.

## Root cause

The lexer greedily absorbs a trailing `!` into an identifier to support mutating method names (`sort!`, `reverse!`, `append!`, `clear!`). The original guard only excluded `!=`, so `r!!` tokenized as `r!` (Ident) + `!` (Error), and `Ok(r!!)` failed with `expected ')'`.

## Fix

`src/lexer.cpp` — one-line change: extend the trailing-bang exclusion from `!=` only to `{!=, !!}`. The operator tokenizer already handles `!!`, so the identifier branch just needs to stop stealing it.

- `sort!(xs)`, `x != y` — unchanged
- `r!!` — now tokenizes as `r` + `!!` (previously Ident `r!` + Error `!`)

## Tests

- `tests/test_lexer.cpp` — 2 new tests: `BangBangAfterIdentifier` + `MutatingMethodIdentifier`
- `tests/spec/option_propagate.test.ry` — 4 new `it()` blocks covering identifier-direct `!!` in call-argument and arithmetic position (both `Some` and `None` propagation paths)

## Test plan

- [x] `./build/ry_tests` — 1883/1883 pass
- [x] `./build/ry test -p` — 161 files, 0 failures
- [x] ASan + UBSan — clean
- [x] TSan (C++) — clean
- [x] libFuzzer `fuzz_parser` 60s — 59816 runs, exit 0
- [x] `KNOWLEDGE.md` entry added (Tags: `parser, lexer, identifier, trailing-bang, bangbang, ambiguity`)
- [x] `changelog.d/1211-bangbang-expr-position.md` fragment added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed the `!!` error-propagation operator to be correctly recognized in expression position when used immediately after identifiers (e.g., `r!!`, `Ok(r!!)`, `Some(v!! + 1)`). Previously, these expressions failed to parse due to incorrect tokenization of the operator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->