### PR TITLE
test(codegen): use ephemeral port reservation in net codegen tests (#1653)

### DIFF
--- a/tests/test_codegen_net.cpp
+++ b/tests/test_codegen_net.cpp
@@ -55,12 +55,21 @@ case bind("127.0.0.1", 0):
 
 TEST_F(CodeGenTest, NetConnectInvalidReturnsErr) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-case connect("127.0.0.1", 19999):
-    Ok(conn):
-        print("connected")
-        close(conn)
+@native
+fn listenerPort(listener: TcpListener) -> int
+
+case bind("127.0.0.1", 0):
+    Ok(server):
+        port = listenerPort(server)
+        close(server)
+        case connect("127.0.0.1", port):
+            Ok(conn):
+                print("connected")
+                close(conn)
+            Err(e):
+                print("err")
     Err(e):
-        print("err")
+        ...
 )"), "err\n");
 }
 
@@ -293,37 +302,64 @@ TEST(TcpRecv, ErrorReturnsNull) {
 
 TEST_F(CodeGenTest, NetSetTimeoutCompiles) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-case connect("127.0.0.1", 19997):
-    Ok(conn):
-        setTimeout(conn, 500)
-        print("ok")
-        close(conn)
+@native
+fn listenerPort(listener: TcpListener) -> int
+
+case bind("127.0.0.1", 0):
+    Ok(server):
+        port = listenerPort(server)
+        close(server)
+        case connect("127.0.0.1", port):
+            Ok(conn):
+                setTimeout(conn, 500)
+                print("ok")
+                close(conn)
+            Err(e):
+                print("err")
     Err(e):
-        print("err")
+        ...
 )"), "err\n");
 }
 
 TEST_F(CodeGenTest, NetSetRecvTimeoutCompiles) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-case connect("127.0.0.1", 19996):
-    Ok(conn):
-        setReceiveTimeout(conn, 500)
-        print("ok")
-        close(conn)
+@native
+fn listenerPort(listener: TcpListener) -> int
+
+case bind("127.0.0.1", 0):
+    Ok(server):
+        port = listenerPort(server)
+        close(server)
+        case connect("127.0.0.1", port):
+            Ok(conn):
+                setReceiveTimeout(conn, 500)
+                print("ok")
+                close(conn)
+            Err(e):
+                print("err")
     Err(e):
-        print("err")
+        ...
 )"), "err\n");
 }
 
 TEST_F(CodeGenTest, NetSetSendTimeoutCompiles) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-case connect("127.0.0.1", 19995):
-    Ok(conn):
-        setSendTimeout(conn, 500)
-        print("ok")
-        close(conn)
+@native
+fn listenerPort(listener: TcpListener) -> int
+
+case bind("127.0.0.1", 0):
+    Ok(server):
+        port = listenerPort(server)
+        close(server)
+        case connect("127.0.0.1", port):
+            Ok(conn):
+                setSendTimeout(conn, 500)
+                print("ok")
+                close(conn)
+            Err(e):
+                print("err")
     Err(e):
-        print("err")
+        ...
 )"), "err\n");
 }
 
@@ -400,12 +436,21 @@ TEST(TcpTimeout, SetTimeoutSetsSocketOptions) {
 
 TEST_F(CodeGenTest, TlsConnectInvalidReturnsErr) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-case tlsConnect("127.0.0.1", 19993):
-    Ok(conn):
-        print("connected")
-        close(conn)
+@native
+fn listenerPort(listener: TcpListener) -> int
+
+case bind("127.0.0.1", 0):
+    Ok(server):
+        port = listenerPort(server)
+        close(server)
+        case tlsConnect("127.0.0.1", port):
+            Ok(conn):
+                print("connected")
+                close(conn)
+            Err(e):
+                print("tls err")
     Err(e):
-        print("tls err")
+        ...
 )"), "tls err\n");
 }
 
