### PR TITLE
feat(testing): add ergonomic matchers toBeBetween / toBeOneOf (#1689)

### DIFF
--- a/changelog.d/1689-ergonomic-matchers.md
+++ b/changelog.d/1689-ergonomic-matchers.md
@@ -1,0 +1,25 @@
+### Added
+
+- Added ergonomic matchers `toBeBetween(min, max)` and
+  `toBeOneOf(list)` to the testing framework. Both express common
+  assertion patterns that previously required verbose combinations:
+  `expect(x).toBeBetween(1, 10)` replaces
+  `expect(x).toBeGreaterThanOrEq(1)` plus
+  `expect(x).toBeLessThanOrEq(10)`, and
+  `expect(status).toBeOneOf([200, 201, 204])` replaces the
+  argument-order-reversed `expect([200, 201, 204]).toContain(status)`.
+  `toBeBetween` is inclusive on both bounds and accepts `int` /
+  `float` operands (mixed int/float is allowed); `toBeOneOf` accepts a
+  `List` whose element type matches the actual value (`int`, `float`,
+  `str`, or `bool`). Both emit `codegenError` for type or shape
+  mismatches. (#1689)
+
+### Fixed
+
+- Fixed the formatter dropping extra arguments on `expect` matchers
+  with more than one argument. Previously `expect(x).toBeCloseTo(1.0,
+  4)` was reformatted as `expect(x).toBeCloseTo(1.0)`, silently
+  discarding the `decimals` argument; the same gap would have affected
+  the new `toBeBetween(min, max)`. The formatter now emits every
+  argument in `ExpectStmt.extra_args` alongside the primary
+  `expected`. (#1689)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -155,6 +155,8 @@ foo("arg", ():
 | `toEndWith(suffix)` | Asserts string ends with suffix | str |
 | `toMatch(pattern)` | Asserts string matches the given regex pattern (unanchored; use `^` / `$` to anchor) | str |
 | `toBeCloseTo(value)` / `toBeCloseTo(value, decimals)` | Asserts approximate equality: `\|actual - value\| < 0.5 * 10^-decimals`. `decimals` defaults to `2` and must be a non-negative integer literal in `[0, 15]` | int, float |
+| `toBeBetween(min, max)` | Asserts `min <= actual <= max` (inclusive on both ends). Both bounds are required | int, float |
+| `toBeOneOf(list)` | Asserts `actual` equals at least one element in `list`. Equivalent to `toContain` with arguments reversed | int, float, str, bool (as List elements) |
 | `toBeNaN()` | Asserts value is NaN (IEEE 754); `NaN == NaN` is false, so use this matcher instead of `toEq` | float |
 | `toBeInfinity()` | Asserts value is positive or negative infinity (`+∞` or `-∞`) | float |
 | `toBeFinite()` | Asserts value is finite (not NaN and not `±∞`) | float |

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -1458,6 +1458,8 @@ void CodeGen::emitStmt(ExpectStmt &s) {
     llvm::Value *cmpResult = nullptr;
     // Save expectedVal from comparison section to reuse in failure message
     llvm::Value *savedExpectedVal = nullptr;
+    // For toBeBetween: capture max so the failure formatter can print "between min and max".
+    llvm::Value *savedMaxVal = nullptr;
     // For toBeCloseTo: capture decimals so the failure formatter can print it.
     int64_t savedDecimals = 0;
     bool savedDecimalsValid = false;
@@ -1675,6 +1677,105 @@ void CodeGen::emitStmt(ExpectStmt &s) {
             codegenError("line " + std::to_string(s.loc.line) +
                 ": " + s.matcher + ": requires int or float operands");
         }
+    } else if (s.matcher == "toBeBetween") {
+        llvm::Value *minVal = emitExpr(*s.expected);
+        savedExpectedVal = minVal;
+        llvm::Value *maxVal = emitExpr(*s.extra_args[0]);
+        savedMaxVal = maxVal;
+        llvm::Type *minTy = minVal->getType();
+        llvm::Type *maxTy = maxVal->getType();
+
+        bool actualOk = (actualTy == i64Ty_ || actualTy == f64Ty_);
+        bool minOk = (minTy == i64Ty_ || minTy == f64Ty_);
+        bool maxOk = (maxTy == i64Ty_ || maxTy == f64Ty_);
+        if (!actualOk || !minOk || !maxOk) {
+            codegenError("line " + std::to_string(s.loc.line) +
+                ": toBeBetween: requires int or float operands");
+        }
+
+        if (actualTy == i64Ty_ && minTy == i64Ty_ && maxTy == i64Ty_) {
+            llvm::Value *geMin = builder_.CreateICmpSGE(actualVal, minVal, "geMin");
+            llvm::Value *leMax = builder_.CreateICmpSLE(actualVal, maxVal, "leMax");
+            cmpResult = builder_.CreateAnd(geMin, leMax, "between");
+        } else {
+            llvm::Value *af = (actualTy == f64Ty_) ? actualVal
+                : builder_.CreateSIToFP(actualVal, f64Ty_, "actual_f");
+            llvm::Value *mf = (minTy == f64Ty_) ? minVal
+                : builder_.CreateSIToFP(minVal, f64Ty_, "min_f");
+            llvm::Value *xf = (maxTy == f64Ty_) ? maxVal
+                : builder_.CreateSIToFP(maxVal, f64Ty_, "max_f");
+            llvm::Value *geMin = builder_.CreateFCmpOGE(af, mf, "geMin");
+            llvm::Value *leMax = builder_.CreateFCmpOLE(af, xf, "leMax");
+            cmpResult = builder_.CreateAnd(geMin, leMax, "between");
+        }
+    } else if (s.matcher == "toBeOneOf") {
+        llvm::Value *listVal = emitExpr(*s.expected);
+        savedExpectedVal = listVal;
+
+        if (listVal->getType() != ptrTy_)
+            codegenError("line " + std::to_string(s.loc.line) +
+                ": toBeOneOf: expected a list argument");
+        llvm::Type *elemTy = getListElementType(listVal);
+        if (!elemTy)
+            codegenError("line " + std::to_string(s.loc.line) +
+                ": toBeOneOf: expected a list argument");
+        if (actualTy != elemTy)
+            codegenError("line " + std::to_string(s.loc.line) +
+                ": toBeOneOf: actual type does not match list element type");
+        if (elemTy != i64Ty_ && elemTy != f64Ty_ && elemTy != i1Ty_ && elemTy != ptrTy_)
+            codegenError("line " + std::to_string(s.loc.line) +
+                ": toBeOneOf: list element type must be int, float, str, or bool");
+
+        llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, listVal, 0, "oo_len_ptr");
+        llvm::Value *len = builder_.CreateLoad(i64Ty_, lenPtr, "oo_len");
+        llvm::Value *dataField = builder_.CreateStructGEP(listHeaderTy_, listVal, 2, "oo_data_field");
+        llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataField, "oo_data_ptr");
+
+        llvm::AllocaInst *foundVar = builder_.CreateAlloca(i1Ty_, nullptr, "oo_found");
+        builder_.CreateStore(llvm::ConstantInt::get(i1Ty_, 0), foundVar);
+        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, "oo_i");
+        builder_.CreateStore(llvm::ConstantInt::get(i64Ty_, 0), iVar);
+
+        llvm::Function *currentFnOO = builder_.GetInsertBlock()->getParent();
+        llvm::BasicBlock *cBB = llvm::BasicBlock::Create(*ctx_, "oneof.cond", currentFnOO);
+        llvm::BasicBlock *bBB = llvm::BasicBlock::Create(*ctx_, "oneof.body", currentFnOO);
+        llvm::BasicBlock *nBB = llvm::BasicBlock::Create(*ctx_, "oneof.next", currentFnOO);
+        llvm::BasicBlock *eBB = llvm::BasicBlock::Create(*ctx_, "oneof.end", currentFnOO);
+
+        builder_.CreateBr(cBB);
+        builder_.SetInsertPoint(cBB);
+        llvm::Value *ci = builder_.CreateLoad(i64Ty_, iVar, "oo_ci");
+        builder_.CreateCondBr(builder_.CreateICmpSLT(ci, len, "oo_clt"), bBB, eBB);
+
+        builder_.SetInsertPoint(bBB);
+        llvm::Value *curI = builder_.CreateLoad(i64Ty_, iVar, "oo_cur_i");
+        llvm::Value *ePtr = builder_.CreateGEP(elemTy, dataPtr, {curI}, "oo_elem_ptr");
+        llvm::Value *elem = builder_.CreateLoad(elemTy, ePtr, "oo_elem");
+        llvm::Value *eq;
+        if (elemTy == ptrTy_) {
+            auto strcmpFn = getStdlibStrcmp();
+            llvm::Value *cmp = builder_.CreateCall(strcmpFn, {actualVal, elem}, "oo_strcmp");
+            eq = builder_.CreateICmpEQ(cmp, llvm::ConstantInt::get(i32Ty_, 0), "oo_eq");
+        } else if (elemTy == f64Ty_) {
+            eq = builder_.CreateFCmpOEQ(actualVal, elem, "oo_eq");
+        } else {
+            eq = builder_.CreateICmpEQ(actualVal, elem, "oo_eq");
+        }
+
+        llvm::BasicBlock *foundBB = llvm::BasicBlock::Create(*ctx_, "oneof.found", currentFnOO);
+        builder_.CreateCondBr(eq, foundBB, nBB);
+        builder_.SetInsertPoint(foundBB);
+        builder_.CreateStore(llvm::ConstantInt::get(i1Ty_, 1), foundVar);
+        builder_.CreateBr(eBB);
+
+        builder_.SetInsertPoint(nBB);
+        llvm::Value *nextI = builder_.CreateAdd(
+            builder_.CreateLoad(i64Ty_, iVar, "oo_ni"), llvm::ConstantInt::get(i64Ty_, 1), "oo_next_i");
+        builder_.CreateStore(nextI, iVar);
+        builder_.CreateBr(cBB);
+
+        builder_.SetInsertPoint(eBB);
+        cmpResult = builder_.CreateLoad(i1Ty_, foundVar, "oo_result");
     } else if (s.matcher == "toHaveLen" || s.matcher == "toBeEmpty") {
         if (actualTy != ptrTy_)
             codegenError("line " + std::to_string(s.loc.line) +
@@ -1912,6 +2013,21 @@ void CodeGen::emitStmt(ExpectStmt &s) {
             llvm::ArrayType::get(llvm::Type::getInt8Ty(*ctx_), 128), nullptr, "cmp_buf");
         llvm::Value *fmt = cachedGlobalString(op + "%s", ".fmt_cmp");
         builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 128), fmt, valStr});
