### PR TITLE
chore(tests): unify @it descriptions to should-form in v0.0.24 testing reference files

### DIFF
--- a/tests/spec/directive_lifecycle.test.ry
+++ b/tests/spec/directive_lifecycle.test.ry
@@ -27,17 +27,17 @@ fn lifecycleExecutionOrder():
     fn teardownAll():
         log = log + "AA;"
 
-    @it("first test sees BA + BE prefix")
+    @it("should see BA + BE prefix on first @it")
     fn first():
         # Before this test ran, BA fired once and BE fired once.
         expect(log).toEq("BA;BE;")
 
-    @it("second test sees afterEach + beforeEach repeating")
+    @it("should see afterEach + beforeEach repeating on second @it")
     fn second():
         # After first: "BA;BE;AE;". Then BE for self: "BA;BE;AE;BE;".
         expect(log).toEq("BA;BE;AE;BE;")
 
-    @it("third test confirms accumulation continues")
+    @it("should confirm hook accumulation continues on third @it")
     fn third():
         # Accumulated: "BA;BE;AE;BE;AE;BE;"
         expect(log).toEq("BA;BE;AE;BE;AE;BE;")
@@ -52,11 +52,11 @@ fn counterAccumulation():
     fn s():
         counter = counter + 1
 
-    @it("counter == 1 after first beforeEach")
+    @it("should reach counter == 1 after first beforeEach")
     fn t1():
         expect(counter).toEq(1)
 
-    @it("counter == 2 after second beforeEach (accumulated)")
+    @it("should reach counter == 2 after second beforeEach (accumulated)")
     fn t2():
         # In Jest each describe-body runs per-test and counter resets to 0;
         # in Ry it runs once, so counter accumulates. This is intentional —
@@ -73,7 +73,7 @@ fn describeScopeMutation():
     fn s():
         label = "ready"
 
-    @it("@it sees @beforeEach mutation via captured var")
+    @it("should observe @beforeEach mutation in @it via captured var")
     fn t():
         expect(label).toEq("ready")
 
@@ -92,12 +92,12 @@ fn beforeAllRunsOnce():
     fn each():
         counter = counter + 1
 
-    @it("first test: setupCount == 1, counter == 1")
+    @it("should see setupCount == 1 and counter == 1 on first @it")
     fn t1():
         expect(setupCount).toEq(1)
         expect(counter).toEq(1)
 
-    @it("second test: setupCount STILL == 1, counter == 2")
+    @it("should see setupCount STILL == 1 and counter == 2 on second @it")
     fn t2():
         expect(setupCount).toEq(1)
         expect(counter).toEq(2)
@@ -112,7 +112,7 @@ fn firstDescribeIsolated():
     fn s():
         visited = visited + 100
 
-    @it("visited == 100")
+    @it("should observe visited == 100")
     fn t():
         expect(visited).toEq(100)
 
@@ -125,7 +125,7 @@ fn secondDescribeIsolated():
     fn s():
         visited = visited + 7
 
-    @it("visited == 7 (not leaked from prior describe)")
+    @it("should observe visited == 7 (not leaked from prior describe)")
     fn t():
         expect(visited).toEq(7)
 
@@ -135,7 +135,7 @@ fn secondDescribeIsolated():
 fn hookPositionIndependent():
     setupRan = false
 
-    @it("@beforeAll runs before this @it even though declared after")
+    @it("should run @beforeAll before this @it even though declared after")
     fn t():
         expect(setupRan).toEq(true)
 
@@ -158,11 +158,11 @@ fn timeoutAfterEachNormal():
         counter = counter + 10
 
     @timeout(2000)
-    @it("fast test within timeout runs both hooks")
+    @it("should run both hooks for a fast test within timeout")
     fn fast():
         expect(counter > 0).toEq(true)
 
-    @it("second test sees prior afterEach cumulative effect")
+    @it("should see prior afterEach cumulative effect on second @it")
     fn second():
         # After fast: counter = 1 (BE) + 10 (AE). Then BE for self = 12.
         expect(counter).toEq(12)
