### PR TITLE
feat(codegen): @native stdlib functions as first-class values (#1569)

### DIFF
--- a/.claude/rules/codegen-fn-and-generic.md
+++ b/.claude/rules/codegen-fn-and-generic.md
@@ -453,3 +453,23 @@ not hardcode `T`.
 
 ---
 
+### `@native` first-class materialization: synthesize a thunk that re-enters the call dispatcher
+
+**Source**: #1569 (2026-05-04, implementation). **Tags**: codegen, native, first-class, thunk, FnScope, multi-overload, default-args
+
+**Rule**: To make a `@native` stdlib function usable as a first-class value (`let f = toInt`, `xs.map(toInt)`), `emitExprVariant<VariableExpr>` must — *immediately after the user-fn lookup branch and before the `undefined variable` error* — call `materializeNativeThunk(name)`. The helper (a) collects candidate `NativeFnSignature` entries from `native_fn_sigs_` matching either the bare name or any `<package>::name` suffix; (b) rejects multi-overload names with `ambiguous reference to @native function 'X': multiple overloads exist; wrap in a lambda to select one`; (c) emits an internal LLVM Function `__ry_native_thunk_<name>` whose body is a synthetic `CallExpr{callee=name, args=VariableExpr{p.name}}` routed back through `emitExpr` so the existing native dispatch chain (Pattern A/B/generic + `@native("libname")` dlopen) is reused without duplication; (d) caches the thunk by name so repeated references share one Function and recursive references resolve mid-emission.
+
+**How to apply**:
+- **`FnScope` is mandatory** around the body emission. The thunk is synthesized lazily from inside the caller's IR builder cursor; without `FnScope`, the synthetic CallExpr's IR would land in the caller's BB and corrupt the surrounding instruction stream. `FnScope` saves/clears/restores `fn_`, `current_function_`, and `IRBuilder` state, then `pushScope()` opens a fresh symbol table for the parameter allocas.
+- **Cache before body emission** (`native_thunk_cache_[name] = thunk;` *before* the synthetic CallExpr is emitted) so any self-referential resolution during synthesis returns the same Function instead of recursing infinitely.
+- **Set `FnTypeInfo` metadata via `getOrCreateMeta(thunk).fn_type_info = info;`** with `info.paramTypeNames` populated from `sig.params[i].typeName` — `lookupFnTypeInfo()` and `emitLambdaCall()` consult these source-level names for higher-order dispatch and Result/JsonValue metadata rehydration. If `resolveTypeAlias(sig.returnTypeName)` is itself a function type, populate `info.returnFnTypeInfo` via `parseFnTypeAnnotation`.
+- **Default arguments materialize at full arity.** The thunk's LLVM signature mirrors `sig.params` 1:1; the default-omission shortcut only works on the original direct `CallExpr` path. Document this in user-facing docs to avoid surprise.
+- **Resolution order matters.** The new path activates only when the user-fn lookup misses, so user-defined `fn` declarations continue to shadow `@native` imports of the same name without behavior change.
+
+**Why this design**:
+- Routing through `emitExpr(CallExpr)` rather than re-implementing the dispatch logic means both bare `@native` and `@native("libname")` work identically — the synthetic call hits the same Pattern A/B/generic chain that handles direct calls. No special-casing for dlopen wiring is needed.
+- Multi-overload reject mirrors user-fn behavior at `codegen_expr.cpp:194` (the existing "ambiguous reference" branch for overloaded user functions); using the same error class keeps the diagnostic surface consistent.
+- Custom-emitter natives (`math.abs`, `math.pow`, `math.round`, `math.log`, etc.) are all multi-overload by construction, so the single-overload rule transparently rejects them as first-class values without an extra "custom emitter" carve-out. Users who need first-class versions wrap them in a lambda (`f = (x) => abs(x)`).
+
+---
+

--- a/changelog.d/1569-native-first-class.md
+++ b/changelog.d/1569-native-first-class.md
@@ -1,0 +1,18 @@
+### Added
+
+- `@native` stdlib functions imported with `from <module> import <name>` can now be
+  used as **first-class function values**: bound to variables (`let f = toInt`),
+  passed to higher-order functions (`xs.map(toInt)`), and forwarded through
+  user-defined `fn(...) -> R`-typed parameters. Internally, the codegen
+  materializes a single internal LLVM thunk per name (cached) that forwards
+  through the existing native dispatch chain, so both bare `@native` and
+  `@native("libname")` declarations work identically. Materialization rules:
+  (a) names with **multiple overloads** (e.g. `toStr` over `int`/`float`/`bool`,
+  most `math` custom-emitter natives like `abs`/`pow`/`round`/`log`) are
+  rejected with `ambiguous reference to @native function 'X': multiple overloads
+  exist; wrap in a lambda to select one`; (b) names with **default arguments**
+  (e.g. `startsWith(haystack, needle, ignoreCase=false)`) materialize at
+  full arity — the resulting binding requires every parameter; the
+  default-omission shortcut is only available on the original direct call.
+  User-defined `fn` declarations continue to take precedence on name conflict
+  (the new path activates only when the user-fn lookup misses). (#1569)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -229,6 +229,32 @@ print(len(range()))           # Error: range() takes 1, 2, or 3 arguments
 
 `@native` overload resolution mirrors [user-defined overload resolution](functions.md#resolution-priority): exact-type matches are preferred, with safe implicit widening (`u8 → int`, `u8 → float`, `int → float`) as a fallback. For instance, `sqrt(4)` widens the `int` to `float` and calls `sqrt(float) -> float`, while `pow(2, 3)` still dispatches to the `(int, int) -> int` overload and returns `8`. Low-level integer types (`i8`, `i16`, …) require explicit `as` casts.
 
+**First-class function values:**
+
+A `@native` function imported with `from <module> import <name>` can be used as a first-class function value — bound to a variable, passed as an argument, or returned from a function — provided it has **exactly one overload**:
+
+```ry
+from convert import toInt
+from str import startsWith
+
+xs: List<str> = ["1", "2", "3"]
+results = xs.map(toInt)              # ok: toInt has a single (str) overload
+f = toInt
+print(f("42"))                       # Ok(42)
+
+g = startsWith                       # ok: full-arity 3-param binding
+print(g("hello", "he", false))       # default arg must be supplied here
+```
+
+Names with multiple overloads (e.g. `toStr` over `int`/`float`/`bool`, and most `math`-module custom-emitter natives such as `abs`/`pow`/`round`/`log`) are rejected at compile time with `ambiguous reference to @native function 'X': multiple overloads exist; wrap in a lambda to select one`. Wrap them in a lambda to pin the desired overload:
+
+```ry
+fmt = (n: int) => toStr(n)           # picks the (int) overload explicitly
+[1, 2, 3].map(fmt)                   # ["1", "2", "3"]
+```
+
+When a `@native` function declares default arguments, the materialized binding is **full-arity** — the default-omission shortcut is only available on the original direct call.
+
 **Standard library declarations (`share/std/`):**
 
 `@native` declarations for all built-in functions live under `share/std/` relative to the `ry` executable, organized by category. These files are automatically loaded as a prelude and enable argument count validation for built-in function calls. For the full function reference, see [Builtins](builtins.md), [Builtins — String](builtins-string.md), and [Collections](collections.md).

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -713,8 +713,15 @@ public:
     llvm::StructType *uniformClosureTy_ = nullptr;
     std::unordered_map<llvm::Function*, llvm::Function*> forwarding_thunk_cache_;
     std::unordered_map<llvm::Function*, llvm::Function*> capturing_thunk_cache_;
+    std::unordered_map<std::string, llvm::Function*> native_thunk_cache_;
     llvm::Function *uniform_closure_dtor_ = nullptr;
     llvm::Function *getOrCreateForwardingThunk(llvm::Function *realFn, const FnTypeInfo &info);
+    // Materialize a single-overload `@native` stdlib function as an internal LLVM Function
+    // so it can be referenced as a first-class value (`xs.map(toInt)`, `let f = toInt`).
+    // Returns nullptr if the name does not resolve to a registered `@native` signature.
+    // Multi-overload references throw a codegen error ("ambiguous"), matching user-fn
+    // behavior for overloaded function references.
+    llvm::Function *materializeNativeThunk(const std::string &name);
     llvm::Function *getOrCreateCapturingThunk(llvm::Function *realFn, const FnTypeInfo &info);
     llvm::Value *wrapAsUniformClosure(llvm::Value *val, const FnTypeInfo &info);
     llvm::Function *getOrCreateUniformClosureDestructor();

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -233,6 +233,10 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
         getOrCreateMeta(func).fn_type_info = info;
         return func;
     }
+    // Try first-class @native function reference: materialize a thunk that
+    // forwards to the existing native dispatch chain.
+    if (auto *thunk = materializeNativeThunk(e.name))
+        return thunk;
     codegenError("undefined variable: " + e.name);
 }
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -233,10 +233,16 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
         getOrCreateMeta(func).fn_type_info = info;
         return func;
     }
