### PR TITLE
fix(codegen): retain/release tuple components on List<(K, V)> slot overwrite (#1670)

### DIFF
--- a/.claude/rules/codegen-arc-cow.md
+++ b/.claude/rules/codegen-arc-cow.md
@@ -833,11 +833,52 @@ if (elemIsTuple) {
 
 **Caveat: literal-built `List<(K, V)>`**: `inferCollectionTypeName` returns empty for tuple values, so `xs: List<(int, str)> = [(1, "a")]` has `list_elem_type_name = ""`. The new destructor branch is gated on a non-empty tuple sig and so is **not dispatched** for literal-built lists — pre-fix behavior (no retain, no release) is preserved. Issue tracking the literal-path metadata gap is out of scope for #1667.
 
-**Caveat: `xs[i] = (a, b)` slot-overwrite on `List<(K, V)>`**: Post-#1667, the destructor releases inner ARC components, but the IndexAssignStmt path does not yet (i) release the overwritten tuple's components or (ii) retain the new tuple's components. This is a leak (safe direction) — UAF is not introduced because the new tuple is reachable through the overwritten slot — and is deferred to a follow-up issue.
+**Caveat: `xs[i] = (a, b)` slot-overwrite on `List<(K, V)>`** (resolved by #1670): Post-#1667, the destructor released inner ARC components but the IndexAssignStmt path did neither — leaking the evicted tuple's components on every overwrite. #1670 closed this gap by emitting per-component retain on the new tuple before per-component release on the old slot (retain-before-release safe for self-assignment), gated on non-empty `list_elem_type_name` with tuple shape `"(...)"`. See "IndexAssignStmt slot overwrite on `List<(K, V)>` must retain new tuple components and release old, gated on `list_elem_type_name` non-empty + tuple shape" entry below.
 
 **How to apply**: When adding a new collection helper that constructs a `List<(K, V)>` (whether by tuple-aware `InsertValue` or by memcpy-then-mutate), use the dispatch pattern above. Per-component sites (single tuple insertion) call `emitTupleComponentRetain` per ARC-managed component; buffer sites (memcpy of the whole tuple-struct array) call `emitTupleElemRetainLoop`. Mirror the destructor's `emitTupleElemReleaseLoop` is automatic via metadata inheritance — but verify by writing a regression test that rebinds the source after the helper call and reads the result through a churn loop. Canonical: `tests/spec/arc_tuple_ownership.test.ry`.
 
-**Related**: #1242 (parent rule for destructor-recursion-implies-retain-on-store), #1659 (items() metadata stamping that exposed the gap), #1664 (tuple-field metadata propagation), #1204 (memcpy retain canonical), #1235 (take memcpy retain), #1046 (destructor caching).
+**Related**: #1242 (parent rule for destructor-recursion-implies-retain-on-store), #1659 (items() metadata stamping that exposed the gap), #1664 (tuple-field metadata propagation), #1204 (memcpy retain canonical), #1235 (take memcpy retain), #1046 (destructor caching), #1670 (IndexAssignStmt slot-overwrite symmetry follow-up).
+
+---
+
+### IndexAssignStmt slot overwrite on `List<(K, V)>` must retain new tuple components and release old, gated on `list_elem_type_name` non-empty + tuple shape
+
+**Source**: #1670 (2026-05-09). **Tags**: ARC, tuple, IndexAssignStmt, slot-overwrite, retain-before-release, list_elem_type_name, traceInsertValueField
+
+**Rule**: When `IndexAssignStmt` writes a tuple value into a slot of `List<(K, V)>` (`xs[i] = (a, b)`), the codegen path must (i) retain each ARC-managed component of the *new* tuple via `emitTupleComponentRetain`, then (ii) release each ARC-managed component of the *old* slot via `emitTupleElemReleaseSlot`, then store. Order matters: retain-before-release is required for self-assignment safety (`e[i] = e[i]` would otherwise transiently drop the refcount to zero).
+
+The block is added **alongside** (not as `else if` of) the existing `if (elemIsArc)` branch in `emitStmt(IndexAssignStmt &)`'s list path — `elementTypeIsArcManaged` returns `false` for tuples by design (tuples are inline structs, not ARC-managed pointer types), so the existing branch never fires. Gate on:
+
+```cpp
+const bool elemIsTuple = elemTypeName.size() >= 2 &&
+                          elemTypeName.front() == '(' &&
+                          elemTypeName.back() == ')';
+```
+
+**Why the gate matters**: `inferCollectionTypeName` returns `""` for tuple values, so a literal-built `xs: List<(int, str)> = [(1, "a")]` has `list_elem_type_name = ""`. The destructor branch added in #1667 is also gated on non-empty tuple sig — keeping the symmetry, IndexAssignStmt also skips for empty sigs (preserving pre-fix behavior, same blind spot as `List<str>` literals). Lists produced by `enumerate` / `items` / `zip` / `slice` / `take` / `appended` / `concat` all stamp a concrete tuple sig in `list_elem_type_name`, so they hit the new branch correctly.
+
+**Trace InsertValue chains for ownership detection**: When the rhs is a freshly-constructed tuple (`InsertValue(InsertValue(undef, k, {0}), v, {1})`), `CreateExtractValue(finalVal, {i})` does NOT fold back to the original SSA value — LLVM's `IRBuilder<>` uses `ConstantFolder` by default which only folds constants, not non-constant InsertValue/ExtractValue chains. Use the `CodeGen::traceInsertValueField` helper (promoted from a static file-local in `codegen_arc.cpp` to a public `static` member in `include/ry/codegen.hpp` for #1670) to walk the chain and recover the original operand, then check `arc_owned_values_` / `arc_str_owned_values_` on the original — not on the fresh ExtractValue. This mirrors the canonical pattern in `emitRecordArcFieldsRetain` (`codegen_arc.cpp:559-562`):
+
+```cpp
+llvm::Value *checkVal = fieldVal;
+if (llvm::isa<llvm::InsertValueInst>(finalVal))
+    if (auto *orig = traceInsertValueField(finalVal, i))
+        checkVal = orig;
+if (arc_owned_values_.count(checkVal) ||
+    arc_str_owned_values_.count(checkVal))
+    continue;  // transfer semantics, no retain needed
+emitTupleComponentRetain(fieldVal, fSig);
+```
+
+Without the InsertValue trace, fresh `+1` allocations from arc_owned literals get double-retained, producing a leak proportional to the number of overwrites (the leak-delta test in `arc_tuple_index_assign.test.ry` grew by +2 per iteration before this fix).
+
+**`emitTupleElemReleaseSlot` helper**: Factored from the per-slot body of `emitTupleElemReleaseLoop` (`codegen_arc.cpp`). The single-slot helper avoids emitting 4 throwaway basic blocks (header/body/latch/post) for a single slot, and is reused by `emitTupleElemReleaseLoop`'s body. Signature: `emitTupleElemReleaseSlot(slotPtr, tag, tupleSig, tupleTy)` — slot is loaded inside, components are extracted, ARC components are released by source-level type name (str at −24, List/Map/Set at −16, nested tuples recurse).
+
+**Compound op (`+=` etc.) is N/A**: Tuples have no arithmetic operators, so the parser/typechecker rejects compound-op `IndexAssignStmt` on `List<(K, V)>` upstream of codegen — no compound-op branch is needed.
+
+**Symmetry principle**: The retain-before-release pattern at slot-overwrite sites generalizes — when a destructor recursively releases ARC components of a typed slot (not just whole-pointer ARC objects), every codegen site that writes into that slot must (i) retain new components and (ii) release evicted components in retain-before-release order. The destructor side is the source of truth; the write-side discipline is mechanical from there. Future tuple-element collection mutators (`xs.append((a, b))`, `xs.insert(i, (a, b))`) need the same per-component retain — verified by the same delta-based regression pattern.
+
+**Related**: #1667 (parent — destructor recursion + tuple-component retain on construction), #855 (whole-pointer slot overwrite release discipline — ancestor), #1242 (destructor-recursion-implies-retain-on-store), #1108 (`emitArcReleaseLoadedElement` inner-sig propagation).
 
 ---
 

--- a/.claude/rules/codegen-arc-cow.md
+++ b/.claude/rules/codegen-arc-cow.md
@@ -847,30 +847,32 @@ if (elemIsTuple) {
 
 **Rule**: When `IndexAssignStmt` writes a tuple value into a slot of `List<(K, V)>` (`xs[i] = (a, b)`), the codegen path must (i) retain each ARC-managed component of the *new* tuple via `emitTupleComponentRetain`, then (ii) release each ARC-managed component of the *old* slot via `emitTupleElemReleaseSlot`, then store. Order matters: retain-before-release is required for self-assignment safety (`e[i] = e[i]` would otherwise transiently drop the refcount to zero).
 
-The block is added **alongside** (not as `else if` of) the existing `if (elemIsArc)` branch in `emitStmt(IndexAssignStmt &)`'s list path — `elementTypeIsArcManaged` returns `false` for tuples by design (tuples are inline structs, not ARC-managed pointer types), so the existing branch never fires. Gate on:
+The block is added **alongside** (not as `else if` of) the existing `if (elemIsArc)` branch in `emitStmt(IndexAssignStmt &)`'s list path — `elementTypeIsArcManaged` returns `false` for tuples by design (tuples are inline structs, not ARC-managed pointer types), so the existing branch never fires. Gate on `resolveTypeAlias(elemTypeName)`, NOT on `elemTypeName` directly:
 
 ```cpp
-const bool elemIsTuple = elemTypeName.size() >= 2 &&
-                          elemTypeName.front() == '(' &&
-                          elemTypeName.back() == ')';
+const std::string resolvedElemTypeName = resolveTypeAlias(elemTypeName);
+const bool elemIsTuple = resolvedElemTypeName.size() >= 2 &&
+                          resolvedElemTypeName.front() == '(' &&
+                          resolvedElemTypeName.back() == ')';
 ```
 
-**Why the gate matters**: `inferCollectionTypeName` returns `""` for tuple values, so a literal-built `xs: List<(int, str)> = [(1, "a")]` has `list_elem_type_name = ""`. The destructor branch added in #1667 is also gated on non-empty tuple sig — keeping the symmetry, IndexAssignStmt also skips for empty sigs (preserving pre-fix behavior, same blind spot as `List<str>` literals). Lists produced by `enumerate` / `items` / `zip` / `slice` / `take` / `appended` / `concat` all stamp a concrete tuple sig in `list_elem_type_name`, so they hit the new branch correctly.
+**Why resolve aliases first**: User-defined type aliases like `type Pair = (int, str)` propagate the alias name (`"Pair"`) into `list_elem_type_name`, not the canonical tuple shape. A naive gate on `elemTypeName.front() == '('` would skip alias-typed lists entirely, leaking the evicted tuple's components on every overwrite. `resolveTypeAlias` walks the alias chain to its canonical form (e.g. `"Pair"` → `"(int, str)"`), so the gate matches correctly. The resolved name must also be passed to `splitTupleSig` and `emitTupleElemReleaseSlot` so component decomposition uses the canonical form.
 
-**Trace InsertValue chains for ownership detection**: When the rhs is a freshly-constructed tuple (`InsertValue(InsertValue(undef, k, {0}), v, {1})`), `CreateExtractValue(finalVal, {i})` does NOT fold back to the original SSA value — LLVM's `IRBuilder<>` uses `ConstantFolder` by default which only folds constants, not non-constant InsertValue/ExtractValue chains. Use the `CodeGen::traceInsertValueField` helper (promoted from a static file-local in `codegen_arc.cpp` to a public `static` member in `include/ry/codegen.hpp` for #1670) to walk the chain and recover the original operand, then check `arc_owned_values_` / `arc_str_owned_values_` on the original — not on the fresh ExtractValue. This mirrors the canonical pattern in `emitRecordArcFieldsRetain` (`codegen_arc.cpp:559-562`):
+**Why the non-empty gate matters**: `inferCollectionTypeName` returns `""` for tuple values, so a literal-built `xs: List<(int, str)> = [(1, "a")]` has `list_elem_type_name = ""`. The destructor branch added in #1667 is also gated on non-empty tuple sig — keeping the symmetry, IndexAssignStmt also skips for empty sigs (preserving pre-fix behavior, same blind spot as `List<str>` literals). Lists produced by `enumerate` / `items` / `zip` / `slice` / `take` / `appended` / `concat` all stamp a concrete tuple sig in `list_elem_type_name`, so they hit the new branch correctly.
+
+**Trace InsertValue chains recursively for nested tuple ownership**: When the rhs is a freshly-constructed tuple (`InsertValue(InsertValue(undef, k, {0}), v, {1})`), `CreateExtractValue(finalVal, {i})` does NOT fold back to the original SSA value — LLVM's `IRBuilder<>` uses `ConstantFolder` by default which only folds constants, not non-constant InsertValue/ExtractValue chains. A single-step `traceInsertValueField` is **insufficient for nested tuple shapes** like `xs[i] = (0, ([1], 2))`: the trace recovers the inner InsertValue (the nested tuple `([1], 2)`), not the leaf `[1]`. The leaf-level ownership check (`arc_owned_values_.count(...)`) then misses, and the redundant retain leaks the inner allocation by +N per overwrite (post-#1667 the destructor releases each leaf once on overwrite, so the asymmetry shows up as a leak proportional to iteration count — `delta = +2` per iteration in the `nestedTupleSlotOverwriteNoLeak` test on the pre-recursive version).
+
+The fix is `emitTupleComponentRetainTraced(fieldVal, sourceAgg, topIdx, fSig)` (`codegen_arc.cpp` for #1670), which (a) traces `sourceAgg` at `topIdx` to find the original operand, (b) if `fSig` resolves to a tuple shape `"(...)"`, recurses over each sub-component using the **traced sub-aggregate** (not the outer `sourceAgg`) as the new source so the recursion can keep tracing into deeper levels, and (c) at leaves checks `arc_owned_values_` / `arc_str_owned_values_` on the traced value before falling through to `emitTupleComponentRetain`. The `IndexAssignStmt` callsite is one line per top-level component:
 
 ```cpp
-llvm::Value *checkVal = fieldVal;
-if (llvm::isa<llvm::InsertValueInst>(finalVal))
-    if (auto *orig = traceInsertValueField(finalVal, i))
-        checkVal = orig;
-if (arc_owned_values_.count(checkVal) ||
-    arc_str_owned_values_.count(checkVal))
-    continue;  // transfer semantics, no retain needed
-emitTupleComponentRetain(fieldVal, fSig);
+for (unsigned i = 0; i < n; ++i) {
+    llvm::Value *fieldVal = builder_.CreateExtractValue(
+        finalVal, {i}, "tup_new_f" + std::to_string(i));
+    emitTupleComponentRetainTraced(fieldVal, finalVal, i, components[i]);
+}
 ```
 
-Without the InsertValue trace, fresh `+1` allocations from arc_owned literals get double-retained, producing a leak proportional to the number of overwrites (the leak-delta test in `arc_tuple_index_assign.test.ry` grew by +2 per iteration before this fix).
+Without the recursive trace, fresh `+1` allocations from arc_owned literals embedded in nested tuple shapes get double-retained, producing a leak proportional to the number of overwrites (the leak-delta test grew by +2 per iteration before the recursive fix).
 
 **`emitTupleElemReleaseSlot` helper**: Factored from the per-slot body of `emitTupleElemReleaseLoop` (`codegen_arc.cpp`). The single-slot helper avoids emitting 4 throwaway basic blocks (header/body/latch/post) for a single slot, and is reused by `emitTupleElemReleaseLoop`'s body. Signature: `emitTupleElemReleaseSlot(slotPtr, tag, tupleSig, tupleTy)` — slot is loaded inside, components are extracted, ARC components are released by source-level type name (str at −24, List/Map/Set at −16, nested tuples recurse).
 

--- a/changelog.d/1670-tuple-elem-arc-on-index-assign.md
+++ b/changelog.d/1670-tuple-elem-arc-on-index-assign.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- `xs[i] = (a, b)` slot overwrite on `List<(K, V)>` now retains the
+  ARC-managed components of the new tuple and releases the components
+  of the evicted tuple. Previously the IndexAssignStmt path was the
+  remaining symmetry gap from #1667: the destructor recursed into
+  inner tuple components, but slot overwrite did neither retain nor
+  release, leaking the evicted tuple's inner ARC values on every
+  reassignment. The fix mirrors #1667's per-component dispatch by
+  source-level type name (str at offset −24, List/Map/Set at −16,
+  nested tuples recurse), gates on a non-empty `list_elem_type_name`
+  with tuple shape `"(...)"` (preserving pre-fix behavior for
+  literal-built lists whose tuple sig is empty — same blind spot as
+  `List<str>` literals), and orders retain-before-release so
+  self-assignment `e[i] = e[i]` is safe. (#1670)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -295,6 +295,23 @@ public:
                                    const std::string &tupleSig,
                                    llvm::StructType *tupleTy);
 
+    // Releases each ARC-managed component of a single tuple-struct slot
+    // pointed to by `slotPtr`. Used both by `emitTupleElemReleaseLoop`
+    // body and by `IndexAssignStmt` slot-overwrite on `List<(K, V)>`
+    // (#1670). Recurses for nested tuple components.
+    void emitTupleElemReleaseSlot(llvm::Value *slotPtr,
+                                   const char *tagPrefix,
+                                   const std::string &tupleSig,
+                                   llvm::StructType *tupleTy);
+
+    // Walks an InsertValue chain and recovers the original SSA value at the
+    // requested field index. LLVM's ConstantFolder does NOT fold
+    // ExtractValue(InsertValue(agg, v, {i}), {i}) → v for non-constant
+    // aggregates, so callers that need to check ownership of an insertvalue
+    // operand must trace the chain. Returns nullptr if no matching insert
+    // is found.
+    static llvm::Value *traceInsertValueField(llvm::Value *agg, unsigned idx);
+
     // Splits a generic type name like "List<str>" into head="List" and
     // inner=["str"].  Returns false for non-generic names (no '<').
     // Extracted from codegen_fn_generic.cpp so callers across translation

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -276,6 +276,21 @@ public:
     // was extended to release tuple fields recursively (#1667).
     void emitTupleComponentRetain(llvm::Value *val, const std::string &fSig);
 
+    // Ownership-aware recursive variant of `emitTupleComponentRetain` for
+    // IndexAssignStmt slot overwrites on `List<(K, V)>` (#1670). Walks the
+    // InsertValue chain on `sourceAgg` at index `topIdx` to recover the
+    // original SSA value, recurses for nested tuple components (carrying the
+    // traced sub-aggregate forward as the new sourceAgg), and skips the leaf
+    // retain when the traced value is in `arc_owned_values_` /
+    // `arc_str_owned_values_` (transfer semantics). Without the recursive
+    // trace, a fresh `+1` allocation embedded inside a nested tuple shape
+    // such as `xs[i] = (0, ([1], 2))` is double-retained because
+    // `traceInsertValueField` returns the inner InsertValue (not a leaf).
+    void emitTupleComponentRetainTraced(llvm::Value *fieldVal,
+                                         llvm::Value *sourceAgg,
+                                         unsigned topIdx,
+                                         const std::string &fSig);
+
     // Counted loop that retains every ARC-managed tuple component in a
     // dense array of tuple struct values [0, len). Mirrors
     // `emitTupleElemReleaseLoop` and is used after memcpy at slice/take/

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -523,7 +523,7 @@ bool CodeGen::recordHasArcFields(llvm::StructType *st) {
 // instruction that is never in arc_owned_values_ / arc_str_owned_values_.
 // This helper recovers the original inserted operand so that ownership
 // checks work correctly for record construction IR.
-static llvm::Value *traceInsertValueField(llvm::Value *agg, unsigned idx) {
+llvm::Value *CodeGen::traceInsertValueField(llvm::Value *agg, unsigned idx) {
     while (auto *iv = llvm::dyn_cast<llvm::InsertValueInst>(agg)) {
         if (iv->getIndices().size() == 1 && iv->getIndices()[0] == idx)
             return iv->getInsertedValueOperand();
@@ -1298,36 +1298,15 @@ static CountedLoopBlocks emitCountedLoopShell(llvm::IRBuilder<> &b,
     return {body, latch, post, iPhi};
 }
 
-void CodeGen::emitTupleElemReleaseLoop(llvm::Value *arrayPtr, llvm::Value *len,
-                                        const char *tag,
+void CodeGen::emitTupleElemReleaseSlot(llvm::Value *slotPtr,
+                                        const char *tagPrefix,
                                         const std::string &tupleSig,
                                         llvm::StructType *tupleTy) {
-    if (!arrayPtr || !len || !tupleTy) return;
+    if (!slotPtr || !tupleTy) return;
     std::vector<std::string> components = splitTupleSig(tupleSig);
     if (components.empty()) return;
 
-    // Skip the loop entirely if no component needs ARC release.
-    bool anyArc = false;
-    for (const auto &c : components) {
-        const std::string r = resolveTypeAlias(c);
-        if (r.empty() || isWeakTypeName(r)) continue;
-        if (r == "str" || isListTypeName(r) || isMapTypeName(r) ||
-            isSetTypeName(r) ||
-            (r.size() >= 2 && r.front() == '(' && r.back() == ')')) {
-            anyArc = true;
-            break;
-        }
-    }
-    if (!anyArc) return;
-
     llvm::Function *fn = builder_.GetInsertBlock()->getParent();
-    std::string tagPrefix = std::string("dtor_tup_") + tag;
-    auto loop = emitCountedLoopShell(builder_, *ctx_, fn, len, i64Ty_,
-                                       tagPrefix);
-
-    // body: GEP into the i'th tuple slot, then release each component.
-    auto *slotPtr = builder_.CreateGEP(tupleTy, arrayPtr, {loop.iPhi},
-                                         tagPrefix + "_slot");
     const unsigned n = static_cast<unsigned>(
         std::min<size_t>(components.size(), tupleTy->getNumElements()));
     for (unsigned i = 0; i < n; ++i) {
@@ -1342,7 +1321,7 @@ void CodeGen::emitTupleElemReleaseLoop(llvm::Value *arrayPtr, llvm::Value *len,
         if (!isStr && !isColl && !isTup) continue;
 
         auto *fieldGEP = builder_.CreateStructGEP(tupleTy, slotPtr, i,
-            tagPrefix + "_f" + std::to_string(i));
+            std::string(tagPrefix) + "_f" + std::to_string(i));
 
         if (isTup) {
             // Recursive tuple component: load nothing (inline struct), recurse
@@ -1352,7 +1331,8 @@ void CodeGen::emitTupleElemReleaseLoop(llvm::Value *arrayPtr, llvm::Value *len,
             if (!nestedTy) continue;
             // Treat a single nested tuple slot as a 1-element array.
             llvm::Value *one = llvm::ConstantInt::get(i64Ty_, 1);
-            std::string subTag = std::string(tag) + "_n" + std::to_string(i);
+            std::string subTag = std::string(tagPrefix) + "_n" +
+                                  std::to_string(i);
             emitTupleElemReleaseLoop(fieldGEP, one, subTag.c_str(), fSig,
                                        nestedTy);
             continue;
@@ -1361,15 +1341,15 @@ void CodeGen::emitTupleElemReleaseLoop(llvm::Value *arrayPtr, llvm::Value *len,
         // ARC pointer component (str / List / Map / Set): load, null-guard,
         // release with the appropriate header offset.
         auto *val = builder_.CreateLoad(ptrTy_, fieldGEP,
-            tagPrefix + "_v" + std::to_string(i));
+            std::string(tagPrefix) + "_v" + std::to_string(i));
         auto *nullBB = llvm::BasicBlock::Create(*ctx_,
-            tagPrefix + "_skip" + std::to_string(i), fn);
+            std::string(tagPrefix) + "_skip" + std::to_string(i), fn);
         auto *relBB  = llvm::BasicBlock::Create(*ctx_,
-            tagPrefix + "_rel"  + std::to_string(i), fn);
+            std::string(tagPrefix) + "_rel"  + std::to_string(i), fn);
         auto *isNull = builder_.CreateICmpEQ(val,
             llvm::ConstantPointerNull::get(
                 llvm::cast<llvm::PointerType>(ptrTy_)),
-            tagPrefix + "_isnull" + std::to_string(i));
+            std::string(tagPrefix) + "_isnull" + std::to_string(i));
         builder_.CreateCondBr(isNull, nullBB, relBB);
 
         builder_.SetInsertPoint(relBB);
@@ -1406,6 +1386,39 @@ void CodeGen::emitTupleElemReleaseLoop(llvm::Value *arrayPtr, llvm::Value *len,
 
         builder_.SetInsertPoint(nullBB);
     }
+}
+
+void CodeGen::emitTupleElemReleaseLoop(llvm::Value *arrayPtr, llvm::Value *len,
+                                        const char *tag,
+                                        const std::string &tupleSig,
+                                        llvm::StructType *tupleTy) {
+    if (!arrayPtr || !len || !tupleTy) return;
+    std::vector<std::string> components = splitTupleSig(tupleSig);
+    if (components.empty()) return;
+
+    // Skip the loop entirely if no component needs ARC release.
+    bool anyArc = false;
+    for (const auto &c : components) {
+        const std::string r = resolveTypeAlias(c);
+        if (r.empty() || isWeakTypeName(r)) continue;
+        if (r == "str" || isListTypeName(r) || isMapTypeName(r) ||
+            isSetTypeName(r) ||
+            (r.size() >= 2 && r.front() == '(' && r.back() == ')')) {
+            anyArc = true;
+            break;
+        }
+    }
+    if (!anyArc) return;
+
+    llvm::Function *fn = builder_.GetInsertBlock()->getParent();
+    std::string tagPrefix = std::string("dtor_tup_") + tag;
+    auto loop = emitCountedLoopShell(builder_, *ctx_, fn, len, i64Ty_,
+                                       tagPrefix);
+
+    // body: GEP into the i'th tuple slot, then release each component.
+    auto *slotPtr = builder_.CreateGEP(tupleTy, arrayPtr, {loop.iPhi},
+                                         tagPrefix + "_slot");
+    emitTupleElemReleaseSlot(slotPtr, tagPrefix.c_str(), tupleSig, tupleTy);
 
     // After all components, branch to the loop latch.
     builder_.CreateBr(loop.latch);

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -1254,6 +1254,54 @@ void CodeGen::emitTupleComponentRetain(llvm::Value *val,
     // int / bool / f64 / weak / record / unknown: no-op
 }
 
+void CodeGen::emitTupleComponentRetainTraced(llvm::Value *fieldVal,
+                                              llvm::Value *sourceAgg,
+                                              unsigned topIdx,
+                                              const std::string &fSig) {
+    if (fSig.empty() || !fieldVal) return;
+    const std::string resolved = resolveTypeAlias(fSig);
+    if (resolved.empty() || isWeakTypeName(resolved)) return;
+
+    // Recover the original SSA value at `topIdx` of `sourceAgg`. When
+    // sourceAgg is an InsertValueInst chain (the freshly-built tuple in
+    // `xs[i] = (a, b)`), `traceInsertValueField` returns the operand
+    // inserted at that index — which may itself be an InsertValue for a
+    // nested tuple shape like `(0, (a, b))`. Pass that traced value down
+    // as the new sourceAgg so the recursion can keep tracing into deeper
+    // levels until it reaches a non-InsertValue leaf.
+    llvm::Value *tracedField = nullptr;
+    if (sourceAgg && llvm::isa<llvm::InsertValueInst>(sourceAgg))
+        tracedField = traceInsertValueField(sourceAgg, topIdx);
+
+    if (resolved.size() >= 2 && resolved.front() == '(' &&
+        resolved.back() == ')') {
+        // Nested tuple component: recurse into each sub-component, carrying
+        // the traced sub-aggregate forward so leaf-level ownership checks
+        // see the original SSA value rather than the fresh ExtractValue.
+        auto *tupleTy = llvm::dyn_cast<llvm::StructType>(fieldVal->getType());
+        if (!tupleTy) return;
+        auto components = splitTupleSig(resolved);
+        const unsigned n = static_cast<unsigned>(
+            std::min<size_t>(components.size(), tupleTy->getNumElements()));
+        for (unsigned i = 0; i < n; ++i) {
+            llvm::Value *subVal = builder_.CreateExtractValue(fieldVal, {i});
+            emitTupleComponentRetainTraced(subVal, tracedField, i,
+                                            components[i]);
+        }
+        return;
+    }
+
+    // Leaf component (str / List / Map / Set / primitive). Check ownership
+    // on the traced source value — `arc_owned_values_` /
+    // `arc_str_owned_values_` are keyed by the original SSA value, not by
+    // an ExtractValue produced post-hoc.
+    llvm::Value *checkVal = tracedField ? tracedField : fieldVal;
+    if (arc_owned_values_.count(checkVal) ||
+        arc_str_owned_values_.count(checkVal))
+        return;
+    emitTupleComponentRetain(fieldVal, resolved);
+}
+
 namespace {
 // Build a counted loop over [0, len) inside `fn` that branches into
 // `bodyEmitter(iPhi)` for each iteration. The body emitter is responsible

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -1212,44 +1212,42 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
     // `elemIsArc` block above never fires here. Compound-op is N/A for
     // tuples — no arithmetic operator is defined on tuple types, so the
     // parser/typechecker rejects compound `IndexAssignStmt` upstream.
-    // Gate on non-empty `elemTypeName` (preserves pre-fix behaviour for
-    // literal-built `List<(K, V)>` whose `list_elem_type_name` is empty,
-    // matching the #1667 caveat for the destructor side).
-    const bool elemIsTuple = elemTypeName.size() >= 2 &&
-                              elemTypeName.front() == '(' &&
-                              elemTypeName.back() == ')';
+    //
+    // Resolve `elemTypeName` via `resolveTypeAlias` first so that user-
+    // defined aliases (`type Pair = (int, str)` → `Pair`) canonicalize to
+    // the literal tuple shape `"(int, str)"` before the shape gate. Without
+    // this, alias-typed `List<Pair>` would skip the gate entirely and leak
+    // tuple components on overwrite. Empty resolution (literal-built
+    // `List<(K, V)>` whose `list_elem_type_name` is empty) preserves
+    // pre-fix behaviour, matching the #1667 caveat on the destructor side.
+    const std::string resolvedElemTypeName = resolveTypeAlias(elemTypeName);
+    const bool elemIsTuple = resolvedElemTypeName.size() >= 2 &&
+                              resolvedElemTypeName.front() == '(' &&
+                              resolvedElemTypeName.back() == ')';
     if (elemIsTuple) {
         if (auto *tupleTy = llvm::dyn_cast<llvm::StructType>(elemTy)) {
-            std::vector<std::string> components = splitTupleSig(elemTypeName);
+            std::vector<std::string> components =
+                splitTupleSig(resolvedElemTypeName);
             const unsigned n = static_cast<unsigned>(
                 std::min<size_t>(components.size(),
                                   tupleTy->getNumElements()));
             // Retain new components from finalVal first (self-assignment
-            // safety: `xs[i] = xs[i]`). For tuple components built via
-            // InsertValue, ExtractValue does NOT fold back to the original
-            // operand — LLVM's ConstantFolder only folds constants. Trace
-            // the InsertValue chain to recover the original SSA value, then
-            // skip the retain when the source is in arc_owned_values_ /
-            // arc_str_owned_values_ (transfer semantics). Otherwise emit an
-            // unconditional retain via emitTupleComponentRetain.
+            // safety: `xs[i] = xs[i]`). `emitTupleComponentRetainTraced`
+            // walks the InsertValue chain on `finalVal` recursively so that
+            // nested tuple shapes like `xs[i] = (0, ([1], 2))` correctly
+            // detect ownership at each leaf (the fresh `[1]` allocation is
+            // in `arc_owned_values_` and must NOT be retained — the
+            // `+1` from its construction transfers to the slot).
             for (unsigned i = 0; i < n; ++i) {
-                const std::string fSig = resolveTypeAlias(components[i]);
-                if (fSig.empty() || isWeakTypeName(fSig)) continue;
                 llvm::Value *fieldVal = builder_.CreateExtractValue(
                     finalVal, {i},
                     "tup_new_f" + std::to_string(i));
-                llvm::Value *checkVal = fieldVal;
-                if (llvm::isa<llvm::InsertValueInst>(finalVal))
-                    if (auto *orig = traceInsertValueField(finalVal, i))
-                        checkVal = orig;
-                if (arc_owned_values_.count(checkVal) ||
-                    arc_str_owned_values_.count(checkVal))
-                    continue;
-                emitTupleComponentRetain(fieldVal, fSig);
+                emitTupleComponentRetainTraced(fieldVal, finalVal, i,
+                                                components[i]);
             }
             // Release old components from the existing slot.
-            emitTupleElemReleaseSlot(elemPtr, "list_tup_old", elemTypeName,
-                                      tupleTy);
+            emitTupleElemReleaseSlot(elemPtr, "list_tup_old",
+                                      resolvedElemTypeName, tupleTy);
         }
     }
 

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -1206,6 +1206,53 @@ void CodeGen::emitStmt(IndexAssignStmt &s) {
         }
     }
 
+    // Tuple-element slot overwrite (#1670): mirror #855's retain-before-
+    // release-old protocol for tuple components. `elementTypeIsArcManaged`
+    // returns false for tuples (inline struct, not pointer), so the
+    // `elemIsArc` block above never fires here. Compound-op is N/A for
+    // tuples — no arithmetic operator is defined on tuple types, so the
+    // parser/typechecker rejects compound `IndexAssignStmt` upstream.
+    // Gate on non-empty `elemTypeName` (preserves pre-fix behaviour for
+    // literal-built `List<(K, V)>` whose `list_elem_type_name` is empty,
+    // matching the #1667 caveat for the destructor side).
+    const bool elemIsTuple = elemTypeName.size() >= 2 &&
+                              elemTypeName.front() == '(' &&
+                              elemTypeName.back() == ')';
+    if (elemIsTuple) {
+        if (auto *tupleTy = llvm::dyn_cast<llvm::StructType>(elemTy)) {
+            std::vector<std::string> components = splitTupleSig(elemTypeName);
+            const unsigned n = static_cast<unsigned>(
+                std::min<size_t>(components.size(),
+                                  tupleTy->getNumElements()));
+            // Retain new components from finalVal first (self-assignment
+            // safety: `xs[i] = xs[i]`). For tuple components built via
+            // InsertValue, ExtractValue does NOT fold back to the original
+            // operand — LLVM's ConstantFolder only folds constants. Trace
+            // the InsertValue chain to recover the original SSA value, then
+            // skip the retain when the source is in arc_owned_values_ /
+            // arc_str_owned_values_ (transfer semantics). Otherwise emit an
+            // unconditional retain via emitTupleComponentRetain.
+            for (unsigned i = 0; i < n; ++i) {
+                const std::string fSig = resolveTypeAlias(components[i]);
+                if (fSig.empty() || isWeakTypeName(fSig)) continue;
+                llvm::Value *fieldVal = builder_.CreateExtractValue(
+                    finalVal, {i},
+                    "tup_new_f" + std::to_string(i));
+                llvm::Value *checkVal = fieldVal;
+                if (llvm::isa<llvm::InsertValueInst>(finalVal))
+                    if (auto *orig = traceInsertValueField(finalVal, i))
+                        checkVal = orig;
+                if (arc_owned_values_.count(checkVal) ||
+                    arc_str_owned_values_.count(checkVal))
+                    continue;
+                emitTupleComponentRetain(fieldVal, fSig);
+            }
+            // Release old components from the existing slot.
+            emitTupleElemReleaseSlot(elemPtr, "list_tup_old", elemTypeName,
+                                      tupleTy);
+        }
+    }
+
     builder_.CreateStore(finalVal, elemPtr);
 }
 

--- a/tests/spec/arc_tuple_index_assign.test.ry
+++ b/tests/spec/arc_tuple_index_assign.test.ry
@@ -1,0 +1,111 @@
+from testing import it, describe, expect
+
+from runtime_internal import arcLiveCount
+
+# Issue #1670: ARC ownership gap on the IndexAssignStmt slot-overwrite path
+# for List<(K, V)>.
+#
+# Background: #1667 (PR #1671, merged) closed the construction and
+# destruction halves of tuple-element ownership for List<(K, V)>:
+#   - items / enumerate / zip retain inner ARC components on InsertValue.
+#   - slice / take / appended / concat retain on memcpy.
+#   - The collection destructor walks the dense tuple-struct buffer and
+#     releases each ARC-managed component.
+#
+# The IndexAssignStmt path (`xs[i] = (a, b)` on List<(K, V)>) was not
+# updated by #1667. Pre-fix:
+#   1. Old slot's tuple ARC components are NOT released → leak per
+#      overwrite (the old inner List<int> is orphaned).
+#   2. New tuple's ARC components are NOT retained → UAF when the new
+#      component's source binding is later rebound.
+#
+# Post-fix: retain new components first (so self-assignment cannot
+# transiently drop refcount to zero), then release old components,
+# then store.
+#
+# Out of scope: literal-built List<(K, V)> whose `list_elem_type_name`
+# is empty. The fix gates on a non-empty tuple sig + tuple struct
+# element type, mirroring #1667's literal-build skip rule.
+
+@describe("ARC tuple-field ownership: IndexAssignStmt (#1670)")
+fn arcTupleFieldOwnershipIndexAssignStmt1670Tests():
+  @it("enumerate(List<List<int>>) overwrite live count grows by O(1) not O(N)")
+  fn enumerateOverwriteLiveCountGrowsByO1NotON():
+    # Each overwrite leaks the previous slot's inner List<int> pre-fix
+    # (no release fires on slot overwrite). Post-fix: O(1) delta
+    # regardless of iteration count.
+    before = arcLiveCount()
+    xs: List<List<int>> = [[1, 2, 3]]
+    e = enumerate(xs)
+    i = 0
+    while i < 16:
+      e[0] = (99, [i, i + 1, i + 2])
+      i = i + 1
+    delta = arcLiveCount() - before
+    expect(delta < 10).toEq(true)
+
+  @it("enumerate(List<List<int>>) e[0] = (k, a) survives a = [...] rebind")
+  fn enumerateIndexAssignSurvivesNewComponentRebind():
+    # Pre-fix: e[0] = (7, a) doesn't retain a's inner List<int>, so the
+    # subsequent a = [77] rebind drops [99, 99]'s refcount to zero and
+    # frees it. The churn loop reuses the freed memory; the read of
+    # e[0].1 then returns garbage / crashes under ASan.
+    # Post-fix: retain bumps [99, 99]'s refcount before the rebind, so
+    # the data survives.
+    xs: List<List<int>> = [[1, 2, 3]]
+    e = enumerate(xs)
+    a: List<int> = [99, 99]
+    e[0] = (7, a)
+    xs = [[88]]
+    a = [77]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(e[0].0).toEq(7)
+    expect(e[0].1[0]).toEq(99)
+    expect(e[0].1[1]).toEq(99)
+
+  @it("self-assignment e[i] = e[i] is safe (retain-before-release ordering)")
+  fn enumerateIndexAssignSelfAssignSafe():
+    # The fix must retain the new tuple's components BEFORE releasing
+    # the old slot's components. If the order were reversed, e[i] = e[i]
+    # would release the inner List (refcount 1 → 0 → freed), then retain
+    # on freed memory, then store the dangling pointer — UAF on read.
+    xs: List<List<int>> = [[1, 2, 3], [4, 5, 6]]
+    e = enumerate(xs)
+    e[0] = e[0]
+    e[1] = e[1]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(e[0].0).toEq(0)
+    expect(e[0].1[0]).toEq(1)
+    expect(e[0].1[2]).toEq(3)
+    expect(e[1].0).toEq(1)
+    expect(e[1].1[0]).toEq(4)
+
+  @it("items(Map<str, List<int>>) overwrite survives source + new-component rebind")
+  fn itemsIndexAssignSurvivesSourceAndNewComponentRebind():
+    # Verify the fix is constructor-agnostic: items() and enumerate()
+    # both stamp list_elem_type_name = "(K, V)" and route through the
+    # same IndexAssignStmt path. Both ARC components (str + List<int>)
+    # exercise the per-component retain dispatch (str → −24 offset,
+    # List → −16 offset).
+    m: Map<str, List<int>> = {"key": [1, 2, 3]}
+    its = items(m)
+    newVal: List<int> = [99, 99]
+    its[0] = ("kkk", newVal)
+    m = {"z": [88]}
+    newVal = [77]
+    j: List<int> = [0]
+    i = 0
+    while i < 64:
+      j = [i, i*2, i*3, i*4, i*5]
+      i = i + 1
+    expect(its[0].0).toEq("kkk")
+    expect(its[0].1[0]).toEq(99)
+    expect(its[0].1[1]).toEq(99)

--- a/tests/spec/arc_tuple_index_assign.test.ry
+++ b/tests/spec/arc_tuple_index_assign.test.ry
@@ -109,3 +109,26 @@ fn arcTupleFieldOwnershipIndexAssignStmt1670Tests():
     expect(its[0].0).toEq("kkk")
     expect(its[0].1[0]).toEq(99)
     expect(its[0].1[1]).toEq(99)
+
+  @it("nested tuple slot overwrite (List<(int, (List<int>, int))>) does not leak fresh inner allocations")
+  fn nestedTupleSlotOverwriteNoLeak():
+    # CodeRabbit follow-up: when the new tuple has a nested tuple shape
+    # like `(0, ([1,2,3], 9))` whose inner ARC leaf is a freshly-built
+    # List<int> in arc_owned_values_, a single-step InsertValue trace
+    # only reaches the inner InsertValue (the nested tuple), not the leaf
+    # — the leaf check then misses and emits a redundant retain. The
+    # destructor releases each inner ARC component once on overwrite, so
+    # the redundant retain leaks the inner List<int> by +2 per iteration.
+    # The recursive trace in emitTupleComponentRetainTraced walks all the
+    # way down to the leaf and recognises arc_owned_values_ ownership,
+    # keeping the per-iteration delta O(1).
+    before = arcLiveCount()
+    xs: List<List<int>> = [[1, 2, 3]]
+    e = enumerate(xs)
+    nested: List<(int, (List<int>, int))> = [(0, ([0], 0))]
+    i = 0
+    while i < 16:
+      nested[0] = (i, ([i, i + 1, i + 2], i * 2))
+      i = i + 1
+    delta = arcLiveCount() - before
+    expect(delta < 10).toEq(true)


### PR DESCRIPTION
## Summary

- Closes #1670 — the remaining symmetry gap from #1667. `xs[i] = (a, b)` slot overwrite on `List<(K, V)>` (where the source is a tuple-element list from `enumerate` / `items` / `zip` / derived helpers) leaked the evicted tuple's inner ARC components because the codegen path neither retained new components nor released evicted ones.
- Mirrors #855's retain-before-release-old slot protocol at the tuple level: per-component retain on the new tuple via `emitTupleComponentRetain`, per-component release on the old slot via the new `emitTupleElemReleaseSlot` helper (factored from `emitTupleElemReleaseLoop`'s body).
- Promotes `traceInsertValueField` from a static file-local in `codegen_arc.cpp` to a `CodeGen` static member and reuses it to recover the original SSA value when checking `arc_owned_values_` / `arc_str_owned_values_` — `IRBuilder<>`'s default `ConstantFolder` does NOT fold `ExtractValue(InsertValue(...), {i})` for non-constant aggregates, so the fresh `ExtractValue` always misses these sets without the trace.
- Gated on non-empty `list_elem_type_name` with tuple shape `"(...)"`, matching #1667's destructor-side gate — preserves pre-fix behavior for literal-built lists whose tuple sig is empty (same blind spot as `List<str>` literals; tracked separately).

## Test plan

- [x] `tests/spec/arc_tuple_index_assign.test.ry` — 4 cases:
  - leak-delta: 16 overwrite iterations, `arcLiveCount()` delta < 10 (pre-fix grows linearly)
  - UAF survival: `e[0] = (k, a); a = [...]` rebind, read components
  - self-assignment safety: `e[i] = e[i]` after rebinding source `xs`
  - `items(Map<str, List<int>>)` source variant
- [x] Full C++ suite: 2142 tests passed
- [x] Full Ry self-test suite: 179 files, 0 failures
- [x] ASan + UBSan (C++ + Ry self-test): clean
- [x] TSan (C++ tests): clean
- [x] clang-tidy / cppcheck: no new diagnostics on changed lines
- Skipped §3.6 libFuzzer — no parser/lexer/json/utf8/string change
- Skipped §3.6.5 tree-sitter grammar check — no grammar change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed memory leaks when assigning tuple values into list slots — tuple components are now retained and released correctly on overwrite, including safe self-assignment handling and nested tuple cases.

* **Tests**
  * Added tests covering nested tuple index assignment and repeated overwrites to validate leak-free reference counting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1672)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->