### PR TITLE
fix(test): poll-wrap accept() in HTTP mock tests to prevent hang

### DIFF
--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -5,6 +5,7 @@
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
+#include <poll.h>
 #include <unistd.h>
 
 
@@ -120,6 +121,20 @@ static int get_server_port(int srv) {
     socklen_t len = sizeof(addr);
     ::getsockname(srv, reinterpret_cast<struct sockaddr *>(&addr), &len);
     return ntohs(addr.sin_port);
+}
+
+// Wait up to timeout_sec for a connection on `srv`, then accept.
+// Returns -1 on timeout/error so the caller's ADD_FAILURE path runs and
+// the server thread exits, allowing JoinGuard to join without hanging.
+static int accept_with_timeout(int srv, int timeout_sec) {
+    struct pollfd pfd{};
+    pfd.fd = srv;
+    pfd.events = POLLIN;
+    int ready = ::poll(&pfd, 1, timeout_sec * 1000);
+    if (ready <= 0) return -1;
+    struct sockaddr_in client_addr{};
+    socklen_t client_len = sizeof(client_addr);
+    return ::accept(srv, reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);
 }
 
 struct JoinGuard {
@@ -380,9 +395,7 @@ TEST_F(CodeGenHttpClientTest, HttpGetCaseBindingPreservesHttpClientResponseMetad
     int port = get_server_port(srv);
 
     std::thread server_thread([&]() {
-        struct sockaddr_in client_addr{};
-        socklen_t client_len = sizeof(client_addr);
-        int conn = ::accept(srv, reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);
+        int conn = accept_with_timeout(srv, 10);
         if (conn < 0) {
             ADD_FAILURE() << "accept failed";
             return;
@@ -412,9 +425,7 @@ TEST_F(CodeGenHttpClientTest, HttpRequestCaseBindingPreservesHttpClientResponseM
 
     std::string captured_request;
     std::thread server_thread([&]() {
-        struct sockaddr_in client_addr{};
-        socklen_t client_len = sizeof(client_addr);
-        int conn = ::accept(srv, reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);
+        int conn = accept_with_timeout(srv, 10);
         if (conn < 0) {
             ADD_FAILURE() << "accept failed";
             return;

--- a/tests/test_codegen_http.cpp
+++ b/tests/test_codegen_http.cpp
@@ -1,4 +1,5 @@
 #include "test_codegen_common.hpp"
+#include <cerrno>
 #include <cstdlib>
 #include <string>
 #include <thread>
@@ -130,8 +131,12 @@ static int accept_with_timeout(int srv, int timeout_sec) {
     struct pollfd pfd{};
     pfd.fd = srv;
     pfd.events = POLLIN;
-    int ready = ::poll(&pfd, 1, timeout_sec * 1000);
+    int ready;
+    do {
+        ready = ::poll(&pfd, 1, timeout_sec * 1000);
+    } while (ready < 0 && errno == EINTR);
     if (ready <= 0) return -1;
+    if (pfd.revents & (POLLERR | POLLNVAL | POLLHUP)) return -1;
     struct sockaddr_in client_addr{};
     socklen_t client_len = sizeof(client_addr);
     return ::accept(srv, reinterpret_cast<struct sockaddr *>(&client_addr), &client_len);


### PR DESCRIPTION
## Summary

- Add `accept_with_timeout(srv, timeout_sec)` static helper using `poll(POLLIN)` (10s) to wrap the server-thread `::accept()` in `HttpGetCaseBindingPreservesHttpClientResponseMetadata` and `HttpRequestCaseBindingPreservesHttpClientResponseMetadata`.
- Before: if `runSource()` exited (Err path or exception) before the Ry client connected, `JoinGuard::~JoinGuard()` tried to join an `accept()`-blocked thread with no timeout and hung forever on macOS.
- After: server thread exits within 10s regardless, `JoinGuard` joins cleanly.

Closes #1975

## Test plan

- [x] `./build/ry_tests --gtest_filter='CodeGenHttpClientTest.Http*CaseBinding*'` PASS 5x consecutive (HttpRequest: 6-7 ms)
- [x] Full `./build/ry_tests` PASS (2523 tests)
- [x] ASan + UBSan (Docker): PASS (no findings)
- [x] TSan (Docker): PASS (no races, 2521 passed + 2 skipped for known siglongjmp issue)
- [x] clang-tidy / cppcheck / scan-build: clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a timeout-based server connection helper for test harnesses to wait for incoming TCP connections without blocking.
  * Updated HTTP client metadata tests to use the timeout helper, preventing test hangs when clients fail to connect within the expected timeframe.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->