### PR TITLE
fix(clang-tidy): suppress macOS libc++ bugprone-exception-escape false positives (#1405)

### DIFF
--- a/.claude/rules/build-warning-flags.md
+++ b/.claude/rules/build-warning-flags.md
@@ -147,5 +147,3 @@ throw std::runtime_error(msg);
 - canonical 例: `src/codegen_expr_literal.cpp:454-458` (set literal 型不一致エラー)、PR #1403 で修正された `src/directive_meta.cpp:127-158`
 
 **Check name**: `performance-inefficient-string-concatenation` (`.clang-tidy` で `performance-*` ファミリー経由で有効)
-
-**Known macOS-only false positives** (#1405): macOS の libc++ 環境で `bugprone-exception-escape` が `src/codegen.cpp:189` (`FnScope::~FnScope`) / `src/main.cpp:23` (`main`) / `src/main.cpp:280` (lambda) の 3 箇所で誤検知される。Linux libstdc++ (CI) では発生しないため CI は green。`#1405` で surgical fix が完了するまで、この 3 件はスキップして**他の clang-tidy エラーがないこと**を local 検証の合格基準とする。

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -118,8 +118,6 @@ CI の `lint` / `clang-tidy` / `scan-build` ジョブを push 前にローカル
 find src -name '*.cpp' | xargs /opt/homebrew/opt/llvm@21/bin/clang-tidy -p build --quiet
 ```
 
-**Known macOS false positives** (#1405): macOS 上では `bugprone-exception-escape` が `src/codegen.cpp:189` (`FnScope::~FnScope`) / `src/main.cpp:23` (`main`) / `src/main.cpp:280` (lambda) の 3 箇所で発火する。これは libc++ vs libstdc++ の noexcept 推論差異に起因する pre-existing platform-specific FP で、CI (Linux libstdc++) では発生しない。#1405 が surgical fix で解決されるまでは、これら 3 件は許容して**それ以外の clang-tidy エラーがないことを確認**する。
-
 **PCH 互換性**: macOS で `cmake --preset default` (Apple clang が PCH 生成) の後に LLVM clang-tidy を実行すると `PCH file built from a different branch` で失敗することがある。`build/` を削除して LLVM clang を CC/CXX に明示してから再 configure する (`SDKROOT` も必須):
 
 ```bash

--- a/.claude/skills/static-analysis-tools/SKILL.md
+++ b/.claude/skills/static-analysis-tools/SKILL.md
@@ -25,6 +25,26 @@ Reference for Clang-Tidy, Cppcheck, and Clang Static Analyzer (scan-build) confi
 - ローカル実行: `find src -name '*.cpp' | xargs clang-tidy -p build --quiet`
 - 新規コードは Clang-Tidy 警告ゼロを維持すること
 
+### Platform-specific false positives (libc++ vs libstdc++)
+
+**Source**: #1405 (2026-04-27)
+**Tags**: clang-tidy, bugprone-exception-escape, libc++, libstdc++, noexcept, platform-specific
+
+**Context**: macOS Homebrew LLVM (libc++) と Linux apt LLVM (libstdc++) は、`bugprone-exception-escape` などの noexcept 推論で挙動が異なる。libc++ のほうが保守的で、std container の move-assignment / `resize()` / lambda の operator() を `noexcept` と推論しないことがある。結果、Linux CI では green でも macOS ローカルでは error になる構成が生じる。
+
+**抑制方針**:
+
+1. **真に noexcept な処理**: `noexcept` を明示する。例: container move-assignment のみで構成された destructor は `~Foo() noexcept;` と宣言・定義の両方を coupled で更新する。これは仕様通りの noexcept なので NOLINT より好ましい。ただし `resize()` のような libc++ が常に保守的に推論する操作を含む場合は、`noexcept` でも警告は消えないため、加えて `// NOLINTNEXTLINE` が必要。
+2. **プロセス境界・watcher・スレッドエントリ**: `std::terminate` 動作が許容済みの箇所は `// NOLINTNEXTLINE(bugprone-exception-escape): <理由>` で抑制する。理由文には「process boundary」「watcher lambda」「thread entry」など具体的なコンテキストを書く。
+
+**抑制すべきでないケース**: 通常の関数で例外を投げうるコードを noexcept と宣言・抑制すること。例外発生で `std::terminate` するため、プロセス境界以外では呼び出し側が捕捉できる例外設計を維持する。
+
+**ローカル検証**: macOS では Homebrew clang で build しないと clang-tidy 21 が PCH を読めない。`CC=/opt/homebrew/opt/llvm@21/bin/clang CXX=/opt/homebrew/opt/llvm@21/bin/clang++ cmake --preset default -DCMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path)` で reconfigure する。
+
+**参照例**:
+- `src/codegen.cpp` の `CodeGen::FnScope::~FnScope() noexcept` — `noexcept` 明示 + NOLINTNEXTLINE 併用（destructor 末尾の `resize()` を libc++ が throwing と推論）
+- `src/main.cpp` の `main()` と watcher lambda — NOLINTNEXTLINE で抑制（process boundary）
+
 ## Cppcheck
 
 プロジェクトルートの `.cppcheck-suppressions` で抑制設定を管理する。CI の `lint` ジョブが `src/` と `include/` に対して実行する。

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1001,7 +1001,7 @@ public:
     class FnScope {
     public:
         explicit FnScope(CodeGen &cg);
-        ~FnScope();
+        ~FnScope() noexcept;
         FnScope(const FnScope&) = delete;
         FnScope& operator=(const FnScope&) = delete;
     private:

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -186,7 +186,8 @@ CodeGen::FnScope::FnScope(CodeGen &cg) : cg_(cg) {
     cg_.current_function_name_.clear();
 }
 
-CodeGen::FnScope::~FnScope() {
+// NOLINTNEXTLINE(bugprone-exception-escape): trailing vector::resize() only shrinks the stack; libc++ conservatively treats resize() as throwing
+CodeGen::FnScope::~FnScope() noexcept {
     cg_.fn_ = savedFn_;
     cg_.scope_stack_ = std::move(savedScope_);
     cg_.immutable_scope_stack_ = std::move(savedConstScope_);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@ using namespace llvm;
 
 namespace fs = std::filesystem;
 
+// NOLINTNEXTLINE(bugprone-exception-escape): process boundary; uncaught exceptions invoke std::terminate
 int main(int argc, char *argv[]) {
     bool skip_global_lib = ry::cli::parseRyEnv(argc, argv);
     bool trace_enabled = false;
@@ -277,6 +278,7 @@ int main(int argc, char *argv[]) {
                 const std::string &root_dir = *root;
                 const char *a0 = argv[0];
                 bool sgl = skip_global_lib;
+                // NOLINTNEXTLINE(bugprone-exception-escape): watcher lambda; exceptions terminate the process
                 ry::watchAndRunTests(root_dir, [root_dir, a0, sgl, parallel, coverage, outline]() {
                     ry::discoverAndRunTests(root_dir, a0, sgl, parallel, coverage, outline);
                 });


### PR DESCRIPTION
## Summary

Resolves three `bugprone-exception-escape` clang-tidy errors that fire on macOS Homebrew LLVM (libc++) but not on Linux apt LLVM (libstdc++). libc++ is more conservative about noexcept inference, treating `std::vector::resize()` and lambda `operator()` as potentially throwing where libstdc++ does not.

- `src/codegen.cpp:189` — `CodeGen::FnScope::~FnScope()` declared `noexcept` (destructor body is move-assigns + a shrinking `resize()`). Trailing `resize()` to a captured pre-push size only ever shrinks, but libc++ still flags it, so paired with `NOLINTNEXTLINE`.
- `src/main.cpp:23` — `main()` suppressed via `NOLINTNEXTLINE` (process boundary; uncaught exceptions invoke `std::terminate`).
- `src/main.cpp:280` — third `watchAndRunTests` watcher lambda suppressed (process boundary).

Also relocates the platform-specific FP guidance into `static-analysis-tools/SKILL.md` and drops the temporary `#1405` stopgap notes from `build-warning-flags.md` and `pre-commit-checklist/SKILL.md`.

Closes #1405.

## Test plan

- [x] `cmake --build build` (Homebrew clang + macOS SDK) — clean
- [x] `./build/ry_tests` — 1985/1985 passed
- [x] `./build/ry test -p` — 168 files / 0 failures
- [x] `clang-tidy -p build src/codegen.cpp src/main.cpp` — 4 NOLINT suppressions, 0 errors
- [x] `cppcheck` — clean
- [x] `ctest -L filecheck` — 10/10 passed
- [x] ASan + UBSan: `./build-asan/ry_tests` 1985/1985 passed; `./build-asan/ry test -p` 168 files / 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code enhancements focused on improving exception handling safety and code robustness. These changes strengthen stability guarantees during resource cleanup and shutdown operations while reducing potential stability risks from unexpected exception behavior. Static analysis configurations and annotations were optimized to provide better code quality assurance and exception safety coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->