### PR TITLE
fix: resolve @native overload ambiguity in lambda return-type inference (#1349)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -5091,6 +5091,16 @@ The retain discipline is **symmetric** with the destructor:
 
 ---
 
+### `inferNativeCallReturnTypeName` must narrow overloads by source-level type name, not LLVM type
+
+**Source**: #1349 (2026-04-24, implementation). **Tags**: codegen, lambda, type-inference, native, overload, ptr-collapse, captured-vars
+
+**Rule**: When narrowing `@native` overloads inside lambda return-type inference, compare `sig.params[i].typeName` against `inferExprTypeName(arg)` (source-level Ry names), not `argTypes[i] == resolveType(sig.params[i].typeName)` (LLVM types). Ptr-backed types (`str`, `List`, `Map`, `Set`) all resolve to the same `ptr` under opaque pointers, so every overload appears to match and the ambiguity guard fires. The companion bug is that captured variables in lambda / nested-fn bodies also need their source-level collection metadata (`list_elem_type_name` / `map_key_type_name` / `set_elem_type_name` / `union_value_type` / `enum_value_type`) propagated from the outer alloca — only `fn_type_info` was being forwarded, so dispatch inside the body misrouted `length(xs)` to the str runtime even after the type-inference fix landed.
+
+**How to apply**: In `inferNativeCallReturnTypeName` (`src/codegen_lambda.cpp`), build `argTypeNames` via `inferExprTypeName()` alongside `argTypes`, match by `resolveTypeAlias(argTypeNames[i]) == resolveTypeAlias(sig.params[i].typeName)` first, and fall back to the LLVM-type equality path only when the source-level name is empty. Keep `isInferenceWidening` — its `isLowLevelTypeName` gate means it won't misfire on ptr-backed types. Thread a `paramTypeNameMap` default parameter so `inferExprTypeName::CallExpr` can forward the outer name map into the check. For captured variables, save the outer `llvm::AllocaInst*` in `CaptureAnalysisResult::capturedSrcAllocas` during `analyzeFreeVariables`, and in both lambda (`emitExprVariant<LambdaExpr>`) and nested-fn (`emitStmt<FnStmt>`) captured-param setup call `propagateMeta(srcAlloca, newAlloca)` after `CreateStore` — this copies the full metadata packet (collection types, type-name strings, `fn_type_info`, resource kinds, ARC-managed flag) in one shot.
+
+---
+
 ### Higher-order Result/lambda boundaries must rehydrate ptr-backed metadata from type names or wrappers
 
 **Source**: #1319 (2026-04-23, implementation). **Tags**: codegen, metadata, lambda, Result, JsonValue, resource, higher-order

--- a/changelog.d/1349-lambda-native-overload-ptr-collapse.md
+++ b/changelog.d/1349-lambda-native-overload-ptr-collapse.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Lambda return-type inference now correctly narrows `@native` overloads that differ only in ptr-backed argument types (`str` vs `List` vs `Map` vs `Set`). Previously `f = () => length(xs)` failed with "ambiguous @native call in lambda return-type inference". Captured collection variables also retain their source-level element/key/value type metadata so the body dispatches to the correct runtime overload. (#1349)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -759,6 +759,10 @@ public:
         std::vector<llvm::Type*> capturedTypes;
         std::vector<CapturedArcKind> capturedArcKinds;
         std::vector<ResourceKind> capturedResourceKinds;
+        // Outer-scope alloca for each capture. Used to propagate source-level
+        // collection/union/enum type metadata into the captured-param alloca
+        // so the closure body can dispatch ptr-collapsed overloads correctly.
+        std::vector<llvm::AllocaInst*> capturedSrcAllocas;
         std::unordered_map<size_t, FnTypeInfo> capturedClosureInfos;
         llvm::SmallVector<bool, 8> capturedIsConst;
     };
@@ -767,6 +771,13 @@ public:
         const ExprPtr &expr_body,
         const std::unordered_set<std::string> &paramNames,
         bool emitLoads = true);
