### PR TITLE
chore(docker): run sanitizer / static-analysis / fuzz tests in container (#1865)

### DIFF
--- a/.claude/skills/libfuzzer-harness/SKILL.md
+++ b/.claude/skills/libfuzzer-harness/SKILL.md
@@ -23,9 +23,9 @@ Reference for libFuzzer toolchain requirements and harness conventions in the ry
 
 3. **Split `-fsanitize=fuzzer-no-link` vs `-fsanitize=fuzzer`**: `ENABLE_FUZZER` adds `-fsanitize=fuzzer-no-link` globally (coverage-only; no `main` injection) and the `add_ry_fuzz_target` CMake helper adds `-fsanitize=fuzzer` at link time **only on fuzz executables**. If `-fsanitize=fuzzer` were applied globally it would inject a competing `main` into `ry` and `ry_tests`, causing link errors.
 
-**macOS extra**: Homebrew LLVM Clang needs `SDKROOT=$(xcrun --show-sdk-path)` to find system C headers; without it the PCH compilation for `ry_lib` fails with libc++ `<cstdio>` not found. The `fuzz` preset does **not** hardcode this path (not portable); callers must set it as an env var.
+**macOS note**: macOS-native libFuzzer builds historically required `SDKROOT=$(xcrun --show-sdk-path)` plus explicit `CC` / `CXX` exports, and `fuzz_json` hung under ASan on Darwin. Local fuzzer runs are now expected to go through `./docker/run.sh fuzz <binary> ...`, which uses the Linux toolchain in `ry-ci:llvm-21` and bypasses these issues entirely (issue #1865).
 
-**How to apply**: When adding a new fuzz harness target, use `add_ry_fuzz_target(name sources...)` in CMakeLists.txt (inside `if(ENABLE_FUZZER)`). Never apply `-fsanitize=fuzzer` globally. When building locally on macOS, always prepend `SDKROOT=$(xcrun --show-sdk-path) CC=<llvm-clang> CXX=<llvm-clang++>`.
+**How to apply**: When adding a new fuzz harness target, use `add_ry_fuzz_target(name sources...)` in CMakeLists.txt (inside `if(ENABLE_FUZZER)`). Never apply `-fsanitize=fuzzer` globally. Run locally via `./docker/run.sh fuzz <binary> -max_total_time=<sec> -artifact_prefix=tests/fuzz/regressions/<name>/ tests/fuzz/corpus/<name>` — the container handles `SDKROOT` / toolchain selection automatically.
 
 ---
 

--- a/.claude/skills/linux-docker-dev/SKILL.md
+++ b/.claude/skills/linux-docker-dev/SKILL.md
@@ -6,7 +6,7 @@ allowed-tools: Bash
 
 # Linux Docker Development Environment
 
-Run tests under Linux (Debian trixie + glibc 2.40, via the pre-baked `ry-ci` GHCR image) from macOS using the scripts in `docker/`. This reproduces the CI `asan`/`tsan` job environment locally and exposes Linux-only behaviour such as glibc heap consolidation checks that are invisible under macOS libSystem malloc.
+Run tests under Linux (Debian trixie + glibc 2.40, via the pre-baked `ry-ci` GHCR image) from macOS using the scripts in `docker/`. This reproduces the CI `asan` / `tsan` / `fuzz` / `clang-tidy` / `lint` / `scan-build` job environments locally and exposes Linux-only behaviour such as glibc heap consolidation checks that are invisible under macOS libSystem malloc. It is also the canonical workflow for sanitizer / libFuzzer / static-analysis runs because macOS-host execution hits known environment issues (issue #1865 — `fuzz_json` hang under ASan, TSan `LargeMmapAllocator` bug, clang-tidy PCH incompatibility, scan-build PATH absence, libFuzzer `SDKROOT` requirement).
 
 > **Source-of-truth note**: previously in `AGENTS.md`; relocated by #1384.
 
@@ -24,22 +24,54 @@ See [`docker/README.md`](../../../docker/README.md) for a quick-start reference.
 ./docker/run.sh asan ry test tests/spec/some.test.ry              # single file
 
 ./docker/run.sh tsan ry_tests                                     # TSan, C++ tests
+
+./docker/run.sh fuzz fuzz_parser -max_total_time=30 \
+    -artifact_prefix=tests/fuzz/regressions/parser/ \
+    tests/fuzz/corpus/parser                                      # libFuzzer parser harness
+./docker/run.sh fuzz fuzz_json   -max_total_time=30 \
+    -artifact_prefix=tests/fuzz/regressions/json/ \
+    tests/fuzz/corpus/json
+./docker/run.sh fuzz fuzz_utf8   -max_total_time=30 \
+    -artifact_prefix=tests/fuzz/regressions/utf8/ \
+    tests/fuzz/corpus/utf8
+
 ./docker/run.sh default bash                                      # interactive shell
 
 ./docker/run.sh --rebuild asan ry_tests                           # force image rebuild
 ```
 
+## Static analysis subcommand
+
+`./docker/run.sh static-analysis <tool>` invokes Clang-Tidy / Cppcheck / scan-build inside the container, reusing the same LLVM 21 toolchain as CI.
+
+```bash
+./docker/run.sh static-analysis clang-tidy                        # uses build-docker/compile_commands.json
+./docker/run.sh static-analysis cppcheck                          # no build required
+./docker/run.sh static-analysis scan-build                        # HTML report in build-scan-docker/scan-build-report/<timestamp>/ (host bind-mount)
+./docker/run.sh static-analysis all                               # clang-tidy → cppcheck → scan-build
+```
+
+> `scan-build` and `all` isolate their analyzer-wrapped CMake configuration in `build-scan-docker/` (host) ↔ `build-scan/` (container), separate from `build-docker/`. This means a subsequent `./docker/run.sh default ...` works immediately without an intervening `rm -rf` — only delete `build-scan-docker/` if you want to discard the analyzer state and report.
+
 ## Preset summary
 
-| Preset | Sanitizers | Sanitizer env vars (auto-set by run.sh) | Host build dir |
-|--------|-----------|----------------------------------------|----------------|
+| Preset / subcommand | Sanitizers | Sanitizer env vars (auto-set by run.sh) | Host build dir |
+|---------------------|-----------|----------------------------------------|----------------|
 | `default` | none | — | `build-docker/` |
 | `asan` | ASan + UBSan | `ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0:halt_on_error=1`, `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1` | `build-asan-docker/` |
 | `tsan` | TSan | `TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1` | `build-tsan-docker/` |
+| `fuzz` | ASan + UBSan | same as `asan` | `build-fuzz-docker/` |
+| `static-analysis` clang-tidy / cppcheck | — | — | `build-docker/` (shared with `default`) |
+| `static-analysis` scan-build / all | — | — | `build-scan-docker/` (dedicated; `build-docker/` also mounted for clang-tidy step in `all` mode) |
 
 ## Known limitations
 
 - **First image build takes ~30 seconds** because `docker/Dockerfile` inherits from `ghcr.io/<owner>/ry-ci:llvm-21` — the heavy toolchain (LLVM 21, cmake, ninja, ccache, OpenSSL, cppcheck, gtest tarball) is pulled, not built. The first compile of ry itself takes 1-2 minutes; subsequent runs use ccache and complete in ~10-30 seconds. If GHCR is unreachable, Docker falls back to whatever image layers are already cached locally.
 - On Apple Silicon, the container runs **arm64 Linux natively**. To test x86_64-specific behaviour, pass `--platform linux/amd64` manually to `docker run` (not wired into `run.sh` by default — qemu emulation is 5-10× slower and rarely needed).
-- macOS builds (`build/`, `build-asan/`, `build-tsan/`) and Docker builds (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`) are **fully separate**. Running Docker commands will not overwrite your local CMake build.
+- macOS builds (`build/`, `build-asan/`, `build-tsan/`, `build-fuzz/`) and Docker builds (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`, `build-fuzz-docker/`, `build-scan-docker/`) are **fully separate**. Running Docker commands will not overwrite your local CMake build.
 - The dev image inherits from `ry-ci`, **not** `ry-ci-glibc-old`. Local Linux builds therefore link against glibc 2.40 (Debian trixie). To reproduce a release-style binary against glibc 2.36, override the base image: `docker build --build-arg CI_IMAGE_OWNER=<owner> --build-arg CI_IMAGE_TAG=llvm-21 -t ry-linux-dev:glibc-old docker/` — but only do this if you are debugging release-specific symbol issues; everyday dev does not need it.
+- **No silent fallback to macOS-native execution**: `run.sh` hard-fails if no Docker daemon is reachable. This is intentional (issue #1865) — falling back to native would re-introduce the platform-specific breakage this script is meant to escape.
+- **Recommended Docker runtime: OrbStack** — its VirtioFS-backed bind-mount delivers materially better throughput than Docker Desktop's gRPC-FUSE, which matters for fuzz corpus I/O. Colima and Docker Desktop are supported alternatives if OrbStack is unavailable.
+- **`/tmp` inside the container is a 2 GB tmpfs**, not the overlay filesystem. `run.sh` mounts it via `--tmpfs /tmp:rw,exec,size=2g` so test temp dirs (`/tmp/ry_entry_test_*`, `mkdtemp` callers in `tests/test_paths.cpp`) and analyzer scratch (`scan-build`'s timestamped working dir) never compete with the Docker storage pool. If a test needs more than 2 GB of `/tmp` it must opt out explicitly — bump the size flag locally for that run.
+- **`--rebuild` invalidates host `build-*-docker/` caches when the image's toolchain layout changes** (e.g. ninja moved from `/usr/bin/ninja` to `/opt/ninja/bin/ninja` between image revisions). Symptom: `cmake: Running '/usr/bin/ninja' '--version' failed`. Remediation: `rm -rf build-docker/ build-asan-docker/ build-tsan-docker/ build-fuzz-docker/ build-scan-docker/` and rerun. CMake reuses `CMAKE_MAKE_PROGRAM` from the cache; only `--fresh` or a wipe forces re-discovery.
+- **`--user $(id -u):$(id -g)` intentionally not passed** to `docker run`. The base image sets `CCACHE_DIR=/home/ubuntu/.cache/ccache` owned by container UID 1000; passing the macOS host UID (typically 502) would break ccache writes inside the named volume `ry-ccache-docker`. macOS Docker runtimes (OrbStack VirtioFS, Docker Desktop gRPC-FUSE) transparently translate bind-mount UIDs, so files created under `/workspace` and `build-*-docker/` end up owned by the host user without needing `--user`. This is a deliberate deviation from the original Plan in issue #1865, which proposed `--user` to fix UID mismatch — that path would have required either chowning the ccache volume per run or relocating ccache into the bind-mount (both worse than relying on runtime UID translation). On Linux hosts where UIDs do not get translated, ccache will simply be skipped or files will be owned by `1000:1000` — acceptable for ad-hoc Linux dev, and out of scope for this script's macOS-centric target.

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -153,12 +153,13 @@ cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry 
 >
 > 出力が空ならスキップ可。スキップ時は PR description に `Skipped §3.5 — no source code change` を記録。
 
+> **macOS 注意**: ASan / UBSan / TSan のローカル実行は Docker に統一する。`fuzz_json` の ASan 下ハングや TSan `LargeMmapAllocator` の Darwin upstream バグなど macOS-host 固有の問題を避けるため (issue #1865)。サニタイザー環境変数は `docker/run.sh` がプリセットに応じて自動設定する。
+
 **ASan + UBSan**（メモリ安全性 + 未定義動作）:
 
 ```bash
-cmake --preset asan && cmake --build build-asan && \
-  ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests && \
-  ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry test -p
+./docker/run.sh asan ry_tests
+./docker/run.sh asan ry test -p
 ```
 
 ASan / UBSan が検出した問題は原因を修正してから作業完了とする。これらのエラーを残したままコミットしてはならない。
@@ -166,9 +167,8 @@ ASan / UBSan が検出した問題は原因を修正してから作業完了と�
 **TSan**（スレッド安全性）:
 
 ```bash
-cmake --preset tsan && cmake --build build-tsan && \
-  TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry_tests && \
-  TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1 ./build-tsan/ry test -p
+./docker/run.sh tsan ry_tests
+./docker/run.sh tsan ry test -p
 ```
 
 C++ TSan テスト (`ry_tests`) は required で、`ConcurrencySpecSuite` (= `tests/spec/concurrency.test.ry` stress test) を検証する。Ry self-test (`ry test -p`) は TSan `LargeMmapAllocator` CHECK 問題 (upstream #1716、Linux 限定) により warn-only — ローカルでも CI でも C++ テストが clean run していれば本 PR スコープでは OK とする。LLVM ORC teardown family の crash (`~LLJIT()` / `removeResourceTracker` / `~CodeGen()` / `~OverloadEntry()`) は両 OS で観測されうるが `src/jit_runner.cpp` の三段階 leak (#1187 + #1657) で suppress 済み — このパターンの再発は新規 issue として起票する。race が検出された場合 (C++ / self-test どちらでも) は本 PR スコープ内で修正すること (`/triage-side-finding` Q1 該当 = CI 検出の再現困難問題 → 即時修正)。既知 race として扱って先送りしてはならない。`/tsan-known-issues` の `LargeMmapAllocator` entry および ORC teardown entry を参照。#630 の audit に無い新規 race パターンを発見した場合は新規 concurrency issue を起票し、再現テストを `tests/spec/concurrency*.test.ry` に追加する。
@@ -177,73 +177,35 @@ C++ TSan テスト (`ry_tests`) は required で、`ConcurrencySpecSuite` (= `te
 
 CI の `lint` / `clang-tidy` / `scan-build` ジョブを push 前にローカルで再現する。設定・抑制ルール・誤検知対処の詳細は `/static-analysis-tools` に委譲。
 
+> **macOS 注意**: clang-tidy の PCH 互換性問題 (Apple clang ↔ Homebrew LLVM clang) / scan-build PATH 不在 / Homebrew LLVM 依存を避けるため、ローカル実行は Docker に統一する (issue #1865)。
+
 **clang-tidy** (required):
 
 ```bash
-# macOS: sysctl -n hw.ncpu / Linux: nproc
-# -n 1 is required — xargs otherwise batches all .cpp paths into a single
-# clang-tidy invocation, defeating the -P parallelism.
-find src -name '*.cpp' -print0 \
-  | xargs -0 -n 1 -P "$(sysctl -n hw.ncpu)" /opt/homebrew/opt/llvm@21/bin/clang-tidy -p build --quiet
+./docker/run.sh static-analysis clang-tidy
 ```
-
-**PCH 互換性**: macOS で `cmake --preset default` (Apple clang が PCH 生成) の後に LLVM clang-tidy を実行すると `PCH file built from a different branch` で失敗することがある。`build/` を削除して LLVM clang を CC/CXX に明示してから再 configure する (`SDKROOT` も必須):
-
-```bash
-rm -rf build
-SDKROOT=$(xcrun --show-sdk-path) \
-CC=/opt/homebrew/opt/llvm@21/bin/clang \
-CXX=/opt/homebrew/opt/llvm@21/bin/clang++ \
-    cmake --preset default && cmake --build build
-```
-
-詳細は `/commands-environment-gotchas` の PCH entry を参照。
 
 **cppcheck** (required):
 
 ```bash
-cppcheck --enable=warning,performance,portability --std=c++17 --error-exitcode=1 \
-    --suppressions-list=.cppcheck-suppressions --inline-suppr \
-    -i build -i build-asan -i build-tsan \
-    -j "$(nproc 2>/dev/null || sysctl -n hw.logicalcpu)" --quiet \
-    src/ include/
+./docker/run.sh static-analysis cppcheck
 ```
 
 **scan-build** (warn-only — 強く推奨):
 
-CI は `continue-on-error: true` で warn-only 運用中。ローカルでも警告即修正は不要だが、新規 null-dereference / use-after-free / division-by-zero が検出された場合は同 PR で対処することを強く推奨する。
-
-CI は event ごとに分析スコープを切り替える (#1738): PR では `--target ry`、push-to-main では全 target。ローカルでも同じ使い分けが可能。scan-build は Homebrew LLVM 21 に同梱されているが PATH には入らない。フルパス `/opt/homebrew/opt/llvm@21/bin/scan-build` で呼び出す。configure ステップは fast / full とも共通:
+CI は `continue-on-error: true` で warn-only 運用中。ローカルでも警告即修正は不要だが、新規 null-dereference / use-after-free / division-by-zero が検出された場合は同 PR で対処することを強く推奨する。CI は event ごとに分析スコープを切り替える (#1738): PR では `--target ry`、push-to-main では全 target — Docker 側は PR 相当の fast scan (`--target ry`) を実行する。
 
 ```bash
-/opt/homebrew/opt/llvm@21/bin/scan-build \
-    --use-analyzer=/opt/homebrew/opt/llvm@21/bin/clang \
-    --use-cc=/opt/homebrew/opt/llvm@21/bin/clang \
-    --use-c++=/opt/homebrew/opt/llvm@21/bin/clang++ \
-    cmake --preset default
+./docker/run.sh static-analysis scan-build
 ```
 
-build + analyze — **高速確認のみ** (PR 相当、`ry` target ≒ ~76 TU):
+3 ツールを一括実行する場合:
 
 ```bash
-/opt/homebrew/opt/llvm@21/bin/scan-build \
-    --use-analyzer=/opt/homebrew/opt/llvm@21/bin/clang \
-    --use-cc=/opt/homebrew/opt/llvm@21/bin/clang \
-    --use-c++=/opt/homebrew/opt/llvm@21/bin/clang++ \
-    -o /tmp/scan-build-report --status-bugs cmake --build build --target ry --parallel
+./docker/run.sh static-analysis all
 ```
 
-build + analyze — **deep verification (推奨)** (push-to-main 相当、全 target):
-
-```bash
-/opt/homebrew/opt/llvm@21/bin/scan-build \
-    --use-analyzer=/opt/homebrew/opt/llvm@21/bin/clang \
-    --use-cc=/opt/homebrew/opt/llvm@21/bin/clang \
-    --use-c++=/opt/homebrew/opt/llvm@21/bin/clang++ \
-    -o /tmp/scan-build-report --status-bugs cmake --build build --parallel
-```
-
-scan-build はビルドをラップするため `build/` の状態が変わる場合がある。以降のステップでビルドが必要なら §3 のコマンドで再ビルドする。
+> `scan-build` および `all` は専用の `build-scan-docker/`（host）↔ `build-scan/`（container）で analyzer wrapper ビルドを行うため、`build-docker/` を汚染しない。直後に `./docker/run.sh default ...` を実行する際の cleanup は不要。HTML レポートは `build-scan-docker/scan-build-report/<timestamp>/index.html` に出力される — 不要になったら `build-scan-docker/` ごと削除して構わない。
 
 clang-tidy / cppcheck で失敗した場合は原因を修正してから作業完了とする。よくある失敗パターン (`performance-inefficient-string-concatenation` 等) と canonical workaround は `.claude/rules/build-warning-flags.md` を参照。
 
@@ -266,24 +228,16 @@ clang-tidy / cppcheck で失敗した場合は原因を修正してから作業�
 
 **CI ジョブは無効のため、フィーチャーブランチで必ずローカル実行すること。** ハーネス要件・既知制限の詳細は `/libfuzzer-harness` を参照。
 
-```bash
-# macOS（build-fuzz/ が既にある場合はビルドをスキップ可）
-SDKROOT=$(xcrun --show-sdk-path) CC=/opt/homebrew/opt/llvm@21/bin/clang CXX=/opt/homebrew/opt/llvm@21/bin/clang++ \
-    cmake --preset fuzz && cmake --build build-fuzz
+> **macOS 注意**: `fuzz_json` は macOS native の ASan 下でハングするため Docker 実行が必須 (issue #1865)。`docker/run.sh` がプリセットに応じてサニタイザー環境変数を自動設定する。
 
-ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0:halt_on_error=1 \
-UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
-    ./build-fuzz/fuzz_parser -max_total_time=60 -rss_limit_mb=512 \
+```bash
+./docker/run.sh fuzz fuzz_parser -max_total_time=60 -rss_limit_mb=512 \
     -artifact_prefix=tests/fuzz/regressions/parser/ tests/fuzz/corpus/parser
 
-ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0:halt_on_error=1 \
-UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
-    ./build-fuzz/fuzz_json -max_total_time=60 -rss_limit_mb=512 \
+./docker/run.sh fuzz fuzz_json -max_total_time=60 -rss_limit_mb=512 \
     -artifact_prefix=tests/fuzz/regressions/json/ tests/fuzz/corpus/json
 
-ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0:halt_on_error=1 \
-UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
-    ./build-fuzz/fuzz_utf8 -max_total_time=60 -rss_limit_mb=512 \
+./docker/run.sh fuzz fuzz_utf8 -max_total_time=60 -rss_limit_mb=512 \
     -artifact_prefix=tests/fuzz/regressions/utf8/ tests/fuzz/corpus/utf8
 ```
 

--- a/.claude/skills/static-analysis-tools/SKILL.md
+++ b/.claude/skills/static-analysis-tools/SKILL.md
@@ -27,10 +27,9 @@ Reference for Clang-Tidy, Cppcheck, and Clang Static Analyzer (scan-build) confi
   - **push to main**: `cmake --build build --parallel` で full build (all target)
   - **注意**: `--target ry` は **build step のみ** narrowing する。clang-tidy 解析は両 event とも `find src -name '*.cpp'` で得られる全 90 ファイル (ry_lib に含まれない 14 TU を含む) を並列解析する
 - 解析は `xargs -0 -n 1 -P "$(nproc)"` で TU 並列実行 (#1741)。`-n 1` は必須 — 省くと xargs が全 .cpp を 1 つの clang-tidy 呼び出しにまとめてしまい、`-P` の並列度が無効化される
-- ローカル実行 (macOS は `sysctl -n hw.ncpu`、Linux は `nproc`):
+- ローカル実行は Docker 経由に統一する (issue #1865 — macOS で PCH 互換性問題 / Homebrew LLVM PATH を回避):
   ```bash
-  find src -name '*.cpp' -print0 \
-    | xargs -0 -n 1 -P "$(sysctl -n hw.ncpu)" clang-tidy -p build --quiet
+  ./docker/run.sh static-analysis clang-tidy
   ```
 - 新規コードは Clang-Tidy 警告ゼロを維持すること
 
@@ -48,7 +47,7 @@ Reference for Clang-Tidy, Cppcheck, and Clang Static Analyzer (scan-build) confi
 
 **抑制すべきでないケース**: 通常の関数で例外を投げうるコードを noexcept と宣言・抑制すること。例外発生で `std::terminate` するため、プロセス境界以外では呼び出し側が捕捉できる例外設計を維持する。
 
-**ローカル検証**: macOS では Homebrew clang で build しないと clang-tidy 21 が PCH を読めない。`CC=/opt/homebrew/opt/llvm@21/bin/clang CXX=/opt/homebrew/opt/llvm@21/bin/clang++ cmake --preset default -DCMAKE_OSX_SYSROOT=$(xcrun --show-sdk-path)` で reconfigure する。
+**ローカル検証**: `./docker/run.sh static-analysis clang-tidy` で Linux + libstdc++ 環境を再現する (issue #1865)。Docker 経由なら toolchain を Apple clang ↔ Homebrew LLVM ↔ Linux LLVM で揃える必要がなく PCH 互換性問題も発生しない。
 
 **参照例**:
 - `src/codegen.cpp` の `CodeGen::FnScope::~FnScope() noexcept` — `noexcept` 明示 + NOLINTNEXTLINE 併用（destructor 末尾の `resize()` を libc++ が throwing と推論）
@@ -65,7 +64,10 @@ Reference for Clang-Tidy, Cppcheck, and Clang Static Analyzer (scan-build) confi
 
 - `compile_commands.json` は使用しない（ビルド不要で高速実行）
 - ソースコード内の `// cppcheck-suppress <id>` コメントも有効（`--inline-suppr`）
-- ローカル実行: `cppcheck --enable=warning,performance,portability --std=c++17 --suppressions-list=.cppcheck-suppressions --inline-suppr -i build -i build-asan -i build-tsan -j "$(nproc)" --quiet src/ include/`
+- ローカル実行は Docker 経由に統一する (issue #1865):
+  ```bash
+  ./docker/run.sh static-analysis cppcheck
+  ```
 - 新規コードは Cppcheck 警告ゼロを維持すること
 
 ## Clang Static Analyzer (scan-build)
@@ -78,30 +80,14 @@ CI は event に応じて分析スコープを切り替える (#1738):
 
 両 event とも `continue-on-error: true` (warn-only) 運用中。
 
-- `scan-build` は CI コンテナ (`ghcr.io/<owner>/ry-ci:llvm-21`) の LLVM 21 source build に同梱されており、`/usr/local/llvm/bin/scan-build` から利用可能。ローカル Linux ホストでは `sudo apt-get install clang-tools-21`、macOS では `brew install llvm@21` で入手する
+- `scan-build` は CI コンテナ (`ghcr.io/<owner>/ry-ci:llvm-21`) の LLVM 21 source build に同梱されており、`/usr/local/llvm/bin/scan-build` から利用可能
 - `compile_commands.json` は使用しない（scan-build がビルドをラップして解析する）
-- ローカル実行 — fast scan (`ry` target のみ、PR と同等):
+- ローカル実行は Docker 経由に統一する (issue #1865 — macOS で scan-build が PATH 外 / Homebrew 依存を回避)。fast scan (`ry` target のみ、PR と同等) を実行:
   ```bash
-  scan-build --use-analyzer=/usr/local/llvm/bin/clang \
-             --use-cc=/usr/local/llvm/bin/clang \
-             --use-c++=/usr/local/llvm/bin/clang++ \
-             cmake --preset default
-  scan-build --use-analyzer=/usr/local/llvm/bin/clang \
-             --use-cc=/usr/local/llvm/bin/clang \
-             --use-c++=/usr/local/llvm/bin/clang++ \
-             -o /tmp/scan-build-report \
-             --status-bugs \
-             cmake --build build --target ry --parallel
+  ./docker/run.sh static-analysis scan-build
   ```
-- ローカル実行 — full scan (push-to-main と同等の広いカバレッジ):
-  ```bash
-  scan-build --use-analyzer=/usr/local/llvm/bin/clang \
-             --use-cc=/usr/local/llvm/bin/clang \
-             --use-c++=/usr/local/llvm/bin/clang++ \
-             -o /tmp/scan-build-report \
-             --status-bugs \
-             cmake --build build --parallel
-  ```
-  HTML レポートが `/tmp/scan-build-report/<timestamp>/index.html` に生成される
+  HTML レポートは bind-mount 経由でホスト側の `build-scan-docker/scan-build-report/<timestamp>/index.html` に生成される（コンテナ内 path は `/workspace/build-scan/scan-build-report/`）。コンテナ終了後もホストに残るので、ブラウザ等で直接開いて確認できる
+- 全 3 ツールを一括実行する場合: `./docker/run.sh static-analysis all`
+- `scan-build` および `all` は専用の `build-scan-docker/`（host）↔ `build-scan/`（container）で analyzer wrapper ビルドを行うため、`build-docker/` は無傷で残る。続けて `./docker/run.sh default ...` を実行する際に `rm -rf` 等は不要。レポートだけ捨てたい場合は `build-scan-docker/` を削除する
 - false positive の抑制は `#ifndef __clang_analyzer__` でインライン抑制する（clang-tidy の `// NOLINT` と同様の粒度）
 - CI は warn-only 運用 (`continue-on-error: true`)。新規 null-dereference / use-after-free / division-by-zero などが検出されたら同 PR で対処することを強く推奨する

--- a/.claude/skills/tsan-known-issues/SKILL.md
+++ b/.claude/skills/tsan-known-issues/SKILL.md
@@ -15,10 +15,10 @@ Reference for ThreadSanitizer policy and known infrastructure limitations in the
 **Source**: #868 (warn-only landed), #874 (split policy)
 **Tags**: tsan, sanitizer, ci, concurrency
 
-**Rule**: The C++ TSan step (`./build-tsan/ry_tests`) is required
+**Rule**: The C++ TSan step (`./docker/run.sh tsan ry_tests`) is required
 and gates #630's P0 race fixes via `ConcurrencySpecSuite` (which
 runs `tests/spec/concurrency.test.ry`). The Ry self-test TSan step
-(`./build-tsan/ry test -p`) runs as `continue-on-error: true`
+(`./docker/run.sh tsan ry test -p`) runs as `continue-on-error: true`
 until upstream https://github.com/google/sanitizers/issues/1716
 is fixed — see the separate `LargeMmapAllocator` entry. A PR that
 introduces a new race must fix it in the same PR; warn-only is a
@@ -34,12 +34,12 @@ surfaces, widen via #872 rather than blindly expanding the flag.
 **Source**: #868 / #874
 **Tags**: tsan, sanitizer, ci, ubuntu, gotcha
 
-**Rule**: Keep `./build-tsan/ry test -p` as `continue-on-error: true`
+**Rule**: Keep `./docker/run.sh tsan ry test -p` as `continue-on-error: true`
 until upstream https://github.com/google/sanitizers/issues/1716
 is fixed: the self-test driver aborts inside TSan's
 `LargeMmapAllocator::Deallocate` — a runtime bug, not a race in
 ry code. Pinning `ubuntu-22.04` and lowering `vm.mmap_rnd_bits=28`
-were both tried. `./build-tsan/ry_tests` (which includes
+were both tried. `./docker/run.sh tsan ry_tests` (which includes
 `ConcurrencySpecSuite`) runs cleanly on the same binary, so that
 is the required gate for #630's race fixes. macOS is unaffected
 **by this specific upstream LargeMmapAllocator CHECK** — but the

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,8 @@ build-fuzz/
 build-docker/
 build-asan-docker/
 build-tsan-docker/
+build-fuzz-docker/
+build-scan-docker/
 
 # Editor / tool caches
 .cache/

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,6 +1,6 @@
 # ry Linux Docker Development Environment
 
-Run tests in a Linux environment (Debian trixie + glibc 2.40, via the pre-baked `ry-ci` GHCR image) from macOS, matching CI conditions for all sanitizer presets.
+Run tests in a Linux environment (Debian trixie + glibc 2.40, via the pre-baked `ry-ci` GHCR image) from macOS, matching CI conditions for all sanitizer presets, libFuzzer, and static analysis.
 
 See [`.claude/skills/linux-docker-dev/SKILL.md`](../.claude/skills/linux-docker-dev/SKILL.md) for full workflow documentation.
 
@@ -20,6 +20,17 @@ See [`.claude/skills/linux-docker-dev/SKILL.md`](../.claude/skills/linux-docker-
 # TSan (mirrors CI tsan job)
 ./docker/run.sh tsan ry_tests
 
+# libFuzzer (mirrors CI fuzz job)
+./docker/run.sh fuzz fuzz_parser -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/parser/ tests/fuzz/corpus/parser
+./docker/run.sh fuzz fuzz_json   -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/json/   tests/fuzz/corpus/json
+./docker/run.sh fuzz fuzz_utf8   -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/utf8/   tests/fuzz/corpus/utf8
+
+# Static analysis (mirrors CI clang-tidy / lint / scan-build jobs)
+./docker/run.sh static-analysis clang-tidy
+./docker/run.sh static-analysis cppcheck
+./docker/run.sh static-analysis scan-build
+./docker/run.sh static-analysis all
+
 # Interactive shell
 ./docker/run.sh default bash
 
@@ -34,10 +45,26 @@ See [`.claude/skills/linux-docker-dev/SKILL.md`](../.claude/skills/linux-docker-
 | `default` | none | — | `build-docker/` |
 | `asan` | ASan + UBSan | `ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0:halt_on_error=1`<br>`UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1` | `build-asan-docker/` |
 | `tsan` | TSan | `TSAN_OPTIONS=halt_on_error=1:second_deadlock_stack=1` | `build-tsan-docker/` |
+| `fuzz` | ASan + UBSan | same as `asan` | `build-fuzz-docker/` |
+
+## Static analysis tools
+
+`./docker/run.sh static-analysis <tool>` invokes the requested tool inside the container using the LLVM 21 toolchain pre-baked in `ry-ci:llvm-21`:
+
+| Tool | Source | Notes |
+|------|--------|-------|
+| `clang-tidy` | `/usr/local/llvm/bin/clang-tidy` | Reuses `build-docker/` for `compile_commands.json` |
+| `cppcheck` | `/opt/cppcheck/bin/cppcheck` | No build required |
+| `scan-build` | `/usr/local/llvm/bin/scan-build` | Configures+builds in dedicated `build-scan-docker/` (host bind-mount), HTML report at `build-scan-docker/scan-build-report/<timestamp>/`, exits non-zero on findings via `--status-bugs` |
+| `all` | — | Runs clang-tidy → cppcheck → scan-build in sequence |
+
+> **`scan-build` and `all`** isolate their analyzer-wrapped CMake configuration in `build-scan-docker/` (host) ↔ `build-scan/` (container). `build-docker/` is untouched, so `./docker/run.sh default ...` works without an intervening cleanup. To wipe the analyzer report, remove `build-scan-docker/` directly (the directory is also recreated on the next scan-build run).
 
 ## Notes
 
-- Host build dirs (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`) are separate from native macOS builds (`build/`, `build-asan/`, `build-tsan/`). They will not interfere with each other.
+- Host build dirs (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`, `build-fuzz-docker/`, `build-scan-docker/`) are separate from native macOS builds (`build/`, `build-asan/`, `build-tsan/`, `build-fuzz/`). They will not interfere with each other.
 - On Apple Silicon the container runs arm64 Linux natively (no x86_64 QEMU emulation).
 - ccache is persisted in a named Docker volume (`ry-ccache-docker`). The first build compiles everything; subsequent runs reuse the cache.
 - Image name: `ry-linux-dev:latest`. Built locally; not pushed to any registry.
+- The script hard-fails when no Docker daemon is reachable (no silent fallback to macOS-native execution — see issue #1865 for the rationale).
+- **Recommended runtime: OrbStack** for VirtioFS bind-mount throughput (matters for fuzz corpus I/O). Colima and Docker Desktop are supported alternatives.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -11,10 +11,85 @@ case "$PRESET" in
   default) BUILD_DIR="build" ;;
   asan)    BUILD_DIR="build-asan" ;;
   tsan)    BUILD_DIR="build-tsan" ;;
-  *)       echo "error: unknown preset '$PRESET' (supported: default, asan, tsan)" >&2; exit 1 ;;
+  fuzz)    BUILD_DIR="build-fuzz" ;;
+  *)       echo "error: unknown preset '$PRESET' (supported: default, asan, tsan, fuzz)" >&2; exit 1 ;;
 esac
 
-# Build
+# static-analysis subcommand: each tool manages its own build needs
+if [[ "${1:-}" == "static-analysis" ]]; then
+  shift
+  TOOL="${1:-all}"
+  shift || true
+  TOOLS=()
+  case "$TOOL" in
+    clang-tidy|cppcheck|scan-build) TOOLS=("$TOOL") ;;
+    all)                            TOOLS=(clang-tidy cppcheck scan-build) ;;
+    *) echo "error: unknown static-analysis tool '$TOOL' (supported: clang-tidy, cppcheck, scan-build, all)" >&2; exit 1 ;;
+  esac
+
+  # clang-tidy needs compile_commands.json from a real build; cppcheck does not;
+  # scan-build wraps its own configure+build below.
+  NEEDS_PREBUILD=0
+  for t in "${TOOLS[@]}"; do
+    [[ "$t" == "clang-tidy" ]] && NEEDS_PREBUILD=1
+  done
+  if [[ "$NEEDS_PREBUILD" -eq 1 ]]; then
+    cmake --preset "$PRESET"
+    cmake --build "$BUILD_DIR"
+  fi
+
+  FAIL=0
+  for t in "${TOOLS[@]}"; do
+    echo "=== static-analysis: $t ==="
+    set +e
+    case "$t" in
+      clang-tidy)
+        find src -name '*.cpp' -print0 \
+          | xargs -0 -n 1 -P "$(nproc)" clang-tidy -p "$BUILD_DIR" --quiet
+        ;;
+      cppcheck)
+        cppcheck --enable=warning,performance,portability --std=c++17 \
+          --suppressions-list=.cppcheck-suppressions --inline-suppr \
+          -i build -i build-asan -i build-tsan -i build-fuzz -i build-debug \
+          -j "$(nproc)" --quiet src/ include/
+        ;;
+      scan-build)
+        # Use a dedicated build dir (bind-mounted to host build-scan-docker/) so
+        # the analyzer-wrapped CMakeCache never touches $BUILD_DIR. Without this
+        # split, a subsequent `./docker/run.sh default ...` would either rebuild
+        # against scan-build's wrapper CC/CXX or require `rm -rf build-docker/`
+        # to recover.
+        SCAN_BUILD_DIR="build-scan"
+        REPORT_DIR="/workspace/$SCAN_BUILD_DIR/scan-build-report"
+        mkdir -p "$REPORT_DIR"
+        # Mirror CMakePresets.json "default" cache vars (LLVM_DIR + Release)
+        # rather than `--preset default` because the preset hardcodes binaryDir.
+        scan-build --use-analyzer=/usr/local/llvm/bin/clang \
+                   --use-cc=/usr/local/llvm/bin/clang \
+                   --use-c++=/usr/local/llvm/bin/clang++ \
+                   -o "$REPORT_DIR" \
+                   cmake -S /workspace -B "/workspace/$SCAN_BUILD_DIR" -G Ninja \
+                     -DLLVM_DIR=/usr/local/llvm/lib/cmake/llvm \
+                     -DCMAKE_BUILD_TYPE=Release \
+          && scan-build --use-analyzer=/usr/local/llvm/bin/clang \
+                        --use-cc=/usr/local/llvm/bin/clang \
+                        --use-c++=/usr/local/llvm/bin/clang++ \
+                        -o "$REPORT_DIR" \
+                        --status-bugs \
+                        cmake --build "/workspace/$SCAN_BUILD_DIR" --target ry --parallel
+        ;;
+    esac
+    RC=$?
+    set -e
+    if [[ $RC -ne 0 ]]; then
+      echo "=== static-analysis: $t exited with $RC ==="
+      FAIL=$RC
+    fi
+  done
+  exit $FAIL
+fi
+
+# Normal preset path: build then dispatch command
 cmake --preset "$PRESET"
 cmake --build "$BUILD_DIR"
 
