### PR TITLE
feat(testing): support mocking overloaded functions per signature (#1682)

### DIFF
--- a/changelog.d/1682-overloaded-mock-support.md
+++ b/changelog.d/1682-overloaded-mock-support.md
@@ -1,0 +1,32 @@
+### Added
+
+- Added per-overload mocking, spying, and verification for overloaded
+  functions across the testing framework. The mock registry is now
+  keyed by canonical signature `"name(T1, T2)"` instead of bare name,
+  so each overload has an independent slot. `mock` /
+  `mockReturnValueOnce` / `spy` / `verify` / `verifyCalledWith` /
+  `mockClear` / `mockReset` all accept the signature-form string
+  (e.g. `mock("add(int, int)", ...)`, `verify("digits(int, int)")`).
+  Custom-emitter `@native` overloads — including the math overload
+  set (`abs`, `floor`, `ceil`, `round`, `log`, `pow`, `digits`) —
+  are now mockable / spy-able via the same signature form; argument
+  recording for `verifyCalledWith` on those natives is not supported
+  in v1 (count-based `verify` works). Whitespace inside the signature
+  is normalized; type aliases are resolved automatically. (#1682)
+
+### Changed
+
+- Bare-name semantics for the testing API on overloaded functions are
+  defined as follows (no change for single-overload functions):
+  `mock(n, repl)` auto-dispatches when the replacement lambda's
+  signature uniquely matches one overload, otherwise errors with the
+  candidate list; `mockReturnValueOnce(n, v)` errors (return-value
+  alone cannot disambiguate); `spy(n)` registers spy for **all**
+  overloads aggregately; `verify(n)` returns the **sum** of call
+  counts across all overloads; `verifyCalledWith(n, ...)` dispatches
+  to the arity-matching overload or errors when ambiguous;
+  `mockClear(n)` / `mockReset(n)` clear / remove every overload. As
+  a consequence, if existing code calls `verify("foo")` and `foo`
+  later gains a second overload, the return value silently becomes
+  the aggregate count — switch to `verify("foo(int)")` to preserve
+  per-overload counting through such a change. (#1682)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -580,10 +580,56 @@ fn mockResetAllTests():
 - Clears spied functions identically — the registry is shared between mock and spy (#1683)
 - **Discards all `mockReturnValueOnce` queues** — every named function's queued values are released (#1681)
 
+### Mocking overloaded functions
+
+Since v0.0.24 (#1682), overloaded functions can be mocked / spied / verified per overload. The mock registry is keyed by **canonical signature** `"name(T1, T2, ...)"` rather than by bare function name, so each overload has an independent slot.
+
+**Signature-form syntax.** Pass `"name(T1, T2)"` instead of the bare name to target a specific overload:
+
+```ry
+from testing import it, describe, mock, verify, verifyCalledWith, expect
+
+fn add(a: int, b: int) -> int:
+    return a + b
+
+fn add(a: float, b: float) -> float:
+    return a + b
+
+@describe("overloaded mock")
+fn overloadedMockTests():
+    @it("targets int overload only")
+    fn targetsIntOverload():
+        mock("add(int, int)", (a: int, b: int) -> int => 100)
+        expect(add(2, 3)).toEq(100)        # mocked
+        expect(add(2.5, 3.5)).toEq(6.0)    # float overload still real
+        expect(verify("add(int, int)")).toEq(1)
+        expect(verify("add(float, float)")).toEq(0)  # not mocked/spied, so not counted
+```
+
+- Whitespace inside the parameter list is normalized — `"add(int, int)"` ≡ `"add( int , int )"`.
+- The parameter types must match the function's declaration form exactly. Type aliases are resolved automatically; equivalent surface spellings such as `int?` vs `Option<int>` are **not** unified (the parser keeps them distinct strings, so use the form the function was declared with).
+- Zero-parameter overloads use `"name()"` — this is distinct from the bare name `"name"`.
+- Available for `mock` / `mockReturnValueOnce` / `spy` / `verify` / `verifyCalledWith` / `mockClear` / `mockReset`.
+
+**Bare-name semantics on overloaded functions.** When the bare name (e.g. `"add"` rather than `"add(int, int)"`) is passed to an overloaded function, each API behaves as follows:
+
+| API | Bare-name behavior on overloaded function |
+|---|---|
+| `mock(n, repl)` | Auto-dispatch when the replacement lambda's signature matches exactly one overload; otherwise compile error listing available signatures |
+| `mockReturnValueOnce(n, v)` | Compile error — the return-value alone cannot disambiguate; signature form required |
+| `spy(n)` | Registers spy for **all** overloads aggregately |
+| `verify(n)` | Returns the **sum** of call counts across all overloads |
+| `verifyCalledWith(n, ...)` | Compile error when the arity does not pinpoint a unique overload; otherwise dispatches to the arity-matching overload |
+| `mockClear(n)` | Clears the call counter for **all** overloads |
+| `mockReset(n)` | Removes mocks/spies for **all** overloads |
+
+**Behavior shift on adding overloads.** If existing code calls `verify("foo")` and a second overload of `foo` is later introduced, the return value silently becomes the aggregate count across both overloads. To preserve per-overload counting through such a change, switch to the signature form (`verify("foo(int)")`) when the function gains overloads. The other aggregate APIs (`mockClear` / `mockReset` / `spy`) are not behavior-sensitive in the same way — their pre- and post-overload semantics coincide on a single-overload function.
+
+**Native (`@native`) overloads.** `customEmitter`-based stdlib overloads — including the math overload set (`abs`, `floor`, `ceil`, `round`, `log`, `pow`, `digits`) — can be mocked / spied via signature form (`mock("digits(int)", ...)`, `spy("abs(float)")`). Argument recording for `verifyCalledWith` on these natives is **not** supported in v1 — only count-based `verify("digits(int)")` works. Other `@native fn` declarations (table-driven without `customEmitter`, hand-written `emitBuiltin*` helpers) cannot be mocked.
+
 ### Limitations
 
-- Overloaded functions cannot be mocked.
-- `@native fn` declarations cannot be mocked.
+- Most `@native fn` declarations cannot be mocked. The exceptions are `customEmitter`-based overloads such as the math module's `abs` / `floor` / `ceil` / `round` / `log` / `pow` / `digits` (see "Mocking overloaded functions" above). Argument recording for `verifyCalledWith` on those natives is not supported in v1.
 - Capture-based closures **are supported as mock replacements** (since v0.0.22, #1678) — the closure can read or mutate variables from the enclosing scope. The captured environment is released automatically when the `it` block ends.
 - For `mockReturnValueOnce`, calls that fall through to the original implementation (after the queue empties and with no default `mock` set) are not counted by `verify(name)` — only queue-served and default-mock-served calls increment the counter. This diverges from strict Jest behavior but matches the Ry convention used by `mockReset` (#1681).
 

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -444,7 +444,7 @@ fn spyTests():
 
 - Requires `from testing import spy` (since v0.0.24, #1683)
 - The argument is the **string literal** name of the function (same convention as `verifyCalledWith`)
-- The function must exist and must not be overloaded; both are compile errors
+- The function must exist (compile error otherwise). Overloaded functions are supported since v0.0.24 (#1682): the bare name registers spies for **all** overloads aggregately, and a signature form (`spy("foo(int)")`) targets a single overload — see "Mocking overloaded functions" below
 - Spy registrations are automatically cleared at the end of each `it` block (same lifecycle as `mock`)
 - `verify(name)` and `verifyCalledWith(name, args...)` work uniformly on spied functions (same call-recording mechanism as `mock`)
 - `mockClear(name)` / `mockReset(name)` / `mockResetAll()` apply to spied functions identically — they share the same internal registry
@@ -481,7 +481,7 @@ fn mockReturnValueOnceTests():
 
 - Requires `from testing import mockReturnValueOnce` (since v0.0.24, #1681)
 - The first argument is the **string literal** name of the function (same convention as `spy` / `verifyCalledWith`, unlike `mock` which takes an identifier); non-literal first arguments are rejected at compile time
-- The function must exist, must not be overloaded, and must not return `Unit`; all are compile errors
+- The function must exist and must not return `Unit` (both are compile errors). Overloaded functions are supported since v0.0.24 (#1682) only via signature form (`mockReturnValueOnce("foo(int)", 1)`) — the bare name is a compile error on overloaded functions because the return value alone cannot disambiguate
 - The second argument's type must match the function's declared return type. Supported types: primitives (`int` / `float` / `bool`), `str`, `List` / `Map` / `Set`, records, `Result`, and `Option` (including bare `None` for `Option`-returning functions)
 - Arguments to the mocked call are ignored — the queue holds values, not call expectations
 - `verify(name)` counts only queue-served and default-mock-served calls. Once the queue empties and the call falls through to the original implementation, those calls are **not** counted (matching `mockReset` semantics — diverges from strict Jest behavior)

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1298,6 +1298,15 @@ private:
     std::string formatNativeFnSignature(const NativeFnSignature &sig);
     std::vector<std::string> collectNativeOverloadCandidateSigs(
         const std::string &callee);
+
+    // #1682: Collect every NativeFnSignature whose `name` field equals `bareName`,
+    // scanning all (package::name) keys in `native_fn_sigs_`. Used by mock /
+    // mockReturnValueOnce / spy / verifyCalledWith to find native overloads
+    // referenced without a package prefix (e.g. `mock("digits(int)", ...)`).
+    // `collectNativeOverloadCandidateSigs` only looks up by exact key, so it
+    // misses package-keyed entries like "math::digits".
+    std::vector<const NativeFnSignature*> collectNativeSigsByBareName(
+        const std::string &bareName) const;
     // Canonical Ry type name string for an argument value. Tries
     // `buildTypeNameFromMeta` first, then `reverseResolveTypeName`. Returns
     // empty when neither resolves; callers substitute "<unknown>" via
@@ -1468,9 +1477,72 @@ public:
                                    llvm::Type *retTy,
                                    const std::string &retTyName);
 
+    // Mock / spy registries (#1682): keyed by canonical sig string
+    // ("name(T1, T2)") so overloaded fns can be mocked/spied per-overload.
+    // For non-overloaded fns the canonical sig is still constructed; runtime
+    // additionally maintains a bare-name index for aggregate verify/clear.
     std::unordered_set<std::string> mocked_functions_;
     std::unordered_set<std::string> spied_functions_;
     std::unordered_map<std::string, llvm::Constant*> mock_name_strings_;
+
+    // Canonical sig helpers (#1682). buildCanonicalSig joins a fn name with
+    // resolveTypeAlias'd + whitespace-normalized param type names into
+    // "name(T1, T2)". parseSigString splits user input "name(T1, T2)" via
+    // paren-depth-aware scanning. Returns false ONLY when input has no '('
+    // (bare-name case, caller handles separately). When '(' is present the
+    // signature form is required: malformed shapes (no matching ')', empty
+    // name, empty parameter) raise codegenError with the offending input —
+    // the function never returns false for paren-bearing inputs. Normalization
+    // is alias + outer whitespace trim only — int? ≡ Option<int> is NOT
+    // unified (parser keeps them distinct strings). Sig form must match the
+    // fn's declaration.
+    std::string buildCanonicalSig(const std::string &name,
+                                   const std::vector<std::string> &paramTypeNames);
+    bool parseSigString(const std::string &input,
+                        std::string &outName,
+                        std::vector<std::string> &outParamTypeNames);
+
+    // Native fn mock/spy support (#1682). Called from emitMockCall / emitSpyCall
+    // when findFunction misses but collectNativeSigsByBareName finds @native
+    // overloads. Registration logic mirrors the user-fn path but compares
+    // FnTypeInfo against NativeFnSignature instead of OverloadEntry.
+    void emitNativeMockCall(CallStmt &s,
+                             const std::string &bareName,
+                             const std::string &fnNameInput,
+                             bool isSigForm,
+                             const std::vector<std::string> &sigParamTypes,
+                             const std::vector<const NativeFnSignature*> &nativeSigs);
+    void emitNativeSpyCall(CallStmt &s,
+                            const std::string &bareName,
+                            const std::string &fnNameInput,
+                            bool isSigForm,
+                            const std::vector<std::string> &sigParamTypes,
+                            const std::vector<const NativeFnSignature*> &nativeSigs);
+
+    // AST-level overload picker for mock dispatch on @native customEmitter path.
+    // Customs emit their own args inside their bodies, so we cannot pre-emit
+    // before resolving — double-emission would impure-eval args twice. Pass 1
+    // matches by arity (sufficient when arities differ as in `digits(n)` vs
+    // `digits(n, base)`); Pass 2 uses inferExprTypeName for multi-arity-match
+    // cases. Returns nullptr when no unique overload matches; caller falls
+    // back to the un-mocked customEmitter path.
+    const NativeFnSignature *pickNativeOverloadByCallShape(
+        const CallExpr &e,
+        const std::vector<NativeFnSignature> &sigs);
+
+    // Emit the tri-block mock dispatch for a customEmitter native call. The
+    // mockBB emits args fresh and dispatches through __ry_mock_get; origBB
+    // delegates to the customEmitter (which emits its own args). Returns the
+    // PHI-merged result. Pre-condition: caller has already verified
+    // (mocked || spied) for this canonicalSig.
+    llvm::Value *emitNativeCustomEmitterMockDispatch(
+        const CallExpr &e,
+        const NativeDispatchEntry *entry,
+        const NativeFnSignature &sig,
+        const std::string &canonicalSig,
+        bool isMocked,
+        bool isSpied);
+
     llvm::Value *toBool(llvm::Value *v);
 
     // Low-level type helpers

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1455,6 +1455,26 @@ public:
                                                  const std::string &retTyName);
     std::unordered_map<llvm::Function*, llvm::Function*> value_return_thunk_cache_;
 
+    // Native variant for @native overloads (#1682). The @native path has no
+    // user-level llvm::Function for the bare callee — param/return types are
+    // derived from NativeFnSignature instead. Cached by canonical sig string
+    // ("name(T1, T2)") so each overload has its own thunk symbol.
+    llvm::Function *getOrCreateNativeValueReturnThunk(
+        const std::string &canonicalSig,
+        const std::vector<llvm::Type*> &paramTypes,
+        llvm::Type *retTy,
+        const std::string &retTyName);
+    std::unordered_map<std::string, llvm::Function*> value_return_thunk_native_cache_;
+
+    // Shared core: builds the thunk body (load env → retain → return) for
+    // either the user-fn or @native flavour. Param types are caller-supplied;
+    // the trailing `ptr env` slot is appended internally.
+    llvm::Function *buildValueReturnThunk(
+        const std::string &symbolName,
+        const std::vector<llvm::Type*> &paramTypes,
+        llvm::Type *retTy,
+        const std::string &retTyName);
+
     // Env destructor for a value-return mock binding. Loads the stored value
     // from env and releases its ARC content (str / List / Map / Set / Record
     // / Result / Option). Returns an empty FunctionCallee when the return
@@ -1518,6 +1538,19 @@ public:
                             bool isSigForm,
                             const std::vector<std::string> &sigParamTypes,
                             const std::vector<const NativeFnSignature*> &nativeSigs);
+    // mockReturnValueOnce on @native overloads (#1682). Mirrors emitNativeMockCall
+    // but registers a value-return thunk + env (sized by sizeof(returnTy)) into
+    // the once_queue via __ry_mock_register_once. __ry_mock_get is polymorphic
+    // on canonical sig and consumes the queue regardless of dispatch path, so
+    // the customEmitter intercept (emitNativeCustomEmitterMockDispatch) and
+    // table-driven intercepts pick this up without additional wiring.
+    void emitNativeMockReturnValueOnceCall(
+        CallStmt &s,
+        const std::string &bareName,
+        const std::string &fnNameInput,
+        bool isSigForm,
+        const std::vector<std::string> &sigParamTypes,
+        const std::vector<const NativeFnSignature*> &nativeSigs);
 
     // AST-level overload picker for mock dispatch on @native customEmitter path.
     // Customs emit their own args inside their bodies, so we cannot pre-emit

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -407,6 +407,18 @@ std::vector<std::string> CodeGen::collectNativeOverloadCandidateSigs(
     return result;
 }
 
+std::vector<const CodeGen::NativeFnSignature*>
+CodeGen::collectNativeSigsByBareName(const std::string &bareName) const {
+    std::vector<const NativeFnSignature*> result;
+    for (const auto &[key, sigs] : native_fn_sigs_) {
+        for (const auto &sig : sigs) {
+            if (sig.name == bareName)
+                result.push_back(&sig);
+        }
+    }
+    return result;
+}
+
 std::string CodeGen::formatActualArgTypeName(llvm::Value *val) {
     if (!val) return "";
     std::string name = buildTypeNameFromMeta(val);

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -195,6 +195,29 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
         }
         if (!hasCallArityMatch)
             return nullptr;  // No sig with this arity — fall through
+
+        // #1682: mock/spy interception for customEmitter natives. We resolve
+        // the call's target overload at AST level (arity-only when arities
+        // differ — sufficient for math.digits-style overloads), build the
+        // canonical sig, and only divert through the tri-block dispatch if
+        // the sig was registered via mock() / spy(). Otherwise fall straight
+        // through to the customEmitter (zero-overhead path).
+        if (test_mode_) {
+            const NativeFnSignature *picked =
+                pickNativeOverloadByCallShape(e, sigIt->second);
+            if (picked) {
+                std::vector<std::string> pn;
+                pn.reserve(picked->params.size());
+                for (const auto &p : picked->params) pn.push_back(p.typeName);
+                const std::string canonicalSig = buildCanonicalSig(e.callee, pn);
+                const bool isMocked = mocked_functions_.count(canonicalSig) > 0;
+                const bool isSpied = spied_functions_.count(canonicalSig) > 0;
+                if (isMocked || isSpied) {
+                    return emitNativeCustomEmitterMockDispatch(
+                        e, entry, *picked, canonicalSig, isMocked, isSpied);
+                }
+            }
+        }
         return entry->customEmitter(*this, e);
     }
 
@@ -703,6 +726,183 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     }
 
     return result;
+}
+
+// ===== #1682: mock/spy for @native customEmitter overloads =====
+
+const CodeGen::NativeFnSignature *CodeGen::pickNativeOverloadByCallShape(
+    const CallExpr &e, const std::vector<NativeFnSignature> &sigs) {
+    // Pass 1: arity-unique match. Covers the digits(n) / digits(n, base)
+    // pattern where each arity has exactly one overload. Most existing
+    // customEmitter natives are arity-disjoint, so this short-circuit
+    // resolves them without needing AST type inference.
+    const NativeFnSignature *picked = nullptr;
+    int matchCount = 0;
+    for (const auto &sig : sigs) {
+        if (sig.params.size() == e.args.size()) {
+            picked = &sig;
+            ++matchCount;
+        }
+    }
+    if (matchCount == 1) return picked;
+    if (matchCount == 0) return nullptr;
+
+    // Pass 2: multiple same-arity overloads (e.g. abs(int) / abs(float),
+    // pow(int, int) / pow(float, float)). Resolve by inferring each arg's
+    // type at the AST level and matching against sig.params[i].typeName
+    // verbatim. Widening (int → float fallback) is NOT applied here — the
+    // unmocked customEmitter path handles widening internally, so for mock
+    // dispatch we only intercept exact-match calls. Mismatched-type calls
+    // fall through to the customEmitter (unchanged behavior).
+    std::unordered_map<std::string, llvm::Type *> emptyParamMap;
+    std::unordered_map<std::string, std::string> emptyParamNameMap;
+    std::vector<std::string> actualNames;
+    actualNames.reserve(e.args.size());
+    for (const auto &arg : e.args) {
+        std::string n = inferExprTypeName(*arg, emptyParamMap, emptyParamNameMap);
+        actualNames.push_back(resolveTypeAlias(trimTypeNameSpaces(n)));
+    }
+
+    picked = nullptr;
+    matchCount = 0;
+    for (const auto &sig : sigs) {
+        if (sig.params.size() != e.args.size()) continue;
+        bool eq = true;
+        for (size_t i = 0; i < sig.params.size(); ++i) {
+            if (resolveTypeAlias(trimTypeNameSpaces(sig.params[i].typeName))
+                    != actualNames[i]) {
+                eq = false; break;
+            }
+        }
+        if (eq) { picked = &sig; ++matchCount; }
+    }
+    return matchCount == 1 ? picked : nullptr;
+}
+
+llvm::Value *CodeGen::emitNativeCustomEmitterMockDispatch(
+    const CallExpr &e,
+    const NativeDispatchEntry *entry,
+    const NativeFnSignature &sig,
+    const std::string &canonicalSig,
+    bool isMocked,
+    bool isSpied) {
+    // Mock/spy intercept for customEmitter natives. Three runtime cases mirror
+    // the user-fn dispatch (see codegen_call_user.cpp):
+    //   - spy-only: linear increment, fall through to customEmitter
+    //   - mocked: tri-block (mockBB calls replacement via __ry_mock_get,
+    //             origBB delegates to customEmitter), PHI-merged
+    //   - mocked+spied: tri-block; origBB additionally increments before
+    //                   delegating (spy semantics when mock is runtime-inactive)
+    //
+    // v1 limitation: customEmitter-path natives do NOT record args for
+    // verifyCalledWith. Only count-style verify("name") is supported. The
+    // recording side requires an OverloadEntry (paramTypes/paramTypeNames) to
+    // dispatch the per-arg store function; NativeFnSignature.params carry
+    // only Ry-level type names, and synthesizing a fake OverloadEntry would
+    // duplicate the dispatch logic. Defer to a follow-up.
+
+    auto &nameStr = mock_name_strings_[canonicalSig];
+    if (!nameStr) nameStr = cachedGlobalString(canonicalSig, ".mock." + canonicalSig);
+
+    llvm::FunctionType *mockIncTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    llvm::FunctionCallee mockIncFn =
+        mod_->getOrInsertFunction("__ry_mock_increment_call", mockIncTy);
+
+    // Spy-only: emit linear increment, then delegate to the customEmitter
+    // (which emits args + the original call).
+    if (isSpied && !isMocked) {
+        builder_.CreateCall(mockIncFn, {nameStr});
+        return entry->customEmitter(*this, e);
+    }
+
+    // Mocked (with or without spy). Use the mock-get probe BEFORE emitting
+    // args so we can split into mockBB / origBB and emit args independently
+    // in each branch — args may have side effects, so we want exactly one
+    // evaluation per runtime path (not two if we pre-emitted).
+    llvm::FunctionType *mockGetTy = llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
+    llvm::FunctionCallee mockGetFn = mod_->getOrInsertFunction("__ry_mock_get", mockGetTy);
+    llvm::FunctionCallee mockGetEnvFn = mod_->getOrInsertFunction("__ry_mock_get_env", mockGetTy);
+
+    llvm::Value *mockPtr = builder_.CreateCall(mockGetFn, {nameStr}, "mock_ptr");
+    llvm::Value *nullPtr = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
+    llvm::Value *mockActive = builder_.CreateICmpNE(mockPtr, nullPtr, "is_mocked");
+
+    llvm::BasicBlock *mockBB = llvm::BasicBlock::Create(*ctx_, "mock_bb", fn_);
+    llvm::BasicBlock *origBB = llvm::BasicBlock::Create(*ctx_, "orig_bb", fn_);
+    llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "merge_bb", fn_);
+    builder_.CreateCondBr(mockActive, mockBB, origBB);
+
+    // Mock path: emit args fresh, increment, dispatch via plain or capture
+    // ABI based on env pointer.
+    builder_.SetInsertPoint(mockBB);
+    builder_.CreateCall(mockIncFn, {nameStr});
+
+    std::vector<llvm::Value *> mockArgs;
+    mockArgs.reserve(e.args.size());
+    std::vector<llvm::Type *> mockParamTys;
+    mockParamTys.reserve(sig.params.size());
+    for (size_t i = 0; i < e.args.size(); ++i) {
+        llvm::Value *v = emitExpr(*e.args[i]);
+        llvm::Type *want = resolveType(sig.params[i].typeName);
+        if (v->getType() != want && isWideningConversion(v, want, sig.params[i].typeName))
+            v = emitWideningConversion(v, want);
+        mockArgs.push_back(v);
+        mockParamTys.push_back(want);
+    }
+    llvm::Type *mockRetTy = resolveType(sig.returnTypeName);
+    llvm::FunctionType *mockFnTy = llvm::FunctionType::get(mockRetTy, mockParamTys, false);
+
+    llvm::Value *envPtr = builder_.CreateCall(mockGetEnvFn, {nameStr}, "mock_env");
+    llvm::Value *isCapture = builder_.CreateICmpNE(envPtr, nullPtr, "is_capture_mock");
+
+    llvm::BasicBlock *plainBB = llvm::BasicBlock::Create(*ctx_, "mock_plain_bb", fn_);
+    llvm::BasicBlock *captureBB = llvm::BasicBlock::Create(*ctx_, "mock_capture_bb", fn_);
+    builder_.CreateCondBr(isCapture, captureBB, plainBB);
+
+    std::vector<llvm::Type *> captureParamTys = mockParamTys;
+    captureParamTys.push_back(ptrTy_);
+    llvm::FunctionType *captureFnTy = llvm::FunctionType::get(
+        mockRetTy, captureParamTys, false);
+    std::vector<llvm::Value *> captureArgs = mockArgs;
+    captureArgs.push_back(envPtr);
+
+    builder_.SetInsertPoint(plainBB);
+    llvm::Value *mockResultPlain = mockRetTy->isVoidTy()
+        ? nullptr
+        : builder_.CreateCall(mockFnTy, mockPtr, mockArgs, "mock_result_plain");
+    if (mockRetTy->isVoidTy())
+        builder_.CreateCall(mockFnTy, mockPtr, mockArgs);
+    builder_.CreateBr(mergeBB);
+    llvm::BasicBlock *plainEndBB = builder_.GetInsertBlock();
+
+    builder_.SetInsertPoint(captureBB);
+    llvm::Value *mockResultCapture = mockRetTy->isVoidTy()
+        ? nullptr
+        : builder_.CreateCall(captureFnTy, mockPtr, captureArgs, "mock_result_capture");
+    if (mockRetTy->isVoidTy())
+        builder_.CreateCall(captureFnTy, mockPtr, captureArgs);
+    builder_.CreateBr(mergeBB);
+    llvm::BasicBlock *captureEndBB = builder_.GetInsertBlock();
+
+    // Original path: delegate to customEmitter (which emits its own args).
+    builder_.SetInsertPoint(origBB);
+    if (isSpied)
+        builder_.CreateCall(mockIncFn, {nameStr});
+    llvm::Value *origResult = entry->customEmitter(*this, e);
+    builder_.CreateBr(mergeBB);
+    llvm::BasicBlock *origEndBB = builder_.GetInsertBlock();
+
+    builder_.SetInsertPoint(mergeBB);
+    if (mockRetTy->isVoidTy())
+        return llvm::ConstantInt::get(i8Ty_, 0);
+
+    llvm::PHINode *phi = builder_.CreatePHI(mockRetTy, 3, "call_result");
+    phi->addIncoming(mockResultPlain, plainEndBB);
+    phi->addIncoming(mockResultCapture, captureEndBB);
+    phi->addIncoming(origResult, origEndBB);
+    propagateTypeMeta(sig.returnTypeName, phi);
+    return phi;
 }
 
 } // namespace ry

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -361,16 +361,32 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
     //                              at runtime — the runtime registry keys
     //                              mocks and spies into the same entry so
     //                              both compile-time sets can be populated)
-    const bool isMocked = test_mode_ && mocked_functions_.count(callee);
-    const bool isSpied = test_mode_ && spied_functions_.count(callee);
+    // Canonical sig key (#1682): mock/spy registry is per-overload. Built from
+    // the resolved overload's paramTypeNames so each (mocked/spied) overload
+    // gets its own dispatch decision; sibling overloads of the same fn name
+    // remain unmocked.
+    const std::string mockKey = matchedEntry
+        ? buildCanonicalSig(callee, matchedEntry->paramTypeNames)
+        : callee;
+    // Both bare name and canonical sig are accepted: the pre-scan in
+    // `collectTestTargetsFromStmt` (codegen.cpp) populates these sets with
+    // bare names (it lacks overload context), while `emitMockCall` /
+    // `emitSpyCall` populate them with canonical sigs. Bare-name presence
+    // therefore means "pre-detected, maybe mocked"; the tri-block emitted
+    // here will fall through to origBB if the runtime registry has no entry
+    // under the canonical sig, so a false-positive is correctness-preserving.
+    const bool isMocked = test_mode_ &&
+        (mocked_functions_.count(mockKey) || mocked_functions_.count(callee));
+    const bool isSpied = test_mode_ &&
+        (spied_functions_.count(mockKey) || spied_functions_.count(callee));
 
     if (isSpied && !isMocked) {
         // Case (b): spy-only. No mock branching needed — runtime entry is
         // populated by __ry_spy_register but never has fn_ptr/env_ptr set,
         // so the mockBB path would be dead. Emit linear increment + arg
         // recording, then fall through to the normal call path below.
-        auto &nameStr = mock_name_strings_[callee];
-        if (!nameStr) nameStr = cachedGlobalString(callee, ".mock." + callee);
+        auto &nameStr = mock_name_strings_[mockKey];
+        if (!nameStr) nameStr = cachedGlobalString(mockKey, ".mock." + mockKey);
         llvm::FunctionType *mockIncTy = llvm::FunctionType::get(
             llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
         llvm::FunctionCallee mockIncFn = mod_->getOrInsertFunction(
@@ -388,8 +404,8 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
             llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
         llvm::FunctionCallee mockIncFn = mod_->getOrInsertFunction("__ry_mock_increment_call", mockIncTy);
 
-        auto &nameStr = mock_name_strings_[callee];
-        if (!nameStr) nameStr = cachedGlobalString(callee, ".mock." + callee);
+        auto &nameStr = mock_name_strings_[mockKey];
+        if (!nameStr) nameStr = cachedGlobalString(mockKey, ".mock." + mockKey);
         llvm::Value *mockPtr = builder_.CreateCall(mockGetFn, {nameStr}, "mock_ptr");
         llvm::Value *nullPtr = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
         llvm::Value *mockActive = builder_.CreateICmpNE(mockPtr, nullPtr, "is_mocked");

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -23,6 +23,58 @@ void CodeGen::emitOutlinePrintf(const std::string &label, llvm::Value *nameVal) 
         builder_.CreateCall(printfFn, {fmt});
 }
 
+// ===== Canonical signature helpers (#1682) =====
+//
+// Both forms share the same "name(T1, T2)" canonical shape. Each component is
+// alias-resolved (via `resolveTypeAlias`) and whitespace-trimmed so user input
+// "add( int , int )" and "add(int, int)" normalize identically. Note: parser
+// preserves the two forms `int?` and `Option<int>` as distinct strings, so the
+// sig string MUST match the fn's declaration form (mirroring how function
+// resolution itself compares paramTypeNames).
+
+std::string CodeGen::buildCanonicalSig(const std::string &name,
+                                        const std::vector<std::string> &paramTypeNames) {
+    std::string result = name;
+    result += '(';
+    for (size_t i = 0; i < paramTypeNames.size(); ++i) {
+        if (i > 0) result += ", ";
+        result += resolveTypeAlias(trimTypeNameSpaces(paramTypeNames[i]));
+    }
+    result += ')';
+    return result;
+}
+
+bool CodeGen::parseSigString(const std::string &input,
+                              std::string &outName,
+                              std::vector<std::string> &outParamTypeNames) {
+    const size_t parenPos = input.find('(');
+    if (parenPos == std::string::npos) return false;
+    // Paren present → user intended signature form. Reject malformed shapes
+    // (missing ')' / empty function name) with a clear error instead of
+    // silently falling through to bare-name lookup (#1682).
+    if (input.empty() || input.back() != ')')
+        codegenError("invalid signature syntax: '" + input +
+                     "' — expected 'name(T1, T2, ...)' with matching parentheses");
+    outName = trimTypeNameSpaces(input.substr(0, parenPos));
+    if (outName.empty())
+        codegenError("invalid signature syntax: '" + input +
+                     "' — function name before '(' is empty");
+    const std::string inner = trimTypeNameSpaces(
+        input.substr(parenPos + 1, input.size() - parenPos - 2));
+    outParamTypeNames.clear();
+    if (inner.empty()) return true;
+    const auto parts = splitTypeArgs(inner);
+    outParamTypeNames.reserve(parts.size());
+    for (const auto &p : parts) {
+        const std::string trimmed = trimTypeNameSpaces(p);
+        if (trimmed.empty())
+            codegenError("invalid signature syntax: '" + input +
+                         "' — empty parameter type between commas");
+        outParamTypeNames.push_back(resolveTypeAlias(trimmed));
+    }
+    return true;
+}
+
 // ===== Test helpers =====
 
 llvm::SmallVector<llvm::Value*, 4> CodeGen::loadCapturedArgs(const OverloadEntry &entry, const std::string &directive) {
@@ -580,49 +632,120 @@ void CodeGen::emitMockCall(CallStmt &s) {
     if (s.args.size() != 2)
         codegenError("mock() requires exactly 2 arguments: function name and replacement");
 
-    // First arg is the function name (converted to StringExpr by parser)
     auto *strExpr = std::get_if<StringExpr>(&s.args[0]->data);
     if (!strExpr)
         codegenError("mock() first argument must be a function name");
-    const std::string &fnName = strExpr->value;
+    const std::string &fnNameInput = strExpr->value;
 
-    // Check function exists
-    auto *fitOverloads = findFunction(fnName);
-    if (!fitOverloads)
-        codegenError("mock(): unknown function '" + fnName + "'");
+    // Sig form ("name(T1, T2)") vs bare name. parseSigString returns true for
+    // the former and populates outName + outParamTypeNames; false means bare.
+    std::string bareName;
+    std::vector<std::string> sigParamTypes;
+    const bool isSigForm = parseSigString(fnNameInput, bareName, sigParamTypes);
+    if (!isSigForm) bareName = fnNameInput;
 
-    // Check no overloads (v1 limitation)
-    if (fitOverloads->size() > 1)
-        codegenError("mock(): overloaded functions are not supported");
+    auto *fitOverloads = findFunction(bareName);
+    if (!fitOverloads) {
+        // #1682: @native overloads (e.g. math.digits) miss findFunction —
+        // delegate to the parallel native-fn registration path.
+        auto nativeSigs = collectNativeSigsByBareName(bareName);
+        if (nativeSigs.empty())
+            codegenError("mock(): unknown function '" + fnNameInput + "'");
+        emitNativeMockCall(s, bareName, fnNameInput,
+                            isSigForm, sigParamTypes, nativeSigs);
+        return;
+    }
 
-    auto &entry = (*fitOverloads)[0];
-    llvm::Function *origFn = entry.func;
+    // Pick the target overload entry. Sig form requires exact match on the
+    // normalized paramTypeNames; bare form requires exactly one overload
+    // (Option C — auto-dispatch by replacement type is handled below for the
+    // overloaded-bare-name case before we land here).
+    OverloadEntry *entry = nullptr;
+    if (isSigForm) {
+        std::vector<std::string> wantNorm;
+        wantNorm.reserve(sigParamTypes.size());
+        for (const auto &p : sigParamTypes)
+            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+        for (auto &ov : *fitOverloads) {
+            if (ov.paramTypeNames.size() != wantNorm.size()) continue;
+            bool eq = true;
+            for (size_t i = 0; i < wantNorm.size(); ++i) {
+                if (resolveTypeAlias(trimTypeNameSpaces(ov.paramTypeNames[i]))
+                        != wantNorm[i]) {
+                    eq = false; break;
+                }
+            }
+            if (eq) { entry = &ov; break; }
+        }
+        if (!entry) {
+            std::string msg = "mock(): no overload of '" + bareName + "' matches signature '" + fnNameInput + "'. Available:";
+            for (const auto &ov : *fitOverloads)
+                msg += "\n  - " + buildCanonicalSig(bareName, ov.paramTypeNames);
+            codegenError(msg);
+        }
+    } else if (fitOverloads->size() == 1) {
+        entry = &(*fitOverloads)[0];
+    }
+    // If bare + overloaded, `entry` stays null — resolved below after emitting
+    // the replacement (Option C: pick the overload whose paramTypes match).
 
-    // Emit the replacement lambda
     llvm::Value *replacement = emitExpr(*s.args[1]);
 
     auto *fnInfo = lookupFnTypeInfo(replacement);
     if (!fnInfo)
         codegenError("mock(): second argument must be a lambda or function reference");
 
-    // Verify type compatibility
-    llvm::Type *origRetTy = origFn->getReturnType();
-    if (fnInfo->returnType != origRetTy)
-        codegenError("mock(): replacement return type does not match '" + fnName + "'");
-    if (fnInfo->paramTypes.size() != entry.paramTypes.size())
-        codegenError("mock(): replacement parameter count does not match '" + fnName + "'");
-    for (size_t i = 0; i < entry.paramTypes.size(); ++i) {
-        if (fnInfo->paramTypes[i] != entry.paramTypes[i])
-            codegenError("mock(): replacement parameter type " + std::to_string(i) +
-                         " does not match '" + fnName + "'");
+    if (!entry) {
+        // Bare name + multiple overloads: find the single overload whose
+        // (paramTypes, returnType) matches the replacement's FnTypeInfo.
+        OverloadEntry *match = nullptr;
+        int matchCount = 0;
+        for (auto &ov : *fitOverloads) {
+            if (ov.paramTypes.size() != fnInfo->paramTypes.size()) continue;
+            if (ov.func->getReturnType() != fnInfo->returnType) continue;
+            bool eq = true;
+            for (size_t i = 0; i < ov.paramTypes.size(); ++i) {
+                if (ov.paramTypes[i] != fnInfo->paramTypes[i]) { eq = false; break; }
+            }
+            if (eq) { match = &ov; ++matchCount; }
+        }
+        if (matchCount == 0 || matchCount > 1) {
+            std::string msg = "mock(): '" + bareName + "' is overloaded; replacement's signature ";
+            msg += (matchCount == 0)
+                ? "does not match any overload."
+                : "is ambiguous (matches multiple overloads).";
+            msg += " Use signature form: mock(\"" + bareName + "(T1, T2)\", ...). Available:";
+            for (const auto &ov : *fitOverloads)
+                msg += "\n  - " + buildCanonicalSig(bareName, ov.paramTypeNames);
+            codegenError(msg);
+        }
+        entry = match;
     }
 
-    // Track that this function is mocked (for selective dispatch in emitUserFnCall)
-    mocked_functions_.insert(fnName);
+    // codegenError above is [[noreturn]], so entry is guaranteed non-null
+    // here when matchCount==1.
+    // cppcheck-suppress nullPointerRedundantCheck
+    llvm::Function *origFn = entry->func;
 
-    // Cache global string per function name
-    auto &nameStr = mock_name_strings_[fnName];
-    if (!nameStr) nameStr = cachedGlobalString(fnName, ".mock." + fnName);
+    // Verify type compatibility against the resolved overload.
+    llvm::Type *origRetTy = origFn->getReturnType();
+    if (fnInfo->returnType != origRetTy)
+        codegenError("mock(): replacement return type does not match '" + bareName + "'");
+    if (fnInfo->paramTypes.size() != entry->paramTypes.size())
+        codegenError("mock(): replacement parameter count does not match '" + bareName + "'");
+    for (size_t i = 0; i < entry->paramTypes.size(); ++i) {
+        if (fnInfo->paramTypes[i] != entry->paramTypes[i])
+            codegenError("mock(): replacement parameter type " + std::to_string(i) +
+                         " does not match '" + bareName + "'");
+    }
+
+    // Canonical sig keys the runtime registry and the dispatch-site check
+    // (mocked_functions_ in src/codegen_call_user.cpp).
+    const std::string canonicalSig = buildCanonicalSig(bareName, entry->paramTypeNames);
+    mocked_functions_.insert(canonicalSig);
+
+    auto &nameStr = mock_name_strings_[canonicalSig];
+    if (!nameStr) nameStr = cachedGlobalString(canonicalSig, ".mock." + canonicalSig);
 
     if (fnInfo->capturedVars.empty()) {
         // Non-capturing: register plain function pointer.
@@ -658,6 +781,196 @@ void CodeGen::emitMockCall(CallStmt &s) {
     llvm::FunctionCallee mockSetClosureFn =
         mod_->getOrInsertFunction("__ry_mock_set_closure", mockSetClosureTy);
     builder_.CreateCall(mockSetClosureFn, {nameStr, thunk, replacement, envDtorVal});
+}
+
+// ===== Mock support for @native overloads (#1682) =====
+//
+// emitMockCall delegates here when findFunction(bareName) returns null but
+// collectNativeSigsByBareName(bareName) finds @native signatures (e.g.
+// math.digits / math.abs). The registration logic mirrors emitMockCall but
+// operates on NativeFnSignature instead of OverloadEntry — type validation
+// uses LLVM-level equality between FnTypeInfo paramTypes/returnType and
+// resolveType()'d sig.params[i].typeName / sig.returnTypeName.
+void CodeGen::emitNativeMockCall(CallStmt &s,
+                                  const std::string &bareName,
+                                  const std::string &fnNameInput,
+                                  bool isSigForm,
+                                  const std::vector<std::string> &sigParamTypes,
+                                  const std::vector<const NativeFnSignature*> &nativeSigs) {
+    auto sigParamNames = [](const NativeFnSignature *sig) {
+        std::vector<std::string> out;
+        out.reserve(sig->params.size());
+        for (const auto &p : sig->params) out.push_back(p.typeName);
+        return out;
+    };
+
+    const NativeFnSignature *target = nullptr;
+    if (isSigForm) {
+        std::vector<std::string> wantNorm;
+        wantNorm.reserve(sigParamTypes.size());
+        for (const auto &p : sigParamTypes)
+            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+        for (const auto *sig : nativeSigs) {
+            if (sig->params.size() != wantNorm.size()) continue;
+            bool eq = true;
+            for (size_t i = 0; i < wantNorm.size(); ++i) {
+                if (resolveTypeAlias(trimTypeNameSpaces(sig->params[i].typeName))
+                        != wantNorm[i]) {
+                    eq = false; break;
+                }
+            }
+            if (eq) { target = sig; break; }
+        }
+        if (!target) {
+            std::string msg = "mock(): no overload of '" + bareName +
+                              "' matches signature '" + fnNameInput + "'. Available:";
+            for (const auto *sig : nativeSigs)
+                msg += "\n  - " + buildCanonicalSig(bareName, sigParamNames(sig));
+            codegenError(msg);
+        }
+    } else if (nativeSigs.size() == 1) {
+        target = nativeSigs[0];
+    }
+    // else (bare + multiple native overloads): target stays null — resolved
+    // below after emitting the replacement (Option C: pick by replacement type).
+
+    llvm::Value *replacement = emitExpr(*s.args[1]);
+    auto *fnInfo = lookupFnTypeInfo(replacement);
+    if (!fnInfo)
+        codegenError("mock(): second argument must be a lambda or function reference");
+
+    if (!target) {
+        const NativeFnSignature *match = nullptr;
+        int matchCount = 0;
+        for (const auto *sig : nativeSigs) {
+            if (sig->params.size() != fnInfo->paramTypes.size()) continue;
+            if (resolveType(sig->returnTypeName) != fnInfo->returnType) continue;
+            bool eq = true;
+            for (size_t i = 0; i < sig->params.size(); ++i) {
+                if (resolveType(sig->params[i].typeName) != fnInfo->paramTypes[i]) {
+                    eq = false; break;
+                }
+            }
+            if (eq) { match = sig; ++matchCount; }
+        }
+        if (matchCount == 0 || matchCount > 1) {
+            std::string msg = "mock(): '" + bareName + "' is overloaded; replacement's signature ";
+            msg += (matchCount == 0)
+                ? "does not match any overload."
+                : "is ambiguous (matches multiple overloads).";
+            msg += " Use signature form: mock(\"" + bareName + "(T1, T2)\", ...). Available:";
+            for (const auto *sig : nativeSigs)
+                msg += "\n  - " + buildCanonicalSig(bareName, sigParamNames(sig));
+            codegenError(msg);
+        }
+        target = match;
+    }
+
+    // Verify type compatibility against the resolved native sig.
+    // codegenError above is [[noreturn]], so target is guaranteed non-null
+    // here when matchCount==1.
+    // cppcheck-suppress nullPointerRedundantCheck
+    llvm::Type *targetRetTy = resolveType(target->returnTypeName);
+    if (fnInfo->returnType != targetRetTy)
+        codegenError("mock(): replacement return type does not match '" + bareName + "'");
+    if (fnInfo->paramTypes.size() != target->params.size())
+        codegenError("mock(): replacement parameter count does not match '" + bareName + "'");
+    for (size_t i = 0; i < target->params.size(); ++i) {
+        llvm::Type *targetParamTy = resolveType(target->params[i].typeName);
+        if (fnInfo->paramTypes[i] != targetParamTy)
+            codegenError("mock(): replacement parameter type " + std::to_string(i) +
+                         " does not match '" + bareName + "'");
+    }
+
+    const std::string canonicalSig = buildCanonicalSig(bareName, sigParamNames(target));
+    mocked_functions_.insert(canonicalSig);
+
+    auto &nameStr = mock_name_strings_[canonicalSig];
+    if (!nameStr) nameStr = cachedGlobalString(canonicalSig, ".mock." + canonicalSig);
+
+    if (fnInfo->capturedVars.empty()) {
+        llvm::FunctionType *mockSetTy = llvm::FunctionType::get(
+            llvm::Type::getVoidTy(*ctx_), {ptrTy_, ptrTy_}, false);
+        llvm::FunctionCallee mockSetFn = mod_->getOrInsertFunction("__ry_mock_set", mockSetTy);
+        builder_.CreateCall(mockSetFn, {nameStr, replacement});
+        return;
+    }
+
+    llvm::Function *realFn = fnInfo->sourceFn;
+    if (!realFn)
+        codegenError("mock(): cannot wrap capturing closure (missing sourceFn)");
+    llvm::Function *thunk = getOrCreateCapturingThunk(realFn, *fnInfo);
+    auto envDtorCallee = getOrCreateClosureDestructor(*fnInfo);
+    auto *nullPtr = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
+    llvm::Value *envDtorVal = envDtorCallee
+        ? llvm::cast<llvm::Value>(envDtorCallee.getCallee())
+        : llvm::cast<llvm::Value>(nullPtr);
+    auto *envHdr = emitArcGetHeaderFromData(replacement);
+    emitArcRetain(envHdr, false);
+    llvm::FunctionType *mockSetClosureTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_),
+        {ptrTy_, ptrTy_, ptrTy_, ptrTy_}, false);
+    llvm::FunctionCallee mockSetClosureFn =
+        mod_->getOrInsertFunction("__ry_mock_set_closure", mockSetClosureTy);
+    builder_.CreateCall(mockSetClosureFn, {nameStr, thunk, replacement, envDtorVal});
+}
+
+// Spy support for @native overloads (#1682). Bare-name spy registers ALL
+// native overloads of `bareName`; sig form picks the one whose normalized
+// paramTypeNames match.
+void CodeGen::emitNativeSpyCall(CallStmt &s,
+                                 const std::string &bareName,
+                                 const std::string &fnNameInput,
+                                 bool isSigForm,
+                                 const std::vector<std::string> &sigParamTypes,
+                                 const std::vector<const NativeFnSignature*> &nativeSigs) {
+    (void)s;
+    auto sigParamNames = [](const NativeFnSignature *sig) {
+        std::vector<std::string> out;
+        out.reserve(sig->params.size());
+        for (const auto &p : sig->params) out.push_back(p.typeName);
+        return out;
+    };
+
+    std::vector<const NativeFnSignature*> targets;
+    if (isSigForm) {
+        std::vector<std::string> wantNorm;
+        wantNorm.reserve(sigParamTypes.size());
+        for (const auto &p : sigParamTypes)
+            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+        for (const auto *sig : nativeSigs) {
+            if (sig->params.size() != wantNorm.size()) continue;
+            bool eq = true;
+            for (size_t i = 0; i < wantNorm.size(); ++i) {
+                if (resolveTypeAlias(trimTypeNameSpaces(sig->params[i].typeName))
+                        != wantNorm[i]) {
+                    eq = false; break;
+                }
+            }
+            if (eq) { targets.push_back(sig); break; }
+        }
+        if (targets.empty()) {
+            std::string msg = "spy(): no overload of '" + bareName +
+                              "' matches signature '" + fnNameInput + "'. Available:";
+            for (const auto *sig : nativeSigs)
+                msg += "\n  - " + buildCanonicalSig(bareName, sigParamNames(sig));
+            codegenError(msg);
+        }
+    } else {
+        for (const auto *sig : nativeSigs) targets.push_back(sig);
+    }
+
+    llvm::FunctionType *spyRegTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+    llvm::FunctionCallee spyRegFn =
+        mod_->getOrInsertFunction("__ry_spy_register", spyRegTy);
+    for (const auto *sig : targets) {
+        const std::string canonicalSig = buildCanonicalSig(bareName, sigParamNames(sig));
+        spied_functions_.insert(canonicalSig);
+        auto &nameStr = mock_name_strings_[canonicalSig];
+        if (!nameStr) nameStr = cachedGlobalString(canonicalSig, ".mock." + canonicalSig);
+        builder_.CreateCall(spyRegFn, {nameStr});
+    }
 }
 
 // ===== Test: mockReturnValueOnce — per-call value-return queue (#1681) =====
@@ -932,18 +1245,61 @@ void CodeGen::emitMockReturnValueOnceCall(CallStmt &s) {
     auto *strExpr = std::get_if<StringExpr>(&s.args[0]->data);
     if (!strExpr)
         codegenError("mockReturnValueOnce() first argument must be a function name");
-    const std::string &fnName = strExpr->value;
+    const std::string &fnNameInput = strExpr->value;
 
-    auto *fitOverloads = findFunction(fnName);
+    // Sig form ("name(T1, T2)") vs bare name. Bare + overloaded is rejected
+    // for mockReturnValueOnce: return value type alone cannot disambiguate
+    // (`Result<int, str>` and `Result<float, str>` both accept the same int
+    // payload), so users must specify sig form when overloads exist.
+    std::string bareName;
+    std::vector<std::string> sigParamTypes;
+    const bool isSigForm = parseSigString(fnNameInput, bareName, sigParamTypes);
+    if (!isSigForm) bareName = fnNameInput;
+
+    auto *fitOverloads = findFunction(bareName);
     if (!fitOverloads)
-        codegenError("mockReturnValueOnce(): unknown function '" + fnName + "'");
-    if (fitOverloads->size() > 1)
-        codegenError("mockReturnValueOnce(): overloaded functions are not supported");
+        codegenError("mockReturnValueOnce(): unknown function '" + fnNameInput + "'");
 
-    auto &entry = (*fitOverloads)[0];
+    OverloadEntry *entryPtr = nullptr;
+    if (isSigForm) {
+        std::vector<std::string> wantNorm;
+        wantNorm.reserve(sigParamTypes.size());
+        for (const auto &p : sigParamTypes)
+            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+        for (auto &ov : *fitOverloads) {
+            if (ov.paramTypeNames.size() != wantNorm.size()) continue;
+            bool eq = true;
+            for (size_t i = 0; i < wantNorm.size(); ++i) {
+                if (resolveTypeAlias(trimTypeNameSpaces(ov.paramTypeNames[i]))
+                        != wantNorm[i]) {
+                    eq = false; break;
+                }
+            }
+            if (eq) { entryPtr = &ov; break; }
+        }
+        if (!entryPtr) {
+            std::string msg = "mockReturnValueOnce(): no overload of '" + bareName +
+                "' matches signature '" + fnNameInput + "'. Available:";
+            for (const auto &ov : *fitOverloads)
+                msg += "\n  - " + buildCanonicalSig(bareName, ov.paramTypeNames);
+            codegenError(msg);
+        }
+    } else if (fitOverloads->size() == 1) {
+        entryPtr = &(*fitOverloads)[0];
+    } else {
+        std::string msg = "mockReturnValueOnce(): '" + bareName +
+            "' is overloaded; return value type alone is ambiguous. "
+            "Specify signature: mockReturnValueOnce(\"" + bareName +
+            "(T1, T2)\", value). Available:";
+        for (const auto &ov : *fitOverloads)
+            msg += "\n  - " + buildCanonicalSig(bareName, ov.paramTypeNames);
+        codegenError(msg);
+    }
+    auto &entry = *entryPtr;
     llvm::Function *origFn = entry.func;
     llvm::Type *retTy = origFn->getReturnType();
     const std::string &retTyName = entry.returnTypeName;
+    const std::string &fnName = bareName;
     std::string resolved = resolveTypeAlias(retTyName);
 
     if (retTy->isVoidTy())
@@ -1034,10 +1390,11 @@ void CodeGen::emitMockReturnValueOnceCall(CallStmt &s) {
     // Retain env so the registry owns +1.
     emitArcRetain(envHdr, false);
 
-    mocked_functions_.insert(fnName);
+    const std::string canonicalSig = buildCanonicalSig(bareName, entry.paramTypeNames);
+    mocked_functions_.insert(canonicalSig);
 
-    auto &nameStr = mock_name_strings_[fnName];
-    if (!nameStr) nameStr = cachedGlobalString(fnName, ".mock." + fnName);
+    auto &nameStr = mock_name_strings_[canonicalSig];
+    if (!nameStr) nameStr = cachedGlobalString(canonicalSig, ".mock." + canonicalSig);
 
     llvm::Function *thunk = getOrCreateValueReturnThunk(origFn, retTyName);
     auto envDtorCallee = getOrCreateValueReturnEnvDestructor(retTy, retTyName);
@@ -1068,25 +1425,66 @@ void CodeGen::emitSpyCall(CallStmt &s) {
     auto *strExpr = std::get_if<StringExpr>(&s.args[0]->data);
     if (!strExpr)
         codegenError("spy() first argument must be a function name");
-    const std::string &fnName = strExpr->value;
+    const std::string &fnNameInput = strExpr->value;
 
-    auto *fitOverloads = findFunction(fnName);
-    if (!fitOverloads)
-        codegenError("spy(): unknown function '" + fnName + "'");
+    // Sig form vs bare. Bare + overloaded registers spy for ALL overloads
+    // (aggregate spy semantics per the plan); sig form registers for exactly one.
+    std::string bareName;
+    std::vector<std::string> sigParamTypes;
+    const bool isSigForm = parseSigString(fnNameInput, bareName, sigParamTypes);
+    if (!isSigForm) bareName = fnNameInput;
 
-    if (fitOverloads->size() > 1)
-        codegenError("spy(): overloaded functions are not supported");
+    auto *fitOverloads = findFunction(bareName);
+    if (!fitOverloads) {
+        // #1682: @native overloads (e.g. math.digits) miss findFunction —
+        // delegate to the parallel native-fn spy path.
+        auto nativeSigs = collectNativeSigsByBareName(bareName);
+        if (nativeSigs.empty())
+            codegenError("spy(): unknown function '" + fnNameInput + "'");
+        emitNativeSpyCall(s, bareName, fnNameInput,
+                           isSigForm, sigParamTypes, nativeSigs);
+        return;
+    }
 
-    spied_functions_.insert(fnName);
-
-    auto &nameStr = mock_name_strings_[fnName];
-    if (!nameStr) nameStr = cachedGlobalString(fnName, ".mock." + fnName);
+    std::vector<OverloadEntry *> targets;
+    if (isSigForm) {
+        std::vector<std::string> wantNorm;
+        wantNorm.reserve(sigParamTypes.size());
+        for (const auto &p : sigParamTypes)
+            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+        for (auto &ov : *fitOverloads) {
+            if (ov.paramTypeNames.size() != wantNorm.size()) continue;
+            bool eq = true;
+            for (size_t i = 0; i < wantNorm.size(); ++i) {
+                if (resolveTypeAlias(trimTypeNameSpaces(ov.paramTypeNames[i]))
+                        != wantNorm[i]) {
+                    eq = false; break;
+                }
+            }
+            if (eq) { targets.push_back(&ov); break; }
+        }
+        if (targets.empty()) {
+            std::string msg = "spy(): no overload of '" + bareName +
+                "' matches signature '" + fnNameInput + "'. Available:";
+            for (const auto &ov : *fitOverloads)
+                msg += "\n  - " + buildCanonicalSig(bareName, ov.paramTypeNames);
+            codegenError(msg);
+        }
+    } else {
+        for (auto &ov : *fitOverloads) targets.push_back(&ov);
+    }
 
     llvm::FunctionType *spyRegTy = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
     llvm::FunctionCallee spyRegFn =
         mod_->getOrInsertFunction("__ry_spy_register", spyRegTy);
-    builder_.CreateCall(spyRegFn, {nameStr});
+    for (auto *ov : targets) {
+        const std::string canonicalSig = buildCanonicalSig(bareName, ov->paramTypeNames);
+        spied_functions_.insert(canonicalSig);
+        auto &nameStr = mock_name_strings_[canonicalSig];
+        if (!nameStr) nameStr = cachedGlobalString(canonicalSig, ".mock." + canonicalSig);
+        builder_.CreateCall(spyRegFn, {nameStr});
+    }
 }
 
 // ===== Mock/spy: argument recording IR for verifyCalledWith =====
@@ -1536,17 +1934,76 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
     auto *strExpr = std::get_if<StringExpr>(&e.args[0]->data);
     if (!strExpr)
         codegenError("verifyCalledWith() first argument must be a function name string literal");
-    const std::string &fnName = strExpr->value;
+    const std::string &fnNameInput = strExpr->value;
 
-    if (!mocked_functions_.count(fnName) && !spied_functions_.count(fnName))
-        codegenError("verifyCalledWith: '" + fnName + "' is not mocked or spied");
+    // Sig form vs bare. Bare-name on an overloaded function is matched
+    // arity-then-type against the supplied args; with multiple matching
+    // overloads (e.g. ambiguous numeric coercion) the user must use sig form.
+    std::string bareName;
+    std::vector<std::string> sigParamTypes;
+    const bool isSigForm = parseSigString(fnNameInput, bareName, sigParamTypes);
+    if (!isSigForm) bareName = fnNameInput;
 
-    auto *overloads = findFunction(fnName);
+    auto *overloads = findFunction(bareName);
     if (!overloads || overloads->empty())
-        codegenError("verifyCalledWith: unknown function '" + fnName + "'");
-    if (overloads->size() > 1)
-        codegenError("verifyCalledWith: overloaded functions are not supported");
-    auto &entry = (*overloads)[0];
+        codegenError("verifyCalledWith: unknown function '" + fnNameInput + "'");
+
+    OverloadEntry *entryPtr = nullptr;
+    if (isSigForm) {
+        std::vector<std::string> wantNorm;
+        wantNorm.reserve(sigParamTypes.size());
+        for (const auto &p : sigParamTypes)
+            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+        for (auto &ov : *overloads) {
+            if (ov.paramTypeNames.size() != wantNorm.size()) continue;
+            bool eq = true;
+            for (size_t i = 0; i < wantNorm.size(); ++i) {
+                if (resolveTypeAlias(trimTypeNameSpaces(ov.paramTypeNames[i]))
+                        != wantNorm[i]) {
+                    eq = false; break;
+                }
+            }
+            if (eq) { entryPtr = &ov; break; }
+        }
+        if (!entryPtr) {
+            std::string msg = "verifyCalledWith: no overload of '" + bareName +
+                "' matches signature '" + fnNameInput + "'. Available:";
+            for (const auto &ov : *overloads)
+                msg += "\n  - " + buildCanonicalSig(bareName, ov.paramTypeNames);
+            codegenError(msg);
+        }
+    } else if (overloads->size() == 1) {
+        entryPtr = &(*overloads)[0];
+    } else {
+        // Bare + overloaded: pick the overload whose arity matches the supplied
+        // arg count. Ambiguous (multiple matches) requires sig form.
+        const size_t suppliedArgs = e.args.size() - 1;
+        OverloadEntry *match = nullptr;
+        int matchCount = 0;
+        for (auto &ov : *overloads) {
+            if (ov.paramTypes.size() == suppliedArgs) { match = &ov; ++matchCount; }
+        }
+        if (matchCount != 1) {
+            std::string msg = "verifyCalledWith: '" + bareName +
+                "' is overloaded; ";
+            msg += (matchCount == 0)
+                ? "no overload accepts " + std::to_string(suppliedArgs) + " argument(s)."
+                : "multiple overloads accept " + std::to_string(suppliedArgs) +
+                  " argument(s).";
+            msg += " Use signature form: verifyCalledWith(\"" + bareName +
+                "(T1, T2)\", ...). Available:";
+            for (const auto &ov : *overloads)
+                msg += "\n  - " + buildCanonicalSig(bareName, ov.paramTypeNames);
+            codegenError(msg);
+        }
+        entryPtr = match;
+    }
+    auto &entry = *entryPtr;
+    const std::string canonicalSig = buildCanonicalSig(bareName, entry.paramTypeNames);
+    const std::string &fnName = bareName;
+
+    if (!mocked_functions_.count(canonicalSig) && !spied_functions_.count(canonicalSig))
+        codegenError("verifyCalledWith: '" + fnName + "' is not mocked or spied");
 
     const size_t expectedNumArgs = e.args.size() - 1;
     if (expectedNumArgs != entry.paramTypes.size())
@@ -1555,9 +2012,9 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                      " argument(s) for '" + fnName + "', got " +
                      std::to_string(expectedNumArgs));
 
-    // Cache global string for the function name.
-    auto &nameStr = mock_name_strings_[fnName];
-    if (!nameStr) nameStr = cachedGlobalString(fnName, ".mock." + fnName);
+    // Cache global string for the function name (keyed by canonical sig).
+    auto &nameStr = mock_name_strings_[canonicalSig];
+    if (!nameStr) nameStr = cachedGlobalString(canonicalSig, ".mock." + canonicalSig);
 
     // Allocate kinds[] and values[] arrays sized to expectedNumArgs.
     llvm::Value *numArgsConst = llvm::ConstantInt::get(i64Ty_, expectedNumArgs);

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -973,6 +973,172 @@ void CodeGen::emitNativeSpyCall(CallStmt &s,
     }
 }
 
+// mockReturnValueOnce support for @native overloads (#1682). Mirrors the
+// user-fn path in emitMockReturnValueOnceCall but resolves the overload from
+// NativeFnSignature rather than OverloadEntry. __ry_mock_register_once is
+// polymorphic on canonical sig, and __ry_mock_get (called by both table-driven
+// and customEmitter native intercepts) consumes the once_queue regardless of
+// dispatch path — so wiring stops at register-time.
+void CodeGen::emitNativeMockReturnValueOnceCall(
+    CallStmt &s,
+    const std::string &bareName,
+    const std::string &fnNameInput,
+    bool isSigForm,
+    const std::vector<std::string> &sigParamTypes,
+    const std::vector<const NativeFnSignature*> &nativeSigs) {
+    auto sigParamNames = [](const NativeFnSignature *sig) {
+        std::vector<std::string> out;
+        out.reserve(sig->params.size());
+        for (const auto &p : sig->params) out.push_back(p.typeName);
+        return out;
+    };
+
+    const NativeFnSignature *target = nullptr;
+    if (isSigForm) {
+        std::vector<std::string> wantNorm;
+        wantNorm.reserve(sigParamTypes.size());
+        for (const auto &p : sigParamTypes)
+            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+        for (const auto *sig : nativeSigs) {
+            if (sig->params.size() != wantNorm.size()) continue;
+            bool eq = true;
+            for (size_t i = 0; i < wantNorm.size(); ++i) {
+                if (resolveTypeAlias(trimTypeNameSpaces(sig->params[i].typeName))
+                        != wantNorm[i]) {
+                    eq = false; break;
+                }
+            }
+            if (eq) { target = sig; break; }
+        }
+        if (!target) {
+            std::string msg = "mockReturnValueOnce(): no overload of '" + bareName +
+                              "' matches signature '" + fnNameInput + "'. Available:";
+            for (const auto *sig : nativeSigs)
+                msg += "\n  - " + buildCanonicalSig(bareName, sigParamNames(sig));
+            codegenError(msg);
+        }
+    } else if (nativeSigs.size() == 1) {
+        target = nativeSigs[0];
+    } else {
+        std::string msg = "mockReturnValueOnce(): '" + bareName +
+            "' is overloaded; return value type alone is ambiguous. "
+            "Specify signature: mockReturnValueOnce(\"" + bareName +
+            "(T1, T2)\", value). Available:";
+        for (const auto *sig : nativeSigs)
+            msg += "\n  - " + buildCanonicalSig(bareName, sigParamNames(sig));
+        codegenError(msg);
+    }
+
+    // cppcheck-suppress nullPointerRedundantCheck
+    llvm::Type *retTy = resolveType(target->returnTypeName);
+    const std::string &retTyName = target->returnTypeName;
+    const std::string &fnName = bareName;
+    std::string resolved = resolveTypeAlias(retTyName);
+
+    if (!retTy || retTy->isVoidTy())
+        codegenError("mockReturnValueOnce(): function '" + fnName +
+                     "' returns Unit; mockReturnValueOnce requires a value-returning function");
+
+    bool supported = (resolved == "int") || (resolved == "float")
+        || (resolved == "bool") || (resolved == "Unit")
+        || isLowLevelTypeName(resolved)
+        || (resolved == "str")
+        || isListTypeName(resolved) || isMapTypeName(resolved) || isSetTypeName(resolved)
+        || (record_types_.count(resolved) > 0)
+        || (resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0)
+        || (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0)
+        || (!resolved.empty() && resolved.back() == '?');
+    if (!supported)
+        codegenError("mockReturnValueOnce(): unsupported return type '" + retTyName +
+                     "' for '" + fnName +
+                     "' (supported: primitives, str, List, Map, Set, Record, Result, Option)");
+
+    llvm::Type *annotOptionInner = nullptr;
+    if (isOptionType(retTy))
+        annotOptionInner = llvm::cast<llvm::StructType>(retTy)->getElementType(1);
+    OptionNoneHintGuard noneHintGuard(*this, annotOptionInner);
+    DeclAnnotationInnerGuard declHintGuard(*this, annotOptionInner);
+
+    llvm::Value *value = nullptr;
+    if (isNoneLiteral(*s.args[1])) {
+        if (!isOptionType(retTy))
+            codegenError("mockReturnValueOnce(): None can only be passed when '"
+                         + fnName + "' returns Option");
+        value = buildNoneValue(retTy);
+    } else {
+        value = emitExpr(*s.args[1]);
+    }
+    if (!value)
+        codegenError("mockReturnValueOnce(): could not evaluate return value");
+    llvm::Type *valTy = value->getType();
+
+    if (valTy != retTy) {
+        if (isOptionType(retTy) && !isOptionType(valTy)) {
+            auto *optTy = llvm::cast<llvm::StructType>(retTy);
+            llvm::Type *innerTy = optTy->getElementType(1);
+            if (valTy != innerTy)
+                codegenError("mockReturnValueOnce(): return value type does not match '"
+                             + fnName + "'");
+            value = buildSomeValue(value, retTy);
+            valTy = retTy;
+        } else if (isResultType(retTy) && isResultType(valTy)) {
+            auto *dstResTy = llvm::cast<llvm::StructType>(retTy);
+            llvm::Value *coerced = coerceResultType(value, dstResTy);
+            if (!coerced)
+                codegenError("mockReturnValueOnce(): return value type does not match '"
+                             + fnName + "'");
+            value = coerced;
+            valTy = retTy;
+        } else if (llvm::Value *lowCoerced = coerceToLowLevelType(value, retTy,
+                                                                  retTyName, "",
+                                                                  "vret.coerce")) {
+            value = lowCoerced;
+            valTy = retTy;
+        }
+    }
+    if (valTy != retTy)
+        codegenError("mockReturnValueOnce(): return value type does not match '"
+                     + fnName + "'");
+
+    const llvm::DataLayout &dl = mod_->getDataLayout();
+    uint64_t retSize = dl.getTypeAllocSize(retTy);
+    if (retSize == 0) retSize = 1;
+    auto *envHdr = emitArcAlloc(llvm::ConstantInt::get(i64Ty_, retSize));
+    auto *envData = emitArcGetDataPtr(envHdr);
+
+    retainValueReturnResult(value, retTy, retTyName);
+    builder_.CreateStore(value, envData);
+
+    emitArcRetain(envHdr, false);
+
+    const std::string canonicalSig = buildCanonicalSig(bareName, sigParamNames(target));
+    mocked_functions_.insert(canonicalSig);
+
+    auto &nameStr = mock_name_strings_[canonicalSig];
+    if (!nameStr) nameStr = cachedGlobalString(canonicalSig, ".mock." + canonicalSig);
+
+    // Build the thunk's param-type list from NativeFnSignature.
+    std::vector<llvm::Type*> paramTypes;
+    paramTypes.reserve(target->params.size());
+    for (const auto &p : target->params)
+        paramTypes.push_back(resolveType(p.typeName));
+    llvm::Function *thunk =
+        getOrCreateNativeValueReturnThunk(canonicalSig, paramTypes, retTy, retTyName);
+
+    auto envDtorCallee = getOrCreateValueReturnEnvDestructor(retTy, retTyName);
+    auto *nullPtr = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
+    llvm::Value *envDtorVal = envDtorCallee
+        ? llvm::cast<llvm::Value>(envDtorCallee.getCallee())
+        : llvm::cast<llvm::Value>(nullPtr);
+
+    llvm::FunctionType *registerOnceTy = llvm::FunctionType::get(
+        llvm::Type::getVoidTy(*ctx_),
+        {ptrTy_, ptrTy_, ptrTy_, ptrTy_}, false);
+    llvm::FunctionCallee registerOnceFn = mod_->getOrInsertFunction(
+        "__ry_mock_register_once", registerOnceTy);
+    builder_.CreateCall(registerOnceFn, {nameStr, thunk, envData, envDtorVal});
+}
+
 // ===== Test: mockReturnValueOnce — per-call value-return queue (#1681) =====
 //
 // Local helper: strip "Option<" or "Result<" prefix and trailing '>', return
@@ -1131,29 +1297,22 @@ void CodeGen::releaseValueReturnResult(llvm::Value *val,
     }
 }
 
-llvm::Function *CodeGen::getOrCreateValueReturnThunk(llvm::Function *origFn,
-                                                     const std::string &retTyName) {
-    auto it = value_return_thunk_cache_.find(origFn);
-    if (it != value_return_thunk_cache_.end())
-        return it->second;
-
-    llvm::Type *retTy = origFn->getReturnType();
-
-    // Thunk signature: (origParams..., ptr env) -> retTy. User-supplied params
-    // are ignored — the thunk loads the pre-stored return value from env and
-    // returns it (after a +1 retain so the caller's reference is independent
-    // of env lifetime).
-    std::vector<llvm::Type*> thunkParams;
-    for (auto &p : origFn->args())
-        thunkParams.push_back(p.getType());
+llvm::Function *CodeGen::buildValueReturnThunk(
+    const std::string &symbolName,
+    const std::vector<llvm::Type*> &paramTypes,
+    llvm::Type *retTy,
+    const std::string &retTyName) {
+    // Thunk signature: (declaredParams..., ptr env) -> retTy. User-supplied
+    // params are ignored — the thunk loads the pre-stored return value from
+    // env and returns it (after a +1 retain so the caller's reference is
+    // independent of env lifetime).
+    std::vector<llvm::Type*> thunkParams = paramTypes;
     thunkParams.push_back(ptrTy_);
     auto *thunkTy = llvm::FunctionType::get(retTy, thunkParams, false);
 
-    std::string name = "__ry_uc_vret_" + origFn->getName().str();
     auto *thunk = llvm::Function::Create(
-        thunkTy, llvm::Function::InternalLinkage, name, mod_.get());
+        thunkTy, llvm::Function::InternalLinkage, symbolName, mod_.get());
     thunk->addFnAttr(llvm::Attribute::NoUnwind);
-    value_return_thunk_cache_[origFn] = thunk;
 
     auto *savedBB = builder_.GetInsertBlock();
     auto savedPt = builder_.GetInsertPoint();
@@ -1164,7 +1323,7 @@ llvm::Function *CodeGen::getOrCreateValueReturnThunk(llvm::Function *origFn,
     if (retTy->isVoidTy()) {
         builder_.CreateRetVoid();
     } else {
-        llvm::Value *envPtr = thunk->getArg(static_cast<unsigned>(origFn->arg_size()));
+        llvm::Value *envPtr = thunk->getArg(static_cast<unsigned>(paramTypes.size()));
         auto *result = builder_.CreateLoad(retTy, envPtr, "vret.val");
         retainValueReturnResult(result, retTy, retTyName);
         builder_.CreateRet(result);
@@ -1173,6 +1332,50 @@ llvm::Function *CodeGen::getOrCreateValueReturnThunk(llvm::Function *origFn,
     if (savedBB)
         builder_.SetInsertPoint(savedBB, savedPt);
 
+    return thunk;
+}
+
+llvm::Function *CodeGen::getOrCreateValueReturnThunk(llvm::Function *origFn,
+                                                     const std::string &retTyName) {
+    auto it = value_return_thunk_cache_.find(origFn);
+    if (it != value_return_thunk_cache_.end())
+        return it->second;
+
+    std::vector<llvm::Type*> paramTypes;
+    paramTypes.reserve(origFn->arg_size());
+    for (auto &p : origFn->args())
+        paramTypes.push_back(p.getType());
+    llvm::Type *retTy = origFn->getReturnType();
+
+    std::string name = "__ry_uc_vret_" + origFn->getName().str();
+    auto *thunk = buildValueReturnThunk(name, paramTypes, retTy, retTyName);
+    value_return_thunk_cache_[origFn] = thunk;
+    return thunk;
+}
+
+llvm::Function *CodeGen::getOrCreateNativeValueReturnThunk(
+    const std::string &canonicalSig,
+    const std::vector<llvm::Type*> &paramTypes,
+    llvm::Type *retTy,
+    const std::string &retTyName) {
+    auto it = value_return_thunk_native_cache_.find(canonicalSig);
+    if (it != value_return_thunk_native_cache_.end())
+        return it->second;
+
+    // Sanitize sig into a symbol-safe suffix. Collisions are rare and would
+    // produce duplicate-symbol link errors which are easy to diagnose.
+    std::string suffix;
+    suffix.reserve(canonicalSig.size());
+    for (char c : canonicalSig) {
+        if ((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+            (c >= '0' && c <= '9') || c == '_')
+            suffix.push_back(c);
+        else
+            suffix.push_back('_');
+    }
+    std::string name = "__ry_uc_vret_native_" + suffix;
+    auto *thunk = buildValueReturnThunk(name, paramTypes, retTy, retTyName);
+    value_return_thunk_native_cache_[canonicalSig] = thunk;
     return thunk;
 }
 
@@ -1257,8 +1460,19 @@ void CodeGen::emitMockReturnValueOnceCall(CallStmt &s) {
     if (!isSigForm) bareName = fnNameInput;
 
     auto *fitOverloads = findFunction(bareName);
-    if (!fitOverloads)
-        codegenError("mockReturnValueOnce(): unknown function '" + fnNameInput + "'");
+    if (!fitOverloads) {
+        // #1682: @native overloads (e.g. math.digits) miss findFunction —
+        // delegate to the parallel native-fn mockReturnValueOnce path. The
+        // runtime once_queue is polymorphic on canonical sig, so existing
+        // table-driven and customEmitter intercepts consume it without extra
+        // wiring on the dispatch side.
+        auto nativeSigs = collectNativeSigsByBareName(bareName);
+        if (nativeSigs.empty())
+            codegenError("mockReturnValueOnce(): unknown function '" + fnNameInput + "'");
+        emitNativeMockReturnValueOnceCall(s, bareName, fnNameInput,
+                                           isSigForm, sigParamTypes, nativeSigs);
+        return;
+    }
 
     OverloadEntry *entryPtr = nullptr;
     if (isSigForm) {
@@ -1945,8 +2159,20 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
     if (!isSigForm) bareName = fnNameInput;
 
     auto *overloads = findFunction(bareName);
-    if (!overloads || overloads->empty())
+    if (!overloads || overloads->empty()) {
+        // #1682: @native overloads (e.g. math.digits) miss findFunction.
+        // Argument recording for @native is intentionally deferred in v1 —
+        // see codegen_call_native.cpp:797 and docs/reference/testing.md
+        // 'Native (@native) overloads' note. Count-based verify("name")
+        // still works since it goes through __ry_mock_count_matching_calls.
+        auto nativeSigs = collectNativeSigsByBareName(bareName);
+        if (!nativeSigs.empty())
+            codegenError("verifyCalledWith: argument recording for @native overloads "
+                         "(e.g. math.digits) is not supported in v1; only count-based "
+                         "verify(\"" + fnNameInput + "\") works (see "
+                         "docs/reference/testing.md 'Native (@native) overloads' note)");
         codegenError("verifyCalledWith: unknown function '" + fnNameInput + "'");
+    }
 
     OverloadEntry *entryPtr = nullptr;
     if (isSigForm) {

--- a/src/test_runtime.cpp
+++ b/src/test_runtime.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <unistd.h>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 
@@ -188,6 +189,35 @@ struct MockEntry {
     std::vector<MockFnSnapshot *> retained_fn_snapshots;
 };
 static std::unordered_map<std::string, MockEntry> g_mock_registry;
+
+// Bare-name → set of canonical sig keys (#1682). Lets aggregate ops
+// (verify("foo") / mockClear("foo")) collect every overload registered under
+// `foo` when the user passes the bare name and no exact-sig entry exists.
+// Updated in lockstep with g_mock_registry inserts / erases.
+static std::unordered_map<std::string, std::unordered_set<std::string>>
+    g_mock_name_index;
+
+// Split "name(T1, T2)" at the first '(' to recover the bare name. Inputs
+// without parens are returned unchanged (bare-name lookups stay as-is).
+static std::string extractBareName(const std::string &key) {
+    const size_t pos = key.find('(');
+    if (pos == std::string::npos) return key;
+    return key.substr(0, pos);
+}
+
+static void mockIndexInsert(const std::string &key) {
+    if (key.find('(') == std::string::npos) return;
+    g_mock_name_index[extractBareName(key)].insert(key);
+}
+
+static void mockIndexErase(const std::string &key) {
+    if (key.find('(') == std::string::npos) return;
+    const std::string bare = extractBareName(key);
+    auto it = g_mock_name_index.find(bare);
+    if (it == g_mock_name_index.end()) return;
+    it->second.erase(key);
+    if (it->second.empty()) g_mock_name_index.erase(it);
+}
 
 // Lightweight retain/release for str handles inside the mock registry.
 // We do not link against the codegen-emitted IR retain/release helpers from
@@ -629,6 +659,7 @@ void __ry_mock_set(const char *name, void *fn_ptr) {
     entry.fn_ptr = fn_ptr;
     entry.env_ptr = nullptr;
     entry.env_dtor = nullptr;
+    mockIndexInsert(name);
 }
 
 // Create-if-absent registration for spy(). Unlike __ry_mock_set, this does NOT
@@ -637,6 +668,7 @@ void __ry_mock_set(const char *name, void *fn_ptr) {
 // call_count and retained_str_args are also preserved.
 void __ry_spy_register(const char *name) {
     (void)g_mock_registry[name];
+    mockIndexInsert(name);
 }
 
 void __ry_mock_set_closure(const char *name, void *thunk_ptr,
@@ -647,6 +679,7 @@ void __ry_mock_set_closure(const char *name, void *thunk_ptr,
     entry.fn_ptr = thunk_ptr;
     entry.env_ptr = env_ptr;
     entry.env_dtor = env_dtor;
+    mockIndexInsert(name);
 }
 
 // Append a per-call binding to the once-queue (#1681). Ownership of env_ptr
@@ -657,23 +690,52 @@ void __ry_mock_register_once(const char *name, void *thunk_ptr,
                               void *env_ptr, void (*env_dtor)(void *)) {
     auto &entry = g_mock_registry[name];
     entry.once_queue.push_back(MockBinding{thunk_ptr, env_ptr, env_dtor});
+    mockIndexInsert(name);
 }
 
 // Jest-compatible mockClear: reset call log/count, preserve default mock
-// AND once-queue. Use mockReset to wipe the queue.
+// AND once-queue. Use mockReset to wipe the queue. When `name` is the bare
+// fn name (no parens) and no exact-sig entry exists, aggregate across every
+// canonical sig recorded under that bare name (#1682).
 void __ry_mock_clear(const char *name) {
     auto it = g_mock_registry.find(name);
-    if (it == g_mock_registry.end()) return;
-    releaseMockEntryRetainedArgs(it->second);
+    if (it != g_mock_registry.end()) {
+        releaseMockEntryRetainedArgs(it->second);
+        return;
+    }
+    auto idxIt = g_mock_name_index.find(name);
+    if (idxIt == g_mock_name_index.end()) return;
+    for (const auto &sig : idxIt->second) {
+        auto sigIt = g_mock_registry.find(sig);
+        if (sigIt != g_mock_registry.end())
+            releaseMockEntryRetainedArgs(sigIt->second);
+    }
 }
 
 void __ry_mock_reset(const char *name) {
     auto it = g_mock_registry.find(name);
-    if (it == g_mock_registry.end()) return;
-    mockReleaseClosureEnv(it->second.env_ptr, it->second.env_dtor);
-    releaseMockOnceQueue(it->second);
-    releaseMockEntryRetainedArgs(it->second);
-    g_mock_registry.erase(it);
+    if (it != g_mock_registry.end()) {
+        mockReleaseClosureEnv(it->second.env_ptr, it->second.env_dtor);
+        releaseMockOnceQueue(it->second);
+        releaseMockEntryRetainedArgs(it->second);
+        const std::string keyCopy = it->first;
+        g_mock_registry.erase(it);
+        mockIndexErase(keyCopy);
+        return;
+    }
+    auto idxIt = g_mock_name_index.find(name);
+    if (idxIt == g_mock_name_index.end()) return;
+    // Copy keys before erasing — mockIndexErase mutates the set we iterate.
+    std::vector<std::string> sigs(idxIt->second.begin(), idxIt->second.end());
+    for (const auto &sig : sigs) {
+        auto sigIt = g_mock_registry.find(sig);
+        if (sigIt == g_mock_registry.end()) continue;
+        mockReleaseClosureEnv(sigIt->second.env_ptr, sigIt->second.env_dtor);
+        releaseMockOnceQueue(sigIt->second);
+        releaseMockEntryRetainedArgs(sigIt->second);
+        g_mock_registry.erase(sigIt);
+    }
+    g_mock_name_index.erase(name);
 }
 
 // Queue-consuming dispatch (#1681). Each call pops one binding from
@@ -719,7 +781,16 @@ void *__ry_mock_get_env(const char *name) {
 int64_t __ry_mock_get_call_count(const char *name) {
     auto it = g_mock_registry.find(name);
     if (it != g_mock_registry.end()) return it->second.call_count;
-    return 0;
+    // Aggregate fallback (#1682): bare-name lookup sums every overload's
+    // call_count when no exact-sig entry exists.
+    auto idxIt = g_mock_name_index.find(name);
+    if (idxIt == g_mock_name_index.end()) return 0;
+    int64_t total = 0;
+    for (const auto &sig : idxIt->second) {
+        auto sigIt = g_mock_registry.find(sig);
+        if (sigIt != g_mock_registry.end()) total += sigIt->second.call_count;
+    }
+    return total;
 }
 
 void __ry_mock_increment_call(const char *name) {
@@ -1112,10 +1183,25 @@ static bool mockArgEqual(const MockArg &recorded, int64_t expectedKind,
 int64_t __ry_mock_count_matching_calls(const char *name, int64_t numArgs,
                                         const int64_t *kinds,
                                         const int64_t *values) {
-    auto it = g_mock_registry.find(name);
+    // Collect every registry entry to inspect: exact-sig hit when registered
+    // under canonical sig; otherwise bare-name index aggregation (#1682).
+    std::vector<MockEntry *> entries;
+    auto exactIt = g_mock_registry.find(name);
+    if (exactIt != g_mock_registry.end()) {
+        entries.push_back(&exactIt->second);
+    } else {
+        auto idxIt = g_mock_name_index.find(name);
+        if (idxIt != g_mock_name_index.end()) {
+            for (const auto &sig : idxIt->second) {
+                auto sigIt = g_mock_registry.find(sig);
+                if (sigIt != g_mock_registry.end())
+                    entries.push_back(&sigIt->second);
+            }
+        }
+    }
     int64_t matched = 0;
-    if (it != g_mock_registry.end()) {
-        for (const auto &call : it->second.calls) {
+    for (MockEntry *entry : entries) {
+        for (const auto &call : entry->calls) {
             if (static_cast<int64_t>(call.args.size()) != numArgs) continue;
             bool ok = true;
             for (int64_t i = 0; i < numArgs; ++i) {
@@ -1162,6 +1248,7 @@ void __ry_mock_clear_all() {
         releaseMockEntryRetainedArgs(entry);
     }
     g_mock_registry.clear();
+    g_mock_name_index.clear();
 }
 
 // ===== Property-based test support =====

--- a/tests/spec/mock_overload.test.ry
+++ b/tests/spec/mock_overload.test.ry
@@ -1,0 +1,123 @@
+from testing import it, describe, expect, mock, mockReturnValueOnce, verify, verifyCalledWith, spy, mockClear, mockReset, mockResetAll, fail
+from math import digits, abs, pow, floor
+
+fn addNum(a: int, b: int) -> int:
+  return a + b
+
+fn addNum(a: float, b: float) -> float:
+  return a + b
+
+fn addNum(a: int, b: int, c: int) -> int:
+  return a + b + c
+
+fn nullary() -> int:
+  return 7
+
+@describe("mock overloaded fns - signature form")
+fn mockOverloadSigTests():
+  @it("mock with explicit signature dispatches by sig key")
+  fn mockSigBasic():
+    mock("addNum(int, int)", (x: int, y: int) => 999)
+    expect(addNum(1, 2)).toEq(999)
+    expect(addNum(1.0, 2.0)).toEq(3.0)  # float overload untouched
+    mockResetAll()
+
+  @it("mock different overloads independently")
+  fn mockSigIndependent():
+    mock("addNum(int, int)", (x: int, y: int) => 11)
+    mock("addNum(float, float)", (x: float, y: float) => 22.5)
+    expect(addNum(1, 2)).toEq(11)
+    expect(addNum(1.0, 2.0)).toEq(22.5)
+    mockResetAll()
+
+  @it("mock 3-arg overload by sig")
+  fn mockSigArity():
+    mock("addNum(int, int, int)", (x: int, y: int, z: int) => 100)
+    expect(addNum(1, 2, 3)).toEq(100)
+    expect(addNum(1, 2)).toEq(3)  # 2-arg untouched
+    mockResetAll()
+
+  @it("mock nullary fn with empty paren sig")
+  fn mockSigEmpty():
+    mock("nullary()", () => 42)
+    expect(nullary()).toEq(42)
+    mockResetAll()
+
+@describe("mock overloaded fns - aggregate verify")
+fn mockOverloadVerifyTests():
+  @it("verify(bare_name) sums calls across all overloads")
+  fn verifyBareSum():
+    spy("addNum(int, int)")
+    spy("addNum(float, float)")
+    a = addNum(1, 2)
+    b = addNum(1.0, 2.0)
+    c = addNum(3, 4)
+    expect(verify("addNum(int, int)")).toEq(2)
+    expect(verify("addNum(float, float)")).toEq(1)
+    expect(verify("addNum")).toEq(3)  # aggregate
+    mockResetAll()
+
+  @it("bare spy spies all overloads")
+  fn bareSpyAll():
+    spy("addNum")
+    a = addNum(1, 2)
+    b = addNum(1.0, 2.0)
+    expect(verify("addNum(int, int)")).toEq(1)
+    expect(verify("addNum(float, float)")).toEq(1)
+    expect(verify("addNum")).toEq(2)
+    mockResetAll()
+
+  @it("mockClear(bare_name) clears all overloads")
+  fn bareMockClear():
+    spy("addNum")
+    a = addNum(1, 2)
+    b = addNum(1.0, 2.0)
+    expect(verify("addNum")).toEq(2)
+    mockClear("addNum")
+    expect(verify("addNum")).toEq(0)
+    mockResetAll()
+
+@describe("mock overloaded stdlib (@native customEmitter) fns")
+fn mockNativeCustomEmitterTests():
+  @it("mock math.digits(int) overrides 1-arg overload")
+  fn mockDigitsArity1():
+    mock("digits(int)", (n: int) => [9, 9, 9])
+    expect(digits(0)).toEq([9, 9, 9])
+    # 2-arg overload untouched
+    expect(digits(255, 16)).toEq([15, 15])
+    mockResetAll()
+
+  @it("mock math.digits(int, int) overrides 2-arg overload")
+  fn mockDigitsArity2():
+    mock("digits(int, int)", (n: int, base: int) => [1, 2])
+    expect(digits(255, 16)).toEq([1, 2])
+    # 1-arg overload untouched
+    expect(digits(0)).toEq([0])
+    mockResetAll()
+
+  @it("mock math.abs(int) overrides int overload only")
+  fn mockAbsInt():
+    mock("abs(int)", (x: int) => 42)
+    expect(abs(-5)).toEq(42)
+    expect(abs(-5.0)).toEq(5.0)  # float overload untouched
+    mockResetAll()
+
+  @it("spy(bare_name) on stdlib counts both overloads")
+  fn spyDigitsBare():
+    spy("digits")
+    a = digits(0)
+    b = digits(255, 16)
+    c = digits(123)
+    expect(verify("digits(int)")).toEq(2)
+    expect(verify("digits(int, int)")).toEq(1)
+    expect(verify("digits")).toEq(3)  # aggregate
+    mockResetAll()
+
+@describe("mock overloaded stdlib (@native normal-path) fns")
+fn mockNativeNormalPathTests():
+  @it("mock math.pow(int, int) overrides int overload via normal path")
+  fn mockPowInt():
+    mock("pow(int, int)", (x: int, y: int) => 100)
+    expect(pow(2, 3)).toEq(100)
+    expect(pow(2.0, 3.0)).toEq(8.0)  # float overload untouched
+    mockResetAll()

--- a/tests/test_codegen_mock.cpp
+++ b/tests/test_codegen_mock.cpp
@@ -1083,9 +1083,10 @@ TEST_F(CodeGenTest, SpyNonExistentFunctionError) {
 // spy() on an overloaded function (bare name) is now legal: it registers all overloads
 // aggregately. Previously rejected with "spy: 'compute' is overloaded" (v1 limit, #1682).
 // Flipped per .claude/rules/tests-rejection-tdd.md "Relaxing a rejection branch requires
-// flipping (not deleting) existing EXPECT_THROW tests".
+// flipping (not deleting) existing EXPECT_THROW tests". Augmented with runtime assertions
+// to verify aggregate vs per-overload counts (PR #1777 CodeRabbit nitpick).
 TEST_F(CodeGenTest, SpyOverloadedFunctionAggregates) {
-    EXPECT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+    EXPECT_EQ(runTestSource(withStdlibDirectiveDecls(
         "fn compute(x: int) -> int:\n"
         "    return x\n"
         "fn compute(x: float) -> float:\n"
@@ -1093,10 +1094,15 @@ TEST_F(CodeGenTest, SpyOverloadedFunctionAggregates) {
         "\n"
         "@describe(\"spy ok\")\n"
         "fn spyOk():\n"
-        "    @it(\"aggregates\")\n"
+        "    @it(\"aggregates across both overloads\")\n"
         "    fn aggregates():\n"
         "        spy(\"compute\")\n"
-    )));
+        "        compute(1)\n"
+        "        compute(1.0)\n"
+        "        expect(verify(\"compute(int)\")).toEq(1)\n"
+        "        expect(verify(\"compute(float)\")).toEq(1)\n"
+        "        expect(verify(\"compute\")).toEq(2)\n"
+    )), "spy ok\n  \033[32m+ aggregates across both overloads\033[0m\n\n1 passed, 0 failed, 0 skipped, 0 todo\n");
 }
 
 // Positive control: verifyCalledWith works on a spied function

--- a/tests/test_codegen_mock.cpp
+++ b/tests/test_codegen_mock.cpp
@@ -1080,20 +1080,23 @@ TEST_F(CodeGenTest, SpyNonExistentFunctionError) {
     )), std::exception);
 }
 
-// spy() on an overloaded function -> compile error
-TEST_F(CodeGenTest, SpyOverloadedFunctionError) {
-    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+// spy() on an overloaded function (bare name) is now legal: it registers all overloads
+// aggregately. Previously rejected with "spy: 'compute' is overloaded" (v1 limit, #1682).
+// Flipped per .claude/rules/tests-rejection-tdd.md "Relaxing a rejection branch requires
+// flipping (not deleting) existing EXPECT_THROW tests".
+TEST_F(CodeGenTest, SpyOverloadedFunctionAggregates) {
+    EXPECT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
         "fn compute(x: int) -> int:\n"
         "    return x\n"
         "fn compute(x: float) -> float:\n"
         "    return x\n"
         "\n"
-        "@describe(\"spy err\")\n"
-        "fn spyErr():\n"
-        "    @it(\"errors\")\n"
-        "    fn errors():\n"
+        "@describe(\"spy ok\")\n"
+        "fn spyOk():\n"
+        "    @it(\"aggregates\")\n"
+        "    fn aggregates():\n"
         "        spy(\"compute\")\n"
-    )), std::exception);
+    )));
 }
 
 // Positive control: verifyCalledWith works on a spied function
@@ -1148,7 +1151,9 @@ TEST_F(CodeGenTest, MockReturnValueOnceUnknownFunctionError) {
     )), std::exception);
 }
 
-// mockReturnValueOnce() on an overloaded function (overloads not supported)
+// mockReturnValueOnce() bare-name on an overloaded function is rejected (#1682):
+// return-value type alone cannot disambiguate the overload; signature form
+// `mockReturnValueOnce("over(int)", 1)` is required.
 TEST_F(CodeGenTest, MockReturnValueOnceOverloadedFunctionError) {
     EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
         "fn over(x: int) -> int:\n"
@@ -1161,6 +1166,27 @@ TEST_F(CodeGenTest, MockReturnValueOnceOverloadedFunctionError) {
         "    @it(\"errors\")\n"
         "    fn errors():\n"
         "        mockReturnValueOnce(\"over\", 1)\n"
+    )), std::exception);
+}
+
+// verifyCalledWith() bare-name on an overloaded function whose overloads all
+// share the supplied arity is rejected (#1682): arity alone cannot pinpoint
+// a unique overload; signature form is required. Covers
+// src/codegen_test.cpp `matchCount != 1` branch (matchCount > 1 case).
+TEST_F(CodeGenTest, VerifyCalledWithOverloadedArityAmbiguousError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn over(a: int, b: int) -> int:\n"
+        "    return a + b\n"
+        "fn over(a: float, b: float) -> float:\n"
+        "    return a + b\n"
+        "\n"
+        "@describe(\"vcw amb\")\n"
+        "fn vcwAmb():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mock(\"over(int, int)\", (a: int, b: int) -> int => 0)\n"
+        "        over(1, 2)\n"
+        "        expect(verifyCalledWith(\"over\", 1, 2)).toEq(0)\n"
     )), std::exception);
 }
 
@@ -1241,4 +1267,66 @@ TEST_F(CodeGenTest, MockReturnValueOnceNoneOnNonOptionError) {
         "    fn errors():\n"
         "        mockReturnValueOnce(\"fetchInt\", None)\n"
     )), std::exception);
+}
+
+// ============================================================
+// Signature-string syntax error tests (#1682)
+// `parseSigString` should emit a clear error for malformed sig
+// inputs instead of silently falling through to bare-name lookup
+// (which would yield a misleading "unknown function 'add(int'" message).
+// ============================================================
+
+TEST_F(CodeGenTest, MockSigStringMissingCloseParenError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn greet() -> str:\n"
+        "    return \"hi\"\n"
+        "\n"
+        "@describe(\"sig err\")\n"
+        "fn sigErr():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mock(\"greet(\", () => \"x\")\n"
+    )), std::exception);
+}
+
+TEST_F(CodeGenTest, MockSigStringEmptyNameError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn greet() -> str:\n"
+        "    return \"hi\"\n"
+        "\n"
+        "@describe(\"sig err\")\n"
+        "fn sigErr():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mock(\"()\", () => \"x\")\n"
+    )), std::exception);
+}
+
+TEST_F(CodeGenTest, MockSigStringEmptyParamError) {
+    EXPECT_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn add(x: int, y: int) -> int:\n"
+        "    return x + y\n"
+        "\n"
+        "@describe(\"sig err\")\n"
+        "fn sigErr():\n"
+        "    @it(\"errors\")\n"
+        "    fn errors():\n"
+        "        mock(\"add(int,,int)\", (a: int, b: int) -> int => a)\n"
+    )), std::exception);
+}
+
+// Zero-arg sig form `"name()"` is the valid empty-param case and must NOT
+// be mistaken for an empty-name malformed shape. This positive test guards
+// the `inner.empty() return true` branch in `parseSigString`.
+TEST_F(CodeGenTest, MockSigStringZeroParamAccepted) {
+    EXPECT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "fn greet() -> str:\n"
+        "    return \"hi\"\n"
+        "\n"
+        "@describe(\"sig ok\")\n"
+        "fn sigOk():\n"
+        "    @it(\"accepts zero-param sig\")\n"
+        "    fn acceptsZeroParamSig():\n"
+        "        mock(\"greet()\", () => \"x\")\n"
+    )));
 }


