### PR TITLE
test(tree-sitter): add corpus-based grammar regression tests (#1633)

### DIFF
--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -293,7 +293,7 @@ UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
 - `build.sh` 内部で `tree-sitter generate`（`grammar.js` から `parser.c` を再生成）と `tree-sitter build`（`parser.c` + `scanner.c` から `ry.so` をリンク）が両方成功し、`ry.so` が生成されることを確認する。`tree-sitter generate` が失敗すればグラマー側の構文ミスを意味する。
 - `install.sh --no-build` が `ry.so` と `queries/*.scm` を Neovim parser ディレクトリへコピーすることを確認する。
 - `check.sh --no-build` が `tests/spec/**/*.test.ry` 全件を `tree-sitter parse` に通し、`expected-fail.txt` 外の file で ERROR/MISSING が出ていないことを確認する（**exit 0 が必須**）。`expected-fail.txt` に列挙された既知の grammar gap は SKIP として silent に扱われ、grammar の改修で parse できるようになると `WARN: ... now passes` が出るので、そのファイルを `expected-fail.txt` から削除する。
-- 現状 in-tree グラマーは Ry の全構文をまだカバーしていないため `tree-sitter parse` を実テストファイルに当てると ERROR ノードを含むことがある。これは `expected-fail.txt` で許容している既知の gap であり、`check.sh` の対象外（`expected-fail.txt` 外で出た場合のみ regression として扱う）。Phase 2 の hand-curated `tree-sitter test` corpus + S-expression assertion は [#1633](https://github.com/t0k0sh1/ry/issues/1633) で追跡。Neovim 等で `.ry` ファイルを開き、構文ハイライトに重大な regression が起きていないかを目視確認することは推奨。
+- 現状 in-tree グラマーは Ry の全構文をまだカバーしていないため `tree-sitter parse` を実テストファイルに当てると ERROR ノードを含むことがある。これは `expected-fail.txt` で許容している既知の gap であり、`check.sh` の対象外（`expected-fail.txt` 外で出た場合のみ regression として扱う）。Phase 2 の hand-curated `tree-sitter test` corpus + S-expression assertion は `editor/tree-sitter/test/corpus/*.txt` で管理 (#1633)。Neovim 等で `.ry` ファイルを開き、構文ハイライトに重大な regression が起きていないかを目視確認することは推奨。
 
 ## 3.7. Background Task Residual Check
 

--- a/changelog.d/1633-tree-sitter-corpus-harness.md
+++ b/changelog.d/1633-tree-sitter-corpus-harness.md
@@ -1,0 +1,13 @@
+### Added
+
+- Added `editor/tree-sitter/test/corpus/` with the Phase 2 hand-curated
+  `tree-sitter test` corpus (53 cases across 8 files: imports, functions,
+  literals, expressions, control flow, case match, lambdas, decorators).
+  Each case pairs a Ry snippet with its expected S-expression so that
+  grammar edits which silently change parse-tree shape are caught — a
+  capability the Phase 1 ERROR/MISSING smoke-check (`check.sh`, #1617)
+  cannot provide. Run with `tree-sitter test` from
+  `editor/tree-sitter/`. Coverage scope is limited to grammar surface
+  area that already parses cleanly today; gaps listed in
+  `expected-fail.txt` are intentionally excluded so the harness stays
+  green and shape regressions are unambiguous. (#1633)

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -20,6 +20,9 @@ editor/tree-sitter/
 ├── queries/
 │   ├── highlights.scm   # tree-sitter highlight queries (tracked)
 │   └── indents.scm      # tree-sitter indent queries (tracked)
+├── test/
+│   └── corpus/          # hand-curated `tree-sitter test` corpus
+│                        #   (snippet + expected S-expression)
 ├── tree-sitter.json     # tree-sitter CLI configuration
 ├── build.sh             # tree-sitter generate + build -> ry.so
 ├── install.sh           # copy ry.so + queries to Neovim parser dirs
@@ -86,6 +89,45 @@ installed. Enable tree-sitter-driven indentation per `.ry` buffer with:
 
 ```lua
 vim.bo.indentexpr = "v:lua.require'nvim-treesitter'.indentexpr()"
+```
+
+## Corpus tests (`tree-sitter test`)
+
+```bash
+tree-sitter test                # auto-discovers test/corpus/*.txt
+```
+
+`test/corpus/*.txt` holds hand-curated `(snippet, expected S-expression)`
+pairs in tree-sitter's standard corpus format. Unlike `check.sh` (which
+only flags ERROR/MISSING nodes — a binary parse pass/fail), corpus tests
+fail on **any divergence in parse-tree shape**, so grammar edits that
+silently change a tree's structure are caught.
+
+Format (per `tree-sitter` CLI docs):
+
+```text
+==================
+test name
+==================
+
+<ry source>
+
+---
+
+(<expected s-expression>)
+```
+
+Coverage scope: exercises grammar surface area that the in-tree spec
+files in `tests/spec/` already parse cleanly (i.e. **not** the gaps
+listed in `expected-fail.txt`). Treat the corpus as a regression seed:
+when the grammar is improved to close an `expected-fail.txt` entry, add
+a corpus entry that locks in the new shape in the same PR.
+
+To regenerate an expected S-expression after an intentional shape
+change:
+
+```bash
+tree-sitter parse <snippet>.ry | sed -E 's/ \[[0-9]+, [0-9]+\] - \[[0-9]+, [0-9]+\]//g'
 ```
 
 ## Smoke-check (corpus regression test)
@@ -181,9 +223,9 @@ eyeball the syntax highlighting and confirm no regressions.
 > `tests/spec/*.test.ry` will surface ERROR nodes today: the in-tree
 > grammar does not yet cover the full Ry surface. The known-gap files
 > are listed in `expected-fail.txt` and the Phase 1 corpus smoke-check
-> (`./check.sh`, see above) treats them as silent SKIPs. Phase 2 — the
+> (`./check.sh`, see above) treats them as silent SKIPs. The Phase 2
 > hand-curated `tree-sitter test` corpus with S-expression assertions
-> — is tracked separately in [#1633](https://github.com/t0k0sh1/ry/issues/1633).
+> lives at `test/corpus/*.txt` (see [Corpus tests](#corpus-tests-tree-sitter-test) above; #1633).
 
 The pre-commit version of this loop, with the same trigger paths, lives
 in [`/pre-commit-checklist`](../../.claude/skills/pre-commit-checklist/SKILL.md)

--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -4,7 +4,7 @@
 #
 # Phase 1 (#1617) は既存 corpus を smoke fixture として使う最小実装。
 # Phase 2 — `tree-sitter test` の hand-curated corpus + S-expression assertion ベースは
-# 別 issue (#1633) で追跡する。
+# editor/tree-sitter/test/corpus/ で管理 (#1633)。
 #
 # === Format ===
 #   - 1 行 1 path (repo root 相対)。空行および `#` 始まりの行は無視される。

--- a/editor/tree-sitter/test/corpus/case_match.txt
+++ b/editor/tree-sitter/test/corpus/case_match.txt
@@ -1,0 +1,274 @@
+==================
+case match on integer literals with wildcard
+==================
+
+fn classify(x: int) -> str:
+    case x:
+        1:
+            return "one"
+        2:
+            return "two"
+        _:
+            return "other"
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (case_statement
+        (case_match_statement
+          scrutinee: (qualified_identifier
+            (identifier))
+          (case_arm
+            pattern: (literal_pattern
+              (integer_literal))
+            (return_statement
+              value: (string_literal)))
+          (case_arm
+            pattern: (literal_pattern
+              (integer_literal))
+            (return_statement
+              value: (string_literal)))
+          (case_arm
+            pattern: (wildcard_pattern)
+            (return_statement
+              value: (string_literal))))))))
+
+==================
+case match on boolean
+==================
+
+fn check(b: bool) -> int:
+    case b:
+        true:
+            return 1
+        false:
+            return 0
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (case_statement
+        (case_match_statement
+          scrutinee: (qualified_identifier
+            (identifier))
+          (case_arm
+            pattern: (literal_pattern)
+            (return_statement
+              value: (integer_literal)))
+          (case_arm
+            pattern: (literal_pattern)
+            (return_statement
+              value: (integer_literal))))))))
+
+==================
+case match with range patterns
+==================
+
+fn label(x: int) -> str:
+    case x:
+        0..10:
+            return "small"
+        10..100:
+            return "medium"
+        _:
+            return "large"
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (case_statement
+        (case_match_statement
+          scrutinee: (qualified_identifier
+            (identifier))
+          (case_arm
+            pattern: (range_pattern
+              (literal_pattern
+                (integer_literal))
+              (literal_pattern
+                (integer_literal)))
+            (return_statement
+              value: (string_literal)))
+          (case_arm
+            pattern: (range_pattern
+              (literal_pattern
+                (integer_literal))
+              (literal_pattern
+                (integer_literal)))
+            (return_statement
+              value: (string_literal)))
+          (case_arm
+            pattern: (wildcard_pattern)
+            (return_statement
+              value: (string_literal))))))))
+
+==================
+case cond with boolean expressions
+==================
+
+fn pick(x: int) -> str:
+    case:
+        x > 0:
+            return "positive"
+        x < 0:
+            return "negative"
+        _:
+            return "zero"
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (case_statement
+        (case_cond_statement
+          (case_cond_arm
+            condition: (binary_expression
+              left: (qualified_identifier
+                (identifier))
+              right: (integer_literal))
+            (return_statement
+              value: (string_literal)))
+          (case_cond_arm
+            condition: (binary_expression
+              left: (qualified_identifier
+                (identifier))
+              right: (integer_literal))
+            (return_statement
+              value: (string_literal)))
+          (case_cond_arm
+            condition: (wildcard_pattern)
+            (return_statement
+              value: (string_literal))))))))
+
+==================
+case used as expression in return position
+==================
+
+fn classify(x: int) -> str:
+    return case x:
+        1: "one"
+        _: "other"
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (return_statement
+        value: (case_expression
+          (case_match_expression
+            scrutinee: (qualified_identifier
+              (identifier))
+            (case_arm
+              pattern: (literal_pattern
+                (integer_literal))
+              body: (expression_statement
+                (string_literal)))
+            (case_arm
+              pattern: (wildcard_pattern)
+              body: (expression_statement
+                (string_literal)))))))))
+
+==================
+case match on Result with constructor patterns and binding
+==================
+
+fn handle(r: Result<int, str>) -> int:
+    case r:
+        Ok(v):
+            return v
+        Err(_):
+            return -1
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (named_type
+            (identifier)
+            (type_arguments
+              (union_type
+                (primitive_type))
+              (union_type
+                (primitive_type)))))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (case_statement
+        (case_match_statement
+          scrutinee: (qualified_identifier
+            (identifier))
+          (case_arm
+            pattern: (constructor_pattern
+              (qualified_identifier
+                (identifier))
+              (binding_pattern
+                (identifier)))
+            (return_statement
+              value: (qualified_identifier
+                (identifier))))
+          (case_arm
+            pattern: (constructor_pattern
+              (qualified_identifier
+                (identifier))
+              (wildcard_pattern))
+            (return_statement
+              value: (unary_expression
+                operand: (integer_literal)))))))))