@@ -179,15 +179,15 @@ fn arcStrBeforeEach():
         # per @it; if ARC retain/release is buggy we crash under ASan.
         greeting = "hello" + ", world"
 
-    @it("first test")
+    @it("should observe a fresh greeting on first @it (ARC str re-emit)")
     fn t1():
         expect(greeting).toEq("hello, world")
 
-    @it("second test")
+    @it("should observe a fresh greeting on second @it (ARC str re-emit)")
     fn t2():
         expect(greeting).toEq("hello, world")
 
-    @it("third test")
+    @it("should observe a fresh greeting on third @it (ARC str re-emit)")
     fn t3():
         expect(greeting).toEq("hello, world")
 
@@ -203,15 +203,15 @@ fn arcListBeforeEach():
         # `items` value must run cleanly each time.
         items = [1, 2, 3]
 
-    @it("first test")
+    @it("should observe a fresh list on first @it (ARC list re-emit)")
     fn t1():
         expect(len(items)).toEq(3)
 
-    @it("second test")
+    @it("should observe a fresh list on second @it (ARC list re-emit)")
     fn t2():
         expect(len(items)).toEq(3)
 
-    @it("third test")
+    @it("should observe a fresh list on third @it (ARC list re-emit)")
     fn t3():
         expect(len(items)).toEq(3)
 
@@ -219,7 +219,7 @@ fn arcListBeforeEach():
 # ─── describe without hooks still works (existing behaviour preserved) ───
 @describe("describe with no hooks")
 fn describeNoHooks():
-    @it("plain test still works")
+    @it("should run a plain test without hooks")
     fn t():
         expect(1 + 1).toEq(2)
 
@@ -233,14 +233,14 @@ fn afterEachAccumulation():
     fn ae():
         log = log + "AE;"
 
-    @it("first test: log empty")
+    @it("should see empty log on first @it (afterEach accumulation)")
     fn t1():
         expect(log).toEq("")
 
-    @it("second test: log shows prior afterEach")
+    @it("should see prior afterEach in log on second @it")
     fn t2():
         expect(log).toEq("AE;")
 
-    @it("third test: log shows two prior afterEach runs")
+    @it("should see two prior afterEach runs in log on third @it")
     fn t3():
         expect(log).toEq("AE;AE;")

--- a/tests/spec/directive_timeout.test.ry
+++ b/tests/spec/directive_timeout.test.ry
@@ -2,13 +2,13 @@ from testing import it, expect, describe, timeout
 
 # Happy path: a test that completes well within its timeout must pass.
 @timeout(1000)
-@it("completes within 1 second")
+@it("should complete within 1 second")
 fn completesWithinOneSecond():
   expect(1 + 1).toEq(2)
 
 # Larger timeout still works; non-trivial body must not consume budget.
 @timeout(60000)
-@it("completes within a generous timeout")
+@it("should complete within a generous timeout")
 fn completesWithinGenerousTimeout():
   total = 0
   for i in range(1, 11):
@@ -19,6 +19,6 @@ fn completesWithinGenerousTimeout():
 @describe("timeout in describe block")
 fn timeoutInDescribeBlock():
   @timeout(500)
-  @it("nested test completes quickly")
+  @it("should run a nested @it within its timeout")
   fn nestedTestCompletesQuickly():
     expect("hello").toEq("hello")

--- a/tests/spec/mock_overload.test.ry
+++ b/tests/spec/mock_overload.test.ry
@@ -15,14 +15,14 @@ fn nullary() -> int:
 
 @describe("mock overloaded fns - signature form")
 fn mockOverloadSigTests():
-  @it("mock with explicit signature dispatches by sig key")
+  @it("should dispatch by sig key when mock uses explicit signature")
   fn mockSigBasic():
     mock("addNum(int, int)", (x: int, y: int) => 999)
     expect(addNum(1, 2)).toEq(999)
     expect(addNum(1.0, 2.0)).toEq(3.0)  # float overload untouched
     mockResetAll()
 
