### PR TITLE
docs(architecture): add layer graduation workflow and codegen layering plan

### DIFF
--- a/changelog.d/1824-layer-graduation-workflow.md
+++ b/changelog.d/1824-layer-graduation-workflow.md
@@ -1,0 +1,3 @@
+### Changed
+
+- Added `docs/architecture/layer-graduation-workflow.md` and `docs/architecture/codegen-layering-plan.md` to define when a compiler/runtime layer is graduate-ready (criteria + per-layer document template) and to record the codegen 2-layer split working hypothesis (Ry semantic lowering vs LLVM IR emission, lowered IR vocabulary, bounds-check pilot). `docs/architecture/compiler-layers.md` is updated to forward-reference the planned split. Documentation-only; no behavior change. Preparation for #1949 (LLVM IR emission shared library) and #1950 (Rust reimplementation). (#1824)

--- a/docs/architecture/codegen-layering-plan.md
+++ b/docs/architecture/codegen-layering-plan.md
@@ -1,0 +1,134 @@
+# Codegen Layering Plan
+
+This document is the working hypothesis for splitting the codegen layer into two conceptual sub-layers — **Ry semantic lowering** and **LLVM IR emission**. It is the stage-3 design deliverable of v0.0.26 (issue #1824) and the design reference that #1949 (LLVM IR emission shared-library extraction) and #1950 (Rust reimplementation) will implement.
+
+This is a **working hypothesis, not a graduation document**. The codegen layer is explicitly **not graduated** by this issue. The final responsibility / I/O / contract for each sub-layer is written only after the refactor in #1949 lands, per [Layer Graduation Workflow](layer-graduation-workflow.md) §"When to write the graduation document".
+
+## Why split codegen at all
+
+The `CodeGen` class (`include/ry/codegen.hpp`, ~2,400 lines) currently mixes two distinct responsibilities:
+
+- **Ry semantic** state and decisions: type registries (`record_types_`, `enum_types_`, `type_aliases_`), ARC bookkeeping, ownership, stdlib dispatch, module-namespace state, type inference hints.
+- **LLVM IR construction**: `IRBuilder<>`, `llvm::Module&`, primitive type accessors (`i64Ty_`, `ptrTy_`, …), block layout, PHI construction, intrinsic emission.
+
+These are coupled through a single class. Replacing the LLVM-touching side with a different implementation language (#1950's Rust target) requires the surface that crosses the boundary to be free of LLVM-owned types, which the current single-class shape prevents. The split is the critical path to #1949 / #1950, which is the stated v0.0.26 milestone goal.
+
+## Two conceptual sub-layers
+
+### Ry semantic lowering
+
+- **Owns**: Ry-level type understanding (Ry types, ownership/ARC intent, stdlib operation semantics, type inference state, qualified-import resolution).
+- **Reads**: AST, sema results, module loader output, source manager.
+- **Produces**: a **lowered IR** — an operation plan that names what should happen, not how to express it in LLVM. The vocabulary is defined below.
+- **Does not call**: `IRBuilder<>::Create*`, `llvm::Module::getOrInsertFunction`, `llvm::Function::Create`. The lowering layer should not need to construct any `llvm::Value` directly.
+
+### LLVM IR emission
+
+- **Owns**: every `IRBuilder<>::Create*` call, basic-block construction, PHI nodes, intrinsic emission, runtime-symbol declaration.
+- **Reads**: lowered IR ops from the semantic lowering layer.
+- **Produces**: LLVM IR (the `llvm::Module` that the JIT or AOT path consumes).
+- **Does not know**: Ry type aliases, ARC ownership rules, stdlib dispatch semantics, qualified-import state. If it needs to make a Ry-semantic decision, the lowering side did not produce the right op.
+
+The boundary the two sides share is the lowered IR vocabulary in §"Lowered IR vocabulary" plus the `extern "C"` ABI surface in [LLVM IR Emission Boundary](llvm-ir-emission-boundary.md) (which already documents the five access categories the extraction will narrow through).
+
+## Lowered IR vocabulary
+
+The vocabulary is kept small so the LLVM IR emission layer can map each op to a near-1:1 sequence of LLVM API calls — required by issue #1824 AC. "Near-1:1" here means each op expands via a fixed playbook keyed on op kind plus its parameters — not one LLVM call per op. The emission side must not need to introspect Ry-level semantics to decide what playbook to run; if it does, the lowering side did not produce the right op. The working set is 10 ops; the final shape may shrink during the pilot.
+
+| Op | Lowering input (Ry intent) | Emission output (LLVM API sequence) | Current implementation site |
+|---|---|---|---|
+| `RuntimeCall` | A Ry-level call resolved to a `__ry_*` runtime symbol with a structured signature and return-wrapping policy. | `mod_->getOrInsertFunction("__ry_…", funcType)` + `CreateCall`. | Scattered across `codegen_call_*.cpp` (no central helper today; see `codegen_any.cpp:199,362,912`, `codegen_call_user.cpp:392-767`). |
+| `BoundsCheck` | An index expression, a length expression, and a structured error spec (error kind + source position). | `CreateICmpSLT` + `CreateICmpSGE` + `CreateCondBr` + `emitBoundsError` (exit IR). | `emitBoundsCheck` in `codegen_call_user.cpp:821` (~35 lines). |
+| `ResultWrap` / `ResultUnwrap` | Wrap a value or runtime-error query as `Result<T, Error>`, or unwrap on a known path. | `CreateInsertValue` for the `Result` struct, or BB split + PHI for unwrap. | Already centralized: `emitResultBranch`, `wrapPtrAsResult`, `wrapStatusAsResult`, `buildErrorFromRuntime` at `codegen_call_dispatch.cpp:430-481`. |
+| `OptionWrap` | Wrap a value as `Some` / `None`. | `CreateInsertValue` for the `Option` struct. | `codegen_call.cpp` `buildSomeValue` / `buildNoneValue` (helpers, not yet a single entry point). |
+| `AnyWrap` / `AnyUnwrap` | Decide the runtime type tag from value metadata and wrap; or unwrap to a concrete type with a tag check. | `CreateInsertValue` / `CreateExtractValue` for the `{i64 tag, [8 x i8] data}` struct + runtime helper calls. | `wrapInAny` (`codegen_any.cpp:44`), `unwrapFromAny` (:230), `tryUnwrapFromAny` (:500). |
+| `ArcRetain` / `ArcRelease` | Increment / decrement the ARC count of an owned value. | `CreateAtomicRMW` + load/store of the header word. | `emitArcRetain` / `emitArcRelease` in `codegen_arc.cpp`. |
+| `CowEnsureUnique` | Ensure a shared collection slot is private before mutation. | Strong-count atomic load + `CreateCondBr` to a clone path that does malloc + memcpy. | `emitCowCheck` in `codegen_arc_cow.cpp:163`. |
+| `CollectionMutate` | A list/map/set mutation request (`append`, `insert`, `removeAt`, `slice`, …) with element-type metadata. | malloc/memcpy chains, header GEP/load/store, ARC retain calls for owned elements. | `emitCollOp_append` (`codegen_call_collection.cpp:382`), `emitCollOp_insert` (:744), `emitListSlice` (:600). |
+| `ControlFlow` | A structured branch / loop / match-arm decision. | Basic block creation, `CreateCondBr` / `CreateBr`, PHI assembly. | `codegen_stmt.cpp`, `codegen_match.cpp`, `codegen_stmt_loop.cpp`. |
+
+**Explicit non-inclusion** (the surface is intentionally not extended to keep emission near-1:1):
+
+- **Low-level primitive arithmetic** (`i32 + i32` → `CreateAdd`, `f64 * f64` → `CreateFMul`, integer comparisons, bit ops). These are **passthrough**: the lowering layer forwards them as a thin "primitive op" without inventing a vocabulary entry. Adding a `PrimitiveOp` op would inflate the vocabulary without giving the lowering layer anything to decide.
+- **Lexical scope and SSA bookkeeping**. These belong inside the emission layer; the lowering layer treats variable bindings as Ry-level names and lets emission map them to allocas / `Value*`.
+- **Module-level symbol declarations** (`@native` symbol registration, global variable emission). The lowering layer states "this call resolves to symbol X with signature S"; the emission layer is responsible for the `getOrInsertFunction` / `GlobalVariable` plumbing.
+
+If a candidate op cannot be expressed as a 1:1 sequence of LLVM API calls on the emission side, it belongs in the lowering layer, not the vocabulary. The vocabulary's purpose is to give emission a stable, narrow surface; if it grows past ~10 ops or any op expands to a deep branching IR construction, the split is leaking.
+
+## Relationship to `llvm-ir-emission-boundary.md`
+
+The two documents are **complementary**, not overlapping:
+
+- `llvm-ir-emission-boundary.md` defines the **`extern "C"` ABI surface** that the shared library (#1949) and the Rust reimplementation (#1950) will expose. It classifies the existing custom-emitter access patterns into five categories and identifies category 3 (runtime wrapper helpers, already centralized in `codegen_call_dispatch.cpp:430-481`) as the most-narrowed candidate for the first extraction step.
+- This document (`codegen-layering-plan.md`) defines the **conceptual responsibility split** (lowering vs emission) and the **lowered IR vocabulary** that the split is built around.
+
+The ABI document is the implementation surface; this document is the conceptual split that gives the ABI its shape. The two are co-maintained: changes to the vocabulary here imply changes to which categories cross the ABI there.
+
+The AC item "LLVM IR emission layer's `extern "C"` ABI surface is sketched and shown to be free of LLVM-owned types" is satisfied jointly by these two documents — the ABI surface and the LLVM-type-exclusion constraint live in `llvm-ir-emission-boundary.md`, and this document specifies what travels across it.
+
+## Pilot area: bounds-check intent
+
+The pilot for the lowering / emission split is the **`BoundsCheck`** op.
+
+### Why bounds-check is the pilot
+
+- **Smallest demonstrator**. `emitBoundsCheck` is ~35 lines with 6 call sites (`codegen_stmt_misc.cpp:428,1082,1320`, `codegen_expr_literal.cpp:927,1145`, `codegen_arc_cow.cpp:433`). The full extraction can be reviewed in a single small PR.
+- **Clear lowering / emission boundary**. The lowering side computes `BoundsCheck { idx, len, error_spec }` from the index expression, the collection length, and a position-tagged error specification. The emission side is fixed shape: `CreateICmpSLT` + `CreateICmpSGE` + `CreateCondBr` + an exit-IR call to `emitBoundsError`. Nothing on the emission side requires Ry semantic knowledge.
+- **Lowest risk**. Behavior is bit-exact preserved (bounds-check IR is well-tested by `tests/spec/`), the runtime error wiring is already centralized via `emitRuntimeError` / exit IR, and the change is observable in a narrow test surface.
+- **Demonstrator value**. Validates that the lowered-IR ↔ LLVM-emission shape works without committing to the wider extraction.
+
+### What the pilot validates
+
+- The lowered IR can carry a structured error spec without leaking `Diagnostic` types into the emission side.
+- The emission side accepts the op via an `EmitterContext`-shaped interface (the narrowing direction documented in `llvm-ir-emission-boundary.md` §"Narrowing direction").
+- The call-site rewrite at the 6 callers is mechanical — i.e. the split does not require redesigning callers.
+
+### Expected post-cleanup documentation deliverable
+
+The pilot PR updates this `codegen-layering-plan.md` to reflect the actual `BoundsCheck` op shape after extraction — including any vocabulary entries that proved redundant or under-specified during the pilot. A separate graduation document for the lowering / emission sub-layers is **not** written at this step; that comes only after step 2 per §"When the codegen layers earn their graduation document". Writing per-layer graduation docs at the pilot stage would be exactly the aspirational anti-pattern the workflow exists to prevent.
+
+### Alternatives considered (not selected)
+
+- **`Result` / `Option` construction**. Helpers (`emitResultBranch`, `wrapPtrAsResult`, …) are already consolidated in `codegen_call_dispatch.cpp:430-481`, making the **extraction** the lowest risk. However, the lowering side has very little to compute (the wrap intent is already determined upstream by the time these helpers are called), so the demonstrator value of the lowering / emission split is weaker than bounds-check.
+- **`any` wrap/unwrap**. `codegen_any.cpp` is ~2,116 lines with deep coupling to type metadata. The split has good semantic clarity (tag determination is lowering; struct construction is emission), but the size is too large for a pilot. This is a strong candidate for a wider extraction once the bounds-check pilot validates the shape.
+- **Runtime ABI call specs**. `mod_->getOrInsertFunction("__ry_…")` is scattered across `codegen_call_*.cpp` with no central helper. A `RuntimeCall` op consolidation would be high-value but high-scope; not suitable as a first pilot.
+- **`typename` utilities**. Already addressed by #1821 (pure-utility extraction); not a codegen-split pilot.
+
+## Staged migration plan
+
+The codegen split proceeds in stages. Each stage has a stop condition; the next stage does not start until the current stage's stop condition is met.
+
+| Step | Scope | Stop condition | Tracking |
+|---|---|---|---|
+| **0** | Workflow + plan + pilot area selected. | This document and `layer-graduation-workflow.md` merged. | This issue (#1824). |
+| **1** | Pilot extraction of `BoundsCheck` into lowering + emission split. Minimal `LoweredOp::BoundsCheck` plumbing; the 6 callers updated to lower-then-emit. No other ops touched. | The 6 call-site updates land; existing tests pass; the lowering / emission separation is observable in the file layout (header + cpp boundary). | Follow-up issue (TBD; see issue #1824 §"Proposed Deliverables" follow-up implementation issues). |
+| **2** | Wider extraction. Successively add the remaining lowered IR ops (start from the lowest-risk: `RuntimeCall`, then `BoundsCheck` callers from collection emitters). Define the shared-library `extern "C"` ABI from category 3 of `llvm-ir-emission-boundary.md` outward. Build the LLVM IR emission layer as a `SHARED` CMake target. | The codegen call sites no longer call `IRBuilder<>` directly; the LLVM-owning side is reachable only through the ABI; the shared library builds. | #1949. |
+| **3** | Reimplement the shared library in Rust behind the same ABI. | All existing tests pass with the Rust implementation; the C++ implementation is removed (or feature-flagged for the brief transition). | #1950. |
+
+Each stage produces evidence that the next stage can start. A graduation document for the codegen sub-layers (lowering / emission) is **not** written at step 1 — the lowering and emission sides have not stabilized yet. The graduation document is written at the end of step 2, after the shared-library shape settles.
+
+## SRP and file-size goals
+
+The pilot (step 1) and the wider extraction (step 2) follow the [Layer Graduation Workflow](layer-graduation-workflow.md) §"SRP and file-size policy":
+
+- Newly created files in step 1 stay at or under 500 lines.
+- Once the lowering and emission sides graduate (end of step 2), target 200–300 lines per file where it improves navigability.
+- No line-count-only splits. Splitting the current `codegen_call_*.cpp` files by filename prefix without a responsibility split is explicitly forbidden by #1819's milestone policy and by the workflow doc.
+
+## When the codegen layers earn their graduation document
+
+The two sub-layers (`codegen-semantic-lowering-graduation.md` and `codegen-llvm-emission-graduation.md`) are written after **all** of the following hold:
+
+1. Step 2 (#1949) has landed — the shared library is built and the codegen call sites dispatch through the ABI.
+2. The lowered IR vocabulary has converged (the working list above may shrink during the pilot; the final list is recorded in the graduation doc, not predicted here).
+3. Existing tests pass against the post-extraction shape — behavior is preserved end-to-end.
+4. The emission layer's `extern "C"` ABI carries no LLVM-owned types (enforced by header-level lint of the public ABI header).
+
+Until then, the lowering / emission sides have a working hypothesis (this document) but are explicitly **not graduated**.
+
+## Related documents
+
+- [Layer Graduation Workflow](layer-graduation-workflow.md) — the workflow this plan operates inside; defines graduation criteria, the document template, and the "write the doc after the refactor" rule.
+- [Compiler Layers](compiler-layers.md) — the lightweight layer-ordering hypothesis the codegen row of which this plan refines.
+- [LLVM IR Emission Boundary](llvm-ir-emission-boundary.md) — the `extern "C"` ABI surface that the wider extraction (step 2 / #1949) will implement.
+- [Runtime ABI Boundary](runtime-abi-boundary.md) — the orthogonal `__ry_*` boundary; codegen's `RuntimeCall` op routes through it, so the lowered IR vocabulary and the runtime ABI categorization stay aligned.

--- a/docs/architecture/compiler-layers.md
+++ b/docs/architecture/compiler-layers.md
@@ -17,7 +17,7 @@ lexer → parser → AST → module loader → sema → codegen → runtime ABI
 | AST | `include/ry/ast/ast.hpp` | Plain-data node definitions shared by every later layer. The AST is the contract between parsing and downstream consumers. |
 | module loader | `include/ry/module/module_loader.hpp` | Resolve `import` graphs, load `.ry` source files lazily, and provide AST roots for each module. |
 | sema | `include/ry/sema/*.hpp` | Static analysis that runs alongside codegen — return-path coverage (`sema_return.hpp`), pattern-match exhaustiveness, etc. |
-| codegen | `include/ry/codegen.hpp` | Lower AST + sema results into LLVM IR. Owns the `CodeGen` monolith (LLVM context, ARC bookkeeping, type/metadata registries, stdlib dispatch). |
+| codegen | `include/ry/codegen.hpp` | Lower AST + sema results into LLVM IR. Owns the `CodeGen` monolith (LLVM context, ARC bookkeeping, type/metadata registries, stdlib dispatch). A 2-layer split into Ry semantic lowering vs LLVM IR emission is the v0.0.26 working hypothesis ([Codegen Layering Plan](codegen-layering-plan.md)) and is the critical path to the shared-library extraction in #1949 and the Rust reimplementation in #1950. |
 | runtime ABI | `include/ry/runtime/{core,native}/*.hpp` | C++ runtime entry points exposed via `extern "C"` symbols (`__ry_*`). See [Runtime ABI Boundary](runtime-abi-boundary.md) for the categorization. |
 
 `codegen_native_dispatch.hpp` / `directive_meta.hpp` / `ry_layout.hpp` / `codegen_guards.hpp` are shared declarations co-owned by codegen and the runtime ABI; they sit at the codegen/runtime interface and intentionally span the two layers.
@@ -47,5 +47,7 @@ The observed adjacency list as of v0.0.26 is:
 
 ## Related documents
 
+- [Layer Graduation Workflow](layer-graduation-workflow.md) — graduation criteria, the per-layer graduation document template, and the "write the contract after the refactor" rule that governs how this layer hypothesis evolves into per-layer contracts.
+- [Codegen Layering Plan](codegen-layering-plan.md) — codegen-specific working hypothesis for the Ry semantic lowering vs LLVM IR emission split, the lowered IR vocabulary, and the pilot extraction target.
 - [LLVM IR Emission Boundary](llvm-ir-emission-boundary.md) — identifies the candidate shared-library boundary inside the codegen layer.
 - [Runtime ABI Boundary](runtime-abi-boundary.md) — categorizes the `__ry_*` `extern "C"` surface for Rust migration planning.

--- a/docs/architecture/layer-graduation-workflow.md
+++ b/docs/architecture/layer-graduation-workflow.md
@@ -1,0 +1,121 @@
+# Layer Graduation Workflow
+
+This document defines how a compiler/runtime layer becomes "done enough" to earn a written contract and be considered a Rust-migration candidate. It is the stage-3 deliverable of v0.0.26 (issue #1824) and the workflow reference for follow-up codegen split work (#1949 → #1950) and for any future per-layer organization.
+
+## Purpose
+
+Writing detailed responsibility / I/O / contract documentation **before** the implementation matches that shape produces aspirational documentation that drifts from reality and provides false confidence. This is the same anti-pattern observed in `docs/reference/*.md` drift incidents (e.g. #889, #1118, #1474), where a written spec lagged or led the code and silently disagreed with it.
+
+The alternative sequence this document prescribes:
+
+1. Keep an initial design hypothesis lightweight (one paragraph in `compiler-layers.md`).
+2. Refactor the code until a layer actually owns a single responsibility and a narrow dependency surface.
+3. Write the layer's graduation document **after** the refactor stabilizes.
+4. Use that graduation document as evidence that the layer is reorganized enough to be a Rust-migration candidate (see `runtime-abi-boundary.md` for the readiness criteria already applied to the runtime side).
+
+A layer that has only the lightweight hypothesis is **not graduated**. A layer that has a written contract but a code shape that does not match the contract is also **not graduated** — that is documentation drift, not graduation.
+
+## Graduation criteria
+
+A layer (or component) is graduate-ready when **all** of the following hold:
+
+1. **Single responsibility**. The layer's responsibility is statable in one sentence without "and" / "also". If the sentence needs a list, the layer has not yet been split far enough.
+2. **Inputs and outputs are typed concretely**. "Takes an AST" / "uses CodeGen context" is not concrete. The contract names the actual types (or opaque handles) crossing the boundary.
+3. **Invariants are enumerated and tested**. Each invariant has at least one test that breaks if it is violated. Untested invariants are aspirational.
+4. **Allowed and forbidden dependencies are header-observable**. The `#include` graph reflects the dependency direction — adding a forbidden include must fail (compile error, lint, or CI grep). The rule in `compiler-layers.md` is the project-wide default; per-layer graduation can narrow it further.
+5. **The boundary is observable in code**. A separate header, namespace, or `extern "C"` ABI surface — not just a comment block. A graduated layer can be located by `grep` for its boundary token (header name, namespace, or symbol prefix).
+6. **Errors owned by the layer are listed with their channel**. Codegen errors surface through `codegenError`; runtime errors surface through `__ry_set_last_error`; lexer errors surface through `Diagnostic`. A graduated layer specifies which channel it uses and which error kinds it owns end-to-end.
+7. **Rust migration readiness is assessed against the runtime-side criteria**. The four conditions in [Runtime ABI Boundary](runtime-abi-boundary.md) "Rust migration readiness criteria" are the project-wide baseline:
+   - Scalar / opaque-pointer / `#[repr(C)]` POD ABI only.
+   - No internal LLVM dependency at the ABI surface.
+   - No transitive C++ template in the ABI.
+   - Uniform error channel (e.g. `__ry_set_last_error` for runtime, structured `Result<T, Error>` wrapping for codegen-emitted calls).
+
+   A layer that fails one of the four criteria is still allowed to graduate, but the graduation document records the blocker so it is visible during Rust-migration planning.
+
+## Graduation document template
+
+Each graduated layer earns a Markdown file under `docs/architecture/<layer>-graduation.md` (or `docs/architecture/<component>-graduation.md` for finer-grained components) with the following sections. The template is intentionally short — long graduation documents tend to repeat themselves and are harder to keep current.
+
+```markdown
+# <Layer name> Graduation
+
+Layer: <layer name as it appears in compiler-layers.md>
+Implementation: <primary header(s) / source directory>
+Test coverage: <pointer to the tests that lock the contract>
+Status: graduated (<date>, <PR or issue link>)
+
+## Responsibility
+
+One sentence. No "and".
+
+## Inputs
+
+The concrete types (or opaque handles) accepted at the boundary.
+
+## Outputs
+
+The concrete types (or opaque handles) produced at the boundary.
+
+## Invariants
+
+Bulleted list. Each invariant cites the test that enforces it.
+
+## Errors
+
+Bulleted list. Each entry: the error kind, the channel it surfaces through, and which side (layer / caller) owns recovery.
+
+## Allowed dependencies
+
+Other layers / utility modules this layer may #include.
+
+## Forbidden dependencies
+
+Other layers this layer must NOT #include. Include a `grep`-able assertion of how the forbid is observable in code.
+
+## Rust migration readiness
+
+For each of the four criteria in runtime-abi-boundary.md, one line: "met" / "blocked by <reason>".
+
+## Remaining blockers
+
+Bulleted list. Only items that block Rust migration or further responsibility narrowing — not nice-to-haves.
+```
+
+The file is checked in at the same time as the PR that completes the layer's refactor, not earlier and not in a separate follow-up. A graduation document landed in a different PR than the corresponding code refactor is treated as evidence of either (a) the refactor wasn't actually done in the cited PR, or (b) the doc is aspirational.
+
+## SRP and file-size policy
+
+The project applies SRP / file-size goals **after** dependency reduction, not as a primary driver:
+
+- **First target**: a new or newly split implementation file stays at or under 500 lines (including comments).
+- **Later target**: once a layer's responsibilities have stabilized, target 200–300 lines per file where it improves navigability.
+- **Line-count-only splits are forbidden**. A split must correspond to a responsibility boundary — splitting a 1,000-line file into two 500-line files that still share state and dependencies is a no-op for graduation purposes (it changes file layout, not the contract).
+- A layer is **not graduated** because its files are small. Small files without a clear responsibility split are just smaller monoliths.
+
+## Anti-patterns to avoid
+
+1. **Aspirational design ahead of code**. Writing a layer's responsibility / I/O / contract before the code has been split. The contract will not match the code, and readers will use the contract as a spec while the code does something else. This is the same drift class as the `docs/reference/*.md` incidents (#889, #1118, #1474) and is explicitly warned about in issue #1824.
+2. **Graduating all layers at the same time**. Each layer's graduation is a separate exercise; trying to write graduation docs for the entire stack at once produces shallow contracts and hides the layers that actually need work.
+3. **Filename-prefix-only "layering"**. Renaming `codegen_call_*.cpp` to `lowering_call_*.cpp` does not graduate the codegen layer. The responsibility split is what graduates, not the file naming.
+4. **Line-count-only splits**. See SRP policy above.
+5. **Writing the graduation doc in a follow-up PR**. If the doc and the refactor are not in the same PR, the doc is either drift in advance (PR ships before doc) or aspirational (doc ships before PR). Both are anti-patterns.
+6. **Treating utility extraction as graduation**. Extracting `ry::util/type_name.hpp` (#1820) is a precondition for graduating the codegen layer, not graduation itself. Pure-utility extraction is necessary but not sufficient.
+
+## When to write the graduation document
+
+After **all** of the following hold:
+
+1. The refactor PR that reorganizes the layer is ready (not yet merged is acceptable; speculative refactor work in a feature branch counts).
+2. The layer's existing tests pass against the refactored shape — i.e. behavior is preserved, only structure changed.
+3. The dependency direction is observable in code (`grep` the forbidden includes; they must not be present).
+4. The error channels owned by the layer are uniform — no mixed-channel paths remain inside the layer.
+
+If any of these fail, the graduation document is premature; finish the refactor first.
+
+## Related documents
+
+- [Compiler Layers](compiler-layers.md) — layer ordering, dependency direction, and the lightweight hypothesis the workflow starts from.
+- [LLVM IR Emission Boundary](llvm-ir-emission-boundary.md) — the `extern "C"` ABI surface design for the codegen-internal split.
+- [Runtime ABI Boundary](runtime-abi-boundary.md) — the existing `__ry_*` boundary classification; its "Rust migration readiness criteria" are the format precedent for graduation criteria.
+- [Codegen Layering Plan](codegen-layering-plan.md) — the codegen-specific working hypothesis (Ry semantic lowering vs LLVM IR emission) and pilot extraction target.


### PR DESCRIPTION
## Summary

- Add `docs/architecture/layer-graduation-workflow.md` defining graduation criteria, the per-layer document template, SRP/file-size policy, and the "write the contract after the refactor" rule.
- Add `docs/architecture/codegen-layering-plan.md` recording the codegen 2-layer split working hypothesis (Ry semantic lowering vs LLVM IR emission), the lowered IR vocabulary (≤10 ops), and the bounds-check pilot extraction target.
- Update `docs/architecture/compiler-layers.md` to forward-reference the planned split (#1824 → #1949 → #1950).

Documentation-only; no behavior change. Preparation for #1949 (LLVM IR emission shared library) and #1950 (Rust reimplementation).

## Test plan

- [x] Markdown links resolve (all four touched files cross-reference correctly)
- [x] Existing C++ tests pass (2523 tests / 76 suites)
- [x] Existing Ry self-tests pass (203 files / 0 failures)
- [x] Build succeeds (`cmake --build build`) — docs-only PR, sanity check
- [x] AC sweep mapped each of issue #1824's 7 acceptance criteria to a specific doc section

## Pre-commit checklist skip log

- Skipped §3 — no source code change (docs / changelog.d only)
- Skipped §3.5 — no source code change
- Skipped §3.6 — no parser/lexer/json/utf8/string change
- Skipped §3.6.5 — no tree-sitter grammar change
- §3.5.5 Static Analysis — validated via CI (lint / clang-tidy / scan-build / CodeQL all SUCCESS); no C++ source touched locally
- §2.5 rules/skills — intentionally no new entry (Plan: graduation rules are promoted only after #1949 lands; otherwise it is the same aspirational anti-pattern the workflow exists to prevent)

Closes #1824