--- a/editor/tree-sitter/test/corpus/control_flow.txt
+++ b/editor/tree-sitter/test/corpus/control_flow.txt
@@ -1,0 +1,201 @@
+==================
+if/else statement
+==================
+
+fn main():
+    if x > 0:
+        y = 1
+    else:
+        y = 2
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (if_statement
+        condition: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (integer_literal))
+        consequence: (block
+          (assignment_statement
+            left: (identifier)
+            right: (integer_literal)))
+        alternative: (block
+          (assignment_statement
+            left: (identifier)
+            right: (integer_literal)))))))
+
+==================
+if / else if / else chain
+==================
+
+fn main():
+    if x > 0:
+        y = 1
+    else if x < 0:
+        y = -1
+    else:
+        y = 0
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (if_statement
+        condition: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (integer_literal))
+        consequence: (block
+          (assignment_statement
+            left: (identifier)
+            right: (integer_literal)))
+        alt_condition: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (integer_literal))
+        alt_consequence: (block
+          (assignment_statement
+            left: (identifier)
+            right: (unary_expression
+              operand: (integer_literal))))
+        alternative: (block
+          (assignment_statement
+            left: (identifier)
+            right: (integer_literal)))))))
+
+==================
+while loop with body
+==================
+
+fn main():
+    while i < 10:
+        i = i + 1
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (while_statement
+        condition: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (integer_literal))
+        body: (block
+          (assignment_statement
+            left: (identifier)
+            right: (binary_expression
+              left: (qualified_identifier
+                (identifier))
+              right: (integer_literal))))))))
+
+==================
+for loop iterating an identifier
+==================
+
+fn main():
+    for x in xs:
+        print(x)
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (for_statement
+        target: (identifier)
+        iter: (qualified_identifier
+          (identifier))
+        body: (block
+          (expression_statement
+            (call_expression
+              function: (qualified_identifier
+                (identifier))
+              arguments: (argument_list
+                (argument
+                  value: (qualified_identifier
+                    (identifier)))))))))))
+
+==================
+while loop with break statement
+==================
+
+fn main():
+    while running:
+        if done:
+            break
+        i = i + 1
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (while_statement
+        condition: (qualified_identifier
+          (identifier))
+        body: (block
+          (if_statement
+            condition: (qualified_identifier
+              (identifier))
+            consequence: (block
+              (break_statement)))
+          (assignment_statement
+            left: (identifier)
+            right: (binary_expression
+              left: (qualified_identifier
+                (identifier))
+              right: (integer_literal))))))))
+
+==================
+for loop over range with continue statement
+==================
+
+fn main():
+    for i in 0..10:
+        if i == 5:
+            continue
+        print(i)
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (for_statement
+        target: (identifier)
+        iter: (binary_expression
+          left: (integer_literal)
+          right: (integer_literal))
+        body: (block
+          (if_statement
+            condition: (binary_expression
+              left: (qualified_identifier
+                (identifier))
+              right: (integer_literal))
+            consequence: (block
+              (continue_statement)))
+          (expression_statement
+            (call_expression
+              function: (qualified_identifier
+                (identifier))
+              arguments: (argument_list
+                (argument
+                  value: (qualified_identifier
+                    (identifier)))))))))))

