### PR TITLE
chore(skills): translate tdd-cycle SKILL.md to English

### DIFF
--- a/.claude/skills/tdd-cycle/SKILL.md
+++ b/.claude/skills/tdd-cycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd-cycle
-description: TDD ベースの開発プロセス — 既存コードの変更時と新機能追加時の両フロー (Red-Green-Refactor)。Use when 新機能追加 / 機能を追加 / 機能追加 / 既存機能修正 / 既存コードの変更 / バグ修正 / 修正する / 実装する / 機能を変更 / フィーチャー開発 / TDD / テスト駆動 / 先にテストを書く / リファクタリング / テスト作成 のとき。フィーチャー開発のメインフローでは常に fire する。
+description: TDD flow (Red-Green-Refactor) — existing-code changes and new features. Always fires during feature development; use when adding a feature, fixing a bug, refactoring, or writing tests. Also fires on Japanese triggers 新機能追加, 機能を追加, 機能追加, 既存機能修正, 既存コードの変更, バグ修正, 修正する, 実装する, 機能を変更, フィーチャー開発, TDD, テスト駆動, 先にテストを書く, リファクタリング, テスト作成.
 allowed-tools: Read, Grep, Glob
 ---
 
@@ -8,18 +8,18 @@ allowed-tools: Read, Grep, Glob
 
 ## Existing Code Changes
 
-1. 変更を検出できるテストが存在することを確認（なければ先に作成）
-2. コード変更を実施（既存テストが失敗する状態になる）
-3. 変更後の仕様に基づくテストを追加
-4. 変更前仕様テスト失敗 & 変更後仕様テスト成功を確認
-5. 失敗しているテスト（変更前仕様）を削除
-6. リファクタリング
+1. Ensure a test detects the change (write one first if needed).
+2. Apply the change; existing tests fail.
+3. Add tests for the new spec.
+4. Confirm old-spec fails, new-spec passes.
+5. Delete the failing old-spec tests.
+6. Refactor.
 
 ## New Feature Addition
 
-一般的な TDD (Red-Green-Refactor) に従う。各テストケース毎にサイクルを内部で回し、ハッピーパス 1 ケースで完了扱いにしない。
+Standard TDD (Red-Green-Refactor). Run a full cycle per test case — not just the happy path.
 
 ## Cross-reference
 
-- **テスト観点**: テスト作成段階で `/test-design-techniques` → `/test-checklist` の順に呼ぶ
-- **完了前**: `/pre-commit-checklist`
+- **Test design step**: `/test-design-techniques` → `/test-checklist`.
+- **Before completion**: `/pre-commit-checklist`.


### PR DESCRIPTION
## Summary

- Translate `.claude/skills/tdd-cycle/SKILL.md` from Japanese to English
- 20.35% size reduction (1,376 → 1,096 bytes)
- Frontmatter `description:` retains all 15 Japanese trigger keywords (`新機能追加`, `機能を追加`, `機能追加`, `既存機能修正`, `既存コードの変更`, `バグ修正`, `修正する`, `実装する`, `機能を変更`, `フィーチャー開発`, `TDD`, `テスト駆動`, `先にテストを書く`, `リファクタリング`, `テスト作成`) via the `Also fires on Japanese triggers ...` appendix to preserve auto-trigger compatibility
- All cross-references preserved: `/test-design-techniques`, `/test-checklist`, `/pre-commit-checklist`

Closes #1912