### PR TITLE
fix(codegen): lazy-evaluate default in 3-arg get(list/map) (#2132)

### DIFF
--- a/.claude/rules/codegen-llvm-ir-conventions.md
+++ b/.claude/rules/codegen-llvm-ir-conventions.md
@@ -6,6 +6,7 @@ paths:
   - "src/codegen.cpp"
   - "src/codegen_test.cpp"
   - "src/codegen_call_user.cpp"
+  - "src/codegen_call_collection.cpp"
   - "src/codegen_lowering_*.cpp"
   - "src/codegen_emission_*.cpp"
   - "src/jit/jit_runner.cpp"
@@ -107,3 +108,14 @@ But the Rust boundary helper `bounds_error` (`crates/emit/src/composite/bounds.r
 That hidden divergence is the trap: a new `emitRuntimeError`-flavored migration that copies `bounds_error`'s shape — the obvious "same shape" choice — silently produces `@.foo` (plain) instead of `@.foo.arc` (str-handle struct) AND reorders the stdout load, breaking bit-exact parity with the C++ baseline (both the `@*.arc` GlobalVariable lines and the fprintf-vs-stdout-load ordering inside every fail BB). For an `emitRuntimeError`-shaped exit, use `get_or_create_arc_msg_global` (`crates/emit/src/composite/arc.rs`) — it mirrors `buildArcGlobal` exactly (struct prefix, `.arc` name suffix, ConstantExpr GEP into the data payload) — AND author a **dedicated** `runtime_error_with_*_arg` free fn that preserves the C++ `emitRuntimeError` instruction order (load stderr → fprintf → load stdout → fflush stdout → fflush stderr → _Exit → unreachable). Do NOT call into `bounds_error` from the new helper. Dedup caches stay independent — `bounds_msg_cache` for plain globals, `arc_msg_cache` for str-handle globals; both key on message bytes. Canonical example: `crates/emit/src/composite/cast.rs::checked_fp_to_int` + `runtime_error_with_value_arg` (#2097, the `emitCheckedFPToInt` migration).
 
 This is the `load_list_header` lesson (#2092) applied to a second pair of look-alike helpers: don't assume two helpers that "do the same thing in C++" produce byte-identical Rust IR — confirm against the baseline. The same discipline applies to any future migration of `emitIntZeroDivGuard` / `emitIntDivOverflowGuard` and similar `emitRuntimeError`-callers (`src/codegen_call_user.cpp`).
+
+### 条件分岐先でしか使われない値は target BB 内で emit する (lazy default rule)
+
+**Source**: #2132 (2026-06-14, fix)
+**Tags**: codegen, branching, PHI, lazy-evaluation, short-circuit, conditional-emission, emitCollOp_get
+
+PHI の片方の incoming にしか使われない値は、 その predecessor BB に `SetInsertPoint` した後で `emitExpr` する。 分岐前の dominator block で emit すると、 他方のパスを通った場合でも IR 上は無条件に評価されるため、副作用付き式 (関数呼び出し、リソース確保等) が常に走る。 Canonical example は `emitCollOp_get` (`src/codegen_call_collection.cpp`) の 3-arg path: `emitExpr(*e.args[2])` と coerce ブロックを `builder_.SetInsertPoint(notFoundBB)` / `SetInsertPoint(oobBB)` の後に置く。 同じ原理は将来の 3-arg overload (例: `pop(list, default)`, `find(list, pred, default)`) や、 条件分岐先でしか値が要らない他の codegen 局所にも適用する。
+
+PHI の predecessor (`notFoundEndBB` / `oobEndBB`) は `emitBranchUncond(mergeBB)` の **後**に `builder_.GetInsertBlock()` で再キャプチャすること。`default` 式が内部で新 BB を生成する場合 (`and`/`or` 短絡、ネスト `get`、`if expr`)、事前にキャプチャした BB ハンドルでは LLVM verify が PHI predecessor 不一致で reject する。
+
+参照パターン: 2-arg get の `oobBB` / `notFoundBB` 内 `buildNoneValue` 構築 (同ファイル `emitCollOp_get` 2-arg arm)、`and` / `or` 短絡評価 (`src/codegen_expr.cpp` の `sc.rhs` BB 内で rhs を emit)。

--- a/changelog.d/2132-fix-get-default-lazy-eval.md
+++ b/changelog.d/2132-fix-get-default-lazy-eval.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `get(list, index, default)` and `get(map, key, default)` now evaluate the `default` expression only when the index is out-of-bounds or the key is not found. Previously the default expression was always evaluated, so passing a function call as the default would invoke it (and run its side effects) even on the in-bounds / key-found path. (#2132)

--- a/docs/reference/collections.md
+++ b/docs/reference/collections.md
@@ -250,7 +250,7 @@ print(xs)   # [1, 2]
 Two overloads are available:
 
 - `get(list, index) -> Option<T>`: Returns `Some(value)` for an in-range index, or `None` for an out-of-range one. Negative indices wrap around from the end, matching [`xs[i]?`](#safe-index-access-xsi) semantics.
-- `get(list, index, default) -> T`: Returns the value at the index, or `default` for any out-of-range case (including a negative index whose wrap is still out of range).
+- `get(list, index, default) -> T`: Returns the value at the index, or `default` for any out-of-range case (including a negative index whose wrap is still out of range). The `default` expression is evaluated lazily — it runs only on the out-of-range path, so passing a function call as the default does not invoke it when the index is in range.
 
 ```ry
 xs = [10, 20, 30]
@@ -899,7 +899,7 @@ print(m)   # {b: 2}
 Two overloads are available:
 
 - `get(map, key) -> Option<V>`: Returns `Some(value)` if the key exists, or `None` if it does not.
-- `get(map, key, default) -> V`: Returns the value for the key, or `default` if the key does not exist.
+- `get(map, key, default) -> V`: Returns the value for the key, or `default` if the key does not exist. The `default` expression is evaluated lazily — it runs only when the key is missing, so passing a function call as the default does not invoke it for keys that are present.
 
 ```ry
 m = {"a": 1, "b": 2}

--- a/src/codegen_call_collection.cpp
+++ b/src/codegen_call_collection.cpp
@@ -929,9 +929,6 @@ llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
         llvm::Value *key = emitExpr(*e.args[1]);
         if (key->getType() != keyTy)
             codegenError("get() key type mismatch");
-        llvm::Value *defaultVal = emitExpr(*e.args[2]);
-        if (defaultVal->getType() != valTy)
-            codegenError("get() default value type must match map's value type");
         // #2094 ([C] = (ii) boundary move): same primitives as the 2-arg
         // arm — the only structural difference is the merge PHI types
         // (V vs Option<V>) and the default-value tail vs None.
@@ -952,8 +949,11 @@ llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
         emitBranchUncond(mergeBB);
 
         builder_.SetInsertPoint(notFoundBB);
-        llvm::BasicBlock *notFoundEndBB = builder_.GetInsertBlock();
+        llvm::Value *defaultVal = emitExpr(*e.args[2]);
+        if (defaultVal->getType() != valTy)
+            codegenError("get() default value type must match map's value type");
         emitBranchUncond(mergeBB);
+        llvm::BasicBlock *notFoundEndBB = builder_.GetInsertBlock();
 
         builder_.SetInsertPoint(mergeBB);
         llvm::PHINode *phi = createPhi(valTy, {}, "get_result");
@@ -1042,16 +1042,6 @@ llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
     }
 
     // 3-arg: -> T
-    llvm::Value *defaultVal = emitExpr(*e.args[2]);
-    if (defaultVal->getType() != elemTy) {
-        if (isAnyType(elemTy))
-            defaultVal = wrapInAny(defaultVal);
-        else if (isAnyType(defaultVal->getType()) && canAnyHoldType(elemTy))
-            defaultVal = unwrapFromAny(defaultVal, elemTy);
-        else
-            codegenError("get() default value type must match list element type");
-    }
-
     llvm::BasicBlock *oobBB = createBB("getl3.oob");
     llvm::BasicBlock *okBB = createBB("getl3.ok");
     llvm::BasicBlock *mergeBB = createBB("getl3.merge");
@@ -1065,6 +1055,15 @@ llvm::Value *CodeGen::emitCollOp_get(const CallExpr &e) {
     llvm::BasicBlock *okEndBB = builder_.GetInsertBlock();
 
     builder_.SetInsertPoint(oobBB);
+    llvm::Value *defaultVal = emitExpr(*e.args[2]);
+    if (defaultVal->getType() != elemTy) {
+        if (isAnyType(elemTy))
+            defaultVal = wrapInAny(defaultVal);
+        else if (isAnyType(defaultVal->getType()) && canAnyHoldType(elemTy))
+            defaultVal = unwrapFromAny(defaultVal, elemTy);
+        else
+            codegenError("get() default value type must match list element type");
+    }
     emitBranchUncond(mergeBB);
     llvm::BasicBlock *oobEndBB = builder_.GetInsertBlock();
 

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -1,4 +1,7 @@
-from testing import it, describe, expect
+from testing import it, describe, expect, mock, verify
+
+fn defaultSideEffect() -> int:
+  return 99
 
 @describe("List")
 fn listTests():
@@ -648,6 +651,26 @@ fn listTests():
     xs: List<any> = [10, 20, 30]
     expect(xs.get(100, 0)).toEq(0)
     expect(xs.get(1, 0)).toEq(20)
+  @it("should not call default fn when index in-bounds in 3-arg get")
+  fn shouldNotCallDefaultFnWhenIndexInBounds():
+    mock("defaultSideEffect", () => 99)
+    xs: List<int> = [10, 20, 30]
+    r = get(xs, 1, defaultSideEffect())
+    expect(r).toEq(20)
+    expect(verify("defaultSideEffect")).toEq(0)
+  @it("should call default fn once when index out-of-bounds in 3-arg get")
+  fn shouldCallDefaultFnOnceWhenOobInListGet():
+    mock("defaultSideEffect", () => 99)
+    xs: List<int> = [10, 20, 30]
+    r = get(xs, 100, defaultSideEffect())
+    expect(r).toEq(99)
+    expect(verify("defaultSideEffect")).toEq(1)
+  @it("should support block-creating default expr in 3-arg get for list")
+  fn shouldSupportBlockCreatingDefaultInListGet():
+    ys: List<int> = [42]
+    xs: List<int> = [10, 20, 30]
+    r = get(xs, 100, get(ys, 999, 0))
+    expect(r).toEq(0)
 
 @describe("Map")
 fn mapTests():
@@ -717,6 +740,26 @@ fn mapTests():
     m = {"a": 1, "b": 2}
     expect(get(m, "a", 0)).toEq(1)
     expect(get(m, "z", 0)).toEq(0)
+  @it("should not call default fn when key found in 3-arg get")
+  fn shouldNotCallDefaultFnWhenKeyFound():
+    mock("defaultSideEffect", () => 99)
+    m = {"a": 1, "b": 2}
+    r = get(m, "a", defaultSideEffect())
+    expect(r).toEq(1)
+    expect(verify("defaultSideEffect")).toEq(0)
+  @it("should call default fn once when key not found in 3-arg get")
+  fn shouldCallDefaultFnOnceWhenKeyNotFound():
+    mock("defaultSideEffect", () => 99)
+    m: Map<str, int> = {"a": 1}
+    r = get(m, "z", defaultSideEffect())
+    expect(r).toEq(99)
+    expect(verify("defaultSideEffect")).toEq(1)
+  @it("should support block-creating default expr in 3-arg get for map")
+  fn shouldSupportBlockCreatingDefaultInMapGet():
+    ys: Map<str, int> = {"x": 42}
+    m: Map<str, int> = {"a": 1}
+    r = get(m, "z", get(ys, "missing", 0))
+    expect(r).toEq(0)
   @it("should get optional")
   fn shouldGetOptional():
     m = {"a": 1, "b": 2}


### PR DESCRIPTION
## Summary

- 3-arg `get(list, i, default)` / `get(map, k, default)` の `default` を分岐先 BB 内で emit するよう変更し、 in-bounds / key-found 時に `default` 式の副作用が常に走る問題を修正
- 同根本原因のため Map 3-arg も同 PR で修正、 `mock`/`verify` による検出テストを `tests/spec/collections.test.ry` に追加

Closes #2132

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * The `get()` function for lists and maps now evaluates default expressions lazily—the default value is only computed when the index is out-of-bounds or the key is not found, preventing unnecessary side effects.

* **Documentation**
  * Updated API reference to clarify lazy evaluation behavior of `get()` default parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->