### PR TITLE
fix(runtime): unify trap-path exit(1) to _Exit(1) + fflush (#1840)

### DIFF
--- a/.claude/rules/runtime-memory-safety.md
+++ b/.claude/rules/runtime-memory-safety.md
@@ -309,18 +309,31 @@ if the crash re-appears, revert to the diagnostic checklist above.
 
 ---
 
-### Ry runtime panics bypass C++ exceptions — they `fprintf + exit(1)`
+### Ry runtime panics bypass C++ exceptions — they `fprintf + _Exit(1)`
 
-**Source**: #828
-**Tags**: panic, runtime, exception, thread, gotcha
+**Source**: #828, #1838 (2026-05-21 codegen trap path), #1840 (2026-05-21 runtime trap-path unification)
+**Tags**: panic, runtime, exception, thread, trap-path, _Exit, fflush, atexit, managed-static, gotcha
 
 **Rule**: Every `CodeGen::emitRuntimeError` call site emits IR that
-runs `fprintf(stderr, ...)` followed by `exit(1)` +
-`CreateUnreachable` (`src/codegen_call_user.cpp:600-618`). Ry's user-level
-panics (divide-by-zero, array OOB, range/contract violations,
-integer overflow, etc.) therefore **terminate the entire process
-immediately** — they do not propagate as C++ exceptions. Any
-feature that plans to "catch a worker panic and report it as a
+runs `fprintf(stderr, ...)`, then `fflush(stdout)` + `fflush(stderr)`,
+followed by `_Exit(1)` + `CreateUnreachable`
+(`src/codegen_call_user.cpp:740-778`). Ry's user-level panics
+(divide-by-zero, array OOB, range/contract violations, integer
+overflow, etc.) therefore **terminate the entire process immediately
+via `_Exit`** — they do not propagate as C++ exceptions, and they
+bypass `atexit` handlers (including LLVM `ManagedStatic` destructors).
+
+The C++ runtime trap-path counterpart — used when JIT'd code calls
+out to a runtime function that panics (e.g. `__ry_utf8_char_at`
+out-of-bounds, JSON parse error, ARC misuse) — is the shared helper
+`ry_runtime_trap_exit()` in `include/ry/runtime_alloc.hpp`. It does
+the same `fflush(stdout); fflush(stderr); std::_Exit(1);`. Any new
+trap path emitted from runtime C++ MUST call this helper, never
+`exit(1)` or `std::exit(1)`. The `lint` job in `.github/workflows/ci.yml`
+("Check for banned direct exit() calls in runtime") blocks
+regressions automatically.
+
+Any feature that plans to "catch a worker panic and report it as a
 value" (e.g. `threadJoin(t) -> Err` for a panicking worker,
 `blockOn(task) -> Err` for a panicking async body) cannot rely on
 existing defensive `try { ... } catch (std::exception &)` blocks
@@ -329,13 +342,33 @@ that escape from LLVM-generated code, which never happens for
 user panics. The existing catch in `__ry_thread_spawn`
 (`src/runtime_thread.cpp`) is dormant defensive code, not an
 active error-propagation path. Fixing this requires refactoring
-`emitRuntimeError` to `throw std::runtime_error(...)` + installing
-a top-level catch in `ry run` / `ry test` — tracked in #880.
-Before writing tests that trigger a panic and expect
-`Err(error_msg)`, verify that the panic *actually* throws a C++
-exception; the only current throw path from runtime code is
+both `emitRuntimeError` and `ry_runtime_trap_exit` to a throw-based
+path + installing a top-level catch in `ry run` / `ry test` —
+tracked in #880. Before writing tests that trigger a panic and
+expect `Err(error_msg)`, verify that the panic *actually* throws a
+C++ exception; the only current throw path from runtime code is
 `__ry_task_join` double-join (`src/runtime_parallel.cpp:292`) and a
 handful of compile-time lexer/loader errors.
