### PR TITLE
chore(skills): translate stdlib-module-add SKILL.md to English

### DIFF
--- a/.claude/skills/stdlib-module-add/SKILL.md
+++ b/.claude/skills/stdlib-module-add/SKILL.md
@@ -1,75 +1,73 @@
 ---
 name: stdlib-module-add
-description: 新しい標準ライブラリモジュール (@native) の追加手順 (5 ステップ + 定数追加 + 既存モジュールへの関数追加)。Use when stdlib モジュール追加 / 新しい標準ライブラリ / @native 宣言 / runtime_<mod>.cpp / add_ry_native_lib / 定数の追加 / share/std/<mod>/<mod>.ry を扱うとき。
+description: Procedure for adding a new stdlib module (`@native`) — 5 steps plus constant-addition and extending existing modules. Use when adding a stdlib module, declaring `@native`, editing `runtime_<mod>.cpp`, calling `add_ry_native_lib`, adding constants, or touching `share/std/<mod>/<mod>.ry`. Also fires on Japanese triggers stdlib モジュール追加, 新しい標準ライブラリ, @native 宣言, 定数の追加.
 allowed-tools: Read, Grep, Glob, Bash
 ---
 
 # Stdlib Module Add
 
-Procedure for adding a new standard library module (e.g. `crypto`) to the ry project, plus the recipes for adding constants and extending existing modules.
+Procedure for adding a new standard library module (e.g. `crypto`) to ry, plus recipes for constants and extending existing modules.
 
-> **Source-of-truth note**: previously in `AGENTS.md`; relocated by #1384.
+> Relocated from `AGENTS.md` by #1384.
 >
