### PR TITLE
feat(str): add count() for non-overlapping substring count (#1571)

### DIFF
--- a/changelog.d/1571-str-count.md
+++ b/changelog.d/1571-str-count.md
@@ -1,0 +1,8 @@
+### Added
+
+- `count(string: str, substring: str, ignoreCase: bool = false) -> int` to the
+  `str` module. Returns the number of non-overlapping occurrences of
+  `substring` in `string`, matching Python / Go semantics
+  (`"aaaa".count("aa") == 2`). Empty `substring` returns `byteLen + 1` (gap
+  count); `ignoreCase` performs ASCII-only folding; arguments may contain
+  embedded NUL bytes. (#1571)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -4,7 +4,7 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 
 > **Note:** All string operations are UTF-8 aware. `len()`, `charAt()`, `substr()`, `find()`, and `reverse()` operate on Unicode code points, not bytes. Use `byteLen()` if you need the byte length.
 >
-> **NUL bytes:** `str` stores an explicit byte length and supports embedded NUL bytes (`\0`). All string operations are fully NUL-safe: `byteLen`, `len`, `==`, `!=`, `<`, `>`, `+`, `*`, hash/Map/Set key lookup (#1022), `contains`, `startsWith`, `endsWith`, `find` (#1047), `replace` (#1048), `substr`, `charAt`, `reverse`, `split("", _)`, `for c in str:`, `enumerate(str)` (#1049), `toUpper`, `toLower`, `trim`, `trimStart`, `trimEnd` (#1050), `split(str, delim)` with non-empty delimiter, `join`, `repeat`, `*` (#1051).
+> **NUL bytes:** `str` stores an explicit byte length and supports embedded NUL bytes (`\0`). All string operations are fully NUL-safe: `byteLen`, `len`, `==`, `!=`, `<`, `>`, `+`, `*`, hash/Map/Set key lookup (#1022), `contains`, `startsWith`, `endsWith`, `find` (#1047), `replace` (#1048), `substr`, `charAt`, `reverse`, `split("", _)`, `for c in str:`, `enumerate(str)` (#1049), `toUpper`, `toLower`, `trim`, `trimStart`, `trimEnd` (#1050), `split(str, delim)` with non-empty delimiter, `join`, `repeat`, `*` (#1051), `count` (#1571).
 >
 > **Index access:** `str` does not support `[]` index syntax. Use `charAt(s, i)` to get the character at position `i`.
 
@@ -18,6 +18,7 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 | `startsWith` | `(str, str, bool = false) -> bool` | Returns whether it starts with a prefix |
 | `endsWith` | `(str, str, bool = false) -> bool` | Returns whether it ends with a suffix |
 | `find` | `(str, str) -> Option<int>` | Returns the character position of a substring (`None` if not found) |
+| `count` | `(str, str, bool = false) -> int` | Returns the count of non-overlapping substring occurrences |
 
 ### Extraction and Transformation
 
@@ -123,6 +124,29 @@ print(find("hello world", "world"))   # Some(6)
 print(find("hello", "xyz"))           # None
 print("abcdef".find("cd"))            # Some(2) (UFCS)
 print(find("a\0b", "\0"))             # Some(1) (NUL-safe)
+```
+
+---
+
+## count
+
+**Signature:** `count(string: str, substring: str, ignoreCase: bool = false) -> int`
+
+Returns the number of non-overlapping occurrences of `substring` in `string`. When `ignoreCase` is `true`, the comparison is case-insensitive (ASCII only). Both arguments may contain embedded NUL bytes (`\0`).
+
+Edge cases match Python / Go semantics:
+- An empty `substring` returns `byteLen(string) + 1` (gap count). Example: `"abc".count("")` returns `4`, `"".count("")` returns `1`.
+- Matches are non-overlapping: `"aaaa".count("aa")` returns `2`, not `3`.
+- Returns `0` when `substring` is longer than `string`.
+
+```ry
+print(count("101", "1"))                       # 2
+print(count("hello world", "l"))               # 3
+print("aaaa".count("aa"))                      # 2 (non-overlapping, UFCS)
+print(count("Hello", "h"))                     # 0 (case-sensitive)
+print(count("Hello", "h", true))               # 1 (case-insensitive ASCII)
+print(count("abc", ""))                        # 4 (gap count)
+print(count("a\0b\0a", "\0"))                  # 2 (NUL-safe)
 ```
 
 ---

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1517,6 +1517,7 @@ public:
     // ======== String Operations ========
     llvm::Value *emitBuiltinString(const CallExpr &e);
     llvm::Value *emitStrOp_contains(const CallExpr &e);
+    llvm::Value *emitStrOp_count(const CallExpr &e);
     llvm::Value *emitStrOp_starts_with(const CallExpr &e);
     llvm::Value *emitStrOp_ends_with(const CallExpr &e);
     llvm::Value *emitStrOp_find(const CallExpr &e);

--- a/share/std/str.ry
+++ b/share/std/str.ry
@@ -5,6 +5,10 @@ fn contains(string: str, substring: str, ignoreCase: bool = false) -> bool
 
 @public
 @native
+fn count(string: str, substring: str, ignoreCase: bool = false) -> int
+
+@public
+@native
 fn startsWith(string: str, prefix: str, ignoreCase: bool = false) -> bool
 
 @public

--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -21,6 +21,7 @@ llvm::Value *CodeGen::emitBuiltinString(const CallExpr &e) {
     using Handler = llvm::Value *(CodeGen::*)(const CallExpr &);
     static const std::unordered_map<std::string, Handler> dispatch = {
         {"contains",   &CodeGen::emitStrOp_contains},
+        {"count",      &CodeGen::emitStrOp_count},
         {"startsWith", &CodeGen::emitStrOp_starts_with},
         {"endsWith",   &CodeGen::emitStrOp_ends_with},
         {"find",       &CodeGen::emitStrOp_find},
@@ -93,6 +94,26 @@ llvm::Value *CodeGen::emitStrOp_contains(const CallExpr &e) {
     return builder_.CreateICmpNE(byteOff,
                                  llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(-1LL)),
                                  "contains");
+}
+
+// count(s, sub[, ignore_case]) → int
+llvm::Value *CodeGen::emitStrOp_count(const CallExpr &e) {
+    if (e.args.size() < 2 || e.args.size() > 3)
+        codegenError("count() takes 2 or 3 arguments");
+    llvm::Value *s = emitExpr(*e.args[0]);
+    llvm::Value *sub = emitExpr(*e.args[1]);
+    llvm::Value *ignoreCase = (e.args.size() == 3)
+        ? emitExpr(*e.args[2])
+        : llvm::ConstantInt::get(i1Ty_, 0);
+    if (s->getType() != ptrTy_ || sub->getType() != ptrTy_)
+        codegenError("count() requires str arguments");
+
+    llvm::Value *sl   = emitStringByteLen(s);
+    llvm::Value *subl = emitStringByteLen(sub);
+    llvm::Value *icI32 = builder_.CreateZExt(ignoreCase, i32Ty_, "ic_i32");
+    auto countByteFn = getRuntimeFn("__ry_str_count_byte", i64Ty_,
+                                     {ptrTy_, i64Ty_, ptrTy_, i64Ty_, i32Ty_});
+    return builder_.CreateCall(countByteFn, {s, sl, sub, subl, icI32}, "str_count");
 }
 
 // startsWith(s, prefix[, ignore_case]) → bool

--- a/src/runtime_string.cpp
+++ b/src/runtime_string.cpp
@@ -111,6 +111,25 @@ int64_t __ry_str_find_byte(const char *s, int64_t hl, const char *p, int64_t nl,
     return static_cast<int64_t>(static_cast<const char *>(found) - s);
 }
 
+// NUL-safe non-overlapping count via repeated __ry_str_find_byte.  Empty needle
+// returns hl + 1 (gap count, matching Python "abc".count("") == 4).  Sharing
+// the find loop keeps case-sensitive (memmem) and case-insensitive (ASCII
+// tolower) semantics in lockstep.
+// Called by codegen for count(s, sub).
+int64_t __ry_str_count_byte(const char *s, int64_t hl, const char *p, int64_t nl,
+                             int32_t ignore_case) {
+    if (nl == 0) return hl + 1;
+    int64_t count = 0;
+    int64_t i = 0;
+    while (i <= hl - nl) {
+        int64_t off = __ry_str_find_byte(s + i, hl - i, p, nl, ignore_case);
+        if (off < 0) break;
+        ++count;
+        i += off + nl;
+    }
+    return count;
+}
+
 // NUL-safe replace: replaces every occurrence of oldStr (length oldLen) in s
 // (length sLen) with newStr (length newLen).  All three arguments may contain
 // embedded NUL bytes.  Empty needle (oldLen == 0) returns a fresh copy of s

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -63,6 +63,52 @@ describe("search and check", ():
   )
 )
 
+describe("count", ():
+  it("should count single-char ASCII occurrences", ():
+    expect(count("101", "1")).toEq(2)
+    expect(count("hello world", "l")).toEq(3)
+    expect("101".count("1")).toEq(2)
+  )
+  it("should count multi-char ASCII substrings", ():
+    expect(count("hello", "ll")).toEq(1)
+    expect(count("hellohello", "ello")).toEq(2)
+  )
+  it("should count non-overlapping occurrences", ():
+    expect(count("aaaa", "aa")).toEq(2)
+    expect(count("aaaaa", "aa")).toEq(2)
+    expect(count("ababab", "aba")).toEq(1)
+  )
+  it("should return 0 when needle not found", ():
+    expect(count("hello", "xyz")).toEq(0)
+    expect(count("hi", "hello")).toEq(0)
+  )
+  it("should return 0 when haystack is empty and needle is non-empty", ():
+    expect(count("", "x")).toEq(0)
+  )
+  it("should return byteLen + 1 for empty needle", ():
+    expect(count("abc", "")).toEq(4)
+    expect(count("hello", "")).toEq(6)
+    expect(count("", "")).toEq(1)
+  )
+  it("should count case-insensitively when ignoreCase=true", ():
+    expect(count("Hello", "h")).toEq(0)
+    expect(count("Hello", "h", true)).toEq(1)
+    expect(count("Hello World", "L", true)).toEq(3)
+    expect(count("HELLO hello", "hello", true)).toEq(2)
+    expect("Hello".count("HELLO", true)).toEq(1)
+  )
+  it("should count substrings crossing embedded NUL bytes (#1571)", ():
+    expect(count("a\0b\0c", "\0")).toEq(2)
+    expect(count("a\0b\0c\0", "\0")).toEq(3)
+    expect(count("a\0a\0a", "\0a")).toEq(2)
+  )
+  it("should count ASCII needle in UTF-8 haystack at byte level", ():
+    expect(count("あa", "a")).toEq(1)
+    expect(count("aあa", "a")).toEq(2)
+    expect(count("あいうえお", "a")).toEq(0)
+  )
+)
+
 describe("extraction and transformation", ():
   it("should extract substr", ():
     expect(substr("hello world", 0, 5)).toEq("hello")


### PR DESCRIPTION
## Summary

Add `count(string: str, substring: str, ignoreCase: bool = false) -> int` to the `str` module. Returns the number of non-overlapping occurrences of `substring` in `string`, matching Python / Go semantics.

- `"aaaa".count("aa")` → `2` (non-overlapping)
- `"abc".count("")` → `4` (gap count = `byteLen + 1`)
- `count("Hello", "h", true)` → `1` (ASCII-only `ignoreCase`)
- NUL-safe: arguments may contain embedded `\0` bytes

The implementation delegates to `__ry_str_find_byte` iteratively, so case-sensitive (memmem) and case-insensitive (ASCII tolower) paths share a single find loop — no duplicated tolower scanner.

Closes #1571.

## Test plan

- [x] 9 new `it` blocks in `tests/spec/strings.test.ry` (single/multi-char ASCII, non-overlapping, no-match, empty haystack/needle, `ignoreCase`, NUL bytes, UTF-8 haystack with ASCII needle, UFCS)
- [x] `./build/ry test tests/spec/strings.test.ry` — 120 passed
- [x] `./build/ry test -p` — 168 files, 0 failures
- [x] `./build/ry_tests` — 2091 passed
- [x] ASan + UBSan: same suites all clean (`build-asan/`)
- [x] Doc examples in `docs/reference/builtins-string.md` verified end-to-end with `./build/ry`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `count()` function to the `str` module to count non-overlapping occurrences of a substring, with optional case-insensitive ASCII matching and full NUL-byte support.

* **Documentation**
  * Updated string module reference documentation with `count()` function description, behavior specifications, and examples.

* **Tests**
  * Added comprehensive test suite for `count()` function covering single/multi-character substrings, edge cases, and special scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->