### PR TITLE
feat(loader,parser): allow `from testing import expect/mock/verify/fail/it/describe` (#712)

### DIFF
--- a/changelog.d/712-testing-intrinsic-import.md
+++ b/changelog.d/712-testing-intrinsic-import.md
@@ -1,0 +1,13 @@
+### Added
+
+- Allowed `from testing import expect / mock / verify / fail / it /
+  describe` by introducing a compiler-intrinsic allow-list in
+  `ModuleLoader` and permitting the `expect` keyword (the only
+  intrinsic that lexes as a reserved token, used elsewhere by the
+  matcher statement form) at the import-name position in the parser.
+  Wildcard `from testing` is also recognized as importing all six
+  intrinsics. Names imported this way are exposed via
+  `ModuleLoader::importedTestingIntrinsics()` for the forthcoming
+  codegen-side enforcement (#713 / #715 / #716). Non-intrinsic names
+  still fail with the existing `'<name>' not found in module
+  'testing'` diagnostic. (#712)

--- a/include/ry/module_loader.hpp
+++ b/include/ry/module_loader.hpp
@@ -21,6 +21,18 @@ public:
 
     Program resolveImports(Program &prog, const std::string &referrer_dir);
 
+    // Names from `from testing import ...` (or wildcard `from testing`)
+    // observed during import resolution (#712). Populated lazily as
+    // `resolveImports` walks each `ImportStmt`, filtered to the testing
+    // intrinsic allow-list (`it / describe / expect / mock / verify / fail`)
+    // — declarations like `each / property` that live in `testing.ry`'s
+    // AST are tracked through the regular export path and excluded here.
+    // Consumers (#713/#715/#716) read this set to enforce that test
+    // sources explicitly import the intrinsics they reference.
+    const std::unordered_set<std::string> &importedTestingIntrinsics() const {
+        return imported_testing_intrinsics_;
+    }
+
 private:
     struct ResolvedPath {
         std::string path;
@@ -50,6 +62,10 @@ private:
     std::unordered_map<std::string, CanonicalEntry> canonical_cache_;
     // Cache: "module_path\0referrer_dir" -> resolved path + is_directory flag
     std::unordered_map<std::string, ResolvedPath> resolve_cache_;
+
+    // Names imported from the testing module via `from testing import ...`
+    // or `from testing` (wildcard). See `importedTestingIntrinsics()`.
+    std::unordered_set<std::string> imported_testing_intrinsics_;
 
     // Cached fs::canonical — populates ec with original error on failure
     std::string cachedCanonical(const std::string &raw, std::error_code &ec);

--- a/include/ry/module_loader.hpp
+++ b/include/ry/module_loader.hpp
@@ -37,6 +37,12 @@ private:
     struct ResolvedPath {
         std::string path;
         bool is_directory = false;
+        // True only when the module was found in `search_paths_` (the stdlib
+        // search roots), not in `referrer_dir`. Used by the testing-intrinsic
+        // allow-list (#712) to ensure a project-local `testing.ry` shadow does
+        // not silently bypass the `'<name>' not found` diagnostic for the six
+        // intrinsic names.
+        bool from_stdlib = false;
     };
     std::vector<std::string> search_paths_;
     SourceManager *sm_ = nullptr;

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -70,9 +70,15 @@ static const std::unordered_set<std::string> &testingIntrinsics() {
     return kSet;
 }
 
-static bool isTestingIntrinsic(const std::string &module_path,
+// Gate the intrinsic bypass on `from_stdlib` so a project-local `testing.ry`
+// shadow (resolved via `referrer_dir`) does NOT silently absorb the six
+// intrinsic names. Only the stdlib testing module gets the bypass; a local
+// shadow continues to fail with the existing `'<name>' not found` diagnostic.
+static bool isTestingIntrinsic(bool from_stdlib,
+                               const std::string &module_path,
                                const std::string &name) {
-    return module_path == "testing" && testingIntrinsics().count(name) > 0;
+    return from_stdlib && module_path == "testing" &&
+           testingIntrinsics().count(name) > 0;
 }
 
 // Returns true when the definition carries an `@public` directive.
@@ -115,7 +121,7 @@ static bool isPublicDefinition(const StmtNode &stmt) {
 static void extractDefinitions(Program &source, Program &dest,
                                 const std::vector<std::string> &requested_names,
                                 const std::string &import_path, int line,
-                                bool cross_package,
+                                bool cross_package, bool from_stdlib,
                                 std::unordered_map<std::string, bool> *out_names = nullptr) {
     // REQ-B3 (#1560): code availability is decoupled from name visibility.
     // Every exportable definition is copied to the importer's program so a
@@ -137,7 +143,7 @@ static void extractDefinitions(Program &source, Program &dest,
     for (const auto &name : requested_names) {
         auto it = found.find(name);
         if (it == found.end()) {
-            if (isTestingIntrinsic(import_path, name)) continue;
+            if (isTestingIntrinsic(from_stdlib, import_path, name)) continue;
             std::string detail = "'";
             detail += name;
             detail += "' not found in module '";
@@ -222,7 +228,8 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
     }
 
     auto try_resolve = [&](const std::string &dir,
-                           const std::string &rel_path) -> ResolvedPath {
+                           const std::string &rel_path,
+                           bool from_stdlib) -> ResolvedPath {
         std::error_code ec;
         std::string base_str = cachedCanonical(dir, ec);
         if (ec) return {};
@@ -239,7 +246,7 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
         if (fs::is_directory(dir_candidate)) {
             std::string resolved = cachedCanonical(dir_candidate);
             if (resolved.empty() || !is_within_base(resolved)) return {};
-            return {resolved, true};
+            return {resolved, /*is_directory=*/true, from_stdlib};
         }
 
         // 2. Single file (backward compatibility)
@@ -247,7 +254,7 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
         if (fs::is_regular_file(file_candidate)) {
             std::string resolved = cachedCanonical(file_candidate);
             if (resolved.empty() || !is_within_base(resolved)) return {};
-            return {resolved, false};
+            return {resolved, /*is_directory=*/false, from_stdlib};
         }
 
         return {};
@@ -274,7 +281,7 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
             return rp;
         }
         std::string rel = module_path.substr(2);
-        ResolvedPath result = try_resolve(referrer_dir, rel);
+        ResolvedPath result = try_resolve(referrer_dir, rel, /*from_stdlib=*/false);
         if (!result.path.empty()) {
             if (ry::traceEnabled()) emitTraceEvent("import.resolve.hit", "compile", &loc,
                            {TraceField("module_path", module_path),
@@ -289,7 +296,7 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
     }
 
     // Absolute import: search referrer_dir first, then search_paths
-    ResolvedPath result = try_resolve(referrer_dir, module_path);
+    ResolvedPath result = try_resolve(referrer_dir, module_path, /*from_stdlib=*/false);
     if (!result.path.empty()) {
         if (ry::traceEnabled()) emitTraceEvent("import.resolve.hit", "compile", &loc,
                        {TraceField("module_path", module_path),
@@ -299,7 +306,7 @@ ModuleLoader::ResolvedPath ModuleLoader::resolve(const std::string &module_path,
     }
 
     for (const auto &dir : search_paths_) {
-        result = try_resolve(dir, module_path);
+        result = try_resolve(dir, module_path, /*from_stdlib=*/true);
         if (!result.path.empty()) {
             if (ry::traceEnabled()) emitTraceEvent("import.resolve.hit", "compile", &loc,
                            {TraceField("module_path", module_path),
@@ -418,6 +425,7 @@ Program ModuleLoader::loadModuleDir(const std::string &abs_dir_path) {
         // each definition's is_public flag for later same-vs-cross-package
         // decisions made at the import site.
         extractDefinitions(sub_prog, collected, {}, "", 0, /*cross_package=*/false,
+                           /*from_stdlib=*/false,
                            &exports_cache_[file_path]);
     }
 
@@ -435,14 +443,15 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
 
         auto &imp = std::get<ImportStmt>(stmt);
 
-        // Record testing-module intrinsics observed in the import statement.
-        // Done after parsing of the ImportStmt and before any resolve work:
-        // the set semantics make this idempotent across cache hits and
-        // first-loads, and a downstream throw never strands "not actually
-        // imported" entries here because non-intrinsic names (e.g. `xyz`
-        // in `from testing import xyz`) are filtered out by the allow-list
-        // membership check.
-        if (imp.module_path == "testing") {
+        ResolvedPath rp = resolve(imp.module_path, referrer_dir);
+        const std::string &abs_path = rp.path;
+
+        // Record testing-module intrinsics observed in the import statement
+        // ONLY when the import resolved to the stdlib testing module. A
+        // project-local `testing.ry` shadow must continue to fail with the
+        // existing `'<name>' not found in module 'testing'` diagnostic — its
+        // intrinsic names are not implicitly imported here either.
+        if (rp.from_stdlib && imp.module_path == "testing") {
             if (imp.names.empty()) {
                 for (const auto &name : testingIntrinsics())
                     imported_testing_intrinsics_.insert(name);
@@ -453,9 +462,6 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                 }
             }
         }
-
-        ResolvedPath rp = resolve(imp.module_path, referrer_dir);
-        const std::string &abs_path = rp.path;
 
         std::string target_dir = rp.is_directory ? abs_path
                                                  : fs::path(abs_path).parent_path().string();
@@ -470,7 +476,7 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                 for (const auto &name : imp.names) {
                     auto it = exports.find(name);
                     if (it == exports.end()) {
-                        if (isTestingIntrinsic(imp.module_path, name)) continue;
+                        if (isTestingIntrinsic(rp.from_stdlib, imp.module_path, name)) continue;
                         std::string detail = "'";
                         detail += name;
                         detail += "' not found in module '";
@@ -498,7 +504,8 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
             loaded_.insert(abs_path);
 
             extractDefinitions(dir_prog, result, imp.names, imp.module_path,
-                               imp.loc.line, cross_package, &exports_cache_[abs_path]);
+                               imp.loc.line, cross_package, rp.from_stdlib,
+                               &exports_cache_[abs_path]);
         } else {
             loading_.insert(abs_path);
             auto sub_prog = loadAndParse(abs_path, sm_);
@@ -508,7 +515,8 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
             loaded_.insert(abs_path);
 
             extractDefinitions(sub_prog, result, imp.names, imp.module_path,
-                               imp.loc.line, cross_package, &exports_cache_[abs_path]);
+                               imp.loc.line, cross_package, rp.from_stdlib,
+                               &exports_cache_[abs_path]);
         }
     }
 

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -56,6 +56,25 @@ static std::string makeImportError(int line, const std::string &detail) {
     return msg;
 }
 
+// Compiler intrinsics exposed by the testing module (#712). These are not
+// declared in `share/std/testing/testing.ry` because they are matched and
+// emitted directly by codegen (`expect <expr> <matcher>` is a parser-level
+// statement form; `mock` / `verify` / `fail` and the directives `it` /
+// `describe` are handled at codegen). Listing them here lets
+// `from testing import expect / mock / verify / fail / it / describe` resolve
+// without producing AST nodes — the allow-list bypass below skips the
+// `'<name>' not found` throw without altering anything else.
+static const std::unordered_set<std::string> &testingIntrinsics() {
+    static const std::unordered_set<std::string> kSet = {
+        "it", "describe", "expect", "mock", "verify", "fail"};
+    return kSet;
+}
+
+static bool isTestingIntrinsic(const std::string &module_path,
+                               const std::string &name) {
+    return module_path == "testing" && testingIntrinsics().count(name) > 0;
+}
+
 // Returns true when the definition carries an `@public` directive.
 static bool isPublicDefinition(const StmtNode &stmt) {
     auto check = [](const std::vector<Directive> &directives) -> bool {
@@ -118,6 +137,7 @@ static void extractDefinitions(Program &source, Program &dest,
     for (const auto &name : requested_names) {
         auto it = found.find(name);
         if (it == found.end()) {
+            if (isTestingIntrinsic(import_path, name)) continue;
             std::string detail = "'";
             detail += name;
             detail += "' not found in module '";
@@ -414,6 +434,26 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
         }
 
         auto &imp = std::get<ImportStmt>(stmt);
+
+        // Record testing-module intrinsics observed in the import statement.
+        // Done after parsing of the ImportStmt and before any resolve work:
+        // the set semantics make this idempotent across cache hits and
+        // first-loads, and a downstream throw never strands "not actually
+        // imported" entries here because non-intrinsic names (e.g. `xyz`
+        // in `from testing import xyz`) are filtered out by the allow-list
+        // membership check.
+        if (imp.module_path == "testing") {
+            if (imp.names.empty()) {
+                for (const auto &name : testingIntrinsics())
+                    imported_testing_intrinsics_.insert(name);
+            } else {
+                for (const auto &name : imp.names) {
+                    if (testingIntrinsics().count(name) > 0)
+                        imported_testing_intrinsics_.insert(name);
+                }
+            }
+        }
+
         ResolvedPath rp = resolve(imp.module_path, referrer_dir);
         const std::string &abs_path = rp.path;
 
@@ -430,6 +470,7 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                 for (const auto &name : imp.names) {
                     auto it = exports.find(name);
                     if (it == exports.end()) {
+                        if (isTestingIntrinsic(imp.module_path, name)) continue;
                         std::string detail = "'";
                         detail += name;
                         detail += "' not found in module '";

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -398,14 +398,18 @@ StmtNode Parser::parseImportStatement() {
     if (lex_.peek().kind == TokenKind::Import) {
         lex_.next(); // consume 'import'
         Token name = lex_.peek();
-        if (name.kind != TokenKind::Ident)
+        // `expect` is the only keyword (TokenKind::Expect) accepted as an
+        // import name; it names the testing intrinsic exposed via
+        // `from testing import expect` (#712). All other keywords remain
+        // rejected at this position.
+        if (name.kind != TokenKind::Ident && name.kind != TokenKind::Expect)
             parseError(name.line, "expected function name after 'import'");
         names.push_back(lex_.next().value);
 
         while (lex_.peek().kind == TokenKind::Comma) {
             lex_.next(); // consume ','
             Token next = lex_.peek();
-            if (next.kind != TokenKind::Ident)
+            if (next.kind != TokenKind::Ident && next.kind != TokenKind::Expect)
                 parseError(next.line, "expected function name after ','");
             names.push_back(lex_.next().value);
         }

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -730,6 +730,20 @@ protected:
         ModuleLoader loader(search_paths);
         return loader.resolveImports(prog, dir);
     }
+
+    std::unordered_set<std::string> resolveAndGetTestingIntrinsics(
+        const std::string &src,
+        const std::string &referrer_dir = "",
+        const std::vector<std::string> &search_paths = {}) {
+        Lexer lex(src);
+        Parser parser(lex);
+        Program prog = parser.parseProgram();
+
+        std::string dir = referrer_dir.empty() ? tmp_dir_.string() : referrer_dir;
+        ModuleLoader loader(search_paths);
+        loader.resolveImports(prog, dir);
+        return loader.importedTestingIntrinsics();
+    }
 };
 
 TEST_F(ImportTest, ImportBasics) {
@@ -1351,6 +1365,142 @@ TEST_F(ImportTest, ImportedDirectiveValidatesAtUseSite) {
         "    return 7\n"
         "print(targetFn())\n"),
         "7\n");
+}
+
+// ===== testing module intrinsic import allow-list (#712) =====
+//
+// `from testing import expect / mock / verify / fail` references compiler
+// intrinsics that have no AST declaration in `share/std/testing/testing.ry`
+// (only `it / describe / each / property` are declared there). The loader
+// must whitelist the intrinsic names for the testing module so the named
+// import does not fail at the "not found in module" check.
+
+namespace {
+// Derive the repo's share/std path from the test source location so the
+// loader can find `testing/testing.ry` regardless of the build cwd.
+inline std::string testingStdlibSearchPath() {
+    return (std::filesystem::path(__FILE__).parent_path().parent_path()
+            / "share" / "std").string();
+}
+} // namespace
+
+// AC #1: `from testing import expect` resolves and `expect` does not appear
+// in the AST (it is a compiler intrinsic, not a declaration).
+TEST_F(ImportTest, FromTestingImportExpectResolves) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    Program prog = resolveImportsOnly(
+        "from testing import expect\n",
+        tmp_dir_.string(),
+        search_paths);
+
+    std::set<std::string> directive_names;
+    std::set<std::string> fn_names;
+    for (const auto &stmt : prog) {
+        if (std::holds_alternative<DirectiveDefStmt>(stmt))
+            directive_names.insert(std::get<DirectiveDefStmt>(stmt).name);
+        if (std::holds_alternative<std::unique_ptr<FnStmt>>(stmt))
+            fn_names.insert(std::get<std::unique_ptr<FnStmt>>(stmt)->name);
+    }
+    // Intrinsics live in codegen, not AST.
+    EXPECT_EQ(directive_names.count("expect"), 0u);
+    EXPECT_EQ(fn_names.count("expect"), 0u);
+    // testing.ry's @directive declarations still flow through (REQ-B3 #1560).
+    EXPECT_EQ(directive_names.count("it"), 1u);
+    EXPECT_EQ(directive_names.count("describe"), 1u);
+}
+
+// AC #2: all six testing intrinsics (`it`, `describe`, `expect`, `mock`,
+// `verify`, `fail`) are accepted as named imports.
+TEST_F(ImportTest, FromTestingImportAllSixIntrinsicsResolve) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_NO_THROW({
+        resolveImportsOnly(
+            "from testing import it, describe, expect, mock, verify, fail\n",
+            tmp_dir_.string(),
+            search_paths);
+    });
+}
+
+// AC #2 (boundary): the cache-hit path in `resolveImports` (line ~427)
+// must apply the same intrinsic allow-list as the first-load path. Without
+// allow-list parity, a wildcard `from testing` followed by a named
+// `from testing import expect` throws on the second statement.
+TEST_F(ImportTest, FromTestingImportExpectViaCacheHit) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_NO_THROW({
+        resolveImportsOnly(
+            "from testing\n"
+            "from testing import expect\n",
+            tmp_dir_.string(),
+            search_paths);
+    });
+}
+
+// AC #4: a name that is neither a testing intrinsic nor a declared symbol
+// is still rejected with the "not found in module" diagnostic.
+TEST_F(ImportTest, FromTestingImportNonIntrinsicErrors) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    try {
+        resolveImportsOnly(
+            "from testing import xyz\n",
+            tmp_dir_.string(),
+            search_paths);
+        FAIL() << "Expected non-intrinsic name to be rejected";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("'xyz'"), std::string::npos) << msg;
+        EXPECT_NE(msg.find("not found in module"), std::string::npos) << msg;
+        EXPECT_NE(msg.find("'testing'"), std::string::npos) << msg;
+    }
+}
+
+TEST_F(ImportTest, FromTestingWildcardRecordsAllSixIntrinsics) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    auto intrinsics = resolveAndGetTestingIntrinsics(
+        "from testing\n",
+        tmp_dir_.string(),
+        search_paths);
+    std::unordered_set<std::string> expected = {
+        "it", "describe", "expect", "mock", "verify", "fail"};
+    EXPECT_EQ(intrinsics.size(), 6u);
+    EXPECT_EQ(intrinsics, expected);
+}
+
+TEST_F(ImportTest, FromTestingWildcardDoesNotLeakDirectiveDecls) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    auto intrinsics = resolveAndGetTestingIntrinsics(
+        "from testing\n",
+        tmp_dir_.string(),
+        search_paths);
+    EXPECT_EQ(intrinsics.count("each"), 0u);
+    EXPECT_EQ(intrinsics.count("property"), 0u);
+}
+
+TEST_F(ImportTest, FromTestingImportSingleIntrinsicRecordsOne) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    auto intrinsics = resolveAndGetTestingIntrinsics(
+        "from testing import expect\n",
+        tmp_dir_.string(),
+        search_paths);
+    std::unordered_set<std::string> expected = {"expect"};
+    EXPECT_EQ(intrinsics, expected);
+}
+
+TEST_F(ImportTest, FromTestingImportMultipleIntrinsicsRecordsAll) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    auto intrinsics = resolveAndGetTestingIntrinsics(
+        "from testing import expect, mock, verify, fail\n",
+        tmp_dir_.string(),
+        search_paths);
+    std::unordered_set<std::string> expected = {"expect", "mock", "verify", "fail"};
+    EXPECT_EQ(intrinsics, expected);
+}
+
+TEST_F(ImportTest, FromMathDoesNotPolluteTestingIntrinsics) {
+    writeFile("mathmod.ry", "fn add(a: int, b: int) -> int:\n    return a + b\n");
+    auto intrinsics = resolveAndGetTestingIntrinsics(
+        "from mathmod import add\n");
+    EXPECT_TRUE(intrinsics.empty());
 }
 
 // ===== type alias =====

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1454,6 +1454,45 @@ TEST_F(ImportTest, FromTestingImportNonIntrinsicErrors) {
     }
 }
 
+// Regression: a project-local `testing.ry` that shadows the stdlib testing
+// module must NOT silently absorb the intrinsic allow-list. `resolve()`
+// finds the local file via `referrer_dir` first, so `rp.from_stdlib` is
+// false and the bypass is gated off — the missing `expect` declaration
+// surfaces as the regular `'expect' not found in module 'testing'` error,
+// and `imported_testing_intrinsics_` is not polluted.
+TEST_F(ImportTest, FromLocalTestingShadowDoesNotBypassIntrinsicCheck) {
+    // Local `testing.ry` declares no `expect` / etc.
+    writeFile("testing.ry", "fn unrelated() -> int:\n    return 1\n");
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    try {
+        resolveImportsOnly(
+            "from testing import expect\n",
+            tmp_dir_.string(),
+            search_paths);
+        FAIL() << "Expected local testing shadow to reject 'expect' as "
+                  "not found";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("'expect'"), std::string::npos) << msg;
+        EXPECT_NE(msg.find("not found in module"), std::string::npos) << msg;
+        EXPECT_NE(msg.find("'testing'"), std::string::npos) << msg;
+    }
+}
+
+// Regression mirror: the wildcard-import recording path must also be gated
+// on `from_stdlib`. A local shadow of `testing` must leave
+// `imported_testing_intrinsics_` empty even on wildcard `from testing`.
+TEST_F(ImportTest, FromLocalTestingShadowDoesNotPolluteIntrinsicSet) {
+    writeFile("testing.ry", "fn unrelated() -> int:\n    return 1\n");
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    auto intrinsics = resolveAndGetTestingIntrinsics(
+        "from testing\n",
+        tmp_dir_.string(),
+        search_paths);
+    EXPECT_TRUE(intrinsics.empty())
+        << "local testing.ry shadow should not record stdlib intrinsics";
+}
+
 TEST_F(ImportTest, FromTestingWildcardRecordsAllSixIntrinsics) {
     auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
     auto intrinsics = resolveAndGetTestingIntrinsics(

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -792,6 +792,44 @@ TEST(ParserTest, ImportParentDirError) {
     EXPECT_THROW(parseStr("from .. import add"), std::runtime_error);
 }
 
+// `expect` is the only Ry keyword (TokenKind::Expect) accepted at the
+// import-name position; it names the testing intrinsic exposed by
+// `from testing import expect` (#712). Other keywords are still rejected
+// here, including `fn` (TokenKind::Fn). The pair below locks both halves
+// of the narrow widening so a future relaxation that accidentally allows
+// any keyword at this position is caught.
+TEST(ParserTest, ImportExpectKeywordAccepted) {
+    Program prog = parseStr("from testing import expect");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<ImportStmt>(prog[0]));
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    EXPECT_EQ(imp.module_path, "testing");
+    ASSERT_EQ(imp.names.size(), 1u);
+    EXPECT_EQ(imp.names[0], "expect");
+}
+
+TEST(ParserTest, ImportFnKeywordRejected) {
+    try {
+        parseStr("from testing import fn");
+        FAIL() << "Expected parser to reject 'fn' at import-name position";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("expected function name after 'import'"), std::string::npos)
+            << "Error message should match the import-name diagnostic: " << msg;
+    }
+}
+
+TEST(ParserTest, ImportFnKeywordRejectedAfterComma) {
+    try {
+        parseStr("from testing import expect, fn");
+        FAIL() << "Expected parser to reject 'fn' after comma in import list";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("expected function name after ','"), std::string::npos)
+            << "Error message should match the post-comma import-name diagnostic: " << msg;
+    }
+}
+
 TEST(ParserTest, DuplicateFieldNameThrows) {
     EXPECT_THROW(parseStr("record Point:\n    x: int\n    x: int"), std::runtime_error);
 }


### PR DESCRIPTION
## Summary

- `ModuleLoader` で testing module の compiler intrinsic allow-list (`it / describe / expect / mock / verify / fail`) を導入。`extractDefinitions` (first-load) と `resolveImports` (cache hit) の両経路で intrinsic 名を AST 不在のまま resolve できる
- `src/parser.cpp` で `TokenKind::Expect` を import 名位置 (2 箇所) で受理。`expect` は intrinsic の中で唯一 reserved token (matcher statement 構文用) のため必要な surgical change。他の keyword (`fn` 等) は引き続き reject
- `ModuleLoader::importedTestingIntrinsics()` getter を追加し、後続の CodeGen 側 enforcement (#713 / #715 / #716) が import された intrinsic 名を読めるようにした
- 非 intrinsic 名 (`from testing import xyz` 等) は既存の `'<name>' not found in module 'testing'` 診断で引き続き reject

Closes #712

## Test plan

- [x] C++ unit tests: `ImportTest` 9 cases (positive / cache-hit boundary / wildcard / leak check / API / non-pollution) + `ParserTest` 3 cases (`expect` 受理 / `fn` 拒否 / comma 後の `fn` 拒否)
- [x] `./build/ry_tests` (2129 tests pass)
- [x] `./build/ry test -p` (Ry self-test 全 pass)
- [x] ASan + UBSan: `./build-asan/ry_tests` + `ry test -p` clean
- [x] TSan: `./build-tsan/ry_tests` clean
- [x] clang-tidy + cppcheck: exit 0
- [x] libFuzzer `fuzz_parser` 60 秒 / 42855 runs / no crash
- [x] smoke test: `./build/ry test` で `from testing import expect` を含む .test.ry が compile + run 確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support importing testing intrinsics (expect, mock, verify, fail, it, describe) from the testing module with allow-list handling and proper import validation.
* **Parser**
  * Parser now accepts the testing intrinsic keyword (e.g., expect) in import-name positions while still rejecting invalid reserved names.
* **Tests**
  * Added comprehensive tests covering named and wildcard testing imports, cross-package cases, and cache behavior.
* **Documentation**
  * New changelog entry documenting the testing intrinsics import behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->