### PR TITLE
feat(testing): support fn-typed args in verifyCalledWith with pointer equality

### DIFF
--- a/changelog.d/1707-verifycalledwith-fn-args.md
+++ b/changelog.d/1707-verifycalledwith-fn-args.md
@@ -1,0 +1,22 @@
+### Added
+
+- `verifyCalledWith(name, args...)` now accepts **function-typed**
+  arguments (`fn(...) -> R` parameters and capture closures), compared
+  by **pointer equality** on the underlying `{thunk_ptr, env_ptr}` pair
+  extracted from the uniform closure struct.
+  - The same closure value passed twice matches (e.g. `let g = lambda;
+    f(g); f(g); verifyCalledWith("f", g)` returns `2`); two
+    independently-constructed but structurally identical lambdas do
+    not match.
+  - Bare `@public fn` references and `let g = f` aliases share the same
+    cached forwarding thunk, so passing `f` and `g` interchangeably
+    matches as expected.
+  - Capture closures with different captured environments (e.g.
+    `makeAdder(5)` vs `makeAdder(6)`) are distinguished by the
+    per-instance `env_ptr` even though they share a single cached
+    capturing thunk.
+  - The fn-snapshot side-table holds `{thunk_ptr, env_ptr}` pairs as
+    plain copies — closure environments are not ARC-retained because
+    the issue's contract is pointer equality only; the caller scope
+    keeps the underlying closure alive for the duration of the test
+    block. (#1707)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -330,18 +330,32 @@ fn verifyCalledWithTests():
         expect(verifyCalledWith("takesStrIntMap", {"b": 2, "a": 1})).toEq(1)
         expect(verifyCalledWith("takesStrIntMap", {"c": 3})).toEq(1)
         expect(verifyCalledWith("takesStrIntMap", {"x": 9})).toEq(0)
+
+    @it("should match fn-typed argument by pointer equality")
+    fn shouldCountFnMatching():
+        mock("takesFn", (f: fn(int) -> int) => f(0))
+        lam = (x: int) => x + 1
+        takesFn(lam)
+        takesFn(lam)
+        # Same closure value → match.
+        expect(verifyCalledWith("takesFn", lam)).toEq(2)
+        # Independently constructed structurally identical lambda
+        # → no match (different thunk pointer).
+        other = (x: int) => x + 1
+        expect(verifyCalledWith("takesFn", other)).toEq(0)
 ```
 
 - Requires `from testing import verifyCalledWith`
 - The first argument must be a string literal — variables / runtime strings are rejected at compile time. This restriction lets the compiler validate the remaining argument types against the original function's signature.
 - The function must already be mocked via `mock(...)` before `verifyCalledWith` is called; calling on a non-mocked function is a compile error.
 - The number and types of `args...` must exactly match the original function's parameter list. Arity mismatch and type mismatch are compile errors.
-- Supported argument types: `int`, `float`, `bool`, `str` (since v0.0.22, #1677), `List<T>` where `T ∈ {int, float, bool, str}` (since v0.0.22, #1703), `Set<T>` where `T ∈ {int, float, bool, str}` (since v0.0.22, #1704), `Map<K, V>` where `K, V ∈ {int, float, bool, str}` (since v0.0.22, #1705), record types whose fields are all in `{int, float, bool, str}` (since v0.0.22, #1706), and tuple types whose elements are all in `{int, float, bool, str}` (since v0.0.22, #1706). Other types (nested `List<List<T>>`, records or tuples containing collections, function values) are rejected at compile time and are tracked for v0.0.x follow-up.
+- Supported argument types: `int`, `float`, `bool`, `str` (since v0.0.22, #1677), `List<T>` where `T ∈ {int, float, bool, str}` (since v0.0.22, #1703), `Set<T>` where `T ∈ {int, float, bool, str}` (since v0.0.22, #1704), `Map<K, V>` where `K, V ∈ {int, float, bool, str}` (since v0.0.22, #1705), record types whose fields are all in `{int, float, bool, str}` (since v0.0.22, #1706), tuple types whose elements are all in `{int, float, bool, str}` (since v0.0.22, #1706), and `fn(...) -> R` (function-typed) arguments compared by pointer equality (since v0.0.22, #1707). Other types (nested `List<List<T>>`, records or tuples containing collections) are rejected at compile time and are tracked for v0.0.x follow-up.
 - `List<T>` arguments are compared by deep snapshot: the recorded call snapshot and the verify-side snapshot must agree on length and element-wise equality. Element comparison is byte-exact for `int` / `float` / `bool` and uses NUL-safe length+`memcmp` for `str`.
 - `Set<T>` arguments are compared by **unordered** deep snapshot: the recorded and verify-side snapshots must have the same length and the same elements as a set, but element order is irrelevant (e.g. recording `{1, 2, 3}` matches `verifyCalledWith("f", {3, 2, 1})`). Per-element comparison uses the same byte-exact / NUL-safe rules as `List<T>`.
 - `Map<K, V>` arguments are compared by **unordered** deep snapshot of the {key → value} pairs: the recorded and verify-side snapshots must have the same length and the same key set, with each key mapping to the same value across the two maps. Insertion order is irrelevant (e.g. recording `{"a": 1, "b": 2}` matches `verifyCalledWith("f", {"b": 2, "a": 1})`). Per-key and per-value comparison uses the same byte-exact / NUL-safe rules as `List<T>`.
 - Record arguments are compared by declared **type name** plus field-by-field equality. Two records with structurally identical fields but different declared names (e.g. `Point(1, 2)` vs `Vec(1, 2)`) do not match and are rejected at compile time when the parameter type is fixed. Per-field comparison uses the same byte-exact / NUL-safe rules as `List<T>`.
 - Tuple arguments are compared by **arity** plus element-by-element equality. Tuples with different arity do not match and are rejected at compile time. Per-element comparison uses the same byte-exact / NUL-safe rules as `List<T>`.
+- `fn(...) -> R` arguments are compared by **pointer equality** on the `{thunk_ptr, env_ptr}` pair extracted from the uniform closure struct, not by structural / behavioral equivalence. Two independently constructed lambdas that happen to be structurally identical (e.g. `(x: int) => x + 1` written twice on different source lines) do not match — only the same closure value (a single named `let f = ...` flowing into both the recorded call and the verify side, or two `let` aliases of the same bare `@public fn`) matches. Capture closures with different captured environments (e.g. `makeAdder(5)` vs `makeAdder(6)`) are distinguished by the per-instance `env_ptr` even though they share a single cached capturing thunk. The fn signature itself is opaque to `verifyCalledWith` — only the pointer pair matters.
 - `int` argument literals are widened to `float` automatically when the parameter type is `float` (matching ordinary call-site coercion).
 - Returns `0` when no recorded call matches the supplied arguments.
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -291,6 +291,9 @@ fn takesIntSet(xs: Set<int>) -> int:
 fn takesStrIntMap(m: Map<str, int>) -> int:
     return len(m)
 
+fn takesFn(f: fn(int) -> int) -> int:
+    return f(0)
+
 @describe("verifyCalledWith")
 fn verifyCalledWithTests():
     @it("should count calls matching argument")

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -381,7 +381,7 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         //   8=map  (snapshot ptr; #1705 — unordered key->value; key/val kind ∈ {1..4}),
         //   9=record (snapshot ptr; #1706 — per-slot compare; field kind ∈ {1..4}),
         //  10=tuple  (snapshot ptr; #1706 — per-slot compare; element kind ∈ {1..4}),
-        //  11=fn (reserved).
+        //  11=fn    (snapshot ptr; #1707 — pointer-equality on {thunk, env}).
         llvm::FunctionType *mockBeginRecTy =
             llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
         llvm::FunctionCallee mockBeginRecFn = mod_->getOrInsertFunction(
@@ -735,6 +735,38 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
                     }
                 }
                 if (emittedRecordOrTuple) continue;
+            }
+            // Fn-typed arg path (#1707): if the declared param type is a
+            // function type, argVals[i] is the post-wrapFnTypedArgs uniform
+            // closure pointer (`{thunk_ptr, env_ptr, env_dtor_ptr}`). Extract
+            // the {thunk_ptr, env_ptr} pair and record as kind=11. env_dtor is
+            // determined by thunk and omitted. Pointer-equality compare lives
+            // in mockArgEqual's kind-11 branch.
+            if (matchedEntry && i < matchedEntry->paramTypeNames.size()) {
+                std::string declared = resolveTypeAlias(
+                    matchedEntry->paramTypeNames[i]);
+                if (isFunctionTypeName(declared) && argTy == ptrTy_) {
+                    auto *ucTy = getUniformClosureTy();
+                    llvm::Value *thunkField = builder_.CreateStructGEP(
+                        ucTy, argVal, 0, "mock_fn.thunk_gep");
+                    llvm::Value *envField = builder_.CreateStructGEP(
+                        ucTy, argVal, 1, "mock_fn.env_gep");
+                    llvm::Value *thunkPtr = builder_.CreateLoad(
+                        ptrTy_, thunkField, "mock_fn.thunk");
+                    llvm::Value *envPtr = builder_.CreateLoad(
+                        ptrTy_, envField, "mock_fn.env");
+                    llvm::FunctionType *mockStoreArgFnTy =
+                        llvm::FunctionType::get(
+                            llvm::Type::getVoidTy(*ctx_),
+                            {ptrTy_, ptrTy_, ptrTy_, ptrTy_}, false);
+                    llvm::FunctionCallee mockStoreArgFnFn =
+                        mod_->getOrInsertFunction(
+                            "__ry_mock_store_arg_fn", mockStoreArgFnTy);
+                    builder_.CreateCall(
+                        mockStoreArgFnFn,
+                        {callRec, thunkPtr, envPtr, nameStr});
+                    continue;
+                }
             }
             int64_t kind = 5;
             llvm::Value *valI64 = llvm::ConstantInt::get(i64Ty_, 0);

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -647,6 +647,10 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
         ptrTy_, {i64Ty_, ptrTy_, ptrTy_}, false);
     llvm::FunctionCallee makeTupleSnapshotFn = mod_->getOrInsertFunction(
         "__ry_mock_make_tuple_snapshot", makeTupleSnapshotTy);
+    llvm::FunctionType *makeFnSnapshotTy = llvm::FunctionType::get(
+        ptrTy_, {ptrTy_, ptrTy_}, false);
+    llvm::FunctionCallee makeFnSnapshotFn = mod_->getOrInsertFunction(
+        "__ry_mock_make_fn_snapshot", makeFnSnapshotTy);
 
     auto isSupportedCollElemName = [](const std::string &n) {
         return n == "int" || n == "float" || n == "bool" || n == "str";
@@ -668,6 +672,9 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                                   declaredParamName.size() >= 2 &&
                                   declaredParamName.front() == '(' &&
                                   declaredParamName.back() == ')';
+        const bool paramIsFn = !paramIsList && !paramIsSet && !paramIsMap &&
+                               !paramIsRecord && !paramIsTuple &&
+                               isFunctionTypeName(declaredParamName);
         std::string paramListInner;
         std::string paramSetInner;
         std::string paramMapKeyInner;
@@ -788,6 +795,11 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 }
                 paramTupleKinds.push_back(k);
             }
+        } else if (paramIsFn) {
+            // #1707: fn-typed params accepted; identity is the {thunk_ptr, env_ptr}
+            // pair extracted from the uniform closure struct. The fn signature
+            // itself is opaque to verifyCalledWith — only pointer equality
+            // matters. No per-param validation needed here.
         } else if (!declaredParamName.empty() &&
                    declaredParamName != "int" && declaredParamName != "float" &&
                    declaredParamName != "bool" && declaredParamName != "str") {
@@ -797,9 +809,9 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             msg += fnName;
             msg += "' has type '";
             msg += declaredParamName;
-            msg += "'; only int, float, bool, str, List<T>, Set<T>, Map<K, V>, "
-                   "record types whose fields are primitives or str, and tuple "
-                   "types whose elements are primitives or str are supported";
+            msg += "'; only int, float, bool, str, fn(...) -> R, List<T>, Set<T>, "
+                   "Map<K, V>, record types whose fields are primitives or str, "
+                   "and tuple types whose elements are primitives or str are supported";
             codegenError(msg);
         }
 
@@ -807,8 +819,32 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
         llvm::Type *argTy = argVal->getType();
         llvm::Type *expectedTy = entry.paramTypes[i];
 
-        // Allow widening int -> float when the original parameter is float.
-        if (argTy != expectedTy) {
+        // For fn params (#1707), normalize the expected value to a uniform
+        // closure (`{thunk, env, env_dtor}` ARC ptr) so {thunk, env} can be
+        // extracted in the kind=11 dispatch below. Bare fn refs and source-level
+        // lambda variables both flow through here; wrapFnTypedArgs only runs on
+        // the recording side (codegen_call_user.cpp:263), so the verify side
+        // must wrap explicitly. Skip the strict argTy/expectedTy compare —
+        // expectedTy is the post-wrap ptrTy_ in the caller's signature, but
+        // argVal at this point may still be a raw fn ptr (Function*) or a
+        // pre-wrap closure value, depending on the source expression.
+        bool fnWrapAllocated = false;
+        if (paramIsFn) {
+            auto *fnInfo = lookupFnTypeInfo(argVal);
+            if (!fnInfo) {
+                codegenError("verifyCalledWith: argument " +
+                             std::to_string(i + 1) +
+                             " of '" + fnName +
+                             "' is fn-typed but its FnTypeInfo could not be "
+                             "recovered; pass a named lambda or function "
+                             "reference (e.g. `let f = (...) => ...; "
+                             "verifyCalledWith(\"...\", f)`)");
+            }
+            fnWrapAllocated = !fnInfo->isUniformClosure;
+            argVal = wrapAsUniformClosure(argVal, *fnInfo);
+            argTy = argVal->getType();
+        } else if (argTy != expectedTy) {
+            // Allow widening int -> float when the original parameter is float.
             if (argTy == i64Ty_ && expectedTy == f64Ty_) {
                 argVal = builder_.CreateSIToFP(argVal, f64Ty_, "vcw_int2f");
                 argTy = f64Ty_;
@@ -1284,6 +1320,37 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                 "vcw_tup_snap");
             kind = 10;
             valI64 = builder_.CreatePtrToInt(snap, i64Ty_, "vcw_snap2i");
+        } else if (paramIsFn) {
+            // #1707: extract {thunk_ptr, env_ptr} from the uniform closure
+            // struct; argVal was normalized to a uniform closure pointer above
+            // via lookupFnTypeInfo + wrapAsUniformClosure. The env_dtor slot
+            // is uniquely determined by thunk and is omitted from the snapshot.
+            auto *ucTy = getUniformClosureTy();
+            llvm::Value *thunkField = builder_.CreateStructGEP(
+                ucTy, argVal, 0, "vcw_fn_thunk_gep");
+            llvm::Value *envField = builder_.CreateStructGEP(
+                ucTy, argVal, 1, "vcw_fn_env_gep");
+            llvm::Value *thunkPtr = builder_.CreateLoad(
+                ptrTy_, thunkField, "vcw_fn_thunk");
+            llvm::Value *envPtr = builder_.CreateLoad(
+                ptrTy_, envField, "vcw_fn_env");
+            llvm::Value *snap = builder_.CreateCall(
+                makeFnSnapshotFn, {thunkPtr, envPtr}, "vcw_fn_snap");
+            kind = 11;
+            valI64 = builder_.CreatePtrToInt(snap, i64Ty_, "vcw_snap2i");
+            // Release the wrap struct allocated above by wrapAsUniformClosure.
+            // wrapAsUniformClosure passes through unchanged when input was
+            // already a uniform closure (no allocation), but for non-uniform
+            // inputs it allocates a fresh ARC struct and retains the captured
+            // env. The default scope-end ARC release uses the generic dtor,
+            // which doesn't know to release env — so we must explicitly
+            // release with the uniform-closure dtor. The snapshot stores raw
+            // {thunk, env} pointers per the issue's pointer-equality contract;
+            // the caller scope keeps the underlying closure alive for the
+            // duration of the test block.
+            if (fnWrapAllocated) {
+                releaseUniformClosureTemps({argVal});
+            }
         } else if (argTy == i64Ty_) {
             kind = 1;
             valI64 = argVal;

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -43,7 +43,8 @@ const char *__ry_test_current_it_name() { return g_current_it_buf; }
 //   8 = map      (ptr to MockMapSnapshot, unordered key->value cmp) — #1705
 //   9 = record   (ptr to MockRecordSnapshot, per-slot compare)      — #1706
 //  10 = tuple    (ptr to MockTupleSnapshot, per-slot compare)       — #1706
-//  11 = fn       (reserved for sibling sub-issue)
+//  11 = fn       (ptr to MockFnSnapshot; pointer-equality on        — #1707
+//                {thunk_ptr, env_ptr})
 struct MockArg {
     int64_t kind;
     int64_t value;
@@ -134,6 +135,19 @@ struct MockTupleSnapshot {
     int64_t *element_values;
 };
 
+// Per-fn argument snapshot for verifyCalledWith (#1707). Identity is the
+// pair {thunk_ptr, env_ptr} extracted from the uniform closure struct
+// `{thunk, env, env_dtor}` produced by wrapAsUniformClosure (env_dtor is
+// determined by thunk and omitted). Pointer equality only — no ARC retain
+// (issue #1707 explicit). Two source-level identical-but-independently-
+// constructed lambdas produce different forwarding/capturing thunks via
+// forwarding_thunk_cache_ / capturing_thunk_cache_ keyed on `realFn`, so
+// they compare not-equal as required by AC 2.
+struct MockFnSnapshot {
+    void *thunk_ptr;
+    void *env_ptr;
+};
+
 // Mock registry. fn_ptr is the replacement function pointer (plain fn ptr
 // or closure thunk). env_ptr / env_dtor are non-null only for capture-based
 // closures (#1678): the dispatch site reads env_ptr via __ry_mock_get_env
@@ -149,6 +163,7 @@ struct MockEntry {
     std::vector<MockMapSnapshot *> retained_map_snapshots;
     std::vector<MockRecordSnapshot *> retained_record_snapshots;
     std::vector<MockTupleSnapshot *> retained_tuple_snapshots;
+    std::vector<MockFnSnapshot *> retained_fn_snapshots;
 };
 static std::unordered_map<std::string, MockEntry> g_mock_registry;
 
@@ -420,6 +435,19 @@ static void freeMockTupleSnapshot(MockTupleSnapshot *snap) {
     delete snap;
 }
 
+// Build an fn-arg snapshot (#1707). thunk_ptr / env_ptr are extracted by the
+// caller from the uniform closure struct `{thunk, env, env_dtor}`. Pointer
+// equality only — no ARC retain on env (issue explicit; closure env lifetime
+// is owned by the caller's scope).
+static MockFnSnapshot *makeMockFnSnapshot(void *thunk_ptr, void *env_ptr) {
+    auto *snap = new MockFnSnapshot{};
+    snap->thunk_ptr = thunk_ptr;
+    snap->env_ptr = env_ptr;
+    return snap;
+}
+
+static void freeMockFnSnapshot(MockFnSnapshot *snap) { delete snap; }
+
 extern "C" {
 void __ry_arc_free_counted(void *header_ptr);
 }
@@ -520,6 +548,7 @@ void __ry_mock_set(const char *name, void *fn_ptr) {
     for (auto *snap : entry.retained_map_snapshots) freeMockMapSnapshot(snap);
     for (auto *snap : entry.retained_record_snapshots) freeMockRecordSnapshot(snap);
     for (auto *snap : entry.retained_tuple_snapshots) freeMockTupleSnapshot(snap);
+    for (auto *snap : entry.retained_fn_snapshots) freeMockFnSnapshot(snap);
     entry = MockEntry{};
     entry.fn_ptr = fn_ptr;
 }
@@ -533,6 +562,7 @@ void __ry_mock_set_closure(const char *name, void *thunk_ptr,
     for (auto *snap : entry.retained_map_snapshots) freeMockMapSnapshot(snap);
     for (auto *snap : entry.retained_record_snapshots) freeMockRecordSnapshot(snap);
     for (auto *snap : entry.retained_tuple_snapshots) freeMockTupleSnapshot(snap);
+    for (auto *snap : entry.retained_fn_snapshots) freeMockFnSnapshot(snap);
     entry = MockEntry{};
     entry.fn_ptr = thunk_ptr;
     entry.env_ptr = env_ptr;
@@ -691,6 +721,27 @@ void __ry_mock_store_arg_tuple(void *record, int64_t arity,
 void *__ry_mock_make_tuple_snapshot(int64_t arity, const int8_t *kinds,
                                       const int64_t *values) {
     return makeMockTupleSnapshot(arity, kinds, values);
+}
+
+// Recording side: store an fn-typed argument as a per-call {thunk, env}
+// snapshot (#1707). thunk_ptr / env_ptr are extracted by codegen from the
+// uniform closure struct produced by wrapAsUniformClosure. Pointer equality
+// only; no retain.
+void __ry_mock_store_arg_fn(void *record, void *thunk_ptr, void *env_ptr,
+                              const char *mockName) {
+    if (!record) return;
+    auto *snap = makeMockFnSnapshot(thunk_ptr, env_ptr);
+    auto *rec = static_cast<MockCallRecord *>(record);
+    rec->args.push_back({11, reinterpret_cast<int64_t>(snap)});
+    if (mockName) {
+        auto it = g_mock_registry.find(mockName);
+        if (it != g_mock_registry.end())
+            it->second.retained_fn_snapshots.push_back(snap);
+    }
+}
+
+void *__ry_mock_make_fn_snapshot(void *thunk_ptr, void *env_ptr) {
+    return makeMockFnSnapshot(thunk_ptr, env_ptr);
 }
 
 static bool mockArgEqual(const MockArg &recorded, int64_t expectedKind,
@@ -875,6 +926,22 @@ static bool mockArgEqual(const MockArg &recorded, int64_t expectedKind,
         }
         return true;
     }
+    if (recorded.kind == 11) {
+        // Fn: identity is the pair {thunk_ptr, env_ptr} extracted from the
+        // uniform closure struct (#1707). For non-capturing fns the env is
+        // null on both sides; for capturing closures the env pointer is the
+        // ARC-managed env data ptr, which is unique per `let g = makeAdder(5)`
+        // invocation. forwarding_thunk_cache_ / capturing_thunk_cache_ ensure
+        // that a single source-level lambda always maps to one thunk, so:
+        //   - same source-level fn passed twice → match
+        //   - different source-level fns → different thunks → no match
+        //   - same `makeAdder` invoked twice → same thunk + different envs → no match
+        auto *a = reinterpret_cast<MockFnSnapshot *>(recorded.value);
+        auto *b = reinterpret_cast<MockFnSnapshot *>(expectedValue);
+        if (a == b) return true;
+        if (!a || !b) return false;
+        return a->thunk_ptr == b->thunk_ptr && a->env_ptr == b->env_ptr;
+    }
     if (recorded.kind == 10) {
         // Tuple: identity is (arity + per-element kinds + per-element values).
         // No declared name; arity mismatch is a compile-time reject (Stage 2)
@@ -944,6 +1011,9 @@ int64_t __ry_mock_count_matching_calls(const char *name, int64_t numArgs,
         } else if (kinds[i] == 10) {
             freeMockTupleSnapshot(
                 reinterpret_cast<MockTupleSnapshot *>(values[i]));
+        } else if (kinds[i] == 11) {
+            freeMockFnSnapshot(
+                reinterpret_cast<MockFnSnapshot *>(values[i]));
         }
     }
     return matched;
@@ -958,6 +1028,7 @@ void __ry_mock_clear_all() {
         for (auto *snap : entry.retained_map_snapshots) freeMockMapSnapshot(snap);
         for (auto *snap : entry.retained_record_snapshots) freeMockRecordSnapshot(snap);
         for (auto *snap : entry.retained_tuple_snapshots) freeMockTupleSnapshot(snap);
+        for (auto *snap : entry.retained_fn_snapshots) freeMockFnSnapshot(snap);
     }
     g_mock_registry.clear();
 }

--- a/tests/spec/mock.test.ry
+++ b/tests/spec/mock.test.ry
@@ -87,6 +87,15 @@ fn takesIntStrPair(p: (int, str)) -> int:
 fn takesStrBoolFloatTriple(t: (str, bool, float)) -> int:
   return 0
 
+fn takesFn(f: fn(int) -> int) -> int:
+  return f(0)
+
+fn makeAdder(n: int) -> fn(int) -> int:
+  return (x: int) => x + n
+
+fn addOne(x: int) -> int:
+  return x + 1
+
 @describe("mock")
 fn mockTests():
   @it("should replace function")
@@ -519,3 +528,43 @@ fn verifyCalledWithRecordTupleArgs():
     expect(verifyCalledWith("takesStrBoolFloatTriple", ("x", true, 1.5))).toEq(1)
     expect(verifyCalledWith("takesStrBoolFloatTriple", ("y", false, 2.5))).toEq(1)
     expect(verifyCalledWith("takesStrBoolFloatTriple", ("x", false, 1.5))).toEq(0)
+
+@describe("verifyCalledWith with function-typed args (#1707)")
+fn verifyCalledWithFnArgs():
+  @it("should match same fn value passed twice")
+  fn shouldMatchSameFnTwice():
+    mock("takesFn", (f: fn(int) -> int) => f(0))
+    lam = (x: int) => x + 1
+    takesFn(lam)
+    takesFn(lam)
+    expect(verifyCalledWith("takesFn", lam)).toEq(2)
+  @it("should not match a different fn value")
+  fn shouldNotMatchDifferentFn():
+    mock("takesFn", (f: fn(int) -> int) => f(0))
+    lamA = (x: int) => x + 1
+    lamB = (x: int) => x + 2
+    takesFn(lamA)
+    expect(verifyCalledWith("takesFn", lamA)).toEq(1)
+    expect(verifyCalledWith("takesFn", lamB)).toEq(0)
+  @it("should not match independently constructed structurally identical lambdas")
+  fn shouldNotMatchIndependentLambdas():
+    mock("takesFn", (f: fn(int) -> int) => f(0))
+    lam1 = (x: int) => x + 1
+    lam2 = (x: int) => x + 1
+    takesFn(lam1)
+    expect(verifyCalledWith("takesFn", lam1)).toEq(1)
+    expect(verifyCalledWith("takesFn", lam2)).toEq(0)
+  @it("should match bare function value passed as first-class")
+  fn shouldMatchBareFn():
+    mock("takesFn", (f: fn(int) -> int) => f(0))
+    takesFn(addOne)
+    takesFn(addOne)
+    expect(verifyCalledWith("takesFn", addOne)).toEq(2)
+  @it("should distinguish capture closures with different env")
+  fn shouldDistinguishCaptureClosures():
+    mock("takesFn", (f: fn(int) -> int) => f(0))
+    add5 = makeAdder(5)
+    add6 = makeAdder(6)
+    takesFn(add5)
+    expect(verifyCalledWith("takesFn", add5)).toEq(1)
+    expect(verifyCalledWith("takesFn", add6)).toEq(0)


### PR DESCRIPTION
## Summary

- Extends `verifyCalledWith` to accept `fn(...) -> R` parameters and capture closures (#1707), completing the v2 series after List (#1703) / Set (#1704) / Map (#1705) / record + tuple (#1706).
- Comparison is by **pointer equality** on the underlying `{thunk_ptr, env_ptr}` pair extracted from the uniform closure struct — recording and verify sides both go through `wrapAsUniformClosure` + `lookupFnTypeInfo`.
- Closure environments are **not ARC-retained** in the snapshot side-table per the issue contract; the caller scope keeps the closure alive for the test block. The verify-side `wrapAsUniformClosure` allocation is explicitly released via `releaseUniformClosureTemps` after extracting the `{thunk, env}` pair, mirroring the recording-side pattern.

## Changes

- `src/codegen_test.cpp` — verify side: relax fn-typed reject, normalize via `lookupFnTypeInfo` + `wrapAsUniformClosure`, extract `{thunk, env}`, dispatch as kind=11. Releases the wrap struct after extraction.
- `src/codegen_call_user.cpp` — recording side: kind=11 branch when `paramTypeNames[i]` is a fn-type. Existing `wrapFnTypedArgs` / `releaseUniformClosureTemps` machinery handles wrap lifecycle.
- `src/test_runtime.cpp` — `MockFnSnapshot` ABI, `__ry_mock_make_fn_snapshot` / `__ry_mock_store_arg_fn`, `mockArgEqual` kind=11 case, `__ry_mock_clear` cleanup.
- `tests/spec/mock.test.ry` — 5 new test cases covering AC1–3 (`shouldMatchSameFnPassedTwice`, `shouldNotMatchDifferentFns`, `shouldDistinguishStructurallyIdenticalLambdas`, `shouldMatchBareFunctionAlias`, `shouldDistinguishCaptureClosures`).
- `docs/reference/testing.md` — fn-arg pointer-equality semantics added to the verifyCalledWith section.
- `changelog.d/1707-verifycalledwith-fn-args.md` — Unreleased fragment.

## Test plan

- [x] `./build/ry test -p` — 179 files, 0 failures
- [x] `./build/ry_tests` — 2197 passed
- [x] `./build-asan/ry test -p` — 179 files, 0 failures
- [x] `./build-asan/ry_tests` — 2197 passed
- [x] `./build-asan/ry test tests/spec/mock.test.ry` — includes all 5 #1707 cases
- [x] `./build-tsan/ry test -p` — 179 files, 0 failures
- [x] `./build-tsan/ry_tests` (parallel/concurrency filter) — 2184 passed
- [x] cppcheck / clang-tidy on changed files — only pre-existing warnings
- [x] libFuzzer §3.6 — N/A (no parser/lexer/json/utf8/string changes)

Closes #1707

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced test verification helper to support function-typed arguments, using pointer-equality of closure identity so the same closure value matches across calls while distinct lambdas do not.

* **Documentation**
  * Added comprehensive docs and examples demonstrating function-typed argument verification behavior.

* **Tests**
  * Added test cases covering repeated closure values, distinct lambdas, bare function references, and captured-environment differences.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1714)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->