-  @it("mock different overloads independently")
+  @it("should mock different overloads independently")
   fn mockSigIndependent():
     mock("addNum(int, int)", (x: int, y: int) => 11)
     mock("addNum(float, float)", (x: float, y: float) => 22.5)
@@ -30,14 +30,14 @@ fn mockOverloadSigTests():
     expect(addNum(1.0, 2.0)).toEq(22.5)
     mockResetAll()
 
-  @it("mock 3-arg overload by sig")
+  @it("should mock 3-arg overload by signature")
   fn mockSigArity():
     mock("addNum(int, int, int)", (x: int, y: int, z: int) => 100)
     expect(addNum(1, 2, 3)).toEq(100)
     expect(addNum(1, 2)).toEq(3)  # 2-arg untouched
     mockResetAll()
 
-  @it("mock nullary fn with empty paren sig")
+  @it("should mock nullary fn with empty paren signature")
   fn mockSigEmpty():
     mock("nullary()", () => 42)
     expect(nullary()).toEq(42)
@@ -45,7 +45,7 @@ fn mockOverloadSigTests():
 
 @describe("mock overloaded fns - aggregate verify")
 fn mockOverloadVerifyTests():
-  @it("verify(bare_name) sums calls across all overloads")
+  @it("should sum calls across all overloads via bare-name verify")
   fn verifyBareSum():
     spy("addNum(int, int)")
     spy("addNum(float, float)")
@@ -57,7 +57,7 @@ fn mockOverloadVerifyTests():
     expect(verify("addNum")).toEq(3)  # aggregate
     mockResetAll()
 
-  @it("bare spy spies all overloads")
+  @it("should spy all overloads via bare-name spy")
   fn bareSpyAll():
     spy("addNum")
     a = addNum(1, 2)
@@ -67,7 +67,7 @@ fn mockOverloadVerifyTests():
     expect(verify("addNum")).toEq(2)
     mockResetAll()
 
-  @it("mockClear(bare_name) clears all overloads")
+  @it("should clear all overloads via bare-name mockClear")
   fn bareMockClear():
     spy("addNum")
     a = addNum(1, 2)
@@ -79,7 +79,7 @@ fn mockOverloadVerifyTests():
 
 @describe("mock overloaded stdlib (@native customEmitter) fns")
 fn mockNativeCustomEmitterTests():
-  @it("mock math.digits(int) overrides 1-arg overload")
+  @it("should override 1-arg overload via mock for digits(int)")
   fn mockDigitsArity1():
     mock("digits(int)", (n: int) => [9, 9, 9])
     expect(digits(0)).toEq([9, 9, 9])
@@ -87,7 +87,7 @@ fn mockNativeCustomEmitterTests():
     expect(digits(255, 16)).toEq([15, 15])
     mockResetAll()
 
-  @it("mock math.digits(int, int) overrides 2-arg overload")
+  @it("should override 2-arg overload via mock for digits(int, int)")
   fn mockDigitsArity2():
     mock("digits(int, int)", (n: int, base: int) => [1, 2])
     expect(digits(255, 16)).toEq([1, 2])
@@ -95,14 +95,14 @@ fn mockNativeCustomEmitterTests():
     expect(digits(0)).toEq([0])
     mockResetAll()
 
-  @it("mock math.abs(int) overrides int overload only")
+  @it("should override int overload only via mock for abs(int)")
   fn mockAbsInt():
     mock("abs(int)", (x: int) => 42)
     expect(abs(-5)).toEq(42)
     expect(abs(-5.0)).toEq(5.0)  # float overload untouched
     mockResetAll()
 
-  @it("spy(bare_name) on stdlib counts both overloads")
+  @it("should count both overloads via bare-name spy on stdlib")
   fn spyDigitsBare():
     spy("digits")
     a = digits(0)
@@ -115,7 +115,7 @@ fn mockNativeCustomEmitterTests():
 
 @describe("mock overloaded stdlib (@native normal-path) fns")
 fn mockNativeNormalPathTests():
