### PR TITLE
fix(parser): reject f<T>(args) angle-bracket generic call with clear diagnostic

### DIFF
--- a/changelog.d/1852-loadas-records-collections-option.md
+++ b/changelog.d/1852-loadas-records-collections-option.md
@@ -6,12 +6,12 @@
   the parsed JSON object is looked up by name and recursively coerced
   into the declared type; missing fields, wrong-typed fields, and
   unsupported source shapes return `Err(Error{message})` with a
-  `loadAs<T>: ...` prefix that locates the failure (e.g.
-  `loadAs<Outer>: field 'inner': loadAs<Inner>: field 'age' missing`).
+  `loadAs[T]: ...` prefix that locates the failure (e.g.
+  `loadAs[Outer]: field 'inner': loadAs[Inner]: field 'age' missing`).
   `Option<T>` accepts JSON `null` as `Ok(None)` and any non-null shape
   as `Ok(Some(_))` (recursively coerced); a primitive source for
-  `Option<Record>` errors with `loadAs<Option<X>>: expected null or
-  loadAs<X>: expected JSON object`. Previously these targets crashed
+  `Option<Record>` errors with `loadAs[Option<X>]: expected null or
+  loadAs[X]: expected JSON object`. Previously these targets crashed
   with `_Exit(1)` via the panic-version `unwrapFromAny`; the new
   `tryUnwrapFromAny` sibling routes Result-based propagation
   end-to-end. (#1852)

--- a/changelog.d/1885-parser-angle-generic-call-error.md
+++ b/changelog.d/1885-parser-angle-generic-call-error.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- Parser: `Ident<...>(args)` in expression position (e.g.
+  `loadAs<int>("1")`) is now rejected with a dedicated diagnostic that
+  directs users to the canonical `[T]` generic-call syntax
+  (`f[int](x)`), instead of silently misparsing the form as a chain of
+  comparison operators and surfacing a misleading
+  `undefined variable: <name>` error. `Foo<T>::Variant` enum
+  constructors and plain comparison chains (`a < b > c`) are
+  unaffected. The runtime `loadAs[T]: ...` error-message prefix and
+  the `tests/spec/json.test.ry` describe/it names are unified with the
+  `[T]` user-facing notation. (#1885)

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -293,7 +293,11 @@ constructor_pattern ::= qualified_ident [ '(' [ pattern { ',' pattern } ] ')' ]
 qualified_ident  ::= IDENT { '::' IDENT }
 /* NOTE: explicit type arguments (`Foo<T>::Variant`) are not yet modeled at
  * the qualified_ident level — `<` always tokenizes as the comparison
- * operator in expression position. */
+ * operator in expression position. As a consequence, `Ident<...>(args)` in
+ * expression position is rejected with a dedicated parser diagnostic
+ * pointing users to the `[T]` generic-call syntax (e.g. `f[int](x)`),
+ * which is the canonical form documented in
+ * docs/reference/functions.md. See #1885. */
 
 range_pattern    ::= literal_pattern '..' literal_pattern
 

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -2309,7 +2309,7 @@ public:
     // recursively `tryUnwrapFromAny`s each value, and builds the record via
     // an `InsertValue` chain. On any field miss / sub-Err, releases every
     // ARC-bearing field collected so far (per advisor's ARC-leak guard) and
-    // returns `Err(Error{message:"loadAs<RecordName>: ..."})`.
+    // returns `Err(Error{message:"loadAs[RecordName]: ..."})`.
     llvm::Value *tryUnwrapRecordFromAny(llvm::Value *anyVal,
                                           llvm::StructType *recordStructTy,
                                           const RecordInfo &info,
@@ -2343,7 +2343,7 @@ public:
     // Typed `Option<T>` reconstruction from `any` (#1852). Accepts two source
     // shapes: Unit (JSON null) maps to `Ok(None)`; any other tag is forwarded
     // to `tryUnwrapFromAny` for the inner type and on success wrapped in
-    // `Some(_)`. Inner err messages are prefixed with `loadAs<Option<X>>: ...`
+    // `Some(_)`. Inner err messages are prefixed with `loadAs[Option<X>]: ...`
     // so the test asserting "null" + "JSON object" simultaneously can match.
     llvm::Value *tryUnwrapOptionFromAny(llvm::Value *anyVal,
                                           llvm::StructType *optTy,

--- a/share/std/json/json.ry
+++ b/share/std/json/json.ry
@@ -106,7 +106,7 @@ fn dump(f: File, value: any) -> Result<Unit, Error>
 fn dump(f: File, value: any, indent: int) -> Result<Unit, Error>
 
 # Typed deserialization (#1852). Each call site monomorphizes per T and the
-# JSON dispatcher intercepts `loadAs<T>(...)` to route through the
+# JSON dispatcher intercepts `loadAs[T](...)` to route through the
 # `tryUnwrapFromAny` coerce path — tag/structure mismatches surface as
 # `Err(Error)` instead of panicking via `_Exit(1)`.
 #
@@ -115,7 +115,7 @@ fn dump(f: File, value: any, indent: int) -> Result<Unit, Error>
 # Map<str, any>, user-defined records (flat and nested), typed collections
 # of records (List<Record>, Map<str, Record>), and Option<T>. Missing
 # fields, wrong-typed fields, and unsupported source shapes surface as
-# `Err(Error{message})` with a `loadAs<T>: ...` prefix that locates the
+# `Err(Error{message})` with a `loadAs[T]: ...` prefix that locates the
 # failure. See docs/reference/json.md for the full T table and error
 # message format.
 @public

--- a/src/codegen_any.cpp
+++ b/src/codegen_any.cpp
@@ -243,7 +243,7 @@ llvm::Value *CodeGen::unwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy,
     // `List<int>` unwrap of a `List<any>` payload strides 8-byte ints over a
     // 16-byte buffer and silently produces garbage (outcome b in the original
     // advisor analysis). The only context where this PR newly exposes the
-    // hazard is generic monomorphization of `loadAs<T>` (and any user-defined
+    // hazard is generic monomorphization of `loadAs[T]` (and any user-defined
     // `fn f<T>(a: any) -> T` analog): the JSON parser materializes
     // `List<any>` but the substituted `T` claims `List<int>`. Direct unwraps
     // like `let ys: List<int> = a` where the source was actually a `List<int>`
@@ -515,7 +515,7 @@ llvm::Value *CodeGen::tryUnwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy
     };
     auto emitUnsupportedErr = [&](const std::string &kindLabel) -> llvm::Value * {
         std::string label = targetTypeName.empty() ? "?" : targetTypeName;
-        std::string msg = "loadAs<" + label + ">: " + kindLabel +
+        std::string msg = "loadAs[" + label + "]: " + kindLabel +
                           " target not yet supported";
         return buildErrValue(buildInlineError(msg), resTy);
     };
@@ -651,7 +651,7 @@ llvm::Value *CodeGen::tryUnwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy
         std::string typeForMsg =
             targetTypeName.empty() ? "float" : targetTypeName;
         std::string msg =
-            "loadAs<" + typeForMsg + ">: expected float or int";
+            "loadAs[" + typeForMsg + "]: expected float or int";
         return emitResultBranch(
             isErr, resTy,
             [&]() -> llvm::Value * {
@@ -701,7 +701,7 @@ llvm::Value *CodeGen::tryUnwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy
                      : (targetTy == ptrTy_) ? "str"
                                             : "unknown";
     }
-    std::string msg = "loadAs<" + typeForMsg + ">: expected " + typeForMsg;
+    std::string msg = "loadAs[" + typeForMsg + "]: expected " + typeForMsg;
 
     return emitResultBranch(
         isErr, resTy,
@@ -734,7 +734,7 @@ llvm::Value *CodeGen::tryUnwrapRecordFromAny(llvm::Value *anyVal,
                                                llvm::StructType *resTy) {
     llvm::Function *fn = builder_.GetInsertBlock()->getParent();
     const std::string typeLabel = targetTypeName.empty() ? "?" : targetTypeName;
-    const std::string prefix = "loadAs<" + typeLabel + ">: ";
+    const std::string prefix = "loadAs[" + typeLabel + "]: ";
 
     // Field-kind classification drives ARC release on every err exit. Records
     // are built field-by-field via InsertValue; if iter k fails, every
@@ -997,7 +997,7 @@ llvm::Value *CodeGen::tryUnwrapListFromAny(llvm::Value *anyVal,
     llvm::Function *fn = builder_.GetInsertBlock()->getParent();
     const std::string typeLabel =
         targetTypeName.empty() ? ("List<" + elemTypeName + ">") : targetTypeName;
-    const std::string prefix = "loadAs<" + typeLabel + ">: ";
+    const std::string prefix = "loadAs[" + typeLabel + "]: ";
 
     auto buildInlineError = [&](const std::string &msg) -> llvm::Value * {
         llvm::Value *errStr = cachedGlobalString(msg);
@@ -1249,7 +1249,7 @@ llvm::Value *CodeGen::tryUnwrapMapFromAny(llvm::Value *anyVal,
     llvm::Function *fn = builder_.GetInsertBlock()->getParent();
     const std::string typeLabel = targetTypeName.empty()
         ? ("Map<str, " + valTypeName + ">") : targetTypeName;
-    const std::string prefix = "loadAs<" + typeLabel + ">: ";
+    const std::string prefix = "loadAs[" + typeLabel + "]: ";
 
     auto buildInlineError = [&](const std::string &msg) -> llvm::Value * {
         llvm::Value *errStr = cachedGlobalString(msg);
@@ -1562,7 +1562,7 @@ llvm::Value *CodeGen::tryUnwrapOptionFromAny(llvm::Value *anyVal,
                                                llvm::StructType *resTy) {
     llvm::Function *fn = builder_.GetInsertBlock()->getParent();
     const std::string typeLabel = targetTypeName.empty() ? "?" : targetTypeName;
-    const std::string prefix = "loadAs<" + typeLabel + ">: ";
+    const std::string prefix = "loadAs[" + typeLabel + "]: ";
 
     // Three-way dispatch on the source `any` tag:
     //   Unit → Ok(None)
@@ -1615,7 +1615,7 @@ llvm::Value *CodeGen::tryUnwrapOptionFromAny(llvm::Value *anyVal,
     llvm::BasicBlock *innerOkEndBB = builder_.GetInsertBlock();
     builder_.CreateBr(doneBB);
 
-    // Inner Err: prepend `loadAs<Option<X>>: expected null or ` to the inner
+    // Inner Err: prepend `loadAs[Option<X>]: expected null or ` to the inner
     // message via __ry_string_make_uninit + memcpy (the same prefix-concat
     // pattern used by tryUnwrapRecordFromAny / tryUnwrapMapFromAny). The
     // resulting wording satisfies the test's "null" + "JSON object"

--- a/src/codegen_call_json.cpp
+++ b/src/codegen_call_json.cpp
@@ -112,8 +112,8 @@ static llvm::Value *emitJsonStringifySortedSafe(CodeGen &cg, const CallExpr &e) 
                                   /*wrapResult=*/true);
 }
 
-// loadAs<T>(text: str) -> Result<T, Error>                   (#1852)
-// loadAs<T>(f: File) -> Result<T, Error>
+// loadAs[T](text: str) -> Result<T, Error>                   (#1852)
+// loadAs[T](f: File) -> Result<T, Error>
 //
 // Parses JSON via the same runtime entry as `load`, then coerces the resulting
 // `any` to the concrete target type via `tryUnwrapFromAny` — which returns
@@ -231,8 +231,9 @@ static llvm::Value *dispatchJson(CodeGen &cg, const CallExpr &e) {
     // codegen-stdlib-dispatcher.md #1856).
     cg.used_native_libraries_.insert("json");
 
-    // Intercept `loadAs<T>(...)` calls (#1852). The parser concatenates the
-    // type-arg literally into `e.callee` (e.g. "loadAs<Person>",
+    // Intercept `loadAs[T](...)` calls (#1852). The parser uses `[T]` syntax for
+    // generic function calls at user-facing call sites, but constructs the
+    // internal callee representation with `<T>` (e.g. "loadAs<Person>",
     // "loadAs<List<Person>>"), so we strip the `loadAs<` prefix and trailing
     // `>` to recover the type-name. The interceptor runs before
     // `emitTableDrivenNativeCall` because the table's name-keyed exact match

--- a/src/parser_expr.cpp
+++ b/src/parser_expr.cpp
@@ -541,7 +541,9 @@ ExprPtr Parser::parsePrimary() {
         // Generic enum constructor: MyOption<int>::MySome(42)
         if (lex_.peek().kind == TokenKind::Less && couldBeGenericEnum()) {
             // Try to parse as generic type: Ident<Type>::Variant(...)
+            Token angleTok = lex_.peek(); // position of '<' for #1885 diagnostic
             auto savedState = lex_.saveState();
+            bool committed = false;
             try {
                 lex_.next(); // consume '<'
                 std::string typeArgs = "<";
@@ -631,9 +633,24 @@ ExprPtr Parser::parsePrimary() {
                     node->loc = locFromToken(t);
                     return node;
                 }
+                // (#1885) `f<T>(args)` at expression position is the
+                // angle-bracket generic call form, which Ry does not support
+                // (`<` in expression position is the comparison operator —
+                // see docs/grammar.ebnf §294-296). The canonical syntax is
+                // `f[T](args)` (docs/reference/functions.md §Generic
+                // Functions). Emit a clear diagnostic so users are not
+                // misled by "undefined variable: f".
+                if (lex_.peek().kind == TokenKind::LParen) {
+                    committed = true;
+                    parseError(angleTok.line,
+                        "use 'f[T](args)' syntax for generic function call "
+                        "in expression position; '<' here is the comparison "
+                        "operator");
+                }
                 // Not a generic enum access, restore
                 lex_.restoreState(savedState);
             } catch (...) {
+                if (committed) throw;
                 lex_.restoreState(savedState);
             }
         }

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -246,57 +246,57 @@ fn jsonStringifyAnyPrettyTests():
       Err(e):
         fail("load [1,2] failed: " + e.message)
 
-@describe("json loadAs<T> — primitives")
+@describe("json loadAs[T] — primitives")
 fn jsonLoadAsPrimitiveTests():
-  @it("should parse int directly via loadAs<int>")
+  @it("should parse int directly via loadAs[int]")
   fn shouldLoadAsInt():
     case loadAs[int]("42"):
       Ok(n):
         expect(n).toEq(42)
       Err(e):
-        fail("loadAs<int> failed: " + e.message)
+        fail("loadAs[int] failed: " + e.message)
 
-  @it("should parse negative int via loadAs<int>")
+  @it("should parse negative int via loadAs[int]")
   fn shouldLoadAsNegativeInt():
     case loadAs[int]("-7"):
       Ok(n):
         expect(n).toEq(-7)
       Err(e):
-        fail("loadAs<int> -7 failed: " + e.message)
+        fail("loadAs[int] -7 failed: " + e.message)
 
-  @it("should parse float via loadAs<float>")
+  @it("should parse float via loadAs[float]")
   fn shouldLoadAsFloat():
     case loadAs[float]("3.5"):
       Ok(f):
         expect(f).toEq(3.5)
       Err(e):
-        fail("loadAs<float> failed: " + e.message)
+        fail("loadAs[float] failed: " + e.message)
 
-  @it("should parse str via loadAs<str>")
+  @it("should parse str via loadAs[str]")
   fn shouldLoadAsStr():
     case loadAs[str]("\"hello\""):
       Ok(s):
         expect(s).toEq("hello")
       Err(e):
-        fail("loadAs<str> failed: " + e.message)
+        fail("loadAs[str] failed: " + e.message)
 
-  @it("should parse bool true via loadAs<bool>")
+  @it("should parse bool true via loadAs[bool]")
   fn shouldLoadAsBoolTrue():
     case loadAs[bool]("true"):
       Ok(b):
         expect(b).toEq(true)
       Err(e):
-        fail("loadAs<bool> true failed: " + e.message)
+        fail("loadAs[bool] true failed: " + e.message)
 
-  @it("should parse bool false via loadAs<bool>")
+  @it("should parse bool false via loadAs[bool]")
   fn shouldLoadAsBoolFalse():
     case loadAs[bool]("false"):
       Ok(b):
         expect(b).toEq(false)
       Err(e):
-        fail("loadAs<bool> false failed: " + e.message)
+        fail("loadAs[bool] false failed: " + e.message)
 
-  @it("should propagate parse error via loadAs<int>")
+  @it("should propagate parse error via loadAs[int]")
   fn shouldPropagateParseError():
     case loadAs[int]("{not json}"):
       Ok(_):
@@ -307,7 +307,7 @@ fn jsonLoadAsPrimitiveTests():
         # with a non-empty message.
         expect(byteLen(e.message) > 0).toEq(true)
 
-@describe("json loadAs<T> — collections")
+@describe("json loadAs[T] — collections")
 fn jsonLoadAsCollectionTests():
   @it("should parse List<any> via loadAs")
   fn shouldLoadAsListOfAny():
@@ -315,7 +315,7 @@ fn jsonLoadAsCollectionTests():
       Ok(xs):
         expect(len(xs)).toEq(3)
       Err(e):
-        fail("loadAs<List<any>> failed: " + e.message)
+        fail("loadAs[List<any>] failed: " + e.message)
 
   @it("should parse empty List<any> via loadAs")
   fn shouldLoadAsEmptyList():
@@ -323,7 +323,7 @@ fn jsonLoadAsCollectionTests():
       Ok(xs):
         expect(len(xs)).toEq(0)
       Err(e):
-        fail("loadAs<List<any>> [] failed: " + e.message)
+        fail("loadAs[List<any>] [] failed: " + e.message)
 
   @it("should parse Map<str, any> via loadAs")
   fn shouldLoadAsMapStrAny():
@@ -331,7 +331,7 @@ fn jsonLoadAsCollectionTests():
       Ok(m):
         expect(len(m)).toEq(2)
       Err(e):
-        fail("loadAs<Map<str, any>> failed: " + e.message)
+        fail("loadAs[Map<str, any>] failed: " + e.message)
 
   @it("should parse empty Map<str, any> via loadAs")
   fn shouldLoadAsEmptyMap():
@@ -339,18 +339,18 @@ fn jsonLoadAsCollectionTests():
       Ok(m):
         expect(len(m)).toEq(0)
       Err(e):
-        fail("loadAs<Map<str, any>> {} failed: " + e.message)
+        fail("loadAs[Map<str, any>] {} failed: " + e.message)
 
 @describe("json NUL round-trip")
 fn jsonNulRoundTripTests():
-  @it("should parse \\u0000 in a string value via loadAs<str>")
+  @it("should parse \\u0000 in a string value via loadAs[str]")
   fn shouldParseU0000InAStringValue():
     case loadAs[str]("\"a\\u0000b\""):
       Ok(s):
         expect(byteLen(s)).toEq(3)
         expect(s == "a\0b").toEq(true)
       Err(e):
-        fail("loadAs<str> failed: " + e.message)
+        fail("loadAs[str] failed: " + e.message)
 
   @it("should stringify NUL back to \\u0000")
   fn shouldStringifyNulBackToU0000():
@@ -390,7 +390,7 @@ fn jsonNulRoundTripTests():
       Ok(m):
         expect(len(m)).toEq(2)
       Err(e):
-        fail("loadAs<Map<str, any>> failed: " + e.message)
+        fail("loadAs[Map<str, any>] failed: " + e.message)
 
 @describe("json parse depth limit")
 fn jsonParseDepthLimitTests():
@@ -623,9 +623,9 @@ fn jsonFileOverloadsTests():
       Err(e):
         fail("open r failed: " + e.message)
 
-@describe("json loadAs<T> — File overloads (#1854 + #1874)")
+@describe("json loadAs[T] — File overloads (#1854 + #1874)")
 fn jsonLoadAsFileOverloadsTests():
-  @it("should parse int directly via loadAs<int>(File)")
+  @it("should parse int directly via loadAs[int](File)")
   fn shouldLoadAsIntFromFile():
     case writeText("/tmp/ry_1854_loadas_int.json", "42"):
       Ok(_): 0
@@ -638,11 +638,11 @@ fn jsonLoadAsFileOverloadsTests():
             close(file)
           Err(e):
             close(file)
-            fail("loadAs<int>(File) failed: " + e.message)
+            fail("loadAs[int](File) failed: " + e.message)
       Err(e):
         fail("open r failed: " + e.message)
 
-  @it("should parse str via loadAs<str>(File)")
+  @it("should parse str via loadAs[str](File)")
   fn shouldLoadAsStrFromFile():
     case writeText("/tmp/ry_1854_loadas_str.json", "\"hello\""):
       Ok(_): 0
@@ -655,11 +655,11 @@ fn jsonLoadAsFileOverloadsTests():
             close(file)
           Err(e):
             close(file)
-            fail("loadAs<str>(File) failed: " + e.message)
+            fail("loadAs[str](File) failed: " + e.message)
       Err(e):
         fail("open r failed: " + e.message)
 
-  @it("should parse Map<str, any> via loadAs<Map<str, any>>(File)")
+  @it("should parse Map<str, any> via loadAs[Map<str, any>](File)")
   fn shouldLoadAsMapFromFile():
     case writeText("/tmp/ry_1854_loadas_map.json", "{\"name\":\"alice\",\"age\":30}"):
       Ok(_): 0
@@ -673,11 +673,11 @@ fn jsonLoadAsFileOverloadsTests():
             close(file)
           Err(e):
             close(file)
-            fail("loadAs<Map>(File) failed: " + e.message)
+            fail("loadAs[Map](File) failed: " + e.message)
       Err(e):
         fail("open r failed: " + e.message)
 
-  @it("should propagate parse error from File via loadAs<int>(File)")
+  @it("should propagate parse error from File via loadAs[int](File)")
   fn shouldPropagateParseErrorViaLoadAsFile():
     case writeText("/tmp/ry_1854_loadas_bad.json", "{not json}"):
       Ok(_): 0
@@ -694,13 +694,13 @@ fn jsonLoadAsFileOverloadsTests():
       Err(e):
         fail("open r failed: " + e.message)
 
-  @it("should keep loadAs<T>(str) overload working alongside File overload")
+  @it("should keep loadAs[T](str) overload working alongside File overload")
   fn shouldRouteStrOverloadAlongsideFileOverload():
     case loadAs[int]("99"):
       Ok(n):
         expect(n).toEq(99)
       Err(e):
-        fail("loadAs<int>(str) regression: " + e.message)
+        fail("loadAs[int](str) regression: " + e.message)
 
 # Diagnostic non-generic wrapper to isolate whether the bug is in
 # generic monomorphization or in @native overload-by-arg-type resolution
@@ -728,7 +728,7 @@ fn jsonDiagLoadFromFnBodyTests():
       Err(e):
         fail("open r failed: " + e.message)
 
-# Records for #1852 — loadAs<T> reconstruction of user-defined records and
+# Records for #1852 — loadAs[T] reconstruction of user-defined records and
 # typed collections. Prefixed with Json1852 to avoid colliding with other
 # record names in this file or in tests imported alongside it.
 
@@ -740,7 +740,7 @@ record Json1852Address:
   person: Json1852Person
   city: str
 
-@describe("json loadAs<T> — flat record reconstruction (#1852)")
+@describe("json loadAs[T] — flat record reconstruction (#1852)")
 fn jsonLoadAsFlatRecordTests():
   @it("should reconstruct a flat record from a JSON object")
   fn shouldReconstructFlatRecord():
@@ -749,7 +749,7 @@ fn jsonLoadAsFlatRecordTests():
         expect(p.name).toEq("alice")
         expect(p.age).toEq(30)
       Err(e):
-        fail("loadAs<Json1852Person> failed: " + e.message)
+        fail("loadAs[Json1852Person] failed: " + e.message)
 
   @it("should accept fields in any order")
   fn shouldAcceptFieldsInAnyOrder():
@@ -758,7 +758,7 @@ fn jsonLoadAsFlatRecordTests():
         expect(p.name).toEq("bob")
         expect(p.age).toEq(7)
       Err(e):
-        fail("loadAs<Json1852Person> reorder failed: " + e.message)
+        fail("loadAs[Json1852Person] reorder failed: " + e.message)
 
   @it("should return Err when a required field is missing")
   fn shouldReturnErrWhenRequiredFieldMissing():
@@ -793,7 +793,7 @@ fn jsonLoadAsFlatRecordTests():
       Err(e):
         expect(e.message).toContain("JSON object")
 
-@describe("json loadAs<T> — nested record reconstruction (#1852)")
+@describe("json loadAs[T] — nested record reconstruction (#1852)")
 fn jsonLoadAsNestedRecordTests():
   @it("should reconstruct a record whose field is itself a record")
   fn shouldReconstructNestedRecord():
@@ -804,7 +804,7 @@ fn jsonLoadAsNestedRecordTests():
         expect(a.person.name).toEq("dan")
         expect(a.person.age).toEq(9)
       Err(e):
-        fail("loadAs<Json1852Address> failed: " + e.message)
+        fail("loadAs[Json1852Address] failed: " + e.message)
 
   @it("should return Err when the nested record is missing a field")
   fn shouldReturnErrWhenNestedFieldMissing():
@@ -835,7 +835,7 @@ fn jsonLoadAsNestedRecordTests():
         expect(e.message).toContain("'city'")
         expect(e.message).toContain("missing")
 
-@describe("json loadAs<T> — typed List<Record> (#1852)")
+@describe("json loadAs[T] — typed List<Record> (#1852)")
 fn jsonLoadAsListRecordTests():
   @it("should reconstruct a List<Record> from a JSON array of objects")
   fn shouldReconstructListOfRecords():
@@ -848,7 +848,7 @@ fn jsonLoadAsListRecordTests():
         expect(xs[1].name).toEq("b")
         expect(xs[1].age).toEq(2)
       Err(e):
-        fail("loadAs<List<Json1852Person>> failed: " + e.message)
+        fail("loadAs[List<Json1852Person>] failed: " + e.message)
 
   @it("should reconstruct an empty List<Record>")
   fn shouldReconstructEmptyListOfRecords():
@@ -856,7 +856,7 @@ fn jsonLoadAsListRecordTests():
       Ok(xs):
         expect(len(xs)).toEq(0)
       Err(e):
-        fail("loadAs<List<Json1852Person>> [] failed: " + e.message)
+        fail("loadAs[List<Json1852Person>] [] failed: " + e.message)
 
   @it("should return Err when an element is missing a field")
   fn shouldReturnErrWhenListElementMissingField():
@@ -876,7 +876,7 @@ fn jsonLoadAsListRecordTests():
       Err(e):
         expect(e.message).toContain("JSON array")
 
-@describe("json loadAs<T> — typed Map<str, Record> (#1852)")
+@describe("json loadAs[T] — typed Map<str, Record> (#1852)")
 fn jsonLoadAsMapRecordTests():
   @it("should reconstruct a Map<str, Record> from a JSON object of objects")
   fn shouldReconstructMapOfRecords():
@@ -889,7 +889,7 @@ fn jsonLoadAsMapRecordTests():
         expect(m["y"].name).toEq("b")
         expect(m["y"].age).toEq(2)
       Err(e):
-        fail("loadAs<Map<str, Json1852Person>> failed: " + e.message)
+        fail("loadAs[Map<str, Json1852Person>] failed: " + e.message)
 
   @it("should reconstruct an empty Map<str, Record>")
   fn shouldReconstructEmptyMapOfRecords():
@@ -897,7 +897,7 @@ fn jsonLoadAsMapRecordTests():
       Ok(m):
         expect(len(m)).toEq(0)
       Err(e):
-        fail("loadAs<Map<str, Json1852Person>> {} failed: " + e.message)
+        fail("loadAs[Map<str, Json1852Person>] {} failed: " + e.message)
 
   @it("should return Err when a value is missing a field")
   fn shouldReturnErrWhenMapValueMissingField():
@@ -917,7 +917,7 @@ fn jsonLoadAsMapRecordTests():
       Err(e):
         expect(e.message).toContain("JSON object")
 
-@describe("json loadAs<T> — Option<Record> (#1852)")
+@describe("json loadAs[T] — Option<Record> (#1852)")
 fn jsonLoadAsOptionRecordTests():
   @it("should reconstruct Some(Record) when JSON value is an object")
   fn shouldReconstructSomeRecord():
@@ -933,7 +933,7 @@ fn jsonLoadAsOptionRecordTests():
             fail("expected Some(...) but got None")
         expect(gotSome).toEq(true)
       Err(e):
-        fail("loadAs<Option<Json1852Person>> failed: " + e.message)
+        fail("loadAs[Option<Json1852Person>] failed: " + e.message)
 
   @it("should reconstruct None when JSON value is null")
   fn shouldReconstructNoneFromNull():
@@ -947,7 +947,7 @@ fn jsonLoadAsOptionRecordTests():
             gotNone = true
         expect(gotNone).toEq(true)
       Err(e):
-        fail("loadAs<Option<Json1852Person>> null failed: " + e.message)
+        fail("loadAs[Option<Json1852Person>] null failed: " + e.message)
 
   @it("should return Err when JSON value is neither object nor null")
   fn shouldReturnErrWhenInputNeitherObjectNorNullForOption():

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -4293,3 +4293,74 @@ TEST(ParserArrayType, RejectsHexLiteralSize) {
 TEST(ParserArrayType, RejectsUnderscoreInSize) {
     EXPECT_THROW(parseStr("x: int[1_000] = 0"), DiagnosticError);
 }
+
+// ---- Angle-bracket generic call rejection (regression for #1885) ----
+//
+// `f<T>(args)` at expression position used to be silently parsed as a
+// comparison-chain (`f < T > (args)`), causing the misleading
+// "undefined variable: f" error. The canonical generic-call syntax is
+// `f[T](args)` (docs/reference/functions.md §Generic Functions); the
+// parser must emit a clear diagnostic for the `<T>(...)` form instead.
+
+TEST(ParserTest, AngleBracketGenericCallRejectsFlat) {
+    try {
+        parseStr("x = loadAs<int>(\"1\")");
+        FAIL() << "expected DiagnosticError";
+    } catch (const DiagnosticError &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("f[T](args)"), std::string::npos)
+            << "should suggest [T] syntax: " << msg;
+    }
+}
+
+TEST(ParserTest, AngleBracketGenericCallRejectsNested) {
+    try {
+        parseStr("x = loadAs<Map<str, int>>(\"{}\")");
+        FAIL() << "expected DiagnosticError";
+    } catch (const DiagnosticError &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("f[T](args)"), std::string::npos)
+            << "should suggest [T] syntax: " << msg;
+    }
+}
+
+TEST(ParserTest, AngleBracketGenericCallRejectsInCaseExpr) {
+    try {
+        parseStr(
+            "case loadAs<int>(\"1\"):\n"
+            "    Ok(v):\n"
+            "        print(v)\n"
+            "    Err(e):\n"
+            "        print(e.message)\n");
+        FAIL() << "expected DiagnosticError";
+    } catch (const DiagnosticError &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("f[T](args)"), std::string::npos)
+            << "should suggest [T] syntax: " << msg;
+    }
+}
+
+TEST(ParserTest, AngleBracketGenericCallPreservesComparisonChain) {
+    // `a < b > c` must still parse as a chained comparison (not a generic call).
+    Program prog = parseStr("x = a < b > c");
+    ASSERT_EQ(prog.size(), 1u);
+}
+
+TEST(ParserTest, AngleBracketGenericCallPreservesIdentLessExpr) {
+    // Plain `f < n` (no closing `>`) is a comparison and must keep parsing.
+    Program prog = parseStr("x = f < n");
+    ASSERT_EQ(prog.size(), 1u);
+}
+
+TEST(ParserTest, SquareBracketGenericCallStillWorks) {
+    // The canonical `f[T](args)` syntax remains accepted unchanged.
+    Program prog = parseStr("x = loadAs[int](\"1\")");
+    ASSERT_EQ(prog.size(), 1u);
+}
+
+TEST(ParserTest, EnumConstructorWithGenericTypeStillWorks) {
+    // `Foo<T>::Variant(args)` enum-constructor path must remain accepted —
+    // it is the sibling branch of the new `<T>(...)` rejection.
+    Program prog = parseStr("x = MyOption<int>::MySome(42)");
+    ASSERT_EQ(prog.size(), 1u);
+}


### PR DESCRIPTION
## Summary
- Parser: `Ident<...>(args)` at expression position (e.g. `loadAs<int>(\"1\")`) used to be silently parsed as a comparison chain, producing the misleading `undefined variable: loadAs` error. Detect the pattern after the existing `couldBeGenericEnum()` lookahead and emit a dedicated diagnostic pointing users to the canonical `[T]` generic-call syntax (`f[int](x)`).
- Runtime: unify the user-visible error message prefix `loadAs<T>:` → `loadAs[T]:` across `tryUnwrapFromAny` / record / list / map / option helpers.
- Tests/docs: align `tests/spec/json.test.ry` describe/it names, `share/std/json/json.ry` docstring, `docs/grammar.ebnf` note, and the unreleased `changelog.d/1852-...` fragment with the new user-facing notation.

`Foo<T>::Variant` enum constructors and plain comparison chains (`a < b > c`) keep their existing parse paths. The parser internal callee representation (`"loadAs<T>"`) and the matching `kLoadAsPrefix = "loadAs<"` constant in `codegen_call_json.cpp` are kept unchanged to preserve dispatch-table compatibility.

### Diagnostic example
```
error: use 'f[T](args)' syntax for generic function call in expression position; '<' here is the comparison operator
  --> <stdin>:1:16
  |
1 | x = loadAs<int>(\"1\")
  |                ^ use 'f[T](args)' syntax for generic function call in expression position; '<' here is the comparison operator
```

### Caret position note
`parseError(int line, ...)` does not currently accept a column parameter, so the caret marks the `LParen` where the determination fired rather than the `<` that the prose names. The diagnostic text identifies the correct operator (`'<' here is ...`); adding a column-aware `parseError` overload is out of scope.

Closes #1885

## Test plan
- [x] `cmake --build build` — clean
- [x] `./build/ry_tests` — 2464 tests pass (incl. 7 new `ParserTest.AngleBracketGenericCall*` regression tests)
- [x] `./build/ry test -p` — 201 spec files pass
- [x] ASan + UBSan: `ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 ./build-asan/ry_tests` & spec — clean
- [x] libFuzzer `parser_fuzz` 60s / 64,616 runs — no crashes
- [x] Manual reproduction: `loadAs<int>("1")` → new diagnostic; `loadAs[int]("42")` → `got: 42`; runtime err → `loadAs[int]: expected int`
- [x] Wide grep sweep for stale `loadAs<` references across `docs/` / `changelog.d/` / `share/` / `include/` / `src/` / `tests/spec/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Parser now rejects invalid angle-bracket generic call syntax (e.g., `f<T>(args)`) with a helpful diagnostic suggesting the correct bracket syntax `f[T](args)`.

* **Documentation**
  * Improved JSON deserialization error messages to provide clearer debugging paths when failures occur in records, collections, and optional types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1896?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->