### PR TITLE
fix: use builtins for arc live counter

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2016,6 +2016,25 @@ because the data buffer uses `checked_malloc`) and `arc_free(header)`.
 **Also**: C++ tests that call these runtime functions directly must also use
 `arc_free` (not `free`) to release the returned struct.
 
+### JIT-visible atomic counters must not expose `std::atomic<T>` storage via raw `T*`
+
+**Source**: #1158 (2026-04-23, implementation)
+**Tags**: runtime, atomic, jit, abi, layout, arc
+
+**Rule**: If JIT-generated IR needs the address of a counter as a raw
+`int64_t*` (or other plain-data pointer), back the storage with an
+`alignas(T) T` object and access it through `__atomic_*` builtins. Do
+not store the counter as `std::atomic<T>` and then return
+`reinterpret_cast<T*>(&atomic_obj)` to the JIT.
+
+**Why**: Ry's JIT emits `atomicrmw` directly against the address returned
+by `__ry_arc_counter_address()`. C++ does not guarantee that
+`std::atomic<int64_t>` has the same layout or address semantics as a
+plain `int64_t`, so exposing its storage as `int64_t*` is a portability
+bug even if it happens to work on one toolchain. `__atomic_fetch_add`,
+`__atomic_fetch_sub`, and `__atomic_load_n` preserve the required
+relaxed-atomic semantics without relying on `std::atomic` object layout.
+
 ### RWLock dispatch state must be thread-local, not guarded by a shared mutex
 
 **Source**: #871 (2026-04-11, implementation; follow-up to #630 P1 audit)

--- a/src/runtime_arc_counter.cpp
+++ b/src/runtime_arc_counter.cpp
@@ -1,5 +1,4 @@
 #include "ry/runtime_alloc.hpp"
-#include <atomic>
 #include <cstdint>
 #include <cstdlib>
 
@@ -18,7 +17,7 @@
 // =========================================================================
 
 namespace {
-    std::atomic<int64_t> g_arc_live_count{0};
+    alignas(int64_t) int64_t g_arc_live_count = 0;
 } // anonymous namespace
 
 extern "C" {
@@ -27,13 +26,13 @@ extern "C" {
 // called from include/ry/runtime_arc.hpp arc_alloc / arc_free.
 void *__ry_arc_alloc_counted(int64_t total_size) {
     void *p = ry::checked_malloc(static_cast<size_t>(total_size));
-    g_arc_live_count.fetch_add(1, std::memory_order_relaxed);
+    __atomic_fetch_add(&g_arc_live_count, 1, __ATOMIC_RELAXED);
     return p;
 }
 
 void __ry_arc_free_counted(void *header_ptr) {
     if (!header_ptr) return;
-    g_arc_live_count.fetch_sub(1, std::memory_order_relaxed);
+    __atomic_fetch_sub(&g_arc_live_count, 1, __ATOMIC_RELAXED);
     std::free(header_ptr);
 }
 
@@ -42,11 +41,11 @@ void __ry_arc_free_counted(void *header_ptr) {
 // function-call symbol in the JIT module (avoids JITLink stub creation on
 // Linux that triggers a teardown crash during RT->remove()).
 int64_t *__ry_arc_counter_address() {
-    return reinterpret_cast<int64_t *>(&g_arc_live_count);
+    return &g_arc_live_count;
 }
 
 int64_t __ry_runtime_internal_arc_live_count() {
-    return g_arc_live_count.load(std::memory_order_relaxed);
+    return __atomic_load_n(&g_arc_live_count, __ATOMIC_RELAXED);
 }
 
 } // extern "C"

--- a/tests/test_codegen_arc.cpp
+++ b/tests/test_codegen_arc.cpp
@@ -6,6 +6,11 @@
 
 
 using namespace ry;
+
+extern "C" int64_t *__ry_arc_counter_address();
+extern "C" int64_t  __ry_runtime_internal_arc_live_count();
+extern "C" void    *__ry_arc_alloc_counted(int64_t total_size);
+extern "C" void     __ry_arc_free_counted(void *header_ptr);
 // ============================================================
 //  ARC Header layout tests (pure C++ — validates the memory
 //  layout contract that codegen_arc.cpp relies on)
@@ -183,6 +188,23 @@ TEST(ArcInfraTest, GetHeaderFromData) {
     void *backToHeader = static_cast<char *>(data) - 16;
     EXPECT_EQ(backToHeader, p);
     std::free(p);
+}
+
+TEST(ArcInfraTest, ArcCounterAddressMatchesRuntimeCount) {
+    int64_t *counter = __ry_arc_counter_address();
+    ASSERT_NE(counter, nullptr);
+
+    const int64_t before = __atomic_load_n(counter, __ATOMIC_RELAXED);
+    EXPECT_EQ(before, __ry_runtime_internal_arc_live_count());
+
+    void *p = __ry_arc_alloc_counted(32);
+    ASSERT_NE(p, nullptr);
+    EXPECT_EQ(__atomic_load_n(counter, __ATOMIC_RELAXED), before + 1);
+    EXPECT_EQ(__ry_runtime_internal_arc_live_count(), before + 1);
+
+    __ry_arc_free_counted(p);
+    EXPECT_EQ(__atomic_load_n(counter, __ATOMIC_RELAXED), before);
+    EXPECT_EQ(__ry_runtime_internal_arc_live_count(), before);
 }
 
 // ===== Integration: collection literals under ARC (functional) =====


### PR DESCRIPTION
## Summary
- replace the ARC live counter storage with aligned plain `int64_t` storage plus `__atomic_*` builtins
- keep `__ry_arc_counter_address()` JIT-safe by returning the real `int64_t*` backing storage
- add a C++ regression test for address-based counter access and record the rule in `KNOWLEDGE.md`

## Testing
- cmake --build build --target ry_tests
- ./build/ry_tests --gtest_filter=ArcInfraTest.ArcCounterAddressMatchesRuntimeCount
- ./build/ry_tests '--gtest_filter=ArcInfraTest.*'
- ./build/ry test tests/spec/arc_release_on_rebind.test.ry
- ./build/ry test tests/spec/arc_release_on_index_overwrite.test.ry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated ARC counter handling guidelines for JIT-generated code

* **Bug Fixes**
  * Improved atomic counter address handling for correct reference counting semantics

* **Tests**
  * Added unit test validating ARC counter consistency between allocation and deallocation operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->