### PR TITLE
fix(build): guard against orphan cdylib in dist after corrosion crate rename (#2041)

### DIFF
--- a/.claude/rules/distribution-packaging.md
+++ b/.claude/rules/distribution-packaging.md
@@ -143,3 +143,59 @@ the cdylib (the cdylib is link-time, not dlopen'd by module name).
 `@rpath` id, and `@loader_path/libLLVM` linkage, so a dropped cdylib FAILs the
 bundle gate. For self-update, `tests/test_self_update.cpp`
 `CopiesRustCdylibLibemit` writes a fake `libemit.*` and asserts it installs.
+
+### Orphan cdylib after a crate rename: exclude via the libLLVM-linkage discriminator, not `ADDITIONAL_CLEAN_FILES`
+
+**Source**: #2041 (2026-06-07; orphan left by the #2040 `ry_codegen` → `emit` rename)
+**Tags**: packaging, cdylib, corrosion, rename, orphan, libLLVM, discriminator, glob, dist
+
+**Context**: A corrosion crate rename (`ry_codegen` → `emit`, #2040; earlier
+`ry_llvm_emit` → `ry_codegen`, #2027) leaves the old cdylib
+(`libry_codegen.{so,dylib}`) as an **orphan** in a non-clean build tree. A
+non-destructive `cmake --preset` reconfigure self-heals `build.ninja` to
+`libemit` but does **not** GC the stale output (corrosion's IMPORTED cargo
+target output rides on no CMake clean tracking). The orphan then (a) confuses
+devs / invites a reflexive `rm -rf`, and (b) is shipped by `bundle-dist.sh`'s
+`libry_*` glob into the release tarball. The orphan shares the `libry_` prefix
+with the legitimate stdlib native libs (`libry_base64`, …), so it **cannot** be
+excluded by name pattern — only by an explicit discriminator.
+
+**Rule**: The emission cdylib is the **only** bundled native lib that links
+`libLLVM`; stdlib `libry_*` libs do not. Use this as a zero-drift discriminator
+(no `RY_NATIVE_LIBS` enumeration needed, catches any future cdylib-rename
+orphan):
+
+- `scripts/verify-bundle.sh` (the pre-`tar` release gate) FAILs if any bundled
+  native lib **other than `libemit`** links `libLLVM` (`otool -L` on darwin /
+  `readelf -d` NEEDED on linux). This is the structural guarantee.
+- `scripts/bundle-dist.sh` skips such orphans when copying (warns, so the stale
+  tree is surfaced) — belt-and-braces so a local dirty bundle is clean by
+  construction.
+- `.claude/skills/pre-commit-checklist/run-tests.sh` removes orphan
+  `libry_*` cdylibs from the host `$BUILD_DIR/lib` after each build (a legit
+  persistent-script `rm`, same class as its `--clean` path), so a manual
+  `--clean` is no longer needed to clear the orphan.
+
+Grep `libLLVM` **case-sensitively** against the dependency listing: it matches
+the libLLVM dependency line, never a self-name that contains lowercase `llvm`
+(e.g. a hypothetical future `libry_llvm_*`). This is the **exclusion** axis and
+is orthogonal to the #2040 entry above, which is the **inclusion** axis (list
+`libemit` separately in every selector). Scope note: pre-cutover artifacts that
+do not link `libLLVM` are out of scope (not the orphan-cdylib class, and absent
+from the CI `build` / local `build-rust` dist sources).
+
+**Rejected — `ADDITIONAL_CLEAN_FILES`**: it is regenerated from the current
+config on every configure and is therefore keyed to `libemit`; an orphan is by
+definition a name the post-rename config no longer knows, so no forward-keyed
+clean mechanism can GC it. (Corrosion IMPORTED targets also ignore CMake
+properties — see the rpath entry above — so the property likely never even
+registers.) An orphan is "a file from a *previous* configuration": only
+enumerate-and-prune, a full wipe, or a catch-at-the-boundary gate can touch it.
+
+**How to verify**: assemble a dist, plant a fake orphan that links `libLLVM`
+(`cp dist/lib/libemit.dylib dist/lib/libry_codegen.dylib`), and confirm
+`verify-bundle.sh` now exits **1** (a green run on a clean dist does not prove
+the FAIL path propagates — exercise the known-bad input, per the verify-helper
+entry above). For the sweep, plant the orphan in `$BUILD_DIR/lib` and confirm
+`run-tests.sh` removes it while leaving `libemit` and the stdlib `libry_*`
+libs intact.

--- a/.claude/skills/pre-commit-checklist/run-tests.sh
+++ b/.claude/skills/pre-commit-checklist/run-tests.sh
@@ -67,5 +67,28 @@ fi
 
 cmake --preset "$PRESET" "${CONFIGURE_ARGS[@]+"${CONFIGURE_ARGS[@]}"}"
 cmake --build "$BUILD_DIR"
+
+# Sweep orphan cdylibs (#2041): a corrosion crate rename (libry_codegen -> libemit,
+# #2040) leaves the old cdylib in $BUILD_DIR/lib. A non-destructive reconfigure
+# self-heals build.ninja to libemit but does NOT GC the stale output, so without
+# --clean the orphan lingers (confusing, and bundle-dist would ship it). The cdylib
+# is the ONLY native lib that links libLLVM — stdlib libry_* libs do not — and
+# libemit is outside the libry_* glob, so any libry_* that links libLLVM is an
+# orphan former-cdylib. rm here is a persistent, reviewed script deletion (same
+# class as the --clean rm above), not an ad-hoc cleanup.
+_links_libllvm() {
+  case "$(uname -s)" in
+    Darwin) otool -L "$1" 2>/dev/null | grep -q 'libLLVM' ;;
+    *)      readelf -d "$1" 2>/dev/null | grep -q 'NEEDED.*libLLVM' ;;
+  esac
+}
+for f in "$BUILD_DIR"/lib/libry_*.dylib "$BUILD_DIR"/lib/libry_*.so; do
+  [[ -e "$f" ]] || continue
+  if _links_libllvm "$f"; then
+    echo "==> removing orphan cdylib $(basename "$f") (links libLLVM but is not libemit; #2041)" >&2
+    rm -f "$f"
+  fi
+done
+
 "./$BUILD_DIR/ry_tests"
 "./$BUILD_DIR/ry" test -p

