### PR TITLE
fix: propagate nested element metadata through appended() (#1239)

### DIFF
--- a/changelog.d/1239-appended-propagate-meta.md
+++ b/changelog.d/1239-appended-propagate-meta.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Fix `appended(lst, elem)` losing nested element metadata
+  (`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`,
+  `map_value_type_name`) when appending to collections such as
+  `List<List<int>>`, `List<Map<str, int>>`, or `List<function>`.
+  Second-level access on the resulting list (e.g.
+  `appended(xs, [5, 6])[0][0]`) now works correctly. (#1239)

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -462,6 +462,7 @@ llvm::Value *CodeGen::emitCollOp_appended(const CallExpr &e) {
         storeListHeaderFields(newHeader, newLen, newLen, newData);
 
         setTypeMeta(TypeMeta::ListElem, newHeader, elemTy);
+        propagateMeta(listPtr, newHeader);
         return newHeader;
     }
     return nullptr;

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -277,6 +277,14 @@ describe("List", ():
     expect(ys).to_have_length(3)
     expect(ys[2]).to_eq(3)
   )
+  it("appended preserves nested List<List<int>> element metadata (#1239)", ():
+    xs = [[1, 2], [3, 4]]
+    ys = appended(xs, [5, 6])
+    expect(ys).to_have_length(3)
+    expect(ys[0][0]).to_eq(1)
+    expect(ys[1][1]).to_eq(4)
+    expect(ys[2][0]).to_eq(5)
+  )
   it("should append! in place", ():
     xs = [1, 2]
     append!(xs, 3)


### PR DESCRIPTION
## Summary

- `CodeGen::emitCollOp_appended` only wrote `TypeMeta::ListElem` on the new list header and skipped the full source-level metadata copy, so `list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`, and `map_value_type_name` were lost.
- As a result, nested indexing on the result of `appended()` (e.g. `appended(xs, [5, 6])[0][0]` when `xs: List<List<int>>`) failed at compile time with `str does not support index access; use char_at(s, i) instead`.
- Fix: pair `setTypeMeta(TypeMeta::ListElem, ...)` with `propagateMeta(listPtr, newHeader)`, matching the #1205 fix for `emitListSlice` and the canonical rule in `KNOWLEDGE.md` ("Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`").

Closes #1239.

## Test plan

- [x] New regression test in `tests/spec/collections.test.ry` covers nested `List<List<int>>` appended → indexed access.
- [x] `./build/ry_tests` (1894 tests) pass.
- [x] `./build/ry test -p` (163 files) pass, including the new `(#1239)` case.
- [x] ASan + UBSan clean on both `ry_tests` and `ry test -p`.
- [x] TSan clean on `ry_tests` (required) and `ry test -p`.
- [x] libFuzzer: `fuzz_parser`, `fuzz_json`, `fuzz_utf8` each 60 s with no crashes.
- [x] Manual reproduction per issue body: `appended(xs, [5, 6])[0][0]` prints `1`; `ys[2][0]` prints `5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata loss when appending elements to nested collections. Accessing nested elements after append operations now works correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->