@@ -33,11 +108,14 @@ case "$CMD" in
   ry)
     exec "./$BUILD_DIR/ry" "$@"
     ;;
+  fuzz_parser|fuzz_json|fuzz_utf8)
+    exec "./$BUILD_DIR/$CMD" "$@"
+    ;;
   bash)
     exec bash "$@"
     ;;
   *)
-    echo "error: unknown command '$CMD' (supported: ry_tests, ry, bash)" >&2
+    echo "error: unknown command '$CMD' (supported: ry_tests, ry, bash, fuzz_parser, fuzz_json, fuzz_utf8)" >&2
     exit 1
     ;;
 esac

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # Run ry tests inside a Linux (Debian trixie + glibc 2.40, via the ry-ci GHCR image) container from macOS.
 # Usage: docker/run.sh [--rebuild] <preset> [cmd [args...]]
-#   preset: default | asan | tsan
-#   cmd:    ry_tests | ry | bash  (omit for build-only)
+#        docker/run.sh [--rebuild] static-analysis <tool>
+#   preset: default | asan | tsan | fuzz
+#   cmd:    ry_tests | ry | bash | fuzz_parser | fuzz_json | fuzz_utf8  (omit for build-only)
+#   tool:   clang-tidy | cppcheck | scan-build | all
 #   Examples:
 #     ./docker/run.sh asan ry_tests
 #     ./docker/run.sh asan ry test -p
 #     ./docker/run.sh asan ry test tests/spec/combinatorial/collection_element.test.ry
