### PR TITLE
chore: dedupe path globs in two rules to reduce auto-load overlap

### DIFF
--- a/.claude/rules/codegen-type-and-metadata.md
+++ b/.claude/rules/codegen-type-and-metadata.md
@@ -1,6 +1,5 @@
 ---
 paths:
-  - "src/codegen*.cpp"
   - "include/ry/codegen.hpp"
   - "src/codegen_type.cpp"
   - "src/codegen_builtin.cpp"

--- a/.claude/rules/runtime-memory-safety.md
+++ b/.claude/rules/runtime-memory-safety.md
@@ -4,7 +4,6 @@ paths:
   - "include/ry/runtime_*.hpp"
   - "include/ry/runtime_alloc.hpp"
   - "src/codegen_stmt_loop.cpp"
-  - "src/codegen_arc*.cpp"
 ---
 
 # Runtime / Memory


### PR DESCRIPTION
## Summary

`AGENTS.md` と `.claude/` 配下の rules / skills を評価した結果、path-scoped rule の `paths:` glob 重複により、codegen ファイル編集時に最大 ~213 KB が auto-load されることを確認した。最高レバレッジの 2 箇所のみ修正（中身は変更せず paths のみ絞り込み）。

## Changes

- `.claude/rules/codegen-type-and-metadata.md`: `src/codegen*.cpp` を削除
  - 同 rule の明示リスト（`codegen_type.cpp` / `codegen_builtin.cpp` / `codegen_metadata.cpp`）が既に意図通りのスコープをカバーしている
  - 広い glob があると `codegen_call.cpp` / `codegen_match.cpp` / `codegen_lambda.cpp` 等にも 59 KB の rule が乗ってしまっていた
- `.claude/rules/runtime-memory-safety.md`: `src/codegen_arc*.cpp` を削除
  - `codegen-arc-cow.md` の `paths:` が既に `codegen_arc*.cpp` をカバーしている
  - ARC alloc / `arc_alloc` vs `checked_malloc` の知見は `codegen-arc-cow.md` 側で重複保持されているため、削除しても codegen-arc 編集時の guidance は失われない

## Effect (auto-load 削減量)

| 編集対象 | 削減量 |
|---|---|
| `src/codegen_{call,match,lambda,fn,call_string,...}.cpp` | ~59 KB |
| `src/codegen_arc*.cpp` | ~23 KB（上記に追加） |
| `include/ry/codegen.hpp` | 変化なし（複数 rule が header を共有する構造上、削減対象外） |

## Test plan

- [ ] `paths:` が意図通り絞り込まれていることを目視確認
- [ ] `codegen_arc*.cpp` 編集時に `codegen-arc-cow.md` 側の ARC ルールが引き続き auto-load されることを確認（重複の片側を残すための削除なので動作変化はない想定）