### PR TITLE
docs(emit): expand crates/emit Rust comments (layering why, boundary contracts, descriptor intent)

### DIFF
--- a/crates/emit/src/abi.rs
+++ b/crates/emit/src/abi.rs
@@ -116,67 +116,150 @@ pub type RyBuildValueFn = Option<unsafe extern "C" fn(user_ctx: *mut c_void) -> 
 
 // =============================================================
 // Descriptor structs (mirror api.h verbatim — field order, types,
-// and layout MUST match the C declarations).
+// and layout MUST match the C declarations). The per-field docs below
+// summarize each field for the Rust reader and call out the handle kind
+// (`RyValueId` u32 intern id the shell `resolve`s, vs. opaque
+// `RyValueRef` / `RyTypeRef` pointers passed straight through) and the
+// core vocabulary the abi shell maps it into. api.h holds the canonical
+// long-form (kind tables, BB-level emission sequences) — keep these
+// short and defer there rather than restating it.
 // =============================================================
 
 #[repr(C)]
 pub struct RyCowEnsureUniqueDesc {
+    /// Current ARC-backed dataPtr (`RyValueId`). The op derives headerPtr as
+    /// `data_ptr - ARC_HEADER_SIZE`.
     pub data_ptr_id: RyValueId,
+    /// Slot (alloca or GEP) that receives the new dataPtr on the copy path;
+    /// left untouched on the unique / immortal path (`RyValueId`).
     pub slot_ptr_id: RyValueId,
+    /// RyCowKind selector, mapped to `CowKind`: 0 = List, 1 = Map, 2 = Set.
     pub kind: c_int,
+    /// RyArcAtomic, mapped to `Atomicity`; gates the strong_count load
+    /// ordering (Acquire vs NotAtomic) and the internal arc_release mode.
     pub atomic: c_int,
+    /// List / Set: element bytes. Map: unused (use `val_size`).
     pub elem_size: u64,
+    /// Map: key bytes. 0 for List / Set.
     pub key_size: u64,
+    /// Map: value bytes. 0 for List / Set.
     pub val_size: u64,
+    /// 1 = retain each cloned element after the memcpy (always NON-atomic);
+    /// mapped to `bool`.
     pub do_elem_retain: c_int,
+    /// Element-retain header offset: 1 = StringHeader (-24), 0 = ArcHeader
+    /// (-16). Consulted only when `do_elem_retain`.
     pub elem_is_str: c_int,
+    /// Map only: 1 = retain each cloned Map key (always NON-atomic); mapped to
+    /// `bool`. Independent of `do_elem_retain`.
     pub do_key_retain: c_int,
+    /// Key-retain header offset: 1 = StringHeader (-24), 0 = ArcHeader (-16).
+    /// Consulted only when `do_key_retain`.
     pub key_is_str: c_int,
+    /// Per-kind collection destructor — opaque `RyValueRef` passed straight to
+    /// the internal arc_release (mapped to `Option<ValueRef>`). NULL when the
+    /// kind has no element-side cleanup.
     pub destructor_callee: RyValueRef,
 }
 
 #[repr(C)]
 pub struct RyAnyWrapDesc {
+    /// `kind` selector, mapped to `AnyWrapKind`: 0 = NonBox, 1 = RecordBox,
+    /// 2 = EnumBox.
     pub kind: c_int,
+    /// RyAnyTag to store in any.tag, passed as a raw i64 (matches the C++
+    /// `ry::RyAnyTag` enum numerically, Int=0..Enum=9) so the boundary need
+    /// not share the enum identifier.
     pub target_tag: i64,
+    /// Value to wrap (`RyValueId`). NonBox: primitive / bool / str /
+    /// collection pointer. Box arms: the record/enum payload.
     pub val_id: RyValueId,
+    /// NonBox only: 1 = retain the collection element header (-16) before the
+    /// alloca/store; mapped to `bool`.
     pub do_collection_retain: c_int,
+    /// NonBox only: 1 = retain the StringHeader (-24) before the alloca/store.
+    /// Mutually exclusive with `do_collection_retain`.
     pub do_str_retain: c_int,
+    /// Box arms only: per-type descriptor LLVM Constant (`RyValueId`; the
+    /// nullable resolve maps it to `Option<ValueRef>`).
     pub descriptor_id: RyValueId,
+    /// Box arms only: `{ ptr desc, payload }` StructType — opaque `RyTypeRef`
+    /// passed straight through (mapped to `Option<TypeRef>`).
     pub box_layout_ty: RyTypeRef,
+    /// Box arms only: DataLayout-derived allocation size of `box_layout_ty` in
+    /// bytes, pre-computed so the boundary need not consult DataLayout.
     pub box_data_size: u64,
+    /// Common: the `any` StructType handle (anyTy_) — opaque `RyTypeRef`.
     pub any_ty: RyTypeRef,
 }
 
 #[repr(C)]
 pub struct RyAnyUnwrapDesc {
+    /// `kind` selector: 0 = Standard (2-way tag check), 1 = F64Promote
+    /// (int→float auto-promote, 5 BBs), 2 = Record (descriptor-chain walk).
     pub kind: c_int,
+    /// Source any value (`RyValueId`).
     pub any_val_id: RyValueId,
+    /// `any` StructType handle (anyTy_) — opaque `RyTypeRef`.
     pub any_ty: RyTypeRef,
+    /// Standard: target LLVM type (i64 / i1 / ptr / ...). Record: ignored
+    /// (`record_struct_ty` is used). F64Promote: ignored. Opaque `RyTypeRef`.
     pub target_ty: RyTypeRef,
+    /// Standard / Record: expected RyAnyTag value (raw i64).
     pub expected_tag: i64,
+    /// Standard only: 1 = retain the collection element header (-16) after the
+    /// load; mapped to `bool`.
     pub do_collection_retain: c_int,
+    /// Standard only: 1 = retain the StringHeader (-24) after the load.
+    /// Mutually exclusive with `do_collection_retain`.
     pub do_str_retain: c_int,
+    /// Tag-mismatch error message — borrowed `*const c_char` (valid only for
+    /// the call) for the cachedGlobalString'd format string.
     pub mismatch_msg: *const c_char,
+    /// Global-name hint for `mismatch_msg`'s interned string (borrowed
+    /// `*const c_char`).
     pub mismatch_global_name: *const c_char,
+    /// Record only: expected per-type descriptor LLVM Constant (`RyValueId`).
     pub expected_desc_id: RyValueId,
+    /// Record only: `{ ptr desc, record struct }` StructType — opaque
+    /// `RyTypeRef`.
     pub box_layout_ty: RyTypeRef,
+    /// Record only: the record's struct type for the payload GEP/load — opaque
+    /// `RyTypeRef`.
     pub record_struct_ty: RyTypeRef,
+    /// Record only: descriptor-mismatch error message (borrowed `*const
+    /// c_char`).
     pub desc_mismatch_msg: *const c_char,
+    /// Record only: global-name hint for `desc_mismatch_msg` (borrowed
+    /// `*const c_char`).
     pub desc_mismatch_global_name: *const c_char,
 }
 
 #[repr(C)]
 pub struct RyAnyTryUnwrapDesc {
+    /// `kind` selector: 0 = Standard (tag-check primitive arm via
+    /// result_branch), 1 = F64Promote (f64 target with int auto-promote).
     pub kind: c_int,
+    /// Source any value (`RyValueId`).
     pub any_val_id: RyValueId,
+    /// `any` StructType handle (anyTy_) — opaque `RyTypeRef`.
     pub any_ty: RyTypeRef,
+    /// `Result<targetTy, Error>` StructType handle — opaque `RyTypeRef`.
     pub res_ty: RyTypeRef,
+    /// `Error` StructType handle (errorTy_) — opaque `RyTypeRef`.
     pub error_ty: RyTypeRef,
+    /// Standard: target LLVM type (i64 / i1 / ptr / ...). F64Promote: ignored
+    /// (f64 hard-coded). Opaque `RyTypeRef`.
     pub target_ty: RyTypeRef,
+    /// Standard only: expected RyAnyTag value (raw i64).
     pub expected_tag: i64,
+    /// Standard only: 1 = retain the collection element header (-16); same
+    /// semantics as `RyAnyUnwrapDesc`. Mapped to `bool`.
     pub do_collection_retain: c_int,
+    /// Standard only: 1 = retain the StringHeader (-24). Mutually exclusive
+    /// with `do_collection_retain`.
     pub do_str_retain: c_int,
+    /// Both kinds: error message string (`RyValueId`) stored into Error slot 0.
     pub err_msg_str_id: RyValueId,
 }
 