+#     ./docker/run.sh tsan ry_tests
+#     ./docker/run.sh fuzz fuzz_parser -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/parser/ tests/fuzz/corpus/parser
+#     ./docker/run.sh static-analysis clang-tidy
+#     ./docker/run.sh static-analysis all
 #     ./docker/run.sh default bash
 #     ./docker/run.sh --rebuild asan ry_tests
 set -euo pipefail
@@ -16,6 +22,16 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 IMAGE="ry-linux-dev:latest"
 CCACHE_VOLUME="ry-ccache-docker"
 
+# Hard-fail when no Docker daemon is reachable. Issue #1865 documents
+# macOS-host breakage (fuzz_json hang under ASan, TSan allocator bug,
+# clang-tidy PCH incompatibility, scan-build PATH friction, libFuzzer SDKROOT)
+# that this script is meant to escape — silently falling back to native would
+# defeat its purpose.
+if ! docker info >/dev/null 2>&1; then
+  echo "error: Docker daemon is not running — start OrbStack, Colima, or Docker Desktop" >&2
+  exit 1
+fi
+
 # Parse --rebuild flag
 REBUILD=0
 if [[ "${1:-}" == "--rebuild" ]]; then
@@ -23,15 +39,41 @@ if [[ "${1:-}" == "--rebuild" ]]; then
   shift
 fi
 