+        expectedStr = buf;
+    } else if (s.matcher == "toBeBetween") {
+        llvm::Value *minStr = formatValue(savedExpectedVal, savedExpectedVal->getType(), "min_buf");
+        llvm::Value *maxStr = formatValue(savedMaxVal, savedMaxVal->getType(), "max_buf");
+        llvm::Value *buf = builder_.CreateAlloca(
+            llvm::ArrayType::get(llvm::Type::getInt8Ty(*ctx_), 128), nullptr, "btw_buf");
+        llvm::Value *fmt = cachedGlobalString("between %s and %s", ".fmt_btw");
+        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 128), fmt, minStr, maxStr});
+        expectedStr = buf;
+    } else if (s.matcher == "toBeOneOf") {
+        llvm::Value *listStr = valueToString(savedExpectedVal);
+        llvm::Value *buf = builder_.CreateAlloca(
+            llvm::ArrayType::get(llvm::Type::getInt8Ty(*ctx_), 256), nullptr, "oo_msg");
+        llvm::Value *fmt = cachedGlobalString("one of %s", ".fmt_oo");
+        builder_.CreateCall(snprintfFn, {buf, llvm::ConstantInt::get(i64Ty_, 256), fmt, listStr});
         expectedStr = buf;
     } else if (s.matcher == "toHaveLen") {
         llvm::Value *buf = builder_.CreateAlloca(

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -1725,6 +1725,19 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         if (elemTy != i64Ty_ && elemTy != f64Ty_ && elemTy != i1Ty_ && elemTy != ptrTy_)
             codegenError("line " + std::to_string(s.loc.line) +
                 ": toBeOneOf: list element type must be int, float, str, or bool");
+        // Pointer-element branch routes to strcmp below; positive-allowlist
+        // narrow to str only — see codegen-llvm-ir-conventions.md "Collection
+        // ops on pointer elements". Mirrors emitListRemove guard.
+        if (elemTy == ptrTy_) {
+            const ValueMetadata *meta = getMeta(listVal);
+            const std::string &elemName = meta ? meta->list_elem_type_name : std::string{};
+            const bool isNonStrName = !elemName.empty() && elemName != "str";
+            const bool hasNestedList = meta && meta->nested_list_elem != nullptr;
+            const bool hasFnInfo = meta && meta->list_elem_fn_type_info.has_value();
+            if (isNonStrName || hasNestedList || hasFnInfo || !isStringValue(actualVal))
+                codegenError("line " + std::to_string(s.loc.line) +
+                    ": toBeOneOf: list element type must be int, float, str, or bool");
+        }
 
         llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, listVal, 0, "oo_len_ptr");
         llvm::Value *len = builder_.CreateLoad(i64Ty_, lenPtr, "oo_len");

--- a/src/formatter_stmt.cpp
+++ b/src/formatter_stmt.cpp
@@ -459,7 +459,12 @@ void Formatter::formatEllipsis(const EllipsisStmt &s) {
 void Formatter::formatExpect(const ExpectStmt &s) {
     emit("expect(" + formatExpr(*s.actual) + ")." + s.matcher);
     if (s.expected) {
-        emit("(" + formatExpr(*s.expected) + ")");
+        std::string args = "(" + formatExpr(*s.expected);
+        for (const auto &arg : s.extra_args) {
+            args += ", " + formatExpr(*arg);
+        }
+        args += ")";
+        emit(args);
     } else {
         emit("()");
     }

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -1210,7 +1210,8 @@ StmtNode Parser::parseExpectStatement() {
         "toEq", "toNotEq", "toContain", "toNotContain",
         "toBeGreaterThan", "toBeLessThan",
         "toBeGreaterThanOrEq", "toBeLessThanOrEq",
-        "toHaveLen", "toStartWith", "toEndWith", "toMatch"
+        "toHaveLen", "toStartWith", "toEndWith", "toMatch",
+        "toBeOneOf"
     };
     static const std::unordered_set<std::string> matchers_no_arg = {
         "toBeTrue", "toBeFalse", "toBeNone", "toBeSome", "toBeOk", "toBeErr", "toBeEmpty",
@@ -1223,6 +1224,12 @@ StmtNode Parser::parseExpectStatement() {
             lex_.next(); // consume ','
             es.extra_args.push_back(parseConditional());
         }
+    } else if (matcher == "toBeBetween") {
+        es.expected = parseConditional();
+        if (lex_.peek().kind != TokenKind::Comma)
+            parseError(matcherTok.line, "toBeBetween requires two arguments: min and max");
+        lex_.next(); // consume ','
+        es.extra_args.push_back(parseConditional());
     } else if (matchers_with_arg.count(matcher)) {
         es.expected = parseConditional();
     } else if (matchers_no_arg.count(matcher)) {

--- a/tests/spec/matchers.test.ry
+++ b/tests/spec/matchers.test.ry
@@ -287,3 +287,58 @@ fn floatIeee754Matchers():
   @it("should pass toBeFinite for very small finite value")
   fn shouldPassToBeFiniteForSmallValue():
     expect(-1.0e308).toBeFinite()
+
+@describe("Range matcher (toBeBetween)")
+fn rangeMatcherToBeBetween():
+  @it("should pass toBeBetween for int strictly inside range")
+  fn shouldPassToBeBetweenIntInside():
+    expect(5).toBeBetween(1, 10)
+  @it("should pass toBeBetween for int equal to lower bound (inclusive)")
+  fn shouldPassToBeBetweenIntLowerBound():
+    expect(1).toBeBetween(1, 10)
+  @it("should pass toBeBetween for int equal to upper bound (inclusive)")
+  fn shouldPassToBeBetweenIntUpperBound():
+    expect(10).toBeBetween(1, 10)
+  @it("should pass toBeBetween for negative int range")
+  fn shouldPassToBeBetweenIntNegative():
+    expect(-5).toBeBetween(-10, -1)
+  @it("should pass toBeBetween for float strictly inside range")
+  fn shouldPassToBeBetweenFloatInside():
+    expect(2.5).toBeBetween(2.0, 3.0)
+  @it("should pass toBeBetween for float equal to bounds")
+  fn shouldPassToBeBetweenFloatBoundary():
+    expect(0.0).toBeBetween(0.0, 0.0)
+  @it("should pass toBeBetween with int actual and float bounds")
+  fn shouldPassToBeBetweenIntActualFloatBounds():
+    expect(2).toBeBetween(1.5, 2.5)
+  @it("should pass toBeBetween with float actual and int bounds")
+  fn shouldPassToBeBetweenFloatActualIntBounds():
+    expect(1.5).toBeBetween(1, 2)
+
+@describe("Membership matcher (toBeOneOf)")
+fn membershipMatcherToBeOneOf():
+  @it("should pass toBeOneOf for int matching first element")
+  fn shouldPassToBeOneOfIntFirst():
+    expect(200).toBeOneOf([200, 201, 204])
+  @it("should pass toBeOneOf for int matching middle element")
+  fn shouldPassToBeOneOfIntMiddle():
+    expect(201).toBeOneOf([200, 201, 204])
+  @it("should pass toBeOneOf for int matching last element")
+  fn shouldPassToBeOneOfIntLast():
+    expect(204).toBeOneOf([200, 201, 204])
+  @it("should pass toBeOneOf for str matching element")
+  fn shouldPassToBeOneOfStr():
+    expect("get").toBeOneOf(["get", "post", "put"])
+  @it("should pass toBeOneOf for float matching element")
+  fn shouldPassToBeOneOfFloat():
+    expect(1.5).toBeOneOf([0.5, 1.5, 2.5])
+  @it("should pass toBeOneOf for bool matching element")
+  fn shouldPassToBeOneOfBool():
+    expect(true).toBeOneOf([true, false])
+  @it("should pass toBeOneOf for single-element list")
+  fn shouldPassToBeOneOfSingleElement():
+    expect(42).toBeOneOf([42])
+  @it("should pass toBeOneOf with list bound to variable")
+  fn shouldPassToBeOneOfListVariable():
+    allowed: List<int> = [1, 2, 3]
+    expect(2).toBeOneOf(allowed)

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1445,6 +1445,21 @@ TEST_F(CodeGenTest, ExpectToBeOneOfRejectsTypeMismatch) {
     EXPECT_THROW(runTestSource(src), std::runtime_error);
 }
 
+TEST_F(CodeGenTest, ExpectToBeOneOfRejectsListOfLists) {
+    // Pointer-element allowlist guard: non-str ptr elements (List<List<int>>)
+    // must be rejected before reaching strcmp on List headers.
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"list of lists\")\n"
+        "    fn listOfLists():\n"
+        "        a: List<int> = [1, 2]\n"
+        "        b: List<int> = [3, 4]\n"
+        "        expect(a).toBeOneOf([a, b])\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
 // ===== Field assignment subtype coercion (#359) =====
 
 TEST_F(CodeGenTest, FieldAssignSubtypeCoercion) {

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1355,6 +1355,96 @@ TEST_F(CodeGenTest, ExpectToBeCloseToCustomDecimals) {
     EXPECT_NO_THROW(runTestSource(src));
 }
 
+// ===== toBeBetween / toBeOneOf (#1689) =====
+
+TEST_F(CodeGenTest, ExpectToBeBetweenIntInside) {
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"in range\")\n"
+        "    fn inRange():\n"
+        "        expect(5).toBeBetween(1, 10)\n"
+    );
+    EXPECT_NO_THROW(runTestSource(src));
+}
+
+TEST_F(CodeGenTest, ExpectToBeBetweenRejectsBoolActual) {
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"bool actual\")\n"
+        "    fn boolActual():\n"
+        "        expect(true).toBeBetween(1, 10)\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ExpectToBeBetweenRejectsStrBound) {
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"str bound\")\n"
+        "    fn strBound():\n"
+        "        expect(5).toBeBetween(\"a\", 10)\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ExpectToBeBetweenRejectsSingleArg) {
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"single arg\")\n"
+        "    fn singleArg():\n"
+        "        expect(5).toBeBetween(1)\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ExpectToBeOneOfIntMatch) {
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"int match\")\n"
+        "    fn intMatch():\n"
+        "        expect(200).toBeOneOf([200, 201, 204])\n"
+    );
+    EXPECT_NO_THROW(runTestSource(src));
+}
+
+TEST_F(CodeGenTest, ExpectToBeOneOfRejectsNonList) {
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"non-list\")\n"
+        "    fn nonList():\n"
+        "        expect(200).toBeOneOf(200)\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ExpectToBeOneOfRejectsStrArg) {
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"str not list\")\n"
+        "    fn strNotList():\n"
+        "        expect(\"foo\").toBeOneOf(\"bar\")\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ExpectToBeOneOfRejectsTypeMismatch) {
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"type mismatch\")\n"
+        "    fn typeMismatch():\n"
+        "        expect(\"foo\").toBeOneOf([1, 2, 3])\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
 // ===== Field assignment subtype coercion (#359) =====
 
 TEST_F(CodeGenTest, FieldAssignSubtypeCoercion) {

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -637,3 +637,21 @@ TEST(FormatterTest, DirectiveDefRoundTripWithPublic) {
     EXPECT_EQ(first, src);
     EXPECT_EQ(Formatter::formatSource(first), first);
 }
+
+TEST(FormatterTest, ExpectToBeBetweenRoundTrip) {
+    auto src = "expect(x).toBeBetween(1, 10)\n";
+    EXPECT_EQ(fmt(src), src);
+    EXPECT_EQ(fmt(fmt(src)), fmt(src));
+}
+
+TEST(FormatterTest, ExpectToBeOneOfRoundTrip) {
+    auto src = "expect(x).toBeOneOf([200, 201, 204])\n";
+    EXPECT_EQ(fmt(src), src);
+    EXPECT_EQ(fmt(fmt(src)), fmt(src));
+}
+
+TEST(FormatterTest, ExpectToBeCloseToWithDecimalsRoundTrip) {
+    auto src = "expect(x).toBeCloseTo(1.0, 4)\n";
+    EXPECT_EQ(fmt(src), src);
+    EXPECT_EQ(fmt(fmt(src)), fmt(src));
+}


### PR DESCRIPTION
## Summary

Closes #1689.

Adds two ergonomic matchers to the `testing` module so frequently-used
assertion patterns can be expressed directly instead of via verbose
combinations:

- **`expect(x).toBeBetween(min, max)`** — inclusive range check,
  replaces `toBeGreaterThanOrEq(min)` + `toBeLessThanOrEq(max)`.
  Accepts `int` and `float` operands (mixed int/float allowed). Both
  bounds are required (single-arg form is rejected at parse time).
- **`expect(status).toBeOneOf([200, 201, 204])`** — membership check,
  replaces the argument-order-reversed `toContain`. Element type is
  one of `int` / `float` / `str` / `bool` and must match the actual
  value's type.

Both matchers are **codegen-only**: no `share/std/testing/testing.ry`
or runtime changes, consistent with the IEEE 754 matchers added in
#1685.

Also fixes a long-standing formatter bug: `ExpectStmt.extra_args` was
not being emitted, so `expect(x).toBeCloseTo(1.0, 4)` was silently
reformatted as `expect(x).toBeCloseTo(1.0)`. The same gap would have
affected the new `toBeBetween(min, max)`. A round-trip lock-in test
for `toBeCloseTo(value, decimals)` is included alongside the new
matcher round-trip tests.

## Test plan

- [x] `./build/ry_tests` — all 2309 C++ tests pass (incl. new
  `ExpectToBeBetween*` / `ExpectToBeOneOf*` rejection tests and
  formatter round-trip tests)
- [x] `./build/ry test -p` — all 186 Ry self-test files pass (incl.
  new `@describe` blocks in `tests/spec/matchers.test.ry`)
- [x] ASan + UBSan (`build-asan/`) clean for both C++ and Ry
  self-tests
- [x] TSan (`build-tsan/`) clean for both C++ and Ry self-tests
- [x] clang-tidy 0 warnings, cppcheck 0 errors
- [x] `fuzz_parser` 60s run clean (44714 runs, no crashes)
- [x] `tree-sitter` grammar unchanged; `editor/tree-sitter/queries/highlights.scm`
  has no per-matcher entries — no update required
- [x] `docs/reference/testing.md` matcher table updated
- [x] `changelog.d/1689-ergonomic-matchers.md` added

## Skipped pre-commit sections

(none — all sections in §0 matrix applied since this PR touches
parser/codegen/formatter and tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added toBeBetween(min, max) matcher (inclusive for int/float)
  * Added toBeOneOf(list) matcher (membership for int/float/str/bool)

* **Bug Fixes**
  * Formatter now preserves all arguments for expect matchers with multiple params

* **Documentation**
  * Updated testing reference with the new matchers

* **Tests**
  * Added unit and formatter tests covering the new matchers and formatting behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->