### PR TITLE
fix(ci): make LLVM mirror workflow non-destructive (#1246)

### DIFF
--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -56,16 +56,20 @@ jobs:
 
       - name: Compute next revision number
         run: |
-          # List all releases, filter to `llvm-toolchain-<V>-rev<N>` with
-          # anchored regex so malformed tags (e.g. missing number, typo)
-          # are skipped rather than crashing the pipeline. Pipe through
-          # standalone `jq` so we can pass the version as `--arg V` and
-          # avoid shell-injecting it into the regex.
+          # Filter to `llvm-toolchain-<V>-rev<N>` via literal string matching
+          # (startswith + ltrimstr), not regex: the dots in $V must match
+          # themselves, but jq `test()` treats `.` as a wildcard so a tag like
+          # `llvm-toolchain-21x1x8-rev999` would sneak in. `tonumber?` yields
+          # empty on non-numeric suffixes (e.g. trailing `-extra`), so those
+          # are skipped from the array. $V is passed via jq `--arg` so the
+          # input value cannot inject jq syntax.
           NEXT=$(gh release list --limit 1000 --json tagName \
-            | jq --arg V "$V" \
-                '[.[] | .tagName
-                      | select(test("^llvm-toolchain-" + $V + "-rev[0-9]+$"))
-                      | capture("-rev(?<n>[0-9]+)$").n | tonumber] | (max // 0) + 1')
+            | jq --arg V "$V" '
+                [ .[] | .tagName
+                  | select(startswith("llvm-toolchain-" + $V + "-rev"))
+                  | ltrimstr("llvm-toolchain-" + $V + "-rev")
+                  | tonumber? ]
+                | (max // 0) + 1')
           {
             echo "N=${NEXT}"
             echo "REV_TAG=llvm-toolchain-${V}-rev${NEXT}"

--- a/.github/workflows/mirror-llvm-toolchain.yml
+++ b/.github/workflows/mirror-llvm-toolchain.yml
@@ -1,5 +1,32 @@
 name: Mirror LLVM Toolchain
 
+# This workflow mirrors an LLVM toolchain tarball to GitHub Releases for
+# CI consumption (see .github/actions/setup-llvm). It is non-destructive:
+#
+#   - Each dispatch creates an immutable `llvm-toolchain-<ver>-rev<N>`
+#     release. These are never deleted and serve as the audit trail.
+#
+#   - The stable pointer `llvm-toolchain-<ver>` is updated in place via
+#     `gh release upload --clobber`. GitHub's API has no atomic replace,
+#     so --clobber is sequential delete-then-POST per file. The missing
+#     window is roughly the POST duration: sub-second for the .sha256,
+#     but seconds to a few minutes for the LLVM tarball itself
+#     (300–500 MB). That is still a large improvement over the previous
+#     `gh release delete --cleanup-tag` flow, which left the release
+#     itself gone for the entire 3–5 minutes it took to rebuild and
+#     re-upload the tarball (#1246).
+#
+#   - During the tarball upload window the stable release exists but
+#     its asset is missing, so `gh release download` in consumers will
+#     get a 404 without triggering setup-llvm's apt.llvm.org fallback
+#     (that path is only taken when `gh release view` itself fails).
+#     Mirror dispatches are rare and manual, so this is accepted for
+#     now; see KNOWLEDGE.md "LLVM mirror workflow" for the tracked
+#     follow-up to harden the consumer side.
+#
+# The consumer side (.github/actions/setup-llvm) only ever resolves the
+# stable tag, so it does not need to know about revisions.
+
 on:
   workflow_dispatch:
     inputs:
@@ -7,82 +34,112 @@ on:
         description: 'LLVM version to mirror'
         required: true
         default: '21.1.8'
-      force:
-        description: 'Force re-upload even if release exists'
-        required: false
-        type: boolean
-        default: false
 
 permissions:
   contents: write
+
+# Serialise dispatches for the same version so two concurrent runs
+# cannot both compute the same `next_rev` and collide when creating
+# the rev release. Different versions can still run in parallel.
+concurrency:
+  group: mirror-llvm-${{ inputs.llvm_version }}
+  cancel-in-progress: false
 
 jobs:
   mirror:
     runs-on: ubuntu-24.04
     env:
       GH_TOKEN: ${{ github.token }}
+      V: ${{ inputs.llvm_version }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check existing release
-        id: check
+      - name: Compute next revision number
         run: |
-          V="${{ inputs.llvm_version }}"
-          if gh release view "llvm-toolchain-${V}" >/dev/null 2>&1; then
-            if [ "${{ inputs.force }}" != "true" ]; then
-              echo "Release llvm-toolchain-${V} already exists. Use force=true to re-upload."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-            else
-              echo "Force mode: deleting existing release"
-              gh release delete "llvm-toolchain-${V}" --yes --cleanup-tag
-              echo "skip=false" >> "$GITHUB_OUTPUT"
-            fi
-          else
-            echo "skip=false" >> "$GITHUB_OUTPUT"
-          fi
+          # List all releases, filter to `llvm-toolchain-<V>-rev<N>` with
+          # anchored regex so malformed tags (e.g. missing number, typo)
+          # are skipped rather than crashing the pipeline. Pipe through
+          # standalone `jq` so we can pass the version as `--arg V` and
+          # avoid shell-injecting it into the regex.
+          NEXT=$(gh release list --limit 1000 --json tagName \
+            | jq --arg V "$V" \
+                '[.[] | .tagName
+                      | select(test("^llvm-toolchain-" + $V + "-rev[0-9]+$"))
+                      | capture("-rev(?<n>[0-9]+)$").n | tonumber] | (max // 0) + 1')
+          {
+            echo "N=${NEXT}"
+            echo "REV_TAG=llvm-toolchain-${V}-rev${NEXT}"
+            echo "STABLE_TAG=llvm-toolchain-${V}"
+          } >> "$GITHUB_ENV"
+          echo "Next revision for LLVM ${V}: rev${NEXT}"
 
       - name: Install LLVM via apt.llvm.org
-        if: steps.check.outputs.skip != 'true'
         run: |
-          V="${{ inputs.llvm_version }}"
           MAJOR="${V%%.*}"
           wget -qO- https://apt.llvm.org/llvm.sh | sudo bash -s -- "${MAJOR}"
           sudo apt-get install -y libllvm"${MAJOR}" llvm-"${MAJOR}"-dev clang-"${MAJOR}" clang-tidy-"${MAJOR}" clang-tools-"${MAJOR}"
           echo "LLVM_MAJOR=${MAJOR}" >> "$GITHUB_ENV"
 
       - name: Repack as portable tarball
-        if: steps.check.outputs.skip != 'true'
         run: |
-          V="${{ inputs.llvm_version }}"
           cd /tmp
-
-          # Copy the apt-installed tree into a clean 'llvm/' directory
           cp -a "/usr/lib/llvm-${LLVM_MAJOR}" llvm
-
-          # Repack
           ASSET="llvm-${V}-linux-x86_64.tar.xz"
           tar -cJf "${ASSET}" llvm/
           sha256sum "${ASSET}" > "${ASSET}.sha256"
-          echo "ASSET=/tmp/${ASSET}" >> "$GITHUB_ENV"
-          echo "ASSET_SHA=/tmp/${ASSET}.sha256" >> "$GITHUB_ENV"
+          {
+            echo "ASSET=/tmp/${ASSET}"
+            echo "ASSET_SHA=/tmp/${ASSET}.sha256"
+            echo "ASSET_NAME=${ASSET}"
+          } >> "$GITHUB_ENV"
 
-      - name: Create release and upload
-        if: steps.check.outputs.skip != 'true'
+      - name: Create immutable rev release
         run: |
-          V="${{ inputs.llvm_version }}"
-          gh release create "llvm-toolchain-${V}" \
-            --title "LLVM Toolchain ${V}" \
-            --notes "LLVM ${V} Linux x86_64 toolchain for CI use. Built from apt.llvm.org packages." \
+          gh release create "${REV_TAG}" \
+            --title "LLVM Toolchain ${V} (rev${N})" \
+            --notes "LLVM ${V} Linux x86_64 toolchain for CI use. Built from apt.llvm.org packages. Immutable revision ${N}; the mutable pointer is \`${STABLE_TAG}\`." \
             "${ASSET}" "${ASSET_SHA}"
 
-      - name: Verify upload
-        if: steps.check.outputs.skip != 'true'
+      - name: Verify rev release assets
         run: |
-          V="${{ inputs.llvm_version }}"
-          gh release view "llvm-toolchain-${V}" --json assets --jq '.assets[].name'
-          mkdir -p /tmp/verify
-          gh release download "llvm-toolchain-${V}" \
-            -p "llvm-${V}-linux-x86_64.tar.xz" \
-            -p "llvm-${V}-linux-x86_64.tar.xz.sha256" \
-            -D /tmp/verify
-          (cd /tmp/verify && sha256sum -c "llvm-${V}-linux-x86_64.tar.xz.sha256")
+          gh release view "${REV_TAG}" --json assets --jq '.assets[].name'
+          mkdir -p /tmp/verify-rev
+          gh release download "${REV_TAG}" \
+            -p "${ASSET_NAME}" \
+            -p "${ASSET_NAME}.sha256" \
+            -D /tmp/verify-rev
+          (cd /tmp/verify-rev && sha256sum -c "${ASSET_NAME}.sha256")
+
+      - name: Promote rev to stable pointer
+        run: |
+          NOTES="LLVM ${V} Linux x86_64 toolchain for CI use. Built from apt.llvm.org packages. Stable pointer; currently backed by ${REV_TAG}."
+
+          if gh release view "${STABLE_TAG}" >/dev/null 2>&1; then
+            # `--clobber` is sequential DELETE-then-POST per file — sub-second
+            # for the .sha256, but seconds to a few minutes for the 300–500 MB
+            # tarball. During that tarball window `gh release download` in
+            # consumers returns 404 without triggering setup-llvm's apt
+            # fallback (the fallback only fires on `gh release view` failure,
+            # see header comment). Accepted because dispatches are rare and
+            # manual, and the window is still much shorter than the previous
+            # 3–5 minute `--cleanup-tag` gap.
+            echo "Updating existing stable release ${STABLE_TAG}..."
+            gh release edit "${STABLE_TAG}" --notes "${NOTES}"
+            gh release upload "${STABLE_TAG}" --clobber "${ASSET}" "${ASSET_SHA}"
+          else
+            echo "Creating stable release ${STABLE_TAG}..."
+            gh release create "${STABLE_TAG}" \
+              --title "LLVM Toolchain ${V}" \
+              --notes "${NOTES}" \
+              "${ASSET}" "${ASSET_SHA}"
+          fi
+
+      - name: Verify stable pointer
+        run: |
+          gh release view "${STABLE_TAG}" --json assets --jq '.assets[].name'
+          mkdir -p /tmp/verify-stable
+          gh release download "${STABLE_TAG}" \
+            -p "${ASSET_NAME}" \
+            -p "${ASSET_NAME}.sha256" \
+            -D /tmp/verify-stable
+          (cd /tmp/verify-stable && sha256sum -c "${ASSET_NAME}.sha256")

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,17 +107,23 @@ CI は `.github/actions/setup-llvm/` composite action 経由で LLVM を取得�
 2. **GitHub Releases ミラー** — `llvm-toolchain-${VERSION}` タグからダウンロード + SHA256 検証
 3. **apt.llvm.org フォールバック** — ミラーが存在しない場合のみ
 
-ミラー tarball は `.github/workflows/mirror-llvm-toolchain.yml`（手動 `workflow_dispatch`）で構築・アップロードする。
+ミラー tarball は `.github/workflows/mirror-llvm-toolchain.yml`（手動 `workflow_dispatch`）で構築・アップロードする。ワークフローは非破壊的 (#1246):
 
-**キャッシュキー**: `llvm-${VERSION}-linux-x86_64-v2-${SHA256_SHORT}`。`restore-keys` は意図的に設定しない — 部分一致ヒットは異なるバージョンの LLVM を復元し、ビルド失敗や ABI 不整合を引き起こす。
+- 各 dispatch は immutable な `llvm-toolchain-<ver>-rev<N>` release を作成する（`<N>` は既存の rev 番号の max + 1）。これは audit trail として永続化し、削除しない。
+- stable pointer `llvm-toolchain-<ver>` は `gh release upload --clobber` で rev の tarball を指すように更新される（既存 release を削除せず assets のみ入れ替え）。`--clobber` は atomic ではなく per-file DELETE-then-POST なので asset の欠損ウィンドウが発生する: `.sha256` は sub-second だが LLVM tarball (300–500 MB) は POST に数秒〜数分かかる。ただしこれは以前の `gh release delete --cleanup-tag` フローの 3〜5 分 gap より大幅短く、mirror dispatch は manual & rare なので現状は許容。詳細と follow-up は `KNOWLEDGE.md`「LLVM mirror workflow」を参照。
+- consumer (`.github/actions/setup-llvm`) は stable tag のみを参照する。rev の存在を知る必要はない。
+
+**キャッシュキー**: `llvm-${VERSION}-linux-x86_64-v3-${SHA256_SHORT}`。`restore-keys` は意図的に設定しない — 部分一致ヒットは異なるバージョンの LLVM を復元し、ビルド失敗や ABI 不整合を引き起こす。
 
 **バージョンバンプ手順**:
 
-1. `mirror-llvm-toolchain.yml` を `workflow_dispatch` で実行し、新バージョンの tarball をアップロード
+1. `mirror-llvm-toolchain.yml` を `workflow_dispatch` で実行し、新バージョンの tarball をアップロード（初回 dispatch で `rev1` + stable release が作成される）
 2. 以下のワークフローの `env.LLVM_VERSION`（および `env.LLVM_SHA256_SHORT`）を更新:
    - `.github/workflows/ci.yml`
    - `.github/workflows/ci-scheduled.yml`
    - `.github/workflows/codeql.yml`
+
+**tarball の rebuild が必要になった場合** (例: apt パッケージが更新されて SHA が変わった場合): 同じ `llvm_version` で `workflow_dispatch` を再実行すれば良い。`rev<N+1>` が追加され、stable pointer が新 rev を指すように更新される。ロールバックが必要な場合は、GitHub UI から stable release の assets を手動で過去の rev release の assets で置き換える。
 
 ## ナレッジベース (KNOWLEDGE.md)
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2422,8 +2422,8 @@ is the required gate for #630's race fixes. macOS is unaffected.
 
 ### LLVM mirror workflow and version-bump checklist
 
-**Source**: #892 / #919 / #934
-**Tags**: llvm, ci, cache, mirror, version-bump
+**Source**: #892 / #919 / #934 / #1246
+**Tags**: llvm, ci, cache, mirror, version-bump, race-condition
 
 **Rule**: CI fetches LLVM from a GitHub Releases mirror via
 `.github/actions/setup-llvm/`. The mirror tarball is built by
@@ -2434,16 +2434,56 @@ The mirror tarball includes `clang-tidy` (added in #934) and `scan-build` / `ana
 the apt fallback path; the mirror/cache path already contains all
 tools. If new tools are needed, add them to
 `mirror-llvm-toolchain.yml`'s apt-get line, bump the cache key
-version suffix (e.g. `v2` → `v3`), and re-dispatch the mirror workflow
-with `force=true`. A follow-up issue tracks adding `llvm-{MAJOR}-tools`
-to the mirror tarball to eliminate the extra apt install step.
+version suffix (e.g. `v2` → `v3`), and re-dispatch the mirror workflow.
+A follow-up issue tracks adding `llvm-{MAJOR}-tools` to the mirror
+tarball to eliminate the extra apt install step.
+
+**Mirror flow is non-destructive (#1246)**: Do NOT reintroduce
+`gh release delete --cleanup-tag` in the mirror workflow. The flow is:
+
+1. Each dispatch computes `next_rev = max(existing rev<N>) + 1` via
+   `gh release list | jq` with an anchored regex
+   `^llvm-toolchain-<V>-rev[0-9]+$` so malformed tags are skipped.
+2. Creates an immutable `llvm-toolchain-<V>-rev<N>` release that is
+   never deleted (audit trail + rollback source).
+3. Promotes the stable pointer `llvm-toolchain-<V>` in place via
+   `gh release upload --clobber`. This is NOT atomic — GitHub's API
+   has no atomic replace, so `--clobber` is implemented as a
+   sequential DELETE-then-POST per file. The missing-asset window
+   per file is the POST duration: sub-second for the `.sha256`, but
+   seconds to a few minutes for the LLVM tarball (300–500 MB). That
+   is still orders of magnitude better than the previous 3–5 minute
+   full-release gap produced by `gh release delete --cleanup-tag`.
+4. A workflow-level `concurrency: group: mirror-llvm-${{ inputs.llvm_version }}`
+   guard serialises dispatches for the same version so two racing
+   runs cannot both compute the same `next_rev`.
+
+The `force` input was removed — idempotent re-dispatches simply append
+a new rev. Rollback is a manual GitHub UI operation: edit the stable
+release and replace its assets with those of a prior `rev<N>` release.
+
+**Known follow-up (setup-llvm hardening)**: During the tarball upload
+window the stable release itself still exists, so
+`.github/actions/setup-llvm/action.yml`'s `gh release view` check
+succeeds and does not trigger the `apt.llvm.org` fallback — but the
+subsequent `gh release download` gets a 404 and the job hard-fails.
+The previous `--cleanup-tag` flow was actually softer here because
+the release was fully gone, so `gh release view` failed and the apt
+fallback kicked in. Because mirror dispatches are rare and manual,
+this was accepted in #1246, but a follow-up issue should harden
+`setup-llvm` to fall back on download failure too (e.g. retry the
+`gh release view`/`download` pair, or unconditionally try apt on any
+download failure). Do NOT re-introduce `--cleanup-tag` as a fix for
+this — that would regress the window from seconds to minutes back
+to 3–5 minutes.
 
 Version bump checklist — update `env.LLVM_VERSION` (and
 `env.LLVM_SHA256_SHORT` when non-empty) in:
 - `.github/workflows/ci.yml`
+- `.github/workflows/ci-scheduled.yml`
 - `.github/workflows/codeql.yml`
 
-Cache key format: `llvm-${VERSION}-linux-x86_64-v2-${SHA256_SHORT}`.
+Cache key format: `llvm-${VERSION}-linux-x86_64-v3-${SHA256_SHORT}`.
 `restore-keys` is intentionally omitted: a partial cache hit would
 restore a mismatched LLVM version, causing build failures or silent ABI
 mismatches. An exact-match-only policy guarantees the correct toolchain.


### PR DESCRIPTION
## Summary

Closes #1246.

Replaces the destructive `gh release delete --cleanup-tag` flow in `.github/workflows/mirror-llvm-toolchain.yml` with a non-destructive rev + stable pointer scheme:

- Each dispatch creates an immutable `llvm-toolchain-<V>-rev<N>` release (audit trail, never deleted). `<N>` = `max(existing rev) + 1`, computed via `gh release list | jq` with an anchored regex so malformed tags are skipped and the version is passed as `jq --arg V` (no shell injection).
- The stable pointer `llvm-toolchain-<V>` is updated in place via `gh release upload --clobber`. This eliminates the 3–5 minute full-release gap that caused concurrent CI consumers to hard-fail.
- Workflow-level `concurrency: group: mirror-llvm-${{ inputs.llvm_version }}` serialises dispatches for the same version so two racing runs cannot claim the same `next_rev`.
- The `force` input is removed — idempotent re-dispatches just append a new rev. Rollback is a manual UI op (swap stable assets for a prior rev release).
- Cache key suffix bumped `v2` → `v3`.

### Known trade-off (documented)

`gh release upload --clobber` is not atomic — it's sequential DELETE-then-POST per file. The missing-asset window per file is the POST duration: sub-second for `.sha256`, but seconds to a few minutes for the 300–500 MB LLVM tarball. During that tarball window, consumers' `gh release download` returns 404 without triggering setup-llvm's apt fallback (the fallback only fires on `gh release view` failure). Accepted because mirror dispatches are rare and manual, and the window is still much shorter than the previous 3–5 minute gap.

A setup-llvm hardening follow-up (fall back on download failure, not just view failure) is tracked in `KNOWLEDGE.md`.

### Files changed

- `.github/workflows/mirror-llvm-toolchain.yml` — non-destructive rewrite.
- `AGENTS.md` — updated "CI: LLVM ツールチェーン (ミラー)" section to describe the new flow and `v3` cache key.
- `KNOWLEDGE.md` — added "Mirror flow is non-destructive (#1246)" and "Known follow-up (setup-llvm hardening)" subsections under the existing LLVM mirror entry.

## Test plan

- [ ] CI (required checks) pass on this PR.
- [ ] After merge: dispatch `Mirror LLVM Toolchain` with `llvm_version=21.1.8` and confirm `llvm-toolchain-21.1.8-rev<N+1>` is created, stable pointer `llvm-toolchain-21.1.8` is updated, and both verify steps pass.
- [ ] Confirm a subsequent `ci.yml` run still restores LLVM from the stable mirror tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated LLVM mirror workflow and version-bump procedures to reflect a non-destructive, immutable-revision release flow and added concurrency guidance to prevent race conditions.
* **Chores**
  * Switched to immutable revisioned releases with a mutable stable pointer updated by replacing release assets.
  * Removed the prior manual "force" dispatch option.
  * Added explicit post-upload verification (download + checksum) and bumped CI cache key version (v2 → v3).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->