### PR TITLE
feat: export directive definitions from packages (#709)

### DIFF
--- a/.claude/rules/tests-cpp-conventions.md
+++ b/.claude/rules/tests-cpp-conventions.md
@@ -43,6 +43,19 @@ smoke tests + document the gap in the PR. Don't add failing
 `expectCompileError` tests for `from math import` / `from json import`
 / etc.
 
+### Test loader-pipeline changes for AST variants with codegen no-op via `resolveImportsOnly` introspection
+
+**Source**: #709 (2026-04-27, implementation — advisor call-out)
+**Tags**: testing, module-loader, codegen-no-op, multi-pr-chain, blind-spot
+
+**Context**: When a new AST variant is introduced across a multi-PR chain (parser lands first, loader/export updates next, codegen registration last), the middle PR adds the variant to `isExportable()` / `getExportName()` in `src/module_loader.cpp` while codegen for the variant is still a deliberate no-op. Execution-based tests (`runWithImports` returning a printed value) cannot directly verify the variant flows through the loader, because nothing in the running program observes its presence. In #709, AC #4 ("private `_`-prefixed directive defs are excluded by wildcard import") had no execution-based test that could distinguish "directive def is in program but does nothing" from "directive def was filtered out". Arguing "`isPrivateName` is a string check, so it must work uniformly for all exportable variants" is logically sound but only indirect evidence — a future refactor of the wildcard path could introduce per-variant filtering and the indirect-coverage tests would not catch it.
+
+**Rule**: When adding a new AST variant to `module_loader.cpp`'s exportable list, and that variant has a codegen no-op until a later PR, add a `resolveImportsOnly()` helper to the `ImportTest` fixture (mirror `runWithImports`, drop `CodeGen::compile` + `runModule`, return the `Program`). Write a Program-introspection test that walks top-level statements with `std::holds_alternative<TheVariant>` and asserts the expected names are present (public) and absent (private).
+
+**How to apply**:
+- Don't rely solely on `EXPECT_THROW` for `from pkg import _name` for the variant — that named-private throw fires at `module_loader.cpp:73-82` before AST traversal in `extractDefinitions`, so it doesn't exercise the variant-specific path.
+- Reference: `ImportTest.DirectiveDefWildcardExcludesPrivate` and the `resolveImportsOnly` helper in `tests/test_codegen_stmt.cpp` (#709).
+
 ### Use `-> Unit` in @it/@describe rejection tests to isolate the directive check
 
 **Source**: #1122 (2026-04-18, implementation)

--- a/changelog.d/709-directive-def-export.md
+++ b/changelog.d/709-directive-def-export.md
@@ -1,0 +1,3 @@
+### Added
+
+- `DirectiveDefStmt` (e.g. `@directive(target="function", stage="compile") fn name(params)`) is now exportable from packages. Both wildcard (`from pkg`) and named (`from pkg import name`) imports include directive definitions, with the same `_`-prefix privacy rules as functions and types. (#709)

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -86,7 +86,7 @@ When a package resolves to a directory:
 - Files starting with `_` are excluded
 - Test files (`.test.ry`) are excluded
 - No special entry file (like `__init__.py`) is needed
-- All functions and types defined in the directory's files are exported
+- All functions, types, and directive definitions defined in the directory's files are exported
 
 ### Private Symbols
 

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -29,7 +29,8 @@ static bool isExportable(const StmtNode &stmt) {
            std::holds_alternative<RecordStmt>(stmt) ||
            std::holds_alternative<EnumStmt>(stmt) ||
            std::holds_alternative<TypeAliasStmt>(stmt) ||
-           std::holds_alternative<AssignStmt>(stmt);
+           std::holds_alternative<AssignStmt>(stmt) ||
+           std::holds_alternative<DirectiveDefStmt>(stmt);
 }
 
 // Get the name of an exportable definition
@@ -44,6 +45,8 @@ static std::string getExportName(const StmtNode &stmt) {
         return std::get<TypeAliasStmt>(stmt).name;
     if (std::holds_alternative<AssignStmt>(stmt))
         return std::get<AssignStmt>(stmt).name;
+    if (std::holds_alternative<DirectiveDefStmt>(stmt))
+        return std::get<DirectiveDefStmt>(stmt).name;
     return "";
 }
 

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <fstream>
+#include <set>
 #include <sstream>
 
 
@@ -649,6 +650,18 @@ protected:
         auto tsm = cg.compile(prog);
         return runModule(std::move(tsm));
     }
+
+    Program resolveImportsOnly(const std::string &src,
+                               const std::string &referrer_dir = "",
+                               const std::vector<std::string> &search_paths = {}) {
+        Lexer lex(src);
+        Parser parser(lex);
+        Program prog = parser.parseProgram();
+
+        std::string dir = referrer_dir.empty() ? tmp_dir_.string() : referrer_dir;
+        ModuleLoader loader(search_paths);
+        return loader.resolveImports(prog, dir);
+    }
 };
 
 TEST_F(ImportTest, ImportBasics) {
@@ -862,6 +875,53 @@ TEST_F(ImportTest, PrivateLetSymbolExcluded) {
     EXPECT_THROW(runWithImports(
         "from mypkg3 import _secret"),
         std::runtime_error);
+}
+
+// ===== Directive definition (@directive) export tests (#709) =====
+
+TEST_F(ImportTest, DirectiveDefSelectiveImport) {
+    writeFile("dirpkg1/mod.ry",
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn my_dir(x: int)\n"
+        "fn marker() -> int:\n"
+        "    return 42\n");
+
+    EXPECT_EQ(runWithImports(
+        "from dirpkg1 import my_dir, marker\n"
+        "print(marker())"),
+        "42\n");
+}
+
+TEST_F(ImportTest, DirectiveDefWildcardImport) {
+    writeFile("dirpkg2/mod.ry",
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn my_dir(x: int)\n"
+        "fn marker() -> int:\n"
+        "    return 42\n");
+
+    EXPECT_EQ(runWithImports(
+        "from dirpkg2\n"
+        "print(marker())"),
+        "42\n");
+}
+
+TEST_F(ImportTest, DirectiveDefWildcardExcludesPrivate) {
+    writeFile("dirpkg3/mod.ry",
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn pub_dir(x: int)\n"
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn _priv_dir(x: int)\n");
+
+    Program prog = resolveImportsOnly("from dirpkg3\n");
+
+    std::set<std::string> directive_names;
+    for (const auto &stmt : prog) {
+        if (std::holds_alternative<DirectiveDefStmt>(stmt)) {
+            directive_names.insert(std::get<DirectiveDefStmt>(stmt).name);
+        }
+    }
+    EXPECT_EQ(directive_names.count("pub_dir"), 1u);
+    EXPECT_EQ(directive_names.count("_priv_dir"), 0u);
 }
 
 // ===== type alias =====


### PR DESCRIPTION
## Summary

Make `DirectiveDefStmt` (the `@directive(target=…, stage=…) fn name(params)` syntax landed in #708) exportable from packages, so it flows through `from pkg` (wildcard) and `from pkg import name` (selective) imports the same way functions, records, enums, type aliases, and let bindings do.

This is the 2nd of 3 PRs for parent issue #704:
- ✅ #708 — parser accepts `@directive` definition syntax (merged)
- ✅ **#709 (this PR)** — exports `DirectiveDefStmt` from the loader pipeline
- ⏳ #710 — register imported directive defs into the validation registry (so `@my_dir(...)` actually does something)

`@directive` codegen remains a deliberate no-op until #710 — this PR's scope is "export pipeline accepts and forwards `DirectiveDefStmt`".

## Changes

- `src/module_loader.cpp`: add `DirectiveDefStmt` to `isExportable()` (+1 line) and `getExportName()` (+2 lines). `extractDefinitions()` is unchanged — it dispatches uniformly through these helpers.
- `tests/test_codegen_stmt.cpp`: 3 new `ImportTest` cases plus a `resolveImportsOnly()` helper that returns the resolved `Program` without running CodeGen, used for direct AST introspection of the wildcard-private path.
- `docs/reference/packages.md`: prose update — directory packages now export "functions, types, and directive definitions".
- `changelog.d/709-directive-def-export.md`: CHANGELOG fragment.
- `.claude/rules/tests-cpp-conventions.md`: rule entry capturing the harness pattern (Program introspection for codegen-no-op AST variants in multi-PR chains).

## Tests

`tests/test_codegen_stmt.cpp` adds three tests after the existing `PrivateLetSymbolExcluded` block:

1. **`DirectiveDefSelectiveImport`** — `from pkg import my_dir, marker` succeeds. Red before fix: `'my_dir' not found in package 'dirpkg1'`.
2. **`DirectiveDefWildcardImport`** — sibling `fn marker()` continues to work under wildcard import (regression guard).
3. **`DirectiveDefWildcardExcludesPrivate`** — `resolveImportsOnly()` + `std::set<std::string>` collected from `std::holds_alternative<DirectiveDefStmt>` walk verifies `pub_dir` is present and `_priv_dir` is absent after `from pkg`. This directly tests AC #4 instead of arguing "`isPrivateName` is a string check, so it works uniformly".

The `_`-prefix policy named-import path (`from pkg import _name`) is already covered by the existing `PrivateSymbolNamedImportError` — that throw fires before AST traversal in `extractDefinitions`, so a `DirectiveDefStmt`-specific test there would not be load-bearing.

## Test plan

- [x] `./build/ry_tests --gtest_filter='ImportTest.*'` — 15/15 pass
- [x] `./build/ry_tests` — 1972/1972 pass
- [x] `RY_ENV=internal ./build/ry test -p` — 168/168 spec files pass
- [x] `ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests` — full suite clean
- [x] `./build-tsan/ry_tests --gtest_filter='ImportTest.*'` — 15/15 pass
- [x] `./build-fuzz/fuzz_{parser,json,utf8} -max_total_time=60` — each ran to completion, no crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Directive definitions are now exportable from packages and can be imported using both wildcard (`from pkg`) and selective (`from pkg import name`) syntax. Privacy rules using underscore prefixes apply.

* **Documentation**
  * Updated package documentation to specify that directive definitions are included in wildcard exports from directory-based packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->