### PR TITLE
fix: retain str keys/values on Map literal construction (#1347 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,6 +210,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   surfaced as "map key not found". The Map/List/Set literal-construction
   variants have a different root cause and are tracked separately in
   #1347 (#1346).
+- `m: Map<str, str> = {k: v}` (non-empty Map literal with str keys/values)
+  now retains each str handle at literal-construction time and stamps
+  `map_key_type_name = "str"` / `map_value_type_name = "str"` on the
+  returned header so the destructor dispatches to the str-releasing
+  variant. Previously the retain gate relied on
+  `inferCollectionTypeName(val)`, which returns `""` for plain str values
+  and short-circuits at `Empty`, so the map held borrowed references to
+  locally-constructed strings. When the source strings went out of scope
+  the map's slots became dangling pointers, reproducing the #1346
+  "map key not found" symptom through the literal path. `retainArcValue`
+  routes through `tryRetainArcSource` Case 2b (no-op for fresh `+1`
+  `makeString` values) and Case 1 (emits retain for `LoadInst` from a
+  bound variable alloca), preserving `#1266` counter symmetry. List/Set
+  literal variants are deferred to v0.0.14+ because the #1266
+  destructor-only carve-out for them has a different resolution path
+  (#1347).
 - Inline if-expression (`if cond: then-expr else: else-expr`) now accepts a
   newline between the then-branch expression and `else:`. Previously the
   parser rejected `if x > 0: x\nelse: -x` because the trailing Newline

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -4750,6 +4750,21 @@ This makes wrong-offset bugs on str literals almost always fatal immediately, wh
 
 ---
 
+### Map literal `{k: v}` with str keys/values needs side-table retain + explicit str stamp
+
+**Source**: #1347 (2026-04-24)
+**Tags**: codegen, Map, literal, str, ARC, inferCollectionTypeName, retainArcValue, map_key_type_name
+
+**Rule**: In `emitExprVariant(MapExpr)` (`src/codegen_expr_literal.cpp`), the existing retain gate `keyTypeName = inferCollectionTypeName(keyVals[0])` returns `""` for plain str values, so the gate short-circuits at `!keyTypeName.empty()` = `false`. A parallel `isStrHandle(v)` side-table check (`arc_str_owned_values_.count(v) > 0 || LoadInst from arc_str_managed_vars_ alloca`) is required; then call `retainArcValue(keyVals[i])` unconditionally on str handles. `retainArcValue → tryRetainArcSource` Case 1 emits retain for bound `LoadInst`; Case 2b is a **transfer-semantic no-op** for fresh `+1` `makeString` values (returns `true` without emitting retain), so the unconditional call doesn't leak on `{"foo": "bar"}`.
+
+The retain side alone is insufficient for Map literals: the non-empty-literal VarDecl path in `codegen_stmt.cpp` only propagates `map_value_type_name` from `val`'s meta, not `map_key_type_name`. The str annotation at `L269-271` only fires for the empty-literal branch. Add symmetric `map_key_type_name` meta propagation from `valMeta` / `loadMeta` / annotation in the non-empty branch (mirror of the existing `mvtn` block), AND stamp `map_key_type_name = "str"` / `map_value_type_name = "str"` on the literal's returned `headerPtr` when `isStrHandle` detects str keys/values. Without those stamps, `resolveCollectionDestructor` dispatches to `__ry_arc_dtor_map` with empty sigs, so `emitInnerReleaseLoop` returns false for the keys array and the str keys never get released — swapping a UAF for a leak.
+
+Why this differs from #1346 SetItem: `m: Map<str, str> = {}` (empty literal, then `m[k] = v`) hits the annotation-driven L269-282 path that stamps both `map_key_type_name` and `map_value_type_name`, so the #1346 fix only had to lift the `!= CollectionKind::Str` gate. `m: Map<str, str> = {k: v}` (non-empty literal) never hits L269-282 and has a fundamentally different root cause (`inferCollectionTypeName` returns empty for str) even though the user-visible symptom ("map key not found") is identical.
+
+**Scope note**: List<str> / Set<str> literal variants are deferred to v0.0.14+ — the #1266 destructor-only carve-out (no `list_elem_type_name = "str"` stamp because of `makeString`/`__ry_arc_alloc_counted` counter asymmetry) means retain-only on the literal side would leak, not fix. Reconciling those paths requires the #1266 carve-out to be revisited, which is outside a v0.0.13 hotfix.
+
+---
+
 ### Record ARC reassignment: use `!CallInst && !InvokeInst` not `LoadInst || ExtractValueInst`
 
 **Source**: PR #1148 review (2026-04-18)

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -321,11 +321,22 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
         }
         return false;
     };
