### PR TITLE
feat(testing): implement fail() as Ry function with @native runtime call (#718)

### DIFF
--- a/.claude/rules/tests-cpp-conventions.md
+++ b/.claude/rules/tests-cpp-conventions.md
@@ -49,6 +49,24 @@ The codegen test harness (`runSource`, `runSourceWithWarnings`, `runTestSource`,
 
 **Why a smoke test is still needed**: The helper bypasses the actual `ModuleLoader` → `builtins.ry` re-export chain, so all-green C++ tests prove the codegen logic but not the loader path. Always also run a smoke test through the real CLI (`./build/ry /tmp/<file>.ry`) when changing the directive declaration locations or the re-export wiring.
 
+### Stdlib `@native` fns reachable from `runTestSource` need APPENDED inline decls (not prepended)
+
+**Source**: #718 (2026-05-07, implementation)
+**Tags**: testing, codegen-test, stdlib, module-loader, harness, line-number, fail
+
+**Context**: After #718, `fail()` is no longer a compiler builtin — its body lives in `share/std/testing/testing.ry` as a Ry function that calls `_reportFail` (`@native("testing")`). For a normal `./build/ry test` invocation the loader resolves `from testing import fail` and codegen sees `fail` as a regular user function. The C++ codegen test harness (`runTestSource` / `runTestSourceNoTestingImports` in `tests/test_codegen_common.hpp`) skips `ModuleLoader` entirely and therefore never sees those declarations — `fail(…)` lookup at codegen time fails with `undefined function: fail`.
+
+**Rule**: When a stdlib `@native` fn (or a Ry fn that wraps a `@native` symbol) becomes reachable from C++ test sources after migration from compiler-magic, inject the inline declarations into the test harness via a helper analogous to `withStdlibDirectiveDecls`. For #718 the helper is `withTestingFnDecls` — it appends `_reportFail` and `fail` declarations to the user source and is applied **inside** `runTestSource` / `runTestSourceNoTestingImports` so existing call sites need no opt-in.
+
+**Why APPEND (not prepend)**: Some tests assert specific line numbers in the printed output (e.g. `CodeGenTest.FailWithMessage` expects the failure to report `line 21`). Prepending decls shifts every user-source line and breaks those assertions silently — the test still runs, but the diagnostic line number is off by the number of injected lines. Appending preserves user-source line numbers because all injected lines come after the user's last meaningful line.
+
+**How to apply**:
+- Adding a new test that uses `fail(...)` (or any future migrated stdlib fn): no opt-in needed — `runTestSource` already injects the decls. Just write the test as if `fail` were a builtin.
+- Adding a new stdlib-migrated fn that other tests must call: extend `withTestingFnDecls` (or add a parallel helper) with the new declaration and the `@native(...)` symbol decl it wraps. Apply via the relevant `runTestSource*` entry points.
+- Tests that assert specific source line numbers in output: keep using the APPEND pattern. A future "prepend" temptation (e.g. to make decls visible to a forward-reference analysis) must come with explicit accounting for the line-shift impact on every line-asserting test.
+
+**Smoke verification**: As with `withStdlibDirectiveDecls`, the helper bypasses the real `ModuleLoader` → `from testing import fail` chain. Run a smoke test through the real CLI (`./build/ry test /tmp/<file>.test.ry`) when changing the testing.ry declarations or the loader wiring for testing intrinsics.
+
 ### CodeGenTest::runSource cannot compile code that imports stdlib modules
 
 **Source**: #842 (2026-04-11, implementation)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,7 @@ add_ry_native_lib(path       src/runtime_path.cpp)
 add_ry_native_lib(convert    src/runtime_convert.cpp)
 add_ry_native_lib(filesystem src/runtime_filesystem.cpp)
 add_ry_native_lib(gc         src/runtime_gc.cpp)
+add_ry_native_lib(testing    src/runtime_testing.cpp)
 
 # All native libs are independent — no inter-library link dependencies.
 # __ry_set_last_error / __ry_get_last_error live in ry_lib (the main executable)
@@ -296,7 +297,7 @@ add_ry_native_lib(http       src/runtime_http.cpp src/runtime_http_client.cpp
                              src/runtime_tls.cpp src/runtime_hash.cpp)
 target_link_libraries(ry_http PRIVATE OpenSSL::SSL OpenSSL::Crypto Threads::Threads)
 
-set(RY_NATIVE_LIBS ry_base64 ry_path ry_convert ry_filesystem ry_gc ry_io ry_json ry_net ry_thread ry_http)
+set(RY_NATIVE_LIBS ry_base64 ry_path ry_convert ry_filesystem ry_gc ry_testing ry_io ry_json ry_net ry_thread ry_http)
 
 # ===== メイン実行ファイル =====
 # Native shared libraries are NOT linked here — the JIT loads them on-demand

--- a/changelog.d/718-fail-as-ry-function.md
+++ b/changelog.d/718-fail-as-ry-function.md
@@ -1,0 +1,15 @@
+### Changed
+
+- `fail()` is now implemented as a Ry function in
+  `share/std/testing/testing.ry` that delegates to a new
+  `@native("testing")` runtime call (`_reportFail`) backed by a new
+  `libry_testing.dylib` shared library. The compiler still
+  special-cases the `fail` callee to inject the call-site line
+  number as the first argument (the `__LINE__` intrinsic from #705
+  was closed as `NOT_PLANNED`, so a hybrid approach keeps
+  line-number injection in codegen), but the function body itself
+  runs as ordinary Ry code. User-facing behavior is unchanged:
+  `fail()` and `fail("message")` still report the call-site line
+  number and message exactly as before, and the
+  `'fail' requires 'from testing import fail'` import-gate from
+  #715 still fires for unimported usages. (#718)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1213,7 +1213,6 @@ public:
     void emitFailCall(CallStmt &s);
     std::unordered_set<std::string> mocked_functions_;
     std::unordered_map<std::string, llvm::Constant*> mock_name_strings_;
-    llvm::Constant *fail_empty_msg_ = nullptr;
     llvm::Value *toBool(llvm::Value *v);
 
     // Low-level type helpers

--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -15,3 +15,10 @@ fn each(data: any)
 @public
 @directive(target=["statement", "function"])
 fn property(count: int = 100)
+
+@native("testing")
+fn _reportFail(line: int, message: str) -> Unit
+
+@public
+fn fail(_line: int, message: str = "") -> Unit:
+  _reportFail(_line, message)

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -970,22 +970,28 @@ void CodeGen::emitFailCall(CallStmt &s) {
     if (s.args.size() > 1)
         codegenError("fail() expects 0 or 1 argument(s), but got " + std::to_string(s.args.size()));
 
-    llvm::FunctionType *failTy = llvm::FunctionType::get(
-        llvm::Type::getVoidTy(*ctx_), {i32Ty_, ptrTy_}, false);
-    llvm::FunctionCallee failFn = mod_->getOrInsertFunction("__ry_test_fail", failTy);
+    // Inject the call-site line as the first argument and dispatch through the
+    // Ry-level `fail(line: int, message: str = "")` function declared in
+    // share/std/testing/testing.ry. The compiler still special-cases the
+    // callee name so it can synthesize the line number; the function body
+    // itself runs as ordinary Ry code that calls the @native _report_fail.
+    std::vector<ExprPtr> synthArgs;
 
-    llvm::Value *msg;
+    auto lineNode = std::make_unique<ExprNode>();
+    lineNode->data = NumberExpr{static_cast<int64_t>(s.loc.line), ""};
+    lineNode->loc = s.loc;
+    synthArgs.push_back(std::move(lineNode));
+
     if (s.args.size() == 1) {
-        msg = emitExpr(*s.args[0]);
-        if (msg->getType() != ptrTy_)
-            codegenError("fail() argument must be a string");
+        synthArgs.push_back(std::move(s.args[0]));
     } else {
-        if (!fail_empty_msg_)
-            fail_empty_msg_ = cachedGlobalString("", ".fail_empty");
-        msg = fail_empty_msg_;
+        auto msgNode = std::make_unique<ExprNode>();
+        msgNode->data = StringExpr{""};
+        msgNode->loc = s.loc;
+        synthArgs.push_back(std::move(msgNode));
     }
 
-    builder_.CreateCall(failFn, {llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(s.loc.line)), msg});
+    emitUserFnCall("fail", synthArgs);
 }
 
 } // namespace ry

