### PR TITLE
feat(codegen): propagate any-element annotation to Map/List/Set literals (#1884)

### DIFF
--- a/.claude/rules/codegen-type-and-metadata.md
+++ b/.claude/rules/codegen-type-and-metadata.md
@@ -129,3 +129,23 @@ Three outcomes:
 - For `Option<T>` specifically, the dispatch is 3-way (NOT 2-way like `emitResultBranch`): `tag == Unit → Ok(None)` / `tag != Unit → recurse via tryUnwrapFromAny(anyVal, innerTy) → inner Ok wrap in Some(...) → inner Err prepend "expected null or " prefix`. Build three independent BBs (`none`, `inner_ok`, `inner_err`) and merge with one 3-incoming PHI on `resTy`. The error wording `load<Option<X>>: expected null or load<X>: ...` deliberately satisfies the test's `toContain("null") + toContain("JSON object")` simultaneous assertion when the source is a primitive (e.g. `42` with `Option<Record>` target).
 - `buildSomeValue(inner, optTy)` calls `tryRetainArcSource(inner)` internally when `inner` is `ptrTy_` — the recursive `tryUnwrapFromAny` already owns one refcount on the extracted Ok value, so the `Some(...)` arm does NOT double-retain (the existing tryRetainArcSource is the single retain the wrapper owes the caller). The same applies to `buildOkValue(rec)` on record / collection results: the field-by-field `InsertValue` build owns the refcount once per ARC-bearing field.
 - The complementary `share/std/json/json.ry` change is a one-line `v: T = a` → `v: T = a?` won't work (the `?` operator requires the LHS Result type to match the function's return Result type). Instead, the Ry-side `load<T>` does NOT need to change — `emitJsonLoad` in `codegen_call_json.cpp` directly emits the `tryUnwrapFromAny` call as part of the `load[T]` codegen and PHI-merges the parse-Err / unwrap-Err / unwrap-Ok paths into a single `Result<T, Error>` SSA value.
+
+### `Map<any, V>` is out of scope for the literal `any`-hint path; key-side must keep the strict same-type gate
+
+**Source**: #1884 (2026-05-27, feat — `Map<K, any>` / `List<any>` / `Set<any>` literal annotation propagation)
+**Tags**: codegen, any, map, literal, hint, rehash, hash-table, scope, strict-type-gate
+
+**Context**: #1884 added a `LiteralAnyHintGuard` RAII helper so that `m: Map<str, any> = {"a": 1, "b": "two", "c": true}` per-element-wraps via `wrapInAny` and skips the strict same-LLVM-type gate in `emitExprVariant(MapExpr / ListExpr / SetExpr)`. The hint structure has separate `map_key_any` / `map_value_any` flags, but **only the value side is wired**. The temptation is to extend the same wrap-skip to `Map<any, V>` for symmetry; this is unsafe.
+
+**Rule**: In both `computeLiteralAnyHintFromAnnot` and `computeLiteralAnyHintFromMeta` (the var-decl / function-local reassign + module-global reassign paths feed through these), force `hint.map_key_any = false` even when the annotation literally says `Map<any, V>`. Both helpers must agree — if only one keeps the gate closed, the reassign path leaks the unsafe wrap on its own. The map literal emitter then falls through to the strict same-LLVM-type key check, which is the user-visible error surface (`map keys must all have the same type`).
+
+**Why**:
+
+- The hash-table rehash dispatch (`__ry_ht_rehash_i64` / `__ry_ht_rehash_f64` / `__ry_ht_rehash_str`) has no 16-byte struct (`anyTy_`) variant. Picking any of the three would write keys at the wrong stride or hash bytes that overlap the tag.
+- The runtime lookup path (`emitMapKeyLookup`) has a linear-scan fallback for `StructType` keys via `__ry_any_eq`, so a populated `Map<any, V>` *would* be lookup-safe in isolation — but the literal-time bucket write hashes the key into a bucket that the lookup linear-scan would have to ignore entirely. There is no current code path that can produce a self-consistent `Map<any, V>` at literal-construction time.
+- The ARC story is also unaddressed for `anyTy_` keys carrying str / List / Map / Set / record / enum payloads (the default map dtor releases the LLVM-typed key slot, not the anyTy_ heap-box descriptor underneath).
+
+**How to apply**:
+
+- In `src/codegen_expr_literal.cpp` (`computeLiteralAnyHintFromAnnot`, `computeLiteralAnyHintFromMeta`), when the annotation matches `Map<K, V>` with `splitTypeArgs` returning 2 args, set `hint.map_value_any = (trimTypeNameSpaces(args[1]) == "any")` and **leave `hint.map_key_any` at its default `false`** — do NOT mirror the check on `args[0]`.
+- Negative tests live in `tests/test_codegen_stmt.cpp` (e.g. `MapKeyTypeMismatchUnderAnyAnnotationRejected`) and verify that `Map<any, V> = {1: "a", "two": "b"}` still produces the strict same-type error. If a future PR lifts this restriction, it must add (a) an `__ry_ht_rehash_any` runtime variant, (b) a bucket-write path that hashes through `__ry_any_hash`, and (c) a per-key ARC release path that dispatches on the inner tag.

