### PR TITLE
docs(grammar): align ensure rule in grammar.ebnf with parser

### DIFF
--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -98,7 +98,7 @@ generic_params   ::= '<' IDENT { ',' IDENT } '>'
 fn_body          ::= ':' INDENT { contract_clause } statement { statement } DEDENT
 
 contract_clause  ::= ( 'require' ':' INDENT condition_list DEDENT
-                     | 'ensure' [ IDENT ] ':' INDENT condition_list DEDENT )
+                     | 'ensure' IDENT { ',' IDENT } ':' INDENT condition_list DEDENT )
 
 condition_list   ::= expression NEWLINE { expression NEWLINE }
 


### PR DESCRIPTION
## Summary

- `docs/grammar.ebnf` の `contract_clause` 規則は `'ensure' [ IDENT ]` と書かれていたが、`parseEnsureClause` (`src/parser/parser_decl.cpp:504-515`) は IDENT を必須とし、さらにカンマ区切りで複数 binding (`ensure q, r:`) を受け付ける。
- `docs/reference/contracts.md` も単一/複数 binding 双方を仕様化しており、EBNF だけが取り残されていた。
- 1 行修正: `'ensure' [ IDENT ]` → `'ensure' IDENT { ',' IDENT }`。実装変更なし。

## Test plan

- [x] tree-sitter check 通過 (pass=157 / fail=0)
- [x] 既存テスト `tests/spec/contracts.test.ry` は単一 binding をカバー済み、コード非変更なので回帰なし

Closes #2152