### PR TITLE
docs(reference): rename packages.md to modules.md under v0.0.17 terminology (#1481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed `docs/reference/packages.md` to `docs/reference/modules.md` and rewrote the page under v0.0.17's module/package terminology (introduced by #1480's glossary). The page is now titled "Module Reference" and uses "module" exclusively for `from ... import ...` units; the word "package" is reserved for the future `ry add` external-library feature. Section headers updated: "Package Resolution" → "Module Resolution", "Directory Packages" → "Directory Modules", "Sub-packages" → "Sub-modules", "Single File Package" / "Directory Package" → "Single File Module" / "Directory Module"; the `__ry_<package>_<symbol>` placeholder in the Native Function Naming Convention section was renamed to `__ry_<module>_<symbol>`; in-prose import-syntax placeholders were also updated (`from pkg` / `from .pkg` → `from mymodule` / `from .submodule`) so no `pkg` (an abbreviation derivative of "package") survives in the page. Anchor-bearing headers ("Standard Library (`std`)" and "RY_ENV") preserved verbatim so existing inbound links keep resolving. Cross-page link targets updated in `docs/README.md`, `docs/reference/glossary.md`, `docs/reference/project.md`, `docs/reference/directives.md`, `docs/reference/builtins.md`, `docs/reference/naming.md`, and a doc-link comment in `tests/test_parser.cpp:1870-1871` (also rephrased "Package-private" → "Module-private" in that comment for consistency with the new `naming.md` prose); `glossary.md`'s pre-existing-names note was simplified after `packages.md` ceased to exist (only `package.toml` remains as a stability-preserved name); `naming.md` prose changed "package-private names" to "module-private names"; `directives.md`'s `@native` paragraph changed "stdlib packages" / "legacy packages" to "stdlib modules" / "legacy modules" for cross-page consistency. The C ABI symbols themselves (`__ry_base64_encode`, `__ry_filesystem_listDir`, etc.) are unchanged — this is a documentation-terminology rename only. (#1481)
+
 ## [0.0.16] - 2026-04-30
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ For detailed language specifications, see the reference pages below.
 | [Filesystem](reference/filesystem.md) | listDir, walk, glob, copy, move, remove, mkdir, chmod, symlink |
 | [Thread](reference/thread.md) | threadSpawn, threadJoin, Lock, RWLock, Semaphore, Barrier, AtomicInt, AtomicBool |
 | [GC](reference/gc.md) | collect, enable, disable, setThreshold — cycle collector for ARC |
-| [Package System](reference/packages.md) | from/import syntax, directory packages, std, RY_HOME |
+| [Module System](reference/modules.md) | from/import syntax, directory modules, std, RY_HOME |
 | [Testing](reference/testing.md) | Testing with describe/it/expect |
 | [Project Management](reference/project.md) | ry init and package.toml specification |
 | [Design by Contract](reference/contracts.md) | require, ensure, invariant |

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -443,7 +443,7 @@ When `RY_ENV` is set, Ry loads environment-specific `.env` files with the follow
 - When `RY_ENV=prod`, no `.env` files are loaded (security)
 - When `RY_ENV` is not set, only `.env` is loaded (backward compatible)
 
-See [RY_ENV](packages.md#ry_env) for details on environment modes.
+See [RY_ENV](modules.md#ry_env) for details on environment modes.
 
 ---
 

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -188,7 +188,7 @@ print(len(range()))           # Error: range() takes 1, 2, or 3 arguments
   2. `exe/lib/` — development/build layout
   3. `$RY_HOME/lib/` — user-installed environment
 - Both `@native` (static) and `@native("libname")` (dynamic) declarations register for argument-count validation and call resolution. The difference is only in how the runtime symbol is provided to the JIT.
-- The runtime function name follows the convention `__ry_<libname>_<symbol>` (e.g., `@native("base64") fn encode(...)` → `__ry_base64_encode`). For most packages the symbol mirrors the Ry function name verbatim (`filesystem::listDir` → `__ry_filesystem_listDir`); legacy packages such as `base64` and `string` still use snake_case C symbols (`encodeUrlSafe` → `__ry_base64_encode_url_safe`). See `packages.md` for the full mapping table. This convention works for both stdlib packages and user-defined native libraries.
+- The runtime function name follows the convention `__ry_<libname>_<symbol>` (e.g., `@native("base64") fn encode(...)` → `__ry_base64_encode`). For most modules the symbol mirrors the Ry function name verbatim (`filesystem::listDir` → `__ry_filesystem_listDir`); legacy modules such as `base64` and `string` still use snake_case C symbols (`encodeUrlSafe` → `__ry_base64_encode_url_safe`). See `modules.md` for the full mapping table. This convention works for both stdlib modules and user-defined native libraries.
 
 ### `@parallel`
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -2,7 +2,7 @@
 
 This page is the canonical definition of the core terminology used throughout the Ry reference documentation. Other reference pages assume these definitions; if any page reads ambiguously, this glossary wins.
 
-The definitions reflect Ry as of **v0.0.17**. Two pre-existing names — the filename [`packages.md`](packages.md) and the manifest filename `package.toml` — use the word "package" in a looser sense than defined below; those names are kept for stability.
+The definitions reflect Ry as of **v0.0.17**. The manifest filename `package.toml` uses the word "package" in a looser sense than defined below; the name is kept for stability (by analogy with Rust's `Cargo.toml`).
 
 ## Module
 
@@ -10,7 +10,7 @@ A **module** is the `xxx` in `from xxx import ...` — either a single `.ry` fil
 
 The standard library, project source files, and any directory tree reachable via `RY_PATH` are addressed as modules through the `from ... import ...` syntax.
 
-See [Package Reference](packages.md) for the full import syntax and resolution rules.
+See [Module Reference](modules.md) for the full import syntax and resolution rules.
 
 ## Package
 
@@ -28,4 +28,4 @@ See [Project Management](project.md) for the manifest specification.
 
 The **standard library**, also written `std`. A collection of built-in modules — including `math`, `io`, `path`, `filesystem`, `thread`, `regex`, and others — that is automatically imported into every program. The stdlib provides core types, conversion helpers (`toInt`, `toStr`, `toFloat`, `toBool`), built-in functions (`print`, `len`, `range`), and common utilities.
 
-See [Package Reference — Standard Library](packages.md#standard-library-std) for the full list of stdlib sub-packages and import semantics.
+See [Module Reference — Standard Library](modules.md#standard-library-std) for the full list of stdlib sub-modules and import semantics.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -1,10 +1,10 @@
-# Package Reference
+# Module Reference
 
 ## Overview
 
-Ry uses a package system to organize code. A **package** can be either a single `.ry` file or a directory containing multiple `.ry` files. Use the `from` statement to import packages.
+Ry uses a module system to organize code. A **module** can be either a single `.ry` file or a directory containing multiple `.ry` files. Use the `from` statement to import modules.
 
-The `std` package (standard library) is automatically imported into every program.
+The standard library (`std`) is automatically imported into every program.
 
 ---
 
@@ -16,7 +16,7 @@ The `std` package (standard library) is automatically imported into every progra
 from math
 ```
 
-Imports all functions and types from the package.
+Imports all functions and types from the module.
 
 ### Selective Import
 
@@ -57,29 +57,29 @@ Imports from a subdirectory relative to the current file's directory.
 from . import add, sub
 ```
 
-Imports specific symbols from the current directory package (all `.ry` files in the directory, excluding `_`-prefixed and `.test.ry` files).
+Imports specific symbols from the current directory module (all `.ry` files in the directory, excluding `_`-prefixed and `.test.ry` files).
 
 ---
 
-## Package Resolution
+## Module Resolution
 
-Packages are resolved using dot-separated notation:
+Modules are resolved using dot-separated notation:
 
 | Import Statement | Resolution |
 |---|---|
-| `from math` | `math/` directory (package) or `math.ry` file |
+| `from math` | `math/` directory (module) or `math.ry` file |
 | `from utils.math` | `utils/math/` directory or `utils/math.ry` file |
 | `from str` | `str/` directory or `str.ry` file |
 
 ### Resolution Order
 
 For each search path, the system checks:
-1. **Directory** (`{path}/`) — if exists, all `.ry` files in the directory are loaded (package)
+1. **Directory** (`{path}/`) — if exists, all `.ry` files in the directory are loaded (directory module)
 2. **File** (`{path}.ry`) — single file (backward compatible)
 
-### Directory Packages
+### Directory Modules
 
-When a package resolves to a directory:
+When a module resolves to a directory:
 - All `.ry` files in the directory are automatically loaded
 - Files starting with `_` are excluded
 - Test files (`.test.ry`) are excluded
@@ -88,10 +88,10 @@ When a package resolves to a directory:
 
 ### Private Symbols
 
-Definitions whose names start with `_` (underscore) are private to the package and cannot be imported:
+Definitions whose names start with `_` (underscore) are private to the module and cannot be imported:
 
-- Wildcard imports (`from pkg`) automatically exclude `_`-prefixed symbols
-- Named imports (`from pkg import _helper`) produce a compile error
+- Wildcard imports (`from mymodule`) automatically exclude `_`-prefixed symbols
+- Named imports (`from mymodule import _helper`) produce a compile error
 
 ```ry
 # mylib/internal.ry
@@ -102,31 +102,31 @@ fn publicApi() -> int:   # public — importable
 ```
 
 ```
-mypackage/
+mymodule/
   calc.ry      # fn add(), fn sub()
   string.ry    # fn concat()
 ```
 
 ```ry
-from mypackage          # imports add, sub, concat
-from mypackage import add   # imports only add
+from mymodule          # imports add, sub, concat
+from mymodule import add   # imports only add
 ```
 
 ---
 
 ## Standard Library (`std`)
 
-The `std` package is automatically imported into every program. It provides:
+The standard library (`std`) is a collection of built-in modules automatically imported into every program. It provides:
 - Built-in functions (`print`, `len`, `range`, etc.)
 - String functions (`contains`, `find`, `replace`, etc.)
 - Type conversion functions (`toInt`, `toFloat`, `toStr`)
 - Collection functions (`map`, `filter`, `sort`, etc.)
 
-### Sub-packages
+### Sub-modules
 
-The following sub-packages require explicit import:
+The following sub-modules require explicit import:
 
-| Package | Description |
+| Module | Description |
 |---------|-------------|
 | [`math`](math.md) | Mathematical constants and functions |
 | [`io`](io.md) | File I/O, standard input, and byte conversions |
@@ -136,7 +136,7 @@ The following sub-packages require explicit import:
 from math import sqrt, PI, sin
 ```
 
-You can also explicitly import specific definitions from standard library packages:
+You can also explicitly import specific definitions from standard library modules:
 
 ```ry
 from str import contains
@@ -186,7 +186,7 @@ RY_ENV=prod ./build/ry app.ry
 RY_ENV=internal ./build/ry test
 ```
 
-When a `ry` executable is built inside the Ry source tree, it can use a repo-local stdlib override from the project's `package.toml`. This keeps repo builds aligned with the checked-out `share/std` even if `~/.ry/share/std` is older. Installed `ry` binaries ignore that override and continue to use `$RY_HOME/share/std`.
+When a `ry` executable is built inside the Ry source tree, it can use a repo-local stdlib override declared in the project manifest (`package.toml`). This keeps repo builds aligned with the checked-out `share/std` even if `~/.ry/share/std` is older. Installed `ry` binaries ignore that override and continue to use `$RY_HOME/share/std`.
 
 ---
 
@@ -202,10 +202,10 @@ When a `ry` executable is built inside the Ry source tree, it can use a repo-loc
 
 ## RY_PATH Environment Variable
 
-Specifying colon-separated directories in `RY_PATH` adds them to the package search path.
+Specifying colon-separated directories in `RY_PATH` adds them to the module search path.
 
 ```bash
-export RY_PATH="/usr/local/ry/lib:/home/user/ry-packages"
+export RY_PATH="/usr/local/ry/lib:/home/user/ry-modules"
 ```
 
 ---
@@ -217,25 +217,25 @@ export RY_PATH="/usr/local/ry/lib:/home/user/ry-packages"
 | Allowed location | Top level only (not inside functions or blocks) |
 | Duplicate imports | Automatically skipped (no error) |
 | Circular imports | Compile error |
-| Relative imports | `from .` and `from .pkg` resolve only against the current file's directory |
+| Relative imports | `from .` and `from .submodule` resolve only against the current file's directory |
 | Parent directory imports | `from ..` is not supported |
-| Package names | Only letters, digits, and underscores are allowed (no hyphens) |
+| Module names | Only letters, digits, and underscores are allowed (no hyphens) |
 
 ```ry
 # Error example: Import inside a block
 fn main():
     from math   # Error: imports only allowed at top level
 
-# OK: Importing the same package multiple times does not cause an error
+# OK: Importing the same module multiple times does not cause an error
 from math
 from math   # Skipped
 ```
 
 ---
 
-## Creating Package Files
+## Creating Module Files
 
-### Single File Package
+### Single File Module
 
 ```ry
 # calc.ry
@@ -254,7 +254,7 @@ print(add(1, 2))   # 3
 print(sub(5, 3))   # 2
 ```
 
-### Directory Package
+### Directory Module
 
 ```
 mylib/
@@ -271,23 +271,23 @@ from mylib import add, concat
 
 ## Native Function Naming Convention
 
-Stdlib package functions that are implemented as C runtime functions follow the `__ry_<package>_<symbol>` convention.
+Stdlib module functions that are implemented as C runtime functions follow the `__ry_<module>_<symbol>` convention.
 
-> **Note**: This convention applies to stdlib package functions (e.g., `base64`, `filesystem`, `path`). Built-in functions (e.g., `print`, `len`) and math functions use varied implementations (inline LLVM IR, libc calls) and do not follow this naming pattern.
+> **Note**: This convention applies to stdlib module functions (e.g., `base64`, `filesystem`, `path`). Built-in functions (e.g., `print`, `len`) and math functions use varied implementations (inline LLVM IR, libc calls) and do not follow this naming pattern.
 
 ### Format
 
 ```text
-__ry_<package>_<symbol>
+__ry_<module>_<symbol>
 ```
 
 ### Rules
 
 1. **Prefix**: `__ry_`
-2. **Package**: The package name (e.g., `base64` from `from base64 import encode`)
-3. **Symbol**: The C symbol name. Most packages now mirror the Ry function name verbatim (camelCase for v0.0.16+, e.g. `filesystem::listDir` → `__ry_filesystem_listDir`). Legacy packages (`base64`, `string`) still use snake_case C symbols regardless of the camelCase Ry name (e.g. `base64::encodeUrlSafe` → `__ry_base64_encode_url_safe`); this is a historical inconsistency tracked for cleanup.
+2. **Module**: The module name (e.g., `base64` from `from base64 import encode`)
+3. **Symbol**: The C symbol name. Most modules now mirror the Ry function name verbatim (camelCase for v0.0.16+, e.g. `filesystem::listDir` → `__ry_filesystem_listDir`). Legacy modules (`base64`, `string`) still use snake_case C symbols regardless of the camelCase Ry name (e.g. `base64::encodeUrlSafe` → `__ry_base64_encode_url_safe`); this is a historical inconsistency tracked for cleanup.
 4. **Overloads**: When a function has multiple overloads with different arities, append the argument count as a suffix (e.g., `__ry_path_join2`, `__ry_path_join3`)
-5. **Error getter**: Each package that returns `Result` types provides `__ry_<pkg>_get_last_error`
+5. **Error getter**: Each module that returns `Result` types provides `__ry_<module>_get_last_error`
 
 ### Examples
 

--- a/docs/reference/naming.md
+++ b/docs/reference/naming.md
@@ -2,7 +2,7 @@
 
 Ry uses two casing styles for identifiers: `camelCase` for runtime values and `PascalCase` for type-like declarations. This page is the single source of truth for the convention; per-feature pages link here instead of restating the rules.
 
-**Scope.** This page covers casing rules and abbreviations. Two related conventions live elsewhere: the trailing `!` suffix that marks mutating functions is documented in [Functions](functions.md), and the leading `_` prefix that marks package-private names is documented in [Packages](packages.md).
+**Scope.** This page covers casing rules and abbreviations. Two related conventions live elsewhere: the trailing `!` suffix that marks mutating functions is documented in [Functions](functions.md), and the leading `_` prefix that marks module-private names is documented in [Modules](modules.md).
 
 ## Overview
 

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -20,7 +20,7 @@ ry self-update [options]            # Update ry itself
 | `-c` | Read and execute code from stdin |
 | `-h`, `--help` | Show help |
 | `-v`, `--version` | Show version |
-| `--env=<env>` | Set environment. Valid values: `prod`/`production`, `dev`/`development`, `internal`, `test`, `staging`. Overrides the `RY_ENV` environment variable. See [Package Reference — RY_ENV](packages.md#ry_env) for details. |
+| `--env=<env>` | Set environment. Valid values: `prod`/`production`, `dev`/`development`, `internal`, `test`, `staging`. Overrides the `RY_ENV` environment variable. See [Module Reference — RY_ENV](modules.md#ry_env) for details. |
 
 ### Entry Point Execution
 

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1893,7 +1893,7 @@ TEST(ParserTest, BangSuffixFunctionAccepted) {
 }
 
 TEST(ParserTest, UnderscorePrefixCamelCaseParamAccepted) {
-    // Package-private convention also applies to function parameters: a `_`
+    // Module-private convention also applies to function parameters: a `_`
     // prefix is allowed as long as the body is camelCase.
     Program prog = parseStr("fn use(_myParam: int) -> int:\n    return 1");
     ASSERT_EQ(prog.size(), 1u);
@@ -1952,7 +1952,7 @@ TEST(ParserTest, TypedDeclAcceptsCamelCase) {
 }
 
 TEST(ParserTest, TypedDeclAcceptsUnderscorePrefix) {
-    // Package-private convention: `_camelCase` is allowed (matches
+    // Module-private convention: `_camelCase` is allowed (matches
     // `isCamelCase` semantics for fn names and lambda params).
     Program prog = parseStr("_myGlobal: int = 42");
     ASSERT_EQ(prog.size(), 1u);
@@ -2650,7 +2650,7 @@ TEST(ParserTest, LambdaParamAcceptsCamelCase) {
 }
 
 TEST(ParserTest, LambdaParamAcceptsUnderscorePrefix) {
-    // _camelCase is package-private convention and must be accepted
+    // _camelCase is module-private convention and must be accepted
     Program prog = parseStr("f = (_a, _b) => _a + _b");
     ASSERT_EQ(prog.size(), 1u);
     const auto &s = std::get<AssignStmt>(prog[0]);

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1867,8 +1867,8 @@ TEST(ParserTest, SnakeCaseFunctionRejected) {
 }
 
 TEST(ParserTest, UnderscorePrefixCamelCaseFunctionAccepted) {
-    // Package-private functions use a leading `_`. The body after the prefix
-    // must still be camelCase (see docs/reference/packages.md).
+    // Module-private functions use a leading `_`. The body after the prefix
+    // must still be camelCase (see docs/reference/modules.md).
     Program prog = parseStr("fn _privateFn() -> int:\n    return 1");
     ASSERT_EQ(prog.size(), 1u);
     auto &function = *std::get<std::unique_ptr<FnStmt>>(prog[0]);


### PR DESCRIPTION
## Summary

Closes #1481.

Renames `docs/reference/packages.md` to `docs/reference/modules.md` via `git mv` (preserving history) and rewrites the page under the module/package terminology introduced by #1480's glossary. The C ABI symbols themselves (`__ry_base64_encode`, `__ry_filesystem_listDir`, etc.) are **unchanged** — this is a documentation-terminology rename only.

### Page-level changes (`modules.md`)
- Title `Package Reference` → `Module Reference`
- Section headers: `Package Resolution` → `Module Resolution`, `Directory Packages` → `Directory Modules`, `Sub-packages` → `Sub-modules`, `Single File Package` / `Directory Package` → `Single File Module` / `Directory Module`
- Native naming convention placeholder `__ry_<package>_<symbol>` → `__ry_<module>_<symbol>`; in-prose import-syntax placeholders `from pkg` / `from .pkg` → `from mymodule` / `from .submodule` so no `pkg` abbreviation survives in the page
- Anchor-bearing headers (`Standard Library (\`std\`)` and `RY_ENV`) preserved verbatim so existing inbound links keep resolving

### Cross-page link updates
- `docs/README.md` — `[Package System](reference/packages.md)` → `[Module System](reference/modules.md)`
- `docs/reference/glossary.md` — pre-existing-names note simplified after `packages.md` ceased to exist (only `package.toml` remains); links to `modules.md`
- `docs/reference/project.md` — `--env` CLI flag link target
- `docs/reference/directives.md` — `@native` paragraph terminology (`stdlib packages` / `legacy packages` → `stdlib modules` / `legacy modules`) and link target
- `docs/reference/builtins.md` — `RY_ENV` link target
- `docs/reference/naming.md` — prose `package-private names` → `module-private names` and link target
- `tests/test_parser.cpp:1870-1871` — doc-link comment (`Package-private` → `Module-private`, `packages.md` → `modules.md`)

## Test plan

- [x] `cmake --build build --target ry_tests` — successful (`ninja: no work to do`, comment-only test source change)
- [x] `./build/ry_tests --gtest_filter='*Parser*'` — 397/397 PASS
- [x] `grep -rn 'reference/packages\|packages\.md' docs/ .claude/` — no current references remain (only frozen audit history in `.claude/rules/docs-reference-conventions.md` referencing past PRs #1118 / #1463)
- [x] Anchor preservation verified: `#standard-library-std` and `#ry_env` slug unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Terminology updated across docs from "Package" to "Module" with revised section titles and cross-links.
  * Reference pages and examples updated to reflect module-based import/resolution and standard-library wording.
  * C runtime naming guidance clarified to use module-based naming conventions (examples updated accordingly).
* **Tests**
  * Test comments updated to use "Module-private" wording; no test behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->