### PR TITLE
fix: support nested tuple destructuring in for loops

### DIFF
--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -230,6 +230,11 @@ for a, b, c in triples:
 
 for a, _, c in triples:
     print(a + c)          # 4, 10 (middle element discarded)
+
+# Nested tuple destructuring also works
+items = [("a", 1), ("b", 2), ("c", 3)]
+for i, (k, v) in enumerate(items):
+    print(f"{i}: {k}={v}")  # 0: a=1, 1: b=2, 2: c=3
 ```
 
 Statement-level destructuring assignment is also available and accepts both a bare and a parenthesized LHS. See [directives.md#const](directives.md) for the `@const` variant.

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -335,6 +335,31 @@ using StmtNode = std::variant<AssignStmt, CallStmt, ExprStmt,
                               std::unique_ptr<CaseStmt>>;
 using Program  = std::vector<StmtNode>;
 
+// ===== Match patterns =====
+
+struct WildcardPattern {};
+struct LiteralPattern { ExprPtr value; };
+struct VariablePattern { std::string name; };
+struct EnumPattern { std::string enum_name; std::string variant_name; };
+struct SomePattern { std::string binding; };
+struct NonePattern {};
+struct OkPattern { std::string binding; };
+struct ErrPattern { std::string binding; };
+struct EnumConstructorPattern;  // defined after Pattern (needs Pattern for nested bindings)
+struct OrPattern;
+struct TuplePattern;   // elements may be nested Patterns (e.g. Some(v) inside a tuple)
+struct RecordPattern;  // positional record destructuring: Point(a, b)
+
+using Pattern = std::variant<
+    WildcardPattern, LiteralPattern, VariablePattern,
+    EnumPattern, SomePattern, NonePattern,
+    OkPattern, ErrPattern,
+    std::unique_ptr<EnumConstructorPattern>,
+    std::unique_ptr<OrPattern>,
+    std::unique_ptr<TuplePattern>,
+    std::unique_ptr<RecordPattern>
+>;
+
 struct IfBranch {
     ExprPtr condition;
     std::vector<StmtNode> body;
@@ -366,7 +391,7 @@ struct WhileStmt {
 };
 
 struct ForStmt {
-    std::vector<std::string> var_names; // 1+ variable names; "_" = wildcard
+    Pattern binding; // variable / wildcard / nested tuple destructuring
     ExprPtr iterable;
     std::vector<StmtNode> body;
     std::vector<Directive> directives;
@@ -457,31 +482,6 @@ struct LambdaExpr {
     std::vector<StmtNode> body;   // multi-line lambda
     ExprPtr expr_body;            // single-expression lambda (if non-null, use this)
 };
-
-// ===== Match patterns =====
-
-struct WildcardPattern {};
-struct LiteralPattern { ExprPtr value; };
-struct VariablePattern { std::string name; };
-struct EnumPattern { std::string enum_name; std::string variant_name; };
-struct SomePattern { std::string binding; };
-struct NonePattern {};
-struct OkPattern { std::string binding; };
-struct ErrPattern { std::string binding; };
-struct EnumConstructorPattern;  // defined after Pattern (needs Pattern for nested bindings)
-struct OrPattern;
-struct TuplePattern;   // elements may be nested Patterns (e.g. Some(v) inside a tuple)
-struct RecordPattern;  // positional record destructuring: Point(a, b)
-
-using Pattern = std::variant<
-    WildcardPattern, LiteralPattern, VariablePattern,
-    EnumPattern, SomePattern, NonePattern,
-    OkPattern, ErrPattern,
-    std::unique_ptr<EnumConstructorPattern>,
-    std::unique_ptr<OrPattern>,
-    std::unique_ptr<TuplePattern>,
-    std::unique_ptr<RecordPattern>
->;
 
 struct OrPattern { std::vector<Pattern> alternatives; };
 // 1-tuple requires trailing comma: (a,).  Bare (p) without comma is grouping in the parser.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1032,9 +1032,9 @@ public:
     // used to propagate per-component metadata onto the bound variables.
     // Pass "" when no source-level name is available (e.g. iterator-sourced
     // tuples); metadata propagation is skipped in that case.
-    void emitTupleDestructure(const std::vector<std::string> &var_names,
-                              llvm::Value *tupleVal, llvm::StructType *structTy,
-                              const std::string &tupleTypeName);
+    void emitForBindingPattern(const Pattern &pattern, llvm::Value *value,
+                               llvm::Type *valueTy,
+                               const std::string &valueTypeName);
     void emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *end, llvm::Value *step);
     void validateParallelFor(const ForStmt &s);
 

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -85,6 +85,7 @@ private:
     Pattern parsePattern();
     void parseOrPattern(Pattern &pat);
     static bool patternHasBinding(const Pattern &p);
+    void validateForBindingPattern(const Pattern &p);
     TypeParam parseOneTypeParam();
     TypeNodePtr parseTypeName();
     TypeNodePtr parseTypeNameSingle();

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -18,6 +18,38 @@ static bool iterableHasExternalAlias(const ExprNode &e) {
         || std::get_if<std::unique_ptr<IndexExpr>>(&e.data) != nullptr;
 }
 
+static void collectForBindingNames(const Pattern &pattern,
+                                   std::vector<std::string> &out) {
+    std::visit([&](const auto &pat) {
+        using T = std::decay_t<decltype(pat)>;
+        if constexpr (std::is_same_v<T, VariablePattern>) {
+            out.push_back(pat.name);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
+            for (const auto &elem : pat->elements)
+                collectForBindingNames(elem, out);
+        }
+    }, pattern);
+}
+
+static size_t forBindingArity(const Pattern &pattern) {
+    if (std::holds_alternative<std::unique_ptr<TuplePattern>>(pattern))
+        return std::get<std::unique_ptr<TuplePattern>>(pattern)->elements.size();
+    return 1;
+}
+
+static bool isSingleVariableForBinding(const Pattern &pattern, std::string *name = nullptr) {
+    if (auto *var = std::get_if<VariablePattern>(&pattern)) {
+        if (name)
+            *name = var->name;
+        return true;
+    }
+    return false;
+}
+
+static bool isWildcardForBinding(const Pattern &pattern) {
+    return std::holds_alternative<WildcardPattern>(pattern);
+}
+
 void CodeGen::emitStmt(std::unique_ptr<WhileStmt> &s) {
     emitCoverage(s->loc);
     llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "while.cond", fn_);
@@ -49,7 +81,7 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
     current_loc_ = s->loc;
     validateDirectives(s->directives);
     if (hasDirective(s->directives, "parallel")) {
-        if (s->var_names.size() > 1)
+        if (!isSingleVariableForBinding(s->binding))
             codegenError(s->loc, "@parallel for does not support destructuring iteration");
 
         validateParallelFor(*s);
@@ -120,19 +152,7 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
         pushScope();
 
         llvm::Value *elem = builder_.CreateExtractValue(opt, 1, "foriter_elem");
-
-        if (s->var_names.size() > 1) {
-            auto *structTy = llvm::dyn_cast<llvm::StructType>(iterElemTy);
-            if (!structTy)
-                codegenError("for loop destructuring requires tuple elements");
-            // Iterator-sourced tuples do not carry a Ry tuple type string
-            // today, so metadata propagation is skipped here. If iterators
-            // grow a source-level element-name slot, thread it through.
-            emitTupleDestructure(s->var_names, elem, structTy, /*tupleTypeName=*/"");
-        } else {
-            llvm::AllocaInst *loopVar = getOrCreateVar(s->var_names[0], iterElemTy);
-            builder_.CreateStore(elem, loopVar);
-        }
+        emitForBindingPattern(s->binding, elem, iterElemTy, /*valueTypeName=*/"");
 
         for (auto &stmt : s->body)
             std::visit([this](auto &st) { emitStmt(st); }, stmt);
@@ -147,7 +167,7 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
     }
 
     // Multi-variable iteration: for k, v in map  OR  for a, b, c in list_of_tuples
-    if (s->var_names.size() > 1) {
+    if (forBindingArity(s->binding) > 1) {
         llvm::Type *keyTy = getMapKeyType(iterable);
         llvm::Type *valTy = getMapValueType(iterable);
         if (!keyTy || !valTy) {
@@ -210,15 +230,15 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
                 llvm::Value *tuplePtr =
                     builder_.CreateGEP(structTy, dataPtr, {iCur}, "for_tuple_ptr");
                 llvm::Value *tuple = builder_.CreateLoad(structTy, tuplePtr, "for_tuple");
-                emitTupleDestructure(s->var_names, tuple, structTy, tupleTypeName);
+                emitForBindingPattern(s->binding, tuple, structTy, tupleTypeName);
             });
             return;
         }
 
         // Map iteration: always exactly 2 variables (key, value)
-        if (s->var_names.size() != 2)
+        if (forBindingArity(s->binding) != 2)
             codegenError("map iteration requires exactly 2 variables (key, value), got " +
-                         std::to_string(s->var_names.size()));
+                         std::to_string(forBindingArity(s->binding)));
 
         // Snapshot the iterable to prevent UAF when the source alias is
         // mutated inside the loop body (#1021, #1041). Applies when the
@@ -286,14 +306,11 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
             llvm::Value *key = builder_.CreateLoad(keyTy, keyPtr, "for_key");
             llvm::Value *valPtr = builder_.CreateGEP(valTy, valsPtr, {iCur}, "for_val_ptr");
             llvm::Value *val = builder_.CreateLoad(valTy, valPtr, "for_val");
-            llvm::AllocaInst *keyVar = getOrCreateVar(s->var_names[0], keyTy);
-            builder_.CreateStore(key, keyVar);
-            llvm::AllocaInst *valVar = getOrCreateVar(s->var_names[1], valTy);
-            builder_.CreateStore(val, valVar);
-            if (!keyTypeName.empty())
-                propagateTypeMeta(keyTypeName, keyVar);
-            if (!valTypeName.empty())
-                propagateTypeMeta(valTypeName, valVar);
+            llvm::Value *pair = llvm::UndefValue::get(llvm::StructType::get(*ctx_, {keyTy, valTy}));
+            pair = builder_.CreateInsertValue(pair, key, 0, "for_pair_key");
+            pair = builder_.CreateInsertValue(pair, val, 1, "for_pair_val");
+            emitForBindingPattern(s->binding, pair, pair->getType(),
+                                  "(" + keyTypeName + ", " + valTypeName + ")");
         });
         return;
     }
@@ -376,50 +393,52 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
         }
         llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {iCur}, "for_elem_ptr");
         llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "for_elem");
-        llvm::AllocaInst *loopVar = getOrCreateVar(s->var_names[0], elemTy);
-        builder_.CreateStore(elem, loopVar);
-        // Propagate Map/Set/closure element metadata for List<Map>, List<Set>, List<closure>
-        if (!elemTypeName.empty())
-            propagateTypeMeta(elemTypeName, loopVar);
-        if (elemFnTypeInfo)
-            getOrCreateMeta(loopVar).fn_type_info = *elemFnTypeInfo;
+        emitForBindingPattern(s->binding, elem, elemTy, elemTypeName);
+        if (elemFnTypeInfo) {
+            std::string loopVarName;
+            if (isSingleVariableForBinding(s->binding, &loopVarName)) {
+                if (llvm::AllocaInst *loopVar = findVar(loopVarName))
+                    getOrCreateMeta(loopVar).fn_type_info = *elemFnTypeInfo;
+            }
+        }
     });
 }
 
-void CodeGen::emitTupleDestructure(const std::vector<std::string> &var_names,
-                                    llvm::Value *tupleVal, llvm::StructType *structTy,
-                                    const std::string &tupleTypeName) {
-    if (structTy->getNumElements() != var_names.size())
+void CodeGen::emitForBindingPattern(const Pattern &pattern, llvm::Value *value,
+                                    llvm::Type *valueTy,
+                                    const std::string &valueTypeName) {
+    if (isWildcardForBinding(pattern))
+        return;
+
+    if (const auto *var = std::get_if<VariablePattern>(&pattern)) {
+        llvm::AllocaInst *loopVar = getOrCreateVar(var->name, valueTy);
+        builder_.CreateStore(value, loopVar);
+        if (!valueTypeName.empty())
+            propagateTypeMeta(valueTypeName, loopVar);
+        return;
+    }
+
+    auto *tuplePat = std::get_if<std::unique_ptr<TuplePattern>>(&pattern);
+    if (!tuplePat)
+        codegenError("for loop pattern only supports tuple destructuring");
+    auto *structTy = llvm::dyn_cast<llvm::StructType>(valueTy);
+    if (!structTy || !isTupleStructType(structTy))
+        codegenError("for loop destructuring requires tuple elements");
+
+    const auto elemSigs = splitTupleSig(valueTypeName);
+    if (structTy->getNumElements() != (*tuplePat)->elements.size())
         codegenError("for loop destructuring: expected " +
-                     std::to_string(var_names.size()) +
+                     std::to_string((*tuplePat)->elements.size()) +
                      "-element tuple, but got " +
                      std::to_string(structTy->getNumElements()) +
                      " elements");
-
-    // If the tuple type name is a Ry tuple literal like "(int, List<int>)",
-    // split the components so we can propagate per-element metadata onto the
-    // bound variables. Without this, destructured collection/enum elements
-    // degrade to `any` (#813). Resolve aliases first so `type Pair = (int,
-    // List<int>)` is treated identically to the literal form (PR #853 review).
-    // splitTypeArgs handles nested <> and ().
-    std::vector<std::string> componentNames;
-    const std::string tupleSig =
-        tupleTypeName.empty() ? tupleTypeName : resolveTypeAlias(tupleTypeName);
-    if (tupleSig.size() >= 2 && tupleSig.front() == '('
-            && tupleSig.back() == ')') {
-        componentNames = splitTypeArgs(
-            tupleSig.substr(1, tupleSig.size() - 2));
-        for (auto &n : componentNames)
-            n = trimTypeNameSpaces(n);
-    }
-
-    for (size_t i = 0; i < var_names.size(); ++i) {
-        if (var_names[i] == "_") continue;
-        llvm::Value *v = builder_.CreateExtractValue(tupleVal, static_cast<unsigned>(i), "for_elem_" + std::to_string(i));
-        llvm::AllocaInst *var = getOrCreateVar(var_names[i], structTy->getElementType(static_cast<unsigned>(i)));
-        builder_.CreateStore(v, var);
-        if (i < componentNames.size() && !componentNames[i].empty())
-            propagateTypeMeta(componentNames[i], var);
+    for (size_t i = 0; i < (*tuplePat)->elements.size(); ++i) {
+        llvm::Value *elem = builder_.CreateExtractValue(
+            value, static_cast<unsigned>(i), "for_elem_" + std::to_string(i));
+        llvm::Type *elemTy = structTy->getElementType(static_cast<unsigned>(i));
+        const std::string elemSig =
+            (i < elemSigs.size()) ? elemSigs[i] : std::string{};
+        emitForBindingPattern((*tuplePat)->elements[i], elem, elemTy, elemSig);
     }
 }
 
@@ -499,7 +518,9 @@ void CodeGen::emitStmt(EllipsisStmt &) {
 
 void CodeGen::validateParallelFor(const ForStmt &s) {
     std::vector<std::unordered_set<std::string>> localScopes(1);
-    for (const auto &name : s.var_names)
+    std::vector<std::string> bindingNames;
+    collectForBindingNames(s.binding, bindingNames);
+    for (const auto &name : bindingNames)
         localScopes.back().insert(name);
 
     auto isLocal = [&](const std::string &name) {
@@ -571,7 +592,9 @@ void CodeGen::validateParallelFor(const ForStmt &s) {
                 // classified as outer/module-global mutations when a
                 // same-named top-level binding exists (#817 follow-up).
                 localScopes.push_back({});
-                for (const auto &name : node->var_names) {
+                std::vector<std::string> nestedNames;
+                collectForBindingNames(node->binding, nestedNames);
+                for (const auto &name : nestedNames) {
                     if (name != "_")
                         localScopes.back().insert(name);
                 }
@@ -592,11 +615,15 @@ void CodeGen::validateParallelFor(const ForStmt &s) {
 }
 
 void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *end, llvm::Value *step) {
+    std::string loopVarName;
+    if (!isSingleVariableForBinding(s.binding, &loopVarName))
+        codegenError(s.loc, "@parallel for does not support destructuring iteration");
+
     std::vector<std::pair<std::string, llvm::AllocaInst*>> captures;
     std::unordered_set<std::string> seen;
     for (auto scopeIt = scope_stack_.rbegin(); scopeIt != scope_stack_.rend(); ++scopeIt) {
         for (const auto &[name, alloca] : *scopeIt) {
-            if (name == s.var_names[0] || seen.count(name))
+            if (name == loopVarName || seen.count(name))
                 continue;
             seen.insert(name);
             captures.push_back({name, alloca});
@@ -735,7 +762,7 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
             }
         }
 
-        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, s.var_names[0]);
+        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, loopVarName);
         builder_.CreateStore(chunkBegin, iVar);
 
         llvm::BasicBlock *condBB = llvm::BasicBlock::Create(*ctx_, "parallel.cond", thunk);
@@ -755,7 +782,7 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
 
         builder_.SetInsertPoint(bodyBB);
         pushScope();
-        scope_stack_.back()[s.var_names[0]] = iVar;
+        scope_stack_.back()[loopVarName] = iVar;
         for (auto &stmt : s.body)
             std::visit([this](auto &st) { emitStmt(st); }, stmt);
         popScope();

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -1,4 +1,5 @@
 #include "ry/formatter.hpp"
+#include <functional>
 
 
 namespace ry {
@@ -282,9 +283,27 @@ void Formatter::formatFor(const ForStmt &s) {
     formatDirectives(s.directives);
     if (!s.directives.empty()) emitIndent();
 
-    emit("for " + s.var_names[0]);
-    for (size_t i = 1; i < s.var_names.size(); ++i)
-        emit(", " + s.var_names[i]);
+    std::function<std::string(const Pattern &, bool)> formatForBinding =
+        [&](const Pattern &pat, bool topLevel) -> std::string {
+            if (auto *tp = std::get_if<std::unique_ptr<TuplePattern>>(&pat)) {
+                std::string result;
+                if (!topLevel)
+                    result += "(";
+                for (size_t i = 0; i < (*tp)->elements.size(); ++i) {
+                    if (i > 0)
+                        result += ", ";
+                    result += formatForBinding((*tp)->elements[i], false);
+                }
+                if ((*tp)->elements.size() == 1)
+                    result += ",";
+                if (!topLevel)
+                    result += ")";
+                return result;
+            }
+            return formatPattern(pat);
+        };
+
+    emit("for " + formatForBinding(s.binding, true));
     emit(" in " + formatExpr(*s.iterable) + ":");
     emitInlineComment(s.loc.line);
     emitNewline();

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -287,7 +287,8 @@ void Formatter::formatFor(const ForStmt &s) {
         [&](const Pattern &pat, bool topLevel) -> std::string {
             if (auto *tp = std::get_if<std::unique_ptr<TuplePattern>>(&pat)) {
                 std::string result;
-                if (!topLevel)
+                const bool wrap = !topLevel || (*tp)->elements.size() == 1;
+                if (wrap)
                     result += "(";
                 for (size_t i = 0; i < (*tp)->elements.size(); ++i) {
                     if (i > 0)
@@ -296,7 +297,7 @@ void Formatter::formatFor(const ForStmt &s) {
                 }
                 if ((*tp)->elements.size() == 1)
                     result += ",";
-                if (!topLevel)
+                if (wrap)
                     result += ")";
                 return result;
             }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -783,29 +783,44 @@ StmtNode Parser::parseWhileStatement() {
 StmtNode Parser::parseForStatement() {
     Token forTok = lex_.next(); // consume 'for'
 
-    std::vector<std::string> var_names;
+    Pattern binding;
+    if (lex_.peek().kind == TokenKind::LParen) {
+        binding = parsePattern();
+    } else {
+        Token firstTok = lex_.peek();
+        if (firstTok.kind != TokenKind::Ident)
+            parseError(firstTok.line, "expected variable name after 'for'");
+        if (firstTok.value == "_")
+            binding = WildcardPattern{};
+        else
+            binding = VariablePattern{firstTok.value};
+        lex_.next(); // consume first binding token
 
-    Token varTok = lex_.peek();
-    if (varTok.kind != TokenKind::Ident)
-        parseError(varTok.line, "expected variable name after 'for'");
-    if (!isSnakeCase(varTok.value))
-        parseError(varTok.line, "loop variable name '" + varTok.value + "' must be snake_case");
-    lex_.next(); // consume var name
-    var_names.push_back(varTok.value);
-
-    while (lex_.peek().kind == TokenKind::Comma) {
-        lex_.next(); // consume ','
-        Token vTok = lex_.peek();
-        if (vTok.kind != TokenKind::Ident)
-            parseError(vTok.line, "expected variable name after ',' in for loop");
-        if (!isSnakeCase(vTok.value))
-            parseError(vTok.line, "loop variable name '" + vTok.value + "' must be snake_case");
-        lex_.next(); // consume var
-        var_names.push_back(vTok.value);
+        if (lex_.peek().kind == TokenKind::Comma) {
+            auto tuple = std::make_unique<TuplePattern>();
+            tuple->elements.push_back(std::move(binding));
+            while (lex_.peek().kind == TokenKind::Comma) {
+                lex_.next(); // consume ','
+                if (lex_.peek().kind == TokenKind::LParen) {
+                    tuple->elements.push_back(parsePattern());
+                    continue;
+                }
+                Token vTok = lex_.peek();
+                if (vTok.kind != TokenKind::Ident)
+                    parseError(vTok.line, "expected variable name after ',' in for loop");
+                if (vTok.value == "_")
+                    tuple->elements.push_back(WildcardPattern{});
+                else
+                    tuple->elements.push_back(VariablePattern{vTok.value});
+                lex_.next(); // consume var
+            }
+            binding = std::move(tuple);
+        }
     }
+    validateForBindingPattern(binding);
 
     if (lex_.peek().kind != TokenKind::In)
-        parseError("expected 'in' after variable name in for loop");
+        parseError("expected 'in' after for loop binding");
     lex_.next(); // consume 'in'
 
     ExprPtr iterable = parseConditional();
@@ -815,7 +830,7 @@ StmtNode Parser::parseForStatement() {
     lex_.next(); // consume ':'
 
     auto forStmt = std::make_unique<ForStmt>();
-    forStmt->var_names = std::move(var_names);
+    forStmt->binding = std::move(binding);
     forStmt->iterable = std::move(iterable);
     forStmt->body = parseBlock();
     forStmt->loc = locFromToken(forTok);

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -855,6 +855,23 @@ bool Parser::patternHasBinding(const Pattern &p) {
     return false;
 }
 
+void Parser::validateForBindingPattern(const Pattern &p) {
+    std::visit([&](const auto &pat) {
+        using T = std::decay_t<decltype(pat)>;
+        if constexpr (std::is_same_v<T, WildcardPattern>) {
+            return;
+        } else if constexpr (std::is_same_v<T, VariablePattern>) {
+            if (!isSnakeCase(pat.name))
+                parseError("loop variable name '" + pat.name + "' must be snake_case");
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {
+            for (const auto &elem : pat->elements)
+                validateForBindingPattern(elem);
+        } else {
+            parseError("for loop pattern only supports variables, '_', and tuple destructuring");
+        }
+    }, p);
+}
+
 void Parser::parseOrPattern(Pattern &pat) {
     if (lex_.peek().kind != TokenKind::Pipe) return;
     auto orPat = std::make_unique<OrPattern>();

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2357,6 +2357,14 @@ TEST_F(CodeGenTest, ForThreeVarWildcardMiddle) {
     EXPECT_EQ(runSource(src), "14\n");
 }
 
+TEST_F(CodeGenTest, ForNestedTupleDestructuring) {
+    std::string src =
+        "items = [(\"a\", 1), (\"b\", 2), (\"c\", 3)]\n"
+        "for i, (k, v) in enumerate(items):\n"
+        "    print(to_str(i) + \": \" + k + \"=\" + to_str(v))";
+    EXPECT_EQ(runSource(src), "0: a=1\n1: b=2\n2: c=3\n");
+}
+
 TEST_F(CodeGenTest, ForThreeVarCountMismatch) {
     std::string src =
         "pairs = [(1, 2), (3, 4)]\n"

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -219,6 +219,12 @@ TEST(Formatter, ControlFlow) {
         auto expected = "for k, v in m:\n  total += v\n";
         EXPECT_EQ(fmt(src), expected);
     }
+    // For loop with nested tuple destructuring
+    {
+        auto src = "for i,(k,v) in enumerate(items):\n    print(k)\n";
+        auto expected = "for i, (k, v) in enumerate(items):\n  print(k)\n";
+        EXPECT_EQ(fmt(src), expected);
+    }
     // While loop
     {
         auto src = "while i < 5:\n    i += 1\n";

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -225,6 +225,12 @@ TEST(Formatter, ControlFlow) {
         auto expected = "for i, (k, v) in enumerate(items):\n  print(k)\n";
         EXPECT_EQ(fmt(src), expected);
     }
+    // For loop with top-level 1-tuple binding must keep parentheses
+    {
+        auto src = "for (x,) in xs:\n    print(x)\n";
+        auto expected = "for (x,) in xs:\n  print(x)\n";
+        EXPECT_EQ(fmt(src), expected);
+    }
     // While loop
     {
         auto src = "while i < 5:\n    i += 1\n";

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1635,27 +1635,54 @@ TEST(ParserTest, ForKVParsing) {
     Program prog = parseStr("for k, v in m:\n    print(k)");
     ASSERT_EQ(prog.size(), 1u);
     auto &fs = std::get<std::unique_ptr<ForStmt>>(prog[0]);
-    ASSERT_EQ(fs->var_names.size(), 2u);
-    EXPECT_EQ(fs->var_names[0], "k");
-    EXPECT_EQ(fs->var_names[1], "v");
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<TuplePattern>>(fs->binding));
+    const auto &tp = *std::get<std::unique_ptr<TuplePattern>>(fs->binding);
+    ASSERT_EQ(tp.elements.size(), 2u);
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(tp.elements[0]));
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(tp.elements[1]));
+    EXPECT_EQ(std::get<VariablePattern>(tp.elements[0]).name, "k");
+    EXPECT_EQ(std::get<VariablePattern>(tp.elements[1]).name, "v");
 }
 
 TEST(ParserTest, ForThreeVariableDestructuring) {
     Program prog = parseStr("for a, b, c in xs:\n    print(a)");
     ASSERT_EQ(prog.size(), 1u);
     auto &fs = std::get<std::unique_ptr<ForStmt>>(prog[0]);
-    ASSERT_EQ(fs->var_names.size(), 3u);
-    EXPECT_EQ(fs->var_names[0], "a");
-    EXPECT_EQ(fs->var_names[1], "b");
-    EXPECT_EQ(fs->var_names[2], "c");
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<TuplePattern>>(fs->binding));
+    const auto &tp = *std::get<std::unique_ptr<TuplePattern>>(fs->binding);
+    ASSERT_EQ(tp.elements.size(), 3u);
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(tp.elements[0]));
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(tp.elements[1]));
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(tp.elements[2]));
+    EXPECT_EQ(std::get<VariablePattern>(tp.elements[0]).name, "a");
+    EXPECT_EQ(std::get<VariablePattern>(tp.elements[1]).name, "b");
+    EXPECT_EQ(std::get<VariablePattern>(tp.elements[2]).name, "c");
+}
+
+TEST(ParserTest, ForNestedTupleDestructuring) {
+    Program prog = parseStr("for i, (k, v) in enumerate(xs):\n    print(k)");
+    ASSERT_EQ(prog.size(), 1u);
+    auto &fs = std::get<std::unique_ptr<ForStmt>>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<TuplePattern>>(fs->binding));
+    const auto &outer = *std::get<std::unique_ptr<TuplePattern>>(fs->binding);
+    ASSERT_EQ(outer.elements.size(), 2u);
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(outer.elements[0]));
+    EXPECT_EQ(std::get<VariablePattern>(outer.elements[0]).name, "i");
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<TuplePattern>>(outer.elements[1]));
+    const auto &inner = *std::get<std::unique_ptr<TuplePattern>>(outer.elements[1]);
+    ASSERT_EQ(inner.elements.size(), 2u);
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(inner.elements[0]));
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(inner.elements[1]));
+    EXPECT_EQ(std::get<VariablePattern>(inner.elements[0]).name, "k");
+    EXPECT_EQ(std::get<VariablePattern>(inner.elements[1]).name, "v");
 }
 
 TEST(ParserTest, ForChannelParsing) {
     Program prog = parseStr("for x in ch:\n    print(x)");
     ASSERT_EQ(prog.size(), 1u);
     auto &fs = std::get<std::unique_ptr<ForStmt>>(prog[0]);
-    ASSERT_EQ(fs->var_names.size(), 1u);
-    EXPECT_EQ(fs->var_names[0], "x");
+    ASSERT_TRUE(std::holds_alternative<VariablePattern>(fs->binding));
+    EXPECT_EQ(std::get<VariablePattern>(fs->binding).name, "x");
     auto *iter = std::get_if<VariableExpr>(&fs->iterable->data);
     ASSERT_NE(iter, nullptr);
     EXPECT_EQ(iter->name, "ch");

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1677,6 +1677,11 @@ TEST(ParserTest, ForNestedTupleDestructuring) {
     EXPECT_EQ(std::get<VariablePattern>(inner.elements[1]).name, "v");
 }
 
+TEST(ParserTest, ForBindingRejectsUnsupportedPatterns) {
+    EXPECT_THROW(parseStr("for Some(x) in xs:\n    print(x)"), std::runtime_error);
+    EXPECT_THROW(parseStr("for Point(x, y) in xs:\n    print(x)"), std::runtime_error);
+}
+
 TEST(ParserTest, ForChannelParsing) {
     Program prog = parseStr("for x in ch:\n    print(x)");
     ASSERT_EQ(prog.size(), 1u);


### PR DESCRIPTION
## Summary
- allow nested tuple destructuring in `for` loop bindings, including `enumerate` cases like `for i, (k, v) in ...`
- switch `ForStmt` from flat variable-name storage to a restricted binding pattern so parser, codegen, and formatter handle nested tuple shapes consistently
- add parser/codegen/formatter regression coverage and document the nested destructuring form

## Testing
- cmake --build build
- ./build/ry_tests --gtest_filter="ParserTest.For*:*Formatter.ControlFlow:*CodeGenTest.For*"
- ./build/ry test tests/spec/for_mutation.test.ry tests/spec/for_mutation_field.test.ry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Loop bindings now support general pattern-based destructuring, including nested tuple destructuring and combined index+tuple captures.

* **Documentation**
  * Added example showing nested tuple destructuring in a for-loop header.

* **Refactor**
  * Internal loop binding handling unified around pattern semantics (no visible API changes).

* **Tests**
  * Added/updated parser, formatter, and codegen tests covering nested destructuring and invalid patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->