### PR TITLE
feat(codegen): enforce `from testing import` for expect/mock/verify/fail (#715)

### DIFF
--- a/changelog.d/715-require-testing-import.md
+++ b/changelog.d/715-require-testing-import.md
@@ -1,0 +1,15 @@
+### Changed
+
+- **Breaking**: `expect` / `mock` / `verify` / `fail` now require an
+  explicit `from testing import <name>` declaration in the test file.
+  Previously, codegen tracked which testing intrinsics were imported
+  (#713) but did not enforce the import; any `*.test.ry` file run via
+  `ry test` could call these intrinsics without declaring them. The
+  compiler now rejects unimported usage with `'<name>' requires
+  'from testing import <name>'` at codegen time, after the existing
+  test-mode check so non-test-mode usage still wins the more useful
+  "only allowed in test mode" diagnostic. All 171 in-tree spec files
+  were migrated to declare these imports under #714, so the suite
+  remains green; downstream test files that omitted the imports must
+  add them. `it` / `describe` enforcement is tracked separately under
+  #716. (#715)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -36,7 +36,7 @@ When `ry test` is run without arguments, it:
 
 ### Syntax
 
-Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Every name a test file uses — including `expect` and friends — must appear in an explicit `from testing import ...` line at the top:
+Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Every intrinsic a test file uses — `expect`, `mock`, `verify`, or `fail` — must appear in an explicit `from testing import ...` line at the top:
 
 ```ry
 from testing import it, describe, expect
@@ -189,7 +189,7 @@ Calculator
 
 ## Example
 
-```
+```ry
 from testing import it, describe, expect
 
 @describe("Arithmetic")
@@ -221,7 +221,7 @@ fn booleansTests():
 
 Replaces a function with a mock implementation for the current `it` block. The mock is automatically cleared when the `it` block ends.
 
-```
+```ry
 from testing import it, describe, mock, expect
 
 fn fetchData() -> str:
@@ -250,7 +250,7 @@ fn mockingTests():
 
 Returns the number of times a mocked function was called (as `int`).
 
-```
+```ry
 from testing import it, describe, mock, verify, expect
 
 @describe("verify")

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -36,10 +36,10 @@ When `ry test` is run without arguments, it:
 
 ### Syntax
 
-Use the `@it` and `@describe` directives to define test cases as ordinary named functions. Both directives are exported from the `testing` module and must be imported at the top of every test file:
+Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Every name a test file uses — including `expect` and friends — must appear in an explicit `from testing import ...` line at the top:
 
 ```ry
-from testing import it, describe
+from testing import it, describe, expect
 
 @it("test case name")
 fn testAdd():
@@ -49,7 +49,7 @@ fn testAdd():
 Group related tests using `@describe`:
 
 ```ry
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("Arithmetic")
 fn arithmeticTests():
@@ -73,6 +73,8 @@ fn arithmeticTests():
 Variables declared in the `@describe` function body are automatically captured by inner `@it` functions:
 
 ```ry
+from testing import it, describe, expect
+
 @describe("User validation")
 fn userValidationTests():
     minLength = 8
@@ -92,6 +94,8 @@ fn userValidationTests():
 `@describe` functions can be nested to create multi-level groupings. Output is indented to reflect the nesting depth:
 
 ```ry
+from testing import it, describe, expect
+
 @describe("API")
 fn apiTests():
     @describe("GET /users")
@@ -150,7 +154,9 @@ foo("arg", ():
 
 Immediately marks the current test as failed.
 
-```
+```ry
+from testing import it, fail
+
 @it("should not reach here")
 fn shouldNotReachHere():
     fail("unexpected error")
@@ -160,6 +166,7 @@ fn shouldNotReachHere():
 - `fail(msg)` — marks the test as failed with a custom message
 - Execution continues after `fail()` (does not abort the test)
 - Only available in `ry test` mode
+- Requires `from testing import fail`
 
 ---
 
@@ -183,7 +190,7 @@ Calculator
 ## Example
 
 ```
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("Arithmetic")
 fn arithmeticTests():
@@ -215,6 +222,8 @@ fn booleansTests():
 Replaces a function with a mock implementation for the current `it` block. The mock is automatically cleared when the `it` block ends.
 
 ```
+from testing import it, describe, mock, expect
+
 fn fetchData() -> str:
     return "real data"
 
@@ -235,12 +244,15 @@ fn mockingTests():
 - The replacement must have the same parameter types and return type as the original function
 - `require` and `ensure` contracts on the original function are still enforced when the mock is called
 - Mocks are automatically restored at the end of each `it` block
+- Requires `from testing import mock`
 
 ### verify(fnName)
 
 Returns the number of times a mocked function was called (as `int`).
 
 ```
+from testing import it, describe, mock, verify, expect
+
 @describe("verify")
 fn verifyTests():
     @it("should count calls")
@@ -250,6 +262,8 @@ fn verifyTests():
         fetchData()
         expect(verify(fetchData)).toEq(2)
 ```
+
+- Requires `from testing import verify`
 
 ### Limitations
 
@@ -266,6 +280,8 @@ fn verifyTests():
 **Syntax:**
 
 ```ry
+from testing import it, expect
+
 @each([
     (1, 2, 3),
     (0, 0, 0),
@@ -288,6 +304,8 @@ fn testAdd(a: int, b: int, expected: int):
 `@property` generates random inputs and runs the test multiple times.
 
 ```ry
+from testing import it, expect
+
 @property(count=100)
 @it("should verify addition is commutative")
 fn testCommutative(a: int, b: int):

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -855,8 +855,9 @@ public:
 
     // Testing intrinsics imported via `from testing import ...`. Set by
     // setTestingIntrinsicsImported() from ModuleLoader::importedTestingIntrinsics()
-    // before compile(). Reserved for future enforcement (#715/#716);
-    // currently unused by codegen.
+    // before compile(). Used by codegen to enforce that `expect`/`mock`/`verify`/
+    // `fail` require an explicit import (#715). `it`/`describe` enforcement is
+    // tracked separately under #716.
     std::unordered_set<std::string> testing_intrinsics_imported_;
 
     // User-defined @directive declarations. Keyed by directive name.

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -63,6 +63,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
     if (e->callee == "verify") {
         if (!test_mode_)
             codegenError("'verify' is only allowed in test mode (use 'ry test')");
+        // CallExpr has no `loc` field; rely on `current_loc_`, which `emitExpr`
+        // (src/codegen_expr.cpp:71) sets from the enclosing ExprNode.loc before
+        // dispatching to emitExprVariant. The `verify` branch is reached only
+        // through that path, so `current_loc_` is valid here.
+        if (!testing_intrinsics_imported_.count("verify"))
+            codegenError("'verify' requires 'from testing import verify'");
         if (e->args.size() != 1)
             codegenError("verify() requires exactly 1 argument");
         auto *strExpr = std::get_if<StringExpr>(&e->args[0]->data);

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -498,6 +498,8 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
 void CodeGen::emitMockCall(CallStmt &s) {
     if (!test_mode_)
         codegenError("'mock' is only allowed in test mode (use 'ry test')");
+    if (!testing_intrinsics_imported_.count("mock"))
+        codegenError(s.loc, "'mock' requires 'from testing import mock'");
 
     if (s.args.size() != 2)
         codegenError("mock() requires exactly 2 arguments: function name and replacement");
@@ -563,6 +565,8 @@ void CodeGen::emitStmt(ExpectStmt &s) {
     emitCoverage(s.loc);
     if (!test_mode_)
         codegenError("'expect' is only allowed in test mode (use 'ry test')");
+    if (!testing_intrinsics_imported_.count("expect"))
+        codegenError(s.loc, "'expect' requires 'from testing import expect'");
 
     llvm::Value *actualVal = emitExpr(*s.actual);
     llvm::Type *actualTy = actualVal->getType();
@@ -956,6 +960,8 @@ void CodeGen::emitStmt(ExpectStmt &s) {
 void CodeGen::emitFailCall(CallStmt &s) {
     if (!test_mode_)
         codegenError("'fail' is only allowed in test mode (use 'ry test')");
+    if (!testing_intrinsics_imported_.count("fail"))
+        codegenError(s.loc, "'fail' requires 'from testing import fail'");
 
     if (s.args.size() > 1)
         codegenError("fail() expects 0 or 1 argument(s), but got " + std::to_string(s.args.size()));

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -105,12 +105,37 @@ protected:
         }
     }
 
+    // The codegen test harness skips ModuleLoader (see CodeGenTest::compileSource).
+    // In production, jit_runner.cpp:165 calls
+    // `cg.setTestingIntrinsicsImported(loader.importedTestingIntrinsics())`
+    // so codegen knows which testing intrinsics the source imported. For the
+    // test harness we mimic the wildcard `from testing` import for the four
+    // names enforced by #715 (expect/mock/verify/fail), so existing tests that
+    // embed those intrinsics literally in their source strings continue to
+    // compile. `it` / `describe` are intentionally omitted: when #716 adds
+    // their enforcement, its negative tests must NOT be written via this
+    // helper (they would pass vacuously). Use `runTestSourceNoTestingImports`
+    // for tests that intentionally exercise the missing-import error.
     static std::string runTestSource(const std::string &src) {
         Lexer lex(src);
         Parser parser(lex);
         Program prog = parser.parseProgram();
 
         CodeGen cg(true);  // test_mode = true
+        cg.setTestingIntrinsicsImported({"expect", "mock", "verify", "fail"});
+        auto tsm = cg.compile(prog);
+        return runModule(std::move(tsm));
+    }
+
+    // Same as runTestSource but does NOT inject any testing intrinsic imports.
+    // Use this when writing a negative test that asserts the
+    // `'<name>' requires 'from testing import <name>'` enforcement fires.
+    static std::string runTestSourceNoTestingImports(const std::string &src) {
+        Lexer lex(src);
+        Parser parser(lex);
+        Program prog = parser.parseProgram();
+
+        CodeGen cg(true);
         auto tsm = cg.compile(prog);
         return runModule(std::move(tsm));
     }

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -41,6 +41,29 @@ TEST_F(CodeGenTest, FailOutsideTestModeIsRejected) {
 }
 
 // ============================================================
+// Diagnostic precedence: when a call is made outside test mode
+// AND without `from testing import ...`, the "only allowed in
+// test mode" error must win over the missing-import error
+// (#715). This pins the order of the two checks at every site:
+// the `!test_mode_` guard fires first, the import guard second.
+// Use `runSource` (test_mode = false, no import injection) so
+// both conditions are simultaneously violated.
+// ============================================================
+
+TEST_F(CodeGenTest, ExpectOutsideTestModeWinsOverImportCheck) {
+    try {
+        runSource("expect(1).toEq(1)\n");
+        FAIL() << "Expected compile error";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("only allowed in test mode"), std::string::npos)
+            << "got: " << msg;
+        EXPECT_EQ(msg.find("requires 'from testing import"), std::string::npos)
+            << "import check must NOT fire first; got: " << msg;
+    }
+}
+
+// ============================================================
 // Testing intrinsics (expect / mock / verify / fail) require
 // the matching `from testing import <name>`. Without it codegen
 // must reject the use even when running in test mode (#715).

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -41,6 +41,70 @@ TEST_F(CodeGenTest, FailOutsideTestModeIsRejected) {
 }
 
 // ============================================================
+// Testing intrinsics (expect / mock / verify / fail) require
+// the matching `from testing import <name>`. Without it codegen
+// must reject the use even when running in test mode (#715).
+// `runTestSourceNoTestingImports` is the only fixture that does
+// not auto-inject the imports.
+// ============================================================
+
+TEST_F(CodeGenTest, ExpectRequiresTestingImport) {
+    try {
+        runTestSourceNoTestingImports("expect(1).toEq(1)\n");
+        FAIL() << "Expected compile error";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("requires 'from testing import expect'"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+TEST_F(CodeGenTest, MockRequiresTestingImport) {
+    try {
+        runTestSourceNoTestingImports(
+            "fn greet() -> str:\n"
+            "  return \"hi\"\n"
+            "mock(greet, () => \"mocked\")\n"
+        );
+        FAIL() << "Expected compile error";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("requires 'from testing import mock'"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+TEST_F(CodeGenTest, VerifyRequiresTestingImport) {
+    try {
+        runTestSourceNoTestingImports(
+            "fn greet() -> str:\n"
+            "  return \"hi\"\n"
+            "x = verify(\"greet\")\n"
+        );
+        FAIL() << "Expected compile error";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("requires 'from testing import verify'"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+TEST_F(CodeGenTest, FailRequiresTestingImport) {
+    try {
+        runTestSourceNoTestingImports("fail(\"oops\")\n");
+        FAIL() << "Expected compile error";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("requires 'from testing import fail'"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// ============================================================
 // Null coalescing (`??`) rejects non-Option/non-Result operands
 // ============================================================
 


### PR DESCRIPTION
## Summary

- Codegen now rejects use of `expect` / `mock` / `verify` / `fail` unless the matching `from testing import <name>` is present (test mode). The import set tracked by #713 was previously unused; this PR turns it into hard enforcement.
- Error precedence is preserved: the existing `!test_mode_` check fires first, so non-test usage still wins the more useful "only allowed in test mode" diagnostic.
- The C++ test harness (`runTestSource`) bypasses `ModuleLoader`, so it now auto-injects the four enforced names to keep existing tests green; `runTestSourceNoTestingImports` is the new helper for negative tests.
- `it` / `describe` enforcement is tracked separately under #716.

Closes #715.

## Changes

- `src/codegen_test.cpp` — guard added at `emitMockCall`, `emitStmt(ExpectStmt&)`, `emitFailCall`.
- `src/codegen_call_dispatch.cpp` — guard added at the `verify` branch in `emitExprVariant<CallExpr>` (uses `current_loc_` since `CallExpr` has no `loc`).
- `tests/test_codegen_common.hpp` — `runTestSource` injects `{expect, mock, verify, fail}`; new `runTestSourceNoTestingImports` for negative tests. Comment block documents the harness convention and the #716 footgun.
- `tests/test_codegen_fail.cpp` — 4 new regression tests pinning the `'<name>' requires 'from testing import <name>'` message.
- `docs/reference/testing.md` — example code updated to include the now-mandatory imports; explicit "Requires …" bullets added for `mock` / `verify` / `fail`.
- `include/ry/codegen.hpp` — comment on `testing_intrinsics_imported_` updated (drop "reserved" wording).
- `changelog.d/715-require-testing-import.md` — breaking change fragment.

## Test plan

- [x] `cmake --build build` succeeds.
- [x] `./build/ry_tests` — 2139 passed.
- [x] `./build/ry_tests --gtest_filter='*RequiresTestingImport*'` — 4 new tests pass.
- [x] `./build/ry test -p` — 173 spec files, 0 failures.
- [x] ASan + UBSan: `ry_tests` 2139 passed / `ry test -p` 173 files 0 failures.
- [x] TSan: `ry_tests` 2139 passed (Ry self-test warn-only via upstream `LargeMmapAllocator`).
- [x] cppcheck clean / clang-tidy no errors on changed files.
- [x] CLI smoke test:
  ```
  $ printf 'expect(1).toEq(1)\n' > /tmp/no_import.test.ry
  $ ./build/ry test /tmp/no_import.test.ry
  error: 'expect' requires 'from testing import expect'
    --> /tmp/no_import.test.ry:1:1
  ```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Testing intrinsics (expect, mock, verify, fail) now require explicit imports from the testing module in test files; unimported usage is rejected at compile/codegen time.

* **Documentation**
  * Testing reference updated with examples showing required named imports and guidance.

* **Tests**
  * Test harness and test-suite updated to cover and enforce the new import requirement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->