### PR TITLE
docs(reference): add explicit testing imports to directives.md examples (#717)

### DIFF
--- a/changelog.d/717-update-testing-docs.md
+++ b/changelog.d/717-update-testing-docs.md
@@ -1,0 +1,17 @@
+### Changed
+
+- `docs/reference/directives.md` testing-related code examples now
+  declare an explicit `from testing import ...` line at the top of
+  each `@each` / `@property` / `@it` / `@describe` block, matching
+  the codegen enforcement introduced in #715 (`expect` / `mock` /
+  `verify` / `fail`) and #716 (`@it` / `@describe`). Previously the
+  prose stated the imports were required but the example bodies
+  omitted them, so the concrete examples (Basic / Composed / Shared
+  setup / Nested) would have been rejected by codegen for missing
+  imports. Each block lists only the names it actually uses
+  (per-block tailored, including non-codegen-enforced names like
+  `each` / `property` for pedagogical consistency), matching the
+  convention already in `docs/reference/testing.md`. The "Syntax:"
+  templates use placeholder bodies (`# test body`, `# assertions`)
+  that do not parse on their own; converting those templates to
+  runnable examples is tracked in #1629. (#717)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -305,6 +305,8 @@ Enables parameterized testing by running a test multiple times with different pa
 **Syntax:**
 
 ```ry
+from testing import it, each
+
 @each([(arg1, arg2, ...), ...])
 @it("should handle {0} and {1}")
 fn testHandle(param1: type, param2: type):
@@ -314,6 +316,8 @@ fn testHandle(param1: type, param2: type):
 The argument can be any expression that evaluates to a list of tuples, including a function call:
 
 ```ry
+from testing import it, each
+
 @each(makeInputs())
 @it("should handle {0}")
 fn testHandle(x: int):
@@ -336,6 +340,8 @@ Enables property-based testing by generating random inputs for a test.
 **Syntax:**
 
 ```ry
+from testing import it, property
+
 @property(count=100)
 @it("should verify property name")
 fn testProperty(a: int, b: int):
@@ -370,6 +376,8 @@ Declares a test case by attaching the directive to a named function. The functio
 **Syntax:**
 
 ```ry
+from testing import it
+
 @it("description")
 fn testName():
     # assertions
@@ -378,6 +386,8 @@ fn testName():
 **Basic example:**
 
 ```ry
+from testing import it, expect
+
 @it("should add 1 + 2 = 3")
 fn testAdd():
     expect(1 + 2).toEq(3)
@@ -386,6 +396,8 @@ fn testAdd():
 **Composed with `@each` or `@property`:**
 
 ```ry
+from testing import it, each, property, expect
+
 @each([(1, 2, 3), (0, 0, 0), (-1, 1, 0)])
 @it("should add {0} + {1} = {2}")
 fn testAddEach(a: int, b: int, expected: int):
@@ -414,6 +426,8 @@ Groups a set of related tests by attaching the directive to a named function. In
 **Syntax:**
 
 ```ry
+from testing import it, describe
+
 @describe("group name")
 fn groupName():
     @it("nested test")
@@ -424,6 +438,8 @@ fn groupName():
 **Basic example:**
 
 ```ry
+from testing import it, describe, expect
+
 @describe("arithmetic")
 fn arithmeticTests():
     @it("should subtract")
@@ -440,6 +456,8 @@ fn arithmeticTests():
 Variables declared in the outer `@describe` body are automatically captured by every inner `@it` function.
 
 ```ry
+from testing import it, describe, expect
+
 @describe("shared setup")
 fn sharedSetupTests():
     base = 100
@@ -457,6 +475,8 @@ fn sharedSetupTests():
 **Nested groups:**
 
 ```ry
+from testing import it, describe, expect
+
 @describe("outer")
 fn outer():
     @describe("inner")


### PR DESCRIPTION
## Summary

Final docs PR in the rolling rollout (parent #703) that enforces explicit `from testing import ...` in test files. This PR addresses `docs/reference/directives.md`, which previously stated the imports were required but omitted them from the concrete code examples.

- Adds `from testing import ...` to the 10 testing-related code blocks (`@each` / `@property` / `@it` / `@describe`).
- Each block lists only the names it actually uses (per-block tailored, including non-codegen-enforced names like `each` / `property` for pedagogical consistency), matching the convention already in `docs/reference/testing.md`.
- The concrete examples (Basic / Composed / Shared setup / Nested) would have been rejected by codegen for missing imports prior to this change.

### Scope clarification

The "Syntax:" templates use placeholder bodies (`# test body`, `# assertions`) that do not parse on their own. Converting those templates to runnable examples is tracked separately in #1629 — it is intentionally out-of-scope for this PR (which is strictly the import enforcement follow-up).

Closes #717

## Test plan

- [x] All 10 modified blocks self-verified by extracting to `/tmp/snippet_*.test.ry` and running `./build/ry test`. Concrete-example blocks (with real `expect(...)` bodies) execute cleanly with the new imports. Syntax-template blocks were verified to parse the import line correctly; the placeholder bodies remain unparseable per #1629.
- [x] `docs/reference/testing.md` re-checked — all 10 blocks already had correct `from testing import ...`, no edits needed.
- [x] `docs/` swept — no other testing directive/intrinsic examples missing imports.
- [x] Pre-commit checklist: doc-only PR. §1 / §2 satisfied by edits themselves; §3-§3.6 skipped (no source code change); §3.7 confirmed clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated examples for testing directives (`@each`, `@property`, `@it`, `@describe`) to include explicit import statements from the testing module. Examples now consistently display `from testing import ...` syntax and related imports like `expect` where applicable, ensuring users can copy examples with proper imports and maintaining alignment with current best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->