### PR TITLE
refactor(testing): convert fail() to pure codegen intrinsic (#1690)

### DIFF
--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -20,9 +20,6 @@ fn each(data: any)
 fn property(count: int = 100)
 
 @native("testing")
-fn _reportFail(line: int, message: str) -> Unit
-
-@native("testing")
 fn _mockGetCallCount(name: str) -> int
 
 @native("testing")
@@ -33,10 +30,6 @@ fn _mockReset(name: str) -> Unit
 
 @native("testing")
 fn _mockResetAll() -> Unit
-
-@public
-fn fail(_line: int, message: str = "") -> Unit:
-  _reportFail(_line, message)
 
 @public
 fn verify(name: str) -> int:

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -2567,28 +2567,18 @@ void CodeGen::emitFailCall(CallStmt &s) {
     if (s.args.size() > 1)
         codegenError("fail() expects 0 or 1 argument(s), but got " + std::to_string(s.args.size()));
 
-    // Inject the call-site line as the first argument and dispatch through the
-    // Ry-level `fail(line: int, message: str = "")` function declared in
-    // share/std/testing/testing.ry. The compiler still special-cases the
-    // callee name so it can synthesize the line number; the function body
-    // itself runs as ordinary Ry code that calls the @native _report_fail.
-    std::vector<ExprPtr> synthArgs;
+    llvm::FunctionType *failFnTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_), {i32Ty_, ptrTy_}, false);
+    llvm::FunctionCallee failFn =
+        mod_->getOrInsertFunction("__ry_test_fail", failFnTy);
 
-    auto lineNode = std::make_unique<ExprNode>();
-    lineNode->data = NumberExpr{static_cast<int64_t>(s.loc.line), ""};
-    lineNode->loc = s.loc;
-    synthArgs.push_back(std::move(lineNode));
+    llvm::Value *lineVal =
+        llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(s.loc.line));
+    llvm::Value *msgVal = s.args.size() == 1
+        ? emitExpr(*s.args[0])
+        : static_cast<llvm::Value *>(cachedGlobalString("", ".fail_empty_msg"));
 
