### PR TITLE
refactor(tests): migrate module-global and it() camelCase residual (#1468)

### DIFF
--- a/.claude/rules/tests-spec-conventions.md
+++ b/.claude/rules/tests-spec-conventions.md
@@ -110,19 +110,19 @@ For setup guards ("if dir exists, remove it"), prefer unconditional `removeAll(d
 `Result<Unit, Error>` is discarded if unused. For `Result<bool, Error>` predicates, use
 `Ok(v): expect(v).toBeTrue()` / `Ok(v): expect(v).toBeFalse()` patterns.
 
-### Naming-convention sweeps must include the implicit `name: type = value` form, not just `let`/`var`
+### Naming-convention sweeps must include the implicit `name: type = value` form, not just `let`/`var`, and must cover module-global declarations
 
-**Source**: #1466 (2026-04-30, follow-up to #1450 / #1451)
-**Tags**: testing, naming, camelCase, sweep, blind-spot
+**Source**: #1466 (2026-04-30, follow-up to #1450 / #1451); #1468 (2026-04-30, module-global blind spot)
+**Tags**: testing, naming, camelCase, sweep, blind-spot, module-global
 
-**Rule**: When grep-driven renaming sweeps target Ry identifiers in `.test.ry` files, the search pattern must include the implicit-binding form (`name: type = value` with no `let`/`var` keyword), not just keyword-prefixed declarations. The camelCase parser flip (#1443) and the `tests/spec/` sweep (#1450 / #1451) both used patterns anchored on `let` / `var`, missing every implicit binding inside `it(...)` blocks. #1466 then had to clean up 7 such sites in 5 files (`no_headers`, `outer_log`, `inner_cond`, `empty_a`).
+**Rule**: When grep-driven renaming sweeps target Ry identifiers in `.test.ry` files, the search pattern must include the implicit-binding form (`name: type = value` with no `let`/`var` keyword), not just keyword-prefixed declarations — and it must cover **module-global** declarations (no leading whitespace) as well as bodies inside `it(...)`. The camelCase parser flip (#1443) and the `tests/spec/` sweep (#1450 / #1451) used patterns anchored on `let` / `var`, missing every implicit binding inside `it(...)` blocks; #1466's follow-up sweep then anchored on `^\s+` (one or more leading spaces), which still missed module-global implicit bindings such as `cow_global_box: CowBox = ...` at column 0 (#1468 cleanup).
 
-**Why**: Top-level test bodies inside `it(...)` use the implicit form heavily — the parser accepts `noHeaders: Map<str, str> = {}` exactly like a `let` declaration, but `grep -E '\b(let|var)\s+...'` skips it. Tests still pass under either spelling, so without an exhaustive grep the rename silently leaves the old name in place.
+**Why**: The parser accepts `noHeaders: Map<str, str> = {}` exactly like a `let` declaration, both as an indented binding inside `it(...)` and as a module-global at the top level. `grep -E '\b(let|var)\s+...'` skips both forms; `grep -E '^\s+...'` skips the module-global form. A second blind spot in #1466's recommended grep was that the identifier body was written as `[a-zA-Z0-9]+`, which excludes `_` — so multi-underscore names (`cow_global_box`) failed to match because the engine consumed only `cow_global` before the trailing `\s*[:=]` check ran into a stray `_box`. Tests still pass under either spelling, so without an exhaustive grep the rename silently leaves the old name in place.
 
-**How to apply**: For any future Ry-identifier sweep, audit with the binding-form-agnostic regex below — it matches both keyword-prefixed and implicit declarations:
+**How to apply**: For any future Ry-identifier sweep, audit with the anchor-form-agnostic regex below — `^\s*` (zero or more leading spaces) matches both indented and module-global declarations, the body uses `[a-zA-Z0-9_]` so the engine can consume any number of underscores, and the trailing `\s*[:=]` covers `name: Type = ...` and `name = ...`. The regex deliberately omits `let` / `var` / `const` keyword forms — the parser camelCase enforcement from #1443 already rejects those at compile time, so a residual snake_case binding under a keyword cannot ship undetected; the implicit-binding form (no keyword) is the one that slips past the parser:
 
 ```bash
-grep -rEn --include='*.ry' '^\s+[a-z][a-zA-Z0-9]*_[a-zA-Z0-9]+\s*[:=]' tests/spec/ \
+grep -rEn --include='*.ry' '^\s*[a-z][a-zA-Z0-9_]*_[a-zA-Z0-9_]+\s*[:=]' tests/spec/ \
   | grep -vE ':\s*#|"[^"]*[a-z_]+[^"]*"'
 ```
 

--- a/tests/spec/cow_path.test.ry
+++ b/tests/spec/cow_path.test.ry
@@ -19,7 +19,7 @@ record CowOuter:
 # Module-global record with an ARC field exercises the `findModuleGlobal`
 # branch of `emitPathCowForChain` and `emitModuleGlobalWriteThrough`'s
 # new record-ARC path (#854 review).
-cow_global_box: CowBox = CowBox([1, 2, 3])
+cowGlobalBox: CowBox = CowBox([1, 2, 3])
 
 describe("path CoW", ():
   describe("nested list", ():
@@ -128,9 +128,9 @@ describe("path CoW", ():
     it("should isolate module-global record alias", ():
       # Exercise emitPathCowForChain's findModuleGlobal branch: alias
       # the top-level record into a local and mutate through the local.
-      localBox = cow_global_box
+      localBox = cowGlobalBox
       localBox.items[0] = 999
-      expect(cow_global_box.items[0]).toEq(1)
+      expect(cowGlobalBox.items[0]).toEq(1)
       expect(localBox.items[0]).toEq(999)
       # Reset for test isolation.
       localBox.items[0] = 1

--- a/tests/spec/result_option_arc_return.test.ry
+++ b/tests/spec/result_option_arc_return.test.ry
@@ -38,7 +38,7 @@ fn makeErrList(v: List<int>) -> Result<int, List<int>>:
   return Err(v)
 
 describe("Result/Option ARC return (#999)", ():
-  it("Ok(list_param) — data survives scope cleanup", ():
+  it("Ok(xs) — data survives scope cleanup", ():
     r: Result<List<int>, Error> = makeOkList([1, 2, 3])
     case r:
       Ok(xs):
@@ -50,7 +50,7 @@ describe("Result/Option ARC return (#999)", ():
         fail("unexpected Err: " + e.message)
   )
 
-  it("Ok(map_param) — data survives scope cleanup", ():
+  it("Ok(m) — data survives scope cleanup", ():
     r: Result<Map<str, int>, Error> = makeOkMap({"a": 1, "b": 2})
     case r:
       Ok(m):
@@ -60,7 +60,7 @@ describe("Result/Option ARC return (#999)", ():
         fail("unexpected Err: " + e.message)
   )
 
-  it("Ok(set_param) — data survives scope cleanup", ():
+  it("Ok(s) — data survives scope cleanup", ():
     r: Result<Set<int>, Error> = makeOkSet({10, 20, 30})
     case r:
       Ok(s):
@@ -72,7 +72,7 @@ describe("Result/Option ARC return (#999)", ():
         fail("unexpected Err: " + e.message)
   )
 
-  it("Some(list_param) — data survives scope cleanup", ():
+  it("Some(xs) — data survives scope cleanup", ():
     opt: Option<List<int>> = makeSomeList([7, 8, 9])
     case opt:
       Some(xs):
@@ -83,7 +83,7 @@ describe("Result/Option ARC return (#999)", ():
         fail("unexpected None")
   )
 
-  it("Ok(list_param) — equality: original reproduction case from #999", ():
+  it("Ok(xs) — equality: original reproduction case from #999", ():
     # Without the fix, both inner pointers dangled to the same freed memory
     # and compared equal.
     a: Result<List<int>, Error> = makeOkList([1, 2])
@@ -92,13 +92,13 @@ describe("Result/Option ARC return (#999)", ():
     expect(a != b).toBeTrue()
   )
 
-  it("Ok(list_param) — equal values compare equal after fix", ():
+  it("Ok(xs) — equal values compare equal after fix", ():
     a: Result<List<int>, Error> = makeOkList([1, 2, 3])
     b: Result<List<int>, Error> = makeOkList([1, 2, 3])
     expect(a == b).toBeTrue()
   )
 
-  it("Some(list_param) — equality: unequal lists", ():
+  it("Some(xs) — equality: unequal lists", ():
     a: Option<List<int>> = makeSomeList([1, 2])
     b: Option<List<int>> = makeSomeList([9, 9])
     expect(a == b).toBeFalse()
@@ -119,7 +119,7 @@ describe("Result/Option ARC return (#999)", ():
         fail("unexpected Err")
   )
 
-  it("Ok(list_param) — inner list is alive after function returns (no use-after-free)", ():
+  it("Ok(xs) — inner list is alive after function returns (no use-after-free)", ():
     # The critical invariant: arcLiveCount rises by 1 when makeOkList returns,
     # proving that the retain in buildOkValue kept the list alive past scope cleanup.
     before = arcLiveCount()
@@ -134,7 +134,7 @@ describe("Result/Option ARC return (#999)", ():
         fail("unexpected Err")
   )
 
-  it("Err(list_param) — data survives scope cleanup", ():
+  it("Err(xs) — data survives scope cleanup", ():
     # Two results with distinct lists; without the fix both inner pointers would
     # dangle to the same freed memory and compare equal.
     a: Result<int, List<int>> = makeErrList([5, 6, 7])
@@ -142,14 +142,14 @@ describe("Result/Option ARC return (#999)", ():
     expect(a == b).toBeFalse()
   )
 
-  it("Err(list_param) — equality: unequal lists", ():
+  it("Err(xs) — equality: unequal lists", ():
     a: Result<int, List<int>> = makeErrList([1, 2])
     b: Result<int, List<int>> = makeErrList([9, 9])
     expect(a == b).toBeFalse()
     expect(a != b).toBeTrue()
   )
 
-  it("Err(list_param) — inner list is alive after function returns", ():
+  it("Err(xs) — inner list is alive after function returns", ():
     # arcLiveCount rises by 1: the retain in buildErrValue keeps the list alive
     # past scope cleanup of the parameter inside makeErrList.
     before = arcLiveCount()


### PR DESCRIPTION
## Summary

Cleans up two snake_case sites missed by the #1466 sweep — both stem from blind spots in #1466's recommended grep, which this PR also fixes in the rule documentation.

### Code changes (3 files, 21+/-21)

- **`tests/spec/cow_path.test.ry`** (3 sites)
  - Module-global `cow_global_box: CowBox = ...` → `cowGlobalBox` (column-0 implicit binding, missed by #1466's `^\s+`-anchored grep)
  - 2 reference sites inside `it(...)` body
- **`tests/spec/result_option_arc_return.test.ry`** (11 `it(...)` descriptions, 22 lines)
  - `Ok(list_param)` / `Some(list_param)` / `Ok(map_param)` / `Ok(set_param)` / `Err(list_param)` → `Ok(xs)` / `Some(xs)` / `Ok(m)` / `Ok(s)` / `Err(xs)` to match the actual binding identifiers used in the case arms (cosmetic only; bodies were already correct)
- **`.claude/rules/tests-spec-conventions.md`**: extends #1466's rule entry to record the two blind spots and document the corrected regex

### Why #1466 missed these

#1466's recommended grep
```
^\s+[a-z][a-zA-Z0-9]*_[a-zA-Z0-9]+\s*[:=]
```
has two compounding blind spots:

1. **Anchor**: `^\s+` (one or more leading spaces) skips module-global declarations at column 0.
2. **Body**: `[a-zA-Z0-9]+` excludes `_`, so multi-underscore names like `cow_global_box` failed to match — the engine consumed only `cow_global` before the trailing `\s*[:=]` ran into a stray `_box`.

The corrected regex documented in this PR is:
```bash
grep -rEn --include='*.ry' '^\s*[a-z][a-zA-Z0-9_]*_[a-zA-Z0-9_]+\s*[:=]' tests/spec/ \
  | grep -vE ':\s*#|"[^"]*[a-z_]+[^"]*"'
```

The rule also clarifies that `let`/`var`/`const` keyword forms are intentionally omitted from the regex because the parser camelCase enforcement (#1443) already rejects those at compile time.

### Out of scope

- C++ test files (`tests/test_parser.cpp`, `tests/test_codegen*.cpp`) embed Ry source as string literals; not audited under `--include='*.ry'`. See [#1468 comment](https://github.com/t0k0sh1/ry/issues/1468#issuecomment-4349727152) for details.
- Parser bug allowing module-global implicit bindings to bypass camelCase enforcement is filed separately as #1470.
- `length` / `substring` → `len` / `substr` residue in docs+rules is filed separately as #1469.

## Test plan

- [x] `./build/ry test tests/spec/cow_path.test.ry` — 12 passed
- [x] `./build/ry test tests/spec/result_option_arc_return.test.ry` — 19 passed
- [x] Corrected regex run across entire repo's `*.ry` files — empty (no residue remains)

Closes #1468

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test identifiers and naming conventions for consistency across test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->