### PR TITLE
fix(codegen): propagate tuple type name in items() result (#1659)

### DIFF
--- a/changelog.d/1659-items-nested-meta.md
+++ b/changelog.d/1659-items-nested-meta.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- `items(map)` now stamps the source map's key/value type names onto
+  the returned `List<(K, V)>` as `list_elem_type_name = "(K, V)"`.
+  Before this fix, `emitCollOp_items`
+  (`src/codegen_call_collection.cpp`) stamped only the LLVM tuple
+  `TypeMeta::ListElem` slot via `setTypeMeta`, leaving
+  `list_elem_type_name` empty. The for-loop destructure
+  `for k, v in items(m):` relies on `splitTupleSig` reading that
+  name to split the tuple into per-component metadata; without it,
+  K/V components fell back to `str` and operations like `v[0]` on
+  `Map<str, List<int>>` raised `str does not support index access`
+  at codegen. The fix snapshots `map_key_type_name` /
+  `map_value_type_name` before any `getOrCreateMeta` call (per the
+  #858 name-snapshot-before-rehash discipline) and writes
+  `list_elem_type_name = "(K, V)"` after `setTypeMeta`, mirroring
+  the format used by `enumerate` and `zip`. Unlike the sibling fix
+  for `keys()` / `values()` (#1655), no `emitCowRetainArcElements`
+  is needed because the destructor for `List<(K, V)>` does not
+  recurse into tuple fields — `fieldTypeIsArcManaged` returns false
+  for tuple-syntax `list_elem_type_name`, so adding a retain would
+  leak. (#1659)

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -1049,6 +1049,15 @@ llvm::Value *CodeGen::emitCollOp_items(const CallExpr &e) {
     llvm::Type *keyTy = getMapKeyType(mapPtr);
     llvm::Type *valTy = getMapValueType(mapPtr);
     if (keyTy && valTy) {
+        // Snapshot source-map element names before any getOrCreateMeta call
+        // (which may rehash value_metadata_ and invalidate the raw pointer
+        // returned by getMeta — see #858 / keys()/values() precedent).
+        std::string keyName, valName;
+        if (auto *srcMeta = getMeta(mapPtr)) {
+            keyName = srcMeta->map_key_type_name;
+            valName = srcMeta->map_value_type_name;
+        }
+
         auto mf = loadMapHeader(mapPtr, "items");
 
         llvm::StructType *tupleTy = llvm::StructType::get(*ctx_, {keyTy, valTy});
@@ -1087,6 +1096,15 @@ llvm::Value *CodeGen::emitCollOp_items(const CallExpr &e) {
 
         storeListHeaderFields(newHeader, mf.len, mf.len, newData);
         setTypeMeta(TypeMeta::ListElem, newHeader, tupleTy);
+        // Stamp the tuple type name so downstream tuple-field access can
+        // dispatch nested index/key lookup (#1659). Mirrors enumerate / zip
+        // (codegen_call.cpp). No retain on inner ARC values: tuple
+        // list_elem_type_name "(K, V)" does not match fieldTypeIsArcManaged,
+        // so the destructor for List<(K, V)> never recurses into tuple fields
+        // (a retain here would leak).
+        if (!keyName.empty() && !valName.empty())
+            getOrCreateMeta(newHeader).list_elem_type_name =
+                "(" + keyName + ", " + valName + ")";
         return newHeader;
     }
     return nullptr;

--- a/tests/spec/collection_meta_propagation.test.ry
+++ b/tests/spec/collection_meta_propagation.test.ry
@@ -206,3 +206,46 @@ fn keysPropagatesInnerCollectionMetadata1655Tests():
       i = i + 1
     expect(ks[0][0]).toEq(1)
     expect(ks[0][2]).toEq(3)
+
+# Regression tests for #1659 — items() must populate `list_elem_type_name` on
+# the returned `List<(K, V)>` (mirroring enumerate / zip), not just the LLVM
+# tuple type slot. Pre-fix, the for-loop destructure `for k, v in items(m):`
+# strips the tuple via `splitTupleSig` then propagates per-component metadata
+# via `propagateTypeMeta` — but only if `list_elem_type_name = "(K, V)"` is
+# present on the result list. Without it, K/V components fall back to `str`
+# and codegen errors with "str does not support index access" (or analogous).
+#
+# Direct tuple field access (`its[0].1[0]`, `its[0].0["k"]`) does NOT
+# discriminate this fix in isolation because IndexExpr → propagateTypeMeta has
+# no tuple branch and FieldAccessExpr's numeric-index arm does not propagate
+# per-field metadata today (pre-existing gap, affects enumerate/zip/items
+# symmetrically — to be filed separately).
+#
+# Unlike #1655 (keys/values), no retain is needed because the destructor for
+# `List<(K, V)>` does not recurse into tuple fields — tuple
+# `list_elem_type_name` syntax does not match `fieldTypeIsArcManaged`.
+@describe("items() propagates inner-collection metadata (#1659)")
+fn itemsPropagatesInnerCollectionMetadata1659Tests():
+  @it("items on Map<str, List<int>> propagates V through for-loop destructure")
+  fn itemsOnMapStrListIntPropagatesVThroughForLoopDestructure():
+    m: Map<str, List<int>> = {"a": [1, 2, 3]}
+    s = 0
+    for k, v in items(m):
+      s = s + v[0] + v[2]
+    expect(s).toEq(4)
+
+  @it("items on Map<List<int>, str> propagates K through for-loop destructure")
+  fn itemsOnMapListIntStrPropagatesKThroughForLoopDestructure():
+    m: Map<List<int>, str> = {[1, 2]: "a", [3, 4]: "b"}
+    total = 0
+    for k, v in items(m):
+      total = total + k[0] + k[1]
+    expect(total).toEq(10)
+
+  @it("items on Map<str, Map<str, int>> propagates V map through for-loop destructure")
+  fn itemsOnMapStrMapStrIntPropagatesVMapThroughForLoopDestructure():
+    m: Map<str, Map<str, int>> = {"outer": {"k": 7}}
+    total = 0
+    for k, v in items(m):
+      total = total + v["k"]
+    expect(total).toEq(7)


### PR DESCRIPTION
## Summary

- `emitCollOp_items` (`src/codegen_call_collection.cpp`) now stamps `list_elem_type_name = "(K, V)"` on the returned `List<(K, V)>`, mirroring the format used by `enumerate` and `zip`.
- The for-loop destructure `for k, v in items(m):` relies on `splitTupleSig` reading that name to split the tuple into per-component metadata. Pre-fix, K/V components fell back to `str` and operations like `v[0]` on `Map<str, List<int>>` raised `"str does not support index access"` at codegen.
- Snapshots `map_key_type_name` / `map_value_type_name` before any `getOrCreateMeta` call (per the #858 name-snapshot-before-rehash discipline).
- Unlike the sibling fix for `keys()` / `values()` (#1655), no `emitCowRetainArcElements` is needed because the destructor for `List<(K, V)>` does not recurse into tuple fields — `fieldTypeIsArcManaged` returns false for tuple-syntax `list_elem_type_name`, so adding a retain would leak.

## Scope note

Tests verify the fix via for-loop destructure, which exercises `splitTupleSig` → `propagateTypeMeta` per component. Direct field access (`its[0].1[0]`) remains broken due to a pre-existing gap in `IndexExpr` / `FieldAccessExpr` tuple-element metadata propagation that affects `enumerate` / `zip` / `items` symmetrically. That gap is tracked separately as #1664 and is intentionally out of scope here.

Closes #1659

## Test plan

- [x] Targeted spec: `./build/ry test tests/spec/collection_meta_propagation.test.ry`
- [x] Full Ry self-test: `./build/ry test -p` (177 files clean)
- [x] C++ unit tests: `./build/ry_tests` (2142 tests clean)
- [x] ASan + UBSan run on full suite (no leak/UAF — fix adds no retain)
- [x] TSan run on `ry_tests` clean (Ry self-test warn-only per upstream LargeMmapAllocator issue)
- [x] clang-tidy / cppcheck exit 0
- [x] Empirically verified red→green: pre-fix all 3 new tests fail with `"str does not support index access"`; post-fix all 3 produce correct values (4, 10, 7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed map iteration to correctly preserve nested collection type information when unpacking key-value pairs in loops, preventing errors and enabling proper type-based operations on tuple elements.

## Tests
* Added regression tests verifying proper metadata propagation for tuple unpacking with nested collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->