--- a/changelog.d/1884-any-literal-annotation-propagation.md
+++ b/changelog.d/1884-any-literal-annotation-propagation.md
@@ -1,0 +1,24 @@
+### Added
+
+- Mixed-type literals for `Map<K, any>`, `List<any>`, and `Set<any>`
+  variable declarations and reassignments. Previously
+  `m: Map<str, any> = {"a": 1, "b": "two", "c": true}` failed at
+  codegen with `map values must all have the same type` because the
+  `MapExpr` / `ListExpr` / `SetExpr` emitters strictly required
+  identical LLVM types across elements and the annotation-driven
+  `wrapInAny` auto-wrap (which works for `x: any = 1`) was never
+  reached. A `LiteralAnyHintGuard` RAII helper, installed at the
+  three assignment-system call sites (var-decl, function-local
+  reassignment, module-global reassignment in `src/codegen_stmt.cpp`),
+  signals to the literal emitters that each element should be
+  individually wrapped via `wrapInAny` and that the strict
+  same-type gate should be skipped. Element-type metadata
+  (`list_elem_type_name` / `set_elem_type_name` /
+  `map_value_type_name`) is stamped as `"any"` on the literal header
+  so downstream destructor dispatch picks the right release path.
+  `Map<any, V>` (any-typed keys) is intentionally out of scope because
+  the rehash dispatch (`__ry_ht_rehash_i64` / `_f64` / `_str`) has no
+  16-byte struct variant; mixed-key annotations continue to be
+  rejected at the strict same-type check. `Map<str, int> = {...}` and
+  other concrete-element annotations continue to enforce strict type
+  equality. (#1884)

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -893,6 +893,27 @@ f: float = getValue()  # any(int) is unwrapped and promoted to float
 
 If the runtime type does not match the target type (e.g., unwrapping `any(str)` into an `int` variable), a **runtime error** occurs.
 
+#### Mixed-type literals in typed `any` collections
+
+When the annotation is `Map<K, any>` / `List<any>` / `Set<any>`, each element in a literal is individually wrapped into `any` during the declaration or reassignment — elements with different concrete types can coexist in the same literal:
+
+```ry
+m: Map<str, any> = {"a": 1, "b": "two", "c": true}   # int / str / bool values
+xs: List<any> = [1, "x", true]
+s:  Set<any>  = {1, "x", true}
+
+# Reassignment uses the same path
+m = {"k": 42, "v": false}
+```
+
+The wrap is only triggered by the `any` element annotation on the destination. With a concrete element annotation, the strict same-type check still applies:
+
+```ry
+# m: Map<str, int> = {"a": 1, "b": "two"}   # error: map values must all have the same type
+```
+
+`Map<any, V>` (any-typed keys) is currently out of scope; mixed-key literals continue to be rejected by the strict same-type check.
+
 ### Reassignment
 
 An `any` variable can be reassigned to a value of any supported type:

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -180,6 +180,23 @@ public:
     // leak into arbitrary sub-expressions (e.g., function arguments).
     llvm::Type *option_decl_annotation_inner_ = nullptr;
 
+    // Literal `any`-element hint (#1884). When set, Map/List/Set literal
+    // emitters wrap each element via wrapInAny on the active axes and stamp
+    // `*_type_name = "any"` on the resulting header metadata. Written by
+    // emitVarDecl / local-reassign / global-reassign when LHS annotation /
+    // existing metadata indicates `Map<K, any>` / `List<any>` / `Set<any>` /
+    // `Map<any, V>`. Each literal emitter snapshots this hint at entry, then
+    // immediately installs an empty hint via LiteralAnyHintGuard so nested
+    // sub-literals do not inherit the outer axis. Non-literal emitters do
+    // NOT read this field, so it cannot leak into arbitrary sub-expressions.
+    struct LiteralAnyHint {
+        bool list_elem_any = false;
+        bool set_elem_any = false;
+        bool map_key_any = false;
+        bool map_value_any = false;
+    };
+    LiteralAnyHint literal_any_hint_;
+
     // Compute an Option inner-type hint from a pair of branch-arm expressions.
     // Returns nullptr when no concrete inner type can be derived
     // (e.g., non-Option arms or placeholder-only outcomes).
@@ -266,6 +283,13 @@ public:
     static bool isMapTypeName(const std::string &typeName);
     static bool isSetTypeName(const std::string &typeName);
     static bool isCollectionTypeName(const std::string &typeName);
+
+    // #1884: derive literal_any_hint_ from an LHS annotation string
+    // (`List<any>` / `Set<any>` / `Map<any, V>` / `Map<K, any>`) or from an
+    // existing collection header's `*_type_name` metadata slots. Returns an
+    // all-false hint when the source does not have `any` on any axis.
+    LiteralAnyHint computeLiteralAnyHintFromAnnot(const std::string &annot);
+    LiteralAnyHint computeLiteralAnyHintFromMeta(llvm::Value *ptr);
 
     // ======== Weak References ========
     static bool isWeakTypeName(const std::string &typeName);

--- a/include/ry/codegen_guards.hpp
+++ b/include/ry/codegen_guards.hpp
@@ -37,6 +37,22 @@ private:
     llvm::Type *saved_;
 };
 
