### PR TITLE
fix: retain ARC container elements loaded via GEP (#1266)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1400,6 +1400,106 @@ emits a compile error: `"'in'/'not in' operator: left side must be str when righ
 **Empty needle**: `"" in s` is `true` for any `s` — the runtime (`__ry_str_find_byte`)
 returns `0` when `nl == 0`, matching Python and the existing `contains` semantics.
 
+### `tryRetainArcSource` LoadInst cases must be metadata-gated
+
+**Source**: #1266 (2026-04-21, fix)
+**Tags**: codegen, arc, retain, tryRetainArcSource, container-element, GEP-load, memory-safety
+
+**Context**: `tryRetainArcSource` is the central retain-side helper for AssignStmt
+(new variable + reassignment), function return, call-site argument pass, match
+binding, type coercion, and lambda capture. Until #1266 it covered only
+LoadInst-from-alloca (Case 1), arc_owned values (Case 2), and ExtractValue with
+container metadata (Case 3) — leaving GEP-loaded container elements (`xs[i]`,
+`m[k]`, `for e in set { ... }`) without a retain. Once #1242 lands the
+destructor-side recursive release, this gap immediately becomes a UAF: 
+`inner = xs[0]; xs = []` would drop the inner list while `inner` still holds it.
+
+**Rule**: When adding a new LoadInst case to `tryRetainArcSource`, gate on
+container-element metadata exactly like Case 3:
+
+```cpp
+if (llvm::isa<llvm::LoadInst>(val) && val->getType() == ptrTy_) {
+    auto *meta = getMeta(val);
+    if (meta && (meta->list_elem || meta->map_key ||
+                 meta->map_value || meta->set_elem)) { /* retain */ }
+}
+```
+
+A bare `ptrTy_` type check is **not** sufficient: weak refs, capturing closures,
+bare function pointers, and resource handles are all `ptrTy_` and would receive
+spurious retains that crash on `−16` offset GEPs into header memory that does
+not belong to ArcHeader. The metadata gate is the same protection #999 added to
+Case 3 for ExtractValueInst.
+
+**Why not switch all callers to `retainArcValue` instead?**: `retainArcValue`'s
+fallback (`emitArcGetHeaderFromData(val)` + `emitArcRetain(...)`) is unconditional.
+That works for IndexAssignStmt / FieldAssignStmt (#1108 / #857) where the
+caller has already proven the slot is ARC-managed, but it is unsafe for
+`tryRetainArcSource`'s callers — `return 42` (i64), `f(closure_arg)` (closure
+ptr), or `let x = weak_ref` (weak ref) all reach these sites without an upstream
+type guarantee. Adding the case inside `tryRetainArcSource` keeps the metadata
+gate as the single audit point.
+
+**`map_value` belongs in the gate too**: For `Map<K,V>`, `propagateTypeMeta` sets
+both `MapKey` and `MapValue` flags — `m["a"]` returns the value side, so a gate
+that omits `map_value` would miss it. Case 3 currently uses
+`list_elem || map_key || set_elem`; if you ever add a Case-3-style retain on a
+new instruction kind, include `map_value` (and double-check whether Case 3
+itself is missing it for some scenario). Verified for Case 4 in #1266; not
+audited for Case 3 yet.
+
+**str elements need a separate flag and a separate header offset**: A str
+container element (`xs: List<str>`, `m: Map<K,str>`) uses
+`StringHeader` at offset −24, not `ArcHeader` at −16. Case 4 discriminates via
+a dedicated `ValueMetadata::str_elem` bool set by `propagateTypeMeta` when the
+element type name resolves to `"str"`, and dispatches to
+`emitStrGetHeaderFromData` instead of `emitArcGetHeaderFromData`. Do not be
+tempted to reuse `low_level_type_name == "str"` — `isLowLevelTypeName` only
+matches numeric types (i8–i64, u8–u64, f32), so the branch would never fire,
+and extending it to include `"str"` pollutes the arith/cast/tostring paths
+that switch on `low_level_type_name`.
+
+**Do NOT stamp `list_elem_type_name = "str"` as the signal for List<str>**:
+That field is also read by `resolveCollectionDestructor`, and setting it to
+`"str"` flips the destructor to the str-aware variant which iterates the
+element buffer and calls `emitArcRelease` on each element. That is the right
+destructor — but it exposes a pre-existing ARC live-count asymmetry: list
+headers are allocated via `__ry_arc_alloc_counted` (counter +1) while str
+handles go through `makeString` (counter no-op). Every str element release
+then subtracts 1 from a counter it never contributed to, breaking
+`arc_split_chars.test.ry` with a large negative delta. The destructor switch
+belongs to #1242; #1266 only needs to reach the indexer. Use the side-channel
+`ValueMetadata::list_elem_is_str` set by the AssignStmt annotation parser
+(`codegen_stmt.cpp`) and read only by the list indexer
+(`codegen_expr_literal.cpp` in `emitExprVariant(IndexExpr)` list branch) to
+stamp `str_elem` on the loaded element without touching
+`list_elem_type_name`. Map<K,str> does not need this side-channel because
+`map_value_type_name = "str"` is already wired correctly on the destructor
+side (Map values are released symmetric with the str allocation in
+`makeStringKeyedMap`-style callers).
+
+**Function parameters use a different path and do not need the side-channel**:
+`applyParamTypeMeta` in `codegen_fn.cpp` calls `propagateTypeMeta(ptype,
+alloca)` directly, so a `xs: List<str>` parameter alloca picks up
+`list_elem_type_name = "str"` via the existing path. The list indexer then
+sees that name, calls `propagateTypeMeta("str", elem)`, and `str_elem` lands
+on the loaded element. This is safe for parameters because the parameter
+alloca is a borrowed view — destructor selection happens at the **caller's
+allocation site**, not at the parameter slot. Only AssignStmt (which IS the
+allocation site for new variables) must avoid `list_elem_type_name = "str"`.
+
+**Verification pattern**: Behavioural ARC tests using
+`runtime_internal.arc_live_count()` cannot detect missed retains directly —
+the counter tracks live allocations, not refcount. Use a FileCheck IR golden
+under `tests/filecheck/` that asserts the `arc.retain:` / `arc.retain.done:`
+basic-block labels appear after the container-element load, and that the
+`getelementptr i8, ptr %elem, i64 -16` (ArcHeader) or `i64 -24` (StringHeader)
+offset matches the element's actual header layout. See
+`tests/filecheck/arc_retain_list_elem_*.ry`,
+`tests/filecheck/arc_retain_map_value_new_var.ry`,
+`tests/filecheck/arc_retain_list_str_elem.ry`, and
+`tests/filecheck/arc_retain_map_str_value.ry` for canonical patterns.
+
 ### Pattern binding ARC and `emitPatternBindingArc`
 
 **Source**: #997 (2026-04-16, fix)

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1451,13 +1451,25 @@ audited for Case 3 yet.
 **str elements need a separate flag and a separate header offset**: A str
 container element (`xs: List<str>`, `m: Map<K,str>`) uses
 `StringHeader` at offset −24, not `ArcHeader` at −16. Case 4 discriminates via
-a dedicated `ValueMetadata::str_elem` bool set by `propagateTypeMeta` when the
-element type name resolves to `"str"`, and dispatches to
-`emitStrGetHeaderFromData` instead of `emitArcGetHeaderFromData`. Do not be
-tempted to reuse `low_level_type_name == "str"` — `isLowLevelTypeName` only
-matches numeric types (i8–i64, u8–u64, f32), so the branch would never fire,
-and extending it to include `"str"` pollutes the arith/cast/tostring paths
-that switch on `low_level_type_name`.
+a dedicated `ValueMetadata::str_elem` bool and dispatches to
+`emitStrGetHeaderFromData` instead of `emitArcGetHeaderFromData`.
+
+**`str_elem` must ONLY be stamped in the List<str> / Map<K,str> / Set<str>
+indexer paths** — `codegen_expr_literal.cpp` (List indexer reads
+`list_elem_is_str`) and wherever a map/set str value is loaded. Do NOT stamp
+it from a shared helper like `propagateTypeMeta("str", ...)`: that helper is
+called from ~50 sites (pattern bindings, enum variant fields, Result/Option
+payload, function return meta, tuple destructure, …) and many of those are
+str values that are **not** container-element borrows. Stamping `str_elem`
+there makes Case 4 dispatch through `emitStrGetHeaderFromData(val)` —
+`val - 24` — on a pointer that does not own a `StringHeader`, corrupting
+adjacent heap state. The corruption is often invisible under macOS libSystem
+malloc but crashes under glibc (tested in CI Linux on `enum_generic_param_type.test.ry`'s
+`MyOpt<str>::MySome(v)` pattern binding, SIGSEGV / exit 139). Do not be
+tempted to reuse `low_level_type_name == "str"` either — `isLowLevelTypeName`
+only matches numeric types (i8–i64, u8–u64, f32), so the branch would never
+fire, and extending it to include `"str"` pollutes the arith/cast/tostring
+paths that switch on `low_level_type_name`.
 
 **Do NOT stamp `list_elem_type_name = "str"` as the signal for List<str>**:
 That field is also read by `resolveCollectionDestructor`, and setting it to

--- a/changelog.d/1266-arc-retain-case4.md
+++ b/changelog.d/1266-arc-retain-case4.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- ARC retain now fires for container element loads (`xs = ys[i]`,
+  `v = m["k"]`, function return, call-site argument passing) for nested
+  ARC containers and `List<str>` / `Map<K,str>` borrows. Previously
+  missed in `AssignStmt`, `return`, caller-side argument passing, match
+  binding, type coercion, and lambda capture — every caller of
+  `tryRetainArcSource`. Prerequisite for the `#1242` destructor fix that
+  makes nested collection headers reclaimable. (#1266)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -941,6 +941,25 @@ public:
         llvm::SmallVector<int, 2> resource_kinds;
         bool json_type_only = false;
 
+        // Set when propagateTypeMeta receives the type name "str". Allows
+        // tryRetainArcSource Case 4 to discriminate str container elements
+        // (StringHeader at offset -24) from ARC nested containers (ArcHeader
+        // at offset -16) without polluting low_level_type_name (which arith /
+        // cast / tostring branch on). (#1266)
+        bool str_elem = false;
+
+        // Set on a List container when the AssignStmt annotation declares
+        // List<str>. Read at indexing time to stamp str_elem on the loaded
+        // element so Case 4 can retain it. Deliberately separate from
+        // list_elem_type_name — that field drives resolveCollectionDestructor
+        // selection and switching it to "str" enables the str-aware
+        // destructor that depends on the unfinished ARC counter symmetry for
+        // str (= #1242 territory). Set<str> isn't covered here because the
+        // only source-level loaded element binding is `for e in s`, which
+        // already snapshots the iterable rather than retaining per element.
+        // (#1266)
+        bool list_elem_is_str = false;
+
         // Mutation helper (avoids duplicates in resource_kinds)
         void addResourceKind(int rk);
 

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -853,7 +853,7 @@ bool CodeGen::tryRetainArcSource(llvm::Value *val) {
             if (isArcContainerElem || isStrElem) {
                 auto *hdr = isStrElem ? emitStrGetHeaderFromData(val)
                                       : emitArcGetHeaderFromData(val);
-                emitArcRetain(hdr, /*atomic=*/false);
+                emitArcRetain(hdr, isArcAtomic(val));
                 return true;
             }
         }

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -837,6 +837,27 @@ bool CodeGen::tryRetainArcSource(llvm::Value *val) {
             return true;
         }
     }
+    // Case 4: GEP-loaded container element borrowed from a long-lived
+    // container. Two metadata gates dispatch to different headers:
+    //   - list_elem / map_key / map_value / set_elem → ArcHeader (-16)
+    //   - str_elem                                   → StringHeader (-24)
+    // Gated on metadata so non-ARC ptrTy_ loads (weak refs, bare fn pointers)
+    // are not incorrectly retained — same guard pattern as Case 3 (#1266).
+    if (llvm::isa<llvm::LoadInst>(val) && val->getType() == ptrTy_) {
+        auto *meta = getMeta(val);
+        if (meta) {
+            const bool isArcContainerElem =
+                meta->list_elem || meta->map_key ||
+                meta->map_value || meta->set_elem;
+            const bool isStrElem = meta->str_elem;
+            if (isArcContainerElem || isStrElem) {
+                auto *hdr = isStrElem ? emitStrGetHeaderFromData(val)
+                                      : emitArcGetHeaderFromData(val);
+                emitArcRetain(hdr, /*atomic=*/false);
+                return true;
+            }
+        }
+    }
     return false;
 }
 

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -171,6 +171,13 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         propagateTypeMeta(resolved.substr(0, resolved.size() - 1), val);
     } else if (isLowLevelTypeName(resolved)) {
         getOrCreateMeta(val).low_level_type_name = resolved;
+    } else if (resolved == "str") {
+        // str is not a "low-level" type for arith/cast purposes (it is heap-
+        // allocated and ARC-managed via StringHeader at offset -24), so we
+        // stamp a dedicated flag instead of low_level_type_name. This is read
+        // by tryRetainArcSource Case 4 to retain str container elements
+        // borrowed from List<str> / Map<K,str> / Set<str>. (#1266)
+        getOrCreateMeta(val).str_elem = true;
     } else if (ensureEnumInstantiated(resolved)) {
         // Concrete enum or generic enum instantiation: tag the value so
         // valueToString() dispatches on enum_value_type metadata (#820).

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -171,13 +171,6 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         propagateTypeMeta(resolved.substr(0, resolved.size() - 1), val);
     } else if (isLowLevelTypeName(resolved)) {
         getOrCreateMeta(val).low_level_type_name = resolved;
-    } else if (resolved == "str") {
-        // str is not a "low-level" type for arith/cast purposes (it is heap-
-        // allocated and ARC-managed via StringHeader at offset -24), so we
-        // stamp a dedicated flag instead of low_level_type_name. This is read
-        // by tryRetainArcSource Case 4 to retain str container elements
-        // borrowed from List<str> / Map<K,str> / Set<str>. (#1266)
-        getOrCreateMeta(val).str_elem = true;
     } else if (ensureEnumInstantiated(resolved)) {
         // Concrete enum or generic enum instantiation: tag the value so
         // valueToString() dispatches on enum_value_type metadata (#820).

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -593,8 +593,15 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
         llvm::Value *mapVal = builder_.CreateLoad(mapValTy, valElemPtr, "map_val");
 
         auto *mvtnMeta = getMeta(objPtr);
-        if (mvtnMeta && !mvtnMeta->map_value_type_name.empty())
+        if (mvtnMeta && !mvtnMeta->map_value_type_name.empty()) {
             propagateTypeMeta(mvtnMeta->map_value_type_name, mapVal);
+            // Map<K,str>: stamp str_elem locally so Case 4 retains via
+            // StringHeader (-24). Kept inside the indexer (not in
+            // propagateTypeMeta) — see KNOWLEDGE.md "str_elem must ONLY be
+            // stamped in the … indexer paths". (#1266)
+            if (mvtnMeta->map_value_type_name == "str")
+                getOrCreateMeta(mapVal).str_elem = true;
+        }
 
         return mapVal;
     }
