### PR TITLE
docs: clarify "main merge != release" semantics and milestone close policy

### DIFF
--- a/.claude/skills/git-merge-pr/SKILL.md
+++ b/.claude/skills/git-merge-pr/SKILL.md
@@ -10,6 +10,8 @@ metadata:
 
 Merge a pull request after verifying its status.
 
+> **Note:** Merging to main = incorporating into mainline only. Release (tag push → GitHub Release) is a separate process.
+
 ## Context
 
 - Current branch: !`git branch --show-current`
@@ -73,6 +75,8 @@ gh issue view <n> --json labels --jq '[.labels[].name]'
 ```
 
 Confirm `wip` is gone and every other pre-existing label is still present. GitHub's `Closes #xx` keyword auto-closes the issue when the PR merges into the default branch, so manual `gh issue close` is not needed.
+
+> **Note:** Issue close records that the feature has entered main — it is not a signal that the release is complete. Release (tag push → GitHub Release) is a separate process. See `AGENTS.md` リリースワークフロー section.
 
 Execute this step autonomously, immediately after merge, without waiting for user confirmation.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -423,7 +423,7 @@ echo 'print(1)' | ./build/ry --trace -c
 - テスト実行
 - セルフ検証
 - ドキュメント更新
-- PR マージ後の `wip` ラベル除去（`git-merge-pr` Step 5 に集約。マージ完了直後に自律実行、ユーザーの指示を待たない。issue クローズは `Closes #xx` キーワードにより GitHub が自動で行う）
+- PR マージ後の `wip` ラベル除去（`git-merge-pr` Step 5 に集約。マージ完了直後に自律実行、ユーザーの指示を待たない。issue クローズは `Closes #xx` キーワードにより GitHub が自動で行う。ただしこれは feature が main に入った記録であり、リリース完了ではない — 「リリースワークフロー」参照）
 
 #### スコープ外の問題を発見した場合の対応ルール
 
@@ -565,7 +565,7 @@ PR レビュー（CodeRabbit / Copilot / 人間）で受けた指摘のうち、
 - Some bugfix description (#545)
 ```
 
-> **注意**: `CHANGELOG.md` を直接編集しないこと。フラグメントファイルはリリース準備時に `scripts/assemble-changelog.sh` で CHANGELOG.md に集約される。
+> **注意**: `CHANGELOG.md` を直接編集しないこと。フラグメントファイルはリリース準備時（現状は手動。「リリースワークフロー > 暫定リリース手順」参照）に `scripts/assemble-changelog.sh` で CHANGELOG.md に集約される。
 
 内部リファクタリング・テスト追加・CI 変更のみの場合はフラグメント作成不要。
 
@@ -667,7 +667,23 @@ UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 
 ## リリースワークフロー
 
+> **注意**: main へのマージ = mainline 取り込みのみ。リリース (タグ push → GitHub Release) は別工程。
+
 - リリースは tag push 駆動。`v*.*.*` glob にマッチするタグ（`v0.0.14` 等）を `main` にプッシュすると `.github/workflows/release.yml` が自動でビルド・テスト・GitHub Release 作成を行う。glob は prerelease タグ（`v0.0.14-rc.1` 等）も拾うため、`build` ジョブ先頭で `^v[0-9]+\.[0-9]+\.[0-9]+$` を厳密検証して non-semver は失敗させる
 - ローカルビルドの `ry -v` は `-DRY_VERSION` 未指定時に `0.0.0` を返す（既定値）。CI ビルドは `-DRY_VERSION=${GITHUB_REF_NAME#v}` で版番号が注入される
 - `workflow_dispatch` も維持してあるが、CI 障害時のリトライ用途に限る（`github.ref_type == 'tag'` ガードあり）
 - `/release` / `/release-prep` スキルは tag-push 駆動への追従が未完了のため使用しない（別 issue で更新）
+
+### 暫定リリース手順
+
+`/release` / `/release-prep` スキルが tag-push 駆動に追従するまではオーナーが以下の手順でバージョンを「released」にする:
+
+1. マイルストーンが feature-complete であることを確認する（配下の全 issue が close 済み）
+2. `scripts/assemble-changelog.sh` を実行して `CHANGELOG.md` を組み立て、結果をコミットする
+3. `main` から `vX.Y.Z` タグを push する（例: `git tag v0.0.14 && git push origin v0.0.14`）
+4. `release.yml` が自動でビルド・テスト・GitHub Release 公開を行うのを待つ
+5. GitHub Release の公開を確認後、対応するマイルストーンを close する（→「マイルストーン close ポリシー」参照）
+
+### マイルストーン close ポリシー
+
+milestone は最後のリリース成果物 (タグ + GitHub Release) が公開された時点で close する。配下の issue が全部 close されただけでは close しない（= main マージ完了 ≠ リリース完了）。


### PR DESCRIPTION
## Summary

- `## リリースワークフロー` 冒頭にリーディングノート、`### 暫定リリース手順` と `### マイルストーン close ポリシー` サブセクションを追加し、main マージとリリース (タグ push → GitHub Release) を別工程として明文化する
- `git-merge-pr` Step 5 の auto-close 段落と「自律処理リスト」（AGENTS.md L426）に「issue close = mainline 取り込み記録であり、リリース完了ではない」旨の note を追加し、誤認源を塞ぐ
- CHANGELOG note の「リリース準備時」を「現状は手動。「リリースワークフロー > 暫定リリース手順」参照」と明示

L426（自律処理リストの issue クローズ言及）の修正は #1374 の "Required changes" 5 項目には含まれないが、親 #1306 のオーナーコメント (2026-04-25) が当該行を「main マージ = リリースと読める」誤認源の一つとして明示挙列しているため本 PR で対応した。

`.codex/skills/` ディレクトリは存在しないためミラー対応は不要。

Refs #1306
Closes #1374

## Test plan

- [x] `grep -n "main マージ\|main merge\|mainline" AGENTS.md .claude/skills/git-merge-pr/SKILL.md` で両ファイルにリーディングノートが存在することを確認
- [x] `grep -n "暫定リリース手順\|マイルストーン close ポリシー" AGENTS.md` で 2 サブセクション + CHANGELOG note + L685 cross-reference の整合を確認
- [x] `grep -n "Closes #xx" AGENTS.md .claude/skills/git-merge-pr/SKILL.md` で auto-close 記述が「リリース完了ではない」note と隣接することを確認
- [x] `pandoc -f gfm -t html` でレンダリング検証 (AGENTS.md `## リリースワークフロー` セクション、SKILL.md intro と Step 5)
- [x] doc-only 変更のためビルド・テスト・サニタイザー・fuzzer 実行はスキップ
- [x] CHANGELOG フラグメント不要 (内部ワークフロー定義の文書化)
- [x] KNOWLEDGE.md 追記不要 (新拒否ブランチなし、非自明な落とし穴なし、コマンドミスなし)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release process documentation to distinguish between mainline incorporation and release completion.
  * Enhanced release workflow with detailed procedures covering changelog assembly methods, provisional release steps, and milestone closure policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->