### PR TITLE
chore: rename pkg residuals to mod in tests and comments (#1523)

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -96,7 +96,7 @@ public:
 
     // ======== LLVM Types & Builder ========
     // Members below are accessed by free-function custom emitters in
-    // codegen_call_<pkg>.cpp files, so they must be public.
+    // codegen_call_<mod>.cpp files, so they must be public.
 public:
     std::unique_ptr<llvm::LLVMContext> ctx_;
     std::unique_ptr<llvm::Module> mod_;

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -80,11 +80,11 @@ std::string CodeGen::deriveNativePackage(const SourceLocation &loc) const {
     fs::path stem = p.stem();
     fs::path parent = p.parent_path();
 
-    // /std/<pkg>/<pkg>.ry (directory module)
+    // /std/<mod>/<mod>.ry (directory module)
     if (parent.filename() == stem && parent.parent_path().filename() == "std")
         return stem.string();
 
-    // /std/<pkg>.ry (single-file module, excluding builtins.ry)
+    // /std/<mod>.ry (single-file module, excluding builtins.ry)
     if (parent.filename() == "std" && stem != "builtins")
         return stem.string();
 

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -210,7 +210,7 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &package_path
         return {};
     };
 
-    // Relative import: "." or "./subpkg" — resolve only against referrer_dir
+    // Relative import: "." or "./submod" — resolve only against referrer_dir
     bool is_relative = (package_path == ".") ||
                        (package_path.size() >= 2 &&
                         package_path[0] == '.' && package_path[1] == '/');

--- a/tests/test_builtin_stdlib_registry.cpp
+++ b/tests/test_builtin_stdlib_registry.cpp
@@ -28,8 +28,8 @@ std::string read_text(const fs::path &path) {
 TEST(BuiltinStdlibRegistry, ExpectedPackagesRegistered) {
     auto &pkgs = StdlibRegistry::instance().packages();
     std::unordered_set<std::string> names;
-    for (auto &pkg : pkgs)
-        names.insert(pkg.package_name);
+    for (auto &mod : pkgs)
+        names.insert(mod.package_name);
     for (auto *expected : {"math", "io", "net", "http", "json", "path", "thread"}) {
         EXPECT_TRUE(names.count(expected))
             << expected << " package not registered — check CMakeLists.txt ry_lib sources";
@@ -37,8 +37,8 @@ TEST(BuiltinStdlibRegistry, ExpectedPackagesRegistered) {
 }
 
 TEST(BuiltinStdlibRegistry, DeclarationFilesExist) {
-    for (auto &pkg : StdlibRegistry::instance().packages()) {
-        EXPECT_TRUE(fs::exists(repo_root() / pkg.decl_path)) << pkg.decl_path;
+    for (auto &mod : StdlibRegistry::instance().packages()) {
+        EXPECT_TRUE(fs::exists(repo_root() / mod.decl_path)) << mod.decl_path;
     }
 }
 
@@ -66,8 +66,8 @@ TEST(BuiltinStdlibRegistry, NativeConstantsAreDeclaredInStdlib) {
     // Verify each constant is declared in at least one package .ry file
     for (auto &[name, entry] : constants) {
         bool found = false;
-        for (auto &pkg : StdlibRegistry::instance().packages()) {
-            const std::string content = read_text(repo_root() / pkg.decl_path);
+        for (auto &mod : StdlibRegistry::instance().packages()) {
+            const std::string content = read_text(repo_root() / mod.decl_path);
             if (content.find("@const\n" + name + ":") != std::string::npos) {
                 found = true;
                 break;

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -765,7 +765,7 @@ TEST(ParserTest, ImportHyphenError) {
 
 TEST(ParserTest, ImportRelativeHyphenError) {
     try {
-        parseStr("from .-pkg import add");
+        parseStr("from .-mod import add");
         FAIL() << "Expected exception";
     } catch (const std::runtime_error &e) {
         std::string msg = e.what();


### PR DESCRIPTION
## Summary

Extends the v0.0.17 glossary sweep (#1480) to the remaining `pkg` residuals
that earlier passes (#1511) left behind. Pure rename of test loop variables
and source comments — no behavior change.

### Changes

- `tests/test_builtin_stdlib_registry.cpp` — rename loop variable `pkg` → `mod` (3 sites). The plural `pkgs` local on line 29 stays as-is per issue scope.
- `tests/test_parser.cpp:768` — relative-import-with-hyphen test fixture string `from .-pkg import add` → `from .-mod import add`. Same error path; semantic unchanged.
- `src/codegen_fn.cpp:83,87` — comments describing stdlib path conventions in `deriveNativePackage` (`<pkg>` → `<mod>`).
- `include/ry/codegen.hpp:99` — comment in `CodeGen` class documenting public access for custom emitters (`codegen_call_<pkg>.cpp` → `codegen_call_<mod>.cpp`).
- `src/module_loader.cpp:213` — comment describing relative import shape (`./subpkg` → `./submod`).

### Carve-outs (intentionally preserved)

Per the v0.0.17 glossary, these legacy names stay as-is for ABI / API stability:

- `package_name`, `decl_path` — `RegisteredStdlibPackage` struct fields
- `.packages()` — `StdlibRegistry` API
- `RY_REGISTER_STDLIB_PACKAGE` — registration macro
- `effectivePackage` — codegen identifier
- `__ry_<symbol>` — C symbol prefix

Closes #1523

## Test plan

- [x] `cmake --build build && ./build/ry_tests` — 2051/2051 passed
- [x] `./build/ry test -p` — 168 files, 0 failures
- [x] ASan+UBSan: `./build-asan/ry_tests` 2051/2051 + `./build-asan/ry test -p` 168/168
- [x] TSan: `./build-tsan/ry_tests` 2051/2051 + `./build-tsan/ry test -p` 168/168
- [x] `clang-tidy` on src/ — clean
- [x] `cppcheck` — clean
- [x] Skipped §3.6 libFuzzer — no parser/lexer/json/utf8/string changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified module filename pattern and refined wording around standard-library module detection and relative import resolution.

* **Tests**
  * Updated tests to reflect the revised module-related terminology and loop variable naming, preserving existing assertions and expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->