### PR TITLE
feat(testing): add @beforeEach / @afterEach / @beforeAll / @afterAll lifecycle hooks (#1686)

### DIFF
--- a/changelog.d/1686-lifecycle-hooks.md
+++ b/changelog.d/1686-lifecycle-hooks.md
@@ -16,8 +16,9 @@
   hook of each kind per describe; lifecycle hooks cannot coexist with
   `@it` / `@describe` / `@timeout` / `@skip` / `@only` / `@todo` /
   `@each` / `@property` on the same function; hooks declared outside
-  a `@describe` are rejected; and hook bodies cannot introduce new
-  named variables (the body is re-emitted per `@it` and the second
-  emission would clash). Known limitation: a test fired by `@timeout`
-  unwinds via `siglongjmp` past the inlined `@afterEach` body, so
-  cleanup runs only on normal completion. (#1686)
+  a `@describe` are rejected; and hook bodies cannot contain
+  top-level declarations (`fn` / `record` / `enum` / type alias /
+  directive / `import`) because re-emission per `@it` would
+  duplicate-register them. Known limitation: a test fired by
+  `@timeout` unwinds via `siglongjmp` past the inlined `@afterEach`
+  body, so cleanup runs only on normal completion. (#1686)

--- a/changelog.d/1686-lifecycle-hooks.md
+++ b/changelog.d/1686-lifecycle-hooks.md
@@ -1,0 +1,23 @@
+### Added
+
+- Added `@beforeEach` / `@afterEach` / `@beforeAll` / `@afterAll`
+  lifecycle hook directives for the testing framework. Each hook is
+  declared on a parameterless, return-typeless function inside a
+  `@describe` block and runs at the corresponding point in the
+  describe's lifecycle: `@beforeAll` once before the first `@it`,
+  `@beforeEach` before every `@it`, `@afterEach` after every `@it`
+  that completes normally, and `@afterAll` once after the last `@it`.
+  Hook bodies are inlined into the describe scope rather than emitted
+  as standalone functions, so they may freely read and reassign
+  describe-scope variables (`@it` bodies, by contrast, capture those
+  variables read-only). `@describe` bodies execute once, so
+  `@beforeEach` mutations accumulate across tests — write an explicit
+  reset if per-test isolation is required. Constraints: at most one
+  hook of each kind per describe; lifecycle hooks cannot coexist with
+  `@it` / `@describe` / `@timeout` / `@skip` / `@only` / `@todo` /
+  `@each` / `@property` on the same function; hooks declared outside
+  a `@describe` are rejected; and hook bodies cannot introduce new
+  named variables (the body is re-emitted per `@it` and the second
+  emission would clash). Known limitation: a test fired by `@timeout`
+  unwinds via `siglongjmp` past the inlined `@afterEach` body, so
+  cleanup runs only on normal completion. (#1686)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -621,6 +621,180 @@ Promoting `@timeout` to TSan-required is gated on either an upstream
 libtsan fix or a redesign that avoids `siglongjmp` from a signal
 handler.
 
+**Composition with `@afterEach`:** when `@timeout` fires mid-test,
+the runtime unwinds via `siglongjmp` past the inlined `@afterEach`
+body, so cleanup runs **only on normal completion**. See `@afterEach`
+below.
+
+### `@beforeEach`
+
+Runs before every `@it` inside the enclosing `@describe`. Used for
+per-test setup (resetting state, allocating fresh fixtures, etc.).
+
+**Defined as:** Declared in `share/std/testing/testing.ry`. Test
+files must add `from testing import beforeEach` at the top (or use
+a wildcard `from testing`).
+
+```ry
+from testing import describe, it, beforeEach, expect
+
+@describe("counter starts fresh each test")
+fn counterTests():
+    counter = 99
+
+    @beforeEach
+    fn reset():
+        counter = 0
+
+    @it("first sees counter == 0 (not 99)")
+    fn first():
+        expect(counter).toEq(0)
+
+    @it("second also sees counter == 0")
+    fn second():
+        expect(counter).toEq(0)
+```
+
+**Supported target:** functions inside a `@describe` body, with no
+parameters and no declared return type.
+
+**Constraints:**
+
+- At most one `@beforeEach` per describe
+- Cannot coexist on the same function with `@it`, `@describe`,
+  `@timeout`, `@skip`, `@only`, `@todo`, `@each`, `@property`, or any
+  other lifecycle hook directive
+- Hooks declared outside a `@describe` (file top-level) are rejected
+- The hook body cannot introduce new named variables (see
+  [Lifecycle Hooks](testing.md#lifecycle-hooks) for the re-emission
+  constraint)
+
+**Implementation:** Hook bodies are not emitted as standalone LLVM
+functions; the AST body is stashed and inlined into the describe
+scope before each `@it` call. Describe-scope variable mutation
+therefore propagates to subsequent `@it` invocations (Ry's
+accumulating semantics — see the testing reference for contrast with
+Jest).
+
+### `@afterEach`
+
+Runs after every `@it` inside the enclosing `@describe` that
+completes **normally**. Used for per-test cleanup.
+
+**Defined as:** Declared in `share/std/testing/testing.ry`.
+
+```ry
+from testing import describe, it, afterEach, expect
+
+@describe("cleanup after each test")
+fn cleanupTests():
+    log = ""
+
+    @afterEach
+    fn appendMarker():
+        log = log + "AE;"
+
+    @it("first test")
+    fn first():
+        expect(log).toEq("")
+
+    @it("second test sees prior afterEach")
+    fn second():
+        expect(log).toEq("AE;")
+```
+
+**Supported target:** functions inside a `@describe` body, with no
+parameters and no declared return type. Same constraints as
+`@beforeEach`.
+
+**Composition with `@timeout`:** when `@timeout` fires for a test,
+the runtime unwinds via `siglongjmp` and the test's `@afterEach`
+body is **skipped**. `@afterEach` runs only when the body completes
+within the timeout budget. Tests that need a cleanup guarantee even
+on timeout must arrange it through external means (e.g. a parent
+process / fixture in the test harness).
+
+**Composition with failing assertions:** when an `expect` fails, the
+test is marked failed but execution within the test body stops at
+the failing assertion. `@afterEach` still runs for the failed test
+because the test function returns normally (the failure is recorded
+via a flag, not an exception).
+
+### `@beforeAll`
+
+Runs **once** before the first `@it` inside the enclosing
+`@describe`. Used for one-time setup that all tests share.
+
+**Defined as:** Declared in `share/std/testing/testing.ry`.
+
+```ry
+from testing import describe, it, beforeAll, expect
+
+@describe("seed shared resource once")
+fn sharedResourceTests():
+    setupCount = 0
+
+    @beforeAll
+    fn seed():
+        setupCount = setupCount + 1
+
+    @it("setupCount == 1")
+    fn first():
+        expect(setupCount).toEq(1)
+
+    @it("setupCount still == 1 (beforeAll did not re-run)")
+    fn second():
+        expect(setupCount).toEq(1)
+```
+
+**Position independence:** `@beforeAll` runs before the first `@it`
+even when declared **after** the `@it` lexically. The describe body
+is scanned for hooks before any tests are emitted.
+
+**Supported target:** functions inside a `@describe` body, with no
+parameters and no declared return type. Same constraints as
+`@beforeEach`.
+
+### `@afterAll`
+
+Runs **once** after the last `@it` inside the enclosing `@describe`.
+Used for one-time teardown.
+
+**Defined as:** Declared in `share/std/testing/testing.ry`.
+
+```ry
+from testing import describe, it, beforeAll, afterAll, expect
+
+@describe("shared handle opened once, closed once")
+fn teardownTests():
+    openCount = 0
+    closeCount = 0
+
+    @beforeAll
+    fn open():
+        openCount = openCount + 1
+
+    @afterAll
+    fn close():
+        closeCount = closeCount + 1
+
+    @it("first test")
+    fn first():
+        expect(openCount).toEq(1)
+
+    @it("second test")
+    fn second():
+        expect(openCount).toEq(1)
+```
+
+**Supported target:** functions inside a `@describe` body, with no
+parameters and no declared return type. Same constraints as
+`@beforeEach`.
+
+**Note:** `@afterAll` runs after the last `@it` regardless of
+whether individual tests failed. It does **not** run if the entire
+test process is terminated by an external signal.
+
 ### `@inline`
 
 Provides inlining hints to the LLVM optimizer. By default, marks the function for aggressive inlining.

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -315,7 +315,7 @@ fn counterTests():
 
 For a describe with `N` tests, hooks run in this order:
 
-```
+```text
 @beforeAll
 (@beforeEach → @it → @afterEach) × N
 @afterAll

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -273,6 +273,86 @@ fn booleansTests():
 
 ---
 
+## Lifecycle Hooks
+
+Four directives — `@beforeEach`, `@afterEach`, `@beforeAll`, `@afterAll` — let you factor common setup/teardown out of every `@it` body. They are declared on parameterless, return-typeless functions inside a `@describe` block; the body is **inlined** into the describe at codegen time and runs in the describe's variable scope.
+
+```ry
+from testing import describe, it, beforeEach, afterEach, beforeAll, afterAll, expect
+
+@describe("counter")
+fn counterTests():
+    counter = 0
+    log = ""
+
+    @beforeAll
+    fn setupAll():
+        log = log + "BA;"
+
+    @beforeEach
+    fn setupEach():
+        counter = counter + 1
+        log = log + "BE;"
+
+    @afterEach
+    fn teardownEach():
+        log = log + "AE;"
+
+    @afterAll
+    fn teardownAll():
+        log = log + "AA;"
+
+    @it("first call sees counter == 1")
+    fn first():
+        expect(counter).toEq(1)
+
+    @it("second call sees counter == 2 (state accumulates)")
+    fn second():
+        expect(counter).toEq(2)
+```
+
+### Execution order
+
+For a describe with `N` tests, hooks run in this order:
+
+```
+@beforeAll
+(@beforeEach → @it → @afterEach) × N
+@afterAll
+```
+
+### Accumulation semantics (differs from Jest)
+
+The `@describe` body executes **once**, not per-test. Variables declared inside the describe are allocated once and live across all tests in the block; `@beforeEach` mutations accumulate across `@it` invocations (the `counter == 1` then `counter == 2` example above). This is intentional and follows from Ry's scope model.
+
+If you need per-test reset semantics, write the reset explicitly:
+
+```ry
+@beforeEach
+fn reset():
+    counter = 0           # explicit reset, not implicit
+```
+
+### Mutability rules
+
+- **Hook bodies** are inlined into the describe scope, so they may freely read and reassign describe-scope variables (`counter = counter + 1` above).
+- **`@it` bodies** are compiled as separate functions that capture describe-scope variables. Captures are read-only — attempting `counter = counter + 1` inside an `@it` body raises `cannot modify captured variable`.
+- A hook body cannot **introduce a new variable** (e.g. `items: List<int> = []`) because hook bodies are re-emitted before every `@it`; the second emission would re-declare the same name and fail with `type annotation not allowed on reassignment`. Declare such variables in the describe scope and have the hook only reassign them.
+
+### Constraints
+
+- A hook function must have no parameters and no declared return type
+- At most one of each hook kind per describe block
+- A function cannot carry two lifecycle directives (e.g. `@beforeEach @afterEach`)
+- A lifecycle hook directive cannot coexist with `@it`, `@describe`, `@timeout`, `@skip`, `@only`, `@todo`, `@each`, or `@property` on the same function
+- Hooks declared outside a `@describe` (file top-level) are rejected
+
+### Interaction with `@timeout`
+
+When `@timeout` fires (the SIGALRM path), the test is aborted via `siglongjmp` past the inlined `@afterEach` body — so `@afterEach` runs only on normal completion. See the [Directives reference](directives.md#timeout) for the underlying mechanism.
+
+---
+
 ## Mocking
 
 ### mock(fnName, replacement)
@@ -766,7 +846,9 @@ it should return error when file is missing
 
 ## Limitations
 
-- `before_each` / `after_each` are not supported
+- File top-level lifecycle hooks (outside any `@describe`) are not supported
+- Nested-describe inheritance of lifecycle hooks is not supported (each `@describe` owns its own hooks)
+- A test fired by `@timeout` (i.e. the test body did not finish within the budget) skips its `@afterEach` — see [Directives reference](directives.md#timeout) for details
 
 ---
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1428,8 +1428,34 @@ public:
     // @each/@property combo) before calling this helper.
     void emitItWithTimeout(int64_t timeoutMs, llvm::Value *descVal,
                            llvm::Function *userFn,
-                           llvm::ArrayRef<llvm::Value*> userArgs);
+                           llvm::ArrayRef<llvm::Value*> userArgs,
+                           std::vector<StmtNode> *afterEachBody);
     void emitDescribeDirective(std::unique_ptr<FnStmt> &s);
+
+    // Lifecycle hooks (#1686): @beforeEach / @afterEach / @beforeAll /
+    // @afterAll. Pre-scanned and AST-rewritten inside emitDescribeDirective —
+    // hook FnStmts are removed from the describe body; @beforeAll / @afterAll
+    // body stmts are spliced to the front / back of the describe body; the
+    // bodies for @beforeEach / @afterEach are moved into the active
+    // DescribeHookContext on describe_hook_stack_, where emitItDirective
+    // inlines them around each test call. The four emit* directive entries
+    // below are defense-in-depth: at normal codegen they are unreachable
+    // because the pre-scan removes the FnStmt; if a user puts a hook fn
+    // outside @describe they emit a clear "must be inside @describe" error.
+    struct DescribeHookContext {
+        std::vector<StmtNode> beforeEach;
+        std::vector<StmtNode> afterEach;
+        std::string beforeEachName;
+        std::string afterEachName;
+    };
+    std::vector<DescribeHookContext> describe_hook_stack_;
+    void emitBeforeEachDirective(std::unique_ptr<FnStmt> &s);
+    void emitAfterEachDirective(std::unique_ptr<FnStmt> &s);
+    void emitBeforeAllDirective(std::unique_ptr<FnStmt> &s);
+    void emitAfterAllDirective(std::unique_ptr<FnStmt> &s);
+    void validateLifecycleHookFnShape(const std::unique_ptr<FnStmt> &s, const char *hookName);
+    void validateLifecycleHookBody(const std::vector<StmtNode> &body, const char *hookName);
+
     void emitEachItLoop(llvm::Value *listPtr, llvm::Type *elemTy, unsigned numFields,
                         const std::string &fmtStr, llvm::Function *testFunc,
                         const std::vector<llvm::Value*> &capturedVals = {});

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -1427,8 +1427,8 @@ public:
     // responsible for arg validation (ms positive integer literal, no
     // @each/@property combo) before calling this helper.
     void emitItWithTimeout(int64_t timeoutMs, llvm::Value *descVal,
-                           llvm::Function *userFn,
-                           llvm::ArrayRef<llvm::Value*> userArgs,
+                           const OverloadEntry &entry,
+                           std::vector<StmtNode> *beforeEachBody,
                            std::vector<StmtNode> *afterEachBody);
     void emitDescribeDirective(std::unique_ptr<FnStmt> &s);
 

--- a/share/std/testing/testing.ry
+++ b/share/std/testing/testing.ry
@@ -35,6 +35,22 @@ fn todo()
 @directive(target=["function"])
 fn timeout(ms: int)
 
+@public
+@directive(target=["function"])
+fn beforeEach()
+
+@public
+@directive(target=["function"])
+fn afterEach()
+
+@public
+@directive(target=["function"])
+fn beforeAll()
+
+@public
+@directive(target=["function"])
+fn afterAll()
+
 @native("testing")
 fn _mockGetCallCount(name: str) -> int
 

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -571,6 +571,25 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         emitDescribeDirective(s);
         return;
     }
+    // Lifecycle hooks (#1686). At normal codegen these are pre-scanned out
+    // by emitDescribeDirective; reaching this dispatch means the hook fn is
+    // outside an @describe and the handler emits a clear diagnostic.
+    if (hasDirective(s->directives, "beforeEach")) {
+        emitBeforeEachDirective(s);
+        return;
+    }
+    if (hasDirective(s->directives, "afterEach")) {
+        emitAfterEachDirective(s);
+        return;
+    }
+    if (hasDirective(s->directives, "beforeAll")) {
+        emitBeforeAllDirective(s);
+        return;
+    }
+    if (hasDirective(s->directives, "afterAll")) {
+        emitAfterAllDirective(s);
+        return;
+    }
 
     emitCoverage(s->loc);
     emitTraceSymbolDefine("fn", s->name, s->loc);

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -520,47 +520,48 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
         codegenError("@it: internal error — fn '" + s->name + "' not found after emit");
     const auto &entry = overloads->back();
 
-    // @beforeEach inline (#1686). Must run BEFORE loadCapturedArgs so any
-    // describe-scope variable that the hook mutates is observed by the test
-    // through its captured copy.
-    if (!describe_hook_stack_.empty()) {
-        for (auto &stmt : describe_hook_stack_.back().beforeEach)
-            std::visit([this](auto &st) { emitStmt(st); }, stmt);
-    }
-
-    auto capturedArgs = loadCapturedArgs(entry, "@it");
-
     llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+    std::vector<StmtNode> *beforeEachBody =
+        (!describe_hook_stack_.empty() && !describe_hook_stack_.back().beforeEach.empty())
+            ? &describe_hook_stack_.back().beforeEach
+            : nullptr;
     std::vector<StmtNode> *afterEachBody =
         (!describe_hook_stack_.empty() && !describe_hook_stack_.back().afterEach.empty())
             ? &describe_hook_stack_.back().afterEach
             : nullptr;
     if (hasTimeout) {
-        // @afterEach is inlined inside emitItWithTimeout's normalBB so it
-        // runs on natural completion within the timeout window. The SIGALRM
-        // siglongjmp path (timeoutBB) intentionally skips @afterEach because
-        // we cannot guarantee user-code state is consistent after the
-        // cross-stack jump; documented as a known limitation.
-        emitItWithTimeout(timeoutMs, descVal, entry.func, capturedArgs, afterEachBody);
+        // @beforeEach / @afterEach are inlined inside emitItWithTimeout's
+        // normalBB between begin and end, so hook failures attribute to the
+        // current @it via __ry_test_record_fail. The SIGALRM siglongjmp path
+        // (timeoutBB) intentionally skips BOTH hooks because cross-stack
+        // jump can leave user state inconsistent; documented as a known
+        // limitation.
+        emitItWithTimeout(timeoutMs, descVal, entry, beforeEachBody, afterEachBody);
         return;
     }
+    // Inline @beforeEach / user fn / @afterEach INSIDE the it_begin/it_end
+    // window so any expect failure inside a hook is recorded against the
+    // current @it slot set by __ry_test_it_begin (#1686). @beforeEach runs
+    // BEFORE loadCapturedArgs so describe-scope variables it mutates are
+    // observed by the test through its captured copies.
     auto [itBeginFn, itEndFn] = getTestItFunctions();
     builder_.CreateCall(itBeginFn, {descVal});
+    if (beforeEachBody) {
+        for (auto &stmt : *beforeEachBody)
+            std::visit([this](auto &st) { emitStmt(st); }, stmt);
+    }
+    auto capturedArgs = loadCapturedArgs(entry, "@it");
     builder_.CreateCall(entry.func, capturedArgs);
-    builder_.CreateCall(itEndFn);
-
-    // @afterEach inline. Runs after every test that completes (success or
-    // expect-failure recorded via __ry_test_record_fail); failure does not
-    // unwind because Ry has no exception-style control flow at this layer.
     if (afterEachBody) {
         for (auto &stmt : *afterEachBody)
             std::visit([this](auto &st) { emitStmt(st); }, stmt);
     }
+    builder_.CreateCall(itEndFn);
 }
 
 void CodeGen::emitItWithTimeout(int64_t timeoutMs, llvm::Value *descVal,
-                                 llvm::Function *userFn,
-                                 llvm::ArrayRef<llvm::Value*> userArgs,
+                                 const OverloadEntry &entry,
+                                 std::vector<StmtNode> *beforeEachBody,
                                  std::vector<StmtNode> *afterEachBody) {
     llvm::FunctionType *voidStrI64Ty = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*ctx_), {ptrTy_, i64Ty_}, false);
@@ -601,17 +602,22 @@ void CodeGen::emitItWithTimeout(int64_t timeoutMs, llvm::Value *descVal,
     builder_.SetInsertPoint(normalBB);
     builder_.CreateCall(beginFn,
         {descVal, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(timeoutMs))});
-    builder_.CreateCall(userFn, userArgs);
-    builder_.CreateCall(endFn);
-    // @afterEach inline on the normal-completion path (#1686): the test
-    // finished within the timeout window, so user state is consistent and
-    // cleanup is safe. The timeoutBB path below intentionally skips this —
-    // SIGALRM siglongjmp tears across the C++ stack and there is no way to
-    // guarantee user-code invariants for the cleanup body.
+    // Inline @beforeEach / user fn / @afterEach INSIDE the begin/end window
+    // on the normal-completion path (#1686) so hook expect failures attribute
+    // to the current @it via __ry_test_record_fail. The timeoutBB path below
+    // intentionally skips all three — SIGALRM siglongjmp tears across the C++
+    // stack and there is no way to guarantee user-code invariants.
+    if (beforeEachBody) {
+        for (auto &stmt : *beforeEachBody)
+            std::visit([this](auto &st) { emitStmt(st); }, stmt);
+    }
+    auto capturedArgs = loadCapturedArgs(entry, "@it");
+    builder_.CreateCall(entry.func, capturedArgs);
     if (afterEachBody) {
         for (auto &stmt : *afterEachBody)
             std::visit([this](auto &st) { emitStmt(st); }, stmt);
     }
+    builder_.CreateCall(endFn);
     builder_.CreateBr(afterBB);
 
     builder_.SetInsertPoint(timeoutBB);
@@ -858,41 +864,39 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
         else          ++it;
     }
 
-    // Splice @beforeAll body immediately BEFORE the first @it / @describe;
-    // @afterAll body immediately AFTER the last @it / @describe. This makes
-    // the hook position independent of where in the source the user declared
-    // it (it still runs before / after all tests) while preserving the
-    // describe-scope let-bindings declared before the tests — splicing at
-    // the very start would break `counter = 0` followed by
-    // `@beforeAll fn s(): counter = counter + 1` because the hook body
-    // would reference `counter` before its alloca exists. If the describe
-    // body contains no @it / @describe at all, the hook bodies fall back to
-    // start / end of body (semantics is irrelevant — nothing runs anyway).
-    auto isTestStmt = [](const StmtNode &stmt) {
+    // Splice @beforeAll body immediately BEFORE the first direct-child @it;
+    // @afterAll body immediately AFTER the last direct-child @it. Anchoring
+    // on @it only (not nested @describe) keeps hooks scoped to the current
+    // describe — MVP does not propagate to nested describes (#1686 follow-up).
+    // Splicing after the bindings preserves describe-scope let-bindings
+    // declared before the tests: `counter = 0` followed by
+    // `@beforeAll fn s(): counter = counter + 1` works because the hook body
+    // sees `counter`'s alloca. If the describe contains no direct @it, the
+    // hook bodies are dropped entirely — the describe body is still emitted
+    // and called, so splicing the hooks would run their side effects with
+    // no test attribution.
+    auto isItStmt = [](const StmtNode &stmt) {
         const auto *fnp = std::get_if<std::unique_ptr<FnStmt>>(&stmt);
         if (!fnp) return false;
-        return hasDirective((*fnp)->directives, "it") ||
-               hasDirective((*fnp)->directives, "describe");
+        return hasDirective((*fnp)->directives, "it");
     };
-    size_t firstTestIdx = s->body.size();
-    size_t lastTestIdx = 0;
-    bool sawTest = false;
+    size_t firstItIdx = s->body.size();
+    size_t lastItIdx = 0;
+    bool sawIt = false;
     for (size_t i = 0; i < s->body.size(); ++i) {
-        if (isTestStmt(s->body[i])) {
-            if (!sawTest) { firstTestIdx = i; sawTest = true; }
-            lastTestIdx = i;
+        if (isItStmt(s->body[i])) {
+            if (!sawIt) { firstItIdx = i; sawIt = true; }
+            lastItIdx = i;
         }
     }
-    if (!beforeAllBody.empty()) {
-        const size_t insertAt = sawTest ? firstTestIdx : 0;
-        s->body.insert(s->body.begin() + static_cast<std::ptrdiff_t>(insertAt),
+    if (sawIt && !beforeAllBody.empty()) {
+        s->body.insert(s->body.begin() + static_cast<std::ptrdiff_t>(firstItIdx),
                        std::make_move_iterator(beforeAllBody.begin()),
                        std::make_move_iterator(beforeAllBody.end()));
-        if (sawTest) lastTestIdx += beforeAllBody.size();
+        lastItIdx += beforeAllBody.size();
     }
-    if (!afterAllBody.empty()) {
-        const size_t insertAt = sawTest ? lastTestIdx + 1 : s->body.size();
-        s->body.insert(s->body.begin() + static_cast<std::ptrdiff_t>(insertAt),
+    if (sawIt && !afterAllBody.empty()) {
+        s->body.insert(s->body.begin() + static_cast<std::ptrdiff_t>(lastItIdx + 1),
                        std::make_move_iterator(afterAllBody.begin()),
                        std::make_move_iterator(afterAllBody.end()));
     }

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -2,7 +2,9 @@
 #include "ry/diagnostic.hpp"
 #include <algorithm>
 #include <cmath>
+#include <cstring>
 #include <initializer_list>
+#include <iterator>
 #include <llvm/IR/Intrinsics.h>
 #include <llvm/IR/Verifier.h>
 #include <llvm/Support/raw_ostream.h>
@@ -419,6 +421,20 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     const bool hasTimeout = hasDirective(s->directives, "timeout");
     const bool implicitSkip = file_has_only_directive_ && !hasOnly && !hasTodo && !hasSkip;
 
+    // Lifecycle-hook × per-iteration combo (#1686): @each / @property fire
+    // the test body N times in a runtime loop; integrating @beforeEach /
+    // @afterEach per-iteration would be MVP+ scope. For now reject the
+    // combination at validation time so the user does not silently get
+    // "@beforeEach runs once before the @each loop" semantics.
+    const bool hasActiveHooks = !describe_hook_stack_.empty() &&
+        (!describe_hook_stack_.back().beforeEach.empty() ||
+         !describe_hook_stack_.back().afterEach.empty());
+    if (hasActiveHooks && (hasEach || hasProperty)) {
+        const char *which = hasEach ? "@each" : "@property";
+        codegenError(std::string("@beforeEach / @afterEach are not yet supported with ") + which +
+                     " on @it '" + s->name + "'");
+    }
+
     // Validate @timeout (#1688): positive int literal, no @each / @property
     // combo. @skip / @todo / @only are checked below in dedicated branches.
     int64_t timeoutMs = 0;
@@ -503,22 +519,49 @@ void CodeGen::emitItDirective(std::unique_ptr<FnStmt> &s) {
     if (!overloads || overloads->empty())
         codegenError("@it: internal error — fn '" + s->name + "' not found after emit");
     const auto &entry = overloads->back();
+
+    // @beforeEach inline (#1686). Must run BEFORE loadCapturedArgs so any
+    // describe-scope variable that the hook mutates is observed by the test
+    // through its captured copy.
+    if (!describe_hook_stack_.empty()) {
+        for (auto &stmt : describe_hook_stack_.back().beforeEach)
+            std::visit([this](auto &st) { emitStmt(st); }, stmt);
+    }
+
     auto capturedArgs = loadCapturedArgs(entry, "@it");
 
     llvm::Value *descVal = cachedGlobalString(desc, ".it_desc");
+    std::vector<StmtNode> *afterEachBody =
+        (!describe_hook_stack_.empty() && !describe_hook_stack_.back().afterEach.empty())
+            ? &describe_hook_stack_.back().afterEach
+            : nullptr;
     if (hasTimeout) {
-        emitItWithTimeout(timeoutMs, descVal, entry.func, capturedArgs);
+        // @afterEach is inlined inside emitItWithTimeout's normalBB so it
+        // runs on natural completion within the timeout window. The SIGALRM
+        // siglongjmp path (timeoutBB) intentionally skips @afterEach because
+        // we cannot guarantee user-code state is consistent after the
+        // cross-stack jump; documented as a known limitation.
+        emitItWithTimeout(timeoutMs, descVal, entry.func, capturedArgs, afterEachBody);
         return;
     }
     auto [itBeginFn, itEndFn] = getTestItFunctions();
     builder_.CreateCall(itBeginFn, {descVal});
     builder_.CreateCall(entry.func, capturedArgs);
     builder_.CreateCall(itEndFn);
+
+    // @afterEach inline. Runs after every test that completes (success or
+    // expect-failure recorded via __ry_test_record_fail); failure does not
+    // unwind because Ry has no exception-style control flow at this layer.
+    if (afterEachBody) {
+        for (auto &stmt : *afterEachBody)
+            std::visit([this](auto &st) { emitStmt(st); }, stmt);
+    }
 }
 
 void CodeGen::emitItWithTimeout(int64_t timeoutMs, llvm::Value *descVal,
                                  llvm::Function *userFn,
-                                 llvm::ArrayRef<llvm::Value*> userArgs) {
+                                 llvm::ArrayRef<llvm::Value*> userArgs,
+                                 std::vector<StmtNode> *afterEachBody) {
     llvm::FunctionType *voidStrI64Ty = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*ctx_), {ptrTy_, i64Ty_}, false);
     llvm::FunctionType *voidTy = llvm::FunctionType::get(
@@ -560,6 +603,15 @@ void CodeGen::emitItWithTimeout(int64_t timeoutMs, llvm::Value *descVal,
         {descVal, llvm::ConstantInt::get(i64Ty_, static_cast<uint64_t>(timeoutMs))});
     builder_.CreateCall(userFn, userArgs);
     builder_.CreateCall(endFn);
+    // @afterEach inline on the normal-completion path (#1686): the test
+    // finished within the timeout window, so user state is consistent and
+    // cleanup is safe. The timeoutBB path below intentionally skips this —
+    // SIGALRM siglongjmp tears across the C++ stack and there is no way to
+    // guarantee user-code invariants for the cleanup body.
+    if (afterEachBody) {
+        for (auto &stmt : *afterEachBody)
+            std::visit([this](auto &st) { emitStmt(st); }, stmt);
+    }
     builder_.CreateBr(afterBB);
 
     builder_.SetInsertPoint(timeoutBB);
@@ -649,6 +701,80 @@ void CodeGen::emitPropertyItDirective(std::unique_ptr<FnStmt> &s) {
                        std::vector<llvm::Value*>(capturedVals.begin(), capturedVals.end()));
 }
 
+// ===== Lifecycle hook directives (#1686) =====
+//
+// All four (@beforeEach / @afterEach / @beforeAll / @afterAll) are AST-rewritten
+// inside emitDescribeDirective's pre-scan and never reach normal stmt emission.
+// The handlers here are defense-in-depth: a hook FnStmt that escapes the
+// pre-scan (placed outside @describe, or — hypothetically — in a code path
+// that bypasses the rewrite) emits a clear diagnostic instead of silently
+// being treated as a regular function.
+
+void CodeGen::validateLifecycleHookFnShape(const std::unique_ptr<FnStmt> &s, const char *hookName) {
+    if (s->is_async)
+        codegenError(std::string("@") + hookName + ": fn '" + s->name + "' cannot be async");
+    if (!s->type_params.empty())
+        codegenError(std::string("@") + hookName + ": fn '" + s->name + "' cannot be generic");
+    if (!s->params.empty())
+        codegenError(std::string("@") + hookName + ": fn '" + s->name + "' cannot have parameters");
+    if (s->return_type)
+        codegenError(std::string("@") + hookName + ": fn '" + s->name + "' cannot have a return type annotation");
+    // Cross-directive incompatibilities. Hook directives target the function
+    // template; combining with @it / @describe / @skip / @only / @todo /
+    // @each / @property / @timeout / another hook is rejected so the user
+    // does not silently get one of the two behaviours.
+    for (const char *bad : {"it", "describe", "skip", "only", "todo", "each", "property", "timeout",
+                            "beforeEach", "afterEach", "beforeAll", "afterAll"}) {
+        if (std::strcmp(bad, hookName) == 0) continue;
+        if (hasDirective(s->directives, bad))
+            codegenError(std::string("@") + hookName + " cannot be combined with @" + bad +
+                         " on fn '" + s->name + "'");
+    }
+}
+
+// Reject stmt kinds that are unsafe to re-emit or that would pollute the
+// describe scope. FnStmt (generic path moves out), RecordStmt / EnumStmt /
+// TypeAliasStmt / DirectiveDefStmt would register a type/directive with a
+// duplicate name on the second re-emit of @beforeEach / @afterEach; Import*
+// has module-load side effects. Helpers should be defined at file scope or
+// in the describe body outside the hook.
+void CodeGen::validateLifecycleHookBody(const std::vector<StmtNode> &body, const char *hookName) {
+    for (const auto &stmt : body) {
+        const char *kind = nullptr;
+        if (std::get_if<std::unique_ptr<FnStmt>>(&stmt))                kind = "fn declaration";
+        else if (std::get_if<RecordStmt>(&stmt))                        kind = "record declaration";
+        else if (std::get_if<EnumStmt>(&stmt))                          kind = "enum declaration";
+        else if (std::get_if<TypeAliasStmt>(&stmt))                     kind = "type alias";
+        else if (std::get_if<DirectiveDefStmt>(&stmt))                  kind = "directive declaration";
+        else if (std::get_if<ImportStmt>(&stmt))                        kind = "import";
+        else if (std::get_if<std::unique_ptr<QualifiedImportStmt>>(&stmt)) kind = "qualified import";
+        else if (std::get_if<ImportAliasStmt>(&stmt))                   kind = "import alias";
+        if (kind)
+            codegenError(std::string("@") + hookName + " body cannot contain a " + kind +
+                         "; define it at file scope or in the @describe body outside the hook");
+    }
+}
+
+void CodeGen::emitBeforeEachDirective(std::unique_ptr<FnStmt> &s) {
+    codegenError("@beforeEach: fn '" + s->name +
+                 "' must be declared inside an @describe block");
+}
+
+void CodeGen::emitAfterEachDirective(std::unique_ptr<FnStmt> &s) {
+    codegenError("@afterEach: fn '" + s->name +
+                 "' must be declared inside an @describe block");
+}
+
+void CodeGen::emitBeforeAllDirective(std::unique_ptr<FnStmt> &s) {
+    codegenError("@beforeAll: fn '" + s->name +
+                 "' must be declared inside an @describe block");
+}
+
+void CodeGen::emitAfterAllDirective(std::unique_ptr<FnStmt> &s) {
+    codegenError("@afterAll: fn '" + s->name +
+                 "' must be declared inside an @describe block");
+}
+
 void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
     if (!test_mode_)
         codegenError("@describe is only allowed in test mode (use 'ry test')");
@@ -676,6 +802,8 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
         for (auto &stmt : s->body) {
             if (auto *fnPtr = std::get_if<std::unique_ptr<FnStmt>>(&stmt)) {
                 auto &fn = *fnPtr;
+                // Hooks are structural setup, not test nodes — skip them in
+                // outline view so the user sees only describe / it hierarchy.
                 if (hasDirective(fn->directives, "it") || hasDirective(fn->directives, "describe"))
                     std::visit([this](auto &st) { emitStmt(st); }, stmt);
             }
@@ -684,8 +812,109 @@ void CodeGen::emitDescribeDirective(std::unique_ptr<FnStmt> &s) {
         return;
     }
 
+    // ----- Pre-scan: extract lifecycle hooks from s->body -----
+    //
+    // Walk linearly; for each FnStmt carrying a hook directive, validate,
+    // steal the body into a local slot, then erase the FnStmt from s->body.
+    // After the walk, splice @beforeAll body to the front, @afterAll body
+    // to the back. The bodies for @beforeEach / @afterEach are moved into
+    // the active DescribeHookContext on describe_hook_stack_.
+    std::vector<StmtNode> beforeAllBody;
+    std::vector<StmtNode> afterAllBody;
+    std::vector<StmtNode> beforeEachBody;
+    std::vector<StmtNode> afterEachBody;
+    std::string beforeAllName, afterAllName, beforeEachName, afterEachName;
+
+    auto extractHook = [&](std::unique_ptr<FnStmt> &fn, const char *hookName,
+                           std::vector<StmtNode> &dest, std::string &destName) {
+        if (!destName.empty())
+            codegenError(std::string("@") + hookName + " can be declared at most once per @describe block (fn '" +
+                         destName + "' already declared)");
+        validateLifecycleHookFnShape(fn, hookName);
+        validateLifecycleHookBody(fn->body, hookName);
+        destName = fn->name;
+        dest = std::move(fn->body);
+    };
+
+    for (auto it = s->body.begin(); it != s->body.end(); ) {
+        auto *fnPtr = std::get_if<std::unique_ptr<FnStmt>>(&*it);
+        if (!fnPtr) { ++it; continue; }
+        auto &fn = *fnPtr;
+        bool consumed = false;
+        if (hasDirective(fn->directives, "beforeEach")) {
+            extractHook(fn, "beforeEach", beforeEachBody, beforeEachName);
+            consumed = true;
+        } else if (hasDirective(fn->directives, "afterEach")) {
+            extractHook(fn, "afterEach", afterEachBody, afterEachName);
+            consumed = true;
+        } else if (hasDirective(fn->directives, "beforeAll")) {
+            extractHook(fn, "beforeAll", beforeAllBody, beforeAllName);
+            consumed = true;
+        } else if (hasDirective(fn->directives, "afterAll")) {
+            extractHook(fn, "afterAll", afterAllBody, afterAllName);
+            consumed = true;
+        }
+        if (consumed) it = s->body.erase(it);
+        else          ++it;
+    }
+
+    // Splice @beforeAll body immediately BEFORE the first @it / @describe;
+    // @afterAll body immediately AFTER the last @it / @describe. This makes
+    // the hook position independent of where in the source the user declared
+    // it (it still runs before / after all tests) while preserving the
+    // describe-scope let-bindings declared before the tests — splicing at
+    // the very start would break `counter = 0` followed by
+    // `@beforeAll fn s(): counter = counter + 1` because the hook body
+    // would reference `counter` before its alloca exists. If the describe
+    // body contains no @it / @describe at all, the hook bodies fall back to
+    // start / end of body (semantics is irrelevant — nothing runs anyway).
+    auto isTestStmt = [](const StmtNode &stmt) {
+        const auto *fnp = std::get_if<std::unique_ptr<FnStmt>>(&stmt);
+        if (!fnp) return false;
+        return hasDirective((*fnp)->directives, "it") ||
+               hasDirective((*fnp)->directives, "describe");
+    };
+    size_t firstTestIdx = s->body.size();
+    size_t lastTestIdx = 0;
+    bool sawTest = false;
+    for (size_t i = 0; i < s->body.size(); ++i) {
+        if (isTestStmt(s->body[i])) {
+            if (!sawTest) { firstTestIdx = i; sawTest = true; }
+            lastTestIdx = i;
+        }
+    }
+    if (!beforeAllBody.empty()) {
+        const size_t insertAt = sawTest ? firstTestIdx : 0;
+        s->body.insert(s->body.begin() + static_cast<std::ptrdiff_t>(insertAt),
+                       std::make_move_iterator(beforeAllBody.begin()),
+                       std::make_move_iterator(beforeAllBody.end()));
+        if (sawTest) lastTestIdx += beforeAllBody.size();
+    }
+    if (!afterAllBody.empty()) {
+        const size_t insertAt = sawTest ? lastTestIdx + 1 : s->body.size();
+        s->body.insert(s->body.begin() + static_cast<std::ptrdiff_t>(insertAt),
+                       std::make_move_iterator(afterAllBody.begin()),
+                       std::make_move_iterator(afterAllBody.end()));
+    }
+
+    // Push @beforeEach / @afterEach into the active hook frame so
+    // emitItDirective can inline them around each test call.
+    describe_hook_stack_.push_back({
+        std::move(beforeEachBody),
+        std::move(afterEachBody),
+        std::move(beforeEachName),
+        std::move(afterEachName)
+    });
+
     stripDirectives(s->directives, {"describe"});
-    emitStmt(s);
+
+    try {
+        emitStmt(s);
+    } catch (...) {
+        describe_hook_stack_.pop_back();
+        throw;
+    }
+    describe_hook_stack_.pop_back();
 
     auto *overloads = findFunction(s->name);
     if (!overloads || overloads->empty())

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -744,6 +744,46 @@ void CodeGen::validateLifecycleHookFnShape(const std::unique_ptr<FnStmt> &s, con
 // duplicate name on the second re-emit of @beforeEach / @afterEach; Import*
 // has module-load side effects. Helpers should be defined at file scope or
 // in the describe body outside the hook.
+namespace {
+// Recursively detect ReturnStmt anywhere in a hook body. The hook is inlined
+// into the surrounding @describe / @it generated function, so a `return` here
+// returns from the enclosing function rather than from the source hook, which
+// bypasses __ry_test_it_end / __ry_test_describe_end. Skip nested FnStmt
+// because that defines a separate function whose return is local to it.
+bool stmtHasReturn(const StmtNode &stmt);
+
+bool bodyHasReturn(const std::vector<StmtNode> &body) {
+    for (const auto &s : body)
+        if (stmtHasReturn(s)) return true;
+    return false;
+}
+
+bool stmtHasReturn(const StmtNode &stmt) {
+    if (std::get_if<ReturnStmt>(&stmt)) return true;
+    if (std::get_if<std::unique_ptr<FnStmt>>(&stmt)) return false;
+    if (auto *p = std::get_if<std::unique_ptr<IfStmt>>(&stmt)) {
+        if (bodyHasReturn((*p)->branch.body)) return true;
+        if (bodyHasReturn((*p)->else_body)) return true;
+        return false;
+    }
+    if (auto *p = std::get_if<std::unique_ptr<CaseCondStmt>>(&stmt)) {
+        for (const auto &arm : (*p)->arms)
+            if (bodyHasReturn(arm.body)) return true;
+        return bodyHasReturn((*p)->else_body);
+    }
+    if (auto *p = std::get_if<std::unique_ptr<WhileStmt>>(&stmt))
+        return bodyHasReturn((*p)->body);
+    if (auto *p = std::get_if<std::unique_ptr<ForStmt>>(&stmt))
+        return bodyHasReturn((*p)->body);
+    if (auto *p = std::get_if<std::unique_ptr<CaseStmt>>(&stmt)) {
+        for (const auto &arm : (*p)->arms)
+            if (bodyHasReturn(arm.body)) return true;
+        return false;
+    }
+    return false;
+}
+}  // namespace
+
 void CodeGen::validateLifecycleHookBody(const std::vector<StmtNode> &body, const char *hookName) {
     for (const auto &stmt : body) {
         const char *kind = nullptr;
@@ -758,6 +798,11 @@ void CodeGen::validateLifecycleHookBody(const std::vector<StmtNode> &body, const
         if (kind)
             codegenError(std::string("@") + hookName + " body cannot contain a " + kind +
                          "; define it at file scope or in the @describe body outside the hook");
+        if (stmtHasReturn(stmt))
+            codegenError(std::string("@") + hookName + " body cannot contain a return statement "
+                         "(including in nested if / case / for / while blocks); the body is inlined "
+                         "into the surrounding @describe/@it function and a return would exit that "
+                         "function, bypassing per-test cleanup");
     }
 }
 

--- a/tests/spec/directive_lifecycle.test.ry
+++ b/tests/spec/directive_lifecycle.test.ry
@@ -1,0 +1,246 @@
+from testing import describe, it, beforeEach, afterEach, beforeAll, afterAll, expect, timeout
+
+# #1686 — @beforeEach / @afterEach / @beforeAll / @afterAll runtime semantics.
+# Each describe verifies one specific contract; counters are kept describe-local
+# (declared with `<name> = 0` inside the describe fn) so the order of describes
+# does not affect any single test. Only hook bodies (inlined into the describe
+# fn) may mutate describe-scope variables — @it bodies capture them by value.
+
+# ─── execution order: beforeAll → (beforeEach → it → afterEach)* → afterAll ───
+@describe("lifecycle execution order")
+fn lifecycleExecutionOrder():
+    log = ""
+
+    @beforeAll
+    fn setupAll():
+        log = log + "BA;"
+
+    @beforeEach
+    fn setupEach():
+        log = log + "BE;"
+
+    @afterEach
+    fn teardownEach():
+        log = log + "AE;"
+
+    @afterAll
+    fn teardownAll():
+        log = log + "AA;"
+
+    @it("first test sees BA + BE prefix")
+    fn first():
+        # Before this test ran, BA fired once and BE fired once.
+        expect(log).toEq("BA;BE;")
+
+    @it("second test sees afterEach + beforeEach repeating")
+    fn second():
+        # After first: "BA;BE;AE;". Then BE for self: "BA;BE;AE;BE;".
+        expect(log).toEq("BA;BE;AE;BE;")
+
+    @it("third test confirms accumulation continues")
+    fn third():
+        # Accumulated: "BA;BE;AE;BE;AE;BE;"
+        expect(log).toEq("BA;BE;AE;BE;AE;BE;")
+
+
+# ─── accumulation semantics (unlike Jest, the describe fn runs ONCE) ───
+@describe("counter accumulation across tests")
+fn counterAccumulation():
+    counter = 0
+
+    @beforeEach
+    fn s():
+        counter = counter + 1
+
+    @it("counter == 1 after first beforeEach")
+    fn t1():
+        expect(counter).toEq(1)
+
+    @it("counter == 2 after second beforeEach (accumulated)")
+    fn t2():
+        # In Jest each describe-body runs per-test and counter resets to 0;
+        # in Ry it runs once, so counter accumulates. This is intentional —
+        # documented in docs/reference/testing.md Lifecycle Hooks section.
+        expect(counter).toEq(2)
+
+
+# ─── mutable describe-scope variable visible from @it ───
+@describe("describe-scope mutation flows to it")
+fn describeScopeMutation():
+    label = "init"
+
+    @beforeEach
+    fn s():
+        label = "ready"
+
+    @it("@it sees @beforeEach mutation via captured var")
+    fn t():
+        expect(label).toEq("ready")
+
+
+# ─── @beforeAll fires exactly once per describe ───
+@describe("beforeAll runs exactly once")
+fn beforeAllRunsOnce():
+    setupCount = 0
+    counter = 0
+
+    @beforeAll
+    fn s():
+        setupCount = setupCount + 1
+
+    @beforeEach
+    fn each():
+        counter = counter + 1
+
+    @it("first test: setupCount == 1, counter == 1")
+    fn t1():
+        expect(setupCount).toEq(1)
+        expect(counter).toEq(1)
+
+    @it("second test: setupCount STILL == 1, counter == 2")
+    fn t2():
+        expect(setupCount).toEq(1)
+        expect(counter).toEq(2)
+
+
+# ─── describes do not share hooks (each describe gets its own hook frame) ───
+@describe("first describe with its own beforeEach")
+fn firstDescribeIsolated():
+    visited = 0
+
+    @beforeEach
+    fn s():
+        visited = visited + 100
+
+    @it("visited == 100")
+    fn t():
+        expect(visited).toEq(100)
+
+
+@describe("second describe with different beforeEach")
+fn secondDescribeIsolated():
+    visited = 0
+
+    @beforeEach
+    fn s():
+        visited = visited + 7
+
+    @it("visited == 7 (not leaked from prior describe)")
+    fn t():
+        expect(visited).toEq(7)
+
+
+# ─── position independence: @beforeAll declared AFTER @it still runs first ───
+@describe("hook position independence")
+fn hookPositionIndependent():
+    setupRan = false
+
+    @it("@beforeAll runs before this @it even though declared after")
+    fn t():
+        expect(setupRan).toEq(true)
+
+    @beforeAll
+    fn lateDeclaration():
+        setupRan = true
+
+
+# ─── @timeout normal completion still runs @afterEach (advisor regression) ───
+@describe("timeout x afterEach normal completion")
+fn timeoutAfterEachNormal():
+    counter = 0
+
+    @beforeEach
+    fn s():
+        counter = counter + 1
+
+    @afterEach
+    fn t():
+        counter = counter + 10
+
+    @timeout(2000)
+    @it("fast test within timeout runs both hooks")
+    fn fast():
+        expect(counter > 0).toEq(true)
+
+    @it("second test sees prior afterEach cumulative effect")
+    fn second():
+        # After fast: counter = 1 (BE) + 10 (AE). Then BE for self = 12.
+        expect(counter).toEq(12)
+
+
+# ─── ARC: str / List re-emission across multiple tests (per advisor #3) ───
+@describe("arc re-emit safety for str beforeEach")
+fn arcStrBeforeEach():
+    greeting = ""
+
+    @beforeEach
+    fn s():
+        # Allocate a fresh str each test — body emitted once but evaluated
+        # per @it; if ARC retain/release is buggy we crash under ASan.
+        greeting = "hello" + ", world"
+
+    @it("first test")
+    fn t1():
+        expect(greeting).toEq("hello, world")
+
+    @it("second test")
+    fn t2():
+        expect(greeting).toEq("hello, world")
+
+    @it("third test")
+    fn t3():
+        expect(greeting).toEq("hello, world")
+
+
+@describe("arc re-emit safety for list beforeEach")
+fn arcListBeforeEach():
+    items: List<int> = []
+
+    @beforeEach
+    fn s():
+        # Allocate a fresh list each test — the literal is emitted once
+        # but evaluated per @it; ARC retain/release on the previous
+        # `items` value must run cleanly each time.
+        items = [1, 2, 3]
+
+    @it("first test")
+    fn t1():
+        expect(len(items)).toEq(3)
+
+    @it("second test")
+    fn t2():
+        expect(len(items)).toEq(3)
+
+    @it("third test")
+    fn t3():
+        expect(len(items)).toEq(3)
+
+
+# ─── describe without hooks still works (existing behaviour preserved) ───
+@describe("describe with no hooks")
+fn describeNoHooks():
+    @it("plain test still works")
+    fn t():
+        expect(1 + 1).toEq(2)
+
+
+# ─── @afterEach accumulates across tests ───
+@describe("afterEach accumulation observable from later it")
+fn afterEachAccumulation():
+    log = ""
+
+    @afterEach
+    fn ae():
+        log = log + "AE;"
+
+    @it("first test: log empty")
+    fn t1():
+        expect(log).toEq("")
+
+    @it("second test: log shows prior afterEach")
+    fn t2():
+        expect(log).toEq("AE;")
+
+    @it("third test: log shows two prior afterEach runs")
+    fn t3():
+        expect(log).toEq("AE;AE;")

--- a/tests/test_codegen_common.hpp
+++ b/tests/test_codegen_common.hpp
@@ -244,7 +244,15 @@ inline std::string withStdlibDirectiveDecls(const std::string &src) {
         "@directive(target=[\"function\"])\n"
         "fn todo()\n"
         "@directive(target=[\"function\"])\n"
-        "fn timeout(ms: int)\n";
+        "fn timeout(ms: int)\n"
+        "@directive(target=[\"function\"])\n"
+        "fn beforeEach()\n"
+        "@directive(target=[\"function\"])\n"
+        "fn afterEach()\n"
+        "@directive(target=[\"function\"])\n"
+        "fn beforeAll()\n"
+        "@directive(target=[\"function\"])\n"
+        "fn afterAll()\n";
     return std::string(kDecls) + src;
 }
 

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -2174,3 +2174,443 @@ TEST_F(DirectiveTest, TimeoutLargeValueAccepted) {
         "    expect(1).toEq(1)\n"
     )));
 }
+
+// ============================================================
+// #1686: lifecycle hook directives
+//   @beforeEach / @afterEach / @beforeAll / @afterAll
+// ============================================================
+
+// --- Rejection: declared outside @describe ---
+
+TEST_F(DirectiveTest, BeforeEachOutsideDescribeRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@beforeEach\n"
+            "fn setup():\n"
+            "    expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for @beforeEach outside @describe";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("must be declared inside an @describe block"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, AfterEachOutsideDescribeRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@afterEach\n"
+            "fn teardown():\n"
+            "    expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for @afterEach outside @describe";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("must be declared inside an @describe block"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, BeforeAllOutsideDescribeRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@beforeAll\n"
+            "fn setupAll():\n"
+            "    expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for @beforeAll outside @describe";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("must be declared inside an @describe block"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, AfterAllOutsideDescribeRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@afterAll\n"
+            "fn teardownAll():\n"
+            "    expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for @afterAll outside @describe";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("must be declared inside an @describe block"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+// --- Rejection: parameters ---
+
+TEST_F(DirectiveTest, BeforeEachWithParameterRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeEach\n"
+            "    fn setup(x: int):\n"
+            "        expect(x).toEq(x)\n"
+        ));
+        FAIL() << "Expected error for @beforeEach with parameter";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot have parameters"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, AfterAllWithParameterRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @afterAll\n"
+            "    fn t(x: int):\n"
+            "        expect(x).toEq(x)\n"
+        ));
+        FAIL() << "Expected error for @afterAll with parameter";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot have parameters"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// --- Rejection: return type annotation ---
+
+TEST_F(DirectiveTest, BeforeAllWithReturnTypeRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeAll\n"
+            "    fn s() -> int:\n"
+            "        return 0\n"
+        ));
+        FAIL() << "Expected error for @beforeAll with return type";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot have a return type annotation"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, AfterEachWithReturnTypeRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @afterEach\n"
+            "    fn t() -> bool:\n"
+            "        return true\n"
+        ));
+        FAIL() << "Expected error for @afterEach with return type";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot have a return type annotation"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+// --- Rejection: async ---
+
+TEST_F(DirectiveTest, BeforeEachAsyncRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeEach\n"
+            "    async fn s():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for async @beforeEach";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot be async"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// --- Rejection: generic ---
+
+TEST_F(DirectiveTest, AfterAllGenericRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @afterAll\n"
+            "    fn t<T>():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for generic @afterAll";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot be generic"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// --- Rejection: duplicate hook in same @describe ---
+
+TEST_F(DirectiveTest, DuplicateBeforeEachInDescribeRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeEach\n"
+            "    fn a():\n"
+            "        expect(1).toEq(1)\n"
+            "    @beforeEach\n"
+            "    fn b():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for duplicate @beforeEach";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("can be declared at most once per @describe block"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, DuplicateBeforeAllInDescribeRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeAll\n"
+            "    fn a():\n"
+            "        expect(1).toEq(1)\n"
+            "    @beforeAll\n"
+            "    fn b():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for duplicate @beforeAll";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("can be declared at most once per @describe block"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+// --- Rejection: combinations with other test directives ---
+
+TEST_F(DirectiveTest, BeforeEachWithItRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeEach\n"
+            "    @it(\"both\")\n"
+            "    fn s():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for @beforeEach + @it";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot be combined with @it"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, AfterEachWithTimeoutRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @afterEach\n"
+            "    @timeout(100)\n"
+            "    fn s():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for @afterEach + @timeout";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot be combined with @timeout"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, BeforeAllWithSkipRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeAll\n"
+            "    @skip\n"
+            "    fn s():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for @beforeAll + @skip";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot be combined with @skip"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, BeforeEachWithAfterEachOnSameFnRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeEach\n"
+            "    @afterEach\n"
+            "    fn s():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for @beforeEach + @afterEach on same fn";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("cannot be combined with @afterEach"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+// --- Rejection: hooks + @each / @property on the wrapped @it ---
+
+TEST_F(DirectiveTest, BeforeEachActiveBlocksEachIt) {
+    // @beforeEach is active when an @each @it is encountered → reject.
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeEach\n"
+            "    fn s():\n"
+            "        expect(1).toEq(1)\n"
+            "    @each([1, 2])\n"
+            "    @it(\"each\")\n"
+            "    fn t(x: int):\n"
+            "        expect(x).toEq(x)\n"
+        ));
+        FAIL() << "Expected error for @beforeEach + @each @it";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("not yet supported with @each"),
+                  std::string::npos) << "got: " << msg;
+    }
+}
+
+// --- Rejection: hook body containing declaration-like statements ---
+
+TEST_F(DirectiveTest, BeforeEachBodyWithFnDeclarationRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeEach\n"
+            "    fn s():\n"
+            "        fn helper():\n"
+            "            expect(1).toEq(1)\n"
+            "        helper()\n"
+        ));
+        FAIL() << "Expected error for fn declaration inside @beforeEach body";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("body cannot contain"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// --- Acceptance: single hook inside @describe compiles ---
+
+TEST_F(DirectiveTest, BeforeEachAcceptedInDescribe) {
+    ASSERT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"d\")\n"
+        "fn d():\n"
+        "    counter = 0\n"
+        "    @beforeEach\n"
+        "    fn s():\n"
+        "        counter = counter + 1\n"
+        "    @it(\"t\")\n"
+        "    fn t():\n"
+        "        expect(counter > 0).toEq(true)\n"
+    )));
+}
+
+TEST_F(DirectiveTest, AfterEachAcceptedInDescribe) {
+    ASSERT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"d\")\n"
+        "fn d():\n"
+        "    counter = 0\n"
+        "    @afterEach\n"
+        "    fn s():\n"
+        "        counter = counter + 1\n"
+        "    @it(\"t\")\n"
+        "    fn t():\n"
+        "        expect(counter).toEq(0)\n"
+    )));
+}
+
+TEST_F(DirectiveTest, BeforeAllAcceptedInDescribe) {
+    ASSERT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"d\")\n"
+        "fn d():\n"
+        "    counter = 0\n"
+        "    @beforeAll\n"
+        "    fn s():\n"
+        "        counter = counter + 100\n"
+        "    @it(\"t\")\n"
+        "    fn t():\n"
+        "        expect(counter).toEq(100)\n"
+    )));
+}
+
+TEST_F(DirectiveTest, AfterAllAcceptedInDescribe) {
+    ASSERT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"d\")\n"
+        "fn d():\n"
+        "    counter = 0\n"
+        "    @afterAll\n"
+        "    fn s():\n"
+        "        counter = counter + 1\n"
+        "    @it(\"t\")\n"
+        "    fn t():\n"
+        "        expect(counter).toEq(0)\n"
+    )));
+}
+
+// --- Acceptance: all 4 hooks together compile ---
+
+TEST_F(DirectiveTest, AllFourHooksAcceptedInDescribe) {
+    ASSERT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"d\")\n"
+        "fn d():\n"
+        "    counter = 0\n"
+        "    @beforeAll\n"
+        "    fn a():\n"
+        "        counter = counter + 100\n"
+        "    @beforeEach\n"
+        "    fn b():\n"
+        "        counter = counter + 1\n"
+        "    @afterEach\n"
+        "    fn c():\n"
+        "        counter = counter + 10\n"
+        "    @afterAll\n"
+        "    fn dh():\n"
+        "        counter = counter + 1000\n"
+        "    @it(\"t\")\n"
+        "    fn t():\n"
+        "        expect(counter > 100).toEq(true)\n"
+    )));
+}
+
+// --- Acceptance: @beforeAll position independent of source position ---
+
+TEST_F(DirectiveTest, BeforeAllAfterItStillAccepted) {
+    // @beforeAll declared AFTER the @it should still compile — the
+    // pre-scan extracts hooks regardless of source position.
+    ASSERT_NO_THROW(runTestSource(withStdlibDirectiveDecls(
+        "@describe(\"d\")\n"
+        "fn d():\n"
+        "    counter = 0\n"
+        "    @it(\"t\")\n"
+        "    fn t():\n"
+        "        expect(counter > 0).toEq(true)\n"
+        "    @beforeAll\n"
+        "    fn s():\n"
+        "        counter = counter + 100\n"
+    )));
+}
+

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -2513,6 +2513,95 @@ TEST_F(DirectiveTest, BeforeEachBodyWithFnDeclarationRejected) {
     }
 }
 
