### PR TITLE
fix: pass --use-analyzer to scan-build for mirror tarball path (#1247)

### DIFF
--- a/.claude/skills/ci-investigate/SKILL.md
+++ b/.claude/skills/ci-investigate/SKILL.md
@@ -142,7 +142,7 @@ Map the CI job name to its local reproduction command and run it:
 | `test (tsan)` / `tsan` | `cmake --preset tsan && cmake --build build-tsan && TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests` |
 | `clang-tidy` | `find src -name '*.cpp' \| xargs clang-tidy -p build --quiet` |
 | `cppcheck` / `lint` | `cppcheck --enable=warning,performance,portability --std=c++17 --suppressions-list=.cppcheck-suppressions --inline-suppr -i build -i build-asan -i build-tsan -j "$(nproc)" --quiet src/ include/` |
-| `scan-build` | `scan-build --use-cc=/usr/local/llvm/bin/clang --use-c++=/usr/local/llvm/bin/clang++ cmake --build build` |
+| `scan-build` | `scan-build --use-analyzer=/usr/local/llvm/bin/clang --use-cc=/usr/local/llvm/bin/clang --use-c++=/usr/local/llvm/bin/clang++ cmake --build build` |
 
 **Known CI-only failure patterns (do not misclassify as PR-caused):**
 

--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -97,6 +97,7 @@ jobs:
       - name: Configure
         run: |
           scan-build \
+            --use-analyzer=/usr/local/llvm/bin/clang \
             --use-cc=/usr/local/llvm/bin/clang \
             --use-c++=/usr/local/llvm/bin/clang++ \
             cmake --preset default
@@ -106,6 +107,7 @@ jobs:
         continue-on-error: true
         run: |
           scan-build \
+            --use-analyzer=/usr/local/llvm/bin/clang \
             --use-cc=/usr/local/llvm/bin/clang \
             --use-c++=/usr/local/llvm/bin/clang++ \
             -o scan-build-report \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
       - name: Configure
         run: |
           scan-build \
+            --use-analyzer=/usr/local/llvm/bin/clang \
             --use-cc=/usr/local/llvm/bin/clang \
             --use-c++=/usr/local/llvm/bin/clang++ \
             cmake --preset default
@@ -142,6 +143,7 @@ jobs:
         continue-on-error: true
         run: |
           scan-build \
+            --use-analyzer=/usr/local/llvm/bin/clang \
             --use-cc=/usr/local/llvm/bin/clang \
             --use-c++=/usr/local/llvm/bin/clang++ \
             -o scan-build-report \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,10 +62,12 @@ CI の `scan-build` ジョブがシンボリック実行ベースのパス感度
 - `compile_commands.json` は使用しない（scan-build がビルドをラップして解析する）
 - ローカル実行:
   ```bash
-  scan-build --use-cc=/usr/local/llvm/bin/clang \
+  scan-build --use-analyzer=/usr/local/llvm/bin/clang \
+             --use-cc=/usr/local/llvm/bin/clang \
              --use-c++=/usr/local/llvm/bin/clang++ \
              cmake --preset default
-  scan-build --use-cc=/usr/local/llvm/bin/clang \
+  scan-build --use-analyzer=/usr/local/llvm/bin/clang \
+             --use-cc=/usr/local/llvm/bin/clang \
              --use-c++=/usr/local/llvm/bin/clang++ \
              -o /tmp/scan-build-report \
              --status-bugs \

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -4539,3 +4539,37 @@ both lands in the original `"argument N requires <type>"` message.
 mixed-type calls) have their own hardcoded `!= cg.f64Ty_` guards and bypass
 the table-driven path entirely. They still reject `int` args. Tracked in
 issue #1230.
+
+### scan-build: mirror tarball uses Debian-patched path for FindClang
+
+**Source**: #1247 (2026-04-20)
+**Tags**: ci, scan-build, llvm, mirror, static-analysis
+
+**Rule**: The Debian-patched `scan-build` Perl script bundled in the LLVM
+mirror tarball (via `clang-tools-{MAJOR}`) has a hard-coded fallback path
+in `FindClang()` (line 1508) that points at `/usr/lib/llvm-{MAJOR}/bin/clang`.
+The mirror tarball extracts to `/usr/local/llvm`, so that Debian path does
+not exist on the runner. Always pass `--use-analyzer=/usr/local/llvm/bin/clang`
+explicitly to `scan-build` — `--use-cc` controls only the build-time compiler
+and is ignored by the analyzer-clang lookup.
+
+**Why**: Before the mirror tarball was introduced, `setup-llvm` fell back
+to `apt.llvm.org`, which populates `/usr/lib/llvm-{MAJOR}/`, so the
+hard-coded Debian path resolved accidentally and `scan-build` worked
+without `--use-analyzer`. Once the mirror took over, the path no longer
+exists and `FindClang()` exhausts all three lookup candidates
+(`$RealBin/bin/clang`, `/usr/lib/llvm-{MAJOR}/bin/clang`, Xcode toolchain)
+and leaves `$Clang` undefined, producing
+`Use of uninitialized value $Clang in concatenation` and
+`scan-build: error: Cannot find an executable 'clang' relative to scan-build`.
+
+**How to apply**: In every CI `scan-build` invocation (`.github/workflows/ci.yml`,
+`.github/workflows/ci-scheduled.yml`) and every local-execution example in
+`AGENTS.md`, include `--use-analyzer=/usr/local/llvm/bin/clang` alongside
+`--use-cc` / `--use-c++`. macOS Homebrew `scan-build` does not have the
+Debian patch, so the flag is redundant there — but keeping it uniform
+prevents drift between local and CI invocations.
+
+**How to verify**: `grep -n 'scan-build' .github/workflows/*.yml AGENTS.md`
+and confirm `--use-analyzer` accompanies every invocation. In CI logs, the
+`Use of uninitialized value $Clang` warning must be absent.


### PR DESCRIPTION
## Summary

- Add `--use-analyzer=/usr/local/llvm/bin/clang` to every `scan-build` invocation across `ci.yml`, `ci-scheduled.yml`, the `ci-investigate` skill's local reproduction table, and the `AGENTS.md` local-execution example.
- Document the root cause (Debian-patched `scan-build` with hard-coded `/usr/lib/llvm-{MAJOR}/bin/clang` fallback) in `KNOWLEDGE.md`.

## Root cause

The mirror tarball produced by `mirror-llvm-toolchain.yml` bundles the Debian-patched `scan-build` Perl script. Its `FindClang()` (line 1504-1525) tries three candidates and falls back to `/usr/lib/llvm-21/bin/clang`. The mirror tarball extracts to `/usr/local/llvm`, so the Debian path no longer exists on the runner and `$Clang` is left undefined, producing `Cannot find an executable 'clang' relative to scan-build`. Before the mirror existed, `setup-llvm` fell back to `apt.llvm.org` which populates `/usr/lib/llvm-21/`, masking the bug.

`--use-cc` only controls the build-time compiler; the analyzer clang is a separate variable. `--use-analyzer` is the correct knob.

## Test plan

- [ ] Trigger `ci-scheduled.yml` via `workflow_dispatch` and confirm the `scan-build` job Configure + Build + Analyze steps succeed without `Use of uninitialized value $Clang` or `Cannot find an executable 'clang'`.
- [ ] Confirm CI logs for the `scan-build` job show `scan-build: Using '/usr/local/llvm/bin/clang' for static analysis` (or equivalent) once run.

> Note: `ci.yml`'s `scan-build` job only fires on `push` to `main`, so it cannot be exercised from this PR. `ci-scheduled.yml` is the effective validation channel. Local macOS Homebrew `scan-build` does not carry the Debian patch and therefore cannot reproduce the failure, but the flag is harmless there.

Closes #1247

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved static analysis tool configuration consistency across CI workflows with explicit analyzer settings.

* **Documentation**
  * Updated local setup and build guides to align with CI configurations.
  * Added documentation addressing a static analysis failure mode, including resolution steps and verification checklist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->