+class LiteralAnyHintGuard {
+public:
+    explicit LiteralAnyHintGuard(CodeGen &cg, CodeGen::LiteralAnyHint hint)
+        : cg_(cg), saved_(cg.literal_any_hint_) {
+        cg_.literal_any_hint_ = hint;
+    }
+
+    ~LiteralAnyHintGuard() { cg_.literal_any_hint_ = saved_; }
+    LiteralAnyHintGuard(const LiteralAnyHintGuard &) = delete;
+    LiteralAnyHintGuard &operator=(const LiteralAnyHintGuard &) = delete;
+
+private:
+    CodeGen &cg_;
+    CodeGen::LiteralAnyHint saved_;
+};
+
 class ParallelForScope {
 public:
     explicit ParallelForScope(CodeGen &cg) : cg_(cg) { ++cg_.parallel_for_depth_; }

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -278,21 +278,79 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<TupleExpr> &e) {
     return result;
 }
 
+CodeGen::LiteralAnyHint CodeGen::computeLiteralAnyHintFromAnnot(const std::string &annot) {
+    LiteralAnyHint hint;
+    std::string resolved = resolveTypeAlias(annot);
+    if (isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
+        std::string inner = trimTypeNameSpaces(resolved.substr(5, resolved.size() - 6));
+        if (inner == "any")
+            hint.list_elem_any = true;
+    } else if (isSetTypeName(resolved) && resolved.size() >= 6 && resolved.back() == '>') {
+        std::string inner = trimTypeNameSpaces(resolved.substr(4, resolved.size() - 5));
+        if (inner == "any")
+            hint.set_elem_any = true;
+    } else if (isMapTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
+        std::string inner = resolved.substr(4, resolved.size() - 5);
+        auto args = splitTypeArgs(inner);
+        if (args.size() == 2) {
+            // Map<any, V> is intentionally out of scope for #1884: the rehash
+            // dispatch (`__ry_ht_rehash_i64` / `_f64` / `_str`) has no anyTy_
+            // (16B struct) variant. Lookup falls back to linear scan and is
+            // safe, but the literal-time rehash would write wrong hashes into
+            // the bucket array. Forcing map_key_any=false keeps the strict
+            // same-type key check; only Map<str, any> / Map<int, any> etc.
+            // (concrete key, any value) are widened.
+            if (trimTypeNameSpaces(args[1]) == "any")
+                hint.map_value_any = true;
+        }
+    }
+    return hint;
+}
+
+CodeGen::LiteralAnyHint CodeGen::computeLiteralAnyHintFromMeta(llvm::Value *ptr) {
+    LiteralAnyHint hint;
+    auto *meta = getMeta(ptr);
+    if (!meta)
+        return hint;
+    if (meta->list_elem_type_name == "any")
+        hint.list_elem_any = true;
+    if (meta->set_elem_type_name == "any")
+        hint.set_elem_any = true;
+    // map_key_any intentionally not propagated — Map<any, V> is out of scope
+    // for #1884 (see computeLiteralAnyHintFromAnnot).
+    if (meta->map_value_type_name == "any")
+        hint.map_value_any = true;
+    return hint;
+}
+
 llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
     if (e->elements.empty())
         codegenError("empty list literal requires type annotation (not yet supported)");
 