@@ -415,21 +460,30 @@ case tlsConnect("127.0.0.1", 19993):
 
 TEST_F(CodeGenTest, TlsStreamOverloadsCompile) {
     EXPECT_EQ(runSource(NET_DECLS + R"(
-case tlsConnect("127.0.0.1", 19992):
-    Ok(conn):
-        case send(conn, toBytes("hello")):
-            Ok(n):
-                print("sent")
+@native
+fn listenerPort(listener: TcpListener) -> int
+
+case bind("127.0.0.1", 0):
+    Ok(server):
+        port = listenerPort(server)
+        close(server)
+        case tlsConnect("127.0.0.1", port):
+            Ok(conn):
+                case send(conn, toBytes("hello")):
+                    Ok(n):
+                        print("sent")
+                    Err(e):
+                        print("send err")
+                case receive(conn, 4096):
+                    Ok(data):
+                        print("recv ok")
+                    Err(e):
+                        print("recv err")
+                close(conn)
             Err(e):
-                print("send err")
-        case receive(conn, 4096):
-            Ok(data):
-                print("recv ok")
-            Err(e):
-                print("recv err")
-        close(conn)
+                print("err")
     Err(e):
-        print("err")
+        ...
 )"), "err\n");
 }
 


### PR DESCRIPTION
## Summary

- Replace hard-coded ports `19992`–`19999` in 6 cases of `tests/test_codegen_net.cpp` (`NetConnectInvalidReturnsErr`, `NetSetTimeoutCompiles`, `NetSetRecvTimeoutCompiles`, `NetSetSendTimeoutCompiles`, `TlsConnectInvalidReturnsErr`, `TlsStreamOverloadsCompile`) with the `bind("127.0.0.1", 0)` → `listenerPort` → `close` → `(tls)connect` ephemeral-port pattern.
- Mirrors the Ry-side fix in #1606 (commit `a0fdc95f`); same root cause and same canonical pattern. `@native fn listenerPort(listener: TcpListener) -> int` is declared inline per case to match the existing pattern in `NetEchoRoundTrip` / `NetRecvTimesOutWithShortTimeout` and avoid touching their `NET_DECLS` consolidation.

Closes #1653.

## Test plan

- [x] `./build/ry_tests` — 2142 tests, all green
- [x] `./build/ry test -p` — 176 spec files, all green
- [x] ASan + UBSan: `./build-asan/ry_tests` (2142 / 2142) and `./build-asan/ry test -p` (176 / 176) all green
- [x] TSan: `./build-tsan/ry_tests` (2142 / 2142) all green (required gate)
- [x] Flakiness check: each of the 6 cases passes while the formerly-hardcoded port (e.g. `nc -l 127.0.0.1 19999 &` for `NetConnectInvalidReturnsErr`) is occupied by another listener
- [x] cppcheck on `src/` `include/` clean

## Pre-commit checklist skip log

- Skipped §1 — no user-visible change (test-only flakiness fix; same category as #1606 which had no doc change)
- Skipped §2 — no user-visible change; no `feat:` / `fix:` / breaking change. Consistent with #1606 (no `changelog.d/` fragment)
- Skipped §3.5.5 clang-tidy — no `src/` / `include/` changes (cppcheck still run; clean)
- Skipped §3.6 libFuzzer — no parser/lexer/json/utf8/string changes
- Skipped §3.6.5 tree-sitter — no grammar changes

## Scope-out filed

- #1657 — TSan macOS SEGV in `OverloadEntry` destructor on combinatorial spec tests (e.g. `combinatorial/collection_element_option_iterate.test.ry`). Pre-existing on `main` (verified by stashing this PR's diff and re-running); affects `./build-tsan/ry test -p` (warn-only per `tsan-known-issues` skill), not the required `./build-tsan/ry_tests` gate. Not blocking this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated network-related codegen tests to use dynamic port allocation instead of hardcoded port numbers, improving test reliability and reducing potential port conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->