### PR TITLE
chore(repo): adopt editor-agnostic layout for tree-sitter (#1614)

### DIFF
--- a/changelog.d/1614-integrate-tree-sitter.md
+++ b/changelog.d/1614-integrate-tree-sitter.md
@@ -1,0 +1,11 @@
+### Added
+
+- Imported the tree-sitter grammar from the standalone `tree-sitter-ry`
+  repository into this repository under a new editor-agnostic layout:
+  `docs/grammar.ebnf` is now the canonical grammar specification (single
+  source of truth) and `editor/tree-sitter/` holds the tree-sitter
+  implementation (`grammar.js`, `src/scanner.c`, `queries/highlights.scm`,
+  `tree-sitter.json`, `build.sh`, `install.sh`). Generated artifacts
+  (`parser.c`, `grammar.json`, `node-types.json`, runtime headers,
+  `bindings/`) are reproducible via `editor/tree-sitter/build.sh` and are
+  excluded from version control. (#1614)

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -1,0 +1,490 @@
+/*
+ * Ry language grammar (EBNF, W3C-style notation)
+ * ===============================================
+ *
+ * Source: ry compiler v0.0.17 — verified against
+ *   include/ry/lexer.hpp / src/lexer.cpp     (terminals & keyword table)
+ *   src/parser*.cpp                          (statement & expression productions)
+ *   tests/spec/*.test.ry                     (concrete syntax samples)
+ *   docs/reference/types.md                  (type system spec)
+ *
+ * Notation
+ *   ::=     production
+ *   |       alternation
+ *   [...]   optional (zero or one)
+ *   {...}   zero or more
+ *   (...)   grouping
+ *   'lit'   terminal literal
+ *   UPPER   terminal token (lexer-emitted, see "Lexical" section)
+ *   lower   non-terminal
+ *
+ * Indentation: Ry is indentation-sensitive. The lexer emits virtual
+ * INDENT / DEDENT / NEWLINE tokens (lexer.hpp TokenKind::Indent /
+ * Dedent / Newline). All block productions use them explicitly.
+ */
+
+
+/* =====================================================================
+ * 1. Compilation Unit
+ * ===================================================================*/
+
+source_file ::= { NEWLINE | top_level_statement }
+
+top_level_statement ::= import_statement
+                     | declaration
+                     | statement
+
+
+/* =====================================================================
+ * 2. Imports
+ * ===================================================================*/
+
+import_statement ::= 'from' module_path 'import' import_list NEWLINE
+
+module_path      ::= IDENT { '.' IDENT }
+
+import_list      ::= import_item { ',' import_item }
+
+import_item      ::= IDENT [ 'as' IDENT ]
+
+
+/* =====================================================================
+ * 3. Declarations
+ *    Decorators (`@name`, `@name(args)`) attach to the next declaration
+ *    or statement. Multiple decorators stack on separate lines.
+ * ===================================================================*/
+
+declaration      ::= { decorator NEWLINE } ( fn_decl
+                                            | record_decl
+                                            | enum_decl
+                                            | type_alias_decl
+                                            | directive_def_decl )
+
+decorator        ::= '@' IDENT [ '(' [ decorator_args ] ')' ]
+
+decorator_args   ::= decorator_arg { ',' decorator_arg }
+
+decorator_arg    ::= [ IDENT '=' ] expression          // named or positional
+
+
+/* ------- Function declaration ------- */
+
+fn_decl          ::= [ 'async' ] 'fn' fn_name [ generic_params ]
+                     '(' [ param_list ] ')'
+                     [ '->' type_expr ]
+                     ( fn_body | NEWLINE )             // body omitted for @native fns
+
+fn_name          ::= ( IDENT | overloadable_op ) [ '!' ]
+
+overloadable_op  ::= 'operator' ( '+' | '-' | '*' | '/' | '%' | '**' | '//'
+                                 | '==' | '!=' | '<' | '<=' | '>' | '>='
+                                 | '[' ']' | '[' ']' '='        // operator[] / operator[]=
+                                 | '(' ')'                       // operator()
+                                 | 'in' | 'not' 'in'
+                                 | 'and' | 'or' | 'not'
+                                 | 'as' )
+
+param_list       ::= param { ',' param }
+
+param            ::= IDENT ':' type_expr [ '=' expression ]
+
+generic_params   ::= '<' IDENT { ',' IDENT } '>'
+
+fn_body          ::= ':' INDENT { contract_clause } statement { statement } DEDENT
+
+contract_clause  ::= ( 'require' ':' INDENT condition_list DEDENT
+                     | 'ensure' [ IDENT ] ':' INDENT condition_list DEDENT )
+
+condition_list   ::= expression NEWLINE { expression NEWLINE }
+
+
+/* ------- Record declaration ------- */
+
+record_decl      ::= 'record' IDENT [ generic_params ] ':'
+                     INDENT { record_member } DEDENT
+
+record_member    ::= { decorator NEWLINE } record_field
+                   | record_invariant
+                   | NEWLINE
+
+record_field     ::= IDENT ':' type_expr [ '=' expression ] NEWLINE
+
+record_invariant ::= 'invariant' ':' INDENT condition_list DEDENT
+
+
+/* ------- Enum declaration (ADT) ------- */
+
+enum_decl        ::= 'enum' IDENT [ generic_params ] ':'
+                     INDENT { enum_variant } DEDENT
+
+enum_variant     ::= IDENT [ '(' [ variant_payload ] ')' ] NEWLINE
+
+variant_payload  ::= variant_field { ',' variant_field }
+
+variant_field    ::= [ IDENT ':' ] type_expr           // tuple-style or named-field
+
+
+/* ------- Type alias ------- */
+
+type_alias_decl  ::= 'type' IDENT [ generic_params ] '=' type_expr NEWLINE
+
+
+/* ------- @directive definition (#708) ------- */
+
+directive_def_decl ::= '@directive' '(' decorator_args ')' fn_decl
+
+
+/* =====================================================================
+ * 4. Types
+ * ===================================================================*/
+
+type_expr        ::= union_type
+
+union_type       ::= primary_type { '|' primary_type }
+
+primary_type     ::= primitive_type
+                   | named_type
+                   | tuple_type
+                   | function_type
+                   | weak_type
+                   | option_type
+                   | array_type
+
+primitive_type   ::= 'int' | 'float' | 'bool' | 'str' | 'Unit' | 'any' | 'Error'
+                   | 'i8'  | 'i16'   | 'i32'  | 'i64'
+                   | 'u8'  | 'u16'   | 'u32'  | 'u64'
+                   | 'f32' | 'f64'
+
+named_type       ::= IDENT [ '<' type_expr { ',' type_expr } '>' ]
+                     { '::' IDENT [ '<' type_expr { ',' type_expr } '>' ] }
+
+tuple_type       ::= '(' type_expr ',' [ type_expr { ',' type_expr } ] ')'
+                   | '(' type_expr ')'                  // grouping only when unambiguous
+
+function_type    ::= 'fn' '(' [ type_expr { ',' type_expr } ] ')' '->' type_expr
+
+weak_type        ::= 'weak' primary_type                // soft keyword
+
+option_type      ::= primary_type '?'                   // sugar for Option<T>
+
+array_type       ::= primary_type '[' [ INTEGER ] ']'   // fixed-length array
+
+
+/* =====================================================================
+ * 5. Statements
+ * ===================================================================*/
+
+statement        ::= simple_statement NEWLINE
+                   | compound_statement
+                   | { decorator NEWLINE } ( fn_decl | record_decl | enum_decl | type_alias_decl )
+
+simple_statement ::= return_stmt
+                   | break_stmt
+                   | continue_stmt
+                   | assign_stmt
+                   | tuple_destruct_stmt
+                   | call_stmt
+                   | expect_stmt
+                   | expression_stmt
+
+return_stmt      ::= 'return' [ expression ]
+break_stmt       ::= 'break'
+continue_stmt    ::= 'continue'
+
+assign_stmt      ::= lvalue ( '=' | compound_assign_op ) expression
+                   | IDENT ':' type_expr '=' expression          // typed binding (no `let`)
+                   | IDENT '=' expression                        // implicit binding
+
+compound_assign_op ::= '+=' | '-=' | '*=' | '/=' | '%='
+                     | '**=' | '//=' | '&=' | '|=' | '^='
+                     | '<<=' | '>>='
+
+lvalue           ::= IDENT { lvalue_postfix }
+
+lvalue_postfix   ::= '.' IDENT
+                   | '[' expression { ',' expression } ']'
+
+tuple_destruct_stmt ::= '(' IDENT { ',' IDENT } ')' '=' expression
+                      | IDENT ',' IDENT { ',' IDENT } '=' expression
+
+call_stmt        ::= postfix_expression                  // expression statement w/ side effect
+
+expect_stmt      ::= 'expect' '(' expression ')' '.' matcher_name
+                                    [ '(' [ expression { ',' expression } ] ')' ]
+
+matcher_name     ::= IDENT                                // toEq, toBeTrue, toThrow, ... (parser whitelist)
+
+expression_stmt  ::= expression                           // limited; bare ident form rejected, use `(expr)`
+
+
+/* ------- Compound statements (own newline handling) ------- */
+
+compound_statement ::= if_stmt
+                     | while_stmt
+                     | for_stmt
+                     | case_stmt
+
+if_stmt          ::= 'if' expression ':' block
+                     { 'else' 'if' expression ':' block }
+                     [ 'else' ':' block ]
+
+while_stmt       ::= 'while' expression ':' block
+
+for_stmt         ::= 'for' for_target 'in' expression ':' block
+
+for_target       ::= IDENT
+                   | '(' IDENT { ',' IDENT } ')'
+                   | IDENT ',' IDENT { ',' IDENT }   // bare-comma destructure
+
+case_stmt        ::= case_match_stmt
+                   | case_cond_stmt
+
+case_match_stmt  ::= 'case' expression ':' INDENT case_arm { case_arm } DEDENT
+
+case_cond_stmt   ::= 'case' ':' INDENT case_cond_arm { case_cond_arm } DEDENT
+
+case_arm         ::= ( pattern | or_pattern ) [ 'if' expression ] ':'
+                       ( expression NEWLINE
+                       | INDENT statement { statement } DEDENT )
+
+or_pattern       ::= pattern '|' pattern { '|' pattern }
+                                                          // OR alternatives may not contain bindings (parser-enforced)
+
+case_cond_arm    ::= ( expression | '_' ) ':' ( expression NEWLINE
+                                              | INDENT statement { statement } DEDENT )
+
+block            ::= INDENT statement { statement } DEDENT
+
+
+/* =====================================================================
+ * 6. Patterns (case arms, destructuring)
+ * ===================================================================*/
+
+pattern          ::= literal_pattern
+                   | wildcard_pattern
+                   | binding_pattern
+                   | tuple_pattern
+                   | constructor_pattern
+                   | range_pattern
+
+literal_pattern  ::= INTEGER | FLOAT | STRING | 'true' | 'false' | 'none'
+                   | '-' ( INTEGER | FLOAT )
+
+wildcard_pattern ::= '_'
+
+binding_pattern  ::= IDENT                                 // captures the scrutinee
+
+tuple_pattern    ::= '(' pattern ',' [ pattern { ',' pattern } ] ')'
+
+constructor_pattern ::= qualified_ident [ '(' [ pattern { ',' pattern } ] ')' ]
+                                                          // Some(x) / Ok(v) / MyOpt::MySome(v)
+
+qualified_ident  ::= IDENT { '::' IDENT }
+/* NOTE: explicit type arguments (`Foo<T>::Variant`) are not yet modeled at
+ * the qualified_ident level — `<` always tokenizes as the comparison
+ * operator in expression position. */
+
+range_pattern    ::= literal_pattern '..' literal_pattern
+
+
+/* =====================================================================
+ * 7. Expressions (precedence climbing — lowest to highest)
+ * ===================================================================*/
+
+expression       ::= conditional_expr
+                   | lambda_expr
+                   | if_expr
+                   | case_expr
+
+/* lambdas */
+lambda_expr      ::= '(' [ lambda_param { ',' lambda_param } ] ')' [ '->' type_expr ] '=>' lambda_body
+                   | IDENT '=>' lambda_body                        // bare-paren single-param (#1572)
+
+lambda_param     ::= IDENT [ ':' type_expr ] [ '=' expression ]
+
+lambda_body      ::= expression
+                   | block
+
+/* if-expression: `if cond => then else else_expr` (single-line block sugar) */
+if_expr          ::= 'if' expression '=>' expression 'else' expression
+
+/* case-expression form (block-bodied case used as an expression) */
+case_expr        ::= case_match_expr
+                   | case_cond_expr
+
+case_match_expr  ::= 'case' expression ':' INDENT case_arm { case_arm } DEDENT
+
+case_cond_expr   ::= 'case' ':' INDENT case_cond_arm { case_cond_arm } DEDENT
+
+/* conditional / null-coalescing */
+conditional_expr ::= logical_or_expr [ '??' conditional_expr ]
+
+logical_or_expr  ::= logical_and_expr { 'or' logical_and_expr }
+logical_and_expr ::= logical_not_expr { 'and' logical_not_expr }
+logical_not_expr ::= [ 'not' ] comparison_expr
+
+comparison_expr  ::= bit_or_expr { comparison_op bit_or_expr }
+                   | bit_or_expr ( 'in' | 'not' 'in' ) bit_or_expr
+
+comparison_op    ::= '==' | '!=' | '<' | '<=' | '>' | '>='
+
+bit_or_expr      ::= bit_xor_expr { '|' bit_xor_expr }
+bit_xor_expr     ::= bit_and_expr { '^' bit_and_expr }
+bit_and_expr     ::= shift_expr   { '&' shift_expr }
+shift_expr       ::= range_expr   { ( '<<' | '>>' | '>>>' ) range_expr }
+
+range_expr       ::= additive_expr [ '..' additive_expr ]
+
+additive_expr    ::= multiplicative_expr { ( '+' | '-' ) multiplicative_expr }
+multiplicative_expr ::= power_expr { ( '*' | '/' | '//' | '%' ) power_expr }
+power_expr       ::= unary_expr { '**' unary_expr }                 // right-associative
+
+unary_expr       ::= ( '-' | '+' | '~' | 'not' | 'await' | 'weak' ) unary_expr
+                   | postfix_expression
+
+/* postfix chain: call, index, field access, ?, ++, -- */
+postfix_expression ::= primary_expression { postfix_op }
+
+postfix_op       ::= '(' [ argument_list ] ')'                       // call
+                   | '[' expression { ',' expression } ']'           // index
+                   | '.' IDENT                                        // field / method
+                   | '?'                                              // unwrap
+                   | '++' | '--'                                      // post-inc/dec
+                   | 'as' type_expr                                   // cast
+
+argument_list    ::= argument { ',' argument }
+argument         ::= [ IDENT '=' ] expression                        // positional or named
+
+
+primary_expression ::= literal
+                     | identifier_or_qualified
+                     | '(' expression ')'                            // grouping
+                     | tuple_literal
+                     | list_literal
+                     | map_or_set_literal
+                     | record_literal
+                     | f_string
+
+identifier_or_qualified ::= IDENT { '::' IDENT }
+/* See `qualified_ident` note above re: explicit type arguments. */
+
+
+/* =====================================================================
+ * 8. Literals
+ * ===================================================================*/
+
+literal          ::= INTEGER | FLOAT
+                   | STRING | REGEX_LITERAL
+                   | boolean_literal | none_literal
+/* `Unit` is a type name only; the singleton unit value cannot be written
+ * directly in source. It appears via `primitive_type`, never as `literal`. */
+
+boolean_literal  ::= 'true' | 'false'
+none_literal     ::= 'none'                              // also: None (constructor)
+
+tuple_literal    ::= '(' expression ',' [ expression { ',' expression } ] ')'
+                   | '(' expression ',' ')'              // 1-tuple
+
+list_literal     ::= '[' [ expression { ',' expression } [ ',' ] ] ']'
+
+/* `{}` is empty-map; `{k: v, ...}` is map; `{e, ...}` is set */
+map_or_set_literal ::= '{' '}'
+                     | '{' expression ':' expression { ',' expression ':' expression } [ ',' ] '}'
+                     | '{' expression { ',' expression } [ ',' ] '}'
+
+record_literal   ::= IDENT '(' [ argument_list ] ')'   // syntactically a call; semantically a record
+
+/* f-string: lexer emits FSTRING_START / FSTRING_MID / FSTRING_END
+   wrapping interpolated expression segments */
+f_string         ::= FSTRING_START expression { FSTRING_MID expression } FSTRING_END
+
+
+/* =====================================================================
+ * 9. Lexical (terminals — emitted by include/ry/lexer.hpp)
+ * ===================================================================*/
+
+/* Whitespace & comments (filtered, not part of grammar) */
+COMMENT          ::= '#' { any_char_except_newline }
+
+/* Identifiers (trailing '!' allowed for mutating method names like sort!) */
+IDENT            ::= ( letter | '_' ) { letter | digit | '_' } [ '!' ]
+                   /* '!' is greedily absorbed except when followed by '=' (-> '!=') */
+
+/* Numeric literals */
+INTEGER          ::= ( decimal_int | hex_int | binary_int ) [ int_suffix ]
+decimal_int      ::= digit { digit | '_' }
+hex_int          ::= '0x' hex_digit { hex_digit | '_' }
+binary_int       ::= '0b' bin_digit { bin_digit | '_' }
+int_suffix       ::= 'i8' | 'i16' | 'i32' | 'i64' | 'u8' | 'u16' | 'u32' | 'u64'
+
+FLOAT            ::= digit { digit | '_' } '.' digit { digit | '_' } [ exponent ] [ float_suffix ]
+                   | digit { digit | '_' } exponent [ float_suffix ]
+exponent         ::= ( 'e' | 'E' ) [ '+' | '-' ] digit { digit | '_' }
+float_suffix     ::= 'f32' | 'f64'
+
+/* String literal: standard escapes, no interpolation (use f-string for that) */
+STRING           ::= '"' { string_char } '"'
+string_char      ::= ( any_char_except_quote_backslash_newline | escape_seq )
+escape_seq       ::= '\\' ( 'n' | 't' | 'r' | '0' | '\\' | '"' | "'" | 'x' hex_digit hex_digit )
+
+/* f-string segments — three lexer states */
+FSTRING_START    ::= 'f"' { string_char } '{'              // up to first interpolation
+FSTRING_MID      ::= '}' { string_char } '{'               // between interpolations
+FSTRING_END      ::= '}' { string_char } '"'               // after last interpolation
+                   | 'f"' { string_char } '"'              // f-string with no interpolation
+
+/* Regex literal: `/pattern/flags` — recognized only in expression contexts.
+   Conflicts with the `/` division operator; the lexer disambiguates by
+   tracking whether an expression is currently expected. */
+REGEX_LITERAL    ::= '/' { regex_char } '/' { regex_flag }
+regex_flag       ::= 'g' | 'i' | 'm' | 's' | 'x'
+
+/* Indentation (virtual tokens emitted by the lexer) */
+NEWLINE          ::= '\n' [ indent ]   /* emitted at end of every logical line */
+INDENT           ::= /* emitted when a logical line's indent exceeds the previous */
+DEDENT           ::= /* emitted when a logical line's indent falls back */
+
+/* Hard keywords (lexer keyword_map @ src/lexer.cpp:35-66) */
+KEYWORD          ::= 'and'    | 'or'     | 'not'
+                   | 'true'   | 'false'  | 'none'
+                   | 'if'     | 'else'   | 'while'
+                   | 'for'    | 'in'     | 'break'  | 'continue'
+                   | 'fn'     | 'return'
+                   | 'from'   | 'import' | 'as'
+                   | 'type'   | 'record' | 'enum'   | 'operator'
+                   | 'case'   | 'expect'
+                   | 'require'| 'ensure' | 'invariant'
+                   | 'Error'
+                   | 'async'  | 'await'
+
+/* Soft keywords (NOT in lexer keyword_map; recognized contextually):
+   weak, Some, None, Ok, Err, _, Unit, any */
+
+/* Character classes */
+letter           ::= 'a'..'z' | 'A'..'Z'
+digit            ::= '0'..'9'
+hex_digit        ::= '0'..'9' | 'a'..'f' | 'A'..'F'
+bin_digit        ::= '0' | '1'
+
+
+/* =====================================================================
+ * 10. Operator precedence summary (lowest → highest)
+ * =====================================================================
+ *
+ *   1.  if-expr / case-expr / lambda                         (statement-level)
+ *   2.  '??' (null-coalescing)                              right-assoc
+ *   3.  'or'                                                left-assoc
+ *   4.  'and'                                               left-assoc
+ *   5.  'not'                                               unary-prefix
+ *   6.  comparison ('==' '!=' '<' '<=' '>' '>=' 'in' 'not in')   non-assoc
+ *   7.  '|'  bitwise-or                                     left-assoc
+ *   8.  '^'  bitwise-xor                                    left-assoc
+ *   9.  '&'  bitwise-and                                    left-assoc
+ *   10. shift ('<<' '>>' '>>>')                             left-assoc
+ *   11. range ('..')                                        non-assoc
+ *   12. additive ('+' '-')                                  left-assoc
+ *   13. multiplicative ('*' '/' '//' '%')                   left-assoc
+ *   14. power ('**')                                        right-assoc
+ *   15. unary ('-' '+' '~' 'not' 'await' 'weak')            unary-prefix
+ *   16. postfix (call, index, '.', '?', '++', '--', 'as')   left-to-right
+ */

--- a/editor/tree-sitter/.gitignore
+++ b/editor/tree-sitter/.gitignore
@@ -1,0 +1,8 @@
+# tree-sitter generated artifacts (reproducible from grammar.js via build.sh).
+# *.so / *.dylib / *.a / *.o are already covered by the repository-root .gitignore.
+src/parser.c
+src/grammar.json
+src/node-types.json
+src/tree_sitter/
+bindings/
+node_modules/

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -11,7 +11,7 @@ alternative parsers, additional editor plugins) may be added under sibling
 
 ## Layout
 
-```
+```text
 editor/tree-sitter/
 ├── grammar.js           # tree-sitter grammar definition (tracked)
 ├── src/

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -1,0 +1,78 @@
+# tree-sitter-ry
+
+Tree-sitter grammar for the Ry language. Lives in-tree under `editor/` so that
+grammar changes can ride alongside the language changes that motivate them.
+
+The canonical grammar specification is [`docs/grammar.ebnf`](../../docs/grammar.ebnf)
+in this repository (single source of truth). `grammar.js` here is the
+tree-sitter implementation of that spec; other consumers (LSP servers,
+alternative parsers, additional editor plugins) may be added under sibling
+`editor/<tool>/` directories in the future.
+
+## Layout
+
+```
+editor/tree-sitter/
+├── grammar.js           # tree-sitter grammar definition (tracked)
+├── src/
+│   └── scanner.c        # external scanner (INDENT/DEDENT/NEWLINE,
+│                        #   f-string segments, regex literals)
+├── queries/
+│   └── highlights.scm   # tree-sitter highlight queries (tracked)
+├── tree-sitter.json     # tree-sitter CLI configuration
+├── build.sh             # tree-sitter generate + build -> ry.so
+├── install.sh           # copy ry.so + queries to Neovim parser dirs
+└── README.md            # this file
+```
+
+The following are reproducible outputs of `tree-sitter generate` / `tree-sitter build`
+and are **not tracked**:
+
+- `src/parser.c`, `src/grammar.json`, `src/node-types.json`
+- `src/tree_sitter/*.h` (tree-sitter runtime headers)
+- `bindings/`, `node_modules/`
+- `ry.so`, `*.dylib`, `*.a`, `*.o`
+
+The first three groups are excluded by `.gitignore` in this directory; the
+binary suffixes are excluded by the repository-root `.gitignore`. If you need
+any of these locally, run `./build.sh`.
+
+## Prerequisites
+
+- **tree-sitter CLI** ≥ 0.22 (`tree-sitter.json` config format).
+  Install with `cargo install tree-sitter-cli` or via your package manager.
+- **GNU gcc**. On macOS the system `cc` / `gcc` are Apple Clang shims;
+  `build.sh` looks for Homebrew `gcc-15` … `gcc-12` in `PATH` and falls back
+  with an error otherwise. Install with `brew install gcc`. On Linux the
+  default `cc` is normally GNU gcc and no extra setup is needed.
+- **Node.js** is *not* required for `tree-sitter generate` / `tree-sitter build`
+  (the standalone CLI handles both). It is only needed if you want to use the
+  optional Node bindings, which this in-tree copy intentionally does not ship.
+
+## Build
+
+```bash
+./build.sh                # tree-sitter generate + build -> ry.so
+./build.sh --no-gen       # skip generate (when only scanner.c changed)
+./build.sh --debug        # build with -O0 -g
+```
+
+`build.sh` regenerates `src/parser.c` from `grammar.js`, then compiles
+`parser.c` + `scanner.c` into `ry.so` via `tree-sitter build`. The script
+honours an existing `CC` env var; otherwise it auto-detects a Homebrew GNU
+gcc on macOS.
+
+## Install (Neovim)
+
+```bash
+./install.sh              # builds ry.so first, then installs
+./install.sh --no-build   # use an existing ry.so as-is
+```
+
+Installs to:
+
+- `${XDG_CONFIG_HOME:-$HOME/.config}/nvim/parser/ry.so`
+- `${XDG_CONFIG_HOME:-$HOME/.config}/nvim/queries/ry/highlights.scm`
+
+Other editors are not yet supported in-tree; integrations may be added under
+`editor/<tool>/` as they appear.

--- a/editor/tree-sitter/build.sh
+++ b/editor/tree-sitter/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# tree-sitter-ry を grammar.js から再生成し、共有ライブラリ ry.so を生成する。
+#
+# Usage:
+#   ./build.sh             # generate + build (ry.so)
+#   ./build.sh --no-gen    # build のみ (scanner.c など C 側だけ変更したとき)
+#   ./build.sh --debug     # debug ビルド (-0 / -O0 -g 相当)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+# tree-sitter build は内部で `cc` を呼ぶ (cc-rs)。macOS の `cc` / `gcc` は
+# どちらも Apple clang のラッパーなので、GNU gcc を使うために Homebrew の
+# バージョン付き gcc を CC に明示する。CC が既に設定されていれば尊重する。
+if [[ -z "${CC:-}" ]]; then
+  for v in 15 14 13 12; do
+    if command -v "gcc-$v" >/dev/null 2>&1; then
+      export CC="gcc-$v"
+      break
+    fi
+  done
+  if [[ -z "${CC:-}" ]]; then
+    echo "ERROR: GNU gcc not found (looked for gcc-15..gcc-12). Run 'brew install gcc'." >&2
+    exit 1
+  fi
+fi
+
+DO_GEN=1
+DEBUG=0
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-gen) DO_GEN=0 ;;
+    --debug)  DEBUG=1 ;;
+    -h|--help)
+      sed -n '3,9p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$DO_GEN" -eq 1 ]]; then
+  echo "==> tree-sitter generate"
+  tree-sitter generate
+fi
+
+echo "==> tree-sitter build -o ry.so (CC=$CC)"
+if [[ "$DEBUG" -eq 1 ]]; then
+  tree-sitter build --debug -o ry.so
+else
+  tree-sitter build -o ry.so
+fi
+
+echo "==> done: $(ls -la ry.so | awk '{print $5, $NF}')"