-> **Terminology** (per `docs/reference/glossary.md`, introduced in v0.0.17 by #1480): the unit imported via `from xxx import ...` is called a **module** — a single `.ry` file or directory. The word "package" is reserved for the future `ry add` external-library feature and is unimplemented today. Older internal C++ identifiers (`effectivePackage`, `RY_REGISTER_STDLIB_PACKAGE`, `__ry_<symbol>` ABI) keep the legacy "package" naming for ABI/source-stability reasons; refer to those identifiers verbatim when editing code, but use "module" in prose.
+> **Terminology** (`docs/reference/glossary.md`, v0.0.17 / #1480): the unit imported via `from xxx import ...` is a **module** (one `.ry` file or directory). "Package" is reserved for the future `ry add` external-library feature. Legacy C++ identifiers (`effectivePackage`, `RY_REGISTER_STDLIB_PACKAGE`, `__ry_<symbol>` ABI) retain "package" for ABI/source stability — use them verbatim in code, "module" in prose.
 
 ## Steps
 
-新しい標準ライブラリモジュール（例: `crypto`）を追加するための手順。
+### 1. Ry declaration file
 
-### 1. Ry 宣言ファイル作成
-
-`share/std/<mod>/<mod>.ry` に `@native("mod")` 宣言を記述する。`manifest.json` の更新は不要だが、宣言ファイルの追加だけでは module は使えるようにならない。
+Declare `@native("mod")` in `share/std/<mod>/<mod>.ry`. `manifest.json` needs no update; the declaration alone does not make the module usable.
 
 ```ry
 @native("crypto")
 fn sha256(data: str) -> str
 ```
 
-### 2. C++ ランタイム実装
+### 2. C++ runtime implementation
 
-`src/runtime_<mod>.cpp` に `extern "C"` 関数を実装する。関数名は `__ry_<mod>_<name>` の規約に従う。
+Implement `extern "C"` functions in `src/runtime_<mod>.cpp`, named per the `__ry_<mod>_<name>` convention.
 
 ```cpp
 extern "C" const char *__ry_crypto_sha256(const char *data) { ... }
 ```
 
-### 3. ビルド設定
+### 3. Build setup
 
-`CMakeLists.txt` で `add_ry_native_lib(mod src/runtime_<mod>.cpp)` を追加して共有ライブラリを作成する。`RY_NATIVE_LIBS` リストにも追加して `ry` と `ry_tests` にリンクする。
+Add `add_ry_native_lib(mod src/runtime_<mod>.cpp)` to `CMakeLists.txt` and append the library to `RY_NATIVE_LIBS` (linked by `ry` and `ry_tests`).
 
-### 4. Codegen dispatcher（カスタムロジックが必要な場合のみ）
+### 4. Codegen dispatcher (custom logic only)
 
-単純な関数（引数をそのまま渡してランタイムを呼ぶだけ）は `emitGenericNativeCall` が自動処理するため、codegen ファイルの作成は不要。
+Simple functions (forward args to the runtime) are handled by `emitGenericNativeCall`; no codegen file needed.
 
-リソーストラッキング、受信者型dispatch、Option wrapping 等のカスタムロジックが必要な場合は:
-1. `src/codegen_call_<mod>.cpp` を作成し、`RY_REGISTER_STDLIB_PACKAGE` マクロで自己登録 + `NativeDispatchEntry` テーブル + free function `custom_emitter` を定義
-2. opaque リソース型がある場合は `ResourceKindRegistry::instance().registerKind(...)` で静的初期化時にリソース種別を登録
-3. `CMakeLists.txt` の `ry_lib` にソースファイルを追加
+For resource tracking, receiver-type dispatch, `Option` wrapping, etc.:
+1. Create `src/codegen_call_<mod>.cpp` with `RY_REGISTER_STDLIB_PACKAGE` (self-registration), a `NativeDispatchEntry` table, and a free-function `custom_emitter`.
+2. For opaque resource types, register the kind in static init via `ResourceKindRegistry::instance().registerKind(...)`.
+3. Add the source to `ry_lib` in `CMakeLists.txt`.
 
-共通ヘルパー（`codegen_call_dispatch.cpp` に実装済み）を活用する:
+Shared helpers (in `codegen_call_dispatch.cpp`):
 
-| ヘルパー | 用途 |
-|---------|------|
+| Helper | Purpose |
+|--------|---------|
 | `wrapPtrAsResult(ptr, errFn)` | nullable ptr → `Result<T, Error>` |
 | `wrapStatusAsResult(status, errFn)` | int status → `Result<Unit, Error>` |
-| `emitResultBranch(isErr, resTy, buildOk, buildErr)` | カスタム Result 構築 |
-| `buildErrorFromRuntime(errFn)` | ランタイムから Error struct を構築 |
+| `emitResultBranch(isErr, resTy, buildOk, buildErr)` | custom Result construction |
+| `buildErrorFromRuntime(errFn)` | build an `Error` struct from runtime |
 
-### 5. テスト追加
+### 5. Tests
 
-- module import テストを追加する
-- 代表的な native function の実行テストを追加する
-- 必要なら declaration file / native constant の registry 整合テストも追加する
+- Module import.
+- Execution of a representative native function.
+- Registry consistency of declaration file / native constants (if applicable).
 
 ## Adding Constants
 
-`share/std/<mod>/<mod>.ry` に `@const` 宣言を追加する。通常は `@native("mod")` を使うが、`math` のように個別の shared library を持たないモジュールでは bare `@native` を使う（詳細は `.claude/rules/stdlib-module-additions.md` を参照）。dispatch ファイル内で `StdlibRegistry::instance().registerConstant(...)` を静的初期化時に呼び出す（registry 本体は `include/ry/stdlib_registry.hpp` の `StdlibRegistry` クラスで、`src/codegen_call.cpp` 内の `MathConstReg` が具体例）。`codegen_stmt.cpp` の変更は不要。
+Add an `@const` declaration in `share/std/<mod>/<mod>.ry`. Usually paired with `@native("mod")`, but modules without a dedicated shared library (e.g. `math`) use bare `@native` — see `.claude/rules/stdlib-module-additions.md`. From the dispatch file, call `StdlibRegistry::instance().registerConstant(...)` in static init (registry: `include/ry/stdlib_registry.hpp`; example: `MathConstReg` in `src/codegen_call.cpp`). `codegen_stmt.cpp` needs no changes.
 
 ## Adding Functions to Existing Modules
 
-既存モジュールに関数を追加する場合は、以下の箇所を確認する:
+Touch:
 
-1. `share/std/<mod>/<mod>.ry` — `@native("mod") fn` 宣言を追加
-2. `src/runtime_<mod>.cpp` — C++ 実装を追加
-3. `src/codegen_call_<mod>.cpp` — カスタム dispatch が必要なら custom_emitter を追加（単純な関数は不要）
-4. テスト — selective import と実行ケースを追加
+1. `share/std/<mod>/<mod>.ry` — `@native("mod") fn` declaration.
+2. `src/runtime_<mod>.cpp` — C++ implementation.
+3. `src/codegen_call_<mod>.cpp` — `custom_emitter` if custom dispatch is required (skip for simple functions).
+4. Tests — selective-import and execution cases.


### PR DESCRIPTION
## Summary

- Translate `.claude/skills/stdlib-module-add/SKILL.md` from Japanese to English
- 20.18% size reduction (4,619 → 3,687 bytes / 75 → 73 lines)
- Frontmatter `description:` retains Japanese trigger keywords (`stdlib モジュール追加`, `新しい標準ライブラリ`, `@native 宣言`, `定数の追加`) via the `Also fires on Japanese triggers ...` appendix to preserve auto-trigger compatibility
- All references preserved: #1384, #1480, glossary, `stdlib_registry`, `MathConstReg`, `RY_REGISTER_STDLIB_PACKAGE`, `__ry_<symbol>`, `effectivePackage`, `add_ry_native_lib`, `ResourceKindRegistry`, `emitGenericNativeCall`, `NativeDispatchEntry`, `codegen_call_dispatch`, `stdlib-module-additions`, `codegen_stmt`

Closes #1914