### PR TITLE
feat(import): qualified import via 'import xxx' syntax (#1723)

### DIFF
--- a/.claude/rules/runtime-memory-safety.md
+++ b/.claude/rules/runtime-memory-safety.md
@@ -8,6 +8,50 @@ paths:
 
 # Runtime / Memory
 
+### Local types in `namespace ry` must not shadow public class names in `include/ry/*.hpp`
+
+**Source**: PR #1729 (2026-05-11, CI asan failure investigation; PR #1723 surfacing)
+**Tags**: odr, namespace, runtime, gotcha, comdat, linker, libstdc++, libc++, asan
+
+**Rule**: Translation-unit-local types declared inside `namespace ry { ... }`
+in any `src/runtime_*.cpp` (or other `.cpp`) must use a name that does **not**
+collide with a public class declared in `include/ry/*.hpp`. Prefix or suffix
+the local type with the module name (e.g. `JsonParser` inside
+`runtime_json.cpp`, not `Parser`). Anonymous namespaces do **not** suffice
+when both definitions sit under `namespace ry` — the linker still merges
+implicit / inline destructor symbols across translation units via COMDAT.
+
+**Why** (concrete incident): `src/runtime_json.cpp` had `struct Parser` in
+`namespace ry` for a TU-local JSON parser. `include/ry/parser.hpp` has
+`class ry::Parser` for the Ry source parser. Both auto-generated
+destructors (`_ZN2ry6ParserD1Ev`) share the same mangled symbol. On Linux
+libstdc++ the linker COMDAT-picked `parser.hpp`'s destructor and applied it
+across every TU, including `__ry_json_parse`. PR #1723 added
+`std::unordered_set<std::string> imported_modules_` to `ry::Parser`, making
+its destructor non-trivial. From that point on, `JsonParser` instances
+were destructed by code that ran `~unordered_set()` on JSON-struct memory,
+reading garbage as the hashtable bucket count and triggering
+`__asan_memset` of multi-GB → `AddressSanitizer: unknown-crash`.
+
+The bug was **latent for years** — both destructors were trivially equal
+until the qualified-import work added a non-POD member. macOS libc++
+happens to avoid the crash because of memory-layout differences; the
+asan CI job (Linux libstdc++) hit it deterministically.
+
+**How to apply**:
+- For every TU-local type inside `src/runtime_*.cpp` (or any `.cpp`
+  declared in `namespace ry`), use a module-qualified name:
+  `JsonParser`, `HttpParser`, `TomlLexer`, etc. — never the bare
+  `Parser` / `Lexer` / `Tokenizer` / etc. used by public headers.
+- Anonymous namespaces (`namespace { struct Parser { ... }; }`) hide
+  external linkage but **do not** prevent the COMDAT collision when the
+  destructor inlines into another TU that includes the public header.
+  Renaming is the safe fix.
+- When auditing existing code, grep for class names in `include/ry/*.hpp`
+  and search `src/*.cpp` for matching `struct <Name>` / `class <Name>`
+  inside `namespace ry`. Surface any matches before they grow non-trivial
+  members.
+
 ### Runtime functions returning ARC-managed structs must use `arc_alloc`, not `checked_malloc`
 
 **Source**: #1007, #1011 (2026-04-16, bug fixes), PR #997 (pattern established for ListHeader)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - **Control Flow** — `if`/`else`, `case`, `while`, `for...in`, `break`/`continue`
 - **File I/O** — File read/write, byte operations, standard input (`std.io`)
 - **Filesystem** — Directory listing, recursive walk, glob, copy, move, remove, permissions (`std.filesystem`)
-- **Modules** — Directory-based modules, auto-imported `std` library, `from ... import ...`
+- **Modules** — Directory-based modules, auto-imported `std` library, `from ... import ...` selective import, `import ...` qualified import
 - **Concurrency** — `async`/`await` with work-stealing scheduler, `@parallel` for loops, native thread API (`std.thread`)
 - **Memory Management** — ARC (Automatic Reference Counting) with a cycle collector (`std.gc`)
 - **Testing Framework** — `@describe` / `@it` directives on named functions, matchers (`expect(x).toEq(...)`), parameterized tests (`@each`), property-based tests (`@property`)
@@ -90,6 +90,11 @@ print(c)               # Red
 # Module import (with optional `as` alias)
 from math import sqrt, PI as PI_CONST
 print(sqrt(PI_CONST))
+
+# Qualified import: bind the module itself
+import math
+print(math.sqrt(2.0))   # 1.4142135623730951
+print(math.PI)          # 3.141592653589793
 ```
 
 ## Installation

--- a/changelog.d/1723-qualified-import.md
+++ b/changelog.d/1723-qualified-import.md
@@ -17,3 +17,14 @@
   [#1724](https://github.com/t0k0sh1/ry/issues/1724); duplicate
   `import` of the same module in a file and local bindings that shadow
   an imported module name are both parse errors. (#1723)
+
+### Fixed
+
+- Renamed the TU-local `struct ry::Parser` in `src/runtime_json.cpp` to
+  `JsonParser` to remove a latent ODR collision with the public
+  `class ry::Parser` declared in `include/ry/parser.hpp`. The collision
+  was benign while both implicit destructors were trivially equivalent,
+  but became a crash (`AddressSanitizer: unknown-crash` inside
+  `__ry_json_parse`) on Linux libstdc++ once `ry::Parser` grew a
+  non-trivial member as part of the qualified-import work in this PR.
+  (#1723)

--- a/changelog.d/1723-qualified-import.md
+++ b/changelog.d/1723-qualified-import.md
@@ -1,0 +1,19 @@
+### Added
+
+- Added qualified import syntax: `import <module>` binds the module
+  itself, and members are accessed via `<module>.<name>` (e.g.
+  `import math; math.sqrt(2.0)`, `math.PI`). Qualified and selective
+  imports compose — `import math` and `from math import PI` may both
+  appear in the same file. Qualified import is the recommended way to
+  resolve name collisions between modules: `from str import contains`
+  alongside `import list` lets the importer use `contains(...)` for the
+  string version and `list.append(...)` for the list version without
+  ambiguity. v0.0.23 supports qualified import for standard library
+  modules only; user-defined modules continue to use
+  `from <mod> import ...`. Constraints: single-identifier modules only
+  (`import a.b` is rejected, use `from a.b import ...`); the
+  `import <mod> as <local>` alias form is parsed but rejected with a
+  pointer to the follow-up issue
+  [#1724](https://github.com/t0k0sh1/ry/issues/1724); duplicate
+  `import` of the same module in a file and local bindings that shadow
+  an imported module name are both parse errors. (#1723)

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -39,7 +39,11 @@ top_level_statement ::= import_statement
  * 2. Imports
  * ===================================================================*/
 
-import_statement ::= 'from' module_path 'import' import_list NEWLINE
+import_statement ::= selective_import | qualified_import
+
+selective_import ::= 'from' module_path 'import' import_list NEWLINE
+
+qualified_import ::= 'import' IDENT [ 'as' IDENT ] NEWLINE
 
 module_path      ::= IDENT { '.' IDENT }
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -2,7 +2,12 @@
 
 ## Overview
 
-Ry uses a module system to organize code. A **module** can be either a single `.ry` file or a directory containing multiple `.ry` files. Use the `from` statement to import modules.
+Ry uses a module system to organize code. A **module** can be either a single `.ry` file or a directory containing multiple `.ry` files. Two import forms are supported:
+
+| Form | Syntax | Behavior |
+|---|---|---|
+| Selective import | `from <module> import <name>` | Binds the named symbol into the current file's scope |
+| Qualified import | `import <module>` | Binds the module itself; access members via `<module>.<name>` |
 
 The standard library (`std`) is automatically imported into every program.
 
@@ -87,6 +92,55 @@ the comma-separated form — the braces are purely syntactic. Editor
 support (tree-sitter): single-line braced imports are recognized; brace-
 internal newline suppression for the multi-line form is tracked in
 [#1727](https://github.com/t0k0sh1/ry/issues/1727).
+
+### Qualified Import
+
+```ry
+import math
+x = math.sqrt(2.0)       # 1.4142135623730951
+y = math.PI              # 3.141592653589793
+```
+
+`import <module>` binds the module name itself; members are then accessed
+via `<module>.<name>` for both functions and constants. The dot here is
+not UFCS — it is a qualified namespace lookup that resolves directly to
+the module's exports.
+
+Qualified import composes with selective import — both forms may target
+the same module in the same file:
+
+```ry
+import math
+from math import PI
+print(math.sqrt(PI))     # 1.7724538509055159
+print(PI)                # 3.141592653589793
+```
+
+Qualified import is especially useful when two modules export the same
+name. Importing one selectively and the other qualified avoids the
+collision:
+
+```ry
+from str import contains
+import list
+
+xs: List<int> = [1, 2, 3]
+list.append(xs, 4)             # list module's append
+contains("hello", "ell")       # str module's contains
+```
+
+**Constraints (v0.0.23)**:
+
+| Constraint | Details |
+|---|---|
+| Module form | Single identifier only. `import a.b` is rejected — use `from a.b import ...` instead. |
+| Alias | `import <module> as <local>` is parsed but rejected. Alias support is tracked in [#1724](https://github.com/t0k0sh1/ry/issues/1724). |
+| Module scope | Standard library modules only. Qualified call to a user-defined module produces a diagnostic suggesting `from <module> import ...`. |
+| Duplicate | `import math` followed by `import math` in the same file is a parse error. |
+| Shadowing | After `import math`, declaring `math: int = ...` (or any local named `math`) is a parse error. Rename the local or remove the matching `import` statement. |
+
+`import` is only valid at top level — placing it inside a function or
+block is rejected, matching the existing rule for `from` imports.
 
 ### Relative Import
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -333,7 +333,8 @@ export RY_PATH="/usr/local/ry/lib:/home/user/ry-modules"
 | Constraint | Details |
 |------|------|
 | Allowed location | Top level only (not inside functions or blocks) |
-| Duplicate imports | Automatically skipped (no error) |
+| Duplicate `from` imports | Automatically skipped (no error) |
+| Duplicate qualified `import` | Compile error (`'import xxx' already in this file`) |
 | Circular imports | Compile error |
 | Relative imports | `from .` and `from .submodule` resolve only against the current file's directory |
 | Parent directory imports | `from ..` is not supported |
@@ -344,9 +345,13 @@ export RY_PATH="/usr/local/ry/lib:/home/user/ry-modules"
 fn main():
     from math   # Error: imports only allowed at top level
 
-# OK: Importing the same module multiple times does not cause an error
+# OK: Repeating the same `from` import is silently skipped
 from math
 from math   # Skipped
+
+# Error: the qualified form rejects duplicates at parse time
+import math
+import math   # Error: 'import math' already in this file
 ```
 
 ---

--- a/editor/tree-sitter/grammar.js
+++ b/editor/tree-sitter/grammar.js
@@ -104,17 +104,30 @@ export default grammar({
 
     _top_level_statement: $ => choice(
       $.import_statement,
+      $.qualified_import_statement,
       $._statement,                          // _statement already includes _declaration
     ),
 
     /* =====================================================================
      * Imports
      * ===================================================================*/
+    // Selective import: `from xxx import name [as alias] [, ...]`
     import_statement: $ => seq(
       'from',
       field('source', $.module_path),
       'import',
       field('items', $.import_list),
+      $._newline,
+    ),
+
+    // Qualified import: `import xxx [as yyy]` (#1723).
+    // The `as` alias form is parsed but rejected by the Ry parser pending
+    // #1724; tree-sitter accepts it so the editor surface tolerates the
+    // syntax in flight.
+    qualified_import_statement: $ => seq(
+      'import',
+      field('module', $.identifier),
+      optional(seq('as', field('alias', $.identifier))),
       $._newline,
     ),
 

--- a/editor/tree-sitter/queries/highlights.scm
+++ b/editor/tree-sitter/queries/highlights.scm
@@ -24,6 +24,19 @@
   "from"
 ] @keyword.import
 
+; Qualified import: `import math` — module identifier is a namespace.
+(qualified_import_statement
+  module: (identifier) @module)
+
+(qualified_import_statement
+  alias: (identifier) @module)
+
+; Treat the module access prefix `math.sqrt(...)` / `math.PI` as a namespace
+; reference. Tree-sitter cannot distinguish stdlib qualified-call receivers
+; from generic field-access objects at the syntactic level, so this falls
+; back to (identifier) @variable below for non-import positions. Editors
+; that prefer a more conservative highlight may drop these two captures.
+
 [
   "fn"
   "record"

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -223,11 +223,13 @@ struct CallExpr {
     std::string callee;
     std::vector<ExprPtr> args;
     std::vector<NamedArg> named_args;
+    std::optional<std::string> qualified_module;  // set when call originates from `<mod>.fn(...)` qualified call
 };
 
 struct FieldAccessExpr {
     ExprPtr object;
     std::string field;
+    std::optional<std::string> qualified_module;  // set when access is `<mod>.x` qualified (mod-name held on .object as VariableExpr too, but this disambiguates from struct field access)
 };
 
 struct TupleExpr {
@@ -267,6 +269,13 @@ struct ImportName {
 struct ImportStmt {
     std::string module_path;              // "utils/math" (resolved to dir or .ry file)
     std::vector<ImportName> names;        // {{"add", nullopt}, {"sub", "minus"}} — empty means import all
+    SourceLocation loc;
+};
+
+struct QualifiedImportStmt {
+    std::string module_name;              // single identifier — multi-segment paths rejected at parse time
+    std::optional<std::string> alias;     // reserved for #1724 (`import xxx as yyy`); parser currently rejects non-empty
+    bool is_stdlib = false;               // set by ModuleLoader::resolveImports — gates qualified-call routing in CodeGen (stdlib dispatch vs. user-fn error in v0.0.23)
     SourceLocation loc;
 };
 
@@ -344,7 +353,7 @@ struct DirectiveDefStmt {
 };
 
 using StmtNode = std::variant<AssignStmt, CallStmt, ExprStmt,
-                              ReturnStmt, ImportStmt, RecordStmt,
+                              ReturnStmt, ImportStmt, QualifiedImportStmt, RecordStmt,
                               IndexAssignStmt, BreakStmt, ContinueStmt, EllipsisStmt,
                               FieldAssignStmt, EnumStmt, ExpectStmt, AwaitStmt,
                               TupleDestructStmt, TypeAliasStmt,

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -945,6 +945,15 @@ public:
     // require an explicit import (#715).
     std::unordered_set<std::string> testing_intrinsics_imported_;
 
+    // Modules introduced by `import xxx` (qualified import) at module scope.
+    // Key = module name, value = `is_stdlib` flag propagated from ModuleLoader.
+    // Populated by `emitStmt(QualifiedImportStmt&)`. Consulted by the call /
+    // field-access dispatchers to route `<mod>.fn(...)` (CallExpr with
+    // `qualified_module` set) — stdlib modules reuse the existing dispatch
+    // chain; user-defined modules raise a "not yet supported in v0.0.23"
+    // codegen error (issue #1723, follow-up #1724 / TBD).
+    std::unordered_map<std::string, bool> module_namespaces_;
+
     // User-defined @directive declarations. Keyed by directive name.
     std::unordered_map<std::string, DirectiveSignature> user_directive_registry_;
 
@@ -1206,6 +1215,7 @@ public:
     void emitStmt(ExprStmt &s);
     void emitStmt(ReturnStmt &s);
     void emitStmt(ImportStmt &s);
+    void emitStmt(QualifiedImportStmt &s);
     void emitStmt(RecordStmt &s);
     void emitStmt(TypeAliasStmt &s);
     void emitStmt(IndexAssignStmt &s);

--- a/include/ry/formatter.hpp
+++ b/include/ry/formatter.hpp
@@ -55,6 +55,7 @@ private:
     void formatExprStmt(const ExprStmt &s);
     void formatReturn(const ReturnStmt &s);
     void formatImport(const ImportStmt &s);
+    void formatQualifiedImport(const QualifiedImportStmt &s);
     void formatRecord(const RecordStmt &s);
     void formatEnum(const EnumStmt &s);
     void formatTypeAlias(const TypeAliasStmt &s);

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -10,6 +10,7 @@
 #include <cstring>
 #include <initializer_list>
 #include <stdexcept>
+#include <unordered_set>
 #include <utility>
 
 
@@ -37,6 +38,11 @@ private:
     // bare-lambda dispatch (`Ident FatArrow`) in parsePrimary so the `=>` is
     // recognised as the if-expression then-arm, not consumed as a lambda body.
     bool in_if_cond_ = false;
+    // Module names introduced by `import xxx` (qualified import) at the top
+    // level of the current source. Used by parsePrimary's Dot dispatch to
+    // disambiguate `mod.f(...)` qualified calls from UFCS / field access, and
+    // by parseStatement to reject `let mod = ...` shadowing.
+    std::unordered_set<std::string> imported_modules_;
     static constexpr int MAX_RECURSION_DEPTH = 256;
 
     struct RecursionGuard {
@@ -69,6 +75,8 @@ private:
     void skipNewlines();
     void skipStructuralTokens();
     StmtNode parseImportStatement();
+    StmtNode parseQualifiedImportStatement();
+    void rejectImportShadowing(const Token &nameTok);
     StmtNode parseStatement();
 
 

--- a/include/ry/parser.hpp
+++ b/include/ry/parser.hpp
@@ -69,6 +69,14 @@ private:
     static bool isCamelCase(const std::string &name);
     static void coerceFirstArgToString(std::vector<ExprPtr> &args);
 
+    // After '.', a field/method name token may be an Ident, a numeric tuple
+    // index, or any keyword from the lexer's keyword_map (e.g. `.and()`,
+    // `.expect(...)`, `.case`). Shared between the expression-side
+    // continuation (`parsePostfixContinuation`) and the statement-side dot
+    // fast path in `parseStatement` so `import testing\ntesting.expect(...)`
+    // parses identically in both positions.
+    static bool isFieldNameTokenKind(TokenKind k);
+
     SourceLocation locFromToken(const Token &t) const { return {t.line, t.col, file_id_}; }
 
     std::vector<Directive> parseDirectives();

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -8,6 +8,28 @@ namespace ry {
 // ===== CallExpr Dispatcher =====
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
+    // Qualified call `<mod>.fn(args)` (#1723). The parser sets
+    // `qualified_module` when the dotted LHS is a single identifier that was
+    // imported via `import <mod>` (parser tracks via `imported_modules_`,
+    // codegen via `module_namespaces_`). In v0.0.23 we route stdlib modules
+    // through the normal dispatch chain (StdlibRegistry already routes by
+    // callee name, so `math.sqrt(2.0)` → `emitBuiltinMath` resolves the same
+    // way `sqrt(2.0)` would once `import math` is in scope). User-defined
+    // qualified imports are not yet supported — emit a clear redirect to the
+    // selective-import form.
+    if (e->qualified_module.has_value()) {
+        const std::string &mod = *e->qualified_module;
+        auto it = module_namespaces_.find(mod);
+        if (it == module_namespaces_.end())
+            codegenError("qualified call to module '" + mod +
+                         "' which was not imported via 'import " + mod + "'");
+        if (!it->second)
+            codegenError("qualified call to user-defined module '" + mod +
+                         "' is not yet supported in v0.0.23; use 'from " + mod +
+                         " import " + e->callee + "' instead");
+        // stdlib module → fall through; downstream dispatchers route by callee.
+    }
+
     // ADT constructor: Enum::Variant(args...)
     {
         auto colonPos = e->callee.find("::");

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -88,6 +88,26 @@ llvm::Value *CodeGen::emitRecordConstructor(const RecordInfo &info,
 }
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e) {
+    // Qualified field access `<mod>.x` (#1723). Same routing rules as the
+    // qualified-call dispatcher in codegen_call_dispatch.cpp: stdlib modules
+    // resolve through the bare-name lookup (the field was inlined as a
+    // top-level binding by ModuleLoader), user-defined modules error with a
+    // redirect to selective import.
+    if (e->qualified_module.has_value()) {
+        const std::string &mod = *e->qualified_module;
+        auto it = module_namespaces_.find(mod);
+        if (it == module_namespaces_.end())
+            codegenError("qualified access on module '" + mod +
+                         "' which was not imported via 'import " + mod + "'");
+        if (!it->second)
+            codegenError("qualified field access on user-defined module '" + mod +
+                         "' is not yet supported in v0.0.23; use 'from " + mod +
+                         " import " + e->field + "' instead");
+        // stdlib: the inlined top-level definition is reachable by bare name.
+        VariableExpr proxy{e->field};
+        return emitExprVariant(proxy);
+    }
+
     llvm::Value *obj = emitExpr(*e->object);
     llvm::Type *objTy = obj->getType();
 

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -837,6 +837,17 @@ void CodeGen::emitStmt(ImportStmt &s) {
                              " (ModuleLoader should have resolved this)");
 }
 
+void CodeGen::emitStmt(QualifiedImportStmt &s) {
+    if (s.loc.isValid()) current_loc_ = s.loc;
+    // ModuleLoader has already loaded the module, inlined its exportable
+    // definitions, populated `exports_cache_`, and set `s.is_stdlib`.
+    // Codegen's job here is purely to register the module name so the
+    // call / field-access dispatchers can recognize `<mod>.fn(...)` /
+    // `<mod>.x` qualified forms. No IR is emitted for the statement
+    // itself (mirrors `emitStmt(ImportStmt&)` which is also IR-less).
+    module_namespaces_[s.module_name] = s.is_stdlib;
+}
+
 void CodeGen::emitStmt(IndexAssignStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -275,8 +275,17 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                 callee[lt] = '[';
                 callee.back() = ']';
             }
-            return callee + "(" + args + ")";
+            // Restore `module.callee(...)` form for qualified imports (#1723).
+            std::string prefix;
+            if (call.qualified_module.has_value())
+                prefix = *call.qualified_module + ".";
+            return prefix + callee + "(" + args + ")";
         } else if constexpr (std::is_same_v<T, std::unique_ptr<FieldAccessExpr>>) {
+            // Qualified const access via `import xxx` (#1723): the parser
+            // creates a FieldAccessExpr with an empty/placeholder object and
+            // `qualified_module` set. Render as `module.field`.
+            if (v->qualified_module.has_value())
+                return *v->qualified_module + "." + v->field;
             return formatExpr(*v->object) + "." + v->field;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<TupleExpr>>) {
             std::string elems;
@@ -614,6 +623,7 @@ int Formatter::getStmtLine(const StmtNode &stmt) const {
         else if constexpr (std::is_same_v<T, ReturnStmt>) return v.loc.line; // NOLINT(bugprone-branch-clone)
         else if constexpr (std::is_same_v<T, ExprStmt>) return v.loc.line;
         else if constexpr (std::is_same_v<T, ImportStmt>) return v.loc.line;
+        else if constexpr (std::is_same_v<T, QualifiedImportStmt>) return v.loc.line;
         else if constexpr (std::is_same_v<T, RecordStmt>) {
             if (!v.directives.empty()) return v.directives.front().loc.line;
             return v.loc.line;
@@ -652,6 +662,7 @@ void Formatter::formatStmt(const StmtNode &stmt) {
         else if constexpr (std::is_same_v<T, ExprStmt>) formatExprStmt(v);
         else if constexpr (std::is_same_v<T, ReturnStmt>) formatReturn(v);
         else if constexpr (std::is_same_v<T, ImportStmt>) formatImport(v);
+        else if constexpr (std::is_same_v<T, QualifiedImportStmt>) formatQualifiedImport(v);
         else if constexpr (std::is_same_v<T, RecordStmt>) formatRecord(v);
         else if constexpr (std::is_same_v<T, IndexAssignStmt>) formatIndexAssign(v);
         else if constexpr (std::is_same_v<T, BreakStmt>) formatBreak(v);

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -166,6 +166,18 @@ void Formatter::formatImport(const ImportStmt &s) {
     last_emitted_line_ = s.loc.line;
 }
 
+void Formatter::formatQualifiedImport(const QualifiedImportStmt &s) {
+    emit("import ");
+    emit(s.module_name);
+    if (s.alias.has_value()) {
+        emit(" as ");
+        emit(*s.alias);
+    }
+    emitInlineComment(s.loc.line);
+    emitNewline();
+    last_emitted_line_ = s.loc.line;
+}
+
 void Formatter::formatRecord(const RecordStmt &s) {
     formatDirectives(s.directives);
     if (!s.directives.empty()) emitIndent();

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -573,13 +573,25 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
             //      (required for stdlib qualified-call dispatch in Task 9).
             //   2. exports_cache_ / exports_kinds_cache_ get populated for any
             //      subsequent `from xxx import` referencing the same module.
+            //
+            // For user-defined modules (`!rp.from_stdlib`), route extracted
+            // definitions to a throwaway Program so they are NOT inlined into
+            // the caller's namespace. The caches still get populated so
+            // `from <mod> import x` after `import <mod>` works (AC2-like).
+            // Without this gate, `import usermod` followed by bare `greet()`
+            // succeeds — bypassing the documented v0.0.23 rejection at call
+            // site. Stdlib path stays unchanged: native-fn registration in
+            // CodeGen still relies on inlining (#1730 tracks proper namespace
+            // isolation for stdlib).
+            Program throwaway;
+            Program &push_target = rp.from_stdlib ? result : throwaway;
             if (rp.is_directory) {
                 loading_.insert(abs_path);
                 Program dir_prog = loadModuleDir(abs_path);
                 loading_.erase(abs_path);
                 loaded_.insert(abs_path);
 
-                extractDefinitions(dir_prog, result, /*requested_items=*/{},
+                extractDefinitions(dir_prog, push_target, /*requested_items=*/{},
                                    qimp.module_name, qimp.loc.line, cross_package,
                                    rp.from_stdlib,
                                    &exports_cache_[abs_path],
@@ -593,7 +605,7 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                 loading_.erase(abs_path);
                 loaded_.insert(abs_path);
 
-                extractDefinitions(sub_prog, result, /*requested_items=*/{},
+                extractDefinitions(sub_prog, push_target, /*requested_items=*/{},
                                    qimp.module_name, qimp.loc.line, cross_package,
                                    rp.from_stdlib,
                                    &exports_cache_[abs_path],

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -540,6 +540,71 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
     Program result;
 
     for (auto &stmt : prog) {
+        if (std::holds_alternative<QualifiedImportStmt>(stmt)) {
+            auto &qimp = std::get<QualifiedImportStmt>(stmt);
+
+            ResolvedPath rp = resolve(qimp.module_name, referrer_dir);
+            const std::string &abs_path = rp.path;
+
+            // Propagate stdlib origin to codegen — Task 9 uses this to gate
+            // qualified-call routing (stdlib → existing dispatch chain;
+            // user-defined → "not yet supported" error in v0.0.23).
+            qimp.is_stdlib = rp.from_stdlib;
+
+            std::string target_dir = rp.is_directory ? abs_path
+                                                     : fs::path(abs_path).parent_path().string();
+            bool cross_package = isCrossPackage(referrer_dir, target_dir);
+
+            if (loading_.count(abs_path))
+                throw std::runtime_error("circular import detected: " + abs_path);
+
+            if (loaded_.count(abs_path)) {
+                // exports_cache_ already populated by an earlier import of the
+                // same module (AC2: `import math` + `from math import PI`).
+                // Just push the QualifiedImportStmt so codegen can register the
+                // module in module_namespaces_.
+                result.push_back(std::move(stmt));
+                continue;
+            }
+
+            // First-time load: inline all exportable definitions (same path as
+            // `from xxx import` with empty names) so that:
+            //   1. @native fn signatures get registered in native_fn_sigs_
+            //      (required for stdlib qualified-call dispatch in Task 9).
+            //   2. exports_cache_ / exports_kinds_cache_ get populated for any
+            //      subsequent `from xxx import` referencing the same module.
+            if (rp.is_directory) {
+                loading_.insert(abs_path);
+                Program dir_prog = loadModuleDir(abs_path);
+                loading_.erase(abs_path);
+                loaded_.insert(abs_path);
+
+                extractDefinitions(dir_prog, result, /*requested_items=*/{},
+                                   qimp.module_name, qimp.loc.line, cross_package,
+                                   rp.from_stdlib,
+                                   &exports_cache_[abs_path],
+                                   &exports_kinds_cache_[abs_path],
+                                   qimp.loc.file_id);
+            } else {
+                loading_.insert(abs_path);
+                auto sub_prog = loadAndParse(abs_path, sm_);
+                std::string sub_dir = fs::path(abs_path).parent_path().string();
+                sub_prog = resolveImports(sub_prog, sub_dir);
+                loading_.erase(abs_path);
+                loaded_.insert(abs_path);
+
+                extractDefinitions(sub_prog, result, /*requested_items=*/{},
+                                   qimp.module_name, qimp.loc.line, cross_package,
+                                   rp.from_stdlib,
+                                   &exports_cache_[abs_path],
+                                   &exports_kinds_cache_[abs_path],
+                                   qimp.loc.file_id);
+            }
+
+            result.push_back(std::move(stmt));
+            continue;
+        }
+
         if (!std::holds_alternative<ImportStmt>(stmt)) {
             result.push_back(std::move(stmt));
             continue;

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1002,10 +1002,12 @@ StmtNode Parser::parseForStatement() {
         Token firstTok = lex_.peek();
         if (firstTok.kind != TokenKind::Ident)
             parseError(firstTok.line, "expected variable name after 'for'");
-        if (firstTok.value == "_")
+        if (firstTok.value == "_") {
             binding = WildcardPattern{};
-        else
+        } else {
+            rejectImportShadowing(firstTok);
             binding = VariablePattern{firstTok.value};
+        }
         lex_.next(); // consume first binding token
 
         if (lex_.peek().kind == TokenKind::Comma) {
@@ -1020,10 +1022,12 @@ StmtNode Parser::parseForStatement() {
                 Token vTok = lex_.peek();
                 if (vTok.kind != TokenKind::Ident)
                     parseError(vTok.line, "expected variable name after ',' in for loop");
-                if (vTok.value == "_")
+                if (vTok.value == "_") {
                     tuple->elements.push_back(WildcardPattern{});
-                else
+                } else {
+                    rejectImportShadowing(vTok);
                     tuple->elements.push_back(VariablePattern{vTok.value});
+                }
                 lex_.next(); // consume var
             }
             binding = std::move(tuple);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -90,6 +90,22 @@ bool Parser::isCamelCase(const std::string &name) {
     parseError(lex_.peek().line, msg);
 }
 
+// ===== Qualified-import shadowing rejection (#1723) =====
+
+// Throws if the given identifier collides with a qualified-imported module.
+// Used at every local-binding site (AssignStmt, TupleDestructStmt, compound
+// assign, increment/decrement) so 'import math\nmath = 42' fails at parse
+// time with a precise diagnostic, instead of crashing in codegen with an
+// opaque resolution error. Shadowing is rejected even inside function
+// bodies — see plan #1723 (AC7-adjacent).
+void Parser::rejectImportShadowing(const Token &nameTok) {
+    if (imported_modules_.count(nameTok.value) > 0)
+        parseError(nameTok.line,
+            "cannot shadow imported module '" + nameTok.value +
+            "' with a local binding; rename the local or remove the matching "
+            "'import " + nameTok.value + "' statement");
+}
+
 // ===== Compound assignment helper: x op= rhs =====
 
 AssignStmt Parser::makeCompoundAssign(const Token &nameTok, const std::string &op, ExprPtr rhs) {
@@ -271,6 +287,8 @@ Program Parser::parseProgram() {
     while (lex_.peek().kind != TokenKind::Eof) {
         if (lex_.peek().kind == TokenKind::From) {
             prog.push_back(parseImportStatement());
+        } else if (lex_.peek().kind == TokenKind::Import) {
+            prog.push_back(parseQualifiedImportStatement());
         } else {
             prog.push_back(parseStatement());
         }
@@ -465,6 +483,46 @@ StmtNode Parser::parseImportStatement() {
     return ImportStmt{modulePath, std::move(names), {fromTok.line, fromTok.col, file_id_}};
 }
 
+StmtNode Parser::parseQualifiedImportStatement() {
+    // Qualified import: `import <ident> [as <ident>]` (#1723)
+    // - Only single identifier accepted; `import a.b` rejected (AC6)
+    // - `as` form reserved for #1724; currently rejected
+    // - Duplicate `import <same>` rejected (AC7)
+    Token importTok = lex_.next(); // consume 'import'
+
+    Token modTok = lex_.peek();
+    if (modTok.kind != TokenKind::Ident)
+        parseError(modTok.line, "expected module name after 'import'");
+    std::string moduleName = lex_.next().value;
+
+    if (lex_.peek().kind == TokenKind::Dot)
+        parseError(lex_.peek().line,
+            "qualified import does not support dotted module paths "
+            "('import a.b'); use 'from a.b import ...' instead");
+
+    std::optional<std::string> alias;
+    if (lex_.peek().kind == TokenKind::As) {
+        Token asTok = lex_.next(); // consume 'as'
+        Token aliasTok = lex_.peek();
+        if (aliasTok.kind != TokenKind::Ident)
+            parseError(aliasTok.line, "expected identifier after 'as'");
+        parseError(asTok.line,
+            "qualified import alias ('import xxx as yyy') is not yet "
+            "supported (tracked by issue #1724)");
+    }
+
+    if (!imported_modules_.insert(moduleName).second)
+        parseError(importTok.line,
+            "duplicate qualified import: 'import " + moduleName +
+            "' was already imported in this file");
+
+    return QualifiedImportStmt{
+        std::move(moduleName),
+        std::move(alias),
+        /*is_stdlib=*/false,
+        {importTok.line, importTok.col, file_id_}};
+}
+
 StmtNode Parser::parseStatement() {
     RecursionGuard guard(*this);
     // Parse directives before the statement
@@ -474,6 +532,9 @@ StmtNode Parser::parseStatement() {
 
     if (first.kind == TokenKind::From)
         parseError(first.line, "'from' import is only allowed at top level");
+
+    if (first.kind == TokenKind::Import)
+        parseError(first.line, "'import' is only allowed at top level");
 
     // @directive(...) declares a new directive (#708). Must be followed by `fn`.
     // Only @public is permitted alongside @directive so stdlib directive
@@ -676,6 +737,7 @@ StmtNode Parser::parseStatement() {
                 "variable name '" + first.value +
                 "' must be camelCase (or SCREAMING_SNAKE_CASE for @native or @const variable names)");
         }
+        rejectImportShadowing(first);
         lex_.next(); // consume ':'
         auto typeAnnotation = parseTypeName();
         AssignStmt s;
@@ -735,8 +797,28 @@ StmtNode Parser::parseStatement() {
         lex_.next(); // consume field name
 
         if (lex_.peek().kind == TokenKind::LParen) {
-            // UFCS call statement: ident.method(args)
             lex_.next(); // consume '('
+            // Qualified module dispatch (#1723): `<mod>.fn(args)` where `mod`
+            // was registered via `import mod` is a qualified call, NOT UFCS.
+            // Produce an ExprStmt wrapping a CallExpr with qualified_module
+            // set so the codegen short-circuit at codegen_call_dispatch.cpp
+            // takes the stdlib dispatcher path.
+            if (imported_modules_.count(first.value) > 0) {
+                auto call = std::make_unique<CallExpr>();
+                call->callee = fieldTok.value;
+                call->qualified_module = first.value;
+                auto rest = parseArgList(&call->named_args);
+                for (auto &arg : rest)
+                    call->args.push_back(std::move(arg));
+                auto node = std::make_unique<ExprNode>();
+                node->data = std::move(call);
+                node->loc = locFromToken(first);
+                ExprStmt es;
+                es.expr = std::move(node);
+                es.loc = locFromToken(first);
+                return es;
+            }
+            // UFCS call statement: ident.method(args)
             CallStmt s;
             s.callee = fieldTok.value;
             s.loc = locFromToken(first);
@@ -771,6 +853,7 @@ StmtNode Parser::parseStatement() {
         std::vector<std::string> names;
         if (first.value != "_" && !isCamelCase(first.value))
             parseError(first.line, "tuple-destructure name '" + first.value + "' must be camelCase");
+        rejectImportShadowing(first);
         names.push_back(first.value);
         while (lex_.peek().kind == TokenKind::Comma) {
             lex_.next(); // consume ','
@@ -779,6 +862,7 @@ StmtNode Parser::parseStatement() {
                 parseError("expected identifier or '_' in tuple destructuring");
             if (n.value != "_" && !isCamelCase(n.value))
                 parseError(n.line, "tuple-destructure name '" + n.value + "' must be camelCase");
+            rejectImportShadowing(n);
             lex_.next(); // consume ident
             names.push_back(n.value);
         }
@@ -794,6 +878,7 @@ StmtNode Parser::parseStatement() {
         s.loc = locFromToken(first);
         return s;
     } else if (next.kind == TokenKind::Equals) {
+        rejectImportShadowing(first);
         lex_.next(); // consume '='
         AssignStmt s;
         s.name  = first.value;
@@ -810,11 +895,13 @@ StmtNode Parser::parseStatement() {
                next.kind == TokenKind::LessLessEq || next.kind == TokenKind::GreaterGreaterEq) {
         if (!directives.empty())
             parseError(first.line, "directives are not supported on compound assignment");
+        rejectImportShadowing(first);
         // Compound assignment: preserve compound_op for codegen resolution
         Token opTok = lex_.next(); // consume +=, -=, //=, **=, etc.
         std::string op = opTok.value.substr(0, opTok.value.size() - 1); // extract "//" from "//="
         return makeCompoundAssign(first, op, parseConditional());
     } else if (next.kind == TokenKind::PlusPlus || next.kind == TokenKind::MinusMinus) {
+        rejectImportShadowing(first);
         Token opTok = lex_.next(); // consume ++ or --
         std::string op = (opTok.kind == TokenKind::PlusPlus) ? "+" : "-";
         auto one = std::make_unique<ExprNode>();

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -92,6 +92,52 @@ bool Parser::isCamelCase(const std::string &name) {
 
 // ===== Qualified-import shadowing rejection (#1723) =====
 
+// After '.', a field/method name may be an Ident, a numeric tuple index, or
+// any keyword token from the lexer's keyword_map (e.g. `.and()`, `.or()`,
+// `.expect(...)`). Keyword tokens arrive as TokenKind::And / Or / Expect /
+// etc., NOT as TokenKind::Ident, so a strict Ident-only check at the
+// statement-side dot fast path would reject legal qualified calls like
+// `testing.expect(1).toEq(1)` that work at expression position.
+bool Parser::isFieldNameTokenKind(TokenKind k) {
+    switch (k) {
+        case TokenKind::Ident:
+        case TokenKind::Number:
+        case TokenKind::And:
+        case TokenKind::Or:
+        case TokenKind::Not:
+        case TokenKind::True:
+        case TokenKind::False:
+        case TokenKind::If:
+        case TokenKind::Else:
+        case TokenKind::While:
+        case TokenKind::For:
+        case TokenKind::In:
+        case TokenKind::Break:
+        case TokenKind::Continue:
+        case TokenKind::Fn:
+        case TokenKind::Return:
+        case TokenKind::From:
+        case TokenKind::Import:
+        case TokenKind::Type:
+        case TokenKind::Record:
+        case TokenKind::Operator:
+        case TokenKind::Enum:
+        case TokenKind::Case:
+        case TokenKind::Expect:
+        case TokenKind::Require:
+        case TokenKind::Ensure:
+        case TokenKind::Invariant:
+        case TokenKind::NoneKw:
+        case TokenKind::As:
+        case TokenKind::ErrorKw:
+        case TokenKind::Async:
+        case TokenKind::Await:
+            return true;
+        default:
+            return false;
+    }
+}
+
 // Throws if the given identifier collides with a qualified-imported module.
 // Used at every local-binding site (AssignStmt, TupleDestructStmt, compound
 // assign, increment/decrement) so 'import math\nmath = 42' fails at parse
@@ -641,6 +687,8 @@ StmtNode Parser::parseStatement() {
             Token n = lex_.peek();
             if (n.value != "_" && !isCamelCase(n.value))
                 parseError(n.line, "tuple-destructure name '" + n.value + "' must be camelCase");
+            if (n.value != "_")
+                rejectImportShadowing(n);
             names.push_back(n.value);
             lex_.next();
         }
@@ -649,6 +697,8 @@ StmtNode Parser::parseStatement() {
             Token n = lex_.peek();
             if (n.value != "_" && !isCamelCase(n.value))
                 parseError(n.line, "tuple-destructure name '" + n.value + "' must be camelCase");
+            if (n.value != "_")
+                rejectImportShadowing(n);
             names.push_back(n.value);
             lex_.next();
         }
@@ -792,17 +842,25 @@ StmtNode Parser::parseStatement() {
         // which produces a CallStmt rather than an ExprStmt<CallExpr>.
         Token dotTok = lex_.next(); // consume '.'
         Token fieldTok = lex_.peek();
-        if (fieldTok.kind != TokenKind::Ident)
-            parseError(fieldTok.line, "expected field name after '.'");
+        // Accept Ident, tuple-index Number, and keyword field names (mirrors
+        // parsePostfixContinuation in parser_expr.cpp). Without this,
+        // qualified calls whose member name is a keyword (e.g.
+        // `testing.expect(1).toEq(1)`) are rejected at statement position
+        // while the same expression succeeds inside `let x = testing.expect(...)`.
+        if (!isFieldNameTokenKind(fieldTok.kind))
+            parseError(fieldTok.line, "expected field name or index after '.'");
         lex_.next(); // consume field name
 
         if (lex_.peek().kind == TokenKind::LParen) {
             lex_.next(); // consume '('
             // Qualified module dispatch (#1723): `<mod>.fn(args)` where `mod`
             // was registered via `import mod` is a qualified call, NOT UFCS.
-            // Produce an ExprStmt wrapping a CallExpr with qualified_module
-            // set so the codegen short-circuit at codegen_call_dispatch.cpp
-            // takes the stdlib dispatcher path.
+            // Build a CallExpr with qualified_module set, then feed it through
+            // parsePostfixContinuation so postfix tails like
+            // `testing.expect(1).toEq(1)` chain through to finishChainedLhs
+            // and emit the correct ExprStmt with the trailing UFCS hop wired
+            // up. Without the continuation, the second `.toEq(...)` would be
+            // left in the token stream and trigger "unexpected token '.'".
             if (imported_modules_.count(first.value) > 0) {
                 auto call = std::make_unique<CallExpr>();
                 call->callee = fieldTok.value;
@@ -813,10 +871,8 @@ StmtNode Parser::parseStatement() {
                 auto node = std::make_unique<ExprNode>();
                 node->data = std::move(call);
                 node->loc = locFromToken(first);
-                ExprStmt es;
-                es.expr = std::move(node);
-                es.loc = locFromToken(first);
-                return es;
+                ExprPtr chain = parsePostfixContinuation(std::move(node));
+                return finishChainedLhs(std::move(chain), first);
             }
             // UFCS call statement: ident.method(args)
             CallStmt s;
@@ -836,12 +892,19 @@ StmtNode Parser::parseStatement() {
         // Build `ident.field` as the chain base and continue parsing any
         // further postfix hops (`.a`, `[i]`, etc.) to support chained LHS
         // forms like `rec.field[i] = v`, `rec.a.b = v`, `rec.a[i].x = v`.
+        // For qualified module access (e.g. `math.PI.toStr()`), the FIRST
+        // FieldAccessExpr carries qualified_module so codegen routes through
+        // the namespace lookup before the trailing UFCS hop sees it as a
+        // value. parsePostfixContinuation only inspects the chain root for
+        // VariableExpr, so subsequent hops stay UFCS even when LHS is qual.
         auto varExpr = std::make_unique<ExprNode>();
         varExpr->data = VariableExpr{first.value};
         varExpr->loc = locFromToken(first);
         auto fa = std::make_unique<FieldAccessExpr>();
         fa->object = std::move(varExpr);
         fa->field = fieldTok.value;
+        if (imported_modules_.count(first.value) > 0)
+            fa->qualified_module = first.value;
         auto chain = std::make_unique<ExprNode>();
         chain->data = std::move(fa);
         chain->loc = locFromToken(dotTok);

--- a/src/parser_decl.cpp
+++ b/src/parser_decl.cpp
@@ -168,6 +168,7 @@ StmtNode Parser::parseFnStatement(const std::vector<Directive> &directives, bool
                 parseError(paramName.line, "expected parameter name");
             if (!isCamelCase(paramName.value))
                 parseError(paramName.line, "parameter name '" + paramName.value + "' must be camelCase");
+            rejectImportShadowing(paramName);
             lex_.next(); // consume param name
 
             TypeNodePtr paramType = TypeNode::makeBasic("any");  // default when type is omitted

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -1146,12 +1146,27 @@ ExprPtr Parser::parsePostfixContinuation(ExprPtr expr) {
         if (!isFieldName)
             parseError(field.line, "expected field name or index after '.'");
         lex_.next(); // consume field name/number
+        // Qualified module dispatch (#1723): when the LHS is a bare identifier
+        // whose name was registered via `import <mod>`, the dot is a namespace
+        // access, not UFCS or field access. The original VariableExpr is left
+        // intact (stored on CallExpr/FieldAccessExpr) but codegen short-circuits
+        // before evaluating it once `qualified_module` is set.
+        std::optional<std::string> qualified_module;
+        if (auto *ve = std::get_if<VariableExpr>(&expr->data)) {
+            if (imported_modules_.count(ve->name) > 0)
+                qualified_module = ve->name;
+        }
         if (lex_.peek().kind == TokenKind::LParen) {
-            // UFCS: a.f(b, c) → f(a, b, c)
             lex_.next(); // consume '('
             auto call = std::make_unique<CallExpr>();
             call->callee = field.value;
-            call->args.push_back(std::move(expr));
+            if (qualified_module.has_value()) {
+                // Qualified call: do NOT prepend LHS as receiver.
+                call->qualified_module = std::move(qualified_module);
+            } else {
+                // UFCS: a.f(b, c) → f(a, b, c)
+                call->args.push_back(std::move(expr));
+            }
             auto rest = parseArgList(&call->named_args); // consumes ')'
             for (auto &arg : rest)
                 call->args.push_back(std::move(arg));
@@ -1160,10 +1175,11 @@ ExprPtr Parser::parsePostfixContinuation(ExprPtr expr) {
             node->loc = locFromToken(dotTok);
             expr = std::move(node);
         } else {
-            // Field access: a.x
+            // Field access: a.x (or qualified const access: math.PI)
             auto fa = std::make_unique<FieldAccessExpr>();
             fa->object = std::move(expr);
             fa->field = field.value;
+            fa->qualified_module = std::move(qualified_module);
             auto node = std::make_unique<ExprNode>();
             node->data = std::move(fa);
             node->loc = locFromToken(dotTok);

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -675,6 +675,12 @@ ExprPtr Parser::parsePrimary() {
         if (lex_.peek().kind == TokenKind::FatArrow && !in_if_cond_) {
             if (!isCamelCase(t.value))
                 parseError(t.line, "parameter name '" + t.value + "' must be camelCase");
+            // #1723: bare lambda param must not shadow an imported module —
+            // the body would then route `math.sqrt(...)` to the qualified
+            // call instead of treating `math` as the lambda parameter.
+            // Mirrors the same guard on parenthesized lambda params
+            // (parseParenLambdaExpr) and fn-decl params (parser_decl.cpp).
+            rejectImportShadowing(t);
             lex_.next(); // consume '=>'
             auto lambda = std::make_unique<LambdaExpr>();
             lambda->params.push_back({t.value, TypeNode::makeBasic("any"), nullptr});
@@ -1099,52 +1105,12 @@ ExprPtr Parser::parsePostfixContinuation(ExprPtr expr) {
         // Dot access follows below
         Token dotTok = lex_.next(); // consume '.'
         Token field = lex_.peek();
-        // After '.', accept identifiers, numbers, and keyword tokens.
-        // Keyword tokens (e.g., '.and()', '.or()', '.not()') come from the
-        // lexer's keyword_map and arrive as TokenKind::And / Or / Not / etc.,
-        // not as TokenKind::Ident. In dot-access context the syntax is
-        // unambiguous, so keywords are valid as field or method names.
-        auto isKeywordAfterDot = [](TokenKind k) {
-            switch (k) {
-                case TokenKind::And:
-                case TokenKind::Or:
-                case TokenKind::Not:
-                case TokenKind::True:
-                case TokenKind::False:
-                case TokenKind::If:
-                case TokenKind::Else:
-                case TokenKind::While:
-                case TokenKind::For:
-                case TokenKind::In:
-                case TokenKind::Break:
-                case TokenKind::Continue:
-                case TokenKind::Fn:
-                case TokenKind::Return:
-                case TokenKind::From:
-                case TokenKind::Import:
-                case TokenKind::Type:
-                case TokenKind::Record:
-                case TokenKind::Operator:
-                case TokenKind::Enum:
-                case TokenKind::Case:
-                case TokenKind::Expect:
-                case TokenKind::Require:
-                case TokenKind::Ensure:
-                case TokenKind::Invariant:
-                case TokenKind::NoneKw:
-                case TokenKind::As:
-                case TokenKind::ErrorKw:
-                case TokenKind::Async:
-                case TokenKind::Await:
-                    return true;
-                default:
-                    return false;
-            }
-        };
-        bool isFieldName = field.kind == TokenKind::Ident
-                        || field.kind == TokenKind::Number
-                        || isKeywordAfterDot(field.kind);
-        if (!isFieldName)
+        // After '.', accept identifiers, numbers (tuple indices), and keyword
+        // tokens (`.and()`, `.expect(...)`, …). The same predicate is reused
+        // by the statement-side dot fast path in parser.cpp so qualified
+        // calls whose member is a keyword behave identically at statement and
+        // expression positions.
+        if (!isFieldNameTokenKind(field.kind))
             parseError(field.line, "expected field name or index after '.'");
         lex_.next(); // consume field name/number
         // Qualified module dispatch (#1723): when the LHS is a bare identifier

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -1004,6 +1004,7 @@ ExprPtr Parser::parseParenLambdaExpr() {
     for (const auto &tok : paramNameTokens) {
         if (!isCamelCase(tok.value))
             parseError(tok.line, "parameter name '" + tok.value + "' must be camelCase");
+        rejectImportShadowing(tok);
     }
 
     if (lex_.peek().kind == TokenKind::Arrow) {

--- a/src/runtime_json.cpp
+++ b/src/runtime_json.cpp
@@ -67,9 +67,9 @@ static void json_release_contents(JsonValue *v) {
     }
 }
 
-// ===== Parser =====
+// ===== JsonParser =====
 
-struct Parser {
+struct JsonParser {
     static constexpr int MAX_NESTING_DEPTH = 256;
 
     const char *src;
@@ -78,15 +78,15 @@ struct Parser {
     std::string error;
     int depth = 0;
 
-    Parser(const char *text) : src(text), pos(0), src_len((size_t)stringByteLen(text)) {}
+    JsonParser(const char *text) : src(text), pos(0), src_len((size_t)stringByteLen(text)) {}
 
     // RAII helper: increments `depth` on construction and decrements on
     // destruction. parse_array / parse_object instantiate it after the
     // `if (depth >= MAX_NESTING_DEPTH)` gate, so multiple early-return paths
     // restore the counter without each having to remember the decrement.
     struct DepthGuard {
-        Parser *p;
-        explicit DepthGuard(Parser *parser) : p(parser) { ++p->depth; }
+        JsonParser *p;
+        explicit DepthGuard(JsonParser *parser) : p(parser) { ++p->depth; }
         ~DepthGuard() { --p->depth; }
         DepthGuard(const DepthGuard&) = delete;
         DepthGuard& operator=(const DepthGuard&) = delete;
@@ -601,7 +601,7 @@ void *__ry_json_parse(const char *text) {
         __ry_set_last_error("json parse: input is null");
         return nullptr;
     }
-    Parser parser(text);
+    JsonParser parser(text);
     JsonValue *val = parser.parse_value();
     if (!val) {
         __ry_set_last_error(parser.error.c_str());

--- a/tests/spec/qualified_import/qualified_import.test.ry
+++ b/tests/spec/qualified_import/qualified_import.test.ry
@@ -1,0 +1,51 @@
+from testing import it, describe, expect
+
+import math
+from math import PI
+
+import list
+from str import contains
+
+@describe("qualified import (#1723)")
+fn qualifiedImportTests():
+  @it("AC1: import math then qualified call resolves to stdlib dispatcher")
+  fn shouldQualifiedCall():
+    expect(math.sqrt(2.0)).toBeCloseTo(1.4142135623730951, 10)
+    expect(math.sqrt(4.0)).toEq(2.0)
+
+  @it("AC1: qualified const access resolves to module constant")
+  fn shouldQualifiedConst():
+    expect(math.PI).toBeCloseTo(3.141592653589793, 10)
+
+  @it("AC2: qualified import and selective import of the same module coexist")
+  fn shouldCoexistWithSelectiveImport():
+    # PI from `from math import PI` is the same value math.PI resolves to.
+    expect(PI).toEq(math.PI)
+    expect(math.sqrt(PI)).toBeCloseTo(1.7724538509055159, 10)
+
+  @it("AC3: qualified import resolves name collisions across modules")
+  fn shouldDisambiguateCollidingNames():
+    # `contains` resolves to str.contains via selective import;
+    # `list.append` is the list-module function reached qualified.
+    xs: List<int> = [1, 2, 3]
+    list.append(xs, 4)
+    expect(xs).toEq([1, 2, 3, 4])
+    expect(contains("hello", "ell")).toBeTrue()
+
+  @it("AC4: UFCS on non-imported receivers still works alongside import math")
+  fn shouldNotBreakUfcs():
+    s: str = "hello"
+    expect(s.contains("ell")).toBeTrue()
+    expect(math.sqrt(9.0)).toEq(3.0)
+
+  @it("AC5: struct field access on record values is unaffected by import")
+  fn shouldNotBreakStructFieldAccess():
+    record Point:
+      x: int
+      y: int
+
+    p = Point(3, 4)
+    expect(p.x).toEq(3)
+    expect(p.y).toEq(4)
+    # math is still a module; p.x is still a field. Both paths coexist.
+    expect(math.sqrt(25.0)).toEq(5.0)

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1783,6 +1783,53 @@ TEST_F(ImportTest, CodeGenReceivesNamedSubsetTestingIntrinsics) {
     EXPECT_EQ(intrinsics, expected);
 }
 
+// Qualified import — user-defined module call rejection (#1723).
+// Triggers the codegen branch in `emitCall` that rejects qualified calls
+// on user-defined modules; covered as a v0.0.23 limitation pointing users
+// at the selective-import form.
+TEST_F(ImportTest, QualifiedImportUserDefinedModuleCallRejected) {
+    writeFile("mymod.ry",
+        "fn greet() -> int:\n"
+        "    return 7\n");
+    try {
+        runWithImports(
+            "import mymod\n"
+            "print(mymod.greet())\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("qualified call to user-defined module 'mymod'"),
+                  std::string::npos)
+            << "got: " << msg;
+        EXPECT_NE(msg.find("from mymod import greet"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// Qualified import — user-defined module field access rejection (#1723).
+// Triggers the codegen branch in field-access lowering that rejects
+// qualified const access on user-defined modules.
+TEST_F(ImportTest, QualifiedImportUserDefinedModuleFieldRejected) {
+    writeFile("constmod2.ry",
+        "@directive(target=[\"statement\"])\n"
+        "fn const()\n"
+        "@const\n"
+        "ANSWER: int = 42\n");
+    try {
+        runWithImports(
+            "import constmod2\n"
+            "print(constmod2.ANSWER)\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("qualified field access on user-defined module 'constmod2'"),
+                  std::string::npos)
+            << "got: " << msg;
+        EXPECT_NE(msg.find("from constmod2 import ANSWER"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
 // ===== type alias =====
 
 TEST_F(CodeGenTest, TypeAlias) {

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1830,6 +1830,27 @@ TEST_F(ImportTest, QualifiedImportUserDefinedModuleFieldRejected) {
     }
 }
 
+// Qualified import — user-defined module must NOT leak bare names into caller (#1723, CR review).
+// Triggers the module_loader.cpp branch that routes user-defined defs to a throwaway
+// Program (instead of inlining them into the caller) so `import usermod\ngreet()`
+// fails with the regular `undefined function: greet` resolver error rather than
+// silently succeeding.
+TEST_F(ImportTest, QualifiedImportUserDefinedDoesNotLeakBareNames) {
+    writeFile("leakmod.ry",
+        "fn greet() -> int:\n"
+        "    return 7\n");
+    try {
+        runWithImports(
+            "import leakmod\n"
+            "print(greet())\n");
+        FAIL() << "Expected exception (bare 'greet' must not resolve through qualified import)";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("undefined function: greet"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
 // ===== type alias =====
 
 TEST_F(CodeGenTest, TypeAlias) {

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -82,6 +82,18 @@ TEST(Formatter, StatementFormatting) {
     EXPECT_EQ(fmt("from math import a, b as B, c\n"), "from math import a, b as B, c\n");
     // Self-alias is normalized away by the parser (alias == name → no alias)
     EXPECT_EQ(fmt("from math import add as add\n"), "from math import add\n");
+    // Qualified import (#1723): `import math` round-trips verbatim.
+    EXPECT_EQ(fmt("import math\n"), "import math\n");
+    // Qualified call site preserves the `module.callee(...)` prefix.
+    EXPECT_EQ(fmt("import math\nx = math.sqrt(2.0)\n"),
+              "import math\nx = math.sqrt(2.0)\n");
+    // Qualified call as a bare statement (#1723): formatter must not rewrite
+    // it into UFCS form (`sqrt(math, 3.0)`).
+    EXPECT_EQ(fmt("import math\nmath.sqrt(3.0)\n"),
+              "import math\nmath.sqrt(3.0)\n");
+    // Qualified const access via `import xxx`.
+    EXPECT_EQ(fmt("import math\nx = math.PI\n"),
+              "import math\nx = math.PI\n");
     // Return
     {
         auto src = "fn f() -> int:\n    return 42\n";

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1220,6 +1220,106 @@ TEST(ParserTest, QualifiedImportShadowingByLambdaParamRejected) {
     }
 }
 
+TEST(ParserTest, QualifiedImportShadowingByBareLambdaParamRejected) {
+    // Bare-paren-omitted single-param lambda `math => expr` (#1572 form)
+    // must also be guarded, mirroring the parenthesized lambda above.
+    // The bare form has no try/catch wrapping so the throw surfaces
+    // directly — but the test makes the guard explicit so a future
+    // refactor that drops the call doesn't silently re-allow shadowing.
+    try {
+        parseStr("import math\nf = math => math + 1\n");
+        FAIL() << "Expected parser to reject bare lambda param that shadows imported module";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot shadow imported module 'math'"), std::string::npos)
+            << "Error should mention shadow rejection: " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportShadowingByParenTupleDestructFirstRejected) {
+    // Parenthesized tuple destructure first-position binding. The bare-form
+    // path was already guarded (QualifiedImportShadowingByTupleDestructFirstRejected
+    // above) but the parenthesized variant lives in a separate code path
+    // (parser.cpp, looksLikeParenthesizedTupleDestructure branch) and must
+    // be guarded independently.
+    EXPECT_THROW(parseStr("import math\n(math, y) = (1, 2)"), std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportShadowingByParenTupleDestructRestRejected) {
+    // Rest-position shadowing in the parenthesized form — mirror of the
+    // first-position guard. Both first and rest sites must be checked.
+    EXPECT_THROW(parseStr("import math\n(x, math) = (1, 2)"), std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportChainedQualifiedFieldAccessAtStmt) {
+    // AC1 / CR-review (#1729): `math.PI.toStr()` at statement position must
+    // set qualified_module on the FIRST FieldAccessExpr so codegen routes
+    // PI through the namespace lookup before the trailing UFCS hop. Without
+    // the fix the multi-hop chain in parser.cpp built the FieldAccessExpr
+    // without qualified_module and codegen errored with "undefined
+    // variable: math".
+    Program prog = parseStr("import math\nmath.PI.toStr()");
+    // [QualifiedImportStmt, ExprStmt] — the qualified import counts as a
+    // statement and lives at prog[0].
+    ASSERT_EQ(prog.size(), 2u);
+    const auto &es = std::get<ExprStmt>(prog.back());
+    // Chain shape: CallExpr{toStr, args=[FieldAccessExpr{math, PI, qm=math}]}
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(es.expr->data));
+    const auto &call = *std::get<std::unique_ptr<CallExpr>>(es.expr->data);
+    EXPECT_EQ(call.callee, "toStr");
+    ASSERT_EQ(call.args.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(call.args[0]->data));
+    const auto &fa = *std::get<std::unique_ptr<FieldAccessExpr>>(call.args[0]->data);
+    EXPECT_EQ(fa.field, "PI");
+    ASSERT_TRUE(fa.qualified_module.has_value());
+    EXPECT_EQ(*fa.qualified_module, "math");
+}
+
+TEST(ParserTest, QualifiedImportChainedQualifiedCallAtStmt) {
+    // CR-review (#1729): statement-side dot fast path used to short-circuit
+    // back to ExprStmt right after the qualified 1-hop call, dropping any
+    // postfix tail. `math.sqrt(2.0).toStr()` at statement position must now
+    // chain through parsePostfixContinuation so the trailing `.toStr()`
+    // wraps the qualified CallExpr as a UFCS first-arg.
+    Program prog = parseStr("import math\nmath.sqrt(2.0).toStr()");
+    ASSERT_EQ(prog.size(), 2u);
+    const auto &es = std::get<ExprStmt>(prog.back());
+    // Outer call is the UFCS hop `.toStr()`, inner first-arg is the
+    // qualified call `math.sqrt(2.0)`.
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(es.expr->data));
+    const auto &outer = *std::get<std::unique_ptr<CallExpr>>(es.expr->data);
+    EXPECT_EQ(outer.callee, "toStr");
+    EXPECT_FALSE(outer.qualified_module.has_value());
+    ASSERT_FALSE(outer.args.empty());
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(outer.args[0]->data));
+    const auto &inner = *std::get<std::unique_ptr<CallExpr>>(outer.args[0]->data);
+    EXPECT_EQ(inner.callee, "sqrt");
+    ASSERT_TRUE(inner.qualified_module.has_value());
+    EXPECT_EQ(*inner.qualified_module, "math");
+}
+
+TEST(ParserTest, QualifiedImportKeywordMemberAtStmt) {
+    // CR-review (#1729): statement-side dot fast path used to require
+    // TokenKind::Ident after `.`, rejecting keyword tokens like `expect`,
+    // `and`, etc. that arrive from the lexer's keyword_map. The expression
+    // side already accepted them via isKeywordAfterDot — the statement
+    // side must now match.
+    //
+    // Use a synthetic stdlib-shaped module that does not exist so codegen
+    // would reject downstream, but parse must succeed and produce the
+    // qualified CallExpr. We import `testing` (a real importable name) and
+    // call its `expect` member, which yields TokenKind::Expect from the
+    // lexer.
+    Program prog = parseStr("import testing\ntesting.expect(1)");
+    ASSERT_EQ(prog.size(), 2u);
+    const auto &es = std::get<ExprStmt>(prog.back());
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(es.expr->data));
+    const auto &call = *std::get<std::unique_ptr<CallExpr>>(es.expr->data);
+    EXPECT_EQ(call.callee, "expect");
+    ASSERT_TRUE(call.qualified_module.has_value());
+    EXPECT_EQ(*call.qualified_module, "testing");
+}
+
 TEST(ParserTest, QualifiedImportDoesNotBreakStructFieldAccess) {
     // AC5: regular struct field access (p.x where p is a value, not a
     // module) still produces FieldAccessExpr with NO qualified_module.

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -984,6 +984,189 @@ TEST(ParserTest, ImportBracedRejectsBadAlias) {
     EXPECT_THROW(parseStr("from math import { add as 123 }"), std::runtime_error);
 }
 
+// ===== qualified import tests (#1723) =====
+
+TEST(ParserTest, QualifiedImportSingleModule) {
+    Program prog = parseStr("import math");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<QualifiedImportStmt>(prog[0]));
+    const auto &qi = std::get<QualifiedImportStmt>(prog[0]);
+    EXPECT_EQ(qi.module_name, "math");
+    EXPECT_FALSE(qi.alias.has_value());
+}
+
+TEST(ParserTest, QualifiedImportDottedPathRejected) {
+    // AC6: 'import a.b' (dot-separated) is rejected with clear error.
+    try {
+        parseStr("import a.b");
+        FAIL() << "Expected parser to reject dotted module path in qualified import";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("dotted module paths"), std::string::npos)
+            << "Error should mention dotted module paths: " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportDuplicateRejected) {
+    // AC7: duplicate 'import math' in same file is a compile error.
+    try {
+        parseStr("import math\nimport math");
+        FAIL() << "Expected parser to reject duplicate qualified import";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("duplicate qualified import"), std::string::npos)
+            << "Error should mention duplicate qualified import: " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportAsNotYetSupported) {
+    // 'import xxx as yyy' is reserved for #1724; reject for now with a
+    // pointer to the tracking issue.
+    try {
+        parseStr("import math as m");
+        FAIL() << "Expected parser to reject 'import ... as ...' (deferred to #1724)";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("#1724"), std::string::npos)
+            << "Error should reference issue #1724: " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportInBlockThrows) {
+    // 'import' is only allowed at top level, mirroring the existing 'from'
+    // block-context rejection.
+    EXPECT_THROW(parseStr("fn f() -> Unit:\n    import math\n    return"),
+                 std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportAsExpectsIdentifierAfterAs) {
+    // Sibling-branch test: when 'as' is present but the next token is not
+    // an identifier, the parser must reject with the dedicated message
+    // BEFORE the "not yet supported" diagnostic fires.
+    try {
+        parseStr("import math as 42");
+        FAIL() << "Expected parser to reject non-identifier after 'as'";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("expected identifier after 'as'"), std::string::npos)
+            << "Error should mention expected identifier after 'as': " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportExpectedModuleName) {
+    try {
+        parseStr("import 42");
+        FAIL() << "Expected parser to reject non-identifier after 'import'";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("expected module name after 'import'"), std::string::npos)
+            << "Error should mention expected module name: " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportCoexistsWithSelectiveImport) {
+    // AC2: 'import math' and 'from math import PI' can coexist in the same
+    // file. The parser must not reject the combination.
+    Program prog = parseStr("import math\nfrom math import PI");
+    ASSERT_EQ(prog.size(), 2u);
+    ASSERT_TRUE(std::holds_alternative<QualifiedImportStmt>(prog[0]));
+    ASSERT_TRUE(std::holds_alternative<ImportStmt>(prog[1]));
+}
+
+TEST(ParserTest, QualifiedImportDotCallProducesQualifiedCallExpr) {
+    // AC1: 'math.sqrt(2.0)' after 'import math' becomes a CallExpr with
+    // qualified_module set and NO prepended receiver (unlike UFCS).
+    Program prog = parseStr("import math\nx = math.sqrt(2.0)");
+    ASSERT_EQ(prog.size(), 2u);
+    const auto &assign = std::get<AssignStmt>(prog[1]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(assign.value->data));
+    const auto &call = *std::get<std::unique_ptr<CallExpr>>(assign.value->data);
+    EXPECT_EQ(call.callee, "sqrt");
+    ASSERT_TRUE(call.qualified_module.has_value());
+    EXPECT_EQ(*call.qualified_module, "math");
+    // Qualified call must NOT prepend the receiver; the only arg is 2.0.
+    ASSERT_EQ(call.args.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<FloatExpr>(call.args[0]->data));
+}
+
+TEST(ParserTest, QualifiedImportDotFieldProducesQualifiedFieldAccess) {
+    // qualified const access: math.PI → FieldAccessExpr with qualified_module
+    Program prog = parseStr("import math\nx = math.PI");
+    ASSERT_EQ(prog.size(), 2u);
+    const auto &assign = std::get<AssignStmt>(prog[1]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(assign.value->data));
+    const auto &fa = *std::get<std::unique_ptr<FieldAccessExpr>>(assign.value->data);
+    EXPECT_EQ(fa.field, "PI");
+    ASSERT_TRUE(fa.qualified_module.has_value());
+    EXPECT_EQ(*fa.qualified_module, "math");
+}
+
+TEST(ParserTest, QualifiedImportDoesNotBreakUFCS) {
+    // AC4: when the LHS is NOT a qualified-imported module name, the dot
+    // still produces UFCS (CallExpr with receiver prepended, NO
+    // qualified_module). 'hello' is a local binding, not an imported module.
+    Program prog = parseStr("import math\nhello = \"x\"\nn = hello.length()");
+    ASSERT_EQ(prog.size(), 3u);
+    const auto &nAssign = std::get<AssignStmt>(prog[2]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(nAssign.value->data));
+    const auto &call = *std::get<std::unique_ptr<CallExpr>>(nAssign.value->data);
+    EXPECT_EQ(call.callee, "length");
+    EXPECT_FALSE(call.qualified_module.has_value());
+    // UFCS prepends the receiver.
+    ASSERT_EQ(call.args.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<VariableExpr>(call.args[0]->data));
+}
+
+TEST(ParserTest, QualifiedImportShadowingByBareAssignRejected) {
+    // 'import math' makes 'math' a module namespace; binding 'math' to a
+    // value would create a confusing namespace conflict, so we reject it
+    // at parse time with a clear diagnostic. (Conservative v0.0.23 behavior
+    // per plan #1723; may be relaxed later.)
+    try {
+        parseStr("import math\nmath = 42");
+        FAIL() << "Expected parser to reject shadowing of imported module";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot shadow imported module 'math'"), std::string::npos)
+            << "Error should mention shadow rejection: " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportShadowingByTypedAssignRejected) {
+    EXPECT_THROW(parseStr("import math\nmath: int = 42"), std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportShadowingByTupleDestructRejected) {
+    // First-position shadowing in tuple destructure.
+    EXPECT_THROW(parseStr("import math\nmath, y = (1, 2)"), std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportShadowingByTupleDestructRestRejected) {
+    // Rest-position shadowing in tuple destructure (mirrors the bare/first
+    // position; both sites must be guarded).
+    EXPECT_THROW(parseStr("import math\nx, math = (1, 2)"), std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportShadowingByCompoundAssignRejected) {
+    EXPECT_THROW(parseStr("import math\nmath += 1"), std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportShadowingByIncrementRejected) {
+    EXPECT_THROW(parseStr("import math\nmath++"), std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportDoesNotBreakStructFieldAccess) {
+    // AC5: regular struct field access (p.x where p is a value, not a
+    // module) still produces FieldAccessExpr with NO qualified_module.
+    Program prog = parseStr(
+        "import math\nrecord Point:\n    x: int\np = Point(3)\nv = p.x");
+    const auto &vAssign = std::get<AssignStmt>(prog.back());
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(vAssign.value->data));
+    const auto &fa = *std::get<std::unique_ptr<FieldAccessExpr>>(vAssign.value->data);
+    EXPECT_EQ(fa.field, "x");
+    EXPECT_FALSE(fa.qualified_module.has_value());
+}
+
 TEST(ParserTest, DuplicateFieldNameThrows) {
     EXPECT_THROW(parseStr("record Point:\n    x: int\n    x: int"), std::runtime_error);
 }

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1155,6 +1155,71 @@ TEST(ParserTest, QualifiedImportShadowingByIncrementRejected) {
     EXPECT_THROW(parseStr("import math\nmath++"), std::runtime_error);
 }
 
+TEST(ParserTest, QualifiedImportShadowingByDecrementRejected) {
+    // Mirror of the increment test — both ++ and -- bind a name locally
+    // and must be guarded the same way.
+    EXPECT_THROW(parseStr("import math\nmath--"), std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportShadowingByForLoopVarRejected) {
+    // 'for math in ...' shadows the imported module inside the loop body,
+    // which then routes 'math.sqrt(...)' to the qualified call rather than
+    // to the loop variable — silently the wrong result. Reject at parse time.
+    try {
+        parseStr("import math\nfor math in [1, 2]:\n    print(math)\n");
+        FAIL() << "Expected parser to reject for-loop binding that shadows imported module";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot shadow imported module 'math'"), std::string::npos)
+            << "Error should mention shadow rejection: " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportShadowingByForLoopTupleElementRejected) {
+    // Rest-position shadowing in for-loop tuple destructure. Both first and
+    // rest positions must be guarded, mirroring the regular tuple-destruct
+    // tests above.
+    EXPECT_THROW(
+        parseStr("import math\nfor i, math in [(1, 2)]:\n    print(math)\n"),
+        std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportShadowingByForLoopTupleFirstRejected) {
+    EXPECT_THROW(
+        parseStr("import math\nfor math, j in [(1, 2)]:\n    print(math)\n"),
+        std::runtime_error);
+}
+
+TEST(ParserTest, QualifiedImportShadowingByFnParamRejected) {
+    // Function parameter named 'math' would silently shadow the import
+    // inside the body but still route 'math.sqrt(...)' to the qualified
+    // call, ignoring the argument. Reject at parse time.
+    try {
+        parseStr("import math\nfn f(math: int) -> int:\n    return math\n");
+        FAIL() << "Expected parser to reject fn parameter that shadows imported module";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot shadow imported module 'math'"), std::string::npos)
+            << "Error should mention shadow rejection: " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportShadowingByLambdaParamRejected) {
+    // Lambda parameter named 'math'. The lambda parser uses the commit-flag
+    // pattern to defer hard errors past the speculative try/catch, so this
+    // throw must surface as a user-visible diagnostic, not get swallowed
+    // and re-emitted as a generic 'expected =' error from the outer stmt
+    // parser.
+    try {
+        parseStr("import math\nf = (math: int) => math + 1\n");
+        FAIL() << "Expected parser to reject lambda parameter that shadows imported module";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot shadow imported module 'math'"), std::string::npos)
+            << "Error should mention shadow rejection: " << msg;
+    }
+}
+
 TEST(ParserTest, QualifiedImportDoesNotBreakStructFieldAccess) {
     // AC5: regular struct field access (p.x where p is a value, not a
     // module) still produces FieldAccessExpr with NO qualified_module.


### PR DESCRIPTION
## Summary

- Adds Python-compatible `import xxx` syntax for binding a module name and reaching its members via `module.fn(...)` / `module.CONST`, complementing the existing `from xxx import ...` selective form.
- Single-identifier modules only in v0.0.23; `as` aliasing follows in #1724. User-defined modules emit a clear redirect to the selective-import form (stdlib modules are fully supported).
- UFCS and struct field access are preserved — the dot is treated as qualified only when the LHS identifier was registered as a module via `import`.

## Acceptance Criteria

- **AC1**: `import math` → `math.sqrt(2.0)` and `math.PI` resolve through the stdlib dispatcher.
- **AC2**: `import math` and `from math import PI` coexist; `math.PI == PI`.
- **AC3**: `from str import contains` + `import list` disambiguate via `contains(...)` (str) and `list.append(xs, ...)` (list).
- **AC4**: UFCS (`s.contains("ell")`) is unaffected.
- **AC5**: Struct field access (`p.x`) on records is unaffected.
- **AC6**: `import a.b` rejected with `module path with '.' not supported`.
- **AC7**: Duplicate `import math` rejected; shadowing (`let math = 42`) rejected; block-level `import` rejected; `import math as <non-id>` and `import math as m` both rejected (`as` not yet implemented — #1724).

## Test plan

- [x] Spec tests: `tests/spec/qualified_import/qualified_import.test.ry` (AC1–AC5)
- [x] Parser unit tests: every new `parseError` branch is directly triggered (`QualifiedImportDottedPathRejected`, `Duplicate...`, `AsNotYetSupported`, `AsExpectsIdentifierAfterAs`, `InBlockThrows`, `ExpectedModuleName`, `ShadowingBy{Bare,Typed}AssignRejected`, `CoexistsWithSelectiveImport`, `DotCallProducesQualifiedCallExpr`, `DotFieldProducesQualifiedFieldAccess`, `DoesNotBreakUFCS`).
- [x] Codegen rejection tests: `ImportTest.QualifiedImportUserDefinedModule{Call,Field}Rejected` cover the v0.0.23 user-defined-module limitation branches.
- [x] Formatter round-trips `QualifiedImportStmt`.
- [x] Tree-sitter grammar parses qualified import; queries highlight the module name.
- [x] Self-verification: 2246/2246 C++ tests + 182 Ry spec files (default + ASan/UBSan + TSan); clang-tidy / cppcheck clean; fuzz_parser 47641 runs / 0 crashes; tree-sitter 135 pass / 47 skip / 0 fail.

Closes #1723.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added qualified import: `import <module>` enabling `module.name` and `module.fn(...)` forms (stdlib modules only; alias/dotted-path/duplicate/top-level constraints apply).

* **Documentation**
  * Updated grammar and module reference with examples, constraints, and guidance for qualified imports.

* **Bug Fixes**
  * Renamed an internal symbol to avoid a runtime/ODR collision on Linux.

* **Tests**
  * Added parser, formatter, and codegen tests covering qualified-import behavior and errors.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1729)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->