### PR TITLE
refactor(codegen): migrate concurrency capability via crates/emit primitives (pilot F)

### DIFF
--- a/crates/emit/src/abi/primitive.rs
+++ b/crates/emit/src/abi/primitive.rs
@@ -358,6 +358,32 @@ pub unsafe extern "C" fn ry_emit_zext(
     intern(c, to_ry_value(v.0))
 }
 
+/// Emit `trunc val to dest_ty` — truncate `val` to the narrower integer type
+/// `dest_ty` (`LLVMBuildTrunc`). NULL ctx / NULL dest_ty / unresolved val → 0.
+/// NULL `name` → empty. Added for #2194 (concurrency capability migration):
+/// thread join i64→i1 bool unwrap, AtomicInt CAS status truncate, AtomicBool
+/// load i64→i1. The NULL-type guard fires before resolve_value, mirroring
+/// `ry_emit_zext`.
+#[no_mangle]
+pub unsafe extern "C" fn ry_emit_trunc(
+    ctx: *mut RyEmitCtx,
+    val_id: RyValueId,
+    dest_ty: RyTypeRef,
+    name: *const c_char,
+) -> RyValueId {
+    let Some(c) = checked_cx(ctx) else {
+        return 0;
+    };
+    if dest_ty.is_null() {
+        return 0;
+    }
+    let Some(val) = resolve_value(c, val_id) else {
+        return 0;
+    };
+    let v = c.build_trunc(val, TypeRef(as_type(dest_ty)), name_or_empty(name));
+    intern(c, to_ry_value(v.0))
+}
+
 /// Emit `icmp <predicate> lhs, rhs`. NULL ctx / unknown predicate / NULL operand → 0.
 #[no_mangle]
 pub unsafe extern "C" fn ry_emit_icmp(

--- a/crates/emit/src/primitive/ops.rs
+++ b/crates/emit/src/primitive/ops.rs
@@ -278,6 +278,21 @@ impl EmitCtx {
         ValueRef(LLVMBuildZExt(self.builder, val.0, dest_ty.0, name))
     }
 
+    // `trunc val to dest_ty` — truncate an integer value to a narrower integer
+    // type (`LLVMBuildTrunc`). Added for #2194 (concurrency capability
+    // migration): thread join unwraps an i64 worker-return slot to i1 for bool
+    // workers, AtomicInt CAS truncates its i64 status to i1, and AtomicBool
+    // load truncates its i64 backing slot to i1. All three sites currently
+    // emit a C++ `builder_.CreateTrunc`; this primitive is the boundary entry.
+    pub(crate) unsafe fn build_trunc(
+        &mut self,
+        val: ValueRef,
+        dest_ty: TypeRef,
+        name: *const c_char,
+    ) -> ValueRef {
+        ValueRef(LLVMBuildTrunc(self.builder, val.0, dest_ty.0, name))
+    }
+
     // `icmp <pred> lhs, rhs`.
     pub(crate) unsafe fn build_icmp(
         &mut self,

--- a/include/ry/codegen.hpp
+++ b/include/ry/codegen.hpp
@@ -2113,6 +2113,11 @@ public:
     // carries no builder_.CreateZExt.
     llvm::Value *emitZExt(llvm::Value *val, llvm::Type *dest_ty, const char *name);
 
+    // trunc an integer value to a narrower integer type. Added for #2194
+    // (concurrency capability migration): thread join i64→i1 bool unwrap,
+    // AtomicInt CAS status truncate, AtomicBool load i64→i1.
+    llvm::Value *emitTrunc(llvm::Value *val, llvm::Type *dest_ty, const char *name);
+
     // Generic atomic primitives — Ry-concept-free LLVM `atomicrmw` / atomic
     // `load` / `cmpxchg` wrappers over the boundary entries
     // `ry_emit_atomic_rmw` / `_atomic_load` / `_atomic_cmpxchg`. Added for

--- a/include/ry/llvm_emit/api.h
+++ b/include/ry/llvm_emit/api.h
@@ -1128,6 +1128,14 @@ RyValueId ry_emit_extract_value(RyEmitCtx *ctx, RyValueId agg_id, uint32_t idx,
 RyValueId ry_emit_zext(RyEmitCtx *ctx, RyValueId val_id, RyTypeRef dest_ty,
                        const char *name);
 
+// Emit `trunc val to dest_ty` — truncate an integer value to the narrower
+// integer type `dest_ty` (`LLVMBuildTrunc`). NULL `name` → empty SSA name.
+// Added for #2194 (concurrency capability migration): thread join i64→i1 bool
+// unwrap, AtomicInt CAS status i64→i1 truncate, AtomicBool load i64→i1.
+// Creates no basic blocks.
+RyValueId ry_emit_trunc(RyEmitCtx *ctx, RyValueId val_id, RyTypeRef dest_ty,
+                        const char *name);
+
 // Emit `icmp <predicate> lhs, rhs` where `predicate` is a RyICmpPred value;
 // return the interned i1 result. An unknown predicate yields sentinel 0.
 RyValueId ry_emit_icmp(RyEmitCtx *ctx, int predicate, RyValueId lhs_id,

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -329,6 +329,13 @@ llvm::Value *CodeGen::emitZExt(llvm::Value *val, llvm::Type *dest_ty,
     return ry::llvm_emit::asLlvmValue(ry_emit_resolve(emit_ctx_, id));
 }
 
+llvm::Value *CodeGen::emitTrunc(llvm::Value *val, llvm::Type *dest_ty,
+                                const char *name) {
+    RyValueId valId = ry_emit_intern(emit_ctx_, ry::llvm_emit::asRyValue(val));
+    RyValueId id = ry_emit_trunc(emit_ctx_, valId, ry::llvm_emit::asRyType(dest_ty), name);
+    return ry::llvm_emit::asLlvmValue(ry_emit_resolve(emit_ctx_, id));
+}
+
 // === Function / call IR primitives (Stage 2-C / #2098, [C]=(ii) boundary move) ===
 // Thin wrappers over the ry_emit_* function / call primitives. emitCreateFunction
 // returns the llvm::Function* recovered from the opaque RyFunctionRef (no

--- a/src/codegen_call_thread.cpp
+++ b/src/codegen_call_thread.cpp
@@ -182,30 +182,30 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                 envFields.push_back(alloca->getAllocatedType());
         llvm::StructType *envTy = llvm::StructType::get(*cg.ctx_, envFields);
 
-        llvm::FunctionCallee mallocFn = cg.getStdlibMalloc();
         const llvm::DataLayout &dl = cg.mod_->getDataLayout();
         uint64_t envSize = std::max<uint64_t>(1, dl.getTypeAllocSize(envTy));
-        envPtr = cg.builder_.CreateCall(
-            mallocFn, {llvm::ConstantInt::get(cg.i64Ty_, envSize)}, "thread_env");
+        envPtr = cg.emitRuntimeCallDirect(
+            "malloc", cg.ptrTy_, {cg.i64Ty_},
+            {cg.emitConstInt(cg.i64Ty_, envSize)}, "thread_env");
 
         if (captures.empty()) {
-            llvm::Value *dummyField = cg.builder_.CreateStructGEP(envTy, envPtr, 0, "thread_env_dummy");
-            cg.builder_.CreateStore(llvm::ConstantInt::get(cg.i8Ty_, 0), dummyField);
+            llvm::Value *dummyField = cg.emitStructGEP(envTy, envPtr, 0, "thread_env_dummy");
+            cg.emitStore(cg.emitConstInt(cg.i8Ty_, 0), dummyField);
         } else {
             for (size_t i = 0; i < captures.size(); ++i) {
-                llvm::Value *fieldPtr = cg.builder_.CreateStructGEP(envTy, envPtr, static_cast<unsigned>(i), "thread_env_field");
+                llvm::Value *fieldPtr = cg.emitStructGEP(envTy, envPtr, static_cast<unsigned>(i), "thread_env_field");
                 llvm::AllocaInst *src = captures[i].second;
-                cg.builder_.CreateStore(
-                    cg.builder_.CreateLoad(src->getAllocatedType(), src, captures[i].first + ".thr_cap"),
+                cg.emitStore(
+                    cg.emitLoad(src->getAllocatedType(), src, (captures[i].first + ".thr_cap").c_str()),
                     fieldPtr);
             }
         }
 
         llvm::FunctionType *thunkTy = llvm::FunctionType::get(
             llvm::Type::getVoidTy(*cg.ctx_), {cg.ptrTy_, cg.ptrTy_}, false);
-        thunk = llvm::Function::Create(
-            thunkTy, llvm::Function::InternalLinkage,
-            "__ry_thread." + std::to_string(cg.lambda_counter_++), *cg.mod_);
+        std::string thunkName = "__ry_thread." + std::to_string(cg.lambda_counter_++);
+        thunk = cg.emitCreateFunction(
+            thunkTy, llvm::Function::InternalLinkage, thunkName.c_str());
 
         {
             CodeGen::FnScope guard(cg);
@@ -215,18 +215,17 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
             llvm::BasicBlock *entryBB = cg.createBBInFn("entry", thunk);
             cg.builder_.SetInsertPoint(entryBB);
 
-            auto argIt = thunk->arg_begin();
-            llvm::Value *envRaw = &*argIt++;
+            llvm::Value *envRaw = cg.emitGetParam(thunk, 0);
             envRaw->setName("env_raw");
-            llvm::Value *resultRaw = &*argIt;
+            llvm::Value *resultRaw = cg.emitGetParam(thunk, 1);
             resultRaw->setName("result_raw");
             if (!captures.empty()) {
                 for (size_t i = 0; i < captures.size(); ++i) {
                     const auto &[name, src] = captures[i];
                     llvm::Type *capTy = src->getAllocatedType();
-                    llvm::Value *fieldPtr = cg.builder_.CreateStructGEP(envTy, envRaw, static_cast<unsigned>(i), name + ".field");
-                    llvm::AllocaInst *dst = cg.builder_.CreateAlloca(capTy, nullptr, name);
-                    cg.builder_.CreateStore(cg.builder_.CreateLoad(capTy, fieldPtr, name + ".cap"), dst);
+                    llvm::Value *fieldPtr = cg.emitStructGEP(envTy, envRaw, static_cast<unsigned>(i), (name + ".field").c_str());
+                    llvm::AllocaInst *dst = llvm::cast<llvm::AllocaInst>(cg.emitAlloca(capTy, name.c_str()));
+                    cg.emitStore(cg.emitLoad(capTy, fieldPtr, (name + ".cap").c_str()), dst);
                     cg.scope_stack_.back()[name] = dst;
 
                     cg.propagateMeta(src, dst);
@@ -255,8 +254,8 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                     // Widen i1 → i64 so the full 8-byte slot is initialized;
                     // the join side reads back as i64 and truncates to i1.
                     if (workerRetTy == cg.i1Ty_)
-                        toStore = cg.builder_.CreateZExt(val, cg.i64Ty_, "thread_ret_bool_ext");
-                    cg.builder_.CreateStore(toStore, resultRaw);
+                        toStore = cg.emitZExt(val, cg.i64Ty_, "thread_ret_bool_ext");
+                    cg.emitStore(toStore, resultRaw);
                 }
             } else {
                 // Block-bodied inline lambda: always Unit (the non-Unit
@@ -267,8 +266,8 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
             }
             resultSize = workerRetTy->isVoidTy() ? 0 : 8;
 
-            // popScope() must run BEFORE CreateRetVoid() because it emits ARC
-            // release diamonds (CreateLoad + CreateCondBr). If the BB is already
+            // popScope() must run BEFORE the void return because it emits ARC
+            // release diamonds (Load + CondBr). If the BB is already
             // terminated those instructions would land after the terminator,
             // producing malformed IR that crashes LowerExpectIntrinsicPass (#1090).
             // If the body ended with an explicit return (already terminated),
@@ -277,7 +276,7 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
             if (!cg.builder_.GetInsertBlock()->getTerminator()) {
                 cg.popScope();
                 if (!cg.builder_.GetInsertBlock()->getTerminator())
-                    cg.builder_.CreateRetVoid();
+                    cg.emitRet(nullptr);
             }
         }
 
@@ -295,7 +294,6 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
         // issue because it requires writing the wrapped fn's return into the
         // ThreadHandle slot from a trampoline.
         llvm::Value *fnVal = cg.emitExpr(*e.args[0]);
-        llvm::FunctionCallee mallocFn = cg.getStdlibMalloc();
         const llvm::DataLayout &dl = cg.mod_->getDataLayout();
 
         auto *fnInfoPtr = cg.lookupFnTypeInfo(fnVal);
@@ -303,9 +301,9 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
 
         llvm::FunctionType *thunkTy = llvm::FunctionType::get(
             llvm::Type::getVoidTy(*cg.ctx_), {cg.ptrTy_, cg.ptrTy_}, false);
-        thunk = llvm::Function::Create(
-            thunkTy, llvm::Function::InternalLinkage,
-            "__ry_thread_tramp." + std::to_string(cg.lambda_counter_++), *cg.mod_);
+        std::string thunkName = "__ry_thread_tramp." + std::to_string(cg.lambda_counter_++);
+        thunk = cg.emitCreateFunction(
+            thunkTy, llvm::Function::InternalLinkage, thunkName.c_str());
 
         if (hasCaps) {
             const CodeGen::FnTypeInfo info = *fnInfoPtr;
@@ -316,19 +314,22 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                 closureFields.push_back(ct);
             llvm::StructType *closureTy = llvm::StructType::get(*cg.ctx_, closureFields);
 
-            envPtr = cg.builder_.CreateCall(
-                mallocFn,
-                {llvm::ConstantInt::get(cg.i64Ty_, dl.getTypeAllocSize(closureTy))},
+            envPtr = cg.emitRuntimeCallDirect(
+                "malloc", cg.ptrTy_, {cg.i64Ty_},
+                {cg.emitConstInt(cg.i64Ty_, dl.getTypeAllocSize(closureTy))},
                 "thread_env");
 
-            llvm::Value *srcFnPtr = cg.builder_.CreateStructGEP(closureTy, fnVal, 0, "src.fn_ptr");
-            llvm::Value *dstFnPtr = cg.builder_.CreateStructGEP(closureTy, envPtr, 0, "dst.fn_ptr");
-            cg.builder_.CreateStore(cg.builder_.CreateLoad(cg.ptrTy_, srcFnPtr, "fn_ptr.val"), dstFnPtr);
+            llvm::Value *srcFnPtr = cg.emitStructGEP(closureTy, fnVal, 0, "src.fn_ptr");
+            llvm::Value *dstFnPtr = cg.emitStructGEP(closureTy, envPtr, 0, "dst.fn_ptr");
+            cg.emitStore(cg.emitLoad(cg.ptrTy_, srcFnPtr, "fn_ptr.val"), dstFnPtr);
             for (size_t i = 0; i < info.capturedTypes.size(); ++i) {
-                llvm::Value *srcCap = cg.builder_.CreateStructGEP(closureTy, fnVal, static_cast<unsigned>(i + 1), "src.cap." + std::to_string(i));
-                llvm::Value *dstCap = cg.builder_.CreateStructGEP(closureTy, envPtr, static_cast<unsigned>(i + 1), "dst.cap." + std::to_string(i));
-                cg.builder_.CreateStore(
-                    cg.builder_.CreateLoad(info.capturedTypes[i], srcCap, "cap.val." + std::to_string(i)),
+                std::string srcCapName = "src.cap." + std::to_string(i);
+                std::string dstCapName = "dst.cap." + std::to_string(i);
+                std::string capValName = "cap.val." + std::to_string(i);
+                llvm::Value *srcCap = cg.emitStructGEP(closureTy, fnVal, static_cast<unsigned>(i + 1), srcCapName.c_str());
+                llvm::Value *dstCap = cg.emitStructGEP(closureTy, envPtr, static_cast<unsigned>(i + 1), dstCapName.c_str());
+                cg.emitStore(
+                    cg.emitLoad(info.capturedTypes[i], srcCap, capValName.c_str()),
                     dstCap);
             }
 
@@ -340,38 +341,40 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
 
                 // Thunk signature is now (env, result_buf); result_buf is
                 // unused for variable-reference workers (Unit only in MVP).
-                llvm::Value *envRaw = &*thunk->arg_begin();
+                llvm::Value *envRaw = cg.emitGetParam(thunk, 0);
                 envRaw->setName("env_raw");
 
-                llvm::Value *loadedFnPtr = cg.builder_.CreateLoad(
+                llvm::Value *loadedFnPtr = cg.emitLoad(
                     cg.ptrTy_,
-                    cg.builder_.CreateStructGEP(closureTy, envRaw, 0, "tramp.fn_ptr"),
+                    cg.emitStructGEP(closureTy, envRaw, 0, "tramp.fn_ptr"),
                     "tramp.fn");
 
                 std::vector<llvm::Value*> callArgs;
                 std::vector<llvm::Type*> allParamTypes;
                 for (size_t i = 0; i < info.capturedTypes.size(); ++i) {
-                    llvm::Value *capField = cg.builder_.CreateStructGEP(
-                        closureTy, envRaw, static_cast<unsigned>(i + 1), "tramp.cap." + std::to_string(i));
-                    callArgs.push_back(cg.builder_.CreateLoad(
-                        info.capturedTypes[i], capField, "tramp.cap_val." + std::to_string(i)));
+                    std::string capFieldName = "tramp.cap." + std::to_string(i);
+                    std::string capValName = "tramp.cap_val." + std::to_string(i);
+                    llvm::Value *capField = cg.emitStructGEP(
+                        closureTy, envRaw, static_cast<unsigned>(i + 1), capFieldName.c_str());
+                    callArgs.push_back(cg.emitLoad(
+                        info.capturedTypes[i], capField, capValName.c_str()));
                     allParamTypes.push_back(info.capturedTypes[i]);
                 }
 
                 llvm::FunctionType *callTy = llvm::FunctionType::get(
                     llvm::Type::getVoidTy(*cg.ctx_), allParamTypes, false);
-                cg.builder_.CreateCall(callTy, loadedFnPtr, callArgs);
-                cg.builder_.CreateRetVoid();
+                cg.emitCallIndirect(callTy, loadedFnPtr, callArgs, "");
+                cg.emitRet(nullptr);
             }
         } else {
             llvm::Type *envFieldTypes[] = {cg.ptrTy_};
             llvm::StructType *envTy = llvm::StructType::get(*cg.ctx_, llvm::ArrayRef(envFieldTypes));
-            envPtr = cg.builder_.CreateCall(
-                mallocFn,
-                {llvm::ConstantInt::get(cg.i64Ty_, dl.getTypeAllocSize(envTy))},
+            envPtr = cg.emitRuntimeCallDirect(
+                "malloc", cg.ptrTy_, {cg.i64Ty_},
+                {cg.emitConstInt(cg.i64Ty_, dl.getTypeAllocSize(envTy))},
                 "thread_env");
-            llvm::Value *fnField = cg.builder_.CreateStructGEP(envTy, envPtr, 0, "thread_env_fn");
-            cg.builder_.CreateStore(fnVal, fnField);
+            llvm::Value *fnField = cg.emitStructGEP(envTy, envPtr, 0, "thread_env_fn");
+            cg.emitStore(fnVal, fnField);
 
             {
                 CodeGen::FnScope guard(cg);
@@ -380,27 +383,27 @@ static llvm::Value *emitThreadSpawn(CodeGen &cg, const CallExpr &e) {
                 cg.builder_.SetInsertPoint(entryBB);
 
                 // Thunk signature is now (env, result_buf); result_buf unused.
-                llvm::Value *envRaw = &*thunk->arg_begin();
+                llvm::Value *envRaw = cg.emitGetParam(thunk, 0);
                 envRaw->setName("env_raw");
 
-                llvm::Value *fnPtrField = cg.builder_.CreateStructGEP(
+                llvm::Value *fnPtrField = cg.emitStructGEP(
                     envTy, envRaw, 0, "tramp.fn_ptr");
-                llvm::Value *loadedFn = cg.builder_.CreateLoad(cg.ptrTy_, fnPtrField, "tramp.fn");
+                llvm::Value *loadedFn = cg.emitLoad(cg.ptrTy_, fnPtrField, "tramp.fn");
 
                 llvm::FunctionType *callTy = llvm::FunctionType::get(
                     llvm::Type::getVoidTy(*cg.ctx_), {}, false);
-                cg.builder_.CreateCall(callTy, loadedFn);
-                cg.builder_.CreateRetVoid();
+                cg.emitCallIndirect(callTy, loadedFn, {}, "");
+                cg.emitRet(nullptr);
             }
         }
     }
 
-    // Call __ry_thread_spawn(thunk, env, result_size)
-    auto spawnFn = cg.getRuntimeFn("__ry_thread_spawn", cg.ptrTy_,
-                                   {cg.ptrTy_, cg.ptrTy_, cg.i64Ty_});
-    llvm::Value *thread = cg.builder_.CreateCall(
-        spawnFn,
-        {thunk, envPtr, llvm::ConstantInt::get(cg.i64Ty_, static_cast<uint64_t>(resultSize))},
+    // Call __ry_thread_spawn(thunk, env, result_size).
+    // thunk is `llvm::Function*` (already `ptr` under opaque pointers — no
+    // bitcast needed); pass it directly as a Value*.
+    llvm::Value *thread = cg.emitRuntimeCallDirect(
+        "__ry_thread_spawn", cg.ptrTy_, {cg.ptrTy_, cg.ptrTy_, cg.i64Ty_},
+        {thunk, envPtr, cg.emitConstInt(cg.i64Ty_, static_cast<uint64_t>(resultSize))},
         "thread");
     cg.addResourceKind(thread, rk_thread);
     // Attach the worker's return type as metadata so that emitThreadJoin
@@ -421,14 +424,12 @@ static llvm::Value *emitThreadJoin(CodeGen &cg, const CallExpr &e) {
     // carry none and fall through to the legacy status-only path.
     llvm::Type *retTy = cg.getThreadResultType(thread);
 
-    auto fn = cg.getRuntimeFn(
-        "__ry_thread_join", cg.i64Ty_, {cg.ptrTy_, cg.ptrTy_});
-
     if (!retTy || retTy->isVoidTy()) {
         llvm::Value *nullBuf =
             llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(cg.ptrTy_));
-        llvm::Value *status = cg.builder_.CreateCall(
-            fn, {thread, nullBuf}, "join_status");
+        llvm::Value *status = cg.emitRuntimeCallDirect(
+            "__ry_thread_join", cg.i64Ty_, {cg.ptrTy_, cg.ptrTy_},
+            {thread, nullBuf}, "join_status");
         return cg.wrapStatusAsResult(status);
     }
 
@@ -437,19 +438,20 @@ static llvm::Value *emitThreadJoin(CodeGen &cg, const CallExpr &e) {
     // so the full 8-byte ThreadHandle slot is initialized.
     llvm::Type *slotTy = retTy->isIntegerTy(1) ? cg.i64Ty_ : retTy;
     llvm::AllocaInst *outSlot =
-        cg.builder_.CreateAlloca(slotTy, nullptr, "thread_join_out");
-    llvm::Value *status = cg.builder_.CreateCall(
-        fn, {thread, outSlot}, "join_status");
-    llvm::Value *isErr = cg.builder_.CreateICmpNE(
-        status, llvm::ConstantInt::get(cg.i64Ty_, 0), "thread_join_err");
+        llvm::cast<llvm::AllocaInst>(cg.emitAlloca(slotTy, "thread_join_out"));
+    llvm::Value *status = cg.emitRuntimeCallDirect(
+        "__ry_thread_join", cg.i64Ty_, {cg.ptrTy_, cg.ptrTy_},
+        {thread, outSlot}, "join_status");
+    llvm::Value *isErr = cg.emitICmpNE(
+        status, cg.emitConstInt(cg.i64Ty_, 0), "thread_join_err");
     llvm::StructType *resTy = cg.getResultType(retTy, cg.errorTy_);
     return cg.emitResultBranch(
         isErr, resTy,
         [&]() -> llvm::Value * {
             llvm::Value *loaded =
-                cg.builder_.CreateLoad(slotTy, outSlot, "thread_join_val");
+                cg.emitLoad(slotTy, outSlot, "thread_join_val");
             if (retTy->isIntegerTy(1))
-                loaded = cg.builder_.CreateTrunc(loaded, cg.i1Ty_, "thread_join_bool");
+                loaded = cg.emitTrunc(loaded, cg.i1Ty_, "thread_join_bool");
             return cg.buildOkValue(loaded, resTy);
         },
         [&]() -> llvm::Value * {
@@ -464,8 +466,8 @@ static llvm::Value *emitThreadSyncNew(CodeGen &cg, const CallExpr &e) {
     int rk;
     if (e.callee == "lockNew") { rtName = "__ry_lock_new"; rk = rk_lock; }
     else { rtName = "__ry_rwlock_new"; rk = rk_rwlock; }
-    auto fn = cg.getRuntimeFn(rtName, cg.ptrTy_, {});
-    llvm::Value *result = cg.builder_.CreateCall(fn, {}, e.callee);
+    llvm::Value *result = cg.emitRuntimeCallDirect(
+        rtName, cg.ptrTy_, {}, {}, e.callee.c_str());
     cg.addResourceKind(result, rk);
     return result;
 }
@@ -478,8 +480,8 @@ static llvm::Value *emitThreadSyncResultNew(CodeGen &cg, const CallExpr &e) {
     int rk;
     if (e.callee == "semaphoreNew") { rtName = "__ry_semaphore_new"; rk = rk_semaphore; }
     else { rtName = "__ry_barrier_new"; rk = rk_barrier; }
-    auto fn = cg.getRuntimeFn(rtName, cg.ptrTy_, {cg.i64Ty_});
-    llvm::Value *ptr = cg.builder_.CreateCall(fn, {count}, e.callee);
+    llvm::Value *ptr = cg.emitRuntimeCallDirect(
+        rtName, cg.ptrTy_, {cg.i64Ty_}, {count}, e.callee.c_str());
     llvm::Value *result = cg.wrapPtrAsResult(ptr);
     cg.addResourceKind(result, rk);
     return result;
@@ -507,8 +509,9 @@ static llvm::Value *emitThreadSyncOp(CodeGen &cg, const CallExpr &e) {
     if (it == ops.end()) return nullptr;
     if (!(cg.*(it->second.check))(arg))
         cg.codegenError(e.callee + "() requires " + it->second.type + " argument");
-    auto fn = cg.getRuntimeFn(it->second.rt, cg.i64Ty_, {cg.ptrTy_});
-    llvm::Value *status = cg.builder_.CreateCall(fn, {arg}, e.callee + "_status");
+    std::string statusName = e.callee + "_status";
+    llvm::Value *status = cg.emitRuntimeCallDirect(
+        it->second.rt, cg.i64Ty_, {cg.ptrTy_}, {arg}, statusName.c_str());
     return cg.wrapStatusAsResult(status);
 }
 
@@ -538,8 +541,8 @@ static llvm::Value *emitThreadSyncFree(CodeGen &cg, const CallExpr &e) {
 static llvm::Value *emitThreadAtomicIntNew(CodeGen &cg, const CallExpr &e) {
     cg.requireArgs(e, 1);
     llvm::Value *val = cg.emitExpr(*e.args[0]);
-    auto fn = cg.getRuntimeFn("__ry_atomic_int_new", cg.ptrTy_, {cg.i64Ty_});
-    llvm::Value *atom = cg.builder_.CreateCall(fn, {val}, "atomic_int");
+    llvm::Value *atom = cg.emitRuntimeCallDirect(
+        "__ry_atomic_int_new", cg.ptrTy_, {cg.i64Ty_}, {val}, "atomic_int");
     cg.addResourceKind(atom, rk_atomic_int);
     return atom;
 }
@@ -553,14 +556,15 @@ static llvm::Value *emitThreadAtomicIntOp(CodeGen &cg, const CallExpr &e) {
 
     if (e.callee == "atomicIntLoad") {
         cg.requireArgs(e, 1);
-        auto fn = cg.getRuntimeFn("__ry_atomic_int_load", cg.i64Ty_, {cg.ptrTy_});
-        return cg.builder_.CreateCall(fn, {atom}, "atomic_int_load");
+        return cg.emitRuntimeCallDirect(
+            "__ry_atomic_int_load", cg.i64Ty_, {cg.ptrTy_}, {atom}, "atomic_int_load");
     }
     if (e.callee == "atomicIntStore") {
         cg.requireArgs(e, 2);
         llvm::Value *val = cg.emitExpr(*e.args[1]);
-        auto fn = cg.getRuntimeFn("__ry_atomic_int_store", llvm::Type::getVoidTy(*cg.ctx_), {cg.ptrTy_, cg.i64Ty_});
-        return cg.builder_.CreateCall(fn, {atom, val});
+        return cg.emitRuntimeCallDirect(
+            "__ry_atomic_int_store", llvm::Type::getVoidTy(*cg.ctx_),
+            {cg.ptrTy_, cg.i64Ty_}, {atom, val}, "");
     }
     // add, sub
     cg.requireArgs(e, 2);
@@ -573,8 +577,8 @@ static llvm::Value *emitThreadAtomicIntOp(CodeGen &cg, const CallExpr &e) {
     } else {
         cg.codegenError("emitThreadAtomicIntOp: unsupported callee '" + e.callee + "'");
     }
-    auto fn = cg.getRuntimeFn(rtName, cg.i64Ty_, {cg.ptrTy_, cg.i64Ty_});
-    return cg.builder_.CreateCall(fn, {atom, delta}, e.callee);
+    return cg.emitRuntimeCallDirect(
+        rtName, cg.i64Ty_, {cg.ptrTy_, cg.i64Ty_}, {atom, delta}, e.callee.c_str());
 }
 
 static llvm::Value *emitThreadAtomicIntCas(CodeGen &cg, const CallExpr &e) {
@@ -584,9 +588,10 @@ static llvm::Value *emitThreadAtomicIntCas(CodeGen &cg, const CallExpr &e) {
         cg.codegenError("atomicIntCas() requires AtomicInt as first argument");
     llvm::Value *expected = cg.emitExpr(*e.args[1]);
     llvm::Value *desired = cg.emitExpr(*e.args[2]);
-    auto fn = cg.getRuntimeFn("__ry_atomic_int_cas", cg.i64Ty_, {cg.ptrTy_, cg.i64Ty_, cg.i64Ty_});
-    llvm::Value *result = cg.builder_.CreateCall(fn, {atom, expected, desired}, "atomic_int_cas");
-    return cg.builder_.CreateTrunc(result, cg.i1Ty_, "atomic_int_cas_bool");
+    llvm::Value *result = cg.emitRuntimeCallDirect(
+        "__ry_atomic_int_cas", cg.i64Ty_, {cg.ptrTy_, cg.i64Ty_, cg.i64Ty_},
+        {atom, expected, desired}, "atomic_int_cas");
+    return cg.emitTrunc(result, cg.i1Ty_, "atomic_int_cas_bool");
 }
 
 static llvm::Value *emitThreadAtomicBoolNew(CodeGen &cg, const CallExpr &e) {
@@ -594,9 +599,9 @@ static llvm::Value *emitThreadAtomicBoolNew(CodeGen &cg, const CallExpr &e) {
     llvm::Value *val = cg.emitExpr(*e.args[0]);
     if (val->getType() != cg.i1Ty_)
         cg.codegenError("atomicBoolNew() requires bool argument");
-    llvm::Value *extended = cg.builder_.CreateZExt(val, cg.i64Ty_, "atomic_bool_ext");
-    auto fn = cg.getRuntimeFn("__ry_atomic_bool_new", cg.ptrTy_, {cg.i64Ty_});
-    llvm::Value *atom = cg.builder_.CreateCall(fn, {extended}, "atomic_bool");
+    llvm::Value *extended = cg.emitZExt(val, cg.i64Ty_, "atomic_bool_ext");
+    llvm::Value *atom = cg.emitRuntimeCallDirect(
+        "__ry_atomic_bool_new", cg.ptrTy_, {cg.i64Ty_}, {extended}, "atomic_bool");
     cg.addResourceKind(atom, rk_atomic_bool);
     return atom;
 }
@@ -610,18 +615,19 @@ static llvm::Value *emitThreadAtomicBoolOp(CodeGen &cg, const CallExpr &e) {
 
     if (e.callee == "atomicBoolLoad") {
         cg.requireArgs(e, 1);
-        auto fn = cg.getRuntimeFn("__ry_atomic_bool_load", cg.i64Ty_, {cg.ptrTy_});
-        llvm::Value *result = cg.builder_.CreateCall(fn, {atom}, "atomic_bool_load");
-        return cg.builder_.CreateTrunc(result, cg.i1Ty_, "atomic_bool_load_bool");
+        llvm::Value *result = cg.emitRuntimeCallDirect(
+            "__ry_atomic_bool_load", cg.i64Ty_, {cg.ptrTy_}, {atom}, "atomic_bool_load");
+        return cg.emitTrunc(result, cg.i1Ty_, "atomic_bool_load_bool");
     }
     // atomicBoolStore
     cg.requireArgs(e, 2);
     llvm::Value *val = cg.emitExpr(*e.args[1]);
     if (val->getType() != cg.i1Ty_)
         cg.codegenError("atomicBoolStore() requires bool as second argument");
-    llvm::Value *extended = cg.builder_.CreateZExt(val, cg.i64Ty_, "atomic_bool_store_ext");
-    auto fn = cg.getRuntimeFn("__ry_atomic_bool_store", llvm::Type::getVoidTy(*cg.ctx_), {cg.ptrTy_, cg.i64Ty_});
-    return cg.builder_.CreateCall(fn, {atom, extended});
+    llvm::Value *extended = cg.emitZExt(val, cg.i64Ty_, "atomic_bool_store_ext");
+    return cg.emitRuntimeCallDirect(
+        "__ry_atomic_bool_store", llvm::Type::getVoidTy(*cg.ctx_),
+        {cg.ptrTy_, cg.i64Ty_}, {atom, extended}, "");
 }
 
 // ===== Thread dispatch table =====

--- a/src/codegen_stmt_loop.cpp
+++ b/src/codegen_stmt_loop.cpp
@@ -679,31 +679,30 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
             envFields.push_back(alloca->getAllocatedType());
     llvm::StructType *envTy = llvm::StructType::get(*ctx_, envFields);
 
-    llvm::FunctionType *mallocTy = llvm::FunctionType::get(ptrTy_, {i64Ty_}, false);
-    llvm::FunctionCallee mallocFn = mod_->getOrInsertFunction("malloc", mallocTy);
     const llvm::DataLayout &dl = mod_->getDataLayout();
     uint64_t envSize = std::max<uint64_t>(1, dl.getTypeAllocSize(envTy));
-    llvm::Value *envPtr = builder_.CreateCall(
-        mallocFn, {llvm::ConstantInt::get(i64Ty_, envSize)}, "parallel_env");
+    llvm::Value *envPtr = emitRuntimeCallDirect(
+        "malloc", ptrTy_, {i64Ty_},
+        {emitConstInt(i64Ty_, envSize)}, "parallel_env");
 
     if (captures.empty()) {
-        llvm::Value *dummyField = builder_.CreateStructGEP(envTy, envPtr, 0, "parallel_env_dummy");
-        builder_.CreateStore(llvm::ConstantInt::get(i8Ty_, 0), dummyField);
+        llvm::Value *dummyField = emitStructGEP(envTy, envPtr, 0, "parallel_env_dummy");
+        emitStore(emitConstInt(i8Ty_, 0), dummyField);
     } else {
         for (size_t i = 0; i < captures.size(); ++i) {
-            llvm::Value *fieldPtr = builder_.CreateStructGEP(envTy, envPtr, static_cast<unsigned>(i), "parallel_env_field");
+            llvm::Value *fieldPtr = emitStructGEP(envTy, envPtr, static_cast<unsigned>(i), "parallel_env_field");
             llvm::AllocaInst *src = captures[i].second;
-            builder_.CreateStore(
-                builder_.CreateLoad(src->getAllocatedType(), src, captures[i].first + ".par_cap"),
+            emitStore(
+                emitLoad(src->getAllocatedType(), src, (captures[i].first + ".par_cap").c_str()),
                 fieldPtr);
         }
     }
 
     llvm::FunctionType *thunkTy = llvm::FunctionType::get(
         llvm::Type::getVoidTy(*ctx_), {ptrTy_, i64Ty_, i64Ty_, i64Ty_}, false);
-    llvm::Function *thunk = llvm::Function::Create(
-        thunkTy, llvm::Function::InternalLinkage,
-        "__ry_parallel_for." + std::to_string(lambda_counter_++), *mod_);
+    std::string thunkName = "__ry_parallel_for." + std::to_string(lambda_counter_++);
+    llvm::Function *thunk = emitCreateFunction(
+        thunkTy, llvm::Function::InternalLinkage, thunkName.c_str());
 
     {
         FnScope guard(*this);
@@ -720,25 +719,28 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
         llvm::BasicBlock *entryBB = createBBInFn("entry", thunk);
         builder_.SetInsertPoint(entryBB);
 
-        auto argIt = thunk->arg_begin();
-        llvm::Value *envRaw = &*argIt++;
+        llvm::Value *envRaw = emitGetParam(thunk, 0);
         envRaw->setName("env_raw");
-        llvm::Value *chunkBegin = &*argIt++;
+        llvm::Value *chunkBegin = emitGetParam(thunk, 1);
         chunkBegin->setName("chunk_begin");
-        llvm::Value *chunkEnd = &*argIt++;
+        llvm::Value *chunkEnd = emitGetParam(thunk, 2);
         chunkEnd->setName("chunk_end");
-        llvm::Value *stepArg = &*argIt;
+        llvm::Value *stepArg = emitGetParam(thunk, 3);
         stepArg->setName("step");
 
-        llvm::Value *typedEnv = builder_.CreateBitCast(envRaw, ptrTy_, "parallel_env_typed");
+        // Under opaque pointers `bitcast envRaw to ptr` is the identity, so the
+        // IRBuilder folded the original `parallel_env_typed` cast to a no-op
+        // (IR baseline has zero `bitcast` lines). Use envRaw directly as the
+        // env pointer below — same byte-exact IR, one fewer instruction to
+        // synthesize.
 
         if (!captures.empty()) {
             for (size_t i = 0; i < captures.size(); ++i) {
                 const auto &[name, src] = captures[i];
                 llvm::Type *capTy = src->getAllocatedType();
-                llvm::Value *fieldPtr = builder_.CreateStructGEP(envTy, typedEnv, static_cast<unsigned>(i), name + ".field");
-                llvm::AllocaInst *dst = builder_.CreateAlloca(capTy, nullptr, name);
-                builder_.CreateStore(builder_.CreateLoad(capTy, fieldPtr, name + ".cap"), dst);
+                llvm::Value *fieldPtr = emitStructGEP(envTy, envRaw, static_cast<unsigned>(i), (name + ".field").c_str());
+                llvm::AllocaInst *dst = llvm::cast<llvm::AllocaInst>(emitAlloca(capTy, name.c_str()));
+                emitStore(emitLoad(capTy, fieldPtr, (name + ".cap").c_str()), dst);
                 scope_stack_.back()[name] = dst;
 
                 propagateMeta(src, dst);
@@ -767,8 +769,8 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
                 // "unique → mutate in place". The matching release is
                 // emitted by popScope() below while ParallelForScope is
                 // still live, so it uses the atomic path too (#630).
-                auto *dataPtr = builder_.CreateLoad(ptrTy_, dst, name + ".par_retain_load");
-                auto *isNull = builder_.CreateICmpEQ(
+                auto *dataPtr = emitLoad(ptrTy_, dst, (name + ".par_retain_load").c_str());
+                auto *isNull = emitICmpEQ(
                     dataPtr,
                     llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_)),
                     "par_retain_null");
@@ -788,8 +790,8 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
             }
         }
 
-        llvm::AllocaInst *iVar = builder_.CreateAlloca(i64Ty_, nullptr, loopVarName);
-        builder_.CreateStore(chunkBegin, iVar);
+        llvm::AllocaInst *iVar = llvm::cast<llvm::AllocaInst>(emitAlloca(i64Ty_, loopVarName.c_str()));
+        emitStore(chunkBegin, iVar);
 
         llvm::BasicBlock *condBB = createBBInFn("parallel.cond", thunk);
         llvm::BasicBlock *bodyBB = createBBInFn("parallel.body", thunk);
@@ -799,11 +801,12 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
         emitBranchUncond(condBB);
 
         builder_.SetInsertPoint(condBB);
-        llvm::Value *iCur = builder_.CreateLoad(i64Ty_, iVar, "parallel_i");
-        llvm::Value *stepPos = builder_.CreateICmpSGT(stepArg, llvm::ConstantInt::get(i64Ty_, 0), "parallel_step_pos");
-        llvm::Value *posCond = builder_.CreateICmpSLT(iCur, chunkEnd, "parallel_pos_cond");
-        llvm::Value *negCond = builder_.CreateICmpSGT(iCur, chunkEnd, "parallel_neg_cond");
-        llvm::Value *loopCond = builder_.CreateSelect(stepPos, posCond, negCond, "parallel_cond");
+        llvm::Value *iCur = emitLoad(i64Ty_, iVar, "parallel_i");
+        llvm::Value *zero = emitConstInt(i64Ty_, 0);
+        llvm::Value *stepPos = emitICmpSGT(stepArg, zero, "parallel_step_pos");
+        llvm::Value *posCond = emitICmpSLT(iCur, chunkEnd, "parallel_pos_cond");
+        llvm::Value *negCond = emitICmpSGT(iCur, chunkEnd, "parallel_neg_cond");
+        llvm::Value *loopCond = emitSelect(stepPos, posCond, negCond, "parallel_cond");
         emitBranchCond(loopCond, bodyBB, endBB);
 
         builder_.SetInsertPoint(bodyBB);
@@ -816,9 +819,9 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
             emitBranchUncond(stepBB);
 
         builder_.SetInsertPoint(stepBB);
-        llvm::Value *iNext = builder_.CreateAdd(
-            builder_.CreateLoad(i64Ty_, iVar, "parallel_i_step"), stepArg, "parallel_i_next");
-        builder_.CreateStore(iNext, iVar);
+        llvm::Value *iNext = emitAdd(
+            emitLoad(i64Ty_, iVar, "parallel_i_step"), stepArg, "parallel_i_next");
+        emitStore(iNext, iVar);
         emitBranchUncond(condBB);
 
         builder_.SetInsertPoint(endBB);
@@ -827,13 +830,16 @@ void CodeGen::emitParallelForRange(ForStmt &s, llvm::Value *begin, llvm::Value *
         // worker entry. Must happen while ParallelForScope is still live
         // so the release uses the atomic path (#630).
         popScope();
-        builder_.CreateRetVoid();
+        emitRet(nullptr);
     }
 
-    llvm::FunctionCallee parallelFn = getRuntimeFn(
+    // `bitcast thunk to ptr` is the identity under opaque pointers (the IR
+    // baseline carries no such bitcast on this site either); pass the Function*
+    // directly as `ptr`.
+    emitRuntimeCallDirect(
         "__ry_parallel_for_i64", llvm::Type::getVoidTy(*ctx_),
-        {i64Ty_, i64Ty_, i64Ty_, ptrTy_, ptrTy_});
-    builder_.CreateCall(parallelFn, {begin, end, step, envPtr, builder_.CreateBitCast(thunk, ptrTy_)});
+        {i64Ty_, i64Ty_, i64Ty_, ptrTy_, ptrTy_},
+        {begin, end, step, envPtr, thunk}, "");
 }
 
 void CodeGen::emitStmt(std::unique_ptr<UsingStmt> &s) {


### PR DESCRIPTION
## Summary

Pilot F — migrate `@parallel for`, thread spawn / join, atomic, lock / rwlock / semaphore / barrier inline IR in `src/codegen_stmt_loop.cpp` (`emitParallelForRange`, L643–836) and `src/codegen_call_thread.cpp` (`emitThreadSpawn` / `emitThreadJoin` / `emitThreadAtomic*` / `emitThreadSync*`) to go through `crates/emit` primitives end-to-end.

### Architecture decision (iii) hybrid

Recorded per the issue's "settle" requirement:

- **Low-level primitive added**: `ry_emit_trunc` (i64→i1 truncation) — the only gap that prevented the migration from going through existing primitives. Lives in `crates/emit/src/primitive/ops.rs` + `crates/emit/src/abi/primitive.rs` symmetric to `ry_emit_zext`, with the C declaration in `include/ry/llvm_emit/api.h` and the C++ wrapper `emitTrunc` in `codegen.hpp`/`codegen.cpp`.
- **Mid-level scaffolds reuse existing primitives**: env-struct malloc / store-per-capture, thunk `Function::Create`, entry BB, arg unpacking, ARC retain guard blocks, parallel-i loop (cond/body/step/end) are built from `emitCreateFunction` / `emitGetParam` / `emitCallIndirect` / `emitStructGEP` / `emitLoad` / `emitStore` / `emitICmp*` / `emitSelect` / `emitAdd` / `emitAlloca` / `emitConstInt` / `emitZExt` / `emitTrunc` / `emitRet` — every primitive from pilots A (#2098), A2 (#2099), and the libc/runtime-call boundary.
- **High-level runtime ops reuse `ry_emit_runtime_call`**: `__ry_thread_spawn`, `__ry_thread_join`, `__ry_parallel_for_i64`, `__ry_atomic_int_*`, `__ry_atomic_bool_*`, `__ry_lock_*`, `__ry_rwlock_*`, `__ry_semaphore_*`, `__ry_barrier_*`, and `malloc` go through `emitRuntimeCallDirect` rather than adding coarse-grained `ry_emit_thread_spawn` / `ry_emit_lock_acquire` / etc.
- **ARC retain/release stays C++-side** in `@parallel for` thunk bodies (`emitArcRetain(hdr, /*atomic=*/true)` + `emitStrGetHeaderFromData` / `emitArcGetHeaderFromData`), since the atomic-ARC decision depends on the C++ `parallel_for_depth_` counter set up by `ParallelForScope` (#630 / #1968 contract preserved).

Hands off the previous pilots' primitive-leaning trend (A–E) end-to-end; rejected (i) because adding `ry_emit_thread_spawn` / `ry_emit_lock_*` / etc. would push Ry semantics into the `crates/emit` C ABI; rejected (ii) because the AtomicInt / AtomicBool ops in `codegen_call_thread.cpp` already go through `__ry_atomic_*` runtime symbols, so a primitive-atomic path is out of scope.

Two no-op `bitcast`s to `ptr` (`envRaw` and `thunk`) that the IRBuilder folded away under opaque pointers are dropped — the baseline IR carried zero `bitcast` lines on those sites, so removing the calls preserves the byte-exact IR.

Single residual `builder_.CreateAdd` carve-out: `parallel_inclusive_end` at `codegen_stmt_loop.cpp:97` lives in `emitStmt(ForStmt)` dispatch (the `0..N` → `range(0, N+1)` rewrite), outside the issue's stated L686–L802 scope for `emitParallelForRange`.

## Commits

1. `feat(emit): add ry_emit_trunc primitive for i64→i1 truncation` — the new boundary primitive.
2. `refactor(codegen): migrate concurrency capability via crates/emit primitives (pilot F)` — the C++ codegen migration.

## Test plan

- [x] IR bit-exact diff via `./build-rust/ry --emit-llvm-ir -c` against an extended baseline probe (after ASLR `inttoptr` normalization) = **0 lines**. The probe covers every cell — inline-lambda spawn (no-cap / int-cap), variable-ref spawn (closure-cap *and* no-cap path with `thread_env_fn` marker), thread join (Unit / typed-int / bool via `thread_join_bool` Trunc), atomic int (load / store / add / sub / cas including the CAS Trunc), atomic bool (new / store ZExt, load Trunc), lock / rwlock / semaphore / barrier, `@parallel for` (no-ARC int cap, ARC-str cap with `str_hdr_from_data`, ARC-non-str List cap with `arc_hdr_from_data`).
- [x] `./build-rust/ry_tests` — 2724 PASS.
- [x] `./build-rust/ry test -p` — 206 files / 0 failures (includes `tests/spec/thread.test.ry`, `tests/spec/concurrency.test.ry`, `tests/spec/concurrency_stress.test.ry`).
- [x] `./.claude/skills/pre-commit-checklist/run-asan.sh` — 206 files / 0 failures.
- [x] `./.claude/skills/pre-commit-checklist/run-tsan.sh` — 206 files / 0 failures (no race / deadlock from `@parallel for` ARC race #630 or `concurrency_stress`).
- [x] `./.claude/skills/pre-commit-checklist/run-static-analysis-all.sh` — scan-build: no bugs.
- [x] `./.claude/skills/pre-commit-checklist/run-rust-lint.sh` — `cargo fmt` + `cargo clippy -p emit -- -D warnings` clean.
- [x] CI gates (`check-emit-abi-no-ir.sh` / `check-emit-composite-no-primitive.sh` / `check-llvm-emit-abi-header.sh` / `check-emit-llvm-ir-gen-concentration.sh`) all green.
- [x] `builder_.Create*` residual in scope: `codegen_call_thread.cpp` = 0; `codegen_stmt_loop.cpp` (L643–L836) = 0.

Closes #2194.