### PR TITLE
refactor: use RAII for local runtime ownership in regex and base64 helpers

### DIFF
--- a/src/runtime/core/regex.cpp
+++ b/src/runtime/core/regex.cpp
@@ -60,29 +60,12 @@ struct NFAFragment {
 
 class NFABuilder {
 public:
-    NFABuilder() = default;
-    ~NFABuilder() {
-        for (auto *s : states_) delete s;
-    }
-    NFABuilder(NFABuilder &&other) noexcept : states_(std::move(other.states_)) {
-        other.states_.clear();
-    }
-    NFABuilder &operator=(NFABuilder &&other) noexcept {
-        if (this != &other) {
-            for (auto *s : states_) delete s;
-            states_ = std::move(other.states_);
-            other.states_.clear();
-        }
-        return *this;
-    }
-    NFABuilder(const NFABuilder &) = delete;
-    NFABuilder &operator=(const NFABuilder &) = delete;
-
     NFAState *newState(NFAState::Kind kind) {
-        auto *s = new NFAState();
-        s->kind = kind;
-        states_.push_back(s);
-        return s;
+        auto state = std::make_unique<NFAState>();
+        state->kind = kind;
+        auto *raw = state.get();
+        states_.push_back(std::move(state));
+        return raw;
     }
 
     // Thompson's construction
@@ -242,7 +225,7 @@ public:
     }
 
 private:
-    std::vector<NFAState *> states_;
+    std::vector<std::unique_ptr<NFAState>> states_;
 };
 
 // ============================================================

--- a/src/runtime/native/base64.cpp
+++ b/src/runtime/native/base64.cpp
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <mutex>
 
 
@@ -72,10 +73,12 @@ static char *base64_encode_impl(const char *input, size_t len, const char *table
     return out;
 }
 
