### PR TITLE
feat(import): support fn/record/enum/type-alias symbol alias (#1725)

### DIFF
--- a/changelog.d/1725-import-symbol-alias-followup.md
+++ b/changelog.d/1725-import-symbol-alias-followup.md
@@ -1,0 +1,14 @@
+### Added
+
+- Extended `from m import foo as bar` symbol alias to `fn`, `record`,
+  `enum`, and `type alias` kinds. The module loader now generates an
+  `ImportAliasStmt` AST node per non-`@const` alias, and codegen
+  registers the alias under the existing function / record / enum /
+  type-alias tables so every call site, type annotation, constructor,
+  enum variant access, and ADT pattern match resolves transparently
+  through the alias name (#1725).
+
+- Generic-fn and generic-enum aliases are explicitly rejected at codegen
+  with a "not yet supported" diagnostic; aliases for non-`@const`
+  mutable globals and `@directive` definitions remain rejected by the
+  module loader (#1725).

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -56,11 +56,12 @@ from math import sqrt as sr, PI, sin as s
 Self-alias (`foo as foo`) is normalized to a plain import — the formatter
 will round-trip it as `from math import foo`.
 
-**Limitation (v0.0.23)**: only `@const` aliases work end-to-end. Aliases
-for functions, records, enums, and type aliases are accepted by the
-parser but rejected by the module loader with a diagnostic pointing at
-follow-up issue [#1725](https://github.com/t0k0sh1/ry/issues/1725). Full
-alias support for those kinds is tracked there.
+Aliases work end-to-end for `@const` values, functions, records, enums,
+and type aliases. Aliases for mutable global values (non-`@const`
+assignments) and `@directive` definitions remain unsupported — mutable
+globals and directives cannot be re-bound via `as`. Aliases for generic
+functions and generic enums are also rejected today; non-generic forms
+work as expected.
 
 ### Braced Selective Import
 

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -279,6 +279,16 @@ struct QualifiedImportStmt {
     SourceLocation loc;
 };
 
+// Synthesized by ModuleLoader::makeAliasBinding for `from m import foo as bar` (#1725 — fn/record/enum/typealias kinds).
+// Const aliases stay on AssignStmt; Value/Directive aliases remain rejected upstream.
+struct ImportAliasStmt {
+    enum class Kind { Fn, Record, Enum, TypeAlias };
+    std::string alias_name;
+    std::string original_name;
+    Kind kind;
+    SourceLocation loc;
+};
+
 struct IndexAssignStmt {
     ExprPtr object;
     std::vector<ExprPtr> indices;
@@ -353,7 +363,7 @@ struct DirectiveDefStmt {
 };
 
 using StmtNode = std::variant<AssignStmt, CallStmt, ExprStmt,
-                              ReturnStmt, ImportStmt, QualifiedImportStmt, RecordStmt,
+                              ReturnStmt, ImportStmt, QualifiedImportStmt, ImportAliasStmt, RecordStmt,
                               IndexAssignStmt, BreakStmt, ContinueStmt, EllipsisStmt,
                               FieldAssignStmt, EnumStmt, ExpectStmt, AwaitStmt,
                               TupleDestructStmt, TypeAliasStmt,

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -553,6 +553,11 @@ public:
         std::unique_ptr<std::unordered_map<size_t, FnTypeInfo>> capturedClosureInfos;
     };
     std::unordered_map<std::string, std::vector<OverloadEntry>> functions_;
+    // Import aliases (`from m import f as g`) — alias name → original name.
+    // Used by `findFunction` to forward to `functions_[orig]` so OverloadEntry
+    // (which is non-copyable due to `unique_ptr<...> capturedClosureInfos`) does
+    // not have to be duplicated. Populated by emitStmt(ImportAliasStmt&).
+    std::unordered_map<std::string, std::string> fn_aliases_;
     std::unordered_set<llvm::Function*> forward_declared_fns_;
     // Lexical scope stack for nested named functions (parallel to scope_stack_)
     std::vector<std::unordered_map<std::string, std::vector<OverloadEntry>>> fn_scope_stack_;
@@ -582,6 +587,16 @@ public:
         }
     };
     std::unordered_map<std::string, RecordInfo> record_types_;
+    // Import aliases (`from m import R as P`) — alias → original. Used by the
+    // `findRecordType` helper so non-copyable `RecordInfo` (its `fields` /
+    // `invariants` hold `unique_ptr<TypeNode>` / `unique_ptr<ExprNode>`) does
+    // not need duplication. Populated by emitStmt(ImportAliasStmt&).
+    std::unordered_map<std::string, std::string> record_aliases_;
+    // Look up a record by user-visible name, walking `record_aliases_` so
+    // import aliases resolve to the original `record_types_` entry. Mirrors
+    // `findFunction` for fn aliases. Returns nullptr on miss.
+    RecordInfo *findRecordType(const std::string &name);
+    const RecordInfo *findRecordType(const std::string &name) const;
 
     // Type ID registry for typeOf builtin.
     // Each distinct type definition gets a unique id, allowing identity-based
@@ -630,6 +645,13 @@ public:
         int64_t type_id = -1;   // unique identity for typeOf
     };
     std::unordered_map<std::string, EnumInfo> enum_types_;
+    // Import aliases (`from m import E as C`) — alias → original. Mirrors
+    // `record_aliases_` / `fn_aliases_`. EnumInfo is technically copyable today
+    // but routing through this map keeps the alias mechanism uniform across
+    // kinds and avoids per-kind divergence as EnumInfo grows.
+    std::unordered_map<std::string, std::string> enum_aliases_;
+    EnumInfo *findEnumType(const std::string &name);
+    const EnumInfo *findEnumType(const std::string &name) const;
     EnumVariantRegistry buildEnumVariantRegistry() const;
     std::string findAdtEnumName(llvm::StructType *st) const;
     std::string findRecordTypeName(llvm::StructType *st) const;
@@ -1224,6 +1246,7 @@ public:
     void emitStmt(ReturnStmt &s);
     void emitStmt(ImportStmt &s);
     void emitStmt(QualifiedImportStmt &s);
+    void emitStmt(ImportAliasStmt &s);
     void emitStmt(RecordStmt &s);
     void emitStmt(TypeAliasStmt &s);
     void emitStmt(IndexAssignStmt &s);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -515,6 +515,73 @@ std::vector<CodeGen::OverloadEntry> *CodeGen::findFunction(const std::string &na
     auto fit = functions_.find(name);
     if (fit != functions_.end())
         return &fit->second;
+    // Import alias fallback: `from m import f as g` registers `g → f` in
+    // `fn_aliases_`. Walk the chain (depth-limited) to support aliased
+    // re-exports without copying non-copyable `OverloadEntry`.
+    std::string cur = name;
+    for (int depth = 0; depth < 64; ++depth) {
+        auto ait = fn_aliases_.find(cur);
+        if (ait == fn_aliases_.end()) break;
+        cur = ait->second;
+        auto rit = functions_.find(cur);
+        if (rit != functions_.end()) return &rit->second;
+    }
+    return nullptr;
+}
+
+CodeGen::RecordInfo *CodeGen::findRecordType(const std::string &name) {
+    auto it = record_types_.find(name);
+    if (it != record_types_.end()) return &it->second;
+    std::string cur = name;
+    for (int depth = 0; depth < 64; ++depth) {
+        auto ait = record_aliases_.find(cur);
+        if (ait == record_aliases_.end()) break;
+        cur = ait->second;
+        auto rit = record_types_.find(cur);
+        if (rit != record_types_.end()) return &rit->second;
+    }
+    return nullptr;
+}
+
+const CodeGen::RecordInfo *CodeGen::findRecordType(const std::string &name) const {
+    auto it = record_types_.find(name);
+    if (it != record_types_.end()) return &it->second;
+    std::string cur = name;
+    for (int depth = 0; depth < 64; ++depth) {
+        auto ait = record_aliases_.find(cur);
+        if (ait == record_aliases_.end()) break;
+        cur = ait->second;
+        auto rit = record_types_.find(cur);
+        if (rit != record_types_.end()) return &rit->second;
+    }
+    return nullptr;
+}
+
+CodeGen::EnumInfo *CodeGen::findEnumType(const std::string &name) {
+    auto it = enum_types_.find(name);
+    if (it != enum_types_.end()) return &it->second;
+    std::string cur = name;
+    for (int depth = 0; depth < 64; ++depth) {
+        auto ait = enum_aliases_.find(cur);
+        if (ait == enum_aliases_.end()) break;
+        cur = ait->second;
+        auto rit = enum_types_.find(cur);
+        if (rit != enum_types_.end()) return &rit->second;
+    }
+    return nullptr;
+}
+
+const CodeGen::EnumInfo *CodeGen::findEnumType(const std::string &name) const {
+    auto it = enum_types_.find(name);
+    if (it != enum_types_.end()) return &it->second;
+    std::string cur = name;
+    for (int depth = 0; depth < 64; ++depth) {
+        auto ait = enum_aliases_.find(cur);
+        if (ait == enum_aliases_.end()) break;
+        cur = ait->second;
+        auto rit = enum_types_.find(cur);
+        if (rit != enum_types_.end()) return &rit->second;
+    }
     return nullptr;
 }
 

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -41,9 +41,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
             std::string variantName = e->callee.substr(colonPos + 2);
             // Try to instantiate generic enum if not found
             ensureEnumInstantiated(enumName);
-            auto eit = enum_types_.find(enumName);
-            if (eit != enum_types_.end() && eit->second.isADT) {
-                auto &info = eit->second;
+            if (auto *einfoPtr = findEnumType(enumName); einfoPtr && einfoPtr->isADT) {
+                auto &info = *einfoPtr;
                 auto vit = info.variants.find(variantName);
                 if (vit == info.variants.end())
                     codegenError("unknown variant '" + variantName + "' in enum '" + enumName + "'");
@@ -124,11 +123,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
     }
 
     // Struct constructor
-    auto sit = record_types_.find(e->callee);
-    if (sit != record_types_.end()) {
+    if (auto *ri = findRecordType(e->callee)) {
         if (deprecated_types_.count(e->callee))
             emitDeprecationWarning(e->callee);
-        return emitRecordConstructor(sit->second, e->callee, e->args);
+        return emitRecordConstructor(*ri, e->callee, e->args);
     }
 
     // Try indirect call via variable (function pointer / lambda)

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -891,9 +891,8 @@ void CodeGen::emitStmt(CallStmt &s) {
         it->second(s.args, s.named_args);
         return;
     }
-    auto sit = record_types_.find(s.callee);
-    if (sit != record_types_.end()) {
-        emitRecordConstructor(sit->second, s.callee, s.args);
+    if (auto *ri = findRecordType(s.callee)) {
+        emitRecordConstructor(*ri, s.callee, s.args);
         return;
     }
     // Intercept collection operations and route through CallExpr emitter

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -637,22 +637,22 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<SetExpr> &e) {
 llvm::Value *CodeGen::emitExprVariant(const EnumAccessExpr &e) {
     // Try to instantiate generic enum if not found
     ensureEnumInstantiated(e.enum_name);
-    auto it = enum_types_.find(e.enum_name);
-    if (it == enum_types_.end())
+    auto *info = findEnumType(e.enum_name);
+    if (!info)
         codegenError("undefined enum: " + e.enum_name);
-    auto vit = it->second.variants.find(e.variant_name);
-    if (vit == it->second.variants.end())
+    auto vit = info->variants.find(e.variant_name);
+    if (vit == info->variants.end())
         codegenError("enum '" + e.enum_name + "' has no variant '" + e.variant_name + "'");
 
-    if (it->second.isADT) {
+    if (info->isADT) {
         // Reject access to payload-carrying variants without arguments
-        auto fit = it->second.variantFields.find(e.variant_name);
-        if (fit != it->second.variantFields.end() && !fit->second.fieldTypes.empty())
+        auto fit = info->variantFields.find(e.variant_name);
+        if (fit != info->variantFields.end() && !fit->second.fieldTypes.empty())
             codegenError("variant '" + e.enum_name + "::" + e.variant_name +
                 "' requires " + std::to_string(fit->second.fieldTypes.size()) +
                 " argument(s); use '" + e.enum_name + "::" + e.variant_name + "(...)' instead");
         // ADT enum: create struct { tag, zero-payload } for data-less variants
-        llvm::Value *adtVal = llvm::UndefValue::get(it->second.adtType);
+        llvm::Value *adtVal = llvm::UndefValue::get(info->adtType);
         adtVal = builder_.CreateInsertValue(adtVal, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(vit->second)), 0, "adt.tag");
         getOrCreateMeta(adtVal).enum_value_type = e.enum_name;
         return adtVal;

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -163,13 +163,13 @@ void CodeGen::checkMatchExhaustiveness(
         }
     }
     if (!enumName.empty()) {
-        if (!enum_types_.count(enumName) && !subjectEnumName.empty()) {
+        if (!findEnumType(enumName) && !subjectEnumName.empty()) {
             auto ltPos = subjectEnumName.find('<');
             if (ltPos != std::string::npos && subjectEnumName.substr(0, ltPos) == enumName)
                 enumName = subjectEnumName;
         }
-        auto it = enum_types_.find(enumName);
-        if (it != enum_types_.end()) {
+        if (auto *einfoPtr = findEnumType(enumName)) {
+            auto &info = *einfoPtr;
             std::unordered_set<std::string> covered;
             for (auto &[pat, hasGuard] : armPatterns) {
                 if (!hasGuard) {
@@ -187,7 +187,7 @@ void CodeGen::checkMatchExhaustiveness(
                     }
                 }
             }
-            for (auto &[vname, _] : it->second.variants) {
+            for (auto &[vname, _] : info.variants) {
                 if (!covered.count(vname)) {
                     std::string exhaustMsg = "non-exhaustive match: missing variant '";
                     exhaustMsg += enumName;
@@ -289,20 +289,20 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
             testResult = llvm::ConstantInt::get(i1Ty_, 1);
         } else if constexpr (std::is_same_v<T, EnumPattern>) {
             std::string resolvedEnum = pat.enum_name;
-            auto enumIt = enum_types_.find(resolvedEnum);
-            if (enumIt == enum_types_.end() && !subjectEnumName.empty()) {
+            auto *enumInfo = findEnumType(resolvedEnum);
+            if (!enumInfo && !subjectEnumName.empty()) {
                 auto ltPos = subjectEnumName.find('<');
                 if (ltPos != std::string::npos && subjectEnumName.substr(0, ltPos) == pat.enum_name) {
                     resolvedEnum = subjectEnumName;
-                    enumIt = enum_types_.find(resolvedEnum);
+                    enumInfo = findEnumType(resolvedEnum);
                 }
             }
-            if (enumIt == enum_types_.end())
+            if (!enumInfo)
                 codegenError("match: unknown enum '" + pat.enum_name + "'");
-            auto varIt = enumIt->second.variants.find(pat.variant_name);
-            if (varIt == enumIt->second.variants.end())
+            auto varIt = enumInfo->variants.find(pat.variant_name);
+            if (varIt == enumInfo->variants.end())
                 codegenError("match: unknown variant '" + pat.enum_name + "::" + pat.variant_name + "'");
-            if (enumIt->second.isADT) {
+            if (enumInfo->isADT) {
                 llvm::Value *subjectTag = builder_.CreateExtractValue(subjectVal, 0, "adt.tag");
                 testResult = builder_.CreateICmpEQ(subjectTag, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(varIt->second)), "match.adt_eq");
             } else {
@@ -311,25 +311,25 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>) {
             std::string resolvedEnum = pat->enum_name;
-            auto enumIt = enum_types_.find(resolvedEnum);
-            if (enumIt == enum_types_.end() && !subjectEnumName.empty()) {
+            auto *enumInfo = findEnumType(resolvedEnum);
+            if (!enumInfo && !subjectEnumName.empty()) {
                 auto ltPos = subjectEnumName.find('<');
                 if (ltPos != std::string::npos && subjectEnumName.substr(0, ltPos) == pat->enum_name) {
                     resolvedEnum = subjectEnumName;
-                    enumIt = enum_types_.find(resolvedEnum);
+                    enumInfo = findEnumType(resolvedEnum);
                 }
             }
-            if (enumIt == enum_types_.end())
+            if (!enumInfo)
                 codegenError("match: unknown enum '" + pat->enum_name + "'");
-            if (!enumIt->second.isADT)
+            if (!enumInfo->isADT)
                 codegenError("match: constructor pattern requires ADT enum, but '" + pat->enum_name + "' is not ADT");
-            auto varIt = enumIt->second.variants.find(pat->variant_name);
-            if (varIt == enumIt->second.variants.end())
+            auto varIt = enumInfo->variants.find(pat->variant_name);
+            if (varIt == enumInfo->variants.end())
                 codegenError("match: unknown variant '" + pat->enum_name + "::" + pat->variant_name + "'");
             llvm::Value *subjectTag = builder_.CreateExtractValue(subjectVal, 0, "adt.tag");
             testResult = builder_.CreateICmpEQ(subjectTag, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(varIt->second)), "match.adt_eq");
-            auto fit = enumIt->second.variantFields.find(pat->variant_name);
-            if (fit != enumIt->second.variantFields.end() && !pat->bindings.empty()) {
+            auto fit = enumInfo->variantFields.find(pat->variant_name);
+            if (fit != enumInfo->variantFields.end() && !pat->bindings.empty()) {
                 const std::vector<Pattern> *fieldPats =
                     unwrapEnumPayloadTuple(pat->bindings, fit->second.fieldTypes.size());
                 // Branch on tag match so payload loads only run when the tag is correct.
@@ -345,7 +345,7 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
                 llvm::AllocaInst *tmpAlloca = builder_.CreateAlloca(subjectTy, nullptr, "ecp.test.tmp");
                 builder_.CreateStore(subjectVal, tmpAlloca);
                 llvm::Value *payloadPtr = builder_.CreateStructGEP(
-                    enumIt->second.adtType, tmpAlloca, 1, "ecp.test.payload");
+                    enumInfo->adtType, tmpAlloca, 1, "ecp.test.payload");
                 const llvm::DataLayout &dl = mod_->getDataLayout();
                 size_t offset = 0;
                 llvm::Value *fieldsMatch = llvm::ConstantInt::get(i1Ty_, 1);
@@ -669,23 +669,22 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<EnumConstructorPattern>>) {
             std::string resolvedEnum = pat->enum_name;
-            if (!enum_types_.count(resolvedEnum) && !subjectEnumName.empty()) {
+            if (!findEnumType(resolvedEnum) && !subjectEnumName.empty()) {
                 auto ltPos = subjectEnumName.find('<');
                 if (ltPos != std::string::npos && subjectEnumName.substr(0, ltPos) == pat->enum_name)
                     resolvedEnum = subjectEnumName;
             }
             // emitPatternTest already validated the enum; skip silently if lookup fails here.
-            auto enumIt = enum_types_.find(resolvedEnum);
-            if (enumIt != enum_types_.end()) {
-                auto fit = enumIt->second.variantFields.find(pat->variant_name);
-                if (fit != enumIt->second.variantFields.end()) {
+            if (auto *enumInfo = findEnumType(resolvedEnum)) {
+                auto fit = enumInfo->variantFields.find(pat->variant_name);
+                if (fit != enumInfo->variantFields.end()) {
                     const std::vector<Pattern> *fieldPats =
                         unwrapEnumPayloadTuple(pat->bindings, fit->second.fieldTypes.size());
                     llvm::Value *sv = builder_.CreateLoad(subjectTy, subjectAlloca, "adt.val");
                     llvm::AllocaInst *tmpAlloca = builder_.CreateAlloca(subjectTy, nullptr, "adt.tmp");
                     builder_.CreateStore(sv, tmpAlloca);
                     llvm::Value *payloadPtr = builder_.CreateStructGEP(
-                        enumIt->second.adtType, tmpAlloca, 1, "adt.payload");
+                        enumInfo->adtType, tmpAlloca, 1, "adt.payload");
                     const llvm::DataLayout &dl = mod_->getDataLayout();
                     size_t offset = 0;
                     for (size_t bi = 0; bi < fieldPats->size() && bi < fit->second.fieldTypes.size(); ++bi) {

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -870,15 +870,40 @@ void CodeGen::emitStmt(ImportAliasStmt &s) {
     const std::string &alias = s.alias_name;
     const std::string &orig = s.original_name;
 
+    // Cross-kind alias-map + generic-template collision check. Each case below
+    // already rejects same-kind collisions against its own primary table +
+    // alias map; this lambda fills in the missing cross-kind checks
+    // (e.g. fn alias `X` then record alias `X`, or fn alias `X` then a
+    // generic fn template named `X` defined later in this module).
+    // `rejectIfTypeNameTakenByOtherKind` covers cross-kind *type* collisions
+    // (record / enum / generic enum / type-alias) but does not see the new
+    // fn/record/enum alias maps or `generic_fn_templates_`.
+    auto rejectCrossKindAliasCollision = [&](ImportAliasStmt::Kind incoming) {
+        if (incoming != ImportAliasStmt::Kind::Fn &&
+            (fn_aliases_.count(alias) || generic_fn_templates_.count(alias)))
+            codegenError("import alias '" + alias +
+                         "' conflicts with an existing function alias or generic function template");
+        if (incoming != ImportAliasStmt::Kind::Record &&
+            record_aliases_.count(alias))
+            codegenError("import alias '" + alias +
+                         "' conflicts with an existing record alias");
+        if (incoming != ImportAliasStmt::Kind::Enum &&
+            enum_aliases_.count(alias))
+            codegenError("import alias '" + alias +
+                         "' conflicts with an existing enum alias");
+    };
+
     switch (s.kind) {
     case ImportAliasStmt::Kind::Fn: {
         // OverloadEntry holds `unique_ptr<...> capturedClosureInfos` and is
         // therefore non-copyable. Route alias lookups through `fn_aliases_`
         // (consulted by `findFunction`) rather than duplicating the entry.
-        if (functions_.count(alias) || fn_aliases_.count(alias))
+        if (functions_.count(alias) || fn_aliases_.count(alias) ||
+            generic_fn_templates_.count(alias))
             codegenError("import alias '" + alias +
                          "' conflicts with an existing function definition");
         rejectIfTypeNameTakenByOtherKind(alias);
+        rejectCrossKindAliasCollision(ImportAliasStmt::Kind::Fn);
         if (generic_fn_templates_.count(orig))
             codegenError("import alias for generic function '" + orig +
                          "' is not yet supported (tracked as a follow-up to #1725)");
@@ -896,6 +921,7 @@ void CodeGen::emitStmt(ImportAliasStmt &s) {
             codegenError("import alias '" + alias +
                          "' conflicts with an existing record definition");
         rejectIfTypeNameTakenByOtherKind(alias);
+        rejectCrossKindAliasCollision(ImportAliasStmt::Kind::Record);
         if (!record_types_.count(orig))
             codegenError("cannot create import alias '" + alias +
                          "': record '" + orig + "' is not defined");
@@ -912,6 +938,7 @@ void CodeGen::emitStmt(ImportAliasStmt &s) {
             codegenError("import alias '" + alias +
                          "' conflicts with an existing enum definition");
         rejectIfTypeNameTakenByOtherKind(alias);
+        rejectCrossKindAliasCollision(ImportAliasStmt::Kind::Enum);
         if (generic_enum_templates_.count(orig))
             codegenError("import alias for generic enum '" + orig +
                          "' is not yet supported (tracked as a follow-up to #1725)");
@@ -928,6 +955,7 @@ void CodeGen::emitStmt(ImportAliasStmt &s) {
             codegenError("import alias '" + alias +
                          "' conflicts with an existing type alias");
         rejectIfTypeNameTakenByOtherKind(alias);
+        rejectCrossKindAliasCollision(ImportAliasStmt::Kind::TypeAlias);
         if (!type_aliases_.count(orig))
             codegenError("cannot create import alias '" + alias +
                          "': type alias '" + orig + "' is not defined");

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -854,6 +854,90 @@ void CodeGen::emitStmt(QualifiedImportStmt &s) {
     module_namespaces_[effective] = ModuleNamespaceInfo{s.module_name, s.is_stdlib};
 }
 
+// `from m import foo as bar` for fn / record / enum / type-alias kinds
+// (#1725 — follow-up to #1721). ModuleLoader::makeAliasBinding synthesizes
+// this node after the original definition has been pushed into the destination
+// program (or, in the cache-hit path, after the prior import already left the
+// original definition registered with codegen). We register `alias_name` as a
+// fresh key into the same codegen table as `original_name`, so every existing
+// name-resolution site (`findFunction`, `record_types_.find`,
+// `enum_types_.find`, `resolveType` chain) keeps working without per-site
+// hooks. `@const` aliases still go through the AssignStmt path; Value /
+// Directive aliases remain rejected at the loader.
+void CodeGen::emitStmt(ImportAliasStmt &s) {
+    if (s.loc.isValid()) current_loc_ = s.loc;
+
+    const std::string &alias = s.alias_name;
+    const std::string &orig = s.original_name;
+
+    switch (s.kind) {
+    case ImportAliasStmt::Kind::Fn: {
+        // OverloadEntry holds `unique_ptr<...> capturedClosureInfos` and is
+        // therefore non-copyable. Route alias lookups through `fn_aliases_`
+        // (consulted by `findFunction`) rather than duplicating the entry.
+        if (functions_.count(alias) || fn_aliases_.count(alias))
+            codegenError("import alias '" + alias +
+                         "' conflicts with an existing function definition");
+        rejectIfTypeNameTakenByOtherKind(alias);
+        if (generic_fn_templates_.count(orig))
+            codegenError("import alias for generic function '" + orig +
+                         "' is not yet supported (tracked as a follow-up to #1725)");
+        if (!functions_.count(orig))
+            codegenError("cannot create import alias '" + alias +
+                         "': function '" + orig + "' is not defined");
+        fn_aliases_[alias] = orig;
+        break;
+    }
+    case ImportAliasStmt::Kind::Record: {
+        // RecordInfo's `fields` / `invariants` hold `unique_ptr<TypeNode>` /
+        // `unique_ptr<ExprNode>` — non-copyable. Route alias lookups through
+        // `record_aliases_` (consulted by `findRecordType`).
+        if (record_types_.count(alias) || record_aliases_.count(alias))
+            codegenError("import alias '" + alias +
+                         "' conflicts with an existing record definition");
+        rejectIfTypeNameTakenByOtherKind(alias);
+        if (!record_types_.count(orig))
+            codegenError("cannot create import alias '" + alias +
+                         "': record '" + orig + "' is not defined");
+        record_aliases_[alias] = orig;
+        // Cycle-collector visit functions key on user-visible type names.
+        // Propagate the orig's cyclic status so `List<P>` (alias) and
+        // `List<Point>` (orig) share the same GC visit decision.
+        if (potentially_cyclic_types_.count(orig))
+            potentially_cyclic_types_.insert(alias);
+        break;
+    }
+    case ImportAliasStmt::Kind::Enum: {
+        if (enum_types_.count(alias) || enum_aliases_.count(alias))
+            codegenError("import alias '" + alias +
+                         "' conflicts with an existing enum definition");
+        rejectIfTypeNameTakenByOtherKind(alias);
+        if (generic_enum_templates_.count(orig))
+            codegenError("import alias for generic enum '" + orig +
+                         "' is not yet supported (tracked as a follow-up to #1725)");
+        if (!enum_types_.count(orig))
+            codegenError("cannot create import alias '" + alias +
+                         "': enum '" + orig + "' is not defined");
+        enum_aliases_[alias] = orig;
+        if (potentially_cyclic_types_.count(orig))
+            potentially_cyclic_types_.insert(alias);
+        break;
+    }
+    case ImportAliasStmt::Kind::TypeAlias: {
+        if (type_aliases_.count(alias))
+            codegenError("import alias '" + alias +
+                         "' conflicts with an existing type alias");
+        rejectIfTypeNameTakenByOtherKind(alias);
+        if (!type_aliases_.count(orig))
+            codegenError("cannot create import alias '" + alias +
+                         "': type alias '" + orig + "' is not defined");
+        // Point alias at orig; resolveType's existing chain walks the rest.
+        type_aliases_[alias] = orig;
+        break;
+    }
+    }
+}
+
 void CodeGen::emitStmt(IndexAssignStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitCoverage(s.loc);

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -18,7 +18,10 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
     {
         auto *evMeta = getMeta(val);
         if (evMeta && !evMeta->enum_value_type.empty()) {
-            auto &einfo = enum_types_[evMeta->enum_value_type];
+            auto *einfoPtr = findEnumType(evMeta->enum_value_type);
+            if (!einfoPtr)
+                codegenError("valueToString: unknown enum type: " + evMeta->enum_value_type);
+            auto &einfo = *einfoPtr;
             if (!einfo.isADT) {
                 if (einfo.hasExplicitValues) {
                     llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "vts.enum.merge", fn_);
@@ -691,10 +694,10 @@ llvm::Function *CodeGen::getOrCreateADTToStringFn(const std::string &enumName) {
     if (cached != adt_to_string_fns_.end())
         return cached->second;
 
-    auto einfoIt = enum_types_.find(enumName);
-    if (einfoIt == enum_types_.end())
+    auto *einfoPtr = findEnumType(enumName);
+    if (!einfoPtr)
         return nullptr;
-    auto &einfo = einfoIt->second;
+    auto &einfo = *einfoPtr;
 
     // enumName may contain '<', '>', ',' (e.g. "Option<int>") — not valid in LLVM identifiers.
     std::string sanitized;

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -220,20 +220,17 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
         return getResultType(okTy, errTy);
     }
 
-    auto it = record_types_.find(typeName);
-    if (it != record_types_.end()) return it->second.llvmType;
+    if (auto *ri = findRecordType(typeName)) return ri->llvmType;
 
     // enum name → i64 (simple) or ADT struct type
     {
-        auto eit = enum_types_.find(typeName);
-        if (eit != enum_types_.end())
-            return eit->second.isADT ? eit->second.adtType : i64Ty_;
+        if (auto *ei = findEnumType(typeName))
+            return ei->isADT ? ei->adtType : i64Ty_;
         // On-demand generic-enum instantiation for type positions that have
         // not been touched by a construction site or pattern yet.
         if (ensureEnumInstantiated(typeName)) {
-            auto eit2 = enum_types_.find(typeName);
-            if (eit2 != enum_types_.end())
-                return eit2->second.isADT ? eit2->second.adtType : i64Ty_;
+            if (auto *ei2 = findEnumType(typeName))
+                return ei2->isADT ? ei2->adtType : i64Ty_;
         }
     }
 

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -105,53 +105,84 @@ static ExportableKind getExportableKind(const StmtNode &stmt) {
     return ExportableKind::Fn; // unreachable: caller already filtered via isExportable
 }
 
-// Build a synthesized binding `alias = orig` for `@const` symbols so the
-// importer's scope sees `alias` as an additional name pointing at the same
-// underlying value. Only `@const` alias is supported in this release:
-// fn / record / enum / type-alias alias requires codegen-side name-resolution
-// fallback that is not yet implemented (tracked in follow-up issue #1725).
-// The caller MUST reject non-Const kinds before reaching here; this function
-// asserts that contract via the switch default.
+// Build a synthesized binding for `from m import orig as alias`.
+//   - `@const` aliases: emit `AssignStmt{alias = orig}` so the existing
+//     module-global / const-folding paths see `alias` as an additional name
+//     pointing at the same underlying value.
+//   - fn / record / enum / type-alias aliases (#1725): emit an
+//     `ImportAliasStmt` whose codegen handler registers `alias_name` as a
+//     fresh key into the corresponding codegen table
+//     (`functions_` / `record_types_` / `enum_types_` / `type_aliases_`).
+// Value (non-@const) and Directive aliases are rejected by
+// `rejectUnsupportedAlias` upstream and must not reach this function.
 static StmtNode makeAliasBinding(ExportableKind kind,
                                   const std::string &orig_name,
                                   const std::string &alias_name,
                                   SourceLocation loc) {
-    (void)kind; // contract: caller guarantees ExportableKind::Const
-    auto var = std::make_unique<ExprNode>();
-    var->data = VariableExpr{orig_name};
-    var->loc = loc;
-    AssignStmt a;
-    a.name = alias_name;
-    a.value = std::move(var);
-    a.loc = loc;
-    return a;
+    switch (kind) {
+        case ExportableKind::Const: {
+            auto var = std::make_unique<ExprNode>();
+            var->data = VariableExpr{orig_name};
+            var->loc = loc;
+            AssignStmt a;
+            a.name = alias_name;
+            a.value = std::move(var);
+            a.loc = loc;
+            return a;
+        }
+        case ExportableKind::Fn:
+            return ImportAliasStmt{alias_name, orig_name,
+                                   ImportAliasStmt::Kind::Fn, loc};
+        case ExportableKind::Record:
+            return ImportAliasStmt{alias_name, orig_name,
+                                   ImportAliasStmt::Kind::Record, loc};
+        case ExportableKind::Enum:
+            return ImportAliasStmt{alias_name, orig_name,
+                                   ImportAliasStmt::Kind::Enum, loc};
+        case ExportableKind::TypeAlias:
+            return ImportAliasStmt{alias_name, orig_name,
+                                   ImportAliasStmt::Kind::TypeAlias, loc};
+        case ExportableKind::Value:
+        case ExportableKind::Directive:
+            // Unreachable: rejectUnsupportedAlias filters these before
+            // we reach the alias-emit path.
+            throw std::runtime_error(
+                "internal: makeAliasBinding invoked with unsupported kind for '" +
+                alias_name + "'");
+    }
+    // Unreachable under a well-formed ExportableKind switch.
+    throw std::runtime_error(
+        "internal: makeAliasBinding fallthrough for '" + alias_name + "'");
 }
 
 // Validate that an `as` alias is only requested for a supported kind.
-// In v0.0.23 (#1721) only `@const` alias is functional; the other kinds
-// (fn / record / enum / type alias) parse and reach the loader, but emitting
-// a binding that survives codegen requires the follow-up work tracked in
-// #1725. Throw a descriptive error so the user understands what to do.
+// Since #1725, alias is functional for `@const`, fn, record, enum, and
+// type-alias kinds; only Value (non-`@const` assignment) and Directive remain
+// rejected, both for semantic reasons documented in the issue scope.
 static void rejectUnsupportedAlias(ExportableKind kind,
                                     const std::string &name,
                                     const std::string &import_path,
                                     int line) {
-    if (kind == ExportableKind::Const) return;
-    std::string detail = "alias not supported for ";
     switch (kind) {
-        case ExportableKind::Fn:        detail += "function";              break;
-        case ExportableKind::Value:     detail += "non-@const assignment"; break;
-        case ExportableKind::Record:    detail += "record";                break;
-        case ExportableKind::Enum:      detail += "enum";                  break;
-        case ExportableKind::TypeAlias: detail += "type alias";            break;
-        case ExportableKind::Directive: detail += "directive";             break;
-        case ExportableKind::Const:     return;
+        case ExportableKind::Const:
+        case ExportableKind::Fn:
+        case ExportableKind::Record:
+        case ExportableKind::Enum:
+        case ExportableKind::TypeAlias:
+            return;
+        case ExportableKind::Value:
+        case ExportableKind::Directive: break;
     }
+    std::string detail = "alias not supported for ";
+    if (kind == ExportableKind::Value)
+        detail += "non-@const assignment";
+    else
+        detail += "directive";
     detail += " '";
     detail += name;
     detail += "' from module '";
     detail += import_path;
-    detail += "': only @const aliases are supported in v0.0.23 (tracked in #1725)";
+    detail += "': mutable globals and directives cannot be re-bound via 'as'";
     throw std::runtime_error(makeImportError(line, detail));
 }
 

--- a/tests/spec/import_alias/import_alias.test.ry
+++ b/tests/spec/import_alias/import_alias.test.ry
@@ -1,6 +1,11 @@
 from testing import it, describe, expect
 
 from .shapes import ORIGIN_X as ZERO_X, ORIGIN_Y
+from .shapes import rectArea as area
+from .shapes import Point as P
+from .shapes import Color as C
+from .shapes import Shape as S
+from .shapes import Distance as D
 
 @describe("import alias")
 fn importAliasTests():
@@ -12,3 +17,32 @@ fn importAliasTests():
     fn shouldMixAliasedAndNonAliased():
         sum: int = ZERO_X + ORIGIN_Y + 7
         expect(sum).toEq(7)
+
+    @it("should call a fn through an alias")
+    fn shouldCallFnThroughAlias():
+        expect(area(3, 4)).toEq(12)
+
+    @it("should construct a record and access fields through an alias")
+    fn shouldConstructRecordThroughAlias():
+        p: P = P(7, 9)
+        expect(p.x).toEq(7)
+        expect(p.y).toEq(9)
+
+    @it("should construct a unit-enum variant through an alias")
+    fn shouldConstructEnumThroughAlias():
+        c: C = C::Red
+        expect(toStr(c)).toEq("Red")
+
+    @it("should pattern-match an ADT enum through an alias")
+    fn shouldPatternMatchAdtThroughAlias():
+        s: S = S::Circle(5)
+        result: int = 0
+        case s:
+            S::Circle(r): result = r
+            S::Square(side): result = side
+        expect(result).toEq(5)
+
+    @it("should use a type alias as a type annotation")
+    fn shouldUseTypeAliasAnnotation():
+        d: D = 42
+        expect(d).toEq(42)

--- a/tests/spec/import_alias/shapes.ry
+++ b/tests/spec/import_alias/shapes.ry
@@ -5,3 +5,26 @@ ORIGIN_X: int = 0
 @public
 @const
 ORIGIN_Y: int = 0
+
+@public
+fn rectArea(w: int, h: int) -> int:
+    return w * h
+
+@public
+record Point:
+    x: int
+    y: int
+
+@public
+enum Color:
+    Red
+    Green
+    Blue
+
+@public
+enum Shape:
+    Circle(radius: int)
+    Square(side: int)
+
+@public
+type Distance = int

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1044,9 +1044,9 @@ TEST_F(ImportTest, ImportAliasTypeAliasChain) {
         "100\n");
 }
 
-// Self-collision: importing a name and aliasing it to itself should be
-// rejected by the alias's name-collision guard.
-TEST_F(ImportTest, ImportAliasNameCollision) {
+// An import alias whose chosen name shadows a local definition in the
+// importing module must be rejected by the alias's name-collision guard.
+TEST_F(ImportTest, ImportAliasCollidesWithLocalDefinition) {
     writeFile("colmod.ry",
         "@public\n"
         "fn helper() -> int:\n"

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -870,90 +870,236 @@ TEST_F(ImportTest, ImportAliasValueRejected) {
         EXPECT_NE(msg.find("alias not supported for non-@const assignment 'counter'"),
                   std::string::npos)
             << "got: " << msg;
-        EXPECT_NE(msg.find("#1725"), std::string::npos) << "got: " << msg;
-    }
-}
-
-TEST_F(ImportTest, ImportAliasFunctionRejected) {
-    writeFile("fnmod.ry",
-        "fn rectArea(w: int, h: int) -> int:\n"
-        "    return w * h\n");
-    try {
-        runWithImports("from fnmod import rectArea as area\n");
-        FAIL() << "Expected exception";
-    } catch (const std::runtime_error &e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("alias not supported for function 'rectArea'"),
+        EXPECT_NE(msg.find("mutable globals and directives cannot be re-bound"),
                   std::string::npos)
             << "got: " << msg;
-        EXPECT_NE(msg.find("#1725"), std::string::npos) << "got: " << msg;
     }
 }
 
-TEST_F(ImportTest, ImportAliasRecordRejected) {
+TEST_F(ImportTest, ImportAliasFunctionWorks) {
+    writeFile("fnmod.ry",
+        "@public\n"
+        "fn rectArea(w: int, h: int) -> int:\n"
+        "    return w * h\n");
+    EXPECT_EQ(runWithImports(
+        "from fnmod import rectArea as area\n"
+        "print(area(3, 4))"),
+        "12\n");
+}
+
+TEST_F(ImportTest, ImportAliasRecordWorks) {
     writeFile("recmod.ry",
+        "@public\n"
         "record Point:\n"
         "    x: int\n"
         "    y: int\n");
-    try {
-        runWithImports("from recmod import Point as P\n");
-        FAIL() << "Expected exception";
-    } catch (const std::runtime_error &e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("alias not supported for record 'Point'"),
-                  std::string::npos)
-            << "got: " << msg;
-    }
+    EXPECT_EQ(runWithImports(
+        "from recmod import Point as P\n"
+        "p: P = P(7, 9)\n"
+        "print(p.x)\n"
+        "print(p.y)"),
+        "7\n9\n");
 }
 
-TEST_F(ImportTest, ImportAliasEnumRejected) {
+TEST_F(ImportTest, ImportAliasEnumWorks) {
     writeFile("enummod.ry",
+        "@public\n"
         "enum Color:\n"
         "    Red\n"
         "    Green\n");
-    try {
-        runWithImports("from enummod import Color as C\n");
-        FAIL() << "Expected exception";
-    } catch (const std::runtime_error &e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("alias not supported for enum 'Color'"),
-                  std::string::npos)
-            << "got: " << msg;
-    }
+    EXPECT_EQ(runWithImports(
+        "from enummod import Color as C\n"
+        "c: C = C::Red\n"
+        "print(toStr(c))"),
+        "Red\n");
 }
 
-TEST_F(ImportTest, ImportAliasTypeAliasRejected) {
+TEST_F(ImportTest, ImportAliasTypeAliasWorks) {
     writeFile("tymod.ry",
+        "@public\n"
         "type Distance = int\n");
-    try {
-        runWithImports("from tymod import Distance as D\n");
-        FAIL() << "Expected exception";
-    } catch (const std::runtime_error &e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("alias not supported for type alias 'Distance'"),
-                  std::string::npos)
-            << "got: " << msg;
-    }
+    EXPECT_EQ(runWithImports(
+        "from tymod import Distance as D\n"
+        "d: D = 42\n"
+        "print(d)"),
+        "42\n");
 }
 
-// Cache-hit path (`loaded_.count(abs_path) != 0`) also enforces the
-// rejection. Two `from <mod>` statements force the second one through
-// the cached branch.
-TEST_F(ImportTest, ImportAliasFunctionRejectedCacheHit) {
+// Cache-hit path (`loaded_.count(abs_path) != 0`) also handles the alias.
+// Two `from <mod>` statements force the second one through the cached branch.
+TEST_F(ImportTest, ImportAliasFunctionWorksCacheHit) {
     writeFile("fnmod2.ry",
+        "@public\n"
+        "fn helper() -> int:\n"
+        "    return 100\n");
+    EXPECT_EQ(runWithImports(
+        "from fnmod2\n"
+        "from fnmod2 import helper as h\n"
+        "print(h())"),
+        "100\n");
+}
+
+// Cache-hit path for record alias: second `from <mod>` triggers the cached
+// branch in module_loader. The alias still registers into record_types_.
+TEST_F(ImportTest, ImportAliasRecordWorksCacheHit) {
+    writeFile("recmod2.ry",
+        "@public\n"
+        "record Pt:\n"
+        "    x: int\n"
+        "    y: int\n");
+    EXPECT_EQ(runWithImports(
+        "from recmod2\n"
+        "from recmod2 import Pt as Q\n"
+        "q: Q = Q(5, 8)\n"
+        "print(q.x)"),
+        "5\n");
+}
+
+TEST_F(ImportTest, ImportAliasEnumWorksCacheHit) {
+    writeFile("enummod2.ry",
+        "@public\n"
+        "enum Mode:\n"
+        "    On\n"
+        "    Off\n");
+    EXPECT_EQ(runWithImports(
+        "from enummod2\n"
+        "from enummod2 import Mode as M\n"
+        "m: M = M::On\n"
+        "print(toStr(m))"),
+        "On\n");
+}
+
+TEST_F(ImportTest, ImportAliasTypeAliasWorksCacheHit) {
+    writeFile("tymod2.ry",
+        "@public\n"
+        "type Count = int\n");
+    EXPECT_EQ(runWithImports(
+        "from tymod2\n"
+        "from tymod2 import Count as N\n"
+        "n: N = 7\n"
+        "print(n)"),
+        "7\n");
+}
+
+// Overloaded function: alias must point at the entire OverloadEntry vector
+// so each arity is callable through the alias.
+TEST_F(ImportTest, ImportAliasFunctionOverload) {
+    writeFile("ovlmod.ry",
+        "@public\n"
+        "fn area(w: int) -> int:\n"
+        "    return w * w\n"
+        "@public\n"
+        "fn area(w: int, h: int) -> int:\n"
+        "    return w * h\n");
+    EXPECT_EQ(runWithImports(
+        "from ovlmod import area as a\n"
+        "print(a(5))\n"
+        "print(a(3, 4))"),
+        "25\n12\n");
+}
+
+// Record with parent: the parent_name field must travel with the alias.
+TEST_F(ImportTest, ImportAliasRecordWithParent) {
+    writeFile("parmod.ry",
+        "@public\n"
+        "record Animal:\n"
+        "    name: str\n"
+        "@public\n"
+        "record Dog < Animal:\n"
+        "    breed: str\n");
+    EXPECT_EQ(runWithImports(
+        "from parmod import Dog as D\n"
+        "d: D = D(\"Rex\", \"Lab\")\n"
+        "print(d.name)\n"
+        "print(d.breed)"),
+        "Rex\nLab\n");
+}
+
+// ADT enum: pattern match on a variant through the alias.
+TEST_F(ImportTest, ImportAliasEnumAdtPatternMatch) {
+    writeFile("adtmod.ry",
+        "@public\n"
+        "enum Shape:\n"
+        "    Circle(radius: int)\n"
+        "    Square(side: int)\n");
+    EXPECT_EQ(runWithImports(
+        "from adtmod import Shape as S\n"
+        "s: S = S::Circle(5)\n"
+        "case s:\n"
+        "    S::Circle(r): print(r)\n"
+        "    S::Square(side): print(side)"),
+        "5\n");
+}
+
+// Type alias chain: `type B = int` in m, then `from m import B as X`. The
+// new alias X resolves through the chain to int.
+TEST_F(ImportTest, ImportAliasTypeAliasChain) {
+    writeFile("chainmod.ry",
+        "@public\n"
+        "type B = int\n");
+    EXPECT_EQ(runWithImports(
+        "from chainmod import B as X\n"
+        "y: X = 100\n"
+        "print(y)"),
+        "100\n");
+}
+
+// Self-collision: importing a name and aliasing it to itself should be
+// rejected by the alias's name-collision guard.
+TEST_F(ImportTest, ImportAliasNameCollision) {
+    writeFile("colmod.ry",
+        "@public\n"
         "fn helper() -> int:\n"
         "    return 1\n");
     try {
         runWithImports(
-            "from fnmod2\n"
-            "from fnmod2 import helper as h\n");
+            "fn helper() -> int:\n"
+            "    return 2\n"
+            "from colmod import helper as helper\n");
         FAIL() << "Expected exception";
     } catch (const std::runtime_error &e) {
         std::string msg = e.what();
-        EXPECT_NE(msg.find("alias not supported for function 'helper'"),
-                  std::string::npos)
+        EXPECT_NE(msg.find("helper"), std::string::npos) << "got: " << msg;
+    }
+}
+
+// Generic fn alias is scope-out: the instantiation cache + mangle keys are
+// driven by the original name, so aliasing breaks them. Reject explicitly.
+TEST_F(ImportTest, ImportAliasGenericFnRejected) {
+    writeFile("genfnmod.ry",
+        "@public\n"
+        "fn identity<T>(x: T) -> T:\n"
+        "    return x\n");
+    try {
+        runWithImports(
+            "from genfnmod import identity as id\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("generic"), std::string::npos)
             << "got: " << msg;
-        EXPECT_NE(msg.find("#1725"), std::string::npos) << "got: " << msg;
+        EXPECT_NE(msg.find("identity"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// Generic enum alias is scope-out for the same reasons as generic fn.
+TEST_F(ImportTest, ImportAliasGenericEnumRejected) {
+    writeFile("genenummod.ry",
+        "@public\n"
+        "enum Maybe<T>:\n"
+        "    Just(value: T)\n"
+        "    Nothing\n");
+    try {
+        runWithImports(
+            "from genenummod import Maybe as M\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("generic"), std::string::npos)
+            << "got: " << msg;
+        EXPECT_NE(msg.find("Maybe"), std::string::npos)
+            << "got: " << msg;
     }
 }
 


### PR DESCRIPTION
## Summary

- `from m import foo as bar` の alias サポートを `@const` 限定 (v0.0.23) から fn / record / enum / type-alias の 4 kind に拡張
- 新規 `ImportAliasStmt` AST node を導入。module loader が non-`@const` alias 用に synthesize し、codegen が `fn_aliases_` / `record_aliases_` / `enum_aliases_` / `type_aliases_` 経由で既存テーブルに alias 名を登録（OverloadEntry / FieldDef が non-copyable のため、primary table への直接 copy ではなく alias map + lookup helper 戦略を採用）
- generic fn / generic enum alias は scope-out（明示的な reject）。非 `@const` mutable global と `@directive` alias も引き続き reject

Closes #1725

## Test plan

- [x] C++ tests: 2277 / 2277 PASS（新規 ImportAlias テスト 17 個 + 既存 flip 5 個含む）
- [x] Ry self-test: 183 / 183 PASS（`tests/spec/import_alias/import_alias.test.ry` に 5 個追加）
- [x] ASan + UBSan: 2277 / 2277 + 183 / 183 PASS
- [x] TSan (C++ required): 2277 / 2277 PASS（Ry self-test は upstream #1716 で warn-only）
- [x] clang-tidy + cppcheck: clean
- [x] Skipped §3.6 (libFuzzer) — parser/lexer/json/utf8/string 系の変更なし
- [x] Skipped §3.6.5 (tree-sitter grammar) — \`docs/grammar.ebnf\` 変更なし
- [x] Background hygiene: orphan プロセスなし

## Follow-up (scope-out)

実装中に発見した audit gap として、`enum_types_` / `record_types_` への直接アクセス site のうち alias 名が到達しうるものが残っています:

- \`src/codegen_call.cpp:87,153\` (typeOf 経由)
- \`src/codegen_match.cpp:60,430,559,655\` (pattern bindings via field type)
- \`src/codegen_arc_gc.cpp:165,170\`、\`src/codegen_fn.cpp:117\`、\`src/codegen_stmt.cpp:991\`、\`src/codegen_call_user.cpp:558\`、\`src/codegen_expr_literal.cpp:158\`、\`src/codegen_test.cpp:669,736\`

現在のテスト 24 個 (17 C++ + 7 spec) では sanitizer も clean ですが、`typeOf` / `verifyCalledWith` / ARC GC visitor を alias 経由で使う edge case は未テスト。後続 issue で `findEnumType` / `findRecordType` 経由に統一する想定です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Import aliasing now works end-to-end for functions, records, enums, and type aliases; generic fn/enum aliases are explicitly rejected with clear diagnostics.

* **Documentation**
  * Updated module reference and changelog to reflect expanded alias support and clarify unsupported cases (mutable globals, directives).

* **Tests**
  * Added comprehensive tests for successful aliasing, pattern-matching/constructors via aliases, type-alias chains, collision handling, and explicit generic-alias rejection; updated an existing rejection message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1733)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->