### PR TITLE
chore(rules): compress .claude/rules/ to reduce auto-load context pressure

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -8,98 +8,41 @@ paths:
 
 ### UBSan must disable `vptr` and `function` checks on this project
 
-**Source**: #630 (2026-04-11, implementation)
+**Source**: #630 (2026-04-11)
 **Tags**: ubsan, sanitizer, cmake, llvm, cxx-flags
 
-**Context**: When enabling UBSan (`-fsanitize=undefined`) on ry, two
-sub-checks fail in ways that have nothing to do with actual
-undefined behavior:
+**Rule**: When adding or extending UBSan flags in `CMakeLists.txt`, always pair `-fsanitize=undefined` with `-fno-sanitize=vptr,function`. Do not try to fix the false positives by changing the LLVM interop code — the checks themselves are the wrong tool for this codebase:
 
-1. `vptr` — ry compiles with `-fno-rtti` (to match LLVM's build
-   flags, see `CMakeLists.txt:25`). The `vptr` check requires RTTI
-   to resolve virtual-call types, so enabling it under `-fno-rtti`
-   produces no coverage and in some toolchains hard-errors.
-2. `function` — LLVM exposes many C-style function pointers that
-   ry casts through `void *` (JIT symbol resolution, runtime
-   dispatch, etc.). UBSan's `function` check flags every one of
-   these as a type mismatch, drowning out real signal.
+1. `vptr` — ry compiles with `-fno-rtti` (matches LLVM's build flags, see `CMakeLists.txt:25`). The `vptr` check requires RTTI to resolve virtual-call types, so enabling it under `-fno-rtti` produces no coverage and in some toolchains hard-errors.
+2. `function` — LLVM exposes many C-style function pointers that ry casts through `void *` (JIT symbol resolution, runtime dispatch). UBSan's `function` check flags every one as a type mismatch, drowning out real signal.
 
-**Rule**: When adding or extending UBSan flags in `CMakeLists.txt`,
-always pair `-fsanitize=undefined` with
-`-fno-sanitize=vptr,function`. Do not try to fix the false positives
-by changing the LLVM interop code — the checks themselves are the
-wrong tool for this codebase.
-
-**Also**: UBSan and ASan are compatible and are enabled together via
-the `asan` CMake preset (`ENABLE_ASAN=ON` + `ENABLE_UBSAN=ON`). TSan
-is **not** compatible with either and lives in its own `tsan` preset
-(`build-tsan/`). `CMakeLists.txt` enforces this with a
-`FATAL_ERROR` if `ENABLE_TSAN` is combined with the others.
+**Also**: UBSan and ASan are compatible and enabled together via the `asan` CMake preset (`ENABLE_ASAN=ON` + `ENABLE_UBSAN=ON`). TSan is **not** compatible with either and lives in its own `tsan` preset (`build-tsan/`). `CMakeLists.txt` enforces this with a `FATAL_ERROR` if `ENABLE_TSAN` is combined with the others.
 
 ### Linux CI runs in pre-baked GHCR container images, no apt usage
 
 **Source**: #1505 (2026-05-02)
 **Tags**: ci, github-actions, container, ghcr, no-apt
 
-**Rule**: Every Linux job in `.github/workflows/*.yml` (CI, CodeQL,
-release) must use
-`container: ghcr.io/${{ github.repository_owner }}/ry-ci:llvm-21`
-(or `ry-ci-glibc-old:llvm-21` for release Linux jobs). Never add
-`apt-get install` or `sudo apt-get` to a Linux job step. The container
-pre-installs the entire toolchain: clang/clang++ 21
-(`/usr/local/llvm`), cmake (`/opt/cmake`), ninja (`/opt/ninja`),
-ccache (`/usr/local/bin`), OpenSSL (`/opt/openssl`), cppcheck
-(`/opt/cppcheck`), and a vendored gtest tarball at
-`$RY_VENDORED_GTEST_TARBALL`. `CC` / `CXX` / `PATH` /
-`LD_LIBRARY_PATH` / `OPENSSL_ROOT_DIR` / `LLVM_DIR` are pre-set as
-ENV.
+**Rule**: Every Linux job in `.github/workflows/*.yml` (CI, CodeQL, release) must use `container: ghcr.io/${{ github.repository_owner }}/ry-ci:llvm-21` (or `ry-ci-glibc-old:llvm-21` for release Linux jobs). Never add `apt-get install` or `sudo apt-get` to a Linux job step. The container pre-installs the entire toolchain: clang/clang++ 21 (`/usr/local/llvm`), cmake (`/opt/cmake`), ninja (`/opt/ninja`), ccache (`/usr/local/bin`), OpenSSL (`/opt/openssl`), cppcheck (`/opt/cppcheck`), and a vendored gtest tarball at `$RY_VENDORED_GTEST_TARBALL`. `CC` / `CXX` / `PATH` / `LD_LIBRARY_PATH` / `OPENSSL_ROOT_DIR` / `LLVM_DIR` are pre-set as ENV.
 
-**Why**: An Ubuntu apt mirror outage on 2026-05-02 (#1505) caused
-`apt-get install` from `archive.ubuntu.com` and `apt.llvm.org` to fail
-intermittently across all CI jobs. Pre-baking the toolchain into
-GHCR-hosted images isolates CI from upstream Ubuntu/Debian repository
-availability. Image rebuild is on demand via `build-ci-image.yml`
-(`workflow_dispatch` + `push` on Dockerfile changes).
+**Why**: An Ubuntu apt mirror outage on 2026-05-02 caused intermittent `apt-get install` failures from `archive.ubuntu.com` and `apt.llvm.org`. Pre-baking isolates CI from upstream Ubuntu/Debian repository availability. Image rebuild is on demand via `build-ci-image.yml` (`workflow_dispatch` + `push` on Dockerfile changes).
 
 **How to apply**:
-- Linux CI / CodeQL / release jobs: set
-  `container: ghcr.io/.../ry-ci:llvm-21`
-- For release Linux only: use `ry-ci-glibc-old:llvm-21`
-  (`gcc:14-bookworm` base, glibc 2.36) so binaries remain runnable on
-  older Linux distros (Ubuntu 22.04 with glibc 2.35, RHEL 9 with
-  glibc 2.34, etc.).
-- macOS jobs continue using Homebrew on the host runner — only Linux
-  is containerised.
-- If a new tool is needed in CI, add it to `docker/ci.Dockerfile`
-  (and `docker/ci-glibc-old.Dockerfile` if release also needs it),
-  trigger a manual image rebuild via `workflow_dispatch`, and wait
-  for the new image before merging the workflow change. See
-  `.claude/skills/ci-image-workflow/SKILL.md`.
+- Linux CI / CodeQL / release jobs: set `container: ghcr.io/.../ry-ci:llvm-21`
+- Release Linux only: use `ry-ci-glibc-old:llvm-21` (`gcc:14-bookworm` base, glibc 2.36) so binaries remain runnable on older Linux distros (Ubuntu 22.04 with glibc 2.35, RHEL 9 with glibc 2.34, etc.).
+- macOS jobs continue using Homebrew on the host runner — only Linux is containerised.
+- New tool needed in CI: add to `docker/ci.Dockerfile` (and `docker/ci-glibc-old.Dockerfile` if release also needs it), trigger manual image rebuild via `workflow_dispatch`, wait for the new image before merging the workflow change. See `.claude/skills/ci-image-workflow/SKILL.md`.
 
-**How to verify**: `grep -rnE 'apt(-get)?\b' .github/workflows/ docker/`
-must return zero hits. CI logs should show every Linux job running
-inside `ghcr.io/.../ry-ci:llvm-21` (visible at the start of each step
-as `Set up job` / `Initialize containers`).
+**How to verify**: `grep -rnE 'apt(-get)?\b' .github/workflows/ docker/` must return zero hits. CI logs should show every Linux job running inside `ghcr.io/.../ry-ci:llvm-21` (visible at the start of each step as `Set up job` / `Initialize containers`).
 
 ### ccache cache path inside container is `/root/.cache/ccache`, not the runner's home
 
 **Source**: #1505 (2026-05-02)
 **Tags**: ci, ccache, container, github-actions, cache
 
-**Context**: `actions/cache@v4` reads / writes paths inside the
-container's filesystem, not the host runner's. The container runs as
-root by default, so ccache writes to `/root/.cache/ccache`, not
-`/home/runner/.cache/ccache` (which is the path you would use on a
-bare runner). `hendrikmuhs/ccache-action@v1` cannot be used in the
-container because it internally invokes `sudo apt-get install ccache`,
-violating the no-apt rule above.
+**Rule**: When adding ccache to a container-based job, use `actions/cache@v4` directly with `path: /root/.cache/ccache`. The container runs as root by default, so ccache writes to `/root/.cache/ccache`, not `/home/runner/.cache/ccache` (the bare-runner path). `actions/cache@v4` reads/writes paths inside the container's filesystem, not the host runner's. The `ccache` binary is already at `/usr/local/bin/ccache` (installed during image build), so no install step is needed. ccache picks up `~/.cache/ccache` which expands to `/root/.cache/ccache` for root automatically; setting `CCACHE_DIR` is unnecessary.
 
-**Rule**: When adding ccache to a container-based job, use
-`actions/cache@v4` directly with `path: /root/.cache/ccache`. The
-`ccache` binary is already at `/usr/local/bin/ccache` (installed
-during image build), so no install step is needed. ccache picks up
-`~/.cache/ccache` which expands to `/root/.cache/ccache` for the
-root user automatically; setting `CCACHE_DIR` is unnecessary.
+`hendrikmuhs/ccache-action@v1` cannot be used in the container because it internally invokes `sudo apt-get install ccache`, violating the no-apt rule above.
 
 **How to apply**:
 
@@ -114,27 +57,14 @@ root user automatically; setting `CCACHE_DIR` is unnecessary.
       ci-${{ matrix.job }}-
 ```
 
-macOS jobs (in `release.yml`) keep using `hendrikmuhs/ccache-action@v1`
-because they run on host runners (no container) and Homebrew is the
-canonical install method on macOS.
+macOS jobs (in `release.yml`) keep using `hendrikmuhs/ccache-action@v1` because they run on host runners (no container) and Homebrew is the canonical install method.
 
 ### Release Linux binaries must use `ry-ci-glibc-old` for older-glibc compatibility
 
 **Source**: #1505 (2026-05-02)
 **Tags**: ci, release, glibc, container, abi, linux
 
-**Context**: Regular CI uses `ry-ci` (Debian trixie via gcc:14-trixie,
-glibc 2.40). Binaries built against trixie's glibc 2.40 fail at
-startup on older Linux distros (Ubuntu 22.04 with glibc 2.35, RHEL 9
-with glibc 2.34, etc.) with errors like
-`/lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.40' not found`.
-
-**Rule**: Release Linux build jobs (`release.yml`) must use
-`ry-ci-glibc-old` (Debian bookworm via `gcc:14-bookworm`, glibc 2.36)
-as the container, **not** `ry-ci`. The `ry-ci-glibc-old` image is
-built from `docker/ci-glibc-old.Dockerfile` and rebuilt by the same
-`build-ci-image.yml` `workflow_dispatch` (matrix includes both image
-names).
+**Rule**: Release Linux build jobs (`release.yml`) must use `ry-ci-glibc-old` (Debian bookworm via `gcc:14-bookworm`, glibc 2.36) as the container, **not** `ry-ci`. Regular CI's `ry-ci` (Debian trixie, glibc 2.40) produces binaries that fail at startup on older Linux distros (Ubuntu 22.04 with glibc 2.35, RHEL 9 with glibc 2.34) with `version 'GLIBC_2.40' not found`. The `ry-ci-glibc-old` image is built from `docker/ci-glibc-old.Dockerfile` and rebuilt by the same `build-ci-image.yml` `workflow_dispatch` (matrix includes both image names).
 
 **How to apply**: in `release.yml`, the Linux container is wired as
 
@@ -142,74 +72,32 @@ names).
 container: ${{ matrix.llvm_install == 'container' && format('ghcr.io/{0}/ry-ci-glibc-old:llvm-21-rev<N>', github.repository_owner) || null }}
 ```
 
-`<N>` is the current immutable rev — see the sibling rule "Release
-container must pin to immutable `:llvm-<MAJOR>-rev<N>` tag" for why
-release uses the rev-suffixed form rather than the mutable
-`:llvm-<MAJOR>` pointer.
+`<N>` is the current immutable rev — see "Release container must pin to immutable `:llvm-<MAJOR>-rev<N>` tag" for why release uses the rev-suffixed form.
 
-Other workflows (`ci.yml`, `codeql.yml`) use `ry-ci:llvm-21` because
-glibc compat does not matter for CI artifacts that never leave the
-runner. The dev `docker/Dockerfile` also inherits from `ry-ci`, not
-`ry-ci-glibc-old`, since dev work does not produce distributable
-binaries.
+Other workflows (`ci.yml`, `codeql.yml`) use `ry-ci:llvm-21` because glibc compat does not matter for CI artifacts that never leave the runner. The dev `docker/Dockerfile` also inherits from `ry-ci` since dev work does not produce distributable binaries.
 
 ### Release container must pin to immutable `:llvm-<MAJOR>-rev<N>` tag
 
 **Source**: #1508 (2026-05-02)
 **Tags**: ci, release, container, ghcr, immutable-tag, reproducibility
 
-**Context**: `build-ci-image.yml`'s `manifest` job publishes
-`:llvm-<MAJOR>` and `:llvm-<MAJOR>-rev<N>` simultaneously per build,
-but `:llvm-<MAJOR>` is overwritten on every subsequent rebuild while
-`:llvm-<MAJOR>-rev<N>` is monotonically increasing and never reused.
-If `release.yml` referenced the mutable `:llvm-<MAJOR>`, re-running
-the workflow on an older `vX.Y.Z` source tag would pull whatever image
-the pointer happens to resolve to today, not the one used for the
-original release. Resulting binaries would be bit-different,
-invalidating downstream `sha256sums.txt`, signatures, and any
-distro-packager checksum mirrors.
+**Rule**: `release.yml`'s `container:` expression must reference the immutable `:llvm-<MAJOR>-rev<N>` tag (e.g. `:llvm-21-rev3`), never the mutable `:llvm-<MAJOR>` (e.g. `:llvm-21`). Other workflows that don't produce externally-distributed artifacts (`ci.yml`, `codeql.yml`) keep the mutable `:llvm-<MAJOR>` pointer because they don't have the reproducibility constraint and should track the latest image automatically.
 
-**Rule**: `release.yml`'s `container:` expression must reference the
-immutable `:llvm-<MAJOR>-rev<N>` tag (e.g. `:llvm-21-rev3`), never the
-mutable `:llvm-<MAJOR>` (e.g. `:llvm-21`). Other workflows that don't
-produce externally-distributed artifacts (`ci.yml`, `codeql.yml`) keep
-the mutable `:llvm-<MAJOR>` pointer because they don't have the
-reproducibility constraint and should track the latest image
-automatically.
+**Why**: `build-ci-image.yml`'s `manifest` job publishes both tags simultaneously per build, but `:llvm-<MAJOR>` is overwritten on every rebuild while `:llvm-<MAJOR>-rev<N>` is monotonically increasing and never reused. If `release.yml` referenced the mutable tag, re-running the workflow on an older `vX.Y.Z` source tag would pull whatever image the pointer resolves to today, not the one used for the original release — bit-different binaries invalidate downstream `sha256sums.txt`, signatures, and distro-packager checksum mirrors.
 
-`@sha256:...` digest pin is stronger but not required for this repo
-because `compute-tag` only emits monotonically increasing rev numbers
-and never reuses an existing `rev<N>` (effectively immutable in
-practice). Digest pinning may be revisited as security hardening in
-a separate issue.
+`@sha256:...` digest pin is stronger but not required: `compute-tag` only emits monotonically increasing rev numbers and never reuses an existing `rev<N>` (effectively immutable in practice). Digest pinning may be revisited as security hardening separately.
 
 **How to apply**:
 
-1. Static-pin the rev tag inside `release.yml` (`container:` line).
-   Workflow files at the original tag's commit are what GitHub
-   replays during a re-run, so a hardcoded literal preserves the
-   image bits used at release time. Dynamic resolution
-   (`needs.<job>.outputs.<n>`, file reads, etc.) cannot solve the
-   problem — they still resolve at re-run time.
-2. Bump only at Release prep (`.claude/skills/preparing-for-release/SKILL.md`
-   Step 4). Mid-cycle merges leave the pin alone — a stale pin during
-   feature work just means the next release inherits the previous
-   image, which is correct.
-3. On LLVM major version bumps, replace **both** the `:llvm-<OLD>`
-   reference (other workflows) and the `:llvm-<OLD>-rev<N>` pin
-   (release.yml) with the new major's tag form. See
-   `.claude/skills/ci-image-workflow/SKILL.md` "How to bump LLVM"
-   for the full sequence.
+1. Static-pin the rev tag inside `release.yml` (`container:` line). Workflow files at the original tag's commit are what GitHub replays during a re-run, so a hardcoded literal preserves the image bits used at release time. Dynamic resolution (`needs.<job>.outputs.<n>`, file reads) cannot solve the problem — they still resolve at re-run time.
+2. Bump only at Release prep (`.claude/skills/preparing-for-release/SKILL.md` Step 4). Mid-cycle merges leave the pin alone — a stale pin during feature work just means the next release inherits the previous image, which is correct.
+3. On LLVM major version bumps, replace **both** the `:llvm-<OLD>` reference (other workflows) and the `:llvm-<OLD>-rev<N>` pin (release.yml) with the new major's tag form. See `.claude/skills/ci-image-workflow/SKILL.md` "How to bump LLVM".
 
 **How to verify**:
 
-1. `grep -nE ':llvm-[0-9]+-rev[0-9]+' .github/workflows/release.yml`
-   must show one match per release Linux container line.
-2. `grep -nE ':llvm-[0-9]+([^-]|$)' .github/workflows/release.yml`
-   must return zero hits — `release.yml` should never have a
-   rev-less mutable tag.
-3. The pinned `:llvm-<MAJOR>-rev<N>` must exist in GHCR (public,
-   no auth needed):
+1. `grep -nE ':llvm-[0-9]+-rev[0-9]+' .github/workflows/release.yml` must show one match per release Linux container line.
+2. `grep -nE ':llvm-[0-9]+([^-]|$)' .github/workflows/release.yml` must return zero hits — `release.yml` should never have a rev-less mutable tag.
+3. The pinned `:llvm-<MAJOR>-rev<N>` must exist in GHCR (public, no auth):
 
    ```bash
    curl -s "https://ghcr.io/token?scope=repository:t0k0sh1/ry-ci-glibc-old:pull" \
@@ -218,108 +106,45 @@ a separate issue.
      | jq -r '.tags[]' | grep -E '^llvm-[0-9]+-rev[0-9]+$' | sort -V
    ```
 
-   The pinned rev should appear in this list.
-
 ### `github.ref_name` points to `main` in scheduled workflows, not the checked-out branch
 
-**Source**: #970 (2026-04-15, implementation)
+**Source**: #970 (2026-04-15)
 **Tags**: ci, github-actions, schedule, ccache, gotcha
 
-**Rule**: In a GitHub Actions scheduled workflow (`on: schedule:`), `github.ref_name` is
-always the **default branch** (`main`), regardless of which branch the job checks out via
-`actions/checkout` with an explicit `ref:`. Expressions like
-`github.ref_name == 'main' || startsWith(github.ref_name, 'v')` therefore always evaluate
-to `true` or `false` based on the workflow file's source branch, not the checked-out branch.
+**Rule**: In a GitHub Actions scheduled workflow (`on: schedule:`), `github.ref_name` is always the **default branch** (`main`), regardless of which branch the job checks out via `actions/checkout` with an explicit `ref:`. Expressions like `github.ref_name == 'main' || startsWith(github.ref_name, 'v')` therefore evaluate based on the workflow file's source branch, not the checked-out branch.
 
-**Why**: When designing a scheduled workflow that dynamically checks out a branch
-via `actions/checkout` with an explicit `ref:`, it is tempting to copy a
-`ccache save:` expression like
-`${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}` from a
-push-triggered workflow. On a scheduled run this always evaluates to `true` (if the
-workflow file lives on `main`) regardless of the resolved branch choice, but if the
-workflow file ever ends up on a non-matching branch the cache would silently never be
-saved. Relying on this expression in scheduled workflows is fragile. (Originally
-encountered while designing the now-removed `ci-scheduled.yml`; the gotcha generalises
-to any `on: schedule:` workflow.)
-
-**How to apply**: In scheduled workflows that dynamically check out a branch, replace the
-conditional `save:` expression with `save: true` (always save) or compute the condition from
-the resolved `ref` output rather than `github.ref_name`.
+**How to apply**: In scheduled workflows that dynamically check out a branch, replace conditional `save:` expressions with `save: true` (always save) or compute the condition from the resolved `ref` output rather than `github.ref_name`. Copying a `ccache save:` expression like `${{ github.ref_name == 'main' || startsWith(github.ref_name, 'v') }}` from a push-triggered workflow is the canonical pitfall — on a scheduled run it always evaluates to `true` (if the workflow file lives on `main`) regardless of resolved branch choice.
 
 ### CodeQL must run on default branch to keep Code Scanning dashboard fresh
 
-**Source**: #1367 (2026-04-25, planning)
+**Source**: #1367 (2026-04-25)
 **Tags**: ci, github-actions, codeql, dashboard, schedule, security
 
-**Rule**: GitHub's Code Scanning Security alerts dashboard reflects the **latest analysis
-on the default branch**, not on PR branches. A CodeQL workflow whose only triggers are
-`pull_request:` and `workflow_dispatch:` will analyze every PR but never refresh the
-dashboard after merge — alerts fixed (or newly introduced) on `main` will not appear
-until someone manually dispatches the workflow.
+**Rule**: Always pair `pull_request:` with `push: branches: [<default>]` when removing a `schedule:` from a CodeQL workflow. Keep `workflow_dispatch:` as a manual escape hatch but never rely on it for dashboard freshness.
 
-**Why**: When migrating off the daily `schedule:` cron in `codeql.yml` (#1367), the
-naive replacement is `pull_request: + workflow_dispatch:`. That covers PR gating but
-silently drops dashboard freshness on `main`. The merge-commit run that GitHub used to
-get from the cron is gone.
+**Why**: GitHub's Code Scanning Security alerts dashboard reflects the **latest analysis on the default branch**, not on PR branches. A CodeQL workflow whose only triggers are `pull_request:` and `workflow_dispatch:` will analyze every PR but never refresh the dashboard after merge — alerts fixed (or newly introduced) on `main` will not appear until someone manually dispatches the workflow. The merge-commit run that GitHub used to get from a daily `schedule:` cron is gone otherwise.
 
-**How to apply**: Always pair `pull_request:` with `push: branches: [<default>]` when
-removing a `schedule:` from a CodeQL workflow. Keep `workflow_dispatch:` as a manual
-escape hatch but never rely on it for dashboard freshness. Verify after merge that
-the next push to the default branch produces a CodeQL run in the Actions tab.
+**How to verify**: After merge, the next push to the default branch should produce a CodeQL run in the Actions tab.
 
 ### Cross-workflow gating via `gh api`: filter by `event=push` and absorb trigger-arrival skew with a Phase 1 initial wait
 
-**Source**: #1542 (2026-05-03, implementation)
+**Source**: #1542 (2026-05-03)
 **Tags**: ci, github-actions, gh-api, cross-workflow-gate, codeql, race-condition, polling
 
-**Context**: When one workflow (e.g. `release.yml`) needs to gate on the
-result of another workflow (e.g. `codeql.yml`) for the same `github.sha`,
-the natural query is
-`gh api 'repos/<owner>/<repo>/actions/workflows/<file>/runs?head_sha=<SHA>'`.
-But that endpoint returns runs from **every trigger** for that SHA —
-PR-triggered (`event=pull_request`), manual (`event=workflow_dispatch`),
-and mainline (`event=push`). A green PR run on the same head SHA would
-satisfy a naive gate even though no mainline analysis ever ran.
-Separately, when both a main push and a tag push fire `release.yml` and
-`codeql.yml` near-simultaneously, the arrival order is non-deterministic
-— `release.yml` may start before `codeql.yml` for the SHA has even been
-enqueued, so a single one-shot query returns zero runs and would
-incorrectly fail-closed before the run had a chance to appear.
+**Rule**: Cross-workflow gates that poll another workflow's run state must:
 
-**Rule**: Cross-workflow gates that poll another workflow's run state
-must:
-
-1. **Always** filter by `event=push` (or whatever trigger represents the
-   "real" mainline run) when querying via
-   `actions/workflows/<file>/runs?head_sha=<SHA>&event=<event>`. PR /
-   manual / scheduled runs do not satisfy a mainline gate.
+1. **Always** filter by `event=push` (or whatever trigger represents the "real" mainline run) when querying via `actions/workflows/<file>/runs?head_sha=<SHA>&event=<event>`. PR / manual / scheduled runs do not satisfy a mainline gate.
 2. Use **two-phase polling** with separate timeouts:
-   - **Phase 1 (initial wait)**: poll for run *existence* up to
-     `INITIAL_WAIT_SECONDS` (default 120s). Absorbs the trigger-arrival
-     skew between the two workflows. If still not found at the deadline,
-     fail-closed — that's the legitimate "tag points to a commit never
-     pushed to main" case.
-   - **Phase 2 (completion poll)**: once a run is found, poll
-     `status=completed` up to `POLL_TIMEOUT_SECONDS` (default 1800s,
-     i.e. 30 min) at `POLL_INTERVAL_SECONDS` intervals (default 30s).
-3. Expose all three timeouts as job-level `env:` so the polling script
-   body can be exercised locally (`INITIAL_WAIT_SECONDS=10
-   POLL_INTERVAL_SECONDS=2 POLL_TIMEOUT_SECONDS=20 bash ...`) without
-   editing the script. The YAML defaults stay production-sized.
-4. Set `permissions: { actions: read }` at job scope (not workflow
-   top-level) — `actions: read` is required to query workflow runs in
-   private/public repos via `gh api`. Keep workflow-top-level
-   `permissions: contents: read` as the minimal baseline.
+   - **Phase 1 (initial wait)**: poll for run *existence* up to `INITIAL_WAIT_SECONDS` (default 120s). Absorbs trigger-arrival skew between the two workflows. If still not found at the deadline, fail-closed — that's the legitimate "tag points to a commit never pushed to main" case.
+   - **Phase 2 (completion poll)**: once a run is found, poll `status=completed` up to `POLL_TIMEOUT_SECONDS` (default 1800s, 30 min) at `POLL_INTERVAL_SECONDS` intervals (default 30s).
+3. Expose all three timeouts as job-level `env:` so the polling script body can be exercised locally (`INITIAL_WAIT_SECONDS=10 POLL_INTERVAL_SECONDS=2 POLL_TIMEOUT_SECONDS=20 bash ...`) without editing the script. YAML defaults stay production-sized.
+4. Set `permissions: { actions: read }` at job scope (not workflow top-level) — required to query workflow runs in private/public repos via `gh api`. Keep workflow-top-level `permissions: contents: read` as the minimal baseline.
 
-**Skip-aware downstream gating**: when adding the gate as a new job, the
-downstream `release` (or equivalent publish) job's `if:` must use
-`always() && needs.<gate>.result in ('success', 'skipped')` so that an
-intentional `workflow_dispatch` skip path (escape hatch) doesn't also
-skip the publish. Without `always()`, the default `success()` semantics
-treat `skipped` as not-success and silently cancel downstream.
+**Skip-aware downstream gating**: when adding the gate as a new job, the downstream `release` (or equivalent publish) job's `if:` must use `always() && needs.<gate>.result in ('success', 'skipped')` so an intentional `workflow_dispatch` skip path (escape hatch) doesn't also skip the publish. Without `always()`, the default `success()` semantics treat `skipped` as not-success and silently cancel downstream.
 
-**How to apply** (canonical pattern from `release.yml` `codeql-gate`
-job):
+**Why this design** — gating against `actions/workflows/<file>/runs?head_sha=<SHA>` returns runs from **every trigger** for that SHA, so a green PR run on the same head SHA would satisfy a naive gate even though no mainline analysis ever ran. Separately, when a main push and a tag push fire `release.yml` and `codeql.yml` near-simultaneously, arrival order is non-deterministic — `release.yml` may start before `codeql.yml` has been enqueued, so a single one-shot query returns zero runs and would fail-closed before the run had a chance to appear.
+
+**How to apply** (canonical pattern from `release.yml` `codeql-gate` job):
 
 ```yaml
 codeql-gate:
@@ -355,97 +180,36 @@ release:
     github.ref_type == 'tag'
 ```
 
-**Why not just one query**: a one-shot `gh api` returning empty cannot
-distinguish "run hasn't started yet" from "run will never exist". Phase
-1 collapses both into the same legitimate timeout boundary, then Phase
-2 can assume the run exists and only watch its completion.
+**Why not just one query**: a one-shot `gh api` returning empty cannot distinguish "run hasn't started yet" from "run will never exist". Phase 1 collapses both into the same legitimate timeout boundary, then Phase 2 can assume the run exists and only watch its completion.
 
-**Why not include PR runs in the gate**: a PR's CodeQL run analyses
-the *PR head* (potentially a merge-commit synthesised by GitHub), not
-the post-merge default-branch state. A green PR run can coexist with a
-red post-merge run if the merge introduces new findings (rare but real
-— consider a PR that adds tests but a concurrent main-push that
-introduces the analysed code). Mainline `event=push` is the only run
-that proves the released SHA itself is clean.
+**Why not include PR runs in the gate**: a PR's CodeQL run analyses the *PR head* (potentially a merge-commit synthesised by GitHub), not the post-merge default-branch state. A green PR run can coexist with a red post-merge run if the merge introduces new findings (rare but real — consider a PR that adds tests but a concurrent main-push that introduces the analysed code). Mainline `event=push` is the only run that proves the released SHA itself is clean.
 
 ### scan-build: pass `--use-analyzer=/usr/local/llvm/bin/clang` explicitly
 
 **Source**: #1247 (2026-04-20), updated for #1505 container migration (2026-05-02)
 **Tags**: ci, scan-build, llvm, container, static-analysis
 
-**Rule**: Always pass `--use-analyzer=/usr/local/llvm/bin/clang`
-explicitly to every `scan-build` invocation in
-`.github/workflows/ci.yml` and every example in
-`.claude/skills/static-analysis-tools/SKILL.md`. The `--use-cc` flag
-controls only the build-time compiler and is ignored by the
-analyzer-clang lookup.
+**Rule**: Always pass `--use-analyzer=/usr/local/llvm/bin/clang` explicitly to every `scan-build` invocation in `.github/workflows/ci.yml` and every example in `.claude/skills/static-analysis-tools/SKILL.md`. The `--use-cc` flag controls only the build-time compiler and is ignored by the analyzer-clang lookup.
 
-**Why**: `scan-build`'s `FindClang()` Perl function tries
-`$RealBin/bin/clang`, `/usr/lib/llvm-{MAJOR}/bin/clang`, and the Xcode
-toolchain in order. None of those resolve in the
-`ghcr.io/.../ry-ci:llvm-21` container — LLVM is source-built and
-installed at `/usr/local/llvm/`, scan-build itself is not in the
-parent of an adjacent `bin/clang` (so `$RealBin/bin/clang`
-mis-expands), and `/usr/lib/llvm-{MAJOR}` is a Debian-specific path
-that does not exist on the container's debian-trixie base because
-clang was never apt-installed. Without `--use-analyzer`, scan-build
-leaves `$Clang` undefined and emits
-`Use of uninitialized value $Clang in concatenation` followed by
-`scan-build: error: Cannot find an executable 'clang' relative to scan-build`.
+**Why**: `scan-build`'s `FindClang()` Perl function tries `$RealBin/bin/clang`, `/usr/lib/llvm-{MAJOR}/bin/clang`, and the Xcode toolchain in order. None resolve in the `ghcr.io/.../ry-ci:llvm-21` container — LLVM is source-built and installed at `/usr/local/llvm/`, scan-build itself is not in the parent of an adjacent `bin/clang` (so `$RealBin/bin/clang` mis-expands), and `/usr/lib/llvm-{MAJOR}` is a Debian-specific path that does not exist on the container's debian-trixie base because clang was never apt-installed. Without `--use-analyzer`, scan-build leaves `$Clang` undefined and emits `Use of uninitialized value $Clang in concatenation` followed by `scan-build: error: Cannot find an executable 'clang' relative to scan-build`.
 
-The same flag was already required before #1505: prior to the
-container migration, the (now-removed) LLVM mirror tarball relied on
-the Debian-patched scan-build script with a hard-coded
-`/usr/lib/llvm-{MAJOR}` fallback that pointed nowhere because the
-mirror extracted to `/usr/local/llvm/` instead. The container removed
-both the Debian patch and the apt-installed `/usr/lib/llvm-*` tree;
-the remediation (`--use-analyzer`) is the same in both worlds, so
-keeping the flag uniform across history avoids drift.
+**How to apply**: In every CI `scan-build` invocation (`.github/workflows/ci.yml`) and every local-execution example (`.claude/skills/static-analysis-tools/SKILL.md`), include `--use-analyzer=/usr/local/llvm/bin/clang` alongside `--use-cc` / `--use-c++`. macOS Homebrew `scan-build` resolves clang via `$RealBin/bin/clang` correctly when scan-build is at `/opt/homebrew/opt/llvm@21/bin/scan-build`, so the flag is redundant there — but keeping it uniform prevents drift between local-macOS and CI invocations.
 
-**How to apply**: In every CI `scan-build` invocation
-(`.github/workflows/ci.yml`) and every local-execution example
-(`.claude/skills/static-analysis-tools/SKILL.md`), include
-`--use-analyzer=/usr/local/llvm/bin/clang` alongside `--use-cc` /
-`--use-c++`. macOS Homebrew `scan-build` resolves clang via
-`$RealBin/bin/clang` correctly when scan-build is at
-`/opt/homebrew/opt/llvm@21/bin/scan-build`, so the flag is redundant
-there — but keeping it uniform prevents drift between local-macOS and
-CI invocations.
-
-**How to verify**: `grep -n 'scan-build' .github/workflows/*.yml .claude/skills/static-analysis-tools/SKILL.md`
-and confirm `--use-analyzer` accompanies every invocation. In CI logs,
-the `Use of uninitialized value $Clang` warning must be absent.
+**How to verify**: `grep -n 'scan-build' .github/workflows/*.yml .claude/skills/static-analysis-tools/SKILL.md` and confirm `--use-analyzer` accompanies every invocation. CI logs must not contain `Use of uninitialized value $Clang`.
 
 ### `actions/download-artifact@v4` `pattern:` is a glob — beware prefix collisions across matrix dimensions
 
 **Source**: #1505 manifest job failure (2026-05-02)
 **Tags**: ci, github-actions, actions/download-artifact, glob, multi-image, multi-arch
 
-**Context**: `build-ci-image.yml` uploads digests as
-`digests-${image}-${arch}` and the manifest job downloads them with
-`pattern: digests-${image}-*`. With two image variants whose names
-share a prefix (`ry-ci` and `ry-ci-glibc-old`), the pattern
-`digests-ry-ci-*` glob-matched **both** sets of artifacts, because `*`
-greedily matches `glibc-old-amd64`. The `ry-ci` manifest job pulled in
-4 digests (2 from each image) and `docker buildx imagetools create`
-exited with `not found` because the `ry-ci-glibc-old` digests don't
-exist in the `ry-ci` namespace. The reverse direction
-(`digests-ry-ci-glibc-old-*`) had no false matches and succeeded —
-asymmetric, surprising failure mode.
+**Rule**: When `actions/download-artifact@v4`'s `pattern:` is used to filter across a matrix, the separator between the discriminator and the rest of the artifact name must be a character that **cannot appear inside the discriminator**. Hyphens are unsafe when matrix values themselves contain hyphens (image names, hyphenated tags). Use `__` (double underscore) as a sentinel separator unlikely to appear inside any matrix value.
 
-**Rule**: When `actions/download-artifact@v4`'s `pattern:` is used to
-filter across a matrix, the separator between the discriminator and
-the rest of the artifact name must be a character that **cannot
-appear inside the discriminator**. Hyphens are unsafe when matrix
-values themselves contain hyphens (image names, hyphenated tags,
-etc.). Use `__` (double underscore) as a sentinel separator that's
-unlikely to appear inside any matrix value.
+**Why**: `build-ci-image.yml` uploaded digests as `digests-${image}-${arch}` and the manifest job downloaded them with `pattern: digests-${image}-*`. With two image variants sharing a prefix (`ry-ci` and `ry-ci-glibc-old`), the pattern `digests-ry-ci-*` glob-matched **both** sets — `*` greedily matched `glibc-old-amd64`. The `ry-ci` manifest job pulled in 4 digests (2 per image) and `docker buildx imagetools create` exited with `not found`. The reverse direction (`digests-ry-ci-glibc-old-*`) had no false matches and succeeded — asymmetric, surprising failure mode.
 
 **How to apply**:
 
 ```yaml
-# Upload — use __ to bracket the matrix dimensions whose values may
-# share prefixes
+# Upload — use __ to bracket matrix dimensions whose values may share prefixes
 - uses: actions/upload-artifact@v4
   with:
     name: digests-${{ matrix.image }}__${{ matrix.arch }}
@@ -457,80 +221,28 @@ unlikely to appear inside any matrix value.
     merge-multiple: true
 ```
 
-This applies any time you have two matrix dimensions whose values
-include user-controlled strings (image / package / module names),
-not just to digests. The general rule: *between glob-discriminated
-prefixes*, the separator must be a character class disjoint from
-every matrix value.
+This applies any time you have two matrix dimensions whose values include user-controlled strings (image / package / module names), not just to digests. General rule: between glob-discriminated prefixes, the separator must be a character class disjoint from every matrix value.
 
-**How to verify**: After uploading, the artifacts UI should show
-names like `digests-ry-ci__amd64` (not `digests-ry-ci-amd64`). In
-the manifest job log, the `for f in /tmp/digests/*; do …` loop
-should iterate exactly the expected number of digests (2 per arch
-matrix per image, not the cross-product).
+**How to verify**: After uploading, the artifacts UI should show names like `digests-ry-ci__amd64` (not `digests-ry-ci-amd64`). In the manifest job log, the `for f in /tmp/digests/*; do …` loop should iterate exactly the expected number of digests (2 per arch matrix per image, not the cross-product).
 
 ### LLVM 17+ source build: `compiler-rt` belongs in `LLVM_ENABLE_RUNTIMES`, not `LLVM_ENABLE_PROJECTS`
 
 **Source**: #1505 follow-up (2026-05-02)
 **Tags**: ci, docker, llvm, compiler-rt, cmake, sanitizer, asan, tsan
 
-**Context**: The first `ry-ci` / `ry-ci-glibc-old` image build for
-issue #1505 only set
-`-DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"` in the LLVM cmake
-invocation, which produces clang+clang-tools but **not** compiler-rt.
-The CI `asan` job failed at link time with
-`cannot find /usr/local/llvm/lib/clang/21/lib/x86_64-unknown-linux-gnu/libclang_rt.asan_static.a`,
-and the `tsan` job failed with the same pattern for
-`libclang_rt.tsan{,_cxx}.a`. From LLVM 17 onward, the runtime
-libraries (`compiler-rt`, `libcxx`, `libcxxabi`, `libunwind`) must
-be built via `LLVM_ENABLE_RUNTIMES` rather than `LLVM_ENABLE_PROJECTS`
-so that the *just-built* clang is used to compile them — putting
-`compiler-rt` in `PROJECTS` is silently legacy and produces broken
-or no libraries on modern LLVM.
+**Rule**: When source-building LLVM in `docker/ci.Dockerfile` / `docker/ci-glibc-old.Dockerfile`, always include `-DLLVM_ENABLE_RUNTIMES="compiler-rt"` alongside `-DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"`. From LLVM 17 onward, the runtime libraries (`compiler-rt`, `libcxx`, `libcxxabi`, `libunwind`) must be built via `LLVM_ENABLE_RUNTIMES` rather than `LLVM_ENABLE_PROJECTS` so the *just-built* clang is used to compile them — putting `compiler-rt` in `PROJECTS` is silently legacy and produces broken or no libraries on modern LLVM (CI `asan` job fails at link with `cannot find libclang_rt.asan_static.a`; `tsan` fails the same way for `libclang_rt.tsan{,_cxx}.a`).
 
-**Rule**: When source-building LLVM in `docker/ci.Dockerfile` /
-`docker/ci-glibc-old.Dockerfile`, always include
-`-DLLVM_ENABLE_RUNTIMES="compiler-rt"` alongside
-`-DLLVM_ENABLE_PROJECTS="clang;clang-tools-extra"`. Disable the
-sub-projects ry doesn't use to keep build time bounded
-(`COMPILER_RT_BUILD_PROFILE=OFF`, `COMPILER_RT_BUILD_XRAY=OFF`,
-`COMPILER_RT_BUILD_MEMPROF=OFF`, `COMPILER_RT_BUILD_ORC=OFF`) but
-keep `BUILD_SANITIZERS=ON`, `BUILD_BUILTINS=ON`, `BUILD_LIBFUZZER=ON`
-(libFuzzer is gated off in CI but the harness build script needs
-the static archive to exist).
+Disable the sub-projects ry doesn't use to keep build time bounded (`COMPILER_RT_BUILD_PROFILE=OFF`, `COMPILER_RT_BUILD_XRAY=OFF`, `COMPILER_RT_BUILD_MEMPROF=OFF`, `COMPILER_RT_BUILD_ORC=OFF`) but keep `BUILD_SANITIZERS=ON`, `BUILD_BUILTINS=ON`, `BUILD_LIBFUZZER=ON` (libFuzzer is gated off in CI but the harness build script needs the static archive to exist).
 
-**How to verify**: After image rebuild,
-`docker run --rm ghcr.io/<owner>/ry-ci:llvm-21 ls /usr/local/llvm/lib/clang/21/lib/x86_64-unknown-linux-gnu/`
-should list `libclang_rt.asan.a`, `libclang_rt.asan_static.a`,
-`libclang_rt.tsan.a`, `libclang_rt.tsan_cxx.a`,
-`libclang_rt.ubsan_standalone.a`, and `libclang_rt.fuzzer.a`. CI
-`asan` and `tsan` jobs link cleanly.
+**How to verify**: After image rebuild, `docker run --rm ghcr.io/<owner>/ry-ci:llvm-21 ls /usr/local/llvm/lib/clang/21/lib/x86_64-unknown-linux-gnu/` should list `libclang_rt.asan.a`, `libclang_rt.asan_static.a`, `libclang_rt.tsan.a`, `libclang_rt.tsan_cxx.a`, `libclang_rt.ubsan_standalone.a`, and `libclang_rt.fuzzer.a`. CI `asan` and `tsan` jobs link cleanly.
 
 ### cppcheck 2.16 raises `normalCheckLevelMaxBranches` to a hard exit under `--error-exitcode=1`
 
 **Source**: #1505 follow-up (2026-05-02)
 **Tags**: ci, cppcheck, lint, gotcha, error-exitcode
 
-**Context**: Earlier CI used Ubuntu's apt-installed cppcheck 2.13,
-which printed the "function exceeds the analysis branch budget"
-notice as `information` severity and exited 0. The pre-baked
-`ry-ci` image source-builds cppcheck 2.16.0 (from
-`github.com/danmar/cppcheck`), and 2.16 changed the semantics so the
-same notice is now hard enough to fire `--error-exitcode=1` and fail
-the `lint` job — even though the notice flags **no defect**, it just
-informs the user that some functions were not fully analyzed at the
-default check level.
+**Rule**: In every cppcheck invocation that uses `--error-exitcode=1`, add `--suppress=normalCheckLevelMaxBranches` at the workflow level. Do **not** put the suppression in `.cppcheck-suppressions` — keeping it in the workflow makes the version-specific reason visible at the call site and avoids polluting the project's defect-suppression file with a CI-environment shim.
 
-**Rule**: In every cppcheck invocation that uses
-`--error-exitcode=1`, add
-`--suppress=normalCheckLevelMaxBranches` at the workflow level. Do
-**not** put the suppression in `.cppcheck-suppressions` — keeping
-it in the workflow makes the version-specific reason visible at the
-call site, and avoids polluting the project's defect-suppression
-file with what is effectively a CI-environment shim.
+**Why**: Earlier CI used Ubuntu's apt-installed cppcheck 2.13 which printed the "function exceeds the analysis branch budget" notice as `information` severity and exited 0. The pre-baked `ry-ci` image source-builds cppcheck 2.16.0 which changed the semantics — the same notice is now hard enough to fire `--error-exitcode=1` and fail the `lint` job, even though the notice flags **no defect** (it just informs that some functions were not fully analyzed at the default check level).
 
-**How to verify**: `grep -n 'normalCheckLevelMaxBranches' .github/workflows/*.yml`
-should match the `Run Cppcheck` step in `ci.yml`. The `lint` job
-should exit 0 even when functions hit the branch budget; cppcheck's
-stdout will still print the notice (which is fine — humans can read
-it, CI just won't fail on it).
+**How to verify**: `grep -n 'normalCheckLevelMaxBranches' .github/workflows/*.yml` should match the `Run Cppcheck` step in `ci.yml`. The `lint` job should exit 0 even when functions hit the branch budget; cppcheck's stdout will still print the notice.

--- a/.claude/rules/codegen-arc-cow.md
+++ b/.claude/rules/codegen-arc-cow.md
@@ -17,90 +17,23 @@ paths:
 **Source**: #855 (2026-04-11)
 **Tags**: codegen, arc, collections, index-assign, slot-overwrite
 
-**Context**: A list/map/set slot whose element type is itself an ARC-managed
-collection holds the sole owning ref to the inner allocation — `append` /
-collection-literal construction insert without retain, and the container's
-`emitArcReleaseVar` only releases the *container's* header on scope exit
-(its destructor walks elements, but only after the container itself dies).
-Therefore overwriting a slot via `list[i] = v`, `m[k] = v`, or their
-compound forms MUST load the previously-stored pointer and `emitArcRelease`
-it before storing the new one, otherwise the prior inner allocation is
-orphaned. The fix mirrors the canonical pattern in
-`src/codegen_stmt.cpp::emitStmt(AssignStmt&)` ARC branch (the retain-then-
-release-with-null-check sequence) but operates on a heap slot rather than
-an alloca-backed variable.
+**Rule**: A list/map/set slot whose element type is itself an ARC-managed collection holds the sole owning ref to the inner allocation. Overwriting via `list[i] = v`, `m[k] = v`, or compound forms MUST load the previously-stored pointer and `emitArcRelease` it before storing the new one. Order: **retain new before releasing old** so self-assignment `xs[i] = xs[i]` cannot transiently drop the refcount to zero.
 
-`tryRetainArcSource` handles the retain only for two cases: a `LoadInst`
-whose pointer operand is an ARC-managed alloca, and a value already in
-`arc_owned_values_` (literals / fresh allocations). It does NOT retain for
-a `LoadInst` from a GEP (cross-slot copy `xs[i] = ys[j]`), so the slot-
-overwrite path manually retains via `emitArcGetHeaderFromData` +
-`emitArcRetain` when `tryRetainArcSource` returns false. Order matters:
-**retain new before releasing old** so self-assignment `xs[i] = xs[i]`
-cannot transiently drop the refcount to zero.
+**How to apply**:
+1. Check `elementTypeIsArcManaged(containerPtr, kind, &elemKind)` (type-name based; strings, weak refs, closures, records intentionally excluded).
+2. Plain form: retain new value first via `tryRetainArcSource`, falling back to manual `emitArcRetain` when rhs is a Load from a GEP (`tryRetainArcSource` does NOT cover GEP loads — see next entry).
+3. Load old slot value with null check, release via `emitArcReleaseLoadedElement(...)` (handles null guard + CFG branching).
+4. Store new value.
+5. Compound form (`xs[i] += v`): reuse `oldVal` already loaded for `applyCompoundOp` rather than re-loading — preserves "evaluate index/slot exactly once" (#812). Compound op produces fresh allocation that never aliases the slot, so no retain of new value needed.
 
-**Rule**: When adding a write into any collection slot whose element is
-pointer-typed and ARC-managed, follow this sequence:
-1. Determine "is the slot's element type ARC-managed?" via
-   `elementTypeIsArcManaged(containerPtr, kind, &elemKind)` — this checks
-   the type *name*, not the LLVM type. Strings, weak refs, closures, and
-   records are intentionally excluded.
-2. For the **plain form**, retain the new value first
-   (`tryRetainArcSource`, falling back to a manual `emitArcRetain` when
-   the rhs is a Load from a GEP).
-3. Load the old slot value with a null check.
-4. Release the old value via `emitArcReleaseLoadedElement(...)` (the
-   helper handles null guard + CFG branching).
-5. Store the new value.
-6. For the **compound form** (`xs[i] += v`), reuse the `oldVal` already
-   loaded for `applyCompoundOp` rather than re-loading from the slot —
-   preserves the "evaluate index/slot exactly once" rule from #812. The
-   compound op produces a fresh ARC allocation that never aliases the
-   slot, so no retain of the new value is needed.
-
-**Verification gap** (resolved by #859): The ARC balance counter
-(`runtime_internal.arcLiveCount()`) is now available for delta-based
-leak assertions. ASan/LSan CI
-coverage remains tracked separately.
-
-**Follow-up landed**: Records and record fields with ARC fields
-(`rec.arcField = newList`) share the same root cause but live in the
-`FieldAssignStmt` write path (`InsertValue`/`store` of whole structs).
-Fixed in #857 by mirroring the retain-then-release-old protocol in all
-three `FieldAssignStmt` branches (VariableExpr / FieldAccessExpr /
-IndexExpr) and introducing a string-based `fieldTypeIsArcManaged`
-predicate that consults the AST `FieldDef.type->toString()` rather than
-container metadata — record fields are typed by declaration, not by
-runtime value metadata.
-
-**Follow-up landed** (#854): Deep-chain middle-hop ARC ownership —
-intermediate record hops that are shallow-copied through
-`writeBackFieldChain`, and more generally any chained LHS whose root is
-not a direct `VariableExpr` — is now handled by path CoW
-(`emitPathCowForChain` in `src/codegen_arc_cow.cpp`), which drives
-`emitCowCheckSlot` at each hop. Record-to-record assignment retains each
-ARC field (`emitRecordArcFieldsRetain`) so path CoW can observe
-strong_count > 1 at the record-field slot; scope exit releases the
-fields (`emitRecordArcFieldsRelease`). See "Path copy-on-write isolates
-chained writes through nested collections" earlier in this file for
-the full protocol and unsupported shapes.
+**Sibling write paths**: `FieldAssignStmt` (#857) mirrors this protocol via `fieldTypeIsArcManaged` (consults AST `FieldDef.type->toString()`). Deep-chain middle hops use path CoW (`emitPathCowForChain` in `src/codegen_arc_cow.cpp`, #854) — see "Path copy-on-write isolates chained writes" below.
 
 ### `tryRetainArcSource` LoadInst cases must be metadata-gated
 
-**Source**: #1266 (2026-04-21, fix)
+**Source**: #1266 (2026-04-21)
 **Tags**: codegen, arc, retain, tryRetainArcSource, container-element, GEP-load, memory-safety
 
-**Context**: `tryRetainArcSource` is the central retain-side helper for AssignStmt
-(new variable + reassignment), function return, call-site argument pass, match
-binding, type coercion, and lambda capture. Until #1266 it covered only
-LoadInst-from-alloca (Case 1), arc_owned values (Case 2), and ExtractValue with
-container metadata (Case 3) — leaving GEP-loaded container elements (`xs[i]`,
-`m[k]`, `for e in set { ... }`) without a retain. Once #1242 lands the
-destructor-side recursive release, this gap immediately becomes a UAF: 
-`inner = xs[0]; xs = []` would drop the inner list while `inner` still holds it.
-
-**Rule**: When adding a new LoadInst case to `tryRetainArcSource`, gate on
-container-element metadata exactly like Case 3:
+**Rule**: Any new LoadInst case in `tryRetainArcSource` must gate on container-element metadata, not on `ptrTy_` alone:
 
 ```cpp
 if (llvm::isa<llvm::LoadInst>(val) && val->getType() == ptrTy_) {
@@ -110,287 +43,154 @@ if (llvm::isa<llvm::LoadInst>(val) && val->getType() == ptrTy_) {
 }
 ```
 
-A bare `ptrTy_` type check is **not** sufficient: weak refs, capturing closures,
-bare function pointers, and resource handles are all `ptrTy_` and would receive
-spurious retains that crash on `−16` offset GEPs into header memory that does
-not belong to ArcHeader. The metadata gate is the same protection #999 added to
-Case 3 for ExtractValueInst.
+A bare `ptrTy_` check is unsafe: weak refs, capturing closures, bare function pointers, and resource handles are all `ptrTy_` and would receive spurious retains that crash on `−16` GEPs into non-ArcHeader memory. Same protection #999 added to Case 3 for ExtractValueInst.
 
-**Why not switch all callers to `retainArcValue` instead?**: `retainArcValue`'s
-fallback (`emitArcGetHeaderFromData(val)` + `emitArcRetain(...)`) is unconditional.
-That works for IndexAssignStmt / FieldAssignStmt (#1108 / #857) where the
-caller has already proven the slot is ARC-managed, but it is unsafe for
-`tryRetainArcSource`'s callers — `return 42` (i64), `f(closureArg)` (closure
-ptr), or `let x = weakRef` (weak ref) all reach these sites without an upstream
-type guarantee. Adding the case inside `tryRetainArcSource` keeps the metadata
-gate as the single audit point.
+**Don't switch all callers to `retainArcValue`**: its fallback (`emitArcGetHeaderFromData` + `emitArcRetain`) is unconditional. Safe for IndexAssignStmt / FieldAssignStmt where the caller has already proven the slot is ARC-managed; unsafe for `tryRetainArcSource` callers (`return 42`, `f(closureArg)`, `let x = weakRef`) that lack upstream type guarantees.
 
-**`map_value` belongs in the gate too**: For `Map<K,V>`, `propagateTypeMeta` sets
-both `MapKey` and `MapValue` flags — `m["a"]` returns the value side, so a gate
-that omits `map_value` would miss it. Case 3 currently uses
-`list_elem || map_key || set_elem`; if you ever add a Case-3-style retain on a
-new instruction kind, include `map_value` (and double-check whether Case 3
-itself is missing it for some scenario). Verified for Case 4 in #1266; not
-audited for Case 3 yet.
+**`map_value` belongs in the gate too**: For `Map<K,V>`, `propagateTypeMeta` sets both `MapKey` and `MapValue` flags. Verified for Case 4 in #1266; not audited for Case 3.
 
-**str elements need a separate flag and a separate header offset**: A str
-container element (`xs: List<str>`, `m: Map<K,str>`) uses
-`StringHeader` at offset −24, not `ArcHeader` at −16. Case 4 discriminates via
-a dedicated `ValueMetadata::str_elem` bool and dispatches to
-`emitStrGetHeaderFromData` instead of `emitArcGetHeaderFromData`.
+**str elements need a separate flag and offset**: A str container element uses `StringHeader` at offset −24, not `ArcHeader` at −16. Case 4 dispatches on dedicated `ValueMetadata::str_elem` bool to `emitStrGetHeaderFromData`.
 
-**`str_elem` must ONLY be stamped in the List<str> / Map<K,str> / Set<str>
-indexer paths** — `codegen_expr_literal.cpp` (List indexer reads
-`list_elem_is_str`) and wherever a map/set str value is loaded. Do NOT stamp
-it from a shared helper like `propagateTypeMeta("str", ...)`: that helper is
-called from ~50 sites (pattern bindings, enum variant fields, Result/Option
-payload, function return meta, tuple destructure, …) and many of those are
-str values that are **not** container-element borrows. Stamping `str_elem`
-there makes Case 4 dispatch through `emitStrGetHeaderFromData(val)` —
-`val - 24` — on a pointer that does not own a `StringHeader`, corrupting
-adjacent heap state. The corruption is often invisible under macOS libSystem
-malloc but crashes under glibc (tested in CI Linux on `enum_generic_param_type.test.ry`'s
-`MyOpt<str>::MySome(v)` pattern binding, SIGSEGV / exit 139). Do not be
-tempted to reuse `low_level_type_name == "str"` either — `isLowLevelTypeName`
-only matches numeric types (i8–i64, u8–u64, f32), so the branch would never
-fire, and extending it to include `"str"` pollutes the arith/cast/tostring
-paths that switch on `low_level_type_name`.
+**`str_elem` must ONLY be stamped in List<str> / Map<K,str> / Set<str> indexer paths** — `codegen_expr_literal.cpp` (List indexer reads `list_elem_is_str`) and wherever a map/set str value is loaded. Do NOT stamp from a shared helper like `propagateTypeMeta("str", ...)`: ~50 callsites (pattern bindings, enum variant fields, Result/Option payload, return meta, tuple destructure) handle str values that are NOT container-element borrows. Misstamping makes Case 4 dispatch through `emitStrGetHeaderFromData(val)` on a pointer that does not own a `StringHeader`, corrupting adjacent heap state. Often invisible under macOS libSystem malloc but crashes under glibc (CI Linux, SIGSEGV / exit 139). Don't reuse `low_level_type_name == "str"` either — `isLowLevelTypeName` matches numeric types only.
 
-**Do NOT stamp `list_elem_type_name = "str"` as the signal for List<str>**
-**(superseded by #1576 — historical only)**: This rule is preserved for
-context and to explain why the `list_elem_is_str` side-channel exists. The
-underlying counter asymmetry has been eliminated: post-#1576, `makeString` /
-`makeStringUninit` / `freeStringSlot` touch `g_arc_live_count` symmetrically
-with `__ry_arc_alloc_counted`, so str-aware destructors no longer underflow
-the counter. The `split()` emitter and the `xs: List<str>` annotation branch
-in `codegen_stmt.cpp` therefore stamp `list_elem_type_name = "str"` directly,
-and `tryRetainArcSource` Case 4 emits retains on destructured str elements.
+**Stamping `list_elem_type_name = "str"` is now safe (post-#1576)**: `makeString` / `makeStringUninit` / `freeStringSlot` touch `g_arc_live_count` symmetrically with `__ry_arc_alloc_counted`, so str-aware destructors no longer underflow the counter. The `split()` emitter and `xs: List<str>` annotation branch in `codegen_stmt.cpp` stamp directly. The `list_elem_is_str` side-channel set by AssignStmt annotation parser is still consulted by the indexer (`codegen_expr_literal.cpp` IndexExpr list branch) to stamp `str_elem` on the loaded element.
 
-The original (now-historical) rationale: setting `list_elem_type_name = "str"`
-flipped the destructor to the str-aware variant which iterates the element
-buffer and calls `emitArcRelease` on each element. List headers were
-allocated via `__ry_arc_alloc_counted` (counter +1) while str handles went
-through `makeString` (counter no-op). Every str element release then
-subtracted 1 from a counter it never contributed to, breaking
-`arc_split_chars.test.ry` with a large negative delta. Pre-#1576, code used
-the side-channel `ValueMetadata::list_elem_is_str` set by the AssignStmt
-annotation parser (`codegen_stmt.cpp`) and read only by the list indexer
-(`codegen_expr_literal.cpp` in `emitExprVariant(IndexExpr)` list branch) to
-stamp `str_elem` on the loaded element without touching
-`list_elem_type_name`. The side-channel is still consulted by the indexer
-read path; the counter-symmetric allocator is the new authority for the
-destructor dispatch path. Map<K,str> never had this asymmetry because
-`map_value_type_name = "str"` was already wired correctly on the destructor
-side (Map values are released symmetric with the str allocation in
-`makeStringKeyedMap`-style callers).
+**Function parameters use a different path**: `applyParamTypeMeta` in `codegen_fn.cpp` calls `propagateTypeMeta(ptype, alloca)` directly — `xs: List<str>` parameter alloca picks up `list_elem_type_name = "str"` via the existing path. Safe because parameter alloca is a borrowed view; destructor selection happens at the caller's allocation site.
 
-**Function parameters use a different path and do not need the side-channel**:
-`applyParamTypeMeta` in `codegen_fn.cpp` calls `propagateTypeMeta(ptype,
-alloca)` directly, so a `xs: List<str>` parameter alloca picks up
-`list_elem_type_name = "str"` via the existing path. The list indexer then
-sees that name, calls `propagateTypeMeta("str", elem)`, and `str_elem` lands
-on the loaded element. This is safe for parameters because the parameter
-alloca is a borrowed view — destructor selection happens at the **caller's
-allocation site**, not at the parameter slot. Only AssignStmt (which IS the
-allocation site for new variables) must avoid `list_elem_type_name = "str"`.
+**Narrowing (#1353, #1354)**: "Never stamp `list_elem_type_name = "str"` on the allocation path" was narrowed to "never stamp **without** a matching insert-side retain". Map/List/Set literals stamp the type-name on `headerPtr` AFTER emitting per-element `retainArcValue` (via `isStrHandle` side-table check). Pre-increment compensates the `makeString`/`__ry_arc_alloc_counted` counter asymmetry at insert time. Pure-annotation AssignStmt path still avoids stamping for non-literal sources — use `inner_is_str` side-channel.
 
-**Narrowing (#1353, #1354)**: The above "never stamp on the allocation path"
-rule has since been narrowed to "never stamp **without** a matching insert-side
-retain". PR #1353 (Map literals) and this PR's sibling fix for List/Set
-literals (#1354) do stamp `map_key_type_name = "str"` /
-`map_value_type_name = "str"` / `list_elem_type_name = "str"` /
-`set_elem_type_name = "str"` on the literal's `headerPtr`, but only after the
-literal path emits an explicit `retainArcValue` for each str handle via the
-`isStrHandle` side-table check. The retain pre-increments the ARC counter by
-+1 per element, which the str-aware destructor then decrements symmetrically —
-the `makeString`/`__ry_arc_alloc_counted` counter asymmetry is compensated at
-insert time rather than suppressed at dispatch time. The rule "no stamp
-without retain" still governs the pure-annotation AssignStmt path (`xs:
-List<str> = some_call()`): valMeta inheritance propagates the stamp set by
-the literal / returned map / returned set, but the annotation fallback in
-`codegen_stmt.cpp` still avoids stamping `list_elem_type_name = "str"` for
-non-literal sources because those sources may not have paid the insert-side
-retain (in practice they did, via their own literal path, but the
-annotation-fallback branch runs only when valMeta is empty and cannot verify
-this). Use `inner_is_str` side-channel there instead.
-
-**Verification pattern**: Behavioural ARC tests using
-`runtime_internal.arcLiveCount()` cannot detect missed retains directly —
-the counter tracks live allocations, not refcount. Use a FileCheck IR golden
-under `tests/filecheck/` that asserts the `arc.retain:` / `arc.retain.done:`
-basic-block labels appear after the container-element load, and that the
-`getelementptr i8, ptr %elem, i64 -16` (ArcHeader) or `i64 -24` (StringHeader)
-offset matches the element's actual header layout. See
-`tests/filecheck/arc_retain_list_elem_*.ry`,
-`tests/filecheck/arc_retain_map_value_new_var.ry`,
-`tests/filecheck/arc_retain_list_str_elem.ry`, and
-`tests/filecheck/arc_retain_map_str_value.ry` for canonical patterns.
+**Verification**: Behavioural ARC tests via `runtime_internal.arcLiveCount()` cannot detect missed retains directly (counter tracks live allocations, not refcount). Use FileCheck IR goldens (`tests/filecheck/arc_retain_*`) asserting `arc.retain:` / `arc.retain.done:` blocks appear after container-element load with `getelementptr i8, ptr %elem, i64 -16` (ArcHeader) or `i64 -24` (StringHeader).
 
 ### Pattern binding ARC and `emitPatternBindingArc`
 
-**Source**: #997 (2026-04-16, fix)
+**Source**: #997 (2026-04-16)
 **Tags**: codegen, arc, pattern, match, retain, memory-safety
 
-**Rule**: Every pattern binding arm that extracts a sub-value (via
-`ExtractValue` or `Load`) must call `emitPatternBindingArc(val, bindAlloca,
-typeSig)` after storing the extracted value. Without this, scoped ARC release
-will call `free(ptr - 16)` on a pointer that was never ARC-retained, causing
-a crash or refcount underflow.
+**Rule**: Every pattern binding arm that extracts a sub-value (via `ExtractValue` or `Load`) must call `emitPatternBindingArc(val, bindAlloca, typeSig)` after storing. Without this, scoped ARC release calls `free(ptr - 16)` on a never-retained pointer → crash or refcount underflow.
 
-Affected patterns and what typeSig to pass:
-- **SomePattern** / **OkPattern**: `innerSig = extractGenericTypeArg(subjectEnumType, "Option<"/"Result<", 0)`
-- **ErrPattern**: `innerSig = extractGenericTypeArg(subjectEnumType, "Result<", 1)`
-- **EnumConstructorPattern**: `fit->second.fieldTypeNames[bi]` for each field
-- **VariablePattern** / **TuplePattern** / **RecordPattern**: pass `""` (fall through to source-alloca heuristic)
+**typeSig per pattern**:
+- `SomePattern` / `OkPattern`: `extractGenericTypeArg(subjectEnumType, "Option<"/"Result<", 0)`
+- `ErrPattern`: `extractGenericTypeArg(subjectEnumType, "Result<", 1)`
+- `EnumConstructorPattern`: `fit->second.fieldTypeNames[bi]` per field
+- `VariablePattern` / `TuplePattern` / `RecordPattern`: `""` (fall through to source-alloca heuristic)
 
 **What `emitPatternBindingArc` does**:
-1. If `val` is a record struct (`llvm::StructType`) with ARC fields: retain the ARC fields for `LoadInst`/`ExtractValueInst` sources via `emitRecordArcFieldsRetain`, and insert `bindAlloca` into `arc_field_record_vars_`. Return.
-2. If `val->getType() != ptrTy_` (scalar, non-ARC) → return.
-3. If `typeSig` resolves to a collection type (`isCollectionTypeName`): retain + mark ARC-managed + insert into `arc_backed_vars_`. Return.
-4. If `typeSig` is a function type (`isFunctionTypeName`): retain and mark ARC-managed **only for capturing/uniform closures** (detected via `fn_type_info` metadata on the source value). Bare function pointers are skipped. Return.
-5. If `typeSig` is `"str"`: retain via `emitStrGetHeaderFromData` (offset −24), mark ARC-managed, insert into `arc_str_managed_vars_`. Return. (see **`str` is ARC-managed** below). Other non-collection non-closure pointer types: do not retain. Return.
-6. Otherwise (no `typeSig`): fall through to `tryRetainArcSource(val)` (source-alloca heuristic); then check `arc_owned_values_`; then check collection-type metadata set by `propagateTypeMeta`.
+1. If `val` is a record struct with ARC fields: retain ARC fields for `LoadInst`/`ExtractValueInst` sources via `emitRecordArcFieldsRetain`, insert `bindAlloca` into `arc_field_record_vars_`. Return.
+2. If `val->getType() != ptrTy_` (scalar) → return.
+3. If `typeSig` is collection (`isCollectionTypeName`): retain + mark ARC-managed + insert into `arc_backed_vars_`. Return.
+4. If `typeSig` is function type: retain + mark ARC-managed only for capturing/uniform closures (`fn_type_info` metadata). Bare function pointers skipped. Return.
+5. If `typeSig == "str"`: retain via `emitStrGetHeaderFromData` (offset −24), mark ARC-managed, insert into `arc_str_managed_vars_`. Return.
+6. Otherwise (no `typeSig`): fall through to `tryRetainArcSource(val)` → `arc_owned_values_` → collection-type metadata.
 
-**`str` is ARC-managed (#1046, updated #1105)**: `str` values are fully ARC-managed since PR #1046. Use `emitStrGetHeaderFromData(handle)` (offset −24, `STRING_HEADER_SIZE`) — **not** `emitArcGetHeaderFromData` (offset −16, `ARC_HEADER_SIZE`) — to get the ARC header for a `str`. Dispatch via `resolveTypeAlias(typeName) == "str"` or check `arc_str_managed_vars_.count(alloca) > 0` before calling retain/release helpers. The `arc_str_managed_vars_` side-table records all AllocaInsts whose type is `str`, enabling correct offset selection in `emitArcReleaseVar`. `fieldTypeIsArcManaged("str")` returns true with `outKind = CollectionKind::Str`. Collection destructors for `List<str>`, `Map<K,str>`, `Set<str>` iterate elements and call `emitArcRelease(emitStrGetHeaderFromData(elem))` before freeing the data buffer.
+**`str` is ARC-managed (#1046, updated #1105)**: Use `emitStrGetHeaderFromData(handle)` (offset −24, `STRING_HEADER_SIZE`), **not** `emitArcGetHeaderFromData` (offset −16, `ARC_HEADER_SIZE`). Dispatch via `resolveTypeAlias(typeName) == "str"` or `arc_str_managed_vars_.count(alloca) > 0`. `fieldTypeIsArcManaged("str")` returns true with `outKind = CollectionKind::Str`. Collection destructors for `List<str>` / `Map<K,str>` / `Set<str>` iterate elements and call `emitArcRelease(emitStrGetHeaderFromData(elem))`.
 
-**ARC header offset dispatch — use helpers, not inline `emitArcGetHeaderFromData` (#1105)**: Never call `emitArcGetHeaderFromData` inline at retain/release sites that may handle `str` handles. Use these helpers instead:
+**ARC header offset dispatch — use helpers, not inline `emitArcGetHeaderFromData` (#1105)**: Never call `emitArcGetHeaderFromData` inline at retain/release sites that may handle `str`. Helpers:
+- **`emitArcHeaderForAlloca(handle, alloca)`** — checks `arc_str_managed_vars_.count(alloca)`, dispatches correctly. Use at all alloca-origin sites.
+- **`CapturedArcKind::Str`** — `detectCapturedArcKind` returns this when captured alloca is in `arc_str_managed_vars_`. Closure construction/destructor switch on it.
+- **`arc_str_owned_values_` guard in ExprStmt** — bare `str` temporaries are in `arc_str_owned_values_`, not `arc_owned_values_`. `emitStmt(ExprStmt)` checks both.
 
-- **`emitArcHeaderForAlloca(handle, alloca)`** — checks `arc_str_managed_vars_.count(alloca)` and dispatches to `emitStrGetHeaderFromData` / `emitArcGetHeaderFromData`. Use at all alloca-origin sites (e.g., `AssignStmt` old-value release).
-- **`CapturedArcKind::Str`** enum variant — returned by `detectCapturedArcKind` when the captured alloca is in `arc_str_managed_vars_`. Closure construction retain (`codegen_lambda.cpp`) and closure destructor release (`codegen_arc_cow.cpp`) switch on this variant to call `emitStrGetHeaderFromData` instead of the default `−16` path.
-- **`arc_str_owned_values_` guard in ExprStmt** — bare `str` temporaries (e.g., `"foo".toUpper()`) are in `arc_str_owned_values_`, not `arc_owned_values_`. `emitStmt(ExprStmt)` checks both sets and dispatches correctly.
-
-**Why inline `emitArcGetHeaderFromData` is dangerous**: Adding a new ARC-managed type with a non-standard header offset (like `str`'s +8 byte `byte_len` field) requires updating every inline callsite. An inline call that misses the update silently corrupts memory — `−16` into a `StringHeader` lands on `weak_count`, so the atomic add increments the wrong field. Use the helpers above to make future additions opt-in-correct rather than opt-in-wrong. The `@parallel for` capture site in `codegen_stmt_loop.cpp` uses a local `capIsArcStr[i]` vector instead of `emitArcHeaderForAlloca` because the thunk's `FnScope` clears `arc_str_managed_vars_` before the thunk body executes; do not change that pattern.
+Inline calls miss future header-offset additions silently — `−16` into `StringHeader` lands on `weak_count`, atomic-add increments the wrong field. The `@parallel for` capture site in `codegen_stmt_loop.cpp` uses local `capIsArcStr[i]` instead of `emitArcHeaderForAlloca` because the thunk's `FnScope` clears `arc_str_managed_vars_` before thunk body executes.
 
 ### StringHeader layout — `str` memory representation (#1022)
 
 **Source**: #1022 (2026-04-16)
 **Tags**: str, StringHeader, ARC, memory-layout, NUL, byte_len, makeString
 
-**Rule**: Every Ry `str` value is a pointer to the *data* region of a `StringHeader` block. Never treat a Ry `str` handle as a raw `char*` allocated with `malloc`/`strdup`; always use `makeString`/`makeStringUninit` to create them and `freeStringSlot` to free them.
+**Rule**: Every Ry `str` is a pointer to the *data* region of a `StringHeader` block. Always use `makeString`/`makeStringUninit` to create, `freeStringSlot` to free. Never treat as raw `char*`.
 
-**Layout** (defined in `include/ry/ry_layout.hpp` and `include/ry/runtime_string.hpp`):
+**Layout** (`include/ry/ry_layout.hpp`, `include/ry/runtime_string.hpp`):
 
 ```text
-Offset from handle:  Field
-  handle - 24       strong_count : i64  (ARC_IMMORTAL for literals; 1 for dynamic)
-  handle - 16       weak_count   : i64  (0 always in PR #1022)
-  handle - 8        byte_len     : i64  (STRING_BYTELEN_OFFSET = 8)
-  handle + 0 ..     data bytes          ← the char* passed to Ry / codegen
-  handle + byte_len '\0'                (null terminator for libc compat)
+handle - 24       strong_count : i64  (ARC_IMMORTAL for literals; 1 for dynamic)
+handle - 16       weak_count   : i64  (0 always in PR #1022)
+handle - 8        byte_len     : i64  (STRING_BYTELEN_OFFSET = 8)
+handle + 0 ..     data bytes          ← the char* passed to Ry / codegen
+handle + byte_len '\0'                (null terminator for libc compat)
 ```
 
-Key constants:
-- `ARC_HEADER_SIZE = 16` (unchanged — collection headers keep this offset)
-- `STRING_HEADER_SIZE = 24` (= ARC_HEADER_SIZE + 8 for the byte_len field)
-- `STRING_BYTELEN_OFFSET = 8`
+Constants: `ARC_HEADER_SIZE = 16`, `STRING_HEADER_SIZE = 24`, `STRING_BYTELEN_OFFSET = 8`.
 
-**How to get byte length in C++**: `stringByteLen(handle)` — reads `*(int64_t*)(handle - 8)`.  
-**How to get byte length in LLVM IR**: `emitStringByteLen(handle)` — emits a GEP + load.  
-**How to free a dynamic str**: `freeStringSlot(handle)` — calls `free(handle - STRING_HEADER_SIZE)`.  
-**Literal globals**: created by `buildArcGlobal` in `src/codegen.cpp`; `strong_count = ARC_IMMORTAL` so retain/release are no-ops. GEP index is `(0, 3, 0)` into the struct.
+**APIs**: `stringByteLen(handle)` (C++) / `emitStringByteLen(handle)` (IR) for length; `freeStringSlot(handle)` calls `free(handle - 24)`. Literal globals built by `buildArcGlobal` in `src/codegen.cpp` use `strong_count = ARC_IMMORTAL`; GEP index `(0, 3, 0)`.
 
-**NUL safety**: All string operations are now fully NUL-safe. Complete list:
-- `byteLen`, `len`, `==`/`!=`/`<`/`>`, `+`, `*`, Map/Set key hash+compare (#1022)
-- `contains`, `startsWith`, `endsWith`, `find` (#1047)
-- `replace` (#1048)
-- `substr`, `charAt`, `reverse`, `split("", _)`, `for c in str:`, `enumerate(str)` (#1049)
-- `isEmpty` (#1069)
-- `toUpper`, `toLower`, `trim`, `trimStart`, `trimEnd` (#1050)
-- `split(str, delim)` with non-empty delimiter (runtime `__ry_str_split` via `memmem`), `join`, `repeat`, `*` operator (#1051)
-- `regexMatch`, `regexSearch`, `regexReplace`, `regexSplit`, `regexFindAll` and all UFCS variants (`isMatch`, `search`, `replace`, `split`, `findAll`) — subject + pattern + replacement all length-driven, no `strlen` (#1052). Regex *literal* syntax also supports `\0` to encode a NUL byte in the pattern (`/a\0b/` matches `"a\0b"`) since #1076.
-- `json.parse`, `json.stringify`, `json.toStr`, `json.get`, `json.keys` (#1053) — `JsonValue::string_val` and `JsonObjectVal::keys[i]` are now StringHeader handles allocated via `makeString`; `stringByteLen` is the single length source; `escape_string` iterates by index and emits `\u0000` for NUL bytes; `Parser` uses explicit `src_len` from `stringByteLen` instead of `strlen`/`'\0'` sentinel. C++ test helpers updated to wrap literals in `makeString` since `__ry_json_parse` / `__ry_json_get` expect StringHeader handles.
-- `io.writeText`, `io.appendText` (#1133) — replaced `fputs(content, f)` (stops at first `\0`) with `fwrite(content, 1, stringByteLen(content), f)`. Binary-transparent round-trip for content now matches `io.writeBytes`. `fclose` return code is still checked so buffered-write errors surface as `Err`.
+**NUL safety**: All string operations are NUL-safe — `byteLen`, `len`, comparison/concat, hashing (#1022); `contains`/`startsWith`/`endsWith`/`find` (#1047); `replace` (#1048); `substr`/`charAt`/`reverse`/`split("",_)`/iteration (#1049); `isEmpty` (#1069); case/trim ops (#1050); `split(s,delim)`/`join`/`repeat`/`*` (#1051); regex APIs incl. `\0` literal in pattern (#1052, #1076); JSON APIs (#1053); `io.writeText`/`appendText` use `fwrite` not `fputs` (#1133).
 
 ### `arc_str_managed_vars_` side-table for str ARC dispatch (#1046)
 
 **Source**: #1046 (2026-04-17)
 **Tags**: ARC, str, side-table, offset, emitStrGetHeaderFromData
 
-**Rule**: Whenever an `AllocaInst` holds a `str` value that participates in ARC (i.e., was retained on assignment), insert it into `arc_str_managed_vars_`. This side-table is the canonical way to select `emitStrGetHeaderFromData` vs `emitArcGetHeaderFromData` at release time in `emitArcReleaseVar`.
+**Rule**: Any `AllocaInst` holding a `str` that participates in ARC must be inserted into `arc_str_managed_vars_`. This is the canonical dispatch source for `emitStrGetHeaderFromData` vs `emitArcGetHeaderFromData` in `emitArcReleaseVar`.
 
-**Why**: LLVM IR has no type-level distinction between a `str` handle (`ptr` at offset −24) and a collection handle (`ptr` at offset −16). Without the side-table, every release would use the wrong offset for one of the types, silently corrupting the ARC header.
+**Why**: LLVM IR has no type-level distinction between str (`ptr` at −24) and collection (`ptr` at −16). Without the side-table, every release uses the wrong offset.
 
-**How to apply**: After inserting into `arc_managed_vars_` (via `markArcManaged`) for a str-typed alloca, also insert into `arc_str_managed_vars_`. Intermediary tmp allocas created in RecordPattern / EnumConstructorPattern must be added too, so that downstream VariablePattern bindings loaded from them inherit the correct offset. Do NOT add allocas to `arc_backed_vars_` (the CoW set) for str — CoW uses `emitArcGetHeaderFromData` offset and would corrupt the str header.
+**How to apply**: After `markArcManaged` for a str-typed alloca, also insert into `arc_str_managed_vars_`. Intermediary tmp allocas in RecordPattern / EnumConstructorPattern need it too (downstream VariablePattern bindings inherit). Do NOT add str allocas to `arc_backed_vars_` (CoW set) — CoW uses −16 and corrupts.
 
 ### `@parallel for` str captures must use `emitStrGetHeaderFromData` (#1046)
 
 **Source**: #1046 (2026-04-17)
 **Tags**: ARC, str, parallel_for, concurrency, offset, segfault
 
-**Rule**: In `emitParallelForRange` (`src/codegen_stmt_loop.cpp`), when a captured variable is a `str` (i.e., it is in `arc_str_managed_vars_`), the thunk entry retain and the `arc_str_managed_vars_` side-table insertion for the thunk-local dst alloca must both use `emitStrGetHeaderFromData` (offset −24), not `emitArcGetHeaderFromData` (offset −16).
+**Rule**: In `emitParallelForRange` (`src/codegen_stmt_loop.cpp`), captured `str` variables (in `arc_str_managed_vars_`) require `emitStrGetHeaderFromData` (−24) at thunk entry retain AND for the thunk-local dst alloca's `arc_str_managed_vars_` insertion. Wrong offset → `weak_count` decrement → `free()` on literal global's read-only static allocation → segfault.
 
-**Why**: Before #1046, str was never ARC-managed, so no str captures reached the retain path. After #1046, a `str` variable captured by `@parallel for` entered the retain path with the wrong offset: `emitArcGetHeaderFromData` pointed to `weak_count` (not `strong_count`). Each worker retained/released `weak_count` instead. When the last worker's release decremented `weak_count` to 0, the destructor called `free()` on a literal global's static allocation → segfault.
-
-**How to apply**: Snapshot `capIsArcStr[i] = arc_str_managed_vars_.count(src) > 0` alongside `capIsArcManaged` and `capIsArcBacked` in the parent context (before `FnScope` clears the side-tables). In the thunk: after `markArcManaged(dst)`, if `capIsArcStr[i]` insert `dst` into `arc_str_managed_vars_`; at the retain site use `capIsArcStr[i] ? emitStrGetHeaderFromData(dataPtr) : emitArcGetHeaderFromData(dataPtr)`. The release via `popScope()→emitArcReleaseVar()` will then automatically select the correct offset via `arc_str_managed_vars_`.
+**How to apply**: Snapshot `capIsArcStr[i] = arc_str_managed_vars_.count(src) > 0` in parent context BEFORE `FnScope` clears the side-tables. In thunk: after `markArcManaged(dst)`, if `capIsArcStr[i]` insert `dst` into `arc_str_managed_vars_`; retain via `capIsArcStr[i] ? emitStrGetHeaderFromData : emitArcGetHeaderFromData`. Release via `popScope→emitArcReleaseVar` auto-selects.
 
 ### `emitPatternBindingArc` path 2b must propagate `arc_str_managed_vars_` from source (#1046)
 
 **Source**: #1046 (2026-04-17)
-**Tags**: ARC, str, pattern-binding, emitPatternBindingArc, arc_str_managed_vars_, segfault
+**Tags**: ARC, str, pattern-binding, arc_str_managed_vars_, segfault
 
-**Rule**: In `emitPatternBindingArc` path 2b ("no type signature — probe heuristically"), when `tryRetainArcSource(val)` returns true and `val` is a `LoadInst` from a source alloca in `arc_str_managed_vars_`, the destination `bindAlloca` must also be inserted into `arc_str_managed_vars_` — **not** into `arc_backed_vars_`. The check must mirror the full set hierarchy: closure → str → arc_backed.
+**Rule**: In path 2b (no type signature, probe heuristically), when `tryRetainArcSource(val)` returns true and `val` is a `LoadInst` from a source alloca in `arc_str_managed_vars_`, the destination `bindAlloca` must be inserted into `arc_str_managed_vars_`, NOT `arc_backed_vars_`. Set hierarchy: closure → str → arc_backed.
 
-**Why**: `emitArcReleaseVar` dispatches on the alloca's set membership to pick the header offset. `arc_backed_vars_` members use `emitArcGetHeaderFromData` (offset −16). For a `str` value, offset −16 is the `weak_count` field, not `strong_count`. When the `strong_count` check reads `weak_count = 0` instead of `ARC_IMMORTAL`, the immortal guard is bypassed and the code tries to atomically decrement `*(handle − 16)`. Since Ry string literal globals are compiled as `isConstant=true` LLVM globals (mapped read-only by the JIT), any write to them causes a SIGSEGV.
+**Why**: `arc_backed_vars_` members use offset −16. For str, that's `weak_count` (0, not `ARC_IMMORTAL`), bypassing the immortal guard, then atomically writing to a read-only literal global → SIGSEGV.
 
-**How to apply**:
 ```cpp
-// Correct propagation in emitPatternBindingArc path 2b:
 if (auto *ld = llvm::dyn_cast<llvm::LoadInst>(val)) {
     auto *src = llvm::dyn_cast<llvm::AllocaInst>(ld->getPointerOperand());
-    if (src && closure_managed_vars_.count(src))
-        closure_managed_vars_.insert(bindAlloca);
-    else if (src && arc_str_managed_vars_.count(src))   // ← must check str before arc_backed
-        arc_str_managed_vars_.insert(bindAlloca);
-    else
-        arc_backed_vars_.insert(bindAlloca);
-} else if (arc_str_owned_values_.count(val)) {          // non-LoadInst str source
+    if (src && closure_managed_vars_.count(src)) closure_managed_vars_.insert(bindAlloca);
+    else if (src && arc_str_managed_vars_.count(src)) arc_str_managed_vars_.insert(bindAlloca);
+    else arc_backed_vars_.insert(bindAlloca);
+} else if (arc_str_owned_values_.count(val)) {
     arc_str_managed_vars_.insert(bindAlloca);
 } else {
     arc_backed_vars_.insert(bindAlloca);
 }
 ```
 
-This matters any time a `str` is extracted from an enum field via `EnumConstructorPattern` with a `VariablePattern` binding: the tmp alloca for the field is in `arc_str_managed_vars_`, and when `emitPatternBindings` recurses into `VariablePattern`, the resulting binding alloca inherits the str classification.
+Triggers when a `str` is extracted from an enum field via `EnumConstructorPattern` with a `VariablePattern` binding — the field's tmp alloca is in `arc_str_managed_vars_`, and `emitPatternBindings` recursing into `VariablePattern` must inherit the str classification.
 
-### Str literal globals are `isConstant=true` — wrong offset → SIGSEGV, not SIGABRT
+### Str literal globals are `isConstant=true` — wrong offset → SIGSEGV not SIGABRT
 
 **Source**: #1046 (2026-04-17)
-**Tags**: ARC, str, StringHeader, isConstant, LLVM, offset, segfault
+**Tags**: ARC, str, StringHeader, isConstant, offset, segfault
 
-**Rule**: In `cachedGlobalString` (`src/codegen.cpp`), the StringHeader global for string literals is created with `isConstant=true`. The JIT maps such globals as read-only pages. Any code that uses `emitArcGetHeaderFromData` (offset −16) instead of `emitStrGetHeaderFromData` (offset −24) on a literal `str` will bypass the `ARC_IMMORTAL` guard (because `weak_count=0 ≠ INT64_MAX`), then attempt an atomic write to the read-only page → SIGSEGV (exit 139), not SIGABRT.
-
-This makes wrong-offset bugs on str literals almost always fatal immediately, which is useful for diagnosis but means the stack trace will point into JIT code at an unusual address. Cross-reference with `arc_str_managed_vars_` membership at the crashing alloca's declaration site.
+**Rule**: `cachedGlobalString` creates StringHeader globals with `isConstant=true`; JIT maps them as read-only. Using `emitArcGetHeaderFromData` (−16) on a literal `str` reads `weak_count = 0 ≠ INT64_MAX`, bypasses `ARC_IMMORTAL` guard, then atomically writes to read-only page → SIGSEGV (exit 139), not SIGABRT. Stack trace points into JIT code at unusual address. Cross-reference `arc_str_managed_vars_` membership at the crashing alloca's declaration site.
 
 ### `List<str>` / `Map<K,str>` / `Set<str>` destructor specialization (#1046)
 
 **Source**: #1046 (2026-04-17)
-**Tags**: ARC, str, collection, destructor, List, Map, Set, memory-leak
+**Tags**: ARC, str, collection, destructor, leak
 
-**Rule**: `getOrCreateCollectionDestructor` uses a `(CollectionKind, elemSig, valSig)` tuple cache key, not `CollectionKind` alone. Caching by kind only would produce a single generic destructor that does not release str elements, causing leaks for any `List<str>`, `Map<K,str>`, or `Set<str>`.
+**Rule**: `getOrCreateCollectionDestructor` cache key is `(CollectionKind, elemSig, valSig)`, not kind alone. When `elemSig == "str"` (or `valSig == "str"` for Map values), the destructor iterates the dense element array and calls `emitArcRelease(emitStrGetHeaderFromData(elem))` before freeing the buffer. Caching by kind only would produce a single generic destructor that leaks str elements.
 
-**Why**: When `elemSig == "str"` (or `valSig == "str"` for Map values), the destructor must iterate the dense element array and call `emitArcRelease(emitStrGetHeaderFromData(elem))` for each element before freeing the buffer. The generic destructor (cache key with empty sigs) only frees the data buffer.
+**How to apply**: `resolveCollectionDestructor(alloca)` reads `list_elem_type_name` / `map_key_type_name` / `map_value_type_name` from `ValueMeta`, calls `resolveTypeAlias` before passing to `getOrCreateCollectionDestructor`. Ensure the alloca carries correct type-name metadata.
 
-**How to apply**: `resolveCollectionDestructor(alloca)` reads `list_elem_type_name` / `map_key_type_name` / `map_value_type_name` from the alloca's `ValueMeta` and calls `resolveTypeAlias` before passing to `getOrCreateCollectionDestructor`. Always ensure the alloca carries the correct type name metadata before this call.
-
-**Extension (#1108)**: The same requirement applies to `emitArcReleaseLoadedElement`. When an ARC-managed element (e.g. `List<str>`) is stored in a slot (`List<List<str>>` element, `Map<K, List<str>>` value, record field), overwriting the slot must call `getOrCreateCollectionDestructor` with the **inner** elem/val signatures derived from the element's type name, not the generic (empty-sig) version. Fix: `emitArcReleaseLoadedElement` now accepts `elemTypeName` and calls `resolveTypeAlias` + `splitGenericTypeName` internally to derive `innerElemSig`/`innerValSig`. Callers must pass the declared element type name; passing `""` falls back to the generic destructor (leaks inner str). Rule: any new ARC release helper that calls `getOrCreateCollectionDestructor` must pass the full element type name, not just the `CollectionKind`.
+**Extension (#1108)**: Same applies to `emitArcReleaseLoadedElement`. Overwriting an ARC-managed element slot (`List<List<str>>`, `Map<K, List<str>>`, record field) must call `getOrCreateCollectionDestructor` with the **inner** elem/val sigs derived from the element's type name. `emitArcReleaseLoadedElement` accepts `elemTypeName` and resolves internally; passing `""` falls back to the generic destructor (leaks inner str).
 
 ### CoW copy of `List<str>` must retain str elements (#1046)
 
 **Source**: #1046 (2026-04-17)
-**Tags**: ARC, str, CoW, copy-on-write, double-free
+**Tags**: ARC, str, CoW, double-free
 
-**Rule**: When CoW-copying a `List<str>` (or `Map<K,str>`, `Set<str>`), str elements **must** be retained immediately after the copy, regardless of whether the `retainElements` parameter is `true`. In `emitCowCheckSlot`, `doElemRetain` is forced `true` when `elemArcKind == CollectionKind::Str`.
+**Rule**: When CoW-copying a `List<str>` / `Map<K,str>` / `Set<str>`, str elements MUST be retained immediately after the copy regardless of `retainElements`. In `emitCowCheckSlot`, `doElemRetain` is forced `true` when `elemArcKind == CollectionKind::Str`. Post-#1046 the destructor releases str elements — without retention both old and CoW copy would double-free.
 
-**Why**: Before #1046 the `List<str>` destructor did not release str elements (only freed the buffer), so no retention was needed during CoW. After #1046 the destructor releases elements — without retention the two lists (old + CoW copy) both try to release the same str elements, causing double-free.
-
-**How to apply**: In `emitCowRetainArcElements`, pass `elemArcKind` and use `emitStrGetHeaderFromData(elem)` (offset −24) when `elemArcKind == CollectionKind::Str`, otherwise `emitArcGetHeaderFromData(elem)` (offset −16). The wrong offset silently corrupts `weak_count` or `byte_len` instead of `strong_count`.
+**How to apply**: In `emitCowRetainArcElements`, pass `elemArcKind`; use `emitStrGetHeaderFromData(elem)` (−24) when `Str`, otherwise `emitArcGetHeaderFromData(elem)` (−16). Wrong offset silently corrupts `weak_count` or `byte_len`.
 
 ### `memcpy` of an element buffer must be paired with ARC retain (#1204)
 
 **Source**: #1204 (2026-04-19)
-**Tags**: codegen, arc, collections, slice, memcpy, retain, memory-safety
+**Tags**: codegen, arc, slice, memcpy, retain, memory-safety
 
-**Rule**: Any codegen path that duplicates a container's element buffer with `memcpy` — `emitListSlice`, `emitCollOp_take_impl`, `emitListConcat`, future helpers — must follow the `memcpy` with a retain loop when the source element type is ARC-managed (`List<str>`, `List<List<T>>`, `List<Map<K,V>>`, closures, …). The canonical pattern is:
+**Rule**: Any path that duplicates a container's element buffer with `memcpy` (`emitListSlice`, `emitCollOp_take_impl`, `emitListConcat`, future helpers) must follow with a retain loop when source elements are ARC-managed:
 
 ```cpp
 CollectionKind elemArcKind = CollectionKind::List;
@@ -399,426 +199,246 @@ if (elementTypeIsArcManaged(srcListPtr, CollectionKind::List, &elemArcKind)) {
 }
 ```
 
-**Why**: `memcpy` copies raw pointers — it does not bump the embedded ARC strong_count. When the source list is later released (scope exit, reassignment, destructor), its destructor walks the element buffer and decrements each element's refcount. Without retention the new buffer's elements are freed out from under it, producing a dangling pointer the holder will eventually dereference (heap-use-after-free on subsequent read, double-free on subsequent release).
+**Why**: `memcpy` copies raw pointers without bumping refcount. When source is later released, its destructor walks elements and decrements each — without retention the new buffer's elements are freed underneath.
 
-**How to apply**: `elementTypeIsArcManaged(containerPtr, kind, &outElemKind)` reads `list_elem_type_name` / `map_*_type_name` from the *source* container's metadata — make sure the source pointer (not the newly-allocated header) is passed. Scalar element types (`List<int>`, `List<f64>`) naturally take the false branch, so the scalar path is unchanged. `emitCowRetainArcElements` handles str offset (−24) vs collection offset (−16) internally based on `elemArcKind`, so the caller does not need to distinguish. `emitCowClone` in `src/codegen_arc_cow.cpp` is the reference implementation — it performs the same memcpy+retain sequence for the CoW path.
+**How to apply**: `elementTypeIsArcManaged` reads from the *source* container's metadata (pass source pointer, not new header). Scalar types take false branch. `emitCowRetainArcElements` handles str (−24) vs collection (−16) offset internally based on `elemArcKind`. Reference: `emitCowClone` in `src/codegen_arc_cow.cpp`.
 
-**Related**: #1046 (CoW str retain), #855 (slot overwrite release), #1184 (slice helper extracted from `emitCollOp_slice`), #1235 (fixed for `emitCollOp_take_impl`), #1236 (same defect in `emitListConcat`).
-
-### `markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`, and `str` fields must also be inserted into `arc_str_managed_vars_`
+### `markArcManaged(tmp)` pre-mark must be guarded by `fieldTypeIsArcManaged`, str fields also into `arc_str_managed_vars_`
 
 **Source**: #1016 (updated #1046)
 **Tags**: ARC, str, pattern-binding, arc_str_managed_vars_, CollectionKind
 
-TuplePattern / RecordPattern / EnumConstructorPattern pre-mark a temporary alloca
-(`tmp`) as ARC-managed so the recursive leaf `VariablePattern` binding can emit a
-single retain via `tryRetainArcSource` Case 1. Without the guard, _any_ `ptrTy_`
-field (including bare fn-ptr and resource ptrs) is incorrectly marked.
-Fix (post-#1046): use `CollectionKind fk; if (fieldTypeIsArcManaged(elemSig, &fk)) { markArcManaged(tmp); if (fk == CollectionKind::Str) arc_str_managed_vars_.insert(tmp); }` at all three sites (`src/codegen_match.cpp`). `fieldTypeIsArcManaged` returns true for List/Map/Set/str and false for fn-ptr/resource/etc. The `arc_str_managed_vars_` insertion is required so `tryRetainArcSource` Case 1 dispatches to `emitStrGetHeaderFromData` (offset −24) instead of `emitArcGetHeaderFromData` (offset −16) for str fields. Capturing closure in tuple/record/enum fields is intentionally excluded: `fn_type_info` metadata is not propagated by `propagateTypeMeta` onto `ExtractValue` intermediates, so closure detection is impossible here; this was also the pre-#1008 behaviour.
+**Rule**: TuplePattern / RecordPattern / EnumConstructorPattern pre-mark a tmp alloca so the leaf `VariablePattern` binding can retain via `tryRetainArcSource` Case 1. Without `fieldTypeIsArcManaged` guard, ANY `ptrTy_` field (incl. fn-ptr, resource ptrs) gets marked. Fix:
+
+```cpp
+CollectionKind fk;
+if (fieldTypeIsArcManaged(elemSig, &fk)) {
+    markArcManaged(tmp);
+    if (fk == CollectionKind::Str) arc_str_managed_vars_.insert(tmp);
+}
+```
+
+at all three sites (`src/codegen_match.cpp`). Capturing closure in tuple/record/enum fields is intentionally excluded: `fn_type_info` metadata is not propagated by `propagateTypeMeta` onto ExtractValue intermediates (pre-#1008 behaviour).
 
 ### `emitStrGetDataPtr` must insert into `arc_str_owned_values_`, not `arc_owned_values_`
 
 **Source**: PR #1148 review (2026-04-18)
-**Tags**: codegen, str, ARC, arc_str_owned_values_, emitStrGetDataPtr, StringHeader
+**Tags**: codegen, str, ARC, arc_str_owned_values_, emitStrGetDataPtr
 
-**Rule**: `emitStrGetDataPtr` recovers the str data handle from a StringHeader pointer (GEP by `+STRING_HEADER_SIZE`). The result must go into `arc_str_owned_values_` (not `arc_owned_values_`), because downstream retain/release for str uses `emitStrGetHeaderFromData` (offset −24) while collection ARC uses `emitArcGetHeaderFromData` (offset −16). Putting a str handle in `arc_owned_values_` causes every subsequent retain/release to corrupt memory by reading the wrong 8 bytes.
+**Rule**: `emitStrGetDataPtr` recovers str data via `GEP(+STRING_HEADER_SIZE)`. Result must go into `arc_str_owned_values_` — downstream retain/release uses `emitStrGetHeaderFromData` (−24). Putting in `arc_owned_values_` causes every retain/release to corrupt 8 bytes via wrong offset.
 
-**How to apply**: Search for `arc_owned_values_.insert` at call sites that received their value from `emitStrGetDataPtr` or from a `GEP(i8*, strHeaderPtr, STRING_HEADER_SIZE)` — these should be `arc_str_owned_values_.insert` instead.
+**How to apply**: Search for `arc_owned_values_.insert` at sites receiving values from `emitStrGetDataPtr` or `GEP(i8*, strHeaderPtr, STRING_HEADER_SIZE)` — should be `arc_str_owned_values_.insert`.
 
-### `emitArithmeticOp` str+str: input owned temps must be released at the concat site, not deferred to ExprStmt
+### `emitArithmeticOp` str+str: input owned temps must be released at concat site
 
-**Source**: #1583 (2026-05-05, fix)
-**Tags**: codegen, arc, str, concat, arc_str_owned_values_, leak, emitArithmeticOp, chained-binary
+**Source**: #1583 (2026-05-05)
+**Tags**: codegen, arc, str, concat, leak, chained-binary
 
-**Rule**: After the second `memcpy` in the str+str branch of `emitArithmeticOp` (`src/codegen_expr.cpp`) and before `arc_str_owned_values_.insert(buf)`, emit `emitArcRelease(emitStrGetHeaderFromData(operand), atomic=false)` plus `arc_str_owned_values_.erase(operand)` for every input (lhs, rhs) that is currently tracked in `arc_str_owned_values_`. The buffer just produced by `__ry_string_make_uninit` is the only owned-temp that must survive the call.
+**Rule**: After the second `memcpy` in str+str branch of `emitArithmeticOp` and before `arc_str_owned_values_.insert(buf)`, emit `emitArcRelease(emitStrGetHeaderFromData(operand), atomic=false)` + `arc_str_owned_values_.erase(operand)` for every input (lhs, rhs) currently in `arc_str_owned_values_`. The freshly allocated `__ry_string_make_uninit` buffer is the only owned-temp that survives the call.
 
-**Why**: `BinaryExpr("+", BinaryExpr("+", "x", "y"), "z")` evaluates the inner concat first, producing an inner buf that is registered in `arc_str_owned_values_`. The outer concat consumes it as its lhs, copies its data, and then leaves it behind. `emitStmt(ExprStmt)` only releases the outermost SSA value, so the inner buf leaks (`g_arc_live_count` grows by 1 per chained inner concat). Releasing at the concat site is enclosing-context-independent: it works equally for bare `ExprStmt`, let-binding, return value, function arg, and nested binary, whereas a snapshot-and-drain approach in `emitStmt(ExprStmt)` only catches the bare-statement case.
+**Why**: `BinaryExpr("+", BinaryExpr("+", "x", "y"), "z")` — inner concat produces inner buf in `arc_str_owned_values_`; outer concat copies it but leaves it. `emitStmt(ExprStmt)` only releases outermost SSA; inner buf leaks per chained inner concat. Releasing at concat site is enclosing-context-independent (works for ExprStmt, let-binding, return, function arg, nested binary).
 
-**Edge cases handled by the `count(operand) > 0` guard**: (a) literal globals — never inserted into `arc_str_owned_values_`, skipped; (b) borrowed `VariableExpr` loads — same, skipped; (c) `lhs == rhs` (e.g. `s + s`) — the first iteration releases and erases, the second iteration sees `count == 0` and skips; (d) immortal handles — `emitArcRelease` checks `ARC_IMMORTAL` internally and short-circuits. The release is emitted **after** `memcpy` so the source data is still valid when copied.
+**Edge cases handled by `count(operand) > 0` guard**: literal globals (never inserted, skipped); borrowed VariableExpr loads (skipped); `lhs == rhs` (`s + s`) — first iteration releases-and-erases, second sees count == 0; immortal handles (`emitArcRelease` short-circuits on `ARC_IMMORTAL`). Release after `memcpy` so source data is still valid when copied.
 
-**How to apply**: Any future code path that produces a freshly-allocated str into `arc_str_owned_values_` and consumes input temps from the same set must mirror this pattern: after the consumer is done reading the input, release any input still in `arc_str_owned_values_` and erase the entry. Verified via `tests/spec/str_arc.test.ry` (chained 3-arg / 4-arg / let-binding `arcLiveCount` deltas) and the `tests/filecheck/str_concat_chain_release.ry` IR golden which asserts the inner buf's `arc.release.body` block lands before the outer buf's `store ptr ..., ptr %s`.
+**How to apply**: Any future path producing a fresh str into `arc_str_owned_values_` and consuming inputs from the same set must mirror this pattern. Verified via `tests/spec/str_arc.test.ry` (chained 3/4-arg, let-binding `arcLiveCount` deltas) and IR golden `tests/filecheck/str_concat_chain_release.ry`.
 
 ### Map CoW must retain str keys independently of value retention
 
 **Source**: PR #1148 review (2026-04-18)
-**Tags**: codegen, CoW, Map, str, ARC, emitCowClone, elementTypeIsArcManaged
+**Tags**: codegen, CoW, Map, str, ARC, emitCowClone
 
-**Rule**: `elementTypeIsArcManaged(containerPtr, CollectionKind::Map, &kind)` only checks `map_value_type_name`, not `map_key_type_name`. Therefore the CoW clone loop (`emitCowClone`) retains values but never keys. For `Map<str, V>`, str keys are released by the destructor but never retained after the clone — use-after-free. After the value-retention block, emit a separate key-retention loop if `meta->map_key_type_name` resolves to an ARC-managed type (check via `fieldTypeIsArcManaged`). The Map destructor already handles str key release (L964 in `codegen_arc.cpp`: `if (elemSig == "str") emitStrElemLoop(keys, len, "mkey")`), so the missing piece is only on the retain side.
+**Rule**: `elementTypeIsArcManaged(containerPtr, CollectionKind::Map, &kind)` checks `map_value_type_name` only, NOT `map_key_type_name`. The CoW clone loop (`emitCowClone`) thus retains values but never keys → `Map<str, V>` str keys are released by destructor but never retained after clone → use-after-free. Emit a separate key-retention loop after value-retention if `meta->map_key_type_name` resolves to ARC-managed (check via `fieldTypeIsArcManaged`). Map destructor already handles str key release (`codegen_arc.cpp:964` `emitStrElemLoop(keys, len, "mkey")`).
 
 ### Map literal `{k: v}` with str keys/values needs side-table retain + explicit str stamp
 
 **Source**: #1347 (2026-04-24)
-**Tags**: codegen, Map, literal, str, ARC, inferCollectionTypeName, retainArcValue, map_key_type_name
+**Tags**: codegen, Map, literal, str, ARC, isStrHandle, retainArcValue
 
-**Rule**: In `emitExprVariant(MapExpr)` (`src/codegen_expr_literal.cpp`), the existing retain gate `keyTypeName = inferCollectionTypeName(keyVals[0])` returns `""` for plain str values, so the gate short-circuits at `!keyTypeName.empty()` = `false`. A parallel `isStrHandle(v)` side-table check (`arc_str_owned_values_.count(v) > 0 || LoadInst from arc_str_managed_vars_ alloca`) is required; then call `retainArcValue(keyVals[i])` unconditionally on str handles. `retainArcValue → tryRetainArcSource` Case 1 emits retain for bound `LoadInst`; Case 2b is a **transfer-semantic no-op** for fresh `+1` `makeString` values (returns `true` without emitting retain), so the unconditional call doesn't leak on `{"foo": "bar"}`.
+**Rule**: In `emitExprVariant(MapExpr)` (`src/codegen_expr_literal.cpp`), the existing retain gate `keyTypeName = inferCollectionTypeName(keyVals[0])` returns `""` for plain str values. Use parallel `isStrHandle(v)` side-table check (`arc_str_owned_values_.count(v) > 0 || LoadInst from arc_str_managed_vars_ alloca`); call `retainArcValue(keyVals[i])` unconditionally on str handles. `retainArcValue → tryRetainArcSource` Case 1 emits retain for bound LoadInst; Case 2b is transfer-semantic no-op for fresh `+1` `makeString` (no leak on `{"foo": "bar"}`).
 
-The retain side alone is insufficient for Map literals: the non-empty-literal VarDecl path in `codegen_stmt.cpp` only propagates `map_value_type_name` from `val`'s meta, not `map_key_type_name`. The str annotation at `L269-271` only fires for the empty-literal branch. Add symmetric `map_key_type_name` meta propagation from `valMeta` / `loadMeta` / annotation in the non-empty branch (mirror of the existing `mvtn` block), AND stamp `map_key_type_name = "str"` / `map_value_type_name = "str"` on the literal's returned `headerPtr` when `isStrHandle` detects str keys/values. Without those stamps, `resolveCollectionDestructor` dispatches to `__ry_arc_dtor_map` with empty sigs, so `emitInnerReleaseLoop` returns false for the keys array and the str keys never get released — swapping a UAF for a leak.
+Retain alone is insufficient: the non-empty-literal VarDecl path in `codegen_stmt.cpp` only propagates `map_value_type_name`, not `map_key_type_name` (str annotation at L269-271 fires only for empty-literal). Add symmetric `map_key_type_name` propagation from `valMeta` / `loadMeta` / annotation in non-empty branch, AND stamp `map_key_type_name = "str"` / `map_value_type_name = "str"` on the literal's `headerPtr` when `isStrHandle` detects str. Without stamps, `resolveCollectionDestructor` dispatches to `__ry_arc_dtor_map` with empty sigs — str keys leak (UAF traded for leak).
 
-Why this differs from #1346 SetItem: `m: Map<str, str> = {}` (empty literal, then `m[k] = v`) hits the annotation-driven L269-282 path that stamps both `map_key_type_name` and `map_value_type_name`, so the #1346 fix only had to lift the `!= CollectionKind::Str` gate. `m: Map<str, str> = {k: v}` (non-empty literal) never hits L269-282 and has a fundamentally different root cause (`inferCollectionTypeName` returns empty for str) even though the user-visible symptom ("map key not found") is identical.
-
-**Scope note**: List<str> / Set<str> literal variants were deferred when #1347 landed and are resolved in #1354 by the same side-table retain + explicit stamp pattern. The #1266 carve-out's "no stamp without retain" rule was narrowed (see the #1266 entry): stamp-with-retain is safe because the per-element retain cancels the `makeString`/`__ry_arc_alloc_counted` counter asymmetry at insert time, so the str-aware destructor can run without the large-negative `arcLiveCount` delta that originally motivated the carve-out.
+**Why this differs from #1346 SetItem**: `m: Map<str, str> = {}` (empty + `m[k] = v`) hits annotation-driven L269-282 path stamping both names; #1346 only had to lift `!= CollectionKind::Str` gate. Non-empty literal never hits L269-282 — different root cause despite identical user-visible symptom.
 
 ### List/Set literal `[s]` / `{s}` with str elements needs side-table retain + explicit str stamp (#1354)
 
 **Source**: #1354 (2026-04-24)
-**Tags**: codegen, List, Set, literal, str, ARC, inferCollectionTypeName, retainArcValue, list_elem_type_name, set_elem_type_name
+**Tags**: codegen, List, Set, literal, str, ARC, isStrHandle
 
-**Rule**: In `emitExprVariant(ListExpr)` and `emitExprVariant(SetExpr)` (`src/codegen_expr_literal.cpp`), mirror the PR #1353 Map fix exactly: use the `CodeGen::isStrHandle` member helper (declared in `include/ry/codegen.hpp`, implemented in `src/codegen_arc.cpp`) to consult both `arc_str_owned_values_` (fresh `+1` `makeString` values) and `arc_str_managed_vars_` (borrowed `LoadInst` sources), apply `retainArcValue` per-entry when `elemTy == ptrTy_ && isStrHandle(v)`, track `anyElemIsStr` for a post-loop stamp of `list_elem_type_name = "str"` / `set_elem_type_name = "str"` on the `headerPtr`. For Set the retain must fire inside the `insertBB` branch (not the main loop body) so that duplicate insertions skipped by dedup do not double-retain. Then in `codegen_stmt.cpp` List tracking, propagate the literal's `list_elem_type_name = "str"` stamp into the indexer-facing side-channel `list_elem_is_str = true` via a single `if (letn == "str") inner_is_str = true;`.
+**Rule**: In `emitExprVariant(ListExpr)` and `emitExprVariant(SetExpr)`, mirror #1353 Map fix: use `CodeGen::isStrHandle` (decl `include/ry/codegen.hpp`, impl `src/codegen_arc.cpp`) consulting `arc_str_owned_values_` (fresh +1) and `arc_str_managed_vars_` (borrowed LoadInst). Apply `retainArcValue` per-entry when `elemTy == ptrTy_ && isStrHandle(v)`; track `anyElemIsStr` for post-loop stamp of `list_elem_type_name = "str"` / `set_elem_type_name = "str"` on `headerPtr`. For Set, retain fires inside `insertBB` branch (not main loop body) so dedup-skipped duplicates don't double-retain. In `codegen_stmt.cpp` List tracking, propagate `list_elem_type_name = "str"` into indexer-facing `list_elem_is_str = true`.
 
-**Why**: `inferCollectionTypeName` returns `""` for plain str values (same root cause as #1347 Map case), so the existing retain gate `element_needs_retain(elemTy)` / `setElemNeedsRetain` / `elemNeedsRetain` short-circuits. Without the side-table retain, `List<str> = [s]` / `Set<str> = {s}` with locally-constructed str elements produces a dangling pointer once the source var goes out of scope. Without the explicit `"str"` stamp on the literal header, `resolveCollectionDestructor` picks the non-str variant and the str elements silently leak. The per-entry retain + post-loop stamp pattern (not "first-entry-only" heuristic) is required because mixed-origin literals like `[bound_s, "literal_s"]` alternate between `LoadInst` and `ExtractValue` origins that escape first-entry detection.
+**Why**: `inferCollectionTypeName` returns `""` for plain str (same as #1347 Map). Without side-table retain, `[s]` / `{s}` produces dangling pointer once source goes out of scope. Without explicit `"str"` stamp, `resolveCollectionDestructor` picks non-str variant → leak. Per-entry retain + post-loop stamp is required for mixed-origin literals like `[bound_s, "literal_s"]` that alternate between LoadInst and ExtractValue origins.
 
-**Chosen resolution framing — "third option"**: The issue body listed two options: (1) reconcile the counter conventions by making `makeString` increment by +1 to match `__ry_arc_alloc_counted`, or (2) provide a parallel dispatch path for str elements. This PR adopts neither, and instead mirrors PR #1353: side-table retain + explicit stamp is the pragmatic path that (a) fits a v0.0.13 hotfix scope, (b) matches the empirical delta = +1 per function call baseline already observed for `Map<int,int>`, and (c) leaves Option 1 (global counter reconciliation) for v0.0.14+ where `include/ry/ry_layout.hpp:29-32` already flags str as "not fully ARC-managed by codegen yet".
-
-**How to apply**: When you see `element_needs_retain(elemTy)` (or its Map/Set analogues) gating a retain on an `inferCollectionTypeName`-returned name, and the element type is `ptrTy_`, audit whether str values can flow through that site with locally-constructed origins. If yes, add the `isStrHandle` side-table check as an OR condition and stamp the corresponding `*_type_name = "str"` on the literal header so the str-aware destructor matches the insert-side retain.
+**How to apply**: When `element_needs_retain(elemTy)` (or Map/Set analogue) gates retain on `inferCollectionTypeName`-returned name and element type is `ptrTy_`, audit whether str values can flow through with locally-constructed origins. If yes, add `isStrHandle` as OR condition and stamp `*_type_name = "str"` on the literal header.
 
 ### Record ARC reassignment: use `!CallInst && !InvokeInst` not `LoadInst || ExtractValueInst`
 
 **Source**: PR #1148 review (2026-04-18)
 **Tags**: codegen, ARC, record, reassignment, InsertValueInst
 
-**Rule**: The guard in `codegen_stmt.cpp` (`AssignStmt` record-with-ARC-fields path) that determines whether to call `emitRecordArcFieldsRetain` must be `!isa<CallInst>(val) && !isa<InvokeInst>(val)` — **not** `isa<LoadInst>(val) || isa<ExtractValueInst>(val)`. Fresh constructions (CallInst = direct call, InvokeInst = call with unwind) are sole owners and must not be retained. Every other value — including `InsertValueInst` chains like `r2 = { r.field, new_val }` — is a view of existing state and must be retained. The original allowlist of two cases was too narrow and caused use-after-free for `InsertValueInst` records.
+**Rule**: The guard in `codegen_stmt.cpp` AssignStmt record-with-ARC-fields path that decides whether to call `emitRecordArcFieldsRetain` must be `!isa<CallInst>(val) && !isa<InvokeInst>(val)` — NOT `isa<LoadInst>(val) || isa<ExtractValueInst>(val)`. Fresh constructions (CallInst/InvokeInst) are sole owners and must not be retained. Every other value — including `InsertValueInst` chains like `r2 = { r.field, new_val }` — is a view of existing state and must be retained. The original allowlist of two cases caused use-after-free for InsertValueInst records.
 
 ### `str` does not support `[]` index syntax — guard with `isStringValue` before list/map dispatch
 
-**Source**: #1026 (2026-04-16, diagnostic improvement)
-**Tags**: codegen, diagnostics, str, index-access, emitExprVariant, IndexExpr, IndexAssignStmt
+**Source**: #1026 (2026-04-16)
+**Tags**: codegen, diagnostics, str, IndexExpr, IndexAssignStmt
 
-**Rule**: In `emitExprVariant(IndexExpr)` (`src/codegen_expr_literal.cpp`) and the `IndexAssignStmt` emitter (`src/codegen_stmt_misc.cpp`), `str` values are `ptrTy_` pointers and pass the "must be ptr" gate. Without an explicit guard they fall through the Map check (no map metadata) and then either (a) hit the List fallthrough and emit the misleading `"cannot determine list element type for index access"` error or (b) reach `emitCowCheck(objPtr, ..., CollectionKind::List)` which may corrupt state.
+**Rule**: In `emitExprVariant(IndexExpr)` (`src/codegen_expr_literal.cpp`) and IndexAssignStmt emitter (`src/codegen_stmt_misc.cpp`), `str` values are `ptrTy_` and pass the "must be ptr" gate. After "index operator requires list or map" gate and before Map dispatch, check `isStringValue(objPtr)`:
+- Read: `"str does not support index access; use charAt(s, i) instead"`
+- Write: `"str does not support index assignment; strings are immutable"` — must come BEFORE `emitCowCheck(objPtr, ..., CollectionKind::List)` (passing str ptr to `emitCowCheck` is unsafe).
 
-**Fix**: After the `"index operator requires list or map"` gate and before the Map dispatch, check `isStringValue(objPtr)` and emit a targeted diagnostic:
-- Read path: `"str does not support index access; use charAt(s, i) instead"`
-- Write path: `"str does not support index assignment; strings are immutable"` — and critically, this guard must come **before** the `emitCowCheck(objPtr, receiverAlloca, CollectionKind::List)` call; passing a `str` pointer with `CollectionKind::List` to `emitCowCheck` is unsafe.
+**Why `isStringValue` is the right predicate**: returns true when `val->getType() == ptrTy_` and `isNonStrPointer(val)` is false (no collection/resource metadata). Lists/Maps/Sets/resource handles all have `hasAnyMeta() == true`, so only `str` triggers. Canonical predicate at `src/codegen_any.cpp:28`.
 
-**Why `isStringValue` is the right predicate**: `isStringValue(val)` (`src/codegen_any.cpp:28`) returns true when `val->getType() == ptrTy_` and `isNonStrPointer(val)` is false (i.e., no collection/resource metadata). Lists, Maps, Sets, and resource handles all have metadata (`hasAnyMeta() == true`), so only `str` triggers the new guard. This is the canonical predicate used throughout codegen to distinguish `str` from other `ptrTy_` values.
+### `emitExprVariant(CaseExpr)`: capture `armEndBB` AFTER `popScope()`
 
-- **#1184 related**: The same emitter also rejects index values that are `RangeExpr` nodes and routes them to the slice path — see "IndexExpr first index is scalar only — RangeExpr routes to emitListSlice" below.
-
-### `emitExprVariant` (CaseExpr): capture `armEndBB` AFTER `popScope()`
-
-**Source**: #997 (2026-04-16, fix)
+**Source**: #997 (2026-04-16)
 **Tags**: codegen, arc, match, phi, case-expr, ir-verification
 
-**Rule**: In `emitExprVariant` for CaseExpr (`src/codegen_match.cpp`), always
-record `armEndBB = builder_.GetInsertBlock()` **after** `popScope()`, never
-before.
+**Rule**: In `emitExprVariant` for CaseExpr (`src/codegen_match.cpp`), record `armEndBB = builder_.GetInsertBlock()` AFTER `popScope()`, never before. `emitPatternBindingArc` may insert `arc.retain` / `arc.retain.done` BBs; `popScope() → emitArcReleaseVar` may insert `arc.var_release` / `arc.var_skip` BBs. Both advance the insert block. Recording before `popScope()` captures stale BB → IR verify error "PHI node entries do not match predecessors".
 
-**Why it matters**: `emitPatternBindingArc` may insert ARC retain calls
-(`arc.retain` / `arc.retain.done` BBs), and `popScope()` → `emitArcReleaseVar`
-may insert `arc.var_release` / `arc.var_skip` BBs. Both operations advance the
-insert block. Recording `armEndBB` *before* `popScope()` captures a stale BB
-as the PHI predecessor; the actual branch to `mergeBB` comes from the final
-`arc.var_skip` BB, causing:
-
-```
-IR verify error: PHI node entries do not match predecessors!
-  %match.expr = phi i64 [ 0, %match.expr.then ], [ %list_len, %arc.retain.done ]
-label %arc.retain.done
-label %arc.var_skip
-```
-
-**Correct pattern**:
 ```cpp
 llvm::Value *armVal = emitExpr(*arm.value);
 popScope();                                          // changes insert block
-llvm::BasicBlock *armEndBB = builder_.GetInsertBlock(); // correct post-cleanup BB
+llvm::BasicBlock *armEndBB = builder_.GetInsertBlock();
 builder_.CreateBr(mergeBB);
 incoming.push_back({armVal, armEndBB});
 ```
 
-The same rule applies to any code that records an insert-block BB for later
-PHI use while a scope with ARC-managed variables is still open.
+Same rule applies to any code recording an insert-block BB for later PHI use while a scope with ARC-managed variables is still open.
 
-### `isStringValue` must not be used to dispatch `weak` header offset
+### `isStringValue` must NOT be used to dispatch `weak` header offset
 
-**Source**: #1022 (2026-04-16, implementation)
-**Tags**: codegen, weak, str, StringHeader, isStringValue, emitWeakExpr
+**Source**: #1022 (2026-04-16)
+**Tags**: codegen, weak, str, StringHeader, emitWeakExpr
 
-**Rule**: Do not use `isStringValue(val)` to choose between `STRING_HEADER_SIZE` (24) and `ARC_HEADER_SIZE` (16) offsets when computing the ARC header pointer for a `weak` variable. `isStringValue` returns `true` for **any** `ptrTy_` value that has no `hasAnyMeta()` flag — captured `List<int>` / `Map` / `Set` values inside closure bodies lack collection metadata after the capture injection in `codegen_fn.cpp` / `codegen_lambda.cpp`, so they are misclassified as `str` and get the wrong `-24` offset.
+**Rule**: Don't use `isStringValue(val)` to choose `STRING_HEADER_SIZE` (24) vs `ARC_HEADER_SIZE` (16) for weak ARC header. `isStringValue` returns true for ANY `ptrTy_` without `hasAnyMeta()` — captured `List<int>` / `Map` / `Set` inside closure bodies lack collection metadata after capture injection in `codegen_fn.cpp` / `codegen_lambda.cpp`, getting misclassified as str with wrong −24 offset.
 
-**How**: The inner type name is available from the annotation at the `LetStmt` site (`weakInnerTypeName(*annot)`) and from `weak_inner_type_names_[ptr]` at reassignment. Use `innerName == "str"` there:
+Use the inner type name from the LetStmt annotation (`weakInnerTypeName(*annot)`) and `weak_inner_type_names_[ptr]` at reassignment:
 
 ```cpp
 // codegen_stmt.cpp — initial let
 llvm::Value *headerPtr = (innerName == "str")
-    ? emitStrGetHeaderFromData(val)
-    : emitArcGetHeaderFromData(val);
+    ? emitStrGetHeaderFromData(val) : emitArcGetHeaderFromData(val);
 
-// codegen_stmt.cpp — reassignment (ptr is the existing weak alloca)
+// codegen_stmt.cpp — reassignment
 auto it = weak_inner_type_names_.find(ptr);
-const std::string &weakInner = (it != weak_inner_type_names_.end())
-    ? it->second : std::string{};
+const std::string &weakInner = (it != weak_inner_type_names_.end()) ? it->second : std::string{};
 llvm::Value *headerPtr = (weakInner == "str")
-    ? emitStrGetHeaderFromData(val)
-    : emitArcGetHeaderFromData(val);
+    ? emitStrGetHeaderFromData(val) : emitArcGetHeaderFromData(val);
 ```
 
-`emitExprVariant(WeakExpr)` (codegen_expr.cpp) must return the raw data pointer; the conversion happens at the call sites above, not inside the emitter.
+`emitExprVariant(WeakExpr)` returns the raw data pointer; conversion happens at the call sites above, not inside the emitter.
 
-### Ry records are SSA struct values, not pointers — nested field writes unroll up to the root alloca
+### Ry records are SSA struct values, not pointers — nested field writes unroll up to root alloca
 
-**Source**: #812 (2026-04-11, implementation)
+**Source**: #812 (2026-04-11)
 **Tags**: codegen, records, lvalue, insertvalue, chained-lhs
 
-**Context**: Records in Ry are *value types*: a `record Point: x: int; y: int`
-is emitted as `{i64, i64}` stored in an alloca. There is no stable address
-for an individual field — `CreateLoad(struct) → ExtractValue(x) → ...` gives
-you an SSA value, not a pointer you can `CreateStore` into. The #812 fix
-for `rec.a.b = v` therefore has to be: load the outer struct, `InsertValue`
-at the right field index, and if the target lives deeper in a chain
-(`rec.a.b.c = v`) walk back up inserting each updated inner struct into its
-parent until we reach the root alloca and do a single `CreateStore`.
-
-**Rule**: When implementing any write through a record field chain, treat
-every intermediate record as an SSA value. Never try to take a pointer into
-a struct field — use `ExtractValue` / `InsertValue` instead, and end the
-chain with one store at the root alloca. See `writeBackFieldChain` in
-`src/codegen_stmt_misc.cpp` for the reference pattern.
+**Rule**: Records are *value types*: `record Point: x: int; y: int` is `{i64, i64}` in an alloca. `CreateLoad(struct) → ExtractValue(x)` gives an SSA value, not a writable pointer. For `rec.a.b.c = v`, walk back inserting each updated inner struct into its parent until reaching the root alloca, then single `CreateStore`. Never take a pointer into a struct field — use `ExtractValue` / `InsertValue`. Reference: `writeBackFieldChain` in `src/codegen_stmt_misc.cpp`.
 
 ### Compound assignment must be expanded in codegen, not desugared in parser
 
-**Source**: #812 (2026-04-11, implementation)
+**Source**: #812 (2026-04-11)
 **Tags**: codegen, compound-assign, side-effects, chained-lhs
 
-**Context**: Naively desugaring `a[f()] += v` as `a[f()] = a[f()] + v` in
-the parser would evaluate `f()` twice — once for the load and once for the
-store. That violates the "each subexpression evaluates once" rule and
-multiplies CoW work. The fix for #812 introduced `applyCompoundOp` in
-`src/codegen_stmt_misc.cpp` and expanded `IndexAssignStmt` / `FieldAssignStmt`
-with an optional `compound_op` field that codegen interprets as
-"load at the resolved slot → apply op → store at the same slot" — a single
-index evaluation per statement.
-
-**Rule**: When adding a new compound-assignment-capable statement form, do
-NOT desugar in the parser. Reuse `applyCompoundOp` and evaluate the LHS
-address exactly once in codegen. For maps, a compound op on a missing key
-is a runtime error (`"compound assignment to missing map key"`) — users
-must insert the key explicitly before accumulating.
+**Rule**: Naively desugaring `a[f()] += v` as `a[f()] = a[f()] + v` in parser evaluates `f()` twice — violates "each subexpression evaluates once" and multiplies CoW work. Use `applyCompoundOp` in `src/codegen_stmt_misc.cpp` with optional `compound_op` field on `IndexAssignStmt` / `FieldAssignStmt` — codegen interprets as "load resolved slot → apply op → store same slot" (single index evaluation per statement). For maps, compound op on missing key is runtime error (`"compound assignment to missing map key"`); users must insert explicitly before accumulating.
 
 ### Path copy-on-write isolates chained writes through nested collections
 
 **Source**: #812 (shallow baseline) + #854 (path CoW) (2026-04-11)
 **Tags**: codegen, cow, arc, nested-collections, path-cow, semantics
 
-**Context**: `emitCowCheck` only copies the top-level header and data
-buffer; inner element pointers are bit-copied. The top-level 1-hop CoW
-path used by `var[i] = v` / `var.append(...)` keeps this "shallow"
-behavior — cheap, documented in `docs/reference/collections.md`, tested
-by `tests/spec/cow.test.ry`. Top-level mutations on simple collections
-do not need element retain because the leaf slot-overwrite protocol
-(#855) owns ownership transfer.
+**Rule**: `emitCowCheck` only copies top-level header + data buffer; inner element pointers are bit-copied. Top-level 1-hop CoW (`var[i] = v` / `var.append(...)`) keeps this shallow behavior — cheap, documented in `docs/reference/collections.md`. Top-level mutations don't need element retain because leaf slot-overwrite (#855) owns ownership transfer.
 
-Chained writes (`b[i][j] = v`, `r.items[i] = v`, `m[k1][k2] = v`) cannot
-use the top-level path: the LHS root would resolve to nullptr CoW anchor
-and the mutation would leak through aliases. The #854 fix introduces
-**path CoW** — a second code path rooted in `emitPathCowForChain` that
-walks the LHS inside-out, privatizes every container level whose
-`strong_count > 1`, and retains each ARC element of the cloned buffer
-(via the previously-unused `emitCowRetainArcElements`). The new
-`emitCowCheckSlot` generalizes `emitCowCheck` to accept any writable
-slot (alloca, module-global storage, nested record field GEP, heap
-container data GEP) rather than just an alloca.
+Chained writes (`b[i][j] = v`, `r.items[i] = v`, `m[k1][k2] = v`) cannot use top-level path: LHS root resolves to nullptr CoW anchor and mutation leaks through aliases. **Path CoW** (`emitPathCowForChain` in `src/codegen_arc_cow.cpp`) walks LHS inside-out, privatizes every container level whose `strong_count > 1`, and retains each ARC element of the cloned buffer (`emitCowRetainArcElements`). `emitCowCheckSlot` generalizes `emitCowCheck` to accept any writable slot (alloca, module-global, nested record field GEP, heap container data GEP).
 
-The collection destructors (`__ry_arc_dtor_list/map/set` in
-`src/codegen_arc.cpp:633-665`) still only free internal buffers and do
-not release ARC-managed elements. This is the pre-existing "element leak
-on destructor" bug, accepted by the `detect_leaks=0` budget. Path CoW's
-retain-on-clone amplifies this leak by a small constant (one extra leak
-per mutation chain on shared inner collections) — same order of
-magnitude, tracked as a separate follow-up along with insertion retain
-protocol changes.
-
-**Rule**: When implementing a new mutation path that can reach a
-container through a chained LHS, route through `emitPathCowForChain`
-(the caller passes `s.object` — everything except the innermost leaf
-index). Do NOT evaluate `s.object` with a plain `emitExpr` first —
-that re-loads the chain against stale parents after privatization.
-The top-level 1-hop CoW in `emitCowCheck` still uses
-`retainElements=false`; the path CoW path uses `retainElements=true`.
-The asymmetry is deliberate: top-level CoW relies on #855's
-retain-then-release-old slot protocol at the leaf store to transfer
-inner ownership, whereas path CoW needs each intermediate container's
-siblings to survive (inner lists that are not on the mutation path).
+**How to apply**: When implementing a mutation path that reaches a container through a chained LHS, route through `emitPathCowForChain` (caller passes `s.object`). Do NOT pre-evaluate `s.object` with plain `emitExpr` — that re-loads against stale parents after privatization. Top-level 1-hop uses `retainElements=false`; path CoW uses `retainElements=true` (deliberate asymmetry: top-level relies on #855's retain-then-release-old leaf protocol; path CoW needs intermediate siblings to survive).
 
 **Unsupported shapes** (compile-time error from path CoW):
 - Method-call roots: `f().items[i] = v`
-- Chains that interleave an index hop inside a record field walk
-  (e.g. `rec.arr[0].items[i] = v`). Assign the intermediate to a local.
-These match the narrow #854 scope; record-of-records chains without
-interleaved index hops (`d.out.items[i] = v`) ARE supported via a
-multi-level struct GEP through the root alloca.
+- Index-hop interleaved inside record-field walk: `rec.arr[0].items[i] = v` (assign intermediate to local). Record-of-records WITHOUT interleaved index hops (`d.out.items[i] = v`) IS supported via multi-level struct GEP through root alloca.
 
 ### Compound-op loaded slot values must propagate container metadata
 
 **Source**: #858, #862 (2026-04-11)
-**Tags**: codegen, compound-assign, metadata, arc, collection, index-assign, field-assign
+**Tags**: codegen, compound-assign, metadata, arc, collection
 
-**Context**: `emitStmt(IndexAssignStmt &)` and `emitStmt(FieldAssignStmt &)`
-in `src/codegen_stmt_misc.cpp` load the compound LHS from the slot via a
-bare `CreateLoad` (for collection slots, #858) or `CreateExtractValue`
-(for record fields, #862) before passing it into `applyCompoundOp`. When
-the element / field type is an ARC-managed collection (`List<T>`,
-`Map<K, V>`, `List<List<T>>`, …) the loaded value is an opaque pointer
-with no metadata attached. The value then flows through
-`applyCompoundOp → emitBinaryOp → emitArithmeticOp`, whose list-concat
-dispatch at `src/codegen_expr.cpp:1015-1023` reads `TypeMeta::ListElem`
-from the SSA value (via `getListElementType(lhs)`), **not** the `lhsHint`
-string parameter. Without metadata on the load, dispatch falls through
-to the str-vs-non-str rejection path and emits a completely misleading
-error for a legal `List<int> + List<int>` operation.
+**Rule**: `IndexAssignStmt` / `FieldAssignStmt` in `src/codegen_stmt_misc.cpp` load compound LHS via bare `CreateLoad` (collection slots, #858) or `CreateExtractValue` (record fields, #862) before `applyCompoundOp`. The loaded value is metadata-less. `applyCompoundOp → emitBinaryOp → emitArithmeticOp` reads `TypeMeta::ListElem` from the SSA value (via `getListElementType(lhs)`), NOT the `lhsHint` string — without metadata, list-concat dispatch falls through to str-vs-non-str rejection and emits misleading error for legal `List<int> + List<int>`.
 
-The fix is to call `propagateTypeMeta(name, loadedVal)` immediately
-after the load, matching the canonical pattern already documented for
-`valueToString` element loads. `propagateTypeMeta` internally rebuilds
-every `TypeMeta::*` slot from the name string, so one call restores the
-full dispatch context. The name source depends on the code path:
+Call `propagateTypeMeta(name, loadedVal)` immediately after the load. Name source:
+- **IndexAssignStmt** (#858): pull from container's metadata (`container_meta->list_elem_type_name` or `map_value_type_name`). **Snapshot the name into a local `std::string` BEFORE calling `propagateTypeMeta`** — the helper inserts into `value_metadata_` and may rehash, invalidating the `ValueMetadata *` from `getMeta`.
+- **FieldAssignStmt** (#862): use `info.fields[fieldIdx].type->toString()` directly — returns `std::string` by value, no rehash aliasing concern.
 
-- `IndexAssignStmt` (#858): pull from the container's metadata
-  (`container_meta->list_elem_type_name` or `map_value_type_name`).
-  **Snapshot the name into a local `std::string` *before* calling
-  `propagateTypeMeta`** — the helper inserts into `value_metadata_` and
-  may rehash, invalidating the `ValueMetadata *` returned by `getMeta`.
-- `FieldAssignStmt` (#862): use `info.fields[fieldIdx].type->toString()`
-  directly. `.toString()` returns a new `std::string` by value, so the
-  rehash aliasing concern from #858 does not apply here. This matches
-  the canonical pattern at `src/codegen_expr_literal.cpp:120-122`.
+`src/codegen_stmt.cpp` (empty-list-declaration path) must record `list_elem_type_name` for `List<List<T>>` as it does for `List<Map>` / `List<Set>` — pre-#858 asymmetry caused `xs: List<List<int>> = []; xs.append(...); xs[0] += ...` to fail.
 
-Also note that `src/codegen_stmt.cpp` (empty-list-declaration path) must
-record `list_elem_type_name` for `List<List<T>>` exactly the way it
-already does for `List<Map>` and `List<Set>` — the asymmetry in the
-pre-#858 code caused the `xs: List<List<int>> = []; xs.append(...); xs[0]
-+= ...` case to fail even after the `codegen_stmt_misc.cpp` fix.
+**Rule (general)**: Any codegen site that loads from a container slot and feeds into a type-dispatched op (formatter, binary op, builtin) MUST propagate the element type name onto the load. Bare LoadInst / CreateExtractValue is metadata-less. Hint parameters (`lhsHint`) are not the dispatch key — `TypeMeta::*` slots on the SSA value are.
 
-**Rule**: Any codegen site that loads an element from a container slot
-and then feeds it into a **type-dispatched operation** (formatter, binary
-op, builtin call) MUST propagate the container's element type name onto
-the loaded value. The bare `LoadInst` / `CreateExtractValue` result is
-metadata-less. Hint parameters on helper signatures (`lhsHint` on
-`emitBinaryOp`) are not the dispatch key — `TypeMeta::*` slots on the SSA
-value are.
-
-**How to verify** (grep before opening a PR):
-
-```bash
-grep -nE 'CreateLoad.*elem|CreateExtractValue.*field|applyCompoundOp' \
-    src/codegen_stmt_misc.cpp src/codegen_tostring.cpp
-```
-
-Every such load that flows into `applyCompoundOp`, `emitBinaryOp`, or
-`valueToString` should be followed by a metadata-propagation block (or
-be an i64/bool/float path where metadata is unnecessary). The remaining
-fixed-length array compound path at `src/codegen_stmt_misc.cpp:597-600`
-is **not** a missing-metadata site: fixed-length array element types
-are restricted to low-level primitive types by a hard compile-time
-check at `src/codegen_type.cpp:125` (`array element type must be a
-low-level type`), so ARC-managed collection element types are rejected
-at type resolution and never reach the compound path.
+**Verify**: `grep -nE 'CreateLoad.*elem|CreateExtractValue.*field|applyCompoundOp' src/codegen_stmt_misc.cpp src/codegen_tostring.cpp` — every load flowing into `applyCompoundOp` / `emitBinaryOp` / `valueToString` should have a metadata-propagation block (or be i64/bool/float). Fixed-length array compound path at `src/codegen_stmt_misc.cpp:597-600` is NOT a missing site — array element types are restricted to low-level primitives by hard check at `src/codegen_type.cpp:125`.
 
 ### `threadSpawn` captures do NOT emit ARC retain/release in the thunk
 
 **Source**: #872
 **Tags**: threadSpawn, arc, concurrency, codegen, gotcha
 
-**Rule**: Unlike `@parallel for` — which explicitly emits atomic
-`emitArcRetain(hdr, true)` at thunk entry and a matching `emitArcRelease` at
-scope exit for each ARC-managed capture — `threadSpawn` thunks do NOT
-retain/release their captures.  The capture is stored as a raw pointer copy
-into the env struct; the thunk loads the pointer and calls the lambda, and
-`FnScope` is destroyed at CODEGEN time without ever calling `popScope()`, so
-no runtime release instruction is emitted.
+**Rule**: Unlike `@parallel for` (which emits atomic `emitArcRetain(hdr, true)` at thunk entry + matching release at scope exit), `threadSpawn` thunks do NOT retain/release captures. The capture is stored as raw pointer copy into the env struct; the thunk loads and calls the lambda, and `FnScope` is destroyed at CODEGEN time without `popScope()` — no runtime release emitted.
 
-Consequence: the main thread's original reference keeps the ARC object alive
-for the worker's lifetime.  As long as `threadJoin` is called before the
-outer scope's variable goes out of scope, this is correct.  TSan does NOT
-report a race for concurrent str captures via `threadSpawn` because no
-concurrent ARC ops are emitted.
-
-Correctness contract: the caller MUST ensure the captured ARC-managed value
-outlives all spawned workers (i.e., call `threadJoin` before the capture's
-owning scope exits).  No retain/release means no race protection beyond that
-lifetime ordering.  A future follow-up could add optional retain-at-capture /
-release-at-thunk-exit for `threadSpawn` (distinct from #877, which tracks
-ARC-managed **return types**, not capture semantics).
+Consequence: main thread's original reference keeps the ARC object alive for the worker's lifetime. Caller MUST ensure the captured ARC value outlives all spawned workers (call `threadJoin` before the capture's owning scope exits). No retain/release means no race protection beyond that lifetime ordering. TSan does NOT report a race for concurrent str captures via `threadSpawn` because no concurrent ARC ops are emitted. Future follow-up may add optional retain-at-capture / release-at-thunk-exit (distinct from #877 which tracks ARC return types).
 
 ### `parallel_for_depth_` design decision — keep scope-counter for now
 
 **Source**: #872
 **Tags**: arc, parallel_for, design-decision, concurrency
 
-**Rule**: The current mechanism (`parallel_for_depth_` counter in `CodeGen`
-→ `isArcAtomic()` returns true → `atomicrmw seqcst` for all ARC ops inside
-the `@parallel for` thunk body) is correct for values emitted **directly**
-inside the thunk.  It does **not** propagate to helper functions the worker
-calls; those emit non-atomic ARC ops.
+**Rule**: Current mechanism (`parallel_for_depth_` counter → `isArcAtomic()` returns true → `atomicrmw seqcst` for all ARC ops inside `@parallel for` thunk body) is correct for values emitted **directly** in the thunk. Does NOT propagate to helper functions the worker calls; those emit non-atomic ARC ops.
 
-Options considered for #872:
-1. **Keep `parallel_for_depth_`** (current) — simple, no perf cost outside
-   `@parallel for`.  Limitation: helper-function races are not covered.
-2. **Whole-program "may cross threads" analysis** — correct but expensive;
-   requires call-graph walk and is a significant compiler feature.
-3. **User-visible `Send`-like marking** — expressive but a language design
-   change with breaking implications.
-4. **Unconditional atomic ARC everywhere** — correct and simple but adds
-   measurable latency to every single-threaded ARC operation.
+Alternatives considered: (1) keep current — simple, no perf cost outside `@parallel for`, but helper-function races uncovered; (2) whole-program "may cross threads" analysis — correct but expensive; (3) user-visible `Send`-like marking — language design change; (4) unconditional atomic ARC everywhere — adds latency to every single-threaded ARC op.
 
-**Decision for #872**: Keep option 1.  The stress tests added in #872
-(`ConcurrencySpecSuite`, `concurrency_stress.test.ry`,
-`test_runtime_arc_contention_stress.cpp`) did NOT expose a helper-function
-race.  Revisit only if future stress tests expose such a race.
+**Decision**: Keep option 1. #872 stress tests (`ConcurrencySpecSuite`, `concurrency_stress.test.ry`, `test_runtime_arc_contention_stress.cpp`) did NOT expose helper-function races. Revisit only if future stress exposes one.
 
 ### Destructor recursion into inner ARC elements forces retain-on-store at every write site
 
-**Source**: #1242 (2026-04-21). **Tags**: ARC, destructor, retain, list-literal, map-literal, set-literal, appended, insert, merge, uaf, regression
+**Source**: #1242 (2026-04-21)
+**Tags**: ARC, destructor, retain, list-literal, map-literal, set-literal, appended, insert, merge, uaf
 
-**Rule**: `getOrCreateCollectionDestructor` for List/Map/Set now walks the element buffer and calls `emitArcRelease` on each ARC-managed inner element (List/Map/Set), not just `free(dataBuf)`. Every codegen site that stores an ARC pointer into a collection slot — literal construction, `appended`, `insert`, set `add`, `append(!)`, map `merge`, IndexAssignStmt Map insert — must emit a matching retain, or the destructor will free shared elements out from under other holders.
+**Rule**: `getOrCreateCollectionDestructor` for List/Map/Set walks the element buffer and calls `emitArcRelease` on each ARC-managed inner element (List/Map/Set), not just `free(dataBuf)`. Every codegen site that stores an ARC pointer into a collection slot — literal construction, `appended`, `insert`, set `add`, `append(!)`, map `merge`, IndexAssignStmt Map insert — must emit a matching retain, or destructor frees shared elements.
 
-The retain discipline is **symmetric** with the destructor:
-- Destructor releases ⇒ source must retain on store (literal + container op).
-- Destructor does not release (str element slot because `list_elem_type_name` is never stamped "str" per #1266) ⇒ retain is skipped.
+Symmetric discipline: destructor releases ⇒ source must retain on store; destructor doesn't release (str element slot, since `list_elem_type_name` is never stamped "str" per #1266) ⇒ retain skipped.
 
-**Why**: Pre-#1242 the destructor only freed the buffer, so the "raw-pointer aliasing" bug between a collection and its inner elements was invisible — inner elements leaked forever and stayed dereferenceable. The destructor fix flips that: the freed memory is now reachable from any dropped alias, producing UAF on the first rebind. `xs: List<List<int>> = [[0]]; while i < N: xs = [[1,2],[3,4]]` showed delta = 3*N+2 pre-fix (pure leak). Once the destructor recurses, the same rebind frees the previous inner lists — safe if and only if every site that duplicated those pointers retained.
+**Why**: Pre-#1242 the destructor only freed the buffer — raw-pointer aliasing between collection and inner elements was invisible (inner elements leaked but stayed dereferenceable). Post-#1242, freed memory is reachable from any dropped alias → UAF on first rebind. `xs: List<List<int>> = [[0]]; while i < N: xs = [[1,2],[3,4]]` showed delta = 3*N+2 pre-fix.
 
-**How to apply**: When adding a new collection write site, ask "does the destructor now release this slot?" — if yes (List/Map/Set element type resolves via `fieldTypeIsArcManaged` with `CollectionKind != Str`), emit `retainArcValue(val)` on freshly-loaded values and `emitCowRetainArcElements(newBuf, len, tag, elemArcKind)` on memcpy'd ranges before the store. For update-in-place patterns (Map insert-or-update, IndexAssignStmt update branch), release the overwritten element first. Callers must read `list_elem_type_name` / `map_*_type_name` / `set_elem_type_name` from the *source* container's metadata, not the newly-allocated header, since the new one is still being populated. The canonical sites fixed in #1242: `codegen_expr_literal.cpp` (List/Map/Set literal store loops), `codegen_call_collection.cpp::emitCollOp_add` / `_append` / `_appended` / `_insert` / `emitMapMergeCore`, `codegen_stmt_misc.cpp::IndexAssignStmt` Map insert path.
+**How to apply**: New collection write site → "does the destructor release this slot?" If yes (List/Map/Set element type resolves via `fieldTypeIsArcManaged` with `CollectionKind != Str`), emit `retainArcValue(val)` on freshly-loaded values and `emitCowRetainArcElements(newBuf, len, tag, elemArcKind)` on memcpy'd ranges before store. For update-in-place (Map insert-or-update, IndexAssignStmt update), release overwritten element first. Read source container's metadata, not the new header (still being populated). Canonical sites fixed in #1242: `codegen_expr_literal.cpp` literal stores, `codegen_call_collection.cpp::emitCollOp_add`/`_append`/`_appended`/`_insert`/`emitMapMergeCore`, `codegen_stmt_misc.cpp::IndexAssignStmt` Map insert.
 
-**Str carve-out preserved**: The destructor extension covers only List/Map/Set inner elements. The str element destructor path (`if (elemSig == "str") emitStrElemLoop(...)` in `getOrCreateCollectionDestructor`) is unchanged per #1266 — `AssignStmt` never stamps `list_elem_type_name = "str"` because flipping the destructor exposes a counter asymmetry between `__ry_arc_alloc_counted` (+1) and `makeString` (no-op), producing a large negative `arcLiveCount()` delta in `arc_split_chars.test.ry`. The side-channel `ValueMetadata::list_elem_is_str` scoped to the indexer (#1266) remains the correct way to propagate str-elementness for read paths. A full str-destructor-switch belongs to a future issue.
-
-**Related**: #1204 (slice retain), #1235 (take retain), #1046 (CoW str retain + original destructor extension for str), #1108 (emitArcReleaseLoadedElement inner-sig propagation), #855 (slot overwrite release discipline), #1266 (str destructor carve-out + `list_elem_is_str` side-channel).
-
----
+**Str carve-out preserved**: Destructor extension covers List/Map/Set inner elements only. Str element destructor path (`if (elemSig == "str") emitStrElemLoop(...)`) unchanged per #1266 — `AssignStmt` never stamps `list_elem_type_name = "str"` because flipping the destructor exposes counter asymmetry between `__ry_arc_alloc_counted` (+1) and `makeString` (no-op). Side-channel `list_elem_is_str` scoped to indexer remains correct for read paths. Full str-destructor-switch is future work.
 
 ### `appended` / `insert` / `merge` duplicate pointers without retain — symmetric to `slice`/`take`
 
-**Source**: #1242 (2026-04-21, discovered during destructor extension). **Tags**: ARC, appended, insert, merge, memcpy, retain-on-store, uaf
+**Source**: #1242 (2026-04-21)
+**Tags**: ARC, appended, insert, merge, memcpy, retain-on-store, uaf
 
-**Rule**: Functions that construct a *new* collection whose element buffer is produced by memcpy from a source (`emitListSlice`, `emitCollOp_take_impl`, `emitCollOp_appended`, `emitMapMergeCore`'s m1 copy) must retain each ARC-managed element after the memcpy. Functions that store an individual ARC value into an existing or new collection (`emitCollOp_add`, `emitCollOp_append`, `emitCollOp_insert`, map merge's m2 insert/update) must retain the value before the store. Update-in-place also needs to release the overwritten element.
+**Rule**: Functions constructing a *new* collection whose buffer is `memcpy`'d from a source (`emitListSlice`, `emitCollOp_take_impl`, `emitCollOp_appended`, `emitMapMergeCore`'s m1 copy) must retain each ARC-managed element after memcpy. Functions storing an individual ARC value into an existing/new collection (`emitCollOp_add`, `emitCollOp_append`, `emitCollOp_insert`, map merge's m2 insert/update) must retain the value before store. Update-in-place also releases the overwritten element.
 
-**Why**: Same defect class as #1204 (slice) / #1235 (take). Pre-#1242 the defect was latent: the source's destructor did not release inner elements, so the memcpy'd pointers stayed valid even after source release. Post-#1242 the destructor does release, so the second holder of the memcpy'd pointer is left with a dangling pointer. Rebind of either side triggers UAF.
+**Why**: Same defect class as #1204 (slice) / #1235 (take). Pre-#1242 latent — source destructor didn't release inner elements, so memcpy'd pointers stayed valid even after release. Post-#1242 destructor releases, leaving second holder of memcpy'd pointer dangling.
 
-**How to apply**: A repro is `m1 = {"a": a}; merged = merge(m1, m2); m1 = {"x": [99]}; print(merged["a"][0])` — pre-fix on a post-destructor-extension build this reads freed memory. Tests that rebind the source AND run an allocation-churning loop before reading the new collection reliably surface the UAF (without the churn, the freed memory still holds the old value and the read looks correct). See `tests/spec/arc_release_on_rebind.test.ry` "merge(Map<str,List<int>>, ...) survives source rebind" and "appended(List<List<int>>, ...) survives source rebind" for the canonical pattern.
+**Repro**: `m1 = {"a": a}; merged = merge(m1, m2); m1 = {"x": [99]}; print(merged["a"][0])` — pre-fix on post-destructor-extension build reads freed memory. Tests rebinding source AND running allocation-churning loop before reading reliably surface UAF (without churn, freed memory holds old value). Canonical: `tests/spec/arc_release_on_rebind.test.ry`.
 
-**Related**: #1204, #1235, #1046 (original CoW retain), #1242.
+### Tuple-element collections need symmetric retain/release on tuple components, dispatched locally
 
----
+**Source**: #1667 (2026-05-09)
+**Tags**: ARC, tuple, destructor, retain, items, enumerate, zip
 
-### Tuple-element collections need symmetric retain/release on tuple components, dispatched locally (not via `fieldTypeIsArcManaged`)
-
-**Source**: #1667 (2026-05-09). **Tags**: ARC, tuple, destructor, retain, items, enumerate, zip, slice, take, appended, concat, uaf
-
-**Rule**: For `List<(K, V)>` results returned by `items` / `enumerate` / `zip` (and any derivation thereof — `slice`, `take`, `appended`, `concat` — that propagates `list_elem_type_name = "(K, V)"` via `propagateMeta`), the collection destructor must walk the dense tuple-struct buffer and release each ARC-managed component (`str` / `List` / `Map` / `Set`), and every codegen site that produces such a result must retain those components symmetrically. Both halves land together; either alone produces a leak (no retain, no release was the pre-fix state) or a UAF (retain only) or a double-free (release only).
-
-This is a tuple-sig-keyed extension of #1242's destructor-recursion-implies-retain-on-store rule. The canonical sites:
+**Rule**: For `List<(K, V)>` from `items` / `enumerate` / `zip` (and derivations `slice` / `take` / `appended` / `concat` propagating `list_elem_type_name = "(K, V)"` via `propagateMeta`), the destructor must walk the dense tuple-struct buffer and release each ARC-managed component (`str` / `List` / `Map` / `Set`), and every codegen site producing such results must retain components symmetrically.
 
 | Stage | Site | Helper |
 |---|---|---|
-| Per-component retain | `emitCollOp_items`, `enumerate`, `zip` (`InsertValue` setup) | `emitTupleComponentRetain(val, fSig)` |
+| Per-component retain | `emitCollOp_items`, `enumerate`, `zip` (InsertValue setup) | `emitTupleComponentRetain(val, fSig)` |
 | Buffer-wide retain | `emitListSlice`, `emitCollOp_take_impl`, `emitCollOp_appended` (memcpy half), `emitListConcat` | `emitTupleElemRetainLoop(arrayPtr, len, tag, tupleSig, tupleTy)` |
-| Buffer-wide release | `getOrCreateCollectionDestructor` → `emitInnerReleaseLoop` lambda | `emitTupleElemReleaseLoop(arrayPtr, len, tag, tupleSig, tupleTy)` |
+| Buffer-wide release | `getOrCreateCollectionDestructor` → `emitInnerReleaseLoop` | `emitTupleElemReleaseLoop(arrayPtr, len, tag, tupleSig, tupleTy)` |
 
-**Why not extend `fieldTypeIsArcManaged`**: Making `fieldTypeIsArcManaged("(K, V)")` return `true` would short-circuit ~30 callers (`elementTypeIsArcManaged`, `emitCowRetainArcElements`, `emitListSlice`, `emitCollOp_take_impl`, `emitCollOp_appended`, `emitListConcat`, `emitCowClone`, ...) into pointer-array retain/release loops. But a `List<(K, V)>` data buffer holds **inline tuple struct values** (`sizeof(StructType)` bytes per slot), not pointers — those callers would read the struct as a pointer and apply a `−16` GEP, causing memory corruption. Tuple isn't a `Kind`-level entity (no `CollectionKind::Tuple`); it's a meta-concept where each field is independently ARC-managed. So the dispatch is added **locally at each site that handles tuple-element buffers**, ahead of any `elementTypeIsArcManaged` call:
+**Why not extend `fieldTypeIsArcManaged`**: making it return true for `"(K, V)"` would short-circuit ~30 callers (`elementTypeIsArcManaged`, `emitCowRetainArcElements`, `emitListSlice`, etc.) into pointer-array retain/release loops. But `List<(K, V)>` data buffer holds **inline tuple struct values** (`sizeof(StructType)` bytes per slot), not pointers — those callers would read struct as pointer and apply `−16` GEP → memory corruption. Tuple isn't a `Kind`-level entity (no `CollectionKind::Tuple`); each field is independently ARC-managed. Dispatch added locally at each tuple-buffer site, ahead of `elementTypeIsArcManaged`:
 
 ```cpp
 const std::string elemSig = srcMeta ? srcMeta->list_elem_type_name : std::string{};
-const bool elemIsTuple =
-    elemSig.size() >= 2 && elemSig.front() == '(' && elemSig.back() == ')';
+const bool elemIsTuple = elemSig.size() >= 2 && elemSig.front() == '(' && elemSig.back() == ')';
 if (elemIsTuple) {
     auto *tupleTy = llvm::cast<llvm::StructType>(elemTy);
     emitTupleElemRetainLoop(newData, count, "<tag>_telem", elemSig, tupleTy);
@@ -827,27 +447,22 @@ if (elemIsTuple) {
 }
 ```
 
-`emitTupleComponentRetain` does not call `fieldTypeIsArcManaged` either — it dispatches by the source-level type name (`"str"` → `StringHeader` offset −24, `List<...>` / `Map<...>` / `Set<...>` → `ArcHeader` offset −16) so the offset is selected from authoritative metadata, not from a heuristic that reads the value (which would conflate `str` and collection cases per the "`tryRetainArcSource` LoadInst cases must be metadata-gated" rule above).
+`emitTupleComponentRetain` dispatches by source-level type name (`"str"` → −24, `List<...>` / `Map<...>` / `Set<...>` → −16) — authoritative metadata, not value-reading heuristic.
 
-**Caching invariant**: The destructor cache key is `(CollectionKind, elemSig, valSig)`. Tuple sigs (`"(int, List<int>)"`, etc.) live in `elemSig`, so destructors for distinct tuple shapes are cached as distinct functions automatically — no manual disambiguation needed (#1046's caching rule extends transparently).
+**Caching invariant**: Destructor cache key `(CollectionKind, elemSig, valSig)` — tuple sigs live in `elemSig`, distinct shapes cached as distinct functions automatically.
 
-**Caveat: literal-built `List<(K, V)>`**: `inferCollectionTypeName` returns empty for tuple values, so `xs: List<(int, str)> = [(1, "a")]` has `list_elem_type_name = ""`. The new destructor branch is gated on a non-empty tuple sig and so is **not dispatched** for literal-built lists — pre-fix behavior (no retain, no release) is preserved. Issue tracking the literal-path metadata gap is out of scope for #1667.
+**Caveat — literal-built `List<(K, V)>`**: `inferCollectionTypeName` returns empty for tuple values; `xs: List<(int, str)> = [(1, "a")]` has `list_elem_type_name = ""`. New destructor branch is gated on non-empty tuple sig — NOT dispatched for literal-built lists (pre-fix behavior preserved). Issue tracking literal-path metadata gap is out of scope for #1667.
 
-**Caveat: `xs[i] = (a, b)` slot-overwrite on `List<(K, V)>`** (resolved by #1670): Post-#1667, the destructor released inner ARC components but the IndexAssignStmt path did neither — leaking the evicted tuple's components on every overwrite. #1670 closed this gap by emitting per-component retain on the new tuple before per-component release on the old slot (retain-before-release safe for self-assignment), gated on non-empty `list_elem_type_name` with tuple shape `"(...)"`. See "IndexAssignStmt slot overwrite on `List<(K, V)>` must retain new tuple components and release old, gated on `list_elem_type_name` non-empty + tuple shape" entry below.
+**Slot overwrite (`xs[i] = (a, b)`)**: resolved by #1670 — see next entry.
 
-**How to apply**: When adding a new collection helper that constructs a `List<(K, V)>` (whether by tuple-aware `InsertValue` or by memcpy-then-mutate), use the dispatch pattern above. Per-component sites (single tuple insertion) call `emitTupleComponentRetain` per ARC-managed component; buffer sites (memcpy of the whole tuple-struct array) call `emitTupleElemRetainLoop`. Mirror the destructor's `emitTupleElemReleaseLoop` is automatic via metadata inheritance — but verify by writing a regression test that rebinds the source after the helper call and reads the result through a churn loop. Canonical: `tests/spec/arc_tuple_ownership.test.ry`.
+### IndexAssignStmt slot overwrite on `List<(K, V)>` must retain new tuple components and release old
 
-**Related**: #1242 (parent rule for destructor-recursion-implies-retain-on-store), #1659 (items() metadata stamping that exposed the gap), #1664 (tuple-field metadata propagation), #1204 (memcpy retain canonical), #1235 (take memcpy retain), #1046 (destructor caching), #1670 (IndexAssignStmt slot-overwrite symmetry follow-up).
+**Source**: #1670 (2026-05-09)
+**Tags**: ARC, tuple, IndexAssignStmt, slot-overwrite, retain-before-release, traceInsertValueField
 
----
+**Rule**: When `IndexAssignStmt` writes a tuple value into a slot of `List<(K, V)>`, codegen must (i) retain each ARC-managed component of the *new* tuple via `emitTupleComponentRetain`, then (ii) release each ARC-managed component of the *old* slot via `emitTupleElemReleaseSlot`, then store. Retain-before-release is required for self-assignment safety (`e[i] = e[i]`).
 
-### IndexAssignStmt slot overwrite on `List<(K, V)>` must retain new tuple components and release old, gated on `list_elem_type_name` non-empty + tuple shape
-
-**Source**: #1670 (2026-05-09). **Tags**: ARC, tuple, IndexAssignStmt, slot-overwrite, retain-before-release, list_elem_type_name, traceInsertValueField
-
-**Rule**: When `IndexAssignStmt` writes a tuple value into a slot of `List<(K, V)>` (`xs[i] = (a, b)`), the codegen path must (i) retain each ARC-managed component of the *new* tuple via `emitTupleComponentRetain`, then (ii) release each ARC-managed component of the *old* slot via `emitTupleElemReleaseSlot`, then store. Order matters: retain-before-release is required for self-assignment safety (`e[i] = e[i]` would otherwise transiently drop the refcount to zero).
-
-The block is added **alongside** (not as `else if` of) the existing `if (elemIsArc)` branch in `emitStmt(IndexAssignStmt &)`'s list path — `elementTypeIsArcManaged` returns `false` for tuples by design (tuples are inline structs, not ARC-managed pointer types), so the existing branch never fires. Gate on `resolveTypeAlias(elemTypeName)`, NOT on `elemTypeName` directly:
+Block added **alongside** (not `else if` of) the existing `if (elemIsArc)` branch — `elementTypeIsArcManaged` returns false for tuples by design (inline structs, not ARC-managed pointer types). Gate on `resolveTypeAlias(elemTypeName)`:
 
 ```cpp
 const std::string resolvedElemTypeName = resolveTypeAlias(elemTypeName);
@@ -856,31 +471,23 @@ const bool elemIsTuple = resolvedElemTypeName.size() >= 2 &&
                           resolvedElemTypeName.back() == ')';
 ```
 
-**Why resolve aliases first**: User-defined type aliases like `type Pair = (int, str)` propagate the alias name (`"Pair"`) into `list_elem_type_name`, not the canonical tuple shape. A naive gate on `elemTypeName.front() == '('` would skip alias-typed lists entirely, leaking the evicted tuple's components on every overwrite. `resolveTypeAlias` walks the alias chain to its canonical form (e.g. `"Pair"` → `"(int, str)"`), so the gate matches correctly. The resolved name must also be passed to `splitTupleSig` and `emitTupleElemReleaseSlot` so component decomposition uses the canonical form.
+**Why resolve aliases first**: `type Pair = (int, str)` propagates the alias name into `list_elem_type_name`, not the canonical tuple shape. Naive `elemTypeName.front() == '('` skips alias-typed lists, leaking on every overwrite. `resolveTypeAlias` walks the chain to canonical form. Resolved name must also feed `splitTupleSig` and `emitTupleElemReleaseSlot`.
 
-**Why the non-empty gate matters**: `inferCollectionTypeName` returns `""` for tuple values, so a literal-built `xs: List<(int, str)> = [(1, "a")]` has `list_elem_type_name = ""`. The destructor branch added in #1667 is also gated on non-empty tuple sig — keeping the symmetry, IndexAssignStmt also skips for empty sigs (preserving pre-fix behavior, same blind spot as `List<str>` literals). Lists produced by `enumerate` / `items` / `zip` / `slice` / `take` / `appended` / `concat` all stamp a concrete tuple sig in `list_elem_type_name`, so they hit the new branch correctly.
+**Why non-empty gate matters**: `inferCollectionTypeName` returns `""` for tuple values. Literal-built `xs: List<(int, str)> = [(1, "a")]` has empty name. Destructor branch added in #1667 is also gated on non-empty — keeps symmetry (same blind spot as `List<str>` literals). Lists from `enumerate` / `items` / `zip` / `slice` / `take` / `appended` / `concat` all stamp concrete tuple sig.
 
-**Trace InsertValue chains recursively for nested tuple ownership**: When the rhs is a freshly-constructed tuple (`InsertValue(InsertValue(undef, k, {0}), v, {1})`), `CreateExtractValue(finalVal, {i})` does NOT fold back to the original SSA value — LLVM's `IRBuilder<>` uses `ConstantFolder` by default which only folds constants, not non-constant InsertValue/ExtractValue chains. A single-step `traceInsertValueField` is **insufficient for nested tuple shapes** like `xs[i] = (0, ([1], 2))`: the trace recovers the inner InsertValue (the nested tuple `([1], 2)`), not the leaf `[1]`. The leaf-level ownership check (`arc_owned_values_.count(...)`) then misses, and the redundant retain leaks the inner allocation by +N per overwrite (post-#1667 the destructor releases each leaf once on overwrite, so the asymmetry shows up as a leak proportional to iteration count — `delta = +2` per iteration in the `nestedTupleSlotOverwriteNoLeak` test on the pre-recursive version).
+**Trace InsertValue chains recursively for nested tuples**: When rhs is `InsertValue(InsertValue(undef, k, {0}), v, {1})`, `CreateExtractValue(finalVal, {i})` does NOT fold back to the original SSA value — `IRBuilder<>` uses `ConstantFolder` which only folds constants. Single-step `traceInsertValueField` is **insufficient for nested shapes** like `xs[i] = (0, ([1], 2))`: trace recovers the inner InsertValue (the nested tuple), not the leaf `[1]`. Leaf `arc_owned_values_.count(...)` misses, and redundant retain leaks the inner allocation by +N per overwrite (post-#1667 destructor releases each leaf once on overwrite — asymmetry shows as leak proportional to iteration; `delta = +2` per iteration in `nestedTupleSlotOverwriteNoLeak` test).
 
-The fix is `emitTupleComponentRetainTraced(fieldVal, sourceAgg, topIdx, fSig)` (`codegen_arc.cpp` for #1670), which (a) traces `sourceAgg` at `topIdx` to find the original operand, (b) if `fSig` resolves to a tuple shape `"(...)"`, recurses over each sub-component using the **traced sub-aggregate** (not the outer `sourceAgg`) as the new source so the recursion can keep tracing into deeper levels, and (c) at leaves checks `arc_owned_values_` / `arc_str_owned_values_` on the traced value before falling through to `emitTupleComponentRetain`. The `IndexAssignStmt` callsite is one line per top-level component:
+Fix: `emitTupleComponentRetainTraced(fieldVal, sourceAgg, topIdx, fSig)` — (a) trace `sourceAgg` at `topIdx` for original operand, (b) if `fSig` resolves to tuple shape, recurse over each sub-component using the **traced sub-aggregate** as new source, (c) at leaves check `arc_owned_values_` / `arc_str_owned_values_` on traced value before falling through to `emitTupleComponentRetain`. Callsite:
 
 ```cpp
 for (unsigned i = 0; i < n; ++i) {
-    llvm::Value *fieldVal = builder_.CreateExtractValue(
-        finalVal, {i}, "tup_new_f" + std::to_string(i));
+    llvm::Value *fieldVal = builder_.CreateExtractValue(finalVal, {i}, "tup_new_f" + std::to_string(i));
     emitTupleComponentRetainTraced(fieldVal, finalVal, i, components[i]);
 }
 ```
 
-Without the recursive trace, fresh `+1` allocations from arc_owned literals embedded in nested tuple shapes get double-retained, producing a leak proportional to the number of overwrites (the leak-delta test grew by +2 per iteration before the recursive fix).
+**`emitTupleElemReleaseSlot` helper**: Factored from per-slot body of `emitTupleElemReleaseLoop`. Avoids 4 throwaway BBs (header/body/latch/post) for a single slot; reused by the loop body. Loads slot, extracts components, releases ARC components by source-level type name (str −24, List/Map/Set −16, nested tuples recurse).
 
-**`emitTupleElemReleaseSlot` helper**: Factored from the per-slot body of `emitTupleElemReleaseLoop` (`codegen_arc.cpp`). The single-slot helper avoids emitting 4 throwaway basic blocks (header/body/latch/post) for a single slot, and is reused by `emitTupleElemReleaseLoop`'s body. Signature: `emitTupleElemReleaseSlot(slotPtr, tag, tupleSig, tupleTy)` — slot is loaded inside, components are extracted, ARC components are released by source-level type name (str at −24, List/Map/Set at −16, nested tuples recurse).
+**Compound op N/A**: tuples have no arithmetic; parser/typechecker rejects compound `IndexAssignStmt` on `List<(K, V)>` upstream of codegen.
 
-**Compound op (`+=` etc.) is N/A**: Tuples have no arithmetic operators, so the parser/typechecker rejects compound-op `IndexAssignStmt` on `List<(K, V)>` upstream of codegen — no compound-op branch is needed.
-
-**Symmetry principle**: The retain-before-release pattern at slot-overwrite sites generalizes — when a destructor recursively releases ARC components of a typed slot (not just whole-pointer ARC objects), every codegen site that writes into that slot must (i) retain new components and (ii) release evicted components in retain-before-release order. The destructor side is the source of truth; the write-side discipline is mechanical from there. Future tuple-element collection mutators (`xs.append((a, b))`, `xs.insert(i, (a, b))`) need the same per-component retain — verified by the same delta-based regression pattern.
-
-**Related**: #1667 (parent — destructor recursion + tuple-component retain on construction), #855 (whole-pointer slot overwrite release discipline — ancestor), #1242 (destructor-recursion-implies-retain-on-store), #1108 (`emitArcReleaseLoadedElement` inner-sig propagation).
-
----
-
+**Symmetry principle**: When destructor recursively releases ARC components of a typed slot (not just whole-pointer ARC), every write site must (i) retain new components and (ii) release evicted components retain-before-release. Future tuple mutators (`xs.append((a, b))`, `xs.insert(i, (a, b))`) need same per-component retain — verified by delta-based regression pattern.

--- a/.claude/rules/codegen-fn-and-generic.md
+++ b/.claude/rules/codegen-fn-and-generic.md
@@ -12,17 +12,18 @@ paths:
 
 ### `inferExprType` / `inferExprTypeName` visitor must handle `IfExpr`/`IfBlockExpr` and ADT constructors (`Ok`/`Err`/`Some`/`None`/`Error`) to infer lambda return type correctly
 
-**Source**: #1024 (2026-04-16, bugfix — lambda if-expr Result branch unification); #1043 (2026-04-17, bugfix — Option analog); #1111 (2026-04-17, bugfix — Error constructor + `anyTy_` IfExpr merge); #1115 (2026-04-18, bugfix — Option branch merge `preferConcrete` + `Some` emitter `anyTy_` unwrap); #1116 (2026-04-18, bugfix — Err emitter analog of #1111 Ok fix)
+**Source**: #1024 / #1043 / #1111 / #1115 / #1116 (2026-04-16 .. 2026-04-18)
 **Tags**: codegen, inference, visitor, lambda, Result, Option, IfExpr, anyTy_, Error
 
-**Rule**: `inferExprType` and `inferExprTypeName` in `src/codegen_lambda.cpp` are the visitor functions that determine the return type of an expression-body lambda (`(x: int) => expr`). Both functions must have explicit `if constexpr` cases for every AST node that can appear as the outermost expression. Any unhandled node falls through to the default which returns `i64Ty_` (= `int`) — silently and without error.
+**Rule**: `inferExprType` and `inferExprTypeName` in `src/codegen_lambda.cpp` determine an expression-body lambda's return type (`(x: int) => expr`). Both must have explicit `if constexpr` cases for every AST node that can be the outermost expression. An unhandled node falls through to the default `i64Ty_` (= `int`) — silently and without error.
 
 Confirmed gaps (all fixed):
-1. **`IfExpr` / `IfBlockExpr`** — neither visitor had a case for these nodes, so any lambda whose body is an `if` expression with mismatched-type branches (e.g., `Ok(T)` vs `Err(E)`) fell through to `int`, baking the wrong return type into the function signature before codegen. (#1024)
-2. **`Ok` / `Err` in CallExpr** — the CallExpr branch had `Some` but not `Ok`/`Err`. Without these, the Ok/Err payload types could not be inferred, making the IfExpr merge logic unreachable even after adding it. (#1024)
-3. **`Error` constructor in CallExpr** — `Err(Error("msg"))` must infer as `getResultType(i8Ty_, errorTy_)`. Without an explicit `if (c == "Error") return errorTy_` case, it falls through to `i64Ty_`, making the inferred branch type `{i1, i8, i64}` instead of `{i1, i8, errorTy_}`. The IfExpr merge then produces the wrong StructType pointer, and `validateBranchTypes` rejects the mismatch. (#1111)
+1. **`IfExpr` / `IfBlockExpr`** — neither visitor had a case, so a lambda whose body is `if` with mismatched-type branches (`Ok(T)` vs `Err(E)`) fell through to `int`, baking the wrong return type before codegen. (#1024)
+2. **`Ok` / `Err` in CallExpr** — the CallExpr branch had `Some` but not `Ok`/`Err`, so Ok/Err payload types could not be inferred. (#1024)
+3. **`Error` constructor in CallExpr** — `Err(Error("msg"))` must infer as `getResultType(i8Ty_, errorTy_)`. Without an explicit `if (c == "Error") return errorTy_` case, the inferred branch type is `{i1, i8, i64}` instead of `{i1, i8, errorTy_}`, and `validateBranchTypes` rejects the StructType pointer mismatch. (#1111)
 
-**Result merge logic (IfExpr)**: When both branches of an `if` expression yield `isResultType`, the inferred types are `{i1, realOkTy, Unit}` and `{i1, Unit, realErrTy}` (each side uses `i8Ty_` as the placeholder for the missing payload). Also, unannotated lambda params yield `anyTy_` — which must lose to a concrete type but win over `i8Ty_`. Use a `preferConcrete` merge:
+**Result merge logic (IfExpr)**: When both branches yield `isResultType`, the inferred types are `{i1, realOkTy, Unit}` and `{i1, Unit, realErrTy}` (each side uses `i8Ty_` as the missing-payload placeholder). Unannotated lambda params yield `anyTy_` — must lose to a concrete type but win over `i8Ty_`. Use `preferConcrete`:
+
 ```cpp
 // Priority: concrete > anyTy_ (unannotated param) > i8Ty_ (absent-payload placeholder)
 auto preferConcrete = [&](llvm::Type *a, llvm::Type *b) -> llvm::Type * {
@@ -32,314 +33,184 @@ auto preferConcrete = [&](llvm::Type *a, llvm::Type *b) -> llvm::Type * {
 };
 return getResultType(preferConcrete(okA, okB), preferConcrete(erA, erB));
 ```
+
 The old `(a == i8Ty_) ? b : a` rule was broken for `anyTy_`: `(any, i8) → i8` (wrong) instead of `any`. (#1111)
 
-**`Ok` / `Err` emitters must unwrap `anyTy_` to the expected slot type**: When `fn_->getReturnType()` indicates a concrete ok/err type (e.g., `i64`) but `Ok(x)` / `Err(x)` emits with `x` of type `anyTy_` (unannotated param), the emitted Result struct contains `anyTy_` for that slot — different from the concrete type produced by the sibling branch. `validateBranchTypes` pointer-equality fails. Fix: in both the `Ok` and `Err` emitters (`codegen_call.cpp`), after deriving the expected slot type from `retStructTy->getElementType(1/2)`, call `unwrapFromAny(inner, expectedSlotTy)` when `isAnyType(inner->getType()) && canAnyHoldType(expectedSlotTy) && expectedSlotTy != i8Ty_`. `canAnyHoldType(errorTy_) = false`, so `Err(Error(...))` is unaffected — the gap is limited to `Result<T, primitive>` (int/float/bool/str) Err slots. (#1111 for Ok; #1116 for Err)
+**`Ok` / `Err` emitters must unwrap `anyTy_` to the expected slot type**: When `fn_->getReturnType()` indicates a concrete ok/err type but `Ok(x)` / `Err(x)` emits with `x` of `anyTy_` (unannotated param), the Result struct contains `anyTy_` for that slot — different from the sibling branch's concrete type, and `validateBranchTypes` pointer-equality fails. Fix: in both emitters (`codegen_call.cpp`), derive expected slot type from `retStructTy->getElementType(1/2)`, then call `unwrapFromAny(inner, expectedSlotTy)` when `isAnyType(inner->getType()) && canAnyHoldType(expectedSlotTy) && expectedSlotTy != i8Ty_`. `canAnyHoldType(errorTy_) = false`, so `Err(Error(...))` is unaffected — gap is limited to `Result<T, primitive>` Err slots. (#1111 Ok; #1116 Err)
 
-**Option merge logic (IfExpr — fixed in #1043, updated in #1115)**: Option layout is 2-slot `{i1, innerTy}` vs Result's 3-slot. Three gaps existed beyond the structural #1024 analog:
-1. `Some` was missing from `inferExprType` (it was only in `inferExprTypeName`), causing `(x) => Some(x)` to fail.
-2. `None()` (zero-arg CallExpr) had no emitter anywhere — it fell through to `findFunction("None")` and failed with `undefined function: None`.
-3. `None` in `inferExprType` also needed a placeholder: `getOptionType(i8Ty_)`.
+**Option merge logic (IfExpr — fixed in #1043, updated in #1115)**: 2-slot `{i1, innerTy}` vs Result's 3-slot. Three gaps beyond the structural #1024 analog:
+1. `Some` was missing from `inferExprType` (only in `inferExprTypeName`), so `(x) => Some(x)` failed.
+2. `None()` (zero-arg CallExpr) had no emitter — fell through to `findFunction("None")` and failed with `undefined function: None`.
+3. `None` in `inferExprType` needed placeholder `getOptionType(i8Ty_)`.
 
-Option merge must use the same `preferConcrete` rule as Result (#1115 — the old `(a == i8Ty_) ? b : a` was broken for `anyTy_`):
-```cpp
-if (isOptionType(thenTy) && isOptionType(elseTy)) {
-    llvm::Type *innerA = thenSt->getElementType(1);
-    llvm::Type *innerB = elseSt->getElementType(1);
-    // Priority: concrete > anyTy_ (unannotated param) > i8Ty_ (None placeholder)
-    auto preferConcrete = [&](llvm::Type *a, llvm::Type *b) -> llvm::Type * {
-        if (a == i8Ty_) return b;
-        if (!isAnyType(a)) return a;
-        return (b != i8Ty_) ? b : a;
-    };
-    return getOptionType(preferConcrete(innerA, innerB));
-}
-```
-`None()` emitter in `codegen_call.cpp` reads `fn_->getReturnType()` to derive inner (like `Err` does for the Ok slot), so the emitted struct matches the inferred return type and `validateBranchTypes` pointer-equality succeeds.
+Option merge uses the **same `preferConcrete` rule** as Result (#1115 — `(a == i8Ty_) ? b : a` was broken for `anyTy_`); apply to `getOptionType(preferConcrete(innerA, innerB))`. `None()` emitter in `codegen_call.cpp` reads `fn_->getReturnType()` to derive inner (like `Err` does for the Ok slot).
 
-**`Some` emitter must also unwrap `anyTy_` (mirrors `Ok` emitter, #1115)**: After the `preferConcrete` lambda-inference fix sets the function return type to `Option<int>`, the `Some(x)` call with unannotated `x` still emits `anyTy_`. Without an explicit unwrap, the produced struct is `{i1, anyTy_}` while `Some(0)` produces `{i1, int}` — `validateBranchTypes` pointer-equality fails. Fix: in the `Some` emitter (`codegen_call.cpp`), derive `expectedInnerTy` from `retStructTy->getElementType(1)`, then call `unwrapFromAny(inner, expectedInnerTy)` when `isAnyType(inner->getType()) && canAnyHoldType(expectedInnerTy)`. Both fixes must be bundled: `preferConcrete` alone converts a silent wrong value into a compile error without fixing correctness.
+**`Some` emitter must also unwrap `anyTy_` (mirrors `Ok` emitter, #1115)**: After `preferConcrete` sets the function return type to `Option<int>`, `Some(x)` with unannotated `x` still emits `anyTy_` → `{i1, anyTy_}` while `Some(0)` produces `{i1, int}`. Fix: derive `expectedInnerTy` from `retStructTy->getElementType(1)`, then `unwrapFromAny(inner, expectedInnerTy)` when `isAnyType(inner->getType()) && canAnyHoldType(expectedInnerTy)`. Both fixes must bundle: `preferConcrete` alone converts a silent wrong value into a compile error without fixing correctness.
 
-**Parser trap — block-form branches with `Some(...)`/`None()` tail**: In an `IfBlockExpr` (colon-indent body), a bare `Some(x)` or `None()` on the last line is parsed as a `CallStmt` (discarded statement), not as the block's return value. Wrap it in parentheses to produce an `ExprStmt` that is recognised as the tail expression:
+**Parser trap — block-form branches with `Some(...)`/`None()` tail**: In `IfBlockExpr` (colon-indent body), bare `Some(x)` / `None()` on the last line parses as `CallStmt` (discarded), not return value. Wrap in parens to produce an `ExprStmt`:
+
 ```ry
 f = (x: int) => if x > 0:
   (Some(x * 2))   # ← parens required; bare Some(x * 2) would be a discarded CallStmt
 else:
   (None())
 ```
-This is the same rule as the `IfBlockExpr` path tested in `tests/spec/option_lambda_if.test.ry`.
 
-**How to check for new gaps**: When adding a new ADT constructor or a new expression-level control-flow node, grep for both `inferExprType` and `inferExprTypeName` and verify each has a case for the new node. A missing case is a silent wrong-type inference, not a compile error.
+Same rule as `IfBlockExpr` tested in `tests/spec/option_lambda_if.test.ry`.
+
+**How to check for new gaps**: When adding a new ADT constructor or expression-level control-flow node, grep both `inferExprType` and `inferExprTypeName` and verify each has a case. A missing case is a silent wrong-type inference, not a compile error.
 
 ### `isNoneLiteral` must match all three None syntactic forms: `None`, `none`, `None()`
 
-**Source**: #1099 (2026-04-17, bugfix — `None()` in let-decl and reassignment contexts)
+**Source**: #1099 (2026-04-17)
 **Tags**: codegen, Option, None, isNoneLiteral, let-decl, reassignment, emitVarDecl, CallExpr
 
-**Rule**: `None`, `none`, and `None()` are semantically identical Option literals. `isNoneLiteral` in `src/codegen_type.cpp` must recognise all three:
-- `NoneExpr` — the keyword `none`
-- `VariableExpr{name:"None"}` — the bareword `None`
-- `std::unique_ptr<CallExpr>{callee:"None", args.empty()}` — the call form `None()`
+**Rule**: `None`, `none`, and `None()` are semantically identical Option literals. `isNoneLiteral` in `src/codegen_type.cpp` must recognise all three: `NoneExpr` (keyword `none`), `VariableExpr{name:"None"}` (bareword), `std::unique_ptr<CallExpr>{callee:"None", args.empty()}` (call form).
 
-`None()` was introduced in #1043 for lambda if-expr unification. Its emitter in `codegen_call.cpp` uses `fn_->getReturnType()` to derive the inner type — correct for return-statement contexts, but wrong in let-decl and reassignment where the enclosing function is unrelated to the variable's annotation. Three sites that use `isNoneLiteral` to short-circuit into annotation-aware `buildNoneValue(annotTy)` were therefore bypassed:
-- `src/codegen_stmt.cpp` `emitVarDecl` (line ≈204) — let-decl short-circuit (auto-fires after fix)
-- `src/codegen_stmt.cpp` local reassignment (line ≈845) — previously had a raw `VariableExpr{"None"}` check
-- `src/codegen_stmt.cpp` module-global reassignment (line ≈1020) — same raw check
+`None()` was introduced in #1043 for lambda if-expr unification. Its emitter uses `fn_->getReturnType()` — correct in return-stmt contexts, wrong in let-decl/reassignment where the enclosing function is unrelated to the variable's annotation. Three sites use `isNoneLiteral` to short-circuit into annotation-aware `buildNoneValue(annotTy)`:
+- `src/codegen_stmt.cpp` `emitVarDecl` (line ≈204) — let-decl short-circuit
+- `src/codegen_stmt.cpp` local reassignment (line ≈845)
+- `src/codegen_stmt.cpp` module-global reassignment (line ≈1020)
 
-**How to apply**: When adding a new syntactic form of `None` to the language, extend `isNoneLiteral` first. Then all three sites above automatically inherit the fix. The `None()` emitter in `codegen_call.cpp` is a separate fallback for contexts where no annotation is available (e.g., return-stmt); it is not a substitute for `isNoneLiteral`. Use `std::get_if<std::unique_ptr<CallExpr>>` (not `std::get_if<CallExpr>`) because `CallExpr` is stored as `unique_ptr` in the `ExprNode` variant.
+**How to apply**: When adding a new syntactic form of `None`, extend `isNoneLiteral` first — all three sites inherit the fix. The `None()` emitter in `codegen_call.cpp` is a fallback for contexts without annotation, not a substitute for `isNoneLiteral`. Use `std::get_if<std::unique_ptr<CallExpr>>` (not `std::get_if<CallExpr>`) because `CallExpr` is stored as `unique_ptr` in `ExprNode`.
 
 ### Hint channel for `None()`/`none` inner type in branch-merge and lambda-call argument positions
 
-**Source**: #1154 (2026-04-18, bugfix — `None()` in if/case branch defaults to `Option<i8>`), #1179 (2026-04-19, bugfix — `None()` in lambda call arg defaults to wrong inner type), #1186 (2026-04-19, bugfix — `None()` in record/struct constructor field position defaults to wrong inner type)
+**Source**: #1154 / #1179 / #1186 (2026-04-18 .. 2026-04-19)
 **Tags**: codegen, Option, None, NoneExpr, branch-merge, IfExpr, CaseExpr, hint-channel, RAII, lambda-call, record-constructor
 
-**Rule**: `None()` and `none` in branch-merge positions (e.g., `if cond => None() else Some(42)`) previously defaulted to `Option<i8>` or `Option<i64>` because the emitters only consulted `fn_->getReturnType()`. The fix introduces a two-field class-state hint channel:
+**Rule**: `None()` / `none` in branch-merge positions (`if cond => None() else Some(42)`) previously defaulted to `Option<i8>` / `Option<i64>` because emitters only consulted `fn_->getReturnType()`. The fix is a two-field class-state hint channel:
 
 - **`option_none_hint_inner_: llvm::Type*`** — arm hint, read directly by `None()` and `NoneExpr` emitters (nullptr = no hint).
-- **`option_decl_annotation_inner_: llvm::Type*`** — declaration-context annotation inner, written by `emitVarDecl`/local-reassign/global-reassign via `DeclAnnotationInnerGuard`. **NOT read by None()/NoneExpr emitters directly** — only used as fallback in IfExpr/IfBlockExpr guards so it cannot leak into arbitrary sub-expressions (e.g., function arguments such as `foo(none)`).
-- `OptionNoneHintGuard` RAII saves/restores `option_none_hint_inner_`; `DeclAnnotationInnerGuard` RAII saves/restores `option_decl_annotation_inner_`.
+- **`option_decl_annotation_inner_: llvm::Type*`** — declaration-context annotation inner, written by `emitVarDecl`/local-reassign/global-reassign via `DeclAnnotationInnerGuard`. **NOT read by None()/NoneExpr emitters directly** — only used as fallback in IfExpr/IfBlockExpr guards so it cannot leak into arbitrary sub-expressions (e.g., `foo(none)`).
+- `OptionNoneHintGuard` / `DeclAnnotationInnerGuard` RAII save/restore the respective fields.
 - `computeBranchOptionInnerHint(a, b)` in `codegen_lambda.cpp` runs `inferExprType` on both arms and picks the more-concrete inner via `preferConcrete`.
-- **Annotation seed** at three `codegen_stmt.cpp` sites: `emitVarDecl`, local reassign, module-global reassign — writes `option_decl_annotation_inner_` (not `option_none_hint_inner_`) from the declared `Option<T>` inner before `emitExpr(RHS)`.
-- **IfExpr / IfBlockExpr pre-scan** in `codegen_expr.cpp`: computes hint **before** condition emit, installs `OptionNoneHintGuard` **after** condition emit. The fallback for all-None arms uses `option_decl_annotation_inner_`. **Critical**: the guard must be installed after the condition because `none`/`None()` in the condition expression must not inherit the arm hint.
-- **`NoneExpr` added to `inferExprType` and `inferExprTypeName`** in `codegen_lambda.cpp`: `inferExprType` returns `getOptionType(i8Ty_)` so `computeBranchOptionInnerHint` detects it as an Option placeholder; `inferExprTypeName` returns `"Option"`.
-- **CaseExpr (pattern match) uses scrutinee-based hint** in `codegen_match.cpp::emitExprVariant(CaseExpr)`: `Some(v)` arm values reference pattern-bound variables not in scope at pre-scan time, so `computeBranchOptionInnerHint` cannot be applied. Instead, the scrutinee type (`subjectTy`) is used — if it is `Option<T>`, its inner `T` is extracted and installed as the `OptionNoneHintGuard` hint before any arm is emitted. Fallback is `option_decl_annotation_inner_`.
-- **CaseCondExpr (`when cond => value`) uses pre-scan** in `codegen_expr.cpp::emitExprVariant(CaseCondExpr)`: no pattern variables are involved, so `computeBranchOptionInnerHint` on the first arm value and `else_expr` is safe. Guard is installed inside each value emit block (after the arm condition) to prevent hint leaking into condition expressions.
-- **Lambda variable (indirect) call arguments** in `codegen_call_dispatch.cpp` (#1179): per-arg `OptionNoneHintGuard` with inner derived from the callee's `FnTypeInfo::paramTypes[i]` — only when that param is `isOptionType`. The hint source is the **callee signature** (not `option_decl_annotation_inner_`), so the invariant "decl annotation must not flow into arg positions" is preserved — the two channels remain disjoint by design. Non-Option params pass `nullptr` as inner (guard saves/restores nullptr, which is also a correct "clear" for nested contexts such as a call inside a branch-merge).
-- **Record/struct constructor field positions** in `codegen_expr_literal.cpp::emitRecordConstructor` (#1186): per-field `OptionNoneHintGuard` with inner derived from `info.llvmType->getElementType(i)` — only when that field is `isOptionType`. The hint source is the **field's declared LLVM struct element type**, which covers inherited fields via `allFields` pre-flattening (parent fields occupy lower indices). Non-Option fields pass `nullptr` as inner (correctly clears any outer hint when emitting e.g. `Outer(Some(UserWithAvatar("carol", None())))` so the nested `None()` inherits `UserWithAvatar.avatar`'s `str` rather than `Outer.inner`'s `UserWithAvatar`).
+- **Annotation seed** at three `codegen_stmt.cpp` sites (`emitVarDecl`, local reassign, module-global reassign): writes `option_decl_annotation_inner_` from the declared `Option<T>` inner before `emitExpr(RHS)`.
+- **IfExpr / IfBlockExpr pre-scan** in `codegen_expr.cpp`: computes hint **before** condition emit, installs `OptionNoneHintGuard` **after** condition emit. Fallback uses `option_decl_annotation_inner_`. **Critical**: the guard must install after the condition because `none`/`None()` in the condition must not inherit the arm hint.
+- **`NoneExpr` added to `inferExprType` and `inferExprTypeName`**: returns `getOptionType(i8Ty_)` / `"Option"` so `computeBranchOptionInnerHint` detects it as Option placeholder.
+- **CaseExpr (pattern match) uses scrutinee-based hint** in `codegen_match.cpp`: `Some(v)` arm values reference pattern-bound variables not in scope at pre-scan time, so `computeBranchOptionInnerHint` cannot apply. Use scrutinee type — if `Option<T>`, install inner `T` as `OptionNoneHintGuard` before any arm is emitted. Fallback `option_decl_annotation_inner_`.
+- **CaseCondExpr (`when cond => value`) uses pre-scan**: no pattern variables, so `computeBranchOptionInnerHint` on first arm + `else_expr` is safe. Guard installed inside each value emit block to prevent hint leaking into condition.
+- **Lambda variable (indirect) call arguments** in `codegen_call_dispatch.cpp` (#1179): per-arg `OptionNoneHintGuard` with inner from `FnTypeInfo::paramTypes[i]` — only when `isOptionType`. Hint source is the **callee signature** (not `option_decl_annotation_inner_`), preserving the disjoint-channels invariant. Non-Option params pass `nullptr`.
+- **Record/struct constructor field positions** in `codegen_expr_literal.cpp::emitRecordConstructor` (#1186): per-field `OptionNoneHintGuard` from `info.llvmType->getElementType(i)` — only for Option fields. Covers inherited fields via `allFields` pre-flattening (parent fields at lower indices). Non-Option fields pass `nullptr` (correctly clears outer hint when emitting e.g. `Outer(Some(UserWithAvatar("carol", None())))` so nested `None()` inherits `UserWithAvatar.avatar`'s `str`, not `Outer.inner`'s `UserWithAvatar`).
 
-**Design invariant**: `option_decl_annotation_inner_` does NOT flow directly into argument positions. Argument-position hints always come from the callee's declared parameter types (lambda variable call), the record's declared field types (record constructor), or are absent (regular `fn` calls, which use `resolveOverload`'s `isNoneLiteral` short-circuit). This prevents LHS declaration annotations from contaminating arbitrary sub-expressions.
+**Design invariant**: `option_decl_annotation_inner_` does NOT flow directly into argument positions. Argument-position hints come from callee-declared param types (lambda call), record-declared field types (constructor), or are absent (regular `fn` calls use `resolveOverload`'s `isNoneLiteral` short-circuit). This prevents LHS declaration annotations from contaminating arbitrary sub-expressions.
 
-**Priority invariant**: `isNoneLiteral` short-circuit at the three annotation-aware `codegen_stmt.cpp` sites must remain the *first* check (runs before the hint seed). It handles the trivial `x: Option<int> = None()` case without touching hint state and is faster.
+**Priority invariant**: `isNoneLiteral` short-circuit at the three annotation-aware sites must remain the *first* check (before hint seed). It handles trivial `x: Option<int> = None()` without touching hint state.
 
-**ADR #1111 compliance**: The hint is threaded via CodeGen class state + RAII guards, not via `emitExpr` signature changes.
+**ADR #1111 compliance**: hint is threaded via CodeGen class state + RAII guards, not via `emitExpr` signature changes.
 
 ### `instantiateGenericEnum` omitted `variantOrder` population
 
-**Source**: #959 (2026-04-15, implementation)
+**Source**: #959 (2026-04-15)
 **Tags**: codegen, generic-enum, ADT, variantOrder, regression
 
-**Rule**: `instantiateGenericEnum` in `src/codegen_fn_generic.cpp` builds `EnumInfo` for
-concrete instantiations (e.g., `MyOpt<int>`). It populates `info.variants` (the
-`unordered_map<name → tag>`) but historically did NOT populate `info.variantOrder` (the
-ordered variant name vector). Any code that iterates `variantOrder` — such as the
-payload-aware ADT equality comparison introduced in #959 — will silently iterate zero
-elements, causing generic enum variants to fall through to the "no payload" fast path and
-produce wrong results (tag-only comparison).
+**Rule**: `instantiateGenericEnum` in `src/codegen_fn_generic.cpp` builds `EnumInfo` for concrete instantiations (e.g., `MyOpt<int>`). It populates `info.variants` (`unordered_map<name → tag>`) but historically did NOT populate `info.variantOrder` (the ordered name vector). Code that iterates `variantOrder` — such as the payload-aware ADT equality comparison from #959 — silently iterates zero elements, falling through to the "no payload" fast path with wrong results (tag-only comparison).
 
-**Why**: The non-generic path in `codegen_stmt_misc.cpp` populates `variantOrder` inside
-the same loop that adds entries to `variants`. The generic path duplicated most of the
-loop body but missed this line.
+**Why**: The non-generic path in `codegen_stmt_misc.cpp` populates `variantOrder` inside the same loop as `variants`. The generic path duplicated most of the loop body but missed this line.
 
-**How to apply**: Any new code that reads `EnumInfo::variantOrder` for logic that must also
-apply to generic enum instantiations must verify that `instantiateGenericEnum` keeps
-`variantOrder` in sync with `variants`. When adding `EnumInfo` fields in the future,
-update both `codegen_stmt_misc.cpp` and `codegen_fn_generic.cpp` together.
+**How to apply**: Any new code reading `EnumInfo::variantOrder` for logic that must apply to generic instantiations must verify `instantiateGenericEnum` keeps `variantOrder` in sync with `variants`. When adding `EnumInfo` fields, update both `codegen_stmt_misc.cpp` and `codegen_fn_generic.cpp` together.
 
 ### Resolving generic enum types as fn param/return/let requires a two-layer fix
 
-**Source**: #1203 (2026-04-19, implementation)
+**Source**: #1203 (2026-04-19)
 **Tags**: codegen, generic-enum, resolveType, type_param_scope_, ensureEnumInstantiated
 
-**Rule**: `CodeGen::resolveType` alone is not sufficient to handle generic enum types in
-type positions. Two independent mechanisms must be combined:
+**Rule**: `CodeGen::resolveType` alone is not sufficient for generic enum types in type positions. Two independent mechanisms must combine:
 
-1. **Substitute type-param names inside `<...>` at `resolveType` entry.** The old code only
-   did a bare-identifier lookup in `type_param_scope_`, so `resolveType("MyOpt<T>")` would
-   fall through to the `unknown type` branch when called during generic-fn instantiation
-   even though `T` was bound. The fix walks the type string recursively — bare name, `weak X`,
-   `X?`, and `Base<Args...>` — substituting any bare identifier that appears in
-   `type_param_scope_`, then re-calls `resolveType` with the rewritten name. See
-   `substituteTypeParamsInName` in `src/codegen_type.cpp`.
-2. **Call `ensureEnumInstantiated(typeName)` before the final `unknown type` error.** Even
-   a fully-qualified instance like `MyOpt<int>` in a non-generic fn signature does not hit
-   the instantiation path automatically — `resolveType` only queries `enum_types_` which is
-   populated on construction, not on type-position mention. Adding the
-   `ensureEnumInstantiated` fallback makes every type position uniform with expression
-   positions.
+1. **Substitute type-param names inside `<...>` at `resolveType` entry.** Old code did bare-identifier lookup in `type_param_scope_`, so `resolveType("MyOpt<T>")` fell through to `unknown type` during generic-fn instantiation even with `T` bound. Fix: walk the type string recursively — bare name, `weak X`, `X?`, `Base<Args...>` — substituting any bare identifier in `type_param_scope_`, then re-call `resolveType`. See `substituteTypeParamsInName` in `src/codegen_type.cpp`.
+2. **Call `ensureEnumInstantiated(typeName)` before the final `unknown type` error.** Even fully-qualified `MyOpt<int>` in a non-generic fn signature does not hit instantiation automatically — `resolveType` only queries `enum_types_`, populated on construction not on type-position mention. The `ensureEnumInstantiated` fallback makes type positions uniform with expression positions.
 
-**Why**: The two failure modes look similar (both say `unknown type: MyOpt<...>`) but have
-different root causes. Fixing only one leaves half the issue.
+The two failure modes look similar (both `unknown type: MyOpt<...>`) but have different root causes — fixing only one leaves half the issue.
 
-**How to apply**: When adding a new type-position site (e.g., new let-binding form, new
-field type, new generic argument shape), ensure both layers flow correctly. In
-`instantiateGenericFn`, surface-name strings used for pattern-matching metadata
-(`paramTypeNames`, `exposedReturnTypeName`) must also be passed through
-`substituteTypeParamsInName` — substituting only the `llvm::Type*` is insufficient because
-downstream code recovers the surface name from metadata to decide dispatch.
+**How to apply**: When adding a new type-position site, ensure both layers flow correctly. In `instantiateGenericFn`, surface-name strings used for pattern-matching metadata (`paramTypeNames`, `exposedReturnTypeName`) must also pass through `substituteTypeParamsInName` — substituting only `llvm::Type*` is insufficient because downstream code recovers surface name from metadata to decide dispatch.
 
 ### Lambda / function return paths need bidirectional `any ↔ narrow` coercion (#1062)
 
-**Source**: #1062 (2026-04-17, fixed in fix/1062-lambda-return-type-annot)
+**Source**: #1062 (2026-04-17)
 **Tags**: codegen, lambda, return-type-annotation, any-type, asymmetric-coercion, type-coercion
 
-**Context**: `reduce([1,2,3,4,5], (a, b) -> int => a + b)` produced:
-`lambda expression return type mismatch: expected 'int', found 'any'`. When lambda params
-are untyped they default to `any`, so `a + b` is evaluated via `emitAnyBinaryOp` and returns
-`any`. The `-> int` annotation resolves to `i64Ty_`. Only `any ← narrow` (via `wrapInAny`)
-was handled; `narrow ← any` (`unwrapFromAny`) was missing in both return codegen sites.
+**Rule**: `reduce([1,2,3,4,5], (a, b) -> int => a + b)` produced `lambda return type mismatch: expected 'int', found 'any'`. Untyped lambda params default to `any`, so `a + b` evaluates via `emitAnyBinaryOp` and returns `any`. The `-> int` annotation resolves to `i64Ty_`. Only `any ← narrow` (via `wrapInAny`) was handled; `narrow ← any` (`unwrapFromAny`) was missing in both return codegen sites.
 
-**Fix**: Added inverse coercion guard at two sites, symmetric with the existing `wrapInAny` branch:
+Fix: inverse coercion guard at two sites, symmetric with the existing `wrapInAny` branch:
 ```cpp
 // src/codegen_lambda.cpp (expression-body) and src/codegen_fn.cpp (block-body + regular fn return)
 else if (isAnyType(val->getType()) && !isAnyType(retTy) && canAnyHoldType(retTy))
     val = unwrapFromAny(val, retTy);
 ```
-`unwrapFromAny` emits a runtime tag check; type mismatches (e.g., float list with `-> int`)
-become runtime errors, not compile errors. `canAnyHoldType` limits the guard to primitives
-(`i64/f64/i1/ptr`); non-primitive return types (List, Result, Map) still produce a compile error.
+`unwrapFromAny` emits a runtime tag check; type mismatches (e.g., float list with `-> int`) become runtime errors. `canAnyHoldType` limits to primitives (`i64/f64/i1/ptr`); non-primitive return types still produce a compile error.
 
-**Rule**: Whenever you add a `wrapInAny` (narrow→any) branch at a return site, audit the
-same site for the inverse `unwrapFromAny` (any→narrow) case. Both directions are required.
-Omitting either direction causes asymmetric behavior between annotated and unannotated lambdas.
+Whenever you add a `wrapInAny` (narrow→any) at a return site, audit for the inverse `unwrapFromAny` (any→narrow). Both directions are required — omitting either causes asymmetric behavior between annotated and unannotated lambdas.
 
-**How to verify**: `tests/spec/collections.test.ry` — `reduce`/`fold` tests with `-> int`
-and `-> float` annotations on untyped params; block-body lambda variant via lambda variable.
+**How to verify**: `tests/spec/collections.test.ry` — `reduce`/`fold` with `-> int` and `-> float` annotations on untyped params; block-body lambda variant via lambda variable.
 
 ### `fold()` rejects untyped lambda with type-check error (#1061)
 
-**Source**: #1061 (2026-04-16, discovered during pre-verification for #1033; resolved in fix/1061-fold-untyped-lambda)
+**Source**: #1061 (2026-04-16)
 **Tags**: codegen, fold, untyped-lambda, type-check
 
-**Context**: `fold(xs, 0, (a, b) => a + b)` produced a compile error:
-`fold() initial value type must match function return type`. Unlike `reduce()` which was
-patched in #1020 to accept untyped lambdas, `fold()` was not given the same treatment.
-The type-check logic in `fold`'s emitter validates that the initial value type matches the
-lambda's return type; when both params are untyped the lambda returns `any`, while `0` is
-inferred as `int` — causing the mismatch.
+**Rule**: `fold(xs, 0, (a, b) => a + b)` produced `fold() initial value type must match function return type`. Unlike `reduce()` (patched in #1020), `fold()` was not given the same treatment. The type-check validates initial-value type against lambda return type; both untyped params → lambda returns `any`, while `0` is `int`.
 
-**Fix** (`src/codegen_call_higher_order.cpp:287-290`): Insert `wrapInAny(initVal)` coercion
-before the equality check, mirroring the reduce fix at L247-248:
+Fix (`src/codegen_call_higher_order.cpp:287-290`): insert `wrapInAny(initVal)` before the equality check, mirroring the reduce fix at L247-248:
 ```cpp
 if (isAnyType(info.returnType) && !isAnyType(initVal->getType()))
     initVal = wrapInAny(initVal);
 ```
-The equality check is preserved — it still rejects genuine typed-lambda mismatches such as
-`fold([1,2,3], "hi", (a: int, b: int) => a + b)`.
+The equality check still rejects genuine typed-lambda mismatches like `fold([1,2,3], "hi", (a: int, b: int) => a + b)`.
 
-**Rule**: When applying a fix for untyped-lambda compatibility to one higher-order function
-(e.g., `reduce`), audit all sibling functions with similar emitters (`fold`, `scan`, etc.)
-for the same gap. Do not assume a fix to one function automatically covers others.
+When applying an untyped-lambda compatibility fix to one higher-order function (e.g., `reduce`), audit all sibling functions with similar emitters (`fold`, `scan`, etc.) for the same gap. Do not assume a fix to one function automatically covers others.
 
-**How to verify**: `tests/spec/collections.test.ry` — untyped-lambda fold cases (int seed,
-float seed, string seed); `tests/test_codegen_fail.cpp::FoldTypedLambdaSeedTypeMismatch`
-verifies the preserved rejection branch.
+**How to verify**: `tests/spec/collections.test.ry` untyped-lambda fold cases (int seed, float seed, string seed); `tests/test_codegen_fail.cpp::FoldTypedLambdaSeedTypeMismatch` verifies the preserved rejection branch.
 
 ### Seed-less reductions over a possibly-empty list must return `Option<T>`, not panic (#1209)
 
 **Source**: #1209 (2026-04-20)
 **Tags**: codegen, reduce, fold, higher-order, option, empty-list, api-design
 
-**Context**: `reduce(list, fn)` (no seed) used to runtime-error on an empty list
-(`runtime error: reduce() on empty list`). Python/JS users also reached for a
-3-argument form `reduce(xs, init, fn)` and hit `reduce() takes exactly 2 arguments`
-with no pointer to `fold`. Both pain points share a root cause: `reduce` and `fold`
-are distinct functions with different safety profiles, but the API does not signal
-the distinction.
+**Rule**: Any reduction without a seed (`reduce`, `min`, `max`) must return `Option<T>` for empty inputs, **not** panic. Reductions with a seed (`fold`) are exempt — the seed makes the empty-list case naturally well-defined and a plain `T` return is correct. Model the Option path on `first`/`last` at `src/codegen_call.cpp:220-290`: empty-check → empty BB with `buildNoneValue` → ok BB with reduction loop + `buildSomeValue` → PHI at merge.
 
-**Rule**: Any reduction that does **not** take a seed (e.g., `reduce`, `min`, `max`)
-must return `Option<T>` for empty inputs, **not** panic. Reductions that take a
-seed (`fold`) are exempt — the seed makes the empty-list case naturally well-defined
-and a plain `T` return is the right choice. Model the Option path on
-`first`/`last` at `src/codegen_call.cpp:220-290`: empty-check → empty BB with
-`buildNoneValue` → ok BB with reduction loop + `buildSomeValue` → PHI at merge.
-
-**Rule**: When two near-identical builtins differ only in a parameter (e.g.,
-`reduce(list, fn)` vs `fold(list, init, fn)`), detect the Python/JS-style miscall
-`reduce(list, init, fn)` at the specific arg count and emit a targeted compile
-error that names the sibling. Ad-hoc hint strings in the dispatch branch are the
-existing precedent (see `src/codegen_call_user.cpp:17`); there is no "did you
-mean" infrastructure to reuse. Scope the hint to exactly the wrong count that
-maps onto the sibling — other wrong arities (0, 4+) should keep the generic
-message.
+**Rule**: When two near-identical builtins differ only in a parameter (e.g., `reduce(list, fn)` vs `fold(list, init, fn)`), detect the Python/JS-style miscall `reduce(list, init, fn)` at the specific arg count and emit a targeted compile error naming the sibling. Ad-hoc hint strings in dispatch are the existing precedent (`src/codegen_call_user.cpp:17`); there is no "did you mean" infrastructure to reuse. Scope the hint to exactly the wrong count that maps onto the sibling — other arities (0, 4+) keep the generic message.
 
 ### `CreateStore(narrowVal, anyTyAlloca)` leaves the `data` field uninitialized
 
-**Source**: #1020 (2026-04-16, bugfix — reduce with untyped lambda returns garbage)
+**Source**: #1020 (2026-04-16)
 **Tags**: codegen, any, alloca, store-width, reduce, fold
 
-**Context**: `anyTy_` is a 16-byte struct `{i64 tag, [8 x i8] data}`.
-Allocating an `any` slot then storing a raw `i64`/`f64`/`ptr` primitive into it writes only
-8 bytes — the store's width is the value's width, not the alloca's width. The tag (offset 0)
-ends up holding the raw value; the `data` field is stack garbage. Reloading as `anyTy_` then
-passing to `__ry_any_*` dispatch routes on the garbage tag → silent wrong answer.
+**Rule**: `anyTy_` is a 16-byte struct `{i64 tag, [8 x i8] data}`. Storing a raw `i64`/`f64`/`ptr` primitive into an `any` slot writes only 8 bytes — the store's width is the value's width, not the alloca's. The tag (offset 0) ends up holding the raw value; `data` is stack garbage. Reloading as `anyTy_` then dispatching to `__ry_any_*` routes on the garbage tag → silent wrong answer.
 
-The `reduce` emitter (`src/codegen_call_higher_order.cpp`) hit this when its lambda had untyped
-params (parser defaults them to `any`), making `info.returnType = anyTy_` while the first list
-element is still raw `elemTy`. Loop-body `elem` values went through `coerceCallArgs` →
-`wrapInAny` and were fine; only the accumulator **seed** skipped coercion.
+The `reduce` emitter hit this when its lambda had untyped params (parser defaults to `any`), making `info.returnType = anyTy_` while the first list element is still raw `elemTy`. Loop-body `elem` values went through `coerceCallArgs` → `wrapInAny` and were fine; only the **accumulator seed** skipped coercion.
 
-**Rule**: Before `CreateStore(v, accSlot)` where `accSlot` has type `anyTy_`, coerce `v` via
-`wrapInAny(v)` (or `coerceCallArgs`-style widening). Equivalently: never rely on a
-`CreateStore` whose source type is narrower than the alloca's allocated type. Grep for
-`CreateAlloca(info.returnType, ...)` / `CreateAlloca(anyTy_, ...)` followed by
-`CreateStore(...)` — each such pair must guarantee the stored value matches the alloca's full
-type.
+Before `CreateStore(v, accSlot)` where `accSlot` has type `anyTy_`, coerce `v` via `wrapInAny(v)` (or `coerceCallArgs`-style widening). Equivalently: never rely on `CreateStore` whose source type is narrower than the alloca's allocated type. Grep `CreateAlloca(info.returnType, ...)` / `CreateAlloca(anyTy_, ...)` followed by `CreateStore(...)` — each pair must guarantee the stored value matches the alloca's full type.
 
-**How to verify**: `tests/spec/collections.test.ry` has untyped-lambda cases for `reduce` on
-int list (sum), 2/3-elem lists, and float list. These cases provide functional regression
-coverage. For uninitialized-read detection specifically, use MemorySanitizer (MSan) rather
-than ASan — ASan detects memory-access errors (buffer overflows, use-after-free) but does
-not detect uninit reads.
+**How to verify**: `tests/spec/collections.test.ry` has untyped-lambda cases for `reduce` on int list (sum), 2/3-elem lists, and float list. For uninitialized-read detection specifically, use MemorySanitizer (MSan) — ASan detects memory-access errors but not uninit reads.
 
 ### `@native` dispatch must run exact-match Pass 1 before widening Pass 2
 
-**Source**: #1193 (2026-04-19, `@native` int→float widening fix)
+**Source**: #1193 (2026-04-19)
 **Tags**: codegen, stdlib, overload, widening, coercion, native-dispatch, resolveOverload
 
-**Context**: User-defined Ry functions accept implicit `int → float` widening
-via `CodeGen::resolveOverload` (`src/codegen_call_user.cpp`). Before #1193,
-`@native` dispatch used strict `args[i]->getType() != expectedTy` — so
-`sqrt(4)` errored even though `takesFloat(4)` worked. All three `@native`
-dispatch sites in `src/codegen_call_native.cpp` — `emitTableDrivenNativeCall`
-fixed-arity path, `emitTableDrivenNativeCall` variadic path, and
-`emitGenericNativeCall` — now run a **two-pass** resolution:
+**Rule**: User-defined Ry functions accept implicit `int → float` widening via `CodeGen::resolveOverload`. Pre-#1193, `@native` dispatch used strict `args[i]->getType() != expectedTy` — so `sqrt(4)` errored even though `takesFloat(4)` worked. All three `@native` dispatch sites in `src/codegen_call_native.cpp` (`emitTableDrivenNativeCall` fixed-arity + variadic, `emitGenericNativeCall`) now run two-pass:
 
 1. Pass 1: exact type match (unchanged behavior).
-2. Pass 2 (only if Pass 1 is empty): accept args via
-   `isWideningConversion` / `emitWideningConversion` (`src/codegen.cpp:761-789`).
+2. Pass 2 (only if Pass 1 is empty): accept args via `isWideningConversion` / `emitWideningConversion` (`src/codegen.cpp:761-789`).
 
-**Rule**: Any new `@native` dispatch path — or any edit to the three existing
-ones — must keep the two passes in this exact order. Exact matches must win
-across the entire overload set before any widening is considered, so that
-`pow(2, 3)` continues to dispatch to the `(int, int) -> int` overload rather
-than silently promoting to `(float, float) -> float`. Reuse the public
-helpers `CodeGen::isWideningConversion` and `CodeGen::emitWideningConversion`;
-do not re-implement `SIToFP` inline.
+Any new `@native` dispatch path — or any edit to the three existing ones — must keep the two passes in this exact order. Exact matches must win across the entire overload set before any widening, so `pow(2, 3)` continues to dispatch to `(int, int) -> int` rather than silently promoting to `(float, float) -> float`. Reuse `CodeGen::isWideningConversion` / `CodeGen::emitWideningConversion`; do not re-implement `SIToFP` inline.
 
-**Why**: Collapsing the passes into a single scored loop (like
-`resolveOverload` does) is tempting but changes precedence semantics when an
-exact match and a widening-eligible match both exist; the two-pass split
-makes the invariant explicit and localises the change.
+**Rejected alternative**: collapsing the passes into a single scored loop (like `resolveOverload`) changes precedence semantics when an exact match and a widening-eligible match coexist; the two-pass split makes the invariant explicit and localises the change.
 
-**How to apply**: For each overload candidate, track a
-`std::vector<bool> needsWidening` alongside the existing `paramLLVMTypes`
-vector. Before emitting `CreateCall`, loop over the matched args and call
-`emitWideningConversion` wherever `needsWidening[i]` is true. The error path
-for "no matching overload" is unchanged — falling through Pass 1 and Pass 2
-both lands in the original `"argument N requires <type>"` message.
+**How to apply**: For each candidate, track `std::vector<bool> needsWidening` alongside `paramLLVMTypes`. Before `CreateCall`, loop over matched args and call `emitWideningConversion` where `needsWidening[i]` is true. The "no matching overload" error path is unchanged — falling through both passes lands in the original `"argument N requires <type>"` message.
 
-Custom emitters must replicate this pattern locally: immediately after
-`emitExpr` of each arg, call `isWideningConversion` + `emitWideningConversion`
-before the hardcoded `x->getType() != cg.f64Ty_` guard. For emitters that
-already have two exact-type branches (`emitMathPow`'s `(f64, f64)` and
-`(i64, i64)`), append the widening branch *after* both exact branches so the
-precedence invariant (`pow(2, 3) → int 8`) is preserved by branch ordering.
-See `emitMathFloorCeilRound` / `emitMathLog` / `emitMathPow` in
-`src/codegen_call.cpp` for the canonical examples.
+Custom emitters must replicate locally: immediately after `emitExpr` of each arg, call `isWideningConversion` + `emitWideningConversion` before the hardcoded `x->getType() != cg.f64Ty_` guard. For emitters with two exact-type branches (`emitMathPow`'s `(f64, f64)` and `(i64, i64)`), append the widening branch *after* both exact branches so `pow(2, 3) → int 8` is preserved. See `emitMathFloorCeilRound` / `emitMathLog` / `emitMathPow` in `src/codegen_call.cpp`.
 
-**Resolved follow-up**: Math custom emitters (`emitMathFloorCeilRound`,
-`emitMathLog`, `emitMathPow` mixed-type) now also accept widened `int` args
-via the local pattern above (#1230, 2026-04-21). `emitMathAbs` was already
-correct because both `abs(int)` and `abs(float)` overloads are declared in
-`share/std/math/math.ry` and the emitter exact-matches on both LLVM types.
+**Resolved follow-up**: Math custom emitters (`emitMathFloorCeilRound`, `emitMathLog`, `emitMathPow` mixed-type) accept widened `int` args via the local pattern (#1230, 2026-04-21). `emitMathAbs` was already correct — both `abs(int)` and `abs(float)` overloads are declared in `share/std/math/math.ry` and the emitter exact-matches on both LLVM types.
 
 ### IndexExpr first index is scalar only — RangeExpr routes to emitListSlice
 
-**Source**: #1184 (2026-04-19, fix)
+**Source**: #1184 (2026-04-19)
 **Tags**: codegen, IndexExpr, RangeExpr, slice, index-type-guard, emitExprVariant, emitListSlice
 
-**Rule**: `emitExprVariant(IndexExpr)` (`src/codegen_expr_literal.cpp`) has always assumed that `emitExpr(*e->indices[0])` produces an i64 (or map key type). `lst[a..b]` is parsed as `IndexExpr{ object: lst, indices: [RangeExpr{a,b}] }` (via `parseConditional` → `parseRange` in `src/parser_expr.cpp`), which means without a type-guard the `RangeExpr` emitter (`src/codegen_expr_cast.cpp`) materialises an ARC-allocated `List<i64>` header (`ptr`). That `ptr` then flows into `emitBoundsCheck` / GEP, producing `ICmp ptr vs i64` type-mismatch errors in the IR verifier.
+**Rule**: `emitExprVariant(IndexExpr)` (`src/codegen_expr_literal.cpp`) assumes `emitExpr(*e->indices[0])` produces an i64 (or map key type). `lst[a..b]` parses as `IndexExpr{ object: lst, indices: [RangeExpr{a,b}] }` (via `parseConditional` → `parseRange`) — without a type-guard the `RangeExpr` emitter materialises an ARC-allocated `List<i64>` header (`ptr`), which flows into `emitBoundsCheck` / GEP, producing `ICmp ptr vs i64` IR verifier errors.
 
-**Fix (since #1184)**: Before the `indexValues` emit loop, check:
+Fix: before `indexValues` emit loop, check:
 ```cpp
 if (e->indices.size() == 1 &&
     std::holds_alternative<std::unique_ptr<RangeExpr>>(e->indices[0]->data)) {
@@ -347,129 +218,92 @@ if (e->indices.size() == 1 &&
     // emitNegativeIndexWrap each bound; endExcl = end + 1; emitListSlice(...)
 }
 ```
-This avoids materialising the intermediate `List<i64>` entirely.
 
 **Semantics**:
 - `lst[a..b]` is **inclusive** on both ends (matches `..` operator semantics per `docs/reference/operators.md`)
-- Negative bounds are **wrapped** against list length (matches `lst[-1]` behaviour via `emitNegativeIndexWrap`)
-- Out-of-bounds bounds are **clamped** (matches `slice()` behaviour)
-- Equivalent to `slice(lst, a, b + 1)` — the `+ 1` conversion from inclusive to exclusive is done at the call site, not inside `emitListSlice`
+- Negative bounds **wrapped** against list length (matches `lst[-1]` behaviour via `emitNegativeIndexWrap`)
+- Out-of-bounds bounds **clamped** (matches `slice()` behaviour)
+- Equivalent to `slice(lst, a, b + 1)` — the inclusive→exclusive `+ 1` is at the call site, not inside `emitListSlice`
 - Non-list receivers (`str`, maps, fixed-length arrays) emit `codegenError` in the new guard
 
 **Related helpers**:
 - `emitListSlice(listPtr, startVal, endExclVal, elemTy)` (`src/codegen_call_collection.cpp`) — shared between `slice()` builtin and `lst[a..b]`. Clamps internally.
-- `emitNegativeIndexWrap(idx, len, prefix)` (`src/codegen_call_user.cpp:645`) — use prefix `"ri_start"` / `"ri_end"` to avoid label collision with scalar-index prefix `"index"`.
-- **#1198**: `emitCollOp_slice` was missing the pre-wrap step required by this contract (negatives were passed raw to `emitListSlice`, which clamps to `[0, len]` → `-3` collapsed to `0`). Fixed by applying `emitNegativeIndexWrap(start, len, "sl_start")` / `emitNegativeIndexWrap(end, len, "sl_end")` before the `emitListSlice` call, mirroring the range-index route. The `emitListSlice` invariant ("caller pre-wraps, I clamp") now applies to both call sites.
-- **#1199**: `emitStrOp_substring` had the same 0-clamp bug on strings. Fixed by mirroring the slice pattern, with one extra step: `wrapBase` must be the UTF-8 codepoint count via `__ry_utf8_len_n(s, byteLen)`, not `emitStringByteLen(s)` (`"あいうえお"` is 5 chars / 15 bytes — using byte length wraps against the wrong base). See the sibling entry "String negative-index wrap uses UTF-8 char count, not byte length" below.
+- `emitNegativeIndexWrap(idx, len, prefix)` (`src/codegen_call_user.cpp:645`) — use prefix `"ri_start"` / `"ri_end"` to avoid label collision with scalar `"index"`.
+- **#1198**: `emitCollOp_slice` was missing pre-wrap (negatives passed raw to `emitListSlice`, which clamps to `[0, len]` → `-3` collapsed to `0`). Fixed by `emitNegativeIndexWrap(start, len, "sl_start")` / `emitNegativeIndexWrap(end, len, "sl_end")` before the call. Invariant: caller pre-wraps, callee clamps.
+- **#1199**: `emitStrOp_substring` had the same 0-clamp bug on strings. Fixed by mirroring slice, with one extra: `wrapBase` must be UTF-8 codepoint count via `__ry_utf8_len_n(s, byteLen)`, not `emitStringByteLen(s)` (`"あいうえお"` is 5 chars / 15 bytes — byte length wraps wrong). See "String negative-index wrap uses UTF-8 char count, not byte length" entry below.
 
 ### Self-referential enum inline fields emit a wrapper-type diagnostic
 
-**Source**: #1203 (2026-04-19, implementation)
+**Source**: #1203 (2026-04-19)
 **Tags**: codegen, enum, self-reference, diagnostic, user-experience
 
-**Rule**: In `emitStmt(EnumStmt &s)` (`src/codegen_stmt_misc.cpp`), a pre-pass walks each
-variant field's `TypeNode` AST recursively via the file-local helper
-`containsInlineSelfReference`. It reports a self-reference when the enum's own name appears
-in any of: a bare identifier (`Tree`), a generic application's base (`LList<T>`), the inner
-of an optional (`Tree?`), a tuple element (`(int, Tree)`), an array element, a union
-component, or inside an arbitrary non-indirection generic (`Option<Tree>`,
-`Pair<Tree, Tree>`). The helper treats `List<_>`, `Map<_, _>`, `Set<_>`, `Task<_>`,
-`Channel<_>`, `weak T`, and `fn(...)` as pointer-backed indirection and stops
-descending — their payload is boxed, so the layout is finite. The recommendation message
-points users to container indirections: `List<T>`, `Map<K, V>`, `Set<T>`, `Task<T>`, and
-`Channel<T>` (#1351). It intentionally excludes `weak T` (weak requires an ARC-managed
-payload, and a separate diagnostic already rejects `weak <ADT>`) and `fn(...)` (unusual
-choice for data storage).
+**Rule**: In `emitStmt(EnumStmt &s)` (`src/codegen_stmt_misc.cpp`), a pre-pass walks each variant field's `TypeNode` AST recursively via the file-local helper `containsInlineSelfReference`. Reports self-reference when the enum's own name appears in any of: bare identifier (`Tree`), generic application's base (`LList<T>`), inner of optional (`Tree?`), tuple element (`(int, Tree)`), array element, union component, arbitrary non-indirection generic (`Option<Tree>`, `Pair<Tree, Tree>`). The helper treats `List<_>`, `Map<_, _>`, `Set<_>`, `Task<_>`, `Channel<_>`, `weak T`, `fn(...)` as pointer-backed indirection and stops descending — payload is boxed, layout is finite. Recommendation message points to container indirections: `List<T>`, `Map<K, V>`, `Set<T>`, `Task<T>`, `Channel<T>` (#1351). Excludes `weak T` (requires ARC-managed payload; separate diagnostic rejects `weak <ADT>`) and `fn(...)` (unusual data storage choice).
 
-**Why**: An earlier substring-based check on the field's `toString()` only caught the bare
-name and the generic base (`ftStr.substr(0, ftStr.find('<'))`). That missed `Tree?`,
-`(int, Tree)`, and `Option<Tree>`, all of which then produced the cryptic
-`unknown type: Tree` at field-type resolution time instead of the helpful diagnostic.
-Switching to an AST walk fixes every wrapping shape uniformly and runs before the
-generic-template save so `generic_enum_templates_` never stores a self-referential
-template that would crash at instantiation time with `unknown type: T`. Full
-recursive-enum support (auto-boxing) is a separate feature tracked as a follow-up issue.
+**Why**: An earlier substring check on the field's `toString()` only caught the bare name and generic base (`ftStr.substr(0, ftStr.find('<'))`), missing `Tree?`, `(int, Tree)`, `Option<Tree>` — these produced cryptic `unknown type: Tree` at field-type resolution instead of the helpful diagnostic. The AST walk fixes every wrapping shape uniformly and runs before generic-template save so `generic_enum_templates_` never stores a self-referential template that would crash at instantiation with `unknown type: T`. Full recursive-enum support (auto-boxing) is a separate follow-up.
 
-**How to apply**: When adding a new indirection wrapper (e.g. `Rc<T>`, `Box<T>`) that
-stores its payload behind a pointer, extend the indirection list in
-`containsInlineSelfReference` *and* add it to the recommendation string. When adding a new
-non-indirection wrapper (e.g. an inline SoA generic) nothing needs to change — the default
-branch already traverses generic type-args. When considering supporting inline
-self-reference in enums, this pre-pass must be removed (or relaxed to only reject when
-auto-boxing cannot recover).
+**How to apply**: When adding a new indirection wrapper (e.g. `Rc<T>`, `Box<T>`) that stores payload behind a pointer, extend the indirection list in `containsInlineSelfReference` *and* the recommendation string. New non-indirection wrapper: nothing needs to change — default branch traverses generic type-args. Supporting inline self-reference would require removing or relaxing this pre-pass.
 
 ### Bare generic-enum name in type positions produces a dedicated diagnostic
 
-**Source**: #1203 (2026-04-19, implementation)
+**Source**: #1203 (2026-04-19)
 **Tags**: codegen, generic-enum, resolveType, diagnostic, user-experience
 
 **Rule**: `CodeGen::resolveType` distinguishes three failure modes for generic enums:
 
-1. `MyOpt` (bare template name, no `<...>`) → `generic enum 'MyOpt' used without type
-   arguments; write MyOpt<T>...` (echoes the template's actual first type-parameter name,
-   not a hardcoded `T`).
-2. `MyOpt<int>` (concrete) → on-demand `ensureEnumInstantiated` before the final `unknown
-   type` error, so the enum is instantiated lazily at any type position.
-3. `MyOpt<T>` with `T` bound in `type_param_scope_` → `substituteTypeParamsInName` rewrites
-   to `MyOpt<int>`, then the case above kicks in.
+1. `MyOpt` (bare template, no `<...>`) → `generic enum 'MyOpt' used without type arguments; write MyOpt<T>...` (echoes the template's actual first type-parameter name, not hardcoded `T`).
+2. `MyOpt<int>` (concrete) → on-demand `ensureEnumInstantiated` before the final `unknown type` error, so the enum is instantiated lazily at any type position.
+3. `MyOpt<T>` with `T` bound in `type_param_scope_` → `substituteTypeParamsInName` rewrites to `MyOpt<int>`, then case 2 kicks in.
 
-**Why**: The user-facing regression in #1203 was that `fn f(opt: MyOpt, ...)` and
-`fn f<T>(opt: MyOpt<T>, ...)` both produced `unknown type: ...` with no hint. Case 1
-now guides the user to the correct syntax; cases 2 and 3 compile silently.
+Pre-#1203 both `fn f(opt: MyOpt, ...)` and `fn f<T>(opt: MyOpt<T>, ...)` produced `unknown type: ...` with no hint. Case 1 now guides the user; cases 2 and 3 compile silently.
 
-**How to apply**: When adding a new generic-template registry (alongside
-`generic_enum_templates_`), mirror the bare-name check in `resolveType` so the user sees a
-template-name-specific error message instead of falling through to the generic `unknown
-type: <name>` branch. The first type-parameter name is read from the template record — do
-not hardcode `T`.
+**How to apply**: When adding a new generic-template registry (alongside `generic_enum_templates_`), mirror the bare-name check in `resolveType` so users see a template-name-specific error instead of falling through to generic `unknown type: <name>`. The first type-parameter name is read from the template record — do not hardcode `T`.
 
 ### Lambda return-type inference must consult `@native` signatures, not just user-function overloads
 
-**Source**: #1318 (2026-04-23, implementation). **Tags**: codegen, lambda, type-inference, native, stdlib, resource, JsonValue
+**Source**: #1318 (2026-04-23)
+**Tags**: codegen, lambda, type-inference, native, stdlib, resource, JsonValue
 
-**Rule**: `inferExprType()` / `inferExprTypeName()` for `CallExpr` must check the `@native` signature registry (`native_fn_sigs_` + `native_lib_index_`) when `findFunction()` misses. Many stdlib calls such as `lockNew()` and `json.parse()` are registered only as `@native` signatures, so falling straight to the scalar fallback (`i64Ty_` / `"int"`) makes lambda return-type checking report nonsense like `expected 'int'` for `fn() -> Lock` or `fn() -> Result<JsonValue, Error>`.
+**Rule**: `inferExprType()` / `inferExprTypeName()` for `CallExpr` must check the `@native` signature registry (`native_fn_sigs_` + `native_lib_index_`) when `findFunction()` misses. Many stdlib calls (`lockNew()`, `json.parse()`) are registered only as `@native` signatures, so falling straight to scalar fallback (`i64Ty_` / `"int"`) makes lambda return-type checking report nonsense like `expected 'int'` for `fn() -> Lock` or `fn() -> Result<JsonValue, Error>`.
 
-**How to apply**: Keep the lambda inference path in sync with native-call dispatch: match `@native` overloads by arity and inferred argument types, allow the same implicit widening tier as normal call resolution, and return the matched signature's declared Ry return type name. Without the name-level lookup, metadata-gated returns (`Result<JsonValue, Error>`, resource handles, function-typed returns) may still compile to the right LLVM type later but fail or lose metadata during lambda pre-checking.
-
----
+**How to apply**: Keep lambda inference in sync with native-call dispatch — match `@native` overloads by arity and inferred argument types, allow the same implicit widening tier as normal call resolution, and return the matched signature's declared Ry return type name. Without name-level lookup, metadata-gated returns (`Result<JsonValue, Error>`, resource handles, function-typed returns) may compile to the right LLVM type later but fail or lose metadata during lambda pre-checking.
 
 ### `inferNativeCallReturnTypeName` must narrow overloads by source-level type name, not LLVM type
 
-**Source**: #1349 (2026-04-24, implementation). **Tags**: codegen, lambda, type-inference, native, overload, ptr-collapse, captured-vars
+**Source**: #1349 (2026-04-24)
+**Tags**: codegen, lambda, type-inference, native, overload, ptr-collapse, captured-vars
 
-**Rule**: When narrowing `@native` overloads inside lambda return-type inference, compare `sig.params[i].typeName` against `inferExprTypeName(arg)` (source-level Ry names), not `argTypes[i] == resolveType(sig.params[i].typeName)` (LLVM types). Ptr-backed types (`str`, `List`, `Map`, `Set`) all resolve to the same `ptr` under opaque pointers, so every overload appears to match and the ambiguity guard fires. The companion bug is that captured variables in lambda / nested-fn bodies also need their source-level collection metadata (`list_elem_type_name` / `map_key_type_name` / `set_elem_type_name` / `union_value_type` / `enum_value_type`) propagated from the outer alloca — only `fn_type_info` was being forwarded, so dispatch inside the body misrouted `length(xs)` to the str runtime even after the type-inference fix landed.
+**Rule**: When narrowing `@native` overloads inside lambda return-type inference, compare `sig.params[i].typeName` against `inferExprTypeName(arg)` (source-level Ry names), not `argTypes[i] == resolveType(sig.params[i].typeName)` (LLVM types). Ptr-backed types (`str`, `List`, `Map`, `Set`) all resolve to the same `ptr` under opaque pointers, so every overload appears to match and the ambiguity guard fires. Companion bug: captured variables in lambda / nested-fn bodies need source-level collection metadata (`list_elem_type_name` / `map_key_type_name` / `set_elem_type_name` / `union_value_type` / `enum_value_type`) propagated from the outer alloca — only `fn_type_info` was being forwarded, so dispatch inside the body misrouted `length(xs)` to the str runtime even after the type-inference fix landed.
 
-**How to apply**: In `inferNativeCallReturnTypeName` (`src/codegen_lambda.cpp`), build `argTypeNames` via `inferExprTypeName()` alongside `argTypes`, match by `resolveTypeAlias(argTypeNames[i]) == resolveTypeAlias(sig.params[i].typeName)` first, and fall back to the LLVM-type equality path only when the source-level name is empty. Keep `isInferenceWidening` — its `isLowLevelTypeName` gate means it won't misfire on ptr-backed types. Thread a `paramTypeNameMap` default parameter so `inferExprTypeName::CallExpr` can forward the outer name map into the check. For captured variables, save the outer `llvm::AllocaInst*` in `CaptureAnalysisResult::capturedSrcAllocas` during `analyzeFreeVariables`, and in both lambda (`emitExprVariant<LambdaExpr>`) and nested-fn (`emitStmt<FnStmt>`) captured-param setup call `propagateMeta(srcAlloca, newAlloca)` after `CreateStore` — this copies the full metadata packet (collection types, type-name strings, `fn_type_info`, resource kinds, ARC-managed flag) in one shot.
-
----
+**How to apply**: In `inferNativeCallReturnTypeName` (`src/codegen_lambda.cpp`), build `argTypeNames` via `inferExprTypeName()` alongside `argTypes`, match by `resolveTypeAlias(argTypeNames[i]) == resolveTypeAlias(sig.params[i].typeName)` first, fall back to LLVM-type equality only when source-level name is empty. Keep `isInferenceWidening` — its `isLowLevelTypeName` gate prevents misfire on ptr-backed types. Thread a `paramTypeNameMap` default parameter so `inferExprTypeName::CallExpr` can forward the outer name map. For captured variables: save outer `llvm::AllocaInst*` in `CaptureAnalysisResult::capturedSrcAllocas` during `analyzeFreeVariables`, and in both `emitExprVariant<LambdaExpr>` and `emitStmt<FnStmt>` captured-param setup call `propagateMeta(srcAlloca, newAlloca)` after `CreateStore` — this copies the full metadata packet (collection types, type-name strings, `fn_type_info`, resource kinds, ARC-managed flag) in one shot.
 
 ### Higher-order Result/lambda boundaries must rehydrate ptr-backed metadata from type names or wrappers
 
-**Source**: #1319 (2026-04-23, implementation). **Tags**: codegen, metadata, lambda, Result, JsonValue, resource, higher-order
+**Source**: #1319 (2026-04-23)
+**Tags**: codegen, metadata, lambda, Result, JsonValue, resource, higher-order
 
 **Rule**: Any higher-order boundary that unwraps a `Result<T, E>` / `Option<T>` payload or calls an indirect lambda must restore metadata for pointer-backed named types. `CreateExtractValue` drops the payload's `ValueMetadata`, and indirect calls return a fresh SSA value with no metadata unless `FnTypeInfo.returnTypeName` is re-applied.
 
-**How to apply**: Mirror the `?` operator path in combinators: after extracting `ok_val` / `some_val`, call `propagateMeta(wrapper, payload)` before passing the value into the callback. In `emitLambdaCall`, always stamp the call result from `FnTypeInfo.returnTypeName` (and `returnFnTypeInfo` for function-typed returns). For lambda return-name inference on `VariableExpr`, prefer `buildTypeNameFromMeta()` over raw `reverseResolveTypeName()` so resource / `JsonValue` names survive opaque-pointer lowering.
-
----
+**How to apply**: Mirror the `?` operator path in combinators: after extracting `ok_val` / `some_val`, call `propagateMeta(wrapper, payload)` before passing into the callback. In `emitLambdaCall`, always stamp the call result from `FnTypeInfo.returnTypeName` (and `returnFnTypeInfo` for function-typed returns). For lambda return-name inference on `VariableExpr`, prefer `buildTypeNameFromMeta()` over raw `reverseResolveTypeName()` so resource / `JsonValue` names survive opaque-pointer lowering.
 
 ### `@native` first-class materialization: synthesize a thunk that re-enters the call dispatcher
 
-**Source**: #1569 (2026-05-04, implementation). **Tags**: codegen, native, first-class, thunk, FnScope, multi-overload, default-args
+**Source**: #1569 (2026-05-04)
+**Tags**: codegen, native, first-class, thunk, FnScope, multi-overload, default-args
 
-**Rule**: To make a `@native` stdlib function usable as a first-class value (`let f = toInt`, `xs.map(toInt)`), `emitExprVariant<VariableExpr>` must — *immediately after the user-fn lookup branch and before the `undefined variable` error* — call `materializeNativeThunk(name)`. The helper (a) collects candidate `NativeFnSignature` entries from `native_fn_sigs_` matching either the bare name or any `<package>::name` suffix; (b) rejects multi-overload names with `ambiguous reference to @native function 'X': multiple overloads exist; wrap in a lambda to select one`; (c) emits an internal LLVM Function `__ry_native_thunk_<name>` whose body is a synthetic `CallExpr{callee=name, args=VariableExpr{p.name}}` routed back through `emitExpr` so the existing native dispatch chain (Pattern A/B/generic + `@native("libname")` dlopen) is reused without duplication; (d) caches the thunk by name so repeated references share one Function and recursive references resolve mid-emission.
+**Rule**: To make `@native` stdlib functions usable as first-class values (`let f = toInt`, `xs.map(toInt)`), `emitExprVariant<VariableExpr>` must — *immediately after the user-fn lookup branch and before the `undefined variable` error* — call `materializeNativeThunk(name)`. The helper:
+- (a) collects candidate `NativeFnSignature` entries from `native_fn_sigs_` matching the bare name or any `<package>::name` suffix
+- (b) rejects multi-overload names with `ambiguous reference to @native function 'X': multiple overloads exist; wrap in a lambda to select one`
+- (c) emits an internal LLVM Function `__ry_native_thunk_<name>` whose body is a synthetic `CallExpr{callee=name, args=VariableExpr{p.name}}` routed back through `emitExpr` so existing native dispatch (Pattern A/B/generic + `@native("libname")` dlopen) is reused without duplication
+- (d) caches the thunk by name so repeated references share one Function and recursive references resolve mid-emission
 
 **How to apply**:
-- **`FnScope` is mandatory** around the body emission. The thunk is synthesized lazily from inside the caller's IR builder cursor; without `FnScope`, the synthetic CallExpr's IR would land in the caller's BB and corrupt the surrounding instruction stream. `FnScope` saves/clears/restores `fn_`, `current_function_`, and `IRBuilder` state, then `pushScope()` opens a fresh symbol table for the parameter allocas.
-- **Cache before body emission** (`native_thunk_cache_[name] = thunk;` *before* the synthetic CallExpr is emitted) so any self-referential resolution during synthesis returns the same Function instead of recursing infinitely.
-- **Set `FnTypeInfo` metadata via `getOrCreateMeta(thunk).fn_type_info = info;`** with `info.paramTypeNames` populated from `sig.params[i].typeName` — `lookupFnTypeInfo()` and `emitLambdaCall()` consult these source-level names for higher-order dispatch and Result/JsonValue metadata rehydration. If `resolveTypeAlias(sig.returnTypeName)` is itself a function type, populate `info.returnFnTypeInfo` via `parseFnTypeAnnotation`.
-- **Default arguments materialize at full arity.** The thunk's LLVM signature mirrors `sig.params` 1:1; the default-omission shortcut only works on the original direct `CallExpr` path. Document this in user-facing docs to avoid surprise.
-- **Resolution order matters.** The new path activates only when the user-fn lookup misses, so user-defined `fn` declarations continue to shadow `@native` imports of the same name without behavior change.
+- **`FnScope` is mandatory** around body emission. The thunk is synthesized lazily from inside the caller's IR builder cursor; without `FnScope`, the synthetic CallExpr's IR lands in the caller's BB and corrupts the surrounding instruction stream. `FnScope` saves/clears/restores `fn_`, `current_function_`, and `IRBuilder` state, then `pushScope()` opens a fresh symbol table.
+- **Cache before body emission** (`native_thunk_cache_[name] = thunk;` *before* the synthetic CallExpr) so any self-referential resolution returns the same Function instead of recursing infinitely.
+- **Set `FnTypeInfo` metadata via `getOrCreateMeta(thunk).fn_type_info = info;`** with `info.paramTypeNames` from `sig.params[i].typeName` — `lookupFnTypeInfo()` and `emitLambdaCall()` consult these source-level names for higher-order dispatch and Result/JsonValue metadata rehydration. If `resolveTypeAlias(sig.returnTypeName)` is itself a function type, populate `info.returnFnTypeInfo` via `parseFnTypeAnnotation`.
+- **Default arguments materialize at full arity.** The thunk's LLVM signature mirrors `sig.params` 1:1; the default-omission shortcut only works on the original direct `CallExpr` path. Document in user-facing docs.
+- **Resolution order matters.** The new path activates only when user-fn lookup misses, so user-defined `fn` declarations continue to shadow `@native` imports of the same name without behavior change.
 
 **Why this design**:
-- Routing through `emitExpr(CallExpr)` rather than re-implementing the dispatch logic means both bare `@native` and `@native("libname")` work identically — the synthetic call hits the same Pattern A/B/generic chain that handles direct calls. No special-casing for dlopen wiring is needed.
-- Multi-overload reject mirrors user-fn behavior at `codegen_expr.cpp:194` (the existing "ambiguous reference" branch for overloaded user functions); using the same error class keeps the diagnostic surface consistent.
+- Routing through `emitExpr(CallExpr)` rather than re-implementing dispatch means both bare `@native` and `@native("libname")` work identically — the synthetic call hits the same Pattern A/B/generic chain that handles direct calls. No special-casing for dlopen wiring is needed.
+- Multi-overload reject mirrors user-fn behavior at `codegen_expr.cpp:194` (the existing "ambiguous reference" branch); same error class keeps the diagnostic surface consistent.
 - Custom-emitter natives (`math.abs`, `math.pow`, `math.round`, `math.log`, etc.) are all multi-overload by construction, so the single-overload rule transparently rejects them as first-class values without an extra "custom emitter" carve-out. Users who need first-class versions wrap them in a lambda (`f = (x) => abs(x)`).
-
----
-

--- a/.claude/rules/codegen-stdlib-dispatcher.md
+++ b/.claude/rules/codegen-stdlib-dispatcher.md
@@ -12,425 +12,160 @@ paths:
 
 ### One dispatch-table entry per fn name handles multiple overloaded arities
 
-**Source**: #842 (2026-04-11, math overloads implementation)
+**Source**: #842
 **Tags**: codegen, stdlib, dispatch-table, custom-emitter, overload
 
-**Context**: The stdlib dispatch tables (`math_table`, `string_table`,
-etc.) in `src/codegen_call*.cpp` are keyed by function name, and
-`emitTableDrivenNativeCall` (`src/codegen_call_native.cpp:21-28`) does a
-first-match-wins linear scan — so adding a second entry for the same
-name is a dead entry. For overloaded functions like `math.round` (1-arg
-→ int, 2-arg → float) or `math.pow` (`(float, float)` vs `(int, int)`),
-you must use a **single entry whose `customEmitter` handles every
-arity / type combination internally**.
+**Rule**: Stdlib dispatch tables (`math_table`, `string_table`, etc.) are scanned first-match-wins by `emitTableDrivenNativeCall` (`src/codegen_call_native.cpp:21-28`); a second entry for the same name is dead. For overloaded fns (`math.round` 1-arg→int / 2-arg→float; `math.pow` (float,float) vs (int,int)) use a **single entry whose `customEmitter` handles every arity / type combination internally**.
 
-The custom-emitter gate at `codegen_call_native.cpp:135-149` dispatches
-based on the CALL's actual argument count against all registered
-`@native` sigs — not against the table entry's `arity` field. That
-means: once the new overload is declared as `@native` in
-`share/std/<mod>/<mod>.ry`, the custom emitter just checks
-`e.args.size()` (and argument LLVM types) and routes accordingly. The
-table-entry `arity` is effectively metadata / legacy hint for custom
-emitters; only the pure-table path (nullptr `customEmitter`) reads it.
+**Why**: The custom-emitter gate (`codegen_call_native.cpp:135-149`) dispatches on the call's actual `e.args.size()` against all registered `@native` sigs, not the table entry's `arity` field. Upstream type matching (L172-189) runs only on the **non**-custom-emitter path, so custom emitters must perform their own argument-type checks and emit `codegenError` for unsupported combinations — otherwise `pow(1, 2.0)` silently reaches the wrong branch.
 
-Upstream type matching (the type-match loop at
-`codegen_call_native.cpp:172-189`) runs only on the non-custom-emitter
-path, so **custom emitters must perform their own argument-type checks
-and emit clear `codegenError` messages** when types don't match any
-supported overload. Otherwise a mixed-type call like
-`pow(1, 2.0)` would silently reach the wrong branch.
-
-**Rule**: When adding an overload for an existing stdlib function with
-a custom emitter, (1) add the `@native fn` declaration, (2)
-extend the existing custom emitter to handle the new arity / type
-combination, (3) add explicit type checks with clear errors for
-unsupported combinations — do NOT add a second table entry, it will
-never fire. See `emitMathFloorCeilRound` / `emitMathLog` /
-`emitMathPow` in `src/codegen_call.cpp` for the canonical pattern.
+**How to apply**: When adding an overload, (1) add the `@native fn` declaration in `share/std/<mod>/<mod>.ry`, (2) extend the existing custom emitter, (3) add explicit type checks. See `emitMathFloorCeilRound` / `emitMathLog` / `emitMathPow` in `src/codegen_call.cpp`.
 
 ### `contains()` on Map must be intercepted in `emitStrOp_contains`, not via `@native`
 
-**Source**: #1185 (2026-04-19, fix)
+**Source**: #1185
 **Tags**: codegen, collections, map, dispatch-order, contains
 
-`emitBuiltinString` is invoked before `emitBuiltinCollection` in
-`src/codegen_call_dispatch.cpp`. Therefore every `contains(x, y)` call reaches
-`emitStrOp_contains` first. Since all collection pointers share `ptrTy_` with
-strings under the opaque pointer model, the Set and Map intercept blocks must
-live inside `emitStrOp_contains` — before the str fall-through logic — rather
-than in `emitBuiltinCollection`.
+**Rule**: `emitBuiltinString` runs before `emitBuiltinCollection` in `src/codegen_call_dispatch.cpp`, so every `contains(x, y)` reaches `emitStrOp_contains` first. Under opaque pointers all collection pointers share `ptrTy_` with strings, so Set/Map intercept blocks must live inside `emitStrOp_contains` (`src/codegen_call_string.cpp`) before the str fall-through. Do NOT declare `@native contains` in the stdlib module file — that routes through the Pattern-A table and interacts unpredictably with the string handler.
 
-**Rule**: If a new collection type needs `contains()` semantics, add a
-`getXxxType(s)` intercept block immediately after the Set block in
-`emitStrOp_contains` (`src/codegen_call_string.cpp`). Do NOT declare a
-`@native` `contains` overload in the stdlib module file; that would route
-through the Pattern-A dispatch table and interact unpredictably with the
-string handler.
-
-The Map intercept mirrors `has_key` (`src/codegen_call.cpp`) exactly:
+The Map intercept mirrors `has_key` (`src/codegen_call.cpp`):
 ```cpp
 if (llvm::Type *mapKeyTy = getMapKeyType(s)) {
-    if (e.args.size() != 2)
-        codegenError("Map.contains() takes exactly 1 argument");
+    if (e.args.size() != 2) codegenError("Map.contains() takes exactly 1 argument");
     llvm::Value *key = emitExpr(*e.args[1]);
-    if (key->getType() != mapKeyTy)
-        codegenError("contains() key type mismatch");
+    if (key->getType() != mapKeyTy) codegenError("contains() key type mismatch");
     llvm::Value *idx = emitMapKeyLookup(s, key, mapKeyTy);
     return builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "map_contains");
 }
 ```
 
-Note: `emitMapKeyLookup` is called without threading `keyName` here, matching
-the existing `has_key` implementation. Structural-key correctness (pointer-typed
-map keys) is a separate issue — see the L1106 entry.
+`emitMapKeyLookup` is called without threading `keyName` here, matching `has_key`. Structural-key correctness for pointer-typed map keys is a separate concern (see "Every caller of emitSetElementLookup..." entry below).
 
 ### Mutating collection operations belong in `codegen_call_higher_order.cpp`, not `codegen_call_string.cpp`
 
-**Source**: #1124 (2026-04-18)
+**Source**: #1124
 **Tags**: codegen, dispatch, placement, list, string
 
-**Rule**: `sort!` and `reverse!` (and any future in-place list mutation) must be registered in `emitBuiltinHigherOrder` (`src/codegen_call_higher_order.cpp`), not in the String dispatcher table in `emitBuiltinString` (`src/codegen_call_string.cpp`). The String dispatcher is tried before HigherOrder in the dispatch chain (`codegen_call_dispatch.cpp`), so a stray entry in the String dispatcher will unconditionally claim the call for every type — including lists — before HigherOrder gets a chance. This caused `reverse!` to silently route list calls through a misleadingly-named `emitStrOp_reverse_mut` function, and to produce the confusing error "requires a list" when called on a string.
+**Rule**: `sort!`, `reverse!`, and any future in-place list mutation must be registered in `emitBuiltinHigherOrder` (`src/codegen_call_higher_order.cpp`), not the String dispatcher. String runs first in the dispatch chain (`codegen_call_dispatch.cpp`), so a stray entry there unconditionally claims the call for every type — including lists — before HigherOrder gets a chance.
 
-**How to apply**: When adding a new mutating built-in that applies to lists, check whether `sort!` already lives in HigherOrder and mirror that placement. If a built-in should error on strings with a user-facing message, add the `getListElementType() == nullptr` guard in the HigherOrder handler and emit a clear diagnostic (e.g. "requires a list; strings are immutable, use reverse() instead").
+**How to apply**: Mirror `sort!`'s placement in HigherOrder. To error on strings, add `getListElementType() == nullptr` guard in the HigherOrder handler with a clear message (e.g. "requires a list; strings are immutable, use reverse() instead").
 
-### Every caller of emitSetElementLookup with a pointer-typed element must thread set_elem_type_name
+### Every caller of `emitSetElementLookup` / `emitMapKeyLookup` with a pointer-typed element must thread the type name
 
-**Source**: #963 (2026-04-15, bugfix)
-**Tags**: codegen, collections, set, linear-scan, metadata, equality, hash-table
+**Source**: #963
+**Tags**: codegen, collections, set, map, equality, hash-table
 
-**Context**: `emitSetElementLookup` decides whether to use structural
-equality (linear scan) or hash-by-pointer-as-C-string (hash-table path,
-via `__ry_ht_find_str`) based on the `elemName` argument:
-
-```cpp
-const bool needsLinearScan =
-    llvm::isa<llvm::StructType>(elemTy) ||
-    (!elemName.empty() && elemName != "str" && ...);
-```
-
-When `elemName` is empty and `elemTy == ptrTy_`, it falls through to
-`emitHashTableLookup`, which calls `__ry_ht_find_str(set_ptr, elem_ptr)`.
-`__ry_ht_find_str` uses `strcmp` + string hash, so it reads the list/map/set
-header bytes as a null-terminated C string. For any two `List<int>` values
-of length 2, the ARC data starts with `\x02` (length=2 in varint encoding)
-followed by a zero byte — every length-2 list has the same "string" `"\x02"`,
-causing all of them to hash and compare equal. This silently deduplicates
-distinct elements during set-literal construction, `add`, `remove`, `in`,
-and `contains`.
-
-**Root cause**: Several callers of `emitSetElementLookup` did not pass
-`elemName` (set it to the empty string default), triggering the wrong path
-for nested collections:
-
-- `emitSetLiteral` (set-literal dedup): `src/codegen_expr_literal.cpp`
-- `emitCollOp_add`: `src/codegen_call_collection.cpp`
-- `emitSetRemove`: `src/codegen_call_collection.cpp`
-- `in`/`not in` operator: `src/codegen_expr.cpp`
-- `contains()` on a Set (routed via `emitStrOp_contains`): `src/codegen_call_string.cpp`
-
-**Rule**: Every call site that passes a pointer-typed element to
-`emitSetElementLookup` must thread `set_elem_type_name`; every call site
-that passes a pointer-typed key to `emitMapKeyLookup` must thread
-`map_key_type_name`. Both functions use an empty name as the signal to
-skip structural equality and fall back to hash-by-ptr-as-C-string, so
-omitting the name silently breaks correctness.
+**Rule**: `emitSetElementLookup` and `emitMapKeyLookup` use an empty name as the signal to skip structural equality and fall back to hash-by-ptr-as-C-string (via `__ry_ht_find_str` → `strcmp`). For nested collections (`List<int>` keys, etc.) this collapses distinct values: every length-2 list starts with `\x02\0` so they all hash equal and silently dedupe during literal construction, `add`, `remove`, `in`, `contains`.
 
 Pattern for sets:
 ```cpp
 std::string elemName = getSetElemName(setPtr);  // reads set_elem_type_name
-if (!elemName.empty())
-    propagateTypeMeta(elemName, elem);
+if (!elemName.empty()) propagateTypeMeta(elemName, elem);
 emitSetElementLookup(setPtr, elem, elemTy, elemName);
 ```
 
-Pattern for maps (use `getMeta()->map_key_type_name`; there is no dedicated
-accessor yet):
+Pattern for maps (no dedicated accessor — use `getMeta()`):
 ```cpp
 const ValueMetadata *meta = getMeta(mapPtr);
 std::string keyName = meta ? meta->map_key_type_name : std::string{};
-if (!keyName.empty())
-    propagateTypeMeta(keyName, key);
+if (!keyName.empty()) propagateTypeMeta(keyName, key);
 emitMapKeyLookup(mapPtr, key, keyTy, keyName);
 ```
 
-Also set the type-name field when building the container (e.g. in the
-set/map literal emitter), so downstream callers can retrieve it via `getMeta`.
-`emitSubsetCheck` (`src/codegen_call_set_ops.cpp`) already follows this
-pattern correctly for sets and is the canonical reference.
+Also stamp the type-name field at container build time (set/map literal emitter) so downstream callers can retrieve it via `getMeta`. `emitSubsetCheck` (`src/codegen_call_set_ops.cpp`) is the canonical reference. Affected sites historically: `emitSetLiteral` / `emitCollOp_add` / `emitSetRemove` (`codegen_call_collection.cpp`), `in`/`not in` (`codegen_expr.cpp`), `contains()` on Set (`codegen_call_string.cpp`).
 
-### Bare builtins that call native-lib runtime symbols must register the library via `used_native_libraries_`
+### Bare builtins calling native-lib runtime symbols must register the library via `used_native_libraries_`
 
-**Source**: #1261 (implementation of `input()` builtin)
+**Source**: #1261
 **Tags**: stdlib, codegen, native-library, builtin, library-loading, @native
 
-**Rule**: When adding a new bare builtin (dispatched via the `builtins_` map or
-an inline branch in `emitBuiltinCore`) whose runtime implementation lives in a
-native shared library (`libry_<mod>.dylib`), the codegen emitter MUST call
-`used_native_libraries_.insert("<mod>")` before emitting the `CreateCall`.
-Otherwise the JIT fails at runtime with
-`JIT session error: Symbols not found: [ ___ry_<name> ]`, because no
-`@native("mod")` directive populated `native_lib_index_` automatically.
+**Rule**: When adding a bare builtin (via `builtins_` map or inline branch in `emitBuiltinCore`) whose runtime lives in a separate `libry_<mod>.dylib`, the codegen emitter MUST call `used_native_libraries_.insert("<mod>")` before emitting `CreateCall`. Otherwise the JIT fails at runtime with `Symbols not found: [ ___ry_<name> ]` because bare `@native` declarations leave `sig.library` empty (no automatic `native_lib_index_` population).
 
-**Why**: Bare `@native` declarations in `share/std/builtins.ry` leave
-`sig.library` empty (see "Bare `@native` vs `@native("mod")` — NOT
-cosmetically equivalent"), so library-load registration does NOT happen
-through the declaration path. The burden shifts entirely to the codegen
-dispatcher.
+**How to apply**:
+- Runtime in `src/runtime_<mod>.cpp` → linked into `libry_<mod>.dylib` → **insert `<mod>`**.
+- Runtime in `runtime_print.cpp` / `runtime_arc.cpp` → linked into `ry_lib` (resolved by `DynamicLibrarySearchGenerator::GetForCurrentProcess`) → no registration needed.
 
-Most bare builtins (`print`, `len`, `range`, `arguments`, etc.) happen to
-call symbols in `ry_lib` — the static library linked directly into the main
-binary — so they resolve through `DynamicLibrarySearchGenerator::GetForCurrentProcess`
-without any explicit registration. The trap surfaces only when the runtime
-symbol lives in a **separate** `.dylib`. For `input()`, `__ry_read_line` and
-`__ry_input_prompt` live in `libry_io.dylib`; without
-`used_native_libraries_.insert("io")`, a user who writes `print(input())`
-(with no `import` from `io`) hits the JIT error.
-
-**How to apply**: When adding a bare builtin branch in `emitBuiltinCore`,
-check which source file defines its runtime symbols:
-
-- If in `src/runtime_<mod>.cpp` (linked into `libry_<mod>.dylib` via
-  `add_ry_native_lib(<mod> ...)` in `CMakeLists.txt`), add
-  `used_native_libraries_.insert("<mod>")`.
-- If in `src/runtime_*.cpp` linked directly into `ry_lib` (e.g. `runtime_print.cpp`,
-  `runtime_arc.cpp`), no registration is needed.
-
-Regression test: exercise the builtin from a program that does NOT
-`import` anything from the target module — this is exactly the usage
-pattern users expect for a bare builtin, and it's the shape that
-surfaces missing registration. Compile-only tests do not catch this
-because the dispatcher succeeds at IR emission; the failure is deferred
-to JIT symbol lookup.
+Regression-test by exercising the builtin from a program that does NOT `import` the target module — that's the user-facing usage shape that exposes missing registration. Compile-only tests pass at IR emission and the failure defers to JIT symbol lookup.
 
 ### Builtin native-underscore wrappers must update the builtin dispatcher too
 
-**Source**: #1277 (2026-04-23, implementation)
+**Source**: #1277
 **Tags**: stdlib, builtin, wrapper, default-args, ufcs, codegen
 
-**Rule**: When converting a bare builtin in `share/std/*.ry` from a direct
-`@native fn name(...)` declaration to the native-underscore wrapper
-pattern (`@native fn _name(...)` + `fn name(... = default)`),
-update the C++ builtin dispatcher as well.
+**Rule**: When converting a bare builtin from `@native fn name(...)` to the wrapper pattern (`@native fn _name(...)` + `fn name(... = default)`), update the C++ dispatcher: (1) register the underscored alias (e.g. `"_split"`) in the relevant table (`emitBuiltinString`, `emitBuiltinCore`) — otherwise the wrapper body fails with `undefined function: _name`; (2) mirror new optional/default-arg behavior in the builtin emitter, because UFCS / direct builtin calls may still route through C++ instead of the Ry wrapper.
 
-**Why**: Bare builtins like `split` are intercepted before ordinary Ry
-fn resolution. Two separate changes may be required:
-
-- Register the underscored alias (for example `"_split"`) in the relevant
-  dispatch table (`emitBuiltinString`, `emitBuiltinCore`, etc.), otherwise the
-  wrapper body itself fails with `undefined function: _name`.
-- Mirror any new optional arity/default-argument behavior in the builtin
-  emitter, because UFCS/direct builtin calls may still route through the C++
-  handler instead of the Ry wrapper body.
-
-**How to apply**: After introducing a builtin wrapper, test both forms:
-ordinary call syntax (`name(...)`) and UFCS (`value.name(...)` when
-supported). A passing spec for only one path is not enough.
+**How to apply**: Test both call shapes — `name(...)` and UFCS `value.name(...)`. A passing spec for only one path is not enough.
 
 ### Byte-list APIs require `TypeMeta::ListElem == i8Ty_`; plain int list literals are rejected at compile time
 
-**Source**: PR #1055. **Tags**: codegen, runtime, IOListHeader, ListHeader, bytesToStr, writeBytes, send
+**Source**: PR #1055
+**Tags**: codegen, runtime, IOListHeader, ListHeader, bytesToStr, writeBytes, send
 
-**Rule**: Any native function that casts a `List` argument to `IOListHeader *` must set `NativeDispatchEntry::requireListU8Arg` to the 0-based index of that argument (or stamp `ListElemMeta::I8` for producers). Codegen enforces the gate via `CodeGen::emitTableDrivenNativeCall`. Do not add a new byte-list consumer without updating the audit table above and adding this field.
-
-`IOListHeader` (`include/ry/runtime_io.hpp`) reads `data` with 1-byte stride (`int8_t *`).
-Plain Ry list literals like `[97, 0, 98]` default element type to `int`, which codegen stores
-with 8-byte (`i64`) stride. Passing such a list to a byte-list consumer produces silent memory
-corruption (reads 8× too much data, interprets padding as bytes).
+**Rule**: Any native function that casts a `List` argument to `IOListHeader *` must set `NativeDispatchEntry::requireListU8Arg` to the 0-based argument index (or stamp `ListElemMeta::I8` for producers). Codegen enforces the gate in `CodeGen::emitTableDrivenNativeCall`. `IOListHeader` reads `data` with 1-byte stride, but plain `[97, 0, 98]` defaults to `int` (8-byte stride) — passing such a list silently reads 8× too much.
 
 ### `emitTableDrivenNativeCall` variadic path must use raw `ptr` type for `ResultPtr` entries
 
-**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: codegen, ResultPtr, variadic, emitTableDrivenNativeCall, nul-safety
+**Source**: PR #1054
+**Tags**: codegen, ResultPtr, variadic, emitTableDrivenNativeCall, nul-safety
 
-**Rule**: In `src/codegen_call_native.cpp`, the fixed-arity path of `emitTableDrivenNativeCall`
-already handled `ReturnWrapping::ResultPtr` (uses `ptrTy_` for the C ABI return, then wraps via
-`wrapPtrAsResult`). The variadic-arity path (for functions like `path.join` with 2/3/4 overloads)
-did **not** — it called `resolveType(matchedSig->returnTypeName)` to determine the C return type.
-After upgrading `.ry` signatures to `Result<str, Error>`, `matchedSig->returnTypeName` becomes
-`"Result<str, Error>"`, which `resolveType` maps to an LLVM struct type instead of `ptr` — causing
-an ABI mismatch crash (the runtime still returns `char *`).
+**Rule**: The fixed-arity path in `emitTableDrivenNativeCall` already handles `ReturnWrapping::ResultPtr` (uses `ptrTy_` for the C ABI return, then `wrapPtrAsResult`). The variadic path (e.g. `path.join` 2/3/4 overloads) calls `resolveType(matchedSig->returnTypeName)` instead — once `.ry` signatures are upgraded to `Result<str, Error>`, this maps to a struct type (not `ptr`) and crashes with ABI mismatch.
 
-**Fix pattern**:
 ```cpp
-// In the variadic path, before CreateCall:
 llvm::Type *cRetTyVariadic = (entry->wrapping == ReturnWrapping::ResultPtr)
     ? ptrTy_
     : resolveType(matchedSig->returnTypeName);
 auto *fnTy = llvm::FunctionType::get(cRetTyVariadic, argTypes, false);
-// ... CreateCall, then:
+// CreateCall, then:
 if (entry->wrapping == ReturnWrapping::ResultPtr) {
-    std::string errFn = getErrFnName();
-    return wrapPtrAsResult(callResult, errFn.c_str());
+    return wrapPtrAsResult(callResult, getErrFnName().c_str());
 }
 return callResult;
 ```
 
-**How to apply**: Any time a function with multiple overloads at different arities (variadic
-dispatch path) is upgraded from bare `-> str` to `-> Result<str, Error>`, both the
-`NativeDispatchEntry::wrapping` field AND the variadic code path in `emitTableDrivenNativeCall`
-need updating. The fixed-arity path handles it automatically once `wrapping = ResultPtr` is set;
-the variadic path requires explicit `ResultPtr` detection before `resolveType`.
+**How to apply**: When upgrading a multi-arity variadic fn from bare `-> str` to `Result<str, Error>`, update both `NativeDispatchEntry::wrapping` and the variadic code path. Fixed-arity is automatic once `wrapping = ResultPtr` is set.
 
 ### Dual-path builtins must share terminator / cleanup handling
 
-**Source**: #821 sweep (2026-04-10)
+**Source**: #821
 **Tags**: codegen, builtins, exit, diverging-call
 
-**Context**: `exit()` had two dispatch paths: (1) as an expression via
-`emitBuiltinCore` in `src/codegen_call.cpp`, which explicitly created a
-fresh `exit.dead` block after emitting `unreachable`, and (2) as a
-statement via `builtins_["exit"]` lambda in `src/codegen.cpp`, which
-just called `emitExit()` and left the insertion point on the terminated
-block. The statement path (the most common usage) broke LLVM basic
-block invariants for any trailing code. Putting the dead-block switch
-inside `emitExit()` itself made both paths behave consistently.
+**Rule**: When a builtin or helper has post-emit fixup — dead-block creation, ARC cleanup, metadata propagation, trace exit — put the fixup inside the core helper (`emitExit`, `emitReturn`, …) so every dispatch path inherits it. If a fixup lives in only one caller, the other caller is a latent bug. (Origin: `exit()` had separate expression-path and statement-path dispatchers; only the expression path created the `exit.dead` block, breaking BB invariants for trailing code on the statement path.)
 
-**Rule**: When a builtin or helper has post-emit fixup — dead block
-creation, ARC cleanup, metadata propagation, trace exit — put the
-fixup inside the core helper (`emitExit`, `emitReturn`, ...) so every
-dispatch path inherits it. If a fixup lives only in one caller, the
-other caller is a latent bug waiting to be triggered.
-
-**How to verify**: grep for all callers of the core helper and confirm
-each one either expects the helper's post-state or explicitly
-re-establishes its own. If any caller is silent about the post-state,
-the fixup belongs in the helper.
-
-### Named arguments for builtins: generic parse, builtin-only dispatch
-
-**Source**: #747 (2026-04-14)
-**Tags**: codegen, builtins, named-args, parser, print
-
-**Context**: `print(end="", sep=", ")` required named/keyword argument
-support, which did not exist in Ry's function call syntax.
-
-Three options were considered:
-1. Full language-wide named args (large scope: AST, type checker,
-   overload resolution)
-2. Special-case `print` in the parser (parser knows builtin names —
-   violates separation of concerns)
-3. Generic named-arg parse + builtin-only codegen restriction ← **chosen**
-
-Option 3 adds `std::vector<NamedArg> named_args` to `CallExpr` /
-`CallStmt`, teaches `parseArgList()` to detect `ident = expr` (same
-lookahead as directive parsing), and restricts usage to builtins at
-codegen time. Non-builtin calls with named args emit a codegen error.
-
-The `=` token is never valid inside an expression (equality uses `==`),
-so the lookahead is unambiguous.
-
-**Rule**: When adding the next named-arg builtin, only `emitPrint()` in
-`src/codegen_call_io.cpp` and the `builtins_` map in `src/codegen.cpp`
-need updating. To lift the builtin-only restriction later, remove the
-check in `codegen_call_user.cpp` and add type-checker support.
+**How to verify**: grep all callers of the core helper; each must either expect the post-state or explicitly re-establish its own.
 
 ### Custom-emitter native functions bypass argument type-checking
 
 **Source**: #828
 **Tags**: codegen, native-dispatch, type-checking, gotcha
 
-**Rule**: Native functions registered with a `customEmitter` in
-their `NativeDispatchEntry` go through the early-return at
-`src/codegen_call_native.cpp:135-150` and **skip** the regular
-argument type validation path (L165-203). That means the Ry
-declaration in `share/std/<mod>/<mod>.ry` (e.g.
-`fn threadSpawn(body: fn() -> Unit) -> Thread`)
-constrains only what IDE/docs consumers see, not what the custom
-emitter actually accepts. When extending a custom-emitter native
-fn (e.g. broadening `threadSpawn` to accept non-Unit
-lambdas, or `assert` to accept new argument shapes), you can
-relax the effective input without touching the Ry declaration.
-Do update the docs and declaration for hygiene, but do not
-assume the parser/type-checker is gating you — your codegen is.
+**Rule**: Functions with a `customEmitter` in `NativeDispatchEntry` early-return at `src/codegen_call_native.cpp:135-150` and **skip** regular argument type validation (L165-203). The Ry declaration in `share/std/<mod>/<mod>.ry` constrains only IDE/docs consumers — the custom emitter dictates what is actually accepted. When extending (e.g. broadening `threadSpawn` to non-Unit lambdas), you can relax effective inputs without touching the Ry declaration. Update docs/declaration for hygiene, but don't assume the parser is gating you.
 
 ### NUL checks belong in the codegen emitter, not the runtime, for multi-context functions
 
-**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: nul-safety, codegen, runtime, c-api-boundary
+**Source**: PR #1054
+**Tags**: nul-safety, codegen, runtime, c-api-boundary
 
-**Context**: `__ry_http_client_request(method, url, headers, body)` is invoked from three contexts:
-1. User Ry code → codegen emitter → all arguments are Ry handles (StringHeader present)
-2. C++ unit tests calling the function directly with `url.c_str()` or C string literals
-3. Internal runtime functions (`__ry_http_post` calls it with the literal `"POST"`)
-
-Applying `hasEmbeddedNul` inside the runtime covers case 1 but produces false positives for
-cases 2 and 3 (reads garbage memory before the pointer).
-
-**Rule**: If a runtime function is called from Ry codegen *and* from C++ or internal C code,
-put NUL checks in the codegen emitter only. Leave the runtime function unchecked (treat it as
-an internal C API). Add a comment in the runtime explaining the split:
+**Rule**: A runtime function called from Ry codegen *and* from C++/internal C code (e.g. `__ry_http_client_request` invoked from user Ry, C++ unit tests with `.c_str()`, and `__ry_http_post` with literal `"POST"`) must put NUL checks in the codegen emitter only. `hasEmbeddedNul` reads a `StringHeader` before the pointer, which is garbage memory for non-Ry strings (false positives → tests hang). Treat the runtime fn as an internal C API. Add a comment in the runtime explaining the split:
 
 ```cpp
 // NUL checks for method and url are done in codegen (emitHttpClientCall) for
 // the user-facing Ry paths. This function is also called directly from C++
-// tests and internally with plain C strings that carry no Ry StringHeader —
-// applying hasEmbeddedNul here would read garbage before those pointers.
+// tests and internally with plain C strings that carry no Ry StringHeader.
 ```
 
 ### String negative-index wrap uses UTF-8 char count, not byte length
 
-**Source**: PR #1199 fix for `emitStrOp_substring` (2026-04-20)
-**Tags**: codegen, substring, emitNegativeIndexWrap, UTF-8, char-count, __ry_utf8_len_n
+**Source**: PR #1199
+**Tags**: codegen, substring, emitNegativeIndexWrap, UTF-8, __ry_utf8_len_n
 
-**Rule**: When applying `emitNegativeIndexWrap(idx, wrapBase, prefix)` to string (char) indices, `wrapBase` MUST be the UTF-8 codepoint count obtained via `__ry_utf8_len_n(s, byteLen)`, not `emitStringByteLen(s)`. For a 5-char, 15-byte string like `"あいうえお"`, using byte length as wrap base gives `-1 + 15 = 14` (a garbage index into a 5-char string); using char count gives `-1 + 5 = 4` (correct last-char index). The `_n` variant is NUL-safe (counts embedded `\0` as one codepoint).
+**Rule**: For `emitNegativeIndexWrap(idx, wrapBase, prefix)` on string (char) indices, `wrapBase` MUST be the UTF-8 codepoint count from `__ry_utf8_len_n(s, byteLen)`, **not** `emitStringByteLen(s)`. For `"あいうえお"` (5 chars, 15 bytes), byte-length wrap gives `-1 + 15 = 14` (garbage); char-count gives `-1 + 5 = 4` (correct). The `_n` variant is NUL-safe.
 
-**Pattern** (copy from `src/codegen_call_string.cpp:218-245`):
 ```cpp
-llvm::Value *byteLen = emitStringByteLen(s);    // hoisted: reused for runtime call
+llvm::Value *byteLen = emitStringByteLen(s);  // hoist: reused downstream
 auto utf8LenFn = getRuntimeFn("__ry_utf8_len_n", i64Ty_, {ptrTy_, i64Ty_});
 llvm::Value *charLen = builder_.CreateCall(utf8LenFn, {s, byteLen}, "charlen");
 llvm::Value *wrapped = emitNegativeIndexWrap(idx, charLen, "prefix");
-// ... then zero-clamp (wrap of very negative idx can still be negative), then runtime call
+// then zero-clamp; very-negative idx still negative after wrap (-100+5=-95)
 ```
 
-Always hoist `emitStringByteLen(s)` into a local so the same byte length feeds both `__ry_utf8_len_n` and the downstream string-indexed runtime call (e.g. `__ry_utf8_substring`). The zero-clamp after wrap is still required: `-100 + 5 = -95` needs to be clamped to `0`.
-
-**Why this differs from `emitCollOp_slice`**: `emitCollOp_slice` uses list length (element count = storage length), so there is no "byte vs codepoint" distinction. String call sites must remember this extra indirection.
-
----
-
-## #1156: split match subject type into enum-only vs broad source name
-
-**Source**: PR #1156 fix for `codegen_match.cpp` subjectEnumType wrong channel
-**Tags**: pattern, match, ARC, codegen, Option, Result, tuple, subjectEnumType
-
-**Rule**: `emitPatternTest`, `emitPatternBindings`, and `checkMatchExhaustiveness`
-take **two** source-name parameters:
-
-- `subjectEnumName` — narrow channel (`ValueMetadata::enum_value_type`).
-  Only set for enum/ADT subjects (from `resolveEnumType()`). Used by
-  `EnumPattern`/`EnumConstructorPattern` generic-instantiated lookup, by
-  `Some`/`Ok`/`Err` binding `extractGenericTypeArg`, and by `VariablePattern`
-  binding's `enum_value_type` write (still guarded by
-  `enum_types_.count(resolveTypeAlias(name))`).
-- `subjectSourceTypeName` — broad channel (`resolveSubjectSourceTypeName()`).
-  Reconstructs `Option<T>` / `Result<T, E>` / `(T1, T2, ...)` from the LLVM
-  subject type when no enum annotation exists. Used by `TuplePattern` /
-  `RecordPattern` structural verification and by `emitPatternBindingArc`
-  Path 2a from `VariablePattern` only.
-
-**Reconstruction lossiness**: `reverseResolveTypeName(ptrTy_)` returns `"str"`;
-unknown structs return `"any"`. So `Option<List<int>>` reconstructs as
-`"Option<str>"`. The reconstructed string is therefore **only** safe for
-structural checks ("is this a tuple struct?" / "does this match record name X?").
-Do NOT re-feed it into `extractGenericTypeArg` for ARC payload classification —
-`Option<List<int>>` would be misclassified as `Option<str>` (wrong header
-offset: str uses -24, List uses -16), causing heap corruption under ASan.
-
-**Defense-in-depth on TuplePattern**: the test arm rejects via
-`!sTy || !isTupleStructType(sTy)` regardless of any source name. This fires
-even when both names are empty — closing the path where Option's `{i1, T}`
-2-element struct silently passed the 2-arity check and crashed with ICmp
-type mismatch (original #1156 crash vector).
-
-**Why split rather than unify**: the previous single `subjectEnumType`
-parameter was overloaded with non-enum names via the new broad helper
-would force every consumer to add an `enum_types_.count(name)` guard.
-The split signature makes "enum-only" vs "broader subject type" a
-compile-time-enforced distinction. The guard at VariablePattern binding
-remains necessary but is now purely defensive
-(subjectEnumName is already enum-only).
-
-**Follow-up**: Add a lossless `source_type_name` field to `ValueMetadata` so
-`Option<List<int>>` reconstruction is accurate, enabling ARC Path 2a for nested
-generics (currently handled by Path 2b heuristic via `propagateMeta`).
-- Pre-existing defect in `emitListSlice`: ARC retain omitted for reference-typed elements (#1204) — tracked separately.
-
+Hoist `emitStringByteLen(s)` so the same byte length feeds `__ry_utf8_len_n` and the downstream call (e.g. `__ry_utf8_substring`). Pattern source: `src/codegen_call_string.cpp:218-245`. Differs from `emitCollOp_slice` because list length already equals storage length — no byte/codepoint distinction.

--- a/.claude/rules/codegen-type-and-metadata.md
+++ b/.claude/rules/codegen-type-and-metadata.md
@@ -11,479 +11,183 @@ paths:
 
 ### Adding a new type kind requires cross-checking every other type registry
 
-**Source**: #815 (2026-04-11, implementation), extended by #850 (2026-04-11)
+**Source**: #815 (2026-04-11), extended by #850
 **Tags**: codegen, types, registry, duplicate-check, naming
 
-**Context**: Type definitions in `include/ry/codegen.hpp` are stored
-across four **user-name** registries: `record_types_` (records),
-`enum_types_` (concrete enums), `generic_enum_templates_` (generic
-enum templates), and `type_aliases_`. All four share a single user-facing
-type name space. The `rejectIfTypeNameTakenByOtherKind()` helper
-(`src/codegen_stmt_misc.cpp`) now consults all four before allowing a
-new declaration. Each `emitStmt(<Decl>Stmt &)` path (Record, Enum concrete,
-Enum generic, TypeAlias) must (a) reject its own same-kind duplicate
-with a kind-specific message, and (b) call
-`rejectIfTypeNameTakenByOtherKind()` for cross-kind collisions.
+**Rule**: When introducing a new type kind (or touching an existing `emitStmt(<Decl>Stmt &)` path), reject the name if it collides with **any other user-name type registry**. Type definitions in `include/ry/codegen.hpp` use four user-name registries — `record_types_`, `enum_types_` (concrete), `generic_enum_templates_`, `type_aliases_` — that share one user-facing name space. Each `emitStmt(<Decl>Stmt &)` path (Record, Enum concrete, Enum generic, TypeAlias) must (a) reject same-kind duplicates with a kind-specific message, and (b) call `rejectIfTypeNameTakenByOtherKind()` (`src/codegen_stmt_misc.cpp`) for cross-kind collisions.
 
-`union_type_info_` (`include/ry/codegen.hpp`) is **not** a user-name
-registry — it is an **anonymous cache** populated by `resolveType()` in
-`src/codegen_type.cpp` when an inline union like `int | str` is
-encountered. Its key is a flattened type string, not a user-chosen
-name. Named unions like `type Foo = int | str` go through
-`TypeAliasStmt` and land in `type_aliases_`, so a cross-kind check
-against `union_type_info_` is unnecessary and would be wrong (it would
-reject legitimate anonymous cache hits).
+`union_type_info_` is **not** a user-name registry — it's an anonymous cache populated by `resolveType()` (`src/codegen_type.cpp`) when an inline union like `int | str` is encountered (key: flattened type string). Named unions like `type Foo = int | str` go through `TypeAliasStmt` and land in `type_aliases_`, so a cross-kind check against `union_type_info_` is unnecessary and would reject legitimate anonymous cache hits.
 
-**Rule**: When introducing a new type kind (or touching an existing
-`emitStmt(<Decl>Stmt &)` path), reject the name if it collides with
-**any other user-name type registry**. Pair
-record/enum/generic-enum/alias as a single name space. Do not treat
-`union_type_info_` as a user-name registry.
-
-**How to verify**: grep the codegen header for
-`std::unordered_map<std::string, .*(?:Info|Template|Type)>` to find
-every type registry, then confirm each `emitStmt` for a type
-declaration consults all user-name registries before inserting. Add a
-regression test (`EXPECT_THROW` with `runSource`) per cross-category
-pair in both orders — legal cases alone won't catch a missing guard.
+**How to verify**: grep `std::unordered_map<std::string, .*(?:Info|Template|Type)>` in the codegen header to find every type registry, then confirm each `emitStmt` for a type declaration consults all user-name registries before inserting. Add `EXPECT_THROW` regression tests (with `runSource`) per cross-category pair in both orders — legal cases alone won't catch a missing guard.
 
 ### Canonicalization that may collapse shape must be handled at all call sites
 
 **Source**: #844 PR review (CodeRabbit, critical)
 **Tags**: codegen, canonicalization, union, types
 
-**Context**: `flattenUnionWithAliases("A | int")` where
-`type A = int` collapses to just `"int"`. Downstream `wrapInUnion`
-then did `union_type_info_.find("int")`, missed, and dereferenced
-`end()`. The fix was to early-return when the flattened result is
-no longer a non-literal union.
+**Rule**: When introducing a normalization/canonicalization step that can change a type's **category** (union → scalar, variadic → single, tuple → element, alias → target), audit every caller that assumes the original category. Add an explicit early-return for the collapsed case.
 
-**Rule**: When introducing a normalization/canonicalization step that
-can change a type's **category** (union → scalar, variadic → single,
-tuple → element, alias → target), audit every caller that assumes the
-original category. Add an explicit early-return for the collapsed case.
+**Why**: `flattenUnionWithAliases("A | int")` where `type A = int` collapses to `"int"`. Downstream `wrapInUnion` then did `union_type_info_.find("int")`, missed, and dereferenced `end()`. The fix was to early-return when the flattened result is no longer a non-literal union.
 
-**How to verify**:
-
-```bash
-grep -n '<normalizer_name>' src/
-```
-
-For each hit ask "what if the result is no longer a union/variadic/
-tuple?". If the caller indexes a map keyed on the original category,
-it needs a guard.
+**How to verify**: `grep -n '<normalizer_name>' src/`, then for each hit ask "what if the result is no longer a union/variadic/tuple?". If the caller indexes a map keyed on the original category, it needs a guard.
 
 ### valueToString element loads must propagate metadata via propagateTypeMeta
 
-**Source**: #811/#836/#810 sweep (2026-04-10, implementation)
+**Source**: #811 / #836 / #810 sweep (2026-04-10)
 **Tags**: codegen, formatter, metadata, collection, nested
 
-**Context**: The formatter in `src/codegen_tostring.cpp` iterates over
-`List` / `Map` / `Set` elements by loading them from the container's
-data array. Each load yields a fresh SSA `Value*` with no metadata. If
-the element type is itself a collection (e.g. `Map<str, List<int>>`),
-calling `valueToString(elem)` without propagating the inner type name
-falls through to the raw string-pointer path and prints empty strings or
-garbage bytes. The `List` branch already had this propagation
-(`list_elem_type_name` + `list_elem_fn_type_info` snapshot), but the
-`Map` and `Set` branches did not — which is why #811 / #810 went
-undetected until this sweep.
+**Rule**: Whenever you add a new outer container type to `valueToString()` (`src/codegen_tostring.cpp`), the element-load block MUST:
 
-**Rule**: Whenever you add a new outer container type to
-`valueToString()`, the element-load block MUST:
+1. Snapshot both the element type name and any `*_fn_type_info` field from the outer container's metadata **before** calling `getOrCreateMeta()` (which may rehash `value_metadata_` and invalidate pointers).
+2. Call `propagateTypeMeta(elemTypeName, elem)` to rebuild the element's collection metadata (`list_elem`, `map_value_type_name`, etc.).
+3. If the snapshot had `*_fn_type_info`, store it on the element's metadata so closures format as `<closure>`.
 
-1. Snapshot both the element type name and any `*_fn_type_info` field
-   from the outer container's metadata **before** calling
-   `getOrCreateMeta()` (which may rehash `value_metadata_` and
-   invalidate pointers).
-2. Call `propagateTypeMeta(elemTypeName, elem)` to rebuild the element's
-   collection metadata (`list_elem`, `map_value_type_name`, etc.).
-3. If the snapshot had `*_fn_type_info`, store it on the element's
-   metadata so closures format as `<closure>`.
+The union-variant branch needs the same pattern (`codegen_tostring.cpp:200-230`, post-#836). The **ADT variant field-load path** in `getOrCreateADTToStringFn()` (same file) has the same requirement — without propagation, fields like `List<Tree>` inside `Tree::Node(int, List<Tree>)` print as `""`, enums print as raw tag integers, `Option<int>` prints as `Some(Some(0))` (#1238). Call `propagateTypeMeta(fieldTypeName, fieldVal)` on each field load instead of only propagating `low_level_type_name`.
 
-The union-variant branch needs the same pattern — see the post-#836
-code in `codegen_tostring.cpp:200-230`.
+**Why**: `List` / `Map` / `Set` element loads from container data arrays produce fresh SSA `Value*` with no metadata. If the element type is itself a collection (e.g. `Map<str, List<int>>`), calling `valueToString(elem)` without propagating the inner type name falls through to the raw string-pointer path and prints empty strings or garbage. The `List` branch had this propagation pre-#811; `Map` and `Set` did not.
 
-The **ADT variant field-load path** in `getOrCreateADTToStringFn()`
-(same file) has the same requirement. #1238 surfaced this: without
-propagation, fields like `List<Tree>` inside `Tree::Node(int,
-List<Tree>)` printed as `""`, enums printed as raw tag integers,
-`Option<int>` printed as `Some(Some(0))`, and so on. Call
-`propagateTypeMeta(fieldTypeName, fieldVal)` on each field load
-instead of just propagating `low_level_type_name`.
+**Codegen-time recursion**: ADT formatting MUST go through a per-type helper function (`getOrCreateADTToStringFn`) rather than inlining the switch body at every `valueToString` call site. Inlining recurses forever at codegen time for self-referential ADTs (Tree → List<Tree> → Tree → ...). The helper caches the emitted function *before* it emits the body, so subsequent references resolve to an ordinary IR `call`. Do not revert to an inline body.
 
-**Codegen-time recursion**: ADT formatting MUST go through a per-type
-helper function (`getOrCreateADTToStringFn`) rather than inlining the
-switch body at every `valueToString` call site. Inlining would recurse
-forever at codegen time for self-referential ADTs (Tree → List<Tree> →
-Tree → …). The helper caches the emitted function *before* it emits
-the body, so subsequent references resolve to an ordinary IR `call`
-and codegen terminates. Do not revert this to an inline body.
-
-**How to verify before opening a PR**:
+**How to verify**:
 
 ```bash
 grep -nE 'CreateLoad.*elem|CreateLoad.*valVal|CreateLoad.*fval' src/codegen_tostring.cpp
 ```
 
-For each hit, confirm that a metadata snapshot + `propagateTypeMeta`
-call follows within ~5 lines, or that the outer container has no
-corresponding `*_type_name` metadata slot (e.g. fixed-length arrays).
+For each hit, confirm a metadata snapshot + `propagateTypeMeta` call follows within ~5 lines, or that the outer container has no corresponding `*_type_name` metadata slot (e.g. fixed-length arrays).
 
 ### wrapInUnion must disambiguate same-LLVM-type variants by metadata
 
-**Source**: #836 sweep (discovered while fixing union collection variants)
+**Source**: #836 sweep
 **Tags**: codegen, union, variant-dispatch, collection, metadata
 
-**Context**: `src/codegen_match.cpp::wrapInUnion` originally picked the
-first variant whose LLVM type matched the value's LLVM type. For unions
-like `List<int> | Map<str, int>` this always picks the first variant
-because both are `ptrTy_`, so a `Map` value gets wrapped with tag=0
-(List) and is then interpreted as a List at dispatch time, producing
-garbage output. This bug was invisible before #836 because the formatter
-rejected collection variants entirely.
+**Rule**: When matching a value to a union component, resolve in three passes: (1) reconstruct the full source-level type name from the value's metadata via `buildTypeNameFromMeta()` and match against `componentNames` exactly — handles same-kind variants like `List<int> | List<str>`; (2) fall back to coarse kind match (`isListTypeName` / `isMapTypeName` / `isSetTypeName` / `isFunctionTypeName`) against the same metadata fields — handles cases where canonical name couldn't be built (literals without annotations, aliases); (3) fall back to LLVM-type equality. The value's `CodeGen::ValueMetadata` fields (`list_elem`, `list_elem_type_name`, `map_key` / `map_value` / `map_value_type_name`, `set_elem` / `set_elem_type_name`, `fn_type_info`) are the source of truth.
 
-**Rule**: When matching a value to a union component, resolve in three
-passes: (1) reconstruct the full source-level type name from the value's
-metadata via `buildTypeNameFromMeta()` and match it against
-`componentNames` exactly — this handles same-kind variants like
-`List<int> | List<str>`; (2) fall back to coarse kind match
-(`isListTypeName` / `isMapTypeName` / `isSetTypeName` /
-`isFunctionTypeName`) against the same metadata fields — this handles
-cases where the canonical name couldn't be built (literals without
-annotations, aliases); (3) fall back to LLVM-type equality. The value's
-`CodeGen::ValueMetadata` fields (`list_elem`, `list_elem_type_name`,
-`map_key` / `map_value` / `map_value_type_name`, `set_elem` /
-`set_elem_type_name`, `fn_type_info`) are the source of truth.
+**Why**: `wrapInUnion` originally picked the first variant whose LLVM type matched. For unions like `List<int> | Map<str, int>` this always picks the first because both are `ptrTy_`, so a `Map` value gets wrapped with tag=0 (List) and is then interpreted as a List at dispatch time, producing garbage. Invisible before #836 because the formatter rejected collection variants entirely.
 
-**How to apply**: Any future dispatch that uses LLVM type equality to
-route between ptr-backed Ry types must first consult the metadata.
-`src/codegen_match.cpp::wrapInUnion()` and the
-`buildTypeNameFromMeta()` helper in `src/codegen_builtin.cpp` are the
-canonical pattern.
+**How to apply**: Any future dispatch using LLVM type equality to route between ptr-backed Ry types must first consult metadata. `src/codegen_match.cpp::wrapInUnion()` and `buildTypeNameFromMeta()` in `src/codegen_builtin.cpp` are the canonical pattern.
 
 ### Float formatter uses std::to_chars shortest round-trip, NOT %.17g
 
 **Source**: #808 sweep (2026-04-10), superseded by #1031 (2026-04-16)
 **Tags**: formatter, float, precision, tests
 
-**Context**: There are two tempting but wrong approaches for `float` →
-`string` conversion:
+**Rule**: `__ry_any_fmt_float` (`src/runtime_any.cpp`) uses `std::to_chars(buf, end, x)` overload 3 (no format arg, C++17), then appends `".0"` when the result has no decimal point, no exponent, and is not `nan`/`inf`. A parallel `__ry_any_fmt_f32` handles `f32` values with `float`-typed `to_chars` (avoids FPExt changing the shortest representation).
 
-- `%g` (= `%.6g`): rounds `0.30000000000000004` to `"0.3"`, so `print`
-  output contradicts equality comparisons (`0.1 + 0.2 == 0.3` → `false`
-  despite `print(0.1 + 0.2)` showing `"0.3"`). This was the original
-  approach, fixed in #1031.
-- `%.17g`: always 17 digits, turns `3.14` into `"3.1400000000000001"`,
-  breaking many existing tests. **Rejected** in the #808 plan.
+**Why this approach**: two tempting alternatives are wrong:
+- `%g` (= `%.6g`): rounds `0.30000000000000004` to `"0.3"`, so `print` output contradicts equality (`0.1 + 0.2 == 0.3` → `false` despite `print(0.1 + 0.2)` showing `"0.3"`). Original approach, fixed in #1031.
+- `%.17g`: always 17 digits, turns `3.14` into `"3.1400000000000001"`, breaking many existing tests. Rejected in the #808 plan.
 
-The correct approach (adopted in #1031) is **`std::to_chars(buf, end, x)`
-overload 3 (no format arg, C++17)**, which gives the *shortest* decimal
-that round-trips exactly — `"3.14"` for `3.14`, `"0.30000000000000004"`
-for `0.1 + 0.2`. No existing literal tests break.
+`std::to_chars` overload 3 gives the *shortest* decimal that round-trips exactly — `"3.14"` for `3.14`, `"0.30000000000000004"` for `0.1 + 0.2`. No existing literal tests break.
 
-**Rule**: `__ry_any_fmt_float` (`src/runtime_any.cpp`) uses
-`std::to_chars` overload 3, then appends `".0"` when the result has no
-decimal point, no exponent, and is not `nan`/`inf`. A parallel
-`__ry_any_fmt_f32` function handles `f32` values with `float`-typed
-`to_chars` (to avoid FPExt changing the shortest representation).
-
-**How to apply**: When modifying float formatting:
-- Do NOT switch to `%.17g` (breaks `"3.14"` assertions).
-- Do NOT revert to `%g` (loses precision, breaks round-trip).
-- Use `std::to_chars` overload 3 (the one with no `chars_format` arg)
-  for both `double` and `float` types separately.
-- Keep the `".0"` suffix logic: it detects `.`/`e`/`E`/`n`/`N`/`i`/`I`
-  to skip correction for nan, inf, and already-fractional values.
+**How to apply**: Do NOT switch to `%.17g` (breaks `"3.14"` assertions). Do NOT revert to `%g` (loses precision). Use `std::to_chars` overload 3 (no `chars_format` arg) for both `double` and `float` separately. Keep the `".0"` suffix logic — it detects `.`/`e`/`E`/`n`/`N`/`i`/`I` to skip correction for nan, inf, and already-fractional values.
 
 ### Diagnose type / control-flow mismatches at the frontend, never at LLVM verify
 
 **Source**: #805 / #818 / #821 sweep (2026-04-10)
 **Tags**: codegen, diagnostics, ir-verify, frontend
 
-**Context**: Three separate bugs all surfaced as cryptic LLVM IR verify
-errors (`icmp ne ptr, i0 0`, `Terminator found in the middle of a
-basic block`, `Call parameter type does not match function signature`)
-because codegen emitted invalid IR and relied on the LLVM verifier to
-flag it. Users saw LLVM internals instead of actionable messages:
-- #805: `Result<T, E>` routed to a `T`-expecting runtime call because
-  `isJsonValue()` trusted a metadata flag without checking `ptrTy_`.
-- #818: `toBool(ptr)` fell through to `ICmpNE(v, ConstantInt::get(ptrTy_,
-  0))` which LLVM printed as `icmp ne ptr, i0 0`.
-- #821: `emitExit()` created an `unreachable` terminator but did not
-  switch insertion blocks, so trailing statements emitted into a
-  terminated block.
+**Rule**: Whenever codegen is about to emit IR that depends on a type or control-flow invariant (argument type, terminator absence, block validity), check the invariant in C++ and call `codegenError(...)` with a user-facing message **before** the invalid IR is written. Never treat LLVM verification as a user-visible error surface.
 
-**Rule**: Whenever codegen is about to emit IR that depends on a type or
-control-flow invariant (argument type, terminator absence, block
-validity), check the invariant in C++ and call `codegenError(...)` with
-a user-facing message **before** the invalid IR is written. Never treat
-LLVM verification as a user-visible error surface.
+**Why**: Three bugs surfaced as cryptic LLVM IR verify errors because codegen emitted invalid IR and relied on the verifier:
+- #805: `Result<T, E>` routed to `T`-expecting runtime call because `isJsonValue()` trusted a metadata flag without checking `ptrTy_`.
+- #818: `toBool(ptr)` fell through to `ICmpNE(v, ConstantInt::get(ptrTy_, 0))` which LLVM printed as `icmp ne ptr, i0 0`.
+- #821: `emitExit()` created an `unreachable` terminator but did not switch insertion blocks, so trailing statements emitted into a terminated block.
 
-**How to verify**: grep for these smells in your change:
+**How to verify**:
 
 ```bash
-git diff origin/<base> -- 'src/**' \
-  | grep -nE 'ConstantInt::get\(.*->getType\(\)'
-git diff origin/<base> -- 'src/**' \
-  | grep -nE 'CreateUnreachable|CreateRet|CreateBr'
+git diff origin/<base> -- 'src/**' | grep -nE 'ConstantInt::get\(.*->getType\(\)'
+git diff origin/<base> -- 'src/**' | grep -nE 'CreateUnreachable|CreateRet|CreateBr'
 ```
 
-Every `ConstantInt::get(v->getType(), ...)` site must be guarded by an
-`isIntegerTy()` check. Every terminator-emitting call that is not the
-last thing in its basic block must either be followed by a new block
-creation + `SetInsertPoint`, or the caller loop must break on
-`GetInsertBlock()->getTerminator()`.
+Every `ConstantInt::get(v->getType(), ...)` site must be guarded by an `isIntegerTy()` check. Every terminator-emitting call that's not the last in its basic block must either be followed by a new block creation + `SetInsertPoint`, or the caller loop must break on `GetInsertBlock()->getTerminator()`.
 
 ### propagateTypeMeta is single-value; callers decompose tuples
 
-**Source**: #820 + #813 sweep (2026-04-11, implementation)
+**Source**: #820 + #813 sweep (2026-04-11)
 **Tags**: codegen, metadata, propagation, tuple, destructure, enum
 
-**Context**: Fixing function-return / for-loop destructure metadata
-propagation (#820, #813) required teaching `propagateTypeMeta` to
-recognize enum type names (concrete and generic templates), but
-deliberately *not* to recognize tuple type strings like
-`"(int, List<int>)"`. Tuples are not a single metadata carrier — the
-components are stored in separate bound variables during destructure,
-so the decomposition must happen at the call site that owns those
-variables (`emitTupleDestructure` in `src/codegen_stmt_loop.cpp`), not
-inside `propagateTypeMeta`. The rejected alternative was to add a
-`tuple_elem_type_names: std::vector<std::string>` field to
-`ValueMetadata`; this was declined because it would require updating
-`propagateMeta`, `hasAnyMeta`, and every metadata-copy site with no
-benefit over parsing the string once at the caller (compile-time O(n)).
+**Rule**: `propagateTypeMeta(name, val)` fills metadata for a single value. Composite types (tuples, future records) that need to split across multiple downstream values must be parsed by the caller using `splitTypeArgs`, which already understands nested `<>` and `()`.
 
-**Rule**: `propagateTypeMeta(name, val)` fills metadata for a single
-value. Composite types (tuples, future records) that need to split
-across multiple downstream values must be parsed by the caller using
-`splitTypeArgs`, which already understands nested `<>` and `()`.
+**How to apply**: When a tuple type string arrives at a destructure / unpacking site (for-loop, `let (a, b) = ...`), parse the components via `splitTypeArgs(inner)` after stripping outer parens and call `propagateTypeMeta(component[i], boundVar[i])` per bound variable. Do **not** extend `propagateTypeMeta` itself to write to a `tuple_elem_type_names` slot — keep the helper single-purpose.
 
-**How to apply**: When you see a tuple type string arriving at a
-destructure or unpacking site (for-loop, `let (a, b) = ...`), parse the
-components via `splitTypeArgs(inner)` after stripping the outer parens
-and call `propagateTypeMeta(component[i], boundVar[i])` for each
-bound variable. Do **not** extend `propagateTypeMeta` itself to write
-to a `tuple_elem_type_names` slot — keep the helper single-purpose.
+**Why**: Fixing function-return / for-loop destructure metadata propagation (#820 / #813) required teaching `propagateTypeMeta` to recognize enum type names but deliberately *not* tuple type strings like `"(int, List<int>)"`. Tuples are not a single metadata carrier — components are stored in separate bound variables during destructure, so decomposition must happen at the call site that owns those variables (`emitTupleDestructure` in `src/codegen_stmt_loop.cpp`). The rejected alternative — adding a `tuple_elem_type_names: std::vector<std::string>` field to `ValueMetadata` — would require updating `propagateMeta`, `hasAnyMeta`, and every metadata-copy site with no benefit over parsing the string once at the caller (compile-time O(n)).
 
 ### IndexExpr → FieldAccessExpr tuple metadata uses `source_type_name` as the boundary channel
 
-**Source**: #1664 (2026-05-09, implementation)
+**Source**: #1664 (2026-05-09)
 **Tags**: codegen, metadata, tuple, IndexExpr, FieldAccessExpr, source_type_name, splitTupleSig, enumerate, zip
 
-**Context**: `enumerate(xs)` / `zip(xs, ys)` / `items(m)` produce
-`List<(K, V)>` whose header carries `list_elem_type_name = "(K, V)"`.
-Reading an element with `xs[0]` already routed through
-`propagateTypeMeta(elemTypeName, elem)` in the IndexExpr List path
-(`src/codegen_expr_literal.cpp`), but per the
-"`propagateTypeMeta` is single-value; callers decompose tuples" rule
-(see entry above), `propagateTypeMeta` deliberately ignores tuple
-sigs. Without an additional channel the loaded tuple value reached
-the FieldAccessExpr numeric-index arm with no metadata; the arm
-emitted a bare `CreateExtractValue` and the field defaulted to `str`
-dispatch — `xs[0].1[0]` then raised "str does not support index
-access" at codegen.
+**Rule**: When a tuple is loaded from a `List<(K, V)>` (the only non-destructure boundary fixed by #1664), stamp the full tuple sig onto the loaded value via `getOrCreateMeta(val).source_type_name = "(K, V)"`. The downstream FieldAccessExpr numeric-index arm reads `source_type_name`, calls `splitTupleSig` to decompose, and propagates the matching component's name onto the extracted field. This mirrors the `Result<T, E>` / `Option<T>` precedent (#1638) — `source_type_name` is the lossless channel for type names that `propagateTypeMeta` cannot carry.
 
-The for-loop destructure site solves the same shape via
-`emitForBindingPattern` calling `splitTupleSig` directly and
-propagating each component to its bound variable. The expression site
-needs the same decomposition, but it cannot bind components to named
-variables — there is no destructure boundary, just a tuple SSA value
-that flows through `.0` / `.1` access.
+Other tuple-producing boundaries (function returns of `(K, V)` outside a `List`, tuple-typed record fields) are NOT covered by #1664 — extending this pattern to them is a future follow-up.
 
-**Rule**: When a tuple is loaded from a `List<(K, V)>` (the only
-non-destructure boundary fixed by #1664), stamp the full tuple sig
-onto the loaded value via
-`getOrCreateMeta(val).source_type_name = "(K, V)"`. The downstream
-FieldAccessExpr numeric-index arm reads `source_type_name`, calls
-`splitTupleSig` to decompose, and propagates the matching component's
-name onto the extracted field. This mirrors the `Result<T, E>` /
-`Option<T>` precedent (#1638) — `source_type_name` is the lossless
-channel for type names that `propagateTypeMeta` cannot carry. Other
-tuple-producing boundaries (function returns of `(K, V)` outside a
-`List`, tuple-typed record fields, etc.) are NOT covered by #1664;
-extending this pattern to them is a future follow-up — don't assume
-they already work.
+**Why**: `enumerate(xs)` / `zip(xs, ys)` produce `List<(K, V)>` with header `list_elem_type_name = "(K, V)"`. Reading via `xs[0]` routes through `propagateTypeMeta` which deliberately ignores tuple sigs (see "single-value; callers decompose tuples" entry above). Without `source_type_name` the loaded tuple reaches FieldAccessExpr's numeric-index arm with no metadata, defaults to `str` dispatch, and `xs[0].1[0]` raises "str does not support index access". The for-loop destructure site solves the same shape via `emitForBindingPattern` + `splitTupleSig`, but the expression site has no named-variable boundary — just a tuple SSA value flowing through `.0` / `.1`.
 
 **How to apply**:
 
-1. At the **stamp side** (IndexExpr List path, function return, future
-   tuple-producing boundaries), guard with
-   `elemTypeName.size() >= 2 && elemTypeName.front() == '(' &&
-   elemTypeName.back() == ')'` and stamp
-   `source_type_name = elemTypeName`. Snapshot `elemTypeName` into a
-   local `std::string` *before* calling `propagateTypeMeta` (#858
-   rehash gotcha) — already required by the existing snapshot block,
-   so reusing the local is sufficient.
+1. **Stamp side** (IndexExpr List path, function return, future tuple-producing boundaries): guard with `elemTypeName.size() >= 2 && elemTypeName.front() == '(' && elemTypeName.back() == ')'` and stamp `source_type_name = elemTypeName`. Snapshot `elemTypeName` into a local `std::string` before calling `propagateTypeMeta` (#858 rehash gotcha) — reusing the existing snapshot block's local is sufficient.
+2. **Decompose side** (FieldAccessExpr numeric-index arm): after `CreateExtractValue`, read `getMeta(obj)->source_type_name` into a local `std::string`, guard with `front() == '(' && back() == ')'`, call `splitTupleSig`, and call `propagateTypeMeta(components[idx], fieldVal)` when `idx < components.size()` and the component name is non-empty.
 
-2. At the **decompose side** (FieldAccessExpr numeric-index arm), after
-   `CreateExtractValue`, read `getMeta(obj)->source_type_name` into a
-   local `std::string`, guard with `front() == '(' && back() == ')'`,
-   call `splitTupleSig`, and call
-   `propagateTypeMeta(components[idx], fieldVal)` when
-   `idx < components.size()` and the component name is non-empty.
+**Why `source_type_name` not a new slot**: same reasoning as #820 — tuples have N downstream targets, not one. Adding `tuple_elem_type_names: std::vector<std::string>` was rejected at #820. The `source_type_name` channel already exists for `Result` / `Option`, so reusing it adds no new fields.
 
-**Why not extend `propagateTypeMeta` itself**: Same reasoning as the
-parent rule — tuples have N downstream targets, not one. Plumbing
-N-ary metadata through a single-value helper would require either a
-`tuple_elem_type_names: std::vector<std::string>` slot (rejected at
-#820) or duplicating the splitTypeArgs logic in every call site of
-`propagateTypeMeta`. The `source_type_name` channel is already in
-`ValueMetadata` for `Result` / `Option`, so reusing it for tuple sigs
-adds no new fields.
-
-**Scope note**: `enumerate` / `zip` / `items` all work end-to-end
-with this fix because their codegen sites stamp
-`list_elem_type_name = "(int, T)"` / `"(T, U)"` / `"(K, V)"`
-(`src/codegen_call.cpp` for enumerate/zip; #1659 added the
-`items(m)` stamp).
+**Scope coverage**: `enumerate` / `zip` / `items` all work end-to-end because their codegen sites stamp `list_elem_type_name = "(int, T)"` / `"(T, U)"` / `"(K, V)"` (`src/codegen_call.cpp` for enumerate/zip; #1659 added `items(m)`).
 
 ### Enum metadata propagation: list literals of enum values need a direct check
 
-**Source**: #820 sweep (2026-04-11, implementation)
+**Source**: #820 sweep (2026-04-11)
 **Tags**: codegen, list, enum, metadata, propagation
 
-**Context**: `emitExprVariant(ListExpr)` in
-`src/codegen_expr_literal.cpp` guards its `inferCollectionTypeName`
-fallback behind `if (elemTy == ptrTy_)` because list-of-list,
-list-of-map, and list-of-set all use pointer-typed elements. Simple
-enums are `i64` and ADT enums are LLVM struct values — neither is a
-pointer type — so the pointer-guarded path skipped them entirely and
-`list_elem_type_name` was never set on the list header. Consequently
-`valueToString`'s list branch (which relies on
-`propagateTypeMeta(list_elem_type_name, loaded_elem)` to rebuild enum
-metadata on each loaded element) received an empty string and printed
-the raw i64 bit pattern.
+**Rule**: When a container literal is built over a non-pointer element type that still carries *source-level* metadata (enums today, potentially small-struct values in future work), copy the element's `enum_value_type` (or equivalent) into the container's `list_elem_type_name` explicitly, **outside** the `elemTy == ptrTy_` guard. The guard exists for nested-collection tracking, not for generic metadata propagation.
 
-**Rule**: When a container literal is built over a non-pointer element
-type that still carries *source-level* metadata (enums today,
-potentially small-struct values in future work), copy the element's
-`enum_value_type` (or equivalent) into the container's
-`list_elem_type_name` explicitly, outside the `elemTy == ptrTy_`
-guard. The guard exists for nested-collection tracking, not for
-generic metadata propagation.
+**Why**: `emitExprVariant(ListExpr)` in `src/codegen_expr_literal.cpp` guards its `inferCollectionTypeName` fallback behind `if (elemTy == ptrTy_)` because list-of-list, list-of-map, and list-of-set all use pointer-typed elements. Simple enums are `i64` and ADT enums are LLVM struct values — neither is a pointer type — so the pointer-guarded path skipped them entirely and `list_elem_type_name` was never set. Consequently `valueToString`'s list branch (which uses `propagateTypeMeta(list_elem_type_name, loaded_elem)` to rebuild enum metadata) received an empty string and printed the raw i64 bit pattern.
 
-**How to verify**: grep for `if (elemTy == ptrTy_)` in container
-literal paths (`codegen_expr_literal.cpp`) and confirm each of them
-handles non-pointer elements whose metadata still needs to reach the
-container's element-type-name slot.
+**How to verify**: grep `if (elemTy == ptrTy_)` in container literal paths (`codegen_expr_literal.cpp`) and confirm each handles non-pointer elements whose metadata still needs to reach the container's element-type-name slot.
 
 ### List literals of `Result<T, E>` / `Option<T>` struct elements need an explicit `list_elem_type_name` stamp
 
-**Source**: #1570 (2026-05-04, implementation)
+**Source**: #1570 (2026-05-04)
 **Tags**: codegen, list, result, option, metadata, propagation, higher-order
 
-**Context**: `emitExprVariant(ListExpr)` in `src/codegen_expr_literal.cpp` runs
-`inferCollectionTypeName` only inside `if (elemTy == ptrTy_)`. `Result` and
-`Option` are LLVM struct values (`{i1, T, E}` / `{i1, T}`), not pointers, so
-the existing path never reaches them. Without an explicit stamp,
-`list_elem_type_name` stays empty on lists of `Result` / `Option` literals.
+**Rule**: For list literals whose element type is `Result<...>` or `Option<...>`, stamp `list_elem_type_name = "Result<inner, err>"` / `"Option<inner>"` on the header explicitly, **outside** the `elemTy == ptrTy_` guard. Recover `inner` via `buildTypeNameFromMeta(vals[0])` (which reads the metadata `propagateMeta` attached at `buildOkValue` / `buildSomeValue`), and fall back to `reverseResolveTypeName(innerTy)` for primitive payloads. Recover `err` via `reverseResolveTypeName(errTy)` only — the Err arm metadata path (#982 / #985) is unreliable for the literal-construction case where most elements are Ok.
 
-This was harmless until #1570 — `valueToString`'s case dispatch reads
-`enum_value_type` (set per-element) rather than `list_elem_type_name`, so
-the printed output was always correct. The gap surfaced when `sequence`'s
-custom emitter needed to reverse-engineer the Ok / Some payload type at
-codegen time to stamp the *output* list's `list_elem_type_name` (so
-subsequent collection ops on `Ok(outList)` dispatch correctly). With an
-empty source name there is no way to recover `T` from the LLVM struct alone
-when `T` is a ptr-typed collection (all such payloads collapse to `ptr`).
+**Why**: `Result` and `Option` are LLVM struct values (`{i1, T, E}` / `{i1, T}`), not pointers, so the pre-existing `inferCollectionTypeName` path inside `if (elemTy == ptrTy_)` never reaches them. Harmless until #1570 — `valueToString` reads `enum_value_type` (set per-element) rather than `list_elem_type_name`, so printed output was correct. The gap surfaced when `sequence`'s custom emitter needed to reverse-engineer the Ok / Some payload type at codegen time to stamp the *output* list's `list_elem_type_name` (so subsequent collection ops on `Ok(outList)` dispatch correctly). With an empty source name there's no way to recover `T` from the LLVM struct alone when `T` is a ptr-typed collection.
 
-**Rule**: For list literals whose element type is `Result<...>` or
-`Option<...>`, stamp `list_elem_type_name = "Result<inner, err>"` /
-`"Option<inner>"` on the header explicitly, outside the `elemTy == ptrTy_`
-guard. Recover `inner` via `buildTypeNameFromMeta(vals[0])` (which reads the
-metadata `propagateMeta` attached at `buildOkValue` / `buildSomeValue`),
-and fall back to `reverseResolveTypeName(innerTy)` for primitive payloads.
-Recover `err` via `reverseResolveTypeName(errTy)` only — the Err arm
-metadata path (#982 / #985) is unreliable for the literal-construction
-case where most elements are Ok.
-
-**How to apply**: Mirror the canonical site at `codegen_expr_literal.cpp`
-in `emitExprVariant(ListExpr)`, immediately after the enum-value-type stamp
-block. Future higher-order combinators on `List<Result<T,E>>` /
-`List<Option<T>>` (e.g. `traverse(f)`, `partition`) that need to construct
-output collections wrapping `T` will rely on this stamp being present.
+**How to apply**: Mirror the canonical site at `codegen_expr_literal.cpp` in `emitExprVariant(ListExpr)`, immediately after the enum-value-type stamp block. Future higher-order combinators on `List<Result<T,E>>` / `List<Option<T>>` (e.g. `traverse(f)`, `partition`) constructing output collections wrapping `T` will rely on this stamp.
 
 ### `inferCollectionTypeName` List branch must prefer stored `list_elem_type_name` over `reverseResolveTypeName`
 
-**Source**: #1094 + #1095 (2026-04-17, implementation)
+**Source**: #1094 + #1095 (2026-04-17)
 **Tags**: codegen, metadata, list, inferCollectionTypeName, reverseResolveTypeName, nested-list, tuple
 
-**Context**: The List branch of `inferCollectionTypeName`
-(`src/codegen_builtin.cpp`) originally called
-`reverseResolveTypeName(elemTy)` unconditionally.
-`reverseResolveTypeName` is lossy:
-- `ptrTy_` → `"str"` (L981 of `codegen_lambda.cpp`), so a
-  `List<List<int>>` whose middle list correctly stored
-  `list_elem_type_name = "List<int>"` had that info discarded, and the
-  outer list was annotated as `"List<str>"` instead of
-  `"List<List<int>>"` (#1095: for-loop over `outer[0][0]` ran 0 times).
-- Unnamed `StructType` (tuples) → fall-through to `"any"` (L989), so
-  a `List<List<(int,int)>>` was annotated as `"List<any>"`, bypassing
-  `emitVarDecl`'s annotation fallback and causing the second destructured
-  variable to receive wrong metadata (#1094).
+**Rule**: In `inferCollectionTypeName` (`src/codegen_builtin.cpp`), check `meta->list_elem_type_name` before falling back to `reverseResolveTypeName`. Additionally, return `""` for unnamed `StructType` elements (tuples) so callers (`emitVarDecl`'s annotation fallback, `codegen_stmt.cpp:491-512`) can derive the correct name from the source annotation. Do **not** return `""` for `ptrTy_` unconditionally — plain `List<str>` lists set no `list_elem_type_name` (string literals have no collection metadata), so returning `""` for them would break nested-list display (e.g. `toStr([["a","b"],["c"]])` prints `["",""]` instead of `[["a","b"],["c"]]`).
 
-The Map branch (`L243-250`) already prefered stored names via
-`meta->map_key_type_name` / `meta->map_value_type_name` — the List
-branch simply wasn't updated.
+**Why**: The List branch originally called `reverseResolveTypeName(elemTy)` unconditionally, which is lossy:
+- `ptrTy_` → `"str"` — `List<List<int>>` whose middle list correctly stored `list_elem_type_name = "List<int>"` had that info discarded; outer list got annotated `"List<str>"` instead of `"List<List<int>>"` (#1095: for-loop over `outer[0][0]` ran 0 times).
+- Unnamed `StructType` (tuples) → fall-through to `"any"` — `List<List<(int,int)>>` annotated as `"List<any>"`, bypassing `emitVarDecl`'s annotation fallback, giving the second destructured variable wrong metadata (#1094).
 
-**Rule**: In `inferCollectionTypeName`, check
-`meta->list_elem_type_name` before falling back to
-`reverseResolveTypeName`. Additionally, return `""` for unnamed
-`StructType` elements (tuples) so callers (`emitVarDecl`'s annotation
-fallback, `codegen_stmt.cpp:491-512`) can derive the correct name from
-the source annotation. Do **not** return `""` for `ptrTy_`
-unconditionally — plain `List<str>` lists set no `list_elem_type_name`
-(string literals have no collection metadata), so returning `""` for
-them would break nested-list display (e.g. `toStr([["a","b"],["c"]])`
-prints `["",""]` instead of `[["a","b"],["c"]]`).
+The Map branch already preferred stored names via `meta->map_key_type_name` / `meta->map_value_type_name`; the List branch wasn't updated.
 
-**How to apply**: When extending `inferCollectionTypeName` for Set or
-other container kinds, mirror the same pattern: (1) stored name first,
-(2) return `""` only for types with no canonical LLVM-to-name mapping
-(currently unnamed StructType), (3) fall back to `reverseResolveTypeName`
-for everything else.
+**How to apply**: When extending `inferCollectionTypeName` for Set or other container kinds, mirror the pattern: (1) stored name first, (2) return `""` only for types with no canonical LLVM-to-name mapping (currently unnamed StructType), (3) fall back to `reverseResolveTypeName` for everything else.
 
 ### Helper-function returns need both declared-type metadata and dynamic return metadata
 
-**Source**: #1317 (2026-04-22, implementation)
+**Source**: #1317 (2026-04-22)
 **Tags**: codegen, metadata, function-return, resource, thread
 
-**Context**: Reapplying only `propagateTypeMeta(entry->returnTypeName, callResult)`
-at user-function call sites is not enough for values whose runtime metadata
-extends beyond the declared type name. `Thread` helper returns need the
-resource kind so `threadJoin(t)` / `lockAcquire(lock)` type checks pass, but
-they may also carry dynamic metadata such as `thread_result` from
-`threadSpawn(() => 7)`. With only the declared type restored, helper returns
-compiled but `threadJoin(mkThread())` silently fell back to the Unit join path
-and produced `0` instead of `7`.
+**Rule**: Rebuild canonical metadata from the declared return type at the call site, but store dynamic return metadata in dedicated per-function slots — not by copying the full `ValueMetadata` onto `llvm::Function`. Full-copying is not branch-safe: a function with multiple `return` sites can overwrite or merge single-valued metadata like `thread_result` / `task_result` / `fn_type_info` and replay the wrong snapshot at every call site. Instead, record only the needed dynamic fields (`ThreadResult`, `TaskResult`, function-return `FnTypeInfo`) and reject inconsistent values across return branches with a compile-time error.
 
-**Rule**: Rebuild canonical metadata from the declared return type at the call
-site, but store dynamic return metadata in dedicated per-function slots — not by
-copying the full `ValueMetadata` onto `llvm::Function`. Full-copying is not
-branch-safe: a function with multiple `return` sites can overwrite or merge
-single-valued metadata like `thread_result` / `task_result` / `fn_type_info` and
-then replay the wrong snapshot at every call site. Instead, record only the
-needed dynamic fields (`ThreadResult`, `TaskResult`, function-return
-`FnTypeInfo`) and reject inconsistent values across return branches with a
-compile-time error.
+**Why**: Reapplying only `propagateTypeMeta(entry->returnTypeName, callResult)` at user-function call sites is not enough for values whose runtime metadata extends beyond the declared type name. `Thread` helper returns need the resource kind so `threadJoin(t)` / `lockAcquire(lock)` type checks pass, but they may also carry dynamic metadata such as `thread_result` from `threadSpawn(() => 7)`. With only the declared type restored, helper returns compiled but `threadJoin(mkThread())` silently fell back to the Unit join path and produced `0` instead of `7`.
 
 ### New primitive types must be wired into every type-reflection site
 
 **Source**: #825 PR review (CodeRabbit, 4 comments)
 **Tags**: codegen, primitive-type, type-reflection, generics
 
-**Context**: #825 added `Type` primitive + `typeOf` builtin. The
-main codegen path worked but `reverseResolveType()`, `inferTypeArgs()`
-(`src/codegen_fn_generic.cpp`), and `inferExprType()` (lambda
-call-site inference) were not updated. Lambdas like
-`(x: int) => typeOf(x)` inferred their return as `i64`, and generic
-inference collapsed `Type` to `any`.
+**Rule**: When adding a new primitive type, grep for existing primitives and update every site. Common sites: `reverseResolveType`, `inferExprType`, `inferTypeArgs`, `resolveType`, pretty printers, docs type tables.
 
-**Rule**: When adding a new primitive type, grep for existing
-primitives and update every site. Common sites to check:
-`reverseResolveType`, `inferExprType`, `inferTypeArgs`, `resolveType`,
-pretty printers, docs type tables.
+**Why**: #825 added `Type` primitive + `typeOf` builtin. Main codegen path worked but `reverseResolveType()`, `inferTypeArgs()` (`src/codegen_fn_generic.cpp`), and `inferExprType()` (lambda call-site inference) were not updated. Lambdas like `(x: int) => typeOf(x)` inferred return as `i64`, and generic inference collapsed `Type` to `any`.
 
 **How to verify**:
 
@@ -491,127 +195,49 @@ pretty printers, docs type tables.
 grep -nE 'i64Ty_|boolTy_|strTy_|f64Ty_' src/ include/
 ```
 
-The new type should appear wherever these existing primitives do
-(justify any exceptions explicitly).
+The new type should appear wherever these existing primitives do (justify any exceptions explicitly).
 
 ### Generic function type inference must walk TypeNode structurally, not string-match `toString()`
 
-**Source**: #823 (2026-04-11, implementation)
+**Source**: #823 (2026-04-11)
 **Tags**: codegen, generics, type-inference, unification
 
-**Context**: The original `inferTypeArgs()` in
-`src/codegen_fn_generic.cpp` compared the whole parameter type
-`toString()` against the set of type-parameter names
-(`if (typeParamSet.count(paramType))`). That check only fires when the
-parameter type *is* a bare type variable — so `fn identity<T>(x: T)`
-worked but `fn firstOf<T>(xs: List<T>)` silently produced no
-binding and the caller saw "could not infer type parameter 'T'". Every
-container, tuple, and function-type parameter was broken the same way
-because `"List<T>" != "T"`.
+**Rule**: Inference must recurse over the `TypeNode` variant (`BasicType` / `GenericType` / `TupleType` / `FnType` / `OptionalType`) and unify each type variable against the matching slice of the argument's inferred type name (`inferExprTypeName`, which already produces shaped strings like `"List<int>"`). Use `unifyTypeParam` in `src/codegen_fn_generic.cpp` as the reference walker, with `splitGenericTypeName` / `splitTupleTypeName` / `splitFunctionTypeName` helpers doing string-side splitting at top-level commas while respecting `<`, `>`, `>>`, `>>>`, parens, and brackets. Keep the LLVM-type fallback (alloca type → `reverseResolveTypeName`) for the bare-variable + scalar-argument case so existing test coverage keeps working.
 
-**Rule**: Inference must recurse over the `TypeNode` variant
-(`BasicType` / `GenericType` / `TupleType` / `FnType` / `OptionalType`)
-and unify each type variable against the matching slice of the
-argument's inferred type name (`inferExprTypeName`, which already
-produces shaped strings like `"List<int>"`). Use `unifyTypeParam` in
-`src/codegen_fn_generic.cpp` as the reference walker, with
-`splitGenericTypeName` / `splitTupleTypeName` / `splitFunctionTypeName`
-helpers doing the string-side splitting at top-level commas while
-respecting `<`, `>`, `>>`, `>>>`, parens, and brackets. Keep the
-LLVM-type fallback (alloca type → `reverseResolveTypeName`) for the
-bare-variable + scalar-argument case so existing test coverage keeps
-working.
+**Why**: The original `inferTypeArgs()` compared the whole parameter type `toString()` against the type-parameter names set (`if (typeParamSet.count(paramType))`). That check only fires when the parameter type *is* a bare type variable — `fn identity<T>(x: T)` worked but `fn firstOf<T>(xs: List<T>)` silently produced no binding ("could not infer type parameter 'T'"). Every container, tuple, and function-type parameter was broken the same way because `"List<T>" != "T"`.
 
-**How to verify**: `tests/spec/generic_infer_container.test.ry` covers
-`List`, `Map`, `Set`, tuple, nested, named-local, and cross-parameter
-unification cases. `tests/test_codegen_fail.cpp` covers the two error
-paths (empty-container "could not infer" and conflicting-bindings).
+**How to verify**: `tests/spec/generic_infer_container.test.ry` covers `List`, `Map`, `Set`, tuple, nested, named-local, and cross-parameter unification cases. `tests/test_codegen_fail.cpp` covers the two error paths (empty-container "could not infer" and conflicting-bindings).
 
 ### `inferExprTypeName` must read alloca metadata for container locals, not just primitives
 
-**Source**: #823 (2026-04-11, implementation)
+**Source**: #823 (2026-04-11)
 **Tags**: codegen, type-inference, value-metadata, generics
 
-**Context**: For a local `xs: List<int> = [1, 2, 3]`, the alloca
-carries `TypeMeta::ListElem = i64Ty_` but **not** the string field
-`list_elem_type_name` — that string is populated only for nested /
-non-primitive inner types (`List<Map<str, int>>`). When
-`inferExprTypeName(VariableExpr)` fell through to
-`reverseResolveTypeName(inferExprType(...))`, it got `ptrTy_` (the
-opaque-pointer alloca type in LLVM 15+) and returned `"str"`, which
-then caused generic inference to bind `T = str` for a list argument.
+**Rule**: In `inferExprTypeName` for `VariableExpr`, look up the alloca with `findVar(name)` and check `getTypeMeta(TypeMeta::ListElem|MapKey|MapValue|SetElem, alloca)` FIRST to build shaped names like `"List<int>"`. Only fall back to `reverseResolveTypeName(alloca->getAllocatedType())` for structs and primitives. The struct-local fallback must use `getAllocatedType()`, not the alloca's pointer type, or bounded generic calls like `get_name<T: Animal>(dog_local)` will regress to inferring `T = str`.
 
-**Rule**: In `inferExprTypeName` for `VariableExpr`, look up the alloca
-with `findVar(name)` and check `getTypeMeta(TypeMeta::ListElem|MapKey|
-MapValue|SetElem, alloca)` FIRST to build shaped names like
-`"List<int>"`. Only fall back to `reverseResolveTypeName(alloca->
-getAllocatedType())` for structs and primitives. The struct-local
-fallback must use `getAllocatedType()`, not the alloca's pointer type,
-or bounded generic calls like `get_name<T: Animal>(dog_local)` will
-regress to inferring `T = str`.
+**Why**: For a local `xs: List<int> = [1, 2, 3]`, the alloca carries `TypeMeta::ListElem = i64Ty_` but **not** the string field `list_elem_type_name` — that string is populated only for nested / non-primitive inner types (`List<Map<str, int>>`). When `inferExprTypeName(VariableExpr)` fell through to `reverseResolveTypeName(inferExprType(...))`, it got `ptrTy_` (the opaque-pointer alloca type in LLVM 15+) and returned `"str"`, which caused generic inference to bind `T = str` for a list argument.
 
 ### `inferReturnType` and `inferReturnTypeName` must be maintained in lockstep
 
 **Source**: #790 (2026-04-11, follow-up to #788)
 **Tags**: codegen, lambda, returnTypeName, inferReturnType, type-inference
 
-**Context**: `#788` added `inferExprTypeName` + `returnTypeName` propagation
-for the **expression-bodied** lambda branch in `emitExprVariant(LambdaExpr)`.
-The symmetric **block-bodied** branch only called `inferReturnType` (which
-returns `llvm::Type*` and loses `List<int>` / `Map<K,V>` shape), leaving
-`returnTypeName` empty. Downstream `propagateTypeMeta()` is gated on
-`if (!info.returnTypeName.empty())`, so collection metadata silently never
-reached the call-site alloca — breaking `result.len()` and `result[i]`
-on values returned by block lambdas with literal-collection returns.
+**Rule**: Any inference helper producing an `llvm::Type*` for a lambda/function return (`inferReturnType` + `collectReturnTypes`) must have a sibling that produces the shaped type-name string (`inferReturnTypeName` + `collectReturnTypeNames` in `src/codegen_lambda.cpp`). When you touch one, update the other. The call site in `emitExprVariant(LambdaExpr)` must populate `returnTypeName` on every inferred-return branch (expression-body AND block-body), not just one.
 
-**Rule**: Any inference helper that produces an `llvm::Type*` for a
-lambda/function return (currently `inferReturnType` + `collectReturnTypes`)
-must have a sibling that produces the shaped type-name string
-(`inferReturnTypeName` + `collectReturnTypeNames` in `src/codegen_lambda.cpp`).
-When you touch one, update the other. The call site in
-`emitExprVariant(LambdaExpr)` must populate `returnTypeName` on every
-inferred-return branch (expression-body AND block-body), not just one.
+**Why**: #788 added `inferExprTypeName` + `returnTypeName` propagation for the **expression-bodied** lambda branch. The symmetric **block-bodied** branch only called `inferReturnType` (which loses `List<int>` / `Map<K,V>` shape), leaving `returnTypeName` empty. Downstream `propagateTypeMeta()` is gated on `if (!info.returnTypeName.empty())`, so collection metadata silently never reached the call-site alloca — breaking `result.len()` / `result[i]` on values returned by block lambdas with literal-collection returns.
 
-**How to verify**: `tests/spec/lambda_collection_return.test.ry` covers
-block-bodied lambdas returning list / map / set literals and branched
-returns with consistent element types. Known limitation (tracked separately):
-returning a **local** collection variable from a block lambda still loses
-shape — see #883.
+**How to verify**: `tests/spec/lambda_collection_return.test.ry` covers block-bodied lambdas returning list / map / set literals and branched returns with consistent element types. Known limitation: returning a **local** collection variable from a block lambda still loses shape (#883).
 
 ### Lambda return-name inference must thread declared param type NAMES, not just `llvm::Type*`
 
 **Source**: #886 (2026-04-11, follow-up to #788 / #790 / #884)
 **Tags**: codegen, lambda, returnTypeName, inferExprTypeName, paramType, type-inference
 
-**Context**: `inferExprTypeName` recovers shaped collection names
-(`List<int>`, `Map<str,int>`, `Set<T>`) for local variables via `findVar(name)`
-→ `TypeMeta`. But lambda parameters are NOT yet in `scope_stack_` during
-return-type inference in `emitExprVariant(LambdaExpr)` — their allocas are
-created only after inference runs. When a lambda body returned one of its
-own parameters (`(xs: List<int>) => xs`, or the block-body equivalent),
-`findVar` missed and the fallback
-`reverseResolveTypeName(inferExprType(expr, paramTypeMap))` collapsed
-`ptrTy_` to `"str"`. The lambda's `returnTypeName` came out wrong and
-downstream `propagateTypeMeta()` skipped populating `list_elem_type_name` /
-`map_*_type_name` / `set_elem_type_name` on the call-site alloca, breaking
-`result.len()` / indexing on the returned collection.
+**Rule**: Whenever `paramTypeMap` (name → `llvm::Type*`) is built and passed to `inferExprTypeName` / `inferReturnTypeName` / `collectReturnTypeNames`, build a parallel `paramTypeNameMap` (name → resolved Ry type-name string via `resolveTypeAlias(p.type->toString())`) and thread it through the same three helpers. In the `VariableExpr` case, consult `paramTypeNameMap` BEFORE falling back to the `inferExprType` path. For nested `LambdaExpr` inside a lambda body, extend BOTH maps symmetrically. This is the parameter-side analog of "`inferReturnType` and `inferReturnTypeName` must be maintained in lockstep" — the string path needs its own data source because `llvm::Type*` is lossy for opaque-pointer collection types.
 
-**Rule**: Whenever `paramTypeMap` (name → `llvm::Type*`) is built and passed
-to `inferExprTypeName` / `inferReturnTypeName` / `collectReturnTypeNames`,
-build a parallel `paramTypeNameMap` (name → resolved Ry type-name string via
-`resolveTypeAlias(p.type->toString())`) and thread it through the same three
-helpers. In the `VariableExpr` case, consult `paramTypeNameMap` BEFORE
-falling back to the `inferExprType` path. For nested `LambdaExpr` inside a
-lambda body, extend BOTH maps symmetrically. This is the parameter-side
-analog of "`inferReturnType` and `inferReturnTypeName` must be maintained in
-lockstep" — the string path needs its own data source because `llvm::Type*`
-is lossy for opaque-pointer collection types.
+**Why**: Lambda parameters are NOT yet in `scope_stack_` during return-type inference in `emitExprVariant(LambdaExpr)` — their allocas are created only after inference runs. When a lambda body returned one of its own parameters (`(xs: List<int>) => xs`, or block-body equivalent), `findVar` missed and the fallback `reverseResolveTypeName(inferExprType(expr, paramTypeMap))` collapsed `ptrTy_` to `"str"`. The lambda's `returnTypeName` came out wrong, downstream `propagateTypeMeta()` skipped populating `list_elem_type_name` / `map_*_type_name` / `set_elem_type_name` on the call-site alloca, breaking `result.len()` / indexing on the returned collection.
 
-**How to verify**: `tests/spec/lambda_collection_return.test.ry` under the
-"lambda returning its collection parameter" describe block covers both
-expression-body and block-body returns of `List<int>`, `Map<str, int>`,
-`Set<int>`, and nested `List<List<int>>` parameters, plus a branched
-block-body case that exercises `collectReturnTypeNames` → `IfStmt` walking.
+**How to verify**: `tests/spec/lambda_collection_return.test.ry` "lambda returning its collection parameter" covers expression-body and block-body returns of `List<int>`, `Map<str, int>`, `Set<int>`, nested `List<List<int>>`, plus a branched block-body case exercising `collectReturnTypeNames` → `IfStmt` walking.
 
 ### Resolve type aliases before registry lookup or type-name equality
 
@@ -627,17 +253,15 @@ block-body case that exercises `collectReturnTypeNames` → `IfStmt` walking.
 
 **Why**: `type A = B` registers `A` only in `type_aliases_`, never in the canonical registries. A `count(name)` or `name == "str"` without alias resolution yields a false negative whenever the user writes an alias, silently breaking the language-level promise that aliases are transparent. Reviews of any diff that contains `count(...)` / `== "<name>"` against a user-supplied type name should always ask "is this resolved?".
 
----
-
 ### `weak T` header-offset dispatch requires alias resolution
 
-**Source**: #1060 (2026-04-17, implementation)
+**Source**: #1060 (2026-04-17)
 **Tags**: codegen, weak, str, StringHeader, type-alias, resolveTypeAlias, emitWeakUpgrade
 
-**Rule**: `weakInnerTypeName()` only strips the `"weak "` prefix — it does **not** resolve type aliases. Before comparing the result to `"str"` (to pick `STRING_HEADER_SIZE` vs `ARC_HEADER_SIZE`), callers must feed the result through `resolveTypeAlias`. The preferred pattern is to store the resolved name at the single write site (`codegen_stmt.cpp LetStmt`) so all downstream readers get the canonical form:
+**Rule**: `weakInnerTypeName()` only strips the `"weak "` prefix — it does **not** resolve type aliases. Before comparing the result to `"str"` (to pick `STRING_HEADER_SIZE` vs `ARC_HEADER_SIZE`), callers must feed the result through `resolveTypeAlias`. Preferred pattern: store the resolved name at the single write site (`codegen_stmt.cpp LetStmt`) so all downstream readers get the canonical form:
 
 ```cpp
-// codegen_stmt.cpp — initial let (resolve at the write site so all readers get canonical name)
+// codegen_stmt.cpp — initial let (resolve at the write site)
 std::string innerName = resolveTypeAlias(weakInnerTypeName(*annot));
 // stored into weak_inner_type_names_[ptr]
 
@@ -646,108 +270,54 @@ const std::string resolvedInner = resolveTypeAlias(innerTypeName);
 // use resolvedInner == "str" (not innerTypeName) for the two data-pointer dispatch branches
 ```
 
-**Why**: `type MyStr = str; w: weak MyStr = weak s` passes `"weak MyStr"` to `weakInnerTypeName`, yielding `"MyStr"`. Without `resolveTypeAlias`, `"MyStr" == "str"` is false → `ARC_HEADER_SIZE` (16) is used instead of `STRING_HEADER_SIZE` (24) → `emitWeakRetain`'s atomic add hits `byte_len` (at `handle−8`) instead of `strong_count` → corrupts `byte_len` → UB / wrong comparison result. Keep `weakInnerTypeName` as a pure static string-slice helper so error messages preserve the user-written alias name (not the resolved RHS).
-
----
+**Why**: `type MyStr = str; w: weak MyStr = weak s` passes `"weak MyStr"` to `weakInnerTypeName`, yielding `"MyStr"`. Without `resolveTypeAlias`, `"MyStr" == "str"` is false → `ARC_HEADER_SIZE` (16) is used instead of `STRING_HEADER_SIZE` (24) → `emitWeakRetain`'s atomic add hits `byte_len` (at `handle−8`) instead of `strong_count` → corrupts `byte_len` → UB / wrong comparison result. Keep `weakInnerTypeName` as a pure static string-slice helper so error messages preserve the user-written alias name.
 
 ### Rebuild metadata on values loaded from collection slots before recursive codegen
 
-**Source**: #736 (2026-04-14, implementation)
+**Source**: #736 (2026-04-14)
 **Tags**: codegen, metadata, equality, collection, emitComparisonOp
 
-**Rule**: `ValueMetadata` is keyed by `llvm::Value*`. When you
-`CreateLoad(elemTy, GEP(data, i))` to read an element from a `List` data pointer,
-a `Map` values slot, or any similar array-of-elements, the produced SSA value is
-fresh and has no entry in `value_metadata_`. Calls to helpers that dispatch on
-metadata — `getListElementType`, `getMapValueType`, `getSetElementType`,
-`isStringValue` — all return null/false, causing silent misclassification (e.g.,
-pointer values treated as `str` and compared via `strcmp`).
+**Rule**: `ValueMetadata` is keyed by `llvm::Value*`. When you `CreateLoad(elemTy, GEP(data, i))` to read an element from a `List` data pointer, `Map` values slot, or any array-of-elements, the produced SSA value is fresh and has no entry in `value_metadata_`. Calls to helpers that dispatch on metadata — `getListElementType`, `getMapValueType`, `getSetElementType`, `isStringValue` — return null/false, causing silent misclassification (e.g. pointer values treated as `str` and compared via `strcmp`).
 
-**Why**: `getMeta` resolves `LoadInst → pointer operand` as a convenience, but a
-`GEP`-produced pointer is itself a fresh SSA value with no entry; the resolution
-stops there.
+**How to apply**: Before passing a GEP-loaded pointer value to any helper that dispatches on metadata, call `propagateTypeMeta(outerMeta->list_elem_type_name, loaded)` (or `map_value_type_name` / `set_elem_type_name` equivalent) to reconstruct `ValueMetadata` from the parent container's stored type name. Guard with `!elemName.empty() && elemName != "str"` — `str` elements are plain `char*` pointers that `isStringValue` already handles correctly without metadata, and the type name may be empty for untyped string literals.
 
-**How to apply**: Before passing a GEP-loaded pointer value to any helper that
-dispatches on metadata, call
-`propagateTypeMeta(outerMeta->list_elem_type_name, loaded)` (or the
-`map_value_type_name` / `set_elem_type_name` equivalent) to reconstruct
-`ValueMetadata` from the parent container's stored type name.
-
-Guard the call with `!elemName.empty() && elemName != "str"` — `str` elements are
-plain `char*` pointers that `isStringValue` already handles correctly without
-metadata, and the type name may be empty for untyped string literals.
+**Why**: `getMeta` resolves `LoadInst → pointer operand` as a convenience, but a `GEP`-produced pointer is itself a fresh SSA value with no entry; resolution stops there.
 
 ### Same-element-type collection helpers must pair `setTypeMeta` with `propagateMeta`
 
-**Source**: #1205 (2026-04-19, implementation); #961 precedent (map merge)
+**Source**: #1205 (2026-04-19); #961 precedent (map merge)
 **Tags**: codegen, metadata, ListHeader, MapHeader, propagateMeta, setTypeMeta, slice, appended, take, distinct
 
-**Context**: `setTypeMeta(TypeMeta::ListElem, newHeader, elemTy)` only
-records the LLVM-level element type. Source-level string metadata
-(`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`,
-`map_value_type_name`, etc.) is NOT touched. Without it, downstream
-code that needs source-level type names (nested indexing on the result,
-`valueToString` formatting, generic dispatch) silently falls through to
-defaults and emits confusing errors like "str does not support index
-access" for a legal `slice(xs, 0, 1)[0][0]` where `xs: List<List<int>>`.
-
-**Rule**: Helpers that allocate a new collection header and copy
-elements verbatim from a source collection of the **same element type**
-(slice, take, drop, appended, distinct, …) must call BOTH:
+**Rule**: Helpers that allocate a new collection header and copy elements verbatim from a source collection of the **same element type** (slice, take, drop, appended, distinct, ...) must call BOTH:
 
 1. `setTypeMeta(TypeMeta::ListElem, newHeader, elemTy)` — LLVM type
-2. `propagateMeta(src, newHeader)` — string names, `list_elem_fn_type_info`,
-   `nested_list_elem`, `map_value_type_name`, `resource_kinds`, etc.
+2. `propagateMeta(src, newHeader)` — string names, `list_elem_fn_type_info`, `nested_list_elem`, `map_value_type_name`, `resource_kinds`, etc.
 
-`propagateMeta` is rehash-safe by construction (`src/codegen_metadata.cpp:
-125-131` calls `getOrCreateMeta(dst)` first, then re-fetches `getMeta(src)`),
-so no local snapshot is required at the call site — unlike
-`propagateTypeMeta(name, val)` which IS subject to the #858 rehash-
-invalidation gotcha documented in the entry above.
+`propagateMeta` is rehash-safe by construction (`src/codegen_metadata.cpp:125-131` calls `getOrCreateMeta(dst)` first, then re-fetches `getMeta(src)`), so no local snapshot is required at the call site — unlike `propagateTypeMeta(name, val)` which IS subject to the #858 rehash gotcha.
 
-**Canonical references**: `src/codegen_call_collection.cpp:1204-1208`
-(map merge, #961), `src/codegen_call_collection.cpp:555-558`
-(`emitListSlice`, #1205), `src/codegen_expr.cpp:emitListConcat`
-(list `+` concat, #1648), `src/codegen_call_higher_order.cpp:emitBuiltinHigherOrder`
-(`filter` `List<T>` → `List<T>`, #1651), `src/codegen_call_higher_order.cpp:emitSortCore`
-(`sort` `List<T>` → `List<T>`, #1651), `src/codegen_call_string.cpp:emitStrOp_reverse`
-(List branch `List<T>` → `List<T>`, #1651), and `src/codegen_call_set_ops.cpp`
-(`emitSetUnionCore`, `emitSetOp_intersection`, `emitSetOp_difference`,
-`emitSetOp_symmetric_difference` — all `Set<T>` × `Set<T>` → `Set<T>`, #1651;
-the redundant `set_elem_type_name` copy block at each set-op site was deleted because
-`propagateMeta` already copies that field — see `src/codegen_metadata.cpp:158`).
+**Why**: `setTypeMeta` only records the LLVM-level element type. Source-level string metadata (`list_elem_type_name`, `list_elem_fn_type_info`, `nested_list_elem`, `map_value_type_name`, etc.) is NOT touched. Without it, downstream code needing source-level type names (nested indexing on the result, `valueToString` formatting, generic dispatch) silently falls through to defaults — `slice(xs, 0, 1)[0][0]` where `xs: List<List<int>>` raises confusing "str does not support index access".
 
-**How to apply**: When adding or reviewing a collection helper that
-returns `List<SameT>` / `Map<SameK, SameV>` / `Set<SameT>`, confirm the
-trailing `setTypeMeta` block is followed by `propagateMeta(src,
-newHeader)`. Helpers that change element type (`flatten`, `enumerate`,
-`zip`, `map`) need a different approach — see the `enumerate`/`zip`
-precedent in `src/codegen_call.cpp:366-443` that manually constructs
-`list_elem_type_name = "(T1, T2)"`.
+**Canonical references**: map merge (#961), `emitListSlice` (#1205), list `+` concat (#1648), `filter` / `sort` / `reverse` List branch (#1651), all set ops (#1651, `emitSetUnionCore` / intersection / difference / symmetric_difference). The redundant `set_elem_type_name` copy block at each set-op site was deleted because `propagateMeta` already copies that field (`src/codegen_metadata.cpp:158`).
+
+**How to apply**: When adding or reviewing a collection helper returning `List<SameT>` / `Map<SameK, SameV>` / `Set<SameT>`, confirm the trailing `setTypeMeta` block is followed by `propagateMeta(src, newHeader)`. Helpers that change element type (`flatten`, `enumerate`, `zip`, `map`) need a different approach — see the `enumerate` / `zip` precedent in `src/codegen_call.cpp:366-443` that manually constructs `list_elem_type_name = "(T1, T2)"`.
 
 ### `propagateTypeMeta`: handle both `Option<T>` prefix and `T?` suffix — they are the same type
 
-**Source**: #1003 (2026-04-16, bugfix); extended by #1015 (2026-04-16, `extractGenericTypeArg` in `codegen_match.cpp`)
+**Source**: #1003 (2026-04-16); extended by #1015 (`extractGenericTypeArg` in `codegen_match.cpp`)
 **Tags**: codegen, metadata, option, shorthand, list_elem, propagateTypeMeta, OptionalType, extractGenericTypeArg
 
-**Rule**: Whenever you add or modify a code path that recognises `"Option<..."` as a prefix string, also handle the `"T?"` suffix form. `OptionalType::toString()` (`src/type_node.cpp:51-52`) emits the `"?"` suffix form, and `OverloadEntry::returnTypeName` stores it verbatim. So functions declared as `-> List<int>?` have `returnTypeName = "List<int>?"`, not `"Option<List<int>>"`. A branch that only checks `resolved.compare(0, 7, "Option<")` will silently skip `T?` returns.
+**Rule**: Whenever you add or modify a code path that recognises `"Option<..."` as a prefix string, also handle the `"T?"` suffix form. `OptionalType::toString()` (`src/type_node.cpp:51-52`) emits the `?` suffix form, and `OverloadEntry::returnTypeName` stores it verbatim. Functions declared as `-> List<int>?` have `returnTypeName = "List<int>?"`, not `"Option<List<int>>"`. A branch that only checks `resolved.compare(0, 7, "Option<")` will silently skip `T?` returns.
 
-**How to apply**: After the `Option<T>` branch, add an `else if (resolved.size() > 1 && resolved.back() == '?')` branch that strips the `?` and recurses: `propagateTypeMeta(resolved.substr(0, resolved.size() - 1), val)`. See `src/codegen_builtin.cpp:169-173` (added #1003) and the earlier precedent in `src/codegen_arc_gc.cpp:136-138`. The `resolveTypeAlias` function is a pure string map lookup and cannot produce `?`-suffixed strings for non-optional aliases (the lexer tokenises `?` as a standalone `Question` token, so identifiers cannot contain it), making the `resolved.back() == '?'` guard safe.
+**How to apply**: After the `Option<T>` branch, add `else if (resolved.size() > 1 && resolved.back() == '?')` that strips the `?` and recurses: `propagateTypeMeta(resolved.substr(0, resolved.size() - 1), val)`. See `src/codegen_builtin.cpp:169-173` (#1003) and earlier precedent `src/codegen_arc_gc.cpp:136-138`. `resolveTypeAlias` is a pure string map lookup and cannot produce `?`-suffixed strings (the lexer tokenises `?` as a standalone `Question` token, so identifiers cannot contain it), making the `resolved.back() == '?'` guard safe.
 
-**Known parallel gaps**: `src/codegen_match.cpp` (`extractGenericTypeArg`) was resolved in #1015 — both `Option<T>` prefix and `T?` suffix are now handled, ensuring the typed ARC retain path (Path 2a in `emitPatternBindingArc`) is taken for `SomePattern`. The remaining gap is `src/codegen_stmt.cpp:430`, which checks `ann.substr(0, 7) == "Option<"` when propagating collection metadata from a variable's explicit type annotation. That gap only matters when the RHS value carries no metadata of its own (e.g., `x: List<int>? = None`). Since `None` contains no collection, any subsequent index on `x` would raise a runtime unwrap error before metadata is needed — so the practical impact is negligible. Track in a future issue if a concrete regression is found.
+**Known parallel gaps**: `extractGenericTypeArg` in `codegen_match.cpp` resolved in #1015 (both forms handled, ensuring the typed ARC retain path — Path 2a in `emitPatternBindingArc` — is taken for `SomePattern`). `src/codegen_stmt.cpp:430` checks `ann.substr(0, 7) == "Option<"` when propagating collection metadata from a variable's annotation — gap only matters when RHS carries no metadata (e.g. `x: List<int>? = None`); since `None` contains no collection, any subsequent index raises a runtime unwrap error before metadata is needed. Track in a future issue if a concrete regression is found.
 
 ### `low_level_type_name` mix check: convert empty metadata to "int" before comparing
 
-**Source**: PR #1063 (CodeRabbit review). **Tags**: codegen, type-metadata, checked-arithmetic, mix-check
+**Source**: PR #1063 (CodeRabbit review)
+**Tags**: codegen, type-metadata, checked-arithmetic, mix-check
 
-The three-way guard `!lhsName.empty() && !rhsName.empty() && lhsName != rhsName` is
-insufficient when one side is bare `int` (empty metadata) and the other is a named low-level
-type (e.g. `"i64"`): both conditions involving emptiness are false, so the mix silently passes.
-
-**Why**: `getLowLevelTypeName` returns `""` for `int` (no `low_level_type_name` metadata). The
-three-way check only fires when *both* names are non-empty.
-
-**How to apply**: Map empty metadata to a display sentinel before comparing:
+**Rule**: Map empty metadata to a display sentinel before comparing low-level type names:
 
 ```cpp
 const std::string &lhsLL = getLowLevelTypeName(lhs);
@@ -758,259 +328,120 @@ if (lhsName != rhsName)
     codegenError(callee + "() cannot mix " + lhsName + " and " + rhsName);
 ```
 
-Two bare `int` args (`"int" == "int"`) correctly pass; `int`+`i64` (`"int" != "i64"`) is caught.
+**Why**: `getLowLevelTypeName` returns `""` for `int` (no `low_level_type_name` metadata). The three-way guard `!lhsName.empty() && !rhsName.empty() && lhsName != rhsName` only fires when both names are non-empty — so `int` (empty) + `i64` ("i64") silently passes. Two bare `int` args (`"int" == "int"`) correctly pass; `int` + `i64` (`"int" != "i64"`) is caught.
 
-**Corollary — testing int vs. low-level mix**: A bare literal `1` alongside `1i64` may be
-coerced to `i64` by type inference, so `checkedAdd(1, 1i64)` appears to succeed. Use typed
-variables (`a = 1; b: i64 = 2i64`) to force the mix in tests.
+**Corollary — testing int vs. low-level mix**: A bare literal `1` alongside `1i64` may be coerced to `i64` by type inference, so `checkedAdd(1, 1i64)` appears to succeed. Use typed variables (`a = 1; b: i64 = 2i64`) to force the mix in tests.
 
 ### `/` is always float + IEEE 754; `//` and `%` are integer and error on zero
 
-**Source**: #1023 (2026-04-16, implementation)
+**Source**: #1023 (2026-04-16)
 **Tags**: codegen, operators, ieee754, division, floor-div, modulo
 
-**Rule**: The `/` operator always returns `float` and follows IEEE 754 for
-zero divisors — `x / 0` → `±inf` (sign follows the dividend), `0 / 0` → `nan`.
-Do NOT add an integer zero-division guard to the `/` branch of
-`emitArithmeticOp` (`src/codegen_expr.cpp:1333`) or to the `(Int, Int)`
-branch of `__ry_any_div` (`src/runtime_any.cpp:229`).
+**Rule**: `/` always returns `float` and follows IEEE 754 for zero divisors — `x / 0` → `±inf` (sign follows dividend), `0 / 0` → `nan`. Do NOT add an integer zero-division guard to the `/` branch of `emitArithmeticOp` (`src/codegen_expr.cpp:1333`) or the `(Int, Int)` branch of `__ry_any_div` (`src/runtime_any.cpp:229`).
 
-The integer-semantics operators `//` and `%` do error on zero divisor
-(`src/codegen_expr.cpp:1318,1364` and `__ry_any_floordiv` / `__ry_any_mod`).
-Low-level native-width integer `/` and `%` (`i32`, `u8`, …) also error
-(`src/codegen_expr.cpp:1170-1178`) because they are true integer division,
-not float-promoted.
+The integer-semantics operators `//` and `%` DO error on zero divisor (`src/codegen_expr.cpp:1318,1364` and `__ry_any_floordiv` / `__ry_any_mod`). Low-level native-width integer `/` and `%` (`i32`, `u8`, …) also error (`src/codegen_expr.cpp:1170-1178`) because they are true integer division, not float-promoted.
 
-Issue #754 previously added an int-specific guard to `/` that contradicted
-the "always float" spec; #1023 reverts that decision for `/` while keeping
-integer semantics (and the guards) for `//` and `%`.
+Issue #754 previously added an int-specific guard to `/` that contradicted the "always float" spec; #1023 reverted that for `/` while keeping integer semantics (and the guards) for `//` and `%`.
 
 ### Implicit int↔float coercion is annotation-driven and limited to assignment-like sites
 
-**Source**: #1192 (2026-04-19, implementation)
+**Source**: #1192 (2026-04-19), extended by #1195 (return values), #1232 (FPToInt)
 **Tags**: codegen, type-coercion, narrowing, widening, int, float, coerceToLowLevelType, applyCompoundOp
 
-**Rule**: High-level `int` and `float` variables accept cross-type values
-implicitly at **var decl**, **reassign**, and **compound assign** sites. The
-fix lives in two places — `coerceToLowLevelType`
-(`src/codegen_call_user.cpp`) adds f64→i64 / i64→f64 branches for var decl
-and reassign, and `applyCompoundOp` (`src/codegen_stmt_misc.cpp`) adds the
-same pair for compound assign, propagating automatically to all 8 call sites
-(scalar local/global + 3 field-assign branches + array/map/list element).
-Narrowing uses `CreateFPToSI` (truncation toward zero, same as `x as int`).
+**Rule**: High-level `int` and `float` variables accept cross-type values implicitly at **var decl**, **reassign**, and **compound assign** sites. The fix lives in two places — `coerceToLowLevelType` (`src/codegen_call_user.cpp`) adds f64→i64 / i64→f64 branches for var decl and reassign; `applyCompoundOp` (`src/codegen_stmt_misc.cpp`) adds the same pair for compound assign, propagating to all 8 call sites (scalar local/global + 3 field-assign branches + array/map/list element). Narrowing uses `CreateFPToSI` (truncation toward zero, same as `x as int`).
 
-**Why**: Prior to #1192, `x: int = 2 ** 3` and `x **= 2` failed because `**`
-and `/` always return `f64` (see the #1023 entry above). Forcing users to
-write `(2 ** 3) as int` everywhere was unergonomic, so we coerce at the
-receiver based on the annotation instead of changing the operator's return
-type.
+**Why**: `**` and `/` always return `f64` (see #1023), so `x: int = 2 ** 3` and `x **= 2` failed pre-#1192. Forcing users to write `(2 ** 3) as int` everywhere was unergonomic, so coerce at the receiver based on annotation instead of changing the operator's return type.
 
 **How to apply**:
-- The gate is `!isLowLevelTypeName(typeName)` in `coerceToLowLevelType` and
-  `getLowLevelTypeName(currentVal).empty()` in `applyCompoundOp`. Low-level
-  types (`i64`, `f32`, `u8`, …) never participate — they still require
-  explicit `as` casts.
-- **Do NOT** extend this to function arguments, if-expr branch unification,
-  or struct field init. Those still reject narrowing; users must write
-  `as int` at those sites. Return values **are** now coerced implicitly as of
-  #1195 (2026-04-19) — the same `coerceToLowLevelType` call is inserted in
-  both `emitStmt(ReturnStmt)` (`src/codegen_fn.cpp`, covers named fns and
-  block-body lambdas) and the lambda expression-body path
-  (`src/codegen_lambda.cpp`). Rejection tests in
-  `tests/test_codegen.cpp::IntFloatCoercionBoundaryRejections` (args only)
-  and `IntFloatCoercionReturnLowLevelStillRejected` (low-level return types)
-  guard the remaining boundaries.
-- Low-level compound assign mixing (e.g. `x: i64 = 5i64; x **= 2`) is
-  rejected upstream in `emitArithmeticOp` via `checkLowLevelTypeMix` before
-  reaching `applyCompoundOp`, **provided the loaded slot value carries its
-  container's low-level metadata**. Fixed-size arrays (`buf: i64[1]`) require
-  an explicit `propagateTypeMeta(array_elem_type_names_[ai], oldVal)` call
-  before `applyCompoundOp`, mirroring the list/map element paths. Without
-  that propagation the f64→i64 branch silently truncates. Canary
-  `IntFloatCoercionCanaryLowLevelStillRejected` exercises both
-  `x: i64 = 5i64; x **= 2` and `buf: i64[1] = [5i64]; buf[0] **= 2`.
-- `fptosi` / `fptoui` on NaN, ±inf, or out-of-range values now goes
-  through the unified `CodeGen::emitCheckedFPToInt` helper (see the
-  `Checked float→int narrowing` entry below). NaN / ±inf / out-of-range
-  inputs raise a runtime error and exit with status 1 rather than
-  producing poison.
+- The gate is `!isLowLevelTypeName(typeName)` in `coerceToLowLevelType` and `getLowLevelTypeName(currentVal).empty()` in `applyCompoundOp`. Low-level types (`i64`, `f32`, `u8`, ...) never participate — they still require explicit `as` casts.
+- **Do NOT** extend this to function arguments, if-expr branch unification, or struct field init — those still reject narrowing; users must write `as int`. Return values **are** coerced implicitly as of #1195 — same `coerceToLowLevelType` call inserted in both `emitStmt(ReturnStmt)` (`src/codegen_fn.cpp`, named fns + block-body lambdas) and the lambda expression-body path (`src/codegen_lambda.cpp`). Rejection tests in `tests/test_codegen.cpp::IntFloatCoercionBoundaryRejections` (args) and `IntFloatCoercionReturnLowLevelStillRejected` (low-level return types) guard remaining boundaries.
+- Low-level compound assign mixing (e.g. `x: i64 = 5i64; x **= 2`) is rejected upstream in `emitArithmeticOp` via `checkLowLevelTypeMix` before reaching `applyCompoundOp`, **provided the loaded slot value carries its container's low-level metadata**. Fixed-size arrays (`buf: i64[1]`) require an explicit `propagateTypeMeta(array_elem_type_names_[ai], oldVal)` before `applyCompoundOp`, mirroring list/map element paths. Without that propagation, the f64→i64 branch silently truncates. Canary `IntFloatCoercionCanaryLowLevelStillRejected` exercises `x: i64 = 5i64; x **= 2` and `buf: i64[1] = [5i64]; buf[0] **= 2`.
+- `fptosi` / `fptoui` on NaN, ±inf, or out-of-range goes through the unified `CodeGen::emitCheckedFPToInt` (see "Checked float→int narrowing" entry below). NaN / ±inf / out-of-range raise a runtime error and exit with status 1 rather than producing poison.
 
 ### Checked float→int narrowing: always go through `emitCheckedFPToInt`
 
 **Source**: #1232 (2026-04-20)
 **Tags**: codegen, conversion, runtime-check, fptosi, fptoui
 
-**Rule**: New code MUST NOT call `builder_.CreateFPToSI` or
-`builder_.CreateFPToUI` directly on a user-visible value. Use
-`CodeGen::emitCheckedFPToInt(val, targetTy, typeName, bbPrefix, siteLabel)`
-instead. The helper inserts a NaN / ±inf / range guard before the
-narrowing LLVM op and branches to `emitRuntimeError` on failure, matching
-the project-wide convention (integer overflow, division by zero, bounds
-checks) of exiting with status 1 instead of producing poison.
+**Rule**: New code MUST NOT call `builder_.CreateFPToSI` or `builder_.CreateFPToUI` directly on a user-visible value. Use `CodeGen::emitCheckedFPToInt(val, targetTy, typeName, bbPrefix, siteLabel)` instead. The helper inserts a NaN / ±inf / range guard before the narrowing LLVM op and branches to `emitRuntimeError` on failure, matching the project-wide convention (integer overflow, division by zero, bounds checks) of exiting with status 1 instead of producing poison.
 
-**Why**: LLVM `fptosi` / `fptoui` return poison (see LangRef) when the
-source is NaN, ±inf, or outside the target's representable range. Poison
-propagates silently through downstream arithmetic and is true undefined
-behavior. #1192 surfaced this in the implicit `float → int` coercion
-path, and the fix sweeps every existing FPToSI / FPToUI site
-(`src/codegen_expr_cast.cpp`, `src/codegen_call_user.cpp`,
-`src/codegen_stmt_misc.cpp`, and the math rounding path in
-`src/codegen_call.cpp`) to share one helper.
+**Why**: LLVM `fptosi` / `fptoui` return poison (LangRef) when the source is NaN, ±inf, or outside the target's representable range. Poison propagates silently through downstream arithmetic and is true UB. #1192 surfaced this in implicit `float → int` coercion; the fix sweeps every existing FPToSI / FPToUI site (`src/codegen_expr_cast.cpp`, `src/codegen_call_user.cpp`, `src/codegen_stmt_misc.cpp`, math rounding path in `src/codegen_call.cpp`) to share one helper.
 
 **How to apply**:
-- `typeName` drives signedness (via `isUnsignedLowLevelName` → `fptoui`)
-  and the error message. Pass `"int"`, `"i32"`, `"u8"`, etc.
-- `bbPrefix` names the fail/ok basic blocks and the error global;
-  keep it unique per call site (`"cast_i"`, `"cast_u8"`, `"floor_i"`, …).
-- `siteLabel` (optional) prefixes the error with call-site context, e.g.
-  `"floor()"` → `runtime error: floor(): cannot convert %g to int`.
-  Leave empty for direct `as` casts.
-- The helper accepts both f32 and f64 inputs: f32 is silently promoted
-  to f64 for the range check, and the final narrowing uses the original
-  `val` so no extra precision is lost.
-- Boundary semantics: signed W-bit uses the half-open range
-  `[-2^(W-1), 2^(W-1))`, unsigned uses `[0, 2^W)`. This correctly accepts
-  `INT64_MIN` (exactly representable in f64) while rejecting `2^63`
-  (which f64 rounds from `INT64_MAX`). Do NOT fall back to the symmetric
-  `fabs(x) >= 2^(W-1)` check — that spuriously rejects `INT64_MIN`.
-- When adapting math-style rounding (`floor` / `ceil` / `round` /
-  `trunc`), pass the **result** of the runtime call — not the input —
-  because `ceil(9.22e+18)` can round up past `INT64_MAX` even though the
-  input was representable.
+- `typeName` drives signedness (via `isUnsignedLowLevelName` → `fptoui`) and the error message. Pass `"int"`, `"i32"`, `"u8"`, etc.
+- `bbPrefix` names the fail/ok basic blocks and the error global; keep it unique per call site (`"cast_i"`, `"cast_u8"`, `"floor_i"`, ...).
+- `siteLabel` (optional) prefixes the error with call-site context, e.g. `"floor()"` → `runtime error: floor(): cannot convert %g to int`. Leave empty for direct `as` casts.
+- Helper accepts both f32 and f64: f32 is silently promoted to f64 for the range check; final narrowing uses the original `val` so no extra precision is lost.
+- **Boundary semantics**: signed W-bit uses the half-open range `[-2^(W-1), 2^(W-1))`, unsigned uses `[0, 2^W)`. Correctly accepts `INT64_MIN` (exactly representable in f64) while rejecting `2^63` (which f64 rounds from `INT64_MAX`). Do NOT fall back to symmetric `fabs(x) >= 2^(W-1)` — that spuriously rejects `INT64_MIN`.
+- When adapting math-style rounding (`floor` / `ceil` / `round` / `trunc`), pass the **result** of the runtime call — not the input — because `ceil(9.22e+18)` can round up past `INT64_MAX` even though the input was representable.
 
-**How to verify**: `grep -nE 'CreateFPTo(SI|UI)' src/ include/` should
-match only the single call inside `emitCheckedFPToInt` itself.
+**How to verify**: `grep -nE 'CreateFPTo(SI|UI)' src/ include/` should match only the single call inside `emitCheckedFPToInt` itself.
 
-**Related note**: The inverse direction (`SIToFP` / `UIToFP`) is total
-— every integer is representable in f64 modulo IEEE-754 rounding, with
-no NaN / inf / out-of-range failure mode — so no runtime check is needed.
-Do not reopen this as a separate issue.
+**Related**: The inverse direction (`SIToFP` / `UIToFP`) is total — every integer is representable in f64 modulo IEEE-754 rounding, with no NaN / inf / out-of-range failure mode — so no runtime check needed. Do not reopen as a separate issue.
 
 ### ExtractValue on Option<Collection> or Result<Collection, E> inner field drops metadata — rebuild before recursive comparison
 
-**Source**: #982 (2026-04-16, bugfix), #985 (2026-04-16, bugfix)
+**Source**: #982, #985 (2026-04-16)
 **Tags**: codegen, metadata, equality, option, result, collection, emitComparisonOp, ExtractValue
 
-**Rule**: `builder_.CreateExtractValue(val, idx)` to read the inner value from an
-`Option<T>` or `Result<T, E>` struct produces a fresh SSA value with no entry in `value_metadata_`,
-exactly like a GEP-loaded pointer. For `Option<List<T>>`, `Option<Map<K,V>>`,
-`Option<Set<T>>`, `Result<List<T>, E>`, `Result<Map<K,V>, E>`, and the symmetric
-`Result<_, List<T>>` / `Result<_, Map<K,V>>` cases, the inner LLVM type is `ptrTy_`.
-Without metadata, the recursive `emitComparisonOp` call falls through to the
-`isStringValue` + `strcmp` path and produces false-positive equality.
+**Rule**: `builder_.CreateExtractValue(val, idx)` on `Option<T>` / `Result<T, E>` produces a fresh SSA value with no entry in `value_metadata_`, like a GEP-loaded pointer. For `Option<Collection>`, `Result<Collection, E>`, and symmetric `Result<_, Collection>` cases, the inner LLVM type is `ptrTy_` — without metadata, the recursive `emitComparisonOp` call falls through to the `isStringValue` + `strcmp` path and produces false-positive equality.
 
-**Why**: `buildSomeValue` and `buildOkValue` call `propagateMeta(inner, val)`, so the
-outer `Option` / `Result` aggregate already carries `list_elem_type_name` /
-`map_*_type_name` / `set_elem_type_name`. The extracted inner is an orphan: there is
-no automatic metadata inheritance from the containing aggregate.
-`buildErrValue` also calls `propagateMeta(inner, val)` (added in #985), so
-`Result<_, Collection>` Err-payload metadata is likewise carried on the outer aggregate.
+**How to apply**: After extracting inner values, check whether element type is `ptrTy_`. If so, call `buildTypeNameFromMeta(lhs)` (or `rhs` as fallback) to snapshot the inner type name, then `propagateTypeMeta(innerName, lhsInner)` + `propagateMeta(lhsInner, rhsInner)` before the recursive comparison. Guard with `!innerName.empty() && innerName != "str"`. Snapshot into a local `std::string` **before** calling `propagateTypeMeta` (#858 rehash gotcha).
 
-**How to apply**: After extracting the inner values, check whether the element type is `ptrTy_`.
-If so, call `buildTypeNameFromMeta(lhs)` (or `rhs` as fallback) to snapshot the inner
-type name, then `propagateTypeMeta(innerName, lhsInner)` + `propagateMeta(lhsInner, rhsInner)`
-before the recursive comparison. Guard with `!innerName.empty() && innerName != "str"`.
-Snapshot into a local `std::string` **before** calling `propagateTypeMeta` to avoid
-rehash-invalidation of `ValueMetadata *` pointers (see #858 gotcha).
+**Why metadata is on the outer aggregate**: `buildSomeValue` and `buildOkValue` call `propagateMeta(inner, val)`, so the outer `Option` / `Result` aggregate carries `list_elem_type_name` / `map_*_type_name` / `set_elem_type_name`. The extracted inner is an orphan: no automatic inheritance from the containing aggregate. `buildErrValue` also calls `propagateMeta(inner, val)` (#985), so `Result<_, Collection>` Err-payload metadata is likewise on the outer aggregate.
 
-**`propagateTypeMeta` now handles `"Result<T,E>"` and `"Option<T>"` type name strings**
-(added #985): When `propagateReturnTypeMeta` is called after a function call returning
-`Result<List<int>, Error>`, `propagateTypeMeta("Result<List<int>, Error>", callResult)`
-now extracts the Ok type "List<int>" and recurses. If the Ok type is not a collection,
-it falls back to the Err type (covering the `Result<int, List<int>>` Err-payload case).
-This ensures the alloca for `a = makeResultFn()` carries `list_elem` metadata even
-without explicit type annotation, so `buildTypeNameFromMeta` can recover the type name
-at compare time.
-
-**ARC — collections inside Result/Option returned from functions** (#999, fixed):
+**`propagateTypeMeta` handles `"Result<T,E>"` and `"Option<T>"` strings** (#985): When `propagateReturnTypeMeta` is called after a function returning `Result<List<int>, Error>`, `propagateTypeMeta("Result<List<int>, Error>", callResult)` extracts the Ok type "List<int>" and recurses. If Ok is not a collection, it falls back to Err type (covers `Result<int, List<int>>` Err-payload). The alloca for `a = makeResultFn()` thus carries `list_elem` metadata even without explicit annotation, so `buildTypeNameFromMeta` can recover the type name at compare time.
 
 ### Outer `emitResultBranch` PHIs must re-propagate Ok-path metadata from inner Result values
 
-**Source**: #1315 (2026-04-23, bugfix)
+**Source**: #1315 (2026-04-23); inline retain mechanism added by #999
 **Tags**: codegen, metadata, result, emitResultBranch, phi, http, resource
 
-**Rule**: If a stdlib dispatcher first builds a metadata-carrying `Result<T, E>`
-on the success path (for example `wrapPtrAsResult(...)` + `addResourceKind(...)`)
-and then wraps that value in an **outer** `emitResultBranch(...)` for a guard such
-as NUL validation, the outer merged PHI does **not** automatically inherit the Ok-path
-metadata. Capture the successful inner Result in a local (e.g. `okIncoming`) and call
-`propagateMeta(okIncoming, mergedResult)` after the outer `emitResultBranch(...)`.
+**Rule**: If a stdlib dispatcher first builds a metadata-carrying `Result<T, E>` on the success path (e.g. `wrapPtrAsResult(...)` + `addResourceKind(...)`) and then wraps it in an **outer** `emitResultBranch(...)` for a guard such as NUL validation, the outer merged PHI does **not** automatically inherit Ok-path metadata. Capture the successful inner Result in a local (e.g. `okIncoming`) and call `propagateMeta(okIncoming, mergedResult)` after the outer `emitResultBranch(...)`.
 
-**Why**: metadata lives in `value_metadata_` keyed by SSA value. The inner success
-Result and the outer merged PHI are distinct SSA values, so the resource/collection
-kind attached to the former is invisible to later consumers such as `Ok(resp)` case
-bindings unless you copy it explicitly.
+**Why**: metadata lives in `value_metadata_` keyed by SSA value. The inner success Result and the outer merged PHI are distinct SSA values, so the resource/collection kind on the former is invisible to later consumers (e.g. `Ok(resp)` case bindings) unless explicitly copied. Concrete manifestation: `httpGet` / `httpPost` tagged the inner `wrapPtrAsResult(...)` value as `HttpClientResponse`, but an outer NUL-check `emitResultBranch(...)` returned a fresh PHI without the tag — `status(resp)` / `body(resp)` inside `case Ok(resp): ...` were rejected as non-`HttpClientResponse` arguments.
 
-**Concrete manifestation**: `httpGet` / `httpPost` / `httpRequest` tagged the
-inner `wrapPtrAsResult(...)` value as `HttpClientResponse`, but an outer NUL-check
-`emitResultBranch(...)` returned a fresh PHI without that tag. `status(resp)` and
-`body(resp)` inside `case httpGet(...): Ok(resp): ...` were then rejected as
-non-`HttpClientResponse` arguments.
-`buildOkValue` / `buildErrValue` / `buildSomeValue` now call `tryRetainArcSource(inner)`
-when `inner->getType() == ptrTy_`. This retains the collection before scope cleanup at
-fn exit can release the local variable. `tryRetainArcSource` handles three cases:
+**Inline retain in `buildOkValue` / `buildErrValue` / `buildSomeValue`** (#999): these now call `tryRetainArcSource(inner)` when `inner->getType() == ptrTy_`, retaining the collection before scope cleanup at fn exit can release the local. `tryRetainArcSource` handles three cases:
 1. `LoadInst` from an ARC-managed alloca (emits retain — the direct-param bugfix case)
 2. `arc_owned_values_` (no-op — `Ok([1, 2])` inline construction stays unaffected)
-3. `ExtractValueInst` (record/tuple field access via `CreateExtractValue`) — retains only
-   when collection metadata (`list_elem` / `map_key` / `set_elem`) is set on the value;
-   this guards against incorrectly retaining non-ARC `ptrTy_` values (closures, weak refs).
-Note: `codegen_expr.cpp` previously had a standalone `tryRetainArcSource(errVal)` after
-`buildErrValue` in the `?` operator error path. With Case 3 added, this became a
-double-retain and was removed — `buildErrValue` now handles the retain internally.
-Regression tests live in `tests/spec/result_option_arc_return.test.ry`.
+3. `ExtractValueInst` (record/tuple field access via `CreateExtractValue`) — retains only when collection metadata (`list_elem` / `map_key` / `set_elem`) is set on the value; guards against incorrectly retaining non-ARC `ptrTy_` values (closures, weak refs).
 
-**Limitation**: For `Result<List<T>, List<U>>` where both Ok and Err payloads are
-collections of different types, the metadata on the outer aggregate reflects whichever
-payload was inserted last (Ok wins in `buildOkValue` since it runs after `buildErrValue`).
-Resolving this cleanly would require per-variant metadata slots on `ValueMetadata`.
-This edge case is rare and out of scope; the common `Result<Collection, Error>` and
-`Result<_, Collection>` cases are fully covered.
+`codegen_expr.cpp` previously had a standalone `tryRetainArcSource(errVal)` after `buildErrValue` in the `?` operator error path. With Case 3 added, this became a double-retain and was removed — `buildErrValue` now handles the retain internally. Regression tests: `tests/spec/result_option_arc_return.test.ry`.
+
+**Limitation**: For `Result<List<T>, List<U>>` where Ok and Err payloads are different-typed collections, the metadata on the outer aggregate reflects whichever payload was inserted last (Ok wins in `buildOkValue` since it runs after `buildErrValue`). Resolving cleanly would require per-variant metadata slots on `ValueMetadata`. Rare edge case, out of scope.
 
 ### Empty collection literal early-return in codegen_stmt.cpp does not propagate closure/nested-type metadata
 
-**Source**: #958 (2026-04-15, implementation)
+**Source**: #958 (2026-04-15)
 **Tags**: codegen, metadata, closure, set, collection, empty-literal
 
-**Rule**: `codegen_stmt.cpp` has special early-return paths for empty collection
-literals (e.g., `a: Set<fn> = {}`, `a: List<fn> = []`) that allocate the header and
-`return` before reaching the general `if (newTy == ptrTy_)` metadata-propagation
-block (L390+). Each such early-return path must explicitly set
-`*_fn_type_info` and `*_elem_type_name` if the annotation's inner type is a closure
-or nested collection — otherwise the metadata will be missing for the variable's
-alloca, and downstream guards (e.g., the `set_elem_fn_type_info` equality rejection
-at `codegen_expr.cpp`) will silently not fire.
+**Rule**: `codegen_stmt.cpp` has special early-return paths for empty collection literals (`a: Set<fn> = {}`, `a: List<fn> = []`) that allocate the header and `return` before reaching the general `if (newTy == ptrTy_)` metadata-propagation block (L390+). Each such early-return path must explicitly set `*_fn_type_info` and `*_elem_type_name` if the annotation's inner type is a closure or nested collection — otherwise metadata is missing for the variable's alloca, and downstream guards (e.g. `set_elem_fn_type_info` equality rejection at `codegen_expr.cpp`) silently won't fire.
 
-**Why**: The empty-literal fast paths (e.g., L28-58 for Set, L102-151 for List)
-were written to handle the common primitive/record case. The L102 List path
-correctly sets `list_elem_fn_type_info` via an explicit `else if` branch. The L28
-Set path was initially missing the equivalent, causing `Set<fn> == Set<fn>` to
-compile without error instead of being rejected.
-
-**How to apply**: Whenever you add or modify an early-return empty-literal path in
-`codegen_stmt.cpp`, audit the block to ensure all of the following metadata fields
-are populated as appropriate:
+**How to apply**: Whenever you add or modify an early-return empty-literal path in `codegen_stmt.cpp`, audit the block to ensure all of the following metadata fields are populated as appropriate:
 - `setTypeMeta(TypeMeta::SetElem / ListElem / MapKey / MapValue, ptr, elemTy)`
-- `getOrCreateMeta(ptr).set_elem_type_name` (for nested collection element types)
-- `getOrCreateMeta(ptr).set_elem_fn_type_info` (for closure element types)
-- `getOrCreateMeta(ptr).map_key_type_name` / `map_key_fn_type_info` (for Map key side — added in #961; mirror of Set path)
-- The `list_*` and remaining `map_value_*` counterparts for List/Map early paths
+- `getOrCreateMeta(ptr).set_elem_type_name` (nested collection element types)
+- `getOrCreateMeta(ptr).set_elem_fn_type_info` (closure element types)
+- `getOrCreateMeta(ptr).map_key_type_name` / `map_key_fn_type_info` (Map key side, #961, mirror of Set path)
+- `list_*` and remaining `map_value_*` counterparts for List/Map early paths
+
+**Why**: empty-literal fast paths (L28-58 for Set, L102-151 for List) were written for the common primitive/record case. The L102 List path correctly sets `list_elem_fn_type_info` via an explicit `else if`. The L28 Set path was initially missing the equivalent — `Set<fn> == Set<fn>` compiled without error instead of being rejected.
 
 ### Post-hoc Result coercion: preferred over modifying Ok/Err constructors for annotation-driven type resolution
 
-**Source**: #1001 (2026-04-16, design choice); updated #1111 (2026-04-17, `anyTy_` runtime branch + both-slot bailout fix); updated #1157 (2026-04-19, disc-static provenance gate)
+**Source**: #1001 (2026-04-16, design choice); updated #1111 (`anyTy_` runtime branch + both-slot bailout fix); updated #1157 (disc-static provenance gate)
 **Tags**: codegen_stmt, coercion, Result, Ok, Err, annotation, emitVarDecl, anyTy_, type-inference
 
-**Rule**: When `Err([...])` (or `Ok(...)`) yields a Result struct whose layout does not match the variable's type annotation, fix the mismatch in `emitVarDecl`'s post-hoc coercion chain (`coerceResultType`) rather than threading the annotation down into the Ok/Err constructor emitter in `codegen_call.cpp`.
+**Rule**: When `Err([...])` (or `Ok(...)`) yields a Result struct whose layout doesn't match the variable's type annotation, fix the mismatch in `emitVarDecl`'s post-hoc coercion chain (`coerceResultType`) rather than threading the annotation down into the Ok/Err constructor emitter in `codegen_call.cpp`.
 
 **Why**: The Ok/Err constructors can be called from many contexts (function arguments, return values, inlined expressions) where the target type is unavailable or ambiguous. Post-hoc coercion at the declaration site is localised, mirrors the existing Option auto-wrap pattern.
 
 **How to apply**: `coerceResultType(val, dstResTy)` in `codegen_stmt.cpp`:
-- Compute `okNeedsRuntimeBranch` and `errNeedsRuntimeBranch` **before** the early bailout. These booleans check: `isAnyType(srcSlotTy) && !isAnyType(dstSlotTy) && dstSlotTy != i8Ty_ && canAnyHoldType(dstSlotTy)`. They must be available at the bailout call site (#1111 CodeRabbit review finding).
+- Compute `okNeedsRuntimeBranch` and `errNeedsRuntimeBranch` **before** the early bailout. These check: `isAnyType(srcSlotTy) && !isAnyType(dstSlotTy) && dstSlotTy != i8Ty_ && canAnyHoldType(dstSlotTy)`. They must be available at the bailout call site (#1111 CodeRabbit review finding).
 - **Bailout condition**: `srcOkTy != dstOkTy && srcErrTy != dstErrTy && (!okNeedsRuntimeBranch || !errNeedsRuntimeBranch)` → return `nullptr` (genuine type error). The original `both differ → nullptr` was wrong for `Result<any,any> → Result<T1,T2>`.
 - Both slots differ AND both can be anyTy_-unwrapped → emit a **runtime disc branch** (disc=1 → Ok, disc=0 → Err), `unwrapFromAny` the any-typed payload to the dst concrete type in the active path, PHI the two rebuilt structs. A compile-time slot selection silently zeroes the active payload for the wrong disc value (#1111 Manifestation 1).
-- **Single-slot mismatch — disc-static gate (#1157)**: Exactly one slot differs → **only** accept when `tryGetStaticResultDisc(val, &staticDisc)` returns true. This function walks the `InsertValueInst` chain (accounting for LLVM constant-folding of all-constant chains into `ConstantStruct`/`ConstantAggregateZero`) and recurses into `PHINode` incomings. Sources with a runtime disc (function call results, loads, mixed Ok/Err PHI) must return `nullptr` — they were silently miscompiling by zero-filling the active payload slot. Literal `Ok()`/`Err()` and if-exprs where all branches share the same disc (e.g., both Ok) remain accepted.
+- **Single-slot mismatch — disc-static gate (#1157)**: Exactly one slot differs → **only** accept when `tryGetStaticResultDisc(val, &staticDisc)` returns true. This walks the `InsertValueInst` chain (accounting for LLVM constant-folding into `ConstantStruct`/`ConstantAggregateZero`) and recurses into `PHINode` incomings. Sources with a runtime disc (function call results, loads, mixed Ok/Err PHI) must return `nullptr` — they were silently miscompiling by zero-filling the active payload slot. Literal `Ok()`/`Err()` and if-exprs where all branches share the same disc remain accepted.
 - **Placeholder types are NOT a safe signal at the LLVM level**: `Result<Unit,E>`, `Result<i8,E>`, and `Result<u8,E>` all lower to `{i1, i8, E}`. Checking `srcOkTy == i8Ty_` cannot distinguish a Unit dummy from a genuine i8 Ok payload. The disc value (static provenance) is the only reliable discriminant.
-- The `Ok` emitter (`codegen_call.cpp`) must also unwrap `anyTy_` inner to the expected ok type from `fn_->getReturnType()` when building the Result struct — otherwise two branches of an if-expr (e.g., `Ok(x)` vs `Ok(0)`) produce different Result struct types and `validateBranchTypes` rejects them (#1111 Manifestation 2, fixed alongside `inferExprType`).
+- The `Ok` emitter (`codegen_call.cpp`) must also unwrap `anyTy_` inner to the expected ok type from `fn_->getReturnType()` when building the Result struct — otherwise two branches of an if-expr (`Ok(x)` vs `Ok(0)`) produce different Result struct types and `validateBranchTypes` rejects them (#1111 Manifestation 2).
 - Add the same coercion branch to variable reassignment handlers for consistency.
 
 ### Collection element-access emitters must apply the canonical any-widening pattern
@@ -1018,90 +449,61 @@ are populated as appropriate:
 **Source**: #1029 (2026-04-16) / #1065 (2026-04-16)
 **Tags**: codegen, any, widening, collections, Map, List, Set
 
-**Rule**: Every site that reads or writes a value from/into a collection element slot must apply
-the canonical 3-branch widening pattern:
+**Rule**: Every site reading or writing a value from/into a collection element slot must apply the canonical 3-branch widening pattern. Without widening, `"x" in s` on `Set<any>` (and equivalent List / Map cases) fails with "type mismatch" even though `any` accepts implicit conversion from all primitives.
 
-Write sites (`Map` index-assign, `List` index-assign, `List.append!`, `List.appended`,
-`List.insert`, `Set.add`):
+Write sites (`Map` index-assign, `List` index-assign, `List.append!` / `appended` / `insert`, `Set.add`):
 
 ```cpp
 if (val->getType() != elemTy) {
     if (isAnyType(elemTy))
-        val = wrapInAny(val);           // concrete → any
+        val = wrapInAny(val);              // concrete → any
     else if (isAnyType(val->getType()) && canAnyHoldType(elemTy))
-        val = unwrapFromAny(val, elemTy); // any → concrete (runtime-checked)
+        val = unwrapFromAny(val, elemTy);  // any → concrete (runtime-checked)
     else
         codegenError("... type mismatch");
 }
 ```
 
-Read sites (`in` / `not in` operator — Set, Map, List membership checks in
-`src/codegen_expr.cpp`): same 3-branch pattern on the LHS element before calling
-`emitSetElementLookup` / `emitMapKeyLookup` or entering the List linear search loop.
+Read sites (`in` / `not in` operator — Set, Map, List membership in `src/codegen_expr.cpp`): same 3-branch pattern on the LHS element before calling `emitSetElementLookup` / `emitMapKeyLookup` or entering the List linear search loop.
 
 For `List` index-assign, the existing `tryEmitSubtypeCoerce` check must remain first.
 
-**Additional rule for inline linear search loops with `anyTy_` elements**: The List `in`
-operator uses an inline loop with a per-type comparison cascade. After widening, if
-`listElemTy` is `anyTy_`, the `icmp eq` / `fcmp oeq` path is invalid (LLVM rejects `icmp eq`
-on `{i64, [8 x i8]}` struct values — see entry `Set<any> element comparison requires
-emitAnyBinaryOp`, below). Hoist scratch allocas for `__ry_any_eq` **outside** the loop
-(mirroring `emitSetElementLookup` at `src/codegen_builtin.cpp:387-436` and
-`emitMapKeyLookup` at `src/codegen_builtin.cpp:440-508`). Do **not** call `emitAnyBinaryOp`
-inside the loop — it creates two allocas per call and does not hoist.
+**Additional rule for inline linear search loops with `anyTy_` elements**: List `in` uses an inline loop with a per-type comparison cascade. After widening, if `listElemTy` is `anyTy_`, the `icmp eq` / `fcmp oeq` path is invalid (LLVM rejects `icmp eq` on `{i64, [8 x i8]}` struct values — see "Set<any> element comparison" entry below). Hoist scratch allocas for `__ry_any_eq` **outside** the loop (mirroring `emitSetElementLookup` at `src/codegen_builtin.cpp:387-436` and `emitMapKeyLookup` at `:440-508`). Do **not** call `emitAnyBinaryOp` inside the loop — it creates two allocas per call and does not hoist.
 
-**Why**: Without widening, `"x" in s` on `Set<any>` (and the equivalent List / Map cases)
-fails with "type mismatch" even though `any` accepts implicit conversion from all primitives.
-
-**Files**: `src/codegen_stmt_misc.cpp` (map + list index-assign),
-`src/codegen_call_collection.cpp` (add, append, appended, insert), and
-`src/codegen_expr.cpp` (`in` / `not in` Set / Map / List branches).
-When adding a new collection mutation or membership emitter, apply this pattern immediately.
+**Files**: `src/codegen_stmt_misc.cpp` (map + list index-assign), `src/codegen_call_collection.cpp` (add, append, appended, insert), `src/codegen_expr.cpp` (`in` / `not in` Set / Map / List branches). When adding a new collection mutation or membership emitter, apply this pattern immediately.
 
 ### `Set<any>` element comparison requires `emitAnyBinaryOp`, not `emitComparisonOp`
 
 **Source**: #1029 (2026-04-16)
 **Tags**: codegen, any, Set, emitSetElementLookup, LLVM, icmp
 
-**Rule**: `anyTy_` is a 16-byte struct `{i64 tag, [8 x i8] data}`. The `[8 x i8]`
-array field cannot be used as an operand to `icmp eq` — LLVM IR verification rejects it.
+**Rule**: `anyTy_` is a 16-byte struct `{i64 tag, [8 x i8] data}`. The `[8 x i8]` array field cannot be used as an operand to `icmp eq` — LLVM IR verification rejects it. In `emitSetElementLookup` (`src/codegen_builtin.cpp`), when `isAnyType(elemTy)`, replace `emitComparisonOp("==", elem, cand, "", "")` with `emitAnyBinaryOp("==", elem, cand)`, which calls `__ry_any_eq` at runtime.
 
-In `emitSetElementLookup` (`src/codegen_builtin.cpp`), when `isAnyType(elemTy)`,
-replace `emitComparisonOp("==", elem, cand, "", "")` with
-`emitAnyBinaryOp("==", elem, cand)`, which calls `__ry_any_eq` at runtime.
-
-The linear-scan path is taken automatically for `anyTy_` because it is a `StructType`
-(`llvm::isa<llvm::StructType>(elemTy)` is true), so no additional predicate is needed.
-
----
+The linear-scan path is taken automatically for `anyTy_` because it is a `StructType` (`llvm::isa<llvm::StructType>(elemTy)` is true), so no additional predicate is needed.
 
 ### `List<T>` annotations must preserve named pointer-backed inner types for index-load metadata rebuilds
 
-**Source**: #1320 (2026-04-22, implementation). **Tags**: codegen, metadata, list, index, annotation, JsonValue, resource
+**Source**: #1320 (2026-04-22)
+**Tags**: codegen, metadata, list, index, annotation, JsonValue, resource
 
 **Rule**: When recording `list_elem_type_name` from a `List<T>` annotation, preserve every non-primitive inner type name except `str` (which must keep using the `list_elem_is_str` side-channel from #1266). Limiting the stored name to nested collections/functions misses pointer-backed named types like `JsonValue` and stdlib resources (`Lock`, `RWLock`, etc.), so `xs[i]` cannot rebuild the loaded element's metadata via `propagateTypeMeta()`.
 
 **How to apply**: In `emitVarDecl`, after handling `str` and function-typed inners, assign `list_elem_type_name = inner` for any inner type other than `int` / `float` / `bool`. This keeps index loads, loop bindings, and other metadata-reconstruction sites able to restore resource kinds or JSON dispatch metadata from the annotation even when the loaded LLVM type is just `ptr`.
 
----
-
 ### For-loop multi-variable destructure and `Set<X>` annotation propagation both trailed the List path until #1350
 
-**Source**: #1350 (2026-04-24, implementation). **Tags**: codegen, for-loop, destructure, set, tuple, metadata, set_elem_type_name
+**Source**: #1350 (2026-04-24)
+**Tags**: codegen, for-loop, destructure, set, tuple, metadata, set_elem_type_name
 
-**Rule**: Two asymmetries between the Set and List codepaths were latent until the multi-variable destructure case surfaced them:
+**Rule**: Two asymmetries between Set and List codepaths must be kept in sync:
 
-1. **Multi-variable for-loop binding path** (`src/codegen_stmt_loop.cpp` multi-var branch) treated "not a map" as "must be a list" and emitted `"for loop destructuring requires a list of tuples"` for any `Set<(T, U)>`. The single-variable path (same file, single-var branch) had already mirrored the Set-first / List-fallback shape via `getSetElementType` + `setHeaderTy_` with `getListElementType` + `listHeaderTy_` as fallback. Multi-var must use the exact same shape — switch the local `headerTy` variable between `setHeaderTy_` and `listHeaderTy_`, set snapshot metadata to `TypeMeta::SetElem` vs `TypeMeta::ListElem`, and prefer `set_elem_type_name` over `list_elem_type_name` when reading the tuple source name for `emitForBindingPattern`. `List` / `Set` headers share field 0 (len) and field 2 (data ptr), so existing GEP arithmetic is reusable.
+1. **Multi-variable for-loop binding** (`src/codegen_stmt_loop.cpp` multi-var branch): use the same Set-first / List-fallback shape as the single-var path — switch local `headerTy` between `setHeaderTy_` and `listHeaderTy_`, set snapshot metadata to `TypeMeta::SetElem` vs `TypeMeta::ListElem`, prefer `set_elem_type_name` over `list_elem_type_name` when reading the tuple source name for `emitForBindingPattern`. List/Set headers share field 0 (len) and field 2 (data ptr), so existing GEP arithmetic is reusable. Pre-#1350 the multi-var branch treated "not a map" as "must be a list" and emitted `"for loop destructuring requires a list of tuples"` for any `Set<(T, U)>`.
 
-2. **`Set<X>` annotation → `set_elem_type_name` propagation** in `codegen_stmt.cpp`'s `emitVarDecl` narrowed the inner type to `{List|Map|Set|FnType}`, so named non-primitive tuple/enum/record/alias inners were dropped. The sibling `List<X>` path (#1320) had already switched to a denylist (`inner != "str" && inner != "int" && inner != "float" && inner != "bool"`). Mirror that denylist on Set, otherwise `Set<(str, List<int>)>` annotations never carry `"(str, List<int>)"` down to the for-loop, and `sum(v)` in the destructured body fails with "sum() requires a list" even after the codegen_stmt_loop fix is in place.
+2. **`Set<X>` annotation → `set_elem_type_name` propagation** in `codegen_stmt.cpp`'s `emitVarDecl`: use the denylist (`inner != "str" && inner != "int" && inner != "float" && inner != "bool"`) — same as List (#1320). Pre-#1350 this narrowed inner type to `{List|Map|Set|FnType}`, dropping named non-primitive tuple/enum/record/alias inners. Without the fix, `Set<(str, List<int>)>` annotations never carry `"(str, List<int>)"` down to the for-loop, and `sum(v)` in the destructured body fails with "sum() requires a list" even with codegen_stmt_loop fixed.
 
-**Why**: These are the same class of asymmetry: every time a List-side enhancement lands (destructure dispatch, annotation denylist widening), the Set-side equivalent should be ported in the same PR unless there is a concrete reason to diverge. The List/Set iteration machinery deliberately shares header layout, so divergent codepaths are a code smell.
+**Why**: Same class of asymmetry — every time a List-side enhancement lands (destructure dispatch, annotation denylist widening), the Set-side equivalent should be ported in the same PR unless there's a concrete reason to diverge. List/Set iteration machinery deliberately shares header layout, so divergent codepaths are a code smell.
 
 **How to apply**:
-
-- Before declaring a List-specific fix complete, grep for sibling `getSetElementType` / `setHeaderTy_` / `set_elem_type_name` sites and check whether the same logic belongs there.
-- The single-variable for-loop path (L324-407) is the canonical Set-first / List-fallback template; new iteration features should mirror both simultaneously.
-- Test both collection-destructure shapes (`for a, b in listOfTuples`, `for a, b in setOfTuples`) whenever a binding-related for-loop change lands.
-- Follow-up candidate: extract the shared `(elemTy, headerTy, typeName, headerMetaKind)` lookup into a helper so multi-var and single-var paths stop growing copy-paste in parallel. Not blocking for v0.0.13, but worth filing if another divergence shows up.
-
----
+- Before declaring a List-specific fix complete, grep sibling `getSetElementType` / `setHeaderTy_` / `set_elem_type_name` sites and check whether the same logic belongs there.
+- The single-variable for-loop path (L324-407) is the canonical Set-first / List-fallback template; mirror both simultaneously for new iteration features.
+- Test both shapes (`for a, b in listOfTuples`, `for a, b in setOfTuples`) whenever a binding-related for-loop change lands.

--- a/.claude/rules/docs-reference-conventions.md
+++ b/.claude/rules/docs-reference-conventions.md
@@ -12,319 +12,133 @@ paths:
 **Source**: #825 PR review (CodeRabbit)
 **Tags**: documentation, syntax
 
-**Context**: #825 docs used `val x: i32 = 1` — the `val` keyword does
-not exist in Ry; the actual syntax is `x: i32 = 1`. The snippet was
-written from memory (probably by analogy to Scala/Kotlin) and never
-verified.
+**Rule**: Don't write doc examples from memory. Either (a) copy a working example from `tests/spec/*.test.ry`, or (b) verify the snippet with `printf '...\n' | ./build/ry -c` before committing.
 
-**Rule**: When writing doc examples, don't rely on memory. Either
-(a) copy a working example from an existing `tests/spec/*.test.ry`, or
-(b) verify the snippet with `printf '...\n' | ./build/ry -c` before committing.
-
-**How to verify**: in `docs/reference/` PRs, grep for keywords that
-don't exist in Ry's lexer:
-
+**How to verify**: grep for non-Ry keywords (the `val`-from-Scala/Kotlin trap):
 ```bash
 grep -nE '\bval\b|\bvar\b|\bpublic\b|\bprivate\b' docs/reference/*.md
 ```
 
 ### `@native` declarations can silently drift from their dispatcher implementation
 
-**Source**: #889 docs audit
+**Source**: #889 / #890 docs audit
 **Tags**: stdlib, native, codegen, drift
 
-**Context**: During a docs audit, `docs/reference/collections.md` was
-suspected of being wrong because `share/std/list.ry` declared
-`removeAt(...) -> Unit` while the docs described a return value.
-Investigation showed the opposite was true: `CodeGen::emitCollOp_remove_at`
-(`src/codegen_call_collection.cpp`) actually returns the removed element,
-and `tests/spec/collections.test.ry` has long asserted on it
-(`v = removeAt(xs, 1); expect(v).toEq(2)`). The `-> Unit` declaration
-in `list.ry` was the bug — it had been ignored by the custom dispatcher
-for so long that nobody noticed.
-
-**Rule**: The declared signature in `share/std/*.ry` is **not** the
-source of truth for `@native` functions that go through a hand-written
-codegen dispatcher (`src/codegen_call_*.cpp`). The dispatcher can —
-and for historical reasons does — produce a different shape than the
-declaration. Before treating a declaration as spec, cross-check the
-dispatcher and the tests.
+**Rule**: The declared signature in `share/std/*.ry` is **not** the source of truth for `@native` functions that go through a hand-written codegen dispatcher (`src/codegen_call_*.cpp`) or a custom emitter. The dispatcher can — and historically does — produce a different shape than the declaration; type inference at the call site consults dispatcher metadata (`setTypeMeta(TypeMeta::ListElem, …)`), not the declared return type.
 
 **How to apply**:
-- When docs disagree with a `@native` signature, diff all three: the
-  declaration file, the dispatcher in `src/codegen_call_*.cpp`, and an
-  existing test in `tests/spec/`. The test's assertions reveal the
-  actually observable return shape.
-- If the declaration is wrong, fix the declaration rather than the
-  docs or the tests; the dispatcher/test pair is the de-facto contract.
-- Consider this whenever you audit or regenerate stdlib signatures.
+- When docs disagree with a `@native` signature, diff all three: declaration / dispatcher / `tests/spec/`. The test's assertions reveal the actually observable shape.
+- If the declaration is wrong, fix the declaration (the dispatcher/test pair is the de-facto contract).
+- Watch for drift in any `emitBuiltin*` helper that calls `setTypeMeta(TypeMeta::ListElem, …, tupleTy)` where `tupleTy` is a `StructType`.
 
-**Follow-up audit (#890)**: A systematic sweep of every `@native`
-declaration in `share/std/**/*.ry` against its dispatcher uncovered two
-more drifts of the same shape and fixed all three:
+**Audit scope** (#890 sweep): drift is possible only in **Pattern A2** (table entries with `customEmitter`, bypassing type checking per `codegen_call_native.cpp:135-149`) and **Pattern B** (hand-written `emitBuiltin*` helpers that never consult the sig). Pattern C (`emitGenericNativeCall`, infers wrapping from the declaration) cannot drift by construction. Pattern A1 (table-driven w/ `ReturnWrapping` enum, no custom emitter) is validated against the sig. Drifts found and fixed: `map.items` (`List<int>` → `List<(str, int)>`), `enumerate` / `zip` (same shape).
 
-| Declaration | Was | Correct |
-|---|---|---|
-| `share/std/map.ry` `items(Map<str, int>)` | `List<int>` | `List<(str, int)>` |
-| `share/std/builtins.ry` `enumerate(List<int>)` | `List<int>` | `List<(int, int)>` |
-| `share/std/builtins.ry` `zip(List<int>, List<int>)` | `List<int>` | `List<(int, int)>` |
-
-In all three the dispatcher (`src/codegen_call.cpp` `emitBuiltinQuery`
-for `enumerate`/`zip`, `src/codegen_call_collection.cpp:925`
-`emitCollOp_items` for `items`) builds an `llvm::StructType::get(ctx,
-{T1, T2})` tuple and calls
-`setTypeMeta(TypeMeta::ListElem, newHeader, tupleTy)`. Type inference at
-the call site consults the dispatcher's `ListElem` metadata, not the
-declaration's return type — which is exactly why these drifts survived
-so long: the compiler silently ignores `pairs: List<int> = enumerate(xs)`
-and lets you call `pairs[0].0` on it without complaint. The declaration
-is dormant documentation, not a gate. **Watch for this drift class in
-any `emitBuiltin*` helper that calls `setTypeMeta(TypeMeta::ListElem,
-..., tupleTy)` where `tupleTy` is a `StructType`.**
-
-**Audit scope limits**: Pattern C (generic fallback, e.g. `base64`,
-`filesystem`, `gc` — `emitGenericNativeCall` infers wrapping from the
-declaration's return type) cannot drift by construction and was skipped.
-Pattern A1 entries (table-driven with `ReturnWrapping` enum but no
-`customEmitter`, e.g. `io`) are validated against the sig's return type
-and got only a spot check. The audit focused on Pattern A2 (table
-entries with `customEmitter`, which bypass type checking per
-`codegen_call_native.cpp:135-149`) and Pattern B (hand-written
-`emitBuiltin*` helpers that never consult the sig). Those are the two
-places where drift is actually possible.
-
-**Polymorphism constraint**: Ry declaration syntax has no generics /
-`List<T>` / `Any`, so polymorphic collection ops (`list::filter`,
-`list::map`, `map::keys`, etc.) will keep using monomorphic placeholder
-element types like `List<int>` even when the dispatcher is
-element-type-agnostic. Only drifts where the **structural shape** is
-wrong (`List<int>` vs `List<tuple>`, `Unit` vs `int`) are actionable
-until generics land. Don't re-chase placeholder-only inaccuracies as
-drift.
+**Polymorphism caveat**: Ry has no `List<T>` / `Any` in declaration syntax, so polymorphic ops (`list::filter`, `map::keys`) keep monomorphic placeholder element types. Only **structural-shape** drift (`List<int>` vs `List<tuple>`, `Unit` vs `int`) is actionable until generics land — don't chase placeholder-only inaccuracies.
 
 ### For heterogeneous return types on custom-emitter natives, use `any` as the declaration placeholder
 
 **Source**: #1135
-**Tags**: `stdlib, @native, codegen, type-declaration, hygiene`
+**Tags**: stdlib, @native, codegen, type-declaration, hygiene
 
-When a custom-emitter native can return multiple concrete types at runtime
-(e.g. `threadSpawn` / `threadJoin` which return `Unit`, `int`, `float`,
-or `bool` depending on the worker body), the declaration in
-`share/std/**/*.ry` cannot use a true generic — several options fail:
+**Rule**: When a custom-emitter native returns multiple concrete types at runtime (e.g. `threadSpawn` / `threadJoin` returning `Unit`/`int`/`float`/`bool`), use `any` in the declaration. `any` resolves cleanly via `src/codegen_type.cpp:23` at both top-level and generic-arg positions (`Result<any, Error>`, `fn() -> any`). The custom emitter still drives runtime dispatch through `TypeMeta` — `any` is never consulted at codegen time.
 
+**Why other options fail**:
 | Option | Why it fails |
 |---|---|
-| `<T>` generic | `src/codegen_fn.cpp:471-481` diverts any function with `type_params` into `generic_fn_templates_` and returns early — no `NativeFnSignature` is registered, breaking dispatch |
+| `<T>` generic | `src/codegen_fn.cpp:471-481` diverts to `generic_fn_templates_` and returns early — no `NativeFnSignature` registered |
 | Bare `T` at top-level | `src/codegen_type.cpp:160-162`: `resolveType` fails for unbound identifier |
-| `fn() -> T` nested | Parser free-pass (interior not validated), but the identifier is semantically meaningless — fragile |
-| Overloads differing only in return type | `src/codegen_fn.cpp:531-545` dedupes on param types only; the second declaration is silently dropped |
+| `fn() -> T` nested | parser free-pass but semantically meaningless |
+| Overloads differing only in return type | `src/codegen_fn.cpp:531-545` dedupes on param types only; second decl silently dropped |
 
-**Rule**: Use `any` as the hygienic placeholder. `any` resolves cleanly via
-`src/codegen_type.cpp:23` at both top-level and generic argument positions
-(e.g. `Result<any, Error>`, `fn() -> any`). The custom emitter still
-drives actual runtime type dispatch through `TypeMeta` metadata — `any` in
-the declaration is never consulted at codegen time.
-
-**Precedent for `any` at generic argument position**: `tests/spec/any.test.ry`
-uses `Map<str, any>` and `List<any>` in 30+ places; `src/parser_decl.cpp:159`
-uses `any` as the default element type for inferred collections. `Result<any, Error>`
-was introduced by #1135 as a new pattern, but the surrounding type machinery
-already handled `any` as a generic argument.
-
-**Annotation in the `.ry` file**: Add a top-of-file comment explaining the
-`any` ↔ `T` spelling gap, e.g.:
+**Annotation**: add a top-of-file comment in the `.ry` file so future readers don't "fix" `any` back to `Unit`:
 ```ry
-# `any` in threadSpawn / threadJoin declarations below stands in for `T`
-# in docs/reference/thread.md. The runtime narrows the actual type to
-# Unit / int / float / bool via TypeMeta::ThreadResult metadata.
+# `any` here stands in for `T`; runtime narrows via TypeMeta::ThreadResult.
 ```
-This prevents future readers from "fixing" `any` back to `Unit`.
 
 ### Ry has soft keywords that are NOT in the lexer `keyword_map`
 
-**Source**: #1118 PR 1 docs audit
+**Source**: #1118 PR 1
 **Tags**: documentation, syntax, lexer
 
-**Context**: Auditing `docs/reference/types.md` found `weak` described as "a keyword".
-`src/lexer.cpp` keyword_map contains only hard keywords. `weak` is handled in
-`parser_expr.cpp:463` and `parser_decl.cpp:726` as a contextual identifier
-(`t.kind == TokenKind::Ident && t.value == "weak"`). Other examples:
-`None`, `Some`, `Ok`, `Err` (variant constructors), and `_` (wildcard) are
-similarly soft — they are legal variable names and only gain special meaning
-in specific syntactic positions.
-
-**Rule**: When writing or auditing docs, do **not** call soft keywords "keywords".
-Use "contextual identifier" instead, or describe the syntax without labeling the
-token class.
-
-**How to verify**: Check `src/lexer.cpp`'s `keyword_map` (lines 35–66). If the
-token is not there, it is not a reserved keyword — the parser must be checking
-`t.value == "..."` explicitly to give it special meaning.
+**Rule**: `weak`, `None`, `Some`, `Ok`, `Err`, `_` are **contextual identifiers**, not reserved keywords. The lexer's `keyword_map` (`src/lexer.cpp:35-66`) contains only hard keywords; soft ones are matched by `t.kind == TokenKind::Ident && t.value == "..."` in the parser. When auditing or writing docs, use "contextual identifier", not "keyword". Verify by grepping `keyword_map` — if absent, it's not reserved.
 
 ### Low-level integer types have different arithmetic semantics from `int`
 
-**Source**: #1118 PR 1 docs audit
+**Source**: #1118 PR 1
 **Tags**: documentation, types, operators
 
-**Context**: `operators.md` described `/` as "always float, IEEE 754". This is
-correct for high-level `int`/`float` operands, but for low-level integer types
-(`i8`..`i64`, `u8`..`u64`) `/` performs **integer division** and returns the
-same type (`7i32 / 2i32` → `3i32`). Mixing a low-level type with `int` in the
-same expression is a compile-time type error.
-
-**Rule**: When auditing or writing docs for arithmetic operators, always
-spot-check behavior with low-level integer types using `./build/ry -c`:
-
+**Rule**: For low-level int types (`i8..i64`, `u8..u64`), `/` performs **integer division** and returns the same type (`7i32 / 2i32` → `3i32`); `+`, `-`, `*`, `%`, `//` similarly produce the same type without promotion. Mixing with `int` is a compile-time type error. The "always float / IEEE 754" description applies only to high-level `int`/`float`. Spot-check with:
 ```bash
 printf 'print(7i32 / 2i32)\nprint(typeOf(7i32 / 2i32))' | ./build/ry -c -
 ```
 
-The pattern extends to `+`, `-`, `*`, `%`, `//` — all produce the same type
-without promotion when both operands are low-level integers.
-
 ### `docs/reference/` directory paths in prose can silently drift when source layout changes
 
-**Source**: #1118 PR 2 docs audit
+**Source**: #1118 PR 2
 **Tags**: documentation, drift, stdlib
 
-**Context**: `docs/reference/directives.md` referred to `core/*.ry` as the location of
-`@native` prelude declarations (e.g. `core/builtins.ry`, `core/str.ry`). The actual
-layout has been `share/std/` for a long time (e.g. `share/std/builtins.ry`). No `core/`
-directory exists. The prose survived because it was never executed — only read.
-
-**Rule**: When auditing stdlib-adjacent docs (PR 3–5 of #1118), grep for hardcoded
-directory names in prose and verify them against the actual filesystem:
-
+**Rule**: Hardcoded directory names in prose (e.g. `core/*.ry`) drift when the source layout changes (actual: `share/std/`). Prose is read but never executed — drift is invisible until audit. When auditing stdlib-adjacent docs, grep + `ls`:
 ```bash
 grep -rn 'core/' docs/reference/
-ls share/std/           # verify actual layout
+ls share/std/
 ```
-
-If a table lists filenames or paths, run `ls` on the claimed directory before trusting it.
 
 ### CLI flag value sets can drift between doc pages independently
 
-**Source**: #1118 PR 2 docs audit
+**Source**: #1118 PR 2
 **Tags**: documentation, drift, CLI
 
-**Context**: `project.md` global options table listed `--env=<env>` as accepting
-`production|development|internal` (3 values). `packages.md` RY_ENV table had
-5 values (`prod`, `dev`, `test`, `staging`, `internal`) plus their aliases. The
-authoritative source is `src/dotenv.cpp:resolveRyEnv` + `src/cli.cpp` help text.
-
-**Rule**: When two doc pages both describe the same CLI flag or env var value set,
-verify they are consistent with each other AND with the implementation. Quick check:
-
-```bash
-# Find all pages that mention --env or RY_ENV
-grep -rn 'env\|RY_ENV' docs/reference/ | grep -v '\.env\.'
-# Check implementation's documented values
-grep -n 'env.*=.*\|' src/cli.cpp | head -10
-```
+**Rule**: When two doc pages describe the same CLI flag or env var value set (e.g. `project.md` listed 3 values for `--env`, `packages.md` listed 5 for `RY_ENV`), verify they match each other AND the implementation (`src/dotenv.cpp:resolveRyEnv` + `src/cli.cpp` help text).
 
 ### Runtime errors in stdlib dispatchers must be mirrored in docs/reference/
 
-**Source**: #1118 PR 3 docs audit
+**Source**: #1118 PR 3
 **Tags**: documentation, drift, stdlib
 
-**Context**: During the PR 3 audit of `docs/reference/{builtins,collections,math}.md`, several
-runtime (and compile-time) errors emitted inside `src/codegen_call_*.cpp` were found to be
-completely absent from the corresponding reference pages. Examples found:
-
-| Error message | Emitter location |
-|---|---|
-| `runtime error: reduce() on empty list` | `codegen_call_higher_order.cpp:237` |
-| `runtime error: min() on empty list` | `codegen_call_higher_order.cpp:480` |
-| `runtime error: max() on empty list` | `codegen_call_higher_order.cpp:480` |
-| `runtime error: floor(): cannot convert %g to int` (also `ceil()`, `round()`, `trunc()`) | `codegen_call.cpp` math path via `emitCheckedFPToInt` |
-| `flatten() requires a list of lists` (compile) | `codegen_call_collection.cpp` |
-| `fold() initial value type must match function return type` (compile) | `codegen_call_higher_order.cpp:291-294` |
-
-**Rule**: When auditing stdlib docs (PR 3–5 of #1118), grep all `codegenError()` and
-`runtime error:` strings in `src/codegen_call_*.cpp` and `src/runtime_*.cpp`, then verify
-each is mentioned (at least as a brief note) in the matching docs page:
-
+**Rule**: Many `codegenError()` and `runtime error: ...` strings in `src/codegen_call_*.cpp` are missing from corresponding `docs/reference/` pages (e.g. `reduce()/min()/max() on empty list`, `floor(): cannot convert %g to int`, `flatten() requires a list of lists`, `fold() initial value type must match...`). When auditing stdlib docs:
 ```bash
 grep -rn '"runtime error:' src/codegen_call_*.cpp src/runtime_*.cpp
 grep -rn 'codegenError' src/codegen_call_*.cpp | grep '"' | grep -v '//'
 ```
-
-Cross-check each hit against the corresponding `docs/reference/*.md` page. Missing ones are α drift.
-
-### Cross-check operator-level specs before flagging per-file code examples as drift
-
-**Source**: #1118 PR 4 docs audit
-**Tags**: documentation, audit, drift, operators
-
-**Context**: During PR 4 audit of `docs/reference/base64.md`, a code example using
-`?` at the top level was initially flagged as drift ("top-level `?` is a compile error").
-However, `docs/reference/operators.md:165-177` explicitly documents that `?` and `!!` work
-at the top level (Err maps to exit 1 with error message). The implementation in
-`src/codegen_expr.cpp:1861-1895` confirms this with a dedicated top-level `?` desugar path.
-The false alarm arose because only per-package docs were consulted, not the canonical
-operator spec.
-
-**Rule**: When a per-file doc example uses a language operator (`?`, `!!`, `case`, `@`
-directives, etc.), do NOT judge it solely by analogy with how that operator appears in
-fn bodies. Always:
-1. Check `docs/reference/operators.md` for the full spec (including top-level usage rules).
-2. Cross-check `src/codegen_expr.cpp` or the relevant codegen for the operator's desugar
-   behavior in different contexts (function body vs. top level vs. lambda).
-
-**How to verify**: For `?` operator specifically, the top-level desugar constraint is
-`src/codegen_expr.cpp:1873-1874`: the `Err` type must be `Error` exactly.
+Cross-check each hit against the matching docs page.
 
 ### Regenerate enumerated doc tables from implementation, not by hand
 
-**Source**: #1118 PR 5 docs audit
+**Source**: #1118 PR 5
 **Tags**: documentation, audit, drift, http, enumerated-tables
 
-**Context**: `__ry_http_reason_phrase` in `src/runtime_http.cpp:639-696` had 50 `case` statements, but `docs/reference/http.md` listed only 38 status codes — 12 were silently missing (402, 407, 412, 418, 421, 425, 428, 431, 451, 507, 508, 511).
-
-**Rule**: When the implementation contains an enumerated list (status code switch, kind string registry, format specifier table) that is mirrored in a documentation table, **regenerate the doc table from the implementation** rather than hand-editing. For HTTP status codes specifically:
-
+**Rule**: When the implementation has an enumerated list (status code switch, kind string registry, format specifier table) mirrored in docs, **regenerate the table from the implementation**. `__ry_http_reason_phrase` had 50 cases; docs listed 38 (12 silently missing). For HTTP:
 ```bash
 grep -nE '^\s*case [0-9]+:' src/runtime_http.cpp
 ```
-
-gives the authoritative list; compare it against the `docs/reference/http.md` table before declaring clean. Apply the same pattern to any other enumerated registry (error kind strings, format specifiers, etc.).
-
-**How to verify**: Count `case` statements in the switch vs. rows in the doc table. A mismatch always signals drift.
+Apply the same to any other enumerated registry. Mismatched count of `case` vs doc rows always signals drift.
 
 ### Canonical-source pattern for deduplicating reference doc sections
 
-**Source**: #1125 (2026-04-18)
+**Source**: #1125
 **Tags**: documentation, dedup, drift, builtins, collections
 
-**Rule**: When two reference pages redundantly describe the same function with full sections (signature + description + examples), pick one as canonical and reduce the other to a stub (`heading + signature + "See also" link`), not parallel bodies. Link stubs to per-function anchors where they exist; fall back to the parent section anchor when heading punctuation (e.g. `!`) would collide with an existing anchor after GitHub slugification (GitHub strips `!`, so `## sort!` → `#sort` which collides with `## sort`). Precedent: `docs/reference/functions.md:778`.
+**Rule**: When two reference pages describe the same function with full sections (signature + description + examples), pick one as canonical and reduce the other to a stub (`heading + signature + "See also" link`). Never parallel bodies. Precedent: `docs/reference/functions.md:778`; `collections.md` is canonical for `filter`/`map`/`sort`/`sort!`/`reverse!`/`appended`/`append!`, with `builtins.md` as stubs.
 
-**Context**: `builtins.md` and `collections.md` both fully described `filter`, `map`, `sort`, `sort!`, `reverse!`, `appended`, `append!` (~200 lines of drift-prone parallel content). After #1125, `collections.md` is canonical; `builtins.md` sections are stubs. The quick-reference table in `builtins.md` stays (it is a useful at-a-glance index) with an umbrella note under the section header pointing to the canonical page.
+**Anchor collision**: bang variants (`sort!`, `reverse!`, `append!`) must link to the parent section anchor (e.g. `#in-place-mutating-variants`), not a per-function anchor. GitHub slugifies `### sort!` to `#sort` — collides with `### sort`. Don't link to `#sort!`; the parent section is the correct fallback.
 
-**Anchor collision detail**: Bang variants (`sort!`, `reverse!`, `append!`) must link to the parent section (e.g. `#in-place-mutating-variants`) rather than a per-function anchor, because GitHub slugifies `### sort!` to `#sort` — identical to the slug for `### sort`. Stubs for these functions must not link to `#sort!` or similar; the parent section anchor is the correct fallback.
+### Doc-wide identifier migrations need multi-pattern sweeps, not just `fn` declarations
 
-### Doc-wide identifier migrations need multi-pattern sweeps, not just `fn ` declarations
-
-**Source**: #1444 (2026-04-30)
+**Source**: #1444
 **Tags**: documentation, migration, audit, naming, sweep
 
-**Context**: When migrating `docs/reference/*.md` from snake_case to camelCase to match the parser's v0.0.16 enforcement, the initial sweep only matched `fn xxx_yyy` declarations. That found most cases, but missed (a) **variable assignments** like `add_base = ...`, `light_spd = 2.998E8`, `fn_val: fn(int) -> int`, `max_u64: u64 = ...`; (b) **record fields and `require/ensure` locals** like `new_balance`, `min_balance`; (c) **function-call expressions inside text** like `dynamic_value()`, `kind(name_val)`; (d) **inline-code metalanguage placeholders** like `<fn_name>` in `__ry_<libname>_<fn_name>`, `param_type1/param_type2` in `fn(...)` syntax templates; and (e) **error-kind table example columns** like `max_int + 1`. Without a broader pattern, these silently survive and produce parse errors when readers copy-paste.
-
-**Rule**: For doc-wide identifier migrations (case style, rename), run **multiple complementary greps** before declaring complete:
+**Rule**: Snake_case → camelCase (or any rename) sweeps must run **multiple complementary greps**. A `fn xxx_yyy` grep alone misses (a) variable assignments / type ascriptions, (b) record fields and `require/ensure` locals, (c) function-call expressions in prose, (d) inline-code metalanguage placeholders (`<fn_name>`, `param_type1`), (e) error-kind table example columns.
 
 ```bash
-# Pattern 1: fn declarations (parameter, return type)
+# Pattern 1: fn declarations
 grep -nE 'fn [a-z]+_[a-z]+\b' docs/reference/*.md
-
 # Pattern 2: variable assignments / type ascriptions at line start
 grep -nE '^\s*[a-z][a-zA-Z0-9]*_[a-z][a-zA-Z0-9_]*\s*[:=]' docs/reference/*.md
-
-# Pattern 3: any snake_case identifier in code-like positions (broadest, noisy)
+# Pattern 3: any snake_case in code-like positions (broadest, noisy)
 grep -nE '\b[a-z][a-zA-Z0-9]*_[a-z][a-zA-Z0-9_]*\b' docs/reference/*.md
 ```
 
-Pattern 3 needs aggressive filtering for false positives (file paths like `hello_copy.txt`, C++ binary names like `ry_tests`, env vars like `RY_ENV`, npm conventions like `node_modules`, ARC concept prose like `strong_count`/`weak_count`, HTTP form keys like `content_type`/`session_id`, historical-prose entries like `naming.md`'s rename log). Build the filter incrementally — every false positive you find is a stable filter term for future sweeps.
-
-**How to apply**: any time a doc-wide rename or convention switch is requested, run all three patterns; do not stop at pattern 1. After each batch of edits, re-run all patterns until each returns zero hits (or only filtered prose entries). Distinguish executable Ry code (must migrate) from frozen prose (`naming.md` historical contrast — keep) and language-foreign identifiers (C struct fields, npm conventions, env vars — keep).
+Pattern 3 needs aggressive false-positive filtering: file paths (`hello_copy.txt`), C++ binaries (`ry_tests`), env vars (`RY_ENV`), npm conventions (`node_modules`), ARC prose (`strong_count`/`weak_count`), HTTP form keys (`content_type`/`session_id`), historical-rename log in `naming.md`. Build the filter incrementally.
 
 → See `/horizontal-sweep` for the integrated 4-step procedure that builds on this rule.
 
@@ -333,48 +147,34 @@ Pattern 3 needs aggressive filtering for false positives (file paths like `hello
 **Source**: #1463 review (CodeRabbit)
 **Tags**: documentation, migration, naming, c-runtime, placeholder
 
-**Context**: During the #1444 snake_case → camelCase doc migration, the C-symbol convention placeholders `__ry_<libname>_<fn_name>` (in `directives.md`) and `__ry_<package>_<function_name>` (in `packages.md`) were migrated to `<functionName>` together with the rest of the sweep. CodeRabbit flagged the change because the actual C runtime symbols are inconsistent: `filesystem`/`path`/`gc`/`json` are camelCase (`__ry_filesystem_listDir`, `__ry_path_isAbsolute`, `__ry_gc_setThreshold`), but `base64` and `string` keep snake_case in the C ABI regardless of the camelCase Ry name (`base64::encodeUrlSafe` → `__ry_base64_encode_url_safe`, `string::makeUninit` → `__ry_string_make_uninit`). Migrating the placeholder to `<functionName>` made it look like a uniform rule when reality was mixed.
-
-**Rule**: When a doc-wide rename touches a **placeholder describing a contract with code outside the Ry source** (C symbol names, manifest keys, JSON field names, env var names, generated artefact names, etc.), do not assume the rename applies. Spot-check the implementation:
+**Rule**: When a doc-wide rename touches a placeholder describing a contract with code outside the Ry source (C symbol names, `manifest.json` keys, JSON field names, env vars, generated artefact names), do not assume the rename applies. The C runtime symbols are mixed: `filesystem`/`path`/`gc`/`json` are camelCase (`__ry_filesystem_listDir`), but `base64`/`string` keep snake_case in the C ABI regardless of the Ry name (`base64::encodeUrlSafe` → `__ry_base64_encode_url_safe`).
 
 ```bash
-# C runtime symbols — verify the actual emitted names
 grep -nE '__ry_[a-z]+_[a-zA-Z_]+' src/runtime_*.cpp | head -30
-
-# Look specifically for snake_case after the package prefix
-grep -nE '__ry_[a-z]+_[a-z]+_[a-z]' src/runtime_*.cpp
+grep -nE '__ry_[a-z]+_[a-z]+_[a-z]' src/runtime_*.cpp  # snake_case after prefix
 ```
 
-If reality is mixed, replace the single-form placeholder (`<functionName>` or `<fn_name>`) with a neutral term like `<symbol>` and add prose enumerating which packages follow which convention, plus an example mapping table.
-
-**How to apply**:
-- Before migrating any placeholder in `__ry_*`, `manifest.json` keys, or other ABI-adjacent strings, grep the implementation to see whether the rename actually holds.
-- If the implementation is consistent with the rename, migrate normally.
-- If the implementation is inconsistent, keep a neutral placeholder (e.g. `<symbol>`) and document the carve-outs with concrete examples.
-- This applies in both directions: snake_case → camelCase migrations *and* camelCase → snake_case (or any rename). Inline-code placeholders mirror an external contract and should reflect what the code actually does.
+If reality is mixed, replace the single-form placeholder (`<functionName>` / `<fn_name>`) with a neutral term like `<symbol>` and document the carve-outs with an example mapping. Applies in both rename directions.
 
 ### Migration notes sections drift when a release rolls out through multiple incremental issues
 
-**Source**: #1474 (2026-04-30)
+**Source**: #1474
 **Tags**: documentation, drift, migration-notes, naming, release-rollout
 
-**Context**: `docs/reference/naming.md` Migration notes initially listed only `#1443` as the enforcement source for v0.0.16 camelCase. After v0.0.16 rolled out through three follow-up issues (#1449 lambda parameters, #1450 tuple-destructure LHS, #1470 module-global typed declarations), CHANGELOG `[Unreleased]` got entries for #1450 and #1470 immediately, but the prose Migration notes paragraph still cited only #1443. Readers reading the prose as a complete list could infer that lambda parameters / tuple-destructure LHS / module-global typed decls were *not* enforced — the opposite of what the parser does. This drift was discovered only at v0.0.16 feature-complete review, not during the individual #1449 / #1450 / #1470 PRs.
+**Rule**: When a release rolls out through follow-up issues sharing a root (e.g. v0.0.16 camelCase: #1443 → #1449 / #1450 / #1470), update the corresponding Migration notes in `docs/reference/*.md` **in the same PR as each follow-up**, not a "doc cleanup at the end" PR. Reviewers should treat a follow-up enforcement PR with no `docs/reference/*.md` diff as suspicious.
 
-**Rule**: When a release is rolled out through a series of incremental enforcement / breaking-change issues that all cite a common root issue (e.g. #1443 → #1449 / #1450 / #1470), update the corresponding Migration notes section in `docs/reference/*.md` *in the same PR* as each follow-up. Do not defer to a "doc cleanup at the end" PR — that pattern is exactly how the drift in #1474 happened.
+```bash
+grep -rn '#1443' docs/reference/   # before opening a follow-up PR
+```
 
-**How to apply**:
-- When opening a PR for a follow-up enforcement issue (e.g. "extend #1443 to lambda parameters"), grep `docs/reference/*.md` for the root issue number (`grep -rn '#1443' docs/reference/`) and update every prose mention that enumerates the enforcement scope.
-- Reviewers should treat a follow-up enforcement PR with no `docs/reference/*.md` diff as suspicious — confirm whether the root issue is cited in any prose lists before approving.
-- This applies symmetrically to other rolling rollouts: stdlib rename waves, error-message format changes, etc. Any time the CHANGELOG `[Unreleased]` accumulates multiple `(#NNNN)` entries that share a common theme, check whether the corresponding `docs/reference/*.md` prose has been updated alongside them.
+Applies symmetrically to other rolling rollouts (stdlib rename waves, error-message format changes, etc.). Any time `[Unreleased]` accumulates multiple `(#NNNN)` entries sharing a theme, check the matching `docs/reference/*.md` prose.
 
 ### Terminology sweeps must include lexical derivatives, not just the canonical word
 
-**Source**: #1482 (2026-05-01)
+**Source**: #1482
 **Tags**: documentation, migration, audit, terminology, sweep
 
-**Context**: During the v0.0.17 "package" → "module" terminology sweep across `docs/reference/*.md`, the initial pass grepped only `[Pp]ackage` and produced clean edits to `directives.md`, `math.md`, `json.md`, `gc.md`, `thread.md`, `filesystem.md`, `builtins.md`, `naming.md`. A verification grep with `[Pp]kg|[Pp]ackage` then surfaced `directives.md:564` containing `pkg/mod.ry` and `from pkg import directiveName` — placeholders left over from before the rename. The shorthand `pkg` is a derivative of `package` that survives a strict `[Pp]ackage` grep.
-
-**Rule**: For terminology sweeps (renaming a concept, not just identifiers), the canonical word grep is necessary but not sufficient. Always also grep for the lexical derivatives the project uses as shorthand. Common pairs to keep in mind:
+**Rule**: For terminology sweeps (renaming a concept), the canonical-word grep (`[Pp]ackage`) is necessary but not sufficient — derivatives (`pkg`, `pkgs`) survive a strict canonical grep. The "package" → "module" sweep missed `pkg/mod.ry` and `from pkg import directiveName` placeholders in `directives.md`.
 
 | Canonical | Common derivatives |
 |-----------|--------------------|
@@ -389,59 +189,22 @@ If reality is mixed, replace the single-form placeholder (`<functionName>` or `<
 | `temporary` | `tmp` |
 | `configuration` | `config`, `cfg` |
 
-Approved abbreviations for Ry are listed in `docs/reference/naming.md` "Approved abbreviations" — that table is the right reference for which derivatives are likely to appear in code samples and inline-code placeholders inside `docs/reference/*.md`.
+Approved abbreviations for Ry are listed in `docs/reference/naming.md` "Approved abbreviations".
 
-**How to apply**:
-- After the canonical-word sweep returns zero, run a second grep that ORs the canonical word with its derivatives (e.g. `grep -nE '[Pp]kg\|[Pp]ackage' docs/reference/*.md`).
-- Repeat until the OR-pattern grep also returns zero (or only intentional carve-outs like `package.toml` manifest references).
-- Be especially careful with placeholder strings inside `<...>`-style metalanguage (e.g. `<pkg>/mod.ry`, `from <pkg> import ...`) — these are easy to miss because they are not real identifiers and do not show up in code-syntax greps.
-- This rule complements the "Doc-wide identifier migrations need multi-pattern sweeps" rule above: identifier migrations are about code-shape patterns (declarations, assignments, type ascriptions), terminology migrations are about lexical equivalences (canonical word + shorthands).
+**How to apply**: After the canonical-word sweep returns zero, run an OR-pattern grep (`grep -nE '[Pp]kg|[Pp]ackage' docs/reference/*.md`) until that also returns zero (or only intentional carve-outs like `package.toml`). Be especially careful with `<...>`-style metalanguage placeholders (`<pkg>/mod.ry`) — they don't show up in code-syntax greps. Complements the multi-pattern sweep rule above: identifier migrations are about code-shape patterns; terminology migrations are about lexical equivalences.
 
 → See `/horizontal-sweep` for the integrated 4-step procedure that builds on this rule.
 
 ### Multi-file design intent must be empirically verified before documenting
 
-**Source**: #1547 (visibility documentation)
+**Source**: #1547 / #1560
 **Tags**: documentation, design-vs-implementation, verification, multi-file, package
 
-**Context**: While writing `docs/guide/visibility.md` for #1547, the planned
-wrapper pattern (REQ-B3 from #1543: "hide a helper inside a sub-module,
-expose only a thin `@public` facade that calls through") was documented
-straight from the design intent. Self-verification with actual `.ry`
-files revealed the pattern does not work — the compiler resolves all
-symbols in a single linkage unit, and cross-package import filtering
-drops non-`@public` helpers from the importer's program before code-gen
-can see them. This was discovered only because the doc author wrote a
-multi-file layout under `/tmp/` (with `package.toml`) and ran
-`./build/ry` end-to-end. A single `./build/ry -c` snippet could not have
-surfaced it because the failure depends on cross-package import behavior.
-Tracking issue for the implementation gap: #1560.
-
-**Rule**: When documenting a feature whose behavior depends on
-**multi-file or multi-package layout** (visibility, module resolution,
-package boundaries, anonymous packages, `RY_PATH` search, relative
-imports, directory modules, etc.), do not trust the design specification
-or issue requirements alone. Construct a minimal multi-file repro under
-`/tmp/` matching the layout in the docs and run `./build/ry` to confirm
-the example works end-to-end before publishing.
+**Rule**: When documenting a feature whose behavior depends on **multi-file or multi-package layout** (visibility, module resolution, package boundaries, anonymous packages, `RY_PATH`, relative imports, directory modules), do not trust the design spec or issue requirements alone. Construct a minimal multi-file repro under `/tmp/` matching the docs and run `./build/ry` end-to-end. Single-snippet `./build/ry -c` is necessary but not sufficient — failures often depend on cross-package import behavior.
 
 **How to apply**:
-- For each example layout in `docs/guide/*.md` or in
-  `docs/reference/{modules,directives}.md` that depends on file
-  arrangement, build it under `/tmp/` and execute it with `./build/ry`.
-  Use `[project]` in `package.toml` (not `[package]`) — see the manifest
-  format in `share/std/package.toml`.
-- Test all import shapes the docs describe: selective
-  (`from foo import x`), wildcard (`from foo`), relative (`from .foo`),
-  and cross-package vs same-package callers. Failure modes can differ
-  per shape: as of v0.0.17, selective imports drop unselected helpers
-  even within the same package; wildcard imports across packages filter
-  non-`@public` symbols silently.
-- If the documented behavior diverges from observed behavior, file an
-  issue (per `/scope-out-issue`), document the discrepancy with an issue
-  link, and revise the docs to describe what works today rather than
-  what the design spec promised. Do not ship aspirational examples in a
-  user-facing guide.
-- Single-snippet `./build/ry -c` verification (the
-  "Example code in docs must match the current Ry syntax" rule above) is
-  necessary but not sufficient for multi-file scenarios.
+- Use `[project]` in `package.toml` (not `[package]`) — see `share/std/package.toml`.
+- Test all import shapes: selective (`from foo import x`), wildcard (`from foo`), relative (`from .foo`), cross-package vs same-package callers. As of v0.0.17, selective imports drop unselected helpers even within the same package; wildcard imports across packages filter non-`@public` symbols silently.
+- If documented behavior diverges from observed, file an issue (`/scope-out-issue`), link it, and revise the docs to describe what works today rather than the design spec.
+
+**Origin**: while writing `docs/guide/visibility.md` for #1547, the planned wrapper pattern (REQ-B3 from #1543) was documented straight from design intent — self-verification with actual `.ry` files revealed it doesn't work because the compiler resolves all symbols in a single linkage unit and cross-package imports drop non-`@public` helpers before code-gen. Tracked in #1560.

--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -21,92 +21,32 @@ paths:
 **Source**: #801 PR
 **Tags**: parser, lexer, delimiters
 
-**Context**: `parseFnTypeAnnotation()` originally used
-`string::find(')')` to locate the closing paren, which broke on
-nested function-typed parameters like
-`fn((int) -> int) -> int`.
-
-**Rule**: When scanning for a matching closing delimiter (`)`, `]`,
-`}`), always use a depth counter that increments on the opening and
-decrements on the closing. Never use `string::find(')')` or similar.
-Reuse `CodeGen::findMatchingCloseParen()` in `src/codegen_type.cpp`
-as the canonical helper.
+**Rule**: When scanning for a matching closing delimiter (`)`, `]`, `}`), always use a depth counter that increments on the opening and decrements on the closing. Never use `string::find(')')` or similar — it breaks on nested function-typed parameters like `fn((int) -> int) -> int`. Reuse `CodeGen::findMatchingCloseParen()` in `src/codegen_type.cpp` as the canonical helper.
 
 ### NumberExpr.value holds a non-negative bit pattern, not a signed magnitude
 
 **Source**: #807 + #819 sweep (2026-04-10)
 **Tags**: parser, codegen, numeric-literal, u64, bit-pattern
 
-**Context**: The parser accepts integer literals up to `UINT64_MAX`
-via `strtoull`, but `NumberExpr.value` is declared as `int64_t`. To
-support `u64` max literals (`18446744073709551615` = bit pattern
-`0xFFFFFFFFFFFFFFFF` = `int64_t(-1)`) without changing the AST type,
-the field is documented to store the non-negative magnitude as a bit
-pattern. The invariant breaks only if a parser site tries to be
-clever and stores a pre-negated value (e.g., the old pattern-literal
-path in `parser_decl.cpp` built `NumberExpr{-val, ""}` for `case -1:`).
-Codegen's empty-suffix emit path then cannot distinguish "legitimate
-negative from unary minus" from "overflow bit pattern >= 2^63".
+**Rule**: `NumberExpr.value` is `int64_t` storing the unsigned bit pattern of a non-negative magnitude. To support `u64` max (`18446744073709551615` = bit pattern `0xFFFFFFFFFFFFFFFF` = `int64_t(-1)`) without changing the AST type, the field stores the magnitude as a bit pattern. Negation is expressed as `UnaryExpr("-", NumberExpr{magnitude, suffix})`, the same as `parser_expr.cpp`. Any new parser site that creates a NumberExpr from a literal that may be negative MUST wrap the node in a UnaryExpr instead of storing a pre-negated `int64_t`. In codegen, interpret `static_cast<uint64_t>(value)` when the target type is unsigned, and for the empty-suffix path treat `value < 0` as "literal exceeds `INT64_MAX`" → emit a "integer literal out of range for int" error.
 
-**Rule**: `NumberExpr.value` is always the unsigned bit pattern of a
-non-negative magnitude. Negation is expressed as
-`UnaryExpr("-", NumberExpr{magnitude, suffix})`, the same as
-`parser_expr.cpp`. Any new parser site that creates a NumberExpr
-from a literal that may be negative MUST wrap the node in a UnaryExpr
-instead of storing a pre-negated `int64_t`. In codegen, interpret
-`static_cast<uint64_t>(value)` when the target type is unsigned, and
-for the empty-suffix path treat `value < 0` as "literal exceeds
-`INT64_MAX`" → emit a "integer literal out of range for int" error.
-
-**How to apply**: Never write `NumberExpr{-val, ...}`. Always wrap in
-UnaryExpr. The empty-suffix `value < 0` check in
-`src/codegen_expr.cpp::emitExprVariant(const NumberExpr &)` depends
-on this invariant — a regression would either silently accept
-`x = 18446744073709551615` (wrong i64 emit) or reject `case -1:`
-(false positive).
+**How to apply**: Never write `NumberExpr{-val, ...}`. Always wrap in UnaryExpr. The empty-suffix `value < 0` check in `src/codegen_expr.cpp::emitExprVariant(const NumberExpr &)` depends on this invariant — a regression would either silently accept `x = 18446744073709551615` (wrong i64 emit) or reject `case -1:` (false positive).
 
 ### Statement-level LHS should reuse parsePostfixContinuation, not re-implement postfix hops
 
 **Source**: #812 (2026-04-11, implementation)
 **Tags**: parser, lvalue, lhs, postfix, assignment
 
-**Context**: Before #812, `Parser::parseStatement` dispatched `Ident [ ... ]`
-and `Ident . field` with a hardcoded 1-hop switch, rejecting any chained
-form (`list[i].field = v`, `record.a.b = v`, `list[i][j] = v`, etc.) with
-"expected '=' after index expression" or "expected '=' after field name".
-The fix split `parsePostfix` into `parsePrimary` + `parsePostfixContinuation(base)`
-and drives the statement LHS by feeding a synthetic `VariableExpr` base
-into the continuation, then inspecting the chain tail (`IndexExpr` /
-`FieldAccessExpr` / `CallExpr`) to decide which `*AssignStmt` variant to
-emit.
+**Rule**: When a new statement form needs to accept the same expression shapes as an lvalue, do NOT duplicate the `.`/`[` loop in the statement parser. Extract a continuation helper from `parsePostfix` and call it from the statement entry point. Dispatch on the chain tail node (`IndexExpr` / `FieldAccessExpr` / `CallExpr`) to choose which `*AssignStmt` variant to emit. Pre-#812 the hardcoded 1-hop switch rejected `list[i].field = v`, `record.a.b = v`, `list[i][j] = v` etc. with "expected '=' after index/field name".
 
-**Rule**: When a new statement form needs to accept the same expression
-shapes as an lvalue, do NOT duplicate the `.`/`[` loop in the statement
-parser. Extract a continuation helper from `parsePostfix` and call it from
-the statement entry point. Dispatch on the chain tail node to choose the
-stmt variant.
-
-**How to apply**: Any statement that starts with `Ident` and may accept
-chained postfix hops (e.g. a future `move var.a.b into ...` or similar)
-should call `parsePostfixContinuation(baseExpr)` rather than re-parsing `.`
-and `[` inline. UFCS call statements (`ident.method(args)`) remain a
-special case detected before entering the continuation, because they
-produce a `CallStmt` rather than an `ExprStmt<CallExpr>`.
+**How to apply**: Any statement starting with `Ident` that may accept chained postfix hops (e.g. a future `move var.a.b into ...`) should call `parsePostfixContinuation(baseExpr)` rather than re-parsing `.` and `[` inline. UFCS call statements (`ident.method(args)`) remain a special case detected before entering the continuation, because they produce a `CallStmt` rather than an `ExprStmt<CallExpr>`.
 
 ### Use strtod, not std::stod, for float literal parsing
 
 **Source**: #819 sweep (2026-04-10)
 **Tags**: parser, float, scientific-notation, exception-safety
 
-**Context**: `std::stod` throws `std::out_of_range` on overflow
-(e.g., `1e400`), which crashes the frontend before diagnostics can
-be produced. #819's scope check explicitly allows overflow to
-surface as `+Inf`, matching the runtime `toFloat` converter.
-
-**Rule**: Use `std::strtod` + `errno` for parsing float literals in
-the frontend. Accept `HUGE_VAL` / `-HUGE_VAL` as valid `Inf` results
-and only treat non-zero trailing characters as errors. See
-`include/ry/parser.hpp::parseFloatLiteral`.
+**Rule**: Use `std::strtod` + `errno` for parsing float literals in the frontend. Accept `HUGE_VAL` / `-HUGE_VAL` as valid `Inf` results and only treat non-zero trailing characters as errors. `std::stod` throws `std::out_of_range` on overflow (e.g., `1e400`), which crashes the frontend before diagnostics can be produced; #819 explicitly allows overflow to surface as `+Inf`, matching the runtime `toFloat` converter. See `include/ry/parser.hpp::parseFloatLiteral`.
 
 ---
 
@@ -115,46 +55,22 @@ and only treat non-zero trailing characters as errors. See
 **Source**: #1259 (2026-04-21, fuzz_parser crash on array size overflow)
 **Tags**: parser, codegen, integer-overflow, exception-safety, strtoull, libfuzzer
 
-**Context**: `std::stoull` / `std::stoul` / `std::stoi` throw
-`std::out_of_range` on overflow and `std::invalid_argument` on
-non-numeric input. These exceptions propagate out of the frontend
-uncaught and abort the process (visible to `fuzz_parser` as
-`SUMMARY: libFuzzer: deadly signal`). #1259's repro: `T[99…99]`
-(84 digits) in `parseTypeNameSingle` via `std::stoull(value)`.
+**Rule**: Never use `std::sto*` on lexer-produced numeric strings. `std::stoull` / `std::stoul` / `std::stoi` throw `std::out_of_range` on overflow and `std::invalid_argument` on non-numeric input — these propagate uncaught and abort the process (visible to `fuzz_parser` as `SUMMARY: libFuzzer: deadly signal`; #1259 repro: `T[99…99]` 84 digits in `parseTypeNameSingle` via `std::stoull(value)`). Worse, `std::stoull` with default base 10 **silently** parses hex/binary/underscore tokens by stopping at the first non-digit — `T[0xFF]` pre-#1259 silently became `T[0]`, `T[1_000]` became `T[1]`. The lexer's `TokenKind::Number` encompasses hex (`0xFF`), binary (`0b10`), and underscore separators (`1_000`), so any `std::stoull` call against a Number token's raw `value` is vulnerable.
 
-Additionally, `std::stoull` with default base 10 **silently** parses
-hex/binary/underscore-containing tokens by stopping at the first
-non-digit character — so `T[0xFF]` pre-#1259 silently became `T[0]`,
-and `T[1_000]` became `T[1]`. The lexer's `TokenKind::Number`
-encompasses hex (`0xFF`) and binary (`0b10`) literals plus
-underscore separators (`1_000`), so any `std::stoull` call against
-a Number token's raw `value` string is vulnerable to both crashes
-and silent miscounts.
-
-**Rule**: Never use `std::sto*` on lexer-produced numeric strings.
 Use `std::strtoull` (or `std::strtoul` for narrower targets) with:
 1. `errno = 0` reset before the call
 2. `char *end` output parameter
 3. Explicit base (`10` for decimal-only, `0` for prefix-sensitive)
 4. Reject if `errno == ERANGE || end != c_str() + size()`
 
-Reference site: `src/parser_decl.cpp` array-size branch in
-`parseTypeNameSingle` (post-#1259) and `NumberExpr.value strtoull`
-entry above for integer literal parsing.
+Reference site: `src/parser_decl.cpp` array-size branch in `parseTypeNameSingle` (post-#1259) and `NumberExpr.value strtoull` entry above for integer literal parsing.
 
 **Known hit sites** (all should be audited with this rule):
 - `src/parser_decl.cpp:787` — fixed in #1259 (array size `T[N]`)
-- `src/codegen_type.cpp:133` — inline-array type resolution from
-  string name; tracked in #1281
-- `src/codegen_expr_literal.cpp:109` — tuple numeric field access
-  (`.0`, `.1`, ...); tracked in #1281
+- `src/codegen_type.cpp:133` — inline-array type resolution from string name; tracked in #1281
+- `src/codegen_expr_literal.cpp:109` — tuple numeric field access (`.0`, `.1`, ...); tracked in #1281
 
-**How to apply**: When you see a new `std::sto*` call anywhere in
-`src/parser*.cpp`, `src/codegen*.cpp`, or any frontend path that
-handles user-provided numeric strings, replace it before merging.
-A fuzz harness (current: `fuzz_parser`, `fuzz_json`, `fuzz_utf8`)
-will catch parser-path regressions, but codegen paths have no
-harness as of #1259 — reviewer diligence is the only gate there.
+**How to apply**: When you see a new `std::sto*` call anywhere in `src/parser*.cpp`, `src/codegen*.cpp`, or any frontend path that handles user-provided numeric strings, replace it before merging. A fuzz harness (current: `fuzz_parser`, `fuzz_json`, `fuzz_utf8`) will catch parser-path regressions, but codegen paths have no harness as of #1259 — reviewer diligence is the only gate there.
 
 ---
 
@@ -163,54 +79,20 @@ harness as of #1259 — reviewer diligence is the only gate there.
 **Source**: #798/#799/#800 implementation (case/if expression unification)
 **Tags**: parser, statement-grammar, expression-statement, if-block-expr
 
-**Context**: Ry's `parseStatement` (`src/parser.cpp:499-664`) handles
-non-identifier tokens as expression statements (`[1,2].map(f)`, `42`,
-`"str"`, etc.) via the generic `parseConditional` fallback at line
-499-501. But when a statement **starts with an identifier**, the parser
-commits to the ident-dispatch path and requires one of `=`, `+=`, `[`,
-`.`, `(`, `++`, `--` to follow. So `y` or `y + 1` as a bare statement is
-rejected with `expected '=', '+=', ... after identifier`.
+**Rule**: When a statement **starts with an identifier**, the parser commits to the ident-dispatch path and requires one of `=`, `+=`, `[`, `.`, `(`, `++`, `--` to follow. So `y` or `y + 1` as a bare statement is rejected with `expected '=', '+=', ... after identifier`. Non-identifier tokens are handled as expression statements (`[1,2].map(f)`, `42`, `"str"`, etc.) via the generic `parseConditional` fallback.
 
-**Implication for `if` expression block form** (#798): the tail
-expression of `if cond: body else: body` is parsed via `parseBlock` →
-`parseStatement`, so the last line cannot be a bare identifier or an
-unparenthesized identifier-starting binary expression. Users must wrap
-such expressions in parens: `(y + 1)`, `(x)`. This is a **real
-limitation** of the block form, not a bug.
+**Implication for `if` expression block form** (#798): the tail expression of `if cond: body else: body` is parsed via `parseBlock` → `parseStatement`, so the last line cannot be a bare identifier or an unparenthesized identifier-starting binary expression. Users must wrap such expressions in parens: `(y + 1)`, `(x)`. This is a **real limitation** of the block form, not a bug.
 
-**Rule**: When introducing new block-valued expression forms, remember
-that Ry's statement grammar cannot parse identifier-starting pure
-expression statements. Either (a) require parenthesized tail expressions
-in user documentation, (b) use non-identifier expressions (literals,
-calls), or (c) write a custom block parser that calls `parseConditional`
-directly for the tail line.
+**How to apply**: When introducing new block-valued expression forms, remember Ry's statement grammar cannot parse identifier-starting pure expression statements. Either (a) require parenthesized tail expressions in user documentation, (b) use non-identifier expressions (literals, calls), or (c) write a custom block parser that calls `parseConditional` directly for the tail line.
 
 ### Identifier-trailing `!` tokenization must exclude every multi-char operator starting with `!`
 
 **Source**: #1211 (2026-04-20, bug fix); updated #1568 (`!!` operator removed)
 **Tags**: parser, lexer, identifier, trailing-bang, ambiguity
 
-**Context**: The lexer greedily absorbs a trailing `!` into an
-identifier to support mutating method names (`sort!`, `reverse!`,
-`append!`, `clear!`). Two-character operators that begin with `!` must
-be excluded from this absorption, otherwise `r<op>` mis-tokenizes as
-`r!` (Ident) + the operator's tail. The currently active such operator
-is `!=`. (#1211 originally added `!!` to the exclusion as well; #1568
-removed the `!!` operator entirely, so the exclusion is now `!=`-only.)
+**Rule**: The trailing-bang absorption in the identifier branch (`src/lexer.cpp` identifier tokenization) must exclude **every** multi-character operator token that begins with `!`, not just whatever operators happen to be present today. The lexer greedily absorbs trailing `!` into an identifier to support mutating method names (`sort!`, `reverse!`, `append!`, `clear!`); two-character operators starting with `!` must be excluded so `r<op>` does not mis-tokenize as `r!` (Ident) + the operator's tail. The currently active such operator is `!=`. (#1211 originally added `!!`; #1568 removed `!!` entirely, so the exclusion is now `!=`-only.)
 
-**Rule**: The trailing-bang absorption in the identifier branch
-(`src/lexer.cpp` identifier tokenization) must exclude **every**
-multi-character operator token that begins with `!`, not just whatever
-operators happen to be present today. Any future operator starting with
-`!` (hypothetical `!~`, `!?`, etc.) must be added to the exclusion set
-at the same time it is introduced in the operator lexer branch.
-
-**How to apply**: When adding a new operator whose first character is
-`!`, update both (a) the operator dispatch in `Lexer::next` and
-(b) the trailing-bang exclusion in the identifier tokenizer. A unit
-test asserting `tokenize("r<op>")` yields `Ident("r")` + the new
-operator prevents regression — `tokenize("<op>")` standalone does not
-catch it because the bug is specific to the identifier-adjacent case.
+**How to apply**: When adding a new operator whose first character is `!`, update both (a) the operator dispatch in `Lexer::next` and (b) the trailing-bang exclusion in the identifier tokenizer. A unit test asserting `tokenize("r<op>")` yields `Ident("r")` + the new operator prevents regression — `tokenize("<op>")` standalone does not catch it because the bug is specific to the identifier-adjacent case.
 
 ---
 
@@ -238,7 +120,7 @@ catch it because the bug is specific to the identifier-adjacent case.
 
 **Why**: Directive-arg syntax `@name(arg, ...)` and statement-level tuple-destructure LHS `(ident, ident, ...) =` both start with `@name LParen Ident`. The only disambiguator is the trailing `=` after `RParen`. Without this guard, `@const (a, b) = expr` is misparsed as `@const(a, b)` with positional args `a` and `b`, and the subsequent `=` trips the "directives are not supported on this statement" gate. `couldBeLambda`-style conservative lookahead (restored via `lex_.saveState()` / `restoreState()`) is the right tool — false negatives are fine because they fall through to the old behavior.
 
-**How to apply**: When adding any new statement form that begins with `LParen` after directives (e.g., `@const (_ as Pattern) = expr`, hypothetical future destructuring variants), extend `looksLikeParenthesizedTupleDestructure` (or add a parallel predicate) and make `parseDirectives` defer to it in the same guard location. Never let `parseDirectives` unconditionally eat `LParen`.
+**How to apply**: When adding any new statement form that begins with `LParen` after directives (e.g., `@const (_ as Pattern) = expr`), extend `looksLikeParenthesizedTupleDestructure` (or add a parallel predicate) and make `parseDirectives` defer to it in the same guard location. Never let `parseDirectives` unconditionally eat `LParen`.
 
 ### Tuple-destructure LHS names must be camelCase (with `_` placeholder allowed)
 
@@ -250,13 +132,11 @@ catch it because the bug is specific to the identifier-adjacent case.
 - Parenthesized form (`(a, b) = expr`): both the first name and every name read inside the comma loop are validated immediately after consuming the `Ident` token.
 - Bare form (`a, b = expr`): the first name is `first.value` (already consumed by the outer `Ident` dispatch in `parseStatement`) and must be checked there too — a position the rest-only sweep would miss. Each rest name is checked inside the comma loop.
 
-The error wording is `"tuple-destructure name '<n>' must be camelCase"`, matching the established pattern used by `parser_decl.cpp` (`fn name '...' must be camelCase`, `parameter name '...' must be camelCase`, `field name '...' must be camelCase`, etc.).
-
-**Why**: Pre-#1450 the two tuple-destructure sites were the last LHS-binding parser sites that accepted snake_case identifiers, even though every other binding site (`fn` decl, `let`/assign LHS via `parseAssignTarget`, lambda params, record fields, enum variant fields, loop variables) had been migrated to camelCase by #1409 / #1443 and follow-ups. The casing rule applies to all identifiers introduced into the local scope, and tuple destructure introduces them — so consistency demanded the same enforcement here.
+The error wording is `"tuple-destructure name '<n>' must be camelCase"`, matching the established pattern from `parser_decl.cpp` (`fn name '...' must be camelCase`, `parameter name '...' must be camelCase`, `field name '...' must be camelCase`, etc.).
 
 **How to apply**:
 - Both forms have a `first` position consumed before the comma loop and a `rest` position consumed inside it. A guard at only one position passes the other-position regression test for the wrong reason; lock both with separate negative tests (see `BareTupleDestructRejectsSnakeCaseFirst` vs `BareTupleDestructRejectsSnakeCaseRest`).
-- The `_` placeholder is a floor (must remain accepted), not a ceiling (allowed only in bare form). It is accepted in both forms at any position because `(_, b)` was already valid pre-#1450 via `ParenTupleDestructWildcard`.
+- The `_` placeholder is a floor (must remain accepted), not a ceiling. It is accepted in both forms at any position because `(_, b)` was already valid pre-#1450 via `ParenTupleDestructWildcard`.
 - The tuple-destructure parse path is gated by `looksLikeParenthesizedTupleDestructure()` (paren form) or the outer `Ident` dispatch (bare form) — neither sits inside a `try / catch (...)` speculative wrapper, so `parseError` propagates as a user-visible diagnostic. The commit-flag pattern from #1449 does **not** apply here.
 
 ### Module-global typed-decl `name: Type = value` enforces camelCase, with `@native`/`@const` SCREAMING_SNAKE_CASE carve-out
@@ -264,13 +144,11 @@ The error wording is `"tuple-destructure name '<n>' must be camelCase"`, matchin
 **Source**: #1470 (2026-04-30, implementation)
 **Tags**: parser, typed-decl, module-global, camelCase, screaming-snake-case, native, const, isCamelCase
 
-**Rule**: The keywordless implicit-binding form `name: Type = value` (parsed in `parseStatement` at the `Ident :` branch in `src/parser.cpp`) enforces `isCamelCase(name)` on the LHS identifier. SCREAMING_SNAKE_CASE is accepted only when the declaration carries a `@native` or `@const` directive, matching the established stdlib convention for built-in / module-level constants (`PI`, `E`, `INF`, `NAN`). The error wording is `"variable name '<n>' must be camelCase (or SCREAMING_SNAKE_CASE for @native or @const variable names)"`.
-
-**Why**: Pre-#1470 this site was the last LHS-binding parser site that silently accepted `snake_case` identifiers, even though every other binding site (`fn` decl, lambda params, record fields, tuple-destructure LHS) had been migrated to camelCase by #1443 / #1449 / #1450. The site is shared between top-level and block contexts (`parseStatement` is called from both), so the fix propagates uniformly to function bodies as well, completing the v0.0.16 naming convention rollout.
+**Rule**: The keywordless implicit-binding form `name: Type = value` (parsed in `parseStatement` at the `Ident :` branch in `src/parser.cpp`) enforces `isCamelCase(name)` on the LHS identifier. SCREAMING_SNAKE_CASE is accepted only when the declaration carries a `@native` or `@const` directive, matching the established stdlib convention for built-in / module-level constants (`PI`, `E`, `INF`, `NAN`). The error wording is `"variable name '<n>' must be camelCase (or SCREAMING_SNAKE_CASE for @native or @const variable names)"`. The site is shared between top-level and block contexts (`parseStatement` is called from both), so the rule propagates uniformly to function bodies as well.
 
 **How to apply**:
 - The carve-out gate is `hasDirective(directives, "native") || hasDirective(directives, "const")`. Do **not** broaden it to allow PascalCase: PascalCase is reserved for type names (records / enums / type aliases) and would create asymmetry with the `fn`-name carve-out at `parser_decl.cpp:130` which only allows camelCase or SCREAMING_SNAKE_CASE.
-- Stdlib `share/std/math/math.ry` constants must be SCREAMING_SNAKE_CASE — `Inf` and `NaN` were renamed to `INF` and `NAN` in the same PR for this reason. Future stdlib constants follow the same convention.
+- Stdlib `share/std/math/math.ry` constants must be SCREAMING_SNAKE_CASE — `Inf` and `NaN` were renamed to `INF` and `NAN` in the same PR. Future stdlib constants follow the same convention.
 - Mathematical concept names (`NaN`, `±Inf`) in prose / docstrings remain unchanged — only the Ry identifier exports were renamed.
 
 ### `@directive` definition syntax bypasses the registry validator
@@ -291,34 +169,32 @@ The error wording is `"tuple-destructure name '<n>' must be camelCase"`, matchin
 
 **Adjacent invariants**:
 - `DirectiveDefStmt.targets` is always `std::vector<std::string>`. Bare-string sugar `target="function"` is canonicalized into `{"function"}` at parse time, so downstream consumers (codegen, formatter, future #710 signature builder) never see the bare-string form.
-- `DirectiveDefStmt` codegen is intentionally a no-op (`emitStmt(DirectiveDefStmt&)` in `src/codegen_stmt_misc.cpp`) until #710 consumes it for runtime registration. A future contributor seeing the empty body should not assume logic is missing — the IR-emission gap is by design.
+- `DirectiveDefStmt` codegen is intentionally a no-op (`emitStmt(DirectiveDefStmt&)` in `src/codegen_stmt_misc.cpp`) until #710 consumes it for runtime registration.
 - Formatter always emits `target=[...]` (List form), even when the source used the bare-string sugar. `FormatterTest.DirectiveDefBareStringSugarCanonicalises` locks this in.
-- After #1397: required params (no default value) are recorded in `DirectiveSignature::positional_param_names` (in declaration order) so they may be passed either positionally or by name at the use site. Optional params (with default) remain in `named_params` (named-only). The `validateDirectiveSignature` shared validator detects positional+named duplicates and missing-required errors using the `positional_param_names` list. Built-in directives leave `positional_param_names` empty for backward compatibility — their existing positional-only semantics are preserved because `min_positional`/`max_positional` still gate them.
+- After #1397: required params (no default value) are recorded in `DirectiveSignature::positional_param_names` (in declaration order) so they may be passed either positionally or by name at the use site. Optional params (with default) remain in `named_params` (named-only). The `validateDirectiveSignature` shared validator detects positional+named duplicates and missing-required errors using the `positional_param_names` list. Built-in directives leave `positional_param_names` empty — their existing positional-only semantics are preserved because `min_positional`/`max_positional` still gate them.
 
 ### User-defined directives applied outside `target=[...]` are silent no-ops
 
 **Source**: #1425 (2026-04-28, implementation)
 **Tags**: codegen, directive, target, silent-no-op, validateDirectives, allowed_targets, parser-asymmetry
 
-**Rule**: When a user-defined directive declared via `@directive(target=[...])` is applied to a node whose kind is **not** in the declared target list, codegen silently skips the directive — no error, no warning, no effect. `validateDirectives()` (`src/codegen_fn.cpp`) takes a `DirectiveTarget current` parameter; for each user-defined directive it `continue`s when `sig.allowed_targets != 0 && !hasTarget(sig.allowed_targets, current)`, so `validateDirectiveSignature()` is never called and any future effect-firing logic guarded by the same check stays inactive too. Argument validation is therefore also skipped on a target mismatch, which is intentional and matches the v0.0.15 spec — a later minor may upgrade this to a warning.
+**Rule**: When a user-defined directive declared via `@directive(target=[...])` is applied to a node whose kind is **not** in the declared target list, codegen silently skips the directive — no error, no warning, no effect. `validateDirectives()` (`src/codegen_fn.cpp`) takes a `DirectiveTarget current` parameter; for each user-defined directive it `continue`s when `sig.allowed_targets != 0 && !hasTarget(sig.allowed_targets, current)`, so `validateDirectiveSignature()` is never called and any future effect-firing logic guarded by the same check stays inactive too. Argument validation is therefore also skipped on a target mismatch, which is intentional — a later minor may upgrade this to a warning.
 
 **Why**: v0.0.15 wants `@directive(...)` to support tag-style usage where a directive declared for one site can be sprinkled on adjacent sites without breaking compilation. Erroring out would force users to declare a separate directive per target; warning would require a noise budget the project does not yet have. Skipping silently keeps the door open for future warning escalation while preserving today's "harmless" semantics.
 
 **How to apply**:
 - Every call site of `validateDirectives()` must pass an explicit `DirectiveTarget`. Today the call sites are: `FnStmt` (Function), `RecordStmt` and field directives in `emitStmt(RecordStmt)` (Record, Field), `AssignStmt` and `TupleDestructStmt` (Statement), `CallStmt` (Statement, reachable from user source after #1427), and `ForStmt` (ForLoop).
-- Built-in directives go through the `validateDirectiveArgs()` registry path inside `validateDirectives()` and are unaffected by the target check — that mismatch detection is intentionally out of scope (#1425 "Out of scope").
+- Built-in directives go through the `validateDirectiveArgs()` registry path inside `validateDirectives()` and are unaffected by the target check — that mismatch detection is intentionally out of scope.
 - The `sig.allowed_targets != 0` guard is defensive: parser already requires `target=[...]` to be non-empty (`src/parser_decl.cpp` rejects the empty list), but if a future change ever permits "any target", `allowed_targets == 0` will fall back to validate-everything rather than silently skip.
 
-**Parser-side asymmetry — resolved by #1427**: Until #1427, `src/parser.cpp:460-462` and `:718-720` rejected every user-defined directive on `for` statements (only `@parallel` allowed) and on function-call statements (only the special `@each` / `@property` on `it(...)` form allowed) at parse time, making the silent-no-op behavior unobservable at those sites. #1427 replaced both gates with a `builtinDirectiveRegistry()` membership check: only registry-tracked directives (today: `@native` only) are rejected, and user-defined directives pass through to codegen `validateDirectives()` where the silent-no-op rule applies. The `ForLoop` and `Statement` codegen wiring added defensively in #1425 is now reachable from user source. Tests `ForLoopAcceptsUserDirectiveAsSilentNoOp` / `CallStmtAcceptsUserDirectiveAsSilentNoOp` (formerly `…RejectsUserDirectiveAtParseTime`, flipped per the "Relaxing a rejection branch …" rule in `.claude/rules/tests-rejection-tdd.md`) lock in the new permissive behavior; `ForLoopRejectsBuiltinNativeDirective` / `CallStmtRejectsBuiltinNativeDirective` / `ForLoopRejectsMultipleParallel` lock in the restrictions that remain.
+**Parser-side asymmetry — resolved by #1427**: Until #1427, `src/parser.cpp:460-462` and `:718-720` rejected every user-defined directive on `for` statements (only `@parallel` allowed) and on function-call statements (only the special `@each` / `@property` on `it(...)` form allowed) at parse time, making the silent-no-op behavior unobservable at those sites. #1427 replaced both gates with a `builtinDirectiveRegistry()` membership check: only registry-tracked directives (today: `@native` only) are rejected, and user-defined directives pass through to codegen `validateDirectives()` where the silent-no-op rule applies. Tests `ForLoopAcceptsUserDirectiveAsSilentNoOp` / `CallStmtAcceptsUserDirectiveAsSilentNoOp` (formerly `…RejectsUserDirectiveAtParseTime`, flipped per the "Relaxing a rejection branch …" rule in `.claude/rules/tests-rejection-tdd.md`) lock in the new permissive behavior; `ForLoopRejectsBuiltinNativeDirective` / `CallStmtRejectsBuiltinNativeDirective` / `ForLoopRejectsMultipleParallel` lock in the restrictions that remain.
 
 ### Formatter→parser roundtrip: `TupleDestructStmt` must not emit `: ` between pattern and `=`
 
 **Source**: #1189 (2026-04-19, implementation)
 **Tags**: formatter, parser, tuple, destructure, roundtrip, latent_bug
 
-**Rule**: `formatTupleDestruct()` in `src/formatter_stmt.cpp` must emit only `<pattern> = <value>` (plus optional `@const` directive on a prior line). Do **not** emit a stray `: ` between the closing `)` of the pattern and the `=`. The immutability is conveyed by the `@const` directive emitted before the statement, not by a `:` suffix on the LHS.
-
-**Why**: Until #1189 landed, the parser rejected all parenthesized tuple-destructure forms, so the formatter's output `(a, b):  = (1, 2)` never round-tripped through parse. Enabling the parenthesized parse branch exposed the latent `: ` bug — formatted output now fails `ry fmt` verification ("formatted output failed to re-parse"). Adding `FormatterTest.ParenTupleDestructRoundTrip` locks this in so future formatter edits cannot regress.
+**Rule**: `formatTupleDestruct()` in `src/formatter_stmt.cpp` must emit only `<pattern> = <value>` (plus optional `@const` directive on a prior line). Do **not** emit a stray `: ` between the closing `)` of the pattern and the `=`. The immutability is conveyed by the `@const` directive emitted before the statement, not by a `:` suffix on the LHS. Until #1189 landed, the parser rejected all parenthesized tuple-destructure forms, so the formatter's output `(a, b):  = (1, 2)` never round-tripped through parse; enabling the parenthesized parse branch exposed the latent `: ` bug — formatted output now fails `ry fmt` verification ("formatted output failed to re-parse").
 
 **How to apply**: When adding or modifying a formatter rule for a new statement shape, grep for a matching parser spec test and add a `verifyFormatting` / roundtrip assertion. Formatter output that fails to re-parse is a silent correctness bug during `ry fmt`; only the verification pass catches it.
 
@@ -327,13 +203,13 @@ The error wording is `"tuple-destructure name '<n>' must be camelCase"`, matchin
 **Source**: #1449 (2026-04-29, implementation — advisor call-out)
 **Tags**: parser, speculative-parse, try-catch, lambda, commit-flag, diagnostic-wording
 
-**Context**: `parsePrimary`'s lambda dispatch wraps `parseParenLambdaExpr()` in `try { ... } catch (...) { lex_.restoreState(...); }` so that `(a, b)` (tuple) and `(a, b) => a + b` (lambda) can share a prefix and fall back if the lambda parse fails. When #1449 added a hard `isCamelCase` check on lambda param names, throwing inline inside the param loop got swallowed by that catch — the lexer rewound to before `(`, the statement parser then re-saw `f = (my_x, my_y) => ...` and emitted the wrong diagnostic ("expected '=', '+=', ... after identifier") instead of the intended `parameter name 'my_x' must be camelCase`.
-
 **Rule**: When you need a hard validation error (one that is **not** an "ambiguity ⇒ try the other branch" signal) inside a function whose caller wraps it in a speculative `try / catch (...)`, introduce a member commit-flag (e.g. `lambda_committed_`) on `Parser`:
 
 1. **Defer the validation** until you have consumed the disambiguator that proves the speculative branch was the right one (for `parseParenLambdaExpr` that is `')'` followed by one of `->` / `=>` / `:`). Collect the data you need to validate (e.g. `paramNameTokens`) up to that point but do not throw yet.
 2. **Set the flag** the instant you confirm commitment, **after** the disambiguator check that decides whether to fall back. Setting it before the disambiguator turns the fallback path into a hard error too (e.g. tuple `(a, b)` with no body marker would lose its fall-through to `parseTuple`).
 3. **Re-throw past the catch** with `if (committed_) { committed_ = prev; throw; } committed_ = prev; lex_.restoreState(...);`. Save and restore the previous flag value so nested speculative parses (e.g. lambda inside lambda body) compose correctly.
+
+`parsePrimary`'s lambda dispatch wraps `parseParenLambdaExpr()` in `try { ... } catch (...) { lex_.restoreState(...); }` so `(a, b)` (tuple) and `(a, b) => a + b` (lambda) can share a prefix. Adding a hard `isCamelCase` check on lambda param names threw inline inside the param loop and got swallowed — the lexer rewound, the statement parser then re-saw `f = (my_x, my_y) => ...` and emitted "expected '=', '+=', ... after identifier" instead of the intended `parameter name 'my_x' must be camelCase`.
 
 **Why a member flag, not an exception subclass**: Using `throw RealParseError` vs `throw SpeculativeFailure` would also work, but every existing `parseError(...)` site in the parser throws the same type, so introducing a hierarchy would require tagging every call site — the flag is a 5-line change confined to the speculative branch.
 
@@ -345,8 +221,6 @@ The error wording is `"tuple-destructure name '<n>' must be camelCase"`, matchin
 
 **Source**: #1572 (2026-05-04, implementation)
 **Tags**: parser, lambda, if-expression, bare-lambda, fatarrow, lookahead, ambiguity, blind-spot
-
-**Context**: #1572 added bare-paren-omitted single-param lambda dispatch (`s => expr`) in `parsePrimary`'s `Ident` branch. Without a guard, the dispatch fires inside the cond of `if cond => then else else`, consuming `=>` as a lambda body marker and breaking every existing `if flag => Some(1) else None()` site (`tests/spec/option_branch_merge_none.test.ry` alone has 14+ such sites).
 
 **Rule**: `parsePrimary`'s `Ident` branch must guard the bare-lambda dispatch with `lex_.peek().kind == TokenKind::FatArrow && !in_if_cond_`. The flag is set by `parseIfExpression` only around the `parseConditional()` call that parses the **condition**:
 
@@ -363,11 +237,13 @@ ExprPtr Parser::parseIfExpression() {
 }
 ```
 
+#1572 added bare-paren-omitted single-param lambda dispatch (`s => expr`). Without the guard, the dispatch fires inside the cond of `if cond => then else else`, consuming `=>` as a lambda body marker and breaking every existing `if flag => Some(1) else None()` site (`tests/spec/option_branch_merge_none.test.ry` alone has 14+ such sites).
+
 **Why a flag, not a richer lookahead**: bare-ident `s` followed by `=>` is locally indistinguishable between "bare lambda" and "if-cond identifier followed by then-arm". Only the surrounding parser state knows which is in scope. A peek-based heuristic would have to scan past the entire then/else arms to find the matching `else` keyword (expensive and still ambiguous with nested `if`s in the cond), or commit prematurely and break existing spec.
 
 **Why save/restore (not unconditional `false` on exit)**: nested if-expressions (`if outer => if inner => x else y else z`) and lambdas inside then/else arms (`if c => x => x*2 else y => y*2`) must compose correctly. Restoring the previous value (rather than clobbering to `false`) preserves the outer context.
 
-**Why no commit-flag**: `Ident FatArrow` is a 2-token commit point with no fallback path. The bare-lambda branch is **not** wrapped in a speculative `try / catch (...)`, so the commit-flag pattern from the entry above does **not** apply — `parseError` for `isCamelCase` violations propagates as a hard diagnostic immediately, and there is no other parse to fall back to.
+**Why no commit-flag**: `Ident FatArrow` is a 2-token commit point with no fallback path. The bare-lambda branch is **not** wrapped in a speculative `try / catch (...)`, so the commit-flag pattern from the entry above does **not** apply — `parseError` for `isCamelCase` violations propagates as a hard diagnostic immediately.
 
 **How to apply**: Any future `Ident <suffix>` dispatch added in `parsePrimary` (hypothetical `s @ pattern`, typed-binding shortcuts, postfix builder shorthands, etc.) that conflicts with an outer-context production must replicate this pattern:
 
@@ -375,32 +251,19 @@ ExprPtr Parser::parseIfExpression() {
 2. Set/restore the flag at the call site that owns the conflicting production (`parseIfExpression` for if-cond, `parseCaseExpression` for case-scrutinee, etc.).
 3. Guard the new `parsePrimary` dispatch with `&& !in_<context>_`.
 
-Reference site: `src/parser_expr.cpp::parsePrimary` Ident branch (bare-lambda dispatch with the `!in_if_cond_` guard) + `src/parser_expr.cpp::parseIfExpression` (save/restore around `parseConditional` for the cond). The flag itself lives on `include/ry/parser.hpp` next to `lambda_committed_`. Tests `BareLambdaPreservesIfExpressionWithBareIdentCond` and `BareLambdaInIfThenElse` in `tests/test_parser.cpp` lock both halves of the invariant.
+Reference site: `src/parser_expr.cpp::parsePrimary` Ident branch (bare-lambda dispatch with the `!in_if_cond_` guard) + `src/parser_expr.cpp::parseIfExpression` (save/restore around `parseConditional` for the cond). The flag lives on `include/ry/parser.hpp` next to `lambda_committed_`. Tests `BareLambdaPreservesIfExpressionWithBareIdentCond` and `BareLambdaInIfThenElse` in `tests/test_parser.cpp` lock both halves of the invariant.
 
 ### UnaryExpr fast-path covers bare int for INT64_MIN (`-9223372036854775808`)
 
 **Source**: #1025 (2026-04-16)
 **Tags**: codegen, numeric-literal, unary-minus, int64-min, ubsan
 
-**Rule**: The `-<NumberExpr>` fast-path in `src/codegen_expr.cpp::emitExprVariant(UnaryExpr)`
-accepts bare int (empty suffix) as equivalent to `i64` for the magnitude check
-(`|INT64_MIN|` = 2^63). A standalone `9223372036854775808` without the unary minus must
-still be rejected by the bare-`NumberExpr` path (`value < 0` check).
+**Rule**: The `-<NumberExpr>` fast-path in `src/codegen_expr.cpp::emitExprVariant(UnaryExpr)` accepts bare int (empty suffix) as equivalent to `i64` for the magnitude check (`|INT64_MIN|` = 2^63). A standalone `9223372036854775808` without the unary minus must still be rejected by the bare-`NumberExpr` path (`value < 0` check). Magnitude > 2^63 on the bare path produces `"integer literal out of range for int: -<mag>"` (matching the existing bare-int error wording); the signed-suffix path keeps the `"<suffix> literal out of range: -<mag>"` wording.
 
-Magnitude > 2^63 on the bare path produces `"integer literal out of range for int: -<mag>"`
-(matching the existing bare-int error wording); the signed-suffix path keeps the
-`"<suffix> literal out of range: -<mag>"` wording.
-
-**UB fix**: The original computation `static_cast<uint64_t>(-static_cast<int64_t>(mag))`
-is signed-integer UB when `mag == 2^63` (negation of INT64_MIN overflows). Use
-unsigned two's-complement arithmetic instead:
+**UB fix**: The original computation `static_cast<uint64_t>(-static_cast<int64_t>(mag))` is signed-integer UB when `mag == 2^63` (negation of INT64_MIN overflows). Use unsigned two's-complement arithmetic instead:
 ```cpp
 const uint64_t negBits = static_cast<uint64_t>(0) - mag;  // well-defined, same bits
 ```
-This also applies to the signed-suffix path — add `-9223372036854775808i64` to
-`SignedSuffixMinAcceptedViaUnaryMinus` to keep it covered.
+This also applies to the signed-suffix path — add `-9223372036854775808i64` to `SignedSuffixMinAcceptedViaUnaryMinus` to keep it covered.
 
-**How to apply**: If you touch this fast-path, keep the bare-int branch in sync with the
-signed-low-level-suffix branch. Always use unsigned subtraction for `negBits`; never
-negate a `uint64_t` value via `static_cast<int64_t>` when the magnitude may equal 2^(N-1).
-
+**How to apply**: If you touch this fast-path, keep the bare-int branch in sync with the signed-low-level-suffix branch. Always use unsigned subtraction for `negBits`; never negate a `uint64_t` value via `static_cast<int64_t>` when the magnitude may equal 2^(N-1).

--- a/.claude/rules/runtime-memory-safety.md
+++ b/.claude/rules/runtime-memory-safety.md
@@ -10,197 +10,72 @@ paths:
 
 ### Runtime functions returning ARC-managed structs must use `arc_alloc`, not `checked_malloc`
 
-**Source**: #1007, #1011 (2026-04-16, bug fixes), PR #997 (pattern established for ListHeader)
-**Tags**: arc, runtime, memory-safety, iolistheader, listheader, mapheader, http, gotcha
+**Source**: #997, #1007, #1011
+**Tags**: arc, runtime, memory-safety, iolistheader, listheader, mapheader, gotcha
 
-**Rule**: Any runtime function that returns a heap-allocated struct (e.g.
-`IOListHeader`, `ListHeader`, `MapHeader`) **to Ry code** must allocate the
-struct with `arc_alloc`, not `checked_malloc`.
+**Rule**: Any runtime function returning a heap-allocated struct (`IOListHeader`, `ListHeader`, `MapHeader`, etc.) **to Ry code** must allocate with `arc_alloc`, not `checked_malloc`. `emitVarDecl` emits a retain that reads `header_ptr - ARC_HEADER_SIZE` (16 bytes) to bump strong-count; with `checked_malloc` that region is malloc metadata and `arc_release` corrupts it (`malloc: *** error for object 0x...: pointer being freed was not allocated`). ASan layout differs and may not reproduce the crash.
 
-**Why**: `emitVarDecl` in the codegen emits a retain that reads
-`header_ptr - ARC_HEADER_SIZE` (16 bytes) to increment the strong-count.
-When the header was allocated with `checked_malloc` that region is malloc
-metadata, not an ARC counter. Corrupting it and then calling
-`arc_release`/`__ry_arc_free_counted` on scope exit causes a crash:
+**Error-path pairing**: when `arc_alloc` succeeds but the function bails before returning, free the header with `arc_free`, not `free`. Inner `data` buffers allocated with `checked_malloc` still use plain `free` (e.g. `__ry_tcp_receive`: `free(header->data)` then `arc_free(header)`).
 
-```text
-malloc: *** error for object 0x...: pointer being freed was not allocated
-```
+**C++ tests** that wrap these headers must use `arc_free` (from `include/ry/runtime_arc.hpp`), not `free`. Individual string elements created by `dupString` are plain `checked_malloc` and freed with plain `free`.
 
-ASan builds do not reproduce the crash because the allocator's internal
-layout differs and the metadata region happens not to be misinterpreted as
-zero.
-
-**Affected sites in this codebase** (checked 2026-04-16):
-
-| Function | File | Fixed by |
-|---|---|---|
-| `makeStringList`, `makeMatchList` | `include/ry/runtime_list.hpp` | PR #997 |
-| `makeByteList` | `include/ry/runtime_io.hpp` | PR #1007 |
-| `__ry_read_bytes` | `src/runtime_io.cpp` | PR #1007 |
-| `makeEmptyIOList`, `__ry_tcp_receive` | `src/runtime_net.cpp` | PR #1007 |
-| `__ry_tls_receive` | `src/runtime_tls.cpp` | PR #1007 |
-| `build_str_map` | `src/runtime_http.cpp` | PR #1011 |
-
-**Error-path pairing**: when an allocation succeeds with `arc_alloc` but
-the function later bails out before returning to Ry, free with `arc_free`,
-not `free`. Example: `__ry_tcp_receive` allocates the header with
-`arc_alloc`, then on `recv()` error calls `free(header->data)` (plain `free`
-because the data buffer uses `checked_malloc`) and `arc_free(header)`.
-
-**Also**: C++ tests that call these runtime functions directly must also use
-`arc_free` (not `free`) to release the returned struct.
+Helpers that already use `arc_alloc`: `makeStringList` / `makeMatchList` (`runtime_list.hpp`), `makeByteList` (`runtime_io.hpp`), `makeEmptyIOList` (`runtime_net.cpp`), `build_str_map` (`runtime_http.cpp`).
 
 ### JIT-visible atomic counters must not expose `std::atomic<T>` storage via raw `T*`
 
-**Source**: #1158 (2026-04-23, implementation)
+**Source**: #1158
 **Tags**: runtime, atomic, jit, abi, layout, arc
 
-**Rule**: If JIT-generated IR needs the address of a counter as a raw
-`int64_t*` (or other plain-data pointer), back the storage with an
-`alignas(T) T` object and access it through `__atomic_*` builtins. Do
-not store the counter as `std::atomic<T>` and then return
-`reinterpret_cast<T*>(&atomic_obj)` to the JIT.
-
-**Why**: Ry's JIT emits `atomicrmw` directly against the address returned
-by `__ry_arc_counter_address()`. C++ does not guarantee that
-`std::atomic<int64_t>` has the same layout or address semantics as a
-plain `int64_t`, so exposing its storage as `int64_t*` is a portability
-bug even if it happens to work on one toolchain. `__atomic_fetch_add`,
-`__atomic_fetch_sub`, and `__atomic_load_n` preserve the required
-relaxed-atomic semantics without relying on `std::atomic` object layout.
+**Rule**: If JIT IR needs the address of a counter as a raw `int64_t*`, back the storage with `alignas(T) T` and access via `__atomic_*` builtins. Do **not** store as `std::atomic<T>` and return `reinterpret_cast<T*>(&atomic_obj)` to the JIT — C++ does not guarantee `std::atomic<int64_t>` has the same layout as plain `int64_t`. Ry's JIT emits `atomicrmw` directly against `__ry_arc_counter_address()`. `__atomic_fetch_add` / `__atomic_fetch_sub` / `__atomic_load_n` preserve relaxed-atomic semantics without depending on `std::atomic` object layout.
 
 ### RWLock dispatch state must be thread-local, not guarded by a shared mutex
 
-**Source**: #871 (2026-04-11, implementation; follow-up to #630 P1 audit)
+**Source**: #871 (follow-up to #630)
 **Tags**: rwlock, runtime-thread, concurrency, deadlock, thread-local, gotcha
 
-**Rule**: In `src/runtime_thread.cpp`, the per-thread counter that tells
-`__ry_rwlock_unlock` whether to call `unlock_shared()` vs `unlock()` on
-the underlying `std::shared_mutex` lives in a
-`thread_local std::unordered_map<RWLockHandle*, int>` at namespace
-scope. Do NOT reintroduce a shared `std::unordered_map<std::thread::id, int>`
-guarded by a separate `mode_mu`.
+**Rule**: In `src/runtime_thread.cpp`, the per-thread counter that tells `__ry_rwlock_unlock` whether to call `unlock_shared()` vs `unlock()` lives in a `thread_local std::unordered_map<RWLockHandle*, int>` at namespace scope. Do NOT reintroduce a shared `unordered_map<thread::id, int>` guarded by a separate `mode_mu`.
 
-**Why**: The #630 audit suggested two fixes for the original two-step
-race (where `mu.lock_shared()` was held before the tracking map was
-updated). Option A — "hold mode_mu across lock_shared()" — **deadlocks**
-under writer contention: a thread holding `mode_mu` while blocked
-inside `lock_shared()` prevents any existing reader from taking
-`mode_mu` to dispatch its own unlock, so the writer it is waiting on
-can never make progress. Three-way deadlock: writer waits for existing
-reader, existing reader waits for `mode_mu`, `mode_mu` owner waits
-for writer. Thread-local tracking (Option B) sidesteps this entirely
-because no shared data structure exists for the dispatch.
+**Why**: holding `mode_mu` across `lock_shared()` produces a three-way deadlock under writer contention — writer waits for existing reader, existing reader waits for `mode_mu`, `mode_mu` owner waits for writer. Thread-local tracking sidesteps it because no shared data structure exists for the dispatch.
 
-**Caveat**: unbalanced `rwlockReadLock` without a matching
-`rwlockUnlock` leaves a stale TLS entry that persists until thread
-exit. If an RWLockHandle is then freed and a new one is allocated at
-the same address, the stale count could be misinterpreted. The
-previous map-based tracker had the same property — unbalanced lock
-usage is a program bug, not something the runtime should engineer
-around.
+**Caveat**: unbalanced `rwlockReadLock`/`rwlockUnlock` leaves a stale TLS entry until thread exit; if the handle is freed and reallocated at the same address, the stale count could be misinterpreted. The previous map-based tracker had the same property — unbalanced lock usage is a program bug.
 
 ### Recursive `lock_shared()` on `std::shared_mutex` is undefined behavior in C++17
 
-**Source**: #871 (2026-04-11, CodeRabbit review on PR #885)
+**Source**: #871 (CodeRabbit on PR #885)
 **Tags**: rwlock, runtime-thread, std-shared-mutex, ub, gotcha
 
-**Rule**: `__ry_rwlock_read_lock` must call `rwlock->mu.lock_shared()`
-**only on the outermost read acquire**, gated by `tls_rwlock_read_counts`
-being empty for that rwlock. Nested reads just bump the TLS counter.
-`__ry_rwlock_unlock` mirrors this: the underlying `unlock_shared()`
-only runs when the TLS counter drops from 1 to 0.
-
-**Why**: Per [thread.sharedmutex.requirements] / cppreference
-"If lock_shared is called by a thread that already owns the mutex in
-any mode (exclusive or shared), the behavior is undefined." The TLS
-counter exists solely to dispatch unlock correctly; it does not make
-the underlying mutex reentrant. An earlier draft of the #871 fix
-called `lock_shared()` unconditionally and still passed tests on
-libc++ because the UB happened to be benign, but it would be a
-time-bomb under a stricter standard library or instrumented build.
-The regression is covered by
-`tests/test_runtime_rwlock_stress.cpp::NestedReadLockPerThread`.
+**Rule**: `__ry_rwlock_read_lock` must call `mu.lock_shared()` **only on the outermost read acquire**, gated by `tls_rwlock_read_counts` being empty for that rwlock. Nested reads only bump the TLS counter. `__ry_rwlock_unlock` mirrors this: `unlock_shared()` runs only when the counter drops 1 → 0. Per [thread.sharedmutex.requirements], calling `lock_shared` while the thread already owns the mutex (any mode) is UB. Earlier draft called `lock_shared()` unconditionally — passed on libc++ (benign UB) but a time-bomb under stricter stdlibs / instrumented builds. Regression covered by `tests/test_runtime_rwlock_stress.cpp::NestedReadLockPerThread`.
 
 ### `for` loop over a collection: snapshot via `emitArcRetain` to prevent buffer-pointer UAF
 
-**Source**: #1021 (2026-04-16), #1041 (2026-04-17), #1091 (2026-04-17)
+**Source**: #1021, #1041, #1091
 **Tags**: codegen, for-loop, list, set, map, arc, cow, use-after-free, iteration
 
-**Rule**: Never cache a collection's internal buffer pointer (`data`, `keys`,
-`vals`) in an SSA value that is read inside the loop body **when the iterable
-carries an external alias** (`VariableExpr`, `FieldAccessExpr`, or `IndexExpr`). `append!`/`add`/map-insert grow the
-collection; when the buffer is full, they `arc_alloc` a new buffer, copy, and
-**`free` the old buffer** — leaving any pre-loop SSA pointer dangling (UAF).
+**Rule**: Never cache a collection's internal buffer pointer (`data`/`keys`/`vals`) in an SSA value read inside the loop body **when the iterable carries an external alias**. `append!` / `add` / map-insert grow the collection: a full buffer triggers `arc_alloc` of a new buffer, copy, and `free` of the old — leaving any pre-loop SSA pointer dangling.
 
-**External-alias gate**: Apply retain+snapshot when
-`iterableHasExternalAlias(*s->iterable)` returns true — i.e., the iterable is
-`VariableExpr`, `FieldAccessExpr` (e.g. `obj.items`, `self.xs`), **or** `IndexExpr`
-(e.g. `xs[i]`, `m["key"]`). For true temporaries (`range(100)`, result of a call
-expression, `emitStringToCharList` output, list/set/map literals, etc.) there is no
-external alias that can mutate the collection through CoW — pre-loop SSA values are safe.
+**External-alias gate** (`iterableHasExternalAlias(*s->iterable)`): true for `VariableExpr`, `FieldAccessExpr` (e.g. `obj.items`), `IndexExpr` (e.g. `xs[i]`, `m["key"]`). True temporaries (`range(100)`, call results, list/set/map literals) have no external alias — pre-loop SSA values are safe.
 
-**FieldAccessExpr / IndexExpr semantic difference**: `tryGetReceiverAlloca` returns `nullptr`
-for `FieldAccessExpr` (only handles `VariableExpr`), so no CoW fork occurs on
-mutation — `append!` mutates in-place. The retain still protects the snapshot:
-the header's `strong_count` is bumped to ≥ 2, so the buffer is not freed. The
-loop iterates the original length read from the snapshot before mutation.
-
+**FieldAccessExpr / IndexExpr nuance**: `tryGetReceiverAlloca` returns `nullptr` for `FieldAccessExpr` (only handles `VariableExpr`), so no CoW fork on mutation — `append!` mutates in-place. The retain still protects the snapshot: `strong_count ≥ 2`, buffer not freed, loop iterates the original length.
 
 **Fix**:
+1. Before the loop header, call `emitArcGetHeaderFromData(iterable)` → `emitArcRetain(arcHdr)` to bump `strong_count`.
+2. Store the data pointer in a scope-owned alloca (`__for_iter_snap_N`). Register with `setTypeMeta` (correct `ListElem`/`SetElem`/`MapKey`) and `markArcManaged` so `popScope()` releases on every exit path.
+3. Load `len` once from the snapshot before `emitIndexedForLoop`. In the body lambda, load `data`/`keys`/`vals` from the snapshot per iteration.
+4. **Do NOT emit explicit release** — `popScope()` / `emitScopeCleanupToDepth` walk `arc_managed_vars_` and emit `emitArcReleaseVar` on every exit.
 
-1. Before emitting the loop header, call `emitArcGetHeaderFromData(iterable)` →
-   `emitArcRetain(arcHdr)` to bump `strong_count`.
-2. Store the collection data pointer in a new scope-owned alloca (e.g.,
-   `__for_iter_snap_N`). Register it with `setTypeMeta` (correct
-   `ListElem`/`SetElem`/`MapKey`) and `markArcManaged` so `popScope()` releases
-   it on normal exit, `return`, and `break`.
-3. Load `len` once from the snapshot alloca right before `emitIndexedForLoop`.
-   Inside the body lambda, load `data`/`keys`/`vals` from the snapshot alloca per
-   iteration (the retain freezes the header; CoW on the source alias forks a new
-   header without touching ours).
-4. **Do NOT emit an explicit release.** `popScope()` / `emitScopeCleanupToDepth`
-   walk `arc_managed_vars_` and call `emitArcReleaseVar` on every exit path.
+**Sequential-loop safety**: per-ForStmt counter for unique snapshot names (`__for_iter_snap_0`, `__for_iter_snap_1`, …). `getOrCreateVar` looks up only the current scope, so different names prevent accidental sharing.
 
-**For non-alias iterables**: load `data`/`keys`/`vals`/`len` once before
-`emitIndexedForLoop` as SSA values, capture them in the body lambda.
-
-**Why retain works**: any mutation through the source alias inside the loop body
-triggers `emitCowCheckSlot`, which sees `strong_count ≥ 2` and forks a new
-header into the source alloca. Our snapshot alloca still points to the original
-frozen header; the loop iterates the original content.
-
-**Sequential-loop safety**: use a per-ForStmt counter for unique snapshot names
-(`__for_iter_snap_0`, `__for_iter_snap_1`, …). `getOrCreateVar` looks up only
-the **current scope**, so sequential loops in the same function scope cannot
-accidentally share a snapshot alloca if the names differ.
-
-**How to verify**: in `codegen_stmt_loop.cpp`, per-iteration buffer loads for
-`iterableHasExternalAlias` paths should read from a `for_snap` alloca; for
-non-alias paths, the captured SSA `dataPtr`/`keysPtr`/`valsPtr` values are used
-directly.
-
----
+**Non-alias iterables**: load `data`/`keys`/`vals`/`len` once before the loop, capture as SSA in the body lambda.
 
 ### Thread / parallel-for thunk epilogue: `popScope()` before `CreateRetVoid()`
 
-**Source**: #1090 (2026-04-17)
+**Source**: #1090
 **Tags**: codegen, thread, parallel-for, arc, thunk, ir-verification
 
-**Rule**: In any internally-generated thunk function (`__ry_thread.N`,
-`__ry_parallel_for.N`), call `popScope()` **before** `builder_.CreateRetVoid()`.
-`popScope()` → `emitScopeCleanupToDepth()` → `emitArcReleaseVar()` emits
-`CreateLoad` + `CreateCondBr` diamond blocks. If `CreateRetVoid()` has already
-terminated the current BB, those instructions land after the terminator, producing
-malformed IR (multiple terminators / post-terminator instructions). The JIT
-optimizer (`LowerExpectIntrinsicPass` for O2) crashes on such IR.
-
-**Correct epilogue pattern** (from `emitParallelForRange`, `codegen_stmt_loop.cpp:765-766`):
+**Rule**: In any internally-generated thunk (`__ry_thread.N`, `__ry_parallel_for.N`), call `popScope()` **before** `builder_.CreateRetVoid()`. `popScope()` → `emitScopeCleanupToDepth()` → `emitArcReleaseVar()` emits `CreateLoad` + `CreateCondBr` diamonds; if `CreateRetVoid()` already terminated the BB, those land after the terminator → malformed IR → `LowerExpectIntrinsicPass` (O2) crashes.
 
 ```cpp
-// body terminated by explicit return?  ReturnStmt already drained
-// arc_managed_vars_; iterator_malloc_stack_ items also emitted; skip.
+// from emitParallelForRange, codegen_stmt_loop.cpp:765-766
 if (!builder_.GetInsertBlock()->getTerminator()) {
     popScope();
     if (!builder_.GetInsertBlock()->getTerminator())
@@ -208,221 +83,102 @@ if (!builder_.GetInsertBlock()->getTerminator()) {
 }
 ```
 
-Note: if `iterator_malloc_stack_` at the current scope has items,
-`emitScopeCleanupToDepth` emits `free` calls but does **not** clear the vector
-(`codegen.cpp:384-390`). If `ReturnStmt` already fired `emitScopeCleanupToDepth(0)`,
-those free calls were already emitted; an unconditional subsequent `popScope()` would
-re-emit them into the (terminated) block. The `if (!terminated)` outer guard prevents
-this double-free / post-terminator insertion.
+If `iterator_malloc_stack_` at the current scope has items, `emitScopeCleanupToDepth` emits `free` calls but does NOT clear the vector (`codegen.cpp:384-390`). If `ReturnStmt` already fired `emitScopeCleanupToDepth(0)`, an unconditional `popScope()` would re-emit them into the terminated block. The `if (!terminated)` outer guard prevents this.
 
-**IR verification gap**: `threadSpawn` thunks now have `llvm::verifyFunction`
-(`codegen_call_thread.cpp:284-288`). `emitParallelForRange` does not yet have it
-(follow-up opportunity). Root cause of #1090 was the missing verify — the malformed
-IR survived codegen and crashed only during JIT optimization.
-
----
+**Verification gap**: `threadSpawn` thunks now have `llvm::verifyFunction` (`codegen_call_thread.cpp:284-288`); `emitParallelForRange` does not yet — root cause of #1090 was the missing verify.
 
 ### `~CodeGen()` glibc heap-check crashes are not destructor bugs
 
-**Source**: #1161 / #1167 (2026-04-18)
+**Source**: #1161 / #1167
 **Tags**: codegen, arc, glibc, debugging, heap-corruption, gotcha
 
-**Scope**: This entry covers crashes that **persist under ASan** (i.e. ASan itself reports
-a heap-buffer-overflow or use-after-free). For crashes where all test cases pass and only
-the teardown crashes — and the crash disappears on re-run — see the ORC JIT flake entry
-([`LLVM ORC JIT intermittent crash`](#llvm-orc-jit-intermittent-crash-in-lljit--removeresourcetracker--codegen-linux--macos))
-instead; those are pre-existing LLVM ORC flakiness, not user-code bugs.
+**Rule**: When `CodeGen::~CodeGen()` aborts on Linux glibc with `corrupted size vs. prev_size while consolidating` and reproduces persistently (especially under ASan), treat it as an **earlier** OOB write or UAF in ARC-managed runtime buffers (Map/List/Set CoW copies, ARC headers) detected only when a neighbouring chunk is freed during `ThreadSafeModule` teardown. NOT a destructor-ordering or member-lifetime bug.
 
-**Rule**: When `ry::CodeGen::~CodeGen()` aborts on Linux glibc with
-`corrupted size vs. prev_size while consolidating` **and the crash reproduces persistently**
-(especially under ASan), treat it as an **earlier** OOB write or UAF in ARC-managed
-runtime buffers (Map/List/Set CoW copies, ARC headers) that glibc only detects when a
-neighbouring chunk is freed during `ThreadSafeModule` teardown — not as a destructor-ordering
-or member-lifetime bug in `CodeGen` itself.
-
-**Why `~CodeGen()` is not the culprit**:
-- `~CodeGen` is compiler-generated. `mod_` / `ctx_` are moved into
-  `ThreadSafeModule` at `src/codegen.cpp:575`; the destructor never touches IR objects.
-- ARC tracking sets (`include/ry/codegen.hpp:184-193`) store bare `llvm::Value*`
-  and only walk hash buckets at destruction — no dereference.
+`~CodeGen` is compiler-generated; `mod_`/`ctx_` are moved into `ThreadSafeModule` at `src/codegen.cpp:575` (destructor never touches IR). ARC tracking sets store bare `llvm::Value*` and only walk hash buckets — no dereference.
 
 **Diagnostic checklist**:
-1. Reproduce on Linux with ASan (ARM64 Docker via `docker/run.sh asan`; x86_64 CI
-   asan job on `v*` push). macOS libSystem malloc does not expose glibc's chunk
-   metadata checks, so the crash is Linux-only even with the same bug.
-2. ASan will pinpoint the actual OOB/UAF site instead of just the late `free()`.
-3. Look first at recent changes to `emitCowCheckSlot` / `emitCowDeepCopy*` /
-   `emitMapKeyLookup` / `emitSetElementLookup`: ARC retain gating, `keyName` /
-   `elemName` propagation, and hash-vs-linear-scan branch selection are the
-   class of change that introduced `~CodeGen()` crash #1161.
+1. Reproduce on Linux with ASan (ARM64 Docker via `docker/run.sh asan`; x86_64 CI asan on `v*` push). macOS libSystem malloc doesn't expose glibc chunk-metadata checks — Linux-only even with the same bug.
+2. ASan pinpoints the actual OOB/UAF site instead of the late `free()`.
+3. Look first at recent changes in `emitCowCheckSlot` / `emitCowDeepCopy*` / `emitMapKeyLookup` / `emitSetElementLookup`: ARC retain gating, `keyName`/`elemName` propagation, hash-vs-linear-scan branch selection.
 
-**History**: #1161 crash (`corrupted size vs. prev_size`) was observed after PR #1148
-landed. The bug was most likely a heap-layout-dependent OOB that became non-reproducible
-after PR #1160 (`emitCowCheckSlot` `doKeyRetain` unconditional + `emitMapKeyLookup`
-`keyName` fix). CI ASan clean on x86_64 Linux was confirmed at commit `998edc42`
-(CI run #24601715375, 2026-04-18). The exact commit that fixed it was not bisected;
-if the crash re-appears, revert to the diagnostic checklist above.
-
----
+**Scope**: this entry is for crashes ASan reports as heap-buffer-overflow / UAF. Crashes where all tests pass and only the teardown crashes (disappears on rerun) are pre-existing LLVM ORC flakiness — see the `LLVM ORC JIT intermittent crash` entry instead.
 
 ### Ry runtime panics bypass C++ exceptions — they `fprintf + exit(1)`
 
 **Source**: #828
 **Tags**: panic, runtime, exception, thread, gotcha
 
-**Rule**: Every `CodeGen::emitRuntimeError` call site emits IR that
-runs `fprintf(stderr, ...)` followed by `exit(1)` +
-`CreateUnreachable` (`src/codegen_call_user.cpp:600-618`). Ry's user-level
-panics (divide-by-zero, array OOB, range/contract violations,
-integer overflow, etc.) therefore **terminate the entire process
-immediately** — they do not propagate as C++ exceptions. Any
-feature that plans to "catch a worker panic and report it as a
-value" (e.g. `threadJoin(t) -> Err` for a panicking worker,
-`blockOn(task) -> Err` for a panicking async body) cannot rely on
-existing defensive `try { ... } catch (std::exception &)` blocks
-inside runtime functions — those only fire for C++ exceptions
-that escape from LLVM-generated code, which never happens for
-user panics. The existing catch in `__ry_thread_spawn`
-(`src/runtime_thread.cpp`) is dormant defensive code, not an
-active error-propagation path. Fixing this requires refactoring
-`emitRuntimeError` to `throw std::runtime_error(...)` + installing
-a top-level catch in `ry run` / `ry test` — tracked in #880.
-Before writing tests that trigger a panic and expect
-`Err(error_msg)`, verify that the panic *actually* throws a C++
-exception; the only current throw path from runtime code is
-`__ry_task_join` double-join (`src/runtime_parallel.cpp:292`) and a
-handful of compile-time lexer/loader errors.
+**Rule**: `CodeGen::emitRuntimeError` emits IR that runs `fprintf(stderr, ...)` + `exit(1)` + `CreateUnreachable` (`src/codegen_call_user.cpp:600-618`). Ry's user-level panics (divide-by-zero, OOB, range/contract violations, integer overflow) **terminate the entire process** — they do NOT propagate as C++ exceptions.
 
-### `ListHeader` / `IOListHeader` returned to Ry code must be `arc_alloc`'d, not `checked_malloc`'d
+Features planning to "catch a worker panic and report as a value" (`threadJoin → Err`, `blockOn → Err`) cannot rely on existing defensive `try/catch (std::exception &)` blocks — those only fire for C++ exceptions escaping LLVM-generated code, which never happens for user panics. The catch in `__ry_thread_spawn` is dormant. Fixing this requires refactoring `emitRuntimeError` to `throw std::runtime_error` + a top-level catch in `ry run`/`ry test` (tracked in #880).
 
-**Source**: #997 (2026-04-16, fix)
-**Tags**: runtime, arc, list, memory-safety, allocation
+**Before writing tests** that trigger a panic and expect `Err(error_msg)`, verify the panic actually throws a C++ exception. Current throw paths from runtime: `__ry_task_join` double-join (`src/runtime_parallel.cpp:292`) and a few compile-time lexer/loader errors.
 
-**Rule**: Every list header (`ListHeader*` or `IOListHeader*`) returned from a
-C++ runtime function to Ry code must be allocated with `arc_alloc(sizeof(…))`,
-not `checked_malloc(sizeof(…))`. The Ry ARC machinery reads/writes
-`header_ptr - 16` (the ARC prefix) when retaining or releasing the list.
-If the header is plain `checked_malloc`, this access lands in malloc metadata
-→ use-after-free / bad-free at scope exit.
+### NUL-safety at C API boundaries: `stringByteLen`, `hasEmbeddedNul`, propagating nullptr
 
-Applies to:
-- `ListHeader` (string/match lists): use `makeStringList` / `makeMatchList` in
-  `include/ry/runtime_list.hpp` — these already use `arc_alloc`.
-- `IOListHeader` (byte lists): use `makeByteList` in `include/ry/runtime_io.hpp`;
-  also `makeEmptyIOList` in `runtime_net.cpp` and inline allocations in
-  `runtime_net.cpp` / `runtime_tls.cpp` / `runtime_io.cpp` — all converted in #997.
+**Source**: PR #1054
+**Tags**: nul-safety, c-api-boundary, stringByteLen, hasEmbeddedNul, Result
 
-**C++ tests that wrap these headers**: Use `arc_free(header)` (from
-`include/ry/runtime_arc.hpp`) instead of `free(header)`. The `data` array
-inside the header is separately `checked_malloc`'d and must be freed with plain
-`free`. Individual string elements created by `dupString` are also plain
-`checked_malloc` and freed with plain `free`.
+**Rule**: PR #1022 introduced `StringHeader.byte_len`, allowing Ry `str` to contain embedded NUL. C APIs (`realpath`, `stat`, `mkdir`, `getaddrinfo`) silently truncate at `\0`. Apply three patterns:
 
-### NUL-safety at C API boundaries: `stringByteLen`, `hasEmbeddedNul`, and propagating nullptr
+**1. Use `stringByteLen(handle)` instead of `strlen(handle)`** for any function receiving a Ry `str` handle.
 
-**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: nul-safety, c-api-boundary, stringByteLen, hasEmbeddedNul, Result
-
-**Rule**: PR #1022 introduced `StringHeader` with an explicit `byte_len` field, allowing Ry `str`
-to contain embedded NUL bytes. C library APIs (`realpath`, `stat`, `mkdir`, `getaddrinfo`, etc.)
-assume NUL-terminated strings and silently truncate at the first `\0`. Apply the following three
-patterns consistently when implementing or auditing runtime functions that pass Ry string handles
-to POSIX/libc:
-
-**1. Use `stringByteLen(handle)` instead of `strlen(handle)`**:
+**2. Validate with `hasEmbeddedNul` before NUL-sensitive C APIs**:
 ```cpp
-// Wrong (silently truncates at \0):
-size_t n = strlen(handle);
-// Right:
-size_t n = static_cast<size_t>(stringByteLen(handle));
-```
-
-**2. Validate with `hasEmbeddedNul` before passing to NUL-sensitive C APIs**:
-```cpp
-// Defined in include/ry/runtime_string.hpp:
-inline bool hasEmbeddedNul(const char *handle) {
-    if (!handle) return false;
-    size_t n = static_cast<size_t>(stringByteLen(handle));
-    return n > 0 && memchr(handle, '\0', n) != nullptr;
-}
-
-// Usage in runtime functions:
 if (hasEmbeddedNul(p)) {
     setLastError("path.basename: argument contains an embedded NUL byte");
-    return nullptr;  // caller wraps as Result<str, Error> via ResultPtr
+    return nullptr;  // wraps as Result<str, Error> via ResultPtr
 }
 ```
 
-**3. Propagate `nullptr` through chained join-style helpers**:
-When a helper like `join2_impl(a, b)` returns nullptr on NUL, callers must guard and propagate:
+**3. Propagate `nullptr` through chained join helpers**:
 ```cpp
-extern "C" const char *__ry_path_join3(const char *a, const char *b, const char *c) {
-    char *ab = join2_impl(a, b);
-    if (!ab) return nullptr;  // without this, join2_impl(nullptr, c) silently returns c
-    char *result = join2_impl(ab, c);
-    freeStringSlot(ab);
-    return result;
-}
+char *ab = join2_impl(a, b);
+if (!ab) return nullptr;  // without this, join2_impl(nullptr, c) silently returns c
+char *result = join2_impl(ab, c);
 ```
-Without the `if (!ab)` guard, `join2_impl(nullptr, c)` treats nullptr as empty string and returns
-a copy of `c` — silently succeeding when it should propagate the error.
 
 **How to apply**:
-- Binary-safe consumers (HTTP body, multipart file values): use `stringByteLen` for length; do NOT
-  reject NUL — these legitimately carry binary payloads.
-- Text/path consumers (URLs, host names, header names, file paths): reject NUL with `hasEmbeddedNul`
-  and return `Err` / nullptr.
-- Upgrade bare `-> str` runtime functions that pass user strings to NUL-sensitive C APIs to
-  `-> Result<str, Error>` (return nullptr + `setLastError`; set `ReturnWrapping::ResultPtr` in
-  the dispatch table).
-- **Audit scope**: PR #1054 covered libc-sensitive modules (path, net, http, http_client,
-  filesystem) but not binary-safe stdlib (e.g. base64). When adding a new stdlib module, grep
-  its runtime for `strlen(input)` and replace with `stringByteLen(input)` for any function that
-  receives a Ry `str` handle. `base64` was fixed as a post-#1054 follow-up in #1129.
+- Binary-safe consumers (HTTP body, multipart values): use `stringByteLen` for length; do NOT reject NUL.
+- Text/path consumers (URLs, host names, header names, file paths): reject NUL with `hasEmbeddedNul`, return `Err`/nullptr.
+- Upgrade bare `-> str` runtime fns passing user strings to NUL-sensitive C APIs to `-> Result<str, Error>` (return nullptr + `setLastError`; set `ReturnWrapping::ResultPtr`).
+- **Audit scope**: PR #1054 covered libc-sensitive modules (path, net, http, http_client, filesystem) but not binary-safe stdlib (e.g. base64). When adding a new module, grep its runtime for `strlen(input)`. `base64` was a post-#1054 follow-up in #1129.
 
 ### `hasEmbeddedNul` / `stringByteLen` are only safe on Ry string handles — never on raw C strings
 
-**Source**: PR #1054 (fix/1054-nul-safety-c-boundaries). **Tags**: nul-safety, stringheader, c-api-boundary, runtime
+**Source**: PR #1054
+**Tags**: nul-safety, stringheader, c-api-boundary, runtime
 
-**Rule**: Both `hasEmbeddedNul(handle)` and `stringByteLen(handle)` read a `StringHeader` struct
-immediately *before* the pointer to obtain `byte_len`. This is only valid when `handle` points
-into a Ry string slot (i.e., the pointer came from `makeString` or was read from a Ry `str` handle).
+**Rule**: Both read a `StringHeader` struct **before** the pointer to obtain `byte_len`. Valid only when `handle` originated from a Ry string slot (`makeString` or read from a Ry `str`).
 
-**It is undefined behaviour** (reads garbage memory) when applied to:
-- C string literals: `hasEmbeddedNul("POST")` — no `StringHeader` prefix
-- `std::string::c_str()` results — allocated by the STL without a `StringHeader`
-- `strdup`/`malloc`-allocated strings (e.g. map keys built by C++ tests) — no `StringHeader` prefix
-- Any other raw `const char *` that did not originate from a Ry string slot
+**UB** when applied to:
+- C string literals: `hasEmbeddedNul("POST")` — no `StringHeader` prefix.
+- `std::string::c_str()` results — STL has no `StringHeader`.
+- `strdup`/`malloc`-allocated strings (e.g. map keys built by C++ tests).
+- Any other raw `const char *` not from a Ry slot.
 
-**Symptoms**:
-- `hasEmbeddedNul` false positive: reads random bytes as `byte_len`, `memchr` finds NUL → returns
-  `true` unexpectedly, causing the runtime function to return nullptr and HTTP mock server tests
-  to hang (server `::accept` waits for a client that never connects).
-- `stringByteLen` garbage value: random bytes interpreted as body/data length → `Content-Length`
-  header wildly wrong → HTTP server reads wrong number of bytes → test hangs.
+**Symptoms** are silent: `hasEmbeddedNul` false positive returns `nullptr` from runtime fn → HTTP mock server `::accept` waits forever (test hangs). `stringByteLen` garbage value → `Content-Length` wildly wrong → server reads wrong byte count → hang.
 
-**How to apply**: Only call `hasEmbeddedNul` inside codegen emitters (where arguments are known
-Ry handles) or inside runtime functions whose callers pass exclusively Ry handles. If a runtime
-fn is also called from C++ unit tests with `.c_str()` or with C literals, move the NUL
-check to the codegen emitter.
+**How to apply**: Only call from codegen emitters (where args are known Ry handles), or from runtime fns whose callers pass exclusively Ry handles. If the runtime fn is also called from C++ tests with `.c_str()` or C literals, move the NUL check to the codegen emitter.
 
-### Do not call `setLastError` in bool-return runtime functions — thread-local `last_error_buf` pollution
+### Do not call `setLastError` in bool-return runtime functions — thread-local pollution
 
-**Source**: #1128 (2026-04-18). **Tags**: nul-safety, setLastError, thread-local, runtime, bool-return
+**Source**: #1128
+**Tags**: nul-safety, setLastError, thread-local, runtime, bool-return
 
-**Rule**: `setLastError` writes to a thread-local buffer (`last_error_buf` in `runtime_error.cpp`). In runtime functions whose Ry return type has **no error channel** (e.g. `bool`-returning `__ry_file_exists`), calling `setLastError` when rejecting NUL would leave stale error text in the buffer. The next Result-returning call on the same thread that fails an unrelated check reads the buffer for `e.message`, and would silently report the stale NUL rejection message instead of its own.
+**Rule**: `setLastError` writes a thread-local buffer (`last_error_buf` in `runtime_error.cpp`). In runtime fns whose Ry return type has **no error channel** (e.g. bool-returning `__ry_file_exists`), calling `setLastError` on NUL rejection leaves stale text in the buffer. The next Result-returning call on the same thread that fails an unrelated check reads the buffer for `e.message` and silently reports the stale NUL message instead of its own.
 
 **How to apply**:
-- Bool-return-only functions (e.g. `exists`) that detect an invalid argument: return the safe conservative value (`false` / `0`) silently — do **not** call `setLastError`.
-- Result-returning functions: call `setLastError("fn: argument contains an embedded NUL byte")` before returning `nullptr` / `1`.
-- This matches the split used in `src/runtime_io.cpp` after #1128: `__ry_file_exists` has `if (hasEmbeddedNul(path)) return 0;` with no `setLastError`, while all other path-taking functions call it.
+- Bool-return-only fns detecting an invalid argument: return the safe conservative value (`false`/`0`) silently — do NOT call `setLastError`.
+- Result-returning fns: `setLastError("fn: argument contains an embedded NUL byte")` before returning `nullptr`/`1`.
+- Reference split in `src/runtime_io.cpp` after #1128: `__ry_file_exists` has `if (hasEmbeddedNul(path)) return 0;` with no `setLastError`; all other path-taking fns call it.
 
 ### Forbidden heap allocation functions in new C++ code
 
-**Source**: #1498 (migrated from AGENTS.md, 2026-05-02)
+**Source**: #1498
 **Tags**: runtime, memory-safety, malloc, oom, checked_malloc, forbidden-functions, lint
 
-**Rule**: Use the safe wrappers from `include/ry/runtime_alloc.hpp`.
-The following functions must **not** be called directly in new code:
+**Rule**: Use the safe wrappers from `include/ry/runtime_alloc.hpp`. The following must NOT be called directly:
 
 | Forbidden | Replacement | Reason |
 |-----------|-------------|--------|
@@ -431,13 +187,9 @@ The following functions must **not** be called directly in new code:
 | `calloc` | `checked_malloc` + `memset` | OOM → null |
 | `strdup` | `checked_strdup` | OOM → null |
 | `strndup` | `checked_strndup` | OOM → null |
-| `malloc(count * sizeof(T))` | `checked_array_malloc(count, sizeof(T))` | integer overflow → heap buffer overflow |
+| `malloc(count * sizeof(T))` | `checked_array_malloc(count, sizeof(T))` | int overflow → heap buffer overflow |
 
 Additional rules:
-- On OOM, call `oom_abort(n)` with the requested size and abort
-  immediately — do not return `nullptr`.
-- Before passing external input (HTTP request body, JSON parse result,
-  etc.) to `strcmp` / `strlen`, check for NULL.
-- The CI `lint` job detects direct calls to forbidden functions and
-  auto-blocks new additions.
-
+- On OOM, call `oom_abort(n)` with the requested size and abort — do not return `nullptr`.
+- Before passing external input (HTTP body, JSON parse result, etc.) to `strcmp` / `strlen`, check for NULL.
+- The CI `lint` job auto-blocks new direct calls to forbidden functions.

--- a/.claude/skills/horizontal-sweep/SKILL.md
+++ b/.claude/skills/horizontal-sweep/SKILL.md
@@ -40,7 +40,7 @@ These legacy identifiers are intentionally preserved (see `AGENTS.md:5`). Add th
 
 ### Step 1: Build the canonical + derivative word table
 
-Use the canonical pairs in `.claude/rules/docs-reference-conventions.md:375-389` as the reference table — do not duplicate it. Add project-specific derivatives only when they are absent from the canonical table. For approved Ry abbreviations consult `docs/reference/naming.md` "Approved abbreviations".
+Use the canonical pairs in the "Terminology sweeps must include lexical derivatives" entry of `.claude/rules/docs-reference-conventions.md` as the reference table — do not duplicate it. Add project-specific derivatives only when they are absent from the canonical table. For approved Ry abbreviations consult `docs/reference/naming.md` "Approved abbreviations".
 
 Worked example for `package` → `module`:
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -11,3 +11,41 @@
 **Tags**: <空白区切りキーワード>
 **Rule**: <教訓本文>
 -->
+
+### Named arguments for builtins: generic parse, builtin-only dispatch
+
+**Source**: #747 (2026-04-14, migrated from `codegen-stdlib-dispatcher.md` 2026-05-10)
+**Tags**: codegen, builtins, named-args, parser, print
+
+**Rule**: Ry has generic named-arg parsing (`std::vector<NamedArg> named_args` on `CallExpr`/`CallStmt`) but codegen-time restricts use to builtins. Non-builtin calls with named args emit a codegen error at `src/codegen_call_user.cpp:504` (`if (!s.named_args.empty() && builtins_.find(s.callee) == builtins_.end())`). The `=` token is never valid inside an expression (equality uses `==`), so the lookahead in `parseArgList()` is unambiguous.
+
+**Why this design (option 3)**: Of three options considered — (1) full language-wide named args, (2) parser-side special-case for `print`, (3) generic parse + builtin-only codegen — option 3 was chosen to keep parser AST-agnostic without a full type-checker rewrite.
+
+**How to apply**: When adding the next named-arg builtin, only `emitPrint()` in `src/codegen_call_io.cpp` and the `builtins_` map in `src/codegen.cpp` need updating. To lift the builtin-only restriction later, remove the check at `codegen_call_user.cpp:504` and add type-checker support.
+
+### #1156: split match subject type into enum-only vs broad source name
+
+**Source**: PR #1156 fix for `codegen_match.cpp` subjectEnumType wrong channel (migrated from `codegen-stdlib-dispatcher.md` 2026-05-10 — that file's `paths:` did not match `src/codegen_match.cpp`)
+**Tags**: pattern, match, ARC, codegen, Option, Result, tuple, subjectEnumType
+
+**Rule**: `emitPatternTest`, `emitPatternBindings`, and `checkMatchExhaustiveness` take **two** source-name parameters:
+
+- `subjectEnumName` — narrow channel (`ValueMetadata::enum_value_type`). Only set for enum/ADT subjects (from `resolveEnumType()`). Used by `EnumPattern`/`EnumConstructorPattern` generic-instantiated lookup, by `Some`/`Ok`/`Err` binding `extractGenericTypeArg`, and by `VariablePattern` binding's `enum_value_type` write (still guarded by `enum_types_.count(resolveTypeAlias(name))`).
+- `subjectSourceTypeName` — broad channel (`resolveSubjectSourceTypeName()`). Reconstructs `Option<T>` / `Result<T, E>` / `(T1, T2, ...)` from the LLVM subject type when no enum annotation exists. Used by `TuplePattern` / `RecordPattern` structural verification and by `emitPatternBindingArc` Path 2a from `VariablePattern` only.
+
+**Reconstruction lossiness**: `reverseResolveTypeName(ptrTy_)` returns `"str"`; unknown structs return `"any"`. So `Option<List<int>>` reconstructs as `"Option<str>"`. The reconstructed string is therefore **only** safe for structural checks ("is this a tuple struct?" / "does this match record name X?"). Do NOT re-feed it into `extractGenericTypeArg` for ARC payload classification — `Option<List<int>>` would be misclassified as `Option<str>` (wrong header offset: str uses -24, List uses -16), causing heap corruption under ASan.
+
+**Defense-in-depth on TuplePattern**: the test arm rejects via `!sTy || !isTupleStructType(sTy)` regardless of any source name. This fires even when both names are empty — closing the path where Option's `{i1, T}` 2-element struct silently passed the 2-arity check and crashed with ICmp type mismatch (original #1156 crash vector).
+
+**Why split rather than unify**: overloading the previous single `subjectEnumType` parameter with non-enum names would force every consumer to add an `enum_types_.count(name)` guard. The split signature makes "enum-only" vs "broader subject type" a compile-time-enforced distinction.
+
+**Follow-up**: Add a lossless `source_type_name` field to `ValueMetadata` so `Option<List<int>>` reconstruction is accurate, enabling ARC Path 2a for nested generics (currently handled by Path 2b heuristic via `propagateMeta`). Pre-existing defect in `emitListSlice`: ARC retain omitted for reference-typed elements (#1204) — tracked separately.
+
+### Cross-check operator-level specs before flagging per-file code examples as drift
+
+**Source**: #1118 PR 4 docs audit (migrated from `docs-reference-conventions.md` 2026-05-10 — procedural audit lesson, code-side guard exists at `src/codegen_expr.cpp:1941`)
+**Tags**: documentation, audit, drift, operators
+
+**Rule**: When a per-file doc example uses a language operator (`?`, `!!`, `case`, `@` directives, etc.), do NOT judge it solely by analogy with how that operator appears in fn bodies. Always: (1) Check `docs/reference/operators.md` for the full spec (including top-level usage rules); (2) Cross-check `src/codegen_expr.cpp` or the relevant codegen for the operator's desugar behavior in different contexts (function body vs. top level vs. lambda). For `?` operator specifically, the top-level desugar constraint is `src/codegen_expr.cpp:1941` (`Err` type must be `Error` exactly; codegen emits `'?' at top level: Result err type must be Error`).
+
+**Why this matters**: During PR 4 audit of `docs/reference/base64.md`, a top-level `?` example was initially flagged as drift, but `docs/reference/operators.md:165-177` documents it as legal. The false alarm arose because only per-package docs were consulted, not the canonical operator spec.


### PR DESCRIPTION
## Summary

- 8 つの path-scoped rule ファイルを圧縮(平均 -34%、合計 -2294 行)。冗長な Context 段落・Pre-#XXXX 履歴・Why/How の重複を削除し、Rule / How to apply / How to verify / mechanism Why / code example / hit-site / rejected-alternative はすべて保持
- 3 件のエントリを KNOWLEDGE.md に移行(named-args builtins、#1156 split match-subject type、per-file doc audit operator cross-check)
- `horizontal-sweep/SKILL.md` の hardcoded 行範囲参照を heading-based 参照に置き換え(圧縮で行番号が変わるため)

| File | 変更 |
|---|---|
| `ci-workflows.md` | -202 |
| `codegen-arc-cow.md` | -393 |
| `codegen-fn-and-generic.md` | -166 |
| `codegen-stdlib-dispatcher.md` | -180 |
| `codegen-type-and-metadata.md` | -598 |
| `docs-reference-conventions.md` | -161 |
| `parser-conventions.md` | -137 |
| `runtime-memory-safety.md` | -209 |
| `KNOWLEDGE.md` | +38 |
| `horizontal-sweep/SKILL.md` | ±1 |

## Test plan

- [ ] 各 rule ファイルが引き続き frontmatter `paths:` glob で auto-load されることを確認
- [ ] KNOWLEDGE.md に移行したエントリが grep で発見可能(`grep -rnE '\*\*Tags\*\*:.*<keyword>' .claude/rules/ .claude/skills/ KNOWLEDGE.md`)
- [ ] `horizontal-sweep/SKILL.md` Step 1 の参照先が heading で resolve できる

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three new technical reference entries to the internal knowledge base. Coverage includes language feature parsing behavior, pattern matching implementation strategies, and specification validation best practices for code review. Enhanced documentation supports development and maintenance workflows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1710)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->