### PR TITLE
chore(ci): drop dead v[0-9]* push trigger from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: ['v[0-9]*']
-    tags-ignore: ['**']
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- `ci.yml` の `push.branches: ['v[0-9]*']` は #1361 (main-only base flow) と #1369 (tag-push release) 以降一度も fire しない dead trigger。`branches: [main]` に置換する
- `tags-ignore: ['**']` は branch push と tag push が排他的なため redundant。一緒に削除
- `pull_request` トリガーは現状維持。main への直接 push (規約違反) のセーフティネットとして push trigger 自体は残す

## Scope check (他 workflow)

| ファイル | 状況 | 判定 |
|--|--|--|
| `release.yml` | tag `v*.*.*` のみ | 影響なし |
| `dev-release.yml` | 内部スクリプトに `origin/v[0-9]*` 参照あるが `workflow_dispatch` のみ・現在停止中 (AGENTS.md 明記) | scope 外、#1306 で扱う |
| `codeql.yml` | `branches: [main]` | 問題なし |
| `copilot-review.yml` | `pull_request_target` のみ | 問題なし |
| `mirror-llvm-toolchain.yml` | `workflow_dispatch` のみ | 問題なし |

## Test plan

- [x] YAML syntax 検証 (ruby YAML パース成功、`on:` と全 jobs キー無傷)
- [x] `grep -nE "branches:.*v\[0-9\]" .github/workflows/*.yml` ヒットゼロ
- [ ] 本 PR の CI ジョブ (`pull_request` 経由) が従来どおり起動・成功する
- [ ] PR マージ後に main への push trigger が `[main]` で fire することを確認

Closes #1371
Refs #1306

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to streamline build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->