### PR TITLE
fix(pre-commit-checklist): make run-tests.sh platform-aware on macOS (#2011)

### DIFF
--- a/.claude/skills/commands-environment-gotchas/SKILL.md
+++ b/.claude/skills/commands-environment-gotchas/SKILL.md
@@ -112,6 +112,33 @@ arrays in shell scripts.
 
 ---
 
+### bash `set -e` + `var=$(cmd)`: a standalone assignment exits on cmd failure; put it in an `if`
+
+**Source**: #2011 run-tests.sh platform-aware preset selection (2026-06-03)
+**Tags**: commands, bash, shell, errexit
+
+**Wrong** (under `set -euo pipefail`) — captures, then guards:
+
+```bash
+rustc_path="$(rustup which rustc)"      # rustup present but no default toolchain → this LINE exits the script
+[[ -n "$rustc_path" ]] && use "$rustc_path"
+```
+
+A standalone assignment takes the exit status of its command substitution, so `set -e` aborts the whole script the moment `rustup which rustc` fails — *before* the `[[ -n ]]` guard ever runs. The guard is dead code on the failure path.
+
+**Correct** — make the assignment part of an `if` condition:
+
+```bash
+if command -v rustup >/dev/null 2>&1 \
+   && rustc_path="$(rustup which rustc 2>/dev/null)" && [[ -n "$rustc_path" ]]; then
+  use "$rustc_path"
+fi
+```
+
+**Why**: `set -e` suppresses failures of commands in an `if`/`while`/`until` condition, in `&&`/`||` lists (every element but the last), and after `!`. An assignment in plain *statement* position is none of those, so its command-substitution failure is fatal. Wrapping it in the `if` condition both captures the value and makes the failure non-fatal in one step. (Related: the empty-array `set -u` guard above — both are `set -euo pipefail` traps that only bite on the rarely-exercised branch.)
+
+---
+
 ### `ry -c` reads from stdin, not argv
 
 **Source**: #1269 manual repro (2026-04-21)

--- a/.claude/skills/pre-commit-checklist/run-tests.sh
+++ b/.claude/skills/pre-commit-checklist/run-tests.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# §3 Run All Tests — cmake default preset + ry_tests + ry test -p
+# §3 Run All Tests — host build (Linux: default/build, macOS: rust-emit/build-rust) + ry_tests + ry test -p
 set -euo pipefail
 cd "$(dirname "${BASH_SOURCE[0]}")/../../.."
 
@@ -10,25 +10,61 @@ for arg in "$@"; do
     -h|--help)
       sed -n '2p;3,8p' "$0"
       echo "Usage: run-tests.sh [--clean]"
+      echo "Env: RY_TEST_PRESET (default|rust-emit), RY_BUILD_DIR, RY_RUST_COMPILER"
       exit 0
       ;;
     *) echo "unknown option: $arg" >&2; exit 2 ;;
   esac
 done
 
-# Auto-heal build/ when its CMakeCache.txt was generated for a sanitizer/fuzzer
-# preset (e.g. user ran cmake --preset asan in build/ by mistake). This is the
-# only host-native build dir; sanitizer / fuzz / static-analysis go through
-# docker/run.sh which uses separate build-*-docker/ dirs.
-if (( CLEAN == 1 )); then
-  rm -rf build
-elif [[ -f build/CMakeCache.txt ]] && \
-     grep -qE '^(ENABLE_ASAN|ENABLE_TSAN|ENABLE_UBSAN|ENABLE_FUZZER):BOOL=ON$' build/CMakeCache.txt; then
-  echo "==> build/CMakeCache.txt has sanitizer/fuzzer preset enabled — removing" >&2
-  rm -rf build
+# Select the cmake preset + build dir for the host. Linux/CI links the static
+# /usr/local/llvm via the `default` preset (build/). macOS's /usr/local/llvm is
+# static-only (no libLLVM.dylib), so the Rust ry_llvm_emit cdylib's shared-libLLVM
+# requirement (#1997) forces the `rust-emit` preset (build-rust/, Homebrew llvm@21).
+# Override with RY_TEST_PRESET / RY_BUILD_DIR. (#2011)
+PRESET="${RY_TEST_PRESET:-}"
+if [[ -z "$PRESET" ]]; then
+  case "$(uname -s)" in
+    Darwin) PRESET=rust-emit ;;
+    *)      PRESET=default ;;
+  esac
+fi
+case "$PRESET" in
+  default)   BUILD_DIR=build ;;
+  rust-emit) BUILD_DIR=build-rust ;;
+  *) echo "unsupported preset: $PRESET (expected default|rust-emit)" >&2; exit 2 ;;
+esac
+BUILD_DIR="${RY_BUILD_DIR:-$BUILD_DIR}"
+
+# corrosion's FindRust can choke on a broken cross toolchain (e.g. a rustup-managed
+# Windows target); pin the host rustc on the rust-emit path when rustup manages the
+# toolchain. Harmless when FindRust would have succeeded, and never added on the
+# Linux/default path. Override the path with RY_RUST_COMPILER. (#2011)
+CONFIGURE_ARGS=()
+if [[ "$PRESET" == "rust-emit" ]]; then
+  if [[ -n "${RY_RUST_COMPILER:-}" ]]; then
+    CONFIGURE_ARGS+=("-DRust_COMPILER=$RY_RUST_COMPILER")
+  elif command -v rustup >/dev/null 2>&1 \
+       && rustc_path="$(rustup which rustc 2>/dev/null)" && [[ -n "$rustc_path" ]]; then
+    CONFIGURE_ARGS+=("-DRust_COMPILER=$rustc_path")
+  fi
 fi
 