+// Inlined hooks share the enclosing @describe/@it generated function, so a
+// `return` inside a hook body would exit that function and bypass
+// __ry_test_it_end / __ry_test_describe_end. Reject return at hook body root
+// and inside nested if / for / while / case branches.
+
+TEST_F(DirectiveTest, BeforeEachBodyWithReturnRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeEach\n"
+            "    fn s():\n"
+            "        return\n"
+            "    @it(\"t\")\n"
+            "    fn t():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for return inside @beforeEach body";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("return"), std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, AfterEachBodyWithReturnInIfRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    flag = true\n"
+            "    @afterEach\n"
+            "    fn s():\n"
+            "        if flag:\n"
+            "            return\n"
+            "    @it(\"t\")\n"
+            "    fn t():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for return inside nested if in @afterEach body";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("return"), std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, BeforeAllBodyWithReturnInForRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    @beforeAll\n"
+            "    fn s():\n"
+            "        for i in 0..3:\n"
+            "            return\n"
+            "    @it(\"t\")\n"
+            "    fn t():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for return inside nested for in @beforeAll body";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("return"), std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(DirectiveTest, AfterAllBodyWithReturnInCaseRejected) {
+    try {
+        runTestSource(withStdlibDirectiveDecls(
+            "@describe(\"d\")\n"
+            "fn d():\n"
+            "    n = 1\n"
+            "    @afterAll\n"
+            "    fn s():\n"
+            "        case:\n"
+            "            n == 1:\n"
+            "                return\n"
+            "            _:\n"
+            "                0\n"
+            "    @it(\"t\")\n"
+            "    fn t():\n"
+            "        expect(1).toEq(1)\n"
+        ));
+        FAIL() << "Expected error for return inside nested case in @afterAll body";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("return"), std::string::npos) << "got: " << msg;
+    }
+}
+
 // --- Acceptance: single hook inside @describe compiles ---
 
 TEST_F(DirectiveTest, BeforeEachAcceptedInDescribe) {

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -13,7 +13,7 @@ TEST_F(CodeGenTest, FailWithMessage) {
         "    @it(\"marks test as failed\")\n"
         "    fn marksTestAsFailed():\n"
         "        fail(\"intentional failure\")\n"
-    )), "fail helper\n    \033[31mline 29: intentional failure\033[0m\n  \033[31m- marks test as failed\033[0m\n\n0 passed, 1 failed, 0 skipped, 0 todo\n");
+    )), "fail helper\n    \033[31mline 37: intentional failure\033[0m\n  \033[31m- marks test as failed\033[0m\n\n0 passed, 1 failed, 0 skipped, 0 todo\n");
 }
 
 // ============================================================
