### PR TITLE
feat(math): add digits(n, base = 10) -> List<int> (#1578)

### DIFF
--- a/.claude/rules/stdlib-module-additions.md
+++ b/.claude/rules/stdlib-module-additions.md
@@ -114,3 +114,45 @@ required because of how the builtin dispatcher resolves names. For
 ordinary stdlib modules (str / convert / json / regex / math / …),
 prefer the direct-default form documented here.
 
+**Carve-out (#1578): default-arg form only works for name-keyed
+dispatchers, NOT for table-driven custom-emitter paths.**
+
+The "single declaration with inline default" pattern above
+(`emitStrOp_starts_with`-style) works because str's dispatcher
+(`src/codegen_call_string.cpp`) keys on the **function name only** and
+re-derives arity inside the handler from `e.args.size()`. The same is
+true for any handler reached through name-keyed dispatch.
+
+The math module uses a different path:
+`emitTableDrivenNativeCall` (`src/codegen_call_native.cpp:191`) gates
+the dispatch with a strict arity check —
+`if (sig.params.size() == e.args.size())`. With a single
+`@native fn digits(n: int, base: int = 10)` declaration, only the
+2-param signature is registered in `native_fn_sigs_`, and a 1-arg call
+site (`digits(0)`) silently fails the arity gate, falling through to
+"undefined function: digits".
+
+**Rule for table-driven custom emitters (math, and any future module
+using the `*_table[]` + `customEmitter` pattern)**: declare **one
+`@native fn` per arity**, mirroring `floor` / `ceil` / `pow` /
+`round`:
+
+```ry
+@public @native fn digits(n: int) -> List<int>
+@public @native fn digits(n: int, base: int) -> List<int>
+```
+
+The custom emitter (`emitMathDigits`) still handles both arities
+internally — supplying a default `ConstantInt::get(i64Ty_, 10)` when
+`e.args.size() == 1`. Only the *declaration side* needs the per-arity
+duplication so each signature passes the arity gate.
+
+**How to tell which dispatch path applies**:
+- Look up the module's emitter in `src/codegen_call.cpp`. If the table
+  entry has a non-null `customEmitter`, the call goes through
+  `emitTableDrivenNativeCall` and the strict arity gate applies.
+- If the emitter is a name-keyed dispatcher (str: `dispatch` map in
+  `emitBuiltinString`), default-arg form is fine.
+- When in doubt, write the test first: a unit test exercising every
+  documented arity will catch the missing arity gate immediately.
+

--- a/changelog.d/1578-math-digits.md
+++ b/changelog.d/1578-math-digits.md
@@ -1,0 +1,9 @@
+### Added
+
+- `digits(n: int) -> List<int>` and `digits(n: int, base: int) -> List<int>`
+  to the `math` module. Decomposes a non-negative integer into its digits
+  low-first (least-significant digit at index 0), matching Ruby's
+  `Integer#digits` (`digits(1234) == [4, 3, 2, 1]`, `digits(255, 16) == [15, 15]`,
+  `digits(0) == [0]`). Default base is 10. Composes with `sum` for digit-sum
+  in one expression: `sum(digits(1234)) == 10`. Aborts with a runtime error
+  on negative `n` or `base < 2`. (#1578)

--- a/docs/reference/math.md
+++ b/docs/reference/math.md
@@ -45,6 +45,41 @@ abs(-3.14)   # 3.14
 
 ---
 
+## Digits
+
+| Function | Signature | Description |
+|----------|-----------|-------------|
+| `digits(n)` | `(int) -> List<int>` | Decompose `n` into base-10 digits, low-first |
+| `digits(n, base)` | `(int, int) -> List<int>` | Decompose `n` into digits of the given base, low-first |
+
+```ry
+from math import digits
+
+digits(1234)         # [4, 3, 2, 1]
+digits(255, 16)      # [15, 15]
+digits(8, 2)         # [0, 0, 0, 1]
+digits(0)            # [0]
+```
+
+The result is ordered low-first (least-significant digit at index 0), matching Ruby's `Integer#digits`. Composing with `sum` yields the digit sum in one expression:
+
+```ry
+from math import digits
+
+sum(digits(1234))    # 10
+```
+
+The default base is `10`. Both `digits(n)` and `digits(n, 10)` produce the same result.
+
+`digits` raises a runtime error and aborts when:
+
+- `n` is negative — `runtime error: digits() n must be non-negative, got <n>`
+- `base` is less than 2 — `runtime error: digits() base must be >= 2, got <base>`
+
+The algorithm uses only `%` and `/` operations, so it has no overflow concerns regardless of input magnitude (`digits(9223372036854775807)` returns a 19-element list).
+
+---
+
 ## Rounding
 
 | Function | Signature | Description |

--- a/share/std/math/math.ry
+++ b/share/std/math/math.ry
@@ -122,3 +122,11 @@ fn isNan(x: float) -> bool
 @public
 @native
 fn isInf(x: float) -> bool
+
+@public
+@native
+fn digits(n: int) -> List<int>
+
+@public
+@native
+fn digits(n: int, base: int) -> List<int>

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -1244,6 +1244,121 @@ static llvm::Value *emitMathIsInf(CodeGen &cg, const CallExpr &e) {
     return cg.builder_.CreateFCmpOEQ(absVal, posInf, "is_inf");
 }
 
+static llvm::Value *emitMathDigits(CodeGen &cg, const CallExpr &e) {
+    if (e.args.size() != 1 && e.args.size() != 2)
+        cg.codegenError("digits() expects 1 or 2 arguments");
+
+    llvm::Value *n = cg.emitExpr(*e.args[0]);
+    if (!n->getType()->isIntegerTy(64))
+        cg.codegenError("digits() requires int argument");
+
+    llvm::Value *base;
+    if (e.args.size() == 2) {
+        base = cg.emitExpr(*e.args[1]);
+        if (!base->getType()->isIntegerTy(64))
+            cg.codegenError("digits() base must be int");
+    } else {
+        base = llvm::ConstantInt::get(cg.i64Ty_, 10);
+    }
+
+    llvm::Value *zero = llvm::ConstantInt::get(cg.i64Ty_, 0);
+    llvm::Value *one  = llvm::ConstantInt::get(cg.i64Ty_, 1);
+    llvm::Value *two  = llvm::ConstantInt::get(cg.i64Ty_, 2);
+
+    {
+        static int negCounter = 0;
+        llvm::Value *isNeg = cg.builder_.CreateICmpSLT(n, zero, "digits_n_neg");
+        llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*cg.ctx_, "digits.n_err", cg.fn_);
+        llvm::BasicBlock *okBB  = llvm::BasicBlock::Create(*cg.ctx_, "digits.n_ok",  cg.fn_);
+        cg.builder_.CreateCondBr(isNeg, errBB, okBB);
+        cg.builder_.SetInsertPoint(errBB);
+        cg.emitRuntimeError(
+            "runtime error: digits() n must be non-negative, got %lld\n",
+            ".digits_n_err_" + std::to_string(negCounter++),
+            {n});
+        cg.builder_.SetInsertPoint(okBB);
+    }
+
+    {
+        static int baseCounter = 0;
+        llvm::Value *isLow = cg.builder_.CreateICmpSLT(base, two, "digits_base_low");
+        llvm::BasicBlock *errBB = llvm::BasicBlock::Create(*cg.ctx_, "digits.base_err", cg.fn_);
+        llvm::BasicBlock *okBB  = llvm::BasicBlock::Create(*cg.ctx_, "digits.base_ok",  cg.fn_);
+        cg.builder_.CreateCondBr(isLow, errBB, okBB);
+        cg.builder_.SetInsertPoint(errBB);
+        cg.emitRuntimeError(
+            "runtime error: digits() base must be >= 2, got %lld\n",
+            ".digits_base_err_" + std::to_string(baseCounter++),
+            {base});
+        cg.builder_.SetInsertPoint(okBB);
+    }
+
+    // do-while loop ensures n=0 yields count=1 (so digits(0) == [0]).
+    llvm::AllocaInst *countSlot = cg.builder_.CreateAlloca(cg.i64Ty_, nullptr, "digits_count");
+    llvm::AllocaInst *qSlot     = cg.builder_.CreateAlloca(cg.i64Ty_, nullptr, "digits_q");
+    cg.builder_.CreateStore(zero, countSlot);
+    cg.builder_.CreateStore(n, qSlot);
+
+    llvm::BasicBlock *countBodyBB = llvm::BasicBlock::Create(*cg.ctx_, "digits.count.body", cg.fn_);
+    llvm::BasicBlock *countEndBB  = llvm::BasicBlock::Create(*cg.ctx_, "digits.count.end",  cg.fn_);
+    cg.builder_.CreateBr(countBodyBB);
+
+    cg.builder_.SetInsertPoint(countBodyBB);
+    llvm::Value *qCur     = cg.builder_.CreateLoad(cg.i64Ty_, qSlot, "digits_q_cur");
+    llvm::Value *qNext    = cg.builder_.CreateSDiv(qCur, base, "digits_q_next");
+    llvm::Value *cCur     = cg.builder_.CreateLoad(cg.i64Ty_, countSlot, "digits_count_cur");
+    llvm::Value *cNext    = cg.builder_.CreateAdd(cCur, one, "digits_count_next");
+    cg.builder_.CreateStore(qNext, qSlot);
+    cg.builder_.CreateStore(cNext, countSlot);
+    llvm::Value *qDone = cg.builder_.CreateICmpEQ(qNext, zero, "digits_count_done");
+    cg.builder_.CreateCondBr(qDone, countEndBB, countBodyBB);
+
+    cg.builder_.SetInsertPoint(countEndBB);
+    llvm::Value *count = cg.builder_.CreateLoad(cg.i64Ty_, countSlot, "digits_count_final");
+
+    llvm::Value *headerPtr = cg.emitArcAllocCollectionHeader(cg.listHeaderTy_);
+    auto mallocFn = cg.getStdlibMalloc();
+    const llvm::DataLayout &dl = cg.mod_->getDataLayout();
+    uint64_t elemSize = dl.getTypeAllocSize(cg.i64Ty_);
+    llvm::Value *dataSize = cg.builder_.CreateMul(
+        count, llvm::ConstantInt::get(cg.i64Ty_, elemSize), "digits_data_size");
+    llvm::Value *dataPtr = cg.builder_.CreateCall(mallocFn, {dataSize}, "digits_data");
+
+    // % and / only — never computes base^k, so input magnitude can't overflow.
+    llvm::AllocaInst *iSlot = cg.builder_.CreateAlloca(cg.i64Ty_, nullptr, "digits_i");
+    llvm::AllocaInst *fSlot = cg.builder_.CreateAlloca(cg.i64Ty_, nullptr, "digits_fill_q");
+    cg.builder_.CreateStore(zero, iSlot);
+    cg.builder_.CreateStore(n, fSlot);
+
+    llvm::BasicBlock *fillCondBB = llvm::BasicBlock::Create(*cg.ctx_, "digits.fill.cond", cg.fn_);
+    llvm::BasicBlock *fillBodyBB = llvm::BasicBlock::Create(*cg.ctx_, "digits.fill.body", cg.fn_);
+    llvm::BasicBlock *fillEndBB  = llvm::BasicBlock::Create(*cg.ctx_, "digits.fill.end",  cg.fn_);
+    cg.builder_.CreateBr(fillCondBB);
+
+    cg.builder_.SetInsertPoint(fillCondBB);
+    llvm::Value *iVal = cg.builder_.CreateLoad(cg.i64Ty_, iSlot, "digits_i_val");
+    llvm::Value *cont = cg.builder_.CreateICmpSLT(iVal, count, "digits_fill_cond");
+    cg.builder_.CreateCondBr(cont, fillBodyBB, fillEndBB);
+
+    cg.builder_.SetInsertPoint(fillBodyBB);
+    llvm::Value *iCur     = cg.builder_.CreateLoad(cg.i64Ty_, iSlot, "digits_i_cur");
+    llvm::Value *fCur     = cg.builder_.CreateLoad(cg.i64Ty_, fSlot, "digits_fill_cur");
+    llvm::Value *digit    = cg.builder_.CreateSRem(fCur, base, "digits_digit");
+    llvm::Value *fNext    = cg.builder_.CreateSDiv(fCur, base, "digits_fill_next");
+    llvm::Value *elemPtr  = cg.builder_.CreateGEP(cg.i64Ty_, dataPtr, {iCur}, "digits_elem_ptr");
+    cg.builder_.CreateStore(digit, elemPtr);
+    cg.builder_.CreateStore(fNext, fSlot);
+    llvm::Value *iNext = cg.builder_.CreateAdd(iCur, one, "digits_i_next");
+    cg.builder_.CreateStore(iNext, iSlot);
+    cg.builder_.CreateBr(fillCondBB);
+
+    cg.builder_.SetInsertPoint(fillEndBB);
+
+    cg.storeListHeaderFields(headerPtr, count, count, dataPtr);
+    cg.setTypeMeta(CodeGen::TypeMeta::ListElem, headerPtr, cg.i64Ty_);
+    return headerPtr;
+}
+
 // ===== Math dispatch table =====
 
 static const CodeGen::NativeDispatchEntry math_table[] = {
@@ -1272,6 +1387,7 @@ static const CodeGen::NativeDispatchEntry math_table[] = {
     {"pow",    nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitMathPow},
     {"isNan",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathIsNan},
     {"isInf",  nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathIsInf},
+    {"digits", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitMathDigits},
 };
 
 RY_REGISTER_STDLIB_PACKAGE(math, "share/std/math/math.ry", dispatchMath)

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -1,4 +1,4 @@
-from math import PI, E, INF, NAN, abs, floor, ceil, round, sqrt, pow, log, log2, log10, exp, sin, cos, tan, asin, acos, atan, atan2, hypot, isNan, isInf
+from math import PI, E, INF, NAN, abs, floor, ceil, round, sqrt, pow, log, log2, log10, exp, sin, cos, tan, asin, acos, atan, atan2, hypot, isNan, isInf, digits
 
 describe("math constants", ():
   it("should define PI", ():
@@ -432,5 +432,36 @@ describe("math custom emitter int->float widening (#1230)", ():
     expect(toStr(pow(2, 3))).toEq("8")
     expect(toStr(pow(2.0, 3))).toEq("8.0")
     expect(toStr(pow(2, 3.0))).toEq("8.0")
+  )
+)
+
+describe("math digits", ():
+  it("returns [0] for n = 0", ():
+    expect(digits(0)).toEq([0])
+  )
+  it("returns [1] for n = 1", ():
+    expect(digits(1)).toEq([1])
+  )
+  it("returns digits low-first in base 10", ():
+    expect(digits(1234)).toEq([4, 3, 2, 1])
+  )
+  it("supports base 16", ():
+    expect(digits(255, 16)).toEq([15, 15])
+  )
+  it("supports base 2", ():
+    expect(digits(8, 2)).toEq([0, 0, 0, 1])
+    expect(digits(1, 2)).toEq([1])
+  )
+  it("composes with sum for digit-sum (Ruby Integer#digits parity)", ():
+    expect(sum(digits(1234))).toEq(10)
+  )
+  it("handles INT64_MAX (~19 digits)", ():
+    ds = digits(9223372036854775807)
+    expect(ds.len()).toEq(19)
+    expect(ds[0]).toEq(7)
+    expect(ds[18]).toEq(9)
+  )
+  it("default base is 10", ():
+    expect(digits(42)).toEq(digits(42, 10))
   )
 )

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -199,6 +199,36 @@ TEST_F(CodeGenTest, MathPowIntNegativeExponentAborts) {
         "pow\\(\\) integer exponent must be non-negative");
 }
 
+TEST_F(CodeGenTest, DigitsNegativeNAborts) {
+    EXPECT_EXIT(
+        runSource(
+            "@native\n"
+            "fn digits(n: int, base: int) -> List<int>\n"
+            "print(digits(-1, 10))\n"),
+        ::testing::ExitedWithCode(1),
+        "digits\\(\\) n must be non-negative");
+}
+
+TEST_F(CodeGenTest, DigitsBaseLessThan2Aborts) {
+    EXPECT_EXIT(
+        runSource(
+            "@native\n"
+            "fn digits(n: int, base: int) -> List<int>\n"
+            "print(digits(10, 1))\n"),
+        ::testing::ExitedWithCode(1),
+        "digits\\(\\) base must be >= 2");
+}
+
+TEST_F(CodeGenTest, DigitsBaseZeroAborts) {
+    EXPECT_EXIT(
+        runSource(
+            "@native\n"
+            "fn digits(n: int, base: int) -> List<int>\n"
+            "print(digits(10, 0))\n"),
+        ::testing::ExitedWithCode(1),
+        "digits\\(\\) base must be >= 2");
+}
+
 TEST_F(CodeGenTest, HelperReturnRejectsIncompatibleThreadResultMetadataAcrossBranches) {
     expectCompileError(
         "@native(\"thread\")\n"


### PR DESCRIPTION
## Summary

- `digits(n: int) -> List<int>` and `digits(n: int, base: int) -> List<int>` in the `math` module — Ruby `Integer#digits` parity, low-first ordering.
- Composes with `sum` for one-expression digit-sum: `sum(digits(1234)) == 10`.
- Aborts at runtime on negative `n` (`digits() n must be non-negative`) or `base < 2` (`digits() base must be >= 2`).
- Algorithm uses `%` and `/` only — no `base^k` computation, so input magnitude has no overflow risk (`digits(INT64_MAX)` returns 19 elements).

## Examples

```ry
from math import digits

digits(1234)         # [4, 3, 2, 1]
digits(255, 16)      # [15, 15]
digits(8, 2)         # [0, 0, 0, 1]
digits(0)            # [0]
sum(digits(1234))    # 10
```

## Implementation notes

- Two `@native fn digits` overloads in `share/std/math/math.ry` (one per arity). The single-declaration default-arg form silently breaks the 1-arg call site here because the math dispatch path uses `emitTableDrivenNativeCall` with a strict arity gate (`codegen_call_native.cpp:191`). New carve-out documented in `.claude/rules/stdlib-module-additions.md` (#1412 entry update).
- `emitMathDigits` (`src/codegen_call.cpp`): two-pass design — count loop (do-while so `n=0` yields count=1) then fill loop. Same scaffolding as `range()`: `emitArcAllocCollectionHeader` → `malloc(count*8)` → `storeListHeaderFields` → `setTypeMeta(ListElem, ptr, i64Ty_)`.

## Test plan

- [x] `./build/ry_tests --gtest_filter="*Digits*"` (3 abort tests pass: negative n, base=1, base=0)
- [x] `./build/ry test tests/spec/math.test.ry` (8 happy-path cases including INT64_MAX, default-base equality)
- [x] `./build/ry test -p` (all 173 spec files green)
- [x] ASan + UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p` clean
- [x] TSan: `./build-tsan/ry_tests` and `./build-tsan/ry test -p` clean

Closes #1578

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `digits()` function to the math module with two variants: `digits(n)` for base-10 conversion and `digits(n, base)` for custom bases.
  * Extracts digits in low-first order (least significant digit at index 0).
  * Includes error handling for invalid inputs (negative numbers, bases less than 2).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->