### PR TITLE
feat: unify case expression arm syntax

### DIFF
--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -415,7 +415,9 @@ matching (formerly `match`) into a single construct. Two forms are supported:
 - `case:` — no subject, each arm is a condition expression (replaces `when:`)
 - `case <expr>:` — with a subject, each arm is a pattern (replaces `match`)
 
-Both forms support a block body (`:`) and an expression body (`=>`).
+Both forms support:
+- block arms (`pattern:` followed by an indented body)
+- expression arms (`pattern : value_expression` on one line)
 
 > **Note**: The `when` and `match` keywords were removed in favor of the
 > unified `case` construct. Legacy Ry code using `when` / `match` must be

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -771,15 +771,15 @@ case seg:
 
 ### Expression Forms
 
-Both `case:` and `case <expr>:` can be used as expressions by replacing `:` with `=>` in each arm. Each arm provides a single expression whose value becomes the result.
+Both `case:` and `case <expr>:` can be used as expressions by writing each arm as `pattern_or_condition: value_expression` on the same line. Each arm provides a single expression whose value becomes the result.
 
 ```ry
 # case: expression (no subject)
 label = case:
-    x > 100 => "huge"
-    x > 10  => "big"
-    x > 0   => "small"
-    _       => "non-positive"
+    x > 100 : "huge"
+    x > 10  : "big"
+    x > 0   : "small"
+    _       : "non-positive"
 ```
 
 Pattern-matching expression form:
@@ -788,9 +788,9 @@ Pattern-matching expression form:
 
 ```ry
 result = case expression:
-    pattern => value_expression
-    pattern if guard => value_expression
-    _ => default_value
+    pattern : value_expression
+    pattern if guard : value_expression
+    _ : default_value
 ```
 
 All patterns supported in `case:` statements are also supported in `case` expressions: literals, variable bindings, enums, ADT enums, `Some`/`None`, `Ok`/`Err`, tuple patterns, record patterns, OR patterns, guards, and wildcards.
@@ -802,38 +802,38 @@ All patterns supported in `case:` statements are also supported in `case` expres
 ```ry
 # Option
 value = case opt:
-    Some(v) => v
-    None    => 0
+    Some(v) : v
+    None    : 0
 
 # Enum
 label = case direction:
-    Direction::North => "N"
-    Direction::South => "S"
-    Direction::East  => "E"
-    Direction::West  => "W"
+    Direction::North : "N"
+    Direction::South : "S"
+    Direction::East  : "E"
+    Direction::West  : "W"
 
 # Guard
 grade = case score:
-    n if n >= 90 => "A"
-    n if n >= 80 => "B"
-    _            => "F"
+    n if n >= 90 : "A"
+    n if n >= 80 : "B"
+    _            : "F"
 
 # OR pattern
 kind = case x:
-    1 | 2 | 3 => "small"
-    _          => "large"
+    1 | 2 | 3 : "small"
+    _          : "large"
 
 # ADT enum
 area = case shape:
-    Shape::Circle(r)  => 3.14 * r * r
-    Shape::Rectangle(w, h) => w * h
-    Shape::Point      => 0.0
+    Shape::Circle(r)  : 3.14 * r * r
+    Shape::Rectangle(w, h) : w * h
+    Shape::Point      : 0.0
 
 # Tuple pattern
 t = (3, 4)
 sum = case t:
-    (a, b) => a + b
-    _ => 0
+    (a, b) : a + b
+    _ : 0
 ```
 
 ### Scope Rules

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -185,26 +185,26 @@ At the top level, a `Result`'s `Err` type must be `Error` (so its `message` fiel
 
 ```ry
 x = case:
-    condition => true_value
-    _ => false_value
+    condition : true_value
+    _ : false_value
 ```
 
-Evaluates conditions from top to bottom and returns the expression from the first truthy arm. All result expressions must have the same type. The `_ =>` wildcard arm is required, so the expression always produces a value.
+Evaluates conditions from top to bottom and returns the expression from the first truthy arm. All result expressions must have the same type. The `_ :` wildcard arm is required, so the expression always produces a value.
 
 ```ry
 x = case:
-    3 > 2 => 10
-    _ => 20     # 10
+    3 > 2 : 10
+    _ : 20     # 10
 
 s = case:
-    false => "yes"
-    _ => "no"  # "no"
+    false : "yes"
+    _ : "no"  # "no"
 
 # Nested ternaries flatten into multiple arms
 y = case:
-    true => 2
-    false => 1
-    _ => 3     # 2
+    true : 2
+    false : 1
+    _ : 3     # 2
 ```
 
 ---

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -384,7 +384,7 @@ struct CaseCondExprArm {
 };
 
 // `case:` expression (no subject) — multi-branch conditional expression.