@@ -27,7 +27,7 @@ TEST_F(CodeGenTest, FailWithoutMessage) {
         "    @it(\"fails generically\")\n"
         "    fn failsGenerically():\n"
         "        fail()\n"
-    )), "fail bare\n    \033[31mline 29: test failed\033[0m\n  \033[31m- fails generically\033[0m\n\n0 passed, 1 failed, 0 skipped, 0 todo\n");
+    )), "fail bare\n    \033[31mline 37: test failed\033[0m\n  \033[31m- fails generically\033[0m\n\n0 passed, 1 failed, 0 skipped, 0 todo\n");
 }
 
 // ============================================================


### PR DESCRIPTION
## Summary

Adds four lifecycle hook directives to the testing framework:

- `@beforeAll` — runs once before the first `@it` in a `@describe`
- `@beforeEach` — runs before every `@it`
- `@afterEach` — runs after every `@it` that completes normally
- `@afterAll` — runs once after the last `@it`

Closes #1686.

## Design

**AST-inline emission.** Hook bodies are not emitted as standalone LLVM functions. The AST body is stashed on a per-describe hook context and inlined into the describe-scope IR at the corresponding point. This lets hooks freely read and reassign describe-scope variables — `@it` bodies, by contrast, capture those variables read-only via the existing closure mechanism.