--- a/changelog.d/2041-orphan-cdylib-dist-guard.md
+++ b/changelog.d/2041-orphan-cdylib-dist-guard.md
@@ -1,0 +1,18 @@
+### Fixed
+
+- A corrosion crate rename (`ry_codegen` → `emit`, #2040) leaves the old
+  cdylib (`libry_codegen.{so,dylib}`) as an orphan in a non-clean build
+  tree: a non-destructive `cmake` reconfigure self-heals `build.ninja` to
+  `libemit` but does not garbage-collect the stale output, and
+  `bundle-dist.sh`'s `libry_*` glob would then ship the dead cdylib in the
+  release tarball. The packaging path now guards against this structurally
+  using a zero-drift discriminator — the emission cdylib is the only native
+  lib that links `libLLVM`, while stdlib `libry_*` libs do not:
+  `scripts/verify-bundle.sh` (the pre-`tar` release gate) now FAILs if any
+  bundled native lib other than `libemit` links `libLLVM`,
+  `scripts/bundle-dist.sh` skips such orphans when copying (with a warning),
+  and `.claude/skills/pre-commit-checklist/run-tests.sh` removes them from
+  the host build tree after each build so a manual `--clean` is no longer
+  required to clear the orphan. `ADDITIONAL_CLEAN_FILES` was intentionally
+  not used: it is keyed to the current target name and cannot retroactively
+  GC a renamed-away output. (#2041)

--- a/scripts/bundle-dist.sh
+++ b/scripts/bundle-dist.sh
@@ -51,8 +51,31 @@ cp "$BUILD_DIR/ry" "$DIST_DIR/ry"
 # build tree. libemit is matched separately from the libry_* glob: it was renamed
 # from libry_codegen to libemit (#2040), so it no longer starts with libry_.
 shopt -s nullglob
-native_libs=("$BUILD_DIR"/lib/libemit.* "$BUILD_DIR"/lib/libry_*.*)
+candidate_libs=("$BUILD_DIR"/lib/libemit.* "$BUILD_DIR"/lib/libry_*.*)
 shopt -u nullglob
+
+# Drop orphan cdylibs (#2041): a corrosion crate rename (libry_codegen -> libemit,
+# #2040) can leave the old cdylib in a non-clean build tree, and the libry_* glob
+# would ship it. The cdylib is the ONLY native lib that links libLLVM — stdlib
+# libry_* libs do not — so skip any non-libemit lib that links libLLVM (warn so the
+# stale build tree is surfaced). verify-bundle.sh asserts this same invariant.
+links_libllvm() {
+    case "$PLATFORM" in
+        darwin) otool -L "$1" 2>/dev/null | grep -q 'libLLVM' ;;
+        linux)  readelf -d "$1" 2>/dev/null | grep -q 'NEEDED.*libLLVM' ;;
+        *) return 1 ;;
+    esac
+}
+native_libs=()
+for f in "${candidate_libs[@]}"; do
+    base="$(basename "$f")"
+    if [[ "$base" != libemit.* ]] && links_libllvm "$f"; then
+        log "skipping orphan cdylib $base (links libLLVM but is not libemit; #2041)"
+        continue
+    fi
+    native_libs+=("$f")
+done
+
 if [[ ${#native_libs[@]} -eq 0 ]]; then
     echo "::warning::bundle-dist: no native libs at $BUILD_DIR/lib/{libemit,libry_*}.*" >&2
 else

--- a/scripts/verify-bundle.sh
+++ b/scripts/verify-bundle.sh
@@ -98,6 +98,29 @@ darwin)
     want   "libemit -> @loader_path/libLLVM" '@loader_path/libLLVM\.dylib'    "$emit_deps"
     absent "libemit no absolute LLVM/build-tree ref" 'llvm@21|build-rust|cargo/build' "$emit_deps"
 
+    # Orphan cdylib guard (#2041): a corrosion crate rename (libry_codegen -> libemit,
+    # #2040) leaves the old cdylib in a non-clean build tree, and bundle-dist's libry_*
+    # glob would ship it. The cdylib is the ONLY bundled native lib that links libLLVM
+    # — stdlib libry_* libs do not — so any non-libemit lib in lib/ that links libLLVM
+    # is an orphan. Case-sensitive 'libLLVM' matches the dependency line, never a
+    # self-name containing lowercase 'llvm' (e.g. a future libry_llvm_*).
+    orphan_cdylibs=""
+    for f in "$LIB"/lib*.dylib; do
+        [[ -e "$f" ]] || continue
+        base="$(basename "$f")"
+        case "$base" in libLLVM.dylib|libzstd.*|libemit.*) continue ;; esac
+        if otool -L "$f" 2>/dev/null | grep -q 'libLLVM'; then
+            orphan_cdylibs+="$base"$'\n'
+        fi
+    done
+    if [[ -n "$orphan_cdylibs" ]]; then
+        echo "  FAIL: orphan cdylib(s) in lib/ link libLLVM but are not libemit (#2041):" >&2
+        printf '%s' "$orphan_cdylibs" | sed 's/^/      /' >&2
+        fail=1
+    else
+        echo "  ok: lib/ has no orphan cdylib (only libemit links libLLVM)"
+    fi
+
     want "libzstd id = @rpath/libzstd.1.dylib" '@rpath/libzstd\.1\.dylib' "$(otool -D "$LIB/libzstd.1.dylib" 2>/dev/null || true)"
 
     # ad-hoc signatures must be valid after install_name_tool rewrites
@@ -124,6 +147,27 @@ linux)
         fail=1
     fi
     ls "$LIB"/libemit.so >/dev/null 2>&1 && echo "  ok: present libemit.so" || { echo "  FAIL: missing libemit.so" >&2; fail=1; }
