### PR TITLE
feat(directives): silent no-op when user-defined directive applied outside target=[...] (#1425)

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -263,6 +263,22 @@ catch it because the bug is specific to the identifier-adjacent case.
 - Formatter always emits `target=[...]` (List form), even when the source used the bare-string sugar. `FormatterTest.DirectiveDefBareStringSugarCanonicalises` locks this in.
 - After #1397: required params (no default value) are recorded in `DirectiveSignature::positional_param_names` (in declaration order) so they may be passed either positionally or by name at the use site. Optional params (with default) remain in `named_params` (named-only). The `validateDirectiveSignature` shared validator detects positional+named duplicates and missing-required errors using the `positional_param_names` list. Built-in directives leave `positional_param_names` empty for backward compatibility — their existing positional-only semantics are preserved because `min_positional`/`max_positional` still gate them.
 
+### User-defined directives applied outside `target=[...]` are silent no-ops
+
+**Source**: #1425 (2026-04-28, implementation)
+**Tags**: codegen, directive, target, silent-no-op, validateDirectives, allowed_targets, parser-asymmetry
+
+**Rule**: When a user-defined directive declared via `@directive(target=[...])` is applied to a node whose kind is **not** in the declared target list, codegen silently skips the directive — no error, no warning, no effect. `validateDirectives()` (`src/codegen_fn.cpp`) takes a `DirectiveTarget current` parameter; for each user-defined directive it `continue`s when `sig.allowed_targets != 0 && !hasTarget(sig.allowed_targets, current)`, so `validateDirectiveSignature()` is never called and any future effect-firing logic guarded by the same check stays inactive too. Argument validation is therefore also skipped on a target mismatch, which is intentional and matches the v0.0.15 spec — a later minor may upgrade this to a warning.
+
+**Why**: v0.0.15 wants `@directive(...)` to support tag-style usage where a directive declared for one site can be sprinkled on adjacent sites without breaking compilation. Erroring out would force users to declare a separate directive per target; warning would require a noise budget the project does not yet have. Skipping silently keeps the door open for future warning escalation while preserving today's "harmless" semantics.
+
+**How to apply**:
+- Every call site of `validateDirectives()` must pass an explicit `DirectiveTarget`. Today the call sites are: `FnStmt` (Function), `RecordStmt` and field directives in `emitStmt(RecordStmt)` (Record, Field), `AssignStmt` and `TupleDestructStmt` (Statement), `CallStmt` (Statement — currently unreachable from user source, see below), and `ForStmt` (ForLoop).
+- Built-in directives go through the `validateDirectiveArgs()` registry path inside `validateDirectives()` and are unaffected by the target check — that mismatch detection is intentionally out of scope (#1425 "Out of scope").
+- The `sig.allowed_targets != 0` guard is defensive: parser already requires `target=[...]` to be non-empty (`src/parser_decl.cpp` rejects the empty list), but if a future change ever permits "any target", `allowed_targets == 0` will fall back to validate-everything rather than silently skip.
+
+**Parser-side asymmetry — important**: `src/parser.cpp:460-462` and `:718-720` reject every user-defined directive on `for` statements (only `@parallel` is allowed) and on function-call statements (only the special `@each` / `@property` on `it(...)` form is allowed) at parse time. Those parse errors fire **before** codegen `validateDirectives()` ever runs, so the silent-no-op behavior is unobservable at those sites today. The codegen wiring for `DirectiveTarget::ForLoop` and the `CallStmt` path remains as defensive prep so that if/when the parser is later relaxed, no second codegen change is required to land silent-no-op semantics. Regression tests `ForLoopRejectsUserDirectiveAtParseTime` and `CallStmtRejectsUserDirectiveAtParseTime` in `tests/test_codegen_directive.cpp` lock in the current parser behavior; the positive silent-no-op tests cover Function / Record / Field / Statement / TupleDestruct sites that the parser already permits. Parser relaxation is tracked as #1427 — when it lands, those two `EXPECT_THROW` regression-guard tests need to be flipped to `EXPECT_NO_THROW` per the "Relaxing a rejection branch …" rule in `.claude/rules/tests-rejection-tdd.md`.
+
 ### Formatter→parser roundtrip: `TupleDestructStmt` must not emit `: ` between pattern and `=`
 
 **Source**: #1189 (2026-04-19, implementation)

--- a/changelog.d/1425-directive-target-silent-noop.md
+++ b/changelog.d/1425-directive-target-silent-noop.md
@@ -1,0 +1,3 @@
+### Changed
+
+- User-defined directives applied to a target outside their declared `target=[...]` list now silently no-op instead of triggering undefined behavior. The compile succeeds, no diagnostic is emitted, and the directive's argument validation is also skipped. Built-in directives are unaffected. Note that for-loop and function-call use sites still reject all user-defined directives at the parser level (tracked separately in #1427). (#1425)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -555,7 +555,9 @@ When the target *does* match, every constraint applies as usual: missing require
 
 This silent-no-op resolution is intentional for v0.0.15 to support tag-style usage of user-defined directives. A later minor version may upgrade the diagnostic to a warning.
 
-**Parser-level limitations.** Today the parser rejects every user-defined directive on `for` statements (only `@parallel` is permitted there) and on function-call statements (only the special `@each` / `@property` on `it(...)` form is permitted). Those rejections fire before the silent-no-op rule runs, so attaching a user-defined directive to either site is still a parse error rather than a silent no-op — even when the directive declares `target=["for"]` or `target=["statement"]`. Relaxing those parser sites is tracked separately and would automatically pick up the silent-no-op behavior once the parse-time gates are widened.
+#### Parser-level limitations
+
+Today the parser rejects every user-defined directive on `for` statements (only `@parallel` is permitted there) and on function-call statements (only the special `@each` / `@property` on `it(...)` form is permitted). Those rejections fire before the silent-no-op rule runs, so attaching a user-defined directive to either site is still a parse error rather than a silent no-op — even when the directive declares `target=["for"]` or `target=["statement"]`. Relaxing those parser sites is tracked separately and would automatically pick up the silent-no-op behavior once the parse-time gates are widened.
 
 ### Export and import
 

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -19,7 +19,7 @@ Directives can be applied to the following declarations:
 - `record` - Record definitions
 - Variable declarations (with or without `@const`)
 - Fields within a `record` definition
-- `for` - Counted loops; among built-ins, only `@parallel` targets `for` (user-defined directives may also declare `target=["for"]`)
+- `for` - Counted loops; among built-ins, only `@parallel` targets `for` (user-defined directives may also declare `target=["for"]`, but parser-level limitations currently prevent applying user-defined directives at `for` use sites — see [Parser-level limitations](#parser-level-limitations))
 - `it` / `describe` calls (legacy lambda form) - Test cases and test groups for `@each` and `@property`
 
 ## Built-in Directives
@@ -533,6 +533,29 @@ fn other_fn() -> int:
 ```
 
 Each parameter may be supplied either positionally or by name, but not both forms for the same parameter — `@logged("hello", label="hi")` is rejected as a duplicate, and likewise `@cached(3600, ttl=7200)` is rejected. `@logged(unknown="y")` is rejected: only declared parameter names may appear at the use site. `@logged()` is rejected when `label` is required (defaulted parameters may still be omitted).
+
+### Target mismatch is a silent no-op
+
+Applying a user-defined directive to a node that is not in its declared `target=[...]` list is a **silent no-op**: compilation and execution proceed normally, no warning or error is produced, and any future effects of the directive (metadata registration, runtime hooks) are suppressed. Argument validation is also skipped for the mismatching application, so a missing required argument does not surface a diagnostic when the target is wrong.
+
+```ry
+@directive(target=["function"])
+fn audit(label: str)
+
+@audit("hello")          # function-only directive applied to a record
+record User:             # → silently ignored, User compiles normally
+    id: int
+
+@audit                   # missing required argument — also silent because
+record Other:            #   the target still doesn't match
+    id: int
+```
+
+When the target *does* match, every constraint applies as usual: missing required arguments, unknown named arguments, and duplicate bindings are all rejected at compile time.
+
+This silent-no-op resolution is intentional for v0.0.15 to support tag-style usage of user-defined directives. A later minor version may upgrade the diagnostic to a warning.
+
+**Parser-level limitations.** Today the parser rejects every user-defined directive on `for` statements (only `@parallel` is permitted there) and on function-call statements (only the special `@each` / `@property` on `it(...)` form is permitted). Those rejections fire before the silent-no-op rule runs, so attaching a user-defined directive to either site is still a parse error rather than a silent no-op — even when the directive declares `target=["for"]` or `target=["statement"]`. Relaxing those parser sites is tracked separately and would automatically pick up the silent-no-op behavior once the parse-time gates are widened.
 
 ### Export and import
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1113,7 +1113,7 @@ public:
         const std::vector<ExprPtr> *postconditions,
         const std::vector<std::string> *ensureBindings);
     void applyInlineDirective(llvm::Function *func, const std::vector<Directive> &directives);
-    void validateDirectives(const std::vector<Directive> &directives);
+    void validateDirectives(const std::vector<Directive> &directives, DirectiveTarget current);
     llvm::Type *tryResolveType(const std::string &typeName);
     void emitStmt(std::unique_ptr<CaseStmt> &s);
     llvm::Value *emitPatternTest(const Pattern &pattern, llvm::Value *subjectVal,

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -393,7 +393,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
 void CodeGen::emitStmt(CallStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
-    validateDirectives(s.directives);
+    validateDirectives(s.directives, DirectiveTarget::Statement);
     if (!s.named_args.empty() && builtins_.find(s.callee) == builtins_.end())
         codegenError(s.loc, "named arguments are only supported for builtin functions");
     if (s.callee == "describe") {

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -5,9 +5,9 @@ namespace ry {
 
 void CodeGen::emitStmt(RecordStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
-    validateDirectives(s.directives);
+    validateDirectives(s.directives, DirectiveTarget::Record);
     for (const auto &f : s.fields)
-        validateDirectives(f.directives);
+        validateDirectives(f.directives, DirectiveTarget::Field);
     emitTraceSymbolDefine("record", s.name, s.loc);
     if (record_types_.count(s.name))
         codegenError("redefined type: " + s.name);

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -484,17 +484,24 @@ void CodeGen::forwardDeclareNestedFunctions(std::vector<StmtNode> &body) {
 
 // ===== Directive validation helper =====
 
-void CodeGen::validateDirectives(const std::vector<Directive> &directives) {
+void CodeGen::validateDirectives(const std::vector<Directive> &directives, DirectiveTarget current) {
     SourceLocation saved_loc = current_loc_;
     for (const auto &d : directives) {
         if (d.loc.isValid()) current_loc_ = d.loc;
 
         try {
             auto userIt = user_directive_registry_.find(d.name);
-            if (userIt != user_directive_registry_.end())
-                validateDirectiveSignature(d.name, d.args, userIt->second);
-            else
+            if (userIt != user_directive_registry_.end()) {
+                // Parser guarantees allowed_targets != 0 for user-defined
+                // directives; the != 0 guard is defensive against a future
+                // relaxation of that invariant.
+                const auto &sig = userIt->second;
+                if (sig.allowed_targets != 0 && !hasTarget(sig.allowed_targets, current))
+                    continue;
+                validateDirectiveSignature(d.name, d.args, sig);
+            } else {
                 validateDirectiveArgs(d.name, d.args);
+            }
         } catch (const std::runtime_error &e) {
             codegenError(e.what());
         }
@@ -507,7 +514,7 @@ void CodeGen::validateDirectives(const std::vector<Directive> &directives) {
 void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
     if (s->loc.isValid()) current_loc_ = s->loc;
 
-    validateDirectives(s->directives);
+    validateDirectives(s->directives, DirectiveTarget::Function);
 
     // Directive-based test case: @it("description") on a named function.
     // Dispatch before coverage/trace so the inner emitStmt(s) call (after

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -1026,7 +1026,7 @@ void CodeGen::emitStmt(ExprStmt &s) {
 void CodeGen::emitStmt(AssignStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
-    validateDirectives(s.directives);
+    validateDirectives(s.directives, DirectiveTarget::Statement);
     bool is_const = hasDirective(s.directives, "const");
     bool is_native = hasDirective(s.directives, "native");
 

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -79,7 +79,7 @@ void CodeGen::emitStmt(std::unique_ptr<WhileStmt> &s) {
 void CodeGen::emitStmt(std::unique_ptr<ForStmt> &s) {
     emitCoverage(s->loc);
     current_loc_ = s->loc;
-    validateDirectives(s->directives);
+    validateDirectives(s->directives, DirectiveTarget::ForLoop);
     if (hasDirective(s->directives, "parallel")) {
         if (!isSingleVariableForBinding(s->binding))
             codegenError(s->loc, "@parallel for does not support destructuring iteration");

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -638,7 +638,7 @@ void CodeGen::emitStmt(EnumStmt &s) {
 void CodeGen::emitStmt(TupleDestructStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
-    validateDirectives(s.directives);
+    validateDirectives(s.directives, DirectiveTarget::Statement);
     llvm::Value *tupleVal = emitExpr(*s.value);
     llvm::StructType *structTy = llvm::dyn_cast<llvm::StructType>(tupleVal->getType());
     if (!structTy)

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1649,3 +1649,120 @@ TEST_F(DirectiveTest, BareItRejectedWithoutTestingImport) {
         std::runtime_error
     );
 }
+
+// ===== #1425: silent no-op when user-defined directive applied outside target=[...] =====
+//
+// Issue #1425 resolves user-defined directive target-mismatch behavior to
+// silent no-op: the directive's effect (future metadata/hooks) is suppressed,
+// argument validation is skipped, and no diagnostic is produced. The use site
+// continues compiling and executing normally.
+
+// `@audit(target=["function"])` applied to a record is silently ignored — the
+// record still compiles. This is the central example from issue #1425.
+TEST_F(DirectiveTest, FunctionOnlyAppliedToRecordCompiles) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"])\n"
+        "fn audit(label: str)\n"
+        "@audit(\"hello\")\n"
+        "record User:\n"
+        "    id: int\n"
+    ));
+}
+
+// `target=["function"]` applied to a record field is silently ignored.
+TEST_F(DirectiveTest, FunctionOnlyAppliedToFieldCompiles) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"])\n"
+        "fn audit(label: str)\n"
+        "record User:\n"
+        "    @audit(\"hi\")\n"
+        "    id: int\n"
+    ));
+}
+
+// `target=["function"]` applied to an assignment statement is silently ignored.
+TEST_F(DirectiveTest, FunctionOnlyAppliedToStatementCompiles) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"])\n"
+        "fn audit(label: str)\n"
+        "@audit(\"hi\")\n"
+        "total = 1\n"
+    ));
+}
+
+// `target=["function"]` applied to a tuple-destructure statement is silently
+// ignored. Covers the `TupleDestructStmt` validateDirectives call site.
+TEST_F(DirectiveTest, FunctionOnlyAppliedToTupleDestructCompiles) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"])\n"
+        "fn audit(label: str)\n"
+        "@audit(\"hi\")\n"
+        "a, b = (1, 2)\n"
+    ));
+}
+
+// Regression guard for `src/parser.cpp:718-720`: the parser rejects every
+// directive on function-call statements at parse time (only the special
+// `@each` / `@property` on `it(...)` form is permitted). The codegen-level
+// silent no-op for `DirectiveTarget::Statement` on `CallStmt` is therefore
+// unreachable from user-written Ry source today — the wiring remains as
+// defensive prep for if/when the parser is later relaxed.
+TEST_F(DirectiveTest, CallStmtRejectsUserDirectiveAtParseTime) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"])\n"
+            "fn audit(label: str)\n"
+            "@audit(\"hi\")\n"
+            "print(1)\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// Regression guard for `src/parser.cpp:460-462`: the parser rejects every
+// user-defined directive on `for` statements at parse time (only `@parallel`
+// is allowed). The codegen-level silent no-op for `DirectiveTarget::ForLoop`
+// is therefore unreachable from Ry source today — it remains as defensive
+// wiring for if/when the parser is later relaxed (tracked separately).
+TEST_F(DirectiveTest, ForLoopRejectsUserDirectiveAtParseTime) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"])\n"
+            "fn audit(label: str)\n"
+            "@audit(\"hi\")\n"
+            "for i in range(3):\n"
+            "    print(i)\n"
+        ),
+        std::runtime_error
+    );
+}
+
+// On a target mismatch, argument validation is also skipped — even a missing
+// required argument compiles silently. The arg-validation skip is the
+// observable mechanism that proves the silent-no-op guard fires before
+// `validateDirectiveSignature`.
+TEST_F(DirectiveTest, MismatchSilencesArgValidation) {
+    EXPECT_NO_THROW(compileSource(
+        "@directive(target=[\"function\"])\n"
+        "fn audit(label: str)\n"
+        "@audit\n"  // missing required arg, but target=record so silent
+        "record User:\n"
+        "    id: int\n"
+    ));
+}
+
+// Regression guard: when the target matches, argument validation still fires
+// — a missing required argument throws as before. Pairs with
+// `MismatchSilencesArgValidation` to lock both halves of the spec.
+TEST_F(DirectiveTest, TargetMatchStillValidatesArgs) {
+    EXPECT_THROW(
+        compileSource(
+            "@directive(target=[\"function\"])\n"
+            "fn audit(label: str)\n"
+            "@audit\n"  // missing required arg, target matches → throws
+            "fn target_fn() -> int:\n"
+            "    return 1\n"
+        ),
+        std::runtime_error
+    );
+}


### PR DESCRIPTION
## Summary

Resolves #1425. User-defined directives declared with `@directive(target=[...])` now silently no-op when applied to a node whose kind is not in the declared target list. Compilation and execution proceed normally, no diagnostic is emitted, and argument validation is also skipped on a target mismatch. Built-in directives are unaffected.

## Changes

- `validateDirectives()` (`src/codegen_fn.cpp`) takes a new `DirectiveTarget current` parameter; user-defined directives whose `allowed_targets` mask does not include `current` are skipped via early `continue` before `validateDirectiveSignature()` is called.
- All 7 call sites updated to pass the appropriate target: `FnStmt` (Function), `RecordStmt` and field directives (Record, Field), `AssignStmt` / `TupleDestructStmt` / `CallStmt` (Statement), `ForStmt` (ForLoop).
- `include/ry/codegen.hpp` — `validateDirectives` signature updated.
- `docs/reference/directives.md` — added "Target mismatch is a silent no-op" subsection with example code, plus a "Parser-level limitations" note covering the for-loop and function-call asymmetries. Quick-table line-22 cross-references the new section.
- `.claude/rules/parser-conventions.md` — new entry documenting the silent-no-op rule and the parser/codegen asymmetry for future contributors.
- `changelog.d/1425-directive-target-silent-noop.md` — Changed-section fragment.

## Tests

8 new GTest cases in `tests/test_codegen_directive.cpp`:
- 4 silent-no-op positive cases: `FunctionOnlyAppliedToRecordCompiles`, `FunctionOnlyAppliedToFieldCompiles`, `FunctionOnlyAppliedToStatementCompiles`, `FunctionOnlyAppliedToTupleDestructCompiles`
- 2 parser-rejection regression guards: `CallStmtRejectsUserDirectiveAtParseTime`, `ForLoopRejectsUserDirectiveAtParseTime` — locks current parser behavior; flipping these to `EXPECT_NO_THROW` is the gate when parser relaxation lands (tracked in #1427)
- 1 `MismatchSilencesArgValidation` — demonstrates that target mismatch also skips arg validation
- 1 `TargetMatchStillValidatesArgs` — regression guard ensuring target match still validates args

## Out of scope

Per the issue body:
- Warning/error escalation for target mismatch (deferred to a future minor)
- Built-in directive target checking
- `target=[]` syntax (parser still rejects)
- User-defined directive effect implementation (metadata registration, runtime hooks)

## Follow-up

Parser-level relaxation for `for` and function-call use sites is filed as #1427. When it lands, the two `EXPECT_THROW` regression guards above should be flipped to `EXPECT_NO_THROW` per `.claude/rules/tests-rejection-tdd.md`.

## Test plan

- [x] `cmake --build build` clean
- [x] `./build/ry_tests` — 1998 tests pass
- [x] `./build/ry test -p` — 168 self-test files pass
- [x] ASan+UBSan clean (`./build-asan/ry_tests` + `./build-asan/ry test -p`)
- [x] TSan C++ tests clean (`./build-tsan/ry_tests`)
- [x] clang-tidy + cppcheck clean
- [x] libFuzzer (parser/json/utf8) — 60s each, exit 0
- [x] Issue's primary example outputs `99` (exit 0)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * User-defined directives applied to unsupported targets now silently no-op: compilation proceeds, argument validation is skipped, and no diagnostics are emitted for mismatched targets.

* **Documentation**
  * Clarified directive docs to describe silent no-op behavior for wrong targets and reaffirm validation still applies when targets match.

* **Tests**
  * Added tests verifying silent no-op behavior for mismatched targets and preserving parse-time rejections and argument validation where applicable.

* **Chores**
  * Added changelog entry documenting the behavior change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->