### PR TITLE
feat(collection): m[k]? — Option-returning index for safe access (#1699)

### DIFF
--- a/changelog.d/1699-option-index.md
+++ b/changelog.d/1699-option-index.md
@@ -1,0 +1,20 @@
+### Added
+
+- `m[k]?` and `xs[i]?` postfix syntax for safe collection access.
+  Applied directly to a Map or List index expression, the trailing `?`
+  changes the semantics from "abort on miss" to "produce an `Option`":
+  `m["a"]?` returns `Some(v): Option<V>` when the key is present and
+  `None` otherwise; `xs[i]?` returns `Some(v): Option<T>` when the
+  (possibly negative-wrapped) index is in range and `None` otherwise.
+  This is a postfix syntax rather than sugar for `get(m, k)` — it
+  parses as `IndexExpr` with a new `try_mode` flag and flows through
+  the same codegen path on both Map and List. The negative-index wrap
+  established by `xs[-1]` is preserved (so `xs[-1]?` on a non-empty
+  list always returns `Some(last)`); only the post-wrap out-of-range
+  case yields `None`. Write-form `m[k]? = v` (including `m[k]?.x = v`
+  and `mm[k]?[k2] = v`), `?` on fixed-length arrays, on `str`, on
+  range slice `xs[a..b]?`, and on `any`-typed nested access are
+  rejected at compile time. The lexer's greedy tokenization of `??`
+  means `m["k"]?? default` (no space) still parses as `m["k"]` +
+  `?? default` — write `m["k"]? ?? default` (with a space) for the
+  Option-returning form coalesced with a default value. (#1699)

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -351,9 +351,9 @@ unary_expr       ::= ( '-' | '+' | '~' | 'not' | 'await' | 'weak' ) unary_expr
 postfix_expression ::= primary_expression { postfix_op }
 
 postfix_op       ::= '(' [ argument_list ] ')'                       // call
-                   | '[' expression { ',' expression } ']'           // index
+                   | '[' expression { ',' expression } ']'           // index; if immediately followed by '?', returns Option<elem> on Map<K,V> / List<T> (#1699)
                    | '.' IDENT                                        // field / method
-                   | '?'                                              // unwrap
+                   | '?'                                              // unwrap Result/Option; after '[..]' becomes the Option-returning index above
                    | '++' | '--'                                      // post-inc/dec
                    | 'as' type_expr                                   // cast
 

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -131,6 +131,21 @@ print(xs[-3])   # 10
 
 Out-of-bounds access (including negative indices that exceed the list length) raises a runtime error.
 
+### Safe Index Access (`xs[i]?`)
+
+`xs[i]?` returns `Option<T>` instead of aborting on out-of-range access. Negative-index wrap is applied first; only when the wrap result is still out of range does the expression evaluate to `None`. See [operators.md](operators.md#option-returning-index-form-mk--xsi) for the cross-collection spec.
+
+```ry
+xs = [10, 20, 30]
+print(xs[1]?)        # Some(20)
+print(xs[100]?)      # None
+print(xs[-1]?)       # Some(30)   — negative wrap to last
+print(xs[-100]?)     # None        — wrap result still out of range
+print(xs[100]? ?? 0) # 0           — coalesce with default (note the space before ??)
+```
+
+Restrictions: read-only — `xs[i]? = v` is a compile error; range-index `xs[a..b]?` is a compile error.
+
 ### Index Assignment
 
 ```ry
@@ -751,6 +766,24 @@ Maps support `==` and `!=`. Two maps are equal when they have the same number of
 m = {"a": 1, "b": 2}
 print(m["a"])   # 1
 ```
+
+Accessing a missing key aborts at runtime. Use `m[k]?` or `get(m, k)` for safe lookup.
+
+### Safe Key Access (`m[k]?`)
+
+`m[k]?` returns `Option<V>` instead of aborting on a missing key. This is a dedicated postfix syntax — not a sugar for `get(m, k)` — and follows the same shape on `List<T>`. See [operators.md](operators.md#option-returning-index-form-mk--xsi) for the cross-collection spec.
+
+```ry
+m = {"a": 1, "b": 2}
+case m["a"]?:
+  Some(v): print(v)            # 1
+  None:    print("missing")
+print(m["z"]? ?? -1)            # -1 — coalesce with default (note the space before ??)
+```
+
+Restrictions: read-only — `m[k]? = v` is a compile error (use `m[k] = v` to insert / update).
+
+For an explicit named-function alternative with the same Option-returning semantics, use [`get(m, k)`](#get).
 
 ### Insert and Update
 

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -127,7 +127,12 @@ shifted = 1 << 8          # 256
 
 ## Error Propagation Operator (`?`)
 
-The postfix `?` operator unwraps a `Result` or `Option` value on the happy path and short-circuits on the unhappy path.
+The postfix `?` operator has two forms:
+
+1. **Unwrap / short-circuit form**: applied to a `Result<T, E>` or `Option<T>` expression — unwraps the inner value on the happy path and short-circuits on the unhappy path.
+2. **Option-returning index form**: applied directly to a Map or List index expression `m[k]?` / `xs[i]?` — returns `Option<V>` / `Option<T>` instead of aborting on missing key / out-of-range index.
+
+### Unwrap / short-circuit form
 
 | Operand | Happy path | Unhappy path |
 |---|---|---|
@@ -159,6 +164,52 @@ fn firstPlusSecond(xs: List<int>) -> Option<int>:
     a = safeGet(xs, 0)?    # returns None early if out of range
     b = safeGet(xs, 1)?
     return Some(a + b)
+```
+
+### Option-returning index form (`m[k]?` / `xs[i]?`)
+
+When `?` immediately follows a Map or List index expression, it changes the semantics from "abort on miss" to "produce an `Option`":
+
+| Receiver | `m[k]` / `xs[i]` (no `?`) | `m[k]?` / `xs[i]?` |
+|---|---|---|
+| `Map<K, V>` — key present | `V` | `Some(v): Option<V>` |
+| `Map<K, V>` — key missing | runtime abort | `None: Option<V>` |
+| `List<T>` — index in range | `T` (after negative-index wrap) | `Some(v): Option<T>` |
+| `List<T>` — index out of range (after wrap) | runtime abort | `None: Option<T>` |
+
+```ry
+m = {"a": 1, "b": 2}
+case m["a"]?:
+  Some(v): print(v)        # 1
+  None:    print("none")
+case m["z"]?:
+  Some(v): print(v)
+  None:    print("none")   # none
+
+# Combine with the `??` null-coalescing operator for a default value.
+# IMPORTANT: leave a space between the two operators.
+print(m["z"]? ?? -1)       # -1
+
+xs = [10, 20, 30]
+print(xs[1]?)              # Some(20)
+print(xs[100]?)            # None
+print(xs[-1]?)             # Some(30)  — negative-index wrap is preserved
+print(xs[-100]?)           # None       — wrap result still out of range
+```
+
+Scope and restrictions (v0.0.25):
+
+- Receivers supported: `Map<K, V>` and `List<T>`.
+- Receivers rejected at compile time: `str` (use `charAt(s, i)`), fixed-length arrays (use `as int` cast on the bounds-checked index), range slice `xs[a..b]?` (no Option-wrapped slice yet), `any`-typed nested `v[k]?` (tracked as #1701).
+- Write-form `m[k]? = v` (and `m[k]?.field = v`, `mm[k]?[k2] = v`) is a compile error — `?` produces an Option, not a slot.
+- Negative-index wrap applies first; the `?` only catches the post-wrap out-of-range case (so `xs[-1]?` on a non-empty list always returns `Some(last)`).
+
+**Footgun — `??` greedy tokenization**: The lexer tokenizes `??` greedily as a single `QuestionQuestion` token. Writing `m["k"]?? default` (no space between `?` and `?`) parses as `m["k"]` (which aborts on a missing key) followed by `?? default`. To get the Option-returning form coalesced with a default, **always leave a space**: `m["k"]? ?? default`.
+
+```ry
+m = {"a": 1}
+print(m["a"]? ?? 99)       # 1   — Option-returning form coalesces missing → 99
+# print(m["z"]?? 99)       # ABORT — `m["z"]` aborts before `??` is reached
 ```
 
 ### At the top level

--- a/include/ry/ast.hpp
+++ b/include/ry/ast.hpp
@@ -243,6 +243,7 @@ struct ListExpr {
 struct IndexExpr {
     ExprPtr object;
     std::vector<ExprPtr> indices;
+    bool try_mode = false;
 };
 
 struct MapExpr {

--- a/src/codegen_arc_cow.cpp
+++ b/src/codegen_arc_cow.cpp
@@ -383,6 +383,11 @@ llvm::Value *CodeGen::emitPathCowForChain(ExprNode &chain) {
     // and privatize the child stored there.
     if (auto *idxPtr = std::get_if<std::unique_ptr<IndexExpr>>(&chain.data)) {
         IndexExpr *idx = idxPtr->get();
+        // #1699: a try-mode IndexExpr in the write-side path-CoW chain
+        // (`m[k]?[i] = v`, `arr[i]?[j] = v`) produces an Option<T> mid-chain
+        // with no writable slot; reject before any CoW work is emitted.
+        if (idx->try_mode)
+            codegenError("'?' index cannot be used as assignment target");
         if (idx->indices.size() != 1)
             codegenError("path CoW: multi-index hop not supported");
         llvm::Value *parent = emitPathCowForChain(*idx->object);

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -749,6 +749,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     // invalid IR (ICmp ptr vs i64). Route to the shared slice helper instead.
     if (e->indices.size() == 1 && objPtr->getType() == ptrTy_) {
         if (const auto *rp = std::get_if<std::unique_ptr<RangeExpr>>(&e->indices[0]->data)) {
+            if (e->try_mode)
+                codegenError("'?' index not supported for range slice");
             if (isStringValue(objPtr))
                 codegenError("str does not support range index; use substr(s, a, b) instead");
             llvm::Type *elemTy = getListElementType(objPtr);
@@ -776,8 +778,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     for (auto &idx : e->indices)
         indexValues.push_back(emitExpr(*idx));
 
-    if (llvm::Value *result = trySubscriptOperatorCall(objPtr, indexValues))
+    if (llvm::Value *result = trySubscriptOperatorCall(objPtr, indexValues)) {
+        if (e->try_mode)
+            codegenError("'?' index not supported for operator[] overload");
         return result;
+    }
     if (indexValues.size() > 1)
         codegenError("multi-index requires operator[] overload");
 
@@ -802,6 +807,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     }
     if (ai) {
         if (auto *arrTy = llvm::dyn_cast<llvm::ArrayType>(ai->getAllocatedType())) {
+            if (e->try_mode)
+                codegenError("'?' index not supported for fixed-length arrays");
             llvm::Type *elemTy = arrTy->getElementType();
             uint64_t arrSize = arrTy->getNumElements();
 
@@ -823,8 +830,11 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     if (objPtr->getType() != ptrTy_)
         codegenError("index operator requires list or map");
 
-    if (isStringValue(objPtr))
+    if (isStringValue(objPtr)) {
+        if (e->try_mode)
+            codegenError("'?' index not supported for str");
         codegenError("str does not support index access; use charAt(s, i) instead");
+    }
 
     // Check if this is a map
     llvm::Type *mapKeyTy = getMapKeyType(objPtr);
@@ -837,8 +847,54 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
         if (index->getType() != mapKeyTy)
             codegenError("map key type mismatch");
 
+        // Snapshot the value type name before any call that may rehash
+        // value_metadata_ and invalidate getMeta(objPtr).
+        std::string mapValTypeName;
+        if (auto *mvtnMeta = getMeta(objPtr))
+            mapValTypeName = mvtnMeta->map_value_type_name;
+
         // Lookup key
         llvm::Value *idx = emitMapKeyLookup(objPtr, index, mapKeyTy);
+
+        if (e->try_mode) {
+            // #1699: m[k]? returns Option<V> instead of aborting on missing key.
+            llvm::StructType *optTy = getOptionType(mapValTy);
+            llvm::Value *found = builder_.CreateICmpSGE(idx, llvm::ConstantInt::get(i64Ty_, 0), "trymap_found");
+
+            llvm::BasicBlock *foundBB = llvm::BasicBlock::Create(*ctx_, "trymap.found", fn_);
+            llvm::BasicBlock *notFoundBB = llvm::BasicBlock::Create(*ctx_, "trymap.notfound", fn_);
+            llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "trymap.merge", fn_);
+            builder_.CreateCondBr(found, foundBB, notFoundBB);
+
+            builder_.SetInsertPoint(foundBB);
+            llvm::Value *valsPtrField = builder_.CreateStructGEP(mapHeaderTy_, objPtr, 3, "trymap_vals_field");
+            llvm::Value *valsPtr = builder_.CreateLoad(ptrTy_, valsPtrField, "trymap_vals");
+            llvm::Value *valPtr = builder_.CreateGEP(mapValTy, valsPtr, {idx}, "trymap_val_ptr");
+            llvm::Value *foundVal = builder_.CreateLoad(mapValTy, valPtr, "trymap_val");
+            // Propagate element metadata onto foundVal BEFORE buildSomeValue,
+            // so the retain inside buildSomeValue picks the right kind
+            // (e.g. str_elem → StringHeader at -24).
+            if (!mapValTypeName.empty()) {
+                propagateTypeMeta(mapValTypeName, foundVal);
+                if (mapValTypeName == "str")
+                    getOrCreateMeta(foundVal).str_elem = true;
+            }
+            llvm::Value *someVal = buildSomeValue(foundVal, optTy);
+            builder_.CreateBr(mergeBB);
+            llvm::BasicBlock *foundEndBB = builder_.GetInsertBlock();
+
+            builder_.SetInsertPoint(notFoundBB);
+            llvm::Value *noneVal = buildNoneValue(optTy);
+            builder_.CreateBr(mergeBB);
+            llvm::BasicBlock *notFoundEndBB = builder_.GetInsertBlock();
+
+            builder_.SetInsertPoint(mergeBB);
+            llvm::PHINode *phi = builder_.CreatePHI(optTy, 2, "trymap_result");
+            phi->addIncoming(someVal, foundEndBB);
+            phi->addIncoming(noneVal, notFoundEndBB);
+            propagateMeta(someVal, phi);
+            return phi;
+        }
 
         // Check if found
         llvm::Value *notFound = builder_.CreateICmpSLT(idx, llvm::ConstantInt::get(i64Ty_, 0), "not_found");
@@ -859,9 +915,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
         llvm::Value *valElemPtr = builder_.CreateGEP(mapValTy, valsPtr, {idx}, "val_elem_ptr");
         llvm::Value *mapVal = builder_.CreateLoad(mapValTy, valElemPtr, "map_val");
 
-        auto *mvtnMeta = getMeta(objPtr);
-        if (mvtnMeta && !mvtnMeta->map_value_type_name.empty()) {
-            propagateTypeMeta(mvtnMeta->map_value_type_name, mapVal);
+        if (!mapValTypeName.empty()) {
+            propagateTypeMeta(mapValTypeName, mapVal);
             // Map<K,str>: stamp str_elem locally so Case 4 retains via
             // StringHeader (-24). MUST be stamped only in the indexer
             // paths, never from a shared helper like propagateTypeMeta —
@@ -870,7 +925,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
             // makes retain dispatch through emitStrGetHeaderFromData
             // (val - 24) on a pointer that does not own a StringHeader,
             // corrupting adjacent heap state.
-            if (mvtnMeta->map_value_type_name == "str")
+            if (mapValTypeName == "str")
                 getOrCreateMeta(mapVal).str_elem = true;
         }
 
@@ -885,30 +940,25 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
     llvm::Value *lenPtr = builder_.CreateStructGEP(listHeaderTy_, objPtr, 0, "len_ptr");
     llvm::Value *length = builder_.CreateLoad(i64Ty_, lenPtr, "length");
 
-    emitBoundsCheck(index, length,
-                    "runtime error: index %lld out of bounds for list of length %lld\n", ".idx_err", "index");
-    llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, objPtr, 2, "data_ptr");
-    llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "data");
-    llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {index}, "elem_ptr");
-    llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "elem");
-
-    // Without this, chained indexing like matrix[i][j] loses element type metadata.
+    // Snapshot list element metadata BEFORE any call (propagateTypeMeta,
+    // setTypeMeta, buildSomeValue) that may rehash value_metadata_ and
+    // invalidate the pointer returned by getMeta(objPtr).
+    std::string elemTypeName;
+    std::optional<FnTypeInfo> elemFnTypeInfo;
+    bool listElemIsStr = false;
+    if (auto *listMeta = getMeta(objPtr)) {
+        elemTypeName   = listMeta->list_elem_type_name;
+        elemFnTypeInfo = listMeta->list_elem_fn_type_info;
+        listElemIsStr  = listMeta->list_elem_is_str;
+    }
     llvm::Type *nestedElemTy = getNestedListElementType(objPtr);
-    if (nestedElemTy)
-        setTypeMeta(TypeMeta::ListElem, elem, nestedElemTy);
 
-    // Propagate Map/Set/closure element metadata (e.g. List<Map<str,int>>, List<closure>)
-    // Copy metadata fields before any call that may rehash value_metadata_ and invalidate
-    // the pointer returned by getMeta().
-    {
-        std::string elemTypeName;
-        std::optional<FnTypeInfo> elemFnTypeInfo;
-        bool listElemIsStr = false;
-        if (auto *listMeta = getMeta(objPtr)) {
-            elemTypeName   = listMeta->list_elem_type_name;
-            elemFnTypeInfo = listMeta->list_elem_fn_type_info;
-            listElemIsStr  = listMeta->list_elem_is_str;
-        }
+    auto stampLoadedElem = [&](llvm::Value *elem) {
+        // Without this, chained indexing like matrix[i][j] loses element type metadata.
+        if (nestedElemTy)
+            setTypeMeta(TypeMeta::ListElem, elem, nestedElemTy);
+
+        // Propagate Map/Set/closure element metadata (e.g. List<Map<str,int>>, List<closure>).
         if (!elemTypeName.empty())
             propagateTypeMeta(elemTypeName, elem);
         // #1664: Stamp tuple sig (e.g. "(int, T)" from enumerate / zip /
@@ -937,7 +987,57 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IndexExpr> &e) {
         // discriminant. (#1266, #1576)
         if (listElemIsStr)
             getOrCreateMeta(elem).str_elem = true;
+    };
+
+    if (e->try_mode) {
+        // #1699: xs[i]? returns Option<T> instead of aborting on OOB.
+        // Apply the existing negative-index wrap (matches the abort path),
+        // then ICmp-only bounds check (no abort) → PHI Some/None.
+        if (index->getType() == i1Ty_)
+            index = builder_.CreateZExt(index, i64Ty_, "tryidx_ext");
+        llvm::Value *wrapped = emitNegativeIndexWrap(index, length, "tryidx");
+        llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
+        llvm::Value *negCheck = builder_.CreateICmpSLT(wrapped, zero, "tryidx_neg");
+        llvm::Value *overCheck = builder_.CreateICmpSGE(wrapped, length, "tryidx_over");
+        llvm::Value *oob = builder_.CreateOr(negCheck, overCheck, "tryidx_oob");
+
+        llvm::StructType *optTy = getOptionType(elemTy);
+        llvm::BasicBlock *oobBB = llvm::BasicBlock::Create(*ctx_, "trylist.oob", fn_);
+        llvm::BasicBlock *okBB = llvm::BasicBlock::Create(*ctx_, "trylist.ok", fn_);
+        llvm::BasicBlock *mergeBB = llvm::BasicBlock::Create(*ctx_, "trylist.merge", fn_);
+        builder_.CreateCondBr(oob, oobBB, okBB);
+
+        builder_.SetInsertPoint(okBB);
+        llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, objPtr, 2, "data_ptr");
+        llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "data");
+        llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {wrapped}, "tryelem_ptr");
+        llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "tryelem");
+        stampLoadedElem(elem);
+        llvm::Value *someVal = buildSomeValue(elem, optTy);
+        builder_.CreateBr(mergeBB);
+        llvm::BasicBlock *okEndBB = builder_.GetInsertBlock();
+
+        builder_.SetInsertPoint(oobBB);
+        llvm::Value *noneVal = buildNoneValue(optTy);
+        builder_.CreateBr(mergeBB);
+        llvm::BasicBlock *oobEndBB = builder_.GetInsertBlock();
+
+        builder_.SetInsertPoint(mergeBB);
+        llvm::PHINode *phi = builder_.CreatePHI(optTy, 2, "trylist_result");
+        phi->addIncoming(someVal, okEndBB);
+        phi->addIncoming(noneVal, oobEndBB);
+        propagateMeta(someVal, phi);
+        return phi;
     }
+
+    emitBoundsCheck(index, length,
+                    "runtime error: index %lld out of bounds for list of length %lld\n", ".idx_err", "index");
+    llvm::Value *dataPtrField = builder_.CreateStructGEP(listHeaderTy_, objPtr, 2, "data_ptr");
+    llvm::Value *dataPtr = builder_.CreateLoad(ptrTy_, dataPtrField, "data");
+    llvm::Value *elemPtr = builder_.CreateGEP(elemTy, dataPtr, {index}, "elem_ptr");
+    llvm::Value *elem = builder_.CreateLoad(elemTy, elemPtr, "elem");
+
+    stampLoadedElem(elem);
 
     return elem;
 }

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -380,6 +380,11 @@ void CodeGen::emitStmt(FieldAssignStmt &s) {
     // through record / nested-collection chains is tracked by issue #854.
     if (auto *idxPtr = std::get_if<std::unique_ptr<IndexExpr>>(&s.object->data)) {
         IndexExpr *idxExpr = idxPtr->get();
+        // #1699: `m[k]?.field = v` would produce an Option<V> mid-chain; that
+        // shape has no addressable field slot, so reject the construction
+        // before any CoW / load is emitted.
+        if (idxExpr->try_mode)
+            codegenError("'?' index cannot be used as assignment target");
         llvm::AllocaInst *receiverAlloca = tryGetReceiverAlloca(*idxExpr->object);
         llvm::Value *containerPtr = emitExpr(*idxExpr->object);
         if (idxExpr->indices.size() != 1)

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -309,7 +309,9 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                 if (i > 0) idxStr += ", ";
                 idxStr += formatExpr(*v->indices[i]);
             }
-            return formatExpr(*v->object) + "[" + idxStr + "]";
+            // #1699: round-trip the Option-returning postfix `?` modifier.
+            return formatExpr(*v->object) + "[" + idxStr + "]" +
+                   (v->try_mode ? "?" : "");
         } else if constexpr (std::is_same_v<T, std::unique_ptr<MapExpr>>) {
             std::string pairs;
             for (size_t i = 0; i < v->keys.size(); ++i) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -199,6 +199,10 @@ StmtNode Parser::finishChainedLhs(ExprPtr chain, const Token &first) {
     auto buildStmt = [&](ExprPtr value, std::optional<std::string> op) -> StmtNode {
         if (tailKindIsIndex(*chain)) {
             auto &idx = std::get<std::unique_ptr<IndexExpr>>(chain->data);
+            // #1699: `m[k]?` and `xs[i]?` are read-only Option-returning forms;
+            // they cannot be used as an assignment target (plain or compound).
+            if (idx->try_mode)
+                parseError(first.line, "'?' index cannot be used as assignment target");
             IndexAssignStmt s;
             s.object = std::move(idx->object);
             s.indices = std::move(idx->indices);
@@ -855,6 +859,14 @@ StmtNode Parser::parseStatement() {
         auto idxExpr = std::make_unique<IndexExpr>();
         idxExpr->object = std::move(varExpr);
         idxExpr->indices = std::move(indices);
+        // #1699: absorb a trailing `?` as the Option-returning index modifier,
+        // matching parsePostfixContinuation. Without this, `m[k]? = v` would
+        // parse as `ErrorPropagateExpr(IndexExpr)` and reach the generic
+        // "not an lvalue" path instead of the targeted try-mode rejection.
+        if (lex_.peek().kind == TokenKind::Question) {
+            lex_.next(); // consume '?'
+            idxExpr->try_mode = true;
+        }
         auto chain = std::make_unique<ExprNode>();
         chain->data = std::move(idxExpr);
         chain->loc = locFromToken(lbTok);

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -1096,6 +1096,10 @@ ExprPtr Parser::parsePostfixContinuation(ExprPtr expr) {
             auto idx = std::make_unique<IndexExpr>();
             idx->object = std::move(expr);
             idx->indices = std::move(indices);
+            if (lex_.peek().kind == TokenKind::Question) {
+                lex_.next(); // consume '?' as Option-returning index modifier (#1699)
+                idx->try_mode = true;
+            }
             auto node = std::make_unique<ExprNode>();
             node->data = std::move(idx);
             node->loc = locFromToken(lbTok);

--- a/tests/spec/index_option.test.ry
+++ b/tests/spec/index_option.test.ry
@@ -1,0 +1,147 @@
+from testing import it, describe, expect, fail
+
+fn lookup(m: Map<str, int>, k: str) -> Option<int>:
+  return m[k]?
+
+fn lookupAt(xs: List<int>, i: int) -> Option<int>:
+  return xs[i]?
+
+@describe("Option-returning index m[k]? / xs[i]?")
+fn indexOptionTests():
+  @describe("Map<str, int>")
+  fn mapStrIntTests():
+    @it("returns Some for existing key")
+    fn mapHit():
+      m = {"a": 1, "b": 2}
+      expect(m["a"]?).toEq(Some(1))
+      expect(m["b"]?).toEq(Some(2))
+    @it("returns None for missing key")
+    fn mapMiss():
+      m = {"a": 1, "b": 2}
+      expect(m["z"]?).toBeNone()
+    @it("combines with ?? default (space-separated)")
+    fn mapWithCoalesce():
+      m = {"a": 1, "b": 2}
+      expect(m["a"]? ?? -1).toEq(1)
+      expect(m["z"]? ?? -1).toEq(-1)
+    @it("works on empty map")
+    fn mapEmpty():
+      m: Map<str, int> = {}
+      expect(m["a"]?).toBeNone()
+
+  @describe("List<int>")
+  fn listIntTests():
+    @it("returns Some for in-range positive index")
+    fn listHit():
+      xs = [10, 20, 30]
+      expect(xs[0]?).toEq(Some(10))
+      expect(xs[1]?).toEq(Some(20))
+      expect(xs[2]?).toEq(Some(30))
+    @it("returns None for positive out-of-bounds index")
+    fn listPositiveOob():
+      xs = [10, 20, 30]
+      expect(xs[3]?).toBeNone()
+      expect(xs[100]?).toBeNone()
+    @it("wraps negative index in-range to Some")
+    fn listNegativeHit():
+      xs = [10, 20, 30]
+      expect(xs[-1]?).toEq(Some(30))
+      expect(xs[-2]?).toEq(Some(20))
+      expect(xs[-3]?).toEq(Some(10))
+    @it("returns None for negative out-of-bounds index")
+    fn listNegativeOob():
+      xs = [10, 20, 30]
+      expect(xs[-4]?).toBeNone()
+      expect(xs[-100]?).toBeNone()
+    @it("returns None on empty list for any index")
+    fn listEmpty():
+      xs: List<int> = []
+      expect(xs[0]?).toBeNone()
+      expect(xs[-1]?).toBeNone()
+    @it("combines with ?? default")
+    fn listWithCoalesce():
+      xs = [10, 20, 30]
+      expect(xs[1]? ?? -1).toEq(20)
+      expect(xs[100]? ?? -1).toEq(-1)
+      expect(xs[-100]? ?? -1).toEq(-1)
+
+  @describe("Function and lambda return-type inference")
+  fn returnTypeTests():
+    @it("propagates as tail return Option<int>")
+    fn tailReturn():
+      m = {"a": 1}
+      case lookup(m, "a"):
+        Some(v): expect(v).toEq(1)
+        None: fail("expected Some")
+      case lookup(m, "z"):
+        Some(v): fail("expected None")
+        None: expect(true).toEq(true)
+    @it("works for List tail return Option<int>")
+    fn tailReturnList():
+      xs = [10, 20, 30]
+      case lookupAt(xs, 1):
+        Some(v): expect(v).toEq(20)
+        None: fail("expected Some")
+      case lookupAt(xs, 99):
+        Some(v): fail("expected None")
+        None: expect(true).toEq(true)
+    @it("works with explicit type annotation")
+    fn typeAnnotation():
+      m = {"a": 7}
+      x: Option<int> = m["a"]?
+      expect(x).toEq(Some(7))
+      y: Option<int> = m["z"]?
+      expect(y).toBeNone()
+    @it("works as lambda body with explicit Option<int> return type")
+    fn lambdaInference():
+      m = {"a": 100, "b": 200}
+      f = (k: str) -> Option<int> => m[k]?
+      case f("a"):
+        Some(v): expect(v).toEq(100)
+        None: fail("expected Some")
+      case f("z"):
+        Some(v): fail("expected None")
+        None: expect(true).toEq(true)
+
+  @describe("ARC: Map<str, str> and List<str>")
+  fn arcStrTests():
+    @it("Map<str, str> retains string element correctly via Some(v)")
+    fn mapStrStr():
+      m = {"k1": "hello", "k2": "world"}
+      case m["k1"]?:
+        Some(v): expect(v).toEq("hello")
+        None: fail("expected Some")
+      case m["zzz"]?:
+        Some(v): fail("expected None")
+        None: expect(true).toEq(true)
+      # ensure the original map is still usable after Some(v) extraction
+      expect(m["k2"]?).toEq(Some("world"))
+    @it("List<str> wraps element into Some without leaking")
+    fn listStr():
+      xs = ["foo", "bar", "baz"]
+      case xs[0]?:
+        Some(v): expect(v).toEq("foo")
+        None: fail("expected Some")
+      case xs[-1]?:
+        Some(v): expect(v).toEq("baz")
+        None: fail("expected Some")
+      case xs[10]?:
+        Some(v): fail("expected None")
+        None: expect(true).toEq(true)
+
+  @describe("Embedded NUL keys (byte-keyed Map)")
+  fn embeddedNulTests():
+    @it("distinguishes keys with embedded NUL bytes")
+    fn nulKey():
+      m = {"a\0b": 1, "a\0c": 2}
+      expect(m["a\0b"]?).toEq(Some(1))
+      expect(m["a\0c"]?).toEq(Some(2))
+      expect(m["a\0z"]?).toBeNone()
+
+  @describe("Coalesce footgun documentation pin")
+  fn coalesceFootgunTests():
+    @it("space-separated ?? coalesces None to default")
+    fn spaceSeparated():
+      m = {"a": 1}
+      expect(m["z"]? ?? 99).toEq(99)
+      expect(m["a"]? ?? 99).toEq(1)

--- a/tests/test_codegen.cpp
+++ b/tests/test_codegen.cpp
@@ -1846,3 +1846,74 @@ TEST_F(CodeGenTest, U64AnnotationFormatterRoundtrip) {
         "print(h)"),
         "18446744073709551615\n");
 }
+
+// ===== Option-returning index `m[k]?` / `xs[i]?` rejections (#1699) =====
+
+TEST_F(CodeGenTest, OptionIndexRejectsMapAssignmentTarget) {
+    // Write-form `m[k]? = v` must be a compile error — `?` returns Option, not a slot.
+    expectCompileError(
+        "m: Map<str, int> = {}\nm[\"k\"]? = 1\n",
+        "'?' index cannot be used as assignment target");
+}
+
+TEST_F(CodeGenTest, OptionIndexRejectsListAssignmentTarget) {
+    // List write-form is rejected the same way.
+    expectCompileError(
+        "xs = [1, 2, 3]\nxs[0]? = 99\n",
+        "'?' index cannot be used as assignment target");
+}
+
+TEST_F(CodeGenTest, OptionIndexRejectsCompoundAssignmentTarget) {
+    // Compound assignment routes through the same lvalue path.
+    expectCompileError(
+        "m: Map<str, int> = {\"a\": 1}\nm[\"a\"]? += 1\n",
+        "'?' index cannot be used as assignment target");
+}
+
+TEST_F(CodeGenTest, OptionIndexRejectsFieldAssignmentChain) {
+    // `m[k]?.x = v` must be rejected at the CoW-chain layer.
+    expectCompileError(
+        "record P:\n  x: int\n"
+        "m: Map<str, P> = {}\nm[\"k\"]?.x = 1\n",
+        "'?' index cannot be used as assignment target");
+}
+
+TEST_F(CodeGenTest, OptionIndexRejectsNestedIndexAssignment) {
+    // Nested `mm[k]?[k2] = v` likewise rejected via path-CoW guard.
+    expectCompileError(
+        "mm: Map<str, Map<str, int>> = {}\nmm[\"a\"]?[\"b\"] = 1\n",
+        "'?' index cannot be used as assignment target");
+}
+
+TEST_F(CodeGenTest, OptionIndexRejectsFixedLengthArray) {
+    // Fixed-length arrays already abort on OOB statically; `?` is meaningless.
+    expectCompileError(
+        "a: i32[3] = [1, 2, 3]\nx = a[0]?\n",
+        "'?' index not supported for fixed-length arrays");
+}
+
+TEST_F(CodeGenTest, OptionIndexRejectsString) {
+    // str does not support `[]` at all; the diagnostic is redirected to charAt(),
+    // but `?` short-circuits to a dedicated message first.
+    expectCompileError(
+        "s = \"hi\"\nx = s[0]?\n",
+        "'?' index not supported for str");
+}
+
+TEST_F(CodeGenTest, OptionIndexRejectsRangeSlice) {
+    // Range slice `xs[a..b]` returns a new list, not a single element — Option<List<T>>
+    // is intentionally out of scope for v0.0.25.
+    expectCompileError(
+        "xs = [1, 2, 3]\nys = xs[0..1]?\n",
+        "'?' index not supported for range slice");
+}
+
+TEST_F(CodeGenTest, OptionIndexRejectsAnyTypedNested) {
+    // `any`-typed nested `v[k]?` falls through to the existing list/map gate (#1701
+    // will lift this restriction). The compile error is "index operator requires list
+    // or map", not the dedicated try_mode message, but it's a compile error either way.
+    expectCompileError(
+        "a: any = 1\nv = a[\"x\"]?\n",
+        "index operator requires list or map");
+}
+


### PR DESCRIPTION
## Summary

- Add postfix `?` syntax to Map / List index expressions to return `Option<V>` / `Option<T>` instead of aborting on missing key / out-of-bounds (`m["a"]?` → `Some(v)` when present, `None` otherwise; `xs[i]?` returns `Some(v)` when the [possibly negative-wrapped] index is in range and `None` otherwise).
- Read-only — write-form `m[k]? = v`, fixed-length array `a[i]?`, `str` `s[i]?`, range slice `xs[a..b]?`, and `any`-nested `v[k]?` are compile errors (the last is tracked separately as #1701).
- Implementation: new `IndexExpr.try_mode` bool. Parser absorbs `?` immediately after `]` in both expression and statement-LHS positions. Codegen emits PHI-merged `buildSomeValue` / `buildNoneValue` over the existing Map lookup and List bounds check; negative-index wrap is applied first so `xs[-1]?` on a non-empty list always returns `Some(last)`. ARC element metadata is snapshotted before the PHI so `Map<str, str>` retains via the correct `str_elem` discriminant.

**Footgun documented**: the lexer tokenizes `??` greedily, so `m["k"]?? default` (no space) parses as `m["k"]` (abort) + `?? default`. Use `m["k"]? ?? default` (with space) for the Option-returning form coalesced with a default. Highlighted in `docs/reference/operators.md`.

## Test plan

- [x] `./build/ry_tests` — 2418 tests PASSED
- [x] `./build/ry test -p` — 196 test files, 0 failures (includes new `tests/spec/index_option.test.ry` with 18 cases: Map / List positive + negative + ARC<str> + embedded-NUL keys + `??` footgun pin + function/lambda Option<int> return-type inference)
- [x] ASan + UBSan — clean on both `ry_tests` and `ry test -p`
- [x] TSan — `ry_tests` 2416 PASSED (2 known `@timeout` skips); targeted `index_option.test.ry` 18/18 pass under TSan
- [x] clang-tidy — no new warnings/errors on modified TUs
- [x] cppcheck — exit 0
- [x] libFuzzer `fuzz_parser` — 60s, 46178 runs, no crashes

## C++ contract tests (added)

Nine `expectCompileError` cases pin the 5 rejection branches plus 3 statement-side write rejections:

- `m[k]? = v` / `xs[i]? = v` / `m[k]? += v` — assignment target
- `m[k]?.field = v` / `mm[k]?[k2] = v` — CoW-chain assignment
- `a[i]?` on fixed-length array — `'?' index not supported for fixed-length arrays`
- `s[i]?` on str — `'?' index not supported for str`
- `xs[a..b]?` — `'?' index not supported for range slice`
- `a["x"]?` on `any` — falls through to existing `index operator requires list or map` gate (#1701 will lift this)

## Documentation

- `docs/reference/operators.md` — split into "Unwrap / short-circuit form" + new "Option-returning index form" subsection with table, examples, scope/restrictions list, and footgun warning
- `docs/reference/collections.md` — added "Safe Index Access (`xs[i]?`)" to List and "Safe Key Access (`m[k]?`)" to Map, both linking back to operators.md
- `docs/grammar.ebnf` — comments on `postfix_op` index and `?` rows pointing to #1699; syntactic shape unchanged
- `changelog.d/1699-option-index.md` — `### Added` entry with full semantics, scope, and the `??` greedy-tokenization footgun

## Out of scope / known follow-ups

- **§3.6.5 tree-sitter check — pre-existing failure on `tests/spec/json.test.ry`**: `loadAs[List<any>]` (generic type parameter via `[...]`) introduced by #1698 (merged earlier today) is not yet covered by the in-tree tree-sitter grammar and is not listed in `expected-fail.txt`. This PR does not touch `editor/tree-sitter/` (`git diff main..HEAD -- editor/tree-sitter/` is empty); the new `tests/spec/index_option.test.ry` parses cleanly. Tracking as a separate concern.
- `any`-nested `v[k]?` will be addressed by #1701.

Closes #1699

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safe indexing with postfix `?` operator for Maps and Lists—`m[k]?` and `xs[i]?` return `Option` values instead of aborting on missing keys or out-of-bounds access.
  * Supports coalescing with `??` operator for default values.

* **Documentation**
  * Updated collection, operator, and grammar reference documentation with comprehensive examples and usage restrictions for safe indexing.
  * Added changelog entry documenting the new optional indexing syntax and its semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1815?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->