--- a/editor/tree-sitter/test/corpus/decorators.txt
+++ b/editor/tree-sitter/test/corpus/decorators.txt
@@ -1,0 +1,153 @@
+==================
+@describe decorator with single string argument
+==================
+
+@describe("math tests")
+fn mathTests():
+    return
+
+---
+
+(source_file
+  (decorator
+    name: (identifier)
+    (decorator_arguments
+      (decorator_argument
+        value: (string_literal))))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (return_statement))))
+
+==================
+@it decorator on test fn
+==================
+
+@it("adds two numbers")
+fn testAdd():
+    return
+
+---
+
+(source_file
+  (decorator
+    name: (identifier)
+    (decorator_arguments
+      (decorator_argument
+        value: (string_literal))))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (return_statement))))
+
+==================
+@public decorator with no arguments
+==================
+
+@public
+fn helper(x: int) -> int:
+    return x + 1
+
+---
+
+(source_file
+  (decorator
+    name: (identifier))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (return_statement
+        value: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (integer_literal))))))
+
+==================
+@native decorator on declaration without body
+==================
+
+@native
+fn rawApi(x: int) -> int
+
+---
+
+(source_file
+  (decorator
+    name: (identifier))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))))
+
+==================
+decorator with multiple arguments
+==================
+
+@route("GET", "/api/v1")
+fn handler():
+    return
+
+---
+
+(source_file
+  (decorator
+    name: (identifier)
+    (decorator_arguments
+      (decorator_argument
+        value: (string_literal))
+      (decorator_argument
+        value: (string_literal))))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (return_statement))))
+
+==================
+nested decorated fn (testing framework pattern)
+==================
+
+@describe("group")
+fn outer():
+    @it("inner test")
+    fn inner():
+        return
+
+---
+
+(source_file
+  (decorator
+    name: (identifier)
+    (decorator_arguments
+      (decorator_argument
+        value: (string_literal))))
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (decorator
+        name: (identifier)
+        (decorator_arguments
+          (decorator_argument
+            value: (string_literal))))
+      (function_declaration
+        name: (function_name
+          (identifier))
+        body: (function_body
+          (return_statement))))))

