### PR TITLE
refactor(parser,codegen): remove deprecated lambda describe/it form (#1602)

### DIFF
--- a/.claude/rules/tests-spec-conventions.md
+++ b/.claude/rules/tests-spec-conventions.md
@@ -68,11 +68,14 @@ expect(e.message).toNotContain("NUL")
 **Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: testing, case, parser, unit, if
 
 **Rule**: Two patterns in case arm bodies trigger parser errors that manifest as a confusing
-"unexpected token ')'" at the nearest enclosing `describe(..., ():` or `it(..., ():` line:
+"unexpected token ')'" pointing at the nearest enclosing call expression with parenthesized
+arguments — historically the most common one was the now-removed `describe(..., ():` /
+`it(..., ():` lambda form (#1602), but the same parser confusion can still surface on any
+function-call boundary inside a `fn` body:
 
 **Pattern 1: `()` as a case arm body**
 ```ry
-# Fails — parser sees ')' and thinks it closes the outer describe/it closure:
+# Fails — parser sees ')' as closing the surrounding call expression:
 case isDir(d):
   Ok(v): removeAll(d)
   Err(_): ()         # <-- breaks parser

--- a/.claude/skills/test-checklist/SKILL.md
+++ b/.claude/skills/test-checklist/SKILL.md
@@ -131,9 +131,9 @@ Output using the **Report Template** section below, with concrete proposed code 
 
 **Required shape (P5 direct-literal):**
 ```ry
-it("should handle INT64_MIN literal directly", ():
+@it("should handle INT64_MIN literal directly")
+fn shouldHandleInt64MinLiteralDirectly():
   expect(-9223372036854775808).toEq(-9223372036854775808)
-)
 ```
 
 **Forbidden shape (P5 workaround — `tests/spec/int_overflow.test.ry:29` is a live instance):**
@@ -154,21 +154,21 @@ min = -9223372036854775807 - 1   -- DO NOT use arithmetic to express boundary li
 
 **Required shape (P3 NUL byte):**
 ```ry
-it("should preserve embedded NUL bytes", ():
+@it("should preserve embedded NUL bytes")
+fn shouldPreserveEmbeddedNulBytes():
   s = "a\0b"
   expect(s.byteLen()).toEq(3)
-)
 ```
 
 **Required shape (P6 error message — both arms, message text verified):**
 ```ry
-it("should report correct error for str indexing", ():
+@it("should report correct error for str indexing")
+fn shouldReportCorrectErrorForStrIndexing():
   case strIndex("hello", 0):
     Ok(v):
       fail("expected Err but got Ok")
     Err(e):
       expect(e.message).toEq("str does not support index access; use charAt(s, i) instead")
-)
 ```
 
 ---
@@ -187,20 +187,20 @@ it("should report correct error for str indexing", ():
 
 **Required shape (P2 mutation-in-iteration):**
 ```ry
-it("should handle append! inside for loop", ():
+@it("should handle append! inside for loop")
+fn shouldHandleAppendInsideForLoop():
   xs = [1, 2, 3]
   for x in [4, 5]:
     xs.append!(x)
   expect(xs).toEq([1, 2, 3, 4, 5])
-)
 ```
 
 **Required shape (P1 fully-untyped lambda with reduce):**
 ```ry
-it("should reduce with fully-untyped lambda", ():
+@it("should reduce with fully-untyped lambda")
+fn shouldReduceWithFullyUntypedLambda():
   result = reduce([1, 2, 3], (a, b) => a + b)
   expect(result).toEq(6)
-)
 ```
 
 ---
@@ -219,14 +219,14 @@ it("should reduce with fully-untyped lambda", ():
 
 **Required shape (P1 untyped lambda returning Result):**
 ```ry
-it("should infer Result type without annotation", ():
+@it("should infer Result type without annotation")
+fn shouldInferResultTypeWithoutAnnotation():
   f = (s) => tryParse(s)   -- no type annotation on f
   case f("42"):
     Ok(v):
       expect(v).toEq(42)
     Err(e):
       fail("unexpected error")
-)
 ```
 
 ---
@@ -263,13 +263,13 @@ expectCompileError(R"(
 
 **Required shape (P6 runtime — both arms required):**
 ```ry
-it("should give helpful error for invalid str operation", ():
+@it("should give helpful error for invalid str operation")
+fn shouldGiveHelpfulErrorForInvalidStrOperation():
   case badStrOp("hello"):
     Ok(v):
       fail("expected Err but got Ok")
     Err(e):
       expect(e.message).toEq("str does not support index access; use charAt(s, i) instead")
-)
 ```
 
 **P7 (compile-time text):** see Parser/Literals section above for the canonical shape; the rule (`expectCompileError` must take a 2nd-argument message) applies to all `expectCompileError` calls regardless of category.
@@ -290,13 +290,13 @@ it("should give helpful error for invalid str operation", ():
 ```ry
 from runtime_internal import arcLiveCount
 
-it("should not leak ARC objects in loop", ():
+@it("should not leak ARC objects in loop")
+fn shouldNotLeakArcObjectsInLoop():
   before = arcLiveCount()
   for _ in range(0, 100):
     s = "hello"
   delta = arcLiveCount() - before
   expect(delta).toEq(0)
-)
 ```
 
 **Forbidden shape (absolute count — unreliable across test runs):**

--- a/changelog.d/1602-remove-lambda-describe-it.md
+++ b/changelog.d/1602-remove-lambda-describe-it.md
@@ -1,0 +1,14 @@
+### Removed
+
+- Removed the deprecated lambda call form of `describe("...", ():)` and
+  `it("...", ():)` from the parser and codegen. After #1599 (stdlib
+  migration) and #1601 (deferred-file migration), all `tests/spec/*.test.ry`
+  files use the canonical `@describe("...") fn name():` / `@it("...") fn name():`
+  named-function form, so the lambda form is no longer reachable from
+  any in-tree source. The trailing-block carve-out for `describe` / `it`
+  in the parser and the dedicated lambda-form codegen helpers
+  (`extractLambdaArg`, `emitDescribeCall`, `emitItCall`, the lambda
+  branches of `emitEachItCall` / `emitPropertyItCall`) were deleted
+  along with the `warned_call_deprecations_` warning-dedup state.
+  Source that still uses the lambda form now fails compilation with
+  `undefined function: describe` / `undefined function: it`. (#1602)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -22,7 +22,6 @@ Directives can be applied to the following declarations:
 - Variable declarations (with or without `@const`)
 - Fields within a `record` definition
 - `for` - Counted loops; among built-ins, only `@parallel` targets `for`. User-defined directives declaring `target=["for"]` may also be applied to `for` statements; directives with a different target are silently ignored per the target-mismatch rule.
-- `it` / `describe` calls (legacy lambda form) - Test cases and test groups for `@each` and `@property`
 - `@directive` declarations themselves (so a directive declaration can be marked `@public` for cross-package import)
 
 ## Built-in Directives
@@ -303,7 +302,7 @@ Enables parameterized testing by running a test multiple times with different pa
 
 **Defined as:** Declared in `share/std/testing/testing.ry`. Test files must add `from testing import each` (or include it in the existing `from testing import` line) at the top.
 
-**Syntax (on a named function, preferred):**
+**Syntax:**
 
 ```ry
 @each([(arg1, arg2, ...), ...])
@@ -311,17 +310,6 @@ Enables parameterized testing by running a test multiple times with different pa
 fn testHandle(param1: type, param2: type):
     # test body
 ```
-
-**Syntax (on a legacy `it` lambda):**
-
-```ry
-@each([(arg1, arg2, ...), ...])
-it("should handle {0} and {1}", (param1: type, param2: type):
-    # test body
-)
-```
-
-> **Note**: The legacy lambda form is deprecated. Prefer the named function form with `@it`. See [Testing Reference](testing.md) for details.
 
 The argument can be any expression that evaluates to a list of tuples, including a function call:
 
@@ -332,7 +320,7 @@ fn testHandle(x: int):
     # test body
 ```
 
-**Supported targets:** functions with the `@it` directive, or legacy `it` calls.
+**Supported targets:** functions with the `@it` directive.
 
 **Constraints:**
 - The argument must evaluate to a list of tuples
@@ -345,7 +333,7 @@ Enables property-based testing by generating random inputs for a test.
 
 **Defined as:** Declared in `share/std/testing/testing.ry`. Test files must add `from testing import property` (or include it in the existing `from testing import` line) at the top.
 
-**Syntax (on a named function, preferred):**
+**Syntax:**
 
 ```ry
 @property(count=100)
@@ -354,18 +342,7 @@ fn testProperty(a: int, b: int):
     # test body with random values
 ```
 
-**Syntax (on a legacy `it` lambda):**
-
-```ry
-@property(count=100)
-it("should verify property name", (a: int, b: int):
-    # test body with random values
-)
-```
-
-> **Note**: The legacy lambda form is deprecated. Prefer the named function form with `@it`. See [Testing Reference](testing.md) for details.
-
-**Supported targets:** functions with the `@it` directive, or legacy `it` calls.
+**Supported targets:** functions with the `@it` directive.
 
 **Parameters:**
 
@@ -430,7 +407,7 @@ fn testCommutative(a: int, b: int):
 
 ### `@describe`
 
-Groups a set of related tests by attaching the directive to a named function. Inner `@it` functions declared in the body belong to the group, and variables declared directly in the body act as shared setup captured by every inner `@it`. Unlike the legacy lambda form, `@describe` groups **may be nested**; output is indented proportionally to nesting depth.
+Groups a set of related tests by attaching the directive to a named function. Inner `@it` functions declared in the body belong to the group, and variables declared directly in the body act as shared setup captured by every inner `@it`. `@describe` groups **may be nested**; output is indented proportionally to nesting depth.
 
 **Defined as:** Declared in `share/std/testing/testing.ry`. Test files must add `from testing import it, describe` at the top.
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -34,7 +34,7 @@ When `ry test` is run without arguments, it:
 
 ## Syntax
 
-### Function-Based Syntax (recommended)
+### Syntax
 
 Use the `@it` and `@describe` directives to define test cases as ordinary named functions. Both directives are exported from the `testing` module and must be imported at the top of every test file:
 
@@ -109,34 +109,9 @@ API
     + should return 200 OK
 ```
 
-### Lambda Syntax (deprecated)
-
-> **Deprecated**: The `describe()` and `it()` lambda call syntax is deprecated. Use `@describe` and `@it` directives on named functions instead. The lambda syntax will be removed in a future release.
->
-> Migration:
->
-> | Lambda syntax | Directive syntax |
-> |---|---|
-> | `it("name", (): ...)` | `@it("name") fn name(): ...` |
-> | `describe("name", (): ...)` | `@describe("name") fn name(): ...` |
-
-```
-describe("description", ():
-    it("test case name", ():
-        # test body
-        expect(actualValue).toEq(expectedValue)
-    )
-)
-```
-
-- `describe` and `it` take a description string and a **lambda argument** `():` as the second parameter
-- `it` blocks and other statements (e.g., variable declarations) can be written inside a `describe` block
-- Each `it` block is an independent test case
-- `describe` / `expect` are only available with `ry test` (compile error with normal `ry` execution)
-
 ### Trailing Block Syntax
 
-Any function call (except `describe`/`it`/`mock`) can use trailing block syntax. A colon after `()` causes the indented block to be passed as a no-argument lambda in the last argument position:
+Any function call (except `mock`) can use trailing block syntax. A colon after `()` causes the indented block to be passed as a no-argument lambda in the last argument position:
 
 ```
 # These are equivalent:
@@ -288,7 +263,7 @@ fn verifyTests():
 
 `@each` runs the same test with multiple sets of parameters.
 
-**Function-based syntax (recommended):**
+**Syntax:**
 
 ```ry
 @each([
@@ -299,19 +274,6 @@ fn verifyTests():
 @it("should add {0} + {1} = {2}")
 fn testAdd(a: int, b: int, expected: int):
     expect(a + b).toEq(expected)
-```
-
-**Lambda syntax (deprecated):**
-
-```ry
-@each([
-    (1, 2, 3),
-    (0, 0, 0),
-    (-1, 1, 0)
-])
-it("should add {0} + {1} = {2}", (a: int, b: int, expected: int):
-    expect(a + b).toEq(expected)
-)
 ```
 
 - The list must contain tuples whose arity matches the parameter count
@@ -325,22 +287,11 @@ it("should add {0} + {1} = {2}", (a: int, b: int, expected: int):
 
 `@property` generates random inputs and runs the test multiple times.
 
-**Function-based syntax (recommended):**
-
 ```ry
 @property(count=100)
 @it("should verify addition is commutative")
 fn testCommutative(a: int, b: int):
     expect(a + b).toEq(b + a)
-```
-
-**Lambda syntax (deprecated):**
-
-```ry
-@property(count=100)
-it("should verify addition is commutative", (a: int, b: int):
-    expect(a + b).toEq(b + a)
-)
 ```
 
 - `count=N` specifies the number of random trials (default: 100). `count` must be a positive integer; zero or negative values are rejected at compile time.
@@ -435,7 +386,6 @@ it should return error when file is missing
 
 ## Limitations
 
-- Nesting of `describe` (lambda syntax) is not supported; use the function-based `@describe` directive syntax for nested grouping
 - `before_each` / `after_each` are not supported
 
 ---

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -836,7 +836,6 @@ public:
     std::unordered_set<std::string> deprecated_variables_;
     std::unordered_set<std::string> deprecated_fields_;  // "TypeName.fieldName"
     std::vector<std::string> warnings_;
-    std::unordered_set<std::string> warned_call_deprecations_;
 
     void emitDeprecationWarning(const std::string &name);
 
@@ -1180,10 +1179,6 @@ public:
     std::string resolveSubjectSourceTypeName(const std::string &subjectEnumName, llvm::Type *subjectTy);
     std::string filterToEnumOnly(const std::string &typeSig);
     void markFieldAllocaArcManaged(llvm::AllocaInst *tmp, llvm::Type *ty, const std::string &typeSig);
-    void emitDescribeCall(CallStmt &s);
-    void emitItCall(CallStmt &s);
-    void emitEachItCall(CallStmt &s);
-    void emitPropertyItCall(CallStmt &s);
     llvm::SmallVector<llvm::Value*, 4> loadCapturedArgs(const OverloadEntry &entry, const std::string &directive);
     void emitItDirective(std::unique_ptr<FnStmt> &s);
     void emitEachItDirective(std::unique_ptr<FnStmt> &s);

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -428,14 +428,6 @@ void CodeGen::emitStmt(CallStmt &s) {
     validateDirectives(s.directives, DirectiveTarget::Statement);
     if (!s.named_args.empty() && builtins_.find(s.callee) == builtins_.end())
         codegenError(s.loc, "named arguments are only supported for builtin functions");
-    if (s.callee == "describe") {
-        emitDescribeCall(s);
-        return;
-    }
-    if (s.callee == "it") {
-        emitItCall(s);
-        return;
-    }
     if (s.callee == "mock") {
         emitMockCall(s);
         return;

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -39,53 +39,6 @@ llvm::SmallVector<llvm::Value*, 4> CodeGen::loadCapturedArgs(const OverloadEntry
     return args;
 }
 
-// ===== Test: describe/it (lambda argument) =====
-
-static LambdaExpr &extractLambdaArg(CallStmt &s, const std::string &callee) {
-    if (s.args.size() != 2)
-        throw std::runtime_error(callee + "() requires exactly one description string and a lambda argument");
-    auto *lambda = std::get_if<std::unique_ptr<LambdaExpr>>(&s.args.back()->data);
-    if (!lambda)
-        throw std::runtime_error(callee + "() last argument must be a lambda argument");
-    return **lambda;
-}
-
-void CodeGen::emitDescribeCall(CallStmt &s) {
-    if (!test_mode_)
-        codegenError("'describe' is only allowed in test mode (use 'ry test')");
-
-    if (warned_call_deprecations_.insert("describe").second)
-        warnings_.push_back("warning: describe() lambda syntax is deprecated; use @describe(\"...\") on a named function instead");
-
-    auto &lambda = extractLambdaArg(s, "describe");
-
-    llvm::Value *descName = emitExpr(*s.args[0]);
-    if (!descName->getType()->isPointerTy())
-        codegenError("describe() first argument must be a string");
-
-    if (outline_mode_) {
-        emitOutlinePrintf("describe %s\n", descName);
-        ++outline_depth_;
-        for (auto &stmt : lambda.body) {
-            if (auto *cs = std::get_if<CallStmt>(&stmt)) {
-                if (cs->callee == "describe" || cs->callee == "it")
-                    emitStmt(*cs);
-            }
-        }
-        --outline_depth_;
-        return;
-    }
-
-    auto [descBeginFn, descEndFn] = getTestDescribeFunctions();
-
-    builder_.CreateCall(descBeginFn, {descName});
-
-    for (auto &stmt : lambda.body)
-        std::visit([this](auto &st) { emitStmt(st); }, stmt);
-
-    builder_.CreateCall(descEndFn);
-}
-
 std::pair<llvm::FunctionCallee, llvm::FunctionCallee> CodeGen::getTestItFunctions() {
     llvm::FunctionType *voidStrTy = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
@@ -169,101 +122,6 @@ static void parseFormatPlaceholders(const std::string &fmtStr,
     }
 }
 
-void CodeGen::emitItCall(CallStmt &s) {
-    if (!test_mode_)
-        codegenError("'it' is only allowed in test mode (use 'ry test')");
-
-    if (warned_call_deprecations_.insert("it").second)
-        warnings_.push_back("warning: it() lambda syntax is deprecated; use @it(\"...\") on a named function instead");
-
-    // Check for @each / @property directives
-    if (hasDirective(s.directives, "each")) {
-        emitEachItCall(s);
-        return;
-    }
-    if (hasDirective(s.directives, "property")) {
-        emitPropertyItCall(s);
-        return;
-    }
-
-    if (outline_mode_) {
-        llvm::Value *itName = emitExpr(*s.args[0]);
-        if (!itName->getType()->isPointerTy())
-            codegenError("it() first argument must be a string");
-        emitOutlinePrintf("it %s\n", itName);
-        return;
-    }
-
-    auto &lambda = extractLambdaArg(s, "it");
-    auto [itBeginFn, itEndFn] = getTestItFunctions();
-
-    llvm::Value *itName = emitExpr(*s.args[0]);
-    if (!itName->getType()->isPointerTy())
-        codegenError("it() first argument must be a string");
-
-    llvm::Function *testFunc = emitTestFunction("__test_", {}, lambda, "test");
-
-    builder_.CreateCall(itBeginFn, {itName});
-    builder_.CreateCall(testFunc);
-    builder_.CreateCall(itEndFn);
-}
-
-// ===== Test: @each parameterized test =====
-
-void CodeGen::emitEachItCall(CallStmt &s) {
-    // Find @each directive
-    Directive *eachDir = nullptr;
-    for (auto &d : s.directives) {
-        if (d.name == "each") { eachDir = &d; break; }
-    }
-    if (!eachDir || eachDir->args.empty() || !eachDir->args[0].value || eachDir->args[0].name.has_value())
-        codegenError("@each directive requires a list expression");
-
-    if (s.args.size() != 2)
-        codegenError("@each it() requires exactly one description string and a lambda argument");
-    auto *lambda = std::get_if<std::unique_ptr<LambdaExpr>>(&s.args.back()->data);
-    if (!lambda)
-        codegenError("@each it() last argument must be a lambda");
-    auto &lam = **lambda;
-
-    // Get the description format string
-    auto *descStr = std::get_if<StringExpr>(&s.args[0]->data);
-    if (!descStr)
-        codegenError("@each it() first argument must be a string literal");
-    std::string fmtStr = descStr->value;
-
-    if (outline_mode_) {
-        llvm::Value *fmtStrVal = cachedGlobalString(fmtStr, ".it_each_desc");
-        emitOutlinePrintf("it %s (@each)\n", fmtStrVal);
-        return;
-    }
-
-    // Evaluate the list expression to get the list header
-    llvm::Value *listPtr = emitExpr(*eachDir->args[0].value);
-    llvm::Type *elemTy = getListElementType(listPtr);
-    if (!elemTy)
-        codegenError("@each requires a list of tuples");
-
-    auto *tupleTy = llvm::dyn_cast<llvm::StructType>(elemTy);
-    if (!tupleTy)
-        codegenError("@each requires a list of tuples");
-
-    unsigned numFields = tupleTy->getNumElements();
-    if (numFields != lam.params.size())
-        codegenError("@each: tuple arity (" + std::to_string(numFields) +
-                     ") doesn't match lambda parameter count (" + std::to_string(lam.params.size()) + ")");
-
-    // Build parameter types from tuple
-    std::vector<llvm::Type*> paramTypes;
-    paramTypes.reserve(numFields);
-    for (unsigned i = 0; i < numFields; ++i)
-        paramTypes.push_back(tupleTy->getElementType(i));
-
-    llvm::Function *testFunc = emitTestFunction("__test_each_", paramTypes, lam, "@each test");
-
-    emitEachItLoop(listPtr, elemTy, numFields, fmtStr, testFunc);
-}
-
 void CodeGen::emitEachItLoop(llvm::Value *listPtr, llvm::Type *elemTy, unsigned numFields,
                               const std::string &fmtStr, llvm::Function *testFunc,
                               const std::vector<llvm::Value*> &capturedVals) {
@@ -333,56 +191,6 @@ void CodeGen::emitEachItLoop(llvm::Value *listPtr, llvm::Type *elemTy, unsigned 
     builder_.CreateBr(condBB);
 
     builder_.SetInsertPoint(endBB);
-}
-
-// ===== Test: @property property-based test =====
-
-void CodeGen::emitPropertyItCall(CallStmt &s) {
-    if (outline_mode_) {
-        llvm::Value *itName = emitExpr(*s.args[0]);
-        if (!itName->getType()->isPointerTy())
-            codegenError("@property it() first argument must be a string");
-        emitOutlinePrintf("it %s (@property)\n", itName);
-        return;
-    }
-
-    // Find @property directive and get count
-    int64_t count = 100; // default
-    if (const ExprNode *countExpr = getDirectiveNamedArg(s.directives, "property", "count")) {
-        if (auto *n = std::get_if<NumberExpr>(&countExpr->data)) {
-            if (n->value <= 0)
-                codegenError("@property 'count' must be a positive integer");
-            count = static_cast<int64_t>(n->value);
-        } else {
-            codegenError("@property 'count' must be an integer literal");
-        }
-    }
-
-    if (s.args.size() != 2)
-        codegenError("@property it() requires exactly one description string and a lambda argument");
-    auto *lambda = std::get_if<std::unique_ptr<LambdaExpr>>(&s.args.back()->data);
-    if (!lambda)
-        codegenError("@property it() last argument must be a lambda");
-    auto &lam = **lambda;
-
-    llvm::Value *itName = emitExpr(*s.args[0]);
-    if (!itName->getType()->isPointerTy())
-        codegenError("@property it() first argument must be a string");
-
-    // Resolve parameter types
-    std::vector<llvm::Type*> paramTypes;
-    paramTypes.reserve(lam.params.size());
-    for (auto &p : lam.params)
-        paramTypes.push_back(resolveType(p.type->toString()));
-
-    llvm::Function *testFunc = emitTestFunction("__prop_test_", paramTypes, lam, "@property test");
-
-    std::vector<std::string> paramNames;
-    paramNames.reserve(lam.params.size());
-    for (auto &p : lam.params)
-        paramNames.push_back(p.name);
-
-    emitPropertyItLoop(testFunc, itName, paramTypes, paramNames, count);
 }
 
 void CodeGen::emitPropertyItLoop(llvm::Function *testFunc, llvm::Value *descVal,
@@ -664,9 +472,6 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
                 auto &fn = *fnPtr;
                 if (hasDirective(fn->directives, "it") || hasDirective(fn->directives, "describe"))
                     std::visit([this](auto &st) { emitStmt(st); }, stmt);
-            } else if (auto *cs = std::get_if<CallStmt>(&stmt)) {
-                if (cs->callee == "describe" || cs->callee == "it")
-                    emitStmt(*cs);
             }
         }
         --outline_depth_;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -787,7 +787,7 @@ StmtNode Parser::parseStatement() {
         s.loc = locFromToken(first);
         if (s.callee == "mock")
             coerceFirstArgToString(s.args);
-        if (s.callee != "mock" && s.callee != "it" && s.callee != "describe") {
+        if (s.callee != "mock") {
             tryParseTrailingBlock(s);
         }
         s.directives = std::move(directives);

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1259,64 +1259,53 @@ TEST_F(CodeGenTest, RawStringConcat) {
 // ===== test matcher: toNotEq =====
 
 TEST_F(CodeGenTest, ExpectToNotEq) {
-    std::string src =
-        "describe(\"matchers\", ():\n"
-        "    it(\"not equal\", ():\n"
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"not equal\")\n"
+        "    fn notEqual():\n"
         "        expect(1).toNotEq(2)\n"
-        "    )\n"
-        ")";
+    );
     EXPECT_NO_THROW(runTestSource(src));
 }
 
 // ===== test matcher: toBeSome =====
 
 TEST_F(CodeGenTest, ExpectToBeSome) {
-    std::string src =
-        "describe(\"matchers\", ():\n"
-        "    it(\"some\", ():\n"
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"some\")\n"
+        "    fn some():\n"
         "        x = Some(5)\n"
         "        expect(x).toBeSome()\n"
-        "    )\n"
-        ")";
+    );
     EXPECT_NO_THROW(runTestSource(src));
 }
 
 // ===== test matcher: toContain =====
 
 TEST_F(CodeGenTest, ExpectToContainList) {
-    std::string src =
-        "describe(\"matchers\", ():\n"
-        "    it(\"contains\", ():\n"
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"contains\")\n"
+        "    fn contains():\n"
         "        xs = [1, 2, 3]\n"
         "        expect(xs).toContain(2)\n"
-        "    )\n"
-        ")";
+    );
     EXPECT_NO_THROW(runTestSource(src));
 }
 
 TEST_F(CodeGenTest, ExpectToContainString) {
-    std::string src =
-        "describe(\"matchers\", ():\n"
-        "    it(\"contains str\", ():\n"
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"contains str\")\n"
+        "    fn containsStr():\n"
         "        s = \"hello world\"\n"
         "        expect(s).toContain(\"world\")\n"
-        "    )\n"
-        ")";
-    EXPECT_NO_THROW(runTestSource(src));
-}
-
-// ===== lambda argument syntax =====
-
-TEST_F(CodeGenTest, LambdaArgDescribeIt) {
-    std::string src =
-        "describe(\"Calculator\", ():\n"
-        "    it(\"adds\", ():\n"
-        "        expect(1 + 2).toEq(3)\n"
-        "    )\n"
-        "    it(\"subtracts\", ():\n"
-        "        expect(5 - 3).toEq(2)\n"
-        "    )\n"
-        ")";
+    );
     EXPECT_NO_THROW(runTestSource(src));
 }
 

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -144,16 +144,6 @@ protected:
         return {runModule(std::move(tsm)), warnings};
     }
 
-    static std::pair<std::string, std::vector<std::string>> runTestSourceWithWarnings(const std::string &src) {
-        Lexer lex(src);
-        Parser parser(lex);
-        Program prog = parser.parseProgram();
-
-        CodeGen cg(true);  // test_mode = true
-        auto tsm = cg.compile(prog);
-        auto warnings = cg.getWarnings();
-        return {runModule(std::move(tsm)), warnings};
-    }
 };
 
 // As of #1390, the non-bootstrap built-in directives (@inline / @parallel /

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1289,44 +1289,6 @@ TEST_F(DirectiveTest, DescribeDirectiveWithProperty) {
     EXPECT_NE(out.find("1 passed, 0 failed"), std::string::npos);
 }
 
-// Old describe() lambda syntax emits a deprecation warning
-TEST_F(DirectiveTest, DescribeCallEmitsDeprecationWarning) {
-    auto [output, warnings] = runTestSourceWithWarnings(
-        "describe(\"old style\", ():\n"
-        "    it(\"test\", ():\n"
-        "        expect(1).toEq(1)\n"
-        "    )\n"
-        ")\n"
-    );
-    const auto describe_warn_count = std::count_if(
-        warnings.begin(), warnings.end(),
-        [](const std::string &w) {
-            return w.find("describe(") != std::string::npos &&
-                   w.find("deprecated") != std::string::npos;
-        });
-    EXPECT_EQ(describe_warn_count, 1u)
-        << "Expected exactly one deprecation warning for describe() call syntax";
-}
-
-// Old it() lambda syntax emits a deprecation warning
-TEST_F(DirectiveTest, ItCallEmitsDeprecationWarning) {
-    auto [output, warnings] = runTestSourceWithWarnings(
-        "describe(\"g\", ():\n"
-        "    it(\"old it\", ():\n"
-        "        expect(1).toEq(1)\n"
-        "    )\n"
-        ")\n"
-    );
-    const auto it_warn_count = std::count_if(
-        warnings.begin(), warnings.end(),
-        [](const std::string &w) {
-            return w.find("it(") != std::string::npos &&
-                   w.find("deprecated") != std::string::npos;
-        });
-    EXPECT_EQ(it_warn_count, 1u)
-        << "Expected exactly one deprecation warning for it() call syntax";
-}
-
 // Unknown directive name: parser now accepts any name (validation deferred to codegen).
 // This test verifies the AST is correctly populated; codegen will reject at emit time.
 TEST(DirectiveSyntax, UnknownDirectiveParseSucceeds) {

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -7,13 +7,13 @@ using namespace ry;
 // ============================================================
 
 TEST_F(CodeGenTest, FailWithMessage) {
-    EXPECT_EQ(runTestSource(
-        "describe(\"fail helper\", ():\n"
-        "    it(\"marks test as failed\", ():\n"
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"fail helper\")\n"
+        "fn failHelper():\n"
+        "    @it(\"marks test as failed\")\n"
+        "    fn marksTestAsFailed():\n"
         "        fail(\"intentional failure\")\n"
-        "    )\n"
-        ")\n"
-    ), "fail helper\n    \033[31mline 3: intentional failure\033[0m\n  \033[31m- marks test as failed\033[0m\n\n0 passed, 1 failed\n");
+    )), "fail helper\n    \033[31mline 21: intentional failure\033[0m\n  \033[31m- marks test as failed\033[0m\n\n0 passed, 1 failed\n");
 }
 
 // ============================================================
@@ -21,13 +21,13 @@ TEST_F(CodeGenTest, FailWithMessage) {
 // ============================================================
 
 TEST_F(CodeGenTest, FailWithoutMessage) {
-    EXPECT_EQ(runTestSource(
-        "describe(\"fail bare\", ():\n"
-        "    it(\"fails generically\", ():\n"
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"fail bare\")\n"
+        "fn failBare():\n"
+        "    @it(\"fails generically\")\n"
+        "    fn failsGenerically():\n"
         "        fail()\n"
-        "    )\n"
-        ")\n"
-    ), "fail bare\n    \033[31mline 3: test failed\033[0m\n  \033[31m- fails generically\033[0m\n\n0 passed, 1 failed\n");
+    )), "fail bare\n    \033[31mline 21: test failed\033[0m\n  \033[31m- fails generically\033[0m\n\n0 passed, 1 failed\n");
 }
 
 // ============================================================

--- a/tests/test_codegen_mock.cpp
+++ b/tests/test_codegen_mock.cpp
@@ -7,17 +7,17 @@ using namespace ry;
 // ============================================================
 
 TEST_F(CodeGenTest, MockBasicReplace) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
         "fn greet() -> str:\n"
         "    return \"hello\"\n"
         "\n"
-        "describe(\"mock basic\", ():\n"
-        "    it(\"replaces function\", ():\n"
+        "@describe(\"mock basic\")\n"
+        "fn mockBasic():\n"
+        "    @it(\"replaces function\")\n"
+        "    fn replacesFunction():\n"
         "        mock(greet, () => \"mocked\")\n"
         "        expect(greet()).toEq(\"mocked\")\n"
-        "    )\n"
-        ")\n"
-    ), "mock basic\n  \033[32m+ replaces function\033[0m\n\n1 passed, 0 failed\n");
+    )), "mock basic\n  \033[32m+ replaces function\033[0m\n\n1 passed, 0 failed\n");
 }
 
 // ============================================================
@@ -25,17 +25,17 @@ TEST_F(CodeGenTest, MockBasicReplace) {
 // ============================================================
 
 TEST_F(CodeGenTest, MockWithArgs) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
         "fn add(a: int, b: int) -> int:\n"
         "    return a + b\n"
         "\n"
-        "describe(\"mock with args\", ():\n"
-        "    it(\"replaces function with args\", ():\n"
+        "@describe(\"mock with args\")\n"
+        "fn mockWithArgs():\n"
+        "    @it(\"replaces function with args\")\n"
+        "    fn replacesFunctionWithArgs():\n"
         "        mock(add, (a: int, b: int) => a * b)\n"
         "        expect(add(3, 4)).toEq(12)\n"
-        "    )\n"
-        ")\n"
-    ), "mock with args\n  \033[32m+ replaces function with args\033[0m\n\n1 passed, 0 failed\n");
+    )), "mock with args\n  \033[32m+ replaces function with args\033[0m\n\n1 passed, 0 failed\n");
 }
 
 // ============================================================
@@ -43,20 +43,21 @@ TEST_F(CodeGenTest, MockWithArgs) {
 // ============================================================
 
 TEST_F(CodeGenTest, MockAutoRestore) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
         "fn greet() -> str:\n"
         "    return \"hello\"\n"
         "\n"
-        "describe(\"mock restore\", ():\n"
-        "    it(\"mocks\", ():\n"
+        "@describe(\"mock restore\")\n"
+        "fn mockRestore():\n"
+        "    @it(\"mocks\")\n"
+        "    fn mocks():\n"
         "        mock(greet, () => \"mocked\")\n"
         "        expect(greet()).toEq(\"mocked\")\n"
-        "    )\n"
-        "    it(\"auto-restores\", ():\n"
+        "\n"
+        "    @it(\"auto-restores\")\n"
+        "    fn autoRestores():\n"
         "        expect(greet()).toEq(\"hello\")\n"
-        "    )\n"
-        ")\n"
-    ), "mock restore\n  \033[32m+ mocks\033[0m\n  \033[32m+ auto-restores\033[0m\n\n2 passed, 0 failed\n");
+    )), "mock restore\n  \033[32m+ mocks\033[0m\n  \033[32m+ auto-restores\033[0m\n\n2 passed, 0 failed\n");
 }
 
 // ============================================================
@@ -64,20 +65,20 @@ TEST_F(CodeGenTest, MockAutoRestore) {
 // ============================================================
 
 TEST_F(CodeGenTest, MockVerifyCallCount) {
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
         "fn greet() -> str:\n"
         "    return \"hello\"\n"
         "\n"
-        "describe(\"verify\", ():\n"
-        "    it(\"counts calls\", ():\n"
+        "@describe(\"verify\")\n"
+        "fn verifyGroup():\n"
+        "    @it(\"counts calls\")\n"
+        "    fn countsCalls():\n"
         "        mock(greet, () => \"mocked\")\n"
         "        greet()\n"
         "        greet()\n"
         "        greet()\n"
         "        expect(verify(greet)).toEq(3)\n"
-        "    )\n"
-        ")\n"
-    ), "verify\n  \033[32m+ counts calls\033[0m\n\n1 passed, 0 failed\n");
+    )), "verify\n  \033[32m+ counts calls\033[0m\n\n1 passed, 0 failed\n");
 }
 
 // ============================================================
@@ -86,19 +87,19 @@ TEST_F(CodeGenTest, MockVerifyCallCount) {
 
 TEST_F(CodeGenTest, MockFunctionUsedAsExpr) {
     // verify() works when mock is called and function result is used
-    EXPECT_EQ(runTestSource(
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
         "fn getValue() -> int:\n"
         "    return 100\n"
         "\n"
-        "describe(\"mock expr\", ():\n"
-        "    it(\"tracks calls in expressions\", ():\n"
+        "@describe(\"mock expr\")\n"
+        "fn mockExpr():\n"
+        "    @it(\"tracks calls in expressions\")\n"
+        "    fn tracksCallsInExpressions():\n"
         "        mock(getValue, () => 999)\n"
         "        x = getValue()\n"
         "        expect(x).toEq(999)\n"
         "        expect(verify(getValue)).toEq(1)\n"
-        "    )\n"
-        ")\n"
-    ), "mock expr\n  \033[32m+ tracks calls in expressions\033[0m\n\n1 passed, 0 failed\n");
+    )), "mock expr\n  \033[32m+ tracks calls in expressions\033[0m\n\n1 passed, 0 failed\n");
 }
 
 // ============================================================
@@ -118,13 +119,13 @@ TEST_F(CodeGenTest, MockOutsideTestModeError) {
 // ============================================================
 
 TEST_F(CodeGenTest, MockNonExistentFunctionError) {
-    EXPECT_THROW(runTestSource(
-        "describe(\"error\", ():\n"
-        "    it(\"errors\", ():\n"
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"error\")\n"
+        "fn errorGroup():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
         "        mock(no_such_fn, () => \"x\")\n"
-        "    )\n"
-        ")\n"
-    ), std::exception);
+    )), std::exception);
 }
 
 // ============================================================
@@ -132,37 +133,38 @@ TEST_F(CodeGenTest, MockNonExistentFunctionError) {
 // ============================================================
 
 TEST_F(CodeGenTest, MockTypeMismatchError) {
-    EXPECT_THROW(runTestSource(
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
         "fn greet() -> str:\n"
         "    return \"hello\"\n"
         "\n"
-        "describe(\"error\", ():\n"
-        "    it(\"errors\", ():\n"
+        "@describe(\"error\")\n"
+        "fn errorGroup():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
         "        mock(greet, () => 42)\n"
-        "    )\n"
-        ")\n"
-    ), std::exception);
+    )), std::exception);
 }
 
 TEST_F(CodeGenTest, MockedFunctionStillChecksRequire) {
-    std::string src =
+    std::string src = withStdlibDirectiveDecls(
         "fn deposit(amount: int, balance: int) -> int:\n"
         "    require:\n"
         "        amount > 0\n"
         "        balance >= 0\n"
         "    return balance + amount\n"
         "\n"
-        "describe(\"mock contracts\", ():\n"
-        "    it(\"checks require on mocked calls\", ():\n"
+        "@describe(\"mock contracts\")\n"
+        "fn mockContracts():\n"
+        "    @it(\"checks require on mocked calls\")\n"
+        "    fn checksRequireOnMockedCalls():\n"
         "        mock(deposit, (amount: int, balance: int) => balance + amount)\n"
         "        deposit(-100, -200)\n"
-        "    )\n"
-        ")\n";
+    );
     EXPECT_EXIT(runTestSource(src), ::testing::ExitedWithCode(1), "");
 }
 
 TEST_F(CodeGenTest, MockedFunctionStillChecksEnsure) {
-    std::string src =
+    std::string src = withStdlibDirectiveDecls(
         "fn deposit(amount: int, balance: int) -> int:\n"
         "    require:\n"
         "        amount > 0\n"
@@ -171,11 +173,12 @@ TEST_F(CodeGenTest, MockedFunctionStillChecksEnsure) {
         "        v > balance\n"
         "    return balance + amount\n"
         "\n"
-        "describe(\"mock contracts\", ():\n"
-        "    it(\"checks ensure on mocked calls\", ():\n"
+        "@describe(\"mock contracts\")\n"
+        "fn mockContracts():\n"
+        "    @it(\"checks ensure on mocked calls\")\n"
+        "    fn checksEnsureOnMockedCalls():\n"
         "        mock(deposit, (amount: int, balance: int) => -999)\n"
         "        deposit(10, 20)\n"
-        "    )\n"
-        ")\n";
+    );
     EXPECT_EXIT(runTestSource(src), ::testing::ExitedWithCode(1), "");
 }

--- a/tests/test_codegen_parameterized.cpp
+++ b/tests/test_codegen_parameterized.cpp
@@ -8,12 +8,12 @@ using namespace ry;
 
 TEST_F(CodeGenTest, EachBasicInt) {
     auto output = runTestSource(withStdlibDirectiveDecls(
-        "describe(\"each\", ():\n"
+        "@describe(\"each\")\n"
+        "fn eachGroup():\n"
         "    @each([(1, 2, 3), (0, 0, 0)])\n"
-        "    it(\"adds {0} + {1} = {2}\", (a: int, b: int, expected: int):\n"
+        "    @it(\"adds {0} + {1} = {2}\")\n"
+        "    fn addsCase(a: int, b: int, expected: int):\n"
         "        expect(a + b).toEq(expected)\n"
-        "    )\n"
-        ")\n"
     ));
     EXPECT_NE(output.find("adds 1 + 2 = 3"), std::string::npos);
     EXPECT_NE(output.find("adds 0 + 0 = 0"), std::string::npos);
@@ -26,12 +26,12 @@ TEST_F(CodeGenTest, EachBasicInt) {
 
 TEST_F(CodeGenTest, EachStringParam) {
     auto output = runTestSource(withStdlibDirectiveDecls(
-        "describe(\"each str\", ():\n"
+        "@describe(\"each str\")\n"
+        "fn eachStr():\n"
         "    @each([(\"hi\", 2), (\"\", 0)])\n"
-        "    it(\"len of {0} is {1}\", (s: str, expected: int):\n"
+        "    @it(\"len of {0} is {1}\")\n"
+        "    fn lenCase(s: str, expected: int):\n"
         "        expect(len(s)).toEq(expected)\n"
-        "    )\n"
-        ")\n"
     ));
     EXPECT_NE(output.find("2 passed, 0 failed"), std::string::npos);
 }
@@ -42,12 +42,12 @@ TEST_F(CodeGenTest, EachStringParam) {
 
 TEST_F(CodeGenTest, EachFailingTest) {
     auto output = runTestSource(withStdlibDirectiveDecls(
-        "describe(\"each fail\", ():\n"
+        "@describe(\"each fail\")\n"
+        "fn eachFail():\n"
         "    @each([(1, 2, 4)])\n"
-        "    it(\"{0}+{1}={2}\", (a: int, b: int, expected: int):\n"
+        "    @it(\"{0}+{1}={2}\")\n"
+        "    fn failCase(a: int, b: int, expected: int):\n"
         "        expect(a + b).toEq(expected)\n"
-        "    )\n"
-        ")\n"
     ));
     EXPECT_NE(output.find("0 passed, 1 failed"), std::string::npos);
 }
@@ -58,12 +58,12 @@ TEST_F(CodeGenTest, EachFailingTest) {
 
 TEST_F(CodeGenTest, PropertyCommutative) {
     auto output = runTestSource(withStdlibDirectiveDecls(
-        "describe(\"prop\", ():\n"
+        "@describe(\"prop\")\n"
+        "fn propGroup():\n"
         "    @property(count=50)\n"
-        "    it(\"a+b == b+a\", (a: int, b: int):\n"
+        "    @it(\"a+b == b+a\")\n"
+        "    fn commutative(a: int, b: int):\n"
         "        expect(a + b).toEq(b + a)\n"
-        "    )\n"
-        ")\n"
     ));
     EXPECT_NE(output.find("1 passed, 0 failed"), std::string::npos);
 }
@@ -74,12 +74,12 @@ TEST_F(CodeGenTest, PropertyCommutative) {
 
 TEST_F(CodeGenTest, PropertyBoolParam) {
     auto output = runTestSource(withStdlibDirectiveDecls(
-        "describe(\"prop bool\", ():\n"
+        "@describe(\"prop bool\")\n"
+        "fn propBool():\n"
         "    @property(count=10)\n"
-        "    it(\"x==x\", (x: bool):\n"
+        "    @it(\"x==x\")\n"
+        "    fn boolEq(x: bool):\n"
         "        expect(x == x).toBeTrue()\n"
-        "    )\n"
-        ")\n"
     ));
     EXPECT_NE(output.find("1 passed, 0 failed"), std::string::npos);
 }

--- a/tests/test_entry_point.cpp
+++ b/tests/test_entry_point.cpp
@@ -175,12 +175,10 @@ TEST_F(EntryPointTest, MissingDotSlashRyPathPrintsNoSuchFile) {
 
 TEST_F(EntryPointTest, RunsBareTestFilenameViaPaths) {
     writePackageToml();
-    writeFile("src/bar.test.ry",
-              "describe(\"bare test\", ():\n"
-              "  it(\"ok\", ():\n"
-              "    expect(1).toEq(1)\n"
-              "  )\n"
-              ")\n");
+    // The test runner resolves bare filenames via [paths]; we only need a file
+    // that prints something the test can grep for. Avoid `from testing import`
+    // so this test does not depend on stdlib resolution under RY_ENV=internal.
+    writeFile("src/bar.test.ry", "print(\"bare test ok\")\n");
     auto [out, rc] = runRyInDir(tmp_dir_.string(), {"test", "bar.test.ry", "-p"});
     EXPECT_EQ(rc, 0);
     EXPECT_NE(out.find("bare test"), std::string::npos);

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -426,17 +426,17 @@ TEST(Formatter, LambdaAndTrailingBlock) {
         auto out = fmt(src);
         EXPECT_NE(out.find("double = (x: int) => x * 2"), std::string::npos);
     }
-    // Trailing block call
+    // Directive-based test group: formatter preserves @describe/@it
     {
         auto src =
-            "describe(\"test\", ():\n"
-            "    it(\"case\", ():\n"
-            "        expect(1 + 1).toEq(2)\n"
-            "    )\n"
-            ")\n";
+            "@describe(\"test\")\n"
+            "fn testGroup():\n"
+            "    @it(\"case\")\n"
+            "    fn caseTest():\n"
+            "        expect(1 + 1).toEq(2)\n";
         auto out = fmt(src);
-        EXPECT_NE(out.find("describe(\"test\", ():"), std::string::npos);
-        EXPECT_NE(out.find("  it(\"case\", ():"), std::string::npos);
+        EXPECT_NE(out.find("@describe(\"test\")"), std::string::npos);
+        EXPECT_NE(out.find("@it(\"case\")"), std::string::npos);
     }
     // Expect statement
     {
@@ -444,11 +444,11 @@ TEST(Formatter, LambdaAndTrailingBlock) {
             "fn id(x: int) -> int:\n"
             "    return x\n"
             "\n"
-            "describe(\"t\", ():\n"
-            "    it(\"c\", ():\n"
-            "        expect(id(5)).toEq(5)\n"
-            "    )\n"
-            ")\n";
+            "@describe(\"t\")\n"
+            "fn tGroup():\n"
+            "    @it(\"c\")\n"
+            "    fn cCase():\n"
+            "        expect(id(5)).toEq(5)\n";
         auto out = fmt(src);
         EXPECT_NE(out.find("expect(id(5)).toEq(5)"), std::string::npos);
     }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2239,23 +2239,6 @@ TEST(ParserTest, SnakeCaseRecordFieldRejected) {
     EXPECT_THROW(parseStr("record Point:\n    my_x: int"), std::runtime_error);
 }
 
-// ===== expect マッチャー =====
-
-TEST(ParserTest, ExpectToNotEq) {
-    Program prog = parseStr("describe(\"test\", ():\n    it(\"t\", ():\n        expect(1).toNotEq(2)\n    )\n)");
-    ASSERT_EQ(prog.size(), 1u);
-}
-
-TEST(ParserTest, ExpectToBeSome) {
-    Program prog = parseStr("describe(\"test\", ():\n    it(\"t\", ():\n        expect(1).toBeSome()\n    )\n)");
-    ASSERT_EQ(prog.size(), 1u);
-}
-
-TEST(ParserTest, ExpectToContain) {
-    Program prog = parseStr("describe(\"test\", ():\n    it(\"t\", ():\n        expect(1).toContain(1)\n    )\n)");
-    ASSERT_EQ(prog.size(), 1u);
-}
-
 // ===== trailing block syntax =====
 
 TEST(ParserTest, TrailingBlockNoArgs) {
@@ -2278,23 +2261,6 @@ TEST(ParserTest, TrailingBlockWithArgs) {
     ASSERT_TRUE(std::holds_alternative<StringExpr>(s.args[0]->data));
     ASSERT_TRUE(std::holds_alternative<NumberExpr>(s.args[1]->data));
     ASSERT_TRUE(std::holds_alternative<std::unique_ptr<LambdaExpr>>(s.args[2]->data));
-}
-
-TEST(ParserTest, LambdaArgNested) {
-    Program prog = parseStr("describe(\"calc\", ():\n    it(\"adds\", ():\n        expect(1 + 2).toEq(3)\n    )\n)");
-    ASSERT_EQ(prog.size(), 1u);
-    ASSERT_TRUE(std::holds_alternative<CallStmt>(prog[0]));
-    const auto &s = std::get<CallStmt>(prog[0]);
-    EXPECT_EQ(s.callee, "describe");
-    ASSERT_EQ(s.args.size(), 2u);
-    auto *lambda = std::get_if<std::unique_ptr<LambdaExpr>>(&s.args[1]->data);
-    ASSERT_NE(lambda, nullptr);
-    ASSERT_EQ((*lambda)->body.size(), 1u);
-    // Inner statement should be a CallStmt (it) with trailing block
-    ASSERT_TRUE(std::holds_alternative<CallStmt>((*lambda)->body[0]));
-    const auto &inner = std::get<CallStmt>((*lambda)->body[0]);
-    EXPECT_EQ(inner.callee, "it");
-    ASSERT_EQ(inner.args.size(), 2u);
 }
 
 TEST(ParserTest, TrailingBlockUFCS) {

--- a/tests/test_trace.cpp
+++ b/tests/test_trace.cpp
@@ -173,11 +173,12 @@ TEST_F(TraceModeTest, TraceWithParallelTestsFallsBackToSequential) {
     std::ofstream mainFile(tmp_dir_ / "main.ry");
     mainFile << "print(\"main\")\n";
     std::ofstream testFile(tmp_dir_ / "tests/sample.test.ry");
-    testFile << "describe(\"x\", ():\n"
-                "  it(\"y\", ():\n"
-                "    expect(1).toEq(1)\n"
-                "  )\n"
-                ")\n";
+    testFile << "from testing import it, describe\n"
+                "@describe(\"x\")\n"
+                "fn xGroup():\n"
+                "  @it(\"y\")\n"
+                "  fn y():\n"
+                "    expect(1).toEq(1)\n";
 
     auto result = runRy({"test", "--parallel", "--trace", "tests"}, tmp_dir_.string());
     EXPECT_EQ(result.exit_code, 0);


### PR DESCRIPTION
## Summary

Removes the deprecated lambda call form of `describe("...", ():)` and `it("...", ():)` from the parser and codegen. After #1599 (stdlib migration) and #1601 (deferred-file migration), all `tests/spec/*.test.ry` files use the canonical `@describe("...") fn name():` / `@it("...") fn name():` form, so the lambda form is no longer reachable from any in-tree source.

- **Parser**: drop `describe`/`it` from the `parseStatement` trailing-block carve-out (only `mock` remains).
- **Codegen**: delete `extractLambdaArg`, `emitDescribeCall`, `emitItCall`, lambda branches of `emitEachItCall`/`emitPropertyItCall`, and the dispatch entries in `codegen_call_user.cpp`. Also remove `warned_call_deprecations_` dedup state from the header.
- **Tests**: migrate 23 C++ fixtures across 7 files (`test_codegen_advanced`, `test_codegen_fail`, `test_codegen_mock`, `test_codegen_parameterized`, `test_entry_point`, `test_trace`, `test_formatter`) to canonical form; delete 6 lambda-only tests (deprecation-warning tests + lambda-arg parser tests). Remove the now-orphaned `runTestSourceWithWarnings` helper.
- **Docs**: drop legacy lambda sections from `docs/reference/testing.md` / `directives.md`; update knowledge base entries (`tests-spec-conventions.md`, `test-checklist/SKILL.md`).

Source that still uses the lambda form now fails compilation with `undefined function: describe` / `undefined function: it` (or a parser error if a trailing block is also present).

Closes #1602

## Test plan

- [x] `cmake --build build` clean
- [x] `./build/ry_tests` — 2117 tests passed
- [x] `./build/ry test -p` — 173 files, 0 failures
- [x] ASan+UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p` clean
- [x] Smoke: `describe("smoke", () => 1)` rejected with `undefined function: describe`
- [x] Smoke: trailing-block `describe("smoke", ():\n  ...)` rejected with parser error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Removed support for lambda-based test declaration syntax; tests must now use the directive-based `@describe` and `@it` syntax. Using the deprecated lambda form will result in undefined function errors.

* **Documentation**
  * Updated testing and directive references to reflect the new canonical syntax and removed legacy syntax examples and guidance.

* **Tests**
  * Migrated test suite to use the updated directive-based test syntax throughout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->