### PR TITLE
feat(io)!: stdin readLine() returns Result<Option<str>, Error> (#1850)

### DIFF
--- a/.claude/rules/tests-cpp-conventions.md
+++ b/.claude/rules/tests-cpp-conventions.md
@@ -198,3 +198,27 @@ failure that may or may not set the buffer. For NUL-safety tests, assert only th
 is `Err` and that `e.message` contains the expected string. Never assert the message is
 *absent* across test boundaries.
 
+### Subprocess tests: `execl` の argv[0] にフルパスを渡す (`"ry"` 短縮は Linux で stdlib 解決を壊す)
+
+**Source**: #1869 (2026-05-23, fix — `/ci-investigate` 経由で発見)
+**Tags**: testing, subprocess, execl, fork, stdlib-resolution, linux, macos, blind-spot
+
+**Context**: `tests/test_*.cpp` の fork+pipe subprocess helper で `execl(RY_BINARY_PATH, "ry", tmp.c_str(), nullptr)` のように argv[0] に bare `"ry"` を渡すと、子プロセス側で `argv[0] = "ry"` (slash なし) が見える。`src/paths.cpp:94` の `find_share_dir` は `fs::path(exe_path).parent_path()` で exe_dir を導出するため、bare `"ry"` だと `parent_path() = ""` → `fs::canonical("", ec)` の挙動が **macOS では CWD を返して成功 (CWD = repo root → `share/std/` 命中)**、**Linux glibc では失敗** → exe-adjacent share lookup (step 3) が機能しない。`setenv("RY_ENV", "internal", 1)` が同時に存在すると global `~/.ry/share` lookup (step 2) もスキップされ、`/tmp/<script>` を referrer に持つ subprocess は `findProjectRoot` も nullopt を返すので step 1 (project override) も塞がる — 結果 `find_share_dir = {}` で「`module not found: io`」になる。macOS native では発生せず Linux CI / Docker でのみ再現するため、ローカル `./build/ry_tests` パスでも CI で FAIL する非対称性が罠。
+
+**Rule**: subprocess を起動する `execl(RY_BINARY_PATH, ...)` 形式では、argv[0] にも **フルパス (`RY_BINARY_PATH`)** を渡す:
+
+```cpp
+// 禁止 (macOS では動くが Linux で fs::canonical("") が失敗し stdlib 解決が壊れる)
+execl(RY_BINARY_PATH, "ry", tmp.c_str(), nullptr);
+
+// 正しい
+execl(RY_BINARY_PATH, RY_BINARY_PATH, tmp.c_str(), nullptr);
+```
+
+**Why**: `RY_BINARY_PATH` は CMake `target_compile_definitions` で `$<TARGET_FILE:ry>` (フルパス) として注入されるため、argv[0] にそのまま流用すれば exe path resolution が両 OS で安定する。kernel の exec 解決は第 1 引数の `RY_BINARY_PATH` (path) を使うため、argv[0] の変更は子プロセス側の自己認識のみに影響する (安全)。
+
+**How to apply**:
+- 新規 subprocess test を追加する時、`execl(RY_BINARY_PATH, ?, ...)` の `?` は **常に `RY_BINARY_PATH`** にする。`"ry"` / `argv[0]` / 任意の短縮形を使わない
+- import を含む Ry source を subprocess で実行するテストでのみ症状が顕在化するが、import を含まないテスト (bare builtin `input()` など) も将来 import を足された瞬間に再発するため、**全 subprocess test に予防適用**する
+- canonical 例: `tests/test_read_line_builtin.cpp` (#1869 で導入), `tests/test_input_builtin.cpp` / `tests/test_help.cpp` / `tests/test_stdin.cpp` (#1869 で予防修正)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,7 @@ add_executable(ry_tests
     tests/test_runtime_string.cpp
     tests/test_stdin.cpp
     tests/test_input_builtin.cpp
+    tests/test_read_line_builtin.cpp
     tests/test_entry_point.cpp
     tests/test_help.cpp
     tests/test_trace.cpp

--- a/changelog.d/1850-stdin-readline-option.md
+++ b/changelog.d/1850-stdin-readline-option.md
@@ -1,0 +1,30 @@
+### Changed
+
+- **Breaking:** Changed the signature of the stdin `readLine()` builtin
+  in `share/std/io/io.ry` from `() -> str` to
+  `() -> Result<Option<str>, Error>`, mirroring the File-handle variant
+  introduced in #1816. Previously `readLine()` returned `""` for both
+  EOF and an empty input line, so callers could not distinguish "stdin
+  closed" from "user pressed Enter on an empty line". The new shape
+  returns `Ok(Some(line))` on success (trailing newline removed),
+  `Ok(None)` at EOF, and `Err(e)` on I/O failure. Migration:
+
+  ```ry
+  # before
+  from io import readLine
+  name = readLine()
+  print(f"Hello, {name}!")
+
+  # after
+  from io import readLine
+  case readLine():
+      Ok(opt):
+          case opt:
+              Some(name): print(f"Hello, {name}!")
+              None: print("(EOF)")
+      Err(e): print(e.message)
+  ```
+
+  The `input()` builtin is unchanged and still returns a bare `str`,
+  so short scripts that do not need EOF distinction can continue using
+  it. (#1850)

--- a/changelog.d/1850-stdin-readline-option.md
+++ b/changelog.d/1850-stdin-readline-option.md
@@ -27,4 +27,5 @@
 
   The `input()` builtin is unchanged and still returns a bare `str`,
   so short scripts that do not need EOF distinction can continue using
-  it. (#1850)
+  it; whether to give `input()` the same EOF distinction is tracked
+  separately in #1868. (#1850)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -228,7 +228,7 @@ print("a", "b", sep="-", end="!\n")  # a-b!
 
 Reads one line from standard input and returns it as a string with the trailing newline (`\n`) removed. Returns an empty string when EOF is reached. When `prompt` is provided, it is written to standard output (with no appended newline) and stdout is flushed before blocking on stdin — mirroring Python's `input(prompt)`.
 
-Equivalent to `io.readLine()` but available as a bare builtin without `import`. Use `input` for short scripts and competitive-programming snippets; use `io.readLine` when explicitly scoping I/O through the `io` module.
+Similar to `io.readLine()`, but returns a bare `str` instead of `Result<Option<str>, Error>` — convenient for short scripts and competitive-programming snippets where EOF / I/O error handling is unnecessary. EOF and read errors both yield `""`, so `input` cannot distinguish them; use `io.readLine` when that distinction matters.
 
 ```ry
 name = input("Enter your name: ")

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -12,7 +12,7 @@ from io import readText, writeText, exists
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `readLine` | `() -> str` | Reads one line from stdin (trailing newline removed) |
+| `readLine` | `() -> Result<Option<str>, Error>` | Reads one line from stdin; `Ok(Some(line))` on success (trailing newline removed), `Ok(None)` at EOF, `Err(e)` on I/O error |
 | `readAll` | `() -> str` | Reads all of stdin until EOF |
 
 ### File I/O
@@ -159,9 +159,18 @@ case writeBytes("data.bin", bs):
 ```ry
 from io import readLine
 
-name = readLine()
-print(f"Hello, {name}!")
+case readLine():
+    Ok(opt):
+        case opt:
+            Some(name):
+                print(f"Hello, {name}!")
+            None:
+                print("(no input)")
+    Err(e):
+        print(e.message)
 ```
+
+`readLine()` returns `Ok(Some(line))` for a successful read (trailing newline removed), `Ok(None)` at EOF (e.g. when stdin is closed), and `Err(e)` on I/O failure. For convenience scripts where EOF / error handling is unnecessary, the `input()` builtin returns a bare `str` (empty string on EOF / error).
 
 ## Error Handling
 
@@ -189,7 +198,7 @@ case open("missing.txt", "r"):
 | `readText` / `writeText` / `appendText` / `deleteFile` / `readBytes` / `writeBytes` | Path contains an embedded NUL byte |
 | `open` | File does not exist (mode `"r"` / `"rb"`), cannot be created/opened (mode `"w"` / `"a"` / `"wb"`), or mode is not `"r"` / `"w"` / `"a"` / `"rb"` / `"wb"` |
 | `readAll` (File) | Read error after opening |
-| `readLine` (File) | Read error (I/O failure, not EOF — EOF is `Ok(None)`) |
+| `readLine` (stdin) / `readLine` (File) | Read error (I/O failure, not EOF — EOF is `Ok(None)`) |
 | `writeText` (File, str) | Write error |
 | `open` / `readText` / `writeText` / `appendText` / `readBytes` / `writeBytes` | Path refers to a symbolic link (rejected by `O_NOFOLLOW`; security hardening) |
 | `readText` / `readBytes` / `readAll` (File) | File exceeds the 256 MiB read limit |

--- a/share/std/io/io.ry
+++ b/share/std/io/io.ry
@@ -3,7 +3,7 @@
 # Standard input
 @public
 @native("io")
-fn readLine() -> str
+fn readLine() -> Result<Option<str>, Error>
 
 @public
 @native("io")

--- a/src/codegen_call_io.cpp
+++ b/src/codegen_call_io.cpp
@@ -223,6 +223,28 @@ static llvm::Value *emitFileReadLine(CodeGen &cg, const CallExpr & /*e*/, llvm::
         });
 }
 
+static llvm::Value *emitStdinReadLine(CodeGen &cg, const CallExpr & /*e*/) {
+    llvm::Value *outAlloca = cg.builder_.CreateAlloca(cg.ptrTy_, nullptr, "srl_out");
+    cg.builder_.CreateStore(
+        llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(cg.ptrTy_)), outAlloca);
+    auto fn = cg.mod_->getOrInsertFunction(
+        "__ry_io_read_line",
+        llvm::FunctionType::get(cg.i64Ty_, {cg.ptrTy_}, false));
+    llvm::Value *status = cg.builder_.CreateCall(fn, {outAlloca}, "srl_status");
+    llvm::Value *isErr = cg.builder_.CreateICmpSLT(
+        status, llvm::ConstantInt::get(cg.i64Ty_, 0), "srl_iserr");
+    llvm::StructType *optTy = cg.getOptionType(cg.ptrTy_);
+    llvm::StructType *resTy = cg.getResultType(optTy, cg.errorTy_);
+    return cg.emitResultBranch(isErr, resTy,
+        [&]() -> llvm::Value * {
+            llvm::Value *linePtr = cg.builder_.CreateLoad(cg.ptrTy_, outAlloca, "srl_line");
+            return cg.buildOkValue(cg.wrapPtrAsOption(linePtr, "readLine"), resTy);
+        },
+        [&]() -> llvm::Value * {
+            return cg.buildErrValue(cg.buildErrorFromRuntime(), resTy);
+        });
+}
+
 static llvm::Value *emitFileLines(CodeGen &cg, const CallExpr & /*e*/, llvm::Value *fileHandle, int fileRk) {
     // State struct: { ptr file } — iterator holds a retained reference to the
     // File handle so the underlying FILE* stays alive even if the user lets
@@ -327,9 +349,8 @@ static llvm::Value *emitFileWriteText(CodeGen &cg, const CallExpr &e, llvm::Valu
 static constexpr const char *IO_ERR = "__ry_get_last_error";
 
 static const CodeGen::NativeDispatchEntry io_table[] = {
-    // 0-arg -> str (stdin)
-    {"readLine",    nullptr, CodeGen::ReturnWrapping::Direct,       0, nullptr,
-     nullptr, "__ry_read_line"},
+    // 0-arg -> str (stdin). readLine() is handled by dispatchIO's custom
+    // intercept (returns Result<Option<str>, Error>), not via this table.
     {"readAll",     nullptr, CodeGen::ReturnWrapping::Direct,       0, nullptr,
      nullptr, "__ry_read_all"},
     // 1-arg -> Result<str, Error>
@@ -382,7 +403,11 @@ static llvm::Value *dispatchIO(CodeGen &cg, const CallExpr &e) {
         return emitFileReadAll(cg, e, arg0);
     }
 
-    // readLine(f: File) — 1-arg (0-arg stdin handled by table)
+    // readLine() — 0-arg stdin reader, returns Result<Option<str>, Error>
+    if (n == "readLine" && sz == 0)
+        return emitStdinReadLine(cg, e);
+
+    // readLine(f: File) — 1-arg
     if (n == "readLine" && sz == 1) {
         llvm::Value *arg0 = cg.emitExpr(*e.args[0]);
         if (!cg.isFile(arg0))

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -65,6 +65,10 @@ extern "C" const char *__ry_read_line() {
 // *out_line is set to a Ry string handle on success (0-return only).
 // stdin counterpart of __ry_io_file_read_line.
 extern "C" int64_t __ry_io_read_line(const char **out_line) {
+    if (!out_line) {
+        setLastError("readLine: output pointer is null");
+        return -1;
+    }
     *out_line = nullptr;
     char *line = nullptr;
     size_t len = 0;
@@ -364,6 +368,10 @@ extern "C" const char *__ry_io_file_read_all(void *handle) {
 // Returns: 0 = line read, 1 = EOF (no data), -1 = error
 // *out_line is set to a Ry string handle on success (0-return only)
 extern "C" int64_t __ry_io_file_read_line(void *handle, const char **out_line) {
+    if (!out_line) {
+        setLastError("readLine: output pointer is null");
+        return -1;
+    }
     *out_line = nullptr;
     auto *h = static_cast<IoFileHandle *>(handle);
     if (!h || !h->fp) {

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -61,6 +61,26 @@ extern "C" const char *__ry_read_line() {
     return result;
 }
 
+// Returns: 0 = line read, 1 = EOF (no data), -1 = error
+// *out_line is set to a Ry string handle on success (0-return only).
+// stdin counterpart of __ry_io_file_read_line.
+extern "C" int64_t __ry_io_read_line(const char **out_line) {
+    *out_line = nullptr;
+    char *line = nullptr;
+    size_t len = 0;
+    ssize_t nread = getline(&line, &len, stdin);
+    if (nread == -1) {
+        free(line);
+        if (feof(stdin)) return 1;
+        setLastError("readLine: I/O error reading from stdin");
+        return -1;
+    }
+    if (nread > 0 && line[nread - 1] == '\n') --nread;
+    *out_line = makeString(line, (size_t)nread);
+    free(line);
+    return 0;
+}
+
 extern "C" const char *__ry_input_prompt(const char *prompt) {
     size_t promptLen = static_cast<size_t>(stringByteLen(prompt));
     if (promptLen > 0)

--- a/tests/test_help.cpp
+++ b/tests/test_help.cpp
@@ -184,7 +184,7 @@ TEST(HelpOption, StdinPipeStillWorks) {
         close(pipeIn[0]);
         close(pipeOut[1]);
         setenv("RY_ENV", "internal", 1);
-        execl(RY_BINARY_PATH, "ry", "-c", nullptr);
+        execl(RY_BINARY_PATH, RY_BINARY_PATH, "-c", nullptr);
         _exit(127);
     }
 

--- a/tests/test_input_builtin.cpp
+++ b/tests/test_input_builtin.cpp
@@ -60,7 +60,7 @@ static std::pair<std::string, int> runRyWithStdin(const std::string &ry_source,
         close(pipeIn[0]);
         close(pipeOut[1]);
         setenv("RY_ENV", "internal", 1);
-        execl(RY_BINARY_PATH, "ry", tmp.c_str(), nullptr);
+        execl(RY_BINARY_PATH, RY_BINARY_PATH, tmp.c_str(), nullptr);
         _exit(127);
     }
 

--- a/tests/test_read_line_builtin.cpp
+++ b/tests/test_read_line_builtin.cpp
@@ -57,7 +57,12 @@ static std::pair<std::string, int> runRyWithStdin(const std::string &ry_source,
         close(pipeIn[0]);
         close(pipeOut[1]);
         setenv("RY_ENV", "internal", 1);
-        execl(RY_BINARY_PATH, "ry", tmp.c_str(), nullptr);
+        // argv[0] must be the full path: find_share_dir uses
+        // fs::path(exe_path).parent_path(), and on Linux fs::canonical("") fails
+        // (unlike macOS), breaking stdlib resolution under RY_ENV=internal where
+        // the global ~/.ry/share fallback is skipped. See PR #1869 / issue
+        // discussion.
+        execl(RY_BINARY_PATH, RY_BINARY_PATH, tmp.c_str(), nullptr);
         _exit(127);
     }
 

--- a/tests/test_read_line_builtin.cpp
+++ b/tests/test_read_line_builtin.cpp
@@ -1,0 +1,174 @@
+#include <gtest/gtest.h>
+#include <array>
+#include <cerrno>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <utility>
+#include <unistd.h>
+#include <sys/wait.h>
+
+
+// Run ry binary with a source file argument, piping stdin_data to the child
+// process's stdin. Returns {stdout+stderr, exit_code}. Mirrors the helper in
+// tests/test_input_builtin.cpp; copied locally because helper extraction is
+// out of scope for #1850.
+static std::pair<std::string, int> runRyWithStdin(const std::string &ry_source,
+                                                  const std::string &stdin_data) {
+    namespace fs = std::filesystem;
+    auto tmp = fs::temp_directory_path() /
+               ("ry_readline_test_" + std::to_string(getpid()) + "_" +
+                std::to_string(reinterpret_cast<uintptr_t>(&ry_source)) + ".ry");
+    {
+        std::ofstream ofs(tmp);
+        ofs << ry_source;
+    }
+
+    int pipeIn[2];
+    int pipeOut[2];
+    if (pipe(pipeIn) != 0) {
+        fs::remove(tmp);
+        return {"", -1};
+    }
+    if (pipe(pipeOut) != 0) {
+        close(pipeIn[0]);
+        close(pipeIn[1]);
+        fs::remove(tmp);
+        return {"", -1};
+    }
+
+    pid_t pid = fork();
+    if (pid < 0) {
+        close(pipeIn[0]);
+        close(pipeIn[1]);
+        close(pipeOut[0]);
+        close(pipeOut[1]);
+        fs::remove(tmp);
+        return {"", -1};
+    }
+
+    if (pid == 0) {
+        close(pipeIn[1]);
+        close(pipeOut[0]);
+        dup2(pipeIn[0], STDIN_FILENO);
+        dup2(pipeOut[1], STDOUT_FILENO);
+        dup2(pipeOut[1], STDERR_FILENO);
+        close(pipeIn[0]);
+        close(pipeOut[1]);
+        setenv("RY_ENV", "internal", 1);
+        execl(RY_BINARY_PATH, "ry", tmp.c_str(), nullptr);
+        _exit(127);
+    }
+
+    close(pipeIn[0]);
+    close(pipeOut[1]);
+
+    if (!stdin_data.empty()) {
+        size_t off = 0;
+        while (off < stdin_data.size()) {
+            ssize_t w = write(pipeIn[1], stdin_data.data() + off,
+                              stdin_data.size() - off);
+            if (w < 0 && errno == EINTR)
+                continue;
+            if (w <= 0)
+                break;
+            off += static_cast<size_t>(w);
+        }
+    }
+    close(pipeIn[1]);
+
+    std::string output;
+    std::array<char, 4096> buf;
+    ssize_t n;
+    while ((n = read(pipeOut[0], buf.data(), buf.size())) > 0) {
+        output.append(buf.data(), static_cast<size_t>(n));
+    }
+    close(pipeOut[0]);
+
+    int status = 0;
+    int exit_code = -1;
+    for (;;) {
+        pid_t wp = waitpid(pid, &status, 0);
+        if (wp >= 0) {
+            exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+            break;
+        }
+        if (errno != EINTR)
+            break;
+    }
+
+    fs::remove(tmp);
+    return {output, exit_code};
+}
+
+// Common driver: prints "line:<s>" / "EOF" / "ERR:<msg>" for one readLine call.
+static const char *driver_print_line = R"(from io import readLine
+case readLine():
+    Ok(opt):
+        case opt:
+            Some(s): print("line:" + s)
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)";
+
+TEST(ReadLineBuiltin, EOFReturnsOkNone) {
+    auto [out, rc] = runRyWithStdin(driver_print_line, "");
+    EXPECT_EQ(out, "EOF\n");
+    EXPECT_EQ(rc, 0);
+}
+
+TEST(ReadLineBuiltin, EmptyLineReturnsOkSomeEmpty) {
+    auto [out, rc] = runRyWithStdin(R"(from io import readLine
+case readLine():
+    Ok(opt):
+        case opt:
+            Some(s): print(len(s))
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)",
+        "\n");
+    EXPECT_EQ(out, "0\n");
+    EXPECT_EQ(rc, 0);
+}
+
+TEST(ReadLineBuiltin, NormalLineReturnsOkSome) {
+    auto [out, rc] = runRyWithStdin(driver_print_line, "hello\n");
+    EXPECT_EQ(out, "line:hello\n");
+    EXPECT_EQ(rc, 0);
+}
+
+TEST(ReadLineBuiltin, MultiLineReturnsSomeSomeNone) {
+    auto [out, rc] = runRyWithStdin(R"(from io import readLine
+fn one():
+    case readLine():
+        Ok(opt):
+            case opt:
+                Some(s): print("line:" + s)
+                None: print("EOF")
+        Err(e): print("ERR:" + e.message)
+one()
+one()
+one()
+)",
+        "a\nb\n");
+    EXPECT_EQ(out, "line:a\nline:b\nEOF\n");
+    EXPECT_EQ(rc, 0);
+}
+
+TEST(ReadLineBuiltin, MissingTrailingNewlineReturnsSomeThenNone) {
+    auto [out, rc] = runRyWithStdin(R"(from io import readLine
+fn one():
+    case readLine():
+        Ok(opt):
+            case opt:
+                Some(s): print("line:" + s)
+                None: print("EOF")
+        Err(e): print("ERR:" + e.message)
+one()
+one()
+)",
+        "bar");
+    EXPECT_EQ(out, "line:bar\nEOF\n");
+    EXPECT_EQ(rc, 0);
+}

--- a/tests/test_stdin.cpp
+++ b/tests/test_stdin.cpp
@@ -29,7 +29,7 @@ static std::pair<std::string, int> runRyStdin(const std::string &code) {
         close(pipeIn[0]);
         close(pipeOut[1]);
         setenv("RY_ENV", "internal", 1);
-        execl(RY_BINARY_PATH, "ry", "-c", nullptr);
+        execl(RY_BINARY_PATH, RY_BINARY_PATH, "-c", nullptr);
         _exit(127);
     }
 
@@ -111,7 +111,7 @@ TEST(StdinExecution, FileExecutionStillWorks) {
         dup2(pipeOut[1], STDERR_FILENO);
         close(pipeOut[1]);
         setenv("RY_ENV", "internal", 1);
-        execl(RY_BINARY_PATH, "ry", tmp.c_str(), nullptr);
+        execl(RY_BINARY_PATH, RY_BINARY_PATH, tmp.c_str(), nullptr);
         _exit(127);
     }
 


### PR DESCRIPTION
Closes #1850

## Summary

- **Breaking:** changes the stdin `readLine()` builtin in `share/std/io/io.ry` from `() -> str` to `() -> Result<Option<str>, Error>`, restoring symmetry with the File-handle variant introduced in #1816.
- Adds a new runtime symbol `__ry_io_read_line` returning a tri-state status (0=success / 1=EOF / -1=I/O error). The legacy `__ry_read_line` is preserved because the `input()` builtin still uses it; follow-up issue #1868 tracks the same EOF distinction question for `input()`.
- `dispatchIO` gains a 0-arg `readLine()` intercept (`emitStdinReadLine`) that mirrors `emitFileReadLine` (alloca → call → `emitResultBranch` → `wrapPtrAsOption` / `buildOkValue` / `buildErrValue` / `buildErrorFromRuntime`), so runtime error messages from `setLastError` are preserved.

## Behavior change

```ry
# before
from io import readLine
name = readLine()
print(f"Hello, {name}!")

# after
from io import readLine
case readLine():
    Ok(opt):
        case opt:
            Some(name): print(f"Hello, {name}!")
            None: print("(EOF)")
    Err(e): print(e.message)
```

Pre-1.0 breaking change accepted because v0.0.25 is the first release to ship the new File-handle shape (#1816); aligning stdin and File before v0.1.0 avoids a permanent asymmetry.

## Test plan

- [x] New GoogleTests in `tests/test_read_line_builtin.cpp` (5 cases: EOF→Ok(None), empty line→Ok(Some("")), normal line→Ok(Some("hello")), multi-line + 3 reads, missing trailing newline + 2 reads)
- [x] `./build/ry_tests` — 2439 tests pass
- [x] `./build/ry test -p` — 200 spec files pass
- [x] `./docker/run.sh asan ry_tests` + `ry test -p` — exit 0
- [x] `./docker/run.sh tsan ry_tests` + `ry test -p` — exit 0
- [x] `./docker/run.sh static-analysis clang-tidy` — exit 0
- [x] `./docker/run.sh static-analysis cppcheck` — exit 0
- [x] `tests/test_input_builtin.cpp` (10 existing cases) — unchanged, all pass
- [x] Manual smoke: heredoc + `printf` for empty stdin / `'\n'` / `'hello\n'` via `/tmp/` script (per CLAUDE.md)

§3.6 (libFuzzer) and §3.6.5 (tree-sitter) skipped per `/pre-commit-checklist` matrix — no parser/lexer/json/utf8/string or grammar changes.

## Documentation

- `docs/reference/io.md`: Standard Input table row, "Reading from Standard Input" example rewritten with full Ok/Err/Some/None pattern, Error Handling table row generalized to "stdin / File".
- `docs/reference/builtins.md`: `input()` prose now explicitly contrasts with `io.readLine()` and notes the EOF/error distinction gap.
- `changelog.d/1850-stdin-readline-option.md`: Breaking change entry with before/after migration snippet.

## Follow-up

- #1868 (new) — same EOF distinction question for the `input()` builtin (`src/codegen_call.cpp:605-624`). Filed as `enhancement` in v0.0.25 with three design options (breaking / additive / status quo).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Stdin readLine() now returns Result<Option<str>, Error> (Ok(Some) = line, Ok(None) = EOF, Err = I/O). input() remains a convenience wrapper returning str.

* **Documentation**
  * Reference and examples updated to show new readLine() semantics and pattern-matching usage.

* **Tests**
  * Added coverage for readLine() success, EOF, no-trailing-newline, multi-read, and error cases; adjusted test execution setup.

* **Chores**
  * Test build configuration updated to include the new test.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1869?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->