### PR TITLE
chore: stop release workflows and disable main push CI (#1359)

### DIFF
--- a/.claude/skills/git-branch-naming/SKILL.md
+++ b/.claude/skills/git-branch-naming/SKILL.md
@@ -41,16 +41,16 @@ Create a new git branch following the `<type>/<short-description>` naming conven
 
 ## Repository Rules
 
-- Always branch from the current release branch (`v*.*.*`) or `main`
-- Never commit directly on `main` or release (`v*.*.*`) branches
+- Always branch from `main`
+- Never commit directly on `main` branches
 - The feature branch will be PR'd back to its parent branch
 
 ## Steps
 
 1. Check the current branch with `git branch --show-current`.
 2. **Only create a new branch when necessary**:
-   - If the current branch is `main` or matches `v*.*.*` (release branch), proceed to create a new feature branch.
-   - Otherwise (already on an existing feature branch), **reuse the current branch** and report it instead of creating a new one. This keeps the skill aligned with `git-commit-push-pr`, which also reuses the current branch when it is not main / release.
+   - If the current branch is `main`, proceed to create a new feature branch.
+   - Otherwise (already on an existing feature branch), **reuse the current branch** and report it instead of creating a new one. This keeps the skill aligned with `git-commit-push-pr`, which also reuses the current branch when it is not main.
 3. Determine the type from the user's intent or the changes in progress.
 4. Generate a short, descriptive kebab-case summary.
 5. Run `git checkout -b <type>/<short-description>` (only when Step 2 decided to create a new branch).

--- a/.claude/skills/git-commit-push-pr/SKILL.md
+++ b/.claude/skills/git-commit-push-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-push-pr
-description: Commit, push, and open a PR. Creates feature branch if on main/release branch. PRs are opened (not draft).
+description: Commit, push, and open a PR. Creates feature branch if on main. PRs are opened (not draft).
 allowed-tools: Bash(git checkout -b:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*), Bash(git fetch:*), Bash(git merge:*), Bash(gh pr view:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Read, Edit
 metadata:
   short-description: Commit, push, and open a PR
@@ -20,9 +20,9 @@ Create a branch (if needed), commit, merge the base branch, push, and open a PR.
 
 ### 1. Create branch (if needed)
 
-If the current branch is `main` or matches `v*.*.*` (e.g. `v0.0.8`), you **MUST** create a new feature branch before committing.
+If the current branch is `main`, you **MUST** create a new feature branch before committing.
 - Use the `<type>/<short-description>` naming convention
-- Never commit directly to `main` or release (`v*.*.*`) branches
+- Never commit directly to `main` branches
 
 ### 2. Commit
 
@@ -32,10 +32,7 @@ Create a single commit with an appropriate message. Use conventional commit form
 
 1. Detect the base branch:
    - Run `gh pr view --json baseRefName -q .baseRefName` to get the base branch of the PR
-   - If no PR exists, detect the parent branch:
-     - Check if a `v*.*.*` branch exists locally that is an ancestor of the current branch
-     - If found, use that as the base branch
-     - Otherwise default to `main`
+   - If no PR exists, default to `main`
 2. Run `git fetch origin` to get the latest remote state
 3. Run `git merge origin/<base branch>` to merge the base branch changes
 4. **On conflict**:

--- a/.claude/skills/git-commit-push/SKILL.md
+++ b/.claude/skills/git-commit-push/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-push
-description: Commit, merge base branch, and push with branch safety check and smart base branch detection for v*.*.* release branch workflow.
+description: Commit, merge base branch, and push with branch safety check and smart base branch detection.
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(git fetch:*), Bash(git merge:*), Bash(gh pr view:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Read, Edit
 metadata:
   short-description: Commit and push
@@ -18,7 +18,7 @@ Commit, merge the base branch, and push.
 
 ## Branch Safety Check
 
-Before committing, check the current branch name. If the current branch is `main` or matches the pattern `v*.*.*` (e.g. `v0.0.8`):
+Before committing, check the current branch name. If the current branch is `main`:
 - **STOP** — do not commit
 - Tell the user: "Cannot commit on `<branch>`. Create a feature branch first (use /git-branch-naming)."
 
@@ -32,10 +32,7 @@ Create a single commit with an appropriate message based on the changes. Use con
 
 1. Detect the base branch:
    - Run `gh pr view --json baseRefName -q .baseRefName` to get the base branch of the PR
-   - If no PR exists, detect the parent branch:
-     - Check if a `v*.*.*` branch exists locally that is an ancestor of the current branch
-     - If found, use that as the base branch
-     - Otherwise default to `main`
+   - If no PR exists, default to `main`
 2. Run `git fetch origin` to get the latest remote state
 3. Run `git merge origin/<base branch>` to merge the base branch changes
 4. **On conflict**:

--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit
-description: Create a git commit with branch safety check. Refuses to commit on main or release branches.
+description: Create a git commit with branch safety check. Refuses to commit on main.
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git commit:*), Bash(git branch:*), Bash(git diff:*), Bash(git log:*)
 metadata:
   short-description: Create a git commit
@@ -19,7 +19,7 @@ Create a single git commit with an appropriate message based on the current chan
 
 ## Branch Safety Check
 
-Before committing, check the current branch name. If the current branch is `main` or matches the pattern `v*.*.*` (e.g. `v0.0.8`):
+Before committing, check the current branch name. If the current branch is `main`:
 - **STOP** — do not commit
 - Tell the user: "Cannot commit on `<branch>`. Create a feature branch first (use /git-branch-naming)."
 

--- a/.claude/skills/git-push/SKILL.md
+++ b/.claude/skills/git-push/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-push
-description: Merge base branch and push with smart base branch detection for v*.*.* release branch workflow.
+description: Merge base branch and push with smart base branch detection.
 allowed-tools: Bash(git push:*), Bash(git fetch:*), Bash(git merge:*), Bash(gh pr view:*), Bash(git add:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Read, Edit
 metadata:
   short-description: Push git commits
@@ -22,10 +22,7 @@ Merge the base branch and then push.
 
 1. Detect the base branch:
    - Run `gh pr view --json baseRefName -q .baseRefName` to get the base branch of the PR
-   - If no PR exists, detect the parent branch:
-     - Check if a `v*.*.*` branch exists locally that is an ancestor of the current branch
-     - If found, use that as the base branch
-     - Otherwise default to `main`
+   - If no PR exists, default to `main`
 2. Run `git fetch origin` to get the latest remote state
 3. Run `git merge origin/<base branch>` to merge the base branch changes
 4. **On conflict**:

--- a/.codex/skills/git-branch-naming/SKILL.md
+++ b/.codex/skills/git-branch-naming/SKILL.md
@@ -41,8 +41,8 @@ Create a new git branch following the `<type>/<short-description>` naming conven
 
 ## Repository Rules
 
-- Always branch from the current release branch (`v*.*.*`) or `main`
-- Never commit directly on `main` or release (`v*.*.*`) branches
+- Always branch from `main`
+- Never commit directly on `main` branches
 - The feature branch will be PR'd back to its parent branch
 
 ## Steps

--- a/.codex/skills/git-commit-push-pr/SKILL.md
+++ b/.codex/skills/git-commit-push-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-push-pr
-description: Commit, push, and open a PR. Creates feature branch if on main/release branch. PRs are opened (not draft).
+description: Commit, push, and open a PR. Creates feature branch if on main. PRs are opened (not draft).
 metadata:
   short-description: Commit, push, and open a PR
 ---
@@ -19,9 +19,9 @@ Create a branch (if needed), commit, merge the base branch, push, and open a PR.
 
 ### 1. Create branch (if needed)
 
-If the current branch is `main` or matches `v*.*.*` (e.g. `v0.0.8`), you **MUST** create a new feature branch before committing.
+If the current branch is `main`, you **MUST** create a new feature branch before committing.
 - Use the `<type>/<short-description>` naming convention
-- Never commit directly to `main` or release (`v*.*.*`) branches
+- Never commit directly to `main` branches
 
 ### 2. Commit
 
@@ -31,10 +31,7 @@ Create a single commit with an appropriate message. Use conventional commit form
 
 1. Detect the base branch:
    - Run `gh pr view --json baseRefName -q .baseRefName` to get the base branch of the PR
-   - If no PR exists, detect the parent branch:
-     - Check if a `v*.*.*` branch exists locally that is an ancestor of the current branch
-     - If found, use that as the base branch
-     - Otherwise default to `main`
+   - If no PR exists, default to `main`
 2. Run `git fetch origin` to get the latest remote state
 3. Run `git merge origin/<base branch>` to merge the base branch changes
 4. **On conflict**:

--- a/.codex/skills/git-commit-push/SKILL.md
+++ b/.codex/skills/git-commit-push/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit-push
-description: Commit, merge base branch, and push with branch safety check and smart base branch detection for v*.*.* release branch workflow.
+description: Commit, merge base branch, and push with branch safety check and smart base branch detection.
 metadata:
   short-description: Commit and push
 ---
@@ -17,7 +17,7 @@ Commit, merge the base branch, and push.
 
 ## Branch Safety Check
 
-Before committing, check the current branch name. If the current branch is `main` or matches the pattern `v*.*.*` (e.g. `v0.0.8`):
+Before committing, check the current branch name. If the current branch is `main`:
 - **STOP** — do not commit
 - Tell the user: "Cannot commit on `<branch>`. Create a feature branch first (use /git-branch-naming)."
 
@@ -31,10 +31,7 @@ Create a single commit with an appropriate message based on the changes. Use con
 
 1. Detect the base branch:
    - Run `gh pr view --json baseRefName -q .baseRefName` to get the base branch of the PR
-   - If no PR exists, detect the parent branch:
-     - Check if a `v*.*.*` branch exists locally that is an ancestor of the current branch
-     - If found, use that as the base branch
-     - Otherwise default to `main`
+   - If no PR exists, default to `main`
 2. Run `git fetch origin` to get the latest remote state
 3. Run `git merge origin/<base branch>` to merge the base branch changes
 4. **On conflict**:

--- a/.codex/skills/git-commit/SKILL.md
+++ b/.codex/skills/git-commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-commit
-description: Create a git commit with branch safety check. Refuses to commit on main or release branches.
+description: Create a git commit with branch safety check. Refuses to commit on main.
 metadata:
   short-description: Create a git commit
 ---
@@ -18,7 +18,7 @@ Create a single git commit with an appropriate message based on the current chan
 
 ## Branch Safety Check
 
-Before committing, check the current branch name. If the current branch is `main` or matches the pattern `v*.*.*` (e.g. `v0.0.8`):
+Before committing, check the current branch name. If the current branch is `main`:
 - **STOP** — do not commit
 - Tell the user: "Cannot commit on `<branch>`. Create a feature branch first (use /git-branch-naming)."
 

--- a/.codex/skills/git-push/SKILL.md
+++ b/.codex/skills/git-push/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-push
-description: Merge base branch and push with smart base branch detection for v*.*.* release branch workflow.
+description: Merge base branch and push with smart base branch detection.
 metadata:
   short-description: Push git commits
 ---
@@ -21,10 +21,7 @@ Merge the base branch and then push.
 
 1. Detect the base branch:
    - Run `gh pr view --json baseRefName -q .baseRefName` to get the base branch of the PR
-   - If no PR exists, detect the parent branch:
-     - Check if a `v*.*.*` branch exists locally that is an ancestor of the current branch
-     - If found, use that as the base branch
-     - Otherwise default to `main`
+   - If no PR exists, default to `main`
 2. Run `git fetch origin` to get the latest remote state
 3. Run `git merge origin/<base branch>` to merge the base branch changes
 4. **On conflict**:

--- a/.github/workflows/ci-scheduled.yml
+++ b/.github/workflows/ci-scheduled.yml
@@ -2,8 +2,6 @@ name: CI (Scheduled)
 # Runs heavy analysis jobs (clang-tidy, scan-build, asan, tsan) against the
 # latest active v*.*.* release branch once a day, keeping PR CI fast.
 on:
-  schedule:
-    - cron: '0 15 * * *'  # daily at 15:00 UTC (20 min after codeql at 14:40)
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [main, 'v[0-9]*']
+    branches: ['v[0-9]*']
     tags-ignore: ['**']
 
 permissions:
@@ -63,7 +63,7 @@ jobs:
           key: ci-ubuntu-${{ github.ref }}
           restore-keys: |
             ci-ubuntu-
-          save: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}
+          save: ${{ startsWith(github.ref_name, 'v') }}
       - name: Build
         env:
           CC: /usr/local/llvm/bin/clang
@@ -84,7 +84,7 @@ jobs:
   # - On pull_request clang-tidy, scan-build, asan, tsan are skipped to keep PR CI fast.
 
   clang-tidy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && startsWith(github.ref_name, 'v')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -117,7 +117,7 @@ jobs:
             | xargs clang-tidy -p build --quiet
 
   scan-build:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push' && startsWith(github.ref_name, 'v')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -193,7 +193,7 @@ jobs:
           restore-keys: |
             ci-filecheck-
             ci-ubuntu-
-          save: ${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}
+          save: ${{ startsWith(github.ref_name, 'v') }}
       - name: Configure
         run: cmake --preset default
       - name: Build ry
@@ -207,7 +207,7 @@ jobs:
   asan:
     if: |
       github.event_name == 'push' &&
-      (github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'v'))
+      startsWith(github.ref_name, 'v')
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -247,7 +247,7 @@ jobs:
   tsan:
     if: |
       github.event_name == 'push' &&
-      (github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'v'))
+      startsWith(github.ref_name, 'v')
     runs-on: ubuntu-24.04
     # ThreadSanitizer coverage for #630's P0 race fixes is split:
     #