-    // Try first-class @native function reference: materialize a thunk that
-    // forwards to the existing native dispatch chain.
-    if (auto *thunk = materializeNativeThunk(e.name))
-        return thunk;
+    // Try first-class @native function reference only when no user fn
+    // shadows the name. User fns of any arity (single or multiple
+    // overloads) take precedence; size==1 is handled by the branch above,
+    // size>1 falls through here and must NOT materialize a native thunk
+    // (the thunk body would re-dispatch the synthetic CallExpr through
+    // user fns and produce a misleading "no matching overload" error).
+    if (!fnOverloads) {
+        if (auto *thunk = materializeNativeThunk(e.name))
+            return thunk;
+    }
     codegenError("undefined variable: " + e.name);
 }
 

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -1218,6 +1218,122 @@ llvm::Function *CodeGen::getOrCreateForwardingThunk(llvm::Function *realFn, cons
     return thunk;
 }
 
+llvm::Function *CodeGen::materializeNativeThunk(const std::string &name) {
+    auto cacheIt = native_thunk_cache_.find(name);
+    if (cacheIt != native_thunk_cache_.end())
+        return cacheIt->second;
+
+    // Collect candidate signatures: bare name, plus any "<package>::name" variants
+    std::vector<const NativeFnSignature*> candidates;
+    if (auto it = native_fn_sigs_.find(name); it != native_fn_sigs_.end()) {
+        for (auto &sig : it->second)
+            candidates.push_back(&sig);
+    }
+    {
+        const std::string suffix = "::" + name;
+        for (auto &kv : native_fn_sigs_) {
+            if (kv.first == name) continue;  // bare-name bucket already collected
+            if (kv.first.size() > suffix.size() &&
+                kv.first.compare(kv.first.size() - suffix.size(), suffix.size(), suffix) == 0) {
+                for (auto &sig : kv.second)
+                    candidates.push_back(&sig);
+            }
+        }
+    }
+
+    if (candidates.empty())
+        return nullptr;
+    if (candidates.size() > 1)
+        codegenError("ambiguous reference to @native function '" + name +
+                     "': multiple overloads exist; wrap in a lambda to select one");
+
+    const NativeFnSignature &sig = *candidates.front();
+
+    std::vector<llvm::Type*> paramLLVMTypes;
+    paramLLVMTypes.reserve(sig.params.size());
+    for (auto &p : sig.params)
+        paramLLVMTypes.push_back(resolveType(p.typeName));
+    llvm::Type *retTy = resolveType(sig.returnTypeName);
+    auto *thunkTy = llvm::FunctionType::get(retTy, paramLLVMTypes, false);
+
+    std::string thunkName = "__ry_native_thunk_" + name;
+    auto *thunk = llvm::Function::Create(
+        thunkTy, llvm::Function::InternalLinkage, thunkName, mod_.get());
+    thunk->addFnAttr(llvm::Attribute::NoUnwind);
+
+    // Cache before emission so any recursive reference resolves
+    native_thunk_cache_[name] = thunk;
+
+    // Set FnTypeInfo metadata so first-class call sites can pick it up
+    FnTypeInfo info;
+    info.paramTypes = paramLLVMTypes;
+    info.paramTypeNames.reserve(sig.params.size());
+    for (auto &p : sig.params)
+        info.paramTypeNames.push_back(p.typeName);
+    info.returnType = retTy;
+    info.returnTypeName = sig.returnTypeName;
+    {
+        std::string resolved = resolveTypeAlias(sig.returnTypeName);
+        if (isFunctionTypeName(resolved))
+            info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(resolved));
+    }
+    info.sourceFn = thunk;
+    getOrCreateMeta(thunk).fn_type_info = std::move(info);
+
+    // Emit body: forward all parameters to the underlying @native dispatch via
+    // a synthetic CallExpr; emitExpr re-enters the existing call dispatch chain
+    // (Pattern A table-driven, Pattern B custom emitter, or generic native).
+    {
+        FnScope guard(*this);
+        fn_ = thunk;
+        pushScope();
+
+        auto *entry = llvm::BasicBlock::Create(*ctx_, "entry", thunk);
+        builder_.SetInsertPoint(entry);
+
+        unsigned idx = 0;
+        for (auto &arg : thunk->args()) {
+            const auto &p = sig.params[idx];
+            arg.setName(p.name);
+            llvm::AllocaInst *alloca = builder_.CreateAlloca(
+                paramLLVMTypes[idx], nullptr, p.name);
+            builder_.CreateStore(&arg, alloca);
+            scope_stack_.back()[p.name] = alloca;
+            applyParamTypeMeta(p.typeName, alloca, paramLLVMTypes[idx], p.name);
+            ++idx;
+        }
+
+        // Build synthetic CallExpr: name(p0, p1, ...). Each arg is a
+        // VariableExpr that resolves to the alloca we just inserted.
+        auto callExpr = std::make_unique<CallExpr>();
+        callExpr->callee = name;
+        for (auto &p : sig.params) {
+            auto argNode = std::make_unique<ExprNode>();
+            argNode->data = VariableExpr{p.name};
+            callExpr->args.push_back(std::move(argNode));
+        }
+        ExprNode callNode;
+        callNode.data = std::move(callExpr);
+
+        llvm::Value *result = emitExpr(callNode);
+
+        if (retTy->isVoidTy()) {
+            popScope();
+            builder_.CreateRetVoid();
+        } else {
+            popScope();
+            builder_.CreateRet(result);
+        }
+
+        std::string err;
+        llvm::raw_string_ostream errStream(err);
+        if (llvm::verifyFunction(*thunk, &errStream))
+            codegenError("IR verify error in native thunk '" + name + "': " + err);
+    }
+
+    return thunk;
+}
+
 llvm::Function *CodeGen::getOrCreateCapturingThunk(llvm::Function *realFn, const FnTypeInfo &info) {
     auto it = capturing_thunk_cache_.find(realFn);
     if (it != capturing_thunk_cache_.end())

--- a/tests/spec/native_first_class.test.ry
+++ b/tests/spec/native_first_class.test.ry
@@ -4,6 +4,8 @@
 # raised "undefined variable: toInt" because emitExprVariant(VariableExpr)
 # never consulted native_fn_sigs_.
 
+from convert import toInt
+
 describe("@native first-class — direct assignment (single-overload)", ():
   it("binds toInt to a variable and invokes it", ():
     f = toInt
@@ -57,5 +59,14 @@ describe("@native first-class — default args materialize as full arity", ():
     expect(g("hello", "he", false)).toBeTrue()
     expect(g("hello", "He", true)).toBeTrue()
     expect(g("hello", "world", false)).toBeFalse()
+  )
+)
+
+describe("@native first-class — explicit import path", ():
+  it("explicit `from convert import toInt` round-trips through a binding", ():
+    f = toInt
+    case f("99"):
+      Ok(v): expect(v).toEq(99)
+      Err(e): fail("toInt failed: " + e.message)
   )
 )

--- a/tests/spec/native_first_class.test.ry
+++ b/tests/spec/native_first_class.test.ry
@@ -1,0 +1,61 @@
+# Tests for #1569: @native stdlib functions can be referenced as
+# first-class function values (assigned to vars / passed as args), not
+# only used in direct CallExpr position. Before #1569, `let f = toInt`
+# raised "undefined variable: toInt" because emitExprVariant(VariableExpr)
+# never consulted native_fn_sigs_.
+
+describe("@native first-class — direct assignment (single-overload)", ():
+  it("binds toInt to a variable and invokes it", ():
+    f = toInt
+    case f("42"):
+      Ok(v): expect(v).toEq(42)
+      Err(e): fail("toInt failed: " + e.message)
+  )
+
+  it("returns Err through the bound variable", ():
+    f = toInt
+    case f("not-a-number"):
+      Ok(v): fail("expected Err, got Ok(" + toStr(v) + ")")
+      Err(e): expect(e.message).toContain("toInt")
+  )
+
+  it("propagates the binding through a chain of let-bindings", ():
+    f = toInt
+    g = f
+    case g("100"):
+      Ok(v): expect(v).toEq(100)
+      Err(e): fail("toInt failed: " + e.message)
+  )
+)
+
+describe("@native first-class — passed as fn parameter", ():
+  it("invokes a passed @native via a user-defined higher-order fn", ():
+    fn invoke(f: fn(str) -> Result<int, Error>, s: str) -> Result<int, Error>:
+      return f(s)
+
+    case invoke(toInt, "7"):
+      Ok(v): expect(v).toEq(7)
+      Err(e): fail("toInt failed: " + e.message)
+  )
+
+  it("xs.map(toInt) routes the @native through stdlib map", ():
+    xs: List<str> = ["1", "2", "3"]
+    results = xs.map(toInt)
+    expect(len(results)).toEq(3)
+    case results[0]:
+      Ok(v): expect(v).toEq(1)
+      Err(e): fail("toInt[0] failed: " + e.message)
+    case results[2]:
+      Ok(v): expect(v).toEq(3)
+      Err(e): fail("toInt[2] failed: " + e.message)
+  )
+)
+
+describe("@native first-class — default args materialize as full arity", ():
+  it("requires every param when calling the materialized binding", ():
+    g = startsWith
+    expect(g("hello", "he", false)).toBeTrue()
+    expect(g("hello", "He", true)).toBeTrue()
+    expect(g("hello", "world", false)).toBeFalse()
+  )
+)

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -697,3 +697,20 @@ TEST_F(CodeGenTest, MultiOverloadNativeCustomEmitterReferenceRejected) {
         "f = pow\n",
         {"pow", "ambiguous"});
 }
+
+// Multi-overload user fn must shadow @native so that VariableExpr
+// resolution yields a "undefined variable" diagnostic, not the
+// misleading "no matching overload" error that would arise if
+// materializeNativeThunk synthesized a CallExpr that re-dispatched
+// through the user-fn overload set.
+TEST_F(CodeGenTest, UserFnMultiOverloadShadowsNativeFirstClass) {
+    expectCompileError(
+        "@native\n"
+        "fn natFoo(x: str) -> int\n"
+        "fn natFoo(x: int) -> int:\n"
+        "  return x\n"
+        "fn natFoo(x: float) -> int:\n"
+        "  return x as int\n"
+        "f = natFoo\n",
+        "undefined variable");
+}

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -656,3 +656,44 @@ TEST_F(CodeGenTest, NestedGenericEnumFieldCompiles) {
         "fn mk() -> Outer<int>:\n"
         "  return Outer<int>::Wrap(Inner<int>::In(1))\n"));
 }
