### PR TITLE
chore(tree-sitter): align editor artifacts with v0.0.23 imports (#1737)

### DIFF
--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -70,6 +70,11 @@ tests/spec/relative_import/relative_import.test.ry
 # by #1727) and `from .symbols import {...}` relative imports — the relative
 # import grammar gap above still causes ERROR nodes for this file.
 tests/spec/braced_import/braced_import.test.ry
+# import_alias.test.ry uses `from .shapes import ...` for its alias coverage.
+# Selective alias parsing itself works (see corpus `import with alias` / `braced
+# import with alias`); the failure is the leading `.` in `module_path` — the
+# same relative import grammar gap above.
+tests/spec/import_alias/import_alias.test.ry
 tests/spec/result_type_inference.test.ry
 tests/spec/trailing_commas.test.ry
 tests/spec/type_of.test.ry
@@ -78,11 +83,9 @@ tests/spec/type_of.test.ry
 # Discovered during #1722 self-verification; the parent PRs introduced these
 # fixtures but did not update expected-fail.txt. Each is an independent grammar
 # gap unrelated to braced selective import.
-#   - import_alias/*.ry: alias-aware selective import (#1721 leftover)
 #   - arc_tuple_*.ry, collection_meta_propagation.ry, mock.test.ry: feature-
 #     specific syntax surfaces not yet covered by editor/tree-sitter/grammar.js
 tests/spec/arc_tuple_index_assign.test.ry
 tests/spec/arc_tuple_ownership.test.ry
 tests/spec/collection_meta_propagation.test.ry
-tests/spec/import_alias/import_alias.test.ry
 tests/spec/mock.test.ry

--- a/editor/tree-sitter/queries/highlights.scm
+++ b/editor/tree-sitter/queries/highlights.scm
@@ -31,6 +31,13 @@
 (qualified_import_statement
   alias: (identifier) @module)
 
+; Selective import alias: `from x import foo as bar` — capture the alias
+; symmetrically with `qualified_import_statement` above. The alias target is
+; not always a module (could be a fn / const / type), but we accept the same
+; semantic compromise as the qualified-import captures noted below.
+(import_item
+  alias: (identifier) @module)
+
 ; Treat the module access prefix `math.sqrt(...)` / `math.PI` as a namespace
 ; reference. Tree-sitter cannot distinguish stdlib qualified-call receivers
 ; from generic field-access objects at the syntactic level, so this falls

--- a/editor/tree-sitter/test/corpus/imports.txt
+++ b/editor/tree-sitter/test/corpus/imports.txt
@@ -196,3 +196,47 @@ from std.io import {
         alias: (identifier))
       (import_item
         name: (identifier)))))
+
+==================
+qualified import single module (#1723)
+==================
+
+import math
+
+---
+
+(source_file
+  (qualified_import_statement
+    module: (identifier)))
+
+==================
+qualified import with alias (#1724)
+==================
+
+import math as m
+
+---
+
+(source_file
+  (qualified_import_statement
+    module: (identifier)
+    alias: (identifier)))
+
+==================
+qualified and selective import of the same module (#1723, #1724)
+==================
+
+import math
+from math import PI
+
+---
+
+(source_file
+  (qualified_import_statement
+    module: (identifier))
+  (import_statement
+    source: (module_path
+      (identifier))
+    items: (import_list
+      (import_item
+        name: (identifier)))))


### PR DESCRIPTION
## Summary

Closes #1737.

editor/tree-sitter/ 配下の 3 種類の artifact を v0.0.23 import 機能 (#1721-#1724) と整合させる chore。grammar.js / scanner.c には触らない。

- **corpus テスト追加** (`test/corpus/imports.txt`): `qualified_import_statement` (#1723) と module alias (#1724) の S-expression assertion を 3 件追加 (single / alias / qualified+selective 共存)。Phase 2 hand-curated corpus (#1633) の qualified import 退行検知ギャップを埋める。
- **highlights.scm**: `(import_item alias: (identifier) @module)` を明示的に定義。既存の `qualified_import_statement` の `module:` / `alias:` キャプチャと対称になり、import 形式間で alias のハイライト色が一致する。
- **expected-fail.txt 再分類**: `tests/spec/import_alias/import_alias.test.ry` を `#1721 leftover` バケットから relative import bucket へ移動。実際の parse 失敗原因は `from .shapes import ...` (leading `.` を `module_path` が受け付けない) で、selective alias 構文 (#1721) ではない。relative import 自体のサポート (`module_path` への先頭 `.` 追加) は本 PR スコープ外。

## Verification

- `cd editor/tree-sitter && tree-sitter test` — 69 ケース全 PASS (新規 #45-47 含む)
- `./editor/tree-sitter/check.sh --no-build` — pass=139 / skip=47 / fail=0 (skip 件数は expected-fail エントリ数 47 と一致)
- `./editor/tree-sitter/build.sh && ./editor/tree-sitter/install.sh --no-build` — 正常完了

## pre-commit-checklist skip ログ

- Skipped §1 — no doc-relevant spec change (docs/reference/modules.md の braced imports 言及は未影響)
- Skipped §2 — chore-only tree-sitter artifact alignment, no functional change (precedent: #1614 / #1619)
- Skipped §3 / §3.5 / §3.6 — no Ry compiler/runtime source change (editor/ artifacts only)
- Skipped §3.6.5 — no grammar.js / scanner.c change (build/install/check は issue 受け入れ条件として実施済み)

## Test plan

- [x] `tree-sitter test` 全 PASS
- [x] `check.sh --no-build` Phase 1 smoke check 通過
- [x] `build.sh && install.sh --no-build` 正常完了
- [ ] Neovim で `.ry` ファイルを開き、selective import alias が qualified import alias と同じ色でハイライトされることを目視確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced syntax highlighting for import aliases in selective imports, improving editor visual feedback.

* **Tests**
  * Expanded test coverage for qualified import syntax variations and import combinations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1755)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->