### PR TITLE
test(spec): include bound error in Err(e): fail(...) helpers (#1447)

### DIFF
--- a/.claude/rules/tests-spec-conventions.md
+++ b/.claude/rules/tests-spec-conventions.md
@@ -113,6 +113,27 @@ For setup guards ("if dir exists, remove it"), prefer unconditional `removeAll(d
 `Result<Unit, Error>` is discarded if unused. For `Result<bool, Error>` predicates, use
 `Ok(v): expect(v).toBeTrue()` / `Ok(v): expect(v).toBeFalse()` patterns.
 
+### `Err(e):` formatting for non-Error Err slots: pick by Result<Ok, Err> shape
+
+**Source**: #1447 (2026-05-08, implementation); #1638 (companion bug)
+**Tags**: testing, case, Err binding, str, ARC, non-Error, f-string, blind-spot
+
+**Rule**: When formatting the bound `e` inside `fail(...)` of an `Err(e):` arm whose Err slot is **not** `Error`, the canonical pattern depends on the Result shape:
+
+| Result type | `"prefix: " + e` | `f"prefix: {e}"` | Canonical |
+|---|---|---|---|
+| `Result<int, str>` | works | works | either |
+| `Result<int, int>` | compile error (no int+str concat) | works | f-string |
+| `Result<List<int>, str>` (ARC Ok slot) | compile error | typechecks, crashes at runtime | see #1638 workaround |
+
+**Why**: `Result<int, str>` preserves the str typing of the Err slot through the binding, so both `+` (str concat) and f-string interpolation work. `Result<int, int>` cannot use `+ e` because there is no `str + int` operator, but f-string accepts int interpolation. `Result<ARC-type, str>` (where the Ok slot holds an ARC-managed type like `List`, `Map`, etc.) loses str typing on the Err side (#1638): `+ e` is rejected at compile time, and `f"{e}"` typechecks but the value is an invalid str representation that crashes when the Err arm actually executes.
+
+**How to apply**: For `Err(e):` arms in `tests/spec/`:
+
+- `Result<int, str>` and `Result<<primitive>, Error>` paths: use `+ e.message` (Error) or `+ e` (str) — most readable.
+- `Result<int, int>` paths: use `f"...({e})"` — f-string is the only way to interpolate an int into the message.
+- `Result<<ARC-type>, str>` paths: until #1638 lands, prefer `Err(_):` if the arm is **reachable** in the test. If the arm is **unreachable** (e.g. a defensive `Err(e): fail("expected Ok but got Err...")` against a fn that only ever returns Ok), `f"{e}"` is acceptable — it compiles and the latent runtime crash is hidden behind the dead code path. The fix in `pattern_arc.test.ry:81` (#1447) follows this convention.
+
 ### Naming-convention sweeps must include the implicit `name: type = value` form, not just `let`/`var`, and must cover module-global declarations
 
 **Source**: #1466 (2026-04-30, follow-up to #1450 / #1451); #1468 (2026-04-30, module-global blind spot)

--- a/tests/spec/arc_iolist.test.ry
+++ b/tests/spec/arc_iolist.test.ry
@@ -40,7 +40,7 @@ fn iolistheaderArcCorrectness1007Tests():
       Ok(_):
         ...
       Err(e):
-        fail("writeBytes failed")
+        fail("writeBytes failed: " + e.message)
     # seed counted before 'before', so only readBytes result appears as delta.
     before = arcLiveCount()
     case readBytes(path):
@@ -50,9 +50,9 @@ fn iolistheaderArcCorrectness1007Tests():
         expect(after - before).toEq(1)
         expect(rb.len()).toEq(9)
       Err(e):
-        fail("readBytes failed")
+        fail("readBytes failed: " + e.message)
     case deleteFile(path):
       Ok(_):
         ...
       Err(e):
-        fail("deleteFile failed")
+        fail("deleteFile failed: " + e.message)

--- a/tests/spec/combinatorial/nested_types.test.ry
+++ b/tests/spec/combinatorial/nested_types.test.ry
@@ -53,7 +53,7 @@ fn nestedResultIntErrorTests():
       Ok(n):
         expect(n).toEq(5)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should propagate Err from nested result")
   fn shouldPropagateErrFromNestedResult():
     r = divide(10, 0)
@@ -117,7 +117,7 @@ fn nestedResultStrErrorTests():
       Ok(s):
         expect(s).toEq("hello, world")
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should return Err when input is invalid")
   fn shouldReturnErrWhenInputIsInvalid():
     r = makeGreeting("")

--- a/tests/spec/http.test.ry
+++ b/tests/spec/http.test.ry
@@ -45,17 +45,17 @@ fn httpServerApiTests():
                         expect(contains(msg, "200 OK")).toEq(true)
                         expect(contains(msg, "Hello!")).toEq(true)
                       Err(e):
-                        fail("unexpected error")
+                        fail("unexpected error: " + e.message)
                   Err(e):
-                    fail("unexpected error")
+                    fail("unexpected error: " + e.message)
                 close(conn)
               Err(e):
-                fail("unexpected error")
+                fail("unexpected error: " + e.message)
             blockOn(t)
           Err(e):
-            fail("unexpected error")
+            fail("unexpected error: " + e.message)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should respond with 404 Not Found")
   fn shouldRespondWith404NotFound():
     async fn server404(server: TcpListener) -> str:
@@ -95,14 +95,14 @@ fn httpServerApiTests():
                       Ok(msg):
                         expect(contains(msg, "404 Not Found")).toEq(true)
                       Err(e):
-                        fail("unexpected error")
+                        fail("unexpected error: " + e.message)
                   Err(e):
-                    fail("unexpected error")
+                    fail("unexpected error: " + e.message)
                 close(conn)
               Err(e):
-                fail("unexpected error")
+                fail("unexpected error: " + e.message)
             blockOn(t)
           Err(e):
-            fail("unexpected error")
+            fail("unexpected error: " + e.message)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)

--- a/tests/spec/io.test.ry
+++ b/tests/spec/io.test.ry
@@ -19,49 +19,49 @@ fn fileIOTests():
           Ok(s):
             expect(s).toEq("hello world")
           Err(e):
-            fail("unexpected error")
+            fail("unexpected error: " + e.message)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
     case deleteFile("/tmp/ry_selftest_io.txt"):
       Ok(_):
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should append text")
   fn shouldAppendText():
     case writeText("/tmp/ry_selftest_io_append.txt", "hello"):
       Ok(_):
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
     case appendText("/tmp/ry_selftest_io_append.txt", " world"):
       Ok(_):
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
     case readText("/tmp/ry_selftest_io_append.txt"):
       Ok(s):
         expect(s).toEq("hello world")
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
     case deleteFile("/tmp/ry_selftest_io_append.txt"):
       Ok(_):
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should check exists")
   fn shouldCheckExists():
     case writeText("/tmp/ry_selftest_io_exists.txt", "test"):
       Ok(_):
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
     expect(exists("/tmp/ry_selftest_io_exists.txt")).toEq(true)
     case deleteFile("/tmp/ry_selftest_io_exists.txt"):
       Ok(_):
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
     expect(exists("/tmp/ry_selftest_io_exists.txt")).toEq(false)
   @it("should handle byte conversions")
   fn shouldHandleByteConversions():
@@ -71,7 +71,7 @@ fn fileIOTests():
       Ok(s):
         expect(s).toEq("ABC")
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should read/write bytes")
   fn shouldReadWriteBytes():
     data = toBytes("binary test")
@@ -79,7 +79,7 @@ fn fileIOTests():
       Ok(_):
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
     case readBytes("/tmp/ry_selftest_io_bytes.bin"):
       Ok(rb):
         expect(len(rb)).toEq(11)
@@ -87,14 +87,14 @@ fn fileIOTests():
           Ok(s):
             expect(s).toEq("binary test")
           Err(e):
-            fail("unexpected error")
+            fail("unexpected error: " + e.message)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
     case deleteFile("/tmp/ry_selftest_io_bytes.bin"):
       Ok(_):
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should return Err from readText for missing file")
   fn shouldReturnErrFromReadtextForMissingFile():
     expect(readText("/tmp/ry_selftest_nonexistent_file.txt")).toBeErr()
@@ -112,9 +112,9 @@ fn fileIOTests():
           Ok(s):
             expect(s).toEq("")
           Err(e):
-            fail("unexpected read error")
+            fail("unexpected read error: " + e.message)
       Err(e):
-        fail("unexpected write error")
+        fail("unexpected write error: " + e.message)
     deleteFile("/tmp/ry_selftest_io_empty.txt")
   @it("should write and read empty bytes")
   fn shouldWriteAndReadEmptyBytes():
@@ -125,9 +125,9 @@ fn fileIOTests():
           Ok(rb):
             expect(len(rb)).toEq(0)
           Err(e):
-            fail("unexpected read error")
+            fail("unexpected read error: " + e.message)
       Err(e):
-        fail("unexpected write error")
+        fail("unexpected write error: " + e.message)
     deleteFile("/tmp/ry_selftest_io_empty.bin")
   @it("should return false from exists for missing file")
   fn shouldReturnFalseFromExistsForMissingFile():
@@ -140,7 +140,7 @@ fn fileIOTests():
       Ok(s):
         expect(s).toEq("second")
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
     deleteFile("/tmp/ry_selftest_io_overwrite.txt")
   @it("should convert u8 list literal including embedded NUL to str")
   fn shouldConvertU8ListLiteralIncludingEmbeddedNulToStr():
@@ -148,7 +148,7 @@ fn fileIOTests():
       Ok(s):
         expect(s == "a\0b").toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should write and read back u8 list literal with embedded NUL")
   fn shouldWriteAndReadBackU8ListLiteralWithEmbeddedNul():
     case writeBytes("/tmp/ry_selftest_io_u8lit.bin", [97u8, 0u8, 98u8]):
@@ -160,11 +160,11 @@ fn fileIOTests():
               Ok(s):
                 expect(s == "a\0b").toEq(true)
               Err(e):
-                fail("unexpected decode error")
+                fail("unexpected decode error: " + e.message)
           Err(e):
-            fail("unexpected read error")
+            fail("unexpected read error: " + e.message)
       Err(e):
-        fail("unexpected write error")
+        fail("unexpected write error: " + e.message)
     deleteFile("/tmp/ry_selftest_io_u8lit.bin")
   @it("should convert toBytes output back to str (regression guard)")
   fn shouldConvertTobytesOutputBackToStrRegressionGuard():
@@ -173,7 +173,7 @@ fn fileIOTests():
       Ok(s):
         expect(s).toEq("hello")
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should accept List<u8> annotation and route through byte stride (#1079)")
   fn shouldAcceptListU8AnnotationAndRouteThroughByteStride1079():
     bs: List<u8> = [97, 0, 98]
@@ -181,7 +181,7 @@ fn fileIOTests():
       Ok(s):
         expect(s == "a\0b").toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should accept List<u8> annotation for writeBytes (#1079)")
   fn shouldAcceptListU8AnnotationForWritebytes1079():
     bs: List<u8> = [72, 105]
@@ -189,9 +189,9 @@ fn fileIOTests():
       Ok(_):
         case readBytes("/tmp/ry_selftest_io_annot_u8.bin"):
           Ok(rb): expect(len(rb)).toEq(2)
-          Err(e): fail("unexpected read error")
+          Err(e): fail("unexpected read error: " + e.message)
       Err(e):
-        fail("unexpected write error")
+        fail("unexpected write error: " + e.message)
     deleteFile("/tmp/ry_selftest_io_annot_u8.bin")
   @it("should accept List<u8> reassignment via bytesToStr (#1085)")
   fn shouldAcceptListU8ReassignmentViaBytestostr1085():
@@ -201,7 +201,7 @@ fn fileIOTests():
       Ok(s):
         expect(s == "cde").toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should accept List<u8> reassignment for writeBytes (#1085)")
   fn shouldAcceptListU8ReassignmentForWritebytes1085():
     bs: List<u8> = [72, 105]
@@ -210,9 +210,9 @@ fn fileIOTests():
       Ok(_):
         case readBytes("/tmp/ry_selftest_io_reassign_u8.bin"):
           Ok(rb): expect(len(rb)).toEq(3)
-          Err(e): fail("unexpected read error")
+          Err(e): fail("unexpected read error: " + e.message)
       Err(e):
-        fail("unexpected write error")
+        fail("unexpected write error: " + e.message)
     deleteFile("/tmp/ry_selftest_io_reassign_u8.bin")
   @it("should accept List<u8> module-global reassignment from function (#1085)")
   fn shouldAcceptListU8ModuleGlobalReassignmentFromFunction1085():
@@ -221,7 +221,7 @@ fn fileIOTests():
       Ok(s):
         expect(s == "cde").toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should accept List<u8> compound assignment (local, #1102)")
   fn shouldAcceptListU8CompoundAssignmentLocal1102():
     bs: List<u8> = [97]
@@ -231,4 +231,4 @@ fn fileIOTests():
       Ok(s):
         expect(s == "ac").toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -46,7 +46,7 @@ fn jsonParseTests():
         expect(kind(data)).toEq("object")
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
   @it("should preserve JsonValue metadata through helper-returned Option")
   fn shouldPreserveJsonvalueMetadataThroughHelperReturnedOption():
     fn maybeObj() -> Option<JsonValue>:
@@ -72,7 +72,7 @@ fn jsonParseTests():
         expect(kind(data)).toEq("object")
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should preserve JsonValue metadata through Result.andThen")
   fn shouldPreserveJsonvalueMetadataThroughResultAndthen():
@@ -139,7 +139,7 @@ fn jsonAccessTests():
             fail("get failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should get int field")
   fn shouldGetIntField():
@@ -156,7 +156,7 @@ fn jsonAccessTests():
             fail("get failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should get float field")
   fn shouldGetFloatField():
@@ -174,7 +174,7 @@ fn jsonAccessTests():
             fail("get failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should get bool field")
   fn shouldGetBoolField():
@@ -191,7 +191,7 @@ fn jsonAccessTests():
             fail("get failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should get null type")
   fn shouldGetNullType():
@@ -204,7 +204,7 @@ fn jsonAccessTests():
             fail("get failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should access array by index")
   fn shouldAccessArrayByIndex():
@@ -230,7 +230,7 @@ fn jsonAccessTests():
             fail("at failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should return Err for missing key")
   fn shouldReturnErrForMissingKey():
@@ -239,7 +239,7 @@ fn jsonAccessTests():
         expect(get(data, "missing")).toBeErr()
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should return Err for out-of-bounds index")
   fn shouldReturnErrForOutOfBoundsIndex():
@@ -248,7 +248,7 @@ fn jsonAccessTests():
         expect(at(data, 5)).toBeErr()
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should return Err for type mismatch")
   fn shouldReturnErrForTypeMismatch():
@@ -261,7 +261,7 @@ fn jsonAccessTests():
             fail("get failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
 @describe("json nested")
 fn jsonNestedTests():
@@ -293,7 +293,7 @@ fn jsonNestedTests():
             fail("get(user) failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should access array of objects")
   fn shouldAccessArrayOfObjects():
@@ -314,7 +314,7 @@ fn jsonNestedTests():
             fail("at failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
 @describe("json keys and len")
 fn jsonKeysAndLenTests():
@@ -328,10 +328,10 @@ fn jsonKeysAndLenTests():
             expect(ks[0]).toEq("a")
             expect(ks[1]).toEq("b")
           Err(e):
-            fail("keys failed")
+            fail("keys failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should return Err for non-object keys")
   fn shouldReturnErrForNonObjectKeys():
@@ -344,7 +344,7 @@ fn jsonKeysAndLenTests():
             expect(e.message).toEq("json_keys: value is not an object")
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should get object len")
   fn shouldGetObjectLen():
@@ -353,7 +353,7 @@ fn jsonKeysAndLenTests():
         expect(len(data)).toEq(3)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
 @describe("json stringify")
 fn jsonStringifyTests():
@@ -375,10 +375,10 @@ fn jsonStringifyTests():
                 fail("get failed: " + e.message)
             jsonFree(data2)
           Err(e):
-            fail("re-parse failed")
+            fail("re-parse failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should pretty print with indent")
   fn shouldPrettyPrintWithIndent():
@@ -388,7 +388,7 @@ fn jsonStringifyTests():
         expect(contains(text, "\n")).toBeTrue()
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
 @describe("json child value ownership")
 fn jsonChildValueOwnershipTests():
@@ -402,12 +402,12 @@ fn jsonChildValueOwnershipTests():
               Ok(name):
                 expect(name).toEq("Alice")
               Err(e):
-                fail("toStr failed")
+                fail("toStr failed: " + e.message)
           Err(e):
             fail("get failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should not cause double-free on scope exit for at() child")
   fn shouldNotCauseDoubleFreeOnScopeExitForAtChild():
@@ -419,12 +419,12 @@ fn jsonChildValueOwnershipTests():
               Ok(s):
                 expect(s).toEq("hello")
               Err(e):
-                fail("toStr failed")
+                fail("toStr failed: " + e.message)
           Err(e):
             fail("at failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should not cause double-free on scope exit for nested get() children")
   fn shouldNotCauseDoubleFreeOnScopeExitForNestedGetChildren():
@@ -438,14 +438,14 @@ fn jsonChildValueOwnershipTests():
                   Ok(name):
                     expect(name).toEq("Bob")
                   Err(e):
-                    fail("toStr failed")
+                    fail("toStr failed: " + e.message)
               Err(e):
                 fail("get(name) failed: " + e.message)
           Err(e):
             fail("get(user) failed: " + e.message)
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
 @describe("json type checks")
 fn jsonTypeChecksTests():
@@ -456,7 +456,7 @@ fn jsonTypeChecksTests():
         expect(kind(data)).toEq("string")
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should identify number type")
   fn shouldIdentifyNumberType():
@@ -465,7 +465,7 @@ fn jsonTypeChecksTests():
         expect(kind(data)).toEq("number")
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should identify boolean type")
   fn shouldIdentifyBooleanType():
@@ -474,7 +474,7 @@ fn jsonTypeChecksTests():
         expect(kind(data)).toEq("boolean")
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
   @it("should identify null type")
   fn shouldIdentifyNullType():
@@ -483,7 +483,7 @@ fn jsonTypeChecksTests():
         expect(kind(data)).toEq("null")
         jsonFree(data)
       Err(e):
-        fail("parse failed")
+        fail("parse failed: " + e.message)
 
 @describe("json NUL round-trip")
 fn jsonNulRoundTripTests():
@@ -546,7 +546,7 @@ fn jsonNulRoundTripTests():
                   Ok(n):
                     expect(n).toEq(42)
                   Err(e):
-                    fail("toInt failed")
+                    fail("toInt failed: " + e.message)
               Err(e):
                 fail("get failed: " + e.message)
           Err(e):
@@ -577,7 +577,7 @@ fn jsonNulRoundTripTests():
                   Ok(n):
                     expect(n).toEq(1)
                   Err(e):
-                    fail("toInt ks[0] failed")
+                    fail("toInt ks[0] failed: " + e.message)
               Err(e):
                 fail("get ks[0] failed: " + e.message)
             case get(data, ks[1]):
@@ -586,7 +586,7 @@ fn jsonNulRoundTripTests():
                   Ok(n):
                     expect(n).toEq(2)
                   Err(e):
-                    fail("toInt ks[1] failed")
+                    fail("toInt ks[1] failed: " + e.message)
               Err(e):
                 fail("get ks[1] failed: " + e.message)
           Err(e):

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -12,7 +12,7 @@ fn tcpSocketApiTests():
         close(server)
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should return Ok on valid listener for listen")
   fn shouldReturnOkOnValidListenerForListen():
     case bind("127.0.0.1", 0):
@@ -21,10 +21,10 @@ fn tcpSocketApiTests():
           Ok(_):
             expect(true).toEq(true)
           Err(e):
-            fail("unexpected error")
+            fail("unexpected error: " + e.message)
         close(server)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should return Err when tlsConnect to closed port")
   fn shouldReturnErrWhenTlsconnectToClosedPort():
     case tlsConnect("127.0.0.1", 19991):
@@ -51,7 +51,7 @@ fn tcpSocketApiTests():
         expect(listenerPort(server) > 0).toBeTrue()
         close(server)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should preserve TcpListener metadata through helper-returned Option")
   fn shouldPreserveTcplistenerMetadataThroughHelperReturnedOption():
     fn maybeListener() -> Option<TcpListener>:
@@ -94,12 +94,12 @@ fn tcpSocketApiTests():
                     expect(true).toEq(true)
                 close(conn)
               Err(e):
-                fail("unexpected error")
+                fail("unexpected error: " + e.message)
             blockOn(t)
           Err(e):
-            fail("unexpected error")
+            fail("unexpected error: " + e.message)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should complete echo round-trip with async fn")
   fn shouldCompleteEchoRoundTripWithAsyncFn():
     async fn runServer(server: TcpListener) -> str:
@@ -155,9 +155,9 @@ fn tcpSocketApiTests():
             expect(respMsg).toEq("echo:hello")
             blockOn(t)
           Err(e):
-            fail("unexpected error")
+            fail("unexpected error: " + e.message)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
 
   @it("should preserve Result<TcpStream, Error> resource metadata across helper returns")
   fn shouldPreserveResultTcpstreamErrorResourceMetadataAcrossHelperReturns():
@@ -186,9 +186,9 @@ fn tcpSocketApiTests():
                 close(conn)
                 expect(true).toEq(true)
               Err(e):
-                fail("unexpected error")
+                fail("unexpected error: " + e.message)
             blockOn(t)
           Err(e):
-            fail("unexpected error")
+            fail("unexpected error: " + e.message)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)

--- a/tests/spec/pattern_arc.test.ry
+++ b/tests/spec/pattern_arc.test.ry
@@ -78,7 +78,7 @@ fn patternBindingArcRetain997Tests():
         expect(xs[0]).toEq(1)
         expect(xs[2]).toEq(3)
       Err(e):
-        fail("expected Ok")
+        fail(f"expected Ok but got Err: {e}")
 
   @it("Err pattern retains str binding")
   fn errPatternRetainsStrBinding():

--- a/tests/spec/result.test.ry
+++ b/tests/spec/result.test.ry
@@ -33,7 +33,7 @@ fn resultTypeTests():
       Ok(v):
         expect(v).toEq(5)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should extract error when Err")
   fn shouldExtractErrorWhenErr():
     case safeDivide(10, 0):
@@ -47,7 +47,7 @@ fn resultTypeTests():
       Ok(v):
         expect(v).toEq(6)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should propagate Err with ?")
   fn shouldPropagateErrWith():
     case divideAndAdd(10, 0):
@@ -61,7 +61,7 @@ fn resultTypeTests():
       Ok(v):
         expect(v).toEq(5)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should propagate chained ? from second call")
   fn shouldPropagateChainedFromSecondCall():
     case chained(100, 10, 0):
@@ -75,7 +75,7 @@ fn resultTypeTests():
       Ok(v):
         expect(v).toEq(6)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should recognize Ok(0) as Ok")
   fn shouldRecognizeOk0AsOk():
     res = Ok(0)
@@ -96,4 +96,4 @@ fn resultTypeTests():
       Ok(_):
         expect(true).toEq(true)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)

--- a/tests/spec/result_option_arc_return.test.ry
+++ b/tests/spec/result_option_arc_return.test.ry
@@ -120,7 +120,7 @@ fn resultOptionArcReturn999Tests():
         expect(xs.len()).toEq(3)
         expect(xs[0]).toEq(10)
       Err(e):
-        fail("unexpected Err")
+        fail("unexpected Err: " + e.message)
 
   @it("Ok(xs) — inner list is alive after function returns (no use-after-free)")
   fn okXsInnerListIsAliveAfterFunctionReturnsNoUseAfterFree():
@@ -135,7 +135,7 @@ fn resultOptionArcReturn999Tests():
         expect(xs[0]).toEq(42)
         expect(xs[1]).toEq(43)
       Err(e):
-        fail("unexpected Err")
+        fail("unexpected Err: " + e.message)
 
   @it("Err(xs) — data survives scope cleanup")
   fn errXsDataSurvivesScopeCleanup():

--- a/tests/spec/result_type_inference.test.ry
+++ b/tests/spec/result_type_inference.test.ry
@@ -131,7 +131,7 @@ fn resultTypeInferenceInUnannotatedLambdasTests():
     r: Result<int, int> = f(42, -1)
     case r:
       Ok(v): expect(v).toEq(42)
-      Err(e): fail("expected Ok but got Err")
+      Err(e): fail(f"expected Ok but got Err({e})")
     r2: Result<int, int> = f(-1, 99)
     case r2:
       Ok(v): fail("expected Err but got Ok")
@@ -145,4 +145,4 @@ fn resultTypeInferenceInUnannotatedLambdasTests():
       Err(e): expect(e).toEq(-5)
     case f(5):
       Ok(v): expect(v).toEq(100)
-      Err(e): fail("expected Ok but got Err")
+      Err(e): fail(f"expected Ok but got Err({e})")

--- a/tests/spec/thread.test.ry
+++ b/tests/spec/thread.test.ry
@@ -98,7 +98,7 @@ fn semaphoreTests():
         threadJoin(t2)
         expect(atomicIntLoad(counter)).toEq(2)
       Err(e):
-        fail("semaphoreNew failed")
+        fail("semaphoreNew failed: " + e.message)
 
 @describe("Barrier")
 fn barrierTests():
@@ -123,7 +123,7 @@ fn barrierTests():
         threadJoin(t2)
         expect(atomicIntLoad(counter)).toEq(2)
       Err(e):
-        fail("barrierNew failed")
+        fail("barrierNew failed: " + e.message)
 
 @describe("AtomicInt")
 fn atomicintTests():
@@ -228,7 +228,7 @@ fn threadspawnReturnValuesMvp828Tests():
       Ok(v):
         expect(v).toEq(42)
       Err(e):
-        fail("expected Ok but got Err")
+        fail("expected Ok but got Err: " + e.message)
 
   @it("should return float from an expression-bodied worker")
   fn shouldReturnFloatFromAnExpressionBodiedWorker():
@@ -237,7 +237,7 @@ fn threadspawnReturnValuesMvp828Tests():
       Ok(v):
         expect(v).toEq(3.14)
       Err(e):
-        fail("expected Ok but got Err")
+        fail("expected Ok but got Err: " + e.message)
 
   @it("should return bool from an expression-bodied worker")
   fn shouldReturnBoolFromAnExpressionBodiedWorker():
@@ -246,7 +246,7 @@ fn threadspawnReturnValuesMvp828Tests():
       Ok(v):
         expect(v).toBeTrue()
       Err(e):
-        fail("expected Ok but got Err")
+        fail("expected Ok but got Err: " + e.message)
 
   @it("should support captured variables in value-returning workers")
   fn shouldSupportCapturedVariablesInValueReturningWorkers():
@@ -256,7 +256,7 @@ fn threadspawnReturnValuesMvp828Tests():
       Ok(v):
         expect(v).toEq(100)
       Err(e):
-        fail("expected Ok but got Err")
+        fail("expected Ok but got Err: " + e.message)
 
   @it("should propagate return-type metadata across variable assignment")
   fn shouldPropagateReturnTypeMetadataAcrossVariableAssignment():
@@ -269,7 +269,7 @@ fn threadspawnReturnValuesMvp828Tests():
       Ok(v):
         expect(v).toEq(7)
       Err(e):
-        fail("expected Ok but got Err")
+        fail("expected Ok but got Err: " + e.message)
 
   @it("should preserve Thread resource metadata across helper returns")
   fn shouldPreserveThreadResourceMetadataAcrossHelperReturns():
@@ -280,7 +280,7 @@ fn threadspawnReturnValuesMvp828Tests():
       Ok(v):
         expect(v).toEq(7)
       Err(e):
-        fail("expected Ok but got Err")
+        fail("expected Ok but got Err: " + e.message)
 
 @describe("threadJoin error paths (MVP, #828)")
 fn threadjoinErrorPathsMvp828Tests():

--- a/tests/spec/type_advanced.test.ry
+++ b/tests/spec/type_advanced.test.ry
@@ -284,7 +284,7 @@ fn resultTypeTests():
       Ok(v):
         expect(v).toEq(5)
       Err(e):
-        fail("unexpected error")
+        fail("unexpected error: " + e.message)
   @it("should return Err on failure")
   fn shouldReturnErrOnFailure():
     res = safeDivide(10, 0)


### PR DESCRIPTION
## Summary

- Sweep 12 `tests/spec/` files (111 sites) to attach the bound Err payload to `fail()` messages — when an `Err(e):` arm fires unexpectedly in CI, the log now shows what the error actually was, instead of a bare `"parse failed"` / `"unexpected error"`.
- Behavior unchanged — purely diagnostic.
- Closes #1447.

## Approach

| Group | Files | Sites | Fix shape |
|---|---|---|---|
| `Result<_, Error>` (mechanical sweep) | 10 | 108 | `fail("MSG")` → `fail("MSG: " + e.message)` via `perl -0pi` |
| `Result<int, int>` (int Err) | `result_type_inference.test.ry` | 2 | `fail(f"expected Ok but got Err({e})")` (f-string for int) |
| `Result<List<int>, str>` (str Err, ARC Ok slot) | `pattern_arc.test.ry` | 1 | `fail(f"expected Ok but got Err: {e}")` (f-string; arm unreachable, see #1638) |

The bulk sweep used the regex `(Err\(e\):\s+fail\(")([^"]+)("\))` to cover both multi-line (`Err(e):\n  fail(...)`) and single-line forms in a single pass. Pre-sweep grep verified the match count per file equalled the expected site count, and `git diff --stat` confirmed exactly 108 in-place modifications.

## Companion findings

While fixing `pattern_arc.test.ry:81`, discovered a pre-existing bug in `Err(e)` binding for `Result<ARC-type, str>`: the str type info is lost on the Err side, causing `+ e` to fail at compile time and `f"{e}"` to crash at runtime. The Err arm in the affected test is unreachable so the latent crash is hidden — filed as #1638 for proper fix. Documented the empirical matrix and workaround in `.claude/rules/tests-spec-conventions.md`.

## Skipped pre-commit-checklist sections

- §1 Doc — `tests/` only, no user-visible behavior change
- §2 CHANGELOG — `tests/` only, no user-visible behavior change
- §3.6 libFuzzer — no parser/lexer/json/utf8/string source change
- §3.5.5 Static Analysis (clang-tidy / cppcheck) — no `src/` or `include/` change
- §3.6.5 tree-sitter — no grammar change

## Test plan

- [x] `./build/ry test -p` — 174 test files / 0 failures
- [x] `./build/ry_tests` — 2142 / 2142 PASSED
- [x] ASan + UBSan: C++ 2142 + Ry 174 / 0 failures
- [x] TSan C++: 2142 / 2142 PASSED
- [x] awk re-detection: 0 hits (with `!/\{e\}/` exclude for f-string fixes)
- [x] `git diff --stat`: 12 test files modified with 111 insertions / 111 deletions (each in-place 1-line modification)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test failure messages across multiple test suites to include detailed error information, replacing generic failure strings with actual error messages from caught exceptions for improved diagnostic output during test failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->