+
+// ============================================================
+// #1569: Referencing a multi-overload @native function as a
+// first-class value must produce a clear "ambiguous" diagnostic,
+// mirroring the user-fn behavior in emitExprVariant(VariableExpr).
+// Single-overload @native references succeed (covered by
+// tests/spec/native_first_class.test.ry); multi-overload
+// references must reject because the materialized thunk would
+// have no unambiguous signature.
+//
+// Inline @native declarations match what convert.ry exposes.
+// CodeGenTest::runSource bypasses ModuleLoader so we cannot
+// `from convert import toStr`.
+// ============================================================
+
+TEST_F(CodeGenTest, MultiOverloadNativeReferenceRejected) {
+    expectCompileError(
+        "@native\n"
+        "fn toStr(value: int) -> str\n"
+        "@native\n"
+        "fn toStr(value: float) -> str\n"
+        "@native\n"
+        "fn toStr(value: bool) -> str\n"
+        "f = toStr\n",
+        {"toStr", "ambiguous"});
+}
+
+// math.pow has multi-arity overloads ((float, float) and (int, int))
+// declared in share/std/math/math.ry. Even though codegen routes to
+// custom emitters via emitMathPow, `let f = pow` must hit the same
+// multi-overload reject path because the materialized thunk has no
+// unambiguous arity/type signature.
+TEST_F(CodeGenTest, MultiOverloadNativeCustomEmitterReferenceRejected) {
+    expectCompileError(
+        "@native\n"
+        "fn pow(x: float, y: float) -> float\n"
+        "@native\n"
+        "fn pow(x: int, y: int) -> int\n"
+        "f = pow\n",
+        {"pow", "ambiguous"});
+}


