### PR TITLE
test(spec): exercise UFCS dispatch in shouldSupportMethodStyleCall (#1604)

### DIFF
--- a/tests/spec/functions.test.ry
+++ b/tests/spec/functions.test.ry
@@ -99,7 +99,7 @@ fn higherOrderFunctionTests():
 fn ufcsTests():
   @it("should support method-style call")
   fn shouldSupportMethodStyleCall():
-    expect(double(5)).toEq(10)
+    expect(5.double()).toEq(10)
   @it("should support UFCS chaining")
   fn shouldSupportUfcsChaining():
     expect(5.double().addOne()).toEq(11)


### PR DESCRIPTION
## Summary

- The `should support method-style call` test under `@describe("UFCS")` in `tests/spec/functions.test.ry` was calling the function as `double(5)`, which duplicated ordinary function-call coverage and would not catch a regression in single-step UFCS dispatch.
- Switch the call site to `5.double()` so the assertion actually exercises the UFCS dispatch path it claims to test.
- Complements the existing chained UFCS case `5.double().addOne()` on the next line — the two now cover single-step and chained UFCS independently.

Closes #1604.

## Test plan

- [x] `cmake --build build`
- [x] `./build/ry test tests/spec/functions.test.ry` — 28/28 pass (`should support method-style call` and `should support UFCS chaining` both green)
- [x] `./build/ry test -p` — 176 files, 0 failures
- [x] `./build/ry_tests` — 2142 PASSED
- [x] ASan + UBSan: `./build-asan/ry_tests` (2142 PASSED), `./build-asan/ry test -p` (176 files, 0 failures)
- [x] TSan (required): `./build-tsan/ry_tests` (2142 PASSED)
- [x] clang-tidy / cppcheck — clean (no C++ source changes in this PR)

## Pre-commit checklist skips

- Skipped §1 — no user-visible change (test description hardening only)
- Skipped §2 — no user-visible change; no CHANGELOG fragment needed
- Skipped §3.6 — no parser/lexer/json/utf8/string change
- Skipped §3.6.5 — no tree-sitter grammar change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases to reflect current function calling conventions and syntax support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->