### PR TITLE
docs(emit): refresh stale `core` doc refs after #2109 split

### DIFF
--- a/crates/emit/src/abi.rs
+++ b/crates/emit/src/abi.rs
@@ -38,7 +38,7 @@ mod primitive;
 mod reduce;
 mod result;
 mod runtime_call;
-// Test-only: exposes core::header_fields for the cross-language header-layout
+// Test-only: exposes context::header_fields for the cross-language header-layout
 // parity test (#2071). IR-free (reads pure data only) — see the module doc.
 mod test_introspect;
 

--- a/crates/emit/src/abi/lifecycle.rs
+++ b/crates/emit/src/abi/lifecycle.rs
@@ -1,6 +1,6 @@
 //! abi::lifecycle — C boundary entry points for the emission-context lifecycle:
 //! create / destroy and the intern / resolve value-handle entry points.
-//! `ctx_create` boxes a `core::EmitCtx::new` and hands back the opaque handle;
+//! `ctx_create` boxes a `context::EmitCtx::new` and hands back the opaque handle;
 //! the rest are boundary plumbing over that handle (intern / resolve are
 //! abi-side). The former `set_function` setter was removed in #2083: every
 //! BB-creating op derives its parent function from the builder's insert block,

--- a/crates/emit/src/abi/result.rs
+++ b/crates/emit/src/abi/result.rs
@@ -3,7 +3,7 @@
 //! handle and interns the aggregate; `ry_emit_result_branch` validates inputs,
 //! resolves `is_err`, wraps each C builder callback (`RyBuildValueFn`) into a
 //! `FnMut() -> ValueRef` closure that re-enters the emitter and resolves the
