### PR TITLE
fix: consult native signatures in lambda return inference

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -5013,3 +5013,13 @@ The retain discipline is **symmetric** with the destructor:
 **Rule**: When recording `list_elem_type_name` from a `List<T>` annotation, preserve every non-primitive inner type name except `str` (which must keep using the `list_elem_is_str` side-channel from #1266). Limiting the stored name to nested collections/functions misses pointer-backed named types like `JsonValue` and stdlib resources (`Lock`, `RWLock`, etc.), so `xs[i]` cannot rebuild the loaded element's metadata via `propagateTypeMeta()`.
 
 **How to apply**: In `emitVarDecl`, after handling `str` and function-typed inners, assign `list_elem_type_name = inner` for any inner type other than `int` / `float` / `bool`. This keeps index loads, loop bindings, and other metadata-reconstruction sites able to restore resource kinds or JSON dispatch metadata from the annotation even when the loaded LLVM type is just `ptr`.
+
+---
+
+### Lambda return-type inference must consult `@native` signatures, not just user-function overloads
+
+**Source**: #1318 (2026-04-23, implementation). **Tags**: codegen, lambda, type-inference, native, stdlib, resource, JsonValue
+
+**Rule**: `inferExprType()` / `inferExprTypeName()` for `CallExpr` must check the `@native` signature registry (`native_fn_sigs_` + `native_lib_index_`) when `findFunction()` misses. Many stdlib calls such as `lock_new()` and `json.parse()` are registered only as `@native` signatures, so falling straight to the scalar fallback (`i64Ty_` / `"int"`) makes lambda return-type checking report nonsense like `expected 'int'` for `function() -> Lock` or `function() -> Result<JsonValue, Error>`.
+
+**How to apply**: Keep the lambda inference path in sync with native-call dispatch: match `@native` overloads by arity and inferred argument types, allow the same implicit widening tier as normal call resolution, and return the matched signature's declared Ry return type name. Without the name-level lookup, metadata-gated returns (`Result<JsonValue, Error>`, resource handles, function-typed returns) may still compile to the right LLVM type later but fail or lose metadata during lambda pre-checking.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1668,6 +1668,9 @@ public:
     void collectReturnTypes(const std::vector<StmtNode> &body,
         const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
         std::vector<llvm::Type*> &out);
+    std::string inferNativeCallReturnTypeName(
+        const CallExpr &expr,
+        const std::unordered_map<std::string, llvm::Type*> &paramTypeMap);
     std::string inferReturnTypeName(const std::vector<StmtNode> &body,
         const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
         const std::unordered_map<std::string, std::string> &paramTypeNameMap);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -571,6 +571,9 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
             auto *itOverloads = findFunction(v->callee);
             if (itOverloads && !itOverloads->empty())
                 return (*itOverloads)[0].func->getReturnType();
+            if (std::string nativeRet = inferNativeCallReturnTypeName(*v, paramTypeMap);
+                !nativeRet.empty())
+                return resolveType(nativeRet);
             // Check if it's a struct constructor
             auto sit = record_types_.find(v->callee);
             if (sit != record_types_.end())
@@ -865,6 +868,9 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             auto *overloads = findFunction(v->callee);
             if (overloads && !overloads->empty() && !(*overloads)[0].returnTypeName.empty())
                 return (*overloads)[0].returnTypeName;
+            if (std::string nativeRet = inferNativeCallReturnTypeName(*v, paramTypeMap);
+                !nativeRet.empty())
+                return nativeRet;
             return "";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
             // Build "function(t1, t2) -> r" from declared annotations.
@@ -951,6 +957,86 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             return reverseResolveTypeName(inferExprType(expr, paramTypeMap));
         }
     }, expr.data);
