### PR TITLE
fix(import): resolve C++-registered resource kinds and builtin records via from-import

### DIFF
--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -41,4 +41,25 @@
 - When adding a new AST variant (new `ExprNode` or `StmtNode` alternative), grep for existing walkers in `src/codegen.cpp` and update them to include the new variant. Walkers that should `if constexpr (...)` over every variant include `collectTestTargetsFromStmt`, `collectTestTargetsFromExpr` (#1765), and `stmtHasOnlyDirective`.
 - The `LambdaExpr` and `IfBlockExpr` alternatives are the only ExprNode variants that carry `std::vector<StmtNode>` — both must hand off to the stmt-walker (`collectTestTargetsFromStmts`) explicitly. Forgetting one of them re-introduces the same class of bug.
 
+### Hot-path helpers that gate on a rarely-populated map should be lookup-first, not normalize-first
+
+**Source**: #1888 (2026-05-27 implementation)
+**Tags**: codegen, allocation, heap-perturbation, alias-resolution, lookup-pattern, latent-bug
+
+**Context**: `registerResourceByTypeName` is called for every fn parameter, variable annotation, and propagate-type-meta site that might be a resource handle — many thousands of times per typical compilation. The naive #1888 fix prefixed `resolveTypeAlias(typeName)` to the `ResourceKindRegistry::lookupByTypeName` call so aliased resource types (`from io import File as MyFile`) resolve to their canonical name. But `resolveTypeAlias` always allocates a `std::unordered_set<std::string>` for cycle detection and copies the input string, even when `type_aliases_` is empty (the overwhelmingly common case — most fns have no `type X = ...` alias in scope). The extra allocation churn measurably shifted heap layout and amplified an unrelated pre-existing latent memory bug in `tests/spec/collection_meta_propagation.test.ry` from a ~3% baseline reproduction rate (origin/main equivalent, 1/30) to ~63% (11/30). Lookup-first restores the failure rate to baseline (~3%, 2/60 across same-session stash and unstash) — it mitigates the amplification, not the underlying bug. The bug surface was "runtime error: map key not found" with exit 1 — not a sanitizer hit (ASan masked it) and not the #1895 SIGABRT teardown family.
+
+**Rule**: When extending a hot-path lookup helper to support a new naming convention (alias, qualified name, deprecated form), try the **direct** lookup first and fall back to the normalization path **only when the direct lookup misses AND the normalization map is non-empty**. The two-clause guard skips both the allocation and the function call entirely for the common case, preserving the original heap signature. Single-clause guards (only "direct lookup misses") still pay the allocation when the map is empty.
+
+**How to apply**:
+- Pattern (canonical form, `src/codegen_fn.cpp:104-111`):
+  ```cpp
+  int rk = ResourceKindRegistry::instance().lookupByTypeName(typeName);
+  if (rk == ResourceKindRegistry::NONE && !type_aliases_.empty()) {
+      rk = ResourceKindRegistry::instance().lookupByTypeName(resolveTypeAlias(typeName));
+  }
+  ```
+- The `!type_aliases_.empty()` test must use the actual map's `empty()` (cheap — single load), not a heuristic.
+- Detection in code review: any prefix of the form `lookup(normalize(x))` inside a per-fn / per-statement / per-expression codegen helper is a candidate. Bisect by reverting only that prefix and re-running a flaky downstream test 30x; if the failure rate drops to baseline (origin/main), the allocation churn is the trigger.
+- Latent memory bugs exposed this way should be filed separately via `/triage-side-finding` Q4(b) — the lookup-first fix mitigates the symptom but does not fix the root cause.
+
 

--- a/changelog.d/1888-import-cpp-registered-types.md
+++ b/changelog.d/1888-import-cpp-registered-types.md
@@ -1,0 +1,23 @@
+### Fixed
+
+- `from <mod> import <Type>` for C++-registered resource types
+  (`File` / `TcpListener` / `TcpStream` / `TlsStream` / `HttpRequest` /
+  `HttpResponse` / `HttpClientResponse` / `Thread` / `Lock` / `RWLock` /
+  `Semaphore` / `Barrier` / `AtomicInt` / `AtomicBool`) and the
+  builtin `regex.Match` record now succeeds, restoring symmetry with
+  `@native fn` imports. Previously `extractDefinitions` only scanned
+  `.ry` AST top-level declarations and rejected names registered via
+  `ResourceKindRegistry` or `CodeGen`'s constructor, surfacing a
+  misleading "typo? deprecated?" diagnostic. `module_loader.cpp` now
+  bypasses the rejection for those names when the import path matches
+  the registered `library` (gated by `from_stdlib=true` so local
+  `<mod>.ry` shadows continue to enforce the .ry-source name set).
+  Alias support (`from io import File as MyFile`) is also wired:
+  `TypeAlias` validation in `emitImportAliasStmt` accepts an `orig`
+  resolved via `ResourceKindRegistry`, and `registerResourceByTypeName`
+  prefixes `resolveTypeAlias` so an aliased type name still receives
+  resource-kind metadata for ARC cleanup. Concurrently fixed a
+  pre-existing hardcoded `if (resolved == "File")` compare in
+  `emitPatternBindingArc` (`src/codegen_match.cpp:795`) by normalising
+  through `resolveTypeAlias` first, preventing handle leaks when a
+  `Result<MyFile, Error>` is destructured via `Ok(f)`. (#1888)

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -103,7 +103,14 @@ EnumVariantRegistry CodeGen::buildEnumVariantRegistry() const {
 }
 
 void CodeGen::registerResourceByTypeName(const std::string &typeName, llvm::Value *val) {
+    // #1888: try direct lookup first, then alias resolution only on miss.
+    // Canonical names (`"File"`) hit immediately; alias names (`"MyFile"`
+    // from `from io import File as MyFile`) take the second branch.
+    // Allocation-free for the common alias-free path.
     int rk = ResourceKindRegistry::instance().lookupByTypeName(typeName);
+    if (rk == ResourceKindRegistry::NONE && !type_aliases_.empty()) {
+        rk = ResourceKindRegistry::instance().lookupByTypeName(resolveTypeAlias(typeName));
+    }
     if (rk != ResourceKindRegistry::NONE) {
         addResourceKind(val, rk);
     }

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -792,8 +792,9 @@ void CodeGen::emitPatternBindingArc(llvm::Value *val, llvm::AllocaInst *bindAllo
         // fieldTypeIsArcManaged), so the original strong count from
         // __ry_io_file_open transfers through the Ok-arm extract without
         // a balancing subject-side release.
-        if (resolved == "File") {
-            int rk = ResourceKindRegistry::instance().lookupByTypeName(resolved);
+        auto canonical = resolveTypeAlias(resolved);
+        if (canonical == "File") {
+            int rk = ResourceKindRegistry::instance().lookupByTypeName(canonical);
             if (rk != ResourceKindRegistry::NONE) {
                 // Guarded-arm copy of the binding lives in a throwaway scope
                 // that pops between the pattern test and the body re-bind.

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -1,5 +1,6 @@
 #include "ry/codegen.hpp"
 #include "ry/builtin_names.hpp"
+#include "ry/stdlib_registry.hpp"
 
 
 namespace ry {
@@ -997,7 +998,17 @@ void CodeGen::emitStmt(ImportAliasStmt &s) {
                          "' conflicts with an existing type alias");
         rejectIfTypeNameTakenByOtherKind(alias);
         rejectCrossKindAliasCollision(ImportAliasStmt::Kind::TypeAlias);
-        if (!type_aliases_.count(orig))
+        // #1888: orig may name either a user-declared `type` alias or a
+        // C++-registered resource kind (File / TcpListener / ...). The latter
+        // has no AST and lives only in `ResourceKindRegistry`; widen the
+        // validation so module_loader's TypeAlias-kind alias for resource
+        // types resolves here. The downstream `resolveType` path walks
+        // `type_aliases_` and falls back to `ResourceKindRegistry` for the
+        // canonical name, so a plain alias entry is enough.
+        bool origKnown = type_aliases_.count(orig) ||
+            (ResourceKindRegistry::instance().lookupByTypeName(orig) !=
+             ResourceKindRegistry::NONE);
+        if (!origKnown)
             codegenError("cannot create import alias '" + alias +
                          "': type alias '" + orig + "' is not defined");
         // Point alias at orig; resolveType's existing chain walks the rest.

--- a/src/module_loader.cpp
+++ b/src/module_loader.cpp
@@ -3,6 +3,7 @@
 #include "ry/parser.hpp"
 #include "ry/diagnostic.hpp"
 #include "ry/project_config.hpp"
+#include "ry/stdlib_registry.hpp"
 #include "ry/trace.hpp"
 #include <algorithm>
 #include <cstdlib>
@@ -89,6 +90,44 @@ static bool isTestingIntrinsic(bool from_stdlib,
                                const std::string &name) {
     return from_stdlib && module_path == "testing" &&
            testingIntrinsics().count(name) > 0;
+}
+
+// #1888: C++-registered resource kinds (File / TcpListener / Thread / ...) are
+// declared programmatically via `ResourceKindRegistry::registerKind` at static
+// init, not as `record` statements in the stdlib `.ry` files, so they are
+// invisible to `extractDefinitions`'s AST scan. The registry stores the owning
+// module in `Info::library`; if it matches `import_path` we treat the name as
+// a resolvable export. Gated on `from_stdlib` for the same reason as
+// `isTestingIntrinsic`: a project-local shadow must not silently absorb a
+// stdlib-only registered type name.
+static bool isCppResourceKind(bool from_stdlib,
+                              const std::string &module_path,
+                              const std::string &name) {
+    if (!from_stdlib) return false;
+    int id = ResourceKindRegistry::instance().lookupByTypeName(name);
+    if (id == ResourceKindRegistry::NONE) return false;
+    const auto *info = ResourceKindRegistry::instance().getInfo(id);
+    if (!info || !info->library) return false;
+    return module_path == info->library;
+}
+
+// #1888: Builtin record types registered in `CodeGen` constructor (not in the
+// stdlib `.ry` file). Only `Match` qualifies today — see truth source
+// `src/codegen.cpp:52` (`record_types_["Match"]` registration). If a new
+// builtin record is added there, sync this map. `Error` is intentionally
+// excluded: it is a global builtin not associated with any module.
+static bool isCppBuiltinRecord(bool from_stdlib,
+                               const std::string &module_path,
+                               const std::string &name) {
+    if (!from_stdlib) return false;
+    static const std::unordered_map<std::string,
+                                    std::unordered_set<std::string>>
+        kModuleToRecords = {
+            {"regex", {"Match"}},
+        };
+    auto it = kModuleToRecords.find(module_path);
+    if (it == kModuleToRecords.end()) return false;
+    return it->second.count(name) > 0;
 }
 
 static ExportableKind getExportableKind(const StmtNode &stmt) {
@@ -268,6 +307,26 @@ static void extractDefinitions(Program &source, Program &dest,
                     detail += import_path;
                     detail += "': intrinsics cannot be re-bound (tracked in #1725)";
                     throw std::runtime_error(makeImportError(line, detail));
+                }
+                continue;
+            }
+            // #1888: C++-registered resource kind (File / TcpListener / ...).
+            if (isCppResourceKind(from_stdlib, import_path, name)) {
+                if (item.alias.has_value()) {
+                    SourceLocation alias_loc{line, 1, file_id};
+                    dest.push_back(makeAliasBinding(ExportableKind::TypeAlias,
+                                                    name, *item.alias,
+                                                    alias_loc));
+                }
+                continue;
+            }
+            // #1888: C++-registered builtin record (Match — see codegen.cpp:52).
+            if (isCppBuiltinRecord(from_stdlib, import_path, name)) {
+                if (item.alias.has_value()) {
+                    SourceLocation alias_loc{line, 1, file_id};
+                    dest.push_back(makeAliasBinding(ExportableKind::Record,
+                                                    name, *item.alias,
+                                                    alias_loc));
                 }
                 continue;
             }
@@ -791,6 +850,26 @@ Program ModuleLoader::resolveImports(Program &prog, const std::string &referrer_
                                 detail += imp.module_path;
                                 detail += "': intrinsics cannot be re-bound (tracked in #1725)";
                                 throw std::runtime_error(makeImportError(imp.loc.line, detail));
+                            }
+                            continue;
+                        }
+                        // #1888: C++-registered resource kind cache-hit branch.
+                        if (isCppResourceKind(rp.from_stdlib, imp.module_path, name)) {
+                            if (item.alias.has_value()) {
+                                SourceLocation alias_loc{imp.loc.line, 1, imp.loc.file_id};
+                                result.push_back(makeAliasBinding(
+                                    ExportableKind::TypeAlias, name,
+                                    *item.alias, alias_loc));
+                            }
+                            continue;
+                        }
+                        // #1888: C++-registered builtin record cache-hit branch.
+                        if (isCppBuiltinRecord(rp.from_stdlib, imp.module_path, name)) {
+                            if (item.alias.has_value()) {
+                                SourceLocation alias_loc{imp.loc.line, 1, imp.loc.file_id};
+                                result.push_back(makeAliasBinding(
+                                    ExportableKind::Record, name,
+                                    *item.alias, alias_loc));
                             }
                             continue;
                         }

--- a/tests/spec/import_cpp_types.test.ry
+++ b/tests/spec/import_cpp_types.test.ry
@@ -1,0 +1,46 @@
+from testing import it, describe, expect, fail
+
+from io import open, close, readText, writeText, deleteFile, File
+from thread import lockNew, lockAcquire, lockRelease, lockFree, Lock
+from regex import regexFindAll, Match
+
+record MatchHolder:
+  m: Match
+
+@describe("import of C++-registered types (#1888)")
+fn importCppTypesTests():
+  @it("should use imported File type as function parameter annotation")
+  fn shouldUseImportedFileTypeAsFunctionParameterAnnotation():
+    case writeText("/tmp/ry_import_cpp_types_io.txt", "hello"):
+      Ok(_): expect(true).toEq(true)
+      Err(e): fail("write failed: " + e.message)
+    fn closeFile(f: File) -> Unit:
+      close(f)
+    case open("/tmp/ry_import_cpp_types_io.txt", "r"):
+      Ok(f):
+        closeFile(f)
+        expect(true).toEq(true)
+      Err(e): fail("open failed: " + e.message)
+    case deleteFile("/tmp/ry_import_cpp_types_io.txt"):
+      Ok(_): expect(true).toEq(true)
+      Err(e): fail("delete failed: " + e.message)
+
+  @it("should use imported Lock type as function parameter annotation")
+  fn shouldUseImportedLockTypeAsFunctionParameterAnnotation():
+    fn acquireAndRelease(l: Lock) -> bool:
+      case lockAcquire(l):
+        Ok(_):
+          case lockRelease(l):
+            Ok(_): return true
+            Err(_): return false
+        Err(_): return false
+    l = lockNew()
+    expect(acquireAndRelease(l)).toEq(true)
+    lockFree(l)
+
+  @it("should use imported Match record from regex as field type")
+  fn shouldUseImportedMatchRecordAsFieldType():
+    matches: List<Match> = regexFindAll("abc 123 def 456", "[0-9]+")
+    expect(len(matches)).toEq(2)
+    holder = MatchHolder(matches[0])
+    expect(holder.m.full).toEq("123")

--- a/tests/spec/import_cpp_types_alias.test.ry
+++ b/tests/spec/import_cpp_types_alias.test.ry
@@ -1,0 +1,62 @@
+from testing import it, describe, expect, fail
+
+from io import open, close, writeText, deleteFile, File as MyFile
+from thread import lockNew, lockAcquire, lockRelease, lockFree, Lock as MyLock
+from regex import regexFindAll, Match as M
+
+record MHolder:
+  m: M
+
+@describe("aliased import of C++-registered types (#1888)")
+fn importCppTypesAliasTests():
+  @it("should not leak when Ok(f) binds a Result<MyFile, Error> with aliased element (#1888 Task 4a)")
+  fn shouldNotLeakWhenOkBindsAliasedResultElement():
+    case writeText("/tmp/ry_import_cpp_types_alias.txt", "hi"):
+      Ok(_): expect(true).toEq(true)
+      Err(e): fail("write failed: " + e.message)
+    r: Result<MyFile, Error> = open("/tmp/ry_import_cpp_types_alias.txt", "r")
+    case r:
+      Ok(f):
+        close(f)
+        expect(true).toEq(true)
+      Err(e):
+        fail("open failed: " + e.message)
+    case deleteFile("/tmp/ry_import_cpp_types_alias.txt"):
+      Ok(_): expect(true).toEq(true)
+      Err(e): fail("delete failed: " + e.message)
+
+  @it("should accept aliased MyFile as function parameter type")
+  fn shouldAcceptAliasedMyFileAsFunctionParameterType():
+    fn closer(f: MyFile) -> Unit:
+      close(f)
+    case writeText("/tmp/ry_import_cpp_types_alias2.txt", "yo"):
+      Ok(_): expect(true).toEq(true)
+      Err(e): fail("write failed: " + e.message)
+    case open("/tmp/ry_import_cpp_types_alias2.txt", "r"):
+      Ok(f):
+        closer(f)
+        expect(true).toEq(true)
+      Err(e): fail("open failed: " + e.message)
+    case deleteFile("/tmp/ry_import_cpp_types_alias2.txt"):
+      Ok(_): expect(true).toEq(true)
+      Err(e): fail("delete failed: " + e.message)
+
+  @it("should use aliased Lock as function parameter type")
+  fn shouldUseAliasedLockAsFunctionParameterType():
+    fn acquireRelease(l: MyLock) -> bool:
+      case lockAcquire(l):
+        Ok(_):
+          case lockRelease(l):
+            Ok(_): return true
+            Err(_): return false
+        Err(_): return false
+    l = lockNew()
+    expect(acquireRelease(l)).toEq(true)
+    lockFree(l)
+
+  @it("should use aliased Match record as record field type")
+  fn shouldUseAliasedMatchRecordAsRecordFieldType():
+    matches: List<M> = regexFindAll("xyz 42 abc 99", "[0-9]+")
+    expect(len(matches)).toEq(2)
+    holder = MHolder(matches[0])
+    expect(holder.m.full).toEq("42")

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -2176,6 +2176,177 @@ TEST_F(ImportTest, QualifiedImportUserDefinedRecordConstructor) {
         "print(p.y)\n"), "3\n4\n");
 }
 
+// ===== #1888: import of C++-registered resource kinds and builtin records =====
+//
+// Resource kinds (File / TcpListener / Thread / ...) and the builtin record
+// Match (regex) are registered programmatically in C++ rather than declared
+// in their stdlib `.ry` files. `from io import File` etc. must resolve
+// because the names are semantically part of those modules even though
+// `extractDefinitions` cannot see them via AST scan.
+TEST_F(ImportTest, FromCppResourceKindImportsResolve) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    struct Case { const char *mod; const char *type; };
+    const Case cases[] = {
+        {"io", "File"},
+        {"net", "TcpListener"},
+        {"net", "TcpStream"},
+        {"http", "TlsStream"},
+        {"http", "HttpRequest"},
+        {"http", "HttpResponse"},
+        {"http", "HttpClientResponse"},
+        {"thread", "Thread"},
+        {"thread", "Lock"},
+        {"thread", "RWLock"},
+        {"thread", "Semaphore"},
+        {"thread", "Barrier"},
+        {"thread", "AtomicInt"},
+        {"thread", "AtomicBool"},
+    };
+    for (const auto &c : cases) {
+        std::string src = std::string("from ") + c.mod + " import " + c.type + "\n";
+        EXPECT_NO_THROW({
+            resolveImportsOnly(src, tmp_dir_.string(), search_paths);
+        }) << "case: " << src;
+    }
+}
+
+TEST_F(ImportTest, FromRegexImportMatchResolves) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_NO_THROW({
+        resolveImportsOnly(
+            "from regex import Match\n",
+            tmp_dir_.string(),
+            search_paths);
+    });
+}
+
+// Cache-hit boundary: a second import in the same loader must use the
+// `resolveImports` cache-hit branch (L778-803), which has its own throw site.
+TEST_F(ImportTest, FromCppResourceKindResolvesViaCacheHit) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_NO_THROW({
+        resolveImportsOnly(
+            "from io\n"
+            "from io import File\n",
+            tmp_dir_.string(),
+            search_paths);
+    });
+}
+
+TEST_F(ImportTest, FromRegexImportMatchResolvesViaCacheHit) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_NO_THROW({
+        resolveImportsOnly(
+            "from regex\n"
+            "from regex import Match\n",
+            tmp_dir_.string(),
+            search_paths);
+    });
+}
+
+// Negative: wrong module rejects (TcpListener belongs to "net", not "io").
+TEST_F(ImportTest, FromIoImportTcpListenerStillRejected) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_THROW({
+        resolveImportsOnly(
+            "from io import TcpListener\n",
+            tmp_dir_.string(),
+            search_paths);
+    }, std::runtime_error);
+}
+
+// Negative: unknown type still rejected.
+TEST_F(ImportTest, FromIoImportUnknownTypeStillRejected) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_THROW({
+        resolveImportsOnly(
+            "from io import NotARealType\n",
+            tmp_dir_.string(),
+            search_paths);
+    }, std::runtime_error);
+}
+
+// Negative: Error type is global, not associated with any module.
+// Importing it from io (or anywhere) must remain rejected.
+TEST_F(ImportTest, FromIoImportErrorStillRejected) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_THROW({
+        resolveImportsOnly(
+            "from io import Error\n",
+            tmp_dir_.string(),
+            search_paths);
+    }, std::runtime_error);
+}
+
+// Symmetry with isTestingIntrinsic's from_stdlib guard: a local `io.ry`
+// shadow must NOT bypass the C++ type check. Importing File from a local
+// io.ry that does not declare File should fail with the standard
+// "not found in module" diagnostic.
+TEST_F(ImportTest, FromLocalIoShadowDoesNotBypassCppTypeCheck) {
+    writeFile("io.ry", "fn dummy() -> int:\n    return 0\n");
+    EXPECT_THROW({
+        resolveImportsOnly(
+            "from io import File\n",
+            tmp_dir_.string(),
+            {});
+    }, std::runtime_error);
+}
+
+// Alias of C++-registered resource kind: `from io import File as MyFile`
+// must (a) parse, (b) reach codegen without throwing, and (c) allow the
+// aliased name to be used in a type annotation that propagates resource
+// metadata for ARC cleanup.
+TEST_F(ImportTest, ImportAliasResourceTypeWorks) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_NO_THROW({
+        runWithImports(
+            "from io import File as MyFile\n"
+            "fn use(f: MyFile) -> bool:\n"
+            "    return true\n",
+            tmp_dir_.string(),
+            search_paths);
+    });
+}
+
+TEST_F(ImportTest, ImportAliasResourceTypeWorksCacheHit) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_NO_THROW({
+        runWithImports(
+            "from io\n"
+            "from io import File as MyFile\n"
+            "fn use(f: MyFile) -> bool:\n"
+            "    return true\n",
+            tmp_dir_.string(),
+            search_paths);
+    });
+}
+
+// Alias of C++-registered builtin record (Match).
+TEST_F(ImportTest, ImportAliasBuiltinRecordWorks) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_NO_THROW({
+        runWithImports(
+            "from regex import Match as M\n"
+            "fn use(m: M) -> str:\n"
+            "    return m.full\n",
+            tmp_dir_.string(),
+            search_paths);
+    });
+}
+
+TEST_F(ImportTest, ImportAliasBuiltinRecordWorksCacheHit) {
+    auto search_paths = std::vector<std::string>{testingStdlibSearchPath()};
+    EXPECT_NO_THROW({
+        runWithImports(
+            "from regex\n"
+            "from regex import Match as M\n"
+            "fn use(m: M) -> str:\n"
+            "    return m.full\n",
+            tmp_dir_.string(),
+            search_paths);
+    });
+}
+
 // ===== type alias =====
 
 TEST_F(CodeGenTest, TypeAlias) {


### PR DESCRIPTION
## Summary

- `from io import File`, `from net import TcpListener`, `from thread import Lock`, `from regex import Match` 等、C++ で programmatic 登録された resource kind / builtin record を `from <mod> import <Type>` 形式で import できるようにした。`@native fn` の import と対称化。
- alias 形式 (`from io import File as MyFile`) も対応。pattern bind (`case open(...): Ok(f: MyFile)`) で ARC cleanup が外れる handle leak (`codegen_match.cpp:795` の hardcoded compare) も同時修正。
- hot-path 最適化: `registerResourceByTypeName` に lookup-first guard (`!type_aliases_.empty()`) を入れ、alias-free な圧倒的多数のケースで allocation-free を維持。naive な `resolveTypeAlias` 前置は無関連の latent flake (`collection_meta_propagation.test.ry`) を ~3% → ~63% に増幅させたため、教訓を `KNOWLEDGE.md` に記録 (詳細は side-finding 別 issue を後追い起票予定)。

Closes #1888

## Test plan

- [x] C++ tests (2503/2503 PASS)
- [x] Ry self-tests (203 files / 0 failures)
- [x] ASan + UBSan (C++ 2503 PASS, Ry spec 0 failures, Docker 経由)
- [x] TSan (C++ 2501/2503 PASS, 2 SKIP は意図的; Ry spec 0 failures, Docker 経由)
- [x] clang-tidy / cppcheck clean (Docker 経由)
- [x] Skipped §3.6 libFuzzer — no parser/lexer/json/utf8/string change
- [x] Skipped §3.6.5 tree-sitter — no grammar change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing C++-registered resource types from standard library modules (e.g., `from regex import Match`, `from io import File`).
  * Enabled type aliasing for imported C++-registered types with proper metadata handling.

* **Improvements**
  * Optimized type lookup in hot-path helper functions to reduce allocation overhead.

* **Tests**
  * Added comprehensive test coverage for importing and aliasing C++-registered resource types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1927?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->