### PR TITLE
fix(tree-sitter): relax block-introducing statement bodies for live-editing indent (#1623)

### DIFF
--- a/.claude/rules/tree-sitter-grammar-editing.md
+++ b/.claude/rules/tree-sitter-grammar-editing.md
@@ -31,6 +31,26 @@ token is reinterpreted as a different token kind. Reproducer and full
 verification steps in `/tree-sitter-grammar-editing` §"Externals enum
 order in scanner.c MUST match the externals array in grammar.js".
 
+### Live-editing tolerance for body fields
+
+**Source**: issue #1623, `editor/tree-sitter/README.md` §"Live-editing tolerance",
+`editor/tree-sitter/grammar.js` (`function_body`, `if_statement`,
+`while_statement`, `for_statement`, `case_match_statement`,
+`case_cond_statement`)
+**Tags**: tree-sitter, grammar, live-editing, optional-body, indents.scm
+
+**Rule**: Block-introducing statement bodies are wrapped in `optional(...)`
+so partial input (`fn foo():` typed but body not yet started) still
+produces a complete named node. This is what allows `indents.scm`
+`@indent.begin` captures to fire during incremental editing and is the
+canonical (intentional) divergence from `docs/grammar.ebnf`. Each relaxed
+rule carries a `// Live-editing tolerance (#1623):` comment in
+`grammar.js`. Do **not** apply the same relaxation to `case_arm` /
+`case_cond_arm` — it introduces a parser conflict; the outer
+`case_*_statement` relaxation is sufficient. Detailed pattern, recipes,
+and ambiguity caveat live in `/tree-sitter-grammar-editing` §"Live-editing
+tolerance".
+
 ### Canonical edit-propagation order
 
 `docs/grammar.ebnf` (canonical EBNF) → `editor/tree-sitter/grammar.js`

--- a/.claude/skills/tree-sitter-grammar-editing/SKILL.md
+++ b/.claude/skills/tree-sitter-grammar-editing/SKILL.md
@@ -243,6 +243,105 @@ or punctuation literal (see `highlights.scm:135-160`).
 
 ---
 
+### Live-editing tolerance: optional body to avoid ERROR nodes during typing
+
+**Source**: issue #1623, `editor/tree-sitter/grammar.js` `function_body` /
+`if_statement` / `while_statement` / `for_statement` /
+`case_match_statement` / `case_cond_statement`,
+`editor/tree-sitter/README.md` §"Live-editing tolerance"
+**Tags**: tree-sitter, grammar, live-editing, optional-body, indents.scm,
+error-recovery
+
+**Rule**: When `indents.scm` `@indent.begin` captures fail to fire during
+live editing (e.g. user types `fn foo():` and presses `<CR>` but the
+cursor stays at column 0), the cause is almost always that the
+block-introducing rule is not completing a named node on partial input —
+the parser wraps it in `(ERROR)` instead. Fix by wrapping the body in
+`optional(...)`:
+
+| Rule shape | Required relaxation |
+|------------|---------------------|
+| `seq(..., ':', field('body', $.block))` | `seq(..., ':', optional(field('body', $.block)))` |
+| `seq(..., ':', $._indent, repeat1($.X), $._dedent)` (named sub-rule) | Wrap the **inside** of the sub-rule's INDENT/DEDENT pair: `seq(':', optional(seq($._indent, repeat1($.X), $._dedent)))`. Do **not** make `field('body', $.named_sub_rule)` itself optional — that would break `indents.scm` field-predicate captures and disambiguation tokens. |
+| `seq(..., ':', $._indent, repeat1($.arm), $._dedent)` (inline) | `seq(..., ':', optional(seq($._indent, repeat1($.arm), $._dedent)))` |
+
+After the relaxation, verify the disambiguation tokens are still
+unambiguous. For Ry specifically, `function_declaration` uses
+`choice(field('body', $.function_body), $._newline)` to distinguish
+`@native fn foo() -> Unit` (no `:`, takes the `_newline` arm) from
+`fn foo():` (takes the `function_body` arm). Keep the `:` mandatory
+inside `function_body` and only optionalise the INDENT body — that
+preserves the disambiguator.
+
+**Trailing-clause `:` relaxation (e.g. `if`-`else`)**: When the
+acceptance criterion is "bare keyword on its own line dedents to the
+parent" (e.g. `else` typed alone after a complete `if cond:` body
+should dedent), making just the body optional is not enough — the
+parser must also accept the keyword without its trailing `:`. For Ry's
+`if_statement`, the trailing `else` clause was relaxed from
+`seq('else', ':', optional(field('alternative', $.block)))` to
+`seq('else', optional(seq(':', optional(field('alternative', $.block)))))`
+so that bare `else` is absorbed into `if_statement` and the existing
+`(if_statement "else" @indent.branch)` capture in `indents.scm`
+fires. This **introduces an ambiguity** with `else if` (continue this
+`if_statement`'s else-if chain vs. end this `if_statement` and start a
+new top-level `if`) that `tree-sitter generate` flags as
+"Unresolved conflict for symbol sequence". Resolve by wrapping the
+entire rule in `prec.right(...)`, which biases toward continuing the
+chain — the expected interpretation. Document the precedence with a
+comment so future maintainers understand why it is required.
+
+**Caveat — arm-level rules can cause genuine ambiguity**: For Ry's
+`case_arm` / `case_cond_arm`, making the body `optional(choice(...))`
+causes `tree-sitter generate` to fail with an unresolved conflict
+because the next-arm condition can begin with `(` (an expression), and
+an inline body can also begin with `(`. The outer
+`case_match_statement` / `case_cond_statement` relaxation is sufficient
+for the primary live-editing case (`case x:` typed and `<CR>` pressed);
+arm-level partial typing falls back to the surrounding statement-level
+`@indent.begin` capture. If you encounter "Unresolved conflict for
+symbol sequence" after a relaxation, this is the canonical failure
+mode — revert the arm-level optional and rely on the outer rule.
+
+**How to verify** (reproduce the live-editing scenarios after rebuild):
+
+```bash
+cd editor/tree-sitter
+./build.sh
+TS=tree-sitter
+$TS parse <(printf 'fn foo():\n')              # function_body now appears as a child; no surrounding (ERROR)
+$TS parse <(printf 'if cond:\n')                # if_statement node present; no (ERROR) wrap
+$TS parse <(printf 'while x:\n')                # while_statement
+$TS parse <(printf 'for x in xs:\n')            # for_statement
+$TS parse <(printf 'case c:\n')                 # case_match_statement
+$TS parse <(printf 'case:\n')                   # case_cond_statement
+$TS parse <(printf 'if cond:\n  body1\nelse\n')   # bare `else` is inside if_statement (not in ERROR)
+$TS parse <(printf '@native\nfn foo() -> Unit\n')  # @native fn unchanged (regression check)
+$TS parse <(printf 'fn foo():\n  return 1\n')   # complete fn parses identically (regression check)
+./check.sh                                       # full-corpus pass/skip/fail counts unchanged
+```
+
+The complete-program parse must be unchanged from baseline (Ry compiler
+will continue to enforce non-empty bodies at compile time — the tolerance
+is editor-only). If `check.sh` surfaces new `FAIL` entries, the
+relaxation introduced a regression in some other rule that depended on
+the body's presence; debug by examining the failing file's parse tree
+with `tree-sitter parse -d <path>`.
+
+**Why this works**: tree-sitter's incremental parser produces a CST even
+on incomplete input; with the body optional, the prefix `fn foo():` is a
+valid full sentence of the grammar, so the parser commits to
+`function_declaration` as soon as it sees the `:`. The
+`@indent.begin` capture in `indents.scm` then matches because its field
+predicate (`body: (function_body)` or similar) is satisfied by the
+empty-body `function_body` node. Without the relaxation the prefix
+cannot terminate any rule, so the parser falls back to error recovery
+and wraps everything in `(ERROR)` — which `indents.scm` cannot match
+because the query syntax has no ERROR-node escape hatch that doesn't
+make the whole indent strategy brittle.
+
+---
+
 ### Verification recipes for grammar / scanner / highlights edits
 
 **Source**: `editor/tree-sitter/README.md:89-122`,

