### PR TITLE
fix: format ADT variant payloads with collection/enum/Option/Result fields (#1238)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -289,10 +289,26 @@ undetected until this sweep.
 The union-variant branch needs the same pattern — see the post-#836
 code in `codegen_tostring.cpp:200-230`.
 
+The **ADT variant field-load path** in `getOrCreateADTToStringFn()`
+(same file) has the same requirement. #1238 surfaced this: without
+propagation, fields like `List<Tree>` inside `Tree::Node(int,
+List<Tree>)` printed as `""`, enums printed as raw tag integers,
+`Option<int>` printed as `Some(Some(0))`, and so on. Call
+`propagateTypeMeta(fieldTypeName, fieldVal)` on each field load
+instead of just propagating `low_level_type_name`.
+
+**Codegen-time recursion**: ADT formatting MUST go through a per-type
+helper function (`getOrCreateADTToStringFn`) rather than inlining the
+switch body at every `valueToString` call site. Inlining would recurse
+forever at codegen time for self-referential ADTs (Tree → List<Tree> →
+Tree → …). The helper caches the emitted function *before* it emits
+the body, so subsequent references resolve to an ordinary IR `call`
+and codegen terminates. Do not revert this to an inline body.
+
 **How to verify before opening a PR**:
 
 ```bash
-grep -nE 'CreateLoad.*elem|CreateLoad.*valVal' src/codegen_tostring.cpp
+grep -nE 'CreateLoad.*elem|CreateLoad.*valVal|CreateLoad.*fval' src/codegen_tostring.cpp
 ```
 
 For each hit, confirm that a metadata snapshot + `propagateTypeMeta`

--- a/changelog.d/1238-adt-variant-field-metadata.md
+++ b/changelog.d/1238-adt-variant-field-metadata.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- ADT enum variant payload fields with collection (`List`/`Map`/`Set`), nested enum, `Option`, or `Result` types now format correctly via `print` / `to_str` instead of rendering as an empty string, raw tag integer, or wrongly-nested value. Self-referential ADTs such as `enum Tree: Node(int, List<Tree>)` now print faithfully (#1238).

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1272,6 +1272,10 @@ public:
     llvm::Value *emitExprVariant(const std::unique_ptr<AwaitExpr> &e);
     llvm::Value *emitExprVariant(const std::unique_ptr<WeakExpr> &e);
     llvm::Value *valueToString(llvm::Value *val, bool inCollection = false);
+    // Per-ADT helper; cached-before-body emission breaks codegen-time recursion
+    // for self-referential ADTs. See `getOrCreateADTToStringFn` definition.
+    llvm::Function *getOrCreateADTToStringFn(const std::string &enumName);
+    std::unordered_map<std::string, llvm::Function *> adt_to_string_fns_;
     llvm::Value *recordToString(llvm::Value *val);
     bool isTupleStructType(llvm::StructType *st);
     llvm::Value *tupleToString(llvm::Value *val, llvm::StructType *st);

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -56,91 +56,16 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
                 return builder_.CreateLoad(ptrTy_, namePtr, "enum_name");
             }
 
-            // ADT enum: sprint buffer + recursive valueToString
-            auto spf = getSprintPrintf();
-            emitSprintBegin();
-
-            llvm::Value *tag = builder_.CreateExtractValue(val, 0, "vts.adt.tag");
-            llvm::Value *namePtr = builder_.CreateGEP(
-                llvm::ArrayType::get(ptrTy_, einfo.variantCount),
-                einfo.nameArray,
-                {llvm::ConstantInt::get(i64Ty_, 0), tag},
-                "vts.adt.name_ptr");
-            llvm::Value *nameStr = builder_.CreateLoad(ptrTy_, namePtr, "vts.adt.name");
-
-            llvm::AllocaInst *adtAlloca = builder_.CreateAlloca(einfo.adtType, nullptr, "vts.adt.tmp");
-            builder_.CreateStore(val, adtAlloca);
-            llvm::Value *payloadPtr = builder_.CreateStructGEP(einfo.adtType, adtAlloca, 1, "vts.adt.payload");
-
-            bool anyFields = false;
-            for (auto &[vn, vf] : einfo.variantFields)
-                if (!vf.fieldTypes.empty()) { anyFields = true; break; }
-
-            if (anyFields) {
-                llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "vts.adt.end", fn_);
-                llvm::BasicBlock *defaultBB = llvm::BasicBlock::Create(*ctx_, "vts.adt.default", fn_);
-                auto *switchInst = builder_.CreateSwitch(tag, defaultBB, static_cast<unsigned>(einfo.variantCount));
-
-                for (auto &[vname, vtag] : einfo.variants) {
-                    llvm::BasicBlock *caseBB = llvm::BasicBlock::Create(*ctx_, "vts.adt." + vname, fn_);
-                    switchInst->addCase(
-                        llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(vtag))), caseBB);
-                    builder_.SetInsertPoint(caseBB);
-
-                    auto fit = einfo.variantFields.find(vname);
-                    if (fit != einfo.variantFields.end() && !fit->second.fieldTypes.empty()) {
-                        llvm::Constant *openFmt = cachedGlobalString("%s(", ".vts_adt_open");
-                        builder_.CreateCall(spf, {openFmt, nameStr});
-
-                        const llvm::DataLayout &dl = mod_->getDataLayout();
-                        size_t offset = 0;
-                        for (size_t fi = 0; fi < fit->second.fieldTypes.size(); ++fi) {
-                            llvm::Type *fieldTy = fit->second.fieldTypes[fi];
-                            uint64_t align = dl.getABITypeAlign(fieldTy).value();
-                            offset = (offset + align - 1) / align * align;
-                            llvm::Value *fieldPtr = builder_.CreateGEP(
-                                llvm::Type::getInt8Ty(*ctx_), payloadPtr,
-                                {llvm::ConstantInt::get(i64Ty_, offset)},
-                                "vts.adt.field." + std::to_string(fi));
-                            llvm::Value *fieldVal = builder_.CreateLoad(fieldTy, fieldPtr, "vts.adt.fval");
-
-                            // Propagate low-level type metadata for correct signedness
-                            if (fi < fit->second.fieldTypeNames.size()) {
-                                const auto &ftName = fit->second.fieldTypeNames[fi];
-                                if (isLowLevelTypeName(ftName))
-                                    getOrCreateMeta(fieldVal).low_level_type_name = ftName;
-                            }
-
-                            if (fi > 0) {
-                                llvm::Constant *commaFmt = cachedGlobalString(", ", ".vts_adt_comma");
-                                builder_.CreateCall(spf, {commaFmt});
-                            }
-
-                            llvm::Value *fieldStr = valueToString(fieldVal, true);
-                            llvm::Constant *sfmt = cachedGlobalString("%s", ".vts_adt_s");
-                            builder_.CreateCall(spf, {sfmt, fieldStr});
-
-                            offset += dl.getTypeAllocSize(fieldTy);
-                        }
-
-                        llvm::Constant *closeFmt = cachedGlobalString(")", ".vts_adt_close");
-                        builder_.CreateCall(spf, {closeFmt});
-                    } else {
-                        llvm::Constant *fmt = cachedGlobalString("%s", ".vts_adt_nodata");
-                        builder_.CreateCall(spf, {fmt, nameStr});
-                    }
-                    builder_.CreateBr(endBB);
-                }
-
-                builder_.SetInsertPoint(defaultBB);
-                builder_.CreateBr(endBB);
-                builder_.SetInsertPoint(endBB);
-            } else {
-                llvm::Constant *fmt = cachedGlobalString("%s", ".vts_adt_simple");
-                builder_.CreateCall(spf, {fmt, nameStr});
-            }
-
-            return emitSprintEnd("vts.adt.str");
+            // ADT enum: delegate to a per-type helper function that is
+            // emitted lazily on first reference and cached thereafter.
+            // This indirection breaks codegen-time recursion for self-
+            // referential ADTs like `enum Tree: Node(int, List<Tree>)`:
+            // inside the helper body, nested references to the same ADT
+            // become an ordinary IR `call` instead of re-inlining the
+            // switch body, so codegen terminates.  See
+            // `getOrCreateADTToStringFn` below (#1238).
+            llvm::Function *adtFn = getOrCreateADTToStringFn(evMeta->enum_value_type);
+            return builder_.CreateCall(adtFn, {val}, "vts.adt.call");
         }
     }
 