--- a/crates/emit/src/abi/any.rs
+++ b/crates/emit/src/abi/any.rs
@@ -81,6 +81,9 @@ unsafe fn opt_value_id(c: &EmitCtx, id: RyValueId) -> Option<ValueRef> {
     }
 }
 
+/// Wrap a value into `any` per `desc` (NonBox / RecordBox / EnumBox); return the
+/// interned boxed value, or 0 on a NULL guard or invalid kind. See
+/// `RyAnyWrapDesc` for the fields.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_any_wrap(
     ctx: *mut RyEmitCtx,
@@ -119,6 +122,9 @@ pub unsafe extern "C" fn ry_emit_any_wrap(
     }
 }
 
+/// Unwrap an `any` to a concrete type per `desc` (Standard / F64Promote /
+/// Record), emitting the tag / descriptor check and the mismatch trap; return
+/// the interned value, or 0 on a guard failure. See `RyAnyUnwrapDesc`.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_any_unwrap(
     ctx: *mut RyEmitCtx,
@@ -162,6 +168,9 @@ pub unsafe extern "C" fn ry_emit_any_unwrap(
     }
 }
 
+/// Fallibly unwrap an `any` per `desc` (Standard / F64Promote) into a
+/// `Result<T, Error>`; return the interned Result, or 0 on a guard failure. See
+/// `RyAnyTryUnwrapDesc`.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_any_try_unwrap(
     ctx: *mut RyEmitCtx,