-// Core decode: writes decoded bytes into a heap buffer. Caller must free().
-// Returns nullptr + setLastError on invalid input; writes byte count to *out_len on success.
-static uint8_t *base64_decode_raw(const char *input, size_t len,
-                                   const int8_t *decode_tbl, size_t *out_len) {
+// Core decode: writes decoded bytes into a heap buffer owned by the returned
+// unique_ptr. Returns an empty unique_ptr + setLastError on invalid input;
+// writes byte count to *out_len on success.
+static std::unique_ptr<uint8_t, decltype(&std::free)>
+base64_decode_raw(const char *input, size_t len,
+                  const int8_t *decode_tbl, size_t *out_len) {
     // Validate padding per RFC 4648 §3.2 strict mode. When any '=' padding is
     // present, the total length must be a multiple of 4 and the padding count
     // must be at most 2. Inputs with no padding (e.g. URL-safe canonical form)
@@ -86,16 +89,18 @@ static uint8_t *base64_decode_raw(const char *input, size_t len,
     if (pad_count > 0) {
         if (pad_count > 2) {
             setLastError("invalid base64: excess padding (%zu padding characters)", pad_count);
-            return nullptr;
+            return {nullptr, &std::free};
         }
         if (len % 4 != 0) {
             setLastError("invalid base64: input length must be a multiple of 4 when padding is present");
-            return nullptr;
+            return {nullptr, &std::free};
         }
     }
     len -= pad_count;
 
-    auto *out = (uint8_t *)checked_malloc(len * 3 / 4 + 1);
+    std::unique_ptr<uint8_t, decltype(&std::free)> out(
+        static_cast<uint8_t *>(checked_malloc(len * 3 / 4 + 1)), &std::free);
+    uint8_t *buf = out.get();
     size_t j = 0;
 
     for (size_t i = 0; i < len; ) {
@@ -104,22 +109,20 @@ static uint8_t *base64_decode_raw(const char *input, size_t len,
         for (int k = 0; k < 4 && i < len; k++, i++) {
             int8_t val = decode_tbl[(uint8_t)input[i]];
             if (val < 0) {
-                free(out);
                 setLastError("invalid base64 character at position %zu", i);
-                return nullptr;
+                return {nullptr, &std::free};
             }
             sextet[k] = static_cast<uint32_t>(static_cast<unsigned char>(val));
             count++;
         }
         if (count < 2) {
-            free(out);
             setLastError("invalid base64: truncated input");
-            return nullptr;
+            return {nullptr, &std::free};
         }
         uint32_t triple = (sextet[0] << 18) | (sextet[1] << 12) | (sextet[2] << 6) | sextet[3];
-        if (count >= 2) out[j++] = (uint8_t)((triple >> 16) & 0xFF);
-        if (count >= 3) out[j++] = (uint8_t)((triple >> 8) & 0xFF);
-        if (count >= 4) out[j++] = (uint8_t)(triple & 0xFF);
+        if (count >= 2) buf[j++] = (uint8_t)((triple >> 16) & 0xFF);
+        if (count >= 3) buf[j++] = (uint8_t)((triple >> 8) & 0xFF);
+        if (count >= 4) buf[j++] = (uint8_t)(triple & 0xFF);
     }
     *out_len = j;
     return out;
@@ -127,11 +130,9 @@ static uint8_t *base64_decode_raw(const char *input, size_t len,
 
 static char *base64_decode_impl(const char *input, size_t len, const int8_t *decode_tbl) {
     size_t j;
-    auto *raw = base64_decode_raw(input, len, decode_tbl, &j);
+    auto raw = base64_decode_raw(input, len, decode_tbl, &j);
     if (!raw) return nullptr;
-    char *result = makeString(reinterpret_cast<const char *>(raw), j);
-    free(raw);
-    return result;
+    return makeString(reinterpret_cast<const char *>(raw.get()), j);
 }
 
 // Null/empty input guard shared by all public functions
@@ -192,11 +193,9 @@ extern "C" void *__ry_base64_decode_bytes(const char *input) {
     if (len == 0) return makeEmptyIOList();
     ensure_decode_tables();
     size_t out_len;
-    auto *raw = base64_decode_raw(input, len, std_decode_tbl, &out_len);
+    auto raw = base64_decode_raw(input, len, std_decode_tbl, &out_len);
     if (!raw) return nullptr;
-    IOListHeader *hdr = makeByteList(raw, static_cast<int64_t>(out_len));
-    free(raw);
-    return hdr;
+    return makeByteList(raw.get(), static_cast<int64_t>(out_len));
 }
 
 extern "C" void *__ry_base64_decode_bytes_url_safe(const char *input) {
@@ -205,11 +204,9 @@ extern "C" void *__ry_base64_decode_bytes_url_safe(const char *input) {
     if (len == 0) return makeEmptyIOList();
     ensure_decode_tables();
     size_t out_len;
-    auto *raw = base64_decode_raw(input, len, url_decode_tbl, &out_len);
+    auto raw = base64_decode_raw(input, len, url_decode_tbl, &out_len);
     if (!raw) return nullptr;
-    IOListHeader *hdr = makeByteList(raw, static_cast<int64_t>(out_len));
-    free(raw);
-    return hdr;
+    return makeByteList(raw.get(), static_cast<int64_t>(out_len));
 }
 
 } // namespace ry


### PR DESCRIPTION
## Summary

- `NFABuilder` (`src/runtime/core/regex.cpp`) は `std::vector<std::unique_ptr<NFAState>>` で所有権管理し、自前 dtor / move ops / explicit copy=delete を撤去 (rule-of-zero)。`newState()` は `unique_ptr::get()` 経由で安定した raw pointer を返す。
- `base64_decode_raw()` (`src/runtime/native/base64.cpp`) は `std::unique_ptr<uint8_t, decltype(&std::free)>` を返す。エラー枝 2 箇所 + 呼び出し側 3 箇所の手動 `free()` を RAII で除去 (project 既存 idiom: `parallel.cpp:265,319`, `thread.cpp:136` と一致)。
- public API / runtime ABI / 振る舞いに変化なし。

## Test plan

- [x] Build (`cmake --build build-rust`)
- [x] `./build-rust/ry_tests` 全 2745 tests PASS
- [x] `./build-rust/ry test -p` 全 206 spec files PASS
- [x] ASan + UBSan (Docker): PASS
- [x] TSan (Docker): PASS
- [x] Static analysis (clang-tidy + cppcheck + scan-build, Docker): No bugs found

## Skipped checks (per pre-commit-checklist)

- Docs / changelog: internal refactor、user-visible 振る舞い変化なし
- Fuzz: regex/base64 用 fuzz harness は存在しない (memory-safety は ASan/UBSan/TSan でカバー)
- Rust lint / prompt-refs lint / tree-sitter: 該当ファイル変更なし

Closes #1833