### PR TITLE
chore(ci): narrow scan-build scope to ry target on PR (#1738)

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -416,6 +416,65 @@ CI invocations.
 and confirm `--use-analyzer` accompanies every invocation. In CI logs,
 the `Use of uninitialized value $Clang` warning must be absent.
 
+### scan-build: `--target ry` (fast) on pull_request, full `all` target on push to main
+
+**Source**: #1738 (2026-05-14, implementation)
+**Tags**: ci, scan-build, static-analysis, performance, target
+
+**Context**: `scan-build` performs path-sensitive symbolic execution
+over every translation unit it sees. Running it across the default
+`all` target builds and analyses `ry_tests` (~45 TU), `ry_<pkg>`
+native shared libraries (~15 TU), and fuzz targets in addition to the
+production compiler/runtime (`src/main.cpp` + `ry_lib`, ~76 TU).
+Including the test and plugin TUs dominates CI time without adding
+meaningful coverage on the production path that releases ship.
+
+**Rule**: In `.github/workflows/ci.yml`, the `scan-build` job's
+build-and-analyse step must select the analysis scope from
+`github.event_name`:
+
+- `pull_request`: pass `--target ry --parallel` to the wrapped
+  `cmake --build build` so only `ry` (i.e. `src/main.cpp` + `ry_lib`)
+  is analysed. PR feedback stays fast.
+- `push` (to `main`): pass `--parallel` but **no** `--target`, so the
+  default `all` target is analysed. Mainline keeps the wider coverage
+  including tests, native plugins, and fuzz harnesses.
+
+The canonical form is a single step using a ternary expression:
+
+```yaml
+cmake --build build ${{ github.event_name == 'pull_request' && '--target ry' || '' }} --parallel
+```
+
+Do not invert the mapping (full on PR, fast on main); this would
+defeat the purpose of fast PR feedback and leave mainline with
+narrower coverage.
+
+**How to apply**:
+
+- When editing the `scan-build` step, keep the existing
+  `--use-analyzer=/usr/local/llvm/bin/clang` flag (see sibling rule
+  "scan-build: pass --use-analyzer=... explicitly"). Only the wrapped
+  `cmake --build` invocation is varied.
+- Both events stay `continue-on-error: true` (warn-only) until the
+  existing findings backlog is triaged. Do not flip required-ness in
+  the same change.
+- Local documentation in `.claude/skills/static-analysis-tools/SKILL.md`
+  and `.claude/skills/pre-commit-checklist/SKILL.md` mirrors the same
+  fast / full split so contributors can reproduce either mode locally.
+
+**How to verify**:
+
+- `grep -n 'cmake --build build' .github/workflows/ci.yml` shows the
+  `scan-build` step using the `github.event_name == 'pull_request'`
+  ternary; no other CI step should accidentally adopt the same
+  ternary without intent.
+- On a PR CI run, the `scan-build` log shows `Building target: ry`
+  (not the full target list) and finishes notably faster than the
+  previous all-target run.
+- On a push-to-main CI run, the same step shows the full target list
+  being built.
+
 ### `actions/download-artifact@v4` `pattern:` is a glob — beware prefix collisions across matrix dimensions
 
 **Source**: #1505 manifest job failure (2026-05-02)

--- a/.claude/skills/ci-investigate/SKILL.md
+++ b/.claude/skills/ci-investigate/SKILL.md
@@ -142,7 +142,8 @@ Map the CI job name to its local reproduction command and run it:
 | `test (tsan)` / `tsan` | `cmake --preset tsan && cmake --build build-tsan && TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests` |
 | `clang-tidy` | `find src -name '*.cpp' \| xargs clang-tidy -p build --quiet` |
 | `cppcheck` / `lint` | `cppcheck --enable=warning,performance,portability --std=c++17 --suppressions-list=.cppcheck-suppressions --inline-suppr -i build -i build-asan -i build-tsan -j "$(nproc)" --quiet src/ include/` |
-| `scan-build` | `scan-build --use-analyzer=/usr/local/llvm/bin/clang --use-cc=/usr/local/llvm/bin/clang --use-c++=/usr/local/llvm/bin/clang++ cmake --build build` |
+| `scan-build` (fast, PR) | `scan-build --use-analyzer=/usr/local/llvm/bin/clang --use-cc=/usr/local/llvm/bin/clang --use-c++=/usr/local/llvm/bin/clang++ cmake --build build --target ry --parallel` |
+| `scan-build` (full, push to main) | `scan-build --use-analyzer=/usr/local/llvm/bin/clang --use-cc=/usr/local/llvm/bin/clang --use-c++=/usr/local/llvm/bin/clang++ cmake --build build --parallel` |
 
 **Known CI-only failure patterns (do not misclassify as PR-caused):**
 

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -209,7 +209,7 @@ cppcheck --enable=warning,performance,portability --std=c++17 --error-exitcode=1
 
 CI は `continue-on-error: true` で warn-only 運用中。ローカルでも警告即修正は不要だが、新規 null-dereference / use-after-free / division-by-zero が検出された場合は同 PR で対処することを強く推奨する。
 
-scan-build は Homebrew LLVM 21 に同梱されているが PATH には入らない。フルパス `/opt/homebrew/opt/llvm@21/bin/scan-build` で呼び出す:
+CI は event ごとに分析スコープを切り替える (#1738): PR では `--target ry`、push-to-main では全 target。ローカルでも同じ使い分けが可能。scan-build は Homebrew LLVM 21 に同梱されているが PATH には入らない。フルパス `/opt/homebrew/opt/llvm@21/bin/scan-build` で呼び出す。configure ステップは fast / full とも共通:
 
 ```bash
 /opt/homebrew/opt/llvm@21/bin/scan-build \
@@ -217,12 +217,26 @@ scan-build は Homebrew LLVM 21 に同梱されているが PATH には入らな
     --use-cc=/opt/homebrew/opt/llvm@21/bin/clang \
     --use-c++=/opt/homebrew/opt/llvm@21/bin/clang++ \
     cmake --preset default
+```
 
+build + analyze — **高速確認のみ** (PR 相当、`ry` target ≒ ~76 TU):
+
+```bash
 /opt/homebrew/opt/llvm@21/bin/scan-build \
     --use-analyzer=/opt/homebrew/opt/llvm@21/bin/clang \
     --use-cc=/opt/homebrew/opt/llvm@21/bin/clang \
     --use-c++=/opt/homebrew/opt/llvm@21/bin/clang++ \
-    -o /tmp/scan-build-report --status-bugs cmake --build build
+    -o /tmp/scan-build-report --status-bugs cmake --build build --target ry --parallel
+```
+
+build + analyze — **deep verification (推奨)** (push-to-main 相当、全 target):
+
+```bash
+/opt/homebrew/opt/llvm@21/bin/scan-build \
+    --use-analyzer=/opt/homebrew/opt/llvm@21/bin/clang \
+    --use-cc=/opt/homebrew/opt/llvm@21/bin/clang \
+    --use-c++=/opt/homebrew/opt/llvm@21/bin/clang++ \
+    -o /tmp/scan-build-report --status-bugs cmake --build build --parallel
 ```
 
 scan-build はビルドをラップするため `build/` の状態が変わる場合がある。以降のステップでビルドが必要なら §3 のコマンドで再ビルドする。

--- a/.claude/skills/static-analysis-tools/SKILL.md
+++ b/.claude/skills/static-analysis-tools/SKILL.md
@@ -63,9 +63,15 @@ Reference for Clang-Tidy, Cppcheck, and Clang Static Analyzer (scan-build) confi
 
 CI の `scan-build` ジョブがシンボリック実行ベースのパス感度解析を実行する。Clang-Tidy / Cppcheck では検出しづらい null 参照・use-after-free・memory leak・未初期化変数・dead store を検出する。
 
+CI は event に応じて分析スコープを切り替える (#1738):
+- **pull request**: `--target ry --parallel` で fast scan (`src/main.cpp` + `ry_lib` ≒ ~76 TU)。test と native plugin の TU は除外し、PR フィードバックを高速化する。
+- **push to main**: `--parallel` 付きの full scan (all target)。test / native plugin / fuzz も含めた広いカバレッジを維持する。
+
+両 event とも `continue-on-error: true` (warn-only) 運用中。
+
 - `scan-build` は CI コンテナ (`ghcr.io/<owner>/ry-ci:llvm-21`) の LLVM 21 source build に同梱されており、`/usr/local/llvm/bin/scan-build` から利用可能。ローカル Linux ホストでは `sudo apt-get install clang-tools-21`、macOS では `brew install llvm@21` で入手する
 - `compile_commands.json` は使用しない（scan-build がビルドをラップして解析する）
-- ローカル実行:
+- ローカル実行 — fast scan (`ry` target のみ、PR と同等):
   ```bash
   scan-build --use-analyzer=/usr/local/llvm/bin/clang \
              --use-cc=/usr/local/llvm/bin/clang \
@@ -76,8 +82,17 @@ CI の `scan-build` ジョブがシンボリック実行ベースのパス感度
              --use-c++=/usr/local/llvm/bin/clang++ \
              -o /tmp/scan-build-report \
              --status-bugs \
-             cmake --build build
-  # HTML レポートが /tmp/scan-build-report/<timestamp>/index.html に生成される
+             cmake --build build --target ry --parallel
   ```
+- ローカル実行 — full scan (push-to-main と同等の広いカバレッジ):
+  ```bash
+  scan-build --use-analyzer=/usr/local/llvm/bin/clang \
+             --use-cc=/usr/local/llvm/bin/clang \
+             --use-c++=/usr/local/llvm/bin/clang++ \
+             -o /tmp/scan-build-report \
+             --status-bugs \
+             cmake --build build --parallel
+  ```
+  HTML レポートが `/tmp/scan-build-report/<timestamp>/index.html` に生成される
 - false positive の抑制は `#ifndef __clang_analyzer__` でインライン抑制する（clang-tidy の `// NOLINT` と同様の粒度）
-- 新規コードは scan-build 警告ゼロを維持すること
+- CI は warn-only 運用 (`continue-on-error: true`)。新規 null-dereference / use-after-free / division-by-zero などが検出されたら同 PR で対処することを強く推奨する

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,9 @@ jobs:
       - name: Build + Analyze
         # warn-only: triage existing findings before making this required.
         # Once findings are resolved, remove continue-on-error.
+        # PR runs analyse only the `ry` target (~76 TU) for faster feedback;
+        # push-to-main keeps full all-target coverage. See
+        # .claude/rules/ci-workflows.md "scan-build: --target ry on PR ...".
         continue-on-error: true
         run: |
           scan-build \
@@ -142,7 +145,7 @@ jobs:
             --use-c++=/usr/local/llvm/bin/clang++ \
             -o scan-build-report \
             --status-bugs \
-            cmake --build build
+            cmake --build build ${{ github.event_name == 'pull_request' && '--target ry' || '' }} --parallel
       - name: Upload scan-build report
         if: always()
         uses: actions/upload-artifact@v4

--- a/changelog.d/1738-scan-build-narrow-scope.md
+++ b/changelog.d/1738-scan-build-narrow-scope.md
@@ -1,0 +1,8 @@
+### Changed
+
+- CI `scan-build` job now analyses only the `ry` target on pull requests
+  for faster feedback (~76 TU instead of the default `all` target,
+  which previously also dragged in `ry_tests`, `ry_<pkg>` native shared
+  libraries, and fuzz harnesses); the full all-target scan is retained
+  for `push` to `main` so mainline keeps the wider coverage. Both
+  invocations now pass `--parallel`. (#1738)


### PR DESCRIPTION
## Summary

CI `scan-build` job analyses only the `ry` target on pull requests for faster feedback (~76 TU instead of the default `all` target, which previously also dragged in `ry_tests`, `ry_<pkg>` native shared libraries, and fuzz harnesses). The full all-target scan is retained for `push` to `main` so mainline keeps the wider coverage. Both invocations now pass `--parallel` explicitly.

- `.github/workflows/ci.yml`: single-step ternary on `github.event_name` selects `--target ry` for PR, full target for push-to-main.
- `.claude/skills/static-analysis-tools/SKILL.md` / `.claude/skills/pre-commit-checklist/SKILL.md` / `.claude/skills/ci-investigate/SKILL.md`: mirror the fast / full split so local reproduction matches CI behavior on either event.
- `.claude/rules/ci-workflows.md`: new path-scoped rule documents the canonical ternary and warns against inverting the mapping.
- `changelog.d/1738-scan-build-narrow-scope.md`: Changed entry.

`continue-on-error: true` (warn-only) is preserved on both events — flipping required-ness is intentionally out of scope until the existing findings backlog is triaged.

Closes #1738

## Test plan

- [ ] CI `scan-build` job on this PR builds only the `ry` target (look for `Building target: ry` and notable runtime drop).
- [ ] Confirm `--parallel` is reflected in the scan-build log on both events.
- [ ] After merge, the first `push` to `main` runs scan-build over the full target list (test / native plugin / fuzz harnesses included).
- [ ] Local fast/full reproduction commands from `static-analysis-tools` / `pre-commit-checklist` skills both succeed.
- [ ] Before/after CI runtime measurement recorded as a follow-up comment on this PR once the first CI run completes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Optimized CI pipeline for pull requests to provide faster feedback by narrowing the static analysis scope, while preserving comprehensive coverage for the main branch.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1739)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->