### PR TITLE
fix: reject non-str pointer elements in distinct() at compile time (#1262)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1057,6 +1057,31 @@ newHeader)`. Helpers that change element type (`flatten`, `enumerate`,
 precedent in `src/codegen_call.cpp:366-443` that manually constructs
 `list_elem_type_name = "(T1, T2)"`.
 
+### Collection ops on pointer elements: guard on `list_elem_type_name`, not on `NestedListElem` alone
+
+**Source**: #1262 (2026-04-21, bugfix)
+**Tags**: codegen, collections, distinct, guard, UB, strcmp, list_elem_type_name, positive-whitelist
+
+**Rule**: When a collection helper's pointer-element branch uses `strcmp` (or any other C-string operation), the guard **must** use a positive allowlist based on `list_elem_type_name`, not a single-field blacklist via `getNestedListElementType`:
+
+```cpp
+if (elemTy == ptrTy_) {
+    const ValueMetadata *meta = getMeta(listVal);
+    const std::string &elemName = meta ? meta->list_elem_type_name : std::string{};
+    const bool isNonStrName = !elemName.empty() && elemName != "str";
+    const bool hasNestedList = meta && meta->nested_list_elem != nullptr;
+    const bool hasFnInfo = meta && meta->list_elem_fn_type_info.has_value();
+    if (isNonStrName || hasNestedList || hasFnInfo)
+        codegenError("<op>() is only supported for lists of primitive values or strings");
+}
+```
+
+**Why**: `getNestedListElementType` only checks `TypeMeta::NestedListElem`, which `propagateTypeMeta` sets only in the `isListTypeName` branch. Map/Set/function element kinds live in different fields (`map_value_type_name`, `list_elem_fn_type_info`). A blacklist on a single field is structurally incomplete — `List<Map<K,V>>` / `List<function(...)>` / `List<Set<T>>` all slip through and `strcmp` runs on Map/Set/closure headers (undefined behaviour). `inferCollectionTypeName` (`src/codegen_builtin.cpp:242-274`) returns non-empty `"Map<...>"` / `"List<...>"` / `"Set<...>"` for non-str pointer types, so treating `""` as str is safe (see sibling entry "List<str> literals can have empty list_elem_type_name"). Resource element lists (`List<TcpStream>`) get a non-empty `list_elem_type_name` and are caught by `isNonStrName`; do not check the list value's own `resource_kinds` — lists are not resources themselves, so that field is always empty for list containers. Access `nested_list_elem` directly on the cached `meta` pointer instead of calling `getNestedListElementType` to avoid a second `value_metadata_` lookup.
+
+**How to apply**: `emitListRemove` (`src/codegen_call_collection.cpp:232`) and the `in` / `not in` list branch (`src/codegen_expr.cpp` around line 1555) have the same deficiency — mirror this guard pattern when fixing them. Always pair with direct regression tests: add a `List<Map<str,int>>` / `List<function(...)>` / `List<Set<T>>` case that expects `expectCompileError`; a single-element list must not be the sole reproduction because `curOutLen == 0` masks the symptom on the first iteration of the dedup loop.
+
+**Related**: #1241 (`propagateMeta` added to `distinct` — did not address the guard), "List<str> literals can have empty list_elem_type_name" (#1235), "Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`".
+
 ### New dispatch branches in `emitArithmeticOp` must precede the str-vs-non-str reject
 
 **Source**: #863 (2026-04-11)

--- a/changelog.d/1262-distinct-guard.md
+++ b/changelog.d/1262-distinct-guard.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `distinct()` now emits a compile error for lists of non-string pointer
+  elements such as `List<Map<K, V>>`, `List<function(...) -> R>`, and
+  `List<Set<T>>`. Previously the guard only rejected `List<List<T>>` and
+  silently fell through to a `strcmp` on non-C-string pointers, which is
+  undefined behaviour. (#1262)

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -519,7 +519,7 @@ print(xs)   # [1, 3, 2, 4]
 
 ### distinct
 
-Returns a new list with duplicate elements removed. The original order is preserved (first occurrence kept). The original list is not modified.
+Returns a new list with duplicate elements removed. The original order is preserved (first occurrence kept). The original list is not modified. Passing a list of non-string pointer elements (e.g. `List<List<T>>`, `List<Map<K, V>>`, `List<Set<T>>`, `List<function(...) -> R>`) is a compile error: `distinct() is only supported for lists of primitive values or strings`.
 
 ```ry
 xs = [1, 2, 3, 2, 1, 4]

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -772,9 +772,19 @@ llvm::Value *CodeGen::emitCollOp_distinct(const CallExpr &e) {
     if (!elemTy)
         codegenError("distinct() requires a list as argument");
 
-    // Reject non-string pointer elements (e.g. list-of-lists) -- strcmp would be UB
-    if (elemTy == ptrTy_ && getNestedListElementType(listVal))
-        codegenError("distinct() is not supported for lists of non-string pointer elements");
+    // Reject non-str pointer elements: the dedup inner loop calls strcmp, which is
+    // UB on Map/Set/List/closure headers. Positive allowlist on list_elem_type_name
+    // (empty or "str" counts as str) with structural fallbacks for NestedListElem /
+    // list_elem_fn_type_info in case the name is unset.
+    if (elemTy == ptrTy_) {
+        const ValueMetadata *meta = getMeta(listVal);
+        const std::string &elemName = meta ? meta->list_elem_type_name : std::string{};
+        const bool isNonStrName = !elemName.empty() && elemName != "str";
+        const bool hasNestedList = meta && meta->nested_list_elem != nullptr;
+        const bool hasFnInfo = meta && meta->list_elem_fn_type_info.has_value();
+        if (isNonStrName || hasNestedList || hasFnInfo)
+            codegenError("distinct() is only supported for lists of primitive values or strings");
+    }
 
     auto lf = loadListHeader(listVal, "dist_src");
 

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -249,19 +249,6 @@ describe("List", ():
     expect(ys[0]).to_eq(1)
     expect(ys[3]).to_eq(4)
   )
-  it("distinct preserves nested List<Map<str,int>> element metadata (#1241)", ():
-    xs: List<Map<str, int>> = [{"a": 1}]
-    ys = distinct(xs)
-    expect(ys).to_have_length(1)
-    expect(ys[0]["a"]).to_eq(1)
-  )
-  it("distinct preserves nested List<function(int) -> int> element metadata (#1241)", ():
-    xs: List<function(int) -> int> = [(x: int) => x + 1]
-    ys = distinct(xs)
-    expect(ys).to_have_length(1)
-    f = ys[0]
-    expect(f(5)).to_eq(6)
-  )
   it("should flatten", ():
     xs = [[1, 2], [3, 4]]
     ys = flatten(xs)

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2105,6 +2105,30 @@ TEST_F(CodeGenTest, DistinctVariants) {
     }
 }
 
+TEST_F(CodeGenTest, DistinctRejectsPointerElements) {
+    const std::string err = "distinct() is only supported for lists of primitive values or strings";
+
+    expectCompileError(
+        "xs: List<Map<str, int>> = [{\"a\": 1}]\n"
+        "ys = distinct(xs)\n",
+        err);
+
+    expectCompileError(
+        "xs: List<function(int) -> int> = [(x: int) => x + 1]\n"
+        "ys = distinct(xs)\n",
+        err);
+
+    expectCompileError(
+        "xs: List<List<int>> = [[1, 2], [3, 4]]\n"
+        "ys = distinct(xs)\n",
+        err);
+
+    expectCompileError(
+        "xs: List<Set<int>> = [{1, 2}]\n"
+        "ys = distinct(xs)\n",
+        err);
+}
+
 // ===== merge(map1, map2) テスト =====
 
 TEST_F(CodeGenTest, MapMergeVariants) {


### PR DESCRIPTION
## Summary

Closes #1262.

The previous guard in `emitCollOp_distinct` (`src/codegen_call_collection.cpp:775-777`) only checked `TypeMeta::NestedListElem` via `getNestedListElementType()`, which is set exclusively by the `List<List<_>>` branch of `propagateTypeMeta`. `List<Map<K,V>>`, `List<function(...)>`, and `List<Set<T>>` all slipped through and the dedup inner loop called `strcmp` on Map/Set/closure header pointers (undefined behaviour).

### Fix

Replace the single-field blacklist with a positive allowlist on `list_elem_type_name` (empty or `"str"` counts as str — see KNOWLEDGE.md "List<str> literals can have empty list_elem_type_name") plus structural fallbacks on `nested_list_elem` and `list_elem_fn_type_info` for cases where the name is unset.

```cpp
if (elemTy == ptrTy_) {
    const ValueMetadata *meta = getMeta(listVal);
    const std::string &elemName = meta ? meta->list_elem_type_name : std::string{};
    const bool isNonStrName = !elemName.empty() && elemName != "str";
    const bool hasNestedList = meta && meta->nested_list_elem != nullptr;
    const bool hasFnInfo = meta && meta->list_elem_fn_type_info.has_value();
    if (isNonStrName || hasNestedList || hasFnInfo)
        codegenError("distinct() is only supported for lists of primitive values or strings");
}
```

Resource element lists (`List<TcpStream>`) get a non-empty `list_elem_type_name` and are caught by `isNonStrName`. The list value's own `resource_kinds` field is not consulted — lists are not resources themselves, so that field is always empty for list containers.

### Scope

Only `distinct()`. Sibling call sites with the same deficiency are filed as scope-out issues:
- `emitListRemove` (`src/codegen_call_collection.cpp:232`) → #1268
- `in` / `not in` list branch (`src/codegen_expr.cpp` around line 1555) → #1269

A third potential site — Set pointer element `__ry_ht_find_str` — was already audited and fixed via #963 (documented in KNOWLEDGE.md lines 1284-1348), so no new issue was filed.

### Breaking change

Two `it(...)` blocks from #1241 in `tests/spec/collections.test.ry` that exercised `distinct` on `List<Map<str,int>>` and `List<function(int) -> int>` are removed — those inputs are now compile errors. The underlying `propagateMeta` behavior they covered is still exercised by `slice` / `take` / `appended` and other same-element-type helpers.

## Test plan

- [x] `./build/ry_tests --gtest_filter='*Distinct*'` — PASS (includes the new `DistinctRejectsPointerElements` with 4 cases: `List<Map<_>>`, `List<function(_)>`, `List<List<_>>`, `List<Set<_>>`)
- [x] `./build/ry_tests` full suite — 1905 tests PASS
- [x] `./build/ry test -p` self-test — 9 passed, 0 failed (163 files)
- [x] ASan + UBSan full run — clean
- [x] TSan full run — clean (C++ required; self-test warn-only per AGENTS.md)
- [x] libFuzzer × 3 targets (parser / json / utf8) 60s each — clean
- [x] Fail-never verification: temporarily reverted the new guard and confirmed the 4 new test cases FAIL against the old single-field blacklist, then restored and reconfirmed PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `distinct()` now rejects at compile time when applied to lists containing non-string pointer elements (maps, sets, function types, and nested lists). Previously, unsafe string-comparison operations could occur.

* **Documentation**
  * Updated `distinct()` reference documentation to specify the compile-time restriction for non-string pointer-element list types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->