### PR TITLE
test(spec): strengthen ARC retain assertions in list_concat_arc (#1605)

### DIFF
--- a/tests/spec/list_concat_arc.test.ry
+++ b/tests/spec/list_concat_arc.test.ry
@@ -31,15 +31,21 @@ fn listListArcRetain1236Tests():
     a = [[99]]
     b = [[88]]
     expect(ys).toHaveLen(3)
+    expect(ys[0][0]).toEq(1)
+    expect(ys[1][1]).toEq(4)
+    expect(ys[2][0]).toEq(5)
 
   @it("List<Map<str, int>> concat retains map values after source drop")
   fn listMapStrIntConcatRetainsMapValuesAfterSourceDrop():
     a: List<Map<str, int>> = [{"a": 1}, {"b": 2}]
     b: List<Map<str, int>> = [{"c": 3}]
-    ys = a + b
+    ys: List<Map<str, int>> = a + b
     a = [{"z": 999}]
     b = [{"y": 888}]
     expect(len(ys)).toEq(3)
+    expect(ys[0]["a"]).toEq(1)
+    expect(ys[1]["b"]).toEq(2)
+    expect(ys[2]["c"]).toEq(3)
 
   @it("empty + non-empty concat is safe in both directions")
   fn emptyNonEmptyConcatIsSafeInBothDirections():


### PR DESCRIPTION
## Summary

- Add nested dereference assertions to the two ARC retain-after-source-drop tests in `tests/spec/list_concat_arc.test.ry` so they actually exercise the inner-payload retain path. The previous `toHaveLen` / `len(ys)` assertions could pass even if `+` forgot to retain inner `List<int>` / `Map<str,int>` payloads — values were never dereferenced post-rebind.
- The `List<Map<str, int>>` case needed an explicit `ys: List<Map<str, int>>` LHS annotation as a workaround for #1648 (`+` loses Map element metadata when inferring without annotation).

## Test plan

- [x] `cmake --build build && ./build/ry_tests && ./build/ry test -p` — 2142 C++ + 176 Ry test files all pass
- [x] ASan + UBSan: 2142 C++ + 176 Ry test files pass (no UAF, no UB)
- [x] TSan: 2142 C++ tests pass (Ry self-test is warn-only per `/tsan-known-issues`)
- Skipped §3.6 libFuzzer — no parser/lexer/json/utf8/string change
- Skipped §3.6.5 tree-sitter — no grammar change
- Skipped §3.5.5 Static Analysis — `tests/spec/*.ry` only, no C++ change
- Skipped §1 doc / §2 CHANGELOG — internal test strengthening, no user-visible behavior change

Closes #1605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for list concatenation operations with improved value retention verification across multiple data structure types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->