### PR TITLE
chore(skills): translate release-orchestrator SKILL.md to English

### DIFF
--- a/.claude/skills/release-orchestrator/SKILL.md
+++ b/.claude/skills/release-orchestrator/SKILL.md
@@ -1,37 +1,27 @@
 ---
 name: release-orchestrator
-description: リリース起動手順 — マイルストーン feature-complete 後に /preparing-for-release を起動し、Release prep + Release + Release cleanup issue を進める。タグ push 駆動の release.yml 自動ビルドの概要も含む。Use when "リリース" / "タグ push" / "リリース手順" / "milestone close" / "バージョンリリース" / "v0.x.y" を扱うとき。
+description: Entry point for the ry release flow. Routes to /preparing-for-release, documents the tag-push driven release.yml build, and explains the milestone-close policy. Use for "リリース" / "タグ push" / "リリース手順" / "milestone close" / "バージョンリリース" / "v0.x.y".
 allowed-tools: Bash(gh issue:*), Bash(gh milestone:*), Bash(git tag:*), Bash(git push:*)
 ---
 
 # Release Orchestrator
 
-Entry-point reference for the ry release flow. Routes the user to `/preparing-for-release` and explains the tag-push driven `release.yml` mechanism plus the milestone-close policy.
-
-> **Source-of-truth note**: previously in `AGENTS.md`; relocated by #1384. AGENTS.md retains a one-paragraph summary; full detail lives here.
+Entry-point reference for the ry release flow (moved from `AGENTS.md` by #1384). Routes to `/preparing-for-release` and documents the tag-push driven `release.yml` mechanism plus the milestone-close policy.
 
 ## Overview
 
-> **注意**: main へのマージ = mainline 取り込みのみ。リリース (タグ push → GitHub Release) は別工程。
+Trigger this skill when the `v<X.Y.Z>` milestone is feature-complete (all issues under it closed). Note: merging to main is mainline uptake only — releases (tag push → GitHub Release) are a separate workflow.
 
-リリースは tag push 駆動。`v*.*.*` glob にマッチするタグ (`v0.0.14` 等) を `main` にプッシュすると `.github/workflows/release.yml` が自動でビルド・テスト・GitHub Release 作成を行う。glob は prerelease タグ (`v0.0.14-rc.1` 等) も拾うため、`build` ジョブ先頭で `^v[0-9]+\.[0-9]+\.[0-9]+$` を厳密検証して non-semver は失敗させる。
+Releases are tag-push driven. Pushing a `v*.*.*`-glob tag (e.g., `v0.0.14`) to `main` runs `.github/workflows/release.yml`, which builds, tests, and publishes the GitHub Release. The glob also matches prereleases (`v0.0.14-rc.1`), so the `build` job's first step strictly validates `^v[0-9]+\.[0-9]+\.[0-9]+$` and rejects non-semver tags.
 
-ローカルビルドの `ry -v` は `-DRY_VERSION` 未指定時に `0.0.0` を返す (既定値)。CI ビルドは `-DRY_VERSION=${GITHUB_REF_NAME#v}` で版番号が注入される。`workflow_dispatch` も維持してあるが、CI 障害時のリトライ用途に限る (`github.ref_type == 'tag'` ガードあり)。
-
-## When to start
-
-リリース対象バージョン `v<X.Y.Z>` のマイルストーンが feature-complete (= 配下の全 issue が close 済み) になったときに起動する。
+`ry -v` returns `0.0.0` when `-DRY_VERSION` is unset (local default); CI injects the version via `-DRY_VERSION=${GITHUB_REF_NAME#v}`. `workflow_dispatch` remains available for CI-failure retries only, guarded by `github.ref_type == 'tag'`.
 
 ## Hand-off
 
-1. `/preparing-for-release <X.Y.Z>` を起動する。スキルが当該マイルストーンに以下 3 つの issue を作成する:
-   - **Release prep: v<X.Y.Z>** — `changelog.d/` を `CHANGELOG.md` に集約し `[X.Y.Z] - YYYY-MM-DD` セクションを確定させる作業。通常の issue 駆動フロー (claim → feature branch → PR → merge) で実施
-   - **Release: v<X.Y.Z>** — prep が merge された後、マイルストーンに残 issue が無いことを確認してタグを push する作業
-   - **Release cleanup: v<X.Y.Z>** — タグ push 後、`release.yml` 完了・GitHub Release 公開を確認し、マイルストーンを close する作業 (verification-only、branch・PR 不要)
-2. Release prep issue を通常通り進める (`git-claim-issue` → Plan → 実装 → `git-merge-pr`)
-3. Release prep PR が main にマージされたら Release issue に着手し、その手順に従ってタグを push する
-4. Release issue が close されたら、同マイルストーン内の Release cleanup issue に着手し、`release.yml` 完了・GitHub Release 公開を確認してからマイルストーンを close する (→「マイルストーン close ポリシー」)
-
-## マイルストーン close ポリシー
-
-milestone close は「全 issue close ≠ リリース完了」の原則のもと、リリース成果物 (タグ + GitHub Release) の公開確認後に行う。具体的な手順は Release cleanup issue に従うこと。
+1. Invoke `/preparing-for-release <X.Y.Z>`. The skill creates three issues under the milestone:
+   - **Release prep: v<X.Y.Z>** — assemble `changelog.d/` fragments into `CHANGELOG.md` under the `[X.Y.Z] - YYYY-MM-DD` section. Standard issue flow (claim → feature branch → PR → merge).
+   - **Release: v<X.Y.Z>** — once prep merges, confirm no issues remain in the milestone and push the tag.
+   - **Release cleanup: v<X.Y.Z>** — after tag push, verify `release.yml` completion and GitHub Release publication, then close the milestone (verification only — no branch/PR).
+2. Progress the Release prep issue through the normal flow (`git-claim-issue` → Plan → implement → `git-merge-pr`).
+3. After Release prep merges to main, work on the Release issue and push the tag per its instructions.
+4. After Release closes, work on the Release cleanup issue. Close the milestone only after release artifacts (tag + GitHub Release) are verified published — "all issues closed ≠ release complete." Follow the cleanup issue's steps.


### PR DESCRIPTION
## Summary

- `.claude/skills/release-orchestrator/SKILL.md` を英語化 (37 行 / 3,439 bytes → 27 行 / 2,522 bytes、26.7% 削減)
- frontmatter `description:` も英語化、末尾に日本語トリガキーワード (`リリース` / `タグ push` / `バージョンリリース` 等) を併記して auto-trigger を維持
- 維持必須項目すべて残存: `v*.*.*` glob と `^v[0-9]+\.[0-9]+\.[0-9]+$` semver 検証 / `ry -v` の `0.0.0` 既定値 / `-DRY_VERSION=${GITHUB_REF_NAME#v}` 注入 / `workflow_dispatch` の `github.ref_type == 'tag'` ガード / 3 issue (Release prep / Release / Release cleanup) フロー / 「全 issue close ≠ リリース完了」原則

Closes #1913

## Test plan

- [x] バイト数 2,522 (受け入れ範囲 2,063-2,751 内、20-40% 削減目標達成)
- [x] frontmatter `description:` 英語化 + 日本語トリガキーワード併記 (`git-claim-issue` で実証済みパターン)
- [x] クロスリファレンス維持: `/preparing-for-release`, `git-claim-issue`, `git-merge-pr`, `.github/workflows/release.yml`
- [x] 参照元 (`AGENTS.md` L212, `.claude/skills/pre-commit-checklist/SKILL.md` L74) が壊れていない (path / slash command 形式変更なし)
- [x] changelog fragment 不要 (兄弟 PR #1928 — static-analysis-tools 翻訳 — も追加していない precedent)