### PR TITLE
fix(filesystem): align macOS copy(dir) with Linux

### DIFF
--- a/changelog.d/2164-filesystem-copy-macos-align.md
+++ b/changelog.d/2164-filesystem-copy-macos-align.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- `copy(src, dst)` now returns `Err` on macOS when the source is a directory or other non-regular file, matching the Linux behavior. Previously the macOS path called `copyfile(... COPYFILE_ALL)` without a pre-check, which silently created an empty destination directory and returned `Ok` for a directory source — a latent data-loss risk if the caller subsequently removed the source. Symbolic links continue to be followed and are accepted when their target is a regular file. (#2164)

--- a/docs/reference/filesystem.md
+++ b/docs/reference/filesystem.md
@@ -163,6 +163,6 @@ chmod("/tmp/data.txt", 420)
 - `isFile` and `isDir` follow symlinks; `isSymlink` uses `lstat` to detect links
 - `listDir` returns entry names only (not full paths)
 - `walk` returns full paths for all entries (both files and directories); returns `Err` when the path is not a directory
-- `copy` is intended for file copies. On Linux, `copy` returns `Err` when the source is a directory or other non-regular file; on macOS, `copyfile(3)` may succeed on directories with no recursion (avoid relying on this for portability). Unlike `cp -r`, `copy` does not recurse into directories — use `walk` + per-file `copy` for tree copies.
+- `copy` is intended for file copies. `copy` returns `Err` when the source is a directory or other non-regular file. Symbolic links are followed (the link target is copied). Unlike `cp -r`, `copy` does not recurse into directories — use `walk` + per-file `copy` for tree copies.
 - `glob` returns an empty list (not an error) when no files match the pattern
 - `remove` fails on non-empty directories; use `removeAll` for recursive deletion

--- a/src/runtime/native/filesystem.cpp
+++ b/src/runtime/native/filesystem.cpp
@@ -182,6 +182,23 @@ int64_t __ry_filesystem_copy(const char *src, const char *dst) {
         return 1;
     }
 #ifdef __APPLE__
+    // stat() follows symlinks to match the Linux path's open()+fstat() semantics
+    // (which omits O_NOFOLLOW). copyfile() also follows symlinks by default, so
+    // both calls observe the same target.
+    //
+    // TOCTOU caveat: there is a small window between stat() and copyfile()
+    // where the source could be replaced. The Linux path closes this gap via
+    // an fd-based fstat(); reproducing that on macOS would require switching
+    // to fcopyfile() and is out of scope for this guard.
+    struct stat src_st;
+    if (stat(src, &src_st) != 0) {
+        setLastError("copy: cannot stat source '%s': %s", src, strerror(errno));
+        return 1;
+    }
+    if (!S_ISREG(src_st.st_mode)) {
+        setLastError("copy: source '%s' is not a regular file", src);
+        return 1;
+    }
     if (copyfile(src, dst, nullptr, COPYFILE_ALL) != 0) {
         setLastError("copy: failed to copy '%s' to '%s': %s", src, dst, strerror(errno));
         return 1;

--- a/tests/spec/filesystem.test.ry
+++ b/tests/spec/filesystem.test.ry
@@ -197,6 +197,56 @@ fn copyTests():
     result = copy("/tmp/ry_fs_test_nosrc.txt", "/tmp/ry_fs_test_nodst.txt")
     expect(result).toBeErr()
 
+  @it("should reject copying a directory")
+  fn shouldRejectCopyingADirectory():
+    srcDir = "/tmp/ry_fs_test/copy_dir_src"
+    dst = "/tmp/ry_fs_test/copy_dir_dst"
+    removeAll(srcDir)
+    removeAll(dst)
+    mkdirAll(srcDir)
+    result = copy(srcDir, dst)
+    expect(result).toBeErr()
+    case isDir(dst):
+      Ok(v): expect(v).toBeFalse()
+      Err(e): fail("isDir failed: " + e.message)
+
+  @it("should reject copying a symlink to a directory")
+  fn shouldRejectCopyingASymlinkToADirectory():
+    targetDir = "/tmp/ry_fs_test/copy_symdir_target"
+    link = "/tmp/ry_fs_test/copy_symdir_link"
+    dst = "/tmp/ry_fs_test/copy_symdir_dst"
+    removeAll(targetDir)
+    removeAll(link)
+    removeAll(dst)
+    mkdirAll(targetDir)
+    case symlink(targetDir, link):
+      Ok(_): 0
+      Err(e): fail("symlink setup failed: " + e.message)
+    result = copy(link, dst)
+    expect(result).toBeErr()
+
+  @it("should follow a symlink to a regular file")
+  fn shouldFollowASymlinkToARegularFile():
+    target = "/tmp/ry_fs_test/copy_symfile_target.txt"
+    link = "/tmp/ry_fs_test/copy_symfile_link.txt"
+    dst = "/tmp/ry_fs_test/copy_symfile_dst.txt"
+    mkdirAll("/tmp/ry_fs_test")
+    writeText(target, "via symlink")
+    removeAll(link)
+    removeAll(dst)
+    case symlink(target, link):
+      Ok(_): 0
+      Err(e): fail("symlink setup failed: " + e.message)
+    case copy(link, dst):
+      Ok(_):
+        case readText(dst):
+          Ok(content):
+            expect(content).toEq("via symlink")
+          Err(e):
+            fail("readText failed: " + e.message)
+      Err(e):
+        fail("copy via symlink failed: " + e.message)
+
 @describe("move")
 fn moveTests():
   @it("should move a file")


### PR DESCRIPTION
## Summary

- macOS の `__ry_filesystem_copy` に `stat()` + `S_ISREG` ガードを追加し、directory / 非 regular file source を `Err` で reject(Linux と同じエラーメッセージ)。従来は `copyfile(... COPYFILE_ALL)` が dir source で空 dst dir を作って `Ok` を返す latent data-loss 経路だった
- 両 OS で同一挙動を assert する spec test 3 件追加 (dir→Err / symlink→dir→Err / symlink→regfile→Ok)。`stat` vs `lstat` の判別テストも含む
- `docs/reference/filesystem.md` Notes の OS 差記述を「両 OS で Err」に統一 (PR #2163 の暫定記述を簡素化)

## Test plan

- [x] macOS (`./build-rust/ry test tests/spec/filesystem.test.ry`): fix 適用前に dir / symlink→dir テストが red であることを確認 → fix 後 26/26 green
- [x] 手動 repro (issue 記載 snippet) で `Err` 返却 + dst 未作成を確認
- [x] `./build-rust/ry test -p`: 205 files, 0 failures
- [x] `./build-rust/ry_tests`: 2714 tests, all passed
- [x] `/pre-commit-checklist`: tests / ASan+UBSan / TSan / 静的解析 (clang-tidy + cppcheck + scan-build "No bugs found") すべて green

## Scope (deferred)

- 完全な TOCTOU 解消 (`fcopyfile()` への切替) — caveat コメントで明記
- `move(dir, _)` 同様の divergence と macOS の same-file inode guard 非対応 — 別 issue 候補 (本 PR では触らない)

Closes #2164