### PR TITLE
docs: propagate macOS build-command caveat beyond AGENTS.md

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -24,6 +24,7 @@ If the caller's request is ambiguous, assume `both` and run `./.claude/skills/pr
 - **Foreground only.** Never use `run_in_background=true` (#1947). Use `timeout: 600000` (10 minutes) for the script invocation.
 - `run-tests.sh` chains `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p`. The script auto-removes `build/` when `CMakeCache.txt` belongs to a sanitizer/fuzzer preset (use `--clean` to force removal). Trust the script's sequencing; do not pre-build manually unless the caller specifies a filter that bypasses the script.
 - Repo `./build/ry` reads project-local `share/std/` via `package.toml [paths]._dev_stdlib` — no `RY_ENV` override needed.
+- **macOS**: `run-tests.sh` (the `both` path) auto-detects the host and uses the `rust-emit` preset → `build-rust/`. For the direct-invocation layers (`cpp` / `filter:` / `file:`), substitute `build-rust/` for `build/` and `./build-rust/ry` for `./build/ry` (post-Rust-cutover preset split; see `AGENTS.md` § "Build & Test").
 
 ## Failure interpretation
 

--- a/.claude/skills/horizontal-sweep/SKILL.md
+++ b/.claude/skills/horizontal-sweep/SKILL.md
@@ -130,4 +130,6 @@ If source files (`*.cpp`, `*.hpp`, `*.ry`) were modified, build + test before de
 cmake --build build && ./build/ry_tests && ./build/ry test -p
 ```
 
+> **macOS**: substitute `cmake --build build-rust` for `cmake --build build` and `./build-rust/ry` for `./build/ry` (post-Rust-cutover preset split; see `AGENTS.md` § "Build & Test").
+
 For docs / `.claude/` only changes, hand off to `/pre-commit-checklist`.

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -108,7 +108,7 @@ If no entry is needed, state the reason (pure bug fix that won't recur, PR-local
 ./.claude/skills/pre-commit-checklist/run-tests.sh
 ```
 
-Runs `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p`. The script auto-removes `build/` when `CMakeCache.txt` belongs to a sanitizer/fuzzer preset; pass `--clean` to force removal. Fix any failure before declaring complete.
+Runs `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p` (on macOS the script auto-detects the host and substitutes the `rust-emit` preset → `build-rust/`; see `AGENTS.md` § "Build & Test"). The script auto-removes the host build dir when its `CMakeCache.txt` belongs to a sanitizer/fuzzer preset; pass `--clean` to force removal. Fix any failure before declaring complete.
 
 ## 3.5. Sanitizer Verification
 

--- a/.claude/skills/preparing-for-release/SKILL.md
+++ b/.claude/skills/preparing-for-release/SKILL.md
@@ -130,7 +130,7 @@ for any maintainer.
 ## Verification
 
 - `git diff CHANGELOG.md` shows new `[<X.Y.Z>]` + empty `[Unreleased]` + updated comparison links; `changelog.d/` no longer contains the assembled fragments
-- `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p` passes (sanitizer/fuzzer runs not required for a docs-only change; see `/pre-commit-checklist`)
+- `cmake --preset default && cmake --build build && ./build/ry_tests && ./build/ry test -p` passes (macOS: substitute `cmake --preset rust-emit` → `build-rust/`, i.e. `./build-rust/ry_tests` / `./build-rust/ry`; sanitizer/fuzzer runs not required for a docs-only change; see `/pre-commit-checklist`)
 
 ## Note
 

--- a/.claude/skills/ry-playground/SKILL.md
+++ b/.claude/skills/ry-playground/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 Execute Ry language snippets via heredoc to verify behavior. This is for ad-hoc verification only, not for self-tests (`ry test`).
 
+> **macOS**: substitute `./build-rust/ry` for `./build/ry` and `cmake --build build-rust` for `cmake --build build` throughout this skill (post-Rust-cutover preset split; see `AGENTS.md` § "Build & Test").
+
 ## Absolute Rules
 
 1. **No file creation** — never create `.ry` files or temp files anywhere (project or external). No `Write` tool, no `echo > file`, no `cat > file`, no `tee`, no redirection to disk

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ cmake --build build
 ```
 
 > `ry` and the Rust cdylib must share one LLVM instance, so the `-DLLVM_DIR` prefix must ship a shared `libLLVM` (a static-only LLVM build will not link). Building inside the `ry-ci` Docker image (`ghcr.io/<owner>/ry-ci:llvm-21-rev<N>`) needs no separate Rust or shared-LLVM setup — both are baked in.
+>
+> **macOS**: `/usr/local/llvm` (shown above) is typically static-only and will not link — point `-DLLVM_DIR` at a shared-`libLLVM` prefix such as Homebrew `llvm@21` (`-DLLVM_DIR=/opt/homebrew/opt/llvm@21/lib/cmake/llvm`).
 
 ## Usage
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -322,6 +322,8 @@ RY_ENV=prod ./build/ry app.ry
 RY_ENV=internal ./build/ry test
 ```
 
+> **macOS**: the `./build/ry` invocations above are the Linux/CI form. On macOS substitute `./build-rust/ry` — the binary built by `cmake --preset rust-emit` (→ `build-rust/`) per the post-Rust-cutover preset split (`AGENTS.md` § "Build & Test").
+
 When a `ry` executable is built inside the Ry source tree, it can use a repo-local stdlib override declared in the project manifest (`package.toml`). This keeps repo builds aligned with the checked-out `share/std` even if `~/.ry/share/std` is older. Installed `ry` binaries ignore that override and continue to use `$RY_HOME/share/std`.
 
 ---

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -257,6 +257,8 @@ test = "./build/ry_tests"
 clean = "rm -rf build"
 ```
 
+> **macOS**: the `[scripts]` example uses the Linux/CI build form. On macOS, substitute `cmake --preset rust-emit` for `cmake --preset default` and `build-rust/` for `build/` (so `test = "./build-rust/ry_tests"`) — post-Rust-cutover preset split (`AGENTS.md` § "Build & Test").
+
 ### `[project]` Section
 
 | Key | Description |

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1029,7 +1029,7 @@ The matcher table near the top of this file lists the full set of float-aware ma
 
 ## Recipes
 
-Worked patterns for situations that compose multiple `testing` features. Each example is taken from `tests/spec/*.test.ry` so you can run it with `./build/ry test <path>` to see it pass.
+Worked patterns for situations that compose multiple `testing` features. Each example is taken from `tests/spec/*.test.ry` so you can run it with `./build/ry test <path>` (macOS: `./build-rust/ry test <path>`) to see it pass.
 
 ### Queueing return values with `mockReturnValueOnce`
 
@@ -1338,6 +1338,8 @@ sudo apt-get install llvm-21-tools   # → /usr/lib/llvm-21/bin/FileCheck
 ```
 
 CMake auto-detects FileCheck at configure time. If not found, `cmake --preset default` prints a status message and skips the `filecheck` CTest label — other tests are unaffected.
+
+> **macOS**: the commands above are the Linux/CI form. On macOS substitute `build-rust/` for `build/` (so `ctest --test-dir build-rust`, `./build-rust/ry`) and `cmake --preset rust-emit` for `cmake --preset default` — post-Rust-cutover preset split (`AGENTS.md` § "Build & Test").
 
 ### CI gate
 


### PR DESCRIPTION
Propagates the macOS build-command caveat (added to `AGENTS.md` in #2008) to the remaining user-facing docs and skill/agent docs, so macOS readers know to substitute `cmake --preset rust-emit` / `build-rust/` / `./build-rust/ry` at each Linux-first command example. Reuses the AGENTS.md substitution-note wording. Docs/`.claude`-only; no source or behavior change.

**Locations (9 files):** `README.md`, `docs/reference/{project,testing,modules}.md`, `.claude/skills/{pre-commit-checklist,preparing-for-release,horizontal-sweep,ry-playground}/SKILL.md`, plus `.claude/agents/test-runner.md` (its command chain is identical to pre-commit-checklist's but was omitted from the issue list).

**Self-verification (`/pre-commit-checklist`):**
- Skipped §2 (CHANGELOG) — docs/.claude-only, not a feat/fix/breaking change
- Skipped §3 / §3.5 / §3.6 / §3.6.5 — no source or grammar change
- §2.5 (rules/skills) — no entry: the macOS/Linux preset split is transitional (slated for future preset unification per the issue's out-of-scope note), so a permanent path-scoped rule would become cleanup debt

Closes #2010

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added macOS-specific guidance for LLVM configuration and build setup.
  * Updated build directory and CMake preset instructions for macOS users.
  * Introduced testing recipes with runnable examples for feature composition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/t0k0sh1/ry/pull/2014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->