### PR TITLE
feat: adopt fn syntax and len alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 - **F-String** — String interpolation with `f"Hello {name}"`
 - **Design by Contract** — `require` (preconditions), `ensure` (postconditions), `invariant` (record invariants)
 - **Directives** — `@deprecated`, `@const`, `@native`, `@parallel`, `@inline`, `@each`, `@property`, `@describe`, `@it` and other compile-time metadata annotations
-- **Functions** — `function` definitions, recursion, overloading, lambdas (closures), higher-order functions, UFCS
+- **Functions** — `fn` definitions, recursion, overloading, lambdas (closures), higher-order functions, UFCS
 - **Control Flow** — `if`/`else`, `case`, `while`, `for...in`, `break`/`continue`
 - **File I/O** — File read/write, byte operations, standard input (`std.io`)
 - **Filesystem** — Directory listing, recursive walk, glob, copy, move, remove, permissions (`std.filesystem`)
@@ -35,7 +35,7 @@ name: str = "hello"
 pi = 3.14159
 
 # Function definition
-function factorial(n: int) -> int:
+fn factorial(n: int) -> int:
     if n <= 1:
         return 1
     return n * factorial(n - 1)
@@ -52,7 +52,7 @@ record Point:
     x: int
     y: int
 
-function operator+(a: Point, b: Point) -> Point:
+fn operator+(a: Point, b: Point) -> Point:
     return Point(a.x + b.x, a.y + b.y)
 
 p = Point(1, 2) + Point(3, 4)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -758,7 +758,8 @@ public:
     // (null for non-capturing functions). Layout mirrored in
     // `getOrCreateUniformClosureDestructor` in src/codegen_lambda.cpp.
     static bool isFunctionTypeName(const std::string &s) {
-        return s.size() > 9 && s.compare(0, 9, "function(") == 0;
+        return (s.size() > 3 && s.compare(0, 3, "fn(") == 0) ||
+               (s.size() > 9 && s.compare(0, 9, "function(") == 0);
     }
     llvm::StructType *getUniformClosureTy() {
         if (!uniformClosureTy_)

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -210,7 +210,7 @@ void CodeGen::propagateReturnFnTypeMeta(const OverloadEntry *entry, llvm::Functi
     }
     if (!entry) return;
     std::string resolved = resolveTypeAlias(entry->returnTypeName);
-    if (resolved.size() <= 9 || resolved.compare(0, 9, "function(") != 0) return;
+    if (!isFunctionTypeName(resolved)) return;
     getOrCreateMeta(result).fn_type_info = parseFnTypeAnnotation(resolved);
 }
 
@@ -293,7 +293,7 @@ std::string CodeGen::inferCollectionTypeName(llvm::Value *val) {
 }
 
 // Reconstruct a canonical source-level type name (e.g. "List<int>",
-// "Map<str, bool>", "function(int) -> str") from a value's collection /
+// "Map<str, bool>", "fn(int) -> str") from a value's collection /
 // function metadata.  Used by wrapInUnion() to disambiguate same-LLVM-type
 // variants like `List<int> | List<str>` by comparing the reconstructed name
 // against each component name.  Returns "" if the value has no collection /