### PR DESCRIPTION
## Summary

Lift the v1 "overloaded functions are not supported" rejection in `mock` / `mockReturnValueOnce` / `spy` / `verifyCalledWith`. The mock registry is now keyed by canonical signature `"name(T1, T2, ...)"`, so each overload has an independent slot. Closes #1682.

### Highlights

- **Signature-form syntax**: `mock("add(int, int)", ...)` targets one overload precisely.
- **Replacement-type auto-dispatch** for `mock()` when the replacement's parameter types uniquely match one overload — bare-name `mock("add", repl)` still works in that case.
- **Bare-name aggregate semantics** for `spy` / `verify` / `verifyCalledWith` / `mockClear` / `mockReset`: bare name spans all overloads.
- **`mockReturnValueOnce` on bare overloaded fns** raises a candidate-listing error (the return type alone cannot disambiguate).
- **Native dispatch** (`math.digits`, `math.abs`, etc.) supported via mock hooks injected into `emitTableDrivenNativeCall`'s normal / variadic / customEmitter paths.

### Behavior shift to flag

`verify("foo")` previously returned the call count for the single `foo`. After this PR, if `foo` later becomes overloaded, `verify("foo")` returns the **sum across all overloads**. Per-overload counts require the sig form. Documented in `changelog.d/1682-overloaded-mock-support.md` and `docs/reference/testing.md`.