--- a/editor/tree-sitter/grammar.js
+++ b/editor/tree-sitter/grammar.js
@@ -1,0 +1,972 @@
+/**
+ * Tree-sitter grammar for Ry (v0.0.17)
+ *
+ * Conforms to grammar.ebnf in this directory. Verified against
+ *   include/ry/lexer.hpp / src/lexer.cpp     (terminals & keyword table)
+ *   src/parser*.cpp                          (statement & expression productions)
+ *   tests/spec/*.test.ry                     (concrete syntax samples)
+ *
+ * Indentation handling
+ * --------------------
+ * Ry is indentation-sensitive. The lexer emits virtual
+ * INDENT / DEDENT / NEWLINE tokens that this grammar declares as
+ * `externals`. A C external scanner (src/scanner.c) is required for
+ * `tree-sitter generate` to produce a buildable parser. This file
+ * defines only the abstract grammar; the scanner implementation is
+ * out of scope for the grammar definition itself.
+ */
+
+// Precedence table — lowest to highest. Mirrors the EBNF section 10 ladder.
+const PREC = {
+  conditional:    1,   // if-expr, case-expr, lambda
+  coalesce:       2,   // ??
+  or:             3,   // or
+  and:            4,   // and
+  not:            5,   // not
+  comparison:     6,   // == != < <= > >= in
+  bit_or:         7,   // |
+  bit_xor:        8,   // ^
+  bit_and:        9,   // &
+  shift:         10,   // << >> >>>
+  range:         11,   // ..
+  additive:      12,   // + -
+  multiplicative:13,   // * / // %
+  power:         14,   // **           (right-assoc)
+  unary:         15,   // - + ~ not await weak
+  postfix:       16,   // call, index, . ? ++ --, as
+  primary:       17,
+};
+
+const PRIMITIVE_TYPES = [
+  'int', 'float', 'bool', 'str', 'Unit', 'any', 'Error',
+  'i8', 'i16', 'i32', 'i64',
+  'u8', 'u16', 'u32', 'u64',
+  'f32', 'f64',
+];
+
+const COMPOUND_ASSIGN_OPS = [
+  '+=', '-=', '*=', '/=', '%=',
+  '**=', '//=',
+  '&=', '|=', '^=',
+  '<<=', '>>=',
+];
+
+export default grammar({
+  name: 'ry',
+
+  // Tokens supplied by the C external scanner (src/scanner.c).
+  // Required for context-sensitive lexing — block structure
+  // (INDENT/DEDENT/NEWLINE), f-string segment switching, and
+  // disambiguating regex literals from the `/` operator. Without
+  // src/scanner.c, the generated parser cannot recognize these.
+  externals: $ => [
+    $._indent,
+    $._dedent,
+    $._newline,
+    $._fstring_start,
+    $._fstring_mid,
+    $._fstring_end,
+    $._regex_literal,
+  ],
+
+  extras: $ => [
+    $.comment,
+    /[ \t\r]/,                  // whitespace; newlines are explicit via _newline
+  ],
+
+  // Make `identifier` the lexer's catch-all for any "word" token, so that
+  // keywords like `if` lex as themselves rather than as identifiers.
+  word: $ => $.identifier,
+
+  conflicts: $ => [
+    // LHS of assignment shares prefix with expression `a.b = c` vs `a.b` as expression.
+    [$._lvalue, $.qualified_identifier],
+    // `(a, b)` — tuple-destructure LHS vs lambda params vs paren-grouped expr.
+    [$.tuple_destructure_statement, $.qualified_identifier, $.lambda_param],
+    [$.qualified_identifier, $.lambda_param],
+    // case-arm identifier: binding pattern `x: ...` vs nullary constructor `Foo: ...`.
+    [$.binding_pattern, $.qualified_identifier],
+    // `case ... :` can be a statement OR an expression with the same prefix.
+    // prec.dynamic biases toward statement form in statement context.
+    [$.case_match_statement, $.case_match_expression],
+    [$.case_cond_statement, $.case_cond_expression],
+  ],
+
+  rules: {
+
+    /* =====================================================================
+     * Top level
+     * ===================================================================*/
+    source_file: $ => repeat(choice(
+      $._newline,
+      $._top_level_statement,
+    )),
+
+    _top_level_statement: $ => choice(
+      $.import_statement,
+      $._statement,                          // _statement already includes _declaration
+    ),
+
+    /* =====================================================================
+     * Imports
+     * ===================================================================*/
+    import_statement: $ => seq(
+      'from',
+      field('source', $.module_path),
+      'import',
+      field('items', $.import_list),
+      $._newline,
+    ),
+
+    module_path: $ => sep1($.identifier, '.'),
+
+    import_list: $ => sep1($.import_item, ','),
+
+    import_item: $ => seq(
+      field('name', $.identifier),
+      optional(seq('as', field('alias', $.identifier))),
+    ),
+
+    /* =====================================================================
+     * Declarations
+     * ===================================================================*/
+    _declaration: $ => seq(
+      repeat(seq($.decorator, $._newline)),
+      choice(
+        $.function_declaration,
+        $.record_declaration,
+        $.enum_declaration,
+        $.type_alias_declaration,
+        $.directive_def_declaration,
+      ),
+    ),
+
+    decorator: $ => seq(
+      '@',
+      field('name', $.identifier),
+      optional(seq(
+        '(',
+        optional($.decorator_arguments),
+        ')',
+      )),
+    ),
+
+    decorator_arguments: $ => sep1($.decorator_argument, ','),
+
+    decorator_argument: $ => choice(
+      seq(field('name', $.identifier), '=', field('value', $._expression)),
+      field('value', $._expression),
+    ),
+
+    /* ------- Function declaration ------- */
+    function_declaration: $ => seq(
+      optional('async'),
+      'fn',
+      field('name', $.function_name),
+      optional(field('generics', $.generic_parameters)),
+      '(',
+      optional(field('parameters', $.parameter_list)),
+      ')',
+      optional(seq('->', field('return_type', $._type))),
+      choice(
+        field('body', $.function_body),
+        $._newline,                  // @native fn — no body
+      ),
+    ),
+
+    // `identifier` already greedily absorbs a trailing `!` (see the
+    // identifier terminal at the bottom), so no extra suffix is needed
+    // for mutating-method names like `sort!`.
+    function_name: $ => choice(
+      $.identifier,
+      $.operator_name,
+    ),
+
+    operator_name: $ => seq(
+      'operator',
+      choice(
+        '+', '-', '*', '/', '%', '**', '//',
+        '==', '!=', '<', '<=', '>', '>=',
+        seq('[', ']', optional('=')),     // operator[]  /  operator[]=
+        seq('(', ')'),                    // operator()
+        'in', seq('not', 'in'),
+        'and', 'or', 'not', 'as',
+      ),
+    ),
+
+    parameter_list: $ => sep1($.parameter, ','),
+
+    parameter: $ => seq(
+      field('name', $.identifier),
+      ':',
+      field('type', $._type),
+      optional(seq('=', field('default', $._expression))),
+    ),
+
+    generic_parameters: $ => seq(
+      '<',
+      sep1($.identifier, ','),
+      '>',
+    ),
+
+    function_body: $ => seq(
+      ':',
+      $._indent,
+      repeat($.contract_clause),
+      repeat1($._statement),
+      $._dedent,
+    ),
+
+    contract_clause: $ => choice(
+      seq(
+        'require',
+        ':',
+        $._indent,
+        $._condition_list,
+        $._dedent,
+      ),
+      seq(
+        'ensure',
+        optional(field('binding', $.identifier)),
+        ':',
+        $._indent,
+        $._condition_list,
+        $._dedent,
+      ),
+    ),
+
+    _condition_list: $ => repeat1(seq($._expression, $._newline)),
+
+    /* ------- Record declaration ------- */
+    record_declaration: $ => seq(
+      'record',
+      field('name', $.identifier),
+      optional(field('generics', $.generic_parameters)),
+      ':',
+      $._indent,
+      repeat($._record_member),
+      $._dedent,
+    ),
+
+    _record_member: $ => choice(
+      $.record_field,
+      $.record_invariant,
+      $._newline,
+    ),
+
+    record_field: $ => seq(
+      repeat(seq($.decorator, $._newline)),
+      field('name', $.identifier),
+      ':',
+      field('type', $._type),
+      optional(seq('=', field('default', $._expression))),
+      $._newline,
+    ),
+
+    record_invariant: $ => seq(
+      'invariant',
+      ':',
+      $._indent,
+      $._condition_list,
+      $._dedent,
+    ),
+
+    /* ------- Enum declaration (ADT) ------- */
+    enum_declaration: $ => seq(
+      'enum',
+      field('name', $.identifier),
+      optional(field('generics', $.generic_parameters)),
+      ':',
+      $._indent,
+      repeat1($.enum_variant),
+      $._dedent,
+    ),
+
+    enum_variant: $ => seq(
+      field('name', $.identifier),
+      optional(seq(
+        '(',
+        optional($.variant_payload),
+        ')',
+      )),
+      $._newline,
+    ),
+
+    variant_payload: $ => sep1($.variant_field, ','),
+
+    variant_field: $ => choice(
+      seq(field('name', $.identifier), ':', field('type', $._type)),
+      field('type', $._type),
+    ),
+
+    /* ------- Type alias ------- */
+    type_alias_declaration: $ => seq(
+      'type',
+      field('name', $.identifier),
+      optional(field('generics', $.generic_parameters)),
+      '=',
+      field('type', $._type),
+      $._newline,
+    ),
+
+    /* ------- @directive definition (#708) ------- */
+    directive_def_declaration: $ => seq(
+      '@directive',
+      '(',
+      $.decorator_arguments,
+      ')',
+      $.function_declaration,
+    ),
+
+    /* =====================================================================
+     * Types
+     * ===================================================================*/
+    _type: $ => $.union_type,
+
+    union_type: $ => prec.left(seq(
+      $._primary_type,
+      repeat(seq('|', $._primary_type)),
+    )),
+
+    _primary_type: $ => choice(
+      $.primitive_type,
+      $.named_type,
+      $.tuple_type,
+      $.function_type,
+      $.weak_type,
+      $.option_type,
+      $.array_type,
+    ),
+
+    primitive_type: $ => choice(...PRIMITIVE_TYPES),
+
+    named_type: $ => prec.right(seq(
+      $.identifier,
+      optional($.type_arguments),
+      repeat(seq(
+        '::',
+        $.identifier,
+        optional($.type_arguments),
+      )),
+    )),
+
+    type_arguments: $ => seq(
+      '<',
+      sep1($._type, ','),
+      '>',
+    ),
+
+    tuple_type: $ => prec(1, seq(
+      '(',
+      $._type,
+      ',',
+      optional(sep1($._type, ',')),
+      ')',
+    )),
+
+    function_type: $ => seq(
+      'fn',
+      '(',
+      optional(sep1($._type, ',')),
+      ')',
+      '->',
+      $._type,
+    ),
+
+    weak_type: $ => prec.right(seq(
+      'weak',
+      $._primary_type,
+    )),
+
+    option_type: $ => prec(PREC.postfix, seq($._primary_type, '?')),
+
+    array_type: $ => prec(PREC.postfix, seq(
+      $._primary_type,
+      '[',
+      optional($.integer_literal),
+      ']',
+    )),
+
+    /* =====================================================================
+     * Statements
+     * ===================================================================*/
+    _statement: $ => choice(
+      seq($._simple_statement, $._newline),
+      $._compound_statement,
+      $._declaration,
+    ),
+
+    _simple_statement: $ => choice(
+      $.return_statement,
+      $.break_statement,
+      $.continue_statement,
+      $.assignment_statement,
+      $.compound_assignment,
+      $.typed_binding_statement,
+      $.tuple_destructure_statement,
+      $.expect_statement,
+      $.expression_statement,
+    ),
+
+    return_statement: $ => prec.right(seq(
+      'return',
+      optional(field('value', $._expression)),
+    )),
+
+    break_statement: $ => 'break',
+    continue_statement: $ => 'continue',
+
+    /* `name = value` and chained-postfix LHS assignment.
+       (typed `name: T = value` is a separate rule to avoid LR(1) trouble.) */
+    assignment_statement: $ => prec.right(PREC.conditional - 1, seq(
+      field('left', $._lvalue),
+      '=',
+      field('right', $._expression),
+    )),
+
+    compound_assignment: $ => prec.right(PREC.conditional - 1, seq(
+      field('left', $._lvalue),
+      field('operator', choice(...COMPOUND_ASSIGN_OPS)),
+      field('right', $._expression),
+    )),
+
+    /* `name: Type = value` — implicit-binding form (no `let` keyword) */
+    typed_binding_statement: $ => seq(
+      field('name', $.identifier),
+      ':',
+      field('type', $._type),
+      '=',
+      field('value', $._expression),
+    ),
+
+    /* Both forms: `(a, b) = expr`  and  `a, b = expr` */
+    tuple_destructure_statement: $ => choice(
+      seq(
+        '(',
+        sep1($.identifier, ','),
+        ')',
+        '=',
+        field('value', $._expression),
+      ),
+      seq(
+        $.identifier,
+        repeat1(seq(',', $.identifier)),
+        '=',
+        field('value', $._expression),
+      ),
+    ),
+
+    expect_statement: $ => seq(
+      'expect',
+      '(',
+      field('actual', $._expression),
+      ')',
+      '.',
+      field('matcher', $.identifier),
+      optional(seq(
+        '(',
+        optional(sep1($._expression, ',')),
+        ')',
+      )),
+    ),
+
+    expression_statement: $ => $._expression,
+
+    _lvalue: $ => choice(
+      $.identifier,
+      $._lvalue_postfix,
+    ),
+
+    _lvalue_postfix: $ => prec(PREC.postfix, choice(
+      seq($._lvalue, '.', $.identifier),
+      seq($._lvalue, '[', sep1($._expression, ','), ']'),
+    )),
+
+    /* ------- Compound statements ------- */
+    _compound_statement: $ => choice(
+      $.if_statement,
+      $.while_statement,
+      $.for_statement,
+      $.case_statement,
+    ),
+
+    if_statement: $ => seq(
+      'if',
+      field('condition', $._expression),
+      ':',
+      field('consequence', $.block),
+      repeat(seq(
+        'else',
+        'if',
+        field('alt_condition', $._expression),
+        ':',
+        field('alt_consequence', $.block),
+      )),
+      optional(seq(
+        'else',
+        ':',
+        field('alternative', $.block),
+      )),
+    ),
+
+    while_statement: $ => seq(
+      'while',
+      field('condition', $._expression),
+      ':',
+      field('body', $.block),
+    ),
+
+    for_statement: $ => seq(
+      'for',
+      field('target', $._for_target),
+      'in',
+      field('iter', $._expression),
+      ':',
+      field('body', $.block),
+    ),
+
+    _for_target: $ => choice(
+      $.identifier,
+      seq('(', sep1($.identifier, ','), ')'),
+      // bare-comma destructure: `for a, b in iter:`
+      seq($.identifier, ',', sep1($.identifier, ',')),
+    ),
+
+    // Two forms: `case <expr>:` (scrutinee form, pattern-matching) and
+    // `case:` (no scrutinee, condition-list form — each arm is a boolean
+    // condition expression). They use different arm grammars so they are
+    // surfaced as distinct rules joined under `case_statement`.
+    case_statement: $ => choice(
+      $.case_match_statement,
+      $.case_cond_statement,
+    ),
+
+    case_match_statement: $ => prec.dynamic(2, seq(
+      'case',
+      field('scrutinee', $._expression),
+      ':',
+      $._indent,
+      repeat1($.case_arm),
+      $._dedent,
+    )),
+
+    case_cond_statement: $ => prec.dynamic(2, seq(
+      'case',
+      ':',
+      $._indent,
+      repeat1($.case_cond_arm),
+      $._dedent,
+    )),
+
+    case_arm: $ => seq(
+      field('pattern', choice($._pattern, $.or_pattern)),
+      optional(seq('if', field('guard', $._expression))),
+      ':',
+      choice(
+        // inline body: single statement on same line as the `:`.
+        // The statement parser handles the trailing newline via `_newline`,
+        // so do NOT add another `_newline` here (it would consume the next
+        // arm's pattern lookahead position).
+        field('body', $._statement),
+        seq($._indent, repeat1($._statement), $._dedent),
+      ),
+    ),
+
+    case_cond_arm: $ => seq(
+      field('condition', choice($._expression, $.wildcard_pattern)),
+      ':',
+      choice(
+        field('body', $._statement),
+        seq($._indent, repeat1($._statement), $._dedent),
+      ),
+    ),
+
+    block: $ => seq(
+      $._indent,
+      repeat1($._statement),
+      $._dedent,
+    ),
+
+    /* =====================================================================
+     * Patterns
+     * ===================================================================*/
+    _pattern: $ => choice(
+      $.literal_pattern,
+      $.wildcard_pattern,
+      $.binding_pattern,
+      $.tuple_pattern,
+      $.constructor_pattern,
+      $.range_pattern,
+    ),
+
+    /* `pat | pat | pat` — only valid as the top-level pattern of a
+     * case_arm; OR alternatives must not contain bindings. The grammar
+     * here permits any nested pattern; the constraint is enforced by
+     * the parser at compile time. */
+    or_pattern: $ => prec.left(seq(
+      $._pattern,
+      repeat1(seq('|', $._pattern)),
+    )),
+
+    literal_pattern: $ => choice(
+      $.integer_literal,
+      $.float_literal,
+      $.string_literal,
+      'true',
+      'false',
+      'none',
+      seq('-', choice($.integer_literal, $.float_literal)),
+    ),
+
+    wildcard_pattern: $ => '_',
+
+    binding_pattern: $ => $.identifier,
+
+    tuple_pattern: $ => prec(2, seq(
+      '(',
+      $._pattern,
+      ',',
+      optional(sep1($._pattern, ',')),
+      ')',
+    )),
+
+    constructor_pattern: $ => seq(
+      $.qualified_identifier,
+      optional(seq(
+        '(',
+        optional(sep1($._pattern, ',')),
+        ')',
+      )),
+    ),
+
+    qualified_identifier: $ => prec.right(seq(
+      $.identifier,
+      repeat(seq('::', $.identifier)),
+    )),
+
+    range_pattern: $ => seq(
+      $.literal_pattern,
+      '..',
+      $.literal_pattern,
+    ),
+
+    /* =====================================================================
+     * Expressions (precedence climbing — lowest to highest)
+     * ===================================================================*/
+    _expression: $ => choice(
+      $.lambda_expression,
+      $.if_expression,
+      $.case_expression,
+      $._conditional_expression,
+    ),
+
+    lambda_expression: $ => prec(PREC.conditional, choice(
+      // bare-paren single-param form (#1572):  x => x + 1
+      seq(
+        field('parameter', $.identifier),
+        '=>',
+        field('body', $._lambda_body),
+      ),
+      // parenthesized form: (x, y) => x + y    or    (x: int) -> int => x
+      seq(
+        field('parameters', $.lambda_params),
+        optional(seq('->', field('return_type', $._type))),
+        '=>',
+        field('body', $._lambda_body),
+      ),
+      // block-body form: (params) -> Type:\n  <indented body>
+      seq(
+        field('parameters', $.lambda_params),
+        optional(seq('->', field('return_type', $._type))),
+        ':',
+        field('body', $.block),
+      ),
+    )),
+
+    lambda_params: $ => seq(
+      '(',
+      optional(sep1($.lambda_param, ',')),
+      ')',
+    ),
+
+    lambda_param: $ => seq(
+      field('name', $.identifier),
+      optional(seq(':', field('type', $._type))),
+      optional(seq('=', field('default', $._expression))),
+    ),
+
+    _lambda_body: $ => choice($._expression, $.block),
+
+    /* if-expression: `if cond => then else else_expr` (single-line sugar) */
+    if_expression: $ => prec.right(PREC.conditional, seq(
+      'if',
+      field('condition', $._expression),
+      '=>',
+      field('consequence', $._expression),
+      'else',
+      field('alternative', $._expression),
+    )),
+
+    case_expression: $ => prec(PREC.conditional, choice(
+      $.case_match_expression,
+      $.case_cond_expression,
+    )),
+
+    case_match_expression: $ => prec.dynamic(1, seq(
+      'case',
+      field('scrutinee', $._expression),
+      ':',
+      $._indent,
+      repeat1($.case_arm),
+      $._dedent,
+    )),
+
+    case_cond_expression: $ => prec.dynamic(1, seq(
+      'case',
+      ':',
+      $._indent,
+      repeat1($.case_cond_arm),
+      $._dedent,
+    )),
+
+    /* coalesce, logical, comparison, bitwise, shift, range, additive, mul, power */
+    _conditional_expression: $ => choice(
+      $.binary_expression,
+      $.unary_expression,
+      $._postfix_expression,
+    ),
+
+    binary_expression: $ => choice(
+      prec.right(PREC.coalesce,
+        seq(field('left', $._expression), field('operator', '??'),  field('right', $._expression))),
+      prec.left(PREC.or,
+        seq(field('left', $._expression), field('operator', 'or'),  field('right', $._expression))),
+      prec.left(PREC.and,
+        seq(field('left', $._expression), field('operator', 'and'), field('right', $._expression))),
+      ...[
+        ['==', PREC.comparison],
+        ['!=', PREC.comparison],
+        ['<',  PREC.comparison],
+        ['<=', PREC.comparison],
+        ['>',  PREC.comparison],
+        ['>=', PREC.comparison],
+        ['|',  PREC.bit_or],
+        ['^',  PREC.bit_xor],
+        ['&',  PREC.bit_and],
+        ['<<', PREC.shift],
+        ['>>', PREC.shift],
+        ['>>>',PREC.shift],
+        ['..', PREC.range],
+        ['+',  PREC.additive],
+        ['-',  PREC.additive],
+        ['*',  PREC.multiplicative],
+        ['/',  PREC.multiplicative],
+        ['//', PREC.multiplicative],
+        ['%',  PREC.multiplicative],
+      ].map(([op, p]) => prec.left(p,
+        seq(field('left', $._expression), field('operator', op), field('right', $._expression)),
+      )),
+      // 'in' / 'not in' membership test
+      prec.left(PREC.comparison,
+        seq(field('left', $._expression),
+            field('operator', choice('in', seq('not', 'in'))),
+            field('right', $._expression))),
+      // power is right-associative
+      prec.right(PREC.power,
+        seq(field('left', $._expression), field('operator', '**'), field('right', $._expression))),
+    ),
+
+    unary_expression: $ => prec.right(PREC.unary, seq(
+      field('operator', choice('-', '+', '~', 'not', 'await', 'weak')),
+      field('operand', $._expression),
+    )),
+
+    /* ------- Postfix chain: call, index, .field, ?, ++, --, as ------- */
+    _postfix_expression: $ => choice(
+      $._primary_expression,
+      $.call_expression,
+      $.index_expression,
+      $.field_access,
+      $.unwrap_expression,
+      $.update_expression,
+      $.cast_expression,
+    ),
+
+    call_expression: $ => prec(PREC.postfix, seq(
+      field('function', $._postfix_expression),
+      '(',
+      optional(field('arguments', $.argument_list)),
+      ')',
+    )),
+
+    index_expression: $ => prec(PREC.postfix, seq(
+      field('object', $._postfix_expression),
+      '[',
+      sep1($._expression, ','),
+      ']',
+    )),
+
+    field_access: $ => prec(PREC.postfix, seq(
+      field('object', $._postfix_expression),
+      '.',
+      field('field', $.identifier),
+    )),
+
+    unwrap_expression: $ => prec(PREC.postfix, seq(
+      $._postfix_expression,
+      '?',
+    )),
+
+    update_expression: $ => prec(PREC.postfix, seq(
+      $._postfix_expression,
+      choice('++', '--'),
+    )),
+
+    cast_expression: $ => prec.left(PREC.postfix, seq(
+      field('value', $._postfix_expression),
+      'as',
+      field('type', $._type),
+    )),
+
+    argument_list: $ => sep1($.argument, ','),
+
+    argument: $ => choice(
+      seq(field('name', $.identifier), '=', field('value', $._expression)),
+      field('value', $._expression),
+    ),
+
+    /* ------- Primary ------- */
+    _primary_expression: $ => choice(
+      $._literal,
+      $.qualified_identifier,
+      $._parenthesized,
+      $.tuple_literal,
+      $.list_literal,
+      $.map_literal,
+      $.set_literal,
+      $.f_string,
+    ),
+
+    _parenthesized: $ => seq('(', $._expression, ')'),
+
+    tuple_literal: $ => choice(
+      // 1-tuple `(e,)`
+      seq('(', $._expression, ',', ')'),
+      // n-tuple `(e1, e2, ...)`  (n >= 2)
+      seq('(', $._expression, ',', sep1($._expression, ','), ')'),
+    ),
+
+    list_literal: $ => seq(
+      '[',
+      optional(seq(sep1($._expression, ','), optional(','))),
+      ']',
+    ),
+
+    map_literal: $ => seq(
+      '{',
+      sep1(seq(field('key', $._expression), ':', field('value', $._expression)), ','),
+      optional(','),
+      '}',
+    ),
+
+    set_literal: $ => choice(
+      seq('{', '}'),                                    // empty (also empty-map; parser decides)
+      seq('{', sep1($._expression, ','), optional(','), '}'),
+    ),
+
+    /* =====================================================================
+     * Literals
+     * ===================================================================*/
+    // `Unit` is a type name only (used in `-> Unit`, `Result<Unit, _>`),
+    // never a value-level literal — the singleton unit value cannot be
+    // written directly in source. Keep it out of `_literal` and let the
+    // type rule pick it up via `primitive_type`.
+    _literal: $ => choice(
+      $.integer_literal,
+      $.float_literal,
+      $.string_literal,
+      $.regex_literal,
+      $.boolean_literal,
+      $.none_literal,
+    ),
+
+    boolean_literal: $ => choice('true', 'false'),
+    none_literal:    $ => 'none',
+
+    /* ------- Integer ------- */
+    integer_literal: $ => token(seq(
+      choice(
+        /[0-9][0-9_]*/,
+        /0x[0-9a-fA-F][0-9a-fA-F_]*/,
+        /0b[01][01_]*/,
+      ),
+      optional(choice('i8','i16','i32','i64','u8','u16','u32','u64')),
+    )),
+
+    /* ------- Float ------- */
+    float_literal: $ => token(seq(
+      choice(
+        seq(/[0-9][0-9_]*/, '.', /[0-9][0-9_]*/, optional(/[eE][+-]?[0-9][0-9_]*/)),
+        seq(/[0-9][0-9_]*/, /[eE][+-]?[0-9][0-9_]*/),
+      ),
+      optional(choice('f32', 'f64')),
+    )),
+
+    /* ------- String -------
+     * Standard double-quoted with escapes. Single-line only (no raw multi-line). */
+    string_literal: $ => token(seq(
+      '"',
+      repeat(choice(
+        /[^"\\\n]/,
+        seq('\\', choice(
+          /[ntr0\\"']/,
+          /x[0-9a-fA-F]{2}/,
+          /u\{[0-9a-fA-F]+\}/,
+        )),
+      )),
+      '"',
+    )),
+
+    /* ------- Regex -------
+     * `/pattern/flags`. Conflicts with `/` (division) — the external
+     * scanner emits `_regex_literal` only when the parser state is
+     * compatible with starting an expression. */
+    regex_literal: $ => $._regex_literal,
+
+    /* ------- f-string -------
+     * The lexer (lexer.hpp / lexer.cpp readFStringSegment) emits three
+     * specialized tokens for f-strings. The external scanner tracks
+     * brace depth across `{...}` interpolations so closing `}` of the
+     * interpolation can resume f-string lexing rather than ending a
+     * map/set/block. */
+    f_string: $ => seq(
+      $._fstring_start,
+      optional(seq(
+        $._expression,
+        repeat(seq($._fstring_mid, $._expression)),
+      )),
+      $._fstring_end,
+    ),
+
+    /* =====================================================================
+     * Identifier & comment
+     * ===================================================================*/
+
+    /* Trailing `!` is greedily absorbed for mutating method names
+     * (sort!, append!, reverse!, clear!). The lexer excludes `!=` from
+     * this absorption (parser-conventions.md, #1211/#1568). */
+    identifier: $ => token(seq(
+      /[a-zA-Z_][a-zA-Z0-9_]*/,
+      optional('!'),
+    )),
+
+    comment: $ => token(seq('#', /.*/)),
+  },
+});
+
+/* =====================================================================
+ * Helpers
+ * ===================================================================*/
+function sep1(rule, separator) {
+  return seq(rule, repeat(seq(separator, rule)));
+}

--- a/editor/tree-sitter/install.sh
+++ b/editor/tree-sitter/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Neovim の parser / queries ディレクトリに ry.so と highlights.scm を配置する。
+#
+#   ry.so            -> $XDG_CONFIG_HOME/nvim/parser/ry.so
+#   highlights.scm   -> $XDG_CONFIG_HOME/nvim/queries/ry/highlights.scm
+#
+# Usage:
+#   ./install.sh        # ry.so が無ければ自動で build.sh を呼ぶ
+#   ./install.sh --no-build  # ビルドをスキップして既存の ry.so をコピーする
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+NVIM_CONFIG="${XDG_CONFIG_HOME:-$HOME/.config}/nvim"
+PARSER_DIR="$NVIM_CONFIG/parser"
+QUERIES_DIR="$NVIM_CONFIG/queries/ry"
+
+DO_BUILD=1
+for arg in "$@"; do
+  case "$arg" in
+    --no-build) DO_BUILD=0 ;;
+    -h|--help)
+      sed -n '3,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$DO_BUILD" -eq 1 ]]; then
+  echo "==> building ry.so via ./build.sh"
+  ./build.sh
+fi
+
+if [[ ! -f ry.so ]]; then
+  echo "ERROR: ry.so not found. Run ./build.sh first or omit --no-build." >&2
+  exit 1
+fi
+
+if [[ ! -f queries/highlights.scm ]]; then
+  echo "ERROR: queries/highlights.scm not found." >&2
+  exit 1
+fi
+
+echo "==> mkdir -p $PARSER_DIR $QUERIES_DIR"
+mkdir -p "$PARSER_DIR" "$QUERIES_DIR"
+
+echo "==> install ry.so -> $PARSER_DIR/ry.so"
+install -m 0755 ry.so "$PARSER_DIR/ry.so"
+
+echo "==> install queries/highlights.scm -> $QUERIES_DIR/highlights.scm"
+install -m 0644 queries/highlights.scm "$QUERIES_DIR/highlights.scm"
+
+echo "==> done"
+ls -la "$PARSER_DIR/ry.so" "$QUERIES_DIR/highlights.scm"

