### PR TITLE
fix(codegen): propagate nested-collection metadata in keys()/values() (#1655)

### DIFF
--- a/changelog.d/1655-keys-values-nested-meta.md
+++ b/changelog.d/1655-keys-values-nested-meta.md
@@ -1,0 +1,24 @@
+### Fixed
+
+- `keys(map)` and `values(map)` now propagate the source map's key /
+  value type metadata onto the returned `List`. Before this fix,
+  `emitBuiltinKeys` and `emitBuiltinValues` (`src/codegen_call.cpp`)
+  stamped only the LLVM `TypeMeta::ListElem` slot via `setTypeMeta`,
+  leaving `list_elem_type_name` and the derived `nested_list_elem` /
+  `list_elem_fn_type_info` empty. The result list's elements were
+  therefore dispatched as `str` by downstream operations, so
+  `len(values(m)[0])` returned `0` (reading the List header's
+  `weak_count` as `byte_len`) and `keys(m)[0][0]` /
+  `values(m)[0]["k"]` raised `str does not support index access` at
+  codegen for nested-collection key / value types like
+  `Map<List<int>, str>` or `Map<str, List<int>>`. The fix snapshots
+  `map_key_type_name` / `map_value_type_name` from the source map's
+  metadata, calls `propagateTypeMeta("List<…>", newHeader)` after
+  `setTypeMeta` to populate every derived slot, and pairs the element
+  buffer `memcpy` with `emitCowRetainArcElements` when the element
+  type is ARC-managed (#1204 / #1242 — required because the newly
+  propagated `list_elem_type_name` flips the result's destructor to
+  recurse into the inner ARC elements). The analogous bug in
+  `items(map)` (`src/codegen_call_collection.cpp`) is tracked
+  separately as #1659 because its tuple element type requires a
+  different fix shape. (#1655)

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -178,6 +178,14 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *mapLen = mf.len;
         llvm::Value *keysData = mf.keys;
 
+        // Snapshot key type name before any propagateTypeMeta call:
+        // getOrCreateMeta inside it may rehash value_metadata_ and
+        // invalidate a raw pointer from getMeta (mirrors the pattern in
+        // codegen_stmt_misc.cpp's IndexAssignStmt).
+        std::string keyName;
+        if (auto *containerMeta = getMeta(mapVal))
+            keyName = containerMeta->map_key_type_name;
+
         auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         llvm::Value *newHeader = emitArcAllocCollectionHeader(listHeaderTy_);
@@ -187,8 +195,22 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         auto memcpyFn = getStdlibMemcpy();
         builder_.CreateCall(memcpyFn, {newData, keysData, dataSize});
 
+        // memcpy duplicates raw pointers without bumping refcounts. Once
+        // propagateTypeMeta below stamps list_elem_type_name on the result,
+        // its destructor recurses into the inner ARC elements (#1242), so
+        // the duplicated pointers must be retained or rebinding the source
+        // map will free them out from under the result (#1204).
+        // elementTypeIsArcManaged inspects the value side of a Map, so
+        // re-derive ARC kind from the key type name directly via
+        // fieldTypeIsArcManaged (the shared name-based predicate).
+        CollectionKind keyArcKind;
+        if (!keyName.empty() && fieldTypeIsArcManaged(keyName, &keyArcKind))
+            emitCowRetainArcElements(newData, mapLen, "keys_elem", keyArcKind);
+
         storeListHeaderFields(newHeader, mapLen, mapLen, newData);
         setTypeMeta(TypeMeta::ListElem, newHeader, keyTy);
+        if (!keyName.empty())
+            propagateTypeMeta("List<" + keyName + ">", newHeader);
         return newHeader;
     }
 
@@ -203,6 +225,13 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *mapLen = mf.len;
         llvm::Value *valsData = mf.vals;
 
+        // Snapshot value type name before any propagateTypeMeta call:
+        // getOrCreateMeta inside it may rehash value_metadata_ and
+        // invalidate a raw pointer from getMeta.
+        std::string valName;
+        if (auto *containerMeta = getMeta(mapVal))
+            valName = containerMeta->map_value_type_name;
+
         auto mallocFn = getStdlibMalloc();
         const llvm::DataLayout &dl = mod_->getDataLayout();
         llvm::Value *newHeader = emitArcAllocCollectionHeader(listHeaderTy_);
@@ -212,8 +241,17 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         auto memcpyFn = getStdlibMemcpy();
         builder_.CreateCall(memcpyFn, {newData, valsData, dataSize});
 
+        // memcpy of an ARC-managed value buffer must be paired with retain;
+        // see keys() above for the rationale (#1204 / #1242).
+        CollectionKind valArcKind = CollectionKind::List;
+        if (elementTypeIsArcManaged(mapVal, CollectionKind::Map, &valArcKind)) {
+            emitCowRetainArcElements(newData, mapLen, "vals_elem", valArcKind);
+        }
+
         storeListHeaderFields(newHeader, mapLen, mapLen, newData);
         setTypeMeta(TypeMeta::ListElem, newHeader, valTy);
+        if (!valName.empty())
+            propagateTypeMeta("List<" + valName + ">", newHeader);
         return newHeader;
     }
 

--- a/tests/spec/collection_meta_propagation.test.ry
+++ b/tests/spec/collection_meta_propagation.test.ry
@@ -140,3 +140,69 @@ fn setSymmetricDifferencePropagatesInnerCollectionMetadata1651Tests():
     for elem in c:
       total = total + elem[0]
     expect(total).toEq(6)