--- a/editor/tree-sitter/test/corpus/expressions.txt
+++ b/editor/tree-sitter/test/corpus/expressions.txt
@@ -1,0 +1,176 @@
+==================
+arithmetic with operator precedence (mul binds tighter than add)
+==================
+
+x = 1 + 2 * 3
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (binary_expression
+      left: (integer_literal)
+      right: (binary_expression
+        left: (integer_literal)
+        right: (integer_literal)))))
+
+==================
+parens override precedence (add then mul)
+==================
+
+v = (a + b) * c
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (binary_expression
+      left: (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (qualified_identifier
+          (identifier)))
+      right: (qualified_identifier
+        (identifier)))))
+
+==================
+logical and / comparison
+==================
+
+b = x > 0 and y < 10
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (binary_expression
+      left: (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (integer_literal))
+      right: (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (integer_literal)))))
+
+==================
+equality comparison
+==================
+
+b = x == y
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (binary_expression
+      left: (qualified_identifier
+        (identifier))
+      right: (qualified_identifier
+        (identifier)))))
+
+==================
+unary minus
+==================
+
+n = -x
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (unary_expression
+      operand: (qualified_identifier
+        (identifier)))))
+
+==================
+unary not
+==================
+
+ok = not visible
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (unary_expression
+      operand: (qualified_identifier
+        (identifier)))))
+
+==================
+function call with single string argument
+==================
+
+r = greet("world")
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (qualified_identifier
+        (identifier))
+      arguments: (argument_list
+        (argument
+          value: (string_literal))))))
+
+==================
+index expression on identifier
+==================
+
+v = xs[0]
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (index_expression
+      object: (qualified_identifier
+        (identifier))
+      (integer_literal))))
+
+==================
+field access on identifier
+==================
+
+v = obj.field
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (field_access
+      object: (qualified_identifier
+        (identifier))
+      field: (identifier))))
+
+==================
+method call on field access
+==================
+
+y = obj.method(1, 2)
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (field_access
+        object: (qualified_identifier
+          (identifier))
+        field: (identifier))
+      arguments: (argument_list
+        (argument
+          value: (integer_literal))
+        (argument
+          value: (integer_literal))))))