@@ -747,6 +672,159 @@ llvm::Value *CodeGen::concatStringParts(
     // NUL at buf[totalLen] already written by __ry_string_make_uninit
     arc_str_owned_values_.insert(buf);
     return buf;
+}
+
+// Lazily emit (and cache) a per-ADT-type formatter.  The helper has signature
+// `char *__ry_adt_to_str_<EnumName>(<ADTStructType>)` and contains the same
+// switch/field-formatting body that used to live inline in valueToString().
+// The key trick: the function is stored in `adt_to_string_fns_` *before* the
+// body is emitted, so when the body's own recursive `valueToString` call
+// revisits the same ADT (via e.g. `List<Tree>` inside `Tree::Node`), the cache
+// hit yields an ordinary IR `call` to this function and codegen terminates.
+//
+// Without this indirection, codegen would walk the ADT switch body for Tree,
+// inline a List formatter, inline the element's ADT body for Tree, etc., and
+// blow the C++ stack (observed as SIGILL / exit 132) for #1238's `Tree::Node(1,
+// [Tree::Leaf(2), Tree::Leaf(3)])` repro.
+llvm::Function *CodeGen::getOrCreateADTToStringFn(const std::string &enumName) {
+    auto cached = adt_to_string_fns_.find(enumName);
+    if (cached != adt_to_string_fns_.end())
+        return cached->second;
+
+    auto einfoIt = enum_types_.find(enumName);
+    if (einfoIt == enum_types_.end())
+        return nullptr;
+    auto &einfo = einfoIt->second;
+
+    // enumName may contain '<', '>', ',' (e.g. "Option<int>") — not valid in LLVM identifiers.
+    std::string sanitized;
+    sanitized.reserve(enumName.size());
+    for (char c : enumName) {
+        if (std::isalnum(static_cast<unsigned char>(c)) || c == '_')
+            sanitized.push_back(c);
+        else
+            sanitized.push_back('_');
+    }
+
+    llvm::FunctionType *fnTy = llvm::FunctionType::get(
+        ptrTy_, {einfo.adtType}, false);
+    llvm::Function *fn = llvm::Function::Create(
+        fnTy, llvm::Function::InternalLinkage,
+        "__ry_adt_to_str_" + sanitized, mod_.get());
+    fn->addFnAttr(llvm::Attribute::NoUnwind);
+
+    // Store BEFORE body emission to break codegen-time recursion.
+    adt_to_string_fns_[enumName] = fn;
+
+    // Save and switch code-generation context.
+    llvm::Function *savedFn = fn_;
+    llvm::BasicBlock *savedBB = builder_.GetInsertBlock();
+    auto savedPt = builder_.GetInsertPoint();
+
+    fn_ = fn;
+    auto *entryBB = llvm::BasicBlock::Create(*ctx_, "entry", fn);
+    builder_.SetInsertPoint(entryBB);
+
+    llvm::Value *val = fn->getArg(0);
+    val->setName("adt");
+
+    auto spf = getSprintPrintf();
+    emitSprintBegin();
+
+    llvm::Value *tag = builder_.CreateExtractValue(val, 0, "vts.adt.tag");
+    llvm::Value *namePtr = builder_.CreateGEP(
+        llvm::ArrayType::get(ptrTy_, einfo.variantCount),
+        einfo.nameArray,
+        {llvm::ConstantInt::get(i64Ty_, 0), tag},
+        "vts.adt.name_ptr");
+    llvm::Value *nameStr = builder_.CreateLoad(ptrTy_, namePtr, "vts.adt.name");
+
+    llvm::AllocaInst *adtAlloca = builder_.CreateAlloca(einfo.adtType, nullptr, "vts.adt.tmp");
+    builder_.CreateStore(val, adtAlloca);
+    llvm::Value *payloadPtr = builder_.CreateStructGEP(einfo.adtType, adtAlloca, 1, "vts.adt.payload");
+
+    bool anyFields = false;
+    for (auto &[vn, vf] : einfo.variantFields)
+        if (!vf.fieldTypes.empty()) { anyFields = true; break; }
+
+    if (anyFields) {
+        llvm::BasicBlock *endBB = llvm::BasicBlock::Create(*ctx_, "vts.adt.end", fn);
+        llvm::BasicBlock *defaultBB = llvm::BasicBlock::Create(*ctx_, "vts.adt.default", fn);
+        auto *switchInst = builder_.CreateSwitch(tag, defaultBB, static_cast<unsigned>(einfo.variantCount));
+
+        for (auto &[vname, vtag] : einfo.variants) {
+            llvm::BasicBlock *caseBB = llvm::BasicBlock::Create(*ctx_, "vts.adt." + vname, fn);
+            switchInst->addCase(
+                llvm::cast<llvm::ConstantInt>(llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(vtag))), caseBB);
+            builder_.SetInsertPoint(caseBB);
+
+            auto fit = einfo.variantFields.find(vname);
+            if (fit != einfo.variantFields.end() && !fit->second.fieldTypes.empty()) {
+                llvm::Constant *openFmt = cachedGlobalString("%s(", ".vts_adt_open");
+                builder_.CreateCall(spf, {openFmt, nameStr});
+
+                const llvm::DataLayout &dl = mod_->getDataLayout();
+                size_t offset = 0;
+                for (size_t fi = 0; fi < fit->second.fieldTypes.size(); ++fi) {
+                    llvm::Type *fieldTy = fit->second.fieldTypes[fi];
+                    uint64_t align = dl.getABITypeAlign(fieldTy).value();
+                    offset = (offset + align - 1) / align * align;
+                    llvm::Value *fieldPtr = builder_.CreateGEP(
+                        llvm::Type::getInt8Ty(*ctx_), payloadPtr,
+                        {llvm::ConstantInt::get(i64Ty_, offset)},
+                        "vts.adt.field." + std::to_string(fi));
+                    llvm::Value *fieldVal = builder_.CreateLoad(fieldTy, fieldPtr, "vts.adt.fval");
+
+                    // Propagate full type metadata (low-level signedness,
+                    // List/Map/Set element types, enum spec, Option/Result
+                    // inner types) so the recursive valueToString dispatch
+                    // can format the field correctly.  See KNOWLEDGE.md
+                    // "valueToString element loads must propagate metadata
+                    // via propagateTypeMeta" (#1238).
+                    if (fi < fit->second.fieldTypeNames.size()) {
+                        const auto &ftName = fit->second.fieldTypeNames[fi];
+                        if (!ftName.empty())
+                            propagateTypeMeta(ftName, fieldVal);
+                    }
+
+                    if (fi > 0) {
+                        llvm::Constant *commaFmt = cachedGlobalString(", ", ".vts_adt_comma");
+                        builder_.CreateCall(spf, {commaFmt});
+                    }
+
+                    llvm::Value *fieldStr = valueToString(fieldVal, true);
+                    llvm::Constant *sfmt = cachedGlobalString("%s", ".vts_adt_s");
+                    builder_.CreateCall(spf, {sfmt, fieldStr});
+
+                    offset += dl.getTypeAllocSize(fieldTy);
+                }
+
+                llvm::Constant *closeFmt = cachedGlobalString(")", ".vts_adt_close");
+                builder_.CreateCall(spf, {closeFmt});
+            } else {
+                llvm::Constant *fmt = cachedGlobalString("%s", ".vts_adt_nodata");
+                builder_.CreateCall(spf, {fmt, nameStr});
+            }
+            builder_.CreateBr(endBB);
+        }
+
+        builder_.SetInsertPoint(defaultBB);
+        builder_.CreateBr(endBB);
+        builder_.SetInsertPoint(endBB);
+    } else {
+        llvm::Constant *fmt = cachedGlobalString("%s", ".vts_adt_simple");
+        builder_.CreateCall(spf, {fmt, nameStr});
+    }
+
+    llvm::Value *result = emitSprintEnd("vts.adt.str");
+    builder_.CreateRet(result);
+
+    // Restore code-generation context.
+    fn_ = savedFn;
+    if (savedBB)
+        builder_.SetInsertPoint(savedBB, savedPt);
+
+    return fn;
 }
 
 } // namespace ry

