### PR TITLE
feat(codegen): track testing intrinsic imports (#713)

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -73,6 +73,12 @@ public:
     // only includes libraries for functions actually called during codegen).
     const std::unordered_set<std::string>& getRequiredLibraries() const;
 
+    // Testing intrinsics (`expect`, `mock`, `verify`, `fail`, `it`, `describe`)
+    // that the program imported via `from testing import ...` (named or wildcard).
+    // Populated by the caller (jit_runner) from ModuleLoader::importedTestingIntrinsics().
+    void setTestingIntrinsicsImported(const std::unordered_set<std::string> &imported);
+    const std::unordered_set<std::string>& getTestingIntrinsicsImported() const;
+
     // Derive the base runtime function name for a stdlib module function.
     // e.g. ("base64", "encode") → "__ry_base64_encode"
     // For overloaded functions, callers must append an arity suffix
@@ -846,6 +852,12 @@ public:
 
     // @native fn rich signature registry
     std::unordered_map<std::string, std::vector<NativeFnSignature>> native_fn_sigs_;
+
+    // Testing intrinsics imported via `from testing import ...`. Set by
+    // setTestingIntrinsicsImported() from ModuleLoader::importedTestingIntrinsics()
+    // before compile(). Reserved for future enforcement (#715/#716);
+    // currently unused by codegen.
+    std::unordered_set<std::string> testing_intrinsics_imported_;
 
     // User-defined @directive declarations. Keyed by directive name.
     std::unordered_map<std::string, DirectiveSignature> user_directive_registry_;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -91,6 +91,14 @@ CodeGen::CodeGen(bool test_mode, const SourceManager *sm, bool coverage_mode,
     fnTy_void_to_ptr_      = llvm::FunctionType::get(ptrTy_, {}, false);
 }
 
+void CodeGen::setTestingIntrinsicsImported(const std::unordered_set<std::string> &imported) {
+    testing_intrinsics_imported_ = imported;
+}
+
+const std::unordered_set<std::string> &CodeGen::getTestingIntrinsicsImported() const {
+    return testing_intrinsics_imported_;
+}
+
 llvm::FunctionCallee CodeGen::getRuntimeFn(const char *name, llvm::Type *retTy,
                                             llvm::ArrayRef<llvm::Type*> argTys) {
     auto *fnTy = llvm::FunctionType::get(retTy, argTys, false);

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -162,6 +162,7 @@ int runRySource(const std::string &src, const std::string &source_name,
         ry::emitTraceEvent("codegen.start", "compile", &sourceLoc,
                            {ry::TraceField("file", source_name)});
     CodeGen cg(test_mode, &sm, coverage_mode, coverage_offset, outline_mode);
+    cg.setTestingIntrinsicsImported(loader.importedTestingIntrinsics());
     ThreadSafeModule tsm = [&]() {
         try {
             auto module = cg.compile(prog);

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -715,6 +715,7 @@ protected:
         prog = loader.resolveImports(prog, dir);
 
         CodeGen cg;
+        cg.setTestingIntrinsicsImported(loader.importedTestingIntrinsics());
         auto tsm = cg.compile(prog);
         return runModule(std::move(tsm));
     }
@@ -743,6 +744,23 @@ protected:
         ModuleLoader loader(search_paths);
         loader.resolveImports(prog, dir);
         return loader.importedTestingIntrinsics();
+    }
+
+    std::unordered_set<std::string> resolveAndGetCodeGenTestingIntrinsics(
+        const std::string &src,
+        const std::string &referrer_dir = "",
+        const std::vector<std::string> &search_paths = {}) {
+        Lexer lex(src);
+        Parser parser(lex);
+        Program prog = parser.parseProgram();
+
+        std::string dir = referrer_dir.empty() ? tmp_dir_.string() : referrer_dir;
+        ModuleLoader loader(search_paths);
+        loader.resolveImports(prog, dir);
+
+        CodeGen cg;
+        cg.setTestingIntrinsicsImported(loader.importedTestingIntrinsics());
+        return cg.getTestingIntrinsicsImported();
     }
 };
 
@@ -1540,6 +1558,45 @@ TEST_F(ImportTest, FromMathDoesNotPolluteTestingIntrinsics) {
     auto intrinsics = resolveAndGetTestingIntrinsics(
         "from mathmod import add\n");
     EXPECT_TRUE(intrinsics.empty());
+}
+
+TEST_F(ImportTest, CodeGenReceivesPartialTestingIntrinsics) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    auto intrinsics = resolveAndGetCodeGenTestingIntrinsics(
+        "from testing import expect, it\n",
+        tmp_dir_.string(),
+        search_paths);
+    std::unordered_set<std::string> expected = {"expect", "it"};
+    EXPECT_EQ(intrinsics, expected);
+}
+
+TEST_F(ImportTest, CodeGenReceivesAllTestingIntrinsicsForWildcard) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    auto intrinsics = resolveAndGetCodeGenTestingIntrinsics(
+        "from testing\n",
+        tmp_dir_.string(),
+        search_paths);
+    std::unordered_set<std::string> expected = {
+        "it", "describe", "expect", "mock", "verify", "fail"};
+    EXPECT_EQ(intrinsics.size(), 6u);
+    EXPECT_EQ(intrinsics, expected);
+}
+
+TEST_F(ImportTest, CodeGenReceivesEmptySetWithoutTestingImport) {
+    writeFile("mathmod.ry", "fn add(a: int, b: int) -> int:\n    return a + b\n");
+    auto intrinsics = resolveAndGetCodeGenTestingIntrinsics(
+        "from mathmod import add\n");
+    EXPECT_TRUE(intrinsics.empty());
+}
+
+TEST_F(ImportTest, CodeGenReceivesNamedSubsetTestingIntrinsics) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    auto intrinsics = resolveAndGetCodeGenTestingIntrinsics(
+        "from testing import expect, fail, it\n",
+        tmp_dir_.string(),
+        search_paths);
+    std::unordered_set<std::string> expected = {"expect", "fail", "it"};
+    EXPECT_EQ(intrinsics, expected);
 }
 
 // ===== type alias =====