--- a/editor/tree-sitter/queries/highlights.scm
+++ b/editor/tree-sitter/queries/highlights.scm
@@ -1,0 +1,163 @@
+; tree-sitter-ry highlight queries
+;
+; Capture names follow nvim-treesitter / Helix conventions.
+; Reorder/edit per editor preference; later captures override earlier ones.
+
+; ---------- Comments ----------
+(comment) @comment
+
+; ---------- Literals ----------
+(integer_literal) @number
+(float_literal)   @number.float
+(string_literal)  @string
+(regex_literal)   @string.regexp
+(boolean_literal) @boolean
+(none_literal)    @constant.builtin
+
+; F-string interpolation: outer quotes/braces are part of the literal,
+; inner expressions are expressions and inherit their own captures.
+(f_string) @string
+
+; ---------- Keywords ----------
+[
+  "import"
+  "from"
+] @keyword.import
+
+[
+  "fn"
+  "record"
+  "enum"
+  "type"
+] @keyword
+
+"return" @keyword.return
+
+[
+  "if"
+  "else"
+  "case"
+] @keyword.conditional
+
+[
+  "for"
+  "while"
+  "in"
+] @keyword.repeat
+
+(break_statement) @keyword.repeat
+(continue_statement) @keyword.repeat
+
+[
+  "and"
+  "or"
+  "not"
+  "as"
+] @keyword.operator
+
+[
+  "async"
+  "await"
+  "weak"
+] @keyword.modifier
+
+[
+  "require"
+  "ensure"
+  "invariant"
+  "expect"
+] @keyword
+
+; ---------- Types ----------
+(primitive_type) @type.builtin
+
+(named_type
+  (identifier) @type)
+
+; ---------- Functions ----------
+(function_declaration
+  name: (function_name (identifier) @function))
+
+(function_declaration
+  name: (function_name (operator_name) @function))
+
+(call_expression
+  function: (qualified_identifier (identifier) @function.call .))
+
+; Method-call style: x.foo(...) — capture the trailing field as the call.
+(call_expression
+  function: (field_access
+    field: (identifier) @function.method.call))
+
+(parameter
+  name: (identifier) @variable.parameter)
+
+(lambda_param
+  name: (identifier) @variable.parameter)
+
+; ---------- Decorators / attributes ----------
+(decorator
+  "@" @attribute
+  (identifier) @attribute)
+
+; ---------- Records / Enums ----------
+(record_declaration
+  name: (identifier) @type)
+
+(enum_declaration
+  name: (identifier) @type)
+
+(enum_variant
+  name: (identifier) @constructor)
+
+(record_field
+  name: (identifier) @property)
+
+(variant_field
+  name: (identifier) @property)
+
+(constructor_pattern
+  (qualified_identifier (identifier) @constructor .))
+
+; ---------- Field access ----------
+(field_access
+  field: (identifier) @property)
+
+; ---------- Identifiers ----------
+; Generic parameter names introduce types.
+(generic_parameters (identifier) @type)
+
+; Bindings and fallback identifiers as variables (after more-specific rules above).
+(binding_pattern (identifier) @variable)
+(identifier) @variable
+
+; ---------- Operators ----------
+[
+  "+" "-" "*" "/" "%"
+  "**" "//"
+  "==" "!=" "<" ">" "<=" ">="
+  "&" "|" "^" "~"
+  "<<" ">>" ">>>"
+  "??"
+  "=" "+=" "-=" "*=" "/=" "%=" "**=" "//="
+  "&=" "|=" "^=" "<<=" ">>="
+  "->" "=>"
+  ".."
+  "?"
+  "++"
+  "--"
+] @operator
+
+; ---------- Punctuation ----------
+[
+  "," ":" "." "::"
+] @punctuation.delimiter
+
+[
+  "(" ")"
+  "[" "]"
+  "{" "}"
+] @punctuation.bracket
+
+; ---------- Errors ----------
+(ERROR) @error

