### PR TITLE
docs(reference): convert testing Syntax templates to runnable examples (#1629)

### DIFF
--- a/changelog.d/1629-fix-syntax-templates.md
+++ b/changelog.d/1629-fix-syntax-templates.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- `docs/reference/directives.md` testing-related "Syntax:" templates
+  (`@each`, `@property`, `@it`, `@describe`) no longer use placeholder
+  bodies (`# test body`, `# assertions`), placeholder type names
+  (`param1: type`), placeholder argument tuples (`(arg1, arg2, ...)`),
+  or undefined function references (`makeInputs()`) that the parser
+  rejected. All five affected blocks are now runnable examples with
+  concrete types, values, and `expect(...)` bodies, matching the
+  convention already established in `docs/reference/testing.md`.
+  Each updated block also adds `expect` to its `from testing import`
+  line. The `@each` w/ function-call block now defines a small
+  `fn makeInputs() -> List<(int, int)>` helper inline so the
+  function-call-as-argument lesson stands on its own. Companion to
+  #717, which addressed the codegen-import side of the same drift.
+  (#1629)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -305,23 +305,26 @@ Enables parameterized testing by running a test multiple times with different pa
 **Syntax:**
 
 ```ry
-from testing import it, each
+from testing import it, each, expect
 
-@each([(arg1, arg2, ...), ...])
-@it("should handle {0} and {1}")
-fn testHandle(param1: type, param2: type):
-    # test body
+@each([(1, 2), (3, 6), (5, 10)])
+@it("should double {0} as {1}")
+fn testDouble(input: int, expected: int):
+    expect(input * 2).toEq(expected)
 ```
 
 The argument can be any expression that evaluates to a list of tuples, including a function call:
 
 ```ry
-from testing import it, each
+from testing import it, each, expect
+
+fn makeInputs() -> List<(int, int)>:
+    return [(1, 1), (2, 4), (3, 9)]
 
 @each(makeInputs())
-@it("should handle {0}")
-fn testHandle(x: int):
-    # test body
+@it("should square {0} as {1}")
+fn testSquare(n: int, expected: int):
+    expect(n * n).toEq(expected)
 ```
 
 **Supported targets:** functions with the `@it` directive.
@@ -340,12 +343,12 @@ Enables property-based testing by generating random inputs for a test.
 **Syntax:**
 
 ```ry
-from testing import it, property
+from testing import it, property, expect
 
 @property(count=100)
-@it("should verify property name")
-fn testProperty(a: int, b: int):
-    # test body with random values
+@it("should verify multiplication is commutative")
+fn testCommutative(a: int, b: int):
+    expect(a * b).toEq(b * a)
 ```
 
 **Supported targets:** functions with the `@it` directive.
@@ -376,11 +379,11 @@ Declares a test case by attaching the directive to a named function. The functio
 **Syntax:**
 
 ```ry
-from testing import it
+from testing import it, expect
 
-@it("description")
-fn testName():
-    # assertions
+@it("should pass simple assertion")
+fn testCase():
+    expect(true).toBeTrue()
 ```
 
 **Basic example:**
@@ -426,13 +429,13 @@ Groups a set of related tests by attaching the directive to a named function. In
 **Syntax:**
 
 ```ry
-from testing import it, describe
+from testing import it, describe, expect
 
 @describe("group name")
 fn groupName():
-    @it("nested test")
+    @it("should pass nested test")
     fn testNested():
-        # assertions
+        expect(true).toBeTrue()
 ```
 
 **Basic example:**


### PR DESCRIPTION
## Summary

- Replaces 5 placeholder-based "Syntax:" code blocks in `docs/reference/directives.md` (`@each`, `@each` w/ function-call, `@property`, `@it`, `@describe`) with runnable examples that the parser actually accepts.
- Removes the parser-rejected placeholders: `# test body`, `# assertions`, `# test body with random values`, `param1: type`, `(arg1, arg2, ...)`, undefined `makeInputs()`.
- The `@each` w/ function-call block now defines `fn makeInputs() -> List<(int, int)>` inline so the function-call-as-argument lesson stands on its own.
- The `@property` Syntax uses `multiplication is commutative` to differentiate from the `@it` Composed example below it (which uses addition).
- Each updated block adds `expect` to its `from testing import` line (consistent with #717's import-side fix).

Companion to #717, which addressed the codegen-import side of the same drift. Closes #1629.

## Test plan

- [x] All 5 code blocks extracted to `/tmp/snippet_*.test.ry` and run with `./build/ry test`; every test case green.
- [x] `./build/ry_tests` — 2142/2142 C++ tests pass.
- [x] `./build/ry test -p` — all 173 Ry spec files pass.
- [x] `grep -nE "# test body|# assertions|# test body with random values" docs/reference/directives.md` returns no hits.
- [x] `grep -nE "param1: type|arg1, arg2|makeInputs\(" docs/reference/directives.md` returns no hits in placeholder positions (the inline `makeInputs()` definition is intentional).
- [x] Pre-commit checklist matrix: doc-only PR — §1 satisfied by edit, §2 satisfied by changelog fragment, §3/§3.5/§3.6 skipped per "no source code change", §4 deferred to `git-merge-pr`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Significantly enhanced examples for testing directives (@each, @property, @it, @describe) with complete, runnable code samples featuring concrete test assertions and proper structure.
  * Updated and standardized testing import statements across all directive examples to include assertion utilities, improving documentation consistency and guiding users toward best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->