### PR TITLE
docs(naming): document camelCase enforcement added by #1449 / #1450 / #1470

### DIFF
--- a/.claude/rules/docs-reference-conventions.md
+++ b/.claude/rules/docs-reference-conventions.md
@@ -350,3 +350,17 @@ If reality is mixed, replace the single-form placeholder (`<functionName>` or `<
 - If the implementation is consistent with the rename, migrate normally.
 - If the implementation is inconsistent, keep a neutral placeholder (e.g. `<symbol>`) and document the carve-outs with concrete examples.
 - This applies in both directions: snake_case → camelCase migrations *and* camelCase → snake_case (or any rename). Inline-code placeholders mirror an external contract and should reflect what the code actually does.
+
+### Migration notes sections drift when a release rolls out through multiple incremental issues
+
+**Source**: #1474 (2026-04-30)
+**Tags**: documentation, drift, migration-notes, naming, release-rollout
+
+**Context**: `docs/reference/naming.md` Migration notes initially listed only `#1443` as the enforcement source for v0.0.16 camelCase. After v0.0.16 rolled out through three follow-up issues (#1449 lambda parameters, #1450 tuple-destructure LHS, #1470 module-global typed declarations), CHANGELOG `[Unreleased]` got entries for #1450 and #1470 immediately, but the prose Migration notes paragraph still cited only #1443. Readers reading the prose as a complete list could infer that lambda parameters / tuple-destructure LHS / module-global typed decls were *not* enforced — the opposite of what the parser does. This drift was discovered only at v0.0.16 feature-complete review, not during the individual #1449 / #1450 / #1470 PRs.
+
+**Rule**: When a release is rolled out through a series of incremental enforcement / breaking-change issues that all cite a common root issue (e.g. #1443 → #1449 / #1450 / #1470), update the corresponding Migration notes section in `docs/reference/*.md` *in the same PR* as each follow-up. Do not defer to a "doc cleanup at the end" PR — that pattern is exactly how the drift in #1474 happened.
+
+**How to apply**:
+- When opening a PR for a follow-up enforcement issue (e.g. "extend #1443 to lambda parameters"), grep `docs/reference/*.md` for the root issue number (`grep -rn '#1443' docs/reference/`) and update every prose mention that enumerates the enforcement scope.
+- Reviewers should treat a follow-up enforcement PR with no `docs/reference/*.md` diff as suspicious — confirm whether the root issue is cited in any prose lists before approving.
+- This applies symmetrically to other rolling rollouts: stdlib rename waves, error-message format changes, etc. Any time the CHANGELOG `[Unreleased]` accumulates multiple `(#NNNN)` entries that share a common theme, check whether the corresponding `docs/reference/*.md` prose has been updated alongside them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Parser now enforces camelCase on tuple-destructure LHS identifiers in both the parenthesized form (`(a, b) = expr`) and the bare form (`a, b = expr`), aligning with the v0.0.16 naming conventions enforced elsewhere by #1443. The `_` placeholder remains accepted at any position. (#1450)
 - Parser now enforces camelCase on module-global typed declarations of the form `name: Type = value` (the keywordless implicit-binding form), closing the last gap left by #1443 / #1449 / #1450. SCREAMING_SNAKE_CASE remains accepted on `@native` and `@const` declarations. (#1470)
+- Migration notes in `docs/reference/naming.md` now also document the camelCase enforcement extensions added by #1449 (lambda parameters), #1450 (tuple-destructure LHS identifiers in both `(a, b) = expr` and bare `a, b = expr` forms), and #1470 (module-global typed declarations of the form `name: Type = value`). Previously the section listed only #1443's seven categories, leaving readers to infer that the follow-up gaps were not enforced. (#1474)
 
 ## [0.0.15] - 2026-04-28
 

--- a/docs/reference/naming.md
+++ b/docs/reference/naming.md
@@ -83,6 +83,8 @@ Two reasons drove the move from `snake_case` to `camelCase` (functions, variable
 
 This page describes the convention as of v0.0.16. The compiler enforces the new casing rules for all user-defined identifiers as of issue #1443 — fn names, parameters, record fields, enum variant fields, loop variables, and `@directive` names/parameters all require `camelCase`.
 
+Three follow-up issues extended the enforcement to the remaining gaps: lambda parameters such as `(myX, myY) => ...` (issue #1449); tuple-destructure LHS identifiers in both the parenthesized form `(a, b) = expr` and the bare form `a, b = expr` (issue #1450, with the `_` placeholder still accepted at any position); and module-global typed declarations of the keywordless implicit-binding form `name: Type = value` (issue #1470, with `SCREAMING_SNAKE_CASE` still accepted on `@native` and `@const` declarations).
+
 The builtins rename (issue #1411) renamed `length` → `len`, `arguments` → `args`, and `available_parallelism` → `availableParallelism`. `print`, `input`, `range`, `zip`, `exit`, `sleep`, `env`, and `enumerate` keep their existing names (`enumerate` cannot be shortened because `enum` is a reserved keyword).
 
 There is no `snake_case → camelCase` alias layer. The change is a hard switch; old names are removed, not deprecated.


### PR DESCRIPTION
## Summary

- Closes #1474
- Update `docs/reference/naming.md` Migration notes to enumerate the three follow-up enforcement issues (#1449 lambda parameters, #1450 tuple-destructure LHS in both forms, #1470 module-global typed declarations) alongside #1443. Previously the prose paragraph cited only #1443, leaving readers to infer the follow-up gaps were not enforced.
- Add a CHANGELOG `[Unreleased]/Fixed` entry describing the doc reflection.
- Add a `.claude/rules/docs-reference-conventions.md` entry capturing the broader pattern: when a release rolls out through multiple incremental issues that cite a common root, update the corresponding `docs/reference/*.md` Migration notes in the same PR — do not defer to a "doc cleanup at the end".

## Out of scope (per #1474)

- `math.Inf` → `math.INF` / `math.NaN` → `math.NAN` rename history (existing Migration notes only cites #1411 builtins rename; staying consistent with that style).
- stdlib package rename history (#1412 / #1413 / #1414 / #1415 / #1416).
- Filename / package-name casing rules.
- New enforcement implementations.

## Verification

- `./build/ry_tests` — 2047/2047 passed
- `./build/ry test -p` — 168 test files executed, 0 failures (1.69s, 8 workers)
- `grep -nE '#1411|#1443|#1449|#1450|#1470' docs/reference/naming.md` — confirms all five issue references are present in the Migration notes section
- `grep -nE 'isCamelCase|isValidCamelCase' src/parser*.cpp` — re-verified that the four enforcement source PRs cover every `isCamelCase()` call site

## Test plan

- [x] Acceptance criteria #1: `docs/reference/naming.md` Migration notes reflects #1443 / #1449 / #1450 / #1470 enforcement
- [x] Acceptance criteria #2: tone matches existing #1411 builtins rename paragraph (single prose paragraph, "issue #xxxx" citation form, comparable density)
- [x] Acceptance criteria #3: `./build/ry test -p` and `./build/ry_tests` both pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated naming convention documentation to clarify camelCase enforcement scope in v0.0.16, now including lambda parameters, tuple destructuring, and module-level declarations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->