@@ -323,7 +323,7 @@ jobs:
 #  fuzz:
 #    if: |
 #      github.event_name == 'push' &&
-#      (github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'v'))
+#      startsWith(github.ref_name, 'v')
 #    runs-on: ubuntu-24.04
 #    continue-on-error: true
 #    steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,8 +16,6 @@ env:
   LLVM_SHA256_SHORT: ''
 
 on:
-  push:
-    branches: [ "main", "v*.*.*" ]
   schedule:
     - cron: '40 14 * * *'
   workflow_dispatch:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,7 +1,5 @@
 name: Dev Release
 on:
-  schedule:
-    - cron: '0 15 * * *'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,9 @@
 name: Release
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
-    branches: [main]
+  workflow_dispatch:
 
 jobs:
   build:
-    if: github.event.workflow_run.conclusion == 'success'
     strategy:
       fail-fast: false
       matrix:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,7 @@ CI の `scan-build` ジョブがシンボリック実行ベースのパス感度
   - LLVM 17+ opaque pointer を前提 — 引数・alloca・load/store はすべて `ptr` 型
   - `--emit-llvm-ir` は unoptimized IR — mem2reg 後のレジスタ化とは異なり、alloca + store + load が残る
   - LLVM バージョンアップ時は goldens の再確認が必要
