### PR TITLE
fix: surface invalid dynamic regex patterns as runtime errors

### DIFF
--- a/include/ry/runtime_regex.hpp
+++ b/include/ry/runtime_regex.hpp
@@ -7,6 +7,8 @@ namespace ry {
 
 extern "C" {
 
+const char *__ry_regex_get_last_error();
+
 // Full match: returns 1 if entire text matches pattern, 0 otherwise.
 // patternLen / textLen are the byte lengths (NUL bytes included).
 int64_t __ry_regex_match(const char *pattern, int64_t patternLen,

--- a/include/ry/runtime_regex_error_sentinels.hpp
+++ b/include/ry/runtime_regex_error_sentinels.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace ry {
+
+inline constexpr int64_t kRegexMatchError = -1;
+inline constexpr int64_t kRegexSearchError = std::numeric_limits<int64_t>::min();
+
+} // namespace ry

--- a/include/ry/runtime_regex_internal.hpp
+++ b/include/ry/runtime_regex_internal.hpp
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <cstdio>
+#include <cstdarg>
 #include <cstdlib>
 #include <cctype>
 #include <cstring>
 #include <memory>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 
@@ -89,6 +92,7 @@ private:
     RegexNodePtr parseShorthandClass(char code);
     RegexNodePtr parseCharClass();
     char parseClassChar();
+    [[noreturn]] void fail(const char *fmt, ...);
 };
 
 } // namespace ry

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -1,15 +1,9 @@
 #include "ry/codegen.hpp"
+#include "ry/runtime_regex_error_sentinels.hpp"
 #include "ry/stdlib_registry.hpp"
 
 
 namespace ry {
-
-namespace {
-
-constexpr int64_t kRegexMatchError = -1;
-constexpr int64_t kRegexSearchError = std::numeric_limits<int64_t>::min();
-
-}
 
 // Resource kind IDs (assigned at static init)
 static int rk_tcp_listener, rk_tcp_stream, rk_tls_stream;

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -4,6 +4,13 @@
 
 namespace ry {
 
+namespace {
+
+constexpr int64_t kRegexMatchError = -1;
+constexpr int64_t kRegexSearchError = std::numeric_limits<int64_t>::min();
+
+}
+
 // Resource kind IDs (assigned at static init)
 static int rk_tcp_listener, rk_tcp_stream, rk_tls_stream;
 static int rk_http_request, rk_http_response, rk_http_client_response;
@@ -47,23 +54,62 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
         return builder_.CreateCall(fn, args, name);
     };
 
+    auto emitRegexRuntimeError = [&]() {
+        auto errFnTy = llvm::FunctionType::get(ptrTy_, {}, false);
+        auto errFn = mod_->getOrInsertFunction("__ry_regex_get_last_error", errFnTy);
+        llvm::Value *msgPtr = builder_.CreateCall(errFn, {}, "regex_err_msg");
+        emitRuntimeError("error: %s\n", ".regex_runtime_err", {msgPtr});
+    };
+
+    auto emitRegexI64Guard = [&](llvm::Value *result, int64_t errSentinel,
+                                 const std::string &prefix) -> llvm::Value * {
+        llvm::Value *isErr = builder_.CreateICmpEQ(
+            result, llvm::ConstantInt::get(*ctx_, llvm::APInt(64, static_cast<uint64_t>(errSentinel), true)),
+            prefix + "_is_err");
+        llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, prefix + ".err", fn_);
+        llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, prefix + ".ok", fn_);
+        builder_.CreateCondBr(isErr, errBB, okBB);
+        builder_.SetInsertPoint(errBB);
+        emitRegexRuntimeError();
+        builder_.SetInsertPoint(okBB);
+        return result;
+    };
+
+    auto emitRegexPtrGuard = [&](llvm::Value *result, const std::string &prefix) -> llvm::Value * {
+        llvm::Value *isNull = builder_.CreateICmpEQ(
+            result, llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
+            prefix + "_is_null");
+        llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, prefix + ".err", fn_);
+        llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, prefix + ".ok", fn_);
+        builder_.CreateCondBr(isNull, errBB, okBB);
+        builder_.SetInsertPoint(errBB);
+        emitRegexRuntimeError();
+        builder_.SetInsertPoint(okBB);
+        return result;
+    };
+
     // regex_match(text, pattern) -> bool
     if (e.callee == "regex_match") {
         llvm::Value *r = emitRegexCall("regex_match", 2,
                                        fnTy_ptr_i64_ptr_i64_to_i64_);
+        r = emitRegexI64Guard(r, kRegexMatchError, "regex_match");
         return builder_.CreateTrunc(r, i1Ty_, "regex_match_bool");
     }
     // regex_search(text, pattern) -> int
