### PR TITLE
fix(json): include line:column in all parse error messages (#1882)

### DIFF
--- a/changelog.d/1882-json-error-position-all-paths.md
+++ b/changelog.d/1882-json-error-position-all-paths.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- `json.load` / `json.loadAs[T]` now report `at line <L>, column <C>
+  (offset <O>)` for the 16 parse-error sites in `runtime_json.cpp` that
+  were left position-less by #1851 — `unexpected end of input`,
+  `unterminated string`, `unterminated string escape`, `incomplete
+  unicode escape`, `invalid hex digit in unicode escape`, `unpaired
+  high surrogate in unicode escape`, `invalid low surrogate in unicode
+  escape`, `unpaired low surrogate in unicode escape`, `invalid escape
+  character '\X'`, `invalid number: expected digit after decimal point`,
+  `invalid number: expected digit in exponent`, `json: maximum nesting
+  depth exceeded`, `array too large`, `unterminated array`, `object too
+  large`, `unterminated object`. Number errors point at the start of
+  the offending number; unterminated containers point at the opening
+  `"` / `[` / `{`; nesting-depth and escape errors point at the failing
+  token. All `json.load` parse-error messages now carry the position
+  suffix consistently. (#1882)

--- a/src/runtime_json.cpp
+++ b/src/runtime_json.cpp
@@ -178,7 +178,7 @@ struct JsonAnyParser {
 
     bool parse_value(RyAny &out) {
         skip_ws();
-        if (at_end()) { error = "unexpected end of input"; return false; }
+        if (at_end()) { error = "unexpected end of input at " + formatPosition(pos); return false; }
         char c = peek();
         if (c == '"') return parse_string(out);
         if (c == '{') return parse_object(out);
@@ -195,6 +195,7 @@ struct JsonAnyParser {
     // Parse a JSON string body and append the decoded bytes (UTF-8) to `out`.
     // Used both for top-level string values and for object keys.
     bool parse_string_bytes(std::string &out) {
+        size_t open_pos = pos;
         pos++; // skip opening "
 
         // Fast path: scan for closing quote without backslash (common case)
@@ -221,7 +222,7 @@ struct JsonAnyParser {
             char c = advance();
             if (c == '"') return true;
             if (c == '\\') {
-                if (at_end()) { error = "unterminated string escape"; return false; }
+                if (at_end()) { error = "unterminated string escape at " + formatPosition(pos - 1); return false; }
                 char esc = advance();
                 switch (esc) {
                     case '"': out += '"'; break;
@@ -234,12 +235,12 @@ struct JsonAnyParser {
                     case 't': out += '\t'; break;
                     case 'u': {
                         auto parse_hex4 = [&](unsigned &cp_out) -> bool {
-                            if (pos + 4 > src_len) { error = "incomplete unicode escape"; return false; }
+                            if (pos + 4 > src_len) { error = "incomplete unicode escape at " + formatPosition(pos); return false; }
                             char hex[5] = {src[pos], src[pos+1], src[pos+2], src[pos+3], 0};
                             for (int hi = 0; hi < 4; hi++) {
                                 char hc = hex[hi];
                                 if (!((hc >= '0' && hc <= '9') || (hc >= 'a' && hc <= 'f') || (hc >= 'A' && hc <= 'F'))) {
-                                    error = "invalid hex digit in unicode escape";
+                                    error = "invalid hex digit in unicode escape at " + formatPosition(pos + static_cast<size_t>(hi));
                                     return false;
                                 }
                             }
@@ -252,19 +253,19 @@ struct JsonAnyParser {
                         // High surrogate: expect a following \uXXXX low surrogate.
                         if (cp >= 0xD800 && cp <= 0xDBFF) {
                             if (pos + 2 > src_len || src[pos] != '\\' || src[pos+1] != 'u') {
-                                error = "unpaired high surrogate in unicode escape";
+                                error = "unpaired high surrogate in unicode escape at " + formatPosition(pos);
                                 return false;
                             }
                             pos += 2;
                             unsigned low;
                             if (!parse_hex4(low)) return false;
                             if (low < 0xDC00 || low > 0xDFFF) {
-                                error = "invalid low surrogate in unicode escape";
+                                error = "invalid low surrogate in unicode escape at " + formatPosition(pos);
                                 return false;
                             }
                             cp = 0x10000 + ((cp - 0xD800) << 10) + (low - 0xDC00);
                         } else if (cp >= 0xDC00 && cp <= 0xDFFF) {
-                            error = "unpaired low surrogate in unicode escape";
+                            error = "unpaired low surrogate in unicode escape at " + formatPosition(pos);
                             return false;
                         }
                         if (cp < 0x80) {
@@ -287,7 +288,7 @@ struct JsonAnyParser {
                     default:
                         error = "invalid escape character '\\";
                         error += esc;
-                        error += "'";
+                        error += "' at " + formatPosition(pos - 2);
                         return false;
                 }
             } else {
@@ -298,7 +299,7 @@ struct JsonAnyParser {
                 out += c;
             }
         }
-        error = "unterminated string";
+        error = "unterminated string at " + formatPosition(open_pos);
         return false;
     }
 
@@ -327,7 +328,7 @@ struct JsonAnyParser {
             is_float = true;
             pos++;
             if (at_end() || !isdigit((unsigned char)src[pos])) {
-                error = "invalid number: expected digit after decimal point";
+                error = "invalid number: expected digit after decimal point at " + formatPosition(start);
                 return false;
             }
             while (!at_end() && isdigit((unsigned char)src[pos])) pos++;
@@ -337,7 +338,7 @@ struct JsonAnyParser {
             pos++;
             if (!at_end() && (src[pos] == '+' || src[pos] == '-')) pos++;
             if (at_end() || !isdigit((unsigned char)src[pos])) {
-                error = "invalid number: expected digit in exponent";
+                error = "invalid number: expected digit in exponent at " + formatPosition(start);
                 return false;
             }
             while (!at_end() && isdigit((unsigned char)src[pos])) pos++;
@@ -392,10 +393,11 @@ struct JsonAnyParser {
 
     bool parse_array(RyAny &out) {
         if (depth >= MAX_NESTING_DEPTH) {
-            error = "json: maximum nesting depth exceeded";
+            error = "json: maximum nesting depth exceeded at " + formatPosition(pos);
             return false;
         }
         DepthGuard guard(this);
+        size_t open_pos = pos;
         pos++; // skip [
         skip_ws();
         if (!at_end() && peek() == ']') {
@@ -423,7 +425,7 @@ struct JsonAnyParser {
                 if (cap > SIZE_MAX / 2 / sizeof(RyAny)) {
                     releaseOwnedAny(item);
                     cleanup();
-                    error = "array too large";
+                    error = "array too large at " + formatPosition(open_pos);
                     return false;
                 }
                 cap *= 2;
@@ -431,7 +433,7 @@ struct JsonAnyParser {
             }
             items[len++] = item;
             skip_ws();
-            if (at_end()) { error = "unterminated array"; cleanup(); return false; }
+            if (at_end()) { error = "unterminated array at " + formatPosition(open_pos); cleanup(); return false; }
             if (peek() == ']') { pos++; break; }
             if (!expect(',')) { cleanup(); return false; }
         }
@@ -446,10 +448,11 @@ struct JsonAnyParser {
 
     bool parse_object(RyAny &out) {
         if (depth >= MAX_NESTING_DEPTH) {
-            error = "json: maximum nesting depth exceeded";
+            error = "json: maximum nesting depth exceeded at " + formatPosition(pos);
             return false;
         }
         DepthGuard guard(this);
+        size_t open_pos = pos;
         pos++; // skip {
         skip_ws();
         if (!at_end() && peek() == '}') {
@@ -499,7 +502,7 @@ struct JsonAnyParser {
                     freeStringSlot(key);
                     releaseOwnedAny(val);
                     cleanup();
-                    error = "object too large";
+                    error = "object too large at " + formatPosition(open_pos);
                     return false;
                 }
                 cap *= 2;
@@ -511,7 +514,7 @@ struct JsonAnyParser {
             len++;
 
             skip_ws();
-            if (at_end()) { error = "unterminated object"; cleanup(); return false; }
+            if (at_end()) { error = "unterminated object at " + formatPosition(open_pos); cleanup(); return false; }
             if (peek() == '}') { pos++; break; }
             if (!expect(',')) { cleanup(); return false; }
         }

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -1199,3 +1199,119 @@ fn jsonStringifySortedSafeTests():
       Err(e):
         fail("load failed: " + e.message)
 
+@describe("json load — error position coverage (#1882)")
+fn jsonLoadErrorPositionCoverageTests():
+  @it("should report position for unexpected end of input")
+  fn shouldReportPositionForUnexpectedEndOfInput():
+    case load(""):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "unexpected end of input at")).toEq(true)
+        expect(contains(e.message, "line 1")).toEq(true)
+        expect(contains(e.message, "offset 0")).toEq(true)
+
+  @it("should report position for unterminated string escape")
+  fn shouldReportPositionForUnterminatedStringEscape():
+    case load("\"\\"):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "unterminated string escape at")).toEq(true)
+        expect(contains(e.message, "offset 1")).toEq(true)
+
+  @it("should report position for incomplete unicode escape")
+  fn shouldReportPositionForIncompleteUnicodeEscape():
+    case load("\"\\u00\""):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "incomplete unicode escape at")).toEq(true)
+        expect(contains(e.message, "offset 3")).toEq(true)
+
+  @it("should report position for invalid hex digit in unicode escape")
+  fn shouldReportPositionForInvalidHexDigitInUnicodeEscape():
+    case load("\"\\uZZZZ\""):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "invalid hex digit in unicode escape at")).toEq(true)
+        expect(contains(e.message, "offset 3")).toEq(true)
+
+  @it("should report position for unpaired high surrogate")
+  fn shouldReportPositionForUnpairedHighSurrogate():
+    case load("\"\\uD800\""):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "unpaired high surrogate in unicode escape at")).toEq(true)
+        expect(contains(e.message, "offset 7")).toEq(true)
+
+  @it("should report position for invalid low surrogate")
+  fn shouldReportPositionForInvalidLowSurrogate():
+    case load("\"\\uD800\\u0041\""):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "invalid low surrogate in unicode escape at")).toEq(true)
+        expect(contains(e.message, "offset 13")).toEq(true)
+
+  @it("should report position for unpaired low surrogate")
+  fn shouldReportPositionForUnpairedLowSurrogate():
+    case load("\"\\uDC00\""):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "unpaired low surrogate in unicode escape at")).toEq(true)
+        expect(contains(e.message, "offset 7")).toEq(true)
+
+  @it("should report position for invalid escape character")
+  fn shouldReportPositionForInvalidEscapeCharacter():
+    case load("\"\\q\""):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "invalid escape character")).toEq(true)
+        expect(contains(e.message, "offset 1")).toEq(true)
+
+  @it("should report position for unterminated string")
+  fn shouldReportPositionForUnterminatedString():
+    case load("\"hello"):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "unterminated string at")).toEq(true)
+        expect(contains(e.message, "offset 0")).toEq(true)
+
+  @it("should report position for invalid number missing digit after decimal point")
+  fn shouldReportPositionForInvalidNumberDecimal():
+    case load("1."):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "expected digit after decimal point at")).toEq(true)
+        expect(contains(e.message, "offset 0")).toEq(true)
+
+  @it("should report position for invalid number missing digit in exponent")
+  fn shouldReportPositionForInvalidNumberExponent():
+    case load("1e"):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "expected digit in exponent at")).toEq(true)
+        expect(contains(e.message, "offset 0")).toEq(true)
+
+  @it("should report position for maximum nesting depth exceeded")
+  fn shouldReportPositionForMaxNestingDepth():
+    deep: str = repeat("[", 257)
+    case load(deep):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "maximum nesting depth exceeded at")).toEq(true)
+        expect(contains(e.message, "offset 256")).toEq(true)
+
+  @it("should report position for unterminated array")
+  fn shouldReportPositionForUnterminatedArray():
+    case load("[1, 2"):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "unterminated array at")).toEq(true)
+        expect(contains(e.message, "offset 0")).toEq(true)
+
+  @it("should report position for unterminated object")
+  fn shouldReportPositionForUnterminatedObject():
+    case load("{\"k\": 1"):
+      Ok(_): fail("expected Err but got Ok")
+      Err(e):
+        expect(contains(e.message, "unterminated object at")).toEq(true)
+        expect(contains(e.message, "offset 0")).toEq(true)
+


