### PR TITLE
refactor: slim down AGENTS.md by pointing duplicate sections to skills

### DIFF
--- a/.claude/skills/commands-environment-gotchas/SKILL.md
+++ b/.claude/skills/commands-environment-gotchas/SKILL.md
@@ -47,6 +47,32 @@ write a 3-line entry under this section with a descriptive subheading.
 
 **Why**: `./build/ry` resolves the stdlib path via `package.toml`'s hidden `[paths]._dev_stdlib` key, which requires a `package.toml` somewhere in the ancestor directory chain. Files under `/tmp/` have no such ancestor, so the module loader falls back to `~/.ry/share/std` (the globally-installed stdlib), which does not contain the newly added declarations. The trace event to look for: `"resolved_path":"/Users/.../.ry/share/std"` instead of `"resolved_path":"/Users/.../Workspace/ry-2/share/std"`.
 
+**Note on `RY_ENV=internal`**: The `_dev_stdlib` resolution above runs automatically for repo-local `./build/ry` invocations — `RY_ENV=internal` is **not** required for routine development. The env var exists for additional isolation (e.g. forcing the in-repo stdlib path even when the working directory has no `package.toml` ancestor chain, or when a globally-installed `ry` would otherwise win); use it only when you explicitly need that override.
+
+---
+
+### ASan + UBSan: `detect_container_overflow=0` and `-fno-sanitize=vptr,function` are not optional
+
+**Source**: AGENTS.md historical note (migrated from inline sanitizer section, 2026-05-28)
+**Tags**: sanitizer, asan, ubsan, cmake, preset, llvm, false-positive
+
+**Rule**: When invoking `./build-asan/ry_tests` or `./build-asan/ry test -p`, always set:
+
+```bash
+ASAN_OPTIONS=detect_container_overflow=0 \
+UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
+    ./build-asan/ry_tests
+```
+
+The `asan` preset itself already builds with `-fno-sanitize=vptr,function`.
+
+**Why**:
+
+- **`detect_container_overflow=0`**: ASan's container-overflow detection requires every C++ allocation to participate in the same ASan-instrumented heap. The repo links against the system LLVM libraries (`/usr/local/llvm/...`) which are **not** built with ASan, so any `std::vector` / `std::string` flowing across the boundary trips false-positive container-overflow reports. Disabling this single check leaves the bulk of ASan (heap UAF, OOB, double-free, leaks) intact.
+- **`-fno-sanitize=vptr,function`** (preset, not env): The project builds with `-fno-rtti`, which strips typeinfo that UBSan's `vptr` check requires. The `function` check trips on LLVM's C-style function-pointer casts (e.g. `reinterpret_cast<void*>(&Func)` patterns inside ORC JIT plumbing) that are well-defined in practice but not provable to UBSan. Excluding both keeps the rest of UBSan (signed overflow, null deref, alignment, etc.) effective.
+
+**How to apply**: If a fresh contributor reports "ASan flagged container-overflow on a trivial vector push" or "UBSan halted on a function-pointer cast in JIT teardown", the answer is one of these two — point them at this entry rather than chasing the false positive into LLVM internals. The TSan build uses a separate preset (`build-tsan/`); see `KNOWLEDGE.md` §サニタイザー既知問題 / TSan.
+
 ---
 
 ### `gh issue edit --label` replaces all labels; use `--add-label` / `--remove-label`

