### PR TITLE
fix(docker): register fuzz_io_open harness in entrypoint dispatch

### DIFF
--- a/.claude/agents/fuzzer-runner.md
+++ b/.claude/agents/fuzzer-runner.md
@@ -1,6 +1,6 @@
 ---
 name: "fuzzer-runner"
-description: "libFuzzer harness (fuzz_parser / fuzz_json / fuzz_utf8) の実行・crash 解析を独立 context で行う subagent。main agent から foreground 並列起動して使う (target 別に複数 fuzzer-runner を同時起動可能)。`/pre-commit-checklist` §3.6 の自動化版。`run-fuzz.sh` を起動し、crash した場合は corpus path と原因要約を短い report で返す。tests/fuzz/regressions/ と tests/fuzz/corpus/ の両方に crash 入力を保存する。コード変更は行わない (修正は呼び出し元 main agent の責務)。"
+description: "libFuzzer harness (fuzz_parser / fuzz_json / fuzz_utf8 / fuzz_io_open) の実行・crash 解析を独立 context で行う subagent。main agent から foreground 並列起動して使う (target 別に複数 fuzzer-runner を同時起動可能)。`/pre-commit-checklist` §3.6 の自動化版。`run-fuzz.sh` を起動し、crash した場合は corpus path と原因要約を短い report で返す。tests/fuzz/regressions/ と tests/fuzz/corpus/ の両方に crash 入力を保存する。コード変更は行わない (修正は呼び出し元 main agent の責務)。"
 tools: Bash, Read, Write
 model: sonnet
 color: orange
@@ -11,7 +11,7 @@ You are a libFuzzer execution and crash-analysis specialist. Your role is to run
 ## Input from caller
 
 The main agent specifies which target(s) to run:
-- `all` — `./.claude/skills/pre-commit-checklist/run-fuzz.sh` (default; runs `fuzz_parser` / `fuzz_json` / `fuzz_utf8` for 60s each)
+- `all` — `./.claude/skills/pre-commit-checklist/run-fuzz.sh` (default; runs `fuzz_parser` / `fuzz_json` / `fuzz_utf8` / `fuzz_io_open` for 60s each)
 - `<target>` — `./docker/run.sh fuzz <target> <duration> <rss_mb>` for a single target (e.g. `fuzz_parser`)
 - `<target>:<seconds>` — same but with explicit duration override
 