--- a/crates/emit/src/abi/arc.rs
+++ b/crates/emit/src/abi/arc.rs
@@ -32,6 +32,8 @@ fn opt_value_ref(p: RyValueRef) -> Option<ValueRef> {
     }
 }
 
+/// Emit an ARC retain on the header at `header_ptr_id` (`atomic` selects atomic
+/// vs non-atomic); immortal objects are skipped. No-op on NULL ctx.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_arc_retain(
     ctx: *mut RyEmitCtx,
@@ -46,6 +48,9 @@ pub unsafe extern "C" fn ry_emit_arc_retain(
     c.arc_retain(header, atomicity_from(atomic));
 }
 
+/// Emit an ARC release on the header at `header_ptr_id` (`atomic` mode),
+/// invoking `destructor_callee` / `gc_visit_fn` when non-NULL on the free path.
+/// No-op on NULL ctx.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_arc_release(
     ctx: *mut RyEmitCtx,

--- a/crates/emit/src/abi/bounds.rs
+++ b/crates/emit/src/abi/bounds.rs
@@ -25,6 +25,10 @@ fn bounds_kind_from(kind: c_int) -> BoundsKind {
     }
 }
 
+/// Emit a bounds-check sequence for the interned index `idx_id` against length
+/// `len_id` (List or Array per `kind`); return the interned wrapped index for the
+/// caller's GEP. `global_name` / `bb_prefix` name the error string and generated
+/// blocks. Precondition: `ry_emit_ctx_set_function` must be set (BBs are created).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_bounds_check(
     ctx: *mut RyEmitCtx,
@@ -41,6 +45,9 @@ pub unsafe extern "C" fn ry_emit_bounds_check(
     intern(c, to_ry_value(result.0))
 }
 
+/// Emit `wrapped = (idx < 0) ? idx + wrap_base : idx` for interned `idx_id` /
+/// `wrap_base_id`; return the interned wrapped index (i64). `prefix` names the
+/// generated blocks.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_negative_index_wrap(
     ctx: *mut RyEmitCtx,
