### PR TITLE
chore(tooling): グローバル CLAUDE.md の LLVM 環境情報を移設・現状化 (#2034)

### DIFF
--- a/.claude/rules/codegen-llvm-ir-conventions.md
+++ b/.claude/rules/codegen-llvm-ir-conventions.md
@@ -29,6 +29,10 @@ paths:
 
 The str branch must come AFTER Set/Map/List because `isStringValue(container)` returns true for any `ptrTy_` value without collection/resource metadata. Set/Map/List headers all have `hasAnyMeta() == true` so `isStringValue` correctly excludes them; placing str earlier would fire on plain `str` RHS before collection branches even run. When RHS is `str` and LHS is `any`, unwrap with `unwrapFromAny(elem, ptrTy_)` (no `wrapInAny` direction needed — str has no element type to promote into). Other LHS types vs str RHS: emit a clear compile error.
 
+### Opaque-pointer codegen: `getUnqual` for pointer types, element-typed `CreateLoad`
+
+Under opaque pointers every codegen-emitted pointer is the untyped `ptr` (the C++ counterpart of the FileCheck-golden rule just below). Build pointer types with `PointerType::getUnqual(*ctx_)` — the cached `ptrTy_` initialized in `src/codegen.cpp` — never a typed `PointerType::get(elem, ...)`. Because a `ptr` carries no pointee type, every `CreateLoad` must pass the element type explicitly (`CreateLoad(type, ptr, name)`); the single-argument form cannot recover it. The codebase follows this uniformly — pointer construction goes through `getUnqual` and all loads are element-typed — so a stray typed pointer or single-arg load is a regression to reject, not a style choice.
+
 ### FileCheck goldens (`tests/filecheck/*.ry`)
 
 Each file is both Ry source and a FileCheck script. Use `# CHECK:` (Ry comment is `#`, never `//`). Goldens run on unoptimized IR (`alloca`/`store`/`load` for every arg are present, `mem2reg` has not run). All pointer types are `ptr` under opaque pointers — never `i64*` / `i8*`. ARC retain/release only appears in CoW clone, lambda capture, and `@parallel for` paths — pick simple goldens accordingly. Result layout: `%Result = type { i1, i64, ptr }`. Goldens are LLVM-version-sensitive — re-verify after LLVM bumps. CI job is `continue-on-error` (advisory) but fix failures before merge anyway.


### PR DESCRIPTION
## 概要

グローバル `~/.claude/CLAUDE.md`（**git 管理外・全プロジェクト常時ロード**）の ry 固有 LLVM 環境情報を git 管理下へ移設・現状化する（#2021 テーマ D）。実態と突き合わせた結果、**リポジトリに未存在だったのは opaque pointer の C++ API 規約 1 点のみ**で、これを `.claude/rules/codegen-llvm-ir-conventions.md` に独立見出しで追加した（実態を追認する現状化）。他の項目はすべて既存（より正確）または obsolete だった。

移設先の形は「既存に統合（新規ファイルを作らない）」を選択。重複排除・`paths:` auto-load の思想に合致する。

## カバレッジマップ（移設の acceptance test / グローバルブロック削除の安全性根拠）

| グローバル L10-32 の項目 | 移設後の着地先 / 判定 |
|---|---|
| バージョン `LLVM 21.1.8` | メジャー番号は `AGENTS.md` の `llvm@21` / CI イメージ `ry-ci:llvm-21` に存在。パッチ `.1.8` は意図的に不採用（下記理由）|
| インストール先 `/usr/local/llvm` | `AGENTS.md` L25 + `CMakePresets.json` default preset `LLVM_DIR` + `CMakeLists.txt` コメントに既存（より正確）→ 追記不要 |
| CMake パス（LLVM）| `CMakePresets.json` が真実ソース → 追記不要 |
| CMake パス（MLIR）| リポジトリ全体で**ゼロ参照**（`find_package(MLIR` / `MLIR_DIR` / `mlir` なし）→ 移植せず（誤情報）|
| ビルドコマンド `cmake --preset default` | `AGENTS.md` §Build & Test が macOS=`rust-emit` / 共有 libLLVM 要件 (#1997) / Homebrew `llvm@21` まで既述（グローバルの「default のみ」は macOS で誤り）→ 追記不要 |
| JIT コンポーネント一覧 `llvm_map_components_to_libnames(...)` | #1997 で `set(LLVM_LIBS LLVM)` 一本化され **obsolete** → 移植せず（下記）|
| **opaque pointer C++ API 規約** | **未存在 → `codegen-llvm-ir-conventions.md` に追加（本 PR の実変更）** |

## パッチバージョン `21.1.8` を採用しない理由

CI イメージ `ry-ci:llvm-21` と Homebrew `llvm@21` がいずれもメジャー番号を pin している。パッチ番号はビルドで強制されず、リポジトリに記録するとドリフト源になるため、既存のメジャー番号粒度に委ねる。

## カテゴリ B（JIT コンポーネント一覧）が obsolete な根拠

グローバルの `llvm_map_components_to_libnames(...)` ブロックはコンポーネント別静的リンク時代の記述。#1997 で「`ry` と Rust emit cdylib が 1 つの LLVM インスタンスを共有しないと `ConstantFP::get` がハングする」ため `set(LLVM_LIBS LLVM)`（共有 libLLVM 一本）へ移行済み（`CMakeLists.txt:85`）。後継説明は `CMakeLists.txt` のコメント + `docs/architecture/llvm-ir-emission-boundary.md` §Sub-issue 3 にある。

## 追加した規約（実変更）

`.claude/rules/codegen-llvm-ir-conventions.md` の FileCheck golden セクション（IR テキスト側の `ptr` 規約）の直前に、対になる **C++ API 側の規約**を独立見出しで追加:

- ポインタ型は `PointerType::getUnqual(*ctx_)`（キャッシュ済み `ptrTy_`）を使う
- `CreateLoad` は要素型を渡す 2 引数形式 `CreateLoad(type, ptr, name)` を使う

グローバルの「非推奨」という framing は使わず、コードベースの positive convention（実態の追認）として記述。バージョン機構の主張（「特定 LLVM バージョンで削除済み」等）は未検証のため含めない。

## 検証

- `grep`: MLIR ゼロ参照 / `set(LLVM_LIBS LLVM)` 一本 / `getUnqual(*ctx_)` のみ・`PointerType::get(` 型付き生成ゼロ・型付きポインタ IR テキスト残留ゼロ を実証
- `run-prompt-refs-lint.sh`: clean（paths / `/skill` links / KNOWLEDGE.md セクション名すべて解決）
- コード/ビルド非変更のため C++ `ry_tests` / Ry セルフテスト / ASan+UBSan / TSan / libFuzzer は非該当

## マージ後の手動作業（git 管理外のため diff に現れない）

`~/.claude/CLAUDE.md` の `## LLVM 環境（ry プロジェクト）` ブロックを手動削除する。**L5-8 の Top-Level Rules（並行実行・批判的応答）は ry 固有でない汎用ユーザー設定のため残す**。行番号は drift するためセクション見出しで指定。

Closes #2034
