### PR TITLE
docs(io): document O_NOFOLLOW symlink rejection and 256 MiB read limit (#1849)

### DIFF
--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -191,6 +191,8 @@ case open("missing.txt", "r"):
 | `readAll` (File) | Read error after opening |
 | `readLine` (File) | Read error (I/O failure, not EOF — EOF is `Ok(None)`) |
 | `writeText` (File, str) | Write error |
+| `open` / `readText` / `writeText` / `appendText` / `readBytes` / `writeBytes` | Path refers to a symbolic link (rejected by `O_NOFOLLOW`; security hardening) |
+| `readText` / `readBytes` / `readAll` (File) | File exceeds the 256 MiB read limit |
 
 ## Notes
 
@@ -200,3 +202,5 @@ case open("missing.txt", "r"):
 - `exists` returns `false` for paths containing an embedded NUL byte (such paths cannot refer to a real file under POSIX).
 - `writeText` and `writeBytes` overwrite existing files. Use `appendText` to add content to existing files.
 - `writeText`, `appendText`, and `readText` are binary-transparent: content may contain embedded NUL bytes and the full byte sequence is preserved (#1133).
+- Symbolic links are rejected by all file-opening operations (`open`, `readText`, `writeText`, `appendText`, `readBytes`, `writeBytes`) via `O_NOFOLLOW` as a security hardening measure. Opening a symlinked path fails with the standard "cannot open file ..." error; the message does not currently distinguish symlinks from other open failures (e.g. missing file, permission denied). (#1849)
+- `readText`, `readBytes`, and `readAll(File)` reject files larger than 256 MiB and return `Err`. The error message includes the actual size, e.g. `file 'big.bin' is too large (300000000 bytes, max 268435456)` for the path-based variants, or `readAll: file too large (300000000 bytes, max 268435456)` for the File-handle variant. `writeText`, `writeBytes`, and `appendText` have no equivalent upper bound. (#1849)


### PR DESCRIPTION
## Summary

- Add two rows to the `## Error Handling` table and two entries to the `## Notes` section of `docs/reference/io.md` covering existing-but-undocumented behavior in the `io` module:
  - **`O_NOFOLLOW` symlink rejection** — `src/runtime_io.cpp:19` sets `O_NOFOLLOW` as the base flag for every mode, so `open` / `readText` / `writeText` / `appendText` / `readBytes` / `writeBytes` all refuse symbolic links. The current error message ("cannot open file ...") does not distinguish symlinks from other open failures.
  - **256 MiB read limit** — `MAX_READ_SIZE = 256 * 1024 * 1024` in `src/runtime_io.cpp:16` applies to `readText` / `readBytes` / `readAll(File)`. The doc entry quotes the actual runtime error templates (`file '...' is too large (... bytes, max ...)` / `readAll: file too large (... bytes, max ...)`) so users see what to grep for. Write paths have no equivalent limit.
- Runtime behavior is unchanged; this is documentation-only.

## Out of scope (tracked separately)

- Opt-out `followSymlinks` parameter for `open`.
- Raising or replacing the 256 MiB limit with a streaming API.
- Symlink-specific error message (tracked under the `open` error-message hardening issue).

## Test plan

- [x] `grep -nE 'symlink|O_NOFOLLOW|256 MiB' docs/reference/io.md` — keywords present at the new table rows and Notes bullets.
- [x] Read-back of lines 184-206 — table rows and Notes bullets are consistent with surrounding entries (issue number `(#1849)` appended per the project convention used in line 204's `(#1133)`).
- [x] Implementation facts cross-checked against `src/runtime_io.cpp` (O_NOFOLLOW at line 19 set as the base flag for all modes; `MAX_READ_SIZE` enforced at lines 118 / 211 / 307 / 332 — write paths intentionally omitted).
- [x] No code change → no `./build/ry_tests` / `./build/ry test -p` / sanitizer / fuzzer runs needed.

Skipped §2 — no user-visible change (docs-only).

Closes #1849

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated file operations documentation to clarify symbolic link handling. All file-opening and path-based operations explicitly reject symbolic links with enhanced error messages providing additional context.
  * Documented a 256 MiB maximum read limit for read operations. Error messages now display actual byte size and maximum threshold values to support troubleshooting and diagnostics.
  * Expanded documentation notes with additional details on symbolic link rejection mechanisms and size-limit failure scenarios with comprehensive error information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1861?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->