### PR TITLE
fix: preserve JsonValue metadata across higher-order boundaries

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -5023,3 +5023,13 @@ The retain discipline is **symmetric** with the destructor:
 **Rule**: `inferExprType()` / `inferExprTypeName()` for `CallExpr` must check the `@native` signature registry (`native_fn_sigs_` + `native_lib_index_`) when `findFunction()` misses. Many stdlib calls such as `lock_new()` and `json.parse()` are registered only as `@native` signatures, so falling straight to the scalar fallback (`i64Ty_` / `"int"`) makes lambda return-type checking report nonsense like `expected 'int'` for `function() -> Lock` or `function() -> Result<JsonValue, Error>`.
 
 **How to apply**: Keep the lambda inference path in sync with native-call dispatch: match `@native` overloads by arity and inferred argument types, allow the same implicit widening tier as normal call resolution, and return the matched signature's declared Ry return type name. Without the name-level lookup, metadata-gated returns (`Result<JsonValue, Error>`, resource handles, function-typed returns) may still compile to the right LLVM type later but fail or lose metadata during lambda pre-checking.
+
+---
+
+### Higher-order Result/lambda boundaries must rehydrate ptr-backed metadata from type names or wrappers
+
+**Source**: #1319 (2026-04-23, implementation). **Tags**: codegen, metadata, lambda, Result, JsonValue, resource, higher-order
+
+**Rule**: Any higher-order boundary that unwraps a `Result<T, E>` / `Option<T>` payload or calls an indirect lambda must restore metadata for pointer-backed named types. `CreateExtractValue` drops the payload's `ValueMetadata`, and indirect calls return a fresh SSA value with no metadata unless `FnTypeInfo.returnTypeName` is re-applied.
+
+**How to apply**: Mirror the `?` operator path in combinators: after extracting `ok_val` / `some_val`, call `propagateMeta(wrapper, payload)` before passing the value into the callback. In `emitLambdaCall`, always stamp the call result from `FnTypeInfo.returnTypeName` (and `returnFnTypeInfo` for function-typed returns). For lambda return-name inference on `VariableExpr`, prefer `buildTypeNameFromMeta()` over raw `reverseResolveTypeName()` so resource / `JsonValue` names survive opaque-pointer lowering.

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -302,6 +302,15 @@ std::string CodeGen::buildTypeNameFromMeta(llvm::Value *val) {
     auto *meta = getMeta(val);
     if (!meta) return "";
 
+    if (meta->json_type_only)
+        return "JsonValue";
+    if (!meta->resource_kinds.empty()) {
+        if (const auto *info = ResourceKindRegistry::instance().getInfo(meta->resource_kinds[0]))
+            return info->typeName;
+    }
+    if (!meta->enum_value_type.empty())
+        return meta->enum_value_type;
+
     // Prefer the stored source-level type name (populated via
     // propagateTypeMeta / emitVarDecl from annotations or literals).  Fall
     // back to reverseResolveTypeName on the llvm::Type when unavailable — this

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -246,6 +246,14 @@ llvm::Value *CodeGen::emitLambdaCall(llvm::Value *lambdaVal, const FnTypeInfo &i
                                       std::vector<llvm::Value*> args, const std::string &name) {
     args = coerceCallArgs(info, std::move(args), "lambda call");
 
+    auto annotateResult = [&](llvm::Value *result) -> llvm::Value * {
+        if (info.returnFnTypeInfo)
+            getOrCreateMeta(result).fn_type_info = *info.returnFnTypeInfo;
+        if (!info.returnTypeName.empty())
+            propagateTypeMeta(info.returnTypeName, result);
+        return result;
+    };
+
     if (info.isUniformClosure) {
         // Uniform closure: {thunk_ptr, env_ptr}
         auto *ucTy = getUniformClosureTy();
@@ -264,7 +272,7 @@ llvm::Value *CodeGen::emitLambdaCall(llvm::Value *lambdaVal, const FnTypeInfo &i
         auto *ft = llvm::FunctionType::get(info.returnType, callTypes, false);
         if (info.returnType->isVoidTy())
             return builder_.CreateCall(ft, thunkPtr, callArgs);
-        return builder_.CreateCall(ft, thunkPtr, callArgs, name);
+        return annotateResult(builder_.CreateCall(ft, thunkPtr, callArgs, name));
     }
 
     if (info.capturedVars.empty()) {
@@ -272,7 +280,7 @@ llvm::Value *CodeGen::emitLambdaCall(llvm::Value *lambdaVal, const FnTypeInfo &i
             info.returnType, info.paramTypes, false);
         if (info.returnType->isVoidTy())
             return builder_.CreateCall(ft, lambdaVal, args);
-        return builder_.CreateCall(ft, lambdaVal, args, name);
+        return annotateResult(builder_.CreateCall(ft, lambdaVal, args, name));
     } else {
         std::vector<llvm::Type*> closureFields;
         closureFields.push_back(ptrTy_);
@@ -299,7 +307,7 @@ llvm::Value *CodeGen::emitLambdaCall(llvm::Value *lambdaVal, const FnTypeInfo &i
             info.returnType, allParamTypes, false);
         if (info.returnType->isVoidTy())
             return builder_.CreateCall(ft, fnPtr, fullArgs);
-        return builder_.CreateCall(ft, fnPtr, fullArgs, name);
+        return annotateResult(builder_.CreateCall(ft, fnPtr, fullArgs, name));
     }
 }
 

--- a/src/codegen_call_result.cpp
+++ b/src/codegen_call_result.cpp
@@ -46,6 +46,7 @@ llvm::Value *CodeGen::emitBuiltinResult(const CallExpr &e, llvm::Value *preEmitt
     llvm::Value *mergedResult = emitResultBranch(isErr, outResTy,
         [&]() {
             llvm::Value *okVal = builder_.CreateExtractValue(resultVal, 1, "ok_val");
+            propagateMeta(resultVal, okVal);
             llvm::Value *result = emitLambdaCall(lambdaVal, info, {okVal},
                                                   isAndThen ? "and_then" : "mapped");
             okIncoming = isAndThen ? result : buildOkValue(result, outResTy);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -813,36 +813,9 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             out += ")";
             return out;
         } else if constexpr (std::is_same_v<T, VariableExpr>) {
-            // Consult the alloca's metadata to recover Ry-level shaped
-            // names (List<int>, Map<str, int>, Set<float>). Falling
-            // through to reverseResolveTypeName on the alloca's
-            // pointer type would lose this information because
-            // LLVM 15+ allocas have opaque-pointer type.
             if (llvm::AllocaInst *alloca = findVar(v.name)) {
-                if (auto *meta = getMeta(alloca)) {
-                    // Prefer string-typed metadata: it carries the
-                    // precise shape for non-primitive inner types
-                    // (e.g., `List<Map<str, int>>`). Checking the
-                    // `llvm::Type*` fields first would collapse
-                    // pointer-backed inners via reverseResolveTypeName
-                    // (`ptrTy_` → `"str"`).
-                    if (!meta->list_elem_type_name.empty())
-                        return "List<" + meta->list_elem_type_name + ">";
-                    if (!meta->map_key_type_name.empty() &&
-                        !meta->map_value_type_name.empty())
-                        return "Map<" + meta->map_key_type_name + ", " +
-                               meta->map_value_type_name + ">";
-                    if (!meta->set_elem_type_name.empty())
-                        return "Set<" + meta->set_elem_type_name + ">";
-                    if (llvm::Type *elemTy = meta->list_elem)
-                        return "List<" + reverseResolveTypeName(elemTy) + ">";
-                    if (llvm::Type *keyTy = meta->map_key)
-                        if (llvm::Type *valTy = meta->map_value)
-                            return "Map<" + reverseResolveTypeName(keyTy) +
-                                   ", " + reverseResolveTypeName(valTy) + ">";
-                    if (llvm::Type *setTy = meta->set_elem)
-                        return "Set<" + reverseResolveTypeName(setTy) + ">";
-                }
+                if (std::string metaName = buildTypeNameFromMeta(alloca); !metaName.empty())
+                    return metaName;
                 return reverseResolveTypeName(alloca->getAllocatedType());
             }
             // Lambda params aren't in scope_stack_ during return-type

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -70,6 +70,54 @@ describe("json parse", ():
       Err(e):
         fail("parse failed")
   )
+
+  it("should preserve JsonValue metadata through Result.and_then", ():
+    function parse_obj() -> Result<JsonValue, Error>:
+      return parse("{\"x\": 42}")
+
+    r = parse_obj().and_then((v: JsonValue) -> Result<JsonValue, Error>:
+      expect(kind(v)).to_eq("object")
+      return Ok(v)
+    )
+
+    case r:
+      Ok(v):
+        expect(kind(v)).to_eq("object")
+        json_free(v)
+      Err(e):
+        fail("and_then failed: " + e.message)
+  )
+
+  it("should preserve JsonValue metadata through Result.map", ():
+    function parse_obj() -> Result<JsonValue, Error>:
+      return parse("{\"x\": 42}")
+
+    r = parse_obj().map((v: JsonValue) -> JsonValue:
+      expect(kind(v)).to_eq("object")
+      return v
+    )
+
+    case r:
+      Ok(v):
+        expect(kind(v)).to_eq("object")
+        json_free(v)
+      Err(e):
+        fail("map failed: " + e.message)
+  )
+
+  it("should preserve JsonValue metadata through closure capture", ():
+    function parse_obj() -> Result<JsonValue, Error>:
+      return parse("{\"x\": 42}")
+
+    case parse_obj():
+      Ok(v):
+        f = () => v
+        x = f()
+        expect(kind(x)).to_eq("object")
+        json_free(x)
+      Err(e):
+        fail("parse failed: " + e.message)
+  )
 )
 
 describe("json access", ():


### PR DESCRIPTION
## Summary
- restore JsonValue/resource metadata when Result combinators unwrap payloads and when indirect lambda calls return ptr-backed named types
- teach lambda variable return-type inference to prefer metadata-derived type names so closure capture keeps JsonValue intact
- add Ry regression coverage for Result.and_then/map and closure capture, and record the rule in KNOWLEDGE.md

## Testing
- cmake --build build
- ./build/ry test tests/spec/json.test.ry
- ./build/ry test tests/spec/result_chain.test.ry
- ./build/ry test tests/spec/lambda_ptr_return.test.ry

Refs #1319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata preservation for JSON values through `Result.and_then`, `Result.map`, and closure operations.
  * Improved type information propagation for lambda call results.

* **Tests**
  * Added validation tests ensuring JsonValue type metadata persists through Result transformations and captures.

* **Documentation**
  * Documented correctness rules for metadata handling in higher-order operations with `Result` and `Option` types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->