### PR TITLE
fix(tree-sitter): accept newlines inside brace-delimited expressions (#1727)

### DIFF
--- a/.claude/rules/tree-sitter-grammar-editing.md
+++ b/.claude/rules/tree-sitter-grammar-editing.md
@@ -67,3 +67,31 @@ Build/install workflow and verification recipes
 block tokens + f-string + regex) live in the skill and in
 `editor/tree-sitter/README.md` §Contributor workflow. Pre-commit gating
 is handled by `/pre-commit-checklist` §3.6.5.
+
+### Brace-internal newline tolerance is a grammar-rule concern, not a scanner concern
+
+**Source**: issue #1727, `editor/tree-sitter/grammar.js`
+(`import_list`, `list_literal`, `map_literal`, `set_literal`,
+`bracedSep1` helper), `editor/tree-sitter/README.md`
+§"Brace-internal newline tolerance"
+**Tags**: tree-sitter, scanner, valid-symbols, brace-internal, newline,
+bracket-depth, blind-spot
+
+**Rule**: `src/scanner.c` cannot suppress NEWLINE / INDENT / DEDENT
+inside `{` / `[` / `(` by tracking bracket depth locally. tree-sitter
+only calls the external scanner when `valid_symbols[]` requests an
+external token, so for `from std.io import {` the scanner is *not*
+invoked between `{` and the first `import_item` (parser expects an
+identifier, no external is valid). A bracket-depth counter that
+increments on `{` lookahead therefore never observes the opening brace,
+and the tolerance must be expressed at the grammar-rule level instead.
+
+**How to apply**: For brace-delimited rules that need to accept
+newlines between elements, use the `bracedSep1(rule, separator,
+newline)` helper in `grammar.js` and pass **only** `$._newline`. Do
+not pass `$._indent` / `$._dedent` — the scanner's indent stack must
+stay clean. This mirrors the C++ parser's `skipStructuralTokens`
+(`src/parser.cpp:352`). Out-of-scope rules (`tuple_literal`,
+`_parenthesized`, `argument_list`, `parameter_list`, `case_*` arm
+bodies) still ERROR for multi-line forms — extend the pattern when
+warranted, tracked as separate issues.

