### PR TITLE
chore(tooling): grill-me skill を追加

### DIFF
--- a/.claude/skills/grill-me/SKILL.md
+++ b/.claude/skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.


### PR DESCRIPTION
## 概要

`grill-me` skill を追加します。

plan / design についてユーザーを徹底的にインタビューし、決定木の各分岐を一つずつ解決して共通理解に到達するための context-triggered skill です。

## 詳細

- `description` マッチ（"grill me"、プランの stress-test 等）または `/grill-me` で起動。
- 質問は一問ずつ提示し、各質問に推奨回答を添える。
- コードベースで答えられる質問は探索で解決する。

紐付く issue はありません（skill 追加のみ）。