### PR TITLE
feat(testing): add spy() for call recording without replacement (#1683)

### DIFF
--- a/changelog.d/1683-spy-call-recording.md
+++ b/changelog.d/1683-spy-call-recording.md
@@ -1,0 +1,16 @@
+### Added
+
+- Added `spy(name)` to the testing framework for recording calls
+  without replacing the implementation. Unlike `mock(name, replacement)`
+  which fully replaces the function body, `spy` keeps the original
+  implementation running and only adds call-count and argument-recording
+  instrumentation around it. The argument is the function's name as a
+  string literal; overloaded functions and non-existent names are
+  rejected at compile time. `verify(name)` and
+  `verifyCalledWith(name, args...)` work uniformly on spied functions
+  (same internal call-recording registry as `mock`), and
+  `mockClear(name)` / `mockReset(name)` / `mockResetAll()` apply
+  identically. A function may be both mocked and spied across different
+  `it` blocks; when both are active in the same block, `mock` takes
+  precedence and the real implementation is bypassed. Spy registrations
+  are automatically cleared at the end of each `it` block. (#1683)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -36,10 +36,10 @@ When `ry test` is run without arguments, it:
 
 ### Syntax
 
-Test files use directives (`@it`, `@describe`) and the helpers `expect`, `mock`, `verify`, `verifyCalledWith`, `fail` from the `testing` module. Import them at the top using either `from testing` (wildcard) or `from testing import ...` (named). Several enforcement paths produce different error messages:
+Test files use directives (`@it`, `@describe`) and the helpers `expect`, `mock`, `spy`, `verify`, `verifyCalledWith`, `fail` from the `testing` module. Import them at the top using either `from testing` (wildcard) or `from testing import ...` (named). Several enforcement paths produce different error messages:
 
 - `@it` / `@describe` are declared in `share/std/testing/testing.ry` as `@directive` declarations. Without the import, codegen rejects them via the general directive-resolution mechanism with `unknown directive '@it'` or `unknown directive '@describe'`.
-- `expect`, `mock`, `fail`, `verifyCalledWith` are compiler intrinsics tracked separately and rejected with `'<name>' requires 'from testing import <name>'`.
+- `expect`, `mock`, `spy`, `fail`, `verifyCalledWith` are compiler intrinsics tracked separately and rejected with `'<name>' requires 'from testing import <name>'`.
 - `verify` is an ordinary `@public fn verify(name: str) -> int` declared in `share/std/testing/testing.ry`. Without the import, codegen rejects the call with the standard `undefined function: verify` diagnostic. (`verifyCalledWith` is an intrinsic — not a `@public fn` — because it must inspect the mocked function's signature at compile time to validate argument types, which a regular Ry function cannot do.)
 
 ```ry
@@ -366,6 +366,42 @@ fn verifyCalledWithTests():
 - `fn(...) -> R` arguments are compared by **pointer equality** on the `{thunk_ptr, env_ptr}` pair extracted from the uniform closure struct, not by structural / behavioral equivalence. Two independently constructed lambdas that happen to be structurally identical (e.g. `(x: int) => x + 1` written twice on different source lines) do not match — only the same closure value (a single named `let f = ...` flowing into both the recorded call and the verify side, or two `let` aliases of the same bare `@public fn`) matches. Capture closures with different captured environments (e.g. `makeAdder(5)` vs `makeAdder(6)`) are distinguished by the per-instance `env_ptr` even though they share a single cached capturing thunk. The fn signature must exactly match the recorded parameter type (since v0.0.22, #1715); mismatched parameter count, parameter types, or return type are rejected at compile time with both signatures included in the diagnostic. Within matching signatures, identity is determined by the pointer pair.
 - `int` argument literals are widened to `float` automatically when the parameter type is `float` (matching ordinary call-site coercion).
 - Returns `0` when no recorded call matches the supplied arguments.
+
+### spy(name)
+
+Records calls to a function without replacing its implementation. Unlike `mock`, the original function body still executes — `spy` only adds call-count and argument-recording instrumentation around it.
+
+```ry
+from testing import it, describe, spy, verify, verifyCalledWith, expect
+
+fn compute(x: int) -> int:
+    return x * 3
+
+@describe("spy")
+fn spyTests():
+    @it("records calls without replacing implementation")
+    fn recordsWithoutReplacing():
+        spy("compute")
+        expect(compute(5)).toEq(15)         # real implementation runs
+        expect(verify("compute")).toEq(1)   # call is recorded
+
+    @it("works with verifyCalledWith")
+    fn worksWithVerifyCalledWith():
+        spy("compute")
+        compute(7)
+        compute(8)
+        compute(7)
+        expect(verifyCalledWith("compute", 7)).toEq(2)
+        expect(verifyCalledWith("compute", 8)).toEq(1)
+```
+
+- Requires `from testing import spy` (since v0.0.24, #1683)
+- The argument is the **string literal** name of the function (same convention as `verifyCalledWith`)
+- The function must exist and must not be overloaded; both are compile errors
+- Spy registrations are automatically cleared at the end of each `it` block (same lifecycle as `mock`)
+- `verify(name)` and `verifyCalledWith(name, args...)` work uniformly on spied functions (same call-recording mechanism as `mock`)
+- `mockClear(name)` / `mockReset(name)` / `mockResetAll()` apply to spied functions identically — they share the same internal registry
+- A function may be both mocked and spied across different `it` blocks within the same describe. When both are active in the same block (mock+spy coexistence), `mock` takes precedence: the replacement runs and the call is counted; the real implementation is bypassed
 
 ### mockClear(name)
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -426,9 +426,10 @@ fn mockClearTests():
 ```
 
 - Requires `from testing import mockClear`
-- The argument is the **string name** of the mocked function (same convention as `verify`)
-- No-op when `name` is not currently mocked (no error)
+- The argument is the **string name** of the mocked or spied function (same convention as `verify`)
+- No-op when `name` is not currently mocked or spied (no error)
 - Affects `verify(name)` and `verifyCalledWith(name, args...)` identically — both observe the cleared call list
+- Applies to spied functions identically — mock and spy share the same call-recording registry (#1683)
 
 ### mockReset(name)
 
@@ -452,9 +453,10 @@ fn mockResetTests():
 ```
 
 - Requires `from testing import mockReset`
-- The argument is the **string name** of the mocked function
-- No-op when `name` is not currently mocked (no error)
+- The argument is the **string name** of the mocked or spied function
+- No-op when `name` is not currently mocked or spied (no error)
 - Releases the replacement closure environment (capturing closures' captured variables are dropped immediately, equivalent to `it`-block end auto-cleanup for this single mock)
+- Applies to spied functions identically — removes the spy registration, after which `verify(name)` returns 0 (#1683)
 
 ### mockResetAll()
 
@@ -486,7 +488,8 @@ fn mockResetAllTests():
 
 - Requires `from testing import mockResetAll`
 - Takes no arguments
-- No-op when no mock is currently registered
+- No-op when no mock or spy is currently registered
+- Clears spied functions identically — the registry is shared between mock and spy (#1683)
 
 ### Limitations
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1412,9 +1412,14 @@ public:
     llvm::Function *emitTestFunction(const std::string &namePrefix,
         const std::vector<llvm::Type*> &paramTypes, LambdaExpr &lam, const std::string &context);
     void emitMockCall(CallStmt &s);
+    void emitSpyCall(CallStmt &s);
     void emitFailCall(CallStmt &s);
     llvm::Value *emitVerifyCalledWithCall(const CallExpr &e);
+    void emitMockArgRecording(llvm::Value *nameStr,
+                               const std::vector<llvm::Value *> &argVals,
+                               OverloadEntry *matchedEntry);
     std::unordered_set<std::string> mocked_functions_;
+    std::unordered_set<std::string> spied_functions_;
     std::unordered_map<std::string, llvm::Constant*> mock_name_strings_;
     llvm::Value *toBool(llvm::Value *v);
 

--- a/include/ry/test_runtime.hpp
+++ b/include/ry/test_runtime.hpp
@@ -14,10 +14,11 @@ extern "C" {
     void __ry_test_fail(int line, const char *msg);
     int  __ry_test_summary();
 
-    // Mock support
+    // Mock / spy support
     void    __ry_mock_set(const char *name, void *fn_ptr);
     void    __ry_mock_set_closure(const char *name, void *thunk_ptr,
                                    void *env_ptr, void (*env_dtor)(void *));
+    void    __ry_spy_register(const char *name);
     void   *__ry_mock_get(const char *name);
     void   *__ry_mock_get_env(const char *name);
     int64_t __ry_mock_get_call_count(const char *name);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -742,47 +742,54 @@ bool CodeGen::isCapturedVar(llvm::AllocaInst *ptr) const {
 }
 
 // Forward declaration for mutual recursion.
-static void collectMockedFunctionsFromStmts(const std::vector<StmtNode> &stmts,
-                                             std::unordered_set<std::string> &out);
+static void collectTestTargetsFromStmts(const std::vector<StmtNode> &stmts,
+                                        std::unordered_set<std::string> &mocked,
+                                        std::unordered_set<std::string> &spied);
 
-// Scan a single statement (and its nested bodies) for mock() call targets.
-static void collectMockedFunctionsFromStmt(const StmtNode &stmt,
-                                            std::unordered_set<std::string> &out) {
+// Scan a single statement (and its nested bodies) for mock() / spy() targets.
+static void collectTestTargetsFromStmt(const StmtNode &stmt,
+                                       std::unordered_set<std::string> &mocked,
+                                       std::unordered_set<std::string> &spied) {
     std::visit([&](const auto &s) {
         using T = std::decay_t<decltype(s)>;
         if constexpr (std::is_same_v<T, CallStmt>) {
-            if (s.callee == "mock" && !s.args.empty()) {
-                if (auto *str = std::get_if<StringExpr>(&s.args[0]->data))
-                    out.insert(str->value);
+            if ((s.callee == "mock" || s.callee == "spy") && !s.args.empty()) {
+                if (auto *str = std::get_if<StringExpr>(&s.args[0]->data)) {
+                    if (s.callee == "mock")
+                        mocked.insert(str->value);
+                    else
+                        spied.insert(str->value);
+                }
             }
             for (auto &arg : s.args) {
                 if (auto *lam = std::get_if<std::unique_ptr<LambdaExpr>>(&arg->data))
-                    collectMockedFunctionsFromStmts((*lam)->body, out);
+                    collectTestTargetsFromStmts((*lam)->body, mocked, spied);
             }
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) {
-            collectMockedFunctionsFromStmts(s->branch.body, out);
-            collectMockedFunctionsFromStmts(s->else_body, out);
+            collectTestTargetsFromStmts(s->branch.body, mocked, spied);
+            collectTestTargetsFromStmts(s->else_body, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondStmt>>) {
             for (auto &arm : s->arms)
-                collectMockedFunctionsFromStmts(arm.body, out);
-            collectMockedFunctionsFromStmts(s->else_body, out);
+                collectTestTargetsFromStmts(arm.body, mocked, spied);
+            collectTestTargetsFromStmts(s->else_body, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) { // NOLINT(bugprone-branch-clone)
-            collectMockedFunctionsFromStmts(s->body, out);
+            collectTestTargetsFromStmts(s->body, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) {
-            collectMockedFunctionsFromStmts(s->body, out);
+            collectTestTargetsFromStmts(s->body, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
-            collectMockedFunctionsFromStmts(s->body, out);
+            collectTestTargetsFromStmts(s->body, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseStmt>>) {
             for (auto &arm : s->arms)
-                collectMockedFunctionsFromStmts(arm.body, out);
+                collectTestTargetsFromStmts(arm.body, mocked, spied);
         }
     }, stmt);
 }
 
-static void collectMockedFunctionsFromStmts(const std::vector<StmtNode> &stmts,
-                                             std::unordered_set<std::string> &out) {
+static void collectTestTargetsFromStmts(const std::vector<StmtNode> &stmts,
+                                        std::unordered_set<std::string> &mocked,
+                                        std::unordered_set<std::string> &spied) {
     for (const auto &stmt : stmts)
-        collectMockedFunctionsFromStmt(stmt, out);
+        collectTestTargetsFromStmt(stmt, mocked, spied);
 }
 
 llvm::orc::ThreadSafeModule CodeGen::compile(Program &prog) {
@@ -792,7 +799,7 @@ llvm::orc::ThreadSafeModule CodeGen::compile(Program &prog) {
     for (auto &stmt : prog) {
         collectTypeGraphFromStmt(stmt, typeGraph, allTypes);
         if (test_mode_)
-            collectMockedFunctionsFromStmt(stmt, mocked_functions_);
+            collectTestTargetsFromStmt(stmt, mocked_functions_, spied_functions_);
     }
     runCyclicTypeAnalysis(typeGraph, allTypes);
 

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -348,8 +348,39 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         popScope();
     };
 
-    // In test mode, inject mock dispatch only for functions targeted by mock()
-    if (test_mode_ && mocked_functions_.count(callee)) {
+    // In test mode, inject mock/spy dispatch for functions targeted by mock()
+    // or spy(). Three cases (#1683):
+    //   (a) mocked only          → tri-block (mockBB increments + replaces,
+    //                              origBB runs real impl)
+    //   (b) spied only           → linear: increment + record args, then fall
+    //                              through to the normal call path below
+    //   (c) mocked AND spied     → tri-block; origBB additionally increments
+    //                              + records before invoking the real impl
+    //                              (so spy() in a sibling it block keeps its
+    //                              recording semantics when mock is inactive
+    //                              at runtime — the runtime registry keys
+    //                              mocks and spies into the same entry so
+    //                              both compile-time sets can be populated)
+    const bool isMocked = test_mode_ && mocked_functions_.count(callee);
+    const bool isSpied = test_mode_ && spied_functions_.count(callee);
+
+    if (isSpied && !isMocked) {
+        // Case (b): spy-only. No mock branching needed — runtime entry is
+        // populated by __ry_spy_register but never has fn_ptr/env_ptr set,
+        // so the mockBB path would be dead. Emit linear increment + arg
+        // recording, then fall through to the normal call path below.
+        auto &nameStr = mock_name_strings_[callee];
+        if (!nameStr) nameStr = cachedGlobalString(callee, ".mock." + callee);
+        llvm::FunctionType *mockIncTy = llvm::FunctionType::get(
+            llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+        llvm::FunctionCallee mockIncFn = mod_->getOrInsertFunction(
+            "__ry_mock_increment_call", mockIncTy);
+        builder_.CreateCall(mockIncFn, {nameStr});
+        emitMockArgRecording(nameStr, argVals, matchedEntry);
+        // fall through to L862+ normal call path
+    }
+
+    if (isMocked) {
         llvm::FunctionType *mockGetTy = llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
         llvm::FunctionCallee mockGetFn = mod_->getOrInsertFunction("__ry_mock_get", mockGetTy);
         llvm::FunctionCallee mockGetEnvFn = mod_->getOrInsertFunction("__ry_mock_get_env", mockGetTy);
@@ -361,437 +392,19 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         if (!nameStr) nameStr = cachedGlobalString(callee, ".mock." + callee);
         llvm::Value *mockPtr = builder_.CreateCall(mockGetFn, {nameStr}, "mock_ptr");
         llvm::Value *nullPtr = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
-        llvm::Value *isMocked = builder_.CreateICmpNE(mockPtr, nullPtr, "is_mocked");
+        llvm::Value *mockActive = builder_.CreateICmpNE(mockPtr, nullPtr, "is_mocked");
 
         llvm::BasicBlock *mockBB = llvm::BasicBlock::Create(*ctx_, "mock_bb", fn_);
         llvm::BasicBlock *origBB = llvm::BasicBlock::Create(*ctx_, "orig_bb", fn_);
         llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "merge_bb", fn_);
 
-        builder_.CreateCondBr(isMocked, mockBB, origBB);
+        builder_.CreateCondBr(mockActive, mockBB, origBB);
 
         // Mock path: branch on env ptr to choose plain vs capture-closure ABI.
         builder_.SetInsertPoint(mockBB);
         emitMockRequireChecks();
         builder_.CreateCall(mockIncFn, {nameStr});
-
-        // Record call args for verifyCalledWith(name, ...). Mock kind tags:
-        //   1=int (raw i64), 2=float (bitcast f64->i64), 3=bool (zext i1->i64),
-        //   4=str (ptr->i64, retain handle),
-        //   5=opaque (unsupported in v1; never matches a verifyCalledWith query),
-        //   6=list (snapshot ptr; #1703 — element kind ∈ {1..4}),
-        //   7=set  (snapshot ptr; #1704 — unordered compare; element kind ∈ {1..4}),
-        //   8=map  (snapshot ptr; #1705 — unordered key->value; key/val kind ∈ {1..4}),
-        //   9=record (snapshot ptr; #1706 — per-slot compare; field kind ∈ {1..4}),
-        //  10=tuple  (snapshot ptr; #1706 — per-slot compare; element kind ∈ {1..4}),
-        //  11=fn    (snapshot ptr; #1707 — pointer-equality on {thunk, env}).
-        llvm::FunctionType *mockBeginRecTy =
-            llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
-        llvm::FunctionCallee mockBeginRecFn = mod_->getOrInsertFunction(
-            "__ry_mock_begin_call_record", mockBeginRecTy);
-        llvm::FunctionType *mockStoreArgTy = llvm::FunctionType::get(
-            llvm::Type::getVoidTy(*ctx_),
-            {ptrTy_, i64Ty_, i64Ty_, ptrTy_}, false);
-        llvm::FunctionCallee mockStoreArgFn = mod_->getOrInsertFunction(
-            "__ry_mock_store_arg", mockStoreArgTy);
-        llvm::FunctionType *mockStoreArgListTy = llvm::FunctionType::get(
-            llvm::Type::getVoidTy(*ctx_),
-            {ptrTy_, ptrTy_, i64Ty_, i64Ty_, ptrTy_}, false);
-        llvm::FunctionCallee mockStoreArgListFn = mod_->getOrInsertFunction(
-            "__ry_mock_store_arg_list", mockStoreArgListTy);
-        llvm::FunctionCallee mockStoreArgSetFn = mod_->getOrInsertFunction(
-            "__ry_mock_store_arg_set", mockStoreArgListTy);
-        llvm::FunctionType *mockStoreArgMapTy = llvm::FunctionType::get(
-            llvm::Type::getVoidTy(*ctx_),
-            {ptrTy_, ptrTy_, i64Ty_, i64Ty_, i64Ty_, i64Ty_, ptrTy_}, false);
-        llvm::FunctionCallee mockStoreArgMapFn = mod_->getOrInsertFunction(
-            "__ry_mock_store_arg_map", mockStoreArgMapTy);
-        llvm::Value *callRec = builder_.CreateCall(
-            mockBeginRecFn, {nameStr}, "mock_call_rec");
-
-        const size_t recordCount = matchedEntry
-            ? std::min(argVals.size(), matchedEntry->paramTypes.size())
-            : argVals.size();
-        for (size_t i = 0; i < recordCount; ++i) {
-            llvm::Value *argVal = argVals[i];
-            llvm::Type *argTy = argVal->getType();
-            // List<T> arg path (#1703): when T ∈ {int, float, bool, str},
-            // record via __ry_mock_store_arg_list which deep-copies the
-            // element buffer into a MockListSnapshot. Other element types
-            // (nested list, Map, record, …) fall through to kind=5 opaque.
-            if (argTy == ptrTy_) {
-                llvm::Type *listElemTy = getListElementType(argVal);
-                if (listElemTy != nullptr) {
-                    const auto *meta = getMeta(argVal);
-                    std::string elemName =
-                        meta ? meta->list_elem_type_name : std::string();
-                    int64_t elemKind = 0;
-                    if (elemName == "int") elemKind = 1;
-                    else if (elemName == "float") elemKind = 2;
-                    else if (elemName == "bool") elemKind = 3;
-                    else if (elemName == "str") elemKind = 4;
-                    else if (elemName.empty()) {
-                        // Fall back to LLVM type when the source-level name
-                        // was not stamped (literal `[1, 2, 3]` may not always
-                        // carry a name on every codepath).
-                        if (listElemTy == i64Ty_) elemKind = 1;
-                        else if (listElemTy == f64Ty_) elemKind = 2;
-                        else if (listElemTy == i1Ty_ || listElemTy == i8Ty_)
-                            elemKind = 3;
-                        else if (listElemTy == ptrTy_) elemKind = 4;
-                    }
-                    if (elemKind != 0) {
-                        const llvm::DataLayout &dl = mod_->getDataLayout();
-                        uint64_t elemSize = dl.getTypeAllocSize(listElemTy);
-                        builder_.CreateCall(
-                            mockStoreArgListFn,
-                            {callRec, argVal,
-                             llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(elemKind), true),
-                             llvm::ConstantInt::get(i64Ty_, elemSize, false),
-                             nameStr});
-                        continue;
-                    }
-                }
-            }
-            // Set<T> arg path (#1704): mirror of the List path. The only
-            // semantic difference (unordered comparison) is realized in
-            // mockArgEqual's kind-7 branch, not here.
-            if (argTy == ptrTy_) {
-                llvm::Type *setElemTy = getSetElementType(argVal);
-                if (setElemTy != nullptr) {
-                    const auto *meta = getMeta(argVal);
-                    std::string elemName =
-                        meta ? meta->set_elem_type_name : std::string();
-                    int64_t elemKind = 0;
-                    if (elemName == "int") elemKind = 1;
-                    else if (elemName == "float") elemKind = 2;
-                    else if (elemName == "bool") elemKind = 3;
-                    else if (elemName == "str") elemKind = 4;
-                    else if (elemName.empty()) {
-                        if (setElemTy == i64Ty_) elemKind = 1;
-                        else if (setElemTy == f64Ty_) elemKind = 2;
-                        else if (setElemTy == i1Ty_ || setElemTy == i8Ty_)
-                            elemKind = 3;
-                        // Do not infer str from a bare ptr element type:
-                        // unknown pointer-backed elements stay opaque (kind
-                        // 5) so List/Map/Set/closure-backed sets cannot
-                        // sneak through the kind-4 path. emitSetLiteral
-                        // stamps set_elem_type_name = "str" via
-                        // anyElemIsStrLike for bare-literal Set<str>, so
-                        // the elemName == "str" branch above covers them.
-                    }
-                    if (elemKind != 0) {
-                        const llvm::DataLayout &dl = mod_->getDataLayout();
-                        uint64_t elemSize = dl.getTypeAllocSize(setElemTy);
-                        builder_.CreateCall(
-                            mockStoreArgSetFn,
-                            {callRec, argVal,
-                             llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(elemKind), true),
-                             llvm::ConstantInt::get(i64Ty_, elemSize, false),
-                             nameStr});
-                        continue;
-                    }
-                }
-            }
-            // Map<K, V> arg path (#1705): K, V ∈ {int, float, bool, str}.
-            // Records via __ry_mock_store_arg_map which deep-copies both
-            // parallel buffers (keys + vals) into a MockMapSnapshot. Other
-            // K / V combinations fall through to kind=5 opaque.
-            if (argTy == ptrTy_) {
-                llvm::Type *mapKeyTy = getMapKeyType(argVal);
-                llvm::Type *mapValTy = getMapValueType(argVal);
-                if (mapKeyTy != nullptr && mapValTy != nullptr) {
-                    const auto *meta = getMeta(argVal);
-                    std::string keyName =
-                        meta ? meta->map_key_type_name : std::string();
-                    std::string valName =
-                        meta ? meta->map_value_type_name : std::string();
-                    auto resolveKind = [&](const std::string &name,
-                                            llvm::Type *ty) -> int64_t {
-                        if (name == "int") return 1;
-                        if (name == "float") return 2;
-                        if (name == "bool") return 3;
-                        if (name == "str") return 4;
-                        if (name.empty()) {
-                            if (ty == i64Ty_) return 1;
-                            if (ty == f64Ty_) return 2;
-                            if (ty == i1Ty_ || ty == i8Ty_) return 3;
-                            // Bare ptr without a stamped name is opaque —
-                            // do not infer str (mirrors the Set guard).
-                        }
-                        return 0;
-                    };
-                    int64_t keyKind = resolveKind(keyName, mapKeyTy);
-                    int64_t valKind = resolveKind(valName, mapValTy);
-                    if (keyKind != 0 && valKind != 0) {
-                        const llvm::DataLayout &dl = mod_->getDataLayout();
-                        uint64_t keySize = dl.getTypeAllocSize(mapKeyTy);
-                        uint64_t valSize = dl.getTypeAllocSize(mapValTy);
-                        builder_.CreateCall(
-                            mockStoreArgMapFn,
-                            {callRec, argVal,
-                             llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(keyKind), true),
-                             llvm::ConstantInt::get(i64Ty_, keySize, false),
-                             llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(valKind), true),
-                             llvm::ConstantInt::get(i64Ty_, valSize, false),
-                             nameStr});
-                        continue;
-                    }
-                }
-            }
-            // Record / tuple arg paths (#1706): when every field/element is
-            // primitive (int/float/bool) or str, build per-slot kinds[] and
-            // values[] stack alloca buffers and call the dedicated runtime
-            // helper. All-or-nothing — any unsupported field/element kind
-            // falls through to kind=5 opaque so cross-shape verifyCalledWith
-            // attempts still produce a clean error in Stage 1 of
-            // emitVerifyCalledWithCall.
-            if (auto *st = llvm::dyn_cast<llvm::StructType>(argTy)) {
-                auto kindForFieldName =
-                    [](const std::string &n) -> int64_t {
-                        if (n == "int") return 1;
-                        if (n == "float") return 2;
-                        if (n == "bool") return 3;
-                        if (n == "str") return 4;
-                        return 0;
-                    };
-                bool emittedRecordOrTuple = false;
-                if (st->hasName()) {
-                    const std::string recName = st->getName().str();
-                    auto recIt = record_types_.find(recName);
-                    if (recIt != record_types_.end()) {
-                        const auto &info = recIt->second;
-                        std::vector<int64_t> kinds;
-                        kinds.reserve(info.fields.size());
-                        bool allOk = true;
-                        for (const auto &fld : info.fields) {
-                            std::string fldName =
-                                resolveTypeAlias(fld.type->toString());
-                            int64_t k = kindForFieldName(fldName);
-                            if (k == 0) { allOk = false; break; }
-                            kinds.push_back(k);
-                        }
-                        if (allOk && !info.fields.empty()) {
-                            llvm::FunctionType *mockStoreArgRecordTy =
-                                llvm::FunctionType::get(
-                                    llvm::Type::getVoidTy(*ctx_),
-                                    {ptrTy_, ptrTy_, i64Ty_, ptrTy_, ptrTy_, ptrTy_},
-                                    false);
-                            llvm::FunctionCallee mockStoreArgRecordFn =
-                                mod_->getOrInsertFunction(
-                                    "__ry_mock_store_arg_record",
-                                    mockStoreArgRecordTy);
-                            llvm::Constant *typeNameStr = cachedGlobalString(
-                                recName, llvm::Twine(".mock.record_name.") + recName);
-                            int64_t fieldCount =
-                                static_cast<int64_t>(info.fields.size());
-                            llvm::Value *kindsAlloca =
-                                builder_.CreateAlloca(
-                                    i8Ty_,
-                                    llvm::ConstantInt::get(
-                                        i64Ty_,
-                                        static_cast<uint64_t>(fieldCount)),
-                                    "mock_rec_kinds");
-                            llvm::Value *valsAlloca =
-                                builder_.CreateAlloca(
-                                    i64Ty_,
-                                    llvm::ConstantInt::get(
-                                        i64Ty_,
-                                        static_cast<uint64_t>(fieldCount)),
-                                    "mock_rec_vals");
-                            for (size_t fi = 0; fi < info.fields.size(); ++fi) {
-                                int64_t k = kinds[fi];
-                                llvm::Value *fieldVal =
-                                    builder_.CreateExtractValue(
-                                        argVal, {static_cast<unsigned>(fi)},
-                                        "mock_rec_fld");
-                                llvm::Value *valI64;
-                                if (k == 1) valI64 = fieldVal;
-                                else if (k == 2)
-                                    valI64 = builder_.CreateBitCast(
-                                        fieldVal, i64Ty_, "mock_rec_f2i");
-                                else if (k == 3)
-                                    valI64 = builder_.CreateZExt(
-                                        fieldVal, i64Ty_, "mock_rec_b2i");
-                                else // k == 4 (str)
-                                    valI64 = builder_.CreatePtrToInt(
-                                        fieldVal, i64Ty_, "mock_rec_p2i");
-                                llvm::Value *kindGEP = builder_.CreateGEP(
-                                    i8Ty_, kindsAlloca,
-                                    llvm::ConstantInt::get(
-                                        i64Ty_, static_cast<uint64_t>(fi)));
-                                builder_.CreateStore(
-                                    llvm::ConstantInt::get(
-                                        i8Ty_, static_cast<uint64_t>(k), true),
-                                    kindGEP);
-                                llvm::Value *valGEP = builder_.CreateGEP(
-                                    i64Ty_, valsAlloca,
-                                    llvm::ConstantInt::get(
-                                        i64Ty_, static_cast<uint64_t>(fi)));
-                                builder_.CreateStore(valI64, valGEP);
-                            }
-                            builder_.CreateCall(
-                                mockStoreArgRecordFn,
-                                {callRec, typeNameStr,
-                                 llvm::ConstantInt::get(
-                                     i64Ty_,
-                                     static_cast<uint64_t>(fieldCount), true),
-                                 kindsAlloca, valsAlloca, nameStr});
-                            emittedRecordOrTuple = true;
-                        }
-                    }
-                }
-                if (!emittedRecordOrTuple && isTupleStructType(st)) {
-                    // Tuple kinds derived from per-element LLVM types only
-                    // when the source-level name is unavailable; if metadata
-                    // carries `source_type_name = "(T1, T2, ...)"`, prefer
-                    // that for str detection (LLVM type ptr alone is opaque).
-                    const auto *meta = getMeta(argVal);
-                    std::vector<std::string> elemNames;
-                    if (meta) {
-                        std::string tupleSig = !meta->source_type_name.empty()
-                            ? meta->source_type_name
-                            : std::string();
-                        if (!tupleSig.empty())
-                            elemNames = splitTupleSig(tupleSig);
-                    }
-                    unsigned arity = st->getNumElements();
-                    std::vector<int64_t> kinds;
-                    kinds.reserve(arity);
-                    bool allOk = arity > 0;
-                    for (unsigned ei = 0; ei < arity; ++ei) {
-                        llvm::Type *elemTy = st->getElementType(ei);
-                        int64_t k = 0;
-                        if (ei < elemNames.size()) {
-                            k = kindForFieldName(elemNames[ei]);
-                        }
-                        if (k == 0) {
-                            // Fall back to LLVM type when source name is missing.
-                            if (elemTy == i64Ty_) k = 1;
-                            else if (elemTy == f64Ty_) k = 2;
-                            else if (elemTy == i1Ty_ || elemTy == i8Ty_) k = 3;
-                            // Bare ptr without a stamped name is opaque —
-                            // do not infer str (mirrors the Set/Map guard).
-                        }
-                        if (k == 0) { allOk = false; break; }
-                        kinds.push_back(k);
-                    }
-                    if (allOk) {
-                        llvm::FunctionType *mockStoreArgTupleTy =
-                            llvm::FunctionType::get(
-                                llvm::Type::getVoidTy(*ctx_),
-                                {ptrTy_, i64Ty_, ptrTy_, ptrTy_, ptrTy_},
-                                false);
-                        llvm::FunctionCallee mockStoreArgTupleFn =
-                            mod_->getOrInsertFunction(
-                                "__ry_mock_store_arg_tuple",
-                                mockStoreArgTupleTy);
-                        llvm::Value *kindsAlloca =
-                            builder_.CreateAlloca(
-                                i8Ty_,
-                                llvm::ConstantInt::get(
-                                    i64Ty_, static_cast<uint64_t>(arity)),
-                                "mock_tup_kinds");
-                        llvm::Value *valsAlloca =
-                            builder_.CreateAlloca(
-                                i64Ty_,
-                                llvm::ConstantInt::get(
-                                    i64Ty_, static_cast<uint64_t>(arity)),
-                                "mock_tup_vals");
-                        for (unsigned ei = 0; ei < arity; ++ei) {
-                            int64_t k = kinds[ei];
-                            llvm::Value *elemVal =
-                                builder_.CreateExtractValue(
-                                    argVal, {ei}, "mock_tup_elem");
-                            llvm::Value *valI64;
-                            if (k == 1) valI64 = elemVal;
-                            else if (k == 2)
-                                valI64 = builder_.CreateBitCast(
-                                    elemVal, i64Ty_, "mock_tup_f2i");
-                            else if (k == 3)
-                                valI64 = builder_.CreateZExt(
-                                    elemVal, i64Ty_, "mock_tup_b2i");
-                            else // k == 4 (str)
-                                valI64 = builder_.CreatePtrToInt(
-                                    elemVal, i64Ty_, "mock_tup_p2i");
-                            llvm::Value *kindGEP = builder_.CreateGEP(
-                                i8Ty_, kindsAlloca,
-                                llvm::ConstantInt::get(
-                                    i64Ty_, static_cast<uint64_t>(ei)));
-                            builder_.CreateStore(
-                                llvm::ConstantInt::get(
-                                    i8Ty_, static_cast<uint64_t>(k), true),
-                                kindGEP);
-                            llvm::Value *valGEP = builder_.CreateGEP(
-                                i64Ty_, valsAlloca,
-                                llvm::ConstantInt::get(
-                                    i64Ty_, static_cast<uint64_t>(ei)));
-                            builder_.CreateStore(valI64, valGEP);
-                        }
-                        builder_.CreateCall(
-                            mockStoreArgTupleFn,
-                            {callRec,
-                             llvm::ConstantInt::get(
-                                 i64Ty_, static_cast<uint64_t>(arity), true),
-                             kindsAlloca, valsAlloca, nameStr});
-                        emittedRecordOrTuple = true;
-                    }
-                }
-                if (emittedRecordOrTuple) continue;
-            }
-            // Fn-typed arg path (#1707): if the declared param type is a
-            // function type, argVals[i] is the post-wrapFnTypedArgs uniform
-            // closure pointer (`{thunk_ptr, env_ptr, env_dtor_ptr}`). Extract
-            // the {thunk_ptr, env_ptr} pair and record as kind=11. env_dtor is
-            // determined by thunk and omitted. Pointer-equality compare lives
-            // in mockArgEqual's kind-11 branch.
-            if (matchedEntry && i < matchedEntry->paramTypeNames.size()) {
-                std::string declared = resolveTypeAlias(
-                    matchedEntry->paramTypeNames[i]);
-                if (isFunctionTypeName(declared) && argTy == ptrTy_) {
-                    auto *ucTy = getUniformClosureTy();
-                    llvm::Value *thunkField = builder_.CreateStructGEP(
-                        ucTy, argVal, 0, "mock_fn.thunk_gep");
-                    llvm::Value *envField = builder_.CreateStructGEP(
-                        ucTy, argVal, 1, "mock_fn.env_gep");
-                    llvm::Value *thunkPtr = builder_.CreateLoad(
-                        ptrTy_, thunkField, "mock_fn.thunk");
-                    llvm::Value *envPtr = builder_.CreateLoad(
-                        ptrTy_, envField, "mock_fn.env");
-                    llvm::FunctionType *mockStoreArgFnTy =
-                        llvm::FunctionType::get(
-                            llvm::Type::getVoidTy(*ctx_),
-                            {ptrTy_, ptrTy_, ptrTy_, ptrTy_}, false);
-                    llvm::FunctionCallee mockStoreArgFnFn =
-                        mod_->getOrInsertFunction(
-                            "__ry_mock_store_arg_fn", mockStoreArgFnTy);
-                    builder_.CreateCall(
-                        mockStoreArgFnFn,
-                        {callRec, thunkPtr, envPtr, nameStr});
-                    continue;
-                }
-            }
-            int64_t kind = 5;
-            llvm::Value *valI64 = llvm::ConstantInt::get(i64Ty_, 0);
-            if (argTy == i64Ty_) {
-                kind = 1;
-                valI64 = argVal;
-            } else if (argTy == f64Ty_) {
-                kind = 2;
-                valI64 = builder_.CreateBitCast(argVal, i64Ty_, "mock_rec_f2i");
-            } else if (argTy == i1Ty_) {
-                kind = 3;
-                valI64 = builder_.CreateZExt(argVal, i64Ty_, "mock_rec_b2i");
-            } else if (argTy == ptrTy_ && isStringValue(argVal)) {
-                kind = 4;
-                valI64 = builder_.CreatePtrToInt(argVal, i64Ty_, "mock_rec_p2i");
-            }
-            builder_.CreateCall(
-                mockStoreArgFn,
-                {callRec,
-                 llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(kind),
-                                         true),
-                 valI64, nameStr});
-        }
+        emitMockArgRecording(nameStr, argVals, matchedEntry);
 
         llvm::Value *envPtr = builder_.CreateCall(mockGetEnvFn, {nameStr}, "mock_env");
         llvm::Value *isCapture = builder_.CreateICmpNE(envPtr, nullPtr, "is_capture_mock");
@@ -821,6 +434,14 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
 
             // Original path (void case)
             builder_.SetInsertPoint(origBB);
+            if (isSpied) {
+                // Case (c): mock + spy. mock is inactive at runtime here
+                // (we are in origBB because __ry_mock_get returned null),
+                // so spy semantics apply: count this call and record args
+                // before invoking the real implementation.
+                builder_.CreateCall(mockIncFn, {nameStr});
+                emitMockArgRecording(nameStr, argVals, matchedEntry);
+            }
             builder_.CreateCall(fn, argVals);
             builder_.CreateBr(mergeBB);
 
@@ -842,6 +463,13 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
 
         // Original path
         builder_.SetInsertPoint(origBB);
+        if (isSpied) {
+            // Case (c): mock + spy. Same rationale as the void path —
+            // origBB is the runtime-mock-inactive branch, so apply spy
+            // semantics here.
+            builder_.CreateCall(mockIncFn, {nameStr});
+            emitMockArgRecording(nameStr, argVals, matchedEntry);
+        }
         llvm::Value *origResult = builder_.CreateCall(fn, argVals, "orig_result");
         builder_.CreateBr(mergeBB);
         llvm::BasicBlock *origEndBB = builder_.GetInsertBlock();
@@ -882,6 +510,10 @@ void CodeGen::emitStmt(CallStmt &s) {
         codegenError(s.loc, "named arguments are only supported for builtin functions");
     if (s.callee == "mock") {
         emitMockCall(s);
+        return;
+    }
+    if (s.callee == "spy") {
+        emitSpyCall(s);
         return;
     }
     if (s.callee == "fail") {

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -323,12 +323,20 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
 
     // inferCollectionTypeName returns "" for bare str, so the primitive gate
     // skips it. Side-table lookup via isStrHandle fills the gap (#1354).
+    // anyElemIsStrLike mirrors the Map/Set path — immortal literal globals from
+    // cachedGlobalString are excluded from arc_str_owned_values_, so isStrHandle
+    // misses them. isStringValue covers any ptr-backed value without other
+    // metadata, which is the correct stamp signal for list_elem_type_name = "str"
+    // (consumed by verifyCalledWith arg recording, etc.).
     bool anyElemIsStr = false;
+    bool anyElemIsStrLike = false;
 
     for (int64_t i = 0; i < count; ++i) {
         const bool elemIsStr =
             elemTy == ptrTy_ && isStrHandle(vals[static_cast<size_t>(i)]);
         anyElemIsStr = anyElemIsStr || elemIsStr;
+        if (elemTy == ptrTy_ && isStringValue(vals[static_cast<size_t>(i)]))
+            anyElemIsStrLike = true;
         llvm::Value *elemPtr = builder_.CreateGEP(
             elemTy, dataPtr, {llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(i))}, "elem_ptr");
         if (elemNeedsRetain || elemIsStr)
@@ -415,7 +423,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
         }
         if (!elemTypeName.empty())
             getOrCreateMeta(headerPtr).list_elem_type_name = elemTypeName;
-        else if (anyElemIsStr)
+        else if (anyElemIsStr || anyElemIsStrLike)
             getOrCreateMeta(headerPtr).list_elem_type_name = "str";
         else if (elemFnTypeInfo)
             getOrCreateMeta(headerPtr).list_elem_fn_type_info = elemFnTypeInfo;

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -586,6 +586,472 @@ void CodeGen::emitMockCall(CallStmt &s) {
     builder_.CreateCall(mockSetClosureFn, {nameStr, thunk, replacement, envDtorVal});
 }
 
+// ===== Test: spy(fn_name) — record calls without replacement =====
+
+void CodeGen::emitSpyCall(CallStmt &s) {
+    if (!test_mode_)
+        codegenError("'spy' is only allowed in test mode (use 'ry test')");
+    if (!testing_intrinsics_imported_.count("spy"))
+        codegenError(s.loc, "'spy' requires 'from testing import spy'");
+
+    if (s.args.size() != 1)
+        codegenError("spy() requires exactly 1 argument: function name");
+
+    auto *strExpr = std::get_if<StringExpr>(&s.args[0]->data);
+    if (!strExpr)
+        codegenError("spy() first argument must be a function name");
+    const std::string &fnName = strExpr->value;
+
+    auto *fitOverloads = findFunction(fnName);
+    if (!fitOverloads)
+        codegenError("spy(): unknown function '" + fnName + "'");
+
+    if (fitOverloads->size() > 1)
+        codegenError("spy(): overloaded functions are not supported");
+
+    spied_functions_.insert(fnName);
+
+    auto &nameStr = mock_name_strings_[fnName];
+    if (!nameStr) nameStr = cachedGlobalString(fnName, ".mock." + fnName);
+
+    llvm::FunctionType *spyRegTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    llvm::FunctionCallee spyRegFn =
+        mod_->getOrInsertFunction("__ry_spy_register", spyRegTy);
+    builder_.CreateCall(spyRegFn, {nameStr});
+}
+
+// ===== Mock/spy: argument recording IR for verifyCalledWith =====
+//
+// Emits a `__ry_mock_begin_call_record` call followed by per-arg
+// `__ry_mock_store_arg*` IR. Reused from:
+//   - mockBB (mock-only path: tri-block; emitted alongside replacement call)
+//   - origBB (spy-only path: linear; before the real call)
+//   - origBB (mock+spy coexistence: spy records before real call in origBB)
+//
+// Mock kind tags:
+//   1=int (raw i64), 2=float (bitcast f64->i64), 3=bool (zext i1->i64),
+//   4=str (ptr->i64, retain handle),
+//   5=opaque (unsupported in v1; never matches a verifyCalledWith query),
+//   6=list (snapshot ptr; #1703 — element kind ∈ {1..4}),
+//   7=set  (snapshot ptr; #1704 — unordered compare; element kind ∈ {1..4}),
+//   8=map  (snapshot ptr; #1705 — unordered key->value; key/val kind ∈ {1..4}),
+//   9=record (snapshot ptr; #1706 — per-slot compare; field kind ∈ {1..4}),
+//  10=tuple  (snapshot ptr; #1706 — per-slot compare; element kind ∈ {1..4}),
+//  11=fn    (snapshot ptr; #1707 — pointer-equality on {thunk, env}).
+void CodeGen::emitMockArgRecording(llvm::Value *nameStr,
+                                    const std::vector<llvm::Value *> &argVals,
+                                    OverloadEntry *matchedEntry) {
+    llvm::FunctionType *mockBeginRecTy =
+        llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
+    llvm::FunctionCallee mockBeginRecFn = mod_->getOrInsertFunction(
+        "__ry_mock_begin_call_record", mockBeginRecTy);
+    llvm::FunctionType *mockStoreArgTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_),
+        {ptrTy_, i64Ty_, i64Ty_, ptrTy_}, false);
+    llvm::FunctionCallee mockStoreArgFn = mod_->getOrInsertFunction(
+        "__ry_mock_store_arg", mockStoreArgTy);
+    llvm::FunctionType *mockStoreArgListTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_),
+        {ptrTy_, ptrTy_, i64Ty_, i64Ty_, ptrTy_}, false);
+    llvm::FunctionCallee mockStoreArgListFn = mod_->getOrInsertFunction(
+        "__ry_mock_store_arg_list", mockStoreArgListTy);
+    llvm::FunctionCallee mockStoreArgSetFn = mod_->getOrInsertFunction(
+        "__ry_mock_store_arg_set", mockStoreArgListTy);
+    llvm::FunctionType *mockStoreArgMapTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_),
+        {ptrTy_, ptrTy_, i64Ty_, i64Ty_, i64Ty_, i64Ty_, ptrTy_}, false);
+    llvm::FunctionCallee mockStoreArgMapFn = mod_->getOrInsertFunction(
+        "__ry_mock_store_arg_map", mockStoreArgMapTy);
+    llvm::Value *callRec = builder_.CreateCall(
+        mockBeginRecFn, {nameStr}, "mock_call_rec");
+
+    const size_t recordCount = matchedEntry
+        ? std::min(argVals.size(), matchedEntry->paramTypes.size())
+        : argVals.size();
+    for (size_t i = 0; i < recordCount; ++i) {
+        llvm::Value *argVal = argVals[i];
+        llvm::Type *argTy = argVal->getType();
+        // List<T> arg path (#1703): when T ∈ {int, float, bool, str},
+        // record via __ry_mock_store_arg_list which deep-copies the
+        // element buffer into a MockListSnapshot. Other element types
+        // (nested list, Map, record, …) fall through to kind=5 opaque.
+        if (argTy == ptrTy_) {
+            llvm::Type *listElemTy = getListElementType(argVal);
+            if (listElemTy != nullptr) {
+                const auto *meta = getMeta(argVal);
+                std::string elemName =
+                    meta ? meta->list_elem_type_name : std::string();
+                int64_t elemKind = 0;
+                if (elemName == "int") elemKind = 1;
+                else if (elemName == "float") elemKind = 2;
+                else if (elemName == "bool") elemKind = 3;
+                else if (elemName == "str") elemKind = 4;
+                else if (elemName.empty()) {
+                    // Fall back to LLVM type when the source-level name
+                    // was not stamped (literal `[1, 2, 3]` may not always
+                    // carry a name on every codepath).
+                    if (listElemTy == i64Ty_) elemKind = 1;
+                    else if (listElemTy == f64Ty_) elemKind = 2;
+                    else if (listElemTy == i1Ty_ || listElemTy == i8Ty_)
+                        elemKind = 3;
+                    else if (listElemTy == ptrTy_) elemKind = 4;
+                }
+                if (elemKind != 0) {
+                    const llvm::DataLayout &dl = mod_->getDataLayout();
+                    uint64_t elemSize = dl.getTypeAllocSize(listElemTy);
+                    builder_.CreateCall(
+                        mockStoreArgListFn,
+                        {callRec, argVal,
+                         llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(elemKind), true),
+                         llvm::ConstantInt::get(i64Ty_, elemSize, false),
+                         nameStr});
+                    continue;
+                }
+            }
+        }
+        // Set<T> arg path (#1704): mirror of the List path. The only
+        // semantic difference (unordered comparison) is realized in
+        // mockArgEqual's kind-7 branch, not here.
+        if (argTy == ptrTy_) {
+            llvm::Type *setElemTy = getSetElementType(argVal);
+            if (setElemTy != nullptr) {
+                const auto *meta = getMeta(argVal);
+                std::string elemName =
+                    meta ? meta->set_elem_type_name : std::string();
+                int64_t elemKind = 0;
+                if (elemName == "int") elemKind = 1;
+                else if (elemName == "float") elemKind = 2;
+                else if (elemName == "bool") elemKind = 3;
+                else if (elemName == "str") elemKind = 4;
+                else if (elemName.empty()) {
+                    if (setElemTy == i64Ty_) elemKind = 1;
+                    else if (setElemTy == f64Ty_) elemKind = 2;
+                    else if (setElemTy == i1Ty_ || setElemTy == i8Ty_)
+                        elemKind = 3;
+                    // Do not infer str from a bare ptr element type:
+                    // unknown pointer-backed elements stay opaque (kind
+                    // 5) so List/Map/Set/closure-backed sets cannot
+                    // sneak through the kind-4 path. emitSetLiteral
+                    // stamps set_elem_type_name = "str" via
+                    // anyElemIsStrLike for bare-literal Set<str>, so
+                    // the elemName == "str" branch above covers them.
+                }
+                if (elemKind != 0) {
+                    const llvm::DataLayout &dl = mod_->getDataLayout();
+                    uint64_t elemSize = dl.getTypeAllocSize(setElemTy);
+                    builder_.CreateCall(
+                        mockStoreArgSetFn,
+                        {callRec, argVal,
+                         llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(elemKind), true),
+                         llvm::ConstantInt::get(i64Ty_, elemSize, false),
+                         nameStr});
+                    continue;
+                }
+            }
+        }
+        // Map<K, V> arg path (#1705): K, V ∈ {int, float, bool, str}.
+        // Records via __ry_mock_store_arg_map which deep-copies both
+        // parallel buffers (keys + vals) into a MockMapSnapshot. Other
+        // K / V combinations fall through to kind=5 opaque.
+        if (argTy == ptrTy_) {
+            llvm::Type *mapKeyTy = getMapKeyType(argVal);
+            llvm::Type *mapValTy = getMapValueType(argVal);
+            if (mapKeyTy != nullptr && mapValTy != nullptr) {
+                const auto *meta = getMeta(argVal);
+                std::string keyName =
+                    meta ? meta->map_key_type_name : std::string();
+                std::string valName =
+                    meta ? meta->map_value_type_name : std::string();
+                auto resolveKind = [&](const std::string &name,
+                                        llvm::Type *ty) -> int64_t {
+                    if (name == "int") return 1;
+                    if (name == "float") return 2;
+                    if (name == "bool") return 3;
+                    if (name == "str") return 4;
+                    if (name.empty()) {
+                        if (ty == i64Ty_) return 1;
+                        if (ty == f64Ty_) return 2;
+                        if (ty == i1Ty_ || ty == i8Ty_) return 3;
+                        // Bare ptr without a stamped name is opaque —
+                        // do not infer str (mirrors the Set guard).
+                    }
+                    return 0;
+                };
+                int64_t keyKind = resolveKind(keyName, mapKeyTy);
+                int64_t valKind = resolveKind(valName, mapValTy);
+                if (keyKind != 0 && valKind != 0) {
+                    const llvm::DataLayout &dl = mod_->getDataLayout();
+                    uint64_t keySize = dl.getTypeAllocSize(mapKeyTy);
+                    uint64_t valSize = dl.getTypeAllocSize(mapValTy);
+                    builder_.CreateCall(
+                        mockStoreArgMapFn,
+                        {callRec, argVal,
+                         llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(keyKind), true),
+                         llvm::ConstantInt::get(i64Ty_, keySize, false),
+                         llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(valKind), true),
+                         llvm::ConstantInt::get(i64Ty_, valSize, false),
+                         nameStr});
+                    continue;
+                }
+            }
+        }
+        // Record / tuple arg paths (#1706): when every field/element is
+        // primitive (int/float/bool) or str, build per-slot kinds[] and
+        // values[] stack alloca buffers and call the dedicated runtime
+        // helper. All-or-nothing — any unsupported field/element kind
+        // falls through to kind=5 opaque so cross-shape verifyCalledWith
+        // attempts still produce a clean error in Stage 1 of
+        // emitVerifyCalledWithCall.
+        if (auto *st = llvm::dyn_cast<llvm::StructType>(argTy)) {
+            auto kindForFieldName =
+                [](const std::string &n) -> int64_t {
+                    if (n == "int") return 1;
+                    if (n == "float") return 2;
+                    if (n == "bool") return 3;
+                    if (n == "str") return 4;
+                    return 0;
+                };
+            bool emittedRecordOrTuple = false;
+            if (st->hasName()) {
+                const std::string recName = st->getName().str();
+                auto recIt = record_types_.find(recName);
+                if (recIt != record_types_.end()) {
+                    const auto &info = recIt->second;
+                    std::vector<int64_t> kinds;
+                    kinds.reserve(info.fields.size());
+                    bool allOk = true;
+                    for (const auto &fld : info.fields) {
+                        std::string fldName =
+                            resolveTypeAlias(fld.type->toString());
+                        int64_t k = kindForFieldName(fldName);
+                        if (k == 0) { allOk = false; break; }
+                        kinds.push_back(k);
+                    }
+                    if (allOk && !info.fields.empty()) {
+                        llvm::FunctionType *mockStoreArgRecordTy =
+                            llvm::FunctionType::get(
+                                llvm::Type::getVoidTy(*ctx_),
+                                {ptrTy_, ptrTy_, i64Ty_, ptrTy_, ptrTy_, ptrTy_},
+                                false);
+                        llvm::FunctionCallee mockStoreArgRecordFn =
+                            mod_->getOrInsertFunction(
+                                "__ry_mock_store_arg_record",
+                                mockStoreArgRecordTy);
+                        llvm::Constant *typeNameStr = cachedGlobalString(
+                            recName, llvm::Twine(".mock.record_name.") + recName);
+                        int64_t fieldCount =
+                            static_cast<int64_t>(info.fields.size());
+                        llvm::Value *kindsAlloca =
+                            builder_.CreateAlloca(
+                                i8Ty_,
+                                llvm::ConstantInt::get(
+                                    i64Ty_,
+                                    static_cast<uint64_t>(fieldCount)),
+                                "mock_rec_kinds");
+                        llvm::Value *valsAlloca =
+                            builder_.CreateAlloca(
+                                i64Ty_,
+                                llvm::ConstantInt::get(
+                                    i64Ty_,
+                                    static_cast<uint64_t>(fieldCount)),
+                                "mock_rec_vals");
+                        for (size_t fi = 0; fi < info.fields.size(); ++fi) {
+                            int64_t k = kinds[fi];
+                            llvm::Value *fieldVal =
+                                builder_.CreateExtractValue(
+                                    argVal, {static_cast<unsigned>(fi)},
+                                    "mock_rec_fld");
+                            llvm::Value *valI64;
+                            if (k == 1) valI64 = fieldVal;
+                            else if (k == 2)
+                                valI64 = builder_.CreateBitCast(
+                                    fieldVal, i64Ty_, "mock_rec_f2i");
+                            else if (k == 3)
+                                valI64 = builder_.CreateZExt(
+                                    fieldVal, i64Ty_, "mock_rec_b2i");
+                            else // k == 4 (str)
+                                valI64 = builder_.CreatePtrToInt(
+                                    fieldVal, i64Ty_, "mock_rec_p2i");
+                            llvm::Value *kindGEP = builder_.CreateGEP(
+                                i8Ty_, kindsAlloca,
+                                llvm::ConstantInt::get(
+                                    i64Ty_, static_cast<uint64_t>(fi)));
+                            builder_.CreateStore(
+                                llvm::ConstantInt::get(
+                                    i8Ty_, static_cast<uint64_t>(k), true),
+                                kindGEP);
+                            llvm::Value *valGEP = builder_.CreateGEP(
+                                i64Ty_, valsAlloca,
+                                llvm::ConstantInt::get(
+                                    i64Ty_, static_cast<uint64_t>(fi)));
+                            builder_.CreateStore(valI64, valGEP);
+                        }
+                        builder_.CreateCall(
+                            mockStoreArgRecordFn,
+                            {callRec, typeNameStr,
+                             llvm::ConstantInt::get(
+                                 i64Ty_,
+                                 static_cast<uint64_t>(fieldCount), true),
+                             kindsAlloca, valsAlloca, nameStr});
+                        emittedRecordOrTuple = true;
+                    }
+                }
+            }
+            if (!emittedRecordOrTuple && isTupleStructType(st)) {
+                // Tuple kinds derived from per-element LLVM types only
+                // when the source-level name is unavailable; if metadata
+                // carries `source_type_name = "(T1, T2, ...)"`, prefer
+                // that for str detection (LLVM type ptr alone is opaque).
+                const auto *meta = getMeta(argVal);
+                std::vector<std::string> elemNames;
+                if (meta) {
+                    std::string tupleSig = !meta->source_type_name.empty()
+                        ? meta->source_type_name
+                        : std::string();
+                    if (!tupleSig.empty())
+                        elemNames = splitTupleSig(tupleSig);
+                }
+                unsigned arity = st->getNumElements();
+                std::vector<int64_t> kinds;
+                kinds.reserve(arity);
+                bool allOk = arity > 0;
+                for (unsigned ei = 0; ei < arity; ++ei) {
+                    llvm::Type *elemTy = st->getElementType(ei);
+                    int64_t k = 0;
+                    if (ei < elemNames.size()) {
+                        k = kindForFieldName(elemNames[ei]);
+                    }
+                    if (k == 0) {
+                        // Fall back to LLVM type when source name is missing.
+                        if (elemTy == i64Ty_) k = 1;
+                        else if (elemTy == f64Ty_) k = 2;
+                        else if (elemTy == i1Ty_ || elemTy == i8Ty_) k = 3;
+                        // Bare ptr without a stamped name is opaque —
+                        // do not infer str (mirrors the Set/Map guard).
+                    }
+                    if (k == 0) { allOk = false; break; }
+                    kinds.push_back(k);
+                }
+                if (allOk) {
+                    llvm::FunctionType *mockStoreArgTupleTy =
+                        llvm::FunctionType::get(
+                            llvm::Type::getVoidTy(*ctx_),
+                            {ptrTy_, i64Ty_, ptrTy_, ptrTy_, ptrTy_},
+                            false);
+                    llvm::FunctionCallee mockStoreArgTupleFn =
+                        mod_->getOrInsertFunction(
+                            "__ry_mock_store_arg_tuple",
+                            mockStoreArgTupleTy);
+                    llvm::Value *kindsAlloca =
+                        builder_.CreateAlloca(
+                            i8Ty_,
+                            llvm::ConstantInt::get(
+                                i64Ty_, static_cast<uint64_t>(arity)),
+                            "mock_tup_kinds");
+                    llvm::Value *valsAlloca =
+                        builder_.CreateAlloca(
+                            i64Ty_,
+                            llvm::ConstantInt::get(
+                                i64Ty_, static_cast<uint64_t>(arity)),
+                            "mock_tup_vals");
+                    for (unsigned ei = 0; ei < arity; ++ei) {
+                        int64_t k = kinds[ei];
+                        llvm::Value *elemVal =
+                            builder_.CreateExtractValue(
+                                argVal, {ei}, "mock_tup_elem");
+                        llvm::Value *valI64;
+                        if (k == 1) valI64 = elemVal;
+                        else if (k == 2)
+                            valI64 = builder_.CreateBitCast(
+                                elemVal, i64Ty_, "mock_tup_f2i");
+                        else if (k == 3)
+                            valI64 = builder_.CreateZExt(
+                                elemVal, i64Ty_, "mock_tup_b2i");
+                        else // k == 4 (str)
+                            valI64 = builder_.CreatePtrToInt(
+                                elemVal, i64Ty_, "mock_tup_p2i");
+                        llvm::Value *kindGEP = builder_.CreateGEP(
+                            i8Ty_, kindsAlloca,
+                            llvm::ConstantInt::get(
+                                i64Ty_, static_cast<uint64_t>(ei)));
+                        builder_.CreateStore(
+                            llvm::ConstantInt::get(
+                                i8Ty_, static_cast<uint64_t>(k), true),
+                            kindGEP);
+                        llvm::Value *valGEP = builder_.CreateGEP(
+                            i64Ty_, valsAlloca,
+                            llvm::ConstantInt::get(
+                                i64Ty_, static_cast<uint64_t>(ei)));
+                        builder_.CreateStore(valI64, valGEP);
+                    }
+                    builder_.CreateCall(
+                        mockStoreArgTupleFn,
+                        {callRec,
+                         llvm::ConstantInt::get(
+                             i64Ty_, static_cast<uint64_t>(arity), true),
+                         kindsAlloca, valsAlloca, nameStr});
+                    emittedRecordOrTuple = true;
+                }
+            }
+            if (emittedRecordOrTuple) continue;
+        }
+        // Fn-typed arg path (#1707): if the declared param type is a
+        // function type, argVals[i] is the post-wrapFnTypedArgs uniform
+        // closure pointer (`{thunk_ptr, env_ptr, env_dtor_ptr}`). Extract
+        // the {thunk_ptr, env_ptr} pair and record as kind=11. env_dtor is
+        // determined by thunk and omitted. Pointer-equality compare lives
+        // in mockArgEqual's kind-11 branch.
+        if (matchedEntry && i < matchedEntry->paramTypeNames.size()) {
+            std::string declared = resolveTypeAlias(
+                matchedEntry->paramTypeNames[i]);
+            if (isFunctionTypeName(declared) && argTy == ptrTy_) {
+                auto *ucTy = getUniformClosureTy();
+                llvm::Value *thunkField = builder_.CreateStructGEP(
+                    ucTy, argVal, 0, "mock_fn.thunk_gep");
+                llvm::Value *envField = builder_.CreateStructGEP(
+                    ucTy, argVal, 1, "mock_fn.env_gep");
+                llvm::Value *thunkPtr = builder_.CreateLoad(
+                    ptrTy_, thunkField, "mock_fn.thunk");
+                llvm::Value *envPtr = builder_.CreateLoad(
+                    ptrTy_, envField, "mock_fn.env");
+                llvm::FunctionType *mockStoreArgFnTy =
+                    llvm::FunctionType::get(
+                        llvm::Type::getVoidTy(*ctx_),
+                        {ptrTy_, ptrTy_, ptrTy_, ptrTy_}, false);
+                llvm::FunctionCallee mockStoreArgFnFn =
+                    mod_->getOrInsertFunction(
+                        "__ry_mock_store_arg_fn", mockStoreArgFnTy);
+                builder_.CreateCall(
+                    mockStoreArgFnFn,
+                    {callRec, thunkPtr, envPtr, nameStr});
+                continue;
+            }
+        }
+        int64_t kind = 5;
+        llvm::Value *valI64 = llvm::ConstantInt::get(i64Ty_, 0);
+        if (argTy == i64Ty_) {
+            kind = 1;
+            valI64 = argVal;
+        } else if (argTy == f64Ty_) {
+            kind = 2;
+            valI64 = builder_.CreateBitCast(argVal, i64Ty_, "mock_rec_f2i");
+        } else if (argTy == i1Ty_) {
+            kind = 3;
+            valI64 = builder_.CreateZExt(argVal, i64Ty_, "mock_rec_b2i");
+        } else if (argTy == ptrTy_ && isStringValue(argVal)) {
+            kind = 4;
+            valI64 = builder_.CreatePtrToInt(argVal, i64Ty_, "mock_rec_p2i");
+        }
+        builder_.CreateCall(
+            mockStoreArgFn,
+            {callRec,
+             llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(kind),
+                                     true),
+             valI64, nameStr});
+    }
+}
+
 // ===== Test: verifyCalledWith(name, args...) -> int =====
 
 llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
@@ -602,8 +1068,8 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
         codegenError("verifyCalledWith() first argument must be a function name string literal");
     const std::string &fnName = strExpr->value;
 
-    if (!mocked_functions_.count(fnName))
-        codegenError("verifyCalledWith: '" + fnName + "' is not mocked");
+    if (!mocked_functions_.count(fnName) && !spied_functions_.count(fnName))
+        codegenError("verifyCalledWith: '" + fnName + "' is not mocked or spied");
 
     auto *overloads = findFunction(fnName);
     if (!overloads || overloads->empty())

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -695,7 +695,9 @@ void CodeGen::emitMockArgRecording(llvm::Value *nameStr,
                     else if (listElemTy == f64Ty_) elemKind = 2;
                     else if (listElemTy == i1Ty_ || listElemTy == i8Ty_)
                         elemKind = 3;
-                    else if (listElemTy == ptrTy_) elemKind = 4;
+                    // Do not infer str from a bare ptr element type
+                    // (mirrors the Set/Map guards below): unknown
+                    // pointer-backed elements stay opaque (kind 5).
                 }
                 if (elemKind != 0) {
                     const llvm::DataLayout &dl = mod_->getDataLayout();

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -76,7 +76,7 @@ static std::string makeImportError(int line, const std::string &detail) {
 // through the same standard mechanism and is NOT a compiler intrinsic.
 static const std::unordered_set<std::string> &testingIntrinsics() {
     static const std::unordered_set<std::string> kSet = {
-        "expect", "mock", "fail", "verifyCalledWith"};
+        "expect", "mock", "spy", "fail", "verifyCalledWith"};
     return kSet;
 }
 

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -575,6 +575,14 @@ void __ry_mock_set(const char *name, void *fn_ptr) {
     entry.env_dtor = nullptr;
 }
 
+// Create-if-absent registration for spy(). Unlike __ry_mock_set, this does NOT
+// overwrite fn_ptr / env_ptr / env_dtor — if a mock has already been registered
+// for `name` in the same it block, the mock takes precedence at runtime.
+// call_count and retained_str_args are also preserved.
+void __ry_spy_register(const char *name) {
+    (void)g_mock_registry[name];
+}
+
 void __ry_mock_set_closure(const char *name, void *thunk_ptr,
                             void *env_ptr, void (*env_dtor)(void *)) {
     auto &entry = g_mock_registry[name];

--- a/tests/spec/spy.test.ry
+++ b/tests/spec/spy.test.ry
@@ -175,3 +175,16 @@ fn spyMockInteropTests():
     # work (real impl is intact) but verify stays at 0.
     expect(computeReal(2)).toEq(6)
     expect(verify("computeReal")).toEq(0)
+
+  @it("mock takes precedence when mock and spy coexist in the same block")
+  fn mockTakesPrecedence():
+    # When both mock() and spy() target the same function inside the same it
+    # block, the replacement runs (real impl is bypassed) and the call is
+    # counted once — see docs/reference/testing.md spy() entry.
+    sideEffectCount[0] = 0
+    mock(tickAndReturn, (x: int) => x + 1000)
+    spy("tickAndReturn")
+    expect(tickAndReturn(1)).toEq(1001)
+    expect(verify("tickAndReturn")).toEq(1)
+    # Real impl bypassed: the side-effect counter must stay at 0.
+    expect(sideEffectCount[0]).toEq(0)

--- a/tests/spec/spy.test.ry
+++ b/tests/spec/spy.test.ry
@@ -1,0 +1,177 @@
+from testing import it, describe, expect, mock, spy, verify, verifyCalledWith, mockClear, mockReset
+
+# Real implementations — these must continue to run when spied.
+fn computeReal(x: int) -> int:
+  return x * 3
+
+fn greet(name: str) -> str:
+  return "hello " + name
+
+fn flagToInt(b: bool) -> int:
+  if b:
+    return 1
+  return 0
+
+fn floatDouble(x: float) -> float:
+  return x * 2.0
+
+fn sumList(xs: List<int>) -> int:
+  total: int = 0
+  for x in xs:
+    total = total + x
+  return total
+
+fn countStrSet(xs: Set<str>) -> int:
+  return len(xs)
+
+fn sumMapValues(m: Map<str, int>) -> int:
+  total: int = 0
+  for k, v in m:
+    total = total + v
+  return total
+
+# Module-global counter so we can confirm the real implementation runs
+# under a spy (mock would normally replace the body).
+sideEffectCount: List<int> = [0]
+
+fn tickAndReturn(x: int) -> int:
+  sideEffectCount[0] = sideEffectCount[0] + 1
+  return x + 100
+
+@describe("spy")
+fn spyTests():
+  @it("records calls without replacing implementation")
+  fn recordsWithoutReplacing():
+    spy("computeReal")
+    result: int = computeReal(5)
+    expect(result).toEq(15)
+    expect(verify("computeReal")).toEq(1)
+
+  @it("counts multiple calls")
+  fn countsMultipleCalls():
+    spy("computeReal")
+    computeReal(1)
+    computeReal(2)
+    computeReal(3)
+    expect(verify("computeReal")).toEq(3)
+
+  @it("preserves side effects of the real implementation")
+  fn preservesSideEffects():
+    sideEffectCount[0] = 0
+    spy("tickAndReturn")
+    r1: int = tickAndReturn(1)
+    r2: int = tickAndReturn(2)
+    expect(r1).toEq(101)
+    expect(r2).toEq(102)
+    expect(sideEffectCount[0]).toEq(2)
+    expect(verify("tickAndReturn")).toEq(2)
+
+  @it("returns 0 for a function that was never spied")
+  fn unspiedReturnsZero():
+    expect(verify("computeReal")).toEq(0)
+
+  @it("auto-restores after the it block")
+  fn autoRestoresAfterItBlock():
+    # The previous it block populated sideEffectCount[0]; this fresh it
+    # block must see a clean registry: verify returns 0 because the spy
+    # registration was cleared by __ry_mock_clear_all between tests.
+    expect(verify("tickAndReturn")).toEq(0)
+
+@describe("spy + verifyCalledWith")
+fn spyVerifyCalledWithTests():
+  @it("matches int argument")
+  fn matchesIntArg():
+    spy("computeReal")
+    computeReal(7)
+    computeReal(8)
+    computeReal(7)
+    expect(verifyCalledWith("computeReal", 7)).toEq(2)
+    expect(verifyCalledWith("computeReal", 8)).toEq(1)
+    expect(verifyCalledWith("computeReal", 999)).toEq(0)
+
+  @it("matches str argument")
+  fn matchesStrArg():
+    spy("greet")
+    greet("alice")
+    greet("bob")
+    greet("alice")
+    expect(verifyCalledWith("greet", "alice")).toEq(2)
+    expect(verifyCalledWith("greet", "bob")).toEq(1)
+
+  @it("matches bool argument")
+  fn matchesBoolArg():
+    spy("flagToInt")
+    flagToInt(true)
+    flagToInt(false)
+    flagToInt(true)
+    expect(verifyCalledWith("flagToInt", true)).toEq(2)
+    expect(verifyCalledWith("flagToInt", false)).toEq(1)
+
+  @it("matches float argument")
+  fn matchesFloatArg():
+    spy("floatDouble")
+    floatDouble(1.5)
+    floatDouble(1.5)
+    floatDouble(3.0)
+    expect(verifyCalledWith("floatDouble", 1.5)).toEq(2)
+    expect(verifyCalledWith("floatDouble", 3.0)).toEq(1)
+
+  @it("matches List<int> argument")
+  fn matchesListIntArg():
+    spy("sumList")
+    sumList([1, 2, 3])
+    sumList([1, 2, 3])
+    sumList([4, 5])
+    expect(verifyCalledWith("sumList", [1, 2, 3])).toEq(2)
+    expect(verifyCalledWith("sumList", [4, 5])).toEq(1)
+    expect(verifyCalledWith("sumList", [9, 9])).toEq(0)
+
+  @it("matches Set<str> argument")
+  fn matchesSetStrArg():
+    spy("countStrSet")
+    countStrSet({"a", "b"})
+    countStrSet({"b", "a"})
+    expect(verifyCalledWith("countStrSet", {"a", "b"})).toEq(2)
+
+  @it("matches Map<str, int> argument")
+  fn matchesMapStrIntArg():
+    spy("sumMapValues")
+    m1: Map<str, int> = {"a": 1, "b": 2}
+    sumMapValues(m1)
+    sumMapValues(m1)
+    expect(verifyCalledWith("sumMapValues", {"a": 1, "b": 2})).toEq(2)
+    expect(verifyCalledWith("sumMapValues", {"x": 9})).toEq(0)
+
+@describe("spy interop with mock and mockClear/mockReset")
+fn spyMockInteropTests():
+  @it("does not leak across it blocks (mock from a sibling it)")
+  fn spyAfterSiblingMock():
+    # Without registry isolation between it blocks, a previous mock("computeReal", ...)
+    # could remain and replace the implementation under spy. The runtime auto-clears
+    # the registry between it blocks, so spy() here must observe the real impl.
+    spy("computeReal")
+    expect(computeReal(4)).toEq(12)
+    expect(verify("computeReal")).toEq(1)
+
+  @it("mockClear zeroes the spy call count")
+  fn mockClearResetsSpyCount():
+    spy("computeReal")
+    computeReal(1)
+    computeReal(2)
+    expect(verify("computeReal")).toEq(2)
+    mockClear("computeReal")
+    expect(verify("computeReal")).toEq(0)
+    computeReal(3)
+    expect(verify("computeReal")).toEq(1)
+
+  @it("mockReset removes the spy registration entirely")
+  fn mockResetRemovesSpyRegistration():
+    spy("computeReal")
+    computeReal(5)
+    expect(verify("computeReal")).toEq(1)
+    mockReset("computeReal")
+    expect(verify("computeReal")).toEq(0)
+    # After reset, the function is no longer spied. Calling it must still
+    # work (real impl is intact) but verify stays at 0.
+    expect(computeReal(2)).toEq(6)
+    expect(verify("computeReal")).toEq(0)

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -165,7 +165,7 @@ protected:
 
         CodeGen cg(true);  // test_mode = true
         cg.setTestingIntrinsicsImported({"expect", "mock", "fail", "it", "describe",
-                                          "verifyCalledWith"});
+                                          "verifyCalledWith", "spy"});
         auto tsm = cg.compile(prog);
         return runModule(std::move(tsm));
     }

--- a/tests/test_codegen_mock.cpp
+++ b/tests/test_codegen_mock.cpp
@@ -1001,3 +1001,118 @@ TEST_F(CodeGenTest, VerifyCalledWithOutsideTestModeError) {
         "verifyCalledWith(\"compute\", 5)\n"
     ), std::exception);
 }
+
+// ============================================================
+// spy() rejection tests (#1683)
+// ============================================================
+
+// spy() outside test mode -> compile error
+TEST_F(CodeGenTest, SpyOutsideTestModeError) {
+    EXPECT_THROW(runSource(
+        "fn compute(x: int) -> int:\n"
+        "    return x\n"
+        "spy(\"compute\")\n"
+    ), std::exception);
+}
+
+// spy() without `from testing import spy` -> compile error
+TEST_F(CodeGenTest, SpyImportMissingError) {
+    EXPECT_THROW(runTestSourceNoTestingImports(
+        "fn compute(x: int) -> int:\n"
+        "    return x\n"
+        "\n"
+        "@describe(\"spy err\")\n"
+        "fn spyErr():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        spy(\"compute\")\n"
+    ), std::exception);
+}
+
+// spy() with no arguments -> compile error
+TEST_F(CodeGenTest, SpyZeroArgsError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"spy err\")\n"
+        "fn spyErr():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        spy()\n"
+    )), std::exception);
+}
+
+// spy() with too many arguments -> compile error
+TEST_F(CodeGenTest, SpyTooManyArgsError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn compute(x: int) -> int:\n"
+        "    return x\n"
+        "\n"
+        "@describe(\"spy err\")\n"
+        "fn spyErr():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        spy(\"compute\", \"extra\")\n"
+    )), std::exception);
+}
+
+// spy() with non-string-literal first arg -> compile error
+TEST_F(CodeGenTest, SpyFirstArgNotStringLiteralError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn compute(x: int) -> int:\n"
+        "    return x\n"
+        "\n"
+        "@describe(\"spy err\")\n"
+        "fn spyErr():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        name = \"compute\"\n"
+        "        spy(name)\n"
+    )), std::exception);
+}
+
+// spy() on a non-existent function -> compile error
+TEST_F(CodeGenTest, SpyNonExistentFunctionError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"spy err\")\n"
+        "fn spyErr():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        spy(\"no_such_fn\")\n"
+    )), std::exception);
+}
+
+// spy() on an overloaded function -> compile error
+TEST_F(CodeGenTest, SpyOverloadedFunctionError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn compute(x: int) -> int:\n"
+        "    return x\n"
+        "fn compute(x: float) -> float:\n"
+        "    return x\n"
+        "\n"
+        "@describe(\"spy err\")\n"
+        "fn spyErr():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        spy(\"compute\")\n"
+    )), std::exception);
+}
+
+// Positive control: verifyCalledWith works on a spied function
+// (parallels VerifyCalledWith* tests above; ensures the spied_functions_
+// guard in emitVerifyCalledWithCall accepts spy-only registration).
+TEST_F(CodeGenTest, VerifyCalledWithSpiedFunction) {
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
+        "fn compute(x: int) -> int:\n"
+        "    return x * 2\n"
+        "\n"
+        "@describe(\"vcw spy\")\n"
+        "fn vcwSpy():\n"
+        "    @it(\"matches spied call\")\n"
+        "    fn matchesSpiedCall():\n"
+        "        spy(\"compute\")\n"
+        "        compute(5)\n"
+        "        compute(7)\n"
+        "        compute(5)\n"
+        "        expect(verifyCalledWith(\"compute\", 5)).toEq(2)\n"
+        "        expect(verifyCalledWith(\"compute\", 7)).toEq(1)\n"
+    )), "vcw spy\n  \033[32m+ matches spied call\033[0m\n\n1 passed, 0 failed\n");
+}

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1835,9 +1835,10 @@ TEST_F(ImportTest, FromTestingWildcardRecordsAllIntrinsics) {
     // share/std/testing/testing.ry — it flows through the normal import
     // path and is no longer recorded in the testing-intrinsic set.
     // #1677 adds `verifyCalledWith` as an intrinsic.
+    // #1683 adds `spy` as an intrinsic.
     std::unordered_set<std::string> expected = {
-        "expect", "mock", "fail", "verifyCalledWith"};
-    EXPECT_EQ(intrinsics.size(), 4u);
+        "expect", "mock", "spy", "fail", "verifyCalledWith"};
+    EXPECT_EQ(intrinsics.size(), 5u);
     EXPECT_EQ(intrinsics, expected);
 }
 
@@ -1904,9 +1905,10 @@ TEST_F(ImportTest, CodeGenReceivesAllTestingIntrinsicsForWildcard) {
     // Post-#722 `verify` is no longer a testing intrinsic (it is a regular
     // `@public fn` in share/std/testing/testing.ry).
     // #1677 adds `verifyCalledWith` as an intrinsic.
+    // #1683 adds `spy` as an intrinsic.
     std::unordered_set<std::string> expected = {
-        "expect", "mock", "fail", "verifyCalledWith"};
-    EXPECT_EQ(intrinsics.size(), 4u);
+        "expect", "mock", "spy", "fail", "verifyCalledWith"};
+    EXPECT_EQ(intrinsics.size(), 5u);
     EXPECT_EQ(intrinsics, expected);
 }
 


### PR DESCRIPTION
## Summary

Adds the `spy(name)` testing intrinsic that records function calls
without replacing the implementation, complementing the existing
`mock(name, replacement)` (which fully replaces the body).

```ry
from testing import it, describe, spy, verify, verifyCalledWith, expect

fn compute(x: int) -> int:
    return x * 3

@describe("spy")
fn spyTests():
    @it("records calls and runs real impl")
    fn records():
        spy("compute")
        expect(compute(5)).toEq(15)               # real impl runs
        expect(verify("compute")).toEq(1)         # call counted
        compute(7)
        expect(verifyCalledWith("compute", 7)).toEq(1)
```

- `spy(name)` requires the function name as a string literal; overloaded
  functions and non-existent names are compile errors.
- `verify` / `verifyCalledWith` / `mockClear` / `mockReset` /
  `mockResetAll` all work uniformly on spied functions via the shared
  internal registry.
- `mock` and `spy` may coexist across different `it` blocks within the
  same describe. When both are active in the same block, `mock` takes
  precedence: the replacement runs, the call is counted, and the real
  implementation is bypassed.
- Spy registrations are automatically cleared at the end of each `it`
  block (same lifecycle as `mock`).

## Implementation notes

- New compiler intrinsic (no `@native` surface declaration). Added
  `"spy"` to `testingIntrinsics()` and a `spied_functions_` set on
  `CodeGen` alongside the existing `mocked_functions_`.
- Call-site interception at `codegen_call_user.cpp:352` now branches
  into three cases: mock-only (existing tri-block), spy-only (linear
  `__ry_mock_increment_call` + `emitMockArgRecording` before real
  call), or both (tri-block with spy recording added inside `origBB`).
- Extracted the ~390-line argument-recording IR (kinds 1–11) into a
  reusable helper `CodeGen::emitMockArgRecording` so all three call
  sites share the same code path.
- New runtime entry `__ry_spy_register(name)` creates a registry entry
  without overwriting any existing fn_ptr / env_ptr / call_count (so
  mock registration is preserved if `mock()` ran first).
- `emitVerifyCalledWithCall` guard relaxed from `mocked_functions_` to
  `mocked_functions_ ∪ spied_functions_`.

## Test plan

- [x] 15 new Ry tests in `tests/spec/spy.test.ry` covering basic
      recording, side-effect preservation, auto-restore between `it`
      blocks, mock+spy coexistence, `mockClear` / `mockReset`, and
      `verifyCalledWith` with int / str / bool / float / List / Set /
      Map argument types.
- [x] 8 new C++ tests in `tests/test_codegen_mock.cpp` covering all 6
      rejection branches (test-mode, import-missing, zero/too-many
      args, non-string-literal arg, non-existent fn, overloaded fn)
      plus a positive `VerifyCalledWithSpiedFunction` control.
- [x] `./build/ry_tests` — 2318 / 2318 pass.
- [x] `./build/ry test -p` — 187 / 187 test files pass.
- [x] ASan+UBSan (`build-asan`) — clean on both `ry_tests` and `ry test -p`.
- [x] TSan (`build-tsan`) — `ry test tests/spec/spy.test.ry` and spy C++
      tests clean.
- [x] clang-tidy clean on modified files.
- [x] Documentation: `docs/reference/testing.md` updated with the
      `spy(name)` section.

Closes #1683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added spy() to record calls without replacing implementations
  * spy registrations auto-clear after each test block
  * verify() and verifyCalledWith() now support spied functions
  * verifyCalledWith() matches common argument shapes (primitives, strings, lists, sets, maps)

* **Behavior Changes**
  * spy(name) requires a string literal and rejects overloaded/non-existent targets
  * When mock and spy target the same function, mock takes precedence

* **Documentation**
  * Testing docs updated with spy() usage and rules

* **Tests**
  * New/updated tests covering spy, verify, and mock/spy interactions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->