-  @it("mock math.pow(int, int) overrides int overload via normal path")
+  @it("should override int overload via normal-path mock for pow(int, int)")
   fn mockPowInt():
     mock("pow(int, int)", (x: int, y: int) => 100)
     expect(pow(2, 3)).toEq(100)

--- a/tests/spec/spy.test.ry
+++ b/tests/spec/spy.test.ry
@@ -40,14 +40,14 @@ fn tickAndReturn(x: int) -> int:
 
 @describe("spy")
 fn spyTests():
-  @it("records calls without replacing implementation")
+  @it("should record calls without replacing implementation")
   fn recordsWithoutReplacing():
     spy("computeReal")
     result: int = computeReal(5)
     expect(result).toEq(15)
     expect(verify("computeReal")).toEq(1)
 
-  @it("counts multiple calls")
+  @it("should count multiple calls")
   fn countsMultipleCalls():
     spy("computeReal")
     computeReal(1)
@@ -55,7 +55,7 @@ fn spyTests():
     computeReal(3)
     expect(verify("computeReal")).toEq(3)
 
-  @it("preserves side effects of the real implementation")
+  @it("should preserve side effects of the real implementation")
   fn preservesSideEffects():
     sideEffectCount[0] = 0
     spy("tickAndReturn")
@@ -66,11 +66,11 @@ fn spyTests():
     expect(sideEffectCount[0]).toEq(2)
     expect(verify("tickAndReturn")).toEq(2)
 
-  @it("returns 0 for a function that was never spied")
+  @it("should return 0 for a function that was never spied")
   fn unspiedReturnsZero():
     expect(verify("computeReal")).toEq(0)
 
-  @it("auto-restores after the it block")
+  @it("should auto-restore after the it block")
   fn autoRestoresAfterItBlock():
     # The previous it block populated sideEffectCount[0]; this fresh it
     # block must see a clean registry: verify returns 0 because the spy
@@ -79,7 +79,7 @@ fn spyTests():
 
 @describe("spy + verifyCalledWith")
 fn spyVerifyCalledWithTests():
-  @it("matches int argument")
+  @it("should match int argument")
   fn matchesIntArg():
     spy("computeReal")
     computeReal(7)
@@ -89,7 +89,7 @@ fn spyVerifyCalledWithTests():
     expect(verifyCalledWith("computeReal", 8)).toEq(1)
     expect(verifyCalledWith("computeReal", 999)).toEq(0)
 
-  @it("matches str argument")
+  @it("should match str argument")
   fn matchesStrArg():
     spy("greet")
     greet("alice")
@@ -98,7 +98,7 @@ fn spyVerifyCalledWithTests():
     expect(verifyCalledWith("greet", "alice")).toEq(2)
     expect(verifyCalledWith("greet", "bob")).toEq(1)
 
-  @it("matches bool argument")
+  @it("should match bool argument")
   fn matchesBoolArg():
     spy("flagToInt")
     flagToInt(true)
@@ -107,7 +107,7 @@ fn spyVerifyCalledWithTests():
     expect(verifyCalledWith("flagToInt", true)).toEq(2)
     expect(verifyCalledWith("flagToInt", false)).toEq(1)
 
-  @it("matches float argument")
+  @it("should match float argument")
   fn matchesFloatArg():
     spy("floatDouble")
     floatDouble(1.5)
@@ -116,7 +116,7 @@ fn spyVerifyCalledWithTests():
     expect(verifyCalledWith("floatDouble", 1.5)).toEq(2)
     expect(verifyCalledWith("floatDouble", 3.0)).toEq(1)
 
-  @it("matches List<int> argument")
+  @it("should match List<int> argument")
   fn matchesListIntArg():
     spy("sumList")
     sumList([1, 2, 3])
@@ -126,14 +126,14 @@ fn spyVerifyCalledWithTests():
     expect(verifyCalledWith("sumList", [4, 5])).toEq(1)
     expect(verifyCalledWith("sumList", [9, 9])).toEq(0)
 
