### PR TITLE
docs(agents): forbid presenting 別 issue 起票 as a user choice (#1981)

### DIFF
--- a/.claude/agents/bug-forensics-analyst.md
+++ b/.claude/agents/bug-forensics-analyst.md
@@ -6,7 +6,7 @@ model: sonnet
 color: green
 ---
 
-You are an elite bug forensics analyst with deep expertise in software archaeology, regression analysis, and test strategy design. Your role is investigative and analytical: you produce evidence-based reports with fix-direction recommendations that enable informed decisions about bug remediation and test coverage improvements, but you do NOT write or apply code changes. Fix timing (即時修正 / 別 issue 起票 / ユーザー確認) は呼び出し元 (典型的には `/triage-side-finding` Q4) の責務。
+You are an elite bug forensics analyst with deep expertise in software archaeology, regression analysis, and test strategy design. Your role is investigative and analytical: you produce evidence-based reports with fix-direction recommendations that enable informed decisions about bug remediation and test coverage improvements, but you do NOT write or apply code changes. Fix timing (Claude Code 自律判断 2 分岐: 即時修正 / 起票許可を求める — AGENTS.md §"起票判断における選択肢提示の禁止" 参照) は呼び出し元 (典型的には `/triage-side-finding` Q4) の責務。
 
 ## Core Responsibilities
 
@@ -27,7 +27,7 @@ You perform exactly four analytical tasks for each bug investigation:
 **Out of scope (do NOT do these)**:
 - Writing or applying code changes (修正コードを書くこと自体は scope 外)
 - Writing actual test code (you propose test cases conceptually; implementation is a separate task)
-- Deciding fix timing (即時修正 / 別 issue 起票 / ユーザー確認) — this judgment belongs to the caller (typically `/triage-side-finding` Q4). Provide fix-direction recommendations as input; the calling skill decides when and where to apply them.
+- Deciding fix timing (Claude Code 自律判断 2 分岐: 即時修正 / 起票許可を求める) — this judgment belongs to the caller (typically `/triage-side-finding` Q4). Provide fix-direction recommendations as input; the calling skill decides when and where to apply them. **Do not** enumerate 3 or more options for the caller's user (AGENTS.md §"起票判断における選択肢提示の禁止" の MUST ルール); your report feeds the caller's autonomous judgment, not a multi-choice user prompt.
 
 ## Investigation Methodology
 
@@ -158,7 +158,7 @@ Omit sections that don't apply (e.g., section 3 for regressions; section 6 when 
 
 - **Concurrency**: When running multiple independent git commands (e.g., `git log` on different files, `git blame` on different ranges), invoke them in parallel via concurrent tool calls.
 - **Evidence over speculation**: Every claim must cite a SHA, file:line, or diff hunk. Phrases like "probably" or "might be" are red flags—either find evidence or explicitly mark the claim as a hypothesis requiring further investigation.
-- **Boundary enforcement**: 本エージェントは修正コードを書かない (code changes は scope 外)。ただし修正方針の Recommendation はレポートに含めてよい (上記 "In scope" 参照)。本レポートは呼び出し元 (典型的には `/triage-side-finding` Q3) が消費し、Q4 で修正タイミング (即時修正 / 別 issue 起票 / ユーザー確認) を決定する。Fix timing の判断は呼び出し元の責務であり、本エージェントは「別タスクを起こせ」と一律 redirect しない。ユーザーが直接コード修正を求めた場合は、「本エージェントは分析と方針提示まで担当する。実装は呼び出し元 (Claude Code 本体や `/triage-side-finding` Q4(a)) で行ってください」と案内する。
+- **Boundary enforcement**: 本エージェントは修正コードを書かない (code changes は scope 外)。ただし修正方針の Recommendation はレポートに含めてよい (上記 "In scope" 参照)。本レポートは呼び出し元 (典型的には `/triage-side-finding` Q3) が消費し、Q4 で修正タイミング (Claude Code 自律判断 2 分岐: 即時修正 / 起票許可を求める) を決定する。Fix timing の判断は呼び出し元の責務であり、本エージェントは「別タスクを起こせ」と一律 redirect しない。ユーザーが直接コード修正を求めた場合は、「本エージェントは分析と方針提示まで担当する。実装は呼び出し元 (Claude Code 本体や `/triage-side-finding` Q4(a)) で行ってください」と案内する。
 - **Scope discipline**: If during investigation you discover unrelated bugs, note them briefly at the end under "### 付録: 調査中に発見した別件" but do not deep-dive into them.
 - **Shell command safety**: Never run destructive git commands (`git reset --hard`, `git push --force`, `git rebase`, branch deletion). Read-only operations only (`log`, `diff`, `blame`, `show`, `grep`, `bisect log`).
 - **Ambiguity handling**: If you cannot determine origin with high confidence (e.g., the buggy logic was refactored multiple times across both pre-existing and current commits), present both hypotheses with their respective evidence and explicitly state which additional information would resolve the ambiguity.

--- a/.claude/skills/plan-rubric/SKILL.md
+++ b/.claude/skills/plan-rubric/SKILL.md
@@ -178,7 +178,7 @@ Agent tool example:
 - **`/test-checklist`** — inductive complement to `/test-design-techniques`; run during implementation
 - **`/tdd-cycle`** — TDD tasks stay as one bundled task in plans (Red-Green-Refactor not split)
 - **`.claude/agents/devils-advocate.md`** — plan-critique mode (Phase 1-4)
-- **`/triage-side-finding`** — Q1-Q4 verdict (Q1 hard-to-reproduce CI / Q2 explicit user / Q3 `bug-forensics-analyst` / Q4 three-way) and Issue Creation Steps for Axis 2 side findings
+- **`/triage-side-finding`** — Q1-Q4 verdict (Q1 hard-to-reproduce CI / Q2 explicit user / Q3 `bug-forensics-analyst` / Q4 two-branch (autonomous)) and Issue Creation Steps for Axis 2 side findings
 - **`/pre-commit-checklist`** — post-implementation completion check (not a plan-stage target)
 
 ---

--- a/.claude/skills/scope-decomposition/SKILL.md
+++ b/.claude/skills/scope-decomposition/SKILL.md
@@ -38,7 +38,7 @@ Net effect: REQ-1 at #1797 filing would have turned #1802 from an "in-Plan disco
 
 | Timing | Trigger | REQs to apply |
 |---|---|---|
-| **Issue creation** | After `/triage-side-finding` Q4(b) judges "file a separate issue", before running `gh issue create`; or when deciding to split an existing issue | REQ-1, REQ-2, REQ-3 |
+| **Issue creation** | After `/triage-side-finding` Q4(b) autonomously judges 起票許可を求める (new issue creation needed), before running `gh issue create`; or when deciding to split an existing issue | REQ-1, REQ-2, REQ-3 |
 | **Plan mode** | After `EnterPlanMode`, when re-scanning the target issue's scope | REQ-4 |
 
 ---

--- a/.claude/skills/triage-side-finding/SKILL.md
+++ b/.claude/skills/triage-side-finding/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: triage-side-finding
-description: Triage hub for side findings — short-circuits via Q1 (hard-to-reproduce CI detection) / Q2 (explicit user direction) / Q3 (bug-forensics-analyst) / Q4 (three-way 即時修正 / 別 issue 起票 / ユーザー確認). Use during implementation, self-verification, or PR review when an out-of-scope finding surfaces. Origin diagnosis (regression vs pre-existing) is delegated to `bug-forensics-analyst` and reached only via Q3. Also fires on Japanese triggers 副次的な発見, side finding, scope, ついでに直したい, 別 issue 起票, 即時修正, OPEN PR 依存, fold-only, orphan issue 防止, triage, 判定フロー.
+description: Triage hub for side findings — short-circuits via Q1 (hard-to-reproduce CI detection) / Q2 (explicit user direction) / Q3 (bug-forensics-analyst) / Q4 (Claude Code 自律判断 2 分岐 即時修正 / 起票許可を求める). Use during implementation, self-verification, or PR review when an out-of-scope finding surfaces. Origin diagnosis (regression vs pre-existing) is delegated to `bug-forensics-analyst` and reached only via Q3. Also fires on Japanese triggers 副次的な発見, side finding, scope, ついでに直したい, 別 issue 起票, 即時修正, OPEN PR 依存, fold-only, orphan issue 防止, triage, 判定フロー, 起票許可, 自律判断.
 allowed-tools: Bash(gh issue:*), Bash(gh search:*), Bash(gh pr:*), Bash(gh api:*), Agent
 ---
 
 # Triage Side Finding
 
-Neutral triage hub for side findings detected during implementation, self-verification, or PR review. Routes to one of three outcomes — (a) 即時修正 / (b) 別 issue 起票 / (c) ユーザー確認.
+Neutral triage hub for side findings detected during implementation, self-verification, or PR review. Q4 では Claude Code が自律的に 2 分岐 — (a) 即時修正 / (b) 起票許可を求める — のいずれかを判定する (旧 3 択 [即時修正 / 別 issue 起票 / ユーザー確認] は廃止)。
 
-> **Source-of-truth note**: previously in `AGENTS.md` §"責務の分離 > スコープ外の問題を発見した場合の対応ルール"; relocated by #1384. The "OPEN PR dependency" gate (Q4(b) Step 1 + fold-only rule) was added by #1694. The Q1-Q4 short-circuit redesign and `bug-forensics-analyst` integration came in #1752.
+> **Source-of-truth note**: previously in `AGENTS.md` §"責務の分離 > スコープ外の問題を発見した場合の対応ルール"; relocated by #1384. The "OPEN PR dependency" gate (Q4(b) Step 1 + fold-only rule) was added by #1694. The Q1-Q4 short-circuit redesign and `bug-forensics-analyst` integration came in #1752. Q4 の自律判断 2 分岐化 (旧 3 択廃止) は #1981 で導入 — AGENTS.md §"起票判断における選択肢提示の禁止" の MUST ルールに準拠。
 
 ## Design intent
 
 The skill must **not** bias side findings toward "file a separate issue." The previous `scope-out-issue` skill did, producing two failure modes (#1752): (a) hard-to-reproduce CI findings (ASan / TSan / UBSan / libFuzzer crashes) went stale before triage finished; (b) when the user said "fix it now," rule discipline overrode the call.
+
+加えて #1981 で、Q4 の判定を「ユーザーへの選択肢提示」に丸投げする旧 3 択 (即時修正 / 別 issue 起票 / ユーザー確認) も廃止した。起票要否は Claude Code が自律判断すべき責務であり、ユーザー選択肢に「別 issue に起票する」を含めることは AGENTS.md §"起票判断における選択肢提示の禁止" の MUST ルールで禁止されている。「禁止対象 = 旧 `scope-out-issue` 型の常時起票バイアス + 選択肢としてのユーザー提示」「許容 = Claude Code 自律判断後の `/git-create-issue` Step 1 経由 1 択 preview による許可要求 (選択肢ではない)」と区別する。
 
 Q1 / Q2 short-circuit to immediate fix without invoking any agent or advisor, preserving the reproduction window. Q3 / Q4 run only when Q1 / Q2 did not settle the case.
 
@@ -69,15 +71,37 @@ The agent emits (full spec in `.claude/agents/bug-forensics-analyst.md`):
 
 > **Caller responsibility**: keep the agent's input context (PR diff / blame range / failing test output) visible in conversation history; same session ⇒ no explicit transfer needed.
 
-### Q4: Three-way verdict
+### Q4: Claude Code 自律判断 2 分岐
 
-Using Q3's analysis and `/plan-rubric`'s PR-size discipline (1 issue ≒ 1 PR), pick one:
+**MUST (#1981)**: ここで 3 択以上の選択肢 (旧 [即時修正 / 別 issue 起票 / ユーザー確認]) をユーザーに提示してはならない。起票要否は Claude Code が自律判断する。詳細は AGENTS.md §"起票判断における選択肢提示の禁止" を参照。
 
-**(a) 即時修正** — fix diff is related to the current PR's scope and doesn't grow it materially; judged a regression; simple fix with low side-effect risk. → Land in the feature branch / current PR.
+Q3 の analysis (origin verdict / impact surface / coverage gap / fix-direction) を input とし、`/plan-rubric` の PR-size discipline (1 issue ≒ 1 PR) を踏まえ、以下の判断基準で **Claude Code が自律的に 2 分岐のいずれかを選ぶ**:
 
-**(b) 別 issue 起票** — unrelated concern (e.g. parser bug surfaced alongside a codegen improvement); materially expands the current PR's scope; pre-existing and loosely related. → Proceed to "Issue Creation Steps" below.
+**判断基準** — 4 軸で評価する:
+1. **PR スコープ関連性**: 現 PR の scope (issue 本体の目的) と直接関係するか
+2. **拡大度**: 修正を含めると PR の diff サイズ・review コストが材料的に膨張するか
+3. **Origin verdict** (Q3 出力): regression (現 PR が混入) / pre-existing exposed (現 PR が露出させた) / pure pre-existing (現 PR と独立)
+4. **サイドエフェクトリスク**: 修正が現 PR の他の変更に副作用を持つ可能性
 
-**(c) ユーザー確認** — design choice is open (multiple fix approaches); regression vs pre-existing boundary is blurry; mid-sized so both (a) and (b) look reasonable. → Present **What / Where / Context / estimated size / recommended option (with reason)** and wait.
+#### 分岐 (a) 即時修正
+
+**条件 (全て満たす場合)**: PR スコープと関連 + 非拡大 (diff 増加が現 PR と同オーダー以下) + regression または pre-existing exposed + 低リスク (狭い影響範囲、確立されたパターン)。
+
+→ feature branch / 現 PR にコミットして対処。`/plan-rubric` の no-incidental-fix rule は「現 PR と無関係な cleanup」を禁止する規則であり、本分岐は「Q1-Q4 トリアージを経て同 PR で対処すべきと自律判断したもの」のため衝突しない。
+
+#### 分岐 (b) 起票許可を求める
+
+**条件**: (a) の条件を 1 つ以上満たさない場合は、自律的に「起票許可を求める」分岐に倒し、**Issue Creation Steps** に進む。
+
+**曖昧ケースの扱い** (旧 Q4(c) 該当): 設計選択肢が複数ある / regression vs pre-existing の境界が曖昧 / mid-sized で (a)/(b) 両方が成立しうる、といった不確実性は **preview 6 項目の Confidence: Medium/Low と理由付き** で表現する (Step 2 の preview gate でユーザーが判断材料を得られる)。ユーザーに 3 択を提示して判断を委ねてはならない。
+
+**decline 時のフォールバック (Q2 への再ルート)**: ユーザーが Step 2 の preview を decline した場合は、**Q2 (informed-consent gate) への再ルート**として扱う:
+
+1. 「現 PR で吸収可能か」を Claude Code が再評価し、`What / Where / 推定サイズ / 推奨アクション (理由付き)` を **1 つの推奨案として提示** してユーザー指示を仰ぐ (複数選択肢の列挙はしない)
+2. ユーザーが「現 PR で対処」を選べば Q2 = Yes として実装、「対処しない」を選べば「発見を記録、現 PR では未対処」を 1 行報告して終了する
+3. 再度メニュー (3 択以上) を提示してはならない (MUST ルール遵守)
+
+> **用語注意**: ここでの「現 PR で吸収」は Step 1 escalate 節の `fold` (OPEN PR 依存時に PR author に scope 拡張を依頼) とは別概念。混同を避けるため本節では `fold` 流用ではなく「Q2 への再ルート」と表現する。
 
 ## Issue Creation Steps
 
@@ -102,9 +126,9 @@ gh pr view <number> --json files,state,headRefName --jq '{state, branch: .headRe
 
 3. **Fold (propose scope expansion)**: ask the PR author to absorb the new finding via PR comment and obtain agreement — do not unilaterally push commits. If you are the author, add a commit to your own feature branch.
 
-4. **Escalate (when fold isn't viable)**: present **What** / **Where** / **estimated size** to the user when any of: extra work materially changes PR scope (design rethink); added diff is comparable to or larger than the PR's existing diff; PR is review-complete / merge-ready and re-review cost is high.
+4. **Escalate (when fold isn't viable)**: present **What** / **Where** / **estimated size** / **推奨アクション (理由付き、1 つに絞る)** to the user when any of: extra work materially changes PR scope (design rethink); added diff is comparable to or larger than the PR's existing diff; PR is review-complete / merge-ready and re-review cost is high.
 
-The user then chooses: file an independent issue, expand the PR's scope, branch off, etc.
+Claude Code は PR スコープ判定 (Q4 判断基準と同じ 4 軸) に基づき、最も妥当な対処方針を 1 つ推奨してユーザーの許可を待つ。**3 択以上の選択肢列挙はしない** (AGENTS.md §"起票判断における選択肢提示の禁止" の MUST ルール)。Claude Code 内部での候補としては典型的に「独立 issue 起票」が選ばれるが、状況により「現 PR scope 拡張」「別ブランチで対応」等もあり得る — ただしこれらは内部判断のための列挙であり、ユーザー提示時は 1 つに絞る。ユーザーが推奨を decline した場合のみ、別の選択肢を再評価して 1 つだけ提示し直す。
 
 **Motivating example (#1692)**: #1692 was filed as a v2 extension of unmerged PR #1693 (`verifyCalledWith`), depending on `__ry_mock_store_arg` / kind tag enum / `mockArgEqual` / `__ry_mock_count_matching_calls` from there — an orphan until #1693 merged. With this gate, the same case routes to fold (extend #1693's scope) or escalate.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,7 @@ issue 確認 → ナレッジベース参照 (path-scoped rule は実装中も a
   - 仕様通りに実装できていることのセルフ検証タスク
   - 英語ドキュメント（README.md / docs）の更新（または変更不要の確認）
   - 用語変更・識別子 rename を含む場合: `/horizontal-sweep` を計画タスクに含める（4 ステップ手順は `.claude/skills/horizontal-sweep/SKILL.md`）
-- **副次的発見への対応**: 「責務の分離」セクション「副次的発見への対応」に従う (`/triage-side-finding`)。`/triage-side-finding` Q4(b) で「別 issue 起票」と判定された場合のみ、実装計画内に「別 issue 起票」タスクを含める (Q1 再現困難 / Q2 ユーザー指示 → 即時修正と判定された場合は同 PR 内で対処するため計画タスク化不要)。**ただし起票の実行はユーザーの明示許可後** — Plan 内に「別 issue 起票」タスクを含める場合も、Claude Code は起票内容を提示するに留め、ユーザー許可を待つ (「責務の分離」§ユーザーが明示的に指示すること 参照)
+- **副次的発見への対応**: 「責務の分離」セクション「副次的発見への対応」に従う (`/triage-side-finding`)。**Claude Code が `/triage-side-finding` Q4(b)「起票許可を求める」と自律判断した場合のみ**、実装計画内に「別 issue 起票」タスクを含める (Q1 再現困難 / Q2 ユーザー指示 → 即時修正と判定された場合は同 PR 内で対処するため計画タスク化不要)。**ただし起票の実行はユーザーの明示許可後** — Plan 内に「別 issue 起票」タスクを含める場合も、Claude Code は起票内容を提示するに留め、ユーザー許可を待つ (「責務の分離」§ユーザーが明示的に指示すること / §起票判断における選択肢提示の禁止 参照)
 - **TDD サイクルの分割禁止**: Red / Green / Refactor は Plan 上で個別タスクに分割せず、1 つの「TDD サイクル」タスクとしてまとめる（各ケース毎にサイクルを内部で回す）
 
 ## 内部挙動の解析に trace を使う
@@ -156,7 +156,7 @@ single message に multiple `Agent` tool calls を入れて **subagent を foreg
 
 #### 副次的発見への対応
 
-副次的な発見 (side finding) を検出したときの early short-circuit フロー (Q1 再現困難 CI 問題 → Q2 ユーザー明示指示 → Q3 `bug-forensics-analyst` → Q4 3 択判定 [即時修正 / 別 issue 起票 / ユーザー確認]) と Issue Creation Steps は `.claude/skills/triage-side-finding/SKILL.md`（または `/triage-side-finding`）参照。
+副次的な発見 (side finding) を検出したときの early short-circuit フロー (Q1 再現困難 CI 問題 → Q2 ユーザー明示指示 → Q3 `bug-forensics-analyst` → Q4 Claude Code 自律判断 2 分岐 [即時修正 / 起票許可を求める]) と Issue Creation Steps は `.claude/skills/triage-side-finding/SKILL.md`（または `/triage-side-finding`）参照。Q4 の自律判断要件は §"起票判断における選択肢提示の禁止" 参照。
 
 #### 副次的発見の判断優先順位
 
@@ -168,12 +168,20 @@ single message に multiple `Agent` tool calls を入れて **subagent を foreg
 
 > **用語注記**: `bug-forensics-analyst` は `.claude/agents/` 配下の subagent (§"ナレッジベース" の catalog 参照、backtick で表記)。advisor は Claude Code 組み込みの advisor tool あるいは外部レビュワーを指す汎用ロールで、`.claude/agents/` に独立ファイルを持たないため backtick なしで表記する。
 
+#### 起票判断における選択肢提示の禁止
+
+- **MUST (例外なし)**: Claude Code がユーザーに提示する選択肢に「別 issue に起票する」を含めてはならない。これは `AskUserQuestion` ツールの options、テキストの選択肢列挙 (「(a)... (b)... (c)...」「以下のいずれか: ...」等)、口頭での 3 択提示など、形態を問わない。起票要否は Claude Code が自律判断する責務であり、ユーザーへの選択肢提示で代替してはならない
+- 起票が必要と Claude Code が自律判断した場合は `/git-create-issue` Step 1 (preview 6 項目 [起票理由 / 概要 / 粒度 / 解決確度 / ラベル案 / マイルストーン候補] → 明示許可待ち) に従う。preview は「起票内容の提示」であって「選択肢の提示」ではない (ユーザーは 1 つの起票案に対して許可/decline のみ判断する)
+- **適用範囲**: 「ユーザーが自発的に『別 issue にすべきか』と問いかけた場合」は Q2 (informed-consent gate) 経由のユーザー指示として扱い、`/triage-side-finding` Q2 のフロー (What / Where / 推定サイズ / Dependency risk を提示してから指示を仰ぐ) に従う。本ルールは「Claude Code 起点で 3 択以上を提示する行為」を禁止するもので、ユーザー起点の問いかけには影響しない
+- **Why**: #1851 の自律誘導失敗 (Claude Code が「別 issue 起票」を選択肢として提示しユーザーを誘導した事故) の再発防止 / `/git-create-issue` permission gate との二重化排除 / ユーザーが判断材料なしで即決を求められる問題の排除
+- 関連: `/triage-side-finding` Q4 (自律判断 2 分岐)、`/triage-side-finding` Issue Creation Steps Step 1 escalate 節 (1 択推奨)、`/git-create-issue` Step 1 (preview gate)
+
 ### ユーザーが明示的に指示すること
 
 - 外部レビュー（GitHub PR レビュー等）
 - git add / commit / push
 - PR 作成
-- **新規 issue の起票 (`gh issue create`)** — Claude Code は起票内容 (理由 / 概要 / 粒度 / 解決確度 / ラベル案 / マイルストーン候補) を提示するに留め、ユーザーの明示許可 (「起票して」 / 「OK」等) を待つ。CI 失敗・サニタイザー検出・fuzz crash 等の repo 全体に影響する事故も口頭 (テキスト) 報告のみで、自律起票しない。詳細手順は `/git-create-issue` 参照
+- **新規 issue の起票 (`gh issue create`)** — Claude Code は起票内容 (理由 / 概要 / 粒度 / 解決確度 / ラベル案 / マイルストーン候補) を提示するに留め、ユーザーの明示許可 (「起票して」 / 「OK」等) を待つ。CI 失敗・サニタイザー検出・fuzz crash 等の repo 全体に影響する事故も口頭 (テキスト) 報告のみで、自律起票しない。詳細手順は `/git-create-issue` 参照。**起票の要否判断時に「別 issue にする」を選択肢としてユーザーに提示してはならない** → §"起票判断における選択肢提示の禁止" も参照
   - **例外**: `preparing-for-release` skill 経由 (Release prep / Release / Cleanup issue) は `/preparing-for-release <X.Y.Z>` のユーザー起動が起票許可を兼ねるため、この許可制の対象外
 
 ### PR レビュー対応

--- a/changelog.d/1981-forbid-issue-creation-as-option.md
+++ b/changelog.d/1981-forbid-issue-creation-as-option.md
@@ -1,0 +1,3 @@
+### Changed
+
+- AGENTS.md に「起票判断における選択肢提示の禁止」サブセクションを追加し、Claude Code がユーザーに提示する選択肢 (`AskUserQuestion` の options、テキストの選択肢列挙等) に「別 issue に起票する」を含めることを MUST 禁止した (#1981)。これに合わせて `/triage-side-finding` の Q4 を「3 択 (即時修正 / 別 issue 起票 / ユーザー確認)」から **Claude Code 自律判断 2 分岐 (即時修正 / 起票許可を求める)** に書き換え、Issue Creation Steps Step 1 の escalate 節も 3 択列挙 (「file an independent issue, expand the PR's scope, branch off, etc.」) を「1 つの推奨案を提示」に置換した。`/git-create-issue` Step 1 (preview 6 項目 → 明示許可待ち) は変更なし — 本ルールと既に整合している。意図: #1851 の自律誘導失敗の再発防止 / `/git-create-issue` permission gate との二重化排除 / ユーザーが判断材料なしで即決を求められる問題の排除。(#1981)


### PR DESCRIPTION
## Summary

- AGENTS.md に MUST ルール「Claude Code の選択肢提示 (`AskUserQuestion` options / テキストの 3 択列挙 / 口頭の 3 択提示) に『別 issue に起票する』を含めることの禁止」を追加 (#1851 自律誘導失敗の再発防止)。
- `/triage-side-finding` Q4 を旧 3 択 (即時修正 / 別 issue 起票 / ユーザー確認) から **Claude Code 自律判断 2 分岐** (即時修正 / 起票許可を求める) に書き換え。曖昧ケースは preview 6 項目の Confidence 表現で吸収。decline 時は Q2 への再ルートで 1 択提示に倒す。
- 連鎖修正: `bug-forensics-analyst` / `scope-decomposition` の旧 3 択言及、`/plan-rubric` cross-reference (Q4 three-way → two-branch) を整合。`/git-create-issue` Step 1 は本ルールと既に整合のため変更なし。

## Test plan

- [x] `/pre-commit-checklist` セルフ検証実施 (§0 matrix: `.claude/` + `AGENTS.md` + `changelog.d/` のみ → §3/§3.5/§3.6/§3.6.5 該当変更なしで skip)
- [x] 横断 grep で旧 3 択構造の意図せざる残存なし確認 (歴史記述のみ保持)
- [x] 英語ドキュメント (`docs/` / `README.md`) への影響なし確認
- [x] §3.7 background hygiene: 本セッション内で background 起動なし
- [x] 5 シナリオシミュレーション (旧 Q4(a)/(b)/(c) + OPEN PR 依存 fold/escalate) でいずれも 3 択提示が消えていることを確認

Closes #1981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Streamlined issue triage workflow decision paths for improved clarity
  * Updated issue creation procedures to require explicit user permission
  * Simplified autonomous decision-making process by removing multiple-choice options
  * Enhanced guidance on handling issue escalation requests

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/1983?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->