### PR TITLE
fix(codegen): retain/release tuple-element ARC components symmetrically (#1667)

### DIFF
--- a/.claude/rules/codegen-arc-cow.md
+++ b/.claude/rules/codegen-arc-cow.md
@@ -799,3 +799,45 @@ The retain discipline is **symmetric** with the destructor:
 
 ---
 
+### Tuple-element collections need symmetric retain/release on tuple components, dispatched locally (not via `fieldTypeIsArcManaged`)
+
+**Source**: #1667 (2026-05-09). **Tags**: ARC, tuple, destructor, retain, items, enumerate, zip, slice, take, appended, concat, uaf
+
+**Rule**: For `List<(K, V)>` results returned by `items` / `enumerate` / `zip` (and any derivation thereof — `slice`, `take`, `appended`, `concat` — that propagates `list_elem_type_name = "(K, V)"` via `propagateMeta`), the collection destructor must walk the dense tuple-struct buffer and release each ARC-managed component (`str` / `List` / `Map` / `Set`), and every codegen site that produces such a result must retain those components symmetrically. Both halves land together; either alone produces a leak (no retain, no release was the pre-fix state) or a UAF (retain only) or a double-free (release only).
+
+This is a tuple-sig-keyed extension of #1242's destructor-recursion-implies-retain-on-store rule. The canonical sites:
+
+| Stage | Site | Helper |
+|---|---|---|
+| Per-component retain | `emitCollOp_items`, `enumerate`, `zip` (`InsertValue` setup) | `emitTupleComponentRetain(val, fSig)` |
+| Buffer-wide retain | `emitListSlice`, `emitCollOp_take_impl`, `emitCollOp_appended` (memcpy half), `emitListConcat` | `emitTupleElemRetainLoop(arrayPtr, len, tag, tupleSig, tupleTy)` |
+| Buffer-wide release | `getOrCreateCollectionDestructor` → `emitInnerReleaseLoop` lambda | `emitTupleElemReleaseLoop(arrayPtr, len, tag, tupleSig, tupleTy)` |
+
+**Why not extend `fieldTypeIsArcManaged`**: Making `fieldTypeIsArcManaged("(K, V)")` return `true` would short-circuit ~30 callers (`elementTypeIsArcManaged`, `emitCowRetainArcElements`, `emitListSlice`, `emitCollOp_take_impl`, `emitCollOp_appended`, `emitListConcat`, `emitCowClone`, ...) into pointer-array retain/release loops. But a `List<(K, V)>` data buffer holds **inline tuple struct values** (`sizeof(StructType)` bytes per slot), not pointers — those callers would read the struct as a pointer and apply a `−16` GEP, causing memory corruption. Tuple isn't a `Kind`-level entity (no `CollectionKind::Tuple`); it's a meta-concept where each field is independently ARC-managed. So the dispatch is added **locally at each site that handles tuple-element buffers**, ahead of any `elementTypeIsArcManaged` call:
+
+```cpp
+const std::string elemSig = srcMeta ? srcMeta->list_elem_type_name : std::string{};
+const bool elemIsTuple =
+    elemSig.size() >= 2 && elemSig.front() == '(' && elemSig.back() == ')';
+if (elemIsTuple) {
+    auto *tupleTy = llvm::cast<llvm::StructType>(elemTy);
+    emitTupleElemRetainLoop(newData, count, "<tag>_telem", elemSig, tupleTy);
+} else if (elementTypeIsArcManaged(srcListPtr, CollectionKind::List, &kind)) {
+    emitCowRetainArcElements(newData, count, "<tag>_elem", kind);
+}
+```
+
+`emitTupleComponentRetain` does not call `fieldTypeIsArcManaged` either — it dispatches by the source-level type name (`"str"` → `StringHeader` offset −24, `List<...>` / `Map<...>` / `Set<...>` → `ArcHeader` offset −16) so the offset is selected from authoritative metadata, not from a heuristic that reads the value (which would conflate `str` and collection cases per the "`tryRetainArcSource` LoadInst cases must be metadata-gated" rule above).
+
+**Caching invariant**: The destructor cache key is `(CollectionKind, elemSig, valSig)`. Tuple sigs (`"(int, List<int>)"`, etc.) live in `elemSig`, so destructors for distinct tuple shapes are cached as distinct functions automatically — no manual disambiguation needed (#1046's caching rule extends transparently).
+
+**Caveat: literal-built `List<(K, V)>`**: `inferCollectionTypeName` returns empty for tuple values, so `xs: List<(int, str)> = [(1, "a")]` has `list_elem_type_name = ""`. The new destructor branch is gated on a non-empty tuple sig and so is **not dispatched** for literal-built lists — pre-fix behavior (no retain, no release) is preserved. Issue tracking the literal-path metadata gap is out of scope for #1667.
+
+**Caveat: `xs[i] = (a, b)` slot-overwrite on `List<(K, V)>`**: Post-#1667, the destructor releases inner ARC components, but the IndexAssignStmt path does not yet (i) release the overwritten tuple's components or (ii) retain the new tuple's components. This is a leak (safe direction) — UAF is not introduced because the new tuple is reachable through the overwritten slot — and is deferred to a follow-up issue.
+
+**How to apply**: When adding a new collection helper that constructs a `List<(K, V)>` (whether by tuple-aware `InsertValue` or by memcpy-then-mutate), use the dispatch pattern above. Per-component sites (single tuple insertion) call `emitTupleComponentRetain` per ARC-managed component; buffer sites (memcpy of the whole tuple-struct array) call `emitTupleElemRetainLoop`. Mirror the destructor's `emitTupleElemReleaseLoop` is automatic via metadata inheritance — but verify by writing a regression test that rebinds the source after the helper call and reads the result through a churn loop. Canonical: `tests/spec/arc_tuple_ownership.test.ry`.
+
+**Related**: #1242 (parent rule for destructor-recursion-implies-retain-on-store), #1659 (items() metadata stamping that exposed the gap), #1664 (tuple-field metadata propagation), #1204 (memcpy retain canonical), #1235 (take memcpy retain), #1046 (destructor caching).
+
+---
+

--- a/changelog.d/1667-tuple-elem-arc-ownership.md
+++ b/changelog.d/1667-tuple-elem-arc-ownership.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- `items()`, `enumerate()`, and `zip()` now correctly retain ARC-managed
+  tuple components when constructing their `List<(K, V)>` results, and
+  the collection destructor now releases inner ARC components for
+  tuple-element lists. Previously both halves were missing simultaneously,
+  so a rebind of the source container (e.g.
+  `m: Map<str, List<int>> = {"a": [1,2,3]}; its = items(m); m = {"z": [99]}`)
+  freed the inner `List<int>` while `its` still held the raw pointer,
+  producing a use-after-free on the next read. The fix lands the retain
+  and release sides symmetrically (parallel to #1242's whole-collection
+  rebind fix). The same retain symmetry is also applied to `slice`,
+  `take`, `appended`, and `concat` on tuple-element lists, since these
+  inherit the new tuple-aware destructor via `propagateMeta`. (#1667)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -269,6 +269,32 @@ public:
                                                           const std::string &elemSig = "",
                                                           const std::string &valSig = "");
 
+    // Retain a single tuple component value by its source-level type name.
+    // Dispatches str (offset −24) / List/Map/Set (offset −16) by name and
+    // is a no-op for primitives, weak refs, and unknown names. Used at
+    // tuple-construction sites (items/enumerate/zip) after the destructor
+    // was extended to release tuple fields recursively (#1667).
+    void emitTupleComponentRetain(llvm::Value *val, const std::string &fSig);
+
+    // Counted loop that retains every ARC-managed tuple component in a
+    // dense array of tuple struct values [0, len). Mirrors
+    // `emitTupleElemReleaseLoop` and is used after memcpy at slice/take/
+    // appended/concat sites that propagate `list_elem_type_name = "(...)"`
+    // metadata (#1667).
+    void emitTupleElemRetainLoop(llvm::Value *arrayPtr, llvm::Value *len,
+                                  const char *tag,
+                                  const std::string &tupleSig,
+                                  llvm::StructType *tupleTy);
+
+    // Counted loop that ARC-releases every tuple component in a dense
+    // array of tuple struct values [0, len). Called from the destructor
+    // path when `list_elem_type_name = "(...)"`. Recurses for nested
+    // tuple components (#1667).
+    void emitTupleElemReleaseLoop(llvm::Value *arrayPtr, llvm::Value *len,
+                                   const char *tag,
+                                   const std::string &tupleSig,
+                                   llvm::StructType *tupleTy);
+
     // Splits a generic type name like "List<str>" into head="List" and
     // inner=["str"].  Returns false for non-generic names (no '<').
     // Extracted from codegen_fn_generic.cpp so callers across translation

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -1058,6 +1058,13 @@ llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kin
                                      const std::string &sig) -> bool {
         if (sig.empty()) return false;
         std::string resolved = resolveTypeAlias(sig);
+        if (resolved.size() >= 2 && resolved.front() == '(' &&
+            resolved.back() == ')') {
+            auto *tupleTy = llvm::dyn_cast<llvm::StructType>(resolveType(resolved));
+            if (!tupleTy) return false;
+            emitTupleElemReleaseLoop(arrayPtr, len, tag, resolved, tupleTy);
+            return true;
+        }
         CollectionKind innerKind;
         if (!fieldTypeIsArcManaged(resolved, &innerKind)) return false;
         if (innerKind == CollectionKind::Str) return false;  // str path handled by caller
@@ -1207,6 +1214,268 @@ llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kin
     llvm::FunctionCallee callee(dtorTy, dtorFn);
     arc_destructors_cache_[cacheKey] = callee;
     return callee;
+}
+
+// ====== Tuple element ARC helpers (#1667) ======
+//
+// Tuple-element lists (`List<(K, V)>` produced by enumerate/zip/items)
+// hold an inline array of tuple struct values, NOT pointers. Per-component
+// retain/release dispatch happens by source-level type name so we never
+// route a non-ARC component through `fieldTypeIsArcManaged` (which would
+// pull in pointer-array predicates that mis-handle inline struct slots).
+
+void CodeGen::emitTupleComponentRetain(llvm::Value *val,
+                                        const std::string &fSig) {
+    if (fSig.empty() || !val) return;
+    const std::string resolved = resolveTypeAlias(fSig);
+    if (resolved.empty() || isWeakTypeName(resolved)) return;
+    if (resolved == "str") {
+        emitArcRetain(emitStrGetHeaderFromData(val), isArcAtomic(val));
+    } else if (isListTypeName(resolved) || isMapTypeName(resolved) ||
+               isSetTypeName(resolved)) {
+        emitArcRetain(emitArcGetHeaderFromData(val), isArcAtomic(val));
+    }
+    // int / bool / f64 / weak / record / unknown: no-op
+}
+
+namespace {
+// Build a counted loop over [0, len) inside `fn` that branches into
+// `bodyEmitter(iPhi)` for each iteration. The body emitter is responsible
+// for branching back to the latch (the lambda receives the latch BB so it
+// can fall through naturally). Both `pre` and `post` BBs are returned via
+// the builder cursor (post is current after the call).
+struct CountedLoopBlocks {
+    llvm::BasicBlock *body;
+    llvm::BasicBlock *latch;
+    llvm::BasicBlock *post;
+    llvm::PHINode    *iPhi;
+};
+} // anonymous
+
+static CountedLoopBlocks emitCountedLoopShell(llvm::IRBuilder<> &b,
+                                               llvm::LLVMContext &ctx,
+                                               llvm::Function *fn,
+                                               llvm::Value *len,
+                                               llvm::Type *i64Ty,
+                                               const std::string &tagPrefix) {
+    auto *hdr   = llvm::BasicBlock::Create(ctx, tagPrefix + "_hdr",   fn);
+    auto *body  = llvm::BasicBlock::Create(ctx, tagPrefix + "_body",  fn);
+    auto *latch = llvm::BasicBlock::Create(ctx, tagPrefix + "_latch", fn);
+    auto *post  = llvm::BasicBlock::Create(ctx, tagPrefix + "_post",  fn);
+
+    auto *prevBB = b.GetInsertBlock();
+    b.CreateBr(hdr);
+
+    b.SetInsertPoint(hdr);
+    auto *iPhi = b.CreatePHI(i64Ty, 2, tagPrefix + "_i");
+    iPhi->addIncoming(llvm::ConstantInt::get(i64Ty, 0), prevBB);
+    auto *done = b.CreateICmpEQ(iPhi, len, tagPrefix + "_done");
+    b.CreateCondBr(done, post, body);
+
+    b.SetInsertPoint(latch);
+    auto *iNext = b.CreateAdd(iPhi, llvm::ConstantInt::get(i64Ty, 1),
+                               tagPrefix + "_inext");
+    iPhi->addIncoming(iNext, latch);
+    b.CreateBr(hdr);
+
+    b.SetInsertPoint(body);
+    return {body, latch, post, iPhi};
+}
+
+void CodeGen::emitTupleElemReleaseLoop(llvm::Value *arrayPtr, llvm::Value *len,
+                                        const char *tag,
+                                        const std::string &tupleSig,
+                                        llvm::StructType *tupleTy) {
+    if (!arrayPtr || !len || !tupleTy) return;
+    std::vector<std::string> components = splitTupleSig(tupleSig);
+    if (components.empty()) return;
+
+    // Skip the loop entirely if no component needs ARC release.
+    bool anyArc = false;
+    for (const auto &c : components) {
+        const std::string r = resolveTypeAlias(c);
+        if (r.empty() || isWeakTypeName(r)) continue;
+        if (r == "str" || isListTypeName(r) || isMapTypeName(r) ||
+            isSetTypeName(r) ||
+            (r.size() >= 2 && r.front() == '(' && r.back() == ')')) {
+            anyArc = true;
+            break;
+        }
+    }
+    if (!anyArc) return;
+
+    llvm::Function *fn = builder_.GetInsertBlock()->getParent();
+    std::string tagPrefix = std::string("dtor_tup_") + tag;
+    auto loop = emitCountedLoopShell(builder_, *ctx_, fn, len, i64Ty_,
+                                       tagPrefix);
+
+    // body: GEP into the i'th tuple slot, then release each component.
+    auto *slotPtr = builder_.CreateGEP(tupleTy, arrayPtr, {loop.iPhi},
+                                         tagPrefix + "_slot");
+    const unsigned n = static_cast<unsigned>(
+        std::min<size_t>(components.size(), tupleTy->getNumElements()));
+    for (unsigned i = 0; i < n; ++i) {
+        const std::string fSig = resolveTypeAlias(components[i]);
+        if (fSig.empty() || isWeakTypeName(fSig)) continue;
+
+        const bool isStr  = (fSig == "str");
+        const bool isColl = isListTypeName(fSig) || isMapTypeName(fSig) ||
+                            isSetTypeName(fSig);
+        const bool isTup  = (fSig.size() >= 2 && fSig.front() == '(' &&
+                              fSig.back() == ')');
+        if (!isStr && !isColl && !isTup) continue;
+
+        auto *fieldGEP = builder_.CreateStructGEP(tupleTy, slotPtr, i,
+            tagPrefix + "_f" + std::to_string(i));
+
+        if (isTup) {
+            // Recursive tuple component: load nothing (inline struct), recurse
+            // with the field's own StructType.
+            auto *nestedTy = llvm::dyn_cast<llvm::StructType>(
+                tupleTy->getElementType(i));
+            if (!nestedTy) continue;
+            // Treat a single nested tuple slot as a 1-element array.
+            llvm::Value *one = llvm::ConstantInt::get(i64Ty_, 1);
+            std::string subTag = std::string(tag) + "_n" + std::to_string(i);
+            emitTupleElemReleaseLoop(fieldGEP, one, subTag.c_str(), fSig,
+                                       nestedTy);
+            continue;
+        }
+
+        // ARC pointer component (str / List / Map / Set): load, null-guard,
+        // release with the appropriate header offset.
+        auto *val = builder_.CreateLoad(ptrTy_, fieldGEP,
+            tagPrefix + "_v" + std::to_string(i));
+        auto *nullBB = llvm::BasicBlock::Create(*ctx_,
+            tagPrefix + "_skip" + std::to_string(i), fn);
+        auto *relBB  = llvm::BasicBlock::Create(*ctx_,
+            tagPrefix + "_rel"  + std::to_string(i), fn);
+        auto *isNull = builder_.CreateICmpEQ(val,
+            llvm::ConstantPointerNull::get(
+                llvm::cast<llvm::PointerType>(ptrTy_)),
+            tagPrefix + "_isnull" + std::to_string(i));
+        builder_.CreateCondBr(isNull, nullBB, relBB);
+
+        builder_.SetInsertPoint(relBB);
+        if (isStr) {
+            emitArcRelease(emitStrGetHeaderFromData(val),
+                            /*atomic=*/false, {}, nullptr);
+        } else {
+            // Resolve inner destructor for nested collection.
+            std::string head;
+            std::vector<std::string> innerArgs;
+            CollectionKind innerKind = CollectionKind::List;
+            std::string innerElemSig, innerValSig;
+            if (isListTypeName(fSig)) innerKind = CollectionKind::List;
+            else if (isMapTypeName(fSig)) innerKind = CollectionKind::Map;
+            else if (isSetTypeName(fSig)) innerKind = CollectionKind::Set;
+            if (splitGenericTypeName(fSig, head, innerArgs)) {
+                if ((innerKind == CollectionKind::List ||
+                     innerKind == CollectionKind::Set) &&
+                    !innerArgs.empty()) {
+                    innerElemSig = resolveTypeAlias(innerArgs[0]);
+                } else if (innerKind == CollectionKind::Map &&
+                            innerArgs.size() >= 2) {
+                    innerElemSig = resolveTypeAlias(innerArgs[0]);
+                    innerValSig  = resolveTypeAlias(innerArgs[1]);
+                }
+            }
+            auto innerDtor = getOrCreateCollectionDestructor(
+                innerKind, innerElemSig, innerValSig);
+            emitArcRelease(emitArcGetHeaderFromData(val),
+                            /*atomic=*/false, innerDtor, nullptr);
+        }
+        // emitArcRelease leaves cursor in its own done BB.
+        builder_.CreateBr(nullBB);
+
+        builder_.SetInsertPoint(nullBB);
+    }
+
+    // After all components, branch to the loop latch.
+    builder_.CreateBr(loop.latch);
+    builder_.SetInsertPoint(loop.post);
+}
+
+void CodeGen::emitTupleElemRetainLoop(llvm::Value *arrayPtr, llvm::Value *len,
+                                       const char *tag,
+                                       const std::string &tupleSig,
+                                       llvm::StructType *tupleTy) {
+    if (!arrayPtr || !len || !tupleTy) return;
+    std::vector<std::string> components = splitTupleSig(tupleSig);
+    if (components.empty()) return;
+
+    bool anyArc = false;
+    for (const auto &c : components) {
+        const std::string r = resolveTypeAlias(c);
+        if (r.empty() || isWeakTypeName(r)) continue;
+        if (r == "str" || isListTypeName(r) || isMapTypeName(r) ||
+            isSetTypeName(r) ||
+            (r.size() >= 2 && r.front() == '(' && r.back() == ')')) {
+            anyArc = true;
+            break;
+        }
+    }
+    if (!anyArc) return;
+
+    llvm::Function *fn = builder_.GetInsertBlock()->getParent();
+    std::string tagPrefix = std::string("ret_tup_") + tag;
+    auto loop = emitCountedLoopShell(builder_, *ctx_, fn, len, i64Ty_,
+                                       tagPrefix);
+
+    auto *slotPtr = builder_.CreateGEP(tupleTy, arrayPtr, {loop.iPhi},
+                                         tagPrefix + "_slot");
+    const unsigned n = static_cast<unsigned>(
+        std::min<size_t>(components.size(), tupleTy->getNumElements()));
+    for (unsigned i = 0; i < n; ++i) {
+        const std::string fSig = resolveTypeAlias(components[i]);
+        if (fSig.empty() || isWeakTypeName(fSig)) continue;
+
+        const bool isStr  = (fSig == "str");
+        const bool isColl = isListTypeName(fSig) || isMapTypeName(fSig) ||
+                            isSetTypeName(fSig);
+        const bool isTup  = (fSig.size() >= 2 && fSig.front() == '(' &&
+                              fSig.back() == ')');
+        if (!isStr && !isColl && !isTup) continue;
+
+        auto *fieldGEP = builder_.CreateStructGEP(tupleTy, slotPtr, i,
+            tagPrefix + "_f" + std::to_string(i));
+
+        if (isTup) {
+            auto *nestedTy = llvm::dyn_cast<llvm::StructType>(
+                tupleTy->getElementType(i));
+            if (!nestedTy) continue;
+            llvm::Value *one = llvm::ConstantInt::get(i64Ty_, 1);
+            std::string subTag = std::string(tag) + "_n" + std::to_string(i);
+            emitTupleElemRetainLoop(fieldGEP, one, subTag.c_str(), fSig,
+                                     nestedTy);
+            continue;
+        }
+
+        auto *val = builder_.CreateLoad(ptrTy_, fieldGEP,
+            tagPrefix + "_v" + std::to_string(i));
+        auto *nullBB = llvm::BasicBlock::Create(*ctx_,
+            tagPrefix + "_skip" + std::to_string(i), fn);
+        auto *retBB  = llvm::BasicBlock::Create(*ctx_,
+            tagPrefix + "_do"   + std::to_string(i), fn);
+        auto *isNull = builder_.CreateICmpEQ(val,
+            llvm::ConstantPointerNull::get(
+                llvm::cast<llvm::PointerType>(ptrTy_)),
+            tagPrefix + "_isnull" + std::to_string(i));
+        builder_.CreateCondBr(isNull, nullBB, retBB);
+
+        builder_.SetInsertPoint(retBB);
+        if (isStr) {
+            emitArcRetain(emitStrGetHeaderFromData(val), isArcAtomic(val));
+        } else {
+            emitArcRetain(emitArcGetHeaderFromData(val), isArcAtomic(val));
+        }
+        builder_.CreateBr(nullBB);
+
+        builder_.SetInsertPoint(nullBB);
+    }
+
+    builder_.CreateBr(loop.latch);
+    builder_.SetInsertPoint(loop.post);
 }
 
 } // namespace ry

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -1234,6 +1234,22 @@ void CodeGen::emitTupleComponentRetain(llvm::Value *val,
     } else if (isListTypeName(resolved) || isMapTypeName(resolved) ||
                isSetTypeName(resolved)) {
         emitArcRetain(emitArcGetHeaderFromData(val), isArcAtomic(val));
+    } else if (resolved.size() >= 2 && resolved.front() == '(' &&
+                resolved.back() == ')') {
+        // Nested tuple component (#1667 follow-up): val is an inline struct
+        // value whose ARC children must be retained recursively, since the
+        // outer tuple destructor now recurses via emitTupleElemReleaseLoop.
+        // Skipping this would re-introduce the asymmetric leak/UAF for shapes
+        // like enumerate(List<(List<int>, int)>) or items(Map<str, (List<int>, int)>).
+        auto *tupleTy = llvm::dyn_cast<llvm::StructType>(val->getType());
+        if (!tupleTy) return;
+        auto components = splitTupleSig(resolved);
+        const unsigned n = static_cast<unsigned>(
+            std::min<size_t>(components.size(), tupleTy->getNumElements()));
+        for (unsigned i = 0; i < n; ++i) {
+            llvm::Value *subVal = builder_.CreateExtractValue(val, {i});
+            emitTupleComponentRetain(subVal, components[i]);
+        }
     }
     // int / bool / f64 / weak / record / unknown: no-op
 }

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -399,7 +399,10 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "enum_elem");
         // #1667: tuple-elem List<(int, T)> destructor now releases T per slot;
         // retain the component to keep the symmetric refcount discipline.
