### PR TITLE
feat(directives): migrate non-bootstrap built-in directives to stdlib (#1390)

### DIFF
--- a/.claude/rules/tests-cpp-conventions.md
+++ b/.claude/rules/tests-cpp-conventions.md
@@ -6,6 +6,24 @@ paths:
 
 # Tests — C++ Conventions
 
+### Stdlib-declared directives need `withStdlibDirectiveDecls()` in C++ tests
+
+**Source**: #1390 (2026-04-27, implementation)
+**Tags**: testing, codegen-test, directives, stdlib, module-loader, harness
+
+**Context**: After #1390, the non-bootstrap built-in directives (`@inline`, `@parallel`, `@const`, `@deprecated`, `@each`, `@property`) and `@it` / `@describe` are declared in stdlib `.ry` files (`share/std/core/directive.ry`, `share/std/testing/testing.ry`). Their declarations reach a normal `./build/ry` invocation only via `ModuleLoader` → `from std import` (wildcard) → `builtins.ry` re-export → `core/directive.ry`, plus the explicit `from testing import ...` for the testing pair.
+
+The codegen test harness (`runSource`, `runSourceWithWarnings`, `runTestSource`, `compileSource` in `tests/test_codegen_common.hpp`) goes `Parser → CodeGen` directly and **skips `ModuleLoader` entirely**. Source that uses any of these directives without inline declarations therefore fails at codegen with `unknown directive '@inline'` (or `@parallel`, etc.) — even though the same source runs fine through the real CLI.
+
+**Rule**: Any C++ test that exercises a directive declared in stdlib `.ry` (the 8 listed above) must wrap its source with `withStdlibDirectiveDecls()` from `tests/test_codegen_common.hpp`. The helper prepends inline `@directive(target=..., stage=...)` declarations equivalent to what the loader would inject.
+
+**How to apply**:
+- Adding a new test that uses any of `@inline / @parallel / @const / @deprecated / @each / @property / @it / @describe`: wrap the source string — `runSource(withStdlibDirectiveDecls("..."))`. Don't try to express the directive declaration inline ad-hoc.
+- Adding a new directive to the stdlib `.ry` declarations: extend `withStdlibDirectiveDecls()` in `tests/test_codegen_common.hpp` to include the new declaration so existing tests that exercise it continue to work.
+- Removing a directive from the C++ registry: registry deletion + stdlib `.ry` declaration + helper update + applying the helper to affected tests must land in **one commit** because `emitStmt(DirectiveDefStmt)`'s collision check rejects builds where a registry entry and a `.ry` declaration coexist for the same name.
+
+**Why a smoke test is still needed**: The helper bypasses the actual `ModuleLoader` → `builtins.ry` re-export chain, so all-green C++ tests prove the codegen logic but not the loader path. Always also run a smoke test through the real CLI (`./build/ry /tmp/<file>.ry`) when changing the directive declaration locations or the re-export wiring.
+
 ### CodeGenTest::runSource cannot compile code that imports stdlib packages
 
 **Source**: #842 (2026-04-11, implementation)

--- a/changelog.d/1390-directive-stdlib-migration.md
+++ b/changelog.d/1390-directive-stdlib-migration.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Migrated 6 built-in directives from the C++ registry to stdlib `.ry` declarations. `@inline`, `@parallel`, `@const`, and `@deprecated` are now declared in `share/std/core/directive.ry` and remain implicitly available via the `share/std/builtins.ry` re-export. `@each` and `@property` are now declared in `share/std/testing/testing.ry` and require an explicit `from testing import each, property` (or the subset used) — consistent with `@it` / `@describe`. Only `@directive` and `@native` remain as compiler built-ins (the bootstrap pair). (#1390)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -28,7 +28,7 @@ Directives can be applied to the following declarations:
 
 Marks a declaration as deprecated. When a deprecated entity is used (called, referenced, or accessed), a compile-time warning is emitted.
 
-**Defined as:** Compiler built-in (currently in C++; planned for stdlib migration in a future release).
+**Defined as:** Declared in `share/std/core/directive.ry` (implicitly imported via `share/std/builtins.ry`).
 
 **On functions:**
 
@@ -80,7 +80,7 @@ print(c.new_setting)     # no warning
 
 Marks a variable as immutable. Variables declared with `@const` cannot be reassigned after initialization. Without `@const`, variables are mutable by default.
 
-**Defined as:** Compiler built-in (currently in C++; planned for stdlib migration in a future release).
+**Defined as:** Declared in `share/std/core/directive.ry` (implicitly imported via `share/std/builtins.ry`).
 
 ```
 @const
@@ -194,7 +194,7 @@ print(length(range()))           # Error: range() takes 1, 2, or 3 arguments
 
 Marks a counted `for` loop for parallel execution.
 
-**Defined as:** Compiler built-in (currently in C++; planned for stdlib migration in a future release).
+**Defined as:** Declared in `share/std/core/directive.ry` (implicitly imported via `share/std/builtins.ry`).
 
 ```
 @parallel
@@ -219,7 +219,7 @@ for i in range(8):
 
 Enables parameterized testing by running a test multiple times with different parameters.
 
-**Defined as:** Compiler built-in (currently in C++; planned for stdlib migration in a future release).
+**Defined as:** Declared in `share/std/testing/testing.ry`. Test files must add `from testing import each` (or include it in the existing `from testing import` line) at the top.
 
 **Syntax (on a named function, preferred):**
 
@@ -261,7 +261,7 @@ fn test_handle(x: int):
 
 Enables property-based testing by generating random inputs for a test.
 
-**Defined as:** Compiler built-in (currently in C++; planned for stdlib migration in a future release).
+**Defined as:** Declared in `share/std/testing/testing.ry`. Test files must add `from testing import property` (or include it in the existing `from testing import` line) at the top.
 
 **Syntax (on a named function, preferred):**
 
@@ -413,7 +413,7 @@ fn outer():
 
 Provides inlining hints to the LLVM optimizer. By default, marks the function for aggressive inlining.
 
-**Defined as:** Compiler built-in (currently in C++; planned for stdlib migration in a future release).
+**Defined as:** Declared in `share/std/core/directive.ry` (implicitly imported via `share/std/builtins.ry`).
 
 **Basic usage (always inline):**
 
@@ -536,13 +536,13 @@ Required parameters may be supplied either positionally or by name, but not both
 
 Directive declarations participate in the standard module system. A directive declared in `pkg/mod.ry` is exported by name and can be imported with `from pkg import directive_name`. Directive names beginning with `_` are private to the declaring package and cannot be imported.
 
-The compiler's built-in directives (listed above) live in the C++ registry and do not need to be imported. The exceptions today are `@it` and `@describe`, which are declared in `share/std/testing/testing.ry`; test files that use them must add `from testing import it, describe` at the top.
+Most built-in directives are now declared in `share/std/`. Core directives (`@deprecated`, `@const`, `@inline`, `@parallel`) are declared in `share/std/core/directive.ry` and are re-exported via `share/std/builtins.ry`, which means they are implicitly available without an explicit import. Testing directives (`@it`, `@describe`, `@each`, `@property`) are declared in `share/std/testing/testing.ry`; test files that use them must add `from testing import it, describe, each, property` (or the subset they need) at the top. Only `@directive` and `@native` remain as compiler built-ins (see "Bootstrap rule" below).
 
 ### Bootstrap rule
 
 `@directive` itself and `@native` are **compiler built-ins** and cannot be redeclared in `.ry` source. (`@native` is registered in `src/directive_meta.cpp`'s built-in registry; `@directive` is handled as a hardcoded special form in the parser.) The reason is self-referential: the `@directive(...)` declaration syntax binds a directive to its C++ implementation through `@native`, and `@native` cannot mark its own declaration. These two directives remain permanently in C++.
 
-The other built-in directives (`@deprecated`, `@const`, `@inline`, `@parallel`, `@each`, `@property`) are also currently in the C++ registry. They are planned to migrate to `.ry` declarations in `share/std/` in a future release; the migration is tracked in separate issues.
+All other built-in directives (`@deprecated`, `@const`, `@inline`, `@parallel`, `@each`, `@property`) are now declared in `share/std/` (the core ones in `share/std/core/directive.ry`, the testing ones in `share/std/testing/testing.ry`). Only `@directive` and `@native` remain in the C++ registry due to the bootstrap constraint.
 
 ### Tier 1 vs Tier 2
 

--- a/share/std/builtins.ry
+++ b/share/std/builtins.ry
@@ -1,4 +1,6 @@
 # Core built-in functions
+from core import inline, parallel, const, deprecated
+
 @native
 fn print(value: str) -> Unit
 

--- a/share/std/core/directive.ry
+++ b/share/std/core/directive.ry
@@ -1,0 +1,13 @@
+# Core directives. Implicitly imported via builtins.ry re-export.
+
+@directive(target=["function"], stage="compile")
+fn inline(mode: str = "always")
+
+@directive(target=["for"], stage="compile")
+fn parallel()
+
+@directive(target=["statement"], stage="compile")
+fn const()
+
+@directive(target=["function", "record", "field", "statement"], stage="compile")
+fn deprecated(reason: str = "")

--- a/share/std/manifest.json
+++ b/share/std/manifest.json
@@ -1,9 +1,9 @@
 {
-  "version": "0.0.5",
+  "version": "0.0.6",
   "files": [
     "builtins.ry", "convert.ry", "higher_order.ry",
     "list.ry", "map.ry", "set.ry", "str.ry", "regex.ry",
-    "base64/base64.ry",
+    "base64/base64.ry", "core/directive.ry",
     "filesystem/filesystem.ry", "gc/gc.ry",
     "http/http.ry", "io/io.ry", "json/json.ry", "math/math.ry", "net/net.ry",
     "path/path.ry", "testing/testing.ry", "thread/thread.ry",

--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -6,3 +6,9 @@ fn it(description: str)
 
 @directive(target=["function"], stage="compile")
 fn describe(group: str)
+
+@directive(target=["statement", "function"], stage="compile")
+fn each(data: any)
+
+@directive(target=["statement", "function"], stage="compile")
+fn property(count: int = 100)

--- a/src/directive_meta.cpp
+++ b/src/directive_meta.cpp
@@ -64,36 +64,6 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
                     }
                 }
             }}},