+
+    // Alloca the captured variable, store the incoming arg into it, register
+    // it in scope_stack_ / captured_vars_ / immutable_scope_stack_, and
+    // propagate source-level type metadata from the outer alloca (#1349).
+    void emitCapturedParamSetup(llvm::Argument &arg,
+                                const CaptureAnalysisResult &captures,
+                                size_t capIdx);
 
     // Build ARC-managed closure struct {fn_ptr, cap1, cap2, ...} and return the closure pointer.
     // Returns the raw function pointer if capturedValues is empty.
@@ -1609,7 +1620,8 @@ public:
         std::vector<llvm::Type*> &out);
     std::string inferNativeCallReturnTypeName(
         const CallExpr &expr,
-        const std::unordered_map<std::string, llvm::Type*> &paramTypeMap);
+        const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+        const std::unordered_map<std::string, std::string> &paramTypeNameMap = {});
     std::string inferReturnTypeName(const std::vector<StmtNode> &body,
         const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
         const std::unordered_map<std::string, std::string> &paramTypeNameMap);

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -767,20 +767,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
                 const std::string &ptype = paramTypeNames[idx];
                 applyParamTypeMeta(ptype, alloca, paramTypes[idx], s->params[idx].name);
             } else {
-                // Captured variable injected as extra parameter
-                size_t capIdx = idx - s->params.size();
-                arg.setName(captures.capturedNames[capIdx] + ".cap");
-                llvm::AllocaInst *alloca = builder_.CreateAlloca(
-                    captures.capturedTypes[capIdx], nullptr, captures.capturedNames[capIdx]);
-                builder_.CreateStore(&arg, alloca);
-                scope_stack_.back()[captures.capturedNames[capIdx]] = alloca;
-                captured_vars_.insert(alloca);
-                if (captures.capturedIsConst[capIdx])
-                    immutable_scope_stack_.back().insert(captures.capturedNames[capIdx]);
-                // Propagate fn_type_info for captured function-type variables
-                auto closureIt = captures.capturedClosureInfos.find(capIdx);
-                if (closureIt != captures.capturedClosureInfos.end())
-                    getOrCreateMeta(alloca).fn_type_info = closureIt->second;
+                emitCapturedParamSetup(arg, captures, idx - s->params.size());
             }
             ++idx;
         }

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -41,6 +41,7 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
             result.capturedValues.push_back(nullptr);
         }
         result.capturedTypes.push_back(capType);
+        result.capturedSrcAllocas.push_back(alloca);
         auto cak = detectCapturedArcKind(alloca);
         result.capturedArcKinds.push_back(cak);
         if (cak == CapturedArcKind::Resource) {
@@ -230,6 +231,24 @@ CodeGen::CaptureAnalysisResult CodeGen::analyzeFreeVariables(
     return result;
 }
 
+void CodeGen::emitCapturedParamSetup(llvm::Argument &arg,
+                                     const CaptureAnalysisResult &captures,
+                                     size_t capIdx) {
+    arg.setName(captures.capturedNames[capIdx] + ".cap");
+    llvm::AllocaInst *alloca = builder_.CreateAlloca(
+        captures.capturedTypes[capIdx], nullptr, captures.capturedNames[capIdx]);
+    builder_.CreateStore(&arg, alloca);
+    scope_stack_.back()[captures.capturedNames[capIdx]] = alloca;
+    captured_vars_.insert(alloca);
+    if (captures.capturedIsConst[capIdx])
+        immutable_scope_stack_.back().insert(captures.capturedNames[capIdx]);
+    // propagateMeta copies collection/union/enum/fn_type_info metadata from
+    // the outer alloca so ptr-collapsed overload dispatch works inside the
+    // closure body (#1349).
+    if (captures.capturedSrcAllocas[capIdx])
+        propagateMeta(captures.capturedSrcAllocas[capIdx], alloca);
+}
+
 // ===== Closure struct builder (shared between lambda and nested named functions) =====
 
 llvm::Value *CodeGen::buildClosureStruct(
@@ -359,20 +378,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
                 const std::string ptype = e->params[idx].type->toString();
                 applyParamTypeMeta(ptype, alloca, paramTypes[idx], e->params[idx].name);
             } else {
-                // Captured variable
-                size_t capIdx = idx - e->params.size();
-                arg.setName(captures.capturedNames[capIdx] + ".cap");
-                llvm::AllocaInst *alloca = builder_.CreateAlloca(
-                    captures.capturedTypes[capIdx], nullptr, captures.capturedNames[capIdx]);
-                builder_.CreateStore(&arg, alloca);
-                scope_stack_.back()[captures.capturedNames[capIdx]] = alloca;
-                captured_vars_.insert(alloca);
-                if (captures.capturedIsConst[capIdx])
-                    immutable_scope_stack_.back().insert(captures.capturedNames[capIdx]);
-                // Propagate fn_type_info for captured function-type variables
-                auto closureIt = captures.capturedClosureInfos.find(capIdx);
-                if (closureIt != captures.capturedClosureInfos.end())
-                    getOrCreateMeta(alloca).fn_type_info = closureIt->second;
+                emitCapturedParamSetup(arg, captures, idx - e->params.size());
             }
             ++idx;
         }
