### PR TITLE
chore(workflow): forbid `main` substring in feature branch names

### DIFF
--- a/.claude/skills/git-push/SKILL.md
+++ b/.claude/skills/git-push/SKILL.md
@@ -35,7 +35,11 @@ metadata:
      | `chore` | Build, CI, dependencies, tooling |
 
   2. **Generate a short kebab-case description** (2-4 words ideal). Examples: `feat/add-crypto-stdlib`, `fix/utf8-overread`, `refactor/parser-cleanup`.
-  3. Run `git checkout -b <type>/<short-description>` and report the chosen branch name in the next message. Do **not** stop to ask for approval — auto-progress matches the legacy `git-branch-naming` behavior. If the user wants a different name afterwards, they can rename via `git branch -m <new>`.
+
+     > **MUST (no exceptions)**: The generated branch name `<type>/<short-description>` must NOT contain `main` as a substring after lowercasing it and stripping every non-alphabetic character. This rejects e.g. `chore/rebase-main-sync` (`chorerebasemainsync` contains `main`), `feat/m-a-i-n` (`featmain` after stripping), and even `feat/domain-driven` (`featdomaindriven` contains `main` inside `domain`). See AGENTS.md §Git ブランチ運用ルール.
+
+  3. **Validate** the chosen branch name before `git checkout -b`: lowercase it, strip every non-alphabetic character, and check that the result does NOT contain the substring `main`. If it does, regenerate a different `<short-description>` and re-validate. Repeat until clean. This is a hard MUST — never bypass.
+  4. Run `git checkout -b <type>/<short-description>` and report the chosen branch name in the next message. Do **not** stop to ask for approval — auto-progress matches the legacy `git-branch-naming` behavior. If the user wants a different name afterwards, they can rename via `git branch -m <new>` (the rename must also satisfy the MUST rule above).
 
 ### 1. Commit
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,6 +152,7 @@ trace の使い方 (`--trace` / `--trace-out` / JSON Lines / 内部挙動・impo
 ## Git ブランチ運用ルール
 
 - フィーチャーブランチは `main` から作成し、PR は `main` に向けて作成する。`main` への直接コミットは禁止
+- **MUST (例外なし)**: フィーチャーブランチ名に文字列 `main` を含めてはならない。判定はブランチ名を小文字化し英字以外 (`/`, `-`, `_`, 数字、記号など) を全て除去した文字列に対して行い、その中に `m`,`a`,`i`,`n` がこの順で連続出現する場合は違反 (記号・大文字小文字・kebab セグメント境界での迂回不可、`domain-driven` のように自然な単語に偶然含まれる場合も禁止)。理由: `git branch | grep -i main` 等の検索ノイズとスクリプト判定の誤マッチを完全排除するため。違反した場合は `git branch -m <new>` で改名してから push すること
 - フィーチャーブランチに main の最新を取り込む際は **`git rebase origin/main`** を使う (履歴の線形性を保つため)。merge commit による合流はしない。具体手順は `/git-push` / `/git-create-pr` / `/git-resolve-conflicts` を参照
 - rebase 後の push は **`git push --force-with-lease`** を使う (二回目以降は SHA が書き換わるため force push が必要。`--force-with-lease` は remote の予期しない進行を検知して上書きをブロックする)。`fetch` と `push` の間で `git fetch` を再実行しない (lease 保護が緩む)
 - 上記の rebase 方針はフィーチャーブランチへの main 取り込みに限る。`/preparing-for-release` での main 自体の更新は別系統で、`git pull --ff-only origin main` のまま (線形性が保証されているため変更不要)


### PR DESCRIPTION
## Summary

- フィーチャーブランチ名に文字列 `main` (m,a,i,n がこの順で連続出現) を含めることを **MUST (例外なし)** で禁止
- 判定アルゴリズム: ブランチ名を小文字化 → 英字以外 (`/`, `-`, `_`, 数字、記号) を全て除去 → 結果に `main` substring が含まれるかチェック。記号・大文字小文字・kebab セグメント境界での迂回は不可、`domain-driven` のように自然な単語に偶然含まれる場合も禁止
- AGENTS.md §Git ブランチ運用ルールに MUST 箇条書きを追加、`.claude/skills/git-push/SKILL.md` Step 0 に description 生成時の制約と pre-checkout バリデーション手順を追加

## Motivation

過去に `chore/1877-rebase-main-sync` のような description に `main` を含むブランチが作成され、`git branch | grep -i main` で main ブランチを検索するときにノイズとして引っかかった。スクリプトやスキル内部で `main` 文字列マッチで判定する箇所の誤マッチも防ぐため、例外なしの MUST ルールとして導入する。

## Test plan

- [x] `./build/ry_tests` PASS (2503/2503)
- [x] `/pre-commit-checklist` 通過
- [x] 本 PR のブランチ名 `chore/forbid-trunk-token-in-branches` がバリデーション PASS (`choreforbidtrunktokeninbranches` に `main` 含まず)

## Skipped sections (per /pre-commit-checklist)

- Skipped §2 — no user-visible change (`.claude/` + top-level `.md` only)
- Skipped §3 — no source code change
- Skipped §3.5 — no source code change
- Skipped §3.5.5 — no source code change
- Skipped §3.6 — no parser/lexer/json/utf8/string change
- Skipped §3.6.5 — no tree-sitter grammar change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Git branch naming guidelines to restrict feature branch names from containing "main" (case-insensitive). Branches violating this constraint must be renamed using `git branch -m <new>` before pushing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1931?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->