### PR TITLE
chore(skills): remove nightly references from release skills (#1534)

### DIFF
--- a/.claude/skills/preparing-for-release/SKILL.md
+++ b/.claude/skills/preparing-for-release/SKILL.md
@@ -238,16 +238,7 @@ gh release view v<X.Y.Z> --repo t0k0sh1/ry \
 
 Expect `isDraft=false`, `isPrerelease=false`, `publishedAt` populated.
 
-### 3. Verify v<X.Y.Z>-nightly was deleted
-
-```bash
-gh api repos/t0k0sh1/ry/releases/tags/v<X.Y.Z>-nightly
-git ls-remote --tags origin v<X.Y.Z>-nightly
-```
-
-Both should be empty / 404 (release.yml deletes the matching nightly per #1365).
-
-### 4. Close the milestone
+### 3. Close the milestone
 
 ```bash
 MS_NUM=$(gh api 'repos/t0k0sh1/ry/milestones?state=open' \

--- a/.claude/skills/release-orchestrator/SKILL.md
+++ b/.claude/skills/release-orchestrator/SKILL.md
@@ -27,10 +27,10 @@ Entry-point reference for the ry release flow. Routes the user to `/preparing-fo
 1. `/preparing-for-release <X.Y.Z>` を起動する。スキルが当該マイルストーンに以下 3 つの issue を作成する:
    - **Release prep: v<X.Y.Z>** — `changelog.d/` を `CHANGELOG.md` に集約し `[X.Y.Z] - YYYY-MM-DD` セクションを確定させる作業。通常の issue 駆動フロー (claim → feature branch → PR → merge) で実施
    - **Release: v<X.Y.Z>** — prep が merge された後、マイルストーンに残 issue が無いことを確認してタグを push する作業
-   - **Release cleanup: v<X.Y.Z>** — タグ push 後、`release.yml` 完了・GitHub Release 公開・nightly タグ削除を確認し、マイルストーンを close する作業 (verification-only、branch・PR 不要)
+   - **Release cleanup: v<X.Y.Z>** — タグ push 後、`release.yml` 完了・GitHub Release 公開を確認し、マイルストーンを close する作業 (verification-only、branch・PR 不要)
 2. Release prep issue を通常通り進める (`git-claim-issue` → Plan → 実装 → `git-merge-pr`)
 3. Release prep PR が main にマージされたら Release issue に着手し、その手順に従ってタグを push する
-4. Release issue が close されたら、同マイルストーン内の Release cleanup issue に着手し、`release.yml` 完了・GitHub Release 公開・nightly タグ削除を確認してからマイルストーンを close する (→「マイルストーン close ポリシー」)
+4. Release issue が close されたら、同マイルストーン内の Release cleanup issue に着手し、`release.yml` 完了・GitHub Release 公開を確認してからマイルストーンを close する (→「マイルストーン close ポリシー」)
 
 ## マイルストーン close ポリシー
 


### PR DESCRIPTION
## Summary

- `preparing-for-release/SKILL.md`: drop the `### 3. Verify v<X.Y.Z>-nightly was deleted` section and renumber `### 4. Close the milestone` to `### 3`.
- `release-orchestrator/SKILL.md`: drop the `nightly タグ削除を確認` phrase from both occurrences in the Release cleanup description.

`dev-release.yml` was retired in #1372 (v0.0.14) and stable release publication auto-deletes the matching `vX.Y.Z-nightly` prerelease per #1365, so the verification guidance is obsolete.

## Out of scope

- `CHANGELOG.md` historical entries for #1365 / #1372 are intentionally left as history (per the issue's "やらないこと").
- `src/` code-level cleanup is tracked separately.

## Test plan

- [x] `grep -rni "nightly" .claude/` returns no matches.
- [x] Section renumbering in `preparing-for-release/SKILL.md` is consistent (Step 6 still has `### 1` / `### 2` / `### 3` / `### 4` no more — now `### 1` / `### 2` / `### 3`).
- [x] Docs-only change; no runtime build/test impact.

Closes #1534