### PR TITLE
chore(workflow): switch feature-branch main sync from merge to rebase

### DIFF
--- a/.claude/skills/git-commit-push-pr/SKILL.md
+++ b/.claude/skills/git-commit-push-pr/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: git-commit-push-pr
-description: Commit, push, and open a PR to main. Creates feature branch if on main. PRs are opened (not draft).
-allowed-tools: Bash(git checkout -b:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*), Bash(git fetch:*), Bash(git merge:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Read, Edit
+description: Commit, rebase onto main, push, and open a PR to main. Creates feature branch if on main. PRs are opened (not draft).
+allowed-tools: Bash(git checkout -b:*), Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(gh pr create:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Read, Edit
 metadata:
   short-description: Commit, push, and open a PR
 ---
 
 # Git Commit Push PR
 
-Create a branch (if needed), commit, merge `main`, push, and open a PR to `main`.
+Create a branch (if needed), commit, rebase onto `main`, push, and open a PR to `main`.
 
 ## Context
 
@@ -28,21 +28,25 @@ If the current branch is `main`, you **MUST** create a new feature branch before
 
 Create a single commit with an appropriate message. Use conventional commit format.
 
-### 3. Merge main
+### 3. Rebase onto main
 
-1. Run `git fetch origin` to get the latest remote state
-2. Run `git merge origin/main` to merge upstream changes
+1. Run `git fetch origin` to get the latest remote state. **Do not re-run `git fetch` after this point until the push completes** — refreshing the remote-tracking ref between rebase and push weakens the `--force-with-lease` guarantee in Step 4.
+2. Run `git rebase origin/main` to replay the current branch onto upstream `main`.
 3. **On conflict**:
    - Run `git diff --name-only --diff-filter=U` to list conflicting files
    - `Read` each conflicting file and examine the conflict markers
    - Use `Edit` to resolve the conflicts
    - Stage each resolved file with `git add`
-   - Once all conflicts are resolved, run `git merge --continue`
-   - If any conflict cannot be resolved, report to the user and stop (do NOT auto-abort the merge)
+   - Once all conflicts are resolved, run `git rebase --continue`
+   - If any conflict cannot be resolved, report to the user and stop (do NOT auto-`git rebase --abort`). The user decides whether to abort with `git rebase --abort`.
 
 ### 4. Push
 
-Push the branch to origin with `-u` flag to set upstream tracking.
+Run `git push -u --force-with-lease origin <branch>` to push the rebased branch and set upstream tracking in one step.
+
+- The rebase rewrites commit SHAs, so a force push is required on the second and later invocations.
+- `--force-with-lease` (no argument) blocks the push if `origin/<branch>` has advanced since the most recent `git fetch`, preventing accidental overwrite of someone else's push.
+- On the **first** push (when no remote ref exists yet), `--force-with-lease` is a safe no-op and `-u` records the upstream.
 
 ### 5. Create PR
 

--- a/.claude/skills/git-commit-push/SKILL.md
+++ b/.claude/skills/git-commit-push/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: git-commit-push
-description: Commit, merge main, and push with branch safety check.
-allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(git fetch:*), Bash(git merge:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Read, Edit
+description: Commit, rebase onto main, and push with branch safety check.
+allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Read, Edit
 metadata:
   short-description: Commit and push
 ---
 
 # Git Commit Push
 
-Commit, merge `main`, and push.
+Commit, rebase onto `main`, and push.
 
 ## Context
 
@@ -28,18 +28,21 @@ Before committing, check the current branch name. If the current branch is `main
 
 Create a single commit with an appropriate message based on the changes. Use conventional commit format.
 
-### 2. Merge main
+### 2. Rebase onto main
 
-1. Run `git fetch origin` to get the latest remote state
-2. Run `git merge origin/main` to merge upstream changes
+1. Run `git fetch origin` to get the latest remote state. **Do not re-run `git fetch` after this point until the push completes** — refreshing the remote-tracking ref between rebase and push weakens the `--force-with-lease` guarantee in Step 3.
+2. Run `git rebase origin/main` to replay the current branch onto upstream `main`.
 3. **On conflict**:
    - Run `git diff --name-only --diff-filter=U` to list conflicting files
    - `Read` each conflicting file and examine the conflict markers
    - Use `Edit` to resolve the conflicts
    - Stage each resolved file with `git add`
-   - Once all conflicts are resolved, run `git merge --continue`
-   - If any conflict cannot be resolved, report to the user and stop (do NOT auto-abort the merge)
+   - Once all conflicts are resolved, run `git rebase --continue`
+   - If any conflict cannot be resolved, report to the user and stop (do NOT auto-`git rebase --abort`). The user decides whether to abort with `git rebase --abort`.
 
 ### 3. Push
 
-Push the branch to origin.
+Run `git push --force-with-lease` to push the rebased branch. The rebase rewrites commit SHAs, so a force push is required on the second and later invocations.
+
+- `--force-with-lease` (no argument) blocks the push if `origin/<branch>` has advanced since the most recent `git fetch`, preventing accidental overwrite of someone else's push.
+- On the **first** push (when no remote ref exists yet), `--force-with-lease` is a safe no-op.

--- a/.claude/skills/git-resolve-conflicts/SKILL.md
+++ b/.claude/skills/git-resolve-conflicts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-resolve-conflicts
-description: Resolve PR merge conflicts locally by merging main, fixing conflicts, and pushing.
+description: Resolve PR merge conflicts locally by rebasing onto main, fixing conflicts, and pushing.
 allowed-tools: Bash(git:*), Bash(gh pr view:*), Read, Edit
 metadata:
   short-description: Resolve PR conflicts locally and push
@@ -8,7 +8,7 @@ metadata:
 
 # Git Resolve Conflicts
 
-Resolve merge conflicts for a PR by merging `main` locally, fixing conflicts, and pushing.
+Resolve merge conflicts for a PR by rebasing onto `main` locally, fixing conflicts, and pushing with `--force-with-lease`.
 
 ## Context
 
@@ -31,20 +31,27 @@ User input: $ARGUMENTS
 
 ### Step 2: Verify current branch matches the PR head
 
-Before touching the working tree, confirm that the currently checked-out branch is the PR's head branch. Otherwise merging `main` here would pollute an unrelated local branch.
+Before touching the working tree, confirm that the currently checked-out branch is the PR's head branch. Otherwise rebasing onto `main` here would pollute an unrelated local branch.
 
 1. Get `headRefName` from the PR (fetch it via `gh pr view` if not already available).
 2. Compare `headRefName` with the current branch (`git branch --show-current`).
 3. If they differ:
-   - If no explicit PR number was provided (i.e. the PR was auto-detected from the current branch), report the mismatch and stop — do NOT merge `main` into the wrong branch.
+   - If no explicit PR number was provided (i.e. the PR was auto-detected from the current branch), report the mismatch and stop — do NOT rebase the wrong branch onto `main`.
    - If the user invoked the skill with an explicit PR number and the current branch is unrelated, run `git switch <headRefName>` (pull from remote with `git switch --track origin/<headRefName>` if it does not exist locally yet). Only proceed after the switch succeeds.
-   - If the switch is not possible (dirty worktree, local branch divergence, etc.), report the mismatch and stop — do NOT merge `main` into the wrong branch.
+   - If the switch is not possible (dirty worktree, local branch divergence, etc.), report the mismatch and stop — do NOT rebase the wrong branch onto `main`.
 
-### Step 3: Fetch and merge main
+### Step 3: Fetch and rebase onto main
 
-1. Run `git fetch origin` to get the latest remote state
-2. Run `git merge origin/main` to merge upstream changes into the current branch
-3. If the merge completes without conflicts, skip to Step 5
+**Mid-rebase guard**: Before starting a new rebase, check whether a rebase is already in progress (e.g. from a previous skill invocation that did not finish):
+
+- Inspect `git status` for the phrase `rebase in progress`, or check for the directory `.git/rebase-merge` or `.git/rebase-apply`.
+- If a rebase is already in progress, **skip the new `git rebase` invocation** and proceed directly to Step 4 to resume conflict resolution. Running `git rebase origin/main` again here would corrupt the in-progress state.
+
+Otherwise, start a fresh rebase:
+
+1. Run `git fetch origin` to get the latest remote state. **Do not re-run `git fetch` after this point until the push completes** — refreshing the remote-tracking ref between rebase and push weakens the `--force-with-lease` guarantee in Step 5.
+2. Run `git rebase origin/main` to replay the current branch onto upstream `main`.
+3. If the rebase completes without conflicts, skip to Step 5.
 
 ### Step 4: Resolve conflicts
 
@@ -52,12 +59,15 @@ Before touching the working tree, confirm that the currently checked-out branch 
 2. `Read` each conflicting file and examine the conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`)
 3. Understand the intent of both the current branch and the base branch changes, then use `Edit` to resolve the conflicts
 4. Stage each resolved file with `git add`
-5. Once all conflicts are resolved, run `git merge --continue` to complete the merge
-6. If any conflict cannot be resolved, report the details to the user and stop (do NOT auto-abort the merge)
+5. Once all conflicts are resolved, run `git rebase --continue` to complete the rebase
+6. If any conflict cannot be resolved, report the details to the user and stop (do NOT auto-`git rebase --abort`). The user decides whether to abort with `git rebase --abort`.
 
 ### Step 5: Push
 
-Push the branch to origin.
+Run `git push --force-with-lease` to push the rebased branch.
+
+- The rebase rewrites commit SHAs, so a force push is required.
+- `--force-with-lease` (no argument) blocks the push if `origin/<branch>` has advanced since the most recent `git fetch`, preventing accidental overwrite of someone else's push.
 
 ### Step 6: Report
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,9 @@ trace の使い方 (`--trace` / `--trace-out` / JSON Lines / 内部挙動・impo
 ## Git ブランチ運用ルール
 
 - フィーチャーブランチは `main` から作成し、PR は `main` に向けて作成する。`main` への直接コミットは禁止
+- フィーチャーブランチに main の最新を取り込む際は **`git rebase origin/main`** を使う (履歴の線形性を保つため)。merge commit による合流はしない。具体手順は `/git-commit-push` / `/git-commit-push-pr` / `/git-resolve-conflicts` を参照
+- rebase 後の push は **`git push --force-with-lease`** を使う (二回目以降は SHA が書き換わるため force push が必要。`--force-with-lease` は remote の予期しない進行を検知して上書きをブロックする)。`fetch` と `push` の間で `git fetch` を再実行しない (lease 保護が緩む)
+- 上記の rebase 方針はフィーチャーブランチへの main 取り込みに限る。`/preparing-for-release` での main 自体の更新は別系統で、`git pull --ff-only origin main` のまま (線形性が保証されているため変更不要)
 - PR マージ前に、未追跡ファイルや未コミットの変更がないか確認すること。ある場合はマージ前にユーザーに報告し、コミットの要否を確認する
 - `.serena/` ディレクトリに差分がある場合は、他の変更と一緒にコミットすること
 


### PR DESCRIPTION
## Summary

- `git-commit-push` / `git-commit-push-pr` / `git-resolve-conflicts` の 3 skill を `git merge origin/main` → `git rebase origin/main` に切り替える
- rebase 後の push は `git push --force-with-lease` を標準化 (`git-commit-push-pr` の初回 push 用 `-u` フラグは維持)
- `git-resolve-conflicts` に mid-rebase ガードを新規追加 (`.git/rebase-merge` / `.git/rebase-apply` / `git status` "rebase in progress" の存在で resume フロー判定)
- AGENTS.md「Git ブランチ運用ルール」に rebase + `--force-with-lease` 方針を追記
- `preparing-for-release` の `git pull --ff-only origin main` (main 自体の更新) は据え置き

## Impact

- 二回目以降の push は force push になる (`--force-with-lease` で safe)
- レビュー履歴中の commit SHA は rebase により書き換わる
- 本 PR の初回 push が新 skill の最初の実運用ケース (本 PR の push 自体で `/git-commit-push-pr` 改定版を live test 済)

## Pre-commit checklist

- Skipped §1 — no user-visible change (`.claude/` / `AGENTS.md` のみ)
- Skipped §2 — no user-visible change (matrix `.claude/` + top-level `*.md` 行に該当)
- Skipped §3 — no source code change
- Skipped §3.5 — no source code change
- Skipped §3.5.5 — no source code change
- Skipped §3.6 — no parser/lexer/json/utf8/string change
- Skipped §3.6.5 — no tree-sitter grammar change

Closes #1877

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development guidelines for Git branch synchronization practices, including guidance on rebasing feature branches and force-pushing with lease protection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->