### PR TITLE
fix: widen fuzz_parser harness catch to `std::exception` (#1275)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2642,6 +2642,38 @@ also work.
 
 ---
 
+### Fuzz harnesses must catch `std::exception`, not subtype specifics
+
+**Source**: #1275 (2026-04-21)
+**Tags**: libfuzzer, fuzzer, harness, exceptions, catch, parser
+
+**Rule**: In `LLVMFuzzerTestOneInput`, wrap the target call in
+`catch (const std::exception &)` — never catch only `std::runtime_error` or
+a named derived type. `std::logic_error` (including `std::out_of_range`
+and `std::invalid_argument`) is a **disjoint** subtree from
+`std::runtime_error`, so a `runtime_error`-only catch silently lets future
+parser/lexer throws escape to `libc++abi`, which the fuzzer reports as a
+deadly signal and terminates the run.
+
+**Context**: `tests/fuzz/fuzz_parser.cpp` originally caught
+`ry::DiagnosticError` and `std::runtime_error` (the first is redundant —
+`DiagnosticError` derives from `std::runtime_error` per
+`include/ry/diagnostic.hpp:22`). This missed `std::out_of_range` thrown by
+`parseFloatLiteral` / `parseIntLiteral` in `include/ry/parser.hpp:196,210`
+for malformed literals like `0B1f32`, causing a libFuzzer crash despite
+the CLI (`src/main.cpp:297-310`) handling the same input cleanly via its
+top-level `catch (const std::exception &)`.
+
+**How to apply**: When writing or reviewing a fuzz harness, match the
+established top-level pattern used across `src/main.cpp:308`,
+`src/cli.cpp:51,96`, `src/runtime_json.cpp:766`, `src/formatter.cpp:702,798`
+— a single `catch (const std::exception &)` backstop. Preserve the
+`// NOLINT(bugprone-empty-catch)` suppression so clang-tidy stays clean
+under AGENTS.md §Clang-Tidy. Document the expected exception types in the
+catch-block comment instead of splitting into multiple specific catches.
+
+---
+
 ## Documentation
 
 ### Example code in docs must match the current Ry syntax

--- a/tests/fuzz/fuzz_parser.cpp
+++ b/tests/fuzz/fuzz_parser.cpp
@@ -1,10 +1,9 @@
-#include "ry/diagnostic.hpp"
 #include "ry/lexer.hpp"
 #include "ry/parser.hpp"
 
 #include <cstddef>
 #include <cstdint>
-#include <stdexcept>
+#include <exception>
 #include <string>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
@@ -12,10 +11,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
         ry::Lexer lex(std::string(reinterpret_cast<const char *>(data), size));
         ry::Parser parser(lex);
         parser.parseProgram();
-    } catch (const ry::DiagnosticError &) { // NOLINT(bugprone-empty-catch)
-        // Expected: parser diagnostics on malformed input.
-    } catch (const std::runtime_error &) { // NOLINT(bugprone-empty-catch)
-        // Expected: lexer hard errors (e.g., invalid UTF-8, unterminated string).
+    } catch (const std::exception &) { // NOLINT(bugprone-empty-catch)
+        // Any parser/lexer exception is a valid rejection for the fuzzer:
+        //   - ry::DiagnosticError (parser diagnostics; derives from std::runtime_error)
+        //   - std::runtime_error (lexer hard errors: invalid UTF-8, unterminated string)
+        //   - std::out_of_range / other std::logic_error subtypes
+        //     (parseFloatLiteral / parseIntLiteral on malformed numeric literals
+        //      such as "0B1f32" — see #1275)
     }
     return 0;
 }


### PR DESCRIPTION
## Summary

- `tests/fuzz/fuzz_parser.cpp` previously caught `ry::DiagnosticError` + `std::runtime_error` separately. The first was redundant (`DiagnosticError` derives from `std::runtime_error` per `include/ry/diagnostic.hpp:22`), and neither clause catches the `std::logic_error` subtree.
- `parseFloatLiteral` / `parseIntLiteral` in `include/ry/parser.hpp:196,210` throw `std::out_of_range` on malformed numeric literals like `0B1f32`. The exception escaped the harness → `libc++abi` abort → libFuzzer reported a crash, even though the CLI (`src/main.cpp:297-310`) handled the same input cleanly via its top-level `catch (const std::exception &)`.
- Widen to a single `catch (const std::exception &)`, matching the convention used across `main.cpp:308`, `cli.cpp:51,96`, `runtime_json.cpp:766`, `formatter.cpp:702,798`. Preserve the `// NOLINT(bugprone-empty-catch)` suppression for clang-tidy. Document the expected subtypes inline.
- Add a `KNOWLEDGE.md` entry so future fuzz harnesses follow the same rule (per AGENTS.md §2.5).

Per issue #1275's recommendation, this PR implements **fix (2) — harness-only widening**. Lexer hardening of `0B…` literal acceptance is explicitly out of scope; `parseFloatLiteral` / `parseIntLiteral` keep throwing `std::out_of_range` unchanged.

Closes #1275

## Reviewer notes

- The crash artifact `tests/fuzz/regressions/parser/crash-460a7788…` is already committed (landed in #1269 — c0ffda31) and its copy at `tests/fuzz/corpus/parser/crash-460a7788…` is also already tracked, so this PR adds **no** corpus/regression files. The plan's "copy to corpus" step turned out to be a no-op for that reason.
- During `§3.5 ASan` verification, `HelpOption.MainHelpWithDoubleDashHelp` failed once (1/1907) then passed on both an isolated re-run and a full-suite re-run. This is a pre-existing subprocess-based test-isolation flake unrelated to this change (the test doesn't touch parser or fuzz harness code).

## Test plan

- [x] `§3 default` — `./build/ry_tests` + `./build/ry test -p` all pass
- [x] `§3.5 ASan + UBSan` — `./build-asan/ry_tests` + `./build-asan/ry test -p` clean
- [x] `§3.5 TSan` — `./build-tsan/ry_tests` clean
- [x] `§3.6 libFuzzer` — `fuzz_parser` / `fuzz_json` / `fuzz_utf8` 60s sweeps all exit 0
- [x] Direct regression: `./build-fuzz/fuzz_parser tests/fuzz/regressions/parser/crash-460a7788…` exits 0 post-fix (pre-fix: `libc++abi` abort)
- [x] `§3.7` no residual background processes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for fuzz harness authors on consistent exception handling patterns across the codebase.

* **Bug Fixes**
  * Improved fuzz test robustness by broadening exception handling to catch all standard exceptions from parsers and lexers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->