### PR TITLE
feat(stdlib): add parseInt / parseFloat returning Result (#1772)

### DIFF
--- a/changelog.d/1772-parse-int-float.md
+++ b/changelog.d/1772-parse-int-float.md
@@ -1,0 +1,3 @@
+### Added
+
+- Added `parseInt(value: str) -> Result<int, Error>` and `parseFloat(value: str) -> Result<float, Error>` as explicit fallible string-parsing APIs. They mirror the parsing behavior of `toInt` / `toFloat` (which are unchanged) and emit `parseInt:` / `parseFloat:` prefixed diagnostics, providing a safe replacement path before any future rename of `toInt` / `toFloat`. (#1772)

--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -64,6 +64,8 @@ A list of operation functions for strings (`str`). All functions support UFCS no
 |------|-----------|------|
 | `toInt` | `str -> Result<int, Error>` | Convert string to integer |
 | `toFloat` | `str -> Result<float, Error>` | Convert string to floating-point number |
+| `parseInt` | `str -> Result<int, Error>` | Parse string to integer (fallible) |
+| `parseFloat` | `str -> Result<float, Error>` | Parse string to floating-point number (fallible) |
 | `toStr` | `any -> str` | Convert value to string |
 
 ---
@@ -429,6 +431,59 @@ case "2.5".toFloat():
 print(toFloat("abc"))         # Err(Error("toFloat: invalid character in 'abc'"))
 print(toFloat(""))            # Err(Error("toFloat: empty string"))
 print(toFloat("1e400"))       # Err(Error("toFloat: out of range in '1e400'"))
+```
+
+---
+
+## parseInt
+
+**Signature:** `parseInt(string: str) -> Result<int, Error>`
+
+Parses a string to an integer, returning `Result`. Same parsing behavior as `toInt` under an explicit "parse" name: leading whitespace is allowed, and it returns `Err` if the string is empty, contains invalid characters, or overflows. Error messages are prefixed with `parseInt:`.
+
+```ry
+case parseInt("42"):
+    Ok(v):
+        print(v)              # 42
+    Err(e):
+        print(e.message)
+
+case "123".parseInt():
+    Ok(v):
+        print(v)              # 123
+    Err(e):
+        print(e.message)
+
+# Invalid input returns Err
+print(parseInt("abc"))          # Err(Error("parseInt: invalid character in 'abc'"))
+print(parseInt(""))             # Err(Error("parseInt: empty string"))
+```
+
+---
+
+## parseFloat
+
+**Signature:** `parseFloat(string: str) -> Result<float, Error>`
+
+Parses a string to a floating-point number, returning `Result`. Same parsing behavior as `toFloat` under an explicit "parse" name: returns `Err` if the string is empty, contains invalid characters, or is out of range for `float`. Error messages are prefixed with `parseFloat:`.
+
+```ry
+case parseFloat("3.14"):
+    Ok(v):
+        print(v)              # 3.14
+    Err(e):
+        print(e.message)
+
+case "2.5".parseFloat():
+    Ok(v):
+        print(v)              # 2.5
+    Err(e):
+        print(e.message)
+
+# Invalid input returns Err
+print(parseFloat("abc"))         # Err(Error("parseFloat: invalid character in 'abc'"))
+print(parseFloat(""))            # Err(Error("parseFloat: empty string"))
+print(parseFloat("1e400"))       # Err(Error("parseFloat: out of range in '1e400'"))
 ```
 
 ---

--- a/docs/reference/builtins.md
+++ b/docs/reference/builtins.md
@@ -139,7 +139,7 @@ All functions accept `int` or any low-level integer type (`i8`..`i64`, `u8`..`u6
 | `reverse(string)` | Reverse a string |
 | `split(string, delimiter = " ")` | Split a string into a list |
 | `join(list, sep)` | Join list elements with a separator |
-| `toInt(s)` / `toFloat(s)` / `toStr(v)` | Type conversion (`toInt` and `toFloat` return `Result<T, Error>`) |
+| `toInt(s)` / `toFloat(s)` / `parseInt(s)` / `parseFloat(s)` / `toStr(v)` | Type conversion (`toInt` / `toFloat` / `parseInt` / `parseFloat` return `Result<T, Error>`) |
 
 -> See **[String Operation Function Reference](builtins-string.md)** for details
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -47,7 +47,7 @@ See [Module Reference — Visibility](modules.md#visibility) for the practical v
 
 ## stdlib (`std`)
 
-The **standard library**, also written `std`. A collection of built-in modules — including `math`, `io`, `path`, `filesystem`, `thread`, `regex`, and others — that is automatically imported into every program. The stdlib provides core types, conversion helpers (`toInt`, `toStr`, `toFloat`, `toBool`), built-in functions (`print`, `len`, `range`), and common utilities.
+The **standard library**, also written `std`. A collection of built-in modules — including `math`, `io`, `path`, `filesystem`, `thread`, `regex`, and others — that is automatically imported into every program. The stdlib provides core types, conversion helpers (`toInt`, `toStr`, `toFloat`, `toBool`, `parseInt`, `parseFloat`), built-in functions (`print`, `len`, `range`), and common utilities.
 
 The entire stdlib forms a single package — `share/std/package.toml` is its package root. Stdlib modules can therefore reference each other's package-internal helpers freely, while user code only sees `@public` stdlib symbols.
 

--- a/docs/reference/modules.md
+++ b/docs/reference/modules.md
@@ -253,7 +253,7 @@ Importing a non-`@public` symbol from another package is a compile error. Wildca
 The standard library (`std`) is a collection of built-in modules automatically imported into every program. It provides:
 - Built-in functions (`print`, `len`, `range`, etc.)
 - String functions (`contains`, `find`, `replace`, etc.)
-- Type conversion functions (`toInt`, `toFloat`, `toStr`)
+- Type conversion functions (`toInt`, `toFloat`, `parseInt`, `parseFloat`, `toStr`)
 - Collection functions (`map`, `filter`, `sort`, etc.)
 
 The entire standard library forms a single package — `share/std/package.toml` is its package root. Stdlib modules can therefore share package-internal helpers across files; user code only sees the symbols marked `@public`. An import such as `from math import sqrt` resolves to a `@public` symbol exposed by the stdlib package.

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -305,9 +305,7 @@ b: int? = none
 print(a ?? 0)    # 10
 print(b ?? 0)    # 0
 
-fn parseInt(s: str) -> Result<int, Error>:
-    # ...
-
+# parseInt is a stdlib builtin returning Result<int, Error>
 i = parseInt("42") ?? -1      # 42 on success, -1 on Err
 j = parseInt("nope") ?? -1    # -1 — the Err value is discarded
 ```

--- a/include/ry/builtin_names.hpp
+++ b/include/ry/builtin_names.hpp
@@ -48,6 +48,8 @@ inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames 
     "map",
     "max",
     "min",
+    "parseFloat",
+    "parseInt",
     "pop",
     "print",
     "range",

--- a/share/std/convert.ry
+++ b/share/std/convert.ry
@@ -7,6 +7,17 @@ fn toInt(value: str) -> Result<int, Error>
 @native
 fn toFloat(value: str) -> Result<float, Error>
 
+# Fallible string-parsing functions. These provide the same parsing behavior
+# as toInt / toFloat under explicit "parse" names (see #1772); the runtime
+# emits parseInt: / parseFloat: prefixed diagnostics.
+@public
+@native
+fn parseInt(value: str) -> Result<int, Error>
+
+@public
+@native
+fn parseFloat(value: str) -> Result<float, Error>
+
 @public
 @native
 fn toStr(value: int) -> str

--- a/src/codegen_call.cpp
+++ b/src/codegen_call.cpp
@@ -50,6 +50,48 @@ llvm::Value *CodeGen::emitBuiltinConversion(const CallExpr &e) {
             [&]() { return buildErrValue(buildErrorFromRuntime("__ry_convert_get_last_error"), resTy); });
     }
 
+    // parseInt(s) → Result<int, Error>  (#1772: explicit fallible-parse name)
+    if (e.callee == "parseInt") {
+        requireArgs(e, 1);
+        llvm::Value *s = emitExpr(*e.args[0]);
+        if (s->getType() != ptrTy_)
+            codegenError("parseInt() requires str argument");
+        llvm::AllocaInst *outSlot = builder_.CreateAlloca(i64Ty_, nullptr, "parse_int_out");
+        auto fn = getRuntimeFn("__ry_str_parse_int", i64Ty_, {ptrTy_, ptrTy_});
+        used_native_libraries_.insert("convert");
+        llvm::Value *status = builder_.CreateCall(fn, {s, outSlot}, "parse_int_status");
+        llvm::Value *isErr = builder_.CreateICmpNE(status,
+            llvm::ConstantInt::get(i64Ty_, 0), "parse_int_err");
+        llvm::StructType *resTy = getResultType(i64Ty_, errorTy_);
+        return emitResultBranch(isErr, resTy,
+            [&]() {
+                llvm::Value *loaded = builder_.CreateLoad(i64Ty_, outSlot, "parse_int_val");
+                return buildOkValue(loaded, resTy);
+            },
+            [&]() { return buildErrValue(buildErrorFromRuntime("__ry_convert_get_last_error"), resTy); });
+    }
+
+    // parseFloat(s) → Result<float, Error>  (#1772: explicit fallible-parse name)
+    if (e.callee == "parseFloat") {
+        requireArgs(e, 1);
+        llvm::Value *s = emitExpr(*e.args[0]);
+        if (s->getType() != ptrTy_)
+            codegenError("parseFloat() requires str argument");
+        llvm::AllocaInst *outSlot = builder_.CreateAlloca(f64Ty_, nullptr, "parse_float_out");
+        auto fn = getRuntimeFn("__ry_str_parse_float", i64Ty_, {ptrTy_, ptrTy_});
+        used_native_libraries_.insert("convert");
+        llvm::Value *status = builder_.CreateCall(fn, {s, outSlot}, "parse_float_status");
+        llvm::Value *isErr = builder_.CreateICmpNE(status,
+            llvm::ConstantInt::get(i64Ty_, 0), "parse_float_err");
+        llvm::StructType *resTy = getResultType(f64Ty_, errorTy_);
+        return emitResultBranch(isErr, resTy,
+            [&]() {
+                llvm::Value *loaded = builder_.CreateLoad(f64Ty_, outSlot, "parse_float_val");
+                return buildOkValue(loaded, resTy);
+            },
+            [&]() { return buildErrValue(buildErrorFromRuntime("__ry_convert_get_last_error"), resTy); });
+    }
+
     // toStr(v) → str
     if (e.callee == "toStr") {
         requireArgs(e, 1);

--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -596,7 +596,7 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 return typeTy_;
             if (c == "len")
                 return i64Ty_;
-            if (c == "toInt")
+            if (c == "toInt" || c == "parseInt")
                 return getResultType(i64Ty_, errorTy_);
             if (c == "find")
                 return getOptionType(i64Ty_);
@@ -610,7 +610,7 @@ llvm::Type *CodeGen::inferExprType(const ExprNode &expr,
                 }
                 return i64Ty_; // conservative default; codegen uses actual element type
             }
-            if (c == "toFloat")
+            if (c == "toFloat" || c == "parseFloat")
                 return getResultType(f64Ty_, errorTy_);
             if (c == "contains" || c == "startsWith" || c == "endsWith" ||
                 c == "hasKey" || c == "any" || c == "all" || c == "isEmpty")

--- a/src/runtime/native/convert.cpp
+++ b/src/runtime/native/convert.cpp
@@ -9,9 +9,12 @@ namespace ry {
 
 DEFINE_LAST_ERROR(convert)
 
-extern "C" int64_t __ry_str_to_int(const char *str, int64_t *out) {
+// Shared parsing core for the integer converters. `label` selects the
+// diagnostic prefix so each public entry point (toInt / parseInt) owns its
+// own error messages while sharing one parsing implementation.
+static int64_t parse_int_impl(const char *str, int64_t *out, const char *label) {
     if (!str || *str == '\0') {
-        setLastError("toInt: empty string");
+        setLastError("%s: empty string", label);
         return 1;
     }
 
@@ -20,11 +23,11 @@ extern "C" int64_t __ry_str_to_int(const char *str, int64_t *out) {
     long long val = strtoll(str, &end, 10);
 
     if (errno == ERANGE) {
-        setLastError("toInt: overflow in '%s'", str);
+        setLastError("%s: overflow in '%s'", label, str);
         return 1;
     }
     if (end == str || *end != '\0') {
-        setLastError("toInt: invalid character in '%s'", str);
+        setLastError("%s: invalid character in '%s'", label, str);
         return 1;
     }
 
@@ -32,9 +35,10 @@ extern "C" int64_t __ry_str_to_int(const char *str, int64_t *out) {
     return 0;
 }
 
-extern "C" int64_t __ry_str_to_float(const char *str, double *out) {
+// Shared parsing core for the float converters; see parse_int_impl.
+static int64_t parse_float_impl(const char *str, double *out, const char *label) {
     if (!str || *str == '\0') {
-        setLastError("toFloat: empty string");
+        setLastError("%s: empty string", label);
         return 1;
     }
 
@@ -43,16 +47,32 @@ extern "C" int64_t __ry_str_to_float(const char *str, double *out) {
     double val = strtod(str, &end);
 
     if (errno == ERANGE) {
-        setLastError("toFloat: out of range in '%s'", str);
+        setLastError("%s: out of range in '%s'", label, str);
         return 1;
     }
     if (end == str || *end != '\0') {
-        setLastError("toFloat: invalid character in '%s'", str);
+        setLastError("%s: invalid character in '%s'", label, str);
         return 1;
     }
 
     *out = val;
     return 0;
+}
+
+extern "C" int64_t __ry_str_to_int(const char *str, int64_t *out) {
+    return parse_int_impl(str, out, "toInt");
+}
+
+extern "C" int64_t __ry_str_to_float(const char *str, double *out) {
+    return parse_float_impl(str, out, "toFloat");
+}
+
+extern "C" int64_t __ry_str_parse_int(const char *str, int64_t *out) {
+    return parse_int_impl(str, out, "parseInt");
+}
+
+extern "C" int64_t __ry_str_parse_float(const char *str, double *out) {
+    return parse_float_impl(str, out, "parseFloat");
 }
 
 } // namespace ry

--- a/tests/spec/native_first_class.test.ry
+++ b/tests/spec/native_first_class.test.ry
@@ -6,7 +6,7 @@
 
 from testing import it, describe, expect, fail
 
-from convert import toInt
+from convert import toInt, parseInt, parseFloat
 
 @describe("@native first-class — direct assignment (single-overload)")
 fn nativeFirstClassDirectAssignmentSingleOverloadTests():
@@ -72,3 +72,43 @@ fn nativeFirstClassExplicitImportPathTests():
     case f("99"):
       Ok(v): expect(v).toEq(99)
       Err(e): fail("toInt failed: " + e.message)
+
+@describe("@native first-class — parseInt / parseFloat (#1772)")
+fn nativeFirstClassParseTests():
+  @it("binds parseInt to a variable and invokes it")
+  fn bindsParseintToAVariableAndInvokesIt():
+    f = parseInt
+    case f("42"):
+      Ok(v): expect(v).toEq(42)
+      Err(e): fail("parseInt failed: " + e.message)
+
+  @it("returns Err with the parseInt prefix through the bound variable")
+  fn returnsErrWithTheParseintPrefixThroughTheBoundVariable():
+    f = parseInt
+    case f("not-a-number"):
+      Ok(v): fail("expected Err, got Ok(" + toStr(v) + ")")
+      Err(e): expect(e.message).toContain("parseInt")
+
+  @it("xs.map(parseInt) routes the @native through stdlib map")
+  fn xsMapParseintRoutesTheNativeThroughStdlibMap():
+    xs: List<str> = ["1", "2", "3"]
+    results = xs.map(parseInt)
+    expect(len(results)).toEq(3)
+    case results[0]:
+      Ok(v): expect(v).toEq(1)
+      Err(e): fail("parseInt[0] failed: " + e.message)
+    case results[2]:
+      Ok(v): expect(v).toEq(3)
+      Err(e): fail("parseInt[2] failed: " + e.message)
+
+  @it("xs.map(parseFloat) infers Result<float, Error> through stdlib map")
+  fn xsMapParsefloatInfersResultFloatThroughStdlibMap():
+    xs: List<str> = ["1.5", "2.5"]
+    results = xs.map(parseFloat)
+    expect(len(results)).toEq(2)
+    case results[0]:
+      Ok(v): expect(v).toEq(1.5)
+      Err(e): fail("parseFloat[0] failed: " + e.message)
+    case results[1]:
+      Ok(v): expect(v).toEq(2.5)
+      Err(e): fail("parseFloat[1] failed: " + e.message)

--- a/tests/spec/strings.test.ry
+++ b/tests/spec/strings.test.ry
@@ -407,6 +407,78 @@ fn typeConversionTests():
     expect(toStr(true)).toEq("true")
     expect(toStr(99)).toEq("99")
 
+@describe("parse conversion")
+fn parseConversionTests():
+  @it("should return Ok for valid parseInt input")
+  fn shouldReturnOkForValidParseintInput():
+    case parseInt("42"):
+      Ok(v):
+        expect(v).toEq(42)
+      Err(_):
+        expect(false).toEq(true)
+    case parseInt("-7"):
+      Ok(v):
+        expect(v).toEq(-7)
+      Err(_):
+        expect(false).toEq(true)
+    expect(parseInt("123")).toBeOk()
+    expect(parseInt("0")).toBeOk()
+  @it("should return Err for invalid parseInt input")
+  fn shouldReturnErrForInvalidParseintInput():
+    expect(parseInt("abc")).toBeErr()
+    expect(parseInt("")).toBeErr()
+    expect(parseInt("12abc")).toBeErr()
+    expect(parseInt("9223372036854775808")).toBeErr()
+    expect(parseInt("-9223372036854775809")).toBeErr()
+  @it("should return Result from parseInt via UFCS")
+  fn shouldReturnResultFromParseintViaUfcs():
+    case "99".parseInt():
+      Ok(v):
+        expect(v).toEq(99)
+      Err(_):
+        expect(false).toEq(true)
+  @it("should carry the parseInt prefix in the error message")
+  fn shouldCarryTheParseintPrefixInTheErrorMessage():
+    case parseInt("abc"):
+      Ok(_):
+        expect(false).toEq(true)
+      Err(e):
+        expect(e.message).toContain("parseInt")
+  @it("should return Ok for valid parseFloat input")
+  fn shouldReturnOkForValidParsefloatInput():
+    case parseFloat("3.14"):
+      Ok(v):
+        expect(v).toEq(3.14)
+      Err(_):
+        expect(false).toEq(true)
+    case parseFloat("-0.5"):
+      Ok(v):
+        expect(v).toEq(-0.5)
+      Err(_):
+        expect(false).toEq(true)
+    expect(parseFloat("2.5")).toBeOk()
+    expect(parseFloat("0")).toBeOk()
+  @it("should return Err for invalid parseFloat input")
+  fn shouldReturnErrForInvalidParsefloatInput():
+    expect(parseFloat("xyz")).toBeErr()
+    expect(parseFloat("")).toBeErr()
+    expect(parseFloat("1.2abc")).toBeErr()
+    expect(parseFloat("1e400")).toBeErr()
+  @it("should return Result from parseFloat via UFCS")
+  fn shouldReturnResultFromParsefloatViaUfcs():
+    case "3.14".parseFloat():
+      Ok(v):
+        expect(v).toEq(3.14)
+      Err(_):
+        expect(false).toEq(true)
+  @it("should carry the parseFloat prefix in the error message")
+  fn shouldCarryTheParsefloatPrefixInTheErrorMessage():
+    case parseFloat("xyz"):
+      Ok(_):
+        expect(false).toEq(true)
+      Err(e):
+        expect(e.message).toContain("parseFloat")
+
 @describe("NUL byte handling")
 fn nulByteHandlingTests():
   @it("byteLen counts embedded NUL bytes")

--- a/tests/test_codegen_collection.cpp
+++ b/tests/test_codegen_collection.cpp
@@ -431,6 +431,71 @@ case s.toFloat():
 )"), "2.5\n");
 }
 
+TEST_F(CodeGenTest, StringParseInt) {
+    auto checkParseInt = [&](const char *input, const char *expected) {
+        std::string src = "case parseInt(\"";
+        src += input;
+        src += "\"):\n    Ok(v):\n        print(v)\n    Err(e):\n        print(\"err\")";
+        EXPECT_EQ(runSource(src), expected);
+    };
+    // Valid input returns Ok
+    checkParseInt("42", "42\n");
+    checkParseInt("-7", "-7\n");
+    checkParseInt("0", "0\n");
+    // Invalid input returns Err
+    checkParseInt("abc", "err\n");
+    checkParseInt("", "err\n");
+    checkParseInt("12abc", "err\n");
+    // Overflow returns Err
+    checkParseInt("9223372036854775808", "err\n");
+    checkParseInt("-9223372036854775809", "err\n");
+    // UFCS
+    EXPECT_EQ(runSource(R"(
+s = "123"
+case s.parseInt():
+    Ok(v):
+        print(v)
+    Err(e):
+        print("err")
+)"), "123\n");
+}
+
+TEST_F(CodeGenTest, StringParseFloat) {
+    auto checkParseFloat = [&](const char *input, const char *expected) {
+        std::string src = "case parseFloat(\"";
+        src += input;
+        src += "\"):\n    Ok(v):\n        print(v)\n    Err(e):\n        print(\"err\")";
+        EXPECT_EQ(runSource(src), expected);
+    };
+    // Valid input returns Ok
+    checkParseFloat("3.14", "3.14\n");
+    checkParseFloat("42", "42.0\n");
+    checkParseFloat("-0.5", "-0.5\n");
+    checkParseFloat("0", "0.0\n");
+    // Invalid input returns Err
+    checkParseFloat("abc", "err\n");
+    checkParseFloat("", "err\n");
+    checkParseFloat("1.2abc", "err\n");
+    // Overflow returns Err
+    checkParseFloat("1e400", "err\n");
+    // UFCS
+    EXPECT_EQ(runSource(R"(
+s = "2.5"
+case s.parseFloat():
+    Ok(v):
+        print(v)
+    Err(e):
+        print("err")
+)"), "2.5\n");
+}
+
+// #1772: parseInt / parseFloat reject a non-str argument at compile time,
+// mirroring toInt / toFloat. Locks in the dedicated rejection branch.
+TEST_F(CodeGenTest, ParseConvertRejectsNonStringArg) {
+    EXPECT_THROW(runSource("print(parseInt(42))"), std::runtime_error);
+    EXPECT_THROW(runSource("print(parseFloat(42))"), std::runtime_error);
+}
+
 TEST_F(CodeGenTest, ToStrVariants) {
     // ToStrInt
     EXPECT_EQ(runSource("print(toStr(42))"), "42\n");


### PR DESCRIPTION
## Summary

Add explicit fallible string-parsing APIs `parseInt(value: str) -> Result<int, Error>` and `parseFloat(value: str) -> Result<float, Error>`, mirroring the parsing behavior of `toInt` / `toFloat` (left **unchanged**) under explicit "parse" names. A shared `parse_int_impl` / `parse_float_impl` core backs all four entry points, with `label`-selected diagnostic prefixes (`parseInt:` / `parseFloat:`). Supports direct-call, UFCS, and first-class (`xs.map(parseInt)`) forms; `parseInt` / `parseFloat` are now reserved builtin names.

This lands the safe replacement path before any future rename of `toInt` / `toFloat` (per #1772 Follow-up).

## Self-verification

- C++ tests: **2534 passed**
- Ry self-tests: **203 files, 0 failures**
- ASan+UBSan: **PASS** (no findings)
- TSan: **PASS** (C++ run clean, `ConcurrencySpecSuite` green)
- Static analysis: clang-tidy / cppcheck / scan-build all **PASS**

Skipped §3.5.6 — no Rust crate change
Skipped §3.5.7 — no prompt-definition change
Skipped §3.6 — no parser/lexer/json/utf8/string/io change
Skipped §3.6.5 — no tree-sitter grammar change

Closes #1772

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `parseInt` and `parseFloat` functions for safe, explicit string-to-number conversions returning `Result` types with proper error handling.

* **Documentation**
  * Updated standard library reference documentation with comprehensive guides for the new string parsing functions, including behavior, supported inputs, and error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->