@@ -55,6 +62,10 @@ pub unsafe extern "C" fn ry_emit_negative_index_wrap(
     intern(c, to_ry_value(result.0))
 }
 
+/// Emit the out-of-bounds exit (`fprintf(stderr, fmt_msg, orig_idx, len)` → exit
+/// → unreachable) for interned `orig_idx_id` / `len_id`. `fmt_msg` needs two
+/// `%lld`; `global_name` hints the dedup'd format-string global. The caller must
+/// split BBs around this call (it terminates the current block).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_bounds_error(
     ctx: *mut RyEmitCtx,

--- a/crates/emit/src/abi/collection.rs
+++ b/crates/emit/src/abi/collection.rs
@@ -11,6 +11,8 @@ use crate::core::{TypeRef, ValueRef};
 
 use super::*;
 
+/// Append the interned `val_id` to the List at `list_ptr_id` (growing the buffer
+/// in place); `list_header_ty` / `elem_ty` / `elem_size` describe the layout.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_collection_append(
     ctx: *mut RyEmitCtx,
@@ -32,6 +34,8 @@ pub unsafe extern "C" fn ry_emit_collection_append(
     );
 }
 
+/// Insert the interned `val_id` at `idx_id` into the List at `list_ptr_id`
+/// (negative index wrapped, shifting the tail up).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_collection_insert(
     ctx: *mut RyEmitCtx,
@@ -56,6 +60,8 @@ pub unsafe extern "C" fn ry_emit_collection_insert(
     );
 }
 
+/// Remove the element at `idx_id` from the List at `list_ptr_id` and return the
+/// interned removed value (negative index wrapped, shifting the tail down).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_collection_remove_at(
     ctx: *mut RyEmitCtx,
@@ -78,6 +84,9 @@ pub unsafe extern "C" fn ry_emit_collection_remove_at(
     intern(c, to_ry_value(removed.0))
 }
 
+/// Slice the List at `list_ptr_id` over `[start_id, end_excl_id)`; write the
+/// interned clamped element count and the freshly-malloc'd sub-list buffer into
+/// the `out_count` / `out_new_data` out-params (the engine's `SliceParts` split).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_list_slice(
     ctx: *mut RyEmitCtx,

--- a/crates/emit/src/abi/control_flow.rs
+++ b/crates/emit/src/abi/control_flow.rs
@@ -9,6 +9,8 @@ use crate::core::{BasicBlockRef, FunctionRef, TypeRef, ValueRef};
 
 use super::*;
 
+/// Create a fresh basic block named `name` inside `fn_handle` and return its
+/// opaque handle. NULL `name` is treated as empty.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_create_basic_block(
     ctx: *mut RyEmitCtx,
@@ -23,6 +25,8 @@ pub unsafe extern "C" fn ry_emit_create_basic_block(
     )
 }
 
+/// Emit a conditional branch on the interned i1 `cond` to `true_bb` / `false_bb`
+/// at the builder's current insert point (insert point unchanged).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_branch_cond(
     ctx: *mut RyEmitCtx,
@@ -39,12 +43,17 @@ pub unsafe extern "C" fn ry_emit_branch_cond(
     );
 }
 
+/// Emit an unconditional branch to `target` at the builder's current insert
+/// point (insert point unchanged).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_branch_uncond(ctx: *mut RyEmitCtx, target: RyBasicBlockRef) {
     let c = cx(ctx);
     c.branch_uncond(BasicBlockRef(as_bb(target)));
 }
 
+/// Emit a PHI of type `ty` from `count` parallel (value, block) incoming pairs
+/// (`incoming_values` / `incoming_blocks`) at the builder's current insert point;
+/// return the interned PHI handle. NULL `name_hint` is treated as empty.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_create_phi(
     ctx: *mut RyEmitCtx,

--- a/crates/emit/src/abi/cow.rs
+++ b/crates/emit/src/abi/cow.rs
@@ -46,6 +46,11 @@ fn cow_kind_from(kind: c_int) -> Option<CowKind> {
     }
 }
 
