### PR TITLE
feat(io): accept "ab" append binary mode for open() (#1862)

### DIFF
--- a/changelog.d/1862-io-open-ab.md
+++ b/changelog.d/1862-io-open-ab.md
@@ -1,0 +1,9 @@
+### Added
+
+- `io.open(path, mode)` now accepts `"ab"` (append binary), completing
+  the binary-mode trio alongside `"rb"` / `"wb"` (added in #1848) and
+  restoring parity with the text-mode triple `"r"` / `"w"` / `"a"`.
+  `"ab"` maps to `O_WRONLY | O_CREAT | O_APPEND` (same POSIX flags as
+  `"a"`); writes always go to end-of-file, the file is created if
+  missing. The invalid-mode error message now reads `(must be "r",
+  "w", "a", "rb", "wb", or "ab")`. (#1862)

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -31,7 +31,7 @@ from io import readText, writeText, exists
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `open` | `(str, str) -> Result<File, Error>` | Opens a file; mode must be `"r"`, `"w"`, `"a"`, `"rb"`, or `"wb"` |
+| `open` | `(str, str) -> Result<File, Error>` | Opens a file; mode must be `"r"`, `"w"`, `"a"`, `"rb"`, `"wb"`, or `"ab"` |
 | `readAll` | `(File) -> Result<str, Error>` | Reads the entire file content into a string |
 | `readLine` | `(File) -> Result<Option<str>, Error>` | Reads one line; returns `Ok(None)` at EOF |
 | `writeText` | `(File, str) -> Result<Unit, Error>` | Writes a string to the file |
@@ -196,7 +196,7 @@ case open("missing.txt", "r"):
 | `writeText` / `writeBytes` / `appendText` | File cannot be opened for writing |
 | `deleteFile` | File cannot be deleted |
 | `readText` / `writeText` / `appendText` / `deleteFile` / `readBytes` / `writeBytes` | Path contains an embedded NUL byte |
-| `open` | File does not exist (mode `"r"` / `"rb"`), cannot be created/opened (mode `"w"` / `"a"` / `"wb"`), or mode is not `"r"` / `"w"` / `"a"` / `"rb"` / `"wb"` |
+| `open` | File does not exist (mode `"r"` / `"rb"`), cannot be created/opened (mode `"w"` / `"a"` / `"wb"` / `"ab"`), or mode is not `"r"` / `"w"` / `"a"` / `"rb"` / `"wb"` / `"ab"` |
 | `readAll` (File) | Read error after opening |
 | `readLine` (stdin) / `readLine` (File) | Read error (I/O failure, not EOF — EOF is `Ok(None)`) |
 | `writeText` (File, str) | Write error |

--- a/src/runtime_io.cpp
+++ b/src/runtime_io.cpp
@@ -21,7 +21,7 @@ static FILE *fopen_nofollow(const char *path, const char *mode) {
         flags |= O_RDONLY;
     else if (strcmp(mode, "w") == 0 || strcmp(mode, "wb") == 0)
         flags |= O_WRONLY | O_CREAT | O_TRUNC;
-    else if (strcmp(mode, "a") == 0)
+    else if (strcmp(mode, "a") == 0 || strcmp(mode, "ab") == 0)
         flags |= O_WRONLY | O_CREAT | O_APPEND;
     int fd = open(path, flags, 0644);
     if (fd < 0) return nullptr;
@@ -295,8 +295,8 @@ extern "C" void *__ry_io_file_open(const char *path, const char *mode) {
         return nullptr;
     }
     if (strcmp(mode, "r") != 0 && strcmp(mode, "w") != 0 && strcmp(mode, "a") != 0 &&
-        strcmp(mode, "rb") != 0 && strcmp(mode, "wb") != 0) {
-        setLastError("open: invalid mode '%s' (must be \"r\", \"w\", \"a\", \"rb\", or \"wb\")", mode);
+        strcmp(mode, "rb") != 0 && strcmp(mode, "wb") != 0 && strcmp(mode, "ab") != 0) {
+        setLastError("open: invalid mode '%s' (must be \"r\", \"w\", \"a\", \"rb\", \"wb\", or \"ab\")", mode);
         return nullptr;
     }
     FILE *fp = fopen_nofollow(path, mode);

--- a/tests/spec/io_file_handle.test.ry
+++ b/tests/spec/io_file_handle.test.ry
@@ -39,6 +39,7 @@ fn fileHandleTests():
         expect(e.message).toContain("invalid mode")
         expect(e.message).toContain("rb")
         expect(e.message).toContain("wb")
+        expect(e.message).toContain("ab")
     deleteFile("/tmp/ry_fh_badmode.txt")
 
   @it("should return Err with detailed message when path contains an embedded NUL byte")
@@ -119,6 +120,37 @@ fn fileHandleTests():
       Err(e):
         fail("open rb failed: " + e.message)
     deleteFile("/tmp/ry_fh_wb.txt")
+
+  @it("should append via 'ab' binary append mode")
+  fn shouldAppendViaAbBinaryAppendMode():
+    deleteFile("/tmp/ry_fh_ab.bin")
+    case open("/tmp/ry_fh_ab.bin", "ab"):
+      Ok(fw):
+        case writeText(fw, "first"):
+          Ok(_): 0
+          Err(e): fail("writeText first failed: " + e.message)
+        close(fw)
+      Err(e):
+        fail("open ab (1) failed: " + e.message)
+    case open("/tmp/ry_fh_ab.bin", "ab"):
+      Ok(fw):
+        case writeText(fw, "second"):
+          Ok(_): 0
+          Err(e): fail("writeText second failed: " + e.message)
+        close(fw)
+      Err(e):
+        fail("open ab (2) failed: " + e.message)
+    case open("/tmp/ry_fh_ab.bin", "r"):
+      Ok(fr):
+        case readAll(fr):
+          Ok(s):
+            expect(s).toEq("firstsecond")
+          Err(e):
+            fail("readAll failed: " + e.message)
+        close(fr)
+      Err(e):
+        fail("open r failed: " + e.message)
+    deleteFile("/tmp/ry_fh_ab.bin")
 
   @it("should detect EOF with readLine returning Ok(None)")
   fn shouldDetectEofWithReadLineReturningOkNone():


### PR DESCRIPTION
## Summary

Closes #1862.

`io.open(path, mode)` now accepts `"ab"` (append binary), completing the binary-mode trio alongside `"rb"` / `"wb"` (added in #1848) and restoring parity with the text-mode triple `"r"` / `"w"` / `"a"`.

- `fopen_nofollow` maps `"ab"` to `O_WRONLY | O_CREAT | O_APPEND` — same POSIX flags as `"a"`.
- `__ry_io_file_open` whitelist accepts `"ab"`; rejection message now reads `(must be "r", "w", "a", "rb", "wb", or "ab")`.
- New spec test `should append via 'ab' binary append mode` verifies the append semantic (open `"ab"` × 2 → readAll → `"firstsecond"`).
- Invalid-mode test extended to assert `"ab"` is mentioned in the error message.
- `docs/reference/io.md` mode lists at L34 and L199 updated (L199 has 3 sub-lists — `"ab"` correctly added to the creates-list and the whitelist, intentionally omitted from the does-not-exist list since `O_CREAT` makes that inapplicable).
- `changelog.d/1862-io-open-ab.md` fragment added under `### Added`.

## Test plan

- [x] `cmake --build build` (default preset, host) — clean
- [x] `./build/ry_tests --gtest_filter='RuntimeIoFile*'` — 7/7 pass
- [x] `./build/ry test tests/spec/io_file_handle.test.ry` — 18/18 pass (incl. new `"ab"` test)
- [x] `./docker/run.sh asan ry_tests --gtest_filter='RuntimeIoFile*'` — 7/7 pass under ASan + UBSan
- [x] `./docker/run.sh asan ry test tests/spec/io_file_handle.test.ry` — 18/18 pass under ASan + UBSan
- [x] `./docker/run.sh tsan ry_tests --gtest_filter='RuntimeIoFile*'` + `CodeGenTest.ConcurrencySpecSuite` — clean
- [x] clang-tidy on `src/runtime_io.cpp` — clean
- [x] cppcheck — clean

## Skipped checklist items

- `Skipped §3.5 host-batch — pre-existing macOS-host Docker env failures (141 subprocess-spawn tests, issue #1865 territory); RuntimeIoFile* + ConcurrencySpecSuite clean under both sanitizers.`
- `Skipped §3.6 — no parser/lexer/json/utf8/string change.`
- `Skipped §3.6.5 — no tree-sitter grammar change.`

## Manual sanity check (heredoc, no scratch file)

```bash
./build/ry -c <<'RY'
from io import open, writeText, close, readAll, deleteFile

deleteFile("/tmp/ab_smoke.bin")
case open("/tmp/ab_smoke.bin", "ab"):
  Ok(f):
    writeText(f, "first")
    close(f)
  Err(e): print("open1 err: " + e.message)
case open("/tmp/ab_smoke.bin", "ab"):
  Ok(f):
    writeText(f, "second")
    close(f)
  Err(e): print("open2 err: " + e.message)
case open("/tmp/ab_smoke.bin", "r"):
  Ok(f):
    case readAll(f):
      Ok(s): print("got: " + s)
      Err(e): print("readAll err: " + e.message)
    close(f)
  Err(e): print("open r err: " + e.message)
deleteFile("/tmp/ab_smoke.bin")
RY
```

Expected output: `got: firstsecond` — append semantics confirmed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for opening files in append-binary mode ("ab"), completing binary-mode file access options and enabling appending to binary files.

* **Documentation**
  * Updated file operation reference documentation to include "ab" mode in supported file opening modes and error conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1872?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->