+    // #1884: snapshot any-element hint then immediately install an empty hint
+    // so nested sub-literals do not inherit the outer axis.
+    const bool wrapElemAsAny = literal_any_hint_.list_elem_any;
+    LiteralAnyHintGuard innerHintGuard(*this, LiteralAnyHint{});
+
     // Evaluate all elements
     std::vector<llvm::Value*> vals;
     vals.reserve(e->elements.size());
-    for (auto &el : e->elements)
-        vals.push_back(emitExpr(*el));
+    for (auto &el : e->elements) {
+        llvm::Value *v = emitExpr(*el);
+        if (wrapElemAsAny && v->getType() != anyTy_)
+            v = wrapInAny(v);
+        vals.push_back(v);
+    }
 
-    // Check all elements have the same type
+    // Check all elements have the same type (skipped when wrapping into any —
+    // wrapInAny normalises every element to anyTy_, so a per-element check is
+    // redundant).
     llvm::Type *elemTy = vals[0]->getType();
-    for (size_t i = 1; i < vals.size(); ++i) {
-        if (vals[i]->getType() != elemTy)
-            codegenError("list elements must all have the same type");
+    if (!wrapElemAsAny) {
+        for (size_t i = 1; i < vals.size(); ++i) {
+            if (vals[i]->getType() != elemTy)
+                codegenError("list elements must all have the same type");
+        }
     }
 
     int64_t count = static_cast<int64_t>(vals.size());
@@ -429,6 +487,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<ListExpr> &e) {
             getOrCreateMeta(headerPtr).list_elem_fn_type_info = elemFnTypeInfo;
     }
 
+    // #1884: stamp list_elem_type_name = "any" for List<any> literals.
+    // Elements are stored as anyTy_ (struct, not ptrTy_), so the ptr-element
+    // branch above does not run.
+    if (wrapElemAsAny)
+        getOrCreateMeta(headerPtr).list_elem_type_name = "any";
+
     return headerPtr;
 }
 
@@ -436,25 +500,47 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
     if (e->keys.empty())
         codegenError("empty map literal requires type annotation");
 
+    // #1884: snapshot any-element hint then immediately install an empty hint
+    // so nested sub-literals do not inherit the outer axes.
+    const bool wrapKeyAsAny = literal_any_hint_.map_key_any;
+    const bool wrapValAsAny = literal_any_hint_.map_value_any;
+    LiteralAnyHintGuard innerHintGuard(*this, LiteralAnyHint{});
+
     // Evaluate all keys and values
     std::vector<llvm::Value*> keyVals, valVals;
     keyVals.reserve(e->keys.size());
     valVals.reserve(e->values.size());
-    for (auto &k : e->keys) keyVals.push_back(emitExpr(*k));
-    for (auto &v : e->values) valVals.push_back(emitExpr(*v));
-
-    // Check all keys have the same type
-    llvm::Type *keyTy = keyVals[0]->getType();
-    for (size_t i = 1; i < keyVals.size(); ++i) {
-        if (keyVals[i]->getType() != keyTy)
-            codegenError("map keys must all have the same type");
+    for (auto &k : e->keys) {
+        llvm::Value *v = emitExpr(*k);
+        if (wrapKeyAsAny && v->getType() != anyTy_)
+            v = wrapInAny(v);
+        keyVals.push_back(v);
+    }
+    for (auto &v : e->values) {
+        llvm::Value *val = emitExpr(*v);
+        if (wrapValAsAny && val->getType() != anyTy_)
+            val = wrapInAny(val);
+        valVals.push_back(val);
     }
 
-    // Check all values have the same type
+    // Check all keys have the same type (skipped on the any axis — wrapInAny
+    // normalises every key to anyTy_).
+    llvm::Type *keyTy = keyVals[0]->getType();
+    if (!wrapKeyAsAny) {
+        for (size_t i = 1; i < keyVals.size(); ++i) {
+            if (keyVals[i]->getType() != keyTy)
+                codegenError("map keys must all have the same type");
+        }
+    }
+
+    // Check all values have the same type (skipped on the any axis — wrapInAny
+    // normalises every value to anyTy_).
     llvm::Type *valTy = valVals[0]->getType();
-    for (size_t i = 1; i < valVals.size(); ++i) {
-        if (valVals[i]->getType() != valTy)
-            codegenError("map values must all have the same type");
+    if (!wrapValAsAny) {
+        for (size_t i = 1; i < valVals.size(); ++i) {
+            if (valVals[i]->getType() != valTy)
+                codegenError("map values must all have the same type");
+        }
     }
 
     int64_t count = static_cast<int64_t>(keyVals.size());
@@ -568,6 +654,14 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<MapExpr> &e) {
     else if (valTy == ptrTy_ && (anyValIsStr || anyValIsStrLike))
         getOrCreateMeta(headerPtr).map_value_type_name = "str";
 
+    // #1884: stamp map_key_type_name / map_value_type_name = "any" for
+    // Map<any, V> / Map<K, any> literals. Keys/values are stored as anyTy_
+    // (struct, not ptrTy_), so the ptr-based branches above do not fire.
+    if (wrapKeyAsAny)
+        getOrCreateMeta(headerPtr).map_key_type_name = "any";
+    if (wrapValAsAny)
+        getOrCreateMeta(headerPtr).map_value_type_name = "any";
+
     return headerPtr;
 }
 
@@ -578,17 +672,29 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<SetExpr> &e) {
         codegenError("empty set literal requires type annotation");
     }
 
