### PR TITLE
fix(codegen): reject user fn shadowing of stdlib built-in names

### DIFF
--- a/.claude/rules/codegen-stdlib-dispatcher.md
+++ b/.claude/rules/codegen-stdlib-dispatcher.md
@@ -101,3 +101,34 @@ The check fires before any dispatch (table-driven stdlib, generic native, user-f
 - Cache the package-name set in a function-local `static std::unordered_set` inside `isStdlibPackageName` (registry is immutable after startup).
 - The bare unqualified-call case (`sqrt(4.0)` without `from math import sqrt`) is intentionally out of scope: distinguishing "user forgot the import" from "user defined `fn sqrt` later in the file" requires context the codegen dispatcher does not have at the call site, and the existing forward-reference hint is genuinely useful for the second case.
 - **#1747 alias-aware variant**: before constructing the "module not imported" message, call `findAliasForCanonical(ve->name)` (linear scan over `effective_to_canonical_`). If an alias exists, emit `"'<canonical>' is not defined. Did you mean '<alias>' (aliased from '<canonical>')?"` instead. The alias check is required because `import math as m` hides the canonical name per the Python-style contract documented in `docs/reference/modules.md`, so the generic `add 'import math'` hint is misleading — the user has already imported the module under a different name. The reverse-lookup helper lives next to `findModuleNamespace` in `include/ry/codegen.hpp` and `src/codegen.cpp`; both guard sites (`codegen_call_dispatch.cpp` CallExpr and `codegen_expr_literal.cpp` FieldAccessExpr) must apply the alias check uniformly so suggestion behavior matches whether the user wrote `math.fn(...)` or `math.field`.
+
+### `kReservedBuiltinFunctionNames` is empirically maintained — exclude `@native` generic stubs and type-aware-dispatched names
+
+**Source**: #1889 (2026-05-27, fix)
+**Tags**: stdlib, dispatch, reserved-names, builtin-shadow, @native, type-aware-dispatch, generic-fn, maintenance
+
+**Context**: #1889 added defense-in-depth guards at codegen entry that reject top-level user `fn` declarations whose name collides with a stdlib built-in (`sum`, `min`, `max`, `len`, `range`, `print`, …). Without the guards the user body was silently ignored — the hardcoded `e.callee == "..."` dispatch chain and `@native` stdlib entries always win over `findFunction`. The reserved list lives in `include/ry/builtin_names.hpp` as `kReservedBuiltinFunctionNames` and is consulted by `rejectIfReservedBuiltin(name)` at three sites: `emitStmt(FnStmt)` (non-generic top-level user fns), `registerGenericFnTemplate` (top-level generic fn templates), and `emitStmt(ImportAliasStmt)` `Kind::Fn` (import alias rename).
+
+**Rule**: The reserved list is determined **empirically**, not by enumerating every `emitBuiltin*` hardcoded `e.callee == "..."` checker or every `@native fn` declaration in `share/std/*.ry`. Most candidates from those two sources are *fall-through* — when the user defines `fn add(x: int, y: int)` and calls `add(1, 2)`, dispatch falls through past the stdlib `add` to the user fn because `add` is type-overloaded by metadata. Including such names in the reserved set produces over-rejection of legitimate user code.
+
+**Exclusions** (entries that look like candidates but must NOT go in `kReservedBuiltinFunctionNames`):
+1. **`@native` generic fn stubs** — declarations like `share/std/json/json.ry`'s `@native("json") fn load<T>(text: str) -> Result<T, Error>` reach `registerGenericFnTemplate` BEFORE the `@native` branch in `emitStmt(FnStmt)` (the generic branch fires first at `src/codegen_fn.cpp:612`). Guard 2 (`registerGenericFnTemplate`) must skip reserved-name rejection when `hasDirective(tmpl.fnStmt->directives, "native")` is true. Without the skip, the stdlib itself fails to load. The complementary check is unnecessary for Guard 1 (non-generic `@native`) because the `@native` branch at `src/codegen_fn.cpp:624+` returns before reaching `declareFunction`.
+2. **Type-aware-dispatched names** — `toStr` for records is a documented user override extension point (`docs/reference/records.md` "Stringification" section; `tests/spec/records.test.ry` "should override auto-generated toStr with user-defined"). For record types, the codegen dispatcher consults user `fn toStr(p: TheRecordType)` FIRST before falling back to the auto-generated builtin. Including `toStr` in the reserved set breaks every legitimate record stringification override. Spot-check similar extension points (`toInt`, `toFloat`, `unwrap`, `iter`) whose dispatch is metadata-driven rather than name-keyed before adding them to the reserved list.
+
+**How to verify a candidate name belongs in the reserved set**:
+
+```bash
+# Build a single-int-arg user fn with the candidate name and check whether
+# the user body or the stdlib wins:
+n=<candidate>
+printf 'fn %s(x:int)->int:\n    return 999\n\nprint(%s(1))' "$n" "$n" | ./build/ry -c
+```
+
+If the output is `999`, the user fn wins (fall-through) — the name does NOT belong in the reserved set. If the output is anything else (or an error), the stdlib silently overrides — the name belongs in the reserved set, subject to the two exclusion rules above. Repeat for `List<int>` and `str` signatures to catch type-dispatched names whose single-int test falls through but list/str test doesn't (`iter`, `pop`).
+
+**When to update `kReservedBuiltinFunctionNames`**:
+- Any new `emitBuiltin*` sub-handler added to the hardcoded `e.callee == "..."` dispatch chain.
+- Any new `@native fn` declaration in `share/std/*.ry` (excluding internal `_xxx` aliases per `stdlib-module-additions.md`).
+- After the change, run the empirical check above for every newly-touched name and add the ones where the stdlib wins. Cross-check the existing list with `grep -rEn "^fn <name>\b" tests/spec/ examples/` to confirm no legitimate top-level user fn would be over-rejected.
+
+**Why this rule cannot be derived from the dispatch chain alone**: the chain's order (qualified_module → ADT → verifyCalledWith → `emitBuiltin*` chain → StdlibRegistry → struct constructor → `findFunction`) is a static property, but whether any specific name "wins" against `findFunction` depends on whether each `emitBuiltin*` checker rejects unknown signatures and falls through, or unconditionally claims the call. That predicate is per-name and only the empirical check reveals it.

--- a/changelog.d/1889-reject-builtin-shadow.md
+++ b/changelog.d/1889-reject-builtin-shadow.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Top-level user `fn` declarations that collide with stdlib built-in function names (e.g. `sum`, `min`, `max`, `len`, `range`, `print`, `enumerate`, `zip`, `map`, `filter`, `Ok`, `Err`, `Some`, `None`) are now rejected at compile time with a clear diagnostic instead of silently being shadowed by the built-in. Generic-fn templates and `from <module> import <name> as <reserved>` aliases are checked the same way. Nested `fn`s, `@native` declarations, qualified-import module members, and type-aware overrides like `fn toStr(p: MyRecord)` remain accepted. (#1889)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -330,6 +330,31 @@ fn calc(x: int) -> int:      # conflicts with calc(int) from above
 
 ---
 
+## Reserved Built-in Names
+
+Top-level user functions cannot reuse names that the standard library reserves for built-ins. Names such as `sum`, `min`, `max`, `len`, `range`, `print`, `enumerate`, `zip`, `map`, `filter`, `fold`, `reduce`, `iter`, `Ok`, `Err`, `Some`, `None`, `Error`, and others dispatch directly through the compiler's built-in chain. A user `fn sum(...)` at the top level would never be called — the body would be silently ignored. The compiler rejects such declarations at definition time with `cannot declare function 'sum': name is reserved for a built-in function`.
+
+```ry
+# Error: cannot declare function 'sum': name is reserved for a built-in function
+fn sum(values: List<int>) -> int:
+    return 999
+```
+
+The check applies to:
+
+- Top-level non-`@native` `fn` declarations.
+- Top-level generic `fn` templates (e.g. `fn map<T, U>(...)`).
+- `from <module> import <name> as <reserved>` import aliases.
+
+The check does **not** apply to:
+
+- `@native` declarations (the stdlib's own implementations).
+- Nested `fn`s inside another function body — these are scope-local and cannot be observed by the built-in dispatcher.
+- Functions defined in a user module accessed via qualified import (`<mod>.<name>` dispatch consults the module's namespace directly).
+- Type-aware extension points such as `fn toStr(p: MyRecord)` — for record types, the codegen consults the user definition first, so `toStr` is not part of the reserved set. See [Records](records.md) for the record `toStr` override pattern.
+
+---
+
 ## Unit Type Functions
 
 Functions without a return value return `Unit`. The return type can be omitted (inferred as `Unit`) or explicitly specified with `-> Unit`.

--- a/include/ry/builtin_names.hpp
+++ b/include/ry/builtin_names.hpp
@@ -1,0 +1,102 @@
+#ifndef RY_BUILTIN_NAMES_HPP
+#define RY_BUILTIN_NAMES_HPP
+
+#include <string_view>
+#include <unordered_set>
+
+namespace ry {
+
+// Reserved stdlib built-in function names; see .claude/rules/codegen-stdlib-dispatcher.md for maintenance.
+inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames = {
+    "Err",
+    "Error",
+    "None",
+    "Ok",
+    "Some",
+    "all",
+    "any",
+    "args",
+    "availableParallelism",
+    "blockOn",
+    "byteLen",
+    "charAt",
+    "checkedAdd",
+    "checkedMul",
+    "checkedSub",
+    "close",
+    "contains",
+    "count",
+    "distinct",
+    "endsWith",
+    "enumerate",
+    "env",
+    "exit",
+    "filter",
+    "find",
+    "first",
+    "flat",
+    "fold",
+    "hasKey",
+    "input",
+    "isEmpty",
+    "iter",
+    "keys",
+    "last",
+    "len",
+    "lines",
+    "load",
+    "map",
+    "max",
+    "min",
+    "pop",
+    "print",
+    "range",
+    "readAll",
+    "readLine",
+    "receive",
+    "reduce",
+    "regexFindAll",
+    "regexMatch",
+    "regexReplace",
+    "regexSearch",
+    "regexSplit",
+    "repeat",
+    "replace",
+    "reverse",
+    "reverse!",
+    "saturatingAdd",
+    "saturatingMul",
+    "saturatingSub",
+    "send",
+    "sequence",
+    "sleep",
+    "sort",
+    "sort!",
+    "split",
+    "startsWith",
+    "substr",
+    "sum",
+    "tap",
+    "toFloat",
+    "toInt",
+    "toLower",
+    "toUpper",
+    "trim",
+    "trimEnd",
+    "trimStart",
+    "typeOf",
+    "unwrap",
+    "values",
+    "wrappingAdd",
+    "wrappingMul",
+    "wrappingSub",
+    "zip",
+};
+
+inline bool isReservedBuiltinFunctionName(std::string_view name) {
+    return kReservedBuiltinFunctionNames.count(name) > 0;
+}
+
+}  // namespace ry
+
+#endif  // RY_BUILTIN_NAMES_HPP

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -828,6 +828,21 @@ public:
     // themselves so they can emit a caller-specific error.
     void rejectIfTypeNameTakenByOtherKind(const std::string &name);
 
+    // Reject `name` if it collides with a stdlib built-in function name (see
+    // `kReservedBuiltinFunctionNames` in `include/ry/builtin_names.hpp`).
+    // Applied at top-level user-fn declarations, generic-fn templates, and
+    // `from ... import ... as <name>` aliases. Nested fns, `@native`, and
+    // qualified-import (`fn`s under `NamespaceEmitScope`) are intentionally
+    // exempt — callers gate accordingly. Nested-fn exemption is empirically
+    // justified: type-aware dispatch (record `toStr`, directive lifecycle
+    // hooks, `@parameterized` `iter` hook) consults user fns BEFORE the
+    // hardcoded `emitBuiltin*` chain, so a nested `fn toStr(p: Point)` /
+    // `fn first(self)` / `fn iter(self)` legitimately overrides the
+    // auto-generated builtin. For hardcoded-dispatch names like `sum`, the
+    // nested shadow silently dispatches to stdlib instead — a pre-existing
+    // limitation outside #1889's scope.
+    void rejectIfReservedBuiltin(const std::string &name);
+
     // Generic function templates. Multiple templates with the same name are
     // allowed as overloads — they must differ in arity or argument types
     // (alpha-equivalent signatures are rejected at registration time).

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -687,6 +687,19 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         return;
     }
 
+    // #1889: reject silent shadow of stdlib built-ins at the top-level.
+    // Nested fns are scope-local closures and never feed the global
+    // hardcoded-dispatch chain that the guard defends against, so the
+    // exemption preserves user freedom inside a function body. Qualified
+    // -import fns emitted under `NamespaceEmitScope` are reachable only
+    // through `<mod>.<name>` dispatch (consults `fn_overloads` directly,
+    // never the hardcoded chain) and are likewise exempt. Type-aware
+    // extension points such as `fn toStr(p: MyRecord)` are accommodated
+    // by excluding those specific names from `kReservedBuiltinFunctionNames`
+    // (see include/ry/builtin_names.hpp), not by the nesting exemption.
+    if (fn_nesting_depth_ == 0 && current_namespace_target_ == nullptr)
+        rejectIfReservedBuiltin(s->name);
+
     std::vector<llvm::Type*> paramTypes;
     paramTypes.reserve(s->params.size());
     for (auto &p : s->params)

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -883,6 +883,21 @@ void CodeGen::registerGenericFnTemplate(const std::string &name,
     if (!tmpl.fnStmt)
         codegenError("internal: registerGenericFnTemplate called with empty template");
 
+    // #1889: generic fn templates live in a flat top-level map
+    // (`generic_fn_templates_`), so a shadow against a stdlib built-in name
+    // is just as silent as for non-generic fns. The caller (`emitStmt(FnStmt)`
+    // generic branch) already rejects generic fns inside qualified-import
+    // namespace targets, so reaching this point implies a top-level template.
+    // Skip `@native` generic templates — those ARE stdlib stubs (e.g.
+    // `share/std/json/json.ry`'s `@native("json") fn load<T>(text: str)`),
+    // not user shadows. The non-generic `@native` path returns early in
+    // `emitStmt(FnStmt)`'s `@native` branch BEFORE Guard 1 fires; the
+    // generic branch reaches `registerGenericFnTemplate` first, so the
+    // skip must live here.
+    if (tmpl.fnStmt->loc.isValid()) current_loc_ = tmpl.fnStmt->loc;
+    if (!hasDirective(tmpl.fnStmt->directives, "native"))
+        rejectIfReservedBuiltin(name);
+
     std::string newFp = buildParamFingerprint(*tmpl.fnStmt);
     size_t newArity = tmpl.fnStmt->params.size();
 

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -1,4 +1,5 @@
 #include "ry/codegen.hpp"
+#include "ry/builtin_names.hpp"
 
 
 namespace ry {
@@ -499,6 +500,12 @@ void CodeGen::rejectIfTypeNameTakenByOtherKind(const std::string &name) {
         codegenError("type '" + name + "' is already defined as a type alias");
 }
 
+void CodeGen::rejectIfReservedBuiltin(const std::string &name) {
+    if (isReservedBuiltinFunctionName(name))
+        codegenError("cannot declare function '" + name +
+                     "': name is reserved for a built-in function");
+}
+
 void CodeGen::emitStmt(EnumStmt &s) {
     if (s.loc.isValid()) current_loc_ = s.loc;
     emitTraceSymbolDefine("enum", s.name, s.loc);
@@ -933,6 +940,9 @@ void CodeGen::emitStmt(ImportAliasStmt &s) {
             generic_fn_templates_.count(alias))
             codegenError("import alias '" + alias +
                          "' conflicts with an existing function definition");
+        // #1889: also reject `from <mod> import <fn> as <builtin>` — silent
+        // shadowing through alias is just as harmful as through declaration.
+        rejectIfReservedBuiltin(alias);
         rejectIfTypeNameTakenByOtherKind(alias);
         rejectCrossKindAliasCollision(ImportAliasStmt::Kind::Fn);
         if (generic_fn_templates_.count(orig))

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -1205,3 +1205,223 @@ TEST_F(CodeGenTest, UsingRejectsListInit) {
         "    print(x)\n",
         "using requires an io.File value");
 }
+
+// ============================================================
+// #1889: stdlib built-in function names cannot be shadowed by
+// user-defined top-level `fn`. Without this guard, the hardcoded
+// dispatch chain (`emitBuiltin*`) silently overrides the user fn,
+// most dangerously when the signature matches exactly
+// (`fn sum(v: List<int>) -> int: return 999` — body ignored,
+// stdlib executes instead). The guard fires for the user fn
+// declaration, not at the call site, so the error is surfaced
+// before any silent shadow has a chance to occur.
+// ============================================================
+
+// Issue reproduction: 4 signature variants of `fn sum` — every one
+// must be rejected, including the exact-signature shadow that was
+// the original silent-shadow bug.
+TEST_F(CodeGenTest, ReservedBuiltinSumTwoIntArgs) {
+    expectCompileError(
+        "fn sum(a: int, b: int) -> int:\n"
+        "    return a + b\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinSumStrArg) {
+    expectCompileError(
+        "fn sum(s: str) -> int:\n"
+        "    return 0\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinSumNoArgs) {
+    expectCompileError(
+        "fn sum() -> int:\n"
+        "    return 0\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinSumListIntExactSignature) {
+    expectCompileError(
+        "fn sum(v: List<int>) -> int:\n"
+        "    return 999\n",
+        "is reserved for a built-in");
+}
+
+// Family representatives: at least one rejection per stdlib family
+// (builtins.ry auto-loaded fn / collection ops / conversion / query /
+// ADT constructor / regex / IO / channel / set ops / arithmetic
+// checked/saturating/wrapping).
+TEST_F(CodeGenTest, ReservedBuiltinPrint) {
+    expectCompileError(
+        "fn print(x: int) -> int:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinLen) {
+    expectCompileError(
+        "fn len(x: int) -> int:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinRange) {
+    expectCompileError(
+        "fn range(n: int) -> int:\n"
+        "    return n\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinMin) {
+    expectCompileError(
+        "fn min(x: int) -> int:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinMax) {
+    expectCompileError(
+        "fn max(x: int) -> int:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
+// ADT constructor names (Ok, Err, Some, None, Error) appear in
+// `kReservedBuiltinFunctionNames` for defense-in-depth, but the parser
+// independently rejects PascalCase `fn` names with "must be camelCase".
+// That sibling rule renders the reserved-builtin guard unreachable for
+// these specific names today, so no direct rejection test is added.
+
+// `toStr` is intentionally excluded from kReservedBuiltinFunctionNames:
+// type-aware dispatch for records consults user `fn toStr(p: RecordType)`
+// BEFORE the auto-generated builtin (see tests/spec/records.test.ry's
+// "should override auto-generated toStr with user-defined" case and the
+// CodeGenTest.RecordUserDefinedToStr family). A top-level
+// `fn toStr(p: Point)` is therefore legitimate Ry, not a silent shadow.
+
+TEST_F(CodeGenTest, ReservedBuiltinTypeOf) {
+    expectCompileError(
+        "fn typeOf(x: int) -> int:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinIter) {
+    expectCompileError(
+        "fn iter(x: int) -> int:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinReverseMutating) {
+    expectCompileError(
+        "fn reverse!(x: int) -> int:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
+// The error message must name the specific function so the user
+// can fix the right declaration when many fns share a file.
+TEST_F(CodeGenTest, ReservedBuiltinErrorNamesTheFunction) {
+    expectCompileError(
+        "fn sum(a: int, b: int) -> int:\n"
+        "    return a + b\n",
+        "'sum'");
+}
+
+// Generic fn templates also flow through reserved-name rejection.
+// `generic_fn_templates_` is a flat top-level map, so shadowing is
+// just as silent without the guard.
+TEST_F(CodeGenTest, ReservedBuiltinGenericMap) {
+    expectCompileError(
+        "fn map<T, U>(x: T) -> U:\n"
+        "    return x as U\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinGenericMin) {
+    expectCompileError(
+        "fn min<T>(x: T) -> T:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinGenericFilter) {
+    expectCompileError(
+        "fn filter<T>(x: T) -> T:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
+// ============================================================
+// #1889 positive cases: the guard MUST NOT over-fire. False
+// positives would block legitimate code, so each accept-path is
+// pinned by a positive test that proves the input compiles.
+// ============================================================
+
+// Non-collision names compile cleanly even when they share a prefix
+// or suffix with a reserved name.
+TEST_F(CodeGenTest, ReservedBuiltinAllowsDistinctName) {
+    EXPECT_NO_THROW(runSource(
+        "fn mySum(x: int) -> int:\n"
+        "    return x\n"
+        "print(mySum(5))\n"
+    ));
+}
+
+// Nested fns are exempt from the reserved-name reject — the
+// declaration is accepted at codegen time. For hardcoded-dispatch
+// builtins like `sum`, the call site silently dispatches to stdlib
+// instead of the nested fn (a pre-existing limitation outside #1889's
+// scope). This test verifies declaration acceptance only.
+TEST_F(CodeGenTest, ReservedBuiltinAllowsNestedShadow) {
+    EXPECT_NO_THROW(runSource(
+        "fn outer() -> int:\n"
+        "    fn sum(x: int) -> int:\n"
+        "        return x + 1\n"
+        "    return 0\n"
+        "print(outer())\n"
+    ));
+}
+
+// `toStr` is excluded from the reserved set (see
+// `kReservedBuiltinFunctionNames` in include/ry/builtin_names.hpp),
+// so a `fn toStr(p: Point)` override is legal at any scope. This test
+// pins the nested form; the top-level form is exercised by the
+// `RecordUserDefinedToStr` family in tests/test_codegen_record.cpp.
+TEST_F(CodeGenTest, NestedToStrOverrideWorks) {
+    EXPECT_NO_THROW(runSource(
+        "record Point:\n"
+        "    x: int\n"
+        "    y: int\n"
+        "fn outer() -> str:\n"
+        "    fn toStr(p: Point) -> str:\n"
+        "        return f\"({p.x}, {p.y})\"\n"
+        "    p = Point(1, 2)\n"
+        "    return toStr(p)\n"
+        "print(outer())\n"
+    ));
+}
+
+// Fall-through builtin names (the 154 names NOT in the empirically
+// filtered 84-name reserved set) keep working — declaring them as
+// user fns is the long-standing override pattern and the 84-name
+// list was chosen to preserve that exactly.
+TEST_F(CodeGenTest, ReservedBuiltinAllowsFallthroughAdd) {
+    EXPECT_NO_THROW(runSource(
+        "fn add(x: int, y: int) -> int:\n"
+        "    return x + y\n"
+        "print(add(2, 3))\n"
+    ));
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinAllowsFallthroughAbs) {
+    EXPECT_NO_THROW(runSource(
+        "fn abs(x: int) -> int:\n"
+        "    if x < 0:\n"
+        "        return -x\n"
+        "    return x\n"
+        "print(abs(-7))\n"
+    ));
+}

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -1425,3 +1425,25 @@ TEST_F(CodeGenTest, ReservedBuiltinAllowsFallthroughAbs) {
         "print(abs(-7))\n"
     ));
 }
+
+// `@native` declarations are exempt by design — the stdlib itself
+// declares reserved names like `@native fn sum(...)` and `@native fn
+// load<T>(...)`. These are exercised indirectly every time a test
+// loads `share/std/higher_order.ry` (Guard 1 path) or
+// `share/std/json/json.ry` (Guard 2 path), but explicit coverage
+// makes the intent obvious and prevents regression. `compileSource`
+// is used (not `runSource`) because `@native` declarations have no
+// body — there is nothing to JIT-execute.
+TEST_F(CodeGenTest, ReservedBuiltinAllowsNativeDeclaration) {
+    EXPECT_NO_THROW(compileSource(
+        "@native\n"
+        "fn sum(a: int, b: int) -> int\n"
+    ));
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinAllowsNativeGenericDeclaration) {
+    EXPECT_NO_THROW(compileSource(
+        "@native\n"
+        "fn map<T, U>(xs: List<T>, f: fn(T) -> U) -> List<U>\n"
+    ));
+}

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -1063,6 +1063,56 @@ TEST_F(ImportTest, ImportAliasCollidesWithLocalDefinition) {
     }
 }
 
+// #1889: `from <mod> import <fn> as <builtin>` is just as dangerous as a
+// direct `fn <builtin>` declaration — the alias goes into `fn_aliases_`
+// where the hardcoded dispatch chain never consults it.
+TEST_F(ImportTest, ImportAliasRejectsReservedBuiltinName) {
+    writeFile("aliasbimod.ry",
+        "@public\n"
+        "fn helper() -> int:\n"
+        "    return 1\n");
+    try {
+        runWithImports(
+            "from aliasbimod import helper as sum\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("is reserved for a built-in"), std::string::npos)
+            << "got: " << msg;
+        EXPECT_NE(msg.find("'sum'"), std::string::npos) << "got: " << msg;
+    }
+}
+
+TEST_F(ImportTest, ImportAliasRejectsReservedBuiltinPrintName) {
+    writeFile("aliasprintmod.ry",
+        "@public\n"
+        "fn writer(x: int) -> int:\n"
+        "    return x\n");
+    try {
+        runWithImports(
+            "from aliasprintmod import writer as print\n");
+        FAIL() << "Expected exception";
+    } catch (const std::runtime_error &e) {
+        std::string msg = e.what();
+        EXPECT_NE(msg.find("is reserved for a built-in"), std::string::npos)
+            << "got: " << msg;
+    }
+}
+
+// #1889 positive case: a user-defined module declaring `fn sum`
+// inside a `QualifiedImportStmt`-emitted bucket compiles cleanly.
+// Reaches the `fn sum` declaration with `current_namespace_target_
+// != nullptr`, which skips Guard 1 (caller dispatch is always via
+// `<mod>.sum(...)` through `fn_overloads`, never the hardcoded chain).
+TEST_F(ImportTest, ImportAllowsReservedNameInQualifiedNamespace) {
+    writeFile("nsmod.ry",
+        "fn sum(x: int, y: int) -> int:\n"
+        "    return x + y\n");
+    EXPECT_EQ(runWithImports(
+        "import nsmod\n"
+        "print(nsmod.sum(2, 3))\n"), "5\n");
+}
+
 // Generic fn alias is scope-out: the instantiation cache + mangle keys are
 // driven by the original name, so aliasing breaks them. Reject explicitly.
 TEST_F(ImportTest, ImportAliasGenericFnRejected) {


### PR DESCRIPTION
## Summary

- Top-level user `fn` declarations that collide with stdlib built-in function names (e.g. `sum`, `min`, `max`, `len`, `range`, `print`) were silently shadowed by the hardcoded `emitBuiltin*` dispatch chain — the user body was discarded and the stdlib executed instead.
- Adds `kReservedBuiltinFunctionNames` (84 empirically determined names) in `include/ry/builtin_names.hpp` and a `rejectIfReservedBuiltin` guard at three codegen entry points: non-generic top-level fns, generic fn templates, and `from <mod> import <fn> as <name>` aliases.
- Nested fns, `@native` declarations, qualified-import module members, and type-aware overrides like `fn toStr(p: MyRecord)` remain accepted.

Closes #1889

## Test plan

- [x] `./build/ry_tests` — 2489 passed
- [x] `./build/ry test -p` — 201 spec files passed
- [x] ASan+UBSan: C++ + Ry spec all passed
- [x] TSan: C++ 2487 + 2 expected skip / Ry spec 201 all passed
- [x] libFuzzer (Docker): fuzz_parser 38k+ runs, fuzz_utf8 412k+ runs, fuzz_json 351k+ runs — no crashes
- [x] Cross-check `grep -rEn "^fn <name>\b" tests/spec/ examples/ share/std/` — no top-level user fn collisions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compiler rejects top-level function names that collide with reserved standard-library built-ins (e.g., `sum`, `min`, `max`, `len`, `range`, `print`, `map`, `filter`, `Ok`, `Err`, `Some`, `None`).
  * Import aliases that would introduce reserved built-in names are now rejected.

* **Documentation**
  * New guidance explaining reserved built-in names, scope of the check, and accepted exceptions (nested functions, `@native`, qualified imports, type-specific overrides).

* **Tests**
  * Added coverage verifying rejected and allowed cases for reserved names.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1924?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->