+}
+
+std::string CodeGen::inferNativeCallReturnTypeName(
+    const CallExpr &expr,
+    const std::unordered_map<std::string, llvm::Type*> &paramTypeMap) {
+    std::vector<llvm::Type*> argTypes;
+    argTypes.reserve(expr.args.size());
+    for (const auto &arg : expr.args)
+        argTypes.push_back(inferExprType(*arg, paramTypeMap));
+
+    auto isInferenceWidening = [&](llvm::Type *argTy,
+                                   llvm::Type *paramTy,
+                                   const std::string &paramTypeName) {
+        if (isLowLevelTypeName(paramTypeName))
+            return false;
+        return (argTy == i8Ty_ && paramTy == i64Ty_) ||
+               (argTy == i8Ty_ && paramTy == f64Ty_) ||
+               (argTy == i64Ty_ && paramTy == f64Ty_);
+    };
+
+    const NativeFnSignature *exactMatch = nullptr;
+    const NativeFnSignature *wideningMatch = nullptr;
+
+    auto tryMatchBucket =
+        [&](const std::vector<NativeFnSignature> &sigs,
+            const NativeFnSignature **slot,
+            bool allowWidening) {
+        for (const auto &sig : sigs) {
+            if (sig.params.size() != argTypes.size())
+                continue;
+            bool matches = true;
+            for (size_t i = 0; i < argTypes.size(); ++i) {
+                llvm::Type *expectedTy = resolveType(sig.params[i].typeName);
+                if (argTypes[i] == expectedTy)
+                    continue;
+                if (allowWidening &&
+                    isInferenceWidening(argTypes[i], expectedTy,
+                                        sig.params[i].typeName))
+                    continue;
+                matches = false;
+                break;
+            }
+            if (!matches)
+                continue;
+            if (*slot && *slot != &sig)
+                codegenError("ambiguous @native call in lambda return-type inference: '" +
+                             expr.callee + "'");
+            *slot = &sig;
+        }
+    };
+
+    if (auto it = native_fn_sigs_.find(expr.callee); it != native_fn_sigs_.end()) {
+        tryMatchBucket(it->second, &exactMatch, false);
+        if (!exactMatch)
+            tryMatchBucket(it->second, &wideningMatch, true);
+    }
+
+    if (auto libIt = native_lib_index_.find(expr.callee);
+        libIt != native_lib_index_.end()) {
+        for (const auto &lib : libIt->second) {
+            auto sigIt = native_fn_sigs_.find(nativeSigKey(lib, expr.callee));
+            if (sigIt == native_fn_sigs_.end())
+                continue;
+            tryMatchBucket(sigIt->second, &exactMatch, false);
+        }
+        if (!exactMatch) {
+            for (const auto &lib : libIt->second) {
+                auto sigIt = native_fn_sigs_.find(nativeSigKey(lib, expr.callee));
+                if (sigIt == native_fn_sigs_.end())
+                    continue;
+                tryMatchBucket(sigIt->second, &wideningMatch, true);
+            }
+        }
+    }
+
+    if (exactMatch)
+        return resolveTypeAlias(exactMatch->returnTypeName);
+    if (wideningMatch)
+        return resolveTypeAlias(wideningMatch->returnTypeName);
+    return "";
 }
 
 llvm::Type *CodeGen::inferReturnType(const std::vector<StmtNode> &body,

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -59,6 +59,17 @@ describe("json parse", ():
       None:
         fail("unexpected None")
   )
+
+  it("should accept lambda typed as function() -> Result<JsonValue, Error>", ():
+    parse_obj: function() -> Result<JsonValue, Error> = () => parse("{\"x\": 1}")
+
+    case parse_obj():
+      Ok(data):
+        expect(kind(data)).to_eq("object")
+        json_free(data)
+      Err(e):
+        fail("parse failed")
+  )
 )
 
 describe("json access", ():

--- a/tests/spec/thread.test.ry
+++ b/tests/spec/thread.test.ry
@@ -206,6 +206,15 @@ describe("resource helper returns", ():
     expect(atomic_int_load(a)).to_eq(9)
     atomic_int_free(a)
   )
+
+  it("should accept lambda typed as function() -> Lock", ():
+    mk_lock: function() -> Lock = () => lock_new()
+
+    lock = mk_lock()
+    expect(lock_acquire(lock)).to_be_ok()
+    expect(lock_release(lock)).to_be_ok()
+    lock_free(lock)
+  )
 )
 
 describe("thread_spawn return values (MVP, #828)", ():


### PR DESCRIPTION
## Summary
- consult `@native` signature metadata during lambda return-type inference
- fix typed lambdas returning stdlib resource and JsonValue-backed Result types
- add Ry regression coverage for `function() -> Lock` and `function() -> Result<JsonValue, Error>`
- record the inference rule in KNOWLEDGE.md

## Testing
- cmake --build build
- ./build/ry test tests/spec/thread.test.ry
- ./build/ry test tests/spec/json.test.ry
- ./build/ry test tests/spec/lambda_collection_return.test.ry
- ./build/ry test tests/spec/functions.test.ry
- ./build/ry_tests

Refs #1318

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed lambda return-type inference when calling native standard library functions (e.g., `json.parse()`, `lock_new()`), eliminating incorrect type-checking diagnostics and restoring proper type metadata during verification.

* **Tests**
  * Added test coverage for lambda functions explicitly typed to return complex standard library types like `Result<JsonValue, Error>` and `Lock`.

* **Documentation**
  * Updated documentation clarifying lambda expression return-type inference behavior with native function calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->