-cmake --preset default
-cmake --build build
-./build/ry_tests
-./build/ry test -p
+echo "==> preset=$PRESET build-dir=$BUILD_DIR" >&2
+
+# Auto-heal the host build dir when its CMakeCache.txt was generated for a
+# sanitizer/fuzzer preset (e.g. user ran cmake --preset asan in it by mistake).
+# This is the only host-native build dir; sanitizer / fuzz / static-analysis go
+# through docker/run.sh which uses separate build-*-docker/ dirs.
+if (( CLEAN == 1 )); then
+  rm -rf "$BUILD_DIR"
+elif [[ -f "$BUILD_DIR/CMakeCache.txt" ]] && \
+     grep -qE '^(ENABLE_ASAN|ENABLE_TSAN|ENABLE_UBSAN|ENABLE_FUZZER):BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+  echo "==> $BUILD_DIR/CMakeCache.txt has sanitizer/fuzzer preset enabled — removing" >&2
+  rm -rf "$BUILD_DIR"
+fi
+
+cmake --preset "$PRESET" "${CONFIGURE_ARGS[@]+"${CONFIGURE_ARGS[@]}"}"
+cmake --build "$BUILD_DIR"
+"./$BUILD_DIR/ry_tests"
+"./$BUILD_DIR/ry" test -p


### PR DESCRIPTION
## Summary

`run-tests.sh` (the executable `/pre-commit-checklist` §3 and the `test-runner` subagent run) hardcoded the Linux/CI path (`cmake --preset default` → `build/` → `./build/ry`), so it failed to link on macOS after the `ry_llvm_emit` Rust cutover (#1999): the static-only `/usr/local/llvm` ships no `libLLVM.dylib`, and the shared-libLLVM requirement (#1997) forces the `rust-emit` preset (`build-rust/`, Homebrew `llvm@21`).

It now selects preset + build-dir by `uname -s` (Darwin → `rust-emit`/`build-rust`, else `default`/`build`), mirroring the `case "$PRESET"` mapping in `docker/entrypoint.sh`. On the `rust-emit` path it auto-pins `-DRust_COMPILER` when rustup manages the toolchain (corrosion FindRust otherwise chokes on a broken cross toolchain). Overridable via `RY_TEST_PRESET` / `RY_BUILD_DIR` / `RY_RUST_COMPILER`. Also documents the `set -e` + `var=$(cmd)` assignment trap in `commands-environment-gotchas`.

## Verification (macOS host, bash 3.2)

- `run-tests.sh` → `==> preset=rust-emit build-dir=build-rust`, exit 0, **C++ 2526 tests PASSED + Ry 203 files, 0 failures**; `-DRust_COMPILER` lands in the cache.
- `RY_TEST_PRESET=bogus` → `exit 2` before configure.
- **Linux/default path proven byte-equivalent**: the empty-array guard `"${CONFIGURE_ARGS[@]+...}"` expands to nothing (verified argc test), so the invocation reduces to exactly `cmake --preset default` / `build/` / `./build/ry…`.
- `bash -n` clean; `--help` documents the new env knobs.

## Pre-commit-checklist (`.claude/`-only change)

- Skipped §1 / §2 — no user-visible change (dev tooling; no changelog fragment)
- Skipped §3 / §3.5 — no source change (ran `run-tests.sh` itself as the fix's proof)
- §3.5.5 N/A — no C++ changed; Skipped §3.6 — no parser/lexer/json/utf8/string/io change; Skipped §3.6.5 — no tree-sitter change
- §3.7 — no background execution used; §2.5 — added the `set -e` assignment gotcha

## Out of scope — unowned finding

`.claude/agents/test-runner.md` L14-18 (the `cpp`/`ry`/`filter`/`file` direct-binary modes) and L25 still hardcode `./build/ry…`; on macOS the subagent's direct modes point at a nonexistent `build/` (the default `both` mode is fixed via run-tests.sh). This gap is **not** in #2008 (AGENTS.md only) nor #2010 (lists `SKILL.md` L111, prose-caveat only — does not list test-runner.md), and is outside this PR's approved scope → currently unowned. Surfaced for routing; not filed.

Closes #2011