### PR TITLE
docs(testing): add follow-up Recipes (#1788)

### DIFF
--- a/changelog.d/1788-testing-recipes.md
+++ b/changelog.d/1788-testing-recipes.md
@@ -1,0 +1,11 @@
+### Added
+
+- Added two follow-up Recipes to `docs/reference/testing.md`:
+  "Per-test mock setup with `@beforeEach`" (reusing the
+  `mockInBeforeEach` fixture from
+  `tests/spec/feature_combinations.test.ry`) and
+  "Setup patterns for `@each` parameterized tests" (backed by new
+  `tests/spec/parameterized_lifecycle.test.ry`, covering both
+  inline per-iteration setup and `@beforeAll` hoist workarounds for
+  the `@each` + `@beforeEach` compile-error case). Completes the
+  recipes deferred from #1783. (#1788)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1145,6 +1145,76 @@ fn mockOverloadSigTests():
 
 The signature key is the parameter type list inside parentheses, exactly as it appears in the function declaration. `verify("addNum")` (bare name) aggregates the call counts across all overloads; `verify("addNum(int, int)")` returns the count for that overload only. See [Mocking overloaded functions](#mocking-overloaded-functions).
 
+### Per-test mock setup with `@beforeEach`
+
+Use when several `@it` blocks in the same describe need a freshly-installed mock with a zeroed call counter. Hoisting `mock(...)` into `@beforeEach` reuses every `@it`'s auto-restore boundary, so each test sees a clean slate without manual `mockReset` / `mockClear`.
+
+```ry
+from testing import describe, it, beforeEach, mock, verify, expect
+
+fn fetchValue() -> int:
+    return 7
+
+@describe("mock installed via beforeEach is fresh per it")
+fn mockInBeforeEach():
+    @beforeEach
+    fn be():
+        mock(fetchValue, () => 42)
+
+    @it("first it sees the mocked value")
+    fn firstIt():
+        expect(fetchValue()).toEq(42)
+        expect(verify("fetchValue")).toEq(1)
+
+    @it("second it sees re-installed mock with fresh call count")
+    fn secondIt():
+        expect(verify("fetchValue")).toEq(0)
+        expect(fetchValue()).toEq(42)
+        expect(verify("fetchValue")).toEq(1)
+```
+
+The Feature interactions section's [`mock` / `spy` inside `@beforeEach`](#mock--spy-inside-beforeeach) entry shows the same fixture as the canonical evidence that this combination is supported and documents the auto-restore mechanics. Compare with [Scope `mock` as tightly as possible](#scope-mock-as-tightly-as-possible) below — describe-wide setup is only the right choice when every `@it` really does need the same mocked baseline.
+
+### Setup patterns for `@each` parameterized tests
+
+Use when an `@each` parameterized `@it` needs per-iteration or once-per-describe setup. `@each` cannot coexist with `@beforeEach` (compile error — see [Lifecycle hooks with `@each` / `@property`](#lifecycle-hooks-with-each--property)), so the workarounds below are the canonical alternatives.
+
+```ry
+from testing import describe, it, each, beforeAll, expect
+
+fn freshCounter() -> int:
+    return 0
+
+
+# Pattern A: per-iteration setup invoked at the top of the @it body
+@describe("per-iteration setup invoked at the top of the @it body")
+fn perIterationInBody():
+    @each([(2,), (3,), (5,)])
+    @it("iteration {0} starts with a freshly-zeroed counter")
+    fn iter(seed: int):
+        counter = freshCounter()
+        counter = counter + seed
+        expect(counter).toEq(seed)
+
+
+# Pattern B: shared setup hoisted into @beforeAll
+@describe("shared setup hoisted into @beforeAll, reused across @each iterations")
+fn sharedSetupInBeforeAll():
+    factor = 0
+
+    @beforeAll
+    fn ba():
+        factor = 10
+
+    @each([(1,), (2,), (3,)])
+    @it("iteration {0} multiplies the hoisted factor by the parameter")
+    fn iter(x: int):
+        expect(factor).toEq(10)
+        expect(x * factor).toEq(x * 10)
+```
+
+Pattern A places setup that must run fresh each iteration (call counters, allocations, mutable scratch state) at the top of the `@it` body — or in a helper, as shown with `freshCounter()`. Pattern B hoists work that does not vary per iteration (loading a reference value, opening a shared connection) into `@beforeAll`, which fires once before the `@each` loop. Both patterns are exercised by `tests/spec/parameterized_lifecycle.test.ry`.
+
 ---
 
 ## Best Practices

--- a/tests/spec/parameterized_lifecycle.test.ry
+++ b/tests/spec/parameterized_lifecycle.test.ry
@@ -1,0 +1,37 @@
+from testing import describe, it, each, beforeAll, expect
+
+# #1788 — companion to the "Setup patterns for @each parameterized tests"
+# recipe in docs/reference/testing.md. The combination @each + @beforeEach
+# is a compile error (see the "Lifecycle hooks with @each / @property"
+# section in docs/reference/testing.md), so callers reach for one of the
+# two workarounds covered below.
+
+fn freshCounter() -> int:
+    return 0
+
+
+# ─── Pattern A: per-iteration setup invoked at the top of the @it body ───
+@describe("per-iteration setup invoked at the top of the @it body")
+fn perIterationInBody():
+    @each([(2,), (3,), (5,)])
+    @it("iteration {0} starts with a freshly-zeroed counter")
+    fn iter(seed: int):
+        counter = freshCounter()
+        counter = counter + seed
+        expect(counter).toEq(seed)
+
+
+# ─── Pattern B: shared setup hoisted into @beforeAll ───
+@describe("shared setup hoisted into @beforeAll, reused across @each iterations")
+fn sharedSetupInBeforeAll():
+    factor = 0
+
+    @beforeAll
+    fn ba():
+        factor = 10
+
+    @each([(1,), (2,), (3,)])
+    @it("iteration {0} multiplies the hoisted factor by the parameter")
+    fn iter(x: int):
+        expect(factor).toEq(10)
+        expect(x * factor).toEq(x * 10)


### PR DESCRIPTION
## Summary

Adds the two Recipes that were deferred from #1783's Recipes / Cookbook section:

- **Per-test mock setup with `@beforeEach`** — reuses the `mockInBeforeEach` fixture from `tests/spec/feature_combinations.test.ry` (added in #1784) and cross-links to the Feature interactions evidence row that already cites this fixture as the canonical proof that `mock` inside `@beforeEach` is supported.
- **Setup patterns for `@each` parameterized tests** — backed by a new fixture `tests/spec/parameterized_lifecycle.test.ry`. Because `@each` + `@beforeEach` is intentionally a compile error (documented in the Lifecycle hooks with `@each` / `@property` section), the recipe is framed as the two canonical workarounds: Pattern A (per-iteration setup at the top of the `@it` body) and Pattern B (`@beforeAll` hoist for non-varying setup).

Recipes section count: 5 → 7.

Closes #1788.

## Test plan

- [x] `./build/ry test tests/spec/feature_combinations.test.ry` — Recipe 6 引用元 fixture pass
- [x] `./build/ry test tests/spec/parameterized_lifecycle.test.ry` — Recipe 7 新規 fixture 全 6 ケース pass (Pattern A: 3, Pattern B: 3)
- [x] `./build/ry test -p` — 全 Ry セルフテスト 195/195 pass
- [x] `./build/ry_tests` — C++ テスト 2391/2391 pass
- [x] ASan + UBSan: C++ 2391/2391 + Ry self-test 195/195 全 pass
- [x] TSan: C++ 2389/2391 pass (2 skipped = TSan-incompatible timeout tests, 既知)
- [x] Docs snippet が fixture と byte-identical (decorative comment の `# ─── ───` を `# ` に最小限 trim のみ)
- Skipped §3.6 libFuzzer — parser/lexer/json/utf8/string 変更なし
- Skipped §3.6.5 tree-sitter — grammar.ebnf / grammar.js / scanner 変更なし

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added testing recipes documenting mock setup patterns for individual tests using lifecycle hooks.
  * Added testing recipes with recommended setup patterns for parameterized tests.

* **Tests**
  * Added new test examples demonstrating workaround patterns for parameterized test lifecycle scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1791?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->