### PR TITLE
feat(import): support braced multi-line selective import (#1722)

### DIFF
--- a/changelog.d/1722-braced-import.md
+++ b/changelog.d/1722-braced-import.md
@@ -1,0 +1,13 @@
+### Added
+
+- Added braced selective import syntax: `from x import { a, b }` and
+  `from x import { a as b, c }`. Both single-line and multi-line forms
+  are accepted, with an optional trailing comma. The new form parses to
+  the same `ImportStmt` AST as the existing `from x import a, b` form,
+  so semantics (including #1721 symbol aliases) are unchanged. Empty
+  braces (`from x import {}`) are rejected with
+  `expected import name after '{'`.
+
+  The tree-sitter grammar accepts braced single-line imports; brace-
+  internal newline suppression for the multi-line form is tracked in
+  #1727 alongside the same gap for list / map / set literals. (#1722)

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -43,7 +43,8 @@ import_statement ::= 'from' module_path 'import' import_list NEWLINE
 
 module_path      ::= IDENT { '.' IDENT }
 
-import_list      ::= import_item { ',' import_item }
+import_list      ::= '{' import_item { ',' import_item } [ ',' ] '}'
+                   | import_item { ',' import_item }
 
 import_item      ::= IDENT [ 'as' IDENT ]
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -57,6 +57,37 @@ parser but rejected by the module loader with a diagnostic pointing at
 follow-up issue [#1725](https://github.com/t0k0sh1/ry/issues/1725). Full
 alias support for those kinds is tracked there.
 
+### Braced Selective Import
+
+```ry
+from math import { PI, E }
+```
+
+The selective import list may be wrapped in braces. Single-line and
+multi-line forms are both accepted, with an optional trailing comma —
+useful for importing many symbols without losing readability:
+
+```ry
+from math import {
+  PI,
+  E,
+}
+```
+
+Braced form composes with `as <ident>` aliases exactly like the
+comma-separated form:
+
+```ry
+from math import { PI as p, E }
+```
+
+The empty form `from math import {}` is rejected as a parse error.
+Symbol resolution, visibility, and alias limitations are identical to
+the comma-separated form — the braces are purely syntactic. Editor
+support (tree-sitter): single-line braced imports are recognized; brace-
+internal newline suppression for the multi-line form is tracked in
+[#1727](https://github.com/t0k0sh1/ry/issues/1727).
+
 ### Relative Import
 
 ```ry

--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -69,3 +69,22 @@ tests/spec/relative_import/relative_import.test.ry
 tests/spec/result_type_inference.test.ry
 tests/spec/trailing_commas.test.ry
 tests/spec/type_of.test.ry
+
+# === Brace-internal newline suppression (list / map / set / braced-import multi-line) ===
+# `editor/tree-sitter/src/scanner.c` does not track bracket depth, so NEWLINE /
+# INDENT / DEDENT tokens fire inside `{` / `[` / `(` and produce ERROR nodes for
+# multi-line brace-delimited expressions. Tracked in #1727.
+tests/spec/braced_import/braced_import.test.ry
+
+# === Housekeeping: pre-existing gaps not registered by earlier PRs ===
+# Discovered during #1722 self-verification; the parent PRs introduced these
+# fixtures but did not update expected-fail.txt. Each is an independent grammar
+# gap unrelated to braced selective import.
+#   - import_alias/*.ry: alias-aware selective import (#1721 leftover)
+#   - arc_tuple_*.ry, collection_meta_propagation.ry, mock.test.ry: feature-
+#     specific syntax surfaces not yet covered by editor/tree-sitter/grammar.js
+tests/spec/arc_tuple_index_assign.test.ry
+tests/spec/arc_tuple_ownership.test.ry
+tests/spec/collection_meta_propagation.test.ry
+tests/spec/import_alias/import_alias.test.ry
+tests/spec/mock.test.ry

--- a/editor/tree-sitter/grammar.js
+++ b/editor/tree-sitter/grammar.js
@@ -120,7 +120,10 @@ export default grammar({
 
     module_path: $ => sep1($.identifier, '.'),
 
-    import_list: $ => sep1($.import_item, ','),
+    import_list: $ => choice(
+      sep1($.import_item, ','),
+      seq('{', sep1($.import_item, ','), optional(','), '}'),
+    ),
 
     import_item: $ => seq(
       field('name', $.identifier),

--- a/editor/tree-sitter/test/corpus/imports.txt
+++ b/editor/tree-sitter/test/corpus/imports.txt
@@ -73,3 +73,59 @@ from std.collections.list import filter, map, reduce
         name: (identifier))
       (import_item
         name: (identifier)))))
+
+==================
+braced single-line import
+==================
+
+from std.io import { print, println }
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier))
+      (import_item
+        name: (identifier)))))
+
+==================
+braced import with alias
+==================
+
+from std.io import { print as p, println }
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier)
+        alias: (identifier))
+      (import_item
+        name: (identifier)))))
+
+==================
+braced single-element import with trailing comma
+==================
+
+from std.io import { print, }
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier)))))

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -416,21 +416,49 @@ StmtNode Parser::parseImportStatement() {
     names.reserve(4);
     if (lex_.peek().kind == TokenKind::Import) {
         lex_.next(); // consume 'import'
-        Token name = lex_.peek();
-        // `expect` is the only keyword (TokenKind::Expect) accepted as an
-        // import name; it names the testing intrinsic exposed via
-        // `from testing import expect` (#712). All other keywords remain
-        // rejected at this position.
-        if (name.kind != TokenKind::Ident && name.kind != TokenKind::Expect)
-            parseError(name.line, "expected function name after 'import'");
-        names.push_back(parseOneImportItem());
-
-        while (lex_.peek().kind == TokenKind::Comma) {
-            lex_.next(); // consume ','
-            Token next = lex_.peek();
-            if (next.kind != TokenKind::Ident && next.kind != TokenKind::Expect)
-                parseError(next.line, "expected function name after ','");
+        if (lex_.peek().kind == TokenKind::LBrace) {
+            // Braced selective import (#1722):
+            //   '{' import_item { ',' import_item } [ ',' ] '}'
+            // Multi-line is supported via skipStructuralTokens (newline/
+            // indent/dedent suppression mirrors the list_literal pattern).
+            lex_.next(); // consume '{'
+            skipStructuralTokens();
+            Token first = lex_.peek();
+            if (first.kind != TokenKind::Ident && first.kind != TokenKind::Expect)
+                parseError(first.line, "expected import name after '{'");
             names.push_back(parseOneImportItem());
+            skipStructuralTokens();
+            while (lex_.peek().kind == TokenKind::Comma) {
+                lex_.next(); // consume ','
+                skipStructuralTokens();
+                if (lex_.peek().kind == TokenKind::RBrace)
+                    break; // trailing comma allowed
+                Token next = lex_.peek();
+                if (next.kind != TokenKind::Ident && next.kind != TokenKind::Expect)
+                    parseError(next.line, "expected import name after ','");
+                names.push_back(parseOneImportItem());
+                skipStructuralTokens();
+            }
+            if (lex_.peek().kind != TokenKind::RBrace)
+                parseError(lex_.peek().line, "expected '}' or ',' in import list");
+            lex_.next(); // consume '}'
+        } else {
+            Token name = lex_.peek();
+            // `expect` is the only keyword (TokenKind::Expect) accepted as an
+            // import name; it names the testing intrinsic exposed via
+            // `from testing import expect` (#712). All other keywords remain
+            // rejected at this position.
+            if (name.kind != TokenKind::Ident && name.kind != TokenKind::Expect)
+                parseError(name.line, "expected function name after 'import'");
+            names.push_back(parseOneImportItem());
+
+            while (lex_.peek().kind == TokenKind::Comma) {
+                lex_.next(); // consume ','
+                Token next = lex_.peek();
+                if (next.kind != TokenKind::Ident && next.kind != TokenKind::Expect)
+                    parseError(next.line, "expected function name after ','");
+                names.push_back(parseOneImportItem());
+            }
         }
     }
 

--- a/tests/spec/braced_import/braced_import.test.ry
+++ b/tests/spec/braced_import/braced_import.test.ry
@@ -1,0 +1,25 @@
+from testing import { it, describe, expect }
+
+from .symbols import {
+  ALPHA,
+  BETA as B,
+  GAMMA,
+  DELTA,
+}
+
+@describe("braced selective import")
+fn bracedImportTests():
+  @it("should bind constants imported via braces")
+  fn shouldBindBracedConstants():
+    expect(ALPHA).toEq(1)
+    expect(GAMMA).toEq(3)
+    expect(DELTA).toEq(4)
+
+  @it("should support alias inside braces")
+  fn shouldSupportAliasInsideBraces():
+    expect(B).toEq(2)
+
+  @it("should mix braced constants across statements")
+  fn shouldMixBracedConstants():
+    sum: int = ALPHA + B + GAMMA + DELTA
+    expect(sum).toEq(10)

--- a/tests/spec/braced_import/symbols.ry
+++ b/tests/spec/braced_import/symbols.ry
@@ -1,0 +1,15 @@
+@public
+@const
+ALPHA: int = 1
+
+@public
+@const
+BETA: int = 2
+
+@public
+@const
+GAMMA: int = 3
+
+@public
+@const
+DELTA: int = 4

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -897,6 +897,93 @@ TEST(ParserTest, ImportAsRequiresAliasNotKeyword) {
     EXPECT_THROW(parseStr("from math import add as fn"), std::runtime_error);
 }
 
+// ===== braced selective import tests (#1722) =====
+
+TEST(ParserTest, ImportBracedSingleItem) {
+    Program prog = parseStr("from math import { add }");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    EXPECT_EQ(imp.module_path, "math");
+    ASSERT_EQ(imp.names.size(), 1u);
+    EXPECT_EQ(imp.names[0].name, "add");
+    EXPECT_FALSE(imp.names[0].alias.has_value());
+}
+
+TEST(ParserTest, ImportBracedMultipleItems) {
+    Program prog = parseStr("from math import { add, sub }");
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 2u);
+    EXPECT_EQ(imp.names[0].name, "add");
+    EXPECT_EQ(imp.names[1].name, "sub");
+}
+
+TEST(ParserTest, ImportBracedSingleTrailingComma) {
+    Program prog = parseStr("from math import { add, }");
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 1u);
+    EXPECT_EQ(imp.names[0].name, "add");
+}
+
+TEST(ParserTest, ImportBracedTrailingComma) {
+    Program prog = parseStr("from math import { a, b, }");
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 2u);
+    EXPECT_EQ(imp.names[0].name, "a");
+    EXPECT_EQ(imp.names[1].name, "b");
+}
+
+TEST(ParserTest, ImportBracedWithAlias) {
+    // Combines with #1721 symbol alias.
+    Program prog = parseStr("from math import { add as plus, sub }");
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 2u);
+    EXPECT_EQ(imp.names[0].name, "add");
+    ASSERT_TRUE(imp.names[0].alias.has_value());
+    EXPECT_EQ(*imp.names[0].alias, "plus");
+    EXPECT_EQ(imp.names[1].name, "sub");
+    EXPECT_FALSE(imp.names[1].alias.has_value());
+}
+
+TEST(ParserTest, ImportBracedMultiLine) {
+    Program prog = parseStr("from math import {\n  add,\n  sub,\n}\n");
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 2u);
+    EXPECT_EQ(imp.names[0].name, "add");
+    EXPECT_EQ(imp.names[1].name, "sub");
+}
+
+TEST(ParserTest, ImportBracedExpectKeyword) {
+    // `expect` keyword carve-out works inside braces as well (mirrors #712).
+    Program prog = parseStr("from testing import { expect }");
+    const auto &imp = std::get<ImportStmt>(prog[0]);
+    ASSERT_EQ(imp.names.size(), 1u);
+    EXPECT_EQ(imp.names[0].name, "expect");
+}
+
+TEST(ParserTest, ImportBracedRejectsEmpty) {
+    try {
+        parseStr("from math import {}");
+        FAIL() << "Expected parser to reject empty braced import list";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("expected import name after '{'"), std::string::npos)
+            << "Error message should match the braced empty diagnostic: " << msg;
+    }
+}
+
+TEST(ParserTest, ImportBracedRejectsUnclosed) {
+    EXPECT_THROW(parseStr("from math import { add"), std::runtime_error);
+}
+
+TEST(ParserTest, ImportBracedRejectsMissingComma) {
+    EXPECT_THROW(parseStr("from math import { a b }"), std::runtime_error);
+}
+
+TEST(ParserTest, ImportBracedRejectsBadAlias) {
+    // Alias rule (#1721) applies inside braces too.
+    EXPECT_THROW(parseStr("from math import { add as 123 }"), std::runtime_error);
+}
+
 TEST(ParserTest, DuplicateFieldNameThrows) {
     EXPECT_THROW(parseStr("record Point:\n    x: int\n    x: int"), std::runtime_error);
 }


### PR DESCRIPTION
## Summary

Add JS-style braced selective import syntax:

```ry
from math import { PI, E }
from math import {
  PI,
  E,
}
from math import { PI as p, E }
```

- Both single-line and multi-line forms with optional trailing comma
- Composes with #1721 symbol alias (`{ a as b, c }`)
- Empty `{}` is rejected with `expected import name after '{'`
- AST output is identical to the existing comma-separated form — same `ImportStmt` shape, no downstream change

Closes #1722

## Implementation notes

- **Parser** (`src/parser.cpp`): added `LBrace` dispatch inside `parseImportStatement`. Uses `skipStructuralTokens()` to drop NEWLINE/INDENT/DEDENT inside braces, mirroring the list/map/set literal pattern.
- **Grammar** (`docs/grammar.ebnf`): `import_list` extended to `'{' import_item { ',' import_item } [ ',' ] '}' | import_item { ',' import_item }`.
- **Tree-sitter** (`editor/tree-sitter/grammar.js`): added a `choice(...)` branch with the braced form. Single-line braced imports work end-to-end; multi-line is tracked in #1727 (depends on scanner.c bracket-depth awareness which is a shared gap with list/map/set literals).
- **Tests**: 11 new C++ unit tests in `tests/test_parser.cpp` (covering single/multiple items, trailing comma, alias, multi-line, `expect` keyword carve-out, empty/unclosed/missing-comma/bad-alias rejections) plus a spec test under `tests/spec/braced_import/`.
- **Docs**: new "Braced Selective Import" section in `docs/reference/modules.md`; changelog fragment at `changelog.d/1722-braced-import.md`.
- **expected-fail.txt**: added `tests/spec/braced_import/braced_import.test.ry` (#1727) plus 5 housekeeping entries for pre-existing grammar gaps (`import_alias`, `arc_tuple_*`, `collection_meta_propagation`, `mock`) that earlier PRs introduced without updating the list.

## Test plan

- [x] §3 C++ tests: `./build/ry_tests` — 2226 passed
- [x] §3 Ry self tests: `./build/ry test -p` — 181 files, 0 failures
- [x] §3.5 ASan+UBSan: `ry_tests` 2226 / self-test 181 passed
- [x] §3.5 TSan: `ry_tests` 2226 / self-test 181 passed
- [x] §3.5.5 clang-tidy + cppcheck: clean (no new findings in `parser.cpp`)
- [x] §3.6 libFuzzer `fuzz_parser`: 60s exit 0, no crashes
- [x] §3.6.5 tree-sitter check.sh: pass=134 skip=47 fail=0
- [x] §3.7 background hygiene: no residual processes

## Related

- #1727 (filed during self-verification): tree-sitter scanner bracket-depth tracking to unblock multi-line braced import / list / map / set literals together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added braced selective import syntax: `from module import { name1, name2 }`
  * Supports single-line and multi-line forms with optional trailing comma
  * Supports symbol aliasing within braces: `from module import { name as alias }`
  * Empty braces are rejected with parse error

* **Documentation**
  * Updated grammar documentation and reference guide with braced import syntax examples and behavior specifications

* **Tests**
  * Added comprehensive test coverage for braced import functionality across various syntax forms

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1728)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->