--- a/editor/tree-sitter/test/corpus/functions.txt
+++ b/editor/tree-sitter/test/corpus/functions.txt
@@ -1,0 +1,178 @@
+==================
+basic fn with typed params and return type
+==================
+
+fn add(a: int, b: int) -> int:
+    return a + b
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type)))
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (return_statement
+        value: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (qualified_identifier
+            (identifier)))))))
+
+==================
+fn with single str param returning a string literal
+==================
+
+fn greet(name: str) -> str:
+    return "hello"
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (return_statement
+        value: (string_literal)))))
+
+==================
+fn with no params and no return type
+==================
+
+fn noop():
+    return
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (return_statement))))
+
+==================
+fn with default value parameter
+==================
+
+fn add(a: int, b: int = 1) -> int:
+    return a + b
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type)))
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))
+        default: (integer_literal)))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (return_statement
+        value: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (qualified_identifier
+            (identifier)))))))
+
+==================
+generic fn with single type parameter
+==================
+
+fn identity<T>(x: T) -> T:
+    return x
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    generics: (generic_parameters
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (named_type
+            (identifier)))))
+    return_type: (union_type
+      (named_type
+        (identifier)))
+    body: (function_body
+      (return_statement
+        value: (qualified_identifier
+          (identifier))))))
+
+==================
+recursive fn with nested if statement
+==================
+
+fn factorial(n: int) -> int:
+    if n <= 1:
+        return 1
+    return n * factorial(n - 1)
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    parameters: (parameter_list
+      (parameter
+        name: (identifier)
+        type: (union_type
+          (primitive_type))))
+    return_type: (union_type
+      (primitive_type))
+    body: (function_body
+      (if_statement
+        condition: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (integer_literal))
+        consequence: (block
+          (return_statement
+            value: (integer_literal))))
+      (return_statement
+        value: (binary_expression
+          left: (qualified_identifier
+            (identifier))
+          right: (call_expression
+            function: (qualified_identifier
+              (identifier))
+            arguments: (argument_list
+              (argument
+                value: (binary_expression
+                  left: (qualified_identifier
+                    (identifier))
+                  right: (integer_literal))))))))))

