### PR TITLE
chore(release): assemble v0.0.14 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Added
+## [0.0.14] - 2026-04-26
 
 ### Changed
 
-### Deprecated
+- Self-referential enum diagnostic now also suggests `Task<T>` and `Channel<T>` as valid indirection wrappers, aligning the recommendation with the existing checker's acceptance. The message previously only mentioned `List`/`Map`/`Set`, even though pointer-backed `Task<T>` and `Channel<T>` are equally valid indirections. (#1351)
+- `release.yml` now deletes the matching `vX.Y.Z-nightly` prerelease (and its tag) after a stable `vX.Y.Z` release is published, preventing `ry self-update` from pinning users to a stale nightly that predates the stable release. (#1365)
+- Heavy CI analysis (`clang-tidy`, `scan-build`, `asan`, `tsan`) now runs on every pull request instead of only on `v*.*.*` branch pushes. CodeQL also runs per PR plus on push to `main`, replacing the previous daily cron. The redundant `ci-scheduled.yml` workflow has been removed. (#1367)
+- Release workflow now triggers on tag push (`v*.*.*`) instead of `workflow_dispatch` only. Pushing a semver tag from `main` builds, tests, and publishes a GitHub Release in one shot. (#1369)
 
 ### Removed
 
+- `VERSION` file removed. CI derives the version from `${GITHUB_REF_NAME#v}`; local builds default to `0.0.0`. (#1369)
+- `ry self-update --nightly` flag and the implicit nightly default (when the running version had a prerelease suffix, `self-update` with no arguments previously targeted the latest prerelease). `self-update` now always targets the latest stable release unless an explicit version tag is given. The nightly build workflow (`dev-release.yml`) has been retired as part of this change. (#1372)
+
 ### Fixed
 
-### Security
+- Lambda return-type inference now correctly narrows `@native` overloads that differ only in ptr-backed argument types (`str` vs `List` vs `Map` vs `Set`). Previously `f = () => length(xs)` failed with "ambiguous @native call in lambda return-type inference". Captured collection variables also retain their source-level element/key/value type metadata so the body dispatches to the correct runtime overload. (#1349)
+- `for a, b in setOfTuples:` no longer fails with "for loop destructuring requires a list of tuples". The multi-variable for-loop binding path now handles `Set<(T, U)>` alongside maps and lists of tuples, and source-level element type names on `Set<T>` annotations are propagated for non-primitive inner types (collections, records, enums, tuples). (#1350)
+- `List<str>` and `Set<str>` literals now correctly retain locally-constructed str elements, preventing dangling pointers when source variables go out of scope. Mirrors the `Map<str, str>` literal fix from #1353. (#1354)
 
 ## [0.0.13] - 2026-04-24
 
@@ -1116,7 +1124,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 Initial release.
 
-[Unreleased]: https://github.com/t0k0sh1/ry/compare/v0.0.13...HEAD
+[Unreleased]: https://github.com/t0k0sh1/ry/compare/v0.0.14...HEAD
+[0.0.14]: https://github.com/t0k0sh1/ry/compare/v0.0.13...v0.0.14
 [0.0.13]: https://github.com/t0k0sh1/ry/compare/v0.0.12...v0.0.13
 [0.0.12]: https://github.com/t0k0sh1/ry/compare/v0.0.11...v0.0.12
 [0.0.11]: https://github.com/t0k0sh1/ry/compare/v0.0.10...v0.0.11

--- a/changelog.d/1349-lambda-native-overload-ptr-collapse.md
+++ b/changelog.d/1349-lambda-native-overload-ptr-collapse.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- Lambda return-type inference now correctly narrows `@native` overloads that differ only in ptr-backed argument types (`str` vs `List` vs `Map` vs `Set`). Previously `f = () => length(xs)` failed with "ambiguous @native call in lambda return-type inference". Captured collection variables also retain their source-level element/key/value type metadata so the body dispatches to the correct runtime overload. (#1349)

--- a/changelog.d/1350-for-destructure-set.md
+++ b/changelog.d/1350-for-destructure-set.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- `for a, b in setOfTuples:` no longer fails with "for loop destructuring requires a list of tuples". The multi-variable for-loop binding path now handles `Set<(T, U)>` alongside maps and lists of tuples, and source-level element type names on `Set<T>` annotations are propagated for non-primitive inner types (collections, records, enums, tuples). (#1350)

--- a/changelog.d/1351-self-ref-enum-diagnostic-task-channel.md
+++ b/changelog.d/1351-self-ref-enum-diagnostic-task-channel.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Self-referential enum diagnostic now also suggests `Task<T>` and `Channel<T>` as valid indirection wrappers, aligning the recommendation with the existing checker's acceptance. The message previously only mentioned `List`/`Map`/`Set`, even though pointer-backed `Task<T>` and `Channel<T>` are equally valid indirections. (#1351)

--- a/changelog.d/1354-list-set-literal-str-retain.md
+++ b/changelog.d/1354-list-set-literal-str-retain.md
@@ -1,3 +1,0 @@
-### Fixed
-
-- `List<str>` and `Set<str>` literals now correctly retain locally-constructed str elements, preventing dangling pointers when source variables go out of scope. Mirrors the `Map<str, str>` literal fix from #1353. (#1354)

--- a/changelog.d/1365-drop-nightly-on-stable-release.md
+++ b/changelog.d/1365-drop-nightly-on-stable-release.md
@@ -1,3 +1,0 @@
-### Changed
-
-- `release.yml` now deletes the matching `vX.Y.Z-nightly` prerelease (and its tag) after a stable `vX.Y.Z` release is published, preventing `ry self-update` from pinning users to a stale nightly that predates the stable release. (#1365)

--- a/changelog.d/1367-ci-heavy-analysis-on-pr.md
+++ b/changelog.d/1367-ci-heavy-analysis-on-pr.md
@@ -1,3 +1,0 @@
-### Changed
-
-- Heavy CI analysis (`clang-tidy`, `scan-build`, `asan`, `tsan`) now runs on every pull request instead of only on `v*.*.*` branch pushes. CodeQL also runs per PR plus on push to `main`, replacing the previous daily cron. The redundant `ci-scheduled.yml` workflow has been removed. (#1367)

--- a/changelog.d/1369-tag-push-release.md
+++ b/changelog.d/1369-tag-push-release.md
@@ -1,7 +1,0 @@
-### Changed
-
-- Release workflow now triggers on tag push (`v*.*.*`) instead of `workflow_dispatch` only. Pushing a semver tag from `main` builds, tests, and publishes a GitHub Release in one shot. (#1369)
-
-### Removed
-
-- `VERSION` file removed. CI derives the version from `${GITHUB_REF_NAME#v}`; local builds default to `0.0.0`. (#1369)

--- a/changelog.d/1372-retire-dev-release-nightly.md
+++ b/changelog.d/1372-retire-dev-release-nightly.md
@@ -1,3 +1,0 @@
-### Removed
-
-- `ry self-update --nightly` flag and the implicit nightly default (when the running version had a prerelease suffix, `self-update` with no arguments previously targeted the latest prerelease). `self-update` now always targets the latest stable release unless an explicit version tag is given. The nightly build workflow (`dev-release.yml`) has been retired as part of this change. (#1372)


### PR DESCRIPTION
## Summary

Closes #1386. Aggregates `changelog.d/` fragments into the `[0.0.14] - 2026-04-26` section and prepares `CHANGELOG.md` for the release tag (handled separately by #1387).

- Ran `scripts/assemble-changelog.sh` to merge 8 fragments into `[Unreleased]`, then renamed the section to `[0.0.14] - 2026-04-26`
- Inserted a fresh empty `[Unreleased]` above `[0.0.14]`
- Updated bottom comparison links: `[Unreleased]` now points at `v0.0.14...HEAD`, and added `[0.0.14]: v0.0.13...v0.0.14`

### Aggregated entries (8 fragments)

- **Changed** (4): #1351, #1365, #1367, #1369
- **Removed** (2): #1369, #1372
- **Fixed** (3): #1349, #1350, #1354

## Out of scope

- `v0.0.14` tag creation/push — handled by sibling issue #1387
- `VERSION` file (does not exist; CMake defaults to `0.0.0`, CI injects from tag)
- Milestone close — manual after release succeeds

## Test plan

- [x] `git diff CHANGELOG.md` shows new empty `[Unreleased]`, `[0.0.14] - 2026-04-26` with 8 entries, and updated comparison links
- [x] `git status` shows 8 fragment files deleted + `CHANGELOG.md` modified, no other unintended changes
- [x] `cmake --preset default && cmake --build build` succeeds
- [x] `./build/ry_tests` — 1935 tests passed (8.151s)
- [x] `./build/ry test -p` — 168 test files, 0 failures (1.76s)
- [x] ASan / UBSan / TSan / libFuzzer / FileCheck skipped per `/pre-commit-checklist` §3.6 (docs-only change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated changelog entries into version 0.0.14 release notes, documenting compiler fixes for lambda type inference, tuple destructuring, and string literal handling; improved enum diagnostics; and updates to release and CI workflows including removal of the nightly update mechanism.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->