### PR TITLE
docs: ban flake/flaky terminology in any language

### DIFF
--- a/.claude/agents/fuzzer-runner.md
+++ b/.claude/agents/fuzzer-runner.md
@@ -53,7 +53,7 @@ If PASS, omit CRASHES.
 
 - If the fuzzer build (`cmake --preset fuzz`) fails: report `RESULT: BUILD_FAIL` with the last 30 lines of build output and stop. Do not retry.
 - If a target hangs past the wall-clock timeout without producing libFuzzer output (no `#NUMBER` progress lines): report `RESULT: HANG` with the last 30 lines and stop.
-- If the crash input cannot be reproduced in the diagnosis re-run (flaky / OS-noise crash): report `RESULT: CRASH` with `REPRO: FAILED` in NOTES and the original libFuzzer output — the main agent decides whether to investigate further or accept as a flake.
+- If the crash input cannot be reproduced in the diagnosis re-run (reproduction conditions not yet identified; possible factors include OS-noise or timing-dependent triggers): report `RESULT: CRASH` with `REPRO: FAILED` in NOTES and the original libFuzzer output — the main agent decides whether to investigate further or to defer with the trigger conditions documented as unidentified.
 
 ## Scope guardrails
 

--- a/.claude/skills/triage-side-finding/SKILL.md
+++ b/.claude/skills/triage-side-finding/SKILL.md
@@ -24,7 +24,7 @@ Evaluate in order. **Once a stage settles, do not run later stages** (no `bug-fo
 
 ### Q1: Reproducing now, but hard to reproduce later?
 
-Covers CI-only sanitizer hits (ASan / TSan / UBSan), libFuzzer crashes, concurrency races, and probabilistic memory corruption — observable right now but flaky on local reproduction.
+Covers CI-only sanitizer hits (ASan / TSan / UBSan), libFuzzer crashes, concurrency races, and probabilistic memory corruption — observable right now but with non-deterministic local reproducibility because the timing / environment trigger conditions are not yet identified.
 
 **Falsifiable criteria** (any one ⇒ Q1 = Yes):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,31 @@ single message に multiple `Agent` tool calls を入れて **subagent を foreg
 - **`/tmp` の限定的例外**: GitHub CLI や外部ツールの仕様上、コマンドライン引数 / ヒアドキュメントだけでは渡せず、どうしてもファイルパスを渡す必要がある場合に限り `/tmp/` 配下のファイルを使ってよい。**ただし作成したファイルは削除しない・削除を試みない**こと (`rm /tmp/...` / `unlink` / cleanup trap を書かない)。OS の tmp cleanup に委ねる
 - 「最終的に削除するファイル」を意図的に作成して回避策にすることは禁止 (プロジェクト内は完全禁止、`/tmp` でも削除コマンドを書かない)。検証手段としては `/ry-playground` (heredoc) / 既存テストファイル本体への追記 / `/tmp` (削除なし) のいずれかを選ぶ
 
+## 禁止用語: flake / flaky
+
+CI #2578 で Claude Code が `tests/spec/collection_meta_propagation.test.ry` のクラッシュを「flake なので re-run」と結論した事故が契機 (#1990)。本来 1% 未満の非決定的事象を指す用語が、50% 以上の確率で発生する現象にも繰り返し適用されてきた。決定論的な Von Neumann 型計算機上で真の意味で flaky な事象は存在せず、条件が満たされれば必ず起きる現象を「flaky」と呼ぶことは **root cause analysis の放棄** と同義。何度も指摘されたが改善されないため、全面禁止以外の選択肢がなくなった。
+
+### 禁止ルール (例外なし)
+
+- **MUST**: Claude Code はあらゆる説明・出力 (応答 / commit message / PR description / 新規 KNOWLEDGE 追記 / コードコメント / `.claude/skills/*.md` / `.claude/agents/*.md` / `.claude/rules/*.md` 等) で `flake` / `flaky` の語を **あらゆる言語で** 使用してはならない
+  - 日本語訳・カタカナ表記 (フレーク / フレーキー / フレーク的 / フレーキーなテスト 等) を含む
+  - 他言語の同義語 (`unstable` / `intermittent` 等) を **`flake` / `flaky` の言い換えとして使う行為** も禁止 (下記「代替表現の要求」に従わない使い方は不可)
+- **MUST**: Claude Code は `flake` / `flaky` を **CI 失敗・テスト失敗の理由・結論** として用いてはならない (口頭・テキスト・自律トリアージ判断のいずれにおいても)
+
+### 代替表現の要求
+
+CI 失敗・テスト失敗を説明する際、Claude Code は以下のいずれかを必須とする:
+
+- **(a) 発生条件の明示**: 例「LLVM ORC JIT teardown で heap consolidation が走るタイミングと glibc tcache の状態が衝突した場合に発生」のように、現象が発生する条件を具体的に特定して書く
+- **(b) `KNOWLEDGE.md` の既存 entry への明示リンク**: issue 番号 + 行番号 (例: `KNOWLEDGE.md` L261, #1895) を必ず付ける。entry 名のみのふんわり参照は不可
+- **(c) root cause 未特定の場合**: 「**発生条件未特定。再現条件の調査が未完了**」と明記する。この場合、**安易な再実行 (re-run) 提案を禁止** する。代わりに、調査タスクとして起票するか、ユーザーに調査着手の許可を求めること
+
+### 既存記述の扱い
+
+- `KNOWLEDGE.md` / `CHANGELOG.md` の歴史的記述 (例: `KNOWLEDGE.md` L261 #1895 の `~5-10 % Linux CI flake`、`CHANGELOG.md` L598 の `Linux CI flake (~5-10 %)` 等) は **変更しない**。理由: 検索性維持。upstream LLVM issue や CI 解析ログ・GitHub Issue との cross-reference が壊れる
+- 本ルールは **新規執筆 (今後の `KNOWLEDGE.md` 追記 / commit message / PR description / Claude Code の応答 / `.claude/skills/*.md` / `.claude/agents/*.md` / `.claude/rules/*.md` 等)** のみを対象とする
+- **MUST**: 歴史的 flake 記述を **引用・参照して `flake` を結論に再導入する行為** も禁止 (CI #2578 の事故経路と同じため)。歴史的記述に当たった症状を説明する場合は (a)/(b)/(c) のいずれかに変換してから書く
+
 ## Git ブランチ運用ルール
 
 - フィーチャーブランチは `main` から作成し、PR は `main` に向けて作成する。`main` への直接コミットは禁止

--- a/changelog.d/1990-ban-flake-flaky-terminology.md
+++ b/changelog.d/1990-ban-flake-flaky-terminology.md
@@ -1,0 +1,3 @@
+### Changed
+
+- AGENTS.md に新規セクション `## 禁止用語: flake / flaky` を追加し、Claude Code の説明・出力で `flake` / `flaky` の語をあらゆる言語 (日本語訳・カタカナ・他言語同義語 `unstable` / `intermittent` の言い換え用法を含む) で使用すること、および CI 失敗・テスト失敗の理由・結論として用いることを MUST 禁止した。代替表現として (a) 発生条件の明示、(b) `KNOWLEDGE.md` 既存 entry への明示リンク (issue 番号 + 行番号)、(c) root cause 未特定の場合「発生条件未特定。再現条件の調査が未完了」と明記し安易な再実行提案を禁止する、のいずれかを必須化した。歴史的記述 (`KNOWLEDGE.md` L261 #1895 / `CHANGELOG.md` L598 等) は検索性維持のため変更しないが、これらを引用・参照して `flake` を結論に再導入する行為も禁止した。新ルール導入時点で違反していた active prompt material 2 箇所 (`.claude/skills/triage-side-finding/SKILL.md` Q1 説明、`.claude/agents/fuzzer-runner.md` REPRO: FAILED 分岐) も同時に新ルール準拠表現に書き換えた。意図: CI #2578 で Claude Code が安易に「flake (re-run)」と結論した事故の再発防止 / root cause analysis 放棄の構造的排除。(#1990)


### PR DESCRIPTION
## Summary

- `AGENTS.md` に新規セクション `## 禁止用語: flake / flaky` を追加し、Claude Code が `flake` / `flaky` をあらゆる言語 (日本語訳・カタカナ・`unstable` / `intermittent` 言い換え用法を含む) で使用すること、および CI 失敗・テスト失敗の理由・結論として用いることを MUST 禁止。
- 代替表現として (a) 発生条件の明示、(b) `KNOWLEDGE.md` 既存 entry への明示リンク (issue + 行番号)、(c) root cause 未特定の場合「発生条件未特定。再現条件の調査が未完了」と明記し安易な re-run 提案を禁止、のいずれかを必須化。`KNOWLEDGE.md` / `CHANGELOG.md` の歴史的記述は検索性維持のため変更しないが、これらを引用・参照して `flake` を結論に再導入する行為も禁止。
- 新ルール導入時点で違反していた active prompt material 2 箇所 (`.claude/skills/triage-side-finding/SKILL.md` Q1 説明、`.claude/agents/fuzzer-runner.md` REPRO: FAILED 分岐) を新ルール準拠表現に書き換え。
- 意図: CI #2578 で Claude Code が安易に「flake (re-run)」と結論した事故の再発防止 / root cause analysis 放棄の構造的排除。

## Pre-commit checklist skip log

- Skipped §1 — Claude Code rule update only, no user-visible CLI/feature change
- Skipped §3 / §3.5 / §3.5.5 / §3.6 / §3.6.5 — no source code change

## Test plan

- [x] \`grep -rn -i -E 'flake|flaky|フレーク|フレーキー' AGENTS.md .claude/\` の残存使用が AGENTS.md 新セクション内 (定義としての出現) のみであり、書き換え対象ファイルに旧表現が残っていないことを確認
- [x] \`git diff --stat KNOWLEDGE.md CHANGELOG.md\` が空 (歴史的記述は不変)
- [x] \`changelog.d/1990-ban-flake-flaky-terminology.md\` が存在し、\`### Changed\` ヘッダと \`(#1990)\` 末尾を含むことを確認

Closes #1990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated test failure diagnostic guidelines to enhance clarity and effectiveness. Failure explanations must now include specific occurrence conditions, relevant historical context references, or explicit investigation status indicators rather than generic descriptions. This change ensures better diagnostics, faster problem identification, and more effective issue resolution by providing concrete, actionable details for troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->