### PR TITLE
chore(ci): drop nightly prerelease when stable release is published (#1365)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,3 +173,15 @@ jobs:
             --notes-file release_notes.txt \
             --latest \
             $ASSETS
+
+      - name: Delete matching nightly prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          NIGHTLY_TAG="${{ steps.version.outputs.version }}-nightly"
+          if gh release view "$NIGHTLY_TAG" >/dev/null 2>&1; then
+            echo "Deleting nightly prerelease: $NIGHTLY_TAG"
+            gh release delete "$NIGHTLY_TAG" --yes --cleanup-tag
+          else
+            echo "No matching nightly prerelease to delete: $NIGHTLY_TAG"
+          fi

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -2609,6 +2609,28 @@ mismatches. An exact-match-only policy guarantees the correct toolchain.
 `release.yml` still uses `apt.llvm.org` directly and is not yet
 migrated — tracked as a separate follow-up from #892.
 
+### `--cleanup-tag` ban is scoped to LLVM mirror, not project-wide
+
+**Source**: #1365
+**Tags**: ci, github-actions, release, cleanup-tag, nightly
+
+**Rule**: The "do not reintroduce `--cleanup-tag`" warning above
+applies only to the LLVM mirror workflow, where the stable release
+pointer must remain downloadable continuously for many concurrent CI
+consumers. It is **not** a project-wide ban.
+
+For one-shot deletes of obsolete tags (e.g. dropping
+`vX.Y.Z-nightly` once the corresponding stable `vX.Y.Z` is published
+in `release.yml`), `--cleanup-tag` is preferred — it removes both the
+release and the matching git tag in one call, avoiding stale tags
+in `git tag -l`. `dev-release.yml` already uses `--cleanup-tag` for
+its per-branch nightly cleanup and stale-nightly cleanup steps.
+
+When evaluating a new use site, ask: does the deletion target compete
+with concurrent fetchers that need the tag/release available
+continuously? If yes (mirror-style), avoid `--cleanup-tag`. If no
+(one-shot retirement), `--cleanup-tag` is the cleaner choice.
+
 ### Compiler warning flags require SYSTEM includes for third-party headers
 
 **Source**: #895 (implementation)

--- a/changelog.d/1365-drop-nightly-on-stable-release.md
+++ b/changelog.d/1365-drop-nightly-on-stable-release.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `release.yml` now deletes the matching `vX.Y.Z-nightly` prerelease (and its tag) after a stable `vX.Y.Z` release is published, preventing `ry self-update` from pinning users to a stale nightly that predates the stable release. (#1365)


### PR DESCRIPTION
## Summary

- Add a `Delete matching nightly prerelease` step at the end of the `release` job in `.github/workflows/release.yml`. After a stable `vX.Y.Z` is published, it deletes the matching `vX.Y.Z-nightly` GitHub Release and its git tag (via `gh release delete --yes --cleanup-tag`).
- The step is idempotent: it first runs `gh release view "$NIGHTLY_TAG"` to confirm the prerelease exists. If absent, it logs a no-op message and exits 0. Workflow re-runs can therefore retroactively clean up existing leftovers (e.g. the current `v0.0.13-nightly`).
- Document in `KNOWLEDGE.md` that the existing `--cleanup-tag` warning above is scoped to the LLVM mirror workflow only, not project-wide. `dev-release.yml` already uses `--cleanup-tag` for nightly cleanup, and `release.yml` now joins that pattern for one-shot retirement.

## Why

`ry self-update --nightly` auto-detects the nightly channel via `is_prerelease()` and selects the first `prerelease: true` entry from `GET /releases?per_page=20` (`src/self_update.cpp:266-284`). When a stable `vX.Y.Z` is published, the matching `vX.Y.Z-nightly` remains and a stable user running `--nightly` could be pinned to a nightly that predates the new stable. This step closes that window without touching the consumer (`self_update.cpp`); `--nightly` users with no live nightly receive the existing graceful "No nightly/prerelease version found" message.

Subtask of #1306 (release workflow redesign).

## Out of scope

- `dev-release.yml`'s `cleanup-stale-nightlies` job remains dormant (no `schedule:` trigger) — pre-existing, not addressed here.
- Nightly tag format migration (`nightly-yyyymmddhhmmss`) — separate subtask of #1306.
- Retroactive removal of the existing `v0.0.13-nightly` leftover — the next `release.yml` invocation will handle it automatically; or it can be removed manually with `gh release delete v0.0.13-nightly --yes --cleanup-tag`.

## Test plan

- [x] YAML parse: `ruby -ryaml -e "YAML.safe_load(File.read('.github/workflows/release.yml'), aliases: true)"` succeeds.
- [x] Shell snippet dry-run: `gh release view v0.0.9999-nightly` returns non-zero (graceful path); `gh release view v0.0.13-nightly` confirms a real prerelease that the step would target on a re-run.
- [x] Build: `cmake --preset default && cmake --build build` (no-op, no source changes).
- [x] C++ tests: `./build/ry_tests` — 1939/1939 passed.
- [x] Ry self-tests: `./build/ry test -p` — 168 files, 0 failures.
- [ ] Production: on the next stable `vX.Y.Z` release publish, confirm via `gh release list` that `vX.Y.Z-nightly` is gone and the stable `vX.Y.Z` remains the latest. Cannot pre-validate locally because `release.yml` is `workflow_dispatch`-only.

Closes #1365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process to automatically remove matching nightly prerelease versions when publishing a stable release, ensuring self-update functionality will not pin users to outdated nightly builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->