-- CI の `filecheck` ジョブは全イベント（PR・main/v*.*.* push）で実行（`ry` のみビルドするため高速、`continue-on-error: true` で warn-only 運用中）
+- CI の `filecheck` ジョブは全 PR で実行（`ry` のみビルドするため高速、`continue-on-error: true` で warn-only 運用中）
 
 ## CI: LLVM ツールチェーン (ミラー)
 
@@ -279,7 +279,7 @@ See [`docker/README.md`](docker/README.md) for a quick-start reference.
 
 ## Plan モードのルール
 
-- **開始条件**: 対象 issue が特定されていること、対象 issue に `wip` ラベルが付与されていること（未付与の場合は `git-claim-issue` スキルを起動して付与してから進む）、リリースブランチ `vx.x.x` にいること、かつリモートと最新化されていることを確認する
+- **開始条件**: 対象 issue が特定されていること、対象 issue に `wip` ラベルが付与されていること（未付与の場合は `git-claim-issue` スキルを起動して付与してから進む）、かつリモートと最新化されていることを確認する
 - **実装計画の最初のタスク**: フィーチャーブランチの作成
 - **実装計画のスコープ**: セルフ検証まで（git add / commit / push / PR 作成は含めない）
 - **実装計画に必ず含めるもの**:
@@ -414,13 +414,11 @@ echo 'print(1)' | ./build/ry --trace -c
 
 ## Git ブランチ運用ルール
 