--- a/changelog.d/1727-ts-brace-newline.md
+++ b/changelog.d/1727-ts-brace-newline.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- tree-sitter grammar now accepts newlines inside brace-delimited
+  expressions: multi-line `list_literal` (`[\n  1,\n  2,\n]`),
+  `map_literal` (`{\n  "a": 1,\n}`), `set_literal` (`{\n  1,\n  2,\n}`),
+  and braced selective import (`from std.io import {\n  print,\n}`)
+  no longer produce `(ERROR (UNEXPECTED '\n'))`. The fix is contained to
+  `editor/tree-sitter/grammar.js` via a new `bracedSep1` helper that
+  absorbs the external `_newline` token around list separators and at
+  the brace boundaries; `_indent` / `_dedent` are intentionally not
+  absorbed so the scanner's indent stack stays clean. This mirrors the
+  C++ parser's `skipStructuralTokens` (`src/parser.cpp:352`) and the
+  Phase 2 corpus gains four `#1727` cases under `imports` / `literals`
+  including a function-body nesting case that exercises indent-stack
+  health. Out of scope (still produce ERROR for multi-line forms):
+  `tuple_literal` / `_parenthesized` / `argument_list` / `parameter_list`
+  / `case_*` arm bodies. (#1727)

--- a/editor/tree-sitter/README.md
+++ b/editor/tree-sitter/README.md
@@ -194,6 +194,32 @@ for the most common live-editing scenario (`case x:` typed and `<CR>`
 pressed); arm-level partial typing falls back to the existing block-level
 `@indent.begin` capture on the surrounding case statement.
 
+## Brace-internal newline tolerance (#1727)
+
+The external scanner (`src/scanner.c`) does not track bracket depth, so
+NEWLINE / INDENT / DEDENT tokens fire even inside `{` / `[` / `(` once
+the parser state requests them. The C++ parser handles this in
+`src/parser.cpp:352` `skipStructuralTokens` by advancing past structural
+tokens while a bracket counter is non-zero. The tree-sitter grammar
+mirrors that behavior at the **grammar-rule level** for brace-delimited
+literal and import forms — the rules below explicitly absorb `_newline`
+around their separators and at the brace boundaries via the
+`bracedSep1(rule, separator, newline)` helper in `grammar.js`.
+
+| Grammar rule    | What is absorbed                                                |
+|-----------------|-----------------------------------------------------------------|
+| `import_list`   | `_newline` around `,` and at `{` / `}` boundaries (braced form) |
+| `list_literal`  | `_newline` around `,` and at `[` / `]` boundaries               |
+| `map_literal`   | `_newline` around `,` and at `{` / `}` boundaries               |
+| `set_literal`   | `_newline` around `,` and at `{` / `}` boundaries               |
+
+Only the `_newline` token is absorbed — `_indent` / `_dedent` are
+intentionally *not* passed into `bracedSep1`, so the scanner's indent
+stack stays clean. Out of scope: `tuple_literal`, the hidden
+`_parenthesized` rule, `argument_list`, `parameter_list`, and `case_*`
+arm bodies still produce ERROR nodes for multi-line forms; extend the
+same `bracedSep1` pattern there when warranted (separate issues).
+
 ## Contributor workflow
 
 Whenever a PR touches one of these paths (paths are relative to the

--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -66,15 +66,13 @@ tests/spec/record_subtyping.test.ry
 tests/spec/records.test.ry
 tests/spec/relative_import/mymath/mymath.test.ry
 tests/spec/relative_import/relative_import.test.ry
+# braced_import.test.ry exercises both multi-line braced imports (resolved
+# by #1727) and `from .symbols import {...}` relative imports — the relative
+# import grammar gap above still causes ERROR nodes for this file.
+tests/spec/braced_import/braced_import.test.ry
 tests/spec/result_type_inference.test.ry
 tests/spec/trailing_commas.test.ry
 tests/spec/type_of.test.ry
-
-# === Brace-internal newline suppression (list / map / set / braced-import multi-line) ===
-# `editor/tree-sitter/src/scanner.c` does not track bracket depth, so NEWLINE /
-# INDENT / DEDENT tokens fire inside `{` / `[` / `(` and produce ERROR nodes for
-# multi-line brace-delimited expressions. Tracked in #1727.
-tests/spec/braced_import/braced_import.test.ry
 
 # === Housekeeping: pre-existing gaps not registered by earlier PRs ===
 # Discovered during #1722 self-verification; the parent PRs introduced these

--- a/editor/tree-sitter/grammar.js
+++ b/editor/tree-sitter/grammar.js
@@ -135,7 +135,19 @@ export default grammar({
 
     import_list: $ => choice(
       sep1($.import_item, ','),
-      seq('{', sep1($.import_item, ','), optional(','), '}'),
+      // Multi-line brace tolerance (#1727): NEWLINE tokens fire inside `{}`
+      // because the external scanner does not track bracket depth; absorb
+      // them around the separator and at the brace boundaries. INDENT /
+      // DEDENT are intentionally NOT absorbed — the indent stack must stay
+      // clean. Mirrors C++ parser's `skipStructuralTokens` (parser.cpp:352).
+      seq(
+        '{',
+        repeat($._newline),
+        bracedSep1($.import_item, ',', $._newline),
+        optional(','),
+        repeat($._newline),
+        '}',
+      ),
     ),
 
     import_item: $ => seq(
@@ -909,22 +921,41 @@ export default grammar({
       seq('(', $._expression, ',', sep1($._expression, ','), ')'),
     ),
 
+    // Multi-line brace tolerance (#1727): see import_list note above.
     list_literal: $ => seq(
       '[',
-      optional(seq(sep1($._expression, ','), optional(','))),
+      repeat($._newline),
+      optional(seq(
+        bracedSep1($._expression, ',', $._newline),
+        optional(','),
+        repeat($._newline),
+      )),
       ']',
     ),
 
     map_literal: $ => seq(
       '{',
-      sep1(seq(field('key', $._expression), ':', field('value', $._expression)), ','),
+      repeat($._newline),
+      bracedSep1(
+        seq(field('key', $._expression), ':', field('value', $._expression)),
+        ',',
+        $._newline,
+      ),
       optional(','),
+      repeat($._newline),
       '}',
     ),
 
     set_literal: $ => choice(
-      seq('{', '}'),                                    // empty (also empty-map; parser decides)
-      seq('{', sep1($._expression, ','), optional(','), '}'),
+      seq('{', repeat($._newline), '}'),               // empty (also empty-map; parser decides)
+      seq(
+        '{',
+        repeat($._newline),
+        bracedSep1($._expression, ',', $._newline),
+        optional(','),
+        repeat($._newline),
+        '}',
+      ),
     ),
 
     /* =====================================================================
@@ -1022,4 +1053,17 @@ export default grammar({
  * ===================================================================*/
 function sep1(rule, separator) {
   return seq(rule, repeat(seq(separator, rule)));
+}
+
+// Like `sep1` but tolerates the given newline token around the separator.
+// Used inside brace-delimited expressions (list_literal, map_literal,
+// set_literal, braced import_list) where the external scanner emits
+// NEWLINE tokens even inside braces (#1727). Only the newline token is
+// absorbed — INDENT / DEDENT must not be passed in here, so the scanner's
+// indent stack stays clean.
+function bracedSep1(rule, separator, newline) {
+  return seq(
+    rule,
+    repeat(seq(repeat(newline), separator, repeat(newline), rule)),
+  );
 }

--- a/editor/tree-sitter/test/corpus/imports.txt
+++ b/editor/tree-sitter/test/corpus/imports.txt
@@ -129,3 +129,70 @@ from std.io import { print, }
     items: (import_list
       (import_item
         name: (identifier)))))
+
+==================
+braced multi-line import (#1727)
+==================
+
+from std.io import {
+  print,
+  println,
+}
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier))
+      (import_item
+        name: (identifier)))))
+
+==================
+braced multi-line import without trailing comma (#1727)
+==================
+
+from std.io import {
+  print,
+  println
+}
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier))
+      (import_item
+        name: (identifier)))))
+
+==================
+braced multi-line import with alias (#1727)
+==================
+
+from std.io import {
+  print as p,
+  println,
+}
+
+---
+
+(source_file
+  (import_statement
+    source: (module_path
+      (identifier)
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier)
+        alias: (identifier))
+      (import_item
+        name: (identifier)))))