**2-pass describe emit.** `emitDescribeDirective` now does a pre-scan to stash hook bodies, then emits `beforeAll → (beforeEach → @it → afterEach)* → afterAll`. Hooks are spliced around direct-child `@it`s only — nested `@describe` is not used as an anchor, and if a describe contains no direct `@it`, the hook bodies are dropped entirely (the describe body is still emitted and called, so splicing would otherwise run hook side effects with no test attribution).

**Hooks live inside the test attribution window.** `@beforeEach` / `@afterEach` are inlined between `__ry_test_it_begin` and `__ry_test_it_end` (and inside the `@timeout` `sigsetjmp` normalBB), so any `expect` failure inside a hook is attributed to the current `@it` via `__ry_test_record_fail`. The SIGALRM `siglongjmp` path of `@timeout` intentionally skips both hooks because the cross-stack jump can leave user state inconsistent.

**Re-emission constraint.** Because the hook body is re-emitted per `@it`, the body cannot contain top-level declarations (`fn` / `record` / `enum` / type alias / directive / `import`) — re-emitting these would duplicate-register them. Plain variable assignments are safe: the second emission reassigns the existing describe-scope alloca.

## Constraints (codegen-enforced)

- At most one hook of each kind per `@describe`
- Hooks cannot coexist with `@it` / `@describe` / `@timeout` / `@skip` / `@only` / `@todo` / `@each` / `@property` on the same function
- Hooks declared outside a `@describe` are rejected
- Hook bodies cannot contain top-level declarations (`fn` / `record` / `enum` / type alias / directive / `import`)