+/// Emit the Copy-on-Write uniqueness check for the slot described by `desc`: if
+/// the collection is shared, deep-copy it, release the old header, and store the
+/// new dataPtr; return the interned dataPtr PHI (original or copied), or 0 on a
+/// NULL guard / invalid kind. See `RyCowEnsureUniqueDesc`. Precondition:
+/// `ry_emit_ctx_set_function` must be set (BBs are created).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_cow_ensure_unique(
     ctx: *mut RyEmitCtx,

--- a/crates/emit/src/abi/lifecycle.rs
+++ b/crates/emit/src/abi/lifecycle.rs
@@ -10,6 +10,9 @@ use crate::core::EmitCtx;
 
 use super::*;
 
+/// Construct an `EmitCtx` from the LLVM module / builder / context / function
+/// handles and return the owning opaque handle (boxed; freed by
+/// `ry_emit_ctx_destroy`).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_ctx_create(
     module: RyModuleRef,
@@ -26,6 +29,7 @@ pub unsafe extern "C" fn ry_emit_ctx_create(
     Box::into_raw(boxed) as *mut RyEmitCtx
 }
 
+/// Free the `EmitCtx` created by `ry_emit_ctx_create`. NULL is a no-op.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_ctx_destroy(ctx: *mut RyEmitCtx) {
     if !ctx.is_null() {
@@ -33,16 +37,21 @@ pub unsafe extern "C" fn ry_emit_ctx_destroy(ctx: *mut RyEmitCtx) {
     }
 }
 
+/// Update the cached current function. Retained pending deprecation (#1968):
+/// BB-creating ops derive the parent from the builder, not this field.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_ctx_set_function(ctx: *mut RyEmitCtx, function: RyFunctionRef) {
     cx(ctx).function = function as LLVMValueRef;
 }
 
+/// Intern an opaque `value` handle into a `RyValueId` (sentinel 0 = invalid).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_intern(ctx: *mut RyEmitCtx, value: RyValueRef) -> RyValueId {
     intern(cx(ctx), value)
 }
 
+/// Resolve a `RyValueId` back to its opaque value handle (inverse of
+/// `ry_emit_intern`).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_resolve(ctx: *mut RyEmitCtx, id: RyValueId) -> RyValueRef {
     resolve(cx(ctx), id)

--- a/crates/emit/src/abi/option.rs
+++ b/crates/emit/src/abi/option.rs
@@ -6,6 +6,8 @@ use crate::core::{TypeRef, ValueRef};
 
 use super::*;
 
+/// Wrap the interned `inner_id` into a `Some` of Option type `opt_ty`; return the
+/// interned aggregate.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_option_wrap_some(
     ctx: *mut RyEmitCtx,
@@ -18,6 +20,7 @@ pub unsafe extern "C" fn ry_emit_option_wrap_some(
     intern(c, to_ry_value(val.0))
 }
 
+/// Build a `None` of Option type `opt_ty`; return the interned aggregate.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_option_wrap_none(
     ctx: *mut RyEmitCtx,

--- a/crates/emit/src/abi/result.rs
+++ b/crates/emit/src/abi/result.rs
@@ -18,6 +18,9 @@ use crate::result::emit_result_branch;
 
 use super::*;
 
+/// Build an `Error` aggregate by calling runtime error function `err_fn_name`,
+/// with `error_ty` the opaque Error StructType; return the interned value.
+/// Returns 0 (sentinel) on NULL ctx / name / type or an uninitialized emitter.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_build_error_from_runtime(
     ctx: *mut RyEmitCtx,
@@ -37,6 +40,10 @@ pub unsafe extern "C" fn ry_emit_build_error_from_runtime(
     intern(c, to_ry_value(result.0))
 }
 
