### PR TITLE
feat(tree-sitter): support [T] generic call syntax (#1906)

### DIFF
--- a/changelog.d/1906-tree-sitter-generic-call.md
+++ b/changelog.d/1906-tree-sitter-generic-call.md
@@ -1,0 +1,18 @@
+### Added
+
+- Tree-sitter grammar (`editor/tree-sitter/grammar.js`) now parses the
+  `[T]` generic call syntax: `load[int]("42")`,
+  `mapHas[str, int](m, "a")`, `load[Map<str, any>]("{}")`, and
+  arbitrarily nested type arguments such as
+  `load[Map<str, List<Foo>>](text)`. The `call_expression` rule gains
+  an optional `type_arguments` field that consumes the existing `_type`
+  rule, so the `function` / `arguments` field names and the highlights
+  query bindings are preserved. Corpus regressions covering the four
+  shape categories are added to
+  `editor/tree-sitter/test/corpus/expressions.txt`, and
+  `tests/spec/json.test.ry` and
+  `tests/spec/collection_element_metadata.test.ry` are dropped from
+  `editor/tree-sitter/expected-fail.txt` now that they parse cleanly.
+  This closes the editor-tooling parity gap introduced when the C++
+  parser added the syntax in #1887; runtime and typecheck behavior is
+  unchanged. (#1906)

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -361,6 +361,9 @@ unary_expr       ::= ( '-' | '+' | '~' | 'not' | 'await' | 'weak' ) unary_expr
 postfix_expression ::= primary_expression { postfix_op }
 
 postfix_op       ::= '(' [ argument_list ] ')'                       // call
+                   | '[' type_expr { ',' type_expr } ']' '(' [ argument_list ] ')'
+                                                                       // generic call: f[T](args); the C++ parser only accepts this form
+                                                                       // when the callee is a bare IDENT (#1906, see #1885 / #1887)
                    | '[' expression { ',' expression } ']'           // index; if immediately followed by '?', returns Option<elem> on Map<K,V> / List<T> (#1699)
                    | '.' ( IDENT | INTEGER )                          // field / method / tuple index
                    | '?'                                              // unwrap Result/Option; after '[..]' becomes the Option-returning index above

--- a/editor/tree-sitter/expected-fail.txt
+++ b/editor/tree-sitter/expected-fail.txt
@@ -58,9 +58,7 @@ tests/spec/top_level_bindings.test.ry
 
 # === Other surface coverage gaps ===
 # (relative imports, trailing commas, records, case unification / arm bindings,
-#  ARC iolist patterns, Result type inference, enum with discriminant value,
-#  type-application brackets at call sites — `loadAs[T](...)`)
-tests/spec/json.test.ry
+#  ARC iolist patterns, Result type inference, enum with discriminant value)
 tests/spec/arc_iolist.test.ry
 tests/spec/case_unification.test.ry
 tests/spec/nul_safety_http.test.ry
@@ -87,11 +85,7 @@ tests/spec/type_of.test.ry
 # gap unrelated to braced selective import.
 #   - arc_tuple_*.ry, collection_meta_propagation.ry, mock.test.ry: feature-
 #     specific syntax surfaces not yet covered by editor/tree-sitter/grammar.js
-#   - collection_element_metadata.test.ry: uses `load[Map<str, any>]("...")`
-#     turbofish-style type application — same grammar gap as json.test.ry
-#     (#1887 registration miss; #1892 self-verification housekeeping)
 tests/spec/arc_tuple_index_assign.test.ry
 tests/spec/arc_tuple_ownership.test.ry
 tests/spec/collection_meta_propagation.test.ry
-tests/spec/collection_element_metadata.test.ry
 tests/spec/mock.test.ry

--- a/editor/tree-sitter/grammar.js
+++ b/editor/tree-sitter/grammar.js
@@ -90,6 +90,14 @@ export default grammar({
     // prec.dynamic biases toward statement form in statement context.
     [$.case_match_statement, $.case_match_expression],
     [$.case_cond_statement, $.case_cond_expression],
+    // `f[T, ...]` — bracket contents look like either a type list (generic call,
+    // when followed by `(`) or an expression list (index_expression). The
+    // ambiguity is resolved at the closing `]` based on the next token. Both
+    // entries are required: the 2-rule form covers `f[T, ...]` (bare type-vs-expr
+    // ambiguity), the 3-rule form covers `f[(x, y), ...]` (paren prefix could
+    // start a lambda param list, a tuple type, or a parenthesized expr). (#1906)
+    [$.named_type, $.qualified_identifier],
+    [$.named_type, $.qualified_identifier, $.lambda_param],
   ],
 
   rules: {
@@ -870,6 +878,11 @@ export default grammar({
 
     call_expression: $ => prec(PREC.postfix, seq(
       field('function', $._postfix_expression),
+      optional(field('type_arguments', seq(
+        '[',
+        sep1($._type, ','),
+        ']',
+      ))),
       '(',
       optional(field('arguments', $.argument_list)),
       ')',

--- a/editor/tree-sitter/test/corpus/expressions.txt
+++ b/editor/tree-sitter/test/corpus/expressions.txt
@@ -174,3 +174,106 @@ y = obj.method(1, 2)
           value: (integer_literal))
         (argument
           value: (integer_literal))))))
+
+==================
+generic call with single primitive type argument (#1906)
+==================
+
+x = load[int]("42")
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (qualified_identifier
+        (identifier))
+      type_arguments: (union_type
+        (primitive_type))
+      arguments: (argument_list
+        (argument
+          value: (string_literal))))))
+
+==================
+generic call with multiple type arguments (#1906)
+==================
+
+b = mapHas[str, int](m, "a")
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (qualified_identifier
+        (identifier))
+      type_arguments: (union_type
+        (primitive_type))
+      type_arguments: (union_type
+        (primitive_type))
+      arguments: (argument_list
+        (argument
+          value: (qualified_identifier
+            (identifier)))
+        (argument
+          value: (string_literal))))))
+
+==================
+generic call with nested generic type (#1906)
+==================
+
+x = load[Map<str, any>]("{}")
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (qualified_identifier
+        (identifier))
+      type_arguments: (union_type
+        (named_type
+          (identifier)
+          (type_arguments
+            (union_type
+              (primitive_type))
+            (union_type
+              (primitive_type)))))
+      arguments: (argument_list
+        (argument
+          value: (string_literal))))))
+
+==================
+generic call with two-level nested generic type (#1906)
+==================
+
+x = load[Map<str, List<Foo>>](text)
+
+---
+
+(source_file
+  (assignment_statement
+    left: (identifier)
+    right: (call_expression
+      function: (qualified_identifier
+        (identifier))
+      type_arguments: (union_type
+        (named_type
+          (identifier)
+          (type_arguments
+            (union_type
+              (primitive_type))
+            (union_type
+              (named_type
+                (identifier)
+                (type_arguments
+                  (union_type
+                    (named_type
+                      (identifier)))))))))
+      arguments: (argument_list
+        (argument
+          value: (qualified_identifier
+            (identifier)))))))


### PR DESCRIPTION
## Summary

- Extend `call_expression` in `editor/tree-sitter/grammar.js` with an optional `type_arguments` field so the in-tree tree-sitter grammar parses `load[int]("42")`, `mapHas[str, int](m, "a")`, `load[Map<str, any>]("{}")`, and nested forms like `load[Map<str, List<Foo>>](text)` without ERROR nodes. The bracket / type-list vs `index_expression` ambiguity is resolved at the closing `]` via two `conflicts` entries — the 3-rule superset (`named_type`, `qualified_identifier`, `lambda_param`) is required to cover `f[(x, y)](...)` which the parser would otherwise treat as a lambda parameter list.
- Pin the four shape categories in `editor/tree-sitter/test/corpus/expressions.txt` (single primitive type arg / multiple type args / nested generic / two-level nested) and drop `tests/spec/json.test.ry` and `tests/spec/collection_element_metadata.test.ry` from `editor/tree-sitter/expected-fail.txt` now that they parse cleanly. `docs/grammar.ebnf` gains the matching `postfix_op` production.
- Editor-tooling parity only — runtime / typecheck behavior unchanged. The C++ parser already accepted this form (`src/parser_expr.cpp:500-540`, introduced in #1887); this PR closes the editor-tooling parity gap.

Closes #1906

## Test plan

- [x] `cd editor/tree-sitter && tree-sitter generate` — exit 0 (no new conflict warnings)
- [x] `cd editor/tree-sitter && tree-sitter test` — 73/73 corpus tests pass (4 new for #1906)
- [x] `./editor/tree-sitter/build.sh && ./editor/tree-sitter/install.sh --no-build` — `ry.so` rebuilt + installed
- [x] `./editor/tree-sitter/check.sh --no-build` — `pass=154 skip=47 warn=0 fail=0` (skip dropped from 49 → 47 as both removed files now pass)
- [x] `./build/ry test -p` — 201 files, 0 failures
- [x] `./build/ry_tests --gtest_filter='*SquareBracketGenericCall*'` — PASSED (no C++ parser regression)
- [x] `git diff editor/tree-sitter/src/scanner.c` — empty (no external token change required)

### Skipped pre-commit-checklist sections

- Skipped §3.5 (ASan + UBSan) — no C++ runtime change; edits are confined to `editor/tree-sitter/grammar.js` (Node.js DSL → generated `parser.c`), the EBNF spec, corpus fixtures, and the `expected-fail.txt` list.
- Skipped §3.6 (libFuzzer) — variant of the same rationale; no parser/lexer/json/utf8/string runtime change.

### Design notes (Plan open-question resolutions)

- **Approach A (extend `call_expression`)** over Approach B (separate `generic_call_expression` rule) — preserves `function` / `arguments` field names so `highlights.scm` queries continue to bind `@function.call` without changes.
- **Permissive callee** — tree-sitter accepts any `_postfix_expression` as the callee (e.g. would also accept `obj.method[T](x)`), while the C++ parser restricts to bare `Ident`. Acceptable false-positive surface for an editor grammar; matches the existing approach for other postfix forms.
- **Two conflicts entries are both required** — verified by minimizing: dropping `[$.named_type, $.qualified_identifier]` and keeping only the 3-rule superset re-introduces the bare `f[T, ...]` ambiguity error during `tree-sitter generate`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generic function calls with bracketed type arguments are now properly supported. Functions can be called with type parameters in square brackets followed by arguments (e.g., `f[T](args)`). This includes support for nested generic types (e.g., `f[Map<str, List<int>>](data)`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1910?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->