### PR TITLE
fix: preserve helper return resource metadata

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -743,12 +743,15 @@ they may also carry dynamic metadata such as `thread_result` from
 compiled but `thread_join(mk_thread())` silently fell back to the Unit join path
 and produced `0` instead of `7`.
 
-**Rule**: When a return path can attach metadata that is not reconstructible
-from the source-level return type alone, snapshot that metadata on the callee
-(`propagateMeta(val, fn_)` in `ReturnStmt`) and reapply it to the call result in
-`propagateReturnTypeMeta` via `propagateMeta(entry->func, result)`. Keep the
-declared-type propagation too; it is still needed for canonical metadata rebuilt
-from the signature (resource kinds, enum names, collection names, etc.).
+**Rule**: Rebuild canonical metadata from the declared return type at the call
+site, but store dynamic return metadata in dedicated per-function slots — not by
+copying the full `ValueMetadata` onto `llvm::Function`. Full-copying is not
+branch-safe: a function with multiple `return` sites can overwrite or merge
+single-valued metadata like `thread_result` / `task_result` / `fn_type_info` and
+then replay the wrong snapshot at every call site. Instead, record only the
+needed dynamic fields (`ThreadResult`, `TaskResult`, function-return
+`FnTypeInfo`) and reject inconsistent values across return branches with a
+compile-time error.
 
 ### New primitive types must be wired into every type-reflection site
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -729,6 +729,27 @@ other container kinds, mirror the same pattern: (1) stored name first,
 (currently unnamed StructType), (3) fall back to `reverseResolveTypeName`
 for everything else.
 
+### Helper-function returns need both declared-type metadata and dynamic return metadata
+
+**Source**: #1317 (2026-04-22, implementation)
+**Tags**: codegen, metadata, function-return, resource, thread
+
+**Context**: Reapplying only `propagateTypeMeta(entry->returnTypeName, callResult)`
+at user-function call sites is not enough for values whose runtime metadata
+extends beyond the declared type name. `Thread` helper returns need the
+resource kind so `thread_join(t)` / `lock_acquire(lock)` type checks pass, but
+they may also carry dynamic metadata such as `thread_result` from
+`thread_spawn(() => 7)`. With only the declared type restored, helper returns
+compiled but `thread_join(mk_thread())` silently fell back to the Unit join path
+and produced `0` instead of `7`.
+
+**Rule**: When a return path can attach metadata that is not reconstructible
+from the source-level return type alone, snapshot that metadata on the callee
+(`propagateMeta(val, fn_)` in `ReturnStmt`) and reapply it to the call result in
+`propagateReturnTypeMeta` via `propagateMeta(entry->func, result)`. Keep the
+declared-type propagation too; it is still needed for canonical metadata rebuilt
+from the signature (resource kinds, enum names, collection names, etc.).
+
 ### New primitive types must be wired into every type-reflection site
 
 **Source**: #825 PR review (CodeRabbit, 4 comments)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -742,7 +742,13 @@ public:
     };
     FnTypeInfo *lookupFnTypeInfo(llvm::Value *val);
     std::unordered_map<llvm::Function*, FnTypeInfo> return_fn_type_info_;
+    std::unordered_map<llvm::Function*, llvm::Type*> return_task_result_types_;
+    std::unordered_map<llvm::Function*, llvm::Type*> return_thread_result_types_;
     llvm::FunctionCallee getOrCreateClosureDestructor(const FnTypeInfo &info);
+    void recordReturnFnTypeInfo(llvm::Function *fn, const FnTypeInfo &info,
+                                const std::string &fnNameForErrors);
+    void recordReturnTypeMetaSnapshot(llvm::Function *fn, llvm::Value *val,
+                                      const std::string &fnNameForErrors);
 
     // Uniform closure support: {thunk_ptr, env_ptr, env_dtor_ptr} for
     // function-type boundaries. `thunk_ptr` is a forwarding or capturing thunk

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -182,7 +182,12 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
 void CodeGen::propagateReturnTypeMeta(const OverloadEntry *entry, llvm::Value *val) {
     if (!entry) return;
     propagateTypeMeta(entry->returnTypeName, val);
-    propagateMeta(entry->func, val);
+    auto taskIt = return_task_result_types_.find(entry->func);
+    if (taskIt != return_task_result_types_.end() && taskIt->second)
+        setTypeMeta(TypeMeta::TaskResult, val, taskIt->second);
+    auto threadIt = return_thread_result_types_.find(entry->func);
+    if (threadIt != return_thread_result_types_.end() && threadIt->second)
+        setTypeMeta(TypeMeta::ThreadResult, val, threadIt->second);
 }
 
 void CodeGen::propagateReturnFnTypeMeta(const OverloadEntry *entry, llvm::Function *fn, llvm::Value *result) {

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -176,11 +176,13 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         // valueToString() dispatches on enum_value_type metadata (#820).
         getOrCreateMeta(val).enum_value_type = resolved;
     }