-
-        {"each", {"each",
-            T::Statement | T::Function,
-            DirectiveStage::CompileTime,
-            /*min_pos=*/1, /*max_pos=*/1, {}, /*positional_param_names=*/{}}},
-
-        {"property", {"property",
-            T::Statement | T::Function,
-            DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {"count"}, /*positional_param_names=*/{}}},
-
-        {"deprecated", {"deprecated",
-            T::Function | T::Record | T::Field | T::Statement,
-            DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {"reason"}, /*positional_param_names=*/{}}},
-
-        {"inline", {"inline",
-            asTarget(T::Function),
-            DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {"mode"}, /*positional_param_names=*/{}}},
-
-        {"parallel", {"parallel",
-            asTarget(T::ForLoop),
-            DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {}, /*positional_param_names=*/{}}},
-
-        {"const", {"const",
-            asTarget(T::Statement),
-            DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/0, {}, /*positional_param_names=*/{}}},
     };
     return registry;
 }

--- a/tests/spec/directive_test.test.ry
+++ b/tests/spec/directive_test.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, each, property
 
 # Tests for @it and @describe directive syntax on named functions (#634)
 

--- a/tests/spec/parameterized.test.ry
+++ b/tests/spec/parameterized.test.ry
@@ -1,3 +1,5 @@
+from testing import each, property
+
 describe("@each parameterized tests", ():
   @each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
   it("should add {0} + {1} = {2}", (a: int, b: int, expected: int):

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -105,8 +105,8 @@ TEST_F(CodeGenTest, VariableBasics) {
 TEST_F(CodeGenTest, VariableBindingBasics) {
     EXPECT_EQ(runSource("x = 10\nprint(x)"), "10\n");
     EXPECT_EQ(runSource("x = 1\nx = 2\nprint(x)"), "2\n");
-    EXPECT_THROW(runSource("@const\nx = 1\nx = 2"), std::runtime_error);
-    EXPECT_THROW(runSource("@const\nx = 1\n@const\nx = 2"), std::runtime_error);
+    EXPECT_THROW(runSource(withStdlibDirectiveDecls("@const\nx = 1\nx = 2")), std::runtime_error);
+    EXPECT_THROW(runSource(withStdlibDirectiveDecls("@const\nx = 1\n@const\nx = 2")), std::runtime_error);
     EXPECT_EQ(runSource("x: int = 42\nprint(x)"), "42\n");
 }
 
@@ -1225,53 +1225,53 @@ TEST_F(CodeGenTest, CheckedFloat) {
 // ===== Top-level bindings accessible from top-level functions (#817) =====
 
 TEST_F(CodeGenTest, TopLevelConstFloatAccessibleFromFunction) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "PI: float = 3.14\n"
         "fn show_pi() -> float:\n"
         "    return PI\n"
-        "print(show_pi())"), "3.14\n");
+        "print(show_pi())")), "3.14\n");
 }
 
 TEST_F(CodeGenTest, TopLevelConstIntAccessibleFromFunction) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "MAX: int = 10\n"
         "fn get_max() -> int:\n"
         "    return MAX\n"
