### PR TITLE
docs(workflow): require explicit user permission for new issue creation (#1864)

### DIFF
--- a/.claude/skills/git-claim-issue/SKILL.md
+++ b/.claude/skills/git-claim-issue/SKILL.md
@@ -10,6 +10,10 @@ metadata:
 
 Mark a GitHub issue as in-progress by adding the `wip` label. This is the counterpart of `git-merge-pr` Step 5, which removes `wip` after merge.
 
+## Scope (what this skill does NOT do)
+
+This skill only adds the `wip` label to an **existing** GitHub issue. Creating a brand-new issue is **out of scope** — see `/git-create-issue`, which enforces an explicit user-permission gate before running `gh issue create` (AGENTS.md §責務の分離「ユーザーが明示的に指示すること」). Do not use this skill to file new issues, even if the user references both flows in the same message.
+
 ## When to use
 
 - As **Task 1** of the implementation plan, immediately after Plan approval (before creating the feature branch)

--- a/.claude/skills/git-create-issue/SKILL.md
+++ b/.claude/skills/git-create-issue/SKILL.md
@@ -33,6 +33,10 @@ The previous failure mode (#1851 self-verification): Claude Code presented "別 
 
 ### Step 1: Present the proposal and wait for explicit permission
 
+> **When invoked from `/triage-side-finding`**: Step 2 of that skill already presents the same 6-item proposal and obtains user approval. To avoid double-prompting, **skip this Step 1 and jump straight to Step 2 (duplicate check)**, carrying forward the approved reason / summary / granularity / confidence / labels / milestone from triage-side-finding Step 2. Re-prompting is required only if those parameters changed during Step 4 splitting (in which case triage-side-finding Step 4 itself re-asks).
+>
+> Run Step 1 only for **direct invocations** (the user typed `/git-create-issue` themselves, or another flow without a prior permission step).
+
 Show the user the following 6 items as a single preview. Do **not** run `gh issue create` yet.
 
 | Item | What to include |
@@ -50,7 +54,7 @@ To fetch the current open milestone:
 gh api repos/t0k0sh1/ry/milestones?state=open --jq '.[] | {title, number, due_on}'
 ```
 
-Take the latest version-numbered milestone as the default candidate (e.g. if `v0.0.25` and `v0.1.0` are both open, the lower one usually represents the active development cycle — confirm with the user).
+Pick the **active development milestone** — typically the nearest upcoming version — as the candidate to present, and **ask the user to confirm** rather than auto-deciding. The project's convention does not always match semver ordering: when multiple open milestones look plausible (e.g. both `v0.0.25` and `v0.1.0` are open), surface both to the user and let them say which is the current development cycle. When in doubt, present "未設定" as an equally valid choice.
 
 #### Presentation template
 

--- a/.claude/skills/git-create-issue/SKILL.md
+++ b/.claude/skills/git-create-issue/SKILL.md
@@ -1,0 +1,130 @@
+---
+name: git-create-issue
+description: Create a new GitHub issue, but ONLY after explicit user permission. Presents a 6-item preview (reason / summary / granularity / confidence / labels / milestone candidate) and waits for the user to approve before running `gh issue create`. Invoked from `/triage-side-finding` Step 2 when Q4(b) "別 issue 起票" is chosen, or directly when the user requests a new issue. Counterpart of `/git-claim-issue` (which only adds the `wip` label to an existing issue).
+allowed-tools: Bash(gh issue create:*), Bash(gh issue view:*), Bash(gh issue list:*), Bash(gh search issues:*), Bash(gh api:*), Bash(gh pr view:*)
+metadata:
+  short-description: Create a new issue with explicit user permission gate
+---
+
+# Git Create Issue
+
+Create a new GitHub issue **only after the user explicitly approves the proposed content**. Counterpart of `/git-claim-issue`, which adds the `wip` label to an existing issue.
+
+## When to use
+
+- After `/triage-side-finding` Step 1 (依存 PR 確認) clears "依存なし" and Q4 = (b) 別 issue 起票 was chosen
+- When the user explicitly asks to file a new issue ("issue 立てて" / "起票して" / "create an issue for X")
+- **NOT** for adding `wip` to an existing issue — use `/git-claim-issue` for that
+
+## Repository
+
+- owner: `t0k0sh1`
+- repo: `ry`
+
+## Critical safety rule
+
+**`gh issue create` requires explicit user permission** (AGENTS.md §責務の分離「ユーザーが明示的に指示すること」). The presentation step (Step 1) is mandatory; Claude Code must not skip it and must wait for an explicit approval ("起票して" / "OK" / "go ahead" 等) before invoking `gh issue create`.
+
+The previous failure mode (#1851 self-verification): Claude Code presented "別 issue 起票" as the leading option without consent, kept embedding it in subsequent suggestions, and only stopped when the user explicitly rejected it. This skill exists to make that path impossible: no `gh issue create` until the user says yes.
+
+**Exception**: `/preparing-for-release` skill files Release prep / Release / Cleanup issues automatically; that flow is out of scope here because the user's `/preparing-for-release <X.Y.Z>` invocation itself counts as the permission.
+
+## Steps
+
+### Step 1: Present the proposal and wait for explicit permission
+
+Show the user the following 6 items as a single preview. Do **not** run `gh issue create` yet.
+
+| Item | What to include |
+|---|---|
+| **起票理由 (Reason)** | Why this finding cannot be folded into the current PR (separation of concerns / scope size / pre-existing / Q4(b) rationale) |
+| **概要 (Summary)** | 1〜3 line gist — not the full body, just the essence |
+| **粒度 (Granularity)** | Whether it fits 1 issue ≒ 1 PR; flag if Step 4 splitting is likely |
+| **解決確度 (Confidence)** | One of: **High** (再現手順あり) / **Medium** (仮説 + 検証手順あり) / **Low** (仮説のみ) — with a one-line justification |
+| **ラベル案 (Labels)** | Auto-suggested label list (e.g. `bug` / `enhancement` / `documentation` / `refactor`). **At least one label is required — never propose an empty list.** Inspect existing repo labels via `gh label list --json name` if unsure |
+| **マイルストーン候補 (Milestone)** | Fetched via the command below. Present the current development milestone as a *candidate*; the user decides whether to adopt it, pick a different one, or leave it unset. **Do not auto-inherit from the current PR.** |
+
+To fetch the current open milestone:
+
+```bash
+gh api repos/t0k0sh1/ry/milestones?state=open --jq '.[] | {title, number, due_on}'
+```
+
+Take the latest version-numbered milestone as the default candidate (e.g. if `v0.0.25` and `v0.1.0` are both open, the lower one usually represents the active development cycle — confirm with the user).
+
+#### Presentation template
+
+```text
+別 issue 起票の許可をお願いします:
+
+- 起票理由: <why this can't fold into the current PR>
+- 概要: <1〜3 line gist>
+- 粒度: <fits 1 PR? / needs splitting?>
+- 解決確度: <High|Medium|Low> (<one-line justification>)
+- ラベル案: <label1>, <label2>
+- マイルストーン候補: <vX.Y.Z> (現開発バージョン) / 別指定 / 未設定 のいずれかを指定してください
+
+起票してよろしいですか?
+```
+
+Wait for the user's reply. Acceptable approvals: 「起票して」 / 「OK」 / 「お願いします」 / "go ahead" / "yes" 等. If the user adjusts items (e.g. different milestone, additional label, refined title), incorporate the change and re-present a short confirmation before running Step 2. If the user declines or asks to defer, stop and do not file the issue.
+
+### Step 2: Check for duplicates
+
+```bash
+gh search issues --repo t0k0sh1/ry "<keywords>" --state open
+```
+
+If a likely duplicate exists, do **not** create a new issue. Instead, surface the duplicate to the user (number + title), ask whether to add a comment to the existing one, and stop the create flow. Optionally use `gh issue edit <n> --milestone "<title>"` to align the existing issue's milestone *after a separate user confirmation*.
+
+### Step 3: Run `gh issue create`
+
+Only reach this step once Step 1 has explicit approval and Step 2 confirmed no duplicate.
+
+```bash
+gh issue create \
+  --title "<明確で記述的なタイトル>" \
+  --milestone "<milestone-title-from-Step-1>" \
+  --label "<label1>" --label "<label2>" \
+  --body "$(cat <<'EOF'
+## Context
+
+<!-- どのファイル / 関数 / コードパスが関与したか、どの PR / issue 作業中に発見したか -->
+
+## Reproduction
+
+<!-- 最小再現スニペットまたは手順 -->
+
+## Expected vs Actual
+
+**Expected:** <!-- 期待動作 -->
+**Actual:** <!-- 実際動作 -->
+
+## Discovery timing
+
+<!-- いずれか: 実装中 / セルフ検証中 / PR レビュー対応中 -->
+EOF
+)"
+```
+
+- Omit `--milestone` if the user chose "未設定".
+- Always pass at least one `--label`. `gh issue create --label foo` is safe (empty initial state); the destructive case applies only to `gh issue edit --label`.
+- For non-bug items, you may drop the **Expected vs Actual** section. The other sections remain mandatory.
+
+### Step 4: Report
+
+Capture the new issue number from the URL printed by `gh issue create`. Report to the user:
+
+- Issue number and title
+- Applied labels
+- Applied milestone (or "未設定")
+- The full URL
+
+If the user originally invoked this from `/triage-side-finding` Q4(b), also reaffirm that the side finding is now tracked and the original PR can proceed without it.
+
+## Related skills
+
+- `/triage-side-finding` — decides whether a side finding warrants a new issue (Q4(b)). Step 2 there delegates here.
+- `/git-claim-issue` — adds `wip` to an *existing* issue. Use it as Task 1 of the implementation plan once the new issue is filed and the user wants to start work on it.
+- `/scope-decomposition` — apply when Step 1 / Step 2 reveals the issue might need splitting (REQ-1〜3).
+- `/preparing-for-release` — files release-tracking issues automatically (exception to the permission gate, as noted above).

--- a/.claude/skills/triage-side-finding/SKILL.md
+++ b/.claude/skills/triage-side-finding/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: triage-side-finding
 description: 副次的な発見 (side finding) の扱いを判定するときの early short-circuit フロー (Q1 再現困難 CI 問題 → Q2 ユーザー指示 → Q3 bug-forensics-analyst → Q4 3 択判定 [即時修正 / 別 issue 起票 / ユーザー確認])。Use when 副次的な発見 / side finding / scope / ついでに直したい / 別 issue 起票 / 即時修正 / OPEN PR 依存 / fold-only / orphan issue 防止 / triage / 判定フロー のとき。実装中・セルフ検証中・PR レビュー対応中に副次的な問題が見つかった場合に呼び出す。**起源判定 (回帰 vs 既存バグ) そのものは `bug-forensics-analyst` agent の領域なので、本 skill は Q3 経由でのみ agent を呼ぶ。**
-allowed-tools: Bash(gh issue:*), Bash(gh search:*), Bash(gh pr:*), Agent
+allowed-tools: Bash(gh issue:*), Bash(gh search:*), Bash(gh pr:*), Bash(gh api:*), Agent
 ---
 
 # Triage Side Finding
@@ -108,6 +108,8 @@ Q3 の分析結果と PR サイズ規律 (`plan-rubric` の 1 issue ≒ 1 PR) �
 
 Q4 = (b) と判定した場合に実行する。
 
+> **重要**: 新規 issue の起票 (`gh issue create`) は **ユーザーの明示許可必須** (AGENTS.md §責務の分離「ユーザーが明示的に指示すること」)。Step 2 で起票内容を提示し、許可を得てから Step 3 以降を実行する。Claude Code は許可なしに `gh issue create` を実行してはならない。
+
 ### Step 1: 依存 PR を確認し、fold または escalate する
 
 このルールは **fold-only** である。「依存 PR がマージされてから再起票する」案は**採らない** — 着手不可な orphan issue は backlog 上で「open かつ着手可能」と区別がつかず tracker の signal を低下させ、依存関係も暗黙化してしまうため。
@@ -134,14 +136,37 @@ gh pr view <number> --json files,state,headRefName --jq '{state, branch: .headRe
 
 **Motivating example (#1692)**: PR #1693 (`verifyCalledWith` v1) が未マージのまま、その v2 拡張として #1692 が起票された。#1692 は PR #1693 で導入される `__ry_mock_store_arg` / kind tag enum / `mockArgEqual` / `__ry_mock_count_matching_calls` を**前提**とするため、PR #1693 マージ前は実装に進めない orphan issue となった。本ゲートにより、今後は同種の起票は fold (PR #1693 への scope 追加) または escalate に振り分けられる。
 
-### Step 2: マイルストーンを特定する
+### Step 2: ユーザー許可確認 (起票内容のプレビュー提示)
 
-新規 issue は現在の PR / ベース issue と同じマイルストーンに揃える。
+Step 1 で「依存なし」と判定された場合のみ実行する (fold / escalate ケースは Step 1 で完結)。
 
-```bash
-gh pr view --json milestone --jq '.milestone.title'
-gh issue list --milestone <title> --limit 1
+ユーザーに以下の 6 項目を提示し、明示の起票許可 (「起票して」 / 「OK」等) を待つ。**許可が得られるまで `gh issue create` を実行しない**。
+
+| 項目 | 内容 |
+|---|---|
+| **起票理由** | なぜこの発見を現 PR で対応せず別 issue にするのか (関心事分離 / scope 規模 / pre-existing 等、Q4(b) の判定根拠) |
+| **概要** | 1〜3 行の要点 (本文ではなく要旨) |
+| **粒度の妥当性** | 1 issue ≒ 1 PR に収まるか、Step 4 の分割対象になりうるか |
+| **解決確度** | High (再現手順あり) / Medium (仮説 + 検証手順あり) / Low (仮説のみ) のいずれかと根拠 |
+| **ラベル案** | 自動判断 (例: `bug` / `enhancement` / `documentation` / `refactor` 等)。**最低 1 個は必須、空にしない** |
+| **マイルストーン候補** | `gh api repos/t0k0sh1/ry/milestones?state=open` で現在 open な milestone を取得し、現開発バージョンの milestone を「候補」として提示。**自動継承しない** — ユーザーが採用 / 別指定 / 未設定を判断する |
+
+提示例:
+
+```text
+別 issue 起票の許可をお願いします:
+
+- 起票理由: パーサ修正 (現 PR) と直交する codegen 側のエラーメッセージ改善で、関心事が異なる
+- 概要: <module>.<fn> でエラー時の line/column が出ない (仮説あり、修正方針も見えている)
+- 粒度: 1 PR で収まる規模 (推定 50〜100 行)
+- 解決確度: High (ローカルで再現済み、修正パスも特定済み)
+- ラベル案: bug, enhancement
+- マイルストーン候補: v0.0.25 (現開発バージョン) / 未設定も可
+
+起票してよろしいですか?
 ```
+
+ユーザーが許可したら、その回答 (採用 milestone を含む) を Step 3 以降の入力とする。許可されなかった場合は起票せず終了する。
 
 ### Step 3: 重複を確認する
 
@@ -149,7 +174,7 @@ gh issue list --milestone <title> --limit 1
 gh search issues --repo t0k0sh1/ry "<keywords>" --state open
 ```
 
-重複があれば追加 context を comment で添え、必要に応じて `gh issue edit <number> --milestone "<title>"` でマイルストーンを揃える。Step 4 を skip して Step 6 へ進む。
+重複があれば追加 context を comment で添え、必要に応じて `gh issue edit <number> --milestone "<title>"` でマイルストーンを揃える (milestone 変更もユーザー確認後)。Step 4 を skip して Step 6 へ進む。
 
 ### Step 4: 分割を判断する
 
@@ -159,34 +184,11 @@ gh search issues --repo t0k0sh1/ry "<keywords>" --state open
 
 分割すると判断した場合の **分割理由の分類 (機能境界 / 依存関係 / 規模) と対称性チェック (typed↔any / wrap↔unwrap / read↔write / base↔derived)、3 段目派生の警戒** は `/scope-decomposition` REQ-1〜3 を参照。
 
+分割が必要になった場合は分割案 (各 issue のタイトル・粒度) を再度ユーザーに提示し、改めて許可を得る (Step 2 と同等)。
+
 ### Step 5: issue を作成する
 
-```bash
-gh issue create \
-  --title "<明確で記述的なタイトル>" \
-  --milestone "<milestone-title>" \
-  --body "$(cat <<'EOF'
-## Context
-
-<!-- どのファイル / 関数 / コードパスが関与したか、どの PR / issue 作業中に発見したか -->
-
-## Reproduction
-
-<!-- 最小再現スニペットまたは手順 -->
-
-## Expected vs Actual
-
-**Expected:** <!-- 期待動作 -->
-**Actual:** <!-- 実際動作 -->
-
-## Discovery timing
-
-<!-- いずれか: 実装中 / セルフ検証中 / PR レビュー対応中 -->
-EOF
-)"
-```
-
-bug 以外の項目では **Expected vs Actual** を省略してよい。それ以外のセクションは必須。
+Step 2 で得た許可と milestone 決定を入力に、`/git-create-issue` skill 経由で起票する。コマンド本体と本文テンプレートは `/git-create-issue` に集約されている。
 
 ### Step 6: 報告する
 

--- a/.claude/skills/triage-side-finding/SKILL.md
+++ b/.claude/skills/triage-side-finding/SKILL.md
@@ -190,6 +190,8 @@ gh search issues --repo t0k0sh1/ry "<keywords>" --state open
 
 Step 2 で得た許可と milestone 決定を入力に、`/git-create-issue` skill 経由で起票する。コマンド本体と本文テンプレートは `/git-create-issue` に集約されている。
 
+**重複した許可確認を避けるため**: `/git-create-issue` Step 1 は許可ゲートだが、本 skill 経由で呼ぶ場合は Step 2 で同等の 6 項目プレビューと承認が完了しているため、`/git-create-issue` 側は **Step 1 を skip し Step 2 (重複確認) から開始**する。Step 2 で承認された 6 項目 (起票理由 / 概要 / 粒度 / 解決確度 / ラベル案 / 採用 milestone) をそのまま `gh issue create` の入力にする。`/git-create-issue` 側にも同等の skip 条件が明記されている。
+
 ### Step 6: 報告する
 
 ユーザーに issue 番号・タイトル・設定したマイルストーンを報告する。複数 issue を起票したらすべて列挙する。fold / escalate を選択した場合はその旨と対象 OPEN PR 番号を報告する。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ issue 確認 → ナレッジベース参照 (path-scoped rule は実装中も a
   - 仕様通りに実装できていることのセルフ検証タスク
   - 英語ドキュメント（README.md / docs）の更新（または変更不要の確認）
   - 用語変更・識別子 rename を含む場合: `/horizontal-sweep` を計画タスクに含める（4 ステップ手順は `.claude/skills/horizontal-sweep/SKILL.md`）
-- **副次的発見への対応**: 「責務の分離」セクション「副次的発見への対応」に従う (`/triage-side-finding`)。`/triage-side-finding` Q4(b) で「別 issue 起票」と判定された場合のみ、実装計画内に「別 issue 起票」タスクを含める (Q1 再現困難 / Q2 ユーザー指示 → 即時修正と判定された場合は同 PR 内で対処するため計画タスク化不要)
+- **副次的発見への対応**: 「責務の分離」セクション「副次的発見への対応」に従う (`/triage-side-finding`)。`/triage-side-finding` Q4(b) で「別 issue 起票」と判定された場合のみ、実装計画内に「別 issue 起票」タスクを含める (Q1 再現困難 / Q2 ユーザー指示 → 即時修正と判定された場合は同 PR 内で対処するため計画タスク化不要)。**ただし起票の実行はユーザーの明示許可後** — Plan 内に「別 issue 起票」タスクを含める場合も、Claude Code は起票内容を提示するに留め、ユーザー許可を待つ (「責務の分離」§ユーザーが明示的に指示すること 参照)
 - **TDD サイクルの分割禁止**: Red / Green / Refactor は Plan 上で個別タスクに分割せず、1 つの「TDD サイクル」タスクとしてまとめる（各ケース毎にサイクルを内部で回す）
 
 ## repo build と stdlib 解決
@@ -184,6 +184,8 @@ trace の使い方 (`--trace` / `--trace-out` / JSON Lines / 内部挙動・impo
 - 外部レビュー（GitHub PR レビュー等）
 - git add / commit / push
 - PR 作成
+- **新規 issue の起票 (`gh issue create`)** — Claude Code は起票内容 (理由 / 概要 / 粒度 / 解決確度 / ラベル案 / マイルストーン候補) を提示するに留め、ユーザーの明示許可 (「起票して」 / 「OK」等) を待つ。CI 失敗・サニタイザー検出・fuzz crash 等の repo 全体に影響する事故も口頭 (テキスト) 報告のみで、自律起票しない。詳細手順は `/git-create-issue` 参照
+  - **例外**: `preparing-for-release` skill 経由 (Release prep / Release / Cleanup issue) は `/preparing-for-release <X.Y.Z>` のユーザー起動が起票許可を兼ねるため、この許可制の対象外
 
 ### PR レビュー対応
 


### PR DESCRIPTION
## Summary

- AGENTS.md §責務の分離 / §Plan モードルール に **「新規 issue の起票 (`gh issue create`)」をユーザー明示指示リスト** に追加 (`/preparing-for-release` 経由は例外)。
- `triage-side-finding/SKILL.md`: Issue Creation Steps を再構成し、新 Step 2「ユーザー許可確認 (6 項目プレビュー)」を挿入。マイルストーンの自動継承を廃し候補提示方式へ。allowed-tools に `Bash(gh api:*)` を追加。
- `git-create-issue/SKILL.md`: 新設。許可ゲート + 6 項目プレビュー + 重複確認 + `gh issue create` 本体を集約。`/git-claim-issue` の counterpart。
- `git-claim-issue/SKILL.md`: 「Scope (what this skill does NOT do)」セクションを追加し、新規起票は対象外と明示。

#1851 セルフ検証時、Claude Code がユーザーの許可なしに「別 issue 起票」を選択肢の筆頭として提示し続けた問題への構造的対応。

## Test plan

ドキュメント / skill 定義のみの変更でビルド・テスト対象外。以下を目視確認済み:

- [x] AGENTS.md §責務の分離「ユーザーが明示的に指示すること」に「新規 issue の起票」が追加され `/preparing-for-release` 例外も明記されている
- [x] AGENTS.md §Plan モードのルール「副次的発見への対応」に「起票実行はユーザー許可後」補足が含まれる
- [x] `triage-side-finding` Step 2 のテンプレに 6 項目 (起票理由 / 概要 / 粒度 / 解決確度 [High/Medium/Low] / ラベル案 [最低 1 個] / マイルストーン候補 [自動継承しない]) が含まれている
- [x] `triage-side-finding` Step 5 が `/git-create-issue` へ delegate する形に簡略化されている
- [x] `triage-side-finding` の frontmatter `allowed-tools` に `Bash(gh api:*)` が含まれる (Step 2 の milestone 取得用)
- [x] `git-create-issue` 新規 skill が許可ゲート / 重複確認 / 起票本体 / 報告の 4 ステップで構成され、`/preparing-for-release` 例外も明記されている
- [x] `git-claim-issue` に「Scope」セクションが追加され、新規起票は `/git-create-issue` を参照すべき旨が明示されている

Closes #1864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified scope boundaries for issue-claiming functionality
  * Added documentation for new issue-creation workflow with explicit user approval requirements
  * Updated triage guidelines to require user permission before creating new issues
  * Refined developer guidelines defining permission-gated issue creation processes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1866?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->