### PR TITLE
feat(testing): add IEEE 754 matchers toBeNaN/toBeInfinity/toBeFinite (#1685)

### DIFF
--- a/changelog.d/1685-ieee754-matchers.md
+++ b/changelog.d/1685-ieee754-matchers.md
@@ -1,0 +1,12 @@
+### Added
+
+- Added IEEE 754 special-value matchers `toBeNaN()`, `toBeInfinity()`,
+  and `toBeFinite()` to the testing framework. Because `NaN == NaN` is
+  false in IEEE 754, `expect(0.0/0.0).toEq(NAN)` always failed and
+  tests had to rely on indirect idioms such as
+  `expect(x == x).toBeFalse()`. The new matchers express the intent
+  directly: `expect(0.0/0.0).toBeNaN()`,
+  `expect(1.0/0.0).toBeInfinity()` (matches both `+∞` and `-∞`), and
+  `expect(3.14).toBeFinite()`. All three accept `float` only and emit
+  a `codegenError` for other types. Complements stdlib `math.isNan` /
+  `math.isInf` (assertion vs. conditional branch). (#1685)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -155,6 +155,9 @@ foo("arg", ():
 | `toEndWith(suffix)` | Asserts string ends with suffix | str |
 | `toMatch(pattern)` | Asserts string matches the given regex pattern (unanchored; use `^` / `$` to anchor) | str |
 | `toBeCloseTo(value)` / `toBeCloseTo(value, decimals)` | Asserts approximate equality: `\|actual - value\| < 0.5 * 10^-decimals`. `decimals` defaults to `2` and must be a non-negative integer literal in `[0, 15]` | int, float |
+| `toBeNaN()` | Asserts value is NaN (IEEE 754); `NaN == NaN` is false, so use this matcher instead of `toEq` | float |
+| `toBeInfinity()` | Asserts value is positive or negative infinity (`+∞` or `-∞`) | float |
+| `toBeFinite()` | Asserts value is finite (not NaN and not `±∞`) | float |
 
 ### fail
 

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -1533,6 +1533,32 @@ void CodeGen::emitStmt(ExpectStmt &s) {
                                      ": toBeErr: expected Result type");
         llvm::Value *isOk = builder_.CreateExtractValue(actualVal, {0}, "is_ok");
         cmpResult = builder_.CreateNot(isOk, "is_err");
+    } else if (s.matcher == "toBeNaN") {
+        if (actualTy != f64Ty_)
+            codegenError("line " + std::to_string(s.loc.line) +
+                                     ": toBeNaN: expected float");
+        cmpResult = builder_.CreateFCmpUNO(actualVal, actualVal, "is_nan");
+    } else if (s.matcher == "toBeInfinity") {
+        if (actualTy != f64Ty_)
+            codegenError("line " + std::to_string(s.loc.line) +
+                                     ": toBeInfinity: expected float");
+        llvm::Function *fabsDecl = llvm::Intrinsic::getDeclaration(
+            mod_.get(), llvm::Intrinsic::fabs, {f64Ty_});
+        llvm::Value *absVal = builder_.CreateCall(fabsDecl, {actualVal}, "abs_val");
+        llvm::Value *posInf = llvm::ConstantFP::getInfinity(f64Ty_);
+        cmpResult = builder_.CreateFCmpOEQ(absVal, posInf, "is_inf");
+    } else if (s.matcher == "toBeFinite") {
+        if (actualTy != f64Ty_)
+            codegenError("line " + std::to_string(s.loc.line) +
+                                     ": toBeFinite: expected float");
+        llvm::Value *isNaN = builder_.CreateFCmpUNO(actualVal, actualVal, "is_nan");
+        llvm::Function *fabsDecl = llvm::Intrinsic::getDeclaration(
+            mod_.get(), llvm::Intrinsic::fabs, {f64Ty_});
+        llvm::Value *absVal = builder_.CreateCall(fabsDecl, {actualVal}, "abs_val");
+        llvm::Value *posInf = llvm::ConstantFP::getInfinity(f64Ty_);
+        llvm::Value *isInf = builder_.CreateFCmpOEQ(absVal, posInf, "is_inf");
+        llvm::Value *nonFinite = builder_.CreateOr(isNaN, isInf, "non_finite");
+        cmpResult = builder_.CreateNot(nonFinite, "is_finite");
     } else if (s.matcher == "toContain" || s.matcher == "toNotContain") {
         llvm::Value *expectedVal = emitExpr(*s.expected);
         savedExpectedVal = expectedVal;
@@ -1857,6 +1883,12 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         expectedStr = cachedGlobalString("Ok(...)", ".exp_ok");
     } else if (s.matcher == "toBeErr") {
         expectedStr = cachedGlobalString("Err(...)", ".exp_err");
+    } else if (s.matcher == "toBeNaN") {
+        expectedStr = cachedGlobalString("NaN", ".exp_nan");
+    } else if (s.matcher == "toBeInfinity") {
+        expectedStr = cachedGlobalString("Infinity", ".exp_inf");
+    } else if (s.matcher == "toBeFinite") {
+        expectedStr = cachedGlobalString("finite float", ".exp_finite");
     } else if (s.matcher == "toContain" || s.matcher == "toNotContain") {
         if (s.matcher == "toNotContain") {
             llvm::Value *valStr = formatValue(savedExpectedVal, savedExpectedVal->getType(), "expected_buf");

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1213,7 +1213,8 @@ StmtNode Parser::parseExpectStatement() {
         "toHaveLen", "toStartWith", "toEndWith", "toMatch"
     };
     static const std::unordered_set<std::string> matchers_no_arg = {
-        "toBeTrue", "toBeFalse", "toBeNone", "toBeSome", "toBeOk", "toBeErr", "toBeEmpty"
+        "toBeTrue", "toBeFalse", "toBeNone", "toBeSome", "toBeOk", "toBeErr", "toBeEmpty",
+        "toBeNaN", "toBeInfinity", "toBeFinite"
     };
 
     if (matcher == "toBeCloseTo") {

--- a/tests/spec/matchers.test.ry
+++ b/tests/spec/matchers.test.ry
@@ -1,4 +1,5 @@
 from testing import it, describe, expect
+from std.math import NAN, INF
 
 @describe("Numeric comparison matchers")
 fn numericComparisonMatchersTests():
@@ -250,3 +251,39 @@ fn floatApproxMatchers():
   @it("should pass toBeCloseTo for very small differences with high decimals")
   fn shouldPassToBeCloseToHighDecimals():
     expect(1.000000001).toBeCloseTo(1.000000002, 8)
+
+@describe("Float IEEE 754 special-value matchers")
+fn floatIeee754Matchers():
+  @it("should pass toBeNaN for NAN constant")
+  fn shouldPassToBeNaNForConstant():
+    expect(NAN).toBeNaN()
+  @it("should pass toBeNaN for 0.0 / 0.0")
+  fn shouldPassToBeNaNForZeroDivZero():
+    expect(0.0 / 0.0).toBeNaN()
+  @it("should pass toBeInfinity for positive infinity (1.0 / 0.0)")
+  fn shouldPassToBeInfinityForPosInf():
+    expect(1.0 / 0.0).toBeInfinity()
+  @it("should pass toBeInfinity for negative infinity (-1.0 / 0.0)")
+  fn shouldPassToBeInfinityForNegInf():
+    expect(-1.0 / 0.0).toBeInfinity()
+  @it("should pass toBeInfinity for INF constant")
+  fn shouldPassToBeInfinityForConstant():
+    expect(INF).toBeInfinity()
+  @it("should pass toBeInfinity for negated INF constant")
+  fn shouldPassToBeInfinityForNegConstant():
+    expect(-INF).toBeInfinity()
+  @it("should pass toBeFinite for normal float")
+  fn shouldPassToBeFiniteForNormal():
+    expect(3.14).toBeFinite()
+  @it("should pass toBeFinite for zero")
+  fn shouldPassToBeFiniteForZero():
+    expect(0.0).toBeFinite()
+  @it("should pass toBeFinite for negative zero")
+  fn shouldPassToBeFiniteForNegZero():
+    expect(-0.0).toBeFinite()
+  @it("should pass toBeFinite for very large finite value")
+  fn shouldPassToBeFiniteForLargeValue():
+    expect(1.0e308).toBeFinite()
+  @it("should pass toBeFinite for very small finite value")
+  fn shouldPassToBeFiniteForSmallValue():
+    expect(-1.0e308).toBeFinite()


### PR DESCRIPTION
## Summary

Adds three no-arg matchers to the testing framework so IEEE 754 special values can be asserted directly:

- `expect(0.0 / 0.0).toBeNaN()`
- `expect(1.0 / 0.0).toBeInfinity()` — accepts both `+∞` and `-∞`
- `expect(3.14).toBeFinite()`

Because `NaN == NaN` is false in IEEE 754, `expect(0.0/0.0).toEq(NAN)` always failed and tests had to rely on indirect idioms such as `expect(x == x).toBeFalse()`. The new matchers express the intent directly.

All three accept `float` only; passing other types raises a `codegenError` consistent with existing no-arg matchers (`toBeTrue`, `toBeNone`, etc.).

Complements stdlib `math.isNan` / `math.isInf` (assertion vs. conditional branch).

Closes #1685.

## Implementation

- `src/parser.cpp` — added `toBeNaN`, `toBeInfinity`, `toBeFinite` to the `matchers_no_arg` whitelist.
- `src/codegen_test.cpp` — IR dispatch in `emitStmt(ExpectStmt)`:
  - `toBeNaN` → `FCmpUNO(actualVal, actualVal)`
  - `toBeInfinity` → `FCmpOEQ(fabs(actualVal), +Inf)` via `Intrinsic::fabs`
  - `toBeFinite` → `Not(Or(isNaN, isInf))`
- Failure messages emit `"NaN"`, `"Infinity"`, `"finite float"` via `cachedGlobalString`, matching the existing no-arg pattern.

## Notes

- `toBeInfinity` deliberately accepts both `±∞`. Use `expect(x).toEq(NEG_INF)` if you need to assert a specific sign.
- Type error tests are not added, matching the existing convention for `toBeTrue` / `toBeNone` / `toBeOk` etc. (no spec or C++ tests exist for those siblings either).
- tree-sitter grammar requires no change — matcher names parse as `\$.identifier`.

## Test plan

- [x] `cmake --build build` succeeds
- [x] `./build/ry test tests/spec/matchers.test.ry` passes (new `Float IEEE 754 special-value matchers` describe block, 11 cases)
- [x] `./build/ry test -p` — 186 spec files, 0 failures
- [x] `./build/ry_tests` — 2298 C++ tests, 0 failures
- [x] ASan + UBSan: `./build-asan/ry_tests` and `./build-asan/ry test -p` both clean
- [x] TSan: `./build-tsan/ry_tests` clean (Ry self-test warn-only per skill)
- [x] clang-tidy + cppcheck on `src/parser.cpp` / `src/codegen_test.cpp` clean
- [x] `fuzz_parser`: 44720 runs / 60s, 0 crashes
- [x] Manual ad-hoc verification of failure messages (`expected NaN, got 3.14`, etc.) and type error (`line N: toBeNaN: expected float`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added three new IEEE 754 special-value matchers: `toBeNaN()`, `toBeInfinity()` (covering both positive and negative infinity), and `toBeFinite()` for improved floating-point assertions in the testing framework.

* **Documentation**
  * Updated testing reference documentation with guidance on using the new special-value matchers.

* **Tests**
  * Added comprehensive test coverage for the new IEEE 754 matchers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->