### PR TITLE
feat(codegen): enforce `from testing import` for @it/@describe (#716)

### DIFF
--- a/changelog.d/716-enforce-it-describe-imports.md
+++ b/changelog.d/716-enforce-it-describe-imports.md
@@ -1,0 +1,14 @@
+### Changed
+
+- **Breaking**: `@it("...")` and `@describe("...")` directives now
+  require an explicit `from testing import it, describe` (or the
+  subset used) declaration in the test file. Codegen rejects
+  unimported usage with `'@it' requires 'from testing import it'`
+  or `'@describe' requires 'from testing import describe'` after
+  the existing test-mode check, so non-test-mode usage still wins
+  the more useful "only allowed in test mode" diagnostic. This
+  completes the enforcement story started in #715 (which covered
+  `expect` / `mock` / `verify` / `fail`). All `tests/spec/*.test.ry`
+  files already declare these imports after the #714 migration,
+  so the Ry self-test suite remains green; downstream test files
+  that omitted the imports must add them. (#716)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -36,7 +36,7 @@ When `ry test` is run without arguments, it:
 
 ### Syntax
 
-Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Every intrinsic a test file uses — `expect`, `mock`, `verify`, or `fail` — must appear in an explicit `from testing import ...` line at the top:
+Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Every directive and intrinsic a test file uses must appear in an explicit `from testing import ...` line at the top; codegen rejects unimported usage with `'<name>' requires 'from testing import <name>'`:
 
 ```ry
 from testing import it, describe, expect

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -324,6 +324,8 @@ static void stripDirectives(
 void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     if (!test_mode_)
         codegenError("@it is only allowed in test mode (use 'ry test')");
+    if (!testing_intrinsics_imported_.count("it"))
+        codegenError(s->loc, "'@it' requires 'from testing import it'");
     if (s->is_async)
         codegenError("@it: fn '" + s->name + "' cannot be async");
     if (!s->type_params.empty())
@@ -452,6 +454,8 @@ void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
 void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
     if (!test_mode_)
         codegenError("@describe is only allowed in test mode (use 'ry test')");
+    if (!testing_intrinsics_imported_.count("describe"))
+        codegenError(s->loc, "'@describe' requires 'from testing import describe'");
     if (s->is_async)
         codegenError("@describe: fn '" + s->name + "' cannot be async");
     if (!s->type_params.empty())

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -109,20 +109,19 @@ protected:
     // In production, jit_runner.cpp:165 calls
     // `cg.setTestingIntrinsicsImported(loader.importedTestingIntrinsics())`
     // so codegen knows which testing intrinsics the source imported. For the
-    // test harness we mimic the wildcard `from testing` import for the four
-    // names enforced by #715 (expect/mock/verify/fail), so existing tests that
-    // embed those intrinsics literally in their source strings continue to
-    // compile. `it` / `describe` are intentionally omitted: when #716 adds
-    // their enforcement, its negative tests must NOT be written via this
-    // helper (they would pass vacuously). Use `runTestSourceNoTestingImports`
-    // for tests that intentionally exercise the missing-import error.
+    // test harness we mimic the wildcard `from testing` import for the six
+    // enforced names (expect/mock/verify/fail from #715, plus it/describe
+    // from #716), so existing tests that embed those intrinsics or directives
+    // literally in their source strings continue to compile. Negative tests
+    // that intentionally exercise the missing-import error must use
+    // `runTestSourceNoTestingImports` instead.
     static std::string runTestSource(const std::string &src) {
         Lexer lex(src);
         Parser parser(lex);
         Program prog = parser.parseProgram();
 
         CodeGen cg(true);  // test_mode = true
-        cg.setTestingIntrinsicsImported({"expect", "mock", "verify", "fail"});
+        cg.setTestingIntrinsicsImported({"expect", "mock", "verify", "fail", "it", "describe"});
         auto tsm = cg.compile(prog);
         return runModule(std::move(tsm));
     }

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -128,6 +128,48 @@ TEST_F(CodeGenTest, FailRequiresTestingImport) {
 }
 
 // ============================================================
+// `@it` / `@describe` directives also require their matching
+// `from testing import` (#716, sibling of #715 above). The
+// directives are stdlib-declared, so the source must be wrapped
+// with `withStdlibDirectiveDecls`. The fn omits a return type
+// annotation because `@it` / `@describe` reject one outright.
+// The body is a trivial assignment so the import check at the
+// top of the directive emitter is the only path that can throw.
+// ============================================================
+
+TEST_F(CodeGenTest, ItRequiresTestingImport) {
+    try {
+        runTestSourceNoTestingImports(withStdlibDirectiveDecls(
+            "@it(\"sample\")\n"
+            "fn sample():\n"
+            "    x = 1\n"
+        ));
+        FAIL() << "Expected compile error";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("requires 'from testing import it'"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+TEST_F(CodeGenTest, DescribeRequiresTestingImport) {
+    try {
+        runTestSourceNoTestingImports(withStdlibDirectiveDecls(
+            "@describe(\"sample group\")\n"
+            "fn sampleGroup():\n"
+            "    x = 1\n"
+        ));
+        FAIL() << "Expected compile error";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("requires 'from testing import describe'"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// ============================================================
 // Null coalescing (`??`) rejects non-Option/non-Result operands
 // ============================================================
 


### PR DESCRIPTION
## Summary

- Sibling enforcement to #715 (which covered `expect`/`mock`/`verify`/`fail`).
- `@it("...")` / `@describe("...")` directives now require an explicit `from testing import it, describe` (or the subset used). Codegen rejects unimported usage with `'@it' requires 'from testing import it'` or `'@describe' requires 'from testing import describe'`.
- Diagnostic order: the new import check fires **after** the existing `!test_mode_` guard, so non-test-mode usage still wins the more useful "only allowed in test mode" diagnostic (matches the #715 ordering pinned by `ExpectOutsideTestModeWinsOverImportCheck`).
- All `tests/spec/*.test.ry` files already declare these imports after #714, so the Ry self-test suite remains green.

Closes #716.

## Changes

- `src/codegen_test.cpp` — `emitItDirective` / `emitDescribeDirective` add the import check after the test-mode guard.
- `tests/test_codegen_common.hpp` — `runTestSource` injection set extended to include `it`/`describe` (matches #715 pattern). Comment block updated to reflect that #716 completes the enforcement story.
- `tests/test_codegen_fail.cpp` — adds `ItRequiresTestingImport` / `DescribeRequiresTestingImport` using `runTestSourceNoTestingImports` + `withStdlibDirectiveDecls`. The fn body is a trivial assignment so the import check at the top of the directive emitter is the only path that can throw.
- `docs/reference/testing.md` — wording updated so that "every directive and intrinsic" must be imported, with the diagnostic format inlined.
- `changelog.d/716-enforce-it-describe-imports.md` — new fragment under `### Changed` (Breaking).

## Out of scope

- The deprecated `it("...", ():)` / `describe("...", ():)` lambda-syntax dispatch in `src/codegen_call_user.cpp` mentioned in the issue body was already removed in #1602; no work needed there.

## Test plan

- [x] `cmake --build build && ./build/ry_tests` — 2142 pass.
- [x] `./build/ry test -p` — 173 files, 0 failures.
- [x] `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests && ... ./build-asan/ry test -p` — clean.
- [x] `cmake --preset tsan && cmake --build build-tsan && TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests` — 2142 pass (Ry self-test warn-only per the LargeMmapAllocator known issue).
- [x] `clang-tidy` baseline preserved (new code is two simple `if` statements).
- [x] `cppcheck` clean.
- [x] §3.6 libFuzzer skipped per the matrix — no parser/lexer/json/utf8/string changes.
- [x] New rejection branches each have a direct trigger test (`ItRequiresTestingImport` / `DescribeRequiresTestingImport`) per `.claude/rules/tests-rejection-tdd.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Testing directives (`@it`, `@describe`) now require explicit imports from the testing module. Test files must include `from testing import it` and/or `from testing import describe` at the top level.

* **Documentation**
  * Updated testing reference documentation to clarify explicit import requirements for all testing directives and utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->