### PR TITLE
fix: preserve Result/Option payload metadata

### DIFF
--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -89,6 +89,11 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
     // their canonical spellings. resolveTypeAlias returns the input unchanged
     // when no alias matches. (PR #853 review)
     const std::string resolved = resolveTypeAlias(typeName);
+    auto propagateResourceLikeMeta = [&](const std::string &resolvedType) {
+        registerResourceByTypeName(resolvedType, val);
+        if (resolvedType == "JsonValue")
+            getOrCreateMeta(val).json_type_only = true;
+    };
     if (resolved.size() > 5 && resolved.compare(0, 5, "Task<") == 0 && resolved.back() == '>') {
         std::string inner = resolved.substr(5, resolved.size() - 6);
         setTypeMeta(TypeMeta::TaskResult, val, resolveType(inner));
@@ -151,6 +156,7 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
                             (getMeta(val)->list_elem || getMeta(val)->map_key ||
                              getMeta(val)->set_elem));
             propagateTypeMeta(okType, val);
+            propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(okType)));
             bool hasMeta = (getMeta(val) != nullptr &&
                             (getMeta(val)->list_elem || getMeta(val)->map_key ||
                              getMeta(val)->set_elem));
@@ -161,16 +167,24 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
                 size_t start = errType.find_first_not_of(' ');
                 if (start != std::string::npos) errType = errType.substr(start);
                 propagateTypeMeta(errType, val);
+                propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(errType)));
             }
         }
     } else if (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0 && resolved.back() == '>') {
         // Same treatment for Option<Collection> (#985 — mirrors Result handling above).
-        propagateTypeMeta(resolved.substr(7, resolved.size() - 8), val);
+        std::string inner = resolved.substr(7, resolved.size() - 8);
+        propagateTypeMeta(inner, val);
+        propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(inner)));
     } else if (resolved.size() > 1 && resolved.back() == '?') {
         // T? suffix is OptionalType::toString() shorthand for Option<T> (#1003).
-        propagateTypeMeta(resolved.substr(0, resolved.size() - 1), val);
+        std::string inner = resolved.substr(0, resolved.size() - 1);
+        propagateTypeMeta(inner, val);
+        propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(inner)));
     } else if (isLowLevelTypeName(resolved)) {
         getOrCreateMeta(val).low_level_type_name = resolved;
+    } else if (ResourceKindRegistry::instance().lookupByTypeName(resolved) !=
+               ResourceKindRegistry::NONE) {
+        propagateResourceLikeMeta(resolved);
     } else if (ensureEnumInstantiated(resolved)) {
         // Concrete enum or generic enum instantiation: tag the value so
         // valueToString() dispatches on enum_value_type metadata (#820).

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -91,8 +91,6 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
     const std::string resolved = resolveTypeAlias(typeName);
     auto propagateResourceLikeMeta = [&](const std::string &resolvedType) {
         registerResourceByTypeName(resolvedType, val);
-        if (resolvedType == "JsonValue")
-            getOrCreateMeta(val).json_type_only = true;
     };
     if (resolved.size() > 5 && resolved.compare(0, 5, "Task<") == 0 && resolved.back() == '>') {
         std::string inner = resolved.substr(5, resolved.size() - 6);

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -40,6 +40,7 @@ describe("json parse", ():
     case parse_obj():
       Ok(data):
         expect(kind(data)).to_eq("object")
+        json_free(data)
       Err(e):
         fail("parse failed")
   )
@@ -54,6 +55,7 @@ describe("json parse", ():
     case maybe_obj():
       Some(data):
         expect(kind(data)).to_eq("object")
+        json_free(data)
       None:
         fail("unexpected None")
   )

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -33,6 +33,30 @@ describe("json parse", ():
     expect(parse("\"a\0b\"")).to_be_err()
     expect(parse("\"a\nb\"")).to_be_err()
   )
+  it("should preserve JsonValue metadata through helper-returned Result", ():
+    function parse_obj() -> Result<JsonValue, Error>:
+      return parse("{\"x\": 42}")
+
+    case parse_obj():
+      Ok(data):
+        expect(kind(data)).to_eq("object")
+      Err(e):
+        fail("parse failed")
+  )
+  it("should preserve JsonValue metadata through helper-returned Option", ():
+    function maybe_obj() -> Option<JsonValue>:
+      case parse("{\"x\": 7}"):
+        Ok(data):
+          return Some(data)
+        Err(e):
+          return None()
+
+    case maybe_obj():
+      Some(data):
+        expect(kind(data)).to_eq("object")
+      None:
+        fail("unexpected None")
+  )
 )
 
 describe("json access", ():

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -38,6 +38,32 @@ describe("TCP socket API", ():
       Err(e):
         expect(true).to_eq(true)
   )
+  it("should preserve TcpListener metadata through helper-returned Result", ():
+    function mk_listener() -> Result<TcpListener, Error>:
+      return bind("127.0.0.1", 0)
+
+    case mk_listener():
+      Ok(server):
+        expect(listener_port(server) > 0).to_be_true()
+        close(server)
+      Err(e):
+        fail("unexpected error")
+  )
+  it("should preserve TcpListener metadata through helper-returned Option", ():
+    function maybe_listener() -> Option<TcpListener>:
+      case bind("127.0.0.1", 0):
+        Ok(server):
+          return Some(server)
+        Err(e):
+          return None()
+
+    case maybe_listener():
+      Some(server):
+        expect(listener_port(server) > 0).to_be_true()
+        close(server)
+      None:
+        fail("unexpected None")
+  )
   it("should cause receive to return Err on timeout via set_receive_timeout", ():
     async function timeout_server(server: TcpListener) -> str:
       case accept(server):


### PR DESCRIPTION
## Summary
- preserve resource and JsonValue metadata when propagating Result/Option payload type metadata
- add regression specs for helper-returned Result/Option values wrapping TcpListener and JsonValue

## Testing
- cmake --build build
- ./build/ry_tests
- ./build/ry test -p

Refs #1316

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure resource-like type metadata is preserved when those types are returned inside Result, Option, or optional shorthand, and for direct resource-like type names.

* **Tests**
  * Added tests validating metadata preservation for JsonValue and TcpListener when returned from helper functions using Result and Option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->