### PR TITLE
chore(tooling): .claude/skills メタデータ整合（allowed-tools 欠如・導線・self-check grep バグ）

### DIFF
--- a/.claude/skills/git-resolve-conflicts/SKILL.md
+++ b/.claude/skills/git-resolve-conflicts/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-resolve-conflicts
-description: Resolve PR merge conflicts locally by rebasing onto main, fixing conflicts, and pushing.
+description: Resolve PR merge conflicts locally by rebasing onto main, fixing conflicts, and pushing. Also fires on Japanese triggers コンフリクト解消, 衝突解決, マージ競合を直す, リベースで解決.
 allowed-tools: Bash(git:*), Bash(gh pr view:*), Read, Edit
 metadata:
   short-description: Resolve PR conflicts locally and push

--- a/.claude/skills/git-search-issues/SKILL.md
+++ b/.claude/skills/git-search-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-search-issues
-description: Search GitHub issues by number, label, keyword, or find next issue candidates to work on.
+description: Search GitHub issues by number, label, keyword, or find next issue candidates to work on. Also fires on Japanese triggers 次の issue 探して, issue 検索, ラベルで絞り込み, 次やる issue 探す.
 allowed-tools: mcp__plugin_github_github__list_issues, mcp__plugin_github_github__search_issues, mcp__plugin_github_github__issue_read
 metadata:
   short-description: Search GitHub issues

--- a/.claude/skills/knowledge-md-management/SKILL.md
+++ b/.claude/skills/knowledge-md-management/SKILL.md
@@ -107,11 +107,12 @@ Generic mentions ("knowledge accumulates in KNOWLEDGE.md") are fine; pointing at
 Before publishing new knowledge-base docs, verify:
 
 ```bash
-grep -nE 'KNOWLEDGE(\.md)?\s*(L[0-9]+|line\s+|entry\s+(above|below|here))' \
-  AGENTS.md .claude/rules/*.md .claude/skills/*/SKILL.md .claude/agents/*.md
+grep -nE 'KNOWLEDGE(\.md)?`?\s*(L[0-9]+|line\s+|entry\s+(above|below|here))' \
+  AGENTS.md .claude/rules/*.md .claude/skills/*/SKILL.md .claude/agents/*.md \
+  | grep -vE 'L261.*#1895'   # drop the two sanctioned citations (see note below)
 ```
 
-Every hit is a violation to fix.
+Every remaining hit is a violation to fix. The `grep -vE 'L261.*#1895'` filter drops the two intentional references in AGENTS.md's terminology-prohibition section — its rule (b) and the "Handling of existing text" bullet, which deliberately cite a fixed `KNOWLEDGE.md L<n>, #<issue>` label that rule REQUIRES for searchability. They are a sanctioned exception to this external-reference policy; do not "fix" them. The `` `? `` added to the pattern catches the back-tick-wrapped `` `KNOWLEDGE.md` L<n> `` form that the bare `\s*` previously missed.
 
 ## 4. Promotion to rules / skills (REQ-4)
 

--- a/.claude/skills/ry-playground/SKILL.md
+++ b/.claude/skills/ry-playground/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: ry-playground
 description: Try Ry language code snippets for ad-hoc behavior verification. Uses heredoc with ./build/ry -c. No file creation allowed. Not for self-tests.
+allowed-tools: Bash
 metadata:
   short-description: Try Ry code snippets in a sandbox
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,7 +84,7 @@ Issue review → consult the knowledge base (path-scoped rules also auto-load du
 ## Issue-driven development
 
 - **Repository**: `t0k0sh1/ry`
-- **Start**: the user specifies an issue number / URL → understand the content → enter Plan mode. When instructed to "find the next issue", fetch open issues (excluding `wip`), present candidates with bugs prioritized → after selection, enter Plan mode.
+- **Start**: the user specifies an issue number / URL → understand the content → enter Plan mode. When instructed to "find the next issue" (`/git-search-issues`), fetch open issues (excluding `wip`), present candidates with bugs prioritized → after selection, enter Plan mode.
 - **Label handling**: labels MUST be attached/removed via skills (`git-claim-issue` / `git-finalize-pr` Step 7 use `--add-label` / `--remove-label`, preserving existing labels).
 - **Scope verification when splitting an issue**: a decision to file or separate a derivative issue is checked via `/scope-decomposition` against symmetry (4 axes, REQ-1), split rationale (3 categories, REQ-2), derivative-chain caution (3rd-degree and beyond, REQ-3), and the single-preview-for-n-split rule when filing an oversized issue (REQ-5). Target-shrinking splits during Plan mode are prohibited by REQ-4.
 


### PR DESCRIPTION
## Summary

#2021（テーマ D アンブレラ）検討中に実地確認した `.claude/skills/` の frontmatter・導線・self-check の不整合 4 件を是正。いずれもエージェント向けツール定義のメタデータで、Ry コンパイラ挙動には影響しない。

- **ry-playground**: `allowed-tools: Bash` 追加（28 skill 中唯一の欠如を是正、#1045 準拠）
- **git-search-issues**: description に日本語トリガー追加 + `AGENTS.md` §Issue-driven development に `/git-search-issues` 導線を追記
- **git-resolve-conflicts**: description に日本語トリガー（コンフリクト解消 等）追加
- **knowledge-md-management**: self-check grep が `` `KNOWLEDGE.md` `` 直後の閉じバッククォートを取りこぼす問題を修正（`` `? `` 追加）。`AGENTS.md` 用語禁止セクション rule (b) が searchability のため必須とする固定ラベル引用 2 件は `grep -vE 'L261.*#1895'` で除外し「ヒット=違反」契約を維持。注記は pattern に自己マッチしないよう `L<n>` 表記で記述。

## 検証

- 修正後 self-check: **exit 1（クリーン）** / バッククォート付き違反を捕捉 / 一般言及は非検出 / 全 28 skill frontmatter 妥当
- 除外前 grep が注記の「two」記述と一致（self-match 源を解消済み）

## pre-commit-checklist skip ログ

ドキュメント/メタデータのみ（C++/Ry コード変更なし）:

- Skipped §2 — no user-visible change
- Skipped §3 / §3.5 — no source code change
- Skipped §3.5.6 — no Rust crate change
- Skipped §3.6 — no parser/lexer/json/utf8/string/io change
- Skipped §3.6.5 — no tree-sitter grammar change
- §1 — `AGENTS.md` edit is agent-workflow internal; no docs/reference or README change needed
- §2.5 — knowledge captured directly in the edited SKILL.md; no separate entry needed
- §3.7 — no background execution this session

Closes #2032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue discovery instructions to include the available slash-command for searching issues, making it easier to find the next issue to work on.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->