### PR TITLE
feat(builtin)!: input() returns Result<Option<str>, Error> (#1868)

### DIFF
--- a/changelog.d/1868-input-result-option.md
+++ b/changelog.d/1868-input-result-option.md
@@ -1,0 +1,29 @@
+### Changed
+
+- **Breaking:** Changed the signature of the `input()` builtin from
+  `() -> str` / `(prompt: str) -> str` to
+  `() -> Result<Option<str>, Error>` /
+  `(prompt: str) -> Result<Option<str>, Error>`, mirroring the
+  stdin `readLine()` change in #1850. Previously `input()` returned
+  `""` for EOF, an empty input line, and I/O errors alike, so callers
+  could not tell them apart. The new shape returns `Ok(Some(line))`
+  on a successful read (trailing newline removed), `Ok(None)` at
+  EOF, and `Err(e)` on I/O failure. Migration:
+
+  ```ry
+  # before
+  name = input("Name? ")
+  print(f"Hello, {name}!")
+
+  # after
+  case input("Name? "):
+      Ok(opt):
+          case opt:
+              Some(name): print(f"Hello, {name}!")
+              None: print("(EOF)")
+      Err(e): print(e.message)
+  ```
+
+  The `input()` builtin and stdin `readLine()` now share the same
+  semantics; pick whichever fits the call site (no `import` for
+  `input()`, explicit `from io import readLine` for the other). (#1868)

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -7,7 +7,7 @@
 | Function | Description |
 |------|------|
 | `print()` / `print(expr1, expr2, ..., sep=" ", end="\n")` | Prints values to standard output. `sep` controls the separator (default: space), `end` controls the line ending (default: newline) |
-| `input()` / `input(prompt)` | Reads one line from standard input and returns it as `str` with the trailing newline removed. With `prompt`, writes it to standard output first (no trailing newline) and flushes. Returns `""` on EOF |
+| `input()` / `input(prompt)` | Reads one line from standard input as `Result<Option<str>, Error>` (trailing newline stripped). `Ok(Some(line))` on a successful read, `Ok(None)` at EOF, `Err(e)` on I/O failure. With `prompt`, writes it to standard output first (no trailing newline) and flushes before reading |
 | `len(value)` | Returns the number of elements in a list, map, or set, or the number of UTF-8 characters in a string |
 | `range(n)` / `range(start, end)` / `range(start, end, step)` | Generates a list of integers |
 | `exit(code)` | Terminates the process with the given exit code |
@@ -224,18 +224,25 @@ print("a", "b", sep="-", end="!\n")  # a-b!
 
 ## input
 
-**Signature:** `input() -> str` / `input(prompt: str) -> str`
+**Signature:** `input() -> Result<Option<str>, Error>` / `input(prompt: str) -> Result<Option<str>, Error>`
 
-Reads one line from standard input and returns it as a string with the trailing newline (`\n`) removed. Returns an empty string when EOF is reached. When `prompt` is provided, it is written to standard output (with no appended newline) and stdout is flushed before blocking on stdin — mirroring Python's `input(prompt)`.
-
-Similar to `io.readLine()`, but returns a bare `str` instead of `Result<Option<str>, Error>` — convenient for short scripts and competitive-programming snippets where EOF / I/O error handling is unnecessary. EOF and read errors both yield `""`, so `input` cannot distinguish them; use `io.readLine` when that distinction matters.
+Reads one line from standard input. Returns `Ok(Some(line))` on a successful read (trailing `\n` stripped), `Ok(None)` at EOF (e.g. when stdin is closed), and `Err(e)` on I/O failure. An empty input line (the user pressed Enter without typing anything) is `Ok(Some(""))` — distinct from EOF. When `prompt` is provided, it is written to standard output (with no appended newline) and stdout is flushed before blocking on stdin — mirroring Python's `input(prompt)`. Equivalent to `io.readLine()`, but available without an `import`.
 
 ```ry
-name = input("Enter your name: ")
-print(f"Hello, {name}!")
+case input("Enter your name: "):
+    Ok(opt):
+        case opt:
+            Some(name): print(f"Hello, {name}!")
+            None: print("(EOF)")
+    Err(e): print(e.message)
 
 # No prompt — reads one line from stdin as-is
-line = input()
+case input():
+    Ok(opt):
+        case opt:
+            Some(line): print(line)
+            None: print("(EOF)")
+    Err(e): print(e.message)
 ```
 
 ---

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -170,7 +170,7 @@ case readLine():
         print(e.message)
 ```
 
-`readLine()` returns `Ok(Some(line))` for a successful read (trailing newline removed), `Ok(None)` at EOF (e.g. when stdin is closed), and `Err(e)` on I/O failure. For convenience scripts where EOF / error handling is unnecessary, the `input()` builtin returns a bare `str` (empty string on EOF / error).
+`readLine()` returns `Ok(Some(line))` for a successful read (trailing newline removed), `Ok(None)` at EOF (e.g. when stdin is closed), and `Err(e)` on I/O failure. The `input()` builtin returns the same `Result<Option<str>, Error>` shape with the same semantics and is available without an `import`.
 
 ## Error Handling
 

--- a/include/ry/runtime_io.hpp
+++ b/include/ry/runtime_io.hpp
@@ -46,9 +46,11 @@ inline IOListHeader *makeByteList(const uint8_t *bytes, int64_t len) {
 extern "C" {
 
 // Standard input
-const char *__ry_read_line();
+// Tri-state result: 0 = line read into *out_line, 1 = EOF (no data),
+// -1 = I/O error (call __ry_get_last_error() for message).
+// On a 0-return *out_line is set to a Ry string handle (trailing '\n' stripped).
+int64_t __ry_io_input_prompt(const char *prompt, const char **out_line);
 const char *__ry_read_all();
-const char *__ry_input_prompt(const char *prompt);
 
 // File I/O (return NULL / non-zero on error; use __ry_get_last_error() for message)
 const char *__ry_read_text(const char *path);

--- a/share/std/builtins.ry
+++ b/share/std/builtins.ry
@@ -7,11 +7,11 @@ fn print(value: str) -> Unit
 
 @public
 @native
-fn input() -> str
+fn input() -> Result<Option<str>, Error>
 
 @public
 @native
-fn input(prompt: str) -> str
+fn input(prompt: str) -> Result<Option<str>, Error>
 
 @public
 @native

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -606,21 +606,42 @@ llvm::Value *CodeGen::emitBuiltinCore(const CallExpr &e) {
         if (e.args.size() > 1)
             codegenError("input() takes 0 or 1 arguments");
         // Runtime lives in libry_io — without this insert the JIT fails to
-        // resolve __ry_read_line / __ry_input_prompt for programs that
+        // resolve __ry_io_read_line / __ry_io_input_prompt for programs that
         // never `import` from io. Bare builtins are not declared as
         // @native("io"), so library registration must happen here.
         used_native_libraries_.insert("io");
+
+        llvm::Value *outAlloca = builder_.CreateAlloca(ptrTy_, nullptr, "inp_out");
+        builder_.CreateStore(
+            llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
+            outAlloca);
+
+        llvm::Value *status;
         if (e.args.size() == 1) {
             llvm::Value *prompt = emitExpr(*e.args[0]);
             if (prompt->getType() != ptrTy_)
                 codegenError("input() prompt must be str");
-            auto fnTy = llvm::FunctionType::get(ptrTy_, {ptrTy_}, false);
-            auto fn = mod_->getOrInsertFunction("__ry_input_prompt", fnTy);
-            return builder_.CreateCall(fn, {prompt}, "input_result");
+            auto fnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_, ptrTy_}, false);
+            auto fn = mod_->getOrInsertFunction("__ry_io_input_prompt", fnTy);
+            status = builder_.CreateCall(fn, {prompt, outAlloca}, "inp_status");
+        } else {
+            auto fnTy = llvm::FunctionType::get(i64Ty_, {ptrTy_}, false);
+            auto fn = mod_->getOrInsertFunction("__ry_io_read_line", fnTy);
+            status = builder_.CreateCall(fn, {outAlloca}, "inp_status");
         }
-        auto fnTy = llvm::FunctionType::get(ptrTy_, false);
-        auto fn = mod_->getOrInsertFunction("__ry_read_line", fnTy);
-        return builder_.CreateCall(fn, {}, "input_result");
+
+        llvm::Value *isErr = builder_.CreateICmpSLT(
+            status, llvm::ConstantInt::get(i64Ty_, 0), "inp_iserr");
+        llvm::StructType *optTy = getOptionType(ptrTy_);
+        llvm::StructType *resTy = getResultType(optTy, errorTy_);
+        return emitResultBranch(isErr, resTy,
+            [&]() -> llvm::Value * {
+                llvm::Value *linePtr = builder_.CreateLoad(ptrTy_, outAlloca, "inp_line");
+                return buildOkValue(wrapPtrAsOption(linePtr, "input"), resTy);
+            },
+            [&]() -> llvm::Value * {
+                return buildErrValue(buildErrorFromRuntime(), resTy);
+            });
     }
 
     if (e.callee == "env") {

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -46,21 +46,6 @@ static void setLastError(const char *fmt, ...) {
 
 // ===== Standard input =====
 
-extern "C" const char *__ry_read_line() {
-    char *line = nullptr;
-    size_t len = 0;
-    ssize_t nread = getline(&line, &len, stdin);
-    if (nread == -1) {
-        free(line);
-        return makeString("", 0);
-    }
-    if (nread > 0 && line[nread - 1] == '\n')
-        --nread;
-    const char *result = makeString(line, static_cast<size_t>(nread));
-    free(line);
-    return result;
-}
-
 // Returns: 0 = line read, 1 = EOF (no data), -1 = error
 // *out_line is set to a Ry string handle on success (0-return only).
 // stdin counterpart of __ry_io_file_read_line.
@@ -85,12 +70,16 @@ extern "C" int64_t __ry_io_read_line(const char **out_line) {
     return 0;
 }
 
-extern "C" const char *__ry_input_prompt(const char *prompt) {
+// Tri-state stdin reader with an optional prompt written to stdout first.
+// Same return contract as __ry_io_read_line. Failures writing the prompt to
+// stdout are intentionally swallowed (a broken stdout should not kill an
+// interactive read) — only the getline outcome drives the return code.
+extern "C" int64_t __ry_io_input_prompt(const char *prompt, const char **out_line) {
     size_t promptLen = static_cast<size_t>(stringByteLen(prompt));
     if (promptLen > 0)
         fwrite(prompt, 1, promptLen, stdout);
     fflush(stdout);
-    return __ry_read_line();
+    return __ry_io_read_line(out_line);
 }
 
 extern "C" const char *__ry_read_all() {

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -75,10 +75,12 @@ extern "C" int64_t __ry_io_read_line(const char **out_line) {
 // stdout are intentionally swallowed (a broken stdout should not kill an
 // interactive read) — only the getline outcome drives the return code.
 extern "C" int64_t __ry_io_input_prompt(const char *prompt, const char **out_line) {
-    size_t promptLen = static_cast<size_t>(stringByteLen(prompt));
-    if (promptLen > 0)
-        fwrite(prompt, 1, promptLen, stdout);
-    fflush(stdout);
+    if (prompt) {
+        size_t promptLen = static_cast<size_t>(stringByteLen(prompt));
+        if (promptLen > 0)
+            fwrite(prompt, 1, promptLen, stdout);
+        fflush(stdout);
+    }
     return __ry_io_read_line(out_line);
 }
 

--- a/tests/test_input_builtin.cpp
+++ b/tests/test_input_builtin.cpp
@@ -105,45 +105,91 @@ static std::pair<std::string, int> runRyWithStdin(const std::string &ry_source,
     return {output, exit_code};
 }
 
+// Common driver: prints "line:<s>" / "EOF" / "ERR:<msg>" for one input() call.
+static const char *kInputDriver_PrintLine = R"(case input():
+    Ok(opt):
+        case opt:
+            Some(s): print("line:" + s)
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)";
+
 TEST(InputBuiltin, NoArg_BasicLine) {
-    auto [out, rc] = runRyWithStdin("print(input())\n", "hello\n");
-    EXPECT_EQ(out, "hello\n");
+    auto [out, rc] = runRyWithStdin(kInputDriver_PrintLine, "hello\n");
+    EXPECT_EQ(out, "line:hello\n");
     EXPECT_EQ(rc, 0);
 }
 
-TEST(InputBuiltin, NoArg_EOFReturnsEmpty) {
-    auto [out, rc] = runRyWithStdin("print(input())\n", "");
-    EXPECT_EQ(out, "\n");
+TEST(InputBuiltin, NoArg_EOFReturnsOkNone) {
+    auto [out, rc] = runRyWithStdin(kInputDriver_PrintLine, "");
+    EXPECT_EQ(out, "EOF\n");
+    EXPECT_EQ(rc, 0);
+}
+
+TEST(InputBuiltin, NoArg_EmptyLineReturnsOkSomeEmpty) {
+    // Core breaking-change guarantee: an empty input line is Ok(Some("")),
+    // distinct from EOF which is Ok(None).
+    auto [out, rc] = runRyWithStdin(R"(case input():
+    Ok(opt):
+        case opt:
+            Some(s): print(len(s))
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)",
+        "\n");
+    EXPECT_EQ(out, "0\n");
     EXPECT_EQ(rc, 0);
 }
 
 TEST(InputBuiltin, NoArg_TrailingNewlineStripped) {
-    auto [out, rc] = runRyWithStdin(
-        "line = input()\nprint(len(line))\n",
+    auto [out, rc] = runRyWithStdin(R"(case input():
+    Ok(opt):
+        case opt:
+            Some(s): print(len(s))
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)",
         "foo\n");
     EXPECT_EQ(out, "3\n");
     EXPECT_EQ(rc, 0);
 }
 
 TEST(InputBuiltin, NoArg_NoTrailingNewline) {
-    auto [out, rc] = runRyWithStdin(
-        "line = input()\nprint(line)\nprint(len(line))\n",
+    auto [out, rc] = runRyWithStdin(R"(case input():
+    Ok(opt):
+        case opt:
+            Some(s):
+                print(s)
+                print(len(s))
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)",
         "bar");
     EXPECT_EQ(out, "bar\n3\n");
     EXPECT_EQ(rc, 0);
 }
 
 TEST(InputBuiltin, Prompt_WritesToStdoutBeforeRead) {
-    auto [out, rc] = runRyWithStdin(
-        "name = input(\"Q: \")\nprint(name)\n",
+    auto [out, rc] = runRyWithStdin(R"(case input("Q: "):
+    Ok(opt):
+        case opt:
+            Some(s): print(s)
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)",
         "answer\n");
     EXPECT_EQ(out, "Q: answer\n");
     EXPECT_EQ(rc, 0);
 }
 
 TEST(InputBuiltin, Prompt_NoTrailingNewlineOnPrompt) {
-    auto [out, rc] = runRyWithStdin(
-        "_ignored = input(\"prefix\")\nprint(\"done\")\n",
+    auto [out, rc] = runRyWithStdin(R"(case input("prefix"):
+    Ok(opt):
+        case opt:
+            Some(_s): print("done")
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)",
         "x\n");
     // The prompt "prefix" must not be followed by a newline before "done".
     EXPECT_EQ(out, "prefixdone\n");
@@ -151,17 +197,29 @@ TEST(InputBuiltin, Prompt_NoTrailingNewlineOnPrompt) {
 }
 
 TEST(InputBuiltin, Prompt_EmptyPromptBehavesLikeNoArg) {
-    auto [out, rc] = runRyWithStdin("print(input(\"\"))\n", "zzz\n");
+    auto [out, rc] = runRyWithStdin(R"(case input(""):
+    Ok(opt):
+        case opt:
+            Some(s): print(s)
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)",
+        "zzz\n");
     EXPECT_EQ(out, "zzz\n");
     EXPECT_EQ(rc, 0);
 }
 
-TEST(InputBuiltin, StatementForm_NoReturnValueUsed) {
-    // input() called as a statement (discarding return value) should not crash.
-    auto [out, rc] = runRyWithStdin(
-        "input()\nprint(\"after\")\n",
-        "discarded\n");
-    EXPECT_EQ(out, "after\n");
+TEST(InputBuiltin, Prompt_EOFReturnsOkNone) {
+    // EOF distinction works for the prompt variant too.
+    auto [out, rc] = runRyWithStdin(R"(case input("> "):
+    Ok(opt):
+        case opt:
+            Some(s): print("line:" + s)
+            None: print("EOF")
+    Err(e): print("ERR:" + e.message)
+)",
+        "");
+    EXPECT_EQ(out, "> EOF\n");
     EXPECT_EQ(rc, 0);
 }
 


### PR DESCRIPTION
## Summary

- **Breaking:** `input()` / `input(prompt)` signature changes from `() -> str` / `(str) -> str` to `() -> Result<Option<str>, Error>` / `(str) -> Result<Option<str>, Error>`, mirroring the stdin `readLine()` change in #1850. EOF, an empty input line, and I/O errors are now distinguishable: `Ok(Some(line))` on a successful read (trailing newline stripped), `Ok(None)` at EOF, `Ok(Some(""))` on an empty line, `Err(e)` on I/O failure.
- Runtime: new `__ry_io_input_prompt(prompt, out_line)` tri-state ABI delegating to existing `__ry_io_read_line`; legacy `__ry_read_line` / `__ry_input_prompt` removed.
- Codegen: `input()` branch in `src/codegen_call.cpp` now emits the same `alloca → CreateCall → ICmpSLT → emitResultBranch / wrapPtrAsOption / buildErrorFromRuntime` shape as `emitStdinReadLine` (#1850).
- Tests, docs, and changelog updated.

## Migration

```ry
# before
name = input("Name? ")
print(f"Hello, {name}!")

# after
case input("Name? "):
    Ok(opt):
        case opt:
            Some(name): print(f"Hello, {name}!")
            None: print("(EOF)")
    Err(e): print(e.message)
```

## Test plan

- [x] `./build/ry_tests --gtest_filter="*Input*"` — 11/11 pass (includes 2 new cases: `NoArg_EmptyLineReturnsOkSomeEmpty`, `Prompt_EOFReturnsOkNone`)
- [x] `./build/ry_tests` — 2440/2440 pass
- [x] `./build/ry test -p` — 200 spec files, 0 failures
- [x] ASan + UBSan (Docker): `./docker/run.sh asan ry_tests` and `ry test -p` — clean
- [x] TSan (Docker): `./docker/run.sh tsan ry_tests` and `ry test -p` — clean
- [x] Static analysis (Docker): `clang-tidy` + `cppcheck` — clean
- [x] libFuzzer skipped — no parser/lexer/json/utf8/string change
- [x] tree-sitter skipped — no grammar change

Closes #1868

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * The input() builtin now returns Result<Option<str>, Error> instead of str. Callers must pattern-match to handle Ok(Some(line)), Ok(None) for EOF, and Err(e) for I/O failures. Trailing newlines are stripped; empty input is Ok(Some("")).

* **Documentation**
  * Reference docs updated with migration examples and clarified semantics matching the line-reading API.

* **Tests**
  * Input tests revised to assert distinct outputs for Some, None (EOF), and Err cases and to verify prompt timing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1871?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->