### PR TITLE
refactor(directives): drop stage parameter from @directive(...) declaration syntax (#1408)

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -246,14 +246,14 @@ catch it because the bug is specific to the identifier-adjacent case.
 **Source**: #708 (2026-04-27, implementation)
 **Tags**: parser, directive, directive-def, ast, formatter, registry
 
-**Rule**: `@directive(target=..., stage=...) fn name(params)` is intercepted in `parseStatement` **before** `validateDirective` runs, and produces a dedicated `DirectiveDefStmt` AST node — it does not flow through `builtinDirectiveRegistry()` like `@native` / `@inline` / `@deprecated`. The dispatch order:
+**Rule**: `@directive(target=...) fn name(params)` is intercepted in `parseStatement` **before** `validateDirective` runs, and produces a dedicated `DirectiveDefStmt` AST node — it does not flow through `builtinDirectiveRegistry()` like `@native` / `@inline` / `@deprecated`. The dispatch order:
 
 1. `parseStatement` calls `parseDirectives()` to collect annotations
 2. If `hasDirective(directives, "directive")` and the next token is `Fn`, call `parseDirectiveDefStatement(directives)` instead of `parseFnStatement`
-3. The directive arg validation (target/stage required, named-only, value-type checks, allowed-target set, `stage="compile"` only) is enforced inside `parseDirectiveDefStatement` directly via `parseError`
+3. The directive arg validation (target required, named-only, value-type checks, allowed-target set) is enforced inside `parseDirectiveDefStatement` directly via `parseError`
 4. `@directive` is **not registered** in `directive_meta.cpp` — `validateDirective` would reject it as unknown if it ever reached that path
 
-**Why**: The `target` / `stage` arguments shape the AST representation (extracted into `DirectiveDefStmt.targets` / `.stage`), so they must be validated at the same point the AST node is built. Registry-routed validators only see the directive args after parsing, which is too late to influence node construction. The early-intercept pattern also lets the parser emit precise diagnostics like `@directive must be followed by 'fn'` and `@directive cannot be combined with other directives` at the right source location.
+**Why**: The `target` argument shapes the AST representation (extracted into `DirectiveDefStmt.targets`), so it must be validated at the same point the AST node is built. Registry-routed validators only see the directive args after parsing, which is too late to influence node construction. The early-intercept pattern also lets the parser emit precise diagnostics like `@directive must be followed by 'fn'` and `@directive cannot be combined with other directives` at the right source location.
 
 **How to apply**: If you add another annotation that produces a dedicated AST node (rather than just decorating an existing statement), follow the same pattern — intercept in `parseStatement` before `validateDirective`, build the dedicated node inside a helper, and skip registry registration. Conversely, do **not** add `@directive` to `builtinDirectiveRegistry()` — it would create a phantom validator that never fires.
 

--- a/.claude/rules/tests-cpp-conventions.md
+++ b/.claude/rules/tests-cpp-conventions.md
@@ -15,7 +15,7 @@ paths:
 
 The codegen test harness (`runSource`, `runSourceWithWarnings`, `runTestSource`, `compileSource` in `tests/test_codegen_common.hpp`) goes `Parser → CodeGen` directly and **skips `ModuleLoader` entirely**. Source that uses any of these directives without inline declarations therefore fails at codegen with `unknown directive '@inline'` (or `@parallel`, etc.) — even though the same source runs fine through the real CLI.
 
-**Rule**: Any C++ test that exercises a directive declared in stdlib `.ry` (the 8 listed above) must wrap its source with `withStdlibDirectiveDecls()` from `tests/test_codegen_common.hpp`. The helper prepends inline `@directive(target=..., stage=...)` declarations equivalent to what the loader would inject.
+**Rule**: Any C++ test that exercises a directive declared in stdlib `.ry` (the 8 listed above) must wrap its source with `withStdlibDirectiveDecls()` from `tests/test_codegen_common.hpp`. The helper prepends inline `@directive(target=...)` declarations equivalent to what the loader would inject.
 
 **How to apply**:
 - Adding a new test that uses any of `@inline / @parallel / @const / @deprecated / @each / @property / @it / @describe`: wrap the source string — `runSource(withStdlibDirectiveDecls("..."))`. Don't try to express the directive declaration inline ad-hoc.

--- a/changelog.d/1392-directive-definition-docs.md
+++ b/changelog.d/1392-directive-definition-docs.md
@@ -1,3 +1,3 @@
 ### Added
 
-- Reference documentation for the user-defined `@directive(target=..., stage="compile")` declaration syntax in `docs/reference/directives.md`, including `target`/`stage` parameter values, parameter mapping rules, the bootstrap rule for `@directive` and `@native`, and the Tier 1 (signature-only) vs Tier 2 (future) distinction. Each existing built-in directive section is also labeled with its definition origin. (#1392)
+- Reference documentation for the user-defined `@directive(target=...)` declaration syntax in `docs/reference/directives.md`, including `target` parameter values, parameter mapping rules, and the bootstrap rule for `@directive` and `@native`. Each existing built-in directive section is also labeled with its definition origin. (#1392)

--- a/changelog.d/1408-drop-directive-stage-param.md
+++ b/changelog.d/1408-drop-directive-stage-param.md
@@ -1,0 +1,3 @@
+### Removed
+
+- Removed the `stage` parameter from user-defined `@directive(...)` declarations. `@directive(target=[...]) fn name(...)` is now the canonical form. `@directive(target=[...], stage="compile")` is rejected as `unknown argument 'stage'` (hard error, no deprecation window). The `stage` knob conveyed no useful information today (only `"compile"` was accepted) and was reserved for a Tier 2 design (#1400) that has been declined. (#1408)

--- a/changelog.d/709-directive-def-export.md
+++ b/changelog.d/709-directive-def-export.md
@@ -1,3 +1,3 @@
 ### Added
 
-- `DirectiveDefStmt` (e.g. `@directive(target="function", stage="compile") fn name(params)`) is now exportable from packages. Both wildcard (`from pkg`) and named (`from pkg import name`) imports include directive definitions, with the same `_`-prefix privacy rules as functions and types. (#709)
+- `DirectiveDefStmt` (e.g. `@directive(target="function") fn name(params)`) is now exportable from packages. Both wildcard (`from pkg`) and named (`from pkg import name`) imports include directive definitions, with the same `_`-prefix privacy rules as functions and types. (#709)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -469,10 +469,10 @@ Packages can declare their own compile-time directives with the `@directive(...)
 
 ### Defining a directive
 
-A directive declaration specifies what kinds of nodes it can be applied to (`target`) and at what compilation phase it runs (`stage`). The declaration is signature-only — the body and return type are both forbidden.
+A directive declaration specifies what kinds of nodes it can be applied to (`target`). The declaration is signature-only — the body and return type are both forbidden.
 
 ```ry
-@directive(target=["function"], stage="compile")
+@directive(target=["function"])
 fn logged(label: str)
 ```
 
@@ -488,10 +488,8 @@ fn logged(label: str)
 
 Multiple targets are allowed via the list form: `target=["function", "record"]`. The bare-string form `target="function"` is sugar for `target=["function"]`.
 
-**`stage` parameter:** Only `"compile"` is accepted in v0.0.15. `"runtime"` is reserved for a future Tier 2 form and is currently rejected by the parser.
-
 **Constraints:**
-- Both `target` and `stage` are required and named-only.
+- `target` is required and named-only.
 - `@directive` must be the sole directive on the `fn` — it cannot be stacked with other directives.
 - The `fn` must not have a body (no `:`-introduced block) and no return type (`->` is forbidden).
 - Declaring a `@directive` whose name collides with a built-in (e.g. `@native`, `@each`, `@property`, `@inline`, `@parallel`, `@const`, `@deprecated`) is rejected at compile time. Declaring the same directive name twice in one program is also rejected.
@@ -501,10 +499,10 @@ Multiple targets are allowed via the list form: `target=["function", "record"]`.
 Parameters use Ry's standard type syntax (`str`, `int`, `bool`, `list`, etc.). Type annotations are optional and default to `any` when omitted; however, a parameter with a default value **must** carry an explicit type annotation. Every parameter (whether required or defaulted) may be passed either positionally — in declaration order — or by name at the use site. Defaulted parameters may also be omitted, in which case the declared default is used. Required parameters must precede defaulted parameters in the declaration.
 
 ```ry
-@directive(target=["function"], stage="compile")
+@directive(target=["function"])
 fn logged(label: str)                     # required (positional or named)
 
-@directive(target=["function"], stage="compile")
+@directive(target=["function"])
 fn cached(ttl: int = 60)                  # defaulted (positional, named, or omitted)
 ```
 
@@ -547,13 +545,6 @@ Most built-in directives are now declared in `share/std/`. Core directives (`@de
 `@directive` itself and `@native` are **compiler built-ins** and cannot be redeclared in `.ry` source. (`@native` is registered in `src/directive_meta.cpp`'s built-in registry; `@directive` is handled as a hardcoded special form in the parser.) The reason is self-referential: the `@directive(...)` declaration syntax binds a directive to its C++ implementation through `@native`, and `@native` cannot mark its own declaration. These two directives remain permanently in C++.
 
 All other built-in directives (`@deprecated`, `@const`, `@inline`, `@parallel`, `@each`, `@property`) are now declared in `share/std/` (the core ones in `share/std/core/directive.ry`, the testing ones in `share/std/testing/testing.ry`). Only `@directive` and `@native` remain in the C++ registry due to the bootstrap constraint.
-
-### Tier 1 vs Tier 2
-
-User-defined directives are introduced in two tiers.
-
-- **Tier 1 (v0.0.15)** — described in this section. The `@directive` declaration is signature-only; the actual compile-time logic is supplied by a C++ implementation bound through `@native`. Tier 1 lets stdlib packages and user packages publish directive *interfaces*, but the behavior is hosted in C++.
-- **Tier 2 (future)** — write the directive's logic directly in Ry. Tier 2 is not available in v0.0.15; specific issue tracking is to be determined.
 
 ## Notes
 

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -332,7 +332,6 @@ struct DirectiveDefStmt {
     std::string name;                     // directive name (e.g., "it", "describe")
     std::vector<FnParam> params;          // declared parameters (param type validation deferred to #710)
     std::vector<std::string> targets;     // canonicalized list ("function"/"record"/"field"/"statement"/"for")
-    std::string stage;                    // "compile" only in v0.0.15
     SourceLocation loc;
 };
 

--- a/include/ry/directive_meta.hpp
+++ b/include/ry/directive_meta.hpp
@@ -22,17 +22,10 @@ inline uint8_t operator|(DirectiveTarget a, DirectiveTarget b) { return asTarget
 inline uint8_t operator|(uint8_t a, DirectiveTarget b) { return a | asTarget(b); }
 inline bool hasTarget(uint8_t mask, DirectiveTarget t) { return (mask & asTarget(t)) != 0; }
 
-// When the directive takes effect.
-enum class DirectiveStage : uint8_t {
-    CompileTime,
-    Runtime,
-};
-
 // Signature metadata for a single built-in directive.
 struct DirectiveSignature {
     std::string name;
     uint8_t allowed_targets;       // bitmask of DirectiveTarget
-    DirectiveStage stage;
     int min_positional = 0;
     int max_positional = 0;        // -1 = unlimited
     // Declared parameters in order. User-defined `@directive` declarations

--- a/share/std/core/directive.ry
+++ b/share/std/core/directive.ry
@@ -1,13 +1,13 @@
 # Core directives. Implicitly imported via builtins.ry re-export.
 
-@directive(target=["function"], stage="compile")
+@directive(target=["function"])
 fn inline(mode: str = "always")
 
-@directive(target=["for"], stage="compile")
+@directive(target=["for"])
 fn parallel()
 
-@directive(target=["statement"], stage="compile")
+@directive(target=["statement"])
 fn const()
 
-@directive(target=["function", "record", "field", "statement"], stage="compile")
+@directive(target=["function", "record", "field", "statement"])
 fn deprecated(reason: str = "")

--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -1,14 +1,14 @@
 # Testing directives. Test files must explicitly
 # `from std/testing import it, describe`.
 
-@directive(target=["function"], stage="compile")
+@directive(target=["function"])
 fn it(description: str)
 
-@directive(target=["function"], stage="compile")
+@directive(target=["function"])
 fn describe(group: str)
 
-@directive(target=["statement", "function"], stage="compile")
+@directive(target=["statement", "function"])
 fn each(data: any)
 
-@directive(target=["statement", "function"], stage="compile")
+@directive(target=["statement", "function"])
 fn property(count: int = 100)

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -1120,7 +1120,6 @@ DirectiveSignature fromDirectiveDef(const DirectiveDefStmt &s) {
     for (const auto &t : s.targets)
         mask |= directiveTargetMask(t);
     sig.allowed_targets = mask;
-    sig.stage = (s.stage == "runtime") ? DirectiveStage::Runtime : DirectiveStage::CompileTime;
 
     for (const auto &p : s.params) {
         sig.positional_param_names.push_back(p.name);

--- a/src/directive_meta.cpp
+++ b/src/directive_meta.cpp
@@ -52,7 +52,6 @@ const std::unordered_map<std::string, DirectiveSignature> &builtinDirectiveRegis
     static const std::unordered_map<std::string, DirectiveSignature> registry = {
         {"native", {"native",
             T::Function | T::Statement,
-            DirectiveStage::CompileTime,
             /*min_pos=*/0, /*max_pos=*/1,
             /*positional_param_names=*/{},
             /*defaulted_params=*/{},

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -479,7 +479,7 @@ void Formatter::formatDirectiveDef(const DirectiveDefStmt &s) {
         if (i > 0) emit(", ");
         emit("\"" + s.targets[i] + "\"");
     }
-    emit("], stage=\"" + s.stage + "\")");
+    emit("])");
     emitNewline();
     emitIndent();
     emit("fn " + s.name + "(" + formatParams(s.params) + ")");

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -315,7 +315,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
 }
 
 // Parse a directive definition statement (#708):
-//   @directive(target=["function"|...], stage="compile")
+//   @directive(target=["function"|...])
 //   fn <name>(<params>)
 // Caller (parseStatement) has already verified the directive list contains
 // exactly one directive named "directive" and that the next token is `Fn`,
@@ -323,10 +323,9 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
 StmtNode Parser::parseDirectiveDefStatement(const Directive *dirAnnot) {
     int annotLine = dirAnnot->loc.line;
 
-    // Validate annotation arguments: named-only, only target/stage allowed,
-    // both required, no duplicates.
+    // Validate annotation arguments: named-only, target is required,
+    // no duplicates.
     const DirectiveArg *targetArg = nullptr;
-    const DirectiveArg *stageArg = nullptr;
     for (const auto &arg : dirAnnot->args) {
         if (!arg.name)
             parseError(annotLine, "@directive arguments must be named");
@@ -334,18 +333,12 @@ StmtNode Parser::parseDirectiveDefStatement(const Directive *dirAnnot) {
             if (targetArg != nullptr)
                 parseError(annotLine, "@directive: duplicate argument 'target'");
             targetArg = &arg;
-        } else if (*arg.name == "stage") {
-            if (stageArg != nullptr)
-                parseError(annotLine, "@directive: duplicate argument 'stage'");
-            stageArg = &arg;
         } else {
             parseError(annotLine, "@directive: unknown argument '" + *arg.name + "'");
         }
     }
     if (targetArg == nullptr)
         parseError(annotLine, "@directive requires 'target' argument");
-    if (stageArg == nullptr)
-        parseError(annotLine, "@directive requires 'stage' argument");
 
     static const std::unordered_set<std::string> kAllowedTargets = {
         "function", "record", "field", "statement", "for"
@@ -385,12 +378,6 @@ StmtNode Parser::parseDirectiveDefStatement(const Directive *dirAnnot) {
     } else {
         parseError(annotLine, "@directive target must be a string or list of strings");
     }
-
-    // stage: StringExpr == "compile"
-    const auto *stageStr = std::get_if<StringExpr>(&stageArg->value->data);
-    if (stageStr == nullptr || stageStr->value != "compile")
-        parseError(annotLine, "@directive stage must be \"compile\"");
-    result.stage = stageStr->value;
 
     // Consume `fn <name>(<params>)` — no return type, no body.
     lex_.next(); // consume 'fn'

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -164,21 +164,21 @@ protected:
 // of the source they hand to the codegen.
 inline std::string withStdlibDirectiveDecls(const std::string &src) {
     static const char *kDecls =
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn inline(mode: str = \"always\")\n"
-        "@directive(target=[\"for\"], stage=\"compile\")\n"
+        "@directive(target=[\"for\"])\n"
         "fn parallel()\n"
-        "@directive(target=[\"statement\"], stage=\"compile\")\n"
+        "@directive(target=[\"statement\"])\n"
         "fn const()\n"
-        "@directive(target=[\"function\", \"record\", \"field\", \"statement\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\", \"record\", \"field\", \"statement\"])\n"
         "fn deprecated(reason: str = \"\")\n"
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn it(description: str)\n"
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn describe(group: str)\n"
-        "@directive(target=[\"statement\", \"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"statement\", \"function\"])\n"
         "fn each(data: any)\n"
-        "@directive(target=[\"statement\", \"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"statement\", \"function\"])\n"
         "fn property(count: int = 100)\n";
     return std::string(kDecls) + src;
 }

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1352,7 +1352,7 @@ TEST(DirectiveSyntax, UnknownDirectiveParseSucceeds) {
 TEST_F(DirectiveTest, DirectiveDefCodegenSmokeBareDefinition) {
     EXPECT_NO_THROW({
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn d(description: str)\n"
         );
     });
@@ -1362,7 +1362,7 @@ TEST_F(DirectiveTest, DirectiveDefCodegenSmokeBareDefinition) {
 // statements still produces a runnable __ry_main__ that prints the expected output.
 TEST_F(DirectiveTest, DirectiveDefCodegenSmokeFollowedByMain) {
     std::string output = runSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn d(description: str)\n"
         "print(\"ok\")\n"
     );
@@ -1374,9 +1374,9 @@ TEST_F(DirectiveTest, DirectiveDefCodegenSmokeFollowedByMain) {
 // the dedicated tests below.
 TEST_F(DirectiveTest, DirectiveDefCodegenSmokeMultiple) {
     std::string output = runSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn my_it(description: str)\n"
-        "@directive(target=[\"function\", \"record\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\", \"record\"])\n"
         "fn cacheable()\n"
         "print(\"ok\")\n"
     );
@@ -1389,7 +1389,7 @@ TEST_F(DirectiveTest, DirectiveDefCodegenSmokeMultiple) {
 // and a subsequent application of `@<name>(...)` passes validation.
 TEST_F(DirectiveTest, UserDirectiveRegistersOnDefStmt) {
     EXPECT_NO_THROW(runSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn logged(label: str)\n"
         "@logged(\"hello\")\n"
         "fn target_fn() -> int:\n"
@@ -1403,7 +1403,7 @@ TEST_F(DirectiveTest, UserDirectiveRegistersOnDefStmt) {
 TEST_F(DirectiveTest, UserDirectiveCollisionWithBuiltinRejected) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn native()\n"
         ),
         std::runtime_error
@@ -1414,9 +1414,9 @@ TEST_F(DirectiveTest, UserDirectiveCollisionWithBuiltinRejected) {
 TEST_F(DirectiveTest, UserDirectiveDuplicateRegistrationRejected) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn dup(label: str)\n"
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn dup(other: str)\n"
         ),
         std::runtime_error
@@ -1440,7 +1440,7 @@ TEST_F(DirectiveTest, UserDirectiveUnknownStillRejected) {
 TEST_F(DirectiveTest, UserDirectiveRejectsUnknownNamedArg) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn mydir(label: str = \"x\")\n"
             "@mydir(unknown_named=\"y\")\n"
             "fn target_fn() -> int:\n"
@@ -1453,7 +1453,7 @@ TEST_F(DirectiveTest, UserDirectiveRejectsUnknownNamedArg) {
 // A required parameter (no default) may also be passed by name (#1397).
 TEST_F(DirectiveTest, UserDirectiveRequiredParamAcceptsNamedArg) {
     EXPECT_NO_THROW(compileSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn mydir(description: str)\n"
         "@mydir(description=\"hi\")\n"
         "fn target_fn() -> int:\n"
@@ -1465,7 +1465,7 @@ TEST_F(DirectiveTest, UserDirectiveRequiredParamAcceptsNamedArg) {
 TEST_F(DirectiveTest, UserDirectiveRejectsUnknownNamedArgWithRequiredParam) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn mydir(description: str)\n"
             "@mydir(unknown=\"x\")\n"
             "fn target_fn() -> int:\n"
@@ -1479,7 +1479,7 @@ TEST_F(DirectiveTest, UserDirectiveRejectsUnknownNamedArgWithRequiredParam) {
 TEST_F(DirectiveTest, UserDirectiveRejectsRequiredParamProvidedTwice) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn mydir(description: str)\n"
             "@mydir(\"hi\", description=\"again\")\n"
             "fn target_fn() -> int:\n"
@@ -1493,7 +1493,7 @@ TEST_F(DirectiveTest, UserDirectiveRejectsRequiredParamProvidedTwice) {
 TEST_F(DirectiveTest, UserDirectiveRejectsMissingRequiredParam) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn mydir(description: str)\n"
             "@mydir()\n"
             "fn target_fn() -> int:\n"
@@ -1507,7 +1507,7 @@ TEST_F(DirectiveTest, UserDirectiveRejectsMissingRequiredParam) {
 TEST_F(DirectiveTest, UserDirectiveRejectsDuplicateNamedArg) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn mydir(label: str = \"x\")\n"
             "@mydir(label=\"a\", label=\"b\")\n"
             "fn target_fn() -> int:\n"
@@ -1520,7 +1520,7 @@ TEST_F(DirectiveTest, UserDirectiveRejectsDuplicateNamedArg) {
 // Required positional + optional named — common usage must remain accepted.
 TEST_F(DirectiveTest, UserDirectiveAcceptsMixedPositionalAndNamed) {
     EXPECT_NO_THROW(compileSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn mydir(description: str, level: str = \"info\")\n"
         "@mydir(\"hi\", level=\"warn\")\n"
         "fn target_fn() -> int:\n"
@@ -1531,7 +1531,7 @@ TEST_F(DirectiveTest, UserDirectiveAcceptsMixedPositionalAndNamed) {
 // A defaulted parameter can be passed positionally (#1402, central spec).
 TEST_F(DirectiveTest, UserDirectiveDefaultedParamAcceptsPositionalArg) {
     EXPECT_NO_THROW(compileSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn logged(label: str = \"info\")\n"
         "@logged(\"warn\")\n"
         "fn target_fn() -> int:\n"
@@ -1542,7 +1542,7 @@ TEST_F(DirectiveTest, UserDirectiveDefaultedParamAcceptsPositionalArg) {
 // A positional argument overrides the declared default (#1402).
 TEST_F(DirectiveTest, UserDirectiveDefaultedParamPositionalOverridesDefault) {
     EXPECT_NO_THROW(compileSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn logged(label: str = \"info\")\n"
         "@logged(\"error\")\n"
         "fn target_fn() -> int:\n"
@@ -1554,7 +1554,7 @@ TEST_F(DirectiveTest, UserDirectiveDefaultedParamPositionalOverridesDefault) {
 // the "missing required" rejection path (Rule 2).
 TEST_F(DirectiveTest, UserDirectiveOmittedDefaultedParamStillUsesDefault) {
     EXPECT_NO_THROW(compileSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn logged(label: str = \"info\")\n"
         "@logged()\n"
         "fn target_fn() -> int:\n"
@@ -1566,7 +1566,7 @@ TEST_F(DirectiveTest, UserDirectiveOmittedDefaultedParamStillUsesDefault) {
 // for `UserDirectiveRejectsDuplicateNamedArg` (Rule 2).
 TEST_F(DirectiveTest, UserDirectiveDefaultedParamAcceptsNamedArg) {
     EXPECT_NO_THROW(compileSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn logged(label: str = \"info\")\n"
         "@logged(label=\"warn\")\n"
         "fn target_fn() -> int:\n"
@@ -1577,7 +1577,7 @@ TEST_F(DirectiveTest, UserDirectiveDefaultedParamAcceptsNamedArg) {
 // All-positional including a defaulted trailing parameter (#1402).
 TEST_F(DirectiveTest, UserDirectiveAcceptsAllPositionalIncludingDefaulted) {
     EXPECT_NO_THROW(compileSource(
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn mydir(description: str, level: str = \"info\")\n"
         "@mydir(\"hi\", \"warn\")\n"
         "fn target_fn() -> int:\n"
@@ -1589,7 +1589,7 @@ TEST_F(DirectiveTest, UserDirectiveAcceptsAllPositionalIncludingDefaulted) {
 TEST_F(DirectiveTest, UserDirectiveRejectsDefaultedParamProvidedTwice) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn mydir(description: str, level: str = \"info\")\n"
             "@mydir(\"hi\", \"warn\", level=\"error\")\n"
             "fn target_fn() -> int:\n"
@@ -1604,7 +1604,7 @@ TEST_F(DirectiveTest, UserDirectiveRejectsDefaultedParamProvidedTwice) {
 TEST_F(DirectiveTest, UserDirectiveRejectsTooManyPositionalArgsWithDefaulted) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn logged(label: str = \"info\")\n"
             "@logged(\"a\", \"b\")\n"
             "fn target_fn() -> int:\n"
@@ -1620,7 +1620,7 @@ TEST_F(DirectiveTest, UserDirectiveRejectsTooManyPositionalArgsWithDefaulted) {
 TEST_F(DirectiveTest, UserDirectiveRejectsMissingRequiredWhenDefaultedAlsoDeclared) {
     EXPECT_THROW(
         compileSource(
-            "@directive(target=[\"function\"], stage=\"compile\")\n"
+            "@directive(target=[\"function\"])\n"
             "fn mydir(description: str, level: str = \"info\")\n"
             "@mydir(level=\"warn\")\n"
             "fn target_fn() -> int:\n"

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -881,7 +881,7 @@ TEST_F(ImportTest, PrivateLetSymbolExcluded) {
 
 TEST_F(ImportTest, DirectiveDefSelectiveImport) {
     writeFile("dirpkg1/mod.ry",
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn my_dir(x: int)\n"
         "fn marker() -> int:\n"
         "    return 42\n");
@@ -894,7 +894,7 @@ TEST_F(ImportTest, DirectiveDefSelectiveImport) {
 
 TEST_F(ImportTest, DirectiveDefWildcardImport) {
     writeFile("dirpkg2/mod.ry",
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn my_dir(x: int)\n"
         "fn marker() -> int:\n"
         "    return 42\n");
@@ -907,9 +907,9 @@ TEST_F(ImportTest, DirectiveDefWildcardImport) {
 
 TEST_F(ImportTest, DirectiveDefWildcardExcludesPrivate) {
     writeFile("dirpkg3/mod.ry",
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn pub_dir(x: int)\n"
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn _priv_dir(x: int)\n");
 
     Program prog = resolveImportsOnly("from dirpkg3\n");
@@ -929,7 +929,7 @@ TEST_F(ImportTest, DirectiveDefWildcardExcludesPrivate) {
 // validation and the program compiles + runs.
 TEST_F(ImportTest, ImportedDirectiveValidatesAtUseSite) {
     writeFile("dirpkg4/mod.ry",
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn logged(label: str)\n");
 
     EXPECT_EQ(runWithImports(

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -546,7 +546,7 @@ TEST(FormatterTest, DefaultArgRoundTrip) {
 // ===== @directive definition syntax (#708) — formatter round-trip =====
 
 TEST(FormatterTest, DirectiveDefRoundTripSingleTarget) {
-    auto src = "@directive(target=[\"function\"], stage=\"compile\")\nfn it(description: str)\n";
+    auto src = "@directive(target=[\"function\"])\nfn it(description: str)\n";
     auto first = Formatter::formatSource(src);
     EXPECT_EQ(first, src);
     EXPECT_EQ(Formatter::formatSource(first), first);
@@ -554,7 +554,7 @@ TEST(FormatterTest, DirectiveDefRoundTripSingleTarget) {
 
 TEST(FormatterTest, DirectiveDefRoundTripMultipleTargets) {
     auto src =
-        "@directive(target=[\"function\", \"record\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\", \"record\"])\n"
         "fn cacheable()\n";
     auto first = Formatter::formatSource(src);
     EXPECT_EQ(first, src);
@@ -564,8 +564,8 @@ TEST(FormatterTest, DirectiveDefRoundTripMultipleTargets) {
 // Bare-string sugar `target="function"` canonicalises to List form
 // `target=["function"]` after one format pass, then round-trips idempotently.
 TEST(FormatterTest, DirectiveDefBareStringSugarCanonicalises) {
-    auto src = "@directive(target=\"function\", stage=\"compile\")\nfn it(d: str)\n";
-    auto expected = "@directive(target=[\"function\"], stage=\"compile\")\nfn it(d: str)\n";
+    auto src = "@directive(target=\"function\")\nfn it(d: str)\n";
+    auto expected = "@directive(target=[\"function\"])\nfn it(d: str)\n";
     auto first = Formatter::formatSource(src);
     EXPECT_EQ(first, expected);
     EXPECT_EQ(Formatter::formatSource(first), first);
@@ -577,7 +577,7 @@ TEST(FormatterTest, DirectiveDefBareStringSugarCanonicalises) {
 
 TEST(FormatterTest, DirectiveDefRoundTripDefaultArg) {
     auto src =
-        "@directive(target=[\"function\"], stage=\"compile\")\n"
+        "@directive(target=[\"function\"])\n"
         "fn inline(mode: str = \"always\")\n";
     auto first = Formatter::formatSource(src);
     EXPECT_EQ(first, src);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2087,118 +2087,102 @@ TEST(ParserTest, NativeFnWithColonError) {
 // ===== @directive (DirectiveDefStmt) rejection tests (#708) =====
 
 TEST(DirectiveDefParserTest, RejectsLetAfterDirectiveAnnotation) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"compile\")\nx = 1\n"),
+    EXPECT_THROW(parseStr("@directive(target=[\"function\"])\nx = 1\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsRecordAfterDirectiveAnnotation) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"compile\")\nrecord Foo:\n    x: int\n"),
+    EXPECT_THROW(parseStr("@directive(target=[\"function\"])\nrecord Foo:\n    x: int\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsAsyncFnAfterDirectiveAnnotation) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"compile\")\nasync fn it():\n    ...\n"),
+    EXPECT_THROW(parseStr("@directive(target=[\"function\"])\nasync fn it():\n    ...\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsBodyOnDirectiveDef) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"compile\")\nfn it(d: str):\n    d\n"),
+    EXPECT_THROW(parseStr("@directive(target=[\"function\"])\nfn it(d: str):\n    d\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsReturnTypeOnDirectiveDef) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"compile\")\nfn it() -> int\n"),
+    EXPECT_THROW(parseStr("@directive(target=[\"function\"])\nfn it() -> int\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsMissingTargetArgument) {
-    EXPECT_THROW(parseStr("@directive(stage=\"compile\")\nfn it()\n"),
+    EXPECT_THROW(parseStr("@directive()\nfn it()\n"),
                  DiagnosticError);
 }
 
-TEST(DirectiveDefParserTest, RejectsMissingStageArgument) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"])\nfn it()\n"),
-                 DiagnosticError);
-}
-
-TEST(DirectiveDefParserTest, RejectsRuntimeStage) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"runtime\")\nfn it()\n"),
-                 DiagnosticError);
-}
-
-TEST(DirectiveDefParserTest, RejectsUnknownStage) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"never\")\nfn it()\n"),
+// #1408: `stage` is no longer a valid argument and is rejected as unknown.
+TEST(DirectiveDefParserTest, RejectsStageArgument) {
+    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"compile\")\nfn it()\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsUnknownTargetValue) {
-    EXPECT_THROW(parseStr("@directive(target=[\"banana\"], stage=\"compile\")\nfn it()\n"),
+    EXPECT_THROW(parseStr("@directive(target=[\"banana\"])\nfn it()\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsNonStringTarget) {
-    EXPECT_THROW(parseStr("@directive(target=42, stage=\"compile\")\nfn it()\n"),
+    EXPECT_THROW(parseStr("@directive(target=42)\nfn it()\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsNonStringElementsInTargetList) {
-    EXPECT_THROW(parseStr("@directive(target=[1, 2], stage=\"compile\")\nfn it()\n"),
+    EXPECT_THROW(parseStr("@directive(target=[1, 2])\nfn it()\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsEmptyTargetList) {
-    EXPECT_THROW(parseStr("@directive(target=[], stage=\"compile\")\nfn it()\n"),
+    EXPECT_THROW(parseStr("@directive(target=[])\nfn it()\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsDuplicateTargetInList) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\", \"function\"], stage=\"compile\")\nfn it()\n"),
+    EXPECT_THROW(parseStr("@directive(target=[\"function\", \"function\"])\nfn it()\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsDuplicateTargetArgument) {
     EXPECT_THROW(parseStr(
-        "@directive(target=[\"function\"], target=[\"record\"], stage=\"compile\")\nfn it()\n"),
-        DiagnosticError);
-}
-
-TEST(DirectiveDefParserTest, RejectsDuplicateStageArgument) {
-    EXPECT_THROW(parseStr(
-        "@directive(target=[\"function\"], stage=\"compile\", stage=\"compile\")\nfn it()\n"),
+        "@directive(target=[\"function\"], target=[\"record\"])\nfn it()\n"),
         DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsUnknownNamedArgument) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"compile\", extra=\"x\")\nfn it()\n"),
+    EXPECT_THROW(parseStr("@directive(target=[\"function\"], extra=\"x\")\nfn it()\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsPositionalArgumentForDirectiveAnnotation) {
-    EXPECT_THROW(parseStr("@directive(\"function\", \"compile\")\nfn it()\n"),
+    EXPECT_THROW(parseStr("@directive(\"function\")\nfn it()\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsCombiningDirectiveWithDeprecatedBefore) {
-    EXPECT_THROW(parseStr("@deprecated\n@directive(target=[\"function\"], stage=\"compile\")\nfn it()\n"),
+    EXPECT_THROW(parseStr("@deprecated\n@directive(target=[\"function\"])\nfn it()\n"),
                  DiagnosticError);
 }
 
 TEST(DirectiveDefParserTest, RejectsCombiningDirectiveWithDeprecatedAfter) {
-    EXPECT_THROW(parseStr("@directive(target=[\"function\"], stage=\"compile\")\n@deprecated\nfn it()\n"),
+    EXPECT_THROW(parseStr("@directive(target=[\"function\"])\n@deprecated\nfn it()\n"),
                  DiagnosticError);
 }
 
 // ===== @directive acceptance tests (#708) =====
 
 TEST(DirectiveDefParserTest, AcceptsBasicDirectiveDef) {
-    Program prog = parseStr("@directive(target=[\"function\"], stage=\"compile\")\nfn it(description: str)\n");
+    Program prog = parseStr("@directive(target=[\"function\"])\nfn it(description: str)\n");
     ASSERT_EQ(prog.size(), 1u);
     ASSERT_TRUE(std::holds_alternative<DirectiveDefStmt>(prog[0]));
     const auto &d = std::get<DirectiveDefStmt>(prog[0]);
     EXPECT_EQ(d.name, "it");
     ASSERT_EQ(d.targets.size(), 1u);
     EXPECT_EQ(d.targets[0], "function");
-    EXPECT_EQ(d.stage, "compile");
     ASSERT_EQ(d.params.size(), 1u);
     EXPECT_EQ(d.params[0].name, "description");
     ASSERT_TRUE(d.params[0].type != nullptr);
@@ -2206,7 +2190,7 @@ TEST(DirectiveDefParserTest, AcceptsBasicDirectiveDef) {
 }
 
 TEST(DirectiveDefParserTest, AcceptsBareStringTargetSugar) {
-    Program prog = parseStr("@directive(target=\"function\", stage=\"compile\")\nfn it(d: str)\n");
+    Program prog = parseStr("@directive(target=\"function\")\nfn it(d: str)\n");
     ASSERT_EQ(prog.size(), 1u);
     ASSERT_TRUE(std::holds_alternative<DirectiveDefStmt>(prog[0]));
     const auto &d = std::get<DirectiveDefStmt>(prog[0]);
@@ -2215,7 +2199,7 @@ TEST(DirectiveDefParserTest, AcceptsBareStringTargetSugar) {
 }
 
 TEST(DirectiveDefParserTest, AcceptsMultipleTargets) {
-    Program prog = parseStr("@directive(target=[\"function\", \"record\"], stage=\"compile\")\nfn cacheable()\n");
+    Program prog = parseStr("@directive(target=[\"function\", \"record\"])\nfn cacheable()\n");
     ASSERT_EQ(prog.size(), 1u);
     const auto &d = std::get<DirectiveDefStmt>(prog[0]);
     ASSERT_EQ(d.targets.size(), 2u);
@@ -2225,14 +2209,14 @@ TEST(DirectiveDefParserTest, AcceptsMultipleTargets) {
 }
 
 TEST(DirectiveDefParserTest, AcceptsConstAsName) {
-    Program prog = parseStr("@directive(target=[\"function\"], stage=\"compile\")\nfn const()\n");
+    Program prog = parseStr("@directive(target=[\"function\"])\nfn const()\n");
     ASSERT_EQ(prog.size(), 1u);
     const auto &d = std::get<DirectiveDefStmt>(prog[0]);
     EXPECT_EQ(d.name, "const");
 }
 
 TEST(DirectiveDefParserTest, AcceptsParamWithDefaultValue) {
-    Program prog = parseStr("@directive(target=[\"function\"], stage=\"compile\")\nfn inline(mode: str = \"always\")\n");
+    Program prog = parseStr("@directive(target=[\"function\"])\nfn inline(mode: str = \"always\")\n");
     ASSERT_EQ(prog.size(), 1u);
     const auto &d = std::get<DirectiveDefStmt>(prog[0]);
     ASSERT_EQ(d.params.size(), 1u);
@@ -2241,7 +2225,7 @@ TEST(DirectiveDefParserTest, AcceptsParamWithDefaultValue) {
 }
 
 TEST(DirectiveDefParserTest, AcceptsStatementTarget) {
-    Program prog = parseStr("@directive(target=[\"statement\"], stage=\"compile\")\nfn debug()\n");
+    Program prog = parseStr("@directive(target=[\"statement\"])\nfn debug()\n");
     ASSERT_EQ(prog.size(), 1u);
     const auto &d = std::get<DirectiveDefStmt>(prog[0]);
     ASSERT_EQ(d.targets.size(), 1u);
@@ -2249,7 +2233,7 @@ TEST(DirectiveDefParserTest, AcceptsStatementTarget) {
 }
 
 TEST(DirectiveDefParserTest, AcceptsForTarget) {
-    Program prog = parseStr("@directive(target=[\"for\"], stage=\"compile\")\nfn parallel()\n");
+    Program prog = parseStr("@directive(target=[\"for\"])\nfn parallel()\n");
     ASSERT_EQ(prog.size(), 1u);
     const auto &d = std::get<DirectiveDefStmt>(prog[0]);
     ASSERT_EQ(d.targets.size(), 1u);


### PR DESCRIPTION
## Summary

Closes #1408.

Removes the `stage` parameter from user-defined `@directive(...)` declarations. `@directive(target=[...]) fn name(...)` is now the canonical form. `@directive(target=[...], stage="compile")` is rejected as `unknown argument 'stage'` (**hard error, no deprecation window**) — v0.0.15 is unreleased and the `stage` parameter had no real users beyond stdlib's own cargo-cult uses.

### Why hard error, not soft migration

- Only `stage="compile"` was ever accepted; the reserved `stage="runtime"` value belonged to a Tier 2 design (#1400) that has been declined alongside the decorator-style runtime directives (#298).
- The `stage` knob conveyed no useful information today.
- v0.0.15 is unreleased — no external users to migrate.
- Aligning the surface syntax with what the compiler actually supports.

### Changes

- **Parser** (`src/parser_decl.cpp`): removed `stage` arg validation (null-check, type-check, `"compile"`-equality check). `stage` now falls through to the generic "unknown argument" rejection branch.
- **AST / metadata** (`include/ry/ast.hpp`, `include/ry/directive_meta.hpp`): removed `DirectiveDefStmt::stage` field, removed `DirectiveSignature::stage` field, removed `DirectiveStage` enum entirely.
- **Codegen / formatter** (`src/codegen_stmt_misc.cpp`, `src/directive_meta.cpp`, `src/formatter_stmt.cpp`): updated to no longer reference `.stage`.
- **Stdlib** (`share/std/core/directive.ry`, `share/std/testing/testing.ry`): removed `, stage="compile"` from all 8 directive declarations.
- **Tests**: collapsed 4 stage-specific rejection tests (`RejectsMissingStageArgument`, `RejectsRuntimeStage`, `RejectsUnknownStage`, `RejectsDuplicateStageArgument`) into a single `RejectsStageArgument` test that asserts the new "unknown argument" rejection path. Updated all `@directive(...)` invocations in `tests/test_parser.cpp`, `tests/test_codegen_directive.cpp`, `tests/test_codegen_stmt.cpp`, `tests/test_formatter.cpp`, and the `withStdlibDirectiveDecls()` test harness.
- **Docs** (`docs/reference/directives.md`): updated examples, removed `**stage parameter:**` paragraph, removed Tier 1 vs Tier 2 section.
- **Knowledge base** (`.claude/rules/parser-conventions.md`, `.claude/rules/tests-cpp-conventions.md`): synced rule wording with the new syntax.
- **Changelog**: new `changelog.d/1408-drop-directive-stage-param.md`. Updated already-merged `changelog.d/709-directive-def-export.md` and `changelog.d/1392-directive-definition-docs.md` to remove `stage="compile"` from their descriptions, since v0.0.15 will bundle them as a single release.

### Out of scope

- Tier 2 / Ry-implemented directives (#1400 — declined)
- Decorator-style directives (#298 — declined)

## Test plan

- [x] `cmake --build build` — clean build, zero warnings
- [x] `./build/ry_tests` — 1990 C++ tests pass
- [x] `./build/ry test -p` — 168 Ry self-test files pass
- [x] ASan + UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p` — clean
- [x] FileCheck: `ctest --test-dir build -L filecheck` — 10/10 pass
- [x] CLI smoke tests:
  - `@directive(target=["function"], stage="compile")` → exits non-zero with `unknown argument 'stage'` diagnostic
  - `@directive(target=["function"])` → parses normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed support for the `stage` parameter from directive definitions. Directives now require the simplified `@directive(target=[...])` syntax without stage specifications. Attempts to use `stage="compile"` or any other stage value will be rejected as an unknown argument with a hard error, with no deprecation period. All built-in and standard library directives have been updated to the new syntax.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->