### PR TITLE
feat: support inline colon if expressions

### DIFF
--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -42,16 +42,16 @@ Inline and block branches can be mixed:
 
 ```ry
 x = if condition: true_value else:
-    compute_other()
+    (compute_other())
 ```
 
 Or both branches can use blocks:
 
 ```ry
 x = if condition:
-    compute_something()
+    (compute_something())
 else:
-    compute_other()
+    (compute_other())
 ```
 
 In the colon form, each branch may be either a same-line expression or an indented block. Indented branches must end with an expression statement (tail-expression semantics). The `else` branch is required, and both branches must produce the same type.

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -32,7 +32,20 @@ label = if score >= 90 => "A" else "B"
 
 The `else` branch in the single-expression form takes a value directly (without `=>`). Both branches must produce the same type, and `else` is required.
 
-**Block form** (`:`):
+**Colon form** (`:`):
+
+```ry
+x = if condition: true_value else: false_value
+```
+
+Inline and block branches can be mixed:
+
+```ry
+x = if condition: true_value else:
+    compute_other()
+```
+
+Or both branches can use blocks:
 
 ```ry
 x = if condition:
@@ -41,7 +54,7 @@ else:
     compute_other()
 ```
 
-In the block form, each block must end with an expression statement (tail-expression semantics). The `else` branch is required, and both branches must produce the same type.
+In the colon form, each branch may be either a same-line expression or an indented block. Indented branches must end with an expression statement (tail-expression semantics). The `else` branch is required, and both branches must produce the same type.
 
 For multi-branch conditionals with values, use `case:` instead (see below).
 

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -390,7 +390,7 @@ struct CaseCondExpr {
     ExprPtr else_expr;
 };
 