+/// Emit a `Result` branch: three BBs (res.ok / res.err / res.merge) joined by a
+/// PHI, with `build_ok` / `build_err` (forwarded `user_ctx`) emitting each arm;
+/// return the interned PHI. Returns 0 on NULL inputs. Precondition:
+/// `ry_emit_ctx_set_function` must be set (three BBs are created).
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_result_branch(
     ctx: *mut RyEmitCtx,

--- a/crates/emit/src/abi/runtime_call.rs
+++ b/crates/emit/src/abi/runtime_call.rs
@@ -11,6 +11,10 @@ use crate::core::{FuncTypeRef, TypeRef, ValueRef};
 
 use super::*;
 
+/// Emit a call to runtime function `name` (return type `ret_ty`) with the
+/// `arg_count` interned `arg_ids` typed by the parallel `arg_tys` (`arg_ty_count`
+/// must equal `arg_count`); return the interned call result. Returns 0 on NULL /
+/// count-mismatch / per-arg NULL. `name_hint` is optional.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_runtime_call(
     ctx: *mut RyEmitCtx,
@@ -76,6 +80,8 @@ pub unsafe extern "C" fn ry_emit_runtime_call(
     intern(c, to_ry_value(result.0))
 }
 
+/// Look up or declare runtime function `name` of type `fn_ty` and return its raw
+/// (un-interned) callee handle. Returns NULL on a guard failure.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_get_runtime_fn(
     ctx: *mut RyEmitCtx,

--- a/crates/emit/src/any.rs
+++ b/crates/emit/src/any.rs
@@ -24,48 +24,85 @@ use crate::core::*;
 // calling the engine. The C `RyAnyWrapDesc` stays the locked boundary surface in
 // `abi.rs`; this is its core-side counterpart, consumed only here.
 pub(crate) struct AnyWrap {
+    /// `kind` validated into `AnyWrapKind` (NonBox / RecordBox / EnumBox).
     pub(crate) kind: AnyWrapKind,
+    /// RyAnyTag to store in any.tag (raw i64).
     pub(crate) target_tag: i64,
+    /// Resolved `val_id` — the value to wrap.
     pub(crate) val: ValueRef,
+    /// `do_collection_retain` as `bool` (NonBox).
     pub(crate) do_collection_retain: bool,
+    /// `do_str_retain` as `bool` (NonBox; exclusive with the above).
     pub(crate) do_str_retain: bool,
+    /// Box arms: resolved `descriptor_id` (per-type descriptor constant).
     pub(crate) descriptor: Option<ValueRef>,
+    /// Box arms: resolved `box_layout_ty` (`{ ptr desc, payload }` struct).
     pub(crate) box_layout_ty: Option<TypeRef>,
+    /// Box arms: allocation size of `box_layout_ty` in bytes.
     pub(crate) box_data_size: u64,
+    /// The `any` StructType.
     pub(crate) any_ty: TypeRef,
 }
 
-// Rust-native descriptor for any_unwrap. The message / global-name fields stay
-// `*const c_char` (per the #2059 Section A name convention); the engine calls
-// `cstr_bytes` at the point of use, keeping this struct Copy / lifetime-free.
+// Rust-native descriptor for any_unwrap (core-side counterpart of the C
+// `RyAnyUnwrapDesc` in `abi.rs`; see there for per-field semantics). The message
+// / global-name fields stay `*const c_char` (per the #2059 Section A name
+// convention); the engine calls `cstr_bytes` at the point of use, keeping this
+// struct Copy / lifetime-free.
 pub(crate) struct AnyUnwrap {
+    /// `kind` validated into `AnyUnwrapKind` (Standard / F64Promote / Record).
     pub(crate) kind: AnyUnwrapKind,
+    /// Resolved `any_val_id` — the source any value.
     pub(crate) any_val: ValueRef,
+    /// The `any` StructType.
     pub(crate) any_ty: TypeRef,
+    /// Standard: target LLVM type; Record / F64Promote: `None` (unused).
     pub(crate) target_ty: Option<TypeRef>,
+    /// Standard / Record: expected RyAnyTag value (raw i64).
     pub(crate) expected_tag: i64,
+    /// `do_collection_retain` as `bool` (Standard).
     pub(crate) do_collection_retain: bool,
+    /// `do_str_retain` as `bool` (Standard; exclusive with the above).
     pub(crate) do_str_retain: bool,
+    /// Tag-mismatch error message (borrowed `*const c_char`, read via
+    /// `cstr_bytes` at the point of use).
     pub(crate) mismatch_msg: *const c_char,
+    /// cachedGlobalString name hint for `mismatch_msg`.
     pub(crate) mismatch_global_name: *const c_char,
+    /// Record only: resolved `expected_desc_id` (expected descriptor constant).
     pub(crate) expected_desc: Option<ValueRef>,
+    /// Record only: resolved `box_layout_ty` (`{ ptr desc, record struct }`).
     pub(crate) box_layout_ty: Option<TypeRef>,
+    /// Record only: the record's struct type for the payload GEP/load.
     pub(crate) record_struct_ty: Option<TypeRef>,
+    /// Record only: descriptor-mismatch error message (borrowed `*const c_char`).
     pub(crate) desc_mismatch_msg: *const c_char,
+    /// Record only: name hint for `desc_mismatch_msg`.
     pub(crate) desc_mismatch_global_name: *const c_char,
 }
 
-// Rust-native descriptor for any_try_unwrap.
+// Rust-native descriptor for any_try_unwrap (core-side counterpart of the C
+// `RyAnyTryUnwrapDesc` in `abi.rs`; see there for per-field semantics).
 pub(crate) struct AnyTryUnwrap {
+    /// `kind` validated into `AnyTryUnwrapKind` (Standard / F64Promote).
     pub(crate) kind: AnyTryUnwrapKind,
+    /// Resolved `any_val_id` — the source any value.
     pub(crate) any_val: ValueRef,
+    /// The `any` StructType.
     pub(crate) any_ty: TypeRef,
+    /// `Result<targetTy, Error>` StructType.
     pub(crate) res_ty: TypeRef,
+    /// `Error` StructType.
     pub(crate) error_ty: TypeRef,
+    /// Standard: target LLVM type; F64Promote: `None` (f64 hard-coded).
     pub(crate) target_ty: Option<TypeRef>,
+    /// Standard only: expected RyAnyTag value (raw i64).
     pub(crate) expected_tag: i64,
+    /// `do_collection_retain` as `bool` (Standard).
     pub(crate) do_collection_retain: bool,
+    /// `do_str_retain` as `bool` (Standard; exclusive with the above).
     pub(crate) do_str_retain: bool,
+    /// Resolved `err_msg_str_id` — stored into Error slot 0.
     pub(crate) err_msg_str: ValueRef,
 }
 

--- a/crates/emit/src/core.rs
+++ b/crates/emit/src/core.rs
@@ -3,8 +3,10 @@
 //! `Atomicity` handle types, the basic-IR layer (LLVM 1:1 type constructors),
 //! and the combination layer (name builders, module-global lookup, layout
 //! constants, the libc / runtime-error / ARC-alloc emitters). Must NOT reference
-//! `crate::abi` — this is the `core⇏abi` invariant (#2057); the only dependency
-//! is on `llvm_sys` + `std`.
+//! `crate::abi` — the `core⇏abi` invariant (#2057): `core` stays compilable
+//! without the removable `abi` C shell (the #2023 Rust-native end-state), and
+//! `core`'s rlib does not depend on the `abi` cdylib once the crate split lands.
+//! The only dependency is `llvm_sys` + `std`. See `lib.rs` for the full layering.
 
 use std::collections::HashMap;
 use std::ffi::{c_char, CStr, CString};

--- a/crates/emit/src/cow.rs
+++ b/crates/emit/src/cow.rs
@@ -21,20 +21,34 @@ use crate::core::*;
 // resolves the u32 handle ids to `ValueRef`, maps the `c_int` kind / atomic and
 // the flag fields into core vocabulary (`CowKind` / `Atomicity` / `bool` /
 // `Option<ValueRef>`), and builds this before calling the engine method. The C
-// `RyCowEnsureUniqueDesc` stays the locked boundary surface in `abi.rs`; this is
-// its core-side counterpart, consumed only here.
+// `RyCowEnsureUniqueDesc` stays the locked boundary surface in `abi.rs` (see
+// there for the per-field semantics); this is its already-converted core-side
+// counterpart, consumed only here, so the docs below note just the post-shell
+// form.
 pub(crate) struct CowEnsureUnique {
+    /// Resolved `data_ptr_id`.
     pub(crate) data_ptr: ValueRef,
+    /// Resolved `slot_ptr_id`.
     pub(crate) slot_ptr: ValueRef,
+    /// `kind` validated into `CowKind`.
     pub(crate) kind: CowKind,
+    /// `atomic` mapped to `Atomicity`.
     pub(crate) atomic: Atomicity,
+    /// Element byte size (List / Set).
     pub(crate) elem_size: u64,
+    /// Key byte size (Map).
     pub(crate) key_size: u64,
+    /// Value byte size (Map).
     pub(crate) val_size: u64,
+    /// `do_elem_retain` as `bool`.
     pub(crate) do_elem_retain: bool,
+    /// `elem_is_str` as `bool` (retain header-offset selector).
     pub(crate) elem_is_str: bool,
+    /// `do_key_retain` as `bool`.
     pub(crate) do_key_retain: bool,
+    /// `key_is_str` as `bool` (retain header-offset selector).
     pub(crate) key_is_str: bool,
+    /// Resolved `destructor_callee` (`None` when null).
     pub(crate) destructor_callee: Option<ValueRef>,
 }
 

--- a/crates/emit/src/lib.rs
+++ b/crates/emit/src/lib.rs
@@ -58,8 +58,13 @@
 //     migrated, no legacy module remains.
 //
 // Dependency direction is one-way `abi → core`, with `ffi` re-exporting the
-// `core` surface. The `#[no_mangle] extern "C"` boundary functions are exported
-// from the cdylib regardless of which (private) module they live in.
+// `core` surface. Why one-way: `abi` is the *removable* C-boundary shell — the
+// #2023 end-state drops `extern "C"` for a Rust-native library — so `core` must
+// stay compilable without it; once the physical crate split lands `abi` becomes
+// a separate cdylib that `core`'s rlib does not depend on, and Rust-direct
+// callers bypass `abi` to call `core` methods (the convergence point `ffi`
+// names). The `#[no_mangle] extern "C"` boundary functions are exported from the
+// cdylib regardless of which (private) module they live in.
 
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]