-        if (elem->getType() == ptrTy_)
+        // The retain helper itself recurses into nested tuple components, so
+        // T may be either a pointer type (str/List/Map/Set) or an inline
+        // tuple struct (e.g. enumerate(List<(List<int>, int)>)).
+        if (!srcElemName.empty())
             emitTupleComponentRetain(elem, srcElemName);
         llvm::Value *tupleVal = llvm::UndefValue::get(tupleTy);
         tupleVal = builder_.CreateInsertValue(tupleVal, i, 0);
@@ -476,9 +479,11 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *e2 = builder_.CreateLoad(elemTy2, ep2, "zip_e2");
         // #1667: tuple-elem List<(T1, T2)> destructor now releases each
         // component per slot; retain on store to keep refcount symmetric.
-        if (e1->getType() == ptrTy_)
+        // The retain helper recurses into nested tuple components, so T1/T2
+        // may be either a pointer type or an inline tuple struct.
+        if (!n1.empty())
             emitTupleComponentRetain(e1, n1);
-        if (e2->getType() == ptrTy_)
+        if (!n2.empty())
             emitTupleComponentRetain(e2, n2);
         llvm::Value *tupleVal = llvm::UndefValue::get(tupleTy);
         tupleVal = builder_.CreateInsertValue(tupleVal, e1, 0);

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -397,6 +397,10 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         builder_.SetInsertPoint(bodyBB);
         llvm::Value *elemPtr = builder_.CreateGEP(elemTy, srcData, {i}, "enum_ep");
         llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "enum_elem");