@@ -39,7 +39,7 @@ Return to the main agent in this shape:
 
 ```
 RESULT: PASS  (or CRASH)
-TARGETS: fuzz_parser, fuzz_json, fuzz_utf8  (or single target name)
+TARGETS: fuzz_parser, fuzz_json, fuzz_utf8, fuzz_io_open  (or single target name)
 DURATION: <wall-clock seconds>
 CRASHES:
   - <target>: <detector> <type> at file:line — artifact tests/fuzz/regressions/<target>/<hash> (also copied to tests/fuzz/corpus/<target>/<hash>) — one-sentence summary

--- a/.claude/skills/linux-docker-dev/SKILL.md
+++ b/.claude/skills/linux-docker-dev/SKILL.md
@@ -25,15 +25,18 @@ See [`docker/README.md`](../../../docker/README.md) for a quick-start reference.
 
 ./docker/run.sh tsan ry_tests                                     # TSan, C++ tests
 
-./docker/run.sh fuzz fuzz_parser -max_total_time=30 \
+./docker/run.sh fuzz fuzz_parser  -max_total_time=30 \
     -artifact_prefix=tests/fuzz/regressions/parser/ \
     tests/fuzz/corpus/parser                                      # libFuzzer parser harness
-./docker/run.sh fuzz fuzz_json   -max_total_time=30 \
+./docker/run.sh fuzz fuzz_json    -max_total_time=30 \
     -artifact_prefix=tests/fuzz/regressions/json/ \
     tests/fuzz/corpus/json
-./docker/run.sh fuzz fuzz_utf8   -max_total_time=30 \
+./docker/run.sh fuzz fuzz_utf8    -max_total_time=30 \
     -artifact_prefix=tests/fuzz/regressions/utf8/ \
     tests/fuzz/corpus/utf8
+./docker/run.sh fuzz fuzz_io_open -max_total_time=30 \
+    -artifact_prefix=tests/fuzz/regressions/fuzz_io_open/ \
+    tests/fuzz/corpus/fuzz_io_open                                # libFuzzer I/O syscall harness
 
 ./docker/run.sh default bash                                      # interactive shell
 

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -26,12 +26,12 @@ git diff --name-only origin/main
 | `changelog.d/` only | skip | ✓ | skip | skip | skip |
 | `.claude/` only | skip | skip | skip | skip | skip |
 | `tests/` only | review | review | ✓ | ✓ | parser-family only |
-| includes parser/lexer/json/utf8/string※ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| includes parser/lexer/json/utf8/string/io※ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | other code changes | ✓ | ✓ | ✓ | ✓ | skip |
 
 **Legend**: `✓` = required / `skip` = may omit (record in PR description) / `review` = judgment call.
 
-※ "parser/lexer/json/utf8/string family" = changes to `src/parser*`, `src/lexer*`, `src/runtime/native/json.cpp`, `src/runtime/core/utf8.cpp`, `src/runtime/core/string.cpp` (also `src/runtime/core/regex_parser.cpp`), or `include/ry/parser*.hpp`, `include/ry/lexer*.hpp`, `include/ry/runtime/native/json.hpp`, `include/ry/runtime/core/string.hpp`. **`runtime/core/string.cpp` is a dependency of both `fuzz_json` and `fuzz_utf8`**, so it always falls in this row.
+※ "parser/lexer/json/utf8/string/io family" = changes to `src/parser*`, `src/lexer*`, `src/runtime/native/json.cpp`, `src/runtime/core/utf8.cpp`, `src/runtime/core/string.cpp` (also `src/runtime/core/regex_parser.cpp`), `src/runtime/native/io.cpp`, or `include/ry/parser*.hpp`, `include/ry/lexer*.hpp`, `include/ry/runtime/native/json.hpp`, `include/ry/runtime/core/string.hpp`, `include/ry/runtime/native/io.hpp`. **`runtime/core/string.cpp` is a dependency of both `fuzz_json` and `fuzz_utf8`**, so it always falls in this row.
 
 **Notes**: multiple matching rows ⇒ take the strictest per column (`✓` > `review` > `skip`). Always required regardless of matrix: §2.5 (rules/skills, when applicable), §3.5.5 (Static Analysis), §3.6.5 (tree-sitter Grammar Regression Check, when applicable), §3.7 (background hygiene), §4 (Label Cleanup, no-op). For `.md` / `docs/`-only and `changelog.d/`-only PRs, §4 is effectively the only required action: the edited area satisfies its own `✓` (self-edit = done), and the Skip-if bash returns `skip` for everything else.
 
@@ -171,10 +171,10 @@ Fix clang-tidy / cppcheck failures before declaring complete. Common patterns (e
 > **Skip if** — changed files do **not** include the parser/lexer/json/utf8/string family:
 >
 > ```bash
