### PR TITLE
fix(codegen): allow required directive params in named-argument form (#1397)

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -261,6 +261,7 @@ catch it because the bug is specific to the identifier-adjacent case.
 - `DirectiveDefStmt.targets` is always `std::vector<std::string>`. Bare-string sugar `target="function"` is canonicalized into `{"function"}` at parse time, so downstream consumers (codegen, formatter, future #710 signature builder) never see the bare-string form.
 - `DirectiveDefStmt` codegen is intentionally a no-op (`emitStmt(DirectiveDefStmt&)` in `src/codegen_stmt_misc.cpp`) until #710 consumes it for runtime registration. A future contributor seeing the empty body should not assume logic is missing — the IR-emission gap is by design.
 - Formatter always emits `target=[...]` (List form), even when the source used the bare-string sugar. `FormatterTest.DirectiveDefBareStringSugarCanonicalises` locks this in.
+- After #1397: required params (no default value) are recorded in `DirectiveSignature::positional_param_names` (in declaration order) so they may be passed either positionally or by name at the use site. Optional params (with default) remain in `named_params` (named-only). The `validateDirectiveSignature` shared validator detects positional+named duplicates and missing-required errors using the `positional_param_names` list. Built-in directives leave `positional_param_names` empty for backward compatibility — their existing positional-only semantics are preserved because `min_positional`/`max_positional` still gate them.
 
 ### Formatter→parser roundtrip: `TupleDestructStmt` must not emit `: ` between pattern and `=`
 

--- a/changelog.d/1397-directive-named-required-args.md
+++ b/changelog.d/1397-directive-named-required-args.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- User-defined `@directive` declarations now accept required parameters in named-argument form. Previously `@mydir(description="hi")` for `fn mydir(description: str)` was rejected with "unknown named argument"; now both `@mydir("hi")` and `@mydir(description="hi")` are accepted. Mixed positional+named for the same parameter is rejected as a duplicate, and missing required parameters produce a clearer error. (#1397)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -498,11 +498,11 @@ Multiple targets are allowed via the list form: `target=["function", "record"]`.
 
 **Parameters:**
 
-Parameters use Ry's standard type syntax (`str`, `int`, `bool`, `list`, etc.). Type annotations are optional and default to `any` when omitted; however, a parameter with a default value **must** carry an explicit type annotation. Parameters without a default become required positional arguments at the use site, and parameters with a default become optional named arguments. Required-positional parameters must precede defaulted parameters in the declaration.
+Parameters use Ry's standard type syntax (`str`, `int`, `bool`, `list`, etc.). Type annotations are optional and default to `any` when omitted; however, a parameter with a default value **must** carry an explicit type annotation. Parameters without a default are required and may be passed either positionally or by name at the use site. Parameters with a default are optional named arguments (named-only). Required parameters must precede defaulted parameters in the declaration.
 
 ```ry
 @directive(target=["function"], stage="compile")
-fn logged(label: str)                     # required positional
+fn logged(label: str)                     # required (positional or named)
 
 @directive(target=["function"], stage="compile")
 fn cached(ttl: int = 60)                  # optional named, default 60
@@ -513,8 +513,12 @@ fn cached(ttl: int = 60)                  # optional named, default 60
 ```ry
 from mypkg import logged, cached
 
-@logged("hello")                          # positional argument
+@logged("hello")                          # required by position
 fn target_fn() -> int:
+    return 1
+
+@logged(label="hello")                    # required by name
+fn target_fn2() -> int:
     return 1
 
 @cached()                                 # use default
@@ -526,7 +530,7 @@ fn other_fn() -> int:
     return 42
 ```
 
-`@logged(unknown="y")` is rejected: only declared parameter names may appear at the use site.
+Required parameters may be supplied either positionally or by name, but not both forms for the same parameter — `@logged("hello", label="hi")` is rejected as a duplicate. `@logged(unknown="y")` is rejected: only declared parameter names may appear at the use site. `@logged()` is rejected when `label` is required.
 
 ### Export and import
 

--- a/include/ry/directive_meta.hpp
+++ b/include/ry/directive_meta.hpp
@@ -35,7 +35,12 @@ struct DirectiveSignature {
     DirectiveStage stage;
     int min_positional = 0;
     int max_positional = 0;        // -1 = unlimited
-    std::vector<std::string> named_params;  // allowed named parameter names
+    std::vector<std::string> named_params;  // optional/defaulted named-only parameter names
+    // Names of parameters that may be filled either positionally (in order)
+    // or by name. Used by user-defined `@directive` declarations to expose
+    // required parameters under both forms. Built-in directives leave this
+    // empty to preserve their existing positional-only semantics.
+    std::vector<std::string> positional_param_names;
     // Optional per-directive validation. Called after generic checks pass.
     // Throws std::runtime_error if validation fails.
     void (*custom_validator)(const std::string &, const std::vector<DirectiveArg> &) = nullptr;

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -1122,16 +1122,14 @@ DirectiveSignature fromDirectiveDef(const DirectiveDefStmt &s) {
     sig.allowed_targets = mask;
     sig.stage = (s.stage == "runtime") ? DirectiveStage::Runtime : DirectiveStage::CompileTime;
 
-    sig.min_positional = 0;
-    sig.max_positional = 0;
     for (const auto &p : s.params) {
-        if (!p.default_value) {
-            ++sig.min_positional;
-            ++sig.max_positional;
-        } else {
+        if (!p.default_value)
+            sig.positional_param_names.push_back(p.name);
+        else
             sig.named_params.push_back(p.name);
-        }
     }
+    sig.min_positional = 0;
+    sig.max_positional = static_cast<int>(sig.positional_param_names.size());
     sig.custom_validator = nullptr;
     return sig;
 }

--- a/src/directive_meta.cpp
+++ b/src/directive_meta.cpp
@@ -1,5 +1,7 @@
 #include "ry/directive_meta.hpp"
+#include <algorithm>
 #include <stdexcept>
+#include <unordered_set>
 
 namespace ry {
 
@@ -51,7 +53,7 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
         {"native", {"native",
             T::Function | T::Statement,
             DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/1, {},
+            /*min_pos=*/0, /*max_pos=*/1, {}, /*positional_param_names=*/{},
             [](const std::string &, const std::vector<DirectiveArg> &args) {
                 if (const ExprNode *p = firstPositionalExpr(args)) {
                     if (auto *s = std::get_if<StringExpr>(&p->data)) {
@@ -66,32 +68,32 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
         {"each", {"each",
             T::Statement | T::Function,
             DirectiveStage::CompileTime,
-            /*min_pos=*/1, /*max_pos=*/1, {}}},
+            /*min_pos=*/1, /*max_pos=*/1, {}, /*positional_param_names=*/{}}},
 
         {"property", {"property",
             T::Statement | T::Function,
             DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {"count"}}},
+            /*min_pos=*/0, /*max_pos=*/0, {"count"}, /*positional_param_names=*/{}}},
 
         {"deprecated", {"deprecated",
             T::Function | T::Record | T::Field | T::Statement,
             DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {"reason"}}},
+            /*min_pos=*/0, /*max_pos=*/0, {"reason"}, /*positional_param_names=*/{}}},
 
         {"inline", {"inline",
             asTarget(T::Function),
             DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {"mode"}}},
+            /*min_pos=*/0, /*max_pos=*/0, {"mode"}, /*positional_param_names=*/{}}},
 
         {"parallel", {"parallel",
             asTarget(T::ForLoop),
             DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {}}},
+            /*min_pos=*/0, /*max_pos=*/0, {}, /*positional_param_names=*/{}}},
 
         {"const", {"const",
             asTarget(T::Statement),
             DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {}}},
+            /*min_pos=*/0, /*max_pos=*/0, {}, /*positional_param_names=*/{}}},
     };
     return registry;
 }
@@ -112,17 +114,24 @@ uint8_t directiveTargetMask(std::string_view name) {
 void validateDirectiveSignature(const std::string &directiveName,
                                 const std::vector<DirectiveArg> &args,
                                 const DirectiveSignature &sig) {
+    auto contains = [](const std::vector<std::string> &v, const std::string &n) {
+        return std::find(v.begin(), v.end(), n) != v.end();
+    };
+
     int positional = 0;
+    std::unordered_set<std::string> named_seen;
     for (const auto &a : args) {
         if (!a.name.has_value()) {
             ++positional;
         } else {
-            bool found = false;
-            for (const auto &np : sig.named_params)
-                if (np == *a.name) { found = true; break; }
-            if (!found)
+            if (!contains(sig.positional_param_names, *a.name) &&
+                !contains(sig.named_params, *a.name))
                 throw std::runtime_error(
                     "unknown named argument '" + *a.name +
+                    "' for directive '@" + directiveName + "'");
+            if (!named_seen.insert(*a.name).second)
+                throw std::runtime_error(
+                    "duplicate named argument '" + *a.name +
                     "' for directive '@" + directiveName + "'");
         }
     }
@@ -135,6 +144,19 @@ void validateDirectiveSignature(const std::string &directiveName,
         throw std::runtime_error(
             "@" + directiveName + " accepts at most " +
             std::to_string(sig.max_positional) + " positional argument(s)");
+
+    for (size_t i = 0; i < sig.positional_param_names.size(); ++i) {
+        const std::string &pname = sig.positional_param_names[i];
+        bool by_pos = static_cast<int>(i) < positional;
+        bool by_name = named_seen.count(pname) > 0;
+        if (by_pos && by_name)
+            throw std::runtime_error(
+                "argument '" + pname + "' for directive '@" + directiveName +
+                "' provided both positionally and by name");
+        if (!by_pos && !by_name)
+            throw std::runtime_error(
+                "@" + directiveName + " missing required argument '" + pname + "'");
+    }
 
     if (sig.custom_validator)
         sig.custom_validator(directiveName, args);

--- a/src/directive_meta.cpp
+++ b/src/directive_meta.cpp
@@ -149,13 +149,22 @@ void validateDirectiveSignature(const std::string &directiveName,
         const std::string &pname = sig.positional_param_names[i];
         bool by_pos = static_cast<int>(i) < positional;
         bool by_name = named_seen.count(pname) > 0;
-        if (by_pos && by_name)
-            throw std::runtime_error(
-                "argument '" + pname + "' for directive '@" + directiveName +
-                "' provided both positionally and by name");
-        if (!by_pos && !by_name)
-            throw std::runtime_error(
-                "@" + directiveName + " missing required argument '" + pname + "'");
+        if (by_pos && by_name) {
+            std::string msg = "argument '";
+            msg += pname;
+            msg += "' for directive '@";
+            msg += directiveName;
+            msg += "' provided both positionally and by name";
+            throw std::runtime_error(msg);
+        }
+        if (!by_pos && !by_name) {
+            std::string msg = "@";
+            msg += directiveName;
+            msg += " missing required argument '";
+            msg += pname;
+            msg += "'";
+            throw std::runtime_error(msg);
+        }
     }
 
     if (sig.custom_validator)

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1446,6 +1446,84 @@ TEST_F(DirectiveTest, UserDirectiveRejectsUnknownNamedArg) {
     );
 }
 
+// A required parameter (no default) may also be passed by name (#1397).
+TEST_F(DirectiveTest, UserDirectiveRequiredParamAcceptsNamedArg) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn mydir(description: str)\n"
+        "@mydir(description=\"hi\")\n"
+        "fn target_fn() -> int:\n"
+        "    return 1\n"
+    ));
+}
+
+// Required-param directives still reject truly unknown named args (#1397).
+TEST_F(DirectiveTest, UserDirectiveRejectsUnknownNamedArgWithRequiredParam) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn mydir(description: str)\n"
+            "@mydir(unknown=\"x\")\n"
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// Providing the same parameter both positionally and by name is rejected.
+TEST_F(DirectiveTest, UserDirectiveRejectsRequiredParamProvidedTwice) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn mydir(description: str)\n"
+            "@mydir(\"hi\", description=\"again\")\n"
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// Omitting a required parameter (with no positional fallback either) is rejected.
+TEST_F(DirectiveTest, UserDirectiveRejectsMissingRequiredParam) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn mydir(description: str)\n"
+            "@mydir()\n"
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// Passing the same named argument twice is rejected.
+TEST_F(DirectiveTest, UserDirectiveRejectsDuplicateNamedArg) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn mydir(label: str = \"x\")\n"
+            "@mydir(label=\"a\", label=\"b\")\n"
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// Required positional + optional named — common usage must remain accepted.
+TEST_F(DirectiveTest, UserDirectiveAcceptsMixedPositionalAndNamed) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn mydir(description: str, level: str = \"info\")\n"
+        "@mydir(\"hi\", level=\"warn\")\n"
+        "fn target_fn() -> int:\n"
+        "    return 1\n"
+    ));
+}
+
 // After @it is migrated out of the built-in registry, source that uses @it
 // without `from std/testing import it` must be rejected with an
 // unknown-directive error.


### PR DESCRIPTION
## Summary

- User-defined `@directive` declarations now accept required (default-less) parameters as both positional **and** named arguments at the use site. `@mydir(description="hi")` for `fn mydir(description: str)` no longer fails with "unknown named argument".
- The shared validator now also rejects duplicate named arguments (`label="a", label="b"`), the same parameter supplied both positionally and by name, and missing required arguments — each with a clearer message.
- Built-in directives are unchanged: they leave the new `positional_param_names` list empty, so their positional-only semantics still flow through `min_positional`/`max_positional`.

## Implementation

- `include/ry/directive_meta.hpp` — adds `DirectiveSignature::positional_param_names` (parameters that may be filled by position **or** name).
- `src/codegen_stmt_misc.cpp` — `fromDirectiveDef` routes required params into `positional_param_names` (in declaration order) and defaulted params into `named_params` (named-only).
- `src/directive_meta.cpp` — `validateDirectiveSignature` cross-checks positional/named coverage, detects duplicate named, and emits missing-required errors.

## Out of scope

Allowing defaulted parameters to be passed positionally (`@logged("foo")` for `fn logged(label: str = "x")`) is tracked separately in #1402.

## Test plan

- [x] New tests in `tests/test_codegen_directive.cpp`:
  - `UserDirectiveRequiredParamAcceptsNamedArg` — required param via name
  - `UserDirectiveRejectsUnknownNamedArgWithRequiredParam` — unknown still rejected
  - `UserDirectiveRejectsRequiredParamProvidedTwice` — positional + named for same param
  - `UserDirectiveRejectsMissingRequiredParam` — required omitted
  - `UserDirectiveRejectsDuplicateNamedArg` — `label="a", label="b"`
  - `UserDirectiveAcceptsMixedPositionalAndNamed` — mixed form preserved
- [x] `./build/ry_tests` — all 1985 C++ tests pass
- [x] `./build/ry test -p` — Ry self-test (168) passes
- [x] ASan + UBSan (`build-asan/`) — full suite passes
- [x] TSan C++ (`build-tsan/ry_tests`) — passes
- [x] libFuzzer 60 s × 3 targets (parser / json / utf8) — exit 0
- [x] Manual repro: `tests/spec/test_1397_repro.test.ry` exercises `@it(description=...)` and `@mydir(description=...)`

## Docs / KB

- `docs/reference/directives.md` — prose updated; declaration-block and use-site examples now show both positional and named forms; rejection notes extended.
- `changelog.d/1397-directive-named-required-args.md` — Fixed entry for `[Unreleased]`.
- `.claude/rules/parser-conventions.md` — invariant added documenting the new `positional_param_names` registration shape and built-in backward compatibility.

Closes #1397

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User-defined `@directive` parameters now accept named-argument syntax (e.g., `@mydir(param="value")`) in addition to positional arguments.

* **Improvements**
  * Validation now rejects providing the same parameter both positionally and by name.
  * Missing required-parameter errors are clearer.

* **Documentation**
  * Updated directive docs and examples to show named usage and duplicate/missing-parameter error cases.

* **Tests**
  * Added tests covering named required args, duplicates, unknown names, and missing-required cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->