--- a/src/runtime_testing.cpp
+++ b/src/runtime_testing.cpp
@@ -1,0 +1,9 @@
+#include "ry/test_runtime.hpp"
+
+namespace ry {
+
+extern "C" void __ry_testing__reportFail(int line, const char *msg) {
+    __ry_test_fail(line, msg);
+}
+
+} // namespace ry

--- a/src/runtime_testing.cpp
+++ b/src/runtime_testing.cpp
@@ -1,9 +1,16 @@
 #include "ry/test_runtime.hpp"
 
+#include <cstdint>
+
 namespace ry {
 
-extern "C" void __ry_testing__reportFail(int line, const char *msg) {
-    __ry_test_fail(line, msg);
+// Ry's `int` lowers to `i64` in IR, so the @native("testing") dispatch
+// emits `call void @__ry_testing__reportFail(i64 %line, ptr %msg)`.  The
+// C signature must therefore receive `int64_t` to match the ABI.  We
+// narrow to `int` for the existing `__ry_test_fail` helper, which keeps
+// its legacy 32-bit line parameter (line numbers fit comfortably).
+extern "C" void __ry_testing__reportFail(int64_t line, const char *msg) {
+    __ry_test_fail(static_cast<int>(line), msg);
 }
 
 } // namespace ry

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -105,6 +105,21 @@ protected:
         }
     }
 
