### PR TITLE
fix(fmt): preserve regex literals

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -451,3 +451,25 @@ This also applies to the signed-suffix path — add `-9223372036854775808i64` to
 signed-low-level-suffix branch. Always use unsigned subtraction for `negBits`; never
 negate a `uint64_t` value via `static_cast<int64_t>` when the magnitude may equal 2^(N-1).
 
+### `formatExprInner` literal branches: escape strategy depends on whether the lexer decoded or preserved escapes — and `verifyFormatting`'s text-idempotency check does NOT catch a dispatch miss
+
+**Source**: #2113 (2026-06-13, fix)
+**Tags**: formatter, regex-literal, string-literal, escape, lexer-asymmetry, verifyFormatting, blind-spot
+
+**Context**: `formatExprInner` in `src/formatter.cpp` dispatches `ExprNode` variants via an `if constexpr` chain ending in a `/* unknown expr */` fallthrough. `StringExpr` routes its value through `escapeString` because the lexer **decoded** `\n` / `\t` / `\\` / `\"` / `\0` into the corresponding bytes (`src/lexer/lexer.cpp` string branch). `RegexExpr` looks like a sibling literal, but the lexer **preserves** the two-byte sequence `\` + next-char verbatim — `/\d+/` produces `pattern = "\d+"` (3 bytes: `\`, `d`, `+`). The only translation the regex lexer performs is `\0` → a single NUL byte. So `RegexExpr` must emit `v.pattern` verbatim and only reverse the NUL translation; routing through `escapeString` would turn `\d` into `\\d`, changing the regex semantics silently.
+
+Why `Formatter::verifyFormatting` (`src/formatter.cpp:778-791`) does **not** rescue a missing dispatch arm: the check is **text idempotency** (`formatSource(formatSource(x)) == formatSource(x)`), not AST equivalence. `/* unknown expr */` appears in a value-token context after a comma (`replace("…", X, "…")`), where the lexer treats the leading `/` as the start of a regex literal (the preceding `,` is not in the lexer's value-producing exclusion set). The whole sequence parses as `RegexExpr{pattern: "* unknown expr *"}`, which the formatter then re-emits via the same fallthrough into the **same** `/* unknown expr */` text. The output is a perfect fixed point of the formatter, so idempotency passes — but the runtime regex engine fails to compile `* unknown expr *`. Likewise inside string-arg position the comment-form is its own fixed point. A missing dispatch arm therefore ships silently.
+
+**Rule**:
+
+1. When adding a new literal kind to `formatExprInner`, look at the lexer's storage form for that kind before choosing the escape strategy:
+   - lexer **decoded** the escapes (escape sequences became bytes) → route through `escapeString` (the StringExpr pattern);
+   - lexer **preserved** the escapes (two-byte `\<x>` kept as-is) → emit `v.<field>` verbatim and only undo any one-off translations (for `RegexExpr` that is NUL → `\0`).
+2. The discriminating test for any verbatim-emit branch is a backslash-bearing input that is *not* a single-char escape (`/\d+/` works because the lexer keeps both bytes; a string literal `"\d+"` would be a parse-time decision and not the same case). The round-trip test must use a backslash sequence that survives the lexer two-byte preserved, because that is the form `escapeString` would corrupt.
+3. Do not rely on `verifyFormatting` to catch a dispatch miss. The `/* unknown expr */` fallthrough is a fixed point of the formatter in every value-token context (after `=`, `,`, `(`, `[`, etc.). Each new variant added to `ExprNode` must come with at least one direct round-trip test in `tests/test_formatter.cpp`.
+
+**How to apply**:
+- Same site whenever extending `formatExprInner`: insert the branch next to siblings, then immediately add a `tests/test_formatter.cpp` test that includes a backslash-bearing input. The test is the primary guard — `verifyFormatting` is not.
+- If a future PR makes `verifyFormatting` AST-aware (current scope rejects it — fixing it would also need a roundtrip-AST equality helper that ignores doc-comment whitespace), this rule's #3 can be relaxed. Until then, treat the safety net as text-level only.
+- Adjacent invariant: `src/lexer/lexer.cpp` regex branch (lines 325–360) and `RegexExpr::pattern` (`include/ry/ast/ast.hpp`) form a contract — backslash-anything is two-byte preserved, only `\0` is one-byte translated. A future addition of regex flags (`/pattern/i`) or a new translation would invalidate the "NUL is the only lossy translation" assumption and the `RegexExpr` formatter branch must be updated in the same PR.
+

--- a/changelog.d/2113-fix-fmt-regex-literal.md
+++ b/changelog.d/2113-fix-fmt-regex-literal.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `ry fmt` now preserves regex literals (`/pattern/`) instead of replacing them with `/* unknown expr */`. The formatter's expression dispatch was missing a `RegexExpr` branch and silently fell through to the unknown-expression placeholder, so any source containing a regex literal formatted to a file that no longer ran. The fix emits the pattern verbatim (the lexer already preserves regex backslashes such as `\d` / `\w` / `\/` byte for byte) and reverses the lexer's only lossy translation by re-encoding embedded NUL bytes as `\0`. (#2113)

--- a/src/formatter.cpp
+++ b/src/formatter.cpp
@@ -270,6 +270,16 @@ std::string Formatter::formatExprInner(const ExprNode &expr) {
             return v.value ? "true" : "false";
         } else if constexpr (std::is_same_v<T, StringExpr>) {
             return "\"" + escapeString(v.value) + "\"";
+        } else if constexpr (std::is_same_v<T, RegexExpr>) {
+            // Lexer stores regex backslashes verbatim (so `escapeString` would
+            // turn `\d` into `\\d`); only NUL is its lossy translation. #2113.
+            std::string out = "/";
+            for (char c : v.pattern) {
+                if (c == '\0') out += "\\0";
+                else out += c;
+            }
+            out += "/";
+            return out;
         } else if constexpr (std::is_same_v<T, VariableExpr>) {
             return v.name;
         } else if constexpr (std::is_same_v<T, NoneExpr>) {

--- a/tests/test_formatter.cpp
+++ b/tests/test_formatter.cpp
@@ -28,6 +28,22 @@ TEST(Formatter, LiteralFormatting) {
     EXPECT_EQ(fmt("x = none\n"), "x = none\n");
 }
 
+// ===== Regex Literal Formatting (#2113) =====
+
+TEST(Formatter, RegexLiteralFormatting) {
+    EXPECT_EQ(fmt("x = /abc/\n"), "x = /abc/\n");
+    // Discriminating: lexer keeps regex backslashes verbatim, so routing
+    // pattern through escapeString would emit /\\d+/ and break regex meaning.
+    EXPECT_EQ(fmt("x = /\\d+/\n"), "x = /\\d+/\n");
+    EXPECT_EQ(fmt("x = /a\\/b/\n"), "x = /a\\/b/\n");
+    // Lexer translates `\0` -> literal NUL inside pattern; formatter must
+    // reverse it so the output file stays text and remains executable.
+    EXPECT_EQ(fmt("x = /a\\0b/\n"), "x = /a\\0b/\n");
+    // End-to-end repro from the issue body.
+    EXPECT_EQ(fmt("from regex import replace\nprint(replace(\"order-12\", /\\d+/, \"N\"))\n"),
+              "from regex import replace\nprint(replace(\"order-12\", /\\d+/, \"N\"))\n");
+}
+
 // ===== Expression Formatting =====
 
 TEST(Formatter, ExpressionFormatting) {


### PR DESCRIPTION
## Summary

- `formatExprInner` was missing a `RegexExpr` branch, so any source containing a regex literal flowed into the `/* unknown expr */` fallthrough. The corrupted output parsed cleanly and even passed `verifyFormatting`'s text-idempotency check as a fixed point, only failing at runtime when the regex engine choked on `* unknown expr *`.
- Emit `v.pattern` verbatim (the lexer preserves regex backslashes, so `escapeString` would double-escape `\d` → `\\d`) and reverse the lexer's only lossy translation (NUL → `\0`) so the formatted file stays text and remains executable.
- Captured the broader literal-kind escape-strategy lesson and the `verifyFormatting` text-level blind spot in `.claude/rules/parser-conventions.md`.

Closes #2113

## Test plan

- [x] `Formatter.RegexLiteralFormatting` added with discriminating sub-cases (`/\d+/` against the `escapeString` trap, `/a\0b/` for the NUL round-trip, plus the issue's exact repro).
- [x] `./build-rust/ry_tests` — 2632 / 2632 passed.
- [x] `./build-rust/ry test -p` — 204 / 204 self-test files passed.
- [x] ASan + UBSan (Docker) — clean.
- [x] TSan (Docker) — clean, no race.
- [x] clang-tidy + cppcheck — clean. scan-build's 2 findings are pre-existing dead-assignments in `codegen_fn.cpp` / `codegen_stmt.cpp`, outside this diff.
- [x] Issue repro: `./build-rust/ry fmt` on `from regex import replace; print(replace("order-12", /\d+/, "N"))` round-trips byte-identical and the formatted file prints `order-N`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed regex literal formatting—patterns like `/pattern/` are now preserved correctly during formatting instead of being converted to placeholder text.

* **Tests**
  * Added comprehensive test coverage for regex literal formatting behavior, including validation of escaped characters and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->