### PR TITLE
fix(codegen): f64 suffix and local record casts in named-fn bodies (#1601)

### DIFF
--- a/changelog.d/1601-f64-suffix-and-local-record-cast.md
+++ b/changelog.d/1601-f64-suffix-and-local-record-cast.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- `f64` literal suffix now resolves correctly inside any named-function
+  body. Previously, `x = 3.14f64` or `1.5_0f64` inside a `fn`/`@it`/`@describe`
+  body (including module-level `fn`) raised `unknown type: f64`, even
+  though the same code worked at module top level and inside lambda
+  bodies. The root cause was a missing `f64` entry in `resolveType`'s
+  primitive type table; the `FloatExpr` lambda return-type inference
+  pre-pass then fell through to the `unknown type` error before any
+  body statement could emit. (#1601)
+- Locally-declared `record` types are now resolvable as `as`-cast
+  targets inside named-function bodies. Previously, declaring a
+  `record` inside a `fn` body and then using `value as <RecordName>`
+  raised `unknown type: <RecordName>` because the lambda return-type
+  inference pre-pass ran before the body emit loop registered the
+  record into `record_types_`. The pre-pass now uses a permissive
+  type lookup with a safe fallback; the strict fatal lookup at body
+  emit time is unchanged, so genuinely unknown cast targets are still
+  diagnosed. (#1601)
+- Migrated the three deferred test files from #1599
+  (`numeric_literal_suffix.test.ry`, `numeric_underscore_separator.test.ry`,
+  `operator_overload.test.ry`) from the deprecated lambda form
+  `describe("...", ():` / `it("...", ():` to the canonical
+  `@describe("...")` / `@it("...")` named-function form. (#1601)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -68,7 +68,7 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
     for (const char *name : {
              "int", "float", "bool", "str", "any", "Unit",
              "i8", "i16", "i32", "i64",
-             "u8", "u16", "u32", "u64", "f32",
+             "u8", "u16", "u32", "u64", "f32", "f64",
              "List", "Map", "Set",
              "Option", "Result",
              "None", "fn", "Type"}) {

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -734,7 +734,10 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
         } else if constexpr (std::is_same_v<T, std::unique_ptr<RangeExpr>>) {
             return ptrTy_;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CastExpr>>) {
-            return resolveType(v->target_type->toString());
+            // Pre-pass runs before RecordStmt registration; fall back rather than fatal.
+            if (auto *ty = tryResolveType(v->target_type->toString()))
+                return ty;
+            return i64Ty_;
         } else if constexpr (std::is_same_v<T, NoneExpr>) {
             // NoneExpr (bare `none`) is an Option literal with placeholder inner.
             // Use i8Ty_ so preferConcrete() will prefer the sibling arm's inner type.

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -39,6 +39,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
     if (typeName == "u32")   return i32Ty_;
     if (typeName == "u64")   return i64Ty_;
     if (typeName == "f32")   return f32Ty_;
+    if (typeName == "f64")   return f64Ty_;
 
     // Weak reference type: "weak str", "weak List<int>"
     if (isWeakTypeName(typeName)) {

--- a/tests/spec/numeric_literal_suffix.test.ry
+++ b/tests/spec/numeric_literal_suffix.test.ry
@@ -1,113 +1,115 @@
-describe("integer literal suffix", ():
-  it("should support i32 suffix", ():
+from testing import it, describe
+
+@describe("integer literal suffix")
+fn integerLiteralSuffixTests():
+  @it("should support i32 suffix")
+  fn shouldSupportI32Suffix():
     x = 42i32
     expect(x as int).toEq(42)
-  )
-  it("should support i16 suffix", ():
+  @it("should support i16 suffix")
+  fn shouldSupportI16Suffix():
     x = 100i16
     expect(x as int).toEq(100)
-  )
-  it("should support i8 suffix", ():
+  @it("should support i8 suffix")
+  fn shouldSupportI8Suffix():
     x = 127i8
     expect(x as int).toEq(127)
-  )
-  it("should support i64 suffix", ():
+  @it("should support i64 suffix")
+  fn shouldSupportI64Suffix():
     x = 1000i64
     expect(x).toEq(1000)
-  )
-  it("should support u8 suffix", ():
+  @it("should support u8 suffix")
+  fn shouldSupportU8Suffix():
     x = 255u8
     expect(x as int).toEq(255)
-  )
-  it("should support u16 suffix", ():
+  @it("should support u16 suffix")
+  fn shouldSupportU16Suffix():
     x = 1000u16
     expect(x as int).toEq(1000)
-  )
-  it("should support u32 suffix", ():
+  @it("should support u32 suffix")
+  fn shouldSupportU32Suffix():
     x = 100u32
     expect(x as int).toEq(100)
-  )
-  it("should support u64 suffix", ():
+  @it("should support u64 suffix")
+  fn shouldSupportU64Suffix():
     x = 100u64
     expect(x as int).toEq(100)
-  )
-  it("should parse zero with suffix", ():
+  @it("should parse zero with suffix")
+  fn shouldParseZeroWithSuffix():
     x = 0i32
     expect(x as int).toEq(0)
-  )
-)
 
-describe("float literal suffix", ():
-  it("should support f32 suffix on float", ():
+@describe("float literal suffix")
+fn floatLiteralSuffixTests():
+  @it("should support f32 suffix on float")
+  fn shouldSupportF32SuffixOnFloat():
     x = 3.14f32
     expect(x as float > 3.0).toEq(true)
-  )
-  it("should support f64 suffix on float", ():
+  @it("should support f64 suffix on float")
+  fn shouldSupportF64SuffixOnFloat():
     x = 3.14f64
     expect(x > 3.0).toEq(true)
-  )
-  it("should make integer with f32 suffix become float", ():
+  @it("should make integer with f32 suffix become float")
+  fn shouldMakeIntegerWithF32SuffixBecomeFloat():
     x = 42f32
     expect(x as float > 41.0).toEq(true)
-  )
-)
 
-describe("hex and binary with suffix", ():
-  it("should support hex with u8 suffix", ():
+@describe("hex and binary with suffix")
+fn hexAndBinaryWithSuffixTests():
+  @it("should support hex with u8 suffix")
+  fn shouldSupportHexWithU8Suffix():
     x = 0xFFu8
     expect(x as int).toEq(255)
-  )
-  it("should support hex with i32 suffix", ():
+  @it("should support hex with i32 suffix")
+  fn shouldSupportHexWithI32Suffix():
     x = 0x1Fi32
     expect(x as int).toEq(31)
-  )
-  it("should support binary with u8 suffix", ():
+  @it("should support binary with u8 suffix")
+  fn shouldSupportBinaryWithU8Suffix():
     x = 0b1010u8
     expect(x as int).toEq(10)
-  )
-)
 
-describe("negative suffixed literals", ():
-  it("should support negative i32", ():
+@describe("negative suffixed literals")
+fn negativeSuffixedLiteralsTests():
+  @it("should support negative i32")
+  fn shouldSupportNegativeI32():
     x = -1i32
     expect(x as int).toEq(-1)
-  )
-  it("should support negative i8", ():
+  @it("should support negative i8")
+  fn shouldSupportNegativeI8():
     x = -128i8
     expect(x as int).toEq(-128)
-  )
-  it("should support negative i16", ():
+  @it("should support negative i16")
+  fn shouldSupportNegativeI16():
     x = -100i16
     expect(x as int).toEq(-100)
-  )
-)
 
-describe("suffixed literal arithmetic", ():
-  it("should add i32", ():
+@describe("suffixed literal arithmetic")
+fn suffixedLiteralArithmeticTests():
+  @it("should add i32")
+  fn shouldAddI32():
     c = 10i32 + 20i32
     expect(c as int).toEq(30)
-  )
-  it("should add u8", ():
+  @it("should add u8")
+  fn shouldAddU8():
     c = 100u8 + 50u8
     expect(c as int).toEq(150)
-  )
-  it("should add f32", ():
+  @it("should add f32")
+  fn shouldAddF32():
     c = 1.5f32 + 2.5f32
     expect(c as float > 3.9).toEq(true)
-  )
-)
 
-describe("suffixed literal with annotation", ():
-  it("should support matching annotation i32", ():
+@describe("suffixed literal with annotation")
+fn suffixedLiteralWithAnnotationTests():
+  @it("should support matching annotation i32")
+  fn shouldSupportMatchingAnnotationI32():
     x: i32 = 42i32
     expect(x as int).toEq(42)
-  )
-  it("should support matching annotation u8", ():
+  @it("should support matching annotation u8")
+  fn shouldSupportMatchingAnnotationU8():
     x: u8 = 200u8
     expect(x as int).toEq(200)
-  )
-  it("should support matching annotation f32", ():
+  @it("should support matching annotation f32")
+  fn shouldSupportMatchingAnnotationF32():
     x: f32 = 1.5f32
     expect(x as float > 1.0).toEq(true)
-  )
-)

--- a/tests/spec/numeric_underscore_separator.test.ry
+++ b/tests/spec/numeric_underscore_separator.test.ry
@@ -1,28 +1,30 @@
-describe("numeric underscore separators", ():
-  it("should parse decimal integer with underscores", ():
+from testing import it, describe
+
+@describe("numeric underscore separators")
+fn numericUnderscoreSeparatorsTests():
+  @it("should parse decimal integer with underscores")
+  fn shouldParseDecimalIntegerWithUnderscores():
     expect(100_000).toEq(100000)
     expect(1_000_000).toEq(1000000)
-  )
-  it("should parse hex with underscores", ():
+  @it("should parse hex with underscores")
+  fn shouldParseHexWithUnderscores():
     expect(0xFF_FF).toEq(0xFFFF)
-  )
-  it("should parse binary with underscores", ():
+  @it("should parse binary with underscores")
+  fn shouldParseBinaryWithUnderscores():
     expect(0b1010_0101).toEq(0b10100101)
-  )
-  it("should parse float with underscores", ():
+  @it("should parse float with underscores")
+  fn shouldParseFloatWithUnderscores():
     expect(3.14_159).toEq(3.14159)
-  )
-  it("should parse leading dot float with underscores", ():
+  @it("should parse leading dot float with underscores")
+  fn shouldParseLeadingDotFloatWithUnderscores():
     expect(.5_0).toEq(0.50)
-  )
-  it("should parse with suffix", ():
+  @it("should parse with suffix")
+  fn shouldParseWithSuffix():
     x: i32 = 100_000i32
     expect(x as int).toEq(100000)
     y = 1.5_0f64
     expect(y as float).toEq(1.50)
-  )
-  it("should compute arithmetic with underscored literals", ():
+  @it("should compute arithmetic with underscored literals")
+  fn shouldComputeArithmeticWithUnderscoredLiterals():
     expect(1_000 + 2_000).toEq(3000)
     expect(1_000_000 / 1_000).toEq(1000)
-  )
-)

--- a/tests/spec/operator_overload.test.ry
+++ b/tests/spec/operator_overload.test.ry
@@ -1,5 +1,9 @@
-describe("operator[]", ():
-  it("should read with single index", ():
+from testing import it, describe
+
+@describe("operator[]")
+fn operatorIndexTests():
+  @it("should read with single index")
+  fn shouldReadWithSingleIndex():
     record Point:
       x: int
       y: int
@@ -14,9 +18,9 @@ describe("operator[]", ():
     expect(p[0]).toEq(10)
     expect(p[1]).toEq(20)
     expect(p[2]).toEq(30)
-  )
 
-  it("should read with multi-index", ():
+  @it("should read with multi-index")
+  fn shouldReadWithMultiIndex():
     record Grid:
       a: int
       b: int
@@ -35,9 +39,9 @@ describe("operator[]", ():
     expect(g[0, 1]).toEq(2)
     expect(g[1, 0]).toEq(3)
     expect(g[1, 1]).toEq(4)
-  )
 
-  it("should dispatch write to operator[]=", ():
+  @it("should dispatch write to operator[]=")
+  fn shouldDispatchWriteToOperatorIndexAssign():
     record Sink:
       lastKey: int
       lastVal: int
@@ -46,11 +50,11 @@ describe("operator[]", ():
       s.lastVal = value
     s = Sink(0, 0)
     s[5] = 42
-  )
-)
 
-describe("operator[] returning collection", ():
-  it("should preserve type info and support chaining for subscript returning List<int>", ():
+@describe("operator[] returning collection")
+fn operatorIndexReturningCollectionTests():
+  @it("should preserve type info and support chaining for subscript returning List<int>")
+  fn shouldPreserveTypeInfoAndSupportChainingForSubscriptReturningListInt():
     record Matrix:
       rows: List<List<int>>
     fn operator[](m: Matrix, i: int) -> List<int>:
@@ -64,11 +68,11 @@ describe("operator[] returning collection", ():
     expect(m[0][2]).toEq(30)
     expect(m[1][0]).toEq(40)
     expect(m[1][2]).toEq(60)
-  )
-)
 
-describe("operator in", ():
-  it("should support custom in", ():
+@describe("operator in")
+fn operatorInTests():
+  @it("should support custom in")
+  fn shouldSupportCustomIn():
     record Range:
       lo: int
       hi: int
@@ -78,9 +82,9 @@ describe("operator in", ():
     expect(5 in r).toBeTrue()
     expect(0 in r).toBeFalse()
     expect(10 in r).toBeFalse()
-  )
 
-  it("should support not in", ():
+  @it("should support not in")
+  fn shouldSupportNotIn():
     record Span:
       lo: int
       hi: int
@@ -89,40 +93,40 @@ describe("operator in", ():
     s = Span(1, 10)
     expect(15 not in s).toBeTrue()
     expect(5 not in s).toBeFalse()
-  )
 
-  it("should still work with built-in in", ():
+  @it("should still work with built-in in")
+  fn shouldStillWorkWithBuiltinIn():
     xs = [1, 2, 3]
     expect(2 in xs).toBeTrue()
     expect(5 in xs).toBeFalse()
     m = {"a": 1, "b": 2}
     expect("a" in m).toBeTrue()
     expect("c" in m).toBeFalse()
-  )
-)
 
-describe("operator()", ():
-  it("should support callable record", ():
+@describe("operator()")
+fn operatorCallTests():
+  @it("should support callable record")
+  fn shouldSupportCallableRecord():
     record Adder:
       base: int
     fn operator()(a: Adder, x: int) -> int:
       return a.base + x
     add5 = Adder(5)
     expect(add5(10)).toEq(15)
-  )
 
-  it("should support multi-arg callable", ():
+  @it("should support multi-arg callable")
+  fn shouldSupportMultiArgCallable():
     record Calc:
       base: int
     fn operator()(c: Calc, x: int, y: int) -> int:
       return c.base + x * y
     calc = Calc(10)
     expect(calc(3, 4)).toEq(22)
-  )
-)
 
-describe("operator as", ():
-  it("should support custom cast", ():
+@describe("operator as")
+fn operatorAsTests():
+  @it("should support custom cast")
+  fn shouldSupportCustomCast():
     record Celsius:
       value: int
     record Fahrenheit:
@@ -132,9 +136,9 @@ describe("operator as", ():
     c = Celsius(100)
     f = c as Fahrenheit
     expect(f.value).toEq(212)
-  )
 
-  it("should support cast to generic Option type", ():
+  @it("should support cast to generic Option type")
+  fn shouldSupportCastToGenericOptionType():
     record Temperature:
       value: int
     fn operator as(t: Temperature) -> int?:
@@ -142,9 +146,9 @@ describe("operator as", ():
     t = Temperature(42)
     result: int? = t as int?
     expect(result ?? -1).toEq(42)
-  )
 
-  it("should preserve type info for cast returning collection", ():
+  @it("should preserve type info for cast returning collection")
+  fn shouldPreserveTypeInfoForCastReturningCollection():
     record Row:
       items: List<int>
     fn operator as(r: Row) -> List<int>:
@@ -153,11 +157,9 @@ describe("operator as", ():
     xs = r as List<int>
     expect(xs[0]).toEq(10)
     expect(xs[2]).toEq(30)
-  )
 
-  it("should still work with built-in cast", ():
+  @it("should still work with built-in cast")
+  fn shouldStillWorkWithBuiltinCast():
     x: float = 42 as float
     expect(x + 0.5).toEq(42.5)
     expect(3.14 as int).toEq(3)
-  )
-)


### PR DESCRIPTION
## Summary

Fixes #1601 — two related codegen bugs surfaced during the #1599 test-migration sweep where the named-`fn` return-type pre-pass diverged from the lambda path:

- **Bug A — `f64` literal suffix**: `x = 3.14f64` (or `1.5_0f64`) inside any `fn` / `@it` / `@describe` body raised `unknown type: f64`. Root cause: `resolveType`'s primitive table was missing an `f64` entry (`f32` was wired but `f64` was not). The `FloatExpr` lambda return-type inference pre-pass then fell through to the `unknown type` error before any body statement could emit. Fixed by adding the `f64` row alongside `f32`. Also added `f64` to `canonical_type_ids_` so `typeOf(1.0f64)` returns a stable ID.
- **Bug B — local-record cast targets**: declaring a `record` inside a `fn` body and then using `value as <RecordName>` raised `unknown type: <RecordName>` because the `inferExprType` pre-pass ran before the body emit loop registered the record into `record_types_`. Switched the `CastExpr` arm in the pre-pass from fatal `resolveType` to permissive `tryResolveType` (with `i64Ty_` fallback). The strict `resolveType` at body emit time is unchanged, so genuinely unknown cast targets are still diagnosed.
- **Test migration**: the three deferred files from #1599 (`numeric_literal_suffix.test.ry`, `numeric_underscore_separator.test.ry`, `operator_overload.test.ry`) are migrated from the deprecated lambda form `describe(..., ():` / `it(..., ():` to the canonical `@describe` / `@it` named-fn form. Local `record` declarations in `operator_overload.test.ry` are intentionally kept inside named-fn bodies — moving them out would erase Bug B's regression coverage.

## Test plan

- [x] `cmake --build build` succeeds
- [x] `./build/ry_tests` passes (2124 / 2124)
- [x] `./build/ry test -p` passes (173 files, 0 failures, 0 deprecation warnings)
- [x] `./build/ry test tests/spec/numeric_literal_suffix.test.ry` — 24 passed
- [x] `./build/ry test tests/spec/numeric_underscore_separator.test.ry` — 7 passed
- [x] `./build/ry test tests/spec/operator_overload.test.ry` — 13 passed
- [x] ASan + UBSan build clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * f64 literal suffix now resolves inside named-function bodies
  * Locally-declared record types can be used as cast targets inside named-function bodies

* **Tests**
  * Expanded test coverage for numeric literals with suffixes, underscore separators, and operator overloads
  * Test suite modernized with updated syntax

<!-- end of auto-generated comment: release notes by coderabbit.ai -->