### PR TITLE
chore: rename std::ofstream 'pkg' to 'manifestFile' in test_trace.cpp

### DIFF
--- a/tests/test_trace.cpp
+++ b/tests/test_trace.cpp
@@ -168,8 +168,8 @@ TEST_F(TraceModeTest, TraceCanBeRedirectedToFile) {
 
 TEST_F(TraceModeTest, TraceWithParallelTestsFallsBackToSequential) {
     fs::create_directories(tmp_dir_ / "tests");
-    std::ofstream pkg(tmp_dir_ / "package.toml");
-    pkg << "[project]\nname = \"trace\"\nversion = \"0.1.0\"\nentry = \"main.ry\"\n";
+    std::ofstream manifestFile(tmp_dir_ / "package.toml");
+    manifestFile << "[project]\nname = \"trace\"\nversion = \"0.1.0\"\nentry = \"main.ry\"\n";
     std::ofstream mainFile(tmp_dir_ / "main.ry");
     mainFile << "print(\"main\")\n";
     std::ofstream testFile(tmp_dir_ / "tests/sample.test.ry");


### PR DESCRIPTION
## Summary

- `tests/test_trace.cpp:171-172` の `std::ofstream pkg` を `manifestFile` に rename
- v0.0.17 の `package` → `module` 用語変更 (#1511) の sweep 残留物。manifest ファイル名 `package.toml` 自体は ABI carve-out として維持、C++ ローカル変数のみ内部命名として更新
- 同ファイル内の `mainFile` / `testFile` (camelCase + 役割接尾辞) スタイルに整合させ、`package.toml` を書く stream の役割を `manifest` で正確に表現

Closes #1524

## Test plan

- [x] `cmake --build build` clean
- [x] `./build/ry_tests --gtest_filter='*TraceModeTest*'` — 4/4 pass (含む `TraceWithParallelTestsFallsBackToSequential`)
- [x] `./build/ry_tests` — 2051 tests pass
- [x] `./build/ry test -p` — 168 test files, 0 failures
- [x] ASan + UBSan: ry_tests 2051 + Ry self-test 168 files all clean
- [x] TSan: ry_tests 2051 + Ry self-test 168 files all clean
- [x] cppcheck (`src/ include/`) exit=0
- [x] `grep -n 'pkg' tests/test_trace.cpp` — 0 hits (rename 完全)

## Pre-commit checklist skip records

- Skipped §1 (Doc) — no user-visible change (test-internal local variable rename)
- Skipped §2 (CHANGELOG) — no user-visible change (chore-only, mirrors #1526 scope)
- Skipped §2.5 (rules/skills) — single judgment case, no recurring pattern
- Skipped §3.5.5 clang-tidy local — macOS Apple-clang PCH SDK 既知問題で `<cstdint>` not found; 解析対象は `src/`/`include/` で本 PR 差分は `tests/` のみ。CI の clang-tidy ジョブで担保
- Skipped §3.6 (libFuzzer) — no parser/lexer/json/utf8/string change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Internal test code refactoring for improved clarity. No user-visible changes or impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->