+        // #1667: tuple-elem List<(int, T)> destructor now releases T per slot;
+        // retain the component to keep the symmetric refcount discipline.
+        if (elem->getType() == ptrTy_)
+            emitTupleComponentRetain(elem, srcElemName);
         llvm::Value *tupleVal = llvm::UndefValue::get(tupleTy);
         tupleVal = builder_.CreateInsertValue(tupleVal, i, 0);
         tupleVal = builder_.CreateInsertValue(tupleVal, elem, 1);
@@ -470,6 +474,12 @@ llvm::Value *CodeGen::emitBuiltinQuery(const CallExpr &e) {
         llvm::Value *ep2 = builder_.CreateGEP(elemTy2, data2, {i}, "zip_ep2");
         llvm::Value *e1 = builder_.CreateLoad(elemTy1, ep1, "zip_e1");
         llvm::Value *e2 = builder_.CreateLoad(elemTy2, ep2, "zip_e2");
+        // #1667: tuple-elem List<(T1, T2)> destructor now releases each
+        // component per slot; retain on store to keep refcount symmetric.
+        if (e1->getType() == ptrTy_)
+            emitTupleComponentRetain(e1, n1);
+        if (e2->getType() == ptrTy_)
+            emitTupleComponentRetain(e2, n2);
         llvm::Value *tupleVal = llvm::UndefValue::get(tupleTy);
         tupleVal = builder_.CreateInsertValue(tupleVal, e1, 0);
         tupleVal = builder_.CreateInsertValue(tupleVal, e2, 1);

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -491,8 +491,14 @@ llvm::Value *CodeGen::emitCollOp_appended(const CallExpr &e) {
         // inherits the tuple-aware destructor, so each tuple slot's ARC
         // components need symmetric retain.
         const ValueMetadata *apdSrcMeta = getMeta(listPtr);
+        // Resolve type aliases so `type Pair = (int, List<int>)` is recognized
+        // as a tuple here (#1667 follow-up). The destructor side already runs
+        // through resolveCollectionDestructor, so without this resolution
+        // alias-backed tuple lists would skip the retain path while the
+        // destructor still releases tuple fields — reintroducing the asymmetry.
         const std::string apdElemSigSnap =
-            apdSrcMeta ? apdSrcMeta->list_elem_type_name : std::string{};
+            apdSrcMeta ? resolveTypeAlias(apdSrcMeta->list_elem_type_name)
+                        : std::string{};
         const bool apdElemIsTuple =
             apdElemSigSnap.size() >= 2 &&
             apdElemSigSnap.front() == '(' && apdElemSigSnap.back() == ')';
@@ -631,8 +637,12 @@ llvm::Value *CodeGen::emitListSlice(llvm::Value *listPtr,
     // new slice still points at (#1204).
     {
         const ValueMetadata *srcMeta = getMeta(listPtr);
+        // resolveTypeAlias so alias-backed tuple types take the tuple path
+        // (#1667 follow-up — destructor resolves aliases via
+        // resolveCollectionDestructor, retain side must mirror).
         const std::string elemSigSnap =
-            srcMeta ? srcMeta->list_elem_type_name : std::string{};
+            srcMeta ? resolveTypeAlias(srcMeta->list_elem_type_name)
+                     : std::string{};
         if (elemSigSnap.size() >= 2 && elemSigSnap.front() == '(' &&
             elemSigSnap.back() == ')') {
             // #1667: tuple-elem List<(K, V)> destructor releases inner ARC
@@ -698,8 +708,11 @@ llvm::Value *CodeGen::emitCollOp_take_impl(const CallExpr &e,
         // class as #1204 for emitListSlice).
         {
             const ValueMetadata *srcMeta = getMeta(listPtr);
+            // resolveTypeAlias so alias-backed tuple types take the tuple path
+            // (#1667 follow-up — destructor resolves aliases, retain mirrors).
             const std::string elemSigSnap =
-                srcMeta ? srcMeta->list_elem_type_name : std::string{};
+                srcMeta ? resolveTypeAlias(srcMeta->list_elem_type_name)
+                         : std::string{};
             if (elemSigSnap.size() >= 2 && elemSigSnap.front() == '(' &&
                 elemSigSnap.back() == ')') {
                 // #1667: tuple-elem propagation extends the destructor to
@@ -1152,10 +1165,12 @@ llvm::Value *CodeGen::emitCollOp_items(const CallExpr &e) {
         llvm::Value *v = builder_.CreateLoad(valTy, vp, "items_v");
         // #1667: tuple-elem List<(K, V)> destructor releases each component
         // per slot; retain on store keeps refcount symmetric (#1242 pattern,
-        // tuple-sig path).
-        if (k->getType() == ptrTy_)
+        // tuple-sig path). The retain helper recurses into nested tuple K/V
+        // (e.g. Map<str, (List<int>, int)>) so inline tuple-struct values
+        // are not skipped.
+        if (!keyName.empty())
             emitTupleComponentRetain(k, keyName);
-        if (v->getType() == ptrTy_)
+        if (!valName.empty())
             emitTupleComponentRetain(v, valName);
         llvm::Value *tuple = llvm::UndefValue::get(tupleTy);
         tuple = builder_.CreateInsertValue(tuple, k, 0);

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -486,17 +486,47 @@ llvm::Value *CodeGen::emitCollOp_appended(const CallExpr &e) {
         // The new list co-owns the memcpy'd range AND the appended value
         // with the source.  After #1242 the destructor recursively releases
         // inner ARC elements, so missing either retain would cause a UAF on
-        // rebind.  str excluded per #1266.
+        // rebind.  str excluded per #1266.  #1667: extends the same retain
+        // discipline to tuple-elem lists (List<(K, V)>) — propagateMeta
+        // inherits the tuple-aware destructor, so each tuple slot's ARC
+        // components need symmetric retain.
+        const ValueMetadata *apdSrcMeta = getMeta(listPtr);
+        const std::string apdElemSigSnap =
+            apdSrcMeta ? apdSrcMeta->list_elem_type_name : std::string{};
+        const bool apdElemIsTuple =
+            apdElemSigSnap.size() >= 2 &&
+            apdElemSigSnap.front() == '(' && apdElemSigSnap.back() == ')';
         CollectionKind apdElemArcKind = CollectionKind::List;
         const bool apdElemIsArc =
+            !apdElemIsTuple &&
             elementTypeIsArcManaged(listPtr, CollectionKind::List, &apdElemArcKind) &&
             apdElemArcKind != CollectionKind::Str;
-        if (apdElemIsArc)
+        if (apdElemIsTuple) {
+            if (auto *tupleTy = llvm::dyn_cast<llvm::StructType>(elemTy)) {
+                emitTupleElemRetainLoop(newData, lf.len, "apd_telem",
+                                         apdElemSigSnap, tupleTy);
+            }
+        } else if (apdElemIsArc) {
             emitCowRetainArcElements(newData, lf.len, "apd_elem", apdElemArcKind);
+        }
 
         llvm::Value *newElemPtr = builder_.CreateGEP(elemTy, newData, lf.len, "apd_new_ep");
-        if (apdElemIsArc)
+        if (apdElemIsTuple) {
+            // Per-component retain on the tuple value being appended.
+            std::vector<std::string> comps = splitTupleSig(apdElemSigSnap);
+            auto *tupleTy = llvm::dyn_cast<llvm::StructType>(elemTy);
+            if (tupleTy && tupleTy->getNumElements() == comps.size()) {
+                for (unsigned i = 0; i < comps.size(); ++i) {
+                    if (tupleTy->getElementType(i) != ptrTy_) continue;
+                    llvm::Value *comp =
+                        builder_.CreateExtractValue(val, {i},
+                            "apd_tcomp_" + std::to_string(i));
+                    emitTupleComponentRetain(comp, comps[i]);
+                }
+            }
+        } else if (apdElemIsArc) {
             retainArcValue(val);
+        }
         builder_.CreateStore(val, newElemPtr);
 
         storeListHeaderFields(newHeader, newLen, newLen, newData);
@@ -599,9 +629,27 @@ llvm::Value *CodeGen::emitListSlice(llvm::Value *listPtr,
     // duplicates raw pointers without bumping refcounts; without retention,
     // releasing the source (or a dropped alias) frees the elements that the
     // new slice still points at (#1204).
-    CollectionKind elemArcKind = CollectionKind::List;
-    if (elementTypeIsArcManaged(listPtr, CollectionKind::List, &elemArcKind)) {
-        emitCowRetainArcElements(newData, count, "sl_elem", elemArcKind);
+    {
+        const ValueMetadata *srcMeta = getMeta(listPtr);
+        const std::string elemSigSnap =
+            srcMeta ? srcMeta->list_elem_type_name : std::string{};
+        if (elemSigSnap.size() >= 2 && elemSigSnap.front() == '(' &&
+            elemSigSnap.back() == ')') {
+            // #1667: tuple-elem List<(K, V)> destructor releases inner ARC
+            // tuple components, so the memcpy'd buffer must retain each
+            // component (mirrors propagateMeta-induced destructor inheritance).
+            if (auto *tupleTy = llvm::dyn_cast<llvm::StructType>(elemTy)) {
+                emitTupleElemRetainLoop(newData, count, "sl_telem",
+                                         elemSigSnap, tupleTy);
+            }
+        } else {
+            CollectionKind elemArcKind = CollectionKind::List;
+            if (elementTypeIsArcManaged(listPtr, CollectionKind::List,
+                                         &elemArcKind)) {
+                emitCowRetainArcElements(newData, count, "sl_elem",
+                                          elemArcKind);
+            }
+        }
     }
 
     storeListHeaderFields(newHeader, count, count, newData);
@@ -648,9 +696,26 @@ llvm::Value *CodeGen::emitCollOp_take_impl(const CallExpr &e,
         // retention, releasing the source (or a dropped alias) frees the
         // elements that the new prefix still points at (#1235, same defect
         // class as #1204 for emitListSlice).
-        CollectionKind elemArcKind = CollectionKind::List;
-        if (elementTypeIsArcManaged(listPtr, CollectionKind::List, &elemArcKind)) {
-            emitCowRetainArcElements(newData, clampedN, "tk_elem", elemArcKind);
+        {
+            const ValueMetadata *srcMeta = getMeta(listPtr);
+            const std::string elemSigSnap =
+                srcMeta ? srcMeta->list_elem_type_name : std::string{};
+            if (elemSigSnap.size() >= 2 && elemSigSnap.front() == '(' &&
+                elemSigSnap.back() == ')') {
+                // #1667: tuple-elem propagation extends the destructor to
+                // inner tuple components; mirror retain on the memcpy'd buf.
+                if (auto *tupleTy = llvm::dyn_cast<llvm::StructType>(elemTy)) {
+                    emitTupleElemRetainLoop(newData, clampedN, "tk_telem",
+                                             elemSigSnap, tupleTy);
+                }
+            } else {
+                CollectionKind elemArcKind = CollectionKind::List;
+                if (elementTypeIsArcManaged(listPtr, CollectionKind::List,
+                                             &elemArcKind)) {
+                    emitCowRetainArcElements(newData, clampedN, "tk_elem",
+                                              elemArcKind);
+                }
+            }
         }
 
         // Set header fields
@@ -1085,6 +1150,13 @@ llvm::Value *CodeGen::emitCollOp_items(const CallExpr &e) {
         llvm::Value *vp = builder_.CreateGEP(valTy, mf.vals, {i}, "items_vp");
         llvm::Value *k = builder_.CreateLoad(keyTy, kp, "items_k");
         llvm::Value *v = builder_.CreateLoad(valTy, vp, "items_v");
+        // #1667: tuple-elem List<(K, V)> destructor releases each component
+        // per slot; retain on store keeps refcount symmetric (#1242 pattern,
+        // tuple-sig path).
+        if (k->getType() == ptrTy_)
+            emitTupleComponentRetain(k, keyName);
+        if (v->getType() == ptrTy_)
+            emitTupleComponentRetain(v, valName);
         llvm::Value *tuple = llvm::UndefValue::get(tupleTy);
         tuple = builder_.CreateInsertValue(tuple, k, 0);
         tuple = builder_.CreateInsertValue(tuple, v, 1);
@@ -1098,10 +1170,11 @@ llvm::Value *CodeGen::emitCollOp_items(const CallExpr &e) {
         setTypeMeta(TypeMeta::ListElem, newHeader, tupleTy);
         // Stamp the tuple type name so downstream tuple-field access can
         // dispatch nested index/key lookup (#1659). Mirrors enumerate / zip
-        // (codegen_call.cpp). No retain on inner ARC values: tuple
-        // list_elem_type_name "(K, V)" does not match fieldTypeIsArcManaged,
-        // so the destructor for List<(K, V)> never recurses into tuple fields
-        // (a retain here would leak).
+        // (codegen_call.cpp). The List<(K, V)> destructor now recurses into
+        // tuple fields and releases each ARC component (#1667 — extension of
+        // #1242 to the tuple-sig path), so the per-component
+        // emitTupleComponentRetain calls above are required to keep the
+        // retain/release symmetry.
         if (!keyName.empty() && !valName.empty())
             getOrCreateMeta(newHeader).list_elem_type_name =
                 "(" + keyName + ", " + valName + ")";

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -2106,9 +2106,24 @@ llvm::Value *CodeGen::emitListConcat(llvm::Value *lhs, llvm::Value *rhs, llvm::T
     // concatenated result still points at (#1236, same defect class as #1204 /
     // #1235). lhs and rhs carry identical element-type metadata (typecheck
     // rejects mismatched operands), so querying lhs suffices for both halves.
-    CollectionKind elemArcKind = CollectionKind::List;
-    if (elementTypeIsArcManaged(lhs, CollectionKind::List, &elemArcKind)) {
-        emitCowRetainArcElements(newData, newLen, "cat_elem", elemArcKind);
+    {
+        const ValueMetadata *srcMeta = getMeta(lhs);
+        const std::string elemSigSnap =
+            srcMeta ? srcMeta->list_elem_type_name : std::string{};
+        if (elemSigSnap.size() >= 2 && elemSigSnap.front() == '(' &&
+            elemSigSnap.back() == ')') {
+            // #1667: tuple-elem List<(K, V)> destructor recurses into inner
+            // tuple components; mirror retain on the concatenated buffer.
+            if (auto *tupleTy = llvm::dyn_cast<llvm::StructType>(elemTy)) {
+                emitTupleElemRetainLoop(newData, newLen, "cat_telem",
+                                         elemSigSnap, tupleTy);
+            }
+        } else {
+            CollectionKind elemArcKind = CollectionKind::List;
+            if (elementTypeIsArcManaged(lhs, CollectionKind::List, &elemArcKind)) {
+                emitCowRetainArcElements(newData, newLen, "cat_elem", elemArcKind);
+            }
+        }
     }
 
     storeListHeaderFields(newHeader, newLen, newLen, newData);

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -2108,8 +2108,11 @@ llvm::Value *CodeGen::emitListConcat(llvm::Value *lhs, llvm::Value *rhs, llvm::T
     // rejects mismatched operands), so querying lhs suffices for both halves.
     {
         const ValueMetadata *srcMeta = getMeta(lhs);
+        // resolveTypeAlias so alias-backed tuple types take the tuple path
+        // (#1667 follow-up — destructor resolves aliases, retain mirrors).
         const std::string elemSigSnap =
-            srcMeta ? srcMeta->list_elem_type_name : std::string{};
+            srcMeta ? resolveTypeAlias(srcMeta->list_elem_type_name)
+                     : std::string{};
         if (elemSigSnap.size() >= 2 && elemSigSnap.front() == '(' &&
             elemSigSnap.back() == ')') {
             // #1667: tuple-elem List<(K, V)> destructor recurses into inner

--- a/tests/spec/arc_tuple_ownership.test.ry
+++ b/tests/spec/arc_tuple_ownership.test.ry
@@ -1,0 +1,232 @@
+from testing import it, describe, expect
+
+from runtime_internal import arcLiveCount
+
+# Issue #1667: ARC ownership gap for tuple fields in enumerate/zip/items.
+#
+# enumerate(list) / zip(list1, list2) / items(map) all return List<(K, V)>.
+# Pre-fix, neither retain (on tuple component) nor release (in collection
+# destructor) was emitted for inner ARC values inside tuple slots.  The two
+# omissions cancelled each other (no leak, no UAF) until the source container
+# was rebound — at which point the source destructor freed the inner ARC value
+# while the result list still held the raw pointer, producing a UAF on read.
+#
+# The fix lands two halves together (parallel to #1242):
+#   1. Collection destructor recurses into tuple components for List<(K, V)>,
+#      releasing each ARC-managed component (str / List / Map / Set).
+#   2. items / enumerate / zip retain each ARC-managed tuple component before
+#      InsertValue — so that named-variable usage `its = items(m); m = {...}`
+#      keeps the inner values alive once the source destructor releases them.
+#   3. By symmetry, slice / take / appended / concat (which propagate
+#      list_elem_type_name = "(K, V)" via propagateMeta and inherit the new
+#      tuple-aware destructor) also need tuple-aware retain on their memcpy /
+#      InsertValue paths — otherwise they reintroduce a UAF on derived results.
+
+@describe("ARC tuple-field ownership: items/enumerate/zip (#1667)")
+fn arcTupleFieldOwnership1667Tests():
+  @it("items(Map<str, List<int>>) survives source rebind")
+  fn itemsMapStrListIntSurvivesSourceRebind():
+    m: Map<str, List<int>> = {"a": [1, 2, 3]}
+    its = items(m)
+    m = {"z": [99]}
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(its[0].1[0]).toEq(1)
+    expect(its[0].1[2]).toEq(3)
+
+  @it("enumerate(List<List<int>>) survives source rebind")
+  fn enumerateListListIntSurvivesSourceRebind():
+    xs: List<List<int>> = [[1, 2, 3], [4, 5, 6]]
+    e = enumerate(xs)
+    xs = [[99]]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(e[0].1[0]).toEq(1)
+    expect(e[0].1[2]).toEq(3)
+    expect(e[1].1[0]).toEq(4)
+    expect(e[1].1[2]).toEq(6)
+
+  @it("zip(List<List<int>>, List<List<int>>) survives both source rebinds")
+  fn zipListListIntListListIntSurvivesBothSourceRebinds():
+    xs: List<List<int>> = [[1, 2, 3]]
+    ys: List<List<int>> = [[10, 20, 30]]
+    z = zip(xs, ys)
+    xs = [[99]]
+    ys = [[88]]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(z[0].0[0]).toEq(1)
+    expect(z[0].0[2]).toEq(3)
+    expect(z[0].1[0]).toEq(10)
+    expect(z[0].1[2]).toEq(30)
+
+  @it("zip(List<int>, List<List<int>>) — mixed ARC dispatch survives rebind")
+  fn zipListIntListListIntMixedArcDispatchSurvivesRebind():
+    # First component (int) needs no retain; second (List<int>) does.
+    # Catches a per-component dispatch bug where retain is gated on the wrong
+    # component or applied unconditionally.
+    xs: List<int> = [10, 20]
+    ys: List<List<int>> = [[1, 2, 3], [4, 5, 6]]
+    z = zip(xs, ys)
+    ys = [[99]]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(z[0].0).toEq(10)
+    expect(z[0].1[0]).toEq(1)
+    expect(z[0].1[2]).toEq(3)
+    expect(z[1].0).toEq(20)
+    expect(z[1].1[0]).toEq(4)
+
+  @it("items(Map<str, str>) — str tuple component survives source rebind")
+  fn itemsMapStrStrStrTupleComponentSurvivesSourceRebind():
+    # Both tuple components are str (ARC header offset −24, distinct from
+    # collection offset −16). Verifies str dispatch in emitTupleComponentRetain
+    # and emitTupleElemReleaseLoop.
+    #
+    # Note: this case passes pre-fix as well — per tests-arc-leak-pattern.md
+    # ("List<str> ... UAF tests on retain paths are silently neutralized"),
+    # symmetric retain+release omission on str produces a leak (not UAF), so
+    # the churn loop alone cannot discriminate Red from Green. The str arm
+    # wiring (offset −24 via emitStrGetHeaderFromData on both retain and
+    # release sides) is verified by IR inspection of emitTupleComponentRetain
+    # (codegen_arc.cpp str branch) and emitTupleElemReleaseLoop (str isStr
+    # branch); the L<L<int>>/L<L<List<int>>> cases above are the actual
+    # discriminators for the broader retain/release symmetry.
+    m: Map<str, str> = {"key1": "value1", "key2": "value2"}
+    its = items(m)
+    m = {"z": "zz"}
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    # Sort-independent assertion: both keys must still be readable.
+    found1 = false
+    found2 = false
+    k = 0
+    while k < len(its):
+      if its[k].0 == "key1":
+        if its[k].1 == "value1":
+          found1 = true
+      if its[k].0 == "key2":
+        if its[k].1 == "value2":
+          found2 = true
+      k = k + 1
+    expect(found1).toEq(true)
+    expect(found2).toEq(true)
+
+@describe("ARC tuple-field ownership: derived collections (#1667 slice/take/appended/concat)")
+fn arcTupleFieldOwnershipDerivedCollections1667Tests():
+  @it("slice(enumerate(List<List<int>>), 1, 3) survives source rebind")
+  fn sliceEnumerateListListIntSurvivesSourceRebind():
+    # enumerate stamps list_elem_type_name = "(int, List<int>)" on the result;
+    # propagateMeta from emitListSlice inherits it, so the slice's destructor
+    # releases the inner List<int>. memcpy must therefore retain.
+    xs: List<List<int>> = [[1], [2, 2], [3, 3, 3], [4, 4, 4, 4]]
+    e = enumerate(xs)
+    s = slice(e, 1, 3)
+    xs = [[99]]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(s[0].0).toEq(1)
+    expect(s[0].1[0]).toEq(2)
+    expect(s[0].1[1]).toEq(2)
+    expect(s[1].0).toEq(2)
+    expect(s[1].1[0]).toEq(3)
+
+  @it("take(items(Map<str, List<int>>), 2) survives source rebind")
+  fn takeItemsMapStrListIntSurvivesSourceRebind():
+    # Use a single-key map so take(its, 2) deterministically picks that entry
+    # (avoids hashmap iteration-order dependence). take(its, 2) on a 1-entry
+    # list still tests the memcpy retain path because take's loop copies
+    # min(n, len) slots, exercising the tuple-aware retain branch.
+    m: Map<str, List<int>> = {"only": [1, 2, 3, 4, 5]}
+    its = items(m)
+    t = take(its, 2)
+    m = {"z": [99]}
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(len(t)).toEq(1)
+    expect(t[0].0).toEq("only")
+    expect(t[0].1[0]).toEq(1)
+    expect(t[0].1[2]).toEq(3)
+    expect(t[0].1[4]).toEq(5)
+
+  @it("appended(zip(List<int>, List<List<int>>), (99, [9, 9])) survives rebind")
+  fn appendedZipListIntListListIntSurvivesRebind():
+    xs: List<int> = [10, 20]
+    ys: List<List<int>> = [[1, 2], [3, 4]]
+    z = zip(xs, ys)
+    a: List<int> = [9, 9]
+    z2 = appended(z, (99, a))
+    xs = [99]
+    ys = [[88]]
+    a = [77]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    # Original entries (memcpy path) must hold retains.
+    expect(z2[0].0).toEq(10)
+    expect(z2[0].1[0]).toEq(1)
+    expect(z2[1].0).toEq(20)
+    expect(z2[1].1[1]).toEq(4)
+    # Newly appended tuple's component (the rebound `a`) must hold retains.
+    expect(z2[2].0).toEq(99)
+    expect(z2[2].1[0]).toEq(9)
+    expect(z2[2].1[1]).toEq(9)
+
+  @it("enumerate(...) + enumerate(...) (concat) survives both source rebinds")
+  fn enumerateConcatEnumerateSurvivesBothSourceRebinds():
+    xs: List<List<int>> = [[1, 2], [3, 4]]
+    ys: List<List<int>> = [[5, 6], [7, 8]]
+    e1 = enumerate(xs)
+    e2 = enumerate(ys)
+    cat = e1 + e2
+    xs = [[99]]
+    ys = [[88]]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(cat[0].1[0]).toEq(1)
+    expect(cat[0].1[1]).toEq(2)
+    expect(cat[1].1[1]).toEq(4)
+    expect(cat[2].1[0]).toEq(5)
+    expect(cat[3].1[1]).toEq(8)
+
+  @it("enumerate(List<List<int>>) live count grows by O(1) not O(N)")
+  fn enumerateListListIntLiveCountGrowsByO1NotON():
+    # Retain/release symmetry check.  Without retain, destructor releases
+    # without prior retain and the counter underflows (or freed-pointer is
+    # double-released).  Without release (and without retain), enumerate
+    # leaks N inner List<int> per iteration.  Only paired retain+release
+    # gives O(1) delta.
+    before = arcLiveCount()
+    xs: List<List<int>> = [[1, 2], [3, 4], [5, 6]]
+    i = 0
+    while i < 16:
+      e = enumerate(xs)
+      i = i + 1
+    delta = arcLiveCount() - before
+    expect(delta < 10).toEq(true)

--- a/tests/spec/arc_tuple_ownership.test.ry
+++ b/tests/spec/arc_tuple_ownership.test.ry
@@ -230,3 +230,31 @@ fn arcTupleFieldOwnershipDerivedCollections1667Tests():
       i = i + 1
     delta = arcLiveCount() - before
     expect(delta < 10).toEq(true)
+
+@describe("ARC tuple-field ownership: alias resolution (#1667 CodeRabbit follow-up)")
+fn arcTupleFieldOwnershipAliasResolution1667Tests():
+  @it("slice(List<Pair>, ...) — type alias is resolved before retain dispatch")
+  fn sliceListPairTypeAliasResolvedBeforeRetainDispatch():
+    # Pre-CodeRabbit-fix: emitListSlice's tuple branch checked
+    # `front == '(' && back == ')'` directly on srcMeta->list_elem_type_name,
+    # so an alias name like "Pair" failed the check and the retain was skipped.
+    # The destructor side already called resolveTypeAlias, so the asymmetry
+    # produced a UAF.  Adding resolveTypeAlias on the retain side closes the gap.
+    type Pair = (int, List<int>)
+    xs: List<Pair> = [(1, [10, 20]), (2, [30, 40]), (3, [50, 60])]
+    s = slice(xs, 0, 2)
+    xs = [(99, [99])]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    # Use for-destructure (the only form Ry tracks fully through tuple aliases
+    # for collection-typed fields; see for_loop_destructure_meta.test.ry).
+    totalKeys: int = 0
+    totalVals: int = 0
+    for k, lst in s:
+      totalKeys = totalKeys + k
+      totalVals = totalVals + sum(lst)
+    expect(totalKeys).toEq(3)        # 1 + 2
+    expect(totalVals).toEq(100)      # 10+20 + 30+40


### PR DESCRIPTION
## Summary

`items()`, `enumerate()`, and `zip()` return `List<(K, V)>` whose tuple components were neither retained on insertion nor released on the collection's destruction. The two omissions cancelled — no UAF, no leak — until the source container was rebound, at which point the source destructor freed the inner ARC value while the result list still held the raw pointer (heap-use-after-free on the next read).

Repro pre-fix:
```ry
m: Map<str, List<int>> = {"a": [1, 2, 3]}
its = items(m)
m = {"z": [99]}      # m's destructor frees the inner List<int>
its[0].1[0]          # UAF
```

Land both halves together (parallel to #1242):

- **Per-component retain** in `emitCollOp_items` / `enumerate` / `zip` via new `emitTupleComponentRetain` (str dispatched at offset −24 via `emitStrGetHeaderFromData`, List/Map/Set at −16 via `emitArcGetHeaderFromData`; weak/scalar are no-ops).
- **Tuple-aware collection destructor** via new `emitTupleElemReleaseLoop`, hooked into `emitInnerReleaseLoop` when `list_elem_type_name` is a tuple sig `"(...)"`.
- **Buffer-wide retain** on derived helpers — `slice` / `take` / `appended` / `concat` — via new `emitTupleElemRetainLoop`, dispatched ahead of `elementTypeIsArcManaged` since the tuple buffer holds inline struct values rather than pointers. Extending `fieldTypeIsArcManaged` to recognize tuples would corrupt ~30 callers that assume pointer arrays.

## Test plan

New regression file `tests/spec/arc_tuple_ownership.test.ry` (10 cases):

- [x] `items(Map<str, List<int>>)` survives source rebind (issue example)
- [x] `enumerate(List<List<int>>)` survives source rebind
- [x] `zip(List<List<int>>, List<List<int>>)` survives both source rebinds
- [x] `zip(List<int>, List<List<int>>)` mixed ARC dispatch (only second component needs retain)
- [x] `items(Map<str, str>)` — str tuple-component dispatch (offset −24); discriminator verified by IR inspection per `tests-arc-leak-pattern.md` rule
- [x] `slice(enumerate(...), 1, 3)` survives source rebind
- [x] `take(items(Map<str, List<int>>), 2)` survives source rebind
- [x] `appended(zip(...), (99, [9, 9]))` survives source rebind (covers both memcpy and single-insert tuple paths)
- [x] `enumerate(...) + enumerate(...)` (concat) survives both source rebinds
- [x] `arcLiveCount()` delta < 10 after 16 enumerate iterations (O(1), confirms retain/release symmetry)

Verification matrix:

- [x] Default (`./build/ry_tests` + `./build/ry test -p`): 2142 + 178 pass, no regression
- [x] ASan + UBSan (`./build-asan/...`): 2142 + 178 pass, no UAF / no UB
- [x] TSan (`./build-tsan/...`): 2142 + 178 pass
- [x] Pre-fix Red phase verified via `git stash`: 7/10 fail under ASan with garbage int reads (`got 27106` etc.) confirming UAF not leak
- [x] libFuzzer skipped per matrix (codegen-only change, no parser/lexer/json/utf8/string surface)

Documentation:

- [x] `.claude/rules/codegen-arc-cow.md` — new rule entry "Tuple-element collections need symmetric retain/release on tuple components, dispatched locally (not via `fieldTypeIsArcManaged`)"
- [x] `changelog.d/1667-tuple-elem-arc-ownership.md` — `### Fixed` entry

Follow-up: scope-out issue #1670 filed for `xs[i] = (a, b)` slot-overwrite leak on `List<(K, V)>` (post-fix leak in safe direction, not UAF).

Closes #1667

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automatic reference counting for tuple elements in collection operations (items(), enumerate(), zip(), slice(), take(), appended(), concat()), preventing use-after-free when rebinding source containers.

* **Tests**
  * Added comprehensive regression tests validating tuple-element ownership across collection and derived-collection scenarios, including alias-resolution cases.

* **Documentation**
  * Added changelog entry describing the tuple-element ownership fix.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1671)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->