### PR TITLE
fix(cli): reject bare main-script filenames as ambiguous (#1745)

### DIFF
--- a/changelog.d/1745-bare-filename-rejection.md
+++ b/changelog.d/1745-bare-filename-rejection.md
@@ -1,0 +1,11 @@
+### Changed
+
+- `ry foo.ry` (a bare filename with no path separator) is now rejected with
+  an actionable error when `foo.ry` exists in the current working directory:
+  `Error: ambiguous script path 'foo.ry'. Use './foo.ry' or an absolute
+  path.` Previously the bare form silently bypassed referrer-directory
+  resolution, causing scripts that used relative imports
+  (`from .sub import ...`) to fail with `relative import requires a
+  referrer directory`. Use `./foo.ry` or an absolute path instead; bare
+  filenames that do not exist in the current directory are still resolved
+  through `package.toml` `[paths]` as before. (#1745)

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -37,6 +37,8 @@ If no `package.toml` is found or no `entry` field is set, `ry` prints help and e
 
 If the first argument is a **single path component** whose name ends with `.ry` (for example `main.ry`) and no file with that name exists in the current working directory, `ry` searches the nearest `package.toml` project in order: **first** the project root directory (the directory containing `package.toml`), **then** each directory listed under `[paths]` (keys sorted alphabetically; keys starting with `_` are reserved and ignored for this search, except `_dev_stdlib` which is handled separately). The **first** existing regular file wins (for example `foo.ry` next to `package.toml` is chosen over `src/foo.ry` when both exist). If none match, `ry` reports that the file does not exist and lists the paths that were tried. Tokens without a `.ry` suffix are not resolved this way (so mistyped subcommands still show “unknown command”).
 
+If the argument is a **single path component** *and* a file with that name exists in the current working directory, `ry` rejects it as ambiguous and exits with status 1 (e.g. `Error: ambiguous script path 'foo.ry'. Use './foo.ry' or an absolute path.`). Prefix the path with `./` or use an absolute path to indicate that the literal file in the current directory is intended; this also makes relative imports inside the script (such as `from .sub import ...`) resolve correctly.
+
 If the argument is a **path with more than one component** (for example `src/foo.ry` or `./foo.ry`) and that path does not exist, `ry` reports **no such file** instead of treating it as an unknown subcommand.
 
 The same rules apply to `ry test <file.ry>` when `<file.ry>` is a basename and does not exist relative to the current directory.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,6 +125,11 @@ int main(int argc, char *argv[]) {
         // try resolving a bare filename against package.toml [paths], else error.
         std::string arg1 = argv[1];
         if (fs::exists(arg1)) {
+            if (!fs::path(arg1).has_parent_path()) {
+                errs() << "Error: ambiguous script path '" << arg1
+                       << "'. Use './" << arg1 << "' or an absolute path.\n";
+                return 1;
+            }
             entry_path_storage.clear();
             filename = argv[1];
         } else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,7 +125,10 @@ int main(int argc, char *argv[]) {
         // try resolving a bare filename against package.toml [paths], else error.
         std::string arg1 = argv[1];
         if (fs::exists(arg1)) {
-            if (!fs::path(arg1).has_parent_path()) {
+            const fs::path arg_path(arg1);
+            if (!arg_path.has_parent_path() &&
+                arg_path.extension() == ".ry" &&
+                fs::is_regular_file(arg_path)) {
                 errs() << "Error: ambiguous script path '" << arg1
                        << "'. Use './" << arg1 << "' or an absolute path.\n";
                 return 1;

--- a/tests/test_entry_point.cpp
+++ b/tests/test_entry_point.cpp
@@ -136,13 +136,40 @@ TEST_F(EntryPointTest, BareFilenameNotFoundListsSearchRoots) {
     EXPECT_NE(out.find("Searched:"), std::string::npos);
 }
 
-TEST_F(EntryPointTest, BareFilenamePrefersProjectRootOverPaths) {
+TEST_F(EntryPointTest, BareFilenameInCwdRejectedAsAmbiguous) {
     writePackageToml();
     writeFile("foo.ry", "print(\"root\")");
     writeFile("src/foo.ry", "print(\"src\")");
     auto [out, rc] = runRyInDir(tmp_dir_.string(), {"foo.ry"});
+    EXPECT_NE(rc, 0);
+    EXPECT_NE(out.find("ambiguous script path 'foo.ry'"), std::string::npos);
+    EXPECT_NE(out.find("./foo.ry"), std::string::npos);
+}
+
+TEST_F(EntryPointTest, DotSlashRyPathInCwdAccepted) {
+    writePackageToml();
+    writeFile("foo.ry", "print(\"ok\")");
+    auto [out, rc] = runRyInDir(tmp_dir_.string(), {"./foo.ry"});
     EXPECT_EQ(rc, 0);
-    EXPECT_EQ(out, "root\n");
+    EXPECT_EQ(out, "ok\n");
+}
+
+TEST_F(EntryPointTest, AbsoluteRyPathAccepted) {
+    writePackageToml();
+    writeFile("foo.ry", "print(\"ok\")");
+    const std::string abs_path = (tmp_dir_ / "foo.ry").string();
+    auto [out, rc] = runRyInDir(tmp_dir_.string(), {abs_path.c_str()});
+    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(out, "ok\n");
+}
+
+TEST_F(EntryPointTest, ParentRelativeRyPathAccepted) {
+    writePackageToml();
+    writeFile("foo.ry", "print(\"ok\")");
+    fs::create_directories(tmp_dir_ / "sub");
+    auto [out, rc] = runRyInDir((tmp_dir_ / "sub").string(), {"../foo.ry"});
+    EXPECT_EQ(rc, 0);
+    EXPECT_EQ(out, "ok\n");
 }
 
 TEST_F(EntryPointTest, BareFilenameFirstMatchWinsAcrossPaths) {

--- a/tests/test_entry_point.cpp
+++ b/tests/test_entry_point.cpp
@@ -172,6 +172,20 @@ TEST_F(EntryPointTest, ParentRelativeRyPathAccepted) {
     EXPECT_EQ(out, "ok\n");
 }
 
+TEST_F(EntryPointTest, BareNonRyFileInCwdNotRejectedAsAmbiguous) {
+    writePackageToml();
+    writeFile("data.txt", "noise");
+    auto [out, rc] = runRyInDir(tmp_dir_.string(), {"data.txt"});
+    EXPECT_EQ(out.find("ambiguous script path"), std::string::npos);
+}
+
+TEST_F(EntryPointTest, BareDirectoryInCwdNotRejectedAsAmbiguous) {
+    writePackageToml();
+    fs::create_directories(tmp_dir_ / "data");
+    auto [out, rc] = runRyInDir(tmp_dir_.string(), {"data"});
+    EXPECT_EQ(out.find("ambiguous script path"), std::string::npos);
+}
+
 TEST_F(EntryPointTest, BareFilenameFirstMatchWinsAcrossPaths) {
     writeFile("package.toml",
               "[project]\nname = \"test\"\nversion = \"0.1.0\"\nentry = \"src/main.ry\"\n\n"


### PR DESCRIPTION
## Summary

Closes #1745.

`ry foo.ry` with no path separator previously bypassed referrer-directory
resolution. Scripts using relative imports (e.g. `from .sub import ...`)
then failed downstream with `relative import requires a referrer directory`.
`./foo.ry` / absolute path / `../tmp/foo.ry` continued to work because
their `parent_path()` is non-empty.

This PR rejects the bare form at the CLI input boundary when a same-named
file exists in the current working directory:

```text
$ ry foo.ry
Error: ambiguous script path 'foo.ry'. Use './foo.ry' or an absolute path.
```

- Check applied only inside the `fs::exists(arg1) == true` branch of
  `src/main.cpp`, so `tryResolveBareRyFile` (the `package.toml` `[paths]`
  search for bare filenames not in cwd) is untouched.
- Existing `RunsBareFilenameViaPaths` / `BareFilenameFirstMatchWinsAcrossPaths`
  continue to pass.

## Tests

- `tests/test_entry_point.cpp`:
  - `BareFilenamePrefersProjectRootOverPaths` → renamed to
    `BareFilenameInCwdRejectedAsAmbiguous` (kept the same fixture, flipped
    the expectation per `.claude/rules/tests-rejection-tdd.md`).
  - Added `DotSlashRyPathInCwdAccepted`, `AbsoluteRyPathAccepted`,
    `ParentRelativeRyPathAccepted`.

## Test plan

- [x] `cmake --build build && ./build/ry_tests` (2286/2286 PASS)
- [x] `./build/ry test -p` (186 files, 0 failures)
- [x] ASan + UBSan (ry_tests + Ry self-test, clean)
- [x] TSan (ry_tests + Ry self-test, clean)
- [x] cppcheck / clang-tidy (clean)
- [x] Smoke test on `/tmp/repro1745` reproducing issue Reproduction:
      bare → rejected (rc=1); `./main.ry` / absolute → 42

## Skipped checklist items

- §3.6 libFuzzer — no parser/lexer/json/utf8/string change
- §3.6.5 tree-sitter — no grammar / EBNF / scanner change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Rejects bare script filenames (e.g., `ry foo.ry`) when a same-named file exists in the current directory, preventing ambiguous path resolution; advises using `./foo.ry` or an absolute path.
* **Documentation**
  * Documents the new behavior for bare `.ry` arguments and recommended explicit paths.
* **Tests**
  * Adds coverage validating ambiguous bare-name rejection and acceptance of explicit relative/absolute paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1749)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->