### PR TITLE
fix(codegen): preserve str typing on Err(e) for Result<ARC-type, str> (#1638)

### DIFF
--- a/.claude/rules/codegen-pattern-and-match.md
+++ b/.claude/rules/codegen-pattern-and-match.md
@@ -49,9 +49,12 @@ compile-time-enforced distinction. The guard at VariablePattern binding
 remains necessary but is now purely defensive
 (subjectEnumName is already enum-only).
 
-**Follow-up**: Add a lossless `source_type_name` field to `ValueMetadata` so
-`Option<List<int>>` reconstruction is accurate, enabling ARC Path 2a for nested
-generics (currently handled by Path 2b heuristic via `propagateMeta`).
+**Follow-up (resolved by #1638, 2026-05-08)**: A lossless
+`source_type_name` field on `ValueMetadata` (added in #1638) is now stamped
+by `propagateTypeMeta` at the Result/Option/T? branch entries
+(`src/codegen_builtin.cpp:75-193`). This is what `emitPatternBindings`'
+Ok/Err/Some arms now consult — see the supersede entry below — instead of
+relying on `propagateMeta`'s broad bulk-copy.
 - Pre-existing defect in `emitListSlice`: ARC retain omitted for reference-typed elements (#1204) — tracked separately.
 
 ### Tuple pattern in `case`: per-element metadata via `splitTypeArgs`
@@ -78,16 +81,32 @@ Records don't set `enum_value_type` on constructed values anywhere in the compil
 
 **How to apply**: Mirrored in `emitPatternTest` too: passing the full field type string as `subjectEnumType` in recursive `emitPatternTest` calls is safe (LiteralPattern and WildcardPattern ignore it; RecordPattern uses `pat->name` for lookup, not `subjectEnumType`). The dangerous place is **only in `emitPatternBindings`** where `VariablePattern` stores `subjectEnumType` directly into `enum_value_type` metadata.
 
-### ErrPattern binding in codegen_match.cpp must propagateMeta to preserve collection element-type metadata
+### Ok/Err/Some pattern bindings: prefer typeSig-driven `propagateTypeMeta`, not bulk `propagateMeta` (supersedes #1001)
 
-**Source**: #1001 (2026-04-16, implementation)
-**Tags**: codegen_match, pattern, Result, Err, metadata, collection, propagateMeta
+**Source**: #1638 (2026-05-08, implementation; supersedes #1001)
+**Tags**: codegen_match, pattern, Result, Err, Ok, Some, metadata, propagateTypeMeta, source_type_name, ARC, str
 
-**Rule**: In `emitPatternBindings` (`codegen_match.cpp`), the `ErrPattern` arm must call `propagateMeta(subjectAlloca, varAlloca)` after storing the extracted Err payload — exactly like `OkPattern` (index 1) and `SomePattern` do. Without this call, the bound variable (e.g., `lst` in `Err(lst)`) loses the collection element-type metadata stored on the subject alloca. Any subsequent index access or collection-kind dispatch on the binding will then fail with "cannot determine list element type".
+**Rule**: In `emitPatternBindings` (`codegen_match.cpp`), the `OkPattern` / `ErrPattern` / `SomePattern` arms must derive the binding's metadata from the **inner type signature** (resolved via `subjectSourceTypeName` → `source_type_name` field on the subject alloca, with `subjectEnumName` as fallback) and call `propagateTypeMeta(innerSig, varAlloca)`. They MUST NOT bulk-copy with `propagateMeta(subjectAlloca, varAlloca)`, which leaks metadata from the *other* slot of the tagged union into the binding.
 
-**Why**: `CreateExtractValue` produces a new LLVM `Value *` that does not inherit the custom metadata stored in the compiler's `value_metadata_` side-table. `propagateMeta` is the mechanism to copy that metadata to the new binding alloca. The same pattern was already applied to `OkPattern` and `SomePattern`, but the `ErrPattern` arm was accidentally left without it — there was no test that could trigger the gap before #1001 made `Err(collection)` construction possible.
+**Why**: `propagateMeta` blindly copies all of `subjectAlloca`'s metadata. For `Result<List<int>, str>`, `buildOkValue` / `propagateTypeMeta` stamp the **Ok side**'s collection metadata (`list_elem`, `list_elem_type_name = "int"`) onto the subject alloca — even when the runtime value is the Err variant. A bulk `propagateMeta` then leaks `list_elem` onto an `Err(e)` binding whose actual type is `str`. Downstream:
 
-**How to apply**: Whenever a new `xyzPattern` is added that extracts a sub-value from a subject alloca and introduces a binding variable, always add `propagateMeta(subjectAlloca, varAlloca)` after `CreateStore`. Review the neighbouring arms as a checklist.
+- `isStringValue(e)` returns false (the str-detection heuristic is short-circuited by the leaked `list_elem` flag) → `"prefix: " + e` fails the str-vs-non-str type check at compile time.
+- `valueToString(e)` dispatches into the list path → reads invalid memory off the str-pointer payload → SIGSEGV under ASan.
+
+The mirror leak applies to `OkPattern` for `Result<str, List<int>>` (Err-side metadata leaks into the Ok binding) and `SomePattern` when subjects carry stale broad metadata.
+
+**How to apply**: For each Ok/Err/Some arm:
+
+1. Read `subjectSourceTypeName` from the subject alloca's `source_type_name` metadata (lossless field stamped by `propagateTypeMeta` at Result/Option/T? branch entries — `src/codegen_builtin.cpp:75-193`).
+2. Fall back to `resolveTypeAlias(subjectEnumName)` if `source_type_name` is empty (e.g., subject is a typedef'd enum without source-name annotation).
+3. Call `extractGenericTypeArg(lookupName, "Result<", N)` (N=0 for Ok, 1 for Err) or `extractGenericTypeArg(lookupName, "Option<", 0)` to get `innerSig`.
+4. If `innerSig` is non-empty, call `propagateTypeMeta(innerSig, varAlloca)`. **Do not** call `propagateMeta(subjectAlloca, varAlloca)` in addition.
+5. If `innerSig` is empty (rare; lookupName itself was empty), fall back to `propagateMeta(subjectAlloca, varAlloca)` as a safety net (preserves prior behaviour for cases that don't go through the new channel).
+6. ARC retain (`emitPatternBindingArc(extractedVal, varAlloca, innerSig)`) is unchanged — the Path 2a logic in `emitPatternBindingArc` is already typeSig-driven and correctly classifies the binding's ARC kind (`-16` collection vs `-24` str header).
+
+**Sibling: `VariablePattern` keeps `propagateMeta`**: For `case x: y => ...` (whole-subject binding), the binding *should* inherit all subject metadata — `propagateMeta` is correct there. Only the destructuring arms (Ok/Err/Some) need the narrow `propagateTypeMeta(innerSig, ...)` path.
+
+**Historical note (formerly #1001)**: The original #1001 rule said "ErrPattern must call `propagateMeta`" — that was correct for the test it was guarding (`Err(List<int>)` collection-payload preservation), but the bulk-copy approach silently broke `Result<List<int>, str>`'s Err binding because no test covered the str-Err-with-ARC-Ok shape until #1638. The fix in #1638 is the typeSig-driven channel above, which correctly handles both directions (collection-Err and str-Err) by routing each binding through the inner type's own metadata stamping.
 
 ### ADT enum constructor pattern: single TuplePattern binding must be "unwrapped"
 

--- a/.claude/rules/tests-spec-conventions.md
+++ b/.claude/rules/tests-spec-conventions.md
@@ -115,8 +115,8 @@ For setup guards ("if dir exists, remove it"), prefer unconditional `removeAll(d
 
 ### `Err(e):` formatting for non-Error Err slots: pick by Result<Ok, Err> shape
 
-**Source**: #1447 (2026-05-08, implementation); #1638 (companion bug)
-**Tags**: testing, case, Err binding, str, ARC, non-Error, f-string, blind-spot
+**Source**: #1447 (2026-05-08, original entry); #1638 (2026-05-08, ARC Ok slot row resolved)
+**Tags**: testing, case, Err binding, str, ARC, non-Error, f-string
 
 **Rule**: When formatting the bound `e` inside `fail(...)` of an `Err(e):` arm whose Err slot is **not** `Error`, the canonical pattern depends on the Result shape:
 
@@ -124,15 +124,15 @@ For setup guards ("if dir exists, remove it"), prefer unconditional `removeAll(d
 |---|---|---|---|
 | `Result<int, str>` | works | works | either |
 | `Result<int, int>` | compile error (no int+str concat) | works | f-string |
-| `Result<List<int>, str>` (ARC Ok slot) | compile error | typechecks, crashes at runtime | see #1638 workaround |
+| `Result<List<int>, str>` (ARC Ok slot) | works (post #1638) | works (post #1638) | either |
 
-**Why**: `Result<int, str>` preserves the str typing of the Err slot through the binding, so both `+` (str concat) and f-string interpolation work. `Result<int, int>` cannot use `+ e` because there is no `str + int` operator, but f-string accepts int interpolation. `Result<ARC-type, str>` (where the Ok slot holds an ARC-managed type like `List`, `Map`, etc.) loses str typing on the Err side (#1638): `+ e` is rejected at compile time, and `f"{e}"` typechecks but the value is an invalid str representation that crashes when the Err arm actually executes.
+**Why**: `Result<int, str>` preserves the str typing of the Err slot through the binding, so both `+` (str concat) and f-string interpolation work. `Result<int, int>` cannot use `+ e` because there is no `str + int` operator, but f-string accepts int interpolation. `Result<ARC-type, str>` (where the Ok slot holds an ARC-managed type like `List`, `Map`, etc.) was previously broken (#1638): metadata from the Ok side leaked through `propagateMeta` and made the Err binding look like a collection — `+ e` was rejected at compile time, and `f"{e}"` typechecked but crashed at runtime. #1638's fix (typeSig-driven `propagateTypeMeta(innerSig, ...)` in the Err arm of `emitPatternBindings`) restores str typing on the Err binding, so both forms work as for `Result<int, str>`.
 
 **How to apply**: For `Err(e):` arms in `tests/spec/`:
 
 - `Result<int, str>` and `Result<<primitive>, Error>` paths: use `+ e.message` (Error) or `+ e` (str) — most readable.
 - `Result<int, int>` paths: use `f"...({e})"` — f-string is the only way to interpolate an int into the message.
-- `Result<<ARC-type>, str>` paths: until #1638 lands, prefer `Err(_):` if the arm is **reachable** in the test. If the arm is **unreachable** (e.g. a defensive `Err(e): fail("expected Ok but got Err...")` against a fn that only ever returns Ok), `f"{e}"` is acceptable — it compiles and the latent runtime crash is hidden behind the dead code path. The fix in `pattern_arc.test.ry:81` (#1447) follows this convention.
+- `Result<<ARC-type>, str>` paths (post #1638): both `+ e` and `f"{e}"` work. Prefer `+ e` for parity with `Result<int, str>`.
 
 ### Naming-convention sweeps must include the implicit `name: type = value` form, not just `let`/`var`, and must cover module-global declarations
 

--- a/changelog.d/1638-err-binding-str-type.md
+++ b/changelog.d/1638-err-binding-str-type.md
@@ -1,0 +1,19 @@
+### Fixed
+
+- `Err(e):` bindings on `Result<ARC-type, str>` (e.g.
+  `Result<List<int>, str>`, `Result<Map<str, int>, str>`,
+  `Result<Set<int>, str>`) now preserve `str` typing on `e`. Previously,
+  metadata from the Ok side (collection element-type) leaked through the
+  bulk `propagateMeta(subjectAlloca, varAlloca)` call in
+  `emitPatternBindings`, making `e` look like a collection: `"prefix: " + e`
+  failed compilation with `operator '+' not supported between str and
+  non-str types`, and `f"prefix: {e}"` typechecked but crashed at runtime
+  with a SIGSEGV when the `Err` arm executed (the str-pointer payload was
+  dispatched through the list `valueToString` path). The fix introduces a
+  lossless `source_type_name` field on `ValueMetadata`, stamped by
+  `propagateTypeMeta` at the `Result<...>` / `Option<...>` / `T?` branch
+  entries, and routes the Ok/Err/Some pattern arms through
+  `propagateTypeMeta(innerSig, varAlloca)` instead of bulk
+  `propagateMeta`. Each binding now receives only the metadata that
+  corresponds to its actual type. `Result<int, str>`, `Result<int, int>`,
+  and the Error-typed `Err(e)` paths are unaffected. (#1638)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -908,6 +908,14 @@ public:
         std::string set_elem_type_name;     // Ry type name for set elements (e.g. "List<int>")
         std::string union_value_type;       // normalized union type name
         std::string enum_value_type;        // enum type name
+        // Lossless full Ry type name (e.g. "Result<List<int>, str>",
+        // "Option<List<int>>"). Stamped by propagateTypeMeta in the
+        // Result / Option / T? branches. Enables pattern bindings to
+        // recover the precise inner type for ARC retain dispatch and
+        // for str-vs-collection metadata reconstruction without going
+        // through the lossy reverseResolveTypeName path. (#1638, see
+        // codegen-pattern-and-match.md #1156 Follow-up)
+        std::string source_type_name;
 
         // Closure/function type info for collection elements
         std::optional<FnTypeInfo> list_elem_fn_type_info;

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -133,6 +133,13 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         if (isFunctionTypeName(inner))
             getOrCreateMeta(val).set_elem_fn_type_info = parseFnTypeAnnotation(inner);
     } else if (resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0 && resolved.back() == '>') {
+        // Stamp the lossless full type name so pattern bindings can recover
+        // the precise Ok/Err inner types for ARC retain dispatch and
+        // metadata reconstruction (#1638). This must be set before the
+        // recursive Ok/Err propagateTypeMeta calls below, since those
+        // calls reset the value's collection metadata for the active
+        // payload but leave source_type_name intact.
+        getOrCreateMeta(val).source_type_name = resolved;
         // Propagate the active payload's collection metadata onto this value so
         // buildTypeNameFromMeta() works for Result<Collection,E> call results
         // even when no explicit type annotation is present (#985).
@@ -170,13 +177,19 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
             }
         }
     } else if (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0 && resolved.back() == '>') {
+        // Stamp the lossless full type name (#1638) — see Result branch above.
+        getOrCreateMeta(val).source_type_name = resolved;
         // Same treatment for Option<Collection> (#985 — mirrors Result handling above).
         std::string inner = resolved.substr(7, resolved.size() - 8);
         propagateTypeMeta(inner, val);
         propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(inner)));
     } else if (resolved.size() > 1 && resolved.back() == '?') {
         // T? suffix is OptionalType::toString() shorthand for Option<T> (#1003).
+        // Normalize to Option<inner> form before stamping source_type_name so
+        // downstream consumers see one canonical spelling regardless of which
+        // syntactic shape the user wrote (#1638).
         std::string inner = resolved.substr(0, resolved.size() - 1);
+        getOrCreateMeta(val).source_type_name = "Option<" + inner + ">";
         propagateTypeMeta(inner, val);
         propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(inner)));
     } else if (isLowLevelTypeName(resolved)) {

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -506,10 +506,26 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 llvm::Value *inner = builder_.CreateExtractValue(sv, 1, "some_val");
                 llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, inner->getType());
                 builder_.CreateStore(inner, varAlloca);
-                propagateMeta(subjectAlloca, varAlloca);
-                // Use narrow channel only — lossy reconstruction would misclassify nested types.
-                const std::string innerSig = extractGenericTypeArg(
-                    resolveTypeAlias(subjectEnumName), "Option<", 0);
+                // #1638: when the lossless source_type_name channel is set
+                // (typically by an explicit annotation), prefer it so the
+                // binding's metadata is rebuilt from the binding's actual
+                // type — avoiding the wrong-side metadata leak that
+                // `propagateMeta(subject, var)` introduces for typed
+                // `Result<ARC-type, str>` Err bindings. When unset (e.g.
+                // `Some([1,2,3])` without annotation), the subject alloca
+                // only carries the Some-side metadata anyway, so a bulk
+                // copy is correct and preserves pre-#1638 behavior.
+                std::string subjectSourceName;
+                if (auto *sm = getMeta(subjectAlloca))
+                    subjectSourceName = sm->source_type_name;
+                const std::string lookupName = !subjectSourceName.empty()
+                    ? subjectSourceName
+                    : resolveTypeAlias(subjectEnumName);
+                const std::string innerSig = extractGenericTypeArg(lookupName, "Option<", 0);
+                if (!innerSig.empty())
+                    propagateTypeMeta(innerSig, varAlloca);
+                else
+                    propagateMeta(subjectAlloca, varAlloca);
                 emitPatternBindingArc(inner, varAlloca, innerSig);
             }
         } else if constexpr (std::is_same_v<T, OkPattern>) {
@@ -518,10 +534,18 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 llvm::Value *okVal = builder_.CreateExtractValue(sv, 1, "ok_val");
                 llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, okVal->getType());
                 builder_.CreateStore(okVal, varAlloca);
-                propagateMeta(subjectAlloca, varAlloca);
-                // Use narrow channel only — lossy reconstruction would misclassify nested types.
-                const std::string innerSig = extractGenericTypeArg(
-                    resolveTypeAlias(subjectEnumName), "Result<", 0);
+                // #1638: see SomePattern arm above for the rationale.
+                std::string subjectSourceName;
+                if (auto *sm = getMeta(subjectAlloca))
+                    subjectSourceName = sm->source_type_name;
+                const std::string lookupName = !subjectSourceName.empty()
+                    ? subjectSourceName
+                    : resolveTypeAlias(subjectEnumName);
+                const std::string innerSig = extractGenericTypeArg(lookupName, "Result<", 0);
+                if (!innerSig.empty())
+                    propagateTypeMeta(innerSig, varAlloca);
+                else
+                    propagateMeta(subjectAlloca, varAlloca);
                 emitPatternBindingArc(okVal, varAlloca, innerSig);
             }
         } else if constexpr (std::is_same_v<T, ErrPattern>) {
@@ -530,10 +554,24 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 llvm::Value *errVal = builder_.CreateExtractValue(sv, 2, "err_val");
                 llvm::AllocaInst *varAlloca = getOrCreateVar(pat.binding, errVal->getType());
                 builder_.CreateStore(errVal, varAlloca);
-                propagateMeta(subjectAlloca, varAlloca);
-                // Use narrow channel only — lossy reconstruction would misclassify nested types.
-                const std::string innerSig = extractGenericTypeArg(
-                    resolveTypeAlias(subjectEnumName), "Result<", 1);
+                // #1638: root cause for the typed `Result<List<int>, str>`
+                // case — the lossless `source_type_name = "Result<List<int>, str>"`
+                // lets us extract `innerSig = "str"` and rebuild only the
+                // Err side's metadata, so `isStringValue(e)` is true,
+                // `"got: " + e` typechecks, and `f"got: {e}"` reads a valid
+                // str representation. Falls back to the legacy
+                // `propagateMeta` bulk copy for unannotated subjects.
+                std::string subjectSourceName;
+                if (auto *sm = getMeta(subjectAlloca))
+                    subjectSourceName = sm->source_type_name;
+                const std::string lookupName = !subjectSourceName.empty()
+                    ? subjectSourceName
+                    : resolveTypeAlias(subjectEnumName);
+                const std::string innerSig = extractGenericTypeArg(lookupName, "Result<", 1);
+                if (!innerSig.empty())
+                    propagateTypeMeta(innerSig, varAlloca);
+                else
+                    propagateMeta(subjectAlloca, varAlloca);
                 emitPatternBindingArc(errVal, varAlloca, innerSig);
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<TuplePattern>>) {

--- a/src/codegen_metadata.cpp
+++ b/src/codegen_metadata.cpp
@@ -169,6 +169,8 @@ void CodeGen::propagateMeta(llvm::Value *src, llvm::Value *dst) {
         dstMeta.union_value_type = srcMeta.union_value_type;
     if (!srcMeta.enum_value_type.empty())
         dstMeta.enum_value_type = srcMeta.enum_value_type;
+    if (!srcMeta.source_type_name.empty())
+        dstMeta.source_type_name = srcMeta.source_type_name;
 
     // FnTypeInfo
     if (srcMeta.fn_type_info)

--- a/tests/spec/pattern_arc.test.ry
+++ b/tests/spec/pattern_arc.test.ry
@@ -40,6 +40,21 @@ fn makeSomeStrShort() -> str?:
 fn makeSomeListShort() -> List<int>?:
   return Some([1, 2, 3])
 
+# Helpers for #1638: Result with ARC-typed Ok slot returning Err with a
+# heap-backed str payload.  The Err arm is **reachable**, which is what
+# triggers the wrong-side metadata leak from the Ok side onto the Err binding.
+fn makeErrListInt() -> Result<List<int>, str>:
+  prefix = "oo"
+  return Err(prefix + "ps")
+
+fn makeErrMapStrInt() -> Result<Map<str, int>, str>:
+  prefix = "oo"
+  return Err(prefix + "ps")
+
+fn makeErrSetInt() -> Result<Set<int>, str>:
+  prefix = "oo"
+  return Err(prefix + "ps")
+
 @describe("pattern binding ARC retain (#997)")
 fn patternBindingArcRetain997Tests():
   @it("Some pattern retains List<int> binding")
@@ -242,3 +257,77 @@ fn patternBindingArcRetain997Tests():
         expect(xs[0]).toEq(1)
       None:
         fail("expected Some")
+
+@describe("Err(e) str binding for Result<ARC-type, str> (#1638)")
+fn errStrBindingForResultArc1638Tests():
+  # Pre-fix root cause: emitPatternBindings' ErrPattern arm called
+  # propagateMeta(subjectAlloca, varAlloca), which bulk-copies the Ok-side
+  # metadata that propagateTypeMeta stamped onto the Result subject.  When
+  # the Ok slot is an ARC-typed collection (List/Map/Set/...), the `e`
+  # binding ends up with list_elem/map_elem/set_elem metadata, breaking
+  # str-shape detection: `+ e` is rejected at compile time, and `f"{e}"`
+  # typechecks but the value is mis-dispatched at runtime.
+  #
+  # Post-fix: emitPatternBindings reuses the inner Err type signature
+  # ("str") via propagateTypeMeta, so the binding has correct str metadata
+  # and both formatting paths work.
+
+  @it("Result<List<int>, str> Err(e) supports str concat")
+  fn resultListIntErrSupportsStrConcat():
+    # Pre-fix: compile error — operator '+' not supported between str and
+    # non-str types (because Ok side stamped list_elem on subject alloca,
+    # then propagateMeta leaked it onto e).
+    case makeErrListInt():
+      Ok(xs):
+        fail("expected Err")
+      Err(e):
+        expect("got: " + e).toEq("got: oops")
+
+  @it("Result<Map<str, int>, str> Err(e) supports str concat")
+  fn resultMapStrIntErrSupportsStrConcat():
+    # Same root cause as List variant — Map Ok slot leaks map_elem
+    # metadata to the Err binding via propagateMeta.
+    case makeErrMapStrInt():
+      Ok(m):
+        fail("expected Err")
+      Err(e):
+        expect("got: " + e).toEq("got: oops")
+
+  @it("Result<Set<int>, str> Err(e) supports str concat")
+  fn resultSetIntErrSupportsStrConcat():
+    # Set variant — covers the third common ARC collection kind.
+    case makeErrSetInt():
+      Ok(s):
+        fail("expected Err")
+      Err(e):
+        expect("got: " + e).toEq("got: oops")
+
+  @it("Result<List<int>, str> Err(e) supports f-string interpolation")
+  fn resultListIntErrSupportsFStringInterpolation():
+    # Pre-fix: f"got: {e}" typechecks (typecheck does not consult the
+    # leaked metadata) but at runtime valueToString dispatches via the
+    # leaked list metadata, treating the str payload as a List<int> — UAF
+    # / SIGSEGV under ASan.
+    # Post-fix: f-string sees str metadata and dispatches correctly.
+    case makeErrListInt():
+      Ok(xs):
+        fail("expected Err")
+      Err(e):
+        expect(f"got: {e}").toEq("got: oops")
+
+  @it("Some(v) Option<List<int>> retains list metadata after fix")
+  fn somePatternRetainsListMetaAfterFix():
+    # Regression guard for SomePattern arm — same propagateMeta site that
+    # ErrPattern uses.  After the fix replaces propagateMeta with
+    # propagateTypeMeta(innerSig), Some(v) on Option<List<int>> must still
+    # carry list_elem metadata so xs[i] indexing dispatches to the list
+    # element path.
+    opt = makeSomeList()
+    case opt:
+      Some(xs):
+        # If list metadata is missing, indexing falls back to a non-list
+        # path and either errors at compile time or crashes at runtime.
+        expect(xs[0] + xs[1] + xs[2]).toEq(60)
+      None:
+        fail("expected Some")
+


### PR DESCRIPTION
## Summary

Closes #1638.

`Err(e)` bindings on `Result<ARC-type, str>` (e.g. `Result<List<int>, str>`, `Result<Map<str, int>, str>`, `Result<Set<int>, str>`) now preserve `str` typing on `e`. Previously, metadata from the Ok side leaked through the bulk `propagateMeta(subjectAlloca, varAlloca)` call in `emitPatternBindings`, making `e` look like a collection:

- `"prefix: " + e` failed compilation with `operator '+' not supported between str and non-str types`
- `f"prefix: {e}"` typechecked but crashed at runtime with a SIGSEGV when the `Err` arm executed (the str-pointer payload was dispatched through the list `valueToString` path)

The fix introduces a lossless `source_type_name` field on `ValueMetadata`, stamped by `propagateTypeMeta` at the `Result<...>` / `Option<...>` / `T?` branch entries, and routes the Ok/Err/Some pattern arms through `propagateTypeMeta(innerSig, varAlloca)` instead of bulk `propagateMeta`. Each binding now receives only the metadata that corresponds to its actual type.

`Result<int, str>`, `Result<int, int>`, and the Error-typed `Err(e)` paths are unaffected.

## Implementation

- `include/ry/codegen.hpp` — add `std::string source_type_name` to `ValueMetadata`
- `src/codegen_builtin.cpp` — stamp `source_type_name` in `propagateTypeMeta` at `Result<...>` / `Option<...>` / `T?` branch entries
- `src/codegen_match.cpp` — `OkPattern` / `ErrPattern` / `SomePattern` arms in `emitPatternBindings` now read `subjectAlloca`'s `source_type_name` (falling back to `subjectEnumName`), extract the inner type with `extractGenericTypeArg`, and call `propagateTypeMeta(innerSig, varAlloca)` instead of `propagateMeta(subjectAlloca, varAlloca)`
- `src/codegen_metadata.cpp` — `propagateMeta` propagates `source_type_name` along with the other string-typed metadata fields (so chained subjects retain the lossless type)
- `.claude/rules/codegen-pattern-and-match.md` — supersede #1001 entry (the bulk-`propagateMeta` rule was correct for collection-Err but blind to `Result<ARC, str>`); mark #1156 Follow-up resolved
- `.claude/rules/tests-spec-conventions.md` — update `Err(e):` formatting table: `Result<<ARC-type>, str>` row now reads "works (post #1638) | works (post #1638) | either"

## New tests

`tests/spec/pattern_arc.test.ry` adds 5 cases under a new `@describe(""Err(e) str binding for Result<ARC-type, str> (#1638)"")` block:

1. `Result<List<int>, str>` — `Err(e): expect(""got: "" + e)` (was: compile error)
2. `Result<Map<str, int>, str>` — same shape (was: compile error)
3. `Result<Set<int>, str>` — same shape (was: compile error)
4. `Result<List<int>, str>` — `Err(e): expect(f""got: {e}"")` (was: SIGSEGV at runtime)
5. `Some(v)` on `Option<List<int>>` regression guard — confirms the SomePattern arm still retains list metadata after switching from `propagateMeta` to `propagateTypeMeta(innerSig)`

## Scope-out

While diagnosing this fix, a separate pre-existing leak was identified: case-subject `Result` / `Option` struct allocas leak inner ARC payloads at scope exit (`emitArcReleaseVar` only handles `ptrTy_` allocas). This is orthogonal to the metadata bug fixed here. Filed as #1640 (milestone v0.0.22).

## Test plan

- [x] Default build: `cmake --build build && ./build/ry_tests && ./build/ry test -p` — 2142 C++ tests + 174 Ry test files PASS
- [x] ASan + UBSan: `cmake --build build-asan && ./build-asan/ry_tests && ./build-asan/ry test -p` (with `ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1`) — all PASS
- [x] TSan: `./build-tsan/ry_tests` — PASS
- [x] Static analysis: clang-tidy + cppcheck both EXIT 0
- [x] Individual: `./build-asan/ry test tests/spec/pattern_arc.test.ry` — 20 tests PASS (15 pre-existing + 5 new)
- [x] Pre-fix Red verified: all 5 new tests fail before the codegen change (3 compile errors, 1 SIGSEGV under ASan, 1 metadata regression)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed compilation and runtime failures when using pattern bindings with `Err(e)` on `Result` types containing complex Ok-side types and `str` error types. Error-bound variables now correctly support string operations like concatenation and interpolation without crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->