### PR TITLE
feat(import): support symbol alias in selective import (#1721)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ c = Color::Red
 print(c)               # Red
 
 # Module import (with optional `as` alias)
-from math import sqrt, PI as TAU
-print(sqrt(TAU))
+from math import sqrt, PI as PI_CONST
+print(sqrt(PI_CONST))
 ```
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ enum Color:
 c = Color::Red
 print(c)               # Red
 
-# Module import
-from math import sqrt, PI
-print(sqrt(PI))
+# Module import (with optional `as` alias)
+from math import sqrt, PI as TAU
+print(sqrt(TAU))
 ```
 
 ## Installation

--- a/changelog.d/1721-import-symbol-alias.md
+++ b/changelog.d/1721-import-symbol-alias.md
@@ -1,0 +1,12 @@
+### Added
+
+- Added symbol alias support in selective import (`from m import foo as bar`).
+  The parser now accepts an optional `as <ident>` after each imported name,
+  the formatter emits it round-trip, and self-alias (`foo as foo`) is
+  normalized away (#1721).
+
+  In this release only `@const` aliases are functional end-to-end; alias
+  requests for `fn` / `record` / `enum` / `type alias` parse and reach the
+  module loader but are rejected with a clear diagnostic pointing at
+  follow-up #1725, which will extend codegen-side name resolution to make
+  the remaining kinds work. (#1721)

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -34,6 +34,29 @@ from math import sqrt, PI
 
 Imports multiple definitions separated by commas.
 
+### Symbol Alias
+
+```ry
+from math import sqrt as squareRoot
+```
+
+Each imported name may carry an optional `as <ident>` clause that binds the
+symbol under a different local name. Aliases can be mixed with non-aliased
+names in a single statement:
+
+```ry
+from math import sqrt as sr, PI, sin as s
+```
+
+Self-alias (`foo as foo`) is normalized to a plain import — the formatter
+will round-trip it as `from math import foo`.
+
+**Limitation (v0.0.23)**: only `@const` aliases work end-to-end. Aliases
+for functions, records, enums, and type aliases are accepted by the
+parser but rejected by the module loader with a diagnostic pointing at
+follow-up issue [#1725](https://github.com/t0k0sh1/ry/issues/1725). Full
+alias support for those kinds is tracked there.
+
 ### Relative Import
 
 ```ry

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -259,9 +259,14 @@ struct ExprStmt   { ExprPtr expr; SourceLocation loc; };
 struct ReturnStmt { ExprPtr value; SourceLocation loc; };
 struct FnParam { std::string name; TypeNodePtr type; ExprPtr default_value; };
 
+struct ImportName {
+    std::string name;                       // original symbol name from the module
+    std::optional<std::string> alias;       // local-side rebinding via `as`; nullopt means no alias (or normalized self-alias)
+};
+
 struct ImportStmt {
     std::string module_path;              // "utils/math" (resolved to dir or .ry file)
-    std::vector<std::string> names;       // {"add", "sub"} — empty means import all
+    std::vector<ImportName> names;        // {{"add", nullopt}, {"sub", "minus"}} — empty means import all
     SourceLocation loc;
 };
 

--- a/include/ry/module_loader.hpp
+++ b/include/ry/module_loader.hpp
@@ -21,7 +21,8 @@ Program loadAndParse(const std::string &abs_path, SourceManager *sm = nullptr);
 // has a dedicated branch.
 enum class ExportableKind {
     Fn,
-    Const,
+    Const,    // module-level `AssignStmt` carrying the `@const` directive
+    Value,    // module-level `AssignStmt` without `@const` (treated as non-aliasable)
     Record,
     Enum,
     TypeAlias,

--- a/include/ry/module_loader.hpp
+++ b/include/ry/module_loader.hpp
@@ -14,6 +14,20 @@ namespace ry {
 
 Program loadAndParse(const std::string &abs_path, SourceManager *sm = nullptr);
 
+// Classification used when emitting alias bindings for `from m import x as y`.
+// Mirrors the variants returned by `isExportable` so the alias binding can be
+// generated with the right AST shape (AssignStmt for values, TypeAliasStmt
+// for types). Directives are tracked here so the alias-not-supported error
+// has a dedicated branch.
+enum class ExportableKind {
+    Fn,
+    Const,
+    Record,
+    Enum,
+    TypeAlias,
+    Directive,
+};
+
 class ModuleLoader {
 public:
     explicit ModuleLoader(const std::vector<std::string> &search_paths = {},
@@ -56,6 +70,10 @@ private:
     // (the nearest ancestor directory containing `package.toml`; files
     // outside any package share an anonymous package).
     std::unordered_map<std::string, std::unordered_map<std::string, bool>> exports_cache_;
+    // Parallel cache of exportable kinds keyed by abs_path then name. Populated
+    // alongside `exports_cache_` so cache-hit imports can synthesize alias
+    // bindings (`from m import x as y`) without re-parsing the source.
+    std::unordered_map<std::string, std::unordered_map<std::string, ExportableKind>> exports_kinds_cache_;
     // Cache: directory path -> nearest ancestor `package.toml` root (or nullopt
     // if the directory is not contained in any rooted package).
     std::unordered_map<std::string, std::optional<std::string>> pkg_root_cache_;

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -154,7 +154,11 @@ void Formatter::formatImport(const ImportStmt &s) {
         emit(" import ");
         for (size_t i = 0; i < s.names.size(); ++i) {
             if (i > 0) emit(", ");
-            emit(s.names[i]);
+            emit(s.names[i].name);
+            if (s.names[i].alias.has_value()) {
+                emit(" as ");
+                emit(*s.names[i].alias);
+            }
         }
     }
     emitInlineComment(s.loc.line);

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -91,6 +91,65 @@ static bool isTestingIntrinsic(bool from_stdlib,
            testingIntrinsics().count(name) > 0;
 }
 
+static ExportableKind getExportableKind(const StmtNode &stmt) {
+    if (std::holds_alternative<std::unique_ptr<FnStmt>>(stmt)) return ExportableKind::Fn;
+    if (std::holds_alternative<AssignStmt>(stmt)) return ExportableKind::Const;
+    if (std::holds_alternative<RecordStmt>(stmt)) return ExportableKind::Record;
+    if (std::holds_alternative<EnumStmt>(stmt)) return ExportableKind::Enum;
+    if (std::holds_alternative<TypeAliasStmt>(stmt)) return ExportableKind::TypeAlias;
+    if (std::holds_alternative<DirectiveDefStmt>(stmt)) return ExportableKind::Directive;
+    return ExportableKind::Fn; // unreachable: caller already filtered via isExportable
+}
+
+// Build a synthesized binding `alias = orig` for `@const` symbols so the
+// importer's scope sees `alias` as an additional name pointing at the same
+// underlying value. Only `@const` alias is supported in this release:
+// fn / record / enum / type-alias alias requires codegen-side name-resolution
+// fallback that is not yet implemented (tracked in follow-up issue #1725).
+// The caller MUST reject non-Const kinds before reaching here; this function
+// asserts that contract via the switch default.
+static StmtNode makeAliasBinding(ExportableKind kind,
+                                  const std::string &orig_name,
+                                  const std::string &alias_name,
+                                  SourceLocation loc) {
+    (void)kind; // contract: caller guarantees ExportableKind::Const
+    auto var = std::make_unique<ExprNode>();
+    var->data = VariableExpr{orig_name};
+    var->loc = loc;
+    AssignStmt a;
+    a.name = alias_name;
+    a.value = std::move(var);
+    a.loc = loc;
+    return a;
+}
+
+// Validate that an `as` alias is only requested for a supported kind.
+// In v0.0.23 (#1721) only `@const` alias is functional; the other kinds
+// (fn / record / enum / type alias) parse and reach the loader, but emitting
+// a binding that survives codegen requires the follow-up work tracked in
+// #1725. Throw a descriptive error so the user understands what to do.
+static void rejectUnsupportedAlias(ExportableKind kind,
+                                    const std::string &name,
+                                    const std::string &import_path,
+                                    int line) {
+    if (kind == ExportableKind::Const) return;
+    std::string detail = "alias not supported for ";
+    switch (kind) {
+        case ExportableKind::Fn:        detail += "function";   break;
+        case ExportableKind::Record:    detail += "record";     break;
+        case ExportableKind::Enum:      detail += "enum";       break;
+        case ExportableKind::TypeAlias: detail += "type alias"; break;
+        case ExportableKind::Directive: detail += "directive";  break;
+        case ExportableKind::Const:     return;
+    }
+    detail += " '";
+    detail += name;
+    detail += "' from module '";
+    detail += import_path;
+    detail += "': only @const aliases are supported in v0.0.23 (tracked in #1725)";
+    throw std::runtime_error(makeImportError(line, detail));
+}
+
 // Returns true when the definition carries an `@public` directive.
 static bool isPublicDefinition(const StmtNode &stmt) {
     auto check = [](const std::vector<Directive> &directives) -> bool {
@@ -129,28 +188,40 @@ static bool isPublicDefinition(const StmtNode &stmt) {
 // is_public flag for subsequent already-loaded import validation against the
 // cache without re-parsing.
 static void extractDefinitions(Program &source, Program &dest,
-                                const std::vector<std::string> &requested_names,
+                                const std::vector<ImportName> &requested_items,
                                 const std::string &import_path, int line,
                                 bool cross_package, bool from_stdlib,
-                                std::unordered_map<std::string, bool> *out_names = nullptr) {
+                                std::unordered_map<std::string, bool> *out_names = nullptr,
+                                std::unordered_map<std::string, ExportableKind> *out_kinds = nullptr,
+                                int file_id = 0) {
     // REQ-B3 (#1560): code availability is decoupled from name visibility.
     // Every exportable definition is copied to the importer's program so a
     // `@public` facade can call its non-`@public` helpers in the same JIT
     // linkage unit. Cross-package `@public` enforcement only narrows what
     // names the importer may write in `from foo import <name>` (validated
     // below), not what the codegen layer can resolve.
-    std::unordered_set<std::string> requested(requested_names.begin(), requested_names.end());
+    std::unordered_set<std::string> requested;
+    requested.reserve(requested_items.size());
+    for (const auto &item : requested_items)
+        requested.insert(item.name);
     std::unordered_map<std::string, bool> found;
+    std::unordered_map<std::string, ExportableKind> found_kinds;
     for (auto &stmt : source) {
         if (!isExportable(stmt)) continue;
         std::string name = getExportName(stmt);
         if (name.empty()) continue;
         bool is_pub = isPublicDefinition(stmt);
+        ExportableKind kind = getExportableKind(stmt);
         if (out_names) (*out_names)[name] = is_pub;
-        if (requested.count(name)) found[name] = is_pub;
+        if (out_kinds) (*out_kinds)[name] = kind;
+        if (requested.count(name)) {
+            found[name] = is_pub;
+            found_kinds[name] = kind;
+        }
         dest.push_back(std::move(stmt));
     }
-    for (const auto &name : requested_names) {
+    for (const auto &item : requested_items) {
+        const std::string &name = item.name;
         auto it = found.find(name);
         if (it == found.end()) {
             if (isTestingIntrinsic(from_stdlib, import_path, name)) continue;
@@ -168,6 +239,12 @@ static void extractDefinitions(Program &source, Program &dest,
             detail += import_path;
             detail += "': symbol is not @public";
             throw std::runtime_error(makeImportError(line, detail));
+        }
+        if (item.alias.has_value()) {
+            ExportableKind kind = found_kinds[name];
+            rejectUnsupportedAlias(kind, name, import_path, line);
+            SourceLocation alias_loc{line, 1, file_id};
+            dest.push_back(makeAliasBinding(kind, name, *item.alias, alias_loc));
         }
     }
 }
@@ -436,7 +513,9 @@ Program ModuleLoader::loadModuleDir(const std::string &abs_dir_path) {
         // decisions made at the import site.
         extractDefinitions(sub_prog, collected, {}, "", 0, /*cross_package=*/false,
                            /*from_stdlib=*/false,
-                           &exports_cache_[file_path]);
+                           &exports_cache_[file_path],
+                           &exports_kinds_cache_[file_path],
+                           /*file_id=*/0);
     }
 
     return collected;
@@ -466,9 +545,9 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                 for (const auto &name : testingIntrinsics())
                     imported_testing_intrinsics_.insert(name);
             } else {
-                for (const auto &name : imp.names) {
-                    if (testingIntrinsics().count(name) > 0)
-                        imported_testing_intrinsics_.insert(name);
+                for (const auto &item : imp.names) {
+                    if (testingIntrinsics().count(item.name) > 0)
+                        imported_testing_intrinsics_.insert(item.name);
                 }
             }
         }
@@ -483,7 +562,9 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
         if (loaded_.count(abs_path)) {
             if (!imp.names.empty()) {
                 auto &exports = exports_cache_[abs_path];
-                for (const auto &name : imp.names) {
+                auto &kinds = exports_kinds_cache_[abs_path];
+                for (const auto &item : imp.names) {
+                    const std::string &name = item.name;
                     auto it = exports.find(name);
                     if (it == exports.end()) {
                         if (isTestingIntrinsic(rp.from_stdlib, imp.module_path, name)) continue;
@@ -502,6 +583,14 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                         detail += "': symbol is not @public";
                         throw std::runtime_error(makeImportError(imp.loc.line, detail));
                     }
+                    if (item.alias.has_value()) {
+                        auto k_it = kinds.find(name);
+                        ExportableKind kind = (k_it != kinds.end()) ? k_it->second
+                                                                    : ExportableKind::Fn;
+                        rejectUnsupportedAlias(kind, name, imp.module_path, imp.loc.line);
+                        SourceLocation alias_loc{imp.loc.line, 1, imp.loc.file_id};
+                        result.push_back(makeAliasBinding(kind, name, *item.alias, alias_loc));
+                    }
                 }
             }
             continue;
@@ -515,7 +604,9 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
 
             extractDefinitions(dir_prog, result, imp.names, imp.module_path,
                                imp.loc.line, cross_package, rp.from_stdlib,
-                               &exports_cache_[abs_path]);
+                               &exports_cache_[abs_path],
+                               &exports_kinds_cache_[abs_path],
+                               imp.loc.file_id);
         } else {
             loading_.insert(abs_path);
             auto sub_prog = loadAndParse(abs_path, sm_);
@@ -526,7 +617,9 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
 
             extractDefinitions(sub_prog, result, imp.names, imp.module_path,
                                imp.loc.line, cross_package, rp.from_stdlib,
-                               &exports_cache_[abs_path]);
+                               &exports_cache_[abs_path],
+                               &exports_kinds_cache_[abs_path],
+                               imp.loc.file_id);
         }
     }
 

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -93,7 +93,11 @@ static bool isTestingIntrinsic(bool from_stdlib,
 
 static ExportableKind getExportableKind(const StmtNode &stmt) {
     if (std::holds_alternative<std::unique_ptr<FnStmt>>(stmt)) return ExportableKind::Fn;
-    if (std::holds_alternative<AssignStmt>(stmt)) return ExportableKind::Const;
+    if (std::holds_alternative<AssignStmt>(stmt)) {
+        const auto &a = std::get<AssignStmt>(stmt);
+        return hasDirective(a.directives, "const") ? ExportableKind::Const
+                                                   : ExportableKind::Value;
+    }
     if (std::holds_alternative<RecordStmt>(stmt)) return ExportableKind::Record;
     if (std::holds_alternative<EnumStmt>(stmt)) return ExportableKind::Enum;
     if (std::holds_alternative<TypeAliasStmt>(stmt)) return ExportableKind::TypeAlias;
@@ -135,11 +139,12 @@ static void rejectUnsupportedAlias(ExportableKind kind,
     if (kind == ExportableKind::Const) return;
     std::string detail = "alias not supported for ";
     switch (kind) {
-        case ExportableKind::Fn:        detail += "function";   break;
-        case ExportableKind::Record:    detail += "record";     break;
-        case ExportableKind::Enum:      detail += "enum";       break;
-        case ExportableKind::TypeAlias: detail += "type alias"; break;
-        case ExportableKind::Directive: detail += "directive";  break;
+        case ExportableKind::Fn:        detail += "function";              break;
+        case ExportableKind::Value:     detail += "non-@const assignment"; break;
+        case ExportableKind::Record:    detail += "record";                break;
+        case ExportableKind::Enum:      detail += "enum";                  break;
+        case ExportableKind::TypeAlias: detail += "type alias";            break;
+        case ExportableKind::Directive: detail += "directive";             break;
         case ExportableKind::Const:     return;
     }
     detail += " '";
@@ -224,7 +229,17 @@ static void extractDefinitions(Program &source, Program &dest,
         const std::string &name = item.name;
         auto it = found.find(name);
         if (it == found.end()) {
-            if (isTestingIntrinsic(from_stdlib, import_path, name)) continue;
+            if (isTestingIntrinsic(from_stdlib, import_path, name)) {
+                if (item.alias.has_value()) {
+                    std::string detail = "alias not supported for testing intrinsic '";
+                    detail += name;
+                    detail += "' from module '";
+                    detail += import_path;
+                    detail += "': intrinsics cannot be re-bound (tracked in #1725)";
+                    throw std::runtime_error(makeImportError(line, detail));
+                }
+                continue;
+            }
             std::string detail = "'";
             detail += name;
             detail += "' not found in module '";
@@ -567,7 +582,17 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                     const std::string &name = item.name;
                     auto it = exports.find(name);
                     if (it == exports.end()) {
-                        if (isTestingIntrinsic(rp.from_stdlib, imp.module_path, name)) continue;
+                        if (isTestingIntrinsic(rp.from_stdlib, imp.module_path, name)) {
+                            if (item.alias.has_value()) {
+                                std::string detail = "alias not supported for testing intrinsic '";
+                                detail += name;
+                                detail += "' from module '";
+                                detail += imp.module_path;
+                                detail += "': intrinsics cannot be re-bound (tracked in #1725)";
+                                throw std::runtime_error(makeImportError(imp.loc.line, detail));
+                            }
+                            continue;
+                        }
                         std::string detail = "'";
                         detail += name;
                         detail += "' not found in module '";

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -393,7 +393,26 @@ StmtNode Parser::parseImportStatement() {
         parseError(modTok.line, "expected module name after 'from'");
     }
 
-    std::vector<std::string> names;
+    // Consume one `<name> [as <alias>]` import item. The name token has
+    // already been validated by the caller. Normalizes self-alias
+    // (`foo as foo`) to nullopt so downstream code and formatter output
+    // stay canonical.
+    auto parseOneImportItem = [&]() -> ImportName {
+        std::string itemName = lex_.next().value;
+        std::optional<std::string> aliasOpt;
+        if (lex_.peek().kind == TokenKind::As) {
+            lex_.next(); // consume 'as'
+            Token aliasTok = lex_.peek();
+            if (aliasTok.kind != TokenKind::Ident && aliasTok.kind != TokenKind::Expect)
+                parseError(aliasTok.line, "expected identifier after 'as'");
+            std::string aliasName = lex_.next().value;
+            if (aliasName != itemName)
+                aliasOpt = std::move(aliasName);
+        }
+        return ImportName{std::move(itemName), std::move(aliasOpt)};
+    };
+
+    std::vector<ImportName> names;
     names.reserve(4);
     if (lex_.peek().kind == TokenKind::Import) {
         lex_.next(); // consume 'import'
@@ -404,18 +423,18 @@ StmtNode Parser::parseImportStatement() {
         // rejected at this position.
         if (name.kind != TokenKind::Ident && name.kind != TokenKind::Expect)
             parseError(name.line, "expected function name after 'import'");
-        names.push_back(lex_.next().value);
+        names.push_back(parseOneImportItem());
 
         while (lex_.peek().kind == TokenKind::Comma) {
             lex_.next(); // consume ','
             Token next = lex_.peek();
             if (next.kind != TokenKind::Ident && next.kind != TokenKind::Expect)
                 parseError(next.line, "expected function name after ','");
-            names.push_back(lex_.next().value);
+            names.push_back(parseOneImportItem());
         }
     }
 
-    return ImportStmt{modulePath, names, {fromTok.line, fromTok.col, file_id_}};
+    return ImportStmt{modulePath, std::move(names), {fromTok.line, fromTok.col, file_id_}};
 }
 
 StmtNode Parser::parseStatement() {

--- a/tests/spec/import_alias/import_alias.test.ry
+++ b/tests/spec/import_alias/import_alias.test.ry
@@ -1,0 +1,15 @@
+from testing import it, describe, expect
+
+from .shapes import ORIGIN_X as ZERO_X, ORIGIN_Y as ZERO_Y
+
+@describe("import alias")
+fn importAliasTests():
+    @it("should bind @const with alias")
+    fn shouldBindConstWithAlias():
+        expect(ZERO_X).toEq(0)
+        expect(ZERO_Y).toEq(0)
+
+    @it("should allow mixing aliased and non-aliased const imports")
+    fn shouldMixAliasedAndNonAliased():
+        sum: int = ZERO_X + ZERO_Y + 7
+        expect(sum).toEq(7)

--- a/tests/spec/import_alias/import_alias.test.ry
+++ b/tests/spec/import_alias/import_alias.test.ry
@@ -1,15 +1,14 @@
 from testing import it, describe, expect
 
-from .shapes import ORIGIN_X as ZERO_X, ORIGIN_Y as ZERO_Y
+from .shapes import ORIGIN_X as ZERO_X, ORIGIN_Y
 
 @describe("import alias")
 fn importAliasTests():
     @it("should bind @const with alias")
     fn shouldBindConstWithAlias():
         expect(ZERO_X).toEq(0)
-        expect(ZERO_Y).toEq(0)
 
     @it("should allow mixing aliased and non-aliased const imports")
     fn shouldMixAliasedAndNonAliased():
-        sum: int = ZERO_X + ZERO_Y + 7
+        sum: int = ZERO_X + ORIGIN_Y + 7
         expect(sum).toEq(7)

--- a/tests/spec/import_alias/shapes.ry
+++ b/tests/spec/import_alias/shapes.ry
@@ -1,0 +1,7 @@
+@public
+@const
+ORIGIN_X: int = 0
+
+@public
+@const
+ORIGIN_Y: int = 0

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -841,16 +841,37 @@ TEST_F(ImportTest, ImportErrors) {
 // fallback that is not yet implemented, so `module_loader.cpp`
 // explicitly rejects them with a message pointing at follow-up #1725.
 TEST_F(ImportTest, ImportAliasConstWorks) {
-    // Use camelCase: SCREAMING_SNAKE_CASE requires @const, but the harness
-    // has no stdlib search path so directive lookup fails. A bare
-    // module-global AssignStmt is still classified as ExportableKind::Const
-    // by `getExportableKind`, which is what the alias logic keys on.
+    // Inline-declare the `@const` directive so the imported file can use it
+    // without relying on stdlib resolution (the harness loader is constructed
+    // with empty search_paths). With CodeRabbit's #1726 fix, only AssignStmts
+    // carrying `@const` qualify as `ExportableKind::Const` and are aliasable.
     writeFile("constmod.ry",
-        "originX: int = 42\n");
+        "@directive(target=[\"statement\"])\n"
+        "fn const()\n"
+        "@const\n"
+        "ORIGIN_X: int = 42\n");
     EXPECT_EQ(runWithImports(
-        "from constmod import originX as zeroX\n"
-        "print(zeroX)"),
+        "from constmod import ORIGIN_X as ZERO_X\n"
+        "print(ZERO_X)"),
         "42\n");
+}
+
+// Non-`@const` module-level assignments are classified as `ExportableKind::Value`
+// and the alias path rejects them. Regression for CodeRabbit's #1726 concern that
+// every AssignStmt was previously classified as Const, bypassing rejection.
+TEST_F(ImportTest, ImportAliasValueRejected) {
+    writeFile("valmod.ry",
+        "counter: int = 42\n");
+    try {
+        runWithImports("from valmod import counter as c\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("alias not supported for non-@const assignment 'counter'"),
+                  std::string::npos)
+            << "got: " << msg;
+        EXPECT_NE(msg.find("#1725"), std::string::npos) << "got: " << msg;
+    }
 }
 
 TEST_F(ImportTest, ImportAliasFunctionRejected) {
@@ -1560,6 +1581,45 @@ TEST_F(ImportTest, FromTestingImportExpectViaCacheHit) {
             tmp_dir_.string(),
             search_paths);
     });
+}
+
+// #1726 (CodeRabbit): testing intrinsics are looked up via the allow-list, not
+// via the AST. The alias path must reject `from testing import expect as e`
+// instead of silently dropping the alias. Both load and cache-hit branches
+// share this check.
+TEST_F(ImportTest, FromTestingImportRejectsAliasOnLoadPath) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    try {
+        resolveImportsOnly(
+            "from testing import expect as e\n",
+            tmp_dir_.string(),
+            search_paths);
+        FAIL() << "Expected alias on testing intrinsic to be rejected";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("alias not supported for testing intrinsic 'expect'"),
+                  std::string::npos) << msg;
+        EXPECT_NE(msg.find("#1725"), std::string::npos) << msg;
+    }
+}
+
+TEST_F(ImportTest, FromTestingImportRejectsAliasOnCacheHitPath) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    try {
+        // First `from testing` warms the cache; the aliased lookup must then
+        // travel the cache-hit branch in resolveImports.
+        resolveImportsOnly(
+            "from testing\n"
+            "from testing import mock as m\n",
+            tmp_dir_.string(),
+            search_paths);
+        FAIL() << "Expected alias on testing intrinsic to be rejected (cache-hit)";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("alias not supported for testing intrinsic 'mock'"),
+                  std::string::npos) << msg;
+        EXPECT_NE(msg.find("#1725"), std::string::npos) << msg;
+    }
 }
 
 // AC #4: a name that is neither a testing intrinsic nor a declared symbol

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -832,6 +832,110 @@ TEST_F(ImportTest, ImportErrors) {
     EXPECT_THROW(runWithImports("from mathmod import nope"), std::runtime_error);
 }
 
+// Symbol alias (`from m import x as y`) — #1721.
+//
+// Only `@const` aliases work end-to-end in v0.0.23: emitting an
+// `AssignStmt { name=alias, value=VariableExpr(orig) }` for a `@const`
+// passes through codegen as a plain top-level binding. fn / record /
+// enum / type-alias aliases require codegen-side name-resolution
+// fallback that is not yet implemented, so `module_loader.cpp`
+// explicitly rejects them with a message pointing at follow-up #1725.
+TEST_F(ImportTest, ImportAliasConstWorks) {
+    // Use camelCase: SCREAMING_SNAKE_CASE requires @const, but the harness
+    // has no stdlib search path so directive lookup fails. A bare
+    // module-global AssignStmt is still classified as ExportableKind::Const
+    // by `getExportableKind`, which is what the alias logic keys on.
+    writeFile("constmod.ry",
+        "originX: int = 42\n");
+    EXPECT_EQ(runWithImports(
+        "from constmod import originX as zeroX\n"
+        "print(zeroX)"),
+        "42\n");
+}
+
+TEST_F(ImportTest, ImportAliasFunctionRejected) {
+    writeFile("fnmod.ry",
+        "fn rectArea(w: int, h: int) -> int:\n"
+        "    return w * h\n");
+    try {
+        runWithImports("from fnmod import rectArea as area\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("alias not supported for function 'rectArea'"),
+                  std::string::npos)
+            << "got: " << msg;
+        EXPECT_NE(msg.find("#1725"), std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(ImportTest, ImportAliasRecordRejected) {
+    writeFile("recmod.ry",
+        "record Point:\n"
+        "    x: int\n"
+        "    y: int\n");
+    try {
+        runWithImports("from recmod import Point as P\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("alias not supported for record 'Point'"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+TEST_F(ImportTest, ImportAliasEnumRejected) {
+    writeFile("enummod.ry",
+        "enum Color:\n"
+        "    Red\n"
+        "    Green\n");
+    try {
+        runWithImports("from enummod import Color as C\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("alias not supported for enum 'Color'"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+TEST_F(ImportTest, ImportAliasTypeAliasRejected) {
+    writeFile("tymod.ry",
+        "type Distance = int\n");
+    try {
+        runWithImports("from tymod import Distance as D\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("alias not supported for type alias 'Distance'"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// Cache-hit path (`loaded_.count(abs_path) != 0`) also enforces the
+// rejection. Two `from <mod>` statements force the second one through
+// the cached branch.
+TEST_F(ImportTest, ImportAliasFunctionRejectedCacheHit) {
+    writeFile("fnmod2.ry",
+        "fn helper() -> int:\n"
+        "    return 1\n");
+    try {
+        runWithImports(
+            "from fnmod2\n"
+            "from fnmod2 import helper as h\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("alias not supported for function 'helper'"),
+                  std::string::npos)
+            << "got: " << msg;
+        EXPECT_NE(msg.find("#1725"), std::string::npos) << "got: " << msg;
+    }
+}
+
 // Lock in the v0.0.17 error-wording switch from "package" -> "module" so that
 // any future regression that re-introduces the old wording is caught directly.
 TEST_F(ImportTest, ModuleNotFoundErrorMentionsModule) {

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -77,6 +77,11 @@ TEST(Formatter, StatementFormatting) {
     // Wildcard import (no 'import' keyword)
     EXPECT_EQ(fmt("from math\n"), "from math\n");
     EXPECT_EQ(fmt("from .\n"), "from .\n");
+    // Import alias (#1721)
+    EXPECT_EQ(fmt("from math import add as plus\n"), "from math import add as plus\n");
+    EXPECT_EQ(fmt("from math import a, b as B, c\n"), "from math import a, b as B, c\n");
+    // Self-alias is normalized away by the parser (alias == name → no alias)
+    EXPECT_EQ(fmt("from math import add as add\n"), "from math import add\n");
     // Return
     {
         auto src = "fn f() -> int:\n    return 42\n";

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -677,7 +677,8 @@ TEST(ParserTest, ImportSingleFunction) {
     const auto &imp = std::get<ImportStmt>(prog[0]);
     EXPECT_EQ(imp.module_path, "math");
     ASSERT_EQ(imp.names.size(), 1u);
-    EXPECT_EQ(imp.names[0], "add");
+    EXPECT_EQ(imp.names[0].name, "add");
+    EXPECT_FALSE(imp.names[0].alias.has_value());
 }
 
 TEST(ParserTest, ImportMultipleFunctions) {
@@ -685,8 +686,10 @@ TEST(ParserTest, ImportMultipleFunctions) {
     const auto &imp = std::get<ImportStmt>(prog[0]);
     EXPECT_EQ(imp.module_path, "math");
     ASSERT_EQ(imp.names.size(), 2u);
-    EXPECT_EQ(imp.names[0], "add");
-    EXPECT_EQ(imp.names[1], "sub");
+    EXPECT_EQ(imp.names[0].name, "add");
+    EXPECT_FALSE(imp.names[0].alias.has_value());
+    EXPECT_EQ(imp.names[1].name, "sub");
+    EXPECT_FALSE(imp.names[1].alias.has_value());
 }
 
 TEST(ParserTest, ImportDotPath) {
@@ -694,7 +697,7 @@ TEST(ParserTest, ImportDotPath) {
     const auto &imp = std::get<ImportStmt>(prog[0]);
     EXPECT_EQ(imp.module_path, "utils/math");
     ASSERT_EQ(imp.names.size(), 1u);
-    EXPECT_EQ(imp.names[0], "add");
+    EXPECT_EQ(imp.names[0].name, "add");
 }
 
 TEST(ParserTest, ImportExpectedModuleName) {
@@ -714,7 +717,7 @@ TEST(ParserTest, RelativeImportDot) {
     const auto &imp = std::get<ImportStmt>(prog[0]);
     EXPECT_EQ(imp.module_path, ".");
     ASSERT_EQ(imp.names.size(), 1u);
-    EXPECT_EQ(imp.names[0], "add");
+    EXPECT_EQ(imp.names[0].name, "add");
 }
 
 TEST(ParserTest, RelativeImportDotMultiple) {
@@ -722,8 +725,8 @@ TEST(ParserTest, RelativeImportDotMultiple) {
     const auto &imp = std::get<ImportStmt>(prog[0]);
     EXPECT_EQ(imp.module_path, ".");
     ASSERT_EQ(imp.names.size(), 2u);
-    EXPECT_EQ(imp.names[0], "add");
-    EXPECT_EQ(imp.names[1], "sub");
+    EXPECT_EQ(imp.names[0].name, "add");
+    EXPECT_EQ(imp.names[1].name, "sub");
 }
 
 TEST(ParserTest, RelativeImportDotAll) {
@@ -739,7 +742,7 @@ TEST(ParserTest, RelativeImportDotSubmodule) {
     const auto &imp = std::get<ImportStmt>(prog[0]);
     EXPECT_EQ(imp.module_path, "./utils");
     ASSERT_EQ(imp.names.size(), 1u);
-    EXPECT_EQ(imp.names[0], "helper");
+    EXPECT_EQ(imp.names[0].name, "helper");
 }
 
 TEST(ParserTest, RelativeImportDotNestedSubmodule) {
@@ -747,7 +750,7 @@ TEST(ParserTest, RelativeImportDotNestedSubmodule) {
     const auto &imp = std::get<ImportStmt>(prog[0]);
     EXPECT_EQ(imp.module_path, "./utils/calc");
     ASSERT_EQ(imp.names.size(), 1u);
-    EXPECT_EQ(imp.names[0], "add");
+    EXPECT_EQ(imp.names[0].name, "add");
 }
 
 TEST(ParserTest, ImportHyphenError) {
@@ -805,7 +808,7 @@ TEST(ParserTest, ImportExpectKeywordAccepted) {
     const auto &imp = std::get<ImportStmt>(prog[0]);
     EXPECT_EQ(imp.module_path, "testing");
     ASSERT_EQ(imp.names.size(), 1u);
-    EXPECT_EQ(imp.names[0], "expect");
+    EXPECT_EQ(imp.names[0].name, "expect");
 }
 
 TEST(ParserTest, ImportFnKeywordRejected) {
@@ -828,6 +831,70 @@ TEST(ParserTest, ImportFnKeywordRejectedAfterComma) {
         EXPECT_NE(msg.find("expected function name after ','"), std::string::npos)
             << "Error message should match the post-comma import-name diagnostic: " << msg;
     }
+}
+
+// ===== alias tests (#1721) =====
+
+TEST(ParserTest, ImportSingleAlias) {
+    Program prog = parseStr("from math import add as plus");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 1u);
+    EXPECT_EQ(imp.names[0].name, "add");
+    ASSERT_TRUE(imp.names[0].alias.has_value());
+    EXPECT_EQ(*imp.names[0].alias, "plus");
+}
+
+TEST(ParserTest, ImportMixedAlias) {
+    Program prog = parseStr("from math import a, b as B, c");
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 3u);
+    EXPECT_EQ(imp.names[0].name, "a");
+    EXPECT_FALSE(imp.names[0].alias.has_value());
+    EXPECT_EQ(imp.names[1].name, "b");
+    ASSERT_TRUE(imp.names[1].alias.has_value());
+    EXPECT_EQ(*imp.names[1].alias, "B");
+    EXPECT_EQ(imp.names[2].name, "c");
+    EXPECT_FALSE(imp.names[2].alias.has_value());
+}
+
+// Self-alias (`foo as foo`) is parser-normalized to no alias so AST and
+// formatter output stay canonical (a redundant binding is never generated).
+TEST(ParserTest, ImportSelfAliasNormalized) {
+    Program prog = parseStr("from math import add as add");
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 1u);
+    EXPECT_EQ(imp.names[0].name, "add");
+    EXPECT_FALSE(imp.names[0].alias.has_value());
+}
+
+TEST(ParserTest, ImportExpectKeywordAsAlias) {
+    // `expect` is accepted as an alias target the same way it is accepted as
+    // an import name (#712 keyword carve-out). Lock both halves so a future
+    // narrowing of one path keeps the other consistent.
+    Program prog = parseStr("from testing import fail as expect");
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 1u);
+    EXPECT_EQ(imp.names[0].name, "fail");
+    ASSERT_TRUE(imp.names[0].alias.has_value());
+    EXPECT_EQ(*imp.names[0].alias, "expect");
+}
+
+TEST(ParserTest, ImportAsRequiresIdent) {
+    try {
+        parseStr("from math import add as 123");
+        FAIL() << "Expected parser to reject non-identifier alias";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("expected identifier after 'as'"), std::string::npos)
+            << "Error message should match the alias diagnostic: " << msg;
+    }
+}
+
+TEST(ParserTest, ImportAsRequiresAliasNotKeyword) {
+    // 'fn' is a keyword; using it as an alias target must be rejected, mirroring
+    // the existing `from m import fn` rejection at the name position.
+    EXPECT_THROW(parseStr("from math import add as fn"), std::runtime_error);
 }
 
 TEST(ParserTest, DuplicateFieldNameThrows) {


### PR DESCRIPTION
## Summary

`from m import foo as bar` を受理可能にする symbol alias 構文を実装。EBNF と tree-sitter 仕様は既に対応済みだったが、C++ パーサ / AST / formatter / module loader に gap があったため、それを埋める。

### 実装スコープ

- **parser / AST / formatter**: alias 構文を完全受理。`as` の後が IDENT でない場合は `parserError("expected identifier after 'as'")` を出力。self-alias (`foo as foo`) はパーサで正規化して `alias = nullopt` に潰し、formatter は `from m import foo` として round-trip する。
- **module_loader**: `@const` alias は `AssignStmt { name=alias, value=VariableExpr(orig) }` を dest に push する binding 生成で動作。fn / record / enum / type-alias の alias 要求は `rejectUnsupportedAlias` で明示的に reject し、follow-up #1725 へリンクする diagnostic を出力。load 経路と cache-hit 経路の両方で同じ rejection を適用。

### スコープ判断 — なぜ const のみか

Plan では emit-alias-binding 戦略で全 kind を扱う予定だったが、実装中に **`AssignStmt` ベースの fn alias が call site で resolve されない / `TypeAliasStmt` ベースの record・enum・type-alias alias が値構築位置で resolve されない** ことが empirically 判明した。これを解消するには codegen 側の name resolution に fallback 経路を追加する必要があり、本 PR のスコープを超える。そのため:

- 構文層 (parser / AST / formatter) は仕様通り全 kind を受理する
- module_loader 層で `@const` 以外を明示的に reject する
- codegen 拡張 (#1725) を follow-up issue として scope out

これにより構文と実装の階層的整合性を保ちつつ、ユーザー向けには明確な diagnostic で「v0.0.23 では @const のみ」を伝える。

## Test plan

- [x] C++ parser tests (`tests/test_parser.cpp`): `ImportSingleAlias` / `ImportMixedAlias` / `ImportSelfAliasNormalized` / `ImportExpectKeywordAsAlias` / `ImportAsRequiresIdent` / `ImportAsRequiresAliasNotKeyword`
- [x] formatter roundtrip (`tests/test_formatter.cpp`): single alias / mixed alias / self-alias canonicalization
- [x] codegen / module_loader tests (`tests/test_codegen_stmt.cpp`): `ImportAliasConstWorks` (@const alias E2E) + 5 件の rejection tests (fn / record / enum / type-alias / cache-hit 経路)
- [x] Ry self-test (`tests/spec/import_alias/`): @const alias の E2E (`ORIGIN_X as ZERO_X`)
- [x] `./build/ry_tests` 全件 (2212/2212 PASS)
- [x] `./build/ry test -p` 全件 (180 files PASS)
- [x] ASan + UBSan (`build-asan/ry_tests` + `build-asan/ry test -p`): clean
- [x] TSan C++ (`build-tsan/ry_tests`): clean
- [x] clang-tidy + cppcheck: PASS
- [x] libFuzzer `fuzz_parser` 60s/50625 runs: no crash
- [x] README.md / docs/reference/modules.md 更新
- [x] CHANGELOG fragment (`changelog.d/1721-import-symbol-alias.md`) 追加

Closes #1721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import symbol aliases supported: use `from module import symbol as alias`.
  * Aliases may be mixed with non-aliased imports; self-aliases are normalized away.
  * Note: Only `@const` aliases work end-to-end in this release; other kinds are parsed but rejected with diagnostics.

* **Documentation**
  * Updated examples and reference docs to show aliasing syntax and limitations.

* **Tests**
  * Added and expanded tests to cover alias parsing, formatting, resolution, and rejection cases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1726)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->