### PR DESCRIPTION
## Summary

Adds CodeGen-side plumbing to receive the set of testing intrinsics (`expect`, `mock`, `verify`, `fail`, `it`, `describe`) that the program imported via `from testing import ...`. The set is collected by `ModuleLoader::importedTestingIntrinsics()` (added in #712) and wired through `jit_runner` into the new `CodeGen::setTestingIntrinsicsImported()`. This is pure plumbing — **no codegen behavior changes yet**, in line with the issue's "No behavioral change yet" acceptance criterion.

The set is consumed by the upcoming enforcement work:

- #715 — reject implicit `expect` / `mock` / `verify` / `fail` (require import).
- #716 — reject implicit `@it` / `@describe` (require import).

This is the third sub-issue under parent #703 / Phase 1 of treating `testing` as an ordinary Ry module rather than compiler-implicit.

Closes #713.

## Changes

- `include/ry/codegen.hpp` — add private `testing_intrinsics_imported_` set plus public `setTestingIntrinsicsImported` / `getTestingIntrinsicsImported` accessors (matches the existing `get*` accessor convention used by `getRequiredLibraries`, `getNativeFnSigs`, `getWarnings`).
- `src/codegen.cpp` — trivial setter (copy-assign) / getter (const-ref) implementation.
- `src/jit_runner.cpp` — invoke the setter between `CodeGen` construction (line 164) and `compile()` (line 167), sourcing the set from the existing `loader`. One-line wiring; no signature change to `CodeGen` constructor.
- `tests/test_codegen_stmt.cpp` — add `resolveAndGetCodeGenTestingIntrinsics` helper (mirrors the existing `resolveAndGetTestingIntrinsics` shape but builds a `CodeGen`, calls the setter, and asserts via the getter) plus four new `ImportTest` cases:
  - `CodeGenReceivesPartialTestingIntrinsics` — `from testing import expect, it` → `{expect, it}`.
  - `CodeGenReceivesAllTestingIntrinsicsForWildcard` — `from testing` → all 6.
  - `CodeGenReceivesEmptySetWithoutTestingImport` — non-testing import → empty set.
  - `CodeGenReceivesNamedSubsetTestingIntrinsics` — `from testing import expect, fail, it` → `{expect, fail, it}`.

  Also wires the setter into the existing `runWithImports` harness so the upcoming #715/#716 rejection tests can build on the same fixture without further plumbing.

## Design notes

- **Setter over constructor extension** — `CodeGen` already takes 5 constructor args; the imported-intrinsics set is runtime-collected post-construction, so a setter keeps the constructor signature stable and preserves the default-constructed `CodeGen cg;` pattern that test fixtures rely on.
- **Reuse loader accessor instead of re-scanning AST in CodeGen** — duplicating the `{it, describe, expect, mock, verify, fail}` literal in CodeGen would create drift risk; the loader's existing `module_loader.cpp:454-464` logic already covers both the named-import and wildcard paths.

## Test plan

- [x] `cmake --build build` clean (no new warnings).
- [x] `./build/ry_tests` — 2135/2135 pass (4 new `ImportTest.CodeGenReceives*` cases plus all #712-derived cases).
- [x] `./build/ry test -p` — all 173 Ry test files green (acceptance: "No behavioral change yet").
- [x] ASan + UBSan: `./build-asan/ry_tests` 2135/2135, `./build-asan/ry test -p` 173/173.
- [x] TSan: `./build-tsan/ry_tests` 2135/2135 (Ry self-test warn-only per upstream `LargeMmapAllocator` issue).
- [x] clang-tidy / cppcheck: 0 findings on changed files.

## Pre-commit checklist skips

- Skipped §1 — public spec is unchanged; docs move with #715/#716 when the first user-visible rejection is introduced.
- Skipped §2 — parent #712 fragment already documents the chain `(#713 / #715 / #716)`; #713 is pure internal plumbing with nothing user-visible to add.
- Skipped §3.6 — no parser/lexer/json/utf8/string changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CodeGen now tracks and exposes imported testing intrinsics from external modules, ensuring proper handling during compilation.
  * Added comprehensive test coverage for testing intrinsics exposure across various import scenarios, including partial imports, wildcards, empty imports, and named subsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->