### PR DESCRIPTION
`crates/emit`（LLVM IR emission cdylib）のコメントのみ拡充。コード挙動の変更なし（#2057-#2063 の abi/core/ffi 層化の可読性向上）。

## 内容（issue の3観点）
- **descriptor 各フィールドの意図**: `abi.rs` の4つの `#[repr(C)]` descriptor（`RyCowEnsureUniqueDesc` / `RyAnyWrapDesc` / `RyAnyUnwrapDesc` / `RyAnyTryUnwrapDesc`）全フィールドに `///` doc。`api.h` の既存フィールド記述を Rust 型へ翻案し、id⇔ref の区別（`RyValueId` は `resolve`、`RyValueRef` / `RyTypeRef` は opaque 素通し）を明示。Rust-native 対応構造体は post-shell（変換後）形に絞り `abi.rs` を参照。
- **abi↔core 責務境界**: `abi/*.rs` の全28 `#[no_mangle]` extern に `///` 契約 doc（op・引数・戻り値・前提）。module `//!` の shell パターン記述と補完関係。
- **層化の why**: `lib.rs` / `core.rs` に `core⇏abi` 一方向依存の理由（`abi` は除去可能な C シェル＝#2023 end-state、`core` は単独コンパイル可能）を point-of-use で追記。

## 検証
- `cargo fmt --check` / `clippy -D warnings` / `check-emit-abi-no-ir.sh` clean
- ビルド（rust-emit）成功、`ry_tests` 2553 passed、`ry test -p` 204 files / 0 failures
- コメントは codegen に到達せず IR バイト同一（`///`→`#[doc]` メタデータ、`//` は除去）

Closes #2076

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added extensive Rust documentation for internal C API boundary functions and descriptor structures, clarifying behavior, preconditions, return values, and edge-case handling across multiple modules. No functional changes or user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->