### PR TITLE
chore(build): ignore build-rust/ build tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ build/
 build-asan/
 build-tsan/
 build-fuzz/
+build-rust/
 build-docker/
 build-asan-docker/
 build-tsan-docker/


### PR DESCRIPTION
`build-rust/` is an ad-hoc CMake build tree created with `-DRY_LLVM_EMIT_IMPL_RUST=ON` to validate the Rust `ry_llvm_emit` crate (#1950). Like the other `build-*/` directories, add it to `.gitignore` so it no longer surfaces as ~349 untracked files in `git status`. No source changes.

### Pre-commit checklist

`.gitignore`-only change, zero source impact (CI already green: test / asan / tsan / clang-tidy / scan-build / filecheck / CodeQL).

- Skipped §1 (doc) — no user-visible behavior change
- Skipped §2 (CHANGELOG) — build/CI-only change, not user-facing
- Skipped §2.5 (rules/skills) — no reject branch / pitfall / design rejection
- Skipped §3 (tests) / §3.5 (sanitizers) / §3.5.5 (static analysis) — no source impact
- Skipped §3.6 (libFuzzer) / §3.6.5 (tree-sitter) — Skip-if empty
- §3.7 background hygiene: foreground-only this session (pass)
- §4 label: no-op (no linked issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to ignore build artifacts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->