## Known limitations (documented)

- **`@timeout` × `@afterEach` (and `@beforeEach`)**: a test fired by `@timeout` unwinds via `siglongjmp` past both inlined hook bodies, so cleanup runs only on normal completion. This is the same constraint as the existing mock-cleanup × `@timeout` interaction.
- **Accumulating semantics**: `@describe` bodies execute once, so `@beforeEach` mutations accumulate across tests. Differs from Jest. Write an explicit reset if per-test isolation is needed.
- **MVP scope**: file top-level / nested-describe inheritance not supported (deferred to future issue).
- **Outline mode**: hooks are not shown in `--outline` (they are not test nodes).

## Test plan

- [x] C++ rejection tests: parameters / return type / async / generic / outside-describe / duplicate / illegal directive combinations for each of 4 hooks
- [x] C++ acceptance tests: each hook in isolation and in combination
- [x] Ry runtime spec (`tests/spec/directive_lifecycle.test.ry`, 23 tests): execution order, `@afterEach` still runs on test failure, accumulating semantics, mutable describe-scope visibility, ARC re-emission safety
- [x] `./build/ry_tests` — 2387 pass
- [x] `./build/ry test -p` — 193 spec pass
- [x] ASan + UBSan — clean
- [x] TSan (C++) — 2385 pass + 2 known siglongjmp skips
- [x] TSan (lifecycle spec single-file) — 23 pass
- [x] clang-tidy / cppcheck — clean
- [x] All documentation snippets verified runnable via `./build/ry test`
- [x] Manual attribution check: `@beforeEach` / `@afterEach` failures recorded against the enclosing `@it` (CodeRabbit feedback)

## Docs

- `docs/reference/testing.md` — removed legacy "before_each / after_each are not supported" line, added Lifecycle Hooks section with execution order, accumulating semantics, and known limitations
- `docs/reference/directives.md` — added entries for each of 4 hooks following the `@timeout` template; documented `@timeout` × `@afterEach` interaction
- `changelog.d/1686-lifecycle-hooks.md` — release fragment under `### Added`

## Skipped checklist sections (per `/pre-commit-checklist` §0 matrix)

- §3.6 libFuzzer — no parser/lexer/json/utf8/string changes
- §3.6.5 tree-sitter — no grammar changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added testing lifecycle hooks: `@beforeEach`, `@afterEach`, `@beforeAll`, `@afterAll` for setup/teardown inside describe blocks; hooks are inlined into describe scope and may mutate describe-scope variables.

* **Documentation**
  * Documented hook semantics, placement rules, execution order, and known limitation: `@afterEach` is skipped when a test aborts via `@timeout`.

* **Tests**
  * Added comprehensive tests covering ordering, isolation, validation, and timeout interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1779?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->