+    // #1884: snapshot any-element hint then immediately install an empty hint
+    // so nested sub-literals do not inherit the outer axis.
+    const bool wrapElemAsAny = literal_any_hint_.set_elem_any;
+    LiteralAnyHintGuard innerHintGuard(*this, LiteralAnyHint{});
+
     // Evaluate all elements
     std::vector<llvm::Value*> vals;
     vals.reserve(e->elements.size());
-    for (auto &el : e->elements)
-        vals.push_back(emitExpr(*el));
+    for (auto &el : e->elements) {
+        llvm::Value *v = emitExpr(*el);
+        if (wrapElemAsAny && v->getType() != anyTy_)
+            v = wrapInAny(v);
+        vals.push_back(v);
+    }
 
-    // Check all elements have the same type
+    // Check all elements have the same type (skipped on the any axis —
+    // wrapInAny normalises every element to anyTy_).
     llvm::Type *elemTy = vals[0]->getType();
-    for (size_t i = 1; i < vals.size(); ++i) {
-        if (vals[i]->getType() != elemTy)
-            codegenError("set elements must all have the same type");
+    if (!wrapElemAsAny) {
+        for (size_t i = 1; i < vals.size(); ++i) {
+            if (vals[i]->getType() != elemTy)
+                codegenError("set elements must all have the same type");
+        }
     }
 
     int64_t count = static_cast<int64_t>(vals.size());
@@ -700,6 +806,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<SetExpr> &e) {
 
     if (elemTy == ptrTy_ && setElemName.empty() && (anyElemIsStr || anyElemIsStrLike))
         getOrCreateMeta(headerPtr).set_elem_type_name = "str";
+
+    // #1884: stamp set_elem_type_name = "any" for Set<any> literals. Elements
+    // are stored as anyTy_ (struct, not ptrTy_), so the ptr-element branch
+    // above does not run.
+    if (wrapElemAsAny)
+        getOrCreateMeta(headerPtr).set_elem_type_name = "any";
 
     return headerPtr;
 }

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -1348,6 +1348,12 @@ void CodeGen::emitStmt(AssignStmt &s) {
     if (isImmutable(s.name))
         codegenError("cannot reassign @const variable: " + s.name);
 
+    // #1884: install the literal-any hint BEFORE the compound-assignment
+    // early-return so `xs: List<any> = []; xs += [1, "x", true]` (and the
+    // analogous Map / Set compound forms) wrap each RHS literal element
+    // individually instead of failing the strict same-type gate.
+    LiteralAnyHintGuard localAnyHintGuard(*this, computeLiteralAnyHintFromMeta(ptr));
+
     // Compound assignment resolution: operator+= → operator+ → built-in.
     // Shares the load-modify-store core with the chained LHS forms (#812)
     // via `applyCompoundOp` so the operator resolution order stays in sync.
@@ -1435,11 +1441,6 @@ void CodeGen::emitStmt(AssignStmt &s) {
             localOptInner = llvm::cast<llvm::StructType>(varTy)->getElementType(1);
     }
     DeclAnnotationInnerGuard localNoneGuard(*this, localOptInner);
-
-    // #1884: when the local variable's collection metadata pins an axis to
-    // `any`, push a literal-any hint so a mixed-type literal RHS wraps each
-    // element individually instead of erroring on type mismatch.
-    LiteralAnyHintGuard localAnyHintGuard(*this, computeLiteralAnyHintFromMeta(ptr));
 
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();
@@ -1665,6 +1666,12 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
     // path reuses `ptr` throughout).
     llvm::Value *storagePtr = loadModuleGlobalStorage(b, s.name);
 
+    // #1884: install the literal-any hint BEFORE the compound-assignment
+    // early-return (mirrors the local-alloca path) so compound forms like
+    // `m += {"a": 1, "b": "two"}` on a `Map<str, any>` module-global also
+    // per-element wrap the RHS literal.
+    LiteralAnyHintGuard globalAnyHintGuard(*this, computeLiteralAnyHintFromMeta(anchor));
+
     // Compound assignment shares the resolution order with the local
     // AssignStmt and chained LHS paths via `applyCompoundOp` (#812).
     if (s.compound_op) {
@@ -1734,11 +1741,6 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
         ? llvm::cast<llvm::StructType>(valueTy)->getElementType(1)
         : nullptr;
     DeclAnnotationInnerGuard globalNoneGuard(*this, globalOptInner);
-
-    // #1884: when the module-global's collection metadata pins an axis to
-    // `any`, push a literal-any hint so a mixed-type literal RHS wraps each
-    // element individually (mirrors the local-alloca path).
-    LiteralAnyHintGuard globalAnyHintGuard(*this, computeLiteralAnyHintFromMeta(anchor));
 
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -536,6 +536,15 @@ void CodeGen::emitVarDecl(const std::string &name,
     }
     DeclAnnotationInnerGuard noneHintGuard(*this, annotOptionInner);
 
+    // #1884: when LHS annotation is `List<any>` / `Set<any>` /
+    // `Map<any, V>` / `Map<K, any>`, push a literal-any hint so the RHS
+    // literal emitter per-element wrap into any (allowing mixed-type
+    // literals like `m: Map<str, any> = {"a": 1, "b": "two"}`).
+    LiteralAnyHint anyHint;
+    if (annot)
+        anyHint = computeLiteralAnyHintFromAnnot(*annot);
+    LiteralAnyHintGuard anyHintGuard(*this, anyHint);
+
     llvm::Value *val = emitExpr(value);
     llvm::Type *newTy = val->getType();
     // #1697: Capture the pre-wrap source-level type name so that, when the
@@ -1427,6 +1436,11 @@ void CodeGen::emitStmt(AssignStmt &s) {
     }
     DeclAnnotationInnerGuard localNoneGuard(*this, localOptInner);
 
+    // #1884: when the local variable's collection metadata pins an axis to
+    // `any`, push a literal-any hint so a mixed-type literal RHS wraps each
+    // element individually instead of erroring on type mismatch.
+    LiteralAnyHintGuard localAnyHintGuard(*this, computeLiteralAnyHintFromMeta(ptr));
+
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();
 
@@ -1720,6 +1734,11 @@ void CodeGen::emitModuleGlobalWriteThrough(const ModuleBinding &b, AssignStmt &s
         ? llvm::cast<llvm::StructType>(valueTy)->getElementType(1)
         : nullptr;
     DeclAnnotationInnerGuard globalNoneGuard(*this, globalOptInner);
+
+    // #1884: when the module-global's collection metadata pins an axis to
+    // `any`, push a literal-any hint so a mixed-type literal RHS wraps each
+    // element individually (mirrors the local-alloca path).
+    LiteralAnyHintGuard globalAnyHintGuard(*this, computeLiteralAnyHintFromMeta(anchor));
 
     llvm::Value *val = emitExpr(*s.value);
     llvm::Type *newTy = val->getType();

--- a/tests/spec/any.test.ry
+++ b/tests/spec/any.test.ry
@@ -465,6 +465,15 @@ fn anyElementInMapTests():
     m["x"] = 1
     k: any = "x"
     expect(k in m).toEq(true)
+  @it("should accept mixed value types in Map<str, any> literal")
+  fn shouldAcceptMixedValueTypesInMapStrAnyLiteral():
+    m: Map<str, any> = {"a": 1, "b": "two", "c": true}
+    vi: int = m["a"]
+    vs: str = m["b"]
+    vb: bool = m["c"]
+    expect(vi).toEq(1)
+    expect(vs).toEq("two")
+    expect(vb).toEq(true)
 
 @describe("any element in List")
 fn anyElementInListTests():
@@ -550,6 +559,25 @@ fn anyElementInListTests():
     xs: List<int> = [1, 2, 3]
     v: any = 2
     expect(v in xs).toEq(true)
+  @it("should accept mixed element types in List<any> literal")
+  fn shouldAcceptMixedElementTypesInListAnyLiteral():
+    xs: List<any> = [1, "x", true]
+    vi: int = xs[0]
+    vs: str = xs[1]
+    vb: bool = xs[2]
+    expect(vi).toEq(1)
+    expect(vs).toEq("x")
+    expect(vb).toEq(true)
+  @it("should accept already-any element mixed with concrete values in List<any> literal")
+  fn shouldAcceptAlreadyAnyElementInListAnyLiteral():
+    a: any = 42
+    xs: List<any> = [a, "x", true]
+    vi: int = xs[0]
+    vs: str = xs[1]
+    vb: bool = xs[2]
+    expect(vi).toEq(42)
+    expect(vs).toEq("x")
+    expect(vb).toEq(true)
 
 @describe("any element in Set")
 fn anyElementInSetTests():
@@ -608,6 +636,13 @@ fn anyElementInSetTests():
     add(s, 5)
     v: any = 5
     expect(v in s).toEq(true)
+  @it("should accept mixed element types in Set<any> literal")
+  fn shouldAcceptMixedElementTypesInSetAnyLiteral():
+    s: Set<any> = {1, "x", true}
+    expect(s).toHaveLen(3)
+    expect(1 in s).toEq(true)
+    expect("x" in s).toEq(true)
+    expect(true in s).toEq(true)
 
 @describe("any holds collection")
 fn anyHoldsCollectionTests():
@@ -1110,3 +1145,37 @@ fn anyHoldsEnumTests():
           Ok(n): expect(n).toEq(42)
           Err(_): fail("expected inner Ok")
       Err(_): fail("expected outer Ok")
+
+mixedAnyMapGlobal: Map<str, any> = {}
+
+@describe("mixed any literal reassignment")
+fn mixedAnyLiteralReassignmentTests():
+  @it("should reassign local Map<str, any> with mixed value types via literal")
+  fn shouldReassignLocalMapStrAnyWithMixedLiteral():
+    m: Map<str, any> = {}
+    m = {"a": 1, "b": "two", "c": true}
+    vi: int = m["a"]
+    vs: str = m["b"]
+    vb: bool = m["c"]
+    expect(vi).toEq(1)
+    expect(vs).toEq("two")
+    expect(vb).toEq(true)
+  @it("should reassign local List<any> with mixed element types via literal")
+  fn shouldReassignLocalListAnyWithMixedLiteral():
+    xs: List<any> = []
+    xs = [1, "x", true]
+    vi: int = xs[0]
+    vs: str = xs[1]
+    vb: bool = xs[2]
+    expect(vi).toEq(1)
+    expect(vs).toEq("x")
+    expect(vb).toEq(true)
+  @it("should reassign module-global Map<str, any> with mixed value types via literal")
+  fn shouldReassignModuleGlobalMapStrAnyWithMixedLiteral():
+    mixedAnyMapGlobal = {"a": 1, "b": "two", "c": true}
+    vi: int = mixedAnyMapGlobal["a"]
+    vs: str = mixedAnyMapGlobal["b"]
+    vb: bool = mixedAnyMapGlobal["c"]
+    expect(vi).toEq(1)
+    expect(vs).toEq("two")
+    expect(vb).toEq(true)

--- a/tests/spec/any.test.ry
+++ b/tests/spec/any.test.ry
@@ -1179,3 +1179,37 @@ fn mixedAnyLiteralReassignmentTests():
     expect(vi).toEq(1)
     expect(vs).toEq("two")
     expect(vb).toEq(true)
+  @it("should reassign local Set<any> with mixed element types via literal")
+  fn shouldReassignLocalSetAnyWithMixedLiteral():
+    s: Set<any> = {}
+    s = {1, "x", true}
+    expect(s).toHaveLen(3)
+    expect(1 in s).toEq(true)
+    expect("x" in s).toEq(true)
+    expect(true in s).toEq(true)
+  @it("should compound-assign local List<any> with mixed element types via literal")
+  fn shouldCompoundAssignLocalListAnyWithMixedLiteral():
+    xs: List<any> = []
+    xs += [1, "x", true]
+    vi: int = xs[0]
+    vs: str = xs[1]
+    vb: bool = xs[2]
+    expect(vi).toEq(1)
+    expect(vs).toEq("x")
+    expect(vb).toEq(true)
+  @it("should compound-assign local Map<str, any> with mixed value types via literal")
+  fn shouldCompoundAssignLocalMapStrAnyWithMixedLiteral():
+    m: Map<str, any> = {}
+    m += {"a": 1, "b": "two"}
+    vi: int = m["a"]
+    vs: str = m["b"]
+    expect(vi).toEq(1)
+    expect(vs).toEq("two")
+  @it("should compound-assign local Set<any> with mixed element types via literal")
+  fn shouldCompoundAssignLocalSetAnyWithMixedLiteral():
+    s: Set<any> = {}
+    s += {1, "x", true}
+    expect(s).toHaveLen(3)
+    expect(1 in s).toEq(true)
+    expect("x" in s).toEq(true)
+    expect(true in s).toEq(true)

--- a/tests/test_codegen_stmt.cpp
+++ b/tests/test_codegen_stmt.cpp
@@ -2796,3 +2796,33 @@ TEST_F(CodeGenTest, AnyToTypedSetConcreteSourceMismatchRejected) {
         "t: Set<str> = a\n",
         "load");
 }
+
+// #1884: when LHS does NOT pin a `*_any` axis, the strict per-element type
+// check must still fire. Guards against accidental hint leakage that would
+// silently legalise mixed-type literals under typed annotations.
+TEST_F(CodeGenTest, MapValueTypeMismatchUnderTypedAnnotationRejected) {
+    expectCompileError(
+        "m: Map<str, int> = {\"a\": 1, \"b\": \"two\"}\n",
+        "map values must all have the same type");
+}
+
+TEST_F(CodeGenTest, ListElementTypeMismatchUnderTypedAnnotationRejected) {
+    expectCompileError(
+        "xs: List<int> = [1, \"x\"]\n",
+        "list elements must all have the same type");
+}
+
+TEST_F(CodeGenTest, SetElementTypeMismatchUnderTypedAnnotationRejected) {
+    expectCompileError(
+        "s: Set<int> = {1, \"x\"}\n",
+        "set elements must all have the same type");
+}
+
+// Map<any, V> is intentionally out of scope for #1884: the rehash dispatch has
+// no anyTy_ (16B struct) variant. Mixed key types under Map<any, V> must
+// continue to fail at the strict same-type check.
+TEST_F(CodeGenTest, MapKeyTypeMismatchUnderAnyAnnotationRejected) {
+    expectCompileError(
+        "m: Map<any, str> = {1: \"a\", \"two\": \"b\"}\n",
+        "map keys must all have the same type");
+}


### PR DESCRIPTION
## Summary

- `m: Map<str, any> = {"a": 1, "b": "two", "c": true}` / `xs: List<any> = [1, "x", true]` / `s: Set<any> = {1, "x", true}` の混在型リテラルを var-decl / 関数ローカル再代入 / モジュールグローバル再代入の 3 サイトで許容
- `LiteralAnyHintGuard` RAII が `wrapInAny` の per-element 適用と厳密同型ゲートのスキップをリテラル emitter に伝達。`*_type_name = "any"` をヘッダーに stamp して destructor dispatch を担保
- `Map<any, V>` は rehash dispatch に anyTy_ variant が無いためスコープ外。`computeLiteralAnyHintFromAnnot` / `computeLiteralAnyHintFromMeta` 両方で `map_key_any = false` を強制し、従来の厳密同型キーエラーを維持

## Test plan

- [x] Ry selftest: `./build/ry test -p` (201/201)
- [x] C++ test: `./build/ry_tests` (2495/2495)
- [x] ASan + UBSan: `./build-asan/ry test -p` + `./build-asan/ry_tests`
- [x] TSan: `./build-tsan/ry test -p` + `./build-tsan/ry_tests`
- [x] libFuzzer `fuzz_parser` (Docker, 60s/46225 runs, 0 crash)
- [x] 既存の `Map<str, any> = {}` 空リテラル経路 / `Map<str, int> = {...}` 厳密型注釈経路の回帰なし
- [x] `Map<any, V>` 混在キーは厳密ゲートで拒否 (`MapKeyTypeMismatchUnderAnyAnnotationRejected`)

Closes #1884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mixed-type literals now work for List<any>, Set<any>, and Map<K, any>, allowing different concrete element types in the same literal and during reassignment.

* **Behavior**
  * Concrete-typed collections (e.g., Map<str,int>, List<int>, Set<int>) still require uniform element types; mixed map keys remain unsupported.

* **Documentation**
  * Reference docs updated to clarify mixed-literal behavior with any-typed collection elements.

* **Tests**
  * New tests cover mixed literals, reassignment, compound ops, and rejection cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1929?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->