### PR TITLE
docs(workflow): add tree-sitter build/install steps to dev workflow

### DIFF
--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -38,7 +38,7 @@ git diff --name-only origin/main
 **補足**:
 
 - 複数行に該当する変更は **各列の最も厳しい要求を採用** する（= `✓` 優先 / 次点 `review` / 最後 `skip`）。
-- マトリクス対象外で **常時必須**: §2.5（rules/skills 更新, 該当時のみ） / §3.5.5（Static Analysis） / §3.7（background hygiene） / §4（Label Cleanup, no-op directive）。
+- マトリクス対象外で **常時必須**: §2.5（rules/skills 更新, 該当時のみ） / §3.5.5（Static Analysis） / §3.6.5（tree-sitter Grammar Regression Check, 該当時のみ） / §3.7（background hygiene） / §4（Label Cleanup, no-op directive）。
 - **`.md` / `docs/` のみの PR** では実質的に §4（Label Cleanup）が唯一の必須アクション。§1 は doc 編集自体で satisfied、§2-§3.6 は全てスキップ可、§3.7 は常時暗黙必須だが sanity check のみで実アクションを伴わない。
 - **`changelog.d/` のみの PR** も同様に §4 が唯一の必須アクション。§2 は fragment 編集自体で satisfied、§1 / §3-§3.6 は全てスキップ可。
 - マトリクスの `✓` のうち、自身を編集対象とするセクション（`.md`/`docs/` 行の §1、`changelog.d/` 行の §2）は **編集自体が satisfy 条件** であり、Skip if の bash も `skip` 判定を返す（自編集 = 完了）。
@@ -271,6 +271,27 @@ UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 
 - 3 ターゲットすべてが 60 秒 exit 0 であることを確認する。
 - crash が発見された場合は、現在の PR のコードが直接引き起こしたものは**同 PR で即座に修正**し、既存バグは `/scope-out-issue` の判定フローに従って別 issue を起票する。crash 入力は `tests/fuzz/regressions/<name>/` と `tests/fuzz/corpus/<name>/` の両方に保存すること。