### PR DESCRIPTION
## Summary

Closes #1569.

`@native` stdlib functions imported with `from <module> import <name>` can now be used as **first-class function values** — bound to variables, passed to higher-order functions, and forwarded through `fn(...) -> R`-typed parameters.

```ry
from convert import toInt

xs: List<str> = ["1", "2", "3"]
results = xs.map(toInt)              # was: undefined variable: toInt

f = toInt
print(f("42"))                       # Ok(42)
```

### Implementation

- **`materializeNativeThunk(name)`** (`src/codegen_lambda.cpp`): synthesizes an internal LLVM Function `__ry_native_thunk_<name>` whose body is a synthetic `CallExpr` routed back through `emitExpr`, so the existing native dispatch chain (Pattern A/B/generic + `@native("libname")` dlopen) is reused without duplication. Thunks are cached by name; `FnTypeInfo` metadata is set so higher-order call sites can resolve the signature.
- **Wire-in** at `src/codegen_expr.cpp:236-239`: `emitExprVariant<VariableExpr>` calls `materializeNativeThunk(e.name)` after the user-fn lookup misses, before the `undefined variable` error. User-defined `fn` declarations retain precedence on name conflict.

### Materialization rules

1. **Single overload only.** Multi-overload names (e.g. `toStr` over `int`/`float`/`bool`, most `math` custom-emitter natives like `abs`/`pow`/`round`/`log`) reject with `ambiguous reference to @native function 'X': multiple overloads exist; wrap in a lambda to select one`. Mirrors user-fn behavior at `codegen_expr.cpp:194`.
2. **Default arguments materialize at full arity.** `g = startsWith` produces a 3-param binding requiring all args; the default-omission shortcut is only available on the original direct call.