-> git diff --name-only origin/main | grep -E '(src/(parser|lexer)|src/runtime/native/json\.cpp|src/runtime/core/(utf8|string)\.cpp|include/ry/(parser|lexer)|include/ry/runtime/native/json\.hpp|include/ry/runtime/core/string\.hpp)' | head -1
+> git diff --name-only origin/main | grep -E '(src/(parser|lexer)|src/runtime/native/(json|io)\.cpp|src/runtime/core/(utf8|string)\.cpp|include/ry/(parser|lexer)|include/ry/runtime/native/(json|io)\.hpp|include/ry/runtime/core/string\.hpp)' | head -1
 > ```
 >
-> **Empty output ⇒ skip**. Otherwise run the matching fuzzer. Record `Skipped §3.6 — no parser/lexer/json/utf8/string change` in the PR description. **Fuzzer mapping**: parser/lexer → `fuzz_parser`; json → `fuzz_json` (+ `fuzz_utf8` if `runtime/core/string.cpp` changed); utf8/string → `fuzz_utf8` (+ `fuzz_json` if `runtime/core/string.cpp` changed). `tests/`-only changes targeting these areas ⇒ run the matching fuzzer only (judgment call); run all three when unsure.
+> **Empty output ⇒ skip**. Otherwise run the matching fuzzer. Record `Skipped §3.6 — no parser/lexer/json/utf8/string/io change` in the PR description. **Fuzzer mapping**: parser/lexer → `fuzz_parser`; json → `fuzz_json` (+ `fuzz_utf8` if `runtime/core/string.cpp` changed); utf8/string → `fuzz_utf8` (+ `fuzz_json` if `runtime/core/string.cpp` changed); io → `fuzz_io_open`. `tests/`-only changes targeting these areas ⇒ run the matching fuzzer only (judgment call); run all four when unsure.
 
 **CI jobs are disabled; always run locally on the feature branch.** Harness requirements and known limits are delegated to `/libfuzzer-harness`.
 
@@ -184,7 +184,7 @@ Fix clang-tidy / cppcheck failures before declaring complete. Common patterns (e
 ./.claude/skills/pre-commit-checklist/run-fuzz.sh
 ```
 
-Runs all three targets (`fuzz_parser` / `fuzz_json` / `fuzz_utf8`) for 60 s each with `-rss_limit_mb=512` and `-artifact_prefix=tests/fuzz/regressions/<name>/`. For a single target, invoke `./docker/run.sh fuzz <target> ...` directly. All three targets must exit 0 after 60 s. On crash, follow `/triage-side-finding`. **Hard-to-reproduce crashes** (no repro in 3 local attempts / no saved corpus / CI-only) ⇒ Q1 = Yes ⇒ **fix in the same PR** (don't lose the reproduction window — same principle as the TSan race rule above). If the current PR's code directly caused it, also fix in the same PR (Q4(a)). Only file a separate issue (Q4(b)) when the bug is locally reproducible, pre-existing, and would substantially expand scope. Save the crash input to both `tests/fuzz/regressions/<name>/` and `tests/fuzz/corpus/<name>/` regardless of reproducibility.
+Runs all four targets (`fuzz_parser` / `fuzz_json` / `fuzz_utf8` / `fuzz_io_open`) for 60 s each with `-rss_limit_mb=2048` and `-artifact_prefix=tests/fuzz/regressions/<name>/`. The 2048 MB cap (raised from 512 MB) accommodates libFuzzer's coverage-tracking overhead (~275k inline 8-bit counters + PC table), which empirically peaks at 400–600 MB across all four harnesses (measured: `fuzz_parser` 514 MB, `fuzz_json` 597 MB, `fuzz_utf8` 429 MB, `fuzz_io_open` 536 MB). The previous 512 MB cap triggered a startup OOM in `fuzz_parser` and was borderline for `fuzz_json` / `fuzz_io_open` — this is a structural corpus + coverage overhead, not a parser-specific bug (#1976). For a single target, invoke `./docker/run.sh fuzz <target> ...` directly. All four targets must exit 0 after 60 s. On crash, follow `/triage-side-finding`. **Hard-to-reproduce crashes** (no repro in 3 local attempts / no saved corpus / CI-only) ⇒ Q1 = Yes ⇒ **fix in the same PR** (don't lose the reproduction window — same principle as the TSan race rule above). If the current PR's code directly caused it, also fix in the same PR (Q4(a)). Only file a separate issue (Q4(b)) when the bug is locally reproducible, pre-existing, and would substantially expand scope. Save the crash input to both `tests/fuzz/regressions/<name>/` and `tests/fuzz/corpus/<name>/` regardless of reproducibility.
 
 ## 3.6.5. tree-sitter Grammar Regression Check
 