-        "print(get_max())"), "10\n");
+        "print(get_max())")), "10\n");
 }
 
 TEST_F(CodeGenTest, TopLevelConstBoolAccessibleFromFunction) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "FLAG: bool = true\n"
         "fn get_flag() -> bool:\n"
         "    return FLAG\n"
-        "print(get_flag())"), "true\n");
+        "print(get_flag())")), "true\n");
 }
 
 TEST_F(CodeGenTest, TopLevelConstStrLiteralAccessibleFromFunction) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "G: str = \"hello\"\n"
         "fn greet() -> str:\n"
         "    return G\n"
-        "print(greet())"), "hello\n");
+        "print(greet())")), "hello\n");
 }
 
 TEST_F(CodeGenTest, TopLevelConstStrComputedAccessibleFromFunction) {
     // Runtime-computed (not a bare string literal) initializer must also work.
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "G: str = \"foo\" + \"bar\"\n"
         "fn greet() -> str:\n"
         "    return G\n"
-        "print(greet())"), "foobar\n");
+        "print(greet())")), "foobar\n");
 }
 
 TEST_F(CodeGenTest, TopLevelConstListAccessibleFromFunction) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "XS: List<int> = [10, 20, 30]\n"
         "fn head_xs() -> int:\n"
@@ -1279,20 +1279,20 @@ TEST_F(CodeGenTest, TopLevelConstListAccessibleFromFunction) {
         "fn sum3() -> int:\n"
         "    return XS[0] + XS[1] + XS[2]\n"
         "print(head_xs())\n"
-        "print(sum3())"), "10\n60\n");
+        "print(sum3())")), "10\n60\n");
 }
 
 TEST_F(CodeGenTest, TopLevelConstMapAccessibleFromFunction) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "M: Map<str, int> = {\"a\": 1, \"b\": 2}\n"
         "fn get_a() -> int:\n"
         "    return M[\"a\"]\n"
-        "print(get_a())"), "1\n");
+        "print(get_a())")), "1\n");
 }
 
 TEST_F(CodeGenTest, TopLevelConstRecordFieldAccessibleFromFunction) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "record Point:\n"
         "    x: int\n"
         "    y: int\n"
@@ -1303,32 +1303,32 @@ TEST_F(CodeGenTest, TopLevelConstRecordFieldAccessibleFromFunction) {
         "fn py() -> int:\n"
         "    return P.y\n"
         "print(px())\n"
-        "print(py())"), "11\n22\n");
+        "print(py())")), "11\n22\n");
 }
 
 TEST_F(CodeGenTest, TopLevelConstTransitiveCallChain) {
     // b -> a -> read top-level @const K
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "K: int = 5\n"
         "fn a() -> int:\n"
         "    return K\n"
         "fn b() -> int:\n"
         "    return a()\n"
-        "print(b())"), "5\n");
+        "print(b())")), "5\n");
 }
 
 TEST_F(CodeGenTest, TopLevelConstReadFromInnerLambda) {
     // An inner lambda inside a top-level function should resolve the top-level
     // @const via the module-global fallback (not via closure capture of a
     // non-existent local).
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "K: int = 42\n"
         "fn outer() -> int:\n"
         "    f = () -> int => K\n"
         "    return f()\n"
-        "print(outer())"), "42\n");
+        "print(outer())")), "42\n");
 }
 
 TEST_F(CodeGenTest, TopLevelLetAccessibleFromFunction) {
@@ -1355,23 +1355,23 @@ TEST_F(CodeGenTest, TopLevelLetMutableWriteThroughFromFunction) {
 
 TEST_F(CodeGenTest, TopLevelConstReassignFromFunctionThrows) {
     // Reassigning a top-level @const from inside a function must be rejected.
-    EXPECT_THROW(runSource(
+    EXPECT_THROW(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "N: int = 5\n"
         "fn bad():\n"
         "    N = 6\n"
-        "bad()"), std::runtime_error);
+        "bad()")), std::runtime_error);
 }
 
 TEST_F(CodeGenTest, TopLevelForwardReferenceSourceOrderStrict) {
     // Source-order strict: a function cannot reference a top-level binding
     // declared textually AFTER the function definition.
-    EXPECT_THROW(runSource(
+    EXPECT_THROW(runSource(withStdlibDirectiveDecls(
         "fn foo() -> int:\n"
         "    return X\n"
         "@const\n"
         "X: int = 1\n"
-        "print(foo())"), std::runtime_error);
+        "print(foo())")), std::runtime_error);
 }
 
 TEST_F(CodeGenTest, TopLevelBindingInsideNestedBlockStaysLocal) {
@@ -1407,7 +1407,7 @@ TEST_F(CodeGenTest, TopLevelConstFieldAssignFromFunctionThrows) {
     // message explicitly so this test can distinguish the @const rejection
     // from an accidental "undefined variable" or other unrelated error.
     try {
-        runSource(
+        runSource(withStdlibDirectiveDecls(
             "record Point:\n"
             "    x: int\n"
             "    y: int\n"
@@ -1415,7 +1415,7 @@ TEST_F(CodeGenTest, TopLevelConstFieldAssignFromFunctionThrows) {
             "P: Point = Point(1, 2)\n"
             "fn bad():\n"
             "    P.x = 99\n"
-            "bad()");
+            "bad()"));
         FAIL() << "expected runtime_error for @const field assignment";
     } catch (const std::runtime_error &e) {
         std::string msg = e.what();
@@ -1428,25 +1428,25 @@ TEST_F(CodeGenTest, TopLevelConstFieldAssignFromFunctionThrows) {
 // module global: reading the parameter returns the argument value, not the
 // module-level constant.
 TEST_F(CodeGenTest, TopLevelConstShadowedByParameter) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "x: int = 100\n"
         "fn f(x: int) -> int:\n"
         "    return x\n"
-        "print(f(3))"), "3\n");
+        "print(f(3))")), "3\n");
 }
 
 // A parameter that shadows a top-level @const must be freely reassignable
 // inside the function body. This is the shadowing regression for the
 // isImmutable() bug where module-level @const leaked through by name.
 TEST_F(CodeGenTest, ParameterCanReassignShadowingTopLevelConst) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "@const\n"
         "n: int = 100\n"
         "fn bump(n: int) -> int:\n"
         "    n = n + 1\n"
         "    return n\n"
