### PR TITLE
feat(testing): add @skip / @only / @todo test selection directives (#1687)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -11,3 +11,18 @@
 **Tags**: <空白区切りキーワード>
 **Rule**: <教訓本文>
 -->
+
+### `tests/spec/<name>/` directories collide with stdlib module names
+
+**Source**: #1687 (2026-05-16 implementation)
+**Tags**: testing, module-loader, stdlib, tests-spec, layout, collision, gotcha
+
+**Context**: While adding new `tests/spec/testing/directive_*.test.ry` files for the `@skip` / `@only` / `@todo` directives, every test in `tests/` started failing with `'it' not found in module 'testing'`. The cause was the directory name `tests/spec/testing/` itself — `ry test`'s module loader treats every directory on the resolution path as a candidate package root, and the local `tests/spec/testing/` (which has no `it` symbol) shadows `share/std/testing/`. The collision is silent at build time and surfaces only as runtime import errors during test discovery.
+
+**Rule**: Do not create a subdirectory under `tests/spec/` whose name matches a stdlib module (e.g. `testing`, `math`, `path`, `filesystem`, `crypto`, `io`, `json`, `regex`, `thread`, `time`, `http`, `str`, `list`, `map`, `set`, `option`, `result`). Place per-file tests at the top level of `tests/spec/` instead (`tests/spec/directive_skip.test.ry`, not `tests/spec/testing/directive_skip.test.ry`). Existing subdirectories such as `tests/spec/braced_import/`, `tests/spec/combinatorial/`, `tests/spec/concurrency/` are safe because their names do not match any stdlib module.
+
+**How to apply**:
+- When adding a new `.test.ry` file under a new subdirectory, grep `share/std/` first: `ls share/std/ | sort | uniq` — pick a directory name that does not appear in the list.
+- If a stdlib module is renamed in the future, audit `tests/spec/` for newly-colliding directories at the same time.
+
+

--- a/changelog.d/1687-skip-only-todo-directives.md
+++ b/changelog.d/1687-skip-only-todo-directives.md
@@ -1,0 +1,19 @@
+### Added
+
+- Added `@skip`, `@only`, and `@todo` testing directives for
+  individual test selection within a file. `@skip @it("...")` skips
+  the test entirely and counts it as `skipped`. `@only @it("...")`
+  causes every non-`@only` test in the same file to be implicitly
+  skipped — useful for focused TDD on a single failing case.
+  `@todo @it("...")` is a placeholder that never emits a body (so
+  the function may reference undefined identifiers and still
+  compile) and counts as `todo`. All three directives compose with
+  `@each` and `@property` and are rejected on `@describe` in this
+  release (MVP scope; tracked for future expansion). The test
+  summary now always prints the 4-item form
+  `N passed, M failed, K skipped, T todo`; only `failed` influences
+  the exit code. Outline mode (`ry test --outline`) renders the
+  directive as a suffix, e.g. `it foo (@skip)`,
+  `it foo (@only @each)`. Mutual combinations
+  (`@skip @only`, `@skip @todo`, `@only @todo`) are codegen errors.
+  (#1687)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -491,6 +491,75 @@ fn outer():
 
 **Supported target:** `fn` declarations only. The function must not have parameters or a return type annotation.
 
+### `@skip`
+
+Marks an `@it` test as skipped. The function body is not executed; the test is reported as `~ <name> (skipped)` (gray) and counted as `skipped` in the summary. The exit code is unaffected (only `failed` counts).
+
+**Defined as:** Declared in `share/std/testing/testing.ry`. Test files must add `from testing import skip` at the top (or use a wildcard `from testing`).
+
+```ry
+from testing import it, expect, skip
+
+@skip
+@it("temporarily disabled while bug #123 is open")
+fn skipped():
+    expect(1).toEq(2)
+```
+
+Composes with `@each` and `@property` — `@skip @each @it(...)` and `@skip @property @it(...)` skip the entire loop without running any iteration.
+
+**Supported target:** functions with the `@it` directive only. Attaching `@skip` to `@describe` is a compile error in the current MVP.
+
+**Mutual exclusion:** `@skip` combined with `@only` or `@todo` is a compile error.
+
+### `@only`
+
+When at least one `@only` appears in a test file, every `@it` in that file **without** `@only` is implicitly skipped. Useful for focused TDD on a single failing case without commenting out or deleting other tests.
+
+**Defined as:** Declared in `share/std/testing/testing.ry`. Test files must add `from testing import only` at the top (or use a wildcard `from testing`).
+
+```ry
+from testing import it, expect, only
+
+@only
+@it("the one failing case I am currently debugging")
+fn focused():
+    expect(1 + 1).toEq(2)
+
+@it("this is implicitly skipped because the file has @only")
+fn other():
+    expect(1).toEq(1)
+```
+
+Composes with `@each` and `@property`. The focus filter is **per file** — it does not affect other test files.
+
+In outline mode (`ry test --outline`), all tests are shown regardless of `@only`, so the focus filter does not hide them; only the suffix `(@only)` is added so the focused tests stand out.
+
+**Supported target:** functions with the `@it` directive only. Attaching `@only` to `@describe` is a compile error in the current MVP.
+
+**Mutual exclusion:** `@only` combined with `@skip` or `@todo` is a compile error.
+
+### `@todo`
+
+Marks an `@it` test as a not-yet-implemented placeholder. The function body is **never emitted** by codegen, so it may reference undefined identifiers, omit a `return`, or otherwise fail compilation; only the directive itself is validated. Reported as `? <name> (todo)` (cyan) and counted as `todo`.
+
+**Defined as:** Declared in `share/std/testing/testing.ry`. Test files must add `from testing import todo` at the top (or use a wildcard `from testing`).
+
+```ry
+from testing import it, todo
+
+@todo
+@it("upcoming feature, body not yet written")
+fn upcoming():
+    notYetDefined()   # body is never compiled
+```
+
+Composes with `@each` and `@property` — the loop body is never emitted; the test is counted as a single `todo` regardless of how many iterations the `@each` table or `@property` count would have produced.
+
+**Supported target:** functions with the `@it` directive only. Attaching `@todo` to `@describe` is a compile error in the current MVP.
+
+**Mutual exclusion:** `@todo` combined with `@skip` or `@only` is a compile error.
+
 ### `@inline`
 
 Provides inlining hints to the LLVM optimizer. By default, marks the function for aggressive inlining.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -202,9 +202,9 @@ fn todo():
     notYetDefined()     # body is never compiled
 ```
 
-- `@skip @it("...")` — the function body is **never emitted** (parallel to `@todo`), so it may reference undefined identifiers or otherwise fail body codegen; only the directive itself and the surrounding declaration are validated. Reported as `~ <name> (skipped)` (gray) and counted as `skipped`. Use this for tests that are temporarily disabled (e.g. while a bug is investigated); use `@todo` when the test has not been written yet.
-- `@only @it("...")` — when at least one `@only` appears on an `@it` function in a file, every `@it` in that file *without* `@only` is implicitly skipped. Useful for focused TDD on a single failing case. The implicit skip is reported the same way as `@skip`. `@only` on a non-`@it` function has no effect on file-wide selection — only `@only` paired with `@it` triggers the focus filter.
-- `@todo @it("...")` — a placeholder. The function body is **never emitted**, so it may reference undefined identifiers, omit a `return`, or otherwise fail compilation; only the directive itself is validated. Reported as `? <name> (todo)` (cyan) and counted as `todo`.
+- `@skip @it("...")` — the test is not executed, but the body **is still compiled** (Jest `xit` / `it.skip` semantics). Type errors, undefined identifiers, and other body-level codegen failures are still surfaced, so typos in skipped tests do not lurk until the test is un-skipped. Reported as `~ <name> (skipped)` (gray) and counted as `skipped`. Use this for tests that are temporarily disabled (e.g. while a bug is investigated); use `@todo` when the test has not been written yet.
+- `@only @it("...")` — when at least one `@only` appears on an `@it` function in a file, every `@it` in that file *without* `@only` is implicitly skipped. Useful for focused TDD on a single failing case. The implicit skip is reported the same way as `@skip` and the implicitly-skipped bodies are likewise still compiled. `@only` on a non-`@it` function has no effect on file-wide selection — only `@only` paired with `@it` triggers the focus filter.
+- `@todo @it("...")` — a placeholder. The function body is **never emitted**, so it may reference undefined identifiers, omit a `return`, or otherwise fail compilation; only the directive itself is validated. Reported as `? <name> (todo)` (cyan) and counted as `todo`. This is the only directive that suppresses body codegen entirely — `@skip` does not, by design.
 
 Composition rules:
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -179,6 +179,50 @@ fn shouldNotReachHere():
 - Only available in `ry test` mode
 - Requires `from testing import fail`
 
+### Test selection: `@skip`, `@only`, `@todo`
+
+Three directives allow individual test selection within a file:
+
+```ry
+from testing import it, expect, skip, only, todo
+
+@skip
+@it("temporarily disabled while bug #123 is open")
+fn skipped():
+    expect(1).toEq(2)   # never runs, counted as `skipped`
+
+@only
+@it("the one failing case I am currently debugging")
+fn focused():
+    expect(1 + 1).toEq(2)
+
+@todo
+@it("upcoming feature, body not yet written")
+fn todo():
+    notYetDefined()     # body is never compiled
+```
+
+- `@skip @it("...")` — the test is not run; it is reported as `~ <name> (skipped)` (gray) and counted as `skipped`.
+- `@only @it("...")` — when at least one `@only` appears in a file, every `@it` in that file *without* `@only` is implicitly skipped. Useful for focused TDD on a single failing case. The implicit skip is reported the same way as `@skip`.
+- `@todo @it("...")` — a placeholder. The function body is **never emitted**, so it may reference undefined identifiers, omit a `return`, or otherwise fail compilation; only the directive itself is validated. Reported as `? <name> (todo)` (cyan) and counted as `todo`.
+
+Composition rules:
+
+- The three directives compose with `@each` and `@property`: `@skip @each @it(...)` skips the entire loop, `@only @property @it(...)` runs every iteration only when `@only` is the file's focus mode, `@todo @each @it(...)` emits nothing and counts as a single `todo`.
+- Mutual combinations (`@skip @only`, `@skip @todo`, `@only @todo`) are rejected at compile time.
+- The MVP supports `@it` only. Attaching `@skip`, `@only`, or `@todo` to `@describe` is a compile error.
+- `skipped` and `todo` do **not** influence the exit code. Only `failed` does.
+
+In outline mode (`ry test --outline`), the directive is appended as a suffix:
+
+```
++ it temporarily disabled while bug #123 is open (@skip)
++ it the one failing case I am currently debugging (@only)
++ it upcoming feature, body not yet written (@todo)
+```
+
+When combined with `@each` or `@property`, the suffix shows both, e.g. `(@only @each)`. Outline mode shows the full structure of all tests regardless of `@only`, so the focus filter does not apply there.
+
 ---
 
 ## Output Format
@@ -189,12 +233,15 @@ Calculator
   + should subtract
   - should fail
     line 10: expected 3, got 2
+  ~ should be skipped (skipped)
+  ? should be todo (todo)
 
-2 passed, 1 failed
+2 passed, 1 failed, 1 skipped, 1 todo
 ```
 
-- `+` indicates pass (green), `-` indicates failure (red)
+- `+` indicates pass (green), `-` indicates failure (red), `~` indicates skip (gray), `?` indicates todo (cyan)
 - On failure, the line number and expected/actual values are displayed
+- The summary always prints the 4-item form; `skipped` and `todo` do not contribute to the exit code (only `failed` does)
 
 ---
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -202,8 +202,8 @@ fn todo():
     notYetDefined()     # body is never compiled
 ```
 
-- `@skip @it("...")` — the test is not run; it is reported as `~ <name> (skipped)` (gray) and counted as `skipped`.
-- `@only @it("...")` — when at least one `@only` appears in a file, every `@it` in that file *without* `@only` is implicitly skipped. Useful for focused TDD on a single failing case. The implicit skip is reported the same way as `@skip`.
+- `@skip @it("...")` — the function body is **never emitted** (parallel to `@todo`), so it may reference undefined identifiers or otherwise fail body codegen; only the directive itself and the surrounding declaration are validated. Reported as `~ <name> (skipped)` (gray) and counted as `skipped`. Use this for tests that are temporarily disabled (e.g. while a bug is investigated); use `@todo` when the test has not been written yet.
+- `@only @it("...")` — when at least one `@only` appears on an `@it` function in a file, every `@it` in that file *without* `@only` is implicitly skipped. Useful for focused TDD on a single failing case. The implicit skip is reported the same way as `@skip`. `@only` on a non-`@it` function has no effect on file-wide selection — only `@only` paired with `@it` triggers the focus filter.
 - `@todo @it("...")` — a placeholder. The function body is **never emitted**, so it may reference undefined identifiers, omit a `return`, or otherwise fail compilation; only the directive itself is validated. Reported as `? <name> (todo)` (cyan) and counted as `todo`.
 
 Composition rules:
@@ -215,7 +215,7 @@ Composition rules:
 
 In outline mode (`ry test --outline`), the directive is appended as a suffix:
 
-```
+```text
 + it temporarily disabled while bug #123 is open (@skip)
 + it the one failing case I am currently debugging (@only)
 + it upcoming feature, body not yet written (@todo)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -930,6 +930,12 @@ public:
     int for_snap_counter_ = 0;   // monotonic counter for unique __for_iter_snap names (#1021)
     bool test_mode_ = false;
     bool outline_mode_ = false;
+    // True iff a top-level or describe-nested `@only @it` directive exists in
+    // the current translation unit. Set during compile()'s pre-pass and read
+    // by emitItDirective / emitEachItDirective / emitPropertyItDirective to
+    // implicitly skip non-@only test cases. Each *.test.ry runs as an
+    // independent subprocess (src/test_runner.cpp), so this stays file-local.
+    bool file_has_only_directive_ = false;
     int outline_depth_ = 0;
     bool coverage_mode_ = false;
     int coverage_file_id_offset_ = 0;
@@ -1409,6 +1415,10 @@ public:
     void emitOutlinePrintf(const std::string &label, llvm::Value *nameVal = nullptr);
     std::pair<llvm::FunctionCallee, llvm::FunctionCallee> getTestItFunctions();
     std::pair<llvm::FunctionCallee, llvm::FunctionCallee> getTestDescribeFunctions();
+    llvm::FunctionCallee getTestItSkipFunction();
+    llvm::FunctionCallee getTestItTodoFunction();
+    void validateTestSelectionDirectives(const std::vector<Directive> &directives,
+                                         const std::string &fnName);
     llvm::Function *emitTestFunction(const std::string &namePrefix,
         const std::vector<llvm::Type*> &paramTypes, LambdaExpr &lam, const std::string &context);
     void emitMockCall(CallStmt &s);

--- a/include/ry/test_runtime.hpp
+++ b/include/ry/test_runtime.hpp
@@ -10,6 +10,8 @@ extern "C" {
     void __ry_test_describe_end();
     void __ry_test_it_begin(const char *name);
     void __ry_test_it_end();
+    void __ry_test_it_skip(const char *name);
+    void __ry_test_it_todo(const char *name);
     void __ry_test_expect_fail(int line, const char *actual, const char *expected);
     void __ry_test_fail(int line, const char *msg);
     int  __ry_test_summary();

--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -19,6 +19,18 @@ fn each(data: any)
 @directive(target=["statement", "function"])
 fn property(count: int = 100)
 
+@public
+@directive(target=["function"])
+fn skip()
+
+@public
+@directive(target=["function"])
+fn only()
+
+@public
+@directive(target=["function"])
+fn todo()
+
 @native("testing")
 fn _mockGetCallCount(name: str) -> int
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -802,7 +802,9 @@ static bool stmtHasOnlyDirective(const StmtNode &stmt) {
     return std::visit([](const auto &s) -> bool {
         using T = std::decay_t<decltype(s)>;
         if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
-            if (hasDirective(s->directives, "only")) return true;
+            if (hasDirective(s->directives, "only") &&
+                hasDirective(s->directives, "it"))
+                return true;
             return stmtsHaveOnlyDirective(s->body);
         }
         return false;

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -792,14 +792,40 @@ static void collectTestTargetsFromStmts(const std::vector<StmtNode> &stmts,
         collectTestTargetsFromStmt(stmt, mocked, spied);
 }
 
+// Forward declaration for mutual recursion.
+static bool stmtsHaveOnlyDirective(const std::vector<StmtNode> &stmts);
+
+// Recursively scan a statement (and any nested fn bodies) for an `@only`
+// directive. Tests inside `@describe` are nested as inner FnStmts, so the
+// recursion through FnStmt::body naturally covers that case.
+static bool stmtHasOnlyDirective(const StmtNode &stmt) {
+    return std::visit([](const auto &s) -> bool {
+        using T = std::decay_t<decltype(s)>;
+        if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
+            if (hasDirective(s->directives, "only")) return true;
+            return stmtsHaveOnlyDirective(s->body);
+        }
+        return false;
+    }, stmt);
+}
+
+static bool stmtsHaveOnlyDirective(const std::vector<StmtNode> &stmts) {
+    for (const auto &stmt : stmts)
+        if (stmtHasOnlyDirective(stmt)) return true;
+    return false;
+}
+
 llvm::orc::ThreadSafeModule CodeGen::compile(Program &prog) {
     // Single pre-pass: collect mock targets and build cyclic type graph together
     std::unordered_map<std::string, std::unordered_set<std::string>> typeGraph;
     std::unordered_set<std::string> allTypes;
     for (auto &stmt : prog) {
         collectTypeGraphFromStmt(stmt, typeGraph, allTypes);
-        if (test_mode_)
+        if (test_mode_) {
             collectTestTargetsFromStmt(stmt, mocked_functions_, spied_functions_);
+            if (!file_has_only_directive_ && stmtHasOnlyDirective(stmt))
+                file_has_only_directive_ = true;
+        }
     }
     runCyclicTypeAnalysis(typeGraph, allTypes);
 

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -63,6 +63,30 @@ std::pair<llvm::FunctionCallee, llvm::FunctionCallee> CodeGen::getTestDescribeFu
     };
 }
 
+llvm::FunctionCallee CodeGen::getTestItSkipFunction() {
+    llvm::FunctionType *voidStrTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    return mod_->getOrInsertFunction("__ry_test_it_skip", voidStrTy);
+}
+
+llvm::FunctionCallee CodeGen::getTestItTodoFunction() {
+    llvm::FunctionType *voidStrTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    return mod_->getOrInsertFunction("__ry_test_it_todo", voidStrTy);
+}
+
+// Reject mutually exclusive combinations of test-selection directives. At
+// most one of @skip / @only / @todo may appear on a single @it function.
+void CodeGen::validateTestSelectionDirectives(const std::vector<Directive> &directives,
+                                              const std::string &fnName) {
+    int count = 0;
+    if (hasDirective(directives, "skip")) ++count;
+    if (hasDirective(directives, "only")) ++count;
+    if (hasDirective(directives, "todo")) ++count;
+    if (count > 1)
+        codegenError("test selection directives @skip / @only / @todo are mutually exclusive on fn '" + fnName + "'");
+}
+
 // Helper: create a test function, bind params, emit body, verify
 llvm::Function *CodeGen::emitTestFunction(
     const std::string &namePrefix,
@@ -333,11 +357,53 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     if (s->return_type)
         codegenError("@it: fn '" + s->name + "' cannot have a return type annotation");
 
-    if (hasDirective(s->directives, "each")) {
+    validateTestSelectionDirectives(s->directives, s->name);
+
+    const bool hasTodo = hasDirective(s->directives, "todo");
+    const bool hasSkip = hasDirective(s->directives, "skip");
+    const bool hasOnly = hasDirective(s->directives, "only");
+    const bool hasEach = hasDirective(s->directives, "each");
+    const bool hasProperty = hasDirective(s->directives, "property");
+    const bool implicitSkip = file_has_only_directive_ && !hasOnly && !hasTodo && !hasSkip;
+
+    std::string desc = getDirectivePositionalArg(s->directives, "it");
+
+    // Outline mode: structural visualization only. The @only-driven implicit
+    // skip filter does not apply; all tests are shown with their directive
+    // suffix so the user can see the full file layout.
+    if (outline_mode_) {
+        std::string suffix;
+        if (hasTodo) suffix = " (@todo)";
+        else if (hasSkip) suffix = " (@skip)";
+        else {
+            std::string inner;
+            if (hasOnly) inner = "@only";
+            if (hasEach) inner = inner.empty() ? "@each" : inner + " @each";
+            else if (hasProperty) inner = inner.empty() ? "@property" : inner + " @property";
+            if (!inner.empty()) suffix = " (" + inner + ")";
+        }
+        llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+        std::string fmt = "it %s" + suffix + "\n";
+        emitOutlinePrintf(fmt.c_str(), descVal);
+        return;
+    }
+
+    if (hasTodo) {
+        llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+        builder_.CreateCall(getTestItTodoFunction(), {descVal});
+        return;
+    }
+    if (hasSkip || implicitSkip) {
+        llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+        builder_.CreateCall(getTestItSkipFunction(), {descVal});
+        return;
+    }
+
+    if (hasEach) {
         emitEachItDirective(s);
         return;
     }
-    if (hasDirective(s->directives, "property")) {
+    if (hasProperty) {
         emitPropertyItDirective(s);
         return;
     }
@@ -346,16 +412,10 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     if (!s->params.empty())
         codegenError("@it: fn '" + s->name + "' has parameters but no @each or @property directive");
 
-    std::string desc = getDirectivePositionalArg(s->directives, "it");
-
-    if (outline_mode_) {
-        llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
-        emitOutlinePrintf("it %s\n", descVal);
-        return;
-    }
-
-    // Strip @it and emit the function normally, then emit it_begin/call/it_end
-    stripDirectives(s->directives, {"it"});
+    // Strip @it (and @only — directive has no runtime effect once we've decided
+    // to execute the case) and emit the function normally, then emit
+    // it_begin/call/it_end.
+    stripDirectives(s->directives, {"it", "only"});
     emitStmt(s);
 
     auto *overloads = findFunction(s->name);
@@ -397,7 +457,7 @@ void CodeGen::emitEachItDirective(std::unique_ptr<FnStmt> &s) {
         codegenError("@each: tuple arity (" + std::to_string(numFields) +
                      ") doesn't match function parameter count (" + std::to_string(s->params.size()) + ")");
 
-    stripDirectives(s->directives, {"it", "each"});
+    stripDirectives(s->directives, {"it", "each", "only"});
     emitStmt(s);
 
     auto *overloads = findFunction(s->name);
@@ -438,7 +498,7 @@ void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
         paramNames.push_back(p.name);
     }
 
-    stripDirectives(s->directives, {"it", "property"});
+    stripDirectives(s->directives, {"it", "property", "only"});
     emitStmt(s);
 
     auto *overloads = findFunction(s->name);
@@ -462,6 +522,12 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
         codegenError("@describe: fn '" + s->name + "' cannot have parameters");
     if (s->return_type)
         codegenError("@describe: fn '" + s->name + "' cannot have a return type annotation");
+    // Test-selection directives (@skip / @only / @todo) only apply to @it.
+    for (const char *bad : {"skip", "only", "todo"}) {
+        if (hasDirective(s->directives, bad))
+            codegenError(std::string("@") + bad + " cannot be applied to @describe (fn '" + s->name +
+                         "'); apply it to individual @it tests instead");
+    }
 
     std::string desc = getDirectivePositionalArg(s->directives, "describe");
     llvm::Value *descVal = cachedGlobalString(desc, ".describe_desc");

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -394,6 +394,14 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
         return;
     }
     if (hasSkip || implicitSkip) {
+        // Jest-compat: validate the body so type errors / undefined references
+        // surface even when the test is skipped. The generated fn is never
+        // invoked (no `it_begin` / call / `it_end` emitted). `@todo` is the
+        // only directive that suppresses body codegen entirely — it is meant
+        // for placeholder tests whose body has not been written yet.
+        stripDirectives(s->directives, {"it", "only", "skip", "each", "property"});
+        emitStmt(s);
+
         llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
         builder_.CreateCall(getTestItSkipFunction(), {descVal});
         return;

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -18,6 +18,8 @@ namespace ry {
 
 static int g_passed = 0;
 static int g_failed = 0;
+static int g_skipped = 0;
+static int g_todo = 0;
 static int g_describe_depth = 0;
 static std::string g_current_it;
 static bool g_current_it_failed = false;
@@ -539,6 +541,20 @@ void __ry_test_it_end() {
     g_current_it.clear();
 }
 
+void __ry_test_it_skip(const char *name) {
+    const auto indent = currentIndent();
+    std::printf("%s\033[90m~ %s (skipped)\033[0m\n", indent.c_str(), name ? name : "");
+    std::fflush(stdout);
+    ++g_skipped;
+}
+
+void __ry_test_it_todo(const char *name) {
+    const auto indent = currentIndent();
+    std::printf("%s\033[36m? %s (todo)\033[0m\n", indent.c_str(), name ? name : "");
+    std::fflush(stdout);
+    ++g_todo;
+}
+
 void __ry_test_expect_fail(int line, const char *actual, const char *expected) {
     g_current_it_failed = true;
     std::printf("%s\033[31mline %d: expected %s, got %s\033[0m\n", currentIndent(2).c_str(), line, expected, actual);
@@ -555,12 +571,15 @@ void __ry_test_fail(int line, const char *msg) {
 }
 
 int __ry_test_summary() {
-    std::printf("\n%d passed, %d failed\n", g_passed, g_failed);
+    std::printf("\n%d passed, %d failed, %d skipped, %d todo\n",
+                g_passed, g_failed, g_skipped, g_todo);
     std::fflush(stdout);
     int result = g_failed;
     // Reset for potential multiple invocations
     g_passed = 0;
     g_failed = 0;
+    g_skipped = 0;
+    g_todo = 0;
     return result;
 }
 

--- a/tests/spec/directive_only.test.ry
+++ b/tests/spec/directive_only.test.ry
@@ -1,0 +1,42 @@
+from testing import it, expect, each, property, only
+
+# When @only exists anywhere in this file, all @it tests WITHOUT @only are
+# implicitly skipped. Only tests tagged with @only run.
+# Non-@only tests would fail if they actually ran — exit 0 proves they were skipped.
+
+@it("should NOT run — implicit skip because @only is present elsewhere")
+fn testNotFocused():
+  expect(1).toEq(2)
+
+@only
+@it("should run — has @only directive")
+fn testFocused():
+  expect(1 + 1).toEq(2)
+
+@it("should also NOT run — another implicit skip")
+fn testAlsoNotFocused():
+  expect("a").toEq("b")
+
+@only
+@it("should also run — second @only test")
+fn testFocusedTwo():
+  expect(3 * 2).toEq(6)
+
+# @each without @only is implicitly skipped when @only exists in file
+@each([(1, 2), (3, 4)])
+@it("@each WITHOUT @only — implicitly skipped: {0}, {1}")
+fn testEachNotFocused(a: int, b: int):
+  expect(a).toEq(b)
+
+# @each with @only runs
+@only
+@each([(1, 1), (2, 2), (3, 3)])
+@it("@each WITH @only runs: {0} == {1}")
+fn testEachFocused(a: int, b: int):
+  expect(a).toEq(b)
+
+# @property without @only is implicitly skipped
+@property(count=50)
+@it("@property WITHOUT @only — implicitly skipped")
+fn testPropertyNotFocused(n: int):
+  expect(n).toEq(n + 1)

--- a/tests/spec/directive_skip.test.ry
+++ b/tests/spec/directive_skip.test.ry
@@ -1,0 +1,31 @@
+from testing import it, expect, each, property, skip
+
+# @skip @it does not execute the function body — even if the body would
+# fail, the file-level exit code stays at 0 (only failed tests bump it).
+# The runtime prints `~ <name> (skipped)` and increments the skipped counter.
+
+@skip
+@it("should not run — failing assertion would fire if not skipped")
+fn testSkipped():
+  expect(1).toEq(2)
+
+@skip
+@it("should also skip — second skipped test")
+fn testSkippedTwo():
+  expect("never").toEq("ran")
+
+@skip
+@each([(1, 2), (3, 4)])
+@it("should skip @each loop entirely: a={0}, b={1}")
+fn testSkippedEach(a: int, b: int):
+  expect(a).toEq(b)
+
+@skip
+@property(count=50)
+@it("should skip @property loop entirely")
+fn testSkippedProperty(n: int):
+  expect(n).toEq(n + 1)
+
+@it("should pass normally and prove non-skip tests still run")
+fn testNormal():
+  expect(1 + 1).toEq(2)

--- a/tests/spec/directive_todo.test.ry
+++ b/tests/spec/directive_todo.test.ry
@@ -1,0 +1,31 @@
+from testing import it, expect, each, property, todo
+
+# @todo @it suppresses body emission entirely — type errors and undefined
+# identifiers in the body are NOT detected (the body never reaches codegen).
+# The runtime prints `? <name> (todo)` and increments the todo counter.
+
+@todo
+@it("should be a todo — body uses undefined variable, must not type-check")
+fn testTodo():
+  expect(undefinedNeverDeclared).toEq(42)
+
+@todo
+@it("should also be todo — second placeholder")
+fn testTodoTwo():
+  expect(anotherUndefined + missingVar).toBeTrue()
+
+@todo
+@each([(1, 2), (3, 4)])
+@it("should be todo even with @each — body never compiles: a={0}, b={1}")
+fn testTodoEach(a: int, b: int):
+  expect(stillUndefined).toEq(missingAgain)
+
+@todo
+@property(count=50)
+@it("should be todo even with @property — body never compiles")
+fn testTodoProperty(n: int):
+  expect(yetAnotherUndefined).toEq(n)
+
+@it("should pass normally and prove non-todo tests still run")
+fn testNormal():
+  expect("ok").toEq("ok")

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -236,7 +236,13 @@ inline std::string withStdlibDirectiveDecls(const std::string &src) {
         "@directive(target=[\"statement\", \"function\"])\n"
         "fn each(data: any)\n"
         "@directive(target=[\"statement\", \"function\"])\n"
-        "fn property(count: int = 100)\n";
+        "fn property(count: int = 100)\n"
+        "@directive(target=[\"function\"])\n"
+        "fn skip()\n"
+        "@directive(target=[\"function\"])\n"
+        "fn only()\n"
+        "@directive(target=[\"function\"])\n"
+        "fn todo()\n";
     return std::string(kDecls) + src;
 }
 

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1967,3 +1967,18 @@ TEST_F(DirectiveTest, TodoOnDescribeRejected) {
         "        expect(1).toEq(1)\n"
     )), std::runtime_error);
 }
+
+// Regression: `@only` on a non-@it function must NOT flip
+// file_has_only_directive_. Before the pre-pass scope fix (PR #1767), bare
+// `@only fn helper()` falsely triggered file-wide implicit skip, causing the
+// plain @it test below to be reported as skipped instead of passed.
+TEST_F(DirectiveTest, OnlyOnNonItDoesNotTriggerFileWideSkip) {
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
+        "@only\n"
+        "fn helper():\n"
+        "    0\n"
+        "@it(\"plain test\")\n"
+        "fn t():\n"
+        "    expect(1).toEq(1)\n"
+    )), "\033[32m+ plain test\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
+}

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -1982,3 +1982,29 @@ TEST_F(DirectiveTest, OnlyOnNonItDoesNotTriggerFileWideSkip) {
         "    expect(1).toEq(1)\n"
     )), "\033[32m+ plain test\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
+
+// Jest-compat: @skip must compile the body so type errors / undefined
+// references in skipped tests are still surfaced. Only @todo suppresses
+// body codegen entirely (placeholder tests whose body has not been written).
+TEST_F(DirectiveTest, SkipValidatesBody) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@skip\n"
+        "@it(\"skipped test with bad body\")\n"
+        "fn t():\n"
+        "    expect(undefinedReference).toEq(0)\n"
+    )), std::runtime_error);
+}
+
+// Implicit skip (@only elsewhere in file forces this @it to skip) must also
+// validate the body. Same Jest-compat rationale as @skip.
+TEST_F(DirectiveTest, ImplicitSkipValidatesBody) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@only\n"
+        "@it(\"focused\")\n"
+        "fn focused():\n"
+        "    expect(1).toEq(1)\n"
+        "@it(\"implicitly skipped with bad body\")\n"
+        "fn t():\n"
+        "    expect(undefinedReference).toEq(0)\n"
+    )), std::runtime_error);
+}

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -922,7 +922,7 @@ TEST_F(DirectiveTest, ItDirectiveBasicCodegen) {
         "@it(\"should add 1 + 2 = 3\")\n"
         "fn testAdd():\n"
         "    expect(1 + 2).toEq(3)\n"
-    )), "\033[32m+ should add 1 + 2 = 3\033[0m\n\n1 passed, 0 failed\n");
+    )), "\033[32m+ should add 1 + 2 = 3\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // @it requires test mode — should error outside test mode
@@ -967,7 +967,7 @@ TEST_F(DirectiveTest, DescribeDirectiveBasicCodegen) {
         "    @it(\"should multiply\")\n"
         "    fn testMul():\n"
         "        expect(4 * 5).toEq(20)\n"
-    )), "math\n  \033[32m+ should subtract\033[0m\n  \033[32m+ should multiply\033[0m\n\n2 passed, 0 failed\n");
+    )), "math\n  \033[32m+ should subtract\033[0m\n  \033[32m+ should multiply\033[0m\n\n2 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // @each + @it on a named function: parameterized tests
@@ -980,7 +980,7 @@ TEST_F(DirectiveTest, ItDirectiveWithEach) {
     )), "\033[32m+ should add 1 + 2 = 3\033[0m\n"
        "\033[32m+ should add 0 + 0 = 0\033[0m\n"
        "\033[32m+ should add -1 + 1 = 0\033[0m\n"
-       "\n3 passed, 0 failed\n");
+       "\n3 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // @property + @it on a named function: property-based tests
@@ -1129,7 +1129,7 @@ TEST_F(DirectiveTest, DescribeDirectiveNestedDescribe) {
        "  \033[32m+ should pass as direct child\033[0m\n"
        "  inner\n"
        "    \033[32m+ should pass as nested child\033[0m\n"
-       "\n2 passed, 0 failed\n");
+       "\n2 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // Positional argument that is a function call expression.
@@ -1237,7 +1237,7 @@ TEST_F(DirectiveTest, DescribeDirectiveSharedSetup) {
     )), "shared setup\n"
        "  \033[32m+ should use x\033[0m\n"
        "  \033[32m+ should use x and y\033[0m\n"
-       "\n2 passed, 0 failed\n");
+       "\n2 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // @describe three levels deep: indentation tracks nesting depth
@@ -1256,7 +1256,7 @@ TEST_F(DirectiveTest, DescribeDirectiveThreeLevelNesting) {
        "  level 2\n"
        "    level 3\n"
        "      \033[32m+ should pass at deep nesting\033[0m\n"
-       "\n1 passed, 0 failed\n");
+       "\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // @each + @it inside @describe: parameterized tests inside a group
@@ -1271,7 +1271,7 @@ TEST_F(DirectiveTest, DescribeDirectiveWithEach) {
     )), "parameterized\n"
        "  \033[32m+ should add 1 + 2 = 3\033[0m\n"
        "  \033[32m+ should add 4 + 5 = 9\033[0m\n"
-       "\n2 passed, 0 failed\n");
+       "\n2 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // @property + @it inside @describe: property tests inside a group
@@ -1869,4 +1869,101 @@ TEST_F(DirectiveTest, PublicDirectiveRejectsArgs) {
     EXPECT_THROW({
         runSource("@public(\"foo\")\nfn bar() -> int:\n    return 1\n");
     }, std::runtime_error);
+}
+
+// ===== #1687: @skip / @only / @todo test-selection directives =====
+
+// Positive cases that must continue to parse and compile cleanly.
+TEST_F(DirectiveTest, SkipOnItCompiles) {
+    EXPECT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@skip\n"
+        "@it(\"placeholder\")\n"
+        "fn t():\n"
+        "    expect(1).toEq(1)\n"
+    )));
+}
+
+TEST_F(DirectiveTest, OnlyOnItCompiles) {
+    EXPECT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@only\n"
+        "@it(\"focused\")\n"
+        "fn t():\n"
+        "    expect(1).toEq(1)\n"
+    )));
+}
+
+TEST_F(DirectiveTest, TodoOnItCompiles) {
+    // Body intentionally uses an undefined identifier — @todo suppresses body
+    // codegen, so this must still compile (no type / lookup check).
+    EXPECT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@todo\n"
+        "@it(\"future implementation\")\n"
+        "fn t():\n"
+        "    expect(undefinedReference).toEq(0)\n"
+    )));
+}
+
+// Mutual exclusivity: any two of @skip / @only / @todo together must reject.
+TEST_F(DirectiveTest, SkipAndOnlyMutuallyExclusive) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@skip\n"
+        "@only\n"
+        "@it(\"conflict\")\n"
+        "fn t():\n"
+        "    expect(1).toEq(1)\n"
+    )), std::runtime_error);
+}
+
+TEST_F(DirectiveTest, SkipAndTodoMutuallyExclusive) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@skip\n"
+        "@todo\n"
+        "@it(\"conflict\")\n"
+        "fn t():\n"
+        "    expect(1).toEq(1)\n"
+    )), std::runtime_error);
+}
+
+TEST_F(DirectiveTest, OnlyAndTodoMutuallyExclusive) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@only\n"
+        "@todo\n"
+        "@it(\"conflict\")\n"
+        "fn t():\n"
+        "    expect(1).toEq(1)\n"
+    )), std::runtime_error);
+}
+
+// @describe must reject @skip / @only / @todo. MVP supports @it only.
+TEST_F(DirectiveTest, SkipOnDescribeRejected) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@skip\n"
+        "@describe(\"group\")\n"
+        "fn g():\n"
+        "    @it(\"inner\")\n"
+        "    fn inner():\n"
+        "        expect(1).toEq(1)\n"
+    )), std::runtime_error);
+}
+
+TEST_F(DirectiveTest, OnlyOnDescribeRejected) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@only\n"
+        "@describe(\"group\")\n"
+        "fn g():\n"
+        "    @it(\"inner\")\n"
+        "    fn inner():\n"
+        "        expect(1).toEq(1)\n"
+    )), std::runtime_error);
+}
+
+TEST_F(DirectiveTest, TodoOnDescribeRejected) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@todo\n"
+        "@describe(\"group\")\n"
+        "fn g():\n"
+        "    @it(\"inner\")\n"
+        "    fn inner():\n"
+        "        expect(1).toEq(1)\n"
+    )), std::runtime_error);
 }

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -13,7 +13,7 @@ TEST_F(CodeGenTest, FailWithMessage) {
         "    @it(\"marks test as failed\")\n"
         "    fn marksTestAsFailed():\n"
         "        fail(\"intentional failure\")\n"
-    )), "fail helper\n    \033[31mline 21: intentional failure\033[0m\n  \033[31m- marks test as failed\033[0m\n\n0 passed, 1 failed\n");
+    )), "fail helper\n    \033[31mline 27: intentional failure\033[0m\n  \033[31m- marks test as failed\033[0m\n\n0 passed, 1 failed, 0 skipped, 0 todo\n");
 }
 
 // ============================================================
@@ -27,7 +27,7 @@ TEST_F(CodeGenTest, FailWithoutMessage) {
         "    @it(\"fails generically\")\n"
         "    fn failsGenerically():\n"
         "        fail()\n"
-    )), "fail bare\n    \033[31mline 21: test failed\033[0m\n  \033[31m- fails generically\033[0m\n\n0 passed, 1 failed\n");
+    )), "fail bare\n    \033[31mline 27: test failed\033[0m\n  \033[31m- fails generically\033[0m\n\n0 passed, 1 failed, 0 skipped, 0 todo\n");
 }
 
 // ============================================================

--- a/tests/test_codegen_mock.cpp
+++ b/tests/test_codegen_mock.cpp
@@ -17,7 +17,7 @@ TEST_F(CodeGenTest, MockBasicReplace) {
         "    fn replacesFunction():\n"
         "        mock(greet, () => \"mocked\")\n"
         "        expect(greet()).toEq(\"mocked\")\n"
-    )), "mock basic\n  \033[32m+ replaces function\033[0m\n\n1 passed, 0 failed\n");
+    )), "mock basic\n  \033[32m+ replaces function\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // ============================================================
@@ -35,7 +35,7 @@ TEST_F(CodeGenTest, MockWithArgs) {
         "    fn replacesFunctionWithArgs():\n"
         "        mock(add, (a: int, b: int) => a * b)\n"
         "        expect(add(3, 4)).toEq(12)\n"
-    )), "mock with args\n  \033[32m+ replaces function with args\033[0m\n\n1 passed, 0 failed\n");
+    )), "mock with args\n  \033[32m+ replaces function with args\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // ============================================================
@@ -57,7 +57,7 @@ TEST_F(CodeGenTest, MockAutoRestore) {
         "    @it(\"auto-restores\")\n"
         "    fn autoRestores():\n"
         "        expect(greet()).toEq(\"hello\")\n"
-    )), "mock restore\n  \033[32m+ mocks\033[0m\n  \033[32m+ auto-restores\033[0m\n\n2 passed, 0 failed\n");
+    )), "mock restore\n  \033[32m+ mocks\033[0m\n  \033[32m+ auto-restores\033[0m\n\n2 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // ============================================================
@@ -78,7 +78,7 @@ TEST_F(CodeGenTest, MockVerifyCallCount) {
         "        greet()\n"
         "        greet()\n"
         "        expect(verify(\"greet\")).toEq(3)\n"
-    )), "verify\n  \033[32m+ counts calls\033[0m\n\n1 passed, 0 failed\n");
+    )), "verify\n  \033[32m+ counts calls\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // ============================================================
@@ -99,7 +99,7 @@ TEST_F(CodeGenTest, MockFunctionUsedAsExpr) {
         "        x = getValue()\n"
         "        expect(x).toEq(999)\n"
         "        expect(verify(\"getValue\")).toEq(1)\n"
-    )), "mock expr\n  \033[32m+ tracks calls in expressions\033[0m\n\n1 passed, 0 failed\n");
+    )), "mock expr\n  \033[32m+ tracks calls in expressions\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // ============================================================
@@ -304,7 +304,7 @@ TEST_F(CodeGenTest, VerifyCalledWithListIntArgAccepted) {
         "        mock(takesList, (xs: List<int>) => len(xs))\n"
         "        takesList([1, 2])\n"
         "        expect(verifyCalledWith(\"takesList\", [1, 2])).toEq(1)\n"
-    )), "vcw list\n  \033[32m+ counts list arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw list\n  \033[32m+ counts list arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithListStrArgAccepted) {
@@ -320,7 +320,7 @@ TEST_F(CodeGenTest, VerifyCalledWithListStrArgAccepted) {
         "        mock(takesList, (xs: List<str>) => len(xs))\n"
         "        takesList([\"a\", \"b\"])\n"
         "        expect(verifyCalledWith(\"takesList\", [\"a\", \"b\"])).toEq(1)\n"
-    )), "vcw list str\n  \033[32m+ counts list str arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw list str\n  \033[32m+ counts list str arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithNestedListArgUnsupportedError) {
@@ -354,7 +354,7 @@ TEST_F(CodeGenTest, VerifyCalledWithMapStrIntArgAccepted) {
         "        mock(takesMap, (m: Map<str, int>) => len(m))\n"
         "        takesMap({\"a\": 1})\n"
         "        expect(verifyCalledWith(\"takesMap\", {\"a\": 1})).toEq(1)\n"
-    )), "vcw map\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw map\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithListParameterRejectedWithPrimitiveArg) {
@@ -431,7 +431,7 @@ TEST_F(CodeGenTest, VerifyCalledWithSetIntArgAccepted) {
         "        mock(takesSet, (xs: Set<int>) => len(xs))\n"
         "        takesSet({1, 2, 3})\n"
         "        expect(verifyCalledWith(\"takesSet\", {1, 2, 3})).toEq(1)\n"
-    )), "vcw set\n  \033[32m+ counts set arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw set\n  \033[32m+ counts set arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithSetStrArgAccepted) {
@@ -447,7 +447,7 @@ TEST_F(CodeGenTest, VerifyCalledWithSetStrArgAccepted) {
         "        mock(takesSet, (xs: Set<str>) => len(xs))\n"
         "        takesSet({\"a\", \"b\"})\n"
         "        expect(verifyCalledWith(\"takesSet\", {\"a\", \"b\"})).toEq(1)\n"
-    )), "vcw set str\n  \033[32m+ counts set str arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw set str\n  \033[32m+ counts set str arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithSetUnorderedMatch) {
@@ -463,7 +463,7 @@ TEST_F(CodeGenTest, VerifyCalledWithSetUnorderedMatch) {
         "        mock(takesSet, (xs: Set<int>) => len(xs))\n"
         "        takesSet({1, 2, 3})\n"
         "        expect(verifyCalledWith(\"takesSet\", {3, 2, 1})).toEq(1)\n"
-    )), "vcw set unordered\n  \033[32m+ matches unordered\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw set unordered\n  \033[32m+ matches unordered\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithSetParameterRejectedWithPrimitiveArg) {
@@ -571,7 +571,7 @@ TEST_F(CodeGenTest, VerifyCalledWithMapIntIntArgAccepted) {
         "        mock(takesMap, (m: Map<int, int>) => len(m))\n"
         "        takesMap({1: 10, 2: 20})\n"
         "        expect(verifyCalledWith(\"takesMap\", {1: 10, 2: 20})).toEq(1)\n"
-    )), "vcw map int int\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw map int int\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithMapStrStrArgAccepted) {
@@ -587,7 +587,7 @@ TEST_F(CodeGenTest, VerifyCalledWithMapStrStrArgAccepted) {
         "        mock(takesMap, (m: Map<str, str>) => len(m))\n"
         "        takesMap({\"a\": \"x\", \"b\": \"y\"})\n"
         "        expect(verifyCalledWith(\"takesMap\", {\"a\": \"x\", \"b\": \"y\"})).toEq(1)\n"
-    )), "vcw map str str\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw map str str\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithMapUnorderedMatch) {
@@ -603,7 +603,7 @@ TEST_F(CodeGenTest, VerifyCalledWithMapUnorderedMatch) {
         "        mock(takesMap, (m: Map<str, int>) => len(m))\n"
         "        takesMap({\"a\": 1, \"b\": 2, \"c\": 3})\n"
         "        expect(verifyCalledWith(\"takesMap\", {\"c\": 3, \"a\": 1, \"b\": 2})).toEq(1)\n"
-    )), "vcw map unordered\n  \033[32m+ matches unordered\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw map unordered\n  \033[32m+ matches unordered\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithMapStrFloatArgAccepted) {
@@ -619,7 +619,7 @@ TEST_F(CodeGenTest, VerifyCalledWithMapStrFloatArgAccepted) {
         "        mock(takesMap, (m: Map<str, float>) => len(m))\n"
         "        takesMap({\"a\": 1.5, \"b\": 2.5})\n"
         "        expect(verifyCalledWith(\"takesMap\", {\"a\": 1.5, \"b\": 2.5})).toEq(1)\n"
-    )), "vcw map str float\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw map str float\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithMapStrBoolArgAccepted) {
@@ -635,7 +635,7 @@ TEST_F(CodeGenTest, VerifyCalledWithMapStrBoolArgAccepted) {
         "        mock(takesMap, (m: Map<str, bool>) => len(m))\n"
         "        takesMap({\"a\": true, \"b\": false})\n"
         "        expect(verifyCalledWith(\"takesMap\", {\"a\": true, \"b\": false})).toEq(1)\n"
-    )), "vcw map str bool\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw map str bool\n  \033[32m+ counts map arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithMapParameterRejectedWithPrimitiveArg) {
@@ -796,7 +796,7 @@ TEST_F(CodeGenTest, VerifyCalledWithRecordArgAccepted) {
         "        mock(takesPoint, (p: Point) => p.x)\n"
         "        takesPoint(Point(1, 2))\n"
         "        expect(verifyCalledWith(\"takesPoint\", Point(1, 2))).toEq(1)\n"
-    )), "vcw record\n  \033[32m+ counts record arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw record\n  \033[32m+ counts record arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithRecordParamDifferentRecordTypeRejected) {
@@ -886,7 +886,7 @@ TEST_F(CodeGenTest, VerifyCalledWithTupleArgAccepted) {
         "        mock(takesPair, (p: (int, int)) => 0)\n"
         "        takesPair((1, 2))\n"
         "        expect(verifyCalledWith(\"takesPair\", (1, 2))).toEq(1)\n"
-    )), "vcw tuple\n  \033[32m+ counts tuple arg\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw tuple\n  \033[32m+ counts tuple arg\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 TEST_F(CodeGenTest, VerifyCalledWithTupleArityMismatchRejected) {
@@ -1114,5 +1114,5 @@ TEST_F(CodeGenTest, VerifyCalledWithSpiedFunction) {
         "        compute(5)\n"
         "        expect(verifyCalledWith(\"compute\", 5)).toEq(2)\n"
         "        expect(verifyCalledWith(\"compute\", 7)).toEq(1)\n"
-    )), "vcw spy\n  \033[32m+ matches spied call\033[0m\n\n1 passed, 0 failed\n");
+    )), "vcw spy\n  \033[32m+ matches spied call\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }


### PR DESCRIPTION
## Summary

Add three directives for per-test selection within a file (#1687):

- `@skip @it("...")` — skip the test, count as `skipped`
- `@only @it("...")` — when any `@only` is present in the file, all non-`@only` tests are implicitly skipped (focused TDD)
- `@todo @it("...")` — placeholder with no body emission (function body may reference undefined identifiers and still compile); counts as `todo`

All three compose with `@each` / `@property` and are rejected on `@describe` in this MVP release. Mutual combinations (`@skip @only` / `@skip @todo` / `@only @todo`) are codegen errors.

The test summary now always prints the 4-item form `N passed, M failed, K skipped, T todo`; only `failed` influences the exit code. Outline mode (`ry test --outline`) renders the directive as a suffix, e.g. `it foo (@skip)`, `it foo (@only @each)`.

## Test plan

- [x] `./build/ry test tests/spec/directive_skip.test.ry` — passes with `1 passed, 0 failed, 4 skipped, 0 todo`
- [x] `./build/ry test tests/spec/directive_only.test.ry` — passes with `5 passed, 0 failed, 4 skipped, 0 todo`
- [x] `./build/ry test tests/spec/directive_todo.test.ry` — passes with `1 passed, 0 failed, 0 skipped, 4 todo`
- [x] `./build/ry test --outline` renders `(@skip)` / `(@only)` / `(@todo)` and combined suffixes (`@only @each`)
- [x] `./build/ry_tests --gtest_filter='*Directive*'` — C++ rejection tests for mutual exclusion + `@describe` rejection
- [x] `./build/ry_tests` — full C++ suite (2329 tests)
- [x] `./build/ry test -p` — full Ry self-test (190 files)
- [x] ASan + UBSan: clean (`ry_tests` + `ry test -p`)
- [x] TSan: clean (`ry_tests` + `ry test -p`)
- [x] clang-tidy / cppcheck: clean
- [x] Docs updated: `docs/reference/testing.md`, `docs/reference/directives.md`
- [x] Changelog fragment: `changelog.d/1687-skip-only-todo-directives.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added test directives `@skip`, `@only`, and `@todo`; outline-mode shows directive suffixes and runtime now reports/skips/totals skipped & todo (only failures affect exit status).
  * Test summary updated to "N passed, M failed, K skipped, T todo".

* **Documentation**
  * Added reference docs and changelog describing directive semantics, composition rules, and constraints.
  * New knowledge entry warns about stdlib-name collisions under tests/spec/ and provides an audit checklist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1767?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->