-    if (s.args.size() == 1) {
-        synthArgs.push_back(std::move(s.args[0]));
-    } else {
-        auto msgNode = std::make_unique<ExprNode>();
-        msgNode->data = StringExpr{""};
-        msgNode->loc = s.loc;
-        synthArgs.push_back(std::move(msgNode));
-    }
-
-    emitUserFnCall("fail", synthArgs);
+    builder_.CreateCall(failFn, {lineVal, msgVal});
 }
 
 } // namespace ry

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -2574,9 +2574,19 @@ void CodeGen::emitFailCall(CallStmt &s) {
 
     llvm::Value *lineVal =
         llvm::ConstantInt::get(i32Ty_, static_cast<uint64_t>(s.loc.line));
-    llvm::Value *msgVal = s.args.size() == 1
-        ? emitExpr(*s.args[0])
-        : static_cast<llvm::Value *>(cachedGlobalString("", ".fail_empty_msg"));
+    llvm::Value *msgVal = nullptr;
+    if (s.args.size() == 1) {
+        msgVal = emitExpr(*s.args[0]);
+        // Previously, dispatching through the Ry-level `fn fail(_line: int,
+        // message: str)` rejected non-str args via signature type-check.
+        // The pure-codegen-intrinsic path bypasses that check, so guard
+        // explicitly — otherwise non-str pointers (List/Map/closure handles)
+        // would flow into `__ry_test_fail`'s `%s` format and read garbage.
+        if (!isStringValue(msgVal))
+            codegenError(s.loc, "fail() message argument must be a str");
+    } else {
+        msgVal = static_cast<llvm::Value *>(cachedGlobalString("", ".fail_empty_msg"));
+    }
 
     builder_.CreateCall(failFn, {lineVal, msgVal});
 }

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -58,13 +58,13 @@ static std::string makeImportError(int line, const std::string &detail) {
 
 // Compiler intrinsics exposed by the testing module (#712). The names listed
 // here either produce no AST node (`expect <expr> <matcher>` is a parser-level
-// statement form; `mock` is recognized at codegen) or are wrapped by codegen
-// synth (`fail` — `codegen_call_user.cpp:435` synthesizes the __LINE__-
-// equivalent argument before delegating to the user-fn `fail` defined in
-// `share/std/testing/testing.ry`). Listing them here lets
-// `from testing import expect / mock / fail` resolve without producing AST
-// nodes — the allow-list bypass below skips the `'<name>' not found` throw
-// without altering anything else.
+// statement form; `mock` / `spy` / `verifyCalledWith` are recognized at
+// codegen) or are emitted directly as IR via a callee-name intercept (`fail`
+// — `codegen_test.cpp:emitFailCall` calls `__ry_test_fail(line, msg)`
+// directly, with the call-site line number embedded as a constant; #1690).
+// Listing them here lets `from testing import expect / mock / fail` resolve
+// without producing AST nodes — the allow-list bypass below skips the
+// `'<name>' not found` throw without altering anything else.
 //
 // Note: `it` / `describe` are NOT listed here. They are declared as regular
 // `@directive` statements in `share/std/testing/testing.ry` and flow through

--- a/src/runtime_testing.cpp
+++ b/src/runtime_testing.cpp
@@ -4,15 +4,6 @@
 
 namespace ry {
 
-// Ry's `int` lowers to `i64` in IR, so the @native("testing") dispatch
-// emits `call void @__ry_testing__reportFail(i64 %line, ptr %msg)`.  The
-// C signature must therefore receive `int64_t` to match the ABI.  We
-// narrow to `int` for the existing `__ry_test_fail` helper, which keeps
-// its legacy 32-bit line parameter (line numbers fit comfortably).
-extern "C" void __ry_testing__reportFail(int64_t line, const char *msg) {
-    __ry_test_fail(static_cast<int>(line), msg);
-}
-
 extern "C" int64_t __ry_testing__mockGetCallCount(const char *name) {
     return __ry_mock_get_call_count(name);
 }

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -108,16 +108,13 @@ protected:
     // Appended after user source so that line numbers in the user source
     // are not shifted (tests like FailWithMessage assert on specific line
     // numbers in `fail()` output).  Mirrors share/std/testing/testing.ry's
-    // declarations of `fail` / `verify` and the underlying `@native` runtime
-    // calls (`_reportFail`, `_mockGetCallCount`).
+    // declarations of `verify` and the underlying `@native` runtime call
+    // (`_mockGetCallCount`).  `fail` is a pure codegen intrinsic — codegen
+    // intercepts the callee name in `emitFailCall` and emits a direct call
+    // to `__ry_test_fail`, so no Ry declaration is needed here.
     static std::string withTestingFnDecls(const std::string &src) {
         static const char *kDecls =
             "\n"
-            "@native(\"testing\")\n"
-            "fn _reportFail(line: int, message: str) -> Unit\n"
-            "@public\n"
-            "fn fail(_line: int, message: str = \"\") -> Unit:\n"
-            "  _reportFail(_line, message)\n"
             "@native(\"testing\")\n"
             "fn _mockGetCallCount(name: str) -> int\n"
             "@public\n"
@@ -152,11 +149,12 @@ protected:
     // intentionally exercise the missing-import error must use
     // `runTestSourceNoTestingImports` instead.
     //
-    // Since #718 made `fail` and #722 made `verify` Ry-level functions
-    // (declared in share/std/testing/testing.ry, bodies emitted via
-    // emitUserFnCall), the harness also appends `fail` / `verify` and their
-    // `@native` backing declarations (`_reportFail`, `_mockGetCallCount`)
-    // after the user source so codegen can find them in user_fns_.
+    // #722 made `verify` a Ry-level function (declared in
+    // share/std/testing/testing.ry, body emitted via emitUserFnCall), so the
+    // harness appends `verify` and its `@native` backing declaration
+    // (`_mockGetCallCount`) after the user source so codegen can find it in
+    // user_fns_.  `fail` reverted to a pure codegen intrinsic in #1690 —
+    // intercepted by name in `emitFailCall`, no Ry declaration needed.
     static std::string runTestSource(const std::string &src) {
         std::string augmented = withTestingFnDecls(src);
         Lexer lex(augmented);

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -118,6 +118,34 @@ TEST_F(CodeGenTest, FailRequiresTestingImport) {
     }
 }
 
+// fail() now bypasses the user-fn signature type-check (#1690 made it a
+// pure codegen intrinsic), so guard non-str message args explicitly —
+// otherwise non-str pointers (List/Map/closure handles) flow into
+// `__ry_test_fail`'s `%s` format and read garbage at runtime.
+TEST_F(CodeGenTest, FailRejectsNonStrMessage) {
+    try {
+        runTestSource("fail(42)\n");
+        FAIL() << "Expected compile error for non-str fail() arg";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("fail() message argument must be a str"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+TEST_F(CodeGenTest, FailRejectsListMessage) {
+    try {
+        runTestSource("fail([1, 2, 3])\n");
+        FAIL() << "Expected compile error for List fail() arg";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("fail() message argument must be a str"),
+                  std::string::npos)
+            << "got: " << msg;
+    }
+}
+
 // ============================================================
 // `@it` / `@describe` directives are declared in
 // `share/std/testing/testing.ry`. Without `from testing import it,


### PR DESCRIPTION
Closes #1690.

## Summary

`share/std/testing/testing.ry` の `fail` 関数は `fn fail(_line: int, message: str = "")` という形でユーザーに `_line` を見せていた。実コードでは call-site の line は既に codegen が自動 inject するため `_line` を渡しているユーザーは存在しないが、`testing.ry` を読んだユーザーが API シグネチャを見て混乱しうる、というコスメティックな問題があった。

本 PR では `fail` を **pure codegen intrinsic** 化し、`mock` / `spy` / `verifyCalledWith` と同じパターンに揃えた。`testing.ry` から `fn fail(...)` のラッパーと `@native _reportFail` 宣言を削除し、`emitFailCall` が直接 `__ry_test_fail(line, msg)` を IR で emit するように変更している。

## Changes

- `share/std/testing/testing.ry` — `fn fail(...)` と `@native _reportFail` 宣言を削除
- `src/codegen_test.cpp` — `emitFailCall` を `emitUserFnCall("fail", ...)` ではなく `__ry_test_fail` の直接 IR call に置き換え (call-site の line を `s.loc.line` から定数として埋め込み)
- `src/runtime_testing.cpp` — `__ry_testing__reportFail` wrapper を削除 (他に caller なし)
- `tests/test_codegen_common.hpp` — `withTestingFnDecls` から `fail` / `_reportFail` の inline 宣言を削除 (callee 名で intercept されるため harness 側の宣言は不要)
- `src/module_loader.cpp` — `testingIntrinsics` allow-list の `fail` エントリは維持 (`from testing import fail` が AST node を produce せずに resolve できるように)、周辺コメントを「Ry 関数に delegate」→「`__ry_test_fail` を IR で直接 emit」に更新

## Behaviour preservation

ユーザーから見た挙動は変わらない:

- `fail()` → `line N: test failed`
- `fail("msg")` → `line N: msg`

`N` は call-site の line 番号で codegen が自動 inject する (従来通り)。

## Test plan

- [x] `cmake --build build` ビルド通過
- [x] `./build/ry_tests` (2318 tests pass — 含む `FailWithMessage` / `FailWithoutMessage` / `FailOutsideTestModeIsRejected` / `FailRequiresTestingImport`)
- [x] `./build/ry test -p` (187 spec files, 0 failures — 503+ の `fail()` 呼び出しを含む)
- [x] ASan+UBSan 版で `./build-asan/ry_tests` 全 pass
- [x] ASan+UBSan 版で `./build-asan/ry test -p` 全 pass
- [x] E2E (ModuleLoader フルパス): `fail("oops")` at line 6 → `line 6: oops`
- [x] Horizontal sweep: `_reportFail` / `__ry_testing__reportFail` の残存参照なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated test failure reporting; the `fail` helper has been removed from the exported testing API.

* **Bug Fixes / Validation**
  * Compile-time validation added to reject non-string messages passed to test failure calls, improving error diagnostics.

* **Tests**
  * New tests added to verify validation behavior for invalid `fail` message arguments.

* **Documentation**
  * Clarified comments around how testing intrinsics are resolved and handled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1766?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->