--- a/changelog.d/1623-tree-sitter-live-editing-indent.md
+++ b/changelog.d/1623-tree-sitter-live-editing-indent.md
@@ -1,0 +1,31 @@
+### Fixed
+
+- `editor/tree-sitter/grammar.js` now produces complete named nodes for
+  partially-typed block-introducing statements, so `indents.scm`
+  `@indent.begin` captures fire during live editing in Neovim. Before this
+  change, typing `fn foo():` and pressing `<CR>` left the cursor at column
+  0 because the parser wrapped the incomplete statement in `(ERROR)`,
+  dropping the `function_body` field that the indent capture matches.
+  After this change, the body of `function_body`, `if_statement`,
+  `while_statement`, `for_statement`, `case_match_statement`, and
+  `case_cond_statement` is wrapped in `optional(...)` so the prefix
+  `fn foo():` / `if cond:` / `while x:` / `for x in xs:` / `case c:` /
+  `case:` is a valid full sentence of the grammar — the parser commits to
+  the surrounding statement node as soon as it sees the `:` and the
+  capture's field predicate is satisfied. The trailing `else` clause of
+  `if_statement` additionally allows its `:` to be missing, so a bare
+  `else` typed on its own line is absorbed into the surrounding
+  `if_statement` and the existing
+  `(if_statement "else" @indent.branch)` capture dedents to the parent
+  `if`'s column. The relaxation introduces a precedence ambiguity with
+  `else if` (continue the chain vs. end the statement and start a new
+  top-level `if`), resolved by wrapping `if_statement` in
+  `prec.right(...)`. The Ry compiler continues to enforce non-empty
+  bodies at compile time; the relaxation is editor-side only and
+  intentionally diverges from `docs/grammar.ebnf` (canonical EBNF spec).
+  `case_arm` / `case_cond_arm` were not relaxed because the next-arm
+  condition can begin with `(`, which would create a parser ambiguity
+  with an inline body; the outer `case_*_statement` relaxation is
+  sufficient for the primary live-editing scenario. See
+  `editor/tree-sitter/README.md` §"Live-editing tolerance" for the full
+  table. (#1623)

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -113,6 +113,45 @@ the entry in the same PR that closes the gap.
 recorded; `check.sh` has no hard-coded skip list. Inline `# reason`
 comments after each path are stripped at read time and are advisory only.
 
+## Live-editing tolerance
+
+The tree-sitter grammar (`grammar.js`) is intentionally **more permissive**
+than the canonical EBNF spec ([`docs/grammar.ebnf`](../../docs/grammar.ebnf))
+in the body of every block-introducing statement. The body content is
+wrapped in `optional(...)` so that **partial input** typed during
+incremental editing still produces a complete named node, allowing
+`indents.scm` `@indent.begin` captures to fire.
+
+| Grammar rule              | EBNF requirement                            | grammar.js tolerance                          |
+|---------------------------|---------------------------------------------|-----------------------------------------------|
+| `function_body`           | `:` then INDENT contracts? statement+ DEDENT | `:` followed by optional INDENT body          |
+| `if_statement`            | `:` then mandatory `block`                  | `:` followed by optional `block` (consequence / alt_consequence / alternative); trailing `else` allows `:` itself to be missing so that bare `else` typed on its own line is absorbed into the surrounding `if_statement` |
+| `while_statement`         | `:` then mandatory `block`                  | `:` followed by optional `block`              |
+| `for_statement`           | `:` then mandatory `block`                  | `:` followed by optional `block`              |
+| `case_match_statement`    | `:` then mandatory INDENT case_arm+ DEDENT  | `:` followed by optional INDENT arms          |
+| `case_cond_statement`     | `:` then mandatory INDENT case_cond_arm+ DEDENT | `:` followed by optional INDENT arms      |
+
+Each relaxed rule carries a `// Live-editing tolerance (#1623):` comment
+in `grammar.js` pointing back to this section. The Ry compiler enforces
+non-empty bodies at compile time — the tolerance is editor-level only.
+
+The `if_statement` rule is wrapped in `prec.right(...)` because making
+the trailing `else`'s `:` optional would otherwise create an ambiguity
+when the parser sees `else if`: it cannot decide whether to continue
+the current `if_statement`'s else-if chain or to end the `if_statement`
+(with bare `else`) and start a new top-level `if`. Right-precedence
+biases toward continuing the chain, which matches the expected
+interpretation.
+
+The `case_arm` and `case_cond_arm` rules **do not** receive the same
+relaxation: making their bodies optional introduces a parser ambiguity
+(the next-arm condition could begin with `(`, which is also a valid
+expression statement that an inline body would absorb). The outer
+`case_match_statement` / `case_cond_statement` relaxation is sufficient
+for the most common live-editing scenario (`case x:` typed and `<CR>`
+pressed); arm-level partial typing falls back to the existing block-level
+`@indent.begin` capture on the surrounding case statement.
+
 ## Contributor workflow
 
 Whenever a PR touches one of these paths (paths are relative to the

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -117,7 +117,7 @@ comments after each path are stripped at read time and are advisory only.
 
 The tree-sitter grammar (`grammar.js`) is intentionally **more permissive**
 than the canonical EBNF spec ([`docs/grammar.ebnf`](../../docs/grammar.ebnf))
-in the body of every block-introducing statement. The body content is
+for the specific block-introducing rules below. Their body content is
 wrapped in `optional(...)` so that **partial input** typed during
 incremental editing still produces a complete named node, allowing
 `indents.scm` `@indent.begin` captures to fire.

--- a/editor/tree-sitter/grammar.js
+++ b/editor/tree-sitter/grammar.js
@@ -209,12 +209,20 @@ export default grammar({
       '>',
     ),
 
+    // Live-editing tolerance (#1623): the INDENT body is optional so that
+    // partial input (`fn foo():` typed but body not yet started) produces
+    // a complete `function_body` named node, allowing indents.scm
+    // `@indent.begin` captures to fire. The Ry compiler enforces a
+    // non-empty body at compile time. See editor/tree-sitter/README.md
+    // §"Live-editing tolerance".
     function_body: $ => seq(
       ':',
-      $._indent,
-      repeat($.contract_clause),
-      repeat1($._statement),
-      $._dedent,
+      optional(seq(
+        $._indent,
+        repeat($.contract_clause),
+        repeat1($._statement),
+        $._dedent,
+      )),
     ),
 
     contract_clause: $ => choice(
@@ -490,39 +498,60 @@ export default grammar({
       $.case_statement,
     ),
 
-    if_statement: $ => seq(
+    // Live-editing tolerance (#1623): the consequence / alt_consequence /
+    // alternative blocks are optional so that partial input (`if cond:` or
+    // `else if other:` or `else:` typed but body not yet started) produces
+    // a complete `if_statement` named node, allowing indents.scm
+    // `@indent.begin` captures to fire. The trailing `:` after the final
+    // `else` is also optional so that `else` typed on its own line is
+    // absorbed into the `if_statement` and the existing
+    // `(if_statement "else" @indent.branch)` capture in indents.scm
+    // dedents to the parent `if`'s column. The Ry compiler enforces a
+    // non-empty body at compile time. See editor/tree-sitter/README.md
+    // §"Live-editing tolerance".
+    // prec.right resolves the ambiguity introduced by relaxing the trailing
+    // `else` to allow `:` to be missing: when the parser sees `else if`, it
+    // could either continue this if_statement's else-if chain OR end this
+    // if_statement (with bare `else`) and start a new top-level `if`.
+    // Right-precedence biases toward continuing the chain, which is the
+    // expected interpretation.
+    if_statement: $ => prec.right(seq(
       'if',
       field('condition', $._expression),
       ':',
-      field('consequence', $.block),
+      optional(field('consequence', $.block)),
       repeat(seq(
         'else',
         'if',
         field('alt_condition', $._expression),
         ':',
-        field('alt_consequence', $.block),
+        optional(field('alt_consequence', $.block)),
       )),
       optional(seq(
         'else',
-        ':',
-        field('alternative', $.block),
+        optional(seq(
+          ':',
+          optional(field('alternative', $.block)),
+        )),
       )),
-    ),
+    )),
 
+    // Live-editing tolerance (#1623): see if_statement note above.
     while_statement: $ => seq(
       'while',
       field('condition', $._expression),
       ':',
-      field('body', $.block),
+      optional(field('body', $.block)),
     ),
 
+    // Live-editing tolerance (#1623): see if_statement note above.
     for_statement: $ => seq(
       'for',
       field('target', $._for_target),
       'in',
       field('iter', $._expression),
       ':',
-      field('body', $.block),
+      optional(field('body', $.block)),
     ),
 
     _for_target: $ => choice(
@@ -541,21 +570,29 @@ export default grammar({
       $.case_cond_statement,
     ),
 
+    // Live-editing tolerance (#1623): the INDENT arm list is optional so
+    // that `case x:` typed alone produces a complete case_match_statement
+    // named node. See editor/tree-sitter/README.md §"Live-editing tolerance".
     case_match_statement: $ => prec.dynamic(2, seq(
       'case',
       field('scrutinee', $._expression),
       ':',
-      $._indent,
-      repeat1($.case_arm),
-      $._dedent,
+      optional(seq(
+        $._indent,
+        repeat1($.case_arm),
+        $._dedent,
+      )),
     )),
 
+    // Live-editing tolerance (#1623): see case_match_statement note above.
     case_cond_statement: $ => prec.dynamic(2, seq(
       'case',
       ':',
-      $._indent,
-      repeat1($.case_cond_arm),
-      $._dedent,
+      optional(seq(
+        $._indent,
+        repeat1($.case_cond_arm),
+        $._dedent,
+      )),
     )),
 
     case_arm: $ => seq(


### PR DESCRIPTION
## Summary

- Wrap the body of `function_body`, `if_statement`, `while_statement`, `for_statement`, `case_match_statement`, `case_cond_statement` in `optional(...)` so partial input (`fn foo():` typed but body not yet started) produces a complete named node instead of `(ERROR)`. This is what allows `indents.scm` `@indent.begin` captures to fire in Neovim 0.12 + nvim-treesitter rewrite, fixing the cursor-stays-at-column-0 regression after `<CR>`.
- Trailing `else` of `if_statement` additionally allows its `:` to be missing so that bare `else` typed on its own line is absorbed into the surrounding `if_statement` and the existing `(if_statement "else" @indent.branch)` capture dedents to the parent `if`'s column. The introduced ambiguity with `else if` (continue the chain vs. end the statement and start a new top-level `if`) is resolved by wrapping `if_statement` in `prec.right(...)`.
- `case_arm` / `case_cond_arm` are intentionally **not** relaxed because the next-arm condition can begin with `(`, creating a parser ambiguity with an inline body; the outer `case_*_statement` relaxation is sufficient for the primary live-editing scenario.
- Ry compiler continues to enforce non-empty bodies at compile time; the relaxation is editor-side only and intentionally diverges from `docs/grammar.ebnf` (canonical EBNF spec). New "Live-editing tolerance" section in `editor/tree-sitter/README.md` documents the table; new entries in `.claude/rules/tree-sitter-grammar-editing.md` and `.claude/skills/tree-sitter-grammar-editing/SKILL.md` capture the pattern + the trailing-clause `:` + `prec.right` workaround for future maintainers.

Closes #1623.

## Test plan

- [x] `tree-sitter parse` on 9 partial-input cases — all produce complete named nodes (no surrounding `(ERROR)`):
  - `fn foo():\n` → `function_declaration` with `function_body` child
  - `if cond:\n` / `while x:\n` / `for x in xs:\n` / `case c:\n` / `case:\n` → respective `*_statement` nodes
  - `else\n` (after a complete `if cond:\n  body\n`) → absorbed into surrounding `if_statement`
  - `else:\n` and `else if cond:\n` → same
- [x] Regression: `tree-sitter parse` on complete programs (`@native fn foo() -> Unit`, `fn foo():\n  return 1`, full `if`/`elif`/`else`) parses identically to baseline.
- [x] Deeply-nested if-else sanity check: `if a:\n  if b:\n    1\n  else if c:\n    2\nelse:\n  3\n` produces outer `if_statement(condition=a, consequence=block(inner if), alternative=block(3))`, inner `if_statement(condition=b, consequence=block(1), alt_condition=c, alt_consequence=block(2))` — `prec.right` does not cause surprise nesting.
- [x] `./editor/tree-sitter/check.sh --no-build` — full corpus baseline match: pass=136 skip=41 warn=0 fail=0.
- [ ] **Not extended this PR** — Task 8 from plan (headless Neovim live-editing acceptance test): parse-tree level confidence only; UI-level dedent confirmation is follow-up.

## Pre-commit checklist (skip log)

- Skipped §3 / §3.5 / §3.6 — tree-sitter editor grammar only; no C++ runtime source change.
- Executed §3.6.5 — `./build.sh` + `./install.sh --no-build` + `./check.sh --no-build` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live-edit indentation and dedent behavior when typing block-introducing statements (functions, if/else chains, loops, and case statements), so the editor recognizes complete blocks and handles bare `else` / `else if` scenarios during incremental typing.

* **Documentation**
  * Added guidance explaining editor-only live-editing tolerance and its differences from the canonical grammar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->