### PR TITLE
fix(codegen): reserve get to prevent silent shadow of stdlib builtin

### DIFF
--- a/changelog.d/2133-reserve-get-builtin-name.md
+++ b/changelog.d/2133-reserve-get-builtin-name.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Top-level `fn get(...)` is now rejected at compile time with `name is reserved for a built-in function`. Previously the collection `get` builtin (#2116) silently shadowed any user-defined `fn get(xs: List<int>, i: int) -> int` (or any 2- / 3-arg signature whose first argument was a `List` or `Map`), turning the user body into dead code with no diagnostic. The single-int form used to compile via fall-through; reservation makes the rejection uniform across all signatures, matching the existing `iter` / `pop` precedent per the `kReservedBuiltinFunctionNames` empirical-maintenance rule. (#2133)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -332,7 +332,7 @@ fn calc(x: int) -> int:      # conflicts with calc(int) from above
 
 ## Reserved Built-in Names
 
-Top-level user functions cannot reuse names that the standard library reserves for built-ins. Names such as `sum`, `min`, `max`, `len`, `range`, `print`, `enumerate`, `zip`, `map`, `filter`, `fold`, `reduce`, `iter`, `Ok`, `Err`, `Some`, `None`, `Error`, and others dispatch directly through the compiler's built-in chain. A user `fn sum(...)` at the top level would never be called — the body would be silently ignored. The compiler rejects such declarations at definition time with `cannot declare function 'sum': name is reserved for a built-in function`.
+Top-level user functions cannot reuse names that the standard library reserves for built-ins. Names such as `sum`, `min`, `max`, `len`, `range`, `print`, `enumerate`, `zip`, `map`, `filter`, `fold`, `reduce`, `iter`, `get`, `Ok`, `Err`, `Some`, `None`, `Error`, and others dispatch directly through the compiler's built-in chain. A user `fn sum(...)` at the top level would never be called — the body would be silently ignored. The compiler rejects such declarations at definition time with `cannot declare function 'sum': name is reserved for a built-in function`.
 
 ```ry
 # Error: cannot declare function 'sum': name is reserved for a built-in function

--- a/include/ry/builtin_names.hpp
+++ b/include/ry/builtin_names.hpp
@@ -37,6 +37,7 @@ inline const std::unordered_set<std::string_view> kReservedBuiltinFunctionNames 
     "flat",
     "float",
     "fold",
+    "get",
     "hasKey",
     "input",
     "int",

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -1453,13 +1453,13 @@ TEST_F(CodeGenTest, ReservedBuiltinAllowsNestedShadow) {
 }
 
 TEST_F(CodeGenTest, ReservedBuiltinGetAllowsNestedShadow) {
-    EXPECT_NO_THROW(runSource(
+    EXPECT_EQ(runSource(
         "fn outer() -> int:\n"
         "    fn get(x: int) -> int:\n"
         "        return x + 1\n"
-        "    return 0\n"
+        "    return get(41)\n"
         "print(outer())\n"
-    ));
+    ), "42\n");
 }
 
 // `str` is excluded from the reserved set (see

--- a/tests/test_codegen_fail.cpp
+++ b/tests/test_codegen_fail.cpp
@@ -1301,6 +1301,20 @@ TEST_F(CodeGenTest, ReservedBuiltinSumListIntExactSignature) {
         "is reserved for a built-in");
 }
 
+TEST_F(CodeGenTest, ReservedBuiltinGetListIntExactSignature) {
+    expectCompileError(
+        "fn get(xs: List<int>, i: int) -> int:\n"
+        "    return 999\n",
+        "is reserved for a built-in");
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinGetSingleIntArg) {
+    expectCompileError(
+        "fn get(x: int) -> int:\n"
+        "    return x\n",
+        "is reserved for a built-in");
+}
+
 // Family representatives: at least one rejection per stdlib family
 // (builtins.ry auto-loaded fn / collection ops / conversion / query /
 // ADT constructor / regex / IO / channel / set ops / arithmetic
@@ -1432,6 +1446,16 @@ TEST_F(CodeGenTest, ReservedBuiltinAllowsNestedShadow) {
     EXPECT_NO_THROW(runSource(
         "fn outer() -> int:\n"
         "    fn sum(x: int) -> int:\n"
+        "        return x + 1\n"
+        "    return 0\n"
+        "print(outer())\n"
+    ));
+}
+
+TEST_F(CodeGenTest, ReservedBuiltinGetAllowsNestedShadow) {
+    EXPECT_NO_THROW(runSource(
+        "fn outer() -> int:\n"
+        "    fn get(x: int) -> int:\n"
         "        return x + 1\n"
         "    return 0\n"
         "print(outer())\n"


### PR DESCRIPTION
## Summary

- Adds `get` to `kReservedBuiltinFunctionNames` in `include/ry/builtin_names.hpp` so top-level `fn get(...)` is rejected at definition time with `name is reserved for a built-in function`.
- Prior to this, a user `fn get(xs: List<int>, i: int) -> int` (or any 2- / 3-arg signature whose first arg was a `List` / `Map`) was silently shadowed by the collection `get` builtin introduced in #2116, turning the user body into dead code with no diagnostic. The single-int form used to compile via fall-through; reservation makes the rejection uniform across all signatures, matching the `iter` / `pop` precedent per the empirically-maintained reserved-set rule in `.claude/rules/codegen-stdlib-dispatcher.md`.
- Adds 3 regression tests in `tests/test_codegen_fail.cpp` (`ReservedBuiltinGetListIntExactSignature`, `ReservedBuiltinGetSingleIntArg`, `ReservedBuiltinGetAllowsNestedShadow`) and one-word doc polish in `docs/reference/functions.md` + changelog entry.

Closes #2133

## Test plan

- [x] `./build-rust/ry_tests` — 2681 passed (3 new `ReservedBuiltinGet*` cases)
- [x] `./build-rust/ry test -p` — all green (one rerun for the KNOWLEDGE.md-tracked `collection_meta_propagation.test.ry` JIT-teardown flake; orthogonal to this diff)
- [x] ASan + UBSan (Docker) — pass
- [x] TSan (Docker) — pass
- [x] static-analysis (clang-tidy + cppcheck + scan-build, Docker) — No bugs found
- [x] Empirical reproduction: `printf 'fn get(xs: List<int>, i: int) -> int:\n    return 999\n\nxs: List<int> = [1, 2]\nprint(get(xs, 0))\n' | ./build-rust/ry -c` — pre-fix `Some(1)`, post-fix `cannot declare function 'get': name is reserved for a built-in function`
- [x] Load-bearing assumption verified: stdlib's own `@native fn get` stubs in `share/std/list.ry` / `map.ry` continue to load (Guard 1's `@native` branch returns before the reserved check), confirmed by `tests/spec/collections.test.ry` passing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * The `get` name is now reserved for a built-in function. User-defined top-level `fn get(...)` declarations are rejected at compile-time with a reserved-name error (including previously shadowed forms).

* **Documentation**
  * Updated the function reference “Reserved Built-in Names” section to include `get`.

* **Tests**
  * Added coverage ensuring reserved-name rejection is enforced consistently, while nested-scope `get` definitions remain allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->