@@ -841,7 +847,8 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
             auto *overloads = findFunction(v->callee);
             if (overloads && !overloads->empty() && !(*overloads)[0].returnTypeName.empty())
                 return (*overloads)[0].returnTypeName;
-            if (std::string nativeRet = inferNativeCallReturnTypeName(*v, paramTypeMap);
+            if (std::string nativeRet = inferNativeCallReturnTypeName(*v, paramTypeMap,
+                                                                       paramTypeNameMap);
                 !nativeRet.empty())
                 return nativeRet;
             return "";
@@ -934,11 +941,21 @@ std::string CodeGen::inferExprTypeName(const ExprNode &expr,
 
 std::string CodeGen::inferNativeCallReturnTypeName(
     const CallExpr &expr,
-    const std::unordered_map<std::string, llvm::Type*> &paramTypeMap) {
+    const std::unordered_map<std::string, llvm::Type*> &paramTypeMap,
+    const std::unordered_map<std::string, std::string> &paramTypeNameMap) {
     std::vector<llvm::Type*> argTypes;
+    std::vector<std::string> argTypeNames;
     argTypes.reserve(expr.args.size());
-    for (const auto &arg : expr.args)
+    argTypeNames.reserve(expr.args.size());
+    // Build both LLVM types and source-level names: ptr-backed types
+    // (str/List/Map/Set) all lower to `ptr`, so overload narrowing needs
+    // the source-level name. `inferExprTypeName` can return "" for exprs
+    // without a spelled-out name — those fall back to LLVM-type match.
+    for (const auto &arg : expr.args) {
         argTypes.push_back(inferExprType(*arg, paramTypeMap));
+        argTypeNames.push_back(
+            inferExprTypeName(*arg, paramTypeMap, paramTypeNameMap));
+    }
 
     auto isInferenceWidening = [&](llvm::Type *argTy,
                                    llvm::Type *paramTy,
@@ -962,12 +979,17 @@ std::string CodeGen::inferNativeCallReturnTypeName(
                 continue;
             bool matches = true;
             for (size_t i = 0; i < argTypes.size(); ++i) {
-                llvm::Type *expectedTy = resolveType(sig.params[i].typeName);
-                if (argTypes[i] == expectedTy)
+                const std::string &paramTn = sig.params[i].typeName;
+                llvm::Type *expectedTy = resolveType(paramTn);
+                if (!argTypeNames[i].empty()) {
+                    if (resolveTypeAlias(argTypeNames[i]) ==
+                        resolveTypeAlias(paramTn))
+                        continue;
+                } else if (argTypes[i] == expectedTy) {
                     continue;
+                }
                 if (allowWidening &&
-                    isInferenceWidening(argTypes[i], expectedTy,
-                                        sig.params[i].typeName))
+                    isInferenceWidening(argTypes[i], expectedTy, paramTn))
                     continue;
                 matches = false;
                 break;

--- a/tests/spec/lambda_native_call.test.ry
+++ b/tests/spec/lambda_native_call.test.ry
@@ -1,0 +1,37 @@
+# Regression tests for #1349: lambda return-type inference over @native
+# overloads that differ only in ptr-backed argument types (str / List / Map /
+# Set). Before the fix, `inferNativeCallReturnTypeName` compared LLVM types,
+# all of which collapse to `ptr`, so every overload "matched" and the
+# ambiguity guard fired with "ambiguous @native call in lambda return-type
+# inference".
+
+describe("lambda return-type inference over @native length overloads", ():
+  it("resolves length(str) inside a lambda", ():
+    s: str = "abc"
+    f = () => length(s)
+    expect(f()).to_eq(3)
+  )
+
+  it("resolves length(List<int>) inside a lambda", ():
+    xs: List<int> = [1, 2, 3]
+    f = () => length(xs)
+    expect(f()).to_eq(3)
+  )
+
+  it("resolves length(Map<str, int>) inside a lambda", ():
+    m: Map<str, int> = {"a": 1, "b": 2}
+    f = () => length(m)
+    expect(f()).to_eq(2)
+  )
+
+  it("resolves length(Set<int>) inside a lambda", ():
+    s: Set<int> = {1, 2, 3}
+    f = () => length(s)
+    expect(f()).to_eq(3)
+  )
+
+  it("resolves length via a lambda parameter", ():
+    f = (xs: List<int>) => length(xs)
+    expect(f([10, 20, 30, 40])).to_eq(4)
+  )
+)


### PR DESCRIPTION
## Summary

- Fix `inferNativeCallReturnTypeName` (`src/codegen_lambda.cpp`) to narrow `@native` overloads by source-level type name instead of LLVM type. Ptr-backed types (`str`/`List`/`Map`/`Set`) all lower to `ptr` under opaque pointers, so every overload appeared to match and the ambiguity guard fired on `f = () => length(xs)`.
- Propagate full source-level metadata (collection element/key/value type names, union/enum value types, `fn_type_info`, resource kinds, ARC-managed flag) from the outer alloca to the captured-param alloca via `propagateMeta`. The previous narrow `fn_type_info`-only path caused captured collections inside the lambda body to misroute `length(xs)` to the str runtime even after the type-inference fix landed.
- Extract `emitCapturedParamSetup` to share the captured-param setup logic that became byte-identical between `emitExprVariant<LambdaExpr>` (`src/codegen_lambda.cpp`) and `emitStmt<FnStmt>` (`src/codegen_fn.cpp`) after the propagation fix.
- Add `tests/spec/lambda_native_call.test.ry` covering `length` on `str` / `List<int>` / `Map<str,int>` / `Set<int>` / lambda-parameter collections.

Closes #1349.

## Test plan

- [x] `./build/ry_tests` — 1937 tests pass
- [x] `./build/ry test -p` — 168 files, 0 failures
- [x] `./build/ry test tests/spec/lambda_native_call.test.ry` — 5 new cases pass
- [x] ASan + UBSan (`build-asan/`) — C++ & Ry self-test clean
- [x] TSan (`build-tsan/`) — C++ clean, self-test clean
- [x] libFuzzer — `fuzz_parser` / `fuzz_json` / `fuzz_utf8` each 60s, no crashes
- [x] FileCheck goldens — 10/10 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed ambiguous overload resolution errors that occurred when lambda functions called `@native` operations on pointer-backed collection types (such as `str`, `List`, `Map`, `Set`). Lambdas now correctly propagate and preserve source-level type metadata for captured collection variables, ensuring proper dispatch to the intended native function overload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->