-    if (e.callee == "regex_search")
-        return emitRegexCall("regex_search", 2, fnTy_ptr_i64_ptr_i64_to_i64_);
+    if (e.callee == "regex_search") {
+        llvm::Value *r = emitRegexCall("regex_search", 2, fnTy_ptr_i64_ptr_i64_to_i64_);
+        return emitRegexI64Guard(r, kRegexSearchError, "regex_search");
+    }
     // regex_replace(text, pattern, replacement) -> str
     if (e.callee == "regex_replace")
-        return emitRegexCall("regex_replace", 3,
-                             fnTy_ptr_i64_ptr_i64_ptr_i64_to_ptr_);
+        return emitRegexPtrGuard(
+            emitRegexCall("regex_replace", 3, fnTy_ptr_i64_ptr_i64_ptr_i64_to_ptr_),
+            "regex_replace");
     // regex_split(text, pattern) -> List<str>
     if (e.callee == "regex_split") {
         llvm::Value *r = emitRegexCall("regex_split", 2,
                                        fnTy_ptr_i64_ptr_i64_to_ptr_);
+        r = emitRegexPtrGuard(r, "regex_split");
         setTypeMeta(TypeMeta::ListElem, r, ptrTy_);
         return r;
     }
@@ -71,6 +117,7 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
     if (e.callee == "regex_find_all") {
         llvm::Value *r = emitRegexCall("regex_find_all", 2,
                                        fnTy_ptr_i64_ptr_i64_to_ptr_);
+        r = emitRegexPtrGuard(r, "regex_find_all");
         setTypeMeta(TypeMeta::ListElem, r, record_types_["Match"].llvmType);
         getOrCreateMeta(r).list_elem_type_name = "Match";
         return r;
@@ -89,8 +136,13 @@ llvm::Value *CodeGen::emitBuiltinRegex(const CallExpr &e) {
         llvm::Value *textLen    = emitStringByteLen(text);
         auto fn = mod_->getOrInsertFunction("__ry_" + rtName, fnTy);
         // Runtime expects (pattern, patternLen, text, textLen).
-        return builder_.CreateCall(fn, {pattern, patternLen, text, textLen},
-                                   rtName);
+        llvm::Value *r = builder_.CreateCall(fn, {pattern, patternLen, text, textLen},
+                                             rtName);
+        if (fnTy->getReturnType() == i64Ty_) {
+            int64_t sentinel = rtName == "regex_search" ? kRegexSearchError : kRegexMatchError;
+            return emitRegexI64Guard(r, sentinel, rtName);
+        }
+        return emitRegexPtrGuard(r, rtName);
     };
 
     if (e.callee == "is_match" && e.args.size() == 2) {

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -271,6 +271,8 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
     // Regex overload: replace(text, /pattern/, replacement) → delegate to regex runtime
     // Regex values are StringHeader-backed so emitStringByteLen is safe (#1052).
     if (isRegex(oldStr) && isStringValue(s)) {
+        if (!isStringValue(newStr))
+            codegenError("replace() requires str arguments");
         auto fn = mod_->getOrInsertFunction("__ry_regex_replace",
                                             fnTy_ptr_i64_ptr_i64_ptr_i64_to_ptr_);
         auto *r = builder_.CreateCall(fn,

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -278,6 +278,18 @@ llvm::Value *CodeGen::emitStrOp_replace(const CallExpr &e) {
              s,      emitStringByteLen(s),
              newStr, emitStringByteLen(newStr)},
             "regex_replace");
+        llvm::Value *isNull = builder_.CreateICmpEQ(
+            r, llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
+            "regex_replace_is_null");
+        llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, "regex_replace.err", fn_);
+        llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "regex_replace.ok", fn_);
+        builder_.CreateCondBr(isNull, errBB, okBB);
+        builder_.SetInsertPoint(errBB);
+        auto errFnTy = llvm::FunctionType::get(ptrTy_, {}, false);
+        auto errFn = mod_->getOrInsertFunction("__ry_regex_get_last_error", errFnTy);
+        llvm::Value *msgPtr = builder_.CreateCall(errFn, {}, "regex_replace_err_msg");
+        emitRuntimeError("error: %s\n", ".regex_replace_runtime_err", {msgPtr});
+        builder_.SetInsertPoint(okBB);
         arc_str_owned_values_.insert(r);
         return r;
     }
