### PR TITLE
ci: validate Rust ry_llvm_emit path before cutover (#1998)

### DIFF
--- a/.claude/skills/commands-environment-gotchas/SKILL.md
+++ b/.claude/skills/commands-environment-gotchas/SKILL.md
@@ -345,3 +345,28 @@ gh pr view <PR> --json mergeable,mergeStateStatus --jq '"\(.mergeable) \(.mergeS
 **Why**: `mergeable` is the merge-conflict judgment only — it returns `MERGEABLE` / `CONFLICTING` / `UNKNOWN` based on whether the base/head can be three-way merged. `mergeStateStatus` is the comprehensive UI state and exposes `CLEAN`, `HAS_HOOKS` (both ready), `BLOCKED` (required checks not green / required reviews missing / signed-commit policy), `BEHIND` (head behind base), `DIRTY` (conflicts; mirrors `mergeable: CONFLICTING`), `DRAFT`, `UNKNOWN`, `UNSTABLE` (non-required failures). CI-pending and branch-protection states show up as `BLOCKED` while `mergeable` stays `MERGEABLE`, so skipping the second check lets the merge call proceed and fail noisily. The `gh pr merge` documentation says "the merge will not happen unless the pull request is in a mergeable state" without spelling out which API field that maps to — the answer is `mergeStateStatus`, not `mergeable`.
 
 **Note (where the strict gate applies)**: This `mergeStateStatus ∈ {CLEAN, HAS_HOOKS}` gate belongs at the actual merge call (e.g. `git-close-pr` Step 6 / `gh pr merge`). Pre-check steps should distinguish structural blockers (`DIRTY` / `mergeable: CONFLICTING`) from transient states (`BLOCKED` while CI runs, `BEHIND`, `UNSTABLE`, `UNKNOWN`, `DRAFT`) that subsequent steps will resolve. See `git-close-pr` Step 1 (structural-only pre-check, warn-and-proceed for transient states) vs Step 6 (strict gate before merge). Issue #1956 (2026-05-29) — applying the strict gate at Step 1 wrongly serialized CI completion with review handling.
+
+---
+
+### In-container `RY_LLVM_EMIT_IMPL_RUST=ON` verification: pull the `ry-ci` image, don't use `docker/run.sh`'s dev image
+
+**Source**: #1998 (2026-06-03, Sub-issue 4 self-verification)
+**Tags**: docker, ry-llvm-emit, rust, cdylib, flag-on, fuzz, in-container, cargo
+
+**Wrong**: verifying a `RY_LLVM_EMIT_IMPL_RUST=ON` build inside the local `docker/run.sh` dev image (`ry-linux-dev:latest`). Two failures: (a) the locally-built dev image can lag the published `ry-ci:llvm-21` base and predate the baked Rust toolchain — `cargo`/`rustc`/`/opt/cargo` don't exist and corrosion's configure fails with `rustc not found`; (b) even on a current image, `docker/run.sh`'s presets are all flag-OFF and `entrypoint.sh` pre-builds `cmake --preset <p>` (flag OFF) before dispatching any command, forcing a wasteful double build. macOS host can't substitute either: the `fuzz` preset rejects AppleClang (requires real Clang) and macOS-host fuzzing has libFuzzer/SDKROOT friction (#1865).
+
+**Correct**: pull the current CI image and run it directly as root (GitHub runs container jobs as root; `/opt/cargo` is root-writable there — note it may not exist until cargo's first build creates it), source bind-mounted read-only, build into a **named volume** (not under the repo mount — sidesteps the macOS Mach-O leak guard and persists across chunked builds when one `cmake --build` exceeds the foreground time budget):
+
+```bash
+docker pull ghcr.io/t0k0sh1/ry-ci:llvm-21
+docker run --rm -v "$PWD:/src:ro" -v ry-fuzz-rust-ci-build:/build \
+  --entrypoint bash ghcr.io/t0k0sh1/ry-ci:llvm-21 -c '
+    cmake -S /src -B /build -G Ninja -DCMAKE_BUILD_TYPE=Debug \
+      -DENABLE_FUZZER=ON -DENABLE_ASAN=ON -DENABLE_UBSAN=ON \
+      -DRY_LLVM_EMIT_IMPL_RUST=ON -DLLVM_DIR=/usr/local/llvm/lib/cmake/llvm
+    cmake --build /build --target fuzz_parser fuzz_json fuzz_utf8 fuzz_io_open'
+```
+
+`LLVM_SYS_211_PREFIX=/usr/local/llvm` is baked as ENV (preserved under `--entrypoint bash`), so llvm-sys/corrosion find the shared libLLVM the flag requires (the image builds LLVM with `LLVM_BUILD_LLVM_DYLIB=ON`). The cdylib lands at `/build/lib/libry_llvm_emit.so` (`file` → ELF shared object), proving the Rust side links on Linux.
+
+**Why it recurs**: the fuzz CI job stays disabled, so this in-container run is the *only* validation of the flag-ON fuzz build (it is NOT covered by the test/asan/tsan rust matrix legs, which exercise `ry`/`ry_tests`, not the fuzz harnesses). Sub-issue 5 (the cutover) and any future cdylib work need the same procedure. If Docker disk fills mid-pull (`no space left on device`), `docker builder prune -a -f` reclaims shared build cache without touching images/volumes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
   push:
     branches: [main]
+  # workflow_dispatch enables the on-demand macos-smoke-rust job below
+  # (#1993 Sub-issue 4). All other jobs run on pull_request / push as before;
+  # macos-smoke-rust is guarded by `if: github.event_name == 'workflow_dispatch'`
+  # so a manual dispatch is the only thing that spends a macOS runner.
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -101,21 +106,34 @@ jobs:
           cargo check -p ry_llvm_emit
 
   test:
+    name: test (${{ matrix.emit }})
     runs-on: ubuntu-24.04
     container: ghcr.io/${{ github.repository_owner }}/ry-ci:llvm-21
+    strategy:
+      fail-fast: false
+      matrix:
+        # cpp = default C++ ry_llvm_emit (flag OFF). rust = Rust cdylib
+        # (RY_LLVM_EMIT_IMPL_RUST=ON, #1993 Sub-issue 4 — validate the Rust
+        # path before the Sub-issue 5 cutover). The cpp leg must stay until
+        # the cutover removes the C++ impl. The container's /usr/local/llvm
+        # is built with LLVM_BUILD_LLVM_DYLIB=ON, so the rust leg's
+        # shared-libLLVM requirement (#1997) is met without an LLVM_DIR
+        # override (see docker/ci.Dockerfile).
+        emit: [cpp, rust]
     steps:
       - uses: actions/checkout@v4
       - name: Restore ccache
         uses: actions/cache@v4
         with:
           path: /root/.cache/ccache
-          key: ci-test-${{ github.ref }}-${{ github.sha }}
+          key: ci-test-${{ matrix.emit }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
-            ci-test-${{ github.ref }}-
+            ci-test-${{ matrix.emit }}-${{ github.ref }}-
+            ci-test-${{ matrix.emit }}-
             ci-test-
       - name: Build
         run: |
-          cmake --preset default
+          cmake --preset default ${{ matrix.emit == 'rust' && '-DRY_LLVM_EMIT_IMPL_RUST=ON' || '' }}
           cmake --build build
       - name: Test (C++)
         run: ./build/ry_tests
@@ -237,21 +255,33 @@ jobs:
         run: ctest --test-dir build -L filecheck --output-on-failure
 
   asan:
+    name: asan (${{ matrix.emit }})
     runs-on: ubuntu-24.04
     container: ghcr.io/${{ github.repository_owner }}/ry-ci:llvm-21
+    strategy:
+      fail-fast: false
+      matrix:
+        # See the `test` job for the cpp/rust leg rationale. In the rust leg
+        # only the C++ side (ry_lib / ry / ry_tests) is ASan+UBSan-instrumented;
+        # the Rust cdylib and shared libLLVM are uninstrumented because
+        # corrosion does not propagate -fsanitize=* into the cargo build
+        # (#1993 Sub-issue 4 PR notes). This mirrors the cpp leg, where LLVM
+        # itself is also linked uninstrumented.
+        emit: [cpp, rust]
     steps:
       - uses: actions/checkout@v4
       - name: Restore ccache
         uses: actions/cache@v4
         with:
           path: /root/.cache/ccache
-          key: ci-asan-${{ github.ref }}-${{ github.sha }}
+          key: ci-asan-${{ matrix.emit }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
-            ci-asan-${{ github.ref }}-
+            ci-asan-${{ matrix.emit }}-${{ github.ref }}-
+            ci-asan-${{ matrix.emit }}-
             ci-asan-
       - name: Build (ASan + UBSan)
         run: |
-          cmake --preset asan
+          cmake --preset asan ${{ matrix.emit == 'rust' && '-DRY_LLVM_EMIT_IMPL_RUST=ON' || '' }}
           cmake --build build-asan
       - name: Test (C++ / ASan + UBSan)
         env:
@@ -265,8 +295,21 @@ jobs:
         run: ./build-asan/ry test -p
 
   tsan:
+    name: tsan (${{ matrix.emit }})
     runs-on: ubuntu-24.04
     container: ghcr.io/${{ github.repository_owner }}/ry-ci:llvm-21
+    strategy:
+      fail-fast: false
+      matrix:
+        # See the `test` job for the cpp/rust leg rationale. The required /
+        # warn-only split documented below applies to BOTH legs. In the rust
+        # leg TSan instruments only the C++ side; the Rust cdylib and shared
+        # libLLVM are uninstrumented (corrosion does not propagate -fsanitize
+        # — see #1993 Sub-issue 4 PR notes). The cdylib's 28 ABI functions
+        # are single-threaded IR-builder calls, so the rust leg does not
+        # weaken the #630 race gate, which lives in the (instrumented) C++
+        # runtime exercised by ry_tests.
+        emit: [cpp, rust]
     # ThreadSanitizer coverage for #630's P0 race fixes is split:
     #
     # - The C++ test step is REQUIRED. It runs ry_tests, which
@@ -303,13 +346,14 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /root/.cache/ccache
-          key: ci-tsan-${{ github.ref }}-${{ github.sha }}
+          key: ci-tsan-${{ matrix.emit }}-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
-            ci-tsan-${{ github.ref }}-
+            ci-tsan-${{ matrix.emit }}-${{ github.ref }}-
+            ci-tsan-${{ matrix.emit }}-
             ci-tsan-
       - name: Build (TSan)
         run: |
-          cmake --preset tsan
+          cmake --preset tsan ${{ matrix.emit == 'rust' && '-DRY_LLVM_EMIT_IMPL_RUST=ON' || '' }}
           cmake --build build-tsan
       - name: Test (C++ / TSan)
         env:
@@ -324,6 +368,58 @@ jobs:
         env:
           TSAN_OPTIONS: halt_on_error=1:second_deadlock_stack=1
         run: ./build-tsan/ry test -p
+
+  macos-smoke-rust:
+    # macOS build/link smoke for the Rust ry_llvm_emit path (flag ON),
+    # #1993 Sub-issue 4. workflow_dispatch-only: macOS runners cost ~10x a
+    # Linux runner, and the purpose is to prove the Apple-linker path works
+    # on demand — specifically that the `-Wl,-undefined,dynamic_lookup`
+    # cdylib link arg in crates/ry_llvm_emit/build.rs resolves __ry_* and
+    # LLVM* symbols from the host process. The per-PR safety net is the
+    # Linux rust legs of test/asan/tsan above. Homebrew llvm@21 ships a
+    # shared libLLVM.dylib, satisfying the flag-ON shared-libLLVM
+    # requirement (#1997). Remove or fold into the cutover in Sub-issue 5.
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache LLVM 21 (brew)
+        id: cache-llvm-brew
+        uses: actions/cache@v4
+        with:
+          path: |
+            /opt/homebrew/opt/llvm@21
+            /opt/homebrew/Cellar/llvm@21
+          key: llvm-21-darwin-arm64
+      - name: Install LLVM 21 (brew)
+        if: steps.cache-llvm-brew.outputs.cache-hit != 'true'
+        run: brew install llvm@21
+      - name: Install dependencies (brew)
+        run: brew install openssl@3 ninja googletest
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1
+        with:
+          key: ci-macos-smoke-rust
+          restore-keys: |
+            ci-macos-smoke-rust-
+      - name: Build (flag ON / Rust ry_llvm_emit)
+        # Homebrew llvm@21 provides the shared libLLVM.dylib that
+        # RY_LLVM_EMIT_IMPL_RUST=ON requires; cargo/rustc are pre-installed
+        # on GitHub macOS runners. LLVM_SYS_211_PREFIX is derived by CMake
+        # from LLVM_DIR via corrosion_set_env_vars (see CMakeLists.txt), so
+        # llvm-sys finds the same Homebrew LLVM. This is the CI form of the
+        # documented local `cmake --preset rust-emit` build.
+        run: |
+          cmake -B build -G Ninja \
+            -DLLVM_DIR="$(brew --prefix llvm@21)/lib/cmake/llvm" \
+            -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DRY_LLVM_EMIT_IMPL_RUST=ON
+          cmake --build build
+      - name: Test (C++)
+        run: ./build/ry_tests
+      - name: Test (Ry self-tests)
+        run: ./build/ry test -p
 
 # ---------------------------------------------------------------------------
 # fuzz job: disabled in CI until the harnesses have proven stable locally.
@@ -350,7 +446,7 @@ jobs:
 #      - name: Build (libFuzzer + ASan + UBSan)
 #        run: |
 #          cmake --preset fuzz
-#          cmake --build build-fuzz --target fuzz_parser fuzz_json fuzz_utf8
+#          cmake --build build-fuzz --target fuzz_parser fuzz_json fuzz_utf8 fuzz_io_open
 #      - name: Fuzz parser (60s)
 #        continue-on-error: true
 #        env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,9 @@ cmake --build build                                     # Ninja parallelizes aut
 >
 > **Shared libLLVM required**: `ry` and the Rust cdylib must share ONE LLVM instance, or `ConstantFP::get` hangs on float constants (two-LLVM `fltSemantics` split, #1997; see `docs/architecture/llvm-ir-emission-boundary.md` §"Sub-issue 3 landed"). The static-only `/usr/local/llvm` does NOT qualify.
 >
-> **`LLVM_DIR`**: the `rust-emit` preset hardcodes `LLVM_DIR` to Homebrew `llvm@21` (ships `libLLVM.dylib`) as a macOS-local convenience. On Linux or any non-Homebrew prefix, override it: `cmake --preset rust-emit -DLLVM_DIR=<shared-LLVM-prefix>/lib/cmake/llvm`. CI's container builds LLVM with `LLVM_BUILD_LLVM_DYLIB=ON` and drives ON via `--preset default` + the entrypoint's `-DLLVM_DIR` override, so the `rust-emit` preset itself is not exercised on CI.
+> **`LLVM_DIR`**: the `rust-emit` preset hardcodes `LLVM_DIR` to Homebrew `llvm@21` (ships `libLLVM.dylib`) as a macOS-local convenience. On Linux or any non-Homebrew prefix, override it: `cmake --preset rust-emit -DLLVM_DIR=<shared-LLVM-prefix>/lib/cmake/llvm`. CI's container builds LLVM with `LLVM_BUILD_LLVM_DYLIB=ON`, so its `/usr/local/llvm` (the `default`/`asan`/`tsan` preset prefix) already qualifies as a shared libLLVM — CI drives flag ON via `--preset {default,asan,tsan} -DRY_LLVM_EMIT_IMPL_RUST=ON` with no `LLVM_DIR` override needed. The `rust-emit` preset (Homebrew path) is macOS-local only and is not used on CI.
+>
+> **CI coverage (#1998, #1993 Sub-issue 4)**: `ci.yml`'s `test` / `asan` / `tsan` jobs carry a `matrix.emit: [cpp, rust]` axis — the `rust` leg validates the flag-ON path on every PR/push (Linux). A `workflow_dispatch`-gated `macos-smoke-rust` job validates the macOS/Apple-linker path (`-Wl,-undefined,dynamic_lookup`) on demand. The Rust cdylib is **not** sanitizer-instrumented (corrosion does not propagate `-fsanitize=*` into the cargo build; only the C++ side is). Flag/option removal (cutover) is Sub-issue 5.
 >
 > **Default (OFF, C++ impl) path is unaffected**: `--preset default` (`/usr/local/llvm` static).
 

--- a/docs/architecture/llvm-ir-emission-boundary.md
+++ b/docs/architecture/llvm-ir-emission-boundary.md
@@ -173,6 +173,14 @@ Opaque handle typedefs — `sizeof` 8 / `alignof` 8 (pointers; per-field offset 
 
 **Consequence — every ON environment must ship a shared libLLVM.** CI satisfies this (`docker/ci.Dockerfile` builds LLVM with `LLVM_BUILD_LLVM_DYLIB=ON`); Homebrew `llvm@21` ships `lib/libLLVM.dylib`. The documented dev prefix `/usr/local/llvm` is **static-only** and does NOT — `cmake --preset rust-emit` (LLVM_DIR → Homebrew) is the local ON build. The OFF (C++ default) path is unaffected: it links the C++ impl into `ry`'s single LLVM (no second copy) and continues to use `/usr/local/llvm` static via `--preset default`.
 
+## Sub-issue 4 landed (#1998 — CI validation of the flag-ON path before cutover)
+
+`ci.yml`'s `test` / `asan` / `tsan` jobs gained a `matrix.emit: [cpp, rust]` axis. The `rust` leg configures with `-DRY_LLVM_EMIT_IMPL_RUST=ON` on top of the same preset; the `cpp` leg is unchanged and stays until the Sub-issue 5 cutover removes the C++ impl. Both legs run on every PR / push (Linux container). The `tsan` required (C++ `ry_tests`, #630 race gate) / warn-only (Ry self-tests, upstream LargeMmapAllocator [google/sanitizers#1716]) split is preserved in both legs. A `workflow_dispatch`-gated `macos-smoke-rust` job builds flag-ON with Homebrew `llvm@21` and runs `ry_tests` + `ry test -p`, proving the Apple-linker `-Wl,-undefined,dynamic_lookup` path (`crates/ry_llvm_emit/build.rs`); it is off the per-PR path because macOS runners cost ~10x.
+
+**No `LLVM_DIR` override on CI.** The container's `/usr/local/llvm` is built with `LLVM_BUILD_LLVM_DYLIB=ON` (`docker/ci.Dockerfile`), so it already ships a shared `libLLVM.so` — unlike the static-only `/usr/local/llvm` on a typical dev box. The `rust` leg therefore reuses the `default` / `asan` / `tsan` preset prefix directly via `--preset <p> -DRY_LLVM_EMIT_IMPL_RUST=ON`; the macOS-only `rust-emit` preset (Homebrew `LLVM_DIR`) is not used on CI.
+
+**Sanitizer instrumentation boundary (data for the Sub-issue 5 `KNOWLEDGE.md` entry).** corrosion does **not** propagate the CMake `-fsanitize=*` flags into the cargo build: `CMakeLists.txt` calls only `corrosion_set_env_vars(ry_llvm_emit "LLVM_SYS_211_PREFIX=...")`, never `corrosion_add_target_rustflags` / `corrosion_add_target_local_rustflags`, and `crates/ry_llvm_emit/build.rs` emits only the macOS `dynamic_lookup` link arg (no sanitizer logic). The CI Rust toolchain is stable (`-Zsanitizer` is nightly-only). So in the `asan` / `tsan` `rust` legs only the C++ side (`ry_lib` / `ry` / `ry_tests`) is instrumented; the Rust cdylib and shared `libLLVM` are not — the same posture as the `cpp` leg, where LLVM itself is linked uninstrumented. This is an intentional, documented gap, not an oversight.
+
 ## Related documents
 
 - [Compiler Layers](compiler-layers.md) — layer ordering and dependency direction.


### PR DESCRIPTION
## Summary

CI で Rust LLVM-emit path (`RY_LLVM_EMIT_IMPL_RUST=ON`) を sanitizer / fuzzer / macOS smoke で end-to-end 検証する safety net を Sub-issue 5 (cutover) の前に確立する (#1993 Sub-issue 4)。

- `ci.yml` の `test` / `asan` / `tsan` に `matrix.emit: [cpp, rust]` 軸を追加。`rust` leg は `--preset <p> -DRY_LLVM_EMIT_IMPL_RUST=ON`。`cpp` leg は Sub-issue 5 まで維持 (AC #6)。コンテナの `/usr/local/llvm` は `LLVM_BUILD_LLVM_DYLIB=ON` なので `LLVM_DIR` override 不要。
- `tsan` の required (C++ `ry_tests`) / warn-only (Ry self-test, upstream LargeMmapAllocator google/sanitizers#1716) split を両 leg で維持。
- `workflow_dispatch`-gated `macos-smoke-rust` job 追加 (Homebrew llvm@21, flag ON)。Apple linker の `-Wl,-undefined,dynamic_lookup` を実証。毎 PR の macOS runner 消費なし。
- コメントアウト fuzz block の build-target 行に `fuzz_io_open` を追加。

## AC #4: corrosion / RUSTFLAGS instrumentation boundary

**corrosion-rs は `-fsanitize=*` を `cargo build` に RUSTFLAGS 経由で伝播しない。Rust cdylib は意図的に未計装。** 根拠:

1. `CMakeLists.txt` は `corrosion_set_env_vars(ry_llvm_emit "LLVM_SYS_211_PREFIX=...")` のみ呼び、`corrosion_add_target_rustflags` / `corrosion_add_target_local_rustflags` は未使用。
2. `crates/ry_llvm_emit/build.rs` は `CARGO_CFG_TARGET_OS` のみ参照 (macOS の `dynamic_lookup` link arg だけ emit)、sanitizer ロジックなし。
3. CI の Rust toolchain は stable 1.83.0 (`-Zsanitizer` は nightly 限定)。

→ `asan` / `tsan` の `rust` leg では C++ 側 (`ry_lib` / `ry` / `ry_tests`) のみ計装され、Rust cdylib + shared libLLVM は未計装。`cpp` leg で LLVM 本体が未計装リンクなのと同じ posture。Sub-issue 5 の `KNOWLEDGE.md` entry の根拠データ。

## Verification

- **actionlint**: clean (matrix name 補間 / ternary / `if:` / `runs-on` / matrix strategy のセマンティクス妥当)。
- **macOS native flag-ON** (`cmake --preset rust-emit`): `ry_tests` **2524 passed**, `ry test -p` **203 files / 0 failures**。Apple linker 経路を実証。
- **in-container Linux fuzz flag-ON** (pulled `ry-ci:llvm-21`, AC #2): `cmake --preset fuzz -DRY_LLVM_EMIT_IMPL_RUST=ON` build 成功、cdylib が `libry_llvm_emit.so` (ELF 64-bit shared object, aarch64) としてビルド、4 harness (`fuzz_parser` / `fuzz_json` / `fuzz_utf8` / `fuzz_io_open`) すべて `-runs=0` で **exit 0** (ASan/UBSan エラーなし)。fuzz CI job は disabled のため、これが AC #2 の唯一の検証。
- **test/asan/tsan の `rust` leg (Linux)**: 本 PR の CI 実行が authoritative。残存リスクは `set(LLVM_LIBS LLVM)` による `ry` の ELF shared libLLVM リンク + 実行時 codegen→cdylib (macOS Mach-O でも lint の `cargo check` でもカバーされない新規部分)。cdylib 単体の ELF ビルドは上記 fuzz 検証で実証済み。

## Pre-commit checklist skip log

- Skipped §2 (CHANGELOG) — CI-only + docs change (user-facing な feat/fix なし; #1993 Sub-issue 1–3 も CHANGELOG entry なしの前例に整合)。
- Skipped §3 / §3.5 (Tests / Sanitizer) — CI YAML + docs のみでソース/ランタイム変更なし。flag-ON path は上記で別途検証。Linux asan/tsan rust leg は本 PR CI が検証。
- §3.5.5 (Static Analysis) — N/A: C++ ソース変更なし (新規 lint surface なし)。
- Skipped §3.6 (libFuzzer) — parser/lexer/json/utf8/string/io family の変更なし (ただし AC #2 のため fuzz flag-ON は in-container 実行済み)。
- Skipped §3.6.5 (tree-sitter) — grammar / EBNF / scanner 変更なし。
- §1 (Doc) — user-facing (docs/reference / README) 更新は不要 (behavior 変更なし)。dev docs (`AGENTS.md`, `docs/architecture/llvm-ir-emission-boundary.md`) は更新済み。
- §2.5 — `.claude/skills/commands-environment-gotchas/SKILL.md` に in-container flag-ON 検証手順を追記 (Sub-issue 5 で再発するため)。
- §3.7 (background hygiene) — OK (本セッションで background 実行なし)。

Closes #1998


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI pipeline with matrix-based testing for C++ and Rust build paths to improve validation coverage
  * Added on-demand macOS smoke test job for Rust builds
  * Expanded sanitizer testing matrix to cover both emission modes

* **Documentation**
  * Updated LLVM configuration guidance for different platforms
  * Clarified CI validation strategy for Rust emission feature in architecture documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->