### PR TITLE
docs(visibility): document @public model and known limitations (#1547)

### DIFF
--- a/.claude/rules/docs-reference-conventions.md
+++ b/.claude/rules/docs-reference-conventions.md
@@ -398,3 +398,50 @@ Approved abbreviations for Ry are listed in `docs/reference/naming.md` "Approved
 - This rule complements the "Doc-wide identifier migrations need multi-pattern sweeps" rule above: identifier migrations are about code-shape patterns (declarations, assignments, type ascriptions), terminology migrations are about lexical equivalences (canonical word + shorthands).
 
 → See `/horizontal-sweep` for the integrated 4-step procedure that builds on this rule.
+
+### Multi-file design intent must be empirically verified before documenting
+
+**Source**: #1547 (visibility documentation)
+**Tags**: documentation, design-vs-implementation, verification, multi-file, package
+
+**Context**: While writing `docs/guide/visibility.md` for #1547, the planned
+wrapper pattern (REQ-B3 from #1543: "hide a helper inside a sub-module,
+expose only a thin `@public` facade that calls through") was documented
+straight from the design intent. Self-verification with actual `.ry`
+files revealed the pattern does not work — the compiler resolves all
+symbols in a single linkage unit, and cross-package import filtering
+drops non-`@public` helpers from the importer's program before code-gen
+can see them. This was discovered only because the doc author wrote a
+multi-file layout under `/tmp/` (with `package.toml`) and ran
+`./build/ry` end-to-end. A single `./build/ry -c` snippet could not have
+surfaced it because the failure depends on cross-package import behavior.
+Tracking issue for the implementation gap: #1560.
+
+**Rule**: When documenting a feature whose behavior depends on
+**multi-file or multi-package layout** (visibility, module resolution,
+package boundaries, anonymous packages, `RY_PATH` search, relative
+imports, directory modules, etc.), do not trust the design specification
+or issue requirements alone. Construct a minimal multi-file repro under
+`/tmp/` matching the layout in the docs and run `./build/ry` to confirm
+the example works end-to-end before publishing.
+
+**How to apply**:
+- For each example layout in `docs/guide/*.md` or in
+  `docs/reference/{modules,directives}.md` that depends on file
+  arrangement, build it under `/tmp/` and execute it with `./build/ry`.
+  Use `[project]` in `package.toml` (not `[package]`) — see the manifest
+  format in `share/std/package.toml`.
+- Test all import shapes the docs describe: selective
+  (`from foo import x`), wildcard (`from foo`), relative (`from .foo`),
+  and cross-package vs same-package callers. Failure modes can differ
+  per shape: as of v0.0.17, selective imports drop unselected helpers
+  even within the same package; wildcard imports across packages filter
+  non-`@public` symbols silently.
+- If the documented behavior diverges from observed behavior, file an
+  issue (per `/scope-out-issue`), document the discrepancy with an issue
+  link, and revise the docs to describe what works today rather than
+  what the design spec promised. Do not ship aspirational examples in a
+  user-facing guide.
+- Single-snippet `./build/ry -c` verification (the
+  "Example code in docs must match the current Ry syntax" rule above) is
+  necessary but not sufficient for multi-file scenarios.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,16 @@ Ry is a simple programming language based on LLVM JIT. It adopts Python-style in
 
 ---
 
+## Guides
+
+Topic-oriented walkthroughs for designing Ry code. Reference pages remain the source of truth for syntax and semantics; guides focus on the "how to think about it" layer.
+
+| Page | Contents |
+|------|----------|
+| [Visibility](guide/visibility.md) | Package-internal default, `@public`, cross-package import behavior, known limitations |
+
+---
+
 ## Reference
 
 For detailed language specifications, see the reference pages below.

--- a/docs/guide/visibility.md
+++ b/docs/guide/visibility.md
@@ -1,0 +1,143 @@
+# Visibility Guide
+
+This guide explains how Ry decides which definitions can be imported from where, and how to organize symbols within a package.
+
+For the formal specification see [Modules — Visibility](../reference/modules.md#visibility) and [Glossary — Visibility scopes](../reference/glossary.md#visibility-scopes); for the directive itself see [Directives — `@public`](../reference/directives.md#public).
+
+## Overview
+
+Ry's visibility model has two levels:
+
+| Level | Marker | Visible from |
+|---|---|---|
+| **package-internal** (default) | none | the same package only |
+| **public** | `@public` | any package (universe scope) |
+
+There is no third level — every definition is either package-internal or `@public`. Designing a multi-file package therefore reduces to one question per definition: should this be importable from outside the package?
+
+## Default: package-internal
+
+A definition with no `@public` marker is visible only inside its **package** — the directory tree rooted at the nearest ancestor directory containing a `package.toml` file. Two source files belong to the same package when they share the same package root.
+
+```text
+mylib/
+  package.toml
+  calc.ry        # fn add() — package-internal
+  helpers.ry     # fn fmt() — package-internal
+```
+
+```ry
+# mylib/calc.ry
+from .helpers import fmt   # OK — same package
+
+fn add(a: int, b: int) -> int:
+    return a + b
+```
+
+```ry
+# mylib/helpers.ry
+fn fmt(n: int) -> str:
+    return "value: " + toStr(n)
+```
+
+Any importer **outside** `mylib/` cannot see `add` or `fmt` until they are marked `@public`.
+
+Files that have no `package.toml` ancestor — for example, ad-hoc scripts run with `./build/ry script.ry`, or expressions passed via REPL `-c` — share a single **anonymous package**. They all behave as one package for visibility purposes, so a script can freely import any non-`@public` definition from another script in the same anonymous-package universe.
+
+## Making a definition public
+
+Apply `@public` on its own line immediately above the declaration. Multiple directives can be stacked.
+
+```ry
+# mylib/calc.ry
+@public
+fn add(a: int, b: int) -> int:
+    return a + b
+
+@public
+record Point:
+    x: int
+    y: int
+
+@public
+@const
+PI = 3.14159
+```
+
+`@public` is accepted on functions, records, enums, type aliases, variable declarations (with or without `@const`), and `@directive` declarations.
+
+### Cross-package import behavior
+
+Suppose `mylib/calc.ry` defines one `@public` function and one package-internal helper:
+
+```ry
+# mylib/calc.ry
+@public
+fn add(a: int, b: int) -> int:
+    return a + b
+
+fn helper(n: int) -> int:    # no @public — package-internal
+    return n * 2
+```
+
+From outside the `mylib/` package:
+
+| Import | Result |
+|---|---|
+| `from mylib import add` | OK — `add` is `@public` |
+| `from mylib import helper` | Compile error — `'helper' is not @public` |
+| `from mylib` (wildcard) | Imports `add` only; `helper` is silently filtered |
+
+The error vs. silent filter distinction is intentional: a named import expresses intent, so importing a non-`@public` symbol by name is treated as a mistake. A wildcard expresses "give me everything you make available," so non-`@public` symbols are simply omitted from "everything."
+
+From **inside** the same package, both `add` and `helper` are importable regardless of `@public`.
+
+## Cross-file private helpers (currently unsupported)
+
+> **Status (v0.0.17):** the wrapper pattern shown below is **not yet implemented**. Tracking issue: [#1560](https://github.com/t0k0sh1/ry/issues/1560).
+
+In a multi-file package, you might want a sub-module to keep a helper hidden while a parent module exposes a thin `@public` facade that calls through. The intent is that external callers can use `bas()` but cannot reach `xxx()`:
+
+```text
+foo/
+  package.toml
+  foo.ry         # @public fn bas() — facade
+  bar.ry         # fn xxx()          — internal helper
+```
+
+```ry
+# foo/foo.ry
+from foo.bar import xxx
+
+@public
+fn bas() -> int:
+    return xxx()
+```
+
+This pattern looks reasonable, but `from foo import bas` from another package fails with `undefined function: xxx`. The Ry compiler resolves all symbols within a single linkage unit, and the cross-package import filter omits non-`@public` symbols — so `bas()`'s body cannot find `xxx` at code-gen time. The same failure occurs with `from .bar import xxx` (relative), with helper and facade in the same `.ry` file, and with `from foo` wildcard. **Today there is no layout that exposes `bas` while hiding `xxx` across a package boundary.**
+
+**Workarounds until #1560 is resolved:**
+
+1. **Mark the helper `@public` too**, accepting that external code can call it directly. Signal "internal use" by naming/comments rather than the type system.
+2. **Inline the helper into the facade function** when the body is small enough to avoid extracting a helper.
+
+(Note that the same-package wildcard import — `from .other` from another file in the same package — is the only multi-file scenario in which a `@public` facade can call a non-`@public` helper today. Selective imports such as `from .other import name` drop the helper from the importer's program even within the same package.)
+
+Records, enums, and type aliases face the same restriction by a different mechanism — only values, not type names, can flow through a function call, so a wrapper function cannot re-export a type even after #1560 is fixed. Types intended to cross package boundaries must be declared directly on a public-facing module with `@public`.
+
+## `_` prefix has no visibility meaning
+
+Earlier versions of Ry treated a leading underscore (`_helper`) as a private marker. As of v0.0.17 this is no longer true — the prefix is purely a naming convention. Visibility is controlled exclusively by `@public`.
+
+See [Naming Conventions](../reference/naming.md) for current style guidance.
+
+## Standard library is a single package
+
+The entire `share/std/` tree is **one** package — `share/std/package.toml` is its package root. Every stdlib sub-module (`math`, `io`, `path`, `filesystem`, `regex`, `thread`, …) lives inside that single package boundary.
+
+Two consequences follow:
+
+1. **From user code**, only stdlib symbols marked `@public` are importable. `from math import sqrt` resolves to a `@public` symbol that the stdlib package chooses to expose. Non-`@public` helpers inside the stdlib (for instance, internal implementation files under `share/std/runtime_internal/` or under `share/std/core/`) remain package-internal and are invisible to importers.
+2. **Inside the stdlib itself**, stdlib modules can freely call each other's package-internal helpers. This keeps maintenance ergonomics close to a single-codebase project even though the stdlib spans many sub-modules.
+
+If the stdlib is ever split into independently-released packages (a future possibility tied to the planned `ry add` system), each piece would gain its own `package.toml` and the cross-stdlib helper calls would need explicit `@public` markers.

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -17,10 +17,13 @@ Directives can be applied to the following declarations:
 
 - `fn` - Function definitions (including named test functions with the `@it` / `@describe` directive)
 - `record` - Record definitions
+- `enum` - Enum definitions (currently `@public` targets enums)
+- `type` - Type alias declarations (currently `@public` targets type aliases)
 - Variable declarations (with or without `@const`)
 - Fields within a `record` definition
 - `for` - Counted loops; among built-ins, only `@parallel` targets `for`. User-defined directives declaring `target=["for"]` may also be applied to `for` statements; directives with a different target are silently ignored per the target-mismatch rule.
 - `it` / `describe` calls (legacy lambda form) - Test cases and test groups for `@each` and `@property`
+- `@directive` declarations themselves (so a directive declaration can be marked `@public` for cross-package import)
 
 ## Built-in Directives
 
@@ -110,6 +113,57 @@ a, b = (1, 2)
 ```
 
 **Top-level `@const` and functions.** A top-level `@const` declaration is visible from any top-level function defined after it in the same source file, and the immutability is enforced for every reference — including field mutations through a top-level `@const` record. See the "Top-Level Variables and `@const` in Function Bodies" section in [functions.md](functions.md) for details.
+
+### `@public`
+
+Marks a definition as visible across package boundaries. Without `@public`, every definition is **package-internal** — visible only within the same package (the directory tree rooted at the nearest ancestor `package.toml`). Adding `@public` lifts the definition to **universe** scope so it can be imported from any package.
+
+**Defined as:** Compiler built-in. Registered in `src/directive_meta.cpp`'s built-in registry; there is no `.ry` declaration for `@public` in `share/std/core/directive.ry`.
+
+**Applicable to:** function (`fn`), record, enum, `type` alias, variable declarations (with or without `@const`), and `@directive` declarations.
+
+The directive accepts no arguments. It is placed on its own line immediately above the declaration, and multiple directives may be stacked.
+
+```ry
+@public
+fn add(a: int, b: int) -> int:
+    return a + b
+
+@public
+record Point:
+    x: int
+    y: int
+
+@public
+@const
+PI = 3.14159
+```
+
+**Cross-package import behavior:**
+
+Given `mylib/calc.ry` (where `mylib/` contains a `package.toml` of its own):
+
+```ry
+# mylib/calc.ry
+@public
+fn add(a: int, b: int) -> int:
+    return a + b
+
+fn helper(n: int) -> int:    # package-internal — no @public
+    return n * 2
+```
+
+From a different package (importer outside `mylib/`):
+
+```ry
+from mylib import add        # OK — add is @public
+from mylib import helper     # Error — 'helper' is not @public
+from mylib                   # wildcard: imports add only; helper is silently filtered
+```
+
+From inside the same package as `mylib/calc.ry`, both `add` and `helper` are importable regardless of `@public`.
+
+The leading `_` underscore on an identifier carries **no** visibility meaning; visibility is controlled exclusively by `@public`. See [Modules — Visibility](modules.md#visibility) for the full rules and [Glossary — Visibility scopes](glossary.md#visibility-scopes) for the underlying scope vocabulary.
 
 ### `@native`
 
@@ -561,15 +615,18 @@ The compiler built-in directive `@native` cannot be applied to `for` statements 
 
 ### Export and import
 
-Directive declarations participate in the standard module system. A directive declared in `mymodule/mod.ry` is exported by name and can be imported with `from mymodule import directiveName`. Like other definitions, directives are package-internal by default and require `@public` to be importable across package boundaries (see [Modules — Visibility](modules.md#visibility)).
+Directive declarations participate in the standard module system. A directive declared in `mymodule/mod.ry` is exported by name and can be imported with `from mymodule import directiveName`. Like other definitions, directives are package-internal by default and require [`@public`](#public) to be importable across package boundaries (see [Modules — Visibility](modules.md#visibility)).
 
-Most built-in directives are now declared in `share/std/`. Core directives (`@deprecated`, `@const`, `@inline`, `@parallel`) are declared in `share/std/core/directive.ry` and are re-exported via `share/std/builtins.ry`, which means they are implicitly available without an explicit import. Testing directives (`@it`, `@describe`, `@each`, `@property`) are declared in `share/std/testing/testing.ry`; test files that use them must add `from testing import it, describe, each, property` (or the subset they need) at the top. Only `@directive` and `@native` remain as compiler built-ins (see "Bootstrap rule" below).
+Most built-in directives are now declared in `share/std/`. Core directives (`@deprecated`, `@const`, `@inline`, `@parallel`) are declared in `share/std/core/directive.ry` and are re-exported via `share/std/builtins.ry`, which means they are implicitly available without an explicit import. Testing directives (`@it`, `@describe`, `@each`, `@property`) are declared in `share/std/testing/testing.ry`; test files that use them must add `from testing import it, describe, each, property` (or the subset they need) at the top. The compiler built-ins `@directive`, `@native`, and `@public` have no `share/std/` declaration (see "Bootstrap rule" below).
 
 ### Bootstrap rule
 
-`@directive` itself and `@native` are **compiler built-ins** and cannot be redeclared in `.ry` source. (`@native` is registered in `src/directive_meta.cpp`'s built-in registry; `@directive` is handled as a hardcoded special form in the parser.) The reason is self-referential: the `@directive(...)` declaration syntax binds a directive to its C++ implementation through `@native`, and `@native` cannot mark its own declaration. These two directives remain permanently in C++.
+`@directive`, `@native`, and `@public` are **compiler built-ins** and have no declaration in `share/std/`. The reasons differ:
 
-All other built-in directives (`@deprecated`, `@const`, `@inline`, `@parallel`, `@each`, `@property`) are now declared in `share/std/` (the core ones in `share/std/core/directive.ry`, the testing ones in `share/std/testing/testing.ry`). Only `@directive` and `@native` remain in the C++ registry due to the bootstrap constraint.
+- `@directive` and `@native` are tied together by self-reference: the `@directive(...)` declaration syntax binds a directive to its C++ implementation through `@native`, and `@native` cannot mark its own declaration. (`@native` is registered in `src/directive_meta.cpp`'s built-in registry; `@directive` is handled as a hardcoded special form in the parser.) These two directives remain permanently in C++.
+- `@public` is registered in `src/directive_meta.cpp` purely so the parser can validate its placement before the visibility model has any user-defined directives to consult — it provides parser-level metadata, not a self-reference workaround.
+
+All other built-in directives (`@deprecated`, `@const`, `@inline`, `@parallel`, `@each`, `@property`) are declared in `share/std/` (the core ones in `share/std/core/directive.ry`, the testing ones in `share/std/testing/testing.ry`).
 
 ## Notes
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -24,16 +24,31 @@ The **project manifest** at the root of a Ry project, describing project metadat
 
 See [Project Management](project.md) for the manifest specification.
 
-## Package boundary (visibility scope)
+## Visibility scopes
 
-The **package boundary** is the directory tree rooted at the nearest ancestor directory containing a `package.toml` file. It is the unit used by the visibility model: package-internal definitions are visible only within their package boundary, while `@public` definitions are visible across boundaries. Source files that have no `package.toml` ancestor share a single anonymous package.
+The visibility model uses three named scopes:
 
-This is a third sense of the word "package" — distinct from the strict ["Package"](#package) definition above (external library) and looser than the ["`package.toml`"](#packagetoml) manifest itself. It is named "package" because the boundary is literally defined by the presence of `package.toml`; the visibility model uses no separate term.
+| Scope | Definition |
+|---|---|
+| **file** | The single `.ry` file in which a definition is declared. |
+| **package** | The directory tree rooted at the nearest ancestor directory containing a `package.toml` file. Two files belong to the same package when they share the same package root. |
+| **universe** | Visible from any package — no boundary applies. Reserved for `@public` definitions. |
 
-See [Module Reference — Visibility](modules.md#visibility) for the visibility rules.
+Source files that have no `package.toml` ancestor (for example, ad-hoc scripts and REPL `-c` input) share a single anonymous package — they all behave as one package for visibility purposes.
+
+The two visibilities supported by Ry today map onto these scopes:
+
+- **package-internal** (default, no marker) — `package` scope
+- **`@public`** — `universe` scope
+
+This is a third sense of the word "package" — distinct from the strict ["Package"](#package) definition above (external library) and looser than the ["`package.toml`"](#packagetoml) manifest itself. It is named "package" because the boundary is literally defined by the presence of `package.toml`; the visibility model uses no separate term. The intermediate `file` scope is reserved as vocabulary; no Ry directive currently targets it.
+
+See [Module Reference — Visibility](modules.md#visibility) for the practical visibility rules and import semantics.
 
 ## stdlib (`std`)
 
 The **standard library**, also written `std`. A collection of built-in modules — including `math`, `io`, `path`, `filesystem`, `thread`, `regex`, and others — that is automatically imported into every program. The stdlib provides core types, conversion helpers (`toInt`, `toStr`, `toFloat`, `toBool`), built-in functions (`print`, `len`, `range`), and common utilities.
+
+The entire stdlib forms a single package — `share/std/package.toml` is its package root. Stdlib modules can therefore reference each other's package-internal helpers freely, while user code only sees `@public` stdlib symbols.
 
 See [Module Reference — Standard Library](modules.md#standard-library-std) for the full list of stdlib sub-modules and import semantics.

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -94,7 +94,7 @@ Every definition (`fn`, `record`, `enum`, `type` alias, `let`, `@directive`) has
 | **package-internal** (default) | none | the same package only |
 | **public** | `@public` | any importer (any package) |
 
-A **package** here means the visibility boundary — the directory tree rooted at the nearest ancestor directory containing a `package.toml` file. Two source files belong to the same package when they share the same package root. Files that have no `package.toml` ancestor (e.g. ad-hoc scripts, REPL `-c` input) share a single anonymous package. (This is distinct from the future external-library "package" reserved in the [glossary](glossary.md#package); see [Package boundary](glossary.md#package-boundary-visibility-scope).)
+A **package** here means the visibility boundary — the directory tree rooted at the nearest ancestor directory containing a `package.toml` file. Two source files belong to the same package when they share the same package root. Files that have no `package.toml` ancestor (e.g. ad-hoc scripts, REPL `-c` input) share a single anonymous package. (This is distinct from the future external-library "package" reserved in the [glossary](glossary.md#package); see [Visibility scopes](glossary.md#visibility-scopes).)
 
 The leading `_` underscore on an identifier carries **no** visibility meaning — it is just a naming convention. Visibility is controlled exclusively by `@public`.
 
@@ -129,6 +129,8 @@ The standard library (`std`) is a collection of built-in modules automatically i
 - String functions (`contains`, `find`, `replace`, etc.)
 - Type conversion functions (`toInt`, `toFloat`, `toStr`)
 - Collection functions (`map`, `filter`, `sort`, etc.)
+
+The entire standard library forms a single package — `share/std/package.toml` is its package root. Stdlib modules can therefore share package-internal helpers across files; user code only sees the symbols marked `@public`. An import such as `from math import sqrt` resolves to a `@public` symbol exposed by the stdlib package.
 
 ### Sub-modules
 


### PR DESCRIPTION
## Summary

Reflects the visibility model redesign from #1543 (and the implementation work from #1544 / #1545 / #1546) into the user-facing documentation:

- **Glossary** — Restructure the visibility scopes section into a 3-row table (`file` / `package` / `universe`) and note the stdlib single-package boundary.
- **Modules reference** — Update the visibility-scope anchor reference and add a stdlib single-package note.
- **Directives reference** — Add a full `### @public` section (definition, applicable targets, cross-package import behavior). Update the Bootstrap rule to list `@public` as the third compiler built-in (parser-level metadata, not a self-reference workaround).
- **Visibility guide** (new) — User-facing walkthrough covering default package-internal scope, `@public`, anonymous packages, cross-package import semantics, the `_` prefix non-meaning, and stdlib single-package consequences.
- **README** — Add a Guides section linking to the new guide.

## Known limitation discovered during self-verification

While writing the guide, I tested the REQ-B3 wrapper pattern from #1543 (hide a helper inside a sub-module, expose only a thin `@public` facade that calls through). It does not work in the current implementation — `module_loader.cpp` conflates visibility filtering with code-availability for JIT linkage, so cross-package facades cannot reach non-`@public` helpers. Filed as #1560.

The guide's "Sub-module facade (wrapper pattern)" section was therefore rewritten as **"Cross-file private helpers (currently unsupported)"** with a status note pointing to #1560 and two practical workarounds. Aspirational examples were not shipped.

Captured the broader lesson (multi-file behavior must be empirically verified, not just specified) as a new entry in `.claude/rules/docs-reference-conventions.md`.

## Pre-commit-checklist

- §1 Doc: ✓ (this PR is the doc update)
- §2 CHANGELOG: skipped — no user-visible code change
- §2.5 rules/skills: ✓ (multi-file verification rule added)
- §3-§3.6 (tests / Sanitizer / libFuzzer): skipped — no source code change
- §3.7 background hygiene: clean
- §4 Label cleanup: deferred to git-merge-pr Step 5

## Test plan

- [x] `grep -nE '\*\*(file|package|universe)\*\*' docs/reference/glossary.md` shows the three scopes
- [x] `grep -rn 'package-boundary-visibility-scope' docs/` returns 0 (old anchor purged)
- [x] `grep -nE '\bval\b|\bvar\b|\bpublic\b|\bprivate\b'` on edited docs returns no false positives
- [x] `grep -nE '[Pp]kg' docs/reference/{glossary,modules,directives}.md docs/guide/visibility.md` returns 0
- [x] Reproduced the @public cross-package examples in `docs/reference/directives.md` against `./build/ry`: `from mylib import add` succeeds, `from mylib import helper` errors with `'helper' is not @public`, `from mylib` (wildcard) imports `add` only.
- [x] Reproduced the relative-import example in `docs/guide/visibility.md` Default section (`from .helpers import fmt` from inside `mylib/`).

Closes #1547.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added new Visibility Guide documenting how visibility works in Ry, including import behavior and current limitations
* Documented the @public directive with placement rules and applicable declaration targets  
* Enhanced reference materials to clarify visibility scopes and standard library organization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->