### PR TITLE
chore: compress test-checklist and preparing-for-release skills (#1503)

### DIFF
--- a/.claude/skills/preparing-for-release/SKILL.md
+++ b/.claude/skills/preparing-for-release/SKILL.md
@@ -8,20 +8,11 @@ metadata:
 
 # Preparing for Release
 
-Open the **Release prep** issue, the **Release** issue, and the **Release cleanup** issue under the target version's milestone, kicking off the tag-push driven release flow described in `AGENTS.md` "リリースワークフロー".
-
-> **Note:** This skill only files issues. Release prep (CHANGELOG aggregation) and Release (tag push) use the standard issue-driven flow (`git-claim-issue` → feature branch → PR → `git-merge-pr`). Release cleanup is verification-only (`gh run list`, `gh release view`, `gh api PATCH milestone`) — no branch or PR needed.
-
-## Repository
-
-- owner: `t0k0sh1`
-- repo: `ry`
+Open **Release prep** + **Release** + **Release cleanup** issues under the target version's milestone (AGENTS.md "リリースワークフロー"). The skill only files issues — prep & release use the standard `git-claim-issue` → branch → PR → `git-merge-pr` flow; cleanup is verification-only (`gh run list`, `gh release view`, `gh api PATCH milestone`).
 
 ## Inputs
 
-User input: `$ARGUMENTS` (release version, e.g. `0.0.14` or `v0.0.14`).
-
-If no version is supplied, **ask the user** before proceeding. Do NOT guess.
+Repository: `t0k0sh1/ry`. User input `$ARGUMENTS` (release version, e.g. `0.0.14` or `v0.0.14`). If absent, **ask the user** — do NOT guess.
 
 ## Steps
 
@@ -69,50 +60,24 @@ gh issue create \
   --body "$(cat <<'EOF'
 ## Goal
 
-Aggregate `changelog.d/` fragments into `CHANGELOG.md` and finalize the `[<X.Y.Z>] - YYYY-MM-DD` section so that the release tag can be cut.
-
-## Scope
-
-This issue follows the standard issue-driven development flow:
-
-1. Claim with `git-claim-issue`
-2. Create a feature branch from `main`
-3. Do the work below
-4. Self-verify
-5. Open a PR to `main` and merge with `git-merge-pr`
-
-The release tag itself is **out of scope** — it is handled by the sibling Release issue.
+Aggregate `changelog.d/` fragments into `CHANGELOG.md` and finalize the `[<X.Y.Z>] - YYYY-MM-DD` section so the release tag can be cut. Standard issue-driven flow (`git-claim-issue` → branch → PR → `git-merge-pr`); the release tag itself is out of scope (sibling Release issue).
 
 ## Tasks
 
-### 1. Run the assembly script
+### 1. Run `scripts/assemble-changelog.sh`
 
-```bash
-scripts/assemble-changelog.sh
-```
+Collapses `changelog.d/*.md` fragments into `[Unreleased]` and deletes them.
 
-This collapses every fragment in `changelog.d/*.md` into the `[Unreleased]` section of `CHANGELOG.md` and deletes the consumed fragments.
-
-### 2. Rename `[Unreleased]` to the released version
-
-In `CHANGELOG.md`, change the heading:
+### 2. Rename `[Unreleased]` → `[<X.Y.Z>] - YYYY-MM-DD` (today's UTC date)
 
 ```diff
 -## [Unreleased]
 +## [<X.Y.Z>] - YYYY-MM-DD
 ```
 
-Use today's date (UTC) in `YYYY-MM-DD` form.
+### 3. Insert a fresh empty `[Unreleased]` heading
 
-### 3. Insert a fresh empty `[Unreleased]` section
-
-Above the new `[<X.Y.Z>]` heading, insert:
-
-```markdown
-## [Unreleased]
-```
-
-(Body intentionally empty — future fragments will repopulate it.)
+Above the new `[<X.Y.Z>]` heading, insert `## [Unreleased]` (body empty; future fragments repopulate).
 
 ### 4. Update comparison links at the bottom of `CHANGELOG.md`
 
@@ -122,19 +87,16 @@ Above the new `[<X.Y.Z>]` heading, insert:
 +[<X.Y.Z>]: https://github.com/t0k0sh1/ry/compare/v<PREV>...v<X.Y.Z>
 ```
 
-`<PREV>` is the previous released version (top of the existing comparison link list).
+`<PREV>` = previous released version (top of the existing list).
 
 ## Verification
 
-- `git diff CHANGELOG.md` shows: new `[<X.Y.Z>]` heading + new empty `[Unreleased]` + updated comparison links
-- `changelog.d/` no longer contains assembled fragments
-- `git status` reflects the deleted fragment files
-- `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p` passes (sanity check; sanitizer / fuzzer runs are not required for a docs-only change)
+- `git diff CHANGELOG.md` shows new `[<X.Y.Z>]` + empty `[Unreleased]` + updated comparison links; `changelog.d/` no longer contains the assembled fragments
+- `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p` passes (sanitizer/fuzzer runs not required for a docs-only change; see `/pre-commit-checklist`)
 
 ## Out of scope
 
-- Bumping any VERSION file (none exists; CMake defaults `RY_VERSION` to `0.0.0` and CI injects from the tag)
-- Pushing the `v<X.Y.Z>` tag — handled by the Release issue
+Bumping VERSION files (none exists; CMake defaults `RY_VERSION` to `0.0.0`, CI injects from tag); pushing `v<X.Y.Z>` (Release issue).
 EOF
 )"
 ````
@@ -143,11 +105,7 @@ Capture the new issue number from the URL printed by `gh issue create` — call 
 
 ### Step 5: Create the Release issue
 
-**Substitution rules before invocation:**
-
-- Replace every `<X.Y.Z>` placeholder with the validated version.
-- Replace every `<P>` placeholder with the prep issue number captured in Step 4.
-- Leave `<NEXT>` as a literal — the release worker fills it in only if they choose to defer remaining open issues.
+**Substitution:** as Step 4 + replace `<P>` with the prep issue number; leave `<NEXT>` literal.
 
 ````bash
 gh issue create \
@@ -200,18 +158,14 @@ git push origin v<X.Y.Z>
 
 ### 4. Report to the user
 
-Tell the user:
+- Tag `v<X.Y.Z>` pushed; `release.yml` running: <https://github.com/t0k0sh1/ry/actions/workflows/release.yml>
+- Once `release.yml` finishes and the Release publishes, proceed to the Release cleanup issue to verify artifacts and close the milestone
 
-- The tag `v<X.Y.Z>` has been pushed
-- `release.yml` is now running — link: <https://github.com/t0k0sh1/ry/actions/workflows/release.yml>
-- They should watch the workflow — once `release.yml` finishes and the GitHub Release is published, proceed to the Release cleanup issue (also in this milestone) to verify artifacts and close the milestone
-
-Then **stop**. Do not poll the workflow, do not auto-close the milestone — those steps belong to the human owner.
+Then **stop** — do not poll the workflow or auto-close the milestone (the human owner does both).
 
 ## Out of scope
 
-- Editing `CHANGELOG.md` (done by prep issue #<P>)
-- Closing the milestone (done by the Release cleanup issue in this milestone)
+Editing `CHANGELOG.md` (prep issue #<P>); closing the milestone (cleanup issue).
 EOF
 )"
 ````
@@ -220,11 +174,7 @@ Capture the new issue number from the URL printed by `gh issue create` — call 
 
 ### Step 6: Create the Release cleanup issue
 
-**Substitution rules before invocation:**
-
-- Replace every `<X.Y.Z>` placeholder with the validated version.
-- Replace every `<R>` placeholder with the release issue number captured in Step 5.
-- Leave everything else as literals — the cleanup worker verifies and executes as-is.
+**Substitution:** as Step 4 + replace `<R>` with the release issue number.
 
 ````bash
 gh issue create \
@@ -280,8 +230,7 @@ gh api -X PATCH "repos/t0k0sh1/ry/milestones/$MS_NUM" -f state=closed
 
 ## Out of scope
 
-- Creating the next milestone (intentionally a separate, deliberate act)
-- Bumping any docs/version files (none today)
+Creating the next milestone (deliberately separate); bumping docs/version files (none today).
 EOF
 )"
 ````
@@ -290,9 +239,4 @@ Capture the new issue number from the URL printed by `gh issue create` — call 
 
 ### Step 7: Report
 
-Report to the user with:
-
-- Release prep issue: `#<P> Release prep: v<X.Y.Z>` and its URL
-- Release issue: `#<R> Release: v<X.Y.Z>` and its URL
-- Release cleanup issue: `#<C> Release cleanup: v<X.Y.Z>` and its URL
-- A note that work should start with `#<P>` (claim with `git-claim-issue`), and that `#<C>` should be addressed after `#<R>` is closed.
+Report `#<P>` (Release prep), `#<R>` (Release), `#<C>` (Release cleanup) with their URLs. Work starts at `#<P>` (claim via `git-claim-issue`); `#<C>` is addressed after `#<R>` closes.

--- a/.claude/skills/test-checklist/SKILL.md
+++ b/.claude/skills/test-checklist/SKILL.md
@@ -16,25 +16,7 @@ Produce a structured checklist of test perspectives for the target feature **bef
 
 ## Why this skill exists
 
-The `/tdd-cycle` skill defines *when* to write tests. This skill defines *what to cover*.
-
-The anti-pattern it breaks:
-
-```text
-Write tests for the happy path
-  → boundary value is set via arithmetic workaround
-  → direct literal path is never exercised
-  → lexer/parser bug ships to release
-```
-
-Recurring omission classes that caused real bugs:
-
-- Annotation variant gap (#1020, #1024) — fully-typed lambda tested; untyped lambda missing
-- Mutation-in-iteration (#1021) — collection mutated inside `for` loop not tested
-- Embedded special bytes (#1022) — `"\0"` inside string never tested
-- Type-cross boundary (#1023) — `int/0` tested but `int/0.0` was not
-- Workaround masking (#1025) — boundary value set via `-MAX - 1` instead of direct literal
-- Error message text (#1026, #1027) — error *occurs* is tested but error *message text* is not
+`/tdd-cycle` defines *when* to write tests; this skill defines *what to cover*. P1–P8 below codify recurring omission classes from past ry releases (#1020–#1027): happy-path tests pass while the targeted parse/codegen branch goes uncovered (annotation variants, in-loop mutation, embedded NUL, type-cross boundary, arithmetic-workaround masking, message-text gaps).
 
 > **Forbidden conclusion**: "Tests pass → this boundary is covered." A test that avoids the direct code path does not cover the underlying parse/codegen branch.
 
@@ -101,46 +83,16 @@ For each selected category, consult the **Categories** section below and list th
 
 ### Step 4: Detect existing-test anti-patterns
 
-Run the following checks on the target test file(s):
+Run these checks against the target test files; report each match with a verdict.
 
-**P5 — INT64_MIN arithmetic workaround (known instance: `tests/spec/int_overflow.test.ry:29`):**
-
-```text
-Grep pattern: -9223372036854775807\s*-\s*1
-Path: tests/spec/
-```
-
-If matched → report location as **P5 FAIL**.
-
-**P5 — Generic MAX/MIN ±1 workaround (named-constant variant):**
-
-```text
-Grep pattern: (MAX|MIN)\w*\s*[+-]\s*1
-Path: tests/spec/
-```
-
-> Note: This pattern catches named-constant workarounds (e.g. `max_val = ...; max_val + 1`). Ry test code typically uses numeric literals, so no match is the common case. Use the INT64_MIN literal pattern above as the primary detection mechanism.
-
-**P3 — Embedded NUL byte coverage absent:**
-
-```text
-Grep (files-without-match) pattern: "\\0"
-Path: tests/spec/str*.test.ry
-```
-
-Files without a match likely lack P3 coverage.
-
-**P6 — Runtime error message text not verified:**
-
-For each file containing `Err(e):`, check whether it also contains an explicit message assertion on `e.message` (e.g. `toEq`, `toContain`, `toMatch`, or any expression that directly checks the text). If only `toBeErr()` is used with no message text check → **P6 PARTIAL**.
-
-**P1 — Annotation variant gap:**
-
-Two-step: (1) grep for a fully-typed lambda `\(\w+:\s*\w+.*\)\s*=>` in the test file; (2) check whether the same file also has an untyped lambda `\(\w+,\s*\w+\)\s*=>` or `\(\w+\)\s*=>`. If typed-only → **P1 FAIL**.
-
-**P7 — Compile-time diagnostic text not verified:**
-
-In `tests/test_codegen_fail.cpp`, check whether `expectCompileError` calls include a second argument (expected message text). Calls with only a source snippet → **P7 PARTIAL**.
+| Pattern | Detection | Path | Verdict |
+|---|---|---|---|
+| P5 INT64_MIN literal workaround | `grep '\-9223372036854775807\s*-\s*1'` | `tests/spec/` | **FAIL** if matched (live: `int_overflow.test.ry:29`) |
+| P5 named-constant workaround | `grep '(MAX\|MIN)\w*\s*[+-]\s*1'` | `tests/spec/` | **FAIL** if matched (rare; literals are primary) |
+| P3 embedded NUL absent | `grep -L '"\\0"'` | `tests/spec/str*.test.ry` | files without match → likely lack coverage |
+| P6 message text not verified | `Err(e):` arms must use `toEq`/`toContain`/`toMatch` on `e.message` (not bare `toBeErr()`) | `tests/spec/` | **PARTIAL** if assertion absent |
+| P1 annotation variant gap | typed lambda `\(\w+:\s*\w+.*\)\s*=>` present but no untyped `\(\w+\)\s*=>` in same file | per-file | **FAIL** if typed-only |
+| P7 compile-time text not verified | `expectCompileError` call has no 2nd argument | `tests/test_codegen_fail.cpp` | **PARTIAL** |
 
 ### Step 5: Emit report
 
@@ -165,16 +117,15 @@ Output using the **Report Template** section below, with concrete proposed code 
 
 ## Categories
 
-### Arithmetic / Operators
+> Generic equivalence/boundary cases (numeric literal forms, empty/single/large collections, ASCII vs UTF-8 partitions, etc.) live in `/test-design-techniques`. The rows below focus on ry-specific patterns (P1–P8).
 
-Applicable patterns: **P1, P4, P5, P8**
+### Arithmetic / Operators (P1, P4, P5, P8)
 
 | Check | Pattern |
 |---|---|
 | All type combinations (int×int, int×float, float×float) | P4 |
 | Zero-division: `int/0`, `int/0.0`, `float/0`, `float/0.0`, `0.0/0.0` | P4 |
 | INT64_MIN as direct literal `-9223372036854775808` | P5 |
-| INT64_MAX, INT64_MIN, 0, -1 as boundary values | P5 |
 | Compound assignment (`+=`, `-=`, `*=`) with the same boundary set as binary ops | P1 |
 | Every rejection branch in arithmetic codegen triggered directly | P8 |
 
@@ -192,15 +143,10 @@ min = -9223372036854775807 - 1   -- DO NOT use arithmetic to express boundary li
 
 ---
 
-### Strings
-
-Applicable patterns: **P3, P6, P8**
+### Strings (P3, P6, P8)
 
 | Check | Pattern |
 |---|---|
-| Empty string `""` | P3 |
-| ASCII-only | P3 |
-| Multibyte UTF-8 | P3 |
 | Embedded NUL byte `"\0"` and `"a\0b"` | P3 |
 | UFCS equivalence: `f(s, ...)` == `s.f(...)` result | — |
 | Runtime error message text verified for invalid operations (e.g. `str[i]`) | P6 |
@@ -227,13 +173,10 @@ it("should report correct error for str indexing", ():
 
 ---
 
-### Collections (List / Map / Set)
-
-Applicable patterns: **P1, P2, P8**
+### Collections (List / Map / Set) (P1, P2, P8)
 
 | Check | Pattern |
 |---|---|
-| Empty collection, 1-element, large (> initial capacity) | — |
 | Lambdas to `map`/`filter`/`reduce`/`fold`: fully-typed, param-only-typed, fully-untyped | P1 |
 | `append!` called inside `for` loop | P2 |
 | `pop` / `remove` called inside `for` loop | P2 |
@@ -262,9 +205,7 @@ it("should reduce with fully-untyped lambda", ():
 
 ---
 
-### Type System / Inference
-
-Applicable patterns: **P1, P8**
+### Type System / Inference (P1, P8)
 
 | Check | Pattern |
 |---|---|
@@ -290,32 +231,16 @@ it("should infer Result type without annotation", ():
 
 ---
 
-### Parser / Literals
-
-Applicable patterns: **P5, P7, P8**
+### Parser / Literals (P5, P7, P8)
 
 | Check | Pattern |
 |---|---|
 | INT64_MIN / INT64_MAX as direct literals | P5 |
-| Hex literals (`0xff`), binary literals (`0b1010`) | — |
-| Scientific notation (`1e10`, `-2.5e-3`) | — |
-| Underscore-separated digits (`1_000_000`) | — |
 | Unsupported octal (`0o17`) diagnostic message text verified | P7 |
-| Type-suffix literals (`42i32`, `255u8`, `3.14f32`) | — |
 | Compile-time error text for unsupported syntax verified with `expectCompileError` 2nd arg | P7 |
 | Every parser rejection branch triggered directly | P8 |
 
-**Forbidden shape (P5):**
-```ry
-min = -9223372036854775807 - 1   -- FORBIDDEN: bypasses the literal parse path
-```
-
-**Required shape (P5 direct literal):**
-```ry
-it("INT64_MIN parses correctly", ():
-  expect(-9223372036854775808).toEq(-9223372036854775808)
-)
-```
+**P5 (direct literal vs workaround):** see Arithmetic section above for required and forbidden shapes; the same rule applies to parser-level boundary literals.
 
 **Required shape (P7 compile-time diagnostic text — C++):**
 ```cpp
@@ -327,9 +252,7 @@ expectCompileError(R"(
 
 ---
 
-### Diagnostic Quality
-
-Applicable patterns: **P6, P7**
+### Diagnostic Quality (P6, P7)
 
 | Check | Pattern |
 |---|---|
@@ -349,20 +272,11 @@ it("should give helpful error for invalid str operation", ():
 )
 ```
 
-**Required vs forbidden (P7 compile-time):**
-```cpp
-// CORRECT: message text verified
-expectCompileError(R"(x = 0o17)", "octal literals are not supported");
-
-// INCORRECT: no second argument — P7 PARTIAL
-expectCompileError(R"(x = 0o17)");
-```
+**P7 (compile-time text):** see Parser/Literals section above for the canonical shape; the rule (`expectCompileError` must take a 2nd-argument message) applies to all `expectCompileError` calls regardless of category.
 
 ---
 
-### ARC / Memory
-
-Applicable patterns: **P8** (and leak-detection)
+### ARC / Memory (P8 + leak-detection)
 
 | Check | Pattern |
 |---|---|
@@ -398,54 +312,28 @@ expect(arcLiveCount()).toEq(0)   -- FORBIDDEN: depends on global ARC state
 
 ```text
 Test Checklist Report: <target>
+Mode: <新機能追加時 | 既存コードの変更時>; Categories: <list>; Patterns: <list>
 
-Mode: <新機能追加時 | 既存コードの変更時>
-Detected categories: <list>
-Applicable patterns: <list>
+[P1] Annotation variant coverage — <verdict>
+[P2] Mutation-in-iteration — <verdict>
+[P3] Embedded special bytes — <verdict>
+[P4] Type-cross boundary matrix — <verdict>
+[P5] Workaround masking — <verdict>     (if FAIL: <file:line> — found <expr>, required <literal>)
+[P6] Runtime error message text — <verdict>
+[P7] Compile-time diagnostic text — <verdict>
+[P8] Rejection-branch direct trigger — <verdict>
 
-[P1] Annotation variant coverage — <COVERED | NOT COVERED | PARTIAL | N/A>
-  <details if NOT COVERED or PARTIAL>
+Verdict vocabulary: COVERED / NOT COVERED / PARTIAL / PASS / FAIL / UNKNOWN / N/A.
+For each NOT COVERED / PARTIAL / FAIL row, append a proposed test snippet (.test.ry or C++).
 
-[P2] Mutation-in-iteration — <COVERED | NOT COVERED | N/A>
-  <details>
-
-[P3] Embedded special bytes — <COVERED | NOT COVERED | N/A>
-  <details>
-
-[P4] Type-cross boundary matrix — <COVERED | PARTIAL | N/A>
-  <missing cells>
-
-[P5] Workaround masking — <PASS | FAIL | N/A>
-  Location: <file:line> — Found: <workaround expression>
-  Required: <direct literal>
-  Proposed fix:
-    <code snippet>
-
-[P6] Runtime error message text — <PASS | PARTIAL | N/A>
-  <files where e.message or toEq is missing>
-
-[P7] Compile-time diagnostic text — <PASS | PARTIAL | N/A>
-  <expectCompileError calls missing second argument>
-
-[P8] Rejection-branch direct trigger — <COVERED | NOT COVERED | UNKNOWN>
-  <rejection branch locations from grepping the source>
-
----
-Proposed test additions:
-<concrete .test.ry or C++ snippets for each NOT COVERED / PARTIAL item>
-
-Reference: `/tdd-cycle` §<mode>; `.claude/rules/tests-rejection-tdd.md` (rejection branch rule)
+Reference: `/tdd-cycle` §<mode>; `.claude/rules/tests-rejection-tdd.md`.
 ```
 
 ---
 
 ## Notes
 
-- This skill performs **read-only** operations only (`Read`, `Grep`, `Glob`, `git diff`, `git log`). It never writes files, edits tests, or creates commits.
-- `.claude/rules/tests-spec-conventions.md` — `.test.ry` `case` arms must have a non-empty body: use `()` for intentional no-op, or `fail("reason")` to mark an unexpected path.
-- For *when* to write tests, see the `/tdd-cycle` skill.
-- For *deductive* test design (equivalence partitioning, boundary value analysis, state transition, decision table, pairwise), see the `/test-design-techniques` skill — this checklist is the inductive complement (ry-specific recurring omissions).
-- For rejection-branch test requirements, see `.claude/rules/tests-rejection-tdd.md`.
-- For ARC leak-detection patterns, see `.claude/rules/tests-arc-leak-pattern.md`.
+- Read-only skill (`Read`, `Grep`, `Glob`, `git diff`, `git log`).
+- Cross-references: `/tdd-cycle` (timing); `/test-design-techniques` (deductive complement); `.claude/rules/tests-rejection-tdd.md` (P8); `.claude/rules/tests-arc-leak-pattern.md` (ARC delta); `.claude/rules/tests-spec-conventions.md` (`case` arm conventions).
 
-*Canonical source for test syntax examples: `tests/spec/result.test.ry` (P6), `tests/spec/arc_release_on_index_overwrite.test.ry` (ARC delta), `tests/spec/int_overflow.test.ry` (P5 live workaround instance).*
+*Canonical source examples: `tests/spec/result.test.ry` (P6), `tests/spec/arc_release_on_index_overwrite.test.ry` (ARC delta), `tests/spec/int_overflow.test.ry` (P5 live workaround instance).*


### PR DESCRIPTION
## Summary

`.claude/skills/` の最大 2 ファイルを圧縮し、fire 時のコンテキスト消費を削減します。

| File | Before | After | Ceiling | Margin |
|---|---|---|---|---|
| `test-checklist/SKILL.md` | 451 | 339 | 370 | 31 |
| `preparing-for-release/SKILL.md` | 298 | 242 | 250 | 8 |

`/test-design-techniques`（演繹）と `/pre-commit-checklist` への委譲、および AGENTS.md 「issue 起点の開発」への参照集約により、機能的な情報損失なく圧縮しました。Closes #1503.

## Acceptance criteria

- [x] `test-checklist` ≤ 370 行（339 行）
- [x] `preparing-for-release` ≤ 250 行（242 行）
- [x] 削除内容の根拠を本 PR で明示（下記 Cut tables）
- [x] `test-checklist` の P1–P8 体系を保持（8 行の表、7 カテゴリ、ry 固有 code shape）
- [x] CI: `./build/ry_tests`（2051 tests）+ `./build/ry test -p`（168 files）green

## Cut justifications: `test-checklist` (-112 lines)

| Cut | 範囲 | 内容 | 根拠 |
|---|---|---|---|
| C1 | "Why this skill exists" | bug list を P1–P8 表に統合済の事実を踏まえ、anti-pattern コードを 1 行説明に置換 | P1–P8 表（保持必須）が同等の情報を持つ |
| C2 | Step 4 grep patterns | 5 grep パターンを 1 つの table に集約（pattern / path / 判定） | 表現密度の改善、情報量は維持 |
| C3a | Parser/Literals P5 forbidden+required shape | Arithmetic 188–192 と完全重複 → 上方参照に置換 | 同一 skill 内の duplicate |
| C3b | Diagnostic Quality P7 required-vs-forbidden | Parser/Literals P7 の例と内容重複 → 1 行参照 | 同一 skill 内の duplicate |
| C4 | Categories 各 check 表内の汎用 BVA/EP 行 | 純粋に境界値分析・同値分割で導ける行を削除し、Categories 冒頭に `/test-design-techniques` への 1 行委譲 | `/test-design-techniques`（#1497 で closed）の §境界値分析 / §同値分割が委譲先 |
| C5 | Report Template | 各 P1–P8 ブロックを `[P<n>] <name> — <verdict>` の 1 行に統合 | 構造化フォーマットで同等の情報量 |
| C6 | Notes | 重複説明を 1 行に統合 | canonical-source 行は維持 |

## Cut justifications: `preparing-for-release` (-56 lines)

| Cut | 範囲 | 内容 | 根拠 |
|---|---|---|---|
| H | Intro 周辺 | Note ブロックを frontmatter description と統合、Inputs を 1 行化 | frontmatter `description` で同等 |
| A | Step 4 body の "Scope" | AGENTS.md と完全重複 → 1 行に圧縮 | AGENTS.md がプロジェクト全体に load される |
| C | Step 4 body の Tasks 1–4 説明文 | tightening、diff ブロックは保持 | コードブロックが核、説明は冗長 |
| D | Step 4 Verification | build sanity check 行を `/pre-commit-checklist` 参照に置換 | `/pre-commit-checklist` §3.1 が canonical |
| B1/B2/B3 | 各 Step の "Out of scope" | 1 行に圧縮 × 3 | sibling issue 参照のみで十分 |
| E | Step 5 Task 4 "Report to the user" | "Tell the user:" boilerplate を削除、bullet × 2 + "Then **stop**" 段落 | stop policy は維持 |
| G1/G2 | Step 5/6 Substitution rules | "Substitution: as Step 4 + replace `<P>` / `<R>`" | Step 4 で導入済 |
| Step 7 | 4 bullets → 1 段落 | 報告フォーマットの記述密度を改善 | 情報損失なし |

## 保持リスト

**`test-checklist`:**
- `## Patterns (P1–P8)` 表（8 行、受け入れ条件 #4）
- 7 つの Category heading（Arithmetic / Strings / Collections / Type System / Parser/Literals / Diagnostic Quality / ARC/Memory）
- ry 固有 "Required shape" / "Forbidden shape" コードブロック（P5 の `tests/spec/int_overflow.test.ry:29` ライブインスタンス言及を含む）
- cross-references: `/test-design-techniques`, `/pre-commit-checklist`, `.claude/rules/tests-rejection-tdd.md`, `.claude/rules/tests-arc-leak-pattern.md`, `.claude/rules/tests-spec-conventions.md`

**`preparing-for-release`:**
- 3 issue body の Goal / Prerequisites / Tasks コードブロック（リリースワーカーが実行する仕様の核）
- Step 1 version validation（regex `^[0-9]+\.[0-9]+\.[0-9]+$`、`release.yml` ミラー）
- Step 2 milestone existence check（auto-create しない deliberate な設計）
- Step 3 duplicate detection（strict title match）
- Step 5 milestone scrub policy（other open issues への (a)/(b)/(c) 選択）

## Verification

\`\`\`
$ wc -l .claude/skills/test-checklist/SKILL.md .claude/skills/preparing-for-release/SKILL.md
     339 .claude/skills/test-checklist/SKILL.md
     242 .claude/skills/preparing-for-release/SKILL.md

$ grep -c '^| P[1-8] ' .claude/skills/test-checklist/SKILL.md
8

$ grep -cE '^### (Arithmetic|Strings|Collections|Type System|Parser|Diagnostic|ARC)' .claude/skills/test-checklist/SKILL.md
7

$ grep -r 'test-checklist\|preparing-for-release' README.md docs/
(empty — no public-doc references)
\`\`\`

Build / test:

\`\`\`
$ cmake --build build         # exit 0
$ ./build/ry_tests            # 2051 tests passed, 0 failed
$ ./build/ry test -p          # 168 test files, 0 failures
\`\`\`

`/pre-commit-checklist` skip matrix により、`.claude/`-only 変更のため ASan / UBSan / TSan / libFuzzer はスキップ。

## Test plan

- [x] `wc -l` で受け入れ上限を確認
- [x] P1–P8 行が 8 件残存
- [x] 7 カテゴリヘッディングが残存
- [x] cross-references が intact
- [x] README.md / docs に参照なし
- [x] `cmake --build build` green
- [x] `./build/ry_tests` green
- [x] `./build/ry test -p` green