### PR TITLE
fix: suggest Task<T>/Channel<T> in self-referential enum diagnostic (#1351)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3566,8 +3566,10 @@ component, or inside an arbitrary non-indirection generic (`Option<Tree>`,
 `Pair<Tree, Tree>`). The helper treats `List<_>`, `Map<_, _>`, `Set<_>`, `Task<_>`,
 `Channel<_>`, `weak T`, and `fn(...)` as pointer-backed indirection and stops
 descending — their payload is boxed, so the layout is finite. The recommendation message
-points users to `List<T>`, `Map<K, T>`, and `Set<T>`; it intentionally excludes `weak T`
-because weak requires an ARC-managed payload and does not apply to an arbitrary ADT.
+points users to container indirections: `List<T>`, `Map<K, V>`, `Set<T>`, `Task<T>`, and
+`Channel<T>` (#1351). It intentionally excludes `weak T` (weak requires an ARC-managed
+payload, and a separate diagnostic already rejects `weak <ADT>`) and `fn(...)` (unusual
+choice for data storage).
 
 **Why**: An earlier substring-based check on the field's `toString()` only caught the bare
 name and the generic base (`ftStr.substr(0, ftStr.find('<'))`). That missed `Tree?`,

--- a/changelog.d/1351-self-ref-enum-diagnostic-task-channel.md
+++ b/changelog.d/1351-self-ref-enum-diagnostic-task-channel.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Self-referential enum diagnostic now also suggests `Task<T>` and `Channel<T>` as valid indirection wrappers, aligning the recommendation with the existing checker's acceptance. The message previously only mentioned `List`/`Map`/`Set`, even though pointer-backed `Task<T>` and `Channel<T>` are equally valid indirections. (#1351)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -572,7 +572,7 @@ enum Tree:
     Node(int, Tree, Tree)   # error: self-referential field requires infinite storage
 ```
 
-Wrap the recursive field in an indirection type — `List<T>`, `Map<K, V>`, or `Set<T>` — which is stored as a pointer and therefore has a fixed layout:
+Wrap the recursive field in an indirection type — `List<T>`, `Map<K, V>`, `Set<T>`, `Task<T>`, or `Channel<T>` — which is stored as a pointer and therefore has a fixed layout:
 
 ```ry
 enum Tree:

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -505,8 +505,12 @@ void CodeGen::emitStmt(EnumStmt &s) {
     // Tree))`, and `Node(Option<Tree>)` all get the same diagnostic as
     // `Node(Tree)`. Stops at true indirections (`List`, `Map`, `Set`, `Task`,
     // `Channel`, `weak T`, `fn(...)`) — those store the payload behind
-    // a pointer so the enum layout stays finite. Must run before the generic-
-    // template save below so `generic_enum_templates_` never stores a
+    // a pointer so the enum layout stays finite. The recommendation message
+    // below only suggests container indirections (`List`/`Map`/`Set`/`Task`/
+    // `Channel`): `weak T` is omitted because it requires an ARC-managed
+    // payload (a separate diagnostic rejects `weak <ADT>`), and `fn(...)` is
+    // omitted as an unusual choice for data storage. Must run before the
+    // generic-template save below so `generic_enum_templates_` never stores a
     // self-ref template that would crash at instantiation with `unknown
     // type: T`. Auto-boxing is the proper fix for the general case and is
     // tracked as a follow-up.
@@ -530,8 +534,10 @@ void CodeGen::emitStmt(EnumStmt &s) {
             msg += "' which would require infinite storage; ";
             msg += "wrap the field in an indirection type such as ";
             msg += "`List<"; msg += qualifiedName; msg += ">`, ";
-            msg += "`Map<K, "; msg += qualifiedName; msg += ">`, or ";
-            msg += "`Set<"; msg += qualifiedName; msg += ">`";
+            msg += "`Map<K, "; msg += qualifiedName; msg += ">`, ";
+            msg += "`Set<"; msg += qualifiedName; msg += ">`, ";
+            msg += "`Task<"; msg += qualifiedName; msg += ">`, or ";
+            msg += "`Channel<"; msg += qualifiedName; msg += ">`";
             codegenError(msg);
         }
     }

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -525,7 +525,8 @@ TEST_F(CodeGenTest, RecursiveEnumInlineSelfRefDiagnostic) {
         "enum Tree:\n"
         "  Leaf(int)\n"
         "  Node(int, Tree, Tree)\n",
-        {"enum 'Tree'", "self-referential", "List<Tree>"});
+        {"enum 'Tree'", "self-referential", "List<Tree>", "Task<Tree>",
+         "Channel<Tree>"});
 }
 
 TEST_F(CodeGenTest, RecursiveEnumInlineSelfRefAllowedInsideList) {
@@ -549,6 +550,24 @@ TEST_F(CodeGenTest, RecursiveEnumInlineSelfRefAllowedInsideSet) {
         "enum Tree:\n"
         "  Leaf(int)\n"
         "  Node(int, Set<Tree>)\n"));
