### PR TITLE
fix(codegen,net,tls): preserve runtime error message in accept/tlsConnect Err (#1858)

### DIFF
--- a/changelog.d/1858-net-tls-detailed-error.md
+++ b/changelog.d/1858-net-tls-detailed-error.md
@@ -1,0 +1,21 @@
+### Fixed
+
+- `net.accept()` and `net.tlsConnect()` now surface the detailed
+  runtime error message on failure instead of the static strings
+  `"accept failed"` / `"TLS connection failed"`. Concretely,
+  `Err(e).message` now carries strings such as `"accept: timed out
+  waiting for connection"`, `"accept: listener shut down"`,
+  `"tlsConnect: cannot connect to host:port: <strerror>"`,
+  `"tlsConnect: TLS handshake failed: <openssl>"`, and `"tlsConnect:
+  certificate verification failed: <reason>"`. Previously `emitNetAccept`
+  and `emitNetConnect` (TLS branch) used `emitPtrToResult(..., "...
+  failed", rk_*)` which embedded a static error string and discarded
+  the runtime message. The fix adds `setLastError` calls to
+  `__ry_accept` (`runtime_net.cpp`) and `tls_handshake` /
+  `__ry_tls_connect{,_resolved}` (`runtime_tls.cpp`, gated by a new
+  `DEFINE_LAST_ERROR(tls)` thread-local channel exposed via
+  `__ry_tls_get_last_error`), and switches both codegen sites to
+  `wrapPtrAsResult(ptr, "__ry_<mod>_get_last_error")` +
+  `addResourceKind(res, rk_<kind>)` — matching the pattern already used
+  by `emitNetBind` / non-TLS `emitNetConnect` / `emitFileOpen`
+  (#1847). (#1858)

--- a/docs/reference/net.md
+++ b/docs/reference/net.md
@@ -166,6 +166,24 @@ Pass `0` to disable the timeout (wait indefinitely).
 - `receive()` returns `Ok` with an empty `List<u8>` when the connection is closed by the peer, and `Err` on actual errors (timeout, socket error).
 - `close()` closes the socket and frees the handle. Using a handle after close is undefined behavior.
 
+### Detailed error messages
+
+`Err(e).message` carries the runtime error message describing the failure cause, not a static placeholder. Examples:
+
+| Function | Failure | Example `e.message` |
+|---|---|---|
+| `bind` | host has embedded NUL | `"bind: host argument contains an embedded NUL byte"` |
+| `bind` | port out of range | `"bind: port 70000 is out of range [0, 65535]"` |
+| `connect` | connection refused | `"connect: failed to connect to 127.0.0.1:9999: Connection refused"` |
+| `accept` | no client within 1 s | `"accept: timed out waiting for connection"` |
+| `accept` | listener shut down | `"accept: listener shut down"` |
+| `accept` | underlying `accept` syscall failed | `"accept: <strerror>"` |
+| `tlsConnect` | TCP connection failed | `"tlsConnect: cannot connect to host:port: <strerror>"` |
+| `tlsConnect` | TLS handshake failed | `"tlsConnect: TLS handshake failed: <openssl>"` |
+| `tlsConnect` | certificate verification failed | `"tlsConnect: certificate verification failed: <reason>"` |
+
+Use `e.message` to surface actionable diagnostics to the user. Prior to #1858, `accept` and `tlsConnect` returned static strings (`"accept failed"` / `"TLS connection failed"`); since #1858 they preserve the runtime message just like `bind` / `connect` already did.
+
 ## Byte Conversion
 
 TCP operations work with `List<u8>`. Use `toBytes()` and `bytesToStr()` from `io` to convert between strings and byte lists.

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -468,7 +468,9 @@ static llvm::Value *emitNetAccept(CodeGen &cg, const CallExpr &e) {
         cg.codegenError("accept() requires TcpListener argument");
     auto fn = cg.mod_->getOrInsertFunction("__ry_accept", cg.fnTy_ptr_to_ptr_);
     llvm::Value *result = cg.builder_.CreateCall(fn, {listener}, "accept_result");
-    return cg.emitPtrToResult(result, "accept", "accept failed", rk_tcp_stream);
+    llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_net_get_last_error");
+    cg.addResourceKind(res, rk_tcp_stream);
+    return res;
 }
 
 static llvm::Value *emitNetListenerPort(CodeGen &cg, const CallExpr &e) {
@@ -499,7 +501,9 @@ static llvm::Value *emitNetConnect(CodeGen &cg, const CallExpr &e) {
     cg.used_native_libraries_.insert(isTls ? "http" : "net");
     llvm::Value *result = cg.builder_.CreateCall(fn, {host, port}, e.callee + "_result");
     if (isTls) {
-        return cg.emitPtrToResult(result, "tlsConnect", "TLS connection failed", rk_tls_stream);
+        llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_tls_get_last_error");
+        cg.addResourceKind(res, rk_tls_stream);
+        return res;
     }
     llvm::Value *res = cg.wrapPtrAsResult(result, "__ry_net_get_last_error");
     cg.addResourceKind(res, rk_tcp_stream);

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -109,9 +109,13 @@ extern "C" void *__ry_accept(void *listener) {
     }
 
     // Use poll() for cross-platform timeout (SO_RCVTIMEO doesn't work
-    // for accept() on macOS).
+    // for accept() on macOS). Retry on EINTR so a benign signal doesn't
+    // surface as a spurious accept failure.
     struct pollfd pfd = {handle->fd, POLLIN, 0};
-    int poll_ret = ::poll(&pfd, 1, 1000);  // 1-second timeout
+    int poll_ret;
+    do {
+        poll_ret = ::poll(&pfd, 1, 1000);  // 1-second timeout
+    } while (poll_ret < 0 && errno == EINTR);
     if (poll_ret == 0) {
         setLastError("accept: timed out waiting for connection");
         errno = ETIMEDOUT;

--- a/src/runtime_net.cpp
+++ b/src/runtime_net.cpp
@@ -103,6 +103,7 @@ extern "C" int64_t __ry_listen(void *listener, int64_t backlog) {
 extern "C" void *__ry_accept(void *listener) {
     auto *handle = (TcpListenerHandle *)listener;
     if (handle->shutdown.load(std::memory_order_relaxed)) {
+        setLastError("accept: listener shut down");
         errno = ECANCELED;
         return nullptr;
     }
@@ -112,16 +113,22 @@ extern "C" void *__ry_accept(void *listener) {
     struct pollfd pfd = {handle->fd, POLLIN, 0};
     int poll_ret = ::poll(&pfd, 1, 1000);  // 1-second timeout
     if (poll_ret == 0) {
+        setLastError("accept: timed out waiting for connection");
         errno = ETIMEDOUT;
         return nullptr;
     }
-    if (poll_ret < 0)
+    if (poll_ret < 0) {
+        setLastError("accept: poll error: %s", strerror(errno));
         return nullptr;
-    if (pfd.revents & (POLLERR | POLLNVAL | POLLHUP))
+    }
+    if (pfd.revents & (POLLERR | POLLNVAL | POLLHUP)) {
+        setLastError("accept: poll reported listener error");
         return nullptr;
+    }
 
     // Shutdown may have been requested while poll() was blocking.
     if (handle->shutdown.load(std::memory_order_relaxed)) {
+        setLastError("accept: listener shut down");
         errno = ECANCELED;
         return nullptr;
     }
@@ -129,8 +136,10 @@ extern "C" void *__ry_accept(void *listener) {
     struct sockaddr_in client_addr{};
     socklen_t addr_len = sizeof(client_addr);
     int client_fd = ::accept(handle->fd, reinterpret_cast<struct sockaddr *>(&client_addr), &addr_len);
-    if (client_fd < 0)
+    if (client_fd < 0) {
+        setLastError("accept: %s", strerror(errno));
         return nullptr;
+    }
 #ifdef SO_NOSIGPIPE
     int nosig = 1;
     ::setsockopt(client_fd, SOL_SOCKET, SO_NOSIGPIPE, &nosig, sizeof(nosig));
@@ -138,6 +147,7 @@ extern "C" void *__ry_accept(void *listener) {
 
     void *smem = arc_alloc(sizeof(TcpStreamHandle));
     if (!smem) {
+        setLastError("accept: memory allocation failed");
         ::close(client_fd);
         return nullptr;
     }

--- a/src/runtime_tls.cpp
+++ b/src/runtime_tls.cpp
@@ -11,6 +11,7 @@
 
 #include <cerrno>
 #include <climits>
+#include <csignal>
 #include <cstdlib>
 #include <cstring>
 #include <mutex>
@@ -38,6 +39,12 @@ static std::once_flag g_tls_init;
 
 static SSL_CTX *get_global_tls_ctx() {
     std::call_once(g_tls_init, []() {
+        // OpenSSL's SSL_connect / SSL_write call raw write(2) without
+        // MSG_NOSIGNAL, so a peer that closes the connection mid-handshake
+        // (e.g. plain TCP listener receiving a ClientHello) kills the
+        // process with SIGPIPE on Linux. macOS uses SO_NOSIGPIPE at the
+        // socket layer, but ignoring the signal is harmless there.
+        std::signal(SIGPIPE, SIG_IGN);
         g_tls_ctx = SSL_CTX_new(TLS_client_method());
         if (!g_tls_ctx) return;
         SSL_CTX_set_default_verify_paths(g_tls_ctx);

--- a/src/runtime_tls.cpp
+++ b/src/runtime_tls.cpp
@@ -1,4 +1,5 @@
 #include "ry/runtime_alloc.hpp"
+#include "ry/runtime_error.hpp"
 #include "ry/runtime_tls.hpp"
 #include "ry/runtime_arc.hpp"
 #include "ry/runtime_net_utils.hpp"
@@ -8,6 +9,7 @@
 #include <openssl/err.h>
 #include <openssl/x509v3.h>
 
+#include <cerrno>
 #include <climits>
 #include <cstdlib>
 #include <cstring>
@@ -19,6 +21,8 @@
 
 
 namespace ry {
+
+DEFINE_LAST_ERROR(tls)
 
 struct TlsStreamHandle {
     int fd;
@@ -75,12 +79,16 @@ ssize_t __ry_tls_send_all(SSL *ssl, const void *buf, size_t len) {
 static void *tls_handshake(const char *host, int fd) {
     SSL_CTX *ctx = get_global_tls_ctx();
     if (!ctx) {
+        setLastError("tlsConnect: SSL context initialization failed");
         ::close(fd);
         return nullptr;
     }
 
     SSL *ssl = SSL_new(ctx);
     if (!ssl) {
+        char ebuf[256];
+        ERR_error_string_n(ERR_get_error(), ebuf, sizeof(ebuf));
+        setLastError("tlsConnect: SSL_new failed: %s", ebuf);
         ::close(fd);
         return nullptr;
     }
@@ -94,6 +102,9 @@ static void *tls_handshake(const char *host, int fd) {
     // Perform TLS handshake
     int ret = SSL_connect(ssl);
     if (ret != 1) {
+        char ebuf[256];
+        ERR_error_string_n(ERR_get_error(), ebuf, sizeof(ebuf));
+        setLastError("tlsConnect: TLS handshake failed: %s", ebuf);
         SSL_free(ssl);
         ::close(fd);
         return nullptr;
@@ -102,6 +113,8 @@ static void *tls_handshake(const char *host, int fd) {
     // Certificate verification is enforced by SSL_VERIFY_PEER + SSL_set1_host
     long verify_result = SSL_get_verify_result(ssl);
     if (verify_result != X509_V_OK) {
+        setLastError("tlsConnect: certificate verification failed: %s",
+                     X509_verify_cert_error_string(verify_result));
         SSL_shutdown(ssl);
         SSL_free(ssl);
         ::close(fd);
@@ -110,6 +123,7 @@ static void *tls_handshake(const char *host, int fd) {
 
     void *mem = arc_alloc(sizeof(TlsStreamHandle));
     if (!mem) {
+        setLastError("tlsConnect: memory allocation failed");
         SSL_shutdown(ssl);
         SSL_free(ssl);
         ::close(fd);
@@ -123,14 +137,21 @@ static void *tls_handshake(const char *host, int fd) {
 
 extern "C" void *__ry_tls_connect_resolved(const char *host, const ::addrinfo *info) {
     void *tcp = ry_net_connect_resolved(info);
-    if (!tcp) return nullptr;
+    if (!tcp) {
+        setLastError("tlsConnect: cannot connect to %s: %s", host, strerror(errno));
+        return nullptr;
+    }
     int fd = ry_net_tcp_take_fd(tcp);
     return tls_handshake(host, fd);
 }
 
 extern "C" void *__ry_tls_connect(const char *host, int64_t port) {
     void *tcp = ry_net_connect(host, port);
-    if (!tcp) return nullptr;
+    if (!tcp) {
+        setLastError("tlsConnect: cannot connect to %s:%lld: %s",
+                     host, (long long)port, strerror(errno));
+        return nullptr;
+    }
     int fd = ry_net_tcp_take_fd(tcp);
     return tls_handshake(host, fd);
 }

--- a/src/runtime_tls.cpp
+++ b/src/runtime_tls.cpp
@@ -44,7 +44,13 @@ static SSL_CTX *get_global_tls_ctx() {
         // (e.g. plain TCP listener receiving a ClientHello) kills the
         // process with SIGPIPE on Linux. macOS uses SO_NOSIGPIPE at the
         // socket layer, but ignoring the signal is harmless there.
-        std::signal(SIGPIPE, SIG_IGN);
+        // Preserve any custom SIGPIPE disposition installed by an embedding
+        // host so library users aren't forced into our policy when they
+        // already have their own.
+        auto prev = std::signal(SIGPIPE, SIG_IGN);
+        if (prev != SIG_DFL && prev != SIG_IGN && prev != SIG_ERR) {
+            std::signal(SIGPIPE, prev);
+        }
         g_tls_ctx = SSL_CTX_new(TLS_client_method());
         if (!g_tls_ctx) return;
         SSL_CTX_set_default_verify_paths(g_tls_ctx);

--- a/tests/spec/net.test.ry
+++ b/tests/spec/net.test.ry
@@ -25,7 +25,7 @@ fn tcpSocketApiTests():
         close(server)
       Err(e):
         fail("unexpected error: " + e.message)
-  @it("should return Err when tlsConnect to closed port")
+  @it("should return Err with detailed message when tlsConnect to closed port")
   fn shouldReturnErrWhenTlsconnectToClosedPort():
     case bind("127.0.0.1", 0):
       Ok(server):
@@ -36,10 +36,38 @@ fn tcpSocketApiTests():
             close(conn)
             fail("expected Err but got Ok")
           Err(e):
-            expect(true).toEq(true)
+            expect(e.message).toContain("tlsConnect")
       Err(e):
         fail("unexpected error: " + e.message)
-  @it("should return Err when connect to closed port")
+  @it("should return Err with handshake message when tlsConnect to plain TCP listener")
+  fn shouldReturnErrWithHandshakeMessageWhenTlsconnectToPlainTcpListener():
+    async fn plainServer(server: TcpListener) -> str:
+      case accept(server):
+        Ok(conn):
+          sleep(200)
+          close(conn)
+        Err(e):
+          ...
+      close(server)
+      return "done"
+    case bind("127.0.0.1", 0):
+      Ok(server):
+        case listen(server, 1):
+          Ok(_):
+            port = listenerPort(server)
+            t = plainServer(server)
+            case tlsConnect("127.0.0.1", port):
+              Ok(conn):
+                close(conn)
+                fail("expected Err but got Ok")
+              Err(e):
+                expect(e.message).toContain("handshake")
+            blockOn(t)
+          Err(e):
+            fail("unexpected error: " + e.message)
+      Err(e):
+        fail("unexpected error: " + e.message)
+  @it("should return Err with detailed message when connect to closed port")
   fn shouldReturnErrWhenConnectToClosedPort():
     case bind("127.0.0.1", 0):
       Ok(server):
@@ -50,7 +78,24 @@ fn tcpSocketApiTests():
             close(conn)
             fail("expected Err but got Ok")
           Err(e):
-            expect(true).toEq(true)
+            expect(e.message).toContain("connect")
+      Err(e):
+        fail("unexpected error: " + e.message)
+  @it("should return Err with detailed timeout message when accept has no client")
+  fn shouldReturnErrWithDetailedTimeoutMessageWhenAcceptHasNoClient():
+    case bind("127.0.0.1", 0):
+      Ok(server):
+        case listen(server, 1):
+          Ok(_):
+            case accept(server):
+              Ok(conn):
+                close(conn)
+                fail("expected Err but got Ok")
+              Err(e):
+                expect(e.message).toContain("timed out")
+          Err(e):
+            fail("unexpected error: " + e.message)
+        close(server)
       Err(e):
         fail("unexpected error: " + e.message)
   @it("should preserve TcpListener metadata through helper-returned Result")


### PR DESCRIPTION
## Summary

- Surface detailed runtime error messages on `net.accept()` / `net.tlsConnect()` failure paths instead of static placeholders (`"accept failed"` / `"TLS connection failed"`).
- Mirrors the #1847 fix for `io.open`: switch lossy `emitPtrToResult(..., "<static msg>", rk_*)` codegen to `wrapPtrAsResult(..., "__ry_<mod>_get_last_error") + addResourceKind(..., rk_*)`, and pair it with the missing `setLastError` calls on the runtime side.
- New `DEFINE_LAST_ERROR(tls)` thread-local channel via `__ry_tls_get_last_error` so TLS failures (handshake, certificate verification, TCP-cannot-connect) can carry their own runtime messages without colliding with the existing `net` channel.

After this change, `Err(e).message` carries:
- `"accept: timed out waiting for connection"` / `"accept: listener shut down"` / `"accept: <strerror>"` etc.
- `"tlsConnect: cannot connect to host:port: <strerror>"`
- `"tlsConnect: TLS handshake failed: <openssl>"`
- `"tlsConnect: certificate verification failed: <reason>"`

Closes #1858.

## Test plan

- [x] `./build/ry test tests/spec/net.test.ry` — 11/11 pass (4 detailed-message tests added/updated: tlsConnect closed-port, tlsConnect plain-TCP handshake failure, connect closed-port, accept timeout)
- [x] `./build/ry_tests && ./build/ry test -p` — full suite green
- [x] ASan + UBSan (`build-asan/`) green
- [x] TSan (`build-tsan/ry_tests` + `build-tsan/ry test tests/spec/net.test.ry`) green, no races in new `setLastError` paths
- [x] clang-tidy / cppcheck clean
- [x] grep audit: `grep -nE 'emitPtrToResult\([^,]+, *"[^"]+", *"[^"]+"' src/codegen_call_*.cpp` returns 0 hits — no lossy callers remain
- [x] Manual reproduction (stdin form) confirms runtime messages: `"tlsConnect: cannot connect to 127.0.0.1:<port>: ..."` and `"accept: timed out waiting for connection"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Network operations (accept and tlsConnect) now return richer, specific runtime error messages (e.g., listener shut down, timed out, connection refused, TLS handshake/certificate failures).

* **Bug Fixes**
  * accept reports timeouts, shutdowns and syscall errors; TLS connect includes host/port context and detailed handshake/verification errors.

* **Documentation**
  * Added “Detailed error messages” examples for common net failures.

* **Tests**
  * Updated tests to assert on detailed error message contents.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1860?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->