### PR TITLE
test(emit): add ABI guard test coverage (#2142 #2143 #2144 #2145)

### DIFF
--- a/crates/emit/src/abi.rs
+++ b/crates/emit/src/abi.rs
@@ -133,6 +133,9 @@ pub const RY_LISTCOPY_TAKE: c_int = 2;
 
 // Integer-comparison predicate selector for ry_emit_icmp (#2072). MUST match the
 // RyICmpPred enum in api.h. abi/primitive.rs maps these to the core `IcmpPred`.
+// Cross-language parity is enforced by tests/test_abi_layout.cpp
+// (AbiLayout.RyICmpPredRustMirrorMatchesCanonical) via the test-only extern
+// `ry_emit_test_icmp_pred_values` in abi/test_introspect.rs (#2143).
 pub const RY_ICMP_EQ: c_int = 0;
 pub const RY_ICMP_NE: c_int = 1;
 pub const RY_ICMP_SLT: c_int = 2;

--- a/crates/emit/src/abi/test_introspect.rs
+++ b/crates/emit/src/abi/test_introspect.rs
@@ -82,6 +82,46 @@ pub extern "C" fn ry_emit_test_field_indices() -> RyTestFieldIndices {
     }
 }
 
+// Flat report of the Rust-side RY_ICMP_* numeric values for the C++ parity test
+// (tests/test_abi_layout.cpp). The 10 fields mirror the RyICmpPred enum in
+// include/ry/llvm_emit/api.h 1:1; any cross-language drift (a C++ reorder the
+// Rust side fails to mirror, or vice versa) fires the runtime parity test.
+#[repr(C)]
+pub struct RyTestICmpPredValues {
+    pub eq: c_int,
+    pub ne: c_int,
+    pub slt: c_int,
+    pub sle: c_int,
+    pub sgt: c_int,
+    pub sge: c_int,
+    pub ult: c_int,
+    pub ule: c_int,
+    pub ugt: c_int,
+    pub uge: c_int,
+}
+
+/// Report the Rust-side RY_ICMP_* numeric values for the cross-language parity
+/// test (#2143). Pure data lookup — emits no IR.
+#[no_mangle]
+pub extern "C" fn ry_emit_test_icmp_pred_values() -> RyTestICmpPredValues {
+    use crate::abi::{
+        RY_ICMP_EQ, RY_ICMP_NE, RY_ICMP_SGE, RY_ICMP_SGT, RY_ICMP_SLE, RY_ICMP_SLT, RY_ICMP_UGE,
+        RY_ICMP_UGT, RY_ICMP_ULE, RY_ICMP_ULT,
+    };
+    RyTestICmpPredValues {
+        eq: RY_ICMP_EQ,
+        ne: RY_ICMP_NE,
+        slt: RY_ICMP_SLT,
+        sle: RY_ICMP_SLE,
+        sgt: RY_ICMP_SGT,
+        sge: RY_ICMP_SGE,
+        ult: RY_ICMP_ULT,
+        ule: RY_ICMP_ULE,
+        ugt: RY_ICMP_UGT,
+        uge: RY_ICMP_UGE,
+    }
+}
+
 /// Report the single-sourced field layout of an internal header for the
 /// cross-language parity test. Pure data lookup — emits no IR.
 #[no_mangle]

