### PR TITLE
docs: align testing intrinsic header comments with current allow-list (#1674)

### DIFF
--- a/changelog.d/1674-testing-intrinsic-header-comments.md
+++ b/changelog.d/1674-testing-intrinsic-header-comments.md
@@ -1,0 +1,10 @@
+### Changed
+
+- Aligned `include/ry/codegen.hpp` and
+  `include/ry/module_loader.hpp` testing-intrinsic header comments
+  with the current allow-list (`expect` / `mock` / `fail`). The
+  pre-existing 6-name listings (`expect` / `mock` / `verify` /
+  `fail` / `it` / `describe`) had drifted from the actual
+  enforcement set after #721 (`it` / `describe` → general
+  user-directive resolution) and #722 (`verify` → Ry function).
+  Documentation-only change; no behavior or ABI impact. (#1674)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -73,7 +73,7 @@ public:
     // only includes libraries for functions actually called during codegen).
     const std::unordered_set<std::string>& getRequiredLibraries() const;
 
-    // Testing intrinsics (`expect`, `mock`, `verify`, `fail`, `it`, `describe`)
+    // Testing intrinsics (`expect`, `mock`, `fail`)
     // that the program imported via `from testing import ...` (named or wildcard).
     // Populated by the caller (jit_runner) from ModuleLoader::importedTestingIntrinsics().
     void setTestingIntrinsicsImported(const std::unordered_set<std::string> &imported);
@@ -941,9 +941,8 @@ public:
 
     // Testing intrinsics imported via `from testing import ...`. Set by
     // setTestingIntrinsicsImported() from ModuleLoader::importedTestingIntrinsics()
-    // before compile(). Used by codegen to enforce that `expect`/`mock`/`verify`/
-    // `fail` require an explicit import (#715). `it`/`describe` enforcement is
-    // tracked separately under #716.
+    // before compile(). Used by codegen to enforce that `expect`/`mock`/`fail`
+    // require an explicit import (#715).
     std::unordered_set<std::string> testing_intrinsics_imported_;
 
     // User-defined @directive declarations. Keyed by directive name.

--- a/include/ry/module_loader.hpp
+++ b/include/ry/module_loader.hpp
@@ -24,7 +24,7 @@ public:
     // Names from `from testing import ...` (or wildcard `from testing`)
     // observed during import resolution (#712). Populated lazily as
     // `resolveImports` walks each `ImportStmt`, filtered to the testing
-    // intrinsic allow-list (`it / describe / expect / mock / verify / fail`)
+    // intrinsic allow-list (`expect / mock / fail`)
     // — declarations like `each / property` that live in `testing.ry`'s
     // AST are tracked through the regular export path and excluded here.
     // Consumers (#713/#715/#716) read this set to enforce that test
@@ -40,7 +40,7 @@ private:
         // True only when the module was found in `search_paths_` (the stdlib
         // search roots), not in `referrer_dir`. Used by the testing-intrinsic
         // allow-list (#712) to ensure a project-local `testing.ry` shadow does
-        // not silently bypass the `'<name>' not found` diagnostic for the six
+        // not silently bypass the `'<name>' not found` diagnostic for the three
         // intrinsic names.
         bool from_stdlib = false;
     };


### PR DESCRIPTION
## Summary

Aligns four header comments with the actual testing-intrinsic enforcement set after #721 / #722 reduced it from 6 to 3 names.

- The implementation (allow-list in `src/module_loader.cpp:77-81`, check sites in `src/codegen_test.cpp`) already reflects 3 names: `expect` / `mock` / `fail`.
- The four header comments below still listed the legacy 6 names (`expect` / `mock` / `verify` / `fail` / `it` / `describe`), creating drift that could mislead future contributors.
- Documentation-only change; no behavior, ABI, or test impact.

## Locations corrected

- `include/ry/codegen.hpp:76` — `setTestingIntrinsicsImported()` doc comment
- `include/ry/codegen.hpp:944-946` — `testing_intrinsics_imported_` member doc
- `include/ry/module_loader.hpp:27` — `importedTestingIntrinsics()` doc
- `include/ry/module_loader.hpp:43` — "six intrinsic names" → "three intrinsic names"

## Why drift existed

- #721 moved `it` / `describe` to general user-directive resolution → no longer in enforcement set
- #722 made `verify` a Ry function in `share/std/testing/testing.ry` → no longer compile-time enforced

## Test plan

- [x] `cmake --build build` succeeds (61 targets, 1 pre-existing unrelated warning)
- [x] `./build/ry_tests` — 2142/2142 PASSED
- [x] `./build/ry test -p` — 179 files, 0 failures
- [x] `cppcheck` static analysis exit 0
- [x] CHANGELOG fragment added at `changelog.d/1674-testing-intrinsic-header-comments.md`

## /pre-commit-checklist matrix notes

- Skipped §1 — no user-visible change (header comments only)
- Skipped §3.5 — no source code change (comment-only header edit, no behavior change)
- Skipped §3.6 — no parser/lexer/json/utf8/string change
- Skipped §3.6.5 — no tree-sitter grammar change

Closes #1674

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Aligned and clarified documentation comments regarding available testing framework intrinsics and their explicit import requirements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1680)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->