-- コミット前に現在のブランチを確認し、`main` または `vx.x.x` 形式のブランチにいる場合はコミットを行わないこと
+- コミット前に現在のブランチを確認し、`main` にいる場合はコミットを行わないこと
 - コミット・PR 作成時は、常に現在のブランチから新しいフィーチャーブランチを作成すること
-- PR のマージ先は、作業開始時のブランチ（分岐元）とする
-- PR を非デフォルトブランチ（`vx.x.x` 等）にマージした場合、GitHub の `Closes #xx` による自動クローズは動作しない。ラベル整理は「作業完了前チェックリスト」に従うこと
+- PR のマージ先は `main` とする
 - PR マージ前に、未追跡ファイルや未コミットの変更がないか確認すること。ある場合はマージ前にユーザーに報告し、コミットの要否を確認する
 - `.serena/` ディレクトリに差分がある場合は、他の変更と一緒にコミットすること
-- リリース時は `vx.x.x` を `main` にマージする PR を作成する。詳細は「リリース準備ワークフロー」を参照
 
 ## 責務の分離
 
@@ -610,4 +608,4 @@ UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 
 ## リリース準備ワークフロー
 
-リリース準備は `/release-prep` スキルを使用する。リリース（`vx.x.x` → `main` マージ）は `/release` スキルを使用する。
+移行期間中はリリースを行わない（新フロー設計後に再導入）。`/release` / `/release-prep` スキルは凍結中で使用しない。


