### PR TITLE
fix: preserve collection element metadata

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -4956,3 +4956,13 @@ The retain discipline is **symmetric** with the destructor:
 **How to apply**: A repro is `m1 = {"a": a}; merged = merge(m1, m2); m1 = {"x": [99]}; print(merged["a"][0])` — pre-fix on a post-destructor-extension build this reads freed memory. Tests that rebind the source AND run an allocation-churning loop before reading the new collection reliably surface the UAF (without the churn, the freed memory still holds the old value and the read looks correct). See `tests/spec/arc_release_on_rebind.test.ry` "merge(Map<str,List<int>>, ...) survives source rebind" and "appended(List<List<int>>, ...) survives source rebind" for the canonical pattern.
 
 **Related**: #1204, #1235, #1046 (original CoW retain), #1242.
+
+---
+
+### `List<T>` annotations must preserve named pointer-backed inner types for index-load metadata rebuilds
+
+**Source**: #1320 (2026-04-22, implementation). **Tags**: codegen, metadata, list, index, annotation, JsonValue, resource
+
+**Rule**: When recording `list_elem_type_name` from a `List<T>` annotation, preserve every non-primitive inner type name except `str` (which must keep using the `list_elem_is_str` side-channel from #1266). Limiting the stored name to nested collections/functions misses pointer-backed named types like `JsonValue` and stdlib resources (`Lock`, `RWLock`, etc.), so `xs[i]` cannot rebuild the loaded element's metadata via `propagateTypeMeta()`.
+
+**How to apply**: In `emitVarDecl`, after handling `str` and function-typed inners, assign `list_elem_type_name = inner` for any inner type other than `int` / `float` / `bool`. This keeps index loads, loop bindings, and other metadata-reconstruction sites able to restore resource kinds or JSON dispatch metadata from the annotation even when the loaded LLVM type is just `ptr`.

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -171,6 +171,9 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         propagateTypeMeta(resolved.substr(0, resolved.size() - 1), val);
     } else if (isLowLevelTypeName(resolved)) {
         getOrCreateMeta(val).low_level_type_name = resolved;
+    } else if (const int rk = ResourceKindRegistry::instance().lookupByTypeName(resolved);
+               rk != ResourceKindRegistry::NONE) {
+        addResourceKind(val, rk);
     } else if (ensureEnumInstantiated(resolved)) {
         // Concrete enum or generic enum instantiation: tag the value so
         // valueToString() dispatches on enum_value_type metadata (#820).

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -330,12 +330,15 @@ void CodeGen::emitVarDecl(const std::string &name,
             getOrCreateMeta(ptr).list_elem_type_name = inner;
         }
 
-        // Set list element type metadata. Also covers low-level int names
-        // ("i8", "u8", …) so AssignStmt (#1085) can recover them faithfully.
-        if (isMapTypeName(inner) || isSetTypeName(inner) || isLowLevelIntTypeName(inner))
-            getOrCreateMeta(ptr).list_elem_type_name = inner;
+        // Keep the source-level inner type name for every non-primitive
+        // List<T> annotation except str, which uses its own side channel
+        // (`list_elem_is_str`) to avoid flipping destructor dispatch (#1266).
+        if (inner == "str")
+            getOrCreateMeta(ptr).list_elem_is_str = true;
         else if (inner.size() > 9 && inner.substr(0, 9) == "function(")
             getOrCreateMeta(ptr).list_elem_fn_type_info = parseFnTypeAnnotation(inner);
+        else if (inner != "int" && inner != "float" && inner != "bool")
+            getOrCreateMeta(ptr).list_elem_type_name = inner;
 
         if (is_immutable)
             immutable_scope_stack_.back().insert(name);
@@ -650,14 +653,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                 if (isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
                     std::string inner = resolved.substr(5, resolved.size() - 6);
                     while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
-                    if (isMapTypeName(inner) || isSetTypeName(inner) ||
-                            isLowLevelIntTypeName(inner)) {
-                        // Also covers low-level int names (e.g. "i8", "u8") so that
-                        // AssignStmt (#1085) can recover the source-level element name
-                        // faithfully without the lossy reverseResolveTypeName round-trip
-                        // (i8Ty_ → "u8" regardless of the declared signedness).
-                        letn = inner;
-                    } else if (inner.size() > 9 && inner.substr(0, 9) == "function(") {
+                    if (inner.size() > 9 && inner.substr(0, 9) == "function(") {
                         lefti = parseFnTypeAnnotation(inner);
                     } else if (inner == "str") {
                         // List<str>: don't stamp list_elem_type_name (that
@@ -666,16 +662,11 @@ void CodeGen::emitVarDecl(const std::string &name,
                         // symmetry that #1242 owns). Use a side-channel
                         // that only the indexer reads. (#1266)
                         inner_is_str = true;
-                    } else {
-                        // Tuple annotation (or alias resolving to one): record
-                        // the resolved tuple signature so for-loop destructure
-                        // in #813 can split per-component metadata. PR #853
-                        // review.
-                        std::string innerResolved = resolveTypeAlias(inner);
-                        if (innerResolved.size() >= 2
-                                && innerResolved.front() == '('
-                                && innerResolved.back() == ')')
-                            letn = innerResolved;
+                    } else if (inner != "int" && inner != "float" && inner != "bool") {
+                        // Preserve named non-primitive inner types
+                        // (records/enums/resources/JsonValue/low-level aliases/etc.)
+                        // so index loads can rebuild downstream metadata.
+                        letn = inner;
                     }
                 }
             }

--- a/tests/spec/collection_element_metadata.test.ry
+++ b/tests/spec/collection_element_metadata.test.ry
@@ -32,4 +32,14 @@ describe("collection element loads preserve metadata (#1320)", ():
     expect(lock_release(y)).to_be_ok()
     lock_free(y)
   )
+
+  it("preserves resource metadata for annotated empty List element loads", ():
+    xs: List<Lock> = []
+    lock = lock_new()
+    append(xs, lock)
+    y = xs[0]
+    expect(lock_acquire(y)).to_be_ok()
+    expect(lock_release(y)).to_be_ok()
+    lock_free(y)
+  )
 )

--- a/tests/spec/collection_element_metadata.test.ry
+++ b/tests/spec/collection_element_metadata.test.ry
@@ -1,0 +1,35 @@
+from json import parse, kind, json_free
+from thread import lock_new, lock_acquire, lock_release, lock_free
+
+describe("collection element loads preserve metadata (#1320)", ():
+  it("preserves JsonValue metadata for List element loads", ():
+    case parse("{\"x\": 1}"):
+      Ok(v):
+        xs: List<JsonValue> = [v]
+        x = xs[0]
+        expect(kind(x)).to_eq("object")
+        json_free(x)
+      Err(e):
+        fail("parse failed: " + e.message)
+  )
+
+  it("preserves JsonValue metadata for Map value loads", ():
+    case parse("{\"x\": 1}"):
+      Ok(v):
+        m: Map<str, JsonValue> = {"k": v}
+        x = m["k"]
+        expect(kind(x)).to_eq("object")
+        json_free(x)
+      Err(e):
+        fail("parse failed: " + e.message)
+  )
+
+  it("preserves resource metadata for List element loads", ():
+    lock = lock_new()
+    xs: List<Lock> = [lock]
+    y = xs[0]
+    expect(lock_acquire(y)).to_be_ok()
+    expect(lock_release(y)).to_be_ok()
+    lock_free(y)
+  )
+)


### PR DESCRIPTION
## Summary
- preserve metadata for named pointer-backed types when rebuilding collection element type info
- restore resource kind metadata through propagateTypeMeta for downstream typed APIs
- add regression coverage for List/Map JsonValue loads and List<Lock> loads

## Testing
- ./build/ry_tests
- ./build/ry test -p

Closes #1320

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve type/resource metadata when loading elements from collections so resources (e.g., locks) and complex types (e.g., JSON values) retain correct runtime kind/info on index-based access.

* **Tests**
  * Added tests validating metadata preservation for JSON objects and resource types accessed from lists and maps.

* **Documentation**
  * Clarified collection annotation rules for when element type names vs. string flags should be recorded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->