--- a/tests/spec/print_to_str_consistency.test.ry
+++ b/tests/spec/print_to_str_consistency.test.ry
@@ -12,6 +12,28 @@ enum Packet:
   Data(u8)
   Empty
 
+enum Box:
+  Int(List<int>)
+
+enum Tree:
+  Leaf(int)
+  Node(int, List<Tree>)
+
+enum MapHolder:
+  MEntry(Map<str, int>)
+
+enum SetHolder:
+  SEntry(Set<int>)
+
+enum Holder:
+  H(int, Color)
+
+enum OptHolder:
+  OWrap(Option<int>)
+
+enum ResHolder:
+  RWrap(Result<int, Error>)
+
 describe("print and to_str consistency", ():
   it("should be consistent for int", ():
     expect(to_str(42)).to_eq("42")
@@ -207,6 +229,71 @@ describe("to_str on ADT enum", ():
     expect(to_str(p)).to_eq("Data(200)")
     print(p)
     # expect-output: Data(200)
+  )
+
+  it("should format ADT variant with List<int> field (#1238)", ():
+    b = Box::Int([1, 2, 3])
+    expect(to_str(b)).to_eq("Int([1, 2, 3])")
+    print(b)
+    # expect-output: Int([1, 2, 3])
+  )
+
+  it("should format ADT variant with List<Tree> field (#1238)", ():
+    t = Tree::Node(1, [Tree::Leaf(2), Tree::Leaf(3)])
+    expect(to_str(t)).to_eq("Node(1, [Leaf(2), Leaf(3)])")
+    print(t)
+    # expect-output: Node(1, [Leaf(2), Leaf(3)])
+  )
+
+  it("should format ADT variant with Map field (#1238)", ():
+    m = MapHolder::MEntry({"x": 1})
+    expect(to_str(m)).to_eq("MEntry({" + "\"x\"" + ": 1})")
+    print(m)
+    # expect-output: MEntry({"x": 1})
+  )
+
+  it("should format ADT variant with Set field (#1238)", ():
+    s = SetHolder::SEntry({5})
+    expect(to_str(s)).to_eq("SEntry({5})")
+    print(s)
+    # expect-output: SEntry({5})
+  )
+
+  it("should format ADT variant with nested simple enum field (#1238)", ():
+    h = Holder::H(7, Color::Red)
+    expect(to_str(h)).to_eq("H(7, Red)")
+    print(h)
+    # expect-output: H(7, Red)
+  )
+
+  it("should format ADT variant with Option Some field (#1238)", ():
+    w = OptHolder::OWrap(Some(5))
+    expect(to_str(w)).to_eq("OWrap(Some(5))")
+    print(w)
+    # expect-output: OWrap(Some(5))
+  )
+
+  it("should format ADT variant with Option None field (#1238)", ():
+    w: OptHolder = OptHolder::OWrap(none)
+    expect(to_str(w)).to_eq("OWrap(None)")
+    print(w)
+    # expect-output: OWrap(None)
+  )
+
+  it("should format ADT variant with Result Ok field (#1238)", ():
+    ok: Result<int, Error> = Ok(5)
+    r = ResHolder::RWrap(ok)
+    expect(to_str(r)).to_eq("RWrap(Ok(5))")
+    print(r)
+    # expect-output: RWrap(Ok(5))
+  )
+
+  it("should format ADT variant with Result Err field (#1238)", ():
+    err: Result<int, Error> = Err(Error("oops"))
+    r = ResHolder::RWrap(err)
+    expect(to_str(r)).to_eq("RWrap(Err(Error: oops (code: 0)))")
+    print(r)
+    # expect-output: RWrap(Err(Error: oops (code: 0)))
   )
 )
 


### PR DESCRIPTION
## Summary

Fixes #1238. ADT enum variant payload fields whose declared type is a collection (`List`/`Map`/`Set`), nested enum, `Option`, or `Result` now format correctly via `print` / `to_str` instead of rendering as empty strings, raw tag integers, or wrongly-nested values. Self-referential ADTs such as `enum Tree: Node(int, List<Tree>)` print faithfully.

## Root cause

The ADT variant field-load path in `valueToString` propagated only `low_level_type_name` onto loaded field values, dropping all other type metadata (`ListElem`, `MapKey`/`Value`, `SetElem`, `OptionInner`, `ResultOk`/`Err`, enum spec). The union-variant path had the unified helper; the ADT path never grew the equivalent.

## Changes

- `src/codegen_tostring.cpp`: Replace the `low_level_type_name`-only propagation with a single unified `propagateTypeMeta(ftName, fieldVal)` call on each ADT field load.
- `src/codegen_tostring.cpp` + `include/ry/codegen.hpp`: Extract the ADT switch/field body into a lazily-emitted, cached per-enum helper `__ry_adt_to_str_<sanitized>`. The `llvm::Function *` is stored in `adt_to_string_fns_` **before** the body is emitted, so nested self-references (e.g. `List<Tree>` → element is `Tree`) resolve to an ordinary IR `call` instead of re-inlining the switch body. Without this indirection, codegen would recurse forever (observed as SIGILL / exit 132) for self-referential ADTs.
- `tests/spec/print_to_str_consistency.test.ry`: 9 new `it` cases covering `List<int>`, `List<Tree>` (self-recursive), `Map`, `Set`, nested simple enum, `Option Some/None`, and `Result Ok/Err` payloads.
- `KNOWLEDGE.md`: Extended entry #264 with the ADT variant field-load path requirement and the codegen-time recursion rule (cache-before-body emit).
- `changelog.d/1238-adt-variant-field-metadata.md`: Fixed-section fragment.

## Notes

- Docs: `print`/`to_str` remain documented as "recursively format" — no reference-level spec change needed.
- Known pre-existing limitation (out of scope, already documented in KNOWLEDGE.md #1157): inline `Err(Error(...))` passed directly as an ADT variant argument is not type-coerced to the declared `Result<int, Error>` field type. Tests use explicit `err: Result<int, Error> = ...` variable annotations to stay on the supported path.

## Test plan

- [x] `./build/ry_tests` — 1905 C++ tests pass
- [x] `./build/ry test -p` — 165 Ry spec files pass (includes the 9 new cases)
- [x] ASan + UBSan — C++ + Ry self-test clean
- [x] TSan — `ry_tests` clean (Ry self-test warn-only per upstream LargeMmapAllocator limitation)
- [x] libFuzzer — `fuzz_parser` / `fuzz_json` / `fuzz_utf8` each 60s exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed ADT enum variant fields to display correctly with collections, nested enums, Option, and Result types.
  * Self-referential ADTs now print faithfully instead of appearing as empty strings or raw values.

* **Documentation**
  * Updated codegen documentation for ADT formatting requirements.

* **Tests**
  * Added test coverage for ADT enum formatting with complex field types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->