### PR TITLE
docs(testing): document feature interactions (#1784)

### DIFF
--- a/changelog.d/1784-feature-interactions.md
+++ b/changelog.d/1784-feature-interactions.md
@@ -1,0 +1,15 @@
+### Added
+
+- Added a `Feature interactions` section to
+  `docs/reference/testing.md` documenting how v0.0.24 testing features
+  combine: `@beforeAll` / `@afterAll` with `@each` / `@property`
+  (parameterized-aware lifecycle), `mock` / `spy` installed from
+  `@beforeEach` (fresh per-`it` state via auto-restore), mutually
+  exclusive combinations (`@beforeEach` / `@afterEach` with `@each` /
+  `@property`, `@timeout` with `@each` / `@property`) with verbatim
+  compile-error messages, and nested-`@describe` lifecycle
+  (hooks are describe-local, not inherited). Adds
+  `tests/spec/feature_combinations.test.ry` covering the four supported
+  combinations, plus verbatim error text in
+  `docs/reference/directives.md` for the `@timeout` mutual exclusion.
+  (#1784)

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -597,8 +597,8 @@ iterations without ambiguity. The compiler emits one of the following
 diagnostics (from `src/codegen_test.cpp`):
 
 ```text
-@timeout cannot be combined with @each on fn '<function_name>'
-@timeout cannot be combined with @property on fn '<function_name>'
+error: @timeout cannot be combined with @each on fn '<function_name>'
+error: @timeout cannot be combined with @property on fn '<function_name>'
 ```
 
 See [Feature interactions](testing.md#feature-interactions) in the testing

--- a/docs/reference/directives.md
+++ b/docs/reference/directives.md
@@ -593,7 +593,16 @@ fn completesWithinOneSecond():
 **Mutual exclusion:** `@timeout` combined with `@each` or `@property` is a
 compile error in the current MVP. The timer applies to one invocation of
 the test body; loop-style runners cannot share a single timer budget across
-iterations without ambiguity.
+iterations without ambiguity. The compiler emits one of the following
+diagnostics (from `src/codegen_test.cpp`):
+
+```text
+@timeout cannot be combined with @each on fn '<function_name>'
+@timeout cannot be combined with @property on fn '<function_name>'
+```
+
+See [Feature interactions](testing.md#feature-interactions) in the testing
+reference for the full mutual-exclusion matrix.
 
 **Composition with `@skip` / `@todo`:** these directives suppress body
 execution, so the timer never starts — there is no conflict. `@only`

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -351,6 +351,118 @@ When `@timeout` fires (the SIGALRM path), the test is aborted via `siglongjmp` p
 
 ---
 
+## Feature interactions
+
+Testing directives compose in specific ways. This section documents every supported (and intentionally rejected) combination so behavior need not be discovered by trial. Worked examples are taken from `tests/spec/feature_combinations.test.ry`.
+
+### Summary matrix
+
+| Combination | Status | Behavior / where to look |
+|---|---|---|
+| `@each` + `@beforeEach` | Compile error | [Lifecycle hooks with `@each` / `@property`](#lifecycle-hooks-with-each--property) |
+| `@each` + `@afterEach` | Compile error | [Lifecycle hooks with `@each` / `@property`](#lifecycle-hooks-with-each--property) |
+| `@property` + `@beforeEach` | Compile error | [Lifecycle hooks with `@each` / `@property`](#lifecycle-hooks-with-each--property) |
+| `@property` + `@afterEach` | Compile error | [Lifecycle hooks with `@each` / `@property`](#lifecycle-hooks-with-each--property) |
+| `@each` + `@timeout` | Compile error | [Mutually exclusive: `@each` / `@property` + `@timeout`](#mutually-exclusive-each--property--timeout) |
+| `@property` + `@timeout` | Compile error | [Mutually exclusive: `@each` / `@property` + `@timeout`](#mutually-exclusive-each--property--timeout) |
+| `mock` in `@beforeEach` | Supported | [`mock` / `spy` inside `@beforeEach`](#mock--spy-inside-beforeeach) |
+| `spy` in `@beforeEach` | Supported | [`mock` / `spy` inside `@beforeEach`](#mock--spy-inside-beforeeach) |
+| `mock` + `spy` in same `@it` | Supported | `mock` takes precedence; see [`spy(name)`](#spyname) |
+| `@beforeAll` + `@each` | Supported | [`@beforeAll` / `@afterAll` with `@each` / `@property`](#beforeall--afterall-with-each--property) |
+| `@afterAll` + `@each` | Supported | [`@beforeAll` / `@afterAll` with `@each` / `@property`](#beforeall--afterall-with-each--property) |
+| Nested `@describe` lifecycle inheritance | Unsupported | [Nested `@describe` lifecycle](#nested-describe-lifecycle) |
+
+The same matrix entries apply when `@property` is substituted for `@each` and vice versa (and for `@afterAll` paired with `@each` / `@property`); the table lists `@each` only to keep the row count manageable.
+
+### Lifecycle hooks with `@each` / `@property`
+
+`@beforeEach` and `@afterEach` cannot decorate an `@it` that also carries `@each` or `@property`. The codegen path (`src/codegen_test.cpp`) raises the compile error verbatim:
+
+```text
+error: @beforeEach / @afterEach are not yet supported with @each on @it '<fn>'
+error: @beforeEach / @afterEach are not yet supported with @property on @it '<fn>'
+```
+
+This is a deliberate MVP limitation (#1686): inlining hooks per iteration would require additional codegen scaffolding to thread hook state through the runtime loop. Workarounds:
+
+- Move per-iteration setup / teardown into the `@it` body itself (or call a helper).
+- Hoist work that is shared across iterations into `@beforeAll`; see [`@beforeAll` / `@afterAll` with `@each` / `@property`](#beforeall--afterall-with-each--property).
+
+### Mutually exclusive: `@each` / `@property` + `@timeout`
+
+The compiler rejects this combination, again from `src/codegen_test.cpp`:
+
+```text
+error: @timeout cannot be combined with @each on fn '<fn>'
+error: @timeout cannot be combined with @property on fn '<fn>'
+```
+
+`@timeout` measures the wall-clock duration of one invocation of the test body; loop-style runners cannot share a single timer budget across iterations without ambiguity. See [`@timeout` in the Directives reference](directives.md#timeout) and the [Troubleshooting entry](#each-or-property-combined-with-timeout-is-rejected-at-compile-time) for the user-facing diagnostic.
+
+### `mock` / `spy` inside `@beforeEach`
+
+Installing a `mock` or `spy` in the describe's `@beforeEach` produces a fresh installation for each `@it`: the hook body is inlined per `@it`, and the auto-restore at `@it` end clears both the implementation override and the call counter.
+
+```ry
+from testing import describe, it, beforeEach, mock, verify, expect
+
+fn fetchValue() -> int:
+    return 7
+
+@describe("mock installed via beforeEach is fresh per it")
+fn mockInBeforeEach():
+    @beforeEach
+    fn be():
+        mock(fetchValue, () => 42)
+
+    @it("first it sees the mocked value")
+    fn firstIt():
+        expect(fetchValue()).toEq(42)
+        expect(verify("fetchValue")).toEq(1)
+
+    @it("second it sees re-installed mock with fresh call count")
+    fn secondIt():
+        expect(verify("fetchValue")).toEq(0)
+        expect(fetchValue()).toEq(42)
+        expect(verify("fetchValue")).toEq(1)
+```
+
+`spy("name")` works the same way — the call count resets to 0 at the start of every `@it`. When `mock` and `spy` are both active on the same function inside one `@it`, `mock` takes precedence: see [`spy(name)`](#spyname).
+
+### `@beforeAll` / `@afterAll` with `@each` / `@property`
+
+`@beforeAll` fires once before the iteration loop begins, and `@afterAll` once after every iteration of every `@it` in the describe completes:
+
+```ry
+from testing import describe, it, each, beforeAll, expect
+
+@describe("beforeAll runs once before all each iterations")
+fn beforeAllRunsOncePerEach():
+    baCount = 0
+
+    @beforeAll
+    fn ba():
+        baCount = baCount + 1
+
+    @each([(1,), (2,), (3,)])
+    @it("iteration {0} sees baCount == 1")
+    fn iter(x: int):
+        expect(baCount).toEq(1)
+        expect(x > 0).toEq(true)
+
+    @it("after iterations baCount is still 1")
+    fn checker():
+        expect(baCount).toEq(1)
+```
+
+The same single-fire semantics apply to `@property` and to `@afterAll`. Because hooks are describe-local, `@afterAll`'s execution is not observable from any `@it` inside the same describe; `tests/spec/feature_combinations.test.ry` verifies the negative — `@afterAll` has not yet fired during any iteration or trailing `@it`.
+
+### Nested `@describe` lifecycle
+
+Each `@describe` owns its own lifecycle hooks. An outer describe's `@beforeEach` / `@afterEach` / `@beforeAll` / `@afterAll` **does not run** before or after the inner describe's `@it` blocks — see the third [Limitations](#limitations) bullet ("Nested-describe inheritance of lifecycle hooks is not supported").
+
+---
+
 ## Mocking
 
 ### mock(fnName, replacement)
@@ -527,6 +639,7 @@ fn spyTests():
 - `verify(name)` and `verifyCalledWith(name, args...)` work uniformly on spied functions (same call-recording mechanism as `mock`)
 - `mockClear(name)` / `mockReset(name)` / `mockResetAll()` apply to spied functions identically — they share the same internal registry
 - A function may be both mocked and spied across different `it` blocks within the same describe. When both are active in the same block (mock+spy coexistence), `mock` takes precedence: the replacement runs and the call is counted; the real implementation is bypassed
+- See [Feature interactions](#feature-interactions) for installing `mock` / `spy` from `@beforeEach` (auto-restore semantics, fresh per-`it` state)
 
 ### mockReturnValueOnce(name, value)
 
@@ -737,6 +850,8 @@ fn testAdd(a: int, b: int, expected: int):
 - Each tuple generates an independent test case
 - Supported parameter types: `int`, `float`, `bool`, `str`
 
+See [Feature interactions](#feature-interactions) for combinations with lifecycle hooks and `@timeout` (the lifecycle and `@timeout` combinations are compile errors in the current MVP).
+
 ---
 
 ## Property-Based Tests (@property)
@@ -756,6 +871,8 @@ fn testCommutative(a: int, b: int):
 - On failure, the counterexample (failing inputs) is printed
 - The test stops at the first failure
 - Supported parameter types: `int` ([-1000, 1000]), `float` ([-1000.0, 1000.0]), `bool`, `str` (random ASCII, 0-20 chars)
+
+See [Feature interactions](#feature-interactions) for combinations with lifecycle hooks and `@timeout` (the lifecycle and `@timeout` combinations are compile errors in the current MVP).
 
 ---
 
@@ -1072,7 +1189,7 @@ If you do need shared mock state, reset it explicitly in `@afterEach` to avoid a
 ## Limitations
 
 - File top-level lifecycle hooks (outside any `@describe`) are not supported
-- Nested-describe inheritance of lifecycle hooks is not supported (each `@describe` owns its own hooks)
+- Nested-describe inheritance of lifecycle hooks is not supported (each `@describe` owns its own hooks) — see [Nested @describe lifecycle](#nested-describe-lifecycle) under Feature interactions
 - A test fired by `@timeout` (i.e. the test body did not finish within the budget) skips its `@afterEach` — see [Directives reference](directives.md#timeout) for details
 
 ---

--- a/tests/spec/feature_combinations.test.ry
+++ b/tests/spec/feature_combinations.test.ry
@@ -1,0 +1,98 @@
+from testing import describe, it, each, beforeAll, afterAll, beforeEach, mock, spy, expect, verify
+
+# #1784 — feature-combination runtime semantics. Companion to the
+# "Feature interactions" section of docs/reference/testing.md. Each
+# describe covers one *supported* combination; mutually-exclusive
+# combinations (@each / @property + @beforeEach / @afterEach / @timeout)
+# are compile errors validated by tests/test_codegen_directive.cpp.
+
+# ─── @beforeAll fires once before the @each iteration loop ───
+@describe("beforeAll runs once before all each iterations")
+fn beforeAllRunsOncePerEach():
+    baCount = 0
+
+    @beforeAll
+    fn ba():
+        baCount = baCount + 1
+
+    @each([(1,), (2,), (3,)])
+    @it("iteration {0} sees baCount == 1")
+    fn iter(x: int):
+        expect(baCount).toEq(1)
+        expect(x > 0).toEq(true)
+
+    @it("after iterations baCount is still 1")
+    fn checker():
+        expect(baCount).toEq(1)
+
+
+# ─── @afterAll does NOT fire during @each iterations ───
+# Hooks are describe-local, so the post-describe state cannot be read
+# from a later describe. We assert the negative: @afterAll has not yet
+# fired during any @it (including the trailing sentinel).
+@describe("afterAll does not fire during each iterations")
+fn afterAllAfterEach():
+    aaCount = 0
+    log = ""
+
+    @beforeAll
+    fn ba():
+        log = log + "BA;"
+
+    @afterAll
+    fn aa():
+        aaCount = aaCount + 1
+
+    @each([(10,), (20,)])
+    @it("iter {0} sees aaCount == 0")
+    fn iter(x: int):
+        expect(aaCount).toEq(0)
+        expect(log).toEq("BA;")
+
+    @it("trailing test still sees aaCount == 0 before afterAll fires")
+    fn trailing():
+        expect(aaCount).toEq(0)
+
+
+# ─── mock installed via @beforeEach is fresh per @it (auto-restore) ───
+fn fetchValue() -> int:
+    return 7
+
+@describe("mock installed via beforeEach is fresh per it")
+fn mockInBeforeEach():
+    @beforeEach
+    fn be():
+        mock(fetchValue, () => 42)
+
+    @it("first it sees the mocked value")
+    fn firstIt():
+        expect(fetchValue()).toEq(42)
+        expect(verify("fetchValue")).toEq(1)
+
+    @it("second it sees re-installed mock with fresh call count")
+    fn secondIt():
+        expect(verify("fetchValue")).toEq(0)
+        expect(fetchValue()).toEq(42)
+        expect(verify("fetchValue")).toEq(1)
+
+
+# ─── spy installed via @beforeEach; call count resets per @it ───
+fn computeValue() -> int:
+    return 99
+
+@describe("spy installed via beforeEach has fresh call count per it")
+fn spyInBeforeEach():
+    @beforeEach
+    fn be():
+        spy("computeValue")
+
+    @it("first it records one call through the real impl")
+    fn firstIt():
+        expect(computeValue()).toEq(99)
+        expect(verify("computeValue")).toEq(1)
+
+    @it("second it re-installs spy with count reset to 0")
+    fn secondIt():
+        expect(verify("computeValue")).toEq(0)
+        expect(computeValue()).toEq(99)
+        expect(verify("computeValue")).toEq(1)


### PR DESCRIPTION
## Summary

- Adds a `## Feature interactions` section to `docs/reference/testing.md` documenting how v0.0.24 testing directives compose, with a 12-row matrix and worked examples drawn from `tests/spec/feature_combinations.test.ry`.
- Documents the four supported combinations (`@beforeAll`/`@afterAll` + `@each`/`@property`, `mock`/`spy` installed from `@beforeEach` with auto-restore semantics) and the mutually-exclusive ones (`@beforeEach`/`@afterEach` + parameterized, `@timeout` + parameterized) with verbatim compile-error messages emitted from `src/codegen_test.cpp`.
- Adds `tests/spec/feature_combinations.test.ry` with 11 cases covering the four supported combinations, plus verbatim `@timeout` error text in `docs/reference/directives.md`.

Cross-references added to existing sections: `### spy(name)` (mock+spy precedence), `## Parameterized Tests (@each)` / `## Property-Based Tests (@property)` (lifecycle + `@timeout` combinations), and the nested-describe `## Limitations` bullet.

Closes #1784

## Test plan

- [x] `./build/ry_tests` — 2391 tests pass
- [x] `./build/ry test -p` — 194 test files pass (including new `feature_combinations.test.ry` with 11 cases)
- [x] ASan + UBSan: clean run on `ry_tests` and `ry test -p`
- [x] TSan: `ry_tests` clean (2389 pass + 2 expected skips); self-test warn-only per upstream `LargeMmapAllocator` issue
- [x] clang-tidy, cppcheck: no warnings
- [x] Empirical re-probe confirmed `@afterEach + @each` and `@afterEach + @property` both reject at compile time with the verbatim error text documented
- [x] Anchor slug verification — all 14 in-section `(#anchor)` references resolve to actual H2/H3 headings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Feature Interactions" section describing how testing directives compose, which combinations are supported or rejected, and lifecycle semantics across nested describes
  * Clarified `@timeout` mutual-exclusion diagnostics with explicit error examples and cross-references
  * Added a compatibility matrix and expanded cross-links to related directive docs

* **Tests**
  * Added a test suite validating supported directive combinations and lifecycle/spy/mock behaviors across iterations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1790?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->