--- a/editor/tree-sitter/test/corpus/literals.txt
+++ b/editor/tree-sitter/test/corpus/literals.txt
@@ -131,3 +131,89 @@ t = (1, "a", true)
       (integer_literal)
       (string_literal)
       (boolean_literal))))
+
+==================
+list literal multi-line with trailing comma (#1727)
+==================
+
+xs = [
+  1,
+  2,
+  3,
+]
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (list_literal
+      (integer_literal)
+      (integer_literal)
+      (integer_literal))))
+
+==================
+map literal multi-line with trailing comma (#1727)
+==================
+
+m = {
+  "a": 1,
+  "b": 2,
+}
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (map_literal
+      key: (string_literal)
+      value: (integer_literal)
+      key: (string_literal)
+      value: (integer_literal))))
+
+==================
+set literal multi-line with trailing comma (#1727)
+==================
+
+s = {
+  1,
+  2,
+  3,
+}
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (set_literal
+      (integer_literal)
+      (integer_literal)
+      (integer_literal))))
+
+==================
+list literal multi-line nested in function body (#1727)
+==================
+
+fn foo():
+  ys = [
+    1,
+  ]
+  bar()
+
+---
+
+(source_file
+  (function_declaration
+    name: (function_name
+      (identifier))
+    body: (function_body
+      (assignment_statement
+        left: (identifier)
+        right: (list_literal
+          (integer_literal)))
+      (expression_statement
+        (call_expression
+          function: (qualified_identifier
+            (identifier)))))))

--- a/editor/tree-sitter/test/corpus/literals.txt
+++ b/editor/tree-sitter/test/corpus/literals.txt
@@ -153,12 +153,52 @@ xs = [
       (integer_literal))))
 
 ==================
