### PR TITLE
chore(skill): /preparing-for-release also opens Release cleanup issue

### DIFF
--- a/.claude/skills/preparing-for-release/SKILL.md
+++ b/.claude/skills/preparing-for-release/SKILL.md
@@ -1,16 +1,16 @@
 ---
 name: preparing-for-release
-description: Open the two issues (Release prep + Release) under a version's milestone to drive the tag-push release flow. Pass the version as the argument (e.g. `0.0.14` or `v0.0.14`); the skill asks if absent.
+description: Open three issues (Release prep + Release + Release cleanup) under a version's milestone to drive the tag-push release flow. Pass the version as the argument (e.g. `0.0.14` or `v0.0.14`); the skill asks if absent.
 allowed-tools: Bash(gh issue:*), Bash(gh api:*)
 metadata:
-  short-description: Open prep + release issues for a target version
+  short-description: Open prep + release + cleanup issues for a target version
 ---
 
 # Preparing for Release
 
-Open the **Release prep** issue and the **Release** issue under the target version's milestone, kicking off the tag-push driven release flow described in `AGENTS.md` "リリースワークフロー".
+Open the **Release prep** issue, the **Release** issue, and the **Release cleanup** issue under the target version's milestone, kicking off the tag-push driven release flow described in `AGENTS.md` "リリースワークフロー".
 
-> **Note:** This skill only files issues. The actual CHANGELOG aggregation and tag push are performed in those issues using the standard issue-driven flow (`git-claim-issue` → feature branch → PR → `git-merge-pr`).
+> **Note:** This skill only files issues. Release prep (CHANGELOG aggregation) and Release (tag push) use the standard issue-driven flow (`git-claim-issue` → feature branch → PR → `git-merge-pr`). Release cleanup is verification-only (`gh run list`, `gh release view`, `gh api PATCH milestone`) — no branch or PR needed.
 
 ## Repository
 
@@ -48,7 +48,7 @@ gh api "repos/t0k0sh1/ry/milestones?state=open" \
 ```bash
 gh issue list --milestone "v<X.Y.Z>" --state open \
   --json number,title \
-  --jq '[.[] | select(.title == "Release prep: v<X.Y.Z>" or .title == "Release: v<X.Y.Z>")]'
+  --jq '[.[] | select(.title == "Release prep: v<X.Y.Z>" or .title == "Release: v<X.Y.Z>" or .title == "Release cleanup: v<X.Y.Z>")]'
 ```
 
 - Strict title match is intentional — `--search` is full-text and can hit unrelated issues.
@@ -204,24 +204,95 @@ Tell the user:
 
 - The tag `v<X.Y.Z>` has been pushed
 - `release.yml` is now running — link: <https://github.com/t0k0sh1/ry/actions/workflows/release.yml>
-- They should watch the workflow, and once the GitHub Release is published, close the milestone (per `/release-orchestrator` "マイルストーン close ポリシー")
+- They should watch the workflow — once `release.yml` finishes and the GitHub Release is published, proceed to the Release cleanup issue (also in this milestone) to verify artifacts and close the milestone
 
 Then **stop**. Do not poll the workflow, do not auto-close the milestone — those steps belong to the human owner.
 
 ## Out of scope
 
 - Editing `CHANGELOG.md` (done by prep issue #<P>)
-- Closing the milestone (done by the human owner after the GitHub Release publishes)
+- Closing the milestone (done by the Release cleanup issue in this milestone)
 EOF
 )"
 ````
 
 Capture the new issue number from the URL printed by `gh issue create` — call it `<R>`.
 
-### Step 6: Report
+### Step 6: Create the Release cleanup issue
+
+**Substitution rules before invocation:**
+
+- Replace every `<X.Y.Z>` placeholder with the validated version.
+- Replace every `<R>` placeholder with the release issue number captured in Step 5.
+- Leave everything else as literals — the cleanup worker verifies and executes as-is.
+
+````bash
+gh issue create \
+  --repo t0k0sh1/ry \
+  --title "Release cleanup: v<X.Y.Z>" \
+  --milestone "v<X.Y.Z>" \
+  --body "$(cat <<'EOF'
+## Goal
+
+Verify the v<X.Y.Z> release artifacts are healthy and close the milestone.
+
+## Prerequisites
+
+- Release issue #<R> is closed (= the tag has been pushed and `release.yml` has finished)
+
+## Tasks
+
+### 1. Verify release.yml run
+
+```bash
+gh run list --repo t0k0sh1/ry --workflow release.yml --limit 5 \
+  --json status,conclusion,headBranch \
+  --jq '.[] | select(.headBranch == "v<X.Y.Z>")'
+```
+
+Expect `status=completed`, `conclusion=success`.
+
+### 2. Verify the GitHub Release
+
+```bash
+gh release view v<X.Y.Z> --repo t0k0sh1/ry \
+  --json tagName,name,isDraft,isPrerelease,publishedAt
+```
+
+Expect `isDraft=false`, `isPrerelease=false`, `publishedAt` populated.
+
+### 3. Verify v<X.Y.Z>-nightly was deleted
+
+```bash
+gh api repos/t0k0sh1/ry/releases/tags/v<X.Y.Z>-nightly
+git ls-remote --tags origin v<X.Y.Z>-nightly
+```
+
+Both should be empty / 404 (release.yml deletes the matching nightly per #1365).
+
+### 4. Close the milestone
+
+```bash
+MS_NUM=$(gh api 'repos/t0k0sh1/ry/milestones?state=open' \
+  --jq '.[] | select(.title == "v<X.Y.Z>") | .number')
+gh api -X PATCH "repos/t0k0sh1/ry/milestones/$MS_NUM" -f state=closed
+```
+
+## Out of scope
+
+- Creating the next milestone (intentionally a separate, deliberate act)
+- Bumping any docs/version files (none today)
+EOF
+)"
+````
+
+Capture the new issue number from the URL printed by `gh issue create` — call it `<C>`.
+
+### Step 7: Report
 
 Report to the user with:
 
 - Release prep issue: `#<P> Release prep: v<X.Y.Z>` and its URL
 - Release issue: `#<R> Release: v<X.Y.Z>` and its URL