-// `if cond => then_value else else_value` — single-expression form (#798).
+// `if cond => then_value else else_value` — fat-arrow single-expression form (#798).
 struct IfExpr {
     ExprPtr condition;
     ExprPtr then_value;
@@ -398,8 +398,10 @@ struct IfExpr {
     SourceLocation loc;
 };
 
-// `if cond: then_body else: else_body` — block form with tail-expression
-// semantics. Both blocks MUST end with an ExprStmt; enforced at codegen.
+// `if cond: ... else: ...` — colon-form if expression. Each branch may be a
+// same-line expression or an indented block; parser normalizes same-line
+// expressions to a single ExprStmt body. Both branches MUST end with an
+// ExprStmt; enforced at codegen.
 struct IfBlockExpr {
     ExprPtr condition;
     std::vector<StmtNode> then_body;

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -81,6 +81,7 @@ private:
     ExprPtr parseCaseExprNoSubject(const Token &caseTok);
     ExprPtr parseCaseExprWithSubject(const Token &caseTok);
     ExprPtr parseIfExpression();
+    std::vector<StmtNode> parseIfExpressionBranchBody();
     Pattern parsePattern();
     void parseOrPattern(Pattern &pat);
     static bool patternHasBinding(const Pattern &p);

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -343,20 +343,32 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                  + formatExpr(*v->then_value) + " else " + formatExpr(*v->else_value);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
             std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
-            std::string out = "if " + formatExpr(*v->condition) + ":\n";
-            for (size_t i = 0; i < v->then_body.size(); ++i) {
-                out += indent;
-                if (const auto *es = std::get_if<ExprStmt>(&v->then_body[i]))
-                    out += formatExpr(*es->expr);
-                if (i + 1 < v->then_body.size()) out += "\n";
-            }
-            out += "\nelse:\n";
-            for (size_t i = 0; i < v->else_body.size(); ++i) {
-                out += indent;
-                if (const auto *es = std::get_if<ExprStmt>(&v->else_body[i]))
-                    out += formatExpr(*es->expr);
-                if (i + 1 < v->else_body.size()) out += "\n";
-            }
+            auto isInlineExprBody = [](const std::vector<StmtNode> &body) -> const ExprStmt * {
+                if (body.size() != 1)
+                    return nullptr;
+                return std::get_if<ExprStmt>(&body[0]);
+            };
+            auto appendBody = [&](std::string &out, const std::vector<StmtNode> &body, bool inlineAllowed) {
+                if (inlineAllowed) {
+                    if (const auto *es = isInlineExprBody(body)) {
+                        out += " " + formatExpr(*es->expr);
+                        return;
+                    }
+                }
+                out += "\n";
+                for (size_t i = 0; i < body.size(); ++i) {
+                    out += indent;
+                    if (const auto *es = std::get_if<ExprStmt>(&body[i]))
+                        out += formatExpr(*es->expr);
+                    if (i + 1 < body.size())
+                        out += "\n";
+                }
+            };
+
+            std::string out = "if " + formatExpr(*v->condition) + ":";
+            appendBody(out, v->then_body, true);
+            out += " else:";
+            appendBody(out, v->else_body, true);
             return out;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<RangeExpr>>) {
             return formatExpr(*v->start) + ".." + formatExpr(*v->end);

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -342,7 +342,6 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
             return "if " + formatExpr(*v->condition) + " => "
                  + formatExpr(*v->then_value) + " else " + formatExpr(*v->else_value);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
-            std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
             auto getInlineExprText = [this](const std::vector<StmtNode> &body) -> std::optional<std::string> {
                 if (body.size() != 1)
                     return std::nullopt;
@@ -354,11 +353,11 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                     return std::nullopt;
                 return formatted;
             };
-            auto appendBody = [&](std::string &out, const std::vector<StmtNode> &body, bool inlineAllowed) {
+            auto appendBody = [&](std::string &out, const std::vector<StmtNode> &body, bool inlineAllowed) -> bool {
                 if (inlineAllowed) {
                     if (auto inlineExpr = getInlineExprText(body)) {
                         out += " " + *inlineExpr;
-                        return;
+                        return true;
                     }
                 }
                 out += "\n";
@@ -367,6 +366,7 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                     out_.clear();
                     int saved_indent = indent_level_;
                     indent_level_ += 1;
+                    emitIndent();
                     formatStmt(body[i]);
                     indent_level_ = saved_indent;
                     std::string stmt_text = std::move(out_);
@@ -374,12 +374,15 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                     if (!stmt_text.empty() && stmt_text.back() == '\n')
                         stmt_text.pop_back();
                     out += stmt_text;
+                    if (i + 1 < body.size())
+                        out += "\n";
                 }
+                return false;
             };
 
             std::string out = "if " + formatExpr(*v->condition) + ":";
-            appendBody(out, v->then_body, true);
-            out += " else:";
+            bool thenInline = appendBody(out, v->then_body, true);
+            out += thenInline ? " else:" : "\nelse:";
             appendBody(out, v->else_body, true);
             return out;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<RangeExpr>>) {

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -343,25 +343,37 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                  + formatExpr(*v->then_value) + " else " + formatExpr(*v->else_value);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
             std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
-            auto isInlineExprBody = [](const std::vector<StmtNode> &body) -> const ExprStmt * {
+            auto getInlineExprText = [this](const std::vector<StmtNode> &body) -> std::optional<std::string> {
                 if (body.size() != 1)
-                    return nullptr;
-                return std::get_if<ExprStmt>(&body[0]);
+                    return std::nullopt;
+                const auto *es = std::get_if<ExprStmt>(&body[0]);
+                if (!es)
+                    return std::nullopt;
+                std::string formatted = formatExpr(*es->expr);
+                if (formatted.find('\n') != std::string::npos)
+                    return std::nullopt;
+                return formatted;
             };
             auto appendBody = [&](std::string &out, const std::vector<StmtNode> &body, bool inlineAllowed) {
                 if (inlineAllowed) {
-                    if (const auto *es = isInlineExprBody(body)) {
-                        out += " " + formatExpr(*es->expr);
+                    if (auto inlineExpr = getInlineExprText(body)) {
+                        out += " " + *inlineExpr;
                         return;
                     }
                 }
                 out += "\n";
                 for (size_t i = 0; i < body.size(); ++i) {
-                    out += indent;
-                    if (const auto *es = std::get_if<ExprStmt>(&body[i]))
-                        out += formatExpr(*es->expr);
-                    if (i + 1 < body.size())
-                        out += "\n";
+                    std::string saved_out = std::move(out_);
+                    out_.clear();
+                    int saved_indent = indent_level_;
+                    indent_level_ += 1;
+                    formatStmt(body[i]);
+                    indent_level_ = saved_indent;
+                    std::string stmt_text = std::move(out_);
+                    out_ = std::move(saved_out);
+                    if (!stmt_text.empty() && stmt_text.back() == '\n')
+                        stmt_text.pop_back();
+                    out += stmt_text;
                 }
             };
 

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -140,10 +140,23 @@ ExprPtr Parser::parseCaseExprWithSubject(const Token &caseTok) {
     return node;
 }
 
+std::vector<StmtNode> Parser::parseIfExpressionBranchBody() {
+    if (lex_.peek().kind == TokenKind::Newline)
+        return parseBlock();
+
+    std::vector<StmtNode> body;
+    body.reserve(1);
+    ExprStmt stmt;
+    stmt.expr = parseConditional();
+    body.push_back(std::move(stmt));
+    return body;
+}
+
 // Parses the expression form of `if` (issue #798):
 //   1. Single-expression form: `if <cond> => <then_val> else <else_val>`
-//   2. Block form: `if <cond>: <then_body> else: <else_body>` — both blocks
-//      must end with an expression statement (tail-expression semantics).
+//   2. Colon form: `if <cond>: <then_body> else: <else_body>` — each branch
+//      may be a same-line expression or an indented block; both branches must
+//      end with an expression statement (tail-expression semantics).
 //
 // The leading `if` token is consumed here.
 ExprPtr Parser::parseIfExpression() {
@@ -176,9 +189,9 @@ ExprPtr Parser::parseIfExpression() {
     }
 
     if (lex_.peek().kind == TokenKind::Colon) {
-        // Block form: if <cond>: <then_body> else: <else_body>
+        // Colon form: if <cond>: <inline-expr|block> else: <inline-expr|block>
         lex_.next(); // consume ':'
-        std::vector<StmtNode> thenBody = parseBlock();
+        std::vector<StmtNode> thenBody = parseIfExpressionBranchBody();
 
         if (lex_.peek().kind != TokenKind::Else)
             parseError("if expression (block form) requires an 'else:' branch");
@@ -187,7 +200,7 @@ ExprPtr Parser::parseIfExpression() {
         if (lex_.peek().kind != TokenKind::Colon)
             parseError("expected ':' after 'else' in if expression block form");
         lex_.next(); // consume ':'
-        std::vector<StmtNode> elseBody = parseBlock();
+        std::vector<StmtNode> elseBody = parseIfExpressionBranchBody();
 
         auto ifBlock = std::make_unique<IfBlockExpr>();
         ifBlock->condition = std::move(cond);

--- a/tests/spec/case_unification.test.ry
+++ b/tests/spec/case_unification.test.ry
@@ -176,3 +176,18 @@ describe("if expression block form", ():
     expect(result).to_eq(21)
   )
 )
+
+describe("if expression colon inline form", ():
+  it("should select inline branches", ():
+    x = 10
+    result = if x > 3: "big" else: "small"
+    expect(result).to_eq("big")
+  )
+
+  it("should allow mixed inline and block branches", ():
+    x = -2
+    result = if x > 0: x else:
+      0 - x
+    expect(result).to_eq(2)
+  )
+)

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -180,6 +180,16 @@ TEST(Formatter, ControlFlow) {
             "case:\n  x > 10:\n    res = 1\n  x == 5:\n    res = 2\n  _:\n    res = 3\n";
         EXPECT_EQ(fmt(src), expected);
     }
+    {
+        auto src = "x = if n > 0: \"pos\" else: \"neg\"\n";
+        auto expected = "x = if n > 0: \"pos\" else: \"neg\"\n";
+        EXPECT_EQ(fmt(src), expected);
+    }
+    {
+        auto src = "x = if n > 0: \"pos\" else:\n    \"neg\"\n";
+        auto expected = "x = if n > 0: \"pos\" else: \"neg\"\n";
+        EXPECT_EQ(fmt(src), expected);
+    }
     // For loop
     {
         auto src = "for i in range(5):\n    sum += i\n";

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -190,6 +190,23 @@ TEST(Formatter, ControlFlow) {
         auto expected = "x = if n > 0: \"pos\" else: \"neg\"\n";
         EXPECT_EQ(fmt(src), expected);
     }
+    {
+        auto src =
+            "x = if n > 0:\n"
+            "    a = 1\n"
+            "    1\n"
+            "else:\n"
+            "    b = 2\n"
+            "    2\n";
+        auto expected =
+            "x = if n > 0:\n"
+            "  a = 1\n"
+            "  1\n"
+            "else:\n"
+            "  b = 2\n"
+            "  2\n";
+        EXPECT_EQ(fmt(src), expected);
+    }
     // For loop
     {
         auto src = "for i in range(5):\n    sum += i\n";

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -408,6 +408,41 @@ TEST(ParserTest, IfElse) {
     ASSERT_EQ(ifStmt.else_body.size(), 1u);
 }
 
+TEST(ParserTest, IfExpressionColonInlineParsesAsIfBlockExpr) {
+    Program prog = parseStr("x = if true: 1 else: 2");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &assign = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(assign.value != nullptr);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<IfBlockExpr>>(assign.value->data));
+    const auto &ifExpr = *std::get<std::unique_ptr<IfBlockExpr>>(assign.value->data);
+    ASSERT_EQ(ifExpr.then_body.size(), 1u);
+    ASSERT_EQ(ifExpr.else_body.size(), 1u);
+    EXPECT_TRUE(std::holds_alternative<ExprStmt>(ifExpr.then_body[0]));
+    EXPECT_TRUE(std::holds_alternative<ExprStmt>(ifExpr.else_body[0]));
+}
+
+TEST(ParserTest, IfExpressionColonAllowsInlineThenBlockElse) {
+    Program prog = parseStr("x = if true: 1 else:\n    2");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &assign = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(assign.value != nullptr);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<IfBlockExpr>>(assign.value->data));
+    const auto &ifExpr = *std::get<std::unique_ptr<IfBlockExpr>>(assign.value->data);
+    ASSERT_EQ(ifExpr.then_body.size(), 1u);
+    ASSERT_EQ(ifExpr.else_body.size(), 1u);
+}
+
+TEST(ParserTest, IfExpressionColonAllowsBlockThenInlineElse) {
+    Program prog = parseStr("x = if true:\n    1\nelse: 2");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &assign = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(assign.value != nullptr);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<IfBlockExpr>>(assign.value->data));
+    const auto &ifExpr = *std::get<std::unique_ptr<IfBlockExpr>>(assign.value->data);
+    ASSERT_EQ(ifExpr.then_body.size(), 1u);
+    ASSERT_EQ(ifExpr.else_body.size(), 1u);
+}
+
 TEST(ParserTest, IfElifRejected) {
     EXPECT_THROW(parseStr("if true:\n    print(1)\nelif false:\n    print(2)\nelse:\n    print(3)"),
                  std::runtime_error);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -430,6 +430,14 @@ TEST(ParserTest, IfExpressionColonAllowsInlineThenBlockElse) {
     const auto &ifExpr = *std::get<std::unique_ptr<IfBlockExpr>>(assign.value->data);
     ASSERT_EQ(ifExpr.then_body.size(), 1u);
     ASSERT_EQ(ifExpr.else_body.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(ifExpr.then_body[0]));
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(ifExpr.else_body[0]));
+    const auto &thenStmt = std::get<ExprStmt>(ifExpr.then_body[0]);
+    const auto &elseStmt = std::get<ExprStmt>(ifExpr.else_body[0]);
+    ASSERT_TRUE(std::holds_alternative<NumberExpr>(thenStmt.expr->data));
+    ASSERT_TRUE(std::holds_alternative<NumberExpr>(elseStmt.expr->data));
+    EXPECT_EQ(std::get<NumberExpr>(thenStmt.expr->data).value, 1);
+    EXPECT_EQ(std::get<NumberExpr>(elseStmt.expr->data).value, 2);
 }
 
 TEST(ParserTest, IfExpressionColonAllowsBlockThenInlineElse) {
@@ -441,6 +449,22 @@ TEST(ParserTest, IfExpressionColonAllowsBlockThenInlineElse) {
     const auto &ifExpr = *std::get<std::unique_ptr<IfBlockExpr>>(assign.value->data);
     ASSERT_EQ(ifExpr.then_body.size(), 1u);
     ASSERT_EQ(ifExpr.else_body.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(ifExpr.then_body[0]));
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(ifExpr.else_body[0]));
+    const auto &thenStmt = std::get<ExprStmt>(ifExpr.then_body[0]);
+    const auto &elseStmt = std::get<ExprStmt>(ifExpr.else_body[0]);
+    ASSERT_TRUE(std::holds_alternative<NumberExpr>(thenStmt.expr->data));
+    ASSERT_TRUE(std::holds_alternative<NumberExpr>(elseStmt.expr->data));
+    EXPECT_EQ(std::get<NumberExpr>(thenStmt.expr->data).value, 1);
+    EXPECT_EQ(std::get<NumberExpr>(elseStmt.expr->data).value, 2);
+}
+
+TEST(ParserTest, IfExpressionColonRejectsMissingThenExpr) {
+    EXPECT_THROW(parseStr("x = if true: else: 2"), std::runtime_error);
+}
+
+TEST(ParserTest, IfExpressionColonRejectsMissingElseExpr) {
+    EXPECT_THROW(parseStr("x = if true: 1 else:"), std::runtime_error);
 }
 
 TEST(ParserTest, IfElifRejected) {


### PR DESCRIPTION
## Summary
- support `if cond: expr else: expr` in expression context
- allow mixed inline/block colon-form branches via `IfBlockExpr`
- add parser, formatter, spec, and docs coverage for the new form

## Testing
- cmake --build build
- ./build/ry_tests --gtest_filter="ParserTest.IfExpressionColon*:Formatter.ControlFlow"
- ./build/ry test tests/spec/case_unification.test.ry
- ./build/ry_tests

Closes #1201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support concise same-line if...else expressions and mixing inline branches with indented block branches; formatter emits inline single-expression branches when suitable.

* **Documentation**
  * Clarified colon-form if syntax, examples for mixing same-line and indented branches, and precise tail-expression semantics.

* **Tests**
  * Added parser and formatter tests covering inline, block, and mixed if...else branch combinations and related parse error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->