### PR TITLE
chore(ci): parallelize clang-tidy and narrow PR scope (#1741)

### DIFF
--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -466,8 +466,10 @@ build *and* the analysis to `ry_lib` + `src/main.cpp`. For clang-tidy,
 `src/*.cpp` (90 files, including TUs not built into `ry_lib` like
 `ry_<pkg>` native libs and fuzz harness sources). The PR-mode wins for
 clang-tidy are therefore (1) skipping the `ry_tests` / native-lib /
-fuzz build cost, and (2) the new `xargs -0 -P "$(nproc)"`
-parallelisation of the analysis step itself.
+fuzz build cost, and (2) the new `xargs -0 -n 1 -P "$(nproc)"`
+parallelisation of the analysis step itself. The `-n 1` is required:
+without it, xargs batches all `.cpp` paths into a single `clang-tidy`
+invocation that processes them sequentially, defeating `-P`.
 
 Do not invert the mapping (full on PR, fast on main); this would
 defeat the purpose of fast PR feedback and leave mainline with
@@ -491,9 +493,10 @@ depend on the wider coverage being produced by mainline runs.
   — do not flip them in the same change.
 - Local documentation in `.claude/skills/static-analysis-tools/SKILL.md`
   and `.claude/skills/pre-commit-checklist/SKILL.md` mirrors the same
-  fast / full split for `scan-build`, and the `xargs -0 -P "$(nproc)"`
-  / `xargs -0 -P "$(sysctl -n hw.ncpu)"` parallel form for clang-tidy,
-  so contributors can reproduce either mode locally. CodeQL has no
+  fast / full split for `scan-build`, and the
+  `xargs -0 -n 1 -P "$(nproc)"` /
+  `xargs -0 -n 1 -P "$(sysctl -n hw.ncpu)"` parallel form for
+  clang-tidy, so contributors can reproduce either mode locally. CodeQL has no
   local-execution skill mirror because contributors do not run CodeQL
   locally — the GitHub `pull_request` event is the only entry point.
 - The inline workflow comment that cites this rule (in `ci.yml`

--- a/.claude/rules/ci-workflows.md
+++ b/.claude/rules/ci-workflows.md
@@ -418,8 +418,8 @@ the `Use of uninitialized value $Clang` warning must be absent.
 
 ### Static-analysis PR scope: `--target ry` on PR, full target on push to main
 
-**Source**: #1738 (2026-05-14, scan-build), #1740 (2026-05-15, CodeQL)
-**Tags**: ci, scan-build, codeql, static-analysis, performance, target
+**Source**: #1738 (2026-05-14, scan-build), #1740 (2026-05-15, CodeQL), #1741 (2026-05-15, clang-tidy)
+**Tags**: ci, scan-build, codeql, clang-tidy, static-analysis, performance, target
 
 **Context**: Whole-TU static analysers (`scan-build`'s path-sensitive
 symbolic execution, CodeQL's extraction + query evaluation) scale with
@@ -454,6 +454,20 @@ Concrete invocations using this pattern today:
   (#1738) — wrapped under `scan-build ... cmake --build build ...`.
 - `.github/workflows/codeql.yml` c-cpp matrix `Build` step (#1740) —
   bare `cmake --build build ...` driven by CodeQL's manual build mode.
+- `.github/workflows/ci.yml` `clang-tidy` job, `Build` step (#1741) —
+  bare `cmake --build build ...`; clang-tidy is then invoked separately
+  on the resulting `compile_commands.json`.
+
+**clang-tidy semantic difference**: for scan-build and CodeQL the
+analyser wraps the build itself, so `--target ry` narrows both the
+build *and* the analysis to `ry_lib` + `src/main.cpp`. For clang-tidy,
+`--target ry` narrows only the `Build` step — the subsequent
+`Run clang-tidy` step still drives `find src -name '*.cpp'` over every
+`src/*.cpp` (90 files, including TUs not built into `ry_lib` like
+`ry_<pkg>` native libs and fuzz harness sources). The PR-mode wins for
+clang-tidy are therefore (1) skipping the `ry_tests` / native-lib /
+fuzz build cost, and (2) the new `xargs -0 -P "$(nproc)"`
+parallelisation of the analysis step itself.
 
 Do not invert the mapping (full on PR, fast on main); this would
 defeat the purpose of fast PR feedback and leave mainline with
@@ -477,27 +491,30 @@ depend on the wider coverage being produced by mainline runs.
   — do not flip them in the same change.
 - Local documentation in `.claude/skills/static-analysis-tools/SKILL.md`
   and `.claude/skills/pre-commit-checklist/SKILL.md` mirrors the same
-  fast / full split for `scan-build` so contributors can reproduce
-  either mode locally. CodeQL has no local-execution skill mirror
-  because contributors do not run CodeQL locally — the GitHub
-  `pull_request` event is the only entry point.
-- The inline workflow comment that cites this rule (in `ci.yml` and
-  `codeql.yml` Build steps) references the heading verbatim. If the
-  heading is renamed again, update both call sites in the same commit
-  to keep grep-based verification truthful.
+  fast / full split for `scan-build`, and the `xargs -0 -P "$(nproc)"`
+  / `xargs -0 -P "$(sysctl -n hw.ncpu)"` parallel form for clang-tidy,
+  so contributors can reproduce either mode locally. CodeQL has no
+  local-execution skill mirror because contributors do not run CodeQL
+  locally — the GitHub `pull_request` event is the only entry point.
+- The inline workflow comment that cites this rule (in `ci.yml`
+  `scan-build` / `clang-tidy` steps and `codeql.yml` Build step)
+  references the heading verbatim. If the heading is renamed again,
+  update all three call sites in the same commit to keep grep-based
+  verification truthful.
 
 **How to verify**:
 
 - `grep -nE 'cmake --build build .*github\.event_name' .github/workflows/*.yml`
-  shows both the `scan-build` step in `ci.yml` and the c-cpp Build
-  step in `codeql.yml` using the `github.event_name == 'pull_request'`
-  ternary; no other CI step should accidentally adopt the same
-  ternary without intent.
-- On a PR CI run, both the `scan-build` log and the CodeQL c-cpp
-  Build log show only the `ry` target being built (not the full target
-  list) and finish notably faster than the previous all-target runs.
-- On a push-to-main CI run, both steps show the full target list being
-  built.
+  shows the three intentional `--target ry` ternary call sites: the
+  `scan-build` and `clang-tidy` steps in `ci.yml`, and the c-cpp Build
+  step in `codeql.yml`. No other CI step should adopt the same ternary
+  without an entry being added to the "Concrete invocations" list above.
+- On a PR CI run, the `scan-build`, `clang-tidy`, and CodeQL c-cpp
+  Build logs all show only the `ry` target being built (not the full
+  target list) and finish notably faster than the previous all-target
+  runs.
+- On a push-to-main CI run, all three steps show the full target list
+  being built.
 
 ### `actions/download-artifact@v4` `pattern:` is a glob — beware prefix collisions across matrix dimensions
 

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -180,7 +180,9 @@ CI の `lint` / `clang-tidy` / `scan-build` ジョブを push 前にローカル
 **clang-tidy** (required):
 
 ```bash
-find src -name '*.cpp' | xargs /opt/homebrew/opt/llvm@21/bin/clang-tidy -p build --quiet
+# macOS: sysctl -n hw.ncpu / Linux: nproc
+find src -name '*.cpp' -print0 \
+  | xargs -0 -P "$(sysctl -n hw.ncpu)" /opt/homebrew/opt/llvm@21/bin/clang-tidy -p build --quiet
 ```
 
 **PCH 互換性**: macOS で `cmake --preset default` (Apple clang が PCH 生成) の後に LLVM clang-tidy を実行すると `PCH file built from a different branch` で失敗することがある。`build/` を削除して LLVM clang を CC/CXX に明示してから再 configure する (`SDKROOT` も必須):

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -181,8 +181,10 @@ CI の `lint` / `clang-tidy` / `scan-build` ジョブを push 前にローカル
 
 ```bash
 # macOS: sysctl -n hw.ncpu / Linux: nproc
+# -n 1 is required — xargs otherwise batches all .cpp paths into a single
+# clang-tidy invocation, defeating the -P parallelism.
 find src -name '*.cpp' -print0 \
-  | xargs -0 -P "$(sysctl -n hw.ncpu)" /opt/homebrew/opt/llvm@21/bin/clang-tidy -p build --quiet
+  | xargs -0 -n 1 -P "$(sysctl -n hw.ncpu)" /opt/homebrew/opt/llvm@21/bin/clang-tidy -p build --quiet
 ```
 
 **PCH 互換性**: macOS で `cmake --preset default` (Apple clang が PCH 生成) の後に LLVM clang-tidy を実行すると `PCH file built from a different branch` で失敗することがある。`build/` を削除して LLVM clang を CC/CXX に明示してから再 configure する (`SDKROOT` も必須):

--- a/.claude/skills/static-analysis-tools/SKILL.md
+++ b/.claude/skills/static-analysis-tools/SKILL.md
@@ -22,7 +22,16 @@ Reference for Clang-Tidy, Cppcheck, and Clang Static Analyzer (scan-build) confi
 - `HeaderFilterRegex` はプロジェクトヘッダ (`include/ry/`) のみに制限
 - LLVM / GoogleTest ヘッダは SYSTEM include のため自動除外
 - `compile_commands.json` は `CMAKE_EXPORT_COMPILE_COMMANDS=ON` で自動生成（`build/` 内）
-- ローカル実行: `find src -name '*.cpp' | xargs clang-tidy -p build --quiet`
+- CI は event に応じて build スコープを切り替える (#1741):
+  - **pull request**: `cmake --build build --target ry --parallel` で fast build (`src/main.cpp` + `ry_lib` ≒ ~76 TU)。`ry_tests` / native plugin / fuzz の TU build は省略
+  - **push to main**: `cmake --build build --parallel` で full build (all target)
+  - **注意**: `--target ry` は **build step のみ** narrowing する。clang-tidy 解析は両 event とも `find src -name '*.cpp'` で得られる全 90 ファイル (ry_lib に含まれない 14 TU を含む) を並列解析する
+- 解析は `xargs -0 -P "$(nproc)"` で TU 並列実行 (#1741)
+- ローカル実行 (macOS は `sysctl -n hw.ncpu`、Linux は `nproc`):
+  ```bash
+  find src -name '*.cpp' -print0 \
+    | xargs -0 -P "$(sysctl -n hw.ncpu)" clang-tidy -p build --quiet
+  ```
 - 新規コードは Clang-Tidy 警告ゼロを維持すること
 
 ### Platform-specific false positives (libc++ vs libstdc++)

--- a/.claude/skills/static-analysis-tools/SKILL.md
+++ b/.claude/skills/static-analysis-tools/SKILL.md
@@ -26,11 +26,11 @@ Reference for Clang-Tidy, Cppcheck, and Clang Static Analyzer (scan-build) confi
   - **pull request**: `cmake --build build --target ry --parallel` で fast build (`src/main.cpp` + `ry_lib` ≒ ~76 TU)。`ry_tests` / native plugin / fuzz の TU build は省略
   - **push to main**: `cmake --build build --parallel` で full build (all target)
   - **注意**: `--target ry` は **build step のみ** narrowing する。clang-tidy 解析は両 event とも `find src -name '*.cpp'` で得られる全 90 ファイル (ry_lib に含まれない 14 TU を含む) を並列解析する
-- 解析は `xargs -0 -P "$(nproc)"` で TU 並列実行 (#1741)
+- 解析は `xargs -0 -n 1 -P "$(nproc)"` で TU 並列実行 (#1741)。`-n 1` は必須 — 省くと xargs が全 .cpp を 1 つの clang-tidy 呼び出しにまとめてしまい、`-P` の並列度が無効化される
 - ローカル実行 (macOS は `sysctl -n hw.ncpu`、Linux は `nproc`):
   ```bash
   find src -name '*.cpp' -print0 \
-    | xargs -0 -P "$(sysctl -n hw.ncpu)" clang-tidy -p build --quiet
+    | xargs -0 -n 1 -P "$(sysctl -n hw.ncpu)" clang-tidy -p build --quiet
   ```
 - 新規コードは Clang-Tidy 警告ゼロを維持すること
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Run clang-tidy
         run: |
           find src -name '*.cpp' -print0 \
-            | xargs -0 -P "$(nproc)" clang-tidy -p build --quiet
+            | xargs -0 -n 1 -P "$(nproc)" clang-tidy -p build --quiet
 
   scan-build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,19 @@ jobs:
             ci-clang-tidy-${{ github.ref }}-
             ci-clang-tidy-
       - name: Build
+        # PR runs build only the `ry` target (~76 TU) for faster feedback;
+        # push-to-main keeps full all-target coverage so clang-tidy has the
+        # same compile_commands.json input as on developer machines. See
+        # .claude/rules/ci-workflows.md "Static-analysis PR scope: --target ry on PR ...".
+        # NOTE: --target ry narrows only the *build* step here; clang-tidy
+        # itself still analyses every file matched by `find src -name '*.cpp'`.
         run: |
           cmake --preset default
-          cmake --build build
+          cmake --build build ${{ github.event_name == 'pull_request' && '--target ry' || '' }} --parallel
       - name: Run clang-tidy
         run: |
-          find src -name '*.cpp' \
-            | xargs clang-tidy -p build --quiet
+          find src -name '*.cpp' -print0 \
+            | xargs -0 -P "$(nproc)" clang-tidy -p build --quiet
 
   scan-build:
     runs-on: ubuntu-24.04

--- a/changelog.d/1741-clang-tidy-parallel-scope.md
+++ b/changelog.d/1741-clang-tidy-parallel-scope.md
@@ -1,0 +1,12 @@
+### Changed
+
+- CI `clang-tidy` job's `Build` step now compiles only the `ry` target
+  on pull requests for faster feedback (~76 TU instead of the default
+  `all` target, which previously also dragged in `ry_tests`,
+  `ry_<pkg>` native shared libraries, and fuzz harnesses); the full
+  all-target build is retained for `push` to `main`. The `cmake --build`
+  invocation now also passes `--parallel`, and the `Run clang-tidy`
+  step now parallelises per-TU via `xargs -0 -P "$(nproc)"` instead of
+  running clang-tidy sequentially. The PR `--target ry` narrows only
+  the build step — clang-tidy still analyses every `src/*.cpp`
+  (90 files) in both event modes. (#1741)

--- a/changelog.d/1741-clang-tidy-parallel-scope.md
+++ b/changelog.d/1741-clang-tidy-parallel-scope.md
@@ -6,7 +6,9 @@
   `ry_<pkg>` native shared libraries, and fuzz harnesses); the full
   all-target build is retained for `push` to `main`. The `cmake --build`
   invocation now also passes `--parallel`, and the `Run clang-tidy`
-  step now parallelises per-TU via `xargs -0 -P "$(nproc)"` instead of
-  running clang-tidy sequentially. The PR `--target ry` narrows only
+  step now parallelises per-TU via `xargs -0 -n 1 -P "$(nproc)"`
+  instead of running clang-tidy sequentially (`-n 1` is required —
+  otherwise xargs batches every `.cpp` path into a single clang-tidy
+  invocation and the `-P` flag does nothing). The PR `--target ry` narrows only
   the build step — clang-tidy still analyses every `src/*.cpp`
   (90 files) in both event modes. (#1741)


### PR DESCRIPTION
Closes #1741.

## Summary

- **Build step**: PR now uses `cmake --build build --target ry --parallel` (~76 TU, just `src/main.cpp` + `ry_lib`). Push to `main` keeps the full all-target build so clang-tidy sees the same `compile_commands.json` as on developer machines.
- **Run step**: `find src -name '*.cpp' -print0 | xargs -0 -n 1 -P "$(nproc)" clang-tidy -p build --quiet` parallelises clang-tidy across CPU cores via `xargs -P`. `-n 1` is required — without it `xargs` batches every `.cpp` path into a single clang-tidy invocation and `-P` is a no-op (caught by CodeRabbit in commit `43c2ef48`). No new tool dependency (kept `xargs` rather than introducing `run-clang-tidy` to avoid image / Python dependency verification).

## clang-tidy semantic difference from #1738 / #1740

For scan-build (#1738) and CodeQL (#1740), `--target ry` narrows both the build *and* the analysis. For clang-tidy here, `--target ry` narrows **only the build step** — clang-tidy itself still drives `find src -name '*.cpp'` over every `src/*.cpp` (90 files, including TUs not linked into `ry_lib` such as `ry_<pkg>` native libs and fuzz harness sources) in both event modes. The PR-mode wins are therefore:

1. Skip the `ry_tests` / native-lib / fuzz build cost.
2. Per-TU analysis parallelisation.

This nuance is documented in the updated `.claude/rules/ci-workflows.md` "Static-analysis PR scope" rule.

## Acceptance criteria (from #1741)

- [x] CI clang-tidy no longer runs translation units sequentially → `xargs -0 -n 1 -P "$(nproc)"`.
- [x] The build step explicitly passes `--parallel`.
- [ ] If changed-file mode is added, it falls back to full scan for header/build/config changes → **deferred to follow-up issue** (out of scope: requires broad-change detection logic that would diverge from the #1738/#1740 pattern; parallelisation + target narrowing alone is expected to deliver the headline speedup).
- [x] Full clang-tidy remains available for `main` / release / deep local verification → push-to-main keeps the all-target build; local skill mirrors the parallel form.
- [x] `.claude/skills/static-analysis-tools/SKILL.md` and `.claude/skills/pre-commit-checklist/SKILL.md` updated with the new commands.
- [x] Before/after runtime recorded → see below.

## Before / after runtime

| Run | Commit | Configuration | clang-tidy job time |
|---|---|---|---|
| main run [25867617061](https://github.com/t0k0sh1/ry/actions/runs/25867617061) | pre-PR | sequential `xargs`, no `-P`, full target build | **13 min 20 s** (15:04:24Z → 15:17:44Z) |
| PR run [25886658537](https://github.com/t0k0sh1/ry/actions/runs/25886658537) | `65d37f9b` | `xargs -P "$(nproc)"` **without `-n 1`** (broken parallelism — see below), `--target ry` | 12 min 15 s (21:27:10Z → 21:39:25Z) |
| PR run [25887376001](https://github.com/t0k0sh1/ry/actions/runs/25887376001) | `43c2ef48` | `xargs -0 -n 1 -P "$(nproc)"` (true parallel), `--target ry` | **6 min 11 s** (21:42:53Z → 21:49:04Z) |

**Result: 13 min 20 s → 6 min 11 s = ~53.6% reduction (~7 min 9 s saved per PR clang-tidy run).**

The intermediate `65d37f9b` run shows that without `-n 1`, the `-P "$(nproc)"` flag was a no-op (xargs batches all 90 paths into a single clang-tidy invocation), so the only speedup there came from skipping `ry_tests` / native-lib / fuzz build cost (~1 min). Adding `-n 1` in `43c2ef48` is what unlocks per-TU parallelism — most of the headline ~7 min 9 s improvement comes from this single character change.

## Files changed

- `.github/workflows/ci.yml` — clang-tidy job: build step ternary + `--parallel`, run step `xargs -0 -n 1 -P "$(nproc)"`.
- `.claude/rules/ci-workflows.md` — "Static-analysis PR scope" rule updated: cite #1741, list the new call site, add the clang-tidy-specific build-vs-analysis paragraph (with `-n 1` mandatory note), update verify grep match count to 3.
- `.claude/skills/static-analysis-tools/SKILL.md` — Clang-Tidy section: document PR/push scope split and parallel local invocation with `-n 1` requirement.
- `.claude/skills/pre-commit-checklist/SKILL.md` — local clang-tidy command swapped to the parallel `-n 1 -P` form.
- `changelog.d/1741-clang-tidy-parallel-scope.md` — new `### Changed` entry.

## Out of scope (deferred)

- `changed-file PR mode` with header/build/config-change full-scan fallback. Requires broad-change detection logic; would diverge from the consistent #1738/#1740 pattern; revisit if speedup from this PR is insufficient.
- Switching to `run-clang-tidy`. Would require verifying the binary is in the `ghcr.io/.../ry-ci:llvm-21` image and adding a Python dependency to the analysis step.

## Pre-commit checklist self-verification

- §3 Tests: `./build/ry_tests` 2283/2283 PASSED, `./build/ry test -p` 186 files PASSED.
- §3.5 ASan + UBSan: `./build-asan/ry_tests` 2283/2283 PASSED.
- Skipped §1 (CI config + internal docs only; no user-visible feature change), §3.5.5 (src/include unchanged; clang-tidy result on src/cpp doesn't change in this PR), §3.6 (no parser/lexer/json/utf8/string change), §3.6.5 (no tree-sitter change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI checks: PR builds compile a reduced set of targets for faster iteration, overall CI uses parallel CMake builds, and static analysis now runs per-file in parallel with robust file-path handling for quicker, more reliable feedback.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1743)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1743)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