--- a/.claude/skills/knowledge-md-management/SKILL.md
+++ b/.claude/skills/knowledge-md-management/SKILL.md
@@ -14,6 +14,17 @@ allowed-tools: Bash
 - You need to grep across the whole knowledge base (KNOWLEDGE.md isn't covered by path-scoped auto-load)
 - A stabilized entry is ready to be split out into `.claude/rules/` or `.claude/skills/`
 
+### Concrete write triggers
+
+ナレッジを書くタイミングは典型的に以下の 4 つに集約される。これらに該当した時点で、§1 のルーティング (既存 entry を更新 vs KNOWLEDGE.md へ追記) を判断する。
+
+| トリガー | 何を書くか |
+|---|---|
+| **PR レビュー対応後** | 他 PR にも再発しうるレビュー指摘 (path-scope に収まれば対応 rule、横断的なら `.claude/skills/pr-review-recurring-patterns/SKILL.md`)。単発の local 指摘は不要 |
+| **実装中** | 非自明な事実 (型システムの落とし穴、ライブラリの裏仕様、再現条件付きバグ等)。「次に誰かが同じ問題に当たったとき即座に解けるか」を基準に判断 |
+| **Plan 中** | 採用しなかった設計判断 (なぜ別案を選ばなかったか)。将来同じ alternative を再検討する時の判断材料 |
+| **コマンドミスのリカバリ時** | `commands-environment-gotchas/SKILL.md` の `Wrong → Correct → Why` triple。プレーン typo は除外、second invocation で初めて気付いた非自明なものが対象 |
+
 ## 1. Where to write (REQ-1)
 
 1. **A matching entry exists** in a rule / skill → append there. Do not touch KNOWLEDGE.md.

--- a/.claude/skills/tree-sitter-grammar-editing/SKILL.md
+++ b/.claude/skills/tree-sitter-grammar-editing/SKILL.md
@@ -11,6 +11,21 @@ grammar at `editor/tree-sitter/`. Cross-reference: build/install workflow
 in `editor/tree-sitter/README.md` §Contributor workflow, and pre-commit
 verification in `/pre-commit-checklist` §3.6.5.
 
+## When to build & install (`ry.so`)
+
+A PR that touches any of the following paths must rebuild `ry.so` and
+install it into the local Neovim parser directory (via
+`./editor/tree-sitter/build.sh && ./editor/tree-sitter/install.sh --no-build`):
+
+- `docs/grammar.ebnf` — the canonical EBNF spec
+- `editor/tree-sitter/grammar.js` — the tree-sitter grammar definition
+- `editor/tree-sitter/src/` — the external scanner (`scanner.c`)
+
+Prerequisites (tree-sitter CLI, GNU gcc) and flag details for each script
+are documented in `editor/tree-sitter/README.md`. Self-verification gating
+runs out of `/pre-commit-checklist` §3.6.5, which checks whether any of
+the three paths above is in the diff.
+
 ---
 
 ### `docs/grammar.ebnf` is the canonical spec — propagate edits in order

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,17 +18,7 @@ cmake --build build                                     # Ninja が自動並列�
 
 ## tree-sitter グラマーのビルド & インストール
 
-以下のいずれかが変更された PR では、`ry.so` を再ビルドしてローカル Neovim parser ディレクトリへインストールすること:
-
-- `docs/grammar.ebnf` — 正準 EBNF 仕様
-- `editor/tree-sitter/grammar.js` — tree-sitter グラマー定義
-- `editor/tree-sitter/src/` — external scanner (`scanner.c`)
-
-```bash
-./editor/tree-sitter/build.sh && ./editor/tree-sitter/install.sh --no-build
-```
-
-前提条件 (tree-sitter CLI / GNU gcc) と各スクリプトのフラグ詳細は `editor/tree-sitter/README.md` を参照。セルフ検証時の確認手順は `/pre-commit-checklist` §3.6.5 を参照。グラマー編集時の落とし穴 (externals enum 順序、`mark_end` / `valid_symbols` セマンティクス、highlights.scm の named-node vs anonymous-literal) と検証レシピは `.claude/skills/tree-sitter-grammar-editing/SKILL.md`（または `/tree-sitter-grammar-editing`）を参照。`editor/tree-sitter/grammar.js` / `src/scanner.c` / `queries/*.scm` を編集する際は同 skill が path-scoped rule 経由で自動 load される。
+`docs/grammar.ebnf` / `editor/tree-sitter/grammar.js` / `editor/tree-sitter/src/scanner.c` のいずれかを変更した PR では `ry.so` の再ビルドが必要。build/install コマンド・前提条件・落とし穴 (externals enum 順序 / `mark_end` / `valid_symbols` セマンティクス / highlights.scm) ・検証レシピは `.claude/skills/tree-sitter-grammar-editing/SKILL.md`（または `/tree-sitter-grammar-editing`）と `editor/tree-sitter/README.md`、セルフ検証手順は `/pre-commit-checklist` §3.6.5 を参照。`editor/tree-sitter/grammar.js` / `src/scanner.c` / `queries/*.scm` 編集時は同 skill が path-scoped rule 経由で自動 load される。
 
 ## コンパイラ警告フラグ
 
@@ -53,31 +43,17 @@ CI Linux ジョブは pre-bake コンテナ (`ghcr.io/<owner>/ry-ci:llvm-21`、r
     - `.claude/agents/test-runner.md` — C++ ry_tests + Ry セルフテストを独立 context で実行・失敗解析する subagent (並列化用)
     - `.claude/agents/fuzzer-runner.md` — libFuzzer harness を独立 context で実行・crash 解析する subagent (並列化用)
     - `.claude/agents/pr-review-responder.md` — CodeRabbit / 人間レビュワー指摘の解析・返信生成・修正案作成を行う subagent
-- **`KNOWLEDGE.md`** (リポジトリ root) — 未分類知見の暫定バッファ。rules / skills のどれにも該当 entry を持たない新規知見をここに蓄積し、安定後に rules / skills へ昇格させる。フォーマット・grep convention・外部参照ポリシー・昇格手順は `/knowledge-md-management` 参照
-- **読む**: 該当ファイルを編集すれば対応 rule が自動 load。手動 grep: `grep -rnE '\*\*Tags\*\*:.*<keyword>' .claude/rules/ .claude/skills/ KNOWLEDGE.md`
-- **書く**: 1 つの教訓 = 1 エントリ。`### <heading>` + `**Source**:` + `**Tags**:` + `**Rule**:` 形式。**該当する rule / skill が既にあればそこを更新**、どこにも該当 entry がない新規知見は **`KNOWLEDGE.md` に追記** (詳細は `/knowledge-md-management`)。path 限定の整理先は `.claude/rules/`、横断的なら `.claude/skills/`。英語推奨
-- **いつ書く**: PR レビュー対応後 (再発しうる指摘) / 実装中 (非自明な事実) / Plan 中 (採用しなかった設計判断) / コマンドミスのリカバリ時
+- **`KNOWLEDGE.md`** (リポジトリ root) — 未分類知見の暫定バッファ。rules / skills のどれにも該当 entry を持たない新規知見をここに蓄積し、安定後に rules / skills へ昇格させる。フォーマット・grep convention・外部参照ポリシー・「いつ書く」トリガー・昇格手順は `/knowledge-md-management` 参照
 
 ## ASan + UBSan（Address + UndefinedBehavior Sanitizer）
 
-ローカル開発では ASan と UBSan を同時に有効化してテストを実行する。`asan` preset は `ENABLE_ASAN=ON` と `ENABLE_UBSAN=ON` を両方設定する:
-
-```bash
-cmake --preset asan                                     # Debug + ASan + UBSan（build-asan/）
-cmake --build build-asan                                # ビルド
-ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
-    ./build-asan/ry_tests                               # C++ テスト
-ASAN_OPTIONS=detect_container_overflow=0 UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
-    ./build-asan/ry test -p                             # Ry セルフテスト
-```
-
-> `detect_container_overflow=0` は ASan なし LLVM ライブラリとの混在 false positive 抑制のため。UBSan は `-fno-sanitize=vptr,function` でビルド (`-fno-rtti` および LLVM の C 風関数ポインタキャスト対策)。
+ローカル開発では `cmake --preset asan` で ASan + UBSan を同時有効化してテストを実行する。ビルドコマンド・実行時 env (`ASAN_OPTIONS=detect_container_overflow=0` / `UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1`) と各設定の根拠 (LLVM 混在 false positive 抑制 / `-fno-sanitize=vptr,function` の理由) は `.claude/skills/commands-environment-gotchas/SKILL.md`（または `/commands-environment-gotchas`）、セルフ検証手順は `/pre-commit-checklist` §3.5 を参照。
 
 ASan または UBSan が検出した問題（メモリリーク、バッファオーバーフロー、use-after-free、未定義動作等）は必ず解消すること。サニタイザーエラーを残したままコミットしてはならない。
 
 ## TSan（ThreadSanitizer）
 
-スレッド安全性の検証には TSan ビルドを使う。TSan は ASan / UBSan と排他で、別ディレクトリ（`build-tsan/`）にビルドされる。ビルドコマンド・required vs warn-only ジョブ分割・upstream TSan allocator バグ・LLVM ORC teardown 等の既知問題は `KNOWLEDGE.md` の `## サニタイザー既知問題` セクションを参照。
+スレッド安全性の検証は TSan preset を使う。ビルドコマンド (`cmake --preset tsan`) / ASan-UBSan との排他性 (`build-tsan/` 隔離) / required vs warn-only ジョブ分割 / 既知の upstream バグ (LargeMmapAllocator / LLVM ORC teardown / signal-handler `siglongjmp`) は `KNOWLEDGE.md` の `## サニタイザー既知問題` セクション、セルフ検証手順は `/pre-commit-checklist` §3.5 を参照。
 
 > 新しい race を導入した場合は同 PR 内で必ず修正すること。warn-only は TSan allocator バグの回避のみであり、実際の race 導入を許容しない。
 
@@ -116,10 +92,6 @@ issue 確認 → ナレッジベース参照 (path-scoped rule は実装中も a
   - 用語変更・識別子 rename を含む場合: `/horizontal-sweep` を計画タスクに含める（4 ステップ手順は `.claude/skills/horizontal-sweep/SKILL.md`）
 - **副次的発見への対応**: 「責務の分離」セクション「副次的発見への対応」に従う (`/triage-side-finding`)。`/triage-side-finding` Q4(b) で「別 issue 起票」と判定された場合のみ、実装計画内に「別 issue 起票」タスクを含める (Q1 再現困難 / Q2 ユーザー指示 → 即時修正と判定された場合は同 PR 内で対処するため計画タスク化不要)。**ただし起票の実行はユーザーの明示許可後** — Plan 内に「別 issue 起票」タスクを含める場合も、Claude Code は起票内容を提示するに留め、ユーザー許可を待つ (「責務の分離」§ユーザーが明示的に指示すること 参照)
 - **TDD サイクルの分割禁止**: Red / Green / Refactor は Plan 上で個別タスクに分割せず、1 つの「TDD サイクル」タスクとしてまとめる（各ケース毎にサイクルを内部で回す）
-
-## repo build と stdlib 解決
-
-repo 内 `./build/ry` / `./build-current/ry` は `package.toml` の hidden 設定 `[paths]._dev_stdlib` で project-local の `share/std/` を参照。OS インストール版は `~/.ry/share/std` を参照。`RY_ENV=internal` は追加の isolation 用であり、repo 開発時の通常動作に必須ではない。
 
 ## 内部挙動の解析に trace を使う
 
@@ -192,7 +164,7 @@ single message に multiple `Agent` tool calls を入れて **subagent を foreg
 2. **再現困難問題の即時修正**: CI 検出の再現困難なメモリ破壊 / 並行性 race / fuzz crash 等 (`/triage-side-finding` Q1 = Yes に該当) は、起源判定 (regression vs pre-existing) より修正タイミングを優先する。再現中のウィンドウを逃さない原則。**ただし副次的発見の判断にのみ適用**。
 3. **分析より修正優先**: Q1 / Q2 該当時は `bug-forensics-analyst` / advisor を呼ばない。意味は「即時修正を選んだあと不要な分析で時間を消費しない」であり、root cause 分析投資原則 (`/plan-rubric` 等) と衝突せず、Q3 経由の分析完了後の修正着手を妨げない。
 
-> **用語注記**: `bug-forensics-analyst` は `.claude/agents/` 配下の subagent (L49 catalog 参照、backtick で表記)。advisor は Claude Code 組み込みの advisor tool あるいは外部レビュワーを指す汎用ロールで、`.claude/agents/` に独立ファイルを持たないため backtick なしで表記する。
+> **用語注記**: `bug-forensics-analyst` は `.claude/agents/` 配下の subagent (§"ナレッジベース" の catalog 参照、backtick で表記)。advisor は Claude Code 組み込みの advisor tool あるいは外部レビュワーを指す汎用ロールで、`.claude/agents/` に独立ファイルを持たないため backtick なしで表記する。
 
 ### ユーザーが明示的に指示すること
 

--- a/KNOWLEDGE.md
+++ b/KNOWLEDGE.md
@@ -68,6 +68,24 @@
 
 ### TSan
 
+#### TSan build commands and preset isolation
+
+**Source**: AGENTS.md historical note (migrated from inline sanitizer section, 2026-05-28)
+**Tags**: tsan, sanitizer, cmake, preset, build, isolation
+
+**Rule**: TSan ビルドは `asan` preset とは別ディレクトリで行う:
+
+```bash
+cmake --preset tsan                                     # Debug + TSan (build-tsan/)
+cmake --build build-tsan                                # ビルド
+./build-tsan/ry_tests                                   # C++ tests
+./build-tsan/ry test -p                                 # Ry self-tests
+```
+
+`tsan` preset は ASan / UBSan と排他であり、別ディレクトリ `build-tsan/` にビルドされる。同じディレクトリで sanitizer を切り替えると CMake キャッシュが壊れるため、必ず別 build tree に分離する。
+
+**How to apply**: TSan ジョブを走らせる前に `build-tsan/` の存在を確認し、無ければ `cmake --preset tsan` から作る。`build-asan/` と `build-tsan/` を混ぜないこと。既知の upstream バグ (LargeMmapAllocator / LLVM ORC teardown / signal-handler siglongjmp) は本セクションの他エントリ参照。
+
 #### TSan job — C++ tests required, Ry self-tests warn-only
 
 **Source**: #868 (warn-only landed), #874 (split policy)


### PR DESCRIPTION
## Summary

- AGENTS.md (常時 load される project instructions) の重複セクションを 1 行ポインタ化し、idle context を圧縮
- 213 → 195 行 (rebase で origin/main の #1947 agents catalog 拡張取り込み後の最終値。my slim-down 単独では 213 → 185 行)
- 移譲先 4 ファイル (commands-environment-gotchas / knowledge-md-management / tree-sitter-grammar-editing / KNOWLEDGE.md) に内容欠落を追記して single source of truth を担保

## スリム化したセクション

| セクション | 移譲先 |
|---|---|
| tree-sitter グラマーのビルド & インストール | `tree-sitter-grammar-editing` SKILL.md |
| ASan + UBSan (preset コード + OPTIONS) | `commands-environment-gotchas` + `/pre-commit-checklist` §3.5 |
| TSan (preset コード) | `KNOWLEDGE.md` サニタイザー既知問題 |
| repo build と stdlib 解決 (完全削除) | L17 brief note + `commands-environment-gotchas` |
| ナレッジベース 「読む / 書く / いつ書く」 3 bullets | `/knowledge-md-management` |

## 残した品質ゲート文 (always-on governance)

- ASan/UBSan「サニタイザーエラーを残したままコミット禁止」
- TSan「新しい race は同 PR 内で必ず修正」「warn-only は race 導入を許容しない」
- libFuzzer「CI 無効、フィーチャーブランチで必ず手動実行」「crash は `tests/fuzz/regressions/` と `tests/fuzz/corpus/` 両方に保存」
- ナレッジベース catalog (rules / skills / agents / KNOWLEDGE.md の役割定義)

## Test plan

- [x] AGENTS.md の品質ゲート文 4 件が本文に残っていること
- [x] always-on governance 5 ブロック (Plan モード / 責務の分離 / Git ブランチ運用 / PR レビュー対応 / ワークフロー全体像) が無傷
- [x] 1:1 diff verification: 削除した 6 情報片すべてが移譲先に grep でヒット
- [x] `/knowledge-md-management` 禁則参照パターン (KNOWLEDGE.md L番号 / `entry above` 等) 違反なし
- [x] `/pre-commit-checklist` セルフ検証 — Skip matrix 適用 (.md / .claude/ only PR のため §1-§3.6.5 スキップ)、§3.7 background hygiene 確認済み
- [x] Rebase で origin/main の #1947 agents catalog 拡張を取り込み、`.claude/agents/<name>.md` bullet を catalog 6 entries で merge
- [x] L49 → §"ナレッジベース" の catalog 参照 へ書き換え (line 番号参照を section 参照に robust 化)

Closes #1951

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified contributor workflow for tree-sitter grammar edits, including explicit rebuild and validation steps and links to a dedicated skill README and self-checklist
  * Rewrote sanitizer guidance to point to presets and gotchas sections rather than long command lists
  * Added a TSan knowledge entry with isolated build/testing checklist and best practices for sanitizer build separation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->