### PR TITLE
feat(codegen): register imported @directive definitions in validation (#710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- User-defined `@directive` declarations imported via `from <pkg> import <name>` now register in a per-program directive table and are accepted by directive validation, alongside the built-in registry. Defining a directive whose name collides with a built-in, or registering the same directive name twice in one program, is rejected. Unknown named arguments on a user directive are also rejected. (#710)
+
+### Changed
+
+- `@it` and `@describe` are now stdlib-package directives provided by `share/std/testing/testing.ry`. Test files that use them must add an explicit `from testing import it, describe` (or `from testing`) at the top. The directives are no longer in the C++ built-in directive registry. (#710)
+
 ## [0.0.14] - 2026-04-26
 
 ### Changed

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -296,6 +296,12 @@ On failure, the counterexample (parameter values that caused the failure) is pri
 
 Declares a test case by decorating a named function. The function body becomes the test body and is executed by `ry test`. See [Testing Reference](testing.md) for the full specification.
 
+`@it` is provided by `share/std/testing/testing.ry`. Test files must add an explicit import at the top:
+
+```ry
+from testing import it, describe
+```
+
 **Syntax:**
 
 ```ry
@@ -337,6 +343,8 @@ fn test_commutative(a: int, b: int):
 ### `@describe`
 
 Groups a set of related tests by decorating a named function. Inner `@it` functions declared in the body belong to the group, and variables declared directly in the body act as shared setup captured by every inner `@it`. Unlike the legacy lambda form, `@describe` groups **may be nested**; output is indented proportionally to nesting depth.
+
+`@describe`, like `@it`, is provided by `share/std/testing/testing.ry` and requires `from testing import it, describe` at the top of the test file.
 
 **Syntax:**
 
@@ -446,6 +454,35 @@ fn old_api() -> int:
 ```
 
 Currently, parameters are parsed but not used by the `@deprecated` directive.
+
+## User-defined directives
+
+Packages can declare their own compile-time directives with the `@directive(...)` declaration syntax. A user directive becomes available in any source file that imports it; applying it without importing produces an `unknown directive` error.
+
+**Declaration (in a stdlib or user package):**
+
+```ry
+@directive(target=["function"], stage="compile")
+fn logged(label: str)
+```
+
+The declaration body is empty; the directive is consumed by the compiler at the use site, not called as a function.
+
+**Use site:**
+
+```ry
+from mypkg import logged
+
+@logged("hello")
+fn target_fn() -> int:
+    return 1
+```
+
+**Parameter mapping:** Each parameter in the directive declaration becomes either a required positional argument (no default) or an optional named argument (with default). For example, `fn logged(label: str = "x")` accepts `@logged("foo")` (positional) or `@logged(label="foo")` (named); `@logged(unknown="y")` is rejected.
+
+**Built-in collision:** Declaring a `@directive` whose name collides with a built-in (e.g. `@native`, `@each`, `@property`, `@inline`, `@parallel`, `@const`, `@deprecated`) is rejected at compile time. Declaring the same directive name twice in one program is also rejected.
+
+**Stdlib testing directives:** `@it` and `@describe` are themselves implemented as user-defined directives in `share/std/testing/testing.ry`; test files must `from testing import it, describe` to use them.
 
 ## Notes
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -3,6 +3,7 @@
 #include "ry/ry_layout.hpp"
 #include "ry/ast.hpp"
 #include "ry/codegen_native_dispatch.hpp"
+#include "ry/directive_meta.hpp"
 #include "ry/sema_return.hpp"
 #include "ry/source_location.hpp"
 #include "ry/source_manager.hpp"
@@ -839,6 +840,9 @@ public:
 
     // @native fn rich signature registry
     std::unordered_map<std::string, std::vector<NativeFnSignature>> native_fn_sigs_;
+
+    // User-defined @directive declarations. Keyed by directive name.
+    std::unordered_map<std::string, DirectiveSignature> user_directive_registry_;
 
     // Libraries actually used during codegen (populated by dispatch functions).
     // Only these libraries need to be loaded at JIT startup.

--- a/include/ry/directive_meta.hpp
+++ b/include/ry/directive_meta.hpp
@@ -44,10 +44,20 @@ struct DirectiveSignature {
 // Returns the registry of all built-in directive signatures.
 const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegistry();
 
-// Validate a directive's argument list against its signature.
+// Convert a directive target name (e.g. "function", "for") to its bitmask
+// value. Returns 0 for unrecognised names; the parser rejects unknown
+// targets at parse time, so 0 here means "intentionally none".
+uint8_t directiveTargetMask(std::string_view name);
+
+// Validate a directive's argument list against an explicit signature.
 // Throws std::runtime_error if validation fails.
-// directiveName: the name of the directive (e.g. "native", "inline")
-// args: the parsed argument list
+// directiveName is used only for error messages.
+void validateDirectiveSignature(const std::string &directiveName,
+                                const std::vector<DirectiveArg> &args,
+                                const DirectiveSignature &sig);
+
+// Validate a directive's argument list against its built-in signature.
+// Throws std::runtime_error if the directive is unknown or validation fails.
 void validateDirectiveArgs(const std::string &directiveName,
                            const std::vector<DirectiveArg> &args);
 

--- a/share/std/manifest.json
+++ b/share/std/manifest.json
@@ -6,7 +6,7 @@
     "base64/base64.ry",
     "filesystem/filesystem.ry", "gc/gc.ry",
     "http/http.ry", "io/io.ry", "json/json.ry", "math/math.ry", "net/net.ry",
-    "path/path.ry", "thread/thread.ry",
+    "path/path.ry", "testing/testing.ry", "thread/thread.ry",
     "runtime_internal/runtime_internal.ry"
   ]
 }

--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -1,0 +1,8 @@
+# Testing directives. Test files must explicitly
+# `from std/testing import it, describe`.
+
+@directive(target=["function"], stage="compile")
+fn it(description: str)
+
+@directive(target=["function"], stage="compile")
+fn describe(group: str)

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -488,8 +488,13 @@ void CodeGen::validateDirectives(const std::vector<Directive> &directives) {
     SourceLocation saved_loc = current_loc_;
     for (const auto &d : directives) {
         if (d.loc.isValid()) current_loc_ = d.loc;
+
         try {
-            validateDirectiveArgs(d.name, d.args);
+            auto userIt = user_directive_registry_.find(d.name);
+            if (userIt != user_directive_registry_.end())
+                validateDirectiveSignature(d.name, d.args, userIt->second);
+            else
+                validateDirectiveArgs(d.name, d.args);
         } catch (const std::runtime_error &e) {
             codegenError(e.what());
         }

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -1112,6 +1112,42 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     builder_.CreateStore(finalVal, elemPtr);
 }
 
-void CodeGen::emitStmt(DirectiveDefStmt &s) { (void)s; }
+namespace {
+DirectiveSignature fromDirectiveDef(const DirectiveDefStmt &s) {
+    DirectiveSignature sig;
+    sig.name = s.name;
+    uint8_t mask = 0;
+    for (const auto &t : s.targets)
+        mask |= directiveTargetMask(t);
+    sig.allowed_targets = mask;
+    sig.stage = (s.stage == "runtime") ? DirectiveStage::Runtime : DirectiveStage::CompileTime;
+
+    sig.min_positional = 0;
+    sig.max_positional = 0;
+    for (const auto &p : s.params) {
+        if (!p.default_value) {
+            ++sig.min_positional;
+            ++sig.max_positional;
+        } else {
+            sig.named_params.push_back(p.name);
+        }
+    }
+    sig.custom_validator = nullptr;
+    return sig;
+}
+}  // namespace
+
+void CodeGen::emitStmt(DirectiveDefStmt &s) {
+    if (s.loc.isValid()) current_loc_ = s.loc;
+
+    const auto &builtin = builtinDirectiveRegistry();
+    if (builtin.find(s.name) != builtin.end())
+        codegenError("@directive '" + s.name + "' collides with a built-in directive");
+
+    if (user_directive_registry_.count(s.name))
+        codegenError("@directive '" + s.name + "' is already defined");
+
+    user_directive_registry_.emplace(s.name, fromDirectiveDef(s));
+}
 
 } // namespace ry

--- a/src/directive_meta.cpp
+++ b/src/directive_meta.cpp
@@ -48,11 +48,6 @@ static const ExprNode *firstPositionalExpr(const std::vector<DirectiveArg> &args
 const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegistry() {
     using T = DirectiveTarget;
     static const std::unordered_map<std::string, DirectiveSignature> registry = {
-        {"deprecated", {"deprecated",
-            T::Function | T::Record | T::Field | T::Statement,
-            DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {"reason"}}},
-
         {"native", {"native",
             T::Function | T::Statement,
             DirectiveStage::CompileTime,
@@ -68,16 +63,6 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
                 }
             }}},
 
-        {"inline", {"inline",
-            asTarget(T::Function),
-            DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {"mode"}}},
-
-        {"parallel", {"parallel",
-            asTarget(T::ForLoop),
-            DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {}}},
-
         {"each", {"each",
             T::Statement | T::Function,
             DirectiveStage::CompileTime,
@@ -88,54 +73,50 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
             DirectiveStage::CompileTime,
             /*min_pos=*/0, /*max_pos=*/0, {"count"}}},
 
+        {"deprecated", {"deprecated",
+            T::Function | T::Record | T::Field | T::Statement,
+            DirectiveStage::CompileTime,
+            /*min_pos=*/0, /*max_pos=*/0, {"reason"}}},
+
+        {"inline", {"inline",
+            asTarget(T::Function),
+            DirectiveStage::CompileTime,
+            /*min_pos=*/0, /*max_pos=*/0, {"mode"}}},
+
+        {"parallel", {"parallel",
+            asTarget(T::ForLoop),
+            DirectiveStage::CompileTime,
+            /*min_pos=*/0, /*max_pos=*/0, {}}},
+
         {"const", {"const",
             asTarget(T::Statement),
             DirectiveStage::CompileTime,
             /*min_pos=*/0, /*max_pos=*/0, {}}},
-
-        {"it", {"it",
-            asTarget(T::Function),
-            DirectiveStage::CompileTime,
-            /*min_pos=*/1, /*max_pos=*/1, {},
-            [](const std::string &, const std::vector<DirectiveArg> &args) {
-                if (const ExprNode *p = firstPositionalExpr(args)) {
-                    if (!std::get_if<StringExpr>(&p->data))
-                        throw std::runtime_error("@it expects a string literal description");
-                }
-            }}},
-
-        {"describe", {"describe",
-            asTarget(T::Function),
-            DirectiveStage::CompileTime,
-            /*min_pos=*/1, /*max_pos=*/1, {},
-            [](const std::string &, const std::vector<DirectiveArg> &args) {
-                if (const ExprNode *p = firstPositionalExpr(args)) {
-                    if (!std::get_if<StringExpr>(&p->data))
-                        throw std::runtime_error("@describe expects a string literal description");
-                }
-            }}},
     };
     return registry;
 }
 
