### PR TITLE
docs(testing): fix immediate defects in testing.md (#1782)

### DIFF
--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -34,8 +34,6 @@ When `ry test` is run without arguments, it:
 
 ## Syntax
 
-### Syntax
-
 Test files use directives (`@it`, `@describe`) and the helpers `expect`, `mock`, `spy`, `verify`, `verifyCalledWith`, `fail` from the `testing` module. Import them at the top using either `from testing` (wildcard) or `from testing import ...` (named). Several enforcement paths produce different error messages:
 
 - `@it` / `@describe` are declared in `share/std/testing/testing.ry` as `@directive` declarations. Without the import, codegen rejects them via the general directive-resolution mechanism with `unknown directive '@it'` or `unknown directive '@describe'`.
@@ -302,11 +300,11 @@ fn counterTests():
     fn teardownAll():
         log = log + "AA;"
 
-    @it("first call sees counter == 1")
+    @it("should see counter == 1 on first call")
     fn first():
         expect(counter).toEq(1)
 
-    @it("second call sees counter == 2 (state accumulates)")
+    @it("should see counter == 2 on second call (state accumulates)")
     fn second():
         expect(counter).toEq(2)
 ```
@@ -482,7 +480,7 @@ fn verifyCalledWithTests():
 
 - Requires `from testing import verifyCalledWith`
 - The first argument must be a string literal — variables / runtime strings are rejected at compile time. This restriction lets the compiler validate the remaining argument types against the original function's signature.
-- The function must already be mocked via `mock(...)` before `verifyCalledWith` is called; calling on a non-mocked function is a compile error.
+- The function must already be mocked via `mock(...)` or spied via `spy(...)` before `verifyCalledWith` is called; calling on a function that has neither is a compile error.
 - The number and types of `args...` must exactly match the original function's parameter list. Arity mismatch and type mismatch are compile errors.
 - Supported argument types: `int`, `float`, `bool`, `str` (since v0.0.22, #1677), `List<T>` where `T ∈ {int, float, bool, str}` (since v0.0.22, #1703), `Set<T>` where `T ∈ {int, float, bool, str}` (since v0.0.22, #1704), `Map<K, V>` where `K, V ∈ {int, float, bool, str}` (since v0.0.22, #1705), record types whose fields are all in `{int, float, bool, str}` (since v0.0.22, #1706), tuple types whose elements are all in `{int, float, bool, str}` (since v0.0.22, #1706), and `fn(...) -> R` (function-typed) arguments compared by pointer equality (since v0.0.22, #1707). Other types (nested `List<List<T>>`, records or tuples containing collections) are rejected at compile time and are tracked for v0.0.x follow-up.
 - `List<T>` arguments are compared by deep snapshot: the recorded call snapshot and the verify-side snapshot must agree on length and element-wise equality. Element comparison is byte-exact for `int` / `float` / `bool` and uses NUL-safe length+`memcmp` for `str`.
@@ -506,13 +504,13 @@ fn compute(x: int) -> int:
 
 @describe("spy")
 fn spyTests():
-    @it("records calls without replacing implementation")
+    @it("should record calls without replacing implementation")
     fn recordsWithoutReplacing():
         spy("compute")
         expect(compute(5)).toEq(15)         # real implementation runs
         expect(verify("compute")).toEq(1)   # call is recorded
 
-    @it("works with verifyCalledWith")
+    @it("should work with verifyCalledWith")
     fn worksWithVerifyCalledWith():
         spy("compute")
         compute(7)
@@ -542,7 +540,7 @@ fn fetchUser() -> str:
 
 @describe("mockReturnValueOnce")
 fn mockReturnValueOnceTests():
-    @it("returns queued values in order then falls back to original")
+    @it("should return queued values in order then fall back to original")
     fn returnsQueuedThenOriginal():
         mockReturnValueOnce("fetchUser", "first")
         mockReturnValueOnce("fetchUser", "second")
@@ -550,7 +548,7 @@ fn mockReturnValueOnceTests():
         expect(fetchUser()).toEq("second")
         expect(fetchUser()).toEq("real")   # queue empty, falls back to original
 
-    @it("can mix with mock() default — queue wins, then default, then original")
+    @it("should mix with mock() default (queue wins, then default, then original)")
     fn mixesWithDefault():
         mock(fetchUser, () => "fallback")
         mockReturnValueOnce("fetchUser", "queued")
@@ -677,7 +675,7 @@ fn add(a: float, b: float) -> float:
 
 @describe("overloaded mock")
 fn overloadedMockTests():
-    @it("targets int overload only")
+    @it("should target int overload only")
     fn targetsIntOverload():
         mock("add(int, int)", (a: int, b: int) -> int => 100)
         expect(add(2, 3)).toEq(100)        # mocked


### PR DESCRIPTION
## Summary

Address three immediate defects in `docs/reference/testing.md` discovered in the v0.0.24 documentation audit (2026-05-17).

- **Duplicate heading** — remove the stale `### Syntax` heading directly under `## Syntax` (L35-37).
- **`verifyCalledWith` precondition** — update to allow `spy(...)` as well as `mock(...)`, matching the `spy` section (L529) and `tests/spec/testing/spy.test.ry:80-143`.
- **Description style violations** — rewrite seven `@it` example descriptions to follow the `should` + base-form verb convention prescribed by the same file's "Test Description Style" section (L815-843). Sites: L305 / L309 / L509 / L515 / L545 / L553 / L680.

Closes #1782.

## Test plan

- [x] L35-37 duplicate heading removed.
- [x] L485 precondition now reads "mocked via `mock(...)` or spied via `spy(...)`".
- [x] Seven `@it` descriptions rewritten in `should ...` form.
- [x] Grep verification: `grep -nE '@it\("' docs/reference/testing.md | grep -v '"should'` returns only the intentional `@skip` / `@only` / `@todo` fixtures (L46 / L188 / L193 / L198) and the prose lines describing those directive shorthands (L203-205).

## Skipped pre-commit checklist sections

- Skipped §2 — no user-visible behavior change (docs-only).
- Skipped §3 — no source code change.
- Skipped §3.5 — no source code change.
- Skipped §3.6 — no parser/lexer/json/utf8/string change.
- Skipped §3.6.5 — no tree-sitter grammar change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guide with improved examples and section structure.
  * Clarified prerequisite: functions must be mocked **or spied** before using `verifyCalledWith`.
  * Refined test descriptions for better clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1787?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->