### PR TITLE
feat(io): accept "rb" and "wb" binary modes for open() (#1848)

### DIFF
--- a/changelog.d/1848-io-open-binary-modes.md
+++ b/changelog.d/1848-io-open-binary-modes.md
@@ -1,0 +1,12 @@
+### Added
+
+- `io.open(path, mode)` now accepts `"rb"` (binary read) and `"wb"`
+  (binary write) in addition to the existing `"r"` / `"w"` / `"a"`
+  text modes. The internal `fopen_nofollow` helper already mapped
+  `"rb"` / `"wb"` to `O_RDONLY` / `O_WRONLY | O_CREAT | O_TRUNC`; only
+  the strcmp guard at the entry of `__ry_io_file_open` was rejecting
+  them. The invalid-mode error message now reads `(must be "r", "w",
+  "a", "rb", or "wb")` to reflect the extended set. This is a
+  prerequisite for the future `readBytes(f: File)` / `writeBytes(f:
+  File, bytes)` overloads (#1816 follow-up). Append-binary `"ab"`
+  remains unsupported and is tracked separately in #1862. (#1848)

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -31,7 +31,7 @@ from io import readText, writeText, exists
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `open` | `(str, str) -> Result<File, Error>` | Opens a file; mode must be `"r"`, `"w"`, or `"a"` |
+| `open` | `(str, str) -> Result<File, Error>` | Opens a file; mode must be `"r"`, `"w"`, `"a"`, `"rb"`, or `"wb"` |
 | `readAll` | `(File) -> Result<str, Error>` | Reads the entire file content into a string |
 | `readLine` | `(File) -> Result<Option<str>, Error>` | Reads one line; returns `Ok(None)` at EOF |
 | `writeText` | `(File, str) -> Result<Unit, Error>` | Writes a string to the file |
@@ -187,7 +187,7 @@ case open("missing.txt", "r"):
 | `writeText` / `writeBytes` / `appendText` | File cannot be opened for writing |
 | `deleteFile` | File cannot be deleted |
 | `readText` / `writeText` / `appendText` / `deleteFile` / `readBytes` / `writeBytes` | Path contains an embedded NUL byte |
-| `open` | File does not exist (mode `"r"`), cannot be created/opened (mode `"w"` / `"a"`), or mode is not `"r"` / `"w"` / `"a"` |
+| `open` | File does not exist (mode `"r"` / `"rb"`), cannot be created/opened (mode `"w"` / `"a"` / `"wb"`), or mode is not `"r"` / `"w"` / `"a"` / `"rb"` / `"wb"` |
 | `readAll` (File) | Read error after opening |
 | `readLine` (File) | Read error (I/O failure, not EOF — EOF is `Ok(None)`) |
 | `writeText` (File, str) | Write error |

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -279,8 +279,9 @@ extern "C" void *__ry_io_file_open(const char *path, const char *mode) {
         setLastError("open: mode contains an embedded NUL byte");
         return nullptr;
     }
-    if (strcmp(mode, "r") != 0 && strcmp(mode, "w") != 0 && strcmp(mode, "a") != 0) {
-        setLastError("open: invalid mode '%s' (must be \"r\", \"w\", or \"a\")", mode);
+    if (strcmp(mode, "r") != 0 && strcmp(mode, "w") != 0 && strcmp(mode, "a") != 0 &&
+        strcmp(mode, "rb") != 0 && strcmp(mode, "wb") != 0) {
+        setLastError("open: invalid mode '%s' (must be \"r\", \"w\", \"a\", \"rb\", or \"wb\")", mode);
         return nullptr;
     }
     FILE *fp = fopen_nofollow(path, mode);

--- a/tests/spec/io_file_handle.test.ry
+++ b/tests/spec/io_file_handle.test.ry
@@ -37,6 +37,8 @@ fn fileHandleTests():
         fail("expected Err for invalid mode, got Ok")
       Err(e):
         expect(e.message).toContain("invalid mode")
+        expect(e.message).toContain("rb")
+        expect(e.message).toContain("wb")
     deleteFile("/tmp/ry_fh_badmode.txt")
 
   @it("should return Err with detailed message when path contains an embedded NUL byte")
@@ -80,6 +82,43 @@ fn fileHandleTests():
       Err(e):
         fail("open r failed: " + e.message)
     deleteFile("/tmp/ry_fh_write.txt")
+
+  @it("should open in 'rb' binary read mode and readAll")
+  fn shouldOpenInRbBinaryReadMode():
+    writeText("/tmp/ry_fh_rb.txt", "binary read")
+    case open("/tmp/ry_fh_rb.txt", "rb"):
+      Ok(f):
+        case readAll(f):
+          Ok(s):
+            expect(s).toEq("binary read")
+          Err(e):
+            fail("readAll failed: " + e.message)
+        close(f)
+      Err(e):
+        fail("open rb failed: " + e.message)
+    deleteFile("/tmp/ry_fh_rb.txt")
+
+  @it("should round-trip through 'wb' write and 'rb' read")
+  fn shouldRoundTripThroughWbWriteAndRbRead():
+    case open("/tmp/ry_fh_wb.txt", "wb"):
+      Ok(fw):
+        case writeText(fw, "binary roundtrip"):
+          Ok(_): 0
+          Err(e): fail("writeText failed: " + e.message)
+        close(fw)
+      Err(e):
+        fail("open wb failed: " + e.message)
+    case open("/tmp/ry_fh_wb.txt", "rb"):
+      Ok(fr):
+        case readAll(fr):
+          Ok(s):
+            expect(s).toEq("binary roundtrip")
+          Err(e):
+            fail("readAll failed: " + e.message)
+        close(fr)
+      Err(e):
+        fail("open rb failed: " + e.message)
+    deleteFile("/tmp/ry_fh_wb.txt")
 
   @it("should detect EOF with readLine returning Ok(None)")
   fn shouldDetectEofWithReadLineReturningOkNone():


### PR DESCRIPTION
## Summary

- `io.open(path, mode)` now accepts `"rb"` (binary read) and `"wb"` (binary write) in addition to the existing `"r"` / `"w"` / `"a"` text modes. The internal `fopen_nofollow` helper already mapped them to the appropriate `open(2)` flags; only the strcmp guard at the entry of `__ry_io_file_open` was rejecting them.
- The invalid-mode error message now reads `(must be "r", "w", "a", "rb", or "wb")` to reflect the extended set.
- This is a prerequisite for the future `readBytes(f: File)` / `writeBytes(f: File, bytes)` overloads (#1816 follow-up).

## Out of scope

- `"ab"` (append binary) — `fopen_nofollow` also lacks the branch. Tracked separately in #1862.

## Test plan

- [x] `./build/ry test tests/spec/io_file_handle.test.ry` → 17/17 pass (3 new cases)
- [x] `./build/ry_tests` → 2434/2434 pass
- [x] `./build/ry test -p` → 200 files / 0 failures
- [x] ASan + UBSan (`build-asan/`) → C++ 2434 / Ry 200 files all pass
- [x] TSan (`build-tsan/`) → C++ 2432 passed + 2 intentional skips
- [x] clang-tidy on `src/runtime_io.cpp` clean
- [x] cppcheck on `src/runtime_io.cpp` + `include/ry/` clean
- [x] Ad-hoc: `"rb"` reads `/etc/hosts`; `"wb"` write → `"rb"` reopen → `readAll` returns same content

## Pre-commit checklist skip log

- Skipped §3.5.5 scan-build — warn-only; change risk is minimal (strcmp guard extension, no new pointer paths)
- Skipped §3.6 libFuzzer — no parser / lexer / json / utf8 / string change
- Skipped §3.6.5 tree-sitter — no grammar / EBNF / scanner change

Closes #1848

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `io.open()` now supports binary file modes: `"rb"` for binary reading and `"wb"` for binary writing.

* **Documentation**
  * Updated function reference documentation to include the newly supported binary file modes.

* **Tests**
  * Added test coverage for binary file mode operations, including read/write round-trip scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1863?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->