### PR TITLE
fix(parser): allow multiline chain after CallStmt leaders (#2138)

### DIFF
--- a/.claude/rules/parser-conventions.md
+++ b/.claude/rules/parser-conventions.md
@@ -89,9 +89,29 @@ stmt variant.
 **How to apply**: Any statement that starts with `Ident` and may accept
 chained postfix hops (e.g. a future `move var.a.b into ...` or similar)
 should call `parsePostfixContinuation(baseExpr)` rather than re-parsing `.`
-and `[` inline. UFCS call statements (`ident.method(args)`) remain a
-special case detected before entering the continuation, because they
-produce a `CallStmt` rather than an `ExprStmt<CallExpr>`.
+and `[` inline. Call-statement leaders — UFCS (`ident.method(args)`)
+and direct (`ident(args)`) — are not detected before the continuation;
+since #2138 they are first built as `CallExpr`, fed through
+`parsePostfixContinuation`, and collapsed back to `CallStmt` (preserving
+`tryParseTrailingBlock`, user-defined directives, and the `mock`
+coercion) only when the continuation returns the same `ExprNode*` it
+was given. When a chain (or any postfix tail) follows, control falls
+through to `finishChainedLhs` and the statement becomes an
+`ExprStmt<CallExpr>` (or `Field/IndexAssignStmt` if the tail is
+assignable).
+
+**Node-identity collapse idiom**: `parsePostfixContinuation` is
+idempotent — when no chain hop is consumed it restores `lex_` state
+and `chain_pending_dedents_` (see `src/parser/parser_expr.cpp`) and
+returns the same `ExprPtr` it was given. Snapshot
+`ExprNode* before = node.get()` before the move; after the call,
+`chain.get() == before` ⇔ no extension. This is more robust than
+inspecting the variant tail (which can be a `CallExpr` either because
+no chain ran or because the chain ended on a `.method()` hop). Any
+future statement leader that wants the "collapse back to a dedicated
+stmt variant when no chain follows, otherwise become ExprStmt" pattern
+should follow the same snapshot-and-compare shape rather than
+re-implementing the speculative skip.
 
 ### Use strtod, not std::stod, for float literal parsing
 

--- a/changelog.d/2138-callstmt-multiline-chain.md
+++ b/changelog.d/2138-callstmt-multiline-chain.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- Parser: a multiline `.method()` chain immediately after a statement-position `CallStmt` (e.g. `xs.sort()\n    .iter()\n    .toList()` or `foo()\n    .iter()`) no longer fails with `unexpected token ''`. Both the 1-hop UFCS path (`ident.method(args)`) and the direct-call path (`ident(args)`) in `src/parser/parser.cpp`'s statement dispatch now route through `parsePostfixContinuation` and fall back to a `CallStmt` (preserving the trailing-block fast path) only when no chain follows. The expression-position chain support added in #2115 / #2121 already covered statements whose leader was a primary expression (list literal, bare ident); this closes the asymmetry for the call-statement leader. Follow-up to #2121. (#2138)

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -925,19 +925,43 @@ StmtNode Parser::parseStatement() {
                 ExprPtr chain = parsePostfixContinuation(std::move(node));
                 return finishChainedLhs(std::move(chain), first);
             }
-            // UFCS call statement: ident.method(args)
-            CallStmt s;
-            s.callee = fieldTok.value;
-            s.loc = locFromToken(first);
+            // UFCS call statement: ident.method(args). #2138: build a
+            // CallExpr in UFCS shape and route it through
+            // parsePostfixContinuation so a trailing multiline `.method()`
+            // chain (`xs.sort()\n    .iter()`) is consumed alongside the
+            // expression-position siblings at :925 / :963. When no chain
+            // follows, the helper is idempotent (lex state and
+            // chain_pending_dedents_ are save/restored on speculative
+            // failure at parser_expr.cpp:1244-1247) and the same ExprNode
+            // we passed in is returned unchanged — pointer-equality on
+            // ExprNode* before vs chain.get() detects that and lets us
+            // collapse back into a CallStmt so the existing
+            // tryParseTrailingBlock fast path keeps working.
+            auto call = std::make_unique<CallExpr>();
+            call->callee = fieldTok.value;
             auto obj = std::make_unique<ExprNode>();
             obj->data = VariableExpr{first.value};
             obj->loc = locFromToken(first);
-            s.args.push_back(std::move(obj));
-            auto rest = parseArgList(&s.named_args);
+            call->args.push_back(std::move(obj));
+            auto rest = parseArgList(&call->named_args);
             for (auto &arg : rest)
-                s.args.push_back(std::move(arg));
-            tryParseTrailingBlock(s);
-            return s;
+                call->args.push_back(std::move(arg));
+            auto node = std::make_unique<ExprNode>();
+            node->data = std::move(call);
+            node->loc = locFromToken(first);
+            ExprNode *before = node.get();
+            ExprPtr chain = parsePostfixContinuation(std::move(node));
+            if (chain.get() == before) {
+                auto &ce = std::get<std::unique_ptr<CallExpr>>(chain->data);
+                CallStmt s;
+                s.callee = std::move(ce->callee);
+                s.args = std::move(ce->args);
+                s.named_args = std::move(ce->named_args);
+                s.loc = locFromToken(first);
+                tryParseTrailingBlock(s);
+                return s;
+            }
+            return finishChainedLhs(std::move(chain), first);
         }
 
         // Build `ident.field` as the chain base and continue parsing any