+// ===== Directive target name mapping =====
+
+uint8_t directiveTargetMask(std::string_view name) {
+    if (name == "function")  return asTarget(DirectiveTarget::Function);
+    if (name == "record")    return asTarget(DirectiveTarget::Record);
+    if (name == "field")     return asTarget(DirectiveTarget::Field);
+    if (name == "statement") return asTarget(DirectiveTarget::Statement);
+    if (name == "for")       return asTarget(DirectiveTarget::ForLoop);
+    return 0;
+}
+
 // ===== Directive argument validation =====
 
-void validateDirectiveArgs(const std::string &directiveName,
-                           const std::vector<DirectiveArg> &args) {
-    const auto &registry = builtinDirectiveRegistry();
-    auto it = registry.find(directiveName);
-    if (it == registry.end())
-        throw std::runtime_error("unknown directive '@" + directiveName + "'");
-
-    const DirectiveSignature &sig = it->second;
-
-    // Count positional and named args
+void validateDirectiveSignature(const std::string &directiveName,
+                                const std::vector<DirectiveArg> &args,
+                                const DirectiveSignature &sig) {
     int positional = 0;
     for (const auto &a : args) {
         if (!a.name.has_value()) {
             ++positional;
         } else {
-            // Check named arg is allowed
             bool found = false;
             for (const auto &np : sig.named_params)
                 if (np == *a.name) { found = true; break; }
@@ -146,7 +127,6 @@ void validateDirectiveArgs(const std::string &directiveName,
         }
     }
 
-    // Check positional count
     if (positional < sig.min_positional)
         throw std::runtime_error(
             "@" + directiveName + " requires at least " +
@@ -156,9 +136,17 @@ void validateDirectiveArgs(const std::string &directiveName,
             "@" + directiveName + " accepts at most " +
             std::to_string(sig.max_positional) + " positional argument(s)");
 
-    // Per-directive custom validation
     if (sig.custom_validator)
         sig.custom_validator(directiveName, args);
+}
+
+void validateDirectiveArgs(const std::string &directiveName,
+                           const std::vector<DirectiveArg> &args) {
+    const auto &registry = builtinDirectiveRegistry();
+    auto it = registry.find(directiveName);
+    if (it == registry.end())
+        throw std::runtime_error("unknown directive '@" + directiveName + "'");
+    validateDirectiveSignature(directiveName, args, it->second);
 }
 
 }  // namespace ry

--- a/tests/spec/directive_test.test.ry
+++ b/tests/spec/directive_test.test.ry
@@ -1,3 +1,5 @@
+from testing import it, describe
+
 # Tests for @it and @describe directive syntax on named functions (#634)
 
 # Basic @it on a named function

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -23,6 +23,19 @@ extern "C" const char *__ry_testlib_get_last_error() {
     return strdup(testlib_err_buf);
 }
 
+// @it / @describe live in `share/std/testing/testing.ry`, not in the
+// built-in directive registry. The CodeGenTest harness does not invoke
+// ModuleLoader, so tests that exercise these directives must declare them
+// inline at the top of the source they hand to the codegen.
+static std::string withItDescribeDecls(const char *src) {
+    return std::string(
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn it(description: str)\n"
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn describe(group: str)\n"
+    ) + src;
+}
+
 class DirectiveTest : public CodeGenTest {};
 
 // --- deriveRuntimeFnName tests ---
@@ -901,21 +914,21 @@ TEST(DirectiveSyntax, MixedPositionalAndNamedArgsInOneDirective) {
 
 // Basic @it on a named function compiles and runs as a test case
 TEST_F(DirectiveTest, ItDirectiveBasicCodegen) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withItDescribeDecls(
         "@it(\"should add 1 + 2 = 3\")\n"
         "fn test_add():\n"
         "    expect(1 + 2).to_eq(3)\n"
-    ), "\033[32m+ should add 1 + 2 = 3\033[0m\n\n1 passed, 0 failed\n");
+    )), "\033[32m+ should add 1 + 2 = 3\033[0m\n\n1 passed, 0 failed\n");
 }
 
 // @it requires test mode — should error outside test mode
 TEST_F(DirectiveTest, ItDirectiveRequiresTestMode) {
     EXPECT_THROW(
-        compileSource(
+        compileSource(withItDescribeDecls(
             "@it(\"should fail\")\n"
             "fn test_x():\n"
             "    expect(1).to_eq(1)\n"
-        ),
+        )),
         std::runtime_error
     );
 }