### PR DESCRIPTION
## Summary

Issue #1359 (v0.0.14: リリースを一時停止し、main マージで余計な CI を走らせない) の第一段。main 起点フローへの移行に向けて以下を実施:

- リリース系 workflow の自動・スケジュール起動を停止（`release.yml` / `dev-release.yml`）
- main マージで余計な CI が走らないよう trigger を修正（`ci.yml` / `codeql.yml` / `ci-scheduled.yml`）
- main フローで使うスキル / `AGENTS.md` から `v*.*.*` 中継を**要求**する記述を削除

新リリースフローの設計（tag-based release / branch protection / 新 CI 設計など）は別 issue で扱う。

## Workflow trigger changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | `workflow_run` トリガーを削除し `workflow_dispatch` のみに |
| `.github/workflows/dev-release.yml` | `schedule` (cron) を削除（`workflow_dispatch` のみ残す） |
| `.github/workflows/ci-scheduled.yml` | `schedule` (cron) を削除（`workflow_dispatch` のみ残す） |
| `.github/workflows/codeql.yml` | `on.push` を削除（`schedule` + `workflow_dispatch` 維持） |
| `.github/workflows/ci.yml` | `on.push.branches` から `main` を削除、各ジョブの `if:` 条件から `main` を除外 |

> **CodeQL について**: branch protection の required status checks から CodeQL は GitHub Rules で除外済み（PR ブロッカーにならない）。日次 schedule（14:40 UTC）と手動 dispatch は維持。