+
+## 3.6.5. tree-sitter Grammar Regression Check
+
+> **Skip if** — 変更ファイルに tree-sitter グラマー / EBNF 仕様 / external scanner を **含まない**:
+>
+> ```bash
+> git diff --name-only origin/main | grep -E '^(docs/grammar\.ebnf$|editor/tree-sitter/(grammar\.js$|src/))' | head -1
+> ```
+>
+> 出力が **空ならスキップ可**。出力があれば再ビルド & 再インストールを実行する。スキップ時は PR description に `Skipped §3.6.5 — no tree-sitter grammar change` を記録。
+
+§0 マトリクスとは独立した常時評価ステップ。`.md` / `docs/` のみの PR でも `docs/grammar.ebnf` を変更していれば発火する（マトリクスの「`.md` / `docs/` のみ」row には載せない理由）。
+
+```bash
+./editor/tree-sitter/build.sh
+./editor/tree-sitter/install.sh --no-build
+```
+
+- `build.sh` 内部で `tree-sitter generate`（`grammar.js` から `parser.c` を再生成）と `tree-sitter build`（`parser.c` + `scanner.c` から `ry.so` をリンク）が両方成功し、`ry.so` が生成されることを確認する。`tree-sitter generate` が失敗すればグラマー側の構文ミスを意味する。
+- `install.sh --no-build` が `ry.so` と `queries/*.scm` を Neovim parser ディレクトリへコピーすることを確認する。
+- 現状 in-tree グラマーは Ry の全構文をまだカバーしていないため `tree-sitter parse` を実テストファイルに当てると ERROR ノードを含むことがある。これはグラマーの未完成部分であり、§3.6.5 のチェック対象ではない（コーパスベースの回帰テストは [#1633](https://github.com/t0k0sh1/ry/issues/1633) で追跡）。Neovim 等で `.ry` ファイルを開き、構文ハイライトに重大な regression が起きていないかを目視確認することは推奨。
 
 ## 3.7. Background Task Residual Check
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ cmake --build build                                     # Ninja が自動並列�
 - `editor/tree-sitter/src/` — external scanner (`scanner.c`)
 
 ```bash
-./editor/tree-sitter/build.sh && ./editor/tree-sitter/install.sh
+./editor/tree-sitter/build.sh && ./editor/tree-sitter/install.sh --no-build
 ```
 
 前提条件 (tree-sitter CLI / GNU gcc) と各スクリプトのフラグ詳細は `editor/tree-sitter/README.md` を参照。セルフ検証時の確認手順は `/pre-commit-checklist` §3.6.5 を参照。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,20 @@ cmake --build build                                     # Ninja が自動並列�
 
 > repo 内でビルドした `./build/ry` は `package.toml` の hidden 設定 `[paths]._dev_stdlib` に従ってプロジェクトローカルの `share/std/` を優先する。`RY_ENV=internal` は追加の isolation が必要な場合だけ使う。
 
+## tree-sitter グラマーのビルド & インストール
+
+以下のいずれかが変更された PR では、`ry.so` を再ビルドしてローカル Neovim parser ディレクトリへインストールすること:
+
+- `docs/grammar.ebnf` — 正準 EBNF 仕様
+- `editor/tree-sitter/grammar.js` — tree-sitter グラマー定義
+- `editor/tree-sitter/src/` — external scanner (`scanner.c`)
+
+```bash
+./editor/tree-sitter/build.sh && ./editor/tree-sitter/install.sh
+```
+
+前提条件 (tree-sitter CLI / GNU gcc) と各スクリプトのフラグ詳細は `editor/tree-sitter/README.md` を参照。セルフ検証時の確認手順は `/pre-commit-checklist` §3.6.5 を参照。
+
 ## コンパイラ警告フラグ
 
 コンパイラ警告フラグの詳細は `.claude/rules/build-warning-flags.md` を参照。

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -86,5 +86,39 @@ installed. Enable tree-sitter-driven indentation per `.ry` buffer with:
 vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
 ```
 
+## Contributor workflow
+
+Whenever a PR touches one of these paths (paths are relative to the
+repo root), the local `ry.so` is no longer in sync with the grammar and
+must be rebuilt + reinstalled before the editor experience matches the
+language change:
+
+- `docs/grammar.ebnf` — canonical EBNF spec
+- `editor/tree-sitter/grammar.js` — tree-sitter grammar definition
+- `editor/tree-sitter/src/` — external scanner (`scanner.c`)
+
+The loop reuses the scripts documented in `## Build` and `## Install
+(Neovim)` above (run from `editor/tree-sitter/`):
+
+```bash
+./build.sh                                 # regenerate parser.c + build ry.so
+./install.sh --no-build                    # copy ry.so + queries to Neovim parser dir
+```
+
+If `tree-sitter generate` fails inside `build.sh`, the grammar has a
+syntax error — fix `grammar.js` (or `scanner.c`) and rerun. After
+`install.sh` succeeds, optionally open a `.ry` file in Neovim to
+eyeball the syntax highlighting and confirm no regressions.
+
+> Running `tree-sitter parse <file>.ry` against existing
+> `tests/spec/*.test.ry` will surface ERROR nodes today: the in-tree
+> grammar does not yet cover the full Ry surface. That's a known gap
+> and not what this loop is checking — corpus-based regression testing
+> is tracked in [#1633](https://github.com/t0k0sh1/ry/issues/1633).
+
+The pre-commit version of this loop, with the same trigger paths, lives
+in [`/pre-commit-checklist`](../../.claude/skills/pre-commit-checklist/SKILL.md)
+§3.6.5.
+
 Other editors are not yet supported in-tree; integrations may be added under
 `editor/<tool>/` as they appear.

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -105,9 +105,10 @@ The loop reuses the scripts documented in `## Build` and `## Install
 ./install.sh --no-build                    # copy ry.so + queries to Neovim parser dir
 ```
 
-If `tree-sitter generate` fails inside `build.sh`, the grammar has a
-syntax error — fix `grammar.js` (or `scanner.c`) and rerun. After
-`install.sh` succeeds, optionally open a `.ry` file in Neovim to
+If `tree-sitter generate` fails inside `build.sh`, the grammar
+definition has a syntax error — fix `grammar.js` and rerun. If the
+subsequent `tree-sitter build` step fails instead, inspect `scanner.c`.
+After `install.sh` succeeds, optionally open a `.ry` file in Neovim to
 eyeball the syntax highlighting and confirm no regressions.
 
 > Running `tree-sitter parse <file>.ry` against existing


### PR DESCRIPTION
## Summary

#1614 brought the tree-sitter grammar in-tree under `editor/tree-sitter/` and moved the canonical EBNF spec to `docs/grammar.ebnf`, but no documented step ties grammar edits to a local parser rebuild + install. Without that loop, a contributor (or Claude Code) can land grammar changes without rebuilding `ry.so`, leaving the editor experience inconsistent with the new grammar.

This PR is docs-only and weaves the rebuild/install loop into the standard dev workflow:

- `AGENTS.md` — new `## tree-sitter グラマーのビルド & インストール` section between `## ビルド & テスト` and `## コンパイラ警告フラグ`.
- `.claude/skills/pre-commit-checklist/SKILL.md` — new `§3.6.5 tree-sitter Grammar Regression Check` between `§3.6` and `§3.7`. Treated as orthogonal to the `§0` matrix (matching `§2.5` / `§3.5.5` / `§3.7` precedent); listed in the "常時必須" footnote so its own skip-if grep is the sole source of truth.
- `editor/tree-sitter/README.md` — new `## Contributor workflow` section after `## Install (Neovim)`, tying the existing Prerequisites / Build / Install sections into the edit loop and pointing back to the pre-commit equivalent.

Trigger paths (stated identically in all three files):

- `docs/grammar.ebnf` — canonical EBNF spec
- `editor/tree-sitter/grammar.js` — tree-sitter grammar definition
- `editor/tree-sitter/src/` — external scanner (`scanner.c`)

A scope-out issue #1633 was filed to track corpus-based regression testing (the in-tree grammar does not yet cover the full Ry surface, so `tree-sitter parse` against `tests/spec/*.test.ry` produces ERROR nodes today — that is a known gap, not a §3.6.5 failure mode).

Closes #1615.

## Pre-commit checklist (selfreview)

- §1 — docs updated (this PR is the doc update).
- Skipped §2 — no user-visible language/runtime change (docs/workflow only).
- Skipped §3 — no source code change.
- Skipped §3.5 — no source code change.
- Skipped §3.5.5 — no source code change.
- Skipped §3.6 — no parser/lexer/json/utf8/string change.
- Skipped §3.6.5 — no tree-sitter grammar/scanner/EBNF change in this PR's diff (verified: skip-if grep returns empty).
- §3.7 — background hygiene clean.
- §4 — `wip` removal handled by `git-merge-pr` after merge.

> Note: the `§2 / §3 / §3.5` skip-if regex `^(\.claude/|docs/|changelog\.d/|[^/]+\.md$)` does not catch nested markdown like `editor/tree-sitter/README.md`, so the skip is justified manually here. Extending the regex to cover nested `*.md` is out of scope for this PR.

## Test plan

- [x] §3.6.5 self-validation: `git diff --name-only origin/main | grep -E '^(docs/grammar\.ebnf$|editor/tree-sitter/(grammar\.js$|src/))'` returns empty against this PR's diff (this PR correctly does **not** trigger §3.6.5).
- [x] Trigger paths stated identically across `AGENTS.md`, `editor/tree-sitter/README.md`, and the `SKILL.md` skip-if regex.
- [x] `#1633` cited in both `editor/tree-sitter/README.md` Contributor workflow and `SKILL.md` §3.6.5 caveat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new grammar regression checklist for tree-sitter parser updates (new checklist section).
  * Added contributor workflow instructions for rebuilding and reinstalling the tree-sitter parser when grammar/scanner sources change.
  * Documented prerequisites, troubleshooting steps, and manual verification guidance for local parser rebuilds.
  * Noted current limitation where parse-time ERROR nodes may appear and recommended visual/manual regression checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->