### PR TITLE
chore(docker): isolate bind mounts and fail-fast on host leaks (#1876)

### DIFF
--- a/.claude/skills/linux-docker-dev/SKILL.md
+++ b/.claude/skills/linux-docker-dev/SKILL.md
@@ -64,6 +64,28 @@ See [`docker/README.md`](../../../docker/README.md) for a quick-start reference.
 | `static-analysis` clang-tidy / cppcheck | — | — | `build-docker/` (shared with `default`) |
 | `static-analysis` scan-build / all | — | — | `build-scan-docker/` (dedicated; `build-docker/` also mounted for clang-tidy step in `all` mode) |
 
+## Mount strategy
+
+`docker/run.sh` bind-mounts each top-level entry the build/tests/static analysis actually read, instead of the entire project root. This closes the cross-OS contamination path that issue #1876 documents: the old `-v PROJECT_DIR:/workspace` outer mount let host `build/`, `build-asan/`, `build-fuzz/` (macOS Mach-O binaries, macOS paths in `compile_commands.json`) appear inside the container alongside the per-preset `-v build-asan-docker:/workspace/build-asan` inner mount. Under OrbStack VirtioFS this leak intermittently surfaced as `clang-tidy` chdir failures into `/Users/...` directories and as `rm -rf build-fuzz-docker/` recovery cycles — see PR #1873 for the failure log.
+
+What gets mounted, per invocation:
+
+- Directories: `src/`, `include/`, `tests/`, `share/`
+- Config files (individual file mounts): `CMakeLists.txt`, `CMakePresets.json`, `package.toml`, `.clang-tidy`, `.cppcheck-suppressions`
+- Per-preset build output: `$BUILD_DIR_HOST` (host) → `$BUILD_DIR_CONTAINER` (container) — unchanged from before
+- ccache: named volume `ry-ccache-docker` → `/home/ubuntu/.cache/ccache`
+- scan-build subcommand additionally mounts `build-scan-docker/` → `/workspace/build-scan`
+
+What is **not** mounted (and therefore invisible inside the container): everything else under the project root — `docker/`, `scripts/`, `editor/`, `docs/`, `.git/`, `.serena/`, `.github/`, `.claude/`, `changelog.d/`, all top-level Markdown / LICENSE / install.sh, and all top-level dotfiles other than the two static analysis configs listed above. Host macOS native build dirs (`build/`, `build-asan/`, `build-tsan/`, `build-fuzz/`) are likewise invisible — recovery no longer needs to `mv build/ build.host-bak/` or `rm -rf` macOS build artifacts to keep the container clean.
+
+`entrypoint.sh` adds three fail-fast guards on startup, all consulting `$RY_HOST_BUILD_DIR` (set by `run.sh`) so the recovery hint names the host-side directory the user can `rm -rf`:
+
+1. **Required-mount presence** (`exit 70`) — verifies `/workspace/{CMakeLists.txt,CMakePresets.json,package.toml,src,include,tests,share}` all exist. Trips when `run.sh`'s mount list drifts (e.g. a new top-level config file is referenced from CMake without being added to `MOUNT_ARGS`).
+2. **ELF magic** (`exit 71`) — if `BUILD_DIR/ry` or `BUILD_DIR/ry_tests` exists, the first four bytes must be `\x7fELF`. Catches Mach-O binaries that a developer copied into the per-preset build dir or that leaked through a misconfigured mount.
+3. **macOS path in `compile_commands.json`** (`exit 72`) — refuses to run when `BUILD_DIR/compile_commands.json` lists any `"directory": "/Users/..."` entry, since that is exactly what previously broke clang-tidy.
+
+**Maintenance rule when adding a new top-level entry to the repo**: if your change adds (a) a new source / test / stdlib subdirectory at the repo root, (b) a new top-level config file that CMake or a static analyser reads, or (c) a new top-level dotfile that the build consumes, you **must** update both `docker/run.sh`'s `MOUNT_ARGS` list and `docker/entrypoint.sh`'s stage-1 required-mount loop in the same PR. Without the mount, the container sees the source tree without the new file and either silently skips it or fails late inside CMake configure; without the guard update, the silent skip slips past CI.
+
 ## Known limitations
 
 - **First image build takes ~30 seconds** because `docker/Dockerfile` inherits from `ghcr.io/<owner>/ry-ci:llvm-21` — the heavy toolchain (LLVM 21, cmake, ninja, ccache, OpenSSL, cppcheck, gtest tarball) is pulled, not built. The first compile of ry itself takes 1-2 minutes; subsequent runs use ccache and complete in ~10-30 seconds. If GHCR is unreachable, Docker falls back to whatever image layers are already cached locally.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -395,6 +395,7 @@ endif()
 
 target_compile_definitions(ry_tests PRIVATE RY_BINARY_PATH="$<TARGET_FILE:ry>")
 target_compile_definitions(ry_tests PRIVATE RY_SOURCE_ROOT="${CMAKE_CURRENT_SOURCE_DIR}")
+target_compile_definitions(ry_tests PRIVATE RY_BINARY_DIR="${CMAKE_BINARY_DIR}")
 target_precompile_headers(ry_tests REUSE_FROM ry_lib)
 target_compile_options(ry_tests PRIVATE ${RY_WARNING_FLAGS})
 

--- a/changelog.d/1876-docker-mount-isolation.md
+++ b/changelog.d/1876-docker-mount-isolation.md
@@ -1,0 +1,28 @@
+### Changed
+
+- `docker/run.sh` now bind-mounts each source directory and config file
+  individually (`src/`, `include/`, `tests/`, `share/`, `CMakeLists.txt`,
+  `CMakePresets.json`, `package.toml`, `.clang-tidy`,
+  `.cppcheck-suppressions`) instead of bind-mounting the entire project
+  root. The per-preset build directory (`build-docker/`,
+  `build-asan-docker/`, etc.) is still mounted into its container
+  counterpart, but host macOS native build dirs (`build/`, `build-asan/`,
+  `build-fuzz/`) are no longer visible inside the container. This closes
+  the cross-OS contamination path where macOS Mach-O binaries leaked
+  through the outer `PROJECT_DIR:/workspace` mount alongside the inner
+  Docker build dir and caused `clang-tidy` to fail when
+  `compile_commands.json` listed `/Users/...` host paths. The
+  `./docker/run.sh <preset> <args>` invocation interface is unchanged;
+  adding a new top-level source or config file the build reads now
+  requires updating `docker/run.sh` `MOUNT_ARGS` (and the matching
+  `entrypoint.sh` guard) in the same PR. (#1876)
+- `docker/entrypoint.sh` validates the container state at startup and
+  fails fast on three contamination patterns: required source/config
+  mounts are missing (exit 70, signals a `docker/run.sh` mount-list
+  drift), a `BUILD_DIR/ry` or `BUILD_DIR/ry_tests` binary that is not
+  ELF (exit 71, signals a macOS Mach-O leak into the container build
+  dir), or `BUILD_DIR/compile_commands.json` listing `/Users/...`
+  directories (exit 72, the symptom that previously broke `clang-tidy`).
+  Each failure message names the host-side build dir to `rm -rf` for
+  recovery, via the `RY_HOST_BUILD_DIR` environment variable that
+  `docker/run.sh` now exports into the container. (#1876)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,12 @@ ENV HOME=/home/${DEV_USER}
 ENV CCACHE_DIR=/home/${DEV_USER}/.cache/ccache
 
 WORKDIR /workspace
+# WORKDIR creates /workspace as root:root 0755 before USER drops to ubuntu.
+# Issue #1876 switched run.sh to per-entry bind mounts, so /workspace is no
+# longer overlaid by a project-root mount — without this chown,
+# test_spec_timeout creates /workspace/build/test_spec_timeout_* under asan/
+# tsan/fuzz presets (where /workspace/build is not mounted) and EACCES.
+RUN chown ${DEV_UID}:${DEV_GID} /workspace
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh

--- a/docker/README.md
+++ b/docker/README.md
@@ -62,7 +62,7 @@ See [`.claude/skills/linux-docker-dev/SKILL.md`](../.claude/skills/linux-docker-
 
 ## Notes
 
-- Host build dirs (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`, `build-fuzz-docker/`, `build-scan-docker/`) are separate from native macOS builds (`build/`, `build-asan/`, `build-tsan/`, `build-fuzz/`). They will not interfere with each other.
+- Host build dirs (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`, `build-fuzz-docker/`, `build-scan-docker/`) are separate from native macOS builds (`build/`, `build-asan/`, `build-tsan/`, `build-fuzz/`). The container only sees the per-preset Docker build dir, never the host macOS ones — `run.sh` bind-mounts source/config entries individually rather than the whole project root, and `entrypoint.sh` fails fast if a host macOS Mach-O binary or macOS path slips into the container build dir. See [`Mount strategy`](../.claude/skills/linux-docker-dev/SKILL.md#mount-strategy) for the full rationale (issue #1876).
 - On Apple Silicon the container runs arm64 Linux natively (no x86_64 QEMU emulation).
 - ccache is persisted in a named Docker volume (`ry-ccache-docker`). The first build compiles everything; subsequent runs reuse the cache.
 - Image name: `ry-linux-dev:latest`. Built locally; not pushed to any registry.

--- a/docker/README.md
+++ b/docker/README.md
@@ -62,7 +62,10 @@ See [`.claude/skills/linux-docker-dev/SKILL.md`](../.claude/skills/linux-docker-
 
 ## Notes
 
-- Host build dirs (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`, `build-fuzz-docker/`, `build-scan-docker/`) are separate from native macOS builds (`build/`, `build-asan/`, `build-tsan/`, `build-fuzz/`). The container only sees the per-preset Docker build dir, never the host macOS ones — `run.sh` bind-mounts source/config entries individually rather than the whole project root, and `entrypoint.sh` fails fast if a host macOS Mach-O binary or macOS path slips into the container build dir. See [`Mount strategy`](../.claude/skills/linux-docker-dev/SKILL.md#mount-strategy) for the full rationale (issue #1876).
+- Host build dirs (`build-docker/`, `build-asan-docker/`, `build-tsan-docker/`, `build-fuzz-docker/`, `build-scan-docker/`) are separate from native macOS builds (`build/`, `build-asan/`, `build-tsan/`, `build-fuzz/`). The container only sees the per-preset Docker build dir, never the host macOS ones.
+- `run.sh` bind-mounts source/config entries individually (`src/`, `include/`, `tests/`, `share/`, `CMakeLists.txt`, `CMakePresets.json`, `package.toml`, analyzer configs) rather than the whole project root, preventing host macOS build artifacts from appearing inside the container.
+- `entrypoint.sh` fails fast (exit codes 70/71/72) if a required mount is missing, a macOS Mach-O binary slips into the per-preset build dir, or `/Users/...` paths appear in `compile_commands.json`.
+- See [`Mount strategy`](../.claude/skills/linux-docker-dev/SKILL.md#mount-strategy) for the full rationale (issue #1876).
 - On Apple Silicon the container runs arm64 Linux natively (no x86_64 QEMU emulation).
 - ccache is persisted in a named Docker volume (`ry-ccache-docker`). The first build compiles everything; subsequent runs reuse the cache.
 - Image name: `ry-linux-dev:latest`. Built locally; not pushed to any registry.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Guard stage 1 (issue #1876): required source mounts must be present.
+# run.sh switched to per-entry bind mounts to keep the host's macOS Mach-O
+# build/ from leaking via an outer PROJECT_DIR:/workspace mount; if its
+# MOUNT_ARGS drifts (e.g. a new top-level config file is added without
+# updating run.sh), fail loudly here instead of silently producing a
+# misconfigured CMake cache.
+for _required in \
+    /workspace/CMakeLists.txt \
+    /workspace/CMakePresets.json \
+    /workspace/package.toml \
+    /workspace/src \
+    /workspace/include \
+    /workspace/tests \
+    /workspace/share; do
+  if [[ ! -e "$_required" ]]; then
+    echo "fatal: required mount $_required is missing — docker/run.sh MOUNT_ARGS drifted" >&2
+    exit 70
+  fi
+done
+unset _required
+
 # Ensure ccache dir exists (volume may be new or owned by a previous root-run)
 mkdir -p "${CCACHE_DIR:-/home/ubuntu/.cache/ccache}"
 
@@ -14,6 +35,35 @@ case "$PRESET" in
   fuzz)    BUILD_DIR="build-fuzz" ;;
   *)       echo "error: unknown preset '$PRESET' (supported: default, asan, tsan, fuzz)" >&2; exit 1 ;;
 esac
+
+# Guard stages 2-3 (issue #1876): detect host build artifact leaks into the
+# container's BUILD_DIR. Stage 2 catches macOS Mach-O binaries left over from
+# a host `cmake --build`; stage 3 catches compile_commands.json entries with
+# /Users/... paths (the symptom that broke clang-tidy in PR #1873).
+# $RY_HOST_BUILD_DIR is set by run.sh so the recovery hint names the host-side
+# directory (e.g. build-asan-docker/) instead of the container path.
+_host_build_dir="${RY_HOST_BUILD_DIR:-$BUILD_DIR}"
+for _bin in "$BUILD_DIR/ry" "$BUILD_DIR/ry_tests"; do
+  if [[ -f "$_bin" ]]; then
+    # ELF magic is 0x7f 0x45 0x4c 0x46. Use `od` for a locale-independent
+    # byte-level comparison; piping head|grep would mis-match on systems
+    # where grep treats the input as text under a non-C locale.
+    _magic=$(od -An -N 4 -tx1 "$_bin" 2>/dev/null | tr -d ' \n')
+    if [[ "$_magic" != "7f454c46" ]]; then
+      echo "fatal: $_bin is not an ELF binary (magic=$_magic) — macOS host build artifact leaked into container" >&2
+      echo "  recovery: rm -rf $_host_build_dir/ (on host) and rerun" >&2
+      exit 71
+    fi
+  fi
+done
+unset _bin _magic
+if [[ -f "$BUILD_DIR/compile_commands.json" ]] \
+    && grep -q '"directory": "/Users/' "$BUILD_DIR/compile_commands.json"; then
+  echo "fatal: $BUILD_DIR/compile_commands.json references macOS host paths" >&2
+  echo "  recovery: rm -rf $_host_build_dir/ (on host) and rerun" >&2
+  exit 72
+fi
+unset _host_build_dir
 
 # static-analysis subcommand: each tool manages its own build needs
 if [[ "${1:-}" == "static-analysis" ]]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,26 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Guard stage 1 (issue #1876): required source mounts must be present.
-# run.sh switched to per-entry bind mounts to keep the host's macOS Mach-O
-# build/ from leaking via an outer PROJECT_DIR:/workspace mount; if its
-# MOUNT_ARGS drifts (e.g. a new top-level config file is added without
-# updating run.sh), fail loudly here instead of silently producing a
-# misconfigured CMake cache.
-for _required in \
+# Guard stage 1 (issue #1876): required source mounts must be present and of
+# the expected type. run.sh switched to per-entry bind mounts to keep the
+# host's macOS Mach-O build/ from leaking via an outer PROJECT_DIR:/workspace
+# mount; if its MOUNT_ARGS drifts (e.g. a new top-level config file is added
+# without updating run.sh, or a file mount is accidentally written as a dir
+# mount), fail loudly here instead of silently producing a misconfigured CMake
+# cache. Type-checking with -f / -d (rather than -e) catches a directory
+# mounted where a file was expected, which would otherwise pass -e and break
+# later in less obvious ways.
+for _required_file in \
     /workspace/CMakeLists.txt \
     /workspace/CMakePresets.json \
-    /workspace/package.toml \
+    /workspace/package.toml; do
+  if [[ ! -f "$_required_file" ]]; then
+    echo "fatal: required file mount $_required_file is missing or not a regular file — docker/run.sh MOUNT_ARGS drifted" >&2
+    exit 70
+  fi
+done
+for _required_dir in \
     /workspace/src \
     /workspace/include \
     /workspace/tests \
     /workspace/share; do
-  if [[ ! -e "$_required" ]]; then
-    echo "fatal: required mount $_required is missing — docker/run.sh MOUNT_ARGS drifted" >&2
+  if [[ ! -d "$_required_dir" ]]; then
+    echo "fatal: required directory mount $_required_dir is missing or not a directory — docker/run.sh MOUNT_ARGS drifted" >&2
     exit 70
   fi
 done
-unset _required
+unset _required_file _required_dir
 
 # Ensure ccache dir exists (volume may be new or owned by a previous root-run)
 mkdir -p "${CCACHE_DIR:-/home/ubuntu/.cache/ccache}"
@@ -58,7 +67,7 @@ for _bin in "$BUILD_DIR/ry" "$BUILD_DIR/ry_tests"; do
 done
 unset _bin _magic
 if [[ -f "$BUILD_DIR/compile_commands.json" ]] \
-    && grep -q '"directory": "/Users/' "$BUILD_DIR/compile_commands.json"; then
+    && grep -Eq '"directory"[[:space:]]*:[[:space:]]*"/Users/' "$BUILD_DIR/compile_commands.json"; then
   echo "fatal: $BUILD_DIR/compile_commands.json references macOS host paths" >&2
   echo "  recovery: rm -rf $_host_build_dir/ (on host) and rerun" >&2
   exit 72

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -87,8 +87,10 @@ if [[ -n "$SCAN_BUILD_DIR_HOST" ]]; then
   mkdir -p "$PROJECT_DIR/$SCAN_BUILD_DIR_HOST"
 fi
 
-# Sanitizer env vars matching CI jobs
-ENV_ARGS=()
+# Sanitizer env vars matching CI jobs.
+# RY_HOST_BUILD_DIR is consumed by entrypoint.sh to print host-side rm -rf
+# recovery commands when its leak/contamination guards fire.
+ENV_ARGS=(-e "RY_HOST_BUILD_DIR=$BUILD_DIR_HOST")
 case "$PRESET" in
   asan|fuzz)
     ENV_ARGS+=(
@@ -117,8 +119,24 @@ fi
 # Docker Desktop gRPC-FUSE) transparently translate bind-mount UIDs.
 # --tmpfs /tmp keeps test-created temp dirs and analyzer scratch off the overlay
 # (Docker storage pools fill up; /workspace bind-mount uses host disk).
+#
+# Per-entry bind mounts (issue #1876): the previous "-v PROJECT_DIR:/workspace"
+# outer mount let host build/, build-asan/, etc. (macOS Mach-O) leak into the
+# container alongside the inner build-*-docker/ mount, which caused clang-tidy
+# to fail when compile_commands.json referenced /Users/... paths. The mount
+# list below exposes only what the build, tests, and static analysis actually
+# read; adding a new top-level source dir or config file requires updating
+# this list AND entrypoint.sh's required-mount guard.
 MOUNT_ARGS=(
-  -v "$PROJECT_DIR:/workspace"
+  -v "$PROJECT_DIR/src:/workspace/src"
+  -v "$PROJECT_DIR/include:/workspace/include"
+  -v "$PROJECT_DIR/tests:/workspace/tests"
+  -v "$PROJECT_DIR/share:/workspace/share"
+  -v "$PROJECT_DIR/CMakeLists.txt:/workspace/CMakeLists.txt"
+  -v "$PROJECT_DIR/CMakePresets.json:/workspace/CMakePresets.json"
+  -v "$PROJECT_DIR/package.toml:/workspace/package.toml"
+  -v "$PROJECT_DIR/.clang-tidy:/workspace/.clang-tidy"
+  -v "$PROJECT_DIR/.cppcheck-suppressions:/workspace/.cppcheck-suppressions"
   -v "$PROJECT_DIR/$BUILD_DIR_HOST:/workspace/$BUILD_DIR_CONTAINER"
   -v "$CCACHE_VOLUME:/home/ubuntu/.cache/ccache"
 )

--- a/tests/test_spec_timeout.cpp
+++ b/tests/test_spec_timeout.cpp
@@ -131,9 +131,13 @@ protected:
     void SetUp() override {
         // Test files must live under a directory whose upward search reaches
         // the repo's package.toml — otherwise dev stdlib resolution fails
-        // and `from testing import timeout` cannot be satisfied.  Use a
-        // per-pid subdir under build/ so parallel test runs don't collide.
-        tmpDir_ = fs::path(RY_SOURCE_ROOT) / "build" /
+        // and `from testing import timeout` cannot be satisfied.  Use the
+        // per-preset CMake binary dir (e.g. build/, build-asan/) so the
+        // directory is host-backed under docker per-preset bind mounts —
+        // a hard-coded `RY_SOURCE_ROOT/build` would route asan/tsan/fuzz
+        // writes to the docker overlay and ENOSPC there.  Per-pid subdir
+        // avoids parallel test-run collisions.
+        tmpDir_ = fs::path(RY_BINARY_DIR) /
                   ("test_spec_timeout_" +
                    std::to_string(static_cast<long>(getpid())));
         fs::create_directories(tmpDir_);


### PR DESCRIPTION
## Summary

- Replace the project-root outer bind mount in `docker/run.sh` with per-entry mounts (`src/`, `include/`, `tests/`, `share/`, `CMakeLists.txt`, `CMakePresets.json`, `package.toml`, `.clang-tidy`, `.cppcheck-suppressions`) so host macOS `build/`, `build-asan/`, `build-fuzz/` are no longer visible inside the container. Closes the cross-OS contamination path documented in #1876 (Mach-O leak + `/Users/...` paths in `compile_commands.json`) that forced repeated `rm -rf build-*-docker/` recovery cycles in PR #1873.
- Add three fail-fast guards in `docker/entrypoint.sh`: exit 70 (required source/config mount missing — signals `run.sh` `MOUNT_ARGS` drift), exit 71 (`BUILD_DIR/ry` or `BUILD_DIR/ry_tests` is not ELF — Mach-O leak detection), exit 72 (`BUILD_DIR/compile_commands.json` lists `/Users/...` paths — clang-tidy break direct detection). Each message names the host-side build dir via the new `RY_HOST_BUILD_DIR` env var so the recovery hint matches what the user can `rm -rf`.
- Side fix: `tests/test_spec_timeout.cpp` now uses a new `RY_BINARY_DIR` CMake macro (= `${CMAKE_BINARY_DIR}`) instead of `RY_SOURCE_ROOT/build`, so asan/tsan/fuzz temp dirs land in the per-preset host-backed `build-*-docker/` instead of the docker overlay (which previously ENOSPC'd). `docker/Dockerfile` chowns `/workspace` to the dev user since per-entry mounts no longer overlay it.

Closes #1876.

## Test plan

Verified **3 consecutive rounds** of `pre-commit-checklist` §3.5 / §3.5.5 / §3.6 with **no `rm -rf` and no workarounds**, all exit 0:

- [x] §3.5 ASan + UBSan — `./docker/run.sh asan ry_tests` (2447 pass) + `./docker/run.sh asan ry test -p` (0 fail)
- [x] §3.5 TSan — `./docker/run.sh tsan ry_tests` (2445 pass + 2 skip, ConcurrencySpecSuite clean)
- [x] §3.5.5 clang-tidy — `./docker/run.sh static-analysis clang-tidy` (clean)
- [x] §3.5.5 cppcheck — `./docker/run.sh static-analysis cppcheck` (clean, only "information" notes)
- [x] §3.6 fuzz_json — `./docker/run.sh fuzz fuzz_json -max_total_time=60 -rss_limit_mb=512 -artifact_prefix=tests/fuzz/regressions/json/ tests/fuzz/corpus/json` (~1.2M-1.4M runs/round, no crashes)
- [x] Plan C guards positive path: no exit 70/71/72 in any of the 9 runs

Skipped §3.6 — no parser/lexer/json/utf8/string change (ran `fuzz_json` anyway as part of the §3.6 verification matrix for the docker mount change, since the goal of this PR is precisely to keep `fuzz_json` runnable in Docker without recovery cycles).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Containers now validate required mounts and detect host build contamination, failing early with clear recovery guidance.
  * Improved mount isolation by bind-mounting required sources/configs rather than the entire project root.
  * Ensured workspace ownership for the development UID/GID to avoid permission-related test failures.

* **Tests**
  * Temporary test directories now use the per-preset binary build directory to avoid overlay/ENOSPC issues.

* **Documentation**
  * Expanded Docker notes to explain mount strategy and failure behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1879?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->