--- a/include/ry/llvm_emit/api.h
+++ b/include/ry/llvm_emit/api.h
@@ -981,7 +981,10 @@ void ry_emit_switch_add_case(RyEmitCtx *ctx, RySwitchRef sw, RyValueId on_val,
 
 // Integer-comparison predicate selector for ry_emit_icmp. Numbers are a stable
 // boundary contract; do not reorder without updating the RY_ICMP_* constants in
-// `crates/emit/src/abi.rs` (which map to the core `IcmpPred`).
+// `crates/emit/src/abi.rs` (which map to the core `IcmpPred`). Cross-language
+// parity is enforced by tests/test_abi_layout.cpp
+// (AbiLayout.RyICmpPredRustMirrorMatchesCanonical) via the test-only extern
+// `ry_emit_test_icmp_pred_values` (#2143).
 typedef enum {
     RY_ICMP_EQ = 0,
     RY_ICMP_NE = 1,

--- a/tests/test_abi_layout.cpp
+++ b/tests/test_abi_layout.cpp
@@ -111,6 +111,51 @@ static_assert(sizeof(RyBoundsKind) == sizeof(int), "RyBoundsKind underlying type
 static_assert(sizeof(RyArcAtomic) == sizeof(int), "RyArcAtomic underlying type is int");
 static_assert(sizeof(RyCowKind) == sizeof(int), "RyCowKind underlying type is int");
 
+// === RyICmpPred cross-language parity (#2143) ===
+// The C++ enumerator literals (api.h L985-996) and the Rust `RY_ICMP_*`
+// constants (crates/emit/src/abi.rs) were previously protected only by a
+// prose "MUST match" comment. Two layered guards now pin them mechanically:
+//   1. `static_assert` below pins the C++ side at compile-time — any
+//      reorder of the api.h enum that changes a numeric value fires.
+//   2. `RyICmpPredRustMirrorMatchesCanonical` below calls the test-only
+//      FFI extern `ry_emit_test_icmp_pred_values` (crates/emit/src/abi/
+//      test_introspect.rs) which reports the Rust constants by value; a
+//      Rust-only edit that drifts from C++ fires the runtime test.
+// Following the precedent in .claude/rules/codegen-llvm-ir-conventions.md
+// "Rust mirrors of C++ header structs need a cross-language parity guard,
+// not a 'keep in sync' comment".
+static_assert(RY_ICMP_EQ == 0 && RY_ICMP_NE == 1,
+              "RyICmpPred EQ/NE literal mismatch (api.h reorder?)");
+static_assert(RY_ICMP_SLT == 2 && RY_ICMP_SLE == 3 && RY_ICMP_SGT == 4 && RY_ICMP_SGE == 5,
+              "RyICmpPred signed predicates literal mismatch (api.h reorder?)");
+static_assert(RY_ICMP_ULT == 6 && RY_ICMP_ULE == 7 && RY_ICMP_UGT == 8 && RY_ICMP_UGE == 9,
+              "RyICmpPred unsigned predicates literal mismatch (api.h reorder?)");
+
+extern "C" {
+// Mirror of the Rust #[repr(C)] RyTestICmpPredValues
+// (crates/emit/src/abi/test_introspect.rs).
+struct RyTestICmpPredValues {
+    int eq, ne;
+    int slt, sle, sgt, sge;
+    int ult, ule, ugt, uge;
+};
+RyTestICmpPredValues ry_emit_test_icmp_pred_values();
+}
+
+TEST(AbiLayout, RyICmpPredRustMirrorMatchesCanonical) {
+    const RyTestICmpPredValues rust = ry_emit_test_icmp_pred_values();
+    EXPECT_EQ(rust.eq,  static_cast<int>(RY_ICMP_EQ));
+    EXPECT_EQ(rust.ne,  static_cast<int>(RY_ICMP_NE));
+    EXPECT_EQ(rust.slt, static_cast<int>(RY_ICMP_SLT));
+    EXPECT_EQ(rust.sle, static_cast<int>(RY_ICMP_SLE));
+    EXPECT_EQ(rust.sgt, static_cast<int>(RY_ICMP_SGT));
+    EXPECT_EQ(rust.sge, static_cast<int>(RY_ICMP_SGE));
+    EXPECT_EQ(rust.ult, static_cast<int>(RY_ICMP_ULT));
+    EXPECT_EQ(rust.ule, static_cast<int>(RY_ICMP_ULE));
+    EXPECT_EQ(rust.ugt, static_cast<int>(RY_ICMP_UGT));
+    EXPECT_EQ(rust.uge, static_cast<int>(RY_ICMP_UGE));
+}
+
 // A no-op runtime test so CTest shows a named green signal confirming this
 // TU (and therefore every static_assert above) compiled successfully.
 TEST(AbiLayout, LayoutContractCompiled) { SUCCEED(); }

--- a/tests/test_emit_abi_guards.cpp
+++ b/tests/test_emit_abi_guards.cpp
@@ -510,6 +510,19 @@ TEST_F(EmitAbiGuardTest, ReduceSumListNullElemTyReturnsZero) {
     ry_emit_ctx_destroy(ctx);
 }
 
+// #2145: mirrors the elem_ty=NULL case above for the list_header_ty=NULL arm of
+// the same `elem_ty.is_null() || list_header_ty.is_null()` guard
+// (crates/emit/src/abi/reduce.rs). Without this, an `||` → `&&` typo silently
+// lets NULL list_header_ty reach LLVMBuildStructGEP2.
+TEST_F(EmitAbiGuardTest, ReduceSumListNullListHeaderTyReturnsZero) {
+    RyEmitCtx *ctx = makeCtx();
+    ASSERT_NE(ctx, nullptr);
+    RyValueId listId = internDummy(ctx);
+    EXPECT_EQ(ry_emit_reduce_sum_list(ctx, listId, asRyType(resultTy_), /*list_header_ty=*/nullptr),
+              0u);
+    ry_emit_ctx_destroy(ctx);
+}
+
 TEST_F(EmitAbiGuardTest, ReduceSumStepNullElemTyReturnsZero) {
     RyEmitCtx *ctx = makeCtx();
     ASSERT_NE(ctx, nullptr);
@@ -594,6 +607,17 @@ TEST_F(EmitAbiGuardTest, CreateFunctionNullFnTypeReturnsNull) {
     RyEmitCtx *ctx = makeCtx();
     ASSERT_NE(ctx, nullptr);
     EXPECT_EQ(ry_emit_create_function(ctx, "f", /*fn_ty=*/nullptr, RY_LINKAGE_EXTERNAL), nullptr);
+    ry_emit_ctx_destroy(ctx);
+}
+
+// #2142: mirrors the fn_ty=NULL case above for the name=NULL arm of the same
+// `fn_ty.is_null() || name.is_null()` guard (crates/emit/src/abi/function.rs).
+TEST_F(EmitAbiGuardTest, CreateFunctionNullNameReturnsNull) {
+    RyEmitCtx *ctx = makeCtx();
+    ASSERT_NE(ctx, nullptr);
+    EXPECT_EQ(ry_emit_create_function(ctx, /*name=*/nullptr, asRyFuncType(fnTy_),
+                                      RY_LINKAGE_EXTERNAL),
+              nullptr);
     ry_emit_ctx_destroy(ctx);
 }
 
@@ -858,6 +882,61 @@ TEST_F(EmitAbiGuardTest, ArrayGepUnresolvableOperandReturnsZero) {
     // A valid array type passes the type guard; base_id 0 then resolves to NULL.
     llvm::ArrayType *arrayTy = llvm::ArrayType::get(llvm::Type::getInt64Ty(llctx_), 4);
     EXPECT_EQ(ry_emit_array_gep(ctx, asRyType(arrayTy), /*base_id=*/0, /*idx_id=*/0, "x"), 0u);
+    ry_emit_ctx_destroy(ctx);
+}
+
+// =============================================================================
+// #2144 — load / single-index gep primitive guards (string-ops migration #2072
+// hot path). Both follow the same three-guard contract as ry_emit_struct_gep /
+// ry_emit_array_gep: NULL ctx, NULL type handle, unresolvable ptr id (id 0).
+// Type guard fires BEFORE resolve_value in both (unlike ry_emit_reduce_sum_list,
+// whose order is the reverse).
+// =============================================================================
+
+// --- ry_emit_load: ctx == NULL / NULL ty / unresolvable ptr → sentinel 0 ---
+
+TEST_F(EmitAbiGuardTest, LoadNullCtxReturnsZero) {
+    EXPECT_EQ(ry_emit_load(nullptr, asRyType(resultTy_), /*ptr_id=*/0, "x"), 0u);
+}
+
+TEST_F(EmitAbiGuardTest, LoadNullTypeReturnsZero) {
+    RyEmitCtx *ctx = makeCtx();
+    ASSERT_NE(ctx, nullptr);
+    // Resolvable ptr_id isolates the NULL-ty guard (it fires before resolve_value).
+    RyValueId id = internDummy(ctx);
+    EXPECT_EQ(ry_emit_load(ctx, /*ty=*/nullptr, id, "x"), 0u);
+    ry_emit_ctx_destroy(ctx);
+}
+
+TEST_F(EmitAbiGuardTest, LoadUnresolvablePtrReturnsZero) {
+    RyEmitCtx *ctx = makeCtx();
+    ASSERT_NE(ctx, nullptr);
+    // A valid ty passes the type guard; ptr_id 0 then resolves to NULL.
+    EXPECT_EQ(ry_emit_load(ctx, asRyType(resultTy_), /*ptr_id=*/0, "x"), 0u);
+    ry_emit_ctx_destroy(ctx);
+}
+
+// --- ry_emit_gep (single-index): ctx == NULL / NULL base_ty / unresolvable
+//     operand → sentinel 0 ---
+
+TEST_F(EmitAbiGuardTest, GepNullCtxReturnsZero) {
+    EXPECT_EQ(ry_emit_gep(nullptr, asRyType(resultTy_), /*ptr_id=*/0, /*idx_id=*/0, "x"), 0u);
+}
+
+TEST_F(EmitAbiGuardTest, GepNullTypeReturnsZero) {
+    RyEmitCtx *ctx = makeCtx();
+    ASSERT_NE(ctx, nullptr);
+    // Resolvable operands isolate the NULL-base_ty guard.
+    RyValueId id = internDummy(ctx);
+    EXPECT_EQ(ry_emit_gep(ctx, /*base_ty=*/nullptr, id, id, "x"), 0u);
+    ry_emit_ctx_destroy(ctx);
+}
+
+TEST_F(EmitAbiGuardTest, GepUnresolvableBaseReturnsZero) {
+    RyEmitCtx *ctx = makeCtx();
+    ASSERT_NE(ctx, nullptr);
+    // A valid base_ty passes the type guard; ptr_id 0 then resolves to NULL.
+    EXPECT_EQ(ry_emit_gep(ctx, asRyType(resultTy_), /*ptr_id=*/0, /*idx_id=*/0, "x"), 0u);
     ry_emit_ctx_destroy(ctx);
 }
 


### PR DESCRIPTION
## Summary

- 4 件の test-only 追加: `ry_emit_create_function` の name=NULL guard (#2142)、`RyICmpPred` cross-language parity guard (#2143)、`ry_emit_load` / `ry_emit_gep` 各 3 件の guard (#2144)、`ry_emit_reduce_sum_list` の list_header_ty=NULL guard (#2145)。
- #2143 は `.claude/rules/codegen-llvm-ir-conventions.md` の "Rust mirrors of C++ header structs need a cross-language parity guard" rule の適用。新規 test-only FFI extern (`ry_emit_test_icmp_pred_values`) + C++ 側 `static_assert` + runtime parity TEST の二段構え (precedent: `tests/test_header_layout.cpp`)。
- production codegen には触れない (test-only / FFI-introspection-only)。

## Test plan

- [x] `./build-rust/ry_tests` 全 2713 件 PASS (新規 9 件含む)
- [x] `./build-rust/ry test -p` 205 test files, 0 failures
- [x] ASan + TSan PASS
- [x] clang-tidy + cppcheck + scan-build (No bugs found)
- [x] `cargo clippy -p emit -- -D warnings` + `cargo fmt --check` PASS
- [x] `scripts/check-emit-abi-no-ir.sh` PASS (新 extern は pure data, IR emit せず)
- [x] #2143 teeth check: Rust 側 `RY_ICMP_SLE=99` で runtime test FAIL を確認、C++ 側 `RY_ICMP_SLE=99` で `static_assert` compile error を確認、両方 revert 後 再 PASS

Closes #2142
Closes #2143
Closes #2144
Closes #2145