### PR TITLE
fix: address v0.0.13 CodeRabbit review batch (#1346 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,6 +191,31 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   non-C-string pointers (Map/Set/closure/list headers), which is undefined
   behaviour. Mirrors the `distinct()` (#1262) and `remove()` (#1268) guards.
   (#1269)
+- `floor(x)`, `ceil(x)`, and `round(x)` with a single `int` argument now
+  short-circuit and return the input unchanged. Previously the value was
+  widened to `f64` and passed through `floor`/`ceil`/`round`, losing
+  precision for magnitudes above `2^53`. The 2-argument form and the
+  widening precedence rules from #1193/#1230 are unaffected (#1346).
+- `for x in s:` on a `Set<T>` now reads element-type metadata from
+  `set_elem_type_name` instead of `list_elem_type_name`. Previously
+  iterating a `Set<str>` silently fell through to the `list_elem` path and
+  misread the loaded element, producing wrong values at the use site
+  (#1346).
+- `m[k] = v` on an empty-then-inserted `Map<str, str>` now retains the str
+  key and value at SetItem time. Previously the retain was gated on
+  `mapKeyArcKind != CollectionKind::Str` / `mapValArcKind != CollectionKind::Str`
+  (a stale leftover from the #1266 destructor-only carve-out), leaving
+  both slots as weak references. When the local source strings went out of
+  scope, the map's slots became dangling pointers and subsequent lookups
+  surfaced as "map key not found". The Map/List/Set literal-construction
+  variants have a different root cause and are tracked separately in
+  #1347 (#1346).
+- Inline if-expression (`if cond: then-expr else: else-expr`) now accepts a
+  newline between the then-branch expression and `else:`. Previously the
+  parser rejected `if x > 0: x\nelse: -x` because the trailing Newline
+  after the inline then-branch was treated as a statement terminator,
+  causing `parseIfExpression` to fail on the missing `else` at the current
+  token (#1346).
 
 ## [0.0.12] - 2026-04-18
 

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -1037,6 +1037,8 @@ static llvm::Value *emitMathFloorCeilRound(CodeGen &cg, const CallExpr &e) {
         cg.codegenError(e.callee + "() expects 1 or 2 arguments");
 
     llvm::Value *x = cg.emitExpr(*e.args[0]);
+    if (e.args.size() == 1 && x->getType()->isIntegerTy(64))
+        return x;
     if (cg.isWideningConversion(x, cg.f64Ty_, "float"))
         x = cg.emitWideningConversion(x, cg.f64Ty_);
     if (x->getType() != cg.f64Ty_)

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -377,7 +377,10 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
     std::string elemTypeName;
     std::optional<FnTypeInfo> elemFnTypeInfo;
     if (auto *iterMeta = getMeta(iterable)) {
-        elemTypeName    = iterMeta->list_elem_type_name;
+        if (headerTy == setHeaderTy_ && !iterMeta->set_elem_type_name.empty())
+            elemTypeName = iterMeta->set_elem_type_name;
+        else
+            elemTypeName = iterMeta->list_elem_type_name;
         elemFnTypeInfo  = iterMeta->list_elem_fn_type_info;
     }
     emitIndexedForLoop(length, s->body, [&](llvm::Value *iCur) {

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -984,9 +984,10 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         builder_.CreateBr(storeBB);
 
         // Store new key-value at index = length.  Retain to give the map
-        // an independent strong reference (#1242); the update path above
-        // already retains via `retainArcValue(rhsVal)`.  str excluded per
-        // #1266 carve-out.
+        // an independent strong reference (#1242).  `retainArcValue` routes
+        // str through the StringHeader path via `arc_str_owned_values_`, so
+        // str keys/values must also be retained here (the old #1266 carve-out
+        // was destructor-only).
         builder_.SetInsertPoint(storeBB);
         llvm::Value *curLen = builder_.CreateLoad(i64Ty_, lenPtr, "cur_len");
         llvm::Value *keysPtrField3 = builder_.CreateStructGEP(mapHeaderTy_, objPtr, 2, "keys_field3");
@@ -998,8 +999,7 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
                 mapKeyTypeName = containerMeta->map_key_type_name;
             CollectionKind mapKeyArcKind = CollectionKind::Str;
             if (!mapKeyTypeName.empty() &&
-                fieldTypeIsArcManaged(mapKeyTypeName, &mapKeyArcKind) &&
-                mapKeyArcKind != CollectionKind::Str) {
+                fieldTypeIsArcManaged(mapKeyTypeName, &mapKeyArcKind)) {
                 retainArcValue(key);
             }
         }
@@ -1008,7 +1008,7 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         llvm::Value *valsPtrField3 = builder_.CreateStructGEP(mapHeaderTy_, objPtr, 3, "vals_field3");
         llvm::Value *curValsPtr = builder_.CreateLoad(ptrTy_, valsPtrField3, "cur_vals");
         llvm::Value *newValPtr = builder_.CreateGEP(mapValTy, curValsPtr, {curLen}, "new_val_ptr");
-        if (mapValIsArc && mapValArcKind != CollectionKind::Str)
+        if (mapValIsArc)
             retainArcValue(rhsVal);
         builder_.CreateStore(rhsVal, newValPtr);
 

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -193,6 +193,11 @@ ExprPtr Parser::parseIfExpression() {
         lex_.next(); // consume ':'
         std::vector<StmtNode> thenBody = parseIfExpressionBranchBody();
 
+        // Inline-expr form may place `else:` on the next line. The trailing
+        // newline after the then-branch expression is not a statement
+        // terminator here — it is interior whitespace inside the if.
+        if (lex_.peek().kind == TokenKind::Newline)
+            lex_.next();
         if (lex_.peek().kind != TokenKind::Else)
             parseError("if expression (block form) requires an 'else:' branch");
         lex_.next(); // consume 'else'

--- a/tests/spec/case_unification.test.ry
+++ b/tests/spec/case_unification.test.ry
@@ -190,4 +190,18 @@ describe("if expression colon inline form", ():
       0 - x
     expect(result).to_eq(2)
   )
+
+  it("should permit newline before else in inline form (PR#1346 hotfix)", ():
+    # The trailing newline after an inline then-branch expression is not a
+    # statement terminator — `else:` on the next line must still parse.
+    x = 5
+    y = if x > 0: x
+    else: 0 - x
+    expect(y).to_eq(5)
+
+    a = -3
+    b = if a > 0: a
+    else: 0 - a
+    expect(b).to_eq(3)
+  )
 )

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -697,6 +697,23 @@ describe("Map", ():
     expect(via_op["b"]).to_eq(via_fn["b"])
     expect(via_op["c"]).to_eq(via_fn["c"])
   )
+  it("should retain str keys/values on SetItem insert (PR#1346 hotfix)", ():
+    # `m[k] = v` where k/v are locally-constructed str must retain both so
+    # the map owns an independent strong reference. Without the retain,
+    # scope-exit destructors free the source and the map keys/values become
+    # dangling pointers, manifesting as "key not found" on later lookup.
+    fn make_map() -> Map<str, str>:
+      m: Map<str, str> = {}
+      k: str = "key_" + "alpha"
+      v: str = "value_" + "alpha"
+      m[k] = v
+      return m
+
+    m: Map<str, str> = make_map()
+    expect(m).to_have_length(1)
+    expect(m.contains("key_alpha")).to_eq(true)
+    expect(m["key_alpha"]).to_eq("value_alpha")
+  )
 )
 
 describe("Set", ():
@@ -864,6 +881,19 @@ describe("Set", ():
     expect(via_op).to_contain(5)
     expect(via_fn).to_contain(1)
     expect(via_fn).to_contain(5)
+  )
+  it("should iterate Set<str> preserving element type metadata (PR#1346)", ():
+    # Set for-loop must dispatch on set_elem_type_name rather than
+    # list_elem_type_name; otherwise str elements silently fall back to
+    # a i64-shaped iteration and corrupt the emitted value.
+    s: Set<str> = {"alpha", "beta", "gamma"}
+    collected: List<str> = []
+    for x in s:
+      collected.append!(x)
+    expect(collected).to_have_length(3)
+    expect(collected).to_contain("alpha")
+    expect(collected).to_contain("beta")
+    expect(collected).to_contain("gamma")
   )
 )
 

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -71,6 +71,15 @@ describe("math rounding", ():
     # floor() must accept -2^63, which is exactly representable in f64 and i64.
     expect(floor(-9.223372036854776e+18)).to_eq(-9223372036854775808)
   )
+  it("should preserve exact int input beyond 2^53 (PR#1346 hotfix)", ():
+    # floor/ceil/round on an int argument must short-circuit and return the
+    # input unchanged — converting to f64 first would lose precision past
+    # 2^53 (the double-precision mantissa limit).
+    x: int = 9223372036854775000
+    expect(floor(x)).to_eq(9223372036854775000)
+    expect(ceil(x)).to_eq(9223372036854775000)
+    expect(round(x)).to_eq(9223372036854775000)
+  )
 )
 
 describe("math rounding with digits", ():


### PR DESCRIPTION
## Summary

Hotfix for four orthogonal correctness issues surfaced by CodeRabbit on the v0.0.13 release PR #1346. Each finding was independently reproduced before being fixed; findings that did not reproduce (or that are out of scope) are covered separately.

### Fixes landed here

| CodeRabbit # | Area | Fix |
|---|---|---|
| 7 | `codegen_call.cpp::emitMathFloorCeilRound` | Short-circuit and return the input unchanged when `floor(x)` / `ceil(x)` / `round(x)` is called on an `int` argument. Previously widened to `f64`, which silently lost precision past `2^53`. |
| 9 | `codegen_stmt_loop.cpp::ForStmt` | Use `set_elem_type_name` (not `list_elem_type_name`) when iterating a `Set`. Previously `for x in s:` on `Set<str>` silently read the wrong metadata and corrupted the loaded value. |
| 10 (SetItem form only) | `codegen_stmt_misc.cpp::IndexAssignStmt` Map branch | Retain str keys and values on `m[k] = v`. The `!= CollectionKind::Str` guard was a stale leftover from the #1266 destructor-only carve-out and produced dangling pointers once the locally-built strs went out of scope. |
| 12 | `parser_expr.cpp::parseIfExpression` | Consume an optional `Newline` before checking for `Else` so `if cond: x\nelse: y` (inline form split across two lines) parses. |

Each fix is covered by a focused regression test in the matching spec suite (`math.test.ry`, `collections.test.ry`, `case_unification.test.ry`).

### Not fixed here

- **#10 literal form** (`{k: v}`, `[s]`, `{s}` for str) — has a different root cause from the SetItem form: `inferCollectionTypeName` returns `""` for plain str, so the literal-path retain gate short-circuits on `!keyTypeName.empty()` before ever reaching the kind check. The `&& != CollectionKind::Str` removal is a no-op at that site. Tracked separately in #1347; fix needs a value-level str detection (likely threading declared element type down from the enclosing var decl).
- **#4** (docker/entrypoint.sh fuzz target) — deferred per user direction; the fuzz job is not yet in CI, so the entrypoint wiring is not a release blocker. Replied on the thread.
- Other findings that did not reproduce against `HEAD` are being replied to individually with the evidence.

### Verification

- Full build: `cmake --build build` — clean
- `./build/ry_tests` — 1937 / 1937 passed
- `./build/ry test -p` — 167 files, 0 failures
- ASan + UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p` — clean
- TSan: `./build-tsan/ry_tests` — clean
- libFuzzer (parser / json / utf8, 60s each) — 0 crashes

## Test plan

- [x] Unit tests for each fix
- [x] Full test suite green locally (default / asan / tsan)
- [x] libFuzzer harnesses run 60s each without crashes
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Integer-argument `floor`, `ceil`, and `round` functions now preserve precision without unnecessary floating-point conversion
* Set iteration now correctly types elements during loops
* Map assignments now properly retain string keys and values
* Parser now tolerates newlines between inline if-expression branches and `else` clauses

<!-- end of auto-generated comment: release notes by coderabbit.ai -->