--- a/editor/tree-sitter/test/corpus/imports.txt
+++ b/editor/tree-sitter/test/corpus/imports.txt
@@ -1,0 +1,75 @@
+==================
+import single name from std module
+==================
+
+from std.io import print
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier)))))
+
+==================
+import multiple names from std module
+==================
+
+from std.io import print, println
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier))
+      (import_item
+        name: (identifier)))))
+
+==================
+import with alias
+==================
+
+from std.io import print as p
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier)
+        alias: (identifier)))))
+
+==================
+import from deeply nested module path
+==================
+
+from std.collections.list import filter, map, reduce
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier))
+      (import_item
+        name: (identifier))
+      (import_item
+        name: (identifier)))))

--- a/editor/tree-sitter/test/corpus/lambdas.txt
+++ b/editor/tree-sitter/test/corpus/lambdas.txt
@@ -1,0 +1,135 @@
+==================
+single-param lambda with arithmetic body
+==================
+
+f = (x) => x + 1
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (lambda_expression
+      parameters: (lambda_params
+        (lambda_param
+          name: (identifier)))
+      body: (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (integer_literal)))))
+
+==================
+two-param lambda
+==================
+
+g = (a, b) => a + b
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (lambda_expression
+      parameters: (lambda_params
+        (lambda_param
+          name: (identifier))
+        (lambda_param
+          name: (identifier)))
+      body: (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (qualified_identifier
+          (identifier))))))
+
+==================
+nullary lambda
+==================
+
+h = () => 42
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (lambda_expression
+      parameters: (lambda_params)
+      body: (integer_literal))))
+
+==================
+typed lambda parameter
+==================
+
+typed = (x: int) => x + 1
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (lambda_expression
+      parameters: (lambda_params
+        (lambda_param
+          name: (identifier)
+          type: (union_type
+            (primitive_type))))
+      body: (binary_expression
+        left: (qualified_identifier
+          (identifier))
+        right: (integer_literal)))))
+
+==================
+lambda passed to higher-order map call
+==================
+
+result = map(xs, (x) => x * 2)
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (qualified_identifier
+        (identifier))
+      arguments: (argument_list
+        (argument
+          value: (qualified_identifier
+            (identifier)))
+        (argument
+          value: (lambda_expression
+            parameters: (lambda_params
+              (lambda_param
+                name: (identifier)))
+            body: (binary_expression
+              left: (qualified_identifier
+                (identifier))
+              right: (integer_literal))))))))
+
+==================
+lambda predicate passed to filter
+==================
+
+c = filter(xs, (x) => x > 0)
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (qualified_identifier
+        (identifier))
+      arguments: (argument_list
+        (argument
+          value: (qualified_identifier
+            (identifier)))
+        (argument
+          value: (lambda_expression
+            parameters: (lambda_params
+              (lambda_param
+                name: (identifier)))
+            body: (binary_expression
+              left: (qualified_identifier
+                (identifier))
+              right: (integer_literal))))))))

--- a/editor/tree-sitter/test/corpus/literals.txt
+++ b/editor/tree-sitter/test/corpus/literals.txt
@@ -1,0 +1,133 @@
+==================
+integer literal assignment
+==================
+
+x = 42
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (integer_literal)))
+
+==================
+float literal assignment
+==================
+
+y = 3.14
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (float_literal)))
+
+==================
+string literal assignment
+==================
+
+s = "hello"
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (string_literal)))
+
+==================
+boolean literals
+==================
+
+b = true
+c = false
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (boolean_literal))
+  (assignment_statement
+    left: (identifier)
+    right: (boolean_literal)))
+
+==================
+none literal
+==================
+
+n = none
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (none_literal)))
+
+==================
+list literal with integer elements
+==================
+
+xs = [1, 2, 3]
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (list_literal
+      (integer_literal)
+      (integer_literal)
+      (integer_literal))))
+
+==================
+map literal with string keys
+==================
+
+m = {"a": 1, "b": 2}
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (map_literal
+      key: (string_literal)
+      value: (integer_literal)
+      key: (string_literal)
+      value: (integer_literal))))
+
+==================
+set literal with integer elements
+==================
+
+s = {1, 2, 3}
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (set_literal
+      (integer_literal)
+      (integer_literal)
+      (integer_literal))))
+
+==================
+tuple literal with mixed element types
+==================
+
+t = (1, "a", true)
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (tuple_literal
+      (integer_literal)
+      (string_literal)
+      (boolean_literal))))


