### PR TITLE
chore(lefthook): drop dead vX.Y.Z branch guard from pre-commit (#1378)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,8 +3,8 @@ pre-commit:
     check-branch:
       run: |
         branch=$(git rev-parse --abbrev-ref HEAD)
-        if [ "$branch" = "main" ] || echo "$branch" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
-          echo "ERROR: '$branch' ブランチへの直接コミットは禁止されています。"
+        if [ "$branch" = "main" ]; then
+          echo "ERROR: 'main' ブランチへの直接コミットは禁止されています。"
           echo "フィーチャーブランチを作成してから作業してください。"
           echo "  git checkout -b <feature-branch-name>"
           exit 1


### PR DESCRIPTION
## Summary

- Drop the dead `^v[0-9]+\.[0-9]+\.[0-9]+$` arm from `lefthook.yml`'s `check-branch` pre-commit guard. After #1361 / #1369 moved us to trunk-based development with tag-push releases, no `vX.Y.Z` branches are created — and tags don't appear via `git rev-parse --abbrev-ref HEAD`, so the arm has been unreachable.
- Simplify the `if` to `[ "$branch" = "main" ]` only and hard-code the error message to `'main'` (consistent with the simplified condition; `$branch` interpolation no longer expands to anything other than `main`).

Concrete change for the `lefthook.yml` item in #1248's investigation scope. Closes #1378.

Out of scope (issue-explicit): GitHub-side branch protection rules, and any future `vX.Y.Z`-named hotfix branches (#1373 / #1306) — if/when those land, the guard can be reintroduced.

## Test plan

- [x] `main` → BLOCK exit=1 (shell-only repro to keep the main worktree clean)
- [x] `feature/test` → OK exit=0 (shell-only repro)
- [x] `v0.0.99` → OK exit=0 (lefthook live run + shell repro — positive evidence the old guard is gone)
- [x] `release/foo` → OK exit=0 (shell-only repro)
- [x] `chore/1378-drop-dead-branch-guard` → OK exit=0 (lefthook live run on this branch; commit hook also passed during this PR's commit)

Full test/sanitizer/fuzzer suites skipped: `lefthook.yml` is a local-only git hook config with no compilation or runtime impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development tooling configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->