-    const bool keyIsStr = keyTy == ptrTy_ && !keyVals.empty() && isStrHandle(keyVals[0]);
-    const bool valIsStr = valTy == ptrTy_ && !valVals.empty() && isStrHandle(valVals[0]);
+    // Per-entry detection: the first-entry-only heuristic misses mixed-origin
+    // literals like `{extractvalue_k: v1, bound_k: v2}` where entry 0 escapes
+    // isStrHandle but entry 1+ is a tracked LoadInst. Retain per entry and
+    // keep aggregate flags for the post-loop metadata stamp.
+    bool anyKeyIsStr = false;
+    bool anyValIsStr = false;
 
     // Store keys and values
     for (int64_t i = 0; i < count; ++i) {
+        const bool keyIsStr =
+            keyTy == ptrTy_ && isStrHandle(keyVals[static_cast<size_t>(i)]);
+        const bool valIsStr =
+            valTy == ptrTy_ && isStrHandle(valVals[static_cast<size_t>(i)]);
+        anyKeyIsStr = anyKeyIsStr || keyIsStr;
+        anyValIsStr = anyValIsStr || valIsStr;
+
         llvm::Value *kp = builder_.CreateGEP(keyTy, keysPtr,
             {llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(i))}, "key_ptr");
         if (keyNeedsRetain || keyIsStr)
@@ -371,11 +382,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
 
     if (keyTy == ptrTy_ && !keyTypeName.empty())
         getOrCreateMeta(headerPtr).map_key_type_name = keyTypeName;
-    else if (keyIsStr)
+    else if (anyKeyIsStr)
         getOrCreateMeta(headerPtr).map_key_type_name = "str";
     if (valTy == ptrTy_ && !valTypeName.empty())
         getOrCreateMeta(headerPtr).map_value_type_name = valTypeName;
-    else if (valIsStr)
+    else if (anyValIsStr)
         getOrCreateMeta(headerPtr).map_value_type_name = "str";
 
     return headerPtr;

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -294,8 +294,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
         mallocFn, {llvm::ConstantInt::get(i64Ty_, valSize * static_cast<uint64_t>(count))}, "map_vals");
 
     // Retain ARC-managed collection keys/values on store so the outer map
-    // owns independent strong references.  See List literal (#1242).  str
-    // is excluded per #1266 carve-out.
+    // owns independent strong references.  See List literal (#1242).
     std::string keyTypeName;
     if (keyTy == ptrTy_) keyTypeName = inferCollectionTypeName(keyVals[0]);
     std::string valTypeName;
@@ -309,16 +308,32 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
         fieldTypeIsArcManaged(valTypeName, &valArcKind) &&
         valArcKind != CollectionKind::Str;
 
+    // Str handle detection: the `inferCollectionTypeName` path above returns
+    // "" for plain str values so the existing gate short-circuits. Parallel
+    // side-table lookup catches borrowed LoadInst sources and fresh +1
+    // makeString values. Counterpart to PR#1346 SetItem str retain (#1347).
+    auto isStrHandle = [&](llvm::Value *v) -> bool {
+        if (v->getType() != ptrTy_) return false;
+        if (arc_str_owned_values_.count(v) > 0) return true;
+        if (auto *ld = llvm::dyn_cast<llvm::LoadInst>(v)) {
+            auto *src = llvm::dyn_cast<llvm::AllocaInst>(ld->getPointerOperand());
+            if (src && arc_str_managed_vars_.count(src) > 0) return true;
+        }
+        return false;
+    };
+    const bool keyIsStr = keyTy == ptrTy_ && !keyVals.empty() && isStrHandle(keyVals[0]);
+    const bool valIsStr = valTy == ptrTy_ && !valVals.empty() && isStrHandle(valVals[0]);
+
     // Store keys and values
     for (int64_t i = 0; i < count; ++i) {
         llvm::Value *kp = builder_.CreateGEP(keyTy, keysPtr,
             {llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(i))}, "key_ptr");
-        if (keyNeedsRetain)
+        if (keyNeedsRetain || keyIsStr)
             retainArcValue(keyVals[static_cast<size_t>(i)]);
         builder_.CreateStore(keyVals[static_cast<size_t>(i)], kp);
         llvm::Value *vp = builder_.CreateGEP(valTy, valsPtr,
             {llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(i))}, "val_ptr");