-//! returned id, then delegates the IR emission to `core::emit_result_branch` and
+//! returned id, then delegates the IR emission to `composite::result::emit_result_branch` and
 //! interns the phi. The closure invocation + intern/resolve juggling is the only
 //! abi-side work; the LLVM IR (BB scaffold + cond-br + phi) lives in `core`,
 //! which holds no `&mut EmitCtx` borrow so the re-entrant `with_ctx(ctx, …)`
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn ry_emit_result_branch(
     // ordering by relying on left-to-right argument evaluation: a single
     // `resolve(cx(ctx), build_ok(user_ctx))` would have held the `cx(ctx)` borrow
     // across the callback. `with_ctx` makes the ordering a borrow-scope guarantee
-    // instead of an evaluation-order subtlety.) `core::emit_result_branch` itself
+    // instead of an evaluation-order subtlety.) `composite::result::emit_result_branch` itself
     // holds no EmitCtx borrow, so each closure's transient `with_ctx` is the only
     // live receiver borrow at callback time (#2081 / #2069).
     let mut do_ok = move || -> ValueRef {

--- a/crates/emit/src/abi/test_introspect.rs
+++ b/crates/emit/src/abi/test_introspect.rs
@@ -2,7 +2,7 @@
 //!
 //! NOT part of the production emission path. It exposes the *same*
 //! single-sourced field-kind table that drives `cow_ensure_unique` /
-//! `arc_header_type` (`core::header_fields`) so the C++ parity test
+//! `arc_header_type` (`context::header_fields`) so the C++ parity test
 //! (`tests/test_header_layout.cpp`) can assert the Rust mirror against C++'s
 //! canonical `listHeaderTy_` / `mapHeaderTy_` / `setHeaderTy_` / `arcHeaderTy_`
 //! (`src/codegen.cpp:57-61`). This closes the layout-drift hole #2071: a C++
@@ -51,7 +51,7 @@ pub struct RyTestHeaderLayout {
 // so the C++ side can assert each constant indexes a field of the expected type
 // in the canonical struct (tests/test_header_layout.cpp). The constants are
 // pinned to GEP positions; a future layout change is a single-point edit in
-// core.rs that this struct + the C++ test catch via per-named-position parity.
+// context.rs that this struct + the C++ test catch via per-named-position parity.
 #[repr(C)]
 pub struct RyTestFieldIndices {
     pub list_len: u32,

--- a/crates/emit/src/composite/collection.rs
+++ b/crates/emit/src/composite/collection.rs
@@ -2,7 +2,7 @@
 //! core engine only, so it is abi-independent and the `core⇏abi` invariant
 //! covers this module). `append` / `insert` / `remove_at` / `slice` build the
 //! malloc / memcpy / memmove + header GEP / load / store sequences; the shared
-//! list-grow and header-load helpers live in `core`. `insert` / `remove_at` call
+//! list-grow and header-load helpers live in `composite::header`. `insert` / `remove_at` call
 //! `self.negative_index_wrap` / `self.bounds_error` directly (no id bridge) — the
 //! former `intern` → extern → `resolve` round-trip is gone (IR-neutral; ids never
 //! appear in the emitted IR). `slice` returns a `SliceParts` aggregate. The C++
@@ -332,7 +332,7 @@ impl EmitCtx {
         let fn_v = LLVMGetBasicBlockParent(LLVMGetInsertBlock(b));
 
         // List header load — INTERLEAVED gep/load to match C++ CodeGen::loadListHeader
-        // (src/codegen_call.cpp); core::load_list_header groups the geps then the
+        // (src/codegen_call.cpp); composite::header::load_list_header groups the geps then the
         // loads, which would reorder the IR. `lrem_cap` is loaded-but-unused, exactly
         // as the C++ helper does, so the IR stays byte-identical.
         let len_ptr = LLVMBuildStructGEP2(
@@ -993,7 +993,7 @@ impl EmitCtx {
         let outer_data = outer_data.0;
         let list_header_ty = list_header_ty.0;
         // arc_header_ty is the C++-side named %ArcHeader struct (vs the
-        // anonymous {i64,i64} from core::arc_header_type); passed across the
+        // anonymous {i64,i64} from composite::header::arc_header_type); passed across the
         // boundary so the migrated GEPs reference the same named type as the
         // C++ baseline byte-for-byte.
         let arc_header_ty = arc_header_ty.0;

--- a/crates/emit/src/composite/cow.rs
+++ b/crates/emit/src/composite/cow.rs
@@ -194,7 +194,7 @@ impl EmitCtx {
         let ptr_ty = ptr_type(context);
         let arc_header_ty = arc_header_type(context);
 
-        // The header struct shape is single-sourced in `core::header_fields`
+        // The header struct shape is single-sourced in `context::header_fields`
         // (mirrors CodeGen's listHeaderTy_/mapHeaderTy_/setHeaderTy_ in
         // src/codegen.cpp); the C++<->Rust sync is mechanically guarded by the
         // parity test (tests/test_header_layout.cpp via ry_emit_test_header_layout)

--- a/crates/emit/src/composite/reduce.rs
+++ b/crates/emit/src/composite/reduce.rs
@@ -8,7 +8,7 @@
 //!   - **list forms** (`sum([..])`, `min/max([..])`): the whole loop lives in one
 //!     coarse boundary op. `reduce_sum_list` loads the list header inline (in the
 //!     INTERLEAVED gep/load order of C++ `CodeGen::loadListHeader`, NOT the
-//!     grouped `core::load_list_header`) and runs the accumulate loop.
+//!     grouped `composite::header::load_list_header`) and runs the accumulate loop.
 //!     `reduce_minmax_list_loop` is deliberately partial: the C++ side keeps
 //!     `loadListHeader` + the empty-list check + `emitRuntimeError` (which builds
 //!     an ARC string global — out of scope for this ARC-free batch), positions
@@ -52,7 +52,7 @@ impl EmitCtx {
         let fn_v = LLVMGetBasicBlockParent(LLVMGetInsertBlock(b));
 
         // List header load — INTERLEAVED gep/load to match C++ CodeGen::loadListHeader
-        // (src/codegen_call.cpp); core::load_list_header groups the geps then the
+        // (src/codegen_call.cpp); composite::header::load_list_header groups the geps then the
         // loads, which would reorder the IR. `sum_cap` is loaded-but-unused, exactly
         // as the C++ helper does, so the IR stays byte-identical.
         let len_ptr = LLVMBuildStructGEP2(

--- a/crates/emit/src/ffi.rs
+++ b/crates/emit/src/ffi.rs
@@ -1,6 +1,6 @@
 //! ffi — the Rust-native public surface: the convergence point where the C++
 //! path (via `abi`) and the Rust-direct path meet, expressed in the engine's
-//! Rust-native vocabulary. For this pilot it is a thin re-export of `core`'s
+//! Rust-native vocabulary. For this pilot it is a thin re-export of `context`'s
 //! `EmitCtx` / `ValueRef` / `Atomicity`; the layer earns its keep once an
 //! external Rust consumer and the physical crate split (cdylib `abi` + rlib
 //! `ffi` + `core`) arrive. NOTE: the name `ffi` is provisional and arguably


### PR DESCRIPTION
## Summary
- `crates/emit/src/` 配下の doc/inline コメントに残っていた解体済み `core` モジュール (PR #2131 / #2109 で `context.rs` / `composite/*.rs` / `primitive/*.rs` に分割済み) への 13 箇所のドットパス参照を、現行の場所に更新。
- Doc-only。emit される IR / ランタイム挙動は不変。アーキテクチャ層名としての bare `core` (`.claude/rules/codegen-llvm-ir-conventions.md` 内でも継続使用) と、解体済みモジュールへの歴史的言及はそのまま。

## Changes
- `core::header_fields` → `context::header_fields` (3 sites)
- `core::load_list_header` → `composite::header::load_list_header` (4 sites)
- `core::arc_header_type` → `composite::header::arc_header_type`
- `core::emit_result_branch` → `composite::result::emit_result_branch` (2 sites)
- `core::EmitCtx::new` → `context::EmitCtx::new`
- `core` / `core.rs` → `context` / `context.rs` (`ffi.rs:3`, `test_introspect.rs:54`)
- bare `core` in `composite/collection.rs:5` → `composite::header`

## Test plan
- [x] cmake --build build-rust
- [x] ./build-rust/ry_tests (2681/2681 passed)
- [x] ./build-rust/ry test -p (205 files / 0 failures)
- [x] Rust lint (cargo fmt + clippy -D warnings + check-emit-abi-no-ir clean)
- [x] scan-build (No bugs found)
- [x] ASan + UBSan (205 files / 0 failures)
- [x] TSan (205 files / 0 failures)

Closes #2135