### PR TITLE
fix(codegen): walk lambda bodies in every ExprPtr slot during test-mode pre-scan (#1765)

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -25,4 +25,20 @@
 - When adding a new `.test.ry` file under a new subdirectory, grep `share/std/` first: `ls share/std/ | sort | uniq` — pick a directory name that does not appear in the list.
 - If a stdlib module is renamed in the future, audit `tests/spec/` for newly-colliding directories at the same time.
 
+### Pre-scan AST walkers must traverse every `ExprPtr` slot, or document the limitation inline
+
+**Source**: #1765 (2026-05-16 implementation)
+**Tags**: codegen, pre-scan, ast-walker, mock, spy, slot-coverage, blind-spot
+
+**Context**: `collectTestTargetsFromStmt` (`src/codegen.cpp`) was introduced for the test-mode pre-scan that populates `mocked_functions_` / `spied_functions_`. The first version walked `LambdaExpr.body` only inside `CallStmt.args`, missing identical lambdas stored in `AssignStmt.value`, `ReturnStmt.value`, `CallExpr.args` (nested at any depth), `IfStmt.condition`, and other ExprPtr slots. The bug surfaces only when the gated callsite is codegen'd BEFORE the lambda body runs — typically inside a module-level helper fn declared above the `@describe` block. `emitMockCall` populates the same set at codegen time, masking the bug whenever the callsite happens to follow the mock-setup statement in emission order.
+
+**Rule**: A pre-scan AST walker that needs to find anonymous nested constructs (lambda bodies, embedded directives, etc.) must traverse **every** `ExprPtr` and `StmtNode` slot reachable from each variant — not just the slots that happen to host the construct on the day the walker was written. Concretely: implement an `expr` visitor over all `ExprNode` alternatives in tandem with the stmt visitor, and route every stmt's ExprPtr field (`AssignStmt.value`, `ReturnStmt.value`, `IfStmt.branch.condition`, `WhileStmt.condition`, `ForStmt.iterable`, `ExpectStmt.{actual,expected,extra_args}`, etc.) through it. The expr visitor descends into compound nodes (`CallExpr.args`, `BinaryExpr.{lhs,rhs}`, `IfBlockExpr.{then_body,else_body}` — the only Expr that contains StmtNodes — and so on) so an anonymous LambdaExpr buried any number of levels deep is reached.
+
+**Why**: Slot coverage gaps are silent at compile time and only surface as runtime correctness bugs in narrow code paths. The fix is mechanical (mirror the AST variant list), the test is unstable to write (depends on emission order to manifest), and the recurrence cost is high if a future pre-scan extension forgets the same slots.
+
+**How to apply**:
+- When adding a new pre-scan walker (`stmtHasOnlyDirective` analogues, future test-mode discovery passes, lint passes), implement the full ExprNode + StmtNode visitor pair up-front. If a slot is intentionally excluded (e.g. `RecordStmt.invariants` is dead for this walker's purpose), add an inline comment naming the slot and stating the reason — silent omission is the bug.
+- When adding a new AST variant (new `ExprNode` or `StmtNode` alternative), grep for existing walkers in `src/codegen.cpp` and update them to include the new variant. Walkers that should `if constexpr (...)` over every variant include `collectTestTargetsFromStmt`, `collectTestTargetsFromExpr` (#1765), and `stmtHasOnlyDirective`.
+- The `LambdaExpr` and `IfBlockExpr` alternatives are the only ExprNode variants that carry `std::vector<StmtNode>` — both must hand off to the stmt-walker (`collectTestTargetsFromStmts`) explicitly. Forgetting one of them re-introduces the same class of bug.
+
 

--- a/changelog.d/1765-mock-spy-lambda-prescan.md
+++ b/changelog.d/1765-mock-spy-lambda-prescan.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `mock()` / `spy()` pre-scan now walks lambda bodies inside every
+  `ExprPtr` slot, not just `CallStmt.args`. Targets defined inside a
+  lambda stored in `AssignStmt.value`, `ReturnStmt.value`,
+  `CallExpr.args` (nested at any depth), `IfStmt.condition`, or any
+  other AST position are now detected, so the mock dispatch gate fires
+  for callsites compiled before the lambda runs. (#1765)

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -763,7 +763,7 @@ static void collectTestTargetsFromExpr(const ExprPtr &expr,
         if constexpr (std::is_same_v<T, std::unique_ptr<BinaryExpr>>) {
             collectTestTargetsFromExpr(e->lhs, mocked, spied);
             collectTestTargetsFromExpr(e->rhs, mocked, spied);
-        } else if constexpr (std::is_same_v<T, std::unique_ptr<UnaryExpr>>) {
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<UnaryExpr>>) { // NOLINT(bugprone-branch-clone)
             collectTestTargetsFromExpr(e->operand, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CallExpr>>) {
             for (auto &a : e->args)
@@ -851,7 +851,7 @@ static void collectTestTargetsFromStmt(const StmtNode &stmt,
                 collectTestTargetsFromExpr(arg, mocked, spied);
             for (auto &na : s.named_args)
                 collectTestTargetsFromExpr(na.value, mocked, spied);
-        } else if constexpr (std::is_same_v<T, AssignStmt>) {
+        } else if constexpr (std::is_same_v<T, AssignStmt>) { // NOLINT(bugprone-branch-clone)
             collectTestTargetsFromExpr(s.value, mocked, spied);
         } else if constexpr (std::is_same_v<T, ExprStmt>) {
             collectTestTargetsFromExpr(s.expr, mocked, spied);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -741,10 +741,96 @@ bool CodeGen::isCapturedVar(llvm::AllocaInst *ptr) const {
     return captured_vars_.count(ptr) > 0;
 }
 
-// Forward declaration for mutual recursion.
+// Forward declarations for mutual recursion.
 static void collectTestTargetsFromStmts(const std::vector<StmtNode> &stmts,
                                         std::unordered_set<std::string> &mocked,
                                         std::unordered_set<std::string> &spied);
+static void collectTestTargetsFromExpr(const ExprPtr &expr,
+                                       std::unordered_set<std::string> &mocked,
+                                       std::unordered_set<std::string> &spied);
+
+// Walk every ExprPtr slot, descending into nested expressions and into the
+// stmt bodies of `LambdaExpr` / `IfBlockExpr`. Pre-scan looks for `mock` /
+// `spy` calls (which are CallStmt, not CallExpr) inside lambda bodies, so
+// the visitor's only job is to reach those bodies regardless of which AST
+// slot the lambda is nested in.
+static void collectTestTargetsFromExpr(const ExprPtr &expr,
+                                       std::unordered_set<std::string> &mocked,
+                                       std::unordered_set<std::string> &spied) {
+    if (!expr) return;
+    std::visit([&](const auto &e) {
+        using T = std::decay_t<decltype(e)>;
+        if constexpr (std::is_same_v<T, std::unique_ptr<BinaryExpr>>) {
+            collectTestTargetsFromExpr(e->lhs, mocked, spied);
+            collectTestTargetsFromExpr(e->rhs, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<UnaryExpr>>) {
+            collectTestTargetsFromExpr(e->operand, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<CallExpr>>) {
+            for (auto &a : e->args)
+                collectTestTargetsFromExpr(a, mocked, spied);
+            for (auto &na : e->named_args)
+                collectTestTargetsFromExpr(na.value, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<FieldAccessExpr>>) {
+            collectTestTargetsFromExpr(e->object, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<TupleExpr>>) {
+            for (auto &el : e->elements)
+                collectTestTargetsFromExpr(el, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<ListExpr>>) {
+            for (auto &el : e->elements)
+                collectTestTargetsFromExpr(el, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<IndexExpr>>) {
+            collectTestTargetsFromExpr(e->object, mocked, spied);
+            for (auto &i : e->indices)
+                collectTestTargetsFromExpr(i, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<MapExpr>>) {
+            for (auto &k : e->keys)
+                collectTestTargetsFromExpr(k, mocked, spied);
+            for (auto &v : e->values)
+                collectTestTargetsFromExpr(v, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<SetExpr>>) {
+            for (auto &el : e->elements)
+                collectTestTargetsFromExpr(el, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<LambdaExpr>>) {
+            collectTestTargetsFromStmts(e->body, mocked, spied);
+            collectTestTargetsFromExpr(e->expr_body, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<CastExpr>>) {
+            collectTestTargetsFromExpr(e->value, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<InterpolatedStringExpr>>) {
+            for (auto &ex : e->exprs)
+                collectTestTargetsFromExpr(ex, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondExpr>>) {
+            for (auto &arm : e->arms) {
+                collectTestTargetsFromExpr(arm.condition, mocked, spied);
+                collectTestTargetsFromExpr(arm.value, mocked, spied);
+            }
+            collectTestTargetsFromExpr(e->else_expr, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseExpr>>) {
+            collectTestTargetsFromExpr(e->subject, mocked, spied);
+            for (auto &arm : e->arms) {
+                collectTestTargetsFromExpr(arm.guard, mocked, spied);
+                collectTestTargetsFromExpr(arm.value, mocked, spied);
+            }
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<IfExpr>>) {
+            collectTestTargetsFromExpr(e->condition, mocked, spied);
+            collectTestTargetsFromExpr(e->then_value, mocked, spied);
+            collectTestTargetsFromExpr(e->else_value, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<IfBlockExpr>>) {
+            collectTestTargetsFromExpr(e->condition, mocked, spied);
+            collectTestTargetsFromStmts(e->then_body, mocked, spied);
+            collectTestTargetsFromStmts(e->else_body, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<RangeExpr>>) {
+            collectTestTargetsFromExpr(e->start, mocked, spied);
+            collectTestTargetsFromExpr(e->end, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<ErrorPropagateExpr>>) {
+            collectTestTargetsFromExpr(e->operand, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<AwaitExpr>>) {
+            collectTestTargetsFromExpr(e->operand, mocked, spied);
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<WeakExpr>>) {
+            collectTestTargetsFromExpr(e->operand, mocked, spied);
+        }
+        // Leaf variants (Number/Float/Bool/String/Regex/Variable/EnumAccess/None) — no recursion.
+    }, expr->data);
+}
 
 // Scan a single statement (and its nested bodies) for mock() / spy() targets.
 static void collectTestTargetsFromStmt(const StmtNode &stmt,
@@ -761,27 +847,73 @@ static void collectTestTargetsFromStmt(const StmtNode &stmt,
                         spied.insert(str->value);
                 }
             }
-            for (auto &arg : s.args) {
-                if (auto *lam = std::get_if<std::unique_ptr<LambdaExpr>>(&arg->data))
-                    collectTestTargetsFromStmts((*lam)->body, mocked, spied);
-            }
+            for (auto &arg : s.args)
+                collectTestTargetsFromExpr(arg, mocked, spied);
+            for (auto &na : s.named_args)
+                collectTestTargetsFromExpr(na.value, mocked, spied);
+        } else if constexpr (std::is_same_v<T, AssignStmt>) {
+            collectTestTargetsFromExpr(s.value, mocked, spied);
+        } else if constexpr (std::is_same_v<T, ExprStmt>) {
+            collectTestTargetsFromExpr(s.expr, mocked, spied);
+        } else if constexpr (std::is_same_v<T, ReturnStmt>) {
+            collectTestTargetsFromExpr(s.value, mocked, spied);
+        } else if constexpr (std::is_same_v<T, IndexAssignStmt>) {
+            collectTestTargetsFromExpr(s.object, mocked, spied);
+            for (auto &i : s.indices)
+                collectTestTargetsFromExpr(i, mocked, spied);
+            collectTestTargetsFromExpr(s.value, mocked, spied);
+        } else if constexpr (std::is_same_v<T, FieldAssignStmt>) {
+            collectTestTargetsFromExpr(s.object, mocked, spied);
+            collectTestTargetsFromExpr(s.value, mocked, spied);
+        } else if constexpr (std::is_same_v<T, TupleDestructStmt>) {
+            collectTestTargetsFromExpr(s.value, mocked, spied);
+        } else if constexpr (std::is_same_v<T, ExpectStmt>) {
+            collectTestTargetsFromExpr(s.actual, mocked, spied);
+            collectTestTargetsFromExpr(s.expected, mocked, spied);
+            for (auto &x : s.extra_args)
+                collectTestTargetsFromExpr(x, mocked, spied);
+        } else if constexpr (std::is_same_v<T, AwaitStmt>) {
+            collectTestTargetsFromExpr(s.operand, mocked, spied);
+        } else if constexpr (std::is_same_v<T, RecordStmt>) {
+            for (auto &inv : s.invariants)
+                collectTestTargetsFromExpr(inv, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<IfStmt>>) {
+            collectTestTargetsFromExpr(s->branch.condition, mocked, spied);
             collectTestTargetsFromStmts(s->branch.body, mocked, spied);
             collectTestTargetsFromStmts(s->else_body, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseCondStmt>>) {
-            for (auto &arm : s->arms)
+            for (auto &arm : s->arms) {
+                collectTestTargetsFromExpr(arm.condition, mocked, spied);
                 collectTestTargetsFromStmts(arm.body, mocked, spied);
+            }
             collectTestTargetsFromStmts(s->else_body, mocked, spied);
-        } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) { // NOLINT(bugprone-branch-clone)
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<WhileStmt>>) {
+            collectTestTargetsFromExpr(s->condition, mocked, spied);
             collectTestTargetsFromStmts(s->body, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<ForStmt>>) {
+            collectTestTargetsFromExpr(s->iterable, mocked, spied);
             collectTestTargetsFromStmts(s->body, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<FnStmt>>) {
+            for (auto &p : s->params)
+                collectTestTargetsFromExpr(p.default_value, mocked, spied);
+            for (auto &pre : s->preconditions)
+                collectTestTargetsFromExpr(pre, mocked, spied);
+            for (auto &post : s->postconditions)
+                collectTestTargetsFromExpr(post, mocked, spied);
             collectTestTargetsFromStmts(s->body, mocked, spied);
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseStmt>>) {
-            for (auto &arm : s->arms)
+            collectTestTargetsFromExpr(s->subject, mocked, spied);
+            for (auto &arm : s->arms) {
+                collectTestTargetsFromExpr(arm.guard, mocked, spied);
                 collectTestTargetsFromStmts(arm.body, mocked, spied);
+            }
+        } else if constexpr (std::is_same_v<T, std::unique_ptr<QualifiedImportStmt>>) {
+            collectTestTargetsFromStmts(s->definitions, mocked, spied);
+        } else if constexpr (std::is_same_v<T, DirectiveDefStmt>) {
+            for (auto &p : s.params)
+                collectTestTargetsFromExpr(p.default_value, mocked, spied);
         }
+        // Other stmts (Import/Break/Continue/Ellipsis/Enum/TypeAlias/ImportAlias) — no ExprPtr slots that can host a mock-bearing lambda.
     }, stmt);
 }
 

--- a/tests/spec/mock.test.ry
+++ b/tests/spec/mock.test.ry
@@ -669,3 +669,84 @@ fn mockResetAllTests():
   fn shouldBeNoopEmptyRegistry():
     mockResetAll()
     expect(verify("anything")).toEq(0)
+
+# Helpers for #1765 — lambda body pre-scan coverage.
+# Each helper pair (realFetchX + callsRealFetchX) exposes the bug: the
+# callsite inside callsRealFetchX's body is codegen'd BEFORE any @it body
+# runs, so a pre-scan miss leaves the gate off and the mock cannot
+# intercept at runtime. Unique target names per test prevent cross-test
+# leakage in the global mocked_functions_ set.
+fn realFetchA() -> str:
+  return "real A"
+
+fn callsRealFetchA() -> str:
+  return realFetchA()
+
+fn realFetchB() -> str:
+  return "real B"
+
+fn callsRealFetchB() -> str:
+  return realFetchB()
+
+fn realFetchC() -> str:
+  return "real C"
+
+fn callsRealFetchC() -> str:
+  return realFetchC()
+
+fn realFetchD() -> str:
+  return "real D"
+
+fn callsRealFetchD() -> str:
+  return realFetchD()
+
+fn realFetchE() -> str:
+  return "real E"
+
+fn callsRealFetchE() -> str:
+  return realFetchE()
+
+fn makeMockSetupForB() -> fn() -> int:
+  return ():
+    mock("realFetchB", () => "fake B")
+
+fn runSetup(setup: fn() -> int) -> int:
+  setup()
+  return 0
+
+fn pickLambda(setup: fn() -> int) -> fn() -> int:
+  return setup
+
+fn applyAndReturnTrue(setup: fn() -> int) -> bool:
+  setup()
+  return true
+
+@describe("mock detection inside non-CallStmt lambda positions (#1765)")
+fn mockInNonCallStmtPositionsTests():
+  @it("detects mock target inside AssignStmt rhs lambda body")
+  fn detectsMockInAssignRhsLambda():
+    f = ():
+      mock("realFetchA", () => "fake A")
+    f()
+    expect(callsRealFetchA()).toEq("fake A")
+
+  @it("detects mock target inside ReturnStmt lambda body (via helper returning lambda)")
+  fn detectsMockInReturnStmtLambda():
+    setup = makeMockSetupForB()
+    setup()
+    expect(callsRealFetchB()).toEq("fake B")
+
+  @it("detects mock target inside AssignStmt rhs CallExpr argument lambda")
+  fn detectsMockInAssignRhsCallExprArgsLambda():
+    _ = runSetup(():
+      mock("realFetchC", () => "fake C")
+    )
+    expect(callsRealFetchC()).toEq("fake C")
+
+  @it("detects mock target inside IfStmt condition CallExpr argument lambda")
+  fn detectsMockInIfStmtConditionLambda():
+    if applyAndReturnTrue(():
+      mock("realFetchE", () => "fake E")
+    ):
+      expect(callsRealFetchE()).toEq("fake E")
+

--- a/tests/spec/spy.test.ry
+++ b/tests/spec/spy.test.ry
@@ -188,3 +188,22 @@ fn spyMockInteropTests():
     expect(verify("tickAndReturn")).toEq(1)
     # Real impl bypassed: the side-effect counter must stay at 0.
     expect(sideEffectCount[0]).toEq(0)
+
+# Helper for #1765 — verifies pre-scan walker also reaches spy() targets in
+# AssignStmt.value lambda bodies (same bug surface as mock(), exercised here
+# to lock in spy-side coverage).
+fn realComputeForSpy(x: int) -> int:
+  return x * 3
+
+fn callsRealComputeForSpy(x: int) -> int:
+  return realComputeForSpy(x)
+
+@describe("spy detection inside non-CallStmt lambda positions (#1765)")
+fn spyInNonCallStmtPositionsTests():
+  @it("detects spy target inside AssignStmt rhs lambda body")
+  fn detectsSpyInAssignRhsLambda():
+    f = ():
+      spy("realComputeForSpy")
+    f()
+    expect(callsRealComputeForSpy(4)).toEq(12)
+    expect(verify("realComputeForSpy")).toEq(1)


### PR DESCRIPTION
## Summary

- `collectTestTargetsFromStmt` (`src/codegen.cpp`) previously descended into `LambdaExpr.body` only inside `CallStmt.args`. Lambdas containing `mock(...)` / `spy(...)` in `AssignStmt.value`, `ReturnStmt.value`, nested `CallExpr.args`, `IfStmt.condition`, etc. were silently missed — the dispatch gate in `codegen_call_user.cpp` did not fire for callsites compiled before the mock-setup statement (typically inside a module-level helper fn declared above `@describe`).
- Added a companion `collectTestTargetsFromExpr` visitor that walks every `ExprNode` variant and hands off `LambdaExpr` / `IfBlockExpr` stmt bodies to the existing stmt walker. Routed every stmt's ExprPtr slot through it (AssignStmt.value, ReturnStmt.value, IfStmt.branch.condition, WhileStmt.condition, ForStmt.iterable, ExpectStmt.*, CaseStmt.subject/arms.guard, FnStmt.{params.default_value, preconditions, postconditions}, DirectiveDefStmt.params.default_value, etc.).
- New positive tests in `tests/spec/mock.test.ry` (4 cases) and `tests/spec/spy.test.ry` (1 case) lock in the previously-missed slot patterns. Each test uses a unique target name + module-level helper fn so the bug surface (callsite codegen before mock-setup codegen) actually fires.
- Added a `KNOWLEDGE.md` entry "Pre-scan AST walkers must traverse every `ExprPtr` slot, or document the limitation inline" so future pre-scan walkers (`stmtHasOnlyDirective` analogues etc.) do not regress the same way.

## Side-finding

- During TDD an unrelated JIT crash surfaced when passing a block-body lambda through a higher-order function that returns the lambda (`pickLambda(f) { return f }` then invoking the returned value). It reproduces without `mock` and is independent of this fix. Filed as #1770 for separate triage; the corresponding test was dropped from this PR.

## Test plan

- [x] `./build/ry_tests` — 2337/2337 passing
- [x] `./build/ry test -p` — 190 files, 0 failures
- [x] ASan + UBSan (`./build-asan/ry_tests` and `./build-asan/ry test -p`) clean
- [x] TSan (`./build-tsan/ry_tests`) clean
- [x] libFuzzer skipped: no harness exercises `test_mode` pre-scan
- [x] `.serena/` no diff

Closes #1765

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mock() and spy() detection so call targets defined inside lambda bodies are reliably discovered regardless of where the lambda appears, ensuring mocks and spies apply correctly at runtime.

* **Tests**
  * Added regression tests covering mock and spy detection for lambdas in various code positions to prevent future regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1771?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->