### PR TITLE
chore(skills): require manual git workflow invocation

### DIFF
--- a/.claude/skills/ci-image-workflow/SKILL.md
+++ b/.claude/skills/ci-image-workflow/SKILL.md
@@ -103,10 +103,11 @@ tab — point it at the branch ref.
    share the same major version pinning.
 2. Update the default in `build-ci-image.yml`
    (`inputs.llvm_version.default`).
-3. Open a PR with the Dockerfile changes. CI will fail because the
-   `:llvm-<MAJOR>` tag does not yet have the new version — that is
+3. PR creation is outside this skill. Do not create, propose, or include
+   PR creation in a plan. Once a PR already exists, its CI will fail because
+   the `:llvm-<MAJOR>` tag does not yet have the new version — that is
    expected.
-4. **Before merging**, manually trigger `Build CI Image` workflow on
+4. **Before merging an existing PR**, manually trigger `Build CI Image` workflow on
    the feature branch (Actions → Build CI Image → Run workflow → pick
    branch). Wait for it (60-90 minutes for both arches × both images).
 5. Verify the new tag is visible:
@@ -186,8 +187,8 @@ have different reproducibility constraints — see
 
 2. Compare the output with the literal in `release.yml`'s `container:`
    line (currently around L32, the `format(...)` argument). If
-   different, open a PR that updates only this line. Use a
-   `chore/<issue>-bump-release-image-rev` branch.
+   different, update only this line. PR creation is outside this skill;
+   do not create, propose, or include it in a plan.
 
 3. Do **not** auto-update from a workflow run. Even though
    `build-ci-image.yml` knows the new rev, the value must be a literal

