### PR TITLE
fix(codegen): suppress ~CodeGen() SEGV under macOS TSan (#1657)

### DIFF
--- a/.claude/rules/codegen-llvm-ir-conventions.md
+++ b/.claude/rules/codegen-llvm-ir-conventions.md
@@ -209,8 +209,8 @@ site owns the basic-block split. See `emitIntZeroDivGuard`
 
 ### LLVM ORC JIT intermittent crash in `~LLJIT()` / `removeResourceTracker` / `~CodeGen()` (Linux + macOS)
 
-**Source**: #1022 (2026-04-16) CI run 24507853564; #1088 (2026-04-17) macOS Darwin 25.3.0; #1043 (2026-04-17) CI runs 24547110395 + 24547575356; #1187 (2026-04-19) macOS Darwin 25.3.0 residual ~16 % rate
-**Tags**: llvm, orc, jit, ci, flaky, linux, macos, cleanup, parallel-test
+**Source**: #1022 (2026-04-16) CI run 24507853564; #1088 (2026-04-17) macOS Darwin 25.3.0; #1043 (2026-04-17) CI runs 24547110395 + 24547575356; #1187 (2026-04-19) macOS Darwin 25.3.0 residual ~16 % rate; #1657 (2026-05-09) macOS TSan `~OverloadEntry()` SEGV
+**Tags**: llvm, orc, jit, ci, flaky, linux, macos, cleanup, parallel-test, tsan
 
 **Symptom**: The Ry self-test (`ry test -p`) completes all `it` blocks
 successfully, then crashes during JIT teardown.
@@ -220,6 +220,12 @@ successfully, then crashes during JIT teardown.
   ("corrupted size vs. prev_size while consolidating"). Same root cause; different destruction order.
 - **macOS (non-ASan)**: intermittent `~40%` failure rate in parallel mode — worker subprocess
   exits with signal (`128+N`) silently; the parent counts `+1 total failures` with no red line.
+- **macOS TSan**: SEGV in `~CodeGen()` → `~unordered_map(functions_)` → `~OverloadEntry()` →
+  `unique_ptr<unordered_map<size_t, FnTypeInfo>>::reset()` calling `free()` on a garbage pointer
+  (e.g. `0x4800000001135036`). Reliably reproduced with combinatorial spec tests that populate
+  `capturedClosureInfos` (`@describe` / `@it` nested fn). ASan + UBSan are both clean on the same
+  binary, confirming this is the same ORC teardown family — TSan exposes the disturbed-heap state
+  the existing Linux `~CodeGen()` variant also lives in.
 
 On Linux (`removeResourceTracker` variant):
 ```text
@@ -247,7 +253,7 @@ just glibc's `cfree` check), it is user-code OOB/UAF — not an ORC flake. In th
 [`~CodeGen() glibc heap-check crashes`](#codegen-glibc-heap-check-crashes-are-not-destructor-bugs)
 entry in the Runtime / Memory section for the diagnostic checklist.
 
-**Fix applied** (two-step suppression — both steps are required):
+**Fix applied** (three-step suppression — all three steps are required):
 
 1. `(void)jit.release()` — guarded by `#if defined(__linux__) || defined(__APPLE__)`. Leaks the
    LLJIT so `~LLJIT()` never runs. Extended from Linux-only to macOS in #1088 (suppressed the
@@ -259,11 +265,20 @@ entry in the Runtime / Memory section for the diagnostic checklist.
    `InProcessMemoryManager::deallocate` → `WrapperFunctionCall::runWithSPSRet` hits the same
    JITLink deallocation crash. Suppressing only the `~LLJIT()` frame left the
    `removeResourceTracker` frame, causing a residual ~16 % failure rate in `ry test -p`.
+3. `(void)cg.release()` — added after `jit.release()` in the same `#if` block (#1657). `CodeGen` is
+   heap-allocated via `std::make_unique<CodeGen>(...)` in `runRySource` so its destructor can be
+   suppressed alongside `~LLJIT()`. Without this, `~CodeGen()` walks
+   `functions_ (unordered_map<string, vector<OverloadEntry>>) → ~OverloadEntry() → unique_ptr<unordered_map<size_t, FnTypeInfo>>::reset()`
+   on a heap whose state has been disturbed by JIT teardown, and intermittently calls `free()` on a
+   garbage pointer under macOS TSan. Suppressing only the LLJIT frames left this `~CodeGen()` frame
+   exposed.
 
 **Rule**: On Linux CI, trigger a re-run if this crash appears — it is pre-existing LLVM ORC
 flakiness, not a regression. The `~CodeGen()` frame variant is the same flake family as
-`removeResourceTracker`. On macOS, both workarounds together suppress the crash; if any failure
-rate reappears after the fix, the root cause is broader than these two frames and needs fresh
-investigation. Do not suppress the LLVM crash reporter or add `|| true` — a genuine double-free in
-user code would produce the same frame.
+`removeResourceTracker`. On macOS, all three workarounds together suppress the crash; if any
+failure rate reappears after the fix, the root cause is broader than these three frames and needs
+fresh investigation. **All three releases are still workarounds, not a true root-cause fix** — the
+underlying LLVM ORC / JITLink heap corruption pattern that propagates into the codegen heap is
+unidentified upstream. Do not suppress the LLVM crash reporter or add `|| true` — a genuine
+double-free in user code would produce the same frame.
 

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -171,7 +171,7 @@ cmake --preset tsan && cmake --build build-tsan && \
   TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry test -p
 ```
 
-C++ TSan テスト (`ry_tests`) は required で、`ConcurrencySpecSuite` (= `tests/spec/concurrency.test.ry` stress test) を検証する。Ry self-test (`ry test -p`) は TSan `LargeMmapAllocator` CHECK 問題 (upstream #1716) により warn-only — ローカルでも CI でも C++ テストが clean run していれば本 PR スコープでは OK とする。race が検出された場合 (C++ / self-test どちらでも) は本 PR スコープ内で修正すること。既知 race として扱って先送りしてはならない。`/tsan-known-issues` の `LargeMmapAllocator` entry を参照。#630 の audit に無い新規 race パターンを発見した場合は新規 concurrency issue を起票し、再現テストを `tests/spec/concurrency*.test.ry` に追加する。
+C++ TSan テスト (`ry_tests`) は required で、`ConcurrencySpecSuite` (= `tests/spec/concurrency.test.ry` stress test) を検証する。Ry self-test (`ry test -p`) は TSan `LargeMmapAllocator` CHECK 問題 (upstream #1716、Linux 限定) により warn-only — ローカルでも CI でも C++ テストが clean run していれば本 PR スコープでは OK とする。LLVM ORC teardown family の crash (`~LLJIT()` / `removeResourceTracker` / `~CodeGen()` / `~OverloadEntry()`) は両 OS で観測されうるが `src/jit_runner.cpp` の三段階 leak (#1187 + #1657) で suppress 済み — このパターンの再発は新規 issue として起票する。race が検出された場合 (C++ / self-test どちらでも) は本 PR スコープ内で修正すること。既知 race として扱って先送りしてはならない。`/tsan-known-issues` の `LargeMmapAllocator` entry および ORC teardown entry を参照。#630 の audit に無い新規 race パターンを発見した場合は新規 concurrency issue を起票し、再現テストを `tests/spec/concurrency*.test.ry` に追加する。
 
 ## 3.5.5. Static Analysis
 

--- a/.claude/skills/tsan-known-issues/SKILL.md
+++ b/.claude/skills/tsan-known-issues/SKILL.md
@@ -41,7 +41,41 @@ is fixed: the self-test driver aborts inside TSan's
 ry code. Pinning `ubuntu-22.04` and lowering `vm.mmap_rnd_bits=28`
 were both tried. `./build-tsan/ry_tests` (which includes
 `ConcurrencySpecSuite`) runs cleanly on the same binary, so that
-is the required gate for #630's race fixes. macOS is unaffected.
+is the required gate for #630's race fixes. macOS is unaffected
+**by this specific upstream LargeMmapAllocator CHECK** — but the
+`continue-on-error` policy also protects against the orthogonal
+LLVM ORC teardown family (see next entry), which TSan exposes on
+both OSes.
+
+---
+
+### TSan exposes LLVM ORC teardown heap corruption (`~CodeGen()` / `~OverloadEntry()` SEGV on macOS)
+
+**Source**: #1657 (2026-05-09) macOS Darwin 25.3.0
+**Tags**: tsan, sanitizer, ci, macos, llvm, orc, jit, teardown, gotcha
+
+**Rule**: A SEGV inside `~CodeGen()` → `~unordered_map(functions_)`
+→ `~OverloadEntry()` → `unique_ptr<...>::reset()` on a garbage
+pointer (e.g. `0x4800000001135036`) under TSan on macOS is **not a
+real codegen UAF** — it is the same #1187 family LLVM ORC heap
+corruption that already forces `~LLJIT()` and `removeResourceTracker`
+to leak. Suppression is now a three-step `(void)jit.release()` +
+`rtCleanup.release()` + `(void)cg.release()` block in
+`src/jit_runner.cpp`. **Why:** ASan + UBSan are clean on the same
+binary and same test, indicating the heap corruption originates in
+the JIT teardown path and only the disturbed-heap sequel shows up
+in `~CodeGen()` under TSan's stricter free-list checking. **How to
+apply:** When a TSan crash report on macOS points at `~OverloadEntry()`
+or any other `~CodeGen()` member destructor, do not start hunting
+for codegen-side `unique_ptr` ownership bugs first — first check
+whether ASan is also clean. If yes, treat as ORC teardown family
+and follow the suppression pattern in `src/jit_runner.cpp`. The
+`LargeMmapAllocator` warn-only policy above continues to protect
+against this family on Linux as well; promotion of Ry self-test
+TSan to required is gated on the upstream LLVM ORC root cause, not
+just the LargeMmapAllocator fix. See full details in
+`.claude/rules/codegen-llvm-ir-conventions.md` "LLVM ORC JIT
+intermittent crash" entry.
 
 ---
 

--- a/changelog.d/1657-tsan-overload-entry-segv.md
+++ b/changelog.d/1657-tsan-overload-entry-segv.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- TSan no longer SEGVs on macOS during `~CodeGen()` teardown after
+  combinatorial spec tests that nest `@describe` / `@it` (e.g.
+  `tests/spec/combinatorial/collection_element_option_iterate.test.ry`).
+  Previously `~CodeGen()` walked
+  `functions_ → vector<OverloadEntry> → ~OverloadEntry() → unique_ptr<unordered_map<size_t, FnTypeInfo>>::reset()`
+  on a heap whose state had already been disturbed by LLVM ORC JIT
+  teardown, and intermittently called `free()` on a garbage pointer
+  (e.g. `0x4800000001135036`). ASan + UBSan were both clean on the
+  same binary and test, confirming this was the same #1187 family
+  ORC teardown heap corruption — TSan exposed the disturbed-heap
+  sequel that the existing `(void)jit.release()` + `rtCleanup.release()`
+  block did not cover. `runRySource` (`src/jit_runner.cpp`) now
+  heap-allocates `CodeGen` via `std::make_unique<CodeGen>(...)` and
+  leaks it via `(void)cg.release()` alongside the existing LLJIT
+  releases under `#if defined(__linux__) || defined(__APPLE__)`. The
+  process exits immediately after `runRySource` returns, so the leak
+  is bounded by process lifetime. This is still a workaround — the
+  upstream LLVM ORC / JITLink heap corruption pattern that propagates
+  into the codegen heap is unidentified — but it suppresses the
+  `~CodeGen()` / `~OverloadEntry()` SEGV reliably under TSan, ASan,
+  UBSan, and default builds. (#1657)

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -157,15 +157,22 @@ int runRySource(const std::string &src, const std::string &source_name,
     }
 
     // CodeGen -> ThreadSafeModule
+    //
+    // CodeGen is heap-allocated (not stack) so its destructor can be
+    // suppressed alongside ~LLJIT() in the #1187 family workaround at the
+    // bottom of this function.  Without this, the ~CodeGen() frame walks
+    // its functions_ map -> vector<OverloadEntry> -> unique_ptr<...>::reset()
+    // chain on a heap whose state has been disturbed by JIT teardown, and
+    // crashes intermittently under TSan on macOS (#1657).
     int coverage_offset = cs ? cs->file_id_offset : 0;
     if (ry::traceEnabled())
         ry::emitTraceEvent("codegen.start", "compile", &sourceLoc,
                            {ry::TraceField("file", source_name)});
-    CodeGen cg(test_mode, &sm, coverage_mode, coverage_offset, outline_mode);
-    cg.setTestingIntrinsicsImported(loader.importedTestingIntrinsics());
+    auto cg = std::make_unique<CodeGen>(test_mode, &sm, coverage_mode, coverage_offset, outline_mode);
+    cg->setTestingIntrinsicsImported(loader.importedTestingIntrinsics());
     ThreadSafeModule tsm = [&]() {
         try {
-            auto module = cg.compile(prog);
+            auto module = cg->compile(prog);
             if (ry::traceEnabled())
                 ry::emitTraceEvent("codegen.done", "compile", &sourceLoc,
                                    {ry::TraceField("file", source_name)});
@@ -179,7 +186,7 @@ int runRySource(const std::string &src, const std::string &source_name,
     // Must precede the emit_llvm_ir early return below to avoid swallowing warnings.
     {
         std::vector<std::string> seen;
-        for (const auto &w : cg.getWarnings()) {
+        for (const auto &w : cg->getWarnings()) {
             if (std::find(seen.begin(), seen.end(), w) == seen.end()) {
                 seen.push_back(w);
                 errs() << w << "\n";
@@ -226,7 +233,7 @@ int runRySource(const std::string &src, const std::string &source_name,
         // argv0 may be a bare name (e.g. "ry" from PATH), so resolve it first.
         std::string resolvedExe = ry::self_update::detail::get_executable_path();
         if (resolvedExe.empty()) resolvedExe = argv0;
-        auto requiredLibs = cg.getRequiredLibraries();
+        auto requiredLibs = cg->getRequiredLibraries();
         for (const auto &libName : requiredLibs) {
             auto libPath = ry::find_native_library(resolvedExe, libName);
             if (libPath.empty()) {
@@ -422,6 +429,19 @@ int runRySource(const std::string &src, const std::string &source_name,
     // invocation leak is bounded by the process lifetime.
     // TODO(#742): Investigate root cause; fix or file upstream LLVM bug.
     (void)jit.release(); // NOLINT(bugprone-unused-return-value)
+
+    // Also leak the CodeGen.  Its destructor walks
+    //   functions_ (unordered_map<string, vector<OverloadEntry>>)
+    //     -> ~OverloadEntry()
+    //       -> unique_ptr<unordered_map<size_t, FnTypeInfo>>::reset()
+    // and on macOS under TSan that reset() intermittently calls free() on a
+    // garbage pointer (e.g. 0x4800000001135036) — symptom of the same #1187
+    // family heap corruption that already forces ~LLJIT() to leak above.
+    // Suppressing only ~LLJIT() leaves ~CodeGen() running on the disturbed
+    // heap; combined leak is the canonical workaround until the LLVM ORC /
+    // TSan upstream root cause is identified (#1657).  This is still a
+    // workaround, not a true root cause fix.
+    (void)cg.release(); // NOLINT(bugprone-unused-return-value)
 #endif
 
     return result > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

- Heap-allocate `CodeGen` via `std::make_unique` in `runRySource` and add `(void)cg.release()` to the existing `#1187`-family suppression block in `src/jit_runner.cpp`.
- This extends the macOS / Linux suppression from a two-step (`(void)jit.release()` + `rtCleanup.release()`) to a three-step leak, covering the `~CodeGen()` destructor frame that the existing block did not protect.
- Closes #1657.

## Why

`~CodeGen()` walks `functions_ (unordered_map<string, vector<OverloadEntry>>) → ~OverloadEntry() → unique_ptr<unordered_map<size_t, FnTypeInfo>>::reset()` on a heap whose state has already been disturbed by LLJIT teardown. Under TSan on macOS this intermittently calls `free()` on a garbage pointer (e.g. `0x4800000001135036`).

Triangulation:

- **TSan**: SEGV reproduces on `tests/spec/combinatorial/collection_element_option_iterate.test.ry` and similar `@describe`/`@it` nested-fn tests that populate `capturedClosureInfos`.
- **ASan + UBSan**: clean on the same binary and same test → not a codegen UAF.
- **Conclusion**: the same `#1187` family ORC teardown heap corruption that already forces `~LLJIT()` + `removeResourceTracker` to leak. TSan's stricter free-list checking exposed the disturbed-heap sequel in `~CodeGen()` that the existing two-step suppression did not cover.

## Workaround disclaimer

This is a workaround, **not** a true root-cause fix. The upstream LLVM ORC / JITLink heap corruption pattern that propagates into the codegen heap is unidentified. The process exits immediately after `runRySource` returns, so the leak is bounded by process lifetime. Promotion of Ry self-test TSan (`./build-tsan/ry test -p`) to required CI is gated on the upstream ORC root cause, not just this suppression.

## Knowledge base updates

- `.claude/rules/codegen-llvm-ir-conventions.md` — extended the existing "LLVM ORC JIT intermittent crash" entry with the `~CodeGen()` macOS TSan symptom and updated the suppression description from "two-step" to "three-step".
- `.claude/skills/tsan-known-issues/SKILL.md` — clarified `LargeMmapAllocator` scope ("by this specific upstream LargeMmapAllocator CHECK") and added a new entry for the ORC teardown family on TSan.
- `.claude/skills/pre-commit-checklist/SKILL.md` — §3.5 now references both `LargeMmapAllocator` (Linux) and ORC teardown (both OSes, suppressed via three-step leak).

## Test plan

- [x] `cmake --preset tsan && cmake --build build-tsan` succeeds
- [x] TSan minimum repro (combinatorial test) — 30 single-run iterations, 0/30 failures
- [x] TSan parallel-mode `./build-tsan/ry test -p` — 10 iterations, 0/10 failures
- [x] TSan `./build-tsan/ry_tests` (C++ 2142 件) — clean
- [x] ASan + UBSan `./build-asan/ry test -p` (177 files) and `./build-asan/ry_tests` (2142 件) — clean
- [x] Default `./build/ry test -p` (177 files) and `./build/ry_tests` (2142 件) — clean
- [x] clang-tidy on `src/jit_runner.cpp` — clean
- [x] cppcheck on `src/jit_runner.cpp` — clean
- [x] Skipped §3.6 — no parser/lexer/json/utf8/string change
- [x] Skipped §1 — no user-facing TSan documentation references found in `docs/` or `README.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a macOS crash that occurred during intensive testing scenarios with complex nested test structures when using Thread Sanitizer and other diagnostic tools. The issue affected all build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->