### PR TITLE
refactor(emit): post-#2086/#2105 cleanups for any/cow and RyFunctionRef doc

### DIFF
--- a/crates/emit/src/composite/any.rs
+++ b/crates/emit/src/composite/any.rs
@@ -545,7 +545,7 @@ impl EmitCtx {
                     );
                     build_ok(chosen)
                 },
-                |_s| build_err(),
+                build_err,
             );
             return Some(phi);
         }
@@ -581,7 +581,7 @@ impl EmitCtx {
                 );
                 build_ok(unwrapped)
             },
-            |_s| build_err(),
+            build_err,
         );
         Some(phi)
     }
@@ -605,7 +605,7 @@ impl EmitCtx {
         res_ty: LLVMTypeRef,
         is_err: LLVMValueRef,
         ok_value: impl FnOnce(&mut Self) -> LLVMValueRef,
-        err_value: impl FnOnce(&mut Self) -> LLVMValueRef,
+        err_value: impl FnOnce() -> LLVMValueRef,
     ) -> ValueRef {
         let b = self.builder;
         let context = self.context;
@@ -621,7 +621,7 @@ impl EmitCtx {
         let ok_incoming = LLVMGetInsertBlock(b);
 
         LLVMPositionBuilderAtEnd(b, err_bb);
-        let err_val = err_value(self);
+        let err_val = err_value();
         LLVMBuildBr(b, merge_bb);
         let err_incoming = LLVMGetInsertBlock(b);
 

--- a/crates/emit/src/composite/cow.rs
+++ b/crates/emit/src/composite/cow.rs
@@ -13,7 +13,6 @@ use llvm_sys::core::*;
 use llvm_sys::prelude::*;
 use llvm_sys::target::{LLVMABISizeOfType, LLVMGetModuleDataLayout};
 use llvm_sys::{LLVMAtomicOrdering, LLVMIntPredicate};
-use std::ffi::c_char;
 
 use crate::composite::arc::{emit_arc_counter_delta, emit_atomic_i64_load};
 use crate::composite::header::{arc_header_type, build_header_struct};
@@ -260,15 +259,11 @@ impl EmitCtx {
 
         LLVMPositionBuilderAtEnd(b, copy_bb);
 
-        // `alloc_buf` stays in the dispatcher for the ARC-box allocation below;
-        // the per-kind copy helpers call `emit_malloc` / `emit_memcpy` directly.
-        let alloc_buf = move |byte_size: LLVMValueRef, name: *const c_char| -> LLVMValueRef {
-            unsafe { emit_malloc(b, module, i64_ty, ptr_ty, byte_size, name) }
-        };
-
         // Allocate the ARC-backed collection header (mirror emitArcAlloc inline).
+        // The dispatcher and per-kind copy helpers (cow_copy_list / _map / _set)
+        // all call `emit_malloc` / `emit_memcpy` directly.
         let box_size = LLVMConstInt(i64_ty, ARC_HEADER_SIZE + header_size, 0);
-        let cow_box = alloc_buf(box_size, c"cow_box".as_ptr());
+        let cow_box = emit_malloc(b, module, i64_ty, ptr_ty, box_size, c"cow_box".as_ptr());
         emit_arc_counter_delta(b, i64_ty, ptr_ty, 1);
         let new_strong_ptr =
             LLVMBuildStructGEP2(b, arc_header_ty, cow_box, 0, c"cow_new_strong_ptr".as_ptr());
@@ -384,12 +379,11 @@ impl EmitCtx {
 // entered after the shared scaffold has allocated `new_data_ptr` and loaded
 // `old_len`, runs on the `cow.copy` block (no new blocks created), and writes the
 // cloned buffers + new-header fields. They allocate via `emit_malloc` / copy via
-// `emit_memcpy` directly (the dispatcher keeps the `alloc_buf` closure only for
-// the ARC-box allocation). The cached LLVM types are threaded individually,
-// mirroring `cow_retain_loop`; the resulting arity trips
-// `clippy::too_many_arguments`, suppressed per the same "intentional pattern"
-// policy (see .claude/rules/build-warning-flags.md) rather than bundled into a
-// struct that would touch this hot codegen path.
+// `emit_memcpy` directly, matching the dispatcher's ARC-box allocation. The
+// cached LLVM types are threaded individually, mirroring `cow_retain_loop`; the
+// resulting arity trips `clippy::too_many_arguments`, suppressed per the same
+// "intentional pattern" policy (see .claude/rules/build-warning-flags.md) rather
+// than bundled into a struct that would touch this hot codegen path.
 
 #[allow(clippy::too_many_arguments)]
 unsafe fn cow_copy_list(

--- a/include/ry/llvm_emit/api.h
+++ b/include/ry/llvm_emit/api.h
@@ -1111,9 +1111,11 @@ typedef enum {
 
 // Create a fresh function `name` of type `fn_ty` with `linkage` (a RyLinkage
 // value) in the module, and return its opaque handle (NOT interned — same shape
-// as ry_emit_create_basic_block's RyBasicBlockRef). Always adds a new function
-// (the caller owns name uniqueness). NULL ctx / fn_ty / name, or an unknown
-// linkage, → NULL. Creates no basic blocks.
+// as ry_emit_create_basic_block's RyBasicBlockRef). Must be interned via
+// ry_emit_intern before use as ry_emit_call_indirect's callee_id (RyFunctionRef
+// is not a RyValueId). Always adds a new function (the caller owns name
+// uniqueness). NULL ctx / fn_ty / name, or an unknown linkage, → NULL. Creates
+// no basic blocks.
 RyFunctionRef ry_emit_create_function(RyEmitCtx *ctx, const char *name,
                                       RyFuncTypeRef fn_ty, int linkage);
 


### PR DESCRIPTION
## Summary

Three small cleanups from the post-merge review of #2086 (any/cow split) and #2105 (fn creation pilot). Behavior- and IR-byte-preserving.

- `any_try_unwrap_result_diamond` (`crates/emit/src/composite/any.rs`): drop the unused `&mut Self` argument from the `err_value` parameter (both callers ignored it via `|_s|`) and pass `build_err` directly, dropping the redundant wrapper closure.
- `cow_ensure_unique` (`crates/emit/src/composite/cow.rs`): inline the single-use `alloc_buf` closure into the ARC-box allocation site so the dispatcher matches the per-kind helpers (`cow_copy_list` / `_map` / `_set`) that already call `emit_malloc` directly; drop the now-unused `std::ffi::c_char` import and update the per-kind helper comment.
- `ry_emit_create_function` doc (`include/ry/llvm_emit/api.h`): note that the returned `RyFunctionRef` must be interned via `ry_emit_intern` before use as `ry_emit_call_indirect`'s `callee_id`. Reference implementation: `tests/test_emit_abi_guards.cpp` ci_dummy (lines 660–671) and `CodeGen::emitCallIndirect`.

Closes #2146

## Test plan

- [x] Capture IR baseline before changes — probe exercises both `any_try_unwrap` diamond sites (`tryany.fp.val` × 2, `tryany.tag.eq` × 2) and the CoW dispatcher (`cow_box` × 12, `cow_new_data` × 26)
- [x] Re-capture IR after changes; ASLR-normalized diff is empty, all 4 marker counts preserved
- [x] `cmake --build build-rust`
- [x] `./build-rust/ry_tests` (2678 / 2678 passed)
- [x] `./build-rust/ry test -p` (205 spec files, 0 failures)
- [x] `run-rust-lint.sh` (cargo fmt + clippy + emit ABI no-IR check)
- [x] `run-static-analysis-all.sh` (clang-tidy + cppcheck + scan-build → no bugs)
- [x] `run-asan.sh` + `run-tsan.sh` (0 failures)

## Skipped checks

- Fuzz: not parser / lexer / json / utf8 / string / io
- prompt-refs lint: `.claude/`, `AGENTS.md`, `CLAUDE.md` unchanged
- tree-sitter: grammar / scanner / query / EBNF unchanged
- changelog / English user docs: pure internal refactor + doc comment clarifying existing C-boundary contract, no user-visible behavior change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified API documentation for function handle lifecycle and usage requirements in emitter functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->