--- a/.claude/skills/git-create-pr/SKILL.md
+++ b/.claude/skills/git-create-pr/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: git-create-pr
-description: Open a PR to main from the current feature branch. Delegates to /git-push first if there are uncommitted or unpushed changes, or when on main (in which case /git-push auto-creates the feature branch per its Step 0). PRs are opened (not draft).
+description: User-invoked slash command that opens a PR to main from a clean, pushed feature branch. Never invoke autonomously, from another skill, or merely because implementation is complete.
 allowed-tools: Bash(git status:*), Bash(gh pr create:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Bash(git rev-parse:*), Read
 metadata:
   short-description: Open a PR
 ---
 
 # Git Create PR
+
+## Invocation Gate
+
+- Run only when the user directly invokes `/git-create-pr`.
+- Never invoke this skill autonomously or from another skill.
+- Never propose this skill, present it as an option, include it in a plan, or list it as a next step.
 
 ## Context
 
@@ -16,16 +22,15 @@ metadata:
 
 ## Steps
 
-### 1. Sync if needed
+### 1. Verify prerequisites
 
-- Invoke `/git-push` first when **any** of the following is true:
+- Stop and report the unmet prerequisite when any of the following is true:
   - Working tree has uncommitted changes (status non-empty)
   - There are local commits not yet on the remote
   - The branch has no upstream
-  - Currently on `main` (`/git-push` Step 0 auto-creates a feature branch from main; AGENTS.md forbids PRs originating from main)
-- After `/git-push` finishes, the current branch will be a feature branch with everything pushed; continue to Step 2.
-- If none of the above apply (already on a clean, up-to-date feature branch), skip to Step 2.
-- **Edge case**: if on `main` with a clean working tree and no unpushed work, STOP and tell the user there is nothing to PR.
+  - Currently on `main`
+- Do not invoke or suggest `/git-push`.
+- Continue only on a clean, up-to-date feature branch.
 
 ### 2. Open PR
 

--- a/.claude/skills/git-finalize-pr/SKILL.md
+++ b/.claude/skills/git-finalize-pr/SKILL.md
@@ -1,20 +1,26 @@
 ---
 name: git-finalize-pr
-description: PR finalization in one pass — addresses review comments, follows up unresolved threads, verifies CI, runs pre-commit checklist, pushes, and merges. Stops at the first blocker; never auto-loops fix→push→CI-wait. Use when the user wants to finalize a PR, "PR を仕上げる", "マージまで一気に", "指摘対応してマージ", "レビュー対応からマージまで", "finalize PR <number>".
-allowed-tools: Bash(gh:*), Bash(git:*), Read, Edit
+description: User-invoked slash command that finalizes an already-pushed PR by addressing review comments, verifying CI, running pre-commit checks, merging, and cleaning up. Never invoke autonomously, from another skill, or merely because a PR is ready.
+allowed-tools: Bash(gh:*), Bash(git branch:*), Read, Edit
 metadata:
-  short-description: Review → CI → push → merge in one pass
+  short-description: Review → CI → merge in one pass
 ---
 
 # Git Finalize PR
 
-Take a pull request end-to-end: address review comments, follow up unresolved threads, verify CI, run the pre-commit checklist, push, and merge.
+## Invocation Gate
+
+- Run only when the user directly invokes `/git-finalize-pr`.
+- Never invoke this skill autonomously or from another skill.
+- Never propose this skill, present it as an option, include it in a plan, or list it as a next step.
+
+Finalize an already-pushed pull request: address review comments, follow up unresolved threads, verify CI, run the pre-commit checklist, and merge.
 
 ## One-pass policy
 
 This skill runs straight through. On any blocker it reports and stops — fix → push → CI wait → re-fix loops are never started automatically. Invoking this skill is the merge consent; no additional "merge しますか？" prompt is shown.
 
-Priority order: (1) CI failures are caught first (Step 2) and stop the flow immediately so investigation takes precedence; (2) review comments are addressed next (Step 3); (3) CI completion is verified strictly at the merge gate (Step 6). Step 1 is a structural-only pre-check that stops on conflicts; transient states like `BLOCKED` (CI pending) warn and proceed so Step 2 and Step 3 run in parallel with CI. When Step 3 produces review-fix commits, Step 5 pushes them and triggers fresh CI runs, so Step 6 will typically stop on `mergeStateStatus ∉ {CLEAN, HAS_HOOKS}` until those checks complete. Rerun once CI is green.
+Priority order: (1) CI failures are caught first (Step 2) and stop the flow immediately so investigation takes precedence; (2) review comments are addressed next (Step 3); (3) CI completion is verified strictly at the merge gate (Step 6). Step 1 is a structural-only pre-check that stops on conflicts; transient states like `BLOCKED` (CI pending) warn and proceed so Step 2 and Step 3 run in parallel with CI. When Step 3 produces changes that require publication, Step 5 stops before the merge gate.
 
 ## Repository
 
@@ -89,15 +95,13 @@ Invoke `/pre-commit-checklist`. If it reports outstanding items, stop:
 
 > Pre-commit checklist reported outstanding items (above). Address them, then rerun.
 
-### Step 5: Push
+### Step 5: Verify branch publication
 
-Invoke `/git-push`. It commits any working-tree changes left by Step 3, rebases onto `origin/main`, and pushes with `--force-with-lease`. On any failure (rebase conflict, lease rejection, etc.) it stops with its own report — surface that message and stop:
-
-> Push failed. Resolve the issue as reported above, then rerun.
+If Step 3 left working-tree changes or local commits that are not on the remote, stop and report that the PR cannot be finalized until the branch is clean and up to date. Do not invoke or suggest `/git-push`.
 
 ### Step 6: Merge
 
-Re-verify status (push triggered fresh CI):
+Re-verify status:
 
 ```bash
 gh pr view <PR> --json state,mergeable,mergeStateStatus

--- a/.claude/skills/git-push/SKILL.md
+++ b/.claude/skills/git-push/SKILL.md
@@ -1,12 +1,18 @@
 ---
 name: git-push
-description: Ensure feature branch (auto-create from main if needed), commit, rebase onto main, and push. Use when starting work on a new feature/fix/task, or when you have local commits or working-tree changes to publish. Auto-creates a feature branch when invoked on main.
+description: User-invoked slash command that ensures a feature branch, commits, rebases onto main, and pushes. Never invoke autonomously, from another skill, or merely because changes are ready to publish.
 allowed-tools: Bash(git add:*), Bash(git status:*), Bash(git push:*), Bash(git commit:*), Bash(git fetch:*), Bash(git rebase:*), Bash(git diff:*), Bash(git branch:*), Bash(git log:*), Bash(git checkout -b:*), Bash(git rev-parse:*), Read, Edit
 metadata:
   short-description: Branch, commit and push
 ---
 
 # Git Push
+
+## Invocation Gate
+
+- Run only when the user directly invokes `/git-push`.
+- Never invoke this skill autonomously or from another skill.
+- Never propose this skill, present it as an option, include it in a plan, or list it as a next step.
 
 ## Context
 

--- a/.claude/skills/pre-commit-checklist/SKILL.md
+++ b/.claude/skills/pre-commit-checklist/SKILL.md
@@ -72,4 +72,4 @@ Use `/knowledge-md-management` when no destination exists.
 
 - Confirm no background or detached process was started.
 - Do not change labels during self-verification.
-- `/git-finalize-pr` handles post-merge `wip` cleanup.
+- Post-merge `wip` cleanup occurs only during a user-invoked `/git-finalize-pr`.

--- a/.claude/skills/preparing-for-release/SKILL.md
+++ b/.claude/skills/preparing-for-release/SKILL.md
@@ -71,7 +71,7 @@ gh issue create \
   --body "$(cat <<'EOF'
 ## Goal
 
-Aggregate `changelog.d/` fragments into `CHANGELOG.md` and finalize the `[<X.Y.Z>] - YYYY-MM-DD` section so the release tag can be cut. Standard issue-driven flow (`scripts/claim-issue.sh '#<P>'` → branch → PR → `git-finalize-pr`); the release tag itself is out of scope (sibling Release issue).
+Aggregate `changelog.d/` fragments into `CHANGELOG.md` and finalize the `[<X.Y.Z>] - YYYY-MM-DD` section so the release tag can be cut. Follow the standard issue implementation flow through self-verification. Git publication and PR creation are outside the implementation plan; the release tag itself is out of scope (sibling Release issue).
 
 ## Tasks
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,7 @@ cmake --build <build-dir>
   - New features: run Red-Green-Refactor for each test case.
 - When using a plan:
   - Cover implementation through self-verification only.
+  - Never include `/git-push`, `/git-create-pr`, or `/git-finalize-pr`.
   - State outcomes, not implementation details.
   - Include matching rules / skills, documentation decision, and verification.
   - Keep each Red-Green-Refactor cycle in one task.
@@ -108,8 +109,11 @@ cmake --build <build-dir>
 - After rebase, push with `--force-with-lease`; do not fetch again before that push.
 - Feature branch creation, commit, rebase, and push: `/git-push`.
 - PR creation: `/git-create-pr`.
+- `/git-push`, `/git-create-pr`, and `/git-finalize-pr` run only when the user directly invokes that exact slash command.
+- Never invoke these skills autonomously or from another skill.
+- Never propose these skills, present them as options, include them in a plan, or list them as next steps.
 - Conflict resolution: `/git-resolve-conflicts`.
-- Final review, CI, verification, push, merge, and `wip` cleanup: `/git-finalize-pr`.
+- Final review, CI, verification, merge, and `wip` cleanup for an already-pushed branch: `/git-finalize-pr`.
 - Before merge, stop and report any uncommitted or untracked files.
 - Commit `.serena/` changes with the related work.
 
@@ -142,4 +146,4 @@ Issue creation:
 ## Completion
 
 - Run `/pre-commit-checklist` before declaring work complete.
-- Do not change labels during self-verification; `/git-finalize-pr` handles post-merge cleanup.
+- Do not change labels during self-verification; post-merge cleanup occurs only during a user-invoked `/git-finalize-pr`.


### PR DESCRIPTION
## Summary
- restrict git-push, git-create-pr, and git-finalize-pr to direct slash-command invocation
- prohibit proposing or including these workflows in plans and next steps
- remove implicit push and PR creation paths from related skills

## Verification
- ./.claude/skills/pre-commit-checklist/run-prompt-refs-lint.sh
- git diff --check