### PR TITLE
chore(ci): narrow CodeQL c-cpp PR scope to ry target (#1740)

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -416,29 +416,31 @@ CI invocations.
 and confirm `--use-analyzer` accompanies every invocation. In CI logs,
 the `Use of uninitialized value $Clang` warning must be absent.
 
-### scan-build: `--target ry` (fast) on pull_request, full `all` target on push to main
+### Static-analysis PR scope: `--target ry` on PR, full target on push to main
 
-**Source**: #1738 (2026-05-14, implementation)
-**Tags**: ci, scan-build, static-analysis, performance, target
+**Source**: #1738 (2026-05-14, scan-build), #1740 (2026-05-15, CodeQL)
+**Tags**: ci, scan-build, codeql, static-analysis, performance, target
 
-**Context**: `scan-build` performs path-sensitive symbolic execution
-over every translation unit it sees. Running it across the default
-`all` target builds and analyses `ry_tests` (~45 TU), `ry_<pkg>`
-native shared libraries (~15 TU), and fuzz targets in addition to the
-production compiler/runtime (`src/main.cpp` + `ry_lib`, ~76 TU).
-Including the test and plugin TUs dominates CI time without adding
-meaningful coverage on the production path that releases ship.
+**Context**: Whole-TU static analysers (`scan-build`'s path-sensitive
+symbolic execution, CodeQL's extraction + query evaluation) scale with
+the number of translation units they see. The default `all` target
+pulls in `ry_tests` (~45 TU), `ry_<pkg>` native shared libraries
+(~15 TU), and fuzz targets in addition to the production
+compiler/runtime (`src/main.cpp` + `ry_lib`, ~76 TU). Including the
+test and plugin TUs dominates CI time without adding meaningful
+coverage on the production path that releases ship.
 
-**Rule**: In `.github/workflows/ci.yml`, the `scan-build` job's
-build-and-analyse step must select the analysis scope from
+**Rule**: In every CI workflow whose job wraps `cmake --build build`
+under a static-analysis tool, select the analysis scope from
 `github.event_name`:
 
-- `pull_request`: pass `--target ry --parallel` to the wrapped
-  `cmake --build build` so only `ry` (i.e. `src/main.cpp` + `ry_lib`)
-  is analysed. PR feedback stays fast.
+- `pull_request`: pass `--target ry --parallel` so only `ry` (i.e.
+  `src/main.cpp` + `ry_lib`) is built and analysed. PR feedback stays
+  fast.
 - `push` (to `main`): pass `--parallel` but **no** `--target`, so the
-  default `all` target is analysed. Mainline keeps the wider coverage
-  including tests, native plugins, and fuzz harnesses.
+  default target is analysed. Mainline keeps the wider coverage
+  including tests, native plugins, and fuzz harnesses, which feeds the
+  Code Scanning dashboard and the release `codeql-gate`.
 
 The canonical form is a single step using a ternary expression:
 
@@ -446,34 +448,56 @@ The canonical form is a single step using a ternary expression:
 cmake --build build ${{ github.event_name == 'pull_request' && '--target ry' || '' }} --parallel
 ```
 
+Concrete invocations using this pattern today:
+
+- `.github/workflows/ci.yml` `scan-build` job, `Build + Analyze` step
+  (#1738) — wrapped under `scan-build ... cmake --build build ...`.
+- `.github/workflows/codeql.yml` c-cpp matrix `Build` step (#1740) —
+  bare `cmake --build build ...` driven by CodeQL's manual build mode.
+
 Do not invert the mapping (full on PR, fast on main); this would
 defeat the purpose of fast PR feedback and leave mainline with
-narrower coverage.
+narrower coverage. Do not narrow the `push` branch on either tool —
+both the scan-build report and the CodeQL Code Scanning dashboard
+depend on the wider coverage being produced by mainline runs.
 
 **How to apply**:
 
-- When editing the `scan-build` step, keep the existing
+- When editing the `scan-build` step in `ci.yml`, keep the existing
   `--use-analyzer=/usr/local/llvm/bin/clang` flag (see sibling rule
   "scan-build: pass --use-analyzer=... explicitly"). Only the wrapped
   `cmake --build` invocation is varied.
-- Both events stay `continue-on-error: true` (warn-only) until the
-  existing findings backlog is triaged. Do not flip required-ness in
-  the same change.
+- For CodeQL, the change is confined to the c-cpp matrix entry
+  (`build-mode: manual`); the `actions` matrix entry uses
+  `build-mode: none` and runs no manual build, so the ternary does not
+  apply there.
+- Both `scan-build` (warn-only, `continue-on-error: true` until the
+  findings backlog is triaged) and CodeQL (no `continue-on-error`,
+  fails the workflow on findings) keep their existing status semantics
+  — do not flip them in the same change.
 - Local documentation in `.claude/skills/static-analysis-tools/SKILL.md`
   and `.claude/skills/pre-commit-checklist/SKILL.md` mirrors the same
-  fast / full split so contributors can reproduce either mode locally.
+  fast / full split for `scan-build` so contributors can reproduce
+  either mode locally. CodeQL has no local-execution skill mirror
+  because contributors do not run CodeQL locally — the GitHub
+  `pull_request` event is the only entry point.
+- The inline workflow comment that cites this rule (in `ci.yml` and
+  `codeql.yml` Build steps) references the heading verbatim. If the
+  heading is renamed again, update both call sites in the same commit
+  to keep grep-based verification truthful.
 
 **How to verify**:
 
-- `grep -n 'cmake --build build' .github/workflows/ci.yml` shows the
-  `scan-build` step using the `github.event_name == 'pull_request'`
+- `grep -nE 'cmake --build build .*github\.event_name' .github/workflows/*.yml`
+  shows both the `scan-build` step in `ci.yml` and the c-cpp Build
+  step in `codeql.yml` using the `github.event_name == 'pull_request'`
   ternary; no other CI step should accidentally adopt the same
   ternary without intent.
-- On a PR CI run, the `scan-build` log shows `Building target: ry`
-  (not the full target list) and finishes notably faster than the
-  previous all-target run.
-- On a push-to-main CI run, the same step shows the full target list
-  being built.
+- On a PR CI run, both the `scan-build` log and the CodeQL c-cpp
+  Build log show only the `ry` target being built (not the full target
+  list) and finish notably faster than the previous all-target runs.
+- On a push-to-main CI run, both steps show the full target list being
+  built.
 
 ### `actions/download-artifact@v4` `pattern:` is a glob — beware prefix collisions across matrix dimensions
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         # Once findings are resolved, remove continue-on-error.
         # PR runs analyse only the `ry` target (~76 TU) for faster feedback;
         # push-to-main keeps full all-target coverage. See
-        # .claude/rules/ci-workflows.md "scan-build: --target ry on PR ...".
+        # .claude/rules/ci-workflows.md "Static-analysis PR scope: --target ry on PR ...".
         continue-on-error: true
         run: |
           scan-build \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,9 +79,12 @@ jobs:
     - name: Build
       if: matrix.build-mode == 'manual'
       shell: bash
+      # PR runs analyse only the `ry` target (~76 TU) for faster feedback;
+      # push-to-main keeps full default-target coverage. See
+      # .claude/rules/ci-workflows.md "Static-analysis PR scope: --target ry on PR ...".
       run: |
         cmake --preset default
-        cmake --build build
+        cmake --build build ${{ github.event_name == 'pull_request' && '--target ry' || '' }} --parallel
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4

--- a/changelog.d/1740-codeql-narrow-scope.md
+++ b/changelog.d/1740-codeql-narrow-scope.md
@@ -1,0 +1,10 @@
+### Changed
+
+- CodeQL Advanced workflow's c-cpp matrix Build step now compiles only
+  the `ry` target on pull requests for faster feedback (~76 TU instead
+  of the default target, which previously also dragged in `ry_tests`,
+  `ry_<pkg>` native shared libraries, and fuzz harnesses); the full
+  default-target build is retained for `push` to `main` and
+  `workflow_dispatch` so the Code Scanning dashboard and the release
+  `codeql-gate` keep the wider coverage. The `cmake --build` invocation
+  now also passes `--parallel`. (#1740)


### PR DESCRIPTION
## Summary

Narrows the CodeQL Advanced c-cpp matrix `Build` step to compile only the `ry` target on `pull_request`, mirroring the canonical "fast PR / full main" idiom established for `scan-build` in #1738. Push to `main` and `workflow_dispatch` keep the full default-target build so the Code Scanning dashboard and the release `codeql-gate` continue to receive wider-coverage analyses. The wrapped `cmake --build` invocation also gains `--parallel`.

Closes #1740.

### Changes

- **`.github/workflows/codeql.yml`** — c-cpp `Build` step: `cmake --build build` → `cmake --build build ${{ github.event_name == 'pull_request' && '--target ry' || '' }} --parallel`, with a 3-line comment citing the rule heading.
- **`.claude/rules/ci-workflows.md`** — generalised the existing rule heading from "scan-build: `--target ry` (fast) on pull_request, full `all` target on push to main" to "Static-analysis PR scope: `--target ry` on PR, full target on push to main"; rewritten body to cover both scan-build and CodeQL as concrete invocations of the same pattern. Status semantics line softened from "CodeQL (always required)" to "CodeQL (no \`continue-on-error\`, fails the workflow on findings)" — `main` is not branch-protected, so "always required" was inaccurate.
- **`.github/workflows/ci.yml`** — string-coupling fix: scan-build step's inline comment quoted the old rule heading verbatim and now references the generalised heading.
- **`changelog.d/1740-codeql-narrow-scope.md`** — new fragment under `### Changed` mirroring `1738-scan-build-narrow-scope.md` style.

### Out of scope (per user direction)

- AC 4 (`build-mode: none` evaluation for the c-cpp matrix as an alternative to `build-mode: manual`) is intentionally not in this PR, and no follow-up issue is being filed.

### Risks

- Push to main keeps the full default-target build, so the Code Scanning dashboard freshness and release `codeql-gate` semantics are unchanged.
- `workflow_dispatch` falls through the ternary to the full build, which matches the issue's "manual / deep verification" intent.
- The release `codeql-gate` (`release.yml`) only keys on the file path `codeql.yml` and the run's overall conclusion; no step name was renamed.

## Test plan

- [x] `actionlint`-equivalent YAML parse OK for both `codeql.yml` and `ci.yml` (ruby YAML loader)
- [x] `cmake --preset default && cmake --build build --target ry --parallel` succeeds locally against the current tree
- [x] `grep -rn "scan-build: --target ry" .github/workflows/ .claude/` returns zero hits (no stale references to the old heading)
- [x] `grep -nE 'cmake --build build .*github\.event_name' .github/workflows/*.yml` shows both `ci.yml` (scan-build) and `codeql.yml` (c-cpp Build) using the ternary
- [x] `grep -n "codeql.yml" .github/workflows/release.yml` confirms `codeql-gate` queries the workflow file path only — step renames inside `codeql.yml` are safe
- [x] AC 5 (before/after CodeQL c-cpp job runtime, captured from Actions tab):

| Environment | c-cpp `Analyze` job runtime |
|---|---|
| `main` (full default target) — last 3 runs | **~18m 58s** (18m22s / 18m55s / 19m36s) |
| This PR (`--target ry --parallel`) | **9m 40s** |
| **Reduction** | **~49 % (~9 min)** |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CodeQL workflow to narrow build scope on pull requests for faster feedback during code review.
  * Enabled parallel builds in the CodeQL workflow process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1742)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
