### PR TITLE
fix: propagate nested element metadata through take() (#1240)

### DIFF
--- a/changelog.d/1240-take-propagate-meta.md
+++ b/changelog.d/1240-take-propagate-meta.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Fix `take(lst, n)` losing nested element metadata
+  (`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`,
+  `map_value_type_name`) when taking the prefix of collections such as
+  `List<List<int>>`, `List<Map<str, int>>`, or `List<function>`.
+  Second-level access on the resulting list (e.g.
+  `take(xs, 2)[0][0]`) now works correctly. (#1240)

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -617,6 +617,7 @@ llvm::Value *CodeGen::emitCollOp_take_impl(const CallExpr &e,
         storeListHeaderFields(newHeader, clampedN, clampedN, newData);
 
         setTypeMeta(TypeMeta::ListElem, newHeader, elemTy);
+        propagateMeta(listPtr, newHeader);
         return newHeader;
     }
     return nullptr;

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -319,6 +319,14 @@ describe("List", ():
     ys = take(xs, -1)
     expect(ys).to_have_length(0)
   )
+  it("take preserves nested List<List<int>> element metadata (#1240)", ():
+    xs = [[1, 2], [3, 4], [5, 6]]
+    ys = take(xs, 2)
+    expect(ys).to_have_length(2)
+    expect(ys[0][0]).to_eq(1)
+    expect(ys[0][1]).to_eq(2)
+    expect(ys[1][0]).to_eq(3)
+  )
   it("should return original list from tap", ():
     xs = [1, 2, 3]
     ys = tap(xs, (x: int) => x * 2)


### PR DESCRIPTION
## Summary

- `emitCollOp_take_impl` was dropping source-level element metadata (`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`, `map_value_type_name`) when producing the new list header. Second-level access on the result (e.g. `take(xs, 2)[0][0]` for `List<List<int>>`) therefore failed with `"str does not support index access; use char_at(s, i) instead"`.
- Fix is a 1-line mirror of #1239 (`appended`) / #1205 (`slice`): pair `setTypeMeta` with `propagateMeta(src, newHeader)`. Canonical rule `KNOWLEDGE.md` "Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`" already tagged `take`.
- Added a regression test (`List<List<int>>`) following the #1239 precedent.

Closes #1240.

## Test plan

- [x] TDD: new test FAILs before the fix (`"str does not support index access..."`), PASSes after
- [x] `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p`
- [x] ASan + UBSan (`./build-asan/ry_tests` + `./build-asan/ry test -p`) clean
- [x] TSan C++ (`./build-tsan/ry_tests`) clean; Ry self-test warn-only (LargeMmapAllocator)
- [x] libFuzzer `fuzz_json` / `fuzz_utf8` 60s exit 0; `fuzz_parser` pre-existing crash triaged as #1259 (not caused by this PR — verified by stash + rebuild)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `take()` function would lose metadata for nested collection types (e.g., `List<List<int>>`), preventing second-level indexing operations from working correctly. Nested element access now functions as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->