### PR TITLE
fix(testing): guard toContain / toNotContain against non-str pointer elements (#1763)

### DIFF
--- a/.claude/rules/codegen-llvm-ir-conventions.md
+++ b/.claude/rules/codegen-llvm-ir-conventions.md
@@ -4,6 +4,7 @@ paths:
   - "src/codegen_expr_cast.cpp"
   - "src/codegen_builtin.cpp"
   - "src/codegen.cpp"
+  - "src/codegen_test.cpp"
   - "include/ry/codegen.hpp"
   - "tests/filecheck/**/*.ry"
 ---
@@ -32,7 +33,7 @@ Each file is both Ry source and a FileCheck script. Use `# CHECK:` (Ry comment i
 
 ### Collection ops on pointer elements: positive allowlist via list_elem_type_name
 
-When a collection helper's pointer-element branch uses `strcmp` (or any C-string op), guard with a positive allowlist on `list_elem_type_name`, not a single-field blacklist via `getNestedListElementType`. The `NestedListElem` field is set only by `propagateTypeMeta`'s isListTypeName branch; Map/Set/function element kinds live in `map_value_type_name` / `list_elem_fn_type_info`. Blacklist on a single field is structurally incomplete — `List<Map<K,V>>` / `List<fn(...)>` / `List<Set<T>>` slip through and `strcmp` on Map/Set/closure headers is UB. Pattern: classify pointer elements as "non-str" if `list_elem_type_name` is non-empty and not `"str"`, OR if `nested_list_elem != nullptr`, OR if `list_elem_fn_type_info.has_value()`; emit "operation only supported for primitive / str lists". Resource lists (`List<TcpStream>`) get a non-empty type name and are caught.
+When a collection helper's pointer-element branch uses `strcmp` (or any C-string op), guard with a positive allowlist on `list_elem_type_name`, not a single-field blacklist via `getNestedListElementType`. The `NestedListElem` field is set only by `propagateTypeMeta`'s isListTypeName branch; Map/Set/function element kinds live in `map_value_type_name` / `list_elem_fn_type_info`. Blacklist on a single field is structurally incomplete — `List<Map<K,V>>` / `List<fn(...)>` / `List<Set<T>>` slip through and `strcmp` on Map/Set/closure headers is UB. Pattern: classify pointer elements as "non-str" if `list_elem_type_name` is non-empty and not `"str"`, OR if `nested_list_elem != nullptr`, OR if `list_elem_fn_type_info.has_value()`; emit "operation only supported for primitive / str lists". Resource lists (`List<TcpStream>`) get a non-empty type name and are caught. For Set elements (`toContain` / `toNotContain` Set branch and similar helpers), apply the analogous classification using `set_elem_type_name` and `set_elem_fn_type_info` — `ValueMetadata` has no `nested_set_elem` field, so the disjunct collapses to two: `set_elem_type_name` non-empty and not `"str"`, OR `set_elem_fn_type_info.has_value()`. Sets of nested collections still flow through these two fields via `propagateTypeMeta`.
 
 ### emitRuntimeError terminates its block — caller pre-splits to continue
 

--- a/changelog.d/1763-tocontain-ptr-elem-guard.md
+++ b/changelog.d/1763-tocontain-ptr-elem-guard.md
@@ -1,0 +1,16 @@
+### Fixed
+
+- Fixed undefined behavior in `expect(x).toContain(y)` and
+  `expect(x).toNotContain(y)` where pointer-typed list/set elements
+  were unconditionally compared with `strcmp`. Under opaque pointers
+  `elemTy == ptrTy_` matches not only `List<str>` / `Set<str>` but
+  also `List<List<T>>` / `List<Map<K, V>>` / `List<Set<T>>` /
+  `List<fn>` / `Set<List<T>>` / `Set<Map<K, V>>` / `Set<fn>`, so the
+  previous code read the bytes of a collection / closure header as a
+  C string — UB that could silently report two distinct length-N
+  lists as "equal" because their headers begin with the same length
+  prefix. These shapes are now rejected at compile time with a clear
+  diagnostic (`list element type must be int, float, str, or bool` /
+  `set element type must be int, float, str, or bool`), mirroring the
+  positive-allowlist guard previously applied to `toBeOneOf`
+  (#1689) and `emitListRemove`. (#1763)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -143,8 +143,8 @@ foo("arg", ():
 | `toBeSome()` | Asserts Option is `Some` | Option |
 | `toBeOk()` | Asserts Result is `Ok` | Result |
 | `toBeErr()` | Asserts Result is `Err` | Result |
-| `toContain(val)` | Asserts container includes value | List, Set, Map, str |
-| `toNotContain(val)` | Asserts container does not include value | List, Set, Map, str |
+| `toContain(val)` | Asserts container includes value (for List/Set, element type must be `int`, `float`, `str`, or `bool`; for Map, checks keys) | List, Set, Map, str |
+| `toNotContain(val)` | Asserts container does not include value (for List/Set, element type must be `int`, `float`, `str`, or `bool`; for Map, checks keys) | List, Set, Map, str |
 | `toBeGreaterThan(v)` | Asserts `actual > v` | int, float |
 | `toBeLessThan(v)` | Asserts `actual < v` | int, float |
 | `toBeGreaterThanOrEq(v)` | Asserts `actual >= v` | int, float |

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -2124,6 +2124,31 @@ void CodeGen::emitStmt(ExpectStmt &s) {
             llvm::Type *elemTy = listElemTy ? listElemTy : setElemTy;
             llvm::StructType *headerTy = listElemTy ? listHeaderTy_ : setHeaderTy_;
 
+            // Pointer-element positive-allowlist guard (mirrors toBeOneOf
+            // L2273-2281 / emitListRemove L244-250). Under opaque pointers
+            // elemTy == ptrTy_ matches List<str> as well as List<List<T>>,
+            // List<Map<K,V>>, List<Set<T>>, List<fn>, Set<List<T>>, etc.
+            // strcmp on collection headers is UB (#1763). Narrow to str only.
+            if (elemTy == ptrTy_) {
+                const ValueMetadata *meta = getMeta(actualVal);
+                if (listElemTy) {
+                    const std::string &elemName = meta ? meta->list_elem_type_name : std::string{};
+                    const bool isNonStrName  = !elemName.empty() && elemName != "str";
+                    const bool hasNestedList = meta && meta->nested_list_elem != nullptr;
+                    const bool hasFnInfo     = meta && meta->list_elem_fn_type_info.has_value();
+                    if (isNonStrName || hasNestedList || hasFnInfo || !isStringValue(expectedVal))
+                        codegenError("line " + std::to_string(s.loc.line) +
+                                     ": " + s.matcher + ": list element type must be int, float, str, or bool");
+                } else {
+                    const std::string &elemName = meta ? meta->set_elem_type_name : std::string{};
+                    const bool isNonStrName = !elemName.empty() && elemName != "str";
+                    const bool hasFnInfo    = meta && meta->set_elem_fn_type_info.has_value();
+                    if (isNonStrName || hasFnInfo || !isStringValue(expectedVal))
+                        codegenError("line " + std::to_string(s.loc.line) +
+                                     ": " + s.matcher + ": set element type must be int, float, str, or bool");
+                }
+            }
+
             llvm::Value *lenPtr = builder_.CreateStructGEP(headerTy, actualVal, 0, "len_ptr");
             llvm::Value *len = builder_.CreateLoad(i64Ty_, lenPtr, "len");
             llvm::Value *dataField = builder_.CreateStructGEP(headerTy, actualVal, 2, "data_field");

--- a/tests/spec/matchers.test.ry
+++ b/tests/spec/matchers.test.ry
@@ -86,6 +86,14 @@ fn containmentMatchersTests():
   fn shouldPassTonotcontainWithMapKey():
     m = {"a": 1, "b": 2}
     expect(m).toNotContain("c")
+  @it("should pass toContain with list of str")
+  fn shouldPassTocontainWithListOfStr():
+    xs: List<str> = ["a", "b", "c"]
+    expect(xs).toContain("b")
+  @it("should pass toContain with set of str")
+  fn shouldPassTocontainWithSetOfStr():
+    s: Set<str> = {"x", "y"}
+    expect(s).toContain("x")
 
 record MatcherPoint:
   x: int

--- a/tests/test_codegen_advanced.cpp
+++ b/tests/test_codegen_advanced.cpp
@@ -1460,6 +1460,85 @@ TEST_F(CodeGenTest, ExpectToBeOneOfRejectsListOfLists) {
     EXPECT_THROW(runTestSource(src), std::runtime_error);
 }
 
+TEST_F(CodeGenTest, ExpectToContainRejectsListOfLists) {
+    // toContain on List<List<T>> must be rejected before reaching strcmp on
+    // List headers (#1763).
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"list of lists\")\n"
+        "    fn listOfLists():\n"
+        "        a: List<int> = [1, 2]\n"
+        "        b: List<int> = [3, 4]\n"
+        "        outer: List<List<int>> = [a, b]\n"
+        "        expect(outer).toContain(a)\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ExpectToContainRejectsListOfMaps) {
+    // toContain on List<Map<K, V>> must be rejected: strcmp on Map headers
+    // is UB (#1763).
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"list of maps\")\n"
+        "    fn listOfMaps():\n"
+        "        m: Map<str, int> = {\"a\": 1}\n"
+        "        outer: List<Map<str, int>> = [m]\n"
+        "        expect(outer).toContain(m)\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ExpectToContainRejectsSetOfLists) {
+    // toContain on Set<List<T>> must be rejected: strcmp on List headers
+    // (Set branch shares the same UB) (#1763).
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"set of lists\")\n"
+        "    fn setOfLists():\n"
+        "        a: List<int> = [1, 2]\n"
+        "        s: Set<List<int>> = {a}\n"
+        "        expect(s).toContain(a)\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ExpectToContainRejectsListOfFns) {
+    // Directly trigger the list_elem_fn_type_info disjunct: List<fn() -> int>
+    // would otherwise read closure header bytes via strcmp (#1763).
+    std::string src = withStdlibDirectiveDecls(
+        "fn helper() -> int:\n"
+        "    return 42\n"
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"list of fns\")\n"
+        "    fn listOfFns():\n"
+        "        flist: List<fn() -> int> = [helper]\n"
+        "        expect(flist).toContain(helper)\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
+TEST_F(CodeGenTest, ExpectToNotContainRejectsListOfLists) {
+    // toNotContain shares the same code path as toContain and must reject
+    // List<List<T>> via the same guard (#1763).
+    std::string src = withStdlibDirectiveDecls(
+        "@describe(\"matchers\")\n"
+        "fn matchers():\n"
+        "    @it(\"toNotContain list of lists\")\n"
+        "    fn notContainListOfLists():\n"
+        "        a: List<int> = [1, 2]\n"
+        "        b: List<int> = [3, 4]\n"
+        "        c: List<int> = [99, 99]\n"
+        "        outer: List<List<int>> = [a, b]\n"
+        "        expect(outer).toNotContain(c)\n"
+    );
+    EXPECT_THROW(runTestSource(src), std::runtime_error);
+}
+
 // ===== Field assignment subtype coercion (#359) =====
 
 TEST_F(CodeGenTest, FieldAssignSubtypeCoercion) {


### PR DESCRIPTION
## Summary

Fixes #1763 — `expect(x).toContain(y)` and `expect(x).toNotContain(y)`
unconditionally called `strcmp` on pointer-typed list/set elements.
Under opaque pointers, `elemTy == ptrTy_` matches not only `List<str>`
/ `Set<str>` but also `List<List<T>>`, `List<Map<K,V>>`, `List<Set<T>>`,
`List<fn>`, `Set<List<T>>`, `Set<Map<K,V>>`, `Set<fn>` — so the
previous code read the bytes of a collection / closure header as a C
string. This is UB and silently false-positives: two distinct length-N
lists report as "equal" because their headers begin with the same
length prefix.

The fix mirrors the canonical positive-allowlist guard already applied
to `toBeOneOf` (PR #1762, closing #1689) and `emitListRemove`. The
guard sits at the entry of the `else if (listElemTy || setElemTy)`
branch in `emitStmt(ExpectStmt)` and rejects non-str pointer elements
at compile time with a clear diagnostic:

- `list element type must be int, float, str, or bool`
- `set element type must be int, float, str, or bool`

The List disjunct uses `list_elem_type_name` / `nested_list_elem` /
`list_elem_fn_type_info`. The Set disjunct uses `set_elem_type_name`
/ `set_elem_fn_type_info` (`ValueMetadata` has no `nested_set_elem`
field; Sets of nested collections still flow through these two via
`propagateTypeMeta`). `s.matcher` is embedded in the message so one
guard covers both `toContain` and `toNotContain`.

Map keys are unaffected — the type system constrains Map keys to
primitives, so the UB is unreachable for the Map branch.

## Changes

- `src/codegen_test.cpp` — positive-allowlist guard at the entry of the List/Set pointer branch
- `tests/test_codegen_advanced.cpp` — 5 rejection tests (`ExpectToContainRejectsListOfLists`, `ExpectToContainRejectsListOfMaps`, `ExpectToContainRejectsSetOfLists`, `ExpectToContainRejectsListOfFns`, `ExpectToNotContainRejectsListOfLists`)
- `tests/spec/matchers.test.ry` — `List<str>` / `Set<str>` positive cases (regression guard for the `!isStringValue(expectedVal)` path)
- `docs/reference/testing.md` — element-type constraint documented on `toContain` / `toNotContain` rows
- `.claude/rules/codegen-llvm-ir-conventions.md` — `src/codegen_test.cpp` added to frontmatter `paths:`; Set-side classification documented in the "Collection ops on pointer elements" entry
- `changelog.d/1763-tocontain-ptr-elem-guard.md` — CHANGELOG fragment

## Test plan

- [x] `cmake --build build` clean
- [x] `./build/ry_tests` — 2337 tests pass (+1 vs main: `ExpectToContainRejectsListOfFns`)
- [x] `./build/ry test -p` — 190 files, 0 failures
- [x] ASan + UBSan — `ry_tests` and `ry test -p` pass on `build-asan/`
- [x] TSan — `ry_tests` and `ry test -p` pass on `build-tsan/`
- [x] cppcheck clean
- [x] clang-tidy clean on `src/codegen_test.cpp`
- [ ] CI green

Closes #1763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed undefined behavior in `toContain()` and `toNotContain()` matchers when using complex element types in collections. Now enforces at compile time that only primitive types (int, float, str, bool) are supported as collection elements, with clear diagnostic messages.

* **Documentation**
  * Updated testing reference documentation to clarify supported element types for containment matchers.

* **Tests**
  * Added comprehensive test coverage for containment matchers with various data types and validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->