### PR TITLE
chore: pin wip-label addition as Plan Task 1

### DIFF
--- a/.claude/skills/git-claim-issue/SKILL.md
+++ b/.claude/skills/git-claim-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-claim-issue
-description: Claim a GitHub issue by safely adding the `wip` label without erasing existing labels. Use when starting work on an issue, e.g. "start working on #123", "claim issue 456", "issue に取り組む", "wip つけて", "着手". **Also trigger proactively** whenever the user provides an issue number for development — even if they did not say "claim" or "wip" — before entering Plan mode.
+description: Claim a GitHub issue by safely adding the `wip` label without erasing existing labels. Invoked as **Task 1 of the implementation plan** (immediately after Plan approval, before creating the feature branch), or on explicit user request: "start working on #123", "claim issue 456", "issue に取り組む", "wip つけて", "着手".
 allowed-tools: Bash(gh issue view:*), Bash(gh issue edit:*)
 metadata:
   short-description: Add wip label to an issue without clobbering other labels
@@ -12,9 +12,8 @@ Mark a GitHub issue as in-progress by adding the `wip` label. This is the counte
 
 ## When to use
 
-- At the start of issue-driven development, before entering Plan mode
+- As **Task 1** of the implementation plan, immediately after Plan approval (before creating the feature branch)
 - When the user says 「取り組む」 / 「着手」 / "start working" / "claim" / 「wip つけて」 for a specific issue
-- Whenever AGENTS.md "Plan モード開始条件" requires confirmation that `wip` is attached
 
 ## Repository
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,7 +71,7 @@ ASan または UBSan が検出した問題（メモリリーク、バッファ�
 
 ## ワークフロー全体像
 
-issue 確認 → `/git-claim-issue` で `wip` 付与 → ナレッジベース参照 (path-scoped rule は実装中も auto-load) → Plan モード → TDD 実装 → `/pre-commit-checklist` でセルフ検証 → 以降の git 操作 (commit / push / PR / merge) は「責務の分離」に従う。
+issue 確認 → ナレッジベース参照 (path-scoped rule は実装中も auto-load) → Plan モード (Task 1 = `/git-claim-issue` で `wip` 付与) → TDD 実装 → `/pre-commit-checklist` でセルフ検証 → 以降の git 操作 (commit / push / PR / merge) は「責務の分離」に従う。
 
 ## issue 起点の開発
 
@@ -81,11 +81,14 @@ issue 確認 → `/git-claim-issue` で `wip` 付与 → ナレッジベース�
 
 ## Plan モードのルール
 
-- **開始条件**: 対象 issue の特定・`wip` ラベル付与済み (未付与なら `git-claim-issue` スキルを起動)・リモートと最新化済み
-- **実装計画の最初のタスク**: `main` からフィーチャーブランチを作成（`git-branch-naming` スキル経由）
+- **開始条件**: 対象 issue の特定 (OPEN 状態を `gh issue view <n>` で確認)・リモートと最新化済み (`wip` 付与は Task 1 で実施するため事前付与不要)
+- **実装計画の最初の 2 タスク (固定・順序厳守)**:
+  - **Task 1**: `/git-claim-issue` で issue に `wip` ラベルを付与する
+  - **Task 2**: `main` からフィーチャーブランチを作成する (`/git-branch-naming` スキル経由)
 - **実装計画のスコープ**: セルフ検証まで（git add / commit / push / PR 作成は含めない）
 - **計画の抽象度（WHAT/HOW 分離）**: 計画は「何を達成するか」(WHAT) にとどめ、「どう実装するか」(HOW) は実装フェーズに委ねる。過剰な HOW 詳細が計画にあれば `/plan-rubric` で検出する
 - **実装計画に必ず含めるもの**:
+  - 最初の 2 タスクが固定どおり (Task 1 = `/git-claim-issue`、Task 2 = `/git-branch-naming` 経由のフィーチャーブランチ作成) であること
   - 編集予定 path の `.claude/rules/<name>.md` / `.claude/skills/<name>/SKILL.md` の関連エントリを参照したか (該当エントリがあれば Plan 本文に引用し、活用方法を明示する)
   - 仕様通りに実装できていることのセルフ検証タスク
   - 英語ドキュメント（README.md / docs）の更新（または変更不要の確認）


### PR DESCRIPTION
## Summary
- Restructure wip-label assignment to be Plan **Task 1 (fixed)** instead of a proactive trigger before Plan mode
- Address the asymmetric enforcement design: `git-merge-pr` Step 5 (removal) is built into the merge flow, but `git-claim-issue` (addition) relied on Claude's proactive judgment — leading to recurring missed `wip` labels
- Pin the first 2 plan tasks: **Task 1 = `/git-claim-issue`**, **Task 2 = `/git-branch-naming`**

## Changes
- `AGENTS.md`
  - L74 (workflow overview): remove `/git-claim-issue` from the top-level chain; surface it inside Plan モード as Task 1
  - L84 (Plan start preconditions): drop "`wip` 付与済み"; replace with OPEN-state check via `gh issue view <n>`
  - L85-87: pin first 2 plan tasks in fixed order (Task 1 / Task 2)
  - L91: add "first 2 tasks must follow the fixed order" to "実装計画に必ず含めるもの"
- `.claude/skills/git-claim-issue/SKILL.md`
  - frontmatter description: rewrite to "Invoked as **Task 1 of the implementation plan**"; remove "**Also trigger proactively**" wording
  - "When to use": rewrite first item to "As **Task 1** of the implementation plan"; drop redundant L17 referencing the removed precondition

## Test plan
- [x] Static integrity check: \`grep -rnE "before entering Plan mode|trigger proactively|wip ラベル付与済み" .claude/ AGENTS.md\` returns 0 hits
- [x] \`grep -nE "wip|git-claim-issue|Task 1|Task 2" AGENTS.md\` shows new wording in 8 expected locations with no leftover legacy phrasing
- [ ] Next issue-driven session: verify Plan generates Task 1 = `/git-claim-issue` automatically and that it is executed as the first action after Plan approval

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated workflow order: knowledge base reference now follows issue confirmation directly.
  * Clarified Plan mode initialization requirements: target issue identification is performed at start, independent of pre-assigned labels.
  * Established mandatory task sequence: first two Plan mode tasks are now fixed and must maintain specified order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->