### PR TITLE
refactor(codegen): extract type-name utilities into ry::util and document compiler boundaries (#1820)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ add_library(ry_lib STATIC
     src/cli/cli.cpp
     src/jit/jit_runner.cpp
     src/jit/test_runner.cpp
+    src/util/type_name.cpp
 )
 target_precompile_headers(ry_lib PRIVATE
     <algorithm>
@@ -374,6 +375,7 @@ add_executable(ry_tests
     tests/test_codegen_call_json_reject.cpp
     tests/test_spec_timeout.cpp
     tests/test_runtime_io_file.cpp
+    tests/test_util_type_name.cpp
 )
 if(APPLE)
     target_link_libraries(ry_tests PRIVATE

--- a/changelog.d/1820-tighten-compiler-runtime-boundaries.md
+++ b/changelog.d/1820-tighten-compiler-runtime-boundaries.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Pure type-name utility helpers (`splitGenericTypeName`, `trimTypeNameSpaces`, `isListTypeName`, `isMapTypeName`, `isSetTypeName`, `isWeakTypeName`, `isFunctionTypeName`, `isLowLevelTypeName`, `deriveRuntimeFnName`, `nativeSigKey`) moved from `CodeGen` static members to a new layer-independent `ry::util` namespace under `include/ry/util/type_name.hpp`. Internal refactor with no behavior change. Added `docs/architecture/{compiler-layers,llvm-ir-emission-boundary,runtime-abi-boundary}.md` to document the compiler layer dependency direction, the candidate LLVM IR emission shared-library boundary, and the runtime ABI surface as preparation for incremental Rust migration. (#1820)

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,3 +47,15 @@ For detailed language specifications, see the reference pages below.
 | [Design by Contract](reference/contracts.md) | require, ensure, invariant |
 | [Directives](reference/directives.md) | @deprecated and other compile-time instructions |
 | [Error List](reference/errors.md) | Compile errors and runtime errors |
+
+---
+
+## Architecture (for contributors)
+
+Internal architecture references for working on the Ry compiler and runtime. These describe layer boundaries, the LLVM IR emission interface, and the runtime ABI surface — they are not needed to write Ry programs.
+
+| Page | Contents |
+|------|----------|
+| [Compiler Layers](architecture/compiler-layers.md) | lexer → parser → AST → module → sema → codegen → runtime ABI dependency direction |
+| [LLVM IR Emission Boundary](architecture/llvm-ir-emission-boundary.md) | Candidate shared-library boundary for the LLVM IR emission layer (#1949/#1950 prep) |
+| [Runtime ABI Boundary](architecture/runtime-abi-boundary.md) | `__ry_*` `extern "C"` surface categorized by core/native for Rust migration planning |

--- a/docs/architecture/compiler-layers.md
+++ b/docs/architecture/compiler-layers.md
@@ -1,0 +1,51 @@
+# Compiler Layers and Dependency Direction
+
+This document records the intended dependency direction between the compiler/runtime layers of the Ry implementation. It is the reference for issue #1820 (v0.0.26 boundary-tightening) and the foundation for the Rust migration path tracked in #1949 (LLVM IR emission shared library) and #1950 (Rust reimplementation).
+
+## Layers
+
+Source code is organized into the following layers, ordered from input (left) to output (right):
+
+```
+lexer → parser → AST → module loader → sema → codegen → runtime ABI
+```
+
+| Layer | Primary header | Responsibility |
+| --- | --- | --- |
+| lexer | `include/ry/lexer/lexer.hpp` | Tokenize source text into a `Token` stream. Owns indentation/dedentation state and source-position tracking. |
+| parser | `include/ry/parser/parser.hpp` | Consume tokens and emit `ast::*` nodes. Owns precedence/associativity tables and recovery decisions. |
+| AST | `include/ry/ast/ast.hpp` | Plain-data node definitions shared by every later layer. The AST is the contract between parsing and downstream consumers. |
+| module loader | `include/ry/module/module_loader.hpp` | Resolve `import` graphs, load `.ry` source files lazily, and provide AST roots for each module. |
+| sema | `include/ry/sema/*.hpp` | Static analysis that runs alongside codegen — return-path coverage (`sema_return.hpp`), pattern-match exhaustiveness, etc. |
+| codegen | `include/ry/codegen.hpp` | Lower AST + sema results into LLVM IR. Owns the `CodeGen` monolith (LLVM context, ARC bookkeeping, type/metadata registries, stdlib dispatch). |
+| runtime ABI | `include/ry/runtime/{core,native}/*.hpp` | C++ runtime entry points exposed via `extern "C"` symbols (`__ry_*`). See [Runtime ABI Boundary](runtime-abi-boundary.md) for the categorization. |
+
+`codegen_native_dispatch.hpp` / `directive_meta.hpp` / `ry_layout.hpp` / `codegen_guards.hpp` are shared declarations co-owned by codegen and the runtime ABI; they sit at the codegen/runtime interface and intentionally span the two layers.
+
+## Dependency direction rule
+
+**Each layer may only `#include` headers that belong to layers strictly to its left.** Adding a back-edge (e.g. `parser/` including `codegen.hpp`) violates the layering and indicates that a shared concern should be lifted into one of the layers on the left, or split into a new layer-independent helper under `include/ry/util/`.
+
+The observed adjacency list as of v0.0.26 is:
+
+| Header | Inbound `ry/` includes |
+| --- | --- |
+| `lexer/lexer.hpp` | (leaf — no `ry/` includes) |
+| `parser/parser.hpp` | `lexer/lexer.hpp`, `ast/ast.hpp`, `source_manager/source_manager.hpp` |
+| `module/module_loader.hpp` | `ast/ast.hpp`, `source_manager/source_manager.hpp` |
+| `sema/sema_return.hpp` | `ast/ast.hpp` |
+| `sema/sema.hpp` | (no `ry/` includes — implementation pulls deps via `.cpp`) |
+| `codegen.hpp` | `ast/ast.hpp`, `sema/sema_return.hpp`, `source_manager/*`, `trace/trace.hpp`, `ry_layout.hpp`, `directive_meta.hpp`, `codegen_native_dispatch.hpp`, `codegen_guards.hpp` |
+
+`source_manager/` and `trace/` are layer-independent utilities; they may be referenced by any layer.
+
+## Invariants
+
+- **`codegen` does not depend on `parser` or `module_loader`.** Codegen receives an already-parsed AST plus a `SourceManager` reference; it does not re-enter the parser. Maintain this invariant when adding new codegen entry points.
+- **`runtime ABI` does not depend on `codegen`.** Runtime `.cpp` files in `src/runtime/{core,native}/` link against LLVM-free headers (`include/ry/runtime/{core,native}/*.hpp`) only. Codegen calls into the runtime ABI by emitting LLVM IR that resolves to `extern "C"` symbols; the runtime side never sees `llvm::Value*` or `IRBuilder<>`. This separation is what makes #1949 and the Rust reimplementation in #1950 feasible.
+- **Layer-independent helpers live under `include/ry/util/`.** Pure utilities that operate on strings, type names, or other plain data (no LLVM, no parser, no codegen state) belong under `util/`. Issue #1820 establishes this directory with `include/ry/util/type_name.hpp` for type-name parsing helpers extracted from `CodeGen`.
+
+## Related documents
+
+- [LLVM IR Emission Boundary](llvm-ir-emission-boundary.md) — identifies the candidate shared-library boundary inside the codegen layer.
+- [Runtime ABI Boundary](runtime-abi-boundary.md) — categorizes the `__ry_*` `extern "C"` surface for Rust migration planning.

--- a/docs/architecture/compiler-layers.md
+++ b/docs/architecture/compiler-layers.md
@@ -6,7 +6,7 @@ This document records the intended dependency direction between the compiler/run
 
 Source code is organized into the following layers, ordered from input (left) to output (right):
 
-```
+```text
 lexer → parser → AST → module loader → sema → codegen → runtime ABI
 ```
 

--- a/docs/architecture/llvm-ir-emission-boundary.md
+++ b/docs/architecture/llvm-ir-emission-boundary.md
@@ -1,0 +1,43 @@
+# LLVM IR Emission Boundary
+
+This document identifies the candidate shared-library boundary inside the codegen layer. It is the design reference for issue #1949 (extract the LLVM IR emission layer as a separate shared library) and #1950 (reimplement that shared library in Rust). Issue #1820 (v0.0.26 stage 2) prepares the surface by extracting layer-independent helpers and documenting the access patterns described here.
+
+## What this boundary is
+
+The "LLVM IR emission layer" is the subset of `CodeGen` that owns LLVM types and the `IRBuilder<>`. Today this is intertwined with type registries, ARC bookkeeping, stdlib dispatch, and module-namespace state inside a single monolithic class (`include/ry/codegen.hpp`). The goal of #1949 is to extract the LLVM-touching surface into its own `.so`/`.dylib` exposing a stable `extern "C"` ABI, so that #1950 can reimplement it in Rust without rewriting the rest of the compiler.
+
+## Constraint: LLVM types must not cross the boundary
+
+In the final design, the following LLVM-owned types **must not appear** in the shared-library ABI:
+
+- `llvm::Value*` / `llvm::Constant*` / any `llvm::*` derivative
+- `llvm::Module&` and `llvm::LLVMContext&`
+- `llvm::IRBuilder<>` and its template instantiations
+- `llvm::Function*` / `llvm::BasicBlock*` / `llvm::Type*`
+
+These types are LLVM-version-coupled and cannot be reasonably exposed through a stable ABI. The boundary instead exchanges opaque handles (or value IDs) that the LLVM side resolves internally. Concretely: anywhere the current C++ code passes an `llvm::Value*` between a custom stdlib emitter and a `CodeGen` helper, that exchange must be redesigned to use a plain integer handle, a small POD struct, or a callback that lives entirely on the LLVM side.
+
+## Access categories observed in custom stdlib emitters
+
+The 16 `src/codegen_call_*.cpp` dispatcher files are the primary consumers of `CodeGen` internals. Their access patterns fall into five categories:
+
+1. **LLVM context handles**: `builder_`, `mod_`, `ctx_`, `fn_`. These are the raw LLVM state — they cannot cross the boundary as-is. Custom emitters that take a `CodeGen&` and read these directly must be reshaped to receive an `EmitterContext` wrapper instead.
+2. **Primitive type accessors**: `i64Ty_`, `ptrTy_`, `anyTy_`, `errorTy_`, `i8Ty_`, `f64Ty_`, etc. These are `llvm::Type*` and share the same constraint as category 1 — wrap behind opaque type-id handles in the boundary.
+3. **Runtime wrapper helpers**: `getRuntimeFn`, `wrapPtrAsResult`, `wrapStatusAsResult`, `emitResultBranch`, `buildErrorFromRuntime`. **This category is the most narrowed existing boundary candidate** — all five helpers are already centralized in `src/codegen_call_dispatch.cpp`, and they encapsulate the canonical "call a runtime symbol, wrap the result as `Result<T, Error>`" pattern. They are the natural starting point for the shared-library extraction in #1949: a thin wrapper layer that exchanges opaque value handles and dispatches to the LLVM-owning side.
+4. **Metadata API**: `propagateTypeMeta`, `setTypeMeta`, `emitExpr`. These mutate or query the `ValueMetadata` keyed by `llvm::Value*`. Crossing the boundary requires the metadata store to live on the LLVM side and be addressed through the same opaque handles as category 1.
+5. **Predicate and error helpers**: `isStringValue`, `isFile`, `codegenError`, `requireArgs`, `propagateTypeMeta`. These mix value inspection (LLVM-coupled) with diagnostic reporting (layer-independent). Diagnostics can move to the caller side; value-inspection predicates must stay LLVM-side.
+
+## Narrowing direction (not implemented in #1820)
+
+The concrete narrowing — replacing direct `CodeGen&` parameters in custom emitters with a smaller `EmitterContext` interface — is **not** in scope for issue #1820. The acceptance criterion is satisfied here by documentation: emitter access is currently broad, the narrowing plan is to introduce a context struct exposing only the surface above, and the implementation is left to a follow-up issue gated on #1949's ABI design.
+
+The recommended sequence is:
+
+1. (this issue, #1820) Document the surface; extract layer-independent string/type-name helpers out of `CodeGen` so they no longer cross the boundary.
+2. (#1949) Define the shared-library ABI starting from category 3 (the most narrowed surface today) and progressively wrap the other categories. Extract the LLVM-owning side into `libry_codegen.so`/`.dylib`.
+3. (#1950) Reimplement `libry_codegen` in Rust behind the same ABI.
+
+## Related documents
+
+- [Compiler Layers](compiler-layers.md) — layer ordering and dependency direction.
+- [Runtime ABI Boundary](runtime-abi-boundary.md) — the orthogonal `__ry_*` boundary on the runtime side.

--- a/docs/architecture/runtime-abi-boundary.md
+++ b/docs/architecture/runtime-abi-boundary.md
@@ -1,0 +1,80 @@
+# Runtime ABI Boundary
+
+This document categorizes the runtime ABI surface so that selected native runtime modules can later be rewritten in Rust behind stable `extern "C"` symbols. It is a deliverable of issue #1820 (v0.0.26 stage 2) and the planning reference for incremental Rust migration. The orthogonal LLVM IR emission boundary is documented in [LLVM IR Emission Boundary](llvm-ir-emission-boundary.md).
+
+## Contract
+
+- **All runtime entry points are `extern "C"` symbols prefixed `__ry_`.** This is the stable ABI: codegen lowers user-level operations into calls to these symbols, and the runtime owns their implementation.
+- **The boundary is C-only.** Parameters and return types are limited to scalar types (`int64_t`, `double`, `bool` as `int8_t`), opaque pointers, and POD structs whose layout is fixed by `include/ry/runtime/{core,native}/*.hpp`. LLVM types must not appear on either side.
+- **Memory ownership crosses the boundary via the ARC contract.** Allocations made by the runtime carry an `ArcHeader` (or `StringHeader` for `str`) at a fixed negative offset; codegen emits the matching retain/release calls. See `.claude/rules/codegen-arc-cow.md` for the full contract.
+
+## Two-category split
+
+The runtime is organized into two top-level subdirectories, established by the #1829 reorganization. The split directly maps to Rust-migration prioritization.
+
+### Core runtime (`src/runtime/core/`, `include/ry/runtime/core/`)
+
+Memory-safety-critical primitives shared by every Ry program. These see the highest exercise from the test suite and the fuzzer harnesses, and they are the largest source of subtle bugs (off-by-one, lifetime, race) — making them attractive Rust-migration targets where the borrow checker pays the most dividend.
+
+| Module | Source | Surface |
+| --- | --- | --- |
+| ARC | `arc_counter.cpp` | Retain / release / atomic refcount ops; cycle-detection hooks |
+| Error | `error.cpp` | `__ry_set_last_error` / `__ry_get_last_error` thread-local channel |
+| String | `string.cpp`, `utf8.cpp` | UTF-8 string ops, `StringHeader`-backed allocations, codepoint-level slicing |
+| Hash | `hash.cpp` | Hash-table primitives backing `Map<K, V>` / `Set<T>` |
+| Any | `any.cpp`, `any_typed_coll.cpp` | `RyAny` arithmetic / comparison / type dispatch, descriptor trampolines |
+| Allocation | `alloc.cpp` (header) | Core `ArcHeader`-aware allocators (`__ry_arc_alloc`, `__ry_arc_free`) |
+| Parallel | `parallel.cpp` | Task spawn / join / `@parallel for` worker pool |
+| Regex | `regex.cpp`, `regex_parser.cpp` | Regex compilation and matching |
+| Sort | `sort.cpp` | List sort primitives |
+| Print | `print.cpp` | Buffered stdout writing |
+
+### Native modules (`src/runtime/native/`, `include/ry/runtime/native/`)
+
+I/O-bound and platform-coupled modules. These are migration candidates of lower priority (less safety-critical than core, but well-isolated and good Rust candidates due to async/error-handling ergonomics).
+
+| Module | Source | Surface |
+| --- | --- | --- |
+| Convert | `convert.cpp` | Type coercion (`__ry_str_to_int`, `__ry_str_to_float`) |
+| Base64 | `base64.cpp` | Encode/decode variants |
+| Net | `net.cpp` | TCP/TLS sockets, `__ry_bind` / `__ry_connect` / send/recv |
+| Thread | `thread.cpp` | User-facing thread spawn/join, locks, condition variables |
+| IO | `io.cpp` | File handle open/read/write/close, `__ry_io_file_*` |
+| Filesystem | `filesystem.cpp` | Path/directory operations |
+| Path | `path.cpp` | Path string manipulation (join/dirname/basename) |
+| GC | `gc.cpp` | User-facing GC hooks |
+| HTTP | `http/` | HTTP client/server (uses Net internally) |
+| JSON | `json.cpp` | JSON parser/serializer |
+| Testing | `testing.cpp` | Mock/spy infrastructure, assertion helpers |
+
+## Rust migration readiness criteria
+
+A native runtime module is a direct Rust-migration candidate when **all** of the following hold:
+
+1. **Parameters and return types are scalar or opaque-pointer only.** Modules that touch fixed-layout POD structs (e.g. `IoFileHandle`) require the Rust side to mirror the layout via `#[repr(C)]`; this is feasible but adds layout-coupling.
+2. **No internal LLVM dependency.** The runtime headers in `include/ry/runtime/{core,native}/` are LLVM-free; modules that quietly reach into codegen state are not migration-ready.
+3. **No transitive C++ template dependency.** STL containers (`std::vector`, `std::unordered_map`) inside the implementation are acceptable because they do not cross the ABI; they can be replaced module-locally during the rewrite.
+4. **The module's failure path uses the `__ry_set_last_error` channel uniformly.** Codegen wraps `Result<T, Error>` at the boundary by reading `__ry_get_last_error` (see [LLVM IR Emission Boundary](llvm-ir-emission-boundary.md) category 3); modules that bypass this channel (e.g. embedding panic in the runtime) break the contract.
+
+### First migration candidates
+
+By the criteria above, the highest-readiness native modules are:
+
+- **Base64** (`base64.cpp`) — pure data transformation, no platform coupling, scalar/pointer ABI.
+- **Convert** (`convert.cpp`) — string-to-number parsing, well-isolated, uses `__ry_set_last_error`.
+- **Path** (`path.cpp`) — string manipulation, no I/O.
+- **JSON** (`json.cpp`) — parsing/serialization, scalar/pointer ABI.
+
+Higher-friction migration targets:
+
+- **Net** / **HTTP** / **Thread** — depend on platform threading primitives; the Rust side needs an async runtime or a `std::thread` bridge.
+- **IO** / **Filesystem** — POD struct layout coupling (`IoFileHandle` with raw `FILE*`).
+- **Testing** — touches the test-mode codegen surface; not a pure runtime module.
+
+Core modules are higher migration value (memory-safety dividend) but higher implementation risk (deeper interaction with `ArcHeader` and codegen-emitted call sites). They should be sequenced after at least one native module has been migrated end-to-end to validate the toolchain.
+
+## Related documents
+
+- [Compiler Layers](compiler-layers.md) — layer ordering and dependency direction.
+- [LLVM IR Emission Boundary](llvm-ir-emission-boundary.md) — the orthogonal LLVM IR emission boundary on the codegen side.
+- `.claude/rules/runtime-memory-safety.md` — runtime memory-safety rules (forbidden functions, OOM handling, NULL checks).

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -8,6 +8,7 @@
 #include "ry/source_manager/source_location.hpp"
 #include "ry/source_manager/source_manager.hpp"
 #include "ry/trace/trace.hpp"
+#include "ry/util/type_name.hpp"
 #include <llvm/ExecutionEngine/Orc/ThreadSafeModule.h>
 #include <llvm/ADT/SmallPtrSet.h>
 #include <llvm/ADT/SmallVector.h>
@@ -78,20 +79,6 @@ public:
     // Populated by the caller (jit_runner) from ModuleLoader::importedTestingIntrinsics().
     void setTestingIntrinsicsImported(const std::unordered_set<std::string> &imported);
     const std::unordered_set<std::string>& getTestingIntrinsicsImported() const;
-
-    // Derive the base runtime function name for a stdlib module function.
-    // e.g. ("base64", "encode") → "__ry_base64_encode"
-    // For overloaded functions, callers must append an arity suffix
-    // (e.g. "__ry_path_join2", "__ry_path_join3") as needed.
-    // Only meaningful for module functions; builtins use varied naming.
-    static std::string deriveRuntimeFnName(const std::string &package,
-                                           const std::string &fn_name);
-
-    // Build the registry key for native_fn_sigs_.
-    static std::string nativeSigKey(const std::string &package,
-                                    const std::string &name) {
-        return package.empty() ? name : package + "::" + name;
-    }
 
     // #1746: returns true when `name` matches a stdlib package registered
     // via RY_REGISTER_STDLIB_PACKAGE (e.g. "math", "json", "path"). Used
@@ -279,9 +266,6 @@ public:
     void retainArcValue(llvm::Value *val);
 
     // Collection type name predicates
-    static bool isListTypeName(const std::string &typeName);
-    static bool isMapTypeName(const std::string &typeName);
-    static bool isSetTypeName(const std::string &typeName);
     static bool isCollectionTypeName(const std::string &typeName);
 
     // #1884: derive literal_any_hint_ from an LHS annotation string
@@ -292,7 +276,6 @@ public:
     LiteralAnyHint computeLiteralAnyHintFromMeta(llvm::Value *ptr);
 
     // ======== Weak References ========
-    static bool isWeakTypeName(const std::string &typeName);
     static std::string weakInnerTypeName(const std::string &typeName);
     void markWeakManaged(llvm::AllocaInst *alloca);
     bool isWeakManaged(llvm::AllocaInst *alloca) const;
@@ -364,14 +347,6 @@ public:
     // operand must trace the chain. Returns nullptr if no matching insert
     // is found.
     static llvm::Value *traceInsertValueField(llvm::Value *agg, unsigned idx);
-
-    // Splits a generic type name like "List<str>" into head="List" and
-    // inner=["str"].  Returns false for non-generic names (no '<').
-    // Extracted from codegen_fn_generic.cpp so callers across translation
-    // units can use the same parsing logic.
-    static bool splitGenericTypeName(const std::string &s,
-                                     std::string &head,
-                                     std::vector<std::string> &inner);
 
     // Predicate: does the container's *element* type itself own an
     // ARC-managed allocation that needs releasing on slot overwrite?
@@ -833,9 +808,6 @@ public:
     // substitution applies. Used by `resolveType` to make generic enum /
     // wrapper types usable at every type position inside a generic function.
     std::string substituteTypeParamsInName(const std::string &typeName);
-    // Strip ASCII spaces from both ends of a type-name substring. Shared by
-    // the comma-separated annotation parsers (Map key/value, tuple destructure).
-    static std::string trimTypeNameSpaces(const std::string &s);
     // Return the best source-level element type name for a list value.
     // Used by enumerate()/zip() to build the tuple `list_elem_type_name`.
     std::string snapshotListElemName(llvm::Value *listVal, llvm::Type *elemTy);
@@ -1026,9 +998,6 @@ public:
     // is the destructor used to release `env_ptr` when the closure is dropped
     // (null for non-capturing functions). Layout mirrored in
     // `getOrCreateUniformClosureDestructor` in src/codegen_lambda.cpp.
-    static bool isFunctionTypeName(const std::string &s) {
-        return s.size() > 3 && s.compare(0, 3, "fn(") == 0;
-    }
     llvm::StructType *getUniformClosureTy() {
         if (!uniformClosureTy_)
             uniformClosureTy_ = llvm::StructType::get(*ctx_, {ptrTy_, ptrTy_, ptrTy_});
@@ -1807,7 +1776,6 @@ public:
     const std::string &getLowLevelTypeName(llvm::Value *val) const;
     bool isUnsignedLowLevel(llvm::Value *val) const;
     static bool isUnsignedLowLevelName(const std::string &name);
-    static bool isLowLevelTypeName(const std::string &name);
     static std::string getExprLowLevelSuffix(const ExprNode &node);
     bool isLowLevelIntTy(llvm::Type *ty) const;
     bool isLowLevelIntTy(llvm::Value *val) const;

--- a/include/ry/util/type_name.hpp
+++ b/include/ry/util/type_name.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace ry {
+namespace util {
+
+// Pure string utilities operating on Ry source-level type names.
+// These helpers carry no codegen state and may be called from any
+// layer (lexer, parser, sema, codegen, runtime). They were extracted
+// from CodeGen by issue #1820 as part of the v0.0.26 boundary cleanup.
+
+// Trim spaces (ASCII ' ' only) from both ends.
+std::string trimTypeNameSpaces(const std::string &s);
+
+// Split a generic type name like "List<int>" into head ("List") and
+// comma-separated inner args (["int"]). Returns false when the input
+// is not in `Head<...>` shape.
+bool splitGenericTypeName(const std::string &s,
+                          std::string &head,
+                          std::vector<std::string> &inner);
+
+bool isListTypeName(const std::string &typeName);
+bool isMapTypeName(const std::string &typeName);
+bool isSetTypeName(const std::string &typeName);
+bool isWeakTypeName(const std::string &typeName);
+
+// Recognises `fn(...)` function type names produced by TypeNode::toString.
+inline bool isFunctionTypeName(const std::string &s) {
+    return s.size() > 3 && s.compare(0, 3, "fn(") == 0;
+}
+
+// Low-level numeric type names (i8 / i16 / i32 / i64 / u8 / u16 / u32 / u64 / f32).
+// Used by codegen to distinguish native-width arithmetic from default int/float.
+bool isLowLevelTypeName(const std::string &name);
+
+// Build the runtime symbol name for a stdlib module function.
+// Empty package returns "__ry_<fn>"; non-empty returns "__ry_<pkg>_<fn>".
+std::string deriveRuntimeFnName(const std::string &package,
+                                const std::string &fn_name);
+
+// Build the registry key for native_fn_sigs_. The format must stay in
+// sync with how CodeGen's native_fn_sigs_ map indexes signatures.
+inline std::string nativeSigKey(const std::string &package,
+                                const std::string &name) {
+    return package.empty() ? name : package + "::" + name;
+}
+
+}  // namespace util
+}  // namespace ry

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1073,21 +1073,16 @@ bool CodeGen::isUnsignedLowLevelName(const std::string &name) {
     return !name.empty() && name[0] == 'u';
 }
 
-bool CodeGen::isLowLevelTypeName(const std::string &name) {
-    return name == "i8" || name == "i16" || name == "i32" || name == "i64" ||
-           name == "u8" || name == "u16" || name == "u32" || name == "u64" || name == "f32";
-}
-
 std::string CodeGen::getExprLowLevelSuffix(const ExprNode &node) {
     if (auto *ue = std::get_if<std::unique_ptr<UnaryExpr>>(&node.data)) {
         if ((*ue)->op == "+" || (*ue)->op == "-")
             return getExprLowLevelSuffix(*(*ue)->operand);
     }
     if (auto *ne = std::get_if<NumberExpr>(&node.data)) {
-        if (isLowLevelTypeName(ne->suffix)) return ne->suffix;
+        if (ry::util::isLowLevelTypeName(ne->suffix)) return ne->suffix;
     }
     if (auto *fe = std::get_if<FloatExpr>(&node.data)) {
-        if (isLowLevelTypeName(fe->suffix)) return fe->suffix;
+        if (ry::util::isLowLevelTypeName(fe->suffix)) return fe->suffix;
     }
     return "";
 }
@@ -1226,7 +1221,7 @@ bool CodeGen::isWideningConversion(llvm::Value *argVal, llvm::Type *paramTy,
                                    const std::string &paramTypeName) const {
     // Block low-level types except i8/u8 (u8 is the successor of byte)
     if (isLowLevelTy(argVal) && argVal->getType() != i8Ty_) return false;
-    if (isLowLevelTypeName(paramTypeName)) return false;
+    if (ry::util::isLowLevelTypeName(paramTypeName)) return false;
     auto *argTy = argVal->getType();
     return (argTy == i8Ty_  && paramTy == i64Ty_) ||   // u8 -> int
            (argTy == i8Ty_  && paramTy == f64Ty_) ||   // u8 -> float

--- a/src/codegen_any.cpp
+++ b/src/codegen_any.cpp
@@ -230,8 +230,8 @@ llvm::Value *CodeGen::buildUnitAny() {
 llvm::Value *CodeGen::unwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy,
                                      const std::string &rawTargetTypeName) {
     // Substitute generic type-parameter names at the helper's entry so every
-    // downstream dispatch (collection-arm via `isListTypeName` /
-    // `isMapTypeName` / `isSetTypeName`, enum-descriptor cache key in
+    // downstream dispatch (collection-arm via `ry::util::isListTypeName` /
+    // `ry::util::isMapTypeName` / `ry::util::isSetTypeName`, enum-descriptor cache key in
     // `unwrapEnumFromAny`, error message, record `findRecordTypeName`) sees
     // the concrete type rather than the raw "T". No-op when `type_param_scope_`
     // is empty, so non-generic call sites stay byte-identical. Mirrors the
@@ -255,8 +255,8 @@ llvm::Value *CodeGen::unwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy,
         targetTypeName != rawTargetTypeName;
     if (fromGenericSubstitution && targetTy == ptrTy_ && !targetTypeName.empty()) {
         std::string resolved = resolveTypeAlias(targetTypeName);
-        if (isListTypeName(resolved)) {
-            std::string inner = trimTypeNameSpaces(
+        if (ry::util::isListTypeName(resolved)) {
+            std::string inner = ry::util::trimTypeNameSpaces(
                 resolved.substr(5, resolved.size() - 6));
             if (inner != "any") {
                 codegenError(
@@ -265,8 +265,8 @@ llvm::Value *CodeGen::unwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy,
                     "be 'any' (use 'List<any>' and unwrap elements "
                     "individually)");
             }
-        } else if (isSetTypeName(resolved)) {
-            std::string inner = trimTypeNameSpaces(
+        } else if (ry::util::isSetTypeName(resolved)) {
+            std::string inner = ry::util::trimTypeNameSpaces(
                 resolved.substr(4, resolved.size() - 5));
             if (inner != "any") {
                 codegenError(
@@ -275,12 +275,12 @@ llvm::Value *CodeGen::unwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy,
                     "be 'any' (use 'Set<any>' and unwrap elements "
                     "individually)");
             }
-        } else if (isMapTypeName(resolved)) {
+        } else if (ry::util::isMapTypeName(resolved)) {
             std::string innerArgs = resolved.substr(4, resolved.size() - 5);
             auto parts = splitTypeArgs(innerArgs);
             if (parts.size() == 2) {
-                std::string k = trimTypeNameSpaces(parts[0]);
-                std::string v = trimTypeNameSpaces(parts[1]);
+                std::string k = ry::util::trimTypeNameSpaces(parts[0]);
+                std::string v = ry::util::trimTypeNameSpaces(parts[1]);
                 if (k != "str" || v != "any") {
                     codegenError(
                         "unwrapping 'any' to '" + targetTypeName +
@@ -437,13 +437,13 @@ llvm::Value *CodeGen::unwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy,
     bool isCollectionUnwrap = false;
     if (targetTy == ptrTy_ && !targetTypeName.empty()) {
         std::string resolved = resolveTypeAlias(targetTypeName);
-        if (isListTypeName(resolved)) {
+        if (ry::util::isListTypeName(resolved)) {
             expectedTag = static_cast<int64_t>(RyAnyTag::List);
             isCollectionUnwrap = true;
-        } else if (isMapTypeName(resolved)) {
+        } else if (ry::util::isMapTypeName(resolved)) {
             expectedTag = static_cast<int64_t>(RyAnyTag::Map);
             isCollectionUnwrap = true;
-        } else if (isSetTypeName(resolved)) {
+        } else if (ry::util::isSetTypeName(resolved)) {
             expectedTag = static_cast<int64_t>(RyAnyTag::Set);
             isCollectionUnwrap = true;
         }
@@ -542,12 +542,12 @@ llvm::Value *CodeGen::tryUnwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy
             if (resolved.size() > kPrefixLen + 1 &&
                 resolved.compare(0, kPrefixLen, kPrefix) == 0 &&
                 resolved.back() == '>') {
-                innerName = trimTypeNameSpaces(
+                innerName = ry::util::trimTypeNameSpaces(
                     resolved.substr(kPrefixLen,
                                     resolved.size() - kPrefixLen - 1));
             } else if (resolved.size() > 1 && resolved.back() == '?') {
                 // `T?` shorthand for `Option<T>`.
-                innerName = trimTypeNameSpaces(
+                innerName = ry::util::trimTypeNameSpaces(
                     resolved.substr(0, resolved.size() - 1));
             }
             return tryUnwrapOptionFromAny(anyVal, st, innerTy, innerName,
@@ -573,8 +573,8 @@ llvm::Value *CodeGen::tryUnwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy
     // of scope for #1852.
     if (targetTy == ptrTy_ && !targetTypeName.empty()) {
         std::string resolved = resolveTypeAlias(targetTypeName);
-        if (isListTypeName(resolved)) {
-            std::string inner = trimTypeNameSpaces(
+        if (ry::util::isListTypeName(resolved)) {
+            std::string inner = ry::util::trimTypeNameSpaces(
                 resolved.substr(5, resolved.size() - 6));
             if (inner == "any") {
                 // Falls through to the standard pointer-tag dispatch below
@@ -587,18 +587,18 @@ llvm::Value *CodeGen::tryUnwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy
                 return tryUnwrapListFromAny(anyVal, elemTy, inner,
                                               targetTypeName, resTy);
             }
-        } else if (isSetTypeName(resolved)) {
-            std::string inner = trimTypeNameSpaces(
+        } else if (ry::util::isSetTypeName(resolved)) {
+            std::string inner = ry::util::trimTypeNameSpaces(
                 resolved.substr(4, resolved.size() - 5));
             if (inner != "any") {
                 return emitUnsupportedErr("typed Set<" + inner + ">");
             }
-        } else if (isMapTypeName(resolved)) {
+        } else if (ry::util::isMapTypeName(resolved)) {
             std::string innerArgs = resolved.substr(4, resolved.size() - 5);
             auto parts = splitTypeArgs(innerArgs);
             if (parts.size() == 2) {
-                std::string k = trimTypeNameSpaces(parts[0]);
-                std::string v = trimTypeNameSpaces(parts[1]);
+                std::string k = ry::util::trimTypeNameSpaces(parts[0]);
+                std::string v = ry::util::trimTypeNameSpaces(parts[1]);
                 if (k != "str") {
                     return emitUnsupportedErr(
                         "typed Map<" + k + ", " + v + ">");
@@ -672,13 +672,13 @@ llvm::Value *CodeGen::tryUnwrapFromAny(llvm::Value *anyVal, llvm::Type *targetTy
     bool isCollectionUnwrap = false;
     if (targetTy == ptrTy_ && !targetTypeName.empty()) {
         std::string resolved = resolveTypeAlias(targetTypeName);
-        if (isListTypeName(resolved)) {
+        if (ry::util::isListTypeName(resolved)) {
             expectedTag = static_cast<int64_t>(RyAnyTag::List);
             isCollectionUnwrap = true;
-        } else if (isMapTypeName(resolved)) {
+        } else if (ry::util::isMapTypeName(resolved)) {
             expectedTag = static_cast<int64_t>(RyAnyTag::Map);
             isCollectionUnwrap = true;
-        } else if (isSetTypeName(resolved)) {
+        } else if (ry::util::isSetTypeName(resolved)) {
             expectedTag = static_cast<int64_t>(RyAnyTag::Set);
             isCollectionUnwrap = true;
         }
@@ -751,8 +751,8 @@ llvm::Value *CodeGen::tryUnwrapRecordFromAny(llvm::Value *anyVal,
         }
         if (fieldLlvmTy != ptrTy_) return FieldKind::None;
         std::string resolved = resolveTypeAlias(fieldTypeName);
-        if (isListTypeName(resolved) || isMapTypeName(resolved) ||
-            isSetTypeName(resolved))
+        if (ry::util::isListTypeName(resolved) || ry::util::isMapTypeName(resolved) ||
+            ry::util::isSetTypeName(resolved))
             return FieldKind::Collection;
         if (resolved == "str") return FieldKind::Str;
         return FieldKind::None;
@@ -784,9 +784,9 @@ llvm::Value *CodeGen::tryUnwrapRecordFromAny(llvm::Value *anyVal,
                     break;
                 case FieldKind::Collection: {
                     CollectionKind ck = CollectionKind::List;
-                    if (isMapTypeName(p.resolvedTypeName))
+                    if (ry::util::isMapTypeName(p.resolvedTypeName))
                         ck = CollectionKind::Map;
-                    else if (isSetTypeName(p.resolvedTypeName))
+                    else if (ry::util::isSetTypeName(p.resolvedTypeName))
                         ck = CollectionKind::Set;
                     emitArcReleaseLoadedElement(p.val, ck, p.resolvedTypeName,
                                                 "tryrec.rel.col");
@@ -982,8 +982,8 @@ static TryUnwrapElemKind classifyTryUnwrapElem(
     }
     if (elemLlvmTy != cg.ptrTy_) return TryUnwrapElemKind::None;
     std::string resolved = cg.resolveTypeAlias(elemTypeName);
-    if (cg.isListTypeName(resolved) || cg.isMapTypeName(resolved) ||
-        cg.isSetTypeName(resolved))
+    if (ry::util::isListTypeName(resolved) || ry::util::isMapTypeName(resolved) ||
+        ry::util::isSetTypeName(resolved))
         return TryUnwrapElemKind::Collection;
     if (resolved == "str") return TryUnwrapElemKind::Str;
     return TryUnwrapElemKind::None;
@@ -1154,8 +1154,8 @@ llvm::Value *CodeGen::tryUnwrapListFromAny(llvm::Value *anyVal,
                 break;
             case TryUnwrapElemKind::Collection: {
                 CollectionKind ck = CollectionKind::List;
-                if (isMapTypeName(resolvedElemTy)) ck = CollectionKind::Map;
-                else if (isSetTypeName(resolvedElemTy)) ck = CollectionKind::Set;
+                if (ry::util::isMapTypeName(resolvedElemTy)) ck = CollectionKind::Map;
+                else if (ry::util::isSetTypeName(resolvedElemTy)) ck = CollectionKind::Set;
                 emitArcReleaseLoadedElement(relVal, ck, resolvedElemTy,
                                             "trylst.rel.col");
                 break;
@@ -1431,8 +1431,8 @@ llvm::Value *CodeGen::tryUnwrapMapFromAny(llvm::Value *anyVal,
                     break;
                 case TryUnwrapElemKind::Collection: {
                     CollectionKind ck = CollectionKind::List;
-                    if (isMapTypeName(resolvedValTy)) ck = CollectionKind::Map;
-                    else if (isSetTypeName(resolvedValTy)) ck = CollectionKind::Set;
+                    if (ry::util::isMapTypeName(resolvedValTy)) ck = CollectionKind::Map;
+                    else if (ry::util::isSetTypeName(resolvedValTy)) ck = CollectionKind::Set;
                     emitArcReleaseLoadedElement(relVal, ck, resolvedValTy,
                                                 "trymap.rel.v.col");
                     break;
@@ -1819,13 +1819,13 @@ void CodeGen::emitAnyReleaseVar(const std::string &name,
             std::string canon = resolveTypeAlias(useTypeName);
             switch (kind) {
                 case CollectionKind::List:
-                    sourceMatchesKind = isListTypeName(canon);
+                    sourceMatchesKind = ry::util::isListTypeName(canon);
                     break;
                 case CollectionKind::Map:
-                    sourceMatchesKind = isMapTypeName(canon);
+                    sourceMatchesKind = ry::util::isMapTypeName(canon);
                     break;
                 case CollectionKind::Set:
-                    sourceMatchesKind = isSetTypeName(canon);
+                    sourceMatchesKind = ry::util::isSetTypeName(canon);
                     break;
                 case CollectionKind::Str:
                     sourceMatchesKind = false;
@@ -2002,13 +2002,13 @@ void CodeGen::emitAnyReleasePayload(llvm::Value *anyVal,
             std::string canon = resolveTypeAlias(useTypeName);
             switch (kind) {
                 case CollectionKind::List:
-                    sourceMatchesKind = isListTypeName(canon);
+                    sourceMatchesKind = ry::util::isListTypeName(canon);
                     break;
                 case CollectionKind::Map:
-                    sourceMatchesKind = isMapTypeName(canon);
+                    sourceMatchesKind = ry::util::isMapTypeName(canon);
                     break;
                 case CollectionKind::Set:
-                    sourceMatchesKind = isSetTypeName(canon);
+                    sourceMatchesKind = ry::util::isSetTypeName(canon);
                     break;
                 case CollectionKind::Str:
                     sourceMatchesKind = false;

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -446,20 +446,8 @@ void CodeGen::emitArcReleaseVar(const std::string &name, llvm::AllocaInst *alloc
 
 // ===== Collection type name helpers =====
 
-bool CodeGen::isListTypeName(const std::string &typeName) {
-    return typeName.size() > 5 && typeName.compare(0, 5, "List<") == 0;
-}
-
-bool CodeGen::isMapTypeName(const std::string &typeName) {
-    return typeName.size() > 4 && typeName.compare(0, 4, "Map<") == 0;
-}
-
-bool CodeGen::isSetTypeName(const std::string &typeName) {
-    return typeName.size() > 4 && typeName.compare(0, 4, "Set<") == 0;
-}
-
 bool CodeGen::isCollectionTypeName(const std::string &typeName) {
-    return isListTypeName(typeName) || isMapTypeName(typeName) || isSetTypeName(typeName);
+    return ry::util::isListTypeName(typeName) || ry::util::isMapTypeName(typeName) || ry::util::isSetTypeName(typeName);
 }
 
 bool CodeGen::fieldTypeIsArcManaged(const std::string &fieldTypeName,
@@ -477,7 +465,7 @@ bool CodeGen::fieldTypeIsArcManaged(const std::string &fieldTypeName,
     if (fieldTypeName.empty())
         return false;
     const std::string resolved = resolveTypeAlias(fieldTypeName);
-    if (isWeakTypeName(resolved))
+    if (ry::util::isWeakTypeName(resolved))
         return false;
     if (resolved == "str") {
         // str is ARC-managed via StringHeader (handle - STRING_HEADER_SIZE = 24).
@@ -485,15 +473,15 @@ bool CodeGen::fieldTypeIsArcManaged(const std::string &fieldTypeName,
         if (outFieldKind) *outFieldKind = CollectionKind::Str;
         return true;
     }
-    if (isListTypeName(resolved)) {
+    if (ry::util::isListTypeName(resolved)) {
         if (outFieldKind) *outFieldKind = CollectionKind::List;
         return true;
     }
-    if (isMapTypeName(resolved)) {
+    if (ry::util::isMapTypeName(resolved)) {
         if (outFieldKind) *outFieldKind = CollectionKind::Map;
         return true;
     }
-    if (isSetTypeName(resolved)) {
+    if (ry::util::isSetTypeName(resolved)) {
         if (outFieldKind) *outFieldKind = CollectionKind::Set;
         return true;
     }
@@ -627,17 +615,17 @@ void CodeGen::emitTaggedUnionRelease(llvm::AllocaInst *alloca,
     std::string okName, errName;
     if (isOption && resolvedSource.size() > 1 && resolvedSource.back() == '?') {
         // T? shorthand for Option<T>
-        okName = trimTypeNameSpaces(
+        okName = ry::util::trimTypeNameSpaces(
             resolvedSource.substr(0, resolvedSource.size() - 1));
     } else {
         std::string head;
         std::vector<std::string> innerArgs;
-        if (splitGenericTypeName(resolvedSource, head, innerArgs)) {
+        if (ry::util::splitGenericTypeName(resolvedSource, head, innerArgs)) {
             if (isResult && head == "Result") {
-                if (!innerArgs.empty()) okName = trimTypeNameSpaces(innerArgs[0]);
-                if (innerArgs.size() >= 2) errName = trimTypeNameSpaces(innerArgs[1]);
+                if (!innerArgs.empty()) okName = ry::util::trimTypeNameSpaces(innerArgs[0]);
+                if (innerArgs.size() >= 2) errName = ry::util::trimTypeNameSpaces(innerArgs[1]);
             } else if (isOption && head == "Option") {
-                if (!innerArgs.empty()) okName = trimTypeNameSpaces(innerArgs[0]);
+                if (!innerArgs.empty()) okName = ry::util::trimTypeNameSpaces(innerArgs[0]);
             }
         }
     }
@@ -713,10 +701,6 @@ bool CodeGen::elementTypeIsArcManaged(llvm::Value *containerPtr,
 }
 
 // ===== Weak reference operations =====
-
-bool CodeGen::isWeakTypeName(const std::string &typeName) {
-    return typeName.size() > 5 && typeName.compare(0, 5, "weak ") == 0;
-}
 
 std::string CodeGen::weakInnerTypeName(const std::string &typeName) {
     return typeName.substr(5);
@@ -1098,7 +1082,7 @@ llvm::FunctionCallee CodeGen::getOrCreateCollectionDestructor(CollectionKind kin
         std::string innerValSig;
         std::string head;
         std::vector<std::string> innerArgs;
-        if (splitGenericTypeName(resolved, head, innerArgs)) {
+        if (ry::util::splitGenericTypeName(resolved, head, innerArgs)) {
             if ((innerKind == CollectionKind::List || innerKind == CollectionKind::Set) &&
                 !innerArgs.empty()) {
                 innerElemSig = resolveTypeAlias(innerArgs[0]);
@@ -1253,11 +1237,11 @@ void CodeGen::emitTupleComponentRetain(llvm::Value *val,
                                         const std::string &fSig) {
     if (fSig.empty() || !val) return;
     const std::string resolved = resolveTypeAlias(fSig);
-    if (resolved.empty() || isWeakTypeName(resolved)) return;
+    if (resolved.empty() || ry::util::isWeakTypeName(resolved)) return;
     if (resolved == "str") {
         emitArcRetain(emitStrGetHeaderFromData(val), isArcAtomic(val));
-    } else if (isListTypeName(resolved) || isMapTypeName(resolved) ||
-               isSetTypeName(resolved)) {
+    } else if (ry::util::isListTypeName(resolved) || ry::util::isMapTypeName(resolved) ||
+               ry::util::isSetTypeName(resolved)) {
         emitArcRetain(emitArcGetHeaderFromData(val), isArcAtomic(val));
     } else if (resolved.size() >= 2 && resolved.front() == '(' &&
                 resolved.back() == ')') {
@@ -1285,7 +1269,7 @@ void CodeGen::emitTupleComponentRetainTraced(llvm::Value *fieldVal,
                                               const std::string &fSig) {
     if (fSig.empty() || !fieldVal) return;
     const std::string resolved = resolveTypeAlias(fSig);
-    if (resolved.empty() || isWeakTypeName(resolved)) return;
+    if (resolved.empty() || ry::util::isWeakTypeName(resolved)) return;
 
     // Recover the original SSA value at `topIdx` of `sourceAgg`. When
     // sourceAgg is an InsertValueInst chain (the freshly-built tuple in
@@ -1384,11 +1368,11 @@ void CodeGen::emitTupleElemReleaseSlot(llvm::Value *slotPtr,
         std::min<size_t>(components.size(), tupleTy->getNumElements()));
     for (unsigned i = 0; i < n; ++i) {
         const std::string fSig = resolveTypeAlias(components[i]);
-        if (fSig.empty() || isWeakTypeName(fSig)) continue;
+        if (fSig.empty() || ry::util::isWeakTypeName(fSig)) continue;
 
         const bool isStr  = (fSig == "str");
-        const bool isColl = isListTypeName(fSig) || isMapTypeName(fSig) ||
-                            isSetTypeName(fSig);
+        const bool isColl = ry::util::isListTypeName(fSig) || ry::util::isMapTypeName(fSig) ||
+                            ry::util::isSetTypeName(fSig);
         const bool isTup  = (fSig.size() >= 2 && fSig.front() == '(' &&
                               fSig.back() == ')');
         if (!isStr && !isColl && !isTup) continue;
@@ -1435,10 +1419,10 @@ void CodeGen::emitTupleElemReleaseSlot(llvm::Value *slotPtr,
             std::vector<std::string> innerArgs;
             CollectionKind innerKind = CollectionKind::List;
             std::string innerElemSig, innerValSig;
-            if (isListTypeName(fSig)) innerKind = CollectionKind::List;
-            else if (isMapTypeName(fSig)) innerKind = CollectionKind::Map;
-            else if (isSetTypeName(fSig)) innerKind = CollectionKind::Set;
-            if (splitGenericTypeName(fSig, head, innerArgs)) {
+            if (ry::util::isListTypeName(fSig)) innerKind = CollectionKind::List;
+            else if (ry::util::isMapTypeName(fSig)) innerKind = CollectionKind::Map;
+            else if (ry::util::isSetTypeName(fSig)) innerKind = CollectionKind::Set;
+            if (ry::util::splitGenericTypeName(fSig, head, innerArgs)) {
                 if ((innerKind == CollectionKind::List ||
                      innerKind == CollectionKind::Set) &&
                     !innerArgs.empty()) {
@@ -1473,9 +1457,9 @@ void CodeGen::emitTupleElemReleaseLoop(llvm::Value *arrayPtr, llvm::Value *len,
     bool anyArc = false;
     for (const auto &c : components) {
         const std::string r = resolveTypeAlias(c);
-        if (r.empty() || isWeakTypeName(r)) continue;
-        if (r == "str" || isListTypeName(r) || isMapTypeName(r) ||
-            isSetTypeName(r) ||
+        if (r.empty() || ry::util::isWeakTypeName(r)) continue;
+        if (r == "str" || ry::util::isListTypeName(r) || ry::util::isMapTypeName(r) ||
+            ry::util::isSetTypeName(r) ||
             (r.size() >= 2 && r.front() == '(' && r.back() == ')')) {
             anyArc = true;
             break;
@@ -1509,9 +1493,9 @@ void CodeGen::emitTupleElemRetainLoop(llvm::Value *arrayPtr, llvm::Value *len,
     bool anyArc = false;
     for (const auto &c : components) {
         const std::string r = resolveTypeAlias(c);
-        if (r.empty() || isWeakTypeName(r)) continue;
-        if (r == "str" || isListTypeName(r) || isMapTypeName(r) ||
-            isSetTypeName(r) ||
+        if (r.empty() || ry::util::isWeakTypeName(r)) continue;
+        if (r == "str" || ry::util::isListTypeName(r) || ry::util::isMapTypeName(r) ||
+            ry::util::isSetTypeName(r) ||
             (r.size() >= 2 && r.front() == '(' && r.back() == ')')) {
             anyArc = true;
             break;
@@ -1530,11 +1514,11 @@ void CodeGen::emitTupleElemRetainLoop(llvm::Value *arrayPtr, llvm::Value *len,
         std::min<size_t>(components.size(), tupleTy->getNumElements()));
     for (unsigned i = 0; i < n; ++i) {
         const std::string fSig = resolveTypeAlias(components[i]);
-        if (fSig.empty() || isWeakTypeName(fSig)) continue;
+        if (fSig.empty() || ry::util::isWeakTypeName(fSig)) continue;
 
         const bool isStr  = (fSig == "str");
-        const bool isColl = isListTypeName(fSig) || isMapTypeName(fSig) ||
-                            isSetTypeName(fSig);
+        const bool isColl = ry::util::isListTypeName(fSig) || ry::util::isMapTypeName(fSig) ||
+                            ry::util::isSetTypeName(fSig);
         const bool isTup  = (fSig.size() >= 2 && fSig.front() == '(' &&
                               fSig.back() == ')');
         if (!isStr && !isColl && !isTup) continue;

--- a/src/codegen_arc_gc.cpp
+++ b/src/codegen_arc_gc.cpp
@@ -137,7 +137,7 @@ bool CodeGen::isPotentiallyCyclic(const std::string &typeName) const {
     if (typeName.size() > 1 && typeName.back() == '?')
         return isPotentiallyCyclic(typeName.substr(0, typeName.size() - 1));
     // Map<K,V> — check both K and V
-    if (isMapTypeName(typeName) && typeName.back() == '>') {
+    if (ry::util::isMapTypeName(typeName) && typeName.back() == '>') {
         std::string inner = typeName.substr(4, typeName.size() - 5);
         // Find the comma separating K and V (handle nested generics)
         int depth = 0;

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -64,14 +64,6 @@ RY_IS_RESOURCE(isRegex,              "Regex")
 #undef RY_IS_RESOURCE
 
 
-std::string CodeGen::trimTypeNameSpaces(const std::string &s) {
-    size_t b = 0;
-    while (b < s.size() && s[b] == ' ') ++b;
-    size_t e = s.size();
-    while (e > b && s[e - 1] == ' ') --e;
-    return s.substr(b, e - b);
-}
-
 bool CodeGen::ensureEnumInstantiated(const std::string &typeName) {
     if (enum_types_.count(typeName)) return true;
     auto lt = typeName.find('<');
@@ -95,17 +87,17 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
     if (resolved.size() > 5 && resolved.compare(0, 5, "Task<") == 0 && resolved.back() == '>') {
         std::string inner = resolved.substr(5, resolved.size() - 6);
         setTypeMeta(TypeMeta::TaskResult, val, resolveType(inner));
-    } else if (isListTypeName(resolved) && resolved.back() == '>') {
+    } else if (ry::util::isListTypeName(resolved) && resolved.back() == '>') {
         std::string inner = resolved.substr(5, resolved.size() - 6);
         setTypeMeta(TypeMeta::ListElem, val, resolveType(inner));
         getOrCreateMeta(val).list_elem_type_name = inner;
-        if (isFunctionTypeName(inner))
+        if (ry::util::isFunctionTypeName(inner))
             getOrCreateMeta(val).list_elem_fn_type_info = parseFnTypeAnnotation(inner);
-        if (isListTypeName(inner) && inner.back() == '>') {
+        if (ry::util::isListTypeName(inner) && inner.back() == '>') {
             std::string nested = inner.substr(5, inner.size() - 6);
             setTypeMeta(TypeMeta::NestedListElem, val, resolveType(nested));
         }
-    } else if (isMapTypeName(resolved) && resolved.back() == '>') {
+    } else if (ry::util::isMapTypeName(resolved) && resolved.back() == '>') {
         auto [keyTy, valTy] = parseMapTypeAnnotation(resolved);
         if (keyTy) setTypeMeta(TypeMeta::MapKey, val, keyTy);
         if (valTy) setTypeMeta(TypeMeta::MapValue, val, valTy);
@@ -113,24 +105,24 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         // (key name is used by map-iteration destructure in #813).
         auto parts = splitTypeArgs(resolved.substr(4, resolved.size() - 5));
         if (parts.size() == 2) {
-            std::string ktn = trimTypeNameSpaces(parts[0]);
-            std::string vtn = trimTypeNameSpaces(parts[1]);
+            std::string ktn = ry::util::trimTypeNameSpaces(parts[0]);
+            std::string vtn = ry::util::trimTypeNameSpaces(parts[1]);
             if (!ktn.empty()) {
                 getOrCreateMeta(val).map_key_type_name = ktn;
-                if (isFunctionTypeName(ktn))
+                if (ry::util::isFunctionTypeName(ktn))
                     getOrCreateMeta(val).map_key_fn_type_info = parseFnTypeAnnotation(ktn);
             }
             if (!vtn.empty()) {
                 getOrCreateMeta(val).map_value_type_name = vtn;
-                if (isFunctionTypeName(vtn))
+                if (ry::util::isFunctionTypeName(vtn))
                     getOrCreateMeta(val).map_value_fn_type_info = parseFnTypeAnnotation(vtn);
             }
         }
-    } else if (isSetTypeName(resolved) && resolved.back() == '>') {
+    } else if (ry::util::isSetTypeName(resolved) && resolved.back() == '>') {
         std::string inner = resolved.substr(4, resolved.size() - 5);
         setTypeMeta(TypeMeta::SetElem, val, resolveType(inner));
         getOrCreateMeta(val).set_elem_type_name = inner;
-        if (isFunctionTypeName(inner))
+        if (ry::util::isFunctionTypeName(inner))
             getOrCreateMeta(val).set_elem_fn_type_info = parseFnTypeAnnotation(inner);
     } else if (resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0 && resolved.back() == '>') {
         // Stamp the lossless full type name so pattern bindings can recover
@@ -162,7 +154,7 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
                             (getMeta(val)->list_elem || getMeta(val)->map_key ||
                              getMeta(val)->set_elem));
             propagateTypeMeta(okType, val);
-            propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(okType)));
+            propagateResourceLikeMeta(resolveTypeAlias(ry::util::trimTypeNameSpaces(okType)));
             bool hasMeta = (getMeta(val) != nullptr &&
                             (getMeta(val)->list_elem || getMeta(val)->map_key ||
                              getMeta(val)->set_elem));
@@ -173,7 +165,7 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
                 size_t start = errType.find_first_not_of(' ');
                 if (start != std::string::npos) errType = errType.substr(start);
                 propagateTypeMeta(errType, val);
-                propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(errType)));
+                propagateResourceLikeMeta(resolveTypeAlias(ry::util::trimTypeNameSpaces(errType)));
             }
         }
     } else if (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0 && resolved.back() == '>') {
@@ -182,7 +174,7 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         // Same treatment for Option<Collection> (#985 — mirrors Result handling above).
         std::string inner = resolved.substr(7, resolved.size() - 8);
         propagateTypeMeta(inner, val);
-        propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(inner)));
+        propagateResourceLikeMeta(resolveTypeAlias(ry::util::trimTypeNameSpaces(inner)));
     } else if (resolved.size() > 1 && resolved.back() == '?') {
         // T? suffix is OptionalType::toString() shorthand for Option<T> (#1003).
         // Normalize to Option<inner> form before stamping source_type_name so
@@ -191,8 +183,8 @@ void CodeGen::propagateTypeMeta(const std::string &typeName, llvm::Value *val) {
         std::string inner = resolved.substr(0, resolved.size() - 1);
         getOrCreateMeta(val).source_type_name = "Option<" + inner + ">";
         propagateTypeMeta(inner, val);
-        propagateResourceLikeMeta(resolveTypeAlias(trimTypeNameSpaces(inner)));
-    } else if (isLowLevelTypeName(resolved)) {
+        propagateResourceLikeMeta(resolveTypeAlias(ry::util::trimTypeNameSpaces(inner)));
+    } else if (ry::util::isLowLevelTypeName(resolved)) {
         getOrCreateMeta(val).low_level_type_name = resolved;
     } else if (ResourceKindRegistry::instance().lookupByTypeName(resolved) !=
                ResourceKindRegistry::NONE) {
@@ -224,7 +216,7 @@ void CodeGen::propagateReturnFnTypeMeta(const OverloadEntry *entry, llvm::Functi
     }
     if (!entry) return;
     std::string resolved = resolveTypeAlias(entry->returnTypeName);
-    if (!isFunctionTypeName(resolved)) return;
+    if (!ry::util::isFunctionTypeName(resolved)) return;
     getOrCreateMeta(result).fn_type_info = parseFnTypeAnnotation(resolved);
 }
 
@@ -232,14 +224,14 @@ std::string CodeGen::extractMapKeyTypeName(const std::string &mapTypeName) {
     std::string inner = mapTypeName.substr(4, mapTypeName.size() - 5);
     auto parts = splitTypeArgs(inner);
     if (parts.size() != 2) return "";
-    return trimTypeNameSpaces(parts[0]);
+    return ry::util::trimTypeNameSpaces(parts[0]);
 }
 
 std::string CodeGen::extractMapValueTypeName(const std::string &mapTypeName) {
     std::string inner = mapTypeName.substr(4, mapTypeName.size() - 5);
     auto parts = splitTypeArgs(inner);
     if (parts.size() != 2) return "";
-    return trimTypeNameSpaces(parts[1]);
+    return ry::util::trimTypeNameSpaces(parts[1]);
 }
 
 std::string CodeGen::snapshotListElemName(llvm::Value *listVal, llvm::Type *elemTy) {

--- a/src/codegen_call_higher_order.cpp
+++ b/src/codegen_call_higher_order.cpp
@@ -676,16 +676,16 @@ llvm::Value *CodeGen::emitBuiltinHigherOrder(const CallExpr &e, llvm::Value *pre
             std::string inside = sourceElemName.substr(7, sourceElemName.size() - 8);
             auto parts = splitTypeArgs(inside);
             if (!parts.empty())
-                innerTypeName = trimTypeNameSpaces(parts[0]);
+                innerTypeName = ry::util::trimTypeNameSpaces(parts[0]);
             if (parts.size() >= 2)
-                errTypeName = trimTypeNameSpaces(parts[1]);
+                errTypeName = ry::util::trimTypeNameSpaces(parts[1]);
         } else if (sourceElemName.size() > 8 &&
                    sourceElemName.compare(0, 7, "Option<") == 0 &&
                    sourceElemName.back() == '>') {
             std::string inside = sourceElemName.substr(7, sourceElemName.size() - 8);
             auto parts = splitTypeArgs(inside);
             if (!parts.empty())
-                innerTypeName = trimTypeNameSpaces(parts[0]);
+                innerTypeName = ry::util::trimTypeNameSpaces(parts[0]);
         } else if (sourceElemName.size() > 1 && sourceElemName.back() == '?') {
             innerTypeName = sourceElemName.substr(0, sourceElemName.size() - 1);
         }

--- a/src/codegen_call_native.cpp
+++ b/src/codegen_call_native.cpp
@@ -12,7 +12,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     // Guard: check if this callee has any registered @native signature
     // for this package (or as a bare name for inline declarations).
     // The sigKey is reused later for signature lookup (variadic + normal paths).
-    std::string sigKey = nativeSigKey(package, e.callee);
+    std::string sigKey = ry::util::nativeSigKey(package, e.callee);
     if (!native_fn_sigs_.count(sigKey) && !native_fn_sigs_.count(e.callee))
         return nullptr;
 
@@ -31,7 +31,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     auto getErrFnName = [&]() -> std::string {
         if (entry->errFnOverride)
             return entry->errFnOverride;
-        return deriveRuntimeFnName(package, "get_last_error");
+        return ry::util::deriveRuntimeFnName(package, "get_last_error");
     };
 
     // Resolve the effective runtime suffix
@@ -145,7 +145,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
 
         std::string rtName = (entry->rtNameOverride
             ? std::string(entry->rtNameOverride)
-            : deriveRuntimeFnName(package, rtSuffix))
+            : ry::util::deriveRuntimeFnName(package, rtSuffix))
             + std::to_string(n);
 
         // For ResultPtr, the C runtime returns a raw pointer; wrap after call.
@@ -322,7 +322,7 @@ llvm::Value *CodeGen::emitTableDrivenNativeCall(
     // Derive runtime function name
     std::string rtName = entry->rtNameOverride
         ? entry->rtNameOverride
-        : deriveRuntimeFnName(package, rtSuffix);
+        : ry::util::deriveRuntimeFnName(package, rtSuffix);
 
     // Pre-compute out-param type for ResultOutParam (used in two places)
     llvm::Type *outTy = nullptr;
@@ -512,7 +512,7 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     candidateTypes.reserve(e.args.size());
 
     for (const auto &lib : libIt->second) {
-        std::string sigKey = nativeSigKey(lib, e.callee);
+        std::string sigKey = ry::util::nativeSigKey(lib, e.callee);
         auto sigIt = native_fn_sigs_.find(sigKey);
         if (sigIt == native_fn_sigs_.end()) continue;
         for (const auto &sig : sigIt->second) {
@@ -548,7 +548,7 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     if (!matchedSig) {
         std::vector<bool> candidateNeedsWidening(e.args.size(), false);
         for (const auto &lib : libIt->second) {
-            std::string sigKey = nativeSigKey(lib, e.callee);
+            std::string sigKey = ry::util::nativeSigKey(lib, e.callee);
             auto sigIt = native_fn_sigs_.find(sigKey);
             if (sigIt == native_fn_sigs_.end()) continue;
             for (const auto &sig : sigIt->second) {
@@ -610,13 +610,13 @@ llvm::Value *CodeGen::emitGenericNativeCall(const CallExpr &e) {
     }
 
     // Derive runtime function name: __ry_<module>_<fn_name>
-    std::string rtName = deriveRuntimeFnName(matchedPackage, e.callee);
+    std::string rtName = ry::util::deriveRuntimeFnName(matchedPackage, e.callee);
 
     // Determine C-level calling convention from the Ry return type
     auto [wrapping, outParamType] = inferReturnWrapping(matchedSig->returnTypeName);
 
     // Error function name for Result wrappings
-    std::string errFnName = deriveRuntimeFnName(matchedPackage, "get_last_error");
+    std::string errFnName = ry::util::deriveRuntimeFnName(matchedPackage, "get_last_error");
 
     // Build C-level return type and handle out-param
     llvm::Type *outTy = nullptr;
@@ -760,7 +760,7 @@ const CodeGen::NativeFnSignature *CodeGen::pickNativeOverloadByCallShape(
     actualNames.reserve(e.args.size());
     for (const auto &arg : e.args) {
         std::string n = inferExprTypeName(*arg, emptyParamMap, emptyParamNameMap);
-        actualNames.push_back(resolveTypeAlias(trimTypeNameSpaces(n)));
+        actualNames.push_back(resolveTypeAlias(ry::util::trimTypeNameSpaces(n)));
     }
 
     picked = nullptr;
@@ -769,7 +769,7 @@ const CodeGen::NativeFnSignature *CodeGen::pickNativeOverloadByCallShape(
         if (sig.params.size() != e.args.size()) continue;
         bool eq = true;
         for (size_t i = 0; i < sig.params.size(); ++i) {
-            if (resolveTypeAlias(trimTypeNameSpaces(sig.params[i].typeName))
+            if (resolveTypeAlias(ry::util::trimTypeNameSpaces(sig.params[i].typeName))
                     != actualNames[i]) {
                 eq = false; break;
             }

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -289,9 +289,9 @@ llvm::Value *CodeGen::emitUserFnCall(const std::string &callee, const std::vecto
         if (!typeName) return;
 
         std::string resolvedType = resolveTypeAlias(*typeName);
-        if (isLowLevelTypeName(resolvedType))
+        if (ry::util::isLowLevelTypeName(resolvedType))
             getOrCreateMeta(alloca).low_level_type_name = resolvedType;
-        if (isFunctionTypeName(resolvedType))
+        if (ry::util::isFunctionTypeName(resolvedType))
             getOrCreateMeta(alloca).fn_type_info = parseFnTypeAnnotation(resolvedType);
         auto constraint = parseTypeConstraint(resolvedType);
         if (constraint)
@@ -931,11 +931,11 @@ llvm::Value *CodeGen::coerceToLowLevelType(llvm::Value *val, llvm::Type *targetT
     }
 
     if (val->getType() == f64Ty_ && targetTy == i64Ty_ &&
-        !isLowLevelTypeName(typeName)) {
+        !ry::util::isLowLevelTypeName(typeName)) {
         return emitCheckedFPToInt(val, i64Ty_, "int", truncName);
     }
     if (val->getType() == i64Ty_ && targetTy == f64Ty_ &&
-        !isLowLevelTypeName(typeName)) {
+        !ry::util::isLowLevelTypeName(typeName)) {
         return builder_.CreateSIToFP(val, f64Ty_, truncName);
     }
 

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -203,7 +203,7 @@ llvm::Value *CodeGen::emitExprVariant(const VariableExpr &e) {
         info.returnTypeName = entry.returnTypeName;
         {
             std::string resolved = resolveTypeAlias(entry.returnTypeName);
-            if (isFunctionTypeName(resolved))
+            if (ry::util::isFunctionTypeName(resolved))
                 info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(resolved));
         }
 
@@ -258,7 +258,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<UnaryExpr> &e) {
         if (auto *ne = std::get_if<NumberExpr>(&e->operand->data)) {
             const bool isBareInt = ne->suffix.empty();
             const bool isSignedSuffix =
-                !ne->suffix.empty() && isLowLevelTypeName(ne->suffix) &&
+                !ne->suffix.empty() && ry::util::isLowLevelTypeName(ne->suffix) &&
                 !isUnsignedLowLevelName(ne->suffix) && ne->suffix != "f32";
             if (isBareInt || isSignedSuffix) {
                 llvm::Type *ty = isBareInt ? i64Ty_ : resolveType(ne->suffix);
@@ -316,7 +316,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<UnaryExpr> &e) {
         bool isLowLevel = isLowLevelTy(val);
         if (!isLowLevel) {
             if (auto *ne = std::get_if<NumberExpr>(&e->operand->data))
-                isLowLevel = isLowLevelTypeName(ne->suffix);
+                isLowLevel = ry::util::isLowLevelTypeName(ne->suffix);
         }
         if (val->getType() == i64Ty_ && !isLowLevel)
             return emitIntOverflowCheck(llvm::Intrinsic::ssub_with_overflow,
@@ -326,7 +326,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<UnaryExpr> &e) {
         std::string llName = getLowLevelTypeName(val);
         if (llName.empty()) {
             if (auto *ne = std::get_if<NumberExpr>(&e->operand->data))
-                if (isLowLevelTypeName(ne->suffix)) llName = ne->suffix;
+                if (ry::util::isLowLevelTypeName(ne->suffix)) llName = ne->suffix;
         }
         if (!llName.empty()) getOrCreateMeta(neg).low_level_type_name = llName;
         return neg;
@@ -588,7 +588,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
                         if (fit == einfo.variantFields.end()) continue;
                         for (size_t fi = 0; fi < fit->second.fieldTypeNames.size(); ++fi) {
                             const std::string &ftn = fit->second.fieldTypeNames[fi];
-                            if (isFunctionTypeName(ftn))
+                            if (ry::util::isFunctionTypeName(ftn))
                                 codegenError("ADT enum == / != is not supported for "
                                     "function-typed payload '" + vname + "." +
                                     std::to_string(fi) + "'");
@@ -754,7 +754,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
 
                 // Reject function-typed variants; collections/records use propagateTypeMeta below.
                 for (const auto &cname : uinfo.componentNames) {
-                    if (isFunctionTypeName(cname))
+                    if (ry::util::isFunctionTypeName(cname))
                         codegenError("union == / != is not supported for "
                             "function-typed variant '" + cname + "'");
                 }
@@ -1053,7 +1053,7 @@ llvm::Value *CodeGen::emitComparisonOp(const std::string &op, llvm::Value *lhs, 
     // Enter when metadata or matching AST hints identify a low-level pair (#595)
     bool cmpLowLevel = lhs->getType() == rhs->getType() &&
         ((isLowLevelTy(lhs) || isLowLevelTy(rhs)) ||
-         (!lhsHint.empty() && lhsHint == rhsHint && isLowLevelTypeName(lhsHint)));
+         (!lhsHint.empty() && lhsHint == rhsHint && ry::util::isLowLevelTypeName(lhsHint)));
     if (cmpLowLevel) {
         if (isLowLevelFloatTy(lhs->getType())) {
             llvm::CmpInst::Predicate pred;
@@ -1130,7 +1130,7 @@ llvm::Value *CodeGen::emitBitwiseOp(const std::string &op, llvm::Value *lhs, llv
     // Low-level integer bitwise at native width (#595)
     bool bwLowLevel = lhs->getType() == rhs->getType() &&
         ((isLowLevelIntTy(lhs) || isLowLevelIntTy(rhs)) ||
-         (!lhsHint.empty() && lhsHint == rhsHint && isLowLevelTypeName(lhsHint) && lhsHint != "f32"));
+         (!lhsHint.empty() && lhsHint == rhsHint && ry::util::isLowLevelTypeName(lhsHint) && lhsHint != "f32"));
     if (bwLowLevel) {
         std::string llName = getLowLevelTypeName(lhs);
         if (llName.empty()) llName = getLowLevelTypeName(rhs);
@@ -1173,7 +1173,7 @@ llvm::Value *CodeGen::emitArithmeticOp(const std::string &op, llvm::Value *lhs, 
     // Low-level type native-width arithmetic (#595)
     bool arithLowLevel = lhs->getType() == rhs->getType() &&
         ((isLowLevelTy(lhs) || isLowLevelTy(rhs)) ||
-         (!lhsHint.empty() && lhsHint == rhsHint && isLowLevelTypeName(lhsHint)));
+         (!lhsHint.empty() && lhsHint == rhsHint && ry::util::isLowLevelTypeName(lhsHint)));
     if (arithLowLevel) {
         llvm::Type *ty = lhs->getType();
         if (op == "**")

--- a/src/codegen_expr_literal.cpp
+++ b/src/codegen_expr_literal.cpp
@@ -281,15 +281,15 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<TupleExpr> &e) {
 CodeGen::LiteralAnyHint CodeGen::computeLiteralAnyHintFromAnnot(const std::string &annot) {
     LiteralAnyHint hint;
     std::string resolved = resolveTypeAlias(annot);
-    if (isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
-        std::string inner = trimTypeNameSpaces(resolved.substr(5, resolved.size() - 6));
+    if (ry::util::isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
+        std::string inner = ry::util::trimTypeNameSpaces(resolved.substr(5, resolved.size() - 6));
         if (inner == "any")
             hint.list_elem_any = true;
-    } else if (isSetTypeName(resolved) && resolved.size() >= 6 && resolved.back() == '>') {
-        std::string inner = trimTypeNameSpaces(resolved.substr(4, resolved.size() - 5));
+    } else if (ry::util::isSetTypeName(resolved) && resolved.size() >= 6 && resolved.back() == '>') {
+        std::string inner = ry::util::trimTypeNameSpaces(resolved.substr(4, resolved.size() - 5));
         if (inner == "any")
             hint.set_elem_any = true;
-    } else if (isMapTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
+    } else if (ry::util::isMapTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
         std::string inner = resolved.substr(4, resolved.size() - 5);
         auto args = splitTypeArgs(inner);
         if (args.size() == 2) {
@@ -300,7 +300,7 @@ CodeGen::LiteralAnyHint CodeGen::computeLiteralAnyHintFromAnnot(const std::strin
             // the bucket array. Forcing map_key_any=false keeps the strict
             // same-type key check; only Map<str, any> / Map<int, any> etc.
             // (concrete key, any value) are widened.
-            if (trimTypeNameSpaces(args[1]) == "any")
+            if (ry::util::trimTypeNameSpaces(args[1]) == "any")
                 hint.map_value_any = true;
         }
     }

--- a/src/codegen_fn.cpp
+++ b/src/codegen_fn.cpp
@@ -25,13 +25,6 @@ bool sameFnTypeInfoShape(const CodeGen::FnTypeInfo &lhs, const CodeGen::FnTypeIn
 
 // --- JNI-like naming convention helpers ---
 
-std::string CodeGen::deriveRuntimeFnName(const std::string &package,
-                                         const std::string &fn_name) {
-    if (package.empty())
-        return "__ry_" + fn_name;
-    return "__ry_" + package + "_" + fn_name;
-}
-
 const std::unordered_set<std::string>& CodeGen::getRequiredLibraries() const {
     return used_native_libraries_;
 }
@@ -128,7 +121,7 @@ void CodeGen::applyParamTypeMeta(const std::string &ptype,
         markArcManaged(alloca);
     {
         std::string resolvedPtype = resolveTypeAlias(ptype);
-        if (isFunctionTypeName(resolvedPtype))
+        if (ry::util::isFunctionTypeName(resolvedPtype))
             getOrCreateMeta(alloca).fn_type_info = parseFnTypeAnnotation(resolvedPtype);
         auto constraint = parseTypeConstraint(resolvedPtype);
         if (constraint) {
@@ -676,7 +669,7 @@ void CodeGen::emitStmt(std::unique_ptr<FnStmt> &s) {
         // a user declares @native("base64") fn encode(str) alongside
         // `from base64 import encode`, while preserving valid type-based
         // overloads like encode(str) and encode(int).
-        auto &sigVec = native_fn_sigs_[nativeSigKey(effectivePackage, sig.name)];
+        auto &sigVec = native_fn_sigs_[ry::util::nativeSigKey(effectivePackage, sig.name)];
         bool duplicate = false;
         for (const auto &existing : sigVec) {
             if (existing.params.size() != sig.params.size()) continue;

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -288,19 +288,6 @@ static std::vector<std::string> splitTopLevelCommas(const std::string &body) {
     return out;
 }
 
-bool CodeGen::splitGenericTypeName(const std::string &s,
-                                    std::string &head,
-                                    std::vector<std::string> &inner) {
-    std::string t = trimWs(s);
-    size_t lt = t.find('<');
-    if (lt == std::string::npos) return false;
-    if (t.back() != '>') return false;
-    head = trimWs(t.substr(0, lt));
-    std::string body = t.substr(lt + 1, t.size() - lt - 2);
-    inner = splitTopLevelCommas(body);
-    return true;
-}
-
 static bool splitTupleTypeName(const std::string &s,
                                 std::vector<std::string> &elements) {
     std::string t = trimWs(s);
@@ -384,7 +371,7 @@ bool CodeGen::unifyTypeParam(
         } else if constexpr (std::is_same_v<T, GenericType>) {
             std::string head;
             std::vector<std::string> innerArgs;
-            if (!splitGenericTypeName(argTypeName, head, innerArgs))
+            if (!ry::util::splitGenericTypeName(argTypeName, head, innerArgs))
                 return false;
             if (head != v.name) return false;
             if (innerArgs.size() != v.type_args.size()) return false;
@@ -429,7 +416,7 @@ bool CodeGen::unifyTypeParam(
             }
             std::string head;
             std::vector<std::string> innerArgs;
-            if (splitGenericTypeName(t, head, innerArgs) &&
+            if (ry::util::splitGenericTypeName(t, head, innerArgs) &&
                 head == "Option" && innerArgs.size() == 1) {
                 return unifyTypeParam(*v.inner, innerArgs[0],
                                       typeParamSet, inferred, fnName);
@@ -483,7 +470,7 @@ static bool argMatchesParam(CodeGen &cg,
         } else if constexpr (std::is_same_v<T, GenericType>) {
             std::string head;
             std::vector<std::string> innerArgs;
-            if (!cg.splitGenericTypeName(argTypeName, head, innerArgs))
+            if (!ry::util::splitGenericTypeName(argTypeName, head, innerArgs))
                 return false;
             if (head != v.name) return false;
             if (innerArgs.size() != v.type_args.size()) return false;
@@ -521,7 +508,7 @@ static bool argMatchesParam(CodeGen &cg,
             }
             std::string head;
             std::vector<std::string> innerArgs;
-            if (cg.splitGenericTypeName(t, head, innerArgs) &&
+            if (ry::util::splitGenericTypeName(t, head, innerArgs) &&
                 head == "Option" && innerArgs.size() == 1) {
                 return argMatchesParam(cg, *v.inner, innerArgs[0], typeParamSet);
             }

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -486,7 +486,7 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<LambdaExpr> &e) {
     info.returnTypeName = returnTypeName;
     if (!retTypeStr.empty()) {
         std::string resolvedRetType = resolveTypeAlias(retTypeStr);
-        if (isFunctionTypeName(resolvedRetType))
+        if (ry::util::isFunctionTypeName(resolvedRetType))
             info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(resolvedRetType));
     }
     info.capturedVars = captures.capturedNames;
@@ -973,7 +973,7 @@ std::string CodeGen::inferNativeCallReturnTypeName(
     auto isInferenceWidening = [&](llvm::Type *argTy,
                                    llvm::Type *paramTy,
                                    const std::string &paramTypeName) {
-        if (isLowLevelTypeName(paramTypeName))
+        if (ry::util::isLowLevelTypeName(paramTypeName))
             return false;
         return (argTy == i8Ty_ && paramTy == i64Ty_) ||
                (argTy == i8Ty_ && paramTy == f64Ty_) ||
@@ -1025,14 +1025,14 @@ std::string CodeGen::inferNativeCallReturnTypeName(
     if (auto libIt = native_lib_index_.find(expr.callee);
         libIt != native_lib_index_.end()) {
         for (const auto &lib : libIt->second) {
-            auto sigIt = native_fn_sigs_.find(nativeSigKey(lib, expr.callee));
+            auto sigIt = native_fn_sigs_.find(ry::util::nativeSigKey(lib, expr.callee));
             if (sigIt == native_fn_sigs_.end())
                 continue;
             tryMatchBucket(sigIt->second, &exactMatch, false);
         }
         if (!exactMatch) {
             for (const auto &lib : libIt->second) {
-                auto sigIt = native_fn_sigs_.find(nativeSigKey(lib, expr.callee));
+                auto sigIt = native_fn_sigs_.find(ry::util::nativeSigKey(lib, expr.callee));
                 if (sigIt == native_fn_sigs_.end())
                     continue;
                 tryMatchBucket(sigIt->second, &wideningMatch, true);
@@ -1283,7 +1283,7 @@ llvm::Function *CodeGen::materializeNativeThunk(const std::string &name) {
     info.returnTypeName = sig.returnTypeName;
     {
         std::string resolved = resolveTypeAlias(sig.returnTypeName);
-        if (isFunctionTypeName(resolved))
+        if (ry::util::isFunctionTypeName(resolved))
             info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(resolved));
     }
     info.sourceFn = thunk;
@@ -1547,7 +1547,7 @@ std::vector<llvm::Value*> CodeGen::wrapFnTypedArgs(
     std::vector<llvm::Value*> temps;
     for (size_t i = 0; i < argVals.size() && i < paramTypeNames.size(); ++i) {
         std::string resolved = resolveTypeAlias(paramTypeNames[i]);
-        if (isFunctionTypeName(resolved)) {
+        if (ry::util::isFunctionTypeName(resolved)) {
             auto *fnInfo = lookupFnTypeInfo(argVals[i]);
             if (fnInfo && !fnInfo->isUniformClosure) {
                 argVals[i] = wrapAsUniformClosure(argVals[i], *fnInfo);

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -107,7 +107,7 @@ std::vector<std::string> CodeGen::splitTupleSig(const std::string &tupleTypeSig)
     const std::string resolved = resolveTypeAlias(tupleTypeSig);
     if (resolved.size() < 2 || resolved.front() != '(' || resolved.back() != ')') return {};
     std::vector<std::string> parts = splitTypeArgs(resolved.substr(1, resolved.size() - 2));
-    for (auto &p : parts) p = trimTypeNameSpaces(p);
+    for (auto &p : parts) p = ry::util::trimTypeNameSpaces(p);
     return parts;
 }
 
@@ -473,7 +473,7 @@ static std::string extractGenericTypeArg(const std::string &typeStr,
     if (prefix == "Option<" && typeStr.size() > 1 && typeStr.back() == '?') {
         if (argIdx != 0)
             return {};
-        return CodeGen::trimTypeNameSpaces(typeStr.substr(0, typeStr.size() - 1));
+        return ry::util::trimTypeNameSpaces(typeStr.substr(0, typeStr.size() - 1));
     }
     if (typeStr.size() <= prefix.size() ||
         typeStr.compare(0, prefix.size(), prefix) != 0 ||
@@ -483,7 +483,7 @@ static std::string extractGenericTypeArg(const std::string &typeStr,
                                               typeStr.size() - prefix.size() - 1);
     const auto parts = CodeGen::splitTypeArgs(inner);
     if (argIdx >= parts.size()) return {};
-    return CodeGen::trimTypeNameSpaces(parts[argIdx]);
+    return ry::util::trimTypeNameSpaces(parts[argIdx]);
 }
 
 void CodeGen::maybeRegisterTaggedUnionSubject(llvm::AllocaInst *subjectAlloca,
@@ -514,17 +514,17 @@ void CodeGen::maybeRegisterTaggedUnionSubject(llvm::AllocaInst *subjectAlloca,
     std::string okName, errName;
     const bool isOpt = isOptionType(subjectTy);
     if (isOpt && resolvedSource.size() > 1 && resolvedSource.back() == '?') {
-        okName = trimTypeNameSpaces(
+        okName = ry::util::trimTypeNameSpaces(
             resolvedSource.substr(0, resolvedSource.size() - 1));
     } else {
         std::string head;
         std::vector<std::string> innerArgs;
-        if (splitGenericTypeName(resolvedSource, head, innerArgs)) {
+        if (ry::util::splitGenericTypeName(resolvedSource, head, innerArgs)) {
             if (head == "Result") {
-                if (!innerArgs.empty()) okName = trimTypeNameSpaces(innerArgs[0]);
-                if (innerArgs.size() >= 2) errName = trimTypeNameSpaces(innerArgs[1]);
+                if (!innerArgs.empty()) okName = ry::util::trimTypeNameSpaces(innerArgs[0]);
+                if (innerArgs.size() >= 2) errName = ry::util::trimTypeNameSpaces(innerArgs[1]);
             } else if (head == "Option") {
-                if (!innerArgs.empty()) okName = trimTypeNameSpaces(innerArgs[0]);
+                if (!innerArgs.empty()) okName = ry::util::trimTypeNameSpaces(innerArgs[0]);
             }
         }
     }
@@ -754,7 +754,7 @@ void CodeGen::emitPatternBindingArc(llvm::Value *val, llvm::AllocaInst *bindAllo
             arc_backed_vars_.insert(bindAlloca);
             return;
         }
-        if (isFunctionTypeName(resolved)) {
+        if (ry::util::isFunctionTypeName(resolved)) {
             // Distinguish capturing closure from bare function pointer via
             // fn_type_info metadata on the source value.
             const ValueMetadata *m = getMeta(val);
@@ -1167,10 +1167,10 @@ llvm::Value *CodeGen::wrapInUnion(llvm::Value *val, const std::string &unionType
         for (size_t i = 0; i < info.componentTypes.size(); ++i) {
             if (info.componentTypes[i] != val->getType()) continue;
             const auto &compName = info.componentNames[i];
-            if ((meta->map_key || meta->map_value) && isMapTypeName(compName)) { tagIdx = i; break; }
-            if (meta->set_elem && isSetTypeName(compName))                     { tagIdx = i; break; }
-            if (meta->list_elem && isListTypeName(compName))                   { tagIdx = i; break; }
-            if (meta->fn_type_info && isFunctionTypeName(compName))            { tagIdx = i; break; }
+            if ((meta->map_key || meta->map_value) && ry::util::isMapTypeName(compName)) { tagIdx = i; break; }
+            if (meta->set_elem && ry::util::isSetTypeName(compName))                     { tagIdx = i; break; }
+            if (meta->list_elem && ry::util::isListTypeName(compName))                   { tagIdx = i; break; }
+            if (meta->fn_type_info && ry::util::isFunctionTypeName(compName))            { tagIdx = i; break; }
         }
     }
     // Fallback: first variant with matching LLVM type.

--- a/src/codegen_stmt.cpp
+++ b/src/codegen_stmt.cpp
@@ -122,8 +122,8 @@ llvm::Value *CodeGen::coerceResultType(llvm::Value *val,
                 kPrefix.size(), resolved.size() - kPrefix.size() - 1);
             auto parts = splitTypeArgs(inner);
             if (parts.size() == 2) {
-                dstOkTypeName  = trimTypeNameSpaces(parts[0]);
-                dstErrTypeName = trimTypeNameSpaces(parts[1]);
+                dstOkTypeName  = ry::util::trimTypeNameSpaces(parts[0]);
+                dstErrTypeName = ry::util::trimTypeNameSpaces(parts[1]);
             }
         }
     }
@@ -255,7 +255,7 @@ void CodeGen::emitVarDecl(const std::string &name,
     if (auto *se = std::get_if<std::unique_ptr<SetExpr>>(&value.data); se && (*se)->elements.empty()) {
         if (!annot)
             codegenError("empty {} literal requires type annotation");
-        if (isSetTypeName(*annot)) {
+        if (ry::util::isSetTypeName(*annot)) {
             std::string inner = annot->substr(4, annot->size() - 5);
             llvm::Type *elemTy = resolveType(inner);
 
@@ -279,7 +279,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             setTypeMeta(TypeMeta::SetElem, ptr, elemTy);
             {
                 const std::string resolvedInner = resolveTypeAlias(inner);
-                if (isFunctionTypeName(resolvedInner)) {
+                if (ry::util::isFunctionTypeName(resolvedInner)) {
                     getOrCreateMeta(ptr).set_elem_fn_type_info = parseFnTypeAnnotation(resolvedInner);
                 } else if (resolvedInner != "str" && resolvedInner != "int" &&
                            resolvedInner != "float" && resolvedInner != "bool") {
@@ -294,7 +294,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                 immutable_scope_stack_.back().insert(name);
             return;
         }
-        if (isMapTypeName(*annot)) {
+        if (ry::util::isMapTypeName(*annot)) {
             auto [keyTy, valTy] = parseMapTypeAnnotation(*annot);
             if (!keyTy || !valTy)
                 codegenError("invalid map type annotation: " + *annot);
@@ -324,7 +324,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                 std::string ktn = resolveTypeAlias(extractMapKeyTypeName(*annot));
                 if (!ktn.empty()) {
                     getOrCreateMeta(ptr).map_key_type_name = ktn;
-                    if (isFunctionTypeName(ktn))
+                    if (ry::util::isFunctionTypeName(ktn))
                         getOrCreateMeta(ptr).map_key_fn_type_info = parseFnTypeAnnotation(ktn);
                 }
             }
@@ -332,7 +332,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                 std::string vtn = extractMapValueTypeName(*annot);
                 if (!vtn.empty()) {
                     getOrCreateMeta(ptr).map_value_type_name = vtn;
-                    if (isFunctionTypeName(vtn))
+                    if (ry::util::isFunctionTypeName(vtn))
                         getOrCreateMeta(ptr).map_value_fn_type_info = parseFnTypeAnnotation(vtn);
                 }
             }
@@ -349,7 +349,7 @@ void CodeGen::emitVarDecl(const std::string &name,
         if (!annot)
             codegenError("empty list literal requires a List<T> type annotation");
         std::string resolvedAnnot = resolveTypeAlias(*annot);
-        if (!isListTypeName(resolvedAnnot) || resolvedAnnot.size() < 7 || resolvedAnnot.back() != '>')
+        if (!ry::util::isListTypeName(resolvedAnnot) || resolvedAnnot.size() < 7 || resolvedAnnot.back() != '>')
             codegenError("empty list literal requires a List<T> type annotation");
         std::string inner = resolvedAnnot.substr(5, resolvedAnnot.size() - 6);
         llvm::Type *elemTy = resolveType(inner);
@@ -373,7 +373,7 @@ void CodeGen::emitVarDecl(const std::string &name,
         arc_backed_vars_.insert(ptr);
 
         // Set nested-list metadata for List<List<T>> annotations
-        if (isListTypeName(inner) && inner.back() == '>') {
+        if (ry::util::isListTypeName(inner) && inner.back() == '>') {
             std::string nestedInner = inner.substr(5, inner.size() - 6);
             llvm::Type *nestedElemTy = resolveType(nestedInner);
             if (nestedElemTy)
@@ -394,7 +394,7 @@ void CodeGen::emitVarDecl(const std::string &name,
         if (inner == "str") {
             getOrCreateMeta(ptr).list_elem_type_name = "str";
             getOrCreateMeta(ptr).list_elem_is_str = true;
-        } else if (isFunctionTypeName(inner))
+        } else if (ry::util::isFunctionTypeName(inner))
             getOrCreateMeta(ptr).list_elem_fn_type_info = parseFnTypeAnnotation(inner);
         else if (inner != "int" && inner != "float" && inner != "bool")
             getOrCreateMeta(ptr).list_elem_type_name = inner;
@@ -505,7 +505,7 @@ void CodeGen::emitVarDecl(const std::string &name,
         if (auto *le = std::get_if<std::unique_ptr<ListExpr>>(&value.data);
                 le && !(*le)->elements.empty()) {
             std::string resolved = resolveTypeAlias(*annot);
-            if (isListTypeName(resolved) && resolved.size() >= 7 &&
+            if (ry::util::isListTypeName(resolved) && resolved.size() >= 7 &&
                     resolved.back() == '>') {
                 std::string inner = resolved.substr(5, resolved.size() - 6);
                 while (!inner.empty() && inner.front() == ' ')
@@ -641,17 +641,17 @@ void CodeGen::emitVarDecl(const std::string &name,
                     // unconditional — payload stride matches destination.
                     if (annotTy == ptrTy_) {
                         const std::string resolvedColl = resolveTypeAlias(resolvedAnnot);
-                        const bool annotIsList = isListTypeName(resolvedColl);
-                        const bool annotIsSet = isSetTypeName(resolvedColl);
-                        const bool annotIsMap = isMapTypeName(resolvedColl);
+                        const bool annotIsList = ry::util::isListTypeName(resolvedColl);
+                        const bool annotIsSet = ry::util::isSetTypeName(resolvedColl);
+                        const bool annotIsMap = ry::util::isMapTypeName(resolvedColl);
                         if (annotIsList || annotIsSet || annotIsMap) {
                             bool whitelisted = false;
                             if (annotIsList) {
-                                std::string inner = trimTypeNameSpaces(
+                                std::string inner = ry::util::trimTypeNameSpaces(
                                     resolvedColl.substr(5, resolvedColl.size() - 6));
                                 whitelisted = (inner == "any");
                             } else if (annotIsSet) {
-                                std::string inner = trimTypeNameSpaces(
+                                std::string inner = ry::util::trimTypeNameSpaces(
                                     resolvedColl.substr(4, resolvedColl.size() - 5));
                                 whitelisted = (inner == "any");
                             } else {
@@ -659,8 +659,8 @@ void CodeGen::emitVarDecl(const std::string &name,
                                     resolvedColl.substr(4, resolvedColl.size() - 5);
                                 auto parts = splitTypeArgs(innerArgs);
                                 if (parts.size() == 2) {
-                                    std::string k = trimTypeNameSpaces(parts[0]);
-                                    std::string vt = trimTypeNameSpaces(parts[1]);
+                                    std::string k = ry::util::trimTypeNameSpaces(parts[0]);
+                                    std::string vt = ry::util::trimTypeNameSpaces(parts[1]);
                                     whitelisted = (k == "str" && vt == "any");
                                 }
                             }
@@ -797,7 +797,7 @@ void CodeGen::emitVarDecl(const std::string &name,
     // Track low-level type metadata
     if (annot) {
         const std::string &ann = *annot;
-        if (isLowLevelTypeName(ann))
+        if (ry::util::isLowLevelTypeName(ann))
             getOrCreateMeta(ptr).low_level_type_name = ann;
     } else {
         // Propagate metadata from initializer expression (e.g., y = x as u32)
@@ -868,7 +868,7 @@ void CodeGen::emitVarDecl(const std::string &name,
     if (newTy == ptrTy_) {
         // --- List tracking ---
         llvm::Type *elemTy = getListElementType(val);
-        if (!elemTy && annot && isListTypeName(*annot)) {
+        if (!elemTy && annot && ry::util::isListTypeName(*annot)) {
             std::string inner = annot->substr(5, annot->size() - 6);
             elemTy = resolveType(inner);
         }
@@ -890,10 +890,10 @@ void CodeGen::emitVarDecl(const std::string &name,
             bool inner_is_str = false;
             if (letn.empty() && !lefti && annot) {
                 std::string resolved = resolveTypeAlias(*annot);
-                if (isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
+                if (ry::util::isListTypeName(resolved) && resolved.size() >= 7 && resolved.back() == '>') {
                     std::string inner = resolved.substr(5, resolved.size() - 6);
                     while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
-                    if (isFunctionTypeName(inner)) {
+                    if (ry::util::isFunctionTypeName(inner)) {
                         lefti = parseFnTypeAnnotation(inner);
                     } else if (inner == "str") {
                         // List<str>: stamp both list_elem_type_name (#1576 —
@@ -944,7 +944,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             }
         }
         // From type annotation: Map<K, V>
-        if (!keyTy && annot && isMapTypeName(*annot)) {
+        if (!keyTy && annot && ry::util::isMapTypeName(*annot)) {
             std::tie(keyTy, valTy) = parseMapTypeAnnotation(*annot);
         }
         if (keyTy) setTypeMeta(TypeMeta::MapKey, ptr, keyTy);
@@ -971,14 +971,14 @@ void CodeGen::emitVarDecl(const std::string &name,
                 }
             }
             // Also derive from annotation: Map<fn(int) -> int, V> → mktn = "fn(int) -> int"
-            if (mktn.empty() && annot && isMapTypeName(resolvedAnnot)) {
+            if (mktn.empty() && annot && ry::util::isMapTypeName(resolvedAnnot)) {
                 std::string ktn = extractMapKeyTypeName(resolvedAnnot);
                 if (!ktn.empty())
                     mktn = ktn;
             }
             if (!mktn.empty()) {
                 getOrCreateMeta(ptr).map_key_type_name = mktn;
-                if (!mkfti && isFunctionTypeName(mktn))
+                if (!mkfti && ry::util::isFunctionTypeName(mktn))
                     mkfti = parseFnTypeAnnotation(mktn);
             }
             if (mkfti)
@@ -1006,14 +1006,14 @@ void CodeGen::emitVarDecl(const std::string &name,
                 }
             }
             // Also derive from annotation: Map<K, fn(int) -> int> → mvtn = "fn(int) -> int"
-            if (mvtn.empty() && annot && isMapTypeName(resolvedAnnot)) {
+            if (mvtn.empty() && annot && ry::util::isMapTypeName(resolvedAnnot)) {
                 std::string vtn = extractMapValueTypeName(resolvedAnnot);
                 if (!vtn.empty())
                     mvtn = vtn;
             }
             if (!mvtn.empty()) {
                 getOrCreateMeta(ptr).map_value_type_name = mvtn;
-                if (!mvfti && isFunctionTypeName(mvtn))
+                if (!mvfti && ry::util::isFunctionTypeName(mvtn))
                     mvfti = parseFnTypeAnnotation(mvtn);
             }
             if (mvfti)
@@ -1027,7 +1027,7 @@ void CodeGen::emitVarDecl(const std::string &name,
                 setElemTy = getSetElementType(load->getPointerOperand());
             }
         }
-        if (!setElemTy && annot && isSetTypeName(*annot)) {
+        if (!setElemTy && annot && ry::util::isSetTypeName(*annot)) {
             std::string inner = annot->substr(4, annot->size() - 5);
             setElemTy = resolveType(inner);
         }
@@ -1057,10 +1057,10 @@ void CodeGen::emitVarDecl(const std::string &name,
                 }
             }
             if (setn.empty() && annot &&
-                isSetTypeName(resolvedAnnot) && resolvedAnnot.size() > 4 && resolvedAnnot.back() == '>') {
+                ry::util::isSetTypeName(resolvedAnnot) && resolvedAnnot.size() > 4 && resolvedAnnot.back() == '>') {
                 std::string inner = resolvedAnnot.substr(4, resolvedAnnot.size() - 5);
                 while (!inner.empty() && inner.front() == ' ') inner = inner.substr(1);
-                if (isFunctionTypeName(inner)) {
+                if (ry::util::isFunctionTypeName(inner)) {
                     sefti = parseFnTypeAnnotation(inner);
                 } else if (inner != "str" && inner != "int" && inner != "float" && inner != "bool") {
                     // `str` is intentionally excluded: Set has no
@@ -1075,7 +1075,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             }
             if (!setn.empty()) {
                 getOrCreateMeta(ptr).set_elem_type_name = setn;
-                if (!sefti && isFunctionTypeName(setn))
+                if (!sefti && ry::util::isFunctionTypeName(setn))
                     sefti = parseFnTypeAnnotation(setn);
             }
             if (sefti)
@@ -1098,7 +1098,7 @@ void CodeGen::emitVarDecl(const std::string &name,
             if (valMeta && valMeta->fn_type_info) {
                 getOrCreateMeta(ptr).fn_type_info = *valMeta->fn_type_info;
             } else if (annot) {
-                if (isFunctionTypeName(resolvedAnnot)) {
+                if (ry::util::isFunctionTypeName(resolvedAnnot)) {
                     getOrCreateMeta(ptr).fn_type_info = parseFnTypeAnnotation(resolvedAnnot);
                 }
             }
@@ -1116,7 +1116,7 @@ void CodeGen::emitVarDecl(const std::string &name,
         }
 
         // --- Weak reference tracking ---
-        if (annot && isWeakTypeName(*annot)) {
+        if (annot && ry::util::isWeakTypeName(*annot)) {
             if (!std::get_if<std::unique_ptr<WeakExpr>>(&value.data))
                 codegenError("weak-typed variable must be initialized with a 'weak' expression");
             std::string innerName = resolveTypeAlias(weakInnerTypeName(*annot));

--- a/src/codegen_stmt_misc.cpp
+++ b/src/codegen_stmt_misc.cpp
@@ -92,7 +92,7 @@ void CodeGen::emitArcReleaseLoadedElement(llvm::Value *oldElemVal,
             std::string resolved = resolveTypeAlias(elemTypeName);
             std::string head;
             std::vector<std::string> innerArgs;
-            if (splitGenericTypeName(resolved, head, innerArgs)) {
+            if (ry::util::splitGenericTypeName(resolved, head, innerArgs)) {
                 if ((elemKind == CollectionKind::List || elemKind == CollectionKind::Set) &&
                     !innerArgs.empty()) {
                     innerElemSig = resolveTypeAlias(innerArgs[0]);

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -40,7 +40,7 @@ std::string CodeGen::buildCanonicalSig(const std::string &name,
     result += '(';
     for (size_t i = 0; i < paramTypeNames.size(); ++i) {
         if (i > 0) result += ", ";
-        result += resolveTypeAlias(trimTypeNameSpaces(paramTypeNames[i]));
+        result += resolveTypeAlias(ry::util::trimTypeNameSpaces(paramTypeNames[i]));
     }
     result += ')';
     return result;
@@ -57,18 +57,18 @@ bool CodeGen::parseSigString(const std::string &input,
     if (input.empty() || input.back() != ')')
         codegenError("invalid signature syntax: '" + input +
                      "' — expected 'name(T1, T2, ...)' with matching parentheses");
-    outName = trimTypeNameSpaces(input.substr(0, parenPos));
+    outName = ry::util::trimTypeNameSpaces(input.substr(0, parenPos));
     if (outName.empty())
         codegenError("invalid signature syntax: '" + input +
                      "' — function name before '(' is empty");
-    const std::string inner = trimTypeNameSpaces(
+    const std::string inner = ry::util::trimTypeNameSpaces(
         input.substr(parenPos + 1, input.size() - parenPos - 2));
     outParamTypeNames.clear();
     if (inner.empty()) return true;
     const auto parts = splitTypeArgs(inner);
     outParamTypeNames.reserve(parts.size());
     for (const auto &p : parts) {
-        const std::string trimmed = trimTypeNameSpaces(p);
+        const std::string trimmed = ry::util::trimTypeNameSpaces(p);
         if (trimmed.empty())
             codegenError("invalid signature syntax: '" + input +
                          "' — empty parameter type between commas");
@@ -1021,12 +1021,12 @@ void CodeGen::emitMockCall(CallStmt &s) {
         std::vector<std::string> wantNorm;
         wantNorm.reserve(sigParamTypes.size());
         for (const auto &p : sigParamTypes)
-            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+            wantNorm.push_back(resolveTypeAlias(ry::util::trimTypeNameSpaces(p)));
         for (auto &ov : *fitOverloads) {
             if (ov.paramTypeNames.size() != wantNorm.size()) continue;
             bool eq = true;
             for (size_t i = 0; i < wantNorm.size(); ++i) {
-                if (resolveTypeAlias(trimTypeNameSpaces(ov.paramTypeNames[i]))
+                if (resolveTypeAlias(ry::util::trimTypeNameSpaces(ov.paramTypeNames[i]))
                         != wantNorm[i]) {
                     eq = false; break;
                 }
@@ -1165,12 +1165,12 @@ void CodeGen::emitNativeMockCall(CallStmt &s,
         std::vector<std::string> wantNorm;
         wantNorm.reserve(sigParamTypes.size());
         for (const auto &p : sigParamTypes)
-            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+            wantNorm.push_back(resolveTypeAlias(ry::util::trimTypeNameSpaces(p)));
         for (const auto *sig : nativeSigs) {
             if (sig->params.size() != wantNorm.size()) continue;
             bool eq = true;
             for (size_t i = 0; i < wantNorm.size(); ++i) {
-                if (resolveTypeAlias(trimTypeNameSpaces(sig->params[i].typeName))
+                if (resolveTypeAlias(ry::util::trimTypeNameSpaces(sig->params[i].typeName))
                         != wantNorm[i]) {
                     eq = false; break;
                 }
@@ -1293,12 +1293,12 @@ void CodeGen::emitNativeSpyCall(CallStmt &s,
         std::vector<std::string> wantNorm;
         wantNorm.reserve(sigParamTypes.size());
         for (const auto &p : sigParamTypes)
-            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+            wantNorm.push_back(resolveTypeAlias(ry::util::trimTypeNameSpaces(p)));
         for (const auto *sig : nativeSigs) {
             if (sig->params.size() != wantNorm.size()) continue;
             bool eq = true;
             for (size_t i = 0; i < wantNorm.size(); ++i) {
-                if (resolveTypeAlias(trimTypeNameSpaces(sig->params[i].typeName))
+                if (resolveTypeAlias(ry::util::trimTypeNameSpaces(sig->params[i].typeName))
                         != wantNorm[i]) {
                     eq = false; break;
                 }
@@ -1354,12 +1354,12 @@ void CodeGen::emitNativeMockReturnValueOnceCall(
         std::vector<std::string> wantNorm;
         wantNorm.reserve(sigParamTypes.size());
         for (const auto &p : sigParamTypes)
-            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+            wantNorm.push_back(resolveTypeAlias(ry::util::trimTypeNameSpaces(p)));
         for (const auto *sig : nativeSigs) {
             if (sig->params.size() != wantNorm.size()) continue;
             bool eq = true;
             for (size_t i = 0; i < wantNorm.size(); ++i) {
-                if (resolveTypeAlias(trimTypeNameSpaces(sig->params[i].typeName))
+                if (resolveTypeAlias(ry::util::trimTypeNameSpaces(sig->params[i].typeName))
                         != wantNorm[i]) {
                     eq = false; break;
                 }
@@ -1397,9 +1397,9 @@ void CodeGen::emitNativeMockReturnValueOnceCall(
 
     bool supported = (resolved == "int") || (resolved == "float")
         || (resolved == "bool") || (resolved == "Unit")
-        || isLowLevelTypeName(resolved)
+        || ry::util::isLowLevelTypeName(resolved)
         || (resolved == "str")
-        || isListTypeName(resolved) || isMapTypeName(resolved) || isSetTypeName(resolved)
+        || ry::util::isListTypeName(resolved) || ry::util::isMapTypeName(resolved) || ry::util::isSetTypeName(resolved)
         || (record_types_.count(resolved) > 0)
         || (resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0)
         || (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0)
@@ -1509,7 +1509,7 @@ static std::string vretExtractGenericArg(const std::string &typeStr,
                                           size_t argIdx) {
     if (prefix == "Option<" && typeStr.size() > 1 && typeStr.back() == '?') {
         if (argIdx != 0) return {};
-        return CodeGen::trimTypeNameSpaces(typeStr.substr(0, typeStr.size() - 1));
+        return ry::util::trimTypeNameSpaces(typeStr.substr(0, typeStr.size() - 1));
     }
     if (typeStr.size() <= prefix.size() ||
         typeStr.compare(0, prefix.size(), prefix) != 0 ||
@@ -1519,7 +1519,7 @@ static std::string vretExtractGenericArg(const std::string &typeStr,
                                               typeStr.size() - prefix.size() - 1);
     const auto parts = CodeGen::splitTypeArgs(inner);
     if (argIdx >= parts.size()) return {};
-    return CodeGen::trimTypeNameSpaces(parts[argIdx]);
+    return ry::util::trimTypeNameSpaces(parts[argIdx]);
 }
 
 void CodeGen::retainValueReturnResult(llvm::Value *val,
@@ -1534,7 +1534,7 @@ void CodeGen::retainValueReturnResult(llvm::Value *val,
         emitArcRetain(hdr, false);
         return;
     }
-    if (isListTypeName(resolved) || isMapTypeName(resolved) || isSetTypeName(resolved)) {
+    if (ry::util::isListTypeName(resolved) || ry::util::isMapTypeName(resolved) || ry::util::isSetTypeName(resolved)) {
         auto *hdr = emitArcGetHeaderFromData(val);
         emitArcRetain(hdr, false);
         return;
@@ -1595,19 +1595,19 @@ void CodeGen::releaseValueReturnResult(llvm::Value *val,
         emitArcRelease(hdr, false, {});
         return;
     }
-    if (isListTypeName(resolved)) {
+    if (ry::util::isListTypeName(resolved)) {
         auto *hdr = emitArcGetHeaderFromData(val);
         auto subDtor = getOrCreateCollectionDestructor(CollectionKind::List);
         emitArcRelease(hdr, false, subDtor);
         return;
     }
-    if (isMapTypeName(resolved)) {
+    if (ry::util::isMapTypeName(resolved)) {
         auto *hdr = emitArcGetHeaderFromData(val);
         auto subDtor = getOrCreateCollectionDestructor(CollectionKind::Map);
         emitArcRelease(hdr, false, subDtor);
         return;
     }
-    if (isSetTypeName(resolved)) {
+    if (ry::util::isSetTypeName(resolved)) {
         auto *hdr = emitArcGetHeaderFromData(val);
         auto subDtor = getOrCreateCollectionDestructor(CollectionKind::Set);
         emitArcRelease(hdr, false, subDtor);
@@ -1744,7 +1744,7 @@ llvm::FunctionCallee CodeGen::getOrCreateValueReturnEnvDestructor(
     // Non-ARC primitives need no dtor — runtime frees env memory unconditionally.
     std::string resolved = resolveTypeAlias(retTyName);
     bool needsDtor = (resolved == "str")
-        || isListTypeName(resolved) || isMapTypeName(resolved) || isSetTypeName(resolved)
+        || ry::util::isListTypeName(resolved) || ry::util::isMapTypeName(resolved) || ry::util::isSetTypeName(resolved)
         || record_types_.count(resolved)
         || (resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0)
         || (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0)
@@ -1837,12 +1837,12 @@ void CodeGen::emitMockReturnValueOnceCall(CallStmt &s) {
         std::vector<std::string> wantNorm;
         wantNorm.reserve(sigParamTypes.size());
         for (const auto &p : sigParamTypes)
-            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+            wantNorm.push_back(resolveTypeAlias(ry::util::trimTypeNameSpaces(p)));
         for (auto &ov : *fitOverloads) {
             if (ov.paramTypeNames.size() != wantNorm.size()) continue;
             bool eq = true;
             for (size_t i = 0; i < wantNorm.size(); ++i) {
-                if (resolveTypeAlias(trimTypeNameSpaces(ov.paramTypeNames[i]))
+                if (resolveTypeAlias(ry::util::trimTypeNameSpaces(ov.paramTypeNames[i]))
                         != wantNorm[i]) {
                     eq = false; break;
                 }
@@ -1881,9 +1881,9 @@ void CodeGen::emitMockReturnValueOnceCall(CallStmt &s) {
     // Reject return types whose retain/release the helpers do not handle.
     bool supported = (resolved == "int") || (resolved == "float")
         || (resolved == "bool") || (resolved == "Unit")
-        || isLowLevelTypeName(resolved)
+        || ry::util::isLowLevelTypeName(resolved)
         || (resolved == "str")
-        || isListTypeName(resolved) || isMapTypeName(resolved) || isSetTypeName(resolved)
+        || ry::util::isListTypeName(resolved) || ry::util::isMapTypeName(resolved) || ry::util::isSetTypeName(resolved)
         || (record_types_.count(resolved) > 0)
         || (resolved.size() > 7 && resolved.compare(0, 7, "Result<") == 0)
         || (resolved.size() > 7 && resolved.compare(0, 7, "Option<") == 0)
@@ -2025,12 +2025,12 @@ void CodeGen::emitSpyCall(CallStmt &s) {
         std::vector<std::string> wantNorm;
         wantNorm.reserve(sigParamTypes.size());
         for (const auto &p : sigParamTypes)
-            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+            wantNorm.push_back(resolveTypeAlias(ry::util::trimTypeNameSpaces(p)));
         for (auto &ov : *fitOverloads) {
             if (ov.paramTypeNames.size() != wantNorm.size()) continue;
             bool eq = true;
             for (size_t i = 0; i < wantNorm.size(); ++i) {
-                if (resolveTypeAlias(trimTypeNameSpaces(ov.paramTypeNames[i]))
+                if (resolveTypeAlias(ry::util::trimTypeNameSpaces(ov.paramTypeNames[i]))
                         != wantNorm[i]) {
                     eq = false; break;
                 }
@@ -2447,7 +2447,7 @@ void CodeGen::emitMockArgRecording(llvm::Value *nameStr,
         if (matchedEntry && i < matchedEntry->paramTypeNames.size()) {
             std::string declared = resolveTypeAlias(
                 matchedEntry->paramTypeNames[i]);
-            if (isFunctionTypeName(declared) && argTy == ptrTy_) {
+            if (ry::util::isFunctionTypeName(declared) && argTy == ptrTy_) {
                 auto *ucTy = getUniformClosureTy();
                 llvm::Value *thunkField = builder_.CreateStructGEP(
                     ucTy, argVal, 0, "mock_fn.thunk_gep");
@@ -2539,12 +2539,12 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
         std::vector<std::string> wantNorm;
         wantNorm.reserve(sigParamTypes.size());
         for (const auto &p : sigParamTypes)
-            wantNorm.push_back(resolveTypeAlias(trimTypeNameSpaces(p)));
+            wantNorm.push_back(resolveTypeAlias(ry::util::trimTypeNameSpaces(p)));
         for (auto &ov : *overloads) {
             if (ov.paramTypeNames.size() != wantNorm.size()) continue;
             bool eq = true;
             for (size_t i = 0; i < wantNorm.size(); ++i) {
-                if (resolveTypeAlias(trimTypeNameSpaces(ov.paramTypeNames[i]))
+                if (resolveTypeAlias(ry::util::trimTypeNameSpaces(ov.paramTypeNames[i]))
                         != wantNorm[i]) {
                     eq = false; break;
                 }
@@ -2640,10 +2640,10 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             i < entry.paramTypeNames.size()
                 ? resolveTypeAlias(entry.paramTypeNames[i])
                 : std::string{};
-        const bool paramIsList = isListTypeName(declaredParamName);
-        const bool paramIsSet = !paramIsList && isSetTypeName(declaredParamName);
+        const bool paramIsList = ry::util::isListTypeName(declaredParamName);
+        const bool paramIsSet = !paramIsList && ry::util::isSetTypeName(declaredParamName);
         const bool paramIsMap = !paramIsList && !paramIsSet &&
-                                isMapTypeName(declaredParamName);
+                                ry::util::isMapTypeName(declaredParamName);
         const bool paramIsRecord = !paramIsList && !paramIsSet && !paramIsMap &&
                                    record_types_.count(declaredParamName) > 0;
         const bool paramIsTuple = !paramIsList && !paramIsSet && !paramIsMap &&
@@ -2653,7 +2653,7 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
                                   declaredParamName.back() == ')';
         const bool paramIsFn = !paramIsList && !paramIsSet && !paramIsMap &&
                                !paramIsRecord && !paramIsTuple &&
-                               isFunctionTypeName(declaredParamName);
+                               ry::util::isFunctionTypeName(declaredParamName);
         std::string paramListInner;
         std::string paramSetInner;
         std::string paramMapKeyInner;
@@ -2695,8 +2695,8 @@ llvm::Value *CodeGen::emitVerifyCalledWithCall(const CallExpr &e) {
             auto parts = splitTypeArgs(
                 declaredParamName.substr(4, declaredParamName.size() - 5));
             if (parts.size() == 2) {
-                paramMapKeyInner = resolveTypeAlias(trimTypeNameSpaces(parts[0]));
-                paramMapValInner = resolveTypeAlias(trimTypeNameSpaces(parts[1]));
+                paramMapKeyInner = resolveTypeAlias(ry::util::trimTypeNameSpaces(parts[0]));
+                paramMapValInner = resolveTypeAlias(ry::util::trimTypeNameSpaces(parts[1]));
             }
             if (!isSupportedCollElemName(paramMapKeyInner) ||
                 !isSupportedCollElemName(paramMapValInner)) {

--- a/src/codegen_tostring.cpp
+++ b/src/codegen_tostring.cpp
@@ -117,8 +117,8 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
 
                 // Closure/function variants: return "<closure>" directly.
                 // Union component names are normalized type strings like "fn(int) -> int",
-                // so use isFunctionTypeName() rather than comparing against the literal "closure".
-                if (uinfo.componentTypes[i]->isPointerTy() && isFunctionTypeName(compName)) {
+                // so use ry::util::isFunctionTypeName() rather than comparing against the literal "closure".
+                if (uinfo.componentTypes[i]->isPointerTy() && ry::util::isFunctionTypeName(compName)) {
                     phi->addIncoming(cachedGlobalString("<closure>", ".vts_closure"),
                                      builder_.GetInsertBlock());
                     builder_.CreateBr(mergeBB);
@@ -131,9 +131,9 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
                 // rather than producing garbage output.
                 if (uinfo.componentTypes[i]->isPointerTy() &&
                     compName != "str" &&
-                    !isListTypeName(compName) &&
-                    !isMapTypeName(compName) &&
-                    !isSetTypeName(compName)) {
+                    !ry::util::isListTypeName(compName) &&
+                    !ry::util::isMapTypeName(compName) &&
+                    !ry::util::isSetTypeName(compName)) {
                     codegenError("cannot convert " + compName +
                                  " variant of union to string");
                 }
@@ -142,12 +142,12 @@ llvm::Value *CodeGen::valueToString(llvm::Value *val, bool inCollection) {
                     uinfo.componentTypes[i], dataTmp, "vts.union.inner");
 
                 // Propagate low-level type metadata for correct signedness formatting
-                if (isLowLevelTypeName(compName))
+                if (ry::util::isLowLevelTypeName(compName))
                     getOrCreateMeta(innerVal).low_level_type_name = compName;
 
                 // Propagate collection type metadata so List/Map/Set variants format
                 // their element types correctly (matches List/Map/Set branches below).
-                if (isListTypeName(compName) || isMapTypeName(compName) || isSetTypeName(compName))
+                if (ry::util::isListTypeName(compName) || ry::util::isMapTypeName(compName) || ry::util::isSetTypeName(compName))
                     propagateTypeMeta(compName, innerVal);
 
                 llvm::Value *innerStr = valueToString(innerVal, inCollection);

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -42,7 +42,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
     if (typeName == "f64")   return f64Ty_;
 
     // Weak reference type: "weak str", "weak List<int>"
-    if (isWeakTypeName(typeName)) {
+    if (ry::util::isWeakTypeName(typeName)) {
         std::string inner = weakInnerTypeName(typeName);
         // Resolve aliases to canonical name
         auto aliasIt = type_aliases_.find(inner);
@@ -128,7 +128,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
             if (s != std::string::npos) sizeStr = sizeStr.substr(s);
             while (!sizeStr.empty() && sizeStr.back() == ' ') sizeStr.pop_back();
 
-            if (!isLowLevelTypeName(elemStr))
+            if (!ry::util::isLowLevelTypeName(elemStr))
                 codegenError("array element type must be a low-level type: " + elemStr);
             llvm::Type *elemTy = resolveType(elemStr);
             uint64_t size = std::stoull(sizeStr);
@@ -164,7 +164,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
     }
 
     // fn(...) -> T function type → opaque pointer
-    if (isFunctionTypeName(typeName)) {
+    if (ry::util::isFunctionTypeName(typeName)) {
         return ptrTy_;
     }
 
@@ -370,7 +370,7 @@ std::string CodeGen::substituteTypeParamsInName(const std::string &typeName) {
     auto it = type_param_scope_.find(typeName);
     if (it != type_param_scope_.end()) return it->second;
 
-    if (isWeakTypeName(typeName)) {
+    if (ry::util::isWeakTypeName(typeName)) {
         std::string inner = weakInnerTypeName(typeName);
         std::string sub = substituteTypeParamsInName(inner);
         if (sub != inner) return "weak " + sub;
@@ -392,7 +392,7 @@ std::string CodeGen::substituteTypeParamsInName(const std::string &typeName) {
         bool changed = false;
         std::string out = base + "<";
         for (size_t i = 0; i < args.size(); ++i) {
-            std::string arg = trimTypeNameSpaces(args[i]);
+            std::string arg = ry::util::trimTypeNameSpaces(args[i]);
             std::string sub = substituteTypeParamsInName(arg);
             if (sub != arg) changed = true;
             if (i) out += ", ";
@@ -509,7 +509,7 @@ CodeGen::FnTypeInfo CodeGen::parseFnTypeAnnotation(const std::string &typeStr) {
                 resolvedRetStr = resolvedRetStr.substr(rs, re - rs + 1);
         }
         info.returnTypeName = resolvedRetStr;
-        if (isFunctionTypeName(resolvedRetStr))
+        if (ry::util::isFunctionTypeName(resolvedRetStr))
             info.returnFnTypeInfo = std::make_unique<FnTypeInfo>(parseFnTypeAnnotation(resolvedRetStr));
     } else {
         info.returnType = llvm::Type::getVoidTy(*ctx_);

--- a/src/util/type_name.cpp
+++ b/src/util/type_name.cpp
@@ -1,0 +1,103 @@
+#include "ry/util/type_name.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+namespace ry {
+namespace util {
+
+namespace {
+
+// trimWs / splitTopLevelCommas are intentionally duplicated from the
+// file-local statics in src/codegen_fn_generic.cpp where they support
+// splitTupleTypeName / splitFunctionTypeName. Consolidation is deferred
+// per #1820's scoped extraction (those siblings remain file-local
+// because they are out of scope for the v0.0.26 stage 2 cleanup).
+
+// Local ASCII-whitespace trim used by splitGenericTypeName and
+// splitTopLevelCommas. Differs from trimTypeNameSpaces (which trims
+// only ' ') because the type-name splitters consume strings from
+// TypeNode::toString() that may contain tabs/newlines on malformed
+// inputs.
+std::string trimWs(const std::string &s) {
+    size_t a = 0;
+    size_t b = s.size();
+    while (a < b && std::isspace(static_cast<unsigned char>(s[a]))) ++a;
+    while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) --b;
+    return s.substr(a, b - a);
+}
+
+// Split `body` on top-level commas, honoring nesting of <, >, (, ),
+// [, ]. Used by splitGenericTypeName for the inner argument list.
+std::vector<std::string> splitTopLevelCommas(const std::string &body) {
+    std::vector<std::string> out;
+    out.reserve(static_cast<size_t>(std::count(body.begin(), body.end(), ',')) + 1);
+    int depth = 0;
+    size_t start = 0;
+    for (size_t i = 0; i < body.size(); ++i) {
+        char c = body[i];
+        if (c == '<' || c == '(' || c == '[') {
+            depth++;
+        } else if (c == '>' || c == ')' || c == ']') {
+            if (depth > 0) depth--;
+        } else if (c == ',' && depth == 0) {
+            out.push_back(trimWs(body.substr(start, i - start)));
+            start = i + 1;
+        }
+    }
+    out.push_back(trimWs(body.substr(start)));
+    return out;
+}
+
+}  // namespace
+
+std::string trimTypeNameSpaces(const std::string &s) {
+    size_t b = 0;
+    while (b < s.size() && s[b] == ' ') ++b;
+    size_t e = s.size();
+    while (e > b && s[e - 1] == ' ') --e;
+    return s.substr(b, e - b);
+}
+
+bool splitGenericTypeName(const std::string &s,
+                          std::string &head,
+                          std::vector<std::string> &inner) {
+    std::string t = trimWs(s);
+    size_t lt = t.find('<');
+    if (lt == std::string::npos) return false;
+    if (t.back() != '>') return false;
+    head = trimWs(t.substr(0, lt));
+    std::string body = t.substr(lt + 1, t.size() - lt - 2);
+    inner = splitTopLevelCommas(body);
+    return true;
+}
+
+bool isListTypeName(const std::string &typeName) {
+    return typeName.size() > 5 && typeName.compare(0, 5, "List<") == 0;
+}
+
+bool isMapTypeName(const std::string &typeName) {
+    return typeName.size() > 4 && typeName.compare(0, 4, "Map<") == 0;
+}
+
+bool isSetTypeName(const std::string &typeName) {
+    return typeName.size() > 4 && typeName.compare(0, 4, "Set<") == 0;
+}
+
+bool isWeakTypeName(const std::string &typeName) {
+    return typeName.size() > 5 && typeName.compare(0, 5, "weak ") == 0;
+}
+
+bool isLowLevelTypeName(const std::string &name) {
+    return name == "i8" || name == "i16" || name == "i32" || name == "i64" ||
+           name == "u8" || name == "u16" || name == "u32" || name == "u64" || name == "f32";
+}
+
+std::string deriveRuntimeFnName(const std::string &package,
+                                const std::string &fn_name) {
+    if (package.empty()) return "__ry_" + fn_name;
+    return "__ry_" + package + "_" + fn_name;
+}
+
+}  // namespace util
+}  // namespace ry

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -2779,7 +2779,7 @@ TEST_F(CodeGenTest, AdtEnumFnPayloadEqualityRejected) {
 }
 
 // Union with a function-typed variant must be rejected at compile time.
-// Regression for the isFunctionTypeName guard added in #960.
+// Regression for the ry::util::isFunctionTypeName guard added in #960.
 TEST_F(CodeGenTest, UnionFnVariantEqualityRejected) {
     expectCompileError(
         "fn makeFn() -> fn(int) -> int:\n"

--- a/tests/test_codegen_directive.cpp
+++ b/tests/test_codegen_directive.cpp
@@ -36,33 +36,33 @@ static std::string withCoreAndTestingDirectiveDecls(const char *src) {
 
 class DirectiveTest : public CodeGenTest {};
 
-// --- deriveRuntimeFnName tests ---
+// --- ry::util::deriveRuntimeFnName tests ---
 
 TEST(NativeFnNaming, PackageFunction) {
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("base64", "encode"), "__ry_base64_encode");
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("base64", "decode"), "__ry_base64_decode");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("base64", "encode"), "__ry_base64_encode");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("base64", "decode"), "__ry_base64_decode");
 }
 
 TEST(NativeFnNaming, MathFunctions) {
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("math", "sin"), "__ry_math_sin");
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("math", "cos"), "__ry_math_cos");
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("math", "floor"), "__ry_math_floor");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("math", "sin"), "__ry_math_sin");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("math", "cos"), "__ry_math_cos");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("math", "floor"), "__ry_math_floor");
 }
 
 TEST(NativeFnNaming, EmptyPackage) {
     // Empty package still produces a name, but callers should not use it
     // for builtins since they use varied naming (libc, inline IR, etc.)
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("", "print"), "__ry_print");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("", "print"), "__ry_print");
 }
 
 TEST(NativeFnNaming, MultiWordFunctionName) {
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("filesystem", "listDir"), "__ry_filesystem_listDir");
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("path", "isAbsolute"), "__ry_path_isAbsolute");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("filesystem", "listDir"), "__ry_filesystem_listDir");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("path", "isAbsolute"), "__ry_path_isAbsolute");
 }
 
 TEST(NativeFnNaming, ErrorGetter) {
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("base64", "get_last_error"), "__ry_base64_get_last_error");
-    EXPECT_EQ(CodeGen::deriveRuntimeFnName("io", "get_last_error"), "__ry_io_get_last_error");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("base64", "get_last_error"), "__ry_base64_get_last_error");
+    EXPECT_EQ(ry::util::deriveRuntimeFnName("io", "get_last_error"), "__ry_io_get_last_error");
 }
 
 // --- NativeFnSignature registry tests ---

--- a/tests/test_util_type_name.cpp
+++ b/tests/test_util_type_name.cpp
@@ -1,0 +1,113 @@
+#include "ry/util/type_name.hpp"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using ry::util::deriveRuntimeFnName;
+using ry::util::isFunctionTypeName;
+using ry::util::isListTypeName;
+using ry::util::isLowLevelTypeName;
+using ry::util::isMapTypeName;
+using ry::util::isSetTypeName;
+using ry::util::isWeakTypeName;
+using ry::util::nativeSigKey;
+using ry::util::splitGenericTypeName;
+using ry::util::trimTypeNameSpaces;
+
+TEST(UtilTypeName, TrimTypeNameSpacesStripsLeadingTrailingSpacesOnly) {
+    EXPECT_EQ(trimTypeNameSpaces("  int  "), "int");
+    EXPECT_EQ(trimTypeNameSpaces("int"), "int");
+    EXPECT_EQ(trimTypeNameSpaces(""), "");
+    EXPECT_EQ(trimTypeNameSpaces("a b"), "a b");
+}
+
+TEST(UtilTypeName, SplitGenericTypeNameParsesListAndMap) {
+    std::string head;
+    std::vector<std::string> inner;
+
+    EXPECT_TRUE(splitGenericTypeName("List<int>", head, inner));
+    EXPECT_EQ(head, "List");
+    ASSERT_EQ(inner.size(), 1u);
+    EXPECT_EQ(inner[0], "int");
+
+    EXPECT_TRUE(splitGenericTypeName("Map<str, int>", head, inner));
+    EXPECT_EQ(head, "Map");
+    ASSERT_EQ(inner.size(), 2u);
+    EXPECT_EQ(inner[0], "str");
+    EXPECT_EQ(inner[1], "int");
+}
+
+TEST(UtilTypeName, SplitGenericTypeNameHandlesNestedGenerics) {
+    std::string head;
+    std::vector<std::string> inner;
+
+    EXPECT_TRUE(splitGenericTypeName("List<Map<str, int>>", head, inner));
+    EXPECT_EQ(head, "List");
+    ASSERT_EQ(inner.size(), 1u);
+    EXPECT_EQ(inner[0], "Map<str, int>");
+}
+
+TEST(UtilTypeName, SplitGenericTypeNameRejectsNonGeneric) {
+    std::string head;
+    std::vector<std::string> inner;
+    EXPECT_FALSE(splitGenericTypeName("int", head, inner));
+    EXPECT_FALSE(splitGenericTypeName("List<int", head, inner));
+}
+
+TEST(UtilTypeName, IsListTypeNameMatchesPrefix) {
+    EXPECT_TRUE(isListTypeName("List<int>"));
+    EXPECT_TRUE(isListTypeName("List<List<int>>"));
+    EXPECT_FALSE(isListTypeName("List"));
+    EXPECT_FALSE(isListTypeName("Map<str, int>"));
+    EXPECT_FALSE(isListTypeName(""));
+}
+
+TEST(UtilTypeName, IsMapTypeNameMatchesPrefix) {
+    EXPECT_TRUE(isMapTypeName("Map<str, int>"));
+    EXPECT_FALSE(isMapTypeName("Map"));
+    EXPECT_FALSE(isMapTypeName("List<int>"));
+}
+
+TEST(UtilTypeName, IsSetTypeNameMatchesPrefix) {
+    EXPECT_TRUE(isSetTypeName("Set<int>"));
+    EXPECT_FALSE(isSetTypeName("Set"));
+    EXPECT_FALSE(isSetTypeName("List<int>"));
+}
+
+TEST(UtilTypeName, IsWeakTypeNameRequiresWeakSpacePrefix) {
+    EXPECT_TRUE(isWeakTypeName("weak Point"));
+    EXPECT_FALSE(isWeakTypeName("weak"));
+    EXPECT_FALSE(isWeakTypeName("Weak Point"));
+}
+
+TEST(UtilTypeName, IsFunctionTypeNameMatchesFnPrefix) {
+    EXPECT_TRUE(isFunctionTypeName("fn() -> int"));
+    EXPECT_TRUE(isFunctionTypeName("fn(int, int) -> int"));
+    EXPECT_FALSE(isFunctionTypeName("fn"));
+    EXPECT_FALSE(isFunctionTypeName("Function<int>"));
+}
+
+TEST(UtilTypeName, IsLowLevelTypeNameCoversIntegerAndFloatVariants) {
+    EXPECT_TRUE(isLowLevelTypeName("i8"));
+    EXPECT_TRUE(isLowLevelTypeName("i64"));
+    EXPECT_TRUE(isLowLevelTypeName("u32"));
+    EXPECT_TRUE(isLowLevelTypeName("f32"));
+    EXPECT_FALSE(isLowLevelTypeName("int"));
+    EXPECT_FALSE(isLowLevelTypeName("float"));
+    EXPECT_FALSE(isLowLevelTypeName("f64"));
+    EXPECT_FALSE(isLowLevelTypeName(""));
+}
+
+TEST(UtilTypeName, DeriveRuntimeFnNamePrefixesUnderscores) {
+    EXPECT_EQ(deriveRuntimeFnName("", "print"), "__ry_print");
+    EXPECT_EQ(deriveRuntimeFnName("path", "join"), "__ry_path_join");
+    EXPECT_EQ(deriveRuntimeFnName("json", "load"), "__ry_json_load");
+}
+
+TEST(UtilTypeName, NativeSigKeyJoinsPackageAndName) {
+    EXPECT_EQ(nativeSigKey("", "len"), "len");
+    EXPECT_EQ(nativeSigKey("math", "sqrt"), "math::sqrt");
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

- Move 10 pure type-name helpers (`splitGenericTypeName`, `trimTypeNameSpaces`, `isList/Map/Set/Weak/Function/LowLevelTypeName`, `deriveRuntimeFnName`, `nativeSigKey`) from `CodeGen` static members into a new layer-independent `ry::util` namespace (`include/ry/util/type_name.hpp` + `src/util/type_name.cpp`). Mechanical move with no behavior change; all ~286 call sites across 21 files updated.
- Add `docs/architecture/{compiler-layers, llvm-ir-emission-boundary, runtime-abi-boundary}.md` to document the layer dependency direction, the candidate LLVM IR emission shared-library boundary (carry-over surface for #1949 / #1950), and the runtime ABI categorization for staged Rust migration.

Closes #1820

## Test plan

- [x] `cmake --build build` succeeds
- [x] `./build/ry_tests` (2523 pass / 0 fail; includes new `UtilTypeName.*` suite)
- [x] `./build/ry test -p` (203 Ry self-test files, 0 failures)
- [x] ASan+UBSan build + tests clean (0 sanitizer findings)
- [x] `grep -rn "CodeGen::splitGenericTypeName|..." src/ include/ tests/` returns empty
- [x] No double-prefix `ry::util::ry::util::` introduced

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture docs for contributors covering compiler layer boundaries, LLVM IR emission interface, and runtime ABI.

* **Refactor**
  * Consolidated type-name parsing/utility logic into a shared utility layer and wired it across the codebase (no behavioral changes).

* **Tests**
  * Added a test suite validating the type-name utilities.

* **Chores**
  * Build updated to compile and run the new utilities and tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1959?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->