### PR TITLE
chore: clarify intent of node_modules pkg fixture in file watcher test (#1525)

### DIFF
--- a/tests/test_file_watcher.cpp
+++ b/tests/test_file_watcher.cpp
@@ -64,8 +64,11 @@ TEST_F(FileWatcherTest, SkipsGitDirectory) {
 }
 
 TEST_F(FileWatcherTest, SkipsNodeModulesDirectory) {
+    // The `node_modules / pkg` path follows the npm convention (where `pkg`
+    // abbreviates `package`); it is unrelated to Ry's `module` term and
+    // exists only to verify that node_modules is excluded from the scan.
     createFile(tmp_dir / "app.ry", "a = 1");
-    createFile(tmp_dir / "node_modules" / "pkg" / "index.ry", "pkg");
+    createFile(tmp_dir / "node_modules" / "pkg" / "index.ry", "fixture");
 
     auto mtimes = ry::collectRyFileMtimes(tmp_dir.string());
 


### PR DESCRIPTION
## Summary

- `FileWatcherTest.SkipsNodeModulesDirectory` の `node_modules / pkg` パスについて、npm 慣習 (`pkg` = `package` の略) に基づくフィクスチャであり Ry の `module` 用語とは別文脈であることを示すコメントを追加
- 未使用のファイル内容文字列 `"pkg"` を中立な `"fixture"` に置き換え（Ry 用語との誤読を避けるため）
- 振る舞いの変更なし — `node_modules` 配下のスキップ動作は実装側 (`src/file_watcher.cpp:16`) で npm 由来の名前としてハードコードされているため、`pkg` を `mod` に rename すると npm/Ry いずれの用語とも整合しなくなる

## Decision

issue 受け入れ条件の policy 判断: **npm 慣習として維持**。

## Scope

- `tests/test_file_watcher.cpp:67-70`（コメント 3 行追加 + 文字列 1 箇所中立化）
- スコープ外: `tests/test_codegen_stmt.cpp` の `mypkg` / `dirpkg*` 残留物 → 別 issue #1529 で追跡

## Test plan

- [x] `cmake --build build`
- [x] `./build/ry_tests --gtest_filter="FileWatcherTest.SkipsNodeModulesDirectory"` (1/1 pass)
- [x] `./build/ry_tests` (2051/2051 pass)
- [x] `./build/ry test -p` (168 files / 0 failures)
- [x] ASan+UBSan (`build-asan/ry_tests` + `ry test -p`) pass
- [x] TSan C++ (required) pass
- [x] clang-tidy / cppcheck exit 0
- [x] libFuzzer skip (parser/lexer/json/utf8/string 非該当)

Closes #1525

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test clarifications and adjusted test fixture content for the file watcher module. Test behavior and expectations remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->