## Test plan

- [x] `tests/spec/native_first_class.test.ry` — 6 spec cases (direct assignment Ok/Err paths, binding chain, user-defined HOF, stdlib `xs.map(toInt)`, default-arg full-arity)
- [x] `tests/test_codegen_fail.cpp` — `MultiOverloadNativeReferenceRejected` + `MultiOverloadNativeCustomEmitterReferenceRejected` (negative TDD per `.claude/rules/tests-rejection-tdd.md`)
- [x] `./build/ry_tests` — 2106 C++ tests pass
- [x] `./build/ry test -p` — 172 Ry self-test files pass
- [x] ASan + UBSan clean (`build-asan`)
- [x] TSan clean (`build-tsan`)
- [x] clang-tidy + cppcheck clean
- [x] Docs: `docs/reference/directives.md` First-class function values section added; example verified end-to-end with `./build/ry`
- [x] Knowledge base: `.claude/rules/codegen-fn-and-generic.md` entry added (FnScope mandatory, cache-before-emission, FnTypeInfo setup, full-arity defaults, resolution order)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Imported native stdlib functions can be used as first-class values (bound to vars, passed to HOFs, used where function-typed).
  * When a native function declares defaults, a bound version requires full arity; direct calls still allow omissions.
  * User-defined functions continue to shadow native names.

* **Behavior**
  * Binding ambiguous (multi-overload) native names is rejected with a compile-time ambiguity error.

* **Documentation**
  * Added guidance on first-class native usage and restrictions.

* **Tests**
  * New tests covering binding, invocation, ambiguity, and default-arity behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->