### PR TITLE
fix: ARC-retain reference-typed elements in take() (#1235)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3949,7 +3949,22 @@ if (elementTypeIsArcManaged(srcListPtr, CollectionKind::List, &elemArcKind)) {
 
 **How to apply**: `elementTypeIsArcManaged(containerPtr, kind, &outElemKind)` reads `list_elem_type_name` / `map_*_type_name` from the *source* container's metadata — make sure the source pointer (not the newly-allocated header) is passed. Scalar element types (`List<int>`, `List<f64>`) naturally take the false branch, so the scalar path is unchanged. `emitCowRetainArcElements` handles str offset (−24) vs collection offset (−16) internally based on `elemArcKind`, so the caller does not need to distinguish. `emitCowClone` in `src/codegen_arc_cow.cpp` is the reference implementation — it performs the same memcpy+retain sequence for the CoW path.
 
-**Related**: #1046 (CoW str retain), #855 (slot overwrite release), #1184 (slice helper extracted from `emitCollOp_slice`), #1235 / #1236 (same defect in `emitCollOp_take_impl` and `emitListConcat`).
+**Related**: #1046 (CoW str retain), #855 (slot overwrite release), #1184 (slice helper extracted from `emitCollOp_slice`), #1235 (fixed for `emitCollOp_take_impl`), #1236 (same defect in `emitListConcat`).
+
+---
+
+### `List<str>` literals can have empty `list_elem_type_name` — UAF tests on retain paths are silently neutralized
+
+**Source**: #1235 (2026-04-20, observation during ARC retain fix)
+**Tags**: codegen, arc, metadata, list_elem_type_name, testing, symmetric-omission
+
+**Rule**: A `List<str>` constructed purely from a list literal (e.g. `xs: List<str> = ["a" + "b", "c" + "d"]`) typically has `list_elem_type_name = ""` rather than `"str"`. Tests that assign `xs = ["dropped"]` after a `take` / `slice` / `concat` and then read the returned list expect to exercise the retain path — but on `List<str>`, the *release* path of the source also skips str destruction (because the destructor only emits `emitStrElemLoop` when `elemSig == "str"`). Retain omission + release omission = leak, not UAF, so the test passes whether or not the retain was implemented. Do NOT rely on `List<str>` UAF tests alone to prove a retain fix is wired up; add a `List<List<int>>` or `List<Map<K,V>>` case (where `list_elem_type_name` *is* populated — see `codegen_stmt.cpp` annotation branch at ~647) or inspect IR for the `cow_*_elem_loop` retain block.
+
+**Why**: `codegen_expr_literal.cpp`'s list-literal path sets `list_elem_type_name = inferCollectionTypeName(vals[0])`, which returns `""` for string values. The annotation branch in `codegen_stmt.cpp:emitVarDecl` (~647-672) fills in `List<Map<…>>`, `List<Set<…>>`, `List<List<…>>`, `List<function(…)>`, `List<Tuple<…>>`, `List<int>` etc., but has no arm that writes `"str"`. The only path that stamps `list_elem_type_name = "str"` is `emitStringToCharList` for `__ry_split_chars` in `codegen_builtin.cpp:225-234`. `elementTypeIsArcManaged` reads this field, so the retain is skipped for plain `List<str>`. Symmetrically, `getOrCreateCollectionDestructor` in `codegen_arc.cpp:843+` only emits str-element release when `elemSig == "str"`, so the element isn't released either — the heap string leaks (small) but no dangling pointer is produced.
+
+**How to apply**: When writing UAF regression tests for collection-element retain paths, prefer `List<List<int>>` / `List<Map<str,int>>` / `List<function(…) -> …>` over `List<str>`, or use both. When reviewing such a PR, verify the test discriminates — a test that passes before the fix indicates the test (or the surrounding metadata pipeline) is not catching what it claims to catch. Also note: #1204's own `list_range_index.test.ry` has the same `List<str>` blind spot — any future fix that addresses the missing `list_elem_type_name = "str"` annotation (possibly a follow-up issue) should re-verify #1204's tests then fail pre-fix.
+
+**Related**: #1204 (slice retain fix — same test pattern, same blind spot), #1235 (take retain fix — discovered property), #1046 (str ARC dispatch via side-table, independent of `list_elem_type_name`).
 
 ---
 

--- a/changelog.d/1235-take-arc-retain.md
+++ b/changelog.d/1235-take-arc-retain.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- `take(lst, n)` now ARC-retains reference-typed elements, preventing
+  use-after-free when the source list is released (same defect class
+  as #1204 for `emitListSlice`). (#1235)

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -602,6 +602,16 @@ llvm::Value *CodeGen::emitCollOp_take_impl(const CallExpr &e,
         // Copy elements
         builder_.CreateCall(memcpyFn, {newData, lf.data, dataSize});
 
+        // Reference-typed elements share ownership with the source list.
+        // memcpy duplicates raw pointers without bumping refcounts; without
+        // retention, releasing the source (or a dropped alias) frees the
+        // elements that the new prefix still points at (#1235, same defect
+        // class as #1204 for emitListSlice).
+        CollectionKind elemArcKind = CollectionKind::List;
+        if (elementTypeIsArcManaged(listPtr, CollectionKind::List, &elemArcKind)) {
+            emitCowRetainArcElements(newData, clampedN, "tk_elem", elemArcKind);
+        }
+
         // Set header fields
         storeListHeaderFields(newHeader, clampedN, clampedN, newData);
 

--- a/tests/spec/list_take_arc.test.ry
+++ b/tests/spec/list_take_arc.test.ry
@@ -1,0 +1,66 @@
+from runtime_internal import arc_live_count
+
+# Dynamic strings ("a" + "b") force heap allocation so the refcount actually
+# drops to zero when the source is released — otherwise literal interning
+# would mask any missing retain.
+describe("take() ARC retain (#1235)", ():
+  # NOTE: this List<str> case does not discriminate pre-fix from post-fix
+  # under ASan — List<str> literals currently get empty list_elem_type_name,
+  # so both retain and release are symmetrically skipped (leak, not UAF).
+  # Tracked by #1255.  The List<List<int>> and List<Map<...>> cases below
+  # are the ones that actually exercise the retain branch.
+  it("List<str> take retains str elements after source drop", ():
+    xs: List<str> = ["alpha" + "x", "beta" + "y", "gamma" + "z"]
+    ys = take(xs, 2)
+    xs = ["dropped"]
+    expect(ys[0]).to_eq("alphax")
+    expect(ys[1]).to_eq("betay")
+  )
+
+  it("List<List<int>> take retains inner lists after source drop", ():
+    xs: List<List<int>> = [[1, 2], [3, 4], [5, 6]]
+    ys = take(xs, 2)
+    xs = [[99]]
+    expect(ys).to_have_length(2)
+  )
+
+  it("List<Map<str, int>> take retains map values after source drop", ():
+    xs: List<Map<str, int>> = [{"a": 1}, {"b": 2}, {"c": 3}]
+    ys = take(xs, 2)
+    xs = [{"z": 999}]
+    expect(length(ys)).to_eq(2)
+  )
+
+  it("empty take of List<str> does not retain anything", ():
+    xs: List<str> = ["a" + "1", "b" + "2", "c" + "3"]
+    ys = take(xs, 0)
+    expect(ys).to_have_length(0)
+  )
+
+  # Differential leak test: compares arc_live_count growth with and without
+  # take() across the same 16-iteration loop shape.  If emitCollOp_take_impl
+  # added a retain without a matching release (e.g. destructor fails to resolve
+  # the element type), the overhead would grow roughly 2 headers per iteration
+  # (= ~32 at N=16).  Symmetric retain/release keeps overhead a small constant.
+  it("take does not leak per iteration on List<List<int>>", ():
+    base_before = arc_live_count()
+    xs_baseline: List<List<int>> = [[0]]
+    i = 0
+    while i < 16:
+      xs_baseline = [[1, 2], [3, 4], [5, 6]]
+      i = i + 1
+    base_delta = arc_live_count() - base_before
+
+    take_before = arc_live_count()
+    xs_take: List<List<int>> = [[0]]
+    ys_take: List<List<int>> = [[0]]
+    j = 0
+    while j < 16:
+      xs_take = [[1, 2], [3, 4], [5, 6]]
+      ys_take = take(xs_take, 2)
+      j = j + 1
+    take_delta = arc_live_count() - take_before
+
+    expect(take_delta - base_delta < 10).to_eq(true)
+  )
+)


### PR DESCRIPTION
## Summary

- `emitCollOp_take_impl` copied the prefix element buffer with `memcpy` but omitted ARC retain for reference-typed elements, so releasing the source list left the returned prefix holding dangling element pointers (heap-use-after-free on read, double-free on release) — same defect class as #1204 for `emitListSlice`.
- Mirror `emitListSlice`'s retain block: call `elementTypeIsArcManaged` on the source list metadata and emit `emitCowRetainArcElements` over the new prefix buffer when the element type is ARC-managed. Scalar paths (`List<int>`, `List<f64>`) are unchanged (false branch).
- Regression suite in `tests/spec/list_take_arc.test.ry` mirrors the #1204 pattern: `List<str>` (annotated — see #1255), `List<List<int>>`, `List<Map<str,int>>`, empty-take guard, and an `arc_live_count()` differential leak loop.

Out of scope: `propagateMeta` is tracked separately by #1240. A newly discovered `List<str>` metadata blind spot (empty `list_elem_type_name` → symmetric retain/release omission that neutralizes UAF tests) is filed as #1255; documented in KNOWLEDGE.md.

Closes #1235.

## Test plan

- [x] `./build/ry_tests` — 1894 passed
- [x] `./build/ry test -p` — 162 files, 0 failures
- [x] `./build/ry test tests/spec/list_take_arc.test.ry` — 5 passed
- [x] ASan + UBSan full suite (C++ + Ry self-test) — clean
- [x] TSan C++ (`ry_tests`, required) + Ry self-test (warn-only) — clean
- [x] libFuzzer × 3 targets × 60s each — 0 crashes
- [x] CHANGELOG fragment added (`changelog.d/1235-take-arc-retain.md`)
- [x] KNOWLEDGE.md updated (cross-reference on memcpy+retain rule; new entry on `List<str>` metadata blind spot)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed `take()` to properly handle reference-typed list elements, preventing data corruption when the source list is released.

* **Tests**
  * Added comprehensive tests for `take()` with various reference-typed elements and memory leak detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->