### PR TITLE
feat: remove `function` keyword, unify on `fn`

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -788,8 +788,8 @@ The new type should appear wherever these existing primitives do
 `src/codegen_fn_generic.cpp` compared the whole parameter type
 `toString()` against the set of type-parameter names
 (`if (typeParamSet.count(paramType))`). That check only fires when the
-parameter type *is* a bare type variable — so `function identity<T>(x: T)`
-worked but `function first_of<T>(xs: List<T>)` silently produced no
+parameter type *is* a bare type variable — so `fn identity<T>(x: T)`
+worked but `fn first_of<T>(xs: List<T>)` silently produced no
 binding and the caller saw "could not infer type parameter 'T'". Every
 container, tuple, and function-type parameter was broken the same way
 because `"List<T>" != "T"`.
@@ -1116,9 +1116,9 @@ if (elemTy == ptrTy_) {
 }
 ```
 
-**Why**: `getNestedListElementType` only checks `TypeMeta::NestedListElem`, which `propagateTypeMeta` sets only in the `isListTypeName` branch. Map/Set/function element kinds live in different fields (`map_value_type_name`, `list_elem_fn_type_info`). A blacklist on a single field is structurally incomplete — `List<Map<K,V>>` / `List<function(...)>` / `List<Set<T>>` all slip through and `strcmp` runs on Map/Set/closure headers (undefined behaviour). `inferCollectionTypeName` (`src/codegen_builtin.cpp:242-274`) returns non-empty `"Map<...>"` / `"List<...>"` / `"Set<...>"` for non-str pointer types, so treating `""` as str is safe (see sibling entry "List<str> literals can have empty list_elem_type_name"). Resource element lists (`List<TcpStream>`) get a non-empty `list_elem_type_name` and are caught by `isNonStrName`; do not check the list value's own `resource_kinds` — lists are not resources themselves, so that field is always empty for list containers. Access `nested_list_elem` directly on the cached `meta` pointer instead of calling `getNestedListElementType` to avoid a second `value_metadata_` lookup.
+**Why**: `getNestedListElementType` only checks `TypeMeta::NestedListElem`, which `propagateTypeMeta` sets only in the `isListTypeName` branch. Map/Set/function element kinds live in different fields (`map_value_type_name`, `list_elem_fn_type_info`). A blacklist on a single field is structurally incomplete — `List<Map<K,V>>` / `List<fn(...)>` / `List<Set<T>>` all slip through and `strcmp` runs on Map/Set/closure headers (undefined behaviour). `inferCollectionTypeName` (`src/codegen_builtin.cpp:242-274`) returns non-empty `"Map<...>"` / `"List<...>"` / `"Set<...>"` for non-str pointer types, so treating `""` as str is safe (see sibling entry "List<str> literals can have empty list_elem_type_name"). Resource element lists (`List<TcpStream>`) get a non-empty `list_elem_type_name` and are caught by `isNonStrName`; do not check the list value's own `resource_kinds` — lists are not resources themselves, so that field is always empty for list containers. Access `nested_list_elem` directly on the cached `meta` pointer instead of calling `getNestedListElementType` to avoid a second `value_metadata_` lookup.
 
-**How to apply**: Fixed in `emitCollOp_distinct` by #1262, `emitListRemove` by #1268, and the `in` / `not in` list branch (`src/codegen_expr.cpp` around line 1555) by #1269. Any new collection op that takes a `List<T>` and compares pointer elements must apply the same positive-allowlist guard before any `strcmp` call. Always pair with direct regression tests: add a `List<Map<str,int>>` / `List<function(...)>` / `List<Set<T>>` case that expects `expectCompileError`; a single-element list must not be the sole reproduction because `curOutLen == 0` masks the symptom on the first iteration of the dedup loop.
+**How to apply**: Fixed in `emitCollOp_distinct` by #1262, `emitListRemove` by #1268, and the `in` / `not in` list branch (`src/codegen_expr.cpp` around line 1555) by #1269. Any new collection op that takes a `List<T>` and compares pointer elements must apply the same positive-allowlist guard before any `strcmp` call. Always pair with direct regression tests: add a `List<Map<str,int>>` / `List<fn(...)>` / `List<Set<T>>` case that expects `expectCompileError`; a single-element list must not be the sole reproduction because `curOutLen == 0` masks the symptom on the first iteration of the dedup loop.
 
 **Related**: #1241 (`propagateMeta` added to `distinct` — did not address the guard), "List<str> literals can have empty list_elem_type_name" (#1235), "Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`".
 
@@ -1313,7 +1313,7 @@ supported overload. Otherwise a mixed-type call like
 `pow(1, 2.0)` would silently reach the wrong branch.
 
 **Rule**: When adding an overload for an existing stdlib function with
-a custom emitter, (1) add the `@native function` declaration, (2)
+a custom emitter, (1) add the `@native fn` declaration, (2)
 extend the existing custom emitter to handle the new arity / type
 combination, (3) add explicit type checks with clear errors for
 unsupported combinations — do NOT add a second table entry, it will
@@ -1772,6 +1772,13 @@ const std::string resolvedInner = resolveTypeAlias(innerTypeName);
 
 ## Parser / Lexer
 
+### Only `fn` is a function declaration keyword; `function` is a normal identifier
+
+**Source**: #1343 (2026-04-23, implementation)
+**Tags**: lexer, keyword, function-type, canonical-type-id, migration
+
+**Rule**: The lexer maps only `fn` to `TokenKind::Fn`. The string `function` tokenizes as `Ident`, so it can be used as a variable or parameter name. Function types are spelled `fn(T) -> R` in source; `isFunctionTypeName` and `splitFunctionTypeName` accept only the `fn(` prefix. The compile-time / `to_str` category name for function-typed values is the canonical type id string `"fn"` (not `"function"`). When updating examples or C++-embedded Ry in tests, avoid leaving `function` as a reserved spelling.
+
 ### Use depth-tracking for nested delimiters, never naive find()
 
 **Source**: #801 PR
@@ -1780,7 +1787,7 @@ const std::string resolvedInner = resolveTypeAlias(innerTypeName);
 **Context**: `parseFnTypeAnnotation()` originally used
 `string::find(')')` to locate the closing paren, which broke on
 nested function-typed parameters like
-`function((int) -> int) -> int`.
+`fn((int) -> int) -> int`.
 
 **Rule**: When scanning for a matching closing delimiter (`)`, `]`,
 `}`), always use a depth counter that increments on the opening and
@@ -2488,10 +2495,10 @@ their `NativeDispatchEntry` go through the early-return at
 `src/codegen_call_native.cpp:135-150` and **skip** the regular
 argument type validation path (L165-203). That means the Ry
 declaration in `share/std/<pkg>/<pkg>.ry` (e.g.
-`function thread_spawn(body: function() -> Unit) -> Thread`)
+`fn thread_spawn(body: fn() -> Unit) -> Thread`)
 constrains only what IDE/docs consumers see, not what the custom
 emitter actually accepts. When extending a custom-emitter native
-function (e.g. broadening `thread_spawn` to accept non-Unit
+fn (e.g. broadening `thread_spawn` to accept non-Unit
 lambdas, or `assert` to accept new argument shapes), you can
 relax the effective input without touching the Ry declaration.
 Do update the docs and declaration for hygiene, but do not
@@ -2920,12 +2927,12 @@ or `bool` depending on the worker body), the declaration in
 |---|---|
 | `<T>` generic | `src/codegen_fn.cpp:471-481` diverts any function with `type_params` into `generic_fn_templates_` and returns early — no `NativeFnSignature` is registered, breaking dispatch |
 | Bare `T` at top-level | `src/codegen_type.cpp:160-162`: `resolveType` fails for unbound identifier |
-| `function() -> T` nested | Parser free-pass (interior not validated), but the identifier is semantically meaningless — fragile |
+| `fn() -> T` nested | Parser free-pass (interior not validated), but the identifier is semantically meaningless — fragile |
 | Overloads differing only in return type | `src/codegen_fn.cpp:531-545` dedupes on param types only; the second declaration is silently dropped |
 
 **Rule**: Use `any` as the hygienic placeholder. `any` resolves cleanly via
 `src/codegen_type.cpp:23` at both top-level and generic argument positions
-(e.g. `Result<any, Error>`, `function() -> any`). The custom emitter still
+(e.g. `Result<any, Error>`, `fn() -> any`). The custom emitter still
 drives actual runtime type dispatch through `TypeMeta` metadata — `any` in
 the declaration is never consulted at codegen time.
 
@@ -3082,7 +3089,7 @@ operator spec.
 
 **Rule**: When a per-file doc example uses a language operator (`?`, `!!`, `case`, `@`
 directives, etc.), do NOT judge it solely by analogy with how that operator appears in
-function bodies. Always:
+fn bodies. Always:
 1. Check `docs/reference/operators.md` for the full spec (including top-level usage rules).
 2. Cross-check `src/codegen_expr.cpp` or the relevant codegen for the operator's desugar
    behavior in different contexts (function body vs. top level vs. lambda).
@@ -3316,12 +3323,12 @@ to JIT symbol lookup.
 **Tags**: stdlib, builtin, wrapper, default-args, ufcs, codegen
 
 **Rule**: When converting a bare builtin in `share/std/*.ry` from a direct
-`@native function name(...)` declaration to the native-underscore wrapper
-pattern (`@native function _name(...)` + `function name(... = default)`),
+`@native fn name(...)` declaration to the native-underscore wrapper
+pattern (`@native fn _name(...)` + `fn name(... = default)`),
 update the C++ builtin dispatcher as well.
 
 **Why**: Bare builtins like `split` are intercepted before ordinary Ry
-function resolution. Two separate changes may be required:
+fn resolution. Two separate changes may be required:
 
 - Register the underscored alias (for example `"_split"`) in the relevant
   dispatch table (`emitBuiltinString`, `emitBuiltinCore`, etc.), otherwise the
@@ -3444,7 +3451,7 @@ inner `wrapPtrAsResult(...)` value as `HttpClientResponse`, but an outer NUL-che
 non-`HttpClientResponse` arguments.
 `buildOkValue` / `buildErrValue` / `buildSomeValue` now call `tryRetainArcSource(inner)`
 when `inner->getType() == ptrTy_`. This retains the collection before scope cleanup at
-function exit can release the local variable. `tryRetainArcSource` handles three cases:
+fn exit can release the local variable. `tryRetainArcSource` handles three cases:
 1. `LoadInst` from an ARC-managed alloca (emits retain — the direct-param bugfix case)
 2. `arc_owned_values_` (no-op — `Ok([1, 2])` inline construction stays unaffected)
 3. `ExtractValueInst` (record/tuple field access via `CreateExtractValue`) — retains only
@@ -3557,7 +3564,7 @@ in any of: a bare identifier (`Tree`), a generic application's base (`LList<T>`)
 of an optional (`Tree?`), a tuple element (`(int, Tree)`), an array element, a union
 component, or inside an arbitrary non-indirection generic (`Option<Tree>`,
 `Pair<Tree, Tree>`). The helper treats `List<_>`, `Map<_, _>`, `Set<_>`, `Task<_>`,
-`Channel<_>`, `weak T`, and `function(...)` as pointer-backed indirection and stops
+`Channel<_>`, `weak T`, and `fn(...)` as pointer-backed indirection and stops
 descending — their payload is boxed, so the layout is finite. The recommendation message
 points users to `List<T>`, `Map<K, T>`, and `Set<T>`; it intentionally excludes `weak T`
 because weak requires an ARC-managed payload and does not apply to an arbitrary ADT.
@@ -3594,8 +3601,8 @@ auto-boxing cannot recover).
 3. `MyOpt<T>` with `T` bound in `type_param_scope_` → `substituteTypeParamsInName` rewrites
    to `MyOpt<int>`, then the case above kicks in.
 
-**Why**: The user-facing regression in #1203 was that `function f(opt: MyOpt, ...)` and
-`function f<T>(opt: MyOpt<T>, ...)` both produced `unknown type: ...` with no hint. Case 1
+**Why**: The user-facing regression in #1203 was that `fn f(opt: MyOpt, ...)` and
+`fn f<T>(opt: MyOpt<T>, ...)` both produced `unknown type: ...` with no hint. Case 1
 now guides the user to the correct syntax; cases 2 and 3 compile silently.
 
 **How to apply**: When adding a new generic-template registry (alongside
@@ -4390,9 +4397,9 @@ if (elementTypeIsArcManaged(srcListPtr, CollectionKind::List, &elemArcKind)) {
 
 **Rule**: A `List<str>` constructed purely from a list literal (e.g. `xs: List<str> = ["a" + "b", "c" + "d"]`) typically has `list_elem_type_name = ""` rather than `"str"`. Tests that assign `xs = ["dropped"]` after a `take` / `slice` / `concat` and then read the returned list expect to exercise the retain path — but on `List<str>`, the *release* path of the source also skips str destruction (because the destructor only emits `emitStrElemLoop` when `elemSig == "str"`). Retain omission + release omission = leak, not UAF, so the test passes whether or not the retain was implemented. Do NOT rely on `List<str>` UAF tests alone to prove a retain fix is wired up; add a `List<List<int>>` or `List<Map<K,V>>` case (where `list_elem_type_name` *is* populated — see `codegen_stmt.cpp` annotation branch at ~647) or inspect IR for the `cow_*_elem_loop` retain block.
 
-**Why**: `codegen_expr_literal.cpp`'s list-literal path sets `list_elem_type_name = inferCollectionTypeName(vals[0])`, which returns `""` for string values. The annotation branch in `codegen_stmt.cpp:emitVarDecl` (~647-672) fills in `List<Map<…>>`, `List<Set<…>>`, `List<List<…>>`, `List<function(…)>`, `List<Tuple<…>>`, `List<int>` etc., but has no arm that writes `"str"`. The only path that stamps `list_elem_type_name = "str"` is `emitStringToCharList` for `__ry_split_chars` in `codegen_builtin.cpp:225-234`. `elementTypeIsArcManaged` reads this field, so the retain is skipped for plain `List<str>`. Symmetrically, `getOrCreateCollectionDestructor` in `codegen_arc.cpp:843+` only emits str-element release when `elemSig == "str"`, so the element isn't released either — the heap string leaks (small) but no dangling pointer is produced.
+**Why**: `codegen_expr_literal.cpp`'s list-literal path sets `list_elem_type_name = inferCollectionTypeName(vals[0])`, which returns `""` for string values. The annotation branch in `codegen_stmt.cpp:emitVarDecl` (~647-672) fills in `List<Map<…>>`, `List<Set<…>>`, `List<List<…>>`, `List<fn(…)>`, `List<Tuple<…>>`, `List<int>` etc., but has no arm that writes `"str"`. The only path that stamps `list_elem_type_name = "str"` is `emitStringToCharList` for `__ry_split_chars` in `codegen_builtin.cpp:225-234`. `elementTypeIsArcManaged` reads this field, so the retain is skipped for plain `List<str>`. Symmetrically, `getOrCreateCollectionDestructor` in `codegen_arc.cpp:843+` only emits str-element release when `elemSig == "str"`, so the element isn't released either — the heap string leaks (small) but no dangling pointer is produced.
 
-**How to apply**: When writing UAF regression tests for collection-element retain paths, prefer `List<List<int>>` / `List<Map<str,int>>` / `List<function(…) -> …>` over `List<str>`, or use both. When reviewing such a PR, verify the test discriminates — a test that passes before the fix indicates the test (or the surrounding metadata pipeline) is not catching what it claims to catch. Also note: #1204's own `list_range_index.test.ry` has the same `List<str>` blind spot — any future fix that addresses the missing `list_elem_type_name = "str"` annotation (possibly a follow-up issue) should re-verify #1204's tests then fail pre-fix.
+**How to apply**: When writing UAF regression tests for collection-element retain paths, prefer `List<List<int>>` / `List<Map<str,int>>` / `List<fn(…) -> …>` over `List<str>`, or use both. When reviewing such a PR, verify the test discriminates — a test that passes before the fix indicates the test (or the surrounding metadata pipeline) is not catching what it claims to catch. Also note: #1204's own `list_range_index.test.ry` has the same `List<str>` blind spot — any future fix that addresses the missing `list_elem_type_name = "str"` annotation (possibly a follow-up issue) should re-verify #1204's tests then fail pre-fix.
 
 **Related**: #1204 (slice retain fix — same test pattern, same blind spot), #1235 (take retain fix — discovered property), #1046 (str ARC dispatch via side-table, independent of `list_elem_type_name`).
 
@@ -4575,7 +4582,7 @@ into a Ry string slot (i.e., the pointer came from `makeString` or was read from
 
 **How to apply**: Only call `hasEmbeddedNul` inside codegen emitters (where arguments are known
 Ry handles) or inside runtime functions whose callers pass exclusively Ry handles. If a runtime
-function is also called from C++ unit tests with `.c_str()` or with C literals, move the NUL
+fn is also called from C++ unit tests with `.c_str()` or with C literals, move the NUL
 check to the codegen emitter.
 
 ### NUL checks belong in the codegen emitter, not the runtime, for multi-context functions
@@ -5063,7 +5070,7 @@ The retain discipline is **symmetric** with the destructor:
 
 **Source**: #1318 (2026-04-23, implementation). **Tags**: codegen, lambda, type-inference, native, stdlib, resource, JsonValue
 
-**Rule**: `inferExprType()` / `inferExprTypeName()` for `CallExpr` must check the `@native` signature registry (`native_fn_sigs_` + `native_lib_index_`) when `findFunction()` misses. Many stdlib calls such as `lock_new()` and `json.parse()` are registered only as `@native` signatures, so falling straight to the scalar fallback (`i64Ty_` / `"int"`) makes lambda return-type checking report nonsense like `expected 'int'` for `function() -> Lock` or `function() -> Result<JsonValue, Error>`.
+**Rule**: `inferExprType()` / `inferExprTypeName()` for `CallExpr` must check the `@native` signature registry (`native_fn_sigs_` + `native_lib_index_`) when `findFunction()` misses. Many stdlib calls such as `lock_new()` and `json.parse()` are registered only as `@native` signatures, so falling straight to the scalar fallback (`i64Ty_` / `"int"`) makes lambda return-type checking report nonsense like `expected 'int'` for `fn() -> Lock` or `fn() -> Result<JsonValue, Error>`.
 
 **How to apply**: Keep the lambda inference path in sync with native-call dispatch: match `@native` overloads by arity and inferred argument types, allow the same implicit widening tier as normal call resolution, and return the matched signature's declared Ry return type name. Without the name-level lookup, metadata-gated returns (`Result<JsonValue, Error>`, resource handles, function-typed returns) may still compile to the right LLVM type later but fail or lose metadata during lambda pre-checking.
 

--- a/changelog.d/1343-fn-only-keyword.md
+++ b/changelog.d/1343-fn-only-keyword.md
@@ -1,0 +1,9 @@
+### Removed
+
+- The `function` keyword is removed; use `fn` for all function definitions and `async fn` for async definitions (#1343).
+
+### Changed
+
+- Function types are written `fn(T1, ...) -> R` only; `function(...)` is no longer accepted as a type or declaration keyword.
+- `type_of` / `to_str` category for function-typed values is reported as `"fn"` (was `"function"`).
+- Trace `symbol_define` entries use kind `"fn"` for user-defined functions (was `"function"`).

--- a/docs/reference/base64.md
+++ b/docs/reference/base64.md
@@ -118,7 +118,7 @@ case decode("!!!not-valid!!!"):
 With the `?` operator:
 
 ```ry
-function process(input: str) -> Result<str, Error>:
+fn process(input: str) -> Result<str, Error>:
     decoded = decode(input)?
     return Ok(decoded)
 ```

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -431,7 +431,7 @@ Converts a value to a string.
 | union | Formatted as the active variant; `List`, `Map`, `Set`, and function variants are all supported |
 | function value (closure / lambda) | `"<closure>"` |
 
-Whole-number `float` values are formatted with a trailing `.0` (e.g. `to_str(3.0) == "3.0"`) so they are visually distinguishable from `int`. Record types automatically generate a `to_str` representation. If a user-defined `function to_str(v: MyRecord) -> str` is provided, it takes precedence over the auto-generated version. This also works with `print()` and f-string interpolation.
+Whole-number `float` values are formatted with a trailing `.0` (e.g. `to_str(3.0) == "3.0"`) so they are visually distinguishable from `int`. Record types automatically generate a `to_str` representation. If a user-defined `fn to_str(v: MyRecord) -> str` is provided, it takes precedence over the auto-generated version. This also works with `print()` and f-string interpolation.
 
 ```ry
 print(to_str(42))         # 42

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -527,7 +527,7 @@ print(xs.take(0))    # []
 
 ## tap
 
-**Signature:** `tap(list: List<T>, function: function(T) -> R) -> List<T>`
+**Signature:** `tap(list: List<T>, function: fn(T) -> R) -> List<T>`
 
 Calls the given function on each element (ignoring any return value), then returns the original list unchanged. Useful for debugging or inserting side effects in a method chain. UFCS notation is also available.
 
@@ -541,7 +541,7 @@ ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 
 ## filter
 
-**Signature:** `filter(list: List<T>, pred: function(T) -> bool) -> List<T>`
+**Signature:** `filter(list: List<T>, pred: fn(T) -> bool) -> List<T>`
 
 > **See also**: [Collections — filter](collections.md#filter) for full semantics and examples. UFCS notation is also available.
 
@@ -549,7 +549,7 @@ ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 
 ## map
 
-**Signature:** `map(list: List<T>, function: function(T) -> U) -> List<U>`
+**Signature:** `map(list: List<T>, function: fn(T) -> U) -> List<U>`
 
 > **See also**: [Collections — map](collections.md#map) for full semantics and examples. UFCS notation is also available.
 
@@ -557,7 +557,7 @@ ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 
 ## sort
 
-**Signature:** `sort(list: List<T>) -> List<T>` / `sort(list: List<T>, comp: function(T, T) -> bool) -> List<T>`
+**Signature:** `sort(list: List<T>) -> List<T>` / `sort(list: List<T>, comp: fn(T, T) -> bool) -> List<T>`
 
 > **See also**: [Collections — sort](collections.md#sort) for full semantics and examples. UFCS notation is also available.
 
@@ -565,7 +565,7 @@ ys = xs.tap((x: int) => print(x)).map((x: int) => x * 2)
 
 ## sort!
 
-**Signature:** `sort!(list: List<T>)` / `sort!(list: List<T>, comp: function(T, T) -> bool)`
+**Signature:** `sort!(list: List<T>)` / `sort!(list: List<T>, comp: fn(T, T) -> bool)`
 
 > **See also**: [Collections — In-Place Mutating Variants](collections.md#in-place-mutating-variants) for full semantics and examples. UFCS notation is also available.
 
@@ -752,7 +752,7 @@ print(to_str(type_of(type_of(42)))) # Type
 | `Some(1)` | `Option` |
 | `x: Option<int> = none` | `Option` |
 | `Ok(1)` / `Err(e)` | `Result` |
-| lambda / closure | `function` |
+| lambda / closure | `fn` |
 | `type_of(x)` | `Type` |
 
 > The bare `none` literal is reported as `"None"` to distinguish it from a typed `Option` value. Any `Option<T>` container — whether constructed via `Some(...)` or assigned from `none` to an `Option<T>`-typed binding — reports as `"Option"`.

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -47,7 +47,7 @@ print(t.1)   # 3.14
 ### Function Return Values
 
 ```ry
-function swap(a: int, b: int) -> (int, int):
+fn swap(a: int, b: int) -> (int, int):
     return (b, a)
 
 result = swap(1, 2)
@@ -509,7 +509,7 @@ print(xs)   # [1, 3, 4]
 
 ### remove
 
-Removes the first occurrence of the specified value from the list. Does nothing if the value is not found. This is a mutating operation. Passing a list of non-string pointer elements (e.g. `List<List<T>>`, `List<Map<K, V>>`, `List<Set<T>>`, `List<function(...) -> R>`) is a compile error: `remove() is only supported for lists of primitive values or strings`.
+Removes the first occurrence of the specified value from the list. Does nothing if the value is not found. This is a mutating operation. Passing a list of non-string pointer elements (e.g. `List<List<T>>`, `List<Map<K, V>>`, `List<Set<T>>`, `List<fn(...) -> R>`) is a compile error: `remove() is only supported for lists of primitive values or strings`.
 
 ```ry
 xs = [1, 2, 3, 2, 4]
@@ -519,7 +519,7 @@ print(xs)   # [1, 3, 2, 4]
 
 ### distinct
 
-Returns a new list with duplicate elements removed. The original order is preserved (first occurrence kept). The original list is not modified. Passing a list of non-string pointer elements (e.g. `List<List<T>>`, `List<Map<K, V>>`, `List<Set<T>>`, `List<function(...) -> R>`) is a compile error: `distinct() is only supported for lists of primitive values or strings`.
+Returns a new list with duplicate elements removed. The original order is preserved (first occurrence kept). The original list is not modified. Passing a list of non-string pointer elements (e.g. `List<List<T>>`, `List<Map<K, V>>`, `List<Set<T>>`, `List<fn(...) -> R>`) is a compile error: `distinct() is only supported for lists of primitive values or strings`.
 
 ```ry
 xs = [1, 2, 3, 2, 1, 4]
@@ -926,7 +926,7 @@ s: Set<int> = {}
 ### Function Parameters
 
 ```ry
-function has_value(s: Set<int>, v: int) -> bool:
+fn has_value(s: Set<int>, v: int) -> bool:
     return v in s
 ```
 

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -11,7 +11,7 @@ Ry supports Eiffel-style Design by Contract with preconditions (`require`), post
 Preconditions are checked at function entry. They specify what must be true for the function to be called correctly.
 
 ```ry
-function deposit(amount: int, balance: int) -> int:
+fn deposit(amount: int, balance: int) -> int:
     require:
         amount > 0
         balance >= 0
@@ -35,7 +35,7 @@ Postconditions are checked before every `return`. They specify what the function
 `ensure` requires a variable name that binds the return value. This variable can be used in the postcondition expressions.
 
 ```ry
-function abs(x: int) -> int:
+fn abs(x: int) -> int:
     ensure v:
         v >= 0
     if x < 0:
@@ -46,7 +46,7 @@ function abs(x: int) -> int:
 Since function arguments are immutable in Ry, you can reference them directly in `ensure` blocks to compare with entry values:
 
 ```ry
-function increment(x: int) -> int:
+fn increment(x: int) -> int:
     ensure v:
         v == x + 1
     return x + 1
@@ -57,7 +57,7 @@ function increment(x: int) -> int:
 For functions that return tuples, multiple variable names can be specified, separated by commas:
 
 ```ry
-function divide(a: int, b: int) -> (int, int):
+fn divide(a: int, b: int) -> (int, int):
     ensure q, r:
         q >= 0
         r >= 0
@@ -71,7 +71,7 @@ The number of binding variables must match the number of tuple elements.
 ## Combined Example
 
 ```ry
-function deposit(amount: int, balance: int) -> int:
+fn deposit(amount: int, balance: int) -> int:
     require:
         amount > 0
         balance >= 0

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -320,10 +320,10 @@ while i < length(xs):
 
 ## async / await
 
-`async function` declares a function that runs concurrently. Calling an `async function` returns `Task<T>`. Use `await` inside another `async function` or `block_on()` from synchronous context to wait for the result.
+`async fn` declares a function that runs concurrently. Calling an `async fn` returns `Task<T>`. Use `await` inside another `async fn` or `block_on()` from synchronous context to wait for the result.
 
 ```ry
-async function add(a: int, b: int) -> int:
+async fn add(a: int, b: int) -> int:
     return a + b
 
 # From synchronous context, use block_on()
@@ -331,22 +331,22 @@ t: Task<int> = add(20, 22)
 print(block_on(t))                  # 42
 print(block_on(add(1, 2)))          # 3
 
-# Inside async function, use await
-async function double_add(a: int, b: int) -> int:
+# Inside async fn, use await
+async fn double_add(a: int, b: int) -> int:
     result = await add(a, b)
     return result * 2
 ```
 
 ### Rules
 
-- `async function name(...) -> T:` is declared with the awaited result type `T`.
-- Calling an `async function` immediately returns `Task<T>`.
+- `async fn name(...) -> T:` is declared with the awaited result type `T`.
+- Calling an `async fn` immediately returns `Task<T>`.
 - `await expr` requires `expr` to be `Task<T>` and produces `T`.
-- `await` can only be used inside an `async function`. Use `block_on(task)` from synchronous context.
+- `await` can only be used inside an `async fn`. Use `block_on(task)` from synchronous context.
 - `block_on(task)` blocks the current thread until the task completes and returns the result.
-- `async function ... -> Unit` is supported; `block_on(task)` is the primary way to wait when no value is produced.
+- `async fn ... -> Unit` is supported; `block_on(task)` is the primary way to wait when no value is produced.
 - Tasks run on the runtime worker pool; they are not implemented as one OS thread per task.
-- `async` lambdas and `async @native function` are not supported in v1.
+- `async` lambdas and `async @native fn` are not supported in v1.
 
 ---
 
@@ -367,7 +367,7 @@ for i in range(8):
 - Assigning to outer mutable bindings is rejected.
 - `break` and `continue` are rejected.
 - Indexed assignment and field assignment inside the loop body are rejected in v1.
-- Nested function definitions (`function` statements) inside the body are not allowed.
+- Nested function definitions (`fn` statements) inside the body are not allowed.
 
 Use `available_parallelism()` to inspect the runtime worker count.
 
@@ -414,7 +414,7 @@ for i in range(5):
 - Can be used in any block: function body, `if`/`else`, `while`, `for`, `case` arm, etc.
 
 ```ry
-function not_yet():
+fn not_yet():
     ...
 
 if true:
@@ -566,7 +566,7 @@ case x:
         print("nothing")
 
 # Result pattern match
-function divide(a: int, b: int) -> Result<int, Error>:
+fn divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
         return Err(Error("division by zero"))
     return Ok(a // b)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -17,7 +17,7 @@ Directives are placed before the target declaration. Multiple directives can be 
 
 Directives can be applied to the following declarations:
 
-- `function` - Function definitions (including named test functions decorated with `@it` / `@describe`)
+- `fn` - Function definitions (including named test functions decorated with `@it` / `@describe`)
 - `record` - Record definitions
 - Variable declarations (with or without `@const`)
 - Fields within a `record` definition
@@ -34,7 +34,7 @@ Marks a declaration as deprecated. When a deprecated entity is used (called, ref
 
 ```
 @deprecated
-function old_function() -> int:
+fn old_function() -> int:
     return 42
 
 print(old_function())   # warning: 'old_function' is deprecated
@@ -124,7 +124,7 @@ An optional string argument specifies the shared library module name. When a `@n
 
 ```
 @native
-function contains(string: str, substring: str) -> bool
+fn contains(string: str, substring: str) -> bool
 
 print(contains("hello world", "world"))  # true
 ```
@@ -133,7 +133,7 @@ print(contains("hello world", "world"))  # true
 
 ```
 @native
-function operator+(a: str, b: str) -> str
+fn operator+(a: str, b: str) -> str
 
 print("hello" + " world")  # hello world
 ```
@@ -142,7 +142,7 @@ print("hello" + " world")  # hello world
 
 ```
 @native
-function to_upper(string: str) -> str
+fn to_upper(string: str) -> str
 
 print("hello".to_upper())  # HELLO
 ```
@@ -153,11 +153,11 @@ When a `@native` declaration includes a type signature, the compiler validates t
 
 ```
 @native
-function range(count: int) -> List<int>
+fn range(count: int) -> List<int>
 @native
-function range(start: int, end: int) -> List<int>
+fn range(start: int, end: int) -> List<int>
 @native
-function range(start: int, end: int, step: int) -> List<int>
+fn range(start: int, end: int, step: int) -> List<int>
 
 print(length(range(5)))          # OK: matches 1-arg overload
 print(length(range(1, 10)))      # OK: matches 2-arg overload
@@ -175,7 +175,7 @@ print(length(range()))           # Error: range() takes 1, 2, or 3 arguments
 
 **Constraints:**
 - `@native` functions must not have a body (no `:` after the signature).
-- Providing a body causes a parse error: `@native function must not have a body`.
+- Providing a body causes a parse error: `@native fn must not have a body`.
 - For bare `@native`, the declared function must correspond to an existing built-in; otherwise the call will fail at compile time. For `@native("libname")`, the function is compiled based on the declared signature and will fail at JIT link time if the symbol cannot be resolved from the loaded library.
 
 **Library specification:**
@@ -207,7 +207,7 @@ for i in range(8):
 - Destructuring iteration is not supported.
 - Assigning to outer mutable variables is rejected.
 - `break`, `continue`, indexed assignment, and field assignment inside the loop body are rejected in v1.
-- Nested function definitions (`function` statements) inside the loop body are not allowed.
+- Nested function definitions (`fn` statements) inside the loop body are not allowed.
 
 ### `@each`
 
@@ -218,7 +218,7 @@ Enables parameterized testing by running a test multiple times with different pa
 ```ry
 @each([(arg1, arg2, ...), ...])
 @it("should handle {0} and {1}")
-function test_handle(param1: type, param2: type):
+fn test_handle(param1: type, param2: type):
     # test body
 ```
 
@@ -238,7 +238,7 @@ The argument can be any expression that evaluates to a list of tuples, including
 ```ry
 @each(make_inputs())
 @it("should handle {0}")
-function test_handle(x: int):
+fn test_handle(x: int):
     # test body
 ```
 
@@ -258,7 +258,7 @@ Enables property-based testing by generating random inputs for a test.
 ```ry
 @property(count=100)
 @it("should verify property name")
-function test_property(a: int, b: int):
+fn test_property(a: int, b: int):
     # test body with random values
 ```
 
@@ -300,7 +300,7 @@ Declares a test case by decorating a named function. The function body becomes t
 
 ```ry
 @it("description")
-function test_name():
+fn test_name():
     # assertions
 ```
 
@@ -308,7 +308,7 @@ function test_name():
 
 ```ry
 @it("should add 1 + 2 = 3")
-function test_add():
+fn test_add():
     expect(1 + 2).to_eq(3)
 ```
 
@@ -317,16 +317,16 @@ function test_add():
 ```ry
 @each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
 @it("should add {0} + {1} = {2}")
-function test_add_each(a: int, b: int, expected: int):
+fn test_add_each(a: int, b: int, expected: int):
     expect(a + b).to_eq(expected)
 
 @property(count=100)
 @it("should verify addition is commutative")
-function test_commutative(a: int, b: int):
+fn test_commutative(a: int, b: int):
     expect(a + b).to_eq(b + a)
 ```
 
-**Supported target:** `function` declarations only.
+**Supported target:** `fn` declarations only.
 
 **Constraints:**
 - Only valid in `*.test.ry` files executed with `ry test`
@@ -342,9 +342,9 @@ Groups a set of related tests by decorating a named function. Inner `@it` functi
 
 ```ry
 @describe("group name")
-function group_name():
+fn group_name():
     @it("nested test")
-    function test_nested():
+    fn test_nested():
         # assertions
 ```
 
@@ -352,13 +352,13 @@ function group_name():
 
 ```ry
 @describe("arithmetic")
-function arithmetic_tests():
+fn arithmetic_tests():
     @it("should subtract")
-    function test_sub():
+    fn test_sub():
         expect(10 - 3).to_eq(7)
 
     @it("should multiply")
-    function test_mul():
+    fn test_mul():
         expect(4 * 5).to_eq(20)
 ```
 
@@ -368,16 +368,16 @@ Variables declared in the outer `@describe` body are automatically captured by e
 
 ```ry
 @describe("shared setup")
-function shared_setup_tests():
+fn shared_setup_tests():
     base = 100
     offset = 5
 
     @it("should use base")
-    function test_base():
+    fn test_base():
         expect(base).to_eq(100)
 
     @it("should use base and offset")
-    function test_combined():
+    fn test_combined():
         expect(base + offset).to_eq(105)
 ```
 
@@ -385,15 +385,15 @@ function shared_setup_tests():
 
 ```ry
 @describe("outer")
-function outer():
+fn outer():
     @describe("inner")
-    function inner():
+    fn inner():
         @it("should pass deeply nested test")
-        function test_deep():
+        fn test_deep():
             expect(1 + 1).to_eq(2)
 ```
 
-**Supported target:** `function` declarations only. The function must not have parameters or a return type annotation.
+**Supported target:** `fn` declarations only. The function must not have parameters or a return type annotation.
 
 ### `@inline`
 
@@ -403,7 +403,7 @@ Provides inlining hints to the LLVM optimizer. By default, marks the function fo
 
 ```
 @inline
-function add(a: int, b: int) -> int:
+fn add(a: int, b: int) -> int:
     return a + b
 ```
 
@@ -411,15 +411,15 @@ function add(a: int, b: int) -> int:
 
 ```
 @inline(mode="always")
-function hot_path(x: int) -> int:
+fn hot_path(x: int) -> int:
     return x * 2 + 1
 
 @inline(mode="hint")
-function medium_path(x: int) -> int:
+fn medium_path(x: int) -> int:
     return x + 1
 
 @inline(mode="never")
-function cold_error_handler(msg: str):
+fn cold_error_handler(msg: str):
     print("ERROR: " + msg)
 ```
 
@@ -441,7 +441,7 @@ Directives support an optional parameter syntax for future extensions:
 
 ```
 @deprecated(reason="use new_api instead")
-function old_api() -> int:
+fn old_api() -> int:
     return 0
 ```
 

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -34,7 +34,7 @@ The table below shows the most common compile errors; it is not exhaustive.
 | Type-changing reassignment | Assigned a value of a different type to a variable | `x = 1` -> `x = 3.14` |
 | Type annotation mismatch | Declared type and assigned value type differ | `x: int = 3.14` |
 | Overload return type conflict | Defined overloads with the same parameter types but different return types only | Two functions with parameters `(int, int)` returning `int` and `float` |
-| Overload resolution failure | No overload matches the argument types | `function add(a: int, b: int)` called with `add(1.0, 2.0)` |
+| Overload resolution failure | No overload matches the argument types | `fn add(a: int, b: int)` called with `add(1.0, 2.0)` |
 | Float in bitwise operation | Passed `float` type to `&`, `\|`, `^`, `~`, `<<`, `>>` | `3.14 & 1` |
 | Empty list | Cannot infer type from empty list literal `[]` | `xs = []` |
 | Empty map | Cannot infer type from empty map literal `{}` | `m = {}` |
@@ -45,8 +45,8 @@ The table below shows the most common compile errors; it is not exhaustive.
 | Duplicate field name | Defined the same field name twice in a record | Defining `x` twice in `type T: x: int` |
 | Non-exhaustive match | `case` does not cover all patterns | Some enum variants uncovered, missing `None` for Option, missing `Ok`/`Err` for Result, no `_` for literals |
 | `?` on non-Result/Option type | Applied `?` to an expression that is not a `Result` or `Option` type (`'?' operator requires a Result or Option type operand`) | `x = 42` -> `x?` |
-| `?` in non-Result function | Used `?` on a `Result` in a function that does not return `Result` (`'?' on Result can only be used in a function that returns Result`) | `function foo() -> int:` with `bar()?` inside |
-| `ensure` on Unit-return function | Used `ensure` in a function with no return value (`'ensure' requires a non-Unit return type`) | `function log():` with `ensure v:` |
+| `?` in non-Result function | Used `?` on a `Result` in a function that does not return `Result` (`'?' on Result can only be used in a fn that returns Result`) | `fn foo() -> int:` with `bar()?` inside |
+| `ensure` on Unit-return function | Used `ensure` in a function with no return value (`'ensure' requires a non-Unit return type`) | `fn log():` with `ensure v:` |
 
 ### Compile Error Examples
 
@@ -67,7 +67,7 @@ xs = []   # Error: type cannot be inferred
 break   # Error: outside loop
 
 # Import inside block
-function foo():
+fn foo():
     from math   # Error: top level only
 
 # Duplicate field name

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -5,13 +5,13 @@
 ## Function Definition Syntax
 
 ```ry
-function function_name(param_name: type, ...) -> return_type:
+fn function_name(param_name: type, ...) -> return_type:
     # body
     return value
 ```
 
 - Parameter types are optional. When omitted, the parameter is treated as `any` type.
-- A trailing comma after the last parameter is allowed: `function f(a: int, b: int,) -> int:`.
+- A trailing comma after the last parameter is allowed: `fn f(a: int, b: int,) -> int:`.
 - Return type is optional. When omitted, the return type is **inferred from the body** (both named functions and lambdas). If the function has no `return` statement, the return type is inferred as `Unit`. Use `-> any` explicitly for functions that should accept any return type.
 - The body is an indented block.
 - Functions with an explicit return type (other than `Unit` or `any`) must have a `return` statement on all control flow paths. The compiler reports an error if any path is missing a return.
@@ -20,10 +20,10 @@ function function_name(param_name: type, ...) -> return_type:
 > **Naming convention**: Function names and parameter names must use snake_case (e.g., `add`, `get_value`, `map_list`). The compiler enforces this convention.
 
 ```ry
-function add(a: int, b: int) -> int:
+fn add(a: int, b: int) -> int:
     return a + b
 
-function greet(name: str) -> Unit:
+fn greet(name: str) -> Unit:
     print("Hello, " + name)   # Return type is Unit (explicit)
 ```
 
@@ -40,13 +40,13 @@ function greet(name: str) -> Unit:
 > **Note**: Function parameters are **immutable**. You cannot reassign a parameter inside the function body. This ensures that parameter values at entry are always available for postcondition checks (see [Design by Contract](contracts.md)).
 
 ```ry
-function no_return(x: int) -> Unit:  # Return type Unit (explicit)
+fn no_return(x: int) -> Unit:  # Return type Unit (explicit)
     print(x)
 
-function get_value() -> int:     # Return type int
+fn get_value() -> int:     # Return type int
     return 42
 
-function identity(x) -> any:    # Parameter type any (omitted)
+fn identity(x) -> any:    # Parameter type any (omitted)
     return x
 ```
 
@@ -56,7 +56,7 @@ When a parameter type annotation is omitted, the parameter is treated as `any` �
 
 ```ry
 # All parameters default to any
-function add(a, b):
+fn add(a, b):
     return a + b
 
 add(1, 2)              # 3 (int + int)
@@ -67,7 +67,7 @@ add(1, 2.0)            # 3.0 (int + float)
 You can also use `any` explicitly in type annotations:
 
 ```ry
-function identity(x: any) -> any:
+fn identity(x: any) -> any:
     return x
 ```
 
@@ -76,17 +76,17 @@ function identity(x: any) -> any:
 When the return type is omitted, it is inferred from the `return` statements in the body:
 
 ```ry
-function double(x: int):     # return type inferred as int
+fn double(x: int):     # return type inferred as int
     return x * 2
 
-function greet(name: str):   # return type inferred as Unit (no return)
+fn greet(name: str):   # return type inferred as Unit (no return)
     print("Hello, " + name)
 ```
 
 To explicitly allow any return type, use `-> any`:
 
 ```ry
-function flexible(x: any) -> any:
+fn flexible(x: any) -> any:
     return x    # can return int, float, str, etc.
 ```
 
@@ -97,8 +97,8 @@ function flexible(x: any) -> any:
 Functions can be defined inside other functions. A nested function is only visible within its enclosing function's scope — it cannot be called from outside.
 
 ```ry
-function outer() -> int:
-    function helper() -> int:
+fn outer() -> int:
+    fn helper() -> int:
         return 42
     return helper()
 
@@ -109,13 +109,13 @@ outer()     # 42
 Same-named nested functions in sibling scopes do not collide:
 
 ```ry
-function foo() -> int:
-    function helper() -> int:
+fn foo() -> int:
+    fn helper() -> int:
         return 1
     return helper()
 
-function bar() -> int:
-    function helper() -> int:
+fn bar() -> int:
+    fn helper() -> int:
         return 2
     return helper()
 
@@ -130,8 +130,8 @@ Nested functions can be used as values and passed to higher-order functions. Mut
 Nested named functions can capture variables from enclosing scopes, just like lambdas. When a nested function references an outer variable, it becomes a closure:
 
 ```ry
-function make_adder(base: int) -> function(int) -> int:
-    function add(x: int) -> int:
+fn make_adder(base: int) -> fn(int) -> int:
+    fn add(x: int) -> int:
         return x + base
     return add
 
@@ -154,7 +154,7 @@ Capture rules:
 Functions can call themselves.
 
 ```ry
-function factorial(n: int) -> int:
+fn factorial(n: int) -> int:
     if n <= 1:
         return 1
     return n * factorial(n - 1)
@@ -165,12 +165,12 @@ function factorial(n: int) -> int:
 Functions can call each other regardless of definition order. The compiler forward-declares functions with explicit return types before processing function bodies — this applies both at the top level and inside another function body (nested functions) — provided all referenced types are already known (primitive types are always available; record/enum types must be defined earlier in the file).
 
 ```ry
-function is_even(n: int) -> bool:
+fn is_even(n: int) -> bool:
     if n == 0:
         return true
     return is_odd(n - 1)       # calls is_odd defined below
 
-function is_odd(n: int) -> bool:
+fn is_odd(n: int) -> bool:
     if n == 0:
         return false
     return is_even(n - 1)      # calls is_even defined above
@@ -195,15 +195,15 @@ MAX_RETRIES: int = 5
 
 counter: int = 0
 
-function area(radius: float) -> float:
+fn area(radius: float) -> float:
     return PI * radius * radius            # reads top-level @const
 
-function clamp_retries(n: int) -> int:
+fn clamp_retries(n: int) -> int:
     if n > MAX_RETRIES:
         return MAX_RETRIES
     return n
 
-function bump():
+fn bump():
     counter = counter + 1                  # writes top-level mutable `let`
 ```
 
@@ -224,7 +224,7 @@ function bump():
 The compiler automatically detects self-recursive tail calls — where the last action in a function is a call to itself — and applies LLVM's `musttail` optimization. This guarantees that tail-recursive functions use constant stack space, preventing stack overflow for deep recursion.
 
 ```ry
-function sum_to(n: int, acc: int) -> int:
+fn sum_to(n: int, acc: int) -> int:
     if n <= 0:
         return acc
     return sum_to(n - 1, acc + n)    # tail call → optimized
@@ -253,10 +253,10 @@ Multiple functions with the same name can be defined if they differ in the numbe
 - Overloading by return type alone is not allowed.
 
 ```ry
-function area(side: int) -> int:
+fn area(side: int) -> int:
     return side * side
 
-function area(w: int, h: int) -> int:
+fn area(w: int, h: int) -> int:
     return w * h
 
 a = area(5)       # 25
@@ -277,10 +277,10 @@ The overload with the most exact matches wins. If two or more overloads have equ
 Low-level numeric types (`i8`, `i16`, `i32`, `i64`, `u8`–`u64`, `f32`) do **not** participate in implicit widening — they require explicit `as` casts.
 
 ```ry
-function process(x: int) -> str:
+fn process(x: int) -> str:
     return "int"
 
-function process(x) -> str:          # x: any
+fn process(x) -> str:          # x: any
     return "any"
 
 process(42)       # "int" — exact match (int) beats any
@@ -288,7 +288,7 @@ process("hello")  # "any" — no exact match for str, falls back to any
 ```
 
 ```ry
-function double(x: float) -> float:
+fn double(x: float) -> float:
     return x * 2.0
 
 double(5)         # OK — int is implicitly widened to float, returns 10.0
@@ -303,7 +303,7 @@ Parameters can have default values, allowing callers to omit trailing arguments.
 ### Syntax
 
 ```ry
-function connect(host: str, port: int = 8080, timeout: int = 30):
+fn connect(host: str, port: int = 8080, timeout: int = 30):
     # ...
 
 connect("localhost")                    # port=8080, timeout=30
@@ -320,9 +320,9 @@ connect("localhost", 3000, 10000)       # port=3000, timeout=10000
 
 ```ry
 # Error: ambiguous overload
-function calc(x: int, y: int = 0) -> int:
+fn calc(x: int, y: int = 0) -> int:
     return x + y
-function calc(x: int) -> int:      # conflicts with calc(int) from above
+fn calc(x: int) -> int:      # conflicts with calc(int) from above
     return x * 2
 ```
 
@@ -337,7 +337,7 @@ function calc(x: int) -> int:      # conflicts with calc(int) from above
 Functions without a return value return `Unit`. The return type can be omitted (inferred as `Unit`) or explicitly specified with `-> Unit`.
 
 ```ry
-function log(msg: str) -> Unit:
+fn log(msg: str) -> Unit:
     print(msg)
 ```
 
@@ -345,10 +345,10 @@ function log(msg: str) -> Unit:
 
 ## Tasks And Async Functions
 
-`Task<T>` is the built-in handle type for concurrent work. `async function` returns `Task<T>`, `await` extracts `T` inside another `async function`, and `block_on(task)` blocks from synchronous context until the task completes.
+`Task<T>` is the built-in handle type for concurrent work. `async fn` returns `Task<T>`, `await` extracts `T` inside another `async fn`, and `block_on(task)` blocks from synchronous context until the task completes.
 
 ```ry
-async function add(a: int, b: int) -> int:
+async fn add(a: int, b: int) -> int:
     return a + b
 
 # From synchronous context, use block_on()
@@ -356,21 +356,21 @@ t: Task<int> = add(20, 22)
 print(block_on(t))                  # 42
 block_on(add(1, 2))                 # waits and discards the result
 
-# Inside async function, use await
-async function double_add(a: int, b: int) -> int:
+# Inside async fn, use await
+async fn double_add(a: int, b: int) -> int:
     return (await add(a, b)) * 2
 ```
 
 ### Rules
 
-- `async function name(...) -> T:` is declared with the awaited result type `T`.
-- Calling an `async function` immediately returns `Task<T>`.
+- `async fn name(...) -> T:` is declared with the awaited result type `T`.
+- Calling an `async fn` immediately returns `Task<T>`.
 - `await expr` requires `expr` to be `Task<T>` and produces `T`.
-- `await` can only be used inside an `async function`. Use `block_on(task)` from synchronous context.
+- `await` can only be used inside an `async fn`. Use `block_on(task)` from synchronous context.
 - `block_on(task)` blocks the current thread until the task completes and returns the result.
-- `async function ... -> Unit` is supported; `block_on(task)` is the primary way to wait when no value is produced.
+- `async fn ... -> Unit` is supported; `block_on(task)` is the primary way to wait when no value is produced.
 - Tasks run on the runtime worker pool; they are not implemented as one OS thread per task.
-- `async` lambdas and `async @native function` are not supported in v1.
+- `async` lambdas and `async @native fn` are not supported in v1.
 
 ---
 
@@ -481,16 +481,16 @@ A type for treating functions as values.
 ### Syntax
 
 ```ry
-function(param_type1, param_type2, ...) -> return_type
+fn(param_type1, param_type2, ...) -> return_type
 ```
 
 ### Example
 
 ```ry
-f: function(int) -> int = (x: int) => x * 2
-g: function(int, int) -> int = (a: int, b: int) => a + b
+f: fn(int) -> int = (x: int) => x * 2
+g: fn(int, int) -> int = (a: int, b: int) => a + b
 
-function apply(func: function(int) -> int, x: int) -> int:
+fn apply(func: fn(int) -> int, x: int) -> int:
     return func(x)
 
 result = apply(f, 5)   # 10
@@ -516,7 +516,7 @@ msg = f"fn={f}"       # "fn=<closure>"
 Functions can accept functions as arguments or return them as values.
 
 ```ry
-function map_list(xs: List<int>, f: function(int) -> int) -> List<int>:
+fn map_list(xs: List<int>, f: fn(int) -> int) -> List<int>:
     result: List<int> = []
     for x in xs:
         result += [f(x)]
@@ -535,14 +535,14 @@ Functions can have type parameters, enabling type-safe reuse without code duplic
 ### Syntax
 
 ```ry
-function name<T, U>(param1: T, param2: U) -> T:
+fn name<T, U>(param1: T, param2: U) -> T:
     # body using T, U as types
 ```
 
 ### Example
 
 ```ry
-function identity<T>(x: T) -> T:
+fn identity<T>(x: T) -> T:
     return x
 
 # Explicit type argument
@@ -557,7 +557,7 @@ result = identity("hello")     # T = str, result = "hello"
 ### Multiple Type Parameters
 
 ```ry
-function pick_first<T, U>(a: T, b: U) -> T:
+fn pick_first<T, U>(a: T, b: U) -> T:
     return a
 
 result = pick_first(1, "x")       # T = int, U = str, result = 1
@@ -568,25 +568,25 @@ result = pick_first("hello", 42)  # T = str, U = int, result = "hello"
 
 Type parameters can appear inside generic container types (`List<T>`,
 `Map<K, V>`, `Set<T>`), tuples `(T, T)`, and function types
-`function(T) -> T`. Inference walks the declared parameter type
+`fn(T) -> T`. Inference walks the declared parameter type
 structurally against the actual argument, so explicit type annotations
 are not required when the shape is unambiguous.
 
 ```ry
-function first_of<T>(xs: List<T>) -> T:
+fn first_of<T>(xs: List<T>) -> T:
     return xs[0]
 
 first_of([1, 2, 3])            # T = int  → 1
 first_of(["hello", "world"])   # T = str  → "hello"
 first_of([[1, 2], [3, 4]])     # T = List<int>  → [1, 2]
 
-function map_lookup<K, V>(m: Map<K, V>, k: K) -> V:
+fn map_lookup<K, V>(m: Map<K, V>, k: K) -> V:
     return m[k]
 
 map_lookup({1: "a", 2: "b"}, 1)     # K = int, V = str → "a"
 map_lookup({"x": 10, "y": 20}, "y") # K = str, V = int → 20
 
-function pair_first<T>(p: (T, T)) -> T:
+fn pair_first<T>(p: (T, T)) -> T:
     return p.0
 
 pair_first((42, 7))      # T = int → 42
@@ -597,7 +597,7 @@ A type parameter referenced across multiple parameter positions is
 unified — both occurrences must resolve to the same concrete type:
 
 ```ry
-function apply_list<T>(xs: List<T>, f: function(T) -> T) -> T:
+fn apply_list<T>(xs: List<T>, f: fn(T) -> T) -> T:
     return f(xs[0])
 
 apply_list([10, 20, 30], (x: int) => x + 1)  # T = int → 11
@@ -615,7 +615,7 @@ naming the type parameter and function rather than an opaque type
 mismatch:
 
 ```ry
-function same<T>(a: T, b: T) -> T:
+fn same<T>(a: T, b: T) -> T:
     return a
 
 same(1, "x")  # error: conflicting type inference for 'T' in call to 'same'
@@ -633,7 +633,7 @@ record Animal:
 record Dog < Animal:
     breed: str
 
-function get_name<T: Animal>(a: T) -> str:
+fn get_name<T: Animal>(a: T) -> str:
     return a.name
 
 get_name(Dog("Rex", 4, "Lab"))  # OK — Dog is a subtype of Animal
@@ -645,7 +645,7 @@ Type aliases that resolve to a record type can be used either as the bound or as
 ```ry
 type AnimalAlias = Animal
 
-function describe<T: AnimalAlias>(a: T) -> str:
+fn describe<T: AnimalAlias>(a: T) -> str:
     return a.name
 
 describe(Dog("Rex", 4, "Lab"))  # OK — AnimalAlias resolves to Animal
@@ -654,7 +654,7 @@ describe(Dog("Rex", 4, "Lab"))  # OK — AnimalAlias resolves to Animal
 Bounded and unbounded type parameters can be mixed:
 
 ```ry
-function pair_name<T: Animal, U>(a: T, x: U) -> str:
+fn pair_name<T: Animal, U>(a: T, x: U) -> str:
     return a.name
 ```
 
@@ -681,10 +681,10 @@ a.f(b)
 ### Chaining
 
 ```ry
-function double(x: int) -> int:
+fn double(x: int) -> int:
     return x * 2
 
-function add_one(x: int) -> int:
+fn add_one(x: int) -> int:
     return x + 1
 
 result = 5.double().add_one()   # double(5) -> 10, add_one(10) -> 11
@@ -709,11 +709,11 @@ You can define operator behavior for user-defined types.
 
 ```ry
 # Binary operator (2 parameters)
-function operator<op>(a: type, b: type) -> return_type:
+fn operator<op>(a: type, b: type) -> return_type:
     ...
 
 # Unary operator (1 parameter)
-function operator<op>(a: type) -> return_type:
+fn operator<op>(a: type) -> return_type:
     ...
 ```
 
@@ -747,11 +747,11 @@ Comparison, logical, and membership operators must return `bool`:
 
 ```ry
 # OK
-function operator==(a: Vec2, b: Vec2) -> bool:
+fn operator==(a: Vec2, b: Vec2) -> bool:
     return a.x == b.x and a.y == b.y
 
 # Error: comparison operator '==' must return 'bool', but returns 'int'
-function operator==(a: Vec2, b: Vec2) -> int:
+fn operator==(a: Vec2, b: Vec2) -> int:
     return 42
 ```
 
@@ -767,15 +767,15 @@ record Vec2:
     y: float
 
 # Binary +
-function operator+(a: Vec2, b: Vec2) -> Vec2:
+fn operator+(a: Vec2, b: Vec2) -> Vec2:
     return Vec2(a.x + b.x, a.y + b.y)
 
 # Unary -
-function operator-(v: Vec2) -> Vec2:
+fn operator-(v: Vec2) -> Vec2:
     return Vec2(-v.x, -v.y)
 
 # Comparison
-function operator==(a: Vec2, b: Vec2) -> bool:
+fn operator==(a: Vec2, b: Vec2) -> bool:
     return a.x == b.x and a.y == b.y
 
 v1 = Vec2(1.0, 2.0)

--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -24,9 +24,9 @@ from http import listen, method, path, header, body, body_bytes, query, query_al
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `listen` | `(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>) -> Result<Unit, Error>` | Starts an HTTP server on the given address. Blocks in an accept loop, calling `handler` for each request. Returns `Err` if bind fails. |
-| `listen` | `(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int) -> Result<Unit, Error>` | Starts an HTTP server that stops after processing `max_requests` requests. Enables `async function` + `block_on()` lifecycle management. |
-| `listen` | `(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int, port_callback: function(int) -> Unit) -> Result<Unit, Error>` | Same as above, but calls `port_callback` with the actual bound port after `bind` + `listen` succeeds. Use with port `0` for OS-assigned ephemeral ports. |
+| `listen` | `(host: str, port: int, handler: fn(HttpRequest) -> Result<HttpResponse, Error>) -> Result<Unit, Error>` | Starts an HTTP server on the given address. Blocks in an accept loop, calling `handler` for each request. Returns `Err` if bind fails. |
+| `listen` | `(host: str, port: int, handler: fn(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int) -> Result<Unit, Error>` | Starts an HTTP server that stops after processing `max_requests` requests. Enables `async fn` + `block_on()` lifecycle management. |
+| `listen` | `(host: str, port: int, handler: fn(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int, port_callback: fn(int) -> Unit) -> Result<Unit, Error>` | Same as above, but calls `port_callback` with the actual bound port after `bind` + `listen` succeeds. Use with port `0` for OS-assigned ephemeral ports. |
 
 ### Request Accessors
 
@@ -70,12 +70,12 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
 )
 ```
 
-### Non-blocking Server with `async function`
+### Non-blocking Server with `async fn`
 
 ```ry
 from http import listen, path, response
 
-async function start_server(port: int) -> str:
+async fn start_server(port: int) -> str:
     listen("127.0.0.1", port, (req: HttpRequest) -> Result<HttpResponse, Error>:
         p = path(req)
         if p == "/api/health":
@@ -94,10 +94,10 @@ t = start_server(8080)
 from http import listen, path, response, http_get, status, body
 
 port_holder = [0]
-function on_port(p: int) -> Unit:
+fn on_port(p: int) -> Unit:
     port_holder[0] = p
 
-async function start_server() -> str:
+async fn start_server() -> str:
     listen("127.0.0.1", 0, (req: HttpRequest) -> Result<HttpResponse, Error>:
         return response(200, {"Content-Type": "text/plain"}, "Hello!")
     , 1, on_port)  # Stop after 1 request; call on_port with bound port
@@ -184,7 +184,7 @@ listen("127.0.0.1", 8080, (req: HttpRequest) -> Result<HttpResponse, Error>:
 
 - `listen()` binds to the address, starts listening, and enters an accept loop.
 - When called with 3 arguments, the accept loop runs indefinitely.
-- When called with 4 arguments (`max_requests`), the server stops after processing the specified number of requests. `max_requests` must be a positive integer. This enables `async function` + `block_on()` lifecycle management. Malformed requests (silently skipped) do not count toward the limit.
+- When called with 4 arguments (`max_requests`), the server stops after processing the specified number of requests. `max_requests` must be a positive integer. This enables `async fn` + `block_on()` lifecycle management. Malformed requests (silently skipped) do not count toward the limit.
 - When called with 5 arguments (`max_requests`, `port_callback`), `port_callback` is called synchronously with the actual bound port after `bind` + `listen` succeeds. This allows safe use of port `0` (OS-assigned ephemeral port) to avoid port conflicts in parallel tests.
 - The server supports HTTP/1.1 keep-alive by default. Multiple requests can be processed on a single connection. The server checks the `Connection` header on each request: if `Connection: close` is sent, the connection is closed after the response; otherwise the connection stays open for subsequent requests. Idle connections are closed after a 5-second timeout.
 - `Content-Length` is automatically added to the response if not provided in the headers map.

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -61,7 +61,7 @@ The `json` package provides functions to parse JSON text into an opaque `JsonVal
 
 `parse`, `get`, and `at` return `Result<JsonValue, Error>`. You must
 unwrap the `Result` before passing the inner value to another json
-function — passing the `Result` directly is rejected at compile time:
+fn — passing the `Result` directly is rejected at compile time:
 
 ```ry
 case parse(text):

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -102,13 +102,13 @@ case connect("127.0.0.1", 8080):
         print("connect failed")
 ```
 
-### Concurrent Echo Server with `async function`
+### Concurrent Echo Server with `async fn`
 
 ```ry
 from net import bind, listen, accept, connect, listener_port
 from io import to_bytes, bytes_to_str
 
-async function echo_server(server: TcpListener) -> str:
+async fn echo_server(server: TcpListener) -> str:
     case accept(server):
         Ok(conn):
             case receive(conn, 4096):

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -76,7 +76,7 @@ All return `bool`.
 - The `not in` operator is the negation of `in` (`x not in s`).
 - For maps, `in` checks whether the key exists.
 - For strings, `in` returns `true` when the left operand is a substring of the right operand. An empty string is always a substring of any string.
-- For lists, passing a list of non-string pointer elements (e.g. `List<List<T>>`, `List<Map<K, V>>`, `List<Set<T>>`, `List<function(...) -> R>`) is a compile error: `'in' operator is only supported for lists of primitive values or strings` (and the analogous error for `not in`). `List<any>` supports heterogeneous primitive values (`int`, `float`, `bool`, `str`) via semantic equality; collection-, function-, and resource-backed elements are not accepted by `any` itself (see [types.md — any Type](types.md#any-type)).
+- For lists, passing a list of non-string pointer elements (e.g. `List<List<T>>`, `List<Map<K, V>>`, `List<Set<T>>`, `List<fn(...) -> R>`) is a compile error: `'in' operator is only supported for lists of primitive values or strings` (and the analogous error for `not in`). `List<any>` supports heterogeneous primitive values (`int`, `float`, `bool`, `str`) via semantic equality; collection-, function-, and resource-backed elements are not accepted by `any` itself (see [types.md — any Type](types.md#any-type)).
 
 ```ry
 x = 3 < 5       # true
@@ -142,22 +142,22 @@ When used inside a function, the operand type must match the enclosing function'
 - `?` on an `Option` value requires the enclosing function to return `Option`.
 
 ```ry
-function safe_divide(a: int, b: int) -> Result<int, Error>:
+fn safe_divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
         return Err(Error("division by zero"))
     return Ok(a // b)
 
-function compute(a: int, b: int, c: int) -> Result<int, Error>:
+fn compute(a: int, b: int, c: int) -> Result<int, Error>:
     x = safe_divide(a, b)?    # returns Err early if b == 0
     y = safe_divide(x, c)!!
     return Ok(y + 1)
 
-function safe_get(xs: List<int>, i: int) -> Option<int>:
+fn safe_get(xs: List<int>, i: int) -> Option<int>:
     if i < 0 or i >= xs.length():
         return none
     return Some(xs[i])
 
-function first_plus_second(xs: List<int>) -> Option<int>:
+fn first_plus_second(xs: List<int>) -> Option<int>:
     a = safe_get(xs, 0)?    # returns None early if out of range
     b = safe_get(xs, 1)?
     return Some(a + b)
@@ -168,7 +168,7 @@ function first_plus_second(xs: List<int>) -> Option<int>:
 `?` and `!!` can also be used directly at the top level of a script. There, `Err(e)` and `None` are treated as fatal errors: the error message is written to stderr and the process exits with status `1`.
 
 ```ry
-function mk() -> Result<int, Error>:
+fn mk() -> Result<int, Error>:
     return Err(Error("something broke"))
 
 v = mk()?   # prints "error: something broke" to stderr and exits with 1
@@ -256,7 +256,7 @@ b: int? = none
 print(a ?? 0)    # 10
 print(b ?? 0)    # 0
 
-function parse_int(s: str) -> Result<int, Error>:
+fn parse_int(s: str) -> Result<int, Error>:
     # ...
 
 i = parse_int("42") ?? -1      # 42 on success, -1 on Err
@@ -394,11 +394,11 @@ You can define operator behavior for user-defined types.
 
 ```ry
 # Binary operator (2 parameters)
-function operator+(a: MyType, b: MyType) -> MyType:
+fn operator+(a: MyType, b: MyType) -> MyType:
     ...
 
 # Unary operator (1 parameter)
-function operator-(a: MyType) -> MyType:
+fn operator-(a: MyType) -> MyType:
     ...
 ```
 
@@ -430,11 +430,11 @@ Comparison and logical operators must return `bool`:
 
 ```ry
 # OK
-function operator==(a: Vec2, b: Vec2) -> bool:
+fn operator==(a: Vec2, b: Vec2) -> bool:
     return a.x == b.x and a.y == b.y
 
 # Error: comparison operator '==' must return 'bool', but returns 'int'
-function operator==(a: Vec2, b: Vec2) -> int:
+fn operator==(a: Vec2, b: Vec2) -> int:
     return 42
 ```
 
@@ -446,11 +446,11 @@ Distinguished by the number of parameters.
 
 ```ry
 # Binary -
-function operator-(a: Vec2, b: Vec2) -> Vec2:
+fn operator-(a: Vec2, b: Vec2) -> Vec2:
     return Vec2(a.x - b.x, a.y - b.y)
 
 # Unary -
-function operator-(v: Vec2) -> Vec2:
+fn operator-(v: Vec2) -> Vec2:
     return Vec2(-v.x, -v.y)
 ```
 
@@ -464,7 +464,7 @@ record Matrix:
     rows: int
     cols: int
 
-function operator+=(a: Matrix, b: Matrix) -> Matrix:
+fn operator+=(a: Matrix, b: Matrix) -> Matrix:
     for i in range(len(a.data)):
         a.data[i] = a.data[i] + b.data[i]
     return a
@@ -483,7 +483,7 @@ record Vec2:
     x: float
     y: float
 
-function operator+=(a: Vec2, b: Vec2) -> Vec2:
+fn operator+=(a: Vec2, b: Vec2) -> Vec2:
     return Vec2(a.x + b.x, a.y + b.y)
 
 v = Vec2(1.0, 2.0)
@@ -505,7 +505,7 @@ record Grid:
     d: int
 
 # Read: requires 2+ parameters (object + indices)
-function operator[](g: Grid, row: int, col: int) -> int:
+fn operator[](g: Grid, row: int, col: int) -> int:
     if row == 0 and col == 0:
         return g.a
     if row == 0 and col == 1:
@@ -515,7 +515,7 @@ function operator[](g: Grid, row: int, col: int) -> int:
     return g.d
 
 # Write: requires 3+ parameters (object + indices + value)
-function operator[]=(g: Grid, row: int, col: int, value: int):
+fn operator[]=(g: Grid, row: int, col: int, value: int):
     ...
 
 g = Grid(1, 2, 3, 4)
@@ -534,7 +534,7 @@ record Range:
     lo: int
     hi: int
 
-function operator in(value: int, r: Range) -> bool:
+fn operator in(value: int, r: Range) -> bool:
     return value >= r.lo and value < r.hi
 
 r = Range(1, 10)
@@ -552,7 +552,7 @@ The `()` operator enables records to behave as callable objects. Requires at lea
 record Adder:
     base: int
 
-function operator()(a: Adder, x: int) -> int:
+fn operator()(a: Adder, x: int) -> int:
     return a.base + x
 
 add5 = Adder(5)
@@ -572,7 +572,7 @@ record Celsius:
 record Fahrenheit:
     value: int
 
-function operator as(c: Celsius) -> Fahrenheit:
+fn operator as(c: Celsius) -> Fahrenheit:
     return Fahrenheit(c.value * 9 // 5 + 32)
 
 c = Celsius(100)
@@ -585,7 +585,7 @@ The target type can be any type the compiler can resolve, including generic type
 record Temperature:
     value: int
 
-function operator as(t: Temperature) -> int?:
+fn operator as(t: Temperature) -> int?:
     return Some(t.value)
 
 t = Temperature(42)

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -97,16 +97,16 @@ Definitions whose names start with `_` (underscore) are private to the package a
 
 ```ry
 # mylib/internal.ry
-function _helper() -> int:     # private — not importable
+fn _helper() -> int:     # private — not importable
     return 42
-function public_api() -> int:  # public — importable
+fn public_api() -> int:  # public — importable
     return _helper()
 ```
 
 ```
 mypackage/
-  calc.ry      # function add(), function sub()
-  string.ry    # function concat()
+  calc.ry      # fn add(), fn sub()
+  string.ry    # fn concat()
 ```
 
 ```ry
@@ -225,7 +225,7 @@ export RY_PATH="/usr/local/ry/lib:/home/user/ry-packages"
 
 ```ry
 # Error example: Import inside a block
-function main():
+fn main():
     from math   # Error: imports only allowed at top level
 
 # OK: Importing the same package multiple times does not cause an error
@@ -241,10 +241,10 @@ from math   # Skipped
 
 ```ry
 # calc.ry
-function add(a: int, b: int) -> int:
+fn add(a: int, b: int) -> int:
     return a + b
 
-function sub(a: int, b: int) -> int:
+fn sub(a: int, b: int) -> int:
     return a - b
 ```
 

--- a/docs/reference/records.md
+++ b/docs/reference/records.md
@@ -104,10 +104,10 @@ the full matrix and the aliasing caveat for nested collections inside records.
 ## Usage as Function Parameters and Return Values
 
 ```ry
-function distance(p: Point) -> float:
+fn distance(p: Point) -> float:
     return (p.x * p.x + p.y * p.y) as float
 
-function make_point(x: int, y: int) -> Point:
+fn make_point(x: int, y: int) -> Point:
     return Point(x, y)
 ```
 
@@ -190,7 +190,7 @@ print(err.status)   # 404 (own field)
 A child value can be passed where the parent type is expected. The child is automatically sliced to extract the parent-prefix fields (value-type slicing).
 
 ```ry
-function handle(e: Error) -> str:
+fn handle(e: Error) -> str:
     return e.message
 
 err = HttpError("fail", 500, 500, "/api")
@@ -301,7 +301,7 @@ case:
 Use the enum name as the type name.
 
 ```ry
-function is_red(c: Color) -> bool:
+fn is_red(c: Color) -> bool:
     return c == Color::Red
 
 print(is_red(Color::Red))    # true
@@ -378,7 +378,7 @@ Shape::Circle(1.0) == Shape::Point        # false — different variant
 Shape::Point       == Shape::Point        # true  — no payload
 ```
 
-Payload fields with function types are not equatable; comparing values whose matching variant carries a `function` payload is a compile-time error.
+Payload fields with function types are not equatable; comparing values whose matching variant carries an `fn(...)` payload is a compile-time error.
 
 ### Constraints and Errors
 

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -68,7 +68,7 @@ from regex import is_match, search, replace, split, find_all
 print(is_match("hello", /[a-z]+/))       # true
 print(is_match("Hello 123 World", /[0-9]+/))  # true — partial (unanchored) match
 
-# UFCS (text.function(pattern))
+# UFCS (text.fn(pattern))
 print("abc123".search(/[0-9]+/))          # 3
 print("abc123".replace(/[0-9]+/, "X"))    # abcX
 parts = "hello world".split(/\s+/)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -115,8 +115,8 @@ API
 >
 > | Lambda syntax | Directive syntax |
 > |---|---|
-> | `it("name", (): ...)` | `@it("name") function name(): ...` |
-> | `describe("name", (): ...)` | `@describe("name") function name(): ...` |
+> | `it("name", (): ...)` | `@it("name") fn name(): ...` |
+> | `describe("name", (): ...)` | `@describe("name") fn name(): ...` |
 
 ```
 describe("description", ():

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -42,7 +42,7 @@ Use the `@it` and `@describe` directives to define test cases as ordinary named 
 
 ```ry
 @it("test case name")
-function test_add():
+fn test_add():
     expect(1 + 2).to_eq(3)
 ```
 
@@ -50,13 +50,13 @@ Group related tests using `@describe`:
 
 ```ry
 @describe("Arithmetic")
-function arithmetic_tests():
+fn arithmetic_tests():
     @it("should add integers")
-    function test_add():
+    fn test_add():
         expect(1 + 2).to_eq(3)
 
     @it("should subtract integers")
-    function test_sub():
+    fn test_sub():
         expect(5 - 3).to_eq(2)
 ```
 
@@ -72,16 +72,16 @@ Variables declared in the `@describe` function body are automatically captured b
 
 ```ry
 @describe("User validation")
-function user_validation_tests():
+fn user_validation_tests():
     min_length = 8
     max_length = 64
 
     @it("should reject short passwords")
-    function test_short():
+    fn test_short():
         expect(min_length).to_be_greater_than(0)
 
     @it("should accept passwords within length limits")
-    function test_range():
+    fn test_range():
         expect(max_length).to_be_greater_than(min_length)
 ```
 
@@ -91,11 +91,11 @@ function user_validation_tests():
 
 ```ry
 @describe("API")
-function api_tests():
+fn api_tests():
     @describe("GET /users")
-    function get_users_tests():
+    fn get_users_tests():
         @it("should return 200 OK")
-        function test_ok():
+        fn test_ok():
             expect(true).to_be_true()
 ```
 
@@ -238,7 +238,7 @@ describe("Booleans", ():
 Replaces a function with a mock implementation for the current `it` block. The mock is automatically cleared when the `it` block ends.
 
 ```
-function fetch_data() -> str:
+fn fetch_data() -> str:
     return "real data"
 
 describe("mocking", ():
@@ -278,7 +278,7 @@ describe("verify", ():
 
 - Overloaded functions cannot be mocked
 - Capture-based closures cannot be used as replacements (use plain lambdas)
-- `@native function` functions cannot be mocked
+- `@native fn` declarations cannot be mocked
 
 ---
 
@@ -295,7 +295,7 @@ describe("verify", ():
     (-1, 1, 0)
 ])
 @it("should add {0} + {1} = {2}")
-function test_add(a: int, b: int, expected: int):
+fn test_add(a: int, b: int, expected: int):
     expect(a + b).to_eq(expected)
 ```
 
@@ -328,7 +328,7 @@ it("should add {0} + {1} = {2}", (a: int, b: int, expected: int):
 ```ry
 @property(count=100)
 @it("should verify addition is commutative")
-function test_commutative(a: int, b: int):
+fn test_commutative(a: int, b: int):
     expect(a + b).to_eq(b + a)
 ```
 
@@ -480,7 +480,7 @@ Create a `.ry` file in `tests/filecheck/`. Place `# CHECK:` directives at the to
 # CHECK:         alloca i64
 # CHECK:         ret i64
 
-function my_func(x: int) -> int:
+fn my_func(x: int) -> int:
   return x
 ```
 

--- a/docs/reference/thread.md
+++ b/docs/reference/thread.md
@@ -28,7 +28,7 @@ from thread import thread_spawn, thread_join, lock_new, lock_acquire, lock_relea
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `thread_spawn` | `(body: function() -> T) -> Thread` | Creates and starts a new OS thread executing `body`. Captured variables are copied by value. `T` may be `Unit`, `int`, `float`, or `bool`; see the limitations section below. |
+| `thread_spawn` | `(body: fn() -> T) -> Thread` | Creates and starts a new OS thread executing `body`. Captured variables are copied by value. `T` may be `Unit`, `int`, `float`, or `bool`; see the limitations section below. |
 | `thread_join` | `(thread: Thread) -> Result<T, Error>` | Waits for the thread to finish and returns the worker's value in `Ok(value)`. Joining an already-joined `Thread` returns `Err("thread already joined")`. |
 
 ### Example — side-effect worker (`Unit`)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -16,7 +16,7 @@
 | `List<T>` | ptr (heap) | `[1, 2, 3]` | Dynamic array |
 | `Map<K, V>` | ptr (heap) | `{"a": 1}` | Hash map |
 | `Set<T>` | ptr (heap) | `{1, 2, 3}` | Set with no duplicates |
-| `function(T1, T2) -> R` | ptr (function pointer) | `(x: int) => x * 2` | Function type |
+| `fn(T1, T2) -> R` | ptr (function pointer) | `(x: int) => x * 2` | Function type |
 | User-defined type | LLVM StructType (named) | `record Point: ...` | Record defined with the `record` keyword |
 | `enum` | i64 / tagged union | `Color::Red`, `Shape::Circle(3.14)` | Enumeration defined with the `enum` keyword (supports associated data) |
 | `Error` | `{ ptr, i64 }` | `Error("msg")`, `Error("msg", 404)` | Built-in error type |
@@ -38,7 +38,7 @@
 | `weak T` | ptr (header) | `weak s` | Weak reference to an ARC-managed value (does not prevent deallocation) |
 | `Regex` | ptr | `/[a-z]+/`, `/\d{3}/` | Regular expression pattern (created via regex literal syntax) |
 | `Result<T, E>` | `{ i1, T, E }` | `Ok(42)`, `Err(Error("fail"))` | A type representing success (`Ok`) or failure (`Err`). Both `T` and `E` slots are always present in the struct; only the active variant is meaningful |
-| `Task<T>` | ptr | (returned by async functions) | Asynchronous task handle (used with `await` and `block_on`) |
+| `Task<T>` | ptr | (returned by async fns) | Asynchronous task handle (used with `await` and `block_on`) |
 | `Iterator<T>` | ptr | (created by `iter()`) | Lazy iterator for sequential element access |
 | `T[N]` | `[N x T]` | `buf: i32[8]` | Fixed-length contiguous array of low-level type T with N elements (stack-allocated) |
 
@@ -57,7 +57,7 @@ t: (int, float) = (1, 3.14)
 xs: List<int> = [1, 2, 3]
 m: Map<str, int> = {"a": 1}
 s: Set<int> = {1, 2, 3}
-fn_val: function(int) -> int = (x: int) => x * 2
+fn_val: fn(int) -> int = (x: int) => x * 2
 rx: Regex = /[0-9]+/
 u: int | str = 42
 a: any = 42
@@ -77,7 +77,7 @@ a: any = 42
 | `List<T>` | Generic dynamic array type |
 | `Map<K, V>` | Generic hash map type |
 | `Set<T>` | Generic set type |
-| `function(T1, ...) -> R` | Function type |
+| `fn(T1, ...) -> R` | Function type |
 | `Error` | Built-in error type (`message: str`, `code: int`) |
 | `any` | Built-in type that can hold any primitive value (`int`, `float`, `bool`, `str`) or `Unit`. Supports implicit conversion: concrete values are automatically wrapped when assigned to `any`, and `any` values are automatically unwrapped (with runtime type check) when assigned to a concrete type. `any(int)` → `float` auto-promotion is supported. See [any Type](#any-type) for details |
 | `T1 \| T2 \| ...` | Union type (one of multiple types separated by `\|`) |
@@ -110,9 +110,9 @@ names: StringList = ["Alice", "Bob"]
 Type aliases also work with function types, literal types, and range types:
 
 ```ry
-type Callback = function(int, int) -> int
+type Callback = fn(int, int) -> int
 
-add: Callback = function(a: int, b: int) => a + b
+add: Callback = fn(a: int, b: int) => a + b
 print(add(3, 4))    # 7
 ```
 
@@ -135,7 +135,7 @@ x: Simple = 42
 y: Simple = "hello"
 z: Simple = true
 
-function describe(v: Simple) -> str:
+fn describe(v: Simple) -> str:
   return to_str(v)
 ```
 
@@ -249,7 +249,7 @@ x = 12                      # OK
 ### In Function Parameters
 
 ```ry
-function set_month(m: 1..12) -> int:
+fn set_month(m: 1..12) -> int:
     return m
 
 set_month(6)                # OK
@@ -268,7 +268,7 @@ The `T?` syntax is a shorthand for `Option<T>`.
 x: int? = 42       # equivalent to Option<int>
 y: int? = none      # equivalent to None
 
-function find(xs: List<int>, val: int) -> int?:
+fn find(xs: List<int>, val: int) -> int?:
     for x in xs:
         if x == val:
             return Some(x)
@@ -506,7 +506,7 @@ Shape::Point       == Shape::Point         # true  — no payload, tag equality
 
 Variants with no payload (e.g. `Point`) compare by tag only, which is always enough.
 Payload fields that are themselves ADT enums, records, collections, or strings are compared recursively.
-Payload fields with function types are not equatable; comparing two values whose matching variant carries a `function` payload is a compile-time error.
+Payload fields with function types are not equatable; comparing two values whose matching variant carries an `fn(...)` payload is a compile-time error.
 
 ### Internal Representation
 
@@ -542,7 +542,7 @@ case a:
 A generic enum can also be used as a function parameter, return type, or let-binding type annotation. The type argument must be supplied wherever the enum appears in the signature:
 
 ```ry
-function unwrap_or_int(opt: MyOption<int>, default: int) -> int:
+fn unwrap_or_int(opt: MyOption<int>, default: int) -> int:
     case opt:
         MyOption::MySome(v):
             return v
@@ -551,7 +551,7 @@ function unwrap_or_int(opt: MyOption<int>, default: int) -> int:
     return default
 
 # Inside a generic function, the type parameter is substituted into nested generics:
-function unwrap_or<T>(opt: MyOption<T>, default: T) -> T:
+fn unwrap_or<T>(opt: MyOption<T>, default: T) -> T:
     case opt:
         MyOption::MySome(v):
             return v
@@ -600,7 +600,7 @@ print(e2)          # Error: not found (code: 404)
 Functions that can fail return `Result<V, E>`:
 
 ```ry
-function divide(a: int, b: int) -> Result<int, Error>:
+fn divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
         return Err(Error("division by zero"))
     return Ok(a // b)
@@ -615,7 +615,7 @@ case divide(10, 2):
 When the return value is not meaningful, use `Result<Unit, Error>`:
 
 ```ry
-function save(path: str, data: str) -> Result<Unit, Error>:
+fn save(path: str, data: str) -> Result<Unit, Error>:
     return Ok(0 as u8)   # Unit placeholder
 
 case save("/tmp/test.txt", "hello"):
@@ -638,7 +638,7 @@ It is used with `case` for exhaustive error handling. Both `Ok` and `Err` cases 
 `Result<T, E>` supports `==` and `!=`. Two results are equal when both variants match (`Ok`/`Ok` or `Err`/`Err`) and the inner values are equal.
 
 ```ry
-function make_ok(v: int) -> Result<int, Error>: return Ok(v)
+fn make_ok(v: int) -> Result<int, Error>: return Ok(v)
 make_ok(42) == make_ok(42)   # true
 make_ok(1)  == make_ok(2)    # false
 make_ok(1)  != Err(Error("e"))  # true
@@ -667,7 +667,7 @@ print(type_of(42) == type_of(3.14)) # false
 
 Key properties:
 
-- Each distinct type definition (primitive, collection, record, enum, `Option`, `Result`, `function`, `Type` itself, etc.) receives a unique identity at compile time.
+- Each distinct type definition (primitive, collection, record, enum, `Option`, `Result`, `fn` (function type), `Type` itself, etc.) receives a unique identity at compile time.
 - `==` / `!=` on `Type` values compare identities, not display names. Two different records (or a record and an enum with the same name) are always distinguishable.
 - `print` and `to_str` display the human-readable type name (for example, `"int"`, `"List"`, `"Point"`, `"i32"`).
 - Low-level numeric types (`i8`, `i16`, …, `f32`) are distinguished from `int` / `float`.
@@ -691,11 +691,11 @@ print(x)        # hello
 ### Usage in Function Parameters and Return Types
 
 ```ry
-function show(x: int | str) -> int:
+fn show(x: int | str) -> int:
     print(x)
     return 0
 
-function get_val(flag: bool) -> int | str:
+fn get_val(flag: bool) -> int | str:
     if flag:
         return 42
     return "hello"
@@ -767,7 +767,7 @@ x: any = 42          # int is wrapped into any
 x = "hello"          # reassignment with a different type is allowed
 
 # Unwrapping: any → concrete
-function get_value() -> any:
+fn get_value() -> any:
     return 42
 n: int = get_value()  # any(int) is unwrapped to int
 
@@ -850,7 +850,7 @@ Conversion rules: `int` → decimal string, `float` → `%g` format, `bool` → 
 An `any` value can be passed to a function with concrete parameter types. The value is automatically unwrapped with a runtime type check:
 
 ```ry
-function add_one(x: int) -> int:
+fn add_one(x: int) -> int:
     return x + 1
 
 v: any = 42

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -40,7 +40,7 @@ public:
     llvm::orc::ThreadSafeModule compile(Program &prog);
     const std::vector<std::string>& getWarnings() const { return warnings_; }
 
-    // --- @native function signature types ---
+    // --- @native fn signature types ---
 
     struct NativeFnParam {
         std::string name;
@@ -63,7 +63,7 @@ public:
     using CustomEmitterFn = CodeGenCustomEmitterFn;
     using ListElemMeta = CodeGenListElemMeta;
 
-    // Access the @native function signature registry.
+    // Access the @native fn signature registry.
     // Keyed by "package::name" for package functions, bare name for builtins.
     const std::unordered_map<std::string, std::vector<NativeFnSignature>>&
     getNativeFnSigs() const { return native_fn_sigs_; }
@@ -697,8 +697,7 @@ public:
     // (null for non-capturing functions). Layout mirrored in
     // `getOrCreateUniformClosureDestructor` in src/codegen_lambda.cpp.
     static bool isFunctionTypeName(const std::string &s) {
-        return (s.size() > 3 && s.compare(0, 3, "fn(") == 0) ||
-               (s.size() > 9 && s.compare(0, 9, "function(") == 0);
+        return s.size() > 3 && s.compare(0, 3, "fn(") == 0;
     }
     llvm::StructType *getUniformClosureTy() {
         if (!uniformClosureTy_)

--- a/share/std/base64/base64.ry
+++ b/share/std/base64/base64.ry
@@ -1,25 +1,25 @@
 # Base64 encoding and decoding
 
 @native("base64")
-function encode(input: str) -> str
+fn encode(input: str) -> str
 
 @native("base64")
-function decode(input: str) -> Result<str, Error>
+fn decode(input: str) -> Result<str, Error>
 
 @native("base64")
-function encode_url_safe(input: str) -> str
+fn encode_url_safe(input: str) -> str
 
 @native("base64")
-function decode_url_safe(input: str) -> Result<str, Error>
+fn decode_url_safe(input: str) -> Result<str, Error>
 
 @native("base64")
-function encode_bytes(input: List<u8>) -> str
+fn encode_bytes(input: List<u8>) -> str
 
 @native("base64")
-function encode_bytes_url_safe(input: List<u8>) -> str
+fn encode_bytes_url_safe(input: List<u8>) -> str
 
 @native("base64")
-function decode_bytes(input: str) -> Result<List<u8>, Error>
+fn decode_bytes(input: str) -> Result<List<u8>, Error>
 
 @native("base64")
-function decode_bytes_url_safe(input: str) -> Result<List<u8>, Error>
+fn decode_bytes_url_safe(input: str) -> Result<List<u8>, Error>

--- a/share/std/builtins.ry
+++ b/share/std/builtins.ry
@@ -1,54 +1,54 @@
 # Core built-in functions
 @native
-function print(value: str) -> Unit
+fn print(value: str) -> Unit
 
 @native
-function input() -> str
+fn input() -> str
 
 @native
-function input(prompt: str) -> str
+fn input(prompt: str) -> str
 
 @native
-function length(value: str) -> int
+fn length(value: str) -> int
 
 @native
-function length(value: List<int>) -> int
+fn length(value: List<int>) -> int
 
 @native
-function length(value: Map<str, int>) -> int
+fn length(value: Map<str, int>) -> int
 
 @native
-function length(value: Set<int>) -> int
+fn length(value: Set<int>) -> int
 
 @native
-function range(count: int) -> List<int>
+fn range(count: int) -> List<int>
 
 @native
-function range(start: int, end: int) -> List<int>
+fn range(start: int, end: int) -> List<int>
 
 @native
-function range(start: int, end: int, step: int) -> List<int>
+fn range(start: int, end: int, step: int) -> List<int>
 
 @native
-function enumerate(values: List<int>) -> List<(int, int)>
+fn enumerate(values: List<int>) -> List<(int, int)>
 
 @native
-function zip(values: List<int>, other_values: List<int>) -> List<(int, int)>
+fn zip(values: List<int>, other_values: List<int>) -> List<(int, int)>
 
 @native
-function exit(code: int) -> Unit
+fn exit(code: int) -> Unit
 
 @native
-function arguments() -> List<str>
+fn arguments() -> List<str>
 
 @native
-function available_parallelism() -> int
+fn available_parallelism() -> int
 
 @native
-function sleep(duration_ms: int) -> Unit
+fn sleep(duration_ms: int) -> Unit
 
 @native
-function env(key: str) -> Option<str>
+fn env(key: str) -> Option<str>
 
 @native
-function env(key: str, default: str) -> str
+fn env(key: str, default: str) -> str

--- a/share/std/convert.ry
+++ b/share/std/convert.ry
@@ -1,15 +1,15 @@
 # Type conversion functions
 @native
-function to_int(value: str) -> Result<int, Error>
+fn to_int(value: str) -> Result<int, Error>
 
 @native
-function to_float(value: str) -> Result<float, Error>
+fn to_float(value: str) -> Result<float, Error>
 
 @native
-function to_str(value: int) -> str
+fn to_str(value: int) -> str
 
 @native
-function to_str(value: float) -> str
+fn to_str(value: float) -> str
 
 @native
-function to_str(value: bool) -> str
+fn to_str(value: bool) -> str

--- a/share/std/filesystem/filesystem.ry
+++ b/share/std/filesystem/filesystem.ry
@@ -3,64 +3,64 @@
 
 # Directory listing (non-recursive)
 @native("filesystem")
-function list_dir(path: str) -> Result<List<str>, Error>
+fn list_dir(path: str) -> Result<List<str>, Error>
 
 # Recursive file/directory traversal
 @native("filesystem")
-function walk(path: str) -> Result<List<str>, Error>
+fn walk(path: str) -> Result<List<str>, Error>
 
 # Glob pattern matching
 @native("filesystem")
-function glob_files(pattern: str) -> Result<List<str>, Error>
+fn glob_files(pattern: str) -> Result<List<str>, Error>
 
 # Copy a single file
 @native("filesystem")
-function copy(src: str, dst: str) -> Result<Unit, Error>
+fn copy(src: str, dst: str) -> Result<Unit, Error>
 
 # Move / rename a file or directory
 @native("filesystem")
-function move(src: str, dst: str) -> Result<Unit, Error>
+fn move(src: str, dst: str) -> Result<Unit, Error>
 
 # Remove a file or empty directory
 @native("filesystem")
-function remove(path: str) -> Result<Unit, Error>
+fn remove(path: str) -> Result<Unit, Error>
 
 # Remove a file, directory, or directory tree recursively
 @native("filesystem")
-function remove_all(path: str) -> Result<Unit, Error>
+fn remove_all(path: str) -> Result<Unit, Error>
 
 # Create a single directory
 @native("filesystem")
-function make_dir(path: str) -> Result<Unit, Error>
+fn make_dir(path: str) -> Result<Unit, Error>
 
 # Create a directory and all missing parents
 @native("filesystem")
-function make_dir_all(path: str) -> Result<Unit, Error>
+fn make_dir_all(path: str) -> Result<Unit, Error>
 
 # Get file size in bytes
 @native("filesystem")
-function file_size(path: str) -> Result<int, Error>
+fn file_size(path: str) -> Result<int, Error>
 
 # Check whether path is a regular file
 @native("filesystem")
-function is_file(path: str) -> Result<bool, Error>
+fn is_file(path: str) -> Result<bool, Error>
 
 # Check whether path is a directory
 @native("filesystem")
-function is_dir(path: str) -> Result<bool, Error>
+fn is_dir(path: str) -> Result<bool, Error>
 
 # Check whether path is a symbolic link
 @native("filesystem")
-function is_symlink(path: str) -> Result<bool, Error>
+fn is_symlink(path: str) -> Result<bool, Error>
 
 # Change file permissions (POSIX mode, e.g. 0o755)
 @native("filesystem")
-function chmod(path: str, mode: int) -> Result<Unit, Error>
+fn chmod(path: str, mode: int) -> Result<Unit, Error>
 
 # Create a symbolic link
 @native("filesystem")
-function symlink(target: str, link_path: str) -> Result<Unit, Error>
+fn symlink(target: str, link_path: str) -> Result<Unit, Error>
 
 # Read the target of a symbolic link
 @native("filesystem")
-function read_link(path: str) -> Result<str, Error>
+fn read_link(path: str) -> Result<str, Error>

--- a/share/std/gc/gc.ry
+++ b/share/std/gc/gc.ry
@@ -2,16 +2,16 @@
 
 # Run a full collection cycle. Returns the number of objects collected.
 @native("gc")
-function collect() -> int
+fn collect() -> int
 
 # Enable automatic collection (enabled by default).
 @native("gc")
-function enable() -> Unit
+fn enable() -> Unit
 
 # Disable automatic collection.
 @native("gc")
-function disable() -> Unit
+fn disable() -> Unit
 
 # Set the candidate count threshold for automatic collection.
 @native("gc")
-function set_threshold(n: int) -> Unit
+fn set_threshold(n: int) -> Unit

--- a/share/std/higher_order.ry
+++ b/share/std/higher_order.ry
@@ -1,27 +1,27 @@
 # Higher-order functions
 @native
-function filter(values: List<int>, predicate: function(int) -> bool) -> List<int>
+fn filter(values: List<int>, predicate: fn(int) -> bool) -> List<int>
 
 @native
-function map(values: List<int>, transform: function(int) -> int) -> List<int>
+fn map(values: List<int>, transform: fn(int) -> int) -> List<int>
 
 @native
-function reduce(values: List<int>, reducer: function(int, int) -> int) -> Option<int>
+fn reduce(values: List<int>, reducer: fn(int, int) -> int) -> Option<int>
 
 @native
-function fold(values: List<int>, init: int, reducer: function(int, int) -> int) -> int
+fn fold(values: List<int>, init: int, reducer: fn(int, int) -> int) -> int
 
 @native
-function any(values: List<int>, predicate: function(int) -> bool) -> bool
+fn any(values: List<int>, predicate: fn(int) -> bool) -> bool
 
 @native
-function all(values: List<int>, predicate: function(int) -> bool) -> bool
+fn all(values: List<int>, predicate: fn(int) -> bool) -> bool
 
 @native
-function sum(values: List<int>) -> int
+fn sum(values: List<int>) -> int
 
 @native
-function min(values: List<int>) -> int
+fn min(values: List<int>) -> int
 
 @native
-function max(values: List<int>) -> int
+fn max(values: List<int>) -> int

--- a/share/std/http/http.ry
+++ b/share/std/http/http.ry
@@ -1,73 +1,73 @@
 # HTTP server operations
 @native("http")
-function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>) -> Result<Unit, Error>
+fn listen(host: str, port: int, handler: fn(HttpRequest) -> Result<HttpResponse, Error>) -> Result<Unit, Error>
 
 @native("http")
-function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int) -> Result<Unit, Error>
+fn listen(host: str, port: int, handler: fn(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int) -> Result<Unit, Error>
 
 @native("http")
-function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int, port_callback: function(int) -> Unit) -> Result<Unit, Error>
+fn listen(host: str, port: int, handler: fn(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int, port_callback: fn(int) -> Unit) -> Result<Unit, Error>
 
 @native("http")
-function method(req: HttpRequest) -> str
+fn method(req: HttpRequest) -> str
 
 @native("http")
-function path(req: HttpRequest) -> str
+fn path(req: HttpRequest) -> str
 
 @native("http")
-function header(req: HttpRequest, key: str) -> Result<Option<str>, Error>
+fn header(req: HttpRequest, key: str) -> Result<Option<str>, Error>
 
 @native("http")
-function body(req: HttpRequest) -> str
+fn body(req: HttpRequest) -> str
 
 @native("http")
-function body_bytes(req: HttpRequest) -> List<u8>
+fn body_bytes(req: HttpRequest) -> List<u8>
 
 @native("http")
-function query(req: HttpRequest, key: str) -> Result<Option<str>, Error>
+fn query(req: HttpRequest, key: str) -> Result<Option<str>, Error>
 
 @native("http")
-function query_all(req: HttpRequest) -> Map<str, str>
+fn query_all(req: HttpRequest) -> Map<str, str>
 
 @native("http")
-function cookie(req: HttpRequest, name: str) -> Result<Option<str>, Error>
+fn cookie(req: HttpRequest, name: str) -> Result<Option<str>, Error>
 
 @native("http")
-function cookies(req: HttpRequest) -> Map<str, str>
+fn cookies(req: HttpRequest) -> Map<str, str>
 
 @native("http")
-function form_field(req: HttpRequest, name: str) -> Result<Option<str>, Error>
+fn form_field(req: HttpRequest, name: str) -> Result<Option<str>, Error>
 
 @native("http")
-function form_file(req: HttpRequest, name: str) -> Result<Option<Map<str, str>>, Error>
+fn form_file(req: HttpRequest, name: str) -> Result<Option<Map<str, str>>, Error>
 
 @native("http")
-function form_fields(req: HttpRequest) -> Map<str, str>
+fn form_fields(req: HttpRequest) -> Map<str, str>
 
 @native("http")
-function response(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>
+fn response(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>
 
 # HTTP client operations
 @native("http")
-function http_get(url: str) -> Result<HttpClientResponse, Error>
+fn http_get(url: str) -> Result<HttpClientResponse, Error>
 
 @native("http")
-function http_post(url: str, body: str, headers: Map<str, str>) -> Result<HttpClientResponse, Error>
+fn http_post(url: str, body: str, headers: Map<str, str>) -> Result<HttpClientResponse, Error>
 
 @native("http")
-function http_request(method: str, url: str, headers: Map<str, str>, body: str) -> Result<HttpClientResponse, Error>
+fn http_request(method: str, url: str, headers: Map<str, str>, body: str) -> Result<HttpClientResponse, Error>
 
 @native("http")
-function status(response: HttpClientResponse) -> int
+fn status(response: HttpClientResponse) -> int
 
 @native("http")
-function body(response: HttpClientResponse) -> str
+fn body(response: HttpClientResponse) -> str
 
 @native("http")
-function body_bytes(response: HttpClientResponse) -> List<u8>
+fn body_bytes(response: HttpClientResponse) -> List<u8>
 
 @native("http")
-function header(response: HttpClientResponse, key: str) -> Result<Option<str>, Error>
+fn header(response: HttpClientResponse, key: str) -> Result<Option<str>, Error>
 
 @native("http")
-function http_client_response_free(response: HttpClientResponse) -> Unit
+fn http_client_response_free(response: HttpClientResponse) -> Unit

--- a/share/std/io/io.ry
+++ b/share/std/io/io.ry
@@ -2,36 +2,36 @@
 
 # Standard input
 @native("io")
-function read_line() -> str
+fn read_line() -> str
 
 @native("io")
-function read_all() -> str
+fn read_all() -> str
 
 # File I/O
 @native("io")
-function read_text(path: str) -> Result<str, Error>
+fn read_text(path: str) -> Result<str, Error>
 
 @native("io")
-function write_text(path: str, content: str) -> Result<Unit, Error>
+fn write_text(path: str, content: str) -> Result<Unit, Error>
 
 @native("io")
-function append_text(path: str, content: str) -> Result<Unit, Error>
+fn append_text(path: str, content: str) -> Result<Unit, Error>
 
 @native("io")
-function exists(path: str) -> bool
+fn exists(path: str) -> bool
 
 @native("io")
-function delete_file(path: str) -> Result<Unit, Error>
+fn delete_file(path: str) -> Result<Unit, Error>
 
 @native("io")
-function read_bytes(path: str) -> Result<List<u8>, Error>
+fn read_bytes(path: str) -> Result<List<u8>, Error>
 
 @native("io")
-function write_bytes(path: str, data: List<u8>) -> Result<Unit, Error>
+fn write_bytes(path: str, data: List<u8>) -> Result<Unit, Error>
 
 # Byte conversions
 @native("io")
-function to_bytes(string: str) -> List<u8>
+fn to_bytes(string: str) -> List<u8>
 
 @native("io")
-function bytes_to_str(bytes: List<u8>) -> Result<str, Error>
+fn bytes_to_str(bytes: List<u8>) -> Result<str, Error>

--- a/share/std/json/json.ry
+++ b/share/std/json/json.ry
@@ -1,40 +1,40 @@
 # JSON parsing and serialization
 
 @native("json")
-function parse(text: str) -> Result<JsonValue, Error>
+fn parse(text: str) -> Result<JsonValue, Error>
 
 @native("json")
-function stringify(value: JsonValue) -> str
+fn stringify(value: JsonValue) -> str
 
 @native("json")
-function stringify(value: JsonValue, indent: int) -> str
+fn stringify(value: JsonValue, indent: int) -> str
 
 @native("json")
-function kind(value: JsonValue) -> str
+fn kind(value: JsonValue) -> str
 
 @native("json")
-function get(value: JsonValue, key: str) -> Result<JsonValue, Error>
+fn get(value: JsonValue, key: str) -> Result<JsonValue, Error>
 
 @native("json")
-function at(value: JsonValue, index: int) -> Result<JsonValue, Error>
+fn at(value: JsonValue, index: int) -> Result<JsonValue, Error>
 
 @native("json")
-function to_str(value: JsonValue) -> Result<str, Error>
+fn to_str(value: JsonValue) -> Result<str, Error>
 
 @native("json")
-function to_int(value: JsonValue) -> Result<int, Error>
+fn to_int(value: JsonValue) -> Result<int, Error>
 
 @native("json")
-function to_float(value: JsonValue) -> Result<float, Error>
+fn to_float(value: JsonValue) -> Result<float, Error>
 
 @native("json")
-function to_bool(value: JsonValue) -> Result<bool, Error>
+fn to_bool(value: JsonValue) -> Result<bool, Error>
 
 @native("json")
-function length(value: JsonValue) -> int
+fn length(value: JsonValue) -> int
 
 @native("json")
-function keys(value: JsonValue) -> Result<List<str>, Error>
+fn keys(value: JsonValue) -> Result<List<str>, Error>
 
 @native("json")
-function json_free(value: JsonValue) -> Unit
+fn json_free(value: JsonValue) -> Unit

--- a/share/std/list.ry
+++ b/share/std/list.ry
@@ -1,63 +1,63 @@
 # List operations
 @native
-function append(values: List<int>, value: int) -> Unit
+fn append(values: List<int>, value: int) -> Unit
 
 @native
-function pop(values: List<int>) -> Option<int>
+fn pop(values: List<int>) -> Option<int>
 
 @native
-function insert(values: List<int>, index: int, value: int) -> Unit
+fn insert(values: List<int>, index: int, value: int) -> Unit
 
 @native
-function remove_at(values: List<int>, index: int) -> int
+fn remove_at(values: List<int>, index: int) -> int
 
 @native
-function slice(values: List<int>, start: int, end: int) -> List<int>
+fn slice(values: List<int>, start: int, end: int) -> List<int>
 
 @native
-function distinct(values: List<int>) -> List<int>
+fn distinct(values: List<int>) -> List<int>
 
 @native
-function flatten(values: List<int>) -> List<int>
+fn flatten(values: List<int>) -> List<int>
 
 @native
-function sort(values: List<int>) -> List<int>
+fn sort(values: List<int>) -> List<int>
 
 @native
-function sort(values: List<int>, comparator: function(int, int) -> bool) -> List<int>
+fn sort(values: List<int>, comparator: fn(int, int) -> bool) -> List<int>
 
 @native
-function first(values: List<int>) -> Option<int>
+fn first(values: List<int>) -> Option<int>
 
 @native
-function last(values: List<int>) -> Option<int>
+fn last(values: List<int>) -> Option<int>
 
 @native
-function sort!(values: List<int>) -> Unit
+fn sort!(values: List<int>) -> Unit
 
 @native
-function sort!(values: List<int>, comparator: function(int, int) -> bool) -> Unit
+fn sort!(values: List<int>, comparator: fn(int, int) -> bool) -> Unit
 
 @native
-function reverse(values: List<int>) -> List<int>
+fn reverse(values: List<int>) -> List<int>
 
 @native
-function reverse!(values: List<int>) -> Unit
+fn reverse!(values: List<int>) -> Unit
 
 @native
-function appended(values: List<int>, value: int) -> List<int>
+fn appended(values: List<int>, value: int) -> List<int>
 
 @native
-function append!(values: List<int>, value: int) -> Unit
+fn append!(values: List<int>, value: int) -> Unit
 
 @native
-function is_empty(values: List<int>) -> bool
+fn is_empty(values: List<int>) -> bool
 
 @native
-function remove(values: List<int>, value: int) -> Unit
+fn remove(values: List<int>, value: int) -> Unit
 
 @native
-function take(values: List<int>, count: int) -> List<int>
+fn take(values: List<int>, count: int) -> List<int>
 
 @native
-function tap(values: List<int>, transform: function(int) -> int) -> List<int>
+fn tap(values: List<int>, transform: fn(int) -> int) -> List<int>

--- a/share/std/map.ry
+++ b/share/std/map.ry
@@ -1,24 +1,24 @@
 # Map operations
 @native
-function keys(map: Map<str, int>) -> List<str>
+fn keys(map: Map<str, int>) -> List<str>
 
 @native
-function values(map: Map<str, int>) -> List<int>
+fn values(map: Map<str, int>) -> List<int>
 
 @native
-function items(map: Map<str, int>) -> List<(str, int)>
+fn items(map: Map<str, int>) -> List<(str, int)>
 
 @native
-function has_key(map: Map<str, int>, key: str) -> bool
+fn has_key(map: Map<str, int>, key: str) -> bool
 
 @native
-function get(map: Map<str, int>, key: str) -> Option<int>
+fn get(map: Map<str, int>, key: str) -> Option<int>
 
 @native
-function get(map: Map<str, int>, key: str, default: int) -> int
+fn get(map: Map<str, int>, key: str, default: int) -> int
 
 @native
-function merge(first_map: Map<str, int>, second_map: Map<str, int>) -> Map<str, int>
+fn merge(first_map: Map<str, int>, second_map: Map<str, int>) -> Map<str, int>
 
 @native
-function remove(map: Map<str, int>, key: str) -> Unit
+fn remove(map: Map<str, int>, key: str) -> Unit

--- a/share/std/math/math.ry
+++ b/share/std/math/math.ry
@@ -16,79 +16,79 @@ Inf: float
 NaN: float
 
 @native
-function abs(x: int) -> int
+fn abs(x: int) -> int
 
 @native
-function abs(x: float) -> float
+fn abs(x: float) -> float
 
 @native
-function floor(x: float) -> int
+fn floor(x: float) -> int
 
 @native
-function floor(x: float, digits: int) -> float
+fn floor(x: float, digits: int) -> float
 
 @native
-function ceil(x: float) -> int
+fn ceil(x: float) -> int
 
 @native
-function ceil(x: float, digits: int) -> float
+fn ceil(x: float, digits: int) -> float
 
 @native
-function round(x: float) -> int
+fn round(x: float) -> int
 
 @native
-function round(x: float, digits: int) -> float
+fn round(x: float, digits: int) -> float
 
 @native
-function sqrt(x: float) -> float
+fn sqrt(x: float) -> float
 
 @native
-function pow(x: float, y: float) -> float
+fn pow(x: float, y: float) -> float
 
 @native
-function pow(x: int, y: int) -> int
+fn pow(x: int, y: int) -> int
 
 @native
-function log(x: float) -> float
+fn log(x: float) -> float
 
 @native
-function log(x: float, base: float) -> float
+fn log(x: float, base: float) -> float
 
 @native
-function log2(x: float) -> float
+fn log2(x: float) -> float
 
 @native
-function log10(x: float) -> float
+fn log10(x: float) -> float
 
 @native
-function exp(x: float) -> float
+fn exp(x: float) -> float
 
 @native
-function sin(x: float) -> float
+fn sin(x: float) -> float
 
 @native
-function cos(x: float) -> float
+fn cos(x: float) -> float
 
 @native
-function tan(x: float) -> float
+fn tan(x: float) -> float
 
 @native
-function asin(x: float) -> float
+fn asin(x: float) -> float
 
 @native
-function acos(x: float) -> float
+fn acos(x: float) -> float
 
 @native
-function atan(x: float) -> float
+fn atan(x: float) -> float
 
 @native
-function atan2(y: float, x: float) -> float
+fn atan2(y: float, x: float) -> float
 
 @native
-function hypot(x: float, y: float) -> float
+fn hypot(x: float, y: float) -> float
 
 @native
-function is_nan(x: float) -> bool
+fn is_nan(x: float) -> bool
 
 @native
-function is_inf(x: float) -> bool
+fn is_inf(x: float) -> bool

--- a/share/std/net/net.ry
+++ b/share/std/net/net.ry
@@ -1,42 +1,42 @@
 # TCP socket operations
 @native("net")
-function bind(host: str, port: int) -> Result<TcpListener, Error>
+fn bind(host: str, port: int) -> Result<TcpListener, Error>
 
 @native("net")
-function listen(listener: TcpListener, backlog: int) -> Result<Unit, Error>
+fn listen(listener: TcpListener, backlog: int) -> Result<Unit, Error>
 
 @native("net")
-function accept(listener: TcpListener) -> Result<TcpStream, Error>
+fn accept(listener: TcpListener) -> Result<TcpStream, Error>
 
 @native("net")
-function listener_port(listener: TcpListener) -> int
+fn listener_port(listener: TcpListener) -> int
 
 @native("net")
-function connect(host: str, port: int) -> Result<TcpStream, Error>
+fn connect(host: str, port: int) -> Result<TcpStream, Error>
 
 @native("net")
-function shutdown(listener: TcpListener) -> Unit
+fn shutdown(listener: TcpListener) -> Unit
 
 # TLS connections
 @native("net")
-function tls_connect(host: str, port: int) -> Result<TlsStream, Error>
+fn tls_connect(host: str, port: int) -> Result<TlsStream, Error>
 
 # Timeout configuration (milliseconds) — TcpStream
 @native("net")
-function set_timeout(stream: TcpStream, ms: int) -> Unit
+fn set_timeout(stream: TcpStream, ms: int) -> Unit
 
 @native("net")
-function set_receive_timeout(stream: TcpStream, ms: int) -> Unit
+fn set_receive_timeout(stream: TcpStream, ms: int) -> Unit
 
 @native("net")
-function set_send_timeout(stream: TcpStream, ms: int) -> Unit
+fn set_send_timeout(stream: TcpStream, ms: int) -> Unit
 
 # Timeout configuration (milliseconds) — TlsStream
 @native("net")
-function set_timeout(stream: TlsStream, ms: int) -> Unit
+fn set_timeout(stream: TlsStream, ms: int) -> Unit
 
 @native("net")
-function set_receive_timeout(stream: TlsStream, ms: int) -> Unit
+fn set_receive_timeout(stream: TlsStream, ms: int) -> Unit
 
 @native("net")
-function set_send_timeout(stream: TlsStream, ms: int) -> Unit
+fn set_send_timeout(stream: TlsStream, ms: int) -> Unit

--- a/share/std/path/path.ry
+++ b/share/std/path/path.ry
@@ -1,25 +1,25 @@
 # File path operations
 
 @native("path")
-function join(first: str, second: str) -> Result<str, Error>
+fn join(first: str, second: str) -> Result<str, Error>
 
 @native("path")
-function join(first: str, second: str, third: str) -> Result<str, Error>
+fn join(first: str, second: str, third: str) -> Result<str, Error>
 
 @native("path")
-function join(first: str, second: str, third: str, fourth: str) -> Result<str, Error>
+fn join(first: str, second: str, third: str, fourth: str) -> Result<str, Error>
 
 @native("path")
-function basename(path: str) -> Result<str, Error>
+fn basename(path: str) -> Result<str, Error>
 
 @native("path")
-function dirname(path: str) -> Result<str, Error>
+fn dirname(path: str) -> Result<str, Error>
 
 @native("path")
-function extension(path: str) -> Result<str, Error>
+fn extension(path: str) -> Result<str, Error>
 
 @native("path")
-function resolve(path: str) -> Result<str, Error>
+fn resolve(path: str) -> Result<str, Error>
 
 @native("path")
-function is_absolute(path: str) -> bool
+fn is_absolute(path: str) -> bool

--- a/share/std/regex.ry
+++ b/share/std/regex.ry
@@ -1,31 +1,31 @@
 # Regular expression operations
 @native
-function regex_match(text: str, pattern: str) -> bool
+fn regex_match(text: str, pattern: str) -> bool
 
 @native
-function regex_search(text: str, pattern: str) -> int
+fn regex_search(text: str, pattern: str) -> int
 
 @native
-function regex_replace(text: str, pattern: str, replacement: str) -> str
+fn regex_replace(text: str, pattern: str, replacement: str) -> str
 
 @native
-function regex_split(text: str, pattern: str) -> List<str>
+fn regex_split(text: str, pattern: str) -> List<str>
 
 @native
-function regex_find_all(text: str, pattern: str) -> List<Match>
+fn regex_find_all(text: str, pattern: str) -> List<Match>
 
 # Regex literal overloads (text-first for UFCS)
 @native
-function is_match(text: str, pattern: Regex) -> bool
+fn is_match(text: str, pattern: Regex) -> bool
 
 @native
-function search(text: str, pattern: Regex) -> int
+fn search(text: str, pattern: Regex) -> int
 
 @native
-function replace(text: str, pattern: Regex, replacement: str) -> str
+fn replace(text: str, pattern: Regex, replacement: str) -> str
 
 @native
-function split(text: str, pattern: Regex) -> List<str>
+fn split(text: str, pattern: Regex) -> List<str>
 
 @native
-function find_all(text: str, pattern: Regex) -> List<Match>
+fn find_all(text: str, pattern: Regex) -> List<Match>

--- a/share/std/runtime_internal/runtime_internal.ry
+++ b/share/std/runtime_internal/runtime_internal.ry
@@ -6,4 +6,4 @@
 # See issue #859 for motivation.
 
 @native
-function arc_live_count() -> int
+fn arc_live_count() -> int

--- a/share/std/set.ry
+++ b/share/std/set.ry
@@ -1,24 +1,24 @@
 # Set operations
 @native
-function add(set: Set<int>, value: int) -> Unit
+fn add(set: Set<int>, value: int) -> Unit
 
 @native
-function remove(set: Set<int>, value: int) -> Unit
+fn remove(set: Set<int>, value: int) -> Unit
 
 @native
-function union(first_set: Set<int>, second_set: Set<int>) -> Set<int>
+fn union(first_set: Set<int>, second_set: Set<int>) -> Set<int>
 
 @native
-function intersection(first_set: Set<int>, second_set: Set<int>) -> Set<int>
+fn intersection(first_set: Set<int>, second_set: Set<int>) -> Set<int>
 
 @native
-function difference(first_set: Set<int>, second_set: Set<int>) -> Set<int>
+fn difference(first_set: Set<int>, second_set: Set<int>) -> Set<int>
 
 @native
-function symmetric_difference(first_set: Set<int>, second_set: Set<int>) -> Set<int>
+fn symmetric_difference(first_set: Set<int>, second_set: Set<int>) -> Set<int>
 
 @native
-function is_subset(first_set: Set<int>, second_set: Set<int>) -> bool
+fn is_subset(first_set: Set<int>, second_set: Set<int>) -> bool
 
 @native
-function is_superset(first_set: Set<int>, second_set: Set<int>) -> bool
+fn is_superset(first_set: Set<int>, second_set: Set<int>) -> bool

--- a/share/std/str.ry
+++ b/share/std/str.ry
@@ -1,63 +1,63 @@
 # String operations
 @native
-function _contains(string: str, substring: str, ignore_case: bool) -> bool
+fn _contains(string: str, substring: str, ignore_case: bool) -> bool
 
-function contains(string: str, substring: str, ignore_case: bool = false) -> bool:
+fn contains(string: str, substring: str, ignore_case: bool = false) -> bool:
     return _contains(string, substring, ignore_case)
 
 @native
-function _starts_with(string: str, prefix: str, ignore_case: bool) -> bool
+fn _starts_with(string: str, prefix: str, ignore_case: bool) -> bool
 
-function starts_with(string: str, prefix: str, ignore_case: bool = false) -> bool:
+fn starts_with(string: str, prefix: str, ignore_case: bool = false) -> bool:
     return _starts_with(string, prefix, ignore_case)
 
 @native
-function _ends_with(string: str, suffix: str, ignore_case: bool) -> bool
+fn _ends_with(string: str, suffix: str, ignore_case: bool) -> bool
 
-function ends_with(string: str, suffix: str, ignore_case: bool = false) -> bool:
+fn ends_with(string: str, suffix: str, ignore_case: bool = false) -> bool:
     return _ends_with(string, suffix, ignore_case)
 
 @native
-function find(string: str, substring: str) -> Option<int>
+fn find(string: str, substring: str) -> Option<int>
 
 @native
-function byte_len(string: str) -> int
+fn byte_len(string: str) -> int
 
 @native
-function substring(string: str, start: int, end: int) -> str
+fn substring(string: str, start: int, end: int) -> str
 
 @native
-function char_at(string: str, index: int) -> str
+fn char_at(string: str, index: int) -> str
 
 @native
-function replace(string: str, target: str, replacement: str) -> str
+fn replace(string: str, target: str, replacement: str) -> str
 
 @native
-function to_upper(string: str) -> str
+fn to_upper(string: str) -> str
 
 @native
-function to_lower(string: str) -> str
+fn to_lower(string: str) -> str
 
 @native
-function trim(string: str) -> str
+fn trim(string: str) -> str
 
 @native
-function trim_start(string: str) -> str
+fn trim_start(string: str) -> str
 
 @native
-function trim_end(string: str) -> str
+fn trim_end(string: str) -> str
 
 @native
-function repeat(string: str, count: int) -> str
+fn repeat(string: str, count: int) -> str
 
 @native
-function reverse(string: str) -> str
+fn reverse(string: str) -> str
 
 @native
-function _split(string: str, delimiter: str) -> List<str>
+fn _split(string: str, delimiter: str) -> List<str>
 
-function split(string: str, delimiter: str = " ") -> List<str>:
+fn split(string: str, delimiter: str = " ") -> List<str>:
     return _split(string, delimiter)
 
 @native
-function join(values: List<str>, delimiter: str) -> str
+fn join(values: List<str>, delimiter: str) -> str

--- a/share/std/thread/thread.ry
+++ b/share/std/thread/thread.ry
@@ -5,94 +5,94 @@
 
 # Thread — spawn and join OS threads
 @native("thread")
-function thread_spawn(body: function() -> any) -> Thread
+fn thread_spawn(body: fn() -> any) -> Thread
 
 @native("thread")
-function thread_join(thread: Thread) -> Result<any, Error>
+fn thread_join(thread: Thread) -> Result<any, Error>
 
 # Lock (mutex)
 @native("thread")
-function lock_new() -> Lock
+fn lock_new() -> Lock
 
 @native("thread")
-function lock_acquire(lock: Lock) -> Result<Unit, Error>
+fn lock_acquire(lock: Lock) -> Result<Unit, Error>
 
 @native("thread")
-function lock_release(lock: Lock) -> Result<Unit, Error>
+fn lock_release(lock: Lock) -> Result<Unit, Error>
 
 @native("thread")
-function lock_free(lock: Lock) -> Unit
+fn lock_free(lock: Lock) -> Unit
 
 # RWLock (read-write lock)
 @native("thread")
-function rwlock_new() -> RWLock
+fn rwlock_new() -> RWLock
 
 @native("thread")
-function rwlock_read_lock(rwlock: RWLock) -> Result<Unit, Error>
+fn rwlock_read_lock(rwlock: RWLock) -> Result<Unit, Error>
 
 @native("thread")
-function rwlock_write_lock(rwlock: RWLock) -> Result<Unit, Error>
+fn rwlock_write_lock(rwlock: RWLock) -> Result<Unit, Error>
 
 @native("thread")
-function rwlock_unlock(rwlock: RWLock) -> Result<Unit, Error>
+fn rwlock_unlock(rwlock: RWLock) -> Result<Unit, Error>
 
 @native("thread")
-function rwlock_free(rwlock: RWLock) -> Unit
+fn rwlock_free(rwlock: RWLock) -> Unit
 
 # Semaphore
 @native("thread")
-function semaphore_new(count: int) -> Result<Semaphore, Error>
+fn semaphore_new(count: int) -> Result<Semaphore, Error>
 
 @native("thread")
-function semaphore_acquire(sem: Semaphore) -> Result<Unit, Error>
+fn semaphore_acquire(sem: Semaphore) -> Result<Unit, Error>
 
 @native("thread")
-function semaphore_release(sem: Semaphore) -> Result<Unit, Error>
+fn semaphore_release(sem: Semaphore) -> Result<Unit, Error>
 
 @native("thread")
-function semaphore_free(sem: Semaphore) -> Unit
+fn semaphore_free(sem: Semaphore) -> Unit
 
 # Barrier
 @native("thread")
-function barrier_new(count: int) -> Result<Barrier, Error>
+fn barrier_new(count: int) -> Result<Barrier, Error>
 
 @native("thread")
-function barrier_wait(barrier: Barrier) -> Result<Unit, Error>
+fn barrier_wait(barrier: Barrier) -> Result<Unit, Error>
 
 @native("thread")
-function barrier_free(barrier: Barrier) -> Unit
+fn barrier_free(barrier: Barrier) -> Unit
 
 # AtomicInt
 @native("thread")
-function atomic_int_new(value: int) -> AtomicInt
+fn atomic_int_new(value: int) -> AtomicInt
 
 @native("thread")
-function atomic_int_load(atomic: AtomicInt) -> int
+fn atomic_int_load(atomic: AtomicInt) -> int
 
 @native("thread")
-function atomic_int_store(atomic: AtomicInt, value: int) -> Unit
+fn atomic_int_store(atomic: AtomicInt, value: int) -> Unit
 
 @native("thread")
-function atomic_int_add(atomic: AtomicInt, delta: int) -> int
+fn atomic_int_add(atomic: AtomicInt, delta: int) -> int
 
 @native("thread")
-function atomic_int_sub(atomic: AtomicInt, delta: int) -> int
+fn atomic_int_sub(atomic: AtomicInt, delta: int) -> int
 
 @native("thread")
-function atomic_int_cas(atomic: AtomicInt, expected: int, desired: int) -> bool
+fn atomic_int_cas(atomic: AtomicInt, expected: int, desired: int) -> bool
 
 @native("thread")
-function atomic_int_free(atomic: AtomicInt) -> Unit
+fn atomic_int_free(atomic: AtomicInt) -> Unit
 
 # AtomicBool
 @native("thread")
-function atomic_bool_new(value: bool) -> AtomicBool
+fn atomic_bool_new(value: bool) -> AtomicBool
 
 @native("thread")
-function atomic_bool_load(atomic: AtomicBool) -> bool
+fn atomic_bool_load(atomic: AtomicBool) -> bool
 
 @native("thread")
-function atomic_bool_store(atomic: AtomicBool, value: bool) -> Unit
+fn atomic_bool_store(atomic: AtomicBool, value: bool) -> Unit
 
 @native("thread")
-function atomic_bool_free(atomic: AtomicBool) -> Unit
+fn atomic_bool_free(atomic: AtomicBool) -> Unit

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -71,7 +71,7 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
              "u8", "u16", "u32", "u64", "f32",
              "List", "Map", "Set",
              "Option", "Result",
-             "None", "function", "Type"}) {
+             "None", "fn", "Type"}) {
         canonical_type_ids_[name] = next_type_id_++;
     }
 

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -93,7 +93,7 @@ std::pair<int64_t, std::string> CodeGen::resolveTypeOfKey(llvm::Value *val) {
                     meta->union_value_type};
         }
         if (meta->fn_type_info.has_value() && vt == ptrTy_)
-            return {getOrAllocateCanonicalTypeId("function"), "function"};
+            return {getOrAllocateCanonicalTypeId("fn"), "fn"};
     }
 
     // Collection kinds collapse to their base name without constructing the

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -12,7 +12,7 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
     auto *overloadsPtr = findFunction(callee);
     if (!overloadsPtr) {
         if (native_fn_sigs_.count(callee) || native_lib_index_.count(callee)) {
-            codegenError("no matching overload for @native function '" + callee + "'");
+            codegenError("no matching overload for @native fn '" + callee + "'");
         } else {
             codegenError("undefined function: " + callee +
                 " (hint: if this function is defined later in the file, "
@@ -225,7 +225,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         }
     }
 
-    // Wrap function-typed arguments as uniform closures for function(...) params
+    // Wrap function-typed arguments as uniform closures for fn(...) params
     std::vector<llvm::Value*> uniformClosureTemps;
     if (matchedEntry)
         uniformClosureTemps = wrapFnTypedArgs(argVals, matchedEntry->paramTypeNames);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1967,7 +1967,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ErrorPropagateExpr> 
 
     if (operandIsResult) {
         if (!isResultType(fnRetTy))
-            codegenError("'?' on Result can only be used in a function that returns Result");
+            codegenError("'?' on Result can only be used in a fn that returns Result");
 
         llvm::StructType *operandResultTy = llvm::cast<llvm::StructType>(operandTy);
         llvm::StructType *retResultTy = llvm::cast<llvm::StructType>(fnRetTy);
@@ -2001,7 +2001,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ErrorPropagateExpr> 
     }
 
     if (!isOptionType(fnRetTy))
-        codegenError("'?' on Option can only be used in a function that returns Option");
+        codegenError("'?' on Option can only be used in a fn that returns Option");
 
     llvm::StructType *retOptionTy = llvm::cast<llvm::StructType>(fnRetTy);
 

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -44,7 +44,7 @@ void CodeGen::recordReturnFnTypeInfo(llvm::Function *fn, const FnTypeInfo &info,
         return;
     }
     if (!sameFnTypeInfoShape(it->second, info)) {
-        codegenError("function '" + fnNameForErrors +
+        codegenError("fn '" + fnNameForErrors +
                      "' returns incompatible function metadata across branches");
     }
 }
@@ -54,14 +54,14 @@ void CodeGen::recordReturnTypeMetaSnapshot(llvm::Function *fn, llvm::Value *val,
     llvm::Type *taskTy = getTaskResultType(val);
     auto [taskIt, taskInserted] = return_task_result_types_.emplace(fn, taskTy);
     if (!taskInserted && taskIt->second != taskTy) {
-        codegenError("function '" + fnNameForErrors +
+        codegenError("fn '" + fnNameForErrors +
                      "' returns incompatible Task result metadata across branches");
     }
 
     llvm::Type *threadTy = getThreadResultType(val);
     auto [threadIt, threadInserted] = return_thread_result_types_.emplace(fn, threadTy);
     if (!threadInserted && threadIt->second != threadTy) {
-        codegenError("function '" + fnNameForErrors +
+        codegenError("fn '" + fnNameForErrors +
                      "' returns incompatible Thread result metadata across branches");
     }
 
@@ -314,10 +314,10 @@ llvm::Function *CodeGen::declareFunction(
     for (auto &entry : overloads) {
         if (entry.paramTypes == paramTypes) {
             if (entry.func->getReturnType() == exposedRetTy)
-                codegenError("function '" + name +
+                codegenError("fn '" + name +
                     "' is already defined with the same signature");
             else
-                codegenError("function '" + name +
+                codegenError("fn '" + name +
                     "': overloads with same parameter types but different return types");
         }
         size_t overlapMin = std::max(newMinArity, entry.minArity);
@@ -328,7 +328,7 @@ llvm::Function *CodeGen::declareFunction(
                 if (paramTypes[i] != entry.paramTypes[i]) { typesMatch = false; break; }
             }
             if (typesMatch)
-                codegenError("function '" + name +
+                codegenError("fn '" + name +
                     "' with default arguments creates ambiguous overload");
         }
     }
@@ -518,7 +518,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     }
 
     emitCoverage(s->loc);
-    emitTraceSymbolDefine("function", s->name, s->loc);
+    emitTraceSymbolDefine("fn", s->name, s->loc);
 
     // Generic function: save as template, don't instantiate yet
     if (!s->type_params.empty()) {
@@ -537,7 +537,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         if (s->is_async)
             codegenError("async native functions are not supported");
         if (hasDirective(s->directives, "inline"))
-            codegenError("@inline cannot be used with @native functions");
+            codegenError("@inline cannot be used with @native fn");
         if (hasDirective(s->directives, "deprecated"))
             deprecated_functions_.insert(s->name);
 
@@ -662,7 +662,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     if (!isAnyType(bodyRetTy) && !bodyRetTy->isVoidTy()
         && !hasDirective(s->directives, "native")) {
         if (!allPathsReturn(s->body, buildEnumVariantRegistry()))
-            codegenError("function '" + s->name + "' with return type '" +
+            codegenError("fn '" + s->name + "' with return type '" +
                          returnTypeStr + "' does not return a value on all code paths");
     }
     std::string exposedReturnTypeName = s->is_async ? "Task<" + returnTypeStr + ">" : returnTypeStr;
@@ -695,7 +695,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
         if (!captures.capturedNames.empty()) {
             if (s->is_async)
-                codegenError("captured nested async functions are not yet supported (function '" +
+                codegenError("captured nested async fns are not yet supported (function '" +
                     s->name + "' captures variables from the enclosing scope)");
 
             size_t expectedArgCount = s->params.size() + captures.capturedNames.size();

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -695,7 +695,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
         if (!captures.capturedNames.empty()) {
             if (s->is_async)
-                codegenError("captured nested async fns are not yet supported (function '" +
+                codegenError("captured nested async fns are not yet supported (fn '" +
                     s->name + "' captures variables from the enclosing scope)");
 
             size_t expectedArgCount = s->params.size() + captures.capturedNames.size();

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -317,14 +317,9 @@ static bool splitFunctionTypeName(const std::string &s,
                                    std::vector<std::string> &params,
                                    std::string &returnType) {
     std::string t = trimWs(s);
-    std::string prefix;
-    if (t.rfind("fn(", 0) == 0) {
-        prefix = "fn(";
-    } else if (t.rfind("function(", 0) == 0) {
-        prefix = "function(";
-    } else {
+    if (t.rfind("fn(", 0) != 0)
         return false;
-    }
+    const std::string prefix = "fn(";
     int depth = 1;
     size_t i = prefix.size();
     for (; i < t.size() && depth > 0; ++i) {

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -726,7 +726,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                     }
                 }
             }
-            // Also derive from annotation: Map<K, function(int) -> int> → mvtn = "function(int) -> int"
+            // Also derive from annotation: Map<K, fn(int) -> int> → mvtn = "fn(int) -> int"
             if (mvtn.empty() && annot && isMapTypeName(resolvedAnnot)) {
                 std::string vtn = extractMapValueTypeName(resolvedAnnot);
                 if (!vtn.empty())

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -7,7 +7,7 @@ namespace ry {
 // a pointer-backed indirection? Used by the `emitStmt(EnumStmt)` pre-pass to
 // reject self-referential ADT variants whose payload struct would be of
 // infinite size. Indirection wrappers (`List<T>`, `Map<K,V>`, `Set<T>`,
-// `Task<T>`, `Channel<T>`, `weak T`, `function(...) -> T`) stop the descent
+// `Task<T>`, `Channel<T>`, `weak T`, `fn(...) -> T`) stop the descent
 // — their runtime representation is a pointer so embedding `target` through
 // them keeps the outer layout finite.
 static bool containsInlineSelfReference(const TypeNode &tn,
@@ -504,7 +504,7 @@ void CodeGen::emitStmt(EnumStmt &s) {
     // that are not pointer-backed) so `enum Tree: Node(Tree?)`, `Node((Tree,
     // Tree))`, and `Node(Option<Tree>)` all get the same diagnostic as
     // `Node(Tree)`. Stops at true indirections (`List`, `Map`, `Set`, `Task`,
-    // `Channel`, `weak T`, `function(...)`) — those store the payload behind
+    // `Channel`, `weak T`, `fn(...)`) — those store the payload behind
     // a pointer so the enum layout stays finite. Must run before the generic-
     // template save below so `generic_enum_templates_` never stores a
     // self-ref template that would crash at instantiation with `unknown

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -517,11 +517,11 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     if (!test_mode_)
         codegenError("@it is only allowed in test mode (use 'ry test')");
     if (s->is_async)
-        codegenError("@it: function '" + s->name + "' cannot be async");
+        codegenError("@it: fn '" + s->name + "' cannot be async");
     if (!s->type_params.empty())
-        codegenError("@it: function '" + s->name + "' cannot be generic");
+        codegenError("@it: fn '" + s->name + "' cannot be generic");
     if (s->return_type)
-        codegenError("@it: function '" + s->name + "' cannot have a return type annotation");
+        codegenError("@it: fn '" + s->name + "' cannot have a return type annotation");
 
     if (hasDirective(s->directives, "each")) {
         emitEachItDirective(s);
@@ -532,9 +532,9 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
         return;
     }
 
-    // Basic @it: function must have no parameters
+    // Basic @it: fn must have no parameters
     if (!s->params.empty())
-        codegenError("@it: function '" + s->name + "' has parameters but no @each or @property directive");
+        codegenError("@it: fn '" + s->name + "' has parameters but no @each or @property directive");
 
     std::string desc = getDirectivePositionalArg(s->directives, "it");
 
@@ -550,7 +550,7 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
 
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
-        codegenError("@it: internal error — function '" + s->name + "' not found after emit");
+        codegenError("@it: internal error — fn '" + s->name + "' not found after emit");
     const auto &entry = overloads->back();
     auto capturedArgs = loadCapturedArgs(entry, "@it");
 
@@ -592,7 +592,7 @@ void CodeGen::emitEachItDirective(std::unique_ptr<FnStmt> &s) {
 
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
-        codegenError("@each @it: internal error — function '" + s->name + "' not found after emit");
+        codegenError("@each @it: internal error — fn '" + s->name + "' not found after emit");
     const auto &entry = overloads->back();
     auto capturedVals = loadCapturedArgs(entry, "@each @it");
     emitEachItLoop(listPtr, elemTy, numFields, fmtStr, entry.func,
@@ -633,7 +633,7 @@ void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
 
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
-        codegenError("@property @it: internal error — function '" + s->name + "' not found after emit");
+        codegenError("@property @it: internal error — fn '" + s->name + "' not found after emit");
     const auto &entry = overloads->back();
     auto capturedVals = loadCapturedArgs(entry, "@property @it");
     llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
@@ -645,13 +645,13 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
     if (!test_mode_)
         codegenError("@describe is only allowed in test mode (use 'ry test')");
     if (s->is_async)
-        codegenError("@describe: function '" + s->name + "' cannot be async");
+        codegenError("@describe: fn '" + s->name + "' cannot be async");
     if (!s->type_params.empty())
-        codegenError("@describe: function '" + s->name + "' cannot be generic");
+        codegenError("@describe: fn '" + s->name + "' cannot be generic");
     if (!s->params.empty())
-        codegenError("@describe: function '" + s->name + "' cannot have parameters");
+        codegenError("@describe: fn '" + s->name + "' cannot have parameters");
     if (s->return_type)
-        codegenError("@describe: function '" + s->name + "' cannot have a return type annotation");
+        codegenError("@describe: fn '" + s->name + "' cannot have a return type annotation");
 
     std::string desc = getDirectivePositionalArg(s->directives, "describe");
     llvm::Value *descVal = cachedGlobalString(desc, ".describe_desc");
@@ -678,7 +678,7 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
 
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())
-        codegenError("@describe: internal error — function '" + s->name + "' not found after emit");
+        codegenError("@describe: internal error — fn '" + s->name + "' not found after emit");
     const auto &entry = overloads->back();
     auto capturedArgs = loadCapturedArgs(entry, "@describe");
 

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -113,7 +113,7 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
                 const auto &compName = uinfo.componentNames[i];
 
                 // Closure/function variants: return "<closure>" directly.
-                // Union component names are normalized type strings like "function(int) -> int",
+                // Union component names are normalized type strings like "fn(int) -> int",
                 // so use isFunctionTypeName() rather than comparing against the literal "closure".
                 if (uinfo.componentTypes[i]->isPointerTy() && isFunctionTypeName(compName)) {
                     phi->addIncoming(cachedGlobalString("<closure>", ".vts_closure"),

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -453,7 +453,7 @@ size_t CodeGen::findMatchingCloseParen(const std::string &s, size_t openParen) {
 }
 
 CodeGen::FnTypeInfo CodeGen::parseFnTypeAnnotation(const std::string &typeStr) {
-    // Parse canonical "fn(int, float) -> int" and the legacy "function(...)" alias.
+    // Parse canonical "fn(int, float) -> int" function type annotations.
     FnTypeInfo info;
     // Find the opening paren
     size_t openParen = typeStr.find('(');

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -317,14 +317,14 @@ void Formatter::formatFn(const FnStmt &s) {
     if (!s.directives.empty()) emitIndent();
 
     if (s.is_async) emit("async ");
-    emit("function " + s.name);
+    emit("fn " + s.name);
     emitTypeParams(s.type_params);
     emit("(" + formatParams(s.params) + ")");
     if (s.return_type) {
         emit(" -> " + s.return_type->toString());
     }
 
-    // @native functions without body: no colon, no block
+    // @native fn (no body): no colon, no block
     if (s.body.empty() && s.preconditions.empty() && s.postconditions.empty()) {
         emitInlineComment(s.loc.line);
         emitNewline();

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -45,7 +45,6 @@ static const std::unordered_map<std::string, TokenKind> keyword_map = {
     {"in",        TokenKind::In},
     {"break",     TokenKind::Break},
     {"continue",  TokenKind::Continue},
-    {"function",  TokenKind::Fn},
     {"fn",        TokenKind::Fn},
     {"return",    TokenKind::Return},
     {"from",      TokenKind::From},

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -439,7 +439,7 @@ StmtNode Parser::parseStatement() {
     if (first.kind == TokenKind::Async) {
         lex_.next(); // consume 'async'
         if (lex_.peek().kind != TokenKind::Fn)
-            parseError(first.line, "expected 'fn' or 'function' after 'async'");
+            parseError(first.line, "expected 'fn' after 'async'");
         auto stmt = parseFnStatement(directives, true);
         auto &fs = std::get<std::unique_ptr<FnStmt>>(stmt);
         fs->directives = std::move(directives);
@@ -546,7 +546,7 @@ StmtNode Parser::parseStatement() {
     if (first.kind == TokenKind::Await) {
         Token awaitTok = lex_.next(); // consume 'await'
         if (!in_async_fn_)
-            parseError(awaitTok.line, "'await' can only be used inside an 'async function'; use 'block_on()' in synchronous context");
+            parseError(awaitTok.line, "'await' can only be used inside an 'async fn'; use 'block_on()' in synchronous context");
         AwaitStmt s;
         s.operand = parseLogicalNot();
         s.loc = locFromToken(awaitTok);

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -42,7 +42,7 @@ TypeParam Parser::parseOneTypeParam() {
 
 
 StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool is_async) {
-    Token fnTok = lex_.next(); // consume 'fn' / 'function'
+    Token fnTok = lex_.next(); // consume 'fn'
 
     auto fnStmt = std::make_unique<FnStmt>();
     fnStmt->params.reserve(4);
@@ -132,7 +132,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         bool validName = isMutationFnName(nameTok.value) ||
                          (hasDirective(directives, "native") && isScreamingSnakeCase(nameTok.value));
         if (!validName)
-            parseError(nameTok.line, "function name '" + nameTok.value + "' must be snake_case (or SCREAMING_SNAKE_CASE for @native functions)");
+            parseError(nameTok.line, "fn name '" + nameTok.value + "' must be snake_case (or SCREAMING_SNAKE_CASE for @native fn names)");
         lex_.next(); // consume name
         fnStmt->name = nameTok.value;
 
@@ -254,10 +254,10 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
         }
     }
 
-    // @native function: body-less declaration
+    // @native fn: body-less declaration
     if (hasDirective(directives, "native")) {
         if (lex_.peek().kind == TokenKind::Colon)
-            parseError("@native function must not have a body");
+            parseError("@native fn must not have a body");
         return StmtNode(std::move(fnStmt));
     }
 
@@ -688,7 +688,7 @@ TypeNodePtr Parser::parseTypeNameSingle() {
 
     // fn(int, int) -> int  function type
     if (lex_.peek().kind == TokenKind::Fn) {
-        lex_.next(); // consume 'fn' / 'function'
+        lex_.next(); // consume 'fn'
         return parseFnType();
     }
 

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -346,7 +346,7 @@ ExprPtr Parser::parseLogicalNot() {
 ExprPtr Parser::parseAwaitExpr() {
     Token awaitTok = lex_.next(); // consume 'await'
     if (!in_async_fn_)
-        parseError(awaitTok.line, "'await' can only be used inside an 'async function'; use 'block_on()' in synchronous context");
+        parseError(awaitTok.line, "'await' can only be used inside an 'async fn'; use 'block_on()' in synchronous context");
     ExprPtr operand = parseLogicalNot();
     auto awaitExpr = std::make_unique<AwaitExpr>();
     awaitExpr->operand = std::move(operand);

--- a/tests/filecheck/arc_retain_list_elem_call_arg.ry
+++ b/tests/filecheck/arc_retain_list_elem_call_arg.ry
@@ -10,9 +10,9 @@
 # CHECK:      arc.retain{{.*}}:
 # CHECK:      arc.retain.done{{.*}}:
 
-function use_inner(xs: List<int>) -> int:
+fn use_inner(xs: List<int>) -> int:
   return xs[0]
 
-function main() -> int:
+fn main() -> int:
   ys: List<List<int>> = [[1, 2]]
   return use_inner(ys[0])

--- a/tests/filecheck/arc_retain_list_elem_new_var.ry
+++ b/tests/filecheck/arc_retain_list_elem_new_var.ry
@@ -16,7 +16,7 @@
 # CHECK:      arc.retain{{.*}}:
 # CHECK:      arc.retain.done{{.*}}:
 
-function main() -> int:
+fn main() -> int:
   xs: List<List<int>> = [[1, 2], [3, 4]]
   inner: List<int> = xs[0]
   return inner[0]

--- a/tests/filecheck/arc_retain_list_elem_rebind.ry
+++ b/tests/filecheck/arc_retain_list_elem_rebind.ry
@@ -17,7 +17,7 @@
 # CHECK:      arc.retain{{[0-9]*}}:
 # CHECK:      arc.retain.done{{[0-9]*}}:
 
-function main() -> int:
+fn main() -> int:
   xs: List<List<int>> = [[1, 2], [3, 4]]
   inner: List<int> = xs[0]
   inner = xs[1]

--- a/tests/filecheck/arc_retain_list_elem_return.ry
+++ b/tests/filecheck/arc_retain_list_elem_return.ry
@@ -11,10 +11,10 @@
 # CHECK:      arc.retain{{.*}}:
 # CHECK:      arc.retain.done{{.*}}:
 
-function get_first(xs: List<List<int>>) -> List<int>:
+fn get_first(xs: List<List<int>>) -> List<int>:
   return xs[0]
 
-function main() -> int:
+fn main() -> int:
   ys: List<List<int>> = [[1, 2]]
   inner = get_first(ys)
   return inner[0]

--- a/tests/filecheck/arc_retain_list_str_elem.ry
+++ b/tests/filecheck/arc_retain_list_str_elem.ry
@@ -15,10 +15,10 @@
 # CHECK:      arc.retain{{.*}}:
 # CHECK:      arc.retain.done{{.*}}:
 
-function inner() -> str:
+fn inner() -> str:
   xs: List<str> = ["x", "y"]
   return xs[0]
 
-function main() -> int:
+fn main() -> int:
   s: str = inner()
   return length(s)

--- a/tests/filecheck/arc_retain_map_str_value.ry
+++ b/tests/filecheck/arc_retain_map_str_value.ry
@@ -11,10 +11,10 @@
 # CHECK:      arc.retain{{.*}}:
 # CHECK:      arc.retain.done{{.*}}:
 
-function lookup() -> str:
+fn lookup() -> str:
   m: Map<str, str> = {"k": "v"}
   return m["k"]
 
-function main() -> int:
+fn main() -> int:
   s: str = lookup()
   return length(s)

--- a/tests/filecheck/arc_retain_map_value_new_var.ry
+++ b/tests/filecheck/arc_retain_map_value_new_var.ry
@@ -14,7 +14,7 @@
 # CHECK:      arc.retain{{.*}}:
 # CHECK:      arc.retain.done{{.*}}:
 
-function main() -> int:
+fn main() -> int:
   m: Map<str, List<int>> = {"a": [1, 2]}
   inner: List<int> = m["a"]
   return inner[0]

--- a/tests/filecheck/function_call.ry
+++ b/tests/filecheck/function_call.ry
@@ -9,5 +9,5 @@
 # CHECK:       add.ok:
 # CHECK-NEXT:    ret i64
 
-function add(a: int, b: int) -> int:
+fn add(a: int, b: int) -> int:
   return a + b

--- a/tests/filecheck/result_wrap.ry
+++ b/tests/filecheck/result_wrap.ry
@@ -8,7 +8,7 @@
 # CHECK:         insertvalue %Result { i1 true,
 # CHECK:         ret %Result
 
-function safe_div(a: int, b: int) -> Result<int, str>:
+fn safe_div(a: int, b: int) -> Result<int, str>:
   if b == 0:
     return Err("division by zero")
   result: int = a // b

--- a/tests/filecheck/str_ptr.ry
+++ b/tests/filecheck/str_ptr.ry
@@ -7,5 +7,5 @@
 # CHECK:         load ptr, ptr
 # CHECK:         ret ptr
 
-function identity(s: str) -> str:
+fn identity(s: str) -> str:
   return s

--- a/tests/fuzz/corpus/parser/control.ry
+++ b/tests/fuzz/corpus/parser/control.ry
@@ -1,4 +1,4 @@
-function count(n: int) -> int:
+fn count(n: int) -> int:
     result = 0
     for i in 0..n:
         if i % 2 == 0:

--- a/tests/fuzz/corpus/parser/decl.ry
+++ b/tests/fuzz/corpus/parser/decl.ry
@@ -1,2 +1,2 @@
-function main():
+fn main():
     print(1)

--- a/tests/fuzz/corpus/parser/pattern.ry
+++ b/tests/fuzz/corpus/parser/pattern.ry
@@ -1,4 +1,4 @@
-function greet(name: Option<str>) -> str:
+fn greet(name: Option<str>) -> str:
     return match name:
         Some(n) => f"Hello, {n}"
         None => "Hello"

--- a/tests/spec/any.test.ry
+++ b/tests/spec/any.test.ry
@@ -19,17 +19,17 @@ describe("any type", ():
 
 describe("optional param type", ():
   it("should accept single param without type annotation", ():
-    function add_one(x) -> int:
+    fn add_one(x) -> int:
       return 1
     expect(add_one(42)).to_eq(1)
   )
   it("should accept multiple params without type annotation", ():
-    function both_any(x, y) -> bool:
+    fn both_any(x, y) -> bool:
       return true
     expect(both_any(1, "hello")).to_eq(true)
   )
   it("should accept mixed typed and untyped params", ():
-    function mixed(x: int, y) -> int:
+    fn mixed(x: int, y) -> int:
       return x
     expect(mixed(10, "hello")).to_eq(10)
   )
@@ -38,22 +38,22 @@ describe("optional param type", ():
     expect(f(42)).to_eq(true)
   )
   it("should accept int as param", ():
-    function accept(v) -> bool:
+    fn accept(v) -> bool:
       return true
     expect(accept(42)).to_eq(true)
   )
   it("should accept float as param", ():
-    function accept_f(v) -> bool:
+    fn accept_f(v) -> bool:
       return true
     expect(accept_f(3.14)).to_eq(true)
   )
   it("should accept str as param", ():
-    function accept_s(v) -> bool:
+    fn accept_s(v) -> bool:
       return true
     expect(accept_s("hello")).to_eq(true)
   )
   it("should accept bool as param", ():
-    function accept_b(v) -> bool:
+    fn accept_b(v) -> bool:
       return true
     expect(accept_b(false)).to_eq(true)
   )
@@ -204,25 +204,25 @@ describe("any comparison operators", ():
 
 describe("any unwrap in function call", ():
   it("should pass any(int) to int param", ():
-    function typed_int(x: int) -> int:
+    fn typed_int(x: int) -> int:
       return x + 1
     v: any = 42
     expect(typed_int(v)).to_eq(43)
   )
   it("should pass any(float) to float param", ():
-    function typed_float(x: float) -> float:
+    fn typed_float(x: float) -> float:
       return x + 1.0
     v: any = 2.5
     expect(typed_float(v)).to_eq(3.5)
   )
   it("should pass any(str) to str param", ():
-    function typed_str(x: str) -> str:
+    fn typed_str(x: str) -> str:
       return x
     v: any = "hello"
     expect(typed_str(v)).to_eq("hello")
   )
   it("should pass any(bool) to bool param", ():
-    function typed_bool(x: bool) -> bool:
+    fn typed_bool(x: bool) -> bool:
       return x
     v: any = true
     expect(typed_bool(v)).to_eq(true)
@@ -231,9 +231,9 @@ describe("any unwrap in function call", ():
 
 describe("overload resolution: concrete preferred over any", ():
   it("should prefer concrete overload over any", ():
-    function dispatch(x: int) -> str:
+    fn dispatch(x: int) -> str:
       return "int"
-    function dispatch(x) -> str:
+    fn dispatch(x) -> str:
       return "any"
     expect(dispatch(42)).to_eq("int")
   )
@@ -284,7 +284,7 @@ describe("any to_str / f-string", ():
     expect(f"value is {x}").to_eq("value is 42")
   )
   it("should convert unit to str", ():
-    function unit_fn() -> any:
+    fn unit_fn() -> any:
       return
     x: any = unit_fn()
     expect(f"{x}").to_eq("Unit")
@@ -306,22 +306,22 @@ describe("any unary negation", ():
 
 describe("any parameter computation", ():
   it("should compute int addition via any params", ():
-    function add(a, b):
+    fn add(a, b):
       return a + b
     expect(add(1, 2)).to_eq(3)
   )
   it("should concatenate strings via any params", ():
-    function concat(a, b):
+    fn concat(a, b):
       return a + b
     expect(concat("hello", " world")).to_eq("hello world")
   )
   it("should multiply mixed int/float", ():
-    function mul(a, b):
+    fn mul(a, b):
       return a * b
     expect(mul(3, 2.0)).to_eq(6.0)
   )
   it("should compare via any params", ():
-    function greater(a, b):
+    fn greater(a, b):
       return a > b
     expect(greater(5, 3)).to_eq(true)
   )
@@ -329,22 +329,22 @@ describe("any parameter computation", ():
 
 describe("any identity / round-trip", ():
   it("should preserve int through identity", ():
-    function identity(x: any) -> any:
+    fn identity(x: any) -> any:
       return x
     expect(identity(42)).to_eq(42)
   )
   it("should preserve str through identity", ():
-    function identity_s(x: any) -> any:
+    fn identity_s(x: any) -> any:
       return x
     expect(identity_s("hi")).to_eq("hi")
   )
   it("should preserve float through identity", ():
-    function identity_f(x: any) -> any:
+    fn identity_f(x: any) -> any:
       return x
     expect(identity_f(3.14)).to_eq(3.14)
   )
   it("should preserve bool through identity", ():
-    function identity_b(x: any) -> any:
+    fn identity_b(x: any) -> any:
       return x
     expect(identity_b(true)).to_eq(true)
   )
@@ -365,7 +365,7 @@ describe("any lambda computation", ():
 
 describe("any default return type", ():
   it("should return computed value from function with omitted return type", ():
-    function double_val(x: int):
+    fn double_val(x: int):
       return x * 2
     expect(double_val(5)).to_eq(10)
   )
@@ -373,37 +373,37 @@ describe("any default return type", ():
 
 describe("any to concrete conversion", ():
   it("should unwrap any(int) to int variable", ():
-    function get_int() -> any:
+    fn get_int() -> any:
       return 42
     x: int = get_int()
     expect(x).to_eq(42)
   )
   it("should unwrap any(str) to str variable", ():
-    function get_str() -> any:
+    fn get_str() -> any:
       return "hello"
     x: str = get_str()
     expect(x).to_eq("hello")
   )
   it("should unwrap any(float) to float variable", ():
-    function get_float() -> any:
+    fn get_float() -> any:
       return 3.14
     x: float = get_float()
     expect(x).to_eq(3.14)
   )
   it("should unwrap any(bool) to bool variable", ():
-    function get_bool() -> any:
+    fn get_bool() -> any:
       return true
     x: bool = get_bool()
     expect(x).to_eq(true)
   )
   it("should auto-promote int to float in unwrap", ():
-    function get_int_any() -> any:
+    fn get_int_any() -> any:
       return 42
     x: float = get_int_any()
     expect(x).to_eq(42.0)
   )
   it("should reassign concrete variable from any value", ():
-    function get_any() -> any:
+    fn get_any() -> any:
       return 99
     x: int = 0
     x = get_any()

--- a/tests/spec/any_fn_return.test.ry
+++ b/tests/spec/any_fn_return.test.ry
@@ -1,36 +1,36 @@
 describe("any return from function", ():
   it("should return int from any-returning function", ():
-    function get_int() -> any:
+    fn get_int() -> any:
       return 42
     x: any = get_int()
     expect(true).to_eq(true)
   )
   it("should return float from any-returning function", ():
-    function get_float() -> any:
+    fn get_float() -> any:
       return 3.14
     x: any = get_float()
     expect(true).to_eq(true)
   )
   it("should return str from any-returning function", ():
-    function get_str() -> any:
+    fn get_str() -> any:
       return "hello"
     x: any = get_str()
     expect(true).to_eq(true)
   )
   it("should return bool from any-returning function", ():
-    function get_bool() -> any:
+    fn get_bool() -> any:
       return true
     x: any = get_bool()
     expect(true).to_eq(true)
   )
   it("should return without value from any-returning function", ():
-    function no_val() -> any:
+    fn no_val() -> any:
       return
     x: any = no_val()
     expect(true).to_eq(true)
   )
   it("should support implicit return from any-returning function", ():
-    function implicit_any() -> any:
+    fn implicit_any() -> any:
       y = 1
     x: any = implicit_any()
     expect(true).to_eq(true)
@@ -59,12 +59,12 @@ describe("any return from lambda", ():
 
 describe("omitted return type function (inferred)", ():
   it("should infer int for function with omitted return type", ():
-    function get_val():
+    fn get_val():
       return 42
     expect(get_val()).to_eq(42)
   )
   it("should infer Unit for function with omitted return type", ():
-    function do_nothing():
+    fn do_nothing():
       y = 1
     do_nothing()
     expect(true).to_eq(true)

--- a/tests/spec/chained_lhs_assign.test.ry
+++ b/tests/spec/chained_lhs_assign.test.ry
@@ -33,11 +33,11 @@ record LhsDeepBox:
 # function per #817 pattern.
 chained_lhs_fcalls: int = 0
 
-function chained_lhs_reset_counter() -> int:
+fn chained_lhs_reset_counter() -> int:
   chained_lhs_fcalls = 0
   return 0
 
-function chained_lhs_fidx() -> int:
+fn chained_lhs_fidx() -> int:
   chained_lhs_fcalls = chained_lhs_fcalls + 1
   return 0
 

--- a/tests/spec/closure_capture_expr_types.test.ry
+++ b/tests/spec/closure_capture_expr_types.test.ry
@@ -1,7 +1,7 @@
 describe("closure capture — SetExpr", ():
   it("should capture variable used in set literal element", ():
-    function make_set_builder(x: str) -> function() -> int:
-      function build() -> int:
+    fn make_set_builder(x: str) -> fn() -> int:
+      fn build() -> int:
         s = {x, "b", "c"}
         return s.length()
       return build
@@ -13,8 +13,8 @@ describe("closure capture — SetExpr", ():
 
 describe("closure capture — CastExpr", ():
   it("should capture variable used in cast expression", ():
-    function make_caster(x: int) -> function() -> float:
-      function cast_it() -> float:
+    fn make_caster(x: int) -> fn() -> float:
+      fn cast_it() -> float:
         return x as float
       return cast_it
 
@@ -25,8 +25,8 @@ describe("closure capture — CastExpr", ():
 
 describe("closure capture — WhenCondExpr", ():
   it("should capture variable in when expression condition", ():
-    function make_classifier(threshold: int) -> function(int) -> str:
-      function classify(x: int) -> str:
+    fn make_classifier(threshold: int) -> fn(int) -> str:
+      fn classify(x: int) -> str:
         return case:
           x > threshold : "big"
           _ : "small"
@@ -38,8 +38,8 @@ describe("closure capture — WhenCondExpr", ():
   )
 
   it("should capture variable in when expression value", ():
-    function make_labeler(label: str) -> function(bool) -> str:
-      function labelize(flag: bool) -> str:
+    fn make_labeler(label: str) -> fn(bool) -> str:
+      fn labelize(flag: bool) -> str:
         return case:
           flag : label
           _ : "none"
@@ -51,8 +51,8 @@ describe("closure capture — WhenCondExpr", ():
   )
 
   it("should capture variable in when expression else branch", ():
-    function make_fallback(default_val: str) -> function(bool) -> str:
-      function pick(flag: bool) -> str:
+    fn make_fallback(default_val: str) -> fn(bool) -> str:
+      fn pick(flag: bool) -> str:
         return case:
           flag : "active"
           _ : default_val
@@ -65,8 +65,8 @@ describe("closure capture — WhenCondExpr", ():
 
 describe("closure capture — MatchExpr", ():
   it("should capture variable in match expression arm value", ():
-    function make_matcher(fallback: str) -> function(int) -> str:
-      function do_match(x: int) -> str:
+    fn make_matcher(fallback: str) -> fn(int) -> str:
+      fn do_match(x: int) -> str:
         return case x:
           1 : "one"
           _ : fallback
@@ -78,8 +78,8 @@ describe("closure capture — MatchExpr", ():
   )
 
   it("should capture variable in match expression guard", ():
-    function make_guard_matcher(limit: int) -> function(int) -> str:
-      function do_match(x: int) -> str:
+    fn make_guard_matcher(limit: int) -> fn(int) -> str:
+      fn do_match(x: int) -> str:
         return case x:
           n if n > limit : "above"
           _ : "below"
@@ -91,8 +91,8 @@ describe("closure capture — MatchExpr", ():
   )
 
   it("should capture variable used as match subject", ():
-    function make_subject_matcher(val: int) -> function() -> str:
-      function do_match() -> str:
+    fn make_subject_matcher(val: int) -> fn() -> str:
+      fn do_match() -> str:
         return case val:
           1 : "one"
           2 : "two"
@@ -106,8 +106,8 @@ describe("closure capture — MatchExpr", ():
 
 describe("closure capture — RangeExpr", ():
   it("should capture variable used as range end bound", ():
-    function make_summer(n: int) -> function() -> int:
-      function sum_up() -> int:
+    fn make_summer(n: int) -> fn() -> int:
+      fn sum_up() -> int:
         total = 0
         for i in 1..n:
           total = total + i
@@ -119,8 +119,8 @@ describe("closure capture — RangeExpr", ():
   )
 
   it("should capture variable used as range start bound", ():
-    function make_range_summer(start: int) -> function() -> int:
-      function sum_up() -> int:
+    fn make_range_summer(start: int) -> fn() -> int:
+      fn sum_up() -> int:
         total = 0
         for i in start..4:
           total = total + i
@@ -133,14 +133,14 @@ describe("closure capture — RangeExpr", ():
 )
 
 describe("closure capture — ErrorPropagateExpr", ():
-  function safe_divide(a: int, b: int) -> Result<int, Error>:
+  fn safe_divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
       return Err(Error("division by zero"))
     return Ok(a // b)
 
   it("should capture variable used with ? operator", ():
-    function make_divider(divisor: int) -> function(int) -> Result<int, Error>:
-      function do_divide(x: int) -> Result<int, Error>:
+    fn make_divider(divisor: int) -> fn(int) -> Result<int, Error>:
+      fn do_divide(x: int) -> Result<int, Error>:
         result = safe_divide(x, divisor)?
         return Ok(result)
       return do_divide
@@ -156,8 +156,8 @@ describe("closure capture — ErrorPropagateExpr", ():
 
 describe("closure capture — WeakExpr", ():
   it("should capture variable used in weak expression", ():
-    function make_weakener(xs: List<int>) -> function() -> bool:
-      function weaken() -> bool:
+    fn make_weakener(xs: List<int>) -> fn() -> bool:
+      fn weaken() -> bool:
         w: weak List<int> = weak xs
         case w:
           Some(v):

--- a/tests/spec/closure_fn_param.test.ry
+++ b/tests/spec/closure_fn_param.test.ry
@@ -1,5 +1,5 @@
 describe("closure fn param", ():
-  function apply(f: function(int) -> int, x: int) -> int:
+  fn apply(f: fn(int) -> int, x: int) -> int:
     return f(x)
 
   it("should pass capturing lambda to function param", ():
@@ -9,8 +9,8 @@ describe("closure fn param", ():
   )
 
   it("should pass nested named function with capture to function param", ():
-    function outer(factor: int) -> int:
-      function mul(x: int) -> int:
+    fn outer(factor: int) -> int:
+      fn mul(x: int) -> int:
         return x * factor
       return apply(mul, 6)
 
@@ -22,14 +22,14 @@ describe("closure fn param", ():
   )
 
   it("should pass top-level function to function param", ():
-    function double(x: int) -> int:
+    fn double(x: int) -> int:
       return x * 2
 
     expect(apply(double, 5)).to_eq(10)
   )
 
   it("should pass closure through two function boundaries", ():
-    function apply2(f: function(int) -> int, x: int) -> int:
+    fn apply2(f: fn(int) -> int, x: int) -> int:
       return apply(f, x)
 
     factor = 7
@@ -38,7 +38,7 @@ describe("closure fn param", ():
   )
 
   it("should survive string capture through function param (ARC)", ():
-    function apply_str(f: function(str) -> str, x: str) -> str:
+    fn apply_str(f: fn(str) -> str, x: str) -> str:
       return f(x)
 
     prefix = "hello "

--- a/tests/spec/closure_higher_order.test.ry
+++ b/tests/spec/closure_higher_order.test.ry
@@ -1,6 +1,6 @@
 describe("closure — returned from function", ():
   it("should return callable closure from make_adder", ():
-    function make_adder(base: int) -> function(int) -> int:
+    fn make_adder(base: int) -> fn(int) -> int:
       return (x: int) => x + base
 
     add5 = make_adder(5)
@@ -8,7 +8,7 @@ describe("closure — returned from function", ():
   )
 
   it("should support returned closure with multiple captures", ():
-    function make_linear(a: int, b: int) -> function(int) -> int:
+    fn make_linear(a: int, b: int) -> fn(int) -> int:
       return (x: int) => a * x + b
 
     f = make_linear(3, 10)
@@ -16,7 +16,7 @@ describe("closure — returned from function", ():
   )
 
   it("should support returned no-capture lambda", ():
-    function make_doubler() -> function(int) -> int:
+    fn make_doubler() -> fn(int) -> int:
       return (x: int) => x * 2
 
     double = make_doubler()
@@ -26,7 +26,7 @@ describe("closure — returned from function", ():
 
 describe("closure — function-type parameter capture", ():
   it("should compose two captured function params", ():
-    function compose(f: function(int) -> int, g: function(int) -> int) -> function(int) -> int:
+    fn compose(f: fn(int) -> int, g: fn(int) -> int) -> fn(int) -> int:
       return (x: int) => f(g(x))
 
     double = (x: int) => x * 2
@@ -36,7 +36,7 @@ describe("closure — function-type parameter capture", ():
   )
 
   it("should capture function param in apply_twice", ():
-    function apply_twice(f: function(int) -> int, x: int) -> int:
+    fn apply_twice(f: fn(int) -> int, x: int) -> int:
       g = (v: int) => f(f(v))
       return g(x)
 

--- a/tests/spec/closure_match_pattern_capture.test.ry
+++ b/tests/spec/closure_match_pattern_capture.test.ry
@@ -1,8 +1,8 @@
 describe("match pattern capture", ():
   it("match expr pattern binding excluded from closure capture", ():
     n = 999
-    function make_matcher(limit: int) -> function(int) -> str:
-      function do_match(x: int) -> str:
+    fn make_matcher(limit: int) -> fn(int) -> str:
+      fn do_match(x: int) -> str:
         return case x:
           n if n > limit : "above"
           _ : "below"
@@ -15,8 +15,8 @@ describe("match pattern capture", ():
 
   it("match stmt pattern binding excluded from closure capture", ():
     n = 999
-    function make_classifier(limit: int) -> function(int) -> str:
-      function classify(x: int) -> str:
+    fn make_classifier(limit: int) -> fn(int) -> str:
+      fn classify(x: int) -> str:
         result = ""
         case x:
           n if n > limit:
@@ -33,8 +33,8 @@ describe("match pattern capture", ():
 
   it("captures outer variable but not pattern binding with same name", ():
     suffix = "!"
-    function make_matcher(limit: int) -> function(int) -> str:
-      function do_match(x: int) -> str:
+    fn make_matcher(limit: int) -> fn(int) -> str:
+      fn do_match(x: int) -> str:
         return case x:
           n if n > limit : f"above{suffix}"
           _ : f"below{suffix}"
@@ -47,8 +47,8 @@ describe("match pattern capture", ():
 
   it("str outer not captured when pattern binds int with same name", ():
     n = "outer_string"
-    function make_matcher(limit: int) -> function(int) -> str:
-      function do_match(x: int) -> str:
+    fn make_matcher(limit: int) -> fn(int) -> str:
+      fn do_match(x: int) -> str:
         return case x:
           n if n > limit : "above"
           _ : "below"

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -874,7 +874,7 @@ describe("Tuple", ():
     expect(t.1).to_eq("hello")
   )
   it("should return tuple from function", ():
-    function swap(a: int, b: int) -> (int, int):
+    fn swap(a: int, b: int) -> (int, int):
       return (b, a)
     res = swap(1, 2)
     expect(res.0).to_eq(2)

--- a/tests/spec/combinatorial/collection_element_result_access.test.ry
+++ b/tests/spec/combinatorial/collection_element_result_access.test.ry
@@ -1,7 +1,7 @@
-function make_ok_int(v: int) -> Result<int, Error>:
+fn make_ok_int(v: int) -> Result<int, Error>:
   return Ok(v)
 
-function make_err_int() -> Result<int, Error>:
+fn make_err_int() -> Result<int, Error>:
   return Err(Error("fail"))
 
 describe("collection element — Result in List", ():

--- a/tests/spec/combinatorial/collection_element_result_iterate.test.ry
+++ b/tests/spec/combinatorial/collection_element_result_iterate.test.ry
@@ -1,7 +1,7 @@
-function make_ok_int(v: int) -> Result<int, Error>:
+fn make_ok_int(v: int) -> Result<int, Error>:
   return Ok(v)
 
-function make_err_int() -> Result<int, Error>:
+fn make_err_int() -> Result<int, Error>:
   return Err(Error("fail"))
 
 describe("collection element — Result in List", ():

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -115,9 +115,9 @@ describe("equality — Option with collection inner types", ():
   )
 )
 
-function res_ok(v: int) -> Result<int, Error>:
+fn res_ok(v: int) -> Result<int, Error>:
   return Ok(v)
-function res_err(msg: str) -> Result<int, Error>:
+fn res_err(msg: str) -> Result<int, Error>:
   return Err(Error(msg))
 
 describe("equality — Result", ():

--- a/tests/spec/combinatorial/fn_argument.test.ry
+++ b/tests/spec/combinatorial/fn_argument.test.ry
@@ -8,27 +8,27 @@ enum FnArgSuit:
   Clubs
   Spades
 
-function take_set(s: Set<int>) -> bool:
+fn take_set(s: Set<int>) -> bool:
   return 10 in s
 
-function take_tuple(t: (int, str)) -> int:
+fn take_tuple(t: (int, str)) -> int:
   return t.0
 
-function take_result_ok(r: Result<int, Error>) -> bool:
+fn take_result_ok(r: Result<int, Error>) -> bool:
   return case r:
     Ok(_) : true
     Err(_) : false
 
-function make_ok_result(v: int) -> Result<int, Error>:
+fn make_ok_result(v: int) -> Result<int, Error>:
   return Ok(v)
 
-function make_err_result(msg: str) -> Result<int, Error>:
+fn make_err_result(msg: str) -> Result<int, Error>:
   return Err(Error(msg))
 
-function take_record(p: FnArgPoint) -> int:
+fn take_record(p: FnArgPoint) -> int:
   return p.x + p.y
 
-function take_enum(s: FnArgSuit) -> bool:
+fn take_enum(s: FnArgSuit) -> bool:
   return s == FnArgSuit::Hearts
 
 describe("fn argument — Set", ():

--- a/tests/spec/combinatorial/fn_return.test.ry
+++ b/tests/spec/combinatorial/fn_return.test.ry
@@ -8,25 +8,25 @@ enum FnReturnDir:
   East
   West
 
-function make_map() -> Map<str, int>:
+fn make_map() -> Map<str, int>:
   m: Map<str, int> = {"a": 1, "b": 2, "c": 3}
   return m
 
-function make_set() -> Set<int>:
+fn make_set() -> Set<int>:
   return {10, 20, 30}
 
-function make_pair() -> (int, str):
+fn make_pair() -> (int, str):
   return (42, "hello")
 
-function flexible(flag: bool) -> int | str:
+fn flexible(flag: bool) -> int | str:
   if flag:
     return 42
   return "hello"
 
-function make_point(a: int, b: int) -> FnReturnPoint:
+fn make_point(a: int, b: int) -> FnReturnPoint:
   return FnReturnPoint(a, b)
 
-function pick_dir(n: int) -> FnReturnDir:
+fn pick_dir(n: int) -> FnReturnDir:
   if n == 0:
     return FnReturnDir::North
   return FnReturnDir::South

--- a/tests/spec/combinatorial/list_element_types.test.ry
+++ b/tests/spec/combinatorial/list_element_types.test.ry
@@ -53,7 +53,7 @@ describe("List<closure> — element access", ():
   it("should call closures from annotated List<closure> in for loop", ():
     add2 = (x: int) => x + 2
     add5 = (x: int) => x + 5
-    fns: List<function(int) -> int> = [add2, add5]
+    fns: List<fn(int) -> int> = [add2, add5]
     results: List<int> = []
     for f in fns:
       results.append!(f(10))

--- a/tests/spec/combinatorial/nested_types.test.ry
+++ b/tests/spec/combinatorial/nested_types.test.ry
@@ -1,9 +1,9 @@
-function divide(a: int, b: int) -> Result<int, Error>:
+fn divide(a: int, b: int) -> Result<int, Error>:
   if b == 0:
     return Err(Error("division by zero"))
   return Ok(a // b)
 
-function try_parse(s: str) -> Result<int, Error>:
+fn try_parse(s: str) -> Result<int, Error>:
   v = s.to_int()
   return case v:
     Ok(n) : Ok(n)
@@ -99,7 +99,7 @@ describe("nested — Option<(int, str)>", ():
   )
 )
 
-function make_greeting(name: str) -> Result<str, Error>:
+fn make_greeting(name: str) -> Result<str, Error>:
   if name == "":
     return Err(Error("name required"))
   return Ok(f"hello, {name}")

--- a/tests/spec/combinatorial/syntax_combinations.test.ry
+++ b/tests/spec/combinatorial/syntax_combinations.test.ry
@@ -3,19 +3,19 @@ enum SyntaxShape:
   Rect
   Triangle
 
-function describe_shape_a(s: SyntaxShape) -> str:
+fn describe_shape_a(s: SyntaxShape) -> str:
   return case s:
     SyntaxShape::Circle : "circle"
     SyntaxShape::Rect : "rect"
     SyntaxShape::Triangle : "triangle"
 
-function describe_shape_b(s: SyntaxShape) -> str:
+fn describe_shape_b(s: SyntaxShape) -> str:
   return case s:
     SyntaxShape::Circle : "round"
     SyntaxShape::Rect : "angular"
     SyntaxShape::Triangle : "pointed"
 
-function make_multiplier(factor: int) -> function(int) -> int:
+fn make_multiplier(factor: int) -> fn(int) -> int:
   return (x: int) => x * factor
 
 describe("syntax combo — lambda with local var, if, return", ():
@@ -80,7 +80,7 @@ describe("syntax combo — when expression (inline case) in expression position"
 
 describe("syntax combo — type annotation with generics in parameter", ():
   it("should pass Map<str, List<int>> as function argument", ():
-    function get_first_item(data: Map<str, List<int>>, key: str) -> int:
+    fn get_first_item(data: Map<str, List<int>>, key: str) -> int:
       xs = data[key]
       return xs[0]
 
@@ -111,7 +111,7 @@ describe("syntax combo — single-element tuple", ():
     expect(t.0).to_eq(42)
   )
   it("should pass single-element tuple as function argument", ():
-    function first_of_one(t: (int,)) -> int:
+    fn first_of_one(t: (int,)) -> int:
       return t.0
 
     expect(first_of_one((99,))).to_eq(99)

--- a/tests/spec/concurrency.test.ry
+++ b/tests/spec/concurrency.test.ry
@@ -1,24 +1,24 @@
 describe("async and await", ():
   it("should await direct async call with block_on", ():
-    async function async_add_direct(a: int, b: int) -> int:
+    async fn async_add_direct(a: int, b: int) -> int:
       return a + b
     expect(block_on(async_add_direct(20, 22))).to_eq(42)
   )
   it("should await task variable with block_on", ():
-    async function async_add_task(a: int, b: int) -> int:
+    async fn async_add_task(a: int, b: int) -> int:
       return a + b
     t: Task<int> = async_add_task(7, 8)
     expect(block_on(t)).to_eq(15)
   )
-  it("should chain async functions with await inside async function", ():
-    async function inner() -> int:
+  it("should chain async fns with await inside async fn", ():
+    async fn inner() -> int:
       return 21
-    async function outer() -> int:
+    async fn outer() -> int:
       return (await inner()) * 2
     expect(block_on(outer())).to_eq(42)
   )
-  it("should support Unit-returning async functions through block_on", ():
-    async function bump() -> Unit:
+  it("should support Unit-returning async fns through block_on", ():
+    async fn bump() -> Unit:
       print("done")
     block_on(bump())
     expect(1).to_eq(1)
@@ -27,7 +27,7 @@ describe("async and await", ():
 
 describe("parallel for", ():
   it("should execute counted loops in parallel", ():
-    function consume(x: int) -> int:
+    fn consume(x: int) -> int:
       return x + 1
     expect(available_parallelism() > 0).to_be_true()
     @parallel
@@ -43,7 +43,7 @@ describe("parallel for", ():
 # every backend — @parallel for semantics are CoW-preserving.
 describe("parallel for ARC race (#630)", ():
   it("parent list is unchanged when workers mutate captured list", ():
-    function noop(x: int) -> int:
+    fn noop(x: int) -> int:
       return x
     shared: List<int> = [10, 20, 30, 40, 50]
     @parallel
@@ -57,7 +57,7 @@ describe("parallel for ARC race (#630)", ():
   )
 
   it("parent string captured read-only stays valid under retain/release contention", ():
-    function touch(s: str) -> int:
+    fn touch(s: str) -> int:
       return length(s)
     shared: str = "hello_ry_630"
     @parallel

--- a/tests/spec/concurrency_stress.test.ry
+++ b/tests/spec/concurrency_stress.test.ry
@@ -14,7 +14,7 @@ from thread import thread_spawn, thread_join, lock_new, lock_acquire, lock_relea
 
 describe("@parallel for with Set capture (CoW, #872)", ():
   it("parent Set is unchanged when workers call add()", ():
-    function noop(x: int) -> int:
+    fn noop(x: int) -> int:
       return x
     parent: Set<int> = {10, 20, 30}
     @parallel
@@ -33,7 +33,7 @@ describe("@parallel for with Set capture (CoW, #872)", ():
 
 describe("@parallel for with Map capture (CoW, #872)", ():
   it("parent Map is unchanged when workers call remove()", ():
-    function noop(x: int) -> int:
+    fn noop(x: int) -> int:
       return x
     parent: Map<str, int> = {"a": 1, "b": 2, "c": 3}
     @parallel
@@ -59,7 +59,7 @@ describe("@parallel for with Map capture (CoW, #872)", ():
 
 describe("GC collect() during @parallel for (#872)", ():
   it("collect() from workers does not crash", ():
-    function noop(x: int) -> int:
+    fn noop(x: int) -> int:
       return x
     results: List<int> = []
     @parallel
@@ -84,7 +84,7 @@ describe("GC collect() during @parallel for (#872)", ():
 
 describe("nested @parallel for (#872)", ():
   it("outer list is unchanged (CoW applies at both levels)", ():
-    function noop(x: int) -> int:
+    fn noop(x: int) -> int:
       return x
     outer_log: List<int> = []
     @parallel
@@ -110,7 +110,7 @@ describe("nested @parallel for (#872)", ():
 
 describe("many thread_spawn workers sharing a str capture (#872)", ():
   it("concurrent reads from same str value are safe", ():
-    function measure(x: str) -> int:
+    fn measure(x: str) -> int:
       total = 0
       for i in range(200):
         total = total + length(x)

--- a/tests/spec/contracts.test.ry
+++ b/tests/spec/contracts.test.ry
@@ -1,17 +1,17 @@
-function deposit(amount: int, balance: int) -> int:
+fn deposit(amount: int, balance: int) -> int:
   require:
     amount > 0
     balance >= 0
   return balance + amount
 
-function abs_val(x: int) -> int:
+fn abs_val(x: int) -> int:
   ensure v:
     v >= 0
   if x < 0:
     return -x
   return x
 
-function increment(x: int) -> int:
+fn increment(x: int) -> int:
   ensure v:
     v == x + 1
   return x + 1

--- a/tests/spec/control_flow.test.ry
+++ b/tests/spec/control_flow.test.ry
@@ -604,19 +604,19 @@ describe("match expression in function argument", ():
 
 # --- ADT enum as function parameter (#507) ---
 
-function shape_area(s: Shape) -> float:
+fn shape_area(s: Shape) -> float:
   return case s:
     Shape::Circle(r) : 3.14 * r * r
     Shape::Rect(w, h) : w * h
     Shape::Point : 0.0
 
-function shape_name(s: Shape) -> str:
+fn shape_name(s: Shape) -> str:
   return case s:
     Shape::Circle(r) : "circle"
     Shape::Rect(w, h) : "rect"
     Shape::Point : "point"
 
-function make_shape(kind: int) -> Shape:
+fn make_shape(kind: int) -> Shape:
   if kind == 0:
     return Shape::Circle(1.0)
   if kind == 1:

--- a/tests/spec/default_args.test.ry
+++ b/tests/spec/default_args.test.ry
@@ -1,31 +1,31 @@
 # --- helper functions ---
 
-function greet(name: str, greeting: str = "Hello") -> str:
+fn greet(name: str, greeting: str = "Hello") -> str:
   return greeting + ", " + name
 
-function connect(host: str, port: int = 8080, timeout: int = 30) -> str:
+fn connect(host: str, port: int = 8080, timeout: int = 30) -> str:
   return host + ":" + to_str(port) + ":" + to_str(timeout)
 
-function with_float(x: float, scale: float = 1.0) -> float:
+fn with_float(x: float, scale: float = 1.0) -> float:
   return x * scale
 
-function with_bool(msg: str, loud: bool = false) -> str:
+fn with_bool(msg: str, loud: bool = false) -> str:
   if loud:
     return msg + "!"
   return msg
 
-function with_none(name: str, title: str? = None) -> str:
+fn with_none(name: str, title: str? = None) -> str:
   return name + ":" + (title ?? "none")
 
 # overload: different arity, no conflict
-function area(s: int) -> int:
+fn area(s: int) -> int:
   return s * s
 
-function area(w: int, h: int) -> int:
+fn area(w: int, h: int) -> int:
   return w * h
 
 # widening + default args
-function calc(x: float, precision: int = 6) -> float:
+fn calc(x: float, precision: int = 6) -> float:
   return x
 
 # --- tests ---

--- a/tests/spec/directive_test.test.ry
+++ b/tests/spec/directive_test.test.ry
@@ -2,69 +2,69 @@
 
 # Basic @it on a named function
 @it("should add 1 + 2 = 3")
-function test_add():
+fn test_add():
   expect(1 + 2).to_eq(3)
 
 @it("should concatenate strings")
-function test_str_concat():
+fn test_str_concat():
   expect("hello" + " " + "world").to_eq("hello world")
 
 @it("should evaluate boolean logic")
-function test_bool():
+fn test_bool():
   expect(true and false).to_be_false()
 
 # @describe wrapping named functions with nested @it
 @describe("arithmetic")
-function arithmetic_tests():
+fn arithmetic_tests():
   @it("should subtract")
-  function test_sub():
+  fn test_sub():
     expect(10 - 3).to_eq(7)
 
   @it("should multiply")
-  function test_mul():
+  fn test_mul():
     expect(4 * 5).to_eq(20)
 
 # @each with @it on a named function
 @each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
 @it("should add {0} + {1} = {2}")
-function test_add_each(a: int, b: int, expected: int):
+fn test_add_each(a: int, b: int, expected: int):
   expect(a + b).to_eq(expected)
 
 @each([("hello", 5), ("", 0), ("ry", 2)])
 @it("should have length of \"{0}\" equal to {1}")
-function test_length_each(s: str, expected: int):
+fn test_length_each(s: str, expected: int):
   expect(length(s)).to_eq(expected)
 
 # @property with @it on a named function
 @property(count=100)
 @it("should verify addition is commutative")
-function test_add_commutative(a: int, b: int):
+fn test_add_commutative(a: int, b: int):
   expect(a + b).to_eq(b + a)
 
 @property(count=50)
 @it("should verify double is always even")
-function test_double_even(n: int):
+fn test_double_even(n: int):
   expect(n * 2 % 2).to_eq(0)
 
 # @describe with shared setup: variables declared in describe body captured by @it (#635)
 @describe("shared setup")
-function shared_setup_tests():
+fn shared_setup_tests():
   base = 100
   offset = 5
 
   @it("should use base value")
-  function test_base():
+  fn test_base():
     expect(base).to_eq(100)
 
   @it("should use both base and offset")
-  function test_combined():
+  fn test_combined():
     expect(base + offset).to_eq(105)
 
 # Nested @describe indentation (#635)
 @describe("outer group")
-function outer_group():
+fn outer_group():
   @describe("inner group")
-  function inner_group():
+  fn inner_group():
     @it("should pass deeply nested test")
-    function test_deep():
+    fn test_deep():
       expect(1 + 1).to_eq(2)

--- a/tests/spec/enum_generic_param_type.test.ry
+++ b/tests/spec/enum_generic_param_type.test.ry
@@ -2,7 +2,7 @@ enum MyOpt<T>:
   MySome(T)
   MyNone
 
-function unwrap_or_int(opt: MyOpt<int>, default: int) -> int:
+fn unwrap_or_int(opt: MyOpt<int>, default: int) -> int:
   res = default
   case opt:
     MyOpt::MySome(v):
@@ -11,7 +11,7 @@ function unwrap_or_int(opt: MyOpt<int>, default: int) -> int:
       res = default
   return res
 
-function unwrap_or_str(opt: MyOpt<str>, default: str) -> str:
+fn unwrap_or_str(opt: MyOpt<str>, default: str) -> str:
   res = default
   case opt:
     MyOpt::MySome(v):
@@ -20,10 +20,10 @@ function unwrap_or_str(opt: MyOpt<str>, default: str) -> str:
       res = default
   return res
 
-function take_opt_return_opt(opt: MyOpt<int>) -> MyOpt<int>:
+fn take_opt_return_opt(opt: MyOpt<int>) -> MyOpt<int>:
   return opt
 
-function unwrap_or<T>(opt: MyOpt<T>, default: T) -> T:
+fn unwrap_or<T>(opt: MyOpt<T>, default: T) -> T:
   case opt:
     MyOpt::MySome(v):
       return v

--- a/tests/spec/fn_len_alias.test.ry
+++ b/tests/spec/fn_len_alias.test.ry
@@ -11,7 +11,7 @@ describe("fn and len aliases", ():
   )
 
   it("keeps function as a backward-compatible alias", ():
-    function dec(x: int) -> int:
+    fn dec(x: int) -> int:
       return x - 1
 
     expect(dec(5)).to_eq(4)

--- a/tests/spec/fn_len_alias.test.ry
+++ b/tests/spec/fn_len_alias.test.ry
@@ -10,11 +10,9 @@ describe("fn and len aliases", ():
     expect(apply((x: int) => x * 2, 4)).to_eq(8)
   )
 
-  it("keeps function as a backward-compatible alias", ():
-    fn dec(x: int) -> int:
-      return x - 1
-
-    expect(dec(5)).to_eq(4)
+  it("allows `function` as a normal identifier (no longer a keyword)", ():
+    function = 7
+    expect(function).to_eq(7)
   )
 
   it("accepts len() as an alias for length()", ():

--- a/tests/spec/fstring_closure_capture.test.ry
+++ b/tests/spec/fstring_closure_capture.test.ry
@@ -1,7 +1,7 @@
 describe("f-string closure capture — nested named function", ():
   it("should capture outer variable in f-string inside nested function", ():
-    function make_greeter(greeting: str) -> function(str) -> str:
-      function greet(name: str) -> str:
+    fn make_greeter(greeting: str) -> fn(str) -> str:
+      fn greet(name: str) -> str:
         return f"{greeting} {name}"
       return greet
 
@@ -10,8 +10,8 @@ describe("f-string closure capture — nested named function", ():
   )
 
   it("should capture int variable in f-string inside nested function", ():
-    function make_formatter(prefix: str) -> function(int) -> str:
-      function fmt(x: int) -> str:
+    fn make_formatter(prefix: str) -> fn(int) -> str:
+      fn fmt(x: int) -> str:
         return f"{prefix}_{x}"
       return fmt
 
@@ -20,8 +20,8 @@ describe("f-string closure capture — nested named function", ():
   )
 
   it("should capture variable used in expression inside f-string", ():
-    function make_calc(base: int) -> function(int) -> str:
-      function calc(x: int) -> str:
+    fn make_calc(base: int) -> fn(int) -> str:
+      fn calc(x: int) -> str:
         return f"result={base + x}"
       return calc
 
@@ -30,8 +30,8 @@ describe("f-string closure capture — nested named function", ():
   )
 
   it("should capture multiple outer variables in f-string", ():
-    function make_pair_fmt(a: str, b: str) -> function() -> str:
-      function fmt() -> str:
+    fn make_pair_fmt(a: str, b: str) -> fn() -> str:
+      fn fmt() -> str:
         return f"{a} {b}"
       return fmt
 
@@ -42,7 +42,7 @@ describe("f-string closure capture — nested named function", ():
 
 describe("f-string closure capture — lambda", ():
   it("should capture outer variable via f-string in lambda", ():
-    function str_len(s: str) -> int:
+    fn str_len(s: str) -> int:
       return s.length()
     name = "world"
     f = () => str_len(f"hello {name}")

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -1,37 +1,37 @@
-function add(a: int, b: int) -> int:
+fn add(a: int, b: int) -> int:
   return a + b
 
-function factorial(n: int) -> int:
+fn factorial(n: int) -> int:
   if n <= 1:
     return 1
   return n * factorial(n - 1)
 
-function area(side: int) -> int:
+fn area(side: int) -> int:
   return side * side
 
-function area(w: int, h: int) -> int:
+fn area(w: int, h: int) -> int:
   return w * h
 
-function apply(f: function(int) -> int, x: int) -> int:
+fn apply(f: fn(int) -> int, x: int) -> int:
   return f(x)
 
-function double(x: int) -> int:
+fn double(x: int) -> int:
   return x * 2
 
-function add_one(x: int) -> int:
+fn add_one(x: int) -> int:
   return x + 1
 
 record Vec2:
   x: float
   y: float
 
-function operator+(a: Vec2, b: Vec2) -> Vec2:
+fn operator+(a: Vec2, b: Vec2) -> Vec2:
   return Vec2(a.x + b.x, a.y + b.y)
 
-function operator==(a: Vec2, b: Vec2) -> bool:
+fn operator==(a: Vec2, b: Vec2) -> bool:
   return a.x == b.x and a.y == b.y
 
-function operator+=(a: Vec2, b: Vec2) -> Vec2:
+fn operator+=(a: Vec2, b: Vec2) -> Vec2:
   return Vec2(a.x + b.x, a.y + b.y)
 
 describe("basic function", ():
@@ -102,22 +102,22 @@ describe("UFCS", ():
   )
 )
 
-function infer_int():
+fn infer_int():
   return 42
 
-function infer_float():
+fn infer_float():
   return 3.14
 
-function infer_str():
+fn infer_str():
   return "hello"
 
-function infer_bool():
+fn infer_bool():
   return true
 
-function infer_unit():
+fn infer_unit():
   print("")
 
-function infer_union(flag: bool):
+fn infer_union(flag: bool):
   if flag:
     return 42
   return 3.14
@@ -126,7 +126,7 @@ record InferPoint:
   x: int
   y: int
 
-function infer_struct():
+fn infer_struct():
   return InferPoint(3, 4)
 
 describe("return type inference", ():
@@ -182,12 +182,12 @@ describe("operator overloading", ():
   )
 )
 
-function sum_to(n: int, acc: int) -> int:
+fn sum_to(n: int, acc: int) -> int:
   if n <= 0:
     return acc
   return sum_to(n - 1, acc + n)
 
-function get_value() -> int:
+fn get_value() -> int:
   return 42
 
 describe("zero arg function", ():
@@ -204,16 +204,16 @@ describe("tail call optimization", ():
 
 # --- Return type inference for local variables (#770) ---
 
-function compute_and_return(r: float):
+fn compute_and_return(r: float):
   v = 4.0 * 3.14 * r * r * r / 3.0
   return v
 
-function transitive_local(x: int):
+fn transitive_local(x: int):
   a = x * 2
   b = a + 1
   return b
 
-function local_float(x: float):
+fn local_float(x: float):
   result = x + 1.0
   return result
 

--- a/tests/spec/generic_bounds.test.ry
+++ b/tests/spec/generic_bounds.test.ry
@@ -8,10 +8,10 @@ record Dog < Animal:
 record GuideDog < Dog:
   handler: str
 
-function get_name<T: Animal>(a: T) -> str:
+fn get_name<T: Animal>(a: T) -> str:
   return a.name
 
-function count_legs<T: Animal>(a: T) -> int:
+fn count_legs<T: Animal>(a: T) -> int:
   return a.legs
 
 type AnimalAlias = Animal
@@ -35,7 +35,7 @@ describe("generic record bounds", ():
     expect(get_name[Dog](Dog("Rex", 4, "Lab"))).to_eq("Rex")
   )
   it("should handle mixed bounded and unbounded params", ():
-    function pair_name<T: Animal, U>(a: T, x: U) -> str:
+    fn pair_name<T: Animal, U>(a: T, x: U) -> str:
       return a.name
     expect(pair_name(Dog("Rex", 4, "Lab"), 42)).to_eq("Rex")
   )
@@ -43,7 +43,7 @@ describe("generic record bounds", ():
     expect(get_name[DogAlias](Dog("Rex", 4, "Lab"))).to_eq("Rex")
   )
   it("should accept bound expressed as alias of record", ():
-    function get_alias_name<T: AnimalAlias>(a: T) -> str:
+    fn get_alias_name<T: AnimalAlias>(a: T) -> str:
       return a.name
     expect(get_alias_name(Dog("Rex", 4, "Lab"))).to_eq("Rex")
   )

--- a/tests/spec/generic_collection_param.test.ry
+++ b/tests/spec/generic_collection_param.test.ry
@@ -1,13 +1,13 @@
-function first_item<T>(items: List<T>) -> T:
+fn first_item<T>(items: List<T>) -> T:
     return items[0]
 
-function second_item<T>(items: List<T>) -> T:
+fn second_item<T>(items: List<T>) -> T:
     return items[1]
 
-function map_has<K, V>(m: Map<K, V>, key: K) -> bool:
+fn map_has<K, V>(m: Map<K, V>, key: K) -> bool:
     return m.contains(key)
 
-function set_count<T>(s: Set<T>) -> int:
+fn set_count<T>(s: Set<T>) -> int:
     return 1
 
 describe("generic function with collection params", ():

--- a/tests/spec/generic_infer_container.test.ry
+++ b/tests/spec/generic_infer_container.test.ry
@@ -1,19 +1,19 @@
-function first_of<T>(xs: List<T>) -> T:
+fn first_of<T>(xs: List<T>) -> T:
     return xs[0]
 
-function second_of<T>(xs: List<T>) -> T:
+fn second_of<T>(xs: List<T>) -> T:
     return xs[1]
 
-function map_lookup<K, V>(m: Map<K, V>, k: K) -> V:
+fn map_lookup<K, V>(m: Map<K, V>, k: K) -> V:
     return m[k]
 
-function set_size<T>(s: Set<T>) -> int:
+fn set_size<T>(s: Set<T>) -> int:
     return 1
 
-function pair_first<T>(p: (T, T)) -> T:
+fn pair_first<T>(p: (T, T)) -> T:
     return p.0
 
-function apply_list<T>(xs: List<T>, f: function(T) -> T) -> T:
+fn apply_list<T>(xs: List<T>, f: fn(T) -> T) -> T:
     return f(xs[0])
 
 describe("generic inference: List<T> literal argument", ():
@@ -85,7 +85,7 @@ describe("generic inference: tuple (T, T) literal argument", ():
 )
 
 describe("generic inference: cross-parameter unification", ():
-  it("should unify T from List<T> and function(T) -> T", ():
+  it("should unify T from List<T> and fn(T) -> T", ():
     expect(apply_list([10, 20, 30], (x: int) => x + 1)).to_eq(11)
   )
   it("should resolve lambda param reference in return-type inference", ():

--- a/tests/spec/generics.test.ry
+++ b/tests/spec/generics.test.ry
@@ -1,7 +1,7 @@
-function identity<T>(x: T) -> T:
+fn identity<T>(x: T) -> T:
     return x
 
-function pick_first<T, U>(a: T, b: U) -> T:
+fn pick_first<T, U>(a: T, b: U) -> T:
     return a
 
 describe("generic function", ():
@@ -38,7 +38,7 @@ describe("generic function", ():
   )
 )
 
-function maybe_none<T>(x: T, flag: bool) -> T?:
+fn maybe_none<T>(x: T, flag: bool) -> T?:
     if flag:
         return none
     return Some(x)

--- a/tests/spec/http.test.ry
+++ b/tests/spec/http.test.ry
@@ -3,7 +3,7 @@ from io import to_bytes, bytes_to_str
 
 describe("HTTP Server API", ():
   it("should respond with 200 OK for matching path", ():
-    async function server_200(server: TcpListener) -> str:
+    async fn server_200(server: TcpListener) -> str:
       case accept(server):
         Ok(conn):
           case receive(conn, 4096):
@@ -54,7 +54,7 @@ describe("HTTP Server API", ():
         fail("unexpected error")
   )
   it("should respond with 404 Not Found", ():
-    async function server_404(server: TcpListener) -> str:
+    async fn server_404(server: TcpListener) -> str:
       case accept(server):
         Ok(conn):
           case receive(conn, 4096):

--- a/tests/spec/implicit_numeric_coerce.test.ry
+++ b/tests/spec/implicit_numeric_coerce.test.ry
@@ -103,25 +103,25 @@ describe("issue #1192: compound assign on map value", ():
 
 describe("issue #1195: function return coercion", ():
   it("widens int to float at return", ():
-    function ret_float() -> float:
+    fn ret_float() -> float:
       return 3
     expect(ret_float()).to_eq(3.0)
   )
 
   it("narrows float to int at return (truncation)", ():
-    function ret_int() -> int:
+    fn ret_int() -> int:
       return 3.14
     expect(ret_int()).to_eq(3)
   )
 
   it("narrows negative float to int at return", ():
-    function ret_int_neg() -> int:
+    fn ret_int_neg() -> int:
       return -3.7
     expect(ret_int_neg()).to_eq(-3)
   )
 
   it("widens ** result when returning from int-annotated fn", ():
-    function pow_int() -> int:
+    fn pow_int() -> int:
       return 2 ** 3
     expect(pow_int()).to_eq(8)
   )

--- a/tests/spec/implicit_widening.test.ry
+++ b/tests/spec/implicit_widening.test.ry
@@ -1,29 +1,29 @@
 # --- helper functions ---
 
-function double_float(x: float) -> float:
+fn double_float(x: float) -> float:
   return x * 2.0
 
-function accept_int(x: int) -> int:
+fn accept_int(x: int) -> int:
   return x
 
-function accept_float(x: float) -> float:
+fn accept_float(x: float) -> float:
   return x
 
-function add_floats(x: float, y: float) -> float:
+fn add_floats(x: float, y: float) -> float:
   return x + y
 
 # overload: exact when should win
-function typed(x: int) -> str:
+fn typed(x: int) -> str:
   return "int"
 
-function typed(x: float) -> str:
+fn typed(x: float) -> str:
   return "float"
 
 # overload: widening should win over any
-function prefer_widening(x: float) -> str:
+fn prefer_widening(x: float) -> str:
   return "float"
 
-function prefer_widening(x) -> str:
+fn prefer_widening(x) -> str:
   return "any"
 
 # --- tests ---

--- a/tests/spec/inline.test.ry
+++ b/tests/spec/inline.test.ry
@@ -1,21 +1,21 @@
 @inline
-function add(a: int, b: int) -> int:
+fn add(a: int, b: int) -> int:
   return a + b
 
 @inline(mode="always")
-function mul(a: int, b: int) -> int:
+fn mul(a: int, b: int) -> int:
   return a * b
 
 @inline(mode="hint")
-function sub(a: int, b: int) -> int:
+fn sub(a: int, b: int) -> int:
   return a - b
 
 @inline(mode="never")
-function negate(a: int) -> int:
+fn negate(a: int) -> int:
   return -a
 
 @inline
-function fact(n: int) -> int:
+fn fact(n: int) -> int:
   if n <= 1:
     return 1
   return n * fact(n - 1)

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -3,7 +3,7 @@ from io import read_text, write_text, append_text, exists, delete_file, read_byt
 # Module-global List<u8> for the emitModuleGlobalWriteThrough test (#1085).
 glob_bs: List<u8> = [97, 0, 98]
 
-function update_glob_bs() -> int:
+fn update_glob_bs() -> int:
   glob_bs = [99, 100, 101]
   return 0
 

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -34,7 +34,7 @@ describe("json parse", ():
     expect(parse("\"a\nb\"")).to_be_err()
   )
   it("should preserve JsonValue metadata through helper-returned Result", ():
-    function parse_obj() -> Result<JsonValue, Error>:
+    fn parse_obj() -> Result<JsonValue, Error>:
       return parse("{\"x\": 42}")
 
     case parse_obj():
@@ -45,7 +45,7 @@ describe("json parse", ():
         fail("parse failed")
   )
   it("should preserve JsonValue metadata through helper-returned Option", ():
-    function maybe_obj() -> Option<JsonValue>:
+    fn maybe_obj() -> Option<JsonValue>:
       case parse("{\"x\": 7}"):
         Ok(data):
           return Some(data)
@@ -60,8 +60,8 @@ describe("json parse", ():
         fail("unexpected None")
   )
 
-  it("should accept lambda typed as function() -> Result<JsonValue, Error>", ():
-    parse_obj: function() -> Result<JsonValue, Error> = () => parse("{\"x\": 1}")
+  it("should accept lambda typed as fn() -> Result<JsonValue, Error>", ():
+    parse_obj: fn() -> Result<JsonValue, Error> = () => parse("{\"x\": 1}")
 
     case parse_obj():
       Ok(data):
@@ -72,7 +72,7 @@ describe("json parse", ():
   )
 
   it("should preserve JsonValue metadata through Result.and_then", ():
-    function parse_obj() -> Result<JsonValue, Error>:
+    fn parse_obj() -> Result<JsonValue, Error>:
       return parse("{\"x\": 42}")
 
     r = parse_obj().and_then((v: JsonValue) -> Result<JsonValue, Error>:
@@ -89,7 +89,7 @@ describe("json parse", ():
   )
 
   it("should preserve JsonValue metadata through Result.map", ():
-    function parse_obj() -> Result<JsonValue, Error>:
+    fn parse_obj() -> Result<JsonValue, Error>:
       return parse("{\"x\": 42}")
 
     r = parse_obj().map((v: JsonValue) -> JsonValue:
@@ -106,7 +106,7 @@ describe("json parse", ():
   )
 
   it("should preserve JsonValue metadata through closure capture", ():
-    function parse_obj() -> Result<JsonValue, Error>:
+    fn parse_obj() -> Result<JsonValue, Error>:
       return parse("{\"x\": 42}")
 
     case parse_obj():

--- a/tests/spec/lambda_ptr_return.test.ry
+++ b/tests/spec/lambda_ptr_return.test.ry
@@ -45,7 +45,7 @@ describe("lambda returning cast", ():
 
 describe("lambda returning lambda", ():
   it("should return nested lambda via named function wrapper", ():
-    function make_adder(x: int) -> function(int) -> int:
+    fn make_adder(x: int) -> fn(int) -> int:
       return (y: int) => x + y
 
     add_ten = make_adder(10)

--- a/tests/spec/list_range_index.test.ry
+++ b/tests/spec/list_range_index.test.ry
@@ -78,7 +78,7 @@ describe("list range-index lst[a..b] (#1184)", ():
     expect(ys[1]["b"]).to_eq(2)
   )
   it("range over List<function> preserves closure invocation (#1205)", ():
-    xs: List<function(int) -> int> = [(x: int) => x + 1, (x: int) => x * 2]
+    xs: List<fn(int) -> int> = [(x: int) => x + 1, (x: int) => x * 2]
     ys = xs[0..0]
     expect(ys).to_have_length(1)
     f = ys[0]

--- a/tests/spec/low_level_types.test.ry
+++ b/tests/spec/low_level_types.test.ry
@@ -458,7 +458,7 @@ describe("Phase 2 casts", ():
 )
 
 describe("Phase 2 function with low-level params", ():
-  function add_u32(a: u32, b: u32) -> u32:
+  fn add_u32(a: u32, b: u32) -> u32:
     return a + b
 
   it("should work with function with u32 params and return", ():
@@ -468,7 +468,7 @@ describe("Phase 2 function with low-level params", ():
     expect(z as int).to_eq(300)
   )
 
-  function negate_i8(x: i8) -> i8:
+  fn negate_i8(x: i8) -> i8:
     zero: i8 = 0
     return zero - x
 

--- a/tests/spec/matchers.test.ry
+++ b/tests/spec/matchers.test.ry
@@ -88,9 +88,9 @@ record MatcherPoint:
   x: int
   y: int
 
-function mk_ok(v: int) -> Result<int, Error>:
+fn mk_ok(v: int) -> Result<int, Error>:
   return Ok(v)
-function mk_err(msg: str) -> Result<int, Error>:
+fn mk_err(msg: str) -> Result<int, Error>:
   return Err(Error(msg))
 
 describe("to_eq / to_not_eq — collection and complex types (#737)", ():

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -322,7 +322,7 @@ describe("math predicates", ():
 )
 
 describe("math native int->float widening (#1193)", ():
-  # @native functions should accept int arguments with implicit int->float
+  # @native fn should accept int arguments with implicit int->float
   # widening, matching user-defined function behavior. These cases exercise
   # the table-driven @native dispatch path (sqrt/sin/cos/tan/exp/log2/log10
   # and other single-arg trig, plus atan2/hypot as 2-arg).

--- a/tests/spec/mock.test.ry
+++ b/tests/spec/mock.test.ry
@@ -1,7 +1,7 @@
-function fetch_data() -> str:
+fn fetch_data() -> str:
   return "real data"
 
-function compute(x: int) -> int:
+fn compute(x: int) -> int:
   return x * 2
 
 describe("mock", ():

--- a/tests/spec/mutual_recursion.test.ry
+++ b/tests/spec/mutual_recursion.test.ry
@@ -1,63 +1,63 @@
 # --- Basic mutual recursion (is_even / is_odd) ---
 
-function is_even(n: int) -> bool:
+fn is_even(n: int) -> bool:
   if n == 0:
     return true
   return is_odd(n - 1)
 
-function is_odd(n: int) -> bool:
+fn is_odd(n: int) -> bool:
   if n == 0:
     return false
   return is_even(n - 1)
 
 # --- Three-way mutual recursion (A -> B -> C -> A) ---
 
-function phase_a(n: int) -> str:
+fn phase_a(n: int) -> str:
   if n <= 0:
     return "a"
   return phase_b(n - 1)
 
-function phase_b(n: int) -> str:
+fn phase_b(n: int) -> str:
   if n <= 0:
     return "b"
   return phase_c(n - 1)
 
-function phase_c(n: int) -> str:
+fn phase_c(n: int) -> str:
   if n <= 0:
     return "c"
   return phase_a(n - 1)
 
 # --- Forward reference without cycle ---
 
-function caller(n: int) -> int:
+fn caller(n: int) -> int:
   return callee(n) + 1
 
-function callee(n: int) -> int:
+fn callee(n: int) -> int:
   return n * 2
 
 # --- Mutual recursion with different return types ---
 
-function count_down(n: int) -> int:
+fn count_down(n: int) -> int:
   if n <= 0:
     return 0
   return bounce(n - 1)
 
-function bounce(n: int) -> int:
+fn bounce(n: int) -> int:
   if check_zero(n):
     return 0
   return count_down(n - 1)
 
-function check_zero(n: int) -> bool:
+fn check_zero(n: int) -> bool:
   return n == 0
 
 # --- Mutual recursion with default arguments ---
 
-function ping(n: int, prefix: str = "ping") -> str:
+fn ping(n: int, prefix: str = "ping") -> str:
   if n <= 0:
     return prefix
   return pong(n - 1)
 
-function pong(n: int, prefix: str = "pong") -> str:
+fn pong(n: int, prefix: str = "pong") -> str:
   if n <= 0:
     return prefix
   return ping(n - 1)

--- a/tests/spec/nested_fn_closure.test.ry
+++ b/tests/spec/nested_fn_closure.test.ry
@@ -1,10 +1,10 @@
-function apply(f: function(int) -> int, x: int) -> int:
+fn apply(f: fn(int) -> int, x: int) -> int:
   return f(x)
 
 describe("nested named function — capture basics", ():
   it("should capture int from enclosing scope", ():
-    function make_adder(base: int) -> function(int) -> int:
-      function add(x: int) -> int:
+    fn make_adder(base: int) -> fn(int) -> int:
+      fn add(x: int) -> int:
         return x + base
       return add
 
@@ -13,8 +13,8 @@ describe("nested named function — capture basics", ():
   )
 
   it("should capture str from enclosing scope (ARC-managed)", ():
-    function choose_prefix(prefix: str) -> function(str) -> str:
-      function decorate(name: str) -> str:
+    fn choose_prefix(prefix: str) -> fn(str) -> str:
+      fn decorate(name: str) -> str:
         return prefix + name
       return decorate
 
@@ -23,8 +23,8 @@ describe("nested named function — capture basics", ():
   )
 
   it("should capture multiple variables", ():
-    function make_linear(a: int, b: int) -> function(int) -> int:
-      function linear(x: int) -> int:
+    fn make_linear(a: int, b: int) -> fn(int) -> int:
+      fn linear(x: int) -> int:
         return a * x + b
       return linear
 
@@ -35,8 +35,8 @@ describe("nested named function — capture basics", ():
 
 describe("nested named function — direct call with captures", ():
   it("should call capturing nested function directly in defining scope", ():
-    function outer(n: int) -> int:
-      function add_n(x: int) -> int:
+    fn outer(n: int) -> int:
+      fn add_n(x: int) -> int:
         return x + n
       return add_n(100)
 
@@ -44,10 +44,10 @@ describe("nested named function — direct call with captures", ():
   )
 
   it("should handle multiple capturing nested functions in same scope", ():
-    function outer(base: int) -> int:
-      function inc(x: int) -> int:
+    fn outer(base: int) -> int:
+      fn inc(x: int) -> int:
         return x + base
-      function dec(x: int) -> int:
+      fn dec(x: int) -> int:
         return x - base
       return inc(10) + dec(10)
 
@@ -55,11 +55,11 @@ describe("nested named function — direct call with captures", ():
   )
 
   it("should not prevent capture when sibling param shadows outer", ():
-    function outer() -> int:
+    fn outer() -> int:
       x = 10
-      function a(x: int) -> int:
+      fn a(x: int) -> int:
         return x + 1
-      function b() -> int:
+      fn b() -> int:
         return x
       return a(5) + b()
 
@@ -69,8 +69,8 @@ describe("nested named function — direct call with captures", ():
 
 describe("nested named function — higher-order interop", ():
   it("should pass no-capture nested function to higher-order function", ():
-    function outer() -> int:
-      function double_it(n: int) -> int:
+    fn outer() -> int:
+      fn double_it(n: int) -> int:
         return n * 2
       return apply(double_it, 5)
 
@@ -78,8 +78,8 @@ describe("nested named function — higher-order interop", ():
   )
 
   it("should support returned capturing nested function called twice", ():
-    function make_step(n: int) -> function(int) -> int:
-      function step(x: int) -> int:
+    fn make_step(n: int) -> fn(int) -> int:
+      fn step(x: int) -> int:
         return x + n
       return step
 
@@ -90,8 +90,8 @@ describe("nested named function — higher-order interop", ():
 
 describe("nested named function — variable assignment and indirect call", ():
   it("should assign capturing nested function to variable and call it", ():
-    function outer(offset: int) -> int:
-      function add_offset(x: int) -> int:
+    fn outer(offset: int) -> int:
+      fn add_offset(x: int) -> int:
         return x + offset
       f = add_offset
       return f(10)
@@ -102,9 +102,9 @@ describe("nested named function — variable assignment and indirect call", ():
 
 describe("nested named function — multi-level capture", ():
   it("should capture variable from two levels up", ():
-    function outer(x: int) -> function(int) -> int:
-      function mid() -> function(int) -> int:
-        function inner(y: int) -> int:
+    fn outer(x: int) -> fn(int) -> int:
+      fn mid() -> fn(int) -> int:
+        fn inner(y: int) -> int:
           return x + y
         return inner
       return mid()
@@ -116,8 +116,8 @@ describe("nested named function — multi-level capture", ():
 
 describe("nested named function — no-capture remains plain function", ():
   it("should keep no-capture nested function behavior unchanged", ():
-    function outer() -> int:
-      function helper(x: int) -> int:
+    fn outer() -> int:
+      fn helper(x: int) -> int:
         return x * 2
       return helper(21)
 
@@ -125,8 +125,8 @@ describe("nested named function — no-capture remains plain function", ():
   )
 
   it("should pass no-capture nested function as value", ():
-    function outer() -> int:
-      function double_it(n: int) -> int:
+    fn outer() -> int:
+      fn double_it(n: int) -> int:
         return n * 2
       return apply(double_it, 5)
 
@@ -136,8 +136,8 @@ describe("nested named function — no-capture remains plain function", ():
 
 describe("nested named function — ARC capture correctness", ():
   it("should keep captured string alive after outer function returns", ():
-    function make_greeter(greeting: str) -> function(str) -> str:
-      function greet(name: str) -> str:
+    fn make_greeter(greeting: str) -> fn(str) -> str:
+      fn greet(name: str) -> str:
         return greeting + " " + name
       return greet
 
@@ -147,8 +147,8 @@ describe("nested named function — ARC capture correctness", ():
   )
 
   it("should keep closures from the same factory independent", ():
-    function make_adder(base: int) -> function(int) -> int:
-      function add(x: int) -> int:
+    fn make_adder(base: int) -> fn(int) -> int:
+      fn add(x: int) -> int:
         return x + base
       return add
 

--- a/tests/spec/nested_fn_return_fn.test.ry
+++ b/tests/spec/nested_fn_return_fn.test.ry
@@ -1,21 +1,21 @@
 describe("two-level nested function return (#752)", ():
   it("should return and call a two-level nested function with type annotations", ():
-    function outer() -> function() -> function() -> int:
-      function middle() -> function() -> int:
-        function inner() -> int:
+    fn outer() -> fn() -> fn() -> int:
+      fn middle() -> fn() -> int:
+        fn inner() -> int:
           return 42
         return inner
       return middle
 
-    f: function() -> function() -> int = outer()
-    g: function() -> int = f()
+    f: fn() -> fn() -> int = outer()
+    g: fn() -> int = f()
     expect(g()).to_eq(42)
   )
 
   it("should return and call a two-level nested function without type annotations", ():
-    function outer() -> function() -> function() -> int:
-      function middle() -> function() -> int:
-        function inner() -> int:
+    fn outer() -> fn() -> fn() -> int:
+      fn middle() -> fn() -> int:
+        fn inner() -> int:
           return 42
         return inner
       return middle
@@ -26,9 +26,9 @@ describe("two-level nested function return (#752)", ():
   )
 
   it("should support chained calls via intermediate variables", ():
-    function make() -> function() -> function() -> int:
-      function mid() -> function() -> int:
-        function leaf() -> int:
+    fn make() -> fn() -> fn() -> int:
+      fn mid() -> fn() -> int:
+        fn leaf() -> int:
           return 99
         return leaf
       return mid
@@ -39,8 +39,8 @@ describe("two-level nested function return (#752)", ():
   )
 
   it("should work with lambdas returning nested functions", ():
-    make = () -> function() -> function() -> int:
-      mid = () -> function() -> int:
+    make = () -> fn() -> fn() -> int:
+      mid = () -> fn() -> int:
         leaf = () -> int:
           return 42
         return leaf
@@ -52,12 +52,12 @@ describe("two-level nested function return (#752)", ():
   )
 
   it("should work with type aliases for nested function returns", ():
-    type Inner = function() -> int
-    type Outer = function() -> Inner
+    type Inner = fn() -> int
+    type Outer = fn() -> Inner
 
-    function make() -> Outer:
-      function mid() -> Inner:
-        function leaf() -> int:
+    fn make() -> Outer:
+      fn mid() -> Inner:
+        fn leaf() -> int:
           return 42
         return leaf
       return mid
@@ -68,9 +68,9 @@ describe("two-level nested function return (#752)", ():
   )
 
   it("should work with parameters at each level", ():
-    function outer(a: int) -> function(int) -> function(int) -> int:
-      function middle(b: int) -> function(int) -> int:
-        function inner(c: int) -> int:
+    fn outer(a: int) -> fn(int) -> fn(int) -> int:
+      fn middle(b: int) -> fn(int) -> int:
+        fn inner(c: int) -> int:
           return a + b + c
         return inner
       return middle

--- a/tests/spec/nested_functions.test.ry
+++ b/tests/spec/nested_functions.test.ry
@@ -1,18 +1,18 @@
-function apply(f: function(int) -> int, x: int) -> int:
+fn apply(f: fn(int) -> int, x: int) -> int:
   return f(x)
 
 describe("nested function basics", ():
   it("should define and call a nested function", ():
-    function outer() -> int:
-      function helper() -> int:
+    fn outer() -> int:
+      fn helper() -> int:
         return 42
       return helper()
     expect(outer()).to_eq(42)
   )
 
   it("should not expose nested function outside enclosing function", ():
-    function outer() -> int:
-      function inner() -> int:
+    fn outer() -> int:
+      fn inner() -> int:
         return 1
       return inner()
     expect(outer()).to_eq(1)
@@ -22,13 +22,13 @@ describe("nested function basics", ():
 
 describe("sibling scope isolation", ():
   it("should not collide same-named nested functions in sibling scopes", ():
-    function foo() -> int:
-      function helper() -> int:
+    fn foo() -> int:
+      fn helper() -> int:
         return 1
       return helper()
 
-    function bar() -> int:
-      function helper() -> int:
+    fn bar() -> int:
+      fn helper() -> int:
         return 2
       return helper()
 
@@ -39,9 +39,9 @@ describe("sibling scope isolation", ():
 
 describe("multi-level nesting", ():
   it("should resolve names across three levels of nesting", ():
-    function outer() -> int:
-      function mid() -> int:
-        function inner() -> int:
+    fn outer() -> int:
+      fn mid() -> int:
+        fn inner() -> int:
           return 3
         return inner()
       return mid()
@@ -49,10 +49,10 @@ describe("multi-level nesting", ():
   )
 
   it("should allow inner function to call sibling at same level", ():
-    function outer() -> int:
-      function a() -> int:
+    fn outer() -> int:
+      fn a() -> int:
         return 10
-      function b() -> int:
+      fn b() -> int:
         return a() + 5
       return b()
     expect(outer()).to_eq(15)
@@ -61,8 +61,8 @@ describe("multi-level nesting", ():
 
 describe("nested function recursion", ():
   it("should support self-recursive nested function", ():
-    function outer() -> int:
-      function factorial(n: int) -> int:
+    fn outer() -> int:
+      fn factorial(n: int) -> int:
         if n <= 1:
           return 1
         return n * factorial(n - 1)
@@ -71,12 +71,12 @@ describe("nested function recursion", ():
   )
 
   it("should support mutual recursion between nested functions", ():
-    function outer() -> bool:
-      function is_even(n: int) -> bool:
+    fn outer() -> bool:
+      fn is_even(n: int) -> bool:
         if n == 0:
           return true
         return is_odd(n - 1)
-      function is_odd(n: int) -> bool:
+      fn is_odd(n: int) -> bool:
         if n == 0:
           return false
         return is_even(n - 1)
@@ -87,8 +87,8 @@ describe("nested function recursion", ():
 
 describe("nested function as value", ():
   it("should pass nested function to higher-order function", ():
-    function outer() -> int:
-      function double_it(n: int) -> int:
+    fn outer() -> int:
+      fn double_it(n: int) -> int:
         return n * 2
       return apply(double_it, 5)
     expect(outer()).to_eq(10)

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -39,7 +39,7 @@ describe("TCP socket API", ():
         expect(true).to_eq(true)
   )
   it("should preserve TcpListener metadata through helper-returned Result", ():
-    function mk_listener() -> Result<TcpListener, Error>:
+    fn mk_listener() -> Result<TcpListener, Error>:
       return bind("127.0.0.1", 0)
 
     case mk_listener():
@@ -50,7 +50,7 @@ describe("TCP socket API", ():
         fail("unexpected error")
   )
   it("should preserve TcpListener metadata through helper-returned Option", ():
-    function maybe_listener() -> Option<TcpListener>:
+    fn maybe_listener() -> Option<TcpListener>:
       case bind("127.0.0.1", 0):
         Ok(server):
           return Some(server)
@@ -65,7 +65,7 @@ describe("TCP socket API", ():
         fail("unexpected None")
   )
   it("should cause receive to return Err on timeout via set_receive_timeout", ():
-    async function timeout_server(server: TcpListener) -> str:
+    async fn timeout_server(server: TcpListener) -> str:
       case accept(server):
         Ok(conn):
           sleep(500)
@@ -97,8 +97,8 @@ describe("TCP socket API", ():
       Err(e):
         fail("unexpected error")
   )
-  it("should complete echo round-trip with async function", ():
-    async function run_server(server: TcpListener) -> str:
+  it("should complete echo round-trip with async fn", ():
+    async fn run_server(server: TcpListener) -> str:
       case accept(server):
         Ok(conn):
           case receive(conn, 4096):
@@ -119,7 +119,7 @@ describe("TCP socket API", ():
           ...
       close(server)
       return "done"
-    function run_client(port: int) -> str:
+    fn run_client(port: int) -> str:
       case connect("127.0.0.1", port):
         Ok(conn):
           case send(conn, to_bytes("hello")):
@@ -157,7 +157,7 @@ describe("TCP socket API", ():
   )
 
   it("should preserve Result<TcpStream, Error> resource metadata across helper returns", ():
-    async function run_server(server: TcpListener) -> str:
+    async fn run_server(server: TcpListener) -> str:
       case accept(server):
         Ok(conn):
           sleep(200)
@@ -167,7 +167,7 @@ describe("TCP socket API", ():
       close(server)
       return "done"
 
-    function mk_conn(port: int) -> Result<TcpStream, Error>:
+    fn mk_conn(port: int) -> Result<TcpStream, Error>:
       return connect("127.0.0.1", port)
 
     case bind("127.0.0.1", 0):

--- a/tests/spec/operator_overload.test.ry
+++ b/tests/spec/operator_overload.test.ry
@@ -4,7 +4,7 @@ describe("operator[]", ():
       x: int
       y: int
       z: int
-    function operator[](p: Point, i: int) -> int:
+    fn operator[](p: Point, i: int) -> int:
       if i == 0:
         return p.x
       if i == 1:
@@ -22,7 +22,7 @@ describe("operator[]", ():
       b: int
       c: int
       d: int
-    function operator[](g: Grid, row: int, col: int) -> int:
+    fn operator[](g: Grid, row: int, col: int) -> int:
       if row == 0 and col == 0:
         return g.a
       if row == 0 and col == 1:
@@ -41,7 +41,7 @@ describe("operator[]", ():
     record Sink:
       last_key: int
       last_val: int
-    function operator[]=(s: Sink, key: int, value: int):
+    fn operator[]=(s: Sink, key: int, value: int):
       s.last_key = key
       s.last_val = value
     s = Sink(0, 0)
@@ -53,7 +53,7 @@ describe("operator[] returning collection", ():
   it("should preserve type info and support chaining for subscript returning List<int>", ():
     record Matrix:
       rows: List<List<int>>
-    function operator[](m: Matrix, i: int) -> List<int>:
+    fn operator[](m: Matrix, i: int) -> List<int>:
       return m.rows[i]
     m = Matrix([[10, 20, 30], [40, 50, 60]])
     row = m[0]
@@ -72,7 +72,7 @@ describe("operator in", ():
     record Range:
       lo: int
       hi: int
-    function operator in(v: int, r: Range) -> bool:
+    fn operator in(v: int, r: Range) -> bool:
       return v >= r.lo and v < r.hi
     r = Range(1, 10)
     expect(5 in r).to_be_true()
@@ -84,7 +84,7 @@ describe("operator in", ():
     record Span:
       lo: int
       hi: int
-    function operator in(v: int, s: Span) -> bool:
+    fn operator in(v: int, s: Span) -> bool:
       return v >= s.lo and v < s.hi
     s = Span(1, 10)
     expect(15 not in s).to_be_true()
@@ -105,7 +105,7 @@ describe("operator()", ():
   it("should support callable record", ():
     record Adder:
       base: int
-    function operator()(a: Adder, x: int) -> int:
+    fn operator()(a: Adder, x: int) -> int:
       return a.base + x
     add5 = Adder(5)
     expect(add5(10)).to_eq(15)
@@ -114,7 +114,7 @@ describe("operator()", ():
   it("should support multi-arg callable", ():
     record Calc:
       base: int
-    function operator()(c: Calc, x: int, y: int) -> int:
+    fn operator()(c: Calc, x: int, y: int) -> int:
       return c.base + x * y
     calc = Calc(10)
     expect(calc(3, 4)).to_eq(22)
@@ -127,7 +127,7 @@ describe("operator as", ():
       value: int
     record Fahrenheit:
       value: int
-    function operator as(c: Celsius) -> Fahrenheit:
+    fn operator as(c: Celsius) -> Fahrenheit:
       return Fahrenheit(c.value * 9 // 5 + 32)
     c = Celsius(100)
     f = c as Fahrenheit
@@ -137,7 +137,7 @@ describe("operator as", ():
   it("should support cast to generic Option type", ():
     record Temperature:
       value: int
-    function operator as(t: Temperature) -> int?:
+    fn operator as(t: Temperature) -> int?:
       return Some(t.value)
     t = Temperature(42)
     result: int? = t as int?
@@ -147,7 +147,7 @@ describe("operator as", ():
   it("should preserve type info for cast returning collection", ():
     record Row:
       items: List<int>
-    function operator as(r: Row) -> List<int>:
+    fn operator as(r: Row) -> List<int>:
       return r.items
     r = Row([10, 20, 30])
     xs = r as List<int>

--- a/tests/spec/operator_overload_fn_type.test.ry
+++ b/tests/spec/operator_overload_fn_type.test.ry
@@ -2,7 +2,7 @@ describe("operator[] returning function type", ():
   it("should return a callable from subscript and allow invocation", ():
     record FnMap:
       base: int
-    function operator[](m: FnMap, key: int) -> function(int) -> int:
+    fn operator[](m: FnMap, key: int) -> fn(int) -> int:
       return (x: int) => m.base + x + key
     fm = FnMap(10)
     f = fm[1]
@@ -12,7 +12,7 @@ describe("operator[] returning function type", ():
   it("should call subscript return via variable", ():
     record Dispatch:
       offset: int
-    function operator[](d: Dispatch, idx: int) -> function(int) -> int:
+    fn operator[](d: Dispatch, idx: int) -> fn(int) -> int:
       return (x: int) => d.offset * idx + x
     d = Dispatch(3)
     g = d[2]
@@ -24,10 +24,10 @@ describe("operator as returning function type", ():
   it("should return a callable from cast and allow invocation", ():
     record Multiplier:
       factor: int
-    function operator as(m: Multiplier) -> function(int) -> int:
+    fn operator as(m: Multiplier) -> fn(int) -> int:
       return (x: int) => x * m.factor
     m = Multiplier(5)
-    f = m as function(int) -> int
+    f = m as fn(int) -> int
     expect(f(7)).to_eq(35)
   )
 )

--- a/tests/spec/operators.test.ry
+++ b/tests/spec/operators.test.ry
@@ -1,4 +1,4 @@
-function make_int_result(ok: bool, v: int, msg: str) -> Result<int, Error>:
+fn make_int_result(ok: bool, v: int, msg: str) -> Result<int, Error>:
   if ok:
     return Ok(v)
   return Err(Error(msg))
@@ -178,7 +178,7 @@ describe("logical", ():
   )
 )
 
-function side_effect_flag() -> bool:
+fn side_effect_flag() -> bool:
   return true
 
 describe("short-circuit evaluation", ():

--- a/tests/spec/option_none_call.test.ry
+++ b/tests/spec/option_none_call.test.ry
@@ -7,10 +7,10 @@
 
 g_none_call_opt: Option<int> = Some(1)
 
-function g_none_call_reset():
+fn g_none_call_reset():
   g_none_call_opt = None()
 
-function accept_none_opt(o: Option<int>) -> bool:
+fn accept_none_opt(o: Option<int>) -> bool:
   return case o:
     Some(_) : false
     None : true

--- a/tests/spec/option_propagate.test.ry
+++ b/tests/spec/option_propagate.test.ry
@@ -1,33 +1,33 @@
-function safe_get(xs: List<int>, i: int) -> Option<int>:
+fn safe_get(xs: List<int>, i: int) -> Option<int>:
   if i < 0 or i >= xs.length():
     return none
   return Some(xs[i])
 
-function first_plus_second(xs: List<int>) -> Option<int>:
+fn first_plus_second(xs: List<int>) -> Option<int>:
   a = safe_get(xs, 0)?
   b = safe_get(xs, 1)?
   return Some(a + b)
 
-function first_plus_second_bang(xs: List<int>) -> Option<int>:
+fn first_plus_second_bang(xs: List<int>) -> Option<int>:
   a = safe_get(xs, 0)!!
   b = safe_get(xs, 1)!!
   return Some(a + b)
 
-function inline_expr(xs: List<int>) -> Option<int>:
+fn inline_expr(xs: List<int>) -> Option<int>:
   return Some(safe_get(xs, 0)? + 1)
 
-function inline_expr_always_none() -> Option<int>:
+fn inline_expr_always_none() -> Option<int>:
   # safe_get on index 99 of a 1-element list always returns None, so the
   # `?` inside the expression position short-circuits to `None`.
   return Some(safe_get([1], 99)? + 1)
 
-function wrap_bang(r: Option<int>) -> Option<int>:
+fn wrap_bang(r: Option<int>) -> Option<int>:
   return Some(r!!)
 
-function add_one_bang(v: Option<int>) -> Option<int>:
+fn add_one_bang(v: Option<int>) -> Option<int>:
   return Some(v!! + 1)
 
-function add_one_bang_none() -> Option<int>:
+fn add_one_bang_none() -> Option<int>:
   x: Option<int> = none
   return Some(x!! + 1)
 

--- a/tests/spec/option_shorthand_metadata.test.ry
+++ b/tests/spec/option_shorthand_metadata.test.ry
@@ -1,13 +1,13 @@
-function make_list_opt(v: List<int>) -> List<int>?:
+fn make_list_opt(v: List<int>) -> List<int>?:
   return Some(v)
 
-function make_map_opt(v: Map<str, int>) -> Map<str, int>?:
+fn make_map_opt(v: Map<str, int>) -> Map<str, int>?:
   return Some(v)
 
-function make_set_opt(v: Set<int>) -> Set<int>?:
+fn make_set_opt(v: Set<int>) -> Set<int>?:
   return Some(v)
 
-function make_list_none() -> List<int>?:
+fn make_list_none() -> List<int>?:
   return None
 
 describe("T? shorthand return type — metadata propagation (#1003)", ():

--- a/tests/spec/pattern_arc.test.ry
+++ b/tests/spec/pattern_arc.test.ry
@@ -15,13 +15,13 @@ enum Tree:
   Leaf(List<int>)
   Node(str)
 
-function make_some_list() -> Option<List<int>>:
+fn make_some_list() -> Option<List<int>>:
   return Some([10, 20, 30])
 
-function make_ok_list() -> Result<List<int>, str>:
+fn make_ok_list() -> Result<List<int>, str>:
   return Ok([1, 2, 3])
 
-function make_err_msg() -> Result<int, str>:
+fn make_err_msg() -> Result<int, str>:
   # Use string concatenation so the payload is a heap-backed ARC string rather
   # than a compile-time constant.  A constant literal would not exercise the
   # ARC retain path even if retention were missing, so this makes the Err(msg)
@@ -29,13 +29,13 @@ function make_err_msg() -> Result<int, str>:
   prefix = "fail"
   return Err(prefix + "ed")
 
-function make_some_str_short() -> str?:
+fn make_some_str_short() -> str?:
   # Use string concatenation so the payload is a heap-backed ARC string rather
   # than a compile-time constant — same technique as make_err_msg.
   prefix = "hello"
   return Some(prefix + " world")
 
-function make_some_list_short() -> List<int>?:
+fn make_some_list_short() -> List<int>?:
   return Some([1, 2, 3])
 
 describe("pattern binding ARC retain (#997)", ():
@@ -143,7 +143,7 @@ describe("pattern binding ARC retain (#997)", ():
 
   it("nested Some pattern retains inner List<int>", ():
     # Nested: Some(xs) inside a function call returning Option<List<int>>.
-    function get_nested() -> Option<List<int>>:
+    fn get_nested() -> Option<List<int>>:
       return Some([42, 43])
     case get_nested():
       Some(xs):

--- a/tests/spec/pattern_tuple.test.ry
+++ b/tests/spec/pattern_tuple.test.ry
@@ -203,7 +203,7 @@ describe("regression - existing patterns unaffected", ():
   )
 
   it("should still work with Ok pattern", ():
-    function try_parse(s: str) -> Result<int, Error>:
+    fn try_parse(s: str) -> Result<int, Error>:
       return Ok(42)
     r = try_parse("42")
     res = 0

--- a/tests/spec/print_to_str_consistency.test.ry
+++ b/tests/spec/print_to_str_consistency.test.ry
@@ -162,7 +162,7 @@ describe("print and to_str consistency", ():
     record Person:
       name: str
       age: int
-    function to_str(p: Person) -> str:
+    fn to_str(p: Person) -> str:
       return f"{p.name} (age {p.age})"
     p = Person("Alice", 30)
     expect(to_str(p)).to_eq("Alice (age 30)")
@@ -186,7 +186,7 @@ describe("print and to_str consistency", ():
   )
 
   it("should print function value inside Map as <closure> (#810)", ():
-    fs: Map<str, function(int) -> int> = {"double": (x: int) => x * 2}
+    fs: Map<str, fn(int) -> int> = {"double": (x: int) => x * 2}
     expected = "{" + "\"double\"" + ": <closure>}"
     expect(to_str(fs)).to_eq(expected)
     print(fs)
@@ -194,7 +194,7 @@ describe("print and to_str consistency", ():
   )
 
   it("should print function value inside List as <closure> (regression)", ():
-    fs: List<function(int) -> int> = [(x: int) => x + 1]
+    fs: List<fn(int) -> int> = [(x: int) => x + 1]
     expect(to_str(fs)).to_eq("[<closure>]")
     print(fs)
     # expect-output: [<closure>]

--- a/tests/spec/record_field_index.test.ry
+++ b/tests/spec/record_field_index.test.ry
@@ -33,7 +33,7 @@ describe("record_field_index", ():
     record Matrix:
       data: List<int>
 
-    function get_element(m: Matrix, idx: int) -> int:
+    fn get_element(m: Matrix, idx: int) -> int:
       return m.data[idx]
 
     mat = Matrix([5, 10, 15, 20])
@@ -64,7 +64,7 @@ describe("record_field_index", ():
     record Vec:
       elems: List<int>
 
-    function operator[](v: Vec, idx: int) -> int:
+    fn operator[](v: Vec, idx: int) -> int:
       return v.elems[idx]
 
     v = Vec([7, 8, 9])

--- a/tests/spec/record_subtyping.test.ry
+++ b/tests/spec/record_subtyping.test.ry
@@ -2,7 +2,7 @@ record HttpError < Error:
   status: int
   url: str
 
-function handle_error(e: Error) -> str:
+fn handle_error(e: Error) -> str:
   return e.message
 
 describe("record subtyping", ():
@@ -67,7 +67,7 @@ describe("invariant inheritance", ():
 record ApiError < Error:
   endpoint: str
 
-function fetch_data(url: str) -> Result<int, Error>:
+fn fetch_data(url: str) -> Result<int, Error>:
   return Err(ApiError("not found", 404, url))
 
 describe("Err auto-slicing", ():
@@ -83,7 +83,7 @@ describe("Err auto-slicing", ():
 )
 
 # --- return subtype coercion ---
-function to_error(msg: str) -> Error:
+fn to_error(msg: str) -> Error:
   return ApiError(msg, 500, "/internal")
 
 describe("return subtype coercion", ():
@@ -101,7 +101,7 @@ record Animal:
 record Dog < Animal:
   breed: str
 
-function describe_animal(a: Animal) -> str:
+fn describe_animal(a: Animal) -> str:
   return f"{a.name} has {a.legs} legs"
 
 describe("non-Error subtyping", ():
@@ -131,10 +131,10 @@ describe("field assignment subtype coercion", ():
 )
 
 # --- #360: ? operator subtype coercion ---
-function fetch_typed(url: str) -> Result<int, ApiError>:
+fn fetch_typed(url: str) -> Result<int, ApiError>:
   return Err(ApiError("fail", 500, url))
 
-function process_data(url: str) -> Result<int, Error>:
+fn process_data(url: str) -> Result<int, Error>:
   val = fetch_typed(url)?
   return Ok(val)
 

--- a/tests/spec/records.test.ry
+++ b/tests/spec/records.test.ry
@@ -39,7 +39,7 @@ describe("record to_str", ():
     expect(to_str(c)).to_eq("Circle(center: Point(x: 1, y: 2), radius: 3.14)")
   )
   it("should override auto-generated to_str with user-defined", ():
-    function to_str(p: Point) -> str:
+    fn to_str(p: Point) -> str:
       return f"({p.x}, {p.y})"
     p = Point(5, 6)
     expect(to_str(p)).to_eq("(5, 6)")
@@ -63,7 +63,7 @@ record Mixed:
 record AlwaysEqual:
   x: int
 
-function operator==(a: AlwaysEqual, b: AlwaysEqual) -> bool:
+fn operator==(a: AlwaysEqual, b: AlwaysEqual) -> bool:
   return true
 
 describe("record equality", ():

--- a/tests/spec/relative_import/helper.ry
+++ b/tests/spec/relative_import/helper.ry
@@ -1,2 +1,2 @@
-function greet() -> str:
+fn greet() -> str:
     return "hello"

--- a/tests/spec/relative_import/mymath/add.ry
+++ b/tests/spec/relative_import/mymath/add.ry
@@ -1,2 +1,2 @@
-function add(a: int, b: int) -> int:
+fn add(a: int, b: int) -> int:
     return a + b

--- a/tests/spec/relative_import/mymath/sub.ry
+++ b/tests/spec/relative_import/mymath/sub.ry
@@ -1,2 +1,2 @@
-function sub(a: int, b: int) -> int:
+fn sub(a: int, b: int) -> int:
     return a - b

--- a/tests/spec/result.test.ry
+++ b/tests/spec/result.test.ry
@@ -1,18 +1,18 @@
-function safe_divide(a: int, b: int) -> Result<int, Error>:
+fn safe_divide(a: int, b: int) -> Result<int, Error>:
   if b == 0:
     return Err(Error("division by zero"))
   return Ok(a // b)
 
-function divide_and_add(a: int, b: int) -> Result<int, Error>:
+fn divide_and_add(a: int, b: int) -> Result<int, Error>:
   v = safe_divide(a, b)?
   return Ok(v + 1)
 
-function chained(a: int, b: int, c: int) -> Result<int, Error>:
+fn chained(a: int, b: int, c: int) -> Result<int, Error>:
   x = safe_divide(a, b)?
   y = safe_divide(x, c)?
   return Ok(y)
 
-function inline_expr(a: int, b: int) -> Result<int, Error>:
+fn inline_expr(a: int, b: int) -> Result<int, Error>:
   return Ok(safe_divide(a, b)? + 1)
 
 describe("Result type", ():
@@ -86,7 +86,7 @@ describe("Result type", ():
     expect(res).to_be_err()
   )
   it("should match Ok with wildcard for Unit result", ():
-    function unit_ok() -> Result<Unit, Error>:
+    fn unit_ok() -> Result<Unit, Error>:
       return Ok(0 as u8)
     case unit_ok():
       Ok(_):

--- a/tests/spec/result_chain.test.ry
+++ b/tests/spec/result_chain.test.ry
@@ -1,4 +1,4 @@
-function safe_divide(a: int, b: int) -> Result<int, Error>:
+fn safe_divide(a: int, b: int) -> Result<int, Error>:
   if b == 0:
     return Err(Error("division by zero"))
   return Ok(a // b)

--- a/tests/spec/result_option_arc_return.test.ry
+++ b/tests/spec/result_option_arc_return.test.ry
@@ -9,32 +9,32 @@ from runtime_internal import arc_live_count
 record Container:
   items: List<int>
 
-function make_ok_from_field(c: Container) -> Result<List<int>, Error>:
+fn make_ok_from_field(c: Container) -> Result<List<int>, Error>:
   return Ok(c.items)
 
-function make_some_from_field(c: Container) -> Option<List<int>>:
+fn make_some_from_field(c: Container) -> Option<List<int>>:
   return Some(c.items)
 
 # --- Direct-parameter helpers ---
 
-function make_ok_list(v: List<int>) -> Result<List<int>, Error>:
+fn make_ok_list(v: List<int>) -> Result<List<int>, Error>:
   return Ok(v)
 
-function make_ok_map(v: Map<str, int>) -> Result<Map<str, int>, Error>:
+fn make_ok_map(v: Map<str, int>) -> Result<Map<str, int>, Error>:
   return Ok(v)
 
-function make_ok_set(v: Set<int>) -> Result<Set<int>, Error>:
+fn make_ok_set(v: Set<int>) -> Result<Set<int>, Error>:
   return Ok(v)
 
 # Use Option<T> spelling (not T?) because the T? shorthand has a pre-existing
 # metadata propagation limitation for Option<Collection> (#999 scope: ARC only).
-function make_some_list(v: List<int>) -> Option<List<int>>:
+fn make_some_list(v: List<int>) -> Option<List<int>>:
   return Some(v)
 
-function make_ok_inline() -> Result<List<int>, Error>:
+fn make_ok_inline() -> Result<List<int>, Error>:
   return Ok([10, 20, 30])
 
-function make_err_list(v: List<int>) -> Result<int, List<int>>:
+fn make_err_list(v: List<int>) -> Result<int, List<int>>:
   return Err(v)
 
 describe("Result/Option ARC return (#999)", ():

--- a/tests/spec/return_check.test.ry
+++ b/tests/spec/return_check.test.ry
@@ -1,6 +1,6 @@
 describe("return check - all paths return", ():
   it("should return on all paths with if/else", ():
-    function abs(x: int) -> int:
+    fn abs(x: int) -> int:
       if x < 0:
         return -x
       else:
@@ -9,7 +9,7 @@ describe("return check - all paths return", ():
     expect(abs(5)).to_eq(5)
   )
   it("should return on all paths with when", ():
-    function sign(x: int) -> int:
+    fn sign(x: int) -> int:
       case:
         x > 0:
           return 1
@@ -22,7 +22,7 @@ describe("return check - all paths return", ():
     expect(sign(0)).to_eq(0)
   )
   it("should return on all paths with when and wildcard", ():
-    function describe(x: int) -> str:
+    fn describe(x: int) -> str:
       case x:
         1:
           return "one"
@@ -34,7 +34,7 @@ describe("return check - all paths return", ():
     expect(describe(99)).to_eq("other")
   )
   it("should return on all paths with nested if/else", ():
-    function classify(x: int) -> str:
+    fn classify(x: int) -> str:
       if x > 0:
         if x > 100:
           return "big"
@@ -47,7 +47,7 @@ describe("return check - all paths return", ():
     expect(classify(-1)).to_eq("non-positive")
   )
   it("should return on all paths with Ok/Err match", ():
-    function check(r: Result<int, Error>) -> str:
+    fn check(r: Result<int, Error>) -> str:
       case r:
         Ok(v):
           return "ok"
@@ -56,7 +56,7 @@ describe("return check - all paths return", ():
     expect(check(Ok(1))).to_eq("ok")
   )
   it("should return on all paths with Some/None match", ():
-    function check(o: Option<int>) -> str:
+    fn check(o: Option<int>) -> str:
       case o:
         Some(v):
           return "some"
@@ -70,7 +70,7 @@ describe("return check - all paths return", ():
       Circle(float)
       Rect(float, float)
 
-    function area(s: Shape) -> float:
+    fn area(s: Shape) -> float:
       case s:
         Shape::Circle(r):
           return 3.14 * r * r
@@ -85,7 +85,7 @@ describe("return check - all paths return", ():
       Green
       Blue
 
-    function name(c: Color) -> str:
+    fn name(c: Color) -> str:
       case c:
         Color::Red:
           return "red"
@@ -98,7 +98,7 @@ describe("return check - all paths return", ():
     expect(name(Color::Blue)).to_eq("blue")
   )
   it("should return on all paths when matching bool with true/false (#513)", ():
-    function describe(b: bool) -> str:
+    fn describe(b: bool) -> str:
       case b:
         true:
           return "yes"

--- a/tests/spec/return_type_meta_enum.test.ry
+++ b/tests/spec/return_type_meta_enum.test.ry
@@ -10,45 +10,45 @@ enum Shape:
 
 describe("enum return value preserves type metadata (#820)", ():
   it("should print simple enum variant name when returned inline", ():
-    function get_color() -> Color:
+    fn get_color() -> Color:
       return Color::Red
     expect(to_str(get_color())).to_eq("Red")
   )
 
   it("should print simple enum variant name when returned via local variable", ():
-    function get_color() -> Color:
+    fn get_color() -> Color:
       return Color::Green
     c = get_color()
     expect(to_str(c)).to_eq("Green")
   )
 
   it("should print simple enum in f-string interpolation", ():
-    function get_color() -> Color:
+    fn get_color() -> Color:
       return Color::Blue
     expect(f"color: {get_color()}").to_eq("color: Blue")
   )
 
   it("should print ADT enum variant with payload when returned inline", ():
-    function make_circle() -> Shape:
+    fn make_circle() -> Shape:
       return Shape::Circle(3.14)
     expect(to_str(make_circle())).to_eq("Circle(3.14)")
   )
 
   it("should print ADT enum variant with payload when returned via local variable", ():
-    function make_rect() -> Shape:
+    fn make_rect() -> Shape:
       return Shape::Rect(3.0, 4.0)
     s = make_rect()
     expect(to_str(s)).to_eq("Rect(3.0, 4.0)")
   )
 
   it("should print ADT enum variant without payload when returned from function", ():
-    function make_point() -> Shape:
+    fn make_point() -> Shape:
       return Shape::Point
     expect(to_str(make_point())).to_eq("Point")
   )
 
   it("should match ADT enum returned from user function (regression guard)", ():
-    function make_circle() -> Shape:
+    fn make_circle() -> Shape:
       return Shape::Circle(5.0)
     case make_circle():
       Shape::Circle(r):
@@ -58,15 +58,15 @@ describe("enum return value preserves type metadata (#820)", ():
   )
 
   it("should propagate enum metadata through a wrapper function call chain", ():
-    function inner() -> Color:
+    fn inner() -> Color:
       return Color::Red
-    function outer() -> Color:
+    fn outer() -> Color:
       return inner()
     expect(to_str(outer())).to_eq("Red")
   )
 
   it("should print simple enum stored in list after function return", ():
-    function get_color() -> Color:
+    fn get_color() -> Color:
       return Color::Green
     xs: List<Color> = [get_color(), Color::Red]
     expect(to_str(xs)).to_eq("[Green, Red]")
@@ -75,19 +75,19 @@ describe("enum return value preserves type metadata (#820)", ():
   it("should propagate enum metadata through a type alias in return position", ():
     # PR #853 review: type aliases need resolution before enum lookup
     type ColorAlias = Color
-    function get_alias() -> ColorAlias:
+    fn get_alias() -> ColorAlias:
       return Color::Red
     expect(to_str(get_alias())).to_eq("Red")
   )
 
   it("should still print Option<int> from function (regression guard)", ():
-    function make_some() -> Option<int>:
+    fn make_some() -> Option<int>:
       return Some(42)
     expect(to_str(make_some())).to_eq("Some(42)")
   )
 
   it("should still print Result<int, Error> from function (regression guard)", ():
-    function make_ok() -> Result<int, Error>:
+    fn make_ok() -> Result<int, Error>:
       return Ok(7)
     expect(to_str(make_ok())).to_eq("Ok(7)")
   )

--- a/tests/spec/str_arc.test.ry
+++ b/tests/spec/str_arc.test.ry
@@ -59,14 +59,14 @@ describe("str ARC — dynamic string operations", ():
   )
 
   it("str returned from function is usable", ():
-    function make_greeting(name: str) -> str:
+    fn make_greeting(name: str) -> str:
       return "Hello, " + name + "!"
     g = make_greeting("World")
     expect(g).to_eq("Hello, World!")
   )
 
   it("str passed through multiple function calls remains valid", ():
-    function double(s: str) -> str:
+    fn double(s: str) -> str:
       return s + s
     a = "ab"
     b = double(a)

--- a/tests/spec/thread.test.ry
+++ b/tests/spec/thread.test.ry
@@ -187,7 +187,7 @@ describe("AtomicBool", ():
 
 describe("resource helper returns", ():
   it("should preserve Lock metadata across helper returns", ():
-    function mk_lock() -> Lock:
+    fn mk_lock() -> Lock:
       return lock_new()
 
     lock = mk_lock()
@@ -197,7 +197,7 @@ describe("resource helper returns", ():
   )
 
   it("should preserve AtomicInt metadata across helper returns", ():
-    function mk_atomic() -> AtomicInt:
+    fn mk_atomic() -> AtomicInt:
       return atomic_int_new(5)
 
     a = mk_atomic()
@@ -207,8 +207,8 @@ describe("resource helper returns", ():
     atomic_int_free(a)
   )
 
-  it("should accept lambda typed as function() -> Lock", ():
-    mk_lock: function() -> Lock = () => lock_new()
+  it("should accept lambda typed as fn() -> Lock", ():
+    mk_lock: fn() -> Lock = () => lock_new()
 
     lock = mk_lock()
     expect(lock_acquire(lock)).to_be_ok()
@@ -269,7 +269,7 @@ describe("thread_spawn return values (MVP, #828)", ():
   )
 
   it("should preserve Thread resource metadata across helper returns", ():
-    function mk_thread() -> Thread:
+    fn mk_thread() -> Thread:
       return thread_spawn(() => 7)
 
     case thread_join(mk_thread()):

--- a/tests/spec/to_str_union.test.ry
+++ b/tests/spec/to_str_union.test.ry
@@ -1,10 +1,10 @@
-function show(x: int | str) -> str:
+fn show(x: int | str) -> str:
   return to_str(x)
 
-function show_with_float(x: int | float) -> str:
+fn show_with_float(x: int | float) -> str:
   return to_str(x)
 
-function show_with_bool(x: bool | str) -> str:
+fn show_with_bool(x: bool | str) -> str:
   return to_str(x)
 
 describe("to_str union", ():

--- a/tests/spec/top_level_bindings.test.ry
+++ b/tests/spec/top_level_bindings.test.ry
@@ -36,54 +36,54 @@ top_counter: int = 0
 
 # Top-level functions that reference the above bindings.
 
-function read_pi() -> float:
+fn read_pi() -> float:
   return TOP_PI
 
-function read_max() -> int:
+fn read_max() -> int:
   return TOP_MAX
 
-function read_flag() -> bool:
+fn read_flag() -> bool:
   return TOP_FLAG
 
-function read_greeting() -> str:
+fn read_greeting() -> str:
   return TOP_GREETING
 
-function read_computed() -> str:
+fn read_computed() -> str:
   return TOP_COMPUTED
 
-function read_list_first() -> int:
+fn read_list_first() -> int:
   return TOP_LIST[0]
 
-function read_list_len() -> int:
+fn read_list_len() -> int:
   return length(TOP_LIST)
 
-function read_map_a() -> int:
+fn read_map_a() -> int:
   return TOP_MAP["a"]
 
-function read_point_x() -> int:
+fn read_point_x() -> int:
   return TOP_POINT.x
 
-function read_point_y() -> int:
+fn read_point_y() -> int:
   return TOP_POINT.y
 
-function clamp(x: int) -> int:
+fn clamp(x: int) -> int:
   if x > TOP_MAX:
     return TOP_MAX
   return x
 
 # Transitive call chain: b -> a -> TOP_PI
-function read_pi_indirect() -> float:
+fn read_pi_indirect() -> float:
   return read_pi()
 
 # Function that reads and mutates the top-level mutable binding.
-function bump_counter():
+fn bump_counter():
   top_counter = top_counter + 1
 
-function get_counter() -> int:
+fn get_counter() -> int:
   return top_counter
 
 # Function with inner lambda that reads a top-level @const.
-function read_pi_via_lambda() -> float:
+fn read_pi_via_lambda() -> float:
   f = () -> float => TOP_PI
   return f()
 

--- a/tests/spec/trailing_commas.test.ry
+++ b/tests/spec/trailing_commas.test.ry
@@ -39,13 +39,13 @@ describe("trailing commas", ():
     expect(7 in s).to_eq(true)
   )
   it("function call - trailing comma", ():
-    function add(a: int, b: int) -> int:
+    fn add(a: int, b: int) -> int:
       return a + b
     result = add(3, 4,)
     expect(result).to_eq(7)
   )
   it("function declaration - trailing comma in params", ():
-    function mul(a: int, b: int,) -> int:
+    fn mul(a: int, b: int,) -> int:
       return a * b
     expect(mul(3, 4)).to_eq(12)
   )

--- a/tests/spec/tuple_destructure_assign_parens.test.ry
+++ b/tests/spec/tuple_destructure_assign_parens.test.ry
@@ -13,7 +13,7 @@ describe("parenthesized tuple destructuring assignment (#1189)", ():
   )
 
   it("should destructure a function return value (issue repro)", ():
-    function min_max(lst: List<int>) -> (int, int):
+    fn min_max(lst: List<int>) -> (int, int):
       return (min(lst), max(lst))
 
     (lo, hi) = min_max([3, 1, 4])

--- a/tests/spec/tuple_single_element.test.ry
+++ b/tests/spec/tuple_single_element.test.ry
@@ -25,7 +25,7 @@ describe("single-element tuple", ():
     expect(t.0).to_eq(42)
   )
   it("should support type annotation in function", ():
-    function wrap(x: int) -> (int,):
+    fn wrap(x: int) -> (int,):
       return (x,)
     t = wrap(99)
     expect(t.0).to_eq(99)

--- a/tests/spec/type_advanced.test.ry
+++ b/tests/spec/type_advanced.test.ry
@@ -168,10 +168,10 @@ describe("nested type alias unions", ():
 
 type TAVal = int | str
 
-function ta_show(v: TAVal) -> str:
+fn ta_show(v: TAVal) -> str:
   return to_str(v)
 
-function ta_choose(b: bool) -> TAVal:
+fn ta_choose(b: bool) -> TAVal:
   if b:
     return 42
   return "zero"
@@ -209,10 +209,10 @@ describe("type alias union of records", ():
 type NTAInner = int | str
 type NTAOuter = NTAInner | bool
 
-function nta_show(v: NTAOuter) -> str:
+fn nta_show(v: NTAOuter) -> str:
   return to_str(v)
 
-function nta_choose(k: int) -> NTAOuter:
+fn nta_choose(k: int) -> NTAOuter:
   if k == 0:
     return 42
   if k == 1:
@@ -270,7 +270,7 @@ describe("Error type", ():
 )
 
 describe("Result type", ():
-  function safe_divide(a: int, b: int) -> Result<int, Error>:
+  fn safe_divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
       return Err(Error("division by zero"))
     return Ok(a // b)
@@ -292,7 +292,7 @@ describe("Result type", ():
   )
 )
 
-function accept_union(x: int | str) -> bool:
+fn accept_union(x: int | str) -> bool:
   return true
 
 describe("union type", ():

--- a/tests/spec/type_of.test.ry
+++ b/tests/spec/type_of.test.ry
@@ -170,23 +170,23 @@ describe("type_of Option", ():
 
 describe("type_of Result", ():
   it("should identify Ok", ():
-    function make_ok() -> Result<int, Error>:
+    fn make_ok() -> Result<int, Error>:
       return Ok(1)
     r = make_ok()
     expect(to_str(type_of(r))).to_eq("Result")
   )
 
   it("should identify Err", ():
-    function make_err() -> Result<int, Error>:
+    fn make_err() -> Result<int, Error>:
       return Err(Error("oops"))
     r = make_err()
     expect(to_str(type_of(r))).to_eq("Result")
   )
 
   it("should identify Ok and Err as the same Result type", ():
-    function ok() -> Result<int, Error>:
+    fn ok() -> Result<int, Error>:
       return Ok(1)
-    function err() -> Result<int, Error>:
+    fn err() -> Result<int, Error>:
       return Err(Error("oops"))
     expect(type_of(ok()) == type_of(err())).to_be_true()
   )
@@ -195,7 +195,7 @@ describe("type_of Result", ():
 describe("type_of function/lambda", ():
   it("should identify a lambda as function", ():
     f = (x: int) => x + 1
-    expect(to_str(type_of(f))).to_eq("function")
+    expect(to_str(type_of(f))).to_eq("fn")
   )
 
   it("should identify two different lambdas as the same function type", ():
@@ -218,7 +218,7 @@ describe("type_of is reflective", ():
   )
 
   it("should round-trip Type through a generic identity function", ():
-    function identity<T>(x: T) -> T:
+    fn identity<T>(x: T) -> T:
       return x
     t = identity(type_of(1))
     expect(to_str(t)).to_eq("int")

--- a/tests/spec/user_fn_collection_return.test.ry
+++ b/tests/spec/user_fn_collection_return.test.ry
@@ -1,5 +1,5 @@
 describe("List returned from user-defined function", ():
-  function get_list() -> List<int>:
+  fn get_list() -> List<int>:
     return [1, 2, 3]
 
   it("should append! on returned list", ():

--- a/tests/spec/weak_ref.test.ry
+++ b/tests/spec/weak_ref.test.ry
@@ -1,4 +1,4 @@
-function make_list() -> List<int>:
+fn make_list() -> List<int>:
   return [10, 20, 30]
 
 describe("Weak references", ():

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -126,7 +126,7 @@ TEST_F(CodeGenTest, OperatorEqInferredNonBoolThrows) {
     EXPECT_THROW(runSource(
         "record Pt:\n"
         "    x: int\n"
-        "function operator==(a: Pt, b: Pt):\n"
+        "fn operator==(a: Pt, b: Pt):\n"
         "    return 42\n"), std::runtime_error);
 }
 
@@ -134,7 +134,7 @@ TEST_F(CodeGenTest, OperatorAndExplicitNonBoolThrows) {
     EXPECT_THROW(runSource(
         "record Pt:\n"
         "    x: int\n"
-        "function operator and(a: Pt, b: Pt) -> int:\n"
+        "fn operator and(a: Pt, b: Pt) -> int:\n"
         "    return 1\n"), std::runtime_error);
 }
 
@@ -142,7 +142,7 @@ TEST_F(CodeGenTest, OperatorOrExplicitNonBoolThrows) {
     EXPECT_THROW(runSource(
         "record Pt:\n"
         "    x: int\n"
-        "function operator or(a: Pt, b: Pt) -> int:\n"
+        "fn operator or(a: Pt, b: Pt) -> int:\n"
         "    return 1\n"), std::runtime_error);
 }
 
@@ -307,40 +307,40 @@ TEST_F(CodeGenTest, IntFloatCoercionCanaryLowLevelStillRejected) {
 
 TEST_F(CodeGenTest, IntFloatCoercionBoundaryRejections) {
     EXPECT_THROW(runSource(
-        "function twice(x: int) -> int:\n  return x\ny = twice(3.14)\nprint(y)"),
+        "fn twice(x: int) -> int:\n  return x\ny = twice(3.14)\nprint(y)"),
         std::runtime_error);
 }
 
 TEST_F(CodeGenTest, IntFloatCoercionReturnWidens) {
     EXPECT_EQ(runSource(
-        "function f() -> float:\n  return 3\nprint(f())"), "3.0\n");
+        "fn f() -> float:\n  return 3\nprint(f())"), "3.0\n");
     EXPECT_EQ(runSource(
         "f = () -> float => 3\nprint(f())"), "3.0\n");
 }
 
 TEST_F(CodeGenTest, IntFloatCoercionReturnNarrows) {
     EXPECT_EQ(runSource(
-        "function f() -> int:\n  return 3.14\nprint(f())"), "3\n");
+        "fn f() -> int:\n  return 3.14\nprint(f())"), "3\n");
     EXPECT_EQ(runSource(
-        "function g() -> int:\n  return -3.7\nprint(g())"), "-3\n");
+        "fn g() -> int:\n  return -3.7\nprint(g())"), "-3\n");
     EXPECT_EQ(runSource(
-        "function h() -> int:\n  return 2 ** 3\nprint(h())"), "8\n");
+        "fn h() -> int:\n  return 2 ** 3\nprint(h())"), "8\n");
     EXPECT_EQ(runSource(
         "f = () -> int => 3.14\nprint(f())"), "3\n");
 }
 
 TEST_F(CodeGenTest, IntFloatCoercionReturnLowLevelStillRejected) {
     EXPECT_THROW(runSource(
-        "function f() -> f32:\n  return 3\nprint(f())"),
+        "fn f() -> f32:\n  return 3\nprint(f())"),
         std::runtime_error);
     EXPECT_THROW(runSource(
-        "function f() -> i64:\n  return 3.14\nprint(f())"),
+        "fn f() -> i64:\n  return 3.14\nprint(f())"),
         std::runtime_error);
     EXPECT_THROW(runSource(
-        "function f() -> i32:\n  return 3.14\nprint(f())"),
+        "fn f() -> i32:\n  return 3.14\nprint(f())"),
         std::runtime_error);
     EXPECT_THROW(runSource(
-        "function f() -> u8:\n  return 3.14\nprint(f())"),
+        "fn f() -> u8:\n  return 3.14\nprint(f())"),
         std::runtime_error);
     EXPECT_THROW(runSource(
         "f = () -> f32 => 3\nprint(f())"),
@@ -445,7 +445,7 @@ TEST_F(CodeGenTest, ExitArgumentErrors) {
 
 TEST_F(CodeGenTest, TopLevelQuestionOnResultOkContinues) {
     EXPECT_EQ(runSource(
-        "function mk() -> Result<int, Error>:\n"
+        "fn mk() -> Result<int, Error>:\n"
         "  return Ok(42)\n"
         "v = mk()?\n"
         "print(v)\n"), "42\n");
@@ -453,7 +453,7 @@ TEST_F(CodeGenTest, TopLevelQuestionOnResultOkContinues) {
 
 TEST_F(CodeGenTest, TopLevelQuestionOnResultErrExits) {
     EXPECT_EXIT(runSource(
-        "function mk() -> Result<int, Error>:\n"
+        "fn mk() -> Result<int, Error>:\n"
         "  return Err(Error(\"top level boom\"))\n"
         "v = mk()?\n"
         "print(v)\n"),
@@ -463,7 +463,7 @@ TEST_F(CodeGenTest, TopLevelQuestionOnResultErrExits) {
 
 TEST_F(CodeGenTest, TopLevelBangBangOnResultErrExits) {
     EXPECT_EXIT(runSource(
-        "function mk() -> Result<int, Error>:\n"
+        "fn mk() -> Result<int, Error>:\n"
         "  return Err(Error(\"bang bang fail\"))\n"
         "v = mk()!!\n"
         "print(v)\n"),
@@ -499,20 +499,20 @@ TEST_F(CodeGenTest, ArgumentsTests) {
         {"foo", "bar"}), "foo\nbar\n");
 }
 
-// ===== @native function missing dispatcher detection =====
+// ===== @native fn missing dispatcher detection =====
 
 TEST_F(CodeGenTest, NativeFunctionMissingDispatcher) {
     try {
         runSource(
             "@native\n"
-            "function unhandled_native(x: str) -> str\n"
+            "fn unhandled_native(x: str) -> str\n"
             "\n"
             "print(unhandled_native(\"hello\"))\n"
         );
-        FAIL() << "Expected exception for unhandled @native function";
+        FAIL() << "Expected exception for unhandled @native fn";
     } catch (const std::runtime_error &e) {
         std::string msg = e.what();
-        EXPECT_NE(msg.find("no matching overload for @native function"), std::string::npos)
+        EXPECT_NE(msg.find("no matching overload for @native fn"), std::string::npos)
             << "Error was: " << msg;
     }
 }
@@ -754,14 +754,14 @@ TEST_F(CodeGenTest, AnyTypeRejection) {
     EXPECT_THROW(runSource("x: any = {\"a\": 1}"), std::runtime_error);
     EXPECT_THROW(runSource("x: any = {1, 2, 3}"), std::runtime_error);
     EXPECT_THROW(runSource(
-        "function f(x):\n"
+        "fn f(x):\n"
         "    return x\n"
         "f([1, 2, 3])"), std::runtime_error);
     EXPECT_THROW(runSource(
-        "function f() -> any:\n"
+        "fn f() -> any:\n"
         "    return [1, 2, 3]"), std::runtime_error);
     EXPECT_THROW(runSource(
-        "function f() -> int:\n"
+        "fn f() -> int:\n"
         "    return 42\n"
         "x: any = f"), std::runtime_error);
 }
@@ -947,7 +947,7 @@ TEST_F(CodeGenTest, UnsignedVariableNegation_u64) {
 
 TEST_F(CodeGenTest, UnsignedFunctionReturnNegation) {
     EXPECT_THROW(runSource(
-        "function get_u32() -> u32:\n"
+        "fn get_u32() -> u32:\n"
         "    return 42u32\n"
         "y = -get_u32()"), std::runtime_error);
 }
@@ -957,7 +957,7 @@ TEST_F(CodeGenTest, UnsignedFunctionReturnNegation) {
 TEST_F(CodeGenTest, ReturnTypeInference_Int) {
     // Omitted return type with return int → inferred as int
     EXPECT_EQ(runSource(
-        "function get_val():\n"
+        "fn get_val():\n"
         "    return 42\n"
         "x = get_val()\n"
         "print(x + 1)"), "43\n");
@@ -966,28 +966,28 @@ TEST_F(CodeGenTest, ReturnTypeInference_Int) {
 TEST_F(CodeGenTest, ReturnTypeInference_Unit) {
     // Omitted return type with no return → inferred as Unit
     EXPECT_EQ(runSource(
-        "function side_effect():\n"
+        "fn side_effect():\n"
         "    print(\"hi\")\n"
         "side_effect()"), "hi\n");
 }
 
 TEST_F(CodeGenTest, ReturnTypeInference_Float) {
     EXPECT_EQ(runSource(
-        "function get_pi():\n"
+        "fn get_pi():\n"
         "    return 3.14\n"
         "print(get_pi())"), "3.14\n");
 }
 
 TEST_F(CodeGenTest, ReturnTypeInference_Str) {
     EXPECT_EQ(runSource(
-        "function get_name():\n"
+        "fn get_name():\n"
         "    return \"hello\"\n"
         "print(get_name())"), "hello\n");
 }
 
 TEST_F(CodeGenTest, ReturnTypeInference_Bool) {
     EXPECT_EQ(runSource(
-        "function is_ok():\n"
+        "fn is_ok():\n"
         "    return true\n"
         "print(is_ok())"), "true\n");
 }
@@ -995,7 +995,7 @@ TEST_F(CodeGenTest, ReturnTypeInference_Bool) {
 TEST_F(CodeGenTest, ReturnTypeInference_UnionIntFloat) {
     // Multiple return types → union type
     EXPECT_EQ(runSource(
-        "function mixed(flag: bool):\n"
+        "fn mixed(flag: bool):\n"
         "    if flag:\n"
         "        return 42\n"
         "    return 3.14\n"
@@ -1005,7 +1005,7 @@ TEST_F(CodeGenTest, ReturnTypeInference_UnionIntFloat) {
 
 TEST_F(CodeGenTest, ReturnTypeInference_UnionStrInt) {
     EXPECT_EQ(runSource(
-        "function mixed(flag: bool):\n"
+        "fn mixed(flag: bool):\n"
         "    if flag:\n"
         "        return \"hello\"\n"
         "    return 42\n"
@@ -1016,7 +1016,7 @@ TEST_F(CodeGenTest, ReturnTypeInference_UnionStrInt) {
 TEST_F(CodeGenTest, ReturnTypeInference_ExplicitAnyUnchanged) {
     // Explicit -> any still works as before
     EXPECT_EQ(runSource(
-        "function get_val() -> any:\n"
+        "fn get_val() -> any:\n"
         "    return 42\n"
         "x: any = get_val()\n"
         "print(x)"), "42\n");
@@ -1228,7 +1228,7 @@ TEST_F(CodeGenTest, TopLevelConstFloatAccessibleFromFunction) {
     EXPECT_EQ(runSource(
         "@const\n"
         "PI: float = 3.14\n"
-        "function show_pi() -> float:\n"
+        "fn show_pi() -> float:\n"
         "    return PI\n"
         "print(show_pi())"), "3.14\n");
 }
@@ -1237,7 +1237,7 @@ TEST_F(CodeGenTest, TopLevelConstIntAccessibleFromFunction) {
     EXPECT_EQ(runSource(
         "@const\n"
         "MAX: int = 10\n"
-        "function get_max() -> int:\n"
+        "fn get_max() -> int:\n"
         "    return MAX\n"
         "print(get_max())"), "10\n");
 }
@@ -1246,7 +1246,7 @@ TEST_F(CodeGenTest, TopLevelConstBoolAccessibleFromFunction) {
     EXPECT_EQ(runSource(
         "@const\n"
         "FLAG: bool = true\n"
-        "function get_flag() -> bool:\n"
+        "fn get_flag() -> bool:\n"
         "    return FLAG\n"
         "print(get_flag())"), "true\n");
 }
@@ -1255,7 +1255,7 @@ TEST_F(CodeGenTest, TopLevelConstStrLiteralAccessibleFromFunction) {
     EXPECT_EQ(runSource(
         "@const\n"
         "G: str = \"hello\"\n"
-        "function greet() -> str:\n"
+        "fn greet() -> str:\n"
         "    return G\n"
         "print(greet())"), "hello\n");
 }
@@ -1265,7 +1265,7 @@ TEST_F(CodeGenTest, TopLevelConstStrComputedAccessibleFromFunction) {
     EXPECT_EQ(runSource(
         "@const\n"
         "G: str = \"foo\" + \"bar\"\n"
-        "function greet() -> str:\n"
+        "fn greet() -> str:\n"
         "    return G\n"
         "print(greet())"), "foobar\n");
 }
@@ -1274,9 +1274,9 @@ TEST_F(CodeGenTest, TopLevelConstListAccessibleFromFunction) {
     EXPECT_EQ(runSource(
         "@const\n"
         "XS: List<int> = [10, 20, 30]\n"
-        "function head_xs() -> int:\n"
+        "fn head_xs() -> int:\n"
         "    return XS[0]\n"
-        "function sum3() -> int:\n"
+        "fn sum3() -> int:\n"
         "    return XS[0] + XS[1] + XS[2]\n"
         "print(head_xs())\n"
         "print(sum3())"), "10\n60\n");
@@ -1286,7 +1286,7 @@ TEST_F(CodeGenTest, TopLevelConstMapAccessibleFromFunction) {
     EXPECT_EQ(runSource(
         "@const\n"
         "M: Map<str, int> = {\"a\": 1, \"b\": 2}\n"
-        "function get_a() -> int:\n"
+        "fn get_a() -> int:\n"
         "    return M[\"a\"]\n"
         "print(get_a())"), "1\n");
 }
@@ -1298,9 +1298,9 @@ TEST_F(CodeGenTest, TopLevelConstRecordFieldAccessibleFromFunction) {
         "    y: int\n"
         "@const\n"
         "P: Point = Point(11, 22)\n"
-        "function px() -> int:\n"
+        "fn px() -> int:\n"
         "    return P.x\n"
-        "function py() -> int:\n"
+        "fn py() -> int:\n"
         "    return P.y\n"
         "print(px())\n"
         "print(py())"), "11\n22\n");
@@ -1311,9 +1311,9 @@ TEST_F(CodeGenTest, TopLevelConstTransitiveCallChain) {
     EXPECT_EQ(runSource(
         "@const\n"
         "K: int = 5\n"
-        "function a() -> int:\n"
+        "fn a() -> int:\n"
         "    return K\n"
-        "function b() -> int:\n"
+        "fn b() -> int:\n"
         "    return a()\n"
         "print(b())"), "5\n");
 }
@@ -1325,7 +1325,7 @@ TEST_F(CodeGenTest, TopLevelConstReadFromInnerLambda) {
     EXPECT_EQ(runSource(
         "@const\n"
         "K: int = 42\n"
-        "function outer() -> int:\n"
+        "fn outer() -> int:\n"
         "    f = () -> int => K\n"
         "    return f()\n"
         "print(outer())"), "42\n");
@@ -1334,7 +1334,7 @@ TEST_F(CodeGenTest, TopLevelConstReadFromInnerLambda) {
 TEST_F(CodeGenTest, TopLevelLetAccessibleFromFunction) {
     EXPECT_EQ(runSource(
         "x: int = 7\n"
-        "function get_x() -> int:\n"
+        "fn get_x() -> int:\n"
         "    return x\n"
         "print(get_x())"), "7\n");
 }
@@ -1345,7 +1345,7 @@ TEST_F(CodeGenTest, TopLevelLetMutableWriteThroughFromFunction) {
     // shadow it with a new local.
     EXPECT_EQ(runSource(
         "counter: int = 0\n"
-        "function bump():\n"
+        "fn bump():\n"
         "    counter = counter + 1\n"
         "bump()\n"
         "bump()\n"
@@ -1358,7 +1358,7 @@ TEST_F(CodeGenTest, TopLevelConstReassignFromFunctionThrows) {
     EXPECT_THROW(runSource(
         "@const\n"
         "N: int = 5\n"
-        "function bad():\n"
+        "fn bad():\n"
         "    N = 6\n"
         "bad()"), std::runtime_error);
 }
@@ -1367,7 +1367,7 @@ TEST_F(CodeGenTest, TopLevelForwardReferenceSourceOrderStrict) {
     // Source-order strict: a function cannot reference a top-level binding
     // declared textually AFTER the function definition.
     EXPECT_THROW(runSource(
-        "function foo() -> int:\n"
+        "fn foo() -> int:\n"
         "    return X\n"
         "@const\n"
         "X: int = 1\n"
@@ -1380,7 +1380,7 @@ TEST_F(CodeGenTest, TopLevelBindingInsideNestedBlockStaysLocal) {
     EXPECT_THROW(runSource(
         "if true:\n"
         "    y: int = 1\n"
-        "function read_y() -> int:\n"
+        "fn read_y() -> int:\n"
         "    return y\n"
         "print(read_y())"), std::runtime_error);
 }
@@ -1394,7 +1394,7 @@ TEST_F(CodeGenTest, TopLevelMutableFieldAssignFromFunction) {
         "    x: int\n"
         "    y: int\n"
         "p: Point = Point(1, 2)\n"
-        "function bump_x():\n"
+        "fn bump_x():\n"
         "    p.x = 99\n"
         "bump_x()\n"
         "print(p.x)\n"
@@ -1413,7 +1413,7 @@ TEST_F(CodeGenTest, TopLevelConstFieldAssignFromFunctionThrows) {
             "    y: int\n"
             "@const\n"
             "P: Point = Point(1, 2)\n"
-            "function bad():\n"
+            "fn bad():\n"
             "    P.x = 99\n"
             "bad()");
         FAIL() << "expected runtime_error for @const field assignment";
@@ -1431,7 +1431,7 @@ TEST_F(CodeGenTest, TopLevelConstShadowedByParameter) {
     EXPECT_EQ(runSource(
         "@const\n"
         "x: int = 100\n"
-        "function f(x: int) -> int:\n"
+        "fn f(x: int) -> int:\n"
         "    return x\n"
         "print(f(3))"), "3\n");
 }
@@ -1443,7 +1443,7 @@ TEST_F(CodeGenTest, ParameterCanReassignShadowingTopLevelConst) {
     EXPECT_EQ(runSource(
         "@const\n"
         "n: int = 100\n"
-        "function bump(n: int) -> int:\n"
+        "fn bump(n: int) -> int:\n"
         "    n = n + 1\n"
         "    return n\n"
         "print(bump(5))"), "6\n");
@@ -1455,7 +1455,7 @@ TEST_F(CodeGenTest, ParameterCanReassignShadowingTopLevelConst) {
 TEST_F(CodeGenTest, TypedLocalShadowsTopLevelLet) {
     EXPECT_EQ(runSource(
         "x: int = 7\n"
-        "function g() -> int:\n"
+        "fn g() -> int:\n"
         "    x: int = 2\n"
         "    return x\n"
         "print(g())\n"
@@ -1467,7 +1467,7 @@ TEST_F(CodeGenTest, TypedLocalShadowsTopLevelLet) {
 TEST_F(CodeGenTest, LocalConstShadowsTopLevelLet) {
     EXPECT_EQ(runSource(
         "k: int = 1\n"
-        "function h() -> int:\n"
+        "fn h() -> int:\n"
         "    @const\n"
         "    k: int = 99\n"
         "    return k\n"
@@ -1485,7 +1485,7 @@ TEST_F(CodeGenTest, LocalRecordShadowsTopLevelConstRecord) {
         "    y: int\n"
         "@const\n"
         "P: Point = Point(1, 2)\n"
-        "function f() -> int:\n"
+        "fn f() -> int:\n"
         "    P: Point = Point(10, 20)\n"
         "    P.x = 99\n"
         "    return P.x\n"
@@ -1502,7 +1502,7 @@ TEST_F(CodeGenTest, WeakTopLevelRejectedFromFunction) {
     EXPECT_THROW(runSource(
         "xs: List<int> = [1, 2, 3]\n"
         "w: weak List<int> = weak xs\n"
-        "function use_w():\n"
+        "fn use_w():\n"
         "    y = w\n"
         "use_w()"), std::runtime_error);
 }
@@ -1517,7 +1517,7 @@ TEST_F(CodeGenTest, WeakTopLevelRejectedFromFunction) {
 TEST_F(CodeGenTest, TopLevelListReassignedManyTimesFromFunction) {
     EXPECT_EQ(runSource(
         "xs: List<int> = [1, 2, 3]\n"
-        "function replace_xs(i: int):\n"
+        "fn replace_xs(i: int):\n"
         "    xs = [i, i+1, i+2]\n"
         "replace_xs(10)\n"
         "replace_xs(20)\n"
@@ -1535,7 +1535,7 @@ TEST_F(CodeGenTest, TopLevelListReassignedManyTimesFromFunction) {
 TEST_F(CodeGenTest, ParallelForNestedLoopVarShadowsModuleGlobal) {
     EXPECT_EQ(runSource(
         "g: int = 999\n"
-        "function f() -> int:\n"
+        "fn f() -> int:\n"
         "    @parallel\n"
         "    for i in 0..3:\n"
         "        for g in [1, 2, 3]:\n"
@@ -1551,7 +1551,7 @@ TEST_F(CodeGenTest, ParallelForNestedLoopVarShadowsModuleGlobal) {
 TEST_F(CodeGenTest, ParallelForInFunctionBodyAllowsShadowOfModuleGlobal) {
     EXPECT_EQ(runSource(
         "x: int = 100\n"
-        "function f():\n"
+        "fn f():\n"
         "    @parallel\n"
         "    for i in 0..3:\n"
         "        x: int = i\n"
@@ -1567,7 +1567,7 @@ TEST_F(CodeGenTest, ParallelForInFunctionBodyAllowsShadowOfModuleGlobal) {
 TEST_F(CodeGenTest, ParallelForRejectsModuleGlobalMutation) {
     EXPECT_THROW(runSource(
         "x: int = 100\n"
-        "function f():\n"
+        "fn f():\n"
         "    @parallel\n"
         "    for i in 0..3:\n"
         "        x = i\n"
@@ -1582,9 +1582,9 @@ TEST_F(CodeGenTest, ParallelForRejectsModuleGlobalMutation) {
 TEST_F(CodeGenTest, TopLevelFixedArrayIndexedFromFunction) {
     EXPECT_EQ(runSource(
         "buf: i32[4] = [10i32, 20i32, 30i32, 40i32]\n"
-        "function head() -> i32:\n"
+        "fn head() -> i32:\n"
         "    return buf[0]\n"
-        "function at_two() -> i32:\n"
+        "fn at_two() -> i32:\n"
         "    return buf[2]\n"
         "print(head())\n"
         "print(at_two())"), "10\n30\n");

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -185,7 +185,7 @@ TEST_F(CodeGenTest, LambdaFloat) {
 
 TEST_F(CodeGenTest, LambdaAsArgument) {
     std::string src =
-        "function apply(f: function(int) -> int, x: int) -> int:\n"
+        "fn apply(f: fn(int) -> int, x: int) -> int:\n"
         "    return f(x)\n"
         "doubled = apply((n: int) => n * 2, 10)\n"
         "print(doubled)";
@@ -194,7 +194,7 @@ TEST_F(CodeGenTest, LambdaAsArgument) {
 
 TEST_F(CodeGenTest, LambdaStoredAndPassed) {
     std::string src =
-        "function apply(f: function(int) -> int, x: int) -> int:\n"
+        "fn apply(f: fn(int) -> int, x: int) -> int:\n"
         "    return f(x)\n"
         "triple = (n: int) => n * 3\n"
         "print(apply(triple, 5))";
@@ -203,9 +203,9 @@ TEST_F(CodeGenTest, LambdaStoredAndPassed) {
 
 TEST_F(CodeGenTest, FunctionReference) {
     std::string src =
-        "function square(x: int) -> int:\n"
+        "fn square(x: int) -> int:\n"
         "    return x * x\n"
-        "function apply(f: function(int) -> int, x: int) -> int:\n"
+        "fn apply(f: fn(int) -> int, x: int) -> int:\n"
         "    return f(x)\n"
         "print(apply(square, 6))";
     EXPECT_EQ(runSource(src), "36\n");
@@ -411,7 +411,7 @@ TEST_F(CodeGenTest, SetEmptyWithAnnotation) {
 
 TEST_F(CodeGenTest, SetInFunction) {
     std::string src =
-        "function has_element(s: Set<int>, x: int) -> bool:\n"
+        "fn has_element(s: Set<int>, x: int) -> bool:\n"
         "    return x in s\n"
         "s = {10, 20, 30}\n"
         "print(has_element(s, 20))\n"
@@ -485,7 +485,7 @@ TEST_F(CodeGenTest, EnumAsParam) {
         "    Red\n"
         "    Green\n"
         "    Blue\n"
-        "function is_red(c: Color) -> bool:\n"
+        "fn is_red(c: Color) -> bool:\n"
         "    return c == Color::Red\n"
         "print(is_red(Color::Red))\n"
         "print(is_red(Color::Blue))";
@@ -628,7 +628,7 @@ TEST_F(CodeGenTest, UnionReassign) {
 
 TEST_F(CodeGenTest, UnionFnParam) {
     std::string src =
-        "function show(x: int | str) -> int:\n"
+        "fn show(x: int | str) -> int:\n"
         "    print(x)\n"
         "    return 0\n"
         "show(42)\n"
@@ -638,7 +638,7 @@ TEST_F(CodeGenTest, UnionFnParam) {
 
 TEST_F(CodeGenTest, UnionFnReturn) {
     std::string src =
-        "function get_val(flag: bool) -> int | str:\n"
+        "fn get_val(flag: bool) -> int | str:\n"
         "    if flag:\n"
         "        return 42\n"
         "    return \"hello\"\n"
@@ -818,7 +818,7 @@ print(e)
 
 TEST_F(CodeGenTest, ResultOkMatch) {
     std::string src = R"(
-function read_file(path: str) -> Result<str, Error>:
+fn read_file(path: str) -> Result<str, Error>:
     if path == "":
         return Err(Error("empty path"))
     return Ok("content")
@@ -835,7 +835,7 @@ case res:
 
 TEST_F(CodeGenTest, ResultErrMatch) {
     std::string src = R"(
-function read_file(path: str) -> Result<str, Error>:
+fn read_file(path: str) -> Result<str, Error>:
     if path == "":
         return Err(Error("empty path"))
     return Ok("content")
@@ -852,7 +852,7 @@ case res:
 
 TEST_F(CodeGenTest, ResultDivideOk) {
     std::string src = R"(
-function divide(a: int, b: int) -> Result<int, Error>:
+fn divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
         return Err(Error("division by zero"))
     return Ok(a // b)
@@ -868,7 +868,7 @@ case divide(10, 2):
 
 TEST_F(CodeGenTest, ResultDivideErr) {
     std::string src = R"(
-function divide(a: int, b: int) -> Result<int, Error>:
+fn divide(a: int, b: int) -> Result<int, Error>:
     if b == 0:
         return Err(Error("division by zero"))
     return Ok(a // b)
@@ -1342,7 +1342,7 @@ TEST_F(CodeGenTest, FieldAssignSubtypeCoercion) {
 
 TEST_F(CodeGenTest, ErrorPropagateSubtypeCoercion) {
     std::string src =
-        "record ApiError < Error:\n    endpoint: str\nfunction fetch(url: str) -> Result<int, ApiError>:\n    return Err(ApiError(\"fail\", 500, url))\nfunction process(url: str) -> Result<int, Error>:\n    val = fetch(url)?\n    return Ok(val)\nresult = process(\"/api\")\ncase result:\n    Err(e):\n        print(e.message)\n    Ok(v):\n        print(v)";
+        "record ApiError < Error:\n    endpoint: str\nfn fetch(url: str) -> Result<int, ApiError>:\n    return Err(ApiError(\"fail\", 500, url))\nfn process(url: str) -> Result<int, Error>:\n    val = fetch(url)?\n    return Ok(val)\nresult = process(\"/api\")\ncase result:\n    Err(e):\n        print(e.message)\n    Ok(v):\n        print(v)";
     EXPECT_EQ(runSource(src), "fail\n");
 }
 
@@ -1355,7 +1355,7 @@ TEST_F(CodeGenTest, GenericRecordBound) {
         "    legs: int\n"
         "record Dog < Animal:\n"
         "    breed: str\n"
-        "function describe<T: Animal>(a: T) -> str:\n"
+        "fn describe<T: Animal>(a: T) -> str:\n"
         "    return a.name\n"
         "print(describe(Dog(\"Rex\", 4, \"Lab\")))";
     EXPECT_EQ(runSource(src), "Rex\n");
@@ -1366,7 +1366,7 @@ TEST_F(CodeGenTest, GenericRecordBoundExactType) {
         "record Animal:\n"
         "    name: str\n"
         "    legs: int\n"
-        "function describe<T: Animal>(a: T) -> str:\n"
+        "fn describe<T: Animal>(a: T) -> str:\n"
         "    return a.name\n"
         "print(describe(Animal(\"Cat\", 4)))";
     EXPECT_EQ(runSource(src), "Cat\n");
@@ -1377,7 +1377,7 @@ TEST_F(CodeGenTest, GenericRecordBoundViolation) {
         "record Animal:\n"
         "    name: str\n"
         "    legs: int\n"
-        "function describe<T: Animal>(a: T) -> str:\n"
+        "fn describe<T: Animal>(a: T) -> str:\n"
         "    return a.name\n"
         "describe(42)";
     EXPECT_THROW(runSource(src), std::runtime_error);
@@ -1391,7 +1391,7 @@ TEST_F(CodeGenTest, GenericRecordBoundDeepInheritance) {
         "    breed: str\n"
         "record GuideDog < Dog:\n"
         "    handler: str\n"
-        "function get_name<T: Animal>(a: T) -> str:\n"
+        "fn get_name<T: Animal>(a: T) -> str:\n"
         "    return a.name\n"
         "print(get_name(GuideDog(\"Rex\", \"Lab\", \"John\")))";
     EXPECT_EQ(runSource(src), "Rex\n");
@@ -1403,7 +1403,7 @@ TEST_F(CodeGenTest, GenericRecordBoundExplicitTypeArg) {
         "    name: str\n"
         "record Dog < Animal:\n"
         "    breed: str\n"
-        "function get_name<T: Animal>(a: T) -> str:\n"
+        "fn get_name<T: Animal>(a: T) -> str:\n"
         "    return a.name\n"
         "print(get_name[Dog](Dog(\"Rex\", \"Lab\")))";
     EXPECT_EQ(runSource(src), "Rex\n");
@@ -1415,7 +1415,7 @@ TEST_F(CodeGenTest, GenericRecordBoundMixedParams) {
         "    name: str\n"
         "record Dog < Animal:\n"
         "    breed: str\n"
-        "function pair_name<T: Animal, U>(a: T, x: U) -> str:\n"
+        "fn pair_name<T: Animal, U>(a: T, x: U) -> str:\n"
         "    return a.name\n"
         "print(pair_name(Dog(\"Rex\", \"Lab\"), 42))";
     EXPECT_EQ(runSource(src), "Rex\n");
@@ -1428,7 +1428,7 @@ TEST_F(CodeGenTest, GenericRecordBoundAliasAcceptsSubtype) {
         "record Dog < Animal:\n"
         "    breed: str\n"
         "type AnimalAlias = Animal\n"
-        "function describe<T: AnimalAlias>(a: T) -> str:\n"
+        "fn describe<T: AnimalAlias>(a: T) -> str:\n"
         "    return a.name\n"
         "print(describe(Dog(\"Rex\", \"Lab\")))";
     EXPECT_EQ(runSource(src), "Rex\n");
@@ -1445,7 +1445,7 @@ TEST_F(CodeGenTest, GenericRecordBoundAliasRejectsNonSubtype) {
         "record Cat:\n"
         "    name: str\n"
         "type AnimalAlias = Animal\n"
-        "function describe<T: AnimalAlias>(a: T) -> str:\n"
+        "fn describe<T: AnimalAlias>(a: T) -> str:\n"
         "    return a.name\n"
         "describe(Cat(\"Tom\"))";
     EXPECT_THROW(runSource(src), std::runtime_error);
@@ -1456,7 +1456,7 @@ TEST_F(CodeGenTest, GenericRecordBoundAliasRejectsNonSubtype) {
 TEST_F(CodeGenTest, TailCallOptimization) {
     // Deep self-recursive tail call should not stack overflow
     EXPECT_EQ(runSource(
-        "function sum_to(n: int, acc: int) -> int:\n"
+        "fn sum_to(n: int, acc: int) -> int:\n"
         "  if n <= 0:\n"
         "    return acc\n"
         "  return sum_to(n - 1, acc + n)\n"
@@ -1466,7 +1466,7 @@ TEST_F(CodeGenTest, TailCallOptimization) {
 TEST_F(CodeGenTest, TailCallFactorial) {
     // Tail-recursive factorial with accumulator
     EXPECT_EQ(runSource(
-        "function factorial(n: int, acc: int) -> int:\n"
+        "fn factorial(n: int, acc: int) -> int:\n"
         "  if n <= 1:\n"
         "    return acc\n"
         "  return factorial(n - 1, n * acc)\n"
@@ -1476,7 +1476,7 @@ TEST_F(CodeGenTest, TailCallFactorial) {
 TEST_F(CodeGenTest, NonTailRecursionStillWorks) {
     // n * factorial(n-1) is NOT a tail call — should still work for small N
     EXPECT_EQ(runSource(
-        "function factorial(n: int) -> int:\n"
+        "fn factorial(n: int) -> int:\n"
         "  if n <= 1:\n"
         "    return 1\n"
         "  return n * factorial(n - 1)\n"
@@ -1487,12 +1487,12 @@ TEST_F(CodeGenTest, NonTailRecursionStillWorks) {
 
 TEST_F(CodeGenTest, MutualRecursion) {
     EXPECT_EQ(runSource(
-        "function is_even(n: int) -> bool:\n"
+        "fn is_even(n: int) -> bool:\n"
         "  if n == 0:\n"
         "    return true\n"
         "  return is_odd(n - 1)\n"
         "\n"
-        "function is_odd(n: int) -> bool:\n"
+        "fn is_odd(n: int) -> bool:\n"
         "  if n == 0:\n"
         "    return false\n"
         "  return is_even(n - 1)\n"
@@ -1503,17 +1503,17 @@ TEST_F(CodeGenTest, MutualRecursion) {
 
 TEST_F(CodeGenTest, ThreeWayMutualRecursion) {
     EXPECT_EQ(runSource(
-        "function fa(n: int) -> str:\n"
+        "fn fa(n: int) -> str:\n"
         "  if n <= 0:\n"
         "    return \"a\"\n"
         "  return fb(n - 1)\n"
         "\n"
-        "function fb(n: int) -> str:\n"
+        "fn fb(n: int) -> str:\n"
         "  if n <= 0:\n"
         "    return \"b\"\n"
         "  return fc(n - 1)\n"
         "\n"
-        "function fc(n: int) -> str:\n"
+        "fn fc(n: int) -> str:\n"
         "  if n <= 0:\n"
         "    return \"c\"\n"
         "  return fa(n - 1)\n"
@@ -1526,10 +1526,10 @@ TEST_F(CodeGenTest, ThreeWayMutualRecursion) {
 
 TEST_F(CodeGenTest, ForwardFunctionReference) {
     EXPECT_EQ(runSource(
-        "function caller(n: int) -> int:\n"
+        "fn caller(n: int) -> int:\n"
         "  return callee(n) + 1\n"
         "\n"
-        "function callee(n: int) -> int:\n"
+        "fn callee(n: int) -> int:\n"
         "  return n * 2\n"
         "\n"
         "print(caller(5))"), "11\n");
@@ -1546,7 +1546,7 @@ TEST_F(CodeGenTest, ResultCoerceIfBothBranchesOk) {
     EXPECT_NO_THROW(compileSource(
         "record MyErr:\n"
         "  msg: str\n"
-        "function test_fn(x: int) -> Result<int, MyErr>:\n"
+        "fn test_fn(x: int) -> Result<int, MyErr>:\n"
         "  r: Result<int, MyErr> = if x > 0:\n"
         "    (Ok(x))\n"
         "  else:\n"

--- a/tests/test_codegen_arc.cpp
+++ b/tests/test_codegen_arc.cpp
@@ -231,5 +231,5 @@ TEST_F(CodeGenTest, CollectionVariableBinding) {
 }
 
 TEST_F(CodeGenTest, CollectionInFunction) {
-    EXPECT_EQ(runSource("function get_length(lst: List<int>) -> int:\n  return length(lst)\n\nx = [10, 20, 30]\nprint(get_length(x))"), "3\n");
+    EXPECT_EQ(runSource("fn get_length(lst: List<int>) -> int:\n  return length(lst)\n\nx = [10, 20, 30]\nprint(get_length(x))"), "3\n");
 }

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -29,7 +29,7 @@ TEST_F(CodeGenTest, ListInFunctions) {
     // ListInFunction
     {
         std::string src =
-            "function head(xs: List<int>) -> int:\n"
+            "fn head(xs: List<int>) -> int:\n"
             "    return xs[0]\n"
             "xs = [10, 20, 30]\n"
             "print(head(xs))";
@@ -38,7 +38,7 @@ TEST_F(CodeGenTest, ListInFunctions) {
     // ListLenInFunction
     {
         std::string src =
-            "function size(xs: List<int>) -> int:\n"
+            "fn size(xs: List<int>) -> int:\n"
             "    return length(xs)\n"
             "xs = [1, 2, 3, 4, 5]\n"
             "print(size(xs))";
@@ -81,7 +81,7 @@ TEST_F(CodeGenTest, ListNegativeIndexOutOfBounds) {
 
 TEST_F(CodeGenTest, UFCSIntLiteral) {
     std::string src =
-        "function double(x: int) -> int:\n"
+        "fn double(x: int) -> int:\n"
         "    return x * 2\n"
         "print(5.double())";
     EXPECT_EQ(runSource(src), "10\n");
@@ -89,7 +89,7 @@ TEST_F(CodeGenTest, UFCSIntLiteral) {
 
 TEST_F(CodeGenTest, UFCSBasicCall) {
     std::string src =
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "x = 1\n"
         "print(x.add(2))";
@@ -98,9 +98,9 @@ TEST_F(CodeGenTest, UFCSBasicCall) {
 
 TEST_F(CodeGenTest, UFCSChainedCall) {
     std::string src =
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
-        "function mul(a: int, b: int) -> int:\n"
+        "fn mul(a: int, b: int) -> int:\n"
         "    return a * b\n"
         "x = 2\n"
         "print(x.add(3).mul(4))";
@@ -112,7 +112,7 @@ TEST_F(CodeGenTest, UFCSWithStruct) {
         "record Point:\n"
         "    x: int\n"
         "    y: int\n"
-        "function get_x(p: Point) -> int:\n"
+        "fn get_x(p: Point) -> int:\n"
         "    return p.x\n"
         "p = Point(42, 99)\n"
         "print(p.get_x())";
@@ -137,7 +137,7 @@ TEST_F(CodeGenTest, MapBasicOperations) {
     // MapInFunction
     {
         std::string src =
-            "function get_val(m: Map<str, int>, k: str) -> int:\n"
+            "fn get_val(m: Map<str, int>, k: str) -> int:\n"
             "    return m[k]\n"
             "m = {\"a\": 10, \"b\": 20}\n"
             "print(get_val(m, \"b\"))";
@@ -666,9 +666,9 @@ TEST_F(CodeGenTest, OverloadBasicResolution) {
     // OverloadByArgCount
     {
         std::string src =
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return x\n"
-            "function f(x: int, y: int) -> int:\n"
+            "fn f(x: int, y: int) -> int:\n"
             "    return x + y\n"
             "print(f(10))\n"
             "print(f(3, 4))";
@@ -677,9 +677,9 @@ TEST_F(CodeGenTest, OverloadBasicResolution) {
     // OverloadByArgType
     {
         std::string src =
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return x * 2\n"
-            "function f(x: float) -> float:\n"
+            "fn f(x: float) -> float:\n"
             "    return x * 3.0\n"
             "print(f(5))\n"
             "print(f(2.0))";
@@ -688,9 +688,9 @@ TEST_F(CodeGenTest, OverloadBasicResolution) {
     // OverloadDifferentReturn
     {
         std::string src =
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return x\n"
-            "function f(x: float) -> bool:\n"
+            "fn f(x: float) -> bool:\n"
             "    return x > 0.0\n"
             "print(f(42))\n"
             "print(f(1.5))";
@@ -699,9 +699,9 @@ TEST_F(CodeGenTest, OverloadBasicResolution) {
     // OverloadWithUFCS
     {
         std::string src =
-            "function process(x: int) -> int:\n"
+            "fn process(x: int) -> int:\n"
             "    return x * 2\n"
-            "function process(x: int, y: int) -> int:\n"
+            "fn process(x: int, y: int) -> int:\n"
             "    return x + y\n"
             "a = 5\n"
             "print(a.process())\n"
@@ -711,11 +711,11 @@ TEST_F(CodeGenTest, OverloadBasicResolution) {
     // OverloadRecursive
     {
         std::string src =
-            "function fact(n: int) -> int:\n"
+            "fn fact(n: int) -> int:\n"
             "    if n <= 1:\n"
             "        return 1\n"
             "    return n * fact(n - 1)\n"
-            "function fact(n: int, acc: int) -> int:\n"
+            "fn fact(n: int, acc: int) -> int:\n"
             "    if n <= 1:\n"
             "        return acc\n"
             "    return fact(n - 1, acc * n)\n"
@@ -729,25 +729,25 @@ TEST_F(CodeGenTest, OverloadErrors) {
     // OverloadSameSignatureError
     {
         std::string src =
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return x\n"
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return x + 1\n";
         EXPECT_THROW(runSource(src), std::runtime_error);
     }
     // OverloadSameParamsDiffReturnError
     {
         std::string src =
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return x\n"
-            "function f(x: int) -> float:\n"
+            "fn f(x: int) -> float:\n"
             "    return 1.0\n";
         EXPECT_THROW(runSource(src), std::runtime_error);
     }
     // OverloadNoMatchError
     {
         std::string src =
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return x\n"
             "f(3.14)";
         EXPECT_THROW(runSource(src), std::runtime_error);
@@ -755,9 +755,9 @@ TEST_F(CodeGenTest, OverloadErrors) {
     // OverloadSameSpecificityRemainsAmbiguous
     {
         std::string src =
-            "function f(x: int | str) -> int:\n"
+            "fn f(x: int | str) -> int:\n"
             "    return 1\n"
-            "function f(x: int | float) -> int:\n"
+            "fn f(x: int | float) -> int:\n"
             "    return 2\n"
             "f(42)";
         EXPECT_THROW(runSource(src), std::runtime_error);
@@ -768,9 +768,9 @@ TEST_F(CodeGenTest, OverloadRanking) {
     // OverloadPrefersExactOverAny
     {
         std::string src =
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return 1\n"
-            "function f(x) -> int:\n"
+            "fn f(x) -> int:\n"
             "    return 2\n"
             "print(f(42))\n"
             "print(f(\"hello\"))";
@@ -779,9 +779,9 @@ TEST_F(CodeGenTest, OverloadRanking) {
     // OverloadPrefersUnionOverAny
     {
         std::string src =
-            "function f(x: int | float) -> int:\n"
+            "fn f(x: int | float) -> int:\n"
             "    return 1\n"
-            "function f(x) -> int:\n"
+            "fn f(x) -> int:\n"
             "    return 2\n"
             "print(f(42))\n"
             "print(f(3.14))\n"
@@ -792,9 +792,9 @@ TEST_F(CodeGenTest, OverloadRanking) {
     {
         std::string src =
             "type Num = int | float\n"
-            "function f(x: Num) -> int:\n"
+            "fn f(x: Num) -> int:\n"
             "    return 1\n"
-            "function f(x) -> int:\n"
+            "fn f(x) -> int:\n"
             "    return 2\n"
             "print(f(42))\n"
             "print(f(3.14))\n"
@@ -804,9 +804,9 @@ TEST_F(CodeGenTest, OverloadRanking) {
     // OverloadPrefersExactOverUnion
     {
         std::string src =
-            "function f(x: int | float) -> int:\n"
+            "fn f(x: int | float) -> int:\n"
             "    return 1\n"
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return 2\n"
             "print(f(42))\n"
             "print(f(3.14))";
@@ -818,9 +818,9 @@ TEST_F(CodeGenTest, OverloadSpecialArgs) {
     // OverloadWithNone
     {
         std::string src =
-            "function f(x: Option<int>) -> int:\n"
+            "fn f(x: Option<int>) -> int:\n"
             "    return 0\n"
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    return x\n"
             "print(f(None))\n"
             "print(f(42))";
@@ -830,7 +830,7 @@ TEST_F(CodeGenTest, OverloadSpecialArgs) {
     {
         std::string src =
             "type Num = int | float\n"
-            "function show(x: Num) -> Unit:\n"
+            "fn show(x: Num) -> Unit:\n"
             "    print(x)\n"
             "show(42)\n"
             "show(3.14)";
@@ -847,7 +847,7 @@ TEST_F(CodeGenTest, OperatorOverloadStruct) {
             "record Vec2:\n"
             "    x: int\n"
             "    y: int\n"
-            "function operator+(a: Vec2, b: Vec2) -> Vec2:\n"
+            "fn operator+(a: Vec2, b: Vec2) -> Vec2:\n"
             "    return Vec2(a.x + b.x, a.y + b.y)\n"
             "v1 = Vec2(1, 2)\n"
             "v2 = Vec2(3, 4)\n"
@@ -862,7 +862,7 @@ TEST_F(CodeGenTest, OperatorOverloadStruct) {
             "record Vec2:\n"
             "    x: int\n"
             "    y: int\n"
-            "function operator-(a: Vec2, b: Vec2) -> Vec2:\n"
+            "fn operator-(a: Vec2, b: Vec2) -> Vec2:\n"
             "    return Vec2(a.x - b.x, a.y - b.y)\n"
             "v1 = Vec2(5, 8)\n"
             "v2 = Vec2(2, 3)\n"
@@ -877,7 +877,7 @@ TEST_F(CodeGenTest, OperatorOverloadStruct) {
             "record Point:\n"
             "    x: int\n"
             "    y: int\n"
-            "function operator==(a: Point, b: Point) -> bool:\n"
+            "fn operator==(a: Point, b: Point) -> bool:\n"
             "    return a.x == b.x and a.y == b.y\n"
             "p1 = Point(1, 2)\n"
             "p2 = Point(1, 2)\n"
@@ -892,7 +892,7 @@ TEST_F(CodeGenTest, OperatorOverloadStruct) {
             "record Vec2:\n"
             "    x: int\n"
             "    y: int\n"
-            "function operator-(a: Vec2) -> Vec2:\n"
+            "fn operator-(a: Vec2) -> Vec2:\n"
             "    return Vec2(0 - a.x, 0 - a.y)\n"
             "v = Vec2(3, 5)\n"
             "neg = -v\n"
@@ -906,9 +906,9 @@ TEST_F(CodeGenTest, OperatorOverloadStruct) {
             "record Vec2:\n"
             "    x: int\n"
             "    y: int\n"
-            "function operator+(a: Vec2, b: Vec2) -> Vec2:\n"
+            "fn operator+(a: Vec2, b: Vec2) -> Vec2:\n"
             "    return Vec2(a.x + b.x, a.y + b.y)\n"
-            "function operator*(a: Vec2, s: int) -> Vec2:\n"
+            "fn operator*(a: Vec2, s: int) -> Vec2:\n"
             "    return Vec2(a.x * s, a.y * s)\n"
             "v = Vec2(1, 2)\n"
             "v2 = v * 3\n"
@@ -927,7 +927,7 @@ TEST_F(CodeGenTest, CompoundAssignWithOperatorPlusEq) {
         "record Vec2:\n"
         "    x: int\n"
         "    y: int\n"
-        "function operator+=(a: Vec2, b: Vec2) -> Vec2:\n"
+        "fn operator+=(a: Vec2, b: Vec2) -> Vec2:\n"
         "    return Vec2(a.x + b.x, a.y + b.y)\n"
         "v = Vec2(1, 2)\n"
         "v += Vec2(3, 4)\n"
@@ -942,7 +942,7 @@ TEST_F(CodeGenTest, CompoundAssignFallbackToOperatorPlus) {
         "record Vec2:\n"
         "    x: int\n"
         "    y: int\n"
-        "function operator+(a: Vec2, b: Vec2) -> Vec2:\n"
+        "fn operator+(a: Vec2, b: Vec2) -> Vec2:\n"
         "    return Vec2(a.x + b.x, a.y + b.y)\n"
         "v = Vec2(1, 2)\n"
         "v += Vec2(3, 4)\n"
@@ -967,9 +967,9 @@ TEST_F(CodeGenTest, CompoundAssignPriorityOverPlus) {
     std::string src =
         "record Counter:\n"
         "    val: int\n"
-        "function operator+(a: Counter, b: Counter) -> Counter:\n"
+        "fn operator+(a: Counter, b: Counter) -> Counter:\n"
         "    return Counter(a.val + b.val + 100)\n"
-        "function operator+=(a: Counter, b: Counter) -> Counter:\n"
+        "fn operator+=(a: Counter, b: Counter) -> Counter:\n"
         "    return Counter(a.val + b.val)\n"
         "c = Counter(1)\n"
         "c += Counter(2)\n"
@@ -1218,8 +1218,8 @@ TEST_F(CodeGenTest, InRejectsPointerElements) {
         err);
 
     expectCompileError(
-        "xs: List<function(int) -> int> = [(x: int) => x + 1]\n"
-        "f: function(int) -> int = (x: int) => x + 1\n"
+        "xs: List<fn(int) -> int> = [(x: int) => x + 1]\n"
+        "f: fn(int) -> int = (x: int) => x + 1\n"
         "print(f in xs)\n",
         err);
 
@@ -2123,7 +2123,7 @@ TEST_F(CodeGenTest, RemoveRejectsPointerElements) {
         err);
 
     expectCompileError(
-        "xs: List<function(int) -> int> = [(x: int) => x + 1]\n"
+        "xs: List<fn(int) -> int> = [(x: int) => x + 1]\n"
         "remove(xs, (x: int) => x + 1)\n",
         err);
 
@@ -2173,7 +2173,7 @@ TEST_F(CodeGenTest, DistinctRejectsPointerElements) {
         err);
 
     expectCompileError(
-        "xs: List<function(int) -> int> = [(x: int) => x + 1]\n"
+        "xs: List<fn(int) -> int> = [(x: int) => x + 1]\n"
         "ys = distinct(xs)\n",
         err);
 
@@ -2381,7 +2381,7 @@ TEST_F(CodeGenTest, OperatorSubscriptReadSingleIndex) {
         "    x: int\n"
         "    y: int\n"
         "    z: int\n"
-        "function operator[](p: Point, i: int) -> int:\n"
+        "fn operator[](p: Point, i: int) -> int:\n"
         "    if i == 0:\n"
         "        return p.x\n"
         "    if i == 1:\n"
@@ -2400,7 +2400,7 @@ TEST_F(CodeGenTest, OperatorSubscriptReadMultiIndex) {
         "    b: int\n"
         "    c: int\n"
         "    d: int\n"
-        "function operator[](g: Grid, row: int, col: int) -> int:\n"
+        "fn operator[](g: Grid, row: int, col: int) -> int:\n"
         "    if row == 0 and col == 0:\n"
         "        return g.a\n"
         "    if row == 0 and col == 1:\n"
@@ -2419,7 +2419,7 @@ TEST_F(CodeGenTest, OperatorSubscriptWrite) {
     std::string src =
         "record Counter:\n"
         "    count: int\n"
-        "function operator[]=(c: Counter, key: int, value: int):\n"
+        "fn operator[]=(c: Counter, key: int, value: int):\n"
         "    print(key)\n"
         "    print(value)\n"
         "c = Counter(0)\n"
@@ -2432,7 +2432,7 @@ TEST_F(CodeGenTest, OperatorIn) {
         "record Range:\n"
         "    start: int\n"
         "    end_val: int\n"
-        "function operator in(value: int, r: Range) -> bool:\n"
+        "fn operator in(value: int, r: Range) -> bool:\n"
         "    return value >= r.start and value < r.end_val\n"
         "r = Range(1, 10)\n"
         "print(5 in r)\n"
@@ -2453,25 +2453,25 @@ TEST_F(CodeGenTest, OperatorSubscriptParamValidation) {
     EXPECT_THROW(runSource(
         "record Foo:\n"
         "    x: int\n"
-        "function operator[](f: Foo) -> int:\n"
+        "fn operator[](f: Foo) -> int:\n"
         "    return f.x\n"), std::runtime_error);
     // operator[]= with < 3 params should fail
     EXPECT_THROW(runSource(
         "record Foo:\n"
         "    x: int\n"
-        "function operator[]=(f: Foo, v: int):\n"
+        "fn operator[]=(f: Foo, v: int):\n"
         "    f.x = v\n"), std::runtime_error);
     // operator in with != 2 params should fail
     EXPECT_THROW(runSource(
         "record Foo:\n"
         "    x: int\n"
-        "function operator in(a: int) -> bool:\n"
+        "fn operator in(a: int) -> bool:\n"
         "    return true\n"), std::runtime_error);
     // operator in must return bool
     EXPECT_THROW(runSource(
         "record Foo:\n"
         "    x: int\n"
-        "function operator in(a: int, f: Foo) -> int:\n"
+        "fn operator in(a: int, f: Foo) -> int:\n"
         "    return 1\n"), std::runtime_error);
 }
 
@@ -2490,7 +2490,7 @@ TEST_F(CodeGenTest, OperatorCallSingleArg) {
     std::string src =
         "record Adder:\n"
         "    base: int\n"
-        "function operator()(a: Adder, x: int) -> int:\n"
+        "fn operator()(a: Adder, x: int) -> int:\n"
         "    return a.base + x\n"
         "add5 = Adder(5)\n"
         "print(add5(10))";
@@ -2501,7 +2501,7 @@ TEST_F(CodeGenTest, OperatorCallMultiArg) {
     std::string src =
         "record Multiplier:\n"
         "    factor: int\n"
-        "function operator()(m: Multiplier, x: int, y: int) -> int:\n"
+        "fn operator()(m: Multiplier, x: int, y: int) -> int:\n"
         "    return m.factor * (x + y)\n"
         "mul = Multiplier(3)\n"
         "print(mul(4, 5))";
@@ -2512,7 +2512,7 @@ TEST_F(CodeGenTest, OperatorCallVoid) {
     std::string src =
         "record Printer:\n"
         "    prefix: str\n"
-        "function operator()(p: Printer, msg: str):\n"
+        "fn operator()(p: Printer, msg: str):\n"
         "    print(p.prefix + msg)\n"
         "p = Printer(\">> \")\n"
         "p(\"hello\")";
@@ -2525,7 +2525,7 @@ TEST_F(CodeGenTest, OperatorAs) {
         "    value: int\n"
         "record Fahrenheit:\n"
         "    value: int\n"
-        "function operator as(c: Celsius) -> Fahrenheit:\n"
+        "fn operator as(c: Celsius) -> Fahrenheit:\n"
         "    return Fahrenheit(c.value * 9 // 5 + 32)\n"
         "c = Celsius(100)\n"
         "f = c as Fahrenheit\n"
@@ -2541,7 +2541,7 @@ TEST_F(CodeGenTest, OperatorCallParamValidation) {
     EXPECT_THROW(runSource(
         "record Foo:\n"
         "    x: int\n"
-        "function operator()(f: Foo) -> int:\n"
+        "fn operator()(f: Foo) -> int:\n"
         "    return f.x\n"), std::runtime_error);
 }
 
@@ -2549,7 +2549,7 @@ TEST_F(CodeGenTest, OperatorAsParamValidation) {
     EXPECT_THROW(runSource(
         "record Foo:\n"
         "    x: int\n"
-        "function operator as(a: int, b: int) -> int:\n"
+        "fn operator as(a: int, b: int) -> int:\n"
         "    return a\n"), std::runtime_error);
 }
 
@@ -2557,7 +2557,7 @@ TEST_F(CodeGenTest, OperatorAsGenericOptionTarget) {
     std::string src =
         "record Celsius:\n"
         "    value: int\n"
-        "function operator as(c: Celsius) -> int?:\n"
+        "fn operator as(c: Celsius) -> int?:\n"
         "    return Some(c.value)\n"
         "c = Celsius(42)\n"
         "result: int? = c as int?\n"
@@ -2702,8 +2702,8 @@ TEST_F(CodeGenTest, DiscardedCollectionResults) {
 // Regression for the list_elem_fn_type_info guard added in #736.
 TEST_F(CodeGenTest, ListFnElemEqualityRejected) {
     expectCompileError(
-        "a: List<function(int) -> int> = []\n"
-        "b: List<function(int) -> int> = []\n"
+        "a: List<fn(int) -> int> = []\n"
+        "b: List<fn(int) -> int> = []\n"
         "_ = a == b\n",
         "function-typed elements");
 }
@@ -2713,18 +2713,18 @@ TEST_F(CodeGenTest, ListFnElemEqualityRejected) {
 // (Set<record> equality was lifted in #958.)
 TEST_F(CodeGenTest, SetFnElemEqualityRejected) {
     expectCompileError(
-        "a: Set<function(int) -> int> = {}\n"
-        "b: Set<function(int) -> int> = {}\n"
+        "a: Set<fn(int) -> int> = {}\n"
+        "b: Set<fn(int) -> int> = {}\n"
         "_ = a == b\n",
         "function-typed");
 }
 
 // Map with a function-typed key via type alias must be rejected at == / != (#961).
-// Direct Map<function(...)...> annotations are rejected by annotation parsing;
+// Direct Map<fn(...)...> annotations are rejected by annotation parsing;
 // the alias path exercises the map_key_fn_type_info guard in codegen_expr.cpp.
 TEST_F(CodeGenTest, MapFnKeyEqualityRejected) {
     expectCompileError(
-        "type FnKey = function(int) -> int\n"
+        "type FnKey = fn(int) -> int\n"
         "a: Map<FnKey, int> = {}\n"
         "b: Map<FnKey, int> = {}\n"
         "_ = a == b\n",
@@ -2736,10 +2736,10 @@ TEST_F(CodeGenTest, MapFnKeyEqualityRejected) {
 TEST_F(CodeGenTest, AdtEnumFnPayloadEqualityRejected) {
     expectCompileError(
         "enum Bad:\n"
-        "    F(function(int) -> int)\n"
-        "function make_id() -> function(int) -> int:\n"
+        "    F(fn(int) -> int)\n"
+        "fn make_id() -> fn(int) -> int:\n"
         "    return (x: int) => x\n"
-        "function make_inc() -> function(int) -> int:\n"
+        "fn make_inc() -> fn(int) -> int:\n"
         "    return (x: int) => x + 1\n"
         "f1 = Bad::F(make_id())\n"
         "f2 = Bad::F(make_inc())\n"
@@ -2751,10 +2751,10 @@ TEST_F(CodeGenTest, AdtEnumFnPayloadEqualityRejected) {
 // Regression for the isFunctionTypeName guard added in #960.
 TEST_F(CodeGenTest, UnionFnVariantEqualityRejected) {
     expectCompileError(
-        "function make_fn() -> function(int) -> int:\n"
+        "fn make_fn() -> fn(int) -> int:\n"
         "    return (x: int) => x\n"
-        "x: function(int) -> int | int = make_fn()\n"
-        "y: function(int) -> int | int = make_fn()\n"
+        "x: fn(int) -> int | int = make_fn()\n"
+        "y: fn(int) -> int | int = make_fn()\n"
         "_ = x == y\n",
         "function-typed variant");
 }

--- a/tests/test_codegen_contract.cpp
+++ b/tests/test_codegen_contract.cpp
@@ -6,7 +6,7 @@ using namespace ry;
 
 TEST_F(CodeGenTest, RequireSatisfied) {
     std::string src =
-        "function deposit(amount: int) -> int:\n"
+        "fn deposit(amount: int) -> int:\n"
         "    require:\n"
         "        amount > 0\n"
         "    return amount\n"
@@ -16,7 +16,7 @@ TEST_F(CodeGenTest, RequireSatisfied) {
 
 TEST_F(CodeGenTest, RequireViolation) {
     std::string src =
-        "function deposit(amount: int) -> int:\n"
+        "fn deposit(amount: int) -> int:\n"
         "    require:\n"
         "        amount > 0\n"
         "    return amount\n"
@@ -26,7 +26,7 @@ TEST_F(CodeGenTest, RequireViolation) {
 
 TEST_F(CodeGenTest, RequireMultipleConditions) {
     std::string src =
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    require:\n"
         "        a >= 0\n"
         "        b >= 0\n"
@@ -37,7 +37,7 @@ TEST_F(CodeGenTest, RequireMultipleConditions) {
 
 TEST_F(CodeGenTest, RequireMultipleConditionsSecondFails) {
     std::string src =
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    require:\n"
         "        a >= 0\n"
         "        b >= 0\n"
@@ -50,7 +50,7 @@ TEST_F(CodeGenTest, RequireMultipleConditionsSecondFails) {
 
 TEST_F(CodeGenTest, EnsureSatisfied) {
     std::string src =
-        "function abs(x: int) -> int:\n"
+        "fn abs(x: int) -> int:\n"
         "    ensure v:\n"
         "        v >= 0\n"
         "    if x < 0:\n"
@@ -62,7 +62,7 @@ TEST_F(CodeGenTest, EnsureSatisfied) {
 
 TEST_F(CodeGenTest, EnsureViolation) {
     std::string src =
-        "function bad() -> int:\n"
+        "fn bad() -> int:\n"
         "    ensure v:\n"
         "        v > 0\n"
         "    return -1\n"
@@ -72,7 +72,7 @@ TEST_F(CodeGenTest, EnsureViolation) {
 
 TEST_F(CodeGenTest, EnsureWithArgReference) {
     std::string src =
-        "function inc(x: int) -> int:\n"
+        "fn inc(x: int) -> int:\n"
         "    ensure v:\n"
         "        v == x + 1\n"
         "    return x + 1\n"
@@ -82,7 +82,7 @@ TEST_F(CodeGenTest, EnsureWithArgReference) {
 
 TEST_F(CodeGenTest, EnsureWithArgReferenceViolation) {
     std::string src =
-        "function inc(x: int) -> int:\n"
+        "fn inc(x: int) -> int:\n"
         "    ensure v:\n"
         "        v == x + 1\n"
         "    return x + 2\n"
@@ -92,7 +92,7 @@ TEST_F(CodeGenTest, EnsureWithArgReferenceViolation) {
 
 TEST_F(CodeGenTest, RequireAndEnsureCombined) {
     std::string src =
-        "function deposit(amount: int, balance: int) -> int:\n"
+        "fn deposit(amount: int, balance: int) -> int:\n"
         "    require:\n"
         "        amount > 0\n"
         "        balance >= 0\n"
@@ -233,10 +233,10 @@ TEST_F(CodeGenTest, DeepInheritedInvariantViolated) {
 
 TEST_F(CodeGenTest, NestedFnWithEnsurePreservesOuterContract) {
     std::string src =
-        "function outer(x: int) -> int:\n"
+        "fn outer(x: int) -> int:\n"
         "    ensure v:\n"
         "        v >= 0\n"
-        "    function inner(y: int) -> int:\n"
+        "    fn inner(y: int) -> int:\n"
         "        ensure w:\n"
         "            w > 0\n"
         "        return y + 1\n"
@@ -247,10 +247,10 @@ TEST_F(CodeGenTest, NestedFnWithEnsurePreservesOuterContract) {
 
 TEST_F(CodeGenTest, NestedFnWithEnsureViolation) {
     std::string src =
-        "function outer(x: int) -> int:\n"
+        "fn outer(x: int) -> int:\n"
         "    ensure v:\n"
         "        v >= 0\n"
-        "    function inner(y: int) -> int:\n"
+        "    fn inner(y: int) -> int:\n"
         "        ensure w:\n"
         "            w > 0\n"
         "        return y + 1\n"
@@ -263,7 +263,7 @@ TEST_F(CodeGenTest, NestedFnWithEnsureViolation) {
 
 TEST_F(CodeGenTest, EnsureTupleDestructuring) {
     std::string src =
-        "function divide(a: int, b: int) -> (int, int):\n"
+        "fn divide(a: int, b: int) -> (int, int):\n"
         "    ensure q, r:\n"
         "        q >= 0\n"
         "        r >= 0\n"
@@ -278,7 +278,7 @@ TEST_F(CodeGenTest, EnsureTupleDestructuring) {
 
 TEST_F(CodeGenTest, EnsureOnUnitFunctionRejected) {
     std::string src =
-        "function greet() -> Unit:\n"
+        "fn greet() -> Unit:\n"
         "    ensure v:\n"
         "        v > 0\n"
         "    print(\"hello\")";

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -60,9 +60,9 @@ TEST(NativeFnSigs, RegistryPopulatedAndKeyed) {
     // Compile source with @native declarations and verify the registry
     std::string src =
         "@native\n"
-        "function print(value: str) -> Unit\n"
+        "fn print(value: str) -> Unit\n"
         "@native\n"
-        "function contains(s: str, sub: str) -> bool\n";
+        "fn contains(s: str, sub: str) -> bool\n";
 
     Lexer lex(src);
     Parser parser(lex);
@@ -93,9 +93,9 @@ TEST(NativeFnSigs, RegistryPopulatedAndKeyed) {
 TEST(NativeFnSigs, OverloadsGrouped) {
     std::string src =
         "@native\n"
-        "function range(n: int) -> List<int>\n"
+        "fn range(n: int) -> List<int>\n"
         "@native\n"
-        "function range(start: int, end_val: int) -> List<int>\n";
+        "fn range(start: int, end_val: int) -> List<int>\n";
 
     Lexer lex(src);
     Parser parser(lex);
@@ -115,7 +115,7 @@ TEST(NativeFnSigs, DirectivesRecorded) {
     std::string src =
         "@native\n"
         "@deprecated\n"
-        "function old_fn(x: int) -> int\n";
+        "fn old_fn(x: int) -> int\n";
 
     Lexer lex(src);
     Parser parser(lex);
@@ -137,7 +137,7 @@ TEST(NativeFnSigs, LibraryFieldParsed) {
     // @native("base64") parses correctly at AST level
     std::string src =
         "@native(\"base64\")\n"
-        "function encode(data: str) -> str\n";
+        "fn encode(data: str) -> str\n";
 
     Lexer lex(src);
     Parser parser(lex);
@@ -164,7 +164,7 @@ TEST(NativeFnSigs, LibraryFieldStoredAtCodegen) {
     // file is not under std/<pkg>/ (i.e., deriveNativePackage returns "").
     std::string src =
         "@native(\"base64\")\n"
-        "function encode(data: str) -> str\n";
+        "fn encode(data: str) -> str\n";
 
     Lexer lex(src);
     Parser parser(lex);
@@ -182,7 +182,7 @@ TEST(NativeFnSigs, LibraryFieldStoredAtCodegen) {
 TEST(NativeFnSigs, LibraryFieldEmptyForBareNative) {
     std::string src =
         "@native\n"
-        "function contains(s: str, sub: str) -> bool\n";
+        "fn contains(s: str, sub: str) -> bool\n";
 
     Lexer lex(src);
     Parser parser(lex);
@@ -201,9 +201,9 @@ TEST(NativeFnSigs, GetRequiredLibrariesOnlyIncludesCalledFunctions) {
     // the base64 function. getRequiredLibraries() should return only "base64".
     std::string src =
         "@native(\"base64\")\n"
-        "function encode(data: str) -> str\n"
+        "fn encode(data: str) -> str\n"
         "@native(\"path\")\n"
-        "function basename(p: str) -> str\n"
+        "fn basename(p: str) -> str\n"
         "print(encode(\"Hello\"))\n";
 
     Lexer lex(src);
@@ -223,7 +223,7 @@ TEST(NativeFnSigs, GetRequiredLibrariesEmptyWhenNothingCalled) {
     // getRequiredLibraries() should return empty (demand-driven loading).
     std::string src =
         "@native(\"base64\")\n"
-        "function encode(data: str) -> str\n"
+        "fn encode(data: str) -> str\n"
         "print(\"no native calls\")\n";
 
     Lexer lex(src);
@@ -240,7 +240,7 @@ TEST(NativeFnSigs, GetRequiredLibrariesEmptyWhenNothingCalled) {
 TEST(NativeFnSigs, GetRequiredLibrariesEmptyForBareNative) {
     std::string src =
         "@native\n"
-        "function contains(s: str, sub: str) -> bool\n";
+        "fn contains(s: str, sub: str) -> bool\n";
 
     Lexer lex(src);
     Parser parser(lex);
@@ -257,7 +257,7 @@ TEST(NativeFnSigs, GetRequiredLibrariesEmptyForBareNative) {
 TEST_F(DirectiveTest, DeprecatedFunctionWarning) {
     auto [output, warnings] = runSourceWithWarnings(
         "@deprecated\n"
-        "function old_func() -> int:\n"
+        "fn old_func() -> int:\n"
         "    return 42\n"
         "print(old_func())\n"
     );
@@ -313,7 +313,7 @@ TEST_F(DirectiveTest, DeprecatedFieldWarning) {
 TEST_F(DirectiveTest, DeprecatedNoWarningOnDefinition) {
     auto [output, warnings] = runSourceWithWarnings(
         "@deprecated\n"
-        "function unused_func() -> int:\n"
+        "fn unused_func() -> int:\n"
         "    return 1\n"
         "@deprecated\n"
         "unused_val = 42\n"
@@ -326,7 +326,7 @@ TEST_F(DirectiveTest, DeprecatedNoWarningOnDefinition) {
 // 6. Non-deprecated entities produce no warnings
 TEST_F(DirectiveTest, NonDeprecatedNoWarning) {
     auto [output, warnings] = runSourceWithWarnings(
-        "function good_func() -> int:\n"
+        "fn good_func() -> int:\n"
         "    return 10\n"
         "good_val = 20\n"
         "print(good_func())\n"
@@ -340,7 +340,7 @@ TEST_F(DirectiveTest, NonDeprecatedNoWarning) {
 TEST_F(DirectiveTest, DeprecatedFunctionStillWorks) {
     auto [output, warnings] = runSourceWithWarnings(
         "@deprecated\n"
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "print(add(3, 4))\n"
     );
@@ -353,7 +353,7 @@ TEST_F(DirectiveTest, MultipleDirectives) {
     auto [output, warnings] = runSourceWithWarnings(
         "@deprecated\n"
         "@deprecated\n"
-        "function multi() -> int:\n"
+        "fn multi() -> int:\n"
         "    return 1\n"
         "print(multi())\n"
     );
@@ -365,7 +365,7 @@ TEST_F(DirectiveTest, MultipleDirectives) {
 TEST_F(DirectiveTest, DirectiveWithParams) {
     auto [output, warnings] = runSourceWithWarnings(
         "@deprecated(reason=\"use new_func instead\")\n"
-        "function old_api() -> int:\n"
+        "fn old_api() -> int:\n"
         "    return 0\n"
         "print(old_api())\n"
     );
@@ -384,41 +384,41 @@ TEST_F(DirectiveTest, UnknownDirectiveError) {
 // 10b. Positional string argument on non-@native directive causes parse error
 TEST_F(DirectiveTest, PositionalArgOnNonNativeError) {
     EXPECT_THROW({
-        runSource("@inline(\"always\")\nfunction add(a: int, b: int) -> int:\n    return a + b\n");
+        runSource("@inline(\"always\")\nfn add(a: int, b: int) -> int:\n    return a + b\n");
     }, std::runtime_error);
     EXPECT_THROW({
-        runSource("@deprecated(\"old\")\nfunction foo() -> int:\n    return 1\n");
+        runSource("@deprecated(\"old\")\nfn foo() -> int:\n    return 1\n");
     }, std::runtime_error);
 }
 
 // 10c. @native("") with empty string causes parse error
 TEST_F(DirectiveTest, NativeEmptyLibraryNameError) {
     EXPECT_THROW({
-        runSource("@native(\"\")\nfunction foo(x: int) -> int\n");
+        runSource("@native(\"\")\nfn foo(x: int) -> int\n");
     }, std::runtime_error);
 }
 
 // 10d. @native("a", "b") or @native("a", key=val) — extra arguments rejected
 TEST_F(DirectiveTest, NativeLibraryExtraArgsError) {
     EXPECT_THROW({
-        runSource("@native(\"a\", \"b\")\nfunction foo(x: int) -> int\n");
+        runSource("@native(\"a\", \"b\")\nfn foo(x: int) -> int\n");
     }, std::runtime_error);
     EXPECT_THROW({
-        runSource("@native(\"a\", key=val)\nfunction foo(x: int) -> int\n");
+        runSource("@native(\"a\", key=val)\nfn foo(x: int) -> int\n");
     }, std::runtime_error);
 }
 
 // 10e-1. @native(123) — non-string positional argument causes validation error
 TEST_F(DirectiveTest, NativeNonStringArgError) {
     EXPECT_THROW({
-        runSource("@native(123)\nfunction foo(x: int) -> int\n");
+        runSource("@native(123)\nfn foo(x: int) -> int\n");
     }, std::runtime_error);
 }
 
 // 10e. @native(key=value) — key-value params not allowed for @native
 TEST_F(DirectiveTest, NativeKeyValueParamsError) {
     EXPECT_THROW({
-        runSource("@native(lib=base64)\nfunction foo(x: int) -> int\n");
+        runSource("@native(lib=base64)\nfn foo(x: int) -> int\n");
     }, std::runtime_error);
 }
 
@@ -478,64 +478,64 @@ TEST_F(DirectiveTest, DirectiveOnInvalidTarget) {
     }, std::runtime_error);
 }
 
-// ===== @native function tests =====
+// ===== @native fn tests =====
 
-// 12. @native function declaration - builtin function still works
+// 12. @native fn declaration - builtin function still works
 TEST_F(DirectiveTest, NativeFnDeclaration) {
     std::string output = runSource(
         "@native\n"
-        "function contains(s: str, sub: str) -> bool\n"
+        "fn contains(s: str, sub: str) -> bool\n"
         "print(contains(\"hello world\", \"world\"))\n"
     );
     EXPECT_EQ(output, "true\n");
 }
 
-// 13. @native function operator declaration - builtin operator still works
+// 13. @native fn operator declaration - builtin operator still works
 TEST_F(DirectiveTest, NativeFnOperatorDeclaration) {
     std::string output = runSource(
         "@native\n"
-        "function operator+(a: str, b: str) -> str\n"
+        "fn operator+(a: str, b: str) -> str\n"
         "print(\"hello\" + \" world\")\n"
     );
     EXPECT_EQ(output, "hello world\n");
 }
 
-// 14. @native function with body causes error
+// 14. @native fn with body causes error
 TEST_F(DirectiveTest, NativeFnWithBodyError) {
     EXPECT_THROW({
         runSource("@native\nfn bad() -> int:\n    return 1\n");
     }, std::runtime_error);
 }
 
-// 15. @native function with UFCS-style builtin
+// 15. @native fn with UFCS-style builtin
 TEST_F(DirectiveTest, NativeFnUfcsBuiltin) {
     std::string output = runSource(
         "@native\n"
-        "function to_upper(s: str) -> str\n"
+        "fn to_upper(s: str) -> str\n"
         "print(to_upper(\"hello\"))\n"
     );
     EXPECT_EQ(output, "HELLO\n");
 }
 
-// 16. Multiple @native function declarations coexist
+// 16. Multiple @native fn declarations coexist
 TEST_F(DirectiveTest, MultipleNativeFnDeclarations) {
     std::string output = runSource(
         "@native\n"
-        "function contains(s: str, sub: str) -> bool\n"
+        "fn contains(s: str, sub: str) -> bool\n"
         "@native\n"
-        "function to_upper(s: str) -> str\n"
+        "fn to_upper(s: str) -> str\n"
         "print(contains(\"hello\", \"ell\"))\n"
         "print(to_upper(\"world\"))\n"
     );
     EXPECT_EQ(output, "true\nWORLD\n");
 }
 
-// ===== @native function type signature validation =====
+// ===== @native fn type signature validation =====
 
 TEST_F(DirectiveTest, NativeFnTypeCheckPass) {
     std::string output = runSource(
         "@native\n"
-        "function contains(s: str, sub: str) -> bool\n"
+        "fn contains(s: str, sub: str) -> bool\n"
         "print(contains(\"hello\", \"ell\"))\n"
     );
     EXPECT_EQ(output, "true\n");
@@ -544,7 +544,7 @@ TEST_F(DirectiveTest, NativeFnTypeCheckPass) {
 TEST_F(DirectiveTest, NativeFnTypeCheckFailArgCount) {
     EXPECT_THROW(runSource(
         "@native\n"
-        "function contains(s: str, sub: str) -> bool\n"
+        "fn contains(s: str, sub: str) -> bool\n"
         "print(contains(\"hello\"))\n"
     ), std::runtime_error);
 }
@@ -552,11 +552,11 @@ TEST_F(DirectiveTest, NativeFnTypeCheckFailArgCount) {
 TEST_F(DirectiveTest, NativeFnOverloadResolution) {
     std::string output = runSource(
         "@native\n"
-        "function range(n: int) -> List<int>\n"
+        "fn range(n: int) -> List<int>\n"
         "@native\n"
-        "function range(start: int, end_val: int) -> List<int>\n"
+        "fn range(start: int, end_val: int) -> List<int>\n"
         "@native\n"
-        "function range(start: int, end_val: int, step: int) -> List<int>\n"
+        "fn range(start: int, end_val: int, step: int) -> List<int>\n"
         "print(length(range(5)))\n"
         "print(length(range(1, 4)))\n"
         "print(length(range(0, 10, 2)))\n"
@@ -575,11 +575,11 @@ TEST_F(DirectiveTest, NativeFnWithoutSignatureStillWorks) {
 TEST_F(DirectiveTest, CoreStrDeclarationsWork) {
     std::string output = runSource(
         "@native\n"
-        "function to_upper(s: str) -> str\n"
+        "fn to_upper(s: str) -> str\n"
         "@native\n"
-        "function contains(s: str, sub: str) -> bool\n"
+        "fn contains(s: str, sub: str) -> bool\n"
         "@native\n"
-        "function starts_with(s: str, prefix: str) -> bool\n"
+        "fn starts_with(s: str, prefix: str) -> bool\n"
         "print(to_upper(\"hello\"))\n"
         "print(contains(\"hello world\", \"world\"))\n"
         "print(starts_with(\"hello\", \"hel\"))\n"
@@ -595,7 +595,7 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchForStdlibName) {
     // the sig key "base64::encode" matches. Verifies the function is callable.
     std::string output = runSource(
         "@native(\"base64\")\n"
-        "function encode(data: str) -> str\n"
+        "fn encode(data: str) -> str\n"
         "print(encode(\"test\"))\n"
     );
     EXPECT_EQ(output, "dGVzdA==\n");
@@ -606,7 +606,7 @@ TEST_F(DirectiveTest, NativeFnLibraryDeclarationOnly) {
     // Without calling the function, the declaration alone is valid.
     std::string output = runSource(
         "@native(\"base64\")\n"
-        "function encode(data: str) -> str\n"
+        "fn encode(data: str) -> str\n"
         "print(\"ok\")\n"
     );
     EXPECT_EQ(output, "ok\n");
@@ -617,7 +617,7 @@ TEST_F(DirectiveTest, NativeFnLibraryDoesNotShadowBuiltin) {
     // built-in functions with the same name.
     std::string output = runSource(
         "@native(\"base64\")\n"
-        "function contains(s: str, sub: str) -> bool\n"
+        "fn contains(s: str, sub: str) -> bool\n"
         "print(contains(\"hello\", \"ell\"))\n"
     );
     EXPECT_EQ(output, "true\n");
@@ -629,8 +629,8 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchFallsThrough) {
     // This uses "mylib" (not a stdlib name) so it goes through the generic path.
     std::string output = runSource(
         "@native(\"mylib\")\n"
-        "function greet(name: str) -> str\n"
-        "function greet(x: int) -> str:\n"
+        "fn greet(name: str) -> str\n"
+        "fn greet(x: int) -> str:\n"
         "    return \"int:\" + to_str(x)\n"
         "print(greet(42))\n"
     );
@@ -645,7 +645,7 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchEndToEnd) {
     // dispatcher. The call MUST go through emitGenericNativeCall.
     std::string output = runSource(
         "@native(\"testlib\")\n"
-        "function greet(name: str) -> str\n"
+        "fn greet(name: str) -> str\n"
         "print(greet(\"world\"))\n"
     );
     EXPECT_EQ(output, "hello world\n");
@@ -656,7 +656,7 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchDirect) {
     // "base64::encode" is found by the table-driven base64 dispatcher.
     std::string output = runSource(
         "@native(\"base64\")\n"
-        "function encode(data: str) -> str\n"
+        "fn encode(data: str) -> str\n"
         "print(encode(\"Hello\"))\n"
     );
     EXPECT_EQ(output, "SGVsbG8=\n");
@@ -666,7 +666,7 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchResultPtr) {
     // @native("base64") fn decode(data: str) -> Result<str, Error>
     // Tests ResultPtr wrapping in the generic dispatch path.
     std::string output = runSource(
-        "@native(\"base64\")\nfunction decode(data: str) -> Result<str, Error>\ncase decode(\"SGVsbG8=\"):\n    Ok(s):\n        print(s)\n    Err(e):\n        print(e.message)\n"
+        "@native(\"base64\")\nfn decode(data: str) -> Result<str, Error>\ncase decode(\"SGVsbG8=\"):\n    Ok(s):\n        print(s)\n    Err(e):\n        print(e.message)\n"
     );
     EXPECT_EQ(output, "Hello\n");
 }
@@ -675,7 +675,7 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchBool) {
     // Tests BoolFromI64 wrapping in the generic dispatch path.
     std::string output = runSource(
         "@native(\"path\")\n"
-        "function is_absolute(p: str) -> bool\n"
+        "fn is_absolute(p: str) -> bool\n"
         "print(is_absolute(\"/usr/bin\"))\n"
         "print(is_absolute(\"relative\"))\n"
     );
@@ -687,7 +687,7 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchResultBool) {
     // runtime symbol (__ry_testlib_check). Exercises the full ResultOutParam
     // ABI: i64 status, i64 out-param, and the final i64→i1 truncation.
     std::string output = runSource(
-        "@native(\"testlib\")\nfunction check(s: str) -> Result<bool, Error>\ncase check(\"yes\"):\n    Ok(b):\n        print(b)\n    Err(e):\n        print(e.message)\n"
+        "@native(\"testlib\")\nfn check(s: str) -> Result<bool, Error>\ncase check(\"yes\"):\n    Ok(b):\n        print(b)\n    Err(e):\n        print(e.message)\n"
     );
     EXPECT_EQ(output, "true\n");
 }
@@ -697,7 +697,7 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchResultBool) {
 TEST_F(DirectiveTest, InlineDefault) {
     std::string output = runSource(
         "@inline\n"
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "print(add(3, 4))\n"
     );
@@ -707,7 +707,7 @@ TEST_F(DirectiveTest, InlineDefault) {
 TEST_F(DirectiveTest, InlineModeAlways) {
     std::string output = runSource(
         "@inline(mode=\"always\")\n"
-        "function mul(a: int, b: int) -> int:\n"
+        "fn mul(a: int, b: int) -> int:\n"
         "    return a * b\n"
         "print(mul(5, 6))\n"
     );
@@ -717,7 +717,7 @@ TEST_F(DirectiveTest, InlineModeAlways) {
 TEST_F(DirectiveTest, InlineModeHint) {
     std::string output = runSource(
         "@inline(mode=\"hint\")\n"
-        "function sub(a: int, b: int) -> int:\n"
+        "fn sub(a: int, b: int) -> int:\n"
         "    return a - b\n"
         "print(sub(10, 3))\n"
     );
@@ -727,7 +727,7 @@ TEST_F(DirectiveTest, InlineModeHint) {
 TEST_F(DirectiveTest, InlineModeNever) {
     std::string output = runSource(
         "@inline(mode=\"never\")\n"
-        "function negate(a: int) -> int:\n"
+        "fn negate(a: int) -> int:\n"
         "    return -a\n"
         "print(negate(-5))\n"
     );
@@ -737,7 +737,7 @@ TEST_F(DirectiveTest, InlineModeNever) {
 TEST_F(DirectiveTest, InlineInvalidMode) {
     EXPECT_THROW(runSource(
         "@inline(mode=\"aggressive\")\n"
-        "function bad() -> int:\n"
+        "fn bad() -> int:\n"
         "    return 1\n"
         "print(bad())\n"
     ), std::runtime_error);
@@ -747,7 +747,7 @@ TEST_F(DirectiveTest, InlineWithNativeError) {
     EXPECT_THROW(runSource(
         "@inline\n"
         "@native\n"
-        "function contains(s: str, sub: str) -> bool\n"
+        "fn contains(s: str, sub: str) -> bool\n"
         "print(contains(\"hello\", \"ell\"))\n"
     ), std::runtime_error);
 }
@@ -756,7 +756,7 @@ TEST_F(DirectiveTest, InlineWithDeprecated) {
     auto [output, warnings] = runSourceWithWarnings(
         "@inline\n"
         "@deprecated\n"
-        "function old_add(a: int, b: int) -> int:\n"
+        "fn old_add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "print(old_add(1, 2))\n"
     );
@@ -768,7 +768,7 @@ TEST_F(DirectiveTest, InlineWithDeprecated) {
 TEST_F(DirectiveTest, InlineRecursive) {
     std::string output = runSource(
         "@inline\n"
-        "function fact(n: int) -> int:\n"
+        "fn fact(n: int) -> int:\n"
         "    if n <= 1:\n"
         "        return 1\n"
         "    return n * fact(n - 1)\n"
@@ -783,7 +783,7 @@ TEST_F(DirectiveTest, InlineRecursive) {
 TEST(DirectiveSyntax, ItDirectiveParsedOnFunction) {
     std::string src =
         "@it(\"should add integers\")\n"
-        "function test_add():\n"
+        "fn test_add():\n"
         "    expect(1 + 2).to_eq(3)\n";
     Lexer lex(src);
     Parser parser(lex);
@@ -806,7 +806,7 @@ TEST(DirectiveSyntax, ItDirectiveParsedOnFunction) {
 TEST(DirectiveSyntax, DescribeDirectiveParsedOnFunction) {
     std::string src =
         "@describe(\"calculator\")\n"
-        "function calculator_tests():\n"
+        "fn calculator_tests():\n"
         "    expect(1 + 1).to_eq(2)\n";
     Lexer lex(src);
     Parser parser(lex);
@@ -831,7 +831,7 @@ TEST(DirectiveSyntax, MixedPositionalAndNamedArgs) {
     std::string src =
         "@property(count=50)\n"
         "@it(\"should commute\")\n"
-        "function test_commute(a: int, b: int):\n"
+        "fn test_commute(a: int, b: int):\n"
         "    expect(a + b).to_eq(b + a)\n";
     Lexer lex(src);
     Parser parser(lex);
@@ -868,7 +868,7 @@ TEST(DirectiveSyntax, MixedPositionalAndNamedArgsInOneDirective) {
     // Use a hypothetical directive name — parser accepts any name; validation is deferred.
     std::string src =
         "@custom_directive(\"label\", count=50)\n"
-        "function foo():\n"
+        "fn foo():\n"
         "    expect(1).to_eq(1)\n";
     Lexer lex(src);
     Parser parser(lex);
@@ -903,7 +903,7 @@ TEST(DirectiveSyntax, MixedPositionalAndNamedArgsInOneDirective) {
 TEST_F(DirectiveTest, ItDirectiveBasicCodegen) {
     EXPECT_EQ(runTestSource(
         "@it(\"should add 1 + 2 = 3\")\n"
-        "function test_add():\n"
+        "fn test_add():\n"
         "    expect(1 + 2).to_eq(3)\n"
     ), "\033[32m+ should add 1 + 2 = 3\033[0m\n\n1 passed, 0 failed\n");
 }
@@ -913,7 +913,7 @@ TEST_F(DirectiveTest, ItDirectiveRequiresTestMode) {
     EXPECT_THROW(
         compileSource(
             "@it(\"should fail\")\n"
-            "function test_x():\n"
+            "fn test_x():\n"
             "    expect(1).to_eq(1)\n"
         ),
         std::runtime_error
@@ -926,7 +926,7 @@ TEST_F(DirectiveTest, ItDirectiveRejectsParamsWithoutEachOrProperty) {
         []() {
             Lexer lex(
                 "@it(\"bad\")\n"
-                "function test_bad(x: int):\n"
+                "fn test_bad(x: int):\n"
                 "    expect(x).to_eq(1)\n"
             );
             Parser parser(lex);
@@ -942,13 +942,13 @@ TEST_F(DirectiveTest, ItDirectiveRejectsParamsWithoutEachOrProperty) {
 TEST_F(DirectiveTest, DescribeDirectiveBasicCodegen) {
     EXPECT_EQ(runTestSource(
         "@describe(\"math\")\n"
-        "function math_tests():\n"
+        "fn math_tests():\n"
         "    @it(\"should subtract\")\n"
-        "    function test_sub():\n"
+        "    fn test_sub():\n"
         "        expect(10 - 3).to_eq(7)\n"
         "\n"
         "    @it(\"should multiply\")\n"
-        "    function test_mul():\n"
+        "    fn test_mul():\n"
         "        expect(4 * 5).to_eq(20)\n"
     ), "math\n  \033[32m+ should subtract\033[0m\n  \033[32m+ should multiply\033[0m\n\n2 passed, 0 failed\n");
 }
@@ -958,7 +958,7 @@ TEST_F(DirectiveTest, ItDirectiveWithEach) {
     EXPECT_EQ(runTestSource(
         "@each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])\n"
         "@it(\"should add {0} + {1} = {2}\")\n"
-        "function test_add(a: int, b: int, expected: int):\n"
+        "fn test_add(a: int, b: int, expected: int):\n"
         "    expect(a + b).to_eq(expected)\n"
     ), "\033[32m+ should add 1 + 2 = 3\033[0m\n"
        "\033[32m+ should add 0 + 0 = 0\033[0m\n"
@@ -971,20 +971,20 @@ TEST_F(DirectiveTest, ItDirectiveWithProperty) {
     std::string out = runTestSource(
         "@property(count=10)\n"
         "@it(\"should verify addition is commutative\")\n"
-        "function test_commutative(a: int, b: int):\n"
+        "fn test_commutative(a: int, b: int):\n"
         "    expect(a + b).to_eq(b + a)\n"
     );
     EXPECT_NE(out.find("+ should verify addition is commutative"), std::string::npos);
     EXPECT_NE(out.find("1 passed, 0 failed"), std::string::npos);
 }
 
-// @it on an async function should error
+// @it on an async fn should error
 TEST_F(DirectiveTest, ItDirectiveRejectsAsyncFunction) {
     EXPECT_THROW(
         []() {
             Lexer lex(
                 "@it(\"bad\")\n"
-                "async function test_async():\n"
+                "async fn test_async():\n"
                 "    expect(1).to_eq(1)\n"
             );
             Parser parser(lex);
@@ -1002,9 +1002,9 @@ TEST_F(DirectiveTest, DescribeDirectiveRejectsParams) {
         []() {
             Lexer lex(
                 "@describe(\"group\")\n"
-                "function grp(x: int):\n"
+                "fn grp(x: int):\n"
                 "    @it(\"sub\")\n"
-                "    function t():\n"
+                "    fn t():\n"
                 "        expect(x).to_eq(1)\n"
             );
             Parser parser(lex);
@@ -1024,7 +1024,7 @@ TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeAnnotation) {
         []() {
             Lexer lex(
                 "@it(\"bad\")\n"
-                "function test_with_ret() -> Unit:\n"
+                "fn test_with_ret() -> Unit:\n"
                 "    expect(1).to_eq(1)\n"
             );
             Parser parser(lex);
@@ -1043,7 +1043,7 @@ TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnEach) {
             Lexer lex(
                 "@each([(1, 2)])\n"
                 "@it(\"bad each {0} {1}\")\n"
-                "function test_each(a: int, b: int) -> Unit:\n"
+                "fn test_each(a: int, b: int) -> Unit:\n"
                 "    expect(a).to_eq(b)\n"
             );
             Parser parser(lex);
@@ -1062,7 +1062,7 @@ TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnProperty) {
             Lexer lex(
                 "@property(count=10)\n"
                 "@it(\"bad property\")\n"
-                "function test_prop(a: int) -> Unit:\n"
+                "fn test_prop(a: int) -> Unit:\n"
                 "    expect(a).to_eq(a)\n"
             );
             Parser parser(lex);
@@ -1080,9 +1080,9 @@ TEST_F(DirectiveTest, DescribeDirectiveRejectsReturnTypeAnnotation) {
         []() {
             Lexer lex(
                 "@describe(\"group\")\n"
-                "function grp() -> Unit:\n"
+                "fn grp() -> Unit:\n"
                 "    @it(\"sub\")\n"
-                "    function t():\n"
+                "    fn t():\n"
                 "        expect(1).to_eq(1)\n"
             );
             Parser parser(lex);
@@ -1098,15 +1098,15 @@ TEST_F(DirectiveTest, DescribeDirectiveRejectsReturnTypeAnnotation) {
 TEST_F(DirectiveTest, DescribeDirectiveNestedDescribe) {
     EXPECT_EQ(runTestSource(
         "@describe(\"outer\")\n"
-        "function outer_tests():\n"
+        "fn outer_tests():\n"
         "    @it(\"should pass as direct child\")\n"
-        "    function test_direct():\n"
+        "    fn test_direct():\n"
         "        expect(1 + 1).to_eq(2)\n"
         "\n"
         "    @describe(\"inner\")\n"
-        "    function inner_tests():\n"
+        "    fn inner_tests():\n"
         "        @it(\"should pass as nested child\")\n"
-        "        function test_nested():\n"
+        "        fn test_nested():\n"
         "            expect(2 * 3).to_eq(6)\n"
     ), "outer\n"
        "  \033[32m+ should pass as direct child\033[0m\n"
@@ -1120,7 +1120,7 @@ TEST_F(DirectiveTest, DescribeDirectiveNestedDescribe) {
 TEST(DirectiveSyntax, CompoundExprCallAsPositionalArg) {
     std::string src =
         "@custom(make_inputs())\n"
-        "function foo():\n"
+        "fn foo():\n"
         "    expect(1).to_eq(1)\n";
     Lexer lex(src);
     Parser parser(lex);
@@ -1143,7 +1143,7 @@ TEST(DirectiveSyntax, CompoundExprCallAsPositionalArg) {
 TEST(DirectiveSyntax, CompoundExprBinaryAsPositionalArg) {
     std::string src =
         "@custom(x + 1)\n"
-        "function foo():\n"
+        "fn foo():\n"
         "    expect(1).to_eq(1)\n";
     Lexer lex(src);
     Parser parser(lex);
@@ -1164,7 +1164,7 @@ TEST(DirectiveSyntax, CompoundExprBinaryAsPositionalArg) {
 TEST(DirectiveSyntax, NamedArgWithCompoundValue) {
     std::string src =
         "@custom(count=2 + 3)\n"
-        "function foo():\n"
+        "fn foo():\n"
         "    expect(1).to_eq(1)\n";
     Lexer lex(src);
     Parser parser(lex);
@@ -1186,7 +1186,7 @@ TEST(DirectiveSyntax, NamedArgWithCompoundValue) {
 TEST(DirectiveSyntax, NamedArgWithCallValue) {
     std::string src =
         "@custom(data=make_data())\n"
-        "function foo():\n"
+        "fn foo():\n"
         "    expect(1).to_eq(1)\n";
     Lexer lex(src);
     Parser parser(lex);
@@ -1208,14 +1208,14 @@ TEST(DirectiveSyntax, NamedArgWithCallValue) {
 TEST_F(DirectiveTest, DescribeDirectiveSharedSetup) {
     EXPECT_EQ(runTestSource(
         "@describe(\"shared setup\")\n"
-        "function shared_tests():\n"
+        "fn shared_tests():\n"
         "    x = 10\n"
         "    y = 20\n"
         "    @it(\"should use x\")\n"
-        "    function test_x():\n"
+        "    fn test_x():\n"
         "        expect(x).to_eq(10)\n"
         "    @it(\"should use x and y\")\n"
-        "    function test_xy():\n"
+        "    fn test_xy():\n"
         "        expect(x + y).to_eq(30)\n"
     ), "shared setup\n"
        "  \033[32m+ should use x\033[0m\n"
@@ -1227,13 +1227,13 @@ TEST_F(DirectiveTest, DescribeDirectiveSharedSetup) {
 TEST_F(DirectiveTest, DescribeDirectiveThreeLevelNesting) {
     EXPECT_EQ(runTestSource(
         "@describe(\"level 1\")\n"
-        "function l1():\n"
+        "fn l1():\n"
         "    @describe(\"level 2\")\n"
-        "    function l2():\n"
+        "    fn l2():\n"
         "        @describe(\"level 3\")\n"
-        "        function l3():\n"
+        "        fn l3():\n"
         "            @it(\"should pass at deep nesting\")\n"
-        "            function test_deep():\n"
+        "            fn test_deep():\n"
         "                expect(true).to_be_true()\n"
     ), "level 1\n"
        "  level 2\n"
@@ -1246,10 +1246,10 @@ TEST_F(DirectiveTest, DescribeDirectiveThreeLevelNesting) {
 TEST_F(DirectiveTest, DescribeDirectiveWithEach) {
     EXPECT_EQ(runTestSource(
         "@describe(\"parameterized\")\n"
-        "function param_tests():\n"
+        "fn param_tests():\n"
         "    @each([(1, 2, 3), (4, 5, 9)])\n"
         "    @it(\"should add {0} + {1} = {2}\")\n"
-        "    function test_add(a: int, b: int, expected: int):\n"
+        "    fn test_add(a: int, b: int, expected: int):\n"
         "        expect(a + b).to_eq(expected)\n"
     ), "parameterized\n"
        "  \033[32m+ should add 1 + 2 = 3\033[0m\n"
@@ -1261,10 +1261,10 @@ TEST_F(DirectiveTest, DescribeDirectiveWithEach) {
 TEST_F(DirectiveTest, DescribeDirectiveWithProperty) {
     std::string out = runTestSource(
         "@describe(\"property group\")\n"
-        "function prop_tests():\n"
+        "fn prop_tests():\n"
         "    @property(count=5)\n"
         "    @it(\"should hold int identity\")\n"
-        "    function test_id(a: int):\n"
+        "    fn test_id(a: int):\n"
         "        expect(a).to_eq(a)\n"
     );
     EXPECT_NE(out.find("property group"), std::string::npos);
@@ -1315,7 +1315,7 @@ TEST_F(DirectiveTest, ItCallEmitsDeprecationWarning) {
 TEST(DirectiveSyntax, UnknownDirectiveParseSucceeds) {
     std::string src =
         "@unknown_directive\n"
-        "function foo() -> int:\n"
+        "fn foo() -> int:\n"
         "    return 1\n";
     Lexer lex(src);
     Parser parser(lex);

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -60,7 +60,7 @@ TEST_F(CodeGenTest, NullCoalesceRhsTypeMismatchOnOption) {
 
 TEST_F(CodeGenTest, NullCoalesceRhsTypeMismatchOnResult) {
     expectCompileError(
-        "function mk() -> Result<int, Error>:\n"
+        "fn mk() -> Result<int, Error>:\n"
         "  return Ok(1)\n"
         "x = mk() ?? \"str\"\n",
         "'" "??" "' on Result");
@@ -83,7 +83,7 @@ TEST_F(CodeGenTest, NullCoalesceRejectsPtrBackedTypeMismatch) {
 
 TEST_F(CodeGenTest, QuestionRequiresResultOrOption) {
     expectCompileError(
-        "function f() -> int:\n"
+        "fn f() -> int:\n"
         "  x = 1?\n"
         "  return x\n",
         "Result or Option");
@@ -95,20 +95,20 @@ TEST_F(CodeGenTest, QuestionRequiresResultOrOption) {
 
 TEST_F(CodeGenTest, QuestionOnOptionRequiresOptionReturn) {
     expectCompileError(
-        "function f() -> int:\n"
+        "fn f() -> int:\n"
         "  a: int? = Some(1)\n"
         "  v = a?\n"
         "  return v\n",
-        "function that returns Option");
+        "fn that returns Option");
 }
 
 TEST_F(CodeGenTest, QuestionOnOptionInResultFnRejected) {
     expectCompileError(
-        "function f() -> Result<int, Error>:\n"
+        "fn f() -> Result<int, Error>:\n"
         "  a: int? = Some(1)\n"
         "  v = a?\n"
         "  return Ok(v)\n",
-        "function that returns Option");
+        "fn that returns Option");
 }
 
 // ============================================================
@@ -117,12 +117,12 @@ TEST_F(CodeGenTest, QuestionOnOptionInResultFnRejected) {
 
 TEST_F(CodeGenTest, QuestionOnResultInOptionFnRejected) {
     expectCompileError(
-        "function mk() -> Result<int, Error>:\n"
+        "fn mk() -> Result<int, Error>:\n"
         "  return Ok(1)\n"
-        "function f() -> Option<int>:\n"
+        "fn f() -> Option<int>:\n"
         "  v = mk()?\n"
         "  return Some(v)\n",
-        "function that returns Result");
+        "fn that returns Result");
 }
 
 // ============================================================
@@ -142,7 +142,7 @@ TEST_F(CodeGenTest, OptionMapRejectsNonCallableSecondArg) {
 
 TEST_F(CodeGenTest, TopLevelQuestionRejectsNonErrorResult) {
     expectCompileError(
-        "function mk() -> Result<int, str>:\n"
+        "fn mk() -> Result<int, str>:\n"
         "  return Err(\"boom\")\n"
         "v = mk()?\n",
         "err type must be Error");
@@ -154,8 +154,8 @@ TEST_F(CodeGenTest, TopLevelQuestionRejectsNonErrorResult) {
 
 TEST_F(CodeGenTest, NestedFunctionNotVisibleOutsideScope) {
     EXPECT_THROW(runSource(
-        "function outer() -> int:\n"
-        "    function inner() -> int:\n"
+        "fn outer() -> int:\n"
+        "    fn inner() -> int:\n"
         "        return 1\n"
         "    return inner()\n"
         "inner()\n"
@@ -168,9 +168,9 @@ TEST_F(CodeGenTest, NestedFunctionNotVisibleOutsideScope) {
 
 TEST_F(CodeGenTest, NestedFunctionCannotModifyCapturedVariable) {
     EXPECT_THROW(runSource(
-        "function outer() -> int:\n"
+        "fn outer() -> int:\n"
         "    x = 10\n"
-        "    function helper() -> int:\n"
+        "    fn helper() -> int:\n"
         "        x = 20\n"
         "        return x\n"
         "    return helper()\n"
@@ -192,7 +192,7 @@ TEST_F(CodeGenTest, MathPowIntNegativeExponentAborts) {
     EXPECT_EXIT(
         runSource(
             "@native\n"
-            "function pow(x: int, y: int) -> int\n"
+            "fn pow(x: int, y: int) -> int\n"
             "print(pow(2, -1))\n"),
         ::testing::ExitedWithCode(1),
         "pow\\(\\) integer exponent must be non-negative");
@@ -201,8 +201,8 @@ TEST_F(CodeGenTest, MathPowIntNegativeExponentAborts) {
 TEST_F(CodeGenTest, HelperReturnRejectsIncompatibleThreadResultMetadataAcrossBranches) {
     expectCompileError(
         "@native(\"thread\")\n"
-        "function thread_spawn(body: function() -> any) -> Thread\n"
-        "function mk_thread(flag: bool) -> Thread:\n"
+        "fn thread_spawn(body: fn() -> any) -> Thread\n"
+        "fn mk_thread(flag: bool) -> Thread:\n"
         "  if flag:\n"
         "    return thread_spawn(() => 1)\n"
         "  return thread_spawn(() => true)\n",
@@ -212,8 +212,8 @@ TEST_F(CodeGenTest, HelperReturnRejectsIncompatibleThreadResultMetadataAcrossBra
 TEST_F(CodeGenTest, HelperReturnRejectsMissingAndPresentThreadResultMetadataMix) {
     expectCompileError(
         "@native(\"thread\")\n"
-        "function thread_spawn(body: function() -> any) -> Thread\n"
-        "function mk_thread(flag: bool, fallback: Thread) -> Thread:\n"
+        "fn thread_spawn(body: fn() -> any) -> Thread\n"
+        "fn mk_thread(flag: bool, fallback: Thread) -> Thread:\n"
         "  if flag:\n"
         "    return thread_spawn(() => 1)\n"
         "  return fallback\n",
@@ -230,7 +230,7 @@ TEST_F(CodeGenTest, HelperReturnRejectsMissingAndPresentThreadResultMetadataMix)
 
 TEST_F(CodeGenTest, GenericInferenceEmptyListHasClearError) {
     expectCompileError(
-        "function first_of<T>(xs: List<T>) -> T:\n"
+        "fn first_of<T>(xs: List<T>) -> T:\n"
         "  return xs[0]\n"
         "print(first_of([]))\n",
         "could not infer type parameter 'T' in call to generic function 'first_of'");
@@ -244,7 +244,7 @@ TEST_F(CodeGenTest, GenericInferenceEmptyListHasClearError) {
 
 TEST_F(CodeGenTest, GenericInferenceConflictingBindingError) {
     expectCompileError(
-        "function same<T>(a: T, b: T) -> T:\n"
+        "fn same<T>(a: T, b: T) -> T:\n"
         "  return a\n"
         "print(same(1, \"x\"))\n",
         "conflicting type inference for 'T'");
@@ -262,7 +262,7 @@ TEST_F(CodeGenTest, PrintUnknownNamedArgError) {
 
 TEST_F(CodeGenTest, NamedArgsOnNonBuiltinError) {
     expectCompileError(
-        "function greet(name: str):\n"
+        "fn greet(name: str):\n"
         "  print(name)\n"
         "greet(name=\"world\")\n",
         "named arguments are only supported for builtin functions");
@@ -420,7 +420,7 @@ TEST_F(CodeGenTest, NoneWithArgsIsRejected) {
 TEST_F(CodeGenTest, Base64EncodeBytesRejectsNonU8List) {
     expectCompileError(
         "@native(\"base64\")\n"
-        "function encode_bytes(input: List<int>) -> str\n"
+        "fn encode_bytes(input: List<int>) -> str\n"
         "xs: List<int> = [1, 2, 3]\n"
         "print(encode_bytes(xs))\n",
         "requires List<u8>");
@@ -429,7 +429,7 @@ TEST_F(CodeGenTest, Base64EncodeBytesRejectsNonU8List) {
 TEST_F(CodeGenTest, Base64EncodeBytesUrlSafeRejectsNonU8List) {
     expectCompileError(
         "@native(\"base64\")\n"
-        "function encode_bytes_url_safe(input: List<int>) -> str\n"
+        "fn encode_bytes_url_safe(input: List<int>) -> str\n"
         "xs: List<int> = [1, 2, 3]\n"
         "print(encode_bytes_url_safe(xs))\n",
         "requires List<u8>");
@@ -451,7 +451,7 @@ TEST_F(CodeGenTest, ResultCoerceFnReturnDifferentErrType) {
         "  msg: str\n"
         "record MyErr2:\n"
         "  msg: str\n"
-        "function f() -> Result<bool, MyErr1>:\n"
+        "fn f() -> Result<bool, MyErr1>:\n"
         "  return Err(MyErr1(\"x\"))\n"
         "r: Result<bool, MyErr2> = f()\n",
         "type error: annotation");
@@ -463,7 +463,7 @@ TEST_F(CodeGenTest, ResultCoerceFnReturnNarrowOkType) {
     // path would copy the Err slot — silently zeroing the Ok payload when
     // the runtime disc is 1 (Ok). The fix rejects this with a type error.
     expectCompileError(
-        "function g() -> Result<i8, Error>:\n"
+        "fn g() -> Result<i8, Error>:\n"
         "  return Err(Error(\"test\"))\n"
         "r: Result<int, Error> = g()\n",
         "type error: annotation");
@@ -475,7 +475,7 @@ TEST_F(CodeGenTest, ResultCoerceFnReturnWideOkType) {
     // path would copy the Err slot — silently zeroing the Ok payload when
     // the runtime disc is 1 (Ok). The fix rejects this with a type error.
     expectCompileError(
-        "function mk() -> Result<int, Error>:\n"
+        "fn mk() -> Result<int, Error>:\n"
         "  return Ok(42)\n"
         "r: Result<bool, Error> = mk()\n",
         "type error: annotation");
@@ -504,7 +504,7 @@ TEST_F(CodeGenTest, TuplePatternOnOptionSubjectRejected) {
 // both Option and Result use the same structural rejection path.
 TEST_F(CodeGenTest, TuplePatternOnResultSubjectRejected) {
     expectCompileError(
-        "function mk() -> Result<int, str>:\n"
+        "fn mk() -> Result<int, str>:\n"
         "  return Ok(1)\n"
         "r = mk()\n"
         "case r:\n"
@@ -584,7 +584,7 @@ TEST_F(CodeGenTest, BareGenericEnumNameWithoutTypeArgsRejected) {
         "enum MyOpt<Item>:\n"
         "  MySome(Item)\n"
         "  MyNone\n"
-        "function unwrap_or(opt: MyOpt, default: int) -> int:\n"
+        "fn unwrap_or(opt: MyOpt, default: int) -> int:\n"
         "  return default\n",
         {"generic enum 'MyOpt'", "without type arguments", "MyOpt<Item>"});
 }
@@ -633,6 +633,6 @@ TEST_F(CodeGenTest, NestedGenericEnumFieldCompiles) {
         "  In(T)\n"
         "enum Outer<T>:\n"
         "  Wrap(Inner<T>)\n"
-        "function mk() -> Outer<int>:\n"
+        "fn mk() -> Outer<int>:\n"
         "  return Outer<int>::Wrap(Inner<int>::In(1))\n"));
 }

--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -11,34 +11,34 @@
 using namespace ry;
 static const std::string HTTP_DECLS = R"(
 @native
-function bind(host: str, port: int) -> Result<TcpListener, Error>
+fn bind(host: str, port: int) -> Result<TcpListener, Error>
 @native
-function listen(listener: TcpListener, backlog: int) -> Result<Unit, Error>
+fn listen(listener: TcpListener, backlog: int) -> Result<Unit, Error>
 @native
-function accept(listener: TcpListener) -> Result<TcpStream, Error>
+fn accept(listener: TcpListener) -> Result<TcpStream, Error>
 @native
-function connect(host: str, port: int) -> Result<TcpStream, Error>
+fn connect(host: str, port: int) -> Result<TcpStream, Error>
 @native
-function listener_port(listener: TcpListener) -> int
+fn listener_port(listener: TcpListener) -> int
 @native
-function to_bytes(s: str) -> List<u8>
+fn to_bytes(s: str) -> List<u8>
 @native
-function bytes_to_str(bs: List<u8>) -> Result<str, Error>
+fn bytes_to_str(bs: List<u8>) -> Result<str, Error>
 @native
-function sleep(ms: int) -> Unit
+fn sleep(ms: int) -> Unit
 )";
 
 static const std::string HTTP_CLIENT_DECLS = R"(
 @native("http")
-function http_get(url: str) -> Result<HttpClientResponse, Error>
+fn http_get(url: str) -> Result<HttpClientResponse, Error>
 @native("http")
-function http_request(method: str, url: str, headers: Map<str, str>, body: str) -> Result<HttpClientResponse, Error>
+fn http_request(method: str, url: str, headers: Map<str, str>, body: str) -> Result<HttpClientResponse, Error>
 @native("http")
-function status(response: HttpClientResponse) -> int
+fn status(response: HttpClientResponse) -> int
 @native("http")
-function body(response: HttpClientResponse) -> str
+fn body(response: HttpClientResponse) -> str
 @native("http")
-function http_client_response_free(response: HttpClientResponse) -> Unit
+fn http_client_response_free(response: HttpClientResponse) -> Unit
 )";
 
 class AllowPrivateHTTPGuard {
@@ -138,12 +138,12 @@ protected:
 // ============================================================
 // Manual server: tests HTTP response parsing via raw TCP.
 // Uses dynamic port allocation. Server binds in main scope,
-// passes listener to async function for accept.
+// passes listener to async fn for accept.
 // ============================================================
 
 TEST_F(CodeGenTest, ManualHttpServer200) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
-async function manual_server(server: TcpListener) -> str:
+async fn manual_server(server: TcpListener) -> str:
     case accept(server):
         Ok(conn):
             case receive(conn, 4096):
@@ -204,7 +204,7 @@ case bind("127.0.0.1", 0):
 
 TEST_F(CodeGenTest, ManualHttpServerEcho) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
-async function run_server(server: TcpListener) -> str:
+async fn run_server(server: TcpListener) -> str:
     case accept(server):
         Ok(conn):
             case receive(conn, 4096):
@@ -262,7 +262,7 @@ case bind("127.0.0.1", 0):
 
 TEST_F(CodeGenTest, HttpResponse404) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
-async function manual_server(server: TcpListener) -> str:
+async fn manual_server(server: TcpListener) -> str:
     case accept(server):
         Ok(conn):
             case receive(conn, 4096):
@@ -320,7 +320,7 @@ case bind("127.0.0.1", 0):
 
 TEST_F(CodeGenTest, ManualHttpServerHeader) {
     EXPECT_EQ(runSource(HTTP_DECLS + R"(
-async function manual_server(server: TcpListener) -> str:
+async fn manual_server(server: TcpListener) -> str:
     case accept(server):
         Ok(conn):
             case receive(conn, 4096):
@@ -442,27 +442,27 @@ TEST_F(CodeGenHttpClientTest, HttpRequestCaseBindingPreservesHttpClientResponseM
 
 // ============================================================
 // listen with max_requests: server exits after N requests
-// Uses async function + port_callback + block_on to verify server lifecycle.
+// Uses async fn + port_callback + block_on to verify server lifecycle.
 // ============================================================
 
 static const std::string HTTP_LISTEN_DECLS = HTTP_DECLS + R"(
 @native
-function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>) -> Result<Unit, Error>
+fn listen(host: str, port: int, handler: fn(HttpRequest) -> Result<HttpResponse, Error>) -> Result<Unit, Error>
 @native
-function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int) -> Result<Unit, Error>
+fn listen(host: str, port: int, handler: fn(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int) -> Result<Unit, Error>
 @native
-function listen(host: str, port: int, handler: function(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int, port_callback: function(int) -> Unit) -> Result<Unit, Error>
+fn listen(host: str, port: int, handler: fn(HttpRequest) -> Result<HttpResponse, Error>, max_requests: int, port_callback: fn(int) -> Unit) -> Result<Unit, Error>
 @native
-function method(req: HttpRequest) -> str
+fn method(req: HttpRequest) -> str
 @native
-function path(req: HttpRequest) -> str
+fn path(req: HttpRequest) -> str
 @native
-function response(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>
+fn response(status: int, headers: Map<str, str>, body: str) -> Result<HttpResponse, Error>
 )";
 
 TEST_F(CodeGenTest, HttpListenMaxRequests) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async function server() -> str:
+async fn server() -> str:
     listen("127.0.0.1", 18932, (req: HttpRequest) -> Result<HttpResponse, Error>:
         return response(200, {"Content-Type": "text/plain"}, "ok")
     , 1)
@@ -500,7 +500,7 @@ print(result)
 
 TEST_F(CodeGenTest, HttpListenMaxRequestsMultiple) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async function server() -> str:
+async fn server() -> str:
     listen("127.0.0.1", 18933, (req: HttpRequest) -> Result<HttpResponse, Error>:
         path = path(req)
         return response(200, {"Content-Type": "text/plain"}, path)
@@ -559,7 +559,7 @@ print(result)
 
 TEST_F(CodeGenTest, HttpKeepAlive) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async function server() -> str:
+async fn server() -> str:
     listen("127.0.0.1", 18934, (req: HttpRequest) -> Result<HttpResponse, Error>:
         path = path(req)
         return response(200, {"Content-Type": "text/plain"}, path)
@@ -623,7 +623,7 @@ print(result)
 
 TEST_F(CodeGenTest, HttpConnectionClose) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async function server() -> str:
+async fn server() -> str:
     listen("127.0.0.1", 18935, (req: HttpRequest) -> Result<HttpResponse, Error>:
         return response(200, {"Content-Type": "text/plain"}, "ok")
     , 2)
@@ -685,7 +685,7 @@ print(result)
 
 TEST_F(CodeGenTest, HttpKeepAliveWithMaxRequests) {
     EXPECT_EQ(runSource(HTTP_LISTEN_DECLS + R"(
-async function server() -> str:
+async fn server() -> str:
     listen("127.0.0.1", 18936, (req: HttpRequest) -> Result<HttpResponse, Error>:
         path = path(req)
         return response(200, {"Content-Type": "text/plain"}, path)

--- a/tests/test_codegen_io.cpp
+++ b/tests/test_codegen_io.cpp
@@ -15,26 +15,26 @@ static void removeIfExists(const std::string &path) {
     std::remove(path.c_str());
 }
 
-// @native function declarations needed for IO functions
+// @native fn declarations needed for IO functions
 static const std::string IO_DECLS = R"(
 @native
-function read_text(path: str) -> Result<str, Error>
+fn read_text(path: str) -> Result<str, Error>
 @native
-function write_text(path: str, content: str) -> Result<Unit, Error>
+fn write_text(path: str, content: str) -> Result<Unit, Error>
 @native
-function append_text(path: str, content: str) -> Result<Unit, Error>
+fn append_text(path: str, content: str) -> Result<Unit, Error>
 @native
-function exists(path: str) -> bool
+fn exists(path: str) -> bool
 @native
-function delete_file(path: str) -> Result<Unit, Error>
+fn delete_file(path: str) -> Result<Unit, Error>
 @native
-function read_bytes(path: str) -> Result<List<u8>, Error>
+fn read_bytes(path: str) -> Result<List<u8>, Error>
 @native
-function write_bytes(path: str, data: List<u8>) -> Result<Unit, Error>
+fn write_bytes(path: str, data: List<u8>) -> Result<Unit, Error>
 @native
-function to_bytes(s: str) -> List<u8>
+fn to_bytes(s: str) -> List<u8>
 @native
-function bytes_to_str(bs: List<u8>) -> Result<str, Error>
+fn bytes_to_str(bs: List<u8>) -> Result<str, Error>
 )";
 
 // ============================================================

--- a/tests/test_codegen_mock.cpp
+++ b/tests/test_codegen_mock.cpp
@@ -8,7 +8,7 @@ using namespace ry;
 
 TEST_F(CodeGenTest, MockBasicReplace) {
     EXPECT_EQ(runTestSource(
-        "function greet() -> str:\n"
+        "fn greet() -> str:\n"
         "    return \"hello\"\n"
         "\n"
         "describe(\"mock basic\", ():\n"
@@ -26,7 +26,7 @@ TEST_F(CodeGenTest, MockBasicReplace) {
 
 TEST_F(CodeGenTest, MockWithArgs) {
     EXPECT_EQ(runTestSource(
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "\n"
         "describe(\"mock with args\", ():\n"
@@ -44,7 +44,7 @@ TEST_F(CodeGenTest, MockWithArgs) {
 
 TEST_F(CodeGenTest, MockAutoRestore) {
     EXPECT_EQ(runTestSource(
-        "function greet() -> str:\n"
+        "fn greet() -> str:\n"
         "    return \"hello\"\n"
         "\n"
         "describe(\"mock restore\", ():\n"
@@ -65,7 +65,7 @@ TEST_F(CodeGenTest, MockAutoRestore) {
 
 TEST_F(CodeGenTest, MockVerifyCallCount) {
     EXPECT_EQ(runTestSource(
-        "function greet() -> str:\n"
+        "fn greet() -> str:\n"
         "    return \"hello\"\n"
         "\n"
         "describe(\"verify\", ():\n"
@@ -87,7 +87,7 @@ TEST_F(CodeGenTest, MockVerifyCallCount) {
 TEST_F(CodeGenTest, MockFunctionUsedAsExpr) {
     // verify() works when mock is called and function result is used
     EXPECT_EQ(runTestSource(
-        "function get_value() -> int:\n"
+        "fn get_value() -> int:\n"
         "    return 100\n"
         "\n"
         "describe(\"mock expr\", ():\n"
@@ -107,7 +107,7 @@ TEST_F(CodeGenTest, MockFunctionUsedAsExpr) {
 
 TEST_F(CodeGenTest, MockOutsideTestModeError) {
     EXPECT_THROW(runSource(
-        "function greet() -> str:\n"
+        "fn greet() -> str:\n"
         "    return \"hello\"\n"
         "mock(greet, () => \"mocked\")\n"
     ), std::exception);
@@ -133,7 +133,7 @@ TEST_F(CodeGenTest, MockNonExistentFunctionError) {
 
 TEST_F(CodeGenTest, MockTypeMismatchError) {
     EXPECT_THROW(runTestSource(
-        "function greet() -> str:\n"
+        "fn greet() -> str:\n"
         "    return \"hello\"\n"
         "\n"
         "describe(\"error\", ():\n"
@@ -146,7 +146,7 @@ TEST_F(CodeGenTest, MockTypeMismatchError) {
 
 TEST_F(CodeGenTest, MockedFunctionStillChecksRequire) {
     std::string src =
-        "function deposit(amount: int, balance: int) -> int:\n"
+        "fn deposit(amount: int, balance: int) -> int:\n"
         "    require:\n"
         "        amount > 0\n"
         "        balance >= 0\n"
@@ -163,7 +163,7 @@ TEST_F(CodeGenTest, MockedFunctionStillChecksRequire) {
 
 TEST_F(CodeGenTest, MockedFunctionStillChecksEnsure) {
     std::string src =
-        "function deposit(amount: int, balance: int) -> int:\n"
+        "fn deposit(amount: int, balance: int) -> int:\n"
         "    require:\n"
         "        amount > 0\n"
         "        balance >= 0\n"

--- a/tests/test_codegen_net.cpp
+++ b/tests/test_codegen_net.cpp
@@ -11,27 +11,27 @@
 using namespace ry;
 static const std::string NET_DECLS = R"(
 @native
-function bind(host: str, port: int) -> Result<TcpListener, Error>
+fn bind(host: str, port: int) -> Result<TcpListener, Error>
 @native
-function listen(listener: TcpListener, backlog: int) -> Result<Unit, Error>
+fn listen(listener: TcpListener, backlog: int) -> Result<Unit, Error>
 @native
-function accept(listener: TcpListener) -> Result<TcpStream, Error>
+fn accept(listener: TcpListener) -> Result<TcpStream, Error>
 @native
-function connect(host: str, port: int) -> Result<TcpStream, Error>
+fn connect(host: str, port: int) -> Result<TcpStream, Error>
 @native
-function tls_connect(host: str, port: int) -> Result<TlsStream, Error>
+fn tls_connect(host: str, port: int) -> Result<TlsStream, Error>
 @native
-function to_bytes(s: str) -> List<u8>
+fn to_bytes(s: str) -> List<u8>
 @native
-function bytes_to_str(bs: List<u8>) -> Result<str, Error>
+fn bytes_to_str(bs: List<u8>) -> Result<str, Error>
 @native
-function set_timeout(stream: TcpStream, ms: int) -> Unit
+fn set_timeout(stream: TcpStream, ms: int) -> Unit
 @native
-function set_receive_timeout(stream: TcpStream, ms: int) -> Unit
+fn set_receive_timeout(stream: TcpStream, ms: int) -> Unit
 @native
-function set_send_timeout(stream: TcpStream, ms: int) -> Unit
+fn set_send_timeout(stream: TcpStream, ms: int) -> Unit
 @native
-function sleep(ms: int) -> Unit
+fn sleep(ms: int) -> Unit
 )";
 
 // ============================================================
@@ -84,16 +84,16 @@ case bind("127.0.0.1", 0):
 }
 
 // ============================================================
-// Echo round-trip: server and client via async function
-// Binds in main scope, passes listener to async function for accept.
+// Echo round-trip: server and client via async fn
+// Binds in main scope, passes listener to async fn for accept.
 // ============================================================
 
 TEST_F(CodeGenTest, NetEchoRoundTrip) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
 @native
-function listener_port(listener: TcpListener) -> int
+fn listener_port(listener: TcpListener) -> int
 
-async function run_server(server: TcpListener) -> str:
+async fn run_server(server: TcpListener) -> str:
     case accept(server):
         Ok(conn):
             case receive(conn, 4096):
@@ -115,7 +115,7 @@ async function run_server(server: TcpListener) -> str:
     close(server)
     return "done"
 
-function run_client(port: int) -> str:
+fn run_client(port: int) -> str:
     case connect("127.0.0.1", port):
         Ok(conn):
             case send(conn, to_bytes("hello")):
@@ -330,9 +330,9 @@ case connect("127.0.0.1", 19995):
 TEST_F(CodeGenTest, NetRecvTimesOutWithShortTimeout) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
 @native
-function listener_port(listener: TcpListener) -> int
+fn listener_port(listener: TcpListener) -> int
 
-async function server_task(server: TcpListener) -> str:
+async fn server_task(server: TcpListener) -> str:
     case accept(server):
         Ok(conn):
             # Don't send anything - let client timeout

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -111,29 +111,29 @@ TEST_F(CodeGenTest, WhileLoopVariants) {
 TEST_F(CodeGenTest, FnBasicDefinitions) {
     // FnBasicAddCall
     EXPECT_EQ(runSource(
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "res = add(1, 2)\n"
         "print(res)"), "3\n");
     // FnNoArgs
     EXPECT_EQ(runSource(
-        "function zero() -> int:\n"
+        "fn zero() -> int:\n"
         "    return 0\n"
         "print(zero())"), "0\n");
     // FnFloatReturn
     EXPECT_EQ(runSource(
-        "function half(x: float) -> float:\n"
+        "fn half(x: float) -> float:\n"
         "    return x / 2.0\n"
         "r = half(7.0)\n"
         "print(r)"), "3.5\n");
     // FnBoolReturn
     EXPECT_EQ(runSource(
-        "function is_positive(x: int) -> bool:\n"
+        "fn is_positive(x: int) -> bool:\n"
         "    return x > 0\n"
         "print(is_positive(5))"), "true\n");
     // FnWithIf
     EXPECT_EQ(runSource(
-        "function abs(x: int) -> int:\n"
+        "fn abs(x: int) -> int:\n"
         "    if x < 0:\n"
         "        return -x\n"
         "    return x\n"
@@ -141,13 +141,13 @@ TEST_F(CodeGenTest, FnBasicDefinitions) {
         "print(abs(3))"), "5\n3\n");
     // FnCallAsStatement
     EXPECT_EQ(runSource(
-        "function greet() -> int:\n"
+        "fn greet() -> int:\n"
         "    print(42)\n"
         "    return 0\n"
         "greet()"), "42\n");
     // FnRecursiveFactorial
     EXPECT_EQ(runSource(
-        "function factorial(n: int) -> int:\n"
+        "fn factorial(n: int) -> int:\n"
         "    if n <= 1:\n"
         "        return 1\n"
         "    return n * factorial(n - 1)\n"
@@ -159,17 +159,17 @@ TEST_F(CodeGenTest, FnErrors) {
     EXPECT_THROW(runSource("x = unknown(1)"), std::runtime_error);
     // FnArgCountMismatchThrows
     EXPECT_THROW(runSource(
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "x = add(1)"), std::runtime_error);
     // FnArgTypeMismatchThrows
     EXPECT_THROW(runSource(
-        "function inc(a: int) -> int:\n"
+        "fn inc(a: int) -> int:\n"
         "    return a + 1\n"
         "x = inc(1.5)"), std::runtime_error);
     // FnReturnTypeMismatchThrows
     EXPECT_THROW(runSource(
-        "function bad() -> int:\n"
+        "fn bad() -> int:\n"
         "    return \"hello\""), std::runtime_error);
 }
 
@@ -243,7 +243,7 @@ TEST_F(CodeGenTest, RecordBasics) {
         "record Point:\n"
         "    x: int\n"
         "    y: int\n"
-        "function get_x(p: Point) -> int:\n"
+        "fn get_x(p: Point) -> int:\n"
         "    return p.x\n"
         "p = Point(42, 99)\n"
         "print(get_x(p))"), "42\n");
@@ -252,7 +252,7 @@ TEST_F(CodeGenTest, RecordBasics) {
         "record Point:\n"
         "    x: int\n"
         "    y: int\n"
-        "function make_point(a: int, b: int) -> Point:\n"
+        "fn make_point(a: int, b: int) -> Point:\n"
         "    return Point(a, b)\n"
         "p = make_point(7, 8)\n"
         "print(p.x)\n"
@@ -357,7 +357,7 @@ TEST_F(CodeGenTest, RecordUserDefinedToStr) {
         "record Point:\n"
         "    x: int\n"
         "    y: int\n"
-        "function to_str(p: Point) -> str:\n"
+        "fn to_str(p: Point) -> str:\n"
         "    return f\"({p.x}, {p.y})\"\n"
         "p = Point(5, 6)\n"
         "print(to_str(p))"), "(5, 6)\n");
@@ -368,7 +368,7 @@ TEST_F(CodeGenTest, RecordUserDefinedToStrWithPrint) {
         "record Point:\n"
         "    x: int\n"
         "    y: int\n"
-        "function to_str(p: Point) -> str:\n"
+        "fn to_str(p: Point) -> str:\n"
         "    return f\"({p.x}, {p.y})\"\n"
         "p = Point(5, 6)\n"
         "print(p)"), "(5, 6)\n");
@@ -392,22 +392,22 @@ TEST_F(CodeGenTest, UnknownTypeAnnotationThrows) {
 TEST_F(CodeGenTest, UnitTypeBasics) {
     // UnitFnNoReturnType
     EXPECT_EQ(runSource(
-        "function greet() -> Unit:\n"
+        "fn greet() -> Unit:\n"
         "    print(42)\n"
         "greet()"), "42\n");
     // UnitFnExplicit
     EXPECT_EQ(runSource(
-        "function greet() -> Unit:\n"
+        "fn greet() -> Unit:\n"
         "    print(99)\n"
         "greet()"), "99\n");
     // UnitFnReturnVoid
     EXPECT_EQ(runSource(
-        "function noop() -> Unit:\n"
+        "fn noop() -> Unit:\n"
         "    return\n"
         "noop()"), "");
     // UnitFnReturnVoidEarly
     EXPECT_EQ(runSource(
-        "function maybe_print(x: int) -> Unit:\n"
+        "fn maybe_print(x: int) -> Unit:\n"
         "    if x > 0:\n"
         "        print(x)\n"
         "        return\n"
@@ -418,7 +418,7 @@ TEST_F(CodeGenTest, UnitTypeBasics) {
 
 TEST_F(CodeGenTest, UnitFnReturnValueThrows) {
     std::string src =
-        "function f() -> Unit:\n"
+        "fn f() -> Unit:\n"
         "    return 42\n"
         "f()";
     EXPECT_THROW(runSource(src), std::runtime_error);
@@ -444,13 +444,13 @@ TEST_F(CodeGenTest, OptionPrintVariants) {
 TEST_F(CodeGenTest, OptionInFunctions) {
     // OptionFnParamAndReturn
     EXPECT_EQ(runSource(
-        "function maybe_double(x: Option<int>) -> Option<int>:\n"
+        "fn maybe_double(x: Option<int>) -> Option<int>:\n"
         "    return x\n"
         "a = maybe_double(Some(21))\n"
         "print(a)"), "Some(21)\n");
     // OptionFnNoneArg
     EXPECT_EQ(runSource(
-        "function f(x: Option<int>) -> int:\n"
+        "fn f(x: Option<int>) -> int:\n"
         "    return 0\n"
         "r = f(None)\n"
         "print(r)"), "0\n");
@@ -555,14 +555,14 @@ TEST_F(CodeGenTest, TupleBasics) {
 TEST_F(CodeGenTest, TupleFnReturn) {
     // TupleFnReturn
     EXPECT_EQ(runSource(
-        "function swap(a: int, b: int) -> (int, int):\n"
+        "fn swap(a: int, b: int) -> (int, int):\n"
         "    return (b, a)\n"
         "res = swap(1, 2)\n"
         "print(res.0)\n"
         "print(res.1)"), "2\n1\n");
     // TupleFnReturnAccessDirect
     EXPECT_EQ(runSource(
-        "function make_pair(a: int, b: float) -> (int, float):\n"
+        "fn make_pair(a: int, b: float) -> (int, float):\n"
         "    return (a, b)\n"
         "p = make_pair(42, 3.14)\n"
         "print(p.0)\n"
@@ -587,7 +587,7 @@ TEST_F(CodeGenTest, TupleDestructuring) {
         "print(c)"), "1\n2\n3\n");
     // TupleDestructFromFn
     EXPECT_EQ(runSource(
-        "function f() -> (int, int):\n"
+        "fn f() -> (int, int):\n"
         "    return (3, 4)\n"
         "a, b = f()\n"
         "print(a)\n"
@@ -654,9 +654,9 @@ protected:
 TEST_F(ImportTest, ImportBasics) {
     // ImportAllFunctions
     writeFile("math.ry",
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
-        "function sub(a: int, b: int) -> int:\n"
+        "fn sub(a: int, b: int) -> int:\n"
         "    return a - b\n");
     EXPECT_EQ(runWithImports(
         "from math\n"
@@ -672,11 +672,11 @@ TEST_F(ImportTest, ImportBasics) {
 
     // ImportMultipleSelected
     writeFile("math2.ry",
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
-        "function sub(a: int, b: int) -> int:\n"
+        "fn sub(a: int, b: int) -> int:\n"
         "    return a - b\n"
-        "function mul(a: int, b: int) -> int:\n"
+        "fn mul(a: int, b: int) -> int:\n"
         "    return a * b\n");
     EXPECT_EQ(runWithImports(
         "from math2 import add, mul\n"
@@ -694,7 +694,7 @@ TEST_F(ImportTest, ImportBasics) {
 
 TEST_F(ImportTest, ImportSubdirectory) {
     writeFile("utils/math.ry",
-        "function double_it(x: int) -> int:\n"
+        "fn double_it(x: int) -> int:\n"
         "    return x * 2\n");
 
     EXPECT_EQ(runWithImports(
@@ -714,18 +714,18 @@ TEST_F(ImportTest, ImportErrors) {
 
     // FunctionNotFoundError
     writeFile("mathmod.ry",
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n");
     EXPECT_THROW(runWithImports("from mathmod import nope"), std::runtime_error);
 }
 
 TEST_F(ImportTest, TransitiveImport) {
     writeFile("base.ry",
-        "function base_fn(x: int) -> int:\n"
+        "fn base_fn(x: int) -> int:\n"
         "    return x + 100\n");
     writeFile("mid.ry",
         "from base\n"
-        "function mid_fn(x: int) -> int:\n"
+        "fn mid_fn(x: int) -> int:\n"
         "    return base_fn(x) + 10\n");
 
     EXPECT_EQ(runWithImports(
@@ -739,7 +739,7 @@ TEST_F(ImportTest, SearchPathRYPATH) {
     std::filesystem::create_directories(lib_dir);
     {
         std::ofstream f(lib_dir / "mylib.ry");
-        f << "function greet() -> int:\n"
+        f << "fn greet() -> int:\n"
              "    print(999)\n"
              "    return 0\n";
     }
@@ -758,10 +758,10 @@ TEST_F(ImportTest, SearchPathRYPATH) {
 
 TEST_F(ImportTest, DirectoryPackageImportAll) {
     writeFile("mypack/math.ry",
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n");
     writeFile("mypack/string.ry",
-        "function greet() -> int:\n"
+        "fn greet() -> int:\n"
         "    print(42)\n"
         "    return 0\n");
 
@@ -774,12 +774,12 @@ TEST_F(ImportTest, DirectoryPackageImportAll) {
 
 TEST_F(ImportTest, DirectoryPackageSelectiveImport) {
     writeFile("mypack2/math.ry",
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
-        "function sub(a: int, b: int) -> int:\n"
+        "fn sub(a: int, b: int) -> int:\n"
         "    return a - b\n");
     writeFile("mypack2/string.ry",
-        "function greet() -> int:\n"
+        "fn greet() -> int:\n"
         "    print(99)\n"
         "    return 0\n");
 
@@ -791,10 +791,10 @@ TEST_F(ImportTest, DirectoryPackageSelectiveImport) {
 
 TEST_F(ImportTest, DirectoryPackageSkipsUnderscoreFiles) {
     writeFile("mypack3/public.ry",
-        "function visible() -> int:\n"
+        "fn visible() -> int:\n"
         "    return 42\n");
     writeFile("mypack3/_hidden.ry",
-        "function secret() -> int:\n"
+        "fn secret() -> int:\n"
         "    return 99\n");
 
     EXPECT_THROW(runWithImports(
@@ -803,7 +803,7 @@ TEST_F(ImportTest, DirectoryPackageSkipsUnderscoreFiles) {
 
 TEST_F(ImportTest, DirectoryPackageFallbackToFile) {
     writeFile("single.ry",
-        "function solo() -> int:\n"
+        "fn solo() -> int:\n"
         "    return 7\n");
 
     EXPECT_EQ(runWithImports(
@@ -816,9 +816,9 @@ TEST_F(ImportTest, DirectoryPackageFallbackToFile) {
 
 TEST_F(ImportTest, PrivateSymbolWildcardImport) {
     writeFile("mypkg/pub.ry",
-        "function public_fn() -> int:\n"
+        "fn public_fn() -> int:\n"
         "    return 42\n"
-        "function _private_fn() -> int:\n"
+        "fn _private_fn() -> int:\n"
         "    return 99\n");
 
     EXPECT_EQ(runWithImports(
@@ -834,9 +834,9 @@ TEST_F(ImportTest, PrivateSymbolWildcardImport) {
 
 TEST_F(ImportTest, PrivateSymbolNamedImportError) {
     writeFile("mypkg2/mod.ry",
-        "function _hidden() -> int:\n"
+        "fn _hidden() -> int:\n"
         "    return 1\n"
-        "function visible() -> int:\n"
+        "fn visible() -> int:\n"
         "    return 2\n");
 
     EXPECT_THROW(runWithImports(
@@ -869,7 +869,7 @@ TEST_F(ImportTest, PrivateLetSymbolExcluded) {
 TEST_F(CodeGenTest, TypeAlias) {
     std::string src =
         "type MyInt = int\n"
-        "function add(a: MyInt, b: MyInt) -> MyInt:\n"
+        "fn add(a: MyInt, b: MyInt) -> MyInt:\n"
         "    return a + b\n"
         "print(add(3, 4))";
     EXPECT_EQ(runSource(src), "7\n");
@@ -933,20 +933,20 @@ TEST_F(CodeGenTest, RangeExprVariants) {
 TEST_F(CodeGenTest, AsyncAwaitBasics) {
     // block_on awaits direct async call
     EXPECT_EQ(runSource(
-        "async function add(a: int, b: int) -> int:\n"
+        "async fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "print(block_on(add(20, 22)))"), "42\n");
     // block_on awaits task variable
     EXPECT_EQ(runSource(
-        "async function add(a: int, b: int) -> int:\n"
+        "async fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "t: Task<int> = add(7, 8)\n"
         "print(block_on(t))"), "15\n");
-    // await chains inside async function, block_on at top level
+    // await chains inside async fn, block_on at top level
     EXPECT_EQ(runSource(
-        "async function inner() -> int:\n"
+        "async fn inner() -> int:\n"
         "    return 21\n"
-        "async function outer() -> int:\n"
+        "async fn outer() -> int:\n"
         "    return (await inner()) * 2\n"
         "print(block_on(outer()))"), "42\n");
 }
@@ -954,13 +954,13 @@ TEST_F(CodeGenTest, AsyncAwaitBasics) {
 TEST_F(CodeGenTest, AsyncStatementForms) {
     // block_on Unit-returning async
     EXPECT_EQ(runSource(
-        "async function bump() -> Unit:\n"
+        "async fn bump() -> Unit:\n"
         "    print(\"done\")\n"
         "block_on(bump())\n"
         "print(\"after\")"), "done\nafter\n");
     // block_on discards value
     EXPECT_EQ(runSource(
-        "async function add(a: int, b: int) -> int:\n"
+        "async fn add(a: int, b: int) -> int:\n"
         "    print(a + b)\n"
         "    return a + b\n"
         "block_on(add(20, 22))\n"
@@ -968,11 +968,11 @@ TEST_F(CodeGenTest, AsyncStatementForms) {
 }
 
 TEST_F(CodeGenTest, AwaitErrors) {
-    // await outside async function is a parse error
-    EXPECT_THROW(runSource("async function add(a: int, b: int) -> int:\n"
+    // await outside async fn is a parse error
+    EXPECT_THROW(runSource("async fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "x = await add(1, 2)\nprint(x)"), std::runtime_error);
-    EXPECT_THROW(runSource("async function bump() -> Unit:\n"
+    EXPECT_THROW(runSource("async fn bump() -> Unit:\n"
         "    print(\"done\")\n"
         "await bump()"), std::runtime_error);
     // block_on requires Task
@@ -988,7 +988,7 @@ TEST_F(CodeGenTest, AvailableParallelismBuiltin) {
 // TODO: print output interleaves across threads (#473)
 // TEST_F(CodeGenTest, ParallelForBasics) {
 //     EXPECT_EQ(runSource(
-//         "function one(x: int) -> int:\n"
+//         "fn one(x: int) -> int:\n"
 //         "    return 1\n"
 //         "@parallel\n"
 //         "for i in range(5):\n"
@@ -1023,7 +1023,7 @@ TEST_F(CodeGenTest, ParallelForErrors) {
     EXPECT_THROW(runSource(
         "@parallel\n"
         "for i in range(4):\n"
-        "    function helper() -> int:\n"
+        "    fn helper() -> int:\n"
         "        return i\n"
         "    print(helper())\n"), std::runtime_error);
 }
@@ -1045,7 +1045,7 @@ TEST_F(CodeGenTest, IntLiteralType) {
 
 TEST_F(CodeGenTest, IntLiteralTypeVarReassignDynamicFail) {
     std::string src =
-        "function get_two() -> int:\n"
+        "fn get_two() -> int:\n"
         "    return 2\n"
         "x: 0 | 1 = 0\n"
         "x = get_two()";
@@ -1075,7 +1075,7 @@ TEST_F(CodeGenTest, RangeType) {
 
 TEST_F(CodeGenTest, RangeTypeVarReassignDynamicFail) {
     std::string src =
-        "function get_thirteen() -> int:\n"
+        "fn get_thirteen() -> int:\n"
         "    return 13\n"
         "x: 1..12 = 6\n"
         "x = get_thirteen()";
@@ -1095,7 +1095,7 @@ TEST_F(CodeGenTest, StrLiteralType) {
 
 TEST_F(CodeGenTest, StrLiteralTypeVarReassignDynamicFail) {
     std::string src =
-        "function get_x() -> str:\n"
+        "fn get_x() -> str:\n"
         "    return \"X\"\n"
         "dir: \"N\" | \"S\" = \"N\"\n"
         "dir = get_x()";
@@ -1131,27 +1131,27 @@ TEST_F(CodeGenTest, TypeAliasRefinedTypes) {
 TEST_F(CodeGenTest, TypeAliasFnType) {
     // TypeAliasFnType
     EXPECT_EQ(runSource(
-        "type Callback = function(int, int) -> int\n"
+        "type Callback = fn(int, int) -> int\n"
         "add: Callback = (a: int, b: int) => a + b\n"
         "print(add(3, 4))"), "7\n");
     // TypeAliasFnTypeParam
     EXPECT_EQ(runSource(
-        "type BinOp = function(int, int) -> int\n"
-        "function apply(f: BinOp, a: int, b: int) -> int:\n"
+        "type BinOp = fn(int, int) -> int\n"
+        "fn apply(f: BinOp, a: int, b: int) -> int:\n"
         "    return f(a, b)\n"
         "res = apply((x: int, y: int) => x + y, 10, 20)\n"
         "print(res)"), "30\n");
     // TypeAliasFnTypeLambdaParam
     EXPECT_EQ(runSource(
-        "type Mapper = function(int) -> int\n"
+        "type Mapper = fn(int) -> int\n"
         "apply = (f: Mapper, x: int) => f(x)\n"
         "print(apply((n: int) => n * 3, 7))"), "21\n");
     // TypeAliasFnTypeNamedFn
     EXPECT_EQ(runSource(
-        "type BinOp = function(int, int) -> int\n"
-        "function add(a: int, b: int) -> int:\n"
+        "type BinOp = fn(int, int) -> int\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
-        "function apply(f: BinOp, a: int, b: int) -> int:\n"
+        "fn apply(f: BinOp, a: int, b: int) -> int:\n"
         "    return f(a, b)\n"
         "print(apply(add, 5, 6))"), "11\n");
 }
@@ -1161,22 +1161,22 @@ TEST_F(CodeGenTest, TypeAliasFnType) {
 TEST_F(CodeGenTest, FnParamConstraints) {
     // FnParamRangeTypeSuccess
     EXPECT_EQ(runSource(
-        "function set_month(m: 1..12) -> int:\n"
+        "fn set_month(m: 1..12) -> int:\n"
         "    return m\n"
         "print(set_month(6))"), "6\n");
     // FnParamRangeTypeConstFail
     EXPECT_THROW(runSource(
-        "function set_month(m: 1..12) -> int:\n"
+        "fn set_month(m: 1..12) -> int:\n"
         "    return m\n"
         "set_month(13)"), std::runtime_error);
     // FnParamIntLiteralSuccess
     EXPECT_EQ(runSource(
-        "function f(x: 0 | 1) -> int:\n"
+        "fn f(x: 0 | 1) -> int:\n"
         "    return x\n"
         "print(f(1))"), "1\n");
     // FnParamIntLiteralFail
     EXPECT_THROW(runSource(
-        "function f(x: 0 | 1) -> int:\n"
+        "fn f(x: 0 | 1) -> int:\n"
         "    return x\n"
         "f(2)"), std::runtime_error);
 }
@@ -1188,7 +1188,7 @@ TEST_F(CodeGenTest, EllipsisVariants) {
     EXPECT_EQ(runSource("..."), "");
     // EllipsisFnBody
     EXPECT_EQ(runSource(
-        "function stub() -> Unit:\n"
+        "fn stub() -> Unit:\n"
         "    ...\n"
         "stub()\n"
         "print(1)"), "1\n");
@@ -1218,28 +1218,28 @@ TEST_F(CodeGenTest, EllipsisVariants) {
 TEST_F(CodeGenTest, ShortCircuitEvaluation) {
     // AndShortCircuitFalse
     EXPECT_EQ(runSource(
-        "function side_effect() -> bool:\n"
+        "fn side_effect() -> bool:\n"
         "    print(\"side\")\n"
         "    return true\n"
         "res = false and side_effect()\n"
         "print(res)"), "false\n");
     // AndShortCircuitTrue
     EXPECT_EQ(runSource(
-        "function side_effect() -> bool:\n"
+        "fn side_effect() -> bool:\n"
         "    print(\"side\")\n"
         "    return true\n"
         "res = true and side_effect()\n"
         "print(res)"), "side\ntrue\n");
     // OrShortCircuitTrue
     EXPECT_EQ(runSource(
-        "function side_effect() -> bool:\n"
+        "fn side_effect() -> bool:\n"
         "    print(\"side\")\n"
         "    return false\n"
         "res = true or side_effect()\n"
         "print(res)"), "true\n");
     // OrShortCircuitFalse
     EXPECT_EQ(runSource(
-        "function side_effect() -> bool:\n"
+        "fn side_effect() -> bool:\n"
         "    print(\"side\")\n"
         "    return true\n"
         "res = false or side_effect()\n"
@@ -1250,7 +1250,7 @@ TEST_F(CodeGenTest, ShortCircuitEvaluation) {
 
 TEST_F(CodeGenTest, DefaultArgBasic) {
     EXPECT_EQ(runSource(
-        "function greet(name: str, greeting: str = \"Hello\") -> str:\n"
+        "fn greet(name: str, greeting: str = \"Hello\") -> str:\n"
         "    return greeting + \", \" + name\n"
         "print(greet(\"Alice\"))\n"
         "print(greet(\"Alice\", \"Hi\"))"), "Hello, Alice\nHi, Alice\n");
@@ -1258,7 +1258,7 @@ TEST_F(CodeGenTest, DefaultArgBasic) {
 
 TEST_F(CodeGenTest, DefaultArgMultiple) {
     EXPECT_EQ(runSource(
-        "function f(a: int, b: int = 10, c: int = 20) -> int:\n"
+        "fn f(a: int, b: int = 10, c: int = 20) -> int:\n"
         "    return a + b + c\n"
         "print(f(1))\n"
         "print(f(1, 2))\n"
@@ -1267,23 +1267,23 @@ TEST_F(CodeGenTest, DefaultArgMultiple) {
 
 TEST_F(CodeGenTest, DefaultArgOverloadConflict) {
     EXPECT_THROW(runSource(
-        "function calc(x: int, y: int = 0) -> int:\n"
+        "fn calc(x: int, y: int = 0) -> int:\n"
         "    return x + y\n"
-        "function calc(x: int) -> int:\n"
+        "fn calc(x: int) -> int:\n"
         "    return x * 2\n"
         "print(calc(1))"), std::runtime_error);
 }
 
 TEST_F(CodeGenTest, DefaultArgWithWidening) {
     EXPECT_EQ(runSource(
-        "function calc(x: float, precision: int = 6) -> float:\n"
+        "fn calc(x: float, precision: int = 6) -> float:\n"
         "    return x\n"
         "print(calc(3))"), "3.0\n");
 }
 
 TEST_F(CodeGenTest, DefaultArgGenericError) {
     EXPECT_THROW(runSource(
-        "function identity<T>(x: T, label: str = \"default\") -> T:\n"
+        "fn identity<T>(x: T, label: str = \"default\") -> T:\n"
         "    return x\n"
         "print(identity(42))"), std::runtime_error);
 }

--- a/tests/test_codegen_type_safety.cpp
+++ b/tests/test_codegen_type_safety.cpp
@@ -332,7 +332,7 @@ TEST_F(CodeGenTest, ExitInFunctionBodyFollowedByStmtCompiles) {
     // exit(). Covers the CallStmt path (emitStmt(CallStmt) routes exit
     // through builtins_["exit"]).
     EXPECT_NO_THROW(compileSource(
-        "function f():\n"
+        "fn f():\n"
         "    exit(1)\n"
         "    print(\"dead\")\n"
         "f()\n"
@@ -347,17 +347,17 @@ TEST_F(CodeGenTest, ExitInFunctionBodyFollowedByStmtCompiles) {
 
 static const std::string JSON_DECLS = R"(
 @native("json")
-function parse(text: str) -> Result<JsonValue, Error>
+fn parse(text: str) -> Result<JsonValue, Error>
 @native("json")
-function stringify(value: JsonValue) -> str
+fn stringify(value: JsonValue) -> str
 @native("json")
-function kind(value: JsonValue) -> str
+fn kind(value: JsonValue) -> str
 @native("json")
-function get(value: JsonValue, key: str) -> Result<JsonValue, Error>
+fn get(value: JsonValue, key: str) -> Result<JsonValue, Error>
 @native("json")
-function to_str(value: JsonValue) -> Result<str, Error>
+fn to_str(value: JsonValue) -> Result<str, Error>
 @native("json")
-function json_free(value: JsonValue) -> Unit
+fn json_free(value: JsonValue) -> Unit
 )";
 
 TEST_F(CodeGenTest, JsonKindOnResultRejected) {
@@ -441,38 +441,38 @@ TEST_F(CodeGenTest, GenericResultToStrStillWorks) {
 // ============================================================
 
 TEST(FindMatchingCloseParen, Simple) {
-    // function(int) -> int
-    //         ^   ^
-    //         8   12
-    std::string s = "function(int) -> int";
-    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), 12u);
+    // fn(int) -> int
+    //   ^   ^
+    //   2   6
+    std::string s = "fn(int) -> int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 2), 6u);
 }
 
 TEST(FindMatchingCloseParen, Nested) {
-    // function(function() -> int) -> int
-    //         ^                 ^
-    //         8                 26
-    std::string s = "function(function() -> int) -> int";
-    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), 26u);
+    // fn(fn() -> int) -> int
+    //   ^              ^
+    //   2              14
+    std::string s = "fn(fn() -> int) -> int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 2), 14u);
 }
 
 TEST(FindMatchingCloseParen, DeeplyNested) {
-    // function(function(function() -> int) -> int) -> int
-    //         ^                                  ^
-    std::string s = "function(function(function() -> int) -> int) -> int";
-    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), 43u);
+    // fn(fn(fn() -> int) -> int) -> int
+    //   ^                        ^
+    std::string s = "fn(fn(fn() -> int) -> int) -> int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 2), 25u);
 }
 
 TEST(FindMatchingCloseParen, MultipleParamsWithNested) {
-    // function(int, function() -> int) -> int
-    //         ^                      ^
-    std::string s = "function(int, function() -> int) -> int";
-    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), 31u);
+    // fn(int, fn() -> int) -> int
+    //   ^                    ^
+    std::string s = "fn(int, fn() -> int) -> int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 2), 19u);
 }
 
 TEST(FindMatchingCloseParen, NoMatch) {
-    std::string s = "function(int";
-    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 8), std::string::npos);
+    std::string s = "fn(int";
+    ASSERT_EQ(CodeGen::findMatchingCloseParen(s, 2), std::string::npos);
 }
 
 // ============================================================
@@ -784,7 +784,7 @@ TEST_F(CodeGenTest, StrLiteralIndexAccessRejected) {
 
 TEST_F(CodeGenTest, StrFnReturnIndexAccessRejected) {
     expectCompileError(
-        "function f() -> str:\n"
+        "fn f() -> str:\n"
         "    return \"x\"\n"
         "_ = f()[0]\n",
         {"str", "char_at"});
@@ -799,7 +799,7 @@ TEST_F(CodeGenTest, StrIndexAssignmentRejected) {
 
 TEST_F(CodeGenTest, StrFnReturnVarIndexAssignmentRejected) {
     expectCompileError(
-        "function f() -> str:\n"
+        "fn f() -> str:\n"
         "    return \"x\"\n"
         "s = f()\n"
         "s[0] = \"y\"\n",
@@ -812,9 +812,9 @@ TEST_F(CodeGenTest, StrFnReturnVarIndexAssignmentRejected) {
 
 static const std::string IO_DECLS_1055 = R"(
 @native
-function bytes_to_str(bs: List<u8>) -> Result<str, Error>
+fn bytes_to_str(bs: List<u8>) -> Result<str, Error>
 @native
-function write_bytes(path: str, data: List<u8>) -> Result<Unit, Error>
+fn write_bytes(path: str, data: List<u8>) -> Result<Unit, Error>
 )";
 
 TEST_F(CodeGenTest, BytesToStrIntListRejected) {
@@ -923,7 +923,7 @@ print(length(bs))
 TEST_F(CodeGenTest, ListU8ModuleGlobalWriteThroughAccepted) {
     EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
 bs: List<u8> = [97, 0, 98]
-function update() -> int:
+fn update() -> int:
     bs = [99, 100, 101]
     return 0
 update()
@@ -957,7 +957,7 @@ print(length(bs))
 TEST_F(CodeGenTest, ListU8ModuleGlobalCompoundAssignmentAccepted) {
     EXPECT_NO_THROW(compileSource(IO_DECLS_1055 + R"(
 bs: List<u8> = [97]
-function update() -> int:
+fn update() -> int:
     bs += [99]
     return 0
 update()

--- a/tests/test_emit_llvm_ir.cpp
+++ b/tests/test_emit_llvm_ir.cpp
@@ -107,7 +107,7 @@ protected:
 
 TEST_F(EmitLlvmIrTest, ValidFileExitZero) {
     auto p = writeTmp("add.ry",
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "  return a + b\n");
     auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
     EXPECT_EQ(r.exit_code, 0);
@@ -115,7 +115,7 @@ TEST_F(EmitLlvmIrTest, ValidFileExitZero) {
 
 TEST_F(EmitLlvmIrTest, OutputContainsModuleId) {
     auto p = writeTmp("add.ry",
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "  return a + b\n");
     auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
     EXPECT_NE(r.out.find("ModuleID"), std::string::npos);
@@ -123,7 +123,7 @@ TEST_F(EmitLlvmIrTest, OutputContainsModuleId) {
 
 TEST_F(EmitLlvmIrTest, OutputContainsFunctionDefine) {
     auto p = writeTmp("add.ry",
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "  return a + b\n");
     auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
     EXPECT_NE(r.out.find("define"), std::string::npos);
@@ -133,7 +133,7 @@ TEST_F(EmitLlvmIrTest, UnoptimizedIrRetainsAlloca) {
     // Unoptimized IR keeps alloca/store/load for function arguments.
     // Post-opt IR would mem2reg these away; --emit-llvm-ir must not run opt.
     auto p = writeTmp("add.ry",
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "  return a + b\n");
     auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
     EXPECT_NE(r.out.find("alloca"), std::string::npos);
@@ -144,7 +144,7 @@ TEST_F(EmitLlvmIrTest, DoesNotExecuteProgram) {
     // aborts with a non-zero exit and stderr output.  With --emit-llvm-ir,
     // codegen must succeed and execution must be skipped entirely.
     auto p = writeTmp("noop.ry",
-        "function main():\n"
+        "fn main():\n"
         "  x: int = 9223372036854775807\n"
         "  x = x + 1\n");
     auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
@@ -162,7 +162,7 @@ TEST_F(EmitLlvmIrTest, NonexistentFileExitNonzero) {
 }
 
 TEST_F(EmitLlvmIrTest, SyntaxErrorExitNonzero) {
-    auto p = writeTmp("bad.ry", "function bad( -> int:\n  return 0\n");
+    auto p = writeTmp("bad.ry", "fn bad( -> int:\n  return 0\n");
     auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
     EXPECT_NE(r.exit_code, 0);
     EXPECT_FALSE(r.err.empty());
@@ -170,7 +170,7 @@ TEST_F(EmitLlvmIrTest, SyntaxErrorExitNonzero) {
 
 TEST_F(EmitLlvmIrTest, SyntaxErrorStdoutEmpty) {
     // On error, no partial IR should appear on stdout.
-    auto p = writeTmp("bad.ry", "function bad( -> int:\n  return 0\n");
+    auto p = writeTmp("bad.ry", "fn bad( -> int:\n  return 0\n");
     auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
     EXPECT_TRUE(r.out.empty());
 }

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -79,7 +79,7 @@ TEST(Formatter, StatementFormatting) {
     EXPECT_EQ(fmt("from .\n"), "from .\n");
     // Return
     {
-        auto src = "function f() -> int:\n    return 42\n";
+        auto src = "fn f() -> int:\n    return 42\n";
         auto out = fmt(src);
         EXPECT_NE(out.find("  return 42"), std::string::npos);
     }
@@ -110,19 +110,19 @@ TEST(Formatter, StatementFormatting) {
 TEST(Formatter, IndentationLevels) {
     // Function indent (2-space)
     {
-        auto src = "function add(a: int, b: int) -> int:\n    return a + b\n";
-        auto expected = "function add(a: int, b: int) -> int:\n  return a + b\n";
+        auto src = "fn add(a: int, b: int) -> int:\n    return a + b\n";
+        auto expected = "fn add(a: int, b: int) -> int:\n  return a + b\n";
         EXPECT_EQ(fmt(src), expected);
     }
     // Nested indent
     {
         auto src =
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "    if x > 0:\n"
             "        return x\n"
             "    return 0\n";
         auto expected =
-            "function f(x: int) -> int:\n"
+            "fn f(x: int) -> int:\n"
             "  if x > 0:\n"
             "    return x\n"
             "  return 0\n";
@@ -131,13 +131,13 @@ TEST(Formatter, IndentationLevels) {
     // Deeply nested
     {
         auto src =
-            "function f() -> int:\n"
+            "fn f() -> int:\n"
             "    if true:\n"
             "        while true:\n"
             "            return 1\n"
             "    return 0\n";
         auto expected =
-            "function f() -> int:\n"
+            "fn f() -> int:\n"
             "  if true:\n"
             "    while true:\n"
             "      return 1\n"
@@ -252,18 +252,18 @@ TEST(Formatter, ControlFlow) {
 TEST(Formatter, FunctionVariants) {
     // Async function
     {
-        auto src = "async function fetch() -> int:\n    return 42\n";
-        auto expected = "async function fetch() -> int:\n  return 42\n";
+        auto src = "async fn fetch() -> int:\n    return 42\n";
+        auto expected = "async fn fetch() -> int:\n  return 42\n";
         EXPECT_EQ(fmt(src), expected);
     }
     // Operator overload
     {
         auto src =
             "record Vec2:\n    x: float\n    y: float\n\n"
-            "function operator+(a: Vec2, b: Vec2) -> Vec2:\n"
+            "fn operator+(a: Vec2, b: Vec2) -> Vec2:\n"
             "    return Vec2(a.x + b.x, a.y + b.y)\n";
         auto out = fmt(src);
-        EXPECT_NE(out.find("function operator+(a: Vec2, b: Vec2) -> Vec2:"), std::string::npos);
+        EXPECT_NE(out.find("fn operator+(a: Vec2, b: Vec2) -> Vec2:"), std::string::npos);
         EXPECT_NE(out.find("  return Vec2(a.x + b.x, a.y + b.y)"), std::string::npos);
     }
 }
@@ -287,12 +287,12 @@ TEST(Formatter, CommentFormatting) {
     // Comment between functions
     {
         auto src =
-            "function a() -> int:\n"
+            "fn a() -> int:\n"
             "    return 1\n"
             "\n"
             "# separator\n"
             "\n"
-            "function b() -> int:\n"
+            "fn b() -> int:\n"
             "    return 2\n";
         auto out = fmt(src);
         EXPECT_NE(out.find("# separator"), std::string::npos);
@@ -313,28 +313,28 @@ TEST(Formatter, CommentFormatting) {
 TEST(Formatter, NativeDirectiveFormatting) {
     // Basic native directive
     {
-        auto src = "@native\nfunction append(values: List<int>, value: int) -> Unit\n";
+        auto src = "@native\nfn append(values: List<int>, value: int) -> Unit\n";
         auto out = fmt(src);
         EXPECT_NE(out.find("@native"), std::string::npos);
-        EXPECT_NE(out.find("function append("), std::string::npos);
+        EXPECT_NE(out.find("fn append("), std::string::npos);
     }
     // Native bang function
     {
-        auto src = "@native\nfunction sort!(values: List<int>) -> Unit\n";
+        auto src = "@native\nfn sort!(values: List<int>) -> Unit\n";
         auto out = fmt(src);
         EXPECT_NE(out.find("@native"), std::string::npos);
-        EXPECT_NE(out.find("function sort!(values: List<int>) -> Unit"), std::string::npos);
+        EXPECT_NE(out.find("fn sort!(values: List<int>) -> Unit"), std::string::npos);
     }
     // Native function has no colon
     {
-        auto src = "@native\nfunction append(values: List<int>, value: int) -> Unit\n";
+        auto src = "@native\nfn append(values: List<int>, value: int) -> Unit\n";
         auto out = fmt(src);
-        EXPECT_NE(out.find("function append(values: List<int>, value: int) -> Unit\n"), std::string::npos);
+        EXPECT_NE(out.find("fn append(values: List<int>, value: int) -> Unit\n"), std::string::npos);
         EXPECT_EQ(out.find("-> Unit:"), std::string::npos);
     }
     // Native function has no body
     {
-        auto src = "@native\nfunction pop(values: List<int>) -> Option<int>\n";
+        auto src = "@native\nfn pop(values: List<int>) -> Option<int>\n";
         auto out = fmt(src);
         EXPECT_EQ(out.find("-> Option<int>:"), std::string::npos);
         EXPECT_NE(out.find("-> Option<int>\n"), std::string::npos);
@@ -350,11 +350,11 @@ TEST(Formatter, NativeDirectiveFormatting) {
     {
         auto src =
             "@native\n"
-            "function read_all() -> str\n"
+            "fn read_all() -> str\n"
             "\n"
             "# File I/O\n"
             "@native\n"
-            "function read_text(path: str) -> str\n";
+            "fn read_text(path: str) -> str\n";
         std::string out = fmt(src);
         EXPECT_EQ(out.find("\n\n\n"), std::string::npos)
             << "Found triple newline (double blank line) in:\n" << out;
@@ -372,7 +372,7 @@ TEST(Formatter, NativeDirectiveFormatting) {
 TEST(Formatter, NativeLibraryDirectiveRoundTrip) {
     // @native("base64") round-trips correctly
     {
-        std::string src = "@native(\"base64\")\nfunction encode(data: str) -> str\n";
+        std::string src = "@native(\"base64\")\nfn encode(data: str) -> str\n";
         auto out = fmt(src);
         EXPECT_NE(out.find("@native(\"base64\")"), std::string::npos)
             << "Expected @native(\"base64\") in:\n" << out;
@@ -381,7 +381,7 @@ TEST(Formatter, NativeLibraryDirectiveRoundTrip) {
     }
     // @inline(mode="always") — value is a string literal, quotes preserved
     {
-        std::string src = "@inline(mode=\"always\")\nfunction add(a: int, b: int) -> int:\n    return a + b\n";
+        std::string src = "@inline(mode=\"always\")\nfn add(a: int, b: int) -> int:\n    return a + b\n";
         auto out = fmt(src);
         EXPECT_NE(out.find("@inline(mode=\"always\")"), std::string::npos)
             << "Expected @inline(mode=\"always\") in:\n" << out;
@@ -389,7 +389,7 @@ TEST(Formatter, NativeLibraryDirectiveRoundTrip) {
     }
     // @deprecated(reason="use new_func") — string value keeps quotes
     {
-        std::string src = "@deprecated(reason=\"use new_func\")\nfunction old() -> int:\n    return 1\n";
+        std::string src = "@deprecated(reason=\"use new_func\")\nfn old() -> int:\n    return 1\n";
         auto out = fmt(src);
         EXPECT_NE(out.find("@deprecated(reason=\"use new_func\")"), std::string::npos)
             << "Expected quoted reason in:\n" << out;
@@ -397,7 +397,7 @@ TEST(Formatter, NativeLibraryDirectiveRoundTrip) {
     }
     // String value with escape sequences round-trips correctly
     {
-        std::string src = "@deprecated(reason=\"has \\\"quotes\\\" inside\")\nfunction old() -> int:\n    return 1\n";
+        std::string src = "@deprecated(reason=\"has \\\"quotes\\\" inside\")\nfn old() -> int:\n    return 1\n";
         auto out = fmt(src);
         EXPECT_NE(out.find("@deprecated(reason=\"has \\\"quotes\\\" inside\")"), std::string::npos)
             << "Expected escaped quotes in:\n" << out;
@@ -409,12 +409,12 @@ TEST(Formatter, NativeLibraryDirectiveRoundTrip) {
 
 TEST(Formatter, BlankLineBetweenDefs) {
     auto src =
-        "function a() -> int:\n"
+        "fn a() -> int:\n"
         "    return 1\n"
-        "function b() -> int:\n"
+        "fn b() -> int:\n"
         "    return 2\n";
     auto out = fmt(src);
-    EXPECT_NE(out.find("  return 1\n\nfunction b"), std::string::npos);
+    EXPECT_NE(out.find("  return 1\n\nfn b"), std::string::npos);
 }
 
 // ===== Lambda / Trailing Block Tests =====
@@ -441,7 +441,7 @@ TEST(Formatter, LambdaAndTrailingBlock) {
     // Expect statement
     {
         auto src =
-            "function id(x: int) -> int:\n"
+            "fn id(x: int) -> int:\n"
             "    return x\n"
             "\n"
             "describe(\"t\", ():\n"
@@ -460,10 +460,10 @@ TEST(Formatter, RoundTripAndIdempotency) {
     // Basic idempotency
     {
         auto src =
-            "function add(a: int, b: int) -> int:\n"
+            "fn add(a: int, b: int) -> int:\n"
             "  return a + b\n"
             "\n"
-            "function sub(a: int, b: int) -> int:\n"
+            "fn sub(a: int, b: int) -> int:\n"
             "  return a - b\n";
         auto first = fmt(src);
         auto second = fmt(first);
@@ -536,7 +536,7 @@ TEST(FormatterTest, ParenTupleDestructRoundTrip) {
 }
 
 TEST(FormatterTest, DefaultArgRoundTrip) {
-    auto src = "function greet(name: str, greeting: str = \"Hello\") -> str:\n  return greeting\n";
+    auto src = "fn greet(name: str, greeting: str = \"Hello\") -> str:\n  return greeting\n";
     auto first = Formatter::formatSource(src);
     EXPECT_EQ(first, src);
     auto second = Formatter::formatSource(first);

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -142,11 +142,11 @@ TEST(LexerTest, KeywordRecognition) {
         EXPECT_EQ(toks[0].kind, TokenKind::While);
         EXPECT_EQ(toks[0].value, "while");
     }
-    // function
+    // `function` is not a keyword — lexes as Ident (alias removed; use `fn`)
     {
         auto toks = tokenize("function");
         ASSERT_EQ(toks.size(), 2u);
-        EXPECT_EQ(toks[0].kind, TokenKind::Fn);
+        EXPECT_EQ(toks[0].kind, TokenKind::Ident);
         EXPECT_EQ(toks[0].value, "function");
     }
     // fn

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -549,14 +549,12 @@ TEST(ParserTest, FnSimple) {
     EXPECT_TRUE(std::holds_alternative<ReturnStmt>(function.body[0]));
 }
 
-TEST(ParserTest, FunctionKeywordSimple) {
-    Program prog = parseStr("fn add(a: int, b: int) -> int:\n    return a + b");
-    ASSERT_EQ(prog.size(), 1u);
-    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FnStmt>>(prog[0]));
-    const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
-    EXPECT_EQ(function.name, "add");
-    ASSERT_EQ(function.params.size(), 2u);
-    EXPECT_EQ(function.return_type->toString(), "int");
+TEST(ParserTest, LegacyFunctionKeywordRejectedInDeclaration) {
+    EXPECT_THROW(parseStr("function add(a: int, b: int) -> int:\n    return a + b"), std::runtime_error);
+}
+
+TEST(ParserTest, LegacyFunctionKeywordRejectedInFnType) {
+    EXPECT_THROW(parseStr("type Callback = function(int, int) -> int"), std::runtime_error);
 }
 
 TEST(ParserTest, FnIdentifierIsRejected) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -534,7 +534,7 @@ TEST(ParserTest, WhileMissingColonThrows) {
 // ===== function / return / CallExpr パーサーテスト =====
 
 TEST(ParserTest, FnSimple) {
-    Program prog = parseStr("function add(a: int, b: int) -> int:\n    return a + b");
+    Program prog = parseStr("fn add(a: int, b: int) -> int:\n    return a + b");
     ASSERT_EQ(prog.size(), 1u);
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FnStmt>>(prog[0]));
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
@@ -550,7 +550,7 @@ TEST(ParserTest, FnSimple) {
 }
 
 TEST(ParserTest, FunctionKeywordSimple) {
-    Program prog = parseStr("function add(a: int, b: int) -> int:\n    return a + b");
+    Program prog = parseStr("fn add(a: int, b: int) -> int:\n    return a + b");
     ASSERT_EQ(prog.size(), 1u);
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FnStmt>>(prog[0]));
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
@@ -564,7 +564,7 @@ TEST(ParserTest, FnIdentifierIsRejected) {
 }
 
 TEST(ParserTest, ReturnStatement) {
-    Program prog = parseStr("function f() -> int:\n    return 42");
+    Program prog = parseStr("fn f() -> int:\n    return 42");
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(function.body.size(), 1u);
     ASSERT_TRUE(std::holds_alternative<ReturnStmt>(function.body[0]));
@@ -584,17 +584,17 @@ TEST(ParserTest, CallExprInLet) {
 }
 
 TEST(ParserTest, FnMissingColonThrows) {
-    EXPECT_THROW(parseStr("function f() -> int\n    return 1"), std::runtime_error);
+    EXPECT_THROW(parseStr("fn f() -> int\n    return 1"), std::runtime_error);
 }
 
 TEST(ParserTest, FnMissingArrowWithTypeThrows) {
     // function f() int: → missing '->' before type, "int" is not ':'
-    EXPECT_THROW(parseStr("function f() int:\n    return 1"), std::runtime_error);
+    EXPECT_THROW(parseStr("fn f() int:\n    return 1"), std::runtime_error);
 }
 
 TEST(ParserTest, FnReturnTypeOmitted) {
     // function f(): → return type defaults to "" (inferred at codegen)
-    Program prog = parseStr("function f():\n    return");
+    Program prog = parseStr("fn f():\n    return");
     ASSERT_EQ(prog.size(), 1u);
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(function.name, "f");
@@ -606,7 +606,7 @@ TEST(ParserTest, FnReturnTypeOmitted) {
 }
 
 TEST(ParserTest, FnExplicitUnitReturn) {
-    Program prog = parseStr("function f() -> Unit:\n    return");
+    Program prog = parseStr("fn f() -> Unit:\n    return");
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(function.return_type->toString(), "Unit");
 }
@@ -650,14 +650,14 @@ TEST(ParserTest, TypeAnnotationOptionInt) {
 }
 
 TEST(ParserTest, FnParamOptionType) {
-    Program prog = parseStr("function f(x: Option<int>) -> int:\n    return 0");
+    Program prog = parseStr("fn f(x: Option<int>) -> int:\n    return 0");
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(function.params.size(), 1u);
     EXPECT_EQ(function.params[0].type->toString(), "Option<int>");
 }
 
 TEST(ParserTest, FnReturnOptionType) {
-    Program prog = parseStr("function f() -> Option<int>:\n    return Some(1)");
+    Program prog = parseStr("fn f() -> Option<int>:\n    return Some(1)");
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(function.return_type->toString(), "Option<int>");
 }
@@ -833,7 +833,7 @@ TEST(ParserTest, TupleIndexAccess) {
 }
 
 TEST(ParserTest, FnReturnTupleType) {
-    Program prog = parseStr("function swap(a: int, b: int) -> (int, int):\n    return (b, a)");
+    Program prog = parseStr("fn swap(a: int, b: int) -> (int, int):\n    return (b, a)");
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(function.return_type->toString(), "(int, int)");
 }
@@ -1074,7 +1074,7 @@ TEST(ParserTest, MapTypeAnnotation) {
 
 TEST(ParserTest, OperatorFnBinaryPlus) {
     std::string src =
-        "function operator+(a: Vec2, b: Vec2) -> Vec2:\n"
+        "fn operator+(a: Vec2, b: Vec2) -> Vec2:\n"
         "    return a\n";
     Program prog = parseStr(src);
     ASSERT_EQ(prog.size(), 1u);
@@ -1092,7 +1092,7 @@ TEST(ParserTest, OperatorFnBinaryPlus) {
 
 TEST(ParserTest, OperatorFnUnaryMinus) {
     std::string src =
-        "function operator-(a: Vec2) -> Vec2:\n"
+        "fn operator-(a: Vec2) -> Vec2:\n"
         "    return a\n";
     Program prog = parseStr(src);
     ASSERT_EQ(prog.size(), 1u);
@@ -1104,7 +1104,7 @@ TEST(ParserTest, OperatorFnUnaryMinus) {
 
 TEST(ParserTest, OperatorFnEqEq) {
     std::string src =
-        "function operator==(a: Vec2, b: Vec2) -> bool:\n"
+        "fn operator==(a: Vec2, b: Vec2) -> bool:\n"
         "    return true\n";
     Program prog = parseStr(src);
     const auto &function = std::get<std::unique_ptr<FnStmt>>(prog[0]);
@@ -1115,7 +1115,7 @@ TEST(ParserTest, OperatorFnEqEq) {
 TEST(ParserTest, OperatorFnTildeUnaryOnly) {
     // ~ with 2 params should fail
     std::string src =
-        "function operator~(a: int, b: int) -> int:\n"
+        "fn operator~(a: int, b: int) -> int:\n"
         "    return a\n";
     EXPECT_THROW(parseStr(src), std::runtime_error);
 }
@@ -1123,7 +1123,7 @@ TEST(ParserTest, OperatorFnTildeUnaryOnly) {
 TEST(ParserTest, OperatorFnInvalidParamCount) {
     // Binary operator with 0 params should fail
     std::string src =
-        "function operator+() -> int:\n"
+        "fn operator+() -> int:\n"
         "    return 0\n";
     EXPECT_THROW(parseStr(src), std::runtime_error);
 }
@@ -1132,127 +1132,127 @@ TEST(ParserTest, OperatorFnInvalidParamCount) {
 
 TEST(ParserTest, OperatorEqMustReturnBool) {
     EXPECT_THROW(parseStr(
-        "function operator==(a: int, b: int) -> int:\n"
+        "fn operator==(a: int, b: int) -> int:\n"
         "    return 42\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorNeqMustReturnBool) {
     EXPECT_THROW(parseStr(
-        "function operator!=(a: int, b: int) -> str:\n"
+        "fn operator!=(a: int, b: int) -> str:\n"
         "    return \"no\"\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorLessMustReturnBool) {
     EXPECT_THROW(parseStr(
-        "function operator<(a: int, b: int) -> int:\n"
+        "fn operator<(a: int, b: int) -> int:\n"
         "    return 0\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorLessEqMustReturnBool) {
     EXPECT_THROW(parseStr(
-        "function operator<=(a: int, b: int) -> int:\n"
+        "fn operator<=(a: int, b: int) -> int:\n"
         "    return 0\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorGreaterMustReturnBool) {
     EXPECT_THROW(parseStr(
-        "function operator>(a: int, b: int) -> int:\n"
+        "fn operator>(a: int, b: int) -> int:\n"
         "    return 0\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorGreaterEqMustReturnBool) {
     EXPECT_THROW(parseStr(
-        "function operator>=(a: int, b: int) -> int:\n"
+        "fn operator>=(a: int, b: int) -> int:\n"
         "    return 0\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorNotMustReturnBool) {
     EXPECT_THROW(parseStr(
-        "function operator not(a: int) -> int:\n"
+        "fn operator not(a: int) -> int:\n"
         "    return 0\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorAndMustReturnBool) {
     EXPECT_THROW(parseStr(
-        "function operator and(a: int, b: int) -> int:\n"
+        "fn operator and(a: int, b: int) -> int:\n"
         "    return 0\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorOrMustReturnBool) {
     EXPECT_THROW(parseStr(
-        "function operator or(a: int, b: int) -> int:\n"
+        "fn operator or(a: int, b: int) -> int:\n"
         "    return 0\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorEqReturnBoolOk) {
     Program prog = parseStr(
-        "function operator==(a: int, b: int) -> bool:\n"
+        "fn operator==(a: int, b: int) -> bool:\n"
         "    return true\n");
     EXPECT_EQ(prog.size(), 1u);
 }
 
 TEST(ParserTest, OperatorPlusReturnsNonBoolOk) {
     Program prog = parseStr(
-        "function operator+(a: int, b: int) -> int:\n"
+        "fn operator+(a: int, b: int) -> int:\n"
         "    return a + b\n");
     EXPECT_EQ(prog.size(), 1u);
 }
 
 TEST(ParserTest, OperatorPlusRejectsSpaceForm) {
     EXPECT_THROW(parseStr(
-        "function operator +(a: int, b: int) -> int:\n"
+        "fn operator +(a: int, b: int) -> int:\n"
         "    return a + b\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorEqEqRejectsSpaceForm) {
     EXPECT_THROW(parseStr(
-        "function operator ==(a: int, b: int) -> bool:\n"
+        "fn operator ==(a: int, b: int) -> bool:\n"
         "    return true\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorPlusEqRejectsSpaceForm) {
     EXPECT_THROW(parseStr(
-        "function operator +=(a: int, b: int) -> int:\n"
+        "fn operator +=(a: int, b: int) -> int:\n"
         "    return a + b\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorTildeRejectsSpaceForm) {
     EXPECT_THROW(parseStr(
-        "function operator ~(a: int) -> int:\n"
+        "fn operator ~(a: int) -> int:\n"
         "    return a\n"), std::runtime_error);
 }
 
 TEST(ParserTest, OperatorAndKeywordAcceptsSpaceForm) {
     Program prog = parseStr(
-        "function operator and(a: bool, b: bool) -> bool:\n"
+        "fn operator and(a: bool, b: bool) -> bool:\n"
         "    return a\n");
     EXPECT_EQ(prog.size(), 1u);
 }
 
 TEST(ParserTest, OperatorInKeywordAcceptsSpaceForm) {
     Program prog = parseStr(
-        "function operator in(a: int, b: int) -> bool:\n"
+        "fn operator in(a: int, b: int) -> bool:\n"
         "    return true\n");
     EXPECT_EQ(prog.size(), 1u);
 }
 
 TEST(ParserTest, OperatorOrKeywordAcceptsSpaceForm) {
     Program prog = parseStr(
-        "function operator or(a: bool, b: bool) -> bool:\n"
+        "fn operator or(a: bool, b: bool) -> bool:\n"
         "    return a\n");
     EXPECT_EQ(prog.size(), 1u);
 }
 
 TEST(ParserTest, OperatorNotKeywordAcceptsSpaceForm) {
     Program prog = parseStr(
-        "function operator not(a: bool) -> bool:\n"
+        "fn operator not(a: bool) -> bool:\n"
         "    return a\n");
     EXPECT_EQ(prog.size(), 1u);
 }
 
 TEST(ParserTest, OperatorAsKeywordAcceptsSpaceForm) {
     Program prog = parseStr(
-        "function operator as(a: int) -> bool:\n"
+        "fn operator as(a: int) -> bool:\n"
         "    return true\n");
     EXPECT_EQ(prog.size(), 1u);
 }
@@ -1308,7 +1308,7 @@ TEST(ParserTest, DecrementPreservesCompoundOp) {
 
 TEST(ParserTest, OperatorFnCompoundPlusEq) {
     std::string src =
-        "function operator+=(a: Vec2, b: Vec2) -> Vec2:\n"
+        "fn operator+=(a: Vec2, b: Vec2) -> Vec2:\n"
         "    return a\n";
     Program prog = parseStr(src);
     ASSERT_EQ(prog.size(), 1u);
@@ -1324,7 +1324,7 @@ TEST(ParserTest, OperatorFnCompoundPlusEq) {
 
 TEST(ParserTest, OperatorFnCompoundAssignRequiresTwoParams) {
     EXPECT_THROW(
-        parseStr("function operator+=(a: Vec2) -> Vec2:\n    return a\n"),
+        parseStr("fn operator+=(a: Vec2) -> Vec2:\n    return a\n"),
         std::runtime_error);
 }
 
@@ -1428,14 +1428,14 @@ TEST(ParserTest, LetUnionTypeAnnotation) {
 }
 
 TEST(ParserTest, FnUnionParam) {
-    Program prog = parseStr("function f(x: int | str) -> int:\n    return 0");
+    Program prog = parseStr("fn f(x: int | str) -> int:\n    return 0");
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(function.params.size(), 1u);
     EXPECT_EQ(function.params[0].type->toString(), "int | str");
 }
 
 TEST(ParserTest, FnUnionReturn) {
-    Program prog = parseStr("function f() -> int | str:\n    return 0");
+    Program prog = parseStr("fn f() -> int | str:\n    return 0");
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(function.return_type->toString(), "int | str");
 }
@@ -1487,7 +1487,7 @@ TEST(ParserTest, UnionThreeTypes) {
 
 TEST(ParserTest, FnWithRequire) {
     std::string src =
-        "function deposit(amount: int) -> int:\n"
+        "fn deposit(amount: int) -> int:\n"
         "    require:\n"
         "        amount > 0\n"
         "    return amount";
@@ -1502,7 +1502,7 @@ TEST(ParserTest, FnWithRequire) {
 
 TEST(ParserTest, FnWithEnsure) {
     std::string src =
-        "function abs(x: int) -> int:\n"
+        "fn abs(x: int) -> int:\n"
         "    ensure v:\n"
         "        v >= 0\n"
         "    if x < 0:\n"
@@ -1518,7 +1518,7 @@ TEST(ParserTest, FnWithEnsure) {
 
 TEST(ParserTest, FnWithRequireAndEnsure) {
     std::string src =
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    require:\n"
         "        a >= 0\n"
         "        b >= 0\n"
@@ -1536,7 +1536,7 @@ TEST(ParserTest, FnWithRequireAndEnsure) {
 
 TEST(ParserTest, FnWithoutContract) {
     std::string src =
-        "function add(a: int, b: int) -> int:\n"
+        "fn add(a: int, b: int) -> int:\n"
         "    return a + b";
     Program prog = parseStr(src);
     auto &function = std::get<std::unique_ptr<FnStmt>>(prog[0]);
@@ -1571,7 +1571,7 @@ TEST(ParserTest, TypeWithoutInvariant) {
 
 TEST(ParserTest, EnsureVariableBinding) {
     std::string src =
-        "function inc(x: int) -> int:\n"
+        "fn inc(x: int) -> int:\n"
         "    ensure v:\n"
         "        v == x + 1\n"
         "    return x + 1";
@@ -1592,7 +1592,7 @@ TEST(ParserTest, EnsureVariableBinding) {
 
 TEST(ParserTest, EnsureTupleBinding) {
     std::string src =
-        "function divide(a: int, b: int) -> (int, int):\n"
+        "fn divide(a: int, b: int) -> (int, int):\n"
         "    ensure q, r:\n"
         "        q >= 0\n"
         "    return (a // b, a % b)";
@@ -1699,7 +1699,7 @@ TEST(ParserTest, ParallelForDirectiveParsing) {
 }
 
 TEST(ParserTest, AsyncFnParsing) {
-    Program prog = parseStr("async function add(a: int, b: int) -> int:\n    return a + b");
+    Program prog = parseStr("async fn add(a: int, b: int) -> int:\n    return a + b");
     ASSERT_EQ(prog.size(), 1u);
     auto &function = std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_TRUE(function->is_async);
@@ -1717,9 +1717,9 @@ TEST(ParserTest, AsyncFnCanonicalParsing) {
 }
 
 TEST(ParserTest, AwaitExprParsing) {
-    // await inside async function should parse successfully
+    // await inside async fn should parse successfully
     Program prog = parseStr(
-        "async function do_fetch() -> int:\n"
+        "async fn do_fetch() -> int:\n"
         "    x = await fetch()\n"
         "    return x");
     ASSERT_EQ(prog.size(), 1u);
@@ -1735,9 +1735,9 @@ TEST(ParserTest, AwaitExprParsing) {
 }
 
 TEST(ParserTest, AwaitStatementParsing) {
-    // await as statement inside async function
+    // await as statement inside async fn
     Program prog = parseStr(
-        "async function do_fetch() -> Unit:\n"
+        "async fn do_fetch() -> Unit:\n"
         "    await fetch()");
     ASSERT_EQ(prog.size(), 1u);
     auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
@@ -1751,12 +1751,12 @@ TEST(ParserTest, AwaitStatementParsing) {
 }
 
 TEST(ParserTest, AwaitOutsideAsyncFnRejected) {
-    // await outside async function should fail
+    // await outside async fn should fail
     EXPECT_THROW(parseStr("x = await fetch()"), std::runtime_error);
     EXPECT_THROW(parseStr("await fetch()"), std::runtime_error);
-    // await inside lambda within async function should also fail (lambda is not async)
+    // await inside lambda within async fn should also fail (lambda is not async)
     EXPECT_THROW(parseStr(
-        "async function foo() -> int:\n"
+        "async fn foo() -> int:\n"
         "    f = (x: int) => await bar()\n"
         "    return 1"), std::runtime_error);
 }
@@ -1809,18 +1809,18 @@ TEST(ParserTest, VariableAssignmentAcceptsCamelCase) {
 }
 
 TEST(ParserTest, SnakeCaseFunctionRequired) {
-    EXPECT_THROW(parseStr("function myFunc() -> int:\n    return 1"), std::runtime_error);
+    EXPECT_THROW(parseStr("fn myFunc() -> int:\n    return 1"), std::runtime_error);
 }
 
 TEST(ParserTest, BangSuffixFunctionAccepted) {
-    Program prog = parseStr("@native\nfunction sort!(values: List<int>) -> Unit");
+    Program prog = parseStr("@native\nfn sort!(values: List<int>) -> Unit");
     ASSERT_EQ(prog.size(), 1u);
     auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(function.name, "sort!");
 }
 
 TEST(ParserTest, BangSuffixNonNativeFunctionAccepted) {
-    Program prog = parseStr("function clear!(xs: List<int>) -> Unit:\n    ...");
+    Program prog = parseStr("fn clear!(xs: List<int>) -> Unit:\n    ...");
     ASSERT_EQ(prog.size(), 1u);
     auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(function.name, "clear!");
@@ -1938,7 +1938,7 @@ TEST(ParserTest, PascalCaseTypeAliasRequired) {
 }
 
 TEST(ParserTest, TypeAliasFnType) {
-    Program prog = parseStr("type Callback = function(int, int) -> int");
+    Program prog = parseStr("type Callback = fn(int, int) -> int");
     auto &ta = std::get<TypeAliasStmt>(prog[0]);
     EXPECT_EQ(ta.name, "Callback");
     EXPECT_EQ(ta.target_type->toString(), "fn(int, int) -> int");
@@ -1956,11 +1956,11 @@ TEST(ParserTest, SnakeCaseForLoopVariable) {
 }
 
 TEST(ParserTest, SnakeCaseParamRequired) {
-    EXPECT_THROW(parseStr("function add(myNum: int) -> int:\n    return myNum"), std::runtime_error);
+    EXPECT_THROW(parseStr("fn add(myNum: int) -> int:\n    return myNum"), std::runtime_error);
 }
 
 TEST(ParserTest, BangSuffixParamRejected) {
-    EXPECT_THROW(parseStr("function add(x!: int) -> int:\n    return x!"), std::runtime_error);
+    EXPECT_THROW(parseStr("fn add(x!: int) -> int:\n    return x!"), std::runtime_error);
 }
 
 // ===== expect マッチャー =====
@@ -2033,10 +2033,10 @@ TEST(ParserTest, TrailingBlockUFCS) {
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(s.args[1]->data));
 }
 
-// ===== @native function tests =====
+// ===== @native fn tests =====
 
 TEST(ParserTest, NativeFnDeclaration) {
-    Program prog = parseStr("@native\nfunction contains(s: str, sub: str) -> bool\n");
+    Program prog = parseStr("@native\nfn contains(s: str, sub: str) -> bool\n");
     ASSERT_EQ(prog.size(), 1u);
     auto &fs = std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(fs->name, "contains");
@@ -2048,7 +2048,7 @@ TEST(ParserTest, NativeFnDeclaration) {
 }
 
 TEST(ParserTest, NativeFnOperatorDeclaration) {
-    Program prog = parseStr("@native\nfunction operator+(a: int, b: int) -> int\n");
+    Program prog = parseStr("@native\nfn operator+(a: int, b: int) -> int\n");
     ASSERT_EQ(prog.size(), 1u);
     auto &fs = std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(fs->name, "operator+");
@@ -2065,7 +2065,7 @@ TEST(ParserTest, EllipsisTopLevel) {
 }
 
 TEST(ParserTest, EllipsisInFnBody) {
-    Program prog = parseStr("function stub():\n    ...\n");
+    Program prog = parseStr("fn stub():\n    ...\n");
     ASSERT_EQ(prog.size(), 1u);
     auto &fs = std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(fs->body.size(), 1u);
@@ -2082,7 +2082,7 @@ TEST(ParserTest, EllipsisInIfBody) {
 
 TEST(ParserTest, NativeFnWithColonError) {
     EXPECT_THROW({
-        parseStr("@native\nfunction bad() -> int:\n    return 1\n");
+        parseStr("@native\nfn bad() -> int:\n    return 1\n");
     }, std::runtime_error);
 }
 
@@ -2165,7 +2165,7 @@ TEST(ParserTest, ModerateNestingSucceeds) {
 // ===== Default arguments =====
 
 TEST(ParserTest, DefaultArgBasic) {
-    Program prog = parseStr("function f(x: int, y: int = 10) -> int:\n    return x + y");
+    Program prog = parseStr("fn f(x: int, y: int = 10) -> int:\n    return x + y");
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(function.params.size(), 2u);
     EXPECT_EQ(function.params[0].name, "x");
@@ -2175,7 +2175,7 @@ TEST(ParserTest, DefaultArgBasic) {
 }
 
 TEST(ParserTest, DefaultArgMultiple) {
-    Program prog = parseStr("function f(a: int, b: int = 1, c: int = 2) -> int:\n    return a");
+    Program prog = parseStr("fn f(a: int, b: int = 1, c: int = 2) -> int:\n    return a");
     const auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(function.params.size(), 3u);
     EXPECT_FALSE(function.params[0].default_value);
@@ -2185,12 +2185,12 @@ TEST(ParserTest, DefaultArgMultiple) {
 
 TEST(ParserTest, DefaultArgNonTrailingError) {
     // default arg followed by non-default arg is a parse error
-    EXPECT_THROW(parseStr("function f(a: int = 0, b: int) -> int:\n    return a"), std::runtime_error);
+    EXPECT_THROW(parseStr("fn f(a: int = 0, b: int) -> int:\n    return a"), std::runtime_error);
 }
 
 TEST(ParserTest, DefaultArgNoTypeError) {
     // default arg without explicit type annotation is a parse error
-    EXPECT_THROW(parseStr("function f(x = 10) -> int:\n    return x"), std::runtime_error);
+    EXPECT_THROW(parseStr("fn f(x = 10) -> int:\n    return x"), std::runtime_error);
 }
 
 TEST(ParserTest, DefaultArgLambdaError) {
@@ -2206,19 +2206,19 @@ TEST(ParserTest, RejectOldColonSingleExprLambda) {
 }
 
 TEST(ParserTest, RejectAnonymousFunctionLambda) {
-    EXPECT_THROW(parseStr("f = function(x: int) => x + 1"), std::runtime_error);
+    EXPECT_THROW(parseStr("f = fn(x: int) => x + 1"), std::runtime_error);
 }
 
 TEST(ParserTest, RejectAnonymousFunctionLambdaWithReturnType) {
-    EXPECT_THROW(parseStr("f = function(x: int) -> int => x + 1"), std::runtime_error);
+    EXPECT_THROW(parseStr("f = fn(x: int) -> int => x + 1"), std::runtime_error);
 }
 
 TEST(ParserTest, RejectAnonymousFunctionLambdaBlock) {
-    EXPECT_THROW(parseStr("f = function(x: int):\n    return x + 1"), std::runtime_error);
+    EXPECT_THROW(parseStr("f = fn(x: int):\n    return x + 1"), std::runtime_error);
 }
 
 TEST(ParserTest, RejectAnonymousFunctionLambdaNoParams) {
-    EXPECT_THROW(parseStr("f = function() => 42"), std::runtime_error);
+    EXPECT_THROW(parseStr("f = fn() => 42"), std::runtime_error);
     EXPECT_THROW(parseStr("f = fn() => 42"), std::runtime_error);
 }
 
@@ -2605,7 +2605,7 @@ TEST(ParserTest, FunctionCallTrailingComma) {
 }
 
 TEST(ParserTest, FunctionParamTrailingComma) {
-    Program prog = parseStr("function foo(a: int, b: int,) -> int:\n    return a\n");
+    Program prog = parseStr("fn foo(a: int, b: int,) -> int:\n    return a\n");
     ASSERT_EQ(prog.size(), 1u);
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     EXPECT_EQ(fn.name, "foo");
@@ -2626,7 +2626,7 @@ TEST(ParserTest, LambdaParamTrailingComma) {
 }
 
 TEST(ParserTest, GenericTypeParamTrailingComma) {
-    Program prog = parseStr("function foo<T, U,>(x: T) -> U:\n    return x as U\n");
+    Program prog = parseStr("fn foo<T, U,>(x: T) -> U:\n    return x as U\n");
     ASSERT_EQ(prog.size(), 1u);
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(fn.type_params.size(), 2u);
@@ -2645,14 +2645,14 @@ TEST(ParserTest, EnumVariantFieldTrailingComma) {
 }
 
 TEST(ParserTest, FnTypeTrailingComma) {
-    Program prog = parseStr("type Callback = function(int, int,) -> int");
+    Program prog = parseStr("type Callback = fn(int, int,) -> int");
     ASSERT_EQ(prog.size(), 1u);
     auto &ta = std::get<TypeAliasStmt>(prog[0]);
     EXPECT_EQ(ta.target_type->toString(), "fn(int, int) -> int");
 }
 
 TEST(ParserTest, GenericTypeArgTrailingComma) {
-    Program prog = parseStr("function foo(x: List<int,>) -> int:\n    return 0\n");
+    Program prog = parseStr("fn foo(x: List<int,>) -> int:\n    return 0\n");
     ASSERT_EQ(prog.size(), 1u);
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(fn.params.size(), 1u);
@@ -2660,7 +2660,7 @@ TEST(ParserTest, GenericTypeArgTrailingComma) {
 }
 
 TEST(ParserTest, MapTypeArgTrailingComma) {
-    Program prog = parseStr("function foo(x: Map<str, int,>) -> int:\n    return 0\n");
+    Program prog = parseStr("fn foo(x: Map<str, int,>) -> int:\n    return 0\n");
     ASSERT_EQ(prog.size(), 1u);
     const auto &fn = *std::get<std::unique_ptr<FnStmt>>(prog[0]);
     ASSERT_EQ(fn.params.size(), 1u);
@@ -2735,7 +2735,7 @@ TEST(ParserTest, DoubleTrailingCommaError) {
 }
 
 TEST(ParserTest, GenericTypeArgDoubleCommaError) {
-    EXPECT_THROW(parseStr("function foo(x: List<int,,>) -> int:\n    return 0\n"), std::runtime_error);
+    EXPECT_THROW(parseStr("fn foo(x: List<int,,>) -> int:\n    return 0\n"), std::runtime_error);
 }
 
 // ============================================================

--- a/tests/test_paths.cpp
+++ b/tests/test_paths.cpp
@@ -63,7 +63,7 @@ TEST(Paths, FindShareDirWithStd) {
     fs::create_directories(tmp + "/bin");
     fs::create_directories(tmp + "/share/std");
 
-    std::ofstream(tmp + "/share/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(tmp + "/share/std/builtins.ry") << "fn noop():\n    return\n";
 
     auto result = ry::find_share_dir(tmp + "/bin/ry");
     EXPECT_EQ(result, fs::canonical(tmp + "/share"));
@@ -81,7 +81,7 @@ TEST(Paths, FindShareDirExeRelativeFallsBackToLib) {
     // Only lib/std exists (old layout), no share/std
     fs::create_directories(tmp + "/bin");
     fs::create_directories(tmp + "/lib/std");
-    std::ofstream(tmp + "/lib/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(tmp + "/lib/std/builtins.ry") << "fn noop():\n    return\n";
 
     auto result = ry::find_share_dir(tmp + "/bin/ry");
     EXPECT_EQ(result, fs::canonical(tmp + "/lib"));
@@ -103,7 +103,7 @@ TEST(Paths, FindShareDirFallsBackToLibStd) {
     ASSERT_NE(mkdtemp(home_dir), nullptr);
     std::string home(home_dir);
     fs::create_directories(home + "/lib/std");
-    std::ofstream(home + "/lib/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(home + "/lib/std/builtins.ry") << "fn noop():\n    return\n";
 
     ScopedEnv guard("RY_HOME", home_dir);
 
@@ -119,9 +119,9 @@ TEST(Paths, FindShareDirPrefersShareOverLib) {
     ASSERT_NE(mkdtemp(home_dir), nullptr);
     std::string home(home_dir);
     fs::create_directories(home + "/share/std");
-    std::ofstream(home + "/share/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(home + "/share/std/builtins.ry") << "fn noop():\n    return\n";
     fs::create_directories(home + "/lib/std");
-    std::ofstream(home + "/lib/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(home + "/lib/std/builtins.ry") << "fn noop():\n    return\n";
 
     ScopedEnv guard("RY_HOME", home_dir);
 
@@ -137,7 +137,7 @@ TEST(Paths, FindShareDirSkipGlobal) {
     ASSERT_NE(mkdtemp(home_dir), nullptr);
     std::string home(home_dir);
     fs::create_directories(home + "/share/std");
-    std::ofstream(home + "/share/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(home + "/share/std/builtins.ry") << "fn noop():\n    return\n";
 
     // Set up exe-relative share/ directory
     char exe_dir[] = "/tmp/ry-exe-XXXXXX";
@@ -145,7 +145,7 @@ TEST(Paths, FindShareDirSkipGlobal) {
     std::string exe(exe_dir);
     fs::create_directories(exe + "/bin");
     fs::create_directories(exe + "/share/std");
-    std::ofstream(exe + "/share/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(exe + "/share/std/builtins.ry") << "fn noop():\n    return\n";
 
     ScopedEnv guard("RY_HOME", home_dir);
 
@@ -166,14 +166,14 @@ TEST(Paths, FindShareDirPrefersProjectOverrideForRepoBuild) {
     ASSERT_NE(mkdtemp(home_dir), nullptr);
     std::string home(home_dir);
     fs::create_directories(home + "/share/std");
-    std::ofstream(home + "/share/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(home + "/share/std/builtins.ry") << "fn noop():\n    return\n";
 
     char project_dir[] = "/tmp/ry-project-XXXXXX";
     ASSERT_NE(mkdtemp(project_dir), nullptr);
     std::string project(project_dir);
     fs::create_directories(project + "/build");
     fs::create_directories(project + "/share/std");
-    std::ofstream(project + "/share/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(project + "/share/std/builtins.ry") << "fn noop():\n    return\n";
     std::ofstream(project + "/package.toml") << R"(
 [project]
 name = "ry"
@@ -199,13 +199,13 @@ TEST(Paths, FindShareDirIgnoresProjectOverrideForInstalledBinary) {
     ASSERT_NE(mkdtemp(home_dir), nullptr);
     std::string home(home_dir);
     fs::create_directories(home + "/share/std");
-    std::ofstream(home + "/share/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(home + "/share/std/builtins.ry") << "fn noop():\n    return\n";
 
     char project_dir[] = "/tmp/ry-project-installed-XXXXXX";
     ASSERT_NE(mkdtemp(project_dir), nullptr);
     std::string project(project_dir);
     fs::create_directories(project + "/share/std");
-    std::ofstream(project + "/share/std/builtins.ry") << "function noop():\n    return\n";
+    std::ofstream(project + "/share/std/builtins.ry") << "fn noop():\n    return\n";
     std::ofstream(project + "/package.toml") << R"(
 [project]
 name = "ry"

--- a/tests/test_sema_return.cpp
+++ b/tests/test_sema_return.cpp
@@ -8,7 +8,7 @@ using namespace ry;
 
 TEST_F(CodeGenTest, MissingReturnInt) {
     EXPECT_THROW(runSource(
-        "function foo() -> int:\n"
+        "fn foo() -> int:\n"
         "    x = 1\n"
         "foo()\n"
     ), std::runtime_error);
@@ -16,7 +16,7 @@ TEST_F(CodeGenTest, MissingReturnInt) {
 
 TEST_F(CodeGenTest, MissingReturnNoElse) {
     EXPECT_THROW(runSource(
-        "function foo(x: int) -> int:\n"
+        "fn foo(x: int) -> int:\n"
         "    if x > 0:\n"
         "        return 1\n"
         "foo(1)\n"
@@ -25,7 +25,7 @@ TEST_F(CodeGenTest, MissingReturnNoElse) {
 
 TEST_F(CodeGenTest, MissingReturnInElseBranch) {
     EXPECT_THROW(runSource(
-        "function foo(x: int) -> int:\n"
+        "fn foo(x: int) -> int:\n"
         "    if x > 0:\n"
         "        return 1\n"
         "    else:\n"
@@ -36,7 +36,7 @@ TEST_F(CodeGenTest, MissingReturnInElseBranch) {
 
 TEST_F(CodeGenTest, MissingReturnStr) {
     EXPECT_THROW(runSource(
-        "function greet() -> str:\n"
+        "fn greet() -> str:\n"
         "    x = \"hello\"\n"
         "greet()\n"
     ), std::runtime_error);
@@ -44,7 +44,7 @@ TEST_F(CodeGenTest, MissingReturnStr) {
 
 TEST_F(CodeGenTest, MissingReturnFloat) {
     EXPECT_THROW(runSource(
-        "function pi() -> float:\n"
+        "fn pi() -> float:\n"
         "    x = 3.14\n"
         "pi()\n"
     ), std::runtime_error);
@@ -52,7 +52,7 @@ TEST_F(CodeGenTest, MissingReturnFloat) {
 
 TEST_F(CodeGenTest, MissingReturnBool) {
     EXPECT_THROW(runSource(
-        "function check() -> bool:\n"
+        "fn check() -> bool:\n"
         "    x = true\n"
         "check()\n"
     ), std::runtime_error);
@@ -72,7 +72,7 @@ TEST_F(CodeGenTest, MissingReturnLambdaExplicitType) {
 
 TEST_F(CodeGenTest, AllPathsReturnIfElse) {
     EXPECT_EQ(runSource(
-        "function foo(x: int) -> int:\n"
+        "fn foo(x: int) -> int:\n"
         "    if x > 0:\n"
         "        return 1\n"
         "    else:\n"
@@ -83,31 +83,31 @@ TEST_F(CodeGenTest, AllPathsReturnIfElse) {
 
 TEST_F(CodeGenTest, AllPathsReturnWhenMultiBranch) {
     EXPECT_EQ(runSource(
-        "function grade(x: int) -> str:\n    case:\n        x >= 90:\n            return \"A\"\n        x >= 80:\n            return \"B\"\n        _:\n            return \"C\"\nprint(grade(95))\n"
+        "fn grade(x: int) -> str:\n    case:\n        x >= 90:\n            return \"A\"\n        x >= 80:\n            return \"B\"\n        _:\n            return \"C\"\nprint(grade(95))\n"
     ), "A\n");
 }
 
 TEST_F(CodeGenTest, AllPathsReturnMatchWildcard) {
     EXPECT_EQ(runSource(
-        "function describe(x: int) -> str:\n    case x:\n        1:\n            return \"one\"\n        _:\n            return \"other\"\nprint(describe(1))\n"
+        "fn describe(x: int) -> str:\n    case x:\n        1:\n            return \"one\"\n        _:\n            return \"other\"\nprint(describe(1))\n"
     ), "one\n");
 }
 
 TEST_F(CodeGenTest, AllPathsReturnMatchOkErr) {
     EXPECT_EQ(runSource(
-        "function check(x: int) -> str:\n    r: Result<int, Error> = Ok(x)\n    case r:\n        Ok(v):\n            return \"ok\"\n        Err(e):\n            return \"err\"\nprint(check(42))\n"
+        "fn check(x: int) -> str:\n    r: Result<int, Error> = Ok(x)\n    case r:\n        Ok(v):\n            return \"ok\"\n        Err(e):\n            return \"err\"\nprint(check(42))\n"
     ), "ok\n");
 }
 
 TEST_F(CodeGenTest, AllPathsReturnMatchSomeNone) {
     EXPECT_EQ(runSource(
-        "function check(x: Option<int>) -> str:\n    case x:\n        Some(v):\n            return \"some\"\n        None:\n            return \"none\"\nprint(check(Some(1)))\n"
+        "fn check(x: Option<int>) -> str:\n    case x:\n        Some(v):\n            return \"some\"\n        None:\n            return \"none\"\nprint(check(Some(1)))\n"
     ), "some\n");
 }
 
 TEST_F(CodeGenTest, UnitFunctionNoReturnOk) {
     EXPECT_EQ(runSource(
-        "function greet() -> Unit:\n"
+        "fn greet() -> Unit:\n"
         "    print(\"hello\")\n"
         "greet()\n"
     ), "hello\n");
@@ -115,7 +115,7 @@ TEST_F(CodeGenTest, UnitFunctionNoReturnOk) {
 
 TEST_F(CodeGenTest, AnyFunctionNoReturnOk) {
     EXPECT_NO_THROW(runSource(
-        "function foo() -> any:\n"
+        "fn foo() -> any:\n"
         "    x = 1\n"
         "foo()\n"
     ));
@@ -123,7 +123,7 @@ TEST_F(CodeGenTest, AnyFunctionNoReturnOk) {
 
 TEST_F(CodeGenTest, OmittedReturnTypeNoReturnOk) {
     EXPECT_NO_THROW(runSource(
-        "function foo():\n"
+        "fn foo():\n"
         "    x = 1\n"
         "foo()\n"
     ));
@@ -131,13 +131,13 @@ TEST_F(CodeGenTest, OmittedReturnTypeNoReturnOk) {
 
 TEST_F(CodeGenTest, AllPathsReturnMatchVariable) {
     EXPECT_EQ(runSource(
-        "function describe(x: int) -> str:\n    case x:\n        1:\n            return \"one\"\n        n:\n            return \"other\"\nprint(describe(1))\n"
+        "fn describe(x: int) -> str:\n    case x:\n        1:\n            return \"one\"\n        n:\n            return \"other\"\nprint(describe(1))\n"
     ), "one\n");
 }
 
 TEST_F(CodeGenTest, NestedIfElseAllReturn) {
     EXPECT_EQ(runSource(
-        "function classify(x: int) -> str:\n"
+        "fn classify(x: int) -> str:\n"
         "    if x > 0:\n"
         "        if x > 100:\n"
         "            return \"big\"\n"
@@ -155,24 +155,24 @@ TEST_F(CodeGenTest, NestedIfElseAllReturn) {
 
 TEST_F(CodeGenTest, AllPathsReturnMatchEnumExhaustive) {
     EXPECT_EQ(runSource(
-        "enum Shape:\n    Circle(float)\n    Rect(float, float)\n\nfunction area(s: Shape) -> float:\n    case s:\n        Shape::Circle(r):\n            return 3.14 * r * r\n        Shape::Rect(w, h):\n            return w * h\nprint(area(Shape::Circle(5.0)))\n"
+        "enum Shape:\n    Circle(float)\n    Rect(float, float)\n\nfn area(s: Shape) -> float:\n    case s:\n        Shape::Circle(r):\n            return 3.14 * r * r\n        Shape::Rect(w, h):\n            return w * h\nprint(area(Shape::Circle(5.0)))\n"
     ), "78.5\n");
 }
 
 TEST_F(CodeGenTest, AllPathsReturnMatchSimpleEnumExhaustive) {
     EXPECT_EQ(runSource(
-        "enum Color:\n    Red\n    Green\n    Blue\n\nfunction name(c: Color) -> str:\n    case c:\n        Color::Red:\n            return \"red\"\n        Color::Green:\n            return \"green\"\n        Color::Blue:\n            return \"blue\"\nprint(name(Color::Red))\n"
+        "enum Color:\n    Red\n    Green\n    Blue\n\nfn name(c: Color) -> str:\n    case c:\n        Color::Red:\n            return \"red\"\n        Color::Green:\n            return \"green\"\n        Color::Blue:\n            return \"blue\"\nprint(name(Color::Red))\n"
     ), "red\n");
 }
 
 TEST_F(CodeGenTest, MissingReturnMatchEnumNotExhaustive) {
     EXPECT_THROW(runSource(
-        "enum Color:\n    Red\n    Green\n    Blue\n\nfunction name(c: Color) -> str:\n    case c:\n        Color::Red:\n            return \"red\"\n        Color::Green:\n            return \"green\"\nname(Color::Red)\n"
+        "enum Color:\n    Red\n    Green\n    Blue\n\nfn name(c: Color) -> str:\n    case c:\n        Color::Red:\n            return \"red\"\n        Color::Green:\n            return \"green\"\nname(Color::Red)\n"
     ), std::runtime_error);
 }
 
 TEST_F(CodeGenTest, AllPathsReturnMatchBoolExhaustive) {
     EXPECT_EQ(runSource(
-        "function describe(b: bool) -> str:\n    case b:\n        true:\n            return \"yes\"\n        false:\n            return \"no\"\nprint(describe(true))\n"
+        "fn describe(b: bool) -> str:\n    case b:\n        true:\n            return \"yes\"\n        false:\n            return \"no\"\nprint(describe(true))\n"
     ), "yes\n");
 }

--- a/tests/test_stdin.cpp
+++ b/tests/test_stdin.cpp
@@ -79,7 +79,7 @@ TEST(StdinExecution, MultilineCode) {
 
 TEST(StdinExecution, IndentedCode) {
     auto [out, rc] = runRyStdin(
-        "function add(x: int, y: int) -> int:\n"
+        "fn add(x: int, y: int) -> int:\n"
         "    return x + y\n"
         "print(add(3, 4))");
     EXPECT_EQ(out, "7\n");

--- a/tests/test_trace.cpp
+++ b/tests/test_trace.cpp
@@ -128,7 +128,7 @@ TEST_F(TraceModeTest, HelpMentionsTraceFlags) {
 TEST_F(TraceModeTest, TraceGoesToStderrAndProgramOutputStaysOnStdout) {
     auto script = writeFile(
         "trace_sample.ry",
-        "function pick(x: int) -> int:\n"
+        "fn pick(x: int) -> int:\n"
         "    if x > 0:\n"
         "        return x\n"
         "    return 0\n"


### PR DESCRIPTION
## Summary

BREAKING: The `function` keyword is removed. Use `fn` for all function definitions and `async fn` for async definitions.

- Lexer: only `fn` maps to `TokenKind::Fn`; `function` tokenizes as an identifier.
- Function types: `fn(T1, ...) -> R` only; `function(...)` is no longer valid.
- Codegen: canonical type id / `type_of` / trace `symbol_define` use `"fn"` (was `"function"`).
- Formatter, stdlib, tests, filecheck, fuzz corpus, and English docs updated.

## Changelog

- `changelog.d/1343-fn-only-keyword.md`

Closes #1343


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The `function` keyword is removed; use `fn` (including `async fn`) for declarations.
  * Function type notation is now `fn(...) -> Type`; runtime/type introspection reports function values as `"fn"`.
  * Diagnostics, error messages, and tooling messages now use `fn` consistently.

* **Documentation**
  * All docs and examples updated to use `fn` syntax.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->