### PR TITLE
fix: use "colon form" wording in if-expression parser diagnostics (#1346 hotfix)

### DIFF
--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -199,11 +199,11 @@ ExprPtr Parser::parseIfExpression() {
         if (lex_.peek().kind == TokenKind::Newline)
             lex_.next();
         if (lex_.peek().kind != TokenKind::Else)
-            parseError("if expression (block form) requires an 'else:' branch");
+            parseError("if expression (colon form) requires an 'else:' branch");
         lex_.next(); // consume 'else'
 
         if (lex_.peek().kind != TokenKind::Colon)
-            parseError("expected ':' after 'else' in if expression block form");
+            parseError("expected ':' after 'else' in if expression colon form");
         lex_.next(); // consume ':'
         std::vector<StmtNode> elseBody = parseIfExpressionBranchBody();
 


### PR DESCRIPTION
## Summary

Small follow-up hotfix on the v0.0.13 release PR #1346. Addresses CodeRabbit review comment 3134759943 pointing out that the `parseIfExpression` diagnostics still say "block form" even after PR #1348 extended the same parser path to accept the inline colon variant (`if x: a\nelse: b`). "Colon form" is the accurate label because it covers both inline and indented variants.

### Change

Two user-visible strings in `src/parser_expr.cpp::parseIfExpression`:

- `"if expression (block form) requires an 'else:' branch"` → `"if expression (colon form) requires an 'else:' branch"`
- `"expected ':' after 'else' in if expression block form"` → `"expected ':' after 'else' in if expression colon form"`

`codegen_expr.cpp::emitExprVariant(IfBlockExpr)` error sites are intentionally **left unchanged** — "block form" there refers to the `IfBlockExpr` AST node (distinguished from `IfSingleExpr`, the `=>` form), which is a different axis from the colon-vs-arrow surface syntax distinction.

### Not included in this hotfix

CodeRabbit's post-hotfix review flagged two additional findings, both **pre-existing bugs** not introduced by the v0.0.13 work:

- `for a, b in setOfTuples:` fails with `"requires a list of tuples"` — filed as #1350 (commit 5284af91, 2026-03-28 origin)
- Self-referential enum diagnostic mentions only `List`/`Map`/`Set`, not `Task`/`Channel`/`weak`/`fn` — filed as #1351 (commit f48fa797, 2026-04-19, #1203 origin)

Both are tracked for a subsequent release.

## Test plan

- [x] `cmake --build build` — clean
- [x] `./build/ry_tests` — 1937 / 1937 passed
- [x] `./build/ry test tests/spec/case_unification.test.ry` — 21 / 21 passed
- [x] Manual reproduction: `y = if x > 0: x` without `else` now errors with `(colon form) requires an 'else:' branch`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for if statements using colon syntax. Diagnostic messages now correctly reference the appropriate syntax form, providing clearer and more accurate feedback when syntax errors are encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->