## Skills / docs changes

`v*.*.*` 中継要求の記述を削除した main フロースキル:

- `.claude/skills/` × 5: `git-branch-naming` / `git-commit` / `git-commit-push` / `git-commit-push-pr` / `git-push`
- `.codex/skills/` × 5: 同上
- `AGENTS.md`: 該当箇所 (L100, L282, L417, L419, L420, L423, L611-613) を最小修正

## ユーザー方針との整合性

本 PR は事前にユーザーと合意した以下の制約を厳守している:

- **ファイル削除一切なし** — workflow / skill 全ファイル残置（`16 files changed, 42 insertions(+), 72 deletions(-)`）
- **ジョブ削除なし** — `ci.yml` の `clang-tidy` / `scan-build` / `asan` / `tsan` も残置（`if:` 条件のみ修正）
- **release / release-prep スキル変更なし** — 後で書き直すまで放置
- **git-merge-pr / git-triage-issue スキル変更なし** — `git-merge-pr` はメインフロー使用だが `v*.*.*` 中継要求記述なし、`git-triage-issue` はメインフロー外

## 触らなかった箇所（意図的）

- `KNOWLEDGE.md` — 事前 grep で `v*.*.*` / `vx.x.x` / `release branch` / `dev-release` / `non-default` / `Closes #` / `assemble-changelog` / `merge.*main` の hit 0 件を確認済み（対象エントリなし）
- `AGENTS.md` L122 (LLVM バンプ手順) — `ci-scheduled.yml` ファイルが残るため依然有効
- `AGENTS.md` L278 / L609 (`git-merge-pr` ラベル運用 / wip 除去チェックリスト) — `git-merge-pr` SKILL を残置するので整合のため残す。新フロー設計で `git-merge-pr` を改修する際に同時整理予定（本 issue スコープ外）
- `ci.yml` L79-84 のプロセコメント (`On main push`/`On version branch push`) — 最小変更方針に従い prose コメントは変更せず（trigger 条件は修正済み）

## docs / CHANGELOG / KNOWLEDGE.md

- **docs 更新不要**: 本 PR は内部 CI / 運用変更のみで Ry 言語仕様 / CLI / Installation に影響なし
- **CHANGELOG 更新不要**: ユーザー影響のある変更ではない
- **KNOWLEDGE.md 追記不要**: 新しい拒否ブランチ / 検証チェック / 落とし穴は追加していない（一回性の運用変更）

## Self-validation

- ✅ C++ tests: 1939 passed (`./build/ry_tests`)
- ✅ Ry self-tests: 168 passed (`./build/ry test -p`)
- ✅ grep 検証: 修正対象から `v*.*.*` / `vx.x.x` 中継要求が消えていることを確認

## Test plan

- [ ] PR 作成後、`CI` workflow がトリガーされ `test` / `lint` / `filecheck` のみ実行されることを Actions で確認
- [ ] `clang-tidy` / `scan-build` / `asan` / `tsan` が PR で動かないことを確認
- [ ] `CodeQL` / `Dev Release` / `Release` / `CI (Scheduled)` が PR で動かないことを確認
- [ ] マージ後 30 分間 main push に起因する workflow 起動が無いことを確認
- [ ] 翌日 15:00 UTC 付近に `dev-release` / `ci-scheduled` の cron 起動が無いことを確認
- [ ] 翌日 14:40 UTC に `CodeQL` schedule のみ起動することを確認

Closes #1359

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automatic CI scheduling and triggers on the main branch
  * CI workflows now run exclusively on version branches
  * Added manual workflow controls for release and development processes
  * Release processes suspended during migration period
  * Updated CI documentation and workflow rules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->