@@ -1033,17 +1057,35 @@ StmtNode Parser::parseStatement() {
                     "built-in directive '@" + d.name + "' is not supported on function calls");
         }
         lex_.next(); // consume '('
-        CallStmt s;
-        s.callee = first.value;
-        s.args = parseArgList(&s.named_args);
-        s.loc = locFromToken(first);
-        if (s.callee == "mock")
-            coerceFirstArgToString(s.args);
-        if (s.callee != "mock") {
-            tryParseTrailingBlock(s);
+        // #2138: mirror the UFCS CallStmt fix above. Build a CallExpr,
+        // route it through parsePostfixContinuation, and only collapse
+        // back into a CallStmt (preserving mock arg coercion, trailing
+        // block, and user-defined directives) when no chain followed.
+        // The chain-extended path produces an ExprStmt via finishChainedLhs.
+        auto call = std::make_unique<CallExpr>();
+        call->callee = first.value;
+        call->args = parseArgList(&call->named_args);
+        auto node = std::make_unique<ExprNode>();
+        node->data = std::move(call);
+        node->loc = locFromToken(first);
+        ExprNode *before = node.get();
+        ExprPtr chain = parsePostfixContinuation(std::move(node));
+        if (chain.get() == before) {
+            auto &ce = std::get<std::unique_ptr<CallExpr>>(chain->data);
+            CallStmt s;
+            s.callee = std::move(ce->callee);
+            s.args = std::move(ce->args);
+            s.named_args = std::move(ce->named_args);
+            s.loc = locFromToken(first);
+            if (s.callee == "mock")
+                coerceFirstArgToString(s.args);
+            if (s.callee != "mock") {
+                tryParseTrailingBlock(s);
+            }
+            s.directives = std::move(directives);
+            return s;
         }
-        s.directives = std::move(directives);
-        return s;
+        return finishChainedLhs(std::move(chain), first);
     }
     parseError(next.line, "expected '=', '+=', '-=', '*=', '/=', '%=', '//=', '**=', '&=', '|=', '^=', '<<=', '>>=', '++', '--', '.', '[', or '(' after identifier");
 }

--- a/tests/spec/expr_stmt_multiline_ufcs.test.ry
+++ b/tests/spec/expr_stmt_multiline_ufcs.test.ry
@@ -7,6 +7,13 @@ from testing import it, describe, expect
 # in editor/tree-sitter/expected-fail.txt instead of degrading the editor
 # view of the entire expr_stmt.test.ry suite.
 
+# #2138 fixtures: helper returning a fresh List<int> so the direct-call
+# CallStmt-leader chain test can exercise the runtime path without
+# depending on side-effect plumbing the discarded chain result would
+# need to observe.
+fn buildList() -> List<int>:
+  return [1, 2, 3]
+
 @describe("multiline UFCS chain")
 fn multilineUfcsChainTests():
   @it("should run iterator pipeline across multiple lines")
@@ -71,3 +78,27 @@ fn multilineUfcsChainTests():
         # finalize
         .toList()
     expect(result).toEq([1, 2, 3])
+  @it("should support multiline UFCS chain after a CallStmt receiver")
+  fn shouldSupportMultilineUfcsChainAfterCallStmtReceiver():
+    # #2138: the statement leader is the UFCS CallStmt `xs.sort()`,
+    # not a primary expression. Pre-fix this raised "unexpected token"
+    # on the continuation `.iter()` line. The chain runs at statement
+    # position and its result is discarded — verification is that the
+    # body executes to the post-chain expect without parser/runtime
+    # error and that `xs` (non-mutated by `sort`) round-trips.
+    xs = [3, 1, 2]
+    xs.sort()
+        .iter()
+        .toList()
+    expect(xs).toEq([3, 1, 2])
+  @it("should support multiline chain after a direct CallStmt leader")
+  fn shouldSupportMultilineChainAfterDirectCallStmtLeader():
+    # #2138 sibling: the direct-call CallStmt path
+    # (src/parser/parser.cpp:1036-1046) shared the same bug; the fix
+    # mirrors the UFCS path. Helper `buildList` is a module-global
+    # function returning List<int>, so the chain leader is a plain
+    # `buildList()` direct call rather than a UFCS receiver.
+    buildList()
+        .iter()
+        .toList()
+    expect(buildList()).toEq([1, 2, 3])

