### PR TITLE
feat(test): default ry test -p workers to cores minus one

### DIFF
--- a/changelog.d/2216-test-default-workers-cores-minus-one.md
+++ b/changelog.d/2216-test-default-workers-cores-minus-one.md
@@ -1,0 +1,3 @@
+### Changed
+
+- `ry test -p` / `ry test --parallel` の暗黙デフォルトワーカー数を `std::thread::hardware_concurrency()` から `hardware_concurrency() - 1`(最低 1)に変更し、1 コアをユーザ操作や他プロセス用に空ける挙動に統一した。`hardware_concurrency()` が `0`(取得失敗)あるいは `1` を返した場合はどちらも 1 ワーカーになる。明示指定の `-p N` / `--parallel N` / `--parallel=N`、およびシーケンシャル `ry test` の挙動は変えない。並列実行開始時に `Running M test files with K workers...` を stderr に表示し、終了サマリーの `(K workers)` 表示と合わせて開始・終了の両端から並列数を確認できる。`.github/workflows/ci.yml` の bare `-p` 呼び出しは新しいデフォルトをそのまま継承する。(#2216)

--- a/docs/reference/project.md
+++ b/docs/reference/project.md
@@ -176,7 +176,7 @@ Discovers and runs test files (`*.test.ry`). See [Testing](testing.md) for full 
 ry test                        # Auto-discover and run all *.test.ry files
 ry test tests/spec             # Run all tests under a directory
 ry test test_file.ry           # Run a specific test file
-ry test -p                     # Run tests in parallel (default workers = CPU count)
+ry test -p                     # Run tests in parallel (default workers = CPU count - 1, minimum 1)
 ry test -p 8                   # Run tests in parallel with 8 workers
 ry test -w                     # Watch mode: re-run on file change
 ry test --coverage             # Collect line coverage information
@@ -186,7 +186,7 @@ ry test --coverage             # Collect line coverage information
 
 | Option | Description |
 |---|---|
-| `-p [N]`, `--parallel [N]` | Run tests in parallel; optional positive integer N selects worker count (default: hardware concurrency). `--parallel=N` is also accepted. |
+| `-p [N]`, `--parallel [N]` | Run tests in parallel; optional positive integer N selects worker count (default: hardware concurrency - 1, minimum 1). `--parallel=N` is also accepted. |
 | `-w`, `--watch` | Watch for changes and re-run |
 | `--coverage`, `--cov` | Collect coverage information |
 | `--outline` | Print the describe/it structure without running tests |

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -10,7 +10,7 @@ Ry has a built-in RSpec-style test syntax. Test files are executed using the `ry
 ry test              # Auto-discover and run all *.test.ry files in the project
 ry test tests/spec   # Run all *.test.ry files under a directory (recursive)
 ry test test_file.ry # Run a specific test file
-ry test -p           # Run all tests in parallel (-p or --parallel; default workers = CPU count)
+ry test -p           # Run all tests in parallel (-p or --parallel; default workers = CPU count - 1, minimum 1)
 ry test -p 8         # Run tests in parallel with 8 workers
 ry test --parallel=4 # Equivalent to `ry test --parallel 4`
 ry test -p tests/    # Run tests in a directory in parallel

--- a/include/ry/jit/test_runner.hpp
+++ b/include/ry/jit/test_runner.hpp
@@ -7,9 +7,16 @@ namespace ry {
 
 std::vector<std::string> findTestFiles(const std::string &root_dir);
 
+// Returns the default worker count for parallel test execution when the user
+// passes -p without an explicit N. Computes hw_concurrency - 1 to leave one
+// core free, with a floor of 1 (hw == 0 / hw == 1 both return 1, also guarding
+// against unsigned underflow at hw == 0).
+unsigned computeDefaultWorkers(unsigned hw_concurrency);
+
 // Returns the effective worker count for parallel test execution.
-// requested_workers == 0 means "use std::thread::hardware_concurrency()".
-// The result is clamped to test_file_count (when non-zero) and floored at 1.
+// requested_workers == 0 means "use computeDefaultWorkers(hardware_concurrency())"
+// (i.e. hw - 1, minimum 1). The result is clamped to test_file_count
+// (when non-zero) and floored at 1.
 int computeParallelism(int requested_workers, std::size_t test_file_count);
 
 int runTestFiles(const std::vector<std::string> &test_files,

--- a/include/ry/jit/test_runner.hpp
+++ b/include/ry/jit/test_runner.hpp
@@ -14,7 +14,7 @@ std::vector<std::string> findTestFiles(const std::string &root_dir);
 unsigned computeDefaultWorkers(unsigned hw_concurrency);
 
 // Returns the effective worker count for parallel test execution.
-// requested_workers == 0 means "use computeDefaultWorkers(hardware_concurrency())"
+// requested_workers <= 0 means "use computeDefaultWorkers(hardware_concurrency())"
 // (i.e. hw - 1, minimum 1). The result is clamped to test_file_count
 // (when non-zero) and floored at 1.
 int computeParallelism(int requested_workers, std::size_t test_file_count);

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -170,7 +170,7 @@ int main(int argc, char *argv[]) {
     } else if (argc >= 2 && std::strcmp(argv[1], "test") == 0) {
         // Parse test subcommand arguments
         bool parallel = false;
-        int parallel_workers = 0; // 0 = use std::thread::hardware_concurrency()
+        int parallel_workers = 0; // 0 = computeDefaultWorkers(hardware_concurrency()) (= hw - 1, min 1)
         bool watch = false;
         bool coverage = false;
         bool outline = false;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -151,7 +151,7 @@ void printTestHelp() {
     llvm::outs() << "Options:\n";
     llvm::outs() << "  -p [N], --parallel [N]\n";
     llvm::outs() << "                       Run tests in parallel; optional positive integer N\n";
-    llvm::outs() << "                       selects the worker count (default: hardware concurrency)\n";
+    llvm::outs() << "                       selects the worker count (default: hardware_concurrency() - 1, minimum 1)\n";
     llvm::outs() << "  -w, --watch          Watch for changes and re-run\n";
     llvm::outs() << "  --coverage, --cov    Collect coverage information\n";
     llvm::outs() << "  --outline            Print describe/it structure without running tests\n";

--- a/src/jit/test_runner.cpp
+++ b/src/jit/test_runner.cpp
@@ -192,6 +192,9 @@ static int runTestFilesParallel(const std::vector<std::string> &test_files,
     std::vector<std::thread> threads;
     threads.reserve(num_workers);
 
+    std::fprintf(stderr, "Running %zu test files with %zu workers...\n",
+                 num_files, num_workers);
+
     auto wall_start = std::chrono::steady_clock::now();
     for (size_t i = 0; i < num_workers; ++i)
         threads.emplace_back(worker);
@@ -217,13 +220,19 @@ static int runTestFilesParallel(const std::vector<std::string> &test_files,
     return total_failed > 0 ? 1 : 0;
 }
 
+unsigned computeDefaultWorkers(unsigned hw_concurrency) {
+    // hw == 0 (取得失敗) と hw == 1 はどちらも 1 を返す。
+    // 減算より前にガードしないと unsigned underflow で巨大値になる。
+    if (hw_concurrency <= 1) return 1u;
+    return hw_concurrency - 1u;
+}
+
 int computeParallelism(int requested_workers, std::size_t test_file_count) {
     unsigned base;
     if (requested_workers > 0) {
         base = static_cast<unsigned>(requested_workers);
     } else {
-        unsigned hw = std::thread::hardware_concurrency();
-        base = (hw > 0) ? hw : 1u;
+        base = computeDefaultWorkers(std::thread::hardware_concurrency());
     }
     if (static_cast<std::size_t>(base) > test_file_count) {
         base = static_cast<unsigned>(test_file_count);

--- a/tests/test_test_runner.cpp
+++ b/tests/test_test_runner.cpp
@@ -2,7 +2,9 @@
 
 #include "ry/jit/test_runner.hpp"
 
+#include <algorithm>
 #include <cstddef>
+#include <limits>
 #include <thread>
 
 TEST(ComputeParallelism, RequestedCappedByFileCount) {
@@ -18,8 +20,8 @@ TEST(ComputeParallelism, ZeroRequestedUsesHardwareDefault) {
     EXPECT_GE(p, 1);
     EXPECT_LE(p, 100);
     unsigned hw = std::thread::hardware_concurrency();
-    if (hw > 0)
-        EXPECT_EQ(static_cast<unsigned>(p), std::min(hw, 100u));
+    unsigned expected = std::min(ry::computeDefaultWorkers(hw), 100u);
+    EXPECT_EQ(static_cast<unsigned>(p), expected);
 }
 
 TEST(ComputeParallelism, MinimumIsOneWithSingleFile) {
@@ -38,4 +40,58 @@ TEST(ComputeParallelism, LargeNCappedByFiles) {
 
 TEST(ComputeParallelism, RequestedOneAlwaysReturnsOne) {
     EXPECT_EQ(ry::computeParallelism(1, 100), 1);
+}
+
+TEST(ComputeParallelism, ExplicitRequestExceedsDefault) {
+    unsigned hw = std::thread::hardware_concurrency();
+    int requested = static_cast<int>(hw == 0 ? 8u : hw + 4u);
+    std::size_t files = static_cast<std::size_t>(requested) + 10;
+    EXPECT_EQ(ry::computeParallelism(requested, files), requested);
+}
+
+TEST(ComputeParallelism, ZeroRequestedSingleFileCapsToOne) {
+    EXPECT_EQ(ry::computeParallelism(0, 1), 1);
+}
+
+TEST(ComputeParallelism, ExplicitAtDefaultBoundary) {
+    unsigned hw = std::thread::hardware_concurrency();
+    if (hw <= 1) GTEST_SKIP();
+    int requested = static_cast<int>(hw - 1u);
+    EXPECT_EQ(ry::computeParallelism(requested, 1000), requested);
+}
+
+TEST(ComputeParallelism, ExplicitJustAboveDefault) {
+    unsigned hw = std::thread::hardware_concurrency();
+    if (hw == 0) GTEST_SKIP();
+    int requested = static_cast<int>(hw);
+    EXPECT_EQ(ry::computeParallelism(requested, 1000), requested);
+}
+
+TEST(ComputeDefaultWorkers, ZeroReturnsOne) {
+    EXPECT_EQ(ry::computeDefaultWorkers(0u), 1u);
+}
+
+TEST(ComputeDefaultWorkers, OneReturnsOne) {
+    EXPECT_EQ(ry::computeDefaultWorkers(1u), 1u);
+}
+
+TEST(ComputeDefaultWorkers, TwoReturnsOne) {
+    EXPECT_EQ(ry::computeDefaultWorkers(2u), 1u);
+}
+
+TEST(ComputeDefaultWorkers, ThreeReturnsTwo) {
+    EXPECT_EQ(ry::computeDefaultWorkers(3u), 2u);
+}
+
+TEST(ComputeDefaultWorkers, EightReturnsSeven) {
+    EXPECT_EQ(ry::computeDefaultWorkers(8u), 7u);
+}
+
+TEST(ComputeDefaultWorkers, LargeValueReturnsMinusOne) {
+    EXPECT_EQ(ry::computeDefaultWorkers(100u), 99u);
+}
+
+TEST(ComputeDefaultWorkers, UintMaxReturnsMaxMinusOne) {
+    constexpr unsigned umax = std::numeric_limits<unsigned>::max();
+    EXPECT_EQ(ry::computeDefaultWorkers(umax), umax - 1u);
 }


### PR DESCRIPTION
## Summary

- `ry test -p` (no explicit count) now uses `hardware_concurrency() - 1` (min 1) so one core is left free for the rest of the system. `hw == 0` (unknown) or `hw == 1` both yield 1 worker. Explicit `-p N` and sequential `ry test` are unaffected.
- Adds a pure helper `computeDefaultWorkers(unsigned)` exposed in `include/ry/jit/test_runner.hpp` so the boundary cases (`hw == 0/1/2/UINT_MAX`) are unit-testable without depending on the host CPU count, and the unsigned-underflow guard is locked in.
- `runTestFilesParallel` now prints `Running M test files with K workers...` to stderr at the start of a parallel run so the active worker count is visible from the console as execution begins (the end-of-run `(K workers)` summary stays).

Closes #2216

## Test plan

- [x] `./build-rust/ry_tests --gtest_filter='ComputeParallelism.*:ComputeDefaultWorkers.*'` — 18/18 pass
- [x] `./build-rust/ry test -p tests/spec` — 207/207 pass, opening line shows `Running 207 test files with 9 workers...` (hw.ncpu = 10)
- [x] `./build-rust/ry test -p 2 tests/spec` / `--parallel=3` — opening line reflects the explicit count
- [x] ASan + UBSan via `./.claude/skills/pre-commit-checklist/run-asan.sh` — 207/207 pass
- [x] TSan via `./.claude/skills/pre-commit-checklist/run-tsan.sh` — 207/207 pass
- [x] `./.claude/skills/pre-commit-checklist/run-static-analysis-all.sh` — clean for the diff (the 2 advisory `scan-build` warnings touch pre-existing code outside this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Default parallel test execution now uses **CPU count − 1** with a **minimum of 1** when running `ry test -p/--parallel` without an explicit worker number.

* **New Features**
  * Parallel runs now print an additional startup line showing the **number of test files** and **worker threads** being used.

* **Documentation**
  * Updated CLI help and reference docs to match the new default worker-count behavior.

* **Tests**
  * Expanded unit tests to cover the parallelism and default worker calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->