+}
+
+TEST_F(CodeGenTest, RecursiveEnumInlineSelfRefAllowedInsideTask) {
+    // `Task<Tree>` stores the payload behind an async-handle pointer, so the
+    // enum layout is finite.
+    ASSERT_NO_THROW(compileSource(
+        "enum Tree:\n"
+        "  Leaf(int)\n"
+        "  Node(int, Task<Tree>)\n"));
+}
+
+TEST_F(CodeGenTest, RecursiveEnumInlineSelfRefAllowedInsideChannel) {
+    // `Channel<Tree>` stores the payload behind a channel-handle pointer, so
+    // the enum layout is finite.
+    ASSERT_NO_THROW(compileSource(
+        "enum Tree:\n"
+        "  Leaf(int)\n"
+        "  Node(int, Channel<Tree>)\n"));
 }
 
 // #1203: generic enums that self-reference (e.g.


### PR DESCRIPTION
## Summary

Closes #1351.

- The `containsInlineSelfReference` checker in `src/codegen_stmt_misc.cpp` already treats `Task<_>` and `Channel<_>` as pointer-backed indirections, but the diagnostic message only mentioned `List`/`Map`/`Set`. This PR aligns the recommendation with the checker's actual acceptance.
- `weak T` and `fn(...)` are intentionally left out of the message even though the checker accepts them:
  - **`weak T`**: a separate diagnostic rejects `weak <ADT>` ("weak references require an ARC-managed type"), so suggesting it would lead users to a different error. Verified via manual `./build/ry -c` primary-source testing.
  - **`fn(...)`**: technically accepted but an unusual choice for data storage.
- KNOWLEDGE.md entry for #1203 updated to reflect the expanded suggestion list and the explicit omission rationale, so future contributors don't re-propose adding `weak`/`fn`.
- `docs/reference/types.md` (user-facing self-referential enum guidance) updated to match.

## Test plan

- [x] `cmake --build build && ./build/ry_tests` — all tests pass (incl. 2 new `RecursiveEnumInlineSelfRefAllowedInside{Task,Channel}` cases + extended `RecursiveEnumInlineSelfRefDiagnostic` asserting `Task<Tree>`/`Channel<Tree>` in the message)
- [x] `./build/ry test -p` — Ry self-test suite passes
- [x] ASan + UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p` clean
- [x] TSan: `./build-tsan/ry_tests` clean (Ry self-test warn-only per upstream LargeMmapAllocator issue)
- [x] libFuzzer: fuzz_parser / fuzz_json / fuzz_utf8 each 60s clean
- [x] Manual smoke via `./build/ry -c`: new message includes `Task<Tree>`/`Channel<Tree>`; `Task<Tree>`/`Channel<Tree>` compile successfully; `weak Tree` rejected by separate ARC diagnostic as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for resolving self-referential enum compilation errors to include `Task<T>` and `Channel<T>` as additional indirection wrapper options alongside existing suggestions.
  * Updated compiler diagnostic messages to reflect the complete set of recommended indirection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->