### PR TITLE
test(grammar): Phase 1 corpus smoke-check for tree-sitter grammar (#1617)

### DIFF
--- a/.claude/skills/commands-environment-gotchas/SKILL.md
+++ b/.claude/skills/commands-environment-gotchas/SKILL.md
@@ -169,6 +169,36 @@ CI (Linux) では `/usr/local/llvm/bin/clang` が `cc` / `c++` symlink を介し
 
 ---
 
+### `printf "%s" "$big_var" | grep -q ...` silently misses matches under `set -o pipefail`
+
+**Source**: #1617 PR review (CodeRabbit, 2026-05-08)
+**Tags**: bash, pipefail, sigpipe, grep, large-output, masked-failure
+
+**Wrong**:
+
+```bash
+set -euo pipefail
+output="$(some_command)"           # output > pipe buffer (~64 KiB)
+if printf '%s' "$output" | grep -qE 'PATTERN'; then
+  has_match=1
+fi
+# has_match stays 0 even when $output clearly contains PATTERN
+```
+
+**Correct** (drop the upstream writer): use a here-string, or pure-bash `[[ =~ ]]`:
+
+```bash
+if grep -qE 'PATTERN' <<< "$output"; then has_match=1; fi
+# or
+if [[ "$output" =~ PATTERN ]]; then has_match=1; fi
+```
+
+**Why**: `grep -q` exits 0 on the first match and closes its end of the pipe. The upstream `printf` is still writing more bytes; the kernel delivers SIGPIPE → `printf` exits 141. Under `set -o pipefail` the pipeline's exit status is the **rightmost non-zero** exit code → the pipeline reports failure → the `if` branch never fires.
+
+The bug only triggers when `$output` exceeds the pipe buffer (≈64 KiB on Linux/macOS); small outputs short-circuit before SIGPIPE can be delivered, which is why this kind of detection logic looks correct in tests but masks failures on real-world large inputs. In #1617 it caused three `tests/spec/*.test.ry` files containing `ERROR` nodes to be silently classified as PASS by `editor/tree-sitter/check.sh`'s self-verification (`pass=138`) until the pattern was switched to a here-string. Here-strings and `[[ =~ ]]` have no upstream writer, so SIGPIPE cannot occur.
+
+---
+
 ### Subprocess GoogleTest: rebuild the `ry` executable, not just `ry_tests`
 
 **Source**: #1424 implementation (2026-05-05)

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -287,11 +287,13 @@ UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 ```bash
 ./editor/tree-sitter/build.sh
 ./editor/tree-sitter/install.sh --no-build
+./editor/tree-sitter/check.sh --no-build
 ```
 
 - `build.sh` 内部で `tree-sitter generate`（`grammar.js` から `parser.c` を再生成）と `tree-sitter build`（`parser.c` + `scanner.c` から `ry.so` をリンク）が両方成功し、`ry.so` が生成されることを確認する。`tree-sitter generate` が失敗すればグラマー側の構文ミスを意味する。
 - `install.sh --no-build` が `ry.so` と `queries/*.scm` を Neovim parser ディレクトリへコピーすることを確認する。
-- 現状 in-tree グラマーは Ry の全構文をまだカバーしていないため `tree-sitter parse` を実テストファイルに当てると ERROR ノードを含むことがある。これはグラマーの未完成部分であり、§3.6.5 のチェック対象ではない（コーパスベースの回帰テストは [#1633](https://github.com/t0k0sh1/ry/issues/1633) で追跡）。Neovim 等で `.ry` ファイルを開き、構文ハイライトに重大な regression が起きていないかを目視確認することは推奨。
+- `check.sh --no-build` が `tests/spec/**/*.test.ry` 全件を `tree-sitter parse` に通し、`expected-fail.txt` 外の file で ERROR/MISSING が出ていないことを確認する（**exit 0 が必須**）。`expected-fail.txt` に列挙された既知の grammar gap は SKIP として silent に扱われ、grammar の改修で parse できるようになると `WARN: ... now passes` が出るので、そのファイルを `expected-fail.txt` から削除する。
+- 現状 in-tree グラマーは Ry の全構文をまだカバーしていないため `tree-sitter parse` を実テストファイルに当てると ERROR ノードを含むことがある。これは `expected-fail.txt` で許容している既知の gap であり、`check.sh` の対象外（`expected-fail.txt` 外で出た場合のみ regression として扱う）。Phase 2 の hand-curated `tree-sitter test` corpus + S-expression assertion は [#1633](https://github.com/t0k0sh1/ry/issues/1633) で追跡。Neovim 等で `.ry` ファイルを開き、構文ハイライトに重大な regression が起きていないかを目視確認することは推奨。
 
 ## 3.7. Background Task Residual Check
 

--- a/changelog.d/1617-tree-sitter-check-sh.md
+++ b/changelog.d/1617-tree-sitter-check-sh.md
@@ -8,7 +8,7 @@
   single place where tolerated divergence is recorded. Files that move
   out of the gap list automatically surface a `WARN: ... now passes`
   on the next run so the entry can be retired in the same PR. The
-  initial `expected-fail.txt` clusters the 38 currently failing fixtures
+  initial `expected-fail.txt` clusters the 41 currently failing fixtures
   into six named buckets (tuple member access, generic syntax variants,
   lambda-block bodies, numeric literal forms, async / decorator /
   operator-overload declarations, and other surface gaps).

--- a/changelog.d/1617-tree-sitter-check-sh.md
+++ b/changelog.d/1617-tree-sitter-check-sh.md
@@ -1,0 +1,18 @@
+### Added
+
+- Added `editor/tree-sitter/check.sh` and `editor/tree-sitter/expected-fail.txt`
+  as a Phase 1 corpus smoke-check for the in-tree tree-sitter grammar.
+  `check.sh` runs `tree-sitter parse` against every
+  `tests/spec/**/*.test.ry` and treats any `ERROR` / `MISSING` node as
+  a regression unless the file is listed in `expected-fail.txt` — the
+  single place where tolerated divergence is recorded. Files that move
+  out of the gap list automatically surface a `WARN: ... now passes`
+  on the next run so the entry can be retired in the same PR. The
+  initial `expected-fail.txt` clusters the 38 currently failing fixtures
+  into six named buckets (tuple member access, generic syntax variants,
+  lambda-block bodies, numeric literal forms, async / decorator /
+  operator-overload declarations, and other surface gaps).
+  `pre-commit-checklist` §3.6.5 now invokes `./check.sh --no-build`
+  alongside the existing `build.sh` + `install.sh --no-build` gate.
+  Phase 2 (hand-curated `tree-sitter test` corpus with S-expression
+  assertions) remains tracked in #1633. (#1617)

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -23,6 +23,8 @@ editor/tree-sitter/
 ├── tree-sitter.json     # tree-sitter CLI configuration
 ├── build.sh             # tree-sitter generate + build -> ry.so
 ├── install.sh           # copy ry.so + queries to Neovim parser dirs
+├── check.sh             # smoke-check ry.so against tests/spec/**/*.test.ry
+├── expected-fail.txt    # files the grammar does not yet parse (allowlist)
 └── README.md            # this file
 ```
 
@@ -86,6 +88,31 @@ installed. Enable tree-sitter-driven indentation per `.ry` buffer with:
 vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
 ```
 
+## Smoke-check (corpus regression test)
+
+```bash
+./check.sh                # auto-builds ry.so if missing, then checks 176 spec files
+./check.sh --no-build     # use the existing ry.so as-is
+./check.sh --verbose      # also list expected-fail entries that still fail (SKIP)
+```
+
+`check.sh` runs `tree-sitter parse` against every `tests/spec/**/*.test.ry`
+and reports any file that surfaces an `ERROR` or `MISSING` node. Files
+listed in `expected-fail.txt` are tolerated — they document grammar gaps
+that have not yet been closed and are organised into named buckets
+(tuple member access, generic bounds, lambda-block bodies, numeric
+literal forms, …). Anything outside that list is treated as a grammar
+regression: the script prints `FAIL: <path>` and exits non-zero.
+
+If a previously failing file now parses cleanly (e.g. after a grammar
+improvement), `check.sh` prints `WARN: <path> now passes; remove from
+expected-fail.txt` but still exits 0 — the developer is expected to drop
+the entry in the same PR that closes the gap.
+
+`expected-fail.txt` is the **single** place where tolerated divergence is
+recorded; `check.sh` has no hard-coded skip list. Inline `# reason`
+comments after each path are stripped at read time and are advisory only.
+
 ## Contributor workflow
 
 Whenever a PR touches one of these paths (paths are relative to the
@@ -113,9 +140,11 @@ eyeball the syntax highlighting and confirm no regressions.
 
 > Running `tree-sitter parse <file>.ry` against existing
 > `tests/spec/*.test.ry` will surface ERROR nodes today: the in-tree
-> grammar does not yet cover the full Ry surface. That's a known gap
-> and not what this loop is checking — corpus-based regression testing
-> is tracked in [#1633](https://github.com/t0k0sh1/ry/issues/1633).
+> grammar does not yet cover the full Ry surface. The known-gap files
+> are listed in `expected-fail.txt` and the Phase 1 corpus smoke-check
+> (`./check.sh`, see above) treats them as silent SKIPs. Phase 2 — the
+> hand-curated `tree-sitter test` corpus with S-expression assertions
+> — is tracked separately in [#1633](https://github.com/t0k0sh1/ry/issues/1633).
 
 The pre-commit version of this loop, with the same trigger paths, lives
 in [`/pre-commit-checklist`](../../.claude/skills/pre-commit-checklist/SKILL.md)

--- a/editor/tree-sitter/check.sh
+++ b/editor/tree-sitter/check.sh
@@ -52,6 +52,11 @@ if [[ ! -d "$SPEC_DIR" ]]; then
   exit 1
 fi
 
+if ! command -v tree-sitter >/dev/null 2>&1; then
+  echo "ERROR: tree-sitter CLI not found in PATH" >&2
+  exit 1
+fi
+
 # expected-fail.txt を pipe-delimited 文字列に正規化する (bash 3.2 互換のため
 # associative array を使わない)。tests/spec/ の path は '|' を含まないので衝突しない。
 EXPECTED_FAIL_STR="|"
@@ -85,12 +90,23 @@ total_pass=0
 total_skip=0
 
 for f in "${test_files[@]}"; do
-  rel="${f#$REPO_ROOT/}"
+  rel="${f#"$REPO_ROOT"/}"
 
-  output="$(tree-sitter parse "$f" 2>&1 || true)"
+  parse_rc=0
+  output="$(tree-sitter parse "$f" 2>&1)" || parse_rc=$?
+  # `grep -q` exits as soon as it matches and closes the pipe, which gives
+  # the upstream `printf` a SIGPIPE (exit 141). Under `set -o pipefail` that
+  # makes the whole pipeline fail and the `if` branch never fires — even for
+  # huge outputs that obviously contain ERROR. Use a here-string instead so
+  # there is no upstream writer to kill.
   has_error=0
-  if printf '%s' "$output" | grep -qE 'ERROR|MISSING'; then
+  if grep -qE 'ERROR|MISSING' <<< "$output"; then
     has_error=1
+  fi
+  if (( parse_rc != 0 && has_error == 0 )); then
+    echo "ERROR: tree-sitter parse failed unexpectedly for $rel (exit $parse_rc)" >&2
+    printf '%s\n' "$output" >&2
+    exit 1
   fi
 
   in_xfail=0

--- a/editor/tree-sitter/check.sh
+++ b/editor/tree-sitter/check.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+#
+# tests/spec/**/*.test.ry を tree-sitter ry.so に通して grammar の regression を検出する。
+# expected-fail.txt に列挙されているファイルは grammar 未対応として除外する。
+#
+#   - 非 expected-fail で ERROR/MISSING ノードが出る → FAIL: <path> 表示 + exit 1
+#   - expected-fail なのに parse 通る → WARN: <path> 表示 (exit は 0、エントリ削除を促す)
+#
+# Usage:
+#   ./check.sh             # ry.so が無ければ自動で build.sh を呼ぶ
+#   ./check.sh --no-build  # ビルドをスキップして既存の ry.so で実行
+#   ./check.sh --verbose   # 期待通り fail している (SKIP) ファイルも表示する
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+REPO_ROOT="$(cd ../.. && pwd)"
+SPEC_DIR="$REPO_ROOT/tests/spec"
+EXPECTED_FAIL="$SCRIPT_DIR/expected-fail.txt"
+
+DO_BUILD=1
+VERBOSE=0
+for arg in "$@"; do
+  case "$arg" in
+    --no-build)   DO_BUILD=0 ;;
+    -v|--verbose) VERBOSE=1 ;;
+    -h|--help)
+      sed -n '3,12p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown option: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$DO_BUILD" -eq 1 && ! -f ry.so ]]; then
+  echo "==> ry.so not found; building via ./build.sh"
+  ./build.sh
+fi
+
+if [[ ! -f ry.so ]]; then
+  echo "ERROR: ry.so not found. Run ./build.sh first or omit --no-build." >&2
+  exit 1
+fi
+
+if [[ ! -d "$SPEC_DIR" ]]; then
+  echo "ERROR: $SPEC_DIR not found" >&2
+  exit 1
+fi
+
+# expected-fail.txt を pipe-delimited 文字列に正規化する (bash 3.2 互換のため
+# associative array を使わない)。tests/spec/ の path は '|' を含まないので衝突しない。
+EXPECTED_FAIL_STR="|"
+if [[ -f "$EXPECTED_FAIL" ]]; then
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ "$line" =~ ^[[:space:]]*(#|$) ]] && continue
+    raw="${line%%#*}"
+    # awk で先頭/末尾の whitespace を除去 (bash 3.2 互換)
+    path="$(printf '%s' "$raw" | awk '{$1=$1; print}')"
+    [[ -z "$path" ]] && continue
+    EXPECTED_FAIL_STR="${EXPECTED_FAIL_STR}${path}|"
+  done < "$EXPECTED_FAIL"
+fi
+
+test_files=()
+while IFS= read -r f; do
+  [[ -z "$f" ]] && continue
+  test_files+=("$f")
+done < <(find "$SPEC_DIR" -type f -name '*.test.ry' | sort)
+
+if (( ${#test_files[@]} == 0 )); then
+  echo "ERROR: no *.test.ry files found under $SPEC_DIR" >&2
+  exit 1
+fi
+
+echo "==> checking ${#test_files[@]} files"
+
+fail_paths=()
+warn_paths=()
+total_pass=0
+total_skip=0
+
+for f in "${test_files[@]}"; do
+  rel="${f#$REPO_ROOT/}"
+
+  output="$(tree-sitter parse "$f" 2>&1 || true)"
+  has_error=0
+  if printf '%s' "$output" | grep -qE 'ERROR|MISSING'; then
+    has_error=1
+  fi
+
+  in_xfail=0
+  [[ "$EXPECTED_FAIL_STR" == *"|$rel|"* ]] && in_xfail=1
+
+  if (( in_xfail == 1 && has_error == 1 )); then
+    total_skip=$((total_skip + 1))
+    [[ "$VERBOSE" -eq 1 ]] && echo "SKIP: $rel"
+  elif (( in_xfail == 1 && has_error == 0 )); then
+    warn_paths+=("$rel")
+  elif (( in_xfail == 0 && has_error == 1 )); then
+    fail_paths+=("$rel")
+  else
+    total_pass=$((total_pass + 1))
+  fi
+done
+
+echo "==> result: pass=$total_pass skip=$total_skip warn=${#warn_paths[@]} fail=${#fail_paths[@]}"
+
+if (( ${#warn_paths[@]} > 0 )); then
+  echo "WARN: the following files are in expected-fail.txt but now parse cleanly."
+  echo "      Remove them from expected-fail.txt:"
+  for p in "${warn_paths[@]}"; do
+    echo "  - $p"
+  done
+fi
+
+if (( ${#fail_paths[@]} > 0 )); then
+  echo "FAIL: tree-sitter grammar regression detected for files NOT in expected-fail.txt:" >&2
+  for p in "${fail_paths[@]}"; do
+    echo "  - $p" >&2
+  done
+  echo "" >&2
+  echo "If these failures are intentional grammar gaps, add the paths to:" >&2
+  echo "  $EXPECTED_FAIL" >&2
+  echo "Otherwise fix grammar.js / src/scanner.c and rebuild via ./build.sh." >&2
+  exit 1
+fi
+
+echo "==> done"

--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -1,0 +1,68 @@
+# tests/spec/**/*.test.ry の中で tree-sitter grammar (editor/tree-sitter/grammar.js)
+# がまだ parse できないファイルを列挙する。check.sh はこのリストにある file だけ
+# ERROR/MISSING ノードを許容し、リスト外は regression として失敗させる。
+#
+# Phase 1 (#1617) は既存 corpus を smoke fixture として使う最小実装。
+# Phase 2 — `tree-sitter test` の hand-curated corpus + S-expression assertion ベースは
+# 別 issue (#1633) で追跡する。
+#
+# === Format ===
+#   - 1 行 1 path (repo root 相対)。空行および `#` 始まりの行は無視される。
+#   - 行末の `# ...` はインラインコメント (任意、check.sh は剥がしてから使う)。
+#   - 既知の grammar gap は `# === ... ===` の section header でグルーピングする。
+#
+# === Known unsupported patterns (no test coverage today) ===
+#   - Nested f-strings: e.g. `f"a={f"b={42}"}"`。tests/spec/ には該当する spec が
+#     存在しないため file path 登録は無し。spec が追加されたら追記する。
+
+# === Tuple member access (`.0`, `.1`, ..., `.N`) ===
+tests/spec/combinatorial/collection_element_tuple_access.test.ry
+tests/spec/combinatorial/collection_element_tuple_iterate.test.ry
+tests/spec/combinatorial/fn_argument.test.ry
+tests/spec/combinatorial/fn_return.test.ry
+tests/spec/combinatorial/match_types.test.ry
+tests/spec/combinatorial/nested_types.test.ry
+tests/spec/combinatorial/syntax_combinations.test.ry
+tests/spec/generic_infer_container.test.ry
+tests/spec/tuple_destructure_assign_parens.test.ry
+tests/spec/tuple_single_element.test.ry
+tests/spec/types.test.ry
+
+# === Generic type syntax variants (`<T: Bound>`, `<T>::Variant` turbofish) ===
+tests/spec/enum_generic_param_type.test.ry
+tests/spec/generic_bounds.test.ry
+
+# === Lambda body with block expressions (`=> if ... :`, `=> if ... else ...`) ===
+tests/spec/lambda_paren_omit.test.ry
+tests/spec/nested_fn_return_fn.test.ry
+tests/spec/option_branch_merge_none.test.ry
+tests/spec/option_lambda_if.test.ry
+tests/spec/result_lambda_if.test.ry
+
+# === Numeric literal forms (leading dot, type suffix, underscore separator) ===
+tests/spec/leading_dot_float.test.ry
+tests/spec/numeric_literal_suffix.test.ry
+tests/spec/numeric_underscore_separator.test.ry
+
+# === Async / decorator / operator-overload / untyped-param declarations ===
+tests/spec/concurrency.test.ry
+tests/spec/concurrency_stress.test.ry
+tests/spec/functions.test.ry
+tests/spec/http.test.ry
+tests/spec/implicit_widening.test.ry
+tests/spec/list_destructure_assign.test.ry
+tests/spec/net.test.ry
+tests/spec/top_level_bindings.test.ry
+
+# === Other surface coverage gaps ===
+# (relative imports, trailing commas, records, case unification / arm bindings,
+#  ARC iolist patterns, Result type inference)
+tests/spec/arc_iolist.test.ry
+tests/spec/case_unification.test.ry
+tests/spec/nul_safety_http.test.ry
+tests/spec/record_subtyping.test.ry
+tests/spec/records.test.ry
+tests/spec/relative_import/mymath/mymath.test.ry
+tests/spec/relative_import/relative_import.test.ry
+tests/spec/result_type_inference.test.ry
+tests/spec/trailing_commas.test.ry

--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -16,6 +16,7 @@
 #     存在しないため file path 登録は無し。spec が追加されたら追記する。
 
 # === Tuple member access (`.0`, `.1`, ..., `.N`) ===
+tests/spec/collections.test.ry
 tests/spec/combinatorial/collection_element_tuple_access.test.ry
 tests/spec/combinatorial/collection_element_tuple_iterate.test.ry
 tests/spec/combinatorial/fn_argument.test.ry
@@ -45,6 +46,7 @@ tests/spec/numeric_literal_suffix.test.ry
 tests/spec/numeric_underscore_separator.test.ry
 
 # === Async / decorator / operator-overload / untyped-param declarations ===
+tests/spec/any.test.ry
 tests/spec/concurrency.test.ry
 tests/spec/concurrency_stress.test.ry
 tests/spec/functions.test.ry
@@ -56,7 +58,7 @@ tests/spec/top_level_bindings.test.ry
 
 # === Other surface coverage gaps ===
 # (relative imports, trailing commas, records, case unification / arm bindings,
-#  ARC iolist patterns, Result type inference)
+#  ARC iolist patterns, Result type inference, enum with discriminant value)
 tests/spec/arc_iolist.test.ry
 tests/spec/case_unification.test.ry
 tests/spec/nul_safety_http.test.ry
@@ -66,3 +68,4 @@ tests/spec/relative_import/mymath/mymath.test.ry
 tests/spec/relative_import/relative_import.test.ry
 tests/spec/result_type_inference.test.ry
 tests/spec/trailing_commas.test.ry
+tests/spec/type_of.test.ry


### PR DESCRIPTION
## Summary

- Add `editor/tree-sitter/check.sh` as a regression gate that runs `tree-sitter parse` against every `tests/spec/**/*.test.ry` and treats any `ERROR` / `MISSING` node as a failure unless the file is allowlisted.
- Add `editor/tree-sitter/expected-fail.txt` — the **single** place where tolerated grammar gaps are recorded. The 38 currently failing fixtures are clustered into six named buckets (tuple member access, generic syntax variants, lambda-block bodies, numeric literal forms, async / decorator / operator-overload declarations, other surface gaps).
- Update `.claude/skills/pre-commit-checklist/SKILL.md` §3.6.5 to invoke `./check.sh --no-build` alongside the existing build/install gate.
- Refine the `editor/tree-sitter/README.md` Layout table and add a `## Smoke-check (corpus regression test)` section.
- Phase 2 (hand-curated `tree-sitter test` corpus with S-expression assertions) remains tracked in #1633.

## Acceptance criteria — empirically verified

| Criterion | Verified by |
|---|---|
| Clean checkout exits 0 | `./check.sh --no-build` → `pass=138 skip=38 warn=0 fail=0 exit=0` |
| Deliberate grammar break exits non-zero | Removing `tests/spec/types.test.ry` from `expected-fail.txt` → `FAIL: tests/spec/types.test.ry exit=1` |
| `expected-fail.txt` is the single divergence record | `check.sh` reads only from `EXPECTED_FAIL`; no hard-coded skip list |
| Unexpected pass is WARN-only | Adding a passing file to `expected-fail.txt` → `WARN: ... now passes; remove from expected-fail.txt exit=0` |
| `--verbose` lists SKIP entries | All 38 xfail entries surfaced as `SKIP: <path>` |

## Notes

- `check.sh` is bash 3.2 compatible (no `declare -A` / `mapfile`) — uses pipe-delimited string set lookup so it works on macOS default bash.
- Detection uses `tree-sitter parse "$f" 2>&1 | grep -qE 'ERROR|MISSING'` because tree-sitter error recovery returns exit 0 for 5 of the 38 failing fixtures.
- Auto-builds `ry.so` via `./build.sh` if missing (mirroring `install.sh`'s pattern); `--no-build` opts out.

Closes #1617.

## Test plan

- [x] `./editor/tree-sitter/check.sh --no-build` exits 0 on a clean checkout
- [x] Removing an xfail entry surfaces a `FAIL:` line and exit 1
- [x] Adding a passing file to `expected-fail.txt` surfaces a `WARN:` line and exit 0
- [x] `--verbose` lists all 38 SKIP entries
- [x] `/pre-commit-checklist` (§1 README updated, §2 changelog created, §2.5 SKILL updated, §3-§3.6 skipped — no source code change, §3.6.5 self-gate, §3.7 background hygiene clean)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated grammar smoke-check with regression detection and pass/skip/warn classification
  * Introduced a curated expected-fail list to track known parsing gaps and surface "now passes" warnings

* **Documentation**
  * Documented the new smoke-check workflow, contributor guidance, and how expected failures are handled in Phase 1
<!-- end of auto-generated comment: release notes by coderabbit.ai -->