--- a/.claude/skills/pre-commit-checklist/run-fuzz.sh
+++ b/.claude/skills/pre-commit-checklist/run-fuzz.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# §3.6 libFuzzer (fuzz_parser / fuzz_json / fuzz_utf8 — 60s each, via Docker)
+# §3.6 libFuzzer (fuzz_parser / fuzz_json / fuzz_utf8 / fuzz_io_open — 60s each, via Docker)
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
 
-./docker/run.sh fuzz fuzz_parser -max_total_time=60 -rss_limit_mb=512 \
+./docker/run.sh fuzz fuzz_parser -max_total_time=60 -rss_limit_mb=2048 \
     -artifact_prefix=tests/fuzz/regressions/parser/ tests/fuzz/corpus/parser
 
-./docker/run.sh fuzz fuzz_json -max_total_time=60 -rss_limit_mb=512 \
+./docker/run.sh fuzz fuzz_json -max_total_time=60 -rss_limit_mb=2048 \
     -artifact_prefix=tests/fuzz/regressions/json/ tests/fuzz/corpus/json
 
-./docker/run.sh fuzz fuzz_utf8 -max_total_time=60 -rss_limit_mb=512 \
+./docker/run.sh fuzz fuzz_utf8 -max_total_time=60 -rss_limit_mb=2048 \
     -artifact_prefix=tests/fuzz/regressions/utf8/ tests/fuzz/corpus/utf8
+
+./docker/run.sh fuzz fuzz_io_open -max_total_time=60 -rss_limit_mb=2048 \
+    -artifact_prefix=tests/fuzz/regressions/fuzz_io_open/ tests/fuzz/corpus/fuzz_io_open

--- a/changelog.d/1976-fuzz-io-open-docker-dispatch.md
+++ b/changelog.d/1976-fuzz-io-open-docker-dispatch.md
@@ -1,0 +1,8 @@
+### Fixed
+
+- `fuzz_io_open` libFuzzer harness は `docker/entrypoint.sh` の case dispatch に登録されておらず、`./docker/run.sh fuzz fuzz_io_open ...` が `error: unknown command 'fuzz_io_open'` で exit 1 していた。CMake target (`add_ry_fuzz_target(fuzz_io_open ...)`) と corpus (`tests/fuzz/corpus/fuzz_io_open/`) は既存だったため Docker 経由の実行手段だけが欠落していた状態。entrypoint.sh の case パターンと error message、`docker/run.sh` の usage コメント、`docker/README.md` / `.claude/skills/linux-docker-dev/SKILL.md` の libFuzzer quickstart 例コマンドを 4 harness 対応に揃えた。(#1976)
+
+### Changed
+
+- `/pre-commit-checklist` §3.6 を 4 harness 対応に拡張。skip-detection grep が `src/runtime/native/io.cpp` / `include/ry/runtime/native/io.hpp` を含むようになり、`io.cpp` を変更する PR は §3.6 を自動的に検証対象に含む。`run-fuzz.sh` は 4 target (`fuzz_parser` / `fuzz_json` / `fuzz_utf8` / `fuzz_io_open`) を 60 s ずつ実行する (合計 ~4 分、従来は ~3 分)。Change-type matrix の row label と Fuzzer mapping、`.claude/agents/fuzzer-runner.md` の TARGETS list / REPORT FORMAT 例も併せて更新した。(#1976)
+- `run-fuzz.sh` および §3.6 の wording で libFuzzer の `-rss_limit_mb` を 512 MB から 2048 MB に引き上げ。実測ピーク RSS は `fuzz_parser` 514 MB / `fuzz_json` 597 MB / `fuzz_utf8` 429 MB / `fuzz_io_open` 536 MB と、いずれの harness も libFuzzer の coverage tracking overhead (~275k inline 8-bit counters + PC table) で 400-600 MB に達する。512 MB cap では `fuzz_parser` で startup OOM を引き起こし、`fuzz_json` / `fuzz_io_open` も borderline だった (parser 固有のバグではなく、全 harness 共通の corpus + coverage 構造的 overhead)。2048 MB に引き上げて 4 harness 全てが安定して完走する。(#1976)

--- a/docker/README.md
+++ b/docker/README.md
@@ -21,9 +21,10 @@ See [`.claude/skills/linux-docker-dev/SKILL.md`](../.claude/skills/linux-docker-
 ./docker/run.sh tsan ry_tests
 
 # libFuzzer (mirrors CI fuzz job)
-./docker/run.sh fuzz fuzz_parser -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/parser/ tests/fuzz/corpus/parser
-./docker/run.sh fuzz fuzz_json   -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/json/   tests/fuzz/corpus/json
-./docker/run.sh fuzz fuzz_utf8   -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/utf8/   tests/fuzz/corpus/utf8
+./docker/run.sh fuzz fuzz_parser  -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/parser/       tests/fuzz/corpus/parser
+./docker/run.sh fuzz fuzz_json    -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/json/         tests/fuzz/corpus/json
+./docker/run.sh fuzz fuzz_utf8    -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/utf8/         tests/fuzz/corpus/utf8
+./docker/run.sh fuzz fuzz_io_open -max_total_time=30 -artifact_prefix=tests/fuzz/regressions/fuzz_io_open/ tests/fuzz/corpus/fuzz_io_open
 
 # Static analysis (mirrors CI clang-tidy / lint / scan-build jobs)
 ./docker/run.sh static-analysis clang-tidy

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -167,14 +167,14 @@ case "$CMD" in
   ry)
     exec "./$BUILD_DIR/ry" "$@"
     ;;
-  fuzz_parser|fuzz_json|fuzz_utf8)
+  fuzz_parser|fuzz_json|fuzz_utf8|fuzz_io_open)
     exec "./$BUILD_DIR/$CMD" "$@"
     ;;
   bash)
     exec bash "$@"
     ;;
   *)
