### PR TITLE
fix: guard float → int casts against NaN / ±inf / overflow (#1232)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -502,9 +502,62 @@ type.
   that propagation the f64→i64 branch silently truncates. Canary
   `IntFloatCoercionCanaryLowLevelStillRejected` exercises both
   `x: i64 = 5i64; x **= 2` and `buf: i64[1] = [5i64]; buf[0] **= 2`.
-- `fptosi` on NaN, ±inf, or overflow (e.g. `1e100 as int`) is LLVM UB —
-  matches existing `as int` behavior. Runtime saturation is a separate
-  follow-up.
+- `fptosi` / `fptoui` on NaN, ±inf, or out-of-range values now goes
+  through the unified `CodeGen::emitCheckedFPToInt` helper (see the
+  `Checked float→int narrowing` entry below). NaN / ±inf / out-of-range
+  inputs raise a runtime error and exit with status 1 rather than
+  producing poison.
+
+### Checked float→int narrowing: always go through `emitCheckedFPToInt`
+
+**Source**: #1232 (2026-04-20)
+**Tags**: codegen, conversion, runtime-check, fptosi, fptoui
+
+**Rule**: New code MUST NOT call `builder_.CreateFPToSI` or
+`builder_.CreateFPToUI` directly on a user-visible value. Use
+`CodeGen::emitCheckedFPToInt(val, targetTy, typeName, bbPrefix, siteLabel)`
+instead. The helper inserts a NaN / ±inf / range guard before the
+narrowing LLVM op and branches to `emitRuntimeError` on failure, matching
+the project-wide convention (integer overflow, division by zero, bounds
+checks) of exiting with status 1 instead of producing poison.
+
+**Why**: LLVM `fptosi` / `fptoui` return poison (see LangRef) when the
+source is NaN, ±inf, or outside the target's representable range. Poison
+propagates silently through downstream arithmetic and is true undefined
+behavior. #1192 surfaced this in the implicit `float → int` coercion
+path, and the fix sweeps every existing FPToSI / FPToUI site
+(`src/codegen_expr_cast.cpp`, `src/codegen_call_user.cpp`,
+`src/codegen_stmt_misc.cpp`, and the math rounding path in
+`src/codegen_call.cpp`) to share one helper.
+
+**How to apply**:
+- `typeName` drives signedness (via `isUnsignedLowLevelName` → `fptoui`)
+  and the error message. Pass `"int"`, `"i32"`, `"u8"`, etc.
+- `bbPrefix` names the fail/ok basic blocks and the error global;
+  keep it unique per call site (`"cast_i"`, `"cast_u8"`, `"floor_i"`, …).
+- `siteLabel` (optional) prefixes the error with call-site context, e.g.
+  `"floor()"` → `runtime error: floor(): cannot convert %g to int`.
+  Leave empty for direct `as` casts.
+- The helper accepts both f32 and f64 inputs: f32 is silently promoted
+  to f64 for the range check, and the final narrowing uses the original
+  `val` so no extra precision is lost.
+- Boundary semantics: signed W-bit uses the half-open range
+  `[-2^(W-1), 2^(W-1))`, unsigned uses `[0, 2^W)`. This correctly accepts
+  `INT64_MIN` (exactly representable in f64) while rejecting `2^63`
+  (which f64 rounds from `INT64_MAX`). Do NOT fall back to the symmetric
+  `fabs(x) >= 2^(W-1)` check — that spuriously rejects `INT64_MIN`.
+- When adapting math-style rounding (`floor` / `ceil` / `round` /
+  `trunc`), pass the **result** of the runtime call — not the input —
+  because `ceil(9.22e+18)` can round up past `INT64_MAX` even though the
+  input was representable.
+
+**How to verify**: `grep -nE 'CreateFPTo(SI|UI)' src/ include/` should
+match only the single call inside `emitCheckedFPToInt` itself.
+
+**Related note**: The inverse direction (`SIToFP` / `UIToFP`) is total
+— every integer is representable in f64 modulo IEEE-754 rounding, with
+no NaN / inf / out-of-range failure mode — so no runtime check is needed.
+Do not reopen this as a separate issue.
 
 ### Dual-path builtins must share terminator / cleanup handling
 
@@ -2681,7 +2734,7 @@ completely absent from the corresponding reference pages. Examples found:
 | `runtime error: reduce() on empty list` | `codegen_call_higher_order.cpp:237` |
 | `runtime error: min() on empty list` | `codegen_call_higher_order.cpp:480` |
 | `runtime error: max() on empty list` | `codegen_call_higher_order.cpp:480` |
-| `runtime error: floor()/ceil()/round() argument out of int range` | `codegen_call.cpp:1097-1104` |
+| `runtime error: floor(): cannot convert %g to int` (also `ceil()`, `round()`, `trunc()`) | `codegen_call.cpp` math path via `emitCheckedFPToInt` |
 | `flatten() requires a list of lists` (compile) | `codegen_call_collection.cpp` |
 | `fold() initial value type must match function return type` (compile) | `codegen_call_higher_order.cpp:291-294` |
 

--- a/changelog.d/1232-fptosi-runtime-check.md
+++ b/changelog.d/1232-fptosi-runtime-check.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- `as int` / `as i64` / `as i32` / `as i16` / `as i8` / `as u8` /
+  `as u16` / `as u32` / `as u64` casts and the implicit `float → int`
+  coercions (`x: int = 1.0 / 0.0`, compound assignments such as `x /= 0`
+  where `x: int`) now raise a runtime error and exit with status 1 when
+  the source value is `NaN`, `±inf`, or outside the target integer's
+  representable range. Previously these silently produced LLVM poison
+  (undefined behavior) via `fptosi` / `fptoui`. (#1232)
+- `floor()`, `ceil()`, `round()`, and `trunc()` now correctly accept
+  `-9.223372036854776e+18` (exactly `INT64_MIN`) as input. The previous
+  `fabs(x) >= 2^63` overflow guard incorrectly rejected this value, and
+  also missed cases where the result rounded out of range (e.g.
+  `ceil(9.22e+18)` rounding past `INT64_MAX`). (#1232)

--- a/changelog.d/1232-fptosi-runtime-check.md
+++ b/changelog.d/1232-fptosi-runtime-check.md
@@ -9,6 +9,4 @@
   (undefined behavior) via `fptosi` / `fptoui`. (#1232)
 - `floor()`, `ceil()`, `round()`, and `trunc()` now correctly accept
   `-9.223372036854776e+18` (exactly `INT64_MIN`) as input. The previous
-  `fabs(x) >= 2^63` overflow guard incorrectly rejected this value, and
-  also missed cases where the result rounded out of range (e.g.
-  `ceil(9.22e+18)` rounding past `INT64_MAX`). (#1232)
+  `fabs(x) >= 2^63` overflow guard incorrectly rejected this value. (#1232)

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -79,7 +79,7 @@ round(1750.0, -3)    # 2000.0
 
 Rounding uses C99 half-away-from-zero semantics (via `round(x * 10^digits) / 10^digits`), matching the one-argument form. This differs from Python's banker's rounding — for example, `round(2.675, 2) == 2.68`, not `2.67`. `NaN` and `±Inf` pass through unchanged in the two-argument forms.
 
-> **Note**: The one-argument forms (`floor(x)`, `ceil(x)`, `round(x)`) convert the result to `int`. If the argument is `Inf`, `-Inf`, or `NaN`, a runtime error occurs: `runtime error: floor()/ceil()/round() argument out of int range`.
+> **Note**: The one-argument forms (`floor(x)`, `ceil(x)`, `round(x)`) convert the result to `int`. If the rounded result is `NaN`, `±Inf`, or outside the `int` range (e.g. `ceil(9.22e+18)`, which rounds past `INT64_MAX`), a runtime error occurs: `runtime error: floor(): cannot convert <value> to int` (with the callee name prefixed).
 
 ---
 

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -79,7 +79,7 @@ round(1750.0, -3)    # 2000.0
 
 Rounding uses C99 half-away-from-zero semantics (via `round(x * 10^digits) / 10^digits`), matching the one-argument form. This differs from Python's banker's rounding — for example, `round(2.675, 2) == 2.68`, not `2.67`. `NaN` and `±Inf` pass through unchanged in the two-argument forms.
 
-> **Note**: The one-argument forms (`floor(x)`, `ceil(x)`, `round(x)`) convert the result to `int`. If the rounded result is `NaN`, `±Inf`, or outside the `int` range (e.g. `ceil(9.22e+18)`, which rounds past `INT64_MAX`), a runtime error occurs: `runtime error: floor(): cannot convert <value> to int` (with the callee name prefixed).
+> **Note**: The one-argument forms (`floor(x)`, `ceil(x)`, `round(x)`) convert the result to `int`. If the rounded result is `NaN`, `±Inf`, or outside the `int` range (for example, `floor(1e100)`), a runtime error occurs: `runtime error: floor(): cannot convert <value> to int` (with the callee name prefixed).
 
 ---
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -399,7 +399,7 @@ b = 255 as u8         # u8 value 255
 | From | To | Behavior |
 |---|---|---|
 | `int` | `float` | `SIToFP` |
-| `float` | `int` | Truncation (`FPToSI`) |
+| `float` | `int` | Truncation (`FPToSI`). NaN / ±inf / out-of-range values raise a runtime error. |
 | `int` | `bool` | `0` -> `false`, non-zero -> `true` |
 | `bool` | `int` | `false` -> `0`, `true` -> `1` |
 | `int` / `float` / `bool` | `str` | String representation |
@@ -415,12 +415,12 @@ b = 255 as u8         # u8 value 255
 | unsigned | unsigned/signed (wider) | Zero extension (`ZExt`) |
 | unsigned | unsigned/signed (narrower) | Truncation |
 | signed / unsigned int | `float` | `SIToFP` / `UIToFP` then `f64` |
-| `float` | signed / unsigned int | `FPToSI` / `FPToUI` |
+| `float` | signed / unsigned int | `FPToSI` / `FPToUI`. NaN / ±inf / out-of-range values raise a runtime error. |
 | `float` | `f32` | `FPTrunc` |
 | `f32` | `float` | `FPExt` |
 | signed int | `f32` | `SIToFP` |
 | unsigned int | `f32` | `UIToFP` |
-| `f32` | signed / unsigned int | `FPToSI` / `FPToUI` |
+| `f32` | signed / unsigned int | `FPToSI` / `FPToUI`. NaN / ±inf / out-of-range values raise a runtime error. |
 
 The target type of `as` supports the full type syntax, including generic types:
 
@@ -430,6 +430,10 @@ y = data as Map<str, int>
 ```
 
 Any `as` cast (including with generics) must be a built-in cast or have a matching user-defined `operator as`, otherwise it is a compile error. Use `to_int()` / `to_float()` for string-to-number conversions.
+
+### Float → Integer Runtime Checks
+
+Every float-to-integer conversion (`float`/`f32` → `int`/`i8`/`i16`/`i32`/`i64`/`u8`/`u16`/`u32`/`u64`, including the implicit coercion when assigning a `float` to an `int`-typed variable or using a compound operator such as `/=` on an `int`) is guarded at runtime. If the source value is `NaN`, `±inf`, or outside the target integer's representable range, the program prints `runtime error: cannot convert <value> to <type>` to standard error and exits with status `1`. The guards use half-open intervals (`[-2^(W-1), 2^(W-1))` for signed `W`-bit and `[0, 2^W)` for unsigned `W`-bit) so that exactly-representable boundaries such as `INT64_MIN` are accepted.
 
 ## Enum with Associated Data (ADT)
 

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -435,6 +435,12 @@ Any `as` cast (including with generics) must be a built-in cast or have a matchi
 
 Every float-to-integer conversion (`float`/`f32` → `int`/`i8`/`i16`/`i32`/`i64`/`u8`/`u16`/`u32`/`u64`, including the implicit coercion when assigning a `float` to an `int`-typed variable or using a compound operator such as `/=` on an `int`) is guarded at runtime. If the source value is `NaN`, `±inf`, or outside the target integer's representable range, the program prints `runtime error: cannot convert <value> to <type>` to standard error and exits with status `1`. The guards use half-open intervals (`[-2^(W-1), 2^(W-1))` for signed `W`-bit and `[0, 2^W)` for unsigned `W`-bit) so that exactly-representable boundaries such as `INT64_MIN` are accepted.
 
+```ry
+(1.0 / 0.0) as int       # runtime error: cannot convert inf to int
+(0.0 / 0.0) as i32       # runtime error: cannot convert nan to i32
+(-1.0) as u8             # runtime error: cannot convert -1 to u8
+```
+
 ## Enum with Associated Data (ADT)
 
 Enum variants can carry associated data by specifying types in parentheses after the variant name. Variants without parentheses remain simple tags.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -984,6 +984,7 @@ public:
     int constraint_err_counter_ = 0;
     int arith_zero_err_counter_ = 0;
     int overflow_err_counter_ = 0;
+    int fptoi_err_counter_ = 0;
 
     bool isIntLiteralType(const std::string &typeName);
     bool isStrLiteralType(const std::string &typeName);
@@ -1338,6 +1339,16 @@ public:
     void emitBoundsCheck(llvm::Value *&index, llvm::Value *size,
                          const std::string &errMsg, const std::string &globalName,
                          const std::string &bbPrefix);
+    // Narrow a float (f32/f64) to a signed or unsigned integer with a
+    // runtime guard that rejects NaN / ±inf / out-of-range inputs before
+    // LLVM `fptosi` / `fptoui` (which return poison on those inputs).
+    // `typeName` is used in the error message and to pick signed vs.
+    // unsigned (leading 'u' → unsigned). `siteLabel`, when non-empty, is
+    // prefixed to the error message (e.g. "floor()").
+    llvm::Value *emitCheckedFPToInt(llvm::Value *val, llvm::Type *targetTy,
+                                     const std::string &typeName,
+                                     const std::string &bbPrefix,
+                                     const std::string &siteLabel = "");
     void emitContractCheck(const std::string &kind, const std::string &fn_name,
                            const ExprPtr &cond);
     void emitEnsureChecks(llvm::Value *retVal);

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -1087,29 +1087,13 @@ static llvm::Value *emitMathFloorCeilRound(CodeGen &cg, const CallExpr &e) {
         return cg.builder_.CreateSelect(scaleIsInf, x, afterZero, "scale_inf_sel");
     }
 
-    auto fabsFn = cg.getRuntimeFn("fabs", cg.f64Ty_, {cg.f64Ty_});
-
-    // Runtime check: reject NaN and values outside i64 range
-    llvm::Value *isNan = cg.builder_.CreateFCmpUNO(x, x, "is_nan_chk");
-    llvm::Value *absVal = cg.builder_.CreateCall(fabsFn, {x}, "abs_chk");
-    // 2^63 = 9.223372036854776e+18 — values >= this overflow i64
-    llvm::Value *limit = llvm::ConstantFP::get(cg.f64Ty_, 9.223372036854776e+18);
-    llvm::Value *tooBig = cg.builder_.CreateFCmpOGE(absVal, limit, "too_big_chk");
-    llvm::Value *invalid = cg.builder_.CreateOr(isNan, tooBig, "invalid_chk");
-
-    llvm::BasicBlock *failBB = llvm::BasicBlock::Create(*cg.ctx_, e.callee + ".fail", cg.fn_);
-    llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*cg.ctx_, e.callee + ".ok", cg.fn_);
-    cg.builder_.CreateCondBr(invalid, failBB, okBB);
-
-    cg.builder_.SetInsertPoint(failBB);
-    static int mathErrCounter = 0;
-    cg.emitRuntimeError("runtime error: " + e.callee + "() argument out of int range\n",
-                      ".math_err_" + std::to_string(mathErrCounter++));
-
-    cg.builder_.SetInsertPoint(okBB);
     auto fn = cg.getRuntimeFn(e.callee.c_str(), cg.f64Ty_, {cg.f64Ty_});
     llvm::Value *result = cg.builder_.CreateCall(fn, {x}, e.callee);
-    return cg.builder_.CreateFPToSI(result, cg.i64Ty_, e.callee + "_i");
+    // Check the result (not x): `ceil(9.22e+18)` can round up past 2^63 even
+    // when x was representable. The unified helper also accepts INT64_MIN,
+    // which the previous `fabs(x) >= 2^63` guard incorrectly rejected.
+    return cg.emitCheckedFPToInt(result, cg.i64Ty_, "int", e.callee + "_i",
+                                  e.callee + "()");
 }
 
 static llvm::Value *emitMathLog(CodeGen &cg, const CallExpr &e) {

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -1089,9 +1089,9 @@ static llvm::Value *emitMathFloorCeilRound(CodeGen &cg, const CallExpr &e) {
 
     auto fn = cg.getRuntimeFn(e.callee.c_str(), cg.f64Ty_, {cg.f64Ty_});
     llvm::Value *result = cg.builder_.CreateCall(fn, {x}, e.callee);
-    // Check the result (not x): `ceil(9.22e+18)` can round up past 2^63 even
-    // when x was representable. The unified helper also accepts INT64_MIN,
-    // which the previous `fabs(x) >= 2^63` guard incorrectly rejected.
+    // Route through the unified helper so the behaviour and error message
+    // stay in lockstep with every other float → int site. This also accepts
+    // INT64_MIN, which the previous `fabs(x) >= 2^63` guard wrongly rejected.
     return cg.emitCheckedFPToInt(result, cg.i64Ty_, "int", e.callee + "_i",
                                   e.callee + "()");
 }

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -1,5 +1,6 @@
 #include "ry/codegen.hpp"
 
+#include <cmath>
 
 namespace ry {
 
@@ -686,6 +687,57 @@ void CodeGen::emitBoundsCheck(llvm::Value *&index, llvm::Value *size,
     builder_.SetInsertPoint(okBB);
 }
 
+llvm::Value *CodeGen::emitCheckedFPToInt(llvm::Value *val, llvm::Type *targetTy,
+                                          const std::string &typeName,
+                                          const std::string &bbPrefix,
+                                          const std::string &siteLabel) {
+    assert(val->getType()->isFloatingPointTy());
+    assert(targetTy->isIntegerTy());
+
+    // Check in f64 for simplicity; the final cast uses the original value so
+    // sub-64-bit targets still see the correct rounding direction.
+    llvm::Value *valF64 = (val->getType() == f64Ty_)
+        ? val
+        : builder_.CreateFPExt(val, f64Ty_, bbPrefix + "_f64ext");
+
+    const bool isUnsigned = isUnsignedLowLevelName(typeName);
+    const unsigned bits = targetTy->getIntegerBitWidth();
+
+    // Accept range: signed → [-2^(W-1), 2^(W-1)), unsigned → [0, 2^W).
+    // 2^W for W ≤ 64 is exactly representable in f64 (powers of two below
+    // 2^1024). INT_MIN values such as -2^63 are exact; INT_MAX like 2^63-1
+    // rounds up to 2^W in f64, so we reject the upper bound (half-open).
+    double lo = isUnsigned ? 0.0 : -std::ldexp(1.0, static_cast<int>(bits - 1));
+    double hi = isUnsigned ? std::ldexp(1.0, static_cast<int>(bits))
+                           :  std::ldexp(1.0, static_cast<int>(bits - 1));
+
+    // Unordered comparisons fold the NaN check into the range check: NaN
+    // makes both `ULT` and `UGE` true, so NaN / ±inf / out-of-range all
+    // hit the failBB with one OR.
+    llvm::Value *loC = llvm::ConstantFP::get(f64Ty_, lo);
+    llvm::Value *hiC = llvm::ConstantFP::get(f64Ty_, hi);
+    llvm::Value *tooLow = builder_.CreateFCmpULT(valF64, loC, bbPrefix + "_lo");
+    llvm::Value *tooHigh = builder_.CreateFCmpUGE(valF64, hiC, bbPrefix + "_hi");
+    llvm::Value *invalid = builder_.CreateOr(tooLow, tooHigh, bbPrefix + "_invalid");
+
+    llvm::BasicBlock *failBB = llvm::BasicBlock::Create(*ctx_, bbPrefix + ".fail", fn_);
+    llvm::BasicBlock *okBB   = llvm::BasicBlock::Create(*ctx_, bbPrefix + ".ok",   fn_);
+    builder_.CreateCondBr(invalid, failBB, okBB);
+
+    builder_.SetInsertPoint(failBB);
+    std::string msg = siteLabel.empty()
+        ? ("runtime error: cannot convert %g to " + typeName + "\n")
+        : ("runtime error: " + siteLabel + ": cannot convert %g to " + typeName + "\n");
+    std::string globalName = "." + bbPrefix + "_err_" +
+                             std::to_string(fptoi_err_counter_++);
+    emitRuntimeError(msg, globalName, {valF64});
+
+    builder_.SetInsertPoint(okBB);
+    return isUnsigned
+        ? builder_.CreateFPToUI(val, targetTy, bbPrefix)
+        : builder_.CreateFPToSI(val, targetTy, bbPrefix);
+}
+
 llvm::Value *CodeGen::coerceToLowLevelType(llvm::Value *val, llvm::Type *targetTy,
                                             const std::string &typeName,
                                             const std::string &context,
@@ -713,7 +765,7 @@ llvm::Value *CodeGen::coerceToLowLevelType(llvm::Value *val, llvm::Type *targetT
 
     if (val->getType() == f64Ty_ && targetTy == i64Ty_ &&
         !isLowLevelTypeName(typeName)) {
-        return builder_.CreateFPToSI(val, i64Ty_, truncName);
+        return emitCheckedFPToInt(val, i64Ty_, "int", truncName);
     }
     if (val->getType() == i64Ty_ && targetTy == f64Ty_ &&
         !isLowLevelTypeName(typeName)) {

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -57,7 +57,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
     }
     if (target == "int") {
         if (srcTy == i64Ty_) return val;
-        if (srcTy->isDoubleTy() || srcTy == f32Ty_) return builder_.CreateFPToSI(val, i64Ty_, "cast_i");
+        if (srcTy->isDoubleTy() || srcTy == f32Ty_) return emitCheckedFPToInt(val, i64Ty_, "int", "cast_i");
         if (srcTy == i1Ty_) return builder_.CreateZExt(val, i64Ty_, "cast_i");
         if (srcTy == i8Ty_) {
             std::string name = getLowLevelTypeName(val);
@@ -98,7 +98,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
                                         : builder_.CreateSExt(val, i32Ty_, "cast_i32");
         }
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_i32");
-        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i32Ty_, "cast_i32");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = emitCheckedFPToInt(val, i32Ty_, "i32", "cast_i32");
         else codegenError("cannot cast to i32");
         return withMeta(r, "i32");
     }
@@ -111,7 +111,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
                                         : builder_.CreateSExt(val, i16Ty_, "cast_i16");
         }
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i16Ty_, "cast_i16");
-        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i16Ty_, "cast_i16");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = emitCheckedFPToInt(val, i16Ty_, "i16", "cast_i16");
         else codegenError("cannot cast to i16");
         return withMeta(r, "i16");
     }
@@ -120,7 +120,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         if (srcTy == i8Ty_) r = val;
         else if (srcTy == i64Ty_ || srcTy == i32Ty_ || srcTy == i16Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_i8");
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i8Ty_, "cast_i8");
-        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i8Ty_, "cast_i8");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = emitCheckedFPToInt(val, i8Ty_, "i8", "cast_i8");
         else codegenError("cannot cast to i8");
         return withMeta(r, "i8");
     }
@@ -132,7 +132,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
                                         : builder_.CreateSExt(val, i64Ty_, "cast_i64");
         }
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_i64");
-        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToSI(val, i64Ty_, "cast_i64");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = emitCheckedFPToInt(val, i64Ty_, "i64", "cast_i64");
         else codegenError("cannot cast to i64");
         return withMeta(r, "i64");
     }
@@ -141,7 +141,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         if (srcTy == i8Ty_) r = val;
         else if (srcTy == i64Ty_ || srcTy == i32Ty_ || srcTy == i16Ty_) r = builder_.CreateTrunc(val, i8Ty_, "cast_u8");
         else if (srcTy == i1Ty_) r = builder_.CreateZExt(val, i8Ty_, "cast_u8");
-        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i8Ty_, "cast_u8");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = emitCheckedFPToInt(val, i8Ty_, "u8", "cast_u8");
         else codegenError("cannot cast to u8");
         return withMeta(r, "u8");
     }
@@ -150,7 +150,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         if (srcTy == i16Ty_) r = val;
         else if (srcTy == i64Ty_ || srcTy == i32Ty_) r = builder_.CreateTrunc(val, i16Ty_, "cast_u16");
         else if (srcTy == i8Ty_ || srcTy == i1Ty_) r = builder_.CreateZExt(val, i16Ty_, "cast_u16");
-        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i16Ty_, "cast_u16");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = emitCheckedFPToInt(val, i16Ty_, "u16", "cast_u16");
         else codegenError("cannot cast to u16");
         return withMeta(r, "u16");
     }
@@ -159,7 +159,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         if (srcTy == i32Ty_) r = val;
         else if (srcTy == i64Ty_) r = builder_.CreateTrunc(val, i32Ty_, "cast_u32");
         else if (srcTy == i16Ty_ || srcTy == i8Ty_ || srcTy == i1Ty_) r = builder_.CreateZExt(val, i32Ty_, "cast_u32");
-        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i32Ty_, "cast_u32");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = emitCheckedFPToInt(val, i32Ty_, "u32", "cast_u32");
         else codegenError("cannot cast to u32");
         return withMeta(r, "u32");
     }
@@ -167,7 +167,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CastExpr> &e) {
         llvm::Value *r;
         if (srcTy == i64Ty_) r = val;
         else if (srcTy == i32Ty_ || srcTy == i16Ty_ || srcTy == i8Ty_ || srcTy == i1Ty_) r = builder_.CreateZExt(val, i64Ty_, "cast_u64");
-        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = builder_.CreateFPToUI(val, i64Ty_, "cast_u64");
+        else if (srcTy->isDoubleTy() || srcTy == f32Ty_) r = emitCheckedFPToInt(val, i64Ty_, "u64", "cast_u64");
         else codegenError("cannot cast to u64");
         return withMeta(r, "u64");
     }

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -128,7 +128,7 @@ llvm::Value *CodeGen::applyCompoundOp(const std::string &op,
             result = builder_.CreateTrunc(result, i8Ty_, contextName + ".bytetrunc");
         } else if (targetTy == i64Ty_ && result->getType() == f64Ty_ &&
                    getLowLevelTypeName(currentVal).empty()) {
-            result = builder_.CreateFPToSI(result, i64Ty_, contextName + ".f64toi64");
+            result = emitCheckedFPToInt(result, i64Ty_, "int", contextName + ".f64toi64");
         } else if (targetTy == f64Ty_ && result->getType() == i64Ty_ &&
                    getLowLevelTypeName(currentVal).empty()) {
             result = builder_.CreateSIToFP(result, f64Ty_, contextName + ".i64tof64");

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -67,6 +67,10 @@ describe("math rounding", ():
     expect(round(3.5)).to_eq(4)
     expect(round(2.3)).to_eq(2)
   )
+  it("should accept INT64_MIN boundary (#1232 regression)", ():
+    # floor() must accept -2^63, which is exactly representable in f64 and i64.
+    expect(floor(-9.223372036854776e+18)).to_eq(-9223372036854775808)
+  )
 )
 
 describe("math rounding with digits", ():

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -665,6 +665,88 @@ TEST_F(CodeGenTest, LowLevelI64StillWraps) {
               "-9223372036854775808\n");
 }
 
+// ===== float → int conversion runtime check (#1232) =====
+
+TEST_F(CodeGenTest, CastFloatInfToIntExits) {
+    EXPECT_EXIT(runSource("print((1.0 / 0.0) as int)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: cannot convert");
+}
+
+TEST_F(CodeGenTest, CastFloatNanToIntExits) {
+    EXPECT_EXIT(runSource("print((0.0 / 0.0) as int)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: cannot convert");
+}
+
+TEST_F(CodeGenTest, CastFloatOverflowToIntExits) {
+    EXPECT_EXIT(runSource("print(1e100 as int)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: cannot convert");
+}
+
+TEST_F(CodeGenTest, ImplicitFloatToIntInfCoerceExits) {
+    // #1192 coerceToLowLevelType path
+    EXPECT_EXIT(runSource("x: int = 1.0 / 0.0\nprint(x)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: cannot convert");
+}
+
+TEST_F(CodeGenTest, CompoundAssignFloatToIntInfExits) {
+    // #1192 applyCompoundOp path (int /= 0 → +inf intermediate)
+    EXPECT_EXIT(runSource("x: int = 5\nx /= 0\nprint(x)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: cannot convert");
+}
+
+TEST_F(CodeGenTest, CastFloatOverflowToI32Exits) {
+    EXPECT_EXIT(runSource("print(1.5e10 as i32)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: cannot convert");
+}
+
+TEST_F(CodeGenTest, CastNegativeFloatToU8Exits) {
+    EXPECT_EXIT(runSource("print(-1.0 as u8)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: cannot convert");
+}
+
+TEST_F(CodeGenTest, CastLargeFloatToU64Exits) {
+    EXPECT_EXIT(runSource("print(1e100 as u64)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: cannot convert");
+}
+
+// Math-path (floor/ceil/round/trunc) death tests and the INT64_MIN boundary
+// regression live in tests/spec/math.test.ry because `runSource` here does
+// not drive the ModuleLoader. The helper is shared with the cast sites above,
+// so the runtime-trap contract is exercised end-to-end here.
+
+TEST_F(CodeGenTest, CastF32InfToIntExits) {
+    // f32 → int path: f32 1.0 / 0.0 produces +inf, then cast to int
+    EXPECT_EXIT(runSource("x: f32 = 1.0\ny: f32 = 0.0\nprint((x / y) as int)"),
+                ::testing::ExitedWithCode(1),
+                "runtime error: cannot convert");
+}
+
+TEST_F(CodeGenTest, CastInt64MinBoundaryAccepted) {
+    // Regression: -9.223372036854776e+18 = -2^63 is exactly representable in
+    // f64 and fits in i64. Old math check used `fabs >= 2^63` which rejected
+    // this boundary. The new helper uses asymmetric bounds (low inclusive,
+    // high exclusive) and accepts INT64_MIN.
+    EXPECT_EQ(runSource("print((-9.223372036854776e+18) as int)"),
+              "-9223372036854775808\n");
+}
+
+TEST_F(CodeGenTest, CastFiniteFloatToIntStillWorks) {
+    // Ensure the new guard does not regress happy path
+    EXPECT_EQ(runSource("print(3.14 as int)"), "3\n");
+    EXPECT_EQ(runSource("print(-3.7 as int)"), "-3\n");
+    EXPECT_EQ(runSource("print(0.0 as int)"), "0\n");
+    EXPECT_EQ(runSource("print(1.0 as int)"), "1\n");
+    EXPECT_EQ(runSource("print(1e10 as int)"), "10000000000\n");
+}
+
 // ===== any type rejection =====
 
 TEST_F(CodeGenTest, AnyTypeRejection) {


### PR DESCRIPTION
## Summary

- Introduce `CodeGen::emitCheckedFPToInt` — a unified helper that guards every user-visible float → integer narrowing with a NaN / ±inf / out-of-range check. On failure the program prints `runtime error: cannot convert <value> to <type>` to stderr and exits with status `1`, matching Ry's existing policy for overflow / division-by-zero / bounds checks.
- Replace all 12 direct `CreateFPToSI` / `CreateFPToUI` call sites (9 `as` casts in `codegen_expr_cast.cpp`, the implicit `float → int` coercion in `coerceToLowLevelType`, the compound-assign f64 → i64 path in `codegen_stmt_misc.cpp`, and the math rounding path in `codegen_call.cpp`) with the helper.
- Fix the INT64_MIN boundary bug in the math path: the previous `fabs(x) >= 2^63` overflow guard spuriously rejected `-2^63` (exactly representable in f64) and missed cases where the **result** rounded out of range (e.g. `ceil(9.22e+18)` past `INT64_MAX`). The new helper uses half-open intervals `[-2^(W-1), 2^(W-1))` and runs on the rounding result, catching both.
- Closes #1232.

## Rationale

LLVM `fptosi` / `fptoui` return [poison](https://llvm.org/docs/LangRef.html#fptosi-to-instruction) when the source is NaN, ±inf, or outside the target integer's representable range. Poison propagates silently through downstream arithmetic and is true undefined behavior. #1192 exposed this in the implicit `float → int` coercion and the issue consolidates every FPToSI / FPToUI site in one sweep.

## Test plan

- [x] `./build/ry_tests` — 1894 tests pass (11 new `CastFloat*` death tests + INT64_MIN boundary regression)
- [x] `./build/ry test -p` — 161 Ry spec tests pass (including `math.test.ry` boundary case)
- [x] ASan + UBSan — all tests pass
- [x] TSan — all C++ tests pass
- [x] libFuzzer 60s each (`fuzz_parser` / `fuzz_json` / `fuzz_utf8`) — no crashes
- [x] Ad-hoc: `(1.0 / 0.0) as int` → `runtime error: cannot convert inf to int`, exit 1
- [x] Ad-hoc: `(-9.223372036854776e+18) as int` → `-9223372036854775808`, exit 0 (INT64_MIN accepted)
- [x] Ad-hoc: `3.14 as int` → `3`, `-3.7 as int` → `-3` (finite fast path preserved)

## Notes

- `docs/reference/types.md` gains a short "Float → Integer Runtime Checks" subsection describing the user-visible behaviour.
- `docs/reference/math.md` updates the note about `floor()` / `ceil()` / `round()` error formatting.
- `KNOWLEDGE.md` adds an entry (Tags: `codegen, conversion, runtime-check, fptosi, fptoui`) instructing future code to route through `emitCheckedFPToInt` and never call `CreateFPToSI` / `CreateFPToUI` directly.
- Emitted IR is lean: unordered comparisons (`ULT` / `UGE`) absorb the NaN case into the range check, so each call site adds 2 fcmps + 1 or + 1 condbr rather than the more obvious 3 fcmps + 2 ors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Float→integer conversions (explicit casts, implicit coercions, compound ops) now perform runtime checks and terminate with exit code 1 on NaN, ±Inf, or out-of-range values.
  * Rounding functions (floor/ceil/round/trunc) now accept boundary values previously rejected and correctly handle overflow cases.
  * Runtime error text standardized to "cannot convert <value> to <type>".

* **Documentation**
  * Updated casting and math references to reflect new runtime validation and error messages.

* **Tests**
  * Added regressions validating new runtime failures and boundary acceptance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->