### PR TITLE
feat(parser): add paren-less single-param lambda `s => expr` (#1572)

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -341,6 +341,42 @@ The error wording is `"tuple-destructure name '<n>' must be camelCase"`, matchin
 - Reference site: `src/parser_expr.cpp::parseParenLambdaExpr` (commit flag set just past `)` and the `'->' / '=>' / ':'` lookahead) + `src/parser_expr.cpp::parsePrimary` (save/restore + conditional re-throw in the lambda dispatch). The flag itself lives on `include/ry/parser.hpp`.
 - The disambiguator-then-flag ordering matters: if you set the flag before the lookahead check, valid tuples with snake_case names like `(my_a, my_b)` would be rejected even though they have no lambda body marker. Tests `LambdaParamRejectsSnakeCase` (negative) and `LambdaParamAcceptsCamelCase` (positive) lock both halves.
 
+### `in_if_cond_` flag suppresses bare-ident `Ident FatArrow` dispatch inside if-expression conditions
+
+**Source**: #1572 (2026-05-04, implementation)
+**Tags**: parser, lambda, if-expression, bare-lambda, fatarrow, lookahead, ambiguity, blind-spot
+
+**Context**: #1572 added bare-paren-omitted single-param lambda dispatch (`s => expr`) in `parsePrimary`'s `Ident` branch. Without a guard, the dispatch fires inside the cond of `if cond => then else else`, consuming `=>` as a lambda body marker and breaking every existing `if flag => Some(1) else None()` site (`tests/spec/option_branch_merge_none.test.ry` alone has 14+ such sites).
+
+**Rule**: `parsePrimary`'s `Ident` branch must guard the bare-lambda dispatch with `lex_.peek().kind == TokenKind::FatArrow && !in_if_cond_`. The flag is set by `parseIfExpression` only around the `parseConditional()` call that parses the **condition**:
+
+```cpp
+ExprPtr Parser::parseIfExpression() {
+    Token ifTok = lex_.next();          // consume 'if'
+    bool prev_in_if_cond = in_if_cond_;
+    in_if_cond_ = true;
+    ExprPtr cond = parseConditional();  // bare lambdas suppressed here
+    in_if_cond_ = prev_in_if_cond;
+    // ... '=>' is consumed by parseIfExpression itself as the then-arm marker.
+    // The then / else arms run with the saved (typically false) state, so
+    // bare lambdas inside them remain accepted.
+}
+```
+
+**Why a flag, not a richer lookahead**: bare-ident `s` followed by `=>` is locally indistinguishable between "bare lambda" and "if-cond identifier followed by then-arm". Only the surrounding parser state knows which is in scope. A peek-based heuristic would have to scan past the entire then/else arms to find the matching `else` keyword (expensive and still ambiguous with nested `if`s in the cond), or commit prematurely and break existing spec.
+
+**Why save/restore (not unconditional `false` on exit)**: nested if-expressions (`if outer => if inner => x else y else z`) and lambdas inside then/else arms (`if c => x => x*2 else y => y*2`) must compose correctly. Restoring the previous value (rather than clobbering to `false`) preserves the outer context.
+
+**Why no commit-flag**: `Ident FatArrow` is a 2-token commit point with no fallback path. The bare-lambda branch is **not** wrapped in a speculative `try / catch (...)`, so the commit-flag pattern from the entry above does **not** apply — `parseError` for `isCamelCase` violations propagates as a hard diagnostic immediately, and there is no other parse to fall back to.
+
+**How to apply**: Any future `Ident <suffix>` dispatch added in `parsePrimary` (hypothetical `s @ pattern`, typed-binding shortcuts, postfix builder shorthands, etc.) that conflicts with an outer-context production must replicate this pattern:
+
+1. Add a `bool in_<context>_ = false;` member to `Parser` in `include/ry/parser.hpp`.
+2. Set/restore the flag at the call site that owns the conflicting production (`parseIfExpression` for if-cond, `parseCaseExpression` for case-scrutinee, etc.).
+3. Guard the new `parsePrimary` dispatch with `&& !in_<context>_`.
+
+Reference site: `src/parser_expr.cpp::parsePrimary` Ident branch (bare-lambda dispatch with the `!in_if_cond_` guard) + `src/parser_expr.cpp::parseIfExpression` (save/restore around `parseConditional` for the cond). The flag itself lives on `include/ry/parser.hpp` next to `lambda_committed_`. Tests `BareLambdaPreservesIfExpressionWithBareIdentCond` and `BareLambdaInIfThenElse` in `tests/test_parser.cpp` lock both halves of the invariant.
+
 ### UnaryExpr fast-path covers bare int for INT64_MIN (`-9223372036854775808`)
 
 **Source**: #1025 (2026-04-16)

--- a/changelog.d/1572-lambda-paren-omit.md
+++ b/changelog.d/1572-lambda-paren-omit.md
@@ -1,0 +1,6 @@
+### Added
+
+- Single-parameter lambdas may now omit the parentheses when the parameter
+  has no type annotation and the body is a single expression: `xs.filter(s => s == "1")`.
+  Multi-arg, type-annotated, and block-bodied lambdas keep their existing paren-required
+  syntax. (#1572)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -385,6 +385,9 @@ Anonymous functions can be defined inline.
 # Parameter type can be omitted (defaults to any)
  (paramName, ...) => expression
 
+# Single-parameter shorthand (paren-less, untyped, single expression)
+ paramName => expression
+
 # Multi-line block
 (paramName: type, ...):
     # multiple statements
@@ -407,12 +410,27 @@ result = double(5)   # 10
 add = (a: int, b: int) => a + b
 sum = add(3, 4)      # 7
 
+# Single-parameter shorthand: paren-less, untyped form
+inc = x => x + 1
+xs = [1, 2, 3, 4]
+big = xs.filter(x => x > 2)   # [3, 4]
+
 # Multi-line lambda
 abs = (x: int):
     if x < 0:
         return -x
     return x
 ```
+
+### Limitations of the paren-less shorthand
+
+The bare `paramName => expression` form is restricted to the simplest case to keep the
+grammar unambiguous:
+
+- **Exactly one parameter** — `s, t => s + t` is rejected (multi-arg conflicts with tuple destructuring).
+- **No parameter type annotation** — `s: str => s` is rejected (conflicts with module-global typed declaration syntax).
+- **Single-expression body only** — block-style bodies require parens: `(s):\n    return s`.
+- The parameter type defaults to `any` (same as `(s) => ...`); add parens to declare a concrete type.
 
 ---
 

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -33,6 +33,10 @@ private:
     // raised after this point must not be swallowed by the speculative
     // try/catch in parsePrimary's lambda dispatch.
     bool lambda_committed_ = false;
+    // True while parsing the condition of an `if` expression. Suppresses the
+    // bare-lambda dispatch (`Ident FatArrow`) in parsePrimary so the `=>` is
+    // recognised as the if-expression then-arm, not consumed as a lambda body.
+    bool in_if_cond_ = false;
     static constexpr int MAX_RECURSION_DEPTH = 256;
 
     struct RecursionGuard {

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -163,7 +163,13 @@ ExprPtr Parser::parseIfExpression() {
     Token ifTok = lex_.next(); // consume 'if'
     bool prev_in_if_cond = in_if_cond_;
     in_if_cond_ = true;
-    ExprPtr cond = parseConditional();
+    ExprPtr cond;
+    try {
+        cond = parseConditional();
+    } catch (...) {
+        in_if_cond_ = prev_in_if_cond;
+        throw;
+    }
     in_if_cond_ = prev_in_if_cond;
 
     if (lex_.peek().kind == TokenKind::FatArrow) {
@@ -677,7 +683,12 @@ ExprPtr Parser::parsePrimary() {
             lambda->return_type = nullptr;
             bool prev_in_async = in_async_fn_;
             in_async_fn_ = false;
-            lambda->expr_body = parseConditional();
+            try {
+                lambda->expr_body = parseConditional();
+            } catch (...) {
+                in_async_fn_ = prev_in_async;
+                throw;
+            }
             in_async_fn_ = prev_in_async;
             auto node = std::make_unique<ExprNode>();
             node->data = std::move(lambda);

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -161,7 +161,10 @@ std::vector<StmtNode> Parser::parseIfExpressionBranchBody() {
 // The leading `if` token is consumed here.
 ExprPtr Parser::parseIfExpression() {
     Token ifTok = lex_.next(); // consume 'if'
+    bool prev_in_if_cond = in_if_cond_;
+    in_if_cond_ = true;
     ExprPtr cond = parseConditional();
+    in_if_cond_ = prev_in_if_cond;
 
     if (lex_.peek().kind == TokenKind::FatArrow) {
         // Single-expression form: if <cond> => <then_val> else <else_val>
@@ -659,6 +662,25 @@ ExprPtr Parser::parsePrimary() {
                 coerceFirstArgToString(call->args);
             auto node = std::make_unique<ExprNode>();
             node->data = std::move(call);
+            node->loc = locFromToken(t);
+            return node;
+        }
+        // Bare-paren-omitted single-param lambda: `s => expr`.
+        // Suppressed inside an if-expression condition so `if flag => then ...`
+        // is parsed as the if then-arm rather than a lambda.
+        if (lex_.peek().kind == TokenKind::FatArrow && !in_if_cond_) {
+            if (!isCamelCase(t.value))
+                parseError(t.line, "parameter name '" + t.value + "' must be camelCase");
+            lex_.next(); // consume '=>'
+            auto lambda = std::make_unique<LambdaExpr>();
+            lambda->params.push_back({t.value, TypeNode::makeBasic("any"), nullptr});
+            lambda->return_type = nullptr;
+            bool prev_in_async = in_async_fn_;
+            in_async_fn_ = false;
+            lambda->expr_body = parseConditional();
+            in_async_fn_ = prev_in_async;
+            auto node = std::make_unique<ExprNode>();
+            node->data = std::move(lambda);
             node->loc = locFromToken(t);
             return node;
         }

--- a/tests/spec/lambda_paren_omit.test.ry
+++ b/tests/spec/lambda_paren_omit.test.ry
@@ -1,0 +1,30 @@
+describe("bare-paren-omitted single-param lambda (#1572)", ():
+  it("should accept bare lambda in filter (length check)", ():
+    xs = [1, 2, 3, 4]
+    result = xs.filter(x => x > 2)
+    expect(result.len()).toEq(2)
+  )
+
+  it("should accept bare lambda in map (length check)", ():
+    xs = [1, 2, 3]
+    result = xs.map(x => x * 2)
+    expect(result.len()).toEq(3)
+  )
+
+  it("should accept chained bare lambdas", ():
+    xs = [1, 2, 3, 4]
+    result = xs.filter(x => x > 1).map(x => x * 10)
+    expect(result.len()).toEq(3)
+  )
+
+  it("should accept bare lambda binding to a name", ():
+    inc = x => x + 1
+    expect(inc(5)).toEq(6)
+  )
+
+  it("should not regress if-expr with bare ident cond", ():
+    flag = true
+    result = if flag => 1 else 2
+    expect(result).toEq(1)
+  )
+)

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -454,6 +454,25 @@ TEST(Formatter, LambdaAndTrailingBlock) {
     }
 }
 
+// ===== Bare-paren-omitted single-param lambda (#1572) =====
+
+TEST(Formatter, BareLambdaCanonicalizesToParen) {
+    // `s => s + 1` should be re-emitted in canonical paren form. The existing
+    // formatter already emits `: any` for inferred-type lambda params, so the
+    // canonical output for both `s => ...` and `(s) => ...` is `(s: any) => ...`.
+    auto out = fmt("f = s => s + 1\n");
+    EXPECT_NE(out.find("f = (s: any) => s + 1"), std::string::npos);
+    // And the result must be identical to the existing paren-only form.
+    EXPECT_EQ(fmt("f = s => s + 1\n"), fmt("f = (s) => s + 1\n"));
+}
+
+TEST(Formatter, BareLambdaRoundTripIdempotent) {
+    // After one formatting pass, a second pass must be a no-op.
+    auto first = fmt("f = s => s + 1\n");
+    auto second = fmt(first);
+    EXPECT_EQ(first, second);
+}
+
 // ===== Round-Trip / Idempotency Tests =====
 
 TEST(Formatter, RoundTripAndIdempotency) {

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2794,6 +2794,96 @@ TEST(ParserTest, NestedLambdaAcceptsCamelCase) {
     EXPECT_EQ(inner.params[0].name, "myY");
 }
 
+// ===== Bare-paren-omitted single-param lambda (#1572) =====
+
+TEST(ParserTest, BareLambdaSingleParamAccepts) {
+    Program prog = parseStr("f = s => s + 1");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &assign = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(assign.value->data));
+    const auto &lambda = *std::get<std::unique_ptr<LambdaExpr>>(assign.value->data);
+    ASSERT_EQ(lambda.params.size(), 1u);
+    EXPECT_EQ(lambda.params[0].name, "s");
+    EXPECT_EQ(lambda.return_type, nullptr);
+    ASSERT_TRUE(lambda.expr_body != nullptr);
+    EXPECT_TRUE(lambda.body.empty());
+    EXPECT_TRUE(std::holds_alternative<std::unique_ptr<BinaryExpr>>(lambda.expr_body->data));
+}
+
+TEST(ParserTest, BareLambdaPreservesIfExpressionWithBareIdentCond) {
+    // The bare lambda dispatch must not preempt `if cond => then else else`
+    // when `cond` is a bare ident — this is a positive sibling test for the
+    // `in_if_cond_` flag.
+    Program prog = parseStr("f = (b: bool) => if b => 1 else 2");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &assign = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(assign.value->data));
+    const auto &outer = *std::get<std::unique_ptr<LambdaExpr>>(assign.value->data);
+    ASSERT_TRUE(outer.expr_body != nullptr);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<IfExpr>>(outer.expr_body->data));
+    const auto &ifExpr = *std::get<std::unique_ptr<IfExpr>>(outer.expr_body->data);
+    ASSERT_TRUE(ifExpr.condition != nullptr);
+    EXPECT_TRUE(std::holds_alternative<VariableExpr>(ifExpr.condition->data));
+}
+
+TEST(ParserTest, BareLambdaRejectsSnakeCase) {
+    EXPECT_THROW(parseStr("f = my_x => my_x"), std::runtime_error);
+}
+
+TEST(ParserTest, BareLambdaRejectsMultiArg) {
+    // Multi-arg paren-omission is forbidden (tuple destructure ambiguity).
+    EXPECT_THROW(parseStr("f = s, t => s + t"), std::runtime_error);
+}
+
+TEST(ParserTest, BareLambdaRejectsAnnotatedParam) {
+    // `s: str => s` is parsed as a typed module-global declaration, not a lambda.
+    EXPECT_THROW(parseStr("f = s: str => s"), std::runtime_error);
+}
+
+TEST(ParserTest, BareLambdaRejectsBlockBody) {
+    // Block body requires paren wrapping; bare form is single-expression only.
+    EXPECT_THROW(parseStr("f = s =>\n    return s\n"), std::runtime_error);
+}
+
+TEST(ParserTest, BareLambdaNestedRightAssoc) {
+    Program prog = parseStr("f = x => y => x + y");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &assign = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(assign.value->data));
+    const auto &outer = *std::get<std::unique_ptr<LambdaExpr>>(assign.value->data);
+    ASSERT_EQ(outer.params.size(), 1u);
+    EXPECT_EQ(outer.params[0].name, "x");
+    ASSERT_TRUE(outer.expr_body != nullptr);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(outer.expr_body->data));
+    const auto &inner = *std::get<std::unique_ptr<LambdaExpr>>(outer.expr_body->data);
+    ASSERT_EQ(inner.params.size(), 1u);
+    EXPECT_EQ(inner.params[0].name, "y");
+}
+
+TEST(ParserTest, BareLambdaInIfThenElse) {
+    // Bare lambda inside if-expression then/else arms must work.
+    Program prog = parseStr("f = (b: bool) => if b => x => x else y => y * 2");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &assign = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(assign.value->data));
+    const auto &outer = *std::get<std::unique_ptr<LambdaExpr>>(assign.value->data);
+    ASSERT_TRUE(outer.expr_body != nullptr);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<IfExpr>>(outer.expr_body->data));
+    const auto &ifExpr = *std::get<std::unique_ptr<IfExpr>>(outer.expr_body->data);
+    ASSERT_TRUE(ifExpr.then_value != nullptr);
+    ASSERT_TRUE(ifExpr.else_value != nullptr);
+    EXPECT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(ifExpr.then_value->data));
+    EXPECT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(ifExpr.else_value->data));
+}
+
+TEST(ParserTest, BareLambdaBodyDoesNotInheritAsyncContext) {
+    // `await` inside a bare lambda body within async fn must be rejected
+    // (lambda body parses with in_async_fn_ = false).
+    EXPECT_THROW(
+        parseStr("async fn outer() -> int:\n    f = s => await s\n    return 1\n"),
+        std::runtime_error);
+}
+
 // ===== Cast expression with generic types (#490) =====
 
 TEST(ParserTest, CastSimpleType) {


### PR DESCRIPTION
## Summary

Closes #1572.

Single-parameter lambdas may now omit the parentheses when the parameter has no type annotation and the body is a single expression: `xs.filter(s => s == "1")`. Multi-arg, type-annotated, and block-bodied lambdas keep the existing paren-required syntax.

| Input | Status |
|---|---|
| `s => expr` | ✅ new |
| `(s) => expr`, `(s: T) => expr`, `() => expr` | ✅ unchanged |
| `s, t => s + t` | ❌ rejected (multi-arg ambiguity with tuple destructure) |
| `s: T => expr` | ❌ rejected (typed-decl ambiguity) |
| `s =>\n  body` | ❌ rejected (block body needs parens) |
| `if cond => then else else` (bare-ident cond) | ✅ preserved |

### Implementation

- `parsePrimary`'s `Ident` branch dispatches a single-param lambda when `peek == FatArrow && !in_if_cond_`. Validates `isCamelCase`, builds `LambdaExpr` with one `any` param, parses body via `parseConditional()` with `in_async_fn_` save/restore (so async context never leaks into the lambda body).
- New `Parser::in_if_cond_` flag, set/restored by `parseIfExpression` around the cond parse, prevents the dispatch from preempting `if flag => then else else` (every `tests/spec/option_branch_merge_none.test.ry` site, etc.).
- Formatter is unchanged: existing `formatLambdaSig` already emits canonical `(s: any) => ...` so `s => x` round-trips to the paren form (case B from the plan).
- Knowledge: new `.claude/rules/parser-conventions.md` entry locks in the `in_if_cond_` invariant for future `Ident <suffix>` dispatches.

## Test plan

- [x] C++ tests: 9 new `BareLambda*` cases in `tests/test_parser.cpp` + 2 in `tests/test_formatter.cpp` (acceptance / multiple rejection branches / nested right-assoc / if-cond positive sibling / async-context isolation / canonical formatter output / idempotency)
- [x] Spec tests: `tests/spec/lambda_paren_omit.test.ry` end-to-end with `filter` / `map` / chained / binding / `if cond` regression
- [x] Full `./build/ry test -p` (169 files) — no regression on `option_branch_merge_none.test.ry` and friends
- [x] ASan + UBSan clean
- [x] libFuzzer 60 sec + bare-lambda seed corpus — no crash
- [x] Doc example `xs.filter(s => s == "1").len()` runs and prints `2`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Single-parameter lambdas can omit parentheses when the parameter has no type and the body is a single expression (e.g., xs.filter(s => s == "1")).

* **Documentation**
  * Updated lambda docs with shorthand examples, usage patterns, and a limitations section describing when parentheses remain required.

* **Formatter**
  * Formatter normalizes the shorthand to canonical parenthesized form (e.g., f = (s: any) => s + 1).

* **Parsing / Behavior**
  * Shorthand is disallowed where it would conflict with existing if-expression syntax to preserve expected semantics.

* **Tests**
  * Added parser and formatter tests covering the shorthand and its edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->