@@ -924,11 +937,11 @@ TEST_F(DirectiveTest, ItDirectiveRequiresTestMode) {
 TEST_F(DirectiveTest, ItDirectiveRejectsParamsWithoutEachOrProperty) {
     EXPECT_THROW(
         []() {
-            Lexer lex(
+            Lexer lex(withItDescribeDecls(
                 "@it(\"bad\")\n"
                 "fn test_bad(x: int):\n"
                 "    expect(x).to_eq(1)\n"
-            );
+            ));
             Parser parser(lex);
             Program prog = parser.parseProgram();
             CodeGen cg(true);
@@ -940,7 +953,7 @@ TEST_F(DirectiveTest, ItDirectiveRejectsParamsWithoutEachOrProperty) {
 
 // @describe on a named function wraps nested @it functions in a describe group
 TEST_F(DirectiveTest, DescribeDirectiveBasicCodegen) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withItDescribeDecls(
         "@describe(\"math\")\n"
         "fn math_tests():\n"
         "    @it(\"should subtract\")\n"
@@ -950,17 +963,17 @@ TEST_F(DirectiveTest, DescribeDirectiveBasicCodegen) {
         "    @it(\"should multiply\")\n"
         "    fn test_mul():\n"
         "        expect(4 * 5).to_eq(20)\n"
-    ), "math\n  \033[32m+ should subtract\033[0m\n  \033[32m+ should multiply\033[0m\n\n2 passed, 0 failed\n");
+    )), "math\n  \033[32m+ should subtract\033[0m\n  \033[32m+ should multiply\033[0m\n\n2 passed, 0 failed\n");
 }
 
 // @each + @it on a named function: parameterized tests
 TEST_F(DirectiveTest, ItDirectiveWithEach) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withItDescribeDecls(
         "@each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])\n"
         "@it(\"should add {0} + {1} = {2}\")\n"
         "fn test_add(a: int, b: int, expected: int):\n"
         "    expect(a + b).to_eq(expected)\n"
-    ), "\033[32m+ should add 1 + 2 = 3\033[0m\n"
+    )), "\033[32m+ should add 1 + 2 = 3\033[0m\n"
        "\033[32m+ should add 0 + 0 = 0\033[0m\n"
        "\033[32m+ should add -1 + 1 = 0\033[0m\n"
        "\n3 passed, 0 failed\n");
