### PR TITLE
refactor(parser): remove `!!` operator alias of `?` (#1568)

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -187,22 +187,21 @@ directly for the tail line.
 
 ### Identifier-trailing `!` tokenization must exclude every multi-char operator starting with `!`
 
-**Source**: #1211 (2026-04-20, bug fix)
-**Tags**: parser, lexer, identifier, trailing-bang, bangbang, ambiguity
+**Source**: #1211 (2026-04-20, bug fix); updated #1568 (`!!` operator removed)
+**Tags**: parser, lexer, identifier, trailing-bang, ambiguity
 
 **Context**: The lexer greedily absorbs a trailing `!` into an
 identifier to support mutating method names (`sort!`, `reverse!`,
-`append!`, `clear!`). The original guard only excluded `!=`, so `r!!`
-tokenized as `r!` (Ident) + `!` (Error) and parse-failed as
-`expected ')'` when used in expression position like `Ok(r!!)`. The
-postfix error-propagation alias `!!` was thus broken for the
-identifier-direct case — the documented equivalence with `?` was only
-honored when the preceding token was not an identifier (e.g. after `)`).
+`append!`, `clear!`). Two-character operators that begin with `!` must
+be excluded from this absorption, otherwise `r<op>` mis-tokenizes as
+`r!` (Ident) + the operator's tail. The currently active such operator
+is `!=`. (#1211 originally added `!!` to the exclusion as well; #1568
+removed the `!!` operator entirely, so the exclusion is now `!=`-only.)
 
 **Rule**: The trailing-bang absorption in the identifier branch
 (`src/lexer.cpp` identifier tokenization) must exclude **every**
-multi-character operator token that begins with `!`, not just `!=`.
-Currently that means `!=` and `!!`; any future operator starting with
+multi-character operator token that begins with `!`, not just whatever
+operators happen to be present today. Any future operator starting with
 `!` (hypothetical `!~`, `!?`, etc.) must be added to the exclusion set
 at the same time it is introduced in the operator lexer branch.
 

