### PR TITLE
fix: preserve HttpClientResponse metadata after Result unwrapping

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3376,6 +3376,29 @@ without explicit type annotation, so `buildTypeNameFromMeta` can recover the typ
 at compare time.
 
 **ARC — collections inside Result/Option returned from functions** (#999, fixed):
+
+### Outer `emitResultBranch` PHIs must re-propagate Ok-path metadata from inner Result values
+
+**Source**: #1315 (2026-04-23, bugfix)
+**Tags**: codegen, metadata, result, emitResultBranch, phi, http, resource
+
+**Rule**: If a stdlib dispatcher first builds a metadata-carrying `Result<T, E>`
+on the success path (for example `wrapPtrAsResult(...)` + `addResourceKind(...)`)
+and then wraps that value in an **outer** `emitResultBranch(...)` for a guard such
+as NUL validation, the outer merged PHI does **not** automatically inherit the Ok-path
+metadata. Capture the successful inner Result in a local (e.g. `okIncoming`) and call
+`propagateMeta(okIncoming, mergedResult)` after the outer `emitResultBranch(...)`.
+
+**Why**: metadata lives in `value_metadata_` keyed by SSA value. The inner success
+Result and the outer merged PHI are distinct SSA values, so the resource/collection
+kind attached to the former is invisible to later consumers such as `Ok(resp)` case
+bindings unless you copy it explicitly.
+
+**Concrete manifestation**: `http_get` / `http_post` / `http_request` tagged the
+inner `wrapPtrAsResult(...)` value as `HttpClientResponse`, but an outer NUL-check
+`emitResultBranch(...)` returned a fresh PHI without that tag. `status(resp)` and
+`body(resp)` inside `case http_get(...): Ok(resp): ...` were then rejected as
+non-`HttpClientResponse` arguments.
 `buildOkValue` / `buildErrValue` / `buildSomeValue` now call `tryRetainArcSource(inner)`
 when `inner->getType() == ptrTy_`. This retains the collection before scope cleanup at
 function exit can release the local variable. `tryRetainArcSource` handles three cases:

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -514,6 +514,21 @@ static llvm::Value *emitHttpFormFile(CodeGen &cg, const CallExpr &e) {
     return res;
 }
 
+static llvm::Value *emitResultBranchWithMeta(
+    CodeGen &cg,
+    llvm::Value *isErr,
+    llvm::StructType *resTy,
+    llvm::function_ref<llvm::Value *(llvm::Value *&)> buildOk,
+    llvm::function_ref<llvm::Value *()> buildErr) {
+    llvm::Value *okIncoming = nullptr;
+    llvm::Value *merged = cg.emitResultBranch(isErr, resTy,
+        [&]() { return buildOk(okIncoming); },
+        [&]() { return buildErr(); });
+    if (okIncoming)
+        cg.propagateMeta(okIncoming, merged);
+    return merged;
+}
+
 static llvm::Value *emitHttpListen(CodeGen &cg, const CallExpr &e) {
     cg.used_native_libraries_.insert("net");
     cg.used_native_libraries_.insert("http");
@@ -757,9 +772,8 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
             llvm::Value *urlNul = emitHttpNulCheck(cg, url, "get_url");
             llvm::StructType *getResTy = cg.getResultType(cg.ptrTy_, cg.errorTy_);
             static int getUrlNulCtr = 0;
-            llvm::Value *okIncoming = nullptr;
-            llvm::Value *merged = cg.emitResultBranch(urlNul, getResTy,
-                [&]() {
+            return emitResultBranchWithMeta(cg, urlNul, getResTy,
+                [&](llvm::Value *&okIncoming) {
                     auto fn = cg.mod_->getOrInsertFunction("__ry_http_get", cg.fnTy_ptr_to_ptr_);
                     llvm::Value *result = cg.builder_.CreateCall(fn, {url}, "http_get_result");
                     llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_http_get_last_error");
@@ -772,9 +786,6 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
                         cg.buildStaticError("http_get: url contains embedded NUL",
                             ".http_get_url_nul_" + std::to_string(getUrlNulCtr++)), getResTy);
                 });
-            if (okIncoming)
-                cg.propagateMeta(okIncoming, merged);
-            return merged;
         }
     }
     if (e.callee == "http_post") {
@@ -792,9 +803,8 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
             llvm::Value *urlNul = emitHttpNulCheck(cg, url, "post_url");
             llvm::StructType *postResTy = cg.getResultType(cg.ptrTy_, cg.errorTy_);
             static int postUrlNulCtr = 0;
-            llvm::Value *okIncoming = nullptr;
-            llvm::Value *merged = cg.emitResultBranch(urlNul, postResTy,
-                [&]() {
+            return emitResultBranchWithMeta(cg, urlNul, postResTy,
+                [&](llvm::Value *&okIncoming) {
                     auto fn = cg.mod_->getOrInsertFunction("__ry_http_post", cg.fnTy_ptr_ptr_ptr_to_ptr_);
                     llvm::Value *result = cg.builder_.CreateCall(fn, {url, body, headers}, "http_post_result");
                     llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_http_get_last_error");
@@ -807,9 +817,6 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
                         cg.buildStaticError("http_post: url contains embedded NUL",
                             ".http_post_url_nul_" + std::to_string(postUrlNulCtr++)), postResTy);
                 });
-            if (okIncoming)
-                cg.propagateMeta(okIncoming, merged);
-            return merged;
         }
     }
     // http_request
@@ -833,9 +840,8 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
     llvm::StructType *reqResTy = cg.getResultType(cg.ptrTy_, cg.errorTy_);
     static int reqMethodNulCtr = 0;
     static int reqUrlNulCtr = 0;
-    llvm::Value *okIncoming = nullptr;
-    llvm::Value *merged = cg.emitResultBranch(methodNul, reqResTy,
-        [&]() {
+    return emitResultBranchWithMeta(cg, methodNul, reqResTy,
+        [&](llvm::Value *&okIncoming) {
             llvm::Value *urlNul = emitHttpNulCheck(cg, url, "req_url");
             return cg.emitResultBranch(urlNul, reqResTy,
                 [&]() {
@@ -857,9 +863,6 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
                 cg.buildStaticError("http_request: method contains embedded NUL",
                     ".http_req_method_nul_" + std::to_string(reqMethodNulCtr++)), reqResTy);
         });
-    if (okIncoming)
-        cg.propagateMeta(okIncoming, merged);
-    return merged;
 }
 
 static llvm::Value *emitHttpStatus(CodeGen &cg, const CallExpr &e) {

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -757,12 +757,14 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
             llvm::Value *urlNul = emitHttpNulCheck(cg, url, "get_url");
             llvm::StructType *getResTy = cg.getResultType(cg.ptrTy_, cg.errorTy_);
             static int getUrlNulCtr = 0;
-            return cg.emitResultBranch(urlNul, getResTy,
+            llvm::Value *okIncoming = nullptr;
+            llvm::Value *merged = cg.emitResultBranch(urlNul, getResTy,
                 [&]() {
                     auto fn = cg.mod_->getOrInsertFunction("__ry_http_get", cg.fnTy_ptr_to_ptr_);
                     llvm::Value *result = cg.builder_.CreateCall(fn, {url}, "http_get_result");
                     llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_http_get_last_error");
                     cg.addResourceKind(res, rk_http_client_response);
+                    okIncoming = res;
                     return res;
                 },
                 [&]() {
@@ -770,6 +772,9 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
                         cg.buildStaticError("http_get: url contains embedded NUL",
                             ".http_get_url_nul_" + std::to_string(getUrlNulCtr++)), getResTy);
                 });
+            if (okIncoming)
+                cg.propagateMeta(okIncoming, merged);
+            return merged;
         }
     }
     if (e.callee == "http_post") {
@@ -787,12 +792,14 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
             llvm::Value *urlNul = emitHttpNulCheck(cg, url, "post_url");
             llvm::StructType *postResTy = cg.getResultType(cg.ptrTy_, cg.errorTy_);
             static int postUrlNulCtr = 0;
-            return cg.emitResultBranch(urlNul, postResTy,
+            llvm::Value *okIncoming = nullptr;
+            llvm::Value *merged = cg.emitResultBranch(urlNul, postResTy,
                 [&]() {
                     auto fn = cg.mod_->getOrInsertFunction("__ry_http_post", cg.fnTy_ptr_ptr_ptr_to_ptr_);
                     llvm::Value *result = cg.builder_.CreateCall(fn, {url, body, headers}, "http_post_result");
                     llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_http_get_last_error");
                     cg.addResourceKind(res, rk_http_client_response);
+                    okIncoming = res;
                     return res;
                 },
                 [&]() {
@@ -800,6 +807,9 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
                         cg.buildStaticError("http_post: url contains embedded NUL",
                             ".http_post_url_nul_" + std::to_string(postUrlNulCtr++)), postResTy);
                 });
+            if (okIncoming)
+                cg.propagateMeta(okIncoming, merged);
+            return merged;
         }
     }
     // http_request
@@ -823,7 +833,8 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
     llvm::StructType *reqResTy = cg.getResultType(cg.ptrTy_, cg.errorTy_);
     static int reqMethodNulCtr = 0;
     static int reqUrlNulCtr = 0;
-    return cg.emitResultBranch(methodNul, reqResTy,
+    llvm::Value *okIncoming = nullptr;
+    llvm::Value *merged = cg.emitResultBranch(methodNul, reqResTy,
         [&]() {
             llvm::Value *urlNul = emitHttpNulCheck(cg, url, "req_url");
             return cg.emitResultBranch(urlNul, reqResTy,
@@ -832,6 +843,7 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
                     llvm::Value *result = cg.builder_.CreateCall(fn, {method, url, headers, body}, "http_request_result");
                     llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_http_get_last_error");
                     cg.addResourceKind(res, rk_http_client_response);
+                    okIncoming = res;
                     return res;
                 },
                 [&]() {
@@ -845,6 +857,9 @@ static llvm::Value *emitHttpClientCall(CodeGen &cg, const CallExpr &e) {
                 cg.buildStaticError("http_request: method contains embedded NUL",
                     ".http_req_method_nul_" + std::to_string(reqMethodNulCtr++)), reqResTy);
         });
+    if (okIncoming)
+        cg.propagateMeta(okIncoming, merged);
+    return merged;
 }
 
 static llvm::Value *emitHttpStatus(CodeGen &cg, const CallExpr &e) {

--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -1,4 +1,11 @@
 #include "test_codegen_common.hpp"
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
 
 
 using namespace ry;
@@ -20,6 +27,113 @@ function bytes_to_str(bs: List<u8>) -> Result<str, Error>
 @native
 function sleep(ms: int) -> Unit
 )";
+
+static const std::string HTTP_CLIENT_DECLS = R"(
+@native("http")
+function http_get(url: str) -> Result<HttpClientResponse, Error>
+@native("http")
+function http_request(method: str, url: str, headers: Map<str, str>, body: str) -> Result<HttpClientResponse, Error>
+@native("http")
+function status(response: HttpClientResponse) -> int
+@native("http")
+function body(response: HttpClientResponse) -> str
+@native("http")
+function http_client_response_free(response: HttpClientResponse) -> Unit
+)";
+
+class AllowPrivateHTTPGuard {
+public:
+    AllowPrivateHTTPGuard() {
+        const char *prev = std::getenv("RY_ALLOW_PRIVATE_HTTP");
+        had_prev_ = (prev != nullptr);
+        if (had_prev_) prev_value_ = prev;
+        ::setenv("RY_ALLOW_PRIVATE_HTTP", "1", 1);
+    }
+
+    ~AllowPrivateHTTPGuard() {
+        if (had_prev_)
+            ::setenv("RY_ALLOW_PRIVATE_HTTP", prev_value_.c_str(), 1);
+        else
+            ::unsetenv("RY_ALLOW_PRIVATE_HTTP");
+    }
+
+private:
+    bool had_prev_ = false;
+    std::string prev_value_;
+};
+
+static void mock_http_server(int fd, const std::string &response) {
+    char buf[4096];
+    (void)::recv(fd, buf, sizeof(buf), 0);
+    size_t sent = 0;
+    while (sent < response.size()) {
+        ssize_t w = ::write(fd, response.c_str() + sent, response.size() - sent);
+        if (w <= 0) break;
+        sent += static_cast<size_t>(w);
+    }
+    ::close(fd);
+}
+
+static std::string mock_http_server_capture(int fd, const std::string &response) {
+    char buf[8192];
+    std::string request;
+    struct timeval tv = {2, 0};
+    ::setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    while (true) {
+        ssize_t n = ::recv(fd, buf, sizeof(buf), 0);
+        if (n <= 0) break;
+        request.append(buf, static_cast<size_t>(n));
+        if (request.find("\r\n\r\n") != std::string::npos) break;
+    }
+    size_t sent = 0;
+    while (sent < response.size()) {
+        ssize_t w = ::write(fd, response.c_str() + sent, response.size() - sent);
+        if (w <= 0) break;
+        sent += static_cast<size_t>(w);
+    }
+    ::close(fd);
+    return request;
+}
+
+static int start_mock_server() {
+    int srv = ::socket(AF_INET, SOCK_STREAM, 0);
+    if (srv < 0) return -1;
+    int opt = 1;
+    ::setsockopt(srv, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+    struct sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    addr.sin_port = 0;
+    if (::bind(srv, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) != 0) {
+        ::close(srv);
+        return -1;
+    }
+    if (::listen(srv, 1) != 0) {
+        ::close(srv);
+        return -1;
+    }
+    return srv;
+}
+
+static int get_server_port(int srv) {
+    struct sockaddr_in addr{};
+    socklen_t len = sizeof(addr);
+    ::getsockname(srv, reinterpret_cast<struct sockaddr *>(&addr), &len);
+    return ntohs(addr.sin_port);
+}
+
+struct JoinGuard {
+    std::thread &t;
+    explicit JoinGuard(std::thread &thread) : t(thread) {}
+    ~JoinGuard() {
+        if (t.joinable()) t.join();
+    }
+};
+
+class CodeGenHttpClientTest : public CodeGenTest {
+protected:
+    AllowPrivateHTTPGuard allow_private_;
+};
 
 // ============================================================
 // Manual server: tests HTTP response parsing via raw TCP.
@@ -256,6 +370,66 @@ case bind("127.0.0.1", 0):
     Err(e):
         ...
 )"), "true\n");
+}
+
+TEST_F(CodeGenHttpClientTest, HttpGetCaseBindingPreservesHttpClientResponseMetadata) {
+    std::string response =
+        "HTTP/1.1 200 OK\r\nContent-Length: 5\r\nConnection: close\r\n\r\nhello";
+    int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
+    int port = get_server_port(srv);
+
+    std::thread server_thread([&]() {
+        struct sockaddr_in client_addr{};
+        socklen_t client_len = sizeof(client_addr);
+        int conn = ::accept(srv, reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);
+        mock_http_server(conn, response);
+    });
+    JoinGuard join_guard(server_thread);
+
+    std::string src = HTTP_CLIENT_DECLS +
+        "case http_get(\"http://127.0.0.1:" + std::to_string(port) + "/case\"):\n"
+        "    Ok(resp):\n"
+        "        print(status(resp))\n"
+        "        print(body(resp))\n"
+        "        http_client_response_free(resp)\n"
+        "    Err(e):\n"
+        "        print(\"err:\" + e.message)\n";
+    EXPECT_EQ(runSource(src), "200\nhello\n");
+    ::close(srv);
+}
+
+TEST_F(CodeGenHttpClientTest, HttpRequestCaseBindingPreservesHttpClientResponseMetadata) {
+    std::string response =
+        "HTTP/1.1 201 Created\r\nContent-Length: 7\r\nConnection: close\r\n\r\ncreated";
+    int srv = start_mock_server();
+    if (srv < 0) GTEST_SKIP() << "could not create mock server (network unavailable)";
+    int port = get_server_port(srv);
+
+    std::string captured_request;
+    std::thread server_thread([&]() {
+        struct sockaddr_in client_addr{};
+        socklen_t client_len = sizeof(client_addr);
+        int conn = ::accept(srv, reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);
+        captured_request = mock_http_server_capture(conn, response);
+    });
+    JoinGuard join_guard(server_thread);
+
+    std::string src = HTTP_CLIENT_DECLS +
+        "headers: Map<str, str> = {\"X-Test\": \"1\"}\n"
+        "case http_request(\"POST\", \"http://127.0.0.1:" + std::to_string(port) + "/echo\", headers, \"payload\"):\n"
+        "    Ok(resp):\n"
+        "        print(status(resp))\n"
+        "        print(body(resp))\n"
+        "        http_client_response_free(resp)\n"
+        "    Err(e):\n"
+        "        print(\"err:\" + e.message)\n";
+    EXPECT_EQ(runSource(src), "201\ncreated\n");
+
+    ::close(srv);
+    server_thread.join();
+    EXPECT_NE(captured_request.find("POST /echo HTTP/1.1"), std::string::npos);
+    EXPECT_NE(captured_request.find("X-Test: 1"), std::string::npos);
 }
 
 // ============================================================

