### PR TITLE
refactor(codegen): migrate UC closure dtor to crates/emit primitives (#2197)

### DIFF
--- a/src/codegen_lambda.cpp
+++ b/src/codegen_lambda.cpp
@@ -1409,9 +1409,9 @@ llvm::Function *CodeGen::getOrCreateUniformClosureDestructor() {
     auto *ucTy = getUniformClosureTy();
 
     auto *dtorTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
-    auto *dtorFn = llvm::Function::Create(
-        dtorTy, llvm::Function::InternalLinkage, "__ry_arc_dtor_uniform_closure", mod_.get());
-    dtorFn->addFnAttr(llvm::Attribute::NoUnwind);
+    auto *dtorFn = emitCreateFunction(dtorTy, llvm::Function::InternalLinkage,
+                                      "__ry_arc_dtor_uniform_closure");
+    emitFunctionSetNounwind(dtorFn);
 
     auto *savedBB = builder_.GetInsertBlock();
     auto savedPt = builder_.GetInsertPoint();
@@ -1419,15 +1419,14 @@ llvm::Function *CodeGen::getOrCreateUniformClosureDestructor() {
     auto *entryBB = createBBInFn("entry", dtorFn);
     builder_.SetInsertPoint(entryBB);
 
-    auto *dataPtr = dtorFn->getArg(0); // points to {thunk, env, env_dtor}
-    auto *envField = builder_.CreateStructGEP(ucTy, dataPtr, 1, "uc_dtor.env_field");
-    auto *envVal = builder_.CreateLoad(ptrTy_, envField, "uc_dtor.env");
-    auto *envDtorField = builder_.CreateStructGEP(ucTy, dataPtr, 2, "uc_dtor.env_dtor_field");
-    auto *envDtorVal = builder_.CreateLoad(ptrTy_, envDtorField, "uc_dtor.env_dtor");
+    auto *dataPtr = emitGetParam(dtorFn, 0); // points to {thunk, env, env_dtor}
+    auto *envField = emitStructGEP(ucTy, dataPtr, 1, "uc_dtor.env_field");
+    auto *envVal = emitLoad(ptrTy_, envField, "uc_dtor.env");
+    auto *envDtorField = emitStructGEP(ucTy, dataPtr, 2, "uc_dtor.env_dtor_field");
+    auto *envDtorVal = emitLoad(ptrTy_, envDtorField, "uc_dtor.env_dtor");
 
-    // If env is non-null, release it with its destructor
-    auto *nullPtr = llvm::ConstantPointerNull::get(llvm::cast<llvm::PointerType>(ptrTy_));
-    auto *isEnvNull = builder_.CreateICmpEQ(envVal, nullPtr, "uc_dtor.env_null");
+    auto *nullPtr = emitConstNull(ptrTy_);
+    auto *isEnvNull = emitICmpEQ(envVal, nullPtr, "uc_dtor.env_null");
     auto *releaseBB = createBBInFn("uc_dtor.release", dtorFn);
     auto *doneBB = createBBInFn("uc_dtor.done", dtorFn);
     emitBranchCond(isEnvNull, doneBB, releaseBB);
@@ -1435,36 +1434,32 @@ llvm::Function *CodeGen::getOrCreateUniformClosureDestructor() {
     builder_.SetInsertPoint(releaseBB);
     auto *hdr = emitArcGetHeaderFromData(envVal);
 
-    // Decrement strong count; if zero, call env_dtor (if non-null) and free
-    auto *strongPtr = builder_.CreateStructGEP(arcHeaderTy_, hdr, 0, "uc_dtor.strong_ptr");
-    auto *cur = builder_.CreateLoad(i64Ty_, strongPtr, "uc_dtor.strong");
-    auto *dec = builder_.CreateSub(cur, llvm::ConstantInt::get(i64Ty_, 1), "uc_dtor.dec");
-    builder_.CreateStore(dec, strongPtr);
-    auto *isDead = builder_.CreateICmpEQ(dec, llvm::ConstantInt::get(i64Ty_, 0), "uc_dtor.dead");
+    auto *strongPtr = emitStructGEP(arcHeaderTy_, hdr, 0, "uc_dtor.strong_ptr");
+    auto *cur = emitLoad(i64Ty_, strongPtr, "uc_dtor.strong");
+    auto *dec = emitSub(cur, emitConstInt(i64Ty_, 1), "uc_dtor.dec");
+    emitStore(dec, strongPtr);
+    auto *isDead = emitICmpEQ(dec, emitConstInt(i64Ty_, 0), "uc_dtor.dead");
 
     auto *freeBB = createBBInFn("uc_dtor.free", dtorFn);
     emitBranchCond(isDead, freeBB, doneBB);
 
     builder_.SetInsertPoint(freeBB);
-    // Call env_dtor(envVal) if non-null to release captured ARC values
-    auto *isDtorNull = builder_.CreateICmpEQ(envDtorVal, nullPtr, "uc_dtor.dtor_null");
+    auto *isDtorNull = emitICmpEQ(envDtorVal, nullPtr, "uc_dtor.dtor_null");
     auto *callDtorBB = createBBInFn("uc_dtor.call_dtor", dtorFn);
     auto *afterDtorBB = createBBInFn("uc_dtor.after_dtor", dtorFn);
     emitBranchCond(isDtorNull, afterDtorBB, callDtorBB);
 
     builder_.SetInsertPoint(callDtorBB);
-    auto *envDtorFnTy = llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false);
-    builder_.CreateCall(envDtorFnTy, envDtorVal, {envVal});
+    emitCallIndirect(dtorTy, envDtorVal, {envVal}, "");
     emitBranchUncond(afterDtorBB);
 
     builder_.SetInsertPoint(afterDtorBB);
-    auto freeFn = mod_->getOrInsertFunction("free",
-        llvm::FunctionType::get(llvm::Type::getVoidTy(*ctx_), {ptrTy_}, false));
-    builder_.CreateCall(freeFn, {hdr});
+    auto freeFn = getStdlibFree();
+    emitCallIndirect(freeFn.getFunctionType(), freeFn.getCallee(), {hdr}, "");
     emitBranchUncond(doneBB);
 
     builder_.SetInsertPoint(doneBB);
-    builder_.CreateRetVoid();
+    emitRet(nullptr);
 
     if (savedBB)
         builder_.SetInsertPoint(savedBB, savedPt);


### PR DESCRIPTION
## Summary

- Route `getOrCreateUniformClosureDestructor` (`src/codegen_lambda.cpp`) through the existing `emit*` thin wrappers — eliminating the last `builder_.Create*` / `llvm::Function::Create` / `addFnAttr` / `getArg` calls in this thunk.
- Combines the strong ARC inline capability (#1968) with the function creation capability (#2098), following the Pilot G pattern (#2196, `createRecordVisitFunction`).
- Bit-exact under #2072: ASLR-normalized `--emit-llvm-ir` diff is empty across the UC closure path; strong decrement remains non-atomic (current shape preserved).
- Folds the duplicated `void(ptr)` `FunctionType` construction into the existing `dtorTy` and replaces the inline `getOrInsertFunction("free", …)` with the existing `getStdlibFree()` helper.

## Test plan

- [x] `./build-rust/ry_tests` — 2792 PASS
- [x] `./build-rust/ry test -p` — 207 spec files PASS
- [x] Bit-exact diff of `--emit-llvm-ir` for a capturing-closure probe — empty diff after ASLR normalization
- [x] `./docker/run.sh asan ry test` — `closure_arc` / `closure_capture_arc` / `nested_fn_closure` PASS, no leak / UAF
- [x] `./.claude/skills/pre-commit-checklist/run-asan.sh` and `run-tsan.sh` — 207 spec files PASS each
- [x] `run-static-analysis-all.sh` — only pre-existing scan-build finding (`src/app/main.cpp:256` dead-store, from dba41b904), unrelated to this PR

Closes #2197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal code generation logic for closure destructor handling to improve code maintainability and consistency with existing patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->