### PR TITLE
fix: restore git-triage-issue skill loading

### DIFF
--- a/.codex/skills/git-triage-issue/SKILL.md
+++ b/.codex/skills/git-triage-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-triage-issue
-description: When a problem is found outside the current task scope, classify and act. Enforces strict triage rules: only direct regressions stay in the branch; everything else becomes a filed issue with full context, proper size split, and milestone set to match the current PR.
+description: "When a problem is found outside the current task scope, classify and act. Enforces strict triage rules: only direct regressions stay in the branch; everything else becomes a filed issue with full context, proper size split, and milestone set to match the current PR."
 metadata:
   short-description: Triage out-of-scope issues with strict filing rules
 ---

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3917,6 +3917,15 @@ When the reproduction command set is open-ended (e.g. "run the CI job's correspo
 
 **Note**: `.codex/skills/` mirrors intentionally omit the `allowed-tools` field — Codex CLI does not support this frontmatter field. Only `.claude/skills/` SKILL.md files use `allowed-tools`. Do not add `allowed-tools` to `.codex/` skill files.
 
+### Quote `.codex/skills` frontmatter values when they contain `: `
+
+**Source**: #1284 (2026-04-21, implementation)
+**Tags**: skill, yaml, frontmatter, codex
+
+**Rule**: In `.codex/skills/*/SKILL.md`, quote any frontmatter scalar that contains `: `, especially long `description` strings. Unquoted YAML plain scalars treat `: ` as a mapping boundary and can make the whole skill unloadable with `mapping values are not allowed in this context`.
+
+**How to verify**: Parse the frontmatter as YAML or reload the skill list and confirm the skill is no longer skipped.
+
 ### `gh run list --branch` returns all runs on a branch, not just the PR head commit
 
 **Source**: #1045 (2026-04-16, CodeRabbit review)


### PR DESCRIPTION
## Summary
- quote the `git-triage-issue` skill description so its front matter is valid YAML
- add a `KNOWLEDGE.md` note covering `.codex/skills` front matter values that contain `: `
- verify the front matter parses successfully with Ruby YAML

## Testing
- `ruby -e 'require "yaml"; text = File.read(".codex/skills/git-triage-issue/SKILL.md"); front = text.split("---", 3)[1]; p YAML.safe_load(front)'`

Closes #1284

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new lesson documenting best practices for configuring skills, including proper formatting guidelines and verification methods to ensure your configuration is processed correctly without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->