@@ -642,6 +654,18 @@ llvm::Value *CodeGen::emitStrOp_split(const CallExpr &e) {
         llvm::Value *r = builder_.CreateCall(fn,
             {delim, emitStringByteLen(delim), s, emitStringByteLen(s)},
             "regex_split");
+        llvm::Value *isNull = builder_.CreateICmpEQ(
+            r, llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
+            "regex_split_is_null");
+        llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, "regex_split.err", fn_);
+        llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "regex_split.ok", fn_);
+        builder_.CreateCondBr(isNull, errBB, okBB);
+        builder_.SetInsertPoint(errBB);
+        auto errFnTy = llvm::FunctionType::get(ptrTy_, {}, false);
+        auto errFn = mod_->getOrInsertFunction("__ry_regex_get_last_error", errFnTy);
+        llvm::Value *msgPtr = builder_.CreateCall(errFn, {}, "regex_split_err_msg");
+        emitRuntimeError("error: %s\n", ".regex_split_runtime_err", {msgPtr});
+        builder_.SetInsertPoint(okBB);
         setTypeMeta(TypeMeta::ListElem, r, ptrTy_);
         return r;
     }

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -1,4 +1,5 @@
 #include "ry/runtime_regex.hpp"
+#include "ry/runtime_error.hpp"
 #include "ry/runtime_regex_internal.hpp"
 #include "ry/runtime_list.hpp"
 #include <algorithm>
