### PR TITLE
feat(lang,io): add Iterator<T> built-in type and io.File.lines() lazy iterator (#1818)

### DIFF
--- a/.claude/rules/codegen-arc-cow.md
+++ b/.claude/rules/codegen-arc-cow.md
@@ -134,6 +134,127 @@ init runs the destructor on a partially-initialized binding. The
 load-bearing nature of this ordering is documented at
 `src/codegen_stmt_loop.cpp:834-837`.
 
+### Resource-handle `close()` is decoupled from ARC release so live iterators survive
+
+**Source**: #1818 (2026-05-21, feat — `lines()` iterator)
+**Tags**: codegen, resource, close, arc, iterator, lifetime, file
+
+**Rule**: For `File` and any future resource that exposes a user-facing
+`close(handle)` together with a long-lived iterator over the same
+handle (`lines(f) -> Iterator<str>`), do **not** route `close()` through
+`emitResourceFree`. `emitResourceFree` combines the runtime
+cleanup call (`__ry_io_file_cleanup`) with an immediate
+`__ry_arc_release` on the ARC header — that releases the box even
+though a live `Iterator<File>` is still pointing at it via its `state`
+field. The next iteration loads `fp` from freed memory → heap-UAF.
+
+Instead, `close(File)` must call only the user-facing
+`__ry_io_file_close` runtime helper, which sets
+`IoFileHandle::fp = nullptr` inside the still-alive ARC box. The
+File's ARC header is released exactly once at scope exit (or when
+the last alias drops). The `lines()` iterator's `next_fn` checks
+`fp == nullptr` at the top of every step and terminates the
+iteration cleanly (no error raised — Python-compatible).
+
+**Why**: Tcp resources (`TcpListener` / `TcpStream` / `TlsStream`)
+historically used `emitResourceFree` because they have no
+long-lived iterator companion — close = the end. File is the first
+resource where close and iterate must coexist, so the contract
+changes shape: close = invalidate the handle inside the box; ARC
+release = drop the box. Bundling the two breaks iterator safety.
+
+**How to apply**:
+- `src/codegen_call.cpp` — `close(File)` dispatch emits a direct
+  call to `__ry_io_file_close` (returns Unit), not
+  `emitResourceFree`.
+- `src/runtime_io.cpp` — keep `__ry_io_file_close` (user-facing,
+  `fp = nullptr`) and `__ry_io_file_cleanup` (ARC destructor,
+  `fclose` + `arc_free`) as separate functions. Never collapse
+  them. The destructor calls `fclose` only if `fp != nullptr`, so
+  close-then-destructor is correct and idempotent.
+- New resources following this pattern must adopt the same
+  split as soon as a streaming iterator API lands. Until then,
+  `emitResourceFree` is acceptable for fire-and-forget close
+  (no iterator companion).
+
+### Resource handles bound through pattern matching need explicit `resource_managed_vars_` registration
+
+**Source**: #1818 (2026-05-21, feat — `lines()` iterator UAF debug)
+**Tags**: codegen, resource, pattern, arc, file, ok-bind, using-alias
+
+**Rule**: When a resource handle (`File`, `TcpListener`, etc.) is
+extracted from a `Result<Resource, Error>` via `Ok(f):` (or similar
+pattern), `emitPatternBindingArc` must (a) call `markArcManaged`
+on the bind alloca, (b) insert into `resource_managed_vars_`
+keyed by the alloca with the kind looked up via
+`ResourceKindRegistry::lookupByTypeName(resolved)`, and (c) call
+`addResourceKind(bindAlloca, rk)`. Without all three,
+`emitScopeCleanupToDepth` will not invoke the resource cleanup
+function on scope exit, and `nullifyResourceVar` (called from
+`close(f)`) will be a no-op (only zeros allocas in
+`resource_managed_vars_`).
+
+A subtle complication: `Result<File, Error>` is **not** in
+`arc_tagged_union_vars_` because `fieldTypeIsArcManaged("File")`
+returns false (File is a resource, not an ARC-payload struct).
+That means the subject of the `case` does NOT emit an ARC release
+at scope exit. Consequently, `emitPatternBindingArc` for File must
+NOT emit a balancing `emitArcRetain` — the strong=1 from
+`__ry_io_file_open` transfers directly to the bind through the
+ExtractValue without a refcount adjustment. Adding a retain in
+that path leaks.
+
+**Why**: The `arc_tagged_union_vars_` registration filter and the
+`emitPatternBindingArc` retain logic must agree on whether the
+subject will release at scope end. Mismatches cause leak (retain
+without release) or double-free (no retain but the subject did
+release).
+
+**How to apply**:
+- In `emitPatternBindingArc` (path 2a — record-typed bind), when
+  `resolved` is a known resource type name (`File`, `TcpListener`,
+  `TcpStream`, `TlsStream`), look up the kind via
+  `ResourceKindRegistry`, register all three side-tables, and
+  return WITHOUT emitting retain.
+- Aliasing the bind via `using fh = f` then requires a one-time
+  retain at the `using` site (next entry), because `popScope`
+  will release the alias and would underflow without the retain.
+
+### `using <alias> = <variable>` retains when the source is a tracked binding
+
+**Source**: #1818 (2026-05-21, feat — `lines()` iterator UAF debug)
+**Tags**: codegen, using, alias, arc, resource, retain
+
+**Rule**: `using fh = f` where `f` is already in
+`resource_managed_vars_` (e.g. `f` came from `Ok(f):` and was
+registered per the previous entry) MUST emit a one-time
+`emitArcRetain` on the source's ARC header before storing it into
+the alias alloca. Without this retain, the alias's scope-end
+release runs `__ry_io_file_cleanup` on a handle that the source
+still holds; when the source then scope-exits, it releases a
+zero-refcount box → double-free.
+
+The retain is conditional: `using f = open(...)` (the fresh-temp
+case) does NOT need a retain because the runtime allocator already
+returns strong=1 and the alias is the sole owner. Only the
+variable-source case adds an aliasing reference.
+
+**Why**: The `using` statement's contract is "scope-bound release".
+For fresh temps the source is anonymous, so the alias inherits the
+sole ownership and one release is correct. For aliased
+variable-source bindings, both the source and the alias must
+release independently, requiring one retain.
+
+**How to apply**: In `emitStmt(UsingStmt)`
+(`src/codegen_stmt_loop.cpp`), after evaluating the init expression
+but before any pointer store, check whether the init was a
+`VariableExpr` whose alloca is in `resource_managed_vars_`. If yes,
+call `emitArcGetHeaderFromData(val)` + `emitArcRetain(hdr, /*atomic=*/false)`.
+Skip the retain for any other init shape (call expression, field
+access, etc.). When generalising to other resource kinds, keep this
+predicate purely structural — do not rely on the resource kind
+itself; only on whether the source is a tracked variable.
+
 ### `threadSpawn` thunks emit no ARC ops; `parallel_for_depth_` is the atomic-ARC scope marker
 
 `threadSpawn` thunks do NOT retain/release captures — env stores raw pointer copies and the thunk's `FnScope` is destroyed at codegen without `popScope()`. Caller MUST call `threadJoin` before the captured value's owning scope exits. `parallel_for_depth_` counter (`isArcAtomic() → atomicrmw seqcst`) covers ARC ops emitted directly inside `@parallel for` thunk bodies; it does NOT propagate to helper-function calls. Decision: keep the scope-counter design; whole-program "may cross threads" analysis was rejected as too expensive.