-PRESET="${1:-default}"
+SUBCOMMAND="${1:-default}"
+SCAN_BUILD_DIR_HOST=""
+SCAN_BUILD_DIR_CONTAINER=""
 
-# Validate preset and resolve host build dir
-case "$PRESET" in
-  default) BUILD_DIR_HOST="build-docker";     BUILD_DIR_CONTAINER="build" ;;
-  asan)    BUILD_DIR_HOST="build-asan-docker"; BUILD_DIR_CONTAINER="build-asan" ;;
-  tsan)    BUILD_DIR_HOST="build-tsan-docker"; BUILD_DIR_CONTAINER="build-tsan" ;;
-  *)       echo "error: unknown preset '$PRESET' (supported: default, asan, tsan)" >&2; exit 1 ;;
-esac
+# Resolve subcommand: either a CMake preset or the static-analysis dispatch.
+if [[ "$SUBCOMMAND" == "static-analysis" ]]; then
+  PRESET="default"
+  BUILD_DIR_HOST="build-docker"
+  BUILD_DIR_CONTAINER="build"
+  TOOL="${2:-all}"
+  case "$TOOL" in
+    clang-tidy|cppcheck|scan-build|all) ;;
+    *) echo "error: unknown static-analysis tool '$TOOL' (supported: clang-tidy, cppcheck, scan-build, all)" >&2; exit 1 ;;
+  esac
+  # scan-build and 'all' use a dedicated build dir so the analyzer-wrapped
+  # CMakeCache never contaminates build-docker/. The HTML report lands here
+  # too (build-scan-docker/scan-build-report/<timestamp>/).
+  case "$TOOL" in
+    scan-build|all)
+      SCAN_BUILD_DIR_HOST="build-scan-docker"
+      SCAN_BUILD_DIR_CONTAINER="build-scan"
+      ;;
+  esac
+  # Pass to entrypoint.sh as: <preset> static-analysis <tool>
+  set -- "$PRESET" static-analysis "$TOOL"
+else
+  PRESET="$SUBCOMMAND"
+  case "$PRESET" in
+    default) BUILD_DIR_HOST="build-docker";      BUILD_DIR_CONTAINER="build" ;;
+    asan)    BUILD_DIR_HOST="build-asan-docker"; BUILD_DIR_CONTAINER="build-asan" ;;
+    tsan)    BUILD_DIR_HOST="build-tsan-docker"; BUILD_DIR_CONTAINER="build-tsan" ;;
+    fuzz)    BUILD_DIR_HOST="build-fuzz-docker"; BUILD_DIR_CONTAINER="build-fuzz" ;;
+    *)       echo "error: unknown preset '$PRESET' (supported: default, asan, tsan, fuzz; or use 'static-analysis')" >&2; exit 1 ;;
+  esac
+fi
 
 # Build image if absent or --rebuild requested
 if [[ "$REBUILD" -eq 1 ]] || ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
