### PR TITLE
chore(tooling): rename git-close-pr skill to git-finalize-pr

### DIFF
--- a/.claude/skills/commands-environment-gotchas/SKILL.md
+++ b/.claude/skills/commands-environment-gotchas/SKILL.md
@@ -90,7 +90,7 @@ The `asan` preset itself already builds with `-fno-sanitize=vptr,function`.
 
 **Why**: `--label` in `gh issue edit` is a *set* operation, not an *append*. The flag name is misleading because `gh issue create --label` is safe (empty initial state). The asymmetry bites every time you remember the create syntax and apply it to edit.
 
-**How to apply**: Use `git-claim-issue` skill for `wip` attachment (enforces `--add-label` internally). Use `git-close-pr` Step 7 for `wip` removal (enforces `--remove-label` internally). Never call `gh issue edit --label` directly for additive changes.
+**How to apply**: Use `git-claim-issue` skill for `wip` attachment (enforces `--add-label` internally). Use `git-finalize-pr` Step 7 for `wip` removal (enforces `--remove-label` internally). Never call `gh issue edit --label` directly for additive changes.
 
 ---
 
@@ -329,7 +329,7 @@ The bug only triggers when `$output` exceeds the pipe buffer (≈64 KiB on Linux
 
 ### GraphQL `viewer` is a root Query field, not a `Repository` field
 
-**Source**: PR #1937 (2026-05-28, `/git-close-pr` dogfood)
+**Source**: PR #1937 (2026-05-28, `/git-finalize-pr` dogfood)
 **Tags**: gh, graphql, viewer, query-type
 
 **Wrong**: `gh api graphql -f query='{ repository(owner: "...", name: "...") { pullRequest(number: N) { ... } } viewer { login } } }'`
@@ -343,7 +343,7 @@ The bug only triggers when `$output` exceeds the pipe buffer (≈64 KiB on Linux
 
 ### `gh pr checks --json` uses `bucket`/`state`/`link`, not `status`/`conclusion`/`detailsUrl`
 
-**Source**: PR #1937 (2026-05-28, `/git-close-pr` dogfood)
+**Source**: PR #1937 (2026-05-28, `/git-finalize-pr` dogfood)
 **Tags**: gh, pr-checks, json-fields
 
 **Wrong**: `gh pr checks <PR> --json name,status,conclusion,detailsUrl`
@@ -357,7 +357,7 @@ The bug only triggers when `$output` exceeds the pipe buffer (≈64 KiB on Linux
 
 ### `gh pr view --json mergeable` is conflict-only; `mergeStateStatus` carries CI / branch-protection state
 
-**Source**: PR #1937 (2026-05-28, `/git-close-pr` dogfood)
+**Source**: PR #1937 (2026-05-28, `/git-finalize-pr` dogfood)
 **Tags**: gh, pr-view, mergeable, merge-state-status, branch-protection
 
 **Wrong**: gating merge on `mergeable` alone — e.g. `gh pr view <PR> --json mergeable --jq .mergeable` returns `MERGEABLE` so the script proceeds, then `gh pr merge` rejects with "Pull request is not mergeable" because branch protection still requires green CI / reviews.
@@ -371,7 +371,7 @@ gh pr view <PR> --json mergeable,mergeStateStatus --jq '"\(.mergeable) \(.mergeS
 
 **Why**: `mergeable` is the merge-conflict judgment only — it returns `MERGEABLE` / `CONFLICTING` / `UNKNOWN` based on whether the base/head can be three-way merged. `mergeStateStatus` is the comprehensive UI state and exposes `CLEAN`, `HAS_HOOKS` (both ready), `BLOCKED` (required checks not green / required reviews missing / signed-commit policy), `BEHIND` (head behind base), `DIRTY` (conflicts; mirrors `mergeable: CONFLICTING`), `DRAFT`, `UNKNOWN`, `UNSTABLE` (non-required failures). CI-pending and branch-protection states show up as `BLOCKED` while `mergeable` stays `MERGEABLE`, so skipping the second check lets the merge call proceed and fail noisily. The `gh pr merge` documentation says "the merge will not happen unless the pull request is in a mergeable state" without spelling out which API field that maps to — the answer is `mergeStateStatus`, not `mergeable`.
 
-**Note (where the strict gate applies)**: This `mergeStateStatus ∈ {CLEAN, HAS_HOOKS}` gate belongs at the actual merge call (e.g. `git-close-pr` Step 6 / `gh pr merge`). Pre-check steps should distinguish structural blockers (`DIRTY` / `mergeable: CONFLICTING`) from transient states (`BLOCKED` while CI runs, `BEHIND`, `UNSTABLE`, `UNKNOWN`, `DRAFT`) that subsequent steps will resolve. See `git-close-pr` Step 1 (structural-only pre-check, warn-and-proceed for transient states) vs Step 6 (strict gate before merge). Issue #1956 (2026-05-29) — applying the strict gate at Step 1 wrongly serialized CI completion with review handling.
+**Note (where the strict gate applies)**: This `mergeStateStatus ∈ {CLEAN, HAS_HOOKS}` gate belongs at the actual merge call (e.g. `git-finalize-pr` Step 6 / `gh pr merge`). Pre-check steps should distinguish structural blockers (`DIRTY` / `mergeable: CONFLICTING`) from transient states (`BLOCKED` while CI runs, `BEHIND`, `UNSTABLE`, `UNKNOWN`, `DRAFT`) that subsequent steps will resolve. See `git-finalize-pr` Step 1 (structural-only pre-check, warn-and-proceed for transient states) vs Step 6 (strict gate before merge). Issue #1956 (2026-05-29) — applying the strict gate at Step 1 wrongly serialized CI completion with review handling.
 
 ---
 

--- a/.claude/skills/git-claim-issue/SKILL.md
+++ b/.claude/skills/git-claim-issue/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Git Claim Issue
 
-Mark a GitHub issue as in-progress by adding the `wip` label. This is the counterpart of `git-close-pr` Step 7, which removes `wip` after merge.
+Mark a GitHub issue as in-progress by adding the `wip` label. This is the counterpart of `git-finalize-pr` Step 7, which removes `wip` after merge.
 
 ## Scope (what this skill does NOT do)
 
@@ -38,7 +38,7 @@ Always use `--add-label`. **Never** use `--label` with `gh issue edit`:
 |---|---|
 | `gh issue edit <n> --label wip` | **Replaces all labels** (destructive — do NOT use) |
 | `gh issue edit <n> --add-label wip` | Appends, preserves existing labels (correct) |
-| `gh issue edit <n> --remove-label wip` | Removes only the named label (used by `git-close-pr` Step 7) |
+| `gh issue edit <n> --remove-label wip` | Removes only the named label (used by `git-finalize-pr` Step 7) |
 
 Note: `gh issue create --label foo` is safe because there are no pre-existing labels to overwrite. The destructive case applies only to `gh issue edit --label`.
 

--- a/.claude/skills/git-finalize-pr/SKILL.md
+++ b/.claude/skills/git-finalize-pr/SKILL.md
@@ -1,12 +1,12 @@
 ---
-name: git-close-pr
-description: PR finalization in one pass — addresses review comments, follows up unresolved threads, verifies CI, runs pre-commit checklist, pushes, and merges. Stops at the first blocker; never auto-loops fix→push→CI-wait. Use when the user wants to finalize a PR, "PR を仕上げる", "マージまで一気に", "指摘対応してマージ", "レビュー対応からマージまで", "close PR <number>".
+name: git-finalize-pr
+description: PR finalization in one pass — addresses review comments, follows up unresolved threads, verifies CI, runs pre-commit checklist, pushes, and merges. Stops at the first blocker; never auto-loops fix→push→CI-wait. Use when the user wants to finalize a PR, "PR を仕上げる", "マージまで一気に", "指摘対応してマージ", "レビュー対応からマージまで", "finalize PR <number>".
 allowed-tools: Bash(gh:*), Bash(git:*), Read, Edit
 metadata:
   short-description: Review → CI → push → merge in one pass
 ---
 
-# Git Close PR
+# Git Finalize PR
 
 Take a pull request end-to-end: address review comments, follow up unresolved threads, verify CI, run the pre-commit checklist, push, and merge.
 

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -248,4 +248,4 @@ Claude (メインエージェント) から起動する background 実行は #19
 
 ## 4. Label Cleanup
 
-**Do not change labels at the self-verification stage.** Label transitions happen post-merge: `git-close-pr` Step 7 removes `wip` autonomously. Do not run individual commands directly.
+**Do not change labels at the self-verification stage.** Label transitions happen post-merge: `git-finalize-pr` Step 7 removes `wip` autonomously. Do not run individual commands directly.

--- a/.claude/skills/preparing-for-release/SKILL.md
+++ b/.claude/skills/preparing-for-release/SKILL.md
@@ -8,7 +8,7 @@ metadata:
 
 # Preparing for Release
 
-Open **Release prep** + **Release** + **Release cleanup** issues under the target version's milestone (AGENTS.md "リリースワークフロー"). The skill only files issues — prep & release use the standard `git-claim-issue` → branch → PR → `git-close-pr` flow; cleanup is verification-only (`gh run list`, `gh release view`, `gh api PATCH milestone`).
+Open **Release prep** + **Release** + **Release cleanup** issues under the target version's milestone (AGENTS.md "リリースワークフロー"). The skill only files issues — prep & release use the standard `git-claim-issue` → branch → PR → `git-finalize-pr` flow; cleanup is verification-only (`gh run list`, `gh release view`, `gh api PATCH milestone`).
 
 ## Inputs
 
@@ -71,7 +71,7 @@ gh issue create \
   --body "$(cat <<'EOF'
 ## Goal
 
-Aggregate `changelog.d/` fragments into `CHANGELOG.md` and finalize the `[<X.Y.Z>] - YYYY-MM-DD` section so the release tag can be cut. Standard issue-driven flow (`git-claim-issue` → branch → PR → `git-close-pr`); the release tag itself is out of scope (sibling Release issue).
+Aggregate `changelog.d/` fragments into `CHANGELOG.md` and finalize the `[<X.Y.Z>] - YYYY-MM-DD` section so the release tag can be cut. Standard issue-driven flow (`git-claim-issue` → branch → PR → `git-finalize-pr`); the release tag itself is out of scope (sibling Release issue).
 
 ## Tasks
 

--- a/.claude/skills/release-orchestrator/SKILL.md
+++ b/.claude/skills/release-orchestrator/SKILL.md
@@ -22,6 +22,6 @@ Releases are tag-push driven. Pushing a `v*.*.*`-glob tag (e.g., `v0.0.14`) to `
    - **Release prep: v<X.Y.Z>** — assemble `changelog.d/` fragments into `CHANGELOG.md` under the `[X.Y.Z] - YYYY-MM-DD` section. Standard issue flow (claim → feature branch → PR → merge).
    - **Release: v<X.Y.Z>** — once prep merges, confirm no issues remain in the milestone and push the tag.
    - **Release cleanup: v<X.Y.Z>** — after tag push, verify `release.yml` completion and GitHub Release publication, then close the milestone (verification only — no branch/PR).
-2. Progress the Release prep issue through the normal flow (`git-claim-issue` → Plan → implement → `git-close-pr`).
+2. Progress the Release prep issue through the normal flow (`git-claim-issue` → Plan → implement → `git-finalize-pr`).
 3. After Release prep merges to main, work on the Release issue and push the tag per its instructions.
 4. After Release closes, work on the Release cleanup issue. Close the milestone only after release artifacts (tag + GitHub Release) are verified published — "all issues closed ≠ release complete." Follow the cleanup issue's steps.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,13 +81,13 @@ The runtime memory-safety rules (forbidden-function table / `oom_abort(n)` / NUL
 
 ## Workflow overview
 
-Issue review → consult the knowledge base (path-scoped rules also auto-load during implementation) → Plan mode (Task 1 = `/git-claim-issue` to attach `wip`) → TDD implementation → self-verification via `/pre-commit-checklist` → subsequent git operations (commit / push / PR / merge) follow "Separation of Concerns". If you want to chain PR review response → CI check → push → merge in a single command, use `/git-close-pr` (it stops on blockers).
+Issue review → consult the knowledge base (path-scoped rules also auto-load during implementation) → Plan mode (Task 1 = `/git-claim-issue` to attach `wip`) → TDD implementation → self-verification via `/pre-commit-checklist` → subsequent git operations (commit / push / PR / merge) follow "Separation of Concerns". If you want to chain PR review response → CI check → push → merge in a single command, use `/git-finalize-pr` (it stops on blockers).
 
 ## Issue-driven development
 
 - **Repository**: `t0k0sh1/ry`
 - **Start**: the user specifies an issue number / URL → understand the content → enter Plan mode. When instructed to "find the next issue", fetch open issues (excluding `wip`), present candidates with bugs prioritized → after selection, enter Plan mode.
-- **Label handling**: labels MUST be attached/removed via skills (`git-claim-issue` / `git-close-pr` Step 7 use `--add-label` / `--remove-label`, preserving existing labels).
+- **Label handling**: labels MUST be attached/removed via skills (`git-claim-issue` / `git-finalize-pr` Step 7 use `--add-label` / `--remove-label`, preserving existing labels).
 - **Scope verification when splitting an issue**: a decision to file or separate a derivative issue is checked via `/scope-decomposition` against symmetry (4 axes, REQ-1), split rationale (3 categories, REQ-2), derivative-chain caution (3rd-degree and beyond, REQ-3), and the single-preview-for-n-split rule when filing an oversized issue (REQ-5). Target-shrinking splits during Plan mode are prohibited by REQ-4.
 
 ## Plan mode rules
@@ -190,7 +190,7 @@ When explaining a CI failure or test failure, Claude Code MUST use one of the fo
 - Test execution
 - Self-verification
 - Documentation updates
-- Removing the `wip` label after PR merge (consolidated into `git-close-pr` Step 7. Executed autonomously immediately after merge completion, without waiting for user instruction. Issue closure is performed automatically by GitHub via the `Closes #xx` keyword. Note that this is a record of the feature landing on `main`, not a release completion — see "Release Workflow").
+- Removing the `wip` label after PR merge (consolidated into `git-finalize-pr` Step 7. Executed autonomously immediately after merge completion, without waiting for user instruction. Issue closure is performed automatically by GitHub via the `Closes #xx` keyword. Note that this is a record of the feature landing on `main`, not a release completion — see "Release Workflow").
 
 #### Handling side findings
 
@@ -226,7 +226,7 @@ The following priority order applies to side-finding triage (Q1–Q4). **The rul
 
 - **Committing/pushing is mandatory**: a fix that is not committed and pushed is not reflected in the PR. When review response is complete, if there are uncommitted changes, report them to the user without fail and encourage commit and push.
 - **Resolve decisions are delegated to the reviewer**: CodeRabbit auto-verifies reply content and resolves the conversation itself, so if Claude Code resolves preemptively, the verification flow does not work. Human reviewer comments are the same — reply only and delegate the resolve decision.
-- **Pre-merge unresolved check**: `git-close-pr` Step 6 automatically detects unresolved conversations and aborts the merge if any remain.
+- **Pre-merge unresolved check**: `git-finalize-pr` Step 6 automatically detects unresolved conversations and aborts the merge if any remain.
 
 ### Accumulating lessons from PR reviews
 


### PR DESCRIPTION
## Summary

Rename the `git-close-pr` skill to `git-finalize-pr` so the `name:` matches its actual scope — the skill already self-describes as "PR finalization in one pass" (review → CI → push → merge → `wip` removal); only `name:` diverged from reality.

- `git mv` the directory (history preserved, 98% similarity); update frontmatter `name`, body heading `# Git Finalize PR`, and the English trigger word (`close PR <number>` → `finalize PR <number>`, per issue decision).
- Swept all 16 hyphenated references across 6 files (`AGENTS.md`, `commands-environment-gotchas`, `preparing-for-release`, `git-claim-issue`, `release-orchestrator`, `pre-commit-checklist`) via horizontal-sweep bulk `sed`.
- **Polysemy carve-out**: issue-closing usages in the skill body (`Closes #<n>` / `gh issue close`) are intentionally preserved — verified via a positive guard, not just a residual grep (horizontal-sweep anti-pattern, #2027).

Side effect: the slash command changes `/git-close-pr` → `/git-finalize-pr`.

## Pre-commit checklist (skip log)

- **Skipped §2 / §3 / §3.5 / §3.5.6 / §3.6 / §3.6.5** — `.claude/` + top-level `*.md` only; no source / crate / grammar impact.
- **§1** — `AGENTS.md` self-edited as part of the rename; README / `docs/` need no update (internal skill rename, no ry-language behavior change).
- **§2.5** — no new entry: the polysemy trap is already in the horizontal-sweep anti-pattern table (#2027); the `changelog.d/` convention is already in `changelog-fragments.md`.
- **§3.7** — clean: all Bash / Explore foreground, no background execution.

Part of #2021.

Closes #2035

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated workflow documentation to reflect changes in command naming and merged pull request finalization processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->