### PR TITLE
chore(tests): add explicit testing imports to all spec files (#714)

### DIFF
--- a/tests/spec/any.test.ry
+++ b/tests/spec/any.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("any type")
 fn anyTypeTests():

--- a/tests/spec/any_fn_return.test.ry
+++ b/tests/spec/any_fn_return.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("any return from function")
 fn anyReturnFromFunctionTests():

--- a/tests/spec/arc_inferred_list_str_rebind.test.ry
+++ b/tests/spec/arc_inferred_list_str_rebind.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/arc_iolist.test.ry
+++ b/tests/spec/arc_iolist.test.ry
@@ -13,7 +13,7 @@
 #   the number of containers still held (not N).  If release is broken (i.e.
 #   the old checked_malloc path) the delta grows linearly with N instead.
 
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from runtime_internal import arcLiveCount
 from io import toBytes, readBytes, writeBytes, deleteFile

--- a/tests/spec/arc_list_destructure.test.ry
+++ b/tests/spec/arc_list_destructure.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from str import split
 

--- a/tests/spec/arc_release_on_field_overwrite.test.ry
+++ b/tests/spec/arc_release_on_field_overwrite.test.ry
@@ -12,7 +12,7 @@
 # detect_leaks=0, so these tests are behavioral — repeated overwrite + value
 # correctness under ASan. Direct leak detection is tracked separately.
 
-from testing import it, describe
+from testing import it, describe, expect
 
 type IntList = List<int>
 type StrIntMap = Map<str, int>

--- a/tests/spec/arc_release_on_index_overwrite.test.ry
+++ b/tests/spec/arc_release_on_index_overwrite.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/arc_release_on_rebind.test.ry
+++ b/tests/spec/arc_release_on_rebind.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/arc_resource_alias_free.test.ry
+++ b/tests/spec/arc_resource_alias_free.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from thread import lockNew, lockAcquire, lockRelease, lockFree, rwlockNew, rwlockReadLock, rwlockUnlock, rwlockFree, atomicIntNew, atomicIntLoad, atomicIntFree
 

--- a/tests/spec/arc_split_chars.test.ry
+++ b/tests/spec/arc_split_chars.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/array.test.ry
+++ b/tests/spec/array.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("fixed-length array")
 fn fixedLengthArrayTests():

--- a/tests/spec/base64.test.ry
+++ b/tests/spec/base64.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from base64 import encode, decode, encodeUrlSafe, decodeUrlSafe, encodeBytes, encodeBytesUrlSafe, decodeBytes, decodeBytesUrlSafe
 

--- a/tests/spec/bounds_check.test.ry
+++ b/tests/spec/bounds_check.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("bounds checking")
 fn boundsCheckingTests():

--- a/tests/spec/builtins.test.ry
+++ b/tests/spec/builtins.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 @describe("length")
 fn lengthTests():

--- a/tests/spec/case_unification.test.ry
+++ b/tests/spec/case_unification.test.ry
@@ -4,7 +4,7 @@
 # replaces `when`/`match`) and the `if` expression forms (single-expression
 # `=>` form and tail-expression block form).
 
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("case with subject")
 fn caseWithSubjectTests():

--- a/tests/spec/chained_lhs_assign.test.ry
+++ b/tests/spec/chained_lhs_assign.test.ry
@@ -5,7 +5,7 @@
 # fix lands. Error-path cases (immutable/const, rvalue LHS, missing map key
 # compound) live in C++ tests, not here.
 
-from testing import it, describe
+from testing import it, describe, expect
 
 record LhsPoint:
   x: int

--- a/tests/spec/checked_arith.test.ry
+++ b/tests/spec/checked_arith.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("checked arithmetic")
 fn checkedArithmeticTests():

--- a/tests/spec/closure_arc.test.ry
+++ b/tests/spec/closure_arc.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("closure ARC — basic lifecycle")
 fn closureArcBasicLifecycleTests():

--- a/tests/spec/closure_capture_arc.test.ry
+++ b/tests/spec/closure_capture_arc.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("closure capturing ARC values — destructor should release captures (#429)")
 fn closureCapturingArcValuesDestructorShouldReleaseCaptures429Tests():

--- a/tests/spec/closure_capture_expr_types.test.ry
+++ b/tests/spec/closure_capture_expr_types.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("closure capture — SetExpr")
 fn closureCaptureSetexprTests():

--- a/tests/spec/closure_fn_param.test.ry
+++ b/tests/spec/closure_fn_param.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("closure fn param")
 fn closureFnParamTests():

--- a/tests/spec/closure_higher_order.test.ry
+++ b/tests/spec/closure_higher_order.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("closure — returned from function")
 fn closureReturnedFromFunctionTests():

--- a/tests/spec/closure_match_pattern_capture.test.ry
+++ b/tests/spec/closure_match_pattern_capture.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("match pattern capture")
 fn matchPatternCaptureTests():

--- a/tests/spec/collection_element_metadata.test.ry
+++ b/tests/spec/collection_element_metadata.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from json import parse, kind, jsonFree
 from thread import lockNew, lockAcquire, lockRelease, lockFree

--- a/tests/spec/collection_string_display.test.ry
+++ b/tests/spec/collection_string_display.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("collection string display")
 fn collectionStringDisplayTests():

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("List")
 fn listTests():

--- a/tests/spec/combinatorial/collection_element_bool_access.test.ry
+++ b/tests/spec/combinatorial/collection_element_bool_access.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("collection element — bool in List")
 fn collectionElementBoolInListTests():

--- a/tests/spec/combinatorial/collection_element_bool_iterate.test.ry
+++ b/tests/spec/combinatorial/collection_element_bool_iterate.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("collection element — bool in List")
 fn collectionElementBoolInListTests():

--- a/tests/spec/combinatorial/collection_element_enum_access.test.ry
+++ b/tests/spec/combinatorial/collection_element_enum_access.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 enum ColElemStatus:
   Active

--- a/tests/spec/combinatorial/collection_element_enum_iterate.test.ry
+++ b/tests/spec/combinatorial/collection_element_enum_iterate.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 enum ColElemStatus:
   Active

--- a/tests/spec/combinatorial/collection_element_nested_list_access.test.ry
+++ b/tests/spec/combinatorial/collection_element_nested_list_access.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("collection element — List<List<int>>")
 fn collectionElementListListIntTests():

--- a/tests/spec/combinatorial/collection_element_nested_list_multiple.test.ry
+++ b/tests/spec/combinatorial/collection_element_nested_list_multiple.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("collection element — List<List<int>>")
 fn collectionElementListListIntTests():

--- a/tests/spec/combinatorial/collection_element_option_access.test.ry
+++ b/tests/spec/combinatorial/collection_element_option_access.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("collection element — Option in List")
 fn collectionElementOptionInListTests():

--- a/tests/spec/combinatorial/collection_element_option_iterate.test.ry
+++ b/tests/spec/combinatorial/collection_element_option_iterate.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("collection element — Option in List")
 fn collectionElementOptionInListTests():

--- a/tests/spec/combinatorial/collection_element_record_access.test.ry
+++ b/tests/spec/combinatorial/collection_element_record_access.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record ColElemItem:
   name: str

--- a/tests/spec/combinatorial/collection_element_record_iterate.test.ry
+++ b/tests/spec/combinatorial/collection_element_record_iterate.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record ColElemItem:
   name: str

--- a/tests/spec/combinatorial/collection_element_result_access.test.ry
+++ b/tests/spec/combinatorial/collection_element_result_access.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn makeOkInt(v: int) -> Result<int, Error>:
   return Ok(v)

--- a/tests/spec/combinatorial/collection_element_result_iterate.test.ry
+++ b/tests/spec/combinatorial/collection_element_result_iterate.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn makeOkInt(v: int) -> Result<int, Error>:
   return Ok(v)

--- a/tests/spec/combinatorial/collection_element_tuple_access.test.ry
+++ b/tests/spec/combinatorial/collection_element_tuple_access.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("collection element — tuple in List")
 fn collectionElementTupleInListTests():

--- a/tests/spec/combinatorial/collection_element_tuple_iterate.test.ry
+++ b/tests/spec/combinatorial/collection_element_tuple_iterate.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("collection element — tuple in List")
 fn collectionElementTupleInListTests():

--- a/tests/spec/combinatorial/equality.test.ry
+++ b/tests/spec/combinatorial/equality.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("equality — tuple")
 fn equalityTupleTests():

--- a/tests/spec/combinatorial/fn_argument.test.ry
+++ b/tests/spec/combinatorial/fn_argument.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record FnArgPoint:
   x: int

--- a/tests/spec/combinatorial/fn_return.test.ry
+++ b/tests/spec/combinatorial/fn_return.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record FnReturnPoint:
   x: int

--- a/tests/spec/combinatorial/list_element_types.test.ry
+++ b/tests/spec/combinatorial/list_element_types.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("List<Map> — element access")
 fn listMapElementAccessTests():

--- a/tests/spec/combinatorial/match_types.test.ry
+++ b/tests/spec/combinatorial/match_types.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record MatchCoord:
   x: int

--- a/tests/spec/combinatorial/nested_types.test.ry
+++ b/tests/spec/combinatorial/nested_types.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 fn divide(a: int, b: int) -> Result<int, Error>:
   if b == 0:

--- a/tests/spec/combinatorial/print_display.test.ry
+++ b/tests/spec/combinatorial/print_display.test.ry
@@ -1,7 +1,7 @@
 # BUG #728: print()/toStr() coverage for union values and closure stringification
 
 
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("print — union")
 fn printUnionTests():

--- a/tests/spec/combinatorial/stdlib_boundary.test.ry
+++ b/tests/spec/combinatorial/stdlib_boundary.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("stdlib boundary — large collection")
 fn stdlibBoundaryLargeCollectionTests():

--- a/tests/spec/combinatorial/syntax_combinations.test.ry
+++ b/tests/spec/combinatorial/syntax_combinations.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 enum SyntaxShape:
   Circle

--- a/tests/spec/compound_assign_arc_element.test.ry
+++ b/tests/spec/compound_assign_arc_element.test.ry
@@ -8,7 +8,7 @@
 # value via propagateTypeMeta, matching the canonical pattern used by
 # valueToString element loads.
 
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("compound assignment on ARC-managed list elements")
 fn compoundAssignmentOnArcManagedListElementsTests():

--- a/tests/spec/compound_assign_arc_field.test.ry
+++ b/tests/spec/compound_assign_arc_field.test.ry
@@ -9,7 +9,7 @@
 # the FieldAssignStmt compound branches instead of IndexAssignStmt. Three
 # sites are fixed — VariableExpr, FieldAccessExpr, IndexExpr-chain.
 
-from testing import it, describe
+from testing import it, describe, expect
 
 record Box:
   items: List<int>

--- a/tests/spec/concurrency.test.ry
+++ b/tests/spec/concurrency.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("async and await")
 fn asyncAndAwaitTests():

--- a/tests/spec/concurrency_stress.test.ry
+++ b/tests/spec/concurrency_stress.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from set import add, union
 from map import hasKey, keys, remove

--- a/tests/spec/constantint_sharing.test.ry
+++ b/tests/spec/constantint_sharing.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("ConstantInt sharing fix (#311)")
 fn constantintSharingFix311Tests():

--- a/tests/spec/contracts.test.ry
+++ b/tests/spec/contracts.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn deposit(amount: int, balance: int) -> int:
   require:

--- a/tests/spec/control_flow.test.ry
+++ b/tests/spec/control_flow.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("if / when")
 fn ifWhenTests():

--- a/tests/spec/cow.test.ry
+++ b/tests/spec/cow.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("Copy-on-Write")
 fn copyOnWriteTests():

--- a/tests/spec/cow_path.test.ry
+++ b/tests/spec/cow_path.test.ry
@@ -7,7 +7,7 @@
 # fields (List/Map/Set) so path CoW can observe strong_count > 1 at the
 # record-field boundary (Layer 2 sub-fix).
 
-from testing import it, describe
+from testing import it, describe, expect
 
 record CowBox:
   items: List<int>

--- a/tests/spec/default_args.test.ry
+++ b/tests/spec/default_args.test.ry
@@ -1,6 +1,6 @@
 # --- helper functions ---
 
-from testing import it, describe
+from testing import it, describe, expect
 
 fn greet(name: str, greeting: str = "Hello") -> str:
   return greeting + ", " + name

--- a/tests/spec/directive_test.test.ry
+++ b/tests/spec/directive_test.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe, each, property
+from testing import it, describe, expect, each, property
 
 # Tests for @it and @describe directive syntax on named functions (#634)
 

--- a/tests/spec/div_zero_guard.test.ry
+++ b/tests/spec/div_zero_guard.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from math import INF, isNan, isInf
 

--- a/tests/spec/enum_generic_param_type.test.ry
+++ b/tests/spec/enum_generic_param_type.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 enum MyOpt<T>:
   MySome(T)

--- a/tests/spec/env.test.ry
+++ b/tests/spec/env.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("env")
 fn envTests():

--- a/tests/spec/expr_stmt.test.ry
+++ b/tests/spec/expr_stmt.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("expression statement")
 fn expressionStatementTests():

--- a/tests/spec/filesystem.test.ry
+++ b/tests/spec/filesystem.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from filesystem import listDir, walk, glob, copy, move, remove, removeAll, mkdir, mkdirAll, fileSize, isFile, isDir, isSymlink, chmod, symlink, readLink
 from io import writeText, readText, exists

--- a/tests/spec/fn_keyword.test.ry
+++ b/tests/spec/fn_keyword.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn add(x: int, y: int) -> int:
   return x + y

--- a/tests/spec/for_loop_destructure_meta.test.ry
+++ b/tests/spec/for_loop_destructure_meta.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 enum Color:
   Red

--- a/tests/spec/for_mutation.test.ry
+++ b/tests/spec/for_mutation.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from thread import threadSpawn, threadJoin, atomicIntNew, atomicIntLoad, atomicIntAdd
 

--- a/tests/spec/for_mutation_field.test.ry
+++ b/tests/spec/for_mutation_field.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from thread import threadSpawn, threadJoin, atomicIntNew, atomicIntLoad, atomicIntAdd
 

--- a/tests/spec/for_mutation_index.test.ry
+++ b/tests/spec/for_mutation_index.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("for mutation safety — IndexExpr iterables (#1091)")
 fn forMutationSafetyIndexexprIterables1091Tests():

--- a/tests/spec/fstring_closure_capture.test.ry
+++ b/tests/spec/fstring_closure_capture.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("f-string closure capture — nested named function")
 fn fStringClosureCaptureNestedNamedFunctionTests():

--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn add(a: int, b: int) -> int:
   return a + b

--- a/tests/spec/gc.test.ry
+++ b/tests/spec/gc.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from gc import collect, enable, disable, setThreshold
 

--- a/tests/spec/gc_record_smoke.test.ry
+++ b/tests/spec/gc_record_smoke.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from gc import collect, enable, setThreshold
 

--- a/tests/spec/generic_bounds.test.ry
+++ b/tests/spec/generic_bounds.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record Animal:
   name: str

--- a/tests/spec/generic_collection_param.test.ry
+++ b/tests/spec/generic_collection_param.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn firstItem<T>(items: List<T>) -> T:
     return items[0]

--- a/tests/spec/generic_infer_container.test.ry
+++ b/tests/spec/generic_infer_container.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn firstOf<T>(xs: List<T>) -> T:
     return xs[0]

--- a/tests/spec/generics.test.ry
+++ b/tests/spec/generics.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn identity<T>(x: T) -> T:
     return x

--- a/tests/spec/http.test.ry
+++ b/tests/spec/http.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from net import bind, listen, accept, connect, listenerPort
 from io import toBytes, bytesToStr

--- a/tests/spec/http_client.test.ry
+++ b/tests/spec/http_client.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from net import bind, listen, accept, listenerPort
 from io import toBytes, bytesToStr

--- a/tests/spec/implicit_numeric_coerce.test.ry
+++ b/tests/spec/implicit_numeric_coerce.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record Counter:
   n: int

--- a/tests/spec/implicit_widening.test.ry
+++ b/tests/spec/implicit_widening.test.ry
@@ -1,6 +1,6 @@
 # --- helper functions ---
 
-from testing import it, describe
+from testing import it, describe, expect
 
 fn doubleFloat(x: float) -> float:
   return x * 2.0

--- a/tests/spec/inline.test.ry
+++ b/tests/spec/inline.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @inline
 fn add(a: int, b: int) -> int:

--- a/tests/spec/int_overflow.test.ry
+++ b/tests/spec/int_overflow.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("int overflow safety")
 fn intOverflowSafetyTests():

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from io import readText, writeText, appendText, exists, deleteFile, readBytes, writeBytes, toBytes, bytesToStr
 

--- a/tests/spec/iterator.test.ry
+++ b/tests/spec/iterator.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("Iterator")
 fn iteratorTests():

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from json import parse, stringify, kind, get, at, toStr, toInt, toFloat, toBool, len, keys, jsonFree
 from str import contains, repeat

--- a/tests/spec/lambda_arc_return.test.ry
+++ b/tests/spec/lambda_arc_return.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("expression-bodied lambda ARC retain on return (#789)")
 fn expressionBodiedLambdaArcRetainOnReturn789Tests():

--- a/tests/spec/lambda_collection_return.test.ry
+++ b/tests/spec/lambda_collection_return.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("lambda returning list literal")
 fn lambdaReturningListLiteralTests():

--- a/tests/spec/lambda_native_call.test.ry
+++ b/tests/spec/lambda_native_call.test.ry
@@ -5,7 +5,7 @@
 # ambiguity guard fired with "ambiguous @native call in lambda return-type
 # inference".
 
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("lambda return-type inference over @native length overloads")
 fn lambdaReturnTypeInferenceOverNativeLengthOverloadsTests():

--- a/tests/spec/lambda_paren_omit.test.ry
+++ b/tests/spec/lambda_paren_omit.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("bare-paren-omitted single-param lambda (#1572)")
 fn bareParenOmittedSingleParamLambda1572Tests():

--- a/tests/spec/lambda_ptr_return.test.ry
+++ b/tests/spec/lambda_ptr_return.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("lambda returning f-string")
 fn lambdaReturningFStringTests():

--- a/tests/spec/leading_dot_float.test.ry
+++ b/tests/spec/leading_dot_float.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("leading-dot float literals")
 fn leadingDotFloatLiteralsTests():

--- a/tests/spec/list_concat_arc.test.ry
+++ b/tests/spec/list_concat_arc.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/list_destructure_assign.test.ry
+++ b/tests/spec/list_destructure_assign.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from str import split
 

--- a/tests/spec/list_range_index.test.ry
+++ b/tests/spec/list_range_index.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/list_take_arc.test.ry
+++ b/tests/spec/list_take_arc.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/low_level_types.test.ry
+++ b/tests/spec/low_level_types.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("i32 type")
 fn i32TypeTests():

--- a/tests/spec/map_chained_index.test.ry
+++ b/tests/spec/map_chained_index.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("chained Map index access")
 fn chainedMapIndexAccessTests():

--- a/tests/spec/matchers.test.ry
+++ b/tests/spec/matchers.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("Numeric comparison matchers")
 fn numericComparisonMatchersTests():

--- a/tests/spec/math.test.ry
+++ b/tests/spec/math.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from math import PI, E, INF, NAN, abs, floor, ceil, round, sqrt, pow, log, log2, log10, exp, sin, cos, tan, asin, acos, atan, atan2, hypot, isNan, isInf, digits
 

--- a/tests/spec/mock.test.ry
+++ b/tests/spec/mock.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, mock, verify
 
 fn fetchData() -> str:
   return "real data"

--- a/tests/spec/mutual_recursion.test.ry
+++ b/tests/spec/mutual_recursion.test.ry
@@ -1,6 +1,6 @@
 # --- Basic mutual recursion (isEven / isOdd) ---
 
-from testing import it, describe
+from testing import it, describe, expect
 
 fn isEven(n: int) -> bool:
   if n == 0:

--- a/tests/spec/native_first_class.test.ry
+++ b/tests/spec/native_first_class.test.ry
@@ -4,7 +4,7 @@
 # raised "undefined variable: toInt" because emitExprVariant(VariableExpr)
 # never consulted native_fn_sigs_.
 
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from convert import toInt
 

--- a/tests/spec/nested_fn_closure.test.ry
+++ b/tests/spec/nested_fn_closure.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn apply(f: fn(int) -> int, x: int) -> int:
   return f(x)

--- a/tests/spec/nested_fn_return_fn.test.ry
+++ b/tests/spec/nested_fn_return_fn.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("two-level nested function return (#752)")
 fn twoLevelNestedFunctionReturn752Tests():

--- a/tests/spec/nested_functions.test.ry
+++ b/tests/spec/nested_functions.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn apply(f: fn(int) -> int, x: int) -> int:
   return f(x)

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from net import bind, listen, accept, connect, listenerPort, setTimeout, setReceiveTimeout, setSendTimeout, tlsConnect
 from io import toBytes, bytesToStr

--- a/tests/spec/nul_safety_filesystem.test.ry
+++ b/tests/spec/nul_safety_filesystem.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from filesystem import listDir, walk, glob, copy, move, remove, removeAll, mkdir, mkdirAll, fileSize, isFile, isDir, isSymlink, chmod, symlink, readLink
 

--- a/tests/spec/nul_safety_http.test.ry
+++ b/tests/spec/nul_safety_http.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from http import response
 

--- a/tests/spec/nul_safety_http_client.test.ry
+++ b/tests/spec/nul_safety_http_client.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from http import httpGet, httpPost, httpRequest
 

--- a/tests/spec/nul_safety_io.test.ry
+++ b/tests/spec/nul_safety_io.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from io import readText, writeText, appendText, exists, deleteFile, readBytes, writeBytes, toBytes
 

--- a/tests/spec/nul_safety_net.test.ry
+++ b/tests/spec/nul_safety_net.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from net import bind, connect
 

--- a/tests/spec/nul_safety_path.test.ry
+++ b/tests/spec/nul_safety_path.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from path import join, basename, dirname, ext, resolve
 

--- a/tests/spec/numeric_literal_suffix.test.ry
+++ b/tests/spec/numeric_literal_suffix.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("integer literal suffix")
 fn integerLiteralSuffixTests():

--- a/tests/spec/numeric_literal_u64_scientific.test.ry
+++ b/tests/spec/numeric_literal_u64_scientific.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("u64 max value literal (#807)")
 fn u64MaxValueLiteral807Tests():

--- a/tests/spec/numeric_underscore_separator.test.ry
+++ b/tests/spec/numeric_underscore_separator.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("numeric underscore separators")
 fn numericUnderscoreSeparatorsTests():

--- a/tests/spec/operator_overload.test.ry
+++ b/tests/spec/operator_overload.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("operator[]")
 fn operatorIndexTests():

--- a/tests/spec/operator_overload_fn_type.test.ry
+++ b/tests/spec/operator_overload_fn_type.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("operator[] returning function type")
 fn operatorReturningFunctionTypeTests():

--- a/tests/spec/operators.test.ry
+++ b/tests/spec/operators.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, mock, verify
 
 fn makeIntResult(ok: bool, v: int, msg: str) -> Result<int, Error>:
   if ok:

--- a/tests/spec/option_branch_merge_none.test.ry
+++ b/tests/spec/option_branch_merge_none.test.ry
@@ -4,7 +4,7 @@
 # defaulted to Option<i8> or Option<i64> respectively, causing a type
 # mismatch with same-branch Some<T> values.
 
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("None() in if-expr then-branch (#1154)")
 fn noneInIfExprThenBranch1154Tests():

--- a/tests/spec/option_lambda_if.test.ry
+++ b/tests/spec/option_lambda_if.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 @describe("Option lambda if-expr inference (unannotated return type)")
 fn optionLambdaIfExprInferenceUnannotatedReturnTypeTests():

--- a/tests/spec/option_map.test.ry
+++ b/tests/spec/option_map.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 @describe("Option map")
 fn optionMapTests():

--- a/tests/spec/option_none_call.test.ry
+++ b/tests/spec/option_none_call.test.ry
@@ -5,7 +5,7 @@
 # paths were broken in let-decl and reassignment contexts because
 # isNoneLiteral did not recognise CallExpr{"None", args.empty()}.
 
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 gNoneCallOpt: Option<int> = Some(1)
 

--- a/tests/spec/option_propagate.test.ry
+++ b/tests/spec/option_propagate.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 fn safeGet(xs: List<int>, i: int) -> Option<int>:
   if i < 0 or i >= xs.len():

--- a/tests/spec/option_shorthand_metadata.test.ry
+++ b/tests/spec/option_shorthand_metadata.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 fn makeListOpt(v: List<int>) -> List<int>?:
   return Some(v)

--- a/tests/spec/parameterized.test.ry
+++ b/tests/spec/parameterized.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe, each, property
+from testing import it, describe, expect, each, property
 
 @describe("@each parameterized tests")
 fn eachParameterizedTests():

--- a/tests/spec/path.test.ry
+++ b/tests/spec/path.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from path import join, basename, dirname, ext, resolve, isAbsolute
 

--- a/tests/spec/pattern_arc.test.ry
+++ b/tests/spec/pattern_arc.test.ry
@@ -7,7 +7,7 @@
 # ASan / UBSan detect refcount underflows as use-after-free at scope exit.
 # The tests verify functional correctness; sanitizer runs verify memory safety.
 
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 record Box:
   items: List<int>

--- a/tests/spec/pattern_enum_nested.test.ry
+++ b/tests/spec/pattern_enum_nested.test.ry
@@ -2,7 +2,7 @@
 
 # ── Setup ────────────────────────────────────────────────────────────────────
 
-from testing import it, describe
+from testing import it, describe, expect
 
 enum Event:
     Click(int, int)

--- a/tests/spec/pattern_record.test.ry
+++ b/tests/spec/pattern_record.test.ry
@@ -10,7 +10,7 @@
 #   - Regression: existing record field access and patterns unaffected
 
 # Record types used throughout this spec file.
-from testing import it, describe
+from testing import it, describe, expect
 
 record Point:
   x: int

--- a/tests/spec/pattern_tuple.test.ry
+++ b/tests/spec/pattern_tuple.test.ry
@@ -10,7 +10,7 @@
 #   - case expression form
 #   - Regression: existing patterns unaffected
 
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("tuple pattern - binding")
 fn tuplePatternBindingTests():

--- a/tests/spec/print_result_option.test.ry
+++ b/tests/spec/print_result_option.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("print Result")
 fn printResultTests():

--- a/tests/spec/print_to_str_consistency.test.ry
+++ b/tests/spec/print_to_str_consistency.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 enum Color:
   Red

--- a/tests/spec/print_tuple_collection.test.ry
+++ b/tests/spec/print_tuple_collection.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("tuple display")
 fn tupleDisplayTests():

--- a/tests/spec/record_field_index.test.ry
+++ b/tests/spec/record_field_index.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("record_field_index")
 fn recordFieldIndexTests():

--- a/tests/spec/record_subtyping.test.ry
+++ b/tests/spec/record_subtyping.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record HttpError < Error:
   status: int

--- a/tests/spec/records.test.ry
+++ b/tests/spec/records.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record Point:
   x: int

--- a/tests/spec/regex_capture.test.ry
+++ b/tests/spec/regex_capture.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from regex import replace, regexReplace, findAll, regexFindAll
 

--- a/tests/spec/regex_literal.test.ry
+++ b/tests/spec/regex_literal.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from regex import isMatch, search, replace, split, findAll
 

--- a/tests/spec/regex_phase2.test.ry
+++ b/tests/spec/regex_phase2.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("range quantifiers")
 fn rangeQuantifiersTests():

--- a/tests/spec/regex_phase3.test.ry
+++ b/tests/spec/regex_phase3.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("word boundary \\b / \\B")
 fn wordBoundaryBBTests():

--- a/tests/spec/relative_import/mymath/mymath.test.ry
+++ b/tests/spec/relative_import/mymath/mymath.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from . import add, sub
 

--- a/tests/spec/relative_import/relative_import.test.ry
+++ b/tests/spec/relative_import/relative_import.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from .helper import greet
 from .mymath import add, sub

--- a/tests/spec/resource_arc.test.ry
+++ b/tests/spec/resource_arc.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from thread import lockNew, lockAcquire, lockRelease, lockFree, atomicIntNew, atomicIntLoad, atomicIntStore, atomicIntFree, threadSpawn, threadJoin
 

--- a/tests/spec/result.test.ry
+++ b/tests/spec/result.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 fn safeDivide(a: int, b: int) -> Result<int, Error>:
   if b == 0:

--- a/tests/spec/result_chain.test.ry
+++ b/tests/spec/result_chain.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 fn safeDivide(a: int, b: int) -> Result<int, Error>:
   if b == 0:

--- a/tests/spec/result_coerce.test.ry
+++ b/tests/spec/result_coerce.test.ry
@@ -2,7 +2,7 @@
 # Verifies that Ok/Err constructors can be coerced to match a type annotation
 # when the inferred struct layout differs from the annotation layout.
 
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 @describe("Result coercion — Err with collection payload")
 fn resultCoercionErrWithCollectionPayloadTests():

--- a/tests/spec/result_lambda_if.test.ry
+++ b/tests/spec/result_lambda_if.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 @describe("Result lambda if-expr inference (unannotated return type)")
 fn resultLambdaIfExprInferenceUnannotatedReturnTypeTests():

--- a/tests/spec/result_option_arc_return.test.ry
+++ b/tests/spec/result_option_arc_return.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/result_type_inference.test.ry
+++ b/tests/spec/result_type_inference.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 @describe("Result type inference in unannotated lambdas")
 fn resultTypeInferenceInUnannotatedLambdasTests():

--- a/tests/spec/return_check.test.ry
+++ b/tests/spec/return_check.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("return check - all paths return")
 fn returnCheckAllPathsReturnTests():

--- a/tests/spec/return_type_meta_enum.test.ry
+++ b/tests/spec/return_type_meta_enum.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 enum Color:
   Red

--- a/tests/spec/sequence.test.ry
+++ b/tests/spec/sequence.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/sleep.test.ry
+++ b/tests/spec/sleep.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("sleep")
 fn sleepTests():

--- a/tests/spec/str_arc.test.ry
+++ b/tests/spec/str_arc.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from runtime_internal import arcLiveCount
 

--- a/tests/spec/string_for_iteration.test.ry
+++ b/tests/spec/string_for_iteration.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("string for-loop iteration (#746, #827)")
 fn stringForLoopIteration746827Tests():

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 from io import bytesToStr, toBytes
 

--- a/tests/spec/thread.test.ry
+++ b/tests/spec/thread.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 from thread import threadSpawn, threadJoin, lockNew, lockAcquire, lockRelease, lockFree, rwlockNew, rwlockReadLock, rwlockWriteLock, rwlockUnlock, semaphoreNew, semaphoreAcquire, semaphoreRelease, barrierNew, barrierWait, atomicIntNew, atomicIntLoad, atomicIntStore, atomicIntAdd, atomicIntSub, atomicIntCas, atomicIntFree, atomicBoolNew, atomicBoolLoad, atomicBoolStore
 

--- a/tests/spec/to_str_union.test.ry
+++ b/tests/spec/to_str_union.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 fn show(x: int | str) -> str:
   return toStr(x)

--- a/tests/spec/top_level_bindings.test.ry
+++ b/tests/spec/top_level_bindings.test.ry
@@ -4,7 +4,7 @@
 # mutable `let`) can be read — and, for mutable bindings, written — from inside
 # any top-level function defined after the binding in the same module.
 
-from testing import it, describe
+from testing import it, describe, expect
 
 @const
 TOP_PI: float = 3.14

--- a/tests/spec/trailing_commas.test.ry
+++ b/tests/spec/trailing_commas.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("trailing commas")
 fn trailingCommasTests():

--- a/tests/spec/tuple_destructure_assign_parens.test.ry
+++ b/tests/spec/tuple_destructure_assign_parens.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("parenthesized tuple destructuring assignment (#1189)")
 fn parenthesizedTupleDestructuringAssignment1189Tests():

--- a/tests/spec/tuple_single_element.test.ry
+++ b/tests/spec/tuple_single_element.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("single-element tuple")
 fn singleElementTupleTests():

--- a/tests/spec/type_advanced.test.ry
+++ b/tests/spec/type_advanced.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 @describe("f-string")
 fn fStringTests():

--- a/tests/spec/type_of.test.ry
+++ b/tests/spec/type_of.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 record TypeOfPoint:
   x: int

--- a/tests/spec/types.test.ry
+++ b/tests/spec/types.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("int")
 fn intTests():

--- a/tests/spec/unsigned_negation.test.ry
+++ b/tests/spec/unsigned_negation.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("signed variable negation (regression)")
 fn signedVariableNegationRegressionTests():

--- a/tests/spec/user_fn_collection_return.test.ry
+++ b/tests/spec/user_fn_collection_return.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("List returned from user-defined function")
 fn listReturnedFromUserDefinedFunctionTests():

--- a/tests/spec/weak_ref.test.ry
+++ b/tests/spec/weak_ref.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe
+from testing import it, describe, expect, fail
 
 fn makeList() -> List<int>:
   return [10, 20, 30]


### PR DESCRIPTION
## Summary

Closes #714. Adds the constructs each `tests/spec/**/*.test.ry` actually uses (`expect`, `fail`, `mock`, `verify`, `each`, `property`) to its `from testing import ...` line, in canonical order:

```
from testing import it, describe[, expect][, fail][, mock][, verify][, each][, property]
```

This is mechanical preparation for #715 / #716, which will turn on enforcement (compile error if a testing intrinsic is used without being imported). Today the imports are tolerated as no-ops; once enforcement lands, every test file must list the constructs it actually uses.

### Distribution of changes

| Pattern | Count |
|---|---|
| `it, describe` → `it, describe, expect` | ~133 |
| `it, describe` → `it, describe, expect, fail` | ~33 |
| `it, describe` → `it, describe, expect, mock, verify` | 2 (`mock.test.ry`, `operators.test.ry`) |
| `it, describe, each, property` → `it, describe, expect, each, property` | 2 (`parameterized.test.ry`, `directive_test.test.ry`) |
| **Modified total** | **170** |
| Unchanged (no `expect(` usage) | 1 (`print_end_sep.test.ry`) |
| Skipped (entirely commented out) | 2 (`http_form.test.ry`, `http_listen.test.ry`) |

### Strategy

Used a per-file scan that detects which testing constructs each file actually invokes (`<name>(` for calls, `@<name>` for directives), then emits the canonical import line. Existing files already had `it, describe` listed first in the original order, and the scan preserves that order — new constructs are appended in canonical order.

The migration was driven by a one-off Python script kept outside the repo (`/tmp/migrate_714.py`). Not committed; the resulting diffs are mechanical and reviewable as-is.

## Verification

- ✅ `./build/ry test -p` (default): 173 pass
- ✅ `./build/ry_tests` (default): 2135 pass
- ✅ `./build-asan/ry test -p` (ASan + UBSan): 173 pass
- ✅ `./build-asan/ry_tests` (ASan + UBSan): 2135 pass
- ✅ TSan C++ tests: 2134/2135 — `HelpOption.FmtSubcommandHelp` was a flaky gtest assertion miss; re-running individually and the entire `HelpOption.*` group passed. No `WARNING: ThreadSanitizer` output. Subprocess spawn timing flake, pre-existing, unrelated to test file imports.
- ✅ Audit grep: for each of `expect` / `fail` / `mock` / `verify` / `each` / `property`, zero files use the construct without listing it in `from testing import`.
- ✅ `http_form.test.ry`, `http_listen.test.ry`: unchanged (intentional skip).

## Test plan

- [x] `./build/ry test -p` passes
- [x] `./build/ry_tests` passes
- [x] ASan/UBSan clean
- [x] TSan C++ run clean (no race warnings; one flaky gtest assertion in `HelpOption.FmtSubcommandHelp`, re-run passed)
- [x] Audit grep confirms no missing imports for any of the 6 constructs

## Skipped checks (per `/pre-commit-checklist` matrix)

- §1 Documentation Update — internal test-file import cleanup, no user-visible behavior change.
- §2 CHANGELOG — same reason; no fragment under `changelog.d/`.
- §3.5.5 Static Analysis — no `src/` or `include/` change; results identical to `origin/main`.
- §3.6 libFuzzer — no parser/lexer/json/utf8/string change.

## Out of scope

- Enforcement implementation (#715 = `expect/mock/verify/fail`, #716 = `@it/@describe`).
- testing docs update (#717).
- Ry-level implementation of `fail` / `expect` (#718, #719+).
- `share/std/testing/testing.ry` source changes (#712 / #713 already handled the loader and codegen-tracking sides).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for ARC memory management, operator overloads, and sequence operations.
  * Updated test infrastructure across all test files with consistent imports for assertion utilities.
  * Expanded test suite organization and improved test structure for better maintainability.

* **Chores**
  * Reorganized test imports for consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->