### PR TITLE
refactor: extract pure typename string utilities (#1821)

### DIFF
--- a/include/ry/util/type_name.hpp
+++ b/include/ry/util/type_name.hpp
@@ -12,7 +12,118 @@ namespace util {
 // from CodeGen by issue #1820 as part of the v0.0.26 boundary cleanup.
 
 // Trim spaces (ASCII ' ' only) from both ends.
+// Distinct from trimTypeNameWhitespace, which trims all std::isspace
+// characters. The two coexist intentionally — typename string sources
+// vary: some emit ASCII space only, others may include tabs/newlines
+// on malformed inputs.
 std::string trimTypeNameSpaces(const std::string &s);
+
+// Trim std::isspace characters (space, tab, LF, CR, VT, FF) from both
+// ends. Used by typename splitters that consume strings whose origins
+// may include non-space whitespace (e.g. TypeNode::toString output on
+// malformed input). Distinct from trimTypeNameSpaces by design.
+std::string trimTypeNameWhitespace(const std::string &s);
+
+// Split `body` on top-level commas, honoring nesting of <, >, (, ),
+// [, ]. Differs from ry::util::splitTypeArgs in that splitTypeArgs
+// tracks only <, >, (, ). Use this variant when the body may contain
+// bracket-typed elements (List index in a tuple/fn signature). Each
+// element is trimmed via trimTypeNameWhitespace.
+std::vector<std::string> splitTopLevelCommas(const std::string &body);
+
+// Split `argsStr` on top-level commas, honoring nesting of <, >, (, ).
+// Unlike splitTopLevelCommas, this does NOT track [, ]. Used by codegen
+// to split the inner of a generic type (e.g. "K, V" from "Map<K, V>")
+// or the parameters of a function type. Elements are NOT trimmed —
+// callers that need whitespace removal apply trimTypeNameSpaces or
+// trimTypeNameWhitespace explicitly.
+std::vector<std::string> splitTypeArgs(const std::string &argsStr);
+
+// Given the index of an opening `(` in `s`, return the index of the
+// matching `)` honoring nested parens. Returns std::string::npos when
+// s[openParen] is not '(' or no matching close exists.
+std::size_t findMatchingCloseParen(const std::string &s,
+                                   std::size_t openParen);
+
+// Split a union type string `"A | B | C"` on the ` | ` separator and
+// trim ASCII spaces from each component. Empty components are dropped.
+std::vector<std::string> parseUnionComponents(const std::string &typeName);
+
+// Sort the union components alphabetically and join them with ` | `.
+// Mutates `components` (sorts in place).
+std::string normalizeUnionType(const std::string &typeName);
+
+// `42` / `-7` / digit-only sequences (with optional leading `-`).
+bool isIntLiteralType(const std::string &typeName);
+
+// Single double-quoted literal `"N"` (exactly 2 quote chars). Rejects
+// `"A" | "B"` because it has 4 quote chars.
+bool isStrLiteralType(const std::string &typeName);
+
+// Range constraint `"1..12"`: requires both sides to be isIntLiteralType.
+// Rejects open-ended `"..5"` / `"1.."` and chained `"1..2..3"`.
+bool isRangeType(const std::string &typeName);
+
+// Union where every component is isIntLiteralType, or every component
+// is isStrLiteralType. Mixed-kind unions return false.
+bool isLiteralUnionType(const std::string &typeName);
+
+// Predicate: any of isList / isMap / isSet.
+bool isCollectionTypeName(const std::string &typeName);
+
+// Strip the leading `"weak "` from a weak-typed name. Caller must
+// ensure isWeakTypeName(typeName) first; this performs no validation.
+std::string weakInnerTypeName(const std::string &typeName);
+
+// Extract `K` from `"Map<K, V>"`. Returns "" if the input is malformed
+// (not exactly 2 comma-separated args after stripping `Map<` / `>`).
+// Caller must ensure isMapTypeName(typeName) first.
+std::string extractMapKeyTypeName(const std::string &mapTypeName);
+
+// Extract `V` from `"Map<K, V>"`. Same contract as extractMapKeyTypeName.
+std::string extractMapValueTypeName(const std::string &mapTypeName);
+
+// True when `name` is a low-level UNSIGNED numeric type name
+// (u8 / u16 / u32 / u64). Treats any name starting with 'u' as
+// unsigned; callers are responsible for first ensuring
+// isLowLevelTypeName(name) when strict classification is required.
+bool isUnsignedLowLevelName(const std::string &name);
+
+// Parse `"(T1, T2, ...)"` into its element list. Returns false when the
+// input is not in parenthesized form. A single-element tuple spells as
+// `"(T,)"` and yields a 1-element list (the empty trailing slot is
+// dropped). Uses splitTopLevelCommas internally so bracket-typed
+// elements are honored.
+bool splitTupleTypeName(const std::string &s,
+                        std::vector<std::string> &elements);
+
+// Parse `"fn(T1, T2) -> Ret"` into params and return type. Returns
+// false when the input does not start with `"fn("` or the parens are
+// unbalanced. `returnType` is empty when no `-> Ret` segment follows
+// the closing paren.
+bool splitFunctionTypeName(const std::string &s,
+                           std::vector<std::string> &params,
+                           std::string &returnType);
+
+// Extract the Nth (0-indexed) type argument from a generic type string
+// like `"Option<T>"`, `"T?"` (OptionalType shorthand for `Option<T>`),
+// or `"Result<T, E>"`. Returns "" when `typeStr` does not start with
+// `prefix` or the index is out of range.
+//
+// Behavior:
+// - `prefix == "Option<"` AND `typeStr` ends with `'?'`: treat as the
+//   `T?` shorthand. Only argIdx == 0 returns the inner; other indices
+//   return "".
+// - Otherwise: typeStr must start with `prefix` and end with `'>'`;
+//   the body is split via splitTypeArgs and parts[argIdx] is returned
+//   after trimTypeNameSpaces.
+//
+// Splits via splitTypeArgs so both angle-bracket and parenthesis depth
+// are tracked correctly (handles function types such as
+// "Option<(int, str) -> bool>").
+std::string extractGenericTypeArg(const std::string &typeStr,
+                                  const std::string &prefix,
+                                  std::size_t argIdx);
 
 // Split a generic type name like "List<int>" into head ("List") and
 // comma-separated inner args (["int"]). Returns false when the input

--- a/src/codegen.cpp
+++ b/src/codegen.cpp
@@ -1545,7 +1545,7 @@ bool CodeGen::isUnsignedLowLevel(llvm::Value *val) const {
 }
 
 bool CodeGen::isUnsignedLowLevelName(const std::string &name) {
-    return !name.empty() && name[0] == 'u';
+    return ry::util::isUnsignedLowLevelName(name);
 }
 
 std::string CodeGen::getExprLowLevelSuffix(const ExprNode &node) {

--- a/src/codegen_arc.cpp
+++ b/src/codegen_arc.cpp
@@ -350,7 +350,7 @@ void CodeGen::emitArcReleaseVar(const std::string &name, llvm::AllocaInst *alloc
 // ===== Collection type name helpers =====
 
 bool CodeGen::isCollectionTypeName(const std::string &typeName) {
-    return ry::util::isListTypeName(typeName) || ry::util::isMapTypeName(typeName) || ry::util::isSetTypeName(typeName);
+    return ry::util::isCollectionTypeName(typeName);
 }
 
 bool CodeGen::fieldTypeIsArcManaged(const std::string &fieldTypeName,
@@ -605,7 +605,7 @@ bool CodeGen::elementTypeIsArcManaged(llvm::Value *containerPtr,
 // ===== Weak reference operations =====
 
 std::string CodeGen::weakInnerTypeName(const std::string &typeName) {
-    return typeName.substr(5);
+    return ry::util::weakInnerTypeName(typeName);
 }
 
 void CodeGen::markWeakManaged(llvm::AllocaInst *alloca) {

--- a/src/codegen_builtin.cpp
+++ b/src/codegen_builtin.cpp
@@ -221,17 +221,11 @@ void CodeGen::propagateReturnFnTypeMeta(const OverloadEntry *entry, llvm::Functi
 }
 
 std::string CodeGen::extractMapKeyTypeName(const std::string &mapTypeName) {
-    std::string inner = mapTypeName.substr(4, mapTypeName.size() - 5);
-    auto parts = splitTypeArgs(inner);
-    if (parts.size() != 2) return "";
-    return ry::util::trimTypeNameSpaces(parts[0]);
+    return ry::util::extractMapKeyTypeName(mapTypeName);
 }
 
 std::string CodeGen::extractMapValueTypeName(const std::string &mapTypeName) {
-    std::string inner = mapTypeName.substr(4, mapTypeName.size() - 5);
-    auto parts = splitTypeArgs(inner);
-    if (parts.size() != 2) return "";
-    return ry::util::trimTypeNameSpaces(parts[1]);
+    return ry::util::extractMapValueTypeName(mapTypeName);
 }
 
 std::string CodeGen::snapshotListElemName(llvm::Value *listVal, llvm::Type *elemTy) {

--- a/src/codegen_fn_generic.cpp
+++ b/src/codegen_fn_generic.cpp
@@ -251,84 +251,8 @@ std::string CodeGen::reverseResolveType(llvm::Value *val) {
 }
 
 // ===== Helpers for structural type-argument unification =====
-
-// Trim ASCII whitespace from both ends. Used by the type-name string
-// splitters below which consume output of `TypeNode::toString()` and
-// `inferExprTypeName` — both produce human-readable strings with
-// optional spaces after commas.
-static std::string trimWs(const std::string &s) {
-    size_t a = 0, b = s.size();
-    while (a < b && std::isspace(static_cast<unsigned char>(s[a]))) ++a;
-    while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) --b;
-    return s.substr(a, b - a);
-}
-
-// Split `body` on top-level commas, honoring nesting of <, >, (, ),
-// [, ], and the lexer-compound tokens `>>` / `>>>` (which can appear
-// when `toString()` emits nested generics).
-static std::vector<std::string> splitTopLevelCommas(const std::string &body) {
-    std::vector<std::string> out;
-    out.reserve(static_cast<size_t>(std::count(body.begin(), body.end(), ',')) + 1);
-    int depth = 0;
-    size_t start = 0;
-    for (size_t i = 0; i < body.size(); ++i) {
-        char c = body[i];
-        if (c == '<' || c == '(' || c == '[') depth++;
-        else if (c == '>' || c == ')' || c == ']') {
-            // Clamp: malformed input with unmatched closers should not
-            // drop `depth` below zero and start splitting mid-group.
-            if (depth > 0) depth--;
-        }
-        else if (c == ',' && depth == 0) {
-            out.push_back(trimWs(body.substr(start, i - start)));
-            start = i + 1;
-        }
-    }
-    out.push_back(trimWs(body.substr(start)));
-    return out;
-}
-
-static bool splitTupleTypeName(const std::string &s,
-                                std::vector<std::string> &elements) {
-    std::string t = trimWs(s);
-    if (t.size() < 2 || t.front() != '(' || t.back() != ')') return false;
-    std::string body = t.substr(1, t.size() - 2);
-    // Single-element tuples spell as "(x,)" — drop the empty trailing slice.
-    elements = splitTopLevelCommas(body);
-    if (!elements.empty() && elements.back().empty())
-        elements.pop_back();
-    return true;
-}
-
-static bool splitFunctionTypeName(const std::string &s,
-                                   std::vector<std::string> &params,
-                                   std::string &returnType) {
-    std::string t = trimWs(s);
-    if (t.rfind("fn(", 0) != 0)
-        return false;
-    const std::string prefix = "fn(";
-    int depth = 1;
-    size_t i = prefix.size();
-    for (; i < t.size() && depth > 0; ++i) {
-        if (t[i] == '(') depth++;
-        else if (t[i] == ')') depth--;
-        if (depth == 0) break;
-    }
-    if (depth != 0) return false;
-    std::string body = t.substr(prefix.size(), i - prefix.size());
-    params = splitTopLevelCommas(body);
-    if (params.size() == 1 && params[0].empty()) params.clear();
-    size_t j = i + 1;
-    while (j < t.size() && std::isspace(static_cast<unsigned char>(t[j]))) ++j;
-    if (j < t.size() && t[j] == '-' && j + 1 < t.size() && t[j + 1] == '>') {
-        j += 2;
-        while (j < t.size() && std::isspace(static_cast<unsigned char>(t[j]))) ++j;
-        returnType = trimWs(t.substr(j));
-    } else {
-        returnType.clear();
-    }
-    return true;
-}
+// splitTopLevelCommas / splitTupleTypeName / splitFunctionTypeName were
+// moved into ry::util in #1821. Callers below use the public API.
 
 void CodeGen::mergeInferredBinding(
     std::unordered_map<std::string, std::string> &inferred,
@@ -383,7 +307,7 @@ bool CodeGen::unifyTypeParam(
             return any;
         } else if constexpr (std::is_same_v<T, TupleType>) {
             std::vector<std::string> elems;
-            if (!splitTupleTypeName(argTypeName, elems)) return false;
+            if (!ry::util::splitTupleTypeName(argTypeName, elems)) return false;
             if (elems.size() != v.elements.size()) return false;
             bool any = false;
             for (size_t k = 0; k < v.elements.size(); ++k)
@@ -394,7 +318,7 @@ bool CodeGen::unifyTypeParam(
         } else if constexpr (std::is_same_v<T, FnType>) {
             std::vector<std::string> fparams;
             std::string fret;
-            if (!splitFunctionTypeName(argTypeName, fparams, fret))
+            if (!ry::util::splitFunctionTypeName(argTypeName, fparams, fret))
                 return false;
             if (fparams.size() != v.param_types.size()) return false;
             bool any = false;
@@ -409,9 +333,10 @@ bool CodeGen::unifyTypeParam(
             return any;
         } else if constexpr (std::is_same_v<T, OptionalType>) {
             // Accept either `"T?"` or the equivalent `"Option<T>"` spelling.
-            std::string t = trimWs(argTypeName);
+            std::string t = ry::util::trimTypeNameWhitespace(argTypeName);
             if (!t.empty() && t.back() == '?') {
-                return unifyTypeParam(*v.inner, trimWs(t.substr(0, t.size() - 1)),
+                return unifyTypeParam(*v.inner,
+                                      ry::util::trimTypeNameWhitespace(t.substr(0, t.size() - 1)),
                                       typeParamSet, inferred, fnName);
             }
             std::string head;
@@ -480,7 +405,7 @@ static bool argMatchesParam(CodeGen &cg,
             return true;
         } else if constexpr (std::is_same_v<T, TupleType>) {
             std::vector<std::string> elems;
-            if (!splitTupleTypeName(argTypeName, elems)) return false;
+            if (!ry::util::splitTupleTypeName(argTypeName, elems)) return false;
             if (elems.size() != v.elements.size()) return false;
             for (size_t k = 0; k < v.elements.size(); ++k)
                 if (!argMatchesParam(cg, *v.elements[k], elems[k], typeParamSet))
@@ -489,7 +414,7 @@ static bool argMatchesParam(CodeGen &cg,
         } else if constexpr (std::is_same_v<T, FnType>) {
             std::vector<std::string> fparams;
             std::string fret;
-            if (!splitFunctionTypeName(argTypeName, fparams, fret))
+            if (!ry::util::splitFunctionTypeName(argTypeName, fparams, fret))
                 return false;
             if (fparams.size() != v.param_types.size()) return false;
             for (size_t k = 0; k < v.param_types.size(); ++k)
@@ -500,10 +425,10 @@ static bool argMatchesParam(CodeGen &cg,
                     return false;
             return true;
         } else if constexpr (std::is_same_v<T, OptionalType>) {
-            std::string t = trimWs(argTypeName);
+            std::string t = ry::util::trimTypeNameWhitespace(argTypeName);
             if (!t.empty() && t.back() == '?') {
                 return argMatchesParam(cg, *v.inner,
-                                       trimWs(t.substr(0, t.size() - 1)),
+                                       ry::util::trimTypeNameWhitespace(t.substr(0, t.size() - 1)),
                                        typeParamSet);
             }
             std::string head;

--- a/src/codegen_match.cpp
+++ b/src/codegen_match.cpp
@@ -458,33 +458,6 @@ llvm::Value *CodeGen::emitPatternTest(const Pattern &pattern,
     return testResult;
 }
 
-// Extract the Nth type argument (0-indexed) from a generic type string like
-// "Option<T>", "T?" (OptionalType shorthand for Option<T>), or "Result<T, E>".
-// Returns "" when the string does not start with `prefix` or the index is out
-// of range.  Delegates to splitTypeArgs so that both angle-bracket and
-// parenthesis depth are tracked correctly (handles function types such as
-// "Option<(int, str) -> bool>").
-static std::string extractGenericTypeArg(const std::string &typeStr,
-                                          const std::string &prefix,
-                                          size_t argIdx) {
-    // T? suffix is OptionalType::toString() shorthand for Option<T> (#1003, #1015).
-    // Only Option has a shorthand form; Result<T, E> does not.
-    if (prefix == "Option<" && typeStr.size() > 1 && typeStr.back() == '?') {
-        if (argIdx != 0)
-            return {};
-        return ry::util::trimTypeNameSpaces(typeStr.substr(0, typeStr.size() - 1));
-    }
-    if (typeStr.size() <= prefix.size() ||
-        typeStr.compare(0, prefix.size(), prefix) != 0 ||
-        typeStr.back() != '>')
-        return {};
-    const std::string inner = typeStr.substr(prefix.size(),
-                                              typeStr.size() - prefix.size() - 1);
-    const auto parts = CodeGen::splitTypeArgs(inner);
-    if (argIdx >= parts.size()) return {};
-    return ry::util::trimTypeNameSpaces(parts[argIdx]);
-}
-
 void CodeGen::maybeRegisterTaggedUnionSubject(llvm::AllocaInst *subjectAlloca,
                                                 llvm::Type *subjectTy,
                                                 const std::string &subjectEnumName) {
@@ -580,7 +553,7 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 const std::string lookupName = !subjectSourceName.empty()
                     ? subjectSourceName
                     : resolveTypeAlias(subjectEnumName);
-                const std::string innerSig = extractGenericTypeArg(lookupName, "Option<", 0);
+                const std::string innerSig = ry::util::extractGenericTypeArg(lookupName, "Option<", 0);
                 if (!innerSig.empty())
                     propagateTypeMeta(innerSig, varAlloca);
                 else
@@ -600,7 +573,7 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 const std::string lookupName = !subjectSourceName.empty()
                     ? subjectSourceName
                     : resolveTypeAlias(subjectEnumName);
-                const std::string innerSig = extractGenericTypeArg(lookupName, "Result<", 0);
+                const std::string innerSig = ry::util::extractGenericTypeArg(lookupName, "Result<", 0);
                 if (!innerSig.empty())
                     propagateTypeMeta(innerSig, varAlloca);
                 else
@@ -626,7 +599,7 @@ void CodeGen::emitPatternBindings(const Pattern &pattern,
                 const std::string lookupName = !subjectSourceName.empty()
                     ? subjectSourceName
                     : resolveTypeAlias(subjectEnumName);
-                const std::string innerSig = extractGenericTypeArg(lookupName, "Result<", 1);
+                const std::string innerSig = ry::util::extractGenericTypeArg(lookupName, "Result<", 1);
                 if (!innerSig.empty())
                     propagateTypeMeta(innerSig, varAlloca);
                 else
@@ -1043,32 +1016,12 @@ llvm::Value *CodeGen::emitExprVariant(const std::unique_ptr<CaseExpr> &e) {
 // ===== Union type helpers =====
 
 std::vector<std::string> CodeGen::parseUnionComponents(const std::string &typeName) {
-    std::vector<std::string> components;
-    size_t sepCount = 0;
-    for (size_t p = 0; (p = typeName.find(" | ", p)) != std::string::npos; p += 3)
-        ++sepCount;
-    components.reserve(sepCount + 1);
-    size_t start = 0;
-    while (start < typeName.size()) {
-        size_t pos = typeName.find(" | ", start);
-        if (pos == std::string::npos) {
-            std::string comp = typeName.substr(start);
-            size_t s = comp.find_first_not_of(' ');
-            size_t e = comp.find_last_not_of(' ');
-            if (s != std::string::npos)
-                components.push_back(comp.substr(s, e - s + 1));
-            break;
-        }
-        std::string comp = typeName.substr(start, pos - start);
-        size_t s = comp.find_first_not_of(' ');
-        size_t e = comp.find_last_not_of(' ');
-        if (s != std::string::npos)
-            components.push_back(comp.substr(s, e - s + 1));
-        start = pos + 3;
-    }
-    return components;
+    return ry::util::parseUnionComponents(typeName);
 }
 
+// Local helper retained for flattenUnionWithAliases which assembles an
+// already-parsed component list. ry::util::normalizeUnionType would
+// re-parse the string; this avoids that round-trip.
 static std::string joinSortedUnion(std::vector<std::string> &components) {
     std::sort(components.begin(), components.end());
     std::string result;
@@ -1080,8 +1033,7 @@ static std::string joinSortedUnion(std::vector<std::string> &components) {
 }
 
 std::string CodeGen::normalizeUnionType(const std::string &typeName) {
-    auto components = parseUnionComponents(typeName);
-    return joinSortedUnion(components);
+    return ry::util::normalizeUnionType(typeName);
 }
 
 bool CodeGen::isUnionType(const std::string &typeName) {

--- a/src/codegen_test.cpp
+++ b/src/codegen_test.cpp
@@ -1565,28 +1565,9 @@ void CodeGen::emitNativeMockReturnValueOnceCall(
 
 // ===== Test: mockReturnValueOnce — per-call value-return queue (#1681) =====
 //
-// Local helper: strip "Option<" or "Result<" prefix and trailing '>', return
-// the nth comma-separated type argument (paren-aware). Mirrors the static
-// helper in codegen_match.cpp but lives here to avoid leaking a private TU
-// symbol. Used to recover the Ok / Err / Some inner type names for retain /
-// release dispatch on tagged-union return types.
-static std::string vretExtractGenericArg(const std::string &typeStr,
-                                          const std::string &prefix,
-                                          size_t argIdx) {
-    if (prefix == "Option<" && typeStr.size() > 1 && typeStr.back() == '?') {
-        if (argIdx != 0) return {};
-        return ry::util::trimTypeNameSpaces(typeStr.substr(0, typeStr.size() - 1));
-    }
-    if (typeStr.size() <= prefix.size() ||
-        typeStr.compare(0, prefix.size(), prefix) != 0 ||
-        typeStr.back() != '>')
-        return {};
-    const std::string inner = typeStr.substr(prefix.size(),
-                                              typeStr.size() - prefix.size() - 1);
-    const auto parts = CodeGen::splitTypeArgs(inner);
-    if (argIdx >= parts.size()) return {};
-    return ry::util::trimTypeNameSpaces(parts[argIdx]);
-}
+// (Previously had a static `vretExtractGenericArg` helper here that
+// mirrored an identical clone in codegen_match.cpp; both were
+// consolidated into ry::util::extractGenericTypeArg by #1821.)
 
 void CodeGen::retainValueReturnResult(llvm::Value *val,
                                        llvm::Type *retTy,
@@ -1616,9 +1597,9 @@ void CodeGen::retainValueReturnResult(llvm::Value *val,
                      || (!resolved.empty() && resolved.back() == '?');
         if (!isResult && !isOption) return;
 
-        std::string okName  = isResult ? vretExtractGenericArg(resolved, "Result<", 0)
-                                       : vretExtractGenericArg(resolved, "Option<", 0);
-        std::string errName = isResult ? vretExtractGenericArg(resolved, "Result<", 1) : "";
+        std::string okName  = isResult ? ry::util::extractGenericTypeArg(resolved, "Result<", 0)
+                                       : ry::util::extractGenericTypeArg(resolved, "Option<", 0);
+        std::string errName = isResult ? ry::util::extractGenericTypeArg(resolved, "Result<", 1) : "";
 
         auto *tag = builder_.CreateExtractValue(val, {0}, "vret.retain.tag");
         auto *isOk = builder_.CreateICmpEQ(tag,
@@ -1689,9 +1670,9 @@ void CodeGen::releaseValueReturnResult(llvm::Value *val,
                      || (!resolved.empty() && resolved.back() == '?');
         if (!isResult && !isOption) return;
 
-        std::string okName  = isResult ? vretExtractGenericArg(resolved, "Result<", 0)
-                                       : vretExtractGenericArg(resolved, "Option<", 0);
-        std::string errName = isResult ? vretExtractGenericArg(resolved, "Result<", 1) : "";
+        std::string okName  = isResult ? ry::util::extractGenericTypeArg(resolved, "Result<", 0)
+                                       : ry::util::extractGenericTypeArg(resolved, "Option<", 0);
+        std::string errName = isResult ? ry::util::extractGenericTypeArg(resolved, "Result<", 1) : "";
 
         auto *tag = builder_.CreateExtractValue(val, {0}, "vret.rel.tag");
         auto *isOk = builder_.CreateICmpEQ(tag,

--- a/src/codegen_type.cpp
+++ b/src/codegen_type.cpp
@@ -407,24 +407,7 @@ std::string CodeGen::substituteTypeParamsInName(const std::string &typeName) {
 }
 
 std::vector<std::string> CodeGen::splitTypeArgs(const std::string &argsStr) {
-    std::vector<std::string> typeArgs;
-    std::string curr;
-    int angleBrackets = 0;
-    int parens = 0;
-    for (char c : argsStr) {
-        if (c == '<') angleBrackets++;
-        else if (c == '>') angleBrackets--;
-        else if (c == '(') parens++;
-        else if (c == ')') parens--;
-        else if (c == ',' && angleBrackets == 0 && parens == 0) {
-            typeArgs.push_back(curr);
-            curr.clear();
-            continue;
-        }
-        curr += c;
-    }
-    if (!curr.empty()) typeArgs.push_back(curr);
-    return typeArgs;
+    return ry::util::splitTypeArgs(argsStr);
 }
 
 std::pair<llvm::Type*, llvm::Type*> CodeGen::parseMapTypeAnnotation(const std::string &typeStr) {
@@ -447,15 +430,7 @@ llvm::Type *CodeGen::getThreadResultType(llvm::Value *threadVal) {
 }
 
 size_t CodeGen::findMatchingCloseParen(const std::string &s, size_t openParen) {
-    if (openParen >= s.size() || s[openParen] != '(')
-        return std::string::npos;
-    int depth = 1;
-    for (size_t i = openParen + 1; i < s.size(); ++i) {
-        if (s[i] == '(') ++depth;
-        else if (s[i] == ')' && --depth == 0)
-            return i;
-    }
-    return std::string::npos;
+    return ry::util::findMatchingCloseParen(s, openParen);
 }
 
 CodeGen::FnTypeInfo CodeGen::parseFnTypeAnnotation(const std::string &typeStr) {
@@ -556,46 +531,19 @@ std::string CodeGen::resolveTypeAlias(const std::string &typeName) {
 }
 
 bool CodeGen::isIntLiteralType(const std::string &typeName) {
-    if (typeName.empty()) return false;
-    size_t start = (typeName[0] == '-') ? 1 : 0;
-    if (start >= typeName.size()) return false;
-    for (size_t i = start; i < typeName.size(); ++i) {
-        if (!std::isdigit(typeName[i])) return false;
-    }
-    return true;
+    return ry::util::isIntLiteralType(typeName);
 }
 
 bool CodeGen::isStrLiteralType(const std::string &typeName) {
-    if (typeName.size() < 2 || typeName.front() != '"' || typeName.back() != '"')
-        return false;
-    // Ensure it's a single quoted string, not a union like "N" | "S"
-    // Check there's exactly one opening and one closing quote
-    size_t quoteCount = 0;
-    for (char c : typeName)
-        if (c == '"') quoteCount++;
-    return quoteCount == 2;
+    return ry::util::isStrLiteralType(typeName);
 }
 
 bool CodeGen::isRangeType(const std::string &typeName) {
-    auto pos = typeName.find("..");
-    if (pos == std::string::npos || pos == 0 || pos == typeName.size() - 2)
-        return false;
-    std::string lo = typeName.substr(0, pos);
-    std::string hi = typeName.substr(pos + 2);
-    return isIntLiteralType(lo) && isIntLiteralType(hi);
+    return ry::util::isRangeType(typeName);
 }
 
 bool CodeGen::isLiteralUnionType(const std::string &typeName) {
-    if (typeName.find(" | ") == std::string::npos) return false;
-    auto components = parseUnionComponents(typeName);
-    if (components.empty()) return false;
-    bool allInt = true, allStr = true;
-    for (auto &c : components) {
-        if (allInt && !isIntLiteralType(c)) allInt = false;
-        if (allStr && !isStrLiteralType(c)) allStr = false;
-        if (!allInt && !allStr) return false;
-    }
-    return allInt || allStr;
+    return ry::util::isLiteralUnionType(typeName);
 }
 
 std::optional<CodeGen::TypeConstraint> CodeGen::parseTypeConstraint(const std::string &typeName) {

--- a/src/util/type_name.cpp
+++ b/src/util/type_name.cpp
@@ -6,20 +6,15 @@
 namespace ry {
 namespace util {
 
-namespace {
+std::string trimTypeNameSpaces(const std::string &s) {
+    size_t b = 0;
+    while (b < s.size() && s[b] == ' ') ++b;
+    size_t e = s.size();
+    while (e > b && s[e - 1] == ' ') --e;
+    return s.substr(b, e - b);
+}
 
-// trimWs / splitTopLevelCommas are intentionally duplicated from the
-// file-local statics in src/codegen_fn_generic.cpp where they support
-// splitTupleTypeName / splitFunctionTypeName. Consolidation is deferred
-// per #1820's scoped extraction (those siblings remain file-local
-// because they are out of scope for the v0.0.26 stage 2 cleanup).
-
-// Local ASCII-whitespace trim used by splitGenericTypeName and
-// splitTopLevelCommas. Differs from trimTypeNameSpaces (which trims
-// only ' ') because the type-name splitters consume strings from
-// TypeNode::toString() that may contain tabs/newlines on malformed
-// inputs.
-std::string trimWs(const std::string &s) {
+std::string trimTypeNameWhitespace(const std::string &s) {
     size_t a = 0;
     size_t b = s.size();
     while (a < b && std::isspace(static_cast<unsigned char>(s[a]))) ++a;
@@ -27,8 +22,6 @@ std::string trimWs(const std::string &s) {
     return s.substr(a, b - a);
 }
 
-// Split `body` on top-level commas, honoring nesting of <, >, (, ),
-// [, ]. Used by splitGenericTypeName for the inner argument list.
 std::vector<std::string> splitTopLevelCommas(const std::string &body) {
     std::vector<std::string> out;
     out.reserve(static_cast<size_t>(std::count(body.begin(), body.end(), ',')) + 1);
@@ -41,32 +34,224 @@ std::vector<std::string> splitTopLevelCommas(const std::string &body) {
         } else if (c == '>' || c == ')' || c == ']') {
             if (depth > 0) depth--;
         } else if (c == ',' && depth == 0) {
-            out.push_back(trimWs(body.substr(start, i - start)));
+            out.push_back(trimTypeNameWhitespace(body.substr(start, i - start)));
             start = i + 1;
         }
     }
-    out.push_back(trimWs(body.substr(start)));
+    out.push_back(trimTypeNameWhitespace(body.substr(start)));
     return out;
 }
 
-}  // namespace
+std::vector<std::string> splitTypeArgs(const std::string &argsStr) {
+    std::vector<std::string> typeArgs;
+    std::string curr;
+    int angleBrackets = 0;
+    int parens = 0;
+    for (char c : argsStr) {
+        if (c == '<') angleBrackets++;
+        else if (c == '>') angleBrackets--;
+        else if (c == '(') parens++;
+        else if (c == ')') parens--;
+        else if (c == ',' && angleBrackets == 0 && parens == 0) {
+            typeArgs.push_back(curr);
+            curr.clear();
+            continue;
+        }
+        curr += c;
+    }
+    if (!curr.empty()) typeArgs.push_back(curr);
+    return typeArgs;
+}
 
-std::string trimTypeNameSpaces(const std::string &s) {
-    size_t b = 0;
-    while (b < s.size() && s[b] == ' ') ++b;
-    size_t e = s.size();
-    while (e > b && s[e - 1] == ' ') --e;
-    return s.substr(b, e - b);
+std::size_t findMatchingCloseParen(const std::string &s, std::size_t openParen) {
+    if (openParen >= s.size() || s[openParen] != '(')
+        return std::string::npos;
+    int depth = 1;
+    for (std::size_t i = openParen + 1; i < s.size(); ++i) {
+        if (s[i] == '(') ++depth;
+        else if (s[i] == ')' && --depth == 0)
+            return i;
+    }
+    return std::string::npos;
+}
+
+std::vector<std::string> parseUnionComponents(const std::string &typeName) {
+    std::vector<std::string> components;
+    size_t sepCount = 0;
+    for (size_t p = 0; (p = typeName.find(" | ", p)) != std::string::npos; p += 3)
+        ++sepCount;
+    components.reserve(sepCount + 1);
+    size_t start = 0;
+    while (start < typeName.size()) {
+        size_t pos = typeName.find(" | ", start);
+        if (pos == std::string::npos) {
+            std::string comp = typeName.substr(start);
+            size_t s = comp.find_first_not_of(' ');
+            size_t e = comp.find_last_not_of(' ');
+            if (s != std::string::npos)
+                components.push_back(comp.substr(s, e - s + 1));
+            break;
+        }
+        std::string comp = typeName.substr(start, pos - start);
+        size_t s = comp.find_first_not_of(' ');
+        size_t e = comp.find_last_not_of(' ');
+        if (s != std::string::npos)
+            components.push_back(comp.substr(s, e - s + 1));
+        start = pos + 3;
+    }
+    return components;
+}
+
+std::string normalizeUnionType(const std::string &typeName) {
+    auto components = parseUnionComponents(typeName);
+    std::sort(components.begin(), components.end());
+    std::string result;
+    for (size_t i = 0; i < components.size(); ++i) {
+        if (i > 0) result += " | ";
+        result += components[i];
+    }
+    return result;
+}
+
+bool isIntLiteralType(const std::string &typeName) {
+    if (typeName.empty()) return false;
+    size_t start = (typeName[0] == '-') ? 1 : 0;
+    if (start >= typeName.size()) return false;
+    for (size_t i = start; i < typeName.size(); ++i) {
+        if (!std::isdigit(static_cast<unsigned char>(typeName[i]))) return false;
+    }
+    return true;
+}
+
+bool isStrLiteralType(const std::string &typeName) {
+    if (typeName.size() < 2 || typeName.front() != '"' || typeName.back() != '"')
+        return false;
+    // Ensure it's a single quoted string, not a union like "N" | "S"
+    size_t quoteCount = 0;
+    for (char c : typeName)
+        if (c == '"') quoteCount++;
+    return quoteCount == 2;
+}
+
+bool isRangeType(const std::string &typeName) {
+    auto pos = typeName.find("..");
+    if (pos == std::string::npos || pos == 0 || pos == typeName.size() - 2)
+        return false;
+    std::string lo = typeName.substr(0, pos);
+    std::string hi = typeName.substr(pos + 2);
+    return isIntLiteralType(lo) && isIntLiteralType(hi);
+}
+
+bool isLiteralUnionType(const std::string &typeName) {
+    if (typeName.find(" | ") == std::string::npos) return false;
+    auto components = parseUnionComponents(typeName);
+    if (components.empty()) return false;
+    bool allInt = true, allStr = true;
+    for (auto &c : components) {
+        if (allInt && !isIntLiteralType(c)) allInt = false;
+        if (allStr && !isStrLiteralType(c)) allStr = false;
+        if (!allInt && !allStr) return false;
+    }
+    return allInt || allStr;
+}
+
+bool isCollectionTypeName(const std::string &typeName) {
+    return isListTypeName(typeName) || isMapTypeName(typeName) || isSetTypeName(typeName);
+}
+
+std::string weakInnerTypeName(const std::string &typeName) {
+    return typeName.substr(5);
+}
+
+std::string extractMapKeyTypeName(const std::string &mapTypeName) {
+    std::string inner = mapTypeName.substr(4, mapTypeName.size() - 5);
+    auto parts = splitTypeArgs(inner);
+    if (parts.size() != 2) return "";
+    return trimTypeNameSpaces(parts[0]);
+}
+
+std::string extractMapValueTypeName(const std::string &mapTypeName) {
+    std::string inner = mapTypeName.substr(4, mapTypeName.size() - 5);
+    auto parts = splitTypeArgs(inner);
+    if (parts.size() != 2) return "";
+    return trimTypeNameSpaces(parts[1]);
+}
+
+bool isUnsignedLowLevelName(const std::string &name) {
+    return !name.empty() && name[0] == 'u';
+}
+
+bool splitTupleTypeName(const std::string &s, std::vector<std::string> &elements) {
+    std::string t = trimTypeNameWhitespace(s);
+    if (t.size() < 2 || t.front() != '(' || t.back() != ')') return false;
+    std::string body = t.substr(1, t.size() - 2);
+    // Single-element tuples spell as "(x,)" — drop the empty trailing slice.
+    elements = splitTopLevelCommas(body);
+    if (!elements.empty() && elements.back().empty())
+        elements.pop_back();
+    return true;
+}
+
+std::string extractGenericTypeArg(const std::string &typeStr,
+                                  const std::string &prefix,
+                                  std::size_t argIdx) {
+    // T? suffix is OptionalType::toString() shorthand for Option<T>
+    // (#1003, #1015). Only Option has a shorthand form; Result<T, E>
+    // does not.
+    if (prefix == "Option<" && typeStr.size() > 1 && typeStr.back() == '?') {
+        if (argIdx != 0)
+            return {};
+        return trimTypeNameSpaces(typeStr.substr(0, typeStr.size() - 1));
+    }
+    if (typeStr.size() <= prefix.size() ||
+        typeStr.compare(0, prefix.size(), prefix) != 0 ||
+        typeStr.back() != '>')
+        return {};
+    const std::string inner = typeStr.substr(prefix.size(),
+                                              typeStr.size() - prefix.size() - 1);
+    const auto parts = splitTypeArgs(inner);
+    if (argIdx >= parts.size()) return {};
+    return trimTypeNameSpaces(parts[argIdx]);
+}
+
+bool splitFunctionTypeName(const std::string &s,
+                           std::vector<std::string> &params,
+                           std::string &returnType) {
+    std::string t = trimTypeNameWhitespace(s);
+    if (t.rfind("fn(", 0) != 0)
+        return false;
+    const std::string prefix = "fn(";
+    int depth = 1;
+    size_t i = prefix.size();
+    for (; i < t.size() && depth > 0; ++i) {
+        if (t[i] == '(') depth++;
+        else if (t[i] == ')') depth--;
+        if (depth == 0) break;
+    }
+    if (depth != 0) return false;
+    std::string body = t.substr(prefix.size(), i - prefix.size());
+    params = splitTopLevelCommas(body);
+    if (params.size() == 1 && params[0].empty()) params.clear();
+    size_t j = i + 1;
+    while (j < t.size() && std::isspace(static_cast<unsigned char>(t[j]))) ++j;
+    if (j < t.size() && t[j] == '-' && j + 1 < t.size() && t[j + 1] == '>') {
+        j += 2;
+        while (j < t.size() && std::isspace(static_cast<unsigned char>(t[j]))) ++j;
+        returnType = trimTypeNameWhitespace(t.substr(j));
+    } else {
+        returnType.clear();
+    }
+    return true;
 }
 
 bool splitGenericTypeName(const std::string &s,
                           std::string &head,
                           std::vector<std::string> &inner) {
-    std::string t = trimWs(s);
+    std::string t = trimTypeNameWhitespace(s);
     size_t lt = t.find('<');
     if (lt == std::string::npos) return false;
     if (t.back() != '>') return false;
-    head = trimWs(t.substr(0, lt));
+    head = trimTypeNameWhitespace(t.substr(0, lt));
     std::string body = t.substr(lt + 1, t.size() - lt - 2);
     inner = splitTopLevelCommas(body);
     return true;

--- a/tests/test_util_type_name.cpp
+++ b/tests/test_util_type_name.cpp
@@ -12,14 +12,338 @@ using ry::util::isMapTypeName;
 using ry::util::isSetTypeName;
 using ry::util::isWeakTypeName;
 using ry::util::nativeSigKey;
+using ry::util::extractGenericTypeArg;
+using ry::util::extractMapKeyTypeName;
+using ry::util::extractMapValueTypeName;
+using ry::util::findMatchingCloseParen;
+using ry::util::isCollectionTypeName;
+using ry::util::isIntLiteralType;
+using ry::util::isLiteralUnionType;
+using ry::util::isRangeType;
+using ry::util::isStrLiteralType;
+using ry::util::isUnsignedLowLevelName;
+using ry::util::normalizeUnionType;
+using ry::util::parseUnionComponents;
+using ry::util::splitFunctionTypeName;
 using ry::util::splitGenericTypeName;
+using ry::util::splitTopLevelCommas;
+using ry::util::splitTupleTypeName;
+using ry::util::splitTypeArgs;
 using ry::util::trimTypeNameSpaces;
+using ry::util::trimTypeNameWhitespace;
+using ry::util::weakInnerTypeName;
 
 TEST(UtilTypeName, TrimTypeNameSpacesStripsLeadingTrailingSpacesOnly) {
     EXPECT_EQ(trimTypeNameSpaces("  int  "), "int");
     EXPECT_EQ(trimTypeNameSpaces("int"), "int");
     EXPECT_EQ(trimTypeNameSpaces(""), "");
     EXPECT_EQ(trimTypeNameSpaces("a b"), "a b");
+}
+
+TEST(UtilTypeName, TrimTypeNameWhitespaceTrimsAllIsspaceChars) {
+    // Distinct from trimTypeNameSpaces: covers tab, CR, LF, VT, FF.
+    EXPECT_EQ(trimTypeNameWhitespace("\tint\t"), "int");
+    EXPECT_EQ(trimTypeNameWhitespace("\nint\n"), "int");
+    EXPECT_EQ(trimTypeNameWhitespace("\r\n int \r\n"), "int");
+    EXPECT_EQ(trimTypeNameWhitespace("  int  "), "int");
+    EXPECT_EQ(trimTypeNameWhitespace(""), "");
+    // Internal whitespace preserved.
+    EXPECT_EQ(trimTypeNameWhitespace("a\tb"), "a\tb");
+}
+
+TEST(UtilTypeName, SplitTypeArgsTracksAngleAndParenDepth) {
+    auto parts = splitTypeArgs("int,str");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], "int");
+    EXPECT_EQ(parts[1], "str");
+
+    // Nested generic: inner comma is at angle-depth 1, not top-level.
+    parts = splitTypeArgs("Map<str,int>,List<bool>");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], "Map<str,int>");
+    EXPECT_EQ(parts[1], "List<bool>");
+
+    // Tuple (paren depth): inner comma at paren-depth 1 is not top-level.
+    parts = splitTypeArgs("(int,str),bool");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], "(int,str)");
+    EXPECT_EQ(parts[1], "bool");
+
+    // Empty input: returns empty vector (NOT 1-element vector — differs
+    // from splitTopLevelCommas which returns ["" ] for empty body).
+    parts = splitTypeArgs("");
+    EXPECT_TRUE(parts.empty());
+
+    // Elements NOT trimmed (callers apply trim explicitly).
+    parts = splitTypeArgs(" int , str ");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], " int ");
+    EXPECT_EQ(parts[1], " str ");
+}
+
+TEST(UtilTypeName, ParseUnionComponentsSplitsOnPipeWithSpaceTrim) {
+    auto parts = parseUnionComponents("int | str | bool");
+    ASSERT_EQ(parts.size(), 3u);
+    EXPECT_EQ(parts[0], "int");
+    EXPECT_EQ(parts[1], "str");
+    EXPECT_EQ(parts[2], "bool");
+
+    // Single-component "union" returns 1-element vector.
+    parts = parseUnionComponents("int");
+    ASSERT_EQ(parts.size(), 1u);
+    EXPECT_EQ(parts[0], "int");
+
+    // Leading/trailing whitespace inside components is trimmed.
+    parts = parseUnionComponents("  int  |  str  ");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], "int");
+    EXPECT_EQ(parts[1], "str");
+
+    // Empty input: returns empty vector.
+    parts = parseUnionComponents("");
+    EXPECT_TRUE(parts.empty());
+}
+
+TEST(UtilTypeName, NormalizeUnionTypeSortsComponentsAlphabetically) {
+    EXPECT_EQ(normalizeUnionType("str | int | bool"), "bool | int | str");
+    EXPECT_EQ(normalizeUnionType("int"), "int");
+    EXPECT_EQ(normalizeUnionType("\"N\" | \"S\" | \"E\" | \"W\""),
+              "\"E\" | \"N\" | \"S\" | \"W\"");
+}
+
+TEST(UtilTypeName, IsIntLiteralTypeAcceptsDigitsAndOptionalSign) {
+    EXPECT_TRUE(isIntLiteralType("0"));
+    EXPECT_TRUE(isIntLiteralType("42"));
+    EXPECT_TRUE(isIntLiteralType("-1"));
+    EXPECT_TRUE(isIntLiteralType("12345"));
+    EXPECT_FALSE(isIntLiteralType(""));
+    EXPECT_FALSE(isIntLiteralType("-"));
+    EXPECT_FALSE(isIntLiteralType("1a"));
+    EXPECT_FALSE(isIntLiteralType("1.5"));
+    EXPECT_FALSE(isIntLiteralType("int"));
+}
+
+TEST(UtilTypeName, IsStrLiteralTypeRequiresExactlyTwoQuotes) {
+    EXPECT_TRUE(isStrLiteralType("\"N\""));
+    EXPECT_TRUE(isStrLiteralType("\"hello\""));
+    EXPECT_TRUE(isStrLiteralType("\"\""));
+    // Union of literals has 4 quotes — must be rejected.
+    EXPECT_FALSE(isStrLiteralType("\"A\" | \"B\""));
+    EXPECT_FALSE(isStrLiteralType("\""));
+    EXPECT_FALSE(isStrLiteralType(""));
+    EXPECT_FALSE(isStrLiteralType("str"));
+    EXPECT_FALSE(isStrLiteralType("'N'"));  // single-quote not accepted
+}
+
+TEST(UtilTypeName, IsRangeTypeRequiresIntLiteralOnBothSides) {
+    EXPECT_TRUE(isRangeType("1..12"));
+    EXPECT_TRUE(isRangeType("-5..5"));
+    EXPECT_TRUE(isRangeType("0..100"));
+    // Open-ended rejected.
+    EXPECT_FALSE(isRangeType("1.."));
+    EXPECT_FALSE(isRangeType("..5"));
+    // Triple-dot not supported.
+    EXPECT_FALSE(isRangeType("1..2..3"));
+    // Non-int sides rejected.
+    EXPECT_FALSE(isRangeType("\"a\"..\"z\""));
+    EXPECT_FALSE(isRangeType(""));
+}
+
+TEST(UtilTypeName, IsLiteralUnionTypeAcceptsHomogeneousIntOrStrUnions) {
+    EXPECT_TRUE(isLiteralUnionType("1 | 2 | 3"));
+    EXPECT_TRUE(isLiteralUnionType("\"N\" | \"S\" | \"E\" | \"W\""));
+    EXPECT_TRUE(isLiteralUnionType("-1 | 0 | 1"));
+    // Mixed int + str rejected.
+    EXPECT_FALSE(isLiteralUnionType("1 | \"a\""));
+    // Non-literal components rejected.
+    EXPECT_FALSE(isLiteralUnionType("int | str"));
+    // Single component is NOT a union.
+    EXPECT_FALSE(isLiteralUnionType("\"N\""));
+    EXPECT_FALSE(isLiteralUnionType("1"));
+    EXPECT_FALSE(isLiteralUnionType(""));
+}
+
+TEST(UtilTypeName, ExtractGenericTypeArgHandlesOptionResultAndShorthand) {
+    // Option<T>: idx 0 returns T.
+    EXPECT_EQ(extractGenericTypeArg("Option<int>", "Option<", 0), "int");
+    // Option<T> idx 1 returns "" (no second arg).
+    EXPECT_EQ(extractGenericTypeArg("Option<int>", "Option<", 1), "");
+
+    // T? shorthand: only argIdx==0 returns inner.
+    EXPECT_EQ(extractGenericTypeArg("int?", "Option<", 0), "int");
+    EXPECT_EQ(extractGenericTypeArg("int?", "Option<", 1), "");
+    EXPECT_EQ(extractGenericTypeArg("List<int>?", "Option<", 0), "List<int>");
+
+    // T? shorthand only applies when prefix is "Option<".
+    EXPECT_EQ(extractGenericTypeArg("int?", "Result<", 0), "");
+
+    // Result<T, E>: idx 0 = T, idx 1 = E.
+    EXPECT_EQ(extractGenericTypeArg("Result<int, str>", "Result<", 0), "int");
+    EXPECT_EQ(extractGenericTypeArg("Result<int, str>", "Result<", 1), "str");
+    EXPECT_EQ(extractGenericTypeArg("Result<int, str>", "Result<", 2), "");
+
+    // Nested generic + paren-aware: Option<(int, str) -> bool>.
+    EXPECT_EQ(extractGenericTypeArg("Option<(int, str) -> bool>", "Option<", 0),
+              "(int, str) -> bool");
+
+    // Mismatched prefix returns "".
+    EXPECT_EQ(extractGenericTypeArg("Option<int>", "Result<", 0), "");
+    EXPECT_EQ(extractGenericTypeArg("int", "Option<", 0), "");
+
+    // Empty / minimal inputs.
+    EXPECT_EQ(extractGenericTypeArg("", "Option<", 0), "");
+    EXPECT_EQ(extractGenericTypeArg("Option<>", "Option<", 0), "");
+}
+
+TEST(UtilTypeName, IsCollectionTypeNameUnionsListMapSet) {
+    EXPECT_TRUE(isCollectionTypeName("List<int>"));
+    EXPECT_TRUE(isCollectionTypeName("Map<str, int>"));
+    EXPECT_TRUE(isCollectionTypeName("Set<int>"));
+    EXPECT_FALSE(isCollectionTypeName("int"));
+    EXPECT_FALSE(isCollectionTypeName("weak List<int>"));
+    EXPECT_FALSE(isCollectionTypeName(""));
+}
+
+TEST(UtilTypeName, WeakInnerTypeNameStripsLeadingFiveChars) {
+    EXPECT_EQ(weakInnerTypeName("weak str"), "str");
+    EXPECT_EQ(weakInnerTypeName("weak List<int>"), "List<int>");
+    EXPECT_EQ(weakInnerTypeName("weak MyRecord"), "MyRecord");
+}
+
+TEST(UtilTypeName, ExtractMapKeyAndValueTypeNamesParseInner) {
+    EXPECT_EQ(extractMapKeyTypeName("Map<str, int>"), "str");
+    EXPECT_EQ(extractMapValueTypeName("Map<str, int>"), "int");
+    EXPECT_EQ(extractMapKeyTypeName("Map<List<int>, str>"), "List<int>");
+    EXPECT_EQ(extractMapValueTypeName("Map<List<int>, str>"), "str");
+    // Malformed (not 2 parts) returns empty.
+    EXPECT_EQ(extractMapKeyTypeName("Map<int>"), "");
+    EXPECT_EQ(extractMapValueTypeName("Map<int>"), "");
+}
+
+TEST(UtilTypeName, IsUnsignedLowLevelNameTreatsUPrefixAsUnsigned) {
+    EXPECT_TRUE(isUnsignedLowLevelName("u8"));
+    EXPECT_TRUE(isUnsignedLowLevelName("u16"));
+    EXPECT_TRUE(isUnsignedLowLevelName("u32"));
+    EXPECT_TRUE(isUnsignedLowLevelName("u64"));
+    EXPECT_FALSE(isUnsignedLowLevelName("i8"));
+    EXPECT_FALSE(isUnsignedLowLevelName("i64"));
+    EXPECT_FALSE(isUnsignedLowLevelName("f32"));
+    EXPECT_FALSE(isUnsignedLowLevelName("int"));
+    EXPECT_FALSE(isUnsignedLowLevelName(""));
+}
+
+TEST(UtilTypeName, SplitTupleTypeNameParsesParenForm) {
+    std::vector<std::string> elems;
+
+    EXPECT_TRUE(splitTupleTypeName("(int, str)", elems));
+    ASSERT_EQ(elems.size(), 2u);
+    EXPECT_EQ(elems[0], "int");
+    EXPECT_EQ(elems[1], "str");
+
+    // Single-element tuple "(T,)" yields 1 element (trailing empty dropped).
+    EXPECT_TRUE(splitTupleTypeName("(int,)", elems));
+    ASSERT_EQ(elems.size(), 1u);
+    EXPECT_EQ(elems[0], "int");
+
+    // Nested generic inside tuple.
+    EXPECT_TRUE(splitTupleTypeName("(Map<str, int>, List<bool>)", elems));
+    ASSERT_EQ(elems.size(), 2u);
+    EXPECT_EQ(elems[0], "Map<str, int>");
+    EXPECT_EQ(elems[1], "List<bool>");
+
+    // Not parenthesized.
+    EXPECT_FALSE(splitTupleTypeName("int, str", elems));
+    EXPECT_FALSE(splitTupleTypeName("", elems));
+    // Empty tuple "()" is accepted (legacy behavior — yields empty elems).
+    EXPECT_TRUE(splitTupleTypeName("()", elems));
+    EXPECT_TRUE(elems.empty());
+}
+
+TEST(UtilTypeName, SplitFunctionTypeNameParsesFnForm) {
+    std::vector<std::string> params;
+    std::string ret;
+
+    EXPECT_TRUE(splitFunctionTypeName("fn(int, str) -> bool", params, ret));
+    ASSERT_EQ(params.size(), 2u);
+    EXPECT_EQ(params[0], "int");
+    EXPECT_EQ(params[1], "str");
+    EXPECT_EQ(ret, "bool");
+
+    // No params.
+    EXPECT_TRUE(splitFunctionTypeName("fn() -> int", params, ret));
+    EXPECT_TRUE(params.empty());
+    EXPECT_EQ(ret, "int");
+
+    // No return type.
+    EXPECT_TRUE(splitFunctionTypeName("fn(int)", params, ret));
+    ASSERT_EQ(params.size(), 1u);
+    EXPECT_EQ(params[0], "int");
+    EXPECT_EQ(ret, "");
+
+    // Not fn shape.
+    EXPECT_FALSE(splitFunctionTypeName("int", params, ret));
+    EXPECT_FALSE(splitFunctionTypeName("(int) -> bool", params, ret));  // no "fn"
+}
+
+TEST(UtilTypeName, FindMatchingCloseParenWalksParenDepth) {
+    // Simple match.
+    EXPECT_EQ(findMatchingCloseParen("()", 0), 1u);
+    EXPECT_EQ(findMatchingCloseParen("(int)", 0), 4u);
+
+    // Nested parens.
+    EXPECT_EQ(findMatchingCloseParen("(fn(int) -> bool)", 0), 16u);
+    EXPECT_EQ(findMatchingCloseParen("(fn(int) -> bool)", 3), 7u);
+
+    // Open paren not at openParen index: returns npos.
+    EXPECT_EQ(findMatchingCloseParen("int", 0), std::string::npos);
+
+    // No matching close: returns npos.
+    EXPECT_EQ(findMatchingCloseParen("(", 0), std::string::npos);
+    EXPECT_EQ(findMatchingCloseParen("(int", 0), std::string::npos);
+
+    // openParen >= s.size(): returns npos.
+    EXPECT_EQ(findMatchingCloseParen("()", 10), std::string::npos);
+}
+
+TEST(UtilTypeName, SplitTopLevelCommasHonorsNestingForAllBracketKinds) {
+    auto parts = splitTopLevelCommas("int, str");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], "int");
+    EXPECT_EQ(parts[1], "str");
+
+    // Angle-bracket nesting: inner ',' is NOT a top-level split.
+    parts = splitTopLevelCommas("Map<str, int>, List<bool>");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], "Map<str, int>");
+    EXPECT_EQ(parts[1], "List<bool>");
+
+    // Paren nesting (fn types).
+    parts = splitTopLevelCommas("fn(int, str) -> bool, int");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], "fn(int, str) -> bool");
+    EXPECT_EQ(parts[1], "int");
+
+    // Bracket nesting (distinguishes from splitTypeArgs).
+    parts = splitTopLevelCommas("a[1, 2], b");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], "a[1, 2]");
+    EXPECT_EQ(parts[1], "b");
+
+    // Single-element body: returns 1-element vector.
+    parts = splitTopLevelCommas("int");
+    ASSERT_EQ(parts.size(), 1u);
+    EXPECT_EQ(parts[0], "int");
+
+    // Empty body: returns 1-element vector with empty string.
+    parts = splitTopLevelCommas("");
+    ASSERT_EQ(parts.size(), 1u);
+    EXPECT_EQ(parts[0], "");
+
+    // Each element is trimmed via trimTypeNameWhitespace.
+    parts = splitTopLevelCommas("  int  ,\tstr\t");
+    ASSERT_EQ(parts.size(), 2u);
+    EXPECT_EQ(parts[0], "int");
+    EXPECT_EQ(parts[1], "str");
 }
 
 TEST(UtilTypeName, SplitGenericTypeNameParsesListAndMap) {


### PR DESCRIPTION
## Summary

- Lift 18 pure typename string helpers from `CodeGen` / file-local statics into `ry::util` as a follow-up to #1820. New entries: `trimTypeNameWhitespace`, `splitTopLevelCommas`, `splitTypeArgs`, `findMatchingCloseParen`, `parseUnionComponents`, `normalizeUnionType`, `isIntLiteralType`, `isStrLiteralType`, `isRangeType`, `isLiteralUnionType`, `isCollectionTypeName`, `weakInnerTypeName`, `extractMapKeyTypeName`, `extractMapValueTypeName`, `isUnsignedLowLevelName`, `splitTupleTypeName`, `splitFunctionTypeName`, `extractGenericTypeArg`.
- Consolidate the byte-identical clone pair `extractGenericTypeArg` (`codegen_match.cpp:467`) ↔ `vretExtractGenericArg` (`codegen_test.cpp:1573`) into a single canonical body — issue's core acceptance criterion. Both file-local statics deleted; 9 caller sites rewired to `ry::util::extractGenericTypeArg`.
- 13 `CodeGen` wrappers retained as 1-line shims (call-site sweep deferred per Proposed Scope's "Keep existing wrapper methods temporarily"); 4 file-local statics in `codegen_fn_generic.cpp` (`trimWs`, `splitTopLevelCommas`, `splitTupleTypeName`, `splitFunctionTypeName`) removed.

## Naming decisions

- `trimTypeNameWhitespace` (full `isspace`) and `trimTypeNameSpaces` (ASCII space only) coexist by design — silently widening would change behavior for inputs containing tabs/newlines.
- `splitTopLevelCommas` (tracks `[]`) and `splitTypeArgs` (does not) coexist by design — caller picks based on whether bracket-typed elements may appear.
- Module/file/function naming confirmed as-is from #1820: `ry::util` namespace, `type_name.hpp/cpp` (avoiding the `typename` C++ keyword), camelCase identifiers.

## Out of scope

- `parseTypeConstraint` stays in `CodeGen` (calls `codegenError`); internal calls updated to use the shimmed predicates.
- `splitEnumLikeName` (codegen_arc.cpp:1765) — incompatible interface; deferred.
- Inline `Result<T, E>` depth-scan blocks at 4 sites (codegen_arc/type/builtin/call_higher_order) — one omits `trimTypeNameSpaces`, so consolidation requires a separate behavior audit.

## Test plan

- [x] `cmake --build build-rust --target ry ry_tests` — clean build, no new warnings
- [x] `./build-rust/ry_tests` — 2745/2745 pass (29 TypeName unit tests including 21 new cases)
- [x] `./build-rust/ry test -p` — 206 spec files, 0 failures
- [x] IR byte-diff against pre-Commit-1 baseline (Map/Result/Option/T?/literal-union/range/weak/tuple/fn/Set probe) — **byte-identical** after ARC counter normalization
- [x] `scan-build` static analysis — No bugs found
- [x] ASan + TSan via Docker — 0 failures

Closes #1821

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated type name parsing utilities into shared components for improved code maintainability and consistency across the codebase.

* **Tests**
  * Expanded test coverage for type name parsing, validation, and generic type extraction utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->