### PR TITLE
feat(stdlib): add get overloads for List index access

### DIFF
--- a/changelog.d/2116-list-get-overloads.md
+++ b/changelog.d/2116-list-get-overloads.md
@@ -1,0 +1,3 @@
+### Added
+
+- `List<T>` now supports `get(list, index) -> Option<T>` and `get(list, index, default) -> T` overloads, symmetric to the existing `Map<K, V>` `get`. Semantics mirror `list[index]?`: negative indices wrap around, out-of-range (after wrap) returns `None` / the default. Both direct-call (`get(xs, i)`) and UFCS (`xs.get(i)`) forms are supported. (#2116)

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -146,6 +146,8 @@ print(xs[100]? ?? 0) # 0           — coalesce with default (note the space bef
 
 Restrictions: read-only — `xs[i]? = v` is a compile error; range-index `xs[a..b]?` is a compile error.
 
+For an explicit named-function alternative with the same Option-returning semantics, use [`get(xs, i)`](#get).
+
 ### Index Assignment
 
 ```ry
@@ -242,6 +244,25 @@ v = xs.pop()
 print(v)    # Some(3)
 print(xs)   # [1, 2]
 ```
+
+### get
+
+Two overloads are available:
+
+- `get(list, index) -> Option<T>`: Returns `Some(value)` for an in-range index, or `None` for an out-of-range one. Negative indices wrap around from the end, matching [`xs[i]?`](#safe-index-access-xsi) semantics.
+- `get(list, index, default) -> T`: Returns the value at the index, or `default` for any out-of-range case (including a negative index whose wrap is still out of range).
+
+```ry
+xs = [10, 20, 30]
+print(get(xs, 1))        # Some(20)
+print(xs.get(100))       # None
+print(get(xs, -1))       # Some(30)  — negative wrap to last
+print(xs.get(-4))        # None       — wrap result still out of range
+print(get(xs, 100, 0))   # 0
+print(xs.get(-1, 0))     # 30
+```
+
+This is the named-function counterpart of [`xs[i]?`](#safe-index-access-xsi) and shares its wrap-then-bounds-check rule; it leaves the abort-on-out-of-range behavior of `xs[i]` unchanged. The same shape is available on `Map<K, V>` — see [`get`](#get-1) under Map.
 
 ### reverse
 
@@ -792,7 +813,7 @@ print(m["z"]? ?? -1)            # -1 — coalesce with default (note the space b
 
 Restrictions: read-only — `m[k]? = v` is a compile error (use `m[k] = v` to insert / update).
 
-For an explicit named-function alternative with the same Option-returning semantics, use [`get(m, k)`](#get).
+For an explicit named-function alternative with the same Option-returning semantics, use [`get(m, k)`](#get-1).
 
 ### Insert and Update
 

--- a/share/std/list.ry
+++ b/share/std/list.ry
@@ -9,6 +9,14 @@ fn pop(values: List<int>) -> Option<int>
 
 @public
 @native
+fn get(values: List<int>, index: int) -> Option<int>
+
+@public
+@native
+fn get(values: List<int>, index: int, default: int) -> int
+
+@public
+@native
 fn insert(values: List<int>, index: int, value: int) -> Unit
 
 @public

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -875,12 +875,19 @@ llvm::Value *CodeGen::emitCollOp_items(const CallExpr &e) {
 }
 
 llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
-    // get(map, key) -- 2-arg -> Option<V>
-    if (e.args.size() == 2) {
-        llvm::Value *mapPtr = emitExpr(*e.args[0]);
-        llvm::Type *keyTy = getMapKeyType(mapPtr);
-        llvm::Type *valTy = getMapValueType(mapPtr);
-        if (keyTy && valTy) {
+    if (e.args.size() != 2 && e.args.size() != 3)
+        return nullptr;
+
+    llvm::Value *recv = emitExpr(*e.args[0]);
+
+    // Map branch ---------------------------------------------------------
+    if (llvm::Type *keyTy = getMapKeyType(recv)) {
+        llvm::Type *valTy = getMapValueType(recv);
+        if (!valTy)
+            return nullptr;
+
+        // get(map, key) -- 2-arg -> Option<V>
+        if (e.args.size() == 2) {
             llvm::Value *key = emitExpr(*e.args[1]);
             if (key->getType() != keyTy)
                 codegenError("get() key type mismatch");
@@ -889,7 +896,7 @@ llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
             // mapHeader vals-field struct GEP + load, and value GEP + load
             // cross via generic primitives. emitMapKeyLookup is already
             // boundary-emitted via #2101 (hash lookup capability).
-            llvm::Value *idx = emitMapKeyLookup(mapPtr, key, keyTy);
+            llvm::Value *idx = emitMapKeyLookup(recv, key, keyTy);
             llvm::Value *found = emitICmpSGE(idx, emitConstInt(i64Ty_, 0), "get2_found");
 
             llvm::BasicBlock *foundBB = createBB("get2.found");
@@ -898,7 +905,7 @@ llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
             emitBranchCond(found, foundBB, notFoundBB);
 
             builder_.SetInsertPoint(foundBB);
-            llvm::Value *valsPtrField = emitStructGEP(mapHeaderTy_, mapPtr, 3, "get2_vals_field");
+            llvm::Value *valsPtrField = emitStructGEP(mapHeaderTy_, recv, 3, "get2_vals_field");
             llvm::Value *valsPtr = emitLoad(ptrTy_, valsPtrField, "get2_vals");
             llvm::Value *valPtr = emitGEP(valTy, valsPtr, idx, "get2_val_ptr");
             llvm::Value *foundVal = emitLoad(valTy, valPtr, "get2_val");
@@ -917,52 +924,150 @@ llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
             phi->addIncoming(noneVal, notFoundEndBB);
             return phi;
         }
+
+        // get(map, key, default) -- 3-arg
+        llvm::Value *key = emitExpr(*e.args[1]);
+        if (key->getType() != keyTy)
+            codegenError("get() key type mismatch");
+        llvm::Value *defaultVal = emitExpr(*e.args[2]);
+        if (defaultVal->getType() != valTy)
+            codegenError("get() default value type must match map's value type");
+        // #2094 ([C] = (ii) boundary move): same primitives as the 2-arg
+        // arm — the only structural difference is the merge PHI types
+        // (V vs Option<V>) and the default-value tail vs None.
+        llvm::Value *idx = emitMapKeyLookup(recv, key, keyTy);
+        llvm::Value *found = emitICmpSGE(idx, emitConstInt(i64Ty_, 0), "get_found");
+
+        llvm::BasicBlock *foundBB = createBB("get.found");
+        llvm::BasicBlock *notFoundBB = createBB("get.notfound");
+        llvm::BasicBlock *mergeBB = createBB("get.merge");
+        emitBranchCond(found, foundBB, notFoundBB);
+
+        builder_.SetInsertPoint(foundBB);
+        llvm::Value *valsPtrField = emitStructGEP(mapHeaderTy_, recv, 3, "get_vals_field");
+        llvm::Value *valsPtr = emitLoad(ptrTy_, valsPtrField, "get_vals");
+        llvm::Value *valPtr = emitGEP(valTy, valsPtr, idx, "get_val_ptr");
+        llvm::Value *foundVal = emitLoad(valTy, valPtr, "get_val");
+        llvm::BasicBlock *foundEndBB = builder_.GetInsertBlock();
+        emitBranchUncond(mergeBB);
+
+        builder_.SetInsertPoint(notFoundBB);
+        llvm::BasicBlock *notFoundEndBB = builder_.GetInsertBlock();
+        emitBranchUncond(mergeBB);
+
+        builder_.SetInsertPoint(mergeBB);
+        llvm::PHINode *phi = createPhi(valTy, {}, "get_result");
+        phi->addIncoming(foundVal, foundEndBB);
+        phi->addIncoming(defaultVal, notFoundEndBB);
+        return phi;
     }
 
-    // get(map, key, default) -- 3-arg
-    if (e.args.size() == 3) {
-        llvm::Value *mapPtr = emitExpr(*e.args[0]);
-        llvm::Type *keyTy = getMapKeyType(mapPtr);
-        llvm::Type *valTy = getMapValueType(mapPtr);
-        if (keyTy && valTy) {
-            llvm::Value *key = emitExpr(*e.args[1]);
-            if (key->getType() != keyTy)
-                codegenError("get() key type mismatch");
-            llvm::Value *defaultVal = emitExpr(*e.args[2]);
-            if (defaultVal->getType() != valTy)
-                codegenError("get() default value type must match map's value type");
-            // #2094 ([C] = (ii) boundary move): same primitives as the 2-arg
-            // arm — the only structural difference is the merge PHI types
-            // (V vs Option<V>) and the default-value tail vs None.
-            llvm::Value *idx = emitMapKeyLookup(mapPtr, key, keyTy);
-            llvm::Value *found = emitICmpSGE(idx, emitConstInt(i64Ty_, 0), "get_found");
+    // List branch --------------------------------------------------------
+    // get(list, index) -> Option<T> / get(list, index, default) -> T
+    // Mirrors `xs[i]?` semantics (codegen_expr_literal.cpp): negative-index
+    // wrap, OOB → None / default, in-range → Some(elem) / elem.
+    llvm::Type *elemTy = getListElementType(recv);
+    if (!elemTy)
+        return nullptr;
 
-            llvm::BasicBlock *foundBB = createBB("get.found");
-            llvm::BasicBlock *notFoundBB = createBB("get.notfound");
-            llvm::BasicBlock *mergeBB = createBB("get.merge");
-            emitBranchCond(found, foundBB, notFoundBB);
+    // Snapshot list element metadata BEFORE any call that may rehash
+    // value_metadata_ (propagateTypeMeta / buildSomeValue / getOptionType / emitExpr).
+    std::string elemTypeName;
+    std::optional<FnTypeInfo> elemFnTypeInfo;
+    bool listElemIsStr = false;
+    if (auto *listMeta = getMeta(recv)) {
+        elemTypeName   = listMeta->list_elem_type_name;
+        elemFnTypeInfo = listMeta->list_elem_fn_type_info;
+        listElemIsStr  = listMeta->list_elem_is_str;
+    }
+    llvm::Type *nestedElemTy = getNestedListElementType(recv);
 
-            builder_.SetInsertPoint(foundBB);
-            llvm::Value *valsPtrField = emitStructGEP(mapHeaderTy_, mapPtr, 3, "get_vals_field");
-            llvm::Value *valsPtr = emitLoad(ptrTy_, valsPtrField, "get_vals");
-            llvm::Value *valPtr = emitGEP(valTy, valsPtr, idx, "get_val_ptr");
-            llvm::Value *foundVal = emitLoad(valTy, valPtr, "get_val");
-            llvm::BasicBlock *foundEndBB = builder_.GetInsertBlock();
-            emitBranchUncond(mergeBB);
+    auto stampLoadedElem = [&](llvm::Value *elem) {
+        // Mirror codegen_expr_literal.cpp's stampLoadedElem so List<str> ARC,
+        // List<List<T>> nested element type, and List<closure> fn_type_info
+        // all survive the load. Without these, `Some(elem)` would drop
+        // metadata and the Option-returning path would skip the str retain
+        // (→ use-after-free post-source-mutation).
+        if (nestedElemTy)
+            setTypeMeta(TypeMeta::ListElem, elem, nestedElemTy);
+        if (!elemTypeName.empty())
+            propagateTypeMeta(elemTypeName, elem);
+        if (!elemTypeName.empty() && elemTypeName.size() >= 2 &&
+            elemTypeName.front() == '(' && elemTypeName.back() == ')')
+            getOrCreateMeta(elem).source_type_name = elemTypeName;
+        if (elemFnTypeInfo)
+            getOrCreateMeta(elem).fn_type_info = *elemFnTypeInfo;
+        if (listElemIsStr)
+            getOrCreateMeta(elem).str_elem = true;
+    };
 
-            builder_.SetInsertPoint(notFoundBB);
-            llvm::BasicBlock *notFoundEndBB = builder_.GetInsertBlock();
-            emitBranchUncond(mergeBB);
+    llvm::Value *index = emitExpr(*e.args[1]);
+    if (index->getType() == i1Ty_)
+        index = emitZExt(index, i64Ty_, "getl_idx_ext");
 
-            builder_.SetInsertPoint(mergeBB);
-            llvm::PHINode *phi = createPhi(valTy, {}, "get_result");
-            phi->addIncoming(foundVal, foundEndBB);
-            phi->addIncoming(defaultVal, notFoundEndBB);
-            return phi;
-        }
+    ListFields lf = loadListHeader(recv, "getl");
+    llvm::Value *wrapped = emitNegativeIndexWrap(index, lf.len, "getl");
+    llvm::Value *zero = emitConstInt(i64Ty_, 0);
+    llvm::Value *negCheck = emitICmpSLT(wrapped, zero, "getl_neg");
+    llvm::Value *overCheck = emitICmpSGE(wrapped, lf.len, "getl_over");
+    llvm::Value *oob = emitOr(negCheck, overCheck, "getl_oob");
+
+    if (e.args.size() == 2) {
+        // 2-arg: -> Option<T>
+        llvm::StructType *optTy = getOptionType(elemTy);
+        llvm::BasicBlock *oobBB = createBB("getl2.oob");
+        llvm::BasicBlock *okBB = createBB("getl2.ok");
+        llvm::BasicBlock *mergeBB = createBB("getl2.merge");
+        emitBranchCond(oob, oobBB, okBB);
+
+        builder_.SetInsertPoint(okBB);
+        llvm::Value *elemPtr = emitGEP(elemTy, lf.data, wrapped, "getl2_elem_ptr");
+        llvm::Value *elem = emitLoad(elemTy, elemPtr, "getl2_elem");
+        stampLoadedElem(elem);
+        llvm::Value *someVal = buildSomeValue(elem, optTy);
+        emitBranchUncond(mergeBB);
+        llvm::BasicBlock *okEndBB = builder_.GetInsertBlock();
+
+        builder_.SetInsertPoint(oobBB);
+        llvm::Value *noneVal = buildNoneValue(optTy);
+        emitBranchUncond(mergeBB);
+        llvm::BasicBlock *oobEndBB = builder_.GetInsertBlock();
+
+        builder_.SetInsertPoint(mergeBB);
+        llvm::PHINode *phi = createPhi(optTy, {}, "getl2_result");
+        phi->addIncoming(someVal, okEndBB);
+        phi->addIncoming(noneVal, oobEndBB);
+        propagateMeta(someVal, phi);
+        return phi;
     }
 
-    return nullptr;
+    // 3-arg: -> T
+    llvm::Value *defaultVal = emitExpr(*e.args[2]);
+    if (defaultVal->getType() != elemTy)
+        codegenError("get() default value type must match list element type");
+
+    llvm::BasicBlock *oobBB = createBB("getl3.oob");
+    llvm::BasicBlock *okBB = createBB("getl3.ok");
+    llvm::BasicBlock *mergeBB = createBB("getl3.merge");
+    emitBranchCond(oob, oobBB, okBB);
+
+    builder_.SetInsertPoint(okBB);
+    llvm::Value *elemPtr = emitGEP(elemTy, lf.data, wrapped, "getl3_elem_ptr");
+    llvm::Value *foundVal = emitLoad(elemTy, elemPtr, "getl3_elem");
+    stampLoadedElem(foundVal);
+    emitBranchUncond(mergeBB);
+    llvm::BasicBlock *okEndBB = builder_.GetInsertBlock();
+
+    builder_.SetInsertPoint(oobBB);
+    emitBranchUncond(mergeBB);
+    llvm::BasicBlock *oobEndBB = builder_.GetInsertBlock();
+
+    builder_.SetInsertPoint(mergeBB);
+    llvm::PHINode *phi = createPhi(elemTy, {}, "getl3_result");
+    phi->addIncoming(foundVal, okEndBB);
+    phi->addIncoming(defaultVal, oobEndBB);
+    propagateMeta(foundVal, phi);
+    return phi;
 }
 
 llvm::Value *CodeGen::emitMapMergeCore(llvm::Value *map1, llvm::Value *map2,

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -1043,8 +1043,14 @@ llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
 
     // 3-arg: -> T
     llvm::Value *defaultVal = emitExpr(*e.args[2]);
-    if (defaultVal->getType() != elemTy)
-        codegenError("get() default value type must match list element type");
+    if (defaultVal->getType() != elemTy) {
+        if (isAnyType(elemTy))
+            defaultVal = wrapInAny(defaultVal);
+        else if (isAnyType(defaultVal->getType()) && canAnyHoldType(elemTy))
+            defaultVal = unwrapFromAny(defaultVal, elemTy);
+        else
+            codegenError("get() default value type must match list element type");
+    }
 
     llvm::BasicBlock *oobBB = createBB("getl3.oob");
     llvm::BasicBlock *okBB = createBB("getl3.ok");

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -563,6 +563,7 @@ void CodeGen::emitStmt(CallStmt &s) {
                      (s.callee == "insert" && nargs == 3) ||
                      (s.callee == "removeAt" && nargs == 2) ||
                      (s.callee == "remove" && nargs == 2) ||
+                     (s.callee == "get" && (nargs == 2 || nargs == 3)) ||
                      (s.callee == "sort!" && (nargs == 1 || nargs == 2)) ||
                      (s.callee == "reverse!" && nargs == 1))) { // NOLINT(bugprone-branch-clone)
                     intercept = true;

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -643,6 +643,11 @@ fn listTests():
     xs: List<int> = [10, 20, 30]
     expect(xs.get(0, 99)).toEq(10)
     expect(xs.get(100, 99)).toEq(99)
+  @it("should wrap int default into any element for List<any>.get-with-default")
+  fn shouldWrapIntDefaultIntoAnyForListAny():
+    xs: List<any> = [10, 20, 30]
+    expect(xs.get(100, 0)).toEq(0)
+    expect(xs.get(1, 0)).toEq(20)
 
 @describe("Map")
 fn mapTests():

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -588,6 +588,62 @@ fn listTests():
     expect(l2[0]).toEq("bound_gamma")
     expect(l2[1]).toEq("literal_last")
 
+  @it("should return Some for in-range index via get")
+  fn shouldReturnSomeForInRangeGet():
+    xs: List<int> = [10, 20, 30]
+    expect(get(xs, 1)).toEq(Some(20))
+  @it("should return None for out-of-bounds get")
+  fn shouldReturnNoneForOobGet():
+    xs: List<int> = [10, 20, 30]
+    expect(get(xs, 100)).toBeNone()
+  @it("should return None for negative out-of-bounds get")
+  fn shouldReturnNoneForNegativeOobGet():
+    xs: List<int> = [10, 20, 30]
+    expect(get(xs, -4)).toBeNone()
+  @it("should wrap negative index in get")
+  fn shouldWrapNegativeIndexInGet():
+    xs: List<int> = [10, 20, 30]
+    expect(get(xs, -1)).toEq(Some(30))
+  @it("should return None for get on empty list")
+  fn shouldReturnNoneForGetOnEmptyList():
+    xs: List<int> = []
+    expect(get(xs, 0)).toBeNone()
+  @it("should support UFCS form for 2-arg get")
+  fn shouldSupportUfcsTwoArgGet():
+    xs: List<int> = [10, 20, 30]
+    expect(xs.get(0)).toEq(Some(10))
+  @it("should support get on List<str>")
+  fn shouldSupportGetOnListStr():
+    xs: List<str> = ["a", "b", "c"]
+    expect(get(xs, 1)).toEq(Some("b"))
+    expect(xs.get(-1)).toEq(Some("c"))
+    expect(get(xs, 9)).toBeNone()
+  @it("should return element for in-range index via get-with-default")
+  fn shouldReturnElementForInRangeGetWithDefault():
+    xs: List<int> = [10, 20, 30]
+    expect(get(xs, 1, 99)).toEq(20)
+  @it("should return default for out-of-bounds get-with-default")
+  fn shouldReturnDefaultForOobGetWithDefault():
+    xs: List<int> = [10, 20, 30]
+    expect(get(xs, 100, 99)).toEq(99)
+  @it("should return default for negative out-of-bounds get-with-default")
+  fn shouldReturnDefaultForNegativeOobGetWithDefault():
+    xs: List<int> = [10, 20, 30]
+    expect(get(xs, -4, 99)).toEq(99)
+  @it("should wrap negative index in get-with-default")
+  fn shouldWrapNegativeIndexInGetWithDefault():
+    xs: List<int> = [10, 20, 30]
+    expect(get(xs, -1, 99)).toEq(30)
+  @it("should return default for get-with-default on empty list")
+  fn shouldReturnDefaultForGetWithDefaultOnEmptyList():
+    xs: List<int> = []
+    expect(get(xs, 0, 99)).toEq(99)
+  @it("should support UFCS form for 3-arg get")
+  fn shouldSupportUfcsThreeArgGet():
+    xs: List<int> = [10, 20, 30]
+    expect(xs.get(0, 99)).toEq(10)
+    expect(xs.get(100, 99)).toEq(99)
+
 @describe("Map")
 fn mapTests():
   @it("should access by key")


### PR DESCRIPTION
## Summary

- Adds `get(list, index) -> Option<T>` and `get(list, index, default) -> T` to `List<T>`, symmetric to the existing `Map<K, V>` `get`.
- Semantics mirror `list[index]?`: negative indices wrap around, out-of-range (after wrap) yields `None` / the default. Both `get(xs, i)` and UFCS `xs.get(i)` are supported.
- Implemented by adding a List branch to `emitCollOp_get` modeled on the existing `xs[i]?` codegen — `List<str>` ARC and nested-element metadata propagate identically.

## Test plan

- [x] `tests/spec/collections.test.ry`: 13 new cases (in-range / OOB / negative wrap / negative OOB / empty list / UFCS / `List<str>`) — all pass
- [x] `./build/ry_tests` (2652) and `./build/ry test -p` (205 files) — no regressions
- [x] ASan+UBSan and TSan via `run-asan.sh` / `run-tsan.sh` — clean
- [x] clang-tidy / cppcheck — clean
- [x] Manual: `values.get(1)` → `Some(20)`, `values.get(100)` → `None`, `values.get(-1)` → `Some(30)`, `values.get(100, 0)` → `0` (matches Issue's Expected behavior)

Closes #2116

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `get()` overloads for List with safe index access. `get(list, index)` returns `Option<T>` for safe retrieval, while `get(list, index, default)` returns `T` with a fallback value. Supports negative index wrapping and UFCS syntax.

* **Documentation**
  * Updated collection reference documentation with examples and specifications for the new List `get()` methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->