### PR TITLE
fix: support Set<(T, U)> in for-loop multi-variable destructure (#1350)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -5108,3 +5108,26 @@ The retain discipline is **symmetric** with the destructor:
 **Rule**: Any higher-order boundary that unwraps a `Result<T, E>` / `Option<T>` payload or calls an indirect lambda must restore metadata for pointer-backed named types. `CreateExtractValue` drops the payload's `ValueMetadata`, and indirect calls return a fresh SSA value with no metadata unless `FnTypeInfo.returnTypeName` is re-applied.
 
 **How to apply**: Mirror the `?` operator path in combinators: after extracting `ok_val` / `some_val`, call `propagateMeta(wrapper, payload)` before passing the value into the callback. In `emitLambdaCall`, always stamp the call result from `FnTypeInfo.returnTypeName` (and `returnFnTypeInfo` for function-typed returns). For lambda return-name inference on `VariableExpr`, prefer `buildTypeNameFromMeta()` over raw `reverseResolveTypeName()` so resource / `JsonValue` names survive opaque-pointer lowering.
+
+---
+
+### For-loop multi-variable destructure and `Set<X>` annotation propagation both trailed the List path until #1350
+
+**Source**: #1350 (2026-04-24, implementation). **Tags**: codegen, for-loop, destructure, set, tuple, metadata, set_elem_type_name
+
+**Rule**: Two asymmetries between the Set and List codepaths were latent until the multi-variable destructure case surfaced them:
+
+1. **Multi-variable for-loop binding path** (`src/codegen_stmt_loop.cpp` multi-var branch) treated "not a map" as "must be a list" and emitted `"for loop destructuring requires a list of tuples"` for any `Set<(T, U)>`. The single-variable path (same file, single-var branch) had already mirrored the Set-first / List-fallback shape via `getSetElementType` + `setHeaderTy_` with `getListElementType` + `listHeaderTy_` as fallback. Multi-var must use the exact same shape — switch the local `headerTy` variable between `setHeaderTy_` and `listHeaderTy_`, set snapshot metadata to `TypeMeta::SetElem` vs `TypeMeta::ListElem`, and prefer `set_elem_type_name` over `list_elem_type_name` when reading the tuple source name for `emitForBindingPattern`. `List` / `Set` headers share field 0 (len) and field 2 (data ptr), so existing GEP arithmetic is reusable.
+
+2. **`Set<X>` annotation → `set_elem_type_name` propagation** in `codegen_stmt.cpp`'s `emitVarDecl` narrowed the inner type to `{List|Map|Set|FnType}`, so named non-primitive tuple/enum/record/alias inners were dropped. The sibling `List<X>` path (#1320) had already switched to a denylist (`inner != "str" && inner != "int" && inner != "float" && inner != "bool"`). Mirror that denylist on Set, otherwise `Set<(str, List<int>)>` annotations never carry `"(str, List<int>)"` down to the for-loop, and `sum(v)` in the destructured body fails with "sum() requires a list" even after the codegen_stmt_loop fix is in place.
+
+**Why**: These are the same class of asymmetry: every time a List-side enhancement lands (destructure dispatch, annotation denylist widening), the Set-side equivalent should be ported in the same PR unless there is a concrete reason to diverge. The List/Set iteration machinery deliberately shares header layout, so divergent codepaths are a code smell.
+
+**How to apply**:
+
+- Before declaring a List-specific fix complete, grep for sibling `getSetElementType` / `setHeaderTy_` / `set_elem_type_name` sites and check whether the same logic belongs there.
+- The single-variable for-loop path (L324-407) is the canonical Set-first / List-fallback template; new iteration features should mirror both simultaneously.
+- Test both collection-destructure shapes (`for a, b in listOfTuples`, `for a, b in setOfTuples`) whenever a binding-related for-loop change lands.
+- Follow-up candidate: extract the shared `(elemTy, headerTy, typeName, headerMetaKind)` lookup into a helper so multi-var and single-var paths stop growing copy-paste in parallel. Not blocking for v0.0.13, but worth filing if another divergence shows up.
+
+---

--- a/changelog.d/1350-for-destructure-set.md
+++ b/changelog.d/1350-for-destructure-set.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `for a, b in setOfTuples:` no longer fails with "for loop destructuring requires a list of tuples". The multi-variable for-loop binding path now handles `Set<(T, U)>` alongside maps and lists of tuples, and source-level element type names on `Set<T>` annotations are propagated for non-primitive inner types (collections, records, enums, tuples). (#1350)

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -209,7 +209,7 @@ for k, v in map_expr:
 
 ### Tuple Destructuring
 
-When iterating over a list of tuples, you can destructure into N variables matching the tuple's element count. Use `_` to discard a value.
+When iterating over a list or set of tuples, you can destructure into N variables matching the tuple's element count. Use `_` to discard a value.
 
 ```ry
 xs = [10, 20, 30]
@@ -235,6 +235,11 @@ for a, _, c in triples:
 items = [("a", 1), ("b", 2), ("c", 3)]
 for i, (k, v) in enumerate(items):
     print(f"{i}: {k}={v}")  # 0: a=1, 1: b=2, 2: c=3
+
+# Sets of tuples destructure the same way (unordered traversal)
+pairs: Set<(int, int)> = {(1, 2), (3, 4)}
+for a, b in pairs:
+    print(a + b)          # 3, 7 (order unspecified)
 ```
 
 Statement-level destructuring assignment is also available and accepts both a bare and a parenthesized LHS. See [directives.md#const](directives.md) for the `@const` variant.

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -229,10 +229,15 @@ void CodeGen::emitVarDecl(const std::string &name,
             setTypeMeta(TypeMeta::SetElem, ptr, elemTy);
             {
                 const std::string resolvedInner = resolveTypeAlias(inner);
-                if (isFunctionTypeName(resolvedInner))
+                if (isFunctionTypeName(resolvedInner)) {
                     getOrCreateMeta(ptr).set_elem_fn_type_info = parseFnTypeAnnotation(resolvedInner);
-                else if (isListTypeName(resolvedInner) || isMapTypeName(resolvedInner) || isSetTypeName(resolvedInner))
+                } else if (resolvedInner != "str" && resolvedInner != "int" &&
+                           resolvedInner != "float" && resolvedInner != "bool") {
+                    // Symmetric to the non-empty Set literal path below: keep
+                    // named non-primitive inner types so later destructure /
+                    // element access can rebuild metadata (#1350).
                     getOrCreateMeta(ptr).set_elem_type_name = resolvedInner;
+                }
             }
             markArcManaged(ptr);
             if (is_immutable)

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -816,10 +816,18 @@ void CodeGen::emitVarDecl(const std::string &name,
                 isSetTypeName(resolvedAnnot) && resolvedAnnot.size() > 4 && resolvedAnnot.back() == '>') {
                 std::string inner = resolvedAnnot.substr(4, resolvedAnnot.size() - 5);
                 while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
-                if (isListTypeName(inner) || isMapTypeName(inner) || isSetTypeName(inner))
-                    setn = inner;
-                else if (isFunctionTypeName(inner))
+                if (isFunctionTypeName(inner)) {
                     sefti = parseFnTypeAnnotation(inner);
+                } else if (inner != "str" && inner != "int" && inner != "float" && inner != "bool") {
+                    // `str` is intentionally excluded: Set has no
+                    // `set_elem_is_str` side channel (unlike List<str> via
+                    // #1266), and TypeMeta::SetElem already carries the i8
+                    // LLVM type. Everything else — collections, records,
+                    // enums, aliases, tuples like "(str, List<int>)" — is
+                    // kept so for-loop destructure can rebuild component
+                    // metadata via propagateTypeMeta / splitTypeArgs.
+                    setn = inner;
+                }
             }
             if (!setn.empty()) {
                 getOrCreateMeta(ptr).set_elem_type_name = setn;

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -171,10 +171,18 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
         llvm::Type *keyTy = getMapKeyType(iterable);
         llvm::Type *valTy = getMapValueType(iterable);
         if (!keyTy || !valTy) {
-            llvm::Type *elemTy = getListElementType(iterable);
+            // Set and list share the same {len, cap, data*} prefix, so once
+            // headerTy is picked the GEP arithmetic is identical.
+            llvm::Type *elemTy = getSetElementType(iterable);
+            llvm::StructType *headerTy = setHeaderTy_;
+            if (!elemTy) {
+                elemTy = getListElementType(iterable);
+                headerTy = listHeaderTy_;
+            }
+            const bool isSet = (headerTy == setHeaderTy_);
             auto *structTy = llvm::dyn_cast_or_null<llvm::StructType>(elemTy);
             if (!structTy)
-                codegenError("for loop destructuring requires a list of tuples");
+                codegenError("for loop destructuring requires a list or set of tuples");
 
             // Snapshot the iterable to prevent UAF when the source alias is
             // mutated inside the loop body (#1021, #1041). Applies when the
@@ -192,19 +200,20 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
                     "__for_iter_snap_" + std::to_string(for_snap_counter_++);
                 tupleSnapAlloca = getOrCreateVar(snapName, ptrTy_);
                 builder_.CreateStore(iterable, tupleSnapAlloca);
-                setTypeMeta(TypeMeta::ListElem, tupleSnapAlloca, structTy);
+                setTypeMeta(isSet ? TypeMeta::SetElem : TypeMeta::ListElem,
+                            tupleSnapAlloca, structTy);
                 markArcManaged(tupleSnapAlloca);
                 llvm::Value *snap0 =
                     builder_.CreateLoad(ptrTy_, tupleSnapAlloca, "for_snap");
                 llvm::Value *lenPtr =
-                    builder_.CreateStructGEP(listHeaderTy_, snap0, 0, "for_len_ptr");
+                    builder_.CreateStructGEP(headerTy, snap0, 0, "for_len_ptr");
                 length = builder_.CreateLoad(i64Ty_, lenPtr, "for_len");
             } else {
                 llvm::Value *lenPtr =
-                    builder_.CreateStructGEP(listHeaderTy_, iterable, 0, "for_len_ptr");
+                    builder_.CreateStructGEP(headerTy, iterable, 0, "for_len_ptr");
                 length = builder_.CreateLoad(i64Ty_, lenPtr, "for_len");
                 llvm::Value *dataPtrField =
-                    builder_.CreateStructGEP(listHeaderTy_, iterable, 2, "for_data_ptr");
+                    builder_.CreateStructGEP(headerTy, iterable, 2, "for_data_ptr");
                 tupleDataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "for_data");
             }
 
@@ -213,8 +222,12 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
             // invalidate any pointer we hold across the boundary (same pattern
             // as the single-variable path below).
             std::string tupleTypeName;
-            if (auto *iterMeta = getMeta(iterable))
-                tupleTypeName = iterMeta->list_elem_type_name;
+            if (auto *iterMeta = getMeta(iterable)) {
+                if (isSet && !iterMeta->set_elem_type_name.empty())
+                    tupleTypeName = iterMeta->set_elem_type_name;
+                else
+                    tupleTypeName = iterMeta->list_elem_type_name;
+            }
 
             emitIndexedForLoop(length, s->body, [&](llvm::Value *iCur) {
                 llvm::Value *dataPtr;
@@ -222,7 +235,7 @@ void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
                     llvm::Value *snap =
                         builder_.CreateLoad(ptrTy_, tupleSnapAlloca, "for_snap");
                     llvm::Value *dataPtrField =
-                        builder_.CreateStructGEP(listHeaderTy_, snap, 2, "for_data_ptr");
+                        builder_.CreateStructGEP(headerTy, snap, 2, "for_data_ptr");
                     dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "for_data");
                 } else {
                     dataPtr = tupleDataPtr;

--- a/tests/spec/for_loop_destructure_meta.test.ry
+++ b/tests/spec/for_loop_destructure_meta.test.ry
@@ -136,4 +136,14 @@ describe("for-loop destructure preserves collection element metadata (#813)", ()
       iterations = iterations + 1 + a + b
     expect(iterations).to_eq(0)
   )
+
+  it("should preserve Set<(str, List<int>)> annotation metadata across empty-literal + add + destructure (#1350 CodeRabbit)", ():
+    s: Set<(str, List<int>)> = {}
+    add(s, ("a", [1, 2, 3]))
+    add(s, ("b", [10, 20]))
+    total: int = 0
+    for k, v in s:
+      total = total + sum(v)
+    expect(total).to_eq(36)
+  )
 )

--- a/tests/spec/for_loop_destructure_meta.test.ry
+++ b/tests/spec/for_loop_destructure_meta.test.ry
@@ -96,4 +96,44 @@ describe("for-loop destructure preserves collection element metadata (#813)", ()
       total = total + x
     expect(total).to_eq(60)
   )
+
+  it("should destructure Set<(T, U)> tuple elements in for loop (#1350)", ():
+    s: Set<(int, int)> = {(1, 2), (3, 4)}
+    total: int = 0
+    for a, b in s:
+      total = total + a + b
+    expect(total).to_eq(10)
+  )
+
+  it("should propagate metadata through Set<(str, List<int>)> destructuring (#1350)", ():
+    s: Set<(str, List<int>)> = {("a", [1, 2]), ("b", [3, 4, 5])}
+    total: int = 0
+    for k, v in s:
+      total = total + sum(v)
+    expect(total).to_eq(15)
+  )
+
+  it("should support wildcard in Set<(T, U)> destructuring (#1350)", ():
+    s: Set<(int, int)> = {(1, 100), (2, 200)}
+    total: int = 0
+    for _, b in s:
+      total = total + b
+    expect(total).to_eq(300)
+  )
+
+  it("should destructure three-element Set<(T, U, V)> (#1350)", ():
+    s: Set<(int, int, int)> = {(1, 2, 3), (4, 5, 6)}
+    total: int = 0
+    for a, b, c in s:
+      total = total + a + b + c
+    expect(total).to_eq(21)
+  )
+
+  it("should handle empty Set<(T, U)> in for-loop destructure without executing body (#1350)", ():
+    s: Set<(int, int)> = {}
+    iterations: int = 0
+    for a, b in s:
+      iterations = iterations + 1 + a + b
+    expect(iterations).to_eq(0)
+  )
 )


### PR DESCRIPTION
## Summary

- `for a, b in setOfTuples:` previously failed with `"for loop destructuring requires a list of tuples"`. The multi-variable binding path in `src/codegen_stmt_loop.cpp` treated every non-map iterable as a list, so `Set<(T, U)>` was rejected before element lookup.
- Mirror the single-variable Set-first / List-fallback pattern (`getSetElementType` + `setHeaderTy_`, falling back to `getListElementType` + `listHeaderTy_`). `List` and `Set` headers share the `{len, cap, data*}` prefix, so the existing GEP arithmetic is reused once `headerTy` is picked. Snapshot `TypeMeta` is routed to `SetElem` vs `ListElem`, and `set_elem_type_name` is preferred when reading the source-level tuple name for `emitForBindingPattern`.

### Scope expansion: `codegen_stmt.cpp` Set annotation path

The `Set<X>` annotation path in `emitVarDecl` previously narrowed the stored inner type to `{List|Map|Set|FnType}`, dropping tuple/enum/record/alias inner types. This PR mirrors the `List<X>` denylist (#1320) so `Set<(str, List<int>)>` annotations actually carry `"(str, List<int>)"` down to the for-loop — otherwise `sum(v)` inside the destructured body fails even after the codegen_stmt_loop fix. **This is wider than the original bug**: named non-primitive inner types (records, enums, aliases, tuples) on `Set<T>` annotations are now propagated as well. `str` stays excluded because Set has no `set_elem_is_str` side channel (unlike List<str> via #1266); `TypeMeta::SetElem` already carries the `i8` LLVM type.

## Test plan

- [x] `./build/ry test tests/spec/for_loop_destructure_meta.test.ry` (16/16, including 5 new `#1350` cases: basic / metadata propagation via `sum(v)` / wildcard / 3-tuple / empty Set)
- [x] `./build/ry_tests` (1937 C++ tests)
- [x] `./build/ry test -p` (168 Ry spec files, 0 failures)
- [x] ASan + UBSan clean
- [x] TSan clean (C++ required tests)
- [x] FileCheck 10/10 pass
- [x] libFuzzer parser/json/utf8 @ 60s each — clean

## Docs & artifacts

- `docs/reference/control-flow.md` — Tuple Destructuring section updated ("list or set of tuples") + new `Set<(int, int)>` example.
- `changelog.d/1350-for-destructure-set.md` — `### Fixed` fragment.
- `KNOWLEDGE.md` — new entry documenting both asymmetries (multi-var for-loop path & `Set<X>` annotation inner-type denylist) trailing the List-side equivalents until this PR, plus a follow-up candidate to extract the shared `(elemTy, headerTy)` selection helper.

Closes #1350

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tuple destructuring in for-loops to support sets: `for a, b in setOfTuples:` no longer errors.
  * Preserved element-type metadata for sets with non-primitive inner types so destructuring and element access work correctly.

* **Documentation**
  * Control-flow docs updated with examples showing tuple destructuring over sets and a note about unspecified iteration order.

* **Tests**
  * Added tests covering multi-variable destructuring and metadata preservation when iterating sets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->