+    // Appended after user source so that line numbers in the user source
+    // are not shifted (tests like FailWithMessage assert on specific line
+    // numbers in `fail()` output).  Mirrors share/std/testing/testing.ry's
+    // declarations of `fail` and the underlying `@native` runtime call.
+    static std::string withTestingFnDecls(const std::string &src) {
+        static const char *kDecls =
+            "\n"
+            "@native(\"testing\")\n"
+            "fn _reportFail(line: int, message: str) -> Unit\n"
+            "@public\n"
+            "fn fail(_line: int, message: str = \"\") -> Unit:\n"
+            "  _reportFail(_line, message)\n";
+        return src + kDecls;
+    }
+
     // The codegen test harness skips ModuleLoader (see CodeGenTest::compileSource).
     // In production, jit_runner.cpp:165 calls
     // `cg.setTestingIntrinsicsImported(loader.importedTestingIntrinsics())`
@@ -115,8 +130,14 @@ protected:
     // literally in their source strings continue to compile. Negative tests
     // that intentionally exercise the missing-import error must use
     // `runTestSourceNoTestingImports` instead.
+    //
+    // Since #718 made `fail` a Ry-level function (declared in
+    // share/std/testing/testing.ry, body emitted via emitUserFnCall), the
+    // harness also appends the `fail` and `_reportFail` declarations after
+    // the user source so codegen can find them in user_fns_.
     static std::string runTestSource(const std::string &src) {
-        Lexer lex(src);
+        std::string augmented = withTestingFnDecls(src);
+        Lexer lex(augmented);
         Parser parser(lex);
         Program prog = parser.parseProgram();
 
@@ -130,7 +151,8 @@ protected:
     // Use this when writing a negative test that asserts the
     // `'<name>' requires 'from testing import <name>'` enforcement fires.
     static std::string runTestSourceNoTestingImports(const std::string &src) {
-        Lexer lex(src);
+        std::string augmented = withTestingFnDecls(src);
+        Lexer lex(augmented);
         Parser parser(lex);
         Program prog = parser.parseProgram();
 


### PR DESCRIPTION
## Summary

Phase 2 of #703 — migrate `fail()` from compiler-magic to a Ry-implemented function backed by a new `@native("testing")` runtime call.

- `share/std/testing/testing.ry` declares `_reportFail(line, message)` (`@native("testing")`) and a `@public fn fail(_line, message = "")` whose body calls `_reportFail`.
- New `src/runtime_testing.cpp` → `libry_testing.dylib` provides `__ry_testing__reportFail`, which delegates to the existing `__ry_test_fail` in `ry_lib`.
- `emitFailCall` (`src/codegen_test.cpp`) now synthesizes the call-site `line` as the first arg and dispatches via `emitUserFnCall("fail", ...)`. The compiler still special-cases the callee name to inject the line number (Hybrid approach — `__LINE__` intrinsic from #705 was closed as `NOT_PLANNED`), but the function body runs as ordinary Ry code.
- `tests/test_codegen_common.hpp` appends `fail` / `_reportFail` declarations after user source inside `runTestSource*` so the codegen-only harness (skips `ModuleLoader`) can resolve `fail`. Appending (not prepending) preserves line numbers in tests asserting specific line outputs (e.g. `FailWithMessage`).

User-facing behavior is unchanged: `fail()` and `fail("message")` still report the call-site line and message exactly as before, and the `'fail' requires 'from testing import fail'` gate from #715 still fires.

Closes #718

## Test plan

- [x] `cmake --build build && ./build/ry_tests` (2142 pass)
- [x] `./build/ry test -p` (173 spec files pass)
- [x] ASan + UBSan: `./build-asan/ry_tests` + `./build-asan/ry test -p` clean
- [x] TSan: `./build-tsan/ry_tests` clean
- [x] cppcheck / clang-tidy: no errors on changed files
- [x] `CodeGenTest.FailRequiresTestingImport` still discriminates after `withTestingFnDecls` injection (verified empirically)
- [x] Smoke test: `tests/spec/<file>.test.ry` with intentional `fail("smoke")` produces correct line number and red ANSI output
- [x] libFuzzer §3.6 skipped (no parser/lexer/json/utf8/string change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reimplemented the test failure facility so it runs as a regular language-level function while preserving call-site line reporting and import gating.

* **Tests**
  * Updated test harness to always provide the testing declarations so codegen tests see the fail API consistently.

* **Chores**
  * Build setup updated to ensure the native testing runtime is built and linked with the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->