### PR TITLE
feat(testing): add mockReturnValueOnce per-call sequence mock (#1681)

### DIFF
--- a/changelog.d/1681-mock-return-value-once.md
+++ b/changelog.d/1681-mock-return-value-once.md
@@ -1,0 +1,19 @@
+### Added
+
+- Added `mockReturnValueOnce(name, value)` to the testing framework for
+  Jest-compatible per-call queued mock returns. Each call to
+  `mockReturnValueOnce` enqueues `value` for the named function; the next
+  call to that function dequeues and returns the head of the queue.
+  When the queue empties, calls fall back to the function set via
+  `mock(name, replacement)` (if any), then to the original implementation
+  — matching Jest's fallback chain. All return types are supported
+  (primitives, `str`, `List` / `Map` / `Set`, records, `Result`,
+  `Option` including bare `None`). The first argument must be a string
+  literal naming the function; overloaded functions, unknown names,
+  Unit-returning functions, and value type mismatches are rejected at
+  compile time. `mockClear(name)` preserves the queue (only resets the
+  call counter), while `mockReset(name)` and `mockResetAll()` discard
+  the queue. Queues are auto-cleared at the end of each `it` block.
+  Note: `verify(name)` counts only queue-served and default-mock-served
+  calls; calls that fall through to the original implementation are not
+  counted (matching `mockReset` semantics). (#1681)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -480,7 +480,7 @@ fn mockReturnValueOnceTests():
 ```
 
 - Requires `from testing import mockReturnValueOnce` (since v0.0.24, #1681)
-- The first argument is the **string literal** name of the function (same convention as `mock` / `spy`); non-literal first arguments are rejected at compile time
+- The first argument is the **string literal** name of the function (same convention as `spy` / `verifyCalledWith`, unlike `mock` which takes an identifier); non-literal first arguments are rejected at compile time
 - The function must exist, must not be overloaded, and must not return `Unit`; all are compile errors
 - The second argument's type must match the function's declared return type. Supported types: primitives (`int` / `float` / `bool`), `str`, `List` / `Map` / `Set`, records, `Result`, and `Option` (including bare `None` for `Option`-returning functions)
 - Arguments to the mocked call are ignored — the queue holds values, not call expectations

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -450,6 +450,45 @@ fn spyTests():
 - `mockClear(name)` / `mockReset(name)` / `mockResetAll()` apply to spied functions identically — they share the same internal registry
 - A function may be both mocked and spied across different `it` blocks within the same describe. When both are active in the same block (mock+spy coexistence), `mock` takes precedence: the replacement runs and the call is counted; the real implementation is bypassed
 
+### mockReturnValueOnce(name, value)
+
+Enqueues a value for the named function. The next call to that function dequeues and returns the head of the queue. When the queue empties, calls fall back to the function set via `mock(name, replacement)` (if any), then to the original implementation — matching Jest's fallback chain.
+
+```ry
+from testing import it, describe, mock, mockReturnValueOnce, verify, expect
+
+fn fetchUser() -> str:
+    return "real"
+
+@describe("mockReturnValueOnce")
+fn mockReturnValueOnceTests():
+    @it("returns queued values in order then falls back to original")
+    fn returnsQueuedThenOriginal():
+        mockReturnValueOnce("fetchUser", "first")
+        mockReturnValueOnce("fetchUser", "second")
+        expect(fetchUser()).toEq("first")
+        expect(fetchUser()).toEq("second")
+        expect(fetchUser()).toEq("real")   # queue empty, falls back to original
+
+    @it("can mix with mock() default — queue wins, then default, then original")
+    fn mixesWithDefault():
+        mock(fetchUser, () => "fallback")
+        mockReturnValueOnce("fetchUser", "queued")
+        expect(fetchUser()).toEq("queued")     # queue
+        expect(fetchUser()).toEq("fallback")   # default mock
+        expect(fetchUser()).toEq("fallback")   # default mock (stays)
+```
+
+- Requires `from testing import mockReturnValueOnce` (since v0.0.24, #1681)
+- The first argument is the **string literal** name of the function (same convention as `mock` / `spy`); non-literal first arguments are rejected at compile time
+- The function must exist, must not be overloaded, and must not return `Unit`; all are compile errors
+- The second argument's type must match the function's declared return type. Supported types: primitives (`int` / `float` / `bool`), `str`, `List` / `Map` / `Set`, records, `Result`, and `Option` (including bare `None` for `Option`-returning functions)
+- Arguments to the mocked call are ignored — the queue holds values, not call expectations
+- `verify(name)` counts only queue-served and default-mock-served calls. Once the queue empties and the call falls through to the original implementation, those calls are **not** counted (matching `mockReset` semantics — diverges from strict Jest behavior)
+- `mockClear(name)` preserves the queue and only resets the call counter; `mockReset(name)` and `mockResetAll()` discard the queue
+- Queues are automatically cleared at the end of each `it` block (same lifecycle as `mock` / `spy`)
+- Capture-based closures registered via `mock(name, replacement)` coexist with queued values — the queue is consumed first, then the closure
+
 ### mockClear(name)
 
 Resets the recorded call list (and call count) for a single mock to zero, but keeps the mock active. Subsequent calls continue to dispatch to the replacement.
@@ -477,6 +516,7 @@ fn mockClearTests():
 - No-op when `name` is not currently mocked or spied (no error)
 - Affects `verify(name)` and `verifyCalledWith(name, args...)` identically — both observe the cleared call list
 - Applies to spied functions identically — mock and spy share the same call-recording registry (#1683)
+- **Preserves the `mockReturnValueOnce` queue** — only the call counter is reset; queued values remain and continue to be dispatched on subsequent calls (matches Jest semantics, #1681)
 
 ### mockReset(name)
 
@@ -504,6 +544,7 @@ fn mockResetTests():
 - No-op when `name` is not currently mocked or spied (no error)
 - Releases the replacement closure environment (capturing closures' captured variables are dropped immediately, equivalent to `it`-block end auto-cleanup for this single mock)
 - Applies to spied functions identically — removes the spy registration, after which `verify(name)` returns 0 (#1683)
+- **Discards the `mockReturnValueOnce` queue** for the named function — any remaining queued values are released (#1681)
 
 ### mockResetAll()
 
@@ -537,12 +578,14 @@ fn mockResetAllTests():
 - Takes no arguments
 - No-op when no mock or spy is currently registered
 - Clears spied functions identically — the registry is shared between mock and spy (#1683)
+- **Discards all `mockReturnValueOnce` queues** — every named function's queued values are released (#1681)
 
 ### Limitations
 
 - Overloaded functions cannot be mocked.
 - `@native fn` declarations cannot be mocked.
 - Capture-based closures **are supported as mock replacements** (since v0.0.22, #1678) — the closure can read or mutate variables from the enclosing scope. The captured environment is released automatically when the `it` block ends.
+- For `mockReturnValueOnce`, calls that fall through to the original implementation (after the queue empties and with no default `mock` set) are not counted by `verify(name)` — only queue-served and default-mock-served calls increment the counter. This diverges from strict Jest behavior but matches the Ry convention used by `mockReset` (#1681).
 
 ---
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1430,12 +1430,44 @@ public:
     llvm::Function *emitTestFunction(const std::string &namePrefix,
         const std::vector<llvm::Type*> &paramTypes, LambdaExpr &lam, const std::string &context);
     void emitMockCall(CallStmt &s);
+    void emitMockReturnValueOnceCall(CallStmt &s);
     void emitSpyCall(CallStmt &s);
     void emitFailCall(CallStmt &s);
     llvm::Value *emitVerifyCalledWithCall(const CallExpr &e);
     void emitMockArgRecording(llvm::Value *nameStr,
                                const std::vector<llvm::Value *> &argVals,
                                OverloadEntry *matchedEntry);
+
+    // mockReturnValueOnce support (#1681): a value-return thunk loads a
+    // pre-stored return value from the env, retains it (so the caller gets
+    // a +1), and returns. Cached by origFn since the thunk body is fully
+    // determined by origFn's return signature.
+    llvm::Function *getOrCreateValueReturnThunk(llvm::Function *origFn,
+                                                 const std::string &retTyName);
+    std::unordered_map<llvm::Function*, llvm::Function*> value_return_thunk_cache_;
+
+    // Env destructor for a value-return mock binding. Loads the stored value
+    // from env and releases its ARC content (str / List / Map / Set / Record
+    // / Result / Option). Returns an empty FunctionCallee when the return
+    // type is non-ARC (primitive) — callers pass null env_dtor in that case.
+    // Cached by retTyName (the source-level Ry type string).
+    llvm::FunctionCallee getOrCreateValueReturnEnvDestructor(
+        llvm::Type *retTy, const std::string &retTyName);
+    std::unordered_map<std::string, llvm::FunctionCallee> value_return_env_dtor_cache_;
+
+    // Emit ARC retain on a value-return result at the current insert point.
+    // Used by getOrCreateValueReturnThunk (per-call retain handed to caller)
+    // and emitMockReturnValueOnceCall (register-time retain handed to env).
+    // Dispatches on the source-level type name (str / List / Map / Set /
+    // Record / Result<T,E> / Option<T> / T?). Primitives are no-ops.
+    void retainValueReturnResult(llvm::Value *val,
+                                  llvm::Type *retTy,
+                                  const std::string &retTyName);
+    // Symmetric to retainValueReturnResult; used by the env destructor body.
+    void releaseValueReturnResult(llvm::Value *val,
+                                   llvm::Type *retTy,
+                                   const std::string &retTyName);
+
     std::unordered_set<std::string> mocked_functions_;
     std::unordered_set<std::string> spied_functions_;
     std::unordered_map<std::string, llvm::Constant*> mock_name_strings_;

--- a/include/ry/test_runtime.hpp
+++ b/include/ry/test_runtime.hpp
@@ -20,6 +20,13 @@ extern "C" {
     void    __ry_mock_set(const char *name, void *fn_ptr);
     void    __ry_mock_set_closure(const char *name, void *thunk_ptr,
                                    void *env_ptr, void (*env_dtor)(void *));
+    // Append a per-call binding to the once-queue (#1681). thunk_ptr is a
+    // (origParams..., env) -> R thunk that ignores its user params and loads
+    // the return value from env; env_ptr is the ARC-managed env holding the
+    // pre-stored return value; env_dtor releases inner ARC ownership before
+    // the env itself is freed.
+    void    __ry_mock_register_once(const char *name, void *thunk_ptr,
+                                     void *env_ptr, void (*env_dtor)(void *));
     void    __ry_spy_register(const char *name);
     void   *__ry_mock_get(const char *name);
     void   *__ry_mock_get_env(const char *name);

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -839,12 +839,13 @@ static void collectTestTargetsFromStmt(const StmtNode &stmt,
     std::visit([&](const auto &s) {
         using T = std::decay_t<decltype(s)>;
         if constexpr (std::is_same_v<T, CallStmt>) {
-            if ((s.callee == "mock" || s.callee == "spy") && !s.args.empty()) {
+            if ((s.callee == "mock" || s.callee == "mockReturnValueOnce" ||
+                 s.callee == "spy") && !s.args.empty()) {
                 if (auto *str = std::get_if<StringExpr>(&s.args[0]->data)) {
-                    if (s.callee == "mock")
-                        mocked.insert(str->value);
-                    else
+                    if (s.callee == "spy")
                         spied.insert(str->value);
+                    else
+                        mocked.insert(str->value);
                 }
             }
             for (auto &arg : s.args)

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -512,6 +512,10 @@ void CodeGen::emitStmt(CallStmt &s) {
         emitMockCall(s);
         return;
     }
+    if (s.callee == "mockReturnValueOnce") {
+        emitMockReturnValueOnceCall(s);
+        return;
+    }
     if (s.callee == "spy") {
         emitSpyCall(s);
         return;

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -660,6 +660,400 @@ void CodeGen::emitMockCall(CallStmt &s) {
     builder_.CreateCall(mockSetClosureFn, {nameStr, thunk, replacement, envDtorVal});
 }
 
+// ===== Test: mockReturnValueOnce — per-call value-return queue (#1681) =====
+//
+// Local helper: strip "Option<" or "Result<" prefix and trailing '>', return
+// the nth comma-separated type argument (paren-aware). Mirrors the static
+// helper in codegen_match.cpp but lives here to avoid leaking a private TU
+// symbol. Used to recover the Ok / Err / Some inner type names for retain /
+// release dispatch on tagged-union return types.
+static std::string vretExtractGenericArg(const std::string &typeStr,
+                                          const std::string &prefix,
+                                          size_t argIdx) {
+    if (prefix == "Option<" && typeStr.size() > 1 && typeStr.back() == '?') {
+        if (argIdx != 0) return {};
+        return CodeGen::trimTypeNameSpaces(typeStr.substr(0, typeStr.size() - 1));
+    }
+    if (typeStr.size() <= prefix.size() ||
+        typeStr.compare(0, prefix.size(), prefix) != 0 ||
+        typeStr.back() != '>')
+        return {};
+    const std::string inner = typeStr.substr(prefix.size(),
+                                              typeStr.size() - prefix.size() - 1);
+    const auto parts = CodeGen::splitTypeArgs(inner);
+    if (argIdx >= parts.size()) return {};
+    return CodeGen::trimTypeNameSpaces(parts[argIdx]);
+}
+
+void CodeGen::retainValueReturnResult(llvm::Value *val,
+                                       llvm::Type *retTy,
+                                       const std::string &retTyName) {
+    if (!val || !retTy || retTy->isVoidTy())
+        return;
+    std::string resolved = resolveTypeAlias(retTyName);
+
+    if (resolved == "str") {
+        auto *hdr = emitStrGetHeaderFromData(val);
+        emitArcRetain(hdr, false);
+        return;
+    }
+    if (isListTypeName(resolved) || isMapTypeName(resolved) || isSetTypeName(resolved)) {
+        auto *hdr = emitArcGetHeaderFromData(val);
+        emitArcRetain(hdr, false);
+        return;
+    }
+    if (auto *st = llvm::dyn_cast<llvm::StructType>(retTy)) {
+        if (record_types_.count(resolved)) {
+            emitRecordArcFieldsRetain(val, st);
+            return;
+        }
+        // Result<T, E> / Option<T> / T?
+        bool isResult = resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0;
+        bool isOption = (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0)
+                     || (!resolved.empty() && resolved.back() == '?');
+        if (!isResult && !isOption) return;
+
+        std::string okName  = isResult ? vretExtractGenericArg(resolved, "Result<", 0)
+                                       : vretExtractGenericArg(resolved, "Option<", 0);
+        std::string errName = isResult ? vretExtractGenericArg(resolved, "Result<", 1) : "";
+
+        auto *tag = builder_.CreateExtractValue(val, {0}, "vret.retain.tag");
+        auto *isOk = builder_.CreateICmpEQ(tag,
+            llvm::ConstantInt::get(tag->getType(), 1), "vret.retain.is_ok");
+        auto *fn = builder_.GetInsertBlock()->getParent();
+        auto *okBB    = llvm::BasicBlock::Create(*ctx_, "vret.retain.ok", fn);
+        auto *errBB   = llvm::BasicBlock::Create(*ctx_, "vret.retain.err", fn);
+        auto *mergeBB = llvm::BasicBlock::Create(*ctx_, "vret.retain.merge", fn);
+        builder_.CreateCondBr(isOk, okBB, errBB);
+
+        builder_.SetInsertPoint(okBB);
+        if (st->getNumElements() >= 2 && !okName.empty()) {
+            auto *okSlot = builder_.CreateExtractValue(val, {1}, "vret.retain.ok_slot");
+            retainValueReturnResult(okSlot, st->getElementType(1), okName);
+        }
+        builder_.CreateBr(mergeBB);
+
+        builder_.SetInsertPoint(errBB);
+        if (isResult && st->getNumElements() >= 3 && !errName.empty()) {
+            auto *errSlot = builder_.CreateExtractValue(val, {2}, "vret.retain.err_slot");
+            retainValueReturnResult(errSlot, st->getElementType(2), errName);
+        }
+        builder_.CreateBr(mergeBB);
+
+        builder_.SetInsertPoint(mergeBB);
+        return;
+    }
+    // int / float / bool / Unit / low-level: no-op
+}
+
+void CodeGen::releaseValueReturnResult(llvm::Value *val,
+                                        llvm::Type *retTy,
+                                        const std::string &retTyName) {
+    if (!val || !retTy || retTy->isVoidTy())
+        return;
+    std::string resolved = resolveTypeAlias(retTyName);
+
+    if (resolved == "str") {
+        auto *hdr = emitStrGetHeaderFromData(val);
+        emitArcRelease(hdr, false, {});
+        return;
+    }
+    if (isListTypeName(resolved)) {
+        auto *hdr = emitArcGetHeaderFromData(val);
+        auto subDtor = getOrCreateCollectionDestructor(CollectionKind::List);
+        emitArcRelease(hdr, false, subDtor);
+        return;
+    }
+    if (isMapTypeName(resolved)) {
+        auto *hdr = emitArcGetHeaderFromData(val);
+        auto subDtor = getOrCreateCollectionDestructor(CollectionKind::Map);
+        emitArcRelease(hdr, false, subDtor);
+        return;
+    }
+    if (isSetTypeName(resolved)) {
+        auto *hdr = emitArcGetHeaderFromData(val);
+        auto subDtor = getOrCreateCollectionDestructor(CollectionKind::Set);
+        emitArcRelease(hdr, false, subDtor);
+        return;
+    }
+    if (auto *st = llvm::dyn_cast<llvm::StructType>(retTy)) {
+        if (record_types_.count(resolved)) {
+            emitRecordArcFieldsRelease(val, st);
+            return;
+        }
+        bool isResult = resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0;
+        bool isOption = (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0)
+                     || (!resolved.empty() && resolved.back() == '?');
+        if (!isResult && !isOption) return;
+
+        std::string okName  = isResult ? vretExtractGenericArg(resolved, "Result<", 0)
+                                       : vretExtractGenericArg(resolved, "Option<", 0);
+        std::string errName = isResult ? vretExtractGenericArg(resolved, "Result<", 1) : "";
+
+        auto *tag = builder_.CreateExtractValue(val, {0}, "vret.rel.tag");
+        auto *isOk = builder_.CreateICmpEQ(tag,
+            llvm::ConstantInt::get(tag->getType(), 1), "vret.rel.is_ok");
+        auto *fn = builder_.GetInsertBlock()->getParent();
+        auto *okBB    = llvm::BasicBlock::Create(*ctx_, "vret.rel.ok", fn);
+        auto *errBB   = llvm::BasicBlock::Create(*ctx_, "vret.rel.err", fn);
+        auto *mergeBB = llvm::BasicBlock::Create(*ctx_, "vret.rel.merge", fn);
+        builder_.CreateCondBr(isOk, okBB, errBB);
+
+        builder_.SetInsertPoint(okBB);
+        if (st->getNumElements() >= 2 && !okName.empty()) {
+            auto *okSlot = builder_.CreateExtractValue(val, {1}, "vret.rel.ok_slot");
+            releaseValueReturnResult(okSlot, st->getElementType(1), okName);
+        }
+        builder_.CreateBr(mergeBB);
+
+        builder_.SetInsertPoint(errBB);
+        if (isResult && st->getNumElements() >= 3 && !errName.empty()) {
+            auto *errSlot = builder_.CreateExtractValue(val, {2}, "vret.rel.err_slot");
+            releaseValueReturnResult(errSlot, st->getElementType(2), errName);
+        }
+        builder_.CreateBr(mergeBB);
+
+        builder_.SetInsertPoint(mergeBB);
+        return;
+    }
+}
+
+llvm::Function *CodeGen::getOrCreateValueReturnThunk(llvm::Function *origFn,
+                                                     const std::string &retTyName) {
+    auto it = value_return_thunk_cache_.find(origFn);
+    if (it != value_return_thunk_cache_.end())
+        return it->second;
+
+    llvm::Type *retTy = origFn->getReturnType();
+
+    // Thunk signature: (origParams..., ptr env) -> retTy. User-supplied params
+    // are ignored — the thunk loads the pre-stored return value from env and
+    // returns it (after a +1 retain so the caller's reference is independent
+    // of env lifetime).
+    std::vector<llvm::Type*> thunkParams;
+    for (auto &p : origFn->args())
+        thunkParams.push_back(p.getType());
+    thunkParams.push_back(ptrTy_);
+    auto *thunkTy = llvm::FunctionType::get(retTy, thunkParams, false);
+
+    std::string name = "__ry_uc_vret_" + origFn->getName().str();
+    auto *thunk = llvm::Function::Create(
+        thunkTy, llvm::Function::InternalLinkage, name, mod_.get());
+    thunk->addFnAttr(llvm::Attribute::NoUnwind);
+    value_return_thunk_cache_[origFn] = thunk;
+
+    auto *savedBB = builder_.GetInsertBlock();
+    auto savedPt = builder_.GetInsertPoint();
+
+    auto *entry = llvm::BasicBlock::Create(*ctx_, "entry", thunk);
+    builder_.SetInsertPoint(entry);
+
+    if (retTy->isVoidTy()) {
+        builder_.CreateRetVoid();
+    } else {
+        llvm::Value *envPtr = thunk->getArg(static_cast<unsigned>(origFn->arg_size()));
+        auto *result = builder_.CreateLoad(retTy, envPtr, "vret.val");
+        retainValueReturnResult(result, retTy, retTyName);
+        builder_.CreateRet(result);
+    }
+
+    if (savedBB)
+        builder_.SetInsertPoint(savedBB, savedPt);
+
+    return thunk;
+}
+
+llvm::FunctionCallee CodeGen::getOrCreateValueReturnEnvDestructor(
+    llvm::Type *retTy, const std::string &retTyName) {
+    if (!retTy || retTy->isVoidTy())
+        return {};
+    // Non-ARC primitives need no dtor — runtime frees env memory unconditionally.
+    std::string resolved = resolveTypeAlias(retTyName);
+    bool needsDtor = (resolved == "str")
+        || isListTypeName(resolved) || isMapTypeName(resolved) || isSetTypeName(resolved)
+        || record_types_.count(resolved)
+        || (resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0)
+        || (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0)
+        || (!resolved.empty() && resolved.back() == '?');
+    if (!needsDtor)
+        return {};
+
+    auto cacheIt = value_return_env_dtor_cache_.find(resolved);
+    if (cacheIt != value_return_env_dtor_cache_.end())
+        return cacheIt->second;
+
+    auto *dtorTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    // Sanitize cache key into a symbol-safe suffix (rough; collisions are rare
+    // and would only produce duplicate-symbol link errors which are easy to
+    // diagnose).
+    std::string suffix;
+    suffix.reserve(resolved.size());
+    for (char c : resolved) {
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') || c == '_')
+            suffix.push_back(c);
+        else
+            suffix.push_back('_');
+    }
+    std::string name = "__ry_uc_vret_dtor_" + suffix;
+    auto *dtorFn = llvm::Function::Create(
+        dtorTy, llvm::Function::InternalLinkage, name, mod_.get());
+    dtorFn->addFnAttr(llvm::Attribute::NoUnwind);
+
+    llvm::FunctionCallee callee(dtorTy, dtorFn);
+    value_return_env_dtor_cache_[resolved] = callee;
+
+    auto *savedBB = builder_.GetInsertBlock();
+    auto savedPt = builder_.GetInsertPoint();
+
+    auto *entry = llvm::BasicBlock::Create(*ctx_, "entry", dtorFn);
+    builder_.SetInsertPoint(entry);
+    auto *envPtr = dtorFn->getArg(0);
+    auto *loaded = builder_.CreateLoad(retTy, envPtr, "vret.dtor.val");
+    releaseValueReturnResult(loaded, retTy, retTyName);
+    builder_.CreateRetVoid();
+
+    if (savedBB)
+        builder_.SetInsertPoint(savedBB, savedPt);
+
+    return callee;
+}
+
+void CodeGen::emitMockReturnValueOnceCall(CallStmt &s) {
+    if (!test_mode_)
+        codegenError("'mockReturnValueOnce' is only allowed in test mode (use 'ry test')");
+    if (!testing_intrinsics_imported_.count("mockReturnValueOnce"))
+        codegenError(s.loc,
+            "'mockReturnValueOnce' requires 'from testing import mockReturnValueOnce'");
+
+    if (s.args.size() != 2)
+        codegenError("mockReturnValueOnce() requires exactly 2 arguments: function name and return value");
+
+    auto *strExpr = std::get_if<StringExpr>(&s.args[0]->data);
+    if (!strExpr)
+        codegenError("mockReturnValueOnce() first argument must be a function name");
+    const std::string &fnName = strExpr->value;
+
+    auto *fitOverloads = findFunction(fnName);
+    if (!fitOverloads)
+        codegenError("mockReturnValueOnce(): unknown function '" + fnName + "'");
+    if (fitOverloads->size() > 1)
+        codegenError("mockReturnValueOnce(): overloaded functions are not supported");
+
+    auto &entry = (*fitOverloads)[0];
+    llvm::Function *origFn = entry.func;
+    llvm::Type *retTy = origFn->getReturnType();
+    const std::string &retTyName = entry.returnTypeName;
+    std::string resolved = resolveTypeAlias(retTyName);
+
+    if (retTy->isVoidTy())
+        codegenError("mockReturnValueOnce(): function '" + fnName +
+                     "' returns Unit; mockReturnValueOnce requires a value-returning function");
+
+    // Reject return types whose retain/release the helpers do not handle.
+    bool supported = (resolved == "int") || (resolved == "float")
+        || (resolved == "bool") || (resolved == "Unit")
+        || isLowLevelTypeName(resolved)
+        || (resolved == "str")
+        || isListTypeName(resolved) || isMapTypeName(resolved) || isSetTypeName(resolved)
+        || (record_types_.count(resolved) > 0)
+        || (resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0)
+        || (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0)
+        || (!resolved.empty() && resolved.back() == '?');
+    if (!supported)
+        codegenError("mockReturnValueOnce(): unsupported return type '" + retTyName +
+                     "' for '" + fnName +
+                     "' (supported: primitives, str, List, Map, Set, Record, Result, Option)");
+
+    // Install Option-inner hint so `None` / `None()` literal pick up the right
+    // inner type from the callee's return signature.
+    llvm::Type *annotOptionInner = nullptr;
+    if (isOptionType(retTy))
+        annotOptionInner = llvm::cast<llvm::StructType>(retTy)->getElementType(1);
+    OptionNoneHintGuard noneHintGuard(*this, annotOptionInner);
+    DeclAnnotationInnerGuard declHintGuard(*this, annotOptionInner);
+
+    llvm::Value *value = nullptr;
+    if (isNoneLiteral(*s.args[1])) {
+        if (!isOptionType(retTy))
+            codegenError("mockReturnValueOnce(): None can only be passed when '"
+                         + fnName + "' returns Option");
+        value = buildNoneValue(retTy);
+    } else {
+        value = emitExpr(*s.args[1]);
+    }
+    if (!value)
+        codegenError("mockReturnValueOnce(): could not evaluate return value");
+    llvm::Type *valTy = value->getType();
+
+    // Coerce common annotation-style mismatches (mirrors emitVarDecl).
+    if (valTy != retTy) {
+        if (isOptionType(retTy) && !isOptionType(valTy)) {
+            auto *optTy = llvm::cast<llvm::StructType>(retTy);
+            llvm::Type *innerTy = optTy->getElementType(1);
+            if (valTy != innerTy)
+                codegenError("mockReturnValueOnce(): return value type does not match '"
+                             + fnName + "'");
+            value = buildSomeValue(value, retTy);
+            valTy = retTy;
+        } else if (isResultType(retTy) && isResultType(valTy)) {
+            auto *dstResTy = llvm::cast<llvm::StructType>(retTy);
+            llvm::Value *coerced = coerceResultType(value, dstResTy);
+            if (!coerced)
+                codegenError("mockReturnValueOnce(): return value type does not match '"
+                             + fnName + "'");
+            value = coerced;
+            valTy = retTy;
+        } else if (llvm::Value *lowCoerced = coerceToLowLevelType(value, retTy,
+                                                                  retTyName, "",
+                                                                  "vret.coerce")) {
+            value = lowCoerced;
+            valTy = retTy;
+        }
+    }
+    if (valTy != retTy)
+        codegenError("mockReturnValueOnce(): return value type does not match '"
+                     + fnName + "'");
+
+    // Allocate env (sizeof(retTy) bytes, ARC-managed) and store the value.
+    // The env's own ARC strong starts at 1 (from emitArcAlloc). emitArcRetain
+    // bumps it to 2 so the registry retains +1 after statement-end cleanup
+    // releases the local alloc +1.
+    const llvm::DataLayout &dl = mod_->getDataLayout();
+    uint64_t retSize = dl.getTypeAllocSize(retTy);
+    if (retSize == 0) retSize = 1;
+    auto *envHdr = emitArcAlloc(llvm::ConstantInt::get(i64Ty_, retSize));
+    auto *envData = emitArcGetDataPtr(envHdr);
+
+    // Retain the value's ARC content for env's ownership. The statement-end
+    // release of the original +1 (from emitExpr) then balances, leaving env
+    // as sole owner of the stored value.
+    retainValueReturnResult(value, retTy, retTyName);
+    builder_.CreateStore(value, envData);
+
+    // Retain env so the registry owns +1.
+    emitArcRetain(envHdr, false);
+
+    mocked_functions_.insert(fnName);
+
+    auto &nameStr = mock_name_strings_[fnName];
+    if (!nameStr) nameStr = cachedGlobalString(fnName, ".mock." + fnName);
+
+    llvm::Function *thunk = getOrCreateValueReturnThunk(origFn, retTyName);
+    auto envDtorCallee = getOrCreateValueReturnEnvDestructor(retTy, retTyName);
+    auto *nullPtr = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
+    llvm::Value *envDtorVal = envDtorCallee
+        ? llvm::cast<llvm::Value>(envDtorCallee.getCallee())
+        : llvm::cast<llvm::Value>(nullPtr);
+
+    llvm::FunctionType *registerOnceTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_),
+        {ptrTy_, ptrTy_, ptrTy_, ptrTy_}, false);
+    llvm::FunctionCallee registerOnceFn = mod_->getOrInsertFunction(
+        "__ry_mock_register_once", registerOnceTy);
+    builder_.CreateCall(registerOnceFn, {nameStr, thunk, envData, envDtorVal});
+}
+
 // ===== Test: spy(fn_name) — record calls without replacement =====
 
 void CodeGen::emitSpyCall(CallStmt &s) {

--- a/src/jit_runner.cpp
+++ b/src/jit_runner.cpp
@@ -295,6 +295,8 @@ int runRySource(const std::string &src, const std::string &source_name,
             {ExecutorAddr::fromPtr(&__ry_mock_set), JITSymbolFlags::Exported};
         testSymbols[es.intern("__ry_mock_set_closure")] =
             {ExecutorAddr::fromPtr(&__ry_mock_set_closure), JITSymbolFlags::Exported};
+        testSymbols[es.intern("__ry_mock_register_once")] =
+            {ExecutorAddr::fromPtr(&__ry_mock_register_once), JITSymbolFlags::Exported};
         testSymbols[es.intern("__ry_mock_get")] =
             {ExecutorAddr::fromPtr(&__ry_mock_get), JITSymbolFlags::Exported};
         testSymbols[es.intern("__ry_mock_get_env")] =

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -76,7 +76,7 @@ static std::string makeImportError(int line, const std::string &detail) {
 // through the same standard mechanism and is NOT a compiler intrinsic.
 static const std::unordered_set<std::string> &testingIntrinsics() {
     static const std::unordered_set<std::string> kSet = {
-        "expect", "mock", "spy", "fail", "verifyCalledWith"};
+        "expect", "mock", "mockReturnValueOnce", "spy", "fail", "verifyCalledWith"};
     return kSet;
 }
 

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <random>
 #include <string>
 #include <unistd.h>
@@ -150,14 +151,33 @@ struct MockFnSnapshot {
     void *env_ptr;
 };
 
+// One mock binding: a function pointer plus an optional capture env.
+// Used for both the default mock (set by mock()) and per-call queue entries
+// (set by mockReturnValueOnce()).
+struct MockBinding {
+    void *fn_ptr = nullptr;
+    void *env_ptr = nullptr;
+    void (*env_dtor)(void *) = nullptr;
+};
+
 // Mock registry. fn_ptr is the replacement function pointer (plain fn ptr
 // or closure thunk). env_ptr / env_dtor are non-null only for capture-based
 // closures (#1678): the dispatch site reads env_ptr via __ry_mock_get_env
 // and calls thunk(env, args...) instead of thunk(args...).
+//
+// once_queue (#1681) is a FIFO of per-call bindings populated by
+// mockReturnValueOnce. Each pop happens inside __ry_mock_get; the popped
+// binding is stashed in current_binding so __ry_mock_get_env (called
+// immediately after) returns the matching env. The queue owns each env's
+// ARC reference; current_owned tracks whether current_binding must be
+// released when it is replaced (queue pop / clear / reset).
 struct MockEntry {
     void *fn_ptr = nullptr;
     void *env_ptr = nullptr;
     void (*env_dtor)(void *) = nullptr;
+    std::deque<MockBinding> once_queue;
+    MockBinding current_binding;
+    bool current_owned = false;
     int64_t call_count = 0;
     std::vector<MockCallRecord> calls;
     std::vector<char *> retained_str_args;
@@ -499,6 +519,23 @@ static void releaseMockEntryRetainedArgs(MockEntry &entry) {
     entry.call_count = 0;
 }
 
+// Release the once-queue (mockReturnValueOnce bindings) and the
+// currently-popped binding when it owns its env. mockReset / mockClearAll
+// call this; mockClear does NOT (Jest semantics — clear() preserves the
+// queue).
+static void releaseMockOnceQueue(MockEntry &entry) {
+    if (entry.current_owned) {
+        mockReleaseClosureEnv(entry.current_binding.env_ptr,
+                              entry.current_binding.env_dtor);
+        entry.current_binding = MockBinding{};
+        entry.current_owned = false;
+    }
+    for (auto &binding : entry.once_queue) {
+        mockReleaseClosureEnv(binding.env_ptr, binding.env_dtor);
+    }
+    entry.once_queue.clear();
+}
+
 extern "C" {
 
 void __ry_test_describe_begin(const char *name) {
@@ -612,6 +649,18 @@ void __ry_mock_set_closure(const char *name, void *thunk_ptr,
     entry.env_dtor = env_dtor;
 }
 
+// Append a per-call binding to the once-queue (#1681). Ownership of env_ptr
+// transfers to the queue; mockReleaseClosureEnv will be invoked when the
+// binding is popped-then-replaced, or when the queue is released by
+// mockReset / mockClearAll.
+void __ry_mock_register_once(const char *name, void *thunk_ptr,
+                              void *env_ptr, void (*env_dtor)(void *)) {
+    auto &entry = g_mock_registry[name];
+    entry.once_queue.push_back(MockBinding{thunk_ptr, env_ptr, env_dtor});
+}
+
+// Jest-compatible mockClear: reset call log/count, preserve default mock
+// AND once-queue. Use mockReset to wipe the queue.
 void __ry_mock_clear(const char *name) {
     auto it = g_mock_registry.find(name);
     if (it == g_mock_registry.end()) return;
@@ -622,20 +671,49 @@ void __ry_mock_reset(const char *name) {
     auto it = g_mock_registry.find(name);
     if (it == g_mock_registry.end()) return;
     mockReleaseClosureEnv(it->second.env_ptr, it->second.env_dtor);
+    releaseMockOnceQueue(it->second);
     releaseMockEntryRetainedArgs(it->second);
     g_mock_registry.erase(it);
 }
 
+// Queue-consuming dispatch (#1681). Each call pops one binding from
+// once_queue and stashes it in current_binding so __ry_mock_get_env can
+// return the matching env. When the queue is empty, fall back to the
+// default mock binding (set by mock()/mockClosure); current_binding aliases
+// the default slot (no ownership transfer). Returns null when neither
+// queue nor default mock exists (caller falls through to original fn).
 void *__ry_mock_get(const char *name) {
     auto it = g_mock_registry.find(name);
-    if (it != g_mock_registry.end()) return it->second.fn_ptr;
-    return nullptr;
+    if (it == g_mock_registry.end()) return nullptr;
+    auto &entry = it->second;
+    // Release previously popped queue binding before advancing.
+    if (entry.current_owned) {
+        mockReleaseClosureEnv(entry.current_binding.env_ptr,
+                              entry.current_binding.env_dtor);
+        entry.current_binding = MockBinding{};
+        entry.current_owned = false;
+    }
+    if (!entry.once_queue.empty()) {
+        entry.current_binding = entry.once_queue.front();
+        entry.once_queue.pop_front();
+        entry.current_owned = true;
+    } else {
+        entry.current_binding.fn_ptr = entry.fn_ptr;
+        entry.current_binding.env_ptr = entry.env_ptr;
+        entry.current_binding.env_dtor = entry.env_dtor;
+        entry.current_owned = false;
+    }
+    return entry.current_binding.fn_ptr;
 }
 
+// Companion to __ry_mock_get — returns env for the binding most recently
+// popped (or aliased) by __ry_mock_get. The dispatch site always calls
+// __ry_mock_get immediately before __ry_mock_get_env, so current_binding
+// matches the fn_ptr the dispatcher is about to invoke.
 void *__ry_mock_get_env(const char *name) {
     auto it = g_mock_registry.find(name);
-    if (it != g_mock_registry.end()) return it->second.env_ptr;
-    return nullptr;
+    if (it == g_mock_registry.end()) return nullptr;
+    return it->second.current_binding.env_ptr;
 }
 
 int64_t __ry_mock_get_call_count(const char *name) {
@@ -1080,6 +1158,7 @@ void __ry_mock_clear_all() {
     for (auto &kv : g_mock_registry) {
         auto &entry = kv.second;
         mockReleaseClosureEnv(entry.env_ptr, entry.env_dtor);
+        releaseMockOnceQueue(entry);
         releaseMockEntryRetainedArgs(entry);
     }
     g_mock_registry.clear();

--- a/tests/spec/mock.test.ry
+++ b/tests/spec/mock.test.ry
@@ -1,4 +1,4 @@
-from testing import it, describe, expect, mock, verify, verifyCalledWith, mockClear, mockReset, mockResetAll
+from testing import it, describe, expect, mock, mockReturnValueOnce, verify, verifyCalledWith, mockClear, mockReset, mockResetAll, fail
 
 fn fetchData() -> str:
   return "real data"
@@ -749,4 +749,267 @@ fn mockInNonCallStmtPositionsTests():
       mock("realFetchE", () => "fake E")
     ):
       expect(callsRealFetchE()).toEq("fake E")
+
+# Helpers for mockReturnValueOnce (#1681) — return types of various shapes.
+fn fetchOnceStr() -> str:
+  return "orig"
+
+fn fetchOnceInt() -> int:
+  return 0
+
+fn fetchOnceFloat() -> float:
+  return 0.0
+
+fn fetchOnceBool() -> bool:
+  return false
+
+fn fetchOncePoint() -> Point:
+  return Point(0, 0)
+
+fn fetchOnceList() -> List<int>:
+  empty: List<int> = []
+  return empty
+
+fn fetchOnceOpt() -> int?:
+  return None
+
+fn fetchOnceRes() -> Result<int, str>:
+  return Ok(0)
+
+fn fetchOnceArg(label: str) -> int:
+  return -1
+
+fn fetchOnceFallback() -> str:
+  return "original"
+
+fn fetchOnceQueueOnly() -> int:
+  return -999
+
+fn fetchOnceMix() -> int:
+  return -1
+
+fn fetchOnceCount() -> int:
+  return 0
+
+fn fetchOnceClearedQueue() -> str:
+  return "orig"
+
+fn fetchOnceResetQueue() -> str:
+  return "orig"
+
+fn fetchOnceA1() -> int:
+  return -1
+
+fn fetchOnceA2() -> str:
+  return "origA2"
+
+fn fetchOnceItCheck() -> int:
+  return -7
+
+fn fetchOnceCapMix() -> int:
+  return -1
+
+@describe("mockReturnValueOnce")
+fn mockReturnValueOnceTests():
+  @it("should return queued str values in order then fall back to original")
+  fn shouldQueueStr():
+    mockReturnValueOnce("fetchOnceStr", "first")
+    mockReturnValueOnce("fetchOnceStr", "second")
+    expect(fetchOnceStr()).toEq("first")
+    expect(fetchOnceStr()).toEq("second")
+    expect(fetchOnceStr()).toEq("orig")
+
+  @it("should return queued int values in order")
+  fn shouldQueueInt():
+    mockReturnValueOnce("fetchOnceInt", 11)
+    mockReturnValueOnce("fetchOnceInt", 22)
+    mockReturnValueOnce("fetchOnceInt", 33)
+    expect(fetchOnceInt()).toEq(11)
+    expect(fetchOnceInt()).toEq(22)
+    expect(fetchOnceInt()).toEq(33)
+    expect(fetchOnceInt()).toEq(0)
+
+  @it("should return queued float values in order")
+  fn shouldQueueFloat():
+    mockReturnValueOnce("fetchOnceFloat", 1.5)
+    mockReturnValueOnce("fetchOnceFloat", 2.5)
+    expect(fetchOnceFloat()).toEq(1.5)
+    expect(fetchOnceFloat()).toEq(2.5)
+    expect(fetchOnceFloat()).toEq(0.0)
+
+  @it("should return queued bool values in order")
+  fn shouldQueueBool():
+    mockReturnValueOnce("fetchOnceBool", true)
+    mockReturnValueOnce("fetchOnceBool", false)
+    mockReturnValueOnce("fetchOnceBool", true)
+    expect(fetchOnceBool()).toEq(true)
+    expect(fetchOnceBool()).toEq(false)
+    expect(fetchOnceBool()).toEq(true)
+    expect(fetchOnceBool()).toEq(false)
+
+  @it("should return queued Record values in order")
+  fn shouldQueueRecord():
+    mockReturnValueOnce("fetchOncePoint", Point(1, 2))
+    mockReturnValueOnce("fetchOncePoint", Point(3, 4))
+    p1 = fetchOncePoint()
+    expect(p1.x).toEq(1)
+    expect(p1.y).toEq(2)
+    p2 = fetchOncePoint()
+    expect(p2.x).toEq(3)
+    expect(p2.y).toEq(4)
+    p3 = fetchOncePoint()
+    expect(p3.x).toEq(0)
+    expect(p3.y).toEq(0)
+
+  @it("should return queued List values and preserve elements")
+  fn shouldQueueList():
+    mockReturnValueOnce("fetchOnceList", [1, 2, 3])
+    mockReturnValueOnce("fetchOnceList", [10, 20])
+    xs1 = fetchOnceList()
+    expect(len(xs1)).toEq(3)
+    expect(xs1[0]).toEq(1)
+    expect(xs1[2]).toEq(3)
+    xs2 = fetchOnceList()
+    expect(len(xs2)).toEq(2)
+    expect(xs2[1]).toEq(20)
+    xs3 = fetchOnceList()
+    expect(len(xs3)).toEq(0)
+
+  @it("should return queued Option values (Some/None auto-wrap)")
+  fn shouldQueueOption():
+    mockReturnValueOnce("fetchOnceOpt", Some(42))
+    mockReturnValueOnce("fetchOnceOpt", None)
+    mockReturnValueOnce("fetchOnceOpt", 99)
+    gotSome = false
+    case fetchOnceOpt():
+      Some(v): expect(v).toEq(42)
+      None: fail("expected Some(42)")
+    gotNone = false
+    case fetchOnceOpt():
+      Some(v): fail("expected None")
+      None: gotNone = true
+    expect(gotNone).toEq(true)
+    case fetchOnceOpt():
+      Some(v): expect(v).toEq(99)
+      None: fail("expected Some(99)")
+
+  @it("should return queued Result values (Ok and Err)")
+  fn shouldQueueResult():
+    mockReturnValueOnce("fetchOnceRes", Ok(10))
+    mockReturnValueOnce("fetchOnceRes", Err("bad"))
+    mockReturnValueOnce("fetchOnceRes", Ok(20))
+    case fetchOnceRes():
+      Ok(v): expect(v).toEq(10)
+      Err(e): fail("expected Ok(10), got Err(" + e + ")")
+    case fetchOnceRes():
+      Ok(v): fail("expected Err")
+      Err(e): expect(e).toEq("bad")
+    case fetchOnceRes():
+      Ok(v): expect(v).toEq(20)
+      Err(e): fail("expected Ok(20)")
+
+  @it("should ignore arguments and still return queued value")
+  fn shouldIgnoreArgs():
+    mockReturnValueOnce("fetchOnceArg", 100)
+    mockReturnValueOnce("fetchOnceArg", 200)
+    expect(fetchOnceArg("first")).toEq(100)
+    expect(fetchOnceArg("second")).toEq(200)
+    expect(fetchOnceArg("third")).toEq(-1)
+
+  @it("should fall back to default mock() lambda after queue is empty")
+  fn shouldFallBackToDefaultMock():
+    mock("fetchOnceFallback", () => "default")
+    mockReturnValueOnce("fetchOnceFallback", "once-a")
+    mockReturnValueOnce("fetchOnceFallback", "once-b")
+    expect(fetchOnceFallback()).toEq("once-a")
+    expect(fetchOnceFallback()).toEq("once-b")
+    expect(fetchOnceFallback()).toEq("default")
+    expect(fetchOnceFallback()).toEq("default")
+
+  @it("should fall back to original when neither queue nor default mock is set")
+  fn shouldFallBackToOriginal():
+    mockReturnValueOnce("fetchOnceQueueOnly", 42)
+    expect(fetchOnceQueueOnly()).toEq(42)
+    expect(fetchOnceQueueOnly()).toEq(-999)
+
+  @it("should consume queue before reaching default mock and original")
+  fn shouldMixQueueAndDefault():
+    mock("fetchOnceMix", () => 7)
+    mockReturnValueOnce("fetchOnceMix", 1)
+    mockReturnValueOnce("fetchOnceMix", 2)
+    expect(fetchOnceMix()).toEq(1)
+    expect(fetchOnceMix()).toEq(2)
+    expect(fetchOnceMix()).toEq(7)
+    expect(fetchOnceMix()).toEq(7)
+
+  @it("should count queue-consuming calls toward verify")
+  fn shouldCountQueueCalls():
+    # Note: Ry's verify() counts only mock-served calls (queue or default mock).
+    # Once the queue empties and no default mock is set, calls fall through to
+    # the original implementation and are NOT counted (matching mockReset semantics).
+    # This diverges from strict Jest semantics where every call increments the counter.
+    mockReturnValueOnce("fetchOnceCount", 1)
+    mockReturnValueOnce("fetchOnceCount", 2)
+    fetchOnceCount()
+    fetchOnceCount()
+    fetchOnceCount()
+    expect(verify("fetchOnceCount")).toEq(2)
+
+  @it("should preserve queue across mockClear and reset only call count")
+  fn shouldPreserveQueueOnClear():
+    mockReturnValueOnce("fetchOnceClearedQueue", "q1")
+    mockReturnValueOnce("fetchOnceClearedQueue", "q2")
+    expect(fetchOnceClearedQueue()).toEq("q1")
+    expect(verify("fetchOnceClearedQueue")).toEq(1)
+    mockClear("fetchOnceClearedQueue")
+    expect(verify("fetchOnceClearedQueue")).toEq(0)
+    expect(fetchOnceClearedQueue()).toEq("q2")
+    expect(verify("fetchOnceClearedQueue")).toEq(1)
+
+  @it("should clear queue on mockReset")
+  fn shouldClearQueueOnReset():
+    mockReturnValueOnce("fetchOnceResetQueue", "q1")
+    mockReturnValueOnce("fetchOnceResetQueue", "q2")
+    expect(fetchOnceResetQueue()).toEq("q1")
+    mockReset("fetchOnceResetQueue")
+    expect(fetchOnceResetQueue()).toEq("orig")
+    expect(fetchOnceResetQueue()).toEq("orig")
+    expect(verify("fetchOnceResetQueue")).toEq(0)
+
+  @it("should clear all queues on mockResetAll")
+  fn shouldClearAllQueuesOnResetAll():
+    mockReturnValueOnce("fetchOnceA1", 1)
+    mockReturnValueOnce("fetchOnceA1", 2)
+    mockReturnValueOnce("fetchOnceA2", "x")
+    mockResetAll()
+    expect(fetchOnceA1()).toEq(-1)
+    expect(fetchOnceA2()).toEq("origA2")
+
+  @it("should auto-clear queue at it block end (first it sets up)")
+  fn shouldAutoClearItFirst():
+    mockReturnValueOnce("fetchOnceItCheck", 100)
+    mockReturnValueOnce("fetchOnceItCheck", 200)
+    expect(fetchOnceItCheck()).toEq(100)
+  @it("should auto-clear queue at it block end (second it sees fresh state)")
+  fn shouldAutoClearItSecond():
+    # After __ry_test_it_end clears the entire registry, the orig fallback
+    # path is taken and (per the divergence noted in shouldCountQueueCalls)
+    # is not counted by verify().
+    expect(fetchOnceItCheck()).toEq(-7)
+    expect(verify("fetchOnceItCheck")).toEq(0)
+
+  @it("should coexist with capture-closure default mock")
+  fn shouldCoexistWithCaptureClosure():
+    counter: List<int> = [0]
+    accumulate = ():
+      counter[0] = counter[0] + 1
+      return counter[0]
+    mock("fetchOnceCapMix", accumulate)
+    mockReturnValueOnce("fetchOnceCapMix", 1000)
+    mockReturnValueOnce("fetchOnceCapMix", 2000)
+    expect(fetchOnceCapMix()).toEq(1000)
+    expect(fetchOnceCapMix()).toEq(2000)
+    expect(fetchOnceCapMix()).toEq(1)
+    expect(fetchOnceCapMix()).toEq(2)
+    expect(counter[0]).toEq(2)
 

--- a/tests/test_codegen_mock.cpp
+++ b/tests/test_codegen_mock.cpp
@@ -1116,3 +1116,129 @@ TEST_F(CodeGenTest, VerifyCalledWithSpiedFunction) {
         "        expect(verifyCalledWith(\"compute\", 7)).toEq(1)\n"
     )), "vcw spy\n  \033[32m+ matches spied call\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
+
+// ============================================================
+// mockReturnValueOnce() rejection tests (#1681)
+// ============================================================
+
+// First argument must be a string literal (parser converts `mockReturnValueOnce(name, ...)`
+// to a CallStmt where args[0] is StringExpr; non-literal must be rejected).
+TEST_F(CodeGenTest, MockReturnValueOnceFirstArgNonLiteralError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn greet() -> str:\n"
+        "    return \"hello\"\n"
+        "\n"
+        "@describe(\"mrvo error\")\n"
+        "fn mrvoError():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        name: str = \"greet\"\n"
+        "        mockReturnValueOnce(name, \"x\")\n"
+    )), std::exception);
+}
+
+// mockReturnValueOnce() on a function that doesn't exist
+TEST_F(CodeGenTest, MockReturnValueOnceUnknownFunctionError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"mrvo error\")\n"
+        "fn mrvoError():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mockReturnValueOnce(\"no_such_fn\", \"x\")\n"
+    )), std::exception);
+}
+
+// mockReturnValueOnce() on an overloaded function (overloads not supported)
+TEST_F(CodeGenTest, MockReturnValueOnceOverloadedFunctionError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn over(x: int) -> int:\n"
+        "    return x\n"
+        "fn over(x: int, y: int) -> int:\n"
+        "    return x + y\n"
+        "\n"
+        "@describe(\"mrvo error\")\n"
+        "fn mrvoError():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mockReturnValueOnce(\"over\", 1)\n"
+    )), std::exception);
+}
+
+// mockReturnValueOnce() with mismatched return value type
+TEST_F(CodeGenTest, MockReturnValueOnceTypeMismatchError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn greet() -> str:\n"
+        "    return \"hello\"\n"
+        "\n"
+        "@describe(\"mrvo error\")\n"
+        "fn mrvoError():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mockReturnValueOnce(\"greet\", 42)\n"
+    )), std::exception);
+}
+
+// mockReturnValueOnce() outside test mode (no 'ry test')
+TEST_F(CodeGenTest, MockReturnValueOnceOutsideTestModeError) {
+    EXPECT_THROW(runSource(
+        "fn greet() -> str:\n"
+        "    return \"hello\"\n"
+        "mockReturnValueOnce(\"greet\", \"x\")\n"
+    ), std::exception);
+}
+
+// mockReturnValueOnce() without `from testing import mockReturnValueOnce`
+TEST_F(CodeGenTest, MockReturnValueOnceWithoutImportError) {
+    EXPECT_THROW(runTestSourceNoTestingImports(withStdlibDirectiveDecls(
+        "fn greet() -> str:\n"
+        "    return \"hello\"\n"
+        "\n"
+        "@describe(\"mrvo error\")\n"
+        "fn mrvoError():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mockReturnValueOnce(\"greet\", \"x\")\n"
+    )), std::exception);
+}
+
+// mockReturnValueOnce() on a Unit-returning function (no value to mock)
+TEST_F(CodeGenTest, MockReturnValueOnceUnitFunctionError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn doNothing() -> Unit:\n"
+        "    return\n"
+        "\n"
+        "@describe(\"mrvo error\")\n"
+        "fn mrvoError():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mockReturnValueOnce(\"doNothing\", 0)\n"
+    )), std::exception);
+}
+
+// mockReturnValueOnce() with wrong arity (1 arg)
+TEST_F(CodeGenTest, MockReturnValueOnceWrongArityError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn greet() -> str:\n"
+        "    return \"hello\"\n"
+        "\n"
+        "@describe(\"mrvo error\")\n"
+        "fn mrvoError():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mockReturnValueOnce(\"greet\")\n"
+    )), std::exception);
+}
+
+// mockReturnValueOnce() with `None` on a non-Option return type
+TEST_F(CodeGenTest, MockReturnValueOnceNoneOnNonOptionError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn fetchInt() -> int:\n"
+        "    return 1\n"
+        "\n"
+        "@describe(\"mrvo error\")\n"
+        "fn mrvoError():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mockReturnValueOnce(\"fetchInt\", None)\n"
+    )), std::exception);
+}

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1836,9 +1836,10 @@ TEST_F(ImportTest, FromTestingWildcardRecordsAllIntrinsics) {
     // path and is no longer recorded in the testing-intrinsic set.
     // #1677 adds `verifyCalledWith` as an intrinsic.
     // #1683 adds `spy` as an intrinsic.
+    // #1681 adds `mockReturnValueOnce` as an intrinsic.
     std::unordered_set<std::string> expected = {
-        "expect", "mock", "spy", "fail", "verifyCalledWith"};
-    EXPECT_EQ(intrinsics.size(), 5u);
+        "expect", "mock", "mockReturnValueOnce", "spy", "fail", "verifyCalledWith"};
+    EXPECT_EQ(intrinsics.size(), 6u);
     EXPECT_EQ(intrinsics, expected);
 }
 
@@ -1906,9 +1907,10 @@ TEST_F(ImportTest, CodeGenReceivesAllTestingIntrinsicsForWildcard) {
     // `@public fn` in share/std/testing/testing.ry).
     // #1677 adds `verifyCalledWith` as an intrinsic.
     // #1683 adds `spy` as an intrinsic.
+    // #1681 adds `mockReturnValueOnce` as an intrinsic.
     std::unordered_set<std::string> expected = {
-        "expect", "mock", "spy", "fail", "verifyCalledWith"};
-    EXPECT_EQ(intrinsics.size(), 5u);
+        "expect", "mock", "mockReturnValueOnce", "spy", "fail", "verifyCalledWith"};
+    EXPECT_EQ(intrinsics.size(), 6u);
     EXPECT_EQ(intrinsics, expected);
 }
 


### PR DESCRIPTION
## Summary

- Adds Jest-compatible `mockReturnValueOnce(name, value)` intrinsic. Each call enqueues `value` for the named function; the next call dequeues and returns the head.
- Fallback chain on queue empty: queue → `mock()` default → original implementation.
- All return types supported (primitives, `str`, `List` / `Map` / `Set`, records, `Result`, `Option` including bare `None`); compile-time rejection for non-literal name, unknown name, overloaded function, `Unit` return, type mismatch.
- `mockClear(name)` preserves the queue (resets counter only); `mockReset(name)` / `mockResetAll()` discard the queue. Queues auto-cleared at end of each `it` block.

## Design note (deliberate divergence from Jest)

`verify(name)` counts only queue-served and default-mock-served calls. Calls that fall through to the original implementation after queue exhaustion are **not** counted — this matches Ry's existing `mockReset` semantics (where the original implementation never increments the counter) but diverges from strict Jest, where every call increments. Documented in:

- `docs/reference/testing.md` (Limitations section + `mockReturnValueOnce` section)
- `changelog.d/1681-mock-return-value-once.md`
- Inline comments in `tests/spec/mock.test.ry`

Happy to revisit if strict Jest parity is preferred.

## Test plan

- [x] C++ tests: `./build/ry_tests` — 2346 pass
- [x] Ry self-tests: `./build/ry test -p` — 190 files, 0 failures
- [x] ASan + UBSan: `./build-asan/ry_tests && ./build-asan/ry test -p` — clean
- [x] TSan: `./build-tsan/ry_tests && ./build-tsan/ry test -p` — clean (C++ required; Ry self-test warn-only per `tsan-known-issues`)
- [x] clang-tidy / cppcheck — no errors
- [x] Skipped §3.6 libFuzzer — no parser/lexer/json/utf8/string change
- [x] Skipped §3.6.5 tree-sitter — no grammar change
- [x] 9 new C++ rejection tests cover all error paths (`test_codegen_mock.cpp`)
- [x] 10 new Ry self-tests cover ordering, fallback chain, type matrix, mix-with-`mock()`, `mockClear` / `mockReset` semantics, auto-cleanup, capture-closure coexistence (`tests/spec/mock.test.ry`)

Closes #1681

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mockReturnValueOnce testing helper to queue per-call mock return values with fallback to default mock or original implementation; queues auto-clear at the end of each test block.

* **Documentation**
  * Updated testing docs with usage, supported return shapes, queue lifecycle, and clear/reset semantics (mockClear preserves queue; mockReset/mockResetAll discard it). verify() excludes fall-through calls.

* **Tests**
  * Added comprehensive tests and compilation-time rejection cases for invalid usages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->