### PR TITLE
chore: clean up release-branch leftovers in skill/docs/KNOWLEDGE (#1248)

### DIFF
--- a/.claude/skills/test-checklist/SKILL.md
+++ b/.claude/skills/test-checklist/SKILL.md
@@ -75,9 +75,8 @@ User input: $ARGUMENTS
 - If `$ARGUMENTS` is a file path or glob → use it as the target.
 - If `$ARGUMENTS` is a feature description → identify the relevant source file(s) with `Glob` or `Grep`.
 - If empty → derive changed files dynamically:
-  1. Find base branch: `git log --format='%D' HEAD | grep -o 'origin/v[0-9][0-9.]*' | head -1`
-  2. If a base branch was found: `git diff --name-only <base-branch>..HEAD`
-  3. If no base branch was found (detached HEAD, fresh branch, etc.):
+  1. Try diff against `origin/main`: `git diff --name-only origin/main..HEAD`
+  2. If `origin/main` is unavailable (no remote, fresh clone, detached HEAD, etc.):
      - Try: `git diff --name-only HEAD~1..HEAD`
      - If `HEAD~1` is unavailable (initial commit or shallow clone): `git diff --name-only --root HEAD`
   - New `.ry` or `.cpp` files → **新機能追加時** mode

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -3667,8 +3667,8 @@ always the **default branch** (`main`), regardless of which branch the job check
 to `true` or `false` based on the workflow file's source branch, not the checked-out branch.
 
 **Why**: When designing a scheduled workflow that dynamically checks out a branch
-(typically via a `resolve-target` step that picks the latest release branch), it is
-tempting to copy a `ccache save:` expression like
+via `actions/checkout` with an explicit `ref:`, it is tempting to copy a
+`ccache save:` expression like
 `${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}` from a
 push-triggered workflow. On a scheduled run this always evaluates to `true` (if the
 workflow file lives on `main`) regardless of the resolved branch choice, but if the
@@ -3697,11 +3697,10 @@ naive replacement is `pull_request: + workflow_dispatch:`. That covers PR gating
 silently drops dashboard freshness on `main`. The merge-commit run that GitHub used to
 get from the cron is gone.
 
-**How to apply**: Always pair `pull_request:` with `push: branches: [<default>]` (and
-optionally any active release branches) when removing a `schedule:` from a CodeQL
-workflow. Keep `workflow_dispatch:` as a manual escape hatch but never rely on it for
-dashboard freshness. Verify after merge that the next push to the default branch
-produces a CodeQL run in the Actions tab.
+**How to apply**: Always pair `pull_request:` with `push: branches: [<default>]` when
+removing a `schedule:` from a CodeQL workflow. Keep `workflow_dispatch:` as a manual
+escape hatch but never rely on it for dashboard freshness. Verify after merge that
+the next push to the default branch produces a CodeQL run in the Actions tab.
 
 ### Tuple pattern in `case`: per-element metadata via `splitTypeArgs`
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -515,4 +515,4 @@ CMake auto-detects FileCheck at configure time. If not found, `cmake --preset de
 
 ### CI gate
 
-The `filecheck` CI job runs on all events — pull requests and push to `main`/`v*.*.*` branches. It builds only the `ry` binary (not `ry_tests`), so it completes quickly. It uses `continue-on-error: true` (warn-only) during the initial rollout. FileCheck is installed explicitly via `apt.llvm.org` because the LLVM mirror tarball does not include `llvm-tools`.
+The `filecheck` CI job runs on pull requests and pushes to `main`. It builds only the `ry` binary (not `ry_tests`), so it completes quickly. It uses `continue-on-error: true` (warn-only) during the initial rollout. FileCheck is installed explicitly via `apt.llvm.org` because the LLVM mirror tarball does not include `llvm-tools`.


### PR DESCRIPTION
## Summary

- Replace the `origin/v[0-9.]+` base-branch heuristic in `.claude/skills/test-checklist/SKILL.md` with a fixed `origin/main` reference (HEAD~1 / --root fallback preserved).
- Drop the `v*.*.*` clause from the `filecheck` CI gate description in `docs/reference/testing.md` so it matches the actual `ci.yml` triggers (`pull_request` + `push: branches: [main]`).
- Reword two `KNOWLEDGE.md` scheduled-workflow entries (`github.ref_name` gotcha + CodeQL dashboard) to drop the release-branch framing while preserving the rules themselves.

Closes #1248.

## Test plan

- [x] Scope grep on the three modified files: no `origin/v[`, `v*.*.*`, or `release.branch` hits.
- [x] Repo-wide grep: remaining hits are only in legitimate scope-out locations (`AGENTS.md` release.yml description, `changelog.d/` historical fragments, `.claude/skills/release{,-prep}/` tracked in #1373, `.github/workflows/release.yml` tag glob).
- [x] `KNOWLEDGE.md` ~85-char hard-wrap preserved.
- [x] `.serena/` unchanged; only the three intended files modified.
- N/A full test suite / sanitizer / libFuzzer — doc/skill/KNOWLEDGE-only edits with no runtime/build/CI implementation impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined guidance on scheduled workflow caching behavior with more concrete scenarios and best practices for CI configuration.
  * Clarified CodeQL migration instructions by specifying exact trigger requirements when transitioning from schedule-based to event-based execution.
  * Updated filecheck CI gate documentation to specify event and branch coverage, now explicitly running on pull requests and pushes to the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->