### PR TITLE
refactor(codegen): route emitStrOp_join / emitStringRepeat ConstantInt through emitConstInt (#2134)

### DIFF
--- a/src/codegen_call_string.cpp
+++ b/src/codegen_call_string.cpp
@@ -816,8 +816,8 @@ llvm::Value *CodeGen::emitStrOp_join(const CallExpr &e) {
     llvm::Value *listLen = lf.len;
     llvm::Value *listData = lf.data;
     llvm::Value *sepLen = emitStringByteLen(sep);
-    llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
-    llvm::Value *one = llvm::ConstantInt::get(i64Ty_, 1);
+    llvm::Value *zero = emitConstInt(i64Ty_, 0);
+    llvm::Value *one = emitConstInt(i64Ty_, 1);
 
     llvm::Value *totalVar = emitAlloca(i64Ty_, "join_total");
     emitStore(zero, totalVar);

--- a/src/codegen_expr_cast.cpp
+++ b/src/codegen_expr_cast.cpp
@@ -299,7 +299,7 @@ llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
     llvm::Value *strLen = emitStringByteLen(strVal);
 
     // If n <= 0, return empty string (a StringHeader global)
-    llvm::Value *zero = llvm::ConstantInt::get(i64Ty_, 0);
+    llvm::Value *zero = emitConstInt(i64Ty_, 0);
     llvm::Value *nPos = emitICmpSGT(n, zero, "n_pos");
 
     llvm::BasicBlock *emptyBB = createBB("str_rep.empty");
@@ -326,7 +326,7 @@ llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
 
     builder_.SetInsertPoint(ovfCheckBB);
     llvm::Value *maxN = emitSDiv(
-        llvm::ConstantInt::get(i64Ty_, INT64_MAX), strLen, "max_n");
+        emitConstInt(i64Ty_, INT64_MAX), strLen, "max_n");
     llvm::Value *wouldOverflow = emitICmpSGT(n, maxN, "would_overflow");
     llvm::BasicBlock *ovfErrBB = createBB("str_rep.ovf_err");
     emitBranchCond(wouldOverflow, ovfErrBB, allocBB);
@@ -356,7 +356,7 @@ llvm::Value *CodeGen::emitStringRepeat(llvm::Value *strVal, llvm::Value *n) {
     emitRuntimeCallDirect("memcpy", ptrTy_, {ptrTy_, ptrTy_, i64Ty_},
                           {dst, strVal, strLen}, "");
 
-    llvm::Value *iNext = emitAdd(i, llvm::ConstantInt::get(i64Ty_, 1), "i_next");
+    llvm::Value *iNext = emitAdd(i, emitConstInt(i64Ty_, 1), "i_next");
     i->addIncoming(iNext, loopBB);
     llvm::Value *cond = emitICmpSLT(iNext, n, "loop_cond");
     emitBranchCond(cond, loopBB, doneBB);


### PR DESCRIPTION
## Summary

- PR #2126 (#2096) で string-build ops を `ry_emit_*` に migrate した際、`emitStrOp_join` / `emitStringRepeat` 内の 5 か所の `llvm::ConstantInt::get(i64Ty_, n)` が直接 LLVM API を呼ぶ形で残っていた。
- 5 行を `emitConstInt(i64Ty_, n)` に置換し、#2126 の architectural goal「all emission through `ry_emit_*`」と整合させる。
- IR は byte-identical (join + repeat probe で ASLR 正規化後 `diff` 空、`join_total` / `str_rep.*` マーカー存在で path coverage 確認)。

## Test plan

- [x] `./build-rust/ry_tests` (2681 tests passed)
- [x] `./build-rust/ry test -p` (205 files / 0 failure)
- [x] `--emit-llvm-ir` byte-identical diff (空) 確認
- [x] `run-static-analysis-all.sh` clang-tidy + cppcheck + scan-build (0 bugs)
- [x] `run-asan.sh` ASan + UBSan
- [x] `run-tsan.sh` TSan

Skipped: Rust lint (`crates/` 不変)、Prompt-refs lint (`.claude/` 不変)、Tree-sitter (grammar 不変)、Fuzz (parser/json/utf8/io_open targets は codegen 経路を踏まず IR byte-identical 下で増分情報なし)、Docs / Changelog (user-visible 変更なし)。

Closes #2134

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal constant initialization for string operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->