### PR TITLE
feat(testing): migrate `verify` to ordinary `@public fn` (#722)

### DIFF
--- a/changelog.d/722-verify-as-ry-function.md
+++ b/changelog.d/722-verify-as-ry-function.md
@@ -1,0 +1,35 @@
+### Changed
+
+- `verify()` is now an ordinary `@public fn verify(name: str) -> int`
+  in `share/std/testing/testing.ry` that delegates to a new
+  `@native("testing")` runtime call (`_mockGetCallCount`). The
+  compiler-level special cases for `verify` were removed: the
+  string-coercion sugar in the parser, the dispatch arm in
+  `codegen_call_dispatch.cpp`, and the `verify` entry in
+  `module_loader.cpp`'s testing-intrinsic allow-list are all gone.
+  `verify` now flows through the ordinary import + user-fn
+  resolution machinery — the same path used by `fail` since #718.
+  (#722)
+
+### Removed
+
+- The bare-identifier form `verify(fnName)` is no longer accepted —
+  the argument must be a string literal or `str`-typed expression
+  (e.g. `verify("fnName")`). All in-tree call sites already used the
+  string form, so no spec migration was required, but external users
+  who relied on the identifier form must quote the function name.
+  (#722)
+- Compile-time validation that the function name passed to `verify`
+  refers to a real function has been removed alongside the dispatch
+  special case. `verify("nonexistent")` now compiles cleanly and
+  returns `0` at runtime — the same value `verify` returns for any
+  function that has not been mocked / called. (#722)
+
+### Fixed
+
+- Without `from testing import verify`, calling `verify(...)` now
+  fails with the standard `undefined function: verify` diagnostic
+  instead of the bespoke `'verify' requires 'from testing import
+  verify'` message. The behavior is unchanged for legitimate users
+  (the import is still required), and the diagnostic is now
+  consistent with every other unimported function. (#722)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -36,10 +36,11 @@ When `ry test` is run without arguments, it:
 
 ### Syntax
 
-Test files use directives (`@it`, `@describe`) and intrinsics (`expect`, `mock`, `verify`, `fail`) from the `testing` module. Import them at the top using either `from testing` (wildcard) or `from testing import ...` (named). The two enforcement paths produce different error messages:
+Test files use directives (`@it`, `@describe`) and the helpers `expect`, `mock`, `verify`, `fail` from the `testing` module. Import them at the top using either `from testing` (wildcard) or `from testing import ...` (named). Several enforcement paths produce different error messages:
 
 - `@it` / `@describe` are declared in `share/std/testing/testing.ry` as `@directive` declarations. Without the import, codegen rejects them via the general directive-resolution mechanism with `unknown directive '@it'` or `unknown directive '@describe'`.
-- `expect`, `mock`, `verify`, `fail` are intrinsics tracked separately and rejected with `'<name>' requires 'from testing import <name>'`.
+- `expect`, `mock`, `fail` are compiler intrinsics tracked separately and rejected with `'<name>' requires 'from testing import <name>'`.
+- `verify` is an ordinary `@public fn verify(name: str) -> int` declared in `share/std/testing/testing.ry`. Without the import, codegen rejects the call with the standard `undefined function: verify` diagnostic.
 
 ```ry
 from testing import it, describe, expect
@@ -249,9 +250,9 @@ fn mockingTests():
 - Mocks are automatically restored at the end of each `it` block
 - Requires `from testing import mock`
 
-### verify(fnName)
+### verify(name)
 
-Returns the number of times a mocked function was called (as `int`).
+Returns the number of times a mocked function was called (as `int`). The argument is the **string name** of the function — `verify` is an ordinary `@public fn` exported by the `testing` module, not a compiler intrinsic, so the bare-identifier sugar that `mock` accepts does not apply here.
 
 ```ry
 from testing import it, describe, mock, verify, expect
@@ -263,10 +264,11 @@ fn verifyTests():
         mock(fetchData, () => "fake")
         fetchData()
         fetchData()
-        expect(verify(fetchData)).toEq(2)
+        expect(verify("fetchData")).toEq(2)
 ```
 
 - Requires `from testing import verify`
+- Returns `0` when no call has been recorded for that name (including unknown function names) — there is no compile-time check that the string corresponds to a real function.
 
 ### Limitations
 

--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -22,6 +22,13 @@ fn property(count: int = 100)
 @native("testing")
 fn _reportFail(line: int, message: str) -> Unit
 
+@native("testing")
+fn _mockGetCallCount(name: str) -> int
+
 @public
 fn fail(_line: int, message: str = "") -> Unit:
   _reportFail(_line, message)
+
+@public
+fn verify(name: str) -> int:
+  return _mockGetCallCount(name)

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -59,32 +59,6 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
         }
     }
 
-    // verify(fn_name) → call count
-    if (e->callee == "verify") {
-        if (!test_mode_)
-            codegenError("'verify' is only allowed in test mode (use 'ry test')");
-        // CallExpr has no `loc` field; rely on `current_loc_`, which `emitExpr`
-        // (src/codegen_expr.cpp:71) sets from the enclosing ExprNode.loc before
-        // dispatching to emitExprVariant. The `verify` branch is reached only
-        // through that path, so `current_loc_` is valid here.
-        if (!testing_intrinsics_imported_.count("verify"))
-            codegenError("'verify' requires 'from testing import verify'");
-        if (e->args.size() != 1)
-            codegenError("verify() requires exactly 1 argument");
-        auto *strExpr = std::get_if<StringExpr>(&e->args[0]->data);
-        if (!strExpr)
-            codegenError("verify() argument must be a function name");
-        auto *vit = findFunction(strExpr->value);
-        if (!vit)
-            codegenError("verify(): unknown function '" + strExpr->value + "'");
-        if (vit->size() != 1)
-            codegenError("verify(): overloaded functions are not supported");
-        auto *getCountTy = fnTy_ptr_to_i64_;
-        llvm::FunctionCallee getCountFn = mod_->getOrInsertFunction("__ry_mock_get_call_count", getCountTy);
-        llvm::Value *nameStr = cachedGlobalString(strExpr->value, ".verify_name");
-        return builder_.CreateCall(getCountFn, {nameStr}, "call_count");
-    }
-
     // Fast path: pre-emit args[0] once for callee names shared by multiple
     // dispatchers, then route through the same try-chain order to avoid
     // emitting dead IR from earlier dispatchers that don't match the type.

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -58,23 +58,25 @@ static std::string makeImportError(int line, const std::string &detail) {
 
 // Compiler intrinsics exposed by the testing module (#712). The names listed
 // here either produce no AST node (`expect <expr> <matcher>` is a parser-level
-// statement form; `mock` / `verify` are recognized at codegen) or are wrapped
-// by codegen synth (`fail` — `codegen_call_user.cpp:435` synthesizes the
-// __LINE__-equivalent argument before delegating to the user-fn `fail` defined
-// in `share/std/testing/testing.ry`). Listing them here lets
-// `from testing import expect / mock / verify / fail` resolve without
-// producing AST nodes — the allow-list bypass below skips the
-// `'<name>' not found` throw without altering anything else.
+// statement form; `mock` is recognized at codegen) or are wrapped by codegen
+// synth (`fail` — `codegen_call_user.cpp:435` synthesizes the __LINE__-
+// equivalent argument before delegating to the user-fn `fail` defined in
+// `share/std/testing/testing.ry`). Listing them here lets
+// `from testing import expect / mock / fail` resolve without producing AST
+// nodes — the allow-list bypass below skips the `'<name>' not found` throw
+// without altering anything else.
 //
 // Note: `it` / `describe` are NOT listed here. They are declared as regular
 // `@directive` statements in `share/std/testing/testing.ry` and flow through
 // the standard import mechanism into `CodeGen::user_directive_registry_`
 // (#721). Validation of unimported usage is handled by `validateDirectives`
 // in the general `@directive` machinery, which raises
-// `unknown directive '@it'` / `unknown directive '@describe'`.
+// `unknown directive '@it'` / `unknown directive '@describe'`. As of #722,
+// `verify` is also a regular `@public fn verify` in testing.ry — it flows
+// through the same standard mechanism and is NOT a compiler intrinsic.
 static const std::unordered_set<std::string> &testingIntrinsics() {
     static const std::unordered_set<std::string> kSet = {
-        "expect", "mock", "verify", "fail"};
+        "expect", "mock", "fail"};
     return kSet;
 }
 

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -8,7 +8,7 @@
 
 namespace ry {
 
-// ===== Mock/verify helper: coerce first arg identifier to string =====
+// ===== Mock helper: coerce first arg identifier to string =====
 
 void Parser::coerceFirstArgToString(std::vector<ExprPtr> &args) {
     if (!args.empty()) {

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -664,8 +664,6 @@ ExprPtr Parser::parsePrimary() {
             auto call = std::make_unique<CallExpr>();
             call->callee = t.value;
             call->args = parseArgList(&call->named_args);
-            if (call->callee == "verify")
-                coerceFirstArgToString(call->args);
             auto node = std::make_unique<ExprNode>();
             node->data = std::move(call);
             node->loc = locFromToken(t);

--- a/src/runtime_testing.cpp
+++ b/src/runtime_testing.cpp
@@ -13,4 +13,8 @@ extern "C" void __ry_testing__reportFail(int64_t line, const char *msg) {
     __ry_test_fail(static_cast<int>(line), msg);
 }
 
+extern "C" int64_t __ry_testing__mockGetCallCount(const char *name) {
+    return __ry_mock_get_call_count(name);
+}
+
 } // namespace ry

--- a/tests/spec/verify_as_function.test.ry
+++ b/tests/spec/verify_as_function.test.ry
@@ -1,0 +1,18 @@
+from testing import it, describe, expect, mock, verify
+
+fn greet() -> str:
+  return "hello"
+
+@describe("verify as a regular function")
+fn verifyAsFunctionTests():
+  @it("accepts a string variable, not just a literal")
+  fn acceptsStringVariable():
+    mock("greet", () => "hi")
+    greet()
+    greet()
+    greet()
+    fnName = "greet"
+    expect(verify(fnName)).toEq(3)
+  @it("returns 0 for an unknown function name")
+  fn returnsZeroForUnknownName():
+    expect(verify("nonexistentFunction")).toEq(0)

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -108,7 +108,8 @@ protected:
     // Appended after user source so that line numbers in the user source
     // are not shifted (tests like FailWithMessage assert on specific line
     // numbers in `fail()` output).  Mirrors share/std/testing/testing.ry's
-    // declarations of `fail` and the underlying `@native` runtime call.
+    // declarations of `fail` / `verify` and the underlying `@native` runtime
+    // calls (`_reportFail`, `_mockGetCallCount`).
     static std::string withTestingFnDecls(const std::string &src) {
         static const char *kDecls =
             "\n"
@@ -116,7 +117,12 @@ protected:
             "fn _reportFail(line: int, message: str) -> Unit\n"
             "@public\n"
             "fn fail(_line: int, message: str = \"\") -> Unit:\n"
-            "  _reportFail(_line, message)\n";
+            "  _reportFail(_line, message)\n"
+            "@native(\"testing\")\n"
+            "fn _mockGetCallCount(name: str) -> int\n"
+            "@public\n"
+            "fn verify(name: str) -> int:\n"
+            "  return _mockGetCallCount(name)\n";
         return src + kDecls;
     }
 

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -130,17 +130,18 @@ protected:
     // In production, jit_runner.cpp:165 calls
     // `cg.setTestingIntrinsicsImported(loader.importedTestingIntrinsics())`
     // so codegen knows which testing intrinsics the source imported. For the
-    // test harness we mimic the wildcard `from testing` import for the six
-    // enforced names (expect/mock/verify/fail from #715, plus it/describe
-    // from #716), so existing tests that embed those intrinsics or directives
-    // literally in their source strings continue to compile. Negative tests
-    // that intentionally exercise the missing-import error must use
+    // test harness we mimic the wildcard `from testing` import for the five
+    // enforced names (expect/mock/fail from #715, plus it/describe from #716),
+    // so existing tests that embed those intrinsics or directives literally
+    // in their source strings continue to compile. Negative tests that
+    // intentionally exercise the missing-import error must use
     // `runTestSourceNoTestingImports` instead.
     //
-    // Since #718 made `fail` a Ry-level function (declared in
-    // share/std/testing/testing.ry, body emitted via emitUserFnCall), the
-    // harness also appends the `fail` and `_reportFail` declarations after
-    // the user source so codegen can find them in user_fns_.
+    // Since #718 made `fail` and #722 made `verify` Ry-level functions
+    // (declared in share/std/testing/testing.ry, bodies emitted via
+    // emitUserFnCall), the harness also appends `fail` / `verify` and their
+    // `@native` backing declarations (`_reportFail`, `_mockGetCallCount`)
+    // after the user source so codegen can find them in user_fns_.
     static std::string runTestSource(const std::string &src) {
         std::string augmented = withTestingFnDecls(src);
         Lexer lex(augmented);
@@ -148,7 +149,7 @@ protected:
         Program prog = parser.parseProgram();
 
         CodeGen cg(true);  // test_mode = true
-        cg.setTestingIntrinsicsImported({"expect", "mock", "verify", "fail", "it", "describe"});
+        cg.setTestingIntrinsicsImported({"expect", "mock", "fail", "it", "describe"});
         auto tsm = cg.compile(prog);
         return runModule(std::move(tsm));
     }

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -64,11 +64,18 @@ TEST_F(CodeGenTest, ExpectOutsideTestModeWinsOverImportCheck) {
 }
 
 // ============================================================
-// Testing intrinsics (expect / mock / verify / fail) require
-// the matching `from testing import <name>`. Without it codegen
-// must reject the use even when running in test mode (#715).
+// Testing intrinsics (expect / mock / fail) require the matching
+// `from testing import <name>`. Without it codegen must reject the
+// use even when running in test mode (#715).
 // `runTestSourceNoTestingImports` is the only fixture that does
 // not auto-inject the imports.
+//
+// Note: as of #722, `verify` is no longer a compiler-recognized
+// intrinsic — it lives as an ordinary `@public fn verify` in
+// `share/std/testing/testing.ry`. Calling `verify` without the
+// import now fails with the generic `undefined function: verify`
+// path rather than the import-enforcement diagnostic, so it is
+// not covered here.
 // ============================================================
 
 TEST_F(CodeGenTest, ExpectRequiresTestingImport) {
@@ -94,22 +101,6 @@ TEST_F(CodeGenTest, MockRequiresTestingImport) {
     } catch (const std::runtime_error &e) {
         std::string msg = e.what();
         EXPECT_NE(msg.find("requires 'from testing import mock'"),
-                  std::string::npos)
-            << "got: " << msg;
-    }
-}
-
-TEST_F(CodeGenTest, VerifyRequiresTestingImport) {
-    try {
-        runTestSourceNoTestingImports(
-            "fn greet() -> str:\n"
-            "  return \"hi\"\n"
-            "x = verify(\"greet\")\n"
-        );
-        FAIL() << "Expected compile error";
-    } catch (const std::runtime_error &e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("requires 'from testing import verify'"),
                   std::string::npos)
             << "got: " << msg;
     }

--- a/tests/test_codegen_mock.cpp
+++ b/tests/test_codegen_mock.cpp
@@ -77,7 +77,7 @@ TEST_F(CodeGenTest, MockVerifyCallCount) {
         "        greet()\n"
         "        greet()\n"
         "        greet()\n"
-        "        expect(verify(greet)).toEq(3)\n"
+        "        expect(verify(\"greet\")).toEq(3)\n"
     )), "verify\n  \033[32m+ counts calls\033[0m\n\n1 passed, 0 failed\n");
 }
 
@@ -98,7 +98,7 @@ TEST_F(CodeGenTest, MockFunctionUsedAsExpr) {
         "        mock(getValue, () => 999)\n"
         "        x = getValue()\n"
         "        expect(x).toEq(999)\n"
-        "        expect(verify(getValue)).toEq(1)\n"
+        "        expect(verify(\"getValue\")).toEq(1)\n"
     )), "mock expr\n  \033[32m+ tracks calls in expressions\033[0m\n\n1 passed, 0 failed\n");
 }
 

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1511,15 +1511,18 @@ TEST_F(ImportTest, FromLocalTestingShadowDoesNotPolluteIntrinsicSet) {
         << "local testing.ry shadow should not record stdlib intrinsics";
 }
 
-TEST_F(ImportTest, FromTestingWildcardRecordsAllFourIntrinsics) {
+TEST_F(ImportTest, FromTestingWildcardRecordsAllThreeIntrinsics) {
     auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
     auto intrinsics = resolveAndGetTestingIntrinsics(
         "from testing\n",
         tmp_dir_.string(),
         search_paths);
+    // Post-#722 `verify` is a regular `@public fn verify` in
+    // share/std/testing/testing.ry — it flows through the normal import
+    // path and is no longer recorded in the testing-intrinsic set.
     std::unordered_set<std::string> expected = {
-        "expect", "mock", "verify", "fail"};
-    EXPECT_EQ(intrinsics.size(), 4u);
+        "expect", "mock", "fail"};
+    EXPECT_EQ(intrinsics.size(), 3u);
     EXPECT_EQ(intrinsics, expected);
 }
 
@@ -1550,10 +1553,10 @@ TEST_F(ImportTest, FromTestingImportSingleIntrinsicRecordsOne) {
 TEST_F(ImportTest, FromTestingImportMultipleIntrinsicsRecordsAll) {
     auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
     auto intrinsics = resolveAndGetTestingIntrinsics(
-        "from testing import expect, mock, verify, fail\n",
+        "from testing import expect, mock, fail\n",
         tmp_dir_.string(),
         search_paths);
-    std::unordered_set<std::string> expected = {"expect", "mock", "verify", "fail"};
+    std::unordered_set<std::string> expected = {"expect", "mock", "fail"};
     EXPECT_EQ(intrinsics, expected);
 }
 
@@ -1583,9 +1586,11 @@ TEST_F(ImportTest, CodeGenReceivesAllTestingIntrinsicsForWildcard) {
         "from testing\n",
         tmp_dir_.string(),
         search_paths);
+    // Post-#722 `verify` is no longer a testing intrinsic (it is a regular
+    // `@public fn` in share/std/testing/testing.ry).
     std::unordered_set<std::string> expected = {
-        "expect", "mock", "verify", "fail"};
-    EXPECT_EQ(intrinsics.size(), 4u);
+        "expect", "mock", "fail"};
+    EXPECT_EQ(intrinsics.size(), 3u);
     EXPECT_EQ(intrinsics, expected);
 }
 

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1387,11 +1387,12 @@ TEST_F(ImportTest, ImportedDirectiveValidatesAtUseSite) {
 
 // ===== testing module intrinsic import allow-list (#712) =====
 //
-// `from testing import expect / mock / verify / fail` references compiler
-// intrinsics that have no AST declaration in `share/std/testing/testing.ry`
-// (only `it / describe / each / property` are declared there). The loader
+// `from testing import expect / mock / fail` references compiler intrinsics
+// that have no AST declaration in `share/std/testing/testing.ry`. The loader
 // must whitelist the intrinsic names for the testing module so the named
-// import does not fail at the "not found in module" check.
+// import does not fail at the "not found in module" check. As of #722,
+// `verify` is no longer an intrinsic — it is a regular `@public fn verify`
+// declared in `share/std/testing/testing.ry` and resolves via normal import.
 
 namespace {
 // Derive the repo's share/std path from the test source location so the
@@ -1427,9 +1428,12 @@ TEST_F(ImportTest, FromTestingImportExpectResolves) {
     EXPECT_EQ(directive_names.count("describe"), 1u);
 }
 
-// AC #2: all six testing intrinsics (`it`, `describe`, `expect`, `mock`,
-// `verify`, `fail`) are accepted as named imports.
-TEST_F(ImportTest, FromTestingImportAllSixIntrinsicsResolve) {
+// AC #2: all testing-module symbols (`it`, `describe`, `expect`, `mock`,
+// `verify`, `fail`) are accepted as named imports. Resolution differs by
+// kind: `expect` / `mock` / `fail` resolve via the intrinsic allow-list,
+// `it` / `describe` via their `@directive` declarations, and `verify`
+// (post-#722) via its `@public fn` declaration in testing.ry.
+TEST_F(ImportTest, FromTestingImportAllTestingSymbolsResolve) {
     auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
     EXPECT_NO_THROW({
         resolveImportsOnly(


### PR DESCRIPTION
## Summary

Migrates `verify` from a compiler-recognized intrinsic to a regular
`@public fn` in `share/std/testing/testing.ry`. The function is now
backed by a new `@native("testing")` runtime entry
`__ry_testing__mockGetCallCount`, which thinly wraps the existing
`__ry_mock_get_call_count`. `mock` stays a compiler intrinsic — it
still requires compile-time function-existence and signature
validation, which an ordinary fn cannot provide.

Closes #722.

## Behavior changes (BC breaks)

- The bare-identifier form `verify(fnName)` is **no longer accepted**;
  the argument must be a `str` (typically a literal). The
  `coerceFirstArgToString` parser sugar for `verify` has been removed
  (`mock`'s sugar at `parser.cpp:792` is retained).
- `verify` no longer performs compile-time function-name validation.
  Calling `verify("nonexistent")` now returns `0` at runtime instead of
  failing to compile.
- Without `from testing import verify`, the diagnostic becomes the
  standard `undefined function: verify` instead of the
  intrinsic-specific `'verify' requires 'from testing import verify'`.

## Files

- `share/std/testing/testing.ry` — declares `_mockGetCallCount` and
  `verify` (mirrors the `_reportFail` / `fail` pattern).
- `src/runtime_testing.cpp` — `__ry_testing__mockGetCallCount` wrapper.
- `src/codegen_call_dispatch.cpp` — verify special-case dispatch removed.
- `src/parser_expr.cpp` — verify's `coerceFirstArgToString` removed.
- `src/module_loader.cpp` — `kSet` no longer lists `"verify"`; comments
  updated to reflect the new flow.
- `tests/spec/verify_as_function.test.ry` (new) — regression / spec test.
- C++ test fixtures updated: `withTestingFnDecls` appends the new decls
  (preserving line numbers); the `VerifyRequiresTestingImport` negative
  test is removed; the testing-intrinsic set is now size-3
  (`expect`, `mock`, `fail`).
- `docs/reference/testing.md` — updated `verify` section.
- `changelog.d/722-verify-as-ry-function.md` (new) — Changed/Removed/Fixed.

## Test plan

- [x] `./build/ry test -p` — 174 / 174 self-test files pass
- [x] `./build/ry_tests` — 2142 / 2142 C++ tests pass
- [x] ASan + UBSan: `./build-asan/ry_tests` + `./build-asan/ry test -p` clean
- [x] TSan required gate: `./build-tsan/ry_tests` clean
- [x] `grep -rn '"verify"' src/ include/` shows no stale special-cases
- [x] No tree-sitter / IR-golden changes (no grammar or IR-shape impact)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * verify() now takes a string (e.g., verify("myFunction")) — bare identifier form is no longer accepted.
  * verify is no longer a compiler intrinsic; import it from the testing module like other helpers.

* **Behavior**
  * verify(...) returns an integer call count and yields 0 for unknown or unrecorded names.

* **Bug Fixes**
  * Missing-import diagnostics for verify now report "undefined function" consistently.

* **Documentation**
  * Testing reference updated to reflect import rules and string-based verify usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->