-        "print(bump(5))"), "6\n");
+        "print(bump(5))")), "6\n");
 }
 
 // An explicitly typed local declaration inside a function that happens to
@@ -1465,21 +1465,21 @@ TEST_F(CodeGenTest, TypedLocalShadowsTopLevelLet) {
 // A local @const declaration inside a function that shadows a top-level
 // mutable `let` must not be rejected as a reassignment of the module global.
 TEST_F(CodeGenTest, LocalConstShadowsTopLevelLet) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "k: int = 1\n"
         "fn h() -> int:\n"
         "    @const\n"
         "    k: int = 99\n"
         "    return k\n"
         "print(h())\n"
-        "print(k)"), "99\n1\n");
+        "print(k)")), "99\n1\n");
 }
 
 // A local mutable variable that shadows a top-level @const record must allow
 // field mutation on the local without the module-level immutability leaking
 // through by name.
 TEST_F(CodeGenTest, LocalRecordShadowsTopLevelConstRecord) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "record Point:\n"
         "    x: int\n"
         "    y: int\n"
@@ -1490,7 +1490,7 @@ TEST_F(CodeGenTest, LocalRecordShadowsTopLevelConstRecord) {
         "    P.x = 99\n"
         "    return P.x\n"
         "print(f())\n"
-        "print(P.x)"), "99\n1\n");
+        "print(P.x)")), "99\n1\n");
 }
 
 // A weak top-level binding must be rejected from function-body reads with
@@ -1533,7 +1533,7 @@ TEST_F(CodeGenTest, TopLevelListReassignedManyTimesFromFunction) {
 // scanner never seeded `var_names` into `localScopes`, so assignments to
 // the inner loop variable were misclassified as module-global mutations.
 TEST_F(CodeGenTest, ParallelForNestedLoopVarShadowsModuleGlobal) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "g: int = 999\n"
         "fn f() -> int:\n"
         "    @parallel\n"
@@ -1541,7 +1541,7 @@ TEST_F(CodeGenTest, ParallelForNestedLoopVarShadowsModuleGlobal) {
         "        for g in [1, 2, 3]:\n"
         "            g = g + 1\n"
         "    return g\n"
-        "print(f())"), "999\n");
+        "print(f())")), "999\n");
 }
 
 // A parallel-for inside a function body must accept an explicitly typed
@@ -1549,14 +1549,14 @@ TEST_F(CodeGenTest, ParallelForNestedLoopVarShadowsModuleGlobal) {
 // — it is a new local shadow, not a data-race-inducing mutation of the
 // outer variable.
 TEST_F(CodeGenTest, ParallelForInFunctionBodyAllowsShadowOfModuleGlobal) {
-    EXPECT_EQ(runSource(
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
         "x: int = 100\n"
         "fn f():\n"
         "    @parallel\n"
         "    for i in 0..3:\n"
         "        x: int = i\n"
         "f()\n"
-        "print(x)"), "100\n");
+        "print(x)")), "100\n");
 }
 
 // The other side of the parallel-for gating: a PLAIN assignment (without