## Test plan

- [x] `./build/ry_tests` — 2351 passed (added `VerifyCalledWithOverloadedArityAmbiguousError` regression test)
- [x] `./build/ry test -p` — 191 files, 0 failures (incl. new `tests/spec/mock_overload.test.ry`)
- [x] `./build-asan/ry_tests` + `./build-asan/ry test -p` — clean under ASan + UBSan
- [x] `./build-tsan/ry_tests` — clean (required suite)
- [x] `clang-tidy` — clean
- [x] `cppcheck` — clean (two `nullPointerRedundantCheck` false positives suppressed with site-local justification; codegenError is `[[noreturn]]` but cppcheck does not recognize the attribute)
- [x] Documentation: `docs/reference/testing.md` gains a "Mocking overloaded functions" section; example executed end-to-end as a self-test before commit
- [x] CHANGELOG fragment: `changelog.d/1682-overloaded-mock-support.md` covers Added + Changed
- [x] `/pre-commit-checklist` — §3.6 libFuzzer and §3.6.5 tree-sitter skipped (no parser/lexer/json/utf8/string/grammar changes); recorded above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-overload mocking/spy/verify via canonical signature strings (e.g. "fn(int,float"); native overloads supported where available.

* **Behavior Changes**
  * Bare-name calls now aggregate across overloads for spy/verify/clear/reset; use signature form to target one overload. 
  * mockReturnValueOnce on overloaded names now requires signature-form.
  * verifyCalledWith argument recording for certain native overloads not supported in v1.

* **Documentation**
  * Updated testing docs with signature syntax, semantics, and limitations.

* **Tests**
  * Added tests covering overload targeting, aggregation, errors, and native paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->