### PR TITLE
docs: remove dead language-switcher lines from docs/ pages (#1398)

### DIFF
--- a/changelog.d/1398-docs-language-switcher-cleanup.md
+++ b/changelog.d/1398-docs-language-switcher-cleanup.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Removed dead language-switcher lines from 25 docs pages (`docs/README.md` and 24 `docs/reference/*.md` pages). Both the three-language `[English] | [日本語] | [繁體中文]` pattern (21 files) and the residual English-only self-link `[English](self.md)` (4 files) pointed to non-existent `docs/ja/` and `docs/zh/` trees. (#1398)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,3 @@
-[English](README.md) | [日本語](ja/README.md) | [繁體中文](zh/README.md)
-
 # Ry Language Documentation
 
 Ry is a simple programming language based on LLVM JIT. It adopts Python-style indentation block syntax, combining static typing with type inference for an easy-to-use design.

--- a/docs/reference/base64.md
+++ b/docs/reference/base64.md
@@ -1,5 +1,3 @@
-[English](base64.md) | [日本語](../ja/reference/base64.md) | [繁體中文](../zh/reference/base64.md)
-
 # Base64 Function Reference
 
 Base64 encoding and decoding. All functions require explicit import from `base64`.

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -1,5 +1,3 @@
-[English](builtins-string.md) | [日本語](../ja/reference/builtins-string.md) | [繁體中文](../zh/reference/builtins-string.md)
-
 # String Operation Function Reference
 
 A list of operation functions for strings (`str`). All functions support UFCS notation.

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -1,5 +1,3 @@
-[English](builtins.md) | [日本語](../ja/reference/builtins.md) | [繁體中文](../zh/reference/builtins.md)
-
 # Built-in Function Reference
 
 ## Function List

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -1,5 +1,3 @@
-[English](collections.md) | [日本語](../ja/reference/collections.md) | [繁體中文](../zh/reference/collections.md)
-
 # Collection Reference (Tuple, List, Map, Set)
 
 ## Tuple

--- a/docs/reference/contracts.md
+++ b/docs/reference/contracts.md
@@ -1,5 +1,3 @@
-[English](contracts.md) | [日本語](../ja/reference/contracts.md) | [繁體中文](../zh/reference/contracts.md)
-
 # Design by Contract (DbC)
 
 Ry supports Eiffel-style Design by Contract with preconditions (`require`), postconditions (`ensure`), and record invariants (`invariant`). Contract violations terminate the process with `exit(1)`.

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -1,5 +1,3 @@
-[English](control-flow.md) | [日本語](../ja/reference/control-flow.md) | [繁體中文](../zh/reference/control-flow.md)
-
 # Control Flow Reference
 
 ## if / else

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -1,5 +1,3 @@
-[English](errors.md) | [日本語](../ja/reference/errors.md) | [繁體中文](../zh/reference/errors.md)
-
 # Error Reference
 
 ## Error Format

--- a/docs/reference/filesystem.md
+++ b/docs/reference/filesystem.md
@@ -1,5 +1,3 @@
-[English](filesystem.md) | [日本語](../ja/reference/filesystem.md) | [繁體中文](../zh/reference/filesystem.md)
-
 # Filesystem Function Reference
 
 File and directory manipulation. All functions require explicit import from `filesystem`.

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -1,5 +1,3 @@
-[English](functions.md) | [日本語](../ja/reference/functions.md) | [繁體中文](../zh/reference/functions.md)
-
 # Function Reference
 
 ## Function Definition Syntax

--- a/docs/reference/gc.md
+++ b/docs/reference/gc.md
@@ -1,5 +1,3 @@
-[English](gc.md)
-
 # GC Reference
 
 The `gc` package provides control over the cycle collector, a safety net that works alongside ARC (Automatic Reference Counting) to detect and reclaim circular reference chains.

--- a/docs/reference/http.md
+++ b/docs/reference/http.md
@@ -1,5 +1,3 @@
-[English](http.md)
-
 # HTTP Reference
 
 ## Types

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -1,5 +1,3 @@
-[English](io.md) | [日本語](../ja/reference/io.md) | [繁體中文](../zh/reference/io.md)
-
 # I/O Function Reference
 
 Standard I/O and file operations. All functions require explicit import from `io`.

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -1,5 +1,3 @@
-[English](json.md) | [日本語](../ja/reference/json.md) | [繁體中文](../zh/reference/json.md)
-
 # JSON Function Reference
 
 JSON parsing and serialization. All functions require explicit import from `json`.

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -1,5 +1,3 @@
-[English](math.md) | [日本語](../ja/reference/math.md) | [繁體中文](../zh/reference/math.md)
-
 # Math Functions (`math`)
 
 ## Overview

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -1,5 +1,3 @@
-[English](net.md)
-
 # Network (TCP) Reference
 
 ## Types

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -1,5 +1,3 @@
-[English](operators.md) | [日本語](../ja/reference/operators.md) | [繁體中文](../zh/reference/operators.md)
-
 # Operator Reference
 
 ## Precedence Table

--- a/docs/reference/packages.md
+++ b/docs/reference/packages.md
@@ -1,5 +1,3 @@
-[English](packages.md) | [日本語](../ja/reference/packages.md) | [繁體中文](../zh/reference/packages.md)
-
 # Package Reference
 
 ## Overview

--- a/docs/reference/path.md
+++ b/docs/reference/path.md
@@ -1,5 +1,3 @@
-[English](path.md) | [日本語](../ja/reference/path.md) | [繁體中文](../zh/reference/path.md)
-
 # Path Function Reference
 
 File path operations. All functions require explicit import from `path`.

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -1,5 +1,3 @@
-[English](project.md) | [日本語](../ja/reference/project.md) | [繁體中文](../zh/reference/project.md)
-
 # Project Management
 
 ## CLI Overview

--- a/docs/reference/records.md
+++ b/docs/reference/records.md
@@ -1,5 +1,3 @@
-[English](records.md) | [日本語](../ja/reference/structs.md) | [繁體中文](../zh/reference/structs.md)
-
 # Record Reference
 
 ## Overview

--- a/docs/reference/regex.md
+++ b/docs/reference/regex.md
@@ -1,5 +1,3 @@
-[English](regex.md) | [日本語](../ja/reference/regex.md) | [繁體中文](../zh/reference/regex.md)
-
 # Regular Expression Reference
 
 ## Regex Literal Syntax

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,5 +1,3 @@
-[English](testing.md) | [日本語](../ja/reference/testing.md) | [繁體中文](../zh/reference/testing.md)
-
 # Testing
 
 Ry has a built-in RSpec-style test syntax. Test files are executed using the `ry test` subcommand.

--- a/docs/reference/thread.md
+++ b/docs/reference/thread.md
@@ -1,5 +1,3 @@
-[English](thread.md)
-
 # Thread Reference
 
 The `thread` package provides OS-level threading primitives for CPU-bound parallel workloads and fine-grained concurrency control.

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -1,5 +1,3 @@
-[English](types.md) | [日本語](../ja/reference/types.md) | [繁體中文](../zh/reference/types.md)
-
 # Type Reference
 
 ## Type List


### PR DESCRIPTION
## Summary

- Remove the leading dead language-switcher line (and the immediately following blank line) from 25 docs pages.
  - **Three-language pattern** (21 files) — `docs/README.md` and 20 `docs/reference/*.md` pages had a `[English] | [日本語] | [繁體中文]` line whose `日本語`/`繁體中文` links pointed to non-existent `docs/ja/` and `docs/zh/` trees.
  - **English-only self-link pattern** (4 files) — `docs/reference/{gc,http,net,thread}.md` had a residual `[English](self.md)` line (presumably from a partial earlier cleanup) that provided no navigation value.
- Add `changelog.d/1398-docs-language-switcher-cleanup.md` under `### Fixed`.

This is the horizontal cleanup of the remaining 25 pages after #1392 dropped the same line from `docs/reference/directives.md`. AGENTS.md and `.claude/skills/pre-commit-checklist/SKILL.md` already declare English-only docs, so no policy update is required to prevent regression.

`docs/reference/records.md` had its dead 日本語/繁體中文 links pointing to `structs.md` (an old filename); the cleanup just deletes the line, no rename work is implied (per issue note).

Diff is uniform across all 25 files: `-2` lines each, no other content changes.

## Test plan

Acceptance criteria from #1398 — all must return no results:

- [x] `grep -rlE '\[English\]' docs/` → 0 matches
- [x] `grep -rlE '\[English\].*\[日本語\].*\[繁體中文\]' docs/` → 0 matches
- [x] `grep -nE '^\[English\]\([a-z_-]+\.md\)$' docs/reference/*.md` → 0 matches
- [x] Each affected file's new line 1 is a markdown heading (`# ...`) — verified for all 25
- [x] `git diff --stat` shows exactly `-2` per file across the 25 (50 deletions total), plus 1 new `changelog.d/` fragment

Closes #1398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed non-functional language switcher links from documentation pages that referenced missing localized content.
  * Cleaned up documentation headers across multiple reference pages for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->