@@ -1565,13 +1565,13 @@ TEST_F(CodeGenTest, ParallelForInFunctionBodyAllowsShadowOfModuleGlobal) {
 // validator must reject it to prevent a data race. Without this test the
 // rejection branch in src/codegen_stmt_loop.cpp could regress silently.
 TEST_F(CodeGenTest, ParallelForRejectsModuleGlobalMutation) {
-    EXPECT_THROW(runSource(
+    EXPECT_THROW(runSource(withStdlibDirectiveDecls(
         "x: int = 100\n"
         "fn f():\n"
         "    @parallel\n"
         "    for i in 0..3:\n"
         "        x = i\n"
-        "f()"), std::runtime_error);
+        "f()")), std::runtime_error);
 }
 
 // Top-level fixed-length array (`i32[N]`) must be indexable from a function

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -57,20 +57,20 @@ TEST_F(CodeGenTest, ContinueInWhile) {
 }
 
 TEST_F(CodeGenTest, ParallelForBreakRejected) {
-    std::string src =
+    std::string src = withStdlibDirectiveDecls(
         "@parallel\n"
         "for i in range(5):\n"
         "    if i == 2:\n"
-        "        break\n";
+        "        break\n");
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
 TEST_F(CodeGenTest, ParallelForContinueRejected) {
-    std::string src =
+    std::string src = withStdlibDirectiveDecls(
         "@parallel\n"
         "for i in range(5):\n"
         "    if i == 2:\n"
-        "        continue\n";
+        "        continue\n");
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
@@ -102,13 +102,13 @@ TEST_F(CodeGenTest, RecordFieldAssignMultiple) {
 }
 
 TEST_F(CodeGenTest, RecordFieldAssignConstError) {
-    std::string src =
+    std::string src = withStdlibDirectiveDecls(
         "record Point:\n"
         "    x: int\n"
         "    y: int\n"
         "@const\n"
         "p = Point(1, 2)\n"
-        "p.x = 10";
+        "p.x = 10");
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 
@@ -326,7 +326,7 @@ TEST_F(CodeGenTest, CapturedVarShadowedByForLoopOK) {
 
 TEST_F(CodeGenTest, CapturedConstFieldAssignError) {
     // @const variable captured by closure must still block field assignment
-    std::string src =
+    std::string src = withStdlibDirectiveDecls(
         "record Point:\n"
         "    x: int\n"
         "\n"
@@ -334,7 +334,7 @@ TEST_F(CodeGenTest, CapturedConstFieldAssignError) {
         "f = ():\n"
         "    p.x = 99\n"
         "\n"
-        "f()";
+        "f()");
     EXPECT_THROW(runSource(src), std::runtime_error);
 }
 

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -155,3 +155,30 @@ protected:
         return {runModule(std::move(tsm)), warnings};
     }
 };
+
+// As of #1390, the non-bootstrap built-in directives (@inline / @parallel /
+// @const / @deprecated / @each / @property) live in stdlib .ry sources and
+// the @it / @describe directives live in share/std/testing/testing.ry, none
+// of which are loaded by the codegen test harness (it skips ModuleLoader).
+// Tests that exercise these directives must declare them inline at the top
+// of the source they hand to the codegen.
+inline std::string withStdlibDirectiveDecls(const std::string &src) {
+    static const char *kDecls =
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn inline(mode: str = \"always\")\n"
+        "@directive(target=[\"for\"], stage=\"compile\")\n"
+        "fn parallel()\n"
+        "@directive(target=[\"statement\"], stage=\"compile\")\n"
+        "fn const()\n"
+        "@directive(target=[\"function\", \"record\", \"field\", \"statement\"], stage=\"compile\")\n"
+        "fn deprecated(reason: str = \"\")\n"
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn it(description: str)\n"
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn describe(group: str)\n"
+        "@directive(target=[\"statement\", \"function\"], stage=\"compile\")\n"
+        "fn each(data: any)\n"
+        "@directive(target=[\"statement\", \"function\"], stage=\"compile\")\n"
+        "fn property(count: int = 100)\n";
+    return std::string(kDecls) + src;
+}

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -23,17 +23,15 @@ extern "C" const char *__ry_testlib_get_last_error() {
     return strdup(testlib_err_buf);
 }
 
-// @it / @describe live in `share/std/testing/testing.ry`, not in the
-// built-in directive registry. The CodeGenTest harness does not invoke
-// ModuleLoader, so tests that exercise these directives must declare them
-// inline at the top of the source they hand to the codegen.
+// Backward-compatible aliases for the shared helper in test_codegen_common.hpp.
+// The shared helper covers @it / @describe (formerly testing-only) plus the
+// six directives migrated from the built-in registry in #1390.
 static std::string withItDescribeDecls(const char *src) {
-    return std::string(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
-        "fn it(description: str)\n"
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
-        "fn describe(group: str)\n"
-    ) + src;
+    return withStdlibDirectiveDecls(src);
+}
+
+static std::string withCoreAndTestingDirectiveDecls(const char *src) {
+    return withStdlibDirectiveDecls(src);
 }
 
 class DirectiveTest : public CodeGenTest {};
@@ -125,10 +123,10 @@ TEST(NativeFnSigs, OverloadsGrouped) {
 }
 
 TEST(NativeFnSigs, DirectivesRecorded) {
-    std::string src =
+    std::string src = withCoreAndTestingDirectiveDecls(
         "@native\n"
         "@deprecated\n"
-        "fn old_fn(x: int) -> int\n";
+        "fn old_fn(x: int) -> int\n");
 
     Lexer lex(src);
     Parser parser(lex);
@@ -268,12 +266,12 @@ TEST(NativeFnSigs, GetRequiredLibrariesEmptyForBareNative) {
 
 // 1. @deprecated function called -> warning, execution normal
 TEST_F(DirectiveTest, DeprecatedFunctionWarning) {
-    auto [output, warnings] = runSourceWithWarnings(
+    auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "@deprecated\n"
         "fn old_func() -> int:\n"
         "    return 42\n"
         "print(old_func())\n"
-    );
+    ));
     EXPECT_EQ(output, "42\n");
     ASSERT_EQ(warnings.size(), 1);
     EXPECT_EQ(warnings[0], "warning: 'old_func' is deprecated");
@@ -281,14 +279,14 @@ TEST_F(DirectiveTest, DeprecatedFunctionWarning) {
 
 // 2. @deprecated type constructed -> warning
 TEST_F(DirectiveTest, DeprecatedTypeWarning) {
-    auto [output, warnings] = runSourceWithWarnings(
+    auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "@deprecated\n"
         "record OldPoint:\n"
         "    x: int\n"
         "    y: int\n"
         "p = OldPoint(1, 2)\n"
         "print(p.x)\n"
-    );
+    ));
     EXPECT_EQ(output, "1\n");
     ASSERT_EQ(warnings.size(), 1);
     EXPECT_EQ(warnings[0], "warning: 'OldPoint' is deprecated");
@@ -296,11 +294,11 @@ TEST_F(DirectiveTest, DeprecatedTypeWarning) {
 
 // 3. @deprecated let referenced -> warning
 TEST_F(DirectiveTest, DeprecatedVariableWarning) {
-    auto [output, warnings] = runSourceWithWarnings(
+    auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "@deprecated\n"
         "old_val = 99\n"
         "print(old_val)\n"
-    );
+    ));
     EXPECT_EQ(output, "99\n");
     ASSERT_EQ(warnings.size(), 1);
     EXPECT_EQ(warnings[0], "warning: 'old_val' is deprecated");
@@ -308,7 +306,7 @@ TEST_F(DirectiveTest, DeprecatedVariableWarning) {
 
 // 4. @deprecated field accessed -> warning
 TEST_F(DirectiveTest, DeprecatedFieldWarning) {
-    auto [output, warnings] = runSourceWithWarnings(
+    auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "record MyType:\n"
         "    @deprecated\n"
         "    old_field: int\n"
@@ -316,7 +314,7 @@ TEST_F(DirectiveTest, DeprecatedFieldWarning) {
         "m = MyType(1, 2)\n"
         "print(m.old_field)\n"
         "print(m.new_field)\n"
-    );
+    ));
     EXPECT_EQ(output, "1\n2\n");
     ASSERT_EQ(warnings.size(), 1);
     EXPECT_EQ(warnings[0], "warning: 'MyType.old_field' is deprecated");
@@ -324,14 +322,14 @@ TEST_F(DirectiveTest, DeprecatedFieldWarning) {
 
 // 5. Definition alone does not produce warnings
 TEST_F(DirectiveTest, DeprecatedNoWarningOnDefinition) {
-    auto [output, warnings] = runSourceWithWarnings(
+    auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "@deprecated\n"
         "fn unused_func() -> int:\n"
         "    return 1\n"
         "@deprecated\n"
         "unused_val = 42\n"
         "print(0)\n"
-    );
+    ));
     EXPECT_EQ(output, "0\n");
     EXPECT_TRUE(warnings.empty());
 }
@@ -351,37 +349,37 @@ TEST_F(DirectiveTest, NonDeprecatedNoWarning) {
 
 // 7. Deprecated function still works correctly
 TEST_F(DirectiveTest, DeprecatedFunctionStillWorks) {
-    auto [output, warnings] = runSourceWithWarnings(
+    auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "@deprecated\n"
         "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "print(add(3, 4))\n"
-    );
+    ));
     EXPECT_EQ(output, "7\n");
     ASSERT_EQ(warnings.size(), 1);
 }
 
 // 8. Multiple directives stacked (parse check)
 TEST_F(DirectiveTest, MultipleDirectives) {
-    auto [output, warnings] = runSourceWithWarnings(
+    auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "@deprecated\n"
         "@deprecated\n"
         "fn multi() -> int:\n"
         "    return 1\n"
         "print(multi())\n"
-    );
+    ));
     EXPECT_EQ(output, "1\n");
     EXPECT_FALSE(warnings.empty());
 }
 
 // 9. Directive with params parses correctly
 TEST_F(DirectiveTest, DirectiveWithParams) {
-    auto [output, warnings] = runSourceWithWarnings(
+    auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "@deprecated(reason=\"use new_func instead\")\n"
         "fn old_api() -> int:\n"
         "    return 0\n"
         "print(old_api())\n"
-    );
+    ));
     EXPECT_EQ(output, "0\n");
     ASSERT_EQ(warnings.size(), 1);
     EXPECT_EQ(warnings[0], "warning: 'old_api' is deprecated");
@@ -397,10 +395,12 @@ TEST_F(DirectiveTest, UnknownDirectiveError) {
 // 10b. Positional string argument on non-@native directive causes parse error
 TEST_F(DirectiveTest, PositionalArgOnNonNativeError) {
     EXPECT_THROW({
-        runSource("@inline(\"always\")\nfn add(a: int, b: int) -> int:\n    return a + b\n");
+        runSource(withCoreAndTestingDirectiveDecls(
+            "@inline(\"always\")\nfn add(a: int, b: int) -> int:\n    return a + b\n"));
     }, std::runtime_error);
     EXPECT_THROW({
-        runSource("@deprecated(\"old\")\nfn foo() -> int:\n    return 1\n");
+        runSource(withCoreAndTestingDirectiveDecls(
+            "@deprecated(\"old\")\nfn foo() -> int:\n    return 1\n"));
     }, std::runtime_error);
 }
 
@@ -466,7 +466,8 @@ TEST_F(DirectiveTest, UnknownDirectiveOnForError) {
 // 10j. @deprecated with positional arg on record causes codegen error
 TEST_F(DirectiveTest, DeprecatedPositionalArgOnRecordError) {
     EXPECT_THROW({
-        runSource("@deprecated(\"old\")\nrecord Foo:\n    x: int\n");
+        runSource(withCoreAndTestingDirectiveDecls(
+            "@deprecated(\"old\")\nrecord Foo:\n    x: int\n"));
     }, std::runtime_error);
 }
 
@@ -487,7 +488,8 @@ TEST_F(DirectiveTest, UnknownDirectiveOnCallStmtError) {
 // 11. Directive on invalid target causes parse error
 TEST_F(DirectiveTest, DirectiveOnInvalidTarget) {
     EXPECT_THROW({
-        runSource("@deprecated\nif true\n    print(1)\n");
+        runSource(withCoreAndTestingDirectiveDecls(
+            "@deprecated\nif true\n    print(1)\n"));
     }, std::runtime_error);
 }
 
@@ -708,85 +710,85 @@ TEST_F(DirectiveTest, NativeFnLibraryGenericDispatchResultBool) {
 // ===== @inline tests =====
 
 TEST_F(DirectiveTest, InlineDefault) {
-    std::string output = runSource(
+    std::string output = runSource(withCoreAndTestingDirectiveDecls(
         "@inline\n"
         "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "print(add(3, 4))\n"
-    );
+    ));
     EXPECT_EQ(output, "7\n");
 }
 
 TEST_F(DirectiveTest, InlineModeAlways) {
-    std::string output = runSource(
+    std::string output = runSource(withCoreAndTestingDirectiveDecls(
         "@inline(mode=\"always\")\n"
         "fn mul(a: int, b: int) -> int:\n"
         "    return a * b\n"
         "print(mul(5, 6))\n"
-    );
+    ));
     EXPECT_EQ(output, "30\n");
 }
 
 TEST_F(DirectiveTest, InlineModeHint) {
-    std::string output = runSource(
+    std::string output = runSource(withCoreAndTestingDirectiveDecls(
         "@inline(mode=\"hint\")\n"
         "fn sub(a: int, b: int) -> int:\n"
         "    return a - b\n"
         "print(sub(10, 3))\n"
-    );
+    ));
     EXPECT_EQ(output, "7\n");
 }
 
 TEST_F(DirectiveTest, InlineModeNever) {
-    std::string output = runSource(
+    std::string output = runSource(withCoreAndTestingDirectiveDecls(
         "@inline(mode=\"never\")\n"
         "fn negate(a: int) -> int:\n"
         "    return -a\n"
         "print(negate(-5))\n"
-    );
+    ));
     EXPECT_EQ(output, "5\n");
 }
 
 TEST_F(DirectiveTest, InlineInvalidMode) {
-    EXPECT_THROW(runSource(
+    EXPECT_THROW(runSource(withCoreAndTestingDirectiveDecls(
         "@inline(mode=\"aggressive\")\n"
         "fn bad() -> int:\n"
         "    return 1\n"
         "print(bad())\n"
-    ), std::runtime_error);
+    )), std::runtime_error);
 }
 
 TEST_F(DirectiveTest, InlineWithNativeError) {
-    EXPECT_THROW(runSource(
+    EXPECT_THROW(runSource(withCoreAndTestingDirectiveDecls(
         "@inline\n"
         "@native\n"
         "fn contains(s: str, sub: str) -> bool\n"
         "print(contains(\"hello\", \"ell\"))\n"
-    ), std::runtime_error);
+    )), std::runtime_error);
 }
 
 TEST_F(DirectiveTest, InlineWithDeprecated) {
-    auto [output, warnings] = runSourceWithWarnings(
+    auto [output, warnings] = runSourceWithWarnings(withCoreAndTestingDirectiveDecls(
         "@inline\n"
         "@deprecated\n"
         "fn old_add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "print(old_add(1, 2))\n"
-    );
+    ));
     EXPECT_EQ(output, "3\n");
     ASSERT_EQ(warnings.size(), 1);
     EXPECT_EQ(warnings[0], "warning: 'old_add' is deprecated");
 }
 
 TEST_F(DirectiveTest, InlineRecursive) {
-    std::string output = runSource(
+    std::string output = runSource(withCoreAndTestingDirectiveDecls(
         "@inline\n"
         "fn fact(n: int) -> int:\n"
         "    if n <= 1:\n"
         "        return 1\n"
         "    return n * fact(n - 1)\n"
         "print(fact(5))\n"
-    );
+    ));
     EXPECT_EQ(output, "120\n");
 }
 
@@ -968,7 +970,7 @@ TEST_F(DirectiveTest, DescribeDirectiveBasicCodegen) {
 
 // @each + @it on a named function: parameterized tests
 TEST_F(DirectiveTest, ItDirectiveWithEach) {
-    EXPECT_EQ(runTestSource(withItDescribeDecls(
+    EXPECT_EQ(runTestSource(withCoreAndTestingDirectiveDecls(
         "@each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])\n"
         "@it(\"should add {0} + {1} = {2}\")\n"
         "fn test_add(a: int, b: int, expected: int):\n"
@@ -981,7 +983,7 @@ TEST_F(DirectiveTest, ItDirectiveWithEach) {
 
 // @property + @it on a named function: property-based tests
 TEST_F(DirectiveTest, ItDirectiveWithProperty) {
-    std::string out = runTestSource(withItDescribeDecls(
+    std::string out = runTestSource(withCoreAndTestingDirectiveDecls(
         "@property(count=10)\n"
         "@it(\"should verify addition is commutative\")\n"
         "fn test_commutative(a: int, b: int):\n"
@@ -1053,7 +1055,7 @@ TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeAnnotation) {
 TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnEach) {
     EXPECT_THROW(
         []() {
-            Lexer lex(withItDescribeDecls(
+            Lexer lex(withCoreAndTestingDirectiveDecls(
                 "@each([(1, 2)])\n"
                 "@it(\"bad each {0} {1}\")\n"
                 "fn test_each(a: int, b: int) -> Unit:\n"
@@ -1072,7 +1074,7 @@ TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnEach) {
 TEST_F(DirectiveTest, ItDirectiveRejectsReturnTypeOnProperty) {
     EXPECT_THROW(
         []() {
-            Lexer lex(withItDescribeDecls(
+            Lexer lex(withCoreAndTestingDirectiveDecls(
                 "@property(count=10)\n"
                 "@it(\"bad property\")\n"
                 "fn test_prop(a: int) -> Unit:\n"
@@ -1257,7 +1259,7 @@ TEST_F(DirectiveTest, DescribeDirectiveThreeLevelNesting) {
 
 // @each + @it inside @describe: parameterized tests inside a group
 TEST_F(DirectiveTest, DescribeDirectiveWithEach) {
-    EXPECT_EQ(runTestSource(withItDescribeDecls(
+    EXPECT_EQ(runTestSource(withCoreAndTestingDirectiveDecls(
         "@describe(\"parameterized\")\n"
         "fn param_tests():\n"
         "    @each([(1, 2, 3), (4, 5, 9)])\n"
@@ -1272,7 +1274,7 @@ TEST_F(DirectiveTest, DescribeDirectiveWithEach) {
 
 // @property + @it inside @describe: property tests inside a group
 TEST_F(DirectiveTest, DescribeDirectiveWithProperty) {
-    std::string out = runTestSource(withItDescribeDecls(
+    std::string out = runTestSource(withCoreAndTestingDirectiveDecls(
         "@describe(\"property group\")\n"
         "fn prop_tests():\n"
         "    @property(count=5)\n"

--- a/tests/test_codegen_parameterized.cpp
+++ b/tests/test_codegen_parameterized.cpp
@@ -7,14 +7,14 @@ using namespace ry;
 // ============================================================
 
 TEST_F(CodeGenTest, EachBasicInt) {
-    auto output = runTestSource(
+    auto output = runTestSource(withStdlibDirectiveDecls(
         "describe(\"each\", ():\n"
         "    @each([(1, 2, 3), (0, 0, 0)])\n"
         "    it(\"adds {0} + {1} = {2}\", (a: int, b: int, expected: int):\n"
         "        expect(a + b).to_eq(expected)\n"
         "    )\n"
         ")\n"
-    );
+    ));
     EXPECT_NE(output.find("adds 1 + 2 = 3"), std::string::npos);
     EXPECT_NE(output.find("adds 0 + 0 = 0"), std::string::npos);
     EXPECT_NE(output.find("2 passed, 0 failed"), std::string::npos);
@@ -25,14 +25,14 @@ TEST_F(CodeGenTest, EachBasicInt) {
 // ============================================================
 
 TEST_F(CodeGenTest, EachStringParam) {
-    auto output = runTestSource(
+    auto output = runTestSource(withStdlibDirectiveDecls(
         "describe(\"each str\", ():\n"
         "    @each([(\"hi\", 2), (\"\", 0)])\n"
         "    it(\"len of {0} is {1}\", (s: str, expected: int):\n"
         "        expect(length(s)).to_eq(expected)\n"
         "    )\n"
         ")\n"
-    );
+    ));
     EXPECT_NE(output.find("2 passed, 0 failed"), std::string::npos);
 }
 
@@ -41,14 +41,14 @@ TEST_F(CodeGenTest, EachStringParam) {
 // ============================================================
 
 TEST_F(CodeGenTest, EachFailingTest) {
-    auto output = runTestSource(
+    auto output = runTestSource(withStdlibDirectiveDecls(
         "describe(\"each fail\", ():\n"
         "    @each([(1, 2, 4)])\n"
         "    it(\"{0}+{1}={2}\", (a: int, b: int, expected: int):\n"
         "        expect(a + b).to_eq(expected)\n"
         "    )\n"
         ")\n"
-    );
+    ));
     EXPECT_NE(output.find("0 passed, 1 failed"), std::string::npos);
 }
 
@@ -57,14 +57,14 @@ TEST_F(CodeGenTest, EachFailingTest) {
 // ============================================================
 
 TEST_F(CodeGenTest, PropertyCommutative) {
-    auto output = runTestSource(
+    auto output = runTestSource(withStdlibDirectiveDecls(
         "describe(\"prop\", ():\n"
         "    @property(count=50)\n"
         "    it(\"a+b == b+a\", (a: int, b: int):\n"
         "        expect(a + b).to_eq(b + a)\n"
         "    )\n"
         ")\n"
-    );
+    ));
     EXPECT_NE(output.find("1 passed, 0 failed"), std::string::npos);
 }
 
@@ -73,13 +73,13 @@ TEST_F(CodeGenTest, PropertyCommutative) {
 // ============================================================
 
 TEST_F(CodeGenTest, PropertyBoolParam) {
-    auto output = runTestSource(
+    auto output = runTestSource(withStdlibDirectiveDecls(
         "describe(\"prop bool\", ():\n"
         "    @property(count=10)\n"
         "    it(\"x==x\", (x: bool):\n"
         "        expect(x == x).to_be_true()\n"
         "    )\n"
         ")\n"
-    );
+    ));
     EXPECT_NE(output.find("1 passed, 0 failed"), std::string::npos);
 }

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1072,10 +1072,10 @@ TEST_F(CodeGenTest, AvailableParallelismBuiltin) {
 //         "    print(one(i))"), "1\n1\n1\n1\n1\n");
 // }
 TEST_F(CodeGenTest, ParallelForPrintComposite) {
-    std::string result = runSource(
+    std::string result = runSource(withStdlibDirectiveDecls(
         "@parallel\n"
         "for i in range(3):\n"
-        "    print([i, i])");
+        "    print([i, i])"));
     // Output lines are unordered across threads, but each line must be well-formed
     std::istringstream ss(result);
     std::string line;
@@ -1090,19 +1090,19 @@ TEST_F(CodeGenTest, ParallelForPrintComposite) {
 
 TEST_F(CodeGenTest, ParallelForErrors) {
     // ParallelForRejectsOuterMutation
-    EXPECT_THROW(runSource(
+    EXPECT_THROW(runSource(withStdlibDirectiveDecls(
         "total = 0\n"
         "@parallel\n"
         "for i in range(4):\n"
         "    total = total + i\n"
-        "print(total)"), std::runtime_error);
+        "print(total)")), std::runtime_error);
     // ParallelForRejectsNestedFunctionDef (#1118)
-    EXPECT_THROW(runSource(
+    EXPECT_THROW(runSource(withStdlibDirectiveDecls(
         "@parallel\n"
         "for i in range(4):\n"
         "    fn helper() -> int:\n"
         "        return i\n"
-        "    print(helper())\n"), std::runtime_error);
+        "    print(helper())\n")), std::runtime_error);
 }
 
 // ===== Int literal type =====

--- a/tests/test_spec_concurrency.cpp
+++ b/tests/test_spec_concurrency.cpp
@@ -28,5 +28,5 @@ std::string readFile(const std::string &path) {
 // thunks use atomicrmw — the root cause is gone.  Verified: passes in
 // 55 ms on macOS (ASAN_OPTIONS=detect_container_overflow=0).
 TEST_F(CodeGenTest, ConcurrencySpecSuite) {
-    EXPECT_NO_THROW(runTestSource(readFile("tests/spec/concurrency.test.ry")));
+    EXPECT_NO_THROW(runTestSource(withStdlibDirectiveDecls(readFile("tests/spec/concurrency.test.ry"))));
 }


### PR DESCRIPTION
## Summary

Closes #1390. Final step in the v0.0.15 directive series (#1389 → #1397 → #1390): migrate the 6 non-bootstrap built-in directives out of the C++ `builtinDirectiveRegistry()` and into stdlib `.ry` `@directive` declarations on top of the user-directive infrastructure that #708/#709/#710 introduced. Only `@native` remains in the C++ registry (bootstrap-required); `@directive` itself stays parser-hardcoded.

### What moves where

| Directive | Was | Now |
|---|---|---|
| `@inline`, `@parallel`, `@const`, `@deprecated` | `src/directive_meta.cpp` registry | `share/std/core/directive.ry` (auto-imported via `share/std/builtins.ry` re-export) |
| `@each`, `@property` | `src/directive_meta.cpp` registry | `share/std/testing/testing.ry` (requires explicit `from testing import each, property`, matching the existing `@it` / `@describe` pair) |
| `@native` | C++ registry | unchanged (bootstrap-required) |
| `@directive` | parser-hardcoded | unchanged |

### Implementation notes

- `share/std/core/directive.ry` (new): four core directives. Reached at runtime via `from std import` (wildcard) → `builtins.ry` → `from core import inline, parallel, const, deprecated`. `manifest.json` is bumped to 0.0.6 (`module_loader` doesn't consume the manifest; the bump keeps `self_update` clean).
- `tests/test_codegen_common.hpp`: new `withStdlibDirectiveDecls()` helper. The codegen test harnesses (`runSource`, `runSourceWithWarnings`, `runTestSource`, `compileSource`) go straight from `Parser → CodeGen` and skip `ModuleLoader`, so any test that uses these directives needs the declarations inlined. The helper is applied across `test_codegen.cpp` / `_advanced` / `_directive` / `_parameterized` / `_stmt` / `test_spec_concurrency.cpp`.
- `tests/spec/parameterized.test.ry`, `tests/spec/directive_test.test.ry`: explicit `from testing import each, property` — matches the new declaration site.
- `docs/reference/directives.md`: `Defined as` lines updated for the 6 migrated directives and the closing summary; `@directive` and `@native` are now the sole C++ builtins. Section restructure (Bootstrap / Core / Testing chapters + supported-target table) is intentionally deferred to #1391.
- `.claude/rules/tests-cpp-conventions.md`: records the harness gotcha so the next test author reaches for the helper instead of debugging a spurious "unknown directive" error.

### Out of scope

- Section restructure of `docs/reference/directives.md` (deferred to #1391).
- Re-declaring `@directive` / `@native` in Ry (bootstrap-impossible by design).
- User-defined decorators (#298).

## Test plan

- [x] `cmake --build build && ./build/ry_tests` — 1985/1985 pass
- [x] `./build/ry test -p` — 168/168 pass
- [x] ASan + UBSan (C++ + Ry self-test) — clean
- [x] TSan (C++ + Ry self-test) — clean
- [x] `clang-tidy` (LLVM 21) + `cppcheck` — clean
- [x] FileCheck IR golden suite — 10/10 pass
- [x] libFuzzer parser / json / utf8 (60s each) — clean (42407 / 300310 / 304196 runs)
- [x] ModuleLoader smoke (real CLI, `RY_ENV=internal`):
  - `@inline fn f() -> int: return 1` then `print(f())` → `1`
  - `@const N: int = 42` then `print(N)` → `42`
  - `@each([(1, 2)]) fn t(...)` without `from testing import` → rejected as expected
- [x] `grep -nE '"(each|property|deprecated|inline|parallel|const)"' src/directive_meta.cpp` — registry entries fully removed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated directive reference documentation to reflect current availability and import requirements.
  
* **Chores**
  * Reorganized directive declarations in standard library modules.
  * Updated test infrastructure to properly declare directives in test contexts.

**Breaking Change:** Testing directives (`@each`, `@property`) now require explicit imports from the `testing` module, similar to `@it` and `@describe`. Core directives (`@inline`, `@parallel`, `@const`, `@deprecated`) remain implicitly available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->