### PR TITLE
refactor(codegen_test): add defensive unknown-matcher guard before CreateCondBr (#1453)

### DIFF
--- a/.claude/rules/tests-rejection-tdd.md
+++ b/.claude/rules/tests-rejection-tdd.md
@@ -94,3 +94,17 @@ Affected sites (all in `codegen_call_collection.cpp`, `codegen_call_string.cpp`,
 
 **If a reachable path is found** (e.g. via a future union type edge case), add
 a direct Ry-source regression test per the `/tdd-cycle` skill and remove this exception entry.
+
+### Codegen dispatch chains over a parser whitelist must end with a defensive `else codegenError` — no regression test required
+
+**Source**: #1453 (2026-04-30, hardening — CodeRabbit nitpick deferred from #1448 / #1452)
+**Tags**: codegen, dispatch-chain, defensive, parser-whitelist, testing, expect-stmt, matcher
+
+**Context**: `CodeGen::emitExpect` (`src/codegen_test.cpp`) routes `ExpectStmt` to per-matcher IR via an `if (s.matcher == "...") { ... } else if (...) { ... }` chain that assigns `cmpResult` in each arm. The accepted matcher names are constrained by the parser whitelist (`matchers_with_arg` / `matchers_no_arg` in `src/parser.cpp`), so any value reaching codegen is one of the 18 known names today. Without a closing `else`, a future whitelist extension that forgets the codegen counterpart would either reuse the previous arm's `cmpResult` or feed a `nullptr`/dangling value into the trailing `builder_.CreateCondBr(cmpResult, contBB, failBB)` — i.e. malformed IR caught only at LLVM verify time.
+
+**Rule**: When introducing or refactoring a codegen dispatch chain whose name set is gated by a parser-side whitelist, terminate the chain with `else { codegenError("line " + std::to_string(<loc>.line) + ": unknown <kind> '" + <name> + "'"); }`. This catches parser ↔ codegen drift at the codegen stage with an actionable diagnostic, rather than relying on whatever the last arm left in a downstream variable. `codegenError` is `[[noreturn]]` (`include/ry/codegen.hpp:1033-1034`), so the compiler correctly proves no fall-through into the trailing IR emitter and `cmpResult`-uninitialized warnings do not fire.
+
+**Decision**: this branch is unreachable from Ry source today. Triggering it requires either modifying the parser (defeating the purpose) or constructing an `ExpectStmt` AST with an out-of-whitelist matcher via direct C++ — no public API supports this. Ship the guard without a regression test, consistent with the sibling rule above ("Defensive ptr-shape validation guards ...").
+
+**Affected sites**:
+- `CodeGen::emitExpect` matcher chain end (`src/codegen_test.cpp` after the `toEndWith` arm) — `"line N: unknown matcher 'X'"`

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -1026,6 +1026,9 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         phi->addIncoming(llvm::ConstantInt::get(i1Ty_, 0), curBB);
         phi->addIncoming(match, checkBB);
         cmpResult = phi;
+    } else {
+        codegenError("line " + std::to_string(s.loc.line) +
+                     ": unknown matcher '" + s.matcher + "'");
     }
 
     // Branch: if cmpResult is false, call __ry_test_expect_fail


### PR DESCRIPTION
## Summary

Closes #1453.

`CodeGen::emitExpect` (`src/codegen_test.cpp`) routes `ExpectStmt` to per-matcher IR via an `if (s.matcher == \"...\") { ... } else if (...) { ... }` chain that assigns `cmpResult` in each arm. The accepted matcher names are constrained by the parser whitelist (`matchers_with_arg` / `matchers_no_arg` in `src/parser.cpp`), so any value reaching codegen is one of the 18 known names today. Without a closing `else`, a future whitelist extension that forgets the codegen counterpart would either reuse the previous arm's `cmpResult` or feed a `nullptr`/dangling value into the trailing `builder_.CreateCondBr(cmpResult, contBB, failBB)` — i.e. malformed IR caught only at LLVM verify time.

This PR terminates the chain with a defensive `else { codegenError(...); }` so future parser ↔ codegen drift fails fast at codegen with an actionable diagnostic. `codegenError` is `[[noreturn]]` (`include/ry/codegen.hpp:1033-1034`), so the compiler proves no fall-through and `cmpResult`-uninitialized warnings do not fire.

### Why no regression test

Triggering the new `else` branch from Ry source is impossible today: the parser whitelist gates `s.matcher` to the 18 known names, and there is no public API to construct an `ExpectStmt` AST with an out-of-whitelist matcher. Ship the guard without a test, consistent with the sibling rule "Defensive ptr-shape validation guards are unreachable from Ry source — no regression test required" in `.claude/rules/tests-rejection-tdd.md`.

The new pattern is documented as a fresh entry in `.claude/rules/tests-rejection-tdd.md` so future codegen dispatch chains gated by a parser-side whitelist follow the same defensive-`else` shape.

### User-visible impact

None. This is purely defensive hardening; behavior on every legal matcher is unchanged.

## Test plan

- [x] default build: zero warnings
- [x] `./build/ry_tests` — 2030/2030 PASSED
- [x] `./build/ry test -p` — 168 files, 0 failures
- [x] ASan + UBSan (`build-asan/`) — clean
- [x] TSan (`build-tsan/`) — clean
- [x] clang-tidy — no new warnings on changed lines
- [x] cppcheck — clean
- [x] libFuzzer 3 targets x 60s — 0 crashes (parser 47480 / json 321865 / utf8 324999 runs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling in code generation to properly detect and report invalid matcher configurations, now providing detailed error messages including exact line numbers where issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->