### PR TITLE
docs: align minor version/build drift across 4 files (#2153)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,13 +126,12 @@ Requirements:
 - Rust 1.83+ (`cargo` / `rustc` on `PATH`) — the LLVM IR emission layer is a Rust cdylib (`crates/emit/`)
 
 ```bash
-cmake -B build -DLLVM_DIR=/usr/local/llvm/lib/cmake/llvm
-cmake --build build
+cmake --preset default && cmake --build build
 ```
 
-> `ry` and the Rust cdylib must share one LLVM instance, so the `-DLLVM_DIR` prefix must ship a shared `libLLVM` (a static-only LLVM build will not link). Building inside the `ry-ci` Docker image (`ghcr.io/<owner>/ry-ci:llvm-21-rev<N>`) needs no separate Rust or shared-LLVM setup — both are baked in.
+> `ry` and the Rust cdylib must share one LLVM instance, so `LLVM_DIR` must point at a shared `libLLVM` prefix (a static-only LLVM build will not link). The `default` preset uses `/usr/local/llvm/lib/cmake/llvm`; override with `-DLLVM_DIR=<path>` (passed to `cmake --preset default`) if your LLVM lives elsewhere. Building inside the `ry-ci` Docker image (`ghcr.io/<owner>/ry-ci:llvm-21-rev<N>`) needs no separate Rust or shared-LLVM setup — both are baked in.
 >
-> **macOS**: `/usr/local/llvm` (shown above) is typically static-only and will not link — point `-DLLVM_DIR` at a shared-`libLLVM` prefix such as Homebrew `llvm@21` (`-DLLVM_DIR=/opt/homebrew/opt/llvm@21/lib/cmake/llvm`).
+> **macOS**: `/usr/local/llvm` is typically static-only and will not link — use `cmake --preset rust-emit && cmake --build build-rust` instead. The `rust-emit` preset points `LLVM_DIR` at Homebrew `llvm@21` (`/opt/homebrew/opt/llvm@21/lib/cmake/llvm`) and outputs to `build-rust/` (`./build-rust/ry`). See `AGENTS.md` § "Build And Test".
 
 ## Usage
 

--- a/docs/grammar.ebnf
+++ b/docs/grammar.ebnf
@@ -2,7 +2,7 @@
  * Ry language grammar (EBNF, W3C-style notation)
  * ===============================================
  *
- * Source: ry compiler v0.0.17 — verified against
+ * Source: ry compiler v0.0.27 — verified against
  *   include/ry/lexer/lexer.hpp / src/lexer/lexer.cpp     (terminals & keyword table)
  *   src/parser/parser*.cpp                               (statement & expression productions)
  *   tests/spec/*.test.ry                     (concrete syntax samples)

--- a/docs/reference/functions.md
+++ b/docs/reference/functions.md
@@ -212,7 +212,7 @@ fn bump():
 - **Mutable top-level writes are write-through.** Assigning to a top-level mutable variable from inside a function actually mutates the top-level binding — it does not create a local with the same name.
 - **Nested blocks are not module-level.** A binding inside a top-level `if`, `while`, or `for` block is local to that block and is not visible from functions.
 
-**Limitations (v0.0.8):**
+**Limitations:**
 
 - A parallel `for` block cannot assign to a top-level mutable variable (data-race avoidance).
 - Top-level `weak` references and resource-typed bindings (file/regex handles) cannot yet be accessed from function bodies — track these use cases in follow-up issues if you need them.

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -272,9 +272,9 @@ case open("out.json", "w"):
 - `load[int]` accepts JSON floats that are whole numbers
   (`42.0` → `42`); `load[float]` accepts JSON integers
   (`42` → `42.0`).
-- Embedded NUL bytes (` `) round-trip: `load` accepts ` ` in
+- Embedded NUL bytes (`U+0000`) round-trip: `load` accepts `\u0000` in
   string values and object keys; `stringify` emits the escape sequence
-  ` ` for any NUL byte in a string.
+  `\u0000` for any NUL byte in a string.
 - `load` enforces a maximum nesting depth of **256** for arrays and
   objects (combined). Inputs that exceed this depth return
   `Err(Error{message: "json: maximum nesting depth exceeded"})`


### PR DESCRIPTION
## Summary

Issue #2153 で挙がっていた将来 drift リスクの 5 件のうち、PR #2139 で解消済みの item 1
を除く 4 件 (items 2–5) を一括修正:

- `docs/reference/functions.md:215` — `**Limitations (v0.0.8):**` の version 表記を撤去。
- `docs/grammar.ebnf:5` — `v0.0.17` → `v0.0.27` (PR #2167 までの parser 整合状態と
  一致)。
- `README.md` Build from Source — 手動 `cmake -B build -DLLVM_DIR=...` を
  `cmake --preset default` ベースに変更し、AGENTS.md および
  `docs/reference/{project,testing}.md` と整合。macOS 脚注は `--preset rust-emit` +
  `build-rust/`。`-DLLVM_DIR=<path>` 上書きヒントを追加。
- `docs/reference/json.md:275-277` — 埋め込み raw NUL (0x00) × 3 箇所を、ラベル位置
  は `U+0000`、入出力位置は JSON spec (RFC 8259 §7) の escape sequence に置換。
  実装は `src/runtime/native/json.cpp:38-41` (stringify は `\u%04x` で emit) /
  `:205,:296` (load は raw 0x00–0x1F を "unescaped control character" として拒否)。

Item 1 (`docs/reference/collections.md:253` の eager-default 注記) は PR #2139 で
実装が lazy 化された際に doc も "evaluated lazily" に更新されており対応不要。

Closes #2153

## Test plan

- [x] `python3 -c "assert b'\x00' not in open('docs/reference/json.md','rb').read()"` — NUL 完全除去
- [x] `grep -n 'Limitations' docs/reference/functions.md` → `**Limitations:**` のみ (version 表記なし)
- [x] `grep -n 'v0\.0\.' docs/grammar.ebnf` → `v0.0.27` のみ
- [x] `grep -n 'cmake (-B|--preset)' README.md` → `--preset default` / `--preset rust-emit` のみ
- [x] tree-sitter regression check (`./.claude/skills/pre-commit-checklist/run-tree-sitter.sh`) — pass=157 skip=48 fail=0
- [x] docs-only 変更のため build/test/sanitizer/fuzz は不要 (`/pre-commit-checklist` 判定)