+
+**Why `_Exit` and not `exit`** (#1838): `exit(1)` invokes the
+`atexit` chain, which on Linux glibc runs LLVM `ManagedStatic`
+destructors (`PassRegistry::~PassRegistry`, etc.) on a heap still
+referenced by the JIT'd module that triggered the trap.
+`free(): invalid pointer` SIGABRT replaces the expected
+`ExitedWithCode(1)` before death-test assertions can observe it.
+`_Exit` bypasses `atexit` entirely; no static destructor runs.
+ASan's allocator interceptor masks the issue, so the symptom only
+reproduces on default (non-ASan) Linux builds — macOS libSystem
+malloc tolerates the same pattern silently. The explicit
+`fflush(stdout); fflush(stderr)` immediately before `_Exit` recovers
+the libc buffer flush that `exit` would have done via `atexit`, so
+panic messages and any preceding `print` output are not lost.
+
+**Why `llvm_shutdown` / RAII don't apply**: those would only help on
+the *normal* exit path (process returns from `main`). The trap path
+runs **inside** a JIT'd thread that has no way to unwind back to
+`main` — `_Exit` from within the JIT is the only correct semantic
+for "abort this process immediately without disturbing the JIT heap".
 
 ### `ListHeader` / `IOListHeader` returned to Ry code must be `arc_alloc`'d, not `checked_malloc`'d
 
@@ -460,10 +493,10 @@ check to the codegen emitter.
 - Result-returning functions: call `setLastError("fn: argument contains an embedded NUL byte")` before returning `nullptr` / `1`.
 - This matches the split used in `src/runtime_io.cpp` after #1128: `__ry_file_exists` has `if (hasEmbeddedNul(path)) return 0;` with no `setLastError`, while all other path-taking functions call it.
 
-### Forbidden heap allocation functions in new C++ code
+### Forbidden heap allocation functions and trap-path exits in new C++ code
 
-**Source**: #1498 (migrated from AGENTS.md, 2026-05-02)
-**Tags**: runtime, memory-safety, malloc, oom, checked_malloc, forbidden-functions, lint
+**Source**: #1498 (migrated from AGENTS.md, 2026-05-02), #1840 (2026-05-21 trap-path unification)
+**Tags**: runtime, memory-safety, malloc, oom, checked_malloc, forbidden-functions, lint, exit, _Exit, trap-path
 
 **Rule**: Use the safe wrappers from `include/ry/runtime_alloc.hpp`.
 The following functions must **not** be called directly in new code:
@@ -476,6 +509,7 @@ The following functions must **not** be called directly in new code:
 | `strdup` | `checked_strdup` | OOM → null |
 | `strndup` | `checked_strndup` | OOM → null |
 | `malloc(count * sizeof(T))` | `checked_array_malloc(count, sizeof(T))` | integer overflow → heap buffer overflow |
+| `exit` / `std::exit` (in `src/runtime_*.cpp`) | `ry_runtime_trap_exit()` | `exit()` runs `atexit` → LLVM `ManagedStatic` destructors on JIT-live heap → SIGABRT (#1838) |
 
 Additional rules:
 - On OOM, call `oom_abort(n)` with the requested size and abort
@@ -483,5 +517,15 @@ Additional rules:
 - Before passing external input (HTTP request body, JSON parse result,
   etc.) to `strcmp` / `strlen`, check for NULL.
 - The CI `lint` job detects direct calls to forbidden functions and
-  auto-blocks new additions.
+  auto-blocks new additions. Two grep-based steps live in
+  `.github/workflows/ci.yml`: "Check for banned unsafe allocation
+  functions" (scans `src/`+`include/` for raw `malloc`/`realloc`/etc.)
+  and "Check for banned direct exit() calls in runtime" (scans
+  `src/runtime_*.cpp` for direct `exit(...)` / `std::exit(...)`).
+- The `exit` ban is scoped to `src/runtime_*.cpp` deliberately: user-visible
+  exit-builtin codegen (`src/codegen_call_user.cpp` `getStdlibExit`,
+  `src/codegen_match.cpp:1172`) and shutdown paths in `main.cpp` still
+  use `exit()` legitimately. The `_Exit`, `_exit`, and `quick_exit`
+  forms are also allowed everywhere — the regex word-boundary in the
+  lint step doesn't match those identifiers.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,24 @@ jobs:
             echo "::error::Raw allocation functions detected. Use checked_* wrappers from include/ry/runtime_alloc.hpp instead."
             exit 1
           fi
+      - name: Check for banned direct exit() calls in runtime
+        run: |
+          # Trap-path runtime functions must use ry_runtime_trap_exit()
+          # from include/ry/runtime_alloc.hpp, not exit(). exit() runs
+          # the atexit chain, which on Linux glibc invokes LLVM
+          # ManagedStatic destructors on a heap still referenced by the
+          # JIT'd module — `free(): invalid pointer` SIGABRT before the
+          # expected ExitedWithCode(1) is observed (#1838). The \b in
+          # the regex prevents matches against the allowed forms _exit,
+          # _Exit, quick_exit, getStdlibExit, getStdlibImmediateExit,
+          # which all have a word character (underscore or letter)
+          # immediately before "exit" and so don't match a word
+          # boundary at the start.
+          if grep -nE '\b(std::)?exit\s*\(' src/runtime_*.cpp \
+            | grep -vE '^[^:]+:[0-9]+:[[:space:]]*//'; then
+            echo "::error::Direct exit() call in src/runtime_*.cpp detected. Use ry_runtime_trap_exit() (from include/ry/runtime_alloc.hpp) instead."
+            exit 1
+          fi
       - name: Run Cppcheck
         run: |
           # `--suppress=normalCheckLevelMaxBranches` is required from

--- a/changelog.d/1840-runtime-trap-exit-unify.md
+++ b/changelog.d/1840-runtime-trap-exit-unify.md
@@ -1,0 +1,22 @@
+### Fixed
+
+- Unified the JIT trap-path exit across the C++ runtime so it matches
+  the codegen-emitted trap path from #1838. A new shared helper
+  `ry_runtime_trap_exit()` in `include/ry/runtime_alloc.hpp` is now used
+  by all 16 `exit(1)` sites that previously lived in
+  `src/runtime_any.cpp`, `src/runtime_utf8.cpp`, `src/runtime_json.cpp`,
+  and `src/runtime_regex.cpp`. The helper calls `fflush(stdout)` +
+  `fflush(stderr)` then `std::_Exit(1)` — bypassing the `atexit` chain
+  (and the LLVM `ManagedStatic` destructors that ran on the still-live
+  JIT heap, causing `free(): invalid pointer` SIGABRT before the
+  expected `ExitedWithCode(1)` was observed). `CodeGen::emitRuntimeError`
+  in `src/codegen_call_user.cpp` was retrofitted to emit matching
+  `fflush(stdout)` / `fflush(stderr)` IR calls immediately before the
+  existing `_Exit(1)` IR call, so panic messages and any preceding
+  `print` output survive even when stdio buffering was line-buffered
+  to a pipe. A new CI `lint` step ("Check for banned direct exit()
+  calls in runtime") blocks regressions by rejecting any direct
+  `exit(...)` / `std::exit(...)` in `src/runtime_*.cpp`; allowed forms
+  (`_Exit`, `_exit`, `quick_exit`, and the codegen helpers
+  `getStdlibExit` / `getStdlibImmediateExit`) are not affected.
+  (#1840)

--- a/include/ry/runtime_alloc.hpp
+++ b/include/ry/runtime_alloc.hpp
@@ -27,6 +27,15 @@ namespace ry {
     abort();
 }
 
+// JIT trap path: bypass atexit / static destructors to avoid the LLVM
+// ManagedStatic double-free observed on JIT teardown (#1838). stdio
+// buffers are flushed explicitly so panic messages are not lost.
+[[noreturn]] inline void ry_runtime_trap_exit() {
+    std::fflush(stdout);
+    std::fflush(stderr);
+    std::_Exit(1);
+}
+
 inline void *checked_malloc(size_t n) {
     void *p = malloc(n);
     if (!p && n > 0) oom_abort(n);

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -742,8 +742,10 @@ void CodeGen::emitRuntimeError(const std::string &message, const std::string &gl
     auto fprintfTy = llvm::FunctionType::get(i32Ty_, {ptrTy_, ptrTy_}, true);
     auto fprintfFn = mod_->getOrInsertFunction("fprintf", fprintfTy);
 #ifdef __APPLE__
+    const char *stdoutName = "__stdoutp";
     const char *stderrName = "__stderrp";
 #else
+    const char *stdoutName = "stdout";
     const char *stderrName = "stderr";
 #endif
     auto *stderrGlobal = mod_->getOrInsertGlobal(stderrName, ptrTy_);
@@ -760,6 +762,14 @@ void CodeGen::emitRuntimeError(const std::string &message, const std::string &gl
     // atexit entirely so no static destructor runs. ASan's allocator
     // interceptor masks the issue, so this only repros on the default Linux
     // build. macOS libSystem malloc tolerates the same pattern silently.
+    // fflush(stdout/stderr) before _Exit since _Exit skips the atexit-driven
+    // libc buffer flush that exit() would have performed.
+    auto fflushTy = llvm::FunctionType::get(i32Ty_, {ptrTy_}, false);
+    auto fflushFn = mod_->getOrInsertFunction("fflush", fflushTy);
+    auto *stdoutGlobal = mod_->getOrInsertGlobal(stdoutName, ptrTy_);
+    llvm::Value *stdoutVal = builder_.CreateLoad(ptrTy_, stdoutGlobal, "stdout");
+    builder_.CreateCall(fflushFn, {stdoutVal});
+    builder_.CreateCall(fflushFn, {stderrVal});
     auto exitFn = getStdlibImmediateExit();
     builder_.CreateCall(exitFn, {llvm::ConstantInt::get(i32Ty_, 1)});
     builder_.CreateUnreachable();

--- a/src/runtime_any.cpp
+++ b/src/runtime_any.cpp
@@ -1,3 +1,4 @@
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_any.hpp"
 #include "ry/runtime_list.hpp"
 #include "ry/runtime_string.hpp"
@@ -110,7 +111,7 @@ static void repeatStr(RyAny *result, const char *s, int64_t n) {
     if (len > 0 && (static_cast<uint64_t>(n) > SIZE_MAX ||
                     static_cast<size_t>(n) > SIZE_MAX / len)) {
         fprintf(stderr, "runtime error: string repeat overflow\n");
-        exit(1);
+        ry_runtime_trap_exit();
     }
     size_t count = static_cast<size_t>(n);
     char *buf = makeStringUninit(len * count);
@@ -263,7 +264,7 @@ extern "C" const char *__ry_any_to_string(const RyAny *a) {
         fprintf(stderr,
                 "runtime error: __ry_any_to_string: unsupported any tag %lld\n",
                 (long long)a->tag);
-        exit(1);
+        ry_runtime_trap_exit();
     }
 }
 
@@ -325,7 +326,7 @@ extern "C" void __ry_arc_dtor_enum_dispatch(void *dataPtr) {
 extern "C" void __ry_any_type_error(const char *op, int64_t tag_a, int64_t tag_b) {
     fprintf(stderr, "runtime error: operator %s not supported for %s and %s\n",
             op, tagName(tag_a), tagName(tag_b));
-    exit(1);
+    ry_runtime_trap_exit();
 }
 
 // ===== Arithmetic operators (#221) =====
@@ -412,7 +413,7 @@ extern "C" void __ry_any_mod(RyAny *result, const RyAny *a, const RyAny *b) {
         int64_t bv = extractInt(b);
         if (bv == 0) {
             fprintf(stderr, "runtime error: modulo by zero\n");
-            exit(1);
+            ry_runtime_trap_exit();
         }
         // Floor modulo: r = a % b; if (r != 0 && sign(r) != sign(b)) r += b
         int64_t av = extractInt(a);
@@ -439,7 +440,7 @@ extern "C" void __ry_any_floordiv(RyAny *result, const RyAny *a, const RyAny *b)
         int64_t av = extractInt(a), bv = extractInt(b);
         if (bv == 0) {
             fprintf(stderr, "runtime error: division by zero\n");
-            exit(1);
+            ry_runtime_trap_exit();
         }
         int64_t q = av / bv;
         if ((av ^ bv) < 0 && q * bv != av) q--;
@@ -475,7 +476,7 @@ extern "C" void __ry_any_neg(RyAny *result, const RyAny *a) {
         makeFloat(result, -extractFloat(a));
     } else {
         fprintf(stderr, "runtime error: unary - not supported for %s\n", tagName(a->tag));
-        exit(1);
+        ry_runtime_trap_exit();
     }
 }
 

--- a/src/runtime_json.cpp
+++ b/src/runtime_json.cpp
@@ -1,4 +1,5 @@
 #include "ry/runtime_json.hpp"
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_io.hpp"
 #include "ry/runtime_arc.hpp"
 #include "ry/runtime_any_typed_coll.hpp"
@@ -533,7 +534,7 @@ static void stringify_any(const RyAny *v, std::string &out,
             if (!std::isfinite(fv)) {
                 fprintf(stderr,
                         "json stringify: non-finite float is not representable in JSON\n");
-                exit(1);
+                ry_runtime_trap_exit();
             }
             char buf[64];
             snprintf(buf, sizeof(buf), "%.17g", fv);
@@ -562,7 +563,7 @@ static void stringify_any(const RyAny *v, std::string &out,
                     "stringify: any holds typed collection '%s' "
                     "— use List<any> / Map<str, any> / Set<any> instead\n",
                     coll_type);
-                exit(1);
+                ry_runtime_trap_exit();
             }
             auto *hdr = static_cast<ListHeader *>(hdr_ptr);
             if (hdr->len == 0) { out += "[]"; break; }
@@ -588,7 +589,7 @@ static void stringify_any(const RyAny *v, std::string &out,
                     "stringify: any holds typed collection '%s' "
                     "— use List<any> / Map<str, any> / Set<any> instead\n",
                     coll_type);
-                exit(1);
+                ry_runtime_trap_exit();
             }
             auto *hdr = static_cast<MapHeader *>(hdr_ptr);
             if (hdr->len == 0) { out += "{}"; break; }
@@ -613,13 +614,13 @@ static void stringify_any(const RyAny *v, std::string &out,
             // so the side-table lookup would be redundant — keep the
             // existing message which is already actionable.
             fprintf(stderr, "json stringify: Set is not representable in JSON\n");
-            exit(1);
+            ry_runtime_trap_exit();
         case RyAnyTag::Record:
             fprintf(stderr, "json stringify: record is not representable in JSON\n");
-            exit(1);
+            ry_runtime_trap_exit();
         case RyAnyTag::Enum:
             fprintf(stderr, "json stringify: enum is not representable in JSON\n");
-            exit(1);
+            ry_runtime_trap_exit();
     }
 }
 

--- a/src/runtime_regex.cpp
+++ b/src/runtime_regex.cpp
@@ -1,4 +1,5 @@
 #include "ry/runtime_regex.hpp"
+#include "ry/runtime_alloc.hpp"
 #include "ry/runtime_regex_error_sentinels.hpp"
 #include "ry/runtime_error.hpp"
 #include "ry/runtime_regex_internal.hpp"
@@ -232,7 +233,7 @@ public:
         }
         // unreachable
         fprintf(stderr, "regex internal error: unknown node kind\n");
-        exit(1);
+        ry_runtime_trap_exit();
     }
 
     void patch(NFAFragment &frag, NFAState *target) {

--- a/src/runtime_utf8.cpp
+++ b/src/runtime_utf8.cpp
@@ -71,7 +71,7 @@ char *__ry_utf8_char_at(const char *s, int64_t i) {
     }
     // Safety net: codegen should have caught this via emitBoundsCheck
     fprintf(stderr, "runtime error: charAt() index out of bounds\n");
-    exit(1);
+    ry_runtime_trap_exit();
 }
 
 char *__ry_utf8_char_at_checked(const char *s, int64_t byte_len, int64_t i) {
@@ -92,7 +92,7 @@ char *__ry_utf8_char_at_checked(const char *s, int64_t byte_len, int64_t i) {
         fprintf(stderr,
                 "runtime error: index %lld out of bounds for string of length %lld\n",
                 (long long)i, (long long)idx);
-        exit(1);
+        ry_runtime_trap_exit();
     }
 
     // Negative index: count all codepoints to resolve wrap.
@@ -106,7 +106,7 @@ char *__ry_utf8_char_at_checked(const char *s, int64_t byte_len, int64_t i) {
         fprintf(stderr,
                 "runtime error: index %lld out of bounds for string of length %lld\n",
                 (long long)i, (long long)count);
-        exit(1);
+        ry_runtime_trap_exit();
     }
     int64_t resolved = i + count;
 


### PR DESCRIPTION
## Summary

Follow-up to #1838. PR #1838 fixed `CodeGen::emitRuntimeError` to emit `_Exit(1)` instead of `exit(1)` in the JIT trap path, but 16 direct `exit(1)` calls remained in `src/runtime_{any,utf8,json,regex}.cpp` with the same root cause. This PR unifies them.

- Introduce shared helper `ry_runtime_trap_exit()` in `include/ry/runtime_alloc.hpp` (does `fflush(stdout); fflush(stderr); std::_Exit(1);`) and replace all 16 sites with it.
- Retrofit `CodeGen::emitRuntimeError` (`src/codegen_call_user.cpp`) to emit matching `fflush(stdout)` + `fflush(stderr)` IR calls immediately before the existing `_Exit(1)` IR call, so panic messages and any preceding `print` output survive line-buffered stdio.
- Add a CI `lint` step ("Check for banned direct exit() calls in runtime") that rejects any direct `exit(...)` / `std::exit(...)` in `src/runtime_*.cpp`. Allowed forms (`_Exit`, `_exit`, `quick_exit`, `getStdlibExit`, `getStdlibImmediateExit`) are unaffected by the word-boundary regex.
- Update `.claude/rules/runtime-memory-safety.md`: forbidden-functions table now lists `exit` / `std::exit` in `src/runtime_*.cpp` with `ry_runtime_trap_exit()` as the replacement, and the panic-semantics entry is updated from `fprintf + exit(1)` to `fprintf + _Exit(1)`.

### Why `_Exit` not `exit`

`exit(1)` invokes the `atexit` chain, which on Linux glibc runs LLVM `ManagedStatic` destructors (`PassRegistry::~PassRegistry`, etc.) on a heap still referenced by the JIT'd module that triggered the trap. `free(): invalid pointer` SIGABRT replaces the expected `ExitedWithCode(1)` before death-test assertions can observe it. `_Exit` bypasses `atexit` entirely. ASan's allocator interceptor masks the issue, so the symptom only reproduces on default (non-ASan) Linux builds. The explicit `fflush(stdout/stderr)` before `_Exit` recovers the libc buffer flush that `exit` would have done.

## Test plan

- [x] `./build/ry_tests` 全 pass (existing `EXPECT_EXIT(..., ExitedWithCode(1), ...)` death tests act as regression guards)
- [x] `./build/ry test -p` 全 pass (197 ファイル)
- [x] ASan+UBSan ビルドで pass (2426 tests + 197 Ry files)
- [x] TSan ビルドで pass (2424 tests + 197 Ry files)
- [x] libFuzzer `fuzz_json` / `fuzz_utf8` 60 秒 budget — crash なし
- [x] CI lint grep ローカル実行 exit 0
- [x] `getStdlibImmediateExit` の呼び出し元検証 — `emitRuntimeError` の 1 箇所のみ (fflush retrofit が全 `_Exit(1)` IR emit 経路をカバー)

Closes #1840

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed output buffering issues that could cause error messages or print statements to be lost when programs terminate unexpectedly or output is redirected.
  * Improved process shutdown to prevent potential data corruption during emergency exit paths.

* **Chores**
  * Added automated checks to prevent regressions in process termination handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1841?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->