### PR TITLE
docs(AGENTS.md): clarify macOS build commands use rust-emit/build-rust

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ cmake --build build                                     # Ninja parallelizes aut
 ```
 
 > **macOS local builds**: the commands above are the Linux/CI form. On macOS, substitute `cmake --preset rust-emit` for `cmake --preset default`, `build-rust/` for `build/`, and `./build-rust/ry` for `./build/ry` throughout this document. The post-cutover shared-libLLVM requirement forces this split — see the **Shared libLLVM required** note below for why (and the `-DRust_COMPILER` note below if `rustc` discovery fails during configure).
-
+>
 > The `./build/ry` built inside the repo prefers the project-local `share/std/` per the hidden `[paths]._dev_stdlib` setting in `package.toml`. Use `RY_ENV=internal` only when extra isolation is needed.
 
 > **`ry_llvm_emit` is a Rust cdylib (`crates/ry_llvm_emit/`, #1949/#1950/#1993)** — the LLVM IR emission shared library is implemented in Rust and built automatically as part of every `cmake` build (via corrosion-rs). This adds two local-build prerequisites outside the Docker CI image:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,8 @@ cmake --build build                                     # Ninja parallelizes aut
 ./build/ry test tests/spec/<file>.test.ry               # run an individual file
 ```
 
+> **macOS local builds**: the commands above are the Linux/CI form. On macOS, substitute `cmake --preset rust-emit` for `cmake --preset default`, `build-rust/` for `build/`, and `./build-rust/ry` for `./build/ry` throughout this document. The post-cutover shared-libLLVM requirement forces this split — see the **Shared libLLVM required** note below for why (and the `-DRust_COMPILER` note below if `rustc` discovery fails during configure).
+
 > The `./build/ry` built inside the repo prefers the project-local `share/std/` per the hidden `[paths]._dev_stdlib` setting in `package.toml`. Use `RY_ENV=internal` only when extra isolation is needed.
 
 > **`ry_llvm_emit` is a Rust cdylib (`crates/ry_llvm_emit/`, #1949/#1950/#1993)** — the LLVM IR emission shared library is implemented in Rust and built automatically as part of every `cmake` build (via corrosion-rs). This adds two local-build prerequisites outside the Docker CI image:


### PR DESCRIPTION
## Summary

Add a platform-substitution note directly below the **Build & Test** fenced block in `AGENTS.md`: on macOS, substitute `cmake --preset rust-emit` / `build-rust/` / `./build-rust/ry` for the Linux/CI `--preset default` / `build/` / `./build/ry` **throughout the document**. The single "throughout" clause covers the scattered `./build/ry` references without per-line annotation, and cross-references the existing **Shared libLLVM required** note for the rationale (post-cutover shared-libLLVM split, #1997).

This closes the discoverability gap: the Build & Test command block was Linux/CI-first, and the macOS difference lived only in a note further down.

Closes #2008

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added macOS local builds instructions to the Build & Test section with macOS-specific build/test commands.
  * Clarified the split tied to the post-cutover shared-libLLVM requirement and linked to the "Shared libLLVM required" and "-DRust_COMPILER" sections for additional context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Pre-commit checklist (§0 matrix: `.md`-only — `AGENTS.md`)

- §1 Doc — ✓ self-edit (`AGENTS.md` is the doc; broader propagation to README/docs/skills tracked in #2010, out of scope here)
- Skipped §2 CHANGELOG — internal dev guidance, no user-visible change
- Skipped §3 Tests / §3.5 Sanitizer — no source code change
- Skipped §3.6 libFuzzer — no parser/lexer/json/utf8/string/io change
- Skipped §3.6.5 tree-sitter — no grammar change
- §3.5.5 Static analysis — no C++ change locally; CI `clang-tidy` / `scan-build` / `lint` green on this PR
- §3.7 Background execution — none used this session (all foreground)
- §2.5 rules/skills — no entry (single local CodeRabbit MD028 nit; per AGENTS.md single local comments don't require an addition)
- §4 Label cleanup — post-merge via `git-close-pr` Step 7
