### PR TITLE
fix(codegen): propagate element-type metadata in emitListConcat (#1648)

### DIFF
--- a/.claude/rules/codegen-type-and-metadata.md
+++ b/.claude/rules/codegen-type-and-metadata.md
@@ -634,8 +634,9 @@ so no local snapshot is required at the call site — unlike
 invalidation gotcha documented in the entry above.
 
 **Canonical references**: `src/codegen_call_collection.cpp:1204-1208`
-(map merge, #961) and `src/codegen_call_collection.cpp:555-558`
-(`emitListSlice`, #1205).
+(map merge, #961), `src/codegen_call_collection.cpp:555-558`
+(`emitListSlice`, #1205), and `src/codegen_expr.cpp:emitListConcat`
+(list `+` concat, #1648).
 
 **How to apply**: When adding or reviewing a collection helper that
 returns `List<SameT>` / `Map<SameK, SameV>` / `Set<SameT>`, confirm the

--- a/changelog.d/1648-list-concat-propagate-meta.md
+++ b/changelog.d/1648-list-concat-propagate-meta.md
@@ -1,0 +1,13 @@
+### Fixed
+
+- `emitListConcat` (the LLVM IR codegen for the list `+` operator)
+  now calls `propagateMeta(lhs, newHeader)` after `setTypeMeta`, so
+  element-type metadata such as `map_key_type_name` /
+  `map_value_type_name` propagates to the concatenated result. Before
+  this fix, an inferred binding like `ys = a + b` where
+  `a, b: List<Map<str, int>>` lost the Map-element metadata and was
+  treated as `List<str>`, causing subsequent `ys[i]["k"]` access to
+  fail at codegen with `str does not support index access`. This
+  brings `emitListConcat` in line with `emitListSlice` and
+  `emitMapMergeCore`, both of which already pair `setTypeMeta` with
+  `propagateMeta` per the existing rule. (#1648)

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -2114,6 +2114,7 @@ llvm::Value *CodeGen::emitListConcat(llvm::Value *lhs, llvm::Value *rhs, llvm::T
     storeListHeaderFields(newHeader, newLen, newLen, newData);
 
     setTypeMeta(TypeMeta::ListElem, newHeader, elemTy);
+    propagateMeta(lhs, newHeader);
 
     // Propagate nested-list metadata so flat() works on concatenated results
     if (elemTy == ptrTy_) {

--- a/tests/spec/list_concat_arc.test.ry
+++ b/tests/spec/list_concat_arc.test.ry
@@ -39,7 +39,7 @@ fn listListArcRetain1236Tests():
   fn listMapStrIntConcatRetainsMapValuesAfterSourceDrop():
     a: List<Map<str, int>> = [{"a": 1}, {"b": 2}]
     b: List<Map<str, int>> = [{"c": 3}]
-    ys: List<Map<str, int>> = a + b
+    ys = a + b
     a = [{"z": 999}]
     b = [{"y": 888}]
     expect(len(ys)).toEq(3)


### PR DESCRIPTION
## Summary

Fix #1648: `emitListConcat` (the LLVM IR codegen for the list `+` operator) now calls `propagateMeta(lhs, newHeader)` after `setTypeMeta`, so element-type metadata such as `map_key_type_name` / `map_value_type_name` propagates to the concatenated result.

Before this fix, an inferred binding like `ys = a + b` where `a, b: List<Map<str, int>>` lost the Map-element metadata and was treated as `List<str>`, causing subsequent `ys[i]["k"]` access to fail at codegen with `str does not support index access`. This brings `emitListConcat` in line with `emitListSlice` and `emitMapMergeCore`, both of which already pair `setTypeMeta` with `propagateMeta` per the existing rule (`.claude/rules/codegen-type-and-metadata.md` "Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`", #1205).

## Changes

- `src/codegen_expr.cpp:emitListConcat` — add `propagateMeta(lhs, newHeader);` after `setTypeMeta`
- `tests/spec/list_concat_arc.test.ry` — drop the workaround `: List<Map<str, int>>` annotation that was masking the bug (regression test)
- `.claude/rules/codegen-type-and-metadata.md` — add `emitListConcat` to canonical references for the same-element-type pairing rule
- `changelog.d/1648-list-concat-propagate-meta.md` — Keep a Changelog fragment

## Follow-up

Audit during this PR found 7 sibling sites in other `emit*Core` helpers that have the same pattern (manual `*_type_name` set without `propagateMeta`). Filed as #1651 (separate PR scope).

## Test plan

- [x] `./build/ry test tests/spec/list_concat_arc.test.ry` — pass (was failing before fix)
- [x] `./build/ry test tests/spec/list_range_index.test.ry` — sibling Map-slice regression guard, pass
- [x] `./build/ry test -p` — full self-test, pass
- [x] `./build/ry_tests` — C++ tests, pass
- [x] ASan + UBSan via `build-asan` — 0 issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where list concatenation (using `+`) would lose element type metadata. Maps within concatenated lists now correctly preserve their key and value type information, preventing downstream processing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->