### PR TITLE
chore: add /horizontal-sweep skill consolidating 4-step rename procedure (#1499)

### DIFF
--- a/.claude/rules/docs-reference-conventions.md
+++ b/.claude/rules/docs-reference-conventions.md
@@ -326,6 +326,8 @@ Pattern 3 needs aggressive filtering for false positives (file paths like `hello
 
 **How to apply**: any time a doc-wide rename or convention switch is requested, run all three patterns; do not stop at pattern 1. After each batch of edits, re-run all patterns until each returns zero hits (or only filtered prose entries). Distinguish executable Ry code (must migrate) from frozen prose (`naming.md` historical contrast — keep) and language-foreign identifiers (C struct fields, npm conventions, env vars — keep).
 
+→ See `/horizontal-sweep` for the integrated 4-step procedure that builds on this rule.
+
 ### Cross-check inline-code placeholders against the implementation, not just the doc-wide rename pattern
 
 **Source**: #1463 review (CodeRabbit)
@@ -394,3 +396,5 @@ Approved abbreviations for Ry are listed in `docs/reference/naming.md` "Approved
 - Repeat until the OR-pattern grep also returns zero (or only intentional carve-outs like `package.toml` manifest references).
 - Be especially careful with placeholder strings inside `<...>`-style metalanguage (e.g. `<pkg>/mod.ry`, `from <pkg> import ...`) — these are easy to miss because they are not real identifiers and do not show up in code-syntax greps.
 - This rule complements the "Doc-wide identifier migrations need multi-pattern sweeps" rule above: identifier migrations are about code-shape patterns (declarations, assignments, type ascriptions), terminology migrations are about lexical equivalences (canonical word + shorthands).
+
+→ See `/horizontal-sweep` for the integrated 4-step procedure that builds on this rule.

--- a/.claude/rules/tests-cpp-conventions.md
+++ b/.claude/rules/tests-cpp-conventions.md
@@ -29,6 +29,8 @@ Don't rely on `.ry`-only sweeps. The build is the authoritative check — if you
 - Always run the cross-tree grep before declaring the rename complete, even if `.ry` files all look clean.
 - For PRs in the snake_case→camelCase series, the embedded-source pattern is `runSource("...@native(\\"<mod>\\")...fn <oldName>...")` — focus the grep on the unique old function name token.
 
+→ See `/horizontal-sweep` for the integrated 4-step procedure that builds on this rule.
+
 ### Stdlib-declared directives need `withStdlibDirectiveDecls()` in C++ tests
 
 **Source**: #1390 (2026-04-27, implementation)

--- a/.claude/rules/tests-spec-conventions.md
+++ b/.claude/rules/tests-spec-conventions.md
@@ -127,3 +127,5 @@ grep -rEn --include='*.ry' '^\s*[a-z][a-zA-Z0-9_]*_[a-zA-Z0-9_]+\s*[:=]' tests/s
 ```
 
 Apply the rewrite via `sed` on the matching files (`sed -i '' 's/oldName/newName/g' <files>`) — per-site `Read` + `Edit` is the pattern that produced #1466's gap in the first place.
+
+→ See `/horizontal-sweep` for the integrated 4-step procedure that builds on this rule.

--- a/.claude/skills/horizontal-sweep/SKILL.md
+++ b/.claude/skills/horizontal-sweep/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: horizontal-sweep
+description: 用語変更 / 識別子 rename / sed 一括置換 / 派生語テーブル / pkg / package / camelCase migration / 水平展開 / 用語統一 / sweep / horizontal sweep / lexical derivative / blind-spot avoidance。Use when a single term or identifier must be renamed across multiple file types (`include/`, `src/`, `share/std/`, `tests/spec/`, `tests/test_*.cpp`, `.claude/`, `docs/`). **Always run this 4-step procedure** instead of per-site `Read` + `Edit` — the latter is the pattern that produced the #1466 / #1482 / #1487 / #1490 sweep gaps.
+allowed-tools: Read, Grep, Glob, Bash
+metadata:
+  short-description: 4-step procedure for horizontal terminology / identifier rename
+---
+
+# Horizontal Sweep
+
+Terminology and identifier renames must be performed via batch grep + `sed -i ''`, not per-site `Read` + `Edit`. The latter is the pattern that produced the #1466 / #1482 / #1487 / #1490 sweep gaps.
+
+## When to use
+
+- A new term replaces an existing one (e.g., `package` → `module`)
+- A naming-convention enforcement requires renaming identifiers (e.g., snake_case → camelCase)
+- A `@native` function rename touches stdlib `.ry`, C++ runtime, dispatcher, and tests
+- Any rename whose scope spans more than two file types
+
+## Cross-references (this skill integrates these rules)
+
+| Rule entry | Source | Contribution |
+|---|---|---|
+| `.claude/rules/tests-spec-conventions.md` "Naming-convention sweeps must include the implicit form" | #1466 / #1468 | Step 2 Pattern A — Ry implicit binding regex |
+| `.claude/rules/docs-reference-conventions.md` "Doc-wide identifier migrations need multi-pattern sweeps" | #1444 | Step 2 Pattern C — declaration / assignment forms |
+| `.claude/rules/docs-reference-conventions.md` "Terminology sweeps must include lexical derivatives" | #1482 | Step 1 derivative table + Step 2 Pattern B |
+| `.claude/rules/tests-cpp-conventions.md` "Renaming stdlib @native functions" | #1414 | Step 2 Pattern D — `runSource("...")` embedded Ry |
+
+## Carve-outs (do NOT rename)
+
+These legacy identifiers are intentionally preserved (see `AGENTS.md:5`). Add them to `grep -v` filters when sweeping `package` / `Package`:
+
+| Identifier | Why preserved |
+|---|---|
+| `effectivePackage` | legacy field name — ABI-adjacent |
+| `RY_REGISTER_STDLIB_PACKAGE` | C macro, ABI-stable |
+| `__ry_<symbol>` (e.g., `__ry_filesystem_listDir`) | C runtime symbols, ABI-stable |
+
+## Steps
+
+### Step 1: Build the canonical + derivative word table
+
+Use the canonical pairs in `.claude/rules/docs-reference-conventions.md:375-389` as the reference table — do not duplicate it. Add project-specific derivatives only when they are absent from the canonical table. For approved Ry abbreviations consult `docs/reference/naming.md` "Approved abbreviations".
+
+Worked example for `package` → `module`:
+
+| Form | Replacement |
+|---|---|
+| `package` | `module` |
+| `Package` | `Module` |
+| `pkg` | `mod` |
+| `pkgs` | `mods` |
+
+### Step 2: Run multi-pattern grep
+
+File-type coverage (every rename must inspect all of these unless explicitly out of scope):
+
+- `include/**/*.hpp`, `src/**/*.cpp`
+- `share/std/**/*.ry`
+- `tests/spec/**/*.test.ry`
+- `tests/test_*.cpp` — GoogleTest names AND `runSource("...")` embedded Ry source (#1414)
+- `.claude/rules/`, `.claude/skills/`
+- `docs/`, `AGENTS.md`, `README.md`, `CHANGELOG.md`
+
+Run all four patterns. Do not stop at Pattern B — the others catch different blind spots. Substitute `<old>`, `<deriv>`, `<token>` from the Step 1 table.
+
+```bash
+# A — Ry implicit binding (#1466). ^\s* matches both module-global (column 0) and indented forms.
+#     Body uses [a-zA-Z0-9_] so multi-underscore names are not truncated.
+grep -rEn --include='*.ry' '^\s*[a-z][a-zA-Z0-9_]*<token>[a-zA-Z0-9_]*\s*[:=]' tests/spec/ share/std/
+
+# B — derivative OR (#1482). Include both lower and capitalized forms.
+grep -rnE '\b(<old>|<Old>|<deriv>|<Deriv>)\b' include/ src/ share/std/ tests/ .claude/ docs/
+
+# C — declaration / assignment forms in docs (#1444).
+grep -rnE 'fn [a-z]+_[a-z]+\b' docs/reference/                              # fn declarations
+grep -rnE '^\s*[a-z][a-zA-Z0-9]*_[a-z][a-zA-Z0-9_]*\s*[:=]' docs/reference/ # variable / type ascription
+
+# D — C++ embedded Ry (#1414). Filter STL false positives.
+grep -rnE '\b<old>\b' tests/test_*.cpp src/ include/ \
+  | grep -vE 'std::filesystem::|fs::'
+```
+
+### Step 3: Bulk replace with `sed -i`
+
+Build the file list first, exclude carve-outs, then `xargs sed`. Never use `Read` + `Edit` per file — that is the #1466 anti-pattern.
+
+```bash
+# Build file list and exclude carve-outs.
+grep -rlE '\b(<old>|<deriv>)\b' include/ src/ share/std/ tests/ .claude/ docs/ \
+  | grep -vE 'effectivePackage|RY_REGISTER_STDLIB_PACKAGE|__ry_' \
+  > /tmp/sweep_targets.txt
+
+# macOS (development): sed -i '' (empty backup-suffix arg required)
+xargs sed -i '' 's/\b<old>\b/<new>/g' < /tmp/sweep_targets.txt
+
+# Linux (CI container): sed -i (no arg)
+xargs sed -i 's/\b<old>\b/<new>/g' < /tmp/sweep_targets.txt
+
+# Verify
+git diff --stat
+git diff | grep -E '^[-+]' | head -50
+```
+
+#### Anti-patterns (do NOT do these)
+
+| Pattern | Why it fails |
+|---|---|
+| `Read` file → `Edit` per occurrence | #1466 root cause — skips pre-grep, misses implicit bindings and module-globals |
+| Grep canonical word only (e.g., `[Pp]ackage`) | #1482 — `pkg` / `Pkg` slip past |
+| Grep `*.ry` only | #1414 — `runSource("...")` embedded Ry in C++ tests is missed |
+| `^\s+` anchor (one-or-more spaces) | Misses module-global declarations at column 0 (#1468) |
+| Body regex `[a-zA-Z0-9]+` (no underscore) | Truncates names like `cow_global_box` mid-identifier |
+
+### Step 4: Re-verify until zero hits
+
+Re-run the Step 2 patterns until each returns zero (or only intentional carve-outs):
+
+```bash
+for pat in '<old>' '<Old>' '<deriv>' '<Deriv>'; do
+  hits=$(grep -rnE "\\b$pat\\b" include/ src/ share/std/ tests/ .claude/ docs/ \
+    | grep -vE 'effectivePackage|RY_REGISTER_STDLIB_PACKAGE|__ry_' | wc -l)
+  echo "$pat: $hits"
+done
+```
+
+If source files (`*.cpp`, `*.hpp`, `*.ry`) were modified, build + test before declaring complete:
+
+```bash
+cmake --build build && ./build/ry_tests && ./build/ry test -p
+```
+
+For docs / `.claude/` only changes, hand off to `/pre-commit-checklist`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ issue 確認 → `/git-claim-issue` で `wip` 付与 → ナレッジベース�
   - 編集予定 path の `.claude/rules/<name>.md` / `.claude/skills/<name>/SKILL.md` の関連エントリを参照したか (該当エントリがあれば Plan 本文に引用し、活用方法を明示する)
   - 仕様通りに実装できていることのセルフ検証タスク
   - 英語ドキュメント（README.md / docs）の更新（または変更不要の確認）
+  - 用語変更・識別子 rename を含む場合: `/horizontal-sweep` を計画タスクに含める（4 ステップ手順は `.claude/skills/horizontal-sweep/SKILL.md`）
 - **スコープ外の問題を発見した場合**: 「責務の分離」セクション「スコープ外の問題を発見した場合の対応ルール」に従う。実装計画内に「スコープ外 issue の起票」タスクを含める
 
 ## repo build と stdlib 解決


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/horizontal-sweep/SKILL.md` (133 lines) — context-triggered skill that unifies the four sweep-gap lessons (#1414 / #1444 / #1466 / #1482) into a single 4-step procedure: derivative table → multi-pattern grep → `sed -i ''` bulk replace → re-verify until zero hits. Anti-pattern table explicitly forbids per-site `Read+Edit` (the #1466 root cause).
- Surfaces the skill from `AGENTS.md` Plan-モードのルール (+1 line) so any plan involving terminology / identifier rename triggers `/horizontal-sweep`.
- Adds cross-reference lines at the end of the four contributing rule entries (`tests-spec-conventions.md` #1466, `docs-reference-conventions.md` #1444 / #1482, `tests-cpp-conventions.md` #1414) so reading those rules also surfaces the integrated procedure.
- The derivative table is **referenced** from `docs-reference-conventions.md:375-389` rather than duplicated, keeping the canonical table single-source.

## Out-of-scope

Legacy residuals (`src/module_loader.cpp:157` `package_path`, `src/codegen_call_dispatch.cpp:113-114` `pkg`) are tracked separately as #1511 and will dogfood this new skill.

## Test plan

- [x] `find .claude/skills/horizontal-sweep -name SKILL.md` — file exists, frontmatter `name:` matches directory
- [x] `description:` includes core trigger words (`用語変更`, `rename`, `sweep`, `sed`, `派生語`)
- [x] Cross-ref landings: 5 instances total (AGENTS.md 1, tests-spec 1, docs-ref 2, tests-cpp 1) — verified via `grep -n "horizontal-sweep" ...`
- [x] AGENTS.md addition is ≤ 2 lines (1 line)
- [x] `./build/ry_tests` (2051 passed) + `./build/ry test -p` (168 files / 0 failures) — unchanged since no source files modified
- [x] No background residual processes
- [x] Stale `MEMORY.md` references (`lib/std/` → `share/std/`) updated locally as a side-cleanup

Closes #1499

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with guidance on development procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->