--- a/changelog.d/1818-io-file-lines-iterator.md
+++ b/changelog.d/1818-io-file-lines-iterator.md
@@ -1,0 +1,10 @@
+### Added
+
+- `io.lines(f: File) -> Iterator<str>` lazy line iterator. Pair with
+  `for line in lines(f) { ... }` to process large files without loading
+  them into memory. The iterator retains the underlying `File` for its
+  lifetime and shares the read position with subsequent `readLine` /
+  `lines` calls. After `close(f)`, iteration terminates at the next
+  step rather than raising (Python-compatible). Closes the `#1700`
+  series of streaming-IO requests (`#1816` File handles, `#1817`
+  `using` statement, `#1818` `lines()` + `Iterator<T>`). (#1818)

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -36,6 +36,7 @@ from io import readText, writeText, exists
 | `readLine` | `(File) -> Result<Option<str>, Error>` | Reads one line; returns `Ok(None)` at EOF |
 | `writeText` | `(File, str) -> Result<Unit, Error>` | Writes a string to the file |
 | `close` | `(File) -> Unit` | Closes the file handle (idempotent) |
+| `lines` | `(File) -> Iterator<str>` | Returns a lazy line iterator usable with `for ... in` |
 
 `File` is an opaque resource handle managed by ARC. The file is closed automatically when the handle goes out of scope; calling `close` explicitly allows earlier release.
 
@@ -43,7 +44,7 @@ from io import readText, writeText, exists
 >
 > **Scope-based release**: A `File` can be bound with the `using` statement to have `close` called automatically on every exit path of a block (`return`, `?`, `break`, `continue`, or normal block end). See [`control-flow.md` § using](control-flow.md#using).
 >
-> **Future**: `lines()` iterator (#1700-C) is tracked as a separate issue.
+> **`lines()` iterator**: `for line in lines(f) { ... }` yields one line at a time without loading the file into memory — suitable for large logs. The iterator retains the underlying `File` for its lifetime and shares the file position with subsequent `readLine` / `lines` calls. After `close(f)`, iteration terminates at the next step (no error is raised, mirroring Python).
 
 ### Byte Conversions
 
@@ -115,6 +116,15 @@ case open("/tmp/hello.txt", "r"):
                     print(e.message)
                     break
         close(f)
+    Err(e):
+        print(e.message)
+
+# Lazy line iteration with lines() — suitable for large files
+case open("/tmp/hello.txt", "r"):
+    Ok(f):
+        using fh = f:
+            for line in lines(fh):
+                print(line)
     Err(e):
         print(e.message)
 

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -82,7 +82,7 @@ case deleteFile("hello.txt"):
 ### File Handle API
 
 ```ry
-from io import open, readAll, readLine, writeText, close, deleteFile
+from io import open, readAll, readLine, writeText, close, deleteFile, lines
 
 # Write then read back via handle
 case open("/tmp/hello.txt", "w"):

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -561,6 +561,15 @@ public:
     std::vector<std::unordered_set<std::string>> immutable_scope_stack_;
     llvm::SmallPtrSet<llvm::AllocaInst*, 8> captured_vars_; // reject reassignment of captured vars inside closure body
     std::vector<std::vector<llvm::Value*>> iterator_malloc_stack_; // per-scope iterator malloc tracking
+    // Parallel stack: per-scope ARC release hooks attached to iterators that
+    // retain external resources in their state (e.g. io.File.lines() retains
+    // the File handle). Each entry holds (data_ptr, resource_kind); cleanup
+    // emits arc release IR before the iterator state malloc is freed.
+    struct IteratorReleaseHook {
+        llvm::Value *data_ptr;
+        int resource_kind;
+    };
+    std::vector<std::vector<IteratorReleaseHook>> iterator_release_hooks_;
 
     // ======== Module-level bindings (#817) ========
     // Top-level `let` and `@const` declarations are stored as alloca in
@@ -1343,6 +1352,7 @@ public:
         std::unordered_map<llvm::AllocaInst*, std::string> savedArcTaggedUnion_;
         std::unordered_map<llvm::AllocaInst*, std::string> savedArcAnyManaged_;
         std::vector<std::vector<llvm::Value*>> savedIteratorMallocs_;
+        std::vector<std::vector<IteratorReleaseHook>> savedIteratorReleaseHooks_;
         llvm::BasicBlock *savedBlock_;
         llvm::BasicBlock::iterator savedPoint_;
         std::vector<ExprPtr> *savedPostconditions_;

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -667,6 +667,13 @@ public:
     std::vector<std::unordered_map<std::string, std::vector<OverloadEntry>>> fn_scope_stack_;
     int nested_fn_counter_ = 0;   // monotonic counter for unique IR names
     int fn_nesting_depth_ = 0;    // 0 = top-level, incremented per FnScope
+    // Bumped while emitPatternBindings is producing the *guard*-scope copy of
+    // an arm's pattern (see codegen_match.cpp). Guard bindings live in a
+    // throwaway scope that pops between the pattern test and the body's
+    // re-bind, so resource-handle binds need a balancing retain to keep the
+    // scrutinee alive across the guard-scope popScope cleanup (#1818 PR
+    // review — CodeRabbit "guarded arms can free File scrutinee").
+    int pattern_binding_in_guard_depth_ = 0;
     std::vector<OverloadEntry> *findFunction(const std::string &name);
     void forwardDeclareFunctionsInBody(std::vector<StmtNode> &stmts, bool validateOperatorReturn);
     void forwardDeclareNestedFunctions(std::vector<StmtNode> &body);

--- a/share/std/io/io.ry
+++ b/share/std/io/io.ry
@@ -67,3 +67,7 @@ fn writeText(f: File, s: str) -> Result<Unit, Error>
 @public
 @native("io")
 fn close(f: File) -> Unit
+
+@public
+@native("io")
+fn lines(f: File) -> Iterator<str>

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -169,6 +169,7 @@ CodeGen::FnScope::FnScope(CodeGen &cg) : cg_(cg) {
     savedArcTaggedUnion_ = std::move(cg_.arc_tagged_union_vars_);
     savedArcAnyManaged_ = std::move(cg_.arc_any_managed_vars_);
     savedIteratorMallocs_ = std::move(cg_.iterator_malloc_stack_);
+    savedIteratorReleaseHooks_ = std::move(cg_.iterator_release_hooks_);
     savedBlock_ = cg_.builder_.GetInsertBlock();
     savedPoint_ = cg_.builder_.GetInsertPoint();
     savedPostconditions_ = cg_.current_postconditions_;
@@ -192,6 +193,7 @@ CodeGen::FnScope::FnScope(CodeGen &cg) : cg_(cg) {
     cg_.arc_tagged_union_vars_.clear();
     cg_.arc_any_managed_vars_.clear();
     cg_.iterator_malloc_stack_.clear();
+    cg_.iterator_release_hooks_.clear();
     cg_.current_postconditions_ = nullptr;
     cg_.ensure_bindings_ = nullptr;
     cg_.in_ensure_context_ = false;
@@ -213,6 +215,7 @@ CodeGen::FnScope::~FnScope() noexcept {
     cg_.arc_tagged_union_vars_ = std::move(savedArcTaggedUnion_);
     cg_.arc_any_managed_vars_ = std::move(savedArcAnyManaged_);
     cg_.iterator_malloc_stack_ = std::move(savedIteratorMallocs_);
+    cg_.iterator_release_hooks_ = std::move(savedIteratorReleaseHooks_);
     cg_.builder_.SetInsertPoint(savedBlock_, savedPoint_);
     cg_.current_postconditions_ = savedPostconditions_;
     cg_.ensure_bindings_ = savedEnsureBindings_;
@@ -435,6 +438,7 @@ void CodeGen::pushScope() {
     scope_stack_.emplace_back();
     immutable_scope_stack_.emplace_back();
     iterator_malloc_stack_.emplace_back();
+    iterator_release_hooks_.emplace_back();
     if (fn_nesting_depth_ > 0)
         fn_scope_stack_.emplace_back();
 }
@@ -459,6 +463,7 @@ void CodeGen::popScope() {
     scope_stack_.pop_back();
     immutable_scope_stack_.pop_back();
     iterator_malloc_stack_.pop_back();
+    iterator_release_hooks_.pop_back();
     if (fn_nesting_depth_ > 0 && !fn_scope_stack_.empty())
         fn_scope_stack_.pop_back();
 }
@@ -510,6 +515,18 @@ void CodeGen::emitScopeCleanupToDepth(size_t targetDepth) {
             }
             if (!arc_managed_vars_.count(alloca)) continue;
             emitArcReleaseVar(name, alloca);
+        }
+        // Iterator-retained resources (#1818): release ARC handles that the
+        // iterator state holds (e.g. io.File.lines() retains the File handle).
+        // Hooks store the data ptr directly so order vs the state free below
+        // is irrelevant, but we emit them first to mirror the conventional
+        // "release contents, then free container" pattern.
+        auto &iterHooks = iterator_release_hooks_[i - 1];
+        for (auto &hook : iterHooks) {
+            auto *hdr = emitArcGetHeaderFromData(hook.data_ptr);
+            bool atomic = isArcAtomic(hook.data_ptr);
+            emitArcRelease(hdr, atomic,
+                           getOrCreateResourceDestructor(hook.resource_kind));
         }
         auto &iterMallocs = iterator_malloc_stack_[i - 1];
         if (!iterMallocs.empty()) {

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -706,6 +706,9 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
             // happens at scope exit (or when the last alias drops); decoupling
             // the user-facing close from refcount-drop keeps lines()/readLine()
             // iterators valid after close (they observe fp==nullptr and finish).
+            // The io runtime symbol lives in libry_io — register the library so
+            // bare close(f) calls (no enclosing io import path) resolve.
+            used_native_libraries_.insert("io");
             auto fnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
             auto fn = mod_->getOrInsertFunction("__ry_io_file_close", fnTy);
             builder_.CreateCall(fn, {val});

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -701,8 +701,16 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
             return emitResourceFree(val, detectResourceKind(val), *e.args[0]);
         if (isTlsStream(val))
             return emitResourceFree(val, detectResourceKind(val), *e.args[0]);
-        if (isFile(val))
-            return emitResourceFree(val, detectResourceKind(val), *e.args[0]);
+        if (isFile(val)) {
+            // close() = invalidate fp inside the still-alive ARC box. ARC release
+            // happens at scope exit (or when the last alias drops); decoupling
+            // the user-facing close from refcount-drop keeps lines()/readLine()
+            // iterators valid after close (they observe fp==nullptr and finish).
+            auto fnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
+            auto fn = mod_->getOrInsertFunction("__ry_io_file_close", fnTy);
+            builder_.CreateCall(fn, {val});
+            return llvm::ConstantInt::get(i8Ty_, 0); // Unit
+        }
         codegenError("close() requires a File, TcpStream, TlsStream, or TcpListener argument");
     }
 

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -221,6 +221,94 @@ static llvm::Value *emitFileReadLine(CodeGen &cg, const CallExpr & /*e*/, llvm::
         });
 }
 
+static llvm::Value *emitFileLines(CodeGen &cg, const CallExpr & /*e*/, llvm::Value *fileHandle, int fileRk) {
+    // State struct: { ptr file } — iterator holds a retained reference to the
+    // File handle so the underlying FILE* stays alive even if the user lets
+    // their `f` binding go out of scope before iteration finishes.
+    llvm::StructType *stateTy = llvm::StructType::get(*cg.ctx_,
+        llvm::ArrayRef<llvm::Type *>{cg.ptrTy_});
+    const llvm::DataLayout &dl = cg.mod_->getDataLayout();
+    uint64_t stateSize = dl.getTypeAllocSize(stateTy);
+
+    // Emit the next function: reads one line via __ry_io_file_read_line,
+    // returns Some(line) on status==0, None on EOF / error / closed.
+    llvm::StructType *optTy = cg.getOptionType(cg.ptrTy_);
+    static int file_lines_counter = 0;
+    std::string fnName = "__iter_file_lines_next." + std::to_string(file_lines_counter++);
+    llvm::FunctionType *nextFnTy = llvm::FunctionType::get(optTy, {cg.ptrTy_}, false);
+    llvm::Function *nextFn = llvm::Function::Create(
+        nextFnTy, llvm::Function::ExternalLinkage, fnName, *cg.mod_);
+
+    {
+        CodeGen::FnScope guard(cg);
+        cg.fn_ = nextFn;
+        cg.pushScope();
+        llvm::BasicBlock *entry = llvm::BasicBlock::Create(*cg.ctx_, "entry", nextFn);
+        cg.builder_.SetInsertPoint(entry);
+
+        llvm::Value *statePtr = nextFn->getArg(0);
+        llvm::Value *file = cg.builder_.CreateLoad(cg.ptrTy_,
+            cg.builder_.CreateStructGEP(stateTy, statePtr, 0), "file");
+
+        llvm::Value *outAlloca = cg.builder_.CreateAlloca(cg.ptrTy_, nullptr, "fl_out");
+        cg.builder_.CreateStore(
+            llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(cg.ptrTy_)),
+            outAlloca);
+
+        auto readLineFn = cg.mod_->getOrInsertFunction(
+            "__ry_io_file_read_line",
+            llvm::FunctionType::get(cg.i64Ty_, {cg.ptrTy_, cg.ptrTy_}, false));
+        llvm::Value *status = cg.builder_.CreateCall(
+            readLineFn, {file, outAlloca}, "fl_status");
+        llvm::Value *isLine = cg.builder_.CreateICmpEQ(
+            status, llvm::ConstantInt::get(cg.i64Ty_, 0), "fl_isline");
+
+        llvm::BasicBlock *someBB = llvm::BasicBlock::Create(*cg.ctx_, "some", nextFn);
+        llvm::BasicBlock *noneBB = llvm::BasicBlock::Create(*cg.ctx_, "none", nextFn);
+        cg.builder_.CreateCondBr(isLine, someBB, noneBB);
+
+        cg.builder_.SetInsertPoint(someBB);
+        llvm::Value *line = cg.builder_.CreateLoad(cg.ptrTy_, outAlloca, "fl_line");
+        cg.builder_.CreateRet(cg.buildSomeValue(line, optTy));
+
+        cg.builder_.SetInsertPoint(noneBB);
+        cg.builder_.CreateRet(cg.buildNoneValue(optTy));
+        cg.popScope();
+    }
+
+    // Allocate the iterator state and retain the File handle into it.
+    auto mallocFn = cg.getStdlibMalloc();
+    llvm::Value *stateAlloc = cg.builder_.CreateCall(
+        mallocFn, {llvm::ConstantInt::get(cg.i64Ty_, stateSize)}, "lines_state");
+    cg.iterator_malloc_stack_.back().push_back(stateAlloc);
+
+    // ARC retain: the iterator must outlive the user's `f` binding.
+    llvm::Value *fileHdr = cg.emitArcGetHeaderFromData(fileHandle);
+    bool atomic = cg.isArcAtomic(fileHandle);
+    cg.emitArcRetain(fileHdr, atomic);
+    cg.iterator_release_hooks_.back().push_back({fileHandle, fileRk});
+
+    cg.builder_.CreateStore(fileHandle,
+        cg.builder_.CreateStructGEP(stateTy, stateAlloc, 0));
+
+    llvm::Value *header = nullptr;
+    {
+        uint64_t headerSize = dl.getTypeAllocSize(cg.iteratorHeaderTy_);
+        header = cg.builder_.CreateCall(
+            mallocFn, {llvm::ConstantInt::get(cg.i64Ty_, headerSize)}, "lines_header");
+        cg.builder_.CreateStore(nextFn,
+            cg.builder_.CreateStructGEP(cg.iteratorHeaderTy_, header, 0));
+        cg.builder_.CreateStore(stateAlloc,
+            cg.builder_.CreateStructGEP(cg.iteratorHeaderTy_, header, 1));
+        cg.setTypeMeta(CodeGen::TypeMeta::IteratorElem, header, cg.ptrTy_);
+        cg.iterator_malloc_stack_.back().push_back(header);
+    }
+    // Tag the iterator's element type as str so downstream consumers
+    // (`for line in ...`, `toList`) treat each value as a Ry string handle.
+    cg.getOrCreateMeta(header).list_elem_type_name = "str";
+    return header;
+}
+
 static llvm::Value *emitFileWriteText(CodeGen &cg, const CallExpr &e, llvm::Value *fileHandle) {
     llvm::Value *s = cg.emitExpr(*e.args[1]);
     if (!cg.isStringValue(s))
@@ -293,6 +381,14 @@ static llvm::Value *dispatchIO(CodeGen &cg, const CallExpr &e) {
             cg.codegenError("readLine(f): argument must be a File handle; "
                             "use readLine() with no arguments to read from stdin");
         return emitFileReadLine(cg, e, arg0);
+    }
+
+    // lines(f: File) -> Iterator<str>
+    if (n == "lines" && sz == 1) {
+        llvm::Value *arg0 = cg.emitExpr(*e.args[0]);
+        if (!cg.isFile(arg0))
+            cg.codegenError("lines(f): argument must be a File handle");
+        return emitFileLines(cg, e, arg0, rk_file);
     }
 
     // writeText — 2-arg: check if arg0 is File or str

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -802,7 +802,7 @@ void CodeGen::emitPatternBindingArc(llvm::Value *val, llvm::AllocaInst *bindAllo
                 // observe a freed handle (#1818 PR review).
                 if (pattern_binding_in_guard_depth_ > 0) {
                     auto *hdr = emitArcGetHeaderFromData(val);
-                    emitArcRetain(hdr, /*atomic=*/false);
+                    emitArcRetain(hdr, isArcAtomic(val));
                 }
                 markArcManaged(bindAlloca);
                 resource_managed_vars_[bindAlloca] = rk;

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -795,6 +795,15 @@ void CodeGen::emitPatternBindingArc(llvm::Value *val, llvm::AllocaInst *bindAllo
         if (resolved == "File") {
             int rk = ResourceKindRegistry::instance().lookupByTypeName(resolved);
             if (rk != ResourceKindRegistry::NONE) {
+                // Guarded-arm copy of the binding lives in a throwaway scope
+                // that pops between the pattern test and the body re-bind.
+                // Without a retain, the popScope cleanup runs
+                // __ry_io_file_cleanup on the File and the body bind would
+                // observe a freed handle (#1818 PR review).
+                if (pattern_binding_in_guard_depth_ > 0) {
+                    auto *hdr = emitArcGetHeaderFromData(val);
+                    emitArcRetain(hdr, /*atomic=*/false);
+                }
                 markArcManaged(bindAlloca);
                 resource_managed_vars_[bindAlloca] = rk;
                 addResourceKind(bindAlloca, rk);
@@ -887,8 +896,10 @@ void CodeGen::emitStmt(std::unique_ptr<CaseStmt> &s) {
             builder_.SetInsertPoint(guardBB);
 
             pushScope();
+            pattern_binding_in_guard_depth_++;
             emitPatternBindings(arm.pattern, subjectAlloca, subjectTy,
                                 subjectEnumName, subjectSourceTypeName);
+            pattern_binding_in_guard_depth_--;
 
             llvm::Value *guardVal = emitExpr(*arm.guard);
             guardVal = toBool(guardVal);
@@ -973,8 +984,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
             builder_.SetInsertPoint(guardBB);
 
             pushScope();
+            pattern_binding_in_guard_depth_++;
             emitPatternBindings(arm.pattern, subjectAlloca, subjectTy,
                                 subjectEnumName, subjectSourceTypeName);
+            pattern_binding_in_guard_depth_--;
 
             llvm::Value *guardVal = emitExpr(*arm.guard);
             guardVal = toBool(guardVal);

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -1,5 +1,6 @@
 #include "ry/codegen.hpp"
 #include "ry/diagnostic.hpp"
+#include "ry/stdlib_registry.hpp"
 #include <cassert>
 
 
@@ -782,8 +783,24 @@ void CodeGen::emitPatternBindingArc(llvm::Value *val, llvm::AllocaInst *bindAllo
             arc_str_managed_vars_.insert(bindAlloca);
             return;
         }
-        // Resource types, enum values stored as ptr, and other non-ARC types:
-        // no ARC management here.
+        // Resource handles (currently File only) — register so scope exit
+        // releases the ARC ref. Required for `Ok(f): close(f); lines(f)` to
+        // work safely: with this registration, scope cleanup releases the
+        // File's strong count exactly once. No retain on bind because the
+        // enclosing Result<File, Error> subject is not in
+        // arc_tagged_union_vars_ (File does not qualify as
+        // fieldTypeIsArcManaged), so the original strong count from
+        // __ry_io_file_open transfers through the Ok-arm extract without
+        // a balancing subject-side release.
+        if (resolved == "File") {
+            int rk = ResourceKindRegistry::instance().lookupByTypeName(resolved);
+            if (rk != ResourceKindRegistry::NONE) {
+                markArcManaged(bindAlloca);
+                resource_managed_vars_[bindAlloca] = rk;
+                addResourceKind(bindAlloca, rk);
+                return;
+            }
+        }
         return;
     }
 

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -861,6 +861,20 @@ void CodeGen::emitStmt(std::unique_ptr<UsingStmt> &s) {
     resource_managed_vars_[ptr] = rk;
     propagateMetaWide(val, ptr);
 
+    // Alias semantics: retain when the source is itself a tracked binding
+    // (e.g. `using fh = f` where f came from `Ok(f)`). Without the retain,
+    // the source's scope-end release would underflow the strong count and
+    // double-free. Fresh temps (`using f = open(...)`) are already at
+    // strong=1 from the runtime alloc, so no retain is needed.
+    if (auto *varExpr = std::get_if<VariableExpr>(&s->value->data)) {
+        if (auto *srcAlloca = findVar(varExpr->name)) {
+            if (resource_managed_vars_.count(srcAlloca)) {
+                auto *hdr = emitArcGetHeaderFromData(val);
+                emitArcRetain(hdr, /*atomic=*/false);
+            }
+        }
+    }
+
     for (auto &stmt : s->body)
         std::visit([this](auto &st) { emitStmt(st); }, stmt);
 

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -870,7 +870,11 @@ void CodeGen::emitStmt(std::unique_ptr<UsingStmt> &s) {
         if (auto *srcAlloca = findVar(varExpr->name)) {
             if (resource_managed_vars_.count(srcAlloca)) {
                 auto *hdr = emitArcGetHeaderFromData(val);
-                emitArcRetain(hdr, /*atomic=*/false);
+                // Match the ARC mode of the surrounding scope so a
+                // @parallel-for worker (atomic ARC) does not race the
+                // scope-end release. isArcAtomic falls back to the worker
+                // scope counter when no per-value flag is set.
+                emitArcRetain(hdr, isArcAtomic(val));
             }
         }
     }

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -183,6 +183,11 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
         return ptrTy_;
     }
 
+    // Iterator<T> parsing — IteratorHeader { ptr next_fn, ptr state }
+    if (typeName.size() > 9 && typeName.compare(0, 9, "Iterator<") == 0 && typeName.back() == '>') {
+        return ptrTy_;
+    }
+
     // Opaque resource handle types (dynamically registered)
     if (ResourceKindRegistry::instance().lookupByTypeName(typeName) != ResourceKindRegistry::NONE)
         return ptrTy_;

--- a/tests/spec/io_file_handle.test.ry
+++ b/tests/spec/io_file_handle.test.ry
@@ -1,6 +1,6 @@
 from testing import it, describe, expect, fail
 
-from io import open, readAll, readLine, writeText, close, deleteFile
+from io import open, readAll, readLine, writeText, close, deleteFile, lines
 
 @describe("file handle API")
 fn fileHandleTests():
@@ -117,6 +117,98 @@ fn fileHandleTests():
       Err(e):
         fail("open failed: " + e.message)
     deleteFile("/tmp/ry_fh_lines.txt")
+
+  @it("should iterate lines via lines() iterator")
+  fn shouldIterateLinesViaLinesIterator():
+    writeText("/tmp/ry_fh_lines_iter.txt", "alpha\nbeta\ngamma")
+    case open("/tmp/ry_fh_lines_iter.txt", "r"):
+      Ok(f):
+        gotLines: List<str> = []
+        for line in lines(f):
+          append!(gotLines, line)
+        expect(gotLines).toEq(["alpha", "beta", "gamma"])
+        close(f)
+      Err(e):
+        fail("open failed: " + e.message)
+    deleteFile("/tmp/ry_fh_lines_iter.txt")
+
+  @it("should iterate lines() with trailing newline")
+  fn shouldIterateLinesWithTrailingNewline():
+    writeText("/tmp/ry_fh_lines_trail.txt", "one\ntwo\n")
+    case open("/tmp/ry_fh_lines_trail.txt", "r"):
+      Ok(f):
+        gotLines: List<str> = []
+        for line in lines(f):
+          append!(gotLines, line)
+        expect(gotLines).toEq(["one", "two"])
+        close(f)
+      Err(e):
+        fail("open failed: " + e.message)
+    deleteFile("/tmp/ry_fh_lines_trail.txt")
+
+  @it("should iterate empty file with lines() yielding nothing")
+  fn shouldIterateEmptyFileWithLines():
+    writeText("/tmp/ry_fh_lines_empty.txt", "")
+    case open("/tmp/ry_fh_lines_empty.txt", "r"):
+      Ok(f):
+        count = 0
+        for line in lines(f):
+          count = count + 1
+        expect(count).toEq(0)
+        close(f)
+      Err(e):
+        fail("open failed: " + e.message)
+    deleteFile("/tmp/ry_fh_lines_empty.txt")
+
+  @it("should continue iteration across two lines() calls on the same file")
+  fn shouldContinueAcrossTwoLinesCalls():
+    writeText("/tmp/ry_fh_lines_cont.txt", "a\nb\nc\nd")
+    case open("/tmp/ry_fh_lines_cont.txt", "r"):
+      Ok(f):
+        first: List<str> = []
+        nTaken = 0
+        for line in lines(f):
+          append!(first, line)
+          nTaken = nTaken + 1
+          if nTaken >= 2:
+            break
+        expect(first).toEq(["a", "b"])
+        rest: List<str> = []
+        for line in lines(f):
+          append!(rest, line)
+        expect(rest).toEq(["c", "d"])
+        close(f)
+      Err(e):
+        fail("open failed: " + e.message)
+    deleteFile("/tmp/ry_fh_lines_cont.txt")
+
+  @it("should yield no lines after the file is closed")
+  fn shouldYieldNoLinesAfterClose():
+    writeText("/tmp/ry_fh_lines_closed.txt", "x\ny")
+    case open("/tmp/ry_fh_lines_closed.txt", "r"):
+      Ok(f):
+        close(f)
+        count = 0
+        for line in lines(f):
+          count = count + 1
+        expect(count).toEq(0)
+      Err(e):
+        fail("open failed: " + e.message)
+    deleteFile("/tmp/ry_fh_lines_closed.txt")
+
+  @it("should auto-close file via using when iterating with lines()")
+  fn shouldAutoCloseFileViaUsingWithLines():
+    writeText("/tmp/ry_fh_lines_using.txt", "p\nq\nr")
+    case open("/tmp/ry_fh_lines_using.txt", "r"):
+      Ok(f):
+        using fh = f:
+          gotLines: List<str> = []
+          for line in lines(fh):
+            append!(gotLines, line)
+          expect(gotLines).toEq(["p", "q", "r"])
+      Err(e):
+        fail("open failed: " + e.message)
+    deleteFile("/tmp/ry_fh_lines_using.txt")
 
   @it("close should be idempotent")
   fn closeShouldBeIdempotent():


### PR DESCRIPTION
## Summary

- Introduce `Iterator<T>` as a parseable return type for `@native` signatures (built-in generic type)
- Add `io.lines(f: File) -> Iterator<str>` for lazy line-by-line file reading without OOM on large files
- Decouple `close(File)` from ARC release so live iterators survive close (Python-compatible: iteration terminates at the next step rather than raising)
- Register `File` pattern bindings in `resource_managed_vars_` to ensure scope-exit cleanup; `using <alias> = <var>` retains when the source is a tracked binding

## Design

- `Iterator<T>` parses as opaque pointer (`IteratorHeader { ptr next_fn, ptr state }`). Currently scoped to `@native` return-type positions and `for ... in` lowering — user-facing value binding is out of scope.
- `lines()` state struct retains the underlying `File` handle (one extra ARC retain) so the iterator stays valid even if the caller's `f` binding goes out of scope first.
- `close(File)` now routes to `__ry_io_file_close` directly (sets `fp = nullptr` in-place), not `emitResourceFree`. The destructor `__ry_io_file_cleanup` still runs at ARC release and is idempotent vs prior close.
- New `iterator_release_hooks_` per-scope stack emits ARC release IR for resources retained inside iterator state, mirroring the existing `iterator_malloc_stack_`.

## Implementation tasks completed

- [x] `share/std/io/io.ry` — `@native fn lines(f: File) -> Iterator<str>`
- [x] `src/codegen_call_io.cpp` — `emitFileLines` constructs IteratorHeader + state, retains File
- [x] `src/codegen.cpp` / `include/ry/codegen.hpp` — `IteratorReleaseHook` stack with save/restore across `FnScope`
- [x] `src/codegen_call.cpp` — `close(File)` decoupled from ARC release
- [x] `src/codegen_match.cpp` — `Ok(f):` File binding registered in `resource_managed_vars_` without spurious retain
- [x] `src/codegen_stmt_loop.cpp` — `using fh = f` retains when source is tracked
- [x] `src/codegen_type.cpp` — `Iterator<T>` parser
- [x] `tests/spec/io_file_handle.test.ry` — 6 new `lines()` cases (basic, trailing newline, empty file, two-call continuation, post-close termination, using-alias auto-close)
- [x] `docs/reference/io.md` — replaced "Future" note with real API description + example
- [x] `changelog.d/1818-io-file-lines-iterator.md` — changelog fragment

## Test plan

- [x] `./build/ry test tests/spec/io_file_handle.test.ry` — 15/15 passing
- [x] `./build/ry test -p` — 198 Ry spec files passing
- [x] `./build/ry_tests` — 2434 C++ tests passing
- [x] ASan + UBSan full suite — clean
- [x] TSan full suite — clean

## Knowledge base

Three new entries added to `.claude/rules/codegen-arc-cow.md`:
1. Resource-handle `close()` is decoupled from ARC release so live iterators survive
2. Resource handles bound through pattern matching need explicit `resource_managed_vars_` registration
3. `using <alias> = <variable>` retains when the source is a tracked binding

Closes #1818
Closes #1700

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a lazy line iterator: lines(File) -> Iterator<str> for streaming large files; preserves file position and keeps the handle alive for the iterator lifetime.

* **Behavior**
  * Iterator cooperates with subsequent readLine/lines calls and stops cleanly after the file is closed (no error). using + lines() auto-closes when iteration completes.

* **Documentation**
  * Updated io docs and examples to show lines usage.

* **Tests**
  * Added tests for empty files, trailing newlines, continued iteration, and post-close behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1846?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->