### PR TITLE
chore(rules): remove dangling KNOWLEDGE.md references (#1550)

### DIFF
--- a/.claude/rules/codegen-arc-cow.md
+++ b/.claude/rules/codegen-arc-cow.md
@@ -60,7 +60,7 @@ pointer-typed and ARC-managed, follow this sequence:
 
 **Verification gap** (resolved by #859): The ARC balance counter
 (`runtime_internal.arcLiveCount()`) is now available for delta-based
-leak assertions — see the dedicated KNOWLEDGE entry below. ASan/LSan CI
+leak assertions. ASan/LSan CI
 coverage remains tracked separately.
 
 **Follow-up landed**: Records and record fields with ARC fields

--- a/.claude/rules/codegen-pattern-and-match.md
+++ b/.claude/rules/codegen-pattern-and-match.md
@@ -20,7 +20,7 @@ take **two** source-name parameters:
   `EnumPattern`/`EnumConstructorPattern` generic-instantiated lookup, by
   `Some`/`Ok`/`Err` binding `extractGenericTypeArg`, and by `VariablePattern`
   binding's `enum_value_type` write (still guarded by
-  `enum_types_.count(resolveTypeAlias(name))` per the KNOWLEDGE L2946 rule).
+  `enum_types_.count(resolveTypeAlias(name))`).
 - `subjectSourceTypeName` — broad channel (`resolveSubjectSourceTypeName()`).
   Reconstructs `Option<T>` / `Result<T, E>` / `(T1, T2, ...)` from the LLVM
   subject type when no enum annotation exists. Used by `TuplePattern` /
@@ -46,7 +46,7 @@ parameter was overloaded with non-enum names via the new broad helper
 would force every consumer to add an `enum_types_.count(name)` guard.
 The split signature makes "enum-only" vs "broader subject type" a
 compile-time-enforced distinction. The guard at VariablePattern binding
-(`KNOWLEDGE L2946`) remains necessary but is now purely defensive
+remains necessary but is now purely defensive
 (subjectEnumName is already enum-only).
 
 **Follow-up**: Add a lossless `source_type_name` field to `ValueMetadata` so

--- a/.claude/rules/codegen-stdlib-dispatcher.md
+++ b/.claude/rules/codegen-stdlib-dispatcher.md
@@ -400,7 +400,7 @@ take **two** source-name parameters:
   `EnumPattern`/`EnumConstructorPattern` generic-instantiated lookup, by
   `Some`/`Ok`/`Err` binding `extractGenericTypeArg`, and by `VariablePattern`
   binding's `enum_value_type` write (still guarded by
-  `enum_types_.count(resolveTypeAlias(name))` per the KNOWLEDGE L2946 rule).
+  `enum_types_.count(resolveTypeAlias(name))`).
 - `subjectSourceTypeName` — broad channel (`resolveSubjectSourceTypeName()`).
   Reconstructs `Option<T>` / `Result<T, E>` / `(T1, T2, ...)` from the LLVM
   subject type when no enum annotation exists. Used by `TuplePattern` /
@@ -426,7 +426,7 @@ parameter was overloaded with non-enum names via the new broad helper
 would force every consumer to add an `enum_types_.count(name)` guard.
 The split signature makes "enum-only" vs "broader subject type" a
 compile-time-enforced distinction. The guard at VariablePattern binding
-(`KNOWLEDGE L2946`) remains necessary but is now purely defensive
+remains necessary but is now purely defensive
 (subjectEnumName is already enum-only).
 
 **Follow-up**: Add a lossless `source_type_name` field to `ValueMetadata` so

