### PR TITLE
feat: add default delimiter to str split

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3291,6 +3291,30 @@ surfaces missing registration. Compile-only tests do not catch this
 because the dispatcher succeeds at IR emission; the failure is deferred
 to JIT symbol lookup.
 
+### Builtin native-underscore wrappers must update the builtin dispatcher too
+
+**Source**: #1277 (2026-04-23, implementation)
+**Tags**: stdlib, builtin, wrapper, default-args, ufcs, codegen
+
+**Rule**: When converting a bare builtin in `share/std/*.ry` from a direct
+`@native function name(...)` declaration to the native-underscore wrapper
+pattern (`@native function _name(...)` + `function name(... = default)`),
+update the C++ builtin dispatcher as well.
+
+**Why**: Bare builtins like `split` are intercepted before ordinary Ry
+function resolution. Two separate changes may be required:
+
+- Register the underscored alias (for example `"_split"`) in the relevant
+  dispatch table (`emitBuiltinString`, `emitBuiltinCore`, etc.), otherwise the
+  wrapper body itself fails with `undefined function: _name`.
+- Mirror any new optional arity/default-argument behavior in the builtin
+  emitter, because UFCS/direct builtin calls may still route through the C++
+  handler instead of the Ry wrapper body.
+
+**How to apply**: After introducing a builtin wrapper, test both forms:
+ordinary call syntax (`name(...)`) and UFCS (`value.name(...)` when
+supported). A passing spec for only one path is not enough.
+
 ### `Match` type is registered programmatically in codegen, not via a `record` declaration in regex.ry
 
 **Source**: #830 (2026-04-14, implementation)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -56,7 +56,7 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 
 | Function | Signature | Description |
 |------|-----------|------|
-| `split` | `(str, str) -> List<str>` | Split by delimiter |
+| `split` | `(str, str = " ") -> List<str>` | Split by delimiter |
 | `join` | `(List<str>, str) -> str` | Join with separator |
 
 ### Type Conversion
@@ -309,7 +309,7 @@ Both `string` and `delimiter` may contain embedded NUL bytes (`\0`); all paths a
 
 ```ry
 parts = "1 2 3".split()
-print(parts)   # [1, 2, 3]
+print(parts)   # ["1", "2", "3"]
 
 parts = split("a,b,c", ",")
 print(parts[0])   # a

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -298,15 +298,19 @@ print(byte_len("a\0b"))    # 3 (NUL byte is counted)
 
 ## split
 
-**Signature:** `split(string: str, delimiter: str) -> List<str>`
+**Signature:** `split(string: str, delimiter: str = " ") -> List<str>`
 
 Splits string `string` by delimiter `delimiter` and returns a `List<str>`.
+When `delimiter` is omitted, it defaults to a single space `" "`.
 
 When the delimiter is an empty string `""`, the string is split into individual characters (UTF-8 aware).
 
 Both `string` and `delimiter` may contain embedded NUL bytes (`\0`); all paths are NUL-safe (#1051).
 
 ```ry