-    echo "error: unknown command '$CMD' (supported: ry_tests, ry, bash, fuzz_parser, fuzz_json, fuzz_utf8)" >&2
+    echo "error: unknown command '$CMD' (supported: ry_tests, ry, bash, fuzz_parser, fuzz_json, fuzz_utf8, fuzz_io_open)" >&2
     exit 1
     ;;
 esac

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -3,7 +3,7 @@
 # Usage: docker/run.sh [--rebuild] <preset> [cmd [args...]]
 #        docker/run.sh [--rebuild] static-analysis <tool>
 #   preset: default | asan | tsan | fuzz
-#   cmd:    ry_tests | ry | bash | fuzz_parser | fuzz_json | fuzz_utf8  (omit for build-only)
+#   cmd:    ry_tests | ry | bash | fuzz_parser | fuzz_json | fuzz_utf8 | fuzz_io_open  (omit for build-only)
 #   tool:   clang-tidy | cppcheck | scan-build | all
 #   Examples:
 #     ./docker/run.sh asan ry_tests

--- a/tests/fuzz/README.md
+++ b/tests/fuzz/README.md
@@ -9,6 +9,7 @@ Coverage-guided fuzzing for the ry compiler and runtime using [LLVM libFuzzer](h
 | `fuzz_parser` | `ry::Lexer` + `ry::Parser::parseProgram()` | Lexer + parser pipeline on arbitrary byte sequences |
 | `fuzz_json` | `__ry_json_parse` | JSON parser on arbitrary byte sequences |
 | `fuzz_utf8` | `__ry_utf8_len_n`, `__ry_utf8_char_at_checked`, `__ry_utf8_reverse`, `__ry_utf8_substring` | Bounded UTF-8 walker functions |
+| `fuzz_io_open` | `__ry_io_file_open` | I/O file-open path-string handling on arbitrary byte sequences across `"r"` / `"w"` / `"a"` / invalid modes |
 
 **Regex is not fuzzed** — `RegexParser::parse()` calls `exit(1)` on malformed patterns, which terminates the libFuzzer process. See the follow-up issue for the planned refactor.
 
@@ -52,7 +53,7 @@ UBSAN_OPTIONS=print_stacktrace=1:halt_on_error=1 \
     -artifact_prefix=tests/fuzz/regressions/parser/ \
     tests/fuzz/corpus/parser
 
-# Same pattern for fuzz_json and fuzz_utf8
+# Same pattern for fuzz_json, fuzz_utf8, and fuzz_io_open
 ```
 
 `-rss_limit_mb=512` prevents OOM — compiler-input harnesses can peak high.
@@ -64,14 +65,17 @@ tests/fuzz/
 ├── fuzz_parser.cpp          # Harness: lexer + parser
 ├── fuzz_json.cpp            # Harness: JSON parser
 ├── fuzz_utf8.cpp            # Harness: bounded UTF-8 walkers
+├── fuzz_io_open.cpp         # Harness: __ry_io_file_open path-string handling
 ├── corpus/
 │   ├── parser/              # Seed inputs for fuzz_parser (*.ry snippets)
 │   ├── json/                # Seed inputs for fuzz_json
-│   └── utf8/                # Seed inputs for fuzz_utf8 (text + binary)
+│   ├── utf8/                # Seed inputs for fuzz_utf8 (text + binary)
+│   └── fuzz_io_open/        # Seed inputs for fuzz_io_open (arbitrary path bytes)
 └── regressions/
     ├── parser/              # Saved crash inputs for fuzz_parser
     ├── json/                # Saved crash inputs for fuzz_json
-    └── utf8/                # Saved crash inputs for fuzz_utf8
+    ├── utf8/                # Saved crash inputs for fuzz_utf8
+    └── fuzz_io_open/        # Saved crash inputs for fuzz_io_open
 ```
 
 **Corpus policy**: hand-curated seeds that cover representative input shapes. libFuzzer augments the corpus with discovered interesting cases at runtime (in-memory only; the on-disk corpus is the starting point). When a regression is fixed, add the crashing input to both `regressions/<name>/` (for reference) and `corpus/<name>/` (so the fuzzer starts from it).


### PR DESCRIPTION
## Summary

- Register `fuzz_io_open` libFuzzer harness in `docker/entrypoint.sh` dispatch (the CMake target and corpus already existed; only the Docker run path was missing).
- Extend `/pre-commit-checklist` §3.6 to cover 4 harnesses: skip-if grep includes `runtime/native/io.{cpp,hpp}`, Fuzzer mapping adds `io → fuzz_io_open`, matrix row label / wording updated.
- Raise libFuzzer's `-rss_limit_mb` from 512 MB to 2048 MB based on measured peak RSS across all 4 harnesses (parser 514 / json 597 / utf8 429 / io_open 536 MB) — a structural corpus + coverage-tracking overhead, not a parser bug.
- Align auxiliary docs (`docker/README.md`, `tests/fuzz/README.md`, `.claude/skills/linux-docker-dev/SKILL.md`, `.claude/agents/fuzzer-runner.md`) to the 4-harness baseline.

## Test plan

- [x] `./docker/run.sh fuzz fuzz_io_open -max_total_time=30 ...` exits 0 (838,975 runs / 31s / no crash)
- [x] `./.claude/skills/pre-commit-checklist/run-fuzz.sh` — all 4 targets exit 0 (~4 min total, peak RSS 429-597 MB)
- [x] §3.6 skip-if grep matches `src/runtime/native/io.cpp` / `include/ry/runtime/native/io.hpp` (positive) and not `src/runtime/native/http.cpp` (negative)
- [x] Grep self-check confirms no leftover 3-harness listings outside intended carve-outs (`parser-conventions.md`, `libfuzzer-harness/SKILL.md`, `ci.yml`)

## Notes for reviewers

- The fuzz_parser run uses ~67s (16,842 seeds processed before mutation iterations begin), so 60s gives effectively a seed-replay rather than meaningful new fuzzing. Corpus minimization (`-merge=1`) is out of scope here but worth a follow-up.
- libFuzzer added 4 new corpus entries during `fuzz_io_open` verification; they are not committed (mutation-derived, non-reproducible) and remain untracked under `tests/fuzz/corpus/fuzz_io_open/`.

Closes #1976