### PR TITLE
chore(checklist): add static analysis step to pre-commit-checklist (#1404)

### DIFF
--- a/.claude/rules/build-warning-flags.md
+++ b/.claude/rules/build-warning-flags.md
@@ -114,3 +114,38 @@ where possible.
 **Gotcha**: Cppcheck 2.13 (Ubuntu 24.04 package) does NOT support `#` comment lines
 in `--suppressions-list` files. Comment syntax was added in 2.14. Keep
 `.cppcheck-suppressions` comment-free to remain compatible with 2.13.
+
+### Clang-Tidy: `performance-inefficient-string-concatenation` — error メッセージで `+` chain を使わない
+
+**Source**: #1404 (2026-04-27, motivated by PR #1403)
+**Tags**: build, clang-tidy, static-analysis, performance, string-concatenation
+
+**Context**: PR #1403 が CI の `clang-tidy` ジョブで失敗した。原因は `src/directive_meta.cpp` の throw メッセージで `std::string operator+` のチェーンを使っていたこと。`performance-inefficient-string-concatenation` は `.clang-tidy` で `performance-*` ファミリー経由で有効化されており、`a + b + c + d` のような連鎖が各ステップで一時 `std::string` を heap-allocate することを警告する。
+
+**Rule**: `throw std::runtime_error(...)`、`codegenError(...)`、その他のエラーメッセージ構築で 3 つ以上の文字列を `+` で連結してはならない。代わりに宣言-代入 + `+=` のチェーンを使う:
+
+```cpp
+// 禁止 (clang-tidy が performance-inefficient-string-concatenation で失敗)
+throw std::runtime_error(
+    "unknown named argument '" + *a.name +
+    "' for directive '@" + directiveName + "'");
+
+// 正しい
+std::string msg = "unknown named argument '";
+msg += *a.name;
+msg += "' for directive '@";
+msg += directiveName;
+msg += "'";
+throw std::runtime_error(msg);
+```
+
+**Why**: `a + b + c + d` は `(((a + b) + c) + d)` と評価され、各 `operator+` で新規 `std::string` を heap-allocate する。`+=` は in-place で再割り当てを最小化する。エラーメッセージのような頻度が低い箇所でも clang-tidy は警告するため、ローカル検出が必須。
+
+**How to apply**:
+- エラーメッセージは `std::string msg = "プレフィックス";` で初期化、残りを `msg += var; msg += "テキスト";` で構築
+- 2 つ連結 (`"prefix " + var`) は警告対象外のことが多いが、3 つ以上は常に `+=` を使う
+- canonical 例: `src/codegen_expr_literal.cpp:454-458` (set literal 型不一致エラー)、PR #1403 で修正された `src/directive_meta.cpp:127-158`
+
+**Check name**: `performance-inefficient-string-concatenation` (`.clang-tidy` で `performance-*` ファミリー経由で有効)
+
+**Known macOS-only false positives** (#1405): macOS の libc++ 環境で `bugprone-exception-escape` が `src/codegen.cpp:189` (`FnScope::~FnScope`) / `src/main.cpp:23` (`main`) / `src/main.cpp:280` (lambda) の 3 箇所で誤検知される。Linux libstdc++ (CI) では発生しないため CI は green。`#1405` で surgical fix が完了するまで、この 3 件はスキップして**他の clang-tidy エラーがないこと**を local 検証の合格基準とする。

--- a/.claude/skills/commands-environment-gotchas/SKILL.md
+++ b/.claude/skills/commands-environment-gotchas/SKILL.md
@@ -140,3 +140,29 @@ Alternatively, derive run IDs directly from `detailsUrl` in the `gh pr checks` o
 **Tags**: skill, gh-cli, review-feedback
 
 **Rule**: Using `gh repo view --json owner,name --jq '.owner.login + "/" + .name'` and storing the result as both `owner` and `repo` is correct only when the downstream code treats the combined value as a single placeholder (e.g. `repos/$FULL/...`). When downstream steps separately substitute `{owner}` and `{repo}` (REST paths like `repos/{owner}/{repo}/pulls/{PR}/...` or GraphQL `repository(owner: "<owner>", name: "<repo>")`), the combined string causes doubled path segments (e.g. `repos/t0k0sh1/ry/ry/pulls/...`) or an incorrect GraphQL `owner` argument. In that case, fetch them separately: `OWNER=$(gh repo view --json owner --jq '.owner.login')` / `REPO=$(gh repo view --json name --jq '.name')`. When writing or reviewing a skill step that stores repository coordinates, verify whether downstream uses the value as one unit or as two — they require different fetch forms.
+
+---
+
+### macOS: Apple clang PCH と LLVM clang-tidy は互換性がない
+
+**Source**: #1404 (2026-04-27)
+**Tags**: cmake, clang-tidy, pch, macos, static-analysis, homebrew
+
+**Wrong**: macOS で `cmake --preset default` (Apple clang で configure) の後そのまま `clang-tidy -p build --quiet` を実行する → `error: PCH file built from a different branch ((clang-apple) vs (clang))` で失敗
+
+**Correct**: `build/` を削除して LLVM clang を CC/CXX に明示し、`SDKROOT` を渡してから再 configure する:
+
+```bash
+rm -rf build
+SDKROOT=$(xcrun --show-sdk-path) \
+CC=/opt/homebrew/opt/llvm@21/bin/clang \
+CXX=/opt/homebrew/opt/llvm@21/bin/clang++ \
+    cmake --preset default && cmake --build build
+find src -name '*.cpp' | xargs /opt/homebrew/opt/llvm@21/bin/clang-tidy -p build --quiet
+```
+
+**Why**: CMake は configure 時のコンパイラに紐づいた PCH (`.gch`) を生成する。macOS デフォルトの `cmake --preset default` は Apple clang で PCH を作るが、Homebrew LLVM clang-tidy は upstream LLVM のバージョン文字列を期待するため、Apple clang 由来の PCH を読めない。CC/CXX を LLVM に固定すれば configure 時から LLVM PCH になり、clang-tidy が読める。
+
+`SDKROOT` を渡さないと LLVM clang は libc++ ヘッダ検索パスから C ヘッダ (`stddef.h`, `cmath` など) を見つけられず、`<cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h> header` で失敗する。Apple clang は PATH 経由で macOS SDK を自動解決するが、Homebrew LLVM clang は明示が必要。
+
+CI (Linux) では `/usr/local/llvm/bin/clang` が `cc` / `c++` symlink を介して PATH に入るため同じ問題は発生しない。

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -108,6 +108,64 @@ cmake --preset tsan && cmake --build build-tsan && \
 
 C++ TSan テスト (`ry_tests`) は required で、`ConcurrencySpecSuite` (= `tests/spec/concurrency.test.ry` stress test) を検証する。Ry self-test (`ry test -p`) は TSan `LargeMmapAllocator` CHECK 問題 (upstream #1716) により warn-only — ローカルでも CI でも C++ テストが clean run していれば本 PR スコープでは OK とする。race が検出された場合 (C++ / self-test どちらでも) は本 PR スコープ内で修正すること。既知 race として扱って先送りしてはならない。`/tsan-known-issues` の `LargeMmapAllocator` entry を参照。#630 の audit に無い新規 race パターンを発見した場合は新規 concurrency issue を起票し、再現テストを `tests/spec/concurrency*.test.ry` に追加する。
 
+## 3.5.5. Static Analysis
+
+CI の `lint` / `clang-tidy` / `scan-build` ジョブを push 前にローカルで再現する。設定・抑制ルール・誤検知対処の詳細は `/static-analysis-tools` に委譲。
+
+**clang-tidy** (required):
+
+```bash
+find src -name '*.cpp' | xargs /opt/homebrew/opt/llvm@21/bin/clang-tidy -p build --quiet
+```
+
+**Known macOS false positives** (#1405): macOS 上では `bugprone-exception-escape` が `src/codegen.cpp:189` (`FnScope::~FnScope`) / `src/main.cpp:23` (`main`) / `src/main.cpp:280` (lambda) の 3 箇所で発火する。これは libc++ vs libstdc++ の noexcept 推論差異に起因する pre-existing platform-specific FP で、CI (Linux libstdc++) では発生しない。#1405 が surgical fix で解決されるまでは、これら 3 件は許容して**それ以外の clang-tidy エラーがないことを確認**する。
+
+**PCH 互換性**: macOS で `cmake --preset default` (Apple clang が PCH 生成) の後に LLVM clang-tidy を実行すると `PCH file built from a different branch` で失敗することがある。`build/` を削除して LLVM clang を CC/CXX に明示してから再 configure する (`SDKROOT` も必須):
+
+```bash
+rm -rf build
+SDKROOT=$(xcrun --show-sdk-path) \
+CC=/opt/homebrew/opt/llvm@21/bin/clang \
+CXX=/opt/homebrew/opt/llvm@21/bin/clang++ \
+    cmake --preset default && cmake --build build
+```
+
+詳細は `/commands-environment-gotchas` の PCH entry を参照。
+
+**cppcheck** (required):
+
+```bash
+cppcheck --enable=warning,performance,portability --std=c++17 --error-exitcode=1 \
+    --suppressions-list=.cppcheck-suppressions --inline-suppr \
+    -i build -i build-asan -i build-tsan \
+    -j "$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)" --quiet \
+    src/ include/
+```
+
+**scan-build** (warn-only — 強く推奨):
+
+CI は `continue-on-error: true` で warn-only 運用中。ローカルでも警告即修正は不要だが、新規 null-dereference / use-after-free / division-by-zero が検出された場合は同 PR で対処することを強く推奨する。
+
+scan-build は Homebrew LLVM 21 に同梱されているが PATH には入らない。フルパス `/opt/homebrew/opt/llvm@21/bin/scan-build` で呼び出す:
+
+```bash
+/opt/homebrew/opt/llvm@21/bin/scan-build \
+    --use-analyzer=/opt/homebrew/opt/llvm@21/bin/clang \
+    --use-cc=/opt/homebrew/opt/llvm@21/bin/clang \
+    --use-c++=/opt/homebrew/opt/llvm@21/bin/clang++ \
+    cmake --preset default
+
+/opt/homebrew/opt/llvm@21/bin/scan-build \
+    --use-analyzer=/opt/homebrew/opt/llvm@21/bin/clang \
+    --use-cc=/opt/homebrew/opt/llvm@21/bin/clang \
+    --use-c++=/opt/homebrew/opt/llvm@21/bin/clang++ \
+    -o /tmp/scan-build-report --status-bugs cmake --build build
+```
+
+scan-build はビルドをラップするため `build/` の状態が変わる場合がある。以降のステップでビルドが必要なら §3 のコマンドで再ビルドする。
+
+clang-tidy / cppcheck で失敗した場合は原因を修正してから作業完了とする。よくある失敗パターン (`performance-inefficient-string-concatenation` 等) と canonical workaround は `.claude/rules/build-warning-flags.md` を参照。
+
 ## 3.6. libFuzzer Fuzzing
 
 **CI ジョブは無効のため、フィーチャーブランチで必ずローカル実行すること。** ハーネス要件・既知制限の詳細は `/libfuzzer-harness` を参照。


### PR DESCRIPTION
## Summary

PR #1403 が `pre-commit-checklist` 全項目クリアで push されたものの CI の `clang-tidy` ジョブで `performance-inefficient-string-concatenation` 失敗が発生。push → CI 失敗 → 修正 → push のロードトリップを防ぐため、`pre-commit-checklist` に静的解析ステップを追加する。

- **`§3.5.5 Static Analysis`** セクションを `pre-commit-checklist/SKILL.md` に追加
  - `clang-tidy` (required) — 失敗 shape のローカル検出
  - `cppcheck` (required)
  - `scan-build` (warn-only — 強く推奨、フルパス `/opt/homebrew/opt/llvm@21/bin/scan-build`)
- **macOS Apple clang PCH 互換性 gotcha** を `commands-environment-gotchas/SKILL.md` に追加 (build 削除 + SDKROOT + LLVM clang 明示)
- **`performance-inefficient-string-concatenation` rule entry** を `build-warning-flags.md` に追加 (canonical `+=` chain workaround、`src/codegen_expr_literal.cpp:454-458` を参照例として記載)
- 既知 macOS-only FP は #1405 で別途追跡し、§3.5.5 と rule entry の両方に caveat を記載

## Verification

セルフ検証 (本ブランチ上):

- `cppcheck`: exit 0 (clean) ✓
- `clang-tidy`: 既知 3 件 FP (#1405) のみ、新規エラーなし ✓
- 委譲先 `/static-analysis-tools` / `/commands-environment-gotchas` 既存確認 ✓

## Out of scope (tracked separately)

- **#1405**: macOS clang-tidy `bugprone-exception-escape` 3 件の surgical fix (libc++ vs libstdc++ noexcept 推論差異の pre-existing platform-specific FP、CI green)

## Test plan

- [x] `pre-commit-checklist/SKILL.md` 更新 (clang-tidy required / cppcheck required / scan-build warn-only)
- [x] PCH 互換性 gotcha を `commands-environment-gotchas` に集約 + `pre-commit-checklist` に inline サマリ
- [x] knowledge base rule entry 1 つ追加 (`performance-inefficient-string-concatenation`)
- [x] PR #1403 と同 shape の CI 失敗が push 前に local で検出可能 (clang-tidy が `directive_meta.cpp` を含む全 `*.cpp` に対して clean run)
- [ ] CI green (`lint` / `clang-tidy` / `scan-build` ジョブが従来通り pass)

Closes #1404