### PR TITLE
fix: propagate nested element metadata through distinct() (#1241)

### DIFF
--- a/changelog.d/1241-distinct-propagate-meta.md
+++ b/changelog.d/1241-distinct-propagate-meta.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- Fix `distinct(lst)` losing nested element metadata
+  (`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`,
+  `map_value_type_name`) when deduplicating collections such as
+  `List<Map<str, int>>` or `List<function>`.
+  Second-level access on the resulting list (e.g.
+  `distinct(xs)[0]["a"]`) now works correctly. (#1241)

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -885,6 +885,7 @@ llvm::Value *CodeGen::emitCollOp_distinct(const CallExpr &e) {
     builder_.CreateStore(finalLen, builder_.CreateStructGEP(listHeaderTy_, newHeader, 0, "dist_len_ptr"));
 
     setTypeMeta(TypeMeta::ListElem, newHeader, elemTy);
+    propagateMeta(listVal, newHeader);
     return newHeader;
 }
 

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -249,6 +249,19 @@ describe("List", ():
     expect(ys[0]).to_eq(1)
     expect(ys[3]).to_eq(4)
   )
+  it("distinct preserves nested List<Map<str,int>> element metadata (#1241)", ():
+    xs: List<Map<str, int>> = [{"a": 1}]
+    ys = distinct(xs)
+    expect(ys).to_have_length(1)
+    expect(ys[0]["a"]).to_eq(1)
+  )
+  it("distinct preserves nested List<function(int) -> int> element metadata (#1241)", ():
+    xs: List<function(int) -> int> = [(x: int) => x + 1]
+    ys = distinct(xs)
+    expect(ys).to_have_length(1)
+    f = ys[0]
+    expect(f(5)).to_eq(6)
+  )
   it("should flatten", ():
     xs = [[1, 2], [3, 4]]
     ys = flatten(xs)


### PR DESCRIPTION
## Summary

- `emitCollOp_distinct` now calls `propagateMeta(listVal, newHeader)` after `setTypeMeta(TypeMeta::ListElem, ...)`, preserving source-level metadata (`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`, `map_value_type_name`, etc.) on the deduplicated result. Previously, only the LLVM-level element type was recorded and downstream nested access / generic dispatch silently fell through to defaults.
- Completes the defect-class audit begun by #1205 (slice), #1239 (appended), and #1240 (take). Canonical rule is already documented in `KNOWLEDGE.md` ("Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`").

## Tests

Added two regression cases to `tests/spec/collections.test.ry` matching the sibling test naming convention ("preserves nested ... element metadata"):

- `List<Map<str, int>>` — second-level index access `distinct(xs)[0]["a"]` now works.
- `List<function(int) -> int>` — closure invocation `distinct(xs)[0](...)` now works.

Single-element inputs sidestep the pre-existing strcmp UB on multi-element non-string pointer lists (see scope-out issue #1262).

Fix-free runs of these tests fail with `str does not support index access` / closure dispatch failures — confirming the bug.

## Scope-out

Filed #1262 for a separate pre-existing defect discovered during exploration: `distinct()`'s codegen guard only rejects `List<List<T>>`, so `List<Map<>>` / `List<function>` with multiple elements reach a `strcmp` on arbitrary pointer payloads (UB). Independent of this PR.

## Test plan

- [x] `./build/ry test tests/spec/collections.test.ry` — 157 passed
- [x] `./build/ry_tests` — 1894 passed
- [x] `./build/ry test -p` — 163 files, 0 failures
- [x] ASan+UBSan (C++ + Ry self-test) — clean
- [x] TSan (C++) — clean
- [x] libFuzzer parser/json/utf8 — 60s each, 0 crashes

Closes #1241

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the `distinct()` function that was inadvertently dropping metadata from nested collection elements during deduplication. Nested element access operations on deduplicated results—such as indexing followed by key access—now function correctly for complex types including lists of maps and lists of functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->