### PR TITLE
fix(jit_runner): emit @deprecated warnings to stderr (#1424)

### DIFF
--- a/.claude/skills/commands-environment-gotchas/SKILL.md
+++ b/.claude/skills/commands-environment-gotchas/SKILL.md
@@ -166,3 +166,16 @@ find src -name '*.cpp' | xargs /opt/homebrew/opt/llvm@21/bin/clang-tidy -p build
 `SDKROOT` を渡さないと LLVM clang は libc++ ヘッダ検索パスから C ヘッダ (`stddef.h`, `cmath` など) を見つけられず、`<cstddef> tried including <stddef.h> but didn't find libc++'s <stddef.h> header` で失敗する。Apple clang は PATH 経由で macOS SDK を自動解決するが、Homebrew LLVM clang は明示が必要。
 
 CI (Linux) では `/usr/local/llvm/bin/clang` が `cc` / `c++` symlink を介して PATH に入るため同じ問題は発生しない。
+
+---
+
+### Subprocess GoogleTest: rebuild the `ry` executable, not just `ry_tests`
+
+**Source**: #1424 implementation (2026-05-05)
+**Tags**: cmake, ninja, googletest, subprocess, fork, exec, test-isolation
+
+**Wrong**: After modifying `src/jit_runner.cpp`, run `cmake --build build --target ry_tests` to retest. Subprocess tests like `DeprecatedWarningsTest` keep failing as if no source change had taken effect.
+
+**Correct**: `cmake --build build` (no `--target`) — Ninja will relink both the test binary **and** the `ry` executable.
+
+**Why**: Tests under `tests/test_emit_llvm_ir.cpp`, `tests/test_help.cpp`, and `tests/test_deprecated_warnings.cpp` use a `fork()` + `execv(RY_BINARY_PATH, ...)` pattern (the `RunResult` / `runRy()` helper). They invoke the on-disk `./build/ry` binary, **not** the `runRySource()` C++ symbol linked into `ry_tests`. The `ry_tests` target depends on `ry_lib.a` (the static library), but it does **not** depend on the `ry` executable. So `--target ry_tests` skips relinking `./build/ry`, and the subprocess test forks an old binary that still has the pre-fix behavior. The failure mode is confusing because in-process tests on the same code change pass — only the subprocess tests see a stale binary. Always rebuild without `--target` (or run `--target ry_tests --target ry`) when subprocess tests are in scope.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,7 @@ add_executable(ry_tests
     tests/test_runtime_lock_stress.cpp
     tests/test_codegen_type_safety.cpp
     tests/test_emit_llvm_ir.cpp
+    tests/test_deprecated_warnings.cpp
 )
 if(APPLE)
     target_link_libraries(ry_tests PRIVATE

--- a/changelog.d/1424-deprecation-warnings.md
+++ b/changelog.d/1424-deprecation-warnings.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `@deprecated` warnings now reach stderr when running a file via `./build/ry`. Previously, the compiler collected `warning: 'X' is deprecated` messages in `CodeGen::warnings_` but no production code path called `getWarnings()`, so users saw nothing despite `docs/reference/directives.md` documenting the behavior. The flush is performed in `runRySource()` right after `compile()` succeeds, before both the `--emit-llvm-ir` early return and JIT setup, so warnings always reach stderr regardless of how compilation continues. CLI-side deduplication keeps repeated call sites of the same deprecated symbol from emitting the same warning multiple times. (#1424)

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -15,6 +15,7 @@
 #include "ry/dotenv.hpp"
 #include <csignal>
 #include <filesystem>
+#include <algorithm>
 #include <iterator>
 #include <unistd.h>
 #include <llvm/ExecutionEngine/Orc/LLJIT.h>
@@ -173,6 +174,17 @@ int runRySource(const std::string &src, const std::string &source_name,
             throw;
         }
     }();
+
+    // Must precede the emit_llvm_ir early return below to avoid swallowing warnings.
+    {
+        std::vector<std::string> seen;
+        for (const auto &w : cg.getWarnings()) {
+            if (std::find(seen.begin(), seen.end(), w) == seen.end()) {
+                seen.push_back(w);
+                errs() << w << "\n";
+            }
+        }
+    }
 
     if (emit_llvm_ir) {
         tsm.getModuleUnlocked()->print(llvm::outs(), nullptr);

--- a/tests/test_deprecated_warnings.cpp
+++ b/tests/test_deprecated_warnings.cpp
@@ -98,7 +98,10 @@ protected:
     fs::path tmpDir_;
 
     void SetUp() override {
-        tmpDir_ = fs::temp_directory_path() / "ry_deprecated_warnings_test";
+        // Place fixtures inside the build tree so the source file's ancestor
+        // chain reaches the repo's package.toml and the loader can resolve
+        // _dev_stdlib (where @deprecated is declared). /tmp has no such ancestor.
+        tmpDir_ = fs::path(RY_BINARY_PATH).parent_path() / "ry_deprecated_warnings_test";
         fs::create_directories(tmpDir_);
     }
 

--- a/tests/test_deprecated_warnings.cpp
+++ b/tests/test_deprecated_warnings.cpp
@@ -1,0 +1,167 @@
+#include <gtest/gtest.h>
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <thread>
+#include <vector>
+#include <unistd.h>
+#include <sys/wait.h>
+
+namespace fs = std::filesystem;
+
+// withStdlibDirectiveDecls() is intentionally omitted: this test exercises the
+// real CLI -> ModuleLoader -> directive.ry path, not the in-process harness.
+struct RunResult {
+    std::string out;
+    std::string err;
+    int exit_code = -1;
+};
+
+static RunResult runRy(std::vector<const char *> args) {
+    int pipeOut[2];
+    int pipeErr[2];
+    if (pipe(pipeOut) != 0)
+        return {};
+    if (pipe(pipeErr) != 0) {
+        close(pipeOut[0]);
+        close(pipeOut[1]);
+        return {};
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipeOut[0]);
+        close(pipeOut[1]);
+        close(pipeErr[0]);
+        close(pipeErr[1]);
+        return {};
+    }
+
+    if (pid == 0) {
+        close(pipeOut[0]);
+        close(pipeErr[0]);
+        dup2(pipeOut[1], STDOUT_FILENO);
+        dup2(pipeErr[1], STDERR_FILENO);
+        close(pipeOut[1]);
+        close(pipeErr[1]);
+        close(STDIN_FILENO);
+        setenv("RY_ENV", "internal", 1);
+
+        std::vector<const char *> argv{"ry"};
+        argv.insert(argv.end(), args.begin(), args.end());
+        argv.push_back(nullptr);
+
+        execv(RY_BINARY_PATH, const_cast<char *const *>(argv.data()));
+        _exit(127);
+    }
+
+    close(pipeOut[1]);
+    close(pipeErr[1]);
+
+    auto readAll = [](int fd) -> std::string {
+        std::string result;
+        std::array<char, 4096> buf{};
+        ssize_t n;
+        while ((n = read(fd, buf.data(), buf.size())) > 0)
+            result.append(buf.data(), static_cast<size_t>(n));
+        close(fd);
+        return result;
+    };
+
+    RunResult r;
+    std::thread outReader([&]() { r.out = readAll(pipeOut[0]); });
+    std::thread errReader([&]() { r.err = readAll(pipeErr[0]); });
+    outReader.join();
+    errReader.join();
+    int status = 0;
+    waitpid(pid, &status, 0);
+    r.exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    return r;
+}
+
+static size_t countOccurrences(const std::string &haystack, const std::string &needle) {
+    if (needle.empty())
+        return 0;
+    size_t count = 0;
+    size_t pos = 0;
+    while ((pos = haystack.find(needle, pos)) != std::string::npos) {
+        ++count;
+        pos += needle.size();
+    }
+    return count;
+}
+
+class DeprecatedWarningsTest : public ::testing::Test {
+protected:
+    fs::path tmpDir_;
+
+    void SetUp() override {
+        tmpDir_ = fs::temp_directory_path() / "ry_deprecated_warnings_test";
+        fs::create_directories(tmpDir_);
+    }
+
+    void TearDown() override { fs::remove_all(tmpDir_); }
+
+    fs::path writeTmp(const std::string &name, const std::string &content) {
+        auto p = tmpDir_ / name;
+        std::ofstream(p) << content;
+        return p;
+    }
+};
+
+TEST_F(DeprecatedWarningsTest, DeprecatedFunctionEmitsWarningToStderr) {
+    auto p = writeTmp("depr_once.ry",
+        "@deprecated\n"
+        "fn oldApi() -> int:\n"
+        "    return 1\n"
+        "print(oldApi())\n");
+    auto r = runRy({p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.out, "1\n");
+    EXPECT_NE(r.err.find("warning: 'oldApi' is deprecated"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(DeprecatedWarningsTest, DeprecatedFunctionWarningDeduplicated) {
+    auto p = writeTmp("depr_many.ry",
+        "@deprecated\n"
+        "fn oldApi() -> int:\n"
+        "    return 1\n"
+        "print(oldApi())\n"
+        "print(oldApi())\n"
+        "print(oldApi())\n"
+        "print(oldApi())\n"
+        "print(oldApi())\n");
+    auto r = runRy({p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.out, "1\n1\n1\n1\n1\n");
+    EXPECT_EQ(countOccurrences(r.err, "warning: 'oldApi' is deprecated"), 1u)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(DeprecatedWarningsTest, NonDeprecatedFunctionNoWarning) {
+    auto p = writeTmp("no_depr.ry",
+        "fn freshApi() -> int:\n"
+        "    return 1\n"
+        "print(freshApi())\n");
+    auto r = runRy({p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_EQ(r.out, "1\n");
+    EXPECT_EQ(r.err.find("deprecated"), std::string::npos)
+        << "stderr was: " << r.err;
+}
+
+TEST_F(DeprecatedWarningsTest, EmitLlvmIrPathEmitsDeprecationWarning) {
+    auto p = writeTmp("depr_ir.ry",
+        "@deprecated\n"
+        "fn oldApi() -> int:\n"
+        "    return 1\n"
+        "print(oldApi())\n");
+    auto r = runRy({"--emit-llvm-ir", p.string().c_str()});
+    EXPECT_EQ(r.exit_code, 0);
+    EXPECT_NE(r.out.find("ModuleID"), std::string::npos);
+    EXPECT_NE(r.err.find("warning: 'oldApi' is deprecated"), std::string::npos)
+        << "stderr was: " << r.err;
+}


### PR DESCRIPTION
## Summary

- `@deprecated` warnings now reach stderr when running a file via `./build/ry`. Previously, `CodeGen::warnings_` collected the messages but no production code path ever called `getWarnings()`, so users saw nothing despite `docs/reference/directives.md` promising the behavior.
- Flush is added in `runRySource()` right after `compile()` succeeds and **before** the `--emit-llvm-ir` early return and JIT setup, so warnings reach stderr regardless of how compilation continues (`build` / `run` / `test` / `-c stdin` / `--emit-llvm-ir`).
- CLI-side dedup with a small `std::vector<std::string>` collapses repeated call sites of the same deprecated symbol so a single deprecation only spams once per program.

Closes #1424.

## Test plan

- [x] New `tests/test_deprecated_warnings.cpp` (GoogleTest, subprocess via `fork`/`execv`) covering 4 paths:
  - single `@deprecated` call → warning on stderr, stdout unchanged, exit 0
  - 5 repeated calls → exactly **one** warning line (dedup)
  - no `@deprecated` → no `"deprecated"` in stderr (false-positive guard)
  - `--emit-llvm-ir` path → warning still flushed before IR dump
- [x] `./build/ry_tests` — 2124 tests pass (4 new)
- [x] `./build/ry test -p` — 173 spec files pass
- [x] ASan + UBSan — `./build-asan/ry_tests` (2124) and `./build-asan/ry test -p` (173) pass
- [x] TSan — `./build-tsan/ry_tests` (2124) and `./build-tsan/ry test -p` (173) pass, no race introduced
- [x] clang-tidy & cppcheck on `src/jit_runner.cpp` — no new warnings

## Self-verification skips (per `/pre-commit-checklist`)

- Skipped §3.5.5 scan-build — change is `std::vector` linear-scan dedup, no null-deref / UAF / div-by-zero risk.
- Skipped §3.6 libFuzzer — no parser / lexer / json / utf8 / string change.

## Follow-up out of scope

- After this PR merges, `./build/ry test -p` will surface two pre-existing warnings (`describe()` / `it()` lambda syntax is deprecated) emitted by `src/codegen_test.cpp` for **171** `.test.ry` files using lambda-form `describe()` / `it()`. The warnings are not new — they were silently dropped before this PR. Migration tracked in #1599.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Deprecation warnings now print to stderr and are consistently shown across compilation paths, including LLVM IR emission.
  * Warnings are deduplicated to avoid repeated messages for the same deprecated symbol.

* **Tests**
  * Added tests that validate deprecation warnings, deduplication, absence for non-deprecated functions, and LLVM IR emission behavior.

* **Chores**
  * Test runner updated to include the new deprecation-warnings test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->