### PR TITLE
docs(directives): align directive terminology in code comments and rules

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -248,14 +248,14 @@ catch it because the bug is specific to the identifier-adjacent case.
 
 **Rule**: `@directive(target=...) fn name(params)` is intercepted in `parseStatement` **before** `validateDirective` runs, and produces a dedicated `DirectiveDefStmt` AST node — it does not flow through `builtinDirectiveRegistry()` like `@native` / `@inline` / `@deprecated`. The dispatch order:
 
-1. `parseStatement` calls `parseDirectives()` to collect annotations
+1. `parseStatement` calls `parseDirectives()` to collect directives
 2. If `hasDirective(directives, "directive")` and the next token is `Fn`, call `parseDirectiveDefStatement(directives)` instead of `parseFnStatement`
 3. The directive arg validation (target required, named-only, value-type checks, allowed-target set) is enforced inside `parseDirectiveDefStatement` directly via `parseError`
 4. `@directive` is **not registered** in `directive_meta.cpp` — `validateDirective` would reject it as unknown if it ever reached that path
 
 **Why**: The `target` argument shapes the AST representation (extracted into `DirectiveDefStmt.targets`), so it must be validated at the same point the AST node is built. Registry-routed validators only see the directive args after parsing, which is too late to influence node construction. The early-intercept pattern also lets the parser emit precise diagnostics like `@directive must be followed by 'fn'` and `@directive cannot be combined with other directives` at the right source location.
 
-**How to apply**: If you add another annotation that produces a dedicated AST node (rather than just decorating an existing statement), follow the same pattern — intercept in `parseStatement` before `validateDirective`, build the dedicated node inside a helper, and skip registry registration. Conversely, do **not** add `@directive` to `builtinDirectiveRegistry()` — it would create a phantom validator that never fires.
+**How to apply**: If you add another directive that produces a dedicated AST node (rather than just attaching to an existing statement), follow the same pattern — intercept in `parseStatement` before `validateDirective`, build the dedicated node inside a helper, and skip registry registration. Conversely, do **not** add `@directive` to `builtinDirectiveRegistry()` — it would create a phantom validator that never fires.
 
 **Adjacent invariants**:
 - `DirectiveDefStmt.targets` is always `std::vector<std::string>`. Bare-string sugar `target="function"` is canonicalized into `{"function"}` at parse time, so downstream consumers (codegen, formatter, future #710 signature builder) never see the bare-string form.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 - **Pattern Matching** — `case` expressions with enum / `Option` / `Result` / literal / tuple / record destructuring, guard clauses (`x if x > 0`), exhaustiveness checking
 - **F-String** — String interpolation with `f"Hello {name}"`
 - **Design by Contract** — `require` (preconditions), `ensure` (postconditions), `invariant` (record invariants)
-- **Directives** — `@deprecated`, `@const`, `@native`, `@parallel`, `@inline`, `@each`, `@property`, `@describe`, `@it` and other compile-time metadata directives
+- **Directives** — `@deprecated`, `@const`, `@native`, `@parallel`, `@inline`, `@each`, `@property`, `@describe`, `@it` and other compile-time instructions
 - **Functions** — `fn` definitions, recursion, overloading, lambdas (closures), higher-order functions, UFCS
 - **Control Flow** — `if`/`else`, `case`, `while`, `for...in`, `break`/`continue`
 - **File I/O** — File read/write, byte operations, standard input (`std.io`)

--- a/changelog.d/1422-directive-terminology-alignment.md
+++ b/changelog.d/1422-directive-terminology-alignment.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Aligned directive terminology in a parser code comment (`src/parser_decl.cpp` `parseDirectiveDefStatement`), in the `@directive` definition section of `.claude/rules/parser-conventions.md`, and in the `README.md` / `docs/README.md` overview lines — now all consistently use "directive(s)" / "compile-time instructions" rather than "annotation(s)" / "decorating" / "compile-time metadata", matching the canonical definition in `docs/reference/directives.md`. (#1422)

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,5 +33,5 @@ For detailed language specifications, see the reference pages below.
 | [Testing](reference/testing.md) | Testing with describe/it/expect |
 | [Project Management](reference/project.md) | ry init and package.toml specification |
 | [Design by Contract](reference/contracts.md) | require, ensure, invariant |
-| [Directives](reference/directives.md) | @deprecated and compile-time metadata |
+| [Directives](reference/directives.md) | @deprecated and other compile-time instructions |
 | [Error List](reference/errors.md) | Compile errors and runtime errors |

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -323,7 +323,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
 StmtNode Parser::parseDirectiveDefStatement(const Directive *dirAnnot) {
     int annotLine = dirAnnot->loc.line;
 
-    // Validate annotation arguments: named-only, target is required,
+    // Validate directive arguments: named-only, target is required,
     // no duplicates.
     const DirectiveArg *targetArg = nullptr;
     for (const auto &arg : dirAnnot->args) {


### PR DESCRIPTION
Closes #1422.

## Summary

`docs/reference/directives.md:3` defines `@name` markers as **directives**, deliberately avoiding "annotation" / "decorator" / "attribute" because Ry uses "type annotation" for the unrelated `: type` ascription concept.

A terminology audit found a small number of places that drifted from this convention. This PR aligns them.

## Changes

| File | Before | After |
|---|---|---|
| `src/parser_decl.cpp:326` (comment in `parseDirectiveDefStatement`) | `Validate annotation arguments` | `Validate directive arguments` |
| `.claude/rules/parser-conventions.md:251` | `to collect annotations` | `to collect directives` |
| `.claude/rules/parser-conventions.md:258` | `another annotation that produces ... rather than just decorating` | `another directive that produces ... rather than just attaching to` |
| `docs/README.md:36` | `@deprecated and compile-time metadata` | `@deprecated and other compile-time instructions` |
| `README.md:18` | `... and other compile-time metadata directives` | `... and other compile-time instructions` |

The `.claude/rules/parser-conventions.md` updates are the highest-leverage fix — that file is auto-loaded when editing `src/parser_*.cpp`, so the wrong terminology there had been quietly available to propagate into future code comments.

## Out of scope (verified false positives)

- All `type annotation` / `return type annotation` mentions in `src/codegen_*.cpp`, `tests/`, `include/ry/ast.hpp` — these refer to `: type` ascriptions and are correct.
- `docs/reference/directives.md:3`'s mention of "decorators" / "annotations" / "attributes" — deliberate cross-language comparison.
- `#pragma once` C++ preprocessor lines.

## Test plan

- [x] `cmake --build build` — green (72 targets)
- [x] `./build/ry_tests` — 1990 / 1990 passed
- [x] `./build/ry test -p` — 168 spec files, 0 failures
- [x] No behavior change (comments and markdown only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated reference materials to consistently describe directives as compile-time instructions.

* **Chores**
  * Aligned directive terminology throughout documentation and comments by replacing inconsistent terms with standardized vocabulary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->