### PR TITLE
fix: guard remove() against non-str pointer list elements (#1268)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -1075,8 +1075,8 @@ precedent in `src/codegen_call.cpp:366-443` that manually constructs
 
 ### Collection ops on pointer elements: guard on `list_elem_type_name`, not on `NestedListElem` alone
 
-**Source**: #1262 (2026-04-21, bugfix)
-**Tags**: codegen, collections, distinct, guard, UB, strcmp, list_elem_type_name, positive-whitelist
+**Source**: #1262, #1268 (2026-04-21, bugfix)
+**Tags**: codegen, collections, distinct, remove, guard, UB, strcmp, list_elem_type_name, positive-whitelist
 
 **Rule**: When a collection helper's pointer-element branch uses `strcmp` (or any other C-string operation), the guard **must** use a positive allowlist based on `list_elem_type_name`, not a single-field blacklist via `getNestedListElementType`:
 
@@ -1094,7 +1094,7 @@ if (elemTy == ptrTy_) {
 
 **Why**: `getNestedListElementType` only checks `TypeMeta::NestedListElem`, which `propagateTypeMeta` sets only in the `isListTypeName` branch. Map/Set/function element kinds live in different fields (`map_value_type_name`, `list_elem_fn_type_info`). A blacklist on a single field is structurally incomplete — `List<Map<K,V>>` / `List<function(...)>` / `List<Set<T>>` all slip through and `strcmp` runs on Map/Set/closure headers (undefined behaviour). `inferCollectionTypeName` (`src/codegen_builtin.cpp:242-274`) returns non-empty `"Map<...>"` / `"List<...>"` / `"Set<...>"` for non-str pointer types, so treating `""` as str is safe (see sibling entry "List<str> literals can have empty list_elem_type_name"). Resource element lists (`List<TcpStream>`) get a non-empty `list_elem_type_name` and are caught by `isNonStrName`; do not check the list value's own `resource_kinds` — lists are not resources themselves, so that field is always empty for list containers. Access `nested_list_elem` directly on the cached `meta` pointer instead of calling `getNestedListElementType` to avoid a second `value_metadata_` lookup.
 
-**How to apply**: `emitListRemove` (`src/codegen_call_collection.cpp:232`) and the `in` / `not in` list branch (`src/codegen_expr.cpp` around line 1555) have the same deficiency — mirror this guard pattern when fixing them. Always pair with direct regression tests: add a `List<Map<str,int>>` / `List<function(...)>` / `List<Set<T>>` case that expects `expectCompileError`; a single-element list must not be the sole reproduction because `curOutLen == 0` masks the symptom on the first iteration of the dedup loop.
+**How to apply**: The `in` / `not in` list branch (`src/codegen_expr.cpp` around line 1555) still has the same deficiency — mirror this guard pattern when fixing it. (Fixed in `emitCollOp_distinct` by #1262 and `emitListRemove` by #1268.) Always pair with direct regression tests: add a `List<Map<str,int>>` / `List<function(...)>` / `List<Set<T>>` case that expects `expectCompileError`; a single-element list must not be the sole reproduction because `curOutLen == 0` masks the symptom on the first iteration of the dedup loop.
 
 **Related**: #1241 (`propagateMeta` added to `distinct` — did not address the guard), "List<str> literals can have empty list_elem_type_name" (#1235), "Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`".
 

--- a/changelog.d/1268-remove-guard.md
+++ b/changelog.d/1268-remove-guard.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- `remove()` on a list now emits a compile error for lists of non-string
+  pointer elements such as `List<List<T>>`, `List<Map<K, V>>`, `List<Set<T>>`,
+  and `List<function(...) -> R>`. Previously the guard only rejected
+  `List<List<T>>` and silently fell through to a `strcmp` on non-C-string
+  pointers, which is undefined behaviour. (#1268)

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -509,7 +509,7 @@ print(xs)   # [1, 3, 4]
 
 ### remove
 
-Removes the first occurrence of the specified value from the list. Does nothing if the value is not found. This is a mutating operation.
+Removes the first occurrence of the specified value from the list. Does nothing if the value is not found. This is a mutating operation. Passing a list of non-string pointer elements (e.g. `List<List<T>>`, `List<Map<K, V>>`, `List<Set<T>>`, `List<function(...) -> R>`) is a compile error: `remove() is only supported for lists of primitive values or strings`.
 
 ```ry
 xs = [1, 2, 3, 2, 4]

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -237,8 +237,17 @@ llvm::Value *CodeGen::emitListRemove(llvm::Value *containerPtr, llvm::Value *val
 
     llvm::Value *match;
     if (listElemTy == ptrTy_) {
-        if (getNestedListElementType(containerPtr))
-            codegenError("remove() is not supported for lists of non-string pointer elements");
+        // Reject non-str pointer elements: the comparison path below calls strcmp, which is
+        // UB on Map/Set/List/closure/resource headers. Positive allowlist on list_elem_type_name
+        // (empty or "str" counts as str) with structural fallbacks for NestedListElem /
+        // list_elem_fn_type_info in case the name is unset. Mirrors #1262 distinct() guard.
+        const ValueMetadata *meta = getMeta(containerPtr);
+        const std::string &elemName = meta ? meta->list_elem_type_name : std::string{};
+        const bool isNonStrName = !elemName.empty() && elemName != "str";
+        const bool hasNestedList = meta && meta->nested_list_elem != nullptr;
+        const bool hasFnInfo = meta && meta->list_elem_fn_type_info.has_value();
+        if (isNonStrName || hasNestedList || hasFnInfo)
+            codegenError("remove() is only supported for lists of primitive values or strings");
         auto strcmpFn = getStdlibStrcmp();
         llvm::Value *cmpResult = builder_.CreateCall(strcmpFn, {val, listElem}, "lrem_strcmp");
         match = builder_.CreateICmpEQ(cmpResult, llvm::ConstantInt::get(i32Ty_, 0), "lrem_match");

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2079,6 +2079,30 @@ TEST_F(CodeGenTest, ListRemoveEdgeCases) {
     }
 }
 
+TEST_F(CodeGenTest, RemoveRejectsPointerElements) {
+    const std::string err = "remove() is only supported for lists of primitive values or strings";
+
+    expectCompileError(
+        "xs: List<Map<str, int>> = [{\"a\": 1}]\n"
+        "remove(xs, {\"a\": 1})\n",
+        err);
+
+    expectCompileError(
+        "xs: List<function(int) -> int> = [(x: int) => x + 1]\n"
+        "remove(xs, (x: int) => x + 1)\n",
+        err);
+
+    expectCompileError(
+        "xs: List<List<int>> = [[1, 2], [3, 4]]\n"
+        "remove(xs, [1, 2])\n",
+        err);
+
+    expectCompileError(
+        "xs: List<Set<int>> = [{1, 2}]\n"
+        "remove(xs, {1, 2})\n",
+        err);
+}
+
 // ===== distinct(list) テスト =====
 
 TEST_F(CodeGenTest, DistinctVariants) {


### PR DESCRIPTION
## Summary

- Replace the `emitListRemove` guard (`src/codegen_call_collection.cpp`) with the positive allowlist pattern landed for `distinct()` in #1262, rejecting `List<Map<K, V>>` / `List<Set<T>>` / `List<function(...)>` / `List<List<T>>` at codegen time.
- The previous guard only checked `getNestedListElementType` (= `TypeMeta::NestedListElem`), catching only `List<List<T>>`. Other non-str pointer element kinds silently fell through to `strcmp` on Map/Set/closure header pointers — undefined behaviour.
- Add direct regression test `RemoveRejectsPointerElements` mirroring `DistinctRejectsPointerElements`; update `docs/reference/collections.md` and `KNOWLEDGE.md` to reflect that `emitListRemove` now uses the pattern (only the `in`/`not in` branch remains — tracked by #1269).

Closes #1268

## Test plan

- [x] `./build/ry_tests` — all C++ tests pass including new `RemoveRejectsPointerElements`
- [x] `./build/ry test -p` — all Ry self-tests pass
- [x] ASan + UBSan — `./build-asan/ry_tests` + `./build-asan/ry test -p` clean (UBSan would have caught the original `strcmp` UB)
- [x] TSan — `./build-tsan/ry_tests` clean
- [x] libFuzzer — `fuzz_parser` / `fuzz_json` / `fuzz_utf8` 60s runs all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * remove() on lists with non-string pointer element types (List<Map>, List<Set>, List<function>, List<List>) now produces a compile-time error instead of undefined behavior at runtime.

* **Documentation**
  * Updated remove() reference documentation to explicitly specify that the operation is only supported for lists of primitive values or strings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->