### PR TITLE
docs(docker): update OS refs to Debian trixie / glibc 2.40 (#1509)

### DIFF
--- a/.claude/skills/ci-image-workflow/SKILL.md
+++ b/.claude/skills/ci-image-workflow/SKILL.md
@@ -194,3 +194,9 @@ docker build \
 - **release.yml uses `ry-ci-glibc-old`, not `ry-ci`**. Mixing them up
   will break Linux release artifacts on older distros (Ubuntu 22.04,
   RHEL 9). See the entry in `.claude/rules/ci-workflows.md`.
+- **Stale distro / glibc references in `docker/**` and
+  `.claude/skills/**/SKILL.md`**. When the Dockerfile base image
+  changes (e.g. `ubuntu:24.04` → `gcc:14-trixie` per #1505), sweep
+  both directories for the previous distro name and glibc version
+  — drift in `docker/README.md` after #1505 surfaced only at #1509.
+  Suggested grep: `grep -rni '<old-distro>\|<old-glibc>' docker/ .claude/skills/`.

--- a/.claude/skills/linux-docker-dev/SKILL.md
+++ b/.claude/skills/linux-docker-dev/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: linux-docker-dev
-description: macOS から Ubuntu 24.04 + glibc 環境で ry をビルド・テストする Docker 開発環境。Use when "Docker" / "Linux 環境" / "glibc" / "docker/run.sh" / "Ubuntu" / "ASan を Linux で確認" / Linux 固有の挙動を再現したいとき。
+description: macOS から Linux 環境 (Debian trixie + glibc 2.40、pre-baked ry-ci GHCR イメージ経由) で ry をビルド・テストする Docker 開発環境。Use when "Docker" / "Linux 環境" / "glibc" / "docker/run.sh" / "Ubuntu" / "Debian" / "trixie" / "ASan を Linux で確認" / Linux 固有の挙動を再現したいとき。
 allowed-tools: Bash
 ---
 
 # Linux Docker Development Environment
 
-Run tests under Linux (Ubuntu 24.04 + glibc) from macOS using the scripts in `docker/`. This reproduces the CI `asan`/`tsan` job environment locally and exposes Linux-only behaviour such as glibc heap consolidation checks that are invisible under macOS libSystem malloc.
+Run tests under Linux (Debian trixie + glibc 2.40, via the pre-baked `ry-ci` GHCR image) from macOS using the scripts in `docker/`. This reproduces the CI `asan`/`tsan` job environment locally and exposes Linux-only behaviour such as glibc heap consolidation checks that are invisible under macOS libSystem malloc.
 
 > **Source-of-truth note**: previously in `AGENTS.md`; relocated by #1384.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # ry Linux Docker Development Environment
 
-Run tests in a Linux (Ubuntu 24.04 + glibc) environment from macOS, matching CI conditions for all sanitizer presets.
+Run tests in a Linux environment (Debian trixie + glibc 2.40, via the pre-baked `ry-ci` GHCR image) from macOS, matching CI conditions for all sanitizer presets.
 
 See [`.claude/skills/linux-docker-dev/SKILL.md`](../.claude/skills/linux-docker-dev/SKILL.md) for full workflow documentation.
 

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Run ry tests inside a Linux (ubuntu:24.04) container from macOS.
+# Run ry tests inside a Linux (Debian trixie + glibc 2.40, via the ry-ci GHCR image) container from macOS.
 # Usage: docker/run.sh [--rebuild] <preset> [cmd [args...]]
 #   preset: default | asan | tsan
 #   cmd:    ry_tests | ry | bash  (omit for build-only)


### PR DESCRIPTION
## Summary

- `docker/README.md:3`, `docker/run.sh:2`, and `.claude/skills/linux-docker-dev/SKILL.md:3,9` had stale "Ubuntu 24.04 + glibc" references after PR #1505 migrated the dev/CI base image to `gcc:14-trixie`. Refreshed to "Debian trixie + glibc 2.40, via the pre-baked `ry-ci` GHCR image" so contributors investigating glibc-version errors or matching CI logs land on the correct baseline
- `.claude/skills/linux-docker-dev/SKILL.md` frontmatter `Use when` keyword bucket gains `"Debian"` / `"trixie"` while keeping `"Ubuntu"` as a discoverability alias
- `.claude/skills/ci-image-workflow/SKILL.md` Pitfall section gains a sweep reminder so the next base-image migration does not leave the same drift behind
- Scope-out issue #1519 filed for `.claude/rules/build-warning-flags.md:116` (Cppcheck 2.13 Ubuntu 24.04 package note) — different root cause (cppcheck moved to source-built 2.16 inside ry-ci) and verification surface

## Test plan

- [x] Negative grep: `grep -rni 'ubuntu 24\.04' docker/ .claude/skills/linux-docker-dev/` → 0 hits
- [x] Negative grep: `grep -rn 'ubuntu:24\.04' docker/` → 0 hits
- [x] Positive grep: `grep -rn 'trixie\|glibc 2\.40' docker/README.md docker/run.sh .claude/skills/linux-docker-dev/SKILL.md` → hit in each file
- [x] Residual `ubuntu` references confirmed legitimate (`DEV_USER=ubuntu`, GitHub runner names, historical apt mirror note)
- [x] SKILL.md frontmatter still parses; `"Ubuntu"` retained as Use-when trigger

## Skipped pre-commit checklist sections

- §2 — pure documentation/comment changes, no user-visible behavior
- §3 / §3.5 / §3.5.5 — no executable C++ changes
- §3.6 — no parser/lexer/json/utf8/string changes

Closes #1509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker environment testing documentation to specify Debian trixie with glibc 2.40 and the ry-ci container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->