### PR TITLE
fix(codegen): propagate tuple-element metadata through IndexExpr/FieldAccessExpr (#1664)

### DIFF
--- a/.claude/rules/codegen-type-and-metadata.md
+++ b/.claude/rules/codegen-type-and-metadata.md
@@ -266,6 +266,81 @@ and call `propagateTypeMeta(component[i], boundVar[i])` for each
 bound variable. Do **not** extend `propagateTypeMeta` itself to write
 to a `tuple_elem_type_names` slot — keep the helper single-purpose.
 
+### IndexExpr → FieldAccessExpr tuple metadata uses `source_type_name` as the boundary channel
+
+**Source**: #1664 (2026-05-09, implementation)
+**Tags**: codegen, metadata, tuple, IndexExpr, FieldAccessExpr, source_type_name, splitTupleSig, enumerate, zip
+
+**Context**: `enumerate(xs)` / `zip(xs, ys)` / `items(m)` produce
+`List<(K, V)>` whose header carries `list_elem_type_name = "(K, V)"`.
+Reading an element with `xs[0]` already routed through
+`propagateTypeMeta(elemTypeName, elem)` in the IndexExpr List path
+(`src/codegen_expr_literal.cpp`), but per the
+"`propagateTypeMeta` is single-value; callers decompose tuples" rule
+(see entry above), `propagateTypeMeta` deliberately ignores tuple
+sigs. Without an additional channel the loaded tuple value reached
+the FieldAccessExpr numeric-index arm with no metadata; the arm
+emitted a bare `CreateExtractValue` and the field defaulted to `str`
+dispatch — `xs[0].1[0]` then raised "str does not support index
+access" at codegen.
+
+The for-loop destructure site solves the same shape via
+`emitForBindingPattern` calling `splitTupleSig` directly and
+propagating each component to its bound variable. The expression site
+needs the same decomposition, but it cannot bind components to named
+variables — there is no destructure boundary, just a tuple SSA value
+that flows through `.0` / `.1` access.
+
+**Rule**: When a tuple is loaded from a `List<(K, V)>` (the only
+non-destructure boundary fixed by #1664), stamp the full tuple sig
+onto the loaded value via
+`getOrCreateMeta(val).source_type_name = "(K, V)"`. The downstream
+FieldAccessExpr numeric-index arm reads `source_type_name`, calls
+`splitTupleSig` to decompose, and propagates the matching component's
+name onto the extracted field. This mirrors the `Result<T, E>` /
+`Option<T>` precedent (#1638) — `source_type_name` is the lossless
+channel for type names that `propagateTypeMeta` cannot carry. Other
+tuple-producing boundaries (function returns of `(K, V)` outside a
+`List`, tuple-typed record fields, etc.) are NOT covered by #1664;
+extending this pattern to them is a future follow-up — don't assume
+they already work.
+
+**How to apply**:
+
+1. At the **stamp side** (IndexExpr List path, function return, future
+   tuple-producing boundaries), guard with
+   `elemTypeName.size() >= 2 && elemTypeName.front() == '(' &&
+   elemTypeName.back() == ')'` and stamp
+   `source_type_name = elemTypeName`. Snapshot `elemTypeName` into a
+   local `std::string` *before* calling `propagateTypeMeta` (#858
+   rehash gotcha) — already required by the existing snapshot block,
+   so reusing the local is sufficient.
+
+2. At the **decompose side** (FieldAccessExpr numeric-index arm), after
+   `CreateExtractValue`, read `getMeta(obj)->source_type_name` into a
+   local `std::string`, guard with `front() == '(' && back() == ')'`,
+   call `splitTupleSig`, and call
+   `propagateTypeMeta(components[idx], fieldVal)` when
+   `idx < components.size()` and the component name is non-empty.
+
+**Why not extend `propagateTypeMeta` itself**: Same reasoning as the
+parent rule — tuples have N downstream targets, not one. Plumbing
+N-ary metadata through a single-value helper would require either a
+`tuple_elem_type_names: std::vector<std::string>` slot (rejected at
+#820) or duplicating the splitTypeArgs logic in every call site of
+`propagateTypeMeta`. The `source_type_name` channel is already in
+`ValueMetadata` for `Result` / `Option`, so reusing it for tuple sigs
+adds no new fields.
+
+**Scope note**: `enumerate` / `zip` work end-to-end with this fix
+because their codegen sites already stamp
+`list_elem_type_name = "(int, T)"` / `"(T, U)"`
+(`src/codegen_call.cpp`). The `items(m)` case requires PR #1665
+(issue #1659) to land first — its emitter does not stamp
+`list_elem_type_name` at all. Tests for `items()` are stubbed with
+`# FIXME(#1659):` in `tests/spec/collection_meta_propagation.test.ry`
+until that PR merges.
+
 ### Enum metadata propagation: list literals of enum values need a direct check
 
 **Source**: #820 sweep (2026-04-11, implementation)

--- a/changelog.d/1664-tuple-elem-metadata-extract.md
+++ b/changelog.d/1664-tuple-elem-metadata-extract.md
@@ -1,0 +1,28 @@
+### Fixed
+
+- Numeric tuple-field access (`xs[0].1`) and chained subscripts
+  (`xs[0].1[0]`) on `List<(K, V)>` results now carry per-component
+  metadata through the extraction. Before this fix, the IndexExpr List
+  path called `propagateTypeMeta(elemTypeName, elem)` with
+  `elemTypeName = "(K, V)"`, but `propagateTypeMeta` is single-value by
+  design (per `.claude/rules/codegen-type-and-metadata.md` —
+  *"propagateTypeMeta is single-value; callers decompose tuples"*),
+  so the tuple components received no metadata. The downstream
+  FieldAccessExpr numeric-index arm then emitted a bare
+  `CreateExtractValue` that fell through to the `str` dispatch, so
+  `print(enumerate(xs)[0].1[0])` (for `xs: List<List<int>>`) raised
+  `str does not support index access` at codegen — the same shape the
+  for-loop destructure path already handled correctly via
+  `splitTupleSig` (`src/codegen_stmt_loop.cpp`). The fix stamps the
+  tuple sig onto the loaded element via the
+  `ValueMetadata::source_type_name` channel (the same lossless slot
+  used for `Result<T, E>` / `Option<T>` since #1638) at the IndexExpr
+  List path in `src/codegen_expr_literal.cpp`, then decomposes
+  per-component via `splitTupleSig` and propagates the matching
+  component's name onto the extracted field at the FieldAccessExpr
+  numeric-index arm in the same file. `enumerate(xs)` and
+  `zip(xs, ys)` work end-to-end because their codegen sites already
+  stamp `list_elem_type_name = "(int, T)"` / `"(T, U)"`. The analogous
+  `items(m)` case is tracked separately as #1659 / PR #1665 because
+  the gap there is in the `items()` emitter (it does not stamp
+  `list_elem_type_name` at all). (#1664)

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -109,7 +109,26 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e)
         auto idx = std::stoul(e->field);
         if (idx >= structTy->getNumElements())
             codegenError("tuple index " + e->field + " out of range");
-        return builder_.CreateExtractValue(obj, static_cast<unsigned>(idx), "tuple." + e->field);
+        llvm::Value *fieldVal = builder_.CreateExtractValue(
+            obj, static_cast<unsigned>(idx), "tuple." + e->field);
+        // #1664: When the tuple was loaded from List<(K, V)> (or similar),
+        // the IndexExpr List path stamps source_type_name on the loaded
+        // tuple value. Decompose per-component via splitTupleSig and
+        // propagate the matching component's name onto the extracted field
+        // so chained access like `xs[0].1[0]` carries List/Map/Set metadata
+        // through to the next subscript. Snapshot into a local std::string
+        // before propagateTypeMeta to dodge value_metadata_ rehash
+        // invalidation (#858).
+        std::string srcTupleSig;
+        if (auto *objMeta = getMeta(obj))
+            srcTupleSig = objMeta->source_type_name;
+        if (!srcTupleSig.empty() && srcTupleSig.size() >= 2 &&
+            srcTupleSig.front() == '(' && srcTupleSig.back() == ')') {
+            auto components = splitTupleSig(srcTupleSig);
+            if (idx < components.size() && !components[idx].empty())
+                propagateTypeMeta(components[idx], fieldVal);
+        }
+        return fieldVal;
     }
 
     std::string typeName = structTy->getName().str();
@@ -756,6 +775,17 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
         }
         if (!elemTypeName.empty())
             propagateTypeMeta(elemTypeName, elem);
+        // #1664: Stamp tuple sig (e.g. "(int, T)" from enumerate / zip /
+        // items) onto the loaded element via source_type_name so that
+        // FieldAccessExpr's numeric-index arm can decompose per-component
+        // metadata via splitTupleSig. propagateTypeMeta is single-value by
+        // design (see "propagateTypeMeta is single-value; callers decompose
+        // tuples"), so the decomposition must happen at the call site that
+        // owns the bound field, mirroring the for-loop destructure precedent
+        // in src/codegen_stmt_loop.cpp.
+        if (!elemTypeName.empty() && elemTypeName.size() >= 2 &&
+            elemTypeName.front() == '(' && elemTypeName.back() == ')')
+            getOrCreateMeta(elem).source_type_name = elemTypeName;
         if (elemFnTypeInfo)
             getOrCreateMeta(elem).fn_type_info = *elemFnTypeInfo;
         // List<str>: read the list_elem_is_str side-channel set by the

--- a/tests/spec/collection_meta_propagation.test.ry
+++ b/tests/spec/collection_meta_propagation.test.ry
@@ -206,3 +206,86 @@ fn keysPropagatesInnerCollectionMetadata1655Tests():
       i = i + 1
     expect(ks[0][0]).toEq(1)
     expect(ks[0][2]).toEq(3)
+
+# Regression tests for #1664 — FieldAccessExpr / IndexExpr drop tuple-element
+# metadata when accessing tuples loaded from List<(K, V)>.  enumerate(xs) and
+# zip(xs, ys) return List<(int, T)> / List<(T, U)> with list_elem_type_name
+# stamped as "(int, T)" / "(T, U)".  Pre-fix, indexing the result list
+# produced a fresh tuple SSA value with no metadata, and the FieldAccessExpr
+# numeric-index arm fell through to a bare ExtractValue.  Chained access
+# like `enumerate(xs)[0].1[0]` then treated `.1` as `str` and codegen
+# rejected the `[0]` subscript with "str does not support index access".
+#
+# The fix stamps the tuple sig onto the loaded element via
+# `source_type_name` (the IndexExpr List path), and the FieldAccessExpr
+# numeric-index arm decomposes per-component metadata via splitTupleSig.
+@describe("enumerate's tuple field carries inner-collection metadata (#1664)")
+fn enumerateTupleFieldCarriesInnerCollectionMetadata1664Tests():
+  @it("enumerate(List<List<int>>) preserves nested index access on .1")
+  fn enumerateListListIntPreservesNestedIndexAccessOnSecond():
+    xs: List<List<int>> = [[1, 2, 3], [4, 5, 6]]
+    e = enumerate(xs)
+    expect(e[0].1[0]).toEq(1)
+    expect(e[0].1[2]).toEq(3)
+    expect(e[1].1[0]).toEq(4)
+    expect(e[1].1[2]).toEq(6)
+
+  @it("enumerate(List<Map<str, int>>) preserves map key access on .1")
+  fn enumerateListMapStrIntPreservesMapKeyAccessOnSecond():
+    xs: List<Map<str, int>> = [{"a": 1, "b": 2}, {"c": 3}]
+    e = enumerate(xs)
+    expect(e[0].1["a"]).toEq(1)
+    expect(e[0].1["b"]).toEq(2)
+    expect(e[1].1["c"]).toEq(3)
+
+@describe("zip's tuple fields carry inner-collection metadata (#1664)")
+fn zipTupleFieldsCarryInnerCollectionMetadata1664Tests():
+  @it("zip(List<int>, List<List<int>>) preserves nested index access on .1")
+  fn zipListIntListListIntPreservesNestedIndexAccessOnSecond():
+    xs: List<int> = [10, 20]
+    ys: List<List<int>> = [[1, 2, 3], [4, 5, 6]]
+    z = zip(xs, ys)
+    expect(z[0].1[0]).toEq(1)
+    expect(z[0].1[2]).toEq(3)
+    expect(z[1].1[0]).toEq(4)
+    expect(z[1].1[2]).toEq(6)
+
+  @it("zip(List<List<int>>, List<List<int>>) preserves access on both .0 and .1")
+  fn zipListListIntListListIntPreservesAccessOnBothFields():
+    xs: List<List<int>> = [[1, 2, 3]]
+    ys: List<List<int>> = [[10, 20, 30]]
+    z = zip(xs, ys)
+    expect(z[0].0[0]).toEq(1)
+    expect(z[0].0[2]).toEq(3)
+    expect(z[0].1[0]).toEq(10)
+    expect(z[0].1[2]).toEq(30)
+
+  @it("zip(List<Map<str, int>>, List<int>) preserves map key access on .0")
+  fn zipListMapStrIntListIntPreservesMapKeyAccessOnFirst():
+    xs: List<Map<str, int>> = [{"k": 7}, {"k": 9}]
+    ys: List<int> = [1, 2]
+    z = zip(xs, ys)
+    expect(z[0].0["k"]).toEq(7)
+    expect(z[1].0["k"]).toEq(9)
+
+# items() returns List<(K, V)> for Map<K, V>, but at the time of #1664 the
+# items() emitter does not stamp list_elem_type_name with "(K, V)" — that
+# gap is tracked in #1659 / PR #1665.  Once that lands, enabling these
+# tests should pass with no further codegen change because the
+# IndexExpr/FieldAccessExpr decomposition added by #1664 is items()-agnostic.
+# FIXME(#1659): re-enable after PR #1665 merges.
+#  @describe("items's tuple fields carry inner-collection metadata (#1664)")
+#  fn itemsTupleFieldsCarryInnerCollectionMetadata1664Tests():
+#    @it("items(Map<str, List<int>>) preserves nested index access on .1")
+#    fn itemsMapStrListIntPreservesNestedIndexAccessOnSecond():
+#      m: Map<str, List<int>> = {"a": [1, 2, 3]}
+#      its = items(m)
+#      expect(its[0].1[0]).toEq(1)
+#      expect(its[0].1[2]).toEq(3)
+#
+#    @it("items(Map<List<int>, str>) preserves nested index access on .0")
+#    fn itemsMapListIntStrPreservesNestedIndexAccessOnFirst():
+#      m: Map<List<int>, str> = {[1, 2, 3]: "v"}
+#      its = items(m)
+#      expect(its[0].0[0]).toEq(1)
+#      expect(its[0].0[2]).toEq(3)


### PR DESCRIPTION
## Summary

Fixes #1664. Numeric tuple-field access (`xs[0].1`) and chained subscripts (`xs[0].1[0]`) on `List<(K, V)>` results from `enumerate(xs)` / `zip(xs, ys)` / `items(m)` lost per-component metadata: the IndexExpr List path called `propagateTypeMeta(elemTypeName, elem)` with `elemTypeName = "(K, V)"`, but `propagateTypeMeta` is single-value by design (per `.claude/rules/codegen-type-and-metadata.md` — *"propagateTypeMeta is single-value; callers decompose tuples"*). The downstream FieldAccessExpr numeric-index arm emitted a bare `CreateExtractValue` that fell through to `str` dispatch, raising `"str does not support index access"` at codegen for inputs like `enumerate(xs)[0].1[0]`.

The fix uses a 2-stage stamp + propagate via the existing `ValueMetadata::source_type_name` channel (the lossless slot reused since #1638 for `Result<T, E>` / `Option<T>`):

1. **`src/codegen_expr_literal.cpp`** — IndexExpr List path stamps the tuple sig (e.g. `"(int, T)"`) onto the loaded element via `getOrCreateMeta(elem).source_type_name = elemTypeName`.
2. **`src/codegen_expr_literal.cpp`** — FieldAccessExpr numeric-index arm reads `source_type_name`, calls `splitTupleSig` to decompose, and propagates the matching component's name onto the extracted field.

`enumerate` / `zip` work end-to-end because their codegen sites already stamp `list_elem_type_name = "(int, T)"` / `"(T, U)"` (`src/codegen_call.cpp`). `items(m)` works end-to-end after merging #1665 (issue #1659), which added the analogous stamp for items's emitter — both fixes together make direct field access (`its[0].1[0]`) carry per-component metadata through the chain.

The for-loop destructure path (`for k, v in items(m): print(v[0])`) was already correct via `splitTupleSig` in `src/codegen_stmt_loop.cpp`; this PR brings the expression-side path to parity at the IndexExpr / FieldAccessExpr boundary.

Adds 7 regression tests to `tests/spec/collection_meta_propagation.test.ry` covering enumerate / zip / items with nested `List<List<int>>`, `List<Map<str, int>>`, etc., and documents the `source_type_name` boundary channel as a new entry in `.claude/rules/codegen-type-and-metadata.md`.

## Test plan

- [x] `cmake --build build` clean
- [x] `./build/ry_tests` — 2142/2142 passed
- [x] `./build/ry test -p` — 177 files / 0 failures
- [x] `./build/ry test tests/spec/collection_meta_propagation.test.ry` — 25/25 passed (incl. 7 new #1664 cases + 3 #1659 cases)
- [x] ASan + UBSan clean
- [x] TSan clean
- [x] libFuzzer (parser / utf8 / json) — 20000 runs each, no crashes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed numeric tuple-field access on lists containing tuples. Tuple components accessed through operations like `enumerate()`, `zip()`, and `items()` now correctly preserve and propagate nested collection metadata, enabling chained field access.

* **Tests**
  * Added regression test coverage for tuple field access with nested collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->