### PR TITLE
docs(naming): add v0.0.16 naming convention reference (#1410)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Reference documentation for Ry's v0.0.16 naming conventions (`docs/reference/naming.md`): camelCase for functions/variables/fields, PascalCase for records/enums/type aliases, acronym first-letter-only rule, approved abbreviations table, and verbose-by-intent rationale for `toInt`/`toStr`. (#1410)
+
 ## [0.0.15] - 2026-04-28
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ For detailed language specifications, see the reference pages below.
 
 | Page | Contents |
 |------|----------|
+| [Naming Conventions](reference/naming.md) | camelCase / PascalCase rules, approved abbreviations, acronym rule |
 | [Types and Type Rules](reference/types.md) | All types, type promotion rules, type conversion |
 | [Operators and Precedence](reference/operators.md) | All operators and precedence table |
 | [Control Flow](reference/control-flow.md) | Complete grammar for if/else, case, while, for |

--- a/docs/reference/naming.md
+++ b/docs/reference/naming.md
@@ -1,0 +1,91 @@
+# Naming Conventions
+
+Ry uses two casing styles for identifiers: `camelCase` for runtime values and `PascalCase` for type-like declarations. This page is the single source of truth for the convention; per-feature reference pages refer back here instead of restating the rules.
+
+**Scope.** This page covers casing rules and abbreviations. Two related conventions live elsewhere: the trailing `!` suffix that marks mutating functions is documented in [Functions](functions.md), and the leading `_` prefix that marks package-private names is documented in [Packages](packages.md).
+
+## Overview
+
+| Identifier | Casing | Examples |
+|------------|--------|----------|
+| Functions, methods | `camelCase` | `httpGet`, `parseJson`, `readText` |
+| Local variables, parameters | `camelCase` | `userName`, `byteCount`, `nextId` |
+| Record fields | `camelCase` | `firstName`, `responseCode`, `headerMap` |
+| Records | `PascalCase` | `Point`, `HttpRequest`, `UserProfile` |
+| Enums and enum variants | `PascalCase` | `Color`, `LogLevel`, `Red`, `Green` |
+| Type aliases | `PascalCase` | `UserId`, `Bytes` |
+| Built-in constructors (unchanged) | `PascalCase` | `Some`, `None`, `Ok`, `Err`, `Error` |
+
+## Functions, variables, and fields
+
+Names of functions, methods, local variables, parameters, and record fields use `camelCase`: the first word is lowercase and each subsequent word starts with an uppercase letter. Treat record fields as a kind of variable — they follow the same rule as ordinary bindings, not the type-name rule of their enclosing record.
+
+Examples: `httpGet`, `parseJson`, `userName`, `byteCount`, `firstName`, `responseCode`.
+
+## Records, enums, and type aliases
+
+Names that introduce a type — `record` declarations, `enum` declarations (and the variants inside them), and type aliases — use `PascalCase`: every word starts with an uppercase letter and there are no separators.
+
+Examples: `Point`, `HttpRequest`, `UserProfile`, `LogLevel`, `Red`, `Green`, `UserId`, `Bytes`.
+
+## Built-in constructors
+
+The standard library's variant constructors `Some`, `None`, `Ok`, `Err`, and `Error` were already `PascalCase` before v0.0.16 and are unchanged.
+
+## Acronym rule
+
+When an acronym appears inside a `camelCase` or `PascalCase` identifier, capitalize only its first letter. The rest of the acronym stays lowercase, so it visually behaves like any other word.
+
+| Convention | Correct | Incorrect |
+|------------|---------|-----------|
+| `camelCase` | `httpGet`, `parseJson`, `urlEncode` | `HTTPGet`, `parseJSON`, `URLEncode` |
+| `PascalCase` | `HttpRequest`, `JsonParser`, `UrlBuilder` | `HTTPRequest`, `JSONParser`, `URLBuilder` |
+
+The reason is uniformity: a fully-capitalized acronym (`HTTPGet`) breaks the visual word boundary that `camelCase` relies on, leaving the next word ambiguous (`HTTPGet` vs. `HttpGet`). The first-letter-only rule keeps every identifier scannable left-to-right.
+
+## Approved abbreviations
+
+The following abbreviations are accepted across the language and standard library. Outside this table, prefer the full word.
+
+| Abbreviation | Full form | Used for |
+|--------------|-----------|----------|
+| `args` | arguments | Function and CLI argument lists |
+| `substr` | substring | String slicing helpers |
+| `mkdir` | make directory | Filesystem package (POSIX-aligned) |
+| `mkdirAll` | make directory (recursive) | Filesystem package |
+| `ext` | extension | Path and filename helpers |
+| `len` | length | Sequence size queries |
+| `flat` | flatten | Collection helpers |
+| `glob` | glob pattern | Filesystem helpers |
+
+`length` is removed entirely in v0.0.16. Use `len` everywhere — there is no `length` alias and no deprecation period.
+
+## Verbose-by-intent: `toInt`, `toStr`, ...
+
+The conversion helpers `toInt`, `toStr`, `toFloat`, and `toBool` keep their `to`-prefix instead of becoming `int`, `str`, `float`, `bool`. The short forms collide with the type names of the same spelling, so `int(x)` could mean either "convert `x` to an int" or "the type `int` itself", and disambiguating would force the parser into context-sensitive lookup. Keeping the `to`-prefix removes the collision at the source.
+
+The verbosity is intentional, not an oversight; do not propose `int` / `str` aliases.
+
+## No ad-hoc abbreviations
+
+Outside the approved table above, do not invent shortenings. Names like `cnt` (for `count`), `n` (for any meaningful integer), `buf` (for `buffer`), `idx` (for `index`), `tmp` (for `temporary`), and `cfg` (for `config`) are not accepted in stdlib code.
+
+The motivation is reading-time clarity. `count` reads correctly on the first pass; `cnt` requires the reader to expand it mentally. Multiplied across an entire standard library and the prompts that include slices of it, the cumulative cost is non-trivial.
+
+## Rationale
+
+Two reasons drove the move from `snake_case` to `camelCase` (functions, variables, fields) and a stricter `PascalCase` (records, enums, type aliases):
+
+1. **AI tooling and token efficiency.** `camelCase` and `PascalCase` identifiers tokenize more compactly than `snake_case` in most modern LLM tokenizers, because the underscore frequently splits an identifier into multiple tokens. Compactness matters when prompts include large slices of stdlib source.
+2. **Alignment with mainstream standard libraries.** JavaScript (`fetch`, `parseInt`, `Map`, `Promise`) and Go (`strings.Builder`, `http.Request`, `unicode/utf8`) consistently combine `camelCase` for callables with `PascalCase` for types. Python is the notable counterexample, mandating `snake_case` for callables, but Ry targets the same systems-level niche as Go and aligning with that stack reduces cognitive friction for users coming from it.
+
+## Migration notes (v0.0.15 → v0.0.16)
+
+This page describes the convention as of v0.0.16. Several other reference pages currently still describe the v0.0.15 compiler's behavior:
+
+- `functions.md`, `records.md`, and `types.md` still describe the v0.0.15 rule that user-defined names must be `snake_case`.
+- Those pages will be updated by the per-package rename PRs that ship under issue #1409 (sub-issues #1411 through #1417).
+
+If a per-feature page disagrees with this page during the transition, **this page is authoritative for v0.0.16 and the per-feature page reflects the v0.0.15 status quo until its rename PR lands**. Compiler enforcement of the new casing flips with #1417.
+
+There is no `snake_case → camelCase` alias layer. The change is a hard switch; old names are removed, not deprecated.

--- a/docs/reference/naming.md
+++ b/docs/reference/naming.md
@@ -1,6 +1,6 @@
 # Naming Conventions
 
-Ry uses two casing styles for identifiers: `camelCase` for runtime values and `PascalCase` for type-like declarations. This page is the single source of truth for the convention; per-feature reference pages refer back here instead of restating the rules.
+Ry uses two casing styles for identifiers: `camelCase` for runtime values and `PascalCase` for type-like declarations. This page is the single source of truth for the convention; per-feature pages link here instead of restating the rules.
 
 **Scope.** This page covers casing rules and abbreviations. Two related conventions live elsewhere: the trailing `!` suffix that marks mutating functions is documented in [Functions](functions.md), and the leading `_` prefix that marks package-private names is documented in [Packages](packages.md).
 
@@ -68,7 +68,7 @@ The verbosity is intentional, not an oversight; do not propose `int` / `str` ali
 
 ## No ad-hoc abbreviations
 
-Outside the approved table above, do not invent shortenings. Names like `cnt` (for `count`), `n` (for any meaningful integer), `buf` (for `buffer`), `idx` (for `index`), `tmp` (for `temporary`), and `cfg` (for `config`) are not accepted in stdlib code.
+Outside the approved table above, do not invent shortenings. Names like `cnt` (for `count`), `n` (for any meaningful integer), `buf` (for `buffer`), `idx` (for `index`), `tmp` (for `temporary`), and `cfg` (for `config`) are not accepted in any Ry code — the rule applies to user code as well as the standard library, matching the scope of the approved abbreviation table above.
 
 The motivation is reading-time clarity. `count` reads correctly on the first pass; `cnt` requires the reader to expand it mentally. Multiplied across an entire standard library and the prompts that include slices of it, the cumulative cost is non-trivial.
 


### PR DESCRIPTION
## Summary

Closes #1410.

Introduces `docs/reference/naming.md` as the **single source of truth** for Ry's v0.0.16 identifier convention. Subsequent rename PRs (#1411–#1417) will cite this page rather than restating the rules.

- `camelCase` for functions, methods, local variables, parameters, and **record fields**
- `PascalCase` for `record`, `enum` (and variants), and type aliases
- Built-in constructors `Some` / `None` / `Ok` / `Err` / `Error` are unchanged
- Acronym rule: first-letter-only (`httpGet` ○, `HTTPGet` ×)
- Approved abbreviations table (8 entries: `args`, `substr`, `mkdir`, `mkdirAll`, `ext`, `len`, `flat`, `glob`); `length` is removed entirely in v0.0.16 with no alias
- Verbose-by-intent rationale for `toInt` / `toStr` / `toFloat` / `toBool` (collision with type names)
- Scope disclaimer pointing readers to `functions.md` for the `!` mutation suffix and `packages.md` for the `_` privacy prefix

Also:

- Adds the page to the `docs/README.md` reference table at the top, since naming is a cross-cutting basis for every other page.
- Adds a CHANGELOG entry under `[Unreleased]` → `### Added`.

## Out of scope

- Compiler enforcement of the new casing — flips with #1417.
- Rewriting `functions.md`, `records.md`, `types.md` — handled by the per-package rename PRs (#1411–#1417). The Migration Notes section in `naming.md` explicitly bridges the disagreement period: this page is authoritative for v0.0.16; per-feature pages reflect the v0.0.15 status quo until their rename PR lands.
- Native ABI naming (`__ry_<package>_<fn>` in `packages.md`) is a separate system, unaffected.
- No `snake_case → camelCase` alias layer; the change is a hard switch.

## Test plan

Docs-only change — no automated tests. Self-verification performed:

- [x] All 8 abbreviations present in the table; `length` removal explicitly noted
- [x] 10 unique `##` heading slugs (no GitHub anchor collisions)
- [x] Linked from `docs/README.md` reference index (1 entry, table head)
- [x] Internal links to `functions.md` and `packages.md` resolve to existing files
- [x] Existing pages (`functions.md`, `records.md`, `types.md`) untouched — they still describe v0.0.15 enforcement and will be updated by #1411–#1417
- [x] CHANGELOG section ordering preserved (`[Unreleased]` → `[0.0.15] - 2026-04-28`)
- [x] No fenced code blocks that would require `./build/ry -c` verification (inline backticks only — see `.claude/rules/docs-reference-conventions.md` #825)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Naming Conventions reference describing identifier casing (when to use camelCase vs PascalCase), acronym capitalization rules, an approved abbreviation list (e.g., use "len" rather than "length"), and naming patterns for conversion helpers.
  * Updated the documentation index to link to the new Naming Conventions page and included migration guidance for v0.0.15 → v0.0.16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->