### PR DESCRIPTION
## Summary

- Adds `at line L, column C (offset O)` suffix to the 16 parse-error sites in `src/runtime_json.cpp` that were left position-less by #1851, so every `json.load` / `json.loadAs[T]` parse-error message is now self-locating.
- Offset choice mirrors the user-facing intent: number errors point at the start of the number, unterminated `string` / `array` / `object` point at the opening `"` / `[` / `{`, nesting-depth and escape errors point at the failing token.
- Adds 14 spec tests in a new `@describe("json load — error position coverage (#1882)")` block covering every reachable error path. The two unreachable defensive guards (`array too large`, `object too large`) are fixed in C++ but excluded from tests per `.claude/rules/tests-rejection-tdd.md` "Defensive guards unreachable from Ry source".

## Test plan

- [x] `./build/ry test tests/spec/json.test.ry` — all JSON spec tests pass (existing + 14 new)
- [x] `./build/ry_tests` — 2447 C++ tests pass
- [x] `./build/ry test -p` — 201 Ry self-test files pass
- [x] ASan + UBSan (Docker): C++ and Ry self-tests all green
- [x] TSan (Docker): C++ all green (2 known-skip timeout tests)
- [x] clang-tidy + cppcheck (Docker): exit 0, no new warnings
- [x] libFuzzer `fuzz_json` (Docker, 60s): 1.46M runs, no crash
- [x] Existing `@describe("json load — error position (line:column)")` (4 cases) and `@describe("json parse depth limit")` (3 cases) — no regression

Closes #1882

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON parsing errors now consistently include precise source positions (line, column, and offset) across all error conditions. Enhanced error reporting covers string escapes, invalid number formats, nesting depth limits, unterminated containers, and other parse failures, making it easier to identify and fix malformed JSON.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->