--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -383,6 +383,10 @@ TEST_F(CodeGenHttpClientTest, HttpGetCaseBindingPreservesHttpClientResponseMetad
         struct sockaddr_in client_addr{};
         socklen_t client_len = sizeof(client_addr);
         int conn = ::accept(srv, reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);
+        if (conn < 0) {
+            ADD_FAILURE() << "accept failed";
+            return;
+        }
         mock_http_server(conn, response);
     });
     JoinGuard join_guard(server_thread);
@@ -411,6 +415,10 @@ TEST_F(CodeGenHttpClientTest, HttpRequestCaseBindingPreservesHttpClientResponseM
         struct sockaddr_in client_addr{};
         socklen_t client_len = sizeof(client_addr);
         int conn = ::accept(srv, reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);
+        if (conn < 0) {
+            ADD_FAILURE() << "accept failed";
+            return;
+        }
         captured_request = mock_http_server_capture(conn, response);
     });
     JoinGuard join_guard(server_thread);


### PR DESCRIPTION
## Summary
- preserve HttpClientResponse resource metadata across the outer Result PHI used by http_get/http_post/http_request
- add codegen regression tests that unwrap Ok(resp) and call status/body/free for both http_get and http_request
- record the emitResultBranch metadata propagation pitfall in KNOWLEDGE.md

## Testing
- cmake --build build --target ry_tests
- ./build/ry_tests --gtest_filter='CodeGenHttpClientTest.HttpGetCaseBindingPreservesHttpClientResponseMetadata:CodeGenHttpClientTest.HttpRequestCaseBindingPreservesHttpClientResponseMetadata'
- ./build/ry test tests/spec/http_client.test.ry
- ./build/ry -c <issue reproduction>

Refs #1315

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata propagation for HTTP client results so response information is preserved when using case-style bindings.

* **Tests**
  * Added native HTTP client tests exercising GET and POST flows, validating status/body extraction and request headers.

* **Documentation**
  * Added guidance documenting the metadata-propagation issue and recommended usage to ensure correct downstream typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->