### PR TITLE
refactor(tests/spec): migrate snake_case locals to camelCase (#1451)

### DIFF
--- a/tests/spec/base64.test.ry
+++ b/tests/spec/base64.test.ry
@@ -56,11 +56,11 @@ describe("base64", ():
     )
     it("should use - and _ instead of + and /", ():
       # "?>>" encodes to "Pz4+" in standard, "Pz4-" in URL-safe
-      std_encoded = encode("?>>")
-      url_encoded = encodeUrlSafe("?>>")
-      expect(contains(std_encoded, "+")).toEq(true)
-      expect(contains(url_encoded, "+")).toEq(false)
-      expect(contains(url_encoded, "/")).toEq(false)
+      stdEncoded = encode("?>>")
+      urlEncoded = encodeUrlSafe("?>>")
+      expect(contains(stdEncoded, "+")).toEq(true)
+      expect(contains(urlEncoded, "+")).toEq(false)
+      expect(contains(urlEncoded, "/")).toEq(false)
     )
   )
 
@@ -168,12 +168,12 @@ describe("base64", ():
     it("should use - and _ instead of + and /", ():
       # [0xFB, 0xFF] -> standard "+/w=", url_safe "-_w"
       b = [0xFBu8, 0xFFu8]
-      std_enc = encodeBytes(b)
-      url_enc = encodeBytesUrlSafe(b)
-      expect(contains(std_enc, "+")).toEq(true)
-      expect(contains(url_enc, "+")).toEq(false)
-      expect(contains(url_enc, "/")).toEq(false)
-      expect(contains(url_enc, "=")).toEq(false)
+      stdEnc = encodeBytes(b)
+      urlEnc = encodeBytesUrlSafe(b)
+      expect(contains(stdEnc, "+")).toEq(true)
+      expect(contains(urlEnc, "+")).toEq(false)
+      expect(contains(urlEnc, "/")).toEq(false)
+      expect(contains(urlEnc, "=")).toEq(false)
     )
     it("should encode empty list", ():
       empty: List<u8> = []

--- a/tests/spec/case_unification.test.ry
+++ b/tests/spec/case_unification.test.ry
@@ -136,8 +136,8 @@ describe("if expression single-expression form", ():
 
   it("should compute absolute value using if expression", ():
     x = -7
-    abs_val = if x >= 0 => x else -x
-    expect(abs_val).toEq(7)
+    absVal = if x >= 0 => x else -x
+    expect(absVal).toEq(7)
   )
 
   it("should allow numeric branches", ():

--- a/tests/spec/chained_lhs_assign.test.ry
+++ b/tests/spec/chained_lhs_assign.test.ry
@@ -31,14 +31,14 @@ record LhsDeepBox:
 
 # Module-level counter for side-effect guards. Written from top-level
 # function per #817 pattern.
-chained_lhs_fcalls: int = 0
+chainedLhsFcalls: int = 0
 
 fn chainedLhsResetCounter() -> int:
-  chained_lhs_fcalls = 0
+  chainedLhsFcalls = 0
   return 0
 
 fn chainedLhsFidx() -> int:
-  chained_lhs_fcalls = chained_lhs_fcalls + 1
+  chainedLhsFcalls = chainedLhsFcalls + 1
   return 0
 
 describe("chained LHS plain assign", ():
@@ -210,7 +210,7 @@ describe("chained LHS side-effect guards", ():
     chainedLhsResetCounter()
     grid = [[1, 2], [3, 4]]
     grid[chainedLhsFidx()][chainedLhsFidx()] = 99
-    expect(chained_lhs_fcalls).toEq(2)
+    expect(chainedLhsFcalls).toEq(2)
     expect(grid[0][0]).toEq(99)
     expect(grid[0][1]).toEq(2)
   )
@@ -219,7 +219,7 @@ describe("chained LHS side-effect guards", ():
     chainedLhsResetCounter()
     xs = [10, 20, 30]
     xs[chainedLhsFidx()] += 5
-    expect(chained_lhs_fcalls).toEq(1)
+    expect(chainedLhsFcalls).toEq(1)
     expect(xs[0]).toEq(15)
     expect(xs[1]).toEq(20)
   )

--- a/tests/spec/closure_arc.test.ry
+++ b/tests/spec/closure_arc.test.ry
@@ -1,8 +1,8 @@
 describe("closure ARC — basic lifecycle", ():
   it("should support closure with captured int", ():
     base = 10
-    add_base = (x: int) => x + base
-    expect(add_base(5)).toEq(15)
+    addBase = (x: int) => x + base
+    expect(addBase(5)).toEq(15)
   )
 
   it("should support closure copy (g = f)", ():

--- a/tests/spec/closure_higher_order.test.ry
+++ b/tests/spec/closure_higher_order.test.ry
@@ -31,8 +31,8 @@ describe("closure — function-type parameter capture", ():
 
     double = (x: int) => x * 2
     inc = (x: int) => x + 1
-    double_then_inc = compose(inc, double)
-    expect(double_then_inc(5)).toEq(11)
+    doubleThenInc = compose(inc, double)
+    expect(doubleThenInc(5)).toEq(11)
   )
 
   it("should capture function param in apply_twice", ():

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -732,11 +732,11 @@ describe("Map", ():
   it("should agree with merge() function for + operator", ():
     m1 = {"a": 1, "b": 2}
     m2 = {"b": 99, "c": 3}
-    via_op = m1 + m2
-    via_fn = merge(m1, m2)
-    expect(via_op["a"]).toEq(via_fn["a"])
-    expect(via_op["b"]).toEq(via_fn["b"])
-    expect(via_op["c"]).toEq(via_fn["c"])
+    viaOp = m1 + m2
+    viaFn = merge(m1, m2)
+    expect(viaOp["a"]).toEq(viaFn["a"])
+    expect(viaOp["b"]).toEq(viaFn["b"])
+    expect(viaOp["c"]).toEq(viaFn["c"])
   )
   it("should retain str keys/values on SetItem insert (PR#1346 hotfix)", ():
     # `m[k] = v` where k/v are locally-constructed str must retain both so
@@ -961,14 +961,14 @@ describe("Set", ():
   it("should agree with union() function for + operator", ():
     s1 = {1, 2, 3}
     s2 = {3, 4, 5}
-    via_op = s1 + s2
-    via_fn = union(s1, s2)
-    expect(via_op).toHaveLen(5)
-    expect(via_fn).toHaveLen(5)
-    expect(via_op).toContain(1)
-    expect(via_op).toContain(5)
-    expect(via_fn).toContain(1)
-    expect(via_fn).toContain(5)
+    viaOp = s1 + s2
+    viaFn = union(s1, s2)
+    expect(viaOp).toHaveLen(5)
+    expect(viaFn).toHaveLen(5)
+    expect(viaOp).toContain(1)
+    expect(viaOp).toContain(5)
+    expect(viaFn).toContain(1)
+    expect(viaFn).toContain(5)
   )
   it("should iterate Set<str> preserving element type metadata (PR#1346)", ():
     # Set for-loop must dispatch on set_elem_type_name rather than

--- a/tests/spec/combinatorial/collection_element_enum_iterate.test.ry
+++ b/tests/spec/combinatorial/collection_element_enum_iterate.test.ry
@@ -5,10 +5,10 @@ enum ColElemStatus:
 describe("collection element — enum in List", ():
   it("should filter list of enums by variant", ():
     xs = [ColElemStatus::Active, ColElemStatus::Inactive, ColElemStatus::Active]
-    active_count = 0
+    activeCount = 0
     for s in xs:
       if s == ColElemStatus::Active:
-        active_count = active_count + 1
-    expect(active_count).toEq(2)
+        activeCount = activeCount + 1
+    expect(activeCount).toEq(2)
   )
 )

--- a/tests/spec/combinatorial/collection_element_result_iterate.test.ry
+++ b/tests/spec/combinatorial/collection_element_result_iterate.test.ry
@@ -7,13 +7,13 @@ fn makeErrInt() -> Result<int, Error>:
 describe("collection element — Result in List", ():
   it("should iterate list of results and count Ok values", ():
     xs = [makeOkInt(1), makeErrInt(), makeOkInt(3)]
-    ok_count = 0
+    okCount = 0
     for r in xs:
       case r:
         Ok(_):
-          ok_count = ok_count + 1
+          okCount = okCount + 1
         Err(_):
-          ok_count = ok_count
-    expect(ok_count).toEq(2)
+          okCount = okCount
+    expect(okCount).toEq(2)
   )
 )

--- a/tests/spec/combinatorial/stdlib_boundary.test.ry
+++ b/tests/spec/combinatorial/stdlib_boundary.test.ry
@@ -58,9 +58,9 @@ describe("stdlib boundary — type boundaries", ():
     expect(-1000000000).toEq(-1000000000)
   )
   it("should parse INT64_MAX literal without crashing", ():
-    max_val = 9223372036854775807
-    expect(max_val > 0).toBeTrue()
-    expect(max_val).toEq(9223372036854775807)
+    maxVal = 9223372036854775807
+    expect(maxVal > 0).toBeTrue()
+    expect(maxVal).toEq(9223372036854775807)
   )
   it("should handle float infinity from division", ():
     inf = 1.0 / 0.0

--- a/tests/spec/control_flow.test.ry
+++ b/tests/spec/control_flow.test.ry
@@ -127,13 +127,13 @@ describe("for", ():
   )
   it("should support enumerate destructuring", ():
     xs = [10, 20, 30]
-    idx_sum = 0
-    val_sum = 0
+    idxSum = 0
+    valSum = 0
     for i, x in enumerate(xs):
-      idx_sum = idx_sum + i
-      val_sum = val_sum + x
-    expect(idx_sum).toEq(3)
-    expect(val_sum).toEq(60)
+      idxSum = idxSum + i
+      valSum = valSum + x
+    expect(idxSum).toEq(3)
+    expect(valSum).toEq(60)
   )
   it("should support zip destructuring", ():
     sum = 0
@@ -143,16 +143,16 @@ describe("for", ():
   )
   it("should support 3-element tuple destructuring", ():
     triples = [(1, 2, 3), (4, 5, 6)]
-    sum_a = 0
-    sum_b = 0
-    sum_c = 0
+    sumA = 0
+    sumB = 0
+    sumC = 0
     for a, b, c in triples:
-      sum_a = sum_a + a
-      sum_b = sum_b + b
-      sum_c = sum_c + c
-    expect(sum_a).toEq(5)
-    expect(sum_b).toEq(7)
-    expect(sum_c).toEq(9)
+      sumA = sumA + a
+      sumB = sumB + b
+      sumC = sumC + c
+    expect(sumA).toEq(5)
+    expect(sumB).toEq(7)
+    expect(sumC).toEq(9)
   )
   it("should support 3-element destructuring with wildcard", ():
     triples = [(1, 2, 3), (4, 5, 6)]

--- a/tests/spec/cow_path.test.ry
+++ b/tests/spec/cow_path.test.ry
@@ -128,12 +128,12 @@ describe("path CoW", ():
     it("should isolate module-global record alias", ():
       # Exercise emitPathCowForChain's findModuleGlobal branch: alias
       # the top-level record into a local and mutate through the local.
-      local_box = cow_global_box
-      local_box.items[0] = 999
+      localBox = cow_global_box
+      localBox.items[0] = 999
       expect(cow_global_box.items[0]).toEq(1)
-      expect(local_box.items[0]).toEq(999)
+      expect(localBox.items[0]).toEq(999)
       # Reset for test isolation.
-      local_box.items[0] = 1
+      localBox.items[0] = 1
     )
   )
 

--- a/tests/spec/env.test.ry
+++ b/tests/spec/env.test.ry
@@ -20,8 +20,8 @@ describe("env", ():
   )
 
   it("should canonicalize RY_ENV when set", ():
-    ry_env = env("RY_ENV")
-    case ry_env:
+    ryEnv = env("RY_ENV")
+    case ryEnv:
       Some(v):
         expect(v).toNotEq("production")
         expect(v).toNotEq("development")

--- a/tests/spec/for_loop_destructure_meta.test.ry
+++ b/tests/spec/for_loop_destructure_meta.test.ry
@@ -14,10 +14,10 @@ describe("for-loop destructure preserves collection element metadata (#813)", ()
 
   it("should preserve Map element type in enumerate over list of maps", ():
     ms: List<Map<str, int>> = [{"a": 1}, {"b": 2, "c": 3}]
-    total_size: int = 0
+    totalSize: int = 0
     for i, mm in enumerate(ms):
-      total_size = total_size + len(mm)
-    expect(total_size).toEq(3)
+      totalSize = totalSize + len(mm)
+    expect(totalSize).toEq(3)
   )
 
   it("should preserve List element type in zip left side", ():

--- a/tests/spec/for_mutation.test.ry
+++ b/tests/spec/for_mutation.test.ry
@@ -6,11 +6,11 @@ describe("for mutation safety", ():
     # dataPtr becomes dangling -> use-after-free.  After the fix, the loop
     # snapshots the list at entry and iterates only the original 3 elements.
     ys = [10, 20, 30]
-    seen_sum = 0
+    seenSum = 0
     for y in ys:
-      seen_sum = seen_sum + y
+      seenSum = seenSum + y
       append!(ys, y + 100)
-    expect(seen_sum).toEq(60)
+    expect(seenSum).toEq(60)
     expect(len(ys)).toEq(6)
   )
 
@@ -18,35 +18,35 @@ describe("for mutation safety", ():
     # Shrink case: remove() CoW-forks the list; the snapshot still holds the
     # original three elements.
     ys = [10, 20, 30]
-    seen_sum = 0
+    seenSum = 0
     for y in ys:
-      seen_sum = seen_sum + y
+      seenSum = seenSum + y
       remove(ys, y)
-    expect(seen_sum).toEq(60)
+    expect(seenSum).toEq(60)
     expect(len(ys)).toEq(0)
   )
 
   it("should not visit appended elements when appending to list in nested loop", ():
     # Both outer and inner loops must each see only their own snapshot.
     xs = [1, 2, 3]
-    outer_count = 0
+    outerCount = 0
     for x in xs:
-      outer_count = outer_count + 1
-      inner_count = 0
+      outerCount = outerCount + 1
+      innerCount = 0
       for z in xs:
-        inner_count = inner_count + 1
+        innerCount = innerCount + 1
         append!(xs, x + z)
         break
-    expect(outer_count).toEq(3)
+    expect(outerCount).toEq(3)
   )
 
   it("should not visit appended elements when appending during tuple destructure iteration", ():
     pairs = [(1, 10), (2, 20), (3, 30)]
-    sum_a = 0
+    sumA = 0
     for a, b in pairs:
-      sum_a = sum_a + a
+      sumA = sumA + a
       append!(pairs, (a + 10, b + 100))
-    expect(sum_a).toEq(6)
+    expect(sumA).toEq(6)
     expect(len(pairs)).toEq(6)
   )
 
@@ -83,10 +83,10 @@ describe("for mutation safety", ():
   it("should work when iterating over a non-variable iterable expression", ():
     # Iterating over a list literal (non-VarExpr): the retain+snapshot path
     # must work even when iterable is not a simple variable reference.
-    seen_sum = 0
+    seenSum = 0
     for x in [10, 20, 30]:
-      seen_sum = seen_sum + x
-    expect(seen_sum).toEq(60)
+      seenSum = seenSum + x
+    expect(seenSum).toEq(60)
   )
 
   it("should visit all elements including those appended before the loop", ():
@@ -96,10 +96,10 @@ describe("for mutation safety", ():
     ys = [10, 20]
     append!(ys, 30)
     append!(ys, 40)
-    seen_sum = 0
+    seenSum = 0
     for y in ys:
-      seen_sum = seen_sum + y
-    expect(seen_sum).toEq(100)
+      seenSum = seenSum + y
+    expect(seenSum).toEq(100)
     expect(len(ys)).toEq(4)
   )
 )

--- a/tests/spec/for_mutation_field.test.ry
+++ b/tests/spec/for_mutation_field.test.ry
@@ -25,13 +25,13 @@ describe("for mutation safety — FieldAccessExpr iterables (#1041)", ():
     # the old buffer and the loop reads dangling memory (UAF).
     b = ListBag([10, 20, 30])
     count = 0
-    seen_sum = 0
+    seenSum = 0
     for x in b.items:
       count = count + 1
-      seen_sum = seen_sum + x
+      seenSum = seenSum + x
       append!(b.items, x + 100)
     expect(count).toEq(3)
-    expect(seen_sum).toEq(60)
+    expect(seenSum).toEq(60)
     expect(len(b.items)).toEq(6)
   )
 

--- a/tests/spec/for_mutation_index.test.ry
+++ b/tests/spec/for_mutation_index.test.ry
@@ -5,13 +5,13 @@ describe("for mutation safety — IndexExpr iterables (#1091)", ():
     # the loop reads dangling memory (UAF).
     xs: List<List<int>> = [[10, 20, 30]]
     count = 0
-    seen_sum = 0
+    seenSum = 0
     for x in xs[0]:
       count = count + 1
-      seen_sum = seen_sum + x
+      seenSum = seenSum + x
       append!(xs[0], x + 100)
     expect(count).toEq(3)
-    expect(seen_sum).toEq(60)
+    expect(seenSum).toEq(60)
     expect(len(xs[0])).toEq(6)
   )
 
@@ -41,13 +41,13 @@ describe("for mutation safety — IndexExpr iterables (#1091)", ():
     # (unnamed StructType fell through reverseResolveTypeName to "any"), causing
     # emitVarDecl's annotation fallback to be skipped and b to receive wrong metadata.
     xs: List<List<(int, int)>> = [[(1, 2), (3, 4), (5, 6)]]
-    sum_a = 0
-    sum_b = 0
+    sumA = 0
+    sumB = 0
     for a, b in xs[0]:
-      sum_a = sum_a + a
-      sum_b = sum_b + b
-    expect(sum_a).toEq(9)
-    expect(sum_b).toEq(12)
+      sumA = sumA + a
+      sumB = sumB + b
+    expect(sumA).toEq(9)
+    expect(sumB).toEq(12)
   )
 
   it("should iterate over innermost list when accessed via double index (#1095)", ():
@@ -57,12 +57,12 @@ describe("for mutation safety — IndexExpr iterables (#1091)", ():
     # elem metadata was corrupted and the loop ran 0 iterations.
     outer: List<List<List<int>>> = [[[10, 20, 30]]]
     count = 0
-    seen_sum = 0
+    seenSum = 0
     for x in outer[0][0]:
       count = count + 1
-      seen_sum = seen_sum + x
+      seenSum = seenSum + x
     expect(count).toEq(3)
-    expect(seen_sum).toEq(60)
+    expect(seenSum).toEq(60)
   )
 
   it("should not visit appended elements when appending via map index (map of list)", ():
@@ -70,13 +70,13 @@ describe("for mutation safety — IndexExpr iterables (#1091)", ():
     # the loop iterates it while append! via the same index expression grows it.
     m: Map<str, List<int>> = {"key": [10, 20, 30]}
     count = 0
-    seen_sum = 0
+    seenSum = 0
     for x in m["key"]:
       count = count + 1
-      seen_sum = seen_sum + x
+      seenSum = seenSum + x
       append!(m["key"], x + 100)
     expect(count).toEq(3)
-    expect(seen_sum).toEq(60)
+    expect(seenSum).toEq(60)
     expect(len(m["key"])).toEq(6)
   )
 )

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -61,20 +61,20 @@ describe("lambda", ():
     expect(double(5)).toEq(10)
   )
   it("should support multi-line lambda", ():
-    abs_val = (x: int):
+    absVal = (x: int):
       if x < 0:
         return -x
       return x
-    expect(abs_val(-5)).toEq(5)
+    expect(absVal(-5)).toEq(5)
   )
 )
 
 describe("closure", ():
   it("should capture by value", ():
     base = 10
-    add_base = (x: int) => x + base
+    addBase = (x: int) => x + base
     base = 99
-    expect(add_base(5)).toEq(15)
+    expect(addBase(5)).toEq(15)
   )
   it("should capture bool", ():
     flag = true

--- a/tests/spec/http.test.ry
+++ b/tests/spec/http.test.ry
@@ -8,8 +8,8 @@ describe("HTTP Server API", ():
         Ok(conn):
           case receive(conn, 4096):
             Ok(data):
-              response_str = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 6\r\n\r\nHello!"
-              case send(conn, toBytes(response_str)):
+              responseStr = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 6\r\n\r\nHello!"
+              case send(conn, toBytes(responseStr)):
                 Ok(_):
                   ...
                 Err(e):
@@ -59,8 +59,8 @@ describe("HTTP Server API", ():
         Ok(conn):
           case receive(conn, 4096):
             Ok(data):
-              response_str = "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 9\r\n\r\nNot Found"
-              case send(conn, toBytes(response_str)):
+              responseStr = "HTTP/1.1 404 Not Found\r\nContent-Type: text/plain\r\nContent-Length: 9\r\n\r\nNot Found"
+              case send(conn, toBytes(responseStr)):
                 Ok(_):
                   ...
                 Err(e):

--- a/tests/spec/int_overflow.test.ry
+++ b/tests/spec/int_overflow.test.ry
@@ -41,14 +41,14 @@ describe("int overflow safety", ():
     expect(x).toEq(500)
   )
   it("should parse INT64_MIN as a direct literal", ():
-    min_direct = -9223372036854775808
-    expect(min_direct).toEq(-9223372036854775807 - 1)
-    expect(min_direct + 1).toEq(-9223372036854775807)
-    expect(min_direct - 0).toEq(-9223372036854775807 - 1)
+    minDirect = -9223372036854775808
+    expect(minDirect).toEq(-9223372036854775807 - 1)
+    expect(minDirect + 1).toEq(-9223372036854775807)
+    expect(minDirect - 0).toEq(-9223372036854775807 - 1)
   )
   it("should parse INT64_MIN with i64 suffix", ():
-    min_i64 = -9223372036854775808i64
-    expect(min_i64).toEq(-9223372036854775807 - 1)
-    expect(min_i64 + 1i64).toEq(-9223372036854775807)
+    minI64 = -9223372036854775808i64
+    expect(minI64).toEq(-9223372036854775807 - 1)
+    expect(minI64 + 1i64).toEq(-9223372036854775807)
   )
 )

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -1,10 +1,10 @@
 from io import readText, writeText, appendText, exists, deleteFile, readBytes, writeBytes, toBytes, bytesToStr
 
 # Module-global List<u8> for the emitModuleGlobalWriteThrough test (#1085).
-glob_bs: List<u8> = [97, 0, 98]
+globBs: List<u8> = [97, 0, 98]
 
 fn updateGlobBs() -> int:
-  glob_bs = [99, 100, 101]
+  globBs = [99, 100, 101]
   return 0
 
 describe("file I/O", ():
@@ -213,7 +213,7 @@ describe("file I/O", ():
   )
   it("should accept List<u8> module-global reassignment from function (#1085)", ():
     updateGlobBs()
-    case bytesToStr(glob_bs):
+    case bytesToStr(globBs):
       Ok(s):
         expect(s == "cde").toEq(true)
       Err(e):

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -268,8 +268,8 @@ describe("json nested", ():
         case get(data, "user"):
           Ok(user):
             case get(user, "name"):
-              Ok(name_val):
-                case toStr(name_val):
+              Ok(nameVal):
+                case toStr(nameVal):
                   Ok(name):
                     expect(name).toEq("Bob")
                   Err(e):
@@ -277,8 +277,8 @@ describe("json nested", ():
               Err(e):
                 fail("get(name) failed: " + e.message)
             case get(user, "age"):
-              Ok(age_val):
-                case toInt(age_val):
+              Ok(ageVal):
+                case toInt(ageVal):
                   Ok(age):
                     expect(age).toEq(25)
                   Err(e):
@@ -298,8 +298,8 @@ describe("json nested", ():
         case at(data, 1):
           Ok(second):
             case get(second, "id"):
-              Ok(id_val):
-                case toInt(id_val):
+              Ok(idVal):
+                case toInt(idVal):
                   Ok(id):
                     expect(id).toEq(2)
                   Err(e):
@@ -361,8 +361,8 @@ describe("json stringify", ():
         case parse(text):
           Ok(data2):
             case get(data2, "name"):
-              Ok(name_val):
-                case toStr(name_val):
+              Ok(nameVal):
+                case toStr(nameVal):
                   Ok(name):
                     expect(name).toEq("Alice")
                   Err(e):
@@ -429,8 +429,8 @@ describe("json child value ownership", ():
         case get(data, "user"):
           Ok(user):
             case get(user, "name"):
-              Ok(name_val):
-                case toStr(name_val):
+              Ok(nameVal):
+                case toStr(nameVal):
                   Ok(name):
                     expect(name).toEq("Bob")
                   Err(e):

--- a/tests/spec/lambda_ptr_return.test.ry
+++ b/tests/spec/lambda_ptr_return.test.ry
@@ -16,15 +16,15 @@ describe("lambda returning record str field", ():
     price: int
 
   it("should return str field from expression-bodied lambda", ():
-    get_name = (i: Item) => i.name
+    getName = (i: Item) => i.name
     item = Item("apple", 100)
-    expect(get_name(item)).toEq("apple")
+    expect(getName(item)).toEq("apple")
   )
 
   it("should return int field from expression-bodied lambda", ():
-    get_price = (i: Item) => i.price
+    getPrice = (i: Item) => i.price
     item = Item("apple", 100)
-    expect(get_price(item)).toEq(100)
+    expect(getPrice(item)).toEq(100)
   )
 )
 
@@ -37,8 +37,8 @@ describe("lambda returning string literal", ():
 
 describe("lambda returning cast", ():
   it("should return cast result from expression-bodied lambda", ():
-    cast_fn = (x: int) => x as float
-    result = cast_fn(42)
+    castFn = (x: int) => x as float
+    result = castFn(42)
     expect(result).toEq(42.0)
   )
 )
@@ -48,8 +48,8 @@ describe("lambda returning lambda", ():
     fn makeAdder(x: int) -> fn(int) -> int:
       return (y: int) => x + y
 
-    add_ten = makeAdder(10)
-    expect(add_ten(20)).toEq(30)
-    expect(add_ten(5)).toEq(15)
+    addTen = makeAdder(10)
+    expect(addTen(20)).toEq(30)
+    expect(addTen(5)).toEq(15)
   )
 )

--- a/tests/spec/list_concat_arc.test.ry
+++ b/tests/spec/list_concat_arc.test.ry
@@ -40,10 +40,10 @@ describe("list + list ARC retain (#1236)", ():
 
   it("empty + non-empty concat is safe in both directions", ():
     empty_a: List<List<int>> = []
-    nonempty_a: List<List<int>> = [[1, 2], [3, 4]]
-    ys1 = empty_a + nonempty_a
-    ys2 = nonempty_a + empty_a
-    nonempty_a = [[99]]
+    nonemptyA: List<List<int>> = [[1, 2], [3, 4]]
+    ys1 = empty_a + nonemptyA
+    ys2 = nonemptyA + empty_a
+    nonemptyA = [[99]]
     expect(ys1).toHaveLen(2)
     expect(ys2).toHaveLen(2)
   )
@@ -54,26 +54,26 @@ describe("list + list ARC retain (#1236)", ():
   # the element type), the overhead would grow roughly 3 headers per iteration
   # (= ~48 at N=16).  Symmetric retain/release keeps overhead a small constant.
   it("concat does not leak per iteration on List<List<int>>", ():
-    base_before = arcLiveCount()
-    xs_baseline: List<List<int>> = [[0]]
+    baseBefore = arcLiveCount()
+    xsBaseline: List<List<int>> = [[0]]
     i = 0
     while i < 16:
-      xs_baseline = [[1, 2], [3, 4], [5, 6]]
+      xsBaseline = [[1, 2], [3, 4], [5, 6]]
       i = i + 1
-    base_delta = arcLiveCount() - base_before
+    baseDelta = arcLiveCount() - baseBefore
 
-    cat_before = arcLiveCount()
-    a_cat: List<List<int>> = [[0]]
-    b_cat: List<List<int>> = [[0]]
-    ys_cat: List<List<int>> = [[0]]
+    catBefore = arcLiveCount()
+    aCat: List<List<int>> = [[0]]
+    bCat: List<List<int>> = [[0]]
+    ysCat: List<List<int>> = [[0]]
     j = 0
     while j < 16:
-      a_cat = [[1, 2], [3, 4]]
-      b_cat = [[5, 6]]
-      ys_cat = a_cat + b_cat
+      aCat = [[1, 2], [3, 4]]
+      bCat = [[5, 6]]
+      ysCat = aCat + bCat
       j = j + 1
-    cat_delta = arcLiveCount() - cat_before
+    catDelta = arcLiveCount() - catBefore
 
-    expect(cat_delta - base_delta < 10).toEq(true)
+    expect(catDelta - baseDelta < 10).toEq(true)
   )
 )

--- a/tests/spec/list_range_index.test.ry
+++ b/tests/spec/list_range_index.test.ry
@@ -142,24 +142,24 @@ describe("list range-index ARC retain (#1204)", ():
   # element type), the overhead would grow roughly 2 headers per iteration
   # (= ~32 at N=16).  Symmetric retain/release keeps overhead a small constant.
   it("slice does not leak per iteration on List<List<int>>", ():
-    base_before = arcLiveCount()
-    xs_baseline: List<List<int>> = [[0]]
+    baseBefore = arcLiveCount()
+    xsBaseline: List<List<int>> = [[0]]
     i = 0
     while i < 16:
-      xs_baseline = [[1, 2], [3, 4], [5, 6]]
+      xsBaseline = [[1, 2], [3, 4], [5, 6]]
       i = i + 1
-    base_delta = arcLiveCount() - base_before
+    baseDelta = arcLiveCount() - baseBefore
 
-    slice_before = arcLiveCount()
-    xs_slice: List<List<int>> = [[0]]
-    ys_slice: List<List<int>> = [[0]]
+    sliceBefore = arcLiveCount()
+    xsSlice: List<List<int>> = [[0]]
+    ysSlice: List<List<int>> = [[0]]
     j = 0
     while j < 16:
-      xs_slice = [[1, 2], [3, 4], [5, 6]]
-      ys_slice = xs_slice[0..1]
+      xsSlice = [[1, 2], [3, 4], [5, 6]]
+      ysSlice = xsSlice[0..1]
       j = j + 1
-    slice_delta = arcLiveCount() - slice_before
+    sliceDelta = arcLiveCount() - sliceBefore
 
-    expect(slice_delta - base_delta < 10).toEq(true)
+    expect(sliceDelta - baseDelta < 10).toEq(true)
   )
 )

--- a/tests/spec/list_take_arc.test.ry
+++ b/tests/spec/list_take_arc.test.ry
@@ -43,24 +43,24 @@ describe("take() ARC retain (#1235)", ():
   # the element type), the overhead would grow roughly 2 headers per iteration
   # (= ~32 at N=16).  Symmetric retain/release keeps overhead a small constant.
   it("take does not leak per iteration on List<List<int>>", ():
-    base_before = arcLiveCount()
-    xs_baseline: List<List<int>> = [[0]]
+    baseBefore = arcLiveCount()
+    xsBaseline: List<List<int>> = [[0]]
     i = 0
     while i < 16:
-      xs_baseline = [[1, 2], [3, 4], [5, 6]]
+      xsBaseline = [[1, 2], [3, 4], [5, 6]]
       i = i + 1
-    base_delta = arcLiveCount() - base_before
+    baseDelta = arcLiveCount() - baseBefore
 
-    take_before = arcLiveCount()
-    xs_take: List<List<int>> = [[0]]
-    ys_take: List<List<int>> = [[0]]
+    takeBefore = arcLiveCount()
+    xsTake: List<List<int>> = [[0]]
+    ysTake: List<List<int>> = [[0]]
     j = 0
     while j < 16:
-      xs_take = [[1, 2], [3, 4], [5, 6]]
-      ys_take = take(xs_take, 2)
+      xsTake = [[1, 2], [3, 4], [5, 6]]
+      ysTake = take(xsTake, 2)
       j = j + 1
-    take_delta = arcLiveCount() - take_before
+    takeDelta = arcLiveCount() - takeBefore
 
-    expect(take_delta - base_delta < 10).toEq(true)
+    expect(takeDelta - baseDelta < 10).toEq(true)
   )
 )

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -147,8 +147,8 @@ describe("TCP socket API", ():
           Ok(_):
             port = listenerPort(server)
             t = runServer(server)
-            resp_msg = runClient(port)
-            expect(resp_msg).toEq("echo:hello")
+            respMsg = runClient(port)
+            expect(respMsg).toEq("echo:hello")
             blockOn(t)
           Err(e):
             fail("unexpected error")

--- a/tests/spec/option_branch_merge_none.test.ry
+++ b/tests/spec/option_branch_merge_none.test.ry
@@ -138,8 +138,8 @@ describe("None() in condition should not be affected by arm hint (#1154)", ():
 
 describe("annotation seed does not leak into function arguments (#1154)", ():
   it("none passed to identity function should use its own type, not LHS annotation", ():
-    id_opt = (o: Option<int>) -> Option<int> => o
-    x: Option<int> = id_opt(none)
+    idOpt = (o: Option<int>) -> Option<int> => o
+    x: Option<int> = idOpt(none)
     expect(x).toBeNone()
   )
 )

--- a/tests/spec/option_map.test.ry
+++ b/tests/spec/option_map.test.ry
@@ -9,12 +9,12 @@ describe("Option map", ():
 
   it("should return None when mapping None", ():
     o: int? = None
-    got_none = false
+    gotNone = false
     result = o.map((x: int) => x * 2)
     case result:
       Some(_): fail("expected None but got Some")
-      None: got_none = true
-    expect(got_none).toEq(true)
+      None: gotNone = true
+    expect(gotNone).toEq(true)
   )
 
   it("should support chained map", ():
@@ -35,11 +35,11 @@ describe("Option map", ():
 
   it("should preserve None through chained map", ():
     o: int? = None
-    got_none = false
+    gotNone = false
     result = o.map((x: int) => x + 5).map((x: int) => x * 2)
     case result:
       Some(_): fail("expected None but got Some")
-      None: got_none = true
-    expect(got_none).toEq(true)
+      None: gotNone = true
+    expect(gotNone).toEq(true)
   )
 )

--- a/tests/spec/option_none_call.test.ry
+++ b/tests/spec/option_none_call.test.ry
@@ -5,10 +5,10 @@
 # paths were broken in let-decl and reassignment contexts because
 # isNoneLiteral did not recognise CallExpr{"None", args.empty()}.
 
-g_none_call_opt: Option<int> = Some(1)
+gNoneCallOpt: Option<int> = Some(1)
 
 fn gNoneCallReset():
-  g_none_call_opt = None()
+  gNoneCallOpt = None()
 
 fn acceptNoneOpt(o: Option<int>) -> bool:
   return case o:
@@ -44,7 +44,7 @@ describe("None() in local variable reassignment (#1099)", ():
 describe("None() in module-global reassignment (#1099)", ():
   it("should reassign module-global Option<int> to None()", ():
     gNoneCallReset()
-    expect(acceptNoneOpt(g_none_call_opt)).toEq(true)
+    expect(acceptNoneOpt(gNoneCallOpt)).toEq(true)
   )
 )
 

--- a/tests/spec/pattern_enum_nested.test.ry
+++ b/tests/spec/pattern_enum_nested.test.ry
@@ -39,34 +39,34 @@ describe("enum constructor pattern - nested tuple literal", ():
 describe("enum constructor pattern - nested variable binding", ():
     it("should bind x and y from Event::Click((x, y))", ():
         e = Event::Click(3, 7)
-        x_out = 0
-        y_out = 0
+        xOut = 0
+        yOut = 0
         case e:
             Event::Click((x, y)):
-                x_out = x
-                y_out = y
+                xOut = x
+                yOut = y
             _:
-                x_out = -1
-                y_out = -1
-        expect(x_out).toEq(3)
-        expect(y_out).toEq(7)
+                xOut = -1
+                yOut = -1
+        expect(xOut).toEq(3)
+        expect(yOut).toEq(7)
     )
 )
 
 describe("enum constructor pattern - backward compat (flat bindings)", ():
     it("should still work with Event::Click(a, b)", ():
         e = Event::Click(10, 20)
-        a_out = 0
-        b_out = 0
+        aOut = 0
+        bOut = 0
         case e:
             Event::Click(a, b):
-                a_out = a
-                b_out = b
+                aOut = a
+                bOut = b
             _:
-                a_out = -1
-                b_out = -1
-        expect(a_out).toEq(10)
-        expect(b_out).toEq(20)
+                aOut = -1
+                bOut = -1
+        expect(aOut).toEq(10)
+        expect(bOut).toEq(20)
     )
 )
 
@@ -86,52 +86,52 @@ describe("enum constructor pattern - nested literal (single field)", ():
 
     it("should fall through to variable binding when literal does not match", ():
         w = Wrapper::Val(99)
-        n_out = 0
+        nOut = 0
         case w:
             Wrapper::Val(42):
-                n_out = -1
+                nOut = -1
             Wrapper::Val(n):
-                n_out = n
+                nOut = n
             _:
-                n_out = -2
-        expect(n_out).toEq(99)
+                nOut = -2
+        expect(nOut).toEq(99)
     )
 )
 
 describe("enum constructor pattern - mixed literal and variable", ():
     it("should bind y from Wrapper::Pair(0, y)", ():
         p = Wrapper::Pair(0, 99)
-        y_out = 0
+        yOut = 0
         case p:
             Wrapper::Pair(0, y):
-                y_out = y
+                yOut = y
             _:
-                y_out = -1
-        expect(y_out).toEq(99)
+                yOut = -1
+        expect(yOut).toEq(99)
     )
 
     it("should not match Wrapper::Pair(0, y) when first field is non-zero", ():
         p = Wrapper::Pair(5, 99)
-        y_out = 0
+        yOut = 0
         case p:
             Wrapper::Pair(0, y):
-                y_out = y
+                yOut = y
             _:
-                y_out = -1
-        expect(y_out).toEq(-1)
+                yOut = -1
+        expect(yOut).toEq(-1)
     )
 )
 
 describe("enum constructor pattern - wildcard in nested tuple", ():
     it("should bind y2 from Event::Click((_, y2))", ():
         e = Event::Click(5, 8)
-        y2_out = 0
+        y2Out = 0
         case e:
             Event::Click((_, y2)):
-                y2_out = y2
+                y2Out = y2
             _:
-                y2_out = -1
-        expect(y2_out).toEq(8)
+                y2Out = -1
+        expect(y2Out).toEq(8)
     )
 )
 
@@ -151,12 +151,12 @@ describe("enum constructor pattern - no match falls through to wildcard", ():
 describe("enum constructor pattern - regression: non-nested variant", ():
     it("should bind k from Event::Key(k)", ():
         e = Event::Key("enter")
-        k_out = ""
+        kOut = ""
         case e:
             Event::Key(k):
-                k_out = k
+                kOut = k
             _:
-                k_out = "other"
-        expect(k_out).toEq("enter")
+                kOut = "other"
+        expect(kOut).toEq("enter")
     )
 )

--- a/tests/spec/pattern_record.test.ry
+++ b/tests/spec/pattern_record.test.ry
@@ -26,49 +26,49 @@ record Segment:
 describe("record pattern - binding", ():
   it("should destructure a 2-field record", ():
     p = Point(3, 4)
-    a_out = 0
-    b_out = 0
+    aOut = 0
+    bOut = 0
     case p:
       Point(a, b):
-        a_out = a
-        b_out = b
+        aOut = a
+        bOut = b
       _:
-        a_out = -1
-        b_out = -1
-    expect(a_out).toEq(3)
-    expect(b_out).toEq(4)
+        aOut = -1
+        bOut = -1
+    expect(aOut).toEq(3)
+    expect(bOut).toEq(4)
   )
 
   it("should destructure a 3-field record", ():
     t = Triple(10, 20, 30)
-    x_out = 0
-    y_out = 0
-    z_out = 0
+    xOut = 0
+    yOut = 0
+    zOut = 0
     case t:
       Triple(x, y, z):
-        x_out = x
-        y_out = y
-        z_out = z
+        xOut = x
+        yOut = y
+        zOut = z
       _:
-        x_out = -1
-        y_out = -1
-        z_out = -1
-    expect(x_out).toEq(10)
-    expect(y_out).toEq(20)
-    expect(z_out).toEq(30)
+        xOut = -1
+        yOut = -1
+        zOut = -1
+    expect(xOut).toEq(10)
+    expect(yOut).toEq(20)
+    expect(zOut).toEq(30)
   )
 )
 
 describe("record pattern - mixed literal and wildcard", ():
   it("should match with a literal first field", ():
     p = Point(0, 5)
-    y_out = -1
+    yOut = -1
     case p:
       Point(0, y):
-        y_out = y
+        yOut = y
       _:
-        y_out = -2
-    expect(y_out).toEq(5)
+        yOut = -2
+    expect(yOut).toEq(5)
   )
 
   it("should not match when literal does not equal field value", ():
@@ -84,13 +84,13 @@ describe("record pattern - mixed literal and wildcard", ():
 
   it("should match with wildcard ignoring second field", ():
     p = Point(7, 99)
-    x_out = 0
+    xOut = 0
     case p:
       Point(x, _):
-        x_out = x
+        xOut = x
       _:
-        x_out = -1
-    expect(x_out).toEq(7)
+        xOut = -1
+    expect(xOut).toEq(7)
   )
 
   it("should match with all wildcards", ():
@@ -133,42 +133,42 @@ describe("record pattern - nested", ():
   it("should match a record pattern inside a tuple", ():
     p = Point(5, 6)
     t = (p, 99)
-    x_out = 0
+    xOut = 0
     case t:
       (Point(x, _), _):
-        x_out = x
+        xOut = x
       _:
-        x_out = -1
-    expect(x_out).toEq(5)
+        xOut = -1
+    expect(xOut).toEq(5)
   )
 
   it("should match record-in-record (nested heads)", ():
     seg = Segment(Point(1, 2), Point(3, 4))
-    x1_out = 0
-    x2_out = 0
+    x1Out = 0
+    x2Out = 0
     case seg:
       Segment(Point(x1, _), Point(x2, _)):
-        x1_out = x1
-        x2_out = x2
+        x1Out = x1
+        x2Out = x2
       _:
-        x1_out = -1
-        x2_out = -1
-    expect(x1_out).toEq(1)
-    expect(x2_out).toEq(3)
+        x1Out = -1
+        x2Out = -1
+    expect(x1Out).toEq(1)
+    expect(x2Out).toEq(3)
   )
 )
 
 describe("record pattern - exhaustiveness", ():
   it("case Point(a, b) with no wildcard should compile (irrefutable)", ():
     p = Point(5, 6)
-    a_out = 0
-    b_out = 0
+    aOut = 0
+    bOut = 0
     case p:
       Point(a, b):
-        a_out = a
-        b_out = b
-    expect(a_out).toEq(5)
-    expect(b_out).toEq(6)
+        aOut = a
+        bOut = b
+    expect(aOut).toEq(5)
+    expect(bOut).toEq(6)
   )
 )
 

--- a/tests/spec/pattern_tuple.test.ry
+++ b/tests/spec/pattern_tuple.test.ry
@@ -13,47 +13,47 @@
 describe("tuple pattern - binding", ():
   it("should destructure a 2-tuple binding", ():
     t = (10, 20)
-    a_out = 0
-    b_out = 0
+    aOut = 0
+    bOut = 0
     case t:
       (x, y):
-        a_out = x
-        b_out = y
+        aOut = x
+        bOut = y
       _:
-        a_out = -1
-        b_out = -1
-    expect(a_out).toEq(10)
-    expect(b_out).toEq(20)
+        aOut = -1
+        bOut = -1
+    expect(aOut).toEq(10)
+    expect(bOut).toEq(20)
   )
 
   it("should destructure a 3-tuple binding", ():
     t = (1, 2, 3)
-    a_out = 0
-    b_out = 0
-    c_out = 0
+    aOut = 0
+    bOut = 0
+    cOut = 0
     case t:
       (x, y, z):
-        a_out = x
-        b_out = y
-        c_out = z
+        aOut = x
+        bOut = y
+        cOut = z
       _:
-        a_out = -1
-        b_out = -1
-        c_out = -1
-    expect(a_out).toEq(1)
-    expect(b_out).toEq(2)
-    expect(c_out).toEq(3)
+        aOut = -1
+        bOut = -1
+        cOut = -1
+    expect(aOut).toEq(1)
+    expect(bOut).toEq(2)
+    expect(cOut).toEq(3)
   )
 
   it("should destructure a 1-tuple (trailing comma)", ():
     t = (42,)
-    v_out = 0
+    vOut = 0
     case t:
       (v,):
-        v_out = v
+        vOut = v
       _:
-        v_out = -1
-    expect(v_out).toEq(42)
+        vOut = -1
+    expect(vOut).toEq(42)
   )
 )
 
@@ -82,24 +82,24 @@ describe("tuple pattern - literal and mixed", ():
 
   it("should match mixed literal + binding pattern", ():
     t = (1, 99)
-    n_out = 0
+    nOut = 0
     case t:
       (1, n):
-        n_out = n
+        nOut = n
       _:
-        n_out = -1
-    expect(n_out).toEq(99)
+        nOut = -1
+    expect(nOut).toEq(99)
   )
 
   it("should match wildcard + binding pattern", ():
     t = (55, 77)
-    n_out = 0
+    nOut = 0
     case t:
       (_, n):
-        n_out = n
+        nOut = n
       _:
-        n_out = -1
-    expect(n_out).toEq(77)
+        nOut = -1
+    expect(nOut).toEq(77)
   )
 )
 
@@ -156,14 +156,14 @@ describe("tuple pattern - nested (tuple as outer container)", ():
 describe("tuple pattern - exhaustiveness", ():
   it("case (x, y) should be treated as irrefutable (no wildcard needed)", ():
     t = (5, 6)
-    a_out = 0
-    b_out = 0
+    aOut = 0
+    bOut = 0
     case t:
       (x, y):
-        a_out = x
-        b_out = y
-    expect(a_out).toEq(5)
-    expect(b_out).toEq(6)
+        aOut = x
+        bOut = y
+    expect(aOut).toEq(5)
+    expect(bOut).toEq(6)
   )
 )
 
@@ -240,13 +240,13 @@ describe("regression - existing patterns unaffected", ():
     # Regression guard: isTupleStructType-based guard must not reject genuine
     # annotated tuple subjects, only Option/Result/record/ADT/union structs.
     ss: (str, str) = ("hello", "world")
-    x_out = ""
-    y_out = ""
+    xOut = ""
+    yOut = ""
     case ss:
       (x, y):
-        x_out = x
-        y_out = y
-    expect(x_out).toEq("hello")
-    expect(y_out).toEq("world")
+        xOut = x
+        yOut = y
+    expect(xOut).toEq("hello")
+    expect(yOut).toEq("world")
   )
 )

--- a/tests/spec/resource_arc.test.ry
+++ b/tests/spec/resource_arc.test.ry
@@ -38,8 +38,8 @@ describe("ARC resource cleanup", ():
     t = threadSpawn(():
       atomicIntStore(result, 99)
     )
-    join_result = threadJoin(t)
-    expect(join_result).toBeOk()
+    joinResult = threadJoin(t)
+    expect(joinResult).toBeOk()
     val = atomicIntLoad(result)
     expect(val).toEq(99)
     atomicIntFree(result)

--- a/tests/spec/result_coerce.test.ry
+++ b/tests/spec/result_coerce.test.ry
@@ -19,13 +19,13 @@ describe("Result coercion — Err with collection payload", ():
   )
   it("Ok arm is unreachable for Err value", ():
     a: Result<int, List<int>> = Err([10, 20])
-    matched_ok = false
+    matchedOk = false
     case a:
       Ok(v):
-        matched_ok = true
+        matchedOk = true
       Err(lst):
         expect(lst.len()).toEq(2)
-    expect(matched_ok).toBeFalse()
+    expect(matchedOk).toBeFalse()
   )
 )
 

--- a/tests/spec/result_option_arc_return.test.ry
+++ b/tests/spec/result_option_arc_return.test.ry
@@ -109,8 +109,8 @@ describe("Result/Option ARC return (#999)", ():
     # arc_owned_values_ path: tryRetainArcSource returns true without retaining.
     before = arcLiveCount()
     r: Result<List<int>, Error> = makeOkInline()
-    after_make = arcLiveCount()
-    expect(after_make - before).toEq(1)
+    afterMake = arcLiveCount()
+    expect(afterMake - before).toEq(1)
     case r:
       Ok(xs):
         expect(xs.len()).toEq(3)
@@ -124,8 +124,8 @@ describe("Result/Option ARC return (#999)", ():
     # proving that the retain in buildOkValue kept the list alive past scope cleanup.
     before = arcLiveCount()
     r: Result<List<int>, Error> = makeOkList([42, 43])
-    after_call = arcLiveCount()
-    expect(after_call - before).toEq(1)
+    afterCall = arcLiveCount()
+    expect(afterCall - before).toEq(1)
     case r:
       Ok(xs):
         expect(xs[0]).toEq(42)

--- a/tests/spec/str_arc.test.ry
+++ b/tests/spec/str_arc.test.ry
@@ -256,9 +256,9 @@ describe("str ARC — closure capture", ():
 
   it("closure capturing str survives reassignment of original", ():
     s = "ori" + "ginal"
-    capture_s = () => s
+    captureS = () => s
     s = "new" + "value"
-    expect(capture_s()).toEq("original")
+    expect(captureS()).toEq("original")
   )
 )
 

--- a/tests/spec/thread.test.ry
+++ b/tests/spec/thread.test.ry
@@ -73,9 +73,9 @@ describe("RWLock", ():
 
 describe("Semaphore", ():
   it("should limit concurrent access", ():
-    sem_result = semaphoreNew(2)
-    expect(sem_result).toBeOk()
-    case sem_result:
+    semResult = semaphoreNew(2)
+    expect(semResult).toBeOk()
+    case semResult:
       Ok(sem):
         counter = atomicIntNew(0)
 
@@ -100,9 +100,9 @@ describe("Semaphore", ():
 
 describe("Barrier", ():
   it("should synchronize threads", ():
-    barrier_result = barrierNew(2)
-    expect(barrier_result).toBeOk()
-    case barrier_result:
+    barrierResult = barrierNew(2)
+    expect(barrierResult).toBeOk()
+    case barrierResult:
       Ok(barrier):
         counter = atomicIntNew(0)
 

--- a/tests/spec/top_level_bindings.test.ry
+++ b/tests/spec/top_level_bindings.test.ry
@@ -32,7 +32,7 @@ record TopPoint:
 @const
 TOP_POINT: TopPoint = TopPoint(11, 22)
 
-top_counter: int = 0
+topCounter: int = 0
 
 # Top-level functions that reference the above bindings.
 
@@ -77,10 +77,10 @@ fn readPiIndirect() -> float:
 
 # Function that reads and mutates the top-level mutable binding.
 fn bumpCounter():
-  top_counter = top_counter + 1
+  topCounter = topCounter + 1
 
 fn getCounter() -> int:
-  return top_counter
+  return topCounter
 
 # Function with inner lambda that reads a top-level @const.
 fn readPiViaLambda() -> float:
@@ -130,7 +130,7 @@ describe("issue #817 — top-level @const visible from top-level functions", ():
 
 describe("issue #817 — top-level mutable let write-through", ():
   it("should allow a top-level function to mutate a top-level let", ():
-    # top_counter starts at 0 from module init
+    # topCounter starts at 0 from module init
     initial = getCounter()
     bumpCounter()
     bumpCounter()

--- a/tests/spec/type_of.test.ry
+++ b/tests/spec/type_of.test.ry
@@ -205,8 +205,8 @@ describe("typeOf function/lambda", ():
   )
 
   it("should infer Type as the return type of an unannotated lambda body", ():
-    get_type = (x: int) => typeOf(x)
-    expect(toStr(get_type(42))).toEq("int")
+    getType = (x: int) => typeOf(x)
+    expect(toStr(getType(42))).toEq("int")
   )
 )
 


### PR DESCRIPTION
## Summary

Closes #1451.

Mechanical rename of snake_case local variables, for-loop bindings, assignment LHS, and case-arm pattern bindings under \`tests/spec/\` to camelCase, aligned with the v0.0.16 naming convention now enforced by:

- #1443 — parser camelCase enforcement for user identifiers
- #1449 — camelCase enforcement for lambda parameters
- #1448 — camelCase test DSL matchers

## Scope

- **In scope**: 75 unique snake_case identifiers renamed to camelCase across 39 files (346 insertions / 346 deletions — symmetric pure rename)
- **Includes**: case-arm pattern bindings in \`tests/spec/json.test.ry\` (e.g. \`Ok(name_val):\` → \`Ok(nameVal):\`) — these satisfy the issue's "no snake_case binding remains" acceptance criterion even though the issue regex undercounts them
- **Includes**: one comment edit in \`tests/spec/top_level_bindings.test.ry:133\` (\`# top_counter starts at 0\` → \`# topCounter starts at 0\`) — the comment names a renamed variable; leaving it stale would produce a dangling reference. Defensible consistency fix.
- **Untouched per scope**: \`_\` placeholders, string literals (describe/it titles), record/enum field names, test message content, embedded Ry source in \`tests/test_*.cpp\`

## Verification

- \`grep -rE '^[[:space:]]*[a-z][a-z0-9]*_[a-z0-9_]+[[:space:]]*=' tests/spec/\` → 0 hits
- \`grep -rE '^[[:space:]]*[A-Z][A-Za-z0-9]*\([a-z][a-z0-9]*_[a-z0-9_]+\):' tests/spec/\` → 0 hits
- \`./build/ry_tests\` — 2030 tests pass
- \`./build/ry test -p\` — 168 files pass
- ASan + UBSan — clean
- TSan — clean

## Test plan

- [x] \`./build/ry_tests\` passes
- [x] \`./build/ry test -p\` passes
- [x] ASan + UBSan clean
- [x] TSan clean
- [x] No CHANGELOG fragment (test-only churn — per issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Standardized variable naming convention across the test suite, converting local and module-level identifiers from snake_case to camelCase for improved code consistency. No functional or behavioral changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->