-- A note that work should start with `#<P>` (claim with `git-claim-issue`).
+- Release cleanup issue: `#<C> Release cleanup: v<X.Y.Z>` and its URL
+- A note that work should start with `#<P>` (claim with `git-claim-issue`), and that `#<C>` should be addressed after `#<R>` is closed.

--- a/.claude/skills/release-orchestrator/SKILL.md
+++ b/.claude/skills/release-orchestrator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release-orchestrator
-description: リリース起動手順 — マイルストーン feature-complete 後に /preparing-for-release を起動し、Release prep + Release issue を進める。タグ push 駆動の release.yml 自動ビルドの概要も含む。Use when "リリース" / "タグ push" / "リリース手順" / "milestone close" / "バージョンリリース" / "v0.x.y" を扱うとき。
+description: リリース起動手順 — マイルストーン feature-complete 後に /preparing-for-release を起動し、Release prep + Release + Release cleanup issue を進める。タグ push 駆動の release.yml 自動ビルドの概要も含む。Use when "リリース" / "タグ push" / "リリース手順" / "milestone close" / "バージョンリリース" / "v0.x.y" を扱うとき。
 allowed-tools: Bash(gh issue:*), Bash(gh milestone:*), Bash(git tag:*), Bash(git push:*)
 ---
 
@@ -24,13 +24,14 @@ Entry-point reference for the ry release flow. Routes the user to `/preparing-fo
 
 ## Hand-off
 
-1. `/preparing-for-release <X.Y.Z>` を起動する。スキルが当該マイルストーンに以下 2 つの issue を作成する:
+1. `/preparing-for-release <X.Y.Z>` を起動する。スキルが当該マイルストーンに以下 3 つの issue を作成する:
    - **Release prep: v<X.Y.Z>** — `changelog.d/` を `CHANGELOG.md` に集約し `[X.Y.Z] - YYYY-MM-DD` セクションを確定させる作業。通常の issue 駆動フロー (claim → feature branch → PR → merge) で実施
    - **Release: v<X.Y.Z>** — prep が merge された後、マイルストーンに残 issue が無いことを確認してタグを push する作業
+   - **Release cleanup: v<X.Y.Z>** — タグ push 後、`release.yml` 完了・GitHub Release 公開・nightly タグ削除を確認し、マイルストーンを close する作業 (verification-only、branch・PR 不要)
 2. Release prep issue を通常通り進める (`git-claim-issue` → Plan → 実装 → `git-merge-pr`)
 3. Release prep PR が main にマージされたら Release issue に着手し、その手順に従ってタグを push する
-4. `release.yml` が GitHub Release を公開するのを確認し、対応するマイルストーンを close する (→「マイルストーン close ポリシー」)
+4. Release issue が close されたら、同マイルストーン内の Release cleanup issue に着手し、`release.yml` 完了・GitHub Release 公開・nightly タグ削除を確認してからマイルストーンを close する (→「マイルストーン close ポリシー」)
 
 ## マイルストーン close ポリシー
 
-milestone は最後のリリース成果物 (タグ + GitHub Release) が公開された時点で close する。配下の issue が全部 close されただけでは close しない (= main マージ完了 ≠ リリース完了)。
+milestone close は「全 issue close ≠ リリース完了」の原則のもと、リリース成果物 (タグ + GitHub Release) の公開確認後に行う。具体的な手順は Release cleanup issue に従うこと。


### PR DESCRIPTION
## Summary

- `/preparing-for-release` が作成する issue を 2 → 3 個に拡張し、新しい `Release cleanup: v<X.Y.Z>` issue を自動作成する
- cleanup issue は `release.yml` 完了 / GitHub Release 公開 / nightly タグ削除の検証と milestone close を tracking する (verification-only、branch・PR 不要)
- `/release-orchestrator` の Hand-off Step 4 と「マイルストーン close ポリシー」を cleanup issue 駆動の流れに合わせて更新

Closes #1433

## Test plan

- [x] `jq` の 3-way OR フィルタを dry-run で文法確認 (`echo '[{"title":"Release cleanup: v0.0.16"},...]' | jq '...'` が期待値を返却)
- [x] `git diff` で意図どおりの変更箇所のみ反映されていることを確認
- [x] Step 4 (Release prep) HEREDOC は完全不変
- [x] Step 5 (Release) HEREDOC は L207 / L214 の 2 行のみ変更で `<X.Y.Z>` `<P>` `<NEXT>` の置換ルールは不変
- [ ] **次サイクル (v0.0.16) で実走確認** — `/preparing-for-release 0.0.16` が 3 つの issue (prep / release / cleanup) を milestone 配下に作成することをマージ後の release cycle で smoke test