### PR TITLE
feat: support fixed-length List destructuring assignment (#1567)

### DIFF
--- a/changelog.d/1567-list-destructuring.md
+++ b/changelog.d/1567-list-destructuring.md
@@ -1,0 +1,10 @@
+### Added
+
+- List destructuring assignment. `a, b = some_list` (and the parenthesized
+  form `(a, b) = some_list`) now unpacks a `List<T>` whose runtime length
+  matches the number of names on the left. The `_` wildcard, `@const`
+  prefix, and function-return values work the same as for tuple
+  destructuring. A length mismatch aborts with
+  `runtime error: list destructuring expected N elements but got M`,
+  matching Python's semantics. The motivating idiom `a, b = split(s, " ")`
+  now works without an intermediate temporary. (#1567)

--- a/changelog.d/1567-list-destructuring.md
+++ b/changelog.d/1567-list-destructuring.md
@@ -2,9 +2,10 @@
 
 - List destructuring assignment. `a, b = some_list` (and the parenthesized
   form `(a, b) = some_list`) now unpacks a `List<T>` whose runtime length
-  matches the number of names on the left. The `_` wildcard, `@const`
-  prefix, and function-return values work the same as for tuple
-  destructuring. A length mismatch aborts with
+  matches the number of positions on the left, where each `_` wildcard
+  still counts as a position (so `_, b = some_list` requires two RHS
+  elements). The `_` wildcard, `@const` prefix, and function-return values
+  work the same as for tuple destructuring. A length mismatch aborts with
   `runtime error: list destructuring expected N elements but got M`,
   matching Python's semantics. The motivating idiom `a, b = split(s, " ")`
   now works without an intermediate temporary. (#1567)

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -248,6 +248,24 @@ a, b = (10, 20)           # bare form
 (_, e) = (50, 60)         # discard first component
 ```
 
+The same form also unpacks a `List<T>` value (#1567). The element count
+on the left-hand side must match the runtime length of the list; a
+mismatch aborts the program with `runtime error: list destructuring
+expected N elements but got M`.
+
+```ry
+xs: List<int> = [10, 20]
+a, b = xs                 # a = 10, b = 20
+
+# Common idiom: split a string into known-shape parts.
+from str import split
+first, second = split("12 34", " ")
+
+# Length mismatch — runtime error, not a static check.
+ys: List<int> = [1, 2, 3]
+a, b = ys                 # runtime error: list destructuring expected 2 elements but got 3
+```
+
 ### Range Operator (`..`)
 
 The `..` operator creates an inclusive integer range. `1 .. 5` produces `[1, 2, 3, 4, 5]`.

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -639,10 +639,106 @@ void CodeGen::emitStmt(TupleDestructStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);
     validateDirectives(s.directives, DirectiveTarget::Statement);
-    llvm::Value *tupleVal = emitExpr(*s.value);
-    llvm::StructType *structTy = llvm::dyn_cast<llvm::StructType>(tupleVal->getType());
+
+    // Redeclaration check (compile-time, shared by tuple and list dispatch).
+    // Hoisted above emitExpr so a duplicate name aborts before any IR or RHS
+    // side effects are emitted.
+    for (size_t i = 0; i < s.names.size(); ++i) {
+        if (s.names[i] == "_") continue;
+        if (scope_stack_.back().count(s.names[i]))
+            codegenError("variable '" + s.names[i] + "' already declared in this scope");
+    }
+
+    llvm::Value *val = emitExpr(*s.value);
+
+    // List destructuring path: runtime length check + ARC-retained element loads.
+    // Selected when the RHS resolves to a List<T> value. The left-hand syntax
+    // (bare `a, b = ...` or paren `(a, b) = ...`) is identical to tuple form;
+    // dispatch is value-driven.
+    if (llvm::Type *elemTy = getListElementType(val)) {
+        ListFields lf = loadListHeader(val, "destruct");
+        llvm::Value *expected = llvm::ConstantInt::get(i64Ty_, s.names.size());
+        llvm::Value *mismatch = builder_.CreateICmpNE(lf.len, expected, "destruct_len_mismatch");
+        llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*ctx_, "destruct.len_err", fn_);
+        llvm::BasicBlock *okBB  = llvm::BasicBlock::Create(*ctx_, "destruct.ok", fn_);
+        builder_.CreateCondBr(mismatch, errBB, okBB);
+
+        builder_.SetInsertPoint(errBB);
+        emitRuntimeError(
+            "runtime error: list destructuring expected %lld elements but got %lld\n",
+            ".list_destruct_len_err", {expected, lf.len});
+
+        builder_.SetInsertPoint(okBB);
+
+        // Snapshot source list metadata once into stack locals: same for every
+        // element, and rehash-safe across the per-element propagateTypeMeta /
+        // getOrCreateMeta calls that follow (see #858 gotcha).
+        std::string elemTypeName;
+        std::optional<FnTypeInfo> elemFnTypeInfo;
+        bool listElemIsStr = false;
+        llvm::Type *nestedElemTy = nullptr;
+        if (auto *listMeta = getMeta(val)) {
+            elemTypeName   = listMeta->list_elem_type_name;
+            elemFnTypeInfo = listMeta->list_elem_fn_type_info;
+            listElemIsStr  = listMeta->list_elem_is_str;
+            if (elemTy == ptrTy_) nestedElemTy = listMeta->nested_list_elem;
+        }
+
+        for (size_t i = 0; i < s.names.size(); ++i) {
+            if (s.names[i] == "_") continue;
+            llvm::Value *idx = llvm::ConstantInt::get(i64Ty_, i);
+            llvm::Value *elemPtr = builder_.CreateGEP(elemTy, lf.data, {idx},
+                                                       "destruct_elem_ptr_" + std::to_string(i));
+            llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr,
+                                                     "destruct_elem_" + std::to_string(i));
+
+            // Stamp metadata on the loaded SSA value so tryRetainArcSource Case 4
+            // can detect ARC-managed elements via list_elem / map_key / set_elem
+            // (#1266 metadata gate). Without this stamp the retain is skipped and
+            // the rebind-source UAF protection is lost.
+            if (elemTy == ptrTy_) {
+                if (nestedElemTy)
+                    setTypeMeta(TypeMeta::ListElem, elem, nestedElemTy);
+                if (!elemTypeName.empty())
+                    propagateTypeMeta(elemTypeName, elem);
+                if (elemFnTypeInfo)
+                    getOrCreateMeta(elem).fn_type_info = *elemFnTypeInfo;
+                if (listElemIsStr)
+                    getOrCreateMeta(elem).str_elem = true;
+            }
+
+            llvm::AllocaInst *ptr = getOrCreateVar(s.names[i], elem->getType());
+            builder_.CreateStore(elem, ptr);
+
+            // Propagate metadata onto the destination alloca so subsequent loads
+            // (e.g. `a[0]` after `a, b = xs`) inherit element type information
+            // through getMeta's LoadInst→PointerOperand resolution.
+            if (elemTy == ptrTy_) {
+                if (nestedElemTy)
+                    setTypeMeta(TypeMeta::ListElem, ptr, nestedElemTy);
+                if (!elemTypeName.empty())
+                    propagateTypeMeta(elemTypeName, ptr);
+                if (elemFnTypeInfo)
+                    getOrCreateMeta(ptr).fn_type_info = *elemFnTypeInfo;
+            }
+
+            if (elemTy == ptrTy_ && tryRetainArcSource(elem)) {
+                if (auto *meta = getMeta(elem); meta && meta->str_elem)
+                    arc_str_managed_vars_.insert(ptr);
+                else
+                    arc_backed_vars_.insert(ptr);
+                markArcManaged(ptr);
+            }
+
+            if (s.is_immutable)
+                immutable_scope_stack_.back().insert(s.names[i]);
+        }
+        return;
+    }
+
+    llvm::StructType *structTy = llvm::dyn_cast<llvm::StructType>(val->getType());
     if (!structTy)
-        codegenError("tuple destructuring requires a tuple value");
+        codegenError("destructuring requires a tuple or list value");
     if (structTy->getNumElements() != s.names.size())
         codegenError("tuple destructuring: expected " +
             std::to_string(s.names.size()) + " elements but got " +
@@ -651,10 +747,7 @@ void CodeGen::emitStmt(TupleDestructStmt &s) {
     for (size_t i = 0; i < s.names.size(); ++i) {
         if (s.names[i] == "_")
             continue;
-        // Redeclaration check (consistent with emitVarDecl)
-        if (scope_stack_.back().count(s.names[i]))
-            codegenError("variable '" + s.names[i] + "' already declared in this scope");
-        llvm::Value *elem = builder_.CreateExtractValue(tupleVal, static_cast<unsigned>(i));
+        llvm::Value *elem = builder_.CreateExtractValue(val, static_cast<unsigned>(i));
         llvm::AllocaInst *ptr = getOrCreateVar(s.names[i], elem->getType());
         builder_.CreateStore(elem, ptr);
         if (s.is_immutable)

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -642,11 +642,15 @@ void CodeGen::emitStmt(TupleDestructStmt &s) {
 
     // Redeclaration check (compile-time, shared by tuple and list dispatch).
     // Hoisted above emitExpr so a duplicate name aborts before any IR or RHS
-    // side effects are emitted.
+    // side effects are emitted. Also rejects same-pattern duplicates like
+    // `a, a = ...` whose two stores would silently race on the same alloca.
+    std::unordered_set<std::string> seen_names;
     for (size_t i = 0; i < s.names.size(); ++i) {
         if (s.names[i] == "_") continue;
         if (scope_stack_.back().count(s.names[i]))
             codegenError("variable '" + s.names[i] + "' already declared in this scope");
+        if (!seen_names.insert(s.names[i]).second)
+            codegenError("variable '" + s.names[i] + "' bound twice in destructuring pattern");
     }
 
     llvm::Value *val = emitExpr(*s.value);

--- a/tests/filecheck/arc_retain_list_destruct_elem.ry
+++ b/tests/filecheck/arc_retain_list_destruct_elem.ry
@@ -1,0 +1,25 @@
+# FileCheck golden for #1567.
+# Statement-level `a, b = xs` on a `List<List<int>>` value must emit an ARC
+# retain on each GEP-loaded element, gated by the ARC_IMMORTAL sentinel.
+# The element header is `ArcHeader` (16-byte prefix), so the retain offset
+# is -16 — same as the indexer Case 4 path covered by
+# arc_retain_list_elem_new_var.ry. Without retain, rebinding the source
+# (e.g. `xs = [[99]]`) would free the inner lists while a, b still hold
+# borrowed pointers — UAF as soon as #1242 destructor fix lands.
+#
+# CHECK-LABEL: define i64 @main()
+# CHECK:      %destruct_elem_0 = load ptr, ptr %destruct_elem_ptr_0
+# CHECK:      store ptr %destruct_elem_0, ptr %a
+# CHECK:      getelementptr i8, ptr %destruct_elem_0, i64 -16
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
+# CHECK:      %destruct_elem_1 = load ptr, ptr %destruct_elem_ptr_1
+# CHECK:      store ptr %destruct_elem_1, ptr %b
+# CHECK:      getelementptr i8, ptr %destruct_elem_1, i64 -16
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
+
+fn main() -> int:
+  xs: List<List<int>> = [[1, 2], [3, 4]]
+  a, b = xs
+  return a[0]

--- a/tests/filecheck/arc_retain_list_destruct_str_elem.ry
+++ b/tests/filecheck/arc_retain_list_destruct_str_elem.ry
@@ -1,0 +1,29 @@
+# FileCheck golden for #1567.
+# Statement-level `a, b = parts` on a `List<str>` value must emit an ARC
+# retain whose header offset is the str-specific -24 (StringHeader), not
+# the generic -16 (ArcHeader). The list_elem_is_str side-channel (#1266)
+# routes str-typed elements to the StringHeader retain offset without
+# flipping destructor dispatch.
+#
+# The explicit `parts: List<str>` annotation is required: the typed
+# annotation branch in codegen_stmt.cpp:342 stamps `list_elem_is_str = true`
+# on the alloca metadata, which the destructure path then snapshots
+# alongside the source list to drive the str-aware retain emission.
+#
+# CHECK-LABEL: define i64 @main()
+# CHECK:      %destruct_elem_0 = load ptr, ptr %destruct_elem_ptr_0
+# CHECK:      store ptr %destruct_elem_0, ptr %a
+# CHECK:      getelementptr i8, ptr %destruct_elem_0, i64 -24
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
+# CHECK:      %destruct_elem_1 = load ptr, ptr %destruct_elem_ptr_1
+# CHECK:      store ptr %destruct_elem_1, ptr %b
+# CHECK:      getelementptr i8, ptr %destruct_elem_1, i64 -24
+# CHECK:      arc.retain{{.*}}:
+# CHECK:      arc.retain.done{{.*}}:
+
+from str import split
+fn main() -> int:
+  parts: List<str> = split("aa bb", " ")
+  a, b = parts
+  return len(a)

--- a/tests/spec/arc_list_destructure.test.ry
+++ b/tests/spec/arc_list_destructure.test.ry
@@ -1,0 +1,62 @@
+from str import split
+
+describe("list destructuring assignment retains pointer-backed elements (#1567)", ():
+  it("List<List<int>> elements survive source rebind", ():
+    xs: List<List<int>> = [[1, 2, 3], [4, 5, 6]]
+    a, b = xs
+    xs = [[99]]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(a[0]).toEq(1)
+    expect(a[2]).toEq(3)
+    expect(b[0]).toEq(4)
+    expect(b[2]).toEq(6)
+  )
+
+  it("List<Map<str, int>> elements survive source rebind", ():
+    xs: List<Map<str, int>> = [{"a": 1}, {"b": 2}]
+    a, b = xs
+    xs = [{"x": 99}]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(a["a"]).toEq(1)
+    expect(b["b"]).toEq(2)
+  )
+
+  it("split() result destructured str elements survive source rebind", ():
+    # This case passes even without retain because split() result has
+    # no list_elem_is_str metadata (no LHS annotation), so destructor
+    # also skips str element release — leak-symmetric, not a UAF
+    # (see .claude/rules/tests-arc-leak-pattern.md). The actual str-elem
+    # retain discriminant is tests/filecheck/arc_retain_list_destruct_str_elem.ry.
+    parts = split("hello world", " ")
+    a, b = parts
+    parts = split("xx yy", " ")
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(a).toEq("hello")
+    expect(b).toEq("world")
+  )
+
+  it("paren-form destructure also retains pointer-backed elements", ():
+    xs: List<List<int>> = [[10, 20], [30, 40]]
+    (a, b) = xs
+    xs = [[99]]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(a[0]).toEq(10)
+    expect(b[1]).toEq(40)
+  )
+)

--- a/tests/spec/list_destructure_assign.test.ry
+++ b/tests/spec/list_destructure_assign.test.ry
@@ -1,0 +1,74 @@
+from str import split
+
+describe("list destructuring assignment (#1567)", ():
+  it("should destructure a 2-element list into two names", ():
+    a, b = [10, 20]
+    expect(a).toEq(10)
+    expect(b).toEq(20)
+  )
+
+  it("should destructure a 3-element list into three names", ():
+    a, b, c = [1, 2, 3]
+    expect(a).toEq(1)
+    expect(b).toEq(2)
+    expect(c).toEq(3)
+  )
+
+  it("should accept the parenthesized form on the LHS", ():
+    (a, b) = [3, 4]
+    expect(a).toEq(3)
+    expect(b).toEq(4)
+  )
+
+  it("should accept `_` wildcard on either side", ():
+    _, b = [10, 20]
+    expect(b).toEq(20)
+    a, _ = [30, 40]
+    expect(a).toEq(30)
+  )
+
+  it("should support the @const prefix", ():
+    @const a, b = [5, 6]
+    expect(a).toEq(5)
+    expect(b).toEq(6)
+  )
+
+  it("should support function returning a List<int>", ():
+    fn pair() -> List<int>:
+      return [7, 8]
+
+    a, b = pair()
+    expect(a).toEq(7)
+    expect(b).toEq(8)
+  )
+
+  it("should destructure split() result (issue motivating example)", ():
+    parts = split("12 34", " ")
+    a, b = parts
+    expect(a).toEq("12")
+    expect(b).toEq("34")
+  )
+
+  it("should bind names to a list bound to a variable first", ():
+    xs: List<int> = [100, 200]
+    a, b = xs
+    expect(a).toEq(100)
+    expect(b).toEq(200)
+  )
+
+  it("should destructure inside @parallel for body without crashing", ():
+    fn touch(x: int) -> int:
+      return x
+
+    shared: List<List<int>> = [[1, 2], [3, 4], [5, 6]]
+    @parallel
+    for i in range(64):
+      a, b = shared[i % 3]
+      touch(a)
+      touch(b)
+
+    expect(len(shared)).toEq(3)
+    expect(shared[0][0]).toEq(1)
+    expect(shared[2][1]).toEq(6)
+  )
+)

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -658,15 +658,17 @@ TEST_F(CodeGenTest, ListDestructuringErrors) {
     // ListDestructLengthMismatchTooManyPanics
     EXPECT_EXIT(runSource(
         "xs: List<int> = [1, 2, 3]\n"
-        "a, b = xs"), ::testing::ExitedWithCode(1), "");
+        "a, b = xs"), ::testing::ExitedWithCode(1), "list destructuring expected");
     // ListDestructLengthMismatchTooFewPanics
     EXPECT_EXIT(runSource(
         "xs: List<int> = [1]\n"
-        "a, b = xs"), ::testing::ExitedWithCode(1), "");
+        "a, b = xs"), ::testing::ExitedWithCode(1), "list destructuring expected");
     // DestructFromScalarRejected
     EXPECT_THROW(runSource("a, b = 42"), std::runtime_error);
     // DestructFromMapRejected
     EXPECT_THROW(runSource("m: Map<str, int> = {}\na, b = m"), std::runtime_error);
+    // SamePatternDuplicateRejected
+    EXPECT_THROW(runSource("a, a = [1, 2]"), std::runtime_error);
 }
 
 // ===== import =====

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -613,6 +613,62 @@ TEST_F(CodeGenTest, TupleErrors) {
     EXPECT_THROW(runSource("t: (int, int) = (1, 3.14)"), std::runtime_error);
 }
 
+TEST_F(CodeGenTest, ListDestructuring) {
+    // ListDestructBasic
+    EXPECT_EQ(runSource(
+        "a, b = [10, 20]\n"
+        "print(a)\n"
+        "print(b)"), "10\n20\n");
+    // ListDestructTriple
+    EXPECT_EQ(runSource(
+        "a, b, c = [1, 2, 3]\n"
+        "print(a)\n"
+        "print(b)\n"
+        "print(c)"), "1\n2\n3\n");
+    // ListDestructWildcard
+    EXPECT_EQ(runSource(
+        "_, b = [10, 20]\n"
+        "print(b)"), "20\n");
+    // ListDestructParenForm
+    EXPECT_EQ(runSource(
+        "(a, b) = [3, 4]\n"
+        "print(a)\n"
+        "print(b)"), "3\n4\n");
+    // ListDestructConst
+    EXPECT_EQ(runSource(withStdlibDirectiveDecls(
+        "@const a, b = [5, 6]\n"
+        "print(a)\n"
+        "print(b)")), "5\n6\n");
+    // ListDestructFromFn
+    EXPECT_EQ(runSource(
+        "fn pair() -> List<int>:\n"
+        "    return [7, 8]\n"
+        "a, b = pair()\n"
+        "print(a)\n"
+        "print(b)"), "7\n8\n");
+    // ListDestructFromVariable
+    EXPECT_EQ(runSource(
+        "xs: List<int> = [100, 200]\n"
+        "a, b = xs\n"
+        "print(a)\n"
+        "print(b)"), "100\n200\n");
+}
+
+TEST_F(CodeGenTest, ListDestructuringErrors) {
+    // ListDestructLengthMismatchTooManyPanics
+    EXPECT_EXIT(runSource(
+        "xs: List<int> = [1, 2, 3]\n"
+        "a, b = xs"), ::testing::ExitedWithCode(1), "");
+    // ListDestructLengthMismatchTooFewPanics
+    EXPECT_EXIT(runSource(
+        "xs: List<int> = [1]\n"
+        "a, b = xs"), ::testing::ExitedWithCode(1), "");
+    // DestructFromScalarRejected
+    EXPECT_THROW(runSource("a, b = 42"), std::runtime_error);
+    // DestructFromMapRejected
+    EXPECT_THROW(runSource("m: Map<str, int> = {}\na, b = m"), std::runtime_error);
+}
+
 // ===== import =====
 
 class ImportTest : public CodeGenTest {


### PR DESCRIPTION
## Summary

Closes #1567.

Extend `a, b = xs` (and the parenthesized form `(a, b) = xs`) to accept `List<T>` values in addition to tuples. The motivating idiom `a, b = split(s, " ")` — common in CSV parsing and competitive programming — now works without an intermediate temporary.

- **Dispatch**: value-driven via `getListElementType(val)`. The left-hand syntax is identical to tuple form; the existing tuple branch is the fallback when the RHS is a `StructType`.
- **Length check**: runtime; mismatch aborts with `runtime error: list destructuring expected N elements but got M` (Python-style semantics).
- **ARC retain**: each element follows the indexer Case 4 protocol — ArcHeader at offset `-16` for inner collections, StringHeader at offset `-24` for `List<str>` via the `list_elem_is_str` side-channel (#1266 metadata gate). Without the retain, rebinding the source list (`xs = [...]`) after destructuring would UAF the inner allocations once #1242's destructor recursion lands.
- **Wildcards / `@const` / function returns** all work identically to tuple destructuring.

## Test plan

- [x] `ctest -R 'TupleDestruct|ListDestruct'` — 26/26 pass (incl. new `ListDestructuring` and `ListDestructuringErrors`)
- [x] `tests/spec/list_destructure_assign.test.ry` — 9/9 pass (basic / wildcard / paren / `@const` / function return / `split()` / `@parallel for` body)
- [x] `tests/spec/arc_list_destructure.test.ry` — 4/4 pass (`List<List<int>>`, `List<Map<str,int>>`, `List<str>` rebind survival with allocation churn)
- [x] `tests/spec/tuple_destructure_assign_parens.test.ry` — 8/8 pass (regression guard)
- [x] FileCheck goldens — `arc_retain_list_destruct_elem.ry` (-16 offset) and `arc_retain_list_destruct_str_elem.ry` (-24 offset) both pass
- [x] Full spec suite (170 files) pass under default build, ASan+UBSan, and TSan
- [x] libFuzzer (`fuzz_parser`, `fuzz_utf8`) — no crashes after ~285K runs
- [x] Docs example verified via `./build/ry -c -`

## Notes

- Old error message `"tuple destructuring requires a tuple value"` updated to `"destructuring requires a tuple or list value"` to reflect the broader acceptance.
- Redeclaration check hoisted above dispatch (shared by both branches).
- The `List<str>` UAF spec test passes regardless of retain implementation due to leak-symmetry on the `list_elem_is_str` carve-out (see `.claude/rules/tests-arc-leak-pattern.md`); the FileCheck golden is the actual discriminant for the str-element retain offset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * List destructuring assignment: unpack lists via `a, b = some_list` or `(a, b) = some_list`.
  * Wildcard `_` and `@const` bindings supported; `split(...)` can be destructured without an intermediate temporary.
  * Runtime length checks with clear error messages on mismatch.

* **Documentation**
  * Added control-flow reference entry and changelog documenting behavior and examples.

* **Tests**
  * Added extensive tests covering patterns, error cases, and pointer-backed element retention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->