+parts = "1 2 3".split()
+print(parts)   # [1, 2, 3]
+
 parts = split("a,b,c", ",")
 print(parts[0])   # a
 print(parts[1])   # b

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -138,7 +138,7 @@ All functions accept `int` or any low-level integer type (`i8`..`i64`, `u8`..`u6
 | `trim(string)` / `trim_start(string)` / `trim_end(string)` | Whitespace removal |
 | `repeat(string, count)` | Repeat a string n times |
 | `reverse(string)` | Reverse a string |
-| `split(string, delimiter)` | Split a string into a list |
+| `split(string, delimiter = " ")` | Split a string into a list |
 | `join(list, sep)` | Join list elements with a separator |
 | `to_int(s)` / `to_float(s)` / `to_str(v)` | Type conversion (`to_int` and `to_float` return `Result<T, Error>`) |
 

--- a/share/std/str.ry
+++ b/share/std/str.ry
@@ -54,7 +54,10 @@ function repeat(string: str, count: int) -> str
 function reverse(string: str) -> str
 
 @native
-function split(string: str, delimiter: str) -> List<str>
+function _split(string: str, delimiter: str) -> List<str>
+
+function split(string: str, delimiter: str = " ") -> List<str>:
+    return _split(string, delimiter)
 
 @native
 function join(values: List<str>, delimiter: str) -> str

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -38,6 +38,7 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
         {"repeat",      &CodeGen::emitStrOp_repeat},
         {"reverse",     &CodeGen::emitStrOp_reverse},
         {"split",       &CodeGen::emitStrOp_split},
+        {"_split",      &CodeGen::emitStrOp_split},
         {"join",        &CodeGen::emitStrOp_join},
     };
     auto it = dispatch.find(e.callee);
@@ -643,11 +644,14 @@ llvm::Value *CodeGen::emitStrOp_reverse(const CallExpr &e) {
     return r;
 }
 
-// split(s, delim) → List<str>
+// split(s[, delim]) → List<str>
 llvm::Value *CodeGen::emitStrOp_split(const CallExpr &e) {
-    requireArgs(e, 2);
+    if (e.args.size() < 1 || e.args.size() > 2)
+        codegenError("split() takes 1 or 2 arguments");
     llvm::Value *s = emitExpr(*e.args[0]);
-    llvm::Value *delim = emitExpr(*e.args[1]);
+    llvm::Value *delim = (e.args.size() == 2)
+        ? emitExpr(*e.args[1])
+        : cachedGlobalString(" ", ".split_default_delim");
     // Regex overload: split(text, /pattern/) → delegate to regex runtime
     // Regex values are StringHeader-backed so emitStringByteLen is safe (#1052).
     if (isRegex(delim) && isStringValue(s)) {

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -646,8 +646,13 @@ llvm::Value *CodeGen::emitStrOp_reverse(const CallExpr &e) {
 
 // split(s[, delim]) → List<str>
 llvm::Value *CodeGen::emitStrOp_split(const CallExpr &e) {
-    if (e.args.size() < 1 || e.args.size() > 2)
-        codegenError("split() takes 1 or 2 arguments");
+    if (e.callee == "_split") {
+        if (e.args.size() != 2)
+            codegenError("_split() takes exactly 2 arguments");
+    } else {
+        if (e.args.size() < 1 || e.args.size() > 2)
+            codegenError("split() takes 1 or 2 arguments");
+    }
     llvm::Value *s = emitExpr(*e.args[0]);
     llvm::Value *delim = (e.args.size() == 2)
         ? emitExpr(*e.args[1])

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -192,6 +192,13 @@ describe("split and join", ():
     expect(parts[1]).to_eq("2")
     expect(parts[2]).to_eq("3")
   )
+  it("should default split delimiter in direct call form", ():
+    parts = split("1 2 3")
+    expect(parts).to_have_length(3)
+    expect(parts[0]).to_eq("1")
+    expect(parts[1]).to_eq("2")
+    expect(parts[2]).to_eq("3")
+  )
   it("should preserve explicit delimiter split behavior", ():
     parts = "a,b,c".split(",")
     expect(parts).to_have_length(3)

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -185,6 +185,20 @@ describe("generation", ():
 )
 
 describe("split and join", ():
+  it("should default split delimiter to a single space", ():
+    parts = "1 2 3".split()
+    expect(parts).to_have_length(3)
+    expect(parts[0]).to_eq("1")
+    expect(parts[1]).to_eq("2")
+    expect(parts[2]).to_eq("3")
+  )
+  it("should preserve explicit delimiter split behavior", ():
+    parts = "a,b,c".split(",")
+    expect(parts).to_have_length(3)
+    expect(parts[0]).to_eq("a")
+    expect(parts[1]).to_eq("b")
+    expect(parts[2]).to_eq("c")
+  )
   it("should split string by delimiter", ():
     parts = split("a,b,c", ",")
     expect(parts).to_have_length(3)


### PR DESCRIPTION
## Summary
- add a Ry wrapper for `str.split` with a default delimiter of a single space
- update the string builtin dispatcher so direct and UFCS split calls accept the zero-argument form
- add spec coverage, docs updates, and a KNOWLEDGE.md note for builtin wrapper pitfalls

## Testing
- cmake --build build
- ./build/ry test tests/spec/strings.test.ry

Refs #1277

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The split() function now accepts an optional delimiter defaulting to a single space, so calling split() (no args) splits on spaces while explicit delimiters continue to work as before.

* **Documentation**
  * Reference docs updated to show the optional delimiter and example usage for split() with and without arguments.

* **Tests**
  * Added tests verifying split() with no delimiter and with explicit delimiters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->