### PR TITLE
feat(codegen): unify @it/@describe import enforcement with general @directive mechanism (#721)

### DIFF
--- a/changelog.d/721-unify-it-describe-import-enforcement.md
+++ b/changelog.d/721-unify-it-describe-import-enforcement.md
@@ -1,0 +1,16 @@
+### Changed
+
+- `@it` and `@describe` directive declarations are now resolved entirely
+  through the general user-directive import mechanism. `share/std/testing/testing.ry`
+  has carried `@directive(target=["function"])` declarations for both since #710,
+  and #716 added a parallel set-based check (`testing_intrinsics_imported_`) that
+  produced `'@it' requires 'from testing import it'` / `'@describe' requires
+  'from testing import describe'` before the directive-resolution path ran. That
+  bespoke check has been removed: usage without the import is now rejected by the
+  same `unknown directive '@<name>'` path that handles every other unimported
+  user-defined directive. The intrinsic enforcement set now tracks only `expect`,
+  `mock`, `verify`, `fail`. Existing test files that already declare
+  `from testing import it, describe` (or use a wildcard `from testing`) are
+  unaffected; the only behavioural change is the diagnostic wording for the
+  unimported case, which now reads `unknown directive '@it'` /
+  `unknown directive '@describe'`. (#721)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -36,7 +36,10 @@ When `ry test` is run without arguments, it:
 
 ### Syntax
 
-Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Every directive and intrinsic a test file uses must appear in an explicit `from testing import ...` line at the top; codegen rejects unimported usage with `'<name>' requires 'from testing import <name>'`:
+Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Every directive and intrinsic a test file uses must appear in an explicit `from testing import ...` line at the top. The two enforcement paths produce different error messages:
+
+- `@it` / `@describe` are declared in `share/std/testing/testing.ry` as `@directive` declarations. Without the import, codegen rejects them via the general directive-resolution mechanism with `unknown directive '@it'` or `unknown directive '@describe'`.
+- `expect`, `mock`, `verify`, `fail` are intrinsics tracked separately and rejected with `'<name>' requires 'from testing import <name>'`.
 
 ```ry
 from testing import it, describe, expect

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -36,7 +36,7 @@ When `ry test` is run without arguments, it:
 
 ### Syntax
 
-Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Every directive and intrinsic a test file uses must appear in an explicit `from testing import ...` line at the top. The two enforcement paths produce different error messages:
+Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Import them at the top using either `from testing` (wildcard) or `from testing import ...` (named). The two enforcement paths produce different error messages:
 
 - `@it` / `@describe` are declared in `share/std/testing/testing.ry` as `@directive` declarations. Without the import, codegen rejects them via the general directive-resolution mechanism with `unknown directive '@it'` or `unknown directive '@describe'`.
 - `expect`, `mock`, `verify`, `fail` are intrinsics tracked separately and rejected with `'<name>' requires 'from testing import <name>'`.

--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -1,5 +1,8 @@
 # Testing directives. Test files must explicitly
-# `from std/testing import it, describe`.
+# `from testing import it, describe`. The @directive declarations
+# below register `it` / `describe` in the importer's user-directive
+# registry; usage without the import is rejected by the general
+# `unknown directive '@<name>'` path (no separate enforcement set).
 @public
 @directive(target=["function"])
 fn it(description: str)

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -324,8 +324,6 @@ static void stripDirectives(
 void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     if (!test_mode_)
         codegenError("@it is only allowed in test mode (use 'ry test')");
-    if (!testing_intrinsics_imported_.count("it"))
-        codegenError(s->loc, "'@it' requires 'from testing import it'");
     if (s->is_async)
         codegenError("@it: fn '" + s->name + "' cannot be async");
     if (!s->type_params.empty())
@@ -454,8 +452,6 @@ void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
 void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
     if (!test_mode_)
         codegenError("@describe is only allowed in test mode (use 'ry test')");
-    if (!testing_intrinsics_imported_.count("describe"))
-        codegenError(s->loc, "'@describe' requires 'from testing import describe'");
     if (s->is_async)
         codegenError("@describe: fn '" + s->name + "' cannot be async");
     if (!s->type_params.empty())

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -56,22 +56,30 @@ static std::string makeImportError(int line, const std::string &detail) {
     return msg;
 }
 
-// Compiler intrinsics exposed by the testing module (#712). These are not
-// declared in `share/std/testing/testing.ry` because they are matched and
-// emitted directly by codegen (`expect <expr> <matcher>` is a parser-level
-// statement form; `mock` / `verify` / `fail` and the directives `it` /
-// `describe` are handled at codegen). Listing them here lets
-// `from testing import expect / mock / verify / fail / it / describe` resolve
-// without producing AST nodes — the allow-list bypass below skips the
+// Compiler intrinsics exposed by the testing module (#712). The names listed
+// here either produce no AST node (`expect <expr> <matcher>` is a parser-level
+// statement form; `mock` / `verify` are recognized at codegen) or are wrapped
+// by codegen synth (`fail` — `codegen_call_user.cpp:435` synthesizes the
+// __LINE__-equivalent argument before delegating to the user-fn `fail` defined
+// in `share/std/testing/testing.ry`). Listing them here lets
+// `from testing import expect / mock / verify / fail` resolve without
+// producing AST nodes — the allow-list bypass below skips the
 // `'<name>' not found` throw without altering anything else.
+//
+// Note: `it` / `describe` are NOT listed here. They are declared as regular
+// `@directive` statements in `share/std/testing/testing.ry` and flow through
+// the standard import mechanism into `CodeGen::user_directive_registry_`
+// (#721). Validation of unimported usage is handled by `validateDirectives`
+// in the general `@directive` machinery, which raises
+// `unknown directive '@it'` / `unknown directive '@describe'`.
 static const std::unordered_set<std::string> &testingIntrinsics() {
     static const std::unordered_set<std::string> kSet = {
-        "it", "describe", "expect", "mock", "verify", "fail"};
+        "expect", "mock", "verify", "fail"};
     return kSet;
 }
 
 // Gate the intrinsic bypass on `from_stdlib` so a project-local `testing.ry`
-// shadow (resolved via `referrer_dir`) does NOT silently absorb the six
+// shadow (resolved via `referrer_dir`) does NOT silently absorb the
 // intrinsic names. Only the stdlib testing module gets the bypass; a local
 // shadow continues to fail with the existing `'<name>' not found` diagnostic.
 static bool isTestingIntrinsic(bool from_stdlib,

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1612,6 +1612,26 @@ TEST_F(DirectiveTest, BareItRejectedWithoutTestingImport) {
     );
 }
 
+// Symmetric to BareItRejectedWithoutTestingImport: source that uses @describe
+// without `from std/testing import describe` must also be rejected with an
+// unknown-directive error after the import-enforcement unification (#721).
+TEST_F(DirectiveTest, BareDescribeRejectedWithoutTestingImport) {
+    EXPECT_THROW(
+        []() {
+            Lexer lex(
+                "@describe(\"my group\")\n"
+                "fn myGroup():\n"
+                "    pass\n"
+            );
+            Parser parser(lex);
+            Program prog = parser.parseProgram();
+            CodeGen cg(true);  // test_mode = true; @describe would otherwise also fail on test-mode check
+            cg.compile(prog);
+        }(),
+        std::runtime_error
+    );
+}
+
 // ===== #1425: silent no-op when user-defined directive applied outside target=[...] =====
 //
 // Issue #1425 resolves user-defined directive target-mismatch behavior to

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -128,42 +128,43 @@ TEST_F(CodeGenTest, FailRequiresTestingImport) {
 }
 
 // ============================================================
-// `@it` / `@describe` directives also require their matching
-// `from testing import` (#716, sibling of #715 above). The
-// directives are stdlib-declared, so the source must be wrapped
-// with `withStdlibDirectiveDecls`. The fn omits a return type
-// annotation because `@it` / `@describe` reject one outright.
-// The body is a trivial assignment so the import check at the
-// top of the directive emitter is the only path that can throw.
+// `@it` / `@describe` directives are declared in
+// `share/std/testing/testing.ry`. Without `from testing import it,
+// describe`, the directive declarations never enter
+// `user_directive_registry_`, so codegen rejects them via the general
+// `@directive` mechanism with `unknown directive '@<name>'` (#721).
+// `withStdlibDirectiveDecls` is intentionally NOT applied so the
+// rejection path mirrors what real user code sees (the only legal way
+// to use `@it` / `@describe` is via the testing import).
 // ============================================================
 
-TEST_F(CodeGenTest, ItRequiresTestingImport) {
+TEST_F(CodeGenTest, ItRejectedAsUnknownDirectiveWithoutTestingImport) {
     try {
-        runTestSourceNoTestingImports(withStdlibDirectiveDecls(
+        runTestSourceNoTestingImports(
             "@it(\"sample\")\n"
             "fn sample():\n"
             "    x = 1\n"
-        ));
+        );
         FAIL() << "Expected compile error";
     } catch (const std::runtime_error &e) {
         std::string msg = e.what();
-        EXPECT_NE(msg.find("requires 'from testing import it'"),
+        EXPECT_NE(msg.find("unknown directive '@it'"),
                   std::string::npos)
             << "got: " << msg;
     }
 }
 
-TEST_F(CodeGenTest, DescribeRequiresTestingImport) {
+TEST_F(CodeGenTest, DescribeRejectedAsUnknownDirectiveWithoutTestingImport) {
     try {
-        runTestSourceNoTestingImports(withStdlibDirectiveDecls(
+        runTestSourceNoTestingImports(
             "@describe(\"sample group\")\n"
             "fn sampleGroup():\n"
             "    x = 1\n"
-        ));
+        );
         FAIL() << "Expected compile error";
     } catch (const std::runtime_error &e) {
         std::string msg = e.what();
-        EXPECT_NE(msg.find("requires 'from testing import describe'"),
+        EXPECT_NE(msg.find("unknown directive '@describe'"),
                   std::string::npos)
             << "got: " << msg;
     }

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1511,15 +1511,15 @@ TEST_F(ImportTest, FromLocalTestingShadowDoesNotPolluteIntrinsicSet) {
         << "local testing.ry shadow should not record stdlib intrinsics";
 }
 
-TEST_F(ImportTest, FromTestingWildcardRecordsAllSixIntrinsics) {
+TEST_F(ImportTest, FromTestingWildcardRecordsAllFourIntrinsics) {
     auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
     auto intrinsics = resolveAndGetTestingIntrinsics(
         "from testing\n",
         tmp_dir_.string(),
         search_paths);
     std::unordered_set<std::string> expected = {
-        "it", "describe", "expect", "mock", "verify", "fail"};
-    EXPECT_EQ(intrinsics.size(), 6u);
+        "expect", "mock", "verify", "fail"};
+    EXPECT_EQ(intrinsics.size(), 4u);
     EXPECT_EQ(intrinsics, expected);
 }
 
@@ -1531,6 +1531,10 @@ TEST_F(ImportTest, FromTestingWildcardDoesNotLeakDirectiveDecls) {
         search_paths);
     EXPECT_EQ(intrinsics.count("each"), 0u);
     EXPECT_EQ(intrinsics.count("property"), 0u);
+    // Post-#721: `it` / `describe` are also `@directive` decls, not
+    // intrinsics. Lock that they never re-enter the intrinsic set.
+    EXPECT_EQ(intrinsics.count("it"), 0u);
+    EXPECT_EQ(intrinsics.count("describe"), 0u);
 }
 
 TEST_F(ImportTest, FromTestingImportSingleIntrinsicRecordsOne) {
@@ -1566,7 +1570,10 @@ TEST_F(ImportTest, CodeGenReceivesPartialTestingIntrinsics) {
         "from testing import expect, it\n",
         tmp_dir_.string(),
         search_paths);
-    std::unordered_set<std::string> expected = {"expect", "it"};
+    // `it` is a `@directive` declaration in testing.ry, not a runtime
+    // intrinsic. Only `expect` (intrinsic) is recorded; `it` flows
+    // through the general directive-import mechanism (#721).
+    std::unordered_set<std::string> expected = {"expect"};
     EXPECT_EQ(intrinsics, expected);
 }
 
@@ -1577,8 +1584,8 @@ TEST_F(ImportTest, CodeGenReceivesAllTestingIntrinsicsForWildcard) {
         tmp_dir_.string(),
         search_paths);
     std::unordered_set<std::string> expected = {
-        "it", "describe", "expect", "mock", "verify", "fail"};
-    EXPECT_EQ(intrinsics.size(), 6u);
+        "expect", "mock", "verify", "fail"};
+    EXPECT_EQ(intrinsics.size(), 4u);
     EXPECT_EQ(intrinsics, expected);
 }
 
@@ -1595,7 +1602,9 @@ TEST_F(ImportTest, CodeGenReceivesNamedSubsetTestingIntrinsics) {
         "from testing import expect, fail, it\n",
         tmp_dir_.string(),
         search_paths);
-    std::unordered_set<std::string> expected = {"expect", "fail", "it"};
+    // `it` is a `@directive` declaration in testing.ry; only `expect`
+    // and `fail` are runtime intrinsics (#721).
+    std::unordered_set<std::string> expected = {"expect", "fail"};
     EXPECT_EQ(intrinsics, expected);
 }
 


### PR DESCRIPTION
## Summary

Closes #721.

`@it` and `@describe` are declared in `share/std/testing/testing.ry` as `@directive` declarations (since #710). Their import enforcement was previously handled by a parallel `testing_intrinsics_imported_` set check introduced in #716, which produced bespoke messages:

- `'@it' requires 'from testing import it'`
- `'@describe' requires 'from testing import describe'`

That bespoke check is removed: usage without the import is now rejected by the same `unknown directive '@<name>'` path that handles every other unimported user-defined directive. The intrinsic enforcement set now tracks only `expect`, `mock`, `verify`, `fail`.

## Behavioural change

Existing test files that already declare `from testing import it, describe` (or use a wildcard `from testing`) are unaffected. The only behavioural change is the diagnostic wording for the unimported case:

| Input | Old message | New message |
|---|---|---|
| `@it` without import | `'@it' requires 'from testing import it'` | `unknown directive '@it'` |
| `@describe` without import | `'@describe' requires 'from testing import describe'` | `unknown directive '@describe'` |

This is the natural consequence of the issue's Design section: "the check can be unified with the general 'was this directive imported?' mechanism from #710."

## Test plan

- [x] `cmake --build build` — clean build
- [x] `./build/ry_tests` — 2143/2143 pass (incl. new `BareDescribeRejectedWithoutTestingImport` symmetric test, renamed `ItRejectedAsUnknownDirectiveWithoutTestingImport` / `DescribeRejectedAsUnknownDirectiveWithoutTestingImport`, and updated intrinsic-set count expectations 6→4 with `it`/`describe` regression guards)
- [x] `./build/ry test -p` — 173 files / 0 failures
- [x] `cmake --preset asan && cmake --build build-asan && ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests` — 2143/2143 pass
- [x] `ASAN_OPTIONS=... UBSAN_OPTIONS=... ./build-asan/ry test -p` — 173 files / 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified import enforcement for `@it` and `@describe` to use the standard directive-resolution path; unimported uses now yield generic "unknown directive '@it'"/"unknown directive '@describe'" errors. Intrinsic set narrowed to `expect`, `mock`, `verify`, and `fail`.

* **Documentation**
  * Updated testing reference and module docs to explain the distinct import/enforcement paths and updated error wording.

* **Tests**
  * Adjusted and added tests to assert the new rejection messages and the reduced intrinsic set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->