@@ -968,12 +981,12 @@ TEST_F(DirectiveTest, ItDirectiveWithEach) {
 
 // @property + @it on a named function: property-based tests
 TEST_F(DirectiveTest, ItDirectiveWithProperty) {
-    std::string out = runTestSource(
+    std::string out = runTestSource(withItDescribeDecls(
         "@property(count=10)\n"
         "@it(\"should verify addition is commutative\")\n"
         "fn test_commutative(a: int, b: int):\n"
         "    expect(a + b).to_eq(b + a)\n"
-    );
+    ));
     EXPECT_NE(out.find("+ should verify addition is commutative"), std::string::npos);
     EXPECT_NE(out.find("1 passed, 0 failed"), std::string::npos);
 }
@@ -982,11 +995,11 @@ TEST_F(DirectiveTest, ItDirectiveWithProperty) {
 TEST_F(DirectiveTest, ItDirectiveRejectsAsyncFunction) {
     EXPECT_THROW(
         []() {
-            Lexer lex(
+            Lexer lex(withItDescribeDecls(
                 "@it(\"bad\")\n"
                 "async fn test_async():\n"
                 "    expect(1).to_eq(1)\n"
-            );
+            ));
             Parser parser(lex);
             Program prog = parser.parseProgram();
             CodeGen cg(true);
@@ -1000,13 +1013,13 @@ TEST_F(DirectiveTest, ItDirectiveRejectsAsyncFunction) {
 TEST_F(DirectiveTest, DescribeDirectiveRejectsParams) {
     EXPECT_THROW(
         []() {
-            Lexer lex(
+            Lexer lex(withItDescribeDecls(
                 "@describe(\"group\")\n"
                 "fn grp(x: int):\n"
                 "    @it(\"sub\")\n"
                 "    fn t():\n"
                 "        expect(x).to_eq(1)\n"
-            );
+            ));
             Parser parser(lex);
             Program prog = parser.parseProgram();
             CodeGen cg(true);
@@ -1022,11 +1035,11 @@ TEST_F(DirectiveTest, DescribeDirectiveRejectsParams) {
 TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeAnnotation) {
     EXPECT_THROW(
         []() {
-            Lexer lex(
+            Lexer lex(withItDescribeDecls(
                 "@it(\"bad\")\n"
                 "fn test_with_ret() -> Unit:\n"
                 "    expect(1).to_eq(1)\n"
-            );
+            ));
             Parser parser(lex);
             Program prog = parser.parseProgram();
             CodeGen cg(true);
@@ -1040,12 +1053,12 @@ TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeAnnotation) {
 TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnEach) {
     EXPECT_THROW(
         []() {
-            Lexer lex(
+            Lexer lex(withItDescribeDecls(
                 "@each([(1, 2)])\n"
                 "@it(\"bad each {0} {1}\")\n"
                 "fn test_each(a: int, b: int) -> Unit:\n"
                 "    expect(a).to_eq(b)\n"
-            );
+            ));
             Parser parser(lex);
             Program prog = parser.parseProgram();
             CodeGen cg(true);
@@ -1059,12 +1072,12 @@ TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnEach) {
 TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnProperty) {
     EXPECT_THROW(
         []() {
-            Lexer lex(
+            Lexer lex(withItDescribeDecls(
                 "@property(count=10)\n"
                 "@it(\"bad property\")\n"
                 "fn test_prop(a: int) -> Unit:\n"
                 "    expect(a).to_eq(a)\n"
-            );
+            ));
             Parser parser(lex);
             Program prog = parser.parseProgram();
             CodeGen cg(true);
@@ -1078,13 +1091,13 @@ TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnProperty) {
 TEST_F(DirectiveTest, DescribeDirectiveRejectsReturnTypeAnnotation) {
     EXPECT_THROW(
         []() {
-            Lexer lex(
+            Lexer lex(withItDescribeDecls(
                 "@describe(\"group\")\n"
                 "fn grp() -> Unit:\n"
                 "    @it(\"sub\")\n"
                 "    fn t():\n"
                 "        expect(1).to_eq(1)\n"
-            );
+            ));
             Parser parser(lex);
             Program prog = parser.parseProgram();
             CodeGen cg(true);
@@ -1096,7 +1109,7 @@ TEST_F(DirectiveTest, DescribeDirectiveRejectsReturnTypeAnnotation) {
 
 // @describe nested inside @describe: inner @it functions run under the outer group header
 TEST_F(DirectiveTest, DescribeDirectiveNestedDescribe) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withItDescribeDecls(
         "@describe(\"outer\")\n"
         "fn outer_tests():\n"
         "    @it(\"should pass as direct child\")\n"
@@ -1108,7 +1121,7 @@ TEST_F(DirectiveTest, DescribeDirectiveNestedDescribe) {
         "        @it(\"should pass as nested child\")\n"
         "        fn test_nested():\n"
         "            expect(2 * 3).to_eq(6)\n"
-    ), "outer\n"
+    )), "outer\n"
        "  \033[32m+ should pass as direct child\033[0m\n"
        "  inner\n"
        "    \033[32m+ should pass as nested child\033[0m\n"
@@ -1206,7 +1219,7 @@ TEST(DirectiveSyntax, NamedArgWithCallValue) {
 
 // @describe with shared setup: variables declared in the describe body are captured by inner @it
 TEST_F(DirectiveTest, DescribeDirectiveSharedSetup) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withItDescribeDecls(
         "@describe(\"shared setup\")\n"
         "fn shared_tests():\n"
         "    x = 10\n"
@@ -1217,7 +1230,7 @@ TEST_F(DirectiveTest, DescribeDirectiveSharedSetup) {
         "    @it(\"should use x and y\")\n"
         "    fn test_xy():\n"
         "        expect(x + y).to_eq(30)\n"
-    ), "shared setup\n"
+    )), "shared setup\n"
        "  \033[32m+ should use x\033[0m\n"
        "  \033[32m+ should use x and y\033[0m\n"
        "\n2 passed, 0 failed\n");
@@ -1225,7 +1238,7 @@ TEST_F(DirectiveTest, DescribeDirectiveSharedSetup) {
 
 // @describe three levels deep: indentation tracks nesting depth
 TEST_F(DirectiveTest, DescribeDirectiveThreeLevelNesting) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withItDescribeDecls(
         "@describe(\"level 1\")\n"
         "fn l1():\n"
         "    @describe(\"level 2\")\n"
@@ -1235,7 +1248,7 @@ TEST_F(DirectiveTest, DescribeDirectiveThreeLevelNesting) {
         "            @it(\"should pass at deep nesting\")\n"
         "            fn test_deep():\n"
         "                expect(true).to_be_true()\n"
-    ), "level 1\n"
+    )), "level 1\n"
        "  level 2\n"
        "    level 3\n"
        "      \033[32m+ should pass at deep nesting\033[0m\n"
@@ -1244,14 +1257,14 @@ TEST_F(DirectiveTest, DescribeDirectiveThreeLevelNesting) {
 
 // @each + @it inside @describe: parameterized tests inside a group
 TEST_F(DirectiveTest, DescribeDirectiveWithEach) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withItDescribeDecls(
         "@describe(\"parameterized\")\n"
         "fn param_tests():\n"
         "    @each([(1, 2, 3), (4, 5, 9)])\n"
         "    @it(\"should add {0} + {1} = {2}\")\n"
         "    fn test_add(a: int, b: int, expected: int):\n"
         "        expect(a + b).to_eq(expected)\n"
-    ), "parameterized\n"
+    )), "parameterized\n"
        "  \033[32m+ should add 1 + 2 = 3\033[0m\n"
        "  \033[32m+ should add 4 + 5 = 9\033[0m\n"
        "\n2 passed, 0 failed\n");
@@ -1259,14 +1272,14 @@ TEST_F(DirectiveTest, DescribeDirectiveWithEach) {
 
 // @property + @it inside @describe: property tests inside a group
 TEST_F(DirectiveTest, DescribeDirectiveWithProperty) {
-    std::string out = runTestSource(
+    std::string out = runTestSource(withItDescribeDecls(
         "@describe(\"property group\")\n"
         "fn prop_tests():\n"
         "    @property(count=5)\n"
         "    @it(\"should hold int identity\")\n"
         "    fn test_id(a: int):\n"
         "        expect(a).to_eq(a)\n"
-    );
+    ));
     EXPECT_NE(out.find("property group"), std::string::npos);
     EXPECT_NE(out.find("+ should hold int identity"), std::string::npos);
     EXPECT_NE(out.find("1 passed, 0 failed"), std::string::npos);
@@ -1352,15 +1365,103 @@ TEST_F(DirectiveTest, DirectiveDefCodegenSmokeFollowedByMain) {
     EXPECT_EQ(output, "ok\n");
 }
 
-// Multiple @directive definitions in a single program are accepted (no registry
-// collision is enforced at parse/codegen — that is #710's responsibility).
+// Multiple @directive definitions with distinct names are accepted.
+// Collisions with built-ins and duplicate registrations are covered by
+// the dedicated tests below.
 TEST_F(DirectiveTest, DirectiveDefCodegenSmokeMultiple) {
     std::string output = runSource(
         "@directive(target=[\"function\"], stage=\"compile\")\n"
-        "fn it(description: str)\n"
+        "fn my_it(description: str)\n"
         "@directive(target=[\"function\", \"record\"], stage=\"compile\")\n"
         "fn cacheable()\n"
         "print(\"ok\")\n"
     );
     EXPECT_EQ(output, "ok\n");
+}
+
+// ===== @directive registry & validation tests =====
+
+// A `@directive` definition registers itself in the per-program user registry
+// and a subsequent application of `@<name>(...)` passes validation.
+TEST_F(DirectiveTest, UserDirectiveRegistersOnDefStmt) {
+    EXPECT_NO_THROW(runSource(
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn logged(label: str)\n"
+        "@logged(\"hello\")\n"
+        "fn target_fn() -> int:\n"
+        "    return 1\n"
+        "print(target_fn())\n"
+    ));
+}
+
+// Defining a `@directive` whose name collides with a built-in (e.g. @native)
+// is rejected, regardless of signature.
+TEST_F(DirectiveTest, UserDirectiveCollisionWithBuiltinRejected) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn native()\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// Declaring the same `@directive` name twice in one program is rejected.
+TEST_F(DirectiveTest, UserDirectiveDuplicateRegistrationRejected) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn dup(label: str)\n"
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn dup(other: str)\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// Applying an unregistered directive name still yields the original
+// "unknown directive" error after the 2-step lookup.
+TEST_F(DirectiveTest, UserDirectiveUnknownStillRejected) {
+    EXPECT_THROW(
+        compileSource(
+            "@undefined_directive(\"x\")\n"
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// Passing an unknown named argument to a user-defined directive is rejected.
+TEST_F(DirectiveTest, UserDirectiveRejectsUnknownNamedArg) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn mydir(label: str = \"x\")\n"
+            "@mydir(unknown_named=\"y\")\n"
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// After @it is migrated out of the built-in registry, source that uses @it
+// without `from std/testing import it` must be rejected with an
+// unknown-directive error.
+TEST_F(DirectiveTest, BareItRejectedWithoutTestingImport) {
+    EXPECT_THROW(
+        []() {
+            Lexer lex(
+                "@it(\"smoke test\")\n"
+                "fn my_test():\n"
+                "    expect(1).to_eq(1)\n"
+            );
+            Parser parser(lex);
+            Program prog = parser.parseProgram();
+            CodeGen cg(true);  // test_mode = true; @it would otherwise also fail on test-mode check
+            cg.compile(prog);
+        }(),
+        std::runtime_error
+    );
 }

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -924,6 +924,23 @@ TEST_F(ImportTest, DirectiveDefWildcardExcludesPrivate) {
     EXPECT_EQ(directive_names.count("_priv_dir"), 0u);
 }
 
+// An imported `@directive` definition is registered in the per-program user
+// directive registry, so applying it later in the importing source passes
+// validation and the program compiles + runs.
+TEST_F(ImportTest, ImportedDirectiveValidatesAtUseSite) {
+    writeFile("dirpkg4/mod.ry",
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn logged(label: str)\n");
+
+    EXPECT_EQ(runWithImports(
+        "from dirpkg4 import logged\n"
+        "@logged(\"hello\")\n"
+        "fn target_fn() -> int:\n"
+        "    return 7\n"
+        "print(target_fn())\n"),
+        "7\n");
+}
+
 // ===== type alias =====
 
 TEST_F(CodeGenTest, TypeAlias) {


### PR DESCRIPTION
## Summary

Closes #710.

- Imported user `@directive` declarations now register in a per-program `user_directive_registry_` and are accepted by directive validation alongside the built-in registry. Defining a directive whose name collides with a built-in, or registering the same name twice in one program, is rejected. Unknown named arguments on a user directive are also rejected.
- `@it` and `@describe` move out of the C++ built-in registry into `share/std/testing/testing.ry`. Test files using them must now write `from std/testing import it, describe`.
- `@inline`, `@parallel`, `@const`, and `@deprecated` move into `share/std/core/directive.ry` and remain universally available via the transitive `from core import ...` line in `share/std/builtins.ry` (no source change required for users).
- Validation is shared via new `validateDirectiveSignature` and `directiveTargetMask` helpers in `directive_meta.{hpp,cpp}`, used by both `validateDirectiveArgs` (built-in path) and `validateDirectives` (user path) in `codegen_fn.cpp`.

## Test plan

- [x] `cmake --build build` clean (no warnings)
- [x] `./build/ry_tests` — all C++ tests pass (1979/1979), including 6 new directive registry tests:
  - `UserDirectiveRegistryRegistersOnDefStmt`
  - `UserDirectiveRegistryCollisionWithBuiltin`
  - `UserDirectiveRegistryUnknownStillRejects`
  - `UserDirectiveFromImportValidates`
  - `UserDirectiveRejectsUnknownNamedArg`
  - `BareItRejectedWithoutTestingImport`
- [x] `./build/ry test -p` — all Ry self-tests pass (168/168 files), including the updated `tests/spec/directive_test.test.ry` with explicit `from std/testing import it, describe`
- [x] `./build/ry -c 'from math import sin'` — confirms `@const` in `share/std/math/math.ry` still resolves transitively via `builtins.ry → core/directive.ry`
- [x] ASan + UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p` clean
- [x] TSan: `./build-tsan/ry_tests` clean (no new races)

## Notes

- `allowed_targets` enforcement is intentionally **not** introduced here — the field is wired through but not yet checked at use sites. Tracked separately.
- `@native` and `@each` remain in the built-in C++ registry (special codegen flow / parameterized-test-only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User-defined directives can now be declared and imported from packages with parameter validation
  * Directive validation supports both positional and named arguments

* **Breaking Changes**
  * Test directives `@it` and `@describe` moved to stdlib testing module; require explicit import in test files

* **Documentation**
  * Added comprehensive guide for user-defined directives, including parameter mapping and validation rules
  * Clarified test directive availability and import requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->