@@ -41,11 +83,14 @@ fi
 
 # Ensure host build dir exists so Docker doesn't create it as root
 mkdir -p "$PROJECT_DIR/$BUILD_DIR_HOST"
+if [[ -n "$SCAN_BUILD_DIR_HOST" ]]; then
+  mkdir -p "$PROJECT_DIR/$SCAN_BUILD_DIR_HOST"
+fi
 
 # Sanitizer env vars matching CI jobs
 ENV_ARGS=()
 case "$PRESET" in
-  asan)
+  asan|fuzz)
     ENV_ARGS+=(
       -e "ASAN_OPTIONS=detect_container_overflow=0:detect_leaks=0:halt_on_error=1"
       -e "UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1"
@@ -66,10 +111,24 @@ else
   TTY_FLAG=(-i)
 fi
 
+# Note: --user $(id -u):$(id -g) intentionally not passed. The Dockerfile sets
+# CCACHE_DIR=/home/ubuntu/.cache/ccache owned by container UID 1000; overriding
+# the user would break ccache writes. macOS Docker runtimes (OrbStack VirtioFS,
+# Docker Desktop gRPC-FUSE) transparently translate bind-mount UIDs.
+# --tmpfs /tmp keeps test-created temp dirs and analyzer scratch off the overlay
+# (Docker storage pools fill up; /workspace bind-mount uses host disk).
+MOUNT_ARGS=(
+  -v "$PROJECT_DIR:/workspace"
+  -v "$PROJECT_DIR/$BUILD_DIR_HOST:/workspace/$BUILD_DIR_CONTAINER"
+  -v "$CCACHE_VOLUME:/home/ubuntu/.cache/ccache"
+)
+if [[ -n "$SCAN_BUILD_DIR_HOST" ]]; then
+  MOUNT_ARGS+=(-v "$PROJECT_DIR/$SCAN_BUILD_DIR_HOST:/workspace/$SCAN_BUILD_DIR_CONTAINER")
+fi
+
 docker run --rm "${TTY_FLAG[@]}" \
-  -v "$PROJECT_DIR:/workspace" \
-  -v "$PROJECT_DIR/$BUILD_DIR_HOST:/workspace/$BUILD_DIR_CONTAINER" \
-  -v "$CCACHE_VOLUME:/home/ubuntu/.cache/ccache" \
+  "${MOUNT_ARGS[@]}" \
+  --tmpfs /tmp:rw,exec,size=2g \
   "${ENV_ARGS[@]+"${ENV_ARGS[@]}"}" \
   "$IMAGE" \
   "$@"


### PR DESCRIPTION
## Summary

Closes #1865.

Migrate macOS-host-dependent test commands (sanitizers, static-analysis, fuzz) to Docker container execution to escape the platform-specific breakage documented in the issue. macOS-native fast iteration (`cmake --preset default + ry_tests + ry test -p`) is preserved.

## What changed

- `docker/run.sh`: add `fuzz` preset and `static-analysis` subcommand (clang-tidy / cppcheck / scan-build / all). Hard-fail when no Docker daemon. Mount `/tmp` as 2 GB tmpfs.
- `docker/entrypoint.sh`: fuzz binary dispatch (`fuzz_parser` / `fuzz_json` / `fuzz_utf8`) + static-analysis dispatch with FAIL-aggregation so `all` runs every tool before reporting.
- **scan-build / `all` use a dedicated `build-scan-docker/` (container: `build-scan/`)** so the analyzer-wrapped `CMakeCache` never contaminates `build-docker/`. Subsequent `./docker/run.sh default ...` runs need no `rm -rf` cleanup.
- Doc rewrites in `.claude/skills/pre-commit-checklist`, `linux-docker-dev`, `libfuzzer-harness`, `tsan-known-issues`, `static-analysis-tools` and `docker/README.md`. macOS-native fallback commands removed (would re-introduce the breakage this PR escapes).
- `.gitignore` ignores `build-scan-docker/`.

## Plan deviation: `--user` not passed to `docker run`

The Plan in #1865 (Task 3) proposed `--user "$(id -u):$(id -g)"` to fix UID mismatch. Implementation **intentionally omits it** — the base image sets `CCACHE_DIR=/home/ubuntu/.cache/ccache` owned by container UID 1000, and overriding the user would break ccache writes inside the named volume `ry-ccache-docker`. macOS Docker runtimes (OrbStack VirtioFS, Docker Desktop gRPC-FUSE) transparently translate bind-mount UIDs, so files in `/workspace` and `build-*-docker/` end up host-owned without `--user`. Rationale is documented in `.claude/skills/linux-docker-dev/SKILL.md` Known limitations.

## scan-build findings (warn-only, pre-existing)

`./docker/run.sh static-analysis scan-build` reports 7 findings, all pre-existing (`git diff origin/main -- src/` is empty for this PR). Matches CI's `continue-on-error: true` warn-only policy. Out of scope for this CI/infra PR — tracked under the existing scan-build findings backlog. Locations:

| Location | Category |
|---|---|
| `src/runtime_json.cpp:288` | Potential memory leak |
| `src/runtime_http.cpp:631, :724` | Potential memory leak (2) |
| `src/codegen_stmt.cpp:1644, :1653, :1663, :1669, :1677` | Value stored to 'newTy' is never read (5 grouped) |
| `src/codegen_fn.cpp:186` | Value stored to 'fnInfo' is never read |
| `src/main.cpp:223` | Value stored to 'sessionStarted' is never read |
| `src/main.cpp:336` | The parameter must not be null |

## Skipped checklist items

- **§2 CHANGELOG** — CI/infra-only (Docker scripts + .gitignore + skill docs). No user-visible Ry behavior change.

## Test plan

Verified end-to-end via the new `docker/run.sh` invocations:

- [x] `./docker/run.sh asan ry_tests`
- [x] `./docker/run.sh asan ry test -p`
- [x] `./docker/run.sh tsan ry_tests`
- [x] `./docker/run.sh fuzz fuzz_parser -max_total_time=30 ... tests/fuzz/corpus/parser`
- [x] `./docker/run.sh fuzz fuzz_json -max_total_time=30 ... tests/fuzz/corpus/json`
- [x] `./docker/run.sh fuzz fuzz_utf8 -max_total_time=30 ... tests/fuzz/corpus/utf8`
- [x] `./docker/run.sh static-analysis clang-tidy`
- [x] `./docker/run.sh static-analysis cppcheck`
- [x] `./docker/run.sh static-analysis scan-build` — exit 1 propagated, 7 pre-existing findings
- [x] `./docker/run.sh static-analysis all` — FAIL aggregation works (3 tools ran, scan-build's exit 1 propagated)
- [x] scan-build split confirmed: `build-docker/CMakeCache.txt` mtime unchanged across scan-build run; `build-scan-docker/CMakeCache.txt` contains analyzer wrappers (`c++-analyzer` / `ccc-analyzer`); HTML report at `build-scan-docker/scan-build-report/<timestamp>/`
- [x] macOS native `cmake --preset default && build && ./build/ry_tests && ./build/ry test -p` unaffected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fuzz build preset support
  * Added static-analysis command with clang-tidy, cppcheck, and scan-build tool options

* **Documentation**
  * Updated Docker documentation to cover new build and analysis workflows

* **Chores**
  * Improved Docker daemon error handling with early failure detection

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1867?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->