### PR TITLE
perf(emit): intern dedup / SmallVector / variadic coverage (#2147)

### DIFF
--- a/crates/emit/src/abi.rs
+++ b/crates/emit/src/abi.rs
@@ -553,8 +553,13 @@ pub(crate) unsafe fn intern(c: &mut EmitCtx, value: RyValueRef) -> RyValueId {
     if value.is_null() {
         return 0;
     }
+    let v = as_value(value);
+    if let Some(&id) = c.value_id_cache.get(&v) {
+        return id;
+    }
     let id = c.values.len() as RyValueId;
-    c.values.push(as_value(value));
+    c.values.push(v);
+    c.value_id_cache.insert(v, id);
     id
 }
 

--- a/crates/emit/src/context.rs
+++ b/crates/emit/src/context.rs
@@ -29,6 +29,13 @@ pub(crate) struct EmitCtx {
     pub(crate) builder: LLVMBuilderRef,
     pub(crate) context: LLVMContextRef,
     pub(crate) values: Vec<LLVMValueRef>,
+    // Dedup cache for ry_emit_intern: maps a previously interned value pointer
+    // to its assigned id so the same LLVMValueRef does not grow `values` per
+    // call (#2147). Raw pointers are Eq + Hash by address, and EmitCtx is
+    // single-threaded. The id type mirrors `abi::RyValueId = u32` (named in
+    // u32 here because `context` sits below `abi` per the layering invariant
+    // documented at the top of this file).
+    pub(crate) value_id_cache: HashMap<LLVMValueRef, u32>,
     // Dedup cache for ry_emit_bounds_error / any-error fmt-string globals
     // (keyed by message bytes).
     pub(crate) bounds_msg_cache: HashMap<Vec<u8>, LLVMValueRef>,
@@ -55,6 +62,7 @@ impl EmitCtx {
             builder,
             context,
             values: vec![std::ptr::null_mut()],
+            value_id_cache: HashMap::new(),
             bounds_msg_cache: HashMap::new(),
             arc_msg_cache: HashMap::new(),
         }

--- a/include/ry/llvm_emit/api.h
+++ b/include/ry/llvm_emit/api.h
@@ -202,9 +202,10 @@ RyEmitCtx *ry_emit_ctx_create(RyModuleRef module, RyBuilderRef builder,
                               RyContextRef context);
 void ry_emit_ctx_destroy(RyEmitCtx *ctx);
 
-// Handle marshalling. ry_emit_intern returns 0 if `value` is NULL; every
-// other value gets a fresh handle. ry_emit_resolve returns NULL for handle 0
-// and for any out-of-range handle.
+// Handle marshalling. ry_emit_intern returns 0 if `value` is NULL; a non-NULL
+// value gets a stable handle — interning the same value pointer twice returns
+// the same id (#2147). ry_emit_resolve returns NULL for handle 0 and for any
+// out-of-range handle.
 RyValueId ry_emit_intern(RyEmitCtx *ctx, RyValueRef value);
 RyValueRef ry_emit_resolve(RyEmitCtx *ctx, RyValueId id);
 

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -420,12 +420,13 @@ llvm::Value *CodeGen::emitRuntimeCallDirect(const char *name, llvm::Type *ret_ty
     // source"). IR-neutral: never fires for the in-tree callers.
     if (arg_tys.size() != args.size())
         codegenError("emitRuntimeCallDirect: arg type/value arity mismatch");
-    std::vector<RyTypeRef> arg_ty_refs;
-    arg_ty_refs.reserve(arg_tys.size());
+    // Inline cap of 5 covers every in-tree call site (max arity: __ry_ht_find_*
+    // and __ry_str_find_byte at 5 args), so the boundary trip allocates zero
+    // heap (#2147).
+    llvm::SmallVector<RyTypeRef, 5> arg_ty_refs;
     for (auto *t : arg_tys)
         arg_ty_refs.push_back(ry::llvm_emit::asRyType(t));
-    std::vector<RyValueId> arg_ids;
-    arg_ids.reserve(args.size());
+    llvm::SmallVector<RyValueId, 5> arg_ids;
     for (auto *v : args)
         arg_ids.push_back(ry_emit_intern(emit_ctx_, ry::llvm_emit::asRyValue(v)));
     RyValueId resultId = ry_emit_runtime_call(

--- a/tests/spec/collections.test.ry
+++ b/tests/spec/collections.test.ry
@@ -200,6 +200,29 @@ fn listTests():
     expect(max(3, 1, 5)).toEq(5)
     expect(min(1.5, 2.5)).toEq(1.5)
     expect(max(1.5, 2.5)).toEq(2.5)
+  @it("should sum variadic non-constant scalars")
+  fn shouldSumVariadicNonConst():
+    x = 3
+    y = 5
+    z = 7
+    expect(sum(x, y)).toEq(8)
+    expect(sum(x, y, z)).toEq(15)
+    a = 1.0
+    b = 2.0
+    c = 3.0
+    expect(sum(a, b, c)).toEq(6.0)
+  @it("should find min and max of variadic non-constant scalars")
+  fn shouldFindMinMaxVariadicNonConst():
+    p = 3
+    q = 5
+    r = 1
+    expect(min(p, q)).toEq(3)
+    expect(min(p, q, r)).toEq(1)
+    expect(max(p, r, q)).toEq(5)
+    f = 1.5
+    g = 2.5
+    expect(min(f, g)).toEq(1.5)
+    expect(max(f, g)).toEq(2.5)
   @it("should return first element")
   fn shouldReturnFirstElement():
     expect(first([10, 20, 30])).toEq(Some(10))

--- a/tests/test_emit_abi_guards.cpp
+++ b/tests/test_emit_abi_guards.cpp
@@ -105,6 +105,36 @@ TEST_F(EmitAbiGuardTest, ResultBranchNullCtxReturnsZero) {
               0u);
 }
 
+// --- #2147 — intern dedup: same value pointer → same handle.
+//     Pre-fix the second intern of the same value got a fresh id; post-fix
+//     the lookup returns the existing handle (memory: EmitCtx::values stops
+//     growing per call when the same LLVMValueRef is reused). Caller-visible
+//     contract: stable handle per pointer, NOT fresh per call. ---
+
+TEST_F(EmitAbiGuardTest, InternSameValueReturnsSameId) {
+    RyEmitCtx *ctx = makeCtx();
+    ASSERT_NE(ctx, nullptr);
+    llvm::Value *v = llvm::ConstantInt::get(llvm::Type::getInt64Ty(llctx_), 42);
+    RyValueId id1 = ry_emit_intern(ctx, asRyValue(v));
+    RyValueId id2 = ry_emit_intern(ctx, asRyValue(v));
+    EXPECT_NE(id1, 0u);
+    EXPECT_EQ(id1, id2);
+    ry_emit_ctx_destroy(ctx);
+}
+
+TEST_F(EmitAbiGuardTest, InternDistinctValuesReturnDistinctIds) {
+    RyEmitCtx *ctx = makeCtx();
+    ASSERT_NE(ctx, nullptr);
+    llvm::Value *v1 = llvm::ConstantInt::get(llvm::Type::getInt64Ty(llctx_), 1);
+    llvm::Value *v2 = llvm::ConstantInt::get(llvm::Type::getInt64Ty(llctx_), 2);
+    RyValueId id1 = ry_emit_intern(ctx, asRyValue(v1));
+    RyValueId id2 = ry_emit_intern(ctx, asRyValue(v2));
+    EXPECT_NE(id1, 0u);
+    EXPECT_NE(id2, 0u);
+    EXPECT_NE(id1, id2);
+    ry_emit_ctx_destroy(ctx);
+}
+
 // --- result_branch with NULL callbacks → sentinel 0 (Critical: replaces the
 //     former unwrap()-panic across the extern "C" boundary) ---
 


### PR DESCRIPTION
## Summary

事後レビュー nit 3 件を #2147 にまとめて対応。3 項目すべて生成 IR は不変、IR-byte-identical を probe 経由で確認済。

- `test(spec)`: variadic `sum`/`min`/`max` の non-constant 引数 test を追加 — literal 引数だと `LLVMBuild{Add,FAdd,ICmp,Select}` が ConstantExpr に畳まれて `reduce_{sum,minmax}_step` の emit パスが exercise されない (#2092 coverage trap)。`x = 3; y = 5; expect(sum(x, y)).toEq(8)` 形で local binding 経由に。
- `fix(emit)`: `EmitCtx::values` の intern に `HashMap<LLVMValueRef, u32>` で dedup — 同一 `LLVMValueRef` を複数回 intern しても vec が伸びない。caller 全 grep で `RyValueId` の `==`/`!=` 比較がないことを確認し、api.h:205 の contract を "fresh handle per call" → "stable handle per pointer" に更新。
- `perf(codegen)`: `emitRuntimeCallDirect` の `std::vector<RyTypeRef>` / `std::vector<RyValueId>` を `llvm::SmallVector<_, 5>` に置換 — 全 in-tree call sites の最大 arity 5 で inline storage 完結、heap allocation 削除。

## Test plan

- [x] `./build-rust/ry_tests` — 2715 tests passed
- [x] `./build-rust/ry test -p` — 205 spec files, 0 failures
- [x] `tests/test_emit_abi_guards.cpp` の `InternSameValue*` / `InternDistinctValues*` で Red → Green
- [x] `tests/spec/collections.test.ry` の `shouldSumVariadicNonConst` / `shouldFindMinMaxVariadicNonConst` で `sum_v` / `mm_cmp` / `mm_best` marker が IR に出ることを確認
- [x] IR-byte-identical: 文字列 concat probe で pre-dedup vs post-dedup の `--emit-llvm-ir` (ASLR ARC counter 正規化後) diff 空
- [x] IR-byte-identical: 同 probe で pre-SmallVector vs post-SmallVector の diff 空
- [x] `run-rust-lint.sh` / `run-static-analysis-all.sh` / `run-asan.sh` / `run-tsan.sh` 全て green

Closes #2147