### PR TITLE
chore(tooling): enable dev plugins in shared .claude/settings.json (#2075)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": true,
+    "rust-analyzer-lsp@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "context7@claude-plugins-official": true,
+    "feature-dev@claude-plugins-official": true,
+    "code-review@claude-plugins-official": true,
+    "security-guidance@claude-plugins-official": true,
+    "serena@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
Track the previously-untracked `.claude/settings.json` as the team-shared Claude Code config (it was gitignore-exempt and only locally edited). Enables 8 plugins: clangd-lsp, rust-analyzer-lsp, frontend-design, context7, feature-dev, code-review, security-guidance, serena. Personal overrides remain in the gitignored `settings.local.json`.

Pre-commit checklist (`.claude/`-only change):
- Skipped §1 — no user-visible change
- Skipped §2 — no user-visible change (no `changelog.d/` fragment)
- Skipped §3 / §3.5 — no source code change
- Skipped §3.5.6 — no Rust crate change
- Skipped §3.6 — no parser/lexer/json/utf8/string/io change
- Skipped §3.6.5 — no tree-sitter grammar change
- §3.5.7 prompt-refs lint: clean
- §3.5.5 static analysis: N/A (no C++ change; CI clang-tidy/scan-build/lint green)

Closes #2075