@@ -11,11 +12,17 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include <stdexcept>
 
 
 namespace ry {
 
+DEFINE_LAST_ERROR(regex)
+
 namespace {
+
+constexpr int64_t kRegexMatchError = -1;
+constexpr int64_t kRegexSearchError = std::numeric_limits<int64_t>::min();
 
 // ============================================================
 // NFA
@@ -889,21 +896,33 @@ extern "C" {
 int64_t __ry_regex_match(const char *pattern, int64_t patternLen,
                           const char *text,    int64_t textLen) {
     if (!pattern || !text) return 0;
-    auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
-    return cr.fullMatch(text, static_cast<size_t>(textLen)) ? 1 : 0;
+    try {
+        auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
+        return cr.fullMatch(text, static_cast<size_t>(textLen)) ? 1 : 0;
+    } catch (const std::runtime_error &e) {
+        setLastError("%s", e.what());
+        return kRegexMatchError;
+    }
 }
 
 int64_t __ry_regex_search(const char *pattern, int64_t patternLen,
                            const char *text,    int64_t textLen) {
     if (!pattern || !text) return -1;
-    auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
-    auto result = cr.search(text, static_cast<size_t>(textLen));
-    return result.first;
+    try {
+        auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
+        auto result = cr.search(text, static_cast<size_t>(textLen));
+        return result.first;
+    } catch (const std::runtime_error &e) {
+        setLastError("%s", e.what());
+        return kRegexSearchError;
+    }
 }
 
 int64_t __ry_regex_is_match(const char *pattern, int64_t patternLen,
                              const char *text,    int64_t textLen) {
-    return __ry_regex_search(pattern, patternLen, text, textLen) >= 0 ? 1 : 0;
+    int64_t result = __ry_regex_search(pattern, patternLen, text, textLen);
+    if (result == kRegexSearchError) return kRegexMatchError;
+    return result >= 0 ? 1 : 0;
 }
 
 const char *__ry_regex_replace(const char *pattern,     int64_t patternLen,
@@ -911,97 +930,112 @@ const char *__ry_regex_replace(const char *pattern,     int64_t patternLen,
                                 const char *replacement, int64_t replacementLen) {
     if (!pattern || !text || !replacement)
         return text ? dupString(text, static_cast<size_t>(textLen)) : dupString("", 0);
-    auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
-    auto matches = cr.findAll(text, static_cast<size_t>(textLen));
-    if (matches.empty())
-        return dupString(text, static_cast<size_t>(textLen));
+    try {
+        auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
+        auto matches = cr.findAll(text, static_cast<size_t>(textLen));
+        if (matches.empty())
+            return dupString(text, static_cast<size_t>(textLen));
 
-    size_t tLen = static_cast<size_t>(textLen);
-    size_t repLen = static_cast<size_t>(replacementLen);
-    bool needsCaptures = hasBackreferences(replacement, repLen);
+        size_t tLen = static_cast<size_t>(textLen);
+        size_t repLen = static_cast<size_t>(replacementLen);
+        bool needsCaptures = hasBackreferences(replacement, repLen);
 
-    std::string result;
-    result.reserve(tLen + matches.size() * repLen);
-    size_t lastEnd = 0;
+        std::string result;
+        result.reserve(tLen + matches.size() * repLen);
+        size_t lastEnd = 0;
 
-    std::unique_ptr<CaptureBacktracker> bt;
-    if (needsCaptures) {
-        bt = std::make_unique<CaptureBacktracker>(
-            cr.start, cr.matchState, cr.groupCount(), cr.caseInsensitive_);
-    }
-
-    for (auto &[start, end] : matches) {
-        result.append(text + lastEnd, static_cast<size_t>(start) - lastEnd);
+        std::unique_ptr<CaptureBacktracker> bt;
         if (needsCaptures) {
-            CaptureVec caps;
-            bt->extractCaptures(text, tLen, start, end, caps);
-            result += expandReplacement(replacement, repLen, text, caps);
-        } else {
-            result.append(replacement, repLen);
+            bt = std::make_unique<CaptureBacktracker>(
+                cr.start, cr.matchState, cr.groupCount(), cr.caseInsensitive_);
         }
-        lastEnd = static_cast<size_t>(end);
+
+        for (auto &[start, end] : matches) {
+            result.append(text + lastEnd, static_cast<size_t>(start) - lastEnd);
+            if (needsCaptures) {
+                CaptureVec caps;
+                bt->extractCaptures(text, tLen, start, end, caps);
+                result += expandReplacement(replacement, repLen, text, caps);
+            } else {
+                result.append(replacement, repLen);
+            }
+            lastEnd = static_cast<size_t>(end);
+        }
+        result.append(text + lastEnd, tLen - lastEnd);
+        return dupString(result.c_str(), result.size());
+    } catch (const std::runtime_error &e) {
+        setLastError("%s", e.what());
+        return nullptr;
     }
-    result.append(text + lastEnd, tLen - lastEnd);
-    return dupString(result.c_str(), result.size());
 }
 
 void *__ry_regex_split(const char *pattern, int64_t patternLen,
                         const char *text,    int64_t textLen) {
     if (!pattern || !text) return makeStringList({});
-    auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
-    auto matches = cr.findAll(text, static_cast<size_t>(textLen));
+    try {
+        auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
+        auto matches = cr.findAll(text, static_cast<size_t>(textLen));
 
-    size_t tLen = static_cast<size_t>(textLen);
-    std::vector<std::string> parts;
-    size_t lastEnd = 0;
-    for (auto &[start, end] : matches) {
-        parts.emplace_back(text + lastEnd, static_cast<size_t>(start) - lastEnd);
-        lastEnd = static_cast<size_t>(end);
+        size_t tLen = static_cast<size_t>(textLen);
+        std::vector<std::string> parts;
+        size_t lastEnd = 0;
+        for (auto &[start, end] : matches) {
+            parts.emplace_back(text + lastEnd, static_cast<size_t>(start) - lastEnd);
+            lastEnd = static_cast<size_t>(end);
+        }
+        parts.emplace_back(text + lastEnd, tLen - lastEnd);
+        return makeStringList(parts);
+    } catch (const std::runtime_error &e) {
+        setLastError("%s", e.what());
+        return nullptr;
     }
-    parts.emplace_back(text + lastEnd, tLen - lastEnd);
-    return makeStringList(parts);
 }
 
 void *__ry_regex_find_all(const char *pattern, int64_t patternLen,
                            const char *text,    int64_t textLen) {
     if (!pattern || !text) return makeMatchList({});
-    auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
-    auto matches = cr.findAll(text, static_cast<size_t>(textLen));
+    try {
+        auto cr = CompiledRegex::compile(pattern, static_cast<size_t>(patternLen));
+        auto matches = cr.findAll(text, static_cast<size_t>(textLen));
 
-    size_t tLen = static_cast<size_t>(textLen);
-    int numGroups = cr.groupCount();
+        size_t tLen = static_cast<size_t>(textLen);
+        int numGroups = cr.groupCount();
 
-    std::unique_ptr<CaptureBacktracker> bt;
-    if (numGroups > 0) {
-        bt = std::make_unique<CaptureBacktracker>(
-            cr.start, cr.matchState, numGroups, cr.caseInsensitive_);
-    }
-
-    std::vector<MatchData> items;
-    items.reserve(matches.size());
-    CaptureVec caps;
-    for (auto &[start, end] : matches) {
-        MatchData md;
-        md.full = dupString(text + start, static_cast<size_t>(end - start));
+        std::unique_ptr<CaptureBacktracker> bt;
         if (numGroups > 0) {
-            bt->extractCaptures(text, tLen, start, end, caps);
-            std::vector<std::string> groupStrs;
-            groupStrs.reserve(static_cast<size_t>(numGroups));
-            for (int g = 1; g <= numGroups; ++g) {
-                auto [gs, ge] = caps[static_cast<size_t>(g)];
-                if (gs >= 0 && ge >= gs)
-                    groupStrs.emplace_back(text + gs,
-                                           static_cast<size_t>(ge - gs));
-                else
-                    groupStrs.emplace_back();
-            }
-            md.groups = makeStringList(groupStrs);
-        } else {
-            md.groups = makeStringList({});
+            bt = std::make_unique<CaptureBacktracker>(
+                cr.start, cr.matchState, numGroups, cr.caseInsensitive_);
         }
-        items.push_back(md);
+
+        std::vector<MatchData> items;
+        items.reserve(matches.size());
+        CaptureVec caps;
+        for (auto &[start, end] : matches) {
+            MatchData md;
+            md.full = dupString(text + start, static_cast<size_t>(end - start));
+            if (numGroups > 0) {
+                bt->extractCaptures(text, tLen, start, end, caps);
+                std::vector<std::string> groupStrs;
+                groupStrs.reserve(static_cast<size_t>(numGroups));
+                for (int g = 1; g <= numGroups; ++g) {
+                    auto [gs, ge] = caps[static_cast<size_t>(g)];
+                    if (gs >= 0 && ge >= gs)
+                        groupStrs.emplace_back(text + gs,
+                                               static_cast<size_t>(ge - gs));
+                    else
+                        groupStrs.emplace_back();
+                }
+                md.groups = makeStringList(groupStrs);
+            } else {
+                md.groups = makeStringList({});
+            }
+            items.push_back(md);
+        }
+        return makeMatchList(items);
+    } catch (const std::runtime_error &e) {
+        setLastError("%s", e.what());
+        return nullptr;
     }
-    return makeMatchList(items);
 }
 
 } // extern "C"

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -1,4 +1,5 @@
 #include "ry/runtime_regex.hpp"
+#include "ry/runtime_regex_error_sentinels.hpp"
 #include "ry/runtime_error.hpp"
 #include "ry/runtime_regex_internal.hpp"
 #include "ry/runtime_list.hpp"
@@ -20,9 +21,6 @@ namespace ry {
 DEFINE_LAST_ERROR(regex)
 
 namespace {
-
-constexpr int64_t kRegexMatchError = -1;
-constexpr int64_t kRegexSearchError = std::numeric_limits<int64_t>::min();
 
 // ============================================================
 // NFA

--- a/src/runtime_regex_parser.cpp
+++ b/src/runtime_regex_parser.cpp
@@ -13,9 +13,8 @@ RegexParser::RegexParser(const char *pattern, size_t len)
 RegexNodePtr RegexParser::parse() {
     auto node = parseAlternation();
     if (pos_ < len_) {
-        fprintf(stderr, "regex error: unexpected character '%c' at position %zu in pattern '%.*s'\n",
-                src_[pos_], pos_, (int)len_, src_);
-        exit(1);
+        fail("regex error: unexpected character '%c' at position %zu in pattern '%.*s'",
+             src_[pos_], pos_, (int)len_, src_);
     }
     return node;
 }
@@ -31,6 +30,15 @@ char RegexParser::advance() {
 
 bool RegexParser::atEnd() const {
     return pos_ >= len_;
+}
+
+[[noreturn]] void RegexParser::fail(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    char buf[512];
+    vsnprintf(buf, sizeof(buf), fmt, args);
+    va_end(args);
+    throw std::runtime_error(buf);
 }
 
 RegexNodePtr RegexParser::parseAlternation() {
@@ -118,8 +126,8 @@ bool RegexParser::parseQuantifierBrace(int &rmin, int &rmax) {
     if (atEnd() || !std::isdigit(static_cast<unsigned char>(peek()))) return false;
     int n = parseNumber();
     if (n > 1000) {
-        fprintf(stderr, "regex error: quantifier value %d exceeds maximum (1000) in pattern '%.*s'\n", n, (int)len_, src_);
-        exit(1);
+        fail("regex error: quantifier value %d exceeds maximum (1000) in pattern '%.*s'",
+             n, (int)len_, src_);
     }
     if (atEnd()) return false;
     if (peek() == '}') {
@@ -138,14 +146,14 @@ bool RegexParser::parseQuantifierBrace(int &rmin, int &rmax) {
         if (!std::isdigit(static_cast<unsigned char>(peek()))) return false;
         int m = parseNumber();
         if (m > 1000) {
-            fprintf(stderr, "regex error: quantifier value %d exceeds maximum (1000) in pattern '%.*s'\n", m, (int)len_, src_);
-            exit(1);
+            fail("regex error: quantifier value %d exceeds maximum (1000) in pattern '%.*s'",
+                 m, (int)len_, src_);
         }
         if (atEnd() || peek() != '}') return false;
         advance();
         if (n > m) {
-            fprintf(stderr, "regex error: invalid quantifier {%d,%d} in pattern '%.*s'\n", n, m, (int)len_, src_);
-            exit(1);
+            fail("regex error: invalid quantifier {%d,%d} in pattern '%.*s'",
+                 n, m, (int)len_, src_);
         }
         rmin = n; rmax = m;
         return true;
@@ -166,9 +174,8 @@ RegexNodePtr RegexParser::parseAtom() {
     char c = peek();
     if (c == '(') {
         if (++groupDepth_ > MAX_GROUP_DEPTH) {
-            fprintf(stderr, "regex error: group nesting too deep (limit: %d) in pattern '%.*s'\n",
-                    MAX_GROUP_DEPTH, (int)len_, src_);
-            exit(1);
+            fail("regex error: group nesting too deep (limit: %d) in pattern '%.*s'",
+                 MAX_GROUP_DEPTH, (int)len_, src_);
         }
         advance(); // consume '('
         // Check for inline flags (?i)
@@ -176,8 +183,8 @@ RegexNodePtr RegexParser::parseAtom() {
             advance(); // consume '?'
             advance(); // consume 'i'
             if (peek() != ')') {
-                fprintf(stderr, "regex error: expected ')' after '(?i' in pattern '%.*s'\n", (int)len_, src_);
-                exit(1);
+                fail("regex error: expected ')' after '(?i' in pattern '%.*s'",
+                     (int)len_, src_);
             }
             advance(); // consume ')'
             --groupDepth_;
@@ -187,8 +194,7 @@ RegexNodePtr RegexParser::parseAtom() {
         }
         auto inner = parseAlternation();
         if (peek() != ')') {
-            fprintf(stderr, "regex error: unmatched '(' in pattern '%.*s'\n", (int)len_, src_);
-            exit(1);
+            fail("regex error: unmatched '(' in pattern '%.*s'", (int)len_, src_);
         }
         advance(); // consume ')'
         --groupDepth_;
@@ -217,8 +223,7 @@ RegexNodePtr RegexParser::parseAtom() {
     if (c == '\\') {
         advance(); // consume backslash
         if (atEnd()) {
-            fprintf(stderr, "regex error: trailing backslash in pattern '%.*s'\n", (int)len_, src_);
-            exit(1);
+            fail("regex error: trailing backslash in pattern '%.*s'", (int)len_, src_);
         }
         char escaped = advance();
         // Handle word boundary
@@ -240,12 +245,12 @@ RegexNodePtr RegexParser::parseAtom() {
         return node;
     }
     if (c == '*' || c == '+' || c == '?') {
-        fprintf(stderr, "regex error: nothing to repeat at position %zu in pattern '%.*s'\n", pos_, (int)len_, src_);
-        exit(1);
+        fail("regex error: nothing to repeat at position %zu in pattern '%.*s'",
+             pos_, (int)len_, src_);
     }
     if (atEnd() || c == '|' || c == ')') {
-        fprintf(stderr, "regex error: unexpected end or character in pattern '%.*s'\n", (int)len_, src_);
-        exit(1);
+        fail("regex error: unexpected end or character in pattern '%.*s'",
+             (int)len_, src_);
     }
     // Regular literal
     advance();
@@ -290,8 +295,7 @@ RegexNodePtr RegexParser::parseCharClass() {
         }
     }
     if (peek() != ']') {
-        fprintf(stderr, "regex error: unmatched '[' in pattern '%.*s'\n", (int)len_, src_);
-        exit(1);
+        fail("regex error: unmatched '[' in pattern '%.*s'", (int)len_, src_);
     }
     advance(); // consume ']'
     return node;
@@ -301,8 +305,8 @@ char RegexParser::parseClassChar() {
     if (peek() == '\\') {
         advance();
         if (atEnd()) {
-            fprintf(stderr, "regex error: trailing backslash in character class in pattern '%.*s'\n", (int)len_, src_);
-            exit(1);
+            fail("regex error: trailing backslash in character class in pattern '%.*s'",
+                 (int)len_, src_);
         }
         char c = advance();
         switch (c) {

--- a/tests/test_codegen_regex.cpp
+++ b/tests/test_codegen_regex.cpp
@@ -109,6 +109,23 @@ print(length(matches))
 )"), "0\n");
 }
 
+TEST_F(CodeGenTest, RegexSearchInvalidPatternExitsThroughLanguageErrorPath) {
+    EXPECT_EXIT(runSource(R"(
+print("before")
+print(regex_search("abc", "["))
+)"),
+                ::testing::ExitedWithCode(1),
+                "error: regex error: unmatched '\\[' in pattern '\\['");
+}
+
+TEST_F(CodeGenTest, RegexReplaceInvalidPatternExitsThroughLanguageErrorPath) {
+    EXPECT_EXIT(runSource(R"(
+print(regex_replace("abc", "(", "x"))
+)"),
+                ::testing::ExitedWithCode(1),
+                "error: regex error: unmatched '\\(' in pattern '\\('");
+}
+
 // ============================================================
 // UFCS: text.regex_match(pattern)
 // ============================================================

--- a/tests/test_codegen_regex.cpp
+++ b/tests/test_codegen_regex.cpp
@@ -126,6 +126,15 @@ print(regex_replace("abc", "(", "x"))
                 "error: regex error: unmatched '\\(' in pattern '\\('");
 }
 
+TEST_F(CodeGenTest, RegexSplitInvalidPatternExitsThroughLanguageErrorPath) {
+    EXPECT_EXIT(runSource(R"(
+parts = regex_split("abc", "[")
+print(length(parts))
+)"),
+                ::testing::ExitedWithCode(1),
+                "error: regex error: unmatched '\\[' in pattern '\\['");
+}
+
 // ============================================================
 // UFCS: text.regex_match(pattern)
 // ============================================================

--- a/tests/test_regex_runtime.cpp
+++ b/tests/test_regex_runtime.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <string>
 
 
@@ -68,6 +69,13 @@ static ListHeader *rsp(const char *p, const char *t) {
 static ListHeader *rfa(const char *p, const char *t) {
     return (ListHeader *)__ry_regex_find_all(p, (int64_t)strlen(p),
                                              t, (int64_t)strlen(t));
+}
+
+static std::string regexLastError() {
+    const char *err = __ry_regex_get_last_error();
+    std::string msg = err ? err : "";
+    if (err) freeStringSlot(const_cast<char *>(err));
+    return msg;
 }
 
 // ============================================================
@@ -200,6 +208,16 @@ TEST(RegexRuntime, SearchNotFound) {
     EXPECT_EQ(rs("xyz", "abc"), -1);
 }
 
+TEST(RegexRuntime, InvalidPatternReturnsRecoverableErrorForMatch) {
+    EXPECT_EQ(rm("[", "abc"), -1);
+    EXPECT_EQ(regexLastError(), "regex error: unmatched '[' in pattern '['");
+}
+
+TEST(RegexRuntime, InvalidPatternReturnsRecoverableErrorForSearch) {
+    EXPECT_EQ(rs("(", "abc"), std::numeric_limits<int64_t>::min());
+    EXPECT_EQ(regexLastError(), "regex error: unmatched '(' in pattern '('");
+}
+
 // ============================================================
 // regex_replace tests
 // ============================================================
@@ -226,6 +244,11 @@ TEST(RegexRuntime, ReplaceEmpty) {
     const char *result = rr("x", "xxx", "");
     EXPECT_STREQ(result, "");
     freeStringSlot(const_cast<char *>(result));
+}
+
+TEST(RegexRuntime, InvalidPatternReturnsNullForReplace) {
+    EXPECT_EQ(rr("(", "abc", "x"), nullptr);
+    EXPECT_EQ(regexLastError(), "regex error: unmatched '(' in pattern '('");
 }
 
 // ============================================================
@@ -258,6 +281,13 @@ TEST(RegexRuntime, ReplaceCaptureSwapGroups) {
     const char *r = rr("(\\w+)@(\\w+)", "user@host", "$2@$1");
     EXPECT_STREQ(r, "host@user");
     freeStringSlot(const_cast<char *>(r));
+}
+
+TEST(RegexRuntime, InvalidPatternReturnsNullForSplitAndFindAll) {
+    EXPECT_EQ(rsp("[", "abc"), nullptr);
+    EXPECT_EQ(regexLastError(), "regex error: unmatched '[' in pattern '['");
+    EXPECT_EQ(rfa("\\", "abc"), nullptr);
+    EXPECT_EQ(regexLastError(), "regex error: trailing backslash in pattern '\\'");
 }
 
 TEST(RegexRuntime, ReplaceCaptureThreeGroups) {


### PR DESCRIPTION
## Summary
- convert invalid dynamic regex parse failures into regex runtime last-error results instead of aborting inside the parser
- route regex builtin and string-overload failures through the language runtime error path for consistent user-facing behavior
- add runtime and codegen regression coverage for invalid dynamic regex patterns

## Testing
- cmake --build build --target ry_tests
- ./build/ry_tests --gtest_filter='RegexRuntime.*:CodeGenTest.Regex*'
- ./build/ry test tests/spec/regex_literal.test.ry

Refs #1314

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a runtime API to retrieve the most recent regex error message.

* **Bug Fixes**
  * Regex operations (match, search, replace, split, find-all) now catch invalid patterns and surface clear runtime error messages instead of crashing or failing silently.
  * Match/search now use standardized failure sentinels so callers can detect errors reliably.

* **Tests**
  * Added tests covering invalid-pattern error reporting and verification of reported messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->