### PR TITLE
docs(rule): drop obsolete reduce row and stale line numbers from stdlib-dispatcher sample (#2165)

### DIFF
--- a/.claude/rules/docs-reference-conventions.md
+++ b/.claude/rules/docs-reference-conventions.md
@@ -232,12 +232,11 @@ completely absent from the corresponding reference pages. Examples found:
 
 | Error message | Emitter location |
 |---|---|
-| `runtime error: reduce() on empty list` | `codegen_call_higher_order.cpp:237` |
-| `runtime error: min() on empty list` | `codegen_call_higher_order.cpp:480` |
-| `runtime error: max() on empty list` | `codegen_call_higher_order.cpp:480` |
+| `runtime error: min() on empty list` | `codegen_call_higher_order.cpp` |
+| `runtime error: max() on empty list` | `codegen_call_higher_order.cpp` |
 | `runtime error: floor(): cannot convert %g to int` (also `ceil()`, `round()`, `trunc()`) | `codegen_call.cpp` math path via `emitCheckedFPToInt` |
 | `flatten() requires a list of lists` (compile) | `codegen_call_collection.cpp` |
-| `fold() initial value type must match function return type` (compile) | `codegen_call_higher_order.cpp:291-294` |
+| `fold() initial value type must match function return type` (compile) | `codegen_call_higher_order.cpp` |
 
 **Rule**: When auditing stdlib docs (PR 3–5 of #1118), grep all `codegenError()` and
 `runtime error:` strings in `src/codegen_call_*.cpp` and `src/runtime/**/*.cpp`, then verify


### PR DESCRIPTION
## Summary

- `.claude/rules/docs-reference-conventions.md` の "Runtime errors in stdlib dispatchers must be mirrored" サンプル表が #1118 監査時点のまま放置され、現状と乖離していたので整理した。
- `reduce() on empty list` 行は PR #1209 で `reduce()` が `Option<T>` 戻り値に変更され panic を廃止したため削除。残った `min`/`max`/`fold` 行の `:NNN` 行番号は #1118 時点のもので、その後の refactor でズレている (`min/max` の実体は現在 `codegen_call_higher_order.cpp:614`) ため、行番号サフィックスのみ削除しファイル名は残した。
- `**Source**: #1118 PR 3 docs audit` メタデータが冒頭にあるため、表の歴史的フレーミングは保たれる。
- `docs/reference/errors.md` / `collections.md` は現状で正しい (`reduce` の Option<T> 戻り値を既に説明済み) ため変更なし。

## Test plan

- [x] `.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh` ➜ clean
- [x] `git diff origin/main` で差分が rule ファイル 1 行のみであることを確認
- [x] `grep "reduce() on empty"` で削除済みを確認、`grep "min() on empty\|max() on empty"` で残置を確認