+    registerResourceByTypeName(resolved, val);
 }
 
 void CodeGen::propagateReturnTypeMeta(const OverloadEntry *entry, llvm::Value *val) {
     if (!entry) return;
     propagateTypeMeta(entry->returnTypeName, val);
+    propagateMeta(entry->func, val);
 }
 
 void CodeGen::propagateReturnFnTypeMeta(const OverloadEntry *entry, llvm::Function *fn, llvm::Value *result) {

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -208,6 +208,11 @@ void CodeGen::emitStmt(ReturnStmt &s) {
                     }
                 }
             }
+
+            // Preserve dynamic return metadata (e.g. resource kinds on helper
+            // returns, thread/task payload metadata) on the callee so user-call
+            // sites can reattach it to the call result.
+            propagateMeta(val, fn_);
         }
 
         // Emit ensure checks (postconditions) before return

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -11,6 +11,18 @@
 
 namespace ry {
 
+namespace {
+
+bool sameFnTypeInfoShape(const CodeGen::FnTypeInfo &lhs, const CodeGen::FnTypeInfo &rhs) {
+    return lhs.paramTypes == rhs.paramTypes &&
+           lhs.paramTypeNames == rhs.paramTypeNames &&
+           lhs.returnType == rhs.returnType &&
+           lhs.returnTypeName == rhs.returnTypeName &&
+           lhs.isUniformClosure == rhs.isUniformClosure;
+}
+
+} // namespace
+
 // --- JNI-like naming convention helpers ---
 
 std::string CodeGen::deriveRuntimeFnName(const std::string &package,
@@ -22,6 +34,44 @@ std::string CodeGen::deriveRuntimeFnName(const std::string &package,
 
 const std::unordered_set<std::string>& CodeGen::getRequiredLibraries() const {
     return used_native_libraries_;
+}
+
+void CodeGen::recordReturnFnTypeInfo(llvm::Function *fn, const FnTypeInfo &info,
+                                     const std::string &fnNameForErrors) {
+    auto it = return_fn_type_info_.find(fn);
+    if (it == return_fn_type_info_.end()) {
+        return_fn_type_info_[fn] = info;
+        return;
+    }
+    if (!sameFnTypeInfoShape(it->second, info)) {
+        codegenError("function '" + fnNameForErrors +
+                     "' returns incompatible function metadata across branches");
+    }
+}
+
+void CodeGen::recordReturnTypeMetaSnapshot(llvm::Function *fn, llvm::Value *val,
+                                           const std::string &fnNameForErrors) {
+    llvm::Type *taskTy = getTaskResultType(val);
+    if (taskTy) {
+        auto [it, inserted] = return_task_result_types_.emplace(fn, taskTy);
+        if (!inserted && it->second != taskTy) {
+            codegenError("function '" + fnNameForErrors +
+                         "' returns incompatible Task result metadata across branches");
+        }
+    }
+
+    llvm::Type *threadTy = getThreadResultType(val);
+    if (threadTy) {
+        auto [it, inserted] = return_thread_result_types_.emplace(fn, threadTy);
+        if (!inserted && it->second != threadTy) {
+            codegenError("function '" + fnNameForErrors +
+                         "' returns incompatible Thread result metadata across branches");
+        }
+    }
+
+    auto *fnInfo = lookupFnTypeInfo(val);
+    if (fnInfo)
+        recordReturnFnTypeInfo(fn, *fnInfo, fnNameForErrors);
 }
 
 std::string CodeGen::deriveNativePackage(const SourceLocation &loc) const {
@@ -139,7 +189,8 @@ void CodeGen::emitStmt(ReturnStmt &s) {
                         val = wrapAsUniformClosure(val, *fnInfo);
                         fnInfo = lookupFnTypeInfo(val);
                     }
-                    return_fn_type_info_[fn_] = *fnInfo;
+                    if (fnInfo)
+                        recordReturnFnTypeInfo(fn_, *fnInfo, current_function_name_);
                 }
             }
 
@@ -209,10 +260,10 @@ void CodeGen::emitStmt(ReturnStmt &s) {
                 }
             }
 
-            // Preserve dynamic return metadata (e.g. resource kinds on helper
-            // returns, thread/task payload metadata) on the callee so user-call
-            // sites can reattach it to the call result.
-            propagateMeta(val, fn_);
+            // Snapshot only branch-stable dynamic return metadata. Writing the
+            // full ValueMetadata onto fn_ would merge unrelated return-site
+            // state (e.g. thread_result) and misapply it at every call site.
+            recordReturnTypeMetaSnapshot(fn_, val, current_function_name_);
         }
 
         // Emit ensure checks (postconditions) before return

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -52,21 +52,17 @@ void CodeGen::recordReturnFnTypeInfo(llvm::Function *fn, const FnTypeInfo &info,
 void CodeGen::recordReturnTypeMetaSnapshot(llvm::Function *fn, llvm::Value *val,
                                            const std::string &fnNameForErrors) {
     llvm::Type *taskTy = getTaskResultType(val);
-    if (taskTy) {
-        auto [it, inserted] = return_task_result_types_.emplace(fn, taskTy);
-        if (!inserted && it->second != taskTy) {
-            codegenError("function '" + fnNameForErrors +
-                         "' returns incompatible Task result metadata across branches");
-        }
+    auto [taskIt, taskInserted] = return_task_result_types_.emplace(fn, taskTy);
+    if (!taskInserted && taskIt->second != taskTy) {
+        codegenError("function '" + fnNameForErrors +
+                     "' returns incompatible Task result metadata across branches");
     }
 
     llvm::Type *threadTy = getThreadResultType(val);
-    if (threadTy) {
-        auto [it, inserted] = return_thread_result_types_.emplace(fn, threadTy);
-        if (!inserted && it->second != threadTy) {
-            codegenError("function '" + fnNameForErrors +
-                         "' returns incompatible Thread result metadata across branches");
-        }
+    auto [threadIt, threadInserted] = return_thread_result_types_.emplace(fn, threadTy);
+    if (!threadInserted && threadIt->second != threadTy) {
+        codegenError("function '" + fnNameForErrors +
+                     "' returns incompatible Thread result metadata across branches");
     }
 
     auto *fnInfo = lookupFnTypeInfo(val);
@@ -189,8 +185,6 @@ void CodeGen::emitStmt(ReturnStmt &s) {
                         val = wrapAsUniformClosure(val, *fnInfo);
                         fnInfo = lookupFnTypeInfo(val);
                     }
-                    if (fnInfo)
-                        recordReturnFnTypeInfo(fn_, *fnInfo, current_function_name_);
                 }
             }
 

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -129,4 +129,38 @@ describe("TCP socket API", ():
       Err(e):
         fail("unexpected error")
   )
+
+  it("should preserve Result<TcpStream, Error> resource metadata across helper returns", ():
+    async function run_server(server: TcpListener) -> str:
+      case accept(server):
+        Ok(conn):
+          sleep(200)
+          close(conn)
+        Err(e):
+          ...
+      close(server)
+      return "done"
+
+    function mk_conn(port: int) -> Result<TcpStream, Error>:
+      return connect("127.0.0.1", port)
+
+    case bind("127.0.0.1", 0):
+      Ok(server):
+        case listen(server, 1):
+          Ok(_):
+            port = listener_port(server)
+            t = run_server(server)
+            case mk_conn(port):
+              Ok(conn):
+                set_receive_timeout(conn, 50)
+                close(conn)
+                expect(true).to_eq(true)
+              Err(e):
+                fail("unexpected error")
+            block_on(t)
+          Err(e):
+            fail("unexpected error")
+      Err(e):
+        fail("unexpected error")
+  )
 )

--- a/tests/spec/thread.test.ry
+++ b/tests/spec/thread.test.ry
@@ -1,4 +1,4 @@
-from thread import thread_spawn, thread_join, lock_new, lock_acquire, lock_release, rwlock_new, rwlock_read_lock, rwlock_write_lock, rwlock_unlock, semaphore_new, semaphore_acquire, semaphore_release, barrier_new, barrier_wait, atomic_int_new, atomic_int_load, atomic_int_store, atomic_int_add, atomic_int_sub, atomic_int_cas, atomic_bool_new, atomic_bool_load, atomic_bool_store
+from thread import thread_spawn, thread_join, lock_new, lock_acquire, lock_release, lock_free, rwlock_new, rwlock_read_lock, rwlock_write_lock, rwlock_unlock, semaphore_new, semaphore_acquire, semaphore_release, barrier_new, barrier_wait, atomic_int_new, atomic_int_load, atomic_int_store, atomic_int_add, atomic_int_sub, atomic_int_cas, atomic_int_free, atomic_bool_new, atomic_bool_load, atomic_bool_store
 
 describe("thread_spawn and thread_join", ():
   it("should spawn a thread and join it", ():
@@ -185,6 +185,29 @@ describe("AtomicBool", ():
   )
 )
 
+describe("resource helper returns", ():
+  it("should preserve Lock metadata across helper returns", ():
+    function mk_lock() -> Lock:
+      return lock_new()
+
+    lock = mk_lock()
+    expect(lock_acquire(lock)).to_be_ok()
+    expect(lock_release(lock)).to_be_ok()
+    lock_free(lock)
+  )
+
+  it("should preserve AtomicInt metadata across helper returns", ():
+    function mk_atomic() -> AtomicInt:
+      return atomic_int_new(5)
+
+    a = mk_atomic()
+    expect(atomic_int_load(a)).to_eq(5)
+    atomic_int_store(a, 9)
+    expect(atomic_int_load(a)).to_eq(9)
+    atomic_int_free(a)
+  )
+)
+
 describe("thread_spawn return values (MVP, #828)", ():
   it("should return int from an expression-bodied worker", ():
     t = thread_spawn(() => 42)
@@ -230,6 +253,17 @@ describe("thread_spawn return values (MVP, #828)", ():
     t = thread_spawn(() => 7)
     r = thread_join(t)
     case r:
+      Ok(v):
+        expect(v).to_eq(7)
+      Err(e):
+        fail("expected Ok but got Err")
+  )
+
+  it("should preserve Thread resource metadata across helper returns", ():
+    function mk_thread() -> Thread:
+      return thread_spawn(() => 7)
+
+    case thread_join(mk_thread()):
       Ok(v):
         expect(v).to_eq(7)
       Err(e):

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -198,6 +198,17 @@ TEST_F(CodeGenTest, MathPowIntNegativeExponentAborts) {
         "pow\\(\\) integer exponent must be non-negative");
 }
 
+TEST_F(CodeGenTest, HelperReturnRejectsIncompatibleThreadResultMetadataAcrossBranches) {
+    expectCompileError(
+        "@native(\"thread\")\n"
+        "function thread_spawn(body: function() -> any) -> Thread\n"
+        "function mk_thread(flag: bool) -> Thread:\n"
+        "  if flag:\n"
+        "    return thread_spawn(() => 1)\n"
+        "  return thread_spawn(() => true)\n",
+        "returns incompatible Thread result metadata across branches");
+}
+
 // ============================================================
 // Generic inference for container parameters (#823).
 // An empty container literal yields no information for the

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -209,6 +209,17 @@ TEST_F(CodeGenTest, HelperReturnRejectsIncompatibleThreadResultMetadataAcrossBra
         "returns incompatible Thread result metadata across branches");
 }
 
+TEST_F(CodeGenTest, HelperReturnRejectsMissingAndPresentThreadResultMetadataMix) {
+    expectCompileError(
+        "@native(\"thread\")\n"
+        "function thread_spawn(body: function() -> any) -> Thread\n"
+        "function mk_thread(flag: bool, fallback: Thread) -> Thread:\n"
+        "  if flag:\n"
+        "    return thread_spawn(() => 1)\n"
+        "  return fallback\n",
+        "returns incompatible Thread result metadata across branches");
+}
+
 // ============================================================
 // Generic inference for container parameters (#823).
 // An empty container literal yields no information for the


### PR DESCRIPTION
## Summary
- preserve resource metadata when helper functions return resource-typed values
- carry dynamic return metadata across user-function boundaries so helper-returned Thread values keep thread result metadata
- add Ry regression tests for Thread, Lock, AtomicInt, and Result<TcpStream, Error> helper returns and record the rule in KNOWLEDGE.md

## Testing
- ./build/ry_tests
- ./build/ry test -p

Closes #1317

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve declared and dynamic return-type/resource metadata when values are returned through helper functions; added compile-time checks that reject inconsistent return metadata across branches.

* **Tests**
  * Added tests validating metadata preservation for networking and threading helpers and new compile-failure tests for incompatible thread/result return metadata.

* **Documentation**
  * Added guidance documenting how helper-function returns must preserve declared and dynamic return metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->