### PR TITLE
feat(parser): case 式にインデントブロック形式の arm を許可 (#1891)

### DIFF
--- a/.claude/rules/codegen-arc-cow.md
+++ b/.claude/rules/codegen-arc-cow.md
@@ -378,18 +378,34 @@ and drops the value's `strong_count` to zero — the PHI input then dangles
 shipped with this latent UAF; #1891 fixed both it and the new case-expr arms.
 
 **Rule**: Before the arm/branch `popScope()`, call
-`retainBlockTailIfScopeOwned(tailVal)` (`src/codegen_arc.cpp`). It retains (via
-`tryRetainArcSource`) **iff** `tailVal` is a `LoadInst` whose source alloca is in
-the innermost frame (`scope_stack_.back()`). That single gate is exactly right:
+`retainBlockTailIfScopeOwned(tailVal)` (`src/codegen_arc.cpp`). It **traces the
+tail back** through the linear `load` / `getelementptr` / `extractvalue` /
+`bitcast` chain to the alloca it ultimately reads from, and retains (via
+`tryRetainArcSource`) **iff** that owning alloca is in the innermost frame
+(`scope_stack_.back()`). The current-frame check is just the "will this
+`popScope()` release the owner?" gate; the retain decision stays with
+`tryRetainArcSource`, whose per-shape cases gate on the same
+`list_elem`/`map_key`/`set_elem` metadata the owner's destructor uses — so
+retain-site and release-site mirror each other by construction:
 
-- block-local / pattern-bound var (in frame) → retain +1, balanced by the frame's
-  own release — the `ReturnStmt` escape-retain, scoped to one frame instead of all;
-- outer-scope var (NOT in frame) → skipped, because this `popScope()` does not
-  release it, so retaining would **leak** (this is the case to get right — the
-  current-frame check excludes it for free);
-- fresh temp (`arc_owned`, not a `LoadInst`) → skipped; it already owns its +1 and
+- block-local / pattern-bound var, direct `load %local` (in frame) → `tryRetainArcSource`
+  Case 1, retain +1, balanced by the frame's own release — the `ReturnStmt`
+  escape-retain, scoped to one frame instead of all;
+- **borrowed sub-value of an in-frame owner** — `box.items` (`ExtractValue`, Case 3),
+  `xss[i]` (GEP-backed element load, Case 4) → traced back to the owner alloca and
+  retained; **this is the trap**: gating on the tail being a *direct* alloca load
+  misses these and they come back freed (`[]`);
+- outer-scope owner (NOT in frame) → skipped, because this `popScope()` does not
+  release it, so retaining would **leak** (the current-frame check excludes it for free);
+- fresh temp (`arc_owned`, traces to no alloca) → skipped; it already owns its +1 and
   transfers through the PHI;
-- non-ARC frame var → `tryRetainArcSource` self-gates on `isArcManaged`, no-op.
+- non-ARC owner → `tryRetainArcSource` self-gates on metadata, no-op.
+
+**Known limitation (documented, not chased)**: a tail derived through a `PHI` /
+`select` (e.g. `if c => localA else localB` as a block tail) does not trace to a
+single alloca, so a *borrowed* PHI/select tail is not retained — the same coverage
+gap `tryRetainArcSource` itself has. PHI-of-locals tails are exotic; expand only if
+one is found in the wild.
 
 **How to apply**: any new block-valued expression form that emits `stmts* tail`
 then `popScope()` must call `retainBlockTailIfScopeOwned(tailVal)` between the

--- a/.claude/rules/codegen-arc-cow.md
+++ b/.claude/rules/codegen-arc-cow.md
@@ -361,3 +361,40 @@ this double-free / post-terminator insertion.
 (`codegen_call_thread.cpp:284-288`). `emitParallelForRange` does not yet have it
 (follow-up opportunity). Root cause of #1090 was the missing verify — the malformed
 IR survived codegen and crashed only during JIT optimization.
+
+### Block-valued expression tails must retain a scope-owned ARC value before `popScope` (current-frame-gated)
+
+**Source**: #1891 (2026-06-07, implementation — advisor-caught)
+**Tags**: codegen, arc, case-expr, if-block-expr, block-tail, scope-cleanup, use-after-free, escape-retain
+
+**Context**: A block-valued expression — a `case`-expression block arm (#1891) or
+an `if`-expression block branch (`IfBlockExpr`, #798) — evaluates intermediate
+statements then a **tail expression** whose value escapes the arm/branch scope
+through the merge PHI. When that tail is a bare load of an ARC-managed variable
+bound *inside* the scope (a block-local `items = [..]` then tail `items`, or a
+pattern binding `Some(v):` … `v`), the imminent `popScope()` releases the binding
+and drops the value's `strong_count` to zero — the PHI input then dangles
+(use-after-free; the result comes back freed/empty, e.g. `[]`). `IfBlockExpr`
+shipped with this latent UAF; #1891 fixed both it and the new case-expr arms.
+
+**Rule**: Before the arm/branch `popScope()`, call
+`retainBlockTailIfScopeOwned(tailVal)` (`src/codegen_arc.cpp`). It retains (via
+`tryRetainArcSource`) **iff** `tailVal` is a `LoadInst` whose source alloca is in
+the innermost frame (`scope_stack_.back()`). That single gate is exactly right:
+
+- block-local / pattern-bound var (in frame) → retain +1, balanced by the frame's
+  own release — the `ReturnStmt` escape-retain, scoped to one frame instead of all;
+- outer-scope var (NOT in frame) → skipped, because this `popScope()` does not
+  release it, so retaining would **leak** (this is the case to get right — the
+  current-frame check excludes it for free);
+- fresh temp (`arc_owned`, not a `LoadInst`) → skipped; it already owns its +1 and
+  transfers through the PHI;
+- non-ARC frame var → `tryRetainArcSource` self-gates on `isArcManaged`, no-op.
+
+**How to apply**: any new block-valued expression form that emits `stmts* tail`
+then `popScope()` must call `retainBlockTailIfScopeOwned(tailVal)` between the
+tail emit and `popScope()`. Verify with a value-asserting ASan matrix
+(block-local / pattern-bound / fresh-temp / outer-var / returned-from-fn / nested
+tails): under-retain corrupts the value (an `expect` assertion catches it),
+over-retain leaks (only ASan catches it). Canonical tests: the "case expression
+block-arm ARC ownership" describe block in `tests/spec/case_unification.test.ry`.

--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -185,6 +185,53 @@ in user documentation, (b) use non-identifier expressions (literals,
 calls), or (c) write a custom block parser that calls `parseConditional`
 directly for the tail line.
 
+### Block-valued case-EXPRESSION arms parse the tail expression-first (option (c)); case-vs-if tail asymmetry is intentional
+
+**Source**: #1891 (2026-06-07, implementation)
+**Tags**: parser, case-expr, block-arm, tail-expression, speculative-parse, if-block-expr, asymmetry
+
+**Context**: #1891 added indented-block arms to `case` *expressions*
+(`parseCaseExprArmBody` in `src/parser/parser_expr.cpp`). The issue's
+motivating example ends a block arm with `tmp * 2` — an
+identifier-starting binary expression that the entry above shows Ry's
+statement grammar rejects. The `if`-expression block form (#798,
+`parseIfExpressionBranchBody` → `parseBlock` → `parseStatement`) takes
+option (a): it requires `(tmp * 2)`. To keep the case-expr feature
+ergonomic, its block arms instead take **option (c)** and do NOT reuse
+`parseBlock`.
+
+**Rule**: `parseCaseExprArmBody` parses each block line
+**expression-first**: `lex_.saveState()`, try `parseConditional()`, and
+treat the line as the arm's tail value only when the expression consumes
+the whole line AND nothing but `DEDENT`/`EOF` follows. Otherwise
+`restoreState()` and re-parse the line via `parseStatement()` — which
+accepts ordinary statements (assignments, calls) and re-surfaces the
+canonical diagnostic for a non-tail bare identifier-binary. A
+`parseConditional()` that throws `DiagnosticError` (statement-only
+construct such as `while`/`for`/`return`, or a real syntax error) is
+caught and likewise routed to `parseStatement()`, so the double-rewind
+never masks a genuine error. A block reaching `DEDENT` with no tail
+expression is rejected: `case arm block must end with an expression`.
+
+Two consequences worth remembering:
+- A UFCS / module-qualified call as the tail (`obj.method()`) parses as a
+  `CallExpr` here (expression context), not the `CallStmt` that
+  `parseStatement` would yield — so it is usable as a value, sidestepping
+  the CallStmt-vs-ExprStmt trap.
+- **case-vs-if tail asymmetry is intentional (an #1891 scope boundary)**:
+  case-expr block tails accept identifier-starting expressions; `if`-expr
+  block tails still require parentheses. Bringing `if` to parity means
+  giving `parseIfExpressionBranchBody` the same expression-first tail
+  loop — deliberately out of scope for #1891, and documented in
+  `docs/reference/control-flow.md`.
+
+**How to apply**: any future block-valued expression form that wants an
+identifier-starting tail should adopt this expression-first/restore
+pattern rather than `parseBlock`. Keep the double-rewind (catch →
+`restoreState`; expr-but-not-tail → `restoreState` → `parseStatement`) so
+genuine statement diagnostics are never swallowed by the speculative
+`parseConditional`.
+
 ### Identifier-trailing `!` tokenization must exclude every multi-char operator starting with `!`
 
 **Source**: #1211 (2026-04-20, bug fix); updated #1568 (`!!` operator removed)

--- a/changelog.d/1891-case-expr-block-arms.md
+++ b/changelog.d/1891-case-expr-block-arms.md
@@ -1,0 +1,17 @@
+### Added
+
+- `case` **expressions** now accept indented-block arms, not only single-line `pattern : value` arms — closing the asymmetry where only "case expression × indented block" was rejected (`unexpected token '\n'`) while the other three case-form / arm-notation combinations parsed. A block arm runs its intermediate statements and yields its **tail expression** as the arm's value (Rust/Scala `match`-style), so an arm that needs a local computation can be written directly:
+
+  ```ry
+  r = case x:
+      1:
+          tmp = x + 10
+          tmp * 2          # tail expression — the arm's value
+      _ : 0
+  ```
+
+  Covers both the subject form (`case x:`) and the no-subject condition form (`case:`), including the latter's `_:` else arm. The tail line is parsed as an expression, so an identifier-starting tail (`tmp * 2`) or a UFCS / method-call tail is accepted without parentheses — unlike `if`-expression block branches, which still require parenthesizing such a tail. A block whose final line produces no value (e.g. an assignment) is rejected at parse time with `case arm block must end with an expression`. Inline and block arms may be mixed within one `case`; the formatter canonicalizes a block arm with no intermediate statements back to the inline `pattern : value` form. (#1891)
+
+### Fixed
+
+- Fixed a pre-existing use-after-free in `if`-expression block branches: a branch that bound an ARC-managed value (`List` / `Map` / `Set` / `str` / `Option` payload) to a local and returned it as the parenthesized tail (e.g. `if c:` … `items = [...]` … `(items)`) released that binding when the branch scope closed, so the result came back freed/empty. The block-tail value is now retained before scope cleanup — the same escape-retain that makes the new `case`-expression block arms above sound. (#1891)

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -323,7 +323,11 @@ lambda_body      ::= expression
 /* if-expression: `if cond => then else else_expr` (single-line block sugar) */
 if_expr          ::= 'if' expression '=>' expression 'else' expression
 
-/* case-expression form (block-bodied case used as an expression) */
+/* case-expression form (block-bodied case used as an expression).
+ * Arm bodies reuse case_arm / case_cond_arm below, so an arm is either a
+ * same-line expression or an indented block. In the expression context the
+ * block's final statement must be an expression, and its value becomes the
+ * arm's value (tail-expression semantics, #1891). */
 case_expr        ::= case_match_expr
                    | case_cond_expr
 

--- a/docs/reference/control-flow.md
+++ b/docs/reference/control-flow.md
@@ -812,7 +812,7 @@ case seg:
 
 ### Expression Forms
 
-Both `case:` and `case <expr>:` can be used as expressions by writing each arm as `patternOrCondition: valueExpression` on the same line. Each arm provides a single expression whose value becomes the result.
+Both `case:` and `case <expr>:` can be used as expressions. Each arm is written either as `patternOrCondition : valueExpression` on the same line, or as an indented block whose final line is an expression (see [Block-form arms](#block-form-arms) below). The value of the matched arm becomes the result.
 
 ```ry
 # case: expression (no subject)
@@ -876,6 +876,38 @@ sum = case t:
     (a, b) : a + b
     _ : 0
 ```
+
+#### Block-form arms
+
+An arm of a `case` expression may also be written as an indented block. The block's final line is an expression whose value becomes the arm's value; any preceding lines are ordinary statements (for example, local bindings used to compute that value):
+
+```ry
+result = case x:
+    1:
+        tmp = x + 10
+        tmp * 2          # tail expression — the arm's value
+    _:
+        0
+```
+
+The same applies to the no-subject `case:` form, including its `_:` arm:
+
+```ry
+label = case:
+    score > 100:
+        bonus = score - 100
+        bonus * 2
+    _:
+        0
+```
+
+Rules:
+
+- The block's **last line must be an expression** (the tail expression). A block whose last line produces no value — e.g. an assignment — is a parse error: `case arm block must end with an expression`.
+- Inline arms (`pattern : value`) and block arms may be mixed freely within the same `case`.
+- All arms must still produce the same type, and exhaustiveness rules are unchanged.
+
+Unlike `if`-expression block branches — whose tail must be parenthesized when it starts with an identifier (e.g. `(tmp * 2)`) — a `case`-expression block tail accepts an identifier-starting expression directly (`tmp * 2`).
 
 ### Scope Rules
 

--- a/include/ry/ast/ast.hpp
+++ b/include/ry/ast/ast.hpp
@@ -468,14 +468,17 @@ struct CastExpr {
 
 struct CaseCondExprArm {
     ExprPtr condition;
-    ExprPtr value;
+    std::vector<StmtNode> stmts;  // block-form intermediate statements (#1891); empty for inline arms
+    ExprPtr value;                // tail expression = arm value (always present)
 };
 
 // `case:` expression (no subject) — multi-branch conditional expression.
-// The wildcard `_ : value` arm (required) is stored in `else_expr`.
+// The wildcard `_ : value` arm (required) is stored in `else_expr`; any
+// block-form intermediate statements before it live in `else_stmts` (#1891).
 struct CaseCondExpr {
     std::vector<CaseCondExprArm> arms;
-    ExprPtr else_expr;
+    std::vector<StmtNode> else_stmts;  // block-form intermediate statements before the else tail; empty for inline
+    ExprPtr else_expr;                 // else tail expression (always present)
 };
 
 // `if cond => then_value else else_value` — fat-arrow single-expression form (#798).
@@ -574,10 +577,14 @@ struct CaseStmt {
     SourceLocation loc;
 };
 
+// `case subject:` expression arm. Block-form arms (#1891) carry their
+// intermediate statements in `stmts` (empty for inline `pattern : value`
+// arms); `value` is always the tail expression that becomes the arm's value.
 struct CaseExprArm {
     Pattern pattern;
     ExprPtr guard;
-    ExprPtr value;
+    std::vector<StmtNode> stmts;  // block-form intermediate statements; empty for inline arms
+    ExprPtr value;                // tail expression = arm value (always present)
 };
 
 // `case subject:` expression — pattern matching with a subject, returns a value.

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -263,6 +263,12 @@ public:
     llvm::FunctionCallee resolveCollectionDestructor(llvm::AllocaInst *alloca);
     void emitArcReleaseVar(const std::string &name, llvm::AllocaInst *alloca);
     bool tryRetainArcSource(llvm::Value *val);
+    // If `tailVal` loads an ARC value from a variable in the current (innermost)
+    // scope frame — one the imminent popScope() is about to release — retain it
+    // so the value survives the scope as a block expression's escaping result
+    // (#1891 case-expr block arms; if-expr block branches). No-op for fresh temps
+    // (arc_owned), outer-scope vars (not in this frame), and non-ARC values.
+    void retainBlockTailIfScopeOwned(llvm::Value *tailVal);
     // Return-only retain for fn-typed param values. Param allocas for
     // fn-typed params are NOT registered in arc_managed_vars_; callers
     // own the uniform-closure wrap temp via releaseUniformClosureTemps.

--- a/include/ry/formatter.hpp
+++ b/include/ry/formatter.hpp
@@ -83,6 +83,11 @@ private:
     // Helpers
     void formatDirectives(const std::vector<Directive> &directives);
     void formatBlock(const std::vector<StmtNode> &body);
+    // Formats a case-EXPRESSION arm body: inline ` : <expr>` when `stmts` is
+    // empty, else a `:`-block with the intermediate statements and the tail
+    // expression indented one level deeper (#1891).
+    std::string formatCaseArmBody(const std::vector<StmtNode> &stmts,
+                                  const ExprNode &tail);
     std::string formatParams(const std::vector<FnParam> &params);
     std::string formatLambdaSig(const LambdaExpr &lambda);
     void emitTypeParams(const std::vector<TypeParam> &params);

--- a/include/ry/parser/parser.hpp
+++ b/include/ry/parser/parser.hpp
@@ -110,6 +110,11 @@ private:
     ExprPtr parseCaseExprWithSubject(const Token &caseTok);
     ExprPtr parseIfExpression();
     std::vector<StmtNode> parseIfExpressionBranchBody();
+    // Parses a case-EXPRESSION arm body after its ':' is consumed. Inline form
+    // leaves `stmts` empty and sets `value` to the same-line expression; block
+    // form fills `stmts` with intermediate statements and `value` with the tail
+    // expression (the arm's value). See definition for the tail-detection rules.
+    void parseCaseExprArmBody(std::vector<StmtNode> &stmts, ExprPtr &value);
     Pattern parsePattern();
     void parseOrPattern(Pattern &pat);
     static bool patternHasBinding(const Pattern &p);

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -834,29 +834,56 @@ void CodeGen::retainBlockTailIfScopeOwned(llvm::Value *tailVal) {
     // tail expression whose value escapes the arm/branch scope through the merge
     // PHI. If that tail loads a variable owned by the scope frame popScope() is
     // about to release (a block-local binding or a pattern binding), the release
-    // would drop the value's strong_count and leave the PHI input dangling. Retain
-    // it here so it survives — mirrors the ReturnStmt escape-retain, but scoped to
-    // the single frame being popped (not all frames to depth 0).
-    auto *ld = llvm::dyn_cast<llvm::LoadInst>(tailVal);
-    if (!ld)
-        return; // fresh temps (arc_owned) and computed values already own their +1
-    auto *src = llvm::dyn_cast<llvm::AllocaInst>(ld->getPointerOperand());
-    if (!src || scope_stack_.empty())
+    // drops the value's strong_count and leaves the PHI input dangling. Retain it
+    // here so it survives — mirrors the ReturnStmt escape-retain, but scoped to the
+    // single frame being popped (not all frames to depth 0).
+    if (!tailVal || scope_stack_.empty())
         return;
-    // Only retain when the source variable lives in the innermost frame. Outer-scope
-    // vars are NOT released by this popScope(), so retaining them would leak.
+    // Trace the tail back to the alloca it ultimately reads from, through the
+    // linear load / GEP / extractvalue / bitcast chain. The borrow is not only a
+    // direct `load %local`: `box.items` is an ExtractValue of a record load, and
+    // `xss[i]` is a GEP-backed element load — both are freed by the owner's
+    // popScope(), so both need the escape-retain. (A tail derived through a PHI /
+    // select is not traced — the same coverage gap tryRetainArcSource itself has —
+    // and is exotic enough to leave to existing handling.)
+    llvm::Value *cur = tailVal;
+    llvm::AllocaInst *owner = nullptr;
+    for (int hops = 0; hops < 16 && cur; ++hops) {
+        if (auto *a = llvm::dyn_cast<llvm::AllocaInst>(cur)) {
+            owner = a;
+            break;
+        }
+        if (auto *ld = llvm::dyn_cast<llvm::LoadInst>(cur)) {
+            cur = ld->getPointerOperand();
+        } else if (auto *gep = llvm::dyn_cast<llvm::GetElementPtrInst>(cur)) {
+            cur = gep->getPointerOperand();
+        } else if (auto *ev = llvm::dyn_cast<llvm::ExtractValueInst>(cur)) {
+            cur = ev->getAggregateOperand();
+        } else if (auto *bc = llvm::dyn_cast<llvm::BitCastInst>(cur)) {
+            cur = bc->getOperand(0);
+        } else {
+            break; // call result / PHI / fresh temp — not traceable to an alloca
+        }
+    }
+    if (!owner)
+        return;
+    // Only retain when the owner lives in the innermost frame — the one this
+    // popScope() releases. An outer-scope owner is NOT released here, so retaining
+    // it would leak.
     const auto &frame = scope_stack_.back();
     bool inCurrentFrame = false;
-    for (const auto &[name, alloca] : frame) {
-        if (alloca == src) {
+    for (const auto &kv : frame) {
+        if (kv.second == owner) {
             inCurrentFrame = true;
             break;
         }
     }
-    // tryRetainArcSource self-gates on isArcManaged, so a non-ARC frame var (int,
-    // bool, ...) is a no-op; only ARC-managed loads actually retain.
-    if (inCurrentFrame)
-        tryRetainArcSource(tailVal);
+    if (!inCurrentFrame)
+        return;
+    // tryRetainArcSource dispatches on the tail's shape (Case 1 load-from-alloca,
+    // Case 3 ExtractValue, Case 4 GEP-loaded element) and self-gates on ARC
+    // metadata, so a non-ARC tail (int / bool / ...) is a no-op.
+    tryRetainArcSource(tailVal);
 }
 
 // Return-only retain for fn-typed param values. Fn-typed param allocas are

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -829,6 +829,36 @@ bool CodeGen::tryRetainArcSource(llvm::Value *val) {
     return false;
 }
 
+void CodeGen::retainBlockTailIfScopeOwned(llvm::Value *tailVal) {
+    // A block-valued expression (case-expr arm / if-expr branch, #1891) ends in a
+    // tail expression whose value escapes the arm/branch scope through the merge
+    // PHI. If that tail loads a variable owned by the scope frame popScope() is
+    // about to release (a block-local binding or a pattern binding), the release
+    // would drop the value's strong_count and leave the PHI input dangling. Retain
+    // it here so it survives — mirrors the ReturnStmt escape-retain, but scoped to
+    // the single frame being popped (not all frames to depth 0).
+    auto *ld = llvm::dyn_cast<llvm::LoadInst>(tailVal);
+    if (!ld)
+        return; // fresh temps (arc_owned) and computed values already own their +1
+    auto *src = llvm::dyn_cast<llvm::AllocaInst>(ld->getPointerOperand());
+    if (!src || scope_stack_.empty())
+        return;
+    // Only retain when the source variable lives in the innermost frame. Outer-scope
+    // vars are NOT released by this popScope(), so retaining them would leak.
+    const auto &frame = scope_stack_.back();
+    bool inCurrentFrame = false;
+    for (const auto &[name, alloca] : frame) {
+        if (alloca == src) {
+            inCurrentFrame = true;
+            break;
+        }
+    }
+    // tryRetainArcSource self-gates on isArcManaged, so a non-ARC frame var (int,
+    // bool, ...) is a no-op; only ARC-managed loads actually retain.
+    if (inCurrentFrame)
+        tryRetainArcSource(tailVal);
+}
+
 // Return-only retain for fn-typed param values. Fn-typed param allocas are
 // not registered in arc_managed_vars_ (callers own the uniform-closure wrap
 // temp via releaseUniformClosureTemps). When `return f` propagates such a

--- a/src/codegen_expr.cpp
+++ b/src/codegen_expr.cpp
@@ -1749,6 +1749,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
         emitBranchCond(cond, thenBB, nextBB);
 
         builder_.SetInsertPoint(thenBB);
+        pushScope();
+        // Block-form arm (#1891): emit intermediate statements before the tail
+        // value, within a scope so locals are visible to the tail and cleaned up
+        // on popScope. Empty for inline arms.
+        for (auto &stmt : arm.stmts)
+            std::visit([this](auto &st) { emitStmt(st); }, stmt);
         llvm::Value *armVal;
         {
             OptionNoneHintGuard g(*this, caseCondFallback);
@@ -1756,6 +1762,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
         }
         if (!firstVal) firstVal = armVal;
         else validateBranchTypes(firstVal, armVal, "case expression");
+        retainBlockTailIfScopeOwned(armVal); // #1891: escape-retain before scope release
+        popScope();
         llvm::BasicBlock *armEndBB = builder_.GetInsertBlock();
         emitBranchUncond(mergeBB);
         incoming.push_back({armVal, armEndBB});
@@ -1763,6 +1771,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
         builder_.SetInsertPoint(nextBB);
     }
 
+    pushScope();
+    // Block-form else (#1891): intermediate statements before the tail value.
+    for (auto &stmt : e->else_stmts)
+        std::visit([this](auto &st) { emitStmt(st); }, stmt);
     llvm::Value *elseVal;
     {
         OptionNoneHintGuard g(*this, caseCondFallback);
@@ -1770,6 +1782,8 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseCondExpr> &e) {
     }
     if (!firstVal) firstVal = elseVal;
     else validateBranchTypes(firstVal, elseVal, "case expression");
+    retainBlockTailIfScopeOwned(elseVal); // #1891: escape-retain before scope release
+    popScope();
     llvm::BasicBlock *elseEndBB = builder_.GetInsertBlock();
     emitBranchUncond(mergeBB);
     incoming.push_back({elseVal, elseEndBB});
@@ -1863,6 +1877,10 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<IfBlockExpr> &e) {
             std::visit([this](auto &s) { emitStmt(s); }, mutBody[i]);
         OptionNoneHintGuard g(*this, tailHint);
         llvm::Value *val = emitExpr(*tail);
+        // #1891: same escape-retain as case-expr block arms — a tail that loads a
+        // scope-local ARC binding must survive popScope() (pre-existing UAF: a bound
+        // ARC var returned from an if-block branch came back freed).
+        retainBlockTailIfScopeOwned(val);
         popScope();
         return {val, builder_.GetInsertBlock()};
     };

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -1005,9 +1005,16 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
 
         // Block-form arm (#1891): emit the intermediate statements before the
         // tail value, within the same scope so they see the pattern bindings and
-        // are cleaned up on popScope. Empty for inline arms.
-        for (auto &stmt : arm.stmts)
-            std::visit([this](auto &st) { emitStmt(st); }, stmt);
+        // are cleaned up on popScope. Empty for inline arms. Suspend the scrutinee
+        // None()-hint over the statements (tail-only scoping, matching CaseCondExpr
+        // and IfBlockExpr) so a `None()` nested in a non-tail statement does not
+        // inherit the match arm's inner-type hint; the tail value below re-enters
+        // the enclosing scrutineeHintGuard.
+        {
+            OptionNoneHintGuard noArmHint(*this, nullptr);
+            for (auto &stmt : arm.stmts)
+                std::visit([this](auto &st) { emitStmt(st); }, stmt);
+        }
         llvm::Value *armVal = emitExpr(*arm.value);
         if (!firstVal) firstVal = armVal;
         else validateBranchTypes(firstVal, armVal, "match expression");

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -1003,10 +1003,18 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
         emitPatternBindings(arm.pattern, subjectAlloca, subjectTy,
                             subjectEnumName, subjectSourceTypeName);
 
+        // Block-form arm (#1891): emit the intermediate statements before the
+        // tail value, within the same scope so they see the pattern bindings and
+        // are cleaned up on popScope. Empty for inline arms.
+        for (auto &stmt : arm.stmts)
+            std::visit([this](auto &st) { emitStmt(st); }, stmt);
         llvm::Value *armVal = emitExpr(*arm.value);
         if (!firstVal) firstVal = armVal;
         else validateBranchTypes(firstVal, armVal, "match expression");
 
+        // #1891: a block-form arm whose tail loads a scope-local ARC binding must
+        // retain it before popScope() releases that binding, else the PHI dangles.
+        retainBlockTailIfScopeOwned(armVal);
         popScope();
         llvm::BasicBlock *armEndBB = builder_.GetInsertBlock();
         emitBranchUncond(mergeBB);

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -221,6 +221,38 @@ std::string Formatter::formatExpr(const ExprNode &expr) {
     return formatExprInner(expr);
 }
 
+std::string Formatter::formatCaseArmBody(const std::vector<StmtNode> &stmts,
+                                         const ExprNode &tail) {
+    // Inline arm (no intermediate statements): canonical ` : <expr>`.
+    if (stmts.empty())
+        return " : " + formatExpr(tail);
+
+    // Block arm (#1891): `:` then each intermediate statement and the tail
+    // expression, indented two levels below the `case` (one below the arm).
+    std::string bodyIndent(static_cast<size_t>(indent_level_ + 2) *
+                               static_cast<size_t>(indent_width_),
+                           ' ');
+    std::string out = ":\n";
+    for (const auto &st : stmts) {
+        // formatStmt writes to out_; save/clear/restore so it does not clobber
+        // the local string being built (mirrors the IfBlockExpr block path).
+        std::string saved_out = std::move(out_);
+        out_.clear();
+        int saved_indent = indent_level_;
+        indent_level_ += 2;
+        emitIndent();
+        formatStmt(st);
+        indent_level_ = saved_indent;
+        std::string stmt_text = std::move(out_);
+        out_ = std::move(saved_out);
+        if (!stmt_text.empty() && stmt_text.back() == '\n')
+            stmt_text.pop_back();
+        out += stmt_text + "\n";
+    }
+    out += bodyIndent + formatExpr(tail);
+    return out;
+}
+
 std::string Formatter::formatExprInner(const ExprNode &expr) {
     return std::visit([this](const auto &v) -> std::string {
         using T = std::decay_t<decltype(v)>;
@@ -332,9 +364,10 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
             std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
             std::string out = "case:\n";
             for (const auto &arm : v->arms) {
-                out += indent + formatExpr(*arm.condition) + " : " + formatExpr(*arm.value) + "\n";
+                out += indent + formatExpr(*arm.condition) +
+                       formatCaseArmBody(arm.stmts, *arm.value) + "\n";
             }
-            out += indent + "_ : " + formatExpr(*v->else_expr);
+            out += indent + "_" + formatCaseArmBody(v->else_stmts, *v->else_expr);
             return out;
         } else if constexpr (std::is_same_v<T, std::unique_ptr<CaseExpr>>) {
             std::string indent(static_cast<size_t>(indent_level_ + 1) * static_cast<size_t>(indent_width_), ' ');
@@ -344,7 +377,7 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
                 out += indent + formatPattern(arm.pattern);
                 if (arm.guard)
                     out += " if " + formatExpr(*arm.guard);
-                out += " : " + formatExpr(*arm.value);
+                out += formatCaseArmBody(arm.stmts, *arm.value);
                 if (i + 1 < v->arms.size())
                     out += "\n";
             }

--- a/src/parser/parser_expr.cpp
+++ b/src/parser/parser_expr.cpp
@@ -54,7 +54,7 @@ ExprPtr Parser::parseCaseExprNoSubject(const Token &caseTok) {
             if (seenWildcard)
                 parseError(saved.line, "duplicate '_' arm in case expression");
             lex_.next(); // consume ':'
-            caseExpr->else_expr = parseConditional();
+            parseCaseExprArmBody(caseExpr->else_stmts, caseExpr->else_expr);
             seenWildcard = true;
         } else {
             if (seenWildcard)
@@ -64,7 +64,7 @@ ExprPtr Parser::parseCaseExprNoSubject(const Token &caseTok) {
             if (lex_.peek().kind != TokenKind::Colon)
                 parseError("expected ':' after case condition");
             lex_.next();
-            arm.value = parseConditional();
+            parseCaseExprArmBody(arm.stmts, arm.value);
             caseExpr->arms.push_back(std::move(arm));
         }
 
@@ -120,7 +120,7 @@ ExprPtr Parser::parseCaseExprWithSubject(const Token &caseTok) {
             parseError("expected ':' after case pattern in case expression");
         lex_.next(); // consume ':'
 
-        arm.value = parseConditional();
+        parseCaseExprArmBody(arm.stmts, arm.value);
         caseExpr->arms.push_back(std::move(arm));
 
         if (lex_.peek().kind == TokenKind::Newline)
@@ -150,6 +150,93 @@ std::vector<StmtNode> Parser::parseIfExpressionBranchBody() {
     stmt.expr = parseConditional();
     body.push_back(std::move(stmt));
     return body;
+}
+
+// Parses a case-EXPRESSION arm body after its ':' has been consumed (#1891).
+//
+//   inline:  `... : expr`           -> stmts empty, value = expr
+//   block :  `... :` NEWLINE INDENT
+//                statement*          -> stmts (intermediate statements)
+//                tail_expr           -> value (the arm's value)
+//            DEDENT
+//
+// The block's final line is parsed as an expression (via parseConditional), so
+// an identifier-starting tail like `tmp * 2` — or a UFCS/module call such as
+// `obj.method()` (which parseStatement would yield as a non-value CallStmt) — is
+// accepted as the value. Each line is parsed expression-first: a line is the
+// tail iff it parses as a complete expression AND nothing but DEDENT follows;
+// otherwise it is re-parsed as a statement (which both surfaces genuine
+// diagnostics and rejects a bare identifier-binary in a non-tail position, per
+// Ry's statement grammar). A block that ends in a non-value statement is a parse
+// error. Consumes exactly the inner block's DEDENT; the enclosing arm loop
+// consumes the outer one.
+void Parser::parseCaseExprArmBody(std::vector<StmtNode> &stmts, ExprPtr &value) {
+    if (lex_.peek().kind != TokenKind::Newline) {
+        // Inline arm: a single same-line expression.
+        value = parseConditional();
+        return;
+    }
+
+    // Block arm.
+    lex_.next(); // consume Newline
+    skipNewlines();
+    if (lex_.peek().kind != TokenKind::Indent)
+        parseError("expected indented block after ':' in case expression arm");
+    lex_.next(); // consume Indent
+
+    while (true) {
+        if (lex_.peek().kind == TokenKind::Dedent ||
+            lex_.peek().kind == TokenKind::Eof)
+            parseError("case arm block must end with an expression");
+
+        auto saved = lex_.saveState();
+
+        // Try this line as the tail expression. It is the tail only if it parses
+        // as a whole-line expression and the block ends right after it; anything
+        // else is rewound and re-parsed as a statement below.
+        ExprPtr expr;
+        bool exprParsed = false;
+        try {
+            expr = parseConditional();
+            exprParsed = true;
+        } catch (const DiagnosticError &) {
+            // Not an expression line (statement-only construct such as
+            // while/for/return, or a genuine syntax error). Rewind; the statement
+            // re-parse below reproduces any real diagnostic.
+            lex_.restoreState(saved);
+        }
+
+        if (exprParsed) {
+            TokenKind after = lex_.peek().kind;
+            if (after == TokenKind::Newline || after == TokenKind::Dedent ||
+                after == TokenKind::Eof) {
+                if (after == TokenKind::Newline)
+                    lex_.next();
+                skipNewlines();
+                if (lex_.peek().kind == TokenKind::Dedent ||
+                    lex_.peek().kind == TokenKind::Eof) {
+                    value = std::move(expr); // tail expression = arm value
+                    break;
+                }
+            }
+            // A complete expression but not the final line: rewind and treat it
+            // as a (non-tail) statement (so a bare `tmp * 2` here is rejected).
+            lex_.restoreState(saved);
+        }
+
+        // Non-tail line: parse it as a statement.
+        StmtNode stmt = parseStatement();
+        if (lex_.peek().kind == TokenKind::Newline)
+            lex_.next();
+        skipNewlines();
+        if (lex_.peek().kind == TokenKind::Dedent ||
+            lex_.peek().kind == TokenKind::Eof)
+            parseError("case arm block must end with an expression");
+        stmts.push_back(std::move(stmt));
+    }
+
+    if (lex_.peek().kind == TokenKind::Dedent)
+        lex_.next(); // consume the inner block's DEDENT
 }
 
 // Parses the expression form of `if` (issue #798):

--- a/tests/spec/case_unification.test.ry
+++ b/tests/spec/case_unification.test.ry
@@ -335,6 +335,10 @@ fn blockArmReturnsList(n: int) -> List<int>:
       [0]
   return r
 
+# Record with an ARC field, for the borrowed-tail (ExtractValue) tests below.
+record BlockTailBox:
+  items: List<int>
+
 @describe("case expression block-arm ARC ownership (#1891)")
 fn caseExprBlockArmArcOwnershipTests():
   # These exercise an ARC-managed value (List / str / Option payload) bound in a
@@ -440,3 +444,45 @@ fn caseExprBlockArmArcOwnershipTests():
     expect(len(r)).toEq(2)
     expect(r[0]).toEq(5)
     expect(r[1]).toEq(6)
+
+  # Borrowed tails (not a direct `load %local`): the tail reads a sub-value of a
+  # scope-local owner via ExtractValue (record field) or a GEP-backed element
+  # load. Both were freed by popScope before the trace-back fix (CodeRabbit).
+  @it("retains a record-field (ExtractValue) borrowed tail")
+  fn retainsRecordFieldBorrowedTail():
+    x = 5
+    r = case x:
+      5:
+        box = BlockTailBox([x, x + 1])
+        box.items
+      _:
+        [0]
+    expect(len(r)).toEq(2)
+    expect(r[0]).toEq(5)
+    expect(r[1]).toEq(6)
+
+  @it("retains a nested-list element (GEP) borrowed tail")
+  fn retainsNestedListElementBorrowedTail():
+    x = 5
+    r = case x:
+      5:
+        xss = [[x, x + 1]]
+        xss[0]
+      _:
+        [0]
+    expect(len(r)).toEq(2)
+    expect(r[0]).toEq(5)
+    expect(r[1]).toEq(6)
+
+  @it("retains a pattern-bound record-field borrowed tail")
+  fn retainsPatternBoundFieldBorrowedTail():
+    w: Option<BlockTailBox> = Some(BlockTailBox([7, 8]))
+    r = case w:
+      Some(v):
+        marker = 1
+        v.items
+      None:
+        [0]
+    expect(len(r)).toEq(2)
+    expect(r[0]).toEq(7)
+    expect(r[1]).toEq(8)

--- a/tests/spec/case_unification.test.ry
+++ b/tests/spec/case_unification.test.ry
@@ -207,3 +207,236 @@ fn ifExpressionColonInlineFormTests():
     b = if a > 0: a
     else: 0 - a
     expect(b).toEq(3)
+
+@describe("case expression block-form arms (#1891)")
+fn caseExprBlockArmTests():
+  @it("should use the block tail expression as the arm value")
+  fn shouldUseBlockTailAsArmValue():
+    x = 1
+    res = case x:
+      1:
+        tmp = x + 10
+        tmp * 2
+      _:
+        0
+    expect(res).toEq(22)
+
+  @it("should allow an identifier-starting tail without parens")
+  fn shouldAllowIdentifierStartingTail():
+    x = 1
+    res = case x:
+      1:
+        msg = "hello"
+        msg
+      _:
+        "other"
+    expect(res).toEq("hello")
+
+  @it("should select and evaluate the wildcard block arm")
+  fn shouldSelectWildcardBlockArm():
+    x = 99
+    res = case x:
+      1:
+        a = 1
+        a
+      _:
+        b = x - 90
+        b * 2
+    expect(res).toEq(18)
+
+  @it("should allow mixing inline and block arms")
+  fn shouldAllowMixingInlineAndBlockArms():
+    x = 3
+    res = case x:
+      1 : "one"
+      3:
+        y = x + x
+        "three-ish"
+      _ : "other"
+    expect(res).toEq("three-ish")
+
+  @it("should unify block and inline arm value types")
+  fn shouldUnifyBlockAndInlineArmTypes():
+    x = 2
+    res = case x:
+      1:
+        p = 10
+        p + 1
+      _ : 0
+    expect(res).toEq(0)
+
+  @it("should support guards on block arms")
+  fn shouldSupportGuardsOnBlockArms():
+    x = 7
+    res = case x:
+      n if n > 5:
+        doubled = n * 2
+        doubled
+      _:
+        0
+    expect(res).toEq(14)
+
+  @it("should support OR patterns on block arms")
+  fn shouldSupportOrPatternsOnBlockArms():
+    x = 2
+    res = case x:
+      1 | 2 | 3:
+        tag = "small"
+        tag
+      _:
+        "big"
+    expect(res).toEq("small")
+
+  @it("should allow a nested case expression as the tail")
+  fn shouldAllowNestedCaseExpressionAsTail():
+    x = 1
+    y = 2
+    res = case x:
+      1:
+        inner = case y:
+          2 : "two"
+          _ : "?"
+        inner
+      _:
+        "other"
+    expect(res).toEq("two")
+
+@describe("case condition-expression block-form arms (#1891)")
+fn caseCondExprBlockArmTests():
+  @it("should use block tails in condition arms")
+  fn shouldUseBlockTailsInConditionArms():
+    x = 15
+    res = case:
+      x > 10:
+        big = x + 1
+        big * 2
+      _:
+        0
+    expect(res).toEq(32)
+
+  @it("should use a block tail in the wildcard else arm")
+  fn shouldUseBlockTailInElseArm():
+    x = 3
+    res = case:
+      x > 10:
+        100
+      _:
+        z = x - 1
+        z
+    expect(res).toEq(2)
+
+# Helper for the return-path ARC-ownership test below.
+fn blockArmReturnsList(n: int) -> List<int>:
+  r = case n:
+    5:
+      items = [n, n + 1]
+      items
+    _:
+      [0]
+  return r
+
+@describe("case expression block-arm ARC ownership (#1891)")
+fn caseExprBlockArmArcOwnershipTests():
+  # These exercise an ARC-managed value (List / str / Option payload) bound in a
+  # block arm and returned as the tail. Under-retain corrupts the value (caught by
+  # the assertions); over-retain leaks (caught by ASan in the self-test run).
+  @it("retains a block-local List tail past scope release")
+  fn retainsBlockLocalListTail():
+    x = 5
+    r = case x:
+      5:
+        items = [x, x + 1]
+        items
+      _:
+        [0]
+    expect(len(r)).toEq(2)
+    expect(r[0]).toEq(5)
+    expect(r[1]).toEq(6)
+
+  @it("retains a computed-str tail past scope release")
+  fn retainsComputedStrTail():
+    x = 5
+    s = case x:
+      5:
+        msg = f"v:{x}"
+        msg
+      _:
+        "none"
+    expect(s).toEq("v:5")
+
+  @it("retains a pattern-bound ARC tail in a block arm")
+  fn retainsPatternBoundArcTail():
+    opt: Option<List<int>> = Some([7, 8])
+    r = case opt:
+      Some(v):
+        marker = 1
+        v
+      None:
+        [0]
+    expect(len(r)).toEq(2)
+    expect(r[0]).toEq(7)
+    expect(r[1]).toEq(8)
+
+  @it("does not corrupt a fresh-temp tail built from a local")
+  fn freshTempTailFromLocal():
+    x = 3
+    r = case x:
+      3:
+        base = [x, x, x]
+        [base[0], base[1]]
+      _:
+        [0]
+    expect(len(r)).toEq(2)
+    expect(r[0]).toEq(3)
+
+  @it("does not over-retain an outer-var tail (outer stays valid)")
+  fn outerVarTailStaysValid():
+    outer = [9, 9]
+    x = 1
+    r = case x:
+      1:
+        tmp = 1
+        outer
+      _:
+        [0]
+    expect(r[0]).toEq(9)
+    expect(outer[0]).toEq(9)
+    expect(outer[1]).toEq(9)
+
+  @it("retains a block-local tail returned from a function")
+  fn blockLocalTailReturnedFromFn():
+    got = blockArmReturnsList(5)
+    expect(len(got)).toEq(2)
+    expect(got[0]).toEq(5)
+    expect(got[1]).toEq(6)
+
+  @it("retains a block-local tail used as a nested case tail")
+  fn blockLocalTailNested():
+    x = 5
+    y = 1
+    r = case y:
+      1:
+        inner = case x:
+          5:
+            items = [x, x + 1]
+            items
+          _:
+            [0]
+        inner
+      _:
+        [0]
+    expect(len(r)).toEq(2)
+    expect(r[0]).toEq(5)
+    expect(r[1]).toEq(6)
+
+  @it("retains an if-block-expr bound-var tail (shared UAF regression)")
+  fn ifBlockBoundVarTail():
+    x = 5
+    r = if x > 0:
+      items = [x, x + 1]
+      (items)
+    else:
+      [0]
+    expect(len(r)).toEq(2)
+    expect(r[0]).toEq(5)
+    expect(r[1]).toEq(6)

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -655,3 +655,29 @@ TEST(FormatterTest, ExpectToBeCloseToWithDecimalsRoundTrip) {
     EXPECT_EQ(fmt(src), src);
     EXPECT_EQ(fmt(fmt(src)), fmt(src));
 }
+
+TEST(FormatterTest, CaseExprBlockArmRoundTrip) {
+    // Block-form subject case arm (#1891): intermediate statement + tail
+    // expression, with the inline `_` arm preserved.
+    auto src = "r = case x:\n    1:\n        tmp = x + 10\n        tmp * 2\n    _ : 0\n";
+    auto expected = "r = case x:\n  1:\n    tmp = x + 10\n    tmp * 2\n  _ : 0\n";
+    EXPECT_EQ(fmt(src), expected);
+    EXPECT_EQ(fmt(fmt(src)), fmt(src)); // idempotent
+    std::string reason;
+    EXPECT_TRUE(Formatter::verifyFormatting(fmt(src), reason)); // re-parses
+}
+
+TEST(FormatterTest, CaseExprTailOnlyBlockCanonicalizesToInline) {
+    // A block arm with no intermediate statements canonicalizes to inline form.
+    auto src = "b = case x:\n    1:\n        100\n    _ : 0\n";
+    EXPECT_EQ(fmt(src), "b = case x:\n  1 : 100\n  _ : 0\n");
+    EXPECT_EQ(fmt(fmt(src)), fmt(src));
+}
+
+TEST(FormatterTest, CaseCondExprBlockArmRoundTrip) {
+    // Block-form condition arm + inline else (#1891).
+    auto src = "s = case:\n    x > 10:\n        big = x + 1\n        big * 2\n    _ : 0\n";
+    auto expected = "s = case:\n  x > 10:\n    big = x + 1\n    big * 2\n  _ : 0\n";
+    EXPECT_EQ(fmt(src), expected);
+    EXPECT_EQ(fmt(fmt(src)), fmt(src));
+}

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -491,6 +491,60 @@ TEST(ParserTest, CaseCondExprWildcardMustBeLast) {
                  std::runtime_error);
 }
 
+TEST(ParserTest, CaseExprBlockArmParsesStmtsAndTail) {
+    // Block-form case-expression arm (#1891): intermediate statements plus a
+    // tail expression; the sibling inline arm carries no statements. This is the
+    // positive preserved-sibling test for the rejection branches below.
+    Program prog =
+        parseStr("r = case x:\n    1:\n        t = 5\n        t * 2\n    _ : 0");
+    ASSERT_EQ(prog.size(), 1u);
+    const auto &s = std::get<AssignStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CaseExpr>>(s.value->data));
+    const auto &caseExpr = *std::get<std::unique_ptr<CaseExpr>>(s.value->data);
+    ASSERT_EQ(caseExpr.arms.size(), 2u);
+    EXPECT_EQ(caseExpr.arms[0].stmts.size(), 1u); // block arm: one intermediate stmt
+    EXPECT_NE(caseExpr.arms[0].value, nullptr);   // ... and a tail value
+    EXPECT_EQ(caseExpr.arms[1].stmts.size(), 0u); // inline arm: no statements
+    EXPECT_NE(caseExpr.arms[1].value, nullptr);
+}
+
+TEST(ParserTest, CaseExprBlockArmMustEndWithExpression) {
+    // A block arm whose last line is a non-value statement (assignment) is
+    // rejected at parse time.
+    try {
+        parseStr("r = case x:\n    1:\n        total = 0\n    _ : 9");
+        FAIL() << "expected exception";
+    } catch (const DiagnosticError &e) {
+        EXPECT_NE(std::string(e.what()).find(
+                      "case arm block must end with an expression"),
+                  std::string::npos);
+    }
+}
+
+TEST(ParserTest, CaseCondExprBlockArmMustEndWithExpression) {
+    // Same rule for the no-subject condition form.
+    try {
+        parseStr("r = case:\n    true:\n        a = 5\n    _ : 0");
+        FAIL() << "expected exception";
+    } catch (const DiagnosticError &e) {
+        EXPECT_NE(std::string(e.what()).find(
+                      "case arm block must end with an expression"),
+                  std::string::npos);
+    }
+}
+
+TEST(ParserTest, CaseExprArmRequiresIndentedBlockOrInline) {
+    // `1:` followed by a dedented next arm (neither an indented block nor an
+    // inline expression) is rejected.
+    try {
+        parseStr("r = case x:\n    1:\n    _ : 0");
+        FAIL() << "expected exception";
+    } catch (const DiagnosticError &e) {
+        EXPECT_NE(std::string(e.what()).find("expected indented block"),
+                  std::string::npos);
+    }
+}
+
 TEST(ParserTest, IfBlockMultipleStatements) {
     Program prog = parseStr("if true:\n    x = 1\n    print(x)");
     const auto &ifStmt = *std::get<std::unique_ptr<IfStmt>>(prog[0]);


### PR DESCRIPTION
case 式の arm をインデントブロックでも書けるようにし、ブロック末尾式を arm の値とする (Rust/Scala の match 相当)。subject 形式 (`case x:`) と no-subject 条件形式 (`case:`)、条件形式の `_:` else に対応。末尾は式優先で parse するため、識別子始まりの末尾 (`tmp * 2`) や UFCS 呼び出しも括弧なしで受理する。値を生まない末尾 (代入等) は parse エラー。inline / block arm の混在可、formatter は中間文なしブロックを 1 行形式に正規化。

副次的に、ブロック末尾がスコープ内 ARC 変数のとき `popScope` が PHI 消費前に解放する use-after-free を、`/triage-side-finding` Phase B (crash-class) として同梱修正。`IfBlockExpr` にも存在した潜在バグで、両者を `retainBlockTailIfScopeOwned` (current-frame gated escape-retain) で修正。

検証: 全テスト (C++ 2549 + Ry 204 ファイル, 新規 spec/parser/formatter/ARC 所有権テスト含む) / ASan+UBSan / TSan / fuzz_parser / clang-tidy / cppcheck / tree-sitter すべてクリーン。

Closes #1891

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `case` expressions now accept indented block arms; an arm’s value is the block’s final (tail) expression and inline+block arms may be mixed. Tail expressions starting with identifiers no longer require extra parentheses.

* **Bug Fixes**
  * Fixed a use-after-free where branch block tails could return managed values that were released too early.

* **Documentation**
  * Control-flow and grammar docs updated to describe block-form case arms.

* **Tests**
  * New parser, formatter, and spec tests for block-form arms and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->