### PR TITLE
fix(parser): enforce camelCase for tuple-destructure LHS identifiers (#1450)

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -241,6 +241,25 @@ catch it because the bug is specific to the identifier-adjacent case.
 
 **How to apply**: When adding any new statement form that begins with `LParen` after directives (e.g., `@const (_ as Pattern) = expr`, hypothetical future destructuring variants), extend `looksLikeParenthesizedTupleDestructure` (or add a parallel predicate) and make `parseDirectives` defer to it in the same guard location. Never let `parseDirectives` unconditionally eat `LParen`.
 
+### Tuple-destructure LHS names must be camelCase (with `_` placeholder allowed)
+
+**Source**: #1450 (2026-04-30, implementation)
+**Tags**: parser, tuple, destructure, casing, camelCase, identifier, isCamelCase
+
+**Rule**: Both forms of tuple destructure assignment in `src/parser.cpp` enforce camelCase on every LHS name via `isCamelCase`, with `_` accepted as a placeholder at any position:
+
+- Parenthesized form (`(a, b) = expr`): both the first name and every name read inside the comma loop are validated immediately after consuming the `Ident` token.
+- Bare form (`a, b = expr`): the first name is `first.value` (already consumed by the outer `Ident` dispatch in `parseStatement`) and must be checked there too — a position the rest-only sweep would miss. Each rest name is checked inside the comma loop.
+
+The error wording is `"tuple-destructure name '<n>' must be camelCase"`, matching the established pattern used by `parser_decl.cpp` (`fn name '...' must be camelCase`, `parameter name '...' must be camelCase`, `field name '...' must be camelCase`, etc.).
+
+**Why**: Pre-#1450 the two tuple-destructure sites were the last LHS-binding parser sites that accepted snake_case identifiers, even though every other binding site (`fn` decl, `let`/assign LHS via `parseAssignTarget`, lambda params, record fields, enum variant fields, loop variables) had been migrated to camelCase by #1409 / #1443 and follow-ups. The casing rule applies to all identifiers introduced into the local scope, and tuple destructure introduces them — so consistency demanded the same enforcement here.
+
+**How to apply**:
+- Both forms have a `first` position consumed before the comma loop and a `rest` position consumed inside it. A guard at only one position passes the other-position regression test for the wrong reason; lock both with separate negative tests (see `BareTupleDestructRejectsSnakeCaseFirst` vs `BareTupleDestructRejectsSnakeCaseRest`).
+- The `_` placeholder is a floor (must remain accepted), not a ceiling (allowed only in bare form). It is accepted in both forms at any position because `(_, b)` was already valid pre-#1450 via `ParenTupleDestructWildcard`.
+- The tuple-destructure parse path is gated by `looksLikeParenthesizedTupleDestructure()` (paren form) or the outer `Ident` dispatch (bare form) — neither sits inside a `try / catch (...)` speculative wrapper, so `parseError` propagates as a user-visible diagnostic. The commit-flag pattern from #1449 does **not** apply here.
+
 ### `@directive` definition syntax bypasses the registry validator
 
 **Source**: #708 (2026-04-27, implementation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **Breaking:** Renamed string-family stdlib functions to align with the v0.0.16 naming conventions. `share/std/str`: `starts_with` → `startsWith`, `ends_with` → `endsWith`, `byte_len` → `byteLen`, `substring` → `substr` (only this one shortens, per the approved abbreviation table), `char_at` → `charAt`, `to_upper` → `toUpper`, `to_lower` → `toLower`, `trim_start` → `trimStart`, `trim_end` → `trimEnd`. `contains`, `find`, `replace`, `trim`, `repeat`, `reverse`, `split`, `join` are already single-word and unchanged. `share/std/convert`: `to_int` → `toInt`, `to_str` → `toStr`, `to_float` → `toFloat` (the `to`-prefix is intentional, not abbreviated to `int` / `str` / `float`, to avoid colliding with the type-name spellings). `share/std/json`: `to_str` / `to_int` / `to_float` / `to_bool` → `toStr` / `toInt` / `toFloat` / `toBool`, and `json_free` → `jsonFree`. `share/std/regex`: `regex_match` / `regex_search` / `regex_replace` / `regex_split` / `regex_find_all` → `regexMatch` / `regexSearch` / `regexReplace` / `regexSplit` / `regexFindAll`, and `is_match` / `find_all` → `isMatch` / `findAll`. The old names are removed entirely; there is no alias or deprecation period. (#1412)
 - **Breaking:** Renamed collection-family stdlib functions to align with the v0.0.16 naming conventions. `share/std/list`: `remove_at` → `removeAt`, `flatten` → `flat` (per the approved abbreviation table), `is_empty` → `isEmpty`. `share/std/map`: `has_key` → `hasKey`. `share/std/set`: `symmetric_difference` → `symmetricDifference`, `is_subset` → `isSubset`, `is_superset` → `isSuperset`. `share/std/higher_order` requires no renames. The old names are removed entirely; there is no alias or deprecation period. (#1413)
 
+### Fixed
+
+- Parser now enforces camelCase on tuple-destructure LHS identifiers in both the parenthesized form (`(a, b) = expr`) and the bare form (`a, b = expr`), aligning with the v0.0.16 naming conventions enforced elsewhere by #1443. The `_` placeholder remains accepted at any position. (#1450)
+
 ## [0.0.15] - 2026-04-28
 
 ### Added

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -512,11 +512,19 @@ StmtNode Parser::parseStatement() {
     if (first.kind == TokenKind::LParen && looksLikeParenthesizedTupleDestructure()) {
         lex_.next();
         std::vector<std::string> names;
-        names.push_back(lex_.peek().value);
-        lex_.next();
+        {
+            Token n = lex_.peek();
+            if (n.value != "_" && !isCamelCase(n.value))
+                parseError(n.line, "tuple-destructure name '" + n.value + "' must be camelCase");
+            names.push_back(n.value);
+            lex_.next();
+        }
         while (lex_.peek().kind == TokenKind::Comma) {
             lex_.next();
-            names.push_back(lex_.peek().value);
+            Token n = lex_.peek();
+            if (n.value != "_" && !isCamelCase(n.value))
+                parseError(n.line, "tuple-destructure name '" + n.value + "' must be camelCase");
+            names.push_back(n.value);
             lex_.next();
         }
         if (lex_.peek().kind != TokenKind::RParen)
@@ -688,12 +696,16 @@ StmtNode Parser::parseStatement() {
     } else if (next.kind == TokenKind::Comma) {
         // Tuple destructuring: a, b = (10, 20)
         std::vector<std::string> names;
+        if (first.value != "_" && !isCamelCase(first.value))
+            parseError(first.line, "tuple-destructure name '" + first.value + "' must be camelCase");
         names.push_back(first.value);
         while (lex_.peek().kind == TokenKind::Comma) {
             lex_.next(); // consume ','
             Token n = lex_.peek();
             if (n.kind != TokenKind::Ident && n.value != "_")
                 parseError("expected identifier or '_' in tuple destructuring");
+            if (n.value != "_" && !isCamelCase(n.value))
+                parseError(n.line, "tuple-destructure name '" + n.value + "' must be camelCase");
             lex_.next(); // consume ident
             names.push_back(n.value);
         }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -964,6 +964,55 @@ TEST(ParserTest, ParenTupleDestructTrailingCommaRejected) {
     EXPECT_THROW(parseStr("(a,) = (1,)"), std::runtime_error);
 }
 
+TEST(ParserTest, ParenTupleDestructRejectsSnakeCase) {
+    // #1450: parenthesized tuple-destructure LHS must enforce camelCase on
+    // every name (both the first and any rest names).
+    EXPECT_THROW(parseStr("(my_x, my_y) = (1, 2)"), std::runtime_error);
+    EXPECT_THROW(parseStr("(a, my_b) = (1, 2)"), std::runtime_error);
+    EXPECT_THROW(parseStr("(my_a, b) = (1, 2)"), std::runtime_error);
+}
+
+TEST(ParserTest, BareTupleDestructRejectsSnakeCaseFirst) {
+    // #1450: bare tuple-destructure form must reject snake_case on the first
+    // name (consumed by the outer Ident dispatch before reaching the comma
+    // branch).
+    EXPECT_THROW(parseStr("my_a, b = (1, 2)"), std::runtime_error);
+}
+
+TEST(ParserTest, BareTupleDestructRejectsSnakeCaseRest) {
+    // #1450: bare tuple-destructure form must reject snake_case on a rest
+    // name (consumed inside the comma loop).
+    EXPECT_THROW(parseStr("a, my_b = (1, 2)"), std::runtime_error);
+}
+
+TEST(ParserTest, BareTupleDestructAcceptsCamelCase) {
+    // #1450 positive baseline: camelCase names parse cleanly in bare form.
+    Program prog = parseStr("myA, myB = (1, 2)");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<TupleDestructStmt>(prog[0]));
+    const auto &s = std::get<TupleDestructStmt>(prog[0]);
+    ASSERT_EQ(s.names.size(), 2u);
+    EXPECT_EQ(s.names[0], "myA");
+    EXPECT_EQ(s.names[1], "myB");
+}
+
+TEST(ParserTest, BareTupleDestructAcceptsUnderscore) {
+    // #1450: `_` placeholder must remain accepted in bare form (and at any
+    // position).
+    Program prog = parseStr("_, b = (1, 2)");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<TupleDestructStmt>(prog[0]);
+    ASSERT_EQ(s.names.size(), 2u);
+    EXPECT_EQ(s.names[0], "_");
+    EXPECT_EQ(s.names[1], "b");
+
+    Program prog2 = parseStr("a, _ = (1, 2)");
+    const auto &s2 = std::get<TupleDestructStmt>(prog2[0]);
+    ASSERT_EQ(s2.names.size(), 2u);
+    EXPECT_EQ(s2.names[0], "a");
+    EXPECT_EQ(s2.names[1], "_");
+}
+
 // ===== UFCS パーサーテスト =====
 
 TEST(ParserTest, UFCSBasic) {


### PR DESCRIPTION
## Summary

- Closes #1450. The two tuple-destructure parser sites in `src/parser.cpp` were the last LHS-binding sites that still accepted snake_case after the v0.0.16 naming migrations (#1409 / #1443). This PR adds `isCamelCase` guards to both forms.
- Parenthesized form `(a, b) = expr` and bare form `a, b = expr` now reject snake_case names with `"tuple-destructure name '<n>' must be camelCase"` (wording matches `parser_decl.cpp`'s `fn name`/`parameter name`/`field name` rejections).
- The `_` placeholder remains accepted at any position in both forms.

## Implementation notes

- **Both forms have a `first` and a `rest` position.** The `first` position is consumed before the comma loop (paren form: just after `LParen`; bare form: by the outer `Ident` dispatch in `parseStatement`). A guard at only one position passes the other-position regression test for the wrong reason — separate negative tests lock both.
- The tuple-destructure parse path is **not** inside a `try / catch` speculative wrapper (gated by `looksLikeParenthesizedTupleDestructure()` for paren form, outer `Ident` dispatch for bare form), so `parseError` propagates as a user-visible diagnostic. The commit-flag pattern from #1449 does not apply here.
- New rule entry in `.claude/rules/parser-conventions.md` documents the dual-position trap and the `try/catch` distinction so future LHS-binding additions catch this class of bug.

## Test plan

- [x] `cmake --build build --target ry ry_tests`
- [x] 5 new tests in `tests/test_parser.cpp`: `ParenTupleDestructRejectsSnakeCase`, `BareTupleDestructRejectsSnakeCaseFirst`, `BareTupleDestructRejectsSnakeCaseRest`, `BareTupleDestructAcceptsCamelCase`, `BareTupleDestructAcceptsUnderscore` — all pass after the parser change, the three negative tests fail before it (Red→Green confirmed)
- [x] `./build/ry_tests` (2035 tests, all green)
- [x] `./build/ry test -p` (168 spec files, all green)
- [x] `ctest --test-dir build -L filecheck` (10 goldens, all green)
- [x] ASan + UBSan clean: `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests` and same for `./build-asan/ry test -p`
- [x] Sweep of `tests/spec/`, `share/std/`, `docs/`, `README.md` — no snake_case tuple destructure exists; no example flips required
- [x] CHANGELOG.md `[Unreleased] / Fixed` entry added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Tuple destructuring assignments now enforce camelCase naming convention for all destructured identifiers, applicable to both parenthesized and comma-separated syntactic forms. The underscore (`_`) placeholder remains valid in any position.

* **Tests**
  * Added unit tests validating camelCase naming enforcement for tuple destructuring patterns, covering rejection of non-compliant identifiers and acceptance of valid bindings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->