+
+    # Orphan cdylib guard (#2041): see the darwin branch. On Linux the cdylib NEEDs
+    # libLLVM.so.X (stdlib libry_* do not); libzstd is a system lib (not bundled), so
+    # only libLLVM* and libemit* are excluded. A leftover libry_codegen.so from a
+    # pre-rename build tree would be caught here before tar.
+    orphan_cdylibs=""
+    for f in "$LIB"/lib*.so*; do
+        [[ -e "$f" ]] || continue
+        base="$(basename "$f")"
+        case "$base" in libLLVM.so*|libemit.so*) continue ;; esac
+        if readelf -d "$f" 2>/dev/null | grep -q 'NEEDED.*libLLVM'; then
+            orphan_cdylibs+="$base"$'\n'
+        fi
+    done
+    if [[ -n "$orphan_cdylibs" ]]; then
+        echo "  FAIL: orphan cdylib(s) in lib/ NEED libLLVM but are not libemit (#2041):" >&2
+        printf '%s' "$orphan_cdylibs" | sed 's/^/      /' >&2
+        fail=1
+    else
+        echo "  ok: lib/ has no orphan cdylib (only libemit needs libLLVM)"
+    fi
 
     ry_dyn="$(readelf -d "$RY" 2>/dev/null || true)"
     # CMake emits DT_RUNPATH (new dtags); accept either RUNPATH or RPATH.