+
+# Regression tests for #1655 — Map.keys() / Map.values() must populate the
+# string-side metadata (`list_elem_type_name` and derived `nested_list_elem` /
+# `list_elem_fn_type_info`) on the returned List, not just the LLVM-type slot.
+# Pre-fix, `setTypeMeta(TypeMeta::ListElem, newHeader, keyTy/valTy)` left
+# `list_elem_type_name` empty and the indexer dispatched the loaded element as
+# `str`, so `len(vs[0])` read `weak_count` (= 0) and `vs[0]["k"]` raised
+# "str does not support index access".
+@describe("values() propagates inner-collection metadata (#1655)")
+fn valuesPropagatesInnerCollectionMetadata1655Tests():
+  @it("values on Map<str, List<int>> preserves nested len + index access")
+  fn valuesOnMapStrListIntPreservesNestedLenAndIndex():
+    m: Map<str, List<int>> = {"a": [1, 2, 3]}
+    vs = values(m)
+    expect(len(vs)).toEq(1)
+    expect(len(vs[0])).toEq(3)
+    expect(vs[0][0]).toEq(1)
+    expect(vs[0][2]).toEq(3)
+
+  @it("values on Map<str, Map<str, int>> preserves nested map key access")
+  fn valuesOnMapStrMapStrIntPreservesNestedMapKeyAccess():
+    m: Map<str, Map<str, int>> = {"outer": {"k": 7}}
+    vs = values(m)
+    expect(len(vs)).toEq(1)
+    expect(vs[0]["k"]).toEq(7)
+
+  @it("values result's inner List<int> survives source map rebind")
+  fn valuesResultsInnerListIntSurvivesSourceMapRebind():
+    # Once values() stamps list_elem_type_name = "List<int>" on the result,
+    # its destructor recurses into the inner lists (#1242). The memcpy of
+    # the source values buffer must therefore be paired with an ARC retain
+    # (#1204) — without it, rebinding the source frees the same inner
+    # lists the result still references.
+    m: Map<str, List<int>> = {"a": [1, 2, 3]}
+    vs = values(m)
+    m = {"x": [99]}
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(vs[0][0]).toEq(1)
+    expect(vs[0][2]).toEq(3)
+
+@describe("keys() propagates inner-collection metadata (#1655)")
+fn keysPropagatesInnerCollectionMetadata1655Tests():
+  @it("keys on Map<List<int>, str> preserves nested index access on result")
+  fn keysOnMapListIntStrPreservesNestedIndexAccessOnResult():
+    m: Map<List<int>, str> = {[1, 2]: "a", [3, 4]: "b"}
+    ks = keys(m)
+    expect(len(ks)).toEq(2)
+    expect(len(ks[0])).toEq(2)
+    expect(ks[0][0] + ks[0][1]).toEq(3)
+
+  @it("keys result's inner List<int> survives source map rebind")
+  fn keysResultsInnerListIntSurvivesSourceMapRebind():
+    m: Map<List<int>, str> = {[1, 2, 3]: "a"}
+    ks = keys(m)
+    m = {[99]: "x"}
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(ks[0][0]).toEq(1)
+    expect(ks[0][2]).toEq(3)


### PR DESCRIPTION
## Summary

`emitBuiltinKeys` / `emitBuiltinValues` (`src/codegen_call.cpp`) only stamped the LLVM `TypeMeta::ListElem` slot via `setTypeMeta`, leaving `list_elem_type_name` and the derived `nested_list_elem` / `list_elem_fn_type_info` empty. Downstream operations therefore dispatched the result list's elements as `str`, so `len(values(m)[0])` returned `0` (reading the List header's `weak_count` as `byte_len`) and `keys(m)[0][0]` / `values(m)[0]["k"]` raised `str does not support index access` for nested-collection key / value types like `Map<List<int>, str>` or `Map<str, List<int>>`.

## Fix

- Snapshot `map_key_type_name` / `map_value_type_name` from the source map's metadata before any `propagateTypeMeta` call (which may rehash `value_metadata_` and invalidate raw pointers from `getMeta`).
- Call `propagateTypeMeta("List<…>", newHeader)` after `setTypeMeta` to populate every derived slot (`list_elem_type_name`, `nested_list_elem`, `list_elem_fn_type_info`).
- Pair the element buffer `memcpy` with `emitCowRetainArcElements` when the element type is ARC-managed (#1204 / #1242 — required because the newly propagated `list_elem_type_name` flips the result's destructor to recurse into the inner ARC elements).
- For `keys()`, use `fieldTypeIsArcManaged(keyName, ...)` (name-based predicate) since `elementTypeIsArcManaged(map, CollectionKind::Map, …)` only inspects the value side.

## Out of scope

The analogous bug in `items(map)` (`src/codegen_call_collection.cpp:1089`) is tracked separately as #1659 because its tuple element type `(K, V)` requires a different fix shape (manual string composition, like `enumerate` / `zip`).

## Test plan

- [x] Added 5 regression tests in `tests/spec/collection_meta_propagation.test.ry` covering `Map<str, List<int>>`, `Map<str, Map<str, int>>`, `Map<List<int>, str>`, plus ARC retain validation under source-map rebind for both `keys()` and `values()`.
- [x] `./build/ry test -p tests/spec/collection_meta_propagation.test.ry` passes.
- [x] `./build/ry test -p` passes (full Ry self-test).
- [x] `./build/ry_tests` passes (full C++ test).
- [x] ASan + UBSan run passes.
- [x] TSan C++ test passes.
- [x] clang-tidy / cppcheck pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `keys()` and `values()` builtins on maps to properly propagate nested type metadata from the source map, resolving runtime errors when accessing elements within returned collections.

* **Tests**
  * Added regression tests to ensure `keys()` and `values()` correctly preserve metadata for nested collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->