### PR TITLE
feat(editor/tree-sitter): add indents.scm and install it for Neovim (#1620)

### DIFF
--- a/changelog.d/1620-tree-sitter-indents.md
+++ b/changelog.d/1620-tree-sitter-indents.md
@@ -2,7 +2,7 @@
 
 - Added `editor/tree-sitter/queries/indents.scm` with the
   nvim-treesitter rewrite capture vocabulary (`@indent.begin` /
-  `@indent.branch`) so Neovim 0.12+ users get tree-sitter driven
+  `@indent.branch`) so Neovim 0.12+ users get tree-sitter-driven
   auto-indent / auto-dedent for `.ry` files: `<CR>` after `fn foo():`
   / `if cond:` bumps +1 indent, `else` / `else if` on its own line
   dedents to the parent `if`, and `]` / `}` / `)` on its own line

--- a/changelog.d/1620-tree-sitter-indents.md
+++ b/changelog.d/1620-tree-sitter-indents.md
@@ -1,0 +1,19 @@
+### Added
+
+- Added `editor/tree-sitter/queries/indents.scm` with the
+  nvim-treesitter rewrite capture vocabulary (`@indent.begin` /
+  `@indent.branch`) so Neovim 0.12+ users get tree-sitter driven
+  auto-indent / auto-dedent for `.ry` files: `<CR>` after `fn foo():`
+  / `if cond:` bumps +1 indent, `else` / `else if` on its own line
+  dedents to the parent `if`, and `]` / `}` / `)` on its own line
+  returns to the opener's column. Multi-element tuples, list / map /
+  set literals, and call / index argument lists are also handled.
+  Known limitation: a parenthesized single expression spanning multiple
+  lines (e.g. `s = (\n  1\n  + 2\n)`) is parsed via the hidden
+  `_parenthesized` grammar rule, which tree-sitter inlines into the
+  parent and cannot be matched by capture queries — contents are not
+  bumped and the closing `)` does not auto-dedent.
+  `editor/tree-sitter/install.sh` now also deploys `indents.scm` to
+  `$XDG_CONFIG_HOME/nvim/queries/ry/indents.scm`. Enable per-buffer with
+  `vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"`.
+  (#1620)

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -80,7 +80,7 @@ Installs to:
 vocabulary (`@indent.begin` / `@indent.branch`), which requires
 **Neovim 0.12+** with the rewrite branch of
 [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
-installed. Enable tree-sitter driven indentation per `.ry` buffer with:
+installed. Enable tree-sitter-driven indentation per `.ry` buffer with:
 
 ```lua
 vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -18,7 +18,8 @@ editor/tree-sitter/
 │   └── scanner.c        # external scanner (INDENT/DEDENT/NEWLINE,
 │                        #   f-string segments, regex literals)
 ├── queries/
-│   └── highlights.scm   # tree-sitter highlight queries (tracked)
+│   ├── highlights.scm   # tree-sitter highlight queries (tracked)
+│   └── indents.scm      # tree-sitter indent queries (tracked)
 ├── tree-sitter.json     # tree-sitter CLI configuration
 ├── build.sh             # tree-sitter generate + build -> ry.so
 ├── install.sh           # copy ry.so + queries to Neovim parser dirs
@@ -73,6 +74,17 @@ Installs to:
 
 - `${XDG_CONFIG_HOME:-$HOME/.config}/nvim/parser/ry.so`
 - `${XDG_CONFIG_HOME:-$HOME/.config}/nvim/queries/ry/highlights.scm`
+- `${XDG_CONFIG_HOME:-$HOME/.config}/nvim/queries/ry/indents.scm`
+
+`indents.scm` uses the nvim-treesitter rewrite (main-branch) capture
+vocabulary (`@indent.begin` / `@indent.branch`), which requires
+**Neovim 0.12+** with the rewrite branch of
+[nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter)
+installed. Enable tree-sitter driven indentation per `.ry` buffer with:
+
+```lua
+vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+```
 
 Other editors are not yet supported in-tree; integrations may be added under
 `editor/<tool>/` as they appear.

--- a/editor/tree-sitter/install.sh
+++ b/editor/tree-sitter/install.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 #
-# Neovim の parser / queries ディレクトリに ry.so と highlights.scm を配置する。
+# Neovim の parser / queries ディレクトリに ry.so と queries を配置する。
 #
 #   ry.so            -> $XDG_CONFIG_HOME/nvim/parser/ry.so
 #   highlights.scm   -> $XDG_CONFIG_HOME/nvim/queries/ry/highlights.scm
+#   indents.scm      -> $XDG_CONFIG_HOME/nvim/queries/ry/indents.scm
 #
 # Usage:
 #   ./install.sh        # ry.so が無ければ自動で build.sh を呼ぶ
@@ -48,6 +49,11 @@ if [[ ! -f queries/highlights.scm ]]; then
   exit 1
 fi
 
+if [[ ! -f queries/indents.scm ]]; then
+  echo "ERROR: queries/indents.scm not found." >&2
+  exit 1
+fi
+
 echo "==> mkdir -p $PARSER_DIR $QUERIES_DIR"
 mkdir -p "$PARSER_DIR" "$QUERIES_DIR"
 
@@ -57,5 +63,8 @@ install -m 0755 ry.so "$PARSER_DIR/ry.so"
 echo "==> install queries/highlights.scm -> $QUERIES_DIR/highlights.scm"
 install -m 0644 queries/highlights.scm "$QUERIES_DIR/highlights.scm"
 
+echo "==> install queries/indents.scm -> $QUERIES_DIR/indents.scm"
+install -m 0644 queries/indents.scm "$QUERIES_DIR/indents.scm"
+
 echo "==> done"
-ls -la "$PARSER_DIR/ry.so" "$QUERIES_DIR/highlights.scm"
+ls -la "$PARSER_DIR/ry.so" "$QUERIES_DIR/highlights.scm" "$QUERIES_DIR/indents.scm"

--- a/editor/tree-sitter/queries/indents.scm
+++ b/editor/tree-sitter/queries/indents.scm
@@ -1,0 +1,124 @@
+; tree-sitter-ry indent queries
+;
+; Capture names follow nvim-treesitter rewrite (main-branch) conventions
+; (see runtime/queries/python/indents.scm in nvim-treesitter for prior art):
+; @indent.begin  — open a new indent level for nodes spanning multiple lines.
+; @indent.branch — re-align the current line with the parent on this token
+;                  (used for `else` and for closing brackets on their own line).
+;
+; The `#set! indent.immediate 1` directive makes the capture fire as soon
+; as the parent node is recognized, even before its body span becomes
+; multi-line. This is required for "press <CR> after `if cond:` to bump
+; indent +1" — without it, the freshly typed single-line statement would
+; not yet meet `@indent.begin`'s multi-line precondition.
+;
+; Ry is indentation-sensitive: INDENT / DEDENT / _newline are produced by
+; src/scanner.c. The scanner suppresses INDENT/DEDENT inside ( [ { because
+; the parser does not request them during expression parsing — that is
+; why bracketed nodes get their own @indent.begin and the closing tokens
+; get @indent.branch (so the closer on its own line returns to the
+; opener's column, while the contents are bumped +1).
+;
+; Note: inside f-string interpolation, the closing brace is parsed as
+; `_fstring_mid` / `_fstring_end`, NOT the anonymous "}" literal, so the
+; `}` @indent.branch capture below never matches inside an f-string.
+;
+; Known limitation: a parenthesized single expression spanning multiple
+; lines (e.g. `s = (\n  1\n  + 2\n)`) is parsed via the hidden grammar
+; rule `_parenthesized`, which tree-sitter inlines into the parent
+; expression. Hidden rules cannot be matched by capture queries, so the
+; contents of such a parenthesized expression do NOT get auto-indented
+; and the closing `)` does NOT auto-dedent. Multi-element tuple literals
+; (`(a, b)` via `tuple_literal`) and call argument lists (`f(\n  a,\n)`
+; via `call_expression`) are real grammar rules and ARE handled.
+
+; ---------- Always-block-opening nodes ----------
+; These nodes always introduce a `: INDENT body DEDENT` block, so we set
+; indent.immediate to fire at parse time of the head, not after the body
+; span exists.
+
+((function_declaration body: (function_body)) @indent.begin
+  (#set! indent.immediate 1))
+
+((record_declaration) @indent.begin
+  (#set! indent.immediate 1))
+
+((record_invariant) @indent.begin
+  (#set! indent.immediate 1))
+
+((enum_declaration) @indent.begin
+  (#set! indent.immediate 1))
+
+((contract_clause) @indent.begin
+  (#set! indent.immediate 1))
+
+((if_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((while_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((for_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((case_match_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((case_cond_statement) @indent.begin
+  (#set! indent.immediate 1))
+
+((case_match_expression) @indent.begin
+  (#set! indent.immediate 1))
+
+((case_cond_expression) @indent.begin
+  (#set! indent.immediate 1))
+
+; ---------- Inline-or-block nodes ----------
+; case_arm / case_cond_arm have both inline (`pat => expr`) and block
+; (`pat =>: INDENT stmts DEDENT`) forms; lambda_expression with a block
+; body is only considered when the body field is a block. Bare
+; @indent.begin (without immediate) fires only when the node already
+; spans multiple lines, which naturally matches the block forms.
+
+(case_arm) @indent.begin
+
+(case_cond_arm) @indent.begin
+
+(lambda_expression body: (block)) @indent.begin
+
+; ---------- Branch keyword ----------
+; `else` / `else if` should align with the parent `if`. Capturing the
+; bare "else" keyword inside if_statement covers both cases (Ry has no
+; `elif`; `else if` is two tokens).
+
+(if_statement "else" @indent.branch)
+
+; ---------- Bracketed multi-line nodes ----------
+; INDENT/DEDENT are suppressed inside ( [ { , so we need @indent.begin
+; on the surrounding node (without indent.immediate) to bump contents +1
+; for multi-line bracket literals / argument lists. The bare form fires
+; only when the node already spans multiple lines, so single-line
+; literals like `[1, 2, 3]` are unaffected.
+
+(list_literal) @indent.begin
+
+(map_literal) @indent.begin
+
+(set_literal) @indent.begin
+
+(tuple_literal) @indent.begin
+
+(call_expression) @indent.begin
+
+(index_expression) @indent.begin
+
+; ---------- Closing brackets ----------
+; The closing token of a multi-line bracketed node, on its own line,
+; dedents back to the opener's column via @indent.branch (which only
+; fires when the captured node starts on the target line).
+
+[
+  ")"
+  "]"
+  "}"
+] @indent.branch


### PR DESCRIPTION
## Summary

Closes #1620. Adds tree-sitter indent queries so Neovim 0.12+ users get
tree-sitter driven auto-indent / auto-dedent for `.ry` files.

- New `editor/tree-sitter/queries/indents.scm` using the
  nvim-treesitter rewrite (main-branch) capture vocabulary
  (`@indent.begin` / `@indent.branch`).
- `editor/tree-sitter/install.sh` now also deploys `indents.scm` to
  `$XDG_CONFIG_HOME/nvim/queries/ry/indents.scm`.
- `editor/tree-sitter/README.md` documents the Neovim 0.12 /
  nvim-treesitter rewrite requirement and the `vim.bo.indentexpr`
  setup snippet.
- `changelog.d/1620-tree-sitter-indents.md` records the change.

## Behavior

The query covers the three acceptance criteria from #1620:

- `<CR>` after `fn foo():` / `if cond:` bumps +1 indent (via
  `#set! indent.immediate 1` so the capture fires before the body
  span exists in the AST).
- `else` / `else if` on its own line dedents to the parent `if`.
- `]` / `}` / `)` on its own line returns to the opener's column.

Multi-element tuples (`tuple_literal`), list / map / set literals,
and call / index argument lists are also handled with bare
`@indent.begin` (no immediate) so single-line forms are unaffected.

`function_declaration` is constrained by `body: (function_body)` so
`@native fn` declarations (which have no body) do not introduce
phantom indent.

## Known limitation

A parenthesized single expression spanning multiple lines, e.g.

```ry
s = (
  1
  + 2
)
```

is parsed via the hidden `_parenthesized` grammar rule, which
tree-sitter inlines into the parent expression. Hidden rules cannot
be matched by capture queries, so the contents do NOT get auto-indented
and the closing `)` does NOT auto-dedent. Multi-element tuples
(`(a, b)`) and call argument lists (`f(\n  a,\n)`) are real grammar
rules and ARE handled. The limitation is documented in the
`indents.scm` header and in the changelog entry.

## Test plan

- [x] `cd editor/tree-sitter && ./build.sh` regenerates and rebuilds
      `ry.so` with no errors.
- [x] `tree-sitter query queries/indents.scm <fixture>.ry` succeeds
      and every one of the 23 capture patterns matches at least once
      against a comprehensive fixture covering `record` /
      `invariant`, `enum`, `fn` with `require:` / `ensure:`,
      `if/else if/else`, `while`, `for`, `case match` and
      `case cond` (statement and expression forms), block-form
      `case_arm`, multi-line list / map / set / tuple / call / index
      literals, and lambda body block.
- [x] `./install.sh --no-build` deploys `ry.so`,
      `highlights.scm`, and `indents.scm` to
      `$XDG_CONFIG_HOME/nvim/...`; the final `ls -la` shows all three.
- [x] Headless Neovim 0.12 acceptance test covering all three
      acceptance criteria (passes for `fn foo():` / `if cond:` +1
      bump, `else` / `else if` dedent, `]` / `}` / `)` dedent).
- [x] Hidden-rule limitation verified by running the same indent
      function against `s = (\n  1\n  + 2\n)` — confirmed not
      auto-indented; documented as a known limitation rather than
      attempting a grammar workaround.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tree-sitter powered automatic indentation for Ry files, improving handling of tuples, literals, argument lists, multi-line brackets and f-string-like constructs.
  * Installer now deploys the indentation queries so indentation support can be enabled per-buffer in Vim/Neovim.

* **Documentation**
  * Updated tree-sitter docs and install instructions with usage and enabling guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->