### PR TITLE
docs: fix README install/test commands and visibility build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ print(math.PI)          # 3.141592653589793
 curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh
 ```
 
-To specify a particular version:
+To specify a particular version (replace `<X.Y.Z>` with a version listed on the [Releases](https://github.com/t0k0sh1/ry/releases) page):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh -s v0.0.8
+curl -fsSL https://raw.githubusercontent.com/t0k0sh1/ry/main/install.sh | sh -s v<X.Y.Z>
 ```
 
 By default, it installs to `~/.local/bin`. You can change this with the `RY_INSTALL_DIR` environment variable.
@@ -174,7 +174,9 @@ ry test --trace tests/spec
 ## Development
 
 ```bash
-cd build && ctest --output-on-failure
+cmake --build build
+./build/ry_tests
+./build/ry test -p
 ```
 
 ## Documentation

--- a/docs/guide/visibility.md
+++ b/docs/guide/visibility.md
@@ -42,7 +42,7 @@ fn fmt(n: int) -> str:
 
 Any importer **outside** `mylib/` cannot see `add` or `fmt` until they are marked `@public`.
 
-Files that have no `package.toml` ancestor — for example, ad-hoc scripts run with `./build/ry script.ry`, or expressions passed via REPL `-c` — share a single **anonymous package**. They all behave as one package for visibility purposes, so a script can freely import any non-`@public` definition from another script in the same anonymous-package universe.
+Files that have no `package.toml` ancestor — for example, ad-hoc scripts run with `<build-dir>/ry script.ry`, or expressions passed via REPL `-c` — share a single **anonymous package**. They all behave as one package for visibility purposes, so a script can freely import any non-`@public` definition from another script in the same anonymous-package universe.
 
 ## Making a definition public
 


### PR DESCRIPTION
## Summary

- `README.md` install example version: `v0.0.8` → `v<X.Y.Z>` placeholder (with Releases page pointer)
- `README.md` Development section: replace `cd build && ctest --output-on-failure` with `cmake --build build` + `./build/ry_tests` + `./build/ry test -p` to match `AGENTS.md` Build And Test guidance
- `docs/guide/visibility.md`: `./build/ry script.ry` → `<build-dir>/ry script.ry` so the example is OS-neutral

Closes #2148

## Test plan

- [x] `cmake --build build-rust` succeeds
- [x] `./build-rust/ry_tests` — 2678/2678 pass
- [x] `./build-rust/ry test -p` — 205 files, 0 failures
- [x] `grep -nE 'v0\.0\.8|cd build && ctest|\./build/ry script\.ry' README.md docs/guide/visibility.md` returns no matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced macOS Apple Silicon installation documentation with detailed guidance on specifying explicit installer versions through command-line parameters for greater installation flexibility and control
  * Refreshed development build and test section with updated compilation and testing command recommendations for improved developer experience
  * Standardized visibility guide examples to use consistent build directory path conventions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->