--- a/editor/tree-sitter/src/scanner.c
+++ b/editor/tree-sitter/src/scanner.c
@@ -1,0 +1,431 @@
+/*
+ * tree-sitter external scanner for Ry (v0.0.17)
+ *
+ * Implements the externals declared in grammar.js:
+ *
+ *   index 0: _indent          virtual block-open token (Python-style)
+ *   index 1: _dedent          virtual block-close token
+ *   index 2: _newline         virtual statement separator
+ *   index 3: _fstring_start   `f"...{`  segment
+ *   index 4: _fstring_mid     `}...{`   segment
+ *   index 5: _fstring_end     `}..."`   segment (or `f"..."` with no interp)
+ *   index 6: _regex_literal   `/pattern/`
+ *
+ * The grammar.js file references these as `$._indent` etc. tree-sitter
+ * matches them by ordinal index in the externals array.
+ *
+ * Behavior follows src/lexer.cpp from the ry-2 reference implementation:
+ *   - Indent stack tracks leading-space columns (tabs not used by Ry).
+ *   - Blank / comment-only lines do not change indent state.
+ *   - At EOF, all open blocks are closed by emitting DEDENTs.
+ *   - Regex `/pattern/` is emitted only when valid_symbols[REGEX_LITERAL] is
+ *     set — the parser turns this on at expression positions and off after
+ *     value-producing tokens, so `a / b` lexes as division correctly.
+ *   - F-string `f"..."` segments are split at every single `{` / `}`; doubled
+ *     braces `{{` / `}}` escape to a literal brace and stay inside the segment.
+ */
+
+#include "tree_sitter/parser.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum TokenType {
+  INDENT,
+  DEDENT,
+  NEWLINE,
+  FSTRING_START,
+  FSTRING_MID,
+  FSTRING_END,
+  REGEX_LITERAL,
+};
+
+#define MAX_INDENT_DEPTH 256
+
+typedef struct {
+  /* Indent stack: indents[0..indent_count-1] is the active sequence of
+   * column thresholds, smallest at index 0 (the implicit 0 is NOT stored;
+   * an empty stack means "at top level"). */
+  uint16_t indent_count;
+  uint16_t indents[MAX_INDENT_DEPTH];
+
+  /* Number of additional DEDENTs to emit on subsequent scan calls without
+   * advancing the lexer position. Used when one source-level dedent crosses
+   * multiple stack levels (e.g., closing two nested blocks at once). */
+  uint16_t pending_dedents;
+
+  /* True after the scanner has emitted a virtual NEWLINE at EOF without
+   * consuming any input character. Prevents infinite NEWLINE emission for
+   * grammars whose top-level rule accepts repeated NEWLINEs (e.g.
+   * `source_file: $ => repeat(choice($._newline, ...))`). Reset whenever
+   * a DEDENT is emitted (a new NEWLINE may be needed after the DEDENT to
+   * terminate an enclosing statement). */
+  bool emitted_eof_newline;
+} Scanner;
+
+/* --------------------------------------------------------------------
+ * tree-sitter lifecycle
+ * ------------------------------------------------------------------ */
+
+void *tree_sitter_ry_external_scanner_create(void) {
+  Scanner *s = (Scanner *)calloc(1, sizeof(Scanner));
+  return s;
+}
+
+void tree_sitter_ry_external_scanner_destroy(void *payload) {
+  free(payload);
+}
+
+unsigned tree_sitter_ry_external_scanner_serialize(void *payload, char *buffer) {
+  Scanner *s = (Scanner *)payload;
+  unsigned size = 0;
+
+  /* pending_dedents (1 byte; capped at 255 — practical depth limit). */
+  uint16_t pd = s->pending_dedents > 255 ? 255 : s->pending_dedents;
+  buffer[size++] = (char)pd;
+
+  /* emitted_eof_newline (1 byte). */
+  buffer[size++] = (char)(s->emitted_eof_newline ? 1 : 0);
+
+  /* indent_count (2 bytes, little-endian). */
+  buffer[size++] = (char)(s->indent_count & 0xFF);
+  buffer[size++] = (char)((s->indent_count >> 8) & 0xFF);
+
+  /* indents (2 bytes each). Truncate at the serialization buffer limit. */
+  for (uint16_t i = 0; i < s->indent_count; i++) {
+    if (size + 2 > TREE_SITTER_SERIALIZATION_BUFFER_SIZE) break;
+    uint16_t v = s->indents[i];
+    buffer[size++] = (char)(v & 0xFF);
+    buffer[size++] = (char)((v >> 8) & 0xFF);
+  }
+
+  return size;
+}
+
+void tree_sitter_ry_external_scanner_deserialize(void *payload,
+                                                 const char *buffer,
+                                                 unsigned length) {
+  Scanner *s = (Scanner *)payload;
+  s->indent_count = 0;
+  s->pending_dedents = 0;
+  s->emitted_eof_newline = false;
+
+  if (length == 0) return;
+
+  unsigned off = 0;
+  s->pending_dedents = (uint8_t)buffer[off++];
+
+  if (off >= length) return;
+  s->emitted_eof_newline = (buffer[off++] != 0);
+
+  if (off + 2 > length) return;
+  uint16_t lo = (uint8_t)buffer[off++];
+  uint16_t hi = (uint8_t)buffer[off++];
+  s->indent_count = (uint16_t)(lo | (hi << 8));
+  if (s->indent_count > MAX_INDENT_DEPTH) s->indent_count = MAX_INDENT_DEPTH;
+
+  for (uint16_t i = 0; i < s->indent_count; i++) {
+    if (off + 2 > length) {
+      s->indent_count = i;
+      break;
+    }
+    uint16_t l = (uint8_t)buffer[off++];
+    uint16_t h = (uint8_t)buffer[off++];
+    s->indents[i] = (uint16_t)(l | (h << 8));
+  }
+}
+
+/* --------------------------------------------------------------------
+ * lexer helpers
+ * ------------------------------------------------------------------ */
+
+static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
+static inline void skip(TSLexer *lexer) { lexer->advance(lexer, true); }
+
+/* --------------------------------------------------------------------
+ * Regex literal
+ *
+ * `/pattern/` — content is any char except unescaped `/` or newline.
+ * `\X` escape passes through verbatim (the runtime regex compiler validates
+ * the actual escape semantics; the lexer only needs to not terminate the
+ * literal on `\/`).
+ * ------------------------------------------------------------------ */
+
+static bool scan_regex(TSLexer *lexer) {
+  if (lexer->lookahead != '/') return false;
+  advance(lexer);  /* opening '/' */
+
+  bool empty = true;
+  while (lexer->lookahead != 0 &&
+         lexer->lookahead != '\n' && lexer->lookahead != '\r') {
+    if (lexer->lookahead == '/') break;
+    if (lexer->lookahead == '\\') {
+      advance(lexer);
+      if (lexer->lookahead == 0 ||
+          lexer->lookahead == '\n' || lexer->lookahead == '\r') {
+        return false;  /* unterminated escape */
+      }
+      advance(lexer);
+    } else {
+      advance(lexer);
+    }
+    empty = false;
+  }
+
+  if (lexer->lookahead != '/' || empty) return false;
+  advance(lexer);  /* closing '/' */
+  lexer->result_symbol = REGEX_LITERAL;
+  return true;
+}
+
+/* --------------------------------------------------------------------
+ * F-string segment
+ *
+ * Reads from current position (just past `f"` for is_start, just past `}`
+ * for continuation) until either:
+ *   - single `{` -> emit FSTRING_START / FSTRING_MID (interp follows)
+ *   - single `"` -> emit FSTRING_END (literal complete)
+ *
+ * `{{` / `}}` escape to literal brace and continue the segment.
+ * `\X` escape passes through (runtime validates actual semantics).
+ * Unmatched single `}` mid-segment is an error.
+ * Newline mid-segment is an error (no multi-line f-strings).
+ * ------------------------------------------------------------------ */
+
+static bool scan_fstring_segment(TSLexer *lexer, bool is_start) {
+  /* Continuation after an interpolation: the parser may call us with
+   * lookahead at the `}` that closes the prior interp (consume it,
+   * then read the trailing segment), OR with lookahead at `"` when
+   * the grammar's optional interp clause was not taken — i.e. an
+   * f-string with no interpolation at all (e.g. `f"hello"`). In the
+   * `"` case fall through and let the main loop emit FSTRING_END. */
+  if (!is_start && lexer->lookahead == '}') {
+    advance(lexer);
+  }
+  while (lexer->lookahead != 0) {
+    if (lexer->lookahead == '\n' || lexer->lookahead == '\r') {
+      return false;  /* unterminated f-string */
+    }
+    if (lexer->lookahead == '\\') {
+      advance(lexer);
+      if (lexer->lookahead == 0) return false;
+      advance(lexer);
+      continue;
+    }
+    if (lexer->lookahead == '{') {
+      advance(lexer);
+      if (lexer->lookahead == '{') {
+        advance(lexer);  /* `{{` -> literal `{` */
+        continue;
+      }
+      lexer->result_symbol = is_start ? FSTRING_START : FSTRING_MID;
+      return true;
+    }
+    if (lexer->lookahead == '}') {
+      advance(lexer);
+      if (lexer->lookahead == '}') {
+        advance(lexer);  /* `}}` -> literal `}` */
+        continue;
+      }
+      return false;  /* unmatched `}` in f-string */
+    }
+    if (lexer->lookahead == '"') {
+      if (is_start) {
+        /* Closing `"` reached without any interpolation. Don't consume it —
+         * leave it for the next scan to emit FSTRING_END. The current token
+         * is the FSTRING_START segment (`f"...`); the closing `"` is a
+         * separate FSTRING_END token per the grammar's
+         * seq(_fstring_start, ..., _fstring_end) shape. */
+        lexer->result_symbol = FSTRING_START;
+        return true;
+      }
+      advance(lexer);
+      lexer->result_symbol = FSTRING_END;
+      return true;
+    }
+    advance(lexer);
+  }
+  return false;  /* hit EOF before closing `"` */
+}
+
+/* --------------------------------------------------------------------
+ * Main scan
+ * ------------------------------------------------------------------ */
+
+bool tree_sitter_ry_external_scanner_scan(void *payload, TSLexer *lexer,
+                                          const bool *valid_symbols) {
+  Scanner *s = (Scanner *)payload;
+
+  /* 1. Drain any DEDENTs queued by a prior scan call. These are zero-width
+   *    and consume no characters. The indent stack was already popped in
+   *    full when the queue was created (see Case B); drain only emits the
+   *    queued tokens, it does NOT pop indents again. Emitting a DEDENT
+   *    re-arms eof-NEWLINE (any statement enclosing the just-closed block
+   *    may now need its terminating NEWLINE). */
+  if (s->pending_dedents > 0 && valid_symbols[DEDENT]) {
+    s->pending_dedents--;
+    s->emitted_eof_newline = false;
+    lexer->result_symbol = DEDENT;
+    return true;
+  }
+
+  /* 2. F-string continuation (after the parser consumed a `}` token,
+   *    lookahead is at the first char of the next segment). */
+  if ((valid_symbols[FSTRING_MID] || valid_symbols[FSTRING_END]) &&
+      lexer->lookahead != '{' && lexer->lookahead != 0) {
+    /* Don't intercept if lookahead is `{` — that's an empty interp `}{` which
+     * is a parse error anyway, but keep grammar-handled. In practice the
+     * parser arrives here only after a real `}` was consumed.
+     * NOTE: scan_fstring_segment must succeed unconditionally here because
+     * the grammar requires either FSTRING_MID or FSTRING_END to follow the
+     * inner expression. */
+    return scan_fstring_segment(lexer, /* is_start */ false);
+  }
+
+  bool any_block_token = valid_symbols[INDENT] ||
+                         valid_symbols[DEDENT] ||
+                         valid_symbols[NEWLINE];
+  bool fstring_start_possible = valid_symbols[FSTRING_START];
+  bool regex_possible = valid_symbols[REGEX_LITERAL];
+
+  /* 3+4. Indent / Dedent / Newline, f-string opener, or regex literal.
+   *      If the parser doesn't want any of these, the scanner has nothing
+   *      to do — fall back to the internal lexer. The lookahead-based
+   *      checks (`f` for f-string, `/` for regex) cannot happen yet
+   *      because horizontal whitespace before the trigger char has not
+   *      been skipped (the parser may call us at the space before
+   *      `f"..."` in `= f"hello"`, or before `/regex/`); we re-check
+   *      after skipping. */
+  if (!any_block_token && !fstring_start_possible && !regex_possible)
+    return false;
+
+  /* Skip horizontal whitespace, newlines, blank lines, and comment-only
+   * lines. Track whether we crossed at least one newline — INDENT and
+   * NEWLINE require it; DEDENT can also fire without if a prior NEWLINE
+   * scan already consumed all newlines and left lookahead at content of
+   * an outer-level line. */
+  bool seen_newline = false;
+  for (;;) {
+    if (lexer->lookahead == ' ' || lexer->lookahead == '\t') {
+      skip(lexer);
+    } else if (lexer->lookahead == '\n') {
+      seen_newline = true;
+      skip(lexer);
+    } else if (lexer->lookahead == '\r') {
+      seen_newline = true;
+      skip(lexer);
+      if (lexer->lookahead == '\n') skip(lexer);
+    } else if (lexer->lookahead == '#') {
+      while (lexer->lookahead != 0 &&
+             lexer->lookahead != '\n' && lexer->lookahead != '\r') {
+        skip(lexer);
+      }
+    } else {
+      break;
+    }
+  }
+
+  /* Regex literal — only after whitespace skipping so that `= /pat/`
+   * (with the parser entering at the space) reaches `/`. scan_regex
+   * starts from the opening `/` and consumes through the closing `/`. */
+  if (regex_possible && lexer->lookahead == '/') {
+    if (scan_regex(lexer)) {
+      lexer->mark_end(lexer);
+      return true;
+    }
+    return false;
+  }
+
+  /* Mark the virtual token boundary at the first non-blank content (or EOF).
+   * INDENT/DEDENT/NEWLINE produce zero-width tokens at this position. */
+  lexer->mark_end(lexer);
+
+  uint32_t current_col;
+  bool at_eof = (lexer->lookahead == 0);
+  if (at_eof) {
+    current_col = 0;  /* EOF treated as logical column 0 to flush the stack */
+  } else {
+    current_col = lexer->get_column(lexer);
+  }
+
+  uint16_t top = s->indent_count > 0 ? s->indents[s->indent_count - 1] : 0;
+
+  /* Case A: deeper indent — open a new block. INDENT only after a newline
+   * and only when the parser actually wants one: mid-line indent jumps
+   * don't exist, and at EOF we should not push a new block we'll never
+   * close. */
+  if (current_col > top && seen_newline && valid_symbols[INDENT] && !at_eof) {
+    if (s->indent_count < MAX_INDENT_DEPTH) {
+      s->indents[s->indent_count++] = (uint16_t)current_col;
+    }
+    lexer->result_symbol = INDENT;
+    return true;
+  }
+
+  /* Case B: shallower indent — close one or more blocks. Does NOT require
+   * seen_newline because a prior scan may have consumed the newline as a
+   * NEWLINE token, leaving us mid-stream at the next line's content; we
+   * still need to close blocks down to the current column. */
+  if (current_col < top && valid_symbols[DEDENT]) {
+    uint16_t popped = 0;
+    while (s->indent_count > 0 &&
+           s->indents[s->indent_count - 1] > current_col) {
+      s->indent_count--;
+      popped++;
+    }
+    if (popped > 0) {
+      s->pending_dedents = (uint16_t)(popped - 1);
+      s->emitted_eof_newline = false;
+      lexer->result_symbol = DEDENT;
+      return true;
+    }
+  }
+
+  /* Case C: saw a newline (or hit EOF) and the parser wants a statement
+   * separator. Indent-aligned-or-mismatched is fine here — Cases A/B took
+   * priority for actual indent changes. */
+  if (seen_newline && valid_symbols[NEWLINE]) {
+    s->emitted_eof_newline = false;  /* real newline resets the eof guard */
+    lexer->result_symbol = NEWLINE;
+    return true;
+  }
+
+  /* Case D: virtual NEWLINE at EOF. Trailing statements that nest inside
+   * multi-line expressions (e.g. `return case x: ...`) need a `_newline`
+   * to terminate them after the inner block-form expression has consumed
+   * all available `\n` characters via its arms. Emit at most one such
+   * virtual NEWLINE per EOF position; the guard is reset by every DEDENT
+   * (each closed block exposes a new statement that may need terminating)
+   * and by every real NEWLINE elsewhere in the file. Without the guard a
+   * top-level rule like `repeat($._newline)` would request NEWLINE
+   * indefinitely. */
+  if (at_eof && valid_symbols[NEWLINE] && !s->emitted_eof_newline) {
+    s->emitted_eof_newline = true;
+    lexer->result_symbol = NEWLINE;
+    return true;
+  }
+
+  /* Case E: f-string opener — only reached when no block-token case fired
+   * AND the lookahead is `f` AND FSTRING_START is valid. The whitespace
+   * skip above leaves the position unchanged when the original lookahead
+   * was `f` (since `f` is not whitespace), so we can speculatively probe
+   * for `f"`. If the next char is not `"`, we've consumed `f` from the
+   * scanner's view but tree-sitter discards the consumed range on `false`
+   * return — the parser then falls back to its internal lexer at `f`. */
+  if (valid_symbols[FSTRING_START] && lexer->lookahead == 'f') {
+    advance(lexer);
+    if (lexer->lookahead != '"') return false;
+    advance(lexer);
+    if (!scan_fstring_segment(lexer, /* is_start */ true)) return false;
+    /* The mark_end above (before Case E) was for zero-width block tokens; it
+     * left the token end at 'f', so without re-marking after consuming the
+     * f-string opener the FSTRING_START token would be zero-width and the
+     * parser would re-read 'f' as an identifier. */
+    lexer->mark_end(lexer);
+    return true;
+  }
+
+  return false;
+}

