### PR TITLE
chore(ci): exclude .claude/, .codex/, .serena/ from CodeRabbit review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,3 +10,6 @@ reviews:
     - '!build/**'
     - '!build-asan/**'
     - '!**/*.pdf'
+    - '!.claude/**'
+    - '!.codex/**'
+    - '!.serena/**'


### PR DESCRIPTION
## Summary

- Add `!.claude/**`, `!.codex/**`, `!.serena/**` to `reviews.path_filters` in `.coderabbit.yaml`
- Stops CodeRabbit from reviewing internal harness / tooling artifacts that never ship to users
- Implements Fix A from parent #1163 — the unconditional, trunk-migration-safe sub-fix

Closes #1278. Fixes B (release-PR review profile) and C (AGENTS.md policy) remain on #1163 because they depend on #1248 (trunk-based migration investigation).

## Motivation

Release PRs (`v*.*.*` → `main`) accumulate disproportionate CodeRabbit review volume. Concrete evidence from PR #1148 (v0.0.12 release): Major-level findings landed on `.claude/skills/git-triage-issue/SKILL.md` and `.codex/skills/git-followup-unresolved-reviews/SKILL.md` — files that are never shipped to end users, so the review cost produces no product value.

Current repo surface: 39+ tracked files under `.claude/skills/`, `.codex/skills/`, `.serena/`.

## Change

```diff
     - '!build/**'
     - '!build-asan/**'
     - '!**/*.pdf'
+    - '!.claude/**'
+    - '!.codex/**'
+    - '!.serena/**'
```

The `!glob` negation form matches the existing `!build/**`, `!build-asan/**`, `!**/*.pdf` entries and is the documented CodeRabbit config syntax, so no schema-change risk.

## Test plan

Functional acceptance can only be observed post-merge (CodeRabbit is an external service). Pre-merge verification performed:

- [x] YAML structure: single `path_filters:` key, indentation and single-quote style match existing entries
- [x] Pattern cross-check: `git ls-files` confirms all three patterns match real tracked files (`.claude/**` → 39 SKILL.md files, `.codex/**` → skill files, `.serena/**` → `.gitignore` + `project.yml`)
- [x] Diff scope: only `.coderabbit.yaml` modified, no stray reformatting
- [x] Syntax precedent: `!glob` negation already in use for `!build/**`, `!build-asan/**`, `!**/*.pdf`

Post-merge observational checks (out of this PR's scope but recorded for follow-up):

- [ ] Next PR touching `.claude/**`, `.codex/**`, or `.serena/**` produces no CodeRabbit comments on those paths
- [ ] Next PR touching `src/**` still receives normal line-by-line review (no regression)

## Out of scope

- Release-PR summarize-only profile (Fix B from #1163)
- AGENTS.md release-PR review policy (Fix C from #1163)

Both deferred to #1163, contingent on #1248 (trunk-based migration).

## Notes

- No code, test, doc, or CHANGELOG impact — this is internal CI tooling configuration only
- No KNOWLEDGE.md entry — boilerplate addition following established in-file pattern
- Build / test suites skipped (YAML config for external service, not observable via `ry_tests` / `ry test -p`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to exclude additional directories from automated review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->