### PR TITLE
feat(import): support module alias in qualified import (#1724)

### DIFF
--- a/.claude/skills/commands-environment-gotchas/SKILL.md
+++ b/.claude/skills/commands-environment-gotchas/SKILL.md
@@ -169,6 +169,70 @@ CI (Linux) では `/usr/local/llvm/bin/clang` が `cc` / `c++` symlink を介し
 
 ---
 
+### macOS: SDK ヘッダ更新後の PCH staleness はフルリビルド不要 — `.pch` だけ削除して再ビルド
+
+**Source**: #1724 セルフ検証 (2026-05-14)
+**Tags**: cmake, ninja, pch, macos, sdk-update, sanitizer
+
+**Wrong**: macOS SDK が xcode-select / Xcode 更新で差し替わった後、既存の `build-asan` / `build-tsan` を `cmake --build` すると `fatal error: file '.../MacOSX.sdk/usr/include/AvailabilityVersions.h' has been modified since the precompiled header '.../cmake_pch.hxx.pch' was built: size changed (was 31882, now 32391)` で失敗する。frustration から `rm -rf build-asan && cmake --preset asan && cmake --build build-asan` するのは時間の無駄（数分かかる）。
+
+**Correct**: 該当ビルドツリーの `.pch` だけを削除して再ビルドする (数十秒で完了):
+
+```bash
+find build-asan -name 'cmake_pch.hxx.pch*' -delete
+cmake --build build-asan
+# 同様に build-tsan / build / build-fuzz も SDK 更新後は同じ症状が出る
+find build-tsan -name 'cmake_pch.hxx.pch*' -delete
+cmake --build build-tsan
+```
+
+**Why**: PCH は生成時に SDK ヘッダのファイルサイズ・mtime をスナップショットとして埋め込む。SDK ヘッダが入れ替わるとこのスナップショットと実体が一致しなくなり、PCH 読み込み時に上記の `fatal error` が発生する。CMake / Ninja は SDK ヘッダの変更を依存関係として追跡しない（システムヘッダは通常 `-MD` の出力に含まれない）ため、`.pch` だけが古い状態のまま残る。
+
+`.pch` だけ削除すれば、次の `cmake --build` で PCH が再生成され、それ以降の翻訳単位は新しい PCH を使う。`build-asan/` 全体を消すと configure からやり直しになり、CMake のキャッシュ生成と LLVM ライブラリ依存の検出に数分かかる。`.pch` だけなら数十秒で済む。
+
+上記の Apple clang vs LLVM clang PCH 互換性の entry はコンパイラ違いによる PCH 読み込み拒否の話で、こちらは SDK ヘッダ更新による staleness — 別の症状で別の対処なので両方を区別して記録する。**この対処は SDK 更新が原因の場合のみ有効**：preset / コンパイラ / フラグ変更を伴う場合は `.pch` 削除では不足するので preset の再 configure が必要。
+
+---
+
+### `cmd 2>&1 | tail -N` は ninja の失敗を silently mask する — exit code を別途確保せよ
+
+**Source**: #1724 セルフ検証 (2026-05-14)
+**Tags**: bash, pipefail, ninja, cmake, masked-failure, build-validation
+
+**Wrong**:
+
+```bash
+cmake --build build-asan 2>&1 | tail -10
+# tail が exit 0 を返すため bash の $? は 0
+# 実際は ninja が exit 1 で PCH staleness エラーを出していたのに気付かない
+# 結果: 古いバイナリで ASan テストを実行 → 既に修正したはずのバグが再現する
+```
+
+**Correct**: `set -o pipefail` を有効にするか、`tail` を通さず exit code を直接確認する:
+
+```bash
+# Option A: pipefail を有効化（zsh/bash 両対応）
+set -o pipefail
+cmake --build build-asan 2>&1 | tail -10
+
+# Option B: tail を通さない（推奨 — エラー出力が完全に見える）
+cmake --build build-asan
+
+# Option C: exit code を別変数に保存
+cmake --build build-asan 2>&1 | tail -10
+# ↑ pipefail なしだと $? は 0
+build_status=${PIPESTATUS[0]}  # bash 専用; zsh は $pipestatus[1]
+[[ $build_status -eq 0 ]] || { echo "build failed"; exit 1; }
+```
+
+**Why**: bash / zsh の pipeline はデフォルトで「最後の要素の exit code」を返す。`cmd | tail` の場合、`cmd` が exit 1 でも `tail` は exit 0 で終わるので pipeline 全体は 0 と報告される。`set -o pipefail` を設定するとパイプ内で最初に失敗した要素の exit code が伝播する。
+
+ninja は失敗時に短いエラー要約 (5-10 行) を末尾に出力するため `| tail -10` で見ようとしがちだが、これがまさに罠。`tail` が exit code を握り潰すので、Claude Code の Bash ツールが「成功」と判断してしまい、後続の sanitizer テスト実行が古いバイナリで走り、結果として「テストは pass したが実は古いコードのまま」という silent regression を生む。検出は downstream 症状（spec test が修正前のエラーメッセージを出す等）でしか起きず、デバッグに時間を浪費する。
+
+`run_in_background=true` でビルドを実行する場合も同じ罠が当てはまる: BashOutput の `tail -N` ライクな表示は同様に exit code を見落としがち。Bash ツールの戻り値の `<exit_code>` 行を必ず確認する。
+
+---
+
 ### `printf "%s" "$big_var" | grep -q ...` silently misses matches under `set -o pipefail`
 
 **Source**: #1617 PR review (CodeRabbit, 2026-05-08)

--- a/changelog.d/1724-qualified-import-alias.md
+++ b/changelog.d/1724-qualified-import-alias.md
@@ -1,0 +1,13 @@
+### Added
+
+- Extended qualified import (#1723) with the alias clause:
+  `import <module> as <local>` registers `<local>` as the effective
+  module name, so `import math as m` makes `m.sqrt(2.0)` and `m.PI`
+  work. The alias **replaces** the original name (Python-style): bare
+  `math.sqrt(2.0)` after `import math as m` is no longer routed to the
+  qualified-call path. The alias must be camelCase, and two imports
+  whose effective names collide (e.g. `import math as m` followed by
+  `import path as m`) are a parse error. The original module name is
+  preserved internally so user-defined-module rejection diagnostics
+  still cite the actual file (`from mymod import greet`, not
+  `from m import greet`). (#1724)

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -134,7 +134,7 @@ contains("hello", "ell")       # str module's contains
 | Constraint | Details |
 |---|---|
 | Module form | Single identifier only. `import a.b` is rejected — use `from a.b import ...` instead. |
-| Alias | `import <module> as <local>` is parsed but rejected. Alias support is tracked in [#1724](https://github.com/t0k0sh1/ry/issues/1724). |
+| Alias | `import <module> as <local>` registers `<local>` as the effective module name (Python-style: alias **replaces** the original — bare `<module>` is no longer in scope). The alias must be camelCase. Two imports that resolve to the same effective name (e.g. `import math as m` then `import path as m`) are a parse error. |
 | Module scope | Standard library modules only. Qualified call to a user-defined module produces a diagnostic suggesting `from <module> import ...`. |
 | Duplicate | `import math` followed by `import math` in the same file is a parse error. |
 | Shadowing | After `import math`, declaring `math: int = ...` (or any local named `math`) is a parse error. Rename the local or remove the matching `import` statement. |

--- a/editor/tree-sitter/grammar.js
+++ b/editor/tree-sitter/grammar.js
@@ -120,10 +120,10 @@ export default grammar({
       $._newline,
     ),
 
-    // Qualified import: `import xxx [as yyy]` (#1723).
-    // The `as` alias form is parsed but rejected by the Ry parser pending
-    // #1724; tree-sitter accepts it so the editor surface tolerates the
-    // syntax in flight.
+    // Qualified import: `import xxx [as yyy]` (#1723, #1724).
+    // The `as` alias form registers the alias as the effective name
+    // (Python-style: `import math as m` makes `m.sqrt(...)` valid and
+    // bare `math` undefined). Same-effective-name collisions are rejected.
     qualified_import_statement: $ => seq(
       'import',
       field('module', $.identifier),

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -945,14 +945,22 @@ public:
     // require an explicit import (#715).
     std::unordered_set<std::string> testing_intrinsics_imported_;
 
-    // Modules introduced by `import xxx` (qualified import) at module scope.
-    // Key = module name, value = `is_stdlib` flag propagated from ModuleLoader.
-    // Populated by `emitStmt(QualifiedImportStmt&)`. Consulted by the call /
-    // field-access dispatchers to route `<mod>.fn(...)` (CallExpr with
-    // `qualified_module` set) — stdlib modules reuse the existing dispatch
-    // chain; user-defined modules raise a "not yet supported in v0.0.23"
-    // codegen error (issue #1723, follow-up #1724 / TBD).
-    std::unordered_map<std::string, bool> module_namespaces_;
+    // Modules introduced by `import xxx [as yyy]` (qualified import) at
+    // module scope. Key = effective name in the importing file (alias when
+    // present, else original module name); value carries the original
+    // module name (for diagnostics that need to point at the file the
+    // module came from) plus the `is_stdlib` flag propagated from
+    // ModuleLoader. Populated by `emitStmt(QualifiedImportStmt&)`.
+    // Consulted by the call / field-access dispatchers to route
+    // `<effective>.fn(...)` (CallExpr with `qualified_module` set) —
+    // stdlib modules reuse the existing dispatch chain; user-defined
+    // modules raise a "not yet supported in v0.0.23" codegen error whose
+    // redirect quotes the original module name (issues #1723 / #1724).
+    struct ModuleNamespaceInfo {
+        std::string original_name;
+        bool is_stdlib;
+    };
+    std::unordered_map<std::string, ModuleNamespaceInfo> module_namespaces_;
 
     // User-defined @directive declarations. Keyed by directive name.
     std::unordered_map<std::string, DirectiveSignature> user_directive_registry_;

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -8,25 +8,28 @@ namespace ry {
 // ===== CallExpr Dispatcher =====
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
-    // Qualified call `<mod>.fn(args)` (#1723). The parser sets
-    // `qualified_module` when the dotted LHS is a single identifier that was
-    // imported via `import <mod>` (parser tracks via `imported_modules_`,
-    // codegen via `module_namespaces_`). In v0.0.23 we route stdlib modules
-    // through the normal dispatch chain (StdlibRegistry already routes by
-    // callee name, so `math.sqrt(2.0)` → `emitBuiltinMath` resolves the same
-    // way `sqrt(2.0)` would once `import math` is in scope). User-defined
-    // qualified imports are not yet supported — emit a clear redirect to the
-    // selective-import form.
+    // Qualified call `<effective>.fn(args)` (#1723, #1724). The parser
+    // sets `qualified_module` when the dotted LHS is a single identifier
+    // that was imported via `import <mod>` or `import <mod> as <alias>`
+    // (parser tracks the effective name via `imported_modules_`, codegen
+    // via `module_namespaces_`). In v0.0.23 we route stdlib modules
+    // through the normal dispatch chain (StdlibRegistry already routes
+    // by callee name, so `math.sqrt(2.0)` → `emitBuiltinMath` resolves
+    // the same way `sqrt(2.0)` would once `import math` is in scope).
+    // User-defined qualified imports are not yet supported — emit a
+    // clear redirect to the selective-import form, quoting the file's
+    // original module name even when the user wrote an alias.
     if (e->qualified_module.has_value()) {
         const std::string &mod = *e->qualified_module;
         auto it = module_namespaces_.find(mod);
         if (it == module_namespaces_.end())
             codegenError("qualified call to module '" + mod +
                          "' which was not imported via 'import " + mod + "'");
-        if (!it->second)
+        if (!it->second.is_stdlib)
             codegenError("qualified call to user-defined module '" + mod +
-                         "' is not yet supported in v0.0.23; use 'from " + mod +
-                         " import " + e->callee + "' instead");
+                         "' is not yet supported in v0.0.23; use 'from " +
+                         it->second.original_name + " import " + e->callee +
+                         "' instead");
         // stdlib module → fall through; downstream dispatchers route by callee.
     }
 

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -88,21 +88,24 @@ llvm::Value *CodeGen::emitRecordConstructor(const RecordInfo &info,
 }
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e) {
-    // Qualified field access `<mod>.x` (#1723). Same routing rules as the
-    // qualified-call dispatcher in codegen_call_dispatch.cpp: stdlib modules
-    // resolve through the bare-name lookup (the field was inlined as a
-    // top-level binding by ModuleLoader), user-defined modules error with a
-    // redirect to selective import.
+    // Qualified field access `<effective>.x` (#1723, #1724). Same routing
+    // rules as the qualified-call dispatcher in codegen_call_dispatch.cpp:
+    // stdlib modules resolve through the bare-name lookup (the field was
+    // inlined as a top-level binding by ModuleLoader), user-defined
+    // modules error with a redirect to selective import. The redirect
+    // quotes the original module name from `module_namespaces_` so an
+    // alias does not mislead the user about which file to import from.
     if (e->qualified_module.has_value()) {
         const std::string &mod = *e->qualified_module;
         auto it = module_namespaces_.find(mod);
         if (it == module_namespaces_.end())
             codegenError("qualified access on module '" + mod +
                          "' which was not imported via 'import " + mod + "'");
-        if (!it->second)
+        if (!it->second.is_stdlib)
             codegenError("qualified field access on user-defined module '" + mod +
-                         "' is not yet supported in v0.0.23; use 'from " + mod +
-                         " import " + e->field + "' instead");
+                         "' is not yet supported in v0.0.23; use 'from " +
+                         it->second.original_name + " import " + e->field +
+                         "' instead");
         // stdlib: the inlined top-level definition is reachable by bare name.
         VariableExpr proxy{e->field};
         return emitExprVariant(proxy);

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -841,11 +841,17 @@ void CodeGen::emitStmt(QualifiedImportStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     // ModuleLoader has already loaded the module, inlined its exportable
     // definitions, populated `exports_cache_`, and set `s.is_stdlib`.
-    // Codegen's job here is purely to register the module name so the
-    // call / field-access dispatchers can recognize `<mod>.fn(...)` /
-    // `<mod>.x` qualified forms. No IR is emitted for the statement
-    // itself (mirrors `emitStmt(ImportStmt&)` which is also IR-less).
-    module_namespaces_[s.module_name] = s.is_stdlib;
+    // Codegen's job here is purely to register the module under the
+    // effective name (alias if present, original name otherwise) so the
+    // call / field-access dispatchers can recognize `<effective>.fn(...)`
+    // / `<effective>.x` qualified forms (#1723, #1724). The original
+    // module name is preserved in the value so the user-defined-module
+    // redirect diagnostic can quote the file's actual module name even
+    // when the user wrote `import mymod as m`. No IR is emitted for the
+    // statement itself (mirrors `emitStmt(ImportStmt&)` which is also
+    // IR-less).
+    const std::string &effective = s.alias.has_value() ? *s.alias : s.module_name;
+    module_namespaces_[effective] = ModuleNamespaceInfo{s.module_name, s.is_stdlib};
 }
 
 void CodeGen::emitStmt(IndexAssignStmt &s) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -530,10 +530,12 @@ StmtNode Parser::parseImportStatement() {
 }
 
 StmtNode Parser::parseQualifiedImportStatement() {
-    // Qualified import: `import <ident> [as <ident>]` (#1723)
+    // Qualified import: `import <ident> [as <ident>]` (#1723, #1724)
     // - Only single identifier accepted; `import a.b` rejected (AC6)
-    // - `as` form reserved for #1724; currently rejected
-    // - Duplicate `import <same>` rejected (AC7)
+    // - `as` clause registers the alias as the effective name (Python-style:
+    //   `import math as m` makes `m.sqrt(...)` valid and bare `math` undefined)
+    // - Duplicate effective-name registrations rejected (alias collision or
+    //   same-module duplicate without alias) (AC7)
     Token importTok = lex_.next(); // consume 'import'
 
     Token modTok = lex_.peek();
@@ -548,19 +550,30 @@ StmtNode Parser::parseQualifiedImportStatement() {
 
     std::optional<std::string> alias;
     if (lex_.peek().kind == TokenKind::As) {
-        Token asTok = lex_.next(); // consume 'as'
+        lex_.next(); // consume 'as'
         Token aliasTok = lex_.peek();
         if (aliasTok.kind != TokenKind::Ident)
             parseError(aliasTok.line, "expected identifier after 'as'");
-        parseError(asTok.line,
-            "qualified import alias ('import xxx as yyy') is not yet "
-            "supported (tracked by issue #1724)");
+        if (!isCamelCase(aliasTok.value))
+            parseError(aliasTok.line,
+                "qualified import alias name '" + aliasTok.value +
+                "' must be camelCase");
+        alias = aliasTok.value;
+        lex_.next(); // consume alias identifier
     }
 
-    if (!imported_modules_.insert(moduleName).second)
-        parseError(importTok.line,
-            "duplicate qualified import: 'import " + moduleName +
-            "' was already imported in this file");
+    const std::string &effective = alias.has_value() ? *alias : moduleName;
+    if (!imported_modules_.insert(effective).second) {
+        if (alias.has_value())
+            parseError(importTok.line,
+                "duplicate qualified import: name '" + effective +
+                "' is already imported in this file (alias collision or "
+                "same-module duplicate)");
+        else
+            parseError(importTok.line,
+                "duplicate qualified import: 'import " + effective +
+                "' was already imported in this file");
+    }
 
     return QualifiedImportStmt{
         std::move(moduleName),

--- a/tests/spec/qualified_import/qualified_import_alias.test.ry
+++ b/tests/spec/qualified_import/qualified_import_alias.test.ry
@@ -1,0 +1,21 @@
+from testing import it, describe, expect
+
+import math as m
+from math import PI
+
+@describe("qualified import alias (#1724)")
+fn qualifiedImportAliasTests():
+  @it("alias-side qualified call dispatches to the original module")
+  fn shouldAliasedCallResolveToStdlib():
+    expect(m.sqrt(2.0)).toBeCloseTo(1.4142135623730951, 10)
+    expect(m.sqrt(4.0)).toEq(2.0)
+
+  @it("alias-side qualified const access reaches the original module's constant")
+  fn shouldAliasedConstResolveToStdlib():
+    expect(m.PI).toBeCloseTo(3.141592653589793, 10)
+    expect(m.PI).toEq(PI)
+
+  @it("alias coexists with selective import of the original module")
+  fn shouldAliasCoexistWithSelectiveImport():
+    expect(m.sqrt(PI)).toBeCloseTo(1.7724538509055159, 10)
+    expect(m.sqrt(9.0)).toEq(3.0)

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1830,6 +1830,59 @@ TEST_F(ImportTest, QualifiedImportUserDefinedModuleFieldRejected) {
     }
 }
 
+// Qualified import alias — user-defined module rejection error must quote the
+// ORIGINAL module name (the actual file basename), not the alias (#1724).
+// Without `ModuleNamespaceInfo::original_name` tracking the redirect text
+// would suggest `from m import greet`, which doesn't resolve because the file
+// is `mymod.ry`.
+TEST_F(ImportTest, QualifiedImportAliasUserDefinedModuleErrorUsesOriginalName) {
+    writeFile("mymod_alias_call.ry",
+        "fn greet() -> int:\n"
+        "    return 7\n");
+    try {
+        runWithImports(
+            "import mymod_alias_call as m\n"
+            "print(m.greet())\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("qualified call to user-defined module 'm'"),
+                  std::string::npos)
+            << "got: " << msg;
+        // The redirect must point at the original module name, not the alias.
+        EXPECT_NE(msg.find("from mymod_alias_call import greet"),
+                  std::string::npos)
+            << "redirect must use original module name, not alias: " << msg;
+        EXPECT_EQ(msg.find("from m import greet"), std::string::npos)
+            << "redirect must NOT use the alias as the module name: " << msg;
+    }
+}
+
+// Qualified import alias — field-access redirect mirrors the call-site fix.
+TEST_F(ImportTest, QualifiedImportAliasUserDefinedFieldErrorUsesOriginalName) {
+    writeFile("mymod_alias_field.ry",
+        "@directive(target=[\"statement\"])\n"
+        "fn const()\n"
+        "@const\n"
+        "ANSWER: int = 42\n");
+    try {
+        runWithImports(
+            "import mymod_alias_field as m\n"
+            "print(m.ANSWER)\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("qualified field access on user-defined module 'm'"),
+                  std::string::npos)
+            << "got: " << msg;
+        EXPECT_NE(msg.find("from mymod_alias_field import ANSWER"),
+                  std::string::npos)
+            << "redirect must use original module name, not alias: " << msg;
+        EXPECT_EQ(msg.find("from m import ANSWER"), std::string::npos)
+            << "redirect must NOT use the alias as the module name: " << msg;
+    }
+}
+
 // Qualified import — user-defined module must NOT leak bare names into caller (#1723, CR review).
 // Triggers the module_loader.cpp branch that routes user-defined defs to a throwaway
 // Program (instead of inlining them into the caller) so `import usermod\ngreet()`

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -94,6 +94,14 @@ TEST(Formatter, StatementFormatting) {
     // Qualified const access via `import xxx`.
     EXPECT_EQ(fmt("import math\nx = math.PI\n"),
               "import math\nx = math.PI\n");
+    // Qualified import alias (#1724): `import math as m` round-trips verbatim.
+    EXPECT_EQ(fmt("import math as m\n"), "import math as m\n");
+    // Alias propagates through qualified call sites.
+    EXPECT_EQ(fmt("import math as m\nx = m.sqrt(2.0)\n"),
+              "import math as m\nx = m.sqrt(2.0)\n");
+    // Alias propagates through qualified const access.
+    EXPECT_EQ(fmt("import math as m\nx = m.PI\n"),
+              "import math as m\nx = m.PI\n");
     // Return
     {
         auto src = "fn f() -> int:\n    return 42\n";

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -1009,6 +1009,9 @@ TEST(ParserTest, QualifiedImportDottedPathRejected) {
 
 TEST(ParserTest, QualifiedImportDuplicateRejected) {
     // AC7: duplicate 'import math' in same file is a compile error.
+    // The same-module-duplicate branch and the alias-collision branch
+    // emit deliberately distinct wordings; assert this case takes the
+    // non-alias branch so a future refactor that collapses them is caught.
     try {
         parseStr("import math\nimport math");
         FAIL() << "Expected parser to reject duplicate qualified import";
@@ -1016,20 +1019,121 @@ TEST(ParserTest, QualifiedImportDuplicateRejected) {
         std::string msg = e.what();
         EXPECT_NE(msg.find("duplicate qualified import"), std::string::npos)
             << "Error should mention duplicate qualified import: " << msg;
+        EXPECT_NE(msg.find("'import math'"), std::string::npos)
+            << "Same-module branch should quote the full 'import <mod>' form: " << msg;
+        EXPECT_EQ(msg.find("alias collision"), std::string::npos)
+            << "Same-module branch must not use alias-collision wording: " << msg;
     }
 }
 
-TEST(ParserTest, QualifiedImportAsNotYetSupported) {
-    // 'import xxx as yyy' is reserved for #1724; reject for now with a
-    // pointer to the tracking issue.
+TEST(ParserTest, QualifiedImportAsRegistersAlias) {
+    // #1724: 'import math as m' parses successfully and stores the alias on
+    // the QualifiedImportStmt while preserving the original module name. This
+    // is the positive sibling of the (formerly rejecting) test that locked
+    // in the pre-#1724 spec — flipped per
+    // .claude/rules/tests-rejection-tdd.md "Relaxing a rejection branch
+    // requires flipping (not deleting) existing EXPECT_THROW tests".
+    Program prog = parseStr("import math as m");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<QualifiedImportStmt>(prog[0]));
+    const auto &qi = std::get<QualifiedImportStmt>(prog[0]);
+    EXPECT_EQ(qi.module_name, "math");
+    ASSERT_TRUE(qi.alias.has_value());
+    EXPECT_EQ(*qi.alias, "m");
+}
+
+TEST(ParserTest, QualifiedImportAliasOnlyRegistersAliasNotOriginal) {
+    // Python-style semantic: `import math as m` makes `m` (and only `m`) a
+    // qualified-import handle. Bare `math.sqrt(2.0)` after the alias must
+    // fall through to UFCS dispatch (CallExpr with receiver prepended,
+    // qualified_module unset) — the qualified-call path requires
+    // `imported_modules_.count(name) > 0`, which only the alias satisfies.
+    Program prog = parseStr("import math as m\nx = math.sqrt(2.0)\n");
+    ASSERT_EQ(prog.size(), 2u);
+    const auto &assign = std::get<AssignStmt>(prog[1]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(assign.value->data));
+    const auto &call = *std::get<std::unique_ptr<CallExpr>>(assign.value->data);
+    EXPECT_EQ(call.callee, "sqrt");
+    EXPECT_FALSE(call.qualified_module.has_value());
+    // UFCS prepends the receiver, so the call has 2 args (math, 2.0).
+    ASSERT_EQ(call.args.size(), 2u);
+    ASSERT_TRUE(std::holds_alternative<VariableExpr>(call.args[0]->data));
+    EXPECT_EQ(std::get<VariableExpr>(call.args[0]->data).name, "math");
+}
+
+TEST(ParserTest, QualifiedImportAliasCollisionRejected) {
+    // Two distinct modules aliased to the same effective name must collide
+    // at parse time, even though they originate from different module names.
+    // The wording is intentionally distinct from the same-module-duplicate
+    // branch (see QualifiedImportDuplicateRejected) so the two cases stay
+    // separable across future refactors.
     try {
-        parseStr("import math as m");
-        FAIL() << "Expected parser to reject 'import ... as ...' (deferred to #1724)";
+        parseStr("import math as m\nimport path as m");
+        FAIL() << "Expected parser to reject duplicate alias 'm'";
     } catch (const std::runtime_error &e) {
         std::string msg = e.what();
-        EXPECT_NE(msg.find("#1724"), std::string::npos)
-            << "Error should reference issue #1724: " << msg;
+        EXPECT_NE(msg.find("duplicate qualified import"), std::string::npos)
+            << "Error should mention duplicate qualified import: " << msg;
+        EXPECT_NE(msg.find("name 'm'"), std::string::npos)
+            << "Alias branch should quote the colliding effective name as `name 'm'`: " << msg;
+        EXPECT_NE(msg.find("alias collision"), std::string::npos)
+            << "Alias branch should mention 'alias collision' to differentiate from the same-module case: " << msg;
     }
+}
+
+TEST(ParserTest, QualifiedImportSelfAliasIsAccepted) {
+    // Degenerate `import math as math` is accepted and behaves identically
+    // to bare `import math` — the effective name is 'math' in both cases.
+    Program prog = parseStr("import math as math");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &qi = std::get<QualifiedImportStmt>(prog[0]);
+    EXPECT_EQ(qi.module_name, "math");
+    ASSERT_TRUE(qi.alias.has_value());
+    EXPECT_EQ(*qi.alias, "math");
+}
+
+TEST(ParserTest, QualifiedImportAliasRejectsSnakeCase) {
+    // Per .claude/rules/parser-conventions.md "Module-global typed-decl ...
+    // enforces camelCase", every binding site rejects snake_case.
+    try {
+        parseStr("import math as my_alias");
+        FAIL() << "Expected parser to reject snake_case alias name";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("'my_alias'"), std::string::npos)
+            << "Error should quote the rejected alias name: " << msg;
+        EXPECT_NE(msg.find("camelCase"), std::string::npos)
+            << "Error should mention camelCase requirement: " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportAliasShadowingRejected) {
+    // The shadow-check at parser.cpp consults `imported_modules_`, which
+    // (post-#1724) is keyed by the alias when present. Binding the alias as
+    // a local must trigger the same diagnostic as bare-import shadowing.
+    try {
+        parseStr("import math as m\nm: int = 1\n");
+        FAIL() << "Expected parser to reject local binding that shadows alias";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot shadow imported module 'm'"), std::string::npos)
+            << "Error should mention shadow rejection of alias 'm': " << msg;
+    }
+}
+
+TEST(ParserTest, QualifiedImportAliasFieldAccessRouting) {
+    // After `import math as m`, the postfix parser must recognize `m.PI`
+    // as a qualified field access (qualified_module == "m"), not as UFCS
+    // on a local `m`. The alias must propagate through the
+    // `imported_modules_.count(ve->name)` gate in src/parser_expr.cpp.
+    Program prog = parseStr("import math as m\nx = m.PI");
+    ASSERT_EQ(prog.size(), 2u);
+    const auto &assign = std::get<AssignStmt>(prog[1]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<FieldAccessExpr>>(assign.value->data));
+    const auto &fa = *std::get<std::unique_ptr<FieldAccessExpr>>(assign.value->data);
+    EXPECT_EQ(fa.field, "PI");
+    ASSERT_TRUE(fa.qualified_module.has_value());
+    EXPECT_EQ(*fa.qualified_module, "m");
 }
 
 TEST(ParserTest, QualifiedImportInBlockThrows) {


### PR DESCRIPTION
## Summary

Closes #1724. Extends the qualified import syntax (`import xxx`) introduced by #1723 with an optional alias clause (`import xxx as yyy`), mirroring Python semantics where the alias **replaces** (not augments) the original module name.

- Parser: accepts `as <alias>`, validates camelCase on the alias name, and registers the **effective name** (alias if present, else module name) into `imported_modules_`. Same-alias collision (`import math as m; import path as m`) and same-module duplicate (`import math; import math`) emit deliberately distinct wordings so the two branches stay separable.
- Codegen: `module_namespaces_` becomes `unordered_map<string, ModuleNamespaceInfo>` keyed by the **effective name**, with the value tracking the **original module name**. The "use `from <mod> import <name>` instead" redirect for user-defined modules quotes the original name, so `import mymod as m; m.greet()` reports `from mymod import greet` (not `from m import greet`).
- Tree-sitter grammar already accepted the `as` form; only the comment was updated.
- Formatter already emitted `as <alias>` from #1723 — added roundtrip tests.

## Test plan

- [x] `./build/ry_tests` — full C++ suite, 2267 PASSED including 8 new `QualifiedImport*Alias*` parser tests, 2 new alias error codegen tests, and 3 formatter roundtrip tests.
- [x] `./build/ry test -p` — Ry self-test, 183 files / 0 failures including new `tests/spec/qualified_import/qualified_import_alias.test.ry`.
- [x] ASan + UBSan on both `ry_tests` and `ry test -p` — clean.
- [x] TSan on both `ry_tests` and `ry test -p` — clean (no new races).
- [x] cppcheck + clang-tidy — exit 0, no warnings.
- [x] tree-sitter `check.sh` — pass=136 / skip=47 / warn=0 / fail=0.
- [x] libFuzzer `fuzz_parser` — 49654 runs in 61s, exit 0, no new regressions in `tests/fuzz/regressions/parser/`.
- [x] Smoke tests:
  - `printf 'import math as m\nprint(m.sqrt(4.0))\n' | ./build/ry -c -` → `2.0`
  - `printf 'import math as m\nprint(math.sqrt(4.0))\n' | ./build/ry -c -` → undefined-symbol diagnostic
  - `printf 'import math as m\nimport path as m\n' | ./build/ry -c -` → alias-collision diagnostic

## Out of scope

- Multi-segment alias paths (`import a.b as c`) — `import a.b` is already rejected by #1723.
- `from <mod> import <name> as <alias>` — already implemented by #1721.
- Runtime aliasing semantics beyond the frontend; the loader resolves the original module name unchanged.

## Knowledge captured

- `.claude/skills/commands-environment-gotchas/SKILL.md` — added two entries from this PR's self-validation: macOS SDK PCH staleness (the `.pch`-only deletion workaround) and the `cmd | tail -N` ninja-failure masking trap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Qualified imports now support aliases (e.g., `import math as m`). Aliases must use camelCase and duplicate effective names are rejected as errors.

* **Documentation**
  * Updated reference documentation and changelog to document qualified import alias syntax, constraints, and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1732)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->