--- a/editor/tree-sitter/tree-sitter.json
+++ b/editor/tree-sitter/tree-sitter.json
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://tree-sitter.github.io/tree-sitter/assets/schemas/config.schema.json",
+  "grammars": [
+    {
+      "name": "ry",
+      "camelcase": "Ry",
+      "title": "Ry",
+      "scope": "source.ry",
+      "file-types": [
+        "ry"
+      ],
+      "injection-regex": "^ry$",
+      "class-name": "TreeSitterRy"
+    }
+  ],
+  "metadata": {
+    "version": "0.1.0",
+    "license": "MIT",
+    "description": "Ry grammar for tree-sitter",
+    "authors": [
+      {
+        "name": "Takashi Yamashina",
+        "email": "takashi.yamashina@gmail.com",
+        "url": "t0k0sh1.io"
+      }
+    ],
+    "links": {
+      "repository": "https://github.com/t0k0sh1/ry.git",
+      "funding": ""
+    }
+  },
+  "bindings": {
+    "c": true,
+    "go": false,
+    "java": false,
+    "node": false,
+    "python": false,
+    "rust": false,
+    "swift": false,
+    "zig": false
+  }
+}

--- a/editor/tree-sitter/tree-sitter.json
+++ b/editor/tree-sitter/tree-sitter.json
@@ -21,7 +21,7 @@
       {
         "name": "Takashi Yamashina",
         "email": "takashi.yamashina@gmail.com",
-        "url": "t0k0sh1.io"
+        "url": "https://t0k0sh1.io"
       }
     ],
     "links": {


### PR DESCRIPTION
## Summary

- Imports the tree-sitter grammar from the standalone `tree-sitter-ry` repository into a new editor-agnostic layout: `docs/grammar.ebnf` becomes the canonical grammar specification (single source of truth), and `editor/tree-sitter/` is the first concrete editor sub-tree (`grammar.js`, `src/scanner.c`, `queries/highlights.scm`, `tree-sitter.json`, `build.sh`, `install.sh`, `README.md`).
- Generated artifacts (`parser.c`, `grammar.json`, `node-types.json`, `tree_sitter/*.h`, `bindings/`, `node_modules/`) are excluded by a scoped `editor/tree-sitter/.gitignore`. Binary suffixes (`*.so`, `*.dylib`, `*.a`, `*.o`) keep their existing exclusion in the repository-root `.gitignore`.
- Misplaced tree-sitter outputs that had appeared under `src/` (untracked) are removed; the `src/` tree stays clean for ry's C++ runtime.

## Verification

- `cd editor/tree-sitter && ./build.sh` reproduces `ry.so` (216k) end-to-end (tree-sitter CLI 0.26.8, GNU `gcc-15`).
- `tree-sitter parse` over a 6-sample probe (1 non-test `share/std/runtime_internal/runtime_internal.ry` + 5 representative `tests/spec/*.test.ry`):
  - 5/6 OK: `runtime_internal.ry`, `builtins.test.ry`, `strings.test.ry`, `regex_literal.test.ry`, `fstring_closure_capture.test.ry`. The post-v0.0.17 `@describe` / `@it` annotation migration is covered.
  - 1/6 FAIL: `tests/spec/records.test.ry` produces `(ERROR ...)` nodes around the explicit-discriminant enum form (`enum HttpStatus: Ok = 200 ...`). This is grammar-side coverage drift, out of scope for this issue. Recorded under #1617 (Phase 1 smoke harness) as an `expected-fail.txt` candidate; no new issue opened to avoid duplication.
- `git status` after a fresh `./build.sh` confirms generated outputs are not listed as untracked — the scoped `.gitignore` is effective.

## Pre-commit checklist skip log

The change touches only `docs/`, `editor/`, `changelog.d/`, and the new scoped `.gitignore`; no C++ source / runtime / build / test code is modified.

- Skipped §3 (full tests) — no C++ source / runtime / build / test change.
- Skipped §3.5 (sanitizers) — same as §3.
- Skipped §3.5.5 (static analysis) — clang-tidy / cppcheck targets unchanged.
- Skipped §3.6 (libFuzzer) — no parser/lexer/json/utf8/string change.

## Test plan

- [ ] `cd editor/tree-sitter && ./build.sh` reproduces `ry.so` from a clean checkout.
- [ ] `tree-sitter parse share/std/runtime_internal/runtime_internal.ry` succeeds without `(ERROR` / `MISSING`.
- [ ] `git status --short` after `./build.sh` lists no extra untracked files under `editor/tree-sitter/`.

Closes #1614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added formal Ry language grammar specification in EBNF
  * Added comprehensive tree-sitter integration and setup guides, including reproducible build/install instructions and usage notes

* **New Features**
  * Integrated tree-sitter support for improved editor experience: syntax highlighting, indentation handling, f-string and regex handling, and more accurate parsing of language constructs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->