--- a/tests/test_parser.cpp
+++ b/tests/test_parser.cpp
@@ -2270,6 +2270,125 @@ TEST(ParserTest, UfcsMultilineChainInLambdaBody) {
     EXPECT_TRUE(std::holds_alternative<CallStmt>(fn.body[1]));
 }
 
+TEST(ParserTest, UfcsOneHopCallStmtShape) {
+    // #2138 regression guard: a 1-hop UFCS call statement (no chain,
+    // no trailing block) must still parse to a CallStmt — not the
+    // ExprStmt that the #2138 fix produces when a chain follows. The
+    // existing TrailingBlockUFCS test only verifies the block form;
+    // this locks the plain form.
+    Program prog = parseStr("xs.sort()");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<CallStmt>(prog[0]));
+    const auto &s = std::get<CallStmt>(prog[0]);
+    EXPECT_EQ(s.callee, "sort");
+    ASSERT_EQ(s.args.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<VariableExpr>(s.args[0]->data));
+    EXPECT_EQ(std::get<VariableExpr>(s.args[0]->data).name, "xs");
+}
+
+TEST(ParserTest, DirectCallStmtShape) {
+    // #2138 regression guard for the sibling direct-call CallStmt
+    // path (parser.cpp:1036-1046). After the fix, a plain `foo()`
+    // with no chain continuation must still produce a CallStmt.
+    Program prog = parseStr("foo()");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<CallStmt>(prog[0]));
+    const auto &s = std::get<CallStmt>(prog[0]);
+    EXPECT_EQ(s.callee, "foo");
+    EXPECT_EQ(s.args.size(), 0u);
+}
+
+TEST(ParserTest, UfcsMultilineChainAfterCallStmt) {
+    // #2138: 1-hop UFCS CallStmt followed by a multiline `.method()`
+    // chain must parse — pre-fix this fired "unexpected token ''" on
+    // the continuation line. The chain hoists the original CallStmt
+    // into a CallExpr that becomes the args[0] receiver of the outer
+    // hop, so the whole statement is now an ExprStmt whose outer
+    // callee is the tail method.
+    Program prog = parseStr("xs.sort()\n    .iter()\n    .toList()");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(prog[0]));
+    const auto &es = std::get<ExprStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(es.expr->data));
+    EXPECT_EQ(std::get<std::unique_ptr<CallExpr>>(es.expr->data)->callee, "toList");
+}
+
+TEST(ParserTest, UfcsMultilineChainAfterCallStmtFiveHops) {
+    // #2138: longer pipeline confirms the fix scales beyond a single
+    // continuation hop and stays compatible with the existing tail-
+    // drain semantics of parsePostfixContinuation.
+    Program prog = parseStr(
+        "xs.sort()\n"
+        "    .iter()\n"
+        "    .filter((x: int) => x > 0)\n"
+        "    .map((x: int) => x * 2)\n"
+        "    .toList()");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(prog[0]));
+    const auto &es = std::get<ExprStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(es.expr->data));
+    EXPECT_EQ(std::get<std::unique_ptr<CallExpr>>(es.expr->data)->callee, "toList");
+}
+
+TEST(ParserTest, DirectCallStmtMultilineChain) {
+    // #2138 (sibling): direct-call CallStmt path (parser.cpp:1036-1046)
+    // shares the same bug; the fix here mirrors the UFCS path. The
+    // chain leader is `foo()` (no UFCS receiver), so the outer CallExpr
+    // chain absorbs `foo()` as args[0] of `.iter()` etc.
+    Program prog = parseStr("foo()\n    .iter()\n    .toList()");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(prog[0]));
+    const auto &es = std::get<ExprStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(es.expr->data));
+    EXPECT_EQ(std::get<std::unique_ptr<CallExpr>>(es.expr->data)->callee, "toList");
+}
+
+TEST(ParserTest, UfcsMultilineChainAfterCallStmtRejectsBlankLineSeparator) {
+    // #2138 scope guard: the single-Newline cap that the original
+    // #2115 fix established at parsePostfixContinuation must apply
+    // uniformly at the new CallStmt-leader call site too. A blank
+    // line between the CallStmt and the continuation `.` is a
+    // statement separator, not a chain continuation — the leading
+    // `.iter()` then fails the same way DotAtStatementStartAloneFails
+    // locks in.
+    EXPECT_THROW(parseStr("xs.sort()\n\n    .iter()"), std::runtime_error);
+}
+
+TEST(ParserTest, UfcsMultilineChainAfterCallStmtCommentBetweenHopsTransparent) {
+    // #2138 cross-check with #2137: a comment-only line between a
+    // CallStmt leader and its first `.method()` continuation hop is
+    // lexer-suppressed to a no-token sequence, so the chain sees the
+    // same token stream as the comment-free form. Locks in the
+    // composition; the equivalent check at expression position lives
+    // at UfcsMultilineChainCommentBetweenHopsTransparent.
+    Program prog = parseStr(
+        "xs.sort()\n    # skip empty\n    .iter()\n    .toList()");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(prog[0]));
+    const auto &es = std::get<ExprStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(es.expr->data));
+    EXPECT_EQ(std::get<std::unique_ptr<CallExpr>>(es.expr->data)->callee, "toList");
+}
+
+TEST(ParserTest, CallStmtLeaderErrorPropagateNowAccepted) {
+    // #2138 scope: routing the CallStmt leader through
+    // parsePostfixContinuation also legalises a trailing `?` on a
+    // statement-position call (the same shape the qualified-module
+    // and field-access leaders already accepted). The chain becomes
+    // ExprStmt with an ErrorPropagateExpr wrapping the CallExpr. The
+    // operand's Result-ness is a codegen concern, not a parser one —
+    // this only locks the AST shape so a future tightening of the
+    // CallStmt leader does not silently revert the capability.
+    Program prog = parseStr("foo()?");
+    ASSERT_EQ(prog.size(), 1u);
+    ASSERT_TRUE(std::holds_alternative<ExprStmt>(prog[0]));
+    const auto &es = std::get<ExprStmt>(prog[0]);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<ErrorPropagateExpr>>(es.expr->data));
+    const auto &ep = *std::get<std::unique_ptr<ErrorPropagateExpr>>(es.expr->data);
+    ASSERT_TRUE(std::holds_alternative<std::unique_ptr<CallExpr>>(ep.operand->data));
+    EXPECT_EQ(std::get<std::unique_ptr<CallExpr>>(ep.operand->data)->callee, "foo");
+}
+
 // ===== Map パーステスト =====
 
 TEST(ParserTest, MapLiteral) {


### PR DESCRIPTION
## Summary

- Route both UFCS (`ident.method(args)`) and direct-call (`ident(args)`) statement-leader paths through `parsePostfixContinuation`, mirroring the qualified-module / field-access siblings. ExprNode pointer-equality detects the no-chain case and collapses back to `CallStmt` (preserving `tryParseTrailingBlock`, `mock` arg coercion, and user-defined directives).
- Side effect: `foo()?` / `xs.method()?` are now also accepted at statement position (consistent with qualified-module and field-access leaders). Locked in by `CallStmtLeaderErrorPropagateNowAccepted`.
- Updates `.claude/rules/parser-conventions.md` #812 entry for the post-#2138 contract and documents the node-identity collapse idiom for future statement-leader additions.

## Test plan

- [x] C++ unit tests (`./build-rust/ry_tests`): 2704 passed, 0 failed — includes 9 new `ParserTest.*` cases (`UfcsOneHopCallStmtShape`, `DirectCallStmtShape`, `UfcsMultilineChainAfterCallStmt`, `UfcsMultilineChainAfterCallStmtFiveHops`, `DirectCallStmtMultilineChain`, `UfcsMultilineChainAfterCallStmtRejectsBlankLineSeparator`, `UfcsMultilineChainAfterCallStmtCommentBetweenHopsTransparent`, `CallStmtLeaderErrorPropagateNowAccepted`).
- [x] Ry self-tests (`./build-rust/ry test -p`): 205 test files, 0 failures (2 new `@it` in `expr_stmt_multiline_ufcs.test.ry` for UFCS-leader and direct-call-leader runtime chains).
- [x] ASan+UBSan via Docker: no findings.
- [x] TSan via Docker: no races.
- [x] libFuzzer (`fuzz_parser` / `fuzz_json` / `fuzz_utf8` / `fuzz_io_open`, 60s each, 2 GB RSS cap): no crashes.
- [x] Static analysis (clang-tidy / cppcheck / scan-build): EXIT 0, "No bugs found".
- [x] prompt-refs lint: EXIT 0.
- [x] Issue repro: `echo 'xs: List<int> = [3, 1, 2]\nxs.sort()\n    .iter()\nprint(xs)' | ./build-rust/ry -c` → `[3, 1, 2]` (pre-fix: parse error).

Closes #2138