### PR TITLE
test(filesystem): make per-test setup self-contained (#1607)

### DIFF
--- a/.claude/rules/tests-spec-conventions.md
+++ b/.claude/rules/tests-spec-conventions.md
@@ -26,6 +26,29 @@ case opt:
 expect(gotNone).toEq(true)
 ```
 
+### Ry has no `pass` — use `0` for no-op `case` arm bodies
+
+**Source**: #1607 (2026-05-09, implementation)
+**Tags**: testing, case, no-op, ry-syntax, coderabbit-translation
+
+**Rule**: Ry has no `pass` keyword. When a `case` arm needs a no-op body (e.g. an `Ok(_):` arm that intentionally discards the result of a verified setup call), use `0` as the canonical no-op statement.
+
+**Why**: Python-style `pass` is parsed as a bare identifier reference, producing a misleading "expected '=', '+=', ... after identifier" error pointing at the token after `pass`. CodeRabbit and other reviewers regularly suggest `pass` in Ry test snippets because their templates are language-agnostic; translating those suggestions to Ry requires substituting `0` (the convention already used in `nul_safety_io.test.ry`, `nul_safety_filesystem.test.ry`, etc.).
+
+```ry
+# ❌ Parser error — pass is not a Ry keyword
+case mkdirAll(parent):
+  Ok(_): pass                         # ← "expected '=' ... after identifier"
+  Err(e): fail("setup failed: " + e.message)
+
+# ✅ Use 0 as the no-op statement
+case mkdirAll(parent):
+  Ok(_): 0
+  Err(e): fail("setup failed: " + e.message)
+```
+
+**How to apply**: When porting a CodeRabbit suggestion or other external code snippet that uses `pass`, replace it with `0`. Empty body is also rejected (see the entry above), so the no-op cannot simply be omitted.
+
 ### `expect(str).toEq("literal")` is NUL-truncating — use `expect(str == "literal").toEq(true)` for NUL-containing strings
 
 **Source**: PR #1048 and #1049 (CodeRabbit review). **Tags**: testing, NUL-safety, codegen_test

--- a/tests/spec/filesystem.test.ry
+++ b/tests/spec/filesystem.test.ry
@@ -22,6 +22,11 @@ fn mkdirMkdirallTests():
   @it("should fail on existing directory")
   fn shouldFailOnExistingDirectory():
     d = "/tmp/ry_fs_test/single_dir"
+    mkdirAll("/tmp/ry_fs_test")
+    removeAll(d)
+    case mkdir(d):
+      Ok(_): 0
+      Err(e): fail("setup mkdir failed: " + e.message)
     result = mkdir(d)
     expect(result).toBeErr()
 
@@ -41,6 +46,7 @@ fn isfileIsdirIssymlinkTests():
   @it("should detect a regular file")
   fn shouldDetectARegularFile():
     f = "/tmp/ry_fs_test/test_file.txt"
+    mkdirAll("/tmp/ry_fs_test")
     case writeText(f, "hello"):
       Ok(_):
         case isFile(f):
@@ -57,6 +63,9 @@ fn isfileIsdirIssymlinkTests():
 
   @it("should detect a directory")
   fn shouldDetectADirectory():
+    case mkdirAll("/tmp/ry_fs_test"):
+      Ok(_): 0
+      Err(e): fail("setup mkdirAll failed: " + e.message)
     case isDir("/tmp/ry_fs_test"):
       Ok(v): expect(v).toBeTrue()
       Err(e): fail("isDir failed: " + e.message)
@@ -82,7 +91,7 @@ fn listdirTests():
   fn shouldListDirectoryEntries():
     d = "/tmp/ry_fs_test/listdir_test"
     removeAll(d)
-    mkdir(d)
+    mkdirAll(d)
     case join(d, "a.txt"):
       Ok(pa): writeText(pa, "a")
       Err(e): fail("join failed: " + e.message)
@@ -138,7 +147,7 @@ fn globTests():
   fn shouldMatchFilesByPattern():
     d = "/tmp/ry_fs_test/glob_test"
     removeAll(d)
-    mkdir(d)
+    mkdirAll(d)
     case join(d, "file1.log"):
       Ok(p): writeText(p, "1")
       Err(e): fail("join failed: " + e.message)
@@ -171,6 +180,7 @@ fn copyTests():
   fn shouldCopyFileContent():
     src = "/tmp/ry_fs_test/copy_src.txt"
     dst = "/tmp/ry_fs_test/copy_dst.txt"
+    mkdirAll("/tmp/ry_fs_test")
     writeText(src, "copy me")
     case copy(src, dst):
       Ok(_):
@@ -193,6 +203,7 @@ fn moveTests():
   fn shouldMoveAFile():
     src = "/tmp/ry_fs_test/move_src.txt"
     dst = "/tmp/ry_fs_test/move_dst.txt"
+    mkdirAll("/tmp/ry_fs_test")
     writeText(src, "move me")
     case move(src, dst):
       Ok(_):
@@ -210,6 +221,7 @@ fn removeRemoveallTests():
   @it("should remove a file")
   fn shouldRemoveAFile():
     f = "/tmp/ry_fs_test/remove_me.txt"
+    mkdirAll("/tmp/ry_fs_test")
     writeText(f, "bye")
     case remove(f):
       Ok(_):
@@ -220,7 +232,7 @@ fn removeRemoveallTests():
   @it("should fail to remove non-empty directory")
   fn shouldFailToRemoveNonEmptyDirectory():
     d = "/tmp/ry_fs_test/nonempty_dir"
-    mkdir(d)
+    mkdirAll(d)
     case join(d, "child.txt"):
       Ok(p): writeText(p, "x")
       Err(e): fail("join failed: " + e.message)
@@ -250,6 +262,7 @@ fn filesizeTests():
   @it("should return correct file size")
   fn shouldReturnCorrectFileSize():
     f = "/tmp/ry_fs_test/size_test.txt"
+    mkdirAll("/tmp/ry_fs_test")
     writeText(f, "12345")
     case fileSize(f):
       Ok(sz):
@@ -267,6 +280,7 @@ fn chmodTests():
   @it("should change file permissions")
   fn shouldChangeFilePermissions():
     f = "/tmp/ry_fs_test/chmod_test.txt"
+    mkdirAll("/tmp/ry_fs_test")
     writeText(f, "x")
     case chmod(f, 420):
       Ok(_):
@@ -282,6 +296,7 @@ fn symlinkReadlinkIssymlinkTests():
   fn shouldCreateAndReadASymbolicLink():
     target = "/tmp/ry_fs_test/symlink_target.txt"
     link = "/tmp/ry_fs_test/symlink_link.txt"
+    mkdirAll("/tmp/ry_fs_test")
     remove(link)
     writeText(target, "target content")
     case symlink(target, link):
@@ -303,6 +318,7 @@ fn symlinkReadlinkIssymlinkTests():
   @it("should fail readLink on non-symlink")
   fn shouldFailReadlinkOnNonSymlink():
     f = "/tmp/ry_fs_test/not_a_link.txt"
+    mkdirAll("/tmp/ry_fs_test")
     writeText(f, "x")
     result = readLink(f)
     expect(result).toBeErr()


### PR DESCRIPTION
## Summary

Refactor `tests/spec/filesystem.test.ry` so each `@it` test is runnable in isolation regardless of execution order, removing the implicit dependency on global `/tmp/ry_fs_test/` state seeded by earlier tests.

- Apply verified `case` setup (Pattern A, with `Ok(_): 0`) to the two tests named in #1607 where setup correctness is load-bearing (`shouldFailOnExistingDirectory`, `shouldDetectADirectory`).
- Apply discardable `mkdirAll` setup (Pattern B) to 11 additional tests with the same implicit-parent-dir hazard found by audit. Three of them swap `mkdir` → `mkdirAll` (idempotent and creates parent chain); eight prepend `mkdirAll("/tmp/ry_fs_test")` before `writeText` calls.
- Module-level `removeAll("/tmp/ry_fs_test")` is preserved as a pre-run guard against stale state from a crashed prior run.
- Add a knowledge entry to `.claude/rules/tests-spec-conventions.md` documenting that Ry has no `pass` keyword (`0` is the canonical no-op for `Ok(_):` arms) — this prevents future CodeRabbit suggestions of Python-style `pass` from being mis-translated to Ry.

Closes #1607

## Test plan

- [x] `./build/ry test tests/spec/filesystem.test.ry` (23/23)
- [x] `./build/ry test -p tests/spec/filesystem.test.ry` (parallel, 23/23)
- [x] `rm -rf /tmp/ry_fs_test && ./build/ry test tests/spec/filesystem.test.ry` (fresh state, no bootstrap dependency on module-level removeAll)
- [x] `./build/ry_tests` (2142/2142)
- [x] `./build/ry test -p` (full Ry self-test suite, 177 files / 0 failures)
- [x] ASan + UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p` clean
- [x] TSan: `./build-tsan/ry_tests` and `./build-tsan/ry test -p` clean
- [x] clang-tidy / cppcheck clean

## Pre-commit checklist skip notes

- Skipped §1 — internal test refactor, no user-visible change
- Skipped §2 — test-only refactor, no user-visible change (CHANGELOG fragment not required)
- Skipped §3.6 — no parser/lexer/json/utf8/string change (libFuzzer not required)
- Skipped §3.6.5 — no tree-sitter grammar change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test setup for filesystem operations to ensure proper directory initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->