### PR TITLE
fix(tree-sitter): outrank `(identifier) @variable` for decorator name

### DIFF
--- a/changelog.d/1988-tree-sitter-decorator-priority.md
+++ b/changelog.d/1988-tree-sitter-decorator-priority.md
@@ -1,0 +1,12 @@
+### Fixed
+
+- Tree-sitter highlight query (`editor/tree-sitter/queries/highlights.scm`)
+  now applies `(#set! "priority" 105)` to the `decorator` pattern so that
+  the decorator's identifier (e.g. `my_dec` in `@my_dec`) is highlighted
+  as `@attribute` instead of being overridden by the generic
+  `(identifier) @variable` fallback. Both patterns previously matched at
+  default priority 100, and tree-sitter's last-match-wins tie-breaker
+  promoted `@variable` — which was semantically wrong (a decorator name
+  is not a variable) and produced no color in colorschemes that leave
+  `@variable` unstyled. The fix is `highlights.scm`-only; `ry.so` does
+  not need to be rebuilt. (#1988)

--- a/editor/tree-sitter/queries/highlights.scm
+++ b/editor/tree-sitter/queries/highlights.scm
@@ -119,7 +119,8 @@
 ; ---------- Decorators / attributes ----------
 (decorator
   "@" @attribute
-  (identifier) @attribute)
+  (identifier) @attribute
+  (#set! "priority" 105))  ; outrank the generic `(identifier) @variable` fallback (default priority 100)
 
 ; ---------- Records / Enums ----------
 (record_declaration


### PR DESCRIPTION
## Summary

- `editor/tree-sitter/queries/highlights.scm` の `decorator` パターンに `(#set! "priority" 105)` を追加し、`@my_dec` の識別子部分が generic `(identifier) @variable` fallback (default priority 100) に上書きされず `@attribute` で解決されるよう修正。
- 同 priority 衝突時に tree-sitter は last-match-wins で後勝ち → `@variable` が勝ってしまい、`karasuma` 等の colorscheme では decorator 名が無色になる事象を解消。
- `highlights.scm` のみの変更で `ry.so` の再ビルドは不要。

## Pre-commit checklist skip log

- `Skipped §1 — SCM コメントで自己説明、README 慣習化は別 issue (横断 sweep) で対応`
- `Skipped §3 — tree-sitter queries (.scm) only; no C++/Ry test impact`
- `Skipped §3.5 — same as §3 (queries only, no source code)`
- `Skipped §3.5.5 — same as §3 (no C++ source change)`
- `Skipped §3.6 — no parser/lexer/json/utf8/string/io change`
- `Skipped §3.6.5 — queries only; grammar.js / scanner / EBNF unchanged`

## Test plan

- [x] `editor/tree-sitter/install.sh --no-build` 相当で Neovim queries 反映
- [x] `.ry` を Neovim で開き `:Inspect` で `@attribute.ry (priority 105)` が `@variable.ry (priority 100)` より上位で解決されることを確認
- [x] `karasuma` colorscheme で `@my_dec` 全体が `@attribute` 色で表示されることを確認

Closes #1988

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Decorator identifiers in the editor now display with proper attribute styling instead of generic variable highlighting.
  * Applies immediately in the editor UI; no rebuild or reinstall required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->