### PR TITLE
feat(directives): allow defaulted directive params in positional form (#1402)

### DIFF
--- a/.claude/rules/tests-rejection-tdd.md
+++ b/.claude/rules/tests-rejection-tdd.md
@@ -45,6 +45,23 @@ For each hit, confirm a test exists that executes that exact line.
 
 **How to apply**: For #1210 this meant `OperatorAndKeywordAcceptsSpaceForm` (`-> bool` + valid params), `OperatorOrKeywordAcceptsSpaceForm`, `OperatorNotKeywordAcceptsSpaceForm`, `OperatorInKeywordAcceptsSpaceForm`, `OperatorAsKeywordAcceptsSpaceForm` alongside the four `OperatorXxxRejectsSpaceForm` negative tests for symbolic operators.
 
+### Relaxing a rejection branch requires flipping (not deleting) existing `EXPECT_THROW` tests that lock in the old narrow spec
+
+**Source**: #1402 (2026-04-27, implementation — advisor call-out); same pattern previously seen in #1397
+**Tags**: testing, tdd, expect-throw, expect-no-throw, narrowing, blind-spot, directive
+
+**Context**: #1397 relaxed the user-defined `@directive` argument check so required parameters could be passed positionally (previously named-only). #1402 did the same for defaulted parameters. In both cases there were pre-existing `EXPECT_THROW` tests whose input string (e.g. `@logged("warn")` against `fn logged(label: str = "info")`) was the very form being legalized. Those tests would silently continue to pass for the wrong reason if the new code accidentally still threw on a different validation, hiding a regression in the legalization itself.
+
+**Rule**: When relaxing a rejection branch (changing `throw` → `no-throw` for some input class), grep `tests/` for existing `EXPECT_THROW` blocks whose source string falls inside the newly-legal class. Each such test must be **flipped to `EXPECT_NO_THROW`** (and renamed if the test name encoded the old rejection — e.g. `DeprecatedPositionalArgOnRecordError` → `DeprecatedPositionalArgOnRecordAccepted`), not deleted. Flipping locks the new positive spec under the same input that previously locked the old negative spec; deleting silently surrenders coverage of that exact wording.
+
+**How to apply**: For #1402 this caught `DeprecatedPositionalArgOnRecordError` in `tests/test_codegen_directive.cpp` (line 467, the `@deprecated("old")` form on records). The grep:
+
+```bash
+grep -nE 'EXPECT_THROW.*<input-pattern-being-legalized>' tests/
+```
+
+Run it for every input shape your relaxation legalizes (e.g. positional defaulted, positional required, named required), not just the central case. Combine with the existing rule "New rejections that narrow a form need a positive test for the preserved sibling" — these are mirror images: narrowing needs new positive tests; widening needs flipped negative tests.
+
 ### Defensive ptr-shape validation guards are unreachable from Ry source — no regression test required
 
 **Source**: #987 (2026-04-16, fix)

--- a/changelog.d/1402-directive-defaulted-positional.md
+++ b/changelog.d/1402-directive-defaulted-positional.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Defaulted parameters of user-defined `@directive` declarations may now be passed positionally in declaration order, in addition to the existing named-argument and omitted (default-value) forms. For example, given `fn logged(label: str = "info")`, all of `@logged("warn")`, `@logged(label="warn")`, and `@logged()` are now accepted. Previously the positional form was rejected with "accepts at most 0 positional argument(s)". Built-in directives (`@native`, etc.) are unaffected. (#1402)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -498,14 +498,14 @@ Multiple targets are allowed via the list form: `target=["function", "record"]`.
 
 **Parameters:**
 
-Parameters use Ry's standard type syntax (`str`, `int`, `bool`, `list`, etc.). Type annotations are optional and default to `any` when omitted; however, a parameter with a default value **must** carry an explicit type annotation. Parameters without a default are required and may be passed either positionally or by name at the use site. Parameters with a default are optional named arguments (named-only). Required parameters must precede defaulted parameters in the declaration.
+Parameters use Ry's standard type syntax (`str`, `int`, `bool`, `list`, etc.). Type annotations are optional and default to `any` when omitted; however, a parameter with a default value **must** carry an explicit type annotation. Every parameter (whether required or defaulted) may be passed either positionally — in declaration order — or by name at the use site. Defaulted parameters may also be omitted, in which case the declared default is used. Required parameters must precede defaulted parameters in the declaration.
 
 ```ry
 @directive(target=["function"], stage="compile")
 fn logged(label: str)                     # required (positional or named)
 
 @directive(target=["function"], stage="compile")
-fn cached(ttl: int = 60)                  # optional named, default 60
+fn cached(ttl: int = 60)                  # defaulted (positional, named, or omitted)
 ```
 
 **Use site:**
@@ -525,12 +525,16 @@ fn target_fn2() -> int:
 fn slow_fn() -> int:
     return compute()
 
+@cached(3600)                             # positional override
+fn fast_fn() -> int:
+    return 7
+
 @cached(ttl=3600)                         # named override
 fn other_fn() -> int:
     return 42
 ```
 
-Required parameters may be supplied either positionally or by name, but not both forms for the same parameter — `@logged("hello", label="hi")` is rejected as a duplicate. `@logged(unknown="y")` is rejected: only declared parameter names may appear at the use site. `@logged()` is rejected when `label` is required.
+Each parameter may be supplied either positionally or by name, but not both forms for the same parameter — `@logged("hello", label="hi")` is rejected as a duplicate, and likewise `@cached(3600, ttl=7200)` is rejected. `@logged(unknown="y")` is rejected: only declared parameter names may appear at the use site. `@logged()` is rejected when `label` is required (defaulted parameters may still be omitted).
 
 ### Export and import
 

--- a/include/ry/directive_meta.hpp
+++ b/include/ry/directive_meta.hpp
@@ -35,12 +35,14 @@ struct DirectiveSignature {
     DirectiveStage stage;
     int min_positional = 0;
     int max_positional = 0;        // -1 = unlimited
-    std::vector<std::string> named_params;  // optional/defaulted named-only parameter names
-    // Names of parameters that may be filled either positionally (in order)
-    // or by name. Used by user-defined `@directive` declarations to expose
-    // required parameters under both forms. Built-in directives leave this
-    // empty to preserve their existing positional-only semantics.
+    // Declared parameters in order. User-defined `@directive` declarations
+    // populate every parameter here so the use site can pass them
+    // positionally or by name. Built-in directives leave this empty.
     std::vector<std::string> positional_param_names;
+    // Subset of positional_param_names whose declarations carry a default
+    // value. Drives validateDirectiveSignature so the missing-required check
+    // fires only for non-defaulted params.
+    std::vector<std::string> defaulted_params;
     // Optional per-directive validation. Called after generic checks pass.
     // Throws std::runtime_error if validation fails.
     void (*custom_validator)(const std::string &, const std::vector<DirectiveArg> &) = nullptr;

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -1123,10 +1123,9 @@ DirectiveSignature fromDirectiveDef(const DirectiveDefStmt &s) {
     sig.stage = (s.stage == "runtime") ? DirectiveStage::Runtime : DirectiveStage::CompileTime;
 
     for (const auto &p : s.params) {
-        if (!p.default_value)
-            sig.positional_param_names.push_back(p.name);
-        else
-            sig.named_params.push_back(p.name);
+        sig.positional_param_names.push_back(p.name);
+        if (p.default_value)
+            sig.defaulted_params.push_back(p.name);
     }
     sig.min_positional = 0;
     sig.max_positional = static_cast<int>(sig.positional_param_names.size());

--- a/src/directive_meta.cpp
+++ b/src/directive_meta.cpp
@@ -53,7 +53,9 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
         {"native", {"native",
             T::Function | T::Statement,
             DirectiveStage::CompileTime,
-            /*min_pos=*/0, /*max_pos=*/1, {}, /*positional_param_names=*/{},
+            /*min_pos=*/0, /*max_pos=*/1,
+            /*positional_param_names=*/{},
+            /*defaulted_params=*/{},
             [](const std::string &, const std::vector<DirectiveArg> &args) {
                 if (const ExprNode *p = firstPositionalExpr(args)) {
                     if (auto *s = std::get_if<StringExpr>(&p->data)) {
@@ -94,8 +96,7 @@ void validateDirectiveSignature(const std::string &directiveName,
         if (!a.name.has_value()) {
             ++positional;
         } else {
-            if (!contains(sig.positional_param_names, *a.name) &&
-                !contains(sig.named_params, *a.name))
+            if (!contains(sig.positional_param_names, *a.name))
                 throw std::runtime_error(
                     "unknown named argument '" + *a.name +
                     "' for directive '@" + directiveName + "'");
@@ -128,6 +129,7 @@ void validateDirectiveSignature(const std::string &directiveName,
             throw std::runtime_error(msg);
         }
         if (!by_pos && !by_name) {
+            if (contains(sig.defaulted_params, pname)) continue;
             std::string msg = "@";
             msg += directiveName;
             msg += " missing required argument '";

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -392,16 +392,17 @@ TEST_F(DirectiveTest, UnknownDirectiveError) {
     }, std::runtime_error);
 }
 
-// 10b. Positional string argument on non-@native directive causes parse error
-TEST_F(DirectiveTest, PositionalArgOnNonNativeError) {
-    EXPECT_THROW({
+// 10b. Defaulted parameters of stdlib-declared user directives accept
+// positional arguments (#1402).
+TEST_F(DirectiveTest, StdlibDirectiveDefaultedParamAcceptsPositionalArg) {
+    EXPECT_NO_THROW({
         runSource(withCoreAndTestingDirectiveDecls(
             "@inline(\"always\")\nfn add(a: int, b: int) -> int:\n    return a + b\n"));
-    }, std::runtime_error);
-    EXPECT_THROW({
+    });
+    EXPECT_NO_THROW({
         runSource(withCoreAndTestingDirectiveDecls(
             "@deprecated(\"old\")\nfn foo() -> int:\n    return 1\n"));
-    }, std::runtime_error);
+    });
 }
 
 // 10c. @native("") with empty string causes parse error
@@ -463,12 +464,13 @@ TEST_F(DirectiveTest, UnknownDirectiveOnForError) {
     }, std::runtime_error);
 }
 
-// 10j. @deprecated with positional arg on record causes codegen error
-TEST_F(DirectiveTest, DeprecatedPositionalArgOnRecordError) {
-    EXPECT_THROW({
+// 10j. @deprecated("old") on a record is now accepted (positional form for
+// defaulted parameter — see #1402).
+TEST_F(DirectiveTest, DeprecatedPositionalArgOnRecordAccepted) {
+    EXPECT_NO_THROW({
         runSource(withCoreAndTestingDirectiveDecls(
             "@deprecated(\"old\")\nrecord Foo:\n    x: int\n"));
-    }, std::runtime_error);
+    });
 }
 
 // 10k. Unknown directive on TupleDestructStmt causes codegen error
@@ -1524,6 +1526,108 @@ TEST_F(DirectiveTest, UserDirectiveAcceptsMixedPositionalAndNamed) {
         "fn target_fn() -> int:\n"
         "    return 1\n"
     ));
+}
+
+// A defaulted parameter can be passed positionally (#1402, central spec).
+TEST_F(DirectiveTest, UserDirectiveDefaultedParamAcceptsPositionalArg) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn logged(label: str = \"info\")\n"
+        "@logged(\"warn\")\n"
+        "fn target_fn() -> int:\n"
+        "    return 1\n"
+    ));
+}
+
+// A positional argument overrides the declared default (#1402).
+TEST_F(DirectiveTest, UserDirectiveDefaultedParamPositionalOverridesDefault) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn logged(label: str = \"info\")\n"
+        "@logged(\"error\")\n"
+        "fn target_fn() -> int:\n"
+        "    return 1\n"
+    ));
+}
+
+// Omitting a defaulted parameter is still legal — sibling positive test for
+// the "missing required" rejection path (Rule 2).
+TEST_F(DirectiveTest, UserDirectiveOmittedDefaultedParamStillUsesDefault) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn logged(label: str = \"info\")\n"
+        "@logged()\n"
+        "fn target_fn() -> int:\n"
+        "    return 1\n"
+    ));
+}
+
+// Named form for a defaulted parameter remains legal — sibling positive test
+// for `UserDirectiveRejectsDuplicateNamedArg` (Rule 2).
+TEST_F(DirectiveTest, UserDirectiveDefaultedParamAcceptsNamedArg) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn logged(label: str = \"info\")\n"
+        "@logged(label=\"warn\")\n"
+        "fn target_fn() -> int:\n"
+        "    return 1\n"
+    ));
+}
+
+// All-positional including a defaulted trailing parameter (#1402).
+TEST_F(DirectiveTest, UserDirectiveAcceptsAllPositionalIncludingDefaulted) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "fn mydir(description: str, level: str = \"info\")\n"
+        "@mydir(\"hi\", \"warn\")\n"
+        "fn target_fn() -> int:\n"
+        "    return 1\n"
+    ));
+}
+
+// Providing a defaulted parameter both positionally and by name is rejected.
+TEST_F(DirectiveTest, UserDirectiveRejectsDefaultedParamProvidedTwice) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn mydir(description: str, level: str = \"info\")\n"
+            "@mydir(\"hi\", \"warn\", level=\"error\")\n"
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// Exceeding the new max_positional (now params.size() including defaulted)
+// is still rejected (#1402, direct trigger for the expanded max bound).
+TEST_F(DirectiveTest, UserDirectiveRejectsTooManyPositionalArgsWithDefaulted) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn logged(label: str = \"info\")\n"
+            "@logged(\"a\", \"b\")\n"
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// In a mixed signature, a missing required parameter still throws even when
+// other parameters are defaulted — direct trigger for the per-parameter
+// `defaulted_params.count(pname)` guard (Rule 1).
+TEST_F(DirectiveTest, UserDirectiveRejectsMissingRequiredWhenDefaultedAlsoDeclared) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "fn mydir(description: str, level: str = \"info\")\n"
+            "@mydir(level=\"warn\")\n"
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
 }
 
 // After @it is migrated out of the built-in registry, source that uses @it


### PR DESCRIPTION
## Summary

Closes #1402.

Defaulted parameters of user-defined `@directive` declarations may now be passed positionally in declaration order, mirroring the named-argument form. Previously they were rejected with `accepts at most 0 positional argument(s)`. This finishes the symmetry started in #1397, where required parameters became positional-or-named.

For example, given:

```ry
@directive(target=["function"], stage="compile")
fn logged(label: str = "info")
```

All three forms are now accepted (previously only the latter two):

- `@logged("warn")` — positional override (newly accepted)
- `@logged(label="warn")` — named override (unchanged)
- `@logged()` — defaulted to `"info"` (unchanged)

Built-in directives (`@native`, etc.) are unaffected because their `positional_param_names` stays empty.

## Implementation notes

- `DirectiveSignature` gains `defaulted_params` (vector of param names with defaults) and drops the now-dead `named_params` field. Every user-defined parameter goes into `positional_param_names`; defaulted ones are also recorded in `defaulted_params`.
- `validateDirectiveSignature` skips the missing-required check per-parameter when the parameter is in `defaulted_params`. The `by_pos && by_name` duplicate check still fires for defaulted params, so `@mydir("hi", "warn", level="error")` is rejected.
- Built-in `@native` registry initializer updated for the new field shape (positional initializer order).
- Two existing `EXPECT_THROW` tests were flipped to `EXPECT_NO_THROW` (and renamed) where the input form is now legal — `PositionalArgOnNonNativeError` → `StdlibDirectiveDefaultedParamAcceptsPositionalArg`, `DeprecatedPositionalArgOnRecordError` → `DeprecatedPositionalArgOnRecordAccepted`. Captured this widening pattern in `.claude/rules/tests-rejection-tdd.md`.

## Test plan

- [x] `./build/ry_tests --gtest_filter='*Directive*'` — 141 pass (8 new tests covering positional-override, omit-default, named, all-positional, duplicate-rejection, too-many-positional, missing-required-with-defaulted)
- [x] `./build/ry_tests` — 1993 pass
- [x] `./build/ry test -p` — 168 spec files, 0 failures
- [x] ASan + UBSan: directive tests + Ry self-test green
- [x] TSan: directive tests green
- [x] libFuzzer: parser/json/utf8 harnesses each ran clean (no crashes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * User-defined directive parameters with default values now accept positional arguments in declaration order, in addition to named arguments and omission to use defaults. Built-in directives remain unchanged.

* **Documentation**
  * Updated directive reference documentation with clarified parameter passing rules for defaulted parameters, including examples demonstrating positional usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->