@@ -635,12 +642,16 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
             propagateTypeMeta(elemTypeName, elem);
         if (elemFnTypeInfo)
             getOrCreateMeta(elem).fn_type_info = *elemFnTypeInfo;
-        // List<str>: route through propagateTypeMeta so the "str" → str_elem
-        // mapping stays in one place. We intentionally avoid stamping
-        // list_elem_type_name="str" — that flips resolveCollectionDestructor
-        // to the str-aware variant (#1242 territory). (#1266)
+        // List<str>: container annotation hint is the only signal — we
+        // intentionally avoid stamping list_elem_type_name="str" because
+        // that flips resolveCollectionDestructor to the str-aware variant
+        // (#1242 territory). Stamp str_elem directly so Case 4 retains
+        // the borrowed handle. Do NOT route through propagateTypeMeta —
+        // that would expose the str→str_elem mapping to every caller and
+        // cause spurious retains on str-typed pattern bindings / enum
+        // variant fields / function returns, crashing under glibc. (#1266)
         if (listElemIsStr)
-            propagateTypeMeta("str", elem);
+            getOrCreateMeta(elem).str_elem = true;
     }
 
     return elem;

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -625,14 +625,22 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     {
         std::string elemTypeName;
         std::optional<FnTypeInfo> elemFnTypeInfo;
+        bool listElemIsStr = false;
         if (auto *listMeta = getMeta(objPtr)) {
             elemTypeName   = listMeta->list_elem_type_name;
             elemFnTypeInfo = listMeta->list_elem_fn_type_info;
+            listElemIsStr  = listMeta->list_elem_is_str;
         }
         if (!elemTypeName.empty())
             propagateTypeMeta(elemTypeName, elem);
         if (elemFnTypeInfo)
             getOrCreateMeta(elem).fn_type_info = *elemFnTypeInfo;
+        // List<str>: route through propagateTypeMeta so the "str" → str_elem
+        // mapping stays in one place. We intentionally avoid stamping
+        // list_elem_type_name="str" — that flips resolveCollectionDestructor
+        // to the str-aware variant (#1242 territory). (#1266)
+        if (listElemIsStr)
+            propagateTypeMeta("str", elem);
     }
 
     return elem;

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -17,9 +17,14 @@ bool CodeGen::ValueMetadata::hasAnyResourceKind() const {
 }
 
 bool CodeGen::ValueMetadata::hasAnyMeta() const {
+    // NOTE: str_elem and list_elem_is_str are intentionally NOT included.
+    // hasAnyMeta() doubles as the non-str-pointer detector via
+    // isNonStrPointer(): adding flags whose semantics is "this value IS a
+    // str container element" inverts the predicate and breaks str typecheck
+    // for `xs[0] == "..."` on List<str>. (#1266 — CodeRabbit reply explains
+    // the divergence between the two callers of this predicate.)
     return hasAnyCollectionType() || hasAnyResourceKind() ||
            fn_type_info.has_value() ||
-           str_elem || list_elem_is_str ||
            !low_level_type_name.empty() ||
            !map_key_type_name.empty() ||
            !map_value_type_name.empty() ||

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -19,6 +19,7 @@ bool CodeGen::ValueMetadata::hasAnyResourceKind() const {
 bool CodeGen::ValueMetadata::hasAnyMeta() const {
     return hasAnyCollectionType() || hasAnyResourceKind() ||
            fn_type_info.has_value() ||
+           str_elem || list_elem_is_str ||
            !low_level_type_name.empty() ||
            !map_key_type_name.empty() ||
            !map_value_type_name.empty() ||

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -173,6 +173,10 @@ void CodeGen::propagateMeta(llvm::Value *src, llvm::Value *dst) {
         dstMeta.addResourceKind(rk);
     if (srcMeta.json_type_only)
         dstMeta.json_type_only = true;
+    if (srcMeta.str_elem)
+        dstMeta.str_elem = true;
+    if (srcMeta.list_elem_is_str)
+        dstMeta.list_elem_is_str = true;
 
     // ARC managed status propagation
     auto *dstAlloca = llvm::dyn_cast<llvm::AllocaInst>(dst);

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -644,6 +644,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                     lefti = valMeta->list_elem_fn_type_info;
             }
             // Also derive from annotation: List<Map<str, int>> → inner = "Map<str, int>"
+            bool inner_is_str = false;
             if (letn.empty() && !lefti && annot) {
                 std::string resolved = resolveTypeAlias(*annot);
                 if (isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
@@ -658,6 +659,13 @@ void CodeGen::emitVarDecl(const std::string &name,
                         letn = inner;
                     } else if (inner.size() > 9 && inner.substr(0, 9) == "function(") {
                         lefti = parseFnTypeAnnotation(inner);
+                    } else if (inner == "str") {
+                        // List<str>: don't stamp list_elem_type_name (that
+                        // would switch resolveCollectionDestructor to the
+                        // str-aware variant which depends on ARC counter
+                        // symmetry that #1242 owns). Use a side-channel
+                        // that only the indexer reads. (#1266)
+                        inner_is_str = true;
                     } else {
                         // Tuple annotation (or alias resolving to one): record
                         // the resolved tuple signature so for-loop destructure
@@ -675,6 +683,8 @@ void CodeGen::emitVarDecl(const std::string &name,
                 getOrCreateMeta(ptr).list_elem_type_name = letn;
             if (lefti)
                 getOrCreateMeta(ptr).list_elem_fn_type_info = lefti;
+            if (inner_is_str)
+                getOrCreateMeta(ptr).list_elem_is_str = true;
         }
 
         // --- Nested list tracking (for flatten) ---

--- a/tests/filecheck/arc_retain_list_elem_call_arg.ry
+++ b/tests/filecheck/arc_retain_list_elem_call_arg.ry
@@ -1,0 +1,18 @@
+# FileCheck golden for #1266.
+# Caller-side argument passing of a container element (`use(xs[0])`) must
+# emit an ARC retain on the GEP-loaded element. Without Case 4, the callee
+# would receive a borrowed pointer that the callee may store into one of its
+# own ARC-managed slots, dangling once `xs` is released.
+#
+# CHECK-LABEL: define i64 @main()
+# CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
+# CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -16
+# CHECK:      arc.retain:
+# CHECK:      arc.retain.done:
+
+function use_inner(xs: List<int>) -> int:
+  return xs[0]
+
+function main() -> int:
+  ys: List<List<int>> = [[1, 2]]
+  return use_inner(ys[0])

--- a/tests/filecheck/arc_retain_list_elem_call_arg.ry
+++ b/tests/filecheck/arc_retain_list_elem_call_arg.ry
@@ -7,8 +7,8 @@
 # CHECK-LABEL: define i64 @main()
 # CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
 # CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -16
-# CHECK:      arc.retain:
-# CHECK:      arc.retain.done:
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
 
 function use_inner(xs: List<int>) -> int:
   return xs[0]

--- a/tests/filecheck/arc_retain_list_elem_new_var.ry
+++ b/tests/filecheck/arc_retain_list_elem_new_var.ry
@@ -1,0 +1,22 @@
+# FileCheck golden for #1266.
+# AssignStmt (new variable) binding a container element (`inner = xs[0]`) must
+# emit an ARC retain on the GEP-loaded element. Before Case 4 was added to
+# tryRetainArcSource, `inner = xs[0]` stored the pointer into the inner alloca
+# without incrementing strong_count — which would UAF as soon as #1242 landed
+# the destructor-side recursive release fix.
+#
+# CHECK-LABEL: define i64 @main()
+# The inner list is GEP-loaded out of %xs, stored into %inner, then
+# ARC-retained. The retain lowers to inline load/inc/store gated on the
+# ARC_IMMORTAL sentinel — the emitArcRetain control-flow labels are the
+# proof that Case 4 fired.
+# CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
+# CHECK:      store ptr %elem{{.*}}, ptr %inner
+# CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -16
+# CHECK:      arc.retain:
+# CHECK:      arc.retain.done:
+
+function main() -> int:
+  xs: List<List<int>> = [[1, 2], [3, 4]]
+  inner: List<int> = xs[0]
+  return inner[0]

--- a/tests/filecheck/arc_retain_list_elem_new_var.ry
+++ b/tests/filecheck/arc_retain_list_elem_new_var.ry
@@ -13,8 +13,8 @@
 # CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
 # CHECK:      store ptr %elem{{.*}}, ptr %inner
 # CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -16
-# CHECK:      arc.retain:
-# CHECK:      arc.retain.done:
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
 
 function main() -> int:
   xs: List<List<int>> = [[1, 2], [3, 4]]

--- a/tests/filecheck/arc_retain_list_elem_rebind.ry
+++ b/tests/filecheck/arc_retain_list_elem_rebind.ry
@@ -1,0 +1,24 @@
+# FileCheck golden for #1266.
+# AssignStmt rebind (`inner = xs[1]` after a prior `inner = xs[0]`) must emit
+# an ARC retain on the new GEP-loaded element. The release of the previous
+# value happens through the existing slot-release path; what Case 4 adds is
+# the *retain* on the right-hand side load. Without it, rebind drops a strong
+# reference to the inner header, leaking ownership when #1242 lands the
+# corresponding release.
+#
+# CHECK-LABEL: define i64 @main()
+# Two retains expected — one per assignment.
+# CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
+# CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -16
+# CHECK:      arc.retain{{[0-9]*}}:
+# CHECK:      arc.retain.done{{[0-9]*}}:
+# CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
+# CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -16
+# CHECK:      arc.retain{{[0-9]*}}:
+# CHECK:      arc.retain.done{{[0-9]*}}:
+
+function main() -> int:
+  xs: List<List<int>> = [[1, 2], [3, 4]]
+  inner: List<int> = xs[0]
+  inner = xs[1]
+  return inner[0]

--- a/tests/filecheck/arc_retain_list_elem_return.ry
+++ b/tests/filecheck/arc_retain_list_elem_return.ry
@@ -1,0 +1,20 @@
+# FileCheck golden for #1266.
+# Function return of a container element (`return xs[0]`) must emit an
+# ARC retain on the GEP-loaded element. Before Case 4 was added to
+# tryRetainArcSource, `return xs[0]` returned the borrowed pointer without
+# incrementing strong_count, so the caller's slot would dangle once
+# #1242 starts reclaiming nested collection headers.
+#
+# CHECK-LABEL: define ptr @get_first(ptr %xs)
+# CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
+# CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -16
+# CHECK:      arc.retain:
+# CHECK:      arc.retain.done:
+
+function get_first(xs: List<List<int>>) -> List<int>:
+  return xs[0]
+
+function main() -> int:
+  ys: List<List<int>> = [[1, 2]]
+  inner = get_first(ys)
+  return inner[0]

--- a/tests/filecheck/arc_retain_list_elem_return.ry
+++ b/tests/filecheck/arc_retain_list_elem_return.ry
@@ -8,8 +8,8 @@
 # CHECK-LABEL: define ptr @get_first(ptr %xs)
 # CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
 # CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -16
-# CHECK:      arc.retain:
-# CHECK:      arc.retain.done:
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
 
 function get_first(xs: List<List<int>>) -> List<int>:
   return xs[0]

--- a/tests/filecheck/arc_retain_list_str_elem.ry
+++ b/tests/filecheck/arc_retain_list_str_elem.ry
@@ -12,8 +12,8 @@
 # CHECK-LABEL: define ptr @inner()
 # CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
 # CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -24
-# CHECK:      arc.retain:
-# CHECK:      arc.retain.done:
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
 
 function inner() -> str:
   xs: List<str> = ["x", "y"]

--- a/tests/filecheck/arc_retain_list_str_elem.ry
+++ b/tests/filecheck/arc_retain_list_str_elem.ry
@@ -1,0 +1,24 @@
+# FileCheck golden for #1266.
+# Function return of a `List<str>` element (`return xs[0]`) must emit an ARC
+# retain whose header offset is the str-specific -24 (StringHeader), not the
+# generic -16 (ArcHeader). The List<str> annotation reaches the indexer via a
+# dedicated `list_elem_is_str` flag (deliberately separate from
+# list_elem_type_name, which would flip resolveCollectionDestructor to the
+# str-aware variant — that's #1242 territory).
+#
+# Without Case 4 + the str_elem propagation path, the borrowed handle would
+# dangle as soon as %xs is released at function exit.
+#
+# CHECK-LABEL: define ptr @inner()
+# CHECK:      %elem{{.*}} = load ptr, ptr %elem_ptr
+# CHECK:      getelementptr i8, ptr %elem{{.*}}, i64 -24
+# CHECK:      arc.retain:
+# CHECK:      arc.retain.done:
+
+function inner() -> str:
+  xs: List<str> = ["x", "y"]
+  return xs[0]
+
+function main() -> int:
+  s: str = inner()
+  return length(s)

--- a/tests/filecheck/arc_retain_map_str_value.ry
+++ b/tests/filecheck/arc_retain_map_str_value.ry
@@ -1,0 +1,20 @@
+# FileCheck golden for #1266.
+# Function return of a `Map<str,str>` value (`return m["k"]`) must emit an ARC
+# retain whose header offset is the str-specific -24 (StringHeader). The
+# Map<K,str> annotation reaches the indexer via the existing map_value_type_name
+# pipeline; this golden pins both that propagateTypeMeta("str") sets the
+# str_elem flag *and* that Case 4 dispatches the str header offset.
+#
+# CHECK-LABEL: define ptr @lookup()
+# CHECK:      %map_val = load ptr, ptr %val_elem_ptr
+# CHECK:      getelementptr i8, ptr %map_val, i64 -24
+# CHECK:      arc.retain:
+# CHECK:      arc.retain.done:
+
+function lookup() -> str:
+  m: Map<str, str> = {"k": "v"}
+  return m["k"]
+
+function main() -> int:
+  s: str = lookup()
+  return length(s)

--- a/tests/filecheck/arc_retain_map_str_value.ry
+++ b/tests/filecheck/arc_retain_map_str_value.ry
@@ -8,8 +8,8 @@
 # CHECK-LABEL: define ptr @lookup()
 # CHECK:      %map_val = load ptr, ptr %val_elem_ptr
 # CHECK:      getelementptr i8, ptr %map_val, i64 -24
-# CHECK:      arc.retain:
-# CHECK:      arc.retain.done:
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
 
 function lookup() -> str:
   m: Map<str, str> = {"k": "v"}

--- a/tests/filecheck/arc_retain_map_value_new_var.ry
+++ b/tests/filecheck/arc_retain_map_value_new_var.ry
@@ -1,0 +1,20 @@
+# FileCheck golden for #1266.
+# AssignStmt (new variable) binding a Map value (`inner = m["a"]`) must emit
+# an ARC retain on the GEP-loaded map value. Before Case 4, map_value loads
+# stored into long-lived slots without retain, leaking the inner container's
+# ownership.
+#
+# Verifies that Case 4's metadata gate includes `map_value` — the flag set
+# by propagateTypeMeta on Map<K,V> element access.
+#
+# CHECK-LABEL: define i64 @main()
+# CHECK:      %map_val = load ptr, ptr %val_elem_ptr
+# CHECK:      store ptr %map_val, ptr %inner
+# CHECK:      getelementptr i8, ptr %map_val, i64 -16
+# CHECK:      arc.retain:
+# CHECK:      arc.retain.done:
+
+function main() -> int:
+  m: Map<str, List<int>> = {"a": [1, 2]}
+  inner: List<int> = m["a"]
+  return inner[0]

--- a/tests/filecheck/arc_retain_map_value_new_var.ry
+++ b/tests/filecheck/arc_retain_map_value_new_var.ry
@@ -11,8 +11,8 @@
 # CHECK:      %map_val = load ptr, ptr %val_elem_ptr
 # CHECK:      store ptr %map_val, ptr %inner
 # CHECK:      getelementptr i8, ptr %map_val, i64 -16
-# CHECK:      arc.retain:
-# CHECK:      arc.retain.done:
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
 
 function main() -> int:
   m: Map<str, List<int>> = {"a": [1, 2]}

--- a/tests/spec/arc_inferred_list_str_rebind.test.ry
+++ b/tests/spec/arc_inferred_list_str_rebind.test.ry
@@ -1,0 +1,13 @@
+from runtime_internal import arc_live_count
+
+describe("inferred List<str> rebind does not leak (#1266)", ():
+  it("literal rebind without type annotation preserves arc_live_count", ():
+    before = arc_live_count()
+    cs = ["abc"]
+    cs = ["def"]
+    cs = ["ghi"]
+    cs = ["jkl"]
+    after = arc_live_count()
+    expect(after - before).to_eq(1)
+  )
+)


### PR DESCRIPTION
## Summary

- Adds `tryRetainArcSource` Case 4 so AssignStmt, function return, call-site arg, match binding, type coercion, and lambda capture emit ARC retain for container-element loads (`xs[i]`, `m[k]`, `for e in set`). Gated on collection metadata (`list_elem` / `map_key` / `map_value` / `set_elem`) to mirror Case 3's protection against weak refs / closures / bare fn pointers.
- `str`-typed container elements (`List<str>`, `Map<K,str>`) dispatch to `StringHeader` (-24) via a new `ValueMetadata::str_elem` flag set by `propagateTypeMeta` on `"str"`.
- `List<str>` annotations on AssignStmt use a side-channel `list_elem_is_str` (read only by the list indexer) to avoid stamping `list_elem_type_name="str"`, which would flip `resolveCollectionDestructor` into the str-aware variant whose ARC counter asymmetry is `#1242` scope.
- Prerequisite for `#1242`'s destructor-side recursive release that makes nested collection headers reclaimable.

Closes #1266.

## Test plan

- [x] `./build/ry_tests` — 1905 tests pass
- [x] `./build/ry test -p` — 164 test files pass
- [x] `ctest --test-dir build -L filecheck` — 10 goldens pass (7 new for #1266)
- [x] `./build-asan/ry_tests` + `./build-asan/ry test -p` — ASan + UBSan clean
- [x] `./build-tsan/ry_tests` — TSan clean (`ConcurrencySpecSuite` required)
- [x] `fuzz_parser` / `fuzz_json` / `fuzz_utf8` — 60s each, clean
- [x] `tests/spec/arc_split_chars.test.ry` — regression guard (no leak under `List<str>` rebind)
- [x] `tests/spec/arc_inferred_list_str_rebind.test.ry` — new regression guard for inferred-type rebind

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * ARC retain now correctly triggers for more container-element load cases (nested containers, List<str>/Map<*,str> elements), covering assigns, returns, call arguments, pattern binds, coercions, and captures to prevent unexpected leaks.

* **Documentation**
  * Added a KNOWLEDGE entry clarifying correct retain gating for container elements and special handling for string elements to avoid spurious retains and incorrect destructor behavior.

* **Tests**
  * Added FileCheck and spec tests validating retain emission and header offsets for list/map element loads and string elements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->