### PR TITLE
docs(reference): fix stdlib reference drift across 4 files

### DIFF
--- a/docs/reference/builtins-string.md
+++ b/docs/reference/builtins-string.md
@@ -444,7 +444,7 @@ Converts a value to a string.
 | Type | Conversion Format |
 |----|---------|
 | `int` | `%ld` |
-| `float` | `%g`, with trailing `.0` for whole-number values (e.g. `"3.0"`, `"0.0"`) |
+| `float` | Shortest round-trip decimal (minimum digits to recover the exact `double`), with trailing `.0` for whole-number values (e.g. `"3.0"`, `"0.0"`) |
 | `bool` | `"true"` / `"false"` |
 | `str` | Returned as-is |
 | enum | Variant name (e.g. `"Red"`) |

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -87,6 +87,7 @@ The table below shows the most common runtime errors; it is not exhaustive.
 | Contract violation | A `require`, `ensure`, or `invariant` condition evaluated to false | See [Design by Contract](contracts.md) |
 | `int` overflow | A checked `int` operation (`+`, `-`, `*`, unary `-`, `//`, `%`, or `math.abs`) overflowed (`runtime error: integer overflow`) | `maxInt + 1`, `(minInt) // -1`, `math.abs(minInt)` |
 | `range()` step zero | Called `range()` with a step argument of `0` (`runtime error: range() step must not be zero`) | `range(1, 10, 0)` |
+| `min()` / `max()` on empty list | Called `min()` or `max()` on an empty list (`runtime error: min() on empty list` / `runtime error: max() on empty list`) | `min([])`, `max([])` |
 
 All runtime errors terminate the process with `exit(1)`.
 

--- a/docs/reference/filesystem.md
+++ b/docs/reference/filesystem.md
@@ -162,6 +162,7 @@ chmod("/tmp/data.txt", 420)
 - `isFile`, `isDir`, and `isSymlink` return `Ok(false)` when the path does not exist; `Err` when the path contains an embedded NUL byte
 - `isFile` and `isDir` follow symlinks; `isSymlink` uses `lstat` to detect links
 - `listDir` returns entry names only (not full paths)
-- `walk` returns full paths for all entries (both files and directories)
+- `walk` returns full paths for all entries (both files and directories); returns `Err` when the path is not a directory
+- `copy` is intended for file copies. On Linux, `copy` returns `Err` when the source is a directory or other non-regular file; on macOS, `copyfile(3)` may succeed on directories with no recursion (avoid relying on this for portability). Unlike `cp -r`, `copy` does not recurse into directories — use `walk` + per-file `copy` for tree copies.
 - `glob` returns an empty list (not an error) when no files match the pattern
 - `remove` fails on non-empty directories; use `removeAll` for recursive deletion

--- a/docs/reference/records.md
+++ b/docs/reference/records.md
@@ -153,6 +153,41 @@ print(p1 != p3)  # true
 
 ---
 
+## String Representation
+
+Record types automatically generate a `str()` conversion that produces `TypeName(field1: val1, field2: val2, ...)`. This is used by `print()` and f-string interpolation.
+
+```ry
+record Point:
+    x: int
+    y: int
+
+p = Point(10, 20)
+print(str(p))      # Point(x: 10, y: 20)
+print(p)           # Point(x: 10, y: 20)
+print(f"pos={p}")  # pos=Point(x: 10, y: 20)
+```
+
+### User-defined `str()` override
+
+A user-defined `fn str(v: MyRecord) -> str` takes precedence over the auto-generated version. This is the canonical extension point for custom record formatting.
+
+```ry
+record Point:
+    x: int
+    y: int
+
+fn str(p: Point) -> str:
+    return f"({p.x}, {p.y})"
+
+p = Point(5, 6)
+print(str(p))   # (5, 6)
+```
+
+See [Built-in String Reference — `str`](builtins-string.md#str) for the full list of types supported by the built-in `str()`.
+
+---
+
 ## Record Subtyping (Inheritance)
 
 Records support single inheritance using the `<` syntax. A child record inherits all fields from its parent.


### PR DESCRIPTION
## Summary

- `builtins-string.md` L447: align `str(float)` format with `builtins.md` (`%g` → shortest round-trip)
- `errors.md` Runtime Errors table: add `min()/max() on empty list` row (`src/codegen_call_higher_order.cpp:614`)
- `filesystem.md` Notes: document `walk` non-directory `Err` and `copy` non-regular-file behavior (with macOS/Linux portability note)
- `records.md`: add `String Representation` section + `User-defined str() override` extension point (`tests/spec/records.test.ry:44-50`)

The `copy` Notes wording reflects an observed OS difference confirmed via primary evidence: `copy(dir, dst)` returns `Err` on Linux (`S_ISREG` check) but `Ok` on macOS (`copyfile(... COPYFILE_ALL)`). Implementation-level alignment is out of scope for this docs PR.

## Test plan

- [x] Examples in `records.md` (`fn str(p: Point)` override + auto-`str`) run via `./build-rust/ry -c -` and produce documented output
- [x] `builtins-string.md#str` anchor uniqueness (`grep -nE '^#+\s+[Ss]tr\b' docs/reference/builtins-string.md` → L436 only)
- [x] macOS `copy(dir, dst)` returns `Ok` (re-verified before adjusting Notes wording)

Closes #2151