-  @it("matches Set<str> argument")
+  @it("should match Set<str> argument")
   fn matchesSetStrArg():
     spy("countStrSet")
     countStrSet({"a", "b"})
     countStrSet({"b", "a"})
     expect(verifyCalledWith("countStrSet", {"a", "b"})).toEq(2)
 
-  @it("matches Map<str, int> argument")
+  @it("should match Map<str, int> argument")
   fn matchesMapStrIntArg():
     spy("sumMapValues")
     m1: Map<str, int> = {"a": 1, "b": 2}
@@ -144,7 +144,7 @@ fn spyVerifyCalledWithTests():
 
 @describe("spy interop with mock and mockClear/mockReset")
 fn spyMockInteropTests():
-  @it("does not leak across it blocks (mock from a sibling it)")
+  @it("should not leak across it blocks (mock from a sibling it)")
   fn spyAfterSiblingMock():
     # Without registry isolation between it blocks, a previous mock("computeReal", ...)
     # could remain and replace the implementation under spy. The runtime auto-clears
@@ -153,7 +153,7 @@ fn spyMockInteropTests():
     expect(computeReal(4)).toEq(12)
     expect(verify("computeReal")).toEq(1)
 
-  @it("mockClear zeroes the spy call count")
+  @it("should zero the spy call count after mockClear")
   fn mockClearResetsSpyCount():
     spy("computeReal")
     computeReal(1)
@@ -164,7 +164,7 @@ fn spyMockInteropTests():
     computeReal(3)
     expect(verify("computeReal")).toEq(1)
 
-  @it("mockReset removes the spy registration entirely")
+  @it("should remove the spy registration entirely after mockReset")
   fn mockResetRemovesSpyRegistration():
     spy("computeReal")
     computeReal(5)
@@ -176,7 +176,7 @@ fn spyMockInteropTests():
     expect(computeReal(2)).toEq(6)
     expect(verify("computeReal")).toEq(0)
 
-  @it("mock takes precedence when mock and spy coexist in the same block")
+  @it("should prefer mock over spy when both coexist in the same block")
   fn mockTakesPrecedence():
     # When both mock() and spy() target the same function inside the same it
     # block, the replacement runs (real impl is bypassed) and the call is
@@ -200,7 +200,7 @@ fn callsRealComputeForSpy(x: int) -> int:
 
 @describe("spy detection inside non-CallStmt lambda positions (#1765)")
 fn spyInNonCallStmtPositionsTests():
-  @it("detects spy target inside AssignStmt rhs lambda body")
+  @it("should detect spy target inside AssignStmt rhs lambda body")
   fn detectsSpyInAssignRhsLambda():
     f = ():
       spy("realComputeForSpy")


### PR DESCRIPTION
## Summary

- Rewrite all 55 `@it("…")` descriptions in `spy.test.ry` / `mock_overload.test.ry` / `directive_lifecycle.test.ry` / `directive_timeout.test.ry` to follow the `should …` convention defined in `docs/reference/testing.md` L820-843.
- Description strings only — test bodies (fn names, expectations) are unchanged. Verified with `./build-rust/ry test` (all 55 pass), ASan/UBSan, TSan, and static analysis (clang-tidy + cppcheck + scan-build), all clean.
- Docs example at `docs/reference/directives.md:579` (`@it("completes within 1 second")`) is intentionally left untouched per the issue's Out of scope section ("Docs example fixes tracked separately").

## Test plan

- [x] `grep '@it(' <file> | grep -v '@it("should'` returns nothing for all four files.
- [x] `grep -c '@it("should' <file>` returns 17 / 12 / 23 / 3 (matches issue table).
- [x] `./build-rust/ry test tests/spec/{spy,mock_overload,directive_lifecycle,directive_timeout}.test.ry` — all pass.
- [x] Full `run-tests.sh`: 206 files, 0 failures.
- [x] Full `run-asan.sh`: 206 files, 0 failures.
- [x] Full `run-tsan.sh`: 206 files, 0 failures.
- [x] `run-static-analysis-all.sh`: clang-tidy + cppcheck + scan-build all clean.

Closes #1786