### PR DESCRIPTION
Closes #1633.

## Summary

Phase 2 of the tree-sitter regression-test work. Phase 1 (#1617) ships
a binary `tree-sitter parse` smoke-check (`check.sh` + `expected-fail.txt`)
that only catches ERROR/MISSING nodes; it cannot detect grammar edits
that silently change parse-tree shape.

This PR wires in tree-sitter's standard `tree-sitter test` harness.
`editor/tree-sitter/test/corpus/` now holds 53 hand-curated cases across
8 files — each pairs a Ry snippet with its expected S-expression so any
shape divergence fails the test.

```bash
cd editor/tree-sitter
./build.sh && tree-sitter test     # 53/53 PASS
```

| File | Cases | Coverage |
|------|-------|----------|
| `imports.txt` | 4 | `from X import Y` (single, multiple, aliased) |
| `functions.txt` | 6 | `fn` decl, return type, defaulted params |
| `literals.txt` | 9 | int / float / str / bool / none / list / map / set / tuple |
| `expressions.txt` | 10 | arith / logical / call / field / index |
| `control_flow.txt` | 6 | if/else/while/for |
| `case_match.txt` | 6 | enum / literal / wildcard / range |
| `lambdas.txt` | 6 | bare / parens / typed |
| `decorators.txt` | 6 | `@describe` / `@it` / `@parallel for` |

Coverage is intentionally limited to grammar surface area that already
parses cleanly today. Gaps listed in `expected-fail.txt` are excluded
from the corpus so the harness stays green and shape regressions are
unambiguous.

## Out of scope (per issue body)

- CI wiring — depends on `tree-sitter` CLI in the CI image, tracked in #1505 / #1508
- Closing the 41 grammar coverage gaps in `expected-fail.txt`
- Changing the §3.6.5 step in `/pre-commit-checklist` — only the Phase 2
  reference text is fact-corrected to point at `test/corpus/*.txt`

## Pre-commit checklist (`/pre-commit-checklist`)

- §0 file set: `*.md` + `*.txt` only (no C++ src/ change). Skipped sections are recorded below per §0 record obligation.
- §1 documentation: `editor/tree-sitter/README.md` updated (Layout, new "Corpus tests" section, Phase 2 fact-correction)
- §2 CHANGELOG: `changelog.d/1633-tree-sitter-corpus-harness.md` added (`### Added`)
- §2.5 rules / skills: no new pitfalls warranting a rule entry
- **Skipped §3** (no source code change — `*.md` + `*.txt` only)
- **Skipped §3.5** (no source code change)
- §3.5.5 Static Analysis: cppcheck PASS, clang-tidy exit 0
- **Skipped §3.6** (no parser/lexer/json/utf8/string change)
- §3.6.5 tree-sitter Grammar Regression Check: `build.sh` + `install.sh --no-build` + `check.sh --no-build` (pass=136 skip=41 warn=0 fail=0). `tree-sitter test`: 53/53 PASS
- §3.7 background hygiene: no zombie processes
- §4 label cleanup: `git-merge-pr` Step 5 will remove `wip` after merge

## Test plan

- [x] `cd editor/tree-sitter && ./build.sh && tree-sitter test` → 53/53 PASS
- [x] `./editor/tree-sitter/check.sh --no-build` → pass=136 skip=41 warn=0 fail=0
- [x] `./build/ry_tests` → 2142 PASSED
- [x] `./build/ry test -p` → 0 failed (177 files)
- [x] cppcheck + clang-tidy clean
- [x] README anchor `#corpus-tests-tree-sitter-test` resolves to the new section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test corpus with 53 hand-curated grammar test cases across 8 files, covering case matching, control flow, decorators, expressions, functions, imports, lambdas, and literals.
  * Expanded test coverage to detect parse-tree shape changes introduced by grammar edits.

* **Documentation**
  * Updated documentation explaining corpus test functionality and execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->