### PR TITLE
refactor(json)!: fold sortKeys into stringify/stringifySafe named arg

### DIFF
--- a/changelog.d/1890-json-stringify-sortkeys.md
+++ b/changelog.d/1890-json-stringify-sortkeys.md
@@ -1,0 +1,7 @@
+### Changed
+
+- `json.stringify` and `json.stringifySafe` now accept a `sortKeys: bool` named argument (default `false`). When `sortKeys=true`, `Map<str, any>` entries — including nested ones — are emitted in byte-lexicographic key order, equivalent to the removed `stringifySorted` / `stringifySortedSafe` functions. The named argument composes with the existing optional `indent` positional, e.g. `stringify(m, sortKeys=true)`, `stringify(m, 2, sortKeys=true)`, `stringifySafe(m, sortKeys=true)`. (#1890)
+
+### Removed
+
+- **Breaking change**: `json.stringifySorted` and `json.stringifySortedSafe` are removed. Migrate `stringifySorted(v)` → `stringify(v, sortKeys=true)` and `stringifySortedSafe(v)` → `stringifySafe(v, sortKeys=true)`; the optional `indent` positional argument still precedes `sortKeys` (`stringifySorted(v, 2)` → `stringify(v, 2, sortKeys=true)`). (#1890)

--- a/docs/reference/json.md
+++ b/docs/reference/json.md
@@ -3,7 +3,7 @@
 JSON parsing and serialization. All functions require explicit import from `json`.
 
 ```ry
-from json import load, stringify, stringifySafe, stringifySorted, stringifySortedSafe, dump
+from json import load, stringify, stringifySafe, dump
 ```
 
 ## Overview
@@ -30,14 +30,8 @@ stringification in a single step.
 |----------|-----------|-------------|
 | `load[T]` | `(str) -> Result<T, Error>` | Parses a JSON string then coerces to `T` (see "Supported `T` in `load[T]`" below). |
 | `load[T]` | `(File) -> Result<T, Error>` | Reads from an open `File` handle, parses, then coerces. Same `T` set as `load[T](str)`. |
-| `stringify` | `(any) -> str` | Serializes an `any` value to compact JSON text. |
-| `stringify` | `(any, int) -> str` | Pretty-prints with `indent` spaces. `indent < 0` falls back to compact form. |
-| `stringifySafe` | `(any) -> Result<str, Error>` | Like `stringify`, but unsupported inputs (non-finite float, typed collection wrapped as `any`, `Set` / record / enum) return `Err(Error)` instead of panicking. |
-| `stringifySafe` | `(any, int) -> Result<str, Error>` | Pretty-printing variant of `stringifySafe`. `indent < 0` falls back to compact form. |
-| `stringifySorted` | `(any) -> str` | Like `stringify`, but `Map<str, any>` entries (including nested ones) are emitted in byte-lexicographic key order so the output is reproducible across runs. Panic semantics match `stringify`. |
-| `stringifySorted` | `(any, int) -> str` | Pretty-printing variant of `stringifySorted`. `indent < 0` falls back to compact form. |
-| `stringifySortedSafe` | `(any) -> Result<str, Error>` | Combines `stringifySafe` and `stringifySorted`: sorted-key output, unsupported inputs surface as `Err(Error)`. |
-| `stringifySortedSafe` | `(any, int) -> Result<str, Error>` | Pretty-printing variant of `stringifySortedSafe`. `indent < 0` falls back to compact form. |
+| `stringify` | `(any[, indent: int][, sortKeys=bool]) -> str` | Serializes an `any` value to JSON. `indent ≥ 0` enables pretty-printing with that many spaces (`indent < 0` falls back to compact form). Named argument `sortKeys=true` (default `false`) emits `Map<str, any>` entries in byte-lexicographic key order. |
+| `stringifySafe` | `(any[, indent: int][, sortKeys=bool]) -> Result<str, Error>` | Like `stringify`, but unsupported inputs (non-finite float, typed collection wrapped as `any`, `Set` / record / enum) return `Err(Error)` instead of panicking. Same positional / named arguments. |
 | `dump` | `(File, any) -> Result<Unit, Error>` | Stringifies `value` compactly and writes to `f`. Equivalent to `io.writeText(f, stringify(value))?`. |
 | `dump` | `(File, any, int) -> Result<Unit, Error>` | Pretty-prints with `indent` spaces and writes to `f`. `indent < 0` falls back to compact form. |
 
@@ -175,23 +169,23 @@ case stringifySafe(m, 2):
   Err(e): print(e.message)
 ```
 
-### `stringifySorted` for reproducible output
+### Sorted output via the `sortKeys` named argument
 
 `stringify` walks `Map<str, any>` in insertion order, which is
-deterministic but depends on how the map was built. `stringifySorted`
-emits keys in byte-lexicographic order (matching Python's
-`json.dumps(sort_keys=True)` for valid UTF-8). Nested maps are sorted
-recursively.
+deterministic but depends on how the map was built. Pass the named
+argument `sortKeys=true` (default `false`) to emit keys in
+byte-lexicographic order (matching Python's `json.dumps(sort_keys=True)`
+for valid UTF-8). Nested maps are sorted recursively.
 
 ```ry
-from json import stringifySorted
+from json import stringify
 
 m: Map<str, any> = {}
 m["c"] = 3
 m["a"] = 1
 m["b"] = 2
-print(stringifySorted(m))           # {"a":1,"b":2,"c":3}
-print(stringifySorted(m, 2))
+print(stringify(m, sortKeys=true))           # {"a":1,"b":2,"c":3}
+print(stringify(m, 2, sortKeys=true))
 # {
 #   "a": 1,
 #   "b": 2,
@@ -199,17 +193,16 @@ print(stringifySorted(m, 2))
 # }
 ```
 
-`stringifySortedSafe` combines both behaviors: sorted output, with
-`Err(Error)` instead of panicking on unsupported inputs.
+Combine with `stringifySafe` for error recovery on unsupported inputs:
 
 ```ry
-from json import stringifySortedSafe
+from json import stringifySafe
 from math import INF
 
 m: Map<str, any> = {}
 m["b"] = 2
 m["a"] = INF
-case stringifySortedSafe(m):
+case stringifySafe(m, sortKeys=true):
   Ok(s): print(s)
   Err(e): print(e.message)
   # stringify: non-finite float cannot be encoded as JSON
@@ -282,20 +275,18 @@ case open("out.json", "w"):
   null) do not contribute to the depth count.
 - `stringify` traverses `Map<str, any>` in **insertion order**. JSON
   itself does not specify object-key ordering, but the encoder is
-  deterministic. Use `stringifySorted` (or `stringifySortedSafe`) when
-  output must be reproducible across runs that build the same logical
-  map via different insertion sequences (snapshot tests, config diffs,
-  content-addressed hashing).
-- `stringify` and `stringifySorted` panic (`exit(1)` with a diagnostic
-  to stderr) when they encounter tags JSON cannot represent:
-  non-finite floats (`NaN`, `±Infinity`), `Set<...>`, records, enums,
-  or maps keyed by anything other than `str`. The return type
-  `-> str` has no `Result` channel, so panic is the only failure mode.
-  Use `stringifySafe` / `stringifySortedSafe` (which return
+  deterministic. Pass `sortKeys=true` when output must be reproducible
+  across runs that build the same logical map via different insertion
+  sequences (snapshot tests, config diffs, content-addressed hashing).
+- `stringify` panics (`exit(1)` with a diagnostic to stderr) when it
+  encounters tags JSON cannot represent: non-finite floats (`NaN`,
+  `±Infinity`), `Set<...>`, records, enums, or maps keyed by anything
+  other than `str`. The return type `-> str` has no `Result` channel,
+  so panic is the only failure mode. Use `stringifySafe` (which returns
   `Result<str, Error>`) when the caller needs to recover instead of
   abort, or convert unsupported values to representable forms before
-  calling the panicking variants.
-- **Runtime error — `stringify(value: any)` / `stringifySorted(value: any)` on typed collections**: the
+  calling the panicking variant.
+- **Runtime error — `stringify(value: any)` on typed collections**: the
   encoder walks the inner `List` / `Map` buffer assuming a uniform `any`
   element stride (16 bytes). `wrapInAny` preserves the original
   collection header pointer, so passing an `any` constructed from a
@@ -303,7 +294,7 @@ case open("out.json", "w"):
   read past valid storage. The runtime detects this case via a
   side-table populated at wrap time and panics with a deterministic
   diagnostic instead (or returns `Err(Error{message})` with the same
-  text under `stringifySafe` / `stringifySortedSafe`):
+  text under `stringifySafe`):
 
   ```text
   stringify: any holds typed collection 'List<int>' — use List<any> / Map<str, any> / Set<any> instead
@@ -369,6 +360,19 @@ case open("out.json", "w"):
   yet cover the reassignment path (`xs = v` after `xs`
   is already declared) or function-boundary `any` passes with
   mismatched element strides — prefer `load[T]` for those cases too.
+- **v0.0.29 breaking change (#1890)**: `stringifySorted` and
+  `stringifySortedSafe` were removed and replaced by a `sortKeys: bool`
+  named argument on `stringify` / `stringifySafe`. Migration:
+
+  | Before (v0.0.28 and earlier) | After (v0.0.29) |
+  |---|---|
+  | `stringifySorted(v)` | `stringify(v, sortKeys=true)` |
+  | `stringifySorted(v, 2)` | `stringify(v, 2, sortKeys=true)` |
+  | `stringifySortedSafe(v)` | `stringifySafe(v, sortKeys=true)` |
+  | `stringifySortedSafe(v, 2)` | `stringifySafe(v, 2, sortKeys=true)` |
+
+  The `indent` positional argument still precedes `sortKeys`.
+  `sortKeys=false` is the explicit default.
 
 ## Error message format
 

--- a/include/ry/runtime/native/json.hpp
+++ b/include/ry/runtime/native/json.hpp
@@ -31,6 +31,18 @@ int64_t __ry_json_parse_to_any(const char *text, RyAny *out);
 // behaviour via spec tests if you depend on it.
 const char *__ry_json_stringify_any(const RyAny *value, int64_t indent_or_neg1);
 
+// Unified stringify with runtime sort_keys flag (#1890). Codegen routes
+// `json.stringify(v, [indent], sortKeys=bool)` through this symbol; the
+// per-name variants above (`_sorted`, `_safe`, `_sorted_safe`) remain to
+// keep direct C++ test callers untouched but are no longer reached from
+// generated IR. sort_keys: 0 = insertion order, non-zero = byte-lex order.
+const char *__ry_json_stringify_any_ex(const RyAny *value,
+                                        int64_t indent_or_neg1,
+                                        uint8_t sort_keys);
+const char *__ry_json_stringify_any_safe_ex(const RyAny *value,
+                                             int64_t indent_or_neg1,
+                                             uint8_t sort_keys);
+
 // Recursively releases a RyAny value produced by `__ry_json_parse_to_any`.
 // Codegen-emitted Ry code uses `emitAnyReleaseVar` instead and never calls
 // this directly. C++ test / fuzz consumers that build a RyAny from C call

--- a/share/std/json/json.ry
+++ b/share/std/json/json.ry
@@ -48,6 +48,15 @@
 # collections / Set / Record / Enum / non-`str` Map keys is inherited by
 # `dump` unchanged.
 
+# `stringify` / `stringifySafe` both accept an optional named argument
+# `sortKeys: bool` (default `false`). When `sortKeys=true`, every
+# `Map<str, any>` (including those nested inside lists or other maps)
+# is emitted in byte-lexicographic key order — reproducible across
+# runs regardless of insertion order. The former `stringifySorted` /
+# `stringifySortedSafe` functions (added in #1853) were folded into
+# this named argument in v0.0.29 (#1890) and removed as a breaking
+# change. Migration: `stringifySorted(v)` → `stringify(v, sortKeys=true)`,
+# `stringifySortedSafe(v, 2)` → `stringifySafe(v, 2, sortKeys=true)`.
 @public
 @native("json")
 fn stringify(value: any) -> str
@@ -68,28 +77,6 @@ fn stringifySafe(value: any) -> Result<str, Error>
 @public
 @native("json")
 fn stringifySafe(value: any, indent: int) -> Result<str, Error>
-
-# Sorted-key variant of `stringify` (#1853). `Map<str, any>` entries
-# (including those nested inside lists / other maps) are emitted in
-# byte-lexicographic key order so the result is reproducible across
-# runs regardless of insertion order. Trap behavior on unsupported
-# inputs matches the existing `stringify` — use `stringifySortedSafe`
-# for the Result-returning equivalent.
-@public
-@native("json")
-fn stringifySorted(value: any) -> str
-
-@public
-@native("json")
-fn stringifySorted(value: any, indent: int) -> str
-
-@public
-@native("json")
-fn stringifySortedSafe(value: any) -> Result<str, Error>
-
-@public
-@native("json")
-fn stringifySortedSafe(value: any, indent: int) -> Result<str, Error>
 
 @public
 @native("json")

--- a/src/codegen_call_json.cpp
+++ b/src/codegen_call_json.cpp
@@ -7,11 +7,13 @@ namespace ry {
 
 // ===== JSON custom emitters (#1698: any-based API; #1887: typed-only load) =====
 
-// Helper for stringify / stringifySafe / stringifySorted / stringifySortedSafe.
-// `runtimeFn`: the C entry point to call. `wrapResult`: whether to wrap the
-// nullable-ptr return in Result<str, Error> via wrapPtrAsResult (Safe variants
-// only). The non-Safe variants pass `wrapResult=false` and return the raw
-// `char*` (ARC string), matching the existing `stringify` contract.
+// Helper for stringify / stringifySafe. Both accept an optional named arg
+// `sortKeys: bool` (default false) that selects byte-lexicographic Map<str,
+// any> key ordering — folded in from the former stringifySorted /
+// stringifySortedSafe variants per #1890. `runtimeFn`: the unified C entry
+// point (__ry_json_stringify_any_ex / __ry_json_stringify_any_safe_ex).
+// `wrapResult`: whether to wrap the nullable-ptr return in Result<str, Error>
+// via wrapPtrAsResult (Safe variants only).
 static llvm::Value *emitJsonStringifyImpl(CodeGen &cg, const CallExpr &e,
                                            const char *runtimeFn,
                                            const char *callName,
@@ -34,38 +36,42 @@ static llvm::Value *emitJsonStringifyImpl(CodeGen &cg, const CallExpr &e,
         if (indent->getType() != cg.i64Ty_)
             cg.codegenError(std::string(e.callee) + "() indent must be an int");
     }
-    llvm::Type *paramTys[] = {cg.ptrTy_, cg.i64Ty_};
+
+    // Named argument: sortKeys (bool, default false).
+    llvm::Value *sortKeysI8 = nullptr;
+    for (const auto &na : e.named_args) {
+        if (na.name != "sortKeys")
+            cg.codegenError("unknown named argument '" + na.name +
+                            "' for " + std::string(e.callee) + "()");
+        llvm::Value *v = cg.emitExpr(*na.value);
+        if (v->getType() != cg.i1Ty_)
+            cg.codegenError(std::string(e.callee) +
+                            "() 'sortKeys' must be bool");
+        sortKeysI8 = cg.builder_.CreateZExt(v, cg.i8Ty_, "sort_keys_i8");
+    }
+    if (!sortKeysI8)
+        sortKeysI8 = llvm::ConstantInt::get(cg.i8Ty_, 0);
+
+    llvm::Type *paramTys[] = {cg.ptrTy_, cg.i64Ty_, cg.i8Ty_};
     auto *fnTy = llvm::FunctionType::get(cg.ptrTy_, paramTys, false);
     auto fn = cg.mod_->getOrInsertFunction(runtimeFn, fnTy);
-    llvm::Value *ptr = cg.builder_.CreateCall(fn, {slot, indent}, callName);
+    llvm::Value *ptr =
+        cg.builder_.CreateCall(fn, {slot, indent, sortKeysI8}, callName);
     if (!wrapResult) return ptr;
     return cg.wrapPtrAsResult(ptr);
 }
 
-// stringify(value: any) -> str
-// stringify(value: any, indent: int) -> str
+// stringify(value: any[, indent: int][, sortKeys=bool]) -> str
 static llvm::Value *emitJsonStringify(CodeGen &cg, const CallExpr &e) {
-    return emitJsonStringifyImpl(cg, e, "__ry_json_stringify_any",
-                                  "json_stringify_any", /*wrapResult=*/false);
-}
-
-// stringifySafe(value: any[, indent: int]) -> Result<str, Error>   (#1853)
-static llvm::Value *emitJsonStringifySafe(CodeGen &cg, const CallExpr &e) {
-    return emitJsonStringifyImpl(cg, e, "__ry_json_stringify_any_safe",
-                                  "json_stringify_any_safe", /*wrapResult=*/true);
-}
-
-// stringifySorted(value: any[, indent: int]) -> str                 (#1853)
-static llvm::Value *emitJsonStringifySorted(CodeGen &cg, const CallExpr &e) {
-    return emitJsonStringifyImpl(cg, e, "__ry_json_stringify_any_sorted",
-                                  "json_stringify_any_sorted",
+    return emitJsonStringifyImpl(cg, e, "__ry_json_stringify_any_ex",
+                                  "json_stringify_any_ex",
                                   /*wrapResult=*/false);
 }
 
-// stringifySortedSafe(value: any[, indent: int]) -> Result<str, Error> (#1853)
-static llvm::Value *emitJsonStringifySortedSafe(CodeGen &cg, const CallExpr &e) {
-    return emitJsonStringifyImpl(cg, e, "__ry_json_stringify_any_sorted_safe",
-                                  "json_stringify_any_sorted_safe",
+// stringifySafe(value: any[, indent: int][, sortKeys=bool]) -> Result<str, Error>
+static llvm::Value *emitJsonStringifySafe(CodeGen &cg, const CallExpr &e) {
+    return emitJsonStringifyImpl(cg, e, "__ry_json_stringify_any_safe_ex",
+                                  "json_stringify_any_safe_ex",
                                   /*wrapResult=*/true);
 }
 
@@ -180,11 +186,9 @@ static const CodeGen::NativeDispatchEntry json_table[] = {
     // `load[T]` is intercepted by `dispatchJson` via suffix match against
     // `e.callee` (which is mangled to `load<T>` by the parser), so it has no
     // entry in this table.
-    {"stringify",           nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJsonStringify},
-    {"stringifySafe",       nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJsonStringifySafe},
-    {"stringifySorted",     nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJsonStringifySorted},
-    {"stringifySortedSafe", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJsonStringifySortedSafe},
-    {"dump",                nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitJsonDumpFile},
+    {"stringify",     nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJsonStringify},
+    {"stringifySafe", nullptr, CodeGen::ReturnWrapping::Direct, 1, nullptr, emitJsonStringifySafe},
+    {"dump",          nullptr, CodeGen::ReturnWrapping::Direct, 2, nullptr, emitJsonDumpFile},
 };
 
 RY_REGISTER_STDLIB_PACKAGE(json, "share/std/json/json.ry", dispatchJson)

--- a/src/runtime/native/json.cpp
+++ b/src/runtime/native/json.cpp
@@ -776,6 +776,41 @@ const char *__ry_json_stringify_any_sorted_safe(const RyAny *value,
     return makeString(out.data(), out.size());
 }
 
+// Unified stringify with runtime sort_keys flag (#1890). Replaces the
+// four name-encoded variants above on the codegen side; the older symbols
+// remain to keep direct C++ tests (`test_runtime_json*.cpp`) untouched.
+// sort_keys: 0 = insertion order (equivalent to __ry_json_stringify_any),
+// non-zero = byte-lexicographic key order (equivalent to *_sorted).
+const char *__ry_json_stringify_any_ex(const RyAny *value,
+                                        int64_t indent_or_neg1,
+                                        uint8_t sort_keys) {
+    std::string out;
+    bool pretty = indent_or_neg1 >= 0;
+    size_t indent = pretty ? static_cast<size_t>(indent_or_neg1) : 0;
+    (void)stringify_any(value, out, indent, 0, pretty,
+                         /*sort_keys=*/sort_keys != 0,
+                         /*error_out=*/nullptr);
+    return makeString(out.data(), out.size());
+}
+
+// Result-mode counterpart of __ry_json_stringify_any_ex (#1890). NULL on
+// failure with __ry_set_last_error populated — same nullable-ptr contract
+// as __ry_json_stringify_any_safe so codegen can wrap via wrapPtrAsResult.
+const char *__ry_json_stringify_any_safe_ex(const RyAny *value,
+                                             int64_t indent_or_neg1,
+                                             uint8_t sort_keys) {
+    std::string out;
+    bool pretty = indent_or_neg1 >= 0;
+    size_t indent = pretty ? static_cast<size_t>(indent_or_neg1) : 0;
+    std::string err;
+    if (!stringify_any(value, out, indent, 0, pretty,
+                        /*sort_keys=*/sort_keys != 0, &err)) {
+        __ry_set_last_error(err.c_str());
+        return nullptr;
+    }
+    return makeString(out.data(), out.size());
+}
+
 // File handle overloads (#1854). Mirror __ry_json_parse_to_any's status-return
 // contract (0 ok / non-zero err) so the codegen-side reuses emitResultBranch /
 // buildErrorFromRuntime / wrapStatusAsResult — no new IR patterns needed.

--- a/tests/spec/json.test.ry
+++ b/tests/spec/json.test.ry
@@ -1,6 +1,6 @@
 from testing import it, describe, expect, fail
 
-from json import load, stringify, stringifySafe, stringifySorted, stringifySortedSafe, dump
+from json import load, stringify, stringifySafe, dump
 from str import contains, repeat, byteLen
 from io import open, close, writeText, readText
 from math import NAN, INF
@@ -1105,13 +1105,13 @@ fn jsonStringifySafeUnsupportedTests():
       Err(e):
         expect(e.message).toContain("record")
 
-@describe("json stringifySorted — sorts Map keys")
-fn jsonStringifySortedTests():
+@describe("json stringify — sortKeys named argument")
+fn jsonStringifySortKeysTests():
   @it("should sort top-level Map keys by byte order")
   fn shouldSortTopLevelKeys():
     case load[Map<str, any>]("{\"c\":1,\"a\":2,\"b\":3}"):
       Ok(v):
-        expect(stringifySorted(v)).toEq("{\"a\":2,\"b\":3,\"c\":1}")
+        expect(stringify(v, sortKeys=true)).toEq("{\"a\":2,\"b\":3,\"c\":1}")
       Err(e):
         fail("load failed: " + e.message)
 
@@ -1119,7 +1119,7 @@ fn jsonStringifySortedTests():
   fn shouldSortNestedKeys():
     case load[Map<str, any>]("{\"z\":{\"y\":1,\"x\":2},\"a\":1}"):
       Ok(v):
-        expect(stringifySorted(v)).toEq("{\"a\":1,\"z\":{\"x\":2,\"y\":1}}")
+        expect(stringify(v, sortKeys=true)).toEq("{\"a\":1,\"z\":{\"x\":2,\"y\":1}}")
       Err(e):
         fail("load failed: " + e.message)
 
@@ -1127,7 +1127,7 @@ fn jsonStringifySortedTests():
   fn shouldSortInsideListElements():
     case load[List<any>]("[{\"b\":1,\"a\":2},{\"d\":3,\"c\":4}]"):
       Ok(v):
-        expect(stringifySorted(v)).toEq("[{\"a\":2,\"b\":1},{\"c\":4,\"d\":3}]")
+        expect(stringify(v, sortKeys=true)).toEq("[{\"a\":2,\"b\":1},{\"c\":4,\"d\":3}]")
       Err(e):
         fail("load failed: " + e.message)
 
@@ -1135,7 +1135,7 @@ fn jsonStringifySortedTests():
   fn shouldSortUnderIndent():
     case load[Map<str, any>]("{\"b\":1,\"a\":2}"):
       Ok(v):
-        expect(stringifySorted(v, 2)).toEq("{\n  \"a\": 2,\n  \"b\": 1\n}")
+        expect(stringify(v, 2, sortKeys=true)).toEq("{\n  \"a\": 2,\n  \"b\": 1\n}")
       Err(e):
         fail("load failed: " + e.message)
 
@@ -1143,7 +1143,7 @@ fn jsonStringifySortedTests():
   fn shouldEmptyMap():
     case load[Map<str, any>]("{}"):
       Ok(v):
-        expect(stringifySorted(v)).toEq("{}")
+        expect(stringify(v, sortKeys=true)).toEq("{}")
       Err(e):
         fail("load failed: " + e.message)
 
@@ -1151,54 +1151,81 @@ fn jsonStringifySortedTests():
   fn shouldPreserveListOrder():
     case load[List<any>]("[3,1,2]"):
       Ok(v):
-        expect(stringifySorted(v)).toEq("[3,1,2]")
+        expect(stringify(v, sortKeys=true)).toEq("[3,1,2]")
       Err(e):
         fail("load failed: " + e.message)
 
   @it("should match stringify for primitives (no Map to sort)")
   fn shouldMatchStringifyForPrimitives():
     v: any = 42
-    expect(stringifySorted(v)).toEq("42")
+    expect(stringify(v, sortKeys=true)).toEq("42")
 
   @it("should sort keys that share a NUL-containing prefix")
   fn shouldSortKeysWithNul():
     # NUL byte sorts before regular ASCII; "k\0a" < "k\0b".
     case load[Map<str, any>]("{\"k\\u0000b\":1,\"k\\u0000a\":2}"):
       Ok(v):
-        expect(stringifySorted(v)).toEq("{\"k\\u0000a\":2,\"k\\u0000b\":1}")
+        expect(stringify(v, sortKeys=true)).toEq("{\"k\\u0000a\":2,\"k\\u0000b\":1}")
       Err(e):
         fail("load failed: " + e.message)
 
-@describe("json stringifySortedSafe — combines Safe and Sorted")
-fn jsonStringifySortedSafeTests():
-  @it("should Ok with sorted output for normal input")
-  fn shouldSortedSafeOk():
+  @it("should match unsorted output when sortKeys=false (explicit default)")
+  fn shouldRespectExplicitDefault():
+    case load[Map<str, any>]("{\"c\":1,\"a\":2,\"b\":3}"):
+      Ok(v):
+        expect(stringify(v, sortKeys=false)).toEq(stringify(v))
+      Err(e):
+        fail("load failed: " + e.message)
+
+  @it("should accept a runtime bool for sortKeys")
+  fn shouldAcceptRuntimeBoolSortKeys():
+    sk: bool = true
     case load[Map<str, any>]("{\"c\":1,\"a\":2}"):
       Ok(v):
-        case stringifySortedSafe(v):
+        expect(stringify(v, sortKeys=sk)).toEq("{\"a\":2,\"c\":1}")
+      Err(e):
+        fail("load failed: " + e.message)
+
+@describe("json stringifySafe — sortKeys named argument")
+fn jsonStringifySafeSortKeysTests():
+  @it("should Ok with sorted output for normal input")
+  fn shouldSafeSortedOk():
+    case load[Map<str, any>]("{\"c\":1,\"a\":2}"):
+      Ok(v):
+        case stringifySafe(v, sortKeys=true):
           Ok(s): expect(s).toEq("{\"a\":2,\"c\":1}")
-          Err(e): fail("stringifySortedSafe failed: " + e.message)
+          Err(e): fail("stringifySafe sortKeys=true failed: " + e.message)
       Err(e):
         fail("load failed: " + e.message)
 
   @it("should Err on NaN buried in an out-of-order Map")
-  fn shouldSortedSafeErrOnNaN():
+  fn shouldSafeSortedErrOnNaN():
     bad: any = NAN
     good: any = 1
     m: Map<str, any> = {"c": bad, "a": good}
     v: any = m
-    case stringifySortedSafe(v):
+    case stringifySafe(v, sortKeys=true):
       Ok(_): fail("expected Err for NaN inside sorted map")
       Err(e):
         expect(e.message).toContain("non-finite")
 
   @it("should Ok with indent and sorted keys")
-  fn shouldSortedSafeIndent():
+  fn shouldSafeSortedIndent():
     case load[Map<str, any>]("{\"b\":1,\"a\":2}"):
       Ok(v):
-        case stringifySortedSafe(v, 2):
+        case stringifySafe(v, 2, sortKeys=true):
           Ok(s): expect(s).toEq("{\n  \"a\": 2,\n  \"b\": 1\n}")
-          Err(e): fail("stringifySortedSafe indent failed: " + e.message)
+          Err(e): fail("stringifySafe sortKeys=true indent failed: " + e.message)
+      Err(e):
+        fail("load failed: " + e.message)
+
+  @it("should accept sortKeys=false as the explicit default")
+  fn shouldSafeAcceptExplicitDefault():
+    case load[Map<str, any>]("{\"c\":1,\"a\":2}"):
+      Ok(v):
+        case stringifySafe(v, sortKeys=false):
+          Ok(s): expect(s).toEq("{\"c\":1,\"a\":2}")
+          Err(e): fail("stringifySafe sortKeys=false failed: " + e.message)
       Err(e):
         fail("load failed: " + e.message)
 

--- a/tests/test_runtime_json.cpp
+++ b/tests/test_runtime_json.cpp
@@ -7,6 +7,7 @@
 #include "ry/runtime/native/http/http_types.hpp"
 #include "ry/ry_layout.hpp"
 #include <gtest/gtest.h>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <string>
@@ -225,4 +226,129 @@ TEST(JsonStringifyAny, EncodesNulInsideString) {
     ASSERT_NE(s, nullptr);
     EXPECT_STREQ(s, "\"a\\u0000b\"");
     freeStringSlot(const_cast<char *>(s));
+}
+
+// ---- Unified stringify ABI (#1890) ----
+//
+// __ry_json_stringify_any_ex / _safe_ex are the codegen-facing entry
+// points after #1890. The four name-encoded variants (`_sorted`, `_safe`,
+// `_sorted_safe`) remain for direct C++ callers but are no longer reached
+// from generated IR. The cross-validation tests below confirm the unified
+// symbols produce identical output to their name-encoded predecessors.
+
+extern "C" {
+const char *__ry_json_stringify_any_sorted(const RyAny *v, int64_t indent);
+const char *__ry_json_stringify_any_safe(const RyAny *v, int64_t indent);
+const char *__ry_json_stringify_any_sorted_safe(const RyAny *v, int64_t indent);
+}
+
+TEST(JsonStringifyAnyEx, SortKeys0MatchesBaseSymbol) {
+    RyAny v = anyFromInt(7);
+    const char *a = __ry_json_stringify_any_ex(&v, -1, 0);
+    const char *b = __ry_json_stringify_any(&v, -1);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+    EXPECT_STREQ(a, b);
+    EXPECT_STREQ(a, "7");
+    freeStringSlot(const_cast<char *>(a));
+    freeStringSlot(const_cast<char *>(b));
+}
+
+TEST(JsonStringifyAnyEx, SortKeys0PreservesInsertionOrder) {
+    RyAny m{};
+    int64_t status = __ry_json_parse_to_any(
+        ms("{\"c\": 3, \"a\": 1, \"b\": 2}"), &m);
+    ASSERT_EQ(status, 0);
+    const char *s = __ry_json_stringify_any_ex(&m, -1, 0);
+    ASSERT_NE(s, nullptr);
+    EXPECT_STREQ(s, "{\"c\":3,\"a\":1,\"b\":2}");
+    freeStringSlot(const_cast<char *>(s));
+    releaseAny(m);
+}
+
+TEST(JsonStringifyAnyEx, SortKeys1SortsMapKeys) {
+    RyAny m{};
+    int64_t status = __ry_json_parse_to_any(
+        ms("{\"c\": 3, \"a\": 1, \"b\": 2}"), &m);
+    ASSERT_EQ(status, 0);
+    const char *s = __ry_json_stringify_any_ex(&m, -1, 1);
+    ASSERT_NE(s, nullptr);
+    EXPECT_STREQ(s, "{\"a\":1,\"b\":2,\"c\":3}");
+    freeStringSlot(const_cast<char *>(s));
+    releaseAny(m);
+}
+
+TEST(JsonStringifyAnyEx, SortKeys1MatchesSortedSymbol) {
+    RyAny m{};
+    int64_t status = __ry_json_parse_to_any(
+        ms("{\"c\": 3, \"a\": 1, \"b\": 2}"), &m);
+    ASSERT_EQ(status, 0);
+    const char *a = __ry_json_stringify_any_ex(&m, -1, 1);
+    const char *b = __ry_json_stringify_any_sorted(&m, -1);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+    EXPECT_STREQ(a, b);
+    freeStringSlot(const_cast<char *>(a));
+    freeStringSlot(const_cast<char *>(b));
+    releaseAny(m);
+}
+
+TEST(JsonStringifyAnyEx, SortKeys1WithIndentMatchesSortedSymbol) {
+    RyAny m{};
+    int64_t status = __ry_json_parse_to_any(
+        ms("{\"c\": 3, \"a\": 1}"), &m);
+    ASSERT_EQ(status, 0);
+    const char *a = __ry_json_stringify_any_ex(&m, 2, 1);
+    const char *b = __ry_json_stringify_any_sorted(&m, 2);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+    EXPECT_STREQ(a, b);
+    freeStringSlot(const_cast<char *>(a));
+    freeStringSlot(const_cast<char *>(b));
+    releaseAny(m);
+}
+
+TEST(JsonStringifyAnySafeEx, SortKeys0OkMatchesSafeSymbol) {
+    RyAny v = anyFromInt(42);
+    const char *a = __ry_json_stringify_any_safe_ex(&v, -1, 0);
+    const char *b = __ry_json_stringify_any_safe(&v, -1);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+    EXPECT_STREQ(a, b);
+    EXPECT_STREQ(a, "42");
+    freeStringSlot(const_cast<char *>(a));
+    freeStringSlot(const_cast<char *>(b));
+}
+
+TEST(JsonStringifyAnySafeEx, SortKeys1OkSortsKeys) {
+    RyAny m{};
+    int64_t status = __ry_json_parse_to_any(
+        ms("{\"z\": 1, \"a\": 2}"), &m);
+    ASSERT_EQ(status, 0);
+    const char *s = __ry_json_stringify_any_safe_ex(&m, -1, 1);
+    ASSERT_NE(s, nullptr);
+    EXPECT_STREQ(s, "{\"a\":2,\"z\":1}");
+    freeStringSlot(const_cast<char *>(s));
+    releaseAny(m);
+}
+
+TEST(JsonStringifyAnySafeEx, ErrOnNaNRegardlessOfSortKeys) {
+    RyAny v = anyFromFloat(std::nan(""));
+    EXPECT_EQ(__ry_json_stringify_any_safe_ex(&v, -1, 0), nullptr);
+    EXPECT_EQ(__ry_json_stringify_any_safe_ex(&v, -1, 1), nullptr);
+}
+
+TEST(JsonStringifyAnySafeEx, SortKeys1MatchesSortedSafeSymbol) {
+    RyAny m{};
+    int64_t status = __ry_json_parse_to_any(
+        ms("{\"c\": 3, \"a\": 1, \"b\": 2}"), &m);
+    ASSERT_EQ(status, 0);
+    const char *a = __ry_json_stringify_any_safe_ex(&m, -1, 1);
+    const char *b = __ry_json_stringify_any_sorted_safe(&m, -1);
+    ASSERT_NE(a, nullptr);
+    ASSERT_NE(b, nullptr);
+    EXPECT_STREQ(a, b);
+    freeStringSlot(const_cast<char *>(a));
+    freeStringSlot(const_cast<char *>(b));
+    releaseAny(m);
 }


### PR DESCRIPTION
## Summary
- Replace the combinatorial `stringifySorted` / `stringifySortedSafe` variants with a `sortKeys: bool` (default `false`) named argument on `stringify` / `stringifySafe`. New unified runtime symbols `__ry_json_stringify_any_ex` / `_safe_ex` accept a runtime `uint8_t sort_keys` flag, so future named-arg axes (escapeUnicode, compact, maxDepth) can be added without doubling the function count again.
- Breaking change: `stringifySorted(v)` → `stringify(v, sortKeys=true)`, `stringifySortedSafe(v, 2)` → `stringifySafe(v, 2, sortKeys=true)`. The four existing ABI symbols (`__ry_json_stringify_any[_sorted][_safe][_sorted_safe]`) are left untouched for direct C++ callers (`test_runtime_json*.cpp`).
- Codegen emitter is named-arg-aware: reads `e.named_args`, rejects unknown names with a precise diagnostic, validates `sortKeys` is `bool` (i1), widens to `uint8_t` for the ABI boundary.

## Test plan
- [x] Step 0 linchpin spike: `stringify(v, sortKeys=true)` reaches the json custom emitter (gate at codegen_call_dispatch.cpp:297 does not fire because `dispatchJson` returns non-null first). Verified before any code change.
- [x] `./build-rust/ry_tests` — full C++ suite green, new `JsonStringifyAnyEx` / `JsonStringifyAnySafeEx` test suites (9 cross-validation cases: `_ex(v, ind, 0)` ≡ base symbol, `_ex(v, ind, 1)` ≡ `_sorted` symbol, NaN err on both safe modes).
- [x] `./build-rust/ry test tests/spec/json.test.ry` — 128 cases pass including new `sortKeys=false` explicit, runtime bool (`sk: bool = true`), and indent+sortKeys combinations.
- [x] `./build-rust/ry test -p` — 207 spec files pass, no regression.
- [x] ASan / TSan / fuzz_parser (1.7M runs) — all green.
- [x] Smoke compile errors:
  - `stringify(v, foo=true)` → `unknown named argument 'foo' for stringify()`
  - `stringify(v, sortKeys=2)` → `stringify() 'sortKeys' must be bool`
- [x] `grep '\b(stringifySorted|stringifySortedSafe)\b'` — only intentional migration prose / history comments remain (verified per file).

Closes #1890

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed `stringifySorted` and `stringifySortedSafe` functions; use `stringify(..., sortKeys=true)` instead.

* **New Features**
  * Added `sortKeys` named argument (default `false`) to `stringify` and `stringifySafe` for deterministic byte-lexicographic key ordering.

* **Documentation**
  * Updated JSON module reference with migration guidance and usage examples for the new parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->