### PR DESCRIPTION
## 概要

corrosion クレート rename (`ry_codegen` → `emit`, #2040) で非クリーンな build tree に残る **orphan cdylib** が release tarball に混入し得る問題を構造的に修正。判別軸は実測で確定した **「libLLVM をリンクする native lib は `libemit` ただ1つ」**（stdlib `libry_*` はリンクしない）— `RY_NATIVE_LIBS` 列挙不要・drift ゼロ・fail-closed。

- **`scripts/verify-bundle.sh`**（pre-`tar` リリースゲート）: `libemit` 以外で libLLVM をリンクする bundled lib があれば FAIL（darwin=`otool -L` / linux=`readelf -d` NEEDED、case-sensitive `libLLVM`）。
- **`scripts/bundle-dist.sh`**: copy 時に orphan を skip + warn（ローカル dist を構築時クリーンに）。
- **`.claude/skills/pre-commit-checklist/run-tests.sh`**: build 後に host build dir の orphan を sweep（永続スクリプト内の正当な `rm`）→ 手動 `--clean` 不要に。

`ADDITIONAL_CLEAN_FILES` は forward-keyed（現行ターゲット名にしかキーされない）で rename orphan を retroactive に GC できないため不採用（理由を `.claude/rules/distribution-packaging.md` に記録）。

## 検証
- **実物の orphan を実測**: `build-docker/lib/libry_codegen.so` が `NEEDED [libLLVM.so.21.1]` を持つ → discriminator が確実に捕捉。control `libry_json.so` は NEED せず。grep パターンが実 `readelf -d` 出力にマッチ（Linux RED パス実測）。
- **FAIL パス実証**（darwin）: orphan 植込み dist → **exit 1**、クリーン dist → **exit 0**。
- **`run-tests.sh` フル実行**: C++ **2531 tests PASSED** + Ry セルフテスト全 pass、orphan のみ除去・`libemit`/stdlib 健在。
- **prompt-refs lint** クリーン、**shellcheck** 追加コードに指摘なし。

## pre-commit-checklist skip ログ
- `Skipped §3.5 Sanitizer` / `§3.5.5 Static Analysis(C++)` — C++ runtime 非変更（shellcheck を該当ツールとして実施・クリーン）
- `Skipped §3.5.6 Rust Lint` — `crates/` 非変更
- `Skipped §3.6 libFuzzer` — parser/lexer/json/utf8/string/io 非変更
- `Skipped §3.6.5 tree-sitter` — grammar 非変更

Closes #2041


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inclusion of orphaned native library artifacts in distribution tarballs that could occur after non-clean builds
  * Added detection and removal of stale libraries during the packaging and verification process to ensure clean releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->