@@ -345,7 +345,7 @@ std::string CodeGen::buildTypeNameFromMeta(llvm::Value *val) {
     }
     if (meta->fn_type_info) {
         const auto &info = *meta->fn_type_info;
-        std::string result = "function(";
+        std::string result = "fn(";
         for (size_t i = 0; i < info.paramTypes.size(); ++i) {
             if (i > 0) result += ", ";
             result += reverseResolveTypeName(info.paramTypes[i]);

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -749,8 +749,8 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         return headerPtr;
     }
 
-    // length(xs) → list/map/array length — fall through for JsonValue
-    if (e.callee == "length") {
+    // length(xs) / len(xs) → list/map/array length — fall through for JsonValue
+    if (e.callee == "length" || e.callee == "len") {
         requireArgs(e, 1);
         llvm::Value *ptr = emitExpr(*e.args[0]);
         if (isJsonValue(ptr)) return nullptr;

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -257,7 +257,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         std::string resolvedType = resolveTypeAlias(*typeName);
         if (isLowLevelTypeName(resolvedType))
             getOrCreateMeta(alloca).low_level_type_name = resolvedType;
-        if (resolvedType.size() > 9 && resolvedType.compare(0, 9, "function(") == 0)
+        if (isFunctionTypeName(resolvedType))
             getOrCreateMeta(alloca).fn_type_info = parseFnTypeAnnotation(resolvedType);
         auto constraint = parseTypeConstraint(resolvedType);
         if (constraint)

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -121,7 +121,7 @@ void CodeGen::applyParamTypeMeta(const std::string &ptype,
         markArcManaged(alloca);
     {
         std::string resolvedPtype = resolveTypeAlias(ptype);
-        if (resolvedPtype.size() > 9 && resolvedPtype.compare(0, 9, "function(") == 0)
+        if (isFunctionTypeName(resolvedPtype))
             getOrCreateMeta(alloca).fn_type_info = parseFnTypeAnnotation(resolvedPtype);
         auto constraint = parseTypeConstraint(resolvedPtype);
         if (constraint) {

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -228,7 +228,7 @@ std::string CodeGen::reverseResolveType(llvm::Value *val) {
         auto *meta = getMeta(val);
         if (meta && meta->fn_type_info) {
             auto &fti = *meta->fn_type_info;
-            std::string result = "function(";
+            std::string result = "fn(";
             for (size_t i = 0; i < fti.paramTypeNames.size(); ++i) {
                 if (i > 0) result += ",";
                 result += fti.paramTypeNames[i];
@@ -317,8 +317,14 @@ static bool splitFunctionTypeName(const std::string &s,
                                    std::vector<std::string> &params,
                                    std::string &returnType) {
     std::string t = trimWs(s);
-    const std::string prefix = "function(";
-    if (t.rfind(prefix, 0) != 0) return false;
+    std::string prefix;
+    if (t.rfind("fn(", 0) == 0) {
+        prefix = "fn(";
+    } else if (t.rfind("function(", 0) == 0) {
+        prefix = "function(";
+    } else {
+        return false;
+    }
     int depth = 1;
     size_t i = prefix.size();
     for (; i < t.size() && depth > 0; ++i) {

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -846,11 +846,11 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
                 return nativeRet;
             return "";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
-            // Build "function(t1, t2) -> r" from declared annotations.
+            // Build canonical "fn(t1, t2) -> r" from declared annotations.
             // A missing annotation (no TypeNode) means we can't build
             // a shaped name and bail — but `any` is a legitimate
             // annotation and is preserved.
-            std::string out = "function(";
+            std::string out = "fn(";
             for (size_t i = 0; i < v->params.size(); ++i) {
                 if (!v->params[i].type) return "";
                 std::string pn = v->params[i].type->toString();

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -335,7 +335,7 @@ void CodeGen::emitVarDecl(const std::string &name,
         // (`list_elem_is_str`) to avoid flipping destructor dispatch (#1266).
         if (inner == "str")
             getOrCreateMeta(ptr).list_elem_is_str = true;
-        else if (inner.size() > 9 && inner.substr(0, 9) == "function(")
+        else if (isFunctionTypeName(inner))
             getOrCreateMeta(ptr).list_elem_fn_type_info = parseFnTypeAnnotation(inner);
         else if (inner != "int" && inner != "float" && inner != "bool")
             getOrCreateMeta(ptr).list_elem_type_name = inner;
@@ -653,7 +653,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                 if (isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
                     std::string inner = resolved.substr(5, resolved.size() - 6);
                     while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
-                    if (inner.size() > 9 && inner.substr(0, 9) == "function(") {
+                    if (isFunctionTypeName(inner)) {
                         lefti = parseFnTypeAnnotation(inner);
                     } else if (inner == "str") {
                         // List<str>: don't stamp list_elem_type_name (that
@@ -811,7 +811,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             if (valMeta && valMeta->fn_type_info) {
                 getOrCreateMeta(ptr).fn_type_info = *valMeta->fn_type_info;
             } else if (annot) {
-                if (resolvedAnnot.size() > 9 && resolvedAnnot.substr(0, 9) == "function(") {
+                if (isFunctionTypeName(resolvedAnnot)) {
                     getOrCreateMeta(ptr).fn_type_info = parseFnTypeAnnotation(resolvedAnnot);
                 }
             }

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -163,7 +163,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
     }
 
     // fn(...) -> T function type → opaque pointer
-    if (typeName.size() > 9 && typeName.compare(0, 9, "function(") == 0) {
+    if (isFunctionTypeName(typeName)) {
         return ptrTy_;
     }
 
@@ -453,7 +453,7 @@ size_t CodeGen::findMatchingCloseParen(const std::string &s, size_t openParen) {
 }
 
 CodeGen::FnTypeInfo CodeGen::parseFnTypeAnnotation(const std::string &typeStr) {
-    // Parse "function(int, float) -> int"
+    // Parse canonical "fn(int, float) -> int" and the legacy "function(...)" alias.
     FnTypeInfo info;
     // Find the opening paren
     size_t openParen = typeStr.find('(');

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -46,6 +46,7 @@ static const std::unordered_map<std::string, TokenKind> keyword_map = {
     {"break",     TokenKind::Break},
     {"continue",  TokenKind::Continue},
     {"function",  TokenKind::Fn},
+    {"fn",        TokenKind::Fn},
     {"return",    TokenKind::Return},
     {"from",      TokenKind::From},
     {"import",    TokenKind::Import},

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -439,7 +439,7 @@ StmtNode Parser::parseStatement() {
     if (first.kind == TokenKind::Async) {
         lex_.next(); // consume 'async'
         if (lex_.peek().kind != TokenKind::Fn)
-            parseError(first.line, "expected 'function' after 'async'");
+            parseError(first.line, "expected 'fn' or 'function' after 'async'");
         auto stmt = parseFnStatement(directives, true);
         auto &fs = std::get<std::unique_ptr<FnStmt>>(stmt);
         fs->directives = std::move(directives);

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -42,7 +42,7 @@ TypeParam Parser::parseOneTypeParam() {
 
 
 StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool is_async) {
-    Token fnTok = lex_.next(); // consume 'function'
+    Token fnTok = lex_.next(); // consume 'fn' / 'function'
 
     auto fnStmt = std::make_unique<FnStmt>();
     fnStmt->params.reserve(4);
@@ -128,7 +128,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
     } else {
         Token nameTok = lex_.peek();
         if (nameTok.kind != TokenKind::Ident)
-            parseError(nameTok.line, "expected function name after 'function'");
+            parseError(nameTok.line, "expected function name after 'fn'");
         bool validName = isMutationFnName(nameTok.value) ||
                          (hasDirective(directives, "native") && isScreamingSnakeCase(nameTok.value));
         if (!validName)
@@ -136,7 +136,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         lex_.next(); // consume name
         fnStmt->name = nameTok.value;
 
-        // Parse optional type parameters: function name<T, U>(...) or function name<T: Bound>(...)
+        // Parse optional type parameters: fn name<T, U>(...) or fn name<T: Bound>(...)
         if (lex_.peek().kind == TokenKind::Less) {
             lex_.next(); // consume '<'
             fnStmt->type_params.reserve(2);
@@ -686,9 +686,9 @@ TypeNodePtr Parser::parseTypeNameSingle() {
         return TypeNode::makeTuple(std::move(elements));
     }
 
-    // function(int, int) -> int  function type
+    // fn(int, int) -> int  function type
     if (lex_.peek().kind == TokenKind::Fn) {
-        lex_.next(); // consume 'function'
+        lex_.next(); // consume 'fn' / 'function'
         return parseFnType();
     }
 
@@ -810,7 +810,7 @@ TypeNodePtr Parser::parseTypeNameSingle() {
 
 TypeNodePtr Parser::parseFnType() {
     if (lex_.peek().kind != TokenKind::LParen)
-        parseError("expected '(' after 'function' in function type");
+        parseError("expected '(' after 'fn' in function type");
     lex_.next(); // consume '('
     std::vector<TypeNodePtr> paramTypes;
     paramTypes.reserve(4);

--- a/src/type_node.cpp
+++ b/src/type_node.cpp
@@ -32,7 +32,7 @@ std::string TypeNode::toString() const {
             result += ")";
             return result;
         } else if constexpr (std::is_same_v<T, FnType>) {
-            std::string result = "function(";
+            std::string result = "fn(";
             for (size_t i = 0; i < v.param_types.size(); ++i) {
                 if (i > 0) result += ", ";
                 result += v.param_types[i]->toString();

--- a/tests/spec/fn_len_alias.test.ry
+++ b/tests/spec/fn_len_alias.test.ry
@@ -1,0 +1,26 @@
+fn add(x: int, y: int) -> int:
+  return x + y
+
+fn apply(f: fn(int) -> int, x: int) -> int:
+  return f(x)
+
+describe("fn and len aliases", ():
+  it("accepts fn declarations and fn type annotations", ():
+    expect(add(2, 3)).to_eq(5)
+    expect(apply((x: int) => x * 2, 4)).to_eq(8)
+  )
+
+  it("keeps function as a backward-compatible alias", ():
+    function dec(x: int) -> int:
+      return x - 1
+
+    expect(dec(5)).to_eq(4)
+  )
+
+  it("accepts len() as an alias for length()", ():
+    xs = [1, 2, 3]
+    expect(len(xs)).to_eq(3)
+    expect(len("あいu")).to_eq(3)
+    expect(length(xs)).to_eq(3)
+  )
+)

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -149,11 +149,11 @@ TEST(LexerTest, KeywordRecognition) {
         EXPECT_EQ(toks[0].kind, TokenKind::Fn);
         EXPECT_EQ(toks[0].value, "function");
     }
-    // fn is no longer a keyword
+    // fn
     {
         auto toks = tokenize("fn");
         ASSERT_EQ(toks.size(), 2u);
-        EXPECT_EQ(toks[0].kind, TokenKind::Ident);
+        EXPECT_EQ(toks[0].kind, TokenKind::Fn);
         EXPECT_EQ(toks[0].value, "fn");
     }
     // return

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1710,6 +1710,15 @@ TEST(ParserTest, AsyncFnParsing) {
     EXPECT_EQ(function->return_type->toString(), "int");
 }
 
+TEST(ParserTest, AsyncFnCanonicalParsing) {
+    Program prog = parseStr("async fn add(a: int, b: int) -> int:\n    return a + b");
+    ASSERT_EQ(prog.size(), 1u);
+    auto &function = std::get<std::unique_ptr<FnStmt>>(prog[0]);
+    EXPECT_TRUE(function->is_async);
+    EXPECT_EQ(function->name, "add");
+    EXPECT_EQ(function->return_type->toString(), "int");
+}
+
 TEST(ParserTest, AwaitExprParsing) {
     // await inside async function should parse successfully
     Program prog = parseStr(
@@ -1935,7 +1944,14 @@ TEST(ParserTest, TypeAliasFnType) {
     Program prog = parseStr("type Callback = function(int, int) -> int");
     auto &ta = std::get<TypeAliasStmt>(prog[0]);
     EXPECT_EQ(ta.name, "Callback");
-    EXPECT_EQ(ta.target_type->toString(), "function(int, int) -> int");
+    EXPECT_EQ(ta.target_type->toString(), "fn(int, int) -> int");
+}
+
+TEST(ParserTest, TypeAliasCanonicalFnType) {
+    Program prog = parseStr("type Callback = fn(int, int) -> int");
+    auto &ta = std::get<TypeAliasStmt>(prog[0]);
+    EXPECT_EQ(ta.name, "Callback");
+    EXPECT_EQ(ta.target_type->toString(), "fn(int, int) -> int");
 }
 
 TEST(ParserTest, SnakeCaseForLoopVariable) {
@@ -2206,6 +2222,7 @@ TEST(ParserTest, RejectAnonymousFunctionLambdaBlock) {
 
 TEST(ParserTest, RejectAnonymousFunctionLambdaNoParams) {
     EXPECT_THROW(parseStr("f = function() => 42"), std::runtime_error);
+    EXPECT_THROW(parseStr("f = fn() => 42"), std::runtime_error);
 }
 
 // ===== Cast expression with generic types (#490) =====
@@ -2634,7 +2651,7 @@ TEST(ParserTest, FnTypeTrailingComma) {
     Program prog = parseStr("type Callback = function(int, int,) -> int");
     ASSERT_EQ(prog.size(), 1u);
     auto &ta = std::get<TypeAliasStmt>(prog[0]);
-    EXPECT_EQ(ta.target_type->toString(), "function(int, int) -> int");
+    EXPECT_EQ(ta.target_type->toString(), "fn(int, int) -> int");
 }
 
 TEST(ParserTest, GenericTypeArgTrailingComma) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -559,11 +559,8 @@ TEST(ParserTest, FunctionKeywordSimple) {
     EXPECT_EQ(function.return_type->toString(), "int");
 }
 
-TEST(ParserTest, FnIdentifierIsAllowed) {
-    Program prog = parseStr("fn = 1\nx = fn + 2");
-    ASSERT_EQ(prog.size(), 2u);
-    ASSERT_TRUE(std::holds_alternative<AssignStmt>(prog[0]));
-    ASSERT_TRUE(std::holds_alternative<AssignStmt>(prog[1]));
+TEST(ParserTest, FnIdentifierIsRejected) {
+    EXPECT_THROW(parseStr("fn = 1\nx = fn + 2"), std::runtime_error);
 }
 
 TEST(ParserTest, ReturnStatement) {


### PR DESCRIPTION
## Summary
- add `fn` as the canonical syntax for function declarations and function types while keeping `function` as a compatible alias
- add `len()` as an alias for `length()` and update canonical type rendering/docs to prefer `fn`
- add parser/lexer regressions and a Ry spec covering `fn` and `len()` behavior

## Testing
- `cmake --build build`
- `./build/ry_tests --gtest_filter="LexerTest.KeywordRecognition:ParserTest.AsyncFnParsing:ParserTest.AsyncFnCanonicalParsing:ParserTest.TypeAliasFnType:ParserTest.TypeAliasCanonicalFnType:ParserTest.RejectAnonymousFunctionLambdaNoParams:ParserTest.FnTypeTrailingComma:FindMatchingCloseParen.*"`
- `./build/ry test tests/spec/fn_len_alias.test.ry`

Refs #1307

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced `fn` as the canonical keyword and function-type syntax; `function` remains a backward-compatible alias.
  * Added `len()` as an alias for `length()` for arrays and strings.

* **Documentation**
  * Updated language examples and feature descriptions to use the `fn` syntax.

* **Tests**
  * Added and updated tests to validate `fn` parsing, canonical type formatting, async-`fn` parsing, and the `len()` alias.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->