### PR TITLE
refactor(skills): shrink /tdd-cycle to ry-specific timing rules

### DIFF
--- a/.claude/skills/tdd-cycle/SKILL.md
+++ b/.claude/skills/tdd-cycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd-cycle
-description: TDD flow (Red-Green-Refactor) — existing-code changes and new features. Always fires during feature development; use when adding a feature, fixing a bug, refactoring, or writing tests. Also fires on Japanese triggers 新機能追加, 機能を追加, 機能追加, 既存機能修正, 既存コードの変更, バグ修正, 修正する, 実装する, 機能を変更, フィーチャー開発, TDD, テスト駆動, 先にテストを書く, リファクタリング, テスト作成.
+description: TDD timing rules for ry — write a detector test BEFORE changing existing code; delete old-spec tests AFTER the new spec passes. Fires on 新機能追加, 既存機能修正, バグ修正, 修正する, 実装する, TDD, テスト駆動, 先にテストを書く, リファクタリング, テスト作成.
 allowed-tools: Read, Grep, Glob
 ---
 
@@ -8,18 +8,12 @@ allowed-tools: Read, Grep, Glob
 
 ## Existing Code Changes
 
-1. Ensure a test detects the change (write one first if needed).
-2. Apply the change; existing tests fail.
-3. Add tests for the new spec.
-4. Confirm old-spec fails, new-spec passes.
-5. Delete the failing old-spec tests.
-6. Refactor.
+Detector test first; delete old-spec tests only after the new spec passes.
 
 ## New Feature Addition
 
-Standard TDD (Red-Green-Refactor). Run a full cycle per test case — not just the happy path.
+Red-Green-Refactor per test case.
 
 ## Cross-reference
 
-- **Test design step**: `/test-design-techniques` → `/test-checklist`.
-- **Before completion**: `/pre-commit-checklist`.
+`/test-design-techniques` and `/test-checklist` at the テスト作成 step.


### PR DESCRIPTION
## Summary

Shrink `.claude/skills/tdd-cycle/SKILL.md` from 24 lines / 1.1 KB to 19 lines / 651 B by dropping redundant standard-TDD prose (Apply/Confirm/Refactor enumeration, "Standard TDD" labeling, happy-path emphasis). Keep ry-specific timing constraints only: detector test before existing-code changes, delete old-spec tests only after the new spec passes. Section names (`## Existing Code Changes` / `## New Feature Addition`) preserved to keep references from `test-checklist` / `test-design-techniques` / `plan-rubric` / `tests-rejection-tdd` / `AGENTS.md` functional.

Closes #1938