+list literal multi-line without trailing comma (#1727)
+==================
+
+xs = [
+  1,
+  2,
+  3
+]
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (list_literal
+      (integer_literal)
+      (integer_literal)
+      (integer_literal))))
+
+==================
 map literal multi-line with trailing comma (#1727)
 ==================
 
 m = {
   "a": 1,
   "b": 2,
+}
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (map_literal
+      key: (string_literal)
+      value: (integer_literal)
+      key: (string_literal)
+      value: (integer_literal))))
+
+==================
+map literal multi-line without trailing comma (#1727)
+==================
+
+m = {
+  "a": 1,
+  "b": 2
 }
 
 ---
@@ -180,6 +220,26 @@ s = {
   1,
   2,
   3,
+}
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (set_literal
+      (integer_literal)
+      (integer_literal)
+      (integer_literal))))
+
+==================
+set literal multi-line without trailing comma (#1727)
+==================
+
+s = {
+  1,
+  2,
+  3
 }
 
 ---


### PR DESCRIPTION
Closes #1727.

## Summary

- **Problem**: `editor/tree-sitter/src/scanner.c` does not track bracket depth, so the external scanner emits NEWLINE / INDENT / DEDENT tokens even inside `{` / `[` / `(`. Multi-line `list_literal` (`[\n  1,\n  2,\n]`), `map_literal`, `set_literal`, and braced selective imports (`from std.io import {\n  print,\n}`) therefore produced `(ERROR (UNEXPECTED '\n'))`.
- **Why not fix in `scanner.c`**: For `from std.io import {`, the scanner is *not* invoked between `{` and the first `import_item` — the parser expects an identifier and no external token is in `valid_symbols[]`. A bracket-depth counter that increments on `{` lookahead therefore never observes the opening brace. Bracket-depth tracking in the scanner is infeasible for this case.
- **Fix at grammar-rule level**: Add a `bracedSep1(rule, separator, newline)` helper that absorbs the given newline token around the separator, and apply it to `import_list` (braced form) / `list_literal` / `map_literal` / `set_literal`, plus `repeat($._newline)` at the brace boundaries. Only `$._newline` is absorbed — `$._indent` / `$._dedent` are intentionally *not* passed in, so the scanner's indent stack stays clean. Mirrors the C++ parser's `skipStructuralTokens` at `src/parser.cpp:352`.

## Rules covered (and out of scope)

| Grammar rule    | Multi-line now accepted? |
|-----------------|--------------------------|
| `import_list` (braced form) | yes |
| `list_literal`  | yes |
| `map_literal`   | yes |
| `set_literal`   | yes |
| `tuple_literal` | no (out of scope; produces ERROR) |
| `_parenthesized` | no (out of scope) |
| `argument_list` | no (out of scope) |
| `parameter_list` | no (out of scope) |
| `case_*` arm bodies | no (out of scope) |

Out-of-scope rules can be extended with the same `bracedSep1` pattern when warranted — tracked as separate issues.

## docs/grammar.ebnf intentionally not updated

EBNF is silent on newlines inside these rules (`import_list ::= '{' import_item { ',' import_item } [ ',' ] '}'` etc.), so the tree-sitter change is purely additive permissiveness — a documented divergence rather than a contradiction. Same shape as the existing live-editing tolerance precedent (#1623). The divergence is recorded in `editor/tree-sitter/README.md` §"Brace-internal newline tolerance (#1727)" and in the new `.claude/rules/tree-sitter-grammar-editing.md` entry.

## Verification

- `tree-sitter generate`: no warnings, no conflicts
- `tree-sitter test`: **63/63** corpus tests pass (7 new #1727 cases under `imports` / `literals` including a function-body nesting case that exercises indent-stack health)
- `editor/tree-sitter/check.sh --no-build`: 139 pass / 47 skip / 0 warn / 0 fail
  - `tests/spec/braced_import/braced_import.test.ry` moved under the `relative_import` section in `expected-fail.txt` — multi-line braces now work, but `from .symbols import {...}` relative imports remain a separate grammar gap
- C++ tests: 2283/2283 (default + ASan+UBSan + TSan)
- Ry self-test: 186/186 (default + ASan+UBSan; TSan on Ry self-test is warn-only per upstream LargeMmapAllocator bug)
- clang-tidy: 0 errors / cppcheck: clean
- libFuzzer §3.6: skipped (no parser/lexer/json/utf8/string source change)

## Files changed

- `editor/tree-sitter/grammar.js` — `bracedSep1` helper + apply to 4 rules with `// Multi-line brace tolerance (#1727)` comments
- `editor/tree-sitter/test/corpus/imports.txt` — 3 new #1727 cases (multi-line braced, trailing-comma variants, with-alias)
- `editor/tree-sitter/test/corpus/literals.txt` — 4 new #1727 cases (list / map / set multi-line + function-body-nested list)
- `editor/tree-sitter/expected-fail.txt` — remove the brace-internal section; move `braced_import.test.ry` to the `relative_import` section with an explanatory comment
- `editor/tree-sitter/README.md` — new §"Brace-internal newline tolerance (#1727)" section
- `.claude/rules/tree-sitter-grammar-editing.md` — new entry "Brace-internal newline tolerance is a grammar-rule concern, not a scanner concern"
- `changelog.d/1727-ts-brace-newline.md` — `### Fixed`

## Test plan

- [x] `tree-sitter test` 63/63 pass (incl. 7 new #1727 cases)
- [x] `check.sh` clean (139/47/0/0)
- [x] `./build/ry_tests` 2283/2283
- [x] `./build/ry test -p` 186 files PASSED
- [x] `./build-asan/ry_tests` 2283/2283 (ASan + UBSan clean)
- [x] `./build-asan/ry test -p` 186 files PASSED
- [x] `./build-tsan/ry_tests` 2283/2283 (no new races)
- [x] clang-tidy 0 errors / cppcheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Multi-line brace-delimited imports and literal collections (lists, maps, sets) now accept internal newlines without producing unexpected parse errors.

* **Documentation**
  * Added guidance explaining newline-tolerance behavior for brace-delimited forms and current out-of-scope cases.

* **Tests**
  * Expanded parsing corpus and updated expected-failure ordering to cover multi-line braced imports and literals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1744)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->