### PR TITLE
test(net): use ephemeral port reservation in closed-port tests (#1606)

### DIFF
--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -27,20 +27,32 @@ fn tcpSocketApiTests():
         fail("unexpected error: " + e.message)
   @it("should return Err when tlsConnect to closed port")
   fn shouldReturnErrWhenTlsconnectToClosedPort():
-    case tlsConnect("127.0.0.1", 19991):
-      Ok(conn):
-        close(conn)
-        fail("expected Err but got Ok")
+    case bind("127.0.0.1", 0):
+      Ok(server):
+        port = listenerPort(server)
+        close(server)
+        case tlsConnect("127.0.0.1", port):
+          Ok(conn):
+            close(conn)
+            fail("expected Err but got Ok")
+          Err(e):
+            expect(true).toEq(true)
       Err(e):
-        expect(true).toEq(true)
+        fail("unexpected error: " + e.message)
   @it("should return Err when connect to closed port")
   fn shouldReturnErrWhenConnectToClosedPort():
-    case connect("127.0.0.1", 19998):
-      Ok(conn):
-        close(conn)
-        fail("expected Err but got Ok")
+    case bind("127.0.0.1", 0):
+      Ok(server):
+        port = listenerPort(server)
+        close(server)
+        case connect("127.0.0.1", port):
+          Ok(conn):
+            close(conn)
+            fail("expected Err but got Ok")
+          Err(e):
+            expect(true).toEq(true)
       Err(e):
-        expect(true).toEq(true)
+        fail("unexpected error: " + e.message)
   @it("should preserve TcpListener metadata through helper-returned Result")
   fn shouldPreserveTcplistenerMetadataThroughHelperReturnedResult():
     fn mkListener() -> Result<TcpListener, Error>:


### PR DESCRIPTION
## Summary

Closes #1606.

The two `closed-port` specs in `tests/spec/net.test.ry` (`shouldReturnErrWhenTlsconnectToClosedPort` and `shouldReturnErrWhenConnectToClosedPort`) used hard-coded ports `19991` / `19998`, which made them flaky on shared CI runners or developer machines where those ports happened to be bound by another process. This PR replaces them with the canonical ephemeral pattern already used 7 times in the same file (lines 10, 18, 47, 58, 81, 148, 177):

`bind("127.0.0.1", 0)` → `port = listenerPort(server)` → `close(server)` → assert `(tls)connect("127.0.0.1", port)` returns `Err`.

The OS-assigned ephemeral port is fresh per run, and the listener is closed before the connect attempt, so `connect` reliably hits `ECONNREFUSED` on loopback.

## Test plan

- [x] `./build/ry test tests/spec/net.test.ry` × 5 consecutive runs — 9 passed / 0 failed each
- [x] Same test executed while another process held `127.0.0.1:19998` open (verified host-state independence) — still 9 passed / 0 failed
- [x] `./build/ry test -p` — 176 spec files, 0 failures
- [x] `./build/ry_tests` — 2142 / 2142 passed
- [x] ASan + UBSan: `./build-asan/ry_tests` — 2142 / 2142 passed
- [x] TSan: `./build-tsan/ry_tests` — 2142 / 2142 passed, no ThreadSanitizer warnings
- [x] cppcheck: clean
- [x] clang-tidy on `src/`: 0 warnings / 0 errors

## Pre-commit checklist deviations

- Skipped §1 — test-only refactor, no user-visible behavior change.
- Skipped §2 — test-only refactor, no `feat:` / `fix:` / breaking-change semantics for end users.
- Skipped §3.6 (libFuzzer) — no parser/lexer/json/utf8/string change.
- Skipped §3.6.5 (tree-sitter) — no grammar / EBNF / scanner change.

## Out of scope (follow-up)

The same hard-coded-port anti-pattern was found in `tests/test_codegen_net.cpp` (lines 58, 296, 308, 320, 403, 418 — ports 19999/19997/19996/19995/19993/19992). Filed as #1653 under the same milestone for a separate PR per the `/scope-out-issue` policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved TCP socket API tests to use dynamic port binding instead of hardcoded ports for better test reliability.
  * Enhanced tests for connection failure scenarios when ports are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->