### PR TITLE
chore(build): clean up 4 accumulated compiler warnings

### DIFF
--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -806,8 +806,7 @@ public:
                           const std::string &fieldTypeName,
                           llvm::Value *visitorFn,
                           llvm::FunctionType *visitorCallTy,
-                          llvm::FunctionType *visitFnTy,
-                          llvm::Function *parentFn);
+                          llvm::FunctionType *visitFnTy);
 
     struct GenericEnumTemplate {
         std::string name;

--- a/src/codegen_arc_gc.cpp
+++ b/src/codegen_arc_gc.cpp
@@ -183,8 +183,7 @@ void CodeGen::emitGcVisitField(llvm::Value *fieldPtr, llvm::Type *fieldTy,
                                 const std::string &fieldTypeName,
                                 llvm::Value *visitorFn,
                                 llvm::FunctionType *visitorCallTy,
-                                llvm::FunctionType *visitFnTy,
-                                llvm::Function *parentFn) {
+                                llvm::FunctionType *visitFnTy) {
     if (fieldTy == ptrTy_) {
         auto *fieldVal = builder_.CreateLoad(ptrTy_, fieldPtr, "gc.visit.val");
         auto *isNull = builder_.CreateICmpEQ(
@@ -241,7 +240,7 @@ llvm::Function *CodeGen::createRecordVisitFunction(const std::string &typeName,
         auto *fieldPtr = builder_.CreateStructGEP(info.llvmType, dataPtr, i,
                                                    "gc.record.field." + std::to_string(i));
         emitGcVisitField(fieldPtr, fieldTy, fieldTypeName,
-                         visitorFnArg, visitorCallTy, visitFnTy, visitFn);
+                         visitorFnArg, visitorCallTy, visitFnTy);
     }
 
     builder_.CreateRetVoid();
@@ -334,7 +333,7 @@ llvm::Function *CodeGen::createAdtVisitFunction(const std::string &typeName,
                     llvm::ConstantInt::get(i64Ty_, offset),
                     "gc.field." + std::to_string(fi));
                 emitGcVisitField(fieldPtr, fieldTy, fieldTypeName,
-                                 visitorFn, visitorCallTy, visitFnTy, visitFn);
+                                 visitorFn, visitorCallTy, visitFnTy);
             }
 
             offset += dl.getTypeAllocSize(fieldTy);

--- a/src/codegen_call_user.cpp
+++ b/src/codegen_call_user.cpp
@@ -792,7 +792,7 @@ void CodeGen::emitIntZeroDivGuard(llvm::Value *divisor, const std::string &bbPre
 
 void CodeGen::emitIntDivOverflowGuard(llvm::Value *dividend, llvm::Value *divisor,
                                        const std::string &bbPrefix) {
-    llvm::Value *minusOne = llvm::ConstantInt::get(divisor->getType(), -1, true);
+    llvm::Value *minusOne = llvm::ConstantInt::getSigned(divisor->getType(), -1);
     llvm::Value *intMin = llvm::ConstantInt::get(
         dividend->getType(), llvm::APInt::getSignedMinValue(64));
     llvm::Value *isMinusOne = builder_.CreateICmpEQ(divisor, minusOne, bbPrefix + "_div_m1");

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -3439,7 +3439,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
         if (actualTy != f64Ty_)
             codegenError("line " + std::to_string(s.loc.line) +
                                      ": toBeInfinity: expected float");
-        llvm::Function *fabsDecl = llvm::Intrinsic::getDeclaration(
+        llvm::Function *fabsDecl = llvm::Intrinsic::getOrInsertDeclaration(
             mod_.get(), llvm::Intrinsic::fabs, {f64Ty_});
         llvm::Value *absVal = builder_.CreateCall(fabsDecl, {actualVal}, "abs_val");
         llvm::Value *posInf = llvm::ConstantFP::getInfinity(f64Ty_);
@@ -3449,7 +3449,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
             codegenError("line " + std::to_string(s.loc.line) +
                                      ": toBeFinite: expected float");
         llvm::Value *isNaN = builder_.CreateFCmpUNO(actualVal, actualVal, "is_nan");
-        llvm::Function *fabsDecl = llvm::Intrinsic::getDeclaration(
+        llvm::Function *fabsDecl = llvm::Intrinsic::getOrInsertDeclaration(
             mod_.get(), llvm::Intrinsic::fabs, {f64Ty_});
         llvm::Value *absVal = builder_.CreateCall(fabsDecl, {actualVal}, "abs_val");
         llvm::Value *posInf = llvm::ConstantFP::getInfinity(f64Ty_);
@@ -3842,7 +3842,7 @@ void CodeGen::emitStmt(ExpectStmt &s) {
 
         auto [lf, rf] = promoteToFloat(actualVal, expectedVal);
         llvm::Value *diff = builder_.CreateFSub(lf, rf, "close_diff");
-        llvm::Function *fabsDecl = llvm::Intrinsic::getDeclaration(
+        llvm::Function *fabsDecl = llvm::Intrinsic::getOrInsertDeclaration(
             mod_.get(), llvm::Intrinsic::fabs, {f64Ty_});
         llvm::Value *absDiff = builder_.CreateCall(fabsDecl, {diff}, "close_abs");
         double thresholdVal = 0.5 * std::pow(10.0, -static_cast<double>(decimals));

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -143,7 +143,7 @@ llvm::Type *CodeGen::resolveType(const std::string &typeName) {
         // Parse element types from "(T1, T2, ...)"
         std::string inner = typeName.substr(1, typeName.size() - 2); // strip parens
         std::vector<llvm::Type*> elementTypes;
-        elementTypes.reserve(std::count(inner.begin(), inner.end(), ',') + 1);
+        elementTypes.reserve(static_cast<size_t>(std::count(inner.begin(), inner.end(), ',')) + 1);
         size_t depth = 0;
         size_t start = 0;
         for (size_t i = 0; i <= inner.size(); ++i) {


### PR DESCRIPTION
## Summary

- `Intrinsic::getDeclaration` → `getOrInsertDeclaration` (LLVM 21 deprecated, last 3 sites in `codegen_test.cpp`)
- `ConstantInt::get(ty, -1, true)` → `ConstantInt::getSigned(ty, -1)` in `codegen_call_user.cpp:795` (`-Wsign-conversion`)
- `static_cast<size_t>` on `std::count()` in `codegen_type.cpp:146` (`-Wsign-conversion`), placement matches existing convention
- Drop unused `parentFn` parameter from `emitGcVisitField` (`-Wunused-parameter`); `createBB` already derives parent from the builder

## Test plan

- [x] `cmake --build build-rust --clean-first 2>&1 | grep -E "warning:|error:"` → empty
- [x] `./build-rust/ry_tests` → 2716/2716 PASSED
- [x] `./build-rust/ry test -p` → 205 files, 0 failures
- [x] `run-static-analysis-all.sh` → No bugs found
- [x] `run-asan.sh` (ASan + UBSan) → 0 failures
- [x] `run-tsan.sh` → 0 failures
- [ ] Linux CI build log → 0 warning (verify after push)

Closes #2179

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected signed integer constant generation in overflow checks
  * Fixed intrinsic function declarations in test expectation matchers

* **Refactor**
  * Simplified garbage collection visitor API
  * Improved tuple type parsing with explicit type casting for better precision

<!-- end of auto-generated comment: release notes by coderabbit.ai -->