### PR TITLE
feat(testing): add mockClear / mockReset / mockResetAll (#1684)

### DIFF
--- a/changelog.d/1684-mock-partial-reset.md
+++ b/changelog.d/1684-mock-partial-reset.md
@@ -1,0 +1,12 @@
+### Added
+
+- Added `mockClear(name)`, `mockReset(name)`, and `mockResetAll()` to
+  the testing framework for partial mock state reset within an `it`
+  block (Jest / Vitest compatible). `mockClear` resets the call count
+  while keeping the mock active; `mockReset` removes a single mock and
+  restores the original implementation; `mockResetAll` removes every
+  mock currently registered, equivalent to the automatic cleanup that
+  runs at the end of each `it` block but explicit and usable
+  mid-block. All three accept the function name as a string (same
+  convention as `verify`) and are no-ops when the name is not
+  currently mocked. (#1684)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -365,6 +365,91 @@ fn verifyCalledWithTests():
 - `int` argument literals are widened to `float` automatically when the parameter type is `float` (matching ordinary call-site coercion).
 - Returns `0` when no recorded call matches the supplied arguments.
 
+### mockClear(name)
+
+Resets the recorded call list (and call count) for a single mock to zero, but keeps the mock active. Subsequent calls continue to dispatch to the replacement.
+
+```ry
+from testing import it, describe, mock, verify, mockClear, expect
+
+@describe("mockClear")
+fn mockClearTests():
+    @it("should reset count but preserve mock")
+    fn shouldClearCount():
+        mock(fetchData, () => "fake")
+        fetchData()
+        fetchData()
+        expect(verify("fetchData")).toEq(2)
+        mockClear("fetchData")
+        expect(verify("fetchData")).toEq(0)
+        # mock is still active — calls continue to hit the replacement
+        x = fetchData()
+        expect(verify("fetchData")).toEq(1)
+```
+
+- Requires `from testing import mockClear`
+- The argument is the **string name** of the mocked function (same convention as `verify`)
+- No-op when `name` is not currently mocked (no error)
+- Affects `verify(name)` and `verifyCalledWith(name, args...)` identically — both observe the cleared call list
+
+### mockReset(name)
+
+Removes a single mock entirely, restoring the original implementation. After `mockReset`, calls dispatch to the original function and the call count is zero.
+
+```ry
+from testing import it, describe, mock, verify, mockReset, expect
+
+fn fetchData() -> str:
+    return "real"
+
+@describe("mockReset")
+fn mockResetTests():
+    @it("should restore original implementation")
+    fn shouldResetMock():
+        mock(fetchData, () => "fake")
+        expect(fetchData()).toEq("fake")
+        mockReset("fetchData")
+        expect(fetchData()).toEq("real")
+        expect(verify("fetchData")).toEq(0)
+```
+
+- Requires `from testing import mockReset`
+- The argument is the **string name** of the mocked function
+- No-op when `name` is not currently mocked (no error)
+- Releases the replacement closure environment (capturing closures' captured variables are dropped immediately, equivalent to `it`-block end auto-cleanup for this single mock)
+
+### mockResetAll()
+
+Removes every mock currently active in the enclosing `it` block. Equivalent to the automatic cleanup that runs when an `it` block ends, but explicit and usable mid-block.
+
+```ry
+from testing import it, describe, mock, verify, mockResetAll, expect
+
+fn fa() -> int:
+    return 1
+
+fn fb() -> int:
+    return 2
+
+@describe("mockResetAll")
+fn mockResetAllTests():
+    @it("should remove all mocks")
+    fn shouldResetAll():
+        mock(fa, () => 10)
+        mock(fb, () => 20)
+        fa()
+        fb()
+        mockResetAll()
+        expect(fa()).toEq(1)
+        expect(fb()).toEq(2)
+        expect(verify("fa")).toEq(0)
+        expect(verify("fb")).toEq(0)
+```
+
+- Requires `from testing import mockResetAll`
+- Takes no arguments
+- No-op when no mock is currently registered
+
 ### Limitations
 
 - Overloaded functions cannot be mocked.

--- a/include/ry/test_runtime.hpp
+++ b/include/ry/test_runtime.hpp
@@ -58,6 +58,8 @@ extern "C" {
                                             const int64_t *kinds,
                                             const int64_t *values);
     void    __ry_mock_clear_all();
+    void    __ry_mock_clear(const char *name);
+    void    __ry_mock_reset(const char *name);
 
     // Indent helpers
     const char *__ry_test_indent(int extra);

--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -25,6 +25,15 @@ fn _reportFail(line: int, message: str) -> Unit
 @native("testing")
 fn _mockGetCallCount(name: str) -> int
 
+@native("testing")
+fn _mockClear(name: str) -> Unit
+
+@native("testing")
+fn _mockReset(name: str) -> Unit
+
+@native("testing")
+fn _mockResetAll() -> Unit
+
 @public
 fn fail(_line: int, message: str = "") -> Unit:
   _reportFail(_line, message)
@@ -32,3 +41,15 @@ fn fail(_line: int, message: str = "") -> Unit:
 @public
 fn verify(name: str) -> int:
   return _mockGetCallCount(name)
+
+@public
+fn mockClear(name: str) -> Unit:
+  _mockClear(name)
+
+@public
+fn mockReset(name: str) -> Unit:
+  _mockReset(name)
+
+@public
+fn mockResetAll() -> Unit:
+  _mockResetAll()

--- a/src/runtime_testing.cpp
+++ b/src/runtime_testing.cpp
@@ -17,4 +17,16 @@ extern "C" int64_t __ry_testing__mockGetCallCount(const char *name) {
     return __ry_mock_get_call_count(name);
 }
 
+extern "C" void __ry_testing__mockClear(const char *name) {
+    __ry_mock_clear(name);
+}
+
+extern "C" void __ry_testing__mockReset(const char *name) {
+    __ry_mock_reset(name);
+}
+
+extern "C" void __ry_testing__mockResetAll() {
+    __ry_mock_clear_all();
+}
+
 } // namespace ry

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -471,6 +471,32 @@ static void mockReleaseClosureEnv(void *env_ptr, void (*env_dtor)(void *)) {
     }
 }
 
+// Release every retained per-call resource on a MockEntry (str arg handles,
+// list/map/record/tuple/fn snapshots) and reset the call counter / call log.
+// fn_ptr / env_ptr / env_dtor are NOT touched — the caller decides whether to
+// keep the mock active (mockClear), set new bindings (__ry_mock_set*), or wipe
+// the slot entirely (mockReset / __ry_mock_clear_all). Each free is paired
+// with an explicit `.clear()` so the vector cannot retain freed pointers if a
+// subsequent operation re-uses the same entry.
+static void releaseMockEntryRetainedArgs(MockEntry &entry) {
+    for (char *s : entry.retained_str_args) mockReleaseStr(s);
+    entry.retained_str_args.clear();
+    for (auto *snap : entry.retained_list_snapshots) freeMockListSnapshot(snap);
+    entry.retained_list_snapshots.clear();
+    for (auto *snap : entry.retained_map_snapshots) freeMockMapSnapshot(snap);
+    entry.retained_map_snapshots.clear();
+    for (auto *snap : entry.retained_record_snapshots)
+        freeMockRecordSnapshot(snap);
+    entry.retained_record_snapshots.clear();
+    for (auto *snap : entry.retained_tuple_snapshots)
+        freeMockTupleSnapshot(snap);
+    entry.retained_tuple_snapshots.clear();
+    for (auto *snap : entry.retained_fn_snapshots) freeMockFnSnapshot(snap);
+    entry.retained_fn_snapshots.clear();
+    entry.calls.clear();
+    entry.call_count = 0;
+}
+
 extern "C" {
 
 void __ry_test_describe_begin(const char *name) {
@@ -543,30 +569,34 @@ int __ry_test_summary() {
 void __ry_mock_set(const char *name, void *fn_ptr) {
     auto &entry = g_mock_registry[name];
     mockReleaseClosureEnv(entry.env_ptr, entry.env_dtor);
-    for (char *s : entry.retained_str_args) mockReleaseStr(s);
-    for (auto *snap : entry.retained_list_snapshots) freeMockListSnapshot(snap);
-    for (auto *snap : entry.retained_map_snapshots) freeMockMapSnapshot(snap);
-    for (auto *snap : entry.retained_record_snapshots) freeMockRecordSnapshot(snap);
-    for (auto *snap : entry.retained_tuple_snapshots) freeMockTupleSnapshot(snap);
-    for (auto *snap : entry.retained_fn_snapshots) freeMockFnSnapshot(snap);
-    entry = MockEntry{};
+    releaseMockEntryRetainedArgs(entry);
     entry.fn_ptr = fn_ptr;
+    entry.env_ptr = nullptr;
+    entry.env_dtor = nullptr;
 }
 
 void __ry_mock_set_closure(const char *name, void *thunk_ptr,
                             void *env_ptr, void (*env_dtor)(void *)) {
     auto &entry = g_mock_registry[name];
     mockReleaseClosureEnv(entry.env_ptr, entry.env_dtor);
-    for (char *s : entry.retained_str_args) mockReleaseStr(s);
-    for (auto *snap : entry.retained_list_snapshots) freeMockListSnapshot(snap);
-    for (auto *snap : entry.retained_map_snapshots) freeMockMapSnapshot(snap);
-    for (auto *snap : entry.retained_record_snapshots) freeMockRecordSnapshot(snap);
-    for (auto *snap : entry.retained_tuple_snapshots) freeMockTupleSnapshot(snap);
-    for (auto *snap : entry.retained_fn_snapshots) freeMockFnSnapshot(snap);
-    entry = MockEntry{};
+    releaseMockEntryRetainedArgs(entry);
     entry.fn_ptr = thunk_ptr;
     entry.env_ptr = env_ptr;
     entry.env_dtor = env_dtor;
+}
+
+void __ry_mock_clear(const char *name) {
+    auto it = g_mock_registry.find(name);
+    if (it == g_mock_registry.end()) return;
+    releaseMockEntryRetainedArgs(it->second);
+}
+
+void __ry_mock_reset(const char *name) {
+    auto it = g_mock_registry.find(name);
+    if (it == g_mock_registry.end()) return;
+    mockReleaseClosureEnv(it->second.env_ptr, it->second.env_dtor);
+    releaseMockEntryRetainedArgs(it->second);
+    g_mock_registry.erase(it);
 }
 
 void *__ry_mock_get(const char *name) {
@@ -1023,12 +1053,7 @@ void __ry_mock_clear_all() {
     for (auto &kv : g_mock_registry) {
         auto &entry = kv.second;
         mockReleaseClosureEnv(entry.env_ptr, entry.env_dtor);
-        for (char *s : entry.retained_str_args) mockReleaseStr(s);
-        for (auto *snap : entry.retained_list_snapshots) freeMockListSnapshot(snap);
-        for (auto *snap : entry.retained_map_snapshots) freeMockMapSnapshot(snap);
-        for (auto *snap : entry.retained_record_snapshots) freeMockRecordSnapshot(snap);
-        for (auto *snap : entry.retained_tuple_snapshots) freeMockTupleSnapshot(snap);
-        for (auto *snap : entry.retained_fn_snapshots) freeMockFnSnapshot(snap);
+        releaseMockEntryRetainedArgs(entry);
     }
     g_mock_registry.clear();
 }

--- a/tests/spec/mock.test.ry
+++ b/tests/spec/mock.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe, expect, mock, verify, verifyCalledWith
+from testing import it, describe, expect, mock, verify, verifyCalledWith, mockClear, mockReset, mockResetAll
 
 fn fetchData() -> str:
   return "real data"
@@ -568,3 +568,104 @@ fn verifyCalledWithFnArgs():
     takesFn(add5)
     expect(verifyCalledWith("takesFn", add5)).toEq(1)
     expect(verifyCalledWith("takesFn", add6)).toEq(0)
+
+@describe("mockClear")
+fn mockClearTests():
+  @it("should reset call count but preserve mock")
+  fn shouldResetCallCountPreserveMock():
+    mock("fetchData", () => "fake")
+    fetchData()
+    fetchData()
+    fetchData()
+    mockClear("fetchData")
+    expect(verify("fetchData")).toEq(0)
+    expect(fetchData()).toEq("fake")
+    expect(verify("fetchData")).toEq(1)
+  @it("should separate verifyCalledWith counts across clear")
+  fn shouldSeparateVerifyCalledWithCounts():
+    mock("compute", (x: int) => x * 10)
+    compute(5)
+    compute(5)
+    expect(verifyCalledWith("compute", 5)).toEq(2)
+    mockClear("compute")
+    expect(verifyCalledWith("compute", 5)).toEq(0)
+    compute(5)
+    expect(verifyCalledWith("compute", 5)).toEq(1)
+  @it("should release retained list-arg snapshots on clear")
+  fn shouldReleaseListArgSnapshots():
+    mock("takesIntList", (xs: List<int>) => len(xs))
+    takesIntList([1, 2, 3])
+    takesIntList([4, 5])
+    mockClear("takesIntList")
+    expect(verify("takesIntList")).toEq(0)
+    takesIntList([6, 7, 8, 9])
+    expect(verify("takesIntList")).toEq(1)
+    expect(verifyCalledWith("takesIntList", [6, 7, 8, 9])).toEq(1)
+  @it("should be selective across mocks")
+  fn shouldBeSelectiveClear():
+    mock("fetchData", () => "fake")
+    mock("compute", (x: int) => x * 10)
+    fetchData()
+    fetchData()
+    compute(1)
+    compute(2)
+    mockClear("fetchData")
+    expect(verify("fetchData")).toEq(0)
+    expect(verify("compute")).toEq(2)
+    expect(fetchData()).toEq("fake")
+  @it("should be no-op for unknown name")
+  fn shouldBeNoopUnknownClear():
+    mockClear("neverMocked")
+    expect(verify("neverMocked")).toEq(0)
+
+@describe("mockReset")
+fn mockResetTests():
+  @it("should restore original implementation")
+  fn shouldRestoreOriginal():
+    mock("fetchData", () => "fake")
+    expect(fetchData()).toEq("fake")
+    mockReset("fetchData")
+    expect(fetchData()).toEq("real data")
+    expect(verify("fetchData")).toEq(0)
+  @it("should release capturing closure env on reset")
+  fn shouldReleaseCapturingClosure():
+    factor = 3
+    mock("compute", (x: int) => x * factor)
+    expect(compute(2)).toEq(6)
+    mockReset("compute")
+    expect(compute(2)).toEq(4)
+    expect(verify("compute")).toEq(0)
+  @it("should be selective across mocks")
+  fn shouldBeSelectiveReset():
+    mock("fetchData", () => "fake")
+    mock("compute", (x: int) => x * 10)
+    mockReset("fetchData")
+    expect(fetchData()).toEq("real data")
+    expect(compute(5)).toEq(50)
+    expect(verify("compute")).toEq(1)
+  @it("should be no-op for unknown name")
+  fn shouldBeNoopUnknownReset():
+    mockReset("neverMocked")
+    expect(verify("neverMocked")).toEq(0)
+
+@describe("mockResetAll")
+fn mockResetAllTests():
+  @it("should remove all mocks in current it")
+  fn shouldRemoveAllMocks():
+    mock("fetchData", () => "fake")
+    mock("compute", (x: int) => x + 100)
+    mock("lookup", (k: str) => "mocked")
+    fetchData()
+    compute(1)
+    lookup("k")
+    mockResetAll()
+    expect(fetchData()).toEq("real data")
+    expect(compute(5)).toEq(10)
+    expect(lookup("hello")).toEq("hello")
+    expect(verify("fetchData")).toEq(0)
+    expect(verify("compute")).toEq(0)
+    expect(verify("lookup")).toEq(0)
+  @it("should be no-op on empty registry")
+  fn shouldBeNoopEmptyRegistry():
+    mockResetAll()
+    expect(verify("anything")).toEq(0)

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -122,7 +122,22 @@ protected:
             "fn _mockGetCallCount(name: str) -> int\n"
             "@public\n"
             "fn verify(name: str) -> int:\n"
-            "  return _mockGetCallCount(name)\n";
+            "  return _mockGetCallCount(name)\n"
+            "@native(\"testing\")\n"
+            "fn _mockClear(name: str) -> Unit\n"
+            "@public\n"
+            "fn mockClear(name: str) -> Unit:\n"
+            "  _mockClear(name)\n"
+            "@native(\"testing\")\n"
+            "fn _mockReset(name: str) -> Unit\n"
+            "@public\n"
+            "fn mockReset(name: str) -> Unit:\n"
+            "  _mockReset(name)\n"
+            "@native(\"testing\")\n"
+            "fn _mockResetAll() -> Unit\n"
+            "@public\n"
+            "fn mockResetAll() -> Unit:\n"
+            "  _mockResetAll()\n";
         return src + kDecls;
     }
 


### PR DESCRIPTION
## Summary

Add three new testing-framework APIs for partial mock state reset within
an `it` block (Jest / Vitest compatible):

- `mockClear(name)` — reset call count to zero, keep mock active
- `mockReset(name)` — remove a single mock, restore original implementation
- `mockResetAll()` — remove every mock currently registered

All three accept the function name as a string (same convention as
`verify`) and are no-ops when the name is not currently mocked.
`mockResetAll` is a thin shim over `__ry_mock_clear_all`, so it is
definitionally equivalent to the automatic cleanup that runs at the end
of each `it` block.

Internally, the three existing cleanup duplications
(`__ry_mock_set` / `__ry_mock_set_closure` / `__ry_mock_clear_all`) are
consolidated into a single `releaseMockEntryRetainedArgs` helper so the
new APIs and the existing paths share one definition. Each `free` loop
inside the helper is paired with an explicit `.clear()` to prevent the
vector from retaining freed pointers.

Closes #1684.

## Test plan

- [x] `tests/spec/mock.test.ry` — added 11 new cases across 3
      `@describe` blocks covering: clear preserves mock, separate
      verifyCalledWith counts, retained list-arg snapshot release
      (ASan regression), selective behavior, no-op for unknown name,
      capturing-closure env release on reset, all-mocks removal.
- [x] `./build/ry_tests` — 2298/2298 passed
- [x] `./build/ry test -p` — 186/186 files passed
- [x] `./build/ry test tests/spec/mock.test.ry` — 68/68 passed (loader path)
- [x] ASan + UBSan: clean (both `ry_tests` and `ry test -p`)
- [x] TSan: C++ `ry_tests` clean
- [x] clang-tidy / cppcheck: clean
- [x] Smoke-tested the three new doc examples end-to-end via `./build/ry test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `mockClear(name)` to reset call counts for a named mock while preserving its implementation
  * Added `mockReset(name)` to remove a specific mock and restore the original implementation
  * Added `mockResetAll()` to remove all active mocks within a test block

* **Documentation**
  * Added guides and usage examples for new mock management helpers

* **Tests**
  * Added comprehensive test coverage for all new mock functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->