--- a/changelog.d/1568-remove-bang-bang.md
+++ b/changelog.d/1568-remove-bang-bang.md
@@ -1,0 +1,6 @@
+### Removed
+
+- `!!` operator. Use `?` instead — the two operators were identical aliases since
+  introduction, and removing one eliminates a stylistic split that added review
+  cost without benefit. Sources using `!!` will fail to parse; replace each `!!`
+  with `?`. (#1568)

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -6,7 +6,7 @@ Lower numbers indicate higher precedence (evaluated first).
 
 | Precedence | Operator | Description | Associativity |
 |---|---|---|---|
-| 0 | `?` `!!` | Error propagation (postfix) | Left |
+| 0 | `?` | Error propagation (postfix) | Left |
 | 1 | `()` | Grouping | -- |
 | 2 | `+x` `-x` `~x` | Unary plus, unary minus, bitwise NOT | Right |
 | 3 | `**` | Exponentiation | Right |
@@ -125,9 +125,9 @@ masked = flags & 0b0011   # 3
 shifted = 1 << 8          # 256
 ```
 
-## Error Propagation Operator (`?` / `!!`)
+## Error Propagation Operator (`?`)
 
-The postfix `?` operator unwraps a `Result` or `Option` value on the happy path and short-circuits on the unhappy path. The `!!` operator is an alias for `?` with identical semantics.
+The postfix `?` operator unwraps a `Result` or `Option` value on the happy path and short-circuits on the unhappy path.
 
 | Operand | Happy path | Unhappy path |
 |---|---|---|
@@ -147,7 +147,7 @@ fn safeDivide(a: int, b: int) -> Result<int, Error>:
 
 fn compute(a: int, b: int, c: int) -> Result<int, Error>:
     x = safeDivide(a, b)?    # returns Err early if b == 0
-    y = safeDivide(x, c)!!
+    y = safeDivide(x, c)?
     return Ok(y + 1)
 
 fn safeGet(xs: List<int>, i: int) -> Option<int>:
@@ -163,7 +163,7 @@ fn firstPlusSecond(xs: List<int>) -> Option<int>:
 
 ### At the top level
 
-`?` and `!!` can also be used directly at the top level of a script. There, `Err(e)` and `None` are treated as fatal errors: the error message is written to stderr and the process exits with status `1`.
+`?` can also be used directly at the top level of a script. There, `Err(e)` and `None` are treated as fatal errors: the error message is written to stderr and the process exits with status `1`.
 
 ```ry
 fn mk() -> Result<int, Error>:

--- a/include/ry/lexer.hpp
+++ b/include/ry/lexer.hpp
@@ -109,7 +109,6 @@ enum class TokenKind {
     As,             // as
     // --- Error type ---
     ErrorKw,        // Error
-    BangBang,       // !!
     Question,       // ?
     Async,          // async
     Await,          // await

--- a/src/lexer.cpp
+++ b/src/lexer.cpp
@@ -374,9 +374,6 @@ Token Lexer::readToken() {
     if (c == ',') { ++pos_; ++col_; return {TokenKind::Comma,  ",", line_, startCol}; }
     if (c == '!') {
         ++pos_; ++col_;
-        if (pos_ < src_.size() && src_[pos_] == '!') {
-            ++pos_; ++col_; return {TokenKind::BangBang, "!!", line_, startCol};
-        }
         if (pos_ < src_.size() && src_[pos_] == '=') {
             ++pos_; ++col_; return {TokenKind::BangEq, "!=", line_, startCol};
         }
@@ -623,10 +620,9 @@ Token Lexer::readToken() {
         size_t start = pos_;
         while (pos_ < src_.size() && (std::isalnum(static_cast<unsigned char>(src_[pos_])) || src_[pos_] == '_')) { ++pos_; ++col_; }
         // Allow trailing '!' for mutating method names (e.g., sort!, reverse!)
-        // but not '!=' (not-equal) or '!!' (error-propagate operator)
+        // but not '!=' (not-equal).
         if (pos_ < src_.size() && src_[pos_] == '!' &&
-            (pos_ + 1 >= src_.size() ||
-             (src_[pos_ + 1] != '=' && src_[pos_ + 1] != '!'))) {
+            (pos_ + 1 >= src_.size() || src_[pos_ + 1] != '=')) {
             ++pos_; ++col_;
         }
         std::string id(src_, start, pos_ - start);

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -1037,15 +1037,10 @@ ExprPtr Parser::parsePostfix() {
 
 ExprPtr Parser::parsePostfixContinuation(ExprPtr expr) {
     while (lex_.peek().kind == TokenKind::Dot || lex_.peek().kind == TokenKind::LBracket ||
-           lex_.peek().kind == TokenKind::BangBang || lex_.peek().kind == TokenKind::Question) {
+           lex_.peek().kind == TokenKind::Question) {
         if (lex_.peek().kind == TokenKind::Question) {
             Token qTok = lex_.next(); // consume '?'
             expr = makeErrorPropagateExpr(std::move(expr), qTok);
-            continue;
-        }
-        if (lex_.peek().kind == TokenKind::BangBang) {
-            Token bangTok = lex_.next(); // consume '!!'
-            expr = makeErrorPropagateExpr(std::move(expr), bangTok);
             continue;
         }
         if (lex_.peek().kind == TokenKind::LBracket) {

--- a/tests/spec/option_propagate.test.ry
+++ b/tests/spec/option_propagate.test.ry
@@ -9,8 +9,8 @@ fn firstPlusSecond(xs: List<int>) -> Option<int>:
   return Some(a + b)
 
 fn firstPlusSecondBang(xs: List<int>) -> Option<int>:
-  a = safeGet(xs, 0)!!
-  b = safeGet(xs, 1)!!
+  a = safeGet(xs, 0)?
+  b = safeGet(xs, 1)?
   return Some(a + b)
 
 fn inlineExpr(xs: List<int>) -> Option<int>:
@@ -22,14 +22,14 @@ fn inlineExprAlwaysNone() -> Option<int>:
   return Some(safeGet([1], 99)? + 1)
 
 fn wrapBang(r: Option<int>) -> Option<int>:
-  return Some(r!!)
+  return Some(r?)
 
 fn addOneBang(v: Option<int>) -> Option<int>:
-  return Some(v!! + 1)
+  return Some(v? + 1)
 
 fn addOneBangNone() -> Option<int>:
   x: Option<int> = none
-  return Some(x!! + 1)
+  return Some(x? + 1)
 
 describe("Option error propagation", ():
   it("should unwrap Some value with ?", ():
@@ -46,14 +46,14 @@ describe("Option error propagation", ():
       None:
         expect(true).toEq(true)
   )
-  it("should support !! as alias for ? on Option", ():
+  it("should support ? on Option (alternate function)", ():
     case firstPlusSecondBang([1, 2]):
       Some(v):
         expect(v).toEq(3)
       None:
         fail("unexpected none")
   )
-  it("should propagate None through !!", ():
+  it("should propagate None through ?", ():
     case firstPlusSecondBang([7]):
       Some(v):
         fail("expected None but got Some")
@@ -74,28 +74,28 @@ describe("Option error propagation", ():
       None:
         expect(true).toEq(true)
   )
-  it("should support !! on identifier inside call argument", ():
+  it("should support ? on identifier inside call argument", ():
     case wrapBang(Some(42)):
       Some(v):
         expect(v).toEq(42)
       None:
         fail("unexpected none")
   )
-  it("should propagate None via !! on identifier inside call argument", ():
+  it("should propagate None via ? on identifier inside call argument", ():
     case wrapBang(none):
       Some(v):
         fail("expected None but got Some")
       None:
         expect(true).toEq(true)
   )
-  it("should support !! on identifier in arithmetic expression", ():
+  it("should support ? on identifier in arithmetic expression", ():
     case addOneBang(Some(41)):
       Some(v):
         expect(v).toEq(42)
       None:
         fail("unexpected none")
   )
-  it("should propagate None via !! on identifier in arithmetic expression", ():
+  it("should propagate None via ? on identifier in arithmetic expression", ():
     case addOneBangNone():
       Some(v):
         fail("expected None but got Some")

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -461,14 +461,12 @@ TEST_F(CodeGenTest, TopLevelQuestionOnResultErrExits) {
         "top level boom");
 }
 
-TEST_F(CodeGenTest, TopLevelBangBangOnResultErrExits) {
-    EXPECT_EXIT(runSource(
+TEST_F(CodeGenTest, BangBangIsRejectedAtParse) {
+    EXPECT_THROW(runSource(
         "fn mk() -> Result<int, Error>:\n"
-        "  return Err(Error(\"bang bang fail\"))\n"
+        "  return Ok(1)\n"
         "v = mk()!!\n"
-        "print(v)\n"),
-        ::testing::ExitedWithCode(1),
-        "bang bang fail");
+        "print(v)\n"), std::runtime_error);
 }
 
 TEST_F(CodeGenTest, TopLevelQuestionOnOptionSomeContinues) {

--- a/tests/test_lexer.cpp
+++ b/tests/test_lexer.cpp
@@ -1157,20 +1157,23 @@ TEST(LexerTest, MapLiteralTokens) {
         EXPECT_EQ(toks[i].kind, expected[i]) << "index: " << i;
 }
 
-TEST(LexerTest, BangBangOperator) {
+TEST(LexerTest, BangBangIsLexedAsTwoErrorBangs) {
     auto toks = tokenize("!!");
-    ASSERT_EQ(toks.size(), 2u);
-    EXPECT_EQ(toks[0].kind, TokenKind::BangBang);
-    EXPECT_EQ(toks[0].value, "!!");
+    ASSERT_EQ(toks.size(), 3u);
+    EXPECT_EQ(toks[0].kind, TokenKind::Error);
+    EXPECT_EQ(toks[0].value, "!");
+    EXPECT_EQ(toks[1].kind, TokenKind::Error);
+    EXPECT_EQ(toks[1].value, "!");
+    EXPECT_EQ(toks[2].kind, TokenKind::Eof);
 }
 
-TEST(LexerTest, BangBangAfterIdentifier) {
+TEST(LexerTest, BangBangAfterIdentifierAbsorbsFirstBang) {
     auto toks = tokenize("r!!");
     ASSERT_EQ(toks.size(), 3u);
     EXPECT_EQ(toks[0].kind, TokenKind::Ident);
-    EXPECT_EQ(toks[0].value, "r");
-    EXPECT_EQ(toks[1].kind, TokenKind::BangBang);
-    EXPECT_EQ(toks[1].value, "!!");
+    EXPECT_EQ(toks[0].value, "r!");
+    EXPECT_EQ(toks[1].kind, TokenKind::Error);
+    EXPECT_EQ(toks[1].value, "!");
     EXPECT_EQ(toks[2].kind, TokenKind::Eof);
 }
 


### PR DESCRIPTION
## Summary

- Removes the `!!` postfix operator entirely from the lexer, parser, AST consumer, codegen, docs, and tests, leaving `?` as the sole error-propagation operator
- Per user direction, this is an immediate removal in v0.0.20 with no deprecation path or backward compatibility — the issue's original two-stage migration (warning → removal) was collapsed into a single breaking change
- Sources that still use `!!` will fail to parse with a generic "unexpected token" error; replace each `!!` with `?`

## Changes

- `include/ry/lexer.hpp`: drop `BangBang` token enum
- `src/lexer.cpp`: drop the `!!` lex branch, restrict identifier-trailing `!` exclusion to `!=`
- `src/parser_expr.cpp`: drop `BangBang` from `parsePostfixContinuation`
- `tests/test_lexer.cpp`: flip the two existing `BangBang` tests to lock in the new lex shape (`r!!` → `Ident("r!") + Error("!")`, `!!` → two `Error("!")`)
- `tests/test_codegen.cpp`: replace `TopLevelBangBangOnResultErrExits` with `BangBangIsRejectedAtParse`; equivalent positive coverage already exists via `TopLevelQuestionOnResultErrExits`
- `tests/spec/option_propagate.test.ry`: rewrite all 11 `!!` occurrences (5 operator usages + 6 `it()` description strings) to `?`
- `docs/reference/operators.md`: drop `!!` from the precedence table, the §Error Propagation heading, the worked example, and the top-level explanation
- `.claude/rules/parser-conventions.md`: update the #1211 entry — the `!=`/`!!` exclusion is now `!=`-only, and the rule is reframed as historical
- `changelog.d/1568-remove-bang-bang.md`: new fragment under `### Removed`

## Test plan

- [x] `./build/ry_tests` (GoogleTest)
- [x] `./build/ry test -p` (Ry self-test)
- [x] ASan + UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p`
- [x] TSan: `./build-tsan/ry_tests` (2091 tests)
- [x] clang-tidy + cppcheck (0 errors)
- [x] `fuzz_parser` 60s — 59922 runs, no crash
- [x] `grep -rnE '!!'` across `tests/spec/`, `share/std/`, `src/`, `include/`, `docs/` — no remaining operator usages
- [x] CLI verification: `./build/ry -c -` with a `!!` source exits non-zero with a parse error

Closes #1568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed**
  * The `!!` postfix operator for error propagation has been removed. All code must be updated to use `?` instead. Existing sources containing `!!` will fail to parse.

* **Documentation**
  * Updated operator reference to reflect current syntax, removing `!!` references and updating all examples to use `?` for error propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->