-// The wildcard `_ => value` arm (required) is stored in `else_expr`.
+// The wildcard `_ : value` arm (required) is stored in `else_expr`.
 struct CaseCondExpr {
     std::vector<CaseCondExprArm> arms;
     ExprPtr else_expr;

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -321,9 +321,9 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
             std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
             std::string out = "case:\n";
             for (const auto &arm : v->arms) {
-                out += indent + formatExpr(*arm.condition) + " => " + formatExpr(*arm.value) + "\n";
+                out += indent + formatExpr(*arm.condition) + " : " + formatExpr(*arm.value) + "\n";
             }
-            out += indent + "_ => " + formatExpr(*v->else_expr);
+            out += indent + "_ : " + formatExpr(*v->else_expr);
             return out;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseExpr>>) {
             std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
@@ -333,7 +333,7 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                 out += indent + formatPattern(arm.pattern);
                 if (arm.guard)
                     out += " if " + formatExpr(*arm.guard);
-                out += " => " + formatExpr(*arm.value);
+                out += " : " + formatExpr(*arm.value);
                 if (i + 1 < v->arms.size())
                     out += "\n";
             }

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -43,26 +43,26 @@ ExprPtr Parser::parseCaseExprNoSubject(const Token &caseTok) {
         Token first = lex_.peek();
         bool isWildcard = (first.kind == TokenKind::Ident && first.value == "_");
         if (isWildcard) {
-            // Need to differentiate `_ => value` (wildcard arm) from `_ used as
+            // Need to differentiate `_ : value` (wildcard arm) from `_` used as
             // a sub-expression of a condition`, but in this context the `_`
             // must always be a wildcard default — no other interpretation is
             // legal at arm position.
             const auto &saved = first;
             lex_.next(); // consume '_'
-            if (lex_.peek().kind != TokenKind::FatArrow)
-                parseError(saved.line, "expected '=>' after '_' in case expression wildcard arm");
+            if (lex_.peek().kind != TokenKind::Colon)
+                parseError(saved.line, "expected ':' after '_' in case expression wildcard arm");
             if (seenWildcard)
                 parseError(saved.line, "duplicate '_' arm in case expression");
-            lex_.next(); // consume '=>'
+            lex_.next(); // consume ':'
             caseExpr->else_expr = parseConditional();
             seenWildcard = true;
         } else {
             if (seenWildcard)
-                parseError("condition arms must appear before '_ =>'");
+                parseError("condition arms must appear before '_:'");
             CaseCondExprArm arm;
             arm.condition = parseConditional();
-            if (lex_.peek().kind != TokenKind::FatArrow)
-                parseError("expected '=>' after case condition");
+            if (lex_.peek().kind != TokenKind::Colon)
+                parseError("expected ':' after case condition");
             lex_.next();
             arm.value = parseConditional();
             caseExpr->arms.push_back(std::move(arm));
@@ -78,7 +78,7 @@ ExprPtr Parser::parseCaseExprNoSubject(const Token &caseTok) {
     if (caseExpr->arms.empty())
         parseError("case expression must have at least one condition arm");
     if (!caseExpr->else_expr)
-        parseError("case expression requires a '_ => ...' wildcard arm");
+        parseError("case expression requires a '_: ...' wildcard arm");
 
     auto node = std::make_unique<ExprNode>();
     node->data = std::move(caseExpr);
@@ -116,9 +116,9 @@ ExprPtr Parser::parseCaseExprWithSubject(const Token &caseTok) {
             arm.guard = parseConditional();
         }
 
-        if (lex_.peek().kind != TokenKind::FatArrow)
-            parseError("expected '=>' after case pattern in case expression");
-        lex_.next(); // consume '=>'
+        if (lex_.peek().kind != TokenKind::Colon)
+            parseError("expected ':' after case pattern in case expression");
+        lex_.next(); // consume ':'
 
         arm.value = parseConditional();
         caseExpr->arms.push_back(std::move(arm));

--- a/tests/spec/case_unification.test.ry
+++ b/tests/spec/case_unification.test.ry
@@ -21,43 +21,43 @@ describe("case with subject", ():
   it("should select literal arm in expression form", ():
     x = 2
     res = case x:
-      1 => "one"
-      2 => "two"
-      _ => "other"
+      1 : "one"
+      2 : "two"
+      _ : "other"
     expect(res).to_eq("two")
   )
 
   it("should respect guard clauses", ():
     x = -5
     got = case x:
-      n if n > 0 => "positive"
-      n if n < 0 => "negative"
-      _ => "zero"
+      n if n > 0 : "positive"
+      n if n < 0 : "negative"
+      _ : "zero"
     expect(got).to_eq("negative")
   )
 
   it("should handle OR patterns", ():
     x = 2
     res = case x:
-      1 | 2 | 3 => "small"
-      _ => "other"
+      1 | 2 | 3 : "small"
+      _ : "other"
     expect(res).to_eq("small")
   )
 
   it("should handle negative literal patterns", ():
     x = -1
     res = case x:
-      -1 => "minus one"
-      0 => "zero"
-      _ => "other"
+      -1 : "minus one"
+      0 : "zero"
+      _ : "other"
     expect(res).to_eq("minus one")
   )
 
   it("should destructure Option::Some", ():
     x: Option<int> = Some(42)
     res = case x:
-      Some(v) => v
-      None => -1
+      Some(v) : v
+      None : -1
     expect(res).to_eq(42)
   )
 
@@ -103,19 +103,19 @@ describe("case without subject", ():
   it("should evaluate condition arms in expression form", ():
     x = 7
     label = case:
-      x > 100 => "huge"
-      x > 10  => "big"
-      x > 0   => "small"
-      _       => "non-positive"
+      x > 100 : "huge"
+      x > 10  : "big"
+      x > 0   : "small"
+      _       : "non-positive"
     expect(label).to_eq("small")
   )
 
   it("should work in parenthesized position", ():
     n = 5
     result = (case:
-      n > 10 => n * 2
-      n > 3  => n + 10
-      _      => n
+      n > 10 : n * 2
+      n > 3  : n + 10
+      _      : n
     )
     expect(result).to_eq(15)
   )

--- a/tests/spec/closure_capture_expr_types.test.ry
+++ b/tests/spec/closure_capture_expr_types.test.ry
@@ -28,8 +28,8 @@ describe("closure capture — WhenCondExpr", ():
     function make_classifier(threshold: int) -> function(int) -> str:
       function classify(x: int) -> str:
         return case:
-          x > threshold => "big"
-          _ => "small"
+          x > threshold : "big"
+          _ : "small"
       return classify
 
     f = make_classifier(10)
@@ -41,8 +41,8 @@ describe("closure capture — WhenCondExpr", ():
     function make_labeler(label: str) -> function(bool) -> str:
       function labelize(flag: bool) -> str:
         return case:
-          flag => label
-          _ => "none"
+          flag : label
+          _ : "none"
       return labelize
 
     f = make_labeler("yes")
@@ -54,8 +54,8 @@ describe("closure capture — WhenCondExpr", ():
     function make_fallback(default_val: str) -> function(bool) -> str:
       function pick(flag: bool) -> str:
         return case:
-          flag => "active"
-          _ => default_val
+          flag : "active"
+          _ : default_val
       return pick
 
     f = make_fallback("inactive")
@@ -68,8 +68,8 @@ describe("closure capture — MatchExpr", ():
     function make_matcher(fallback: str) -> function(int) -> str:
       function do_match(x: int) -> str:
         return case x:
-          1 => "one"
-          _ => fallback
+          1 : "one"
+          _ : fallback
       return do_match
 
     f = make_matcher("other")
@@ -81,8 +81,8 @@ describe("closure capture — MatchExpr", ():
     function make_guard_matcher(limit: int) -> function(int) -> str:
       function do_match(x: int) -> str:
         return case x:
-          n if n > limit => "above"
-          _ => "below"
+          n if n > limit : "above"
+          _ : "below"
       return do_match
 
     f = make_guard_matcher(50)
@@ -94,9 +94,9 @@ describe("closure capture — MatchExpr", ():
     function make_subject_matcher(val: int) -> function() -> str:
       function do_match() -> str:
         return case val:
-          1 => "one"
-          2 => "two"
-          _ => "other"
+          1 : "one"
+          2 : "two"
+          _ : "other"
       return do_match
 
     f = make_subject_matcher(2)

--- a/tests/spec/closure_match_pattern_capture.test.ry
+++ b/tests/spec/closure_match_pattern_capture.test.ry
@@ -4,8 +4,8 @@ describe("match pattern capture", ():
     function make_matcher(limit: int) -> function(int) -> str:
       function do_match(x: int) -> str:
         return case x:
-          n if n > limit => "above"
-          _ => "below"
+          n if n > limit : "above"
+          _ : "below"
       return do_match
 
     f = make_matcher(5)
@@ -36,8 +36,8 @@ describe("match pattern capture", ():
     function make_matcher(limit: int) -> function(int) -> str:
       function do_match(x: int) -> str:
         return case x:
-          n if n > limit => f"above{suffix}"
-          _ => f"below{suffix}"
+          n if n > limit : f"above{suffix}"
+          _ : f"below{suffix}"
       return do_match
 
     f = make_matcher(5)
@@ -50,8 +50,8 @@ describe("match pattern capture", ():
     function make_matcher(limit: int) -> function(int) -> str:
       function do_match(x: int) -> str:
         return case x:
-          n if n > limit => "above"
-          _ => "below"
+          n if n > limit : "above"
+          _ : "below"
       return do_match
 
     f = make_matcher(5)

--- a/tests/spec/combinatorial/fn_argument.test.ry
+++ b/tests/spec/combinatorial/fn_argument.test.ry
@@ -16,8 +16,8 @@ function take_tuple(t: (int, str)) -> int:
 
 function take_result_ok(r: Result<int, Error>) -> bool:
   return case r:
-    Ok(_) => true
-    Err(_) => false
+    Ok(_) : true
+    Err(_) : false
 
 function make_ok_result(v: int) -> Result<int, Error>:
   return Ok(v)

--- a/tests/spec/combinatorial/match_types.test.ry
+++ b/tests/spec/combinatorial/match_types.test.ry
@@ -6,23 +6,23 @@ describe("match — float", ():
   it("should match float literal", ():
     x = 3.14
     res = case x:
-      3.14 => "pi"
-      _ => "other"
+      3.14 : "pi"
+      _ : "other"
     expect(res).to_eq("pi")
   )
   it("should match float with guard", ():
     x = 2.71
     res = case x:
-      v if v > 3.0 => "big"
-      v if v > 2.0 => "medium"
-      _ => "small"
+      v if v > 3.0 : "big"
+      v if v > 2.0 : "medium"
+      _ : "small"
     expect(res).to_eq("medium")
   )
   it("should fall through to wildcard for unmatched float", ():
     x = 0.5
     res = case x:
-      3.14 => "pi"
-      _ => "other"
+      3.14 : "pi"
+      _ : "other"
     expect(res).to_eq("other")
   )
 )
@@ -31,15 +31,15 @@ describe("match — str (additional cases)", ():
   it("should match empty string literal", ():
     s = ""
     res = case s:
-      "" => "empty"
-      _ => "non-empty"
+      "" : "empty"
+      _ : "non-empty"
     expect(res).to_eq("empty")
   )
   it("should match multiple string alternatives with OR", ():
     s = "yes"
     res = case s:
-      "yes" | "y" | "true" => "affirmative"
-      _ => "other"
+      "yes" | "y" | "true" : "affirmative"
+      _ : "other"
     expect(res).to_eq("affirmative")
   )
 )
@@ -48,22 +48,22 @@ describe("match — bool", ():
   it("should match true literal", ():
     x = true
     res = case x:
-      true => "yes"
-      false => "no"
+      true : "yes"
+      false : "no"
     expect(res).to_eq("yes")
   )
   it("should match false literal", ():
     x = false
     res = case x:
-      true => "yes"
-      false => "no"
+      true : "yes"
+      false : "no"
     expect(res).to_eq("no")
   )
   it("should use match expression on bool as return value", ():
     flag = true
     label = case flag:
-      true => "on"
-      false => "off"
+      true : "on"
+      false : "off"
     expect(label).to_eq("on")
   )
 )
@@ -72,15 +72,15 @@ describe("match — List", ():
   it("should match non-empty list using guard", ():
     xs = [1, 2, 3]
     res = case xs:
-      _ if xs.is_empty() => "empty"
-      _ => "non-empty"
+      _ if xs.is_empty() : "empty"
+      _ : "non-empty"
     expect(res).to_eq("non-empty")
   )
   it("should match empty list using guard", ():
     xs: List<int> = []
     res = case xs:
-      _ if xs.is_empty() => "empty"
-      _ => "non-empty"
+      _ if xs.is_empty() : "empty"
+      _ : "non-empty"
     expect(res).to_eq("empty")
   )
 )
@@ -89,15 +89,15 @@ describe("match — Map", ():
   it("should match map by key presence using guard", ():
     m: Map<str, int> = {"a": 1, "b": 2}
     res = case m:
-      _ if m.get("a") != none => "has a"
-      _ => "no a"
+      _ if m.get("a") != none : "has a"
+      _ : "no a"
     expect(res).to_eq("has a")
   )
   it("should match empty map using guard", ():
     m: Map<str, int> = {}
     res = case m:
-      _ if m.get("x") != none => "has x"
-      _ => "no x"
+      _ if m.get("x") != none : "has x"
+      _ : "no x"
     expect(res).to_eq("no x")
   )
 )
@@ -106,15 +106,15 @@ describe("match — Set", ():
   it("should match set by membership using guard", ():
     s = {1, 2, 3}
     res = case s:
-      _ if 1 in s => "has 1"
-      _ => "no 1"
+      _ if 1 in s : "has 1"
+      _ : "no 1"
     expect(res).to_eq("has 1")
   )
   it("should match set without target element using guard", ():
     s = {4, 5, 6}
     res = case s:
-      _ if 1 in s => "has 1"
-      _ => "no 1"
+      _ if 1 in s : "has 1"
+      _ : "no 1"
     expect(res).to_eq("no 1")
   )
 )
@@ -123,15 +123,15 @@ describe("match — tuple", ():
   it("should match tuple with guard on first element", ():
     t = (5, "hello")
     res = case t:
-      v if v.0 > 0 => "positive"
-      _ => "non-positive"
+      v if v.0 > 0 : "positive"
+      _ : "non-positive"
     expect(res).to_eq("positive")
   )
   it("should use match expression with tuple", ():
     t = (0, "zero")
     label = case t:
-      v if v.0 == 0 => "zero"
-      _ => "non-zero"
+      v if v.0 == 0 : "zero"
+      _ : "non-zero"
     expect(label).to_eq("zero")
   )
 )
@@ -140,15 +140,15 @@ describe("match — record", ():
   it("should match record with guard on field", ():
     p = MatchCoord(10, 20)
     res = case p:
-      v if v.x > 0 => "positive x"
-      _ => "non-positive x"
+      v if v.x > 0 : "positive x"
+      _ : "non-positive x"
     expect(res).to_eq("positive x")
   )
   it("should use match expression with record guard", ():
     p = MatchCoord(0, 5)
     label = case p:
-      v if v.x == 0 and v.y > 0 => "on y-axis"
-      _ => "other"
+      v if v.x == 0 and v.y > 0 : "on y-axis"
+      _ : "other"
     expect(label).to_eq("on y-axis")
   )
 )
@@ -157,7 +157,7 @@ describe("match — closure", ():
   it("should match closure with wildcard", ():
     f = (x: int) => x * 2
     res = case f:
-      _ => "got closure"
+      _ : "got closure"
     expect(res).to_eq("got closure")
   )
 )

--- a/tests/spec/combinatorial/nested_types.test.ry
+++ b/tests/spec/combinatorial/nested_types.test.ry
@@ -6,8 +6,8 @@ function divide(a: int, b: int) -> Result<int, Error>:
 function try_parse(s: str) -> Result<int, Error>:
   v = s.to_int()
   return case v:
-    Ok(n) => Ok(n)
-    Err(e) => Err(e)
+    Ok(n) : Ok(n)
+    Err(e) : Err(e)
 
 describe("nested — Option<List<int>>", ():
   it("should wrap list in Some and unwrap it", ():

--- a/tests/spec/combinatorial/syntax_combinations.test.ry
+++ b/tests/spec/combinatorial/syntax_combinations.test.ry
@@ -5,15 +5,15 @@ enum SyntaxShape:
 
 function describe_shape_a(s: SyntaxShape) -> str:
   return case s:
-    SyntaxShape::Circle => "circle"
-    SyntaxShape::Rect => "rect"
-    SyntaxShape::Triangle => "triangle"
+    SyntaxShape::Circle : "circle"
+    SyntaxShape::Rect : "rect"
+    SyntaxShape::Triangle : "triangle"
 
 function describe_shape_b(s: SyntaxShape) -> str:
   return case s:
-    SyntaxShape::Circle => "round"
-    SyntaxShape::Rect => "angular"
-    SyntaxShape::Triangle => "pointed"
+    SyntaxShape::Circle : "round"
+    SyntaxShape::Rect : "angular"
+    SyntaxShape::Triangle : "pointed"
 
 function make_multiplier(factor: int) -> function(int) -> int:
   return (x: int) => x * factor
@@ -60,9 +60,9 @@ describe("syntax combo — when expression (inline case) in expression position"
   it("should use when expression to select label", ():
     x = 3
     label = case:
-      x == 1 => "one"
-      x == 3 => "three"
-      _ => "other"
+      x == 1 : "one"
+      x == 3 : "three"
+      _ : "other"
     expect(label).to_eq("three")
   )
   it("should use when expression in expression position", ():
@@ -70,9 +70,9 @@ describe("syntax combo — when expression (inline case) in expression position"
     # test exercises when in expression position (parenthesized) instead.
     n = 5
     result = (case:
-      n > 10 => n * 2
-      n > 3 => n + 10
-      _ => n
+      n > 10 : n * 2
+      n > 3 : n + 10
+      _ : n
     )
     expect(result).to_eq(15)
   )

--- a/tests/spec/control_flow.test.ry
+++ b/tests/spec/control_flow.test.ry
@@ -492,57 +492,57 @@ describe("match expression", ():
   it("should match literal pattern as expression", ():
     x = 2
     res = case x:
-      1 => "one"
-      2 => "two"
-      _ => "other"
+      1 : "one"
+      2 : "two"
+      _ : "other"
     expect(res).to_eq("two")
   )
   it("should fall back to wildcard in match expression", ():
     x = 999
     res = case x:
-      0 => "zero"
-      _ => "other"
+      0 : "zero"
+      _ : "other"
     expect(res).to_eq("other")
   )
   it("should match with variable binding and guard in expression", ():
     score = 85
     grade = case score:
-      n if n >= 90 => "A"
-      n if n >= 80 => "B"
-      n if n >= 70 => "C"
-      _ => "F"
+      n if n >= 90 : "A"
+      n if n >= 80 : "B"
+      n if n >= 70 : "C"
+      _ : "F"
     expect(grade).to_eq("B")
   )
   it("should match OR pattern in expression", ():
     x = 3
     kind = case x:
-      1 | 2 | 3 => "small"
-      4 | 5 | 6 => "medium"
-      _ => "large"
+      1 | 2 | 3 : "small"
+      4 | 5 | 6 : "medium"
+      _ : "large"
     expect(kind).to_eq("small")
   )
   it("should match string literal in expression", ():
     s = "hello"
     res = case s:
-      "hello" => "greeting"
-      "bye" => "farewell"
-      _ => "unknown"
+      "hello" : "greeting"
+      "bye" : "farewell"
+      _ : "unknown"
     expect(res).to_eq("greeting")
   )
   it("should match negative literal in expression", ():
     x = -1
     res = case x:
-      -1 => "minus one"
-      0 => "zero"
-      _ => "other"
+      -1 : "minus one"
+      0 : "zero"
+      _ : "other"
     expect(res).to_eq("minus one")
   )
   it("should fall back to wildcard when guard fails in expression", ():
     x = 5
     res = case x:
-      n if n > 100 => "big"
-      n if n > 50 => "medium"
-      _ => "small"
+      n if n > 100 : "big"
+      n if n > 50 : "medium"
+      _ : "small"
     expect(res).to_eq("small")
   )
 )
@@ -551,15 +551,15 @@ describe("match expression Option", ():
   it("should match Some in expression", ():
     x: Option<int> = Some(42)
     res = case x:
-      Some(v) => v
-      None => -1
+      Some(v) : v
+      None : -1
     expect(res).to_eq(42)
   )
   it("should match None in expression", ():
     x: Option<int> = None
     res = case x:
-      Some(v) => v
-      None => -1
+      Some(v) : v
+      None : -1
     expect(res).to_eq(-1)
   )
 )
@@ -568,26 +568,26 @@ describe("match expression enum", ():
   it("should match simple enum in expression", ():
     d = Direction::North
     res = case d:
-      Direction::North => "N"
-      Direction::South => "S"
-      Direction::East => "E"
-      Direction::West => "W"
+      Direction::North : "N"
+      Direction::South : "S"
+      Direction::East : "E"
+      Direction::West : "W"
     expect(res).to_eq("N")
   )
   it("should match ADT enum in expression", ():
     s = Shape::Rect(4.0, 5.0)
     area = case s:
-      Shape::Circle(r) => r * r
-      Shape::Rect(w, h) => w * h
-      Shape::Point => 0.0
+      Shape::Circle(r) : r * r
+      Shape::Rect(w, h) : w * h
+      Shape::Point : 0.0
     expect(area).to_eq(20.0)
   )
   it("should match ADT no-data variant in expression", ():
     s = Shape::Point
     area = case s:
-      Shape::Circle(r) => r * r
-      Shape::Rect(w, h) => w * h
-      Shape::Point => -1.0
+      Shape::Circle(r) : r * r
+      Shape::Rect(w, h) : w * h
+      Shape::Point : -1.0
     expect(area).to_eq(-1.0)
   )
 )
@@ -596,8 +596,8 @@ describe("match expression in function argument", ():
   it("should support inline match expr as function argument", ():
     x = 1
     expect(case x:
-      1 => 100
-      _ => 0
+      1 : 100
+      _ : 0
     ).to_eq(100)
   )
 )
@@ -606,15 +606,15 @@ describe("match expression in function argument", ():
 
 function shape_area(s: Shape) -> float:
   return case s:
-    Shape::Circle(r) => 3.14 * r * r
-    Shape::Rect(w, h) => w * h
-    Shape::Point => 0.0
+    Shape::Circle(r) : 3.14 * r * r
+    Shape::Rect(w, h) : w * h
+    Shape::Point : 0.0
 
 function shape_name(s: Shape) -> str:
   return case s:
-    Shape::Circle(r) => "circle"
-    Shape::Rect(w, h) => "rect"
-    Shape::Point => "point"
+    Shape::Circle(r) : "circle"
+    Shape::Rect(w, h) : "rect"
+    Shape::Point : "point"
 
 function make_shape(kind: int) -> Shape:
   if kind == 0:

--- a/tests/spec/operators.test.ry
+++ b/tests/spec/operators.test.ry
@@ -231,39 +231,39 @@ describe("bitwise", ():
 describe("when expression", ():
   it("should take true branch", ():
     expect(case:
-      true => 10
-      _ => 20
+      true : 10
+      _ : 20
     ).to_eq(10)
   )
   it("should take false branch", ():
     expect(case:
-      false => 10
-      _ => 20
+      false : 10
+      _ : 20
     ).to_eq(20)
   )
   it("should select correct branch in multi-branch when", ():
     x = 2
     r = case:
-      x == 1 => "one"
-      x == 2 => "two"
-      x == 3 => "three"
-      _ => "other"
+      x == 1 : "one"
+      x == 2 : "two"
+      x == 3 : "three"
+      _ : "other"
     expect(r).to_eq("two")
   )
   it("should fall to else when all branches are false", ():
     x = 99
     r = case:
-      x == 1 => "one"
-      x == 2 => "two"
-      _ => "none"
+      x == 1 : "one"
+      x == 2 : "two"
+      _ : "none"
     expect(r).to_eq("none")
   )
   it("should select second branch when first is false and second is true", ():
     x = 5
     r = case:
-      x > 10 => "big"
-      x > 3 => "medium"
-      _ => "small"
+      x > 10 : "big"
+      x > 3 : "medium"
+      _ : "small"
     expect(r).to_eq("medium")
   )
 )

--- a/tests/spec/option_branch_merge_none.test.ry
+++ b/tests/spec/option_branch_merge_none.test.ry
@@ -73,24 +73,24 @@ describe("None() in case-expr arms (#1154)", ():
   it("should unify None() with Some<int> in case match arm", ():
     o: Option<int> = Some(3)
     result: Option<int> = case o:
-      Some(v) => Some(v * 2)
-      None => None()
+      Some(v) : Some(v * 2)
+      None : None()
     expect(result).to_be_some()
   )
 
   it("should unify Some<str> with None() in case match arm", ():
     o: Option<str> = None
     result: Option<str> = case o:
-      Some(s) => Some(s)
-      None => None()
+      Some(s) : Some(s)
+      None : None()
     expect(result).to_be_none()
   )
 
   it("should unify None() arms with annotation in case", ():
     o: Option<int> = None
     result: Option<int> = case o:
-      Some(_) => None()
-      None => None()
+      Some(_) : None()
+      None : None()
     expect(result).to_be_none()
   )
 )
@@ -99,8 +99,8 @@ describe("bare none in case-expr arms (#1154)", ():
   it("should unify bare none with Some<int> in case arm", ():
     o: Option<int> = Some(5)
     result: Option<int> = case o:
-      Some(v) => Some(v)
-      None => none
+      Some(v) : Some(v)
+      None : none
     expect(result).to_be_some()
   )
 )
@@ -148,24 +148,24 @@ describe("None() in case-cond-expr arms (case: with no subject) (#1154)", ():
   it("should unify None() in first arm with Some<int> in else", ():
     flag: bool = false
     x: Option<int> = case:
-      flag => None()
-      _ => Some(42)
+      flag : None()
+      _ : Some(42)
     expect(x).to_be_some()
   )
 
   it("should unify Some<str> in first arm with None() in else", ():
     flag: bool = true
     x: Option<str> = case:
-      flag => Some("hi")
-      _ => None()
+      flag : Some("hi")
+      _ : None()
     expect(x).to_be_some()
   )
 
   it("should handle all-None() arms with annotation in case-cond", ():
     flag: bool = false
     x: Option<int> = case:
-      flag => None()
-      _ => None()
+      flag : None()
+      _ : None()
     expect(x).to_be_none()
   )
 
@@ -173,17 +173,17 @@ describe("None() in case-cond-expr arms (case: with no subject) (#1154)", ():
     a: bool = false
     b: bool = false
     x: Option<int> = case:
-      a => None()
-      b => Some(7)
-      _ => None()
+      a : None()
+      b : Some(7)
+      _ : None()
     expect(x).to_be_none()
   )
 
   it("regression: lambda with explicit Option<int> return and None() arm in case-cond", ():
     # fn_->getReturnType() already handled this in old code; kept as regression guard.
     f = (flag: bool) -> Option<int> => case:
-      flag => Some(99)
-      _ => None()
+      flag : Some(99)
+      _ : None()
     expect(f(true)).to_be_some()
     expect(f(false)).to_be_none()
   )
@@ -194,9 +194,9 @@ describe("None() in case-cond-expr arms (case: with no subject) (#1154)", ():
     # → guard gives nullptr → None() defaults to i8 → Option<i8> vs Option<int> mismatch.
     # With full-arm scan: finds Some(42) in arm 1 → hint = int → all arms emit Option<int>.
     x = case:
-      false => None()
-      true  => Some(42)
-      _     => None()
+      false : None()
+      true  : Some(42)
+      _     : None()
     result: Option<int> = x
     expect(result).to_be_some()
   )
@@ -211,8 +211,8 @@ describe("None() as return from if-expr function body (#1154)", ():
 
   it("should compile function returning case-expr with None() arm", ():
     g = (o: Option<str>) -> Option<str> => case o:
-      Some(s) => Some(s)
-      None => None()
+      Some(s) : Some(s)
+      None : None()
     expect(g(Some("x"))).to_be_some()
     expect(g(None())).to_be_none()
   )
@@ -237,8 +237,8 @@ describe("None()/none in lambda call arguments (#1179)", ():
   )
   it("issue repro: case-returning lambda accepts None() argument directly", ():
     g = (o: Option<str>) -> Option<str> => case o:
-      Some(s) => Some(s)
-      None => None()
+      Some(s) : Some(s)
+      None : None()
     expect(g(Some("x"))).to_be_some()
     expect(g(None())).to_be_none()
   )

--- a/tests/spec/option_none_call.test.ry
+++ b/tests/spec/option_none_call.test.ry
@@ -12,8 +12,8 @@ function g_none_call_reset():
 
 function accept_none_opt(o: Option<int>) -> bool:
   return case o:
-    Some(_) => false
-    None => true
+    Some(_) : false
+    None : true
 
 describe("None() in let-decl (#1099)", ():
   it("should accept None() with Option<int> annotation", ():

--- a/tests/spec/pattern_record.test.ry
+++ b/tests/spec/pattern_record.test.ry
@@ -176,16 +176,16 @@ describe("record pattern - case expression form", ():
   it("should work in expression position", ():
     p = Point(3, 4)
     result = case p:
-      Point(a, b) => a + b
-      _ => -1
+      Point(a, b) : a + b
+      _ : -1
     expect(result).to_eq(7)
   )
 
   it("should work with literal pattern in expression form", ():
     p = Point(0, 0)
     label = case p:
-      Point(0, 0) => "origin"
-      _ => "other"
+      Point(0, 0) : "origin"
+      _ : "other"
     expect(label).to_eq("origin")
   )
 )
@@ -200,8 +200,8 @@ describe("regression - existing record usage unaffected", ():
   it("should still work with Some/None alongside record patterns", ():
     opt: Option<int> = Some(10)
     res = case opt:
-      Some(v) => v
-      None => 0
+      Some(v) : v
+      None : 0
     expect(res).to_eq(10)
   )
 
@@ -212,9 +212,9 @@ describe("regression - existing record usage unaffected", ():
       Blue
     c: Color = Color::Green
     res = case c:
-      Color::Red => 0
-      Color::Green => 1
-      Color::Blue => 2
+      Color::Red : 0
+      Color::Green : 1
+      Color::Blue : 2
     expect(res).to_eq(1)
   )
 )

--- a/tests/spec/pattern_tuple.test.ry
+++ b/tests/spec/pattern_tuple.test.ry
@@ -171,16 +171,16 @@ describe("tuple pattern - case expression form", ():
   it("should work in expression position", ():
     t = (3, 4)
     result = case t:
-      (a, b) => a + b
-      _ => -1
+      (a, b) : a + b
+      _ : -1
     expect(result).to_eq(7)
   )
 
   it("should work with literal pattern in expression form", ():
     t = (0, 0)
     label = case t:
-      (0, 0) => "origin"
-      _ => "other"
+      (0, 0) : "origin"
+      _ : "other"
     expect(label).to_eq("origin")
   )
 )
@@ -189,16 +189,16 @@ describe("regression - existing patterns unaffected", ():
   it("should still work with literal patterns", ():
     x = 42
     res = case x:
-      42 => "found"
-      _ => "not found"
+      42 : "found"
+      _ : "not found"
     expect(res).to_eq("found")
   )
 
   it("should still work with Some/None", ():
     opt: Option<int> = Some(10)
     res = case opt:
-      Some(v) => v
-      None => 0
+      Some(v) : v
+      None : 0
     expect(res).to_eq(10)
   )
 
@@ -218,8 +218,8 @@ describe("regression - existing patterns unaffected", ():
   it("should still work with OR patterns", ():
     x = 2
     res = case x:
-      1 | 2 | 3 => "small"
-      _ => "other"
+      1 | 2 | 3 : "small"
+      _ : "other"
     expect(res).to_eq("small")
   )
 
@@ -230,9 +230,9 @@ describe("regression - existing patterns unaffected", ():
       Blue
     c: Color = Color::Green
     res = case c:
-      Color::Red => 0
-      Color::Green => 1
-      Color::Blue => 2
+      Color::Red : 0
+      Color::Green : 1
+      Color::Blue : 2
     expect(res).to_eq(1)
   )
 

--- a/tests/spec/result_option_arc_return.test.ry
+++ b/tests/spec/result_option_arc_return.test.ry
@@ -238,8 +238,8 @@ describe("Err(xs) named binding — metadata propagation (#1004)", ():
     # protects CaseExpr metadata propagation.
     r: Result<int, List<int>> = make_err_list([7, 8, 9])
     v = case r:
-      Ok(_) => 0
-      Err(xs) => xs.length()
+      Ok(_) : 0
+      Err(xs) : xs.length()
     expect(v).to_eq(3)
   )
 )

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -10,22 +10,22 @@ using namespace ry;
 // ===== when expression =====
 
 TEST_F(CodeGenTest, WhenExprBasics) {
-    EXPECT_EQ(runSource("x = case:\n    true => 1\n    _ => 2\nprint(x)"), "1\n");
-    EXPECT_EQ(runSource("x = case:\n    false => 1\n    _ => 2\nprint(x)"), "2\n");
-    EXPECT_EQ(runSource("x = case:\n    3 > 2 => 10\n    _ => 20\nprint(x)"), "10\n");
-    EXPECT_EQ(runSource("s = case:\n    true => \"yes\"\n    _ => \"no\"\nprint(s)"), "yes\n");
-    EXPECT_EQ(runSource("x = case:\n    true => case:\n        false => 1\n        _ => 2\n    _ => 3\nprint(x)"), "2\n");
-    EXPECT_EQ(runSource("x = case:\n    true => \"a\"\n    _ => \"b\"\nprint(x)"), "a\n");
+    EXPECT_EQ(runSource("x = case:\n    true : 1\n    _ : 2\nprint(x)"), "1\n");
+    EXPECT_EQ(runSource("x = case:\n    false : 1\n    _ : 2\nprint(x)"), "2\n");
+    EXPECT_EQ(runSource("x = case:\n    3 > 2 : 10\n    _ : 20\nprint(x)"), "10\n");
+    EXPECT_EQ(runSource("s = case:\n    true : \"yes\"\n    _ : \"no\"\nprint(s)"), "yes\n");
+    EXPECT_EQ(runSource("x = case:\n    true : case:\n        false : 1\n        _ : 2\n    _ : 3\nprint(x)"), "2\n");
+    EXPECT_EQ(runSource("x = case:\n    true : \"a\"\n    _ : \"b\"\nprint(x)"), "a\n");
 }
 
 TEST_F(CodeGenTest, WhenExprTypeMismatchErrors) {
-    EXPECT_THROW(runSource("x = case:\n    true => \"hello\"\n    _ => [1, 2, 3]\nprint(x)"), std::runtime_error);
-    EXPECT_THROW(runSource("x = case:\n    true => [1, 2]\n    _ => {\"a\": 1}\nprint(x)"), std::runtime_error);
+    EXPECT_THROW(runSource("x = case:\n    true : \"hello\"\n    _ : [1, 2, 3]\nprint(x)"), std::runtime_error);
+    EXPECT_THROW(runSource("x = case:\n    true : [1, 2]\n    _ : {\"a\": 1}\nprint(x)"), std::runtime_error);
 }
 
 TEST_F(CodeGenTest, WhenExprListSameType) {
     std::string src =
-        "x = case:\n    true => [1, 2]\n    _ => [3, 4]\nprint(x)";
+        "x = case:\n    true : [1, 2]\n    _ : [3, 4]\nprint(x)";
     EXPECT_EQ(runSource(src), "[1, 2]\n");
 }
 

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -49,8 +49,8 @@ TEST(Formatter, ComplexExprFormatting) {
     // Map
     EXPECT_EQ(fmt("x = {\"a\": 1, \"b\": 2}\n"), "x = {\"a\": 1, \"b\": 2}\n");
     // when expression
-    EXPECT_EQ(fmt("x = case:\n    a > 0 => 1\n    _ => 0\n"),
-              "x = case:\n  a > 0 => 1\n  _ => 0\n");
+    EXPECT_EQ(fmt("x = case:\n    a > 0 : 1\n    _ : 0\n"),
+              "x = case:\n  a > 0 : 1\n  _ : 0\n");
     // Range
     EXPECT_EQ(fmt("x = 1..10\n"), "x = 1..10\n");
     // Enum access

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -428,7 +428,7 @@ TEST(ParserTest, CaseCondWildcardMustBeLast) {
 }
 
 TEST(ParserTest, CaseCondExprWildcardMustBeLast) {
-    EXPECT_THROW(parseStr("x = case:\n    _ => 0\n    true => 1"),
+    EXPECT_THROW(parseStr("x = case:\n    _ : 0\n    true : 1"),
                  std::runtime_error);
 }
 
@@ -2173,7 +2173,7 @@ TEST(ParserTest, CastChained) {
 // ===== case <subject> 式パーサーテスト =====
 
 TEST(ParserTest, CaseExprBasic) {
-    Program prog = parseStr("x = case y:\n    1 => 10\n    _ => 0");
+    Program prog = parseStr("x = case y:\n    1 : 10\n    _ : 0");
     ASSERT_EQ(prog.size(), 1u);
     ASSERT_TRUE(std::holds_alternative<AssignStmt>(prog[0]));
     const auto &s = std::get<AssignStmt>(prog[0]);
@@ -2185,7 +2185,7 @@ TEST(ParserTest, CaseExprBasic) {
 }
 
 TEST(ParserTest, CaseExprWithGuard) {
-    Program prog = parseStr("x = case y:\n    n if n > 0 => n\n    _ => 0");
+    Program prog = parseStr("x = case y:\n    n if n > 0 : n\n    _ : 0");
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
     const auto &me = *std::get<std::unique_ptr<CaseExpr>>(s.value->data);
@@ -2196,7 +2196,7 @@ TEST(ParserTest, CaseExprWithGuard) {
 }
 
 TEST(ParserTest, CaseExprOrPattern) {
-    Program prog = parseStr("x = case y:\n    1 | 2 | 3 => 10\n    _ => 0");
+    Program prog = parseStr("x = case y:\n    1 | 2 | 3 : 10\n    _ : 0");
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);
     const auto &me = *std::get<std::unique_ptr<CaseExpr>>(s.value->data);
@@ -2206,6 +2206,16 @@ TEST(ParserTest, CaseExprOrPattern) {
 
 TEST(ParserTest, CaseExprEmptyThrows) {
     EXPECT_THROW(parseStr("x = case y:\n"), std::runtime_error);
+}
+
+TEST(ParserTest, CaseCondExprFatArrowRejected) {
+    EXPECT_THROW(parseStr("x = case:\n    true => 1\n    _ : 0"),
+                 std::runtime_error);
+}
+
+TEST(ParserTest, CaseExprFatArrowRejected) {
+    EXPECT_THROW(parseStr("x = case y:\n    1 => 10\n    _ : 0"),
+                 std::runtime_error);
 }
 
 TEST(ParserTest, IntLiteralInt64Max) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2213,6 +2213,11 @@ TEST(ParserTest, CaseCondExprFatArrowRejected) {
                  std::runtime_error);
 }
 
+TEST(ParserTest, CaseCondExprWildcardFatArrowRejected) {
+    EXPECT_THROW(parseStr("x = case:\n    true : 1\n    _ => 0"),
+                 std::runtime_error);
+}
+
 TEST(ParserTest, CaseExprFatArrowRejected) {
     EXPECT_THROW(parseStr("x = case y:\n    1 => 10\n    _ : 0"),
                  std::runtime_error);


### PR DESCRIPTION
## Summary
- switch case expressions to use ':' arm separators instead of '=>'
- reject the old '=>' syntax in the parser and update formatter output
- migrate spec tests, C++ tests, and reference docs to the unified syntax

## Testing
- cmake --build build
- ./build/ry_tests --gtest_filter=ParserTest.Case*:*Formatter.ComplexExprFormatting:*CodeGenTest.WhenExpr*
- ./build/ry test tests/spec/case_unification.test.ry
- ./build/ry test tests/spec/control_flow.test.ry
- ./build/ry test -p
- ./build/ry_tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated `case` expression guidance: arms now use `:` instead of `=>` between patterns/conditions and their result expressions for both subject and subjectless forms.

* **Formatting**
  * Formatter output adjusted to render `case` arms with `:` separators.

* **Tests**
  * Test suite updated to reflect the new `case` arm syntax across parser, formatter, and behavior tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->