-        if (valNeedsRetain)
+        if (valNeedsRetain || valIsStr)
             retainArcValue(valVals[static_cast<size_t>(i)]);
         builder_.CreateStore(valVals[static_cast<size_t>(i)], vp);
     }
@@ -356,8 +371,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
 
     if (keyTy == ptrTy_ && !keyTypeName.empty())
         getOrCreateMeta(headerPtr).map_key_type_name = keyTypeName;
+    else if (keyIsStr)
+        getOrCreateMeta(headerPtr).map_key_type_name = "str";
     if (valTy == ptrTy_ && !valTypeName.empty())
         getOrCreateMeta(headerPtr).map_value_type_name = valTypeName;
+    else if (valIsStr)
+        getOrCreateMeta(headerPtr).map_value_type_name = "str";
 
     return headerPtr;
 }

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -707,6 +707,41 @@ void CodeGen::emitVarDecl(const std::string &name,
         if (valTy) setTypeMeta(TypeMeta::MapValue, ptr, valTy);
         {
             auto *valMeta = getMeta(val);
+            std::string mktn;
+            std::optional<FnTypeInfo> mkfti;
+            if (valMeta) {
+                if (!valMeta->map_key_type_name.empty())
+                    mktn = valMeta->map_key_type_name;
+                if (valMeta->map_key_fn_type_info)
+                    mkfti = valMeta->map_key_fn_type_info;
+            }
+            if (mktn.empty()) {
+                if (auto *load = llvm::dyn_cast<llvm::LoadInst>(val)) {
+                    auto *loadMeta = getMeta(load->getPointerOperand());
+                    if (loadMeta) {
+                        if (!loadMeta->map_key_type_name.empty())
+                            mktn = loadMeta->map_key_type_name;
+                        if (!mkfti && loadMeta->map_key_fn_type_info)
+                            mkfti = loadMeta->map_key_fn_type_info;
+                    }
+                }
+            }
+            // Also derive from annotation: Map<fn(int) -> int, V> → mktn = "fn(int) -> int"
+            if (mktn.empty() && annot && isMapTypeName(resolvedAnnot)) {
+                std::string ktn = extractMapKeyTypeName(resolvedAnnot);
+                if (!ktn.empty())
+                    mktn = ktn;
+            }
+            if (!mktn.empty()) {
+                getOrCreateMeta(ptr).map_key_type_name = mktn;
+                if (!mkfti && isFunctionTypeName(mktn))
+                    mkfti = parseFnTypeAnnotation(mktn);
+            }
+            if (mkfti)
+                getOrCreateMeta(ptr).map_key_fn_type_info = mkfti;
+        }
+        {
+            auto *valMeta = getMeta(val);
             std::string mvtn;
             std::optional<FnTypeInfo> mvfti;
             if (valMeta) {

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -733,6 +733,34 @@ describe("Map", ():
     expect(m.contains("key_alpha")).to_eq(true)
     expect(m["key_alpha"]).to_eq("value_alpha")
   )
+  it("should retain str keys/values across all entries on mixed-origin Map literal (#1347 hotfix)", ():
+    # Multi-entry literals may combine literal keys (fresh +1 makeString tracked
+    # in arc_str_owned_values_) and bound keys (LoadInst from
+    # arc_str_managed_vars_ alloca). A first-entry-only detection would miss
+    # later entries with a different origin, leaving their retains skipped.
+    # Exercise both orderings to lock per-entry retain behavior.
+    fn make_literal_first() -> Map<str, str>:
+      k: str = "bound_key_" + "beta"
+      v: str = "bound_val_" + "beta"
+      m: Map<str, str> = {"literal_key": "literal_value", k: v}
+      return m
+
+    fn make_bound_first() -> Map<str, str>:
+      k: str = "bound_key_" + "gamma"
+      v: str = "bound_val_" + "gamma"
+      m: Map<str, str> = {k: v, "literal_key": "literal_value"}
+      return m
+
+    m1: Map<str, str> = make_literal_first()
+    expect(m1).to_have_length(2)
+    expect(m1["literal_key"]).to_eq("literal_value")
+    expect(m1["bound_key_beta"]).to_eq("bound_val_beta")
+
+    m2: Map<str, str> = make_bound_first()
+    expect(m2).to_have_length(2)
+    expect(m2["literal_key"]).to_eq("literal_value")
+    expect(m2["bound_key_gamma"]).to_eq("bound_val_gamma")
+  )
 )
 
 describe("Set", ():

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -714,6 +714,25 @@ describe("Map", ():
     expect(m.contains("key_alpha")).to_eq(true)
     expect(m["key_alpha"]).to_eq("value_alpha")
   )
+  it("should retain str keys/values on Map literal construction (#1347 hotfix)", ():
+    # `{k: v}` where k/v are locally-constructed str must retain both so the
+    # map owns an independent strong reference. Without the literal-side
+    # retain, scope-exit destructors free the sources and the map keys/values
+    # become dangling pointers. Counterpart to PR#1346 which fixed the
+    # `m[k] = v` form; literal path has a different root cause
+    # (inferCollectionTypeName returns "" for plain str, short-circuiting the
+    # existing retain gate at Empty).
+    fn make_map_lit() -> Map<str, str>:
+      k: str = "key_" + "alpha"
+      v: str = "value_" + "alpha"
+      m: Map<str, str> = {k: v}
+      return m
+
+    m: Map<str, str> = make_map_lit()
+    expect(m).to_have_length(1)
+    expect(m.contains("key_alpha")).to_eq(true)
+    expect(m["key_alpha"]).to_eq("value_alpha")
+  )
 )
 
 describe("Set", ():


### PR DESCRIPTION
## Summary

- Fixes #1347: `m: Map<str, str> = {k: v}` (non-empty Map literal with str keys/values) did not retain str handles at literal-construction time, so scope-exit destructors on the source strings left the map holding dangling pointers — reproducing the #1346 "map key not found" symptom via a different root cause.
- `src/codegen_expr_literal.cpp`: `inferCollectionTypeName(val)` returns `""` for plain str and short-circuits the existing retain gate. Added a parallel `isStrHandle(v)` side-table check (`arc_str_owned_values_` or `LoadInst` from an `arc_str_managed_vars_` alloca) and ORed it into `keyNeedsRetain` / `valNeedsRetain`. `retainArcValue → tryRetainArcSource` Case 2b is a transfer-semantic no-op for fresh `+1` `makeString` values, so unconditional retain is safe on `{"foo": "bar"}` shapes. Also stamp `map_key_type_name = "str"` / `map_value_type_name = "str"` on `headerPtr` when `isStrHandle` fires, so `resolveCollectionDestructor` dispatches to the str-releasing variant.
- `src/codegen_stmt.cpp`: The non-empty-literal VarDecl path previously only propagated `map_value_type_name` from `val`'s meta / `LoadInst` source / annotation — not `map_key_type_name`. Added a symmetric `mktn` propagation block (mirrors the existing `mvtn` block) so the destructor sees the str key sig and releases both halves. Without this, a retain-only fix would swap a UAF for a leak.
- `tests/spec/collections.test.ry`: Added regression test `should retain str keys/values on Map literal construction (#1347 hotfix)` — `fn make_map_lit() -> Map<str, str>` constructs a map from locally-built strs, returns it, and the caller reads keys/values after the constructor's scope has ended.
- `CHANGELOG.md`, `KNOWLEDGE.md`: Documented fix shape, why Map literal differs from the #1346 SetItem fix (empty-literal `m: Map<str, str> = {}` hits the annotation-driven stamp at L269-282; non-empty `{k: v}` never does), and scope note explaining why List/Set literal variants are deferred.

## Test plan

- [x] `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p` — 1937 C++ tests, 167 Ry self-test suites pass
- [x] `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests && ASAN_OPTIONS=... ./build-asan/ry test -p` — clean
- [x] `cmake --preset tsan && cmake --build build-tsan && TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests && TSAN_OPTIONS=... ./build-tsan/ry test -p` — clean
- [x] Linux Docker + LSan enabled: pre-fix `845,951 bytes / 1,643 allocs` vs post-fix `846,145 bytes / 1,649 allocs`. Delta of 6 allocations matches exactly 1 new test case's overhead (2 strs + map header + keys/vals arrays + bucket table) — no over-retention
- [x] `ctest --test-dir build -L filecheck --output-on-failure` — 10/10 goldens pass
- [x] cppcheck — clean
- [x] libFuzzer (fuzz_parser / fuzz_json / fuzz_utf8, 60s each) — all exit 0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Map literal construction with string keys/values now retains and stamps type metadata so entries remain valid after scope exit and are properly released (fixes map-key-not-found and leak symptoms).

* **Documentation**
  * Added release/changelog and knowledge notes describing Map literal retain and metadata behavior for string keys/values.

* **Tests**
  * Added regression tests covering single- and multi-entry Map literals with string keys/values and mixed origins.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->