### PR TITLE
feat(import): qualified import for user-defined modules (#1730)

### DIFF
--- a/changelog.d/1730-qualified-import-user-defined.md
+++ b/changelog.d/1730-qualified-import-user-defined.md
@@ -1,0 +1,22 @@
+### Added
+
+- Extended qualified import (#1723 / #1724) to user-defined modules: after
+  `import usermod`, the qualified forms `usermod.foo()`, `usermod.PI`, and
+  `usermod.MyRecord(...)` resolve through a per-module namespace bucket on
+  `CodeGen`, replacing the previous "throwaway Program" carve-out that
+  outright rejected qualified calls into user-defined modules. The
+  selective form (`from usermod import foo`) continues to share the same
+  loader cache, so mixing both in one file (`import usermod` followed by
+  `from usermod import foo`) reuses the AST without re-parsing. Bare-name
+  leak isolation is preserved: `import usermod` alone never exposes
+  `foo()` as a top-level identifier. (#1730)
+
+### Changed
+
+- Generic functions, `enum` declarations, and `type` aliases inside a
+  user-defined module reached through qualified import are now rejected
+  at codegen with an actionable diagnostic suggesting
+  `from <module> import ...`. These constructs route through flat tables
+  (`generic_fn_templates_` / `enum_types_` / `type_aliases_`) that the
+  per-module namespace bucket cannot intercept; surfacing the limitation
+  early avoids silent bare-name leaks. (#1730)

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -136,7 +136,7 @@ contains("hello", "ell")       # str module's contains
 |---|---|
 | Module form | Single identifier only. `import a.b` is rejected — use `from a.b import ...` instead. |
 | Alias | `import <module> as <local>` registers `<local>` as the effective module name (Python-style: alias **replaces** the original — bare `<module>` is no longer in scope). The alias must be camelCase. Two imports that resolve to the same effective name (e.g. `import math as m` then `import path as m`) are a parse error. |
-| Module scope | Standard library modules only. Qualified call to a user-defined module produces a diagnostic suggesting `from <module> import ...`. |
+| Module scope | Both standard library and user-defined modules are supported. Generic functions, `enum` declarations, and `type` aliases inside a qualified-imported user-defined module are rejected with a diagnostic suggesting `from <module> import ...` (Phase 2). |
 | Duplicate | `import math` followed by `import math` in the same file is a parse error. |
 | Shadowing | After `import math`, declaring `math: int = ...` (or any local named `math`) is a parse error. Rename the local or remove the matching `import` statement. |
 

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -272,12 +272,12 @@ struct ImportStmt {
     SourceLocation loc;
 };
 
-struct QualifiedImportStmt {
-    std::string module_name;              // single identifier — multi-segment paths rejected at parse time
-    std::optional<std::string> alias;     // reserved for #1724 (`import xxx as yyy`); parser currently rejects non-empty
-    bool is_stdlib = false;               // set by ModuleLoader::resolveImports — gates qualified-call routing in CodeGen (stdlib dispatch vs. user-fn error in v0.0.23)
-    SourceLocation loc;
-};
+// `QualifiedImportStmt` is held by `unique_ptr` in `StmtNode` (#1730) because
+// its `definitions` field is a `Program` whose element type `StmtNode` is the
+// variant itself — a value-type alternative would require completeness before
+// the variant is defined, which is impossible. Full definition lives after the
+// `Program` alias below.
+struct QualifiedImportStmt;
 
 // Synthesized by ModuleLoader::makeAliasBinding for `from m import foo as bar` (#1725 — fn/record/enum/typealias kinds).
 // Const aliases stay on AssignStmt; Value/Directive aliases remain rejected upstream.
@@ -363,7 +363,7 @@ struct DirectiveDefStmt {
 };
 
 using StmtNode = std::variant<AssignStmt, CallStmt, ExprStmt,
-                              ReturnStmt, ImportStmt, QualifiedImportStmt, ImportAliasStmt, RecordStmt,
+                              ReturnStmt, ImportStmt, std::unique_ptr<QualifiedImportStmt>, ImportAliasStmt, RecordStmt,
                               IndexAssignStmt, BreakStmt, ContinueStmt, EllipsisStmt,
                               FieldAssignStmt, EnumStmt, ExpectStmt, AwaitStmt,
                               TupleDestructStmt, TypeAliasStmt,
@@ -375,6 +375,18 @@ using StmtNode = std::variant<AssignStmt, CallStmt, ExprStmt,
                               std::unique_ptr<FnStmt>,
                               std::unique_ptr<CaseStmt>>;
 using Program  = std::vector<StmtNode>;
+
+struct QualifiedImportStmt {
+    std::string module_name;              // single identifier — multi-segment paths rejected at parse time
+    std::optional<std::string> alias;     // `import xxx as yyy` (#1724); parser stores user's alias if present
+    bool is_stdlib = false;               // set by ModuleLoader::resolveImports — stdlib still inlines into the top-level Program; user-defined modules carry decls in `definitions` (#1730)
+    // User-defined module decls extracted by ModuleLoader (#1730). Empty for
+    // stdlib (which still inlines into the top-level Program for native-fn
+    // signature registration). Codegen emits these under a namespace bucket
+    // keyed by the effective alias so bare names do not leak.
+    Program definitions;
+    SourceLocation loc;
+};
 
 // ===== Match patterns =====
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -597,6 +597,13 @@ public:
     // `findFunction` for fn aliases. Returns nullptr on miss.
     RecordInfo *findRecordType(const std::string &name);
     const RecordInfo *findRecordType(const std::string &name) const;
+    // Look up a record by its LLVM struct type, walking both `record_types_`
+    // and `module_namespaces_[*].records`. Used by codegen sites that receive
+    // a `llvm::StructType*` from a value (FieldAccessExpr, ARC dispatch on
+    // record fields, etc.) and need to find the source-level RecordInfo
+    // regardless of which module declared the record (#1730).
+    RecordInfo *findRecordInfoForType(llvm::StructType *st);
+    const RecordInfo *findRecordInfoForType(llvm::StructType *st) const;
 
     // Type ID registry for typeOf builtin.
     // Each distinct type definition gets a unique id, allowing identity-based
@@ -971,18 +978,30 @@ public:
     // module scope. Key = effective name in the importing file (alias when
     // present, else original module name); value carries the original
     // module name (for diagnostics that need to point at the file the
-    // module came from) plus the `is_stdlib` flag propagated from
-    // ModuleLoader. Populated by `emitStmt(QualifiedImportStmt&)`.
-    // Consulted by the call / field-access dispatchers to route
-    // `<effective>.fn(...)` (CallExpr with `qualified_module` set) —
-    // stdlib modules reuse the existing dispatch chain; user-defined
-    // modules raise a "not yet supported in v0.0.23" codegen error whose
-    // redirect quotes the original module name (issues #1723 / #1724).
+    // module came from), the `is_stdlib` flag propagated from
+    // ModuleLoader, and (for user-defined modules only, #1730) per-kind
+    // decl buckets populated while `emitStmt(QualifiedImportStmt&)` emits
+    // `qimp.definitions` under a `NamespaceEmitScope` guard. Stdlib
+    // modules still inline into the top-level Program so their buckets
+    // stay empty.
     struct ModuleNamespaceInfo {
         std::string original_name;
-        bool is_stdlib;
+        bool is_stdlib = false;
+        // User-defined module decls (#1730). Keyed by bare fn / const /
+        // record name. Empty for stdlib.
+        std::unordered_map<std::string, std::vector<OverloadEntry>> fn_overloads;
+        std::unordered_map<std::string, ModuleBinding> consts;
+        std::unordered_map<std::string, RecordInfo> records;
     };
     std::unordered_map<std::string, ModuleNamespaceInfo> module_namespaces_;
+
+    // While non-null, `emitStmt(FnStmt&)` / `emitStmt(RecordStmt&)` /
+    // top-level `@const AssignStmt` redirect their registration into this
+    // namespace's per-kind buckets instead of `functions_` /
+    // `record_types_` / `module_globals_`. Set/cleared by RAII
+    // `NamespaceEmitScope` while emitting a user-defined module's
+    // `QualifiedImportStmt::definitions` (#1730).
+    ModuleNamespaceInfo *current_namespace_target_ = nullptr;
 
     // User-defined @directive declarations. Keyed by directive name.
     std::unordered_map<std::string, DirectiveSignature> user_directive_registry_;
@@ -1155,6 +1174,27 @@ public:
     void validateParallelFor(const ForStmt &s);
 
     // RAII scope for function emission (B5)
+    // RAII guard that redirects FnStmt / RecordStmt / top-level @const
+    // AssignStmt registrations into `target`'s per-kind buckets instead of
+    // `functions_` / `record_types_` / `module_globals_`. Active for the
+    // duration of one user-defined `QualifiedImportStmt::definitions`
+    // emission (#1730).
+    class NamespaceEmitScope {
+    public:
+        NamespaceEmitScope(CodeGen &cg, ModuleNamespaceInfo *target)
+            : cg_(cg), saved_(cg.current_namespace_target_) {
+            cg_.current_namespace_target_ = target;
+        }
+        ~NamespaceEmitScope() noexcept {
+            cg_.current_namespace_target_ = saved_;
+        }
+        NamespaceEmitScope(const NamespaceEmitScope&) = delete;
+        NamespaceEmitScope& operator=(const NamespaceEmitScope&) = delete;
+    private:
+        CodeGen &cg_;
+        ModuleNamespaceInfo *saved_;
+    };
+
     class FnScope {
     public:
         explicit FnScope(CodeGen &cg);
@@ -1245,7 +1285,7 @@ public:
     void emitStmt(ExprStmt &s);
     void emitStmt(ReturnStmt &s);
     void emitStmt(ImportStmt &s);
-    void emitStmt(QualifiedImportStmt &s);
+    void emitStmt(std::unique_ptr<QualifiedImportStmt> &s);
     void emitStmt(ImportAliasStmt &s);
     void emitStmt(RecordStmt &s);
     void emitStmt(TypeAliasStmt &s);
@@ -1473,11 +1513,17 @@ public:
     llvm::Value *emitAnyBinaryOp(const std::string &op, llvm::Value *lhs, llvm::Value *rhs);
     llvm::Value *emitAnyUnaryNeg(llvm::Value *operand);
 
-    // Function call helper (B4)
-    llvm::Value *emitUserFnCall(const std::string &callee, const std::vector<ExprPtr> &args);
+    // Function call helper (B4).
+    // `explicitOverloads`, when non-null, bypasses findFunction() and uses
+    // the provided list directly. Used by qualified-call dispatch (#1730)
+    // to route `usermod.foo(...)` into the namespace bucket without
+    // setting current_namespace_target_ during arg emission.
+    llvm::Value *emitUserFnCall(const std::string &callee, const std::vector<ExprPtr> &args,
+                                std::vector<OverloadEntry> *explicitOverloads = nullptr);
     llvm::Function *resolveOverload(const std::string &callee,
                                     const std::vector<ExprPtr> &args,
-                                    std::vector<llvm::Value*> &outArgVals);
+                                    std::vector<llvm::Value*> &outArgVals,
+                                    std::vector<OverloadEntry> *explicitOverloads = nullptr);
 
     llvm::Value *emitRecordConstructor(const RecordInfo &info, const std::string &name, const std::vector<ExprPtr> &args);
     llvm::Type *resolveType(const std::string &typeName);

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -975,15 +975,19 @@ public:
     std::unordered_set<std::string> testing_intrinsics_imported_;
 
     // Modules introduced by `import xxx [as yyy]` (qualified import) at
-    // module scope. Key = effective name in the importing file (alias when
-    // present, else original module name); value carries the original
-    // module name (for diagnostics that need to point at the file the
-    // module came from), the `is_stdlib` flag propagated from
-    // ModuleLoader, and (for user-defined modules only, #1730) per-kind
-    // decl buckets populated while `emitStmt(QualifiedImportStmt&)` emits
-    // `qimp.definitions` under a `NamespaceEmitScope` guard. Stdlib
-    // modules still inline into the top-level Program so their buckets
-    // stay empty.
+    // module scope. Keyed by the **canonical module name** (the actual
+    // source-file module path, e.g. `usermod`), not the effective alias
+    // — multiple `import usermod` / `import usermod as u` from the same
+    // file share one bucket, so any decl emitted on the first import is
+    // visible under every alias. Aliases redirect through
+    // `effective_to_canonical_` (lookup-only; aliases do not own a
+    // separate bucket). Value carries the original module name (for
+    // diagnostics that need to point at the file the module came from),
+    // the `is_stdlib` flag propagated from ModuleLoader, and (for
+    // user-defined modules only, #1730) per-kind decl buckets populated
+    // while `emitStmt(QualifiedImportStmt&)` emits `qimp.definitions`
+    // under a `NamespaceEmitScope` guard. Stdlib modules still inline
+    // into the top-level Program so their buckets stay empty.
     struct ModuleNamespaceInfo {
         std::string original_name;
         bool is_stdlib = false;
@@ -994,6 +998,16 @@ public:
         std::unordered_map<std::string, RecordInfo> records;
     };
     std::unordered_map<std::string, ModuleNamespaceInfo> module_namespaces_;
+    // Alias → canonical redirect for qualified imports. Populated only
+    // when `import <mod> as <alias>` introduces an alias different from
+    // the canonical module name. `findModuleNamespace(effective)` walks
+    // this map before `module_namespaces_.find(effective)`.
+    std::unordered_map<std::string, std::string> effective_to_canonical_;
+    // Look up a qualified-imported module by its effective name (the
+    // identifier used at the call / field-access site: alias if present,
+    // else the original module name). Returns nullptr on miss.
+    ModuleNamespaceInfo *findModuleNamespace(const std::string &effective);
+    const ModuleNamespaceInfo *findModuleNamespace(const std::string &effective) const;
 
     // While non-null, `emitStmt(FnStmt&)` / `emitStmt(RecordStmt&)` /
     // top-level `@const AssignStmt` redirect their registration into this

--- a/include/ry/module_loader.hpp
+++ b/include/ry/module_loader.hpp
@@ -63,6 +63,15 @@ private:
     SourceManager *sm_ = nullptr;
     std::unordered_set<std::string> loaded_;
     std::unordered_set<std::string> loading_;
+    // Modules that were loaded via `import <mod>` (qualified-only) to a
+    // user-defined module — their decls landed in `QualifiedImportStmt::definitions`
+    // and were NOT inlined to the top-level Program. If a subsequent
+    // `from <mod> import x` references the same module, the cache-hit branch
+    // would normally short-circuit without pushing decls anywhere; this set
+    // forces re-extract so the requested names reach the top-level Program
+    // (AC3 of #1730). Stdlib modules are not tracked here because their decls
+    // are still inlined to `result` on first load.
+    std::unordered_set<std::string> qualified_only_user_loaded_;
     // Cache: abs_path -> map of exported name -> is_public flag (true if @public).
     // Stores every exportable kind (functions, records, lets, enums, type
     // aliases, directive defs), so the name "fn" no longer applies — kept as

--- a/include/ry/module_loader.hpp
+++ b/include/ry/module_loader.hpp
@@ -115,6 +115,14 @@ private:
     // Load all .ry files from a module directory and return collected statements
     Program loadModuleDir(const std::string &abs_dir_path);
 
+    // Drop @p abs_path from `loaded_` / `qualified_only_user_loaded_` so the
+    // next reference re-runs the cache-miss path. For directory modules,
+    // also drops every contained `.ry` file from `loaded_` because
+    // `loadModuleDir` inserts each per-file canonical path independently.
+    // Without that recursive walk, re-extracting a directory module would
+    // observe the per-file `loaded_` entries and silently skip every file.
+    void invalidateLoaded(const std::string &abs_path, bool is_directory);
+
     // Cached `findProjectRoot` for a given directory.
     std::optional<std::string> packageRootOfDir(const std::string &dir);
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -512,6 +512,15 @@ std::vector<CodeGen::OverloadEntry> *CodeGen::findFunction(const std::string &na
         if (found != it->end())
             return &found->second;
     }
+    // When emitting decls inside a qualified-imported user-defined module,
+    // peer fns live in the namespace bucket — check it first so intra-module
+    // calls resolve. After NamespaceEmitScope exits, this branch is skipped,
+    // preserving bare-name isolation (AC4).
+    if (current_namespace_target_) {
+        auto nsit = current_namespace_target_->fn_overloads.find(name);
+        if (nsit != current_namespace_target_->fn_overloads.end())
+            return &nsit->second;
+    }
     auto fit = functions_.find(name);
     if (fit != functions_.end())
         return &fit->second;
@@ -530,6 +539,11 @@ std::vector<CodeGen::OverloadEntry> *CodeGen::findFunction(const std::string &na
 }
 
 CodeGen::RecordInfo *CodeGen::findRecordType(const std::string &name) {
+    if (current_namespace_target_) {
+        auto nsit = current_namespace_target_->records.find(name);
+        if (nsit != current_namespace_target_->records.end())
+            return &nsit->second;
+    }
     auto it = record_types_.find(name);
     if (it != record_types_.end()) return &it->second;
     std::string cur = name;
@@ -544,6 +558,11 @@ CodeGen::RecordInfo *CodeGen::findRecordType(const std::string &name) {
 }
 
 const CodeGen::RecordInfo *CodeGen::findRecordType(const std::string &name) const {
+    if (current_namespace_target_) {
+        auto nsit = current_namespace_target_->records.find(name);
+        if (nsit != current_namespace_target_->records.end())
+            return &nsit->second;
+    }
     auto it = record_types_.find(name);
     if (it != record_types_.end()) return &it->second;
     std::string cur = name;
@@ -554,6 +573,24 @@ const CodeGen::RecordInfo *CodeGen::findRecordType(const std::string &name) cons
         auto rit = record_types_.find(cur);
         if (rit != record_types_.end()) return &rit->second;
     }
+    return nullptr;
+}
+
+CodeGen::RecordInfo *CodeGen::findRecordInfoForType(llvm::StructType *st) {
+    for (auto &[name, info] : record_types_)
+        if (info.llvmType == st) return &info;
+    for (auto &[mod, ns] : module_namespaces_)
+        for (auto &[name, info] : ns.records)
+            if (info.llvmType == st) return &info;
+    return nullptr;
+}
+
+const CodeGen::RecordInfo *CodeGen::findRecordInfoForType(llvm::StructType *st) const {
+    for (auto &[name, info] : record_types_)
+        if (info.llvmType == st) return &info;
+    for (auto &[mod, ns] : module_namespaces_)
+        for (auto &[name, info] : ns.records)
+            if (info.llvmType == st) return &info;
     return nullptr;
 }
 
@@ -598,6 +635,11 @@ bool CodeGen::isImmutable(const std::string &name) const {
         if (it->count(name))
             return false;
     }
+    if (current_namespace_target_) {
+        auto nsit = current_namespace_target_->consts.find(name);
+        if (nsit != current_namespace_target_->consts.end() && nsit->second.is_immutable)
+            return true;
+    }
     auto mit = module_globals_.find(name);
     if (mit != module_globals_.end() && mit->second.is_immutable)
         return true;
@@ -607,6 +649,14 @@ bool CodeGen::isImmutable(const std::string &name) const {
 // ===== Module-level bindings (#817) =====
 
 const CodeGen::ModuleBinding *CodeGen::findModuleGlobal(const std::string &name) const {
+    // While inside a NamespaceEmitScope, peer @const lookups go to the
+    // namespace bucket first. After the scope exits, bare-name lookup of
+    // namespaced consts must not succeed (AC4).
+    if (current_namespace_target_) {
+        auto nsit = current_namespace_target_->consts.find(name);
+        if (nsit != current_namespace_target_->consts.end())
+            return &nsit->second;
+    }
     auto it = module_globals_.find(name);
     if (it == module_globals_.end())
         return nullptr;
@@ -616,6 +666,12 @@ const CodeGen::ModuleBinding *CodeGen::findModuleGlobal(const std::string &name)
 void CodeGen::registerModuleGlobal(const std::string &name,
                                     llvm::AllocaInst *alloca,
                                     bool is_immutable) {
+    // Qualified-import of user-defined module: route into namespace bucket
+    // instead of the flat module_globals_, preserving AC4 isolation.
+    bool isNamespaced = current_namespace_target_ != nullptr;
+    std::string trampolineName = isNamespaced
+        ? "__ry_modvar_" + current_namespace_target_->original_name + "__" + name
+        : "__ry_modvar_" + name;
     // The trampoline is a private module-level pointer variable initialized to
     // null at module load; __ry_main__ stores the alloca address into it just
     // after the alloca is materialized, so lookups from other top-level
@@ -627,7 +683,7 @@ void CodeGen::registerModuleGlobal(const std::string &name,
         /*isConstant=*/false,
         llvm::GlobalValue::PrivateLinkage,
         llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
-        "__ry_modvar_" + name);
+        trampolineName);
     // Store the alloca address into the trampoline global at __ry_main__'s
     // current insert point, which is source-order during the top-level loop.
     builder_.CreateStore(alloca, gv);
@@ -647,7 +703,10 @@ void CodeGen::registerModuleGlobal(const std::string &name,
     mb.is_resource = resource_managed_vars_.count(alloca) > 0;
     mb.is_str = arc_str_managed_vars_.count(alloca) > 0;
     mb.destructor = resolveDestructor(alloca);
-    module_globals_[name] = mb;
+    if (isNamespaced)
+        current_namespace_target_->consts[name] = mb;
+    else
+        module_globals_[name] = mb;
 }
 
 llvm::Value *CodeGen::loadModuleGlobalStorage(const ModuleBinding &b,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -594,6 +594,22 @@ const CodeGen::RecordInfo *CodeGen::findRecordInfoForType(llvm::StructType *st) 
     return nullptr;
 }
 
+CodeGen::ModuleNamespaceInfo *CodeGen::findModuleNamespace(const std::string &effective) {
+    auto ait = effective_to_canonical_.find(effective);
+    const std::string &canonical = (ait != effective_to_canonical_.end()) ? ait->second : effective;
+    auto it = module_namespaces_.find(canonical);
+    if (it == module_namespaces_.end()) return nullptr;
+    return &it->second;
+}
+
+const CodeGen::ModuleNamespaceInfo *CodeGen::findModuleNamespace(const std::string &effective) const {
+    auto ait = effective_to_canonical_.find(effective);
+    const std::string &canonical = (ait != effective_to_canonical_.end()) ? ait->second : effective;
+    auto it = module_namespaces_.find(canonical);
+    if (it == module_namespaces_.end()) return nullptr;
+    return &it->second;
+}
+
 CodeGen::EnumInfo *CodeGen::findEnumType(const std::string &name) {
     auto it = enum_types_.find(name);
     if (it != enum_types_.end()) return &it->second;

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -26,24 +26,27 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
     //   misresolve caller-scope bare fn refs in the args).
     if (e->qualified_module.has_value()) {
         const std::string &mod = *e->qualified_module;
-        auto it = module_namespaces_.find(mod);
-        if (it == module_namespaces_.end())
+        // findModuleNamespace walks `effective_to_canonical_` so aliases
+        // (`import usermod as u` followed by `u.greet()`) resolve to the
+        // canonical-keyed bucket populated by the original import (#1730).
+        ModuleNamespaceInfo *ns = findModuleNamespace(mod);
+        if (!ns)
             codegenError("qualified call to module '" + mod +
                          "' which was not imported via 'import " + mod + "'");
-        if (!it->second.is_stdlib) {
+        if (!ns->is_stdlib) {
             // Record constructor `usermod.MyRecord(args)` — look in the
             // namespace's records bucket before fn_overloads. Records and
             // fns share the call-syntax namespace, mirroring the bare-name
             // dispatch order at line 134.
-            auto rit = it->second.records.find(e->callee);
-            if (rit != it->second.records.end()) {
+            auto rit = ns->records.find(e->callee);
+            if (rit != ns->records.end()) {
                 if (deprecated_types_.count(e->callee))
                     emitDeprecationWarning(e->callee);
                 return emitRecordConstructor(rit->second, e->callee, e->args);
             }
-            auto fit = it->second.fn_overloads.find(e->callee);
-            if (fit == it->second.fn_overloads.end()) {
-                codegenError("module '" + it->second.original_name +
+            auto fit = ns->fn_overloads.find(e->callee);
+            if (fit == ns->fn_overloads.end()) {
+                codegenError("module '" + ns->original_name +
                              "' has no function or record '" + e->callee + "'");
             }
             return emitUserFnCall(e->callee, e->args, &fit->second);

--- a/src/codegen_call_dispatch.cpp
+++ b/src/codegen_call_dispatch.cpp
@@ -8,28 +8,46 @@ namespace ry {
 // ===== CallExpr Dispatcher =====
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CallExpr> &e) {
-    // Qualified call `<effective>.fn(args)` (#1723, #1724). The parser
-    // sets `qualified_module` when the dotted LHS is a single identifier
-    // that was imported via `import <mod>` or `import <mod> as <alias>`
-    // (parser tracks the effective name via `imported_modules_`, codegen
-    // via `module_namespaces_`). In v0.0.23 we route stdlib modules
-    // through the normal dispatch chain (StdlibRegistry already routes
-    // by callee name, so `math.sqrt(2.0)` → `emitBuiltinMath` resolves
-    // the same way `sqrt(2.0)` would once `import math` is in scope).
-    // User-defined qualified imports are not yet supported — emit a
-    // clear redirect to the selective-import form, quoting the file's
-    // original module name even when the user wrote an alias.
+    // Qualified call `<effective>.fn(args)` (#1723, #1724, #1730).
+    //
+    // The parser sets `qualified_module` when the dotted LHS is a single
+    // identifier imported via `import <mod>` / `import <mod> as <alias>`.
+    // Two dispatch flavors:
+    //
+    // - stdlib module: fall through to the regular call dispatch chain.
+    //   The stdlib loader inlines @native decls at the top level so the
+    //   bare-name route (`math.sqrt(2.0)` → callee `sqrt` → emitBuiltinMath)
+    //   resolves naturally.
+    //
+    // - user-defined module: look up the callee in the namespace's
+    //   `fn_overloads` bucket populated by NamespaceEmitScope (#1730).
+    //   Pass the bucket explicitly to emitUserFnCall to avoid setting
+    //   current_namespace_target_ during arg emission (which would
+    //   misresolve caller-scope bare fn refs in the args).
     if (e->qualified_module.has_value()) {
         const std::string &mod = *e->qualified_module;
         auto it = module_namespaces_.find(mod);
         if (it == module_namespaces_.end())
             codegenError("qualified call to module '" + mod +
                          "' which was not imported via 'import " + mod + "'");
-        if (!it->second.is_stdlib)
-            codegenError("qualified call to user-defined module '" + mod +
-                         "' is not yet supported in v0.0.23; use 'from " +
-                         it->second.original_name + " import " + e->callee +
-                         "' instead");
+        if (!it->second.is_stdlib) {
+            // Record constructor `usermod.MyRecord(args)` — look in the
+            // namespace's records bucket before fn_overloads. Records and
+            // fns share the call-syntax namespace, mirroring the bare-name
+            // dispatch order at line 134.
+            auto rit = it->second.records.find(e->callee);
+            if (rit != it->second.records.end()) {
+                if (deprecated_types_.count(e->callee))
+                    emitDeprecationWarning(e->callee);
+                return emitRecordConstructor(rit->second, e->callee, e->args);
+            }
+            auto fit = it->second.fn_overloads.find(e->callee);
+            if (fit == it->second.fn_overloads.end()) {
+                codegenError("module '" + it->second.original_name +
+                             "' has no function or record '" + e->callee + "'");
+            }
+            return emitUserFnCall(e->callee, e->args, &fit->second);
+        }
         // stdlib module → fall through; downstream dispatchers route by callee.
     }
 

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -8,8 +8,9 @@ namespace ry {
 
 llvm::Function *CodeGen::resolveOverload(const std::string &callee,
                                           const std::vector<ExprPtr> &args,
-                                          std::vector<llvm::Value*> &outArgVals) {
-    auto *overloadsPtr = findFunction(callee);
+                                          std::vector<llvm::Value*> &outArgVals,
+                                          std::vector<OverloadEntry> *explicitOverloads) {
+    auto *overloadsPtr = explicitOverloads ? explicitOverloads : findFunction(callee);
     if (!overloadsPtr) {
         if (native_fn_sigs_.count(callee) || native_lib_index_.count(callee)) {
             codegenError("no matching overload for @native fn '" + callee + "'");
@@ -230,15 +231,16 @@ llvm::Function *CodeGen::resolveOverload(const std::string &callee,
     return chosen->func;
 }
 
-llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vector<ExprPtr> &args) {
+llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vector<ExprPtr> &args,
+                                     std::vector<OverloadEntry> *explicitOverloads) {
     if (deprecated_functions_.count(callee))
         emitDeprecationWarning(callee);
     std::vector<llvm::Value*> argVals;
-    llvm::Function *fn = resolveOverload(callee, args, argVals);
+    llvm::Function *fn = resolveOverload(callee, args, argVals, explicitOverloads);
 
     // Find the matching overload entry (single scan for constraints + result type)
     OverloadEntry *matchedEntry = nullptr;
-    auto *fnOverloads = findFunction(callee);
+    auto *fnOverloads = explicitOverloads ? explicitOverloads : findFunction(callee);
     if (fnOverloads) {
         for (auto &entry : *fnOverloads) {
             if (entry.func == fn) { matchedEntry = &entry; break; }

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -213,6 +213,9 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<InterpolatedStringEx
 void CodeGen::emitStmt(TypeAliasStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitTraceSymbolDefine("type_alias", s.name, s.loc);
+    if (current_namespace_target_) {
+        codegenError("type alias declarations in qualified-imported user-defined modules are not yet supported; use 'from <mod> import <type>' instead");
+    }
     if (type_aliases_.count(s.name))
         codegenError("type alias '" + s.name + "' is already defined");
     rejectIfTypeNameTakenByOtherKind(s.name);

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -9,17 +9,29 @@ void CodeGen::emitStmt(RecordStmt &s) {
     for (const auto &f : s.fields)
         validateDirectives(f.directives, DirectiveTarget::Field);
     emitTraceSymbolDefine("record", s.name, s.loc);
-    if (record_types_.count(s.name))
+
+    // Qualified-import of user-defined module: register into namespace bucket
+    // instead of the flat record_types_, preserving AC4 isolation.
+    bool isNamespaced = current_namespace_target_ != nullptr;
+    auto &record_table = isNamespaced
+        ? current_namespace_target_->records
+        : record_types_;
+
+    if (record_table.count(s.name))
         codegenError("redefined type: " + s.name);
-    rejectIfTypeNameTakenByOtherKind(s.name);
+    if (!isNamespaced)
+        rejectIfTypeNameTakenByOtherKind(s.name);
 
     std::string parentName;
     std::vector<FieldDef> allFields;
 
     if (s.parent_name) {
         parentName = *s.parent_name;
-        auto pit = record_types_.find(parentName);
-        if (pit == record_types_.end())
+        // Parent lookup uses the same scope: namespace bucket if active,
+        // flat table otherwise. Inherited records must be defined earlier
+        // in the same module.
+        auto pit = record_table.find(parentName);
+        if (pit == record_table.end())
             codegenError("parent record '" + parentName + "' not defined");
 
         const auto &parentInfo = pit->second;
@@ -55,7 +67,7 @@ void CodeGen::emitStmt(RecordStmt &s) {
     }
 
     RecordInfo info{structTy, std::move(allFields), std::move(s.invariants), parentName, next_type_id_++};
-    record_types_[s.name] = std::move(info);
+    record_table[s.name] = std::move(info);
 }
 
 llvm::Value *CodeGen::emitRecordConstructor(const RecordInfo &info,
@@ -88,24 +100,38 @@ llvm::Value *CodeGen::emitRecordConstructor(const RecordInfo &info,
 }
 
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e) {
-    // Qualified field access `<effective>.x` (#1723, #1724). Same routing
-    // rules as the qualified-call dispatcher in codegen_call_dispatch.cpp:
-    // stdlib modules resolve through the bare-name lookup (the field was
-    // inlined as a top-level binding by ModuleLoader), user-defined
-    // modules error with a redirect to selective import. The redirect
-    // quotes the original module name from `module_namespaces_` so an
-    // alias does not mislead the user about which file to import from.
+    // Qualified field access `<effective>.x` (#1723, #1724, #1730).
+    //
+    // - stdlib module: the inlined top-level binding is reachable by bare
+    //   name; route through VariableExpr.
+    // - user-defined module: load through the namespace's `consts` bucket
+    //   (mirrors the bare-name module-global path at codegen_expr.cpp:170).
     if (e->qualified_module.has_value()) {
         const std::string &mod = *e->qualified_module;
         auto it = module_namespaces_.find(mod);
         if (it == module_namespaces_.end())
             codegenError("qualified access on module '" + mod +
                          "' which was not imported via 'import " + mod + "'");
-        if (!it->second.is_stdlib)
-            codegenError("qualified field access on user-defined module '" + mod +
-                         "' is not yet supported in v0.0.23; use 'from " +
-                         it->second.original_name + " import " + e->field +
-                         "' instead");
+        if (!it->second.is_stdlib) {
+            auto cit = it->second.consts.find(e->field);
+            if (cit == it->second.consts.end())
+                codegenError("module '" + it->second.original_name +
+                             "' has no constant '" + e->field + "'");
+            const ModuleBinding &b = cit->second;
+            if (b.is_weak)
+                codegenError("weak top-level variables are not yet accessible from functions (#817 follow-up)");
+            if (b.is_resource)
+                codegenError("resource-typed top-level variables are not yet accessible from functions (#817 follow-up)");
+            auto *storagePtr = loadModuleGlobalStorage(b, e->field);
+            llvm::Type *valueTy = b.valueTy();
+            if (llvm::isa<llvm::ArrayType>(valueTy)) {
+                array_storage_to_alloca_[storagePtr] = b.original_alloca;
+                return storagePtr;
+            }
+            auto *loaded = builder_.CreateLoad(valueTy, storagePtr, e->field);
+            propagateMeta(b.original_alloca, loaded);
+            return loaded;
+        }
         // stdlib: the inlined top-level definition is reachable by bare name.
         VariableExpr proxy{e->field};
         return emitExprVariant(proxy);
@@ -155,11 +181,14 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e)
     }
 
     std::string typeName = structTy->getName().str();
-    auto it = record_types_.find(typeName);
-    if (it == record_types_.end())
+    // Walk both flat record_types_ and module_namespaces_[*].records by LLVM
+    // type identity so qualified-imported records (#1730) are findable from
+    // user code emitted with current_namespace_target_ unset.
+    const RecordInfo *infoPtr = findRecordInfoForType(structTy);
+    if (!infoPtr)
         codegenError("unknown record type: " + typeName);
 
-    const auto &info = it->second;
+    const auto &info = *infoPtr;
     for (unsigned i = 0; i < info.fields.size(); ++i) {
         if (info.fields[i].name == e->field) {
             std::string qualifiedField = typeName + "." + e->field;

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -108,14 +108,16 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<FieldAccessExpr> &e)
     //   (mirrors the bare-name module-global path at codegen_expr.cpp:170).
     if (e->qualified_module.has_value()) {
         const std::string &mod = *e->qualified_module;
-        auto it = module_namespaces_.find(mod);
-        if (it == module_namespaces_.end())
+        // findModuleNamespace walks `effective_to_canonical_` so aliases
+        // resolve to the canonical-keyed bucket (#1730).
+        ModuleNamespaceInfo *ns = findModuleNamespace(mod);
+        if (!ns)
             codegenError("qualified access on module '" + mod +
                          "' which was not imported via 'import " + mod + "'");
-        if (!it->second.is_stdlib) {
-            auto cit = it->second.consts.find(e->field);
-            if (cit == it->second.consts.end())
-                codegenError("module '" + it->second.original_name +
+        if (!ns->is_stdlib) {
+            auto cit = ns->consts.find(e->field);
+            if (cit == ns->consts.end())
+                codegenError("module '" + ns->original_name +
                              "' has no constant '" + e->field + "'");
             const ModuleBinding &b = cit->second;
             if (b.is_weak)

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -502,10 +502,13 @@ void CodeGen::forwardDeclareFunctions(Program &prog) {
         if (!qp) continue;
         auto &qs = **qp;
         if (qs.is_stdlib || qs.definitions.empty()) continue;
-        const std::string &eff = qs.alias.has_value() ? *qs.alias : qs.module_name;
-        auto [it, inserted] = module_namespaces_.try_emplace(eff);
+        // Bucket keyed by canonical module name (#1730) — multiple
+        // imports of the same module share one bucket. Aliases register
+        // an `effective_to_canonical_` redirect in `emitStmt`.
+        const std::string &canonical = qs.module_name;
+        auto [it, inserted] = module_namespaces_.try_emplace(canonical);
         if (inserted) {
-            it->second.original_name = qs.module_name;
+            it->second.original_name = canonical;
             it->second.is_stdlib = qs.is_stdlib;
         }
         NamespaceEmitScope guard(*this, &it->second);

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -306,9 +306,17 @@ llvm::Function *CodeGen::declareFunction(
     }
     size_t newMaxArity = paramTypes.size();
 
-    // Determine registration target: nested functions use fn_scope_stack_
+    // Determine registration target:
+    // - Nested fns use fn_scope_stack_
+    // - Qualified-imported user-defined module fns use the namespace bucket
+    // - Otherwise the flat functions_ table
     bool isNested = fn_nesting_depth_ > 0 && !fn_scope_stack_.empty();
-    auto &overloads = isNested ? fn_scope_stack_.back()[name] : functions_[name];
+    bool isNamespaced = !isNested && current_namespace_target_ != nullptr;
+    auto &overloads = isNested
+        ? fn_scope_stack_.back()[name]
+        : (isNamespaced
+            ? current_namespace_target_->fn_overloads[name]
+            : functions_[name]);
 
     // Check for duplicate/conflicting signatures
     for (auto &entry : overloads) {
@@ -338,6 +346,13 @@ llvm::Function *CodeGen::declareFunction(
     llvm::Function::LinkageTypes linkage;
     if (isNested) {
         irName = current_function_name_ + "." + name + "." + std::to_string(nested_fn_counter_++);
+        linkage = llvm::Function::InternalLinkage;
+    } else if (isNamespaced) {
+        // Mangle namespace fns to avoid LLVM-level symbol collisions when
+        // multiple user-defined modules export the same fn name.
+        irName = current_namespace_target_->original_name + "__" + name;
+        if (!overloads.empty())
+            irName += "." + std::to_string(overloads.size());
         linkage = llvm::Function::InternalLinkage;
     } else {
         irName = name;
@@ -475,6 +490,27 @@ void CodeGen::forwardDeclareFunctionsInBody(std::vector<StmtNode> &stmts, bool v
 }
 
 void CodeGen::forwardDeclareFunctions(Program &prog) {
+    // First, forward-declare functions inside `QualifiedImportStmt::definitions`
+    // (user-defined modules, #1730). Set up the namespace target so the
+    // declarations land in `module_namespaces_[effective].fn_overloads` rather
+    // than the flat `functions_` table. Without this, intra-module peer-fn
+    // forward references would miss; and if a sibling `from <mod> import x`
+    // re-extracts the same fn at the top level, the top-level entry must end
+    // up in flat while the qimp-inner entry lives only in the namespace bucket.
+    for (auto &stmt : prog) {
+        auto *qp = std::get_if<std::unique_ptr<QualifiedImportStmt>>(&stmt);
+        if (!qp) continue;
+        auto &qs = **qp;
+        if (qs.is_stdlib || qs.definitions.empty()) continue;
+        const std::string &eff = qs.alias.has_value() ? *qs.alias : qs.module_name;
+        auto [it, inserted] = module_namespaces_.try_emplace(eff);
+        if (inserted) {
+            it->second.original_name = qs.module_name;
+            it->second.is_stdlib = qs.is_stdlib;
+        }
+        NamespaceEmitScope guard(*this, &it->second);
+        forwardDeclareFunctionsInBody(qs.definitions, /*validateOperatorReturn=*/true);
+    }
     forwardDeclareFunctionsInBody(prog, /*validateOperatorReturn=*/true);
 }
 
@@ -531,6 +567,11 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
 
     emitCoverage(s->loc);
     emitTraceSymbolDefine("fn", s->name, s->loc);
+
+    // Qualified import of user-defined module: reject generic fns (Phase 2)
+    if (current_namespace_target_ && !s->type_params.empty()) {
+        codegenError("generic functions in qualified-imported user-defined modules are not yet supported; use 'from <mod> import <fn>' instead");
+    }
 
     // Generic function: save as template, don't instantiate yet
     if (!s->type_params.empty()) {

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -1073,6 +1073,19 @@ void CodeGen::emitStmt(AssignStmt &s) {
             auto it = scope_stack_[0].find(s.name);
             if (it != scope_stack_[0].end() && it->second != nullptr)
                 registerModuleGlobal(s.name, it->second, is_const);
+            // Qualified-imported user-defined module (#1730): keep the namespace
+            // bucket as the sole source of truth. emitVarDecl added the alloca
+            // to scope_stack_[0] / immutable_scope_stack_[0]; remove those
+            // entries so (a) AC4 bare-name isolation holds (importer code that
+            // only writes `import usermod` cannot read bare `ANSWER`), and
+            // (b) the AC3 re-extract wildcard push, which inserts a duplicate
+            // top-level AssignStmt for every exportable @const, does not see
+            // an existing alloca via findVar and mis-fire as a reassignment.
+            if (current_namespace_target_) {
+                scope_stack_[0].erase(s.name);
+                if (!immutable_scope_stack_.empty())
+                    immutable_scope_stack_[0].erase(s.name);
+            }
         }
         return;
     }

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -1045,6 +1045,24 @@ void CodeGen::emitStmt(AssignStmt &s) {
     if (native_constants_.count(s.name))
         codegenError("cannot reassign native constant: " + s.name);
 
+    // AC3 re-extract duplicate (Bug 2 of #1730): when `from <mod> import x`
+    // wildcard-extracted every exportable @const into the top-level Program,
+    // and a later `import <mod>` then triggers the loader's force-populate
+    // path to also push every decl into `QualifiedImportStmt::definitions`,
+    // the second emission runs under NamespaceEmitScope. `findVar(s.name)`
+    // would return the existing top-level alloca and the reassignment-rejection
+    // path below would fire on the @const's type annotation. Detect this
+    // duplicate by checking the flat `module_globals_` table directly (which
+    // bypasses `findModuleGlobal`'s namespace-first lookup); register the
+    // SAME binding into the namespace bucket and return — no new init.
+    if (current_namespace_target_ && is_const) {
+        auto mit = module_globals_.find(s.name);
+        if (mit != module_globals_.end()) {
+            current_namespace_target_->consts[s.name] = mit->second;
+            return;
+        }
+    }
+
     llvm::AllocaInst *ptr = findVar(s.name);
     if (!ptr) {
         // Write-through to a previously declared top-level module global

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -846,16 +846,25 @@ void CodeGen::emitStmt(std::unique_ptr<QualifiedImportStmt> &sp) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     // ModuleLoader has already loaded the module, inlined its exportable
     // definitions (stdlib) or stashed them in `s.definitions` (user-defined,
-    // #1730), populated `exports_cache_`, and set `s.is_stdlib`. Codegen
-    // registers the module under the effective name (alias if present, else
-    // original name) so the call / field-access dispatchers recognize
-    // `<effective>.fn(...)` / `<effective>.x` qualified forms. The original
-    // module name is preserved so diagnostics can quote the file's actual
-    // module name even when the user wrote `import mymod as m`.
+    // #1730), populated `exports_cache_`, and set `s.is_stdlib`. The
+    // namespace bucket is keyed by the **canonical module name** so multiple
+    // imports of the same module (`import usermod` + `import usermod as u`,
+    // or `from usermod import x` + `import usermod`) share a single decl
+    // bucket. Aliases register an `effective_to_canonical_` redirect; only
+    // the canonical-keyed entry owns the actual decls.
     const std::string &effective = s.alias.has_value() ? *s.alias : s.module_name;
-    auto [it, inserted] = module_namespaces_.try_emplace(effective);
-    it->second.original_name = s.module_name;
-    it->second.is_stdlib = s.is_stdlib;
+    const std::string &canonical = s.module_name;
+    auto [it, inserted] = module_namespaces_.try_emplace(canonical);
+    if (inserted) {
+        it->second.original_name = canonical;
+        it->second.is_stdlib = s.is_stdlib;
+    } else if (it->second.is_stdlib != s.is_stdlib) {
+        // Defense-in-depth — ModuleLoader resolves the same module path to
+        // the same `from_stdlib` flag, so a flip here means the module
+        // pipeline misclassified one of the imports.
+        codegenError("internal: module '" + canonical + "' imported with inconsistent stdlib origin");
+    }
+    if (effective != canonical) effective_to_canonical_[effective] = canonical;
 
     // User-defined modules: emit the stashed decls under a namespace guard
     // so registrations land in `it->second.{fn_overloads, consts, records}`

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -498,6 +498,10 @@ void CodeGen::emitStmt(EnumStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitTraceSymbolDefine("enum", s.name, s.loc);
 
+    if (current_namespace_target_) {
+        codegenError("enum declarations in qualified-imported user-defined modules are not yet supported; use 'from <mod> import <enum>' instead");
+    }
+
     // Reject direct inline self-reference in variant fields. Recurses through
     // inline layouts (`T?`, tuples, unions, arrays, and generic applications
     // that are not pointer-backed) so `enum Tree: Node(Tree?)`, `Node((Tree,
@@ -837,21 +841,34 @@ void CodeGen::emitStmt(ImportStmt &s) {
                              " (ModuleLoader should have resolved this)");
 }
 
-void CodeGen::emitStmt(QualifiedImportStmt &s) {
+void CodeGen::emitStmt(std::unique_ptr<QualifiedImportStmt> &sp) {
+    QualifiedImportStmt &s = *sp;
     if (s.loc.isValid()) current_loc_ = s.loc;
     // ModuleLoader has already loaded the module, inlined its exportable
-    // definitions, populated `exports_cache_`, and set `s.is_stdlib`.
-    // Codegen's job here is purely to register the module under the
-    // effective name (alias if present, original name otherwise) so the
-    // call / field-access dispatchers can recognize `<effective>.fn(...)`
-    // / `<effective>.x` qualified forms (#1723, #1724). The original
-    // module name is preserved in the value so the user-defined-module
-    // redirect diagnostic can quote the file's actual module name even
-    // when the user wrote `import mymod as m`. No IR is emitted for the
-    // statement itself (mirrors `emitStmt(ImportStmt&)` which is also
-    // IR-less).
+    // definitions (stdlib) or stashed them in `s.definitions` (user-defined,
+    // #1730), populated `exports_cache_`, and set `s.is_stdlib`. Codegen
+    // registers the module under the effective name (alias if present, else
+    // original name) so the call / field-access dispatchers recognize
+    // `<effective>.fn(...)` / `<effective>.x` qualified forms. The original
+    // module name is preserved so diagnostics can quote the file's actual
+    // module name even when the user wrote `import mymod as m`.
     const std::string &effective = s.alias.has_value() ? *s.alias : s.module_name;
-    module_namespaces_[effective] = ModuleNamespaceInfo{s.module_name, s.is_stdlib};
+    auto [it, inserted] = module_namespaces_.try_emplace(effective);
+    it->second.original_name = s.module_name;
+    it->second.is_stdlib = s.is_stdlib;
+
+    // User-defined modules: emit the stashed decls under a namespace guard
+    // so registrations land in `it->second.{fn_overloads, consts, records}`
+    // rather than the flat `functions_` / `module_globals_` / `record_types_`
+    // tables. Stdlib modules still inline at the top-level Program for
+    // native-fn signature registration, so their `definitions` is empty and
+    // the guard is unnecessary.
+    if (!s.is_stdlib && !s.definitions.empty()) {
+        NamespaceEmitScope guard(*this, &it->second);
+        for (auto &decl : s.definitions) {
+            std::visit([this](auto &st) { emitStmt(st); }, decl);
+        }
+    }
 }
 
 // `from m import foo as bar` for fn / record / enum / type-alias kinds

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -623,7 +623,7 @@ int Formatter::getStmtLine(const StmtNode &stmt) const {
         else if constexpr (std::is_same_v<T, ReturnStmt>) return v.loc.line; // NOLINT(bugprone-branch-clone)
         else if constexpr (std::is_same_v<T, ExprStmt>) return v.loc.line;
         else if constexpr (std::is_same_v<T, ImportStmt>) return v.loc.line;
-        else if constexpr (std::is_same_v<T, QualifiedImportStmt>) return v.loc.line;
+        else if constexpr (std::is_same_v<T, std::unique_ptr<QualifiedImportStmt>>) return v->loc.line;
         else if constexpr (std::is_same_v<T, RecordStmt>) {
             if (!v.directives.empty()) return v.directives.front().loc.line;
             return v.loc.line;
@@ -662,7 +662,7 @@ void Formatter::formatStmt(const StmtNode &stmt) {
         else if constexpr (std::is_same_v<T, ExprStmt>) formatExprStmt(v);
         else if constexpr (std::is_same_v<T, ReturnStmt>) formatReturn(v);
         else if constexpr (std::is_same_v<T, ImportStmt>) formatImport(v);
-        else if constexpr (std::is_same_v<T, QualifiedImportStmt>) formatQualifiedImport(v);
+        else if constexpr (std::is_same_v<T, std::unique_ptr<QualifiedImportStmt>>) formatQualifiedImport(*v);
         else if constexpr (std::is_same_v<T, RecordStmt>) formatRecord(v);
         else if constexpr (std::is_same_v<T, IndexAssignStmt>) formatIndexAssign(v);
         else if constexpr (std::is_same_v<T, BreakStmt>) formatBreak(v);

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -522,6 +522,31 @@ bool ModuleLoader::isCrossPackage(const std::string &caller_dir,
     return *caller_root != *target_root;
 }
 
+void ModuleLoader::invalidateLoaded(const std::string &abs_path, bool is_directory) {
+    loaded_.erase(abs_path);
+    qualified_only_user_loaded_.erase(abs_path);
+    if (!is_directory) return;
+    // `loadModuleDir` inserts each contained `.ry` file's canonical path
+    // into `loaded_` independently from the directory path itself. If we
+    // only erased the directory entry, the next `loadModuleDir` would
+    // observe the per-file `loaded_.count(file_path)` guard at line 546
+    // and silently skip every file — leaving the re-extract destination
+    // empty. Walk the directory and clear those entries too.
+    std::error_code dec;
+    fs::directory_iterator dit(abs_path, dec);
+    if (dec) return;
+    for (const auto &entry : dit) {
+        if (!entry.is_regular_file()) continue;
+        auto filename = entry.path().filename().string();
+        if (filename.size() < 3 || filename.compare(filename.size() - 3, 3, ".ry") != 0) continue;
+        if (filename.size() >= 8 && filename.compare(filename.size() - 8, 8, ".test.ry") == 0) continue;
+        std::error_code ec;
+        std::string canonical = cachedCanonical(entry.path(), ec);
+        if (canonical.empty()) continue;
+        loaded_.erase(canonical);
+    }
+}
+
 Program ModuleLoader::loadModuleDir(const std::string &abs_dir_path) {
     Program collected;
     std::vector<std::string> ry_files;
@@ -569,6 +594,19 @@ Program ModuleLoader::loadModuleDir(const std::string &abs_dir_path) {
 
 Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_dir) {
     Program result;
+    // Track canonical module names whose `QualifiedImportStmt::definitions`
+    // have already been populated in this resolveImports run. The codegen-side
+    // `module_namespaces_` bucket is keyed by canonical name (#1730 alias
+    // indirection), so only the FIRST qimp per canonical may carry decls —
+    // any subsequent qimp for the same canonical (whether bare or aliased)
+    // must leave `definitions` empty, otherwise `forwardDeclareFunctions`
+    // walks both and `declareFunction` rejects the second emit with
+    // "fn 'X' is already defined with the same signature". Mixed-form
+    // scenarios that hit this: `import M` → `import M as X` → `from M import y`
+    // → `import M as Z` — step 3's inline invalidates qualified_only_user_loaded_,
+    // which then re-enables step 4's force-populate branch and re-extracts
+    // every decl into the second qimp's definitions.
+    std::unordered_set<std::string> canonicals_with_populated_qimp;
 
     for (auto &stmt : prog) {
         if (std::holds_alternative<std::unique_ptr<QualifiedImportStmt>>(stmt)) {
@@ -588,6 +626,44 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
 
             if (loading_.count(abs_path))
                 throw std::runtime_error("circular import detected: " + abs_path);
+
+            // Cache-hit for user-defined modules that were previously loaded
+            // ONLY via `from <mod> import x` (i.e. the module's decls landed
+            // in the top-level `result`, not in any prior
+            // `QualifiedImportStmt::definitions`). Without re-extracting,
+            // this `import <mod>` would leave `qimp.definitions` empty and
+            // codegen would create an empty `module_namespaces_[...]` bucket
+            // — the subsequent `<mod>.foo()` call would then fail with
+            // "module '<mod>' has no function or record 'foo'" (#1730
+            // CodeRabbit Bug 2). Invalidate to force the cache-miss path
+            // below to repopulate `qimp.definitions`. Stdlib is excluded
+            // because its decls remain valid in `result` from the prior
+            // `from <stdlib> import` and codegen routes stdlib qualified
+            // calls through the regular dispatch chain.
+            //
+            // For user-defined modules previously loaded via `import <mod>`
+            // (qualified-only), `qualified_only_user_loaded_` is set; codegen
+            // reuses the bucket keyed by canonical module name (#1730 codegen
+            // alias indirection) so a second `import <mod> [as <alias>]`
+            // does NOT need its own `qimp.definitions` — fast cache-hit path.
+            // If a prior qimp in this Program already populated the canonical
+            // bucket, suppress the force-populate path — codegen will register
+            // any alias on this stmt via `effective_to_canonical_` and reuse
+            // the already-populated bucket. Without this guard, mixed-form
+            // input would re-extract the same decls into a second
+            // `qimp.definitions`, producing duplicate-signature errors at
+            // forward-declare time.
+            bool canonical_already_populated = !rp.from_stdlib &&
+                canonicals_with_populated_qimp.count(qimp.module_name) > 0;
+
+            if (!rp.from_stdlib && loaded_.count(abs_path) &&
+                !qualified_only_user_loaded_.count(abs_path) &&
+                !canonical_already_populated) {
+                invalidateLoaded(abs_path, rp.is_directory);
+                // exports_cache_ / exports_kinds_cache_ remain populated;
+                // they will be refreshed by the upcoming
+                // extractDefinitions call below.
+            }
 
             if (loaded_.count(abs_path)) {
                 // exports_cache_ already populated by an earlier import of the
@@ -613,6 +689,7 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
             Program &push_target = rp.from_stdlib ? result : qimp.definitions;
             if (!rp.from_stdlib) {
                 qualified_only_user_loaded_.insert(abs_path);
+                canonicals_with_populated_qimp.insert(qimp.module_name);
             }
             if (rp.is_directory) {
                 loading_.insert(abs_path);
@@ -685,11 +762,11 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
         // QualifiedImportStmt::definitions and were not inlined to the
         // top-level Program. To honor a subsequent `from <mod> import x`
         // (AC3), re-parse and re-extract so the requested names reach
-        // `result`. Erase from both sets so the next reference cache-hits
-        // normally.
+        // `result`. `invalidateLoaded` walks directory modules too so the
+        // per-file `loaded_` entries that `loadModuleDir` adds are also
+        // dropped — otherwise the directory-walk would skip every file.
         if (qualified_only_user_loaded_.count(abs_path) && !imp.names.empty()) {
-            qualified_only_user_loaded_.erase(abs_path);
-            loaded_.erase(abs_path);
+            invalidateLoaded(abs_path, rp.is_directory);
             // exports_cache_ / exports_kinds_cache_ remain populated; they
             // get refreshed by the upcoming extractDefinitions call below
             // (cache-miss path).

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -571,8 +571,8 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
     Program result;
 
     for (auto &stmt : prog) {
-        if (std::holds_alternative<QualifiedImportStmt>(stmt)) {
-            auto &qimp = std::get<QualifiedImportStmt>(stmt);
+        if (std::holds_alternative<std::unique_ptr<QualifiedImportStmt>>(stmt)) {
+            auto &qimp = *std::get<std::unique_ptr<QualifiedImportStmt>>(stmt);
 
             ResolvedPath rp = resolve(qimp.module_name, referrer_dir);
             const std::string &abs_path = rp.path;
@@ -601,21 +601,19 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
             // First-time load: inline all exportable definitions (same path as
             // `from xxx import` with empty names) so that:
             //   1. @native fn signatures get registered in native_fn_sigs_
-            //      (required for stdlib qualified-call dispatch in Task 9).
+            //      (required for stdlib qualified-call dispatch).
             //   2. exports_cache_ / exports_kinds_cache_ get populated for any
             //      subsequent `from xxx import` referencing the same module.
             //
-            // For user-defined modules (`!rp.from_stdlib`), route extracted
-            // definitions to a throwaway Program so they are NOT inlined into
-            // the caller's namespace. The caches still get populated so
-            // `from <mod> import x` after `import <mod>` works (AC2-like).
-            // Without this gate, `import usermod` followed by bare `greet()`
-            // succeeds — bypassing the documented v0.0.23 rejection at call
-            // site. Stdlib path stays unchanged: native-fn registration in
-            // CodeGen still relies on inlining (#1730 tracks proper namespace
-            // isolation for stdlib).
-            Program throwaway;
-            Program &push_target = rp.from_stdlib ? result : throwaway;
+            // For user-defined modules (`!rp.from_stdlib`, #1730), route
+            // extracted definitions to `qimp.definitions` so codegen can emit
+            // them under a namespace bucket keyed by the effective alias
+            // rather than the top-level Program. Stdlib path stays unchanged:
+            // native-fn registration in CodeGen still relies on inlining.
+            Program &push_target = rp.from_stdlib ? result : qimp.definitions;
+            if (!rp.from_stdlib) {
+                qualified_only_user_loaded_.insert(abs_path);
+            }
             if (rp.is_directory) {
                 loading_.insert(abs_path);
                 Program dir_prog = loadModuleDir(abs_path);
@@ -681,6 +679,21 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
 
         if (loading_.count(abs_path))
             throw std::runtime_error("circular import detected: " + abs_path);
+
+        // If the module was previously loaded only via `import <mod>` to a
+        // user-defined module (#1730), its decls reside in the prior
+        // QualifiedImportStmt::definitions and were not inlined to the
+        // top-level Program. To honor a subsequent `from <mod> import x`
+        // (AC3), re-parse and re-extract so the requested names reach
+        // `result`. Erase from both sets so the next reference cache-hits
+        // normally.
+        if (qualified_only_user_loaded_.count(abs_path) && !imp.names.empty()) {
+            qualified_only_user_loaded_.erase(abs_path);
+            loaded_.erase(abs_path);
+            // exports_cache_ / exports_kinds_cache_ remain populated; they
+            // get refreshed by the upcoming extractDefinitions call below
+            // (cache-miss path).
+        }
 
         if (loaded_.count(abs_path)) {
             if (!imp.names.empty()) {

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -594,18 +594,21 @@ Program ModuleLoader::loadModuleDir(const std::string &abs_dir_path) {
 
 Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_dir) {
     Program result;
-    // Track canonical module names whose `QualifiedImportStmt::definitions`
-    // have already been populated in this resolveImports run. The codegen-side
-    // `module_namespaces_` bucket is keyed by canonical name (#1730 alias
-    // indirection), so only the FIRST qimp per canonical may carry decls —
-    // any subsequent qimp for the same canonical (whether bare or aliased)
-    // must leave `definitions` empty, otherwise `forwardDeclareFunctions`
-    // walks both and `declareFunction` rejects the second emit with
-    // "fn 'X' is already defined with the same signature". Mixed-form
-    // scenarios that hit this: `import M` → `import M as X` → `from M import y`
-    // → `import M as Z` — step 3's inline invalidates qualified_only_user_loaded_,
-    // which then re-enables step 4's force-populate branch and re-extracts
-    // every decl into the second qimp's definitions.
+    // Track canonical resolved paths (`abs_path` from ResolvedPath) whose
+    // `QualifiedImportStmt::definitions` have already been populated in this
+    // resolveImports run. The codegen-side `module_namespaces_` bucket is
+    // keyed by canonical name (#1730 alias indirection), so only the FIRST
+    // qimp per canonical may carry decls — any subsequent qimp for the same
+    // canonical (whether bare or aliased) must leave `definitions` empty,
+    // otherwise `forwardDeclareFunctions` walks both and `declareFunction`
+    // rejects the second emit with "fn 'X' is already defined with the same
+    // signature". Mixed-form scenarios that hit this: `import M` → `import M
+    // as X` → `from M import y` → `import M as Z` — step 3's inline
+    // invalidates qualified_only_user_loaded_, which then re-enables step
+    // 4's force-populate branch and re-extracts every decl into the second
+    // qimp's definitions. Keyed by `abs_path` (not raw `qimp.module_name`)
+    // so equivalent imports of the same module via different spelling
+    // (relative vs absolute, symlink) share dedup state.
     std::unordered_set<std::string> canonicals_with_populated_qimp;
 
     for (auto &stmt : prog) {
@@ -654,7 +657,7 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
             // `qimp.definitions`, producing duplicate-signature errors at
             // forward-declare time.
             bool canonical_already_populated = !rp.from_stdlib &&
-                canonicals_with_populated_qimp.count(qimp.module_name) > 0;
+                canonicals_with_populated_qimp.count(abs_path) > 0;
 
             if (!rp.from_stdlib && loaded_.count(abs_path) &&
                 !qualified_only_user_loaded_.count(abs_path) &&
@@ -689,7 +692,7 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
             Program &push_target = rp.from_stdlib ? result : qimp.definitions;
             if (!rp.from_stdlib) {
                 qualified_only_user_loaded_.insert(abs_path);
-                canonicals_with_populated_qimp.insert(qimp.module_name);
+                canonicals_with_populated_qimp.insert(abs_path);
             }
             if (rp.is_directory) {
                 loading_.insert(abs_path);

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -575,11 +575,12 @@ StmtNode Parser::parseQualifiedImportStatement() {
                 "' was already imported in this file");
     }
 
-    return QualifiedImportStmt{
+    return std::make_unique<QualifiedImportStmt>(QualifiedImportStmt{
         std::move(moduleName),
         std::move(alias),
         /*is_stdlib=*/false,
-        {importTok.line, importTok.col, file_id_}};
+        /*definitions=*/{},
+        {importTok.line, importTok.col, file_id_}});
 }
 
 StmtNode Parser::parseStatement() {

--- a/tests/spec/qualified_import/qualified_import_user_defined.test.ry
+++ b/tests/spec/qualified_import/qualified_import_user_defined.test.ry
@@ -1,0 +1,26 @@
+from testing import it, describe, expect
+
+import usermod
+from usermod import double
+
+@describe("qualified import — user-defined modules (#1730)")
+fn qualifiedImportUserDefinedTests():
+    @it("AC1: qualified fn call dispatches to the user-defined module")
+    fn shouldCallUserDefinedFn():
+        expect(usermod.greet()).toEq(7)
+        expect(usermod.double(21)).toEq(42)
+
+    @it("AC1: qualified @const access reads the user-defined module's value")
+    fn shouldReadUserDefinedConst():
+        expect(usermod.ANSWER).toEq(42)
+
+    @it("AC1: qualified record constructor + field access on a user-defined module")
+    fn shouldConstructAndAccessRecord():
+        p = usermod.Point(3, 4)
+        expect(p.x).toEq(3)
+        expect(p.y).toEq(4)
+
+    @it("AC3: qualified import and selective import of the same module coexist")
+    fn shouldCoexistWithSelectiveImport():
+        expect(double(21)).toEq(42)
+        expect(usermod.greet()).toEq(7)

--- a/tests/spec/qualified_import/qualified_import_user_defined_directory.test.ry
+++ b/tests/spec/qualified_import/qualified_import_user_defined_directory.test.ry
@@ -1,0 +1,30 @@
+from testing import it, describe, expect
+
+# Directory-module form: `usermoddir/` resolves to the directory module
+# whose files (`part_a.ry`, `part_b.ry`) are merged at load time. Qualified
+# access (`usermoddir.dirGreet()`) must reach decls defined in any file of
+# the directory. The `invalidateLoaded` walk also dropping per-file
+# `loaded_` entries is what enables a subsequent reload (`from <dir> import`
+# after `import <dir>`, AC3) to work — without it the directory walk would
+# skip every file.
+import usermoddir
+
+# AC3 for directory modules: `import <dir>` followed by `from <dir> import
+# <x>` exposes both the namespaced form and the imported bare name.
+from usermoddir import dirDouble
+
+@describe("qualified import — user-defined directory module (#1730)")
+fn qualifiedImportUserDefinedDirectoryTests():
+    @it("qualified call across files of the directory module")
+    fn shouldCallAcrossFiles():
+        expect(usermoddir.dirGreet()).toEq(11)
+        expect(usermoddir.dirDouble(7)).toEq(14)
+
+    @it("qualified @const access reaches a sibling file's decl")
+    fn shouldReadConstFromSibling():
+        expect(usermoddir.DIR_ANSWER).toEq(88)
+
+    @it("AC3: qualified-then-selective coexists for a directory module")
+    fn shouldCoexistWithSelectiveImport():
+        expect(dirDouble(21)).toEq(42)
+        expect(usermoddir.dirGreet()).toEq(11)

--- a/tests/spec/qualified_import/qualified_import_user_defined_mixed.test.ry
+++ b/tests/spec/qualified_import/qualified_import_user_defined_mixed.test.ry
@@ -1,0 +1,43 @@
+from testing import it, describe, expect
+
+# Bug 1 of PR #1736: `import usermod` + `import usermod as u`. Before the
+# fix the namespace bucket was keyed by the effective (alias-rewritten) name
+# so the second import created a fresh, empty bucket and `u.greet()` reported
+# "module 'u' has no function or record 'greet'". Canonical-keying the
+# bucket and routing aliases through `effective_to_canonical_` makes both
+# `usermod.greet()` and `u.greet()` resolve to the same registered fn.
+import usermod
+import usermod as u
+
+# Bug 2 of PR #1736: `from usermod import greet` first inlined every
+# exportable decl into the top-level Program (REQ-B3 wildcard side-effect)
+# and set `loaded_`. A subsequent `import usermod` then short-circuited
+# without populating `QualifiedImportStmt::definitions`, so `usermod.greet`
+# was not registered. The loader now force-populates via `invalidateLoaded`,
+# and the codegen handles the duplicate @const re-extract by re-binding into
+# the namespace bucket without re-emitting an alloca.
+from usermod import double
+import usermod as v
+
+@describe("qualified import — user-defined modules, mixed import forms (#1730)")
+fn qualifiedImportUserDefinedMixedTests():
+    @it("Bug 1: alias-then-bare share the same canonical namespace")
+    fn aliasAndBareShareCanonical():
+        expect(usermod.greet()).toEq(7)
+        expect(u.greet()).toEq(7)
+        expect(usermod.ANSWER).toEq(42)
+        expect(u.ANSWER).toEq(42)
+
+    @it("Bug 1: alias resolves records to the same registered type")
+    fn aliasResolvesRecord():
+        pBare = usermod.Point(1, 2)
+        pAlias = u.Point(3, 4)
+        expect(pBare.x).toEq(1)
+        expect(pAlias.y).toEq(4)
+
+    @it("Bug 2: `from <mod> import x` followed by `import <mod>` exposes qualified access")
+    fn fromBeforeImportExposesQualified():
+        expect(double(7)).toEq(14)
+        expect(v.greet()).toEq(7)
+        expect(v.double(21)).toEq(42)
+        expect(v.ANSWER).toEq(42)

--- a/tests/spec/qualified_import/usermod.ry
+++ b/tests/spec/qualified_import/usermod.ry
@@ -1,0 +1,16 @@
+@public
+@const
+ANSWER: int = 42
+
+@public
+fn greet() -> int:
+    return 7
+
+@public
+fn double(x: int) -> int:
+    return x * 2
+
+@public
+record Point:
+    x: int
+    y: int

--- a/tests/spec/qualified_import/usermoddir/part_a.ry
+++ b/tests/spec/qualified_import/usermoddir/part_a.ry
@@ -1,0 +1,7 @@
+@public
+fn dirGreet() -> int:
+    return 11
+
+@public
+@const
+DIR_ANSWER: int = 88

--- a/tests/spec/qualified_import/usermoddir/part_b.ry
+++ b/tests/spec/qualified_import/usermoddir/part_b.ry
@@ -1,0 +1,3 @@
+@public
+fn dirDouble(n: int) -> int:
+    return n * 2

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1929,104 +1929,57 @@ TEST_F(ImportTest, CodeGenReceivesNamedSubsetTestingIntrinsics) {
     EXPECT_EQ(intrinsics, expected);
 }
 
-// Qualified import — user-defined module call rejection (#1723).
-// Triggers the codegen branch in `emitCall` that rejects qualified calls
-// on user-defined modules; covered as a v0.0.23 limitation pointing users
-// at the selective-import form.
-TEST_F(ImportTest, QualifiedImportUserDefinedModuleCallRejected) {
+// Qualified import — user-defined module call works (#1730).
+// Previously rejected as a v0.0.23 limitation; with the namespace-isolation
+// rewrite (#1730), `import usermod` + `usermod.greet()` resolves through the
+// per-module namespace bucket on CodeGen.
+TEST_F(ImportTest, QualifiedImportUserDefinedModuleCallWorks) {
     writeFile("mymod.ry",
         "fn greet() -> int:\n"
         "    return 7\n");
-    try {
-        runWithImports(
-            "import mymod\n"
-            "print(mymod.greet())\n");
-        FAIL() << "Expected exception";
-    } catch (const std::runtime_error &e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("qualified call to user-defined module 'mymod'"),
-                  std::string::npos)
-            << "got: " << msg;
-        EXPECT_NE(msg.find("from mymod import greet"), std::string::npos)
-            << "got: " << msg;
-    }
+    EXPECT_EQ(runWithImports(
+        "import mymod\n"
+        "print(mymod.greet())\n"), "7\n");
 }
 
-// Qualified import — user-defined module field access rejection (#1723).
-// Triggers the codegen branch in field-access lowering that rejects
-// qualified const access on user-defined modules.
-TEST_F(ImportTest, QualifiedImportUserDefinedModuleFieldRejected) {
+// Qualified import — user-defined module field access works (#1730).
+// `@const` declarations now route through `ModuleNamespaceInfo::consts`
+// when emitted under `NamespaceEmitScope`; qualified field-access reads
+// from that bucket via the namespace `consts` map.
+TEST_F(ImportTest, QualifiedImportUserDefinedModuleFieldWorks) {
     writeFile("constmod2.ry",
         "@directive(target=[\"statement\"])\n"
         "fn const()\n"
         "@const\n"
         "ANSWER: int = 42\n");
-    try {
-        runWithImports(
-            "import constmod2\n"
-            "print(constmod2.ANSWER)\n");
-        FAIL() << "Expected exception";
-    } catch (const std::runtime_error &e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("qualified field access on user-defined module 'constmod2'"),
-                  std::string::npos)
-            << "got: " << msg;
-        EXPECT_NE(msg.find("from constmod2 import ANSWER"), std::string::npos)
-            << "got: " << msg;
-    }
+    EXPECT_EQ(runWithImports(
+        "import constmod2\n"
+        "print(constmod2.ANSWER)\n"), "42\n");
 }
 
-// Qualified import alias — user-defined module rejection error must quote the
-// ORIGINAL module name (the actual file basename), not the alias (#1724).
-// Without `ModuleNamespaceInfo::original_name` tracking the redirect text
-// would suggest `from m import greet`, which doesn't resolve because the file
-// is `mymod.ry`.
-TEST_F(ImportTest, QualifiedImportAliasUserDefinedModuleErrorUsesOriginalName) {
+// Qualified import alias — user-defined module call works with alias (#1730).
+// `import mymod_alias_call as m` registers the module under effective alias `m`
+// while preserving `original_name = "mymod_alias_call"`; the qualified call
+// `m.greet()` dispatches through the namespace bucket keyed by `m`.
+TEST_F(ImportTest, QualifiedImportAliasUserDefinedModuleCallWorks) {
     writeFile("mymod_alias_call.ry",
         "fn greet() -> int:\n"
         "    return 7\n");
-    try {
-        runWithImports(
-            "import mymod_alias_call as m\n"
-            "print(m.greet())\n");
-        FAIL() << "Expected exception";
-    } catch (const std::runtime_error &e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("qualified call to user-defined module 'm'"),
-                  std::string::npos)
-            << "got: " << msg;
-        // The redirect must point at the original module name, not the alias.
-        EXPECT_NE(msg.find("from mymod_alias_call import greet"),
-                  std::string::npos)
-            << "redirect must use original module name, not alias: " << msg;
-        EXPECT_EQ(msg.find("from m import greet"), std::string::npos)
-            << "redirect must NOT use the alias as the module name: " << msg;
-    }
+    EXPECT_EQ(runWithImports(
+        "import mymod_alias_call as m\n"
+        "print(m.greet())\n"), "7\n");
 }
 
-// Qualified import alias — field-access redirect mirrors the call-site fix.
-TEST_F(ImportTest, QualifiedImportAliasUserDefinedFieldErrorUsesOriginalName) {
+// Qualified import alias — user-defined module field access works with alias (#1730).
+TEST_F(ImportTest, QualifiedImportAliasUserDefinedFieldWorks) {
     writeFile("mymod_alias_field.ry",
         "@directive(target=[\"statement\"])\n"
         "fn const()\n"
         "@const\n"
         "ANSWER: int = 42\n");
-    try {
-        runWithImports(
-            "import mymod_alias_field as m\n"
-            "print(m.ANSWER)\n");
-        FAIL() << "Expected exception";
-    } catch (const std::runtime_error &e) {
-        std::string msg = e.what();
-        EXPECT_NE(msg.find("qualified field access on user-defined module 'm'"),
-                  std::string::npos)
-            << "got: " << msg;
-        EXPECT_NE(msg.find("from mymod_alias_field import ANSWER"),
-                  std::string::npos)
-            << "redirect must use original module name, not alias: " << msg;
-        EXPECT_EQ(msg.find("from m import ANSWER"), std::string::npos)
-            << "redirect must NOT use the alias as the module name: " << msg;
-    }
+    EXPECT_EQ(runWithImports(
+        "import mymod_alias_field as m\n"
+        "print(m.ANSWER)\n"), "42\n");
 }
 
 // Qualified import — user-defined module must NOT leak bare names into caller (#1723, CR review).
@@ -2048,6 +2001,125 @@ TEST_F(ImportTest, QualifiedImportUserDefinedDoesNotLeakBareNames) {
         EXPECT_NE(msg.find("undefined function: greet"), std::string::npos)
             << "got: " << msg;
     }
+}
+
+// Qualified import — user-defined module `@const` must NOT leak bare names
+// into caller (#1730 AC4). Mirrors `QualifiedImportUserDefinedDoesNotLeakBareNames`
+// but for `@const` declarations. `AssignStmt` is the only namespace-routed kind
+// that flows through `emitVarDecl` (which adds to `scope_stack_[0]` unconditionally);
+// without the scope_stack_[0]/immutable_scope_stack_[0] cleanup after
+// `registerModuleGlobal`, a bare reference to the namespaced const would resolve
+// via the top-level scope alloca and break AC4 isolation.
+TEST_F(ImportTest, QualifiedImportUserDefinedDoesNotLeakBareConst) {
+    writeFile("leakconst.ry",
+        "@directive(target=[\"statement\"])\n"
+        "fn const()\n"
+        "@const\n"
+        "ANSWER: int = 42\n");
+    try {
+        runWithImports(
+            "import leakconst\n"
+            "print(ANSWER)\n");
+        FAIL() << "Expected exception (bare 'ANSWER' must not resolve through qualified import)";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("ANSWER"), std::string::npos) << "got: " << msg;
+    }
+}
+
+// Qualified import — generic functions in user-defined modules are explicitly
+// rejected with an actionable error (#1730 scope-out).
+// Generic fn declarations route through `generic_fn_templates_` flat-table,
+// which the per-module namespace bucket cannot intercept; reject under
+// `NamespaceEmitScope` with a redirect to the `from <mod> import <fn>` form.
+TEST_F(ImportTest, QualifiedImportUserDefinedGenericFnRejected) {
+    writeFile("genmod.ry",
+        "fn id<T>(x: T) -> T:\n"
+        "    return x\n");
+    try {
+        runWithImports(
+            "import genmod\n"
+            "print(genmod.id(7))\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("generic functions in qualified-imported user-defined modules"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// Qualified import — `enum` declarations in user-defined modules are
+// explicitly rejected (#1730 scope-out). Enums register via the flat
+// `enum_types_` table; the per-module namespace bucket has no slot for
+// them. Reject under `NamespaceEmitScope` with an actionable error.
+TEST_F(ImportTest, QualifiedImportUserDefinedEnumRejected) {
+    writeFile("enummod.ry",
+        "enum Color:\n"
+        "    Red\n"
+        "    Green\n"
+        "    Blue\n");
+    try {
+        runWithImports(
+            "import enummod\n"
+            "print(0)\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("enum declarations in qualified-imported user-defined modules"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// Qualified import — `type` aliases in user-defined modules are
+// explicitly rejected (#1730 scope-out). Type aliases register via the
+// flat `type_aliases_` table; the per-module namespace bucket has no slot
+// for them. Reject under `NamespaceEmitScope` with an actionable error.
+TEST_F(ImportTest, QualifiedImportUserDefinedTypeAliasRejected) {
+    writeFile("aliasmod.ry",
+        "type Age = int\n");
+    try {
+        runWithImports(
+            "import aliasmod\n"
+            "print(0)\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("type alias declarations in qualified-imported user-defined modules"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// Qualified import — `import usermod` followed by `from usermod import foo`
+// must reuse the cached AST so the selective form sees `foo` (AC3 from #1730).
+TEST_F(ImportTest, QualifiedImportThenSelectiveImportReusesCache) {
+    writeFile("cachemod.ry",
+        "fn greet() -> int:\n"
+        "    return 42\n");
+    EXPECT_EQ(runWithImports(
+        "import cachemod\n"
+        "from cachemod import greet\n"
+        "print(greet())\n"
+        "print(cachemod.greet())\n"), "42\n42\n");
+}
+
+// Qualified import — record constructor in user-defined module works (#1730).
+// `usermod.MyRecord(...)` resolves through `ModuleNamespaceInfo::records`
+// when `NamespaceEmitScope` reroutes record registration during import emission.
+// Note: qualified type annotations (`p: recmod.Point = ...`) are not yet
+// supported by the parser; rely on inference for the let binding.
+TEST_F(ImportTest, QualifiedImportUserDefinedRecordConstructor) {
+    writeFile("recmod.ry",
+        "record Point:\n"
+        "    x: int\n"
+        "    y: int\n");
+    EXPECT_EQ(runWithImports(
+        "import recmod\n"
+        "p = recmod.Point(3, 4)\n"
+        "print(p.x)\n"
+        "print(p.y)\n"), "3\n4\n");
 }
 
 // ===== type alias =====

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -989,8 +989,8 @@ TEST(ParserTest, ImportBracedRejectsBadAlias) {
 TEST(ParserTest, QualifiedImportSingleModule) {
     Program prog = parseStr("import math");
     ASSERT_EQ(prog.size(), 1u);
-    ASSERT_TRUE(std::holds_alternative<QualifiedImportStmt>(prog[0]));
-    const auto &qi = std::get<QualifiedImportStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<QualifiedImportStmt>>(prog[0]));
+    const auto &qi = *std::get<std::unique_ptr<QualifiedImportStmt>>(prog[0]);
     EXPECT_EQ(qi.module_name, "math");
     EXPECT_FALSE(qi.alias.has_value());
 }
@@ -1035,8 +1035,8 @@ TEST(ParserTest, QualifiedImportAsRegistersAlias) {
     // requires flipping (not deleting) existing EXPECT_THROW tests".
     Program prog = parseStr("import math as m");
     ASSERT_EQ(prog.size(), 1u);
-    ASSERT_TRUE(std::holds_alternative<QualifiedImportStmt>(prog[0]));
-    const auto &qi = std::get<QualifiedImportStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<QualifiedImportStmt>>(prog[0]));
+    const auto &qi = *std::get<std::unique_ptr<QualifiedImportStmt>>(prog[0]);
     EXPECT_EQ(qi.module_name, "math");
     ASSERT_TRUE(qi.alias.has_value());
     EXPECT_EQ(*qi.alias, "m");
@@ -1086,7 +1086,7 @@ TEST(ParserTest, QualifiedImportSelfAliasIsAccepted) {
     // to bare `import math` — the effective name is 'math' in both cases.
     Program prog = parseStr("import math as math");
     ASSERT_EQ(prog.size(), 1u);
-    const auto &qi = std::get<QualifiedImportStmt>(prog[0]);
+    const auto &qi = *std::get<std::unique_ptr<QualifiedImportStmt>>(prog[0]);
     EXPECT_EQ(qi.module_name, "math");
     ASSERT_TRUE(qi.alias.has_value());
     EXPECT_EQ(*qi.alias, "math");
@@ -1173,7 +1173,7 @@ TEST(ParserTest, QualifiedImportCoexistsWithSelectiveImport) {
     // file. The parser must not reject the combination.
     Program prog = parseStr("import math\nfrom math import PI");
     ASSERT_EQ(prog.size(), 2u);
-    ASSERT_TRUE(std::holds_alternative<QualifiedImportStmt>(prog[0]));
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<QualifiedImportStmt>>(prog[0]));
     ASSERT_TRUE(std::holds_alternative<ImportStmt>(prog[1]));
 }
 


### PR DESCRIPTION
## Summary

- Replaces the "throwaway Program" carve-out in `ModuleLoader` with a per-module namespace bucket (`ModuleNamespaceInfo`) on `CodeGen`, enabling `import usermod` + `usermod.foo()` / `usermod.PI` / `usermod.MyRecord(...)`.
- User-defined module declarations flow into `QualifiedImportStmt::definitions` and emit under a `NamespaceEmitScope` RAII guard that reroutes `FnStmt` / `RecordStmt` / `AssignStmt(@const)` registration into per-kind buckets keyed by effective alias. Qualified lookup consults these buckets first; bare-name leak isolation (`greet()` after `import usermod` → `undefined function`) is preserved.
- Generic functions, `enum` declarations, and `type` aliases inside a qualified-imported user-defined module are rejected at codegen with a diagnostic suggesting `from <module> import ...` (Phase 2).
- Stdlib qualified import path (`import math` + `math.sqrt(2.0)`) is unchanged.

Closes #1730.

## Test plan

- [x] `./build/ry_tests` (2283 PASS)
- [x] `./build/ry test -p` (184 files, 0 failures)
- [x] ASan + UBSan: `./build-asan/ry_tests` + `./build-asan/ry test -p` (PASS)
- [x] TSan: `./build-tsan/ry_tests` + `./build-tsan/ry test -p` (PASS, no races)
- [x] cppcheck (warning,performance,portability) PASS
- [x] clang-tidy on full `src/` (exit 0, 91 files)
- [x] libFuzzer × 3: `fuzz_parser` 34929 / `fuzz_json` 244663 / `fuzz_utf8` 240910 runs, 60s exit 0
- [x] Skipped §3.6.5 — no tree-sitter grammar changes
- [x] New spec: `tests/spec/qualified_import/qualified_import_user_defined.test.ry` covers AC1 (`usermod.foo()`/`usermod.PI`/`usermod.MyRecord(...)`), AC3 (`import usermod` + `from usermod import foo`), AC4 (bare-name leak rejection)
- [x] Flipped 4 `EXPECT_THROW` tests to `EXPECT_NO_THROW` in `tests/test_codegen_stmt.cpp` (qualified user-defined call/field, with and without alias), and added generic/enum/type-alias rejection tests
- [x] README / `docs/reference/modules.md` constraints table updated
- [x] CHANGELOG fragment: `changelog.d/1730-qualified-import-user-defined.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Qualified imports now work for user-defined modules: dot-access to functions, constants, and record constructors (including directory modules and aliases).

* **Bug Fixes**
  * Qualified imports no longer leak bare names or constants into the importer’s scope.
  * Mixed use of `import <mod>` and `from <mod> import ...` reuses parsed module data where possible.

* **Known Limitations**
  * Generic functions, enums, and type aliases cannot be accessed via qualified imports; use `from <module> import ...`.

* **Docs**
  * Reference updated to reflect expanded qualified-import behavior for user modules.

* **Tests**
  * New and updated tests covering user-defined qualified imports and mixed import scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1736)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->