--- a/.claude/rules/tests-arc-leak-pattern.md
+++ b/.claude/rules/tests-arc-leak-pattern.md
@@ -34,8 +34,8 @@ expect(delta).toEq(k)   # k = #containers still live, not proportional to N
 ```
 
 Why delta (not absolute): the collection destructor does NOT recursively
-release ARC-managed elements (pre-existing "element leak on destructor",
-KNOWLEDGE line ≈692).  Absolute counts are therefore always non-zero after
+release ARC-managed elements (pre-existing "element leak on destructor").
+Absolute counts are therefore always non-zero after
 any collection is created.  Delta-based assertions isolate the overwrite
 path from this background noise.
 

--- a/.claude/skills/knowledge-md-management/SKILL.md
+++ b/.claude/skills/knowledge-md-management/SKILL.md
@@ -55,7 +55,7 @@ grep -rnE '\*\*Tags\*\*:.*<keyword>' .claude/rules/ .claude/skills/ KNOWLEDGE.md
 
 ## 3. 外部参照ポリシー (REQ-3)
 
-KNOWLEDGE.md の **個別 entry を指す参照** を、AGENTS.md / `.claude/rules/<*>.md` / `.claude/skills/<*>/SKILL.md` / `.claude/agents/<*>.md` から作成してはならない。理由: KNOWLEDGE.md の編集 (entry の追加・削除・順序変更・移植) で参照が容易に dangling 化する。実例として `.claude/rules/` 配下に 6 行の dangling reference が残存した実績がある (現在は別 issue で整理予定)。
+KNOWLEDGE.md の **個別 entry を指す参照** を、AGENTS.md / `.claude/rules/<*>.md` / `.claude/skills/<*>/SKILL.md` / `.claude/agents/<*>.md` から作成してはならない。理由: KNOWLEDGE.md の編集 (entry の追加・削除・順序変更・移植) で参照が容易に dangling 化する。実例として `.claude/rules/` 配下に 6 行の dangling reference が残存した実績がある (#1550 で整理済み)。
 
 ### 禁止される参照パターン
 

--- a/changelog.d/1550-knowledge-refs-cleanup.md
+++ b/changelog.d/1550-knowledge-refs-cleanup.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Removed 6 dangling references to a previously existing `KNOWLEDGE.md` from `.claude/rules/` (4 files: `tests-arc-leak-pattern.md`, `codegen-pattern-and-match.md`, `codegen-stdlib-dispatcher.md`, `codegen-arc-cow.md`). All references were broken pointers — the surrounding sentences are self-contained, so only the citation fragments were removed. Brings the rules tree into alignment with `/knowledge-md-management` REQ-3 (no individual-entry references to KNOWLEDGE.md from `AGENTS.md` / `.claude/rules/` / `.claude/skills/` / `.claude/agents/`). Also updated the skill's own self-reference (`.claude/skills/knowledge-md-management/SKILL.md`) to mark the cleanup as completed. Knowledge-base only — no code, ABI, or build behavior changes. (#1550)


### PR DESCRIPTION
## Summary

Closes #1550.

Removes 6 dangling references to a previously existing `KNOWLEDGE.md` from `.claude/rules/` (4 files). All references were broken pointers — the surrounding sentences are self-contained, so only the citation fragments were removed.

Brings the rules tree into alignment with `/knowledge-md-management` REQ-3 (no individual-entry references to KNOWLEDGE.md from `AGENTS.md` / `.claude/rules/` / `.claude/skills/` / `.claude/agents/`), established in #1549.

### Changes

- `.claude/rules/tests-arc-leak-pattern.md` — removed `KNOWLEDGE line ≈692` citation
- `.claude/rules/codegen-pattern-and-match.md` — removed two `KNOWLEDGE L2946` citations (L23, L49)
- `.claude/rules/codegen-stdlib-dispatcher.md` — same two citations (L403, L429)
- `.claude/rules/codegen-arc-cow.md` — removed `— see the dedicated KNOWLEDGE entry below`
- `.claude/skills/knowledge-md-management/SKILL.md` — updated self-reference from `(現在は別 issue で整理予定)` to `(#1550 で整理済み)`
- `changelog.d/1550-knowledge-refs-cleanup.md` — added CHANGELOG fragment

Knowledge-base only — no code, ABI, or build behavior changes.

### Pre-commit Checklist

Per `/pre-commit-checklist` skip-if matrix (`.claude/` + `changelog.d/` only):

- §1 Documentation — Skipped (no user-visible change)
- §2 CHANGELOG — Satisfied via `changelog.d/1550-knowledge-refs-cleanup.md` fragment
- §3 Tests / §3.5 Sanitizer / §3.6 libFuzzer — Skipped (no source code change)
- §3.7 Background Task Hygiene — Verified (no residual tasks)

## Test plan

- [x] `grep -rnE 'KNOWLEDGE(\.md)?\s*(L[0-9]+|line\s+|entry\s+(above|below|here))' .claude/rules/` → 0 lines
- [x] `grep -rn 'KNOWLEDGE' .claude/rules/` → 0 lines (